### PR TITLE
[Perf] Add an adaptive prefill delayer for data-parallel serving

### DIFF
--- a/tests/v1/engine/test_prefill_alignment.py
+++ b/tests/v1/engine/test_prefill_alignment.py
@@ -1,0 +1,255 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+
+from vllm.v1.engine.coordinator import PrefillAlignmentCoordinator
+from vllm.v1.metrics.stats import SchedulerStats
+
+
+def observation(
+    step: int,
+    *,
+    deferred: bool,
+    candidate: bool | None = None,
+    running: int = 1,
+    max_prefill: int | None = None,
+    max_running_requests: int = 8,
+    force_allow: bool = False,
+    wave: int = 0,
+    generation: int = 0,
+    ack_generation: int = -1,
+    ack_target_step: int = -1,
+    actual_requests: int = 0,
+    actual_tokens: int = 0,
+) -> SchedulerStats:
+    candidate = deferred if candidate is None else candidate
+    max_prefill = int(candidate) if max_prefill is None else max_prefill
+    return SchedulerStats(
+        step_counter=step,
+        current_wave=wave,
+        prefill_alignment_phase=1,
+        prefill_alignment_generation=generation,
+        prefill_alignment_ack_generation=ack_generation,
+        prefill_alignment_ack_target_step=ack_target_step,
+        prefillable=candidate,
+        prefill_deferred=deferred,
+        prefill_force_allow=force_allow,
+        prefill_running_batch=running,
+        prefill_max_batch=max_prefill,
+        prefill_max_running_requests=max_running_requests,
+        prefill_waiting_queue_len=int(candidate),
+        actual_prefill_requests=actual_requests,
+        actual_prefill_tokens=actual_tokens,
+    )
+
+
+def final_ack(
+    release_generation: int,
+    target_step: int,
+    *,
+    requests: int = 0,
+    tokens: int = 0,
+    wave: int = 0,
+) -> SchedulerStats:
+    return SchedulerStats(
+        current_wave=wave,
+        prefill_alignment_phase=2,
+        prefill_alignment_generation=release_generation + 1,
+        prefill_alignment_ack_generation=release_generation,
+        prefill_alignment_ack_target_step=target_step,
+        actual_prefill_requests=requests,
+        actual_prefill_tokens=tokens,
+    )
+
+
+def update_step(
+    coordinator: PrefillAlignmentCoordinator,
+    step: int,
+    deferred: list[bool],
+    **kwargs,
+):
+    release = None
+    for engine_index, value in enumerate(deferred):
+        result = coordinator.update(
+            engine_index,
+            observation(step, deferred=value, **kwargs),
+        )
+        release = result or release
+    return release
+
+
+def test_all_prefillable_release_and_piggybacked_ack() -> None:
+    coordinator = PrefillAlignmentCoordinator(4, target_step_lead=2)
+
+    release = update_step(coordinator, 7, [True] * 4)
+
+    assert release is not None
+    assert release.release_id == 0
+    assert release.target_step == 9
+    assert release.reason == "all_prefillable"
+
+    for engine_index in range(4):
+        coordinator.update(
+            engine_index,
+            observation(
+                10,
+                deferred=False,
+                generation=1,
+                ack_generation=0,
+                ack_target_step=9,
+                actual_requests=1,
+                actual_tokens=1024,
+            ),
+        )
+
+    assert coordinator.pending_release is None
+    assert coordinator.current_release_id == 1
+    assert coordinator.last_actual_prefill == {
+        engine_index: (1, 1024) for engine_index in range(4)
+    }
+
+
+@pytest.mark.parametrize("max_delay_passes", [1, 7, 30])
+def test_mixed_prefill_is_bounded_by_fail_open_limit(
+    max_delay_passes: int,
+) -> None:
+    coordinator = PrefillAlignmentCoordinator(
+        4,
+        max_delay_passes=max_delay_passes,
+        target_step_lead=3,
+    )
+
+    for step in range(max_delay_passes - 1):
+        assert update_step(coordinator, step, [True, False, False, False]) is None
+
+    release = update_step(
+        coordinator,
+        max_delay_passes - 1,
+        [True, False, False, False],
+    )
+
+    assert release is not None
+    assert release.target_step == max_delay_passes + 2
+    assert release.reason == "max_delay_fail_open"
+
+
+def test_mixed_prefill_without_decode_still_waits() -> None:
+    coordinator = PrefillAlignmentCoordinator(4, max_delay_passes=2)
+
+    assert (
+        update_step(
+            coordinator,
+            3,
+            [True, False, False, False],
+            running=0,
+        )
+        is None
+    )
+    release = update_step(
+        coordinator,
+        4,
+        [True, False, False, False],
+        running=0,
+    )
+
+    assert release is not None
+    assert release.reason == "max_delay_fail_open"
+
+
+def test_capacity_force_allow_is_global() -> None:
+    coordinator = PrefillAlignmentCoordinator(4, target_step_lead=2)
+    release = None
+    for engine_index in range(4):
+        result = coordinator.update(
+            engine_index,
+            observation(
+                5,
+                deferred=engine_index == 0,
+                force_allow=engine_index == 0,
+            ),
+        )
+        release = result or release
+
+    assert release is not None
+    assert release.reason == "capacity_force_allow"
+    assert release.target_step == 7
+
+
+def test_first_slot_limited_delay_is_skipped_then_bounded() -> None:
+    coordinator = PrefillAlignmentCoordinator(2, max_delay_passes=2)
+    kwargs = {"running": 8, "max_prefill": 1, "max_running_requests": 8}
+
+    first = update_step(coordinator, 0, [True, True], **kwargs)
+    assert first is not None
+    assert first.reason == "first_delay_skip"
+    for engine_index in range(2):
+        coordinator.update(engine_index, final_ack(0, first.target_step))
+
+    assert update_step(coordinator, 3, [True, True], generation=1, **kwargs) is None
+    second = update_step(coordinator, 4, [True, True], generation=1, **kwargs)
+    assert second is not None
+    assert second.reason == "max_delay_fail_open"
+
+
+def test_scheduled_candidate_is_not_false_positive_demand() -> None:
+    coordinator = PrefillAlignmentCoordinator(2)
+
+    release = update_step(
+        coordinator,
+        1,
+        [False, False],
+        candidate=True,
+        actual_requests=1,
+        actual_tokens=1024,
+    )
+
+    assert release is None
+    assert coordinator.delayed_passes == 0
+
+
+def test_missing_release_ack_broadcasts_fail_open_resync() -> None:
+    coordinator = PrefillAlignmentCoordinator(
+        2,
+        max_delay_passes=3,
+        target_step_lead=1,
+    )
+    release = update_step(coordinator, 0, [True, True])
+    assert release is not None and release.target_step == 1
+
+    coordinator.update(0, final_ack(0, 1, requests=1, tokens=512))
+    assert coordinator.current_release_id == 0
+
+    # Rank 1's ack is lost. Observations keep flowing, and the coordinator
+    # advances after the bounded grace period instead of blocking DP progress.
+    retry = coordinator.update(
+        0,
+        observation(4, deferred=False, generation=1),
+    )
+
+    assert coordinator.current_release_id == 1
+    assert retry is not None
+    assert retry.release_id == 1
+    assert retry.target_step == 5
+    assert retry.reason == "ack_timeout_resync"
+
+    for engine_index in range(2):
+        coordinator.update(engine_index, final_ack(1, 5))
+    assert coordinator.pending_release is None
+    assert coordinator.current_release_id == 2
+
+
+def test_new_wave_resets_release_id_and_rejects_stale_stats() -> None:
+    coordinator = PrefillAlignmentCoordinator(2)
+    release = update_step(coordinator, 0, [True, True])
+    assert release is not None
+
+    coordinator.reset_wave(3)
+    assert coordinator.current_wave == 3
+    assert coordinator.current_release_id == 0
+    assert coordinator.pending_release is None
+    assert coordinator.skip_first_delay
+
+    stale = observation(5, deferred=True, wave=2)
+    assert coordinator.update(0, stale) is None
+    assert coordinator.snapshots == {}

