### PR TITLE
[Bugfix][KV Offload] Clean up resources after initialization failure

### DIFF
--- a/vllm/v1/kv_offload/cpu/spec.py
+++ b/vllm/v1/kv_offload/cpu/spec.py
@@ -165,12 +165,17 @@ class CPUOffloadingSpec(OffloadingSpec):
                 kv_bytes_per_block=self.kv_bytes_per_chunk,
                 cpu_page_size=self.cpu_page_size_per_worker,
             )
-        return CPUOffloadingWorker(
-            kv_caches=kv_caches,
-            blocks_per_chunk=self.blocks_per_chunk,
-            num_cpu_blocks=self.num_blocks,
-            mmap_region=mmap_region,
-        )
+        try:
+            return CPUOffloadingWorker(
+                kv_caches=kv_caches,
+                blocks_per_chunk=self.blocks_per_chunk,
+                num_cpu_blocks=self.num_blocks,
+                mmap_region=mmap_region,
+            )
+        except Exception:
+            if mmap_region is not None:
+                mmap_region.cleanup()
+            raise
 
     @override
     def get_worker(self, kv_caches: CanonicalKVCaches) -> OffloadingWorker:

--- a/vllm/v1/kv_offload/tiering/spec.py
+++ b/vllm/v1/kv_offload/tiering/spec.py
@@ -190,19 +190,22 @@ class TieringOffloadingSpec(CPUOffloadingSpec):
                     "store_threshold is not supported for TieringOffloadingSpec"
                 )
 
-            # Create scheduler-side SharedOffloadRegion (rank=None) so the
-            # primary tier can eagerly create a memoryview over _base.
-            scheduler_mmap = SharedOffloadRegion(
-                engine_id=self._engine_id,
-                num_blocks=self.num_blocks,
-                rank=None,
-                kv_bytes_per_block=self.kv_bytes_per_chunk,
-                cpu_page_size=self.cpu_page_size_per_worker,
-            )
-            self._scheduler_mmap = scheduler_mmap
-
-            # Create primary tier (CPU-based)
+            scheduler_mmap: SharedOffloadRegion | None = None
+            primary_tier: CPUPrimaryTierOffloadingManager | None = None
+            secondary_tiers = []
             try:
+                # Create scheduler-side SharedOffloadRegion (rank=None) so the
+                # primary tier can eagerly create a memoryview over _base.
+                scheduler_mmap = SharedOffloadRegion(
+                    engine_id=self._engine_id,
+                    num_blocks=self.num_blocks,
+                    rank=None,
+                    kv_bytes_per_block=self.kv_bytes_per_chunk,
+                    cpu_page_size=self.cpu_page_size_per_worker,
+                )
+                self._scheduler_mmap = scheduler_mmap
+
+                # Create primary tier (CPU-based)
                 primary_tier = CPUPrimaryTierOffloadingManager(
                     num_blocks=self.num_blocks,
                     cache_policy=self.eviction_policy,
@@ -210,22 +213,10 @@ class TieringOffloadingSpec(CPUOffloadingSpec):
                     enable_events=self.kv_events_config.enable_kv_cache_events,
                     mmap_region=scheduler_mmap,
                 )
-            except Exception:
-                try:
-                    scheduler_mmap.cleanup()
-                except Exception:
-                    logger.exception(
-                        "Failed to clean up scheduler mmap after primary tier "
-                        "initialization failure"
-                    )
-                self._scheduler_mmap = None
-                raise
 
-            # Create secondary tiers
-            primary_kv_view = primary_tier.get_kv_memoryview()
-            secondary_tiers = []
-            for i, tier_config in enumerate(self.secondary_tier_configs):
-                try:
+                # Create secondary tiers
+                primary_kv_view = primary_tier.get_kv_memoryview()
+                for i, tier_config in enumerate(self.secondary_tier_configs):
                     tier = SecondaryTierFactory.create_secondary_tier(
                         tier_config, primary_kv_view, self
                     )
@@ -235,20 +226,26 @@ class TieringOffloadingSpec(CPUOffloadingSpec):
                         i,
                         tier.tier_type,
                     )
