### PR TITLE
update gitignore to ignore codebuddy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -254,3 +254,6 @@ vllm/grpc/vllm_engine_pb2.pyi
 
 # Ignore generated cpu headers 
 csrc/cpu/cpu_attn_dispatch_generated.h
+
+# CodeBuddy
+.codebuddy/


### PR DESCRIPTION
When I use Tencent `CodeBuddy` plugin, which will generate a `.codebuddy` directory to store agent configs, so I update the `.gitignore file` to ignore this directory.