### PR TITLE
fix(security): bound lifetime of ownerless Mooncake transfer placeholders

### DIFF
--- a/docs/features/mooncake_connector_usage.md
+++ b/docs/features/mooncake_connector_usage.md
@@ -56,6 +56,10 @@ Now you can send requests to the proxy server through port 8000.
     - Default: 480
     - If a request is aborted and the decoder has not yet notified the prefiller, the prefill instance will release its KV-cache blocks after this timeout to avoid holding them indefinitely.
 
+- `VLLM_MOONCAKE_ORPHAN_TRANSFER_TIMEOUT`: Timeout (in seconds) for unclaimed transfer placeholders on the prefiller. (Optional)
+    - Default: 60
+    - When the decoder sends a transfer request for an ID that the prefiller has not yet registered (e.g. the request was rejected before engine admission), the prefiller creates a placeholder and waits. If the placeholder is not claimed within this timeout, it is discarded and the sender task is released. This prevents resource exhaustion from orphaned transfer IDs.
+
 ## KV Transfer Config
 
 ### KV Role Options

--- a/tests/v1/kv_connector/unit/test_mooncake_connector.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_connector.py
@@ -1361,3 +1361,174 @@ async def test_kv_producer_heterogeneous_tp(monkeypatch, d_tp_size):
 
         prefill_worker.sender_loop = origin_sender_loop
         prefill_worker.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_fetch_finished_sending_reqs_cleans_ownerless_placeholders():