--- a/vllm/config/scheduler.py
+++ b/vllm/config/scheduler.py
@@ -145,6 +145,16 @@ class SchedulerConfig:
     once every N engine steps, aligned across DP ranks, to better balance
     per-step forward-pass times."""
 
+    enable_adaptive_prefill_alignment: bool = False
+    """Use coordinator-driven adaptive prefill alignment for data-parallel
+    deployments."""
+
+    prefill_alignment_max_delay_passes: int = Field(default=30, ge=1)
+    """Maximum number of mixed-prefill DP steps before a fail-open release."""
+
+    prefill_alignment_target_step_lead: int = Field(default=2, ge=1)
+    """Number of DP steps between a coordinator decision and its release."""
+
     async_scheduling: bool | None = None
     """If set to False, disable async scheduling. Async scheduling helps to
     avoid gaps in GPU utilization, leading to better latency and throughput.
@@ -225,6 +235,15 @@ class SchedulerConfig:
         return None if value is None else handler(value)
 
     def __post_init__(self, max_model_len: int, is_encoder_decoder: bool) -> None:
+        if (
+            self.enable_adaptive_prefill_alignment
+            and self.prefill_schedule_interval != 1
+        ):
+            raise ValueError(
+                "Adaptive prefill alignment cannot be combined with "
+                "prefill_schedule_interval > 1."
+            )
+
         if is_encoder_decoder:
             # Chunked prefill should be disabled for encoder-decoder models.
             self.disable_chunked_mm_input = True

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -621,6 +621,15 @@ class EngineArgs:
 
     scheduler_reserve_full_isl: bool = SchedulerConfig.scheduler_reserve_full_isl
     prefill_schedule_interval: int = SchedulerConfig.prefill_schedule_interval
+    enable_adaptive_prefill_alignment: bool = (
+        SchedulerConfig.enable_adaptive_prefill_alignment
+    )
+    prefill_alignment_max_delay_passes: int = (
+        SchedulerConfig.prefill_alignment_max_delay_passes
+    )
+    prefill_alignment_target_step_lead: int = (
+        SchedulerConfig.prefill_alignment_target_step_lead
+    )
 
     watermark: float = SchedulerConfig.watermark
 
@@ -1514,6 +1523,18 @@ class EngineArgs:
             **scheduler_kwargs["prefill_schedule_interval"],
         )
         scheduler_group.add_argument(
+            "--enable-adaptive-prefill-alignment",
+            **scheduler_kwargs["enable_adaptive_prefill_alignment"],
+        )
+        scheduler_group.add_argument(
+            "--prefill-alignment-max-delay-passes",
+            **scheduler_kwargs["prefill_alignment_max_delay_passes"],
+        )
+        scheduler_group.add_argument(
+            "--prefill-alignment-target-step-lead",
+            **scheduler_kwargs["prefill_alignment_target_step_lead"],
+        )
+        scheduler_group.add_argument(
             "--disable-hybrid-kv-cache-manager",
             **scheduler_kwargs["disable_hybrid_kv_cache_manager"],
         )
@@ -2278,6 +2299,13 @@ class EngineArgs:
             scheduler_reserve_full_isl=self.scheduler_reserve_full_isl,
             watermark=self.watermark,
             prefill_schedule_interval=self.prefill_schedule_interval,
+            enable_adaptive_prefill_alignment=(self.enable_adaptive_prefill_alignment),
+            prefill_alignment_max_delay_passes=(
+                self.prefill_alignment_max_delay_passes
+            ),
+            prefill_alignment_target_step_lead=(
+                self.prefill_alignment_target_step_lead
+            ),
             disable_hybrid_kv_cache_manager=self.disable_hybrid_kv_cache_manager,
             async_scheduling=self.async_scheduling,
             stream_interval=self.stream_interval,

--- a/vllm/v1/core/sched/interface.py
+++ b/vllm/v1/core/sched/interface.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
     from vllm.v1.core.sched.output import GrammarOutput, SchedulerOutput
     from vllm.v1.engine import EngineCoreOutputs
     from vllm.v1.kv_cache_interface import KVCacheConfig