-                except Exception as e:
-                    logger.error(
-                        "Failed to create secondary tier from config index %i: %s",
-                        i,
-                        e,
-                    )
-                    for tier in reversed(secondary_tiers):
-                        try:
-                            tier.shutdown()
-                        except Exception:
-                            logger.exception(
-                                "Failed to shut down secondary tier during "
-                                "initialization cleanup"
-                            )
+
+                # Create TieringOffloadingManager. GPU↔CPU transfers use the inherited
+                # get_worker(). Secondary tier transfers are handled by the
+                # secondary tier managers and need no additional workers here.
+                tiering_manager = TieringOffloadingManager(
+                    primary_tier=primary_tier,
+                    secondary_tiers=secondary_tiers,
+                )
+                self._manager = tiering_manager
+            except Exception:
+                logger.exception("Failed to initialize tiering offloading manager")
+                for tier in reversed(secondary_tiers):
+                    try:
+                        tier.shutdown()
+                    except Exception:
+                        logger.exception(
+                            "Failed to shut down secondary tier during "
+                            "initialization cleanup"
+                        )
+                if primary_tier is not None:
                     try:
                         primary_tier.shutdown()
                     except Exception:
@@ -256,17 +253,16 @@ class TieringOffloadingSpec(CPUOffloadingSpec):
                             "Failed to shut down primary tier during "
                             "initialization cleanup"
                         )
-                    self._scheduler_mmap = None
-                    raise
-
-            # Create TieringOffloadingManager. GPU↔CPU transfers use the inherited
-            # get_worker(). Secondary tier transfers are handled by the
-            # secondary tier managers and need no additional workers here.
-            tiering_manager = TieringOffloadingManager(
-                primary_tier=primary_tier,
-                secondary_tiers=secondary_tiers,
-            )
-            self._manager = tiering_manager
+                elif scheduler_mmap is not None:
+                    try:
+                        scheduler_mmap.cleanup()
+                    except Exception:
+                        logger.exception(
+                            "Failed to clean up scheduler mmap during "
+                            "initialization cleanup"
+                        )
+                self._scheduler_mmap = None
+                raise
 
             logger.info(
                 "Created TieringOffloadingManager with primary tier "

--- a/vllm/v1/kv_offload/tiering/spec.py
+++ b/vllm/v1/kv_offload/tiering/spec.py
@@ -197,13 +197,24 @@ class TieringOffloadingSpec(CPUOffloadingSpec):
             self._scheduler_mmap = scheduler_mmap
 
             # Create primary tier (CPU-based)
-            primary_tier = CPUPrimaryTierOffloadingManager(
-                num_blocks=self.num_blocks,
-                cache_policy=self.eviction_policy,
-                cache_policy_module_path=self.cache_policy_module_path,
-                enable_events=self.kv_events_config.enable_kv_cache_events,
-                mmap_region=scheduler_mmap,
-            )
+            try:
+                primary_tier = CPUPrimaryTierOffloadingManager(
+                    num_blocks=self.num_blocks,
+                    cache_policy=self.eviction_policy,
+                    cache_policy_module_path=self.cache_policy_module_path,
+                    enable_events=self.kv_events_config.enable_kv_cache_events,
+                    mmap_region=scheduler_mmap,
+                )
+            except Exception:
+                try:
+                    scheduler_mmap.cleanup()
+                except Exception:
+                    logger.exception(
+                        "Failed to clean up scheduler mmap after primary tier "
+                        "initialization failure"
+                    )
+                self._scheduler_mmap = None
+                raise
 
             # Create secondary tiers
             primary_kv_view = primary_tier.get_kv_memoryview()
@@ -225,6 +236,22 @@ class TieringOffloadingSpec(CPUOffloadingSpec):
                         i,
                         e,
                     )