+    """Ownerless placeholders (p_req_id='') should be evicted once expired."""
+
+    vllm_config = create_vllm_config(
+        kv_connector="MooncakeConnector", kv_role="kv_producer"
+    )
+    with set_current_vllm_config(vllm_config), patch_worker_dependencies():
+        prefill_connector = MooncakeConnector(
+            vllm_config,
+            KVConnectorRole.WORKER,
+            _make_test_kv_cache_config(),
+        )
+        prefill_worker = prefill_connector.connector_worker
+
+        now = time.perf_counter()
+
+        # Ownerless placeholder that has expired.
+        prefill_worker.reqs_need_send["tx-orphan-expired"] = SendBlockMeta(
+            p_req_id="",
+            transfer_id="tx-orphan-expired",
+            local_block_ids=[],
+            ready=asyncio.Event(),
+            expire_time=now - 10,
+            created_at=now - 70,
+        )
+
+        # Ownerless placeholder that has NOT expired yet.
+        prefill_worker.reqs_need_send["tx-orphan-active"] = SendBlockMeta(
+            p_req_id="",
+            transfer_id="tx-orphan-active",
+            local_block_ids=[],
+            ready=asyncio.Event(),
+            expire_time=now + 50,
+            created_at=now - 10,
+        )
+
+        # Claimed entry that has expired (normal timeout path).
+        prefill_worker.reqs_need_send["tx-claimed-expired"] = SendBlockMeta(
+            p_req_id="p-req-claimed",
+            transfer_id="tx-claimed-expired",
+            local_block_ids=[[1, 2]],
+            ready=MagicMock(),
+            expire_time=now - 5,
+            created_at=now - 500,
+        )
+
+        # Claimed entry that is still active.
+        prefill_worker.reqs_need_send["tx-claimed-active"] = SendBlockMeta(
+            p_req_id="p-req-active",
+            transfer_id="tx-claimed-active",
+            local_block_ids=[[3, 4]],
+            ready=MagicMock(),
+            expire_time=now + 100,
+            created_at=now - 10,
+        )
+
+        finished_reqs = await prefill_worker.fetch_finished_sending_reqs()
+
+        # Ownerless expired entry removed, no p_req_id added to finished set.
+        assert "tx-orphan-expired" not in prefill_worker.reqs_need_send
+
+        # Ownerless non-expired entry still present.
+        assert "tx-orphan-active" in prefill_worker.reqs_need_send
+
+        # Claimed expired entry removed and its p_req_id is in finished set.
+        assert "tx-claimed-expired" not in prefill_worker.reqs_need_send
+        assert "p-req-claimed" in finished_reqs
+
+        # Claimed active entry still present.
+        assert "tx-claimed-active" in prefill_worker.reqs_need_send
+        assert "p-req-active" not in finished_reqs
+
+
+@pytest.mark.asyncio
+async def test_send_kv_to_decode_orphan_timeout_and_cleanup(monkeypatch):
+    """Unclaimed placeholders should time out using the orphan timeout
+    and be removed from reqs_need_send."""
+
+    monkeypatch.setattr(envs, "VLLM_MOONCAKE_ORPHAN_TRANSFER_TIMEOUT", 0)
+
+    vllm_config = create_vllm_config(
+        kv_connector="MooncakeConnector", kv_role="kv_producer"
+    )
+    with set_current_vllm_config(vllm_config), patch_worker_dependencies():
+        prefill_connector = MooncakeConnector(
+            vllm_config,
+            KVConnectorRole.WORKER,
+            _make_test_kv_cache_config(),
+        )
+        prefill_worker = prefill_connector.connector_worker
+        origin_sender_loop = prefill_worker.sender_loop
+        prefill_worker.sender_loop = asyncio.get_event_loop()
+
+        mock_socket = AsyncMock()
+
+        meta = MooncakeXferMetadata(
+            remote_engine_id="engine-d",
+            remote_hostname="decode-host",
+            remote_port=9999,
+            remote_tp_size=1,
+            remote_tp_rank=0,
+            req_blocks={"d-req-0": ("xfer-orphan-0", [0, 1])},
+            kv_caches_base_addr=[0x2000],
+            block_lens=[256],
+            kv_block_lens=[128],
+            registered_layer_names=["model.layers.0.self_attn"],
+            registered_layer_indices=[0],
+            registered_group_indices=[0],
+        )
+
+        prefill_worker.registered_layer_names = ["model.layers.0.self_attn"]
+        prefill_worker.registered_layer_indices = [0]
+        prefill_worker.registered_group_indices = [0]
+        prefill_worker.kv_caches_base_addr = [0x1000]
+        prefill_worker.block_len_per_layer = [256]
+        prefill_worker.kv_block_len_per_layer = [128]
+
+        await prefill_worker.send_kv_to_decode(b"identity", mock_socket, meta)
+
+        # The ownerless placeholder should have been removed after timeout.
+        assert "xfer-orphan-0" not in prefill_worker.reqs_need_send
+
+        # Verify an error response was sent.
+        mock_socket.send_multipart.assert_called_once()
+        _, payload = mock_socket.send_multipart.call_args[0][0]
+        response = prefill_worker._xfer_resp_decoder.decode(payload)
+        assert response.status == MooncakeXferResponseStatus.FINISH
+        assert "d-req-0" in response.err_reqs
+        assert "Timeout" in response.err_msg
+
+        prefill_worker.sender_loop = origin_sender_loop
+        prefill_worker.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_claimed_placeholder_uses_full_timeout(monkeypatch):
+    """Once a placeholder is claimed via record_send_reqs, it should use
+    the full VLLM_MOONCAKE_ABORT_REQUEST_TIMEOUT, not the orphan timeout."""
+
+    vllm_config = create_vllm_config(
+        kv_connector="MooncakeConnector", kv_role="kv_producer"
+    )
+    with set_current_vllm_config(vllm_config), patch_worker_dependencies():
+        prefill_connector = MooncakeConnector(
+            vllm_config,
+            KVConnectorRole.WORKER,
+            _make_test_kv_cache_config(),
+        )
+        prefill_worker = prefill_connector.connector_worker
+
+        now = time.perf_counter()
+
+        # Simulate a placeholder that was created with the orphan timeout
+        # but then claimed by record_send_reqs (which resets expire_time).
+        prefill_worker.reqs_need_send["tx-claimed"] = SendBlockMeta(
+            p_req_id="p-req-claimed",
+            transfer_id="tx-claimed",
+            local_block_ids=[[1, 2]],
+            ready=MagicMock(),
+            expire_time=now + envs.VLLM_MOONCAKE_ABORT_REQUEST_TIMEOUT,
+            created_at=now - 30,
+        )
+
+        finished_reqs = await prefill_worker.fetch_finished_sending_reqs()
+
+        # Should NOT be expired — it has the full abort timeout.
+        assert "tx-claimed" in prefill_worker.reqs_need_send
+        assert "p-req-claimed" not in finished_reqs

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py
@@ -432,6 +432,7 @@ class SendBlockMeta:
     local_block_ids: list[list[int]]
     ready: asyncio.Event
     expire_time: float = float("inf")
+    created_at: float = 0.0
     need_send: int = 0
     sent: int = 0
     sending: int = 0
@@ -1251,12 +1252,14 @@ class MooncakeConnectorWorker:
             return
         for d_req_id, (transfer_id, _) in meta.req_blocks.items():
             if transfer_id not in self.reqs_need_send:
-                # This req is not enqueued in P side yet, create it here.
+                now = time.perf_counter()
                 self.reqs_need_send[transfer_id] = SendBlockMeta(
                     p_req_id="",
                     transfer_id=transfer_id,
                     local_block_ids=[],
                     ready=asyncio.Event(),
+                    expire_time=now + envs.VLLM_MOONCAKE_ORPHAN_TRANSFER_TIMEOUT,
+                    created_at=now,
                 )
             send_meta = self.reqs_need_send[transfer_id]
             pending_reqs[d_req_id] = send_meta
