### PR TITLE
[Bugfix] MiniMax-M3: structured output silently ignored with thinking enabled (scheduler reasoning-end gate never fires)

### DIFF
--- a/tests/reasoning/test_minimax_m3_reasoning_parser.py
+++ b/tests/reasoning/test_minimax_m3_reasoning_parser.py
@@ -459,3 +459,118 @@ def test_token_id_helpers_enabled_mode():
     assert parser.count_reasoning_tokens(open_reasoning_ids) == len(
         tokenizer.encode("abc")
     )
+
+
+def test_reasoning_end_streaming_scheduler_pattern_enabled_mode():
+    """The scheduler's structured-output gate calls is_reasoning_end_streaming
+    on a request-local parser without ever calling
+    extract_reasoning_streaming (which owns the frontend streaming-state
+    flags). With thinking_mode="enabled" the parser starts inside a reasoning
+    block; detection must still fire once </mm:think> is generated, or grammar
+    constraints never engage and structured output is silently ignored.
+    """
+    parser, tokenizer = make_parser(chat_template_kwargs={"thinking_mode": "enabled"})
+    token_ids = tokenizer.encode(
+        'some reasoning</mm:think>{"a": 1}', add_special_tokens=False
+    )
+    end_marker_index = token_ids.index(tokenizer.convert_tokens_to_ids("</mm:think>"))
+
+    all_ids: list[int] = []
+    fired_at = None
+    for i, token in enumerate(token_ids):
+        all_ids.append(token)
+        if parser.is_reasoning_end_streaming(all_ids, [token]) and fired_at is None:
+            fired_at = i
+
+    assert fired_at == end_marker_index
+    # Once the marker is in the history, detection must keep returning True.
+    assert parser.is_reasoning_end_streaming(all_ids, [])
+
+
+def test_reasoning_end_streaming_scheduler_pattern_spec_decode_window():
+    """Same scheduler pattern, but with multi-token deltas as produced by
+    speculative decoding: the end marker may land mid-window."""
+    parser, tokenizer = make_parser(chat_template_kwargs={"thinking_mode": "enabled"})
+    token_ids = tokenizer.encode(
+        'thinking</mm:think>{"a": 1}', add_special_tokens=False
+    )
+    end_marker_index = token_ids.index(tokenizer.convert_tokens_to_ids("</mm:think>"))
+
+    window = 4
+    all_ids: list[int] = []
+    fired_in_window = None
+    for start in range(0, len(token_ids), window):
+        delta = token_ids[start : start + window]
+        all_ids.extend(delta)
+        if (
+            parser.is_reasoning_end_streaming(all_ids, delta)
+            and fired_in_window is None
+        ):
+            fired_in_window = start
+
+    assert fired_in_window is not None
+    assert fired_in_window <= end_marker_index < fired_in_window + window
+
+
+def test_reasoning_end_streaming_ignores_prompt_scaffolding_markers():
+    """The real chat template embeds literal marker text inside the prompt (a
+    <thinking_instructions> block mentions <mm:think> and </mm:think>) and then
+    prefills a trailing <mm:think>. The scheduler passes prompt+output token
+    ids; naive containment fires at step 0, suppressing thinking entirely.
+    Detection must stay False until the model itself emits </mm:think>."""
+    parser, tokenizer = make_parser(chat_template_kwargs={"thinking_mode": "enabled"})
+    prompt_ids = tokenizer.encode(
+        "instructions: wrap thinking in <mm:think> and </mm:think> tags.\n"
+        "user: hi\nai: <mm:think>",
+        add_special_tokens=False,
+    )
+    generated = tokenizer.encode(
+        'thinking here</mm:think>{"a": 1}', add_special_tokens=False
+    )
+    end_offset = generated.index(tokenizer.convert_tokens_to_ids("</mm:think>"))
+
+    all_ids = list(prompt_ids)
+    # Step 0 sanity: prompt scaffolding alone must not end reasoning.
+    assert parser.is_reasoning_end_streaming(all_ids, []) is False
+
+    fired_at = None
+    for i, token in enumerate(generated):
+        all_ids.append(token)
+        if parser.is_reasoning_end_streaming(all_ids, [token]) and fired_at is None:
+            fired_at = i
+
+    assert fired_at == end_offset
+
+
+def test_reasoning_end_streaming_incremental_scan_split_marker():
+    """Scheduler pattern with a tokenizer that splits markers into many
+    tokens: the incremental history scan must still detect a marker that
+    straddles successive scan windows, and must not fire early."""
+    tokenizer = SplitMiniMaxM3Tokenizer()
+    parser = MiniMaxM3ReasoningParser(
+        tokenizer, chat_template_kwargs={"thinking_mode": "enabled"}
+    )
+    generated = tokenizer.encode('r</mm:think>{"a": 1}', add_special_tokens=False)
+    # Marker is split into one token per character; it completes at the
+    # index of its final '>' character.
+    end_offset = len("r</mm:think>") - 1
+
+    all_ids: list[int] = []
+    fired_at = None
+    for i, token in enumerate(generated):
+        all_ids.append(token)
+        if parser.is_reasoning_end_streaming(all_ids, [token]) and fired_at is None:
+            fired_at = i
+    assert fired_at == end_offset
+
+
+def test_reasoning_end_streaming_scan_cache_resets_on_new_stream():
+    """Reusing a parser on a shorter, fresh token stream must reset the
+    incremental scan cache rather than reuse stale marker positions."""
+    parser, tokenizer = make_parser(chat_template_kwargs={"thinking_mode": "enabled"})
+    first = tokenizer.encode("abc</mm:think>x", add_special_tokens=False)
+    assert parser.is_reasoning_end_streaming(first, first[-1:]) is True
+
+    fresh = tokenizer.encode("ab", add_special_tokens=False)
+    parser._reasoning_ended_streaming = False
+    assert parser.is_reasoning_end_streaming(fresh, fresh[-1:]) is False

