### PR TITLE
[Bugfix] Close usage telemetry HTTP sessions

### DIFF
--- a/vllm/usage/usage_lib.py
+++ b/vllm/usage/usage_lib.py
@@ -19,7 +19,6 @@ import requests
 import torch
 
 import vllm.envs as envs
-from vllm.connections import global_http_connection
 from vllm.logger import init_logger
 from vllm.utils.platform_utils import cuda_get_device_properties
 from vllm.version import __version__ as VLLM_VERSION
@@ -265,8 +264,8 @@ class UsageMessage:
 
     def _send_to_server(self, data: dict[str, Any]) -> None:
         try:
-            global_http_client = global_http_connection.get_sync_client()
-            global_http_client.post(_USAGE_STATS_SERVER, json=data)
+            with requests.Session() as client:
+                client.post(_USAGE_STATS_SERVER, json=data)
         except requests.exceptions.RequestException:
             # silently ignore unless we are using debug log
             logging.debug("Failed to send usage data to server")


### PR DESCRIPTION
## The bug

#6600 intentionally moved vLLM's HTTP callers onto a shared reusable session. That remains useful for repeated asset and media requests. Usage reporting sends during startup and then once every ten minutes. The shared client leaves an external HTTPS socket in the frontend between those reports.

## Measured

I tested vLLM `d36f24b66` with Qwen3-1.7B on one RTX 4090 Laptop GPU. With usage reporting enabled, the post-initialization process tree retained one established external IPv6 HTTPS socket. The checkpoint harness rejected that state before creating a snapshot. With `VLLM_NO_USAGE_STATS=1`, the same source recorded zero external sockets. One snapshot then completed six additional exact-output restores.

## Verified on hardware

With this change and usage reporting still enabled, the socket inventory recorded zero established external connections. One full GPU checkpoint and five additional restores returned the expected token. Restore-to-token was 5.052525 seconds median, n=6. The warm control was 18.096237 seconds, n=1. Snapshot creation was outside the restore clock.

This is evidence for the socket-lifecycle fix, not a claim that telemetry changes startup latency.

## The fix

Use a context-managed, one-shot `requests.Session` for usage reports. The report is still sent, but the session closes when the request completes. The shared connection remains unchanged for asset, media, and batch request paths. The tradeoff is one new connection for each ten-minute telemetry report instead of retaining that connection between reports.

## Test plan

- `pytest -q tests/test_envs.py` (55 passed)
- `ruff check vllm/usage/usage_lib.py tests/test_envs.py`
- `ruff format --check vllm/usage/usage_lib.py tests/test_envs.py`