@@ -1273,9 +1276,14 @@ class MooncakeConnectorWorker:
         ]
 
         while wait_tasks:
+            min_expiry = min(
+                send_meta.expire_time for send_meta in pending_reqs.values()
+            )
+            wait_timeout = max(0, min_expiry - time.perf_counter())
+
             done, pending = await asyncio.wait(
                 wait_tasks,
-                timeout=envs.VLLM_MOONCAKE_ABORT_REQUEST_TIMEOUT,
+                timeout=wait_timeout,
                 return_when=asyncio.FIRST_COMPLETED,
             )
 
@@ -1283,6 +1291,9 @@ class MooncakeConnectorWorker:
                 # Timeout, abort all pending requests.
                 for task in wait_tasks:
                     task.cancel()
+                for send_meta in pending_reqs.values():
+                    if not send_meta.p_req_id:
+                        self.reqs_need_send.pop(send_meta.transfer_id, None)
                 logger.warning(
                     "Timeout waiting for P side ready: %s", list(pending_reqs)
                 )
@@ -1757,11 +1768,9 @@ class MooncakeConnectorWorker:
 
         expired_transfer_id = []
         for transfer_id, send_meta in self.reqs_need_send.items():
-            if (
-                send_meta.p_req_id
-                and send_meta.expire_time < now
-                and send_meta.sending == 0
-            ):
+            if send_meta.sending != 0:
+                continue
+            if send_meta.p_req_id and send_meta.expire_time < now:
                 logger.warning(
                     "Request %s timed out after %d seconds without "
                     "being sent. Freeing its blocks on the producer side.",
@@ -1770,6 +1779,14 @@ class MooncakeConnectorWorker:
                 )
                 self.xfer_stats.record_kv_expired_req()
                 finished_sending_reqs.add(send_meta.p_req_id)
+                expired_transfer_id.append(transfer_id)
+            elif not send_meta.p_req_id and send_meta.expire_time < now:
+                logger.warning(
+                    "Ownerless transfer %s expired after %d seconds "
+                    "without being claimed. Removing placeholder.",
+                    transfer_id,
+                    envs.VLLM_MOONCAKE_ORPHAN_TRANSFER_TIMEOUT,
+                )
                 expired_transfer_id.append(transfer_id)
 
         for transfer_id in expired_transfer_id:

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -237,6 +237,7 @@ if TYPE_CHECKING:
     VLLM_ROCM_QUICK_REDUCE_MIN_SIZE_BYTES_MB: int | None = None
     VLLM_ROCM_QUICK_REDUCE_QUANTIZATION_MIN_SIZE_KB: int | None = None
     VLLM_MOONCAKE_ABORT_REQUEST_TIMEOUT: int = 480
+    VLLM_MOONCAKE_ORPHAN_TRANSFER_TIMEOUT: int = 60
     VLLM_ENABLE_CUDAGRAPH_GC: bool = False
     VLLM_LOOPBACK_IP: str = ""
     VLLM_ALLOW_CHUNKED_LOCAL_ATTN_WITH_HYBRID_KV_CACHE: bool = True
@@ -1731,6 +1732,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Timeout (in seconds) for MooncakeConnector in PD disaggregated setup.
     "VLLM_MOONCAKE_ABORT_REQUEST_TIMEOUT": lambda: int(
         os.getenv("VLLM_MOONCAKE_ABORT_REQUEST_TIMEOUT", "480")
+    ),
+    # Timeout (in seconds) for unclaimed Mooncake transfer placeholders.
+    # Limits how long a sender task waits for a transfer ID that was never
+    # registered on the P side (e.g. request rejected before engine admission).
+    "VLLM_MOONCAKE_ORPHAN_TRANSFER_TIMEOUT": lambda: int(
+        os.getenv("VLLM_MOONCAKE_ORPHAN_TRANSFER_TIMEOUT", "60")
     ),
     # If set, it means we pre-downloaded cubin files and flashinfer will
     # read the cubin files directly.


### PR DESCRIPTION
When the decoder sends transfer metadata for an ID that was never registered on the prefiller (e.g. request rejected before engine admission), send_kv_to_decode() creates a placeholder that blocks a sender task for the full VLLM_MOONCAKE_ABORT_REQUEST_TIMEOUT (480s) and is never cleaned up. With only 20 default sender tasks, 20 such requests exhaust the pool and delay legitimate transfers.

Introduce VLLM_MOONCAKE_ORPHAN_TRANSFER_TIMEOUT (default 60s) to cap how long unclaimed placeholders can occupy a sender task. After expiry, placeholders are removed from reqs_need_send. Claimed entries still receive the full abort timeout via record_send_reqs().
