### PR TITLE
[Bugfix][Core] Make EncoderDecoderCacheManager slot release idempotent

### DIFF
--- a/tests/v1/core/test_encoder_cache_manager.py
+++ b/tests/v1/core/test_encoder_cache_manager.py
@@ -365,3 +365,35 @@ def test_encoder_decoder_cache_manager_reset_allows_fresh_allocations():
 
     assert manager.num_free_slots == 2
     assert "img2" in manager.allocated
+
+
+def test_encoder_decoder_repeated_free_releases_slots_once():
+    """The scheduler frees encoder inputs on every decode step, so releasing
+    the same input repeatedly must not credit `num_free_slots` more than once.
+    """
+    manager = EncoderDecoderCacheManager(cache_size=20)
+
+    req = MockRequest("req1", ["img1"], [5])
+    manager.allocate(req, 0)
+    assert manager.num_free_slots == 15
+
+    for _ in range(5):
+        manager.free_encoder_input(req, 0)
+        assert manager.num_free_slots == 20
+
+
+def test_encoder_decoder_free_ignores_unallocated_inputs():
+    """`free` is also called for requests whose encoder inputs were never
+    allocated (aborted or preempted while waiting), which must be a no-op.
+    """
+    manager = EncoderDecoderCacheManager(cache_size=20)
+
+    never_allocated = MockRequest("req1", ["img1"], [5])
+    manager.free(never_allocated)
+    assert manager.num_free_slots == 20
+
+    allocated = MockRequest("req2", ["img2"], [5])
+    manager.allocate(allocated, 0)
+    manager.free(allocated)
+    manager.free(allocated)
+    assert manager.num_free_slots == 20

--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -5065,6 +5065,53 @@ def test_cross_attn_zero_blocks_without_encoder_inputs():
     )
 
 