-    from vllm.v1.metrics.stats import SchedulerStats
+    from vllm.v1.metrics.stats import PrefillAlignmentTelemetry, SchedulerStats
     from vllm.v1.outputs import DraftTokenIds, ModelRunnerOutput
     from vllm.v1.request import Request, RequestStatus
     from vllm.v1.structured_output import StructuredOutputManager
@@ -238,6 +238,16 @@ class SchedulerInterface(ABC):
     def get_kv_cache_usage(self) -> float:
         """Returns the fraction of the KV cache currently in use (0.0-1.0)."""
         return 0.0
+
+    def get_prefill_alignment_telemetry(
+        self,
+    ) -> "PrefillAlignmentTelemetry | None":
+        """Returns telemetry from the most recent scheduler walk."""
+        return None
+
+    def set_prefill_capacity_override_enabled(self, enabled: bool) -> None:
+        """Control whether local capacity may override prefill throttling."""
+        del enabled
 
     @abstractmethod
     def make_stats(self) -> "SchedulerStats | None":

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -55,7 +55,11 @@ from vllm.v1.core.sched.utils import check_stop, remove_all
 from vllm.v1.engine import EngineCoreEventType, EngineCoreOutput, EngineCoreOutputs
 from vllm.v1.kv_cache_interface import KVCacheConfig
 from vllm.v1.metrics.perf import ModelMetrics, PerfStats
-from vllm.v1.metrics.stats import PrefixCacheStats, SchedulerStats
+from vllm.v1.metrics.stats import (
+    PrefillAlignmentTelemetry,
+    PrefixCacheStats,
+    SchedulerStats,
+)
 from vllm.v1.outputs import DraftTokenIds, KVConnectorOutput, ModelRunnerOutput
 from vllm.v1.request import Request, RequestStatus, StreamingUpdate
 from vllm.v1.spec_decode.dynamic.utils import build_dynamic_sd_schedule_lookup
@@ -303,6 +307,13 @@ class Scheduler(SchedulerInterface):
         # prefill batch fully drained the waiting queue. Prefill throttling
         # is disabled in this case.
         self.prefill_capacity_bound = False
+        self.prefill_capacity_override_enabled = True
+        self.prefill_alignment_schedule_sequence = 0
+        self.last_prefill_candidate_seen = False
+        self.last_prefill_candidate_deferred = False
+        self.last_prefill_max_batch = 0
+        self.last_prefill_requests_scheduled = 0
+        self.last_prefill_tokens_scheduled = 0
         self.scheduler_reserve_full_isl = (
             self.scheduler_config.scheduler_reserve_full_isl
         )
@@ -439,6 +450,7 @@ class Scheduler(SchedulerInterface):
 
     def schedule(self, throttle_prefills: bool = False) -> SchedulerOutput:
         self.current_step += 1
+
         # NOTE(woosuk) on the scheduling algorithm:
         # There's no "decoding phase" nor "prefill phase" in the scheduler.
         # Each request just has the num_computed_tokens and
@@ -449,6 +461,15 @@ class Scheduler(SchedulerInterface):
         # num_tokens_with_spec. This is general enough to cover
         # chunked prefills, prefix caching, speculative decoding,
         # and the "jump decoding" optimization in the future.
+
+        # Bookkeeping for the DP prefill delayer. This tracks prompt work that
+        # can be aligned across DP engines; it does not add scheduler phases.
+        self.prefill_alignment_schedule_sequence += 1
+        prefill_candidate_seen = False
+        prefill_candidate_deferred = False
+        prefill_candidate_count = 0
+        actual_prefill_requests = 0
+        actual_prefill_tokens = 0
 
         scheduled_new_reqs: list[Request] = []
         scheduled_resumed_reqs: list[Request] = []
@@ -478,13 +499,24 @@ class Scheduler(SchedulerInterface):
         # DP prefill balancing: on a throttled (non-cadence-aligned) step, defer
         # all prefill compute unless saturated.
         defer_prefills = (
-            throttle_prefills and not self.prefill_capacity_bound
-        ) and any(not r.is_prefill_chunk for r in self.running)
+            throttle_prefills
+            and (
+                not self.prefill_capacity_override_enabled
+                or not self.prefill_capacity_bound
+            )
+            and (
+                not self.prefill_capacity_override_enabled
+                or any(not r.is_prefill_chunk for r in self.running)
+            )
+        )
 
         # First, schedule the RUNNING requests.
         req_index = 0
         while req_index < len(self.running) and token_budget > 0:
             request = self.running[req_index]