--- a/tests/reasoning/test_minimax_m3_reasoning_parser.py
+++ b/tests/reasoning/test_minimax_m3_reasoning_parser.py
@@ -574,3 +574,34 @@ def test_reasoning_end_streaming_scan_cache_resets_on_new_stream():
     fresh = tokenizer.encode("ab", add_special_tokens=False)
     parser._reasoning_ended_streaming = False
     assert parser.is_reasoning_end_streaming(fresh, fresh[-1:]) is False
+
+
+def test_reasoning_end_streaming_rejected_draft_marker_not_cached():
+    """The scheduler's bitmask path scans simulated sequences that include
+    scheduled speculative draft tokens. A draft proposing </mm:think> can be
+    rejected by the verifier while a later real sequence reaches the same
+    length with different tokens (accept-all-but-last + bonus). The scan
+    cache must not treat the rejected draft's marker as real - that engages
+    the grammar mid-reasoning and empties the response content."""
+    parser, tokenizer = make_parser(chat_template_kwargs={"thinking_mode": "enabled"})
+    end_id = tokenizer.convert_tokens_to_ids("</mm:think>")
+
+    history = tokenizer.encode("thinking a", add_special_tokens=False)
+    drafts = [
+        tokenizer.convert_tokens_to_ids("b"),
+        end_id,
+        tokenizer.convert_tokens_to_ids("c"),
+    ]
+    simulated = history + drafts
+    # Bitmask-path probe over the simulated (draft-containing) sequence.
+    assert parser.is_reasoning_end_streaming(simulated, drafts) is True
+
+    # Verifier rejected the marker draft; the real sequence reaches the SAME
+    # length with different tokens. Detection must NOT fire from the cache.
+    real = history + tokenizer.encode("bde", add_special_tokens=False)
+    assert len(real) == len(simulated)
+    assert parser.is_reasoning_end_streaming(real, real[-1:]) is False
+
+    # And the genuine marker must still be detected when it arrives.
+    real2 = real + [end_id]
+    assert parser.is_reasoning_end_streaming(real2, [end_id]) is True

--- a/vllm/reasoning/minimax_m3_reasoning_parser.py
+++ b/vllm/reasoning/minimax_m3_reasoning_parser.py
@@ -46,6 +46,12 @@ class MiniMaxM3ReasoningParser(BaseThinkingReasoningParser):
         self._pending_marker_streaming = False
         self._last_streaming_delta_token_ids: tuple[int, ...] | None = None
         self._last_streaming_content_token_ids: list[int] | None = None
+        # Incremental marker-scan cache for _reasoning_end_in_history.
+        # The parser is request-local and its token history is append-only,
+        # so each call only needs to scan tokens it has not seen yet.
+        self._history_scan_pos = 0
+        self._history_last_start_pos = -1
+        self._history_last_end_pos = -1
 
     def _encode_text(self, text: str) -> list[int]:
         try:
@@ -194,20 +200,73 @@ class MiniMaxM3ReasoningParser(BaseThinkingReasoningParser):
 
         return reasoning, (content_before + content_after) or None
 