+                    for tier in reversed(secondary_tiers):
+                        try:
+                            tier.shutdown()
+                        except Exception:
+                            logger.exception(
+                                "Failed to shut down secondary tier during "
+                                "initialization cleanup"
+                            )
+                    try:
+                        primary_tier.shutdown()
+                    except Exception:
+                        logger.exception(
+                            "Failed to shut down primary tier during "
+                            "initialization cleanup"
+                        )
+                    self._scheduler_mmap = None
                     raise
 
             # Create TieringOffloadingManager. GPU↔CPU transfers use the inherited
@@ -273,9 +300,13 @@ class TieringOffloadingSpec(CPUOffloadingSpec):
             kv_bytes_per_block=self.kv_bytes_per_chunk,
             cpu_page_size=self.cpu_page_size_per_worker,
         )
-        return CPUOffloadingWorker(
-            kv_caches=kv_caches,
-            blocks_per_chunk=self.blocks_per_chunk,
-            num_cpu_blocks=self.num_blocks,
-            mmap_region=worker_mmap,
-        )
+        try:
+            return CPUOffloadingWorker(
+                kv_caches=kv_caches,
+                blocks_per_chunk=self.blocks_per_chunk,
+                num_cpu_blocks=self.num_blocks,
+                mmap_region=worker_mmap,
+            )
+        except Exception:
+            worker_mmap.cleanup()
+            raise

--- a/vllm/v1/kv_offload/tiering/spec.py
+++ b/vllm/v1/kv_offload/tiering/spec.py
@@ -236,7 +236,6 @@ class TieringOffloadingSpec(CPUOffloadingSpec):
                 )
                 self._manager = tiering_manager
             except Exception:
-                logger.exception("Failed to initialize tiering offloading manager")
                 for tier in reversed(secondary_tiers):
                     try:
                         tier.shutdown()

--- a/vllm/v1/kv_offload/tiering/spec.py
+++ b/vllm/v1/kv_offload/tiering/spec.py
@@ -185,6 +185,11 @@ class TieringOffloadingSpec(CPUOffloadingSpec):
             TieringOffloadingManager instance
         """
         if not self._manager:
+            if int(self.extra_config.get("store_threshold", 0)) >= 2:
+                raise ValueError(
+                    "store_threshold is not supported for TieringOffloadingSpec"
+                )
+
             # Create scheduler-side SharedOffloadRegion (rank=None) so the
             # primary tier can eagerly create a memoryview over _base.
             scheduler_mmap = SharedOffloadRegion(
@@ -261,10 +266,6 @@ class TieringOffloadingSpec(CPUOffloadingSpec):
                 primary_tier=primary_tier,
                 secondary_tiers=secondary_tiers,
             )
-            if int(self.extra_config.get("store_threshold", 0)) >= 2:
-                raise ValueError(
-                    "store_threshold is not supported for TieringOffloadingSpec"
-                )
             self._manager = tiering_manager
 
             logger.info(


### PR DESCRIPTION
# [Bugfix][KV Offload] Clean up resources after initialization failure

## Purpose

Prevent `/dev/shm/vllm_offload_*.mmap` and tier resources from leaking when KV
offloading initialization fails.

- Clean up the scheduler mmap when primary-tier construction fails.
- Shutdown already-created secondary tiers in reverse order when a later tier
  fails, then continue with primary cleanup.
- Clean up CPU/tiering worker mmap regions when worker construction fails.
- Preserve the original initialization exception and clear `_scheduler_mmap`.

The change covers ordinary Python initialization exceptions only; OOM,
SIGKILL, and process crashes remain outside its scope. No duplicate open PR was
found; #51116 and #51081 address unrelated mmap fallback and registration
changes.

## Test Plan

No tests were added for this PR. The initialization-failure cleanup branches
are not directly covered by the existing unit tests; existing
`SharedOffloadRegion` tests only validate the underlying mmap/fd/file cleanup
behavior.

```bash
pre-commit run --files \
  vllm/v1/kv_offload/cpu/spec.py \
  vllm/v1/kv_offload/tiering/spec.py PR_DESCRIPTION.md
```

## Test Result

- Linux unit tests: passed (verified by the author).
- pre-commit: passed.

AI assistance was used; all changed lines require human review.