+def test_encoder_decoder_decode_steps_preserve_encoder_cache_budget():
+    """Decoding must not inflate the encoder cache budget.
+
+    `_free_encoder_inputs` runs on every step once an encoder-decoder request
+    has produced a token. When the release is not idempotent, `num_free_slots`
+    grows past `cache_size` and `can_allocate` stops rejecting oversized
+    encoder inputs.
+    """
+    scheduler = _create_encoder_decoder_scheduler()
+    encoder_cache_manager = scheduler.encoder_cache_manager
+    encoder_cache_size = encoder_cache_manager.cache_size
+
+    request = create_requests(
+        num_requests=1,
+        num_tokens=20,
+        max_tokens=20,
+        mm_hashes_list=[["enc_hash"]],
+        mm_positions=[[PlaceholderRange(offset=0, length=1500)]],
+        req_ids=["req_enc_dec"],
+    )[0]
+    scheduler.add_request(request)
+
+    for _ in range(5):
+        output = scheduler.schedule()
+        scheduler.update_from_output(
+            output,
+            ModelRunnerOutput(
+                req_ids=[request.request_id],
+                req_id_to_index={request.request_id: 0},
+                sampled_token_ids=[[100]],
+                logprobs=None,
+                prompt_logprobs_dict={},
+                pooler_output=[],
+            ),
+        )
+        assert encoder_cache_manager.num_free_slots <= encoder_cache_size
+
+    oversized = create_requests(
+        num_requests=1,
+        num_tokens=20,
+        mm_hashes_list=[["enc_hash_big"]],
+        mm_positions=[[PlaceholderRange(offset=0, length=encoder_cache_size + 1)]],
+        req_ids=["req_oversized"],
+    )[0]
+    assert not encoder_cache_manager.can_allocate(oversized, 0, int(1e9), 0)
+
+
 def test_eagle3_mm_encoder_cache_with_shift():
     """Test EAGLE3 encoder scheduling accounts for shift_computed_tokens.
 

--- a/vllm/v1/core/encoder_cache_manager.py
+++ b/vllm/v1/core/encoder_cache_manager.py
@@ -330,12 +330,15 @@ class EncoderDecoderCacheManager(EncoderCacheManager):
         self.num_free_slots = cache_size
         self.allocated: list[str] = []
         self.to_free: list[str] = []
+        # request_id => set of input_ids currently holding slots
+        self.request_cached_ids: dict[str, set[int]] = {}
 
     def reset(self) -> None:
         """Reset the encoder cache to its initial state."""
         self.num_free_slots = self.cache_size
         self.allocated.clear()
         self.to_free.clear()
+        self.request_cached_ids.clear()
 
     def check_and_update_cache(self, request: Request, input_id: int) -> bool:
         return False
@@ -362,13 +365,7 @@ class EncoderDecoderCacheManager(EncoderCacheManager):
 
         mm_hash = request.mm_features[input_id].identifier
         self.allocated.append(mm_hash)
-
-    def free(self, request: Request) -> None:
-        for input_id in range(len(request.mm_features)):
-            self.free_encoder_input(request, input_id)
-
-    def get_cached_input_ids(self, request: Request) -> set[int]:
-        return set(range(len(request.mm_features)))
+        self.request_cached_ids.setdefault(request.request_id, set()).add(input_id)
 
     def get_freed_mm_hashes(self) -> list[str]:
         # As encoder cache is not used for enc-dec models, we can free the entries here
@@ -381,5 +378,18 @@ class EncoderDecoderCacheManager(EncoderCacheManager):
         return to_free
 
     def free_encoder_input(self, request: Request, input_id: int) -> None:
-        num_encoder_embeds = request.get_num_encoder_embeds(input_id)
-        self.num_free_slots += num_encoder_embeds
+        """Release the slots held by `input_id`, at most once per allocation.
+
+        The scheduler calls this on every step once the request has produced a
+        token, so a non-idempotent release grows `num_free_slots` past
+        `cache_size` and `can_allocate` stops enforcing the cache budget.
+        """
+        req_id = request.request_id
+        cached_ids = self.request_cached_ids.get(req_id)
+        if cached_ids is None or input_id not in cached_ids:
+            return
+
+        cached_ids.discard(input_id)
+        if not cached_ids:
+            del self.request_cached_ids[req_id]
+        self.num_free_slots += request.get_num_encoder_embeds(input_id)


### PR DESCRIPTION
## Purpose

For encoder-decoder models (Whisper, Voxtral), the encoder cache budget silently stops being enforced after the first decode step.

`EncoderDecoderCacheManager.allocate()` runs **once** per request — encoder scheduling short-circuits on every later step (`scheduler.py:1528-1542`, `num_computed_tokens > 0`). But `Scheduler._free_encoder_inputs()` runs on **every** step from `update_from_output` (`scheduler.py:1795-1796`), and its enc-dec branch (`scheduler.py:2144-2148`) calls `free_encoder_input()` whenever `num_computed_tokens > 0`.

Two things made that per-step call non-idempotent:

1. `EncoderDecoderCacheManager.free_encoder_input()` credited `num_free_slots` unconditionally, with no reference guard — unlike the base class, which checks `self.cached`.
2. `EncoderDecoderCacheManager.get_cached_input_ids()` returned `set(range(len(request.mm_features)))` unconditionally, so the `if not cached_encoder_input_ids: return` early-out in `_free_encoder_inputs` (`scheduler.py:2129-2131`) never fired.

So `num_free_slots` grew by `num_encoder_embeds` per generated token. Once it exceeds `cache_size`, `can_allocate()` becomes a tautology and the encoder cache size is no longer enforced; worker-side encoder cache occupancy is then bounded only by `max_num_encoder_input_tokens` and `max_num_seqs`.

A second, smaller instance: `free()` iterated `range(len(request.mm_features))` and credited slots for inputs that were never allocated (request aborted or preempted while `WAITING` — `scheduler.py:994`, `:1292`).

### Fix

Track allocated input ids the way the base class does (`request_cached_ids`), make `free_encoder_input()` a no-op unless the input currently holds slots, and drop the `free()` / `get_cached_input_ids()` overrides so the base implementations apply. The `allocated`/`to_free` shuffle in `get_freed_mm_hashes()` is intentionally untouched — it correctly models "free after the runner executes".

No change to model output or sampling, so no eval run applies.

## Test Plan

```bash
pytest tests/v1/core/test_encoder_cache_manager.py -q
pytest tests/v1/core/test_scheduler.py -q -k "encoder or cross_attn"
pytest tests/v1/core/ -q          # regression sweep, compared against origin/main
pre-commit run ruff-check --files <changed files>
pre-commit run ruff-format --files <changed files>
python tools/pre_commit/mypy.py "3.12" vllm/v1/core/encoder_cache_manager.py
```

New regression tests:

- `tests/v1/core/test_encoder_cache_manager.py::test_encoder_decoder_repeated_free_releases_slots_once` — repeated `free_encoder_input` credits `num_free_slots` exactly once.
- `tests/v1/core/test_encoder_cache_manager.py::test_encoder_decoder_free_ignores_unallocated_inputs` — `free()` on a never-allocated (or already released) request is a no-op.
- `tests/v1/core/test_scheduler.py::test_encoder_decoder_decode_steps_preserve_encoder_cache_budget` — drives prefill + 5 decode steps through the existing `_create_encoder_decoder_scheduler` fixture, asserts `num_free_slots <= cache_size` throughout, and asserts `can_allocate` still rejects an oversized encoder input afterwards.

All three fail on `main` and pass with this change.

## Test Result

Scheduler-level reproduction, `cache_size = 8192`, one request with a 1500-embedding encoder input. `num_free_slots` after each step:

| | step 1 | 2 | 3 | 4 | 5 | 6 |
|---|---|---|---|---|---|---|
| before | 8192 | 9692 | 11192 | 12692 | 14192 | 15692 |
| after | 8192 | 8192 | 8192 | 8192 | 8192 | 8192 |

Before the fix, `can_allocate()` for an encoder input larger than the whole cache returns `True` after a few decode steps; after the fix it returns `False`.

```
tests/v1/core/test_encoder_cache_manager.py ......... 18 passed
tests/v1/core/test_scheduler.py -k "encoder or cross_attn" ......... 22 passed
```

Full `tests/v1/core/` sweep, same environment, this branch vs. `origin/main`:

| | passed | failed | errors |
|---|---|---|---|
| `origin/main` | 459 | 1 | 2 |
| this branch | 462 | 1 | 2 |

+3 passed is exactly the three added tests; the residual `test_reset_prefix_cache_e2e` failure and the two `test_scheduler_e2e.py` errors are identical before and after (they are e2e tests needing real model execution, which this CPU-only dev box cannot provide).

`ruff check`, `ruff format --check`, and `tools/pre_commit/mypy.py "3.12"` are clean on all changed files.

## Notes

- **Not a duplicate.** `gh search prs --repo vllm-project/vllm "EncoderDecoderCacheManager" / "free_encoder_input" / "num_free_slots" / "encoder cache slot"` returns no open PR touching enc-dec slot accounting. PR #38330 (score encoder cache manager) appends a new `ScoreEncoderCacheManager` class and does not modify `EncoderDecoderCacheManager`; PR #44049 and #47771 touch `scheduler.py` in unrelated places. Closed PR #40836 concerned encoder-cache hit/miss *stats*, not slot accounting. No open issue describes this behavior.