+    def _reasoning_end_in_history(self, input_ids: Sequence[int]) -> bool:
+        """Incremental equivalent of ``is_reasoning_end(input_ids)``.
+
+        Tracks the last-seen start/end marker positions across calls,
+        scanning only tokens beyond the previous scan position (plus a
+        marker-length overlap for markers straddling the line). If the
+        sequence shrank since the last call - a new stream reusing the
+        parser - the cache resets and the scan restarts from zero.
+        """
+        n = len(input_ids)
+        if n < self._history_scan_pos:
+            self._history_scan_pos = 0
+            self._history_last_start_pos = -1
+            self._history_last_end_pos = -1
+        overlap = max(len(self._start_token_ids), len(self._end_token_ids)) - 1
+        begin = max(0, self._history_scan_pos - overlap)
+        window = input_ids[begin:n] if begin else input_ids
+        start_pos = self._rfind_token_sequence(window, self._start_token_ids)
+        if start_pos >= 0:
+            self._history_last_start_pos = max(
+                self._history_last_start_pos, begin + start_pos
+            )
+        end_pos = self._rfind_token_sequence(window, self._end_token_ids)
+        if end_pos >= 0:
+            self._history_last_end_pos = max(
+                self._history_last_end_pos, begin + end_pos
+            )
+        self._history_scan_pos = n
+        return (
+            self._history_last_end_pos >= 0
+            and self._history_last_end_pos > self._history_last_start_pos
+        )
+
     def is_reasoning_end_streaming(
         self, input_ids: Sequence[int], delta_ids: Iterable[int]
     ) -> bool:
         if self._reasoning_ended_streaming:
             return True
 
-        if self._reasoning_active_streaming or self._pending_marker_streaming:
-            return False
+        # Check the token stream for the end marker before consulting the
+        # frontend streaming-state flags: the scheduler's structured-output
+        # gate (StructuredOutputManager.should_advance) calls this method on a
+        # request-local parser without ever calling
+        # extract_reasoning_streaming, which is the only place those flags are
+        # updated. With thinking_mode="enabled",
+        # ``_reasoning_active_streaming`` starts True and would otherwise gate
+        # detection off forever, so grammar constraints never engage
+        # (structured output is silently ignored).
+        #
+        # Ordering matters, not mere containment: ``input_ids`` spans prompt
+        # and output, and the chat template's <thinking_instructions> block
+        # embeds literal marker text in the prompt. Reasoning has ended only
+        # when the last end marker follows the last start marker (the
+        # template's trailing ``<mm:think>`` prefill keeps this False until
+        # the model really closes the block) - the same predicate as
+        # ``is_reasoning_end``, evaluated incrementally so per-token calls
+        # from the scheduler stay O(new tokens) instead of O(history).
+        if self._reasoning_end_in_history(input_ids):
+            return True
 
         delta_ids = tuple(delta_ids)
         if self._contains_token_sequence(delta_ids, self._end_token_ids):
             return True
-        if self._contains_token_sequence(input_ids, self._end_token_ids):
-            return True
+
+        if self._reasoning_active_streaming or self._pending_marker_streaming:
+            return False
+
         if self._initial_in_reasoning:
             return False
         if self._ends_with_token_sequence_prefix(input_ids, self._start_token_ids):

--- a/vllm/reasoning/minimax_m3_reasoning_parser.py
+++ b/vllm/reasoning/minimax_m3_reasoning_parser.py
@@ -208,12 +208,35 @@ class MiniMaxM3ReasoningParser(BaseThinkingReasoningParser):
         marker-length overlap for markers straddling the line). If the
         sequence shrank since the last call - a new stream reusing the
         parser - the cache resets and the scan restarts from zero.