+            if request.is_prefill_chunk:
+                prefill_candidate_seen = True
+                prefill_candidate_count += 1
 
             if (
                 request.num_output_placeholders > 0
@@ -511,6 +543,7 @@ class Scheduler(SchedulerInterface):
             if defer_prefills and request.is_prefill_chunk:
                 # DP prefill balancing: defer this in-progress prefill chunk to a
                 # cadence-aligned step; decodes still run to fill this step.
+                prefill_candidate_deferred = True
                 req_index += 1
                 continue
 
@@ -632,6 +665,9 @@ class Scheduler(SchedulerInterface):
             # Schedule the request.
             scheduled_running_reqs.append(request)
             prefill_scheduled |= request.is_prefill_chunk
+            if request.is_prefill_chunk:
+                actual_prefill_requests += 1
+                actual_prefill_tokens += num_new_tokens
             request_id = request.request_id
             req_to_new_blocks[request_id] = new_blocks
             num_scheduled_tokens[request_id] = num_new_tokens
@@ -871,6 +907,9 @@ class Scheduler(SchedulerInterface):
                 elif defer_prefills and num_computed_tokens < request.num_tokens - 1:
                     # DP prefill balancing: defer this step's local prefill
                     # compute to a cadence-aligned step.
+                    prefill_candidate_seen = True
+                    prefill_candidate_deferred = True
+                    prefill_candidate_count += 1
                     break
                 else:
                     # Number of tokens to be scheduled.
@@ -1019,6 +1058,12 @@ class Scheduler(SchedulerInterface):
                     self.kv_cache_manager.record_prefix_cache_stats(
                         request, num_new_local_computed_tokens
                     )
+
+                if num_new_tokens > 0 and num_computed_tokens < request.num_tokens - 1:
+                    prefill_candidate_seen = True
+                    prefill_candidate_count += 1
+                    actual_prefill_requests += 1
+                    actual_prefill_tokens += num_new_tokens
 
                 request = request_queue.pop_request()
                 if load_kv_async:
@@ -1251,6 +1296,11 @@ class Scheduler(SchedulerInterface):
 
         with record_function_or_nullcontext("schedule: update_after_schedule"):
             self._update_after_schedule(scheduler_output)
+        self.last_prefill_candidate_seen = prefill_candidate_seen
+        self.last_prefill_candidate_deferred = prefill_candidate_deferred
+        self.last_prefill_max_batch = prefill_candidate_count
+        self.last_prefill_requests_scheduled = actual_prefill_requests
+        self.last_prefill_tokens_scheduled = actual_prefill_tokens
         return scheduler_output
 
     def _build_kv_connector_meta(
@@ -2221,6 +2271,24 @@ class Scheduler(SchedulerInterface):
     def get_kv_cache_usage(self) -> float:
         """Returns the fraction of the KV cache currently in use (0.0-1.0)."""
         return self.kv_cache_manager.usage
+
+    def set_prefill_capacity_override_enabled(self, enabled: bool) -> None:
+        self.prefill_capacity_override_enabled = enabled
+
+    def get_prefill_alignment_telemetry(self) -> PrefillAlignmentTelemetry:
+        return PrefillAlignmentTelemetry(
+            schedule_sequence=self.prefill_alignment_schedule_sequence,
+            candidate_seen=self.last_prefill_candidate_seen,
+            candidate_deferred=self.last_prefill_candidate_deferred,
+            capacity_force_allow=self.prefill_capacity_bound,
+            token_usage=self.kv_cache_manager.usage,
+            running_batch=len(self.running),
+            max_prefill_batch=self.last_prefill_max_batch,
+            max_running_requests=self.max_num_running_reqs,
+            waiting_queue_len=len(self.waiting) + len(self.skipped_waiting),
+            actual_prefill_requests=self.last_prefill_requests_scheduled,
+            actual_prefill_tokens=self.last_prefill_tokens_scheduled,
+        )
 
     def add_request(self, request: Request) -> None:
         existing = self.requests.get(request.request_id)

--- a/vllm/v1/engine/__init__.py
+++ b/vllm/v1/engine/__init__.py
@@ -274,6 +274,7 @@ class EngineCoreRequestType(enum.Enum):
     EXECUTOR_FAILED = b"\x04"
     # Sentinel to wake up input_queue.get() during shutdown.
     WAKEUP = b"\x05"
+    PREFILL_ALIGNMENT_RELEASE = b"\x06"
 
 
 class ReconfigureDistributedRequest(msgspec.Struct):

--- a/vllm/v1/engine/coordinator.py
+++ b/vllm/v1/engine/coordinator.py
@@ -5,6 +5,7 @@ import multiprocessing
 import multiprocessing.connection
 import time
 import weakref
+from dataclasses import dataclass
 
 import msgspec.msgpack
 import zmq
@@ -14,10 +15,192 @@ from vllm.logger import init_logger
 from vllm.utils.network_utils import make_zmq_socket
 from vllm.utils.system_utils import get_mp_context, set_process_title
 from vllm.v1.engine import EngineCoreOutputs, EngineCoreRequestType
+from vllm.v1.metrics.stats import SchedulerStats
 from vllm.v1.serial_utils import MsgpackDecoder
 from vllm.v1.utils import get_engine_client_zmq_addr, shutdown
 
 logger = init_logger(__name__)
+
+_PREFILL_ALIGNMENT_OBSERVE = 1
+_PREFILL_ALIGNMENT_ACTUAL = 2
+
+
+@dataclass(frozen=True)
+class PrefillAlignmentRelease:
+    wave: int
+    release_id: int
+    target_step: int
+    reason: str
+
+
+class PrefillAlignmentCoordinator:
+    """Nonblocking coordinator state for adaptive DP prefill alignment."""
+
+    def __init__(
+        self,
+        engine_count: int,
+        max_delay_passes: int = 30,
+        target_step_lead: int = 2,
+    ) -> None:
+        self.engine_count = engine_count
+        self.max_delay_passes = max_delay_passes
+        self.target_step_lead = target_step_lead
+        self.current_wave = 0
+        self.current_release_id = 0
+        self.delayed_passes = 0
+        self.pending_release: PrefillAlignmentRelease | None = None
+        self.pending_acks: set[int] = set()
+        self.snapshots: dict[int, dict[int, SchedulerStats]] = {}
+        self.last_actual_prefill: dict[int, tuple[int, int]] = {}
+        self.skip_first_delay = True
+        self.first_completion_logged = False
+
+    def reset_wave(self, wave: int) -> None:
+        self.current_wave = wave
+        self.current_release_id = 0
+        self.delayed_passes = 0
+        self.pending_release = None
+        self.pending_acks.clear()
+        self.snapshots.clear()
+        self.last_actual_prefill.clear()
+        self.skip_first_delay = True
+
+    def resize(self, engine_count: int) -> None:
+        self.engine_count = engine_count
+        self.reset_wave(self.current_wave)
+
+    def update(
+        self, engine_index: int, stats: SchedulerStats
+    ) -> PrefillAlignmentRelease | None:
+        if stats.current_wave < self.current_wave:
+            return None
+        if stats.current_wave > self.current_wave:
+            self.reset_wave(stats.current_wave)
+
+        if stats.prefill_alignment_ack_generation >= 0:
+            self._acknowledge(engine_index, stats)
+
+        if stats.prefill_alignment_phase == _PREFILL_ALIGNMENT_ACTUAL:
+            return None
+        if stats.prefill_alignment_phase != _PREFILL_ALIGNMENT_OBSERVE:
+            return None
+
+        if self.pending_release is not None:
+            if (
+                stats.step_counter - self.pending_release.target_step
+                < self.max_delay_passes
+            ):
+                return None
+            logger.warning(
+                "Prefill alignment release %d timed out waiting for acks; "
+                "advancing and broadcasting a fail-open resync.",
+                self.pending_release.release_id,
+            )
+            self._finish_release()
+            return self._release(stats.step_counter, "ack_timeout_resync")
+
+        if stats.prefill_alignment_generation != self.current_release_id:
+            return None
+
+        step_snapshots = self.snapshots.setdefault(stats.step_counter, {})
+        step_snapshots[engine_index] = stats
+        if len(step_snapshots) < self.engine_count:
+            return None
+
+        self.snapshots = {
+            step: values
+            for step, values in self.snapshots.items()
+            if step > stats.step_counter
+        }
+        ordered = [step_snapshots[i] for i in range(self.engine_count)]
+        num_prefillable = sum(item.prefill_deferred for item in ordered)
+        if num_prefillable == 0:
+            self.delayed_passes = 0
+            return None
+
+        if any(item.prefill_force_allow for item in ordered):
+            return self._release(stats.step_counter, "capacity_force_allow")
+
+        if num_prefillable == self.engine_count:
+            max_running = max(item.prefill_running_batch for item in ordered)
+            max_prefill = max(item.prefill_max_batch for item in ordered)
+            max_running_requests = max(
+                item.prefill_max_running_requests for item in ordered
+            )
+            slot_limited = max_running_requests - max_running < max_prefill
+            if slot_limited:
+                if self.skip_first_delay:
+                    self.skip_first_delay = False
+                    return self._release(stats.step_counter, "first_delay_skip")
+                self.delayed_passes += 1
+                if self.delayed_passes >= self.max_delay_passes:
+                    return self._release(stats.step_counter, "max_delay_fail_open")
+                return None
+            return self._release(stats.step_counter, "all_prefillable")
+
+        self.delayed_passes += 1
+        if self.delayed_passes >= self.max_delay_passes:
+            return self._release(stats.step_counter, "max_delay_fail_open")
+        return None
+
+    def _release(self, step: int, reason: str) -> PrefillAlignmentRelease:
+        release = PrefillAlignmentRelease(
+            wave=self.current_wave,
+            release_id=self.current_release_id,
+            target_step=step + self.target_step_lead,
+            reason=reason,
+        )
+        self.pending_release = release
+        self.pending_acks.clear()
+        self.last_actual_prefill.clear()
+        self.delayed_passes = 0
+        return release
+
+    def _acknowledge(self, engine_index: int, stats: SchedulerStats) -> None:
+        release = self.pending_release
+        if release is None:
+            return
+        if (
+            stats.prefill_alignment_ack_generation != release.release_id
+            or stats.prefill_alignment_ack_target_step != release.target_step
+        ):
+            return
+        self.pending_acks.add(engine_index)
+        self.last_actual_prefill[engine_index] = (
+            stats.actual_prefill_requests,
+            stats.actual_prefill_tokens,
+        )
+        if stats.prefill_alignment_release_late:
+            logger.warning(
+                "Prefill alignment late release application: "
+                "engine=%d release_id=%d target_step=%d current_step=%d",
+                engine_index,
+                release.release_id,
+                release.target_step,
+                stats.step_counter,
+            )
+        if len(self.pending_acks) == self.engine_count:
+            if not self.first_completion_logged:
+                logger.info(
+                    "Prefill alignment first release completed across all "
+                    "%d engines: release_id=%d actual=%s",
+                    self.engine_count,
+                    release.release_id,
+                    self.last_actual_prefill,
+                )
+                self.first_completion_logged = True
+            logger.debug(
+                "Prefill alignment release %d completed: %s",
+                release.release_id,
+                self.last_actual_prefill,
+            )
+            self._finish_release()
+
+    def _finish_release(self) -> None:
+        self.current_release_id += 1
+        self.pending_release = None
+        self.pending_acks.clear()
+        self.snapshots.clear()
 
 
 class DPCoordinator:
@@ -77,7 +260,12 @@ class DPCoordinator:
             zmq_addr_pipe.close()
 
     def __init__(
-        self, parallel_config: ParallelConfig, enable_wave_coordination: bool = True
+        self,
+        parallel_config: ParallelConfig,
+        enable_wave_coordination: bool = True,
+        enable_prefill_alignment: bool = False,
+        prefill_alignment_max_delay_passes: int = 30,
+        prefill_alignment_target_step_lead: int = 2,
     ):
         dp_size = parallel_config.data_parallel_size
         assert dp_size > 1, "Coordinator only used for data parallel"
@@ -108,6 +296,13 @@ class DPCoordinator:
                 "back_publish_address": back_publish_address,
                 "zmq_addr_pipe": child_zmq_addr_pipe,
                 "enable_wave_coordination": enable_wave_coordination,
+                "enable_prefill_alignment": enable_prefill_alignment,
+                "prefill_alignment_max_delay_passes": (
+                    prefill_alignment_max_delay_passes
+                ),
+                "prefill_alignment_target_step_lead": (
+                    prefill_alignment_target_step_lead
+                ),
             },
             daemon=True,
         )
