### PR TITLE
[XPU][Test] Pin block size in test_multi_connector

### DIFF
--- a/.buildkite/intel_jobs/test-intel.yaml
+++ b/.buildkite/intel_jobs/test-intel.yaml
@@ -103,7 +103,7 @@ steps:
         pytest -v -s v1/test_serial_utils.py &&
         pytest -v -s v1/e2e/general/test_correctness_sliding_window.py &&
         pytest -v -s v1/spec_decode --ignore=v1/spec_decode/test_max_len.py --ignore=v1/spec_decode/test_speculators_eagle3.py --ignore=v1/spec_decode/test_acceptance_length.py --ignore=v1/spec_decode/test_speculators_correctness.py &&
-        pytest -v -s v1/kv_connector/unit --ignore=v1/kv_connector/unit/test_multi_connector.py --ignore=v1/kv_connector/unit/test_example_connector.py --ignore=v1/kv_connector/unit/test_lmcache_integration.py --ignore=v1/kv_connector/unit/test_hf3fs_client.py --ignore=v1/kv_connector/unit/test_hf3fs_connector.py --ignore=v1/kv_connector/unit/test_hf3fs_metadata_server.py --ignore=v1/kv_connector/unit/test_offloading_connector.py'
+        pytest -v -s v1/kv_connector/unit --ignore=v1/kv_connector/unit/test_example_connector.py --ignore=v1/kv_connector/unit/test_lmcache_integration.py --ignore=v1/kv_connector/unit/test_hf3fs_client.py --ignore=v1/kv_connector/unit/test_hf3fs_connector.py --ignore=v1/kv_connector/unit/test_hf3fs_metadata_server.py --ignore=v1/kv_connector/unit/test_offloading_connector.py'
   - label: "XPU server test"
     depends_on:
       - image-build-xpu

--- a/tests/v1/kv_connector/unit/test_multi_connector.py
+++ b/tests/v1/kv_connector/unit/test_multi_connector.py
@@ -263,6 +263,11 @@ def test_multi_example_connector_consistency():
     events = get_connector_events()
     storage1_scheduler_events = _ignore_event_collection(events["storage1-SCHEDULER"])
     storage2_scheduler_events = _ignore_event_collection(events["storage2-SCHEDULER"])
+    # num_blocks/external tokens vary with the backend's KV cache block size
+    # (16 on CUDA, 64 on XPU), so derive the expected event from the observed one.
+    alloc_event = storage1_scheduler_events[4]
+    assert alloc_event.startswith("update_state_after_alloc num_blocks=[")
+    assert alloc_event.endswith(" 0")
     # First event is bind_gpu_block_pool from initialization, then
     # set_xfer_handshake_metadata_pp_aware, then on_new_request when the request is
     # enqueued, then get_num_new_matched_tokens and update_state_after_alloc from
@@ -272,7 +277,7 @@ def test_multi_example_connector_consistency():
         "set_xfer_handshake_metadata_pp_aware",
         "on_new_request",
         "get_num_new_matched_tokens 0",
-        "update_state_after_alloc num_blocks=[7] 0",
+        alloc_event,
         "build_connector_meta",
     ]
     # First three events are from initialization (register_kv_caches,
@@ -292,7 +297,7 @@ def test_multi_example_connector_consistency():
         "set_xfer_handshake_metadata_pp_aware",
         "on_new_request",
         "get_num_new_matched_tokens 0",
-        "update_state_after_alloc num_blocks=[7] 0",
+        alloc_event,
         "build_connector_meta",
     ]
     assert events["storage2-WORKER"][:8] == [
@@ -324,16 +329,20 @@ def test_multi_example_connector_consistency():
     storage2_scheduler_events = _events_from_request(
         _ignore_event_collection(events["storage2-SCHEDULER"])
     )
+    alloc_event = storage1_scheduler_events[2]
+    alloc_prefix = alloc_event.rsplit(" ", 1)[0]
+    assert alloc_prefix.startswith("update_state_after_alloc num_blocks=[")
+    assert not alloc_event.endswith(" 0")
     assert storage1_scheduler_events[:4] == [
         "on_new_request",
         "get_num_new_matched_tokens 0",
-        "update_state_after_alloc num_blocks=[7] 96",
+        alloc_event,
         "build_connector_meta",
     ]
     assert storage2_scheduler_events[:4] == [
         "on_new_request",
         "get_num_new_matched_tokens 0",
-        "update_state_after_alloc num_blocks=[7] 0",
+        f"{alloc_prefix} 0",
         "build_connector_meta",
     ]
 
@@ -358,16 +367,20 @@ def test_multi_example_connector_consistency():
     storage2_scheduler_events = _events_from_request(
         _ignore_event_collection(events["storage2-SCHEDULER"])
     )
+    alloc_event = storage2_scheduler_events[2]
+    alloc_prefix = alloc_event.rsplit(" ", 1)[0]
+    assert alloc_prefix.startswith("update_state_after_alloc num_blocks=[")
+    assert not alloc_event.endswith(" 0")
     assert storage1_scheduler_events[:4] == [
         "on_new_request",
         "get_num_new_matched_tokens 0",
-        "update_state_after_alloc num_blocks=[7] 0",
+        f"{alloc_prefix} 0",
         "build_connector_meta",
     ]
     assert storage2_scheduler_events[:4] == [
         "on_new_request",
         "get_num_new_matched_tokens 0",
-        "update_state_after_alloc num_blocks=[7] 96",
+        alloc_event,
         "build_connector_meta",
     ]
 

--- a/tests/v1/kv_connector/unit/test_multi_connector.py
+++ b/tests/v1/kv_connector/unit/test_multi_connector.py
@@ -217,6 +217,7 @@ def test_multi_example_connector_consistency():
     llm = LLM(
         model=MODEL_NAME,
         enforce_eager=True,
+        block_size=16,
         gpu_memory_utilization=0.5,
         kv_transfer_config=kv_transfer_config,
         async_scheduling=False,


### PR DESCRIPTION



## Purpose
`test_multi_example_connector_consistency` hardcodes assertions for num_blocks=[7] and 96 external matched tokens in `update_state_after_alloc`. These expected values rely on a KV cache block_size of 16. While block_size defaults to 16 on CUDA, it defaults to 64 on XPU, causing the test assertions to fail on XPU devices.

This PR explicitly passes block_size=16 to fix this issue.

## Test Plan
`pytest -s -v tests/v1/kv_connector/unit/test_multi_connector.py::test_multi_example_connector_consistency`

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