+
+        Cached positions are re-verified against the current tokens before
+        being trusted: the scheduler's bitmask path scans *simulated*
+        sequences that include scheduled speculative draft tokens, and a
+        draft that proposes a marker can be rejected by the verifier while
+        the same sequence length is later reached by different tokens
+        (accept-all-but-last plus bonus). A stale cached marker would then
+        end reasoning that never ended - engaging the grammar mid-thought
+        and leaving the response with empty content. Verification is
+        O(marker length); a mismatch triggers a full rescan.
         """
         n = len(input_ids)
         if n < self._history_scan_pos:
             self._history_scan_pos = 0
             self._history_last_start_pos = -1
             self._history_last_end_pos = -1
+        else:
+            for pos, marker in (
+                (self._history_last_start_pos, self._start_token_ids),
+                (self._history_last_end_pos, self._end_token_ids),
+            ):
+                if pos >= 0 and (
+                    pos + len(marker) > n
+                    or tuple(input_ids[pos : pos + len(marker)]) != marker
+                ):
+                    self._history_scan_pos = 0
+                    self._history_last_start_pos = -1
+                    self._history_last_end_pos = -1
+                    break
         overlap = max(len(self._start_token_ids), len(self._end_token_ids)) - 1
         begin = max(0, self._history_scan_pos - overlap)
         window = input_ids[begin:n] if begin else input_ids


### PR DESCRIPTION
## Purpose

Structured output (`response_format: json_schema` / `json_object`) is **silently ignored** for MiniMax-M3 whenever thinking is enabled (`chat_template_kwargs: {"thinking_mode": "enabled"}`): the server returns HTTP 200 with unconstrained prose. Cause: the scheduler's structured-output gate can never observe the end of reasoning.

`StructuredOutputManager.should_advance` calls `is_reasoning_end_streaming` on its request-local parser. `MiniMaxM3ReasoningParser.is_reasoning_end_streaming` early-returns `False` while `_reasoning_active_streaming` is set — but that flag is only ever cleared by `extract_reasoning_streaming`, a frontend/detokenizer method the scheduler never calls. With `thinking_mode: "enabled"` the flag initializes `True`, so:

- detection never fires → `reasoning_ended` never latches,
- `should_fill_bitmask` stays `False` forever → the grammar never engages,
- the request completes normally, making the failure invisible to clients.

Related failure family: #34650, #39130 (reasoning gates silently disabling structured output).

## Fix

Evaluate the reasoning-end predicate over the token history **before** the frontend streaming-state early return.

Two subtleties, both encoded in the regression tests:

1. **Ordering, not containment.** `input_ids` spans prompt+output, and the M3 chat template's `<thinking_instructions>` block embeds literal `<mm:think>` / `</mm:think>` text inside the prompt. A naive "history contains end marker" check fires at step 0, engaging the grammar immediately — which suppresses thinking entirely and (because no `</mm:think>` is ever emitted) makes the frontend parser classify the whole JSON as `reasoning`, leaving `content` empty. The correct predicate is `is_reasoning_end`'s ordering rule: last end marker *after* last start marker — the template's trailing `<mm:think>` prefill keeps it `False` until the model truly closes the block.
2. **Incremental scan.** The scheduler calls this per token; a full-history `rfind` per call is O(history) and measurable on long-context requests (M3 supports 1M). The parser now caches the last-seen marker positions and scans only unseen tokens (with a marker-length overlap), resetting if the sequence shrinks (fresh stream reusing the parser).

Frontend streaming extraction is unchanged — the state flags still gate the adaptive-mode heuristics; once a block truly ends, the marker check fires identically to before.

## Verification

- 28/28 parser unit tests, including 6 new regression tests: scheduler calling pattern (single-token deltas), spec-decode-style multi-token windows, **prompt-scaffolding marker text**, split-marker incremental scan, scan-cache reset, and **rejected-draft cache poisoning** (second commit: cached marker positions are re-verified against the current tokens, since the bitmask path probes with simulated sequences containing scheduled draft tokens — a rejected marker draft must not end reasoning; observed live at ~1/15 structured requests under batched EAGLE3 load before the fix, 45/45 clean after). The scheduler-pattern, scaffolding, and rejected-draft tests fail on the unpatched parser.
- Live end-to-end on a production TP8 B300 deployment (v0.25.1 overlay) serving MiniMax-M3 with EAGLE3 speculative decoding (`num_speculative_tokens: 3`): before the fix, 10/10 `thinking + json_schema` requests returned unconstrained markdown; with this fix (combined with the pre-commit boundary filter — see note), 10/10 returned schema-valid JSON in `content` with genuine reasoning in `reasoning`, streaming and tool calling intact, spec decode confirmed active via `/metrics`.

## Note on speculative decoding

This fix makes the boundary *detectable*; under spec decode the boundary step can still commit post-marker tokens sampled before the mask engaged. #43424's pre-commit grammar filter handles that leak — the two compose (without this fix, that filter can never trigger for MiniMax-M3, since detection is what arms it). On v0.25.1-era code we also needed the exact boundary index stored at pre-commit time; on main, #43388's `new_token_ids`-based window in `should_advance` already provides the equivalent.

Happy to add the observed-but-preexisting cleanup separately: `accept_tokens` logs `ERROR ... Please file an issue` for draft-token rejections that the reasoning-boundary bitmask path explicitly tolerates — a dry-run `validate_tokens` in that path would silence expected noise.


Generated with Claude Code / Fable 5