@@ -149,6 +344,9 @@ class DPCoordinatorProc:
         engine_count: int,
         min_stats_update_interval_ms: int = 100,
         enable_wave_coordination: bool = True,
+        enable_prefill_alignment: bool = False,
+        prefill_alignment_max_delay_passes: int = 30,
+        prefill_alignment_target_step_lead: int = 2,
     ):
         set_process_title("DPCoordinator")
         self.ctx = zmq.Context()
@@ -157,6 +355,15 @@ class DPCoordinatorProc:
 
         self.stats_update_interval_ms = min_stats_update_interval_ms
         self.enable_wave_coordination = enable_wave_coordination
+        self.prefill_alignment = (
+            PrefillAlignmentCoordinator(
+                engine_count,
+                prefill_alignment_max_delay_passes,
+                prefill_alignment_target_step_lead,
+            )
+            if enable_prefill_alignment
+            else None
+        )
 
     @staticmethod
     def run_coordinator(
@@ -167,11 +374,17 @@ class DPCoordinatorProc:
         zmq_addr_pipe=None,
         min_stats_update_interval_ms: int = 100,
         enable_wave_coordination: bool = True,
+        enable_prefill_alignment: bool = False,
+        prefill_alignment_max_delay_passes: int = 30,
+        prefill_alignment_target_step_lead: int = 2,
     ):
         coordinator = DPCoordinatorProc(
             engine_count=engine_count,
             min_stats_update_interval_ms=min_stats_update_interval_ms,
             enable_wave_coordination=enable_wave_coordination,
+            enable_prefill_alignment=enable_prefill_alignment,
+            prefill_alignment_max_delay_passes=(prefill_alignment_max_delay_passes),
+            prefill_alignment_target_step_lead=(prefill_alignment_target_step_lead),
         )
         try:
             coordinator.process_input_socket(
@@ -342,6 +555,8 @@ class DPCoordinatorProc:
                                 current_count,
                                 new_engine_count,
                             )
+                        if self.prefill_alignment is not None:
+                            self.prefill_alignment.resize(new_engine_count)
                         continue  # Skip normal engine notification processing
 
                     # Wave coordination: handle new-request messages from front-end.
@@ -375,10 +590,14 @@ class DPCoordinatorProc:
 
                     eng_index = outputs.engine_index
                     scheduler_stats = outputs.scheduler_stats
-                    if scheduler_stats:
-                        # Elastic EP stats may arrive while the engine list changes.
-                        if eng_index >= len(self.engines):
-                            continue
+                    # Elastic EP stats may arrive while the engine list changes.
+                    if scheduler_stats and eng_index >= len(self.engines):
+                        continue
+
+                    if scheduler_stats and (
+                        scheduler_stats.prefill_alignment_phase
+                        != _PREFILL_ALIGNMENT_ACTUAL
+                    ):
                         # 1. Updated request load stats - update our local
                         # state with these.
                         stats = self.engines[eng_index].request_counts
@@ -416,6 +635,13 @@ class DPCoordinatorProc:
                         stats[2] = scheduler_stats.kv_cache_usage
                         stats_changed = True
 
+                    if scheduler_stats and self.prefill_alignment is not None:
+                        release = self.prefill_alignment.update(
+                            eng_index, scheduler_stats
+                        )
+                        if release is not None:
+                            self._send_prefill_alignment_release(publish_back, release)
+
                     # Wave coordination: handle wave completion and start notifications
                     # Only process these when wave coordination is enabled
                     if self.enable_wave_coordination:
@@ -433,6 +659,8 @@ class DPCoordinatorProc:
                                 current_wave = new_wave
                                 engines_running = False
                                 wave_state_changed = True
+                                if self.prefill_alignment is not None:
+                                    self.prefill_alignment.reset_wave(new_wave)
                         elif (wave := outputs.start_wave) is not None and (
                             wave > current_wave
                             or (wave == current_wave and not engines_running)
@@ -465,6 +693,22 @@ class DPCoordinatorProc:
         """
         wave_encoded = msgspec.msgpack.encode((wave, exclude_engine_index))
         socket.send_multipart((EngineCoreRequestType.START_DP_WAVE.value, wave_encoded))
+
+    @staticmethod
+    def _send_prefill_alignment_release(
+        socket: zmq.Socket, release: PrefillAlignmentRelease
+    ) -> None:
+        payload = msgspec.msgpack.encode(
+            (
+                release.wave,
+                release.release_id,
+                release.target_step,
+                release.reason,
+            )
+        )
+        socket.send_multipart(
+            (EngineCoreRequestType.PREFILL_ALIGNMENT_RELEASE.value, payload)
+        )
 
     def _get_engine_counts(self, do_copy=False) -> list[list[int | float]]:
         """Return list of [waiting, running] count lists for each engine."""

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -1931,6 +1931,14 @@ class DPEngineCoreProc(EngineCoreProc):
 
         scheduler_config = vllm_config.scheduler_config
         self.prefill_schedule_interval = scheduler_config.prefill_schedule_interval
+        self.enable_adaptive_prefill_alignment = (
+            scheduler_config.enable_adaptive_prefill_alignment
+        )
+        self.prefill_alignment_generation = 0
+        self.prefill_alignment_release: tuple[int, int, int, str] | None = None
+        self.prefill_alignment_applied: tuple[int, int, bool] | None = None
+        self.prefill_alignment_allow_this_step = False
+        self.prefill_alignment_last_schedule_sequence = 0
 
         # Counts forward-passes of the model so that we can synchronize
         # finished with DP peers every N steps.
@@ -1961,6 +1969,10 @@ class DPEngineCoreProc(EngineCoreProc):
             engine_index=dp_rank,
             tensor_queue=tensor_queue,
         )
+        if self.enable_adaptive_prefill_alignment:
+            # In adaptive mode a saturated rank reports the condition to the
+            # coordinator. It must not independently bypass global alignment.
+            self.scheduler.set_prefill_capacity_override_enabled(False)
 
     def _init_data_parallel(self, vllm_config: VllmConfig):
         # Configure GPUs and stateless process group for data parallel.
@@ -2006,6 +2018,7 @@ class DPEngineCoreProc(EngineCoreProc):
         if self.has_coordinator and request_wave != self.current_wave:
             if request_wave > self.current_wave:
                 self.current_wave = request_wave
+                self._reset_prefill_alignment()
             elif (
                 not self.engines_running
                 and self.scheduler.pause_state == PauseState.UNPAUSED
@@ -2058,6 +2071,8 @@ class DPEngineCoreProc(EngineCoreProc):
             if exclude_eng_index != self.engine_index and (
                 new_wave >= self.current_wave
             ):
+                if new_wave > self.current_wave:
+                    self._reset_prefill_alignment()
                 self.current_wave = new_wave
                 if not self.engines_running:
                     logger.debug(
@@ -2065,11 +2080,155 @@ class DPEngineCoreProc(EngineCoreProc):
                         new_wave,
                     )
                     self.engines_running = True
+        elif request_type == EngineCoreRequestType.PREFILL_ALIGNMENT_RELEASE:
+            wave, generation, target_step, reason = request
+            if not self.enable_adaptive_prefill_alignment or wave != self.current_wave:
+                return
+            if generation < self.prefill_alignment_generation:
+                return
+            if generation > self.prefill_alignment_generation:
+                logger.warning(
+                    "DP%d resynchronizing prefill alignment generation %d to %d.",
+                    self.dp_rank,
+                    self.prefill_alignment_generation,
+                    generation,
+                )
+                self.prefill_alignment_generation = generation
+            self.prefill_alignment_release = (
+                wave,
+                generation,
+                target_step,
+                reason,
+            )
+            logger.debug(
+                "DP%d received prefill release wave=%d generation=%d "
+                "target_step=%d reason=%s.",
+                self.dp_rank,
+                wave,
+                generation,
+                target_step,
+                reason,
+            )
         else:
             super()._handle_client_request(request_type, request)
 
+    def _reset_prefill_alignment(self) -> None:
+        self.prefill_alignment_generation = 0
+        self.prefill_alignment_release = None
+        self.prefill_alignment_applied = None
+        self.prefill_alignment_allow_this_step = False
+
+    def _prepare_prefill_alignment_step(self) -> None:
+        if not self.enable_adaptive_prefill_alignment or not self.has_coordinator:
+            return
+        self.prefill_alignment_allow_this_step = False
+        release = self.prefill_alignment_release
+        if release is None:
+            return
+        wave, generation, target_step, _ = release
+        if wave != self.current_wave:
+            self.prefill_alignment_release = None
+            return
+        if self.step_counter < target_step:
+            return
+
+        release_late = self.step_counter > target_step
+        self.prefill_alignment_applied = (
+            generation,
+            target_step,
+            release_late,
+        )
+        self.prefill_alignment_generation = generation + 1
+        self.prefill_alignment_release = None
+        self.prefill_alignment_allow_this_step = True
+        logger.debug(
+            "DP%d applying prefill release wave=%d generation=%d "
+            "target_step=%d current_step=%d late=%s.",
+            self.dp_rank,
+            wave,
+            generation,
+            target_step,
+            self.step_counter,
+            release_late,
+        )
+
+    def _publish_prefill_alignment_observation(self) -> None:
+        if not self.enable_adaptive_prefill_alignment or not self.has_coordinator:
+            return
+        counts = self.scheduler.get_request_counts()
+        telemetry = self.scheduler.get_prefill_alignment_telemetry()
+        has_new_walk = (
+            telemetry is not None
+            and telemetry.schedule_sequence
+            != self.prefill_alignment_last_schedule_sequence
+        )
+        if has_new_walk:
+            assert telemetry is not None
+            self.prefill_alignment_last_schedule_sequence = telemetry.schedule_sequence
+        applied = self.prefill_alignment_applied
+        ack_generation, ack_target_step, release_late = (
+            applied if applied is not None else (-1, -1, False)
+        )
+        stats = SchedulerStats(
+            *counts,
+            step_counter=self.step_counter,
+            current_wave=self.current_wave,
+            prefill_alignment_phase=1,
+            prefill_alignment_generation=self.prefill_alignment_generation,
+            prefill_alignment_ack_generation=ack_generation,
+            prefill_alignment_ack_target_step=ack_target_step,
+            prefill_alignment_release_late=release_late,
+            prefillable=bool(has_new_walk and telemetry.candidate_seen),
+            prefill_deferred=bool(has_new_walk and telemetry.candidate_deferred),
+            prefill_force_allow=bool(has_new_walk and telemetry.capacity_force_allow),
+            prefill_token_usage=telemetry.token_usage if telemetry else 0.0,
+            prefill_running_batch=telemetry.running_batch if telemetry else 0,
+            prefill_max_batch=(telemetry.max_prefill_batch if has_new_walk else 0),
+            prefill_max_running_requests=(
+                telemetry.max_running_requests if telemetry else 0
+            ),
+            prefill_waiting_queue_len=(telemetry.waiting_queue_len if telemetry else 0),
+            actual_prefill_requests=(
+                telemetry.actual_prefill_requests if has_new_walk else 0
+            ),
+            actual_prefill_tokens=(
+                telemetry.actual_prefill_tokens if has_new_walk else 0
+            ),
+        )
+        self.output_queue.put_nowait((-1, EngineCoreOutputs(scheduler_stats=stats)))
+        self.prefill_alignment_applied = None
+
+    def _publish_prefill_alignment_final_ack(self) -> None:
+        if (
+            not self.enable_adaptive_prefill_alignment
+            or not self.has_coordinator
+            or self.prefill_alignment_applied is None
+        ):
+            return
+        generation, target_step, release_late = self.prefill_alignment_applied
+        telemetry = self.scheduler.get_prefill_alignment_telemetry()
+        counts = self.scheduler.get_request_counts()
+        stats = SchedulerStats(
+            *counts,
+            step_counter=self.step_counter,
+            current_wave=self.current_wave,
+            prefill_alignment_phase=2,
+            prefill_alignment_generation=self.prefill_alignment_generation,
+            prefill_alignment_ack_generation=generation,
+            prefill_alignment_ack_target_step=target_step,
+            prefill_alignment_release_late=release_late,
+            actual_prefill_requests=(
+                telemetry.actual_prefill_requests if telemetry else 0
+            ),
+            actual_prefill_tokens=(telemetry.actual_prefill_tokens if telemetry else 0),
+        )
+        self.output_queue.put_nowait((-1, EngineCoreOutputs(scheduler_stats=stats)))
+        self.prefill_alignment_applied = None
+
     def _maybe_publish_request_counts(self):
-        if not self.publish_dp_lb_stats:
+        if not self.publish_dp_lb_stats or (
+            self.enable_adaptive_prefill_alignment and self.has_coordinator
+        ):
             return
 
         # Publish our request counts (if they've changed), stamped with the
@@ -2086,6 +2245,9 @@ class DPEngineCoreProc(EngineCoreProc):
             self.output_queue.put_nowait((-1, EngineCoreOutputs(scheduler_stats=stats)))
 
     def _should_throttle_prefills(self) -> bool:
+        if self.enable_adaptive_prefill_alignment and self.has_coordinator:
+            return not self.prefill_alignment_allow_this_step
+
         # Throttle new prefills to cadence-aligned steps for DP balancing.
         # step_counter is identical across DP ranks. On a fresh wave the
         # counter is 0, so prefills are admitted immediately after idle.
@@ -2104,6 +2266,8 @@ class DPEngineCoreProc(EngineCoreProc):
             self._process_input_queue()
             # Publish request counts before and after GPU step to ensure freshness.
             self._maybe_publish_request_counts()
+            self._publish_prefill_alignment_observation()
+            self._prepare_prefill_alignment_step()
 
             if self.eep_scaling_state is not None:
                 state = self.eep_scaling_state
@@ -2143,6 +2307,7 @@ class DPEngineCoreProc(EngineCoreProc):
             )
 
             if not self.engines_running:
+                self._publish_prefill_alignment_final_ack()
                 if self.dp_rank == 0 or not self.has_coordinator:
                     # Notify client that we are pausing the loop.
                     logger.debug(
@@ -2161,6 +2326,7 @@ class DPEngineCoreProc(EngineCoreProc):
                 # Increment wave count and reset step counter.
                 self.current_wave += 1
                 self.step_counter = 0
+                self._reset_prefill_alignment()
 
         raise SystemExit
 

--- a/vllm/v1/engine/utils.py
+++ b/vllm/v1/engine/utils.py
@@ -1096,6 +1096,15 @@ def launch_core_engines(
         coordinator = DPCoordinator(
             parallel_config,
             enable_wave_coordination=vllm_config.model_config.is_moe,
+            enable_prefill_alignment=(
+                vllm_config.scheduler_config.enable_adaptive_prefill_alignment
+            ),
+            prefill_alignment_max_delay_passes=(
+                vllm_config.scheduler_config.prefill_alignment_max_delay_passes
+            ),
+            prefill_alignment_target_step_lead=(
+                vllm_config.scheduler_config.prefill_alignment_target_step_lead
+            ),
         )
 
         addresses.coordinator_input, addresses.coordinator_output = (

--- a/vllm/v1/metrics/stats.py
+++ b/vllm/v1/metrics/stats.py
@@ -167,6 +167,21 @@ class KVCacheEvictionEvent:
     reuse_gaps_seconds: tuple[float, ...]
 
 
+@dataclass(frozen=True)
+class PrefillAlignmentTelemetry:
+    schedule_sequence: int = 0
+    candidate_seen: bool = False
+    candidate_deferred: bool = False
+    capacity_force_allow: bool = False
+    token_usage: float = 0.0
+    running_batch: int = 0
+    max_prefill_batch: int = 0
+    max_running_requests: int = 0
+    waiting_queue_len: int = 0
+    actual_prefill_requests: int = 0
+    actual_prefill_tokens: int = 0
+
+
 @dataclass
 class SchedulerIterationDetails:
     """Scheduler-side details for one engine iteration."""
@@ -194,6 +209,25 @@ class SchedulerStats:
     # These are used for internal DP load-balancing.
     step_counter: int = 0
     current_wave: int = 0
+
+    # Coordinator-driven DP prefill alignment. Phase 1 is the regular
+    # observation (including the previous step's actual/ack); phase 2 is only
+    # a final ack when a wave pauses before another observation can be sent.
+    prefill_alignment_phase: int = 0
+    prefill_alignment_generation: int = -1
+    prefill_alignment_ack_generation: int = -1
+    prefill_alignment_ack_target_step: int = -1
+    prefill_alignment_release_late: bool = False
+    prefillable: bool = False
+    prefill_deferred: bool = False
+    prefill_force_allow: bool = False
+    prefill_token_usage: float = 0.0
+    prefill_running_batch: int = 0
+    prefill_max_batch: int = 0
+    prefill_max_running_requests: int = 0
+    prefill_waiting_queue_len: int = 0
+    actual_prefill_requests: int = 0
+    actual_prefill_tokens: int = 0
 
     kv_cache_usage: float = 0.0
     iteration_details: SchedulerIterationDetails | None = None


### PR DESCRIPTION
  ## Purpose

  When a large prefill is scheduled on only one DP engine, that engine performs a
  much longer model iteration while the other engines wait for it to finish. This
  creates uneven iteration times and delays ongoing decode requests.

  This PR adds an optional adaptive prefill delayer. It coordinates large prefill
  work onto the same engine steps across DP ranks, reducing iterations where one
  rank is doing prefill while others are decoding. Decode continues while prefill
  is delayed, with bounded fail-open and recovery behavior to guarantee progress.

  ## Test Plan

  Tested DeepSeek-V4 using:

  ```bash
  vllm serve "$MODEL" \
      --trust-remote-code \
      --kv-cache-dtype fp8 \
      --block-size 256 \
      --no-enable-prefix-caching \
      --tensor-parallel-size 1 \
      --data-parallel-size 8 \
      --enable-expert-parallel \
      --moe-backend deep_gemm_mega_moe \
      --prefill-schedule-interval 1 \
      --enable-adaptive-prefill-alignment \
      --prefill-alignment-max-delay-passes 30 \
      --prefill-alignment-target-step-lead 2 \
      --max-model-len 16384 \
      --max-num-batched-tokens 2048
  ```

  Added unit tests for coordinated release, delay limits, capacity release,
  missing acknowledgments, and DP-wave resets.

  ## Test Result

  ```text
  10 passed in 9.68s
  Ruff checks passed
  All changed files are formatted
  ```