### PR TITLE
[Perf][Reasoning] O(delta) reasoning-end check for engine parsers

### DIFF
--- a/tests/parser/engine/test_parser_engine.py
+++ b/tests/parser/engine/test_parser_engine.py
@@ -8,6 +8,7 @@ DeltaMessage / ExtractedToolCallInformation protocol.
 from __future__ import annotations
 
 import json
+from collections.abc import Sequence
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
@@ -1694,3 +1695,79 @@ class TestDropSpecialTokens:
             e.value for e in events if e.type == EventType.REASONING_CHUNK
         )
         assert "<bos>" not in reasoning_text
+
+
+# ── TestIsReasoningEndStreaming ──────────────────────────────────────
+
+
+class _CountingSequence(Sequence):
+    """Sequence that records how many elements were read.
+
+    Used to assert the decode-step check stays proportional to the step rather
+    than the whole sequence, without timing anything.
+    """
+
+    def __init__(self, data: list[int]):
+        self._data = data
+        self.reads = 0
+
+    def __getitem__(self, index):
+        self.reads += 1
+        return self._data[index]
+
+    def __len__(self) -> int:
+        return len(self._data)
+
+
+class TestIsReasoningEndStreaming:
+    """The scheduler calls this once per request per decode step while a
+    request is still reasoning (see ``should_advance`` in
+    vllm/v1/structured_output/__init__.py), so its cost must depend on the
+    step, not on the accumulated context.
+    """
+
+    def test_does_not_scan_the_whole_sequence(self):
+        engine = _make_engine()
+        all_ids = _CountingSequence([200] + [72] * 5000)
+
+        assert not engine.is_reasoning_end_streaming(all_ids, [72])
+
+        assert all_ids.reads == 0, (
+            "the decode-step check must not walk the accumulated sequence"
+        )
+
+    def test_detects_end_marker_in_the_step(self):
+        engine = _make_engine()
+        assert engine.is_reasoning_end_streaming([200, 72, 201], [201])
+
+    def test_start_marker_in_the_step_keeps_reasoning_open(self):
+        engine = _make_engine()
+        assert not engine.is_reasoning_end_streaming([201, 72, 200], [200])
+
+    def test_empty_delta_falls_back_to_the_full_predicate(self):
+        engine = _make_engine()
+        assert engine.is_reasoning_end_streaming([200, 72, 201], []) is True
+        assert engine.is_reasoning_end_streaming([201, 72, 200], []) is False
+
+    @pytest.mark.parametrize(
+        "sequence",
+        [
+            [200, 72, 201],
+            [200, 72, 72, 201, 73],
+            [201, 200, 72],
+            [200, 201, 200],
+            [72, 73],
+        ],
+    )
+    def test_agrees_with_full_predicate_while_reasoning(self, sequence):
+        """Stepping one token at a time must match the full-sequence answer
+        for every step up to the first one that ends reasoning."""
+        engine = _make_engine()
+        for end in range(1, len(sequence) + 1):
+            prefix = sequence[:end]
+            full = engine.is_reasoning_end(prefix)
+            assert (
+                engine.is_reasoning_end_streaming(prefix, [sequence[end - 1]]) == full
+            )
+            if full:
+                break

--- a/tests/parser/engine/test_parser_engine.py
+++ b/tests/parser/engine/test_parser_engine.py
@@ -8,6 +8,7 @@ DeltaMessage / ExtractedToolCallInformation protocol.
 from __future__ import annotations
 
 import json
+from collections.abc import Sequence
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
@@ -2106,3 +2107,79 @@ class TestThinkMarkupWithoutReasoningParser:
         assert tool_calls is not None and len(tool_calls) == 1
         assert tool_calls[0].name == "get_weather"
         assert content == think
+
+
+# ── TestIsReasoningEndStreaming ──────────────────────────────────────
+
+
+class _CountingSequence(Sequence):
+    """Sequence that records how many elements were read.
+
+    Used to assert the decode-step check stays proportional to the step rather
+    than the whole sequence, without timing anything.
+    """
+
+    def __init__(self, data: list[int]):
+        self._data = data
+        self.reads = 0
+
+    def __getitem__(self, index):
+        self.reads += 1
+        return self._data[index]
+
+    def __len__(self) -> int:
+        return len(self._data)
+
+
+class TestIsReasoningEndStreaming:
+    """The scheduler calls this once per request per decode step while a
+    request is still reasoning (see ``should_advance`` in
+    vllm/v1/structured_output/__init__.py), so its cost must depend on the
+    step, not on the accumulated context.
+    """
+
+    def test_does_not_scan_the_whole_sequence(self):
+        engine = _make_engine()
+        all_ids = _CountingSequence([200] + [72] * 5000)
+
+        assert not engine.is_reasoning_end_streaming(all_ids, [72])
+
+        assert all_ids.reads == 0, (
+            "the decode-step check must not walk the accumulated sequence"
+        )
+
+    def test_detects_end_marker_in_the_step(self):
+        engine = _make_engine()
+        assert engine.is_reasoning_end_streaming([200, 72, 201], [201])
+
+    def test_start_marker_in_the_step_keeps_reasoning_open(self):
+        engine = _make_engine()
+        assert not engine.is_reasoning_end_streaming([201, 72, 200], [200])
+
+    def test_empty_delta_falls_back_to_the_full_predicate(self):
+        engine = _make_engine()
+        assert engine.is_reasoning_end_streaming([200, 72, 201], []) is True
+        assert engine.is_reasoning_end_streaming([201, 72, 200], []) is False
+
+    @pytest.mark.parametrize(
+        "sequence",
+        [
+            [200, 72, 201],
+            [200, 72, 72, 201, 73],
+            [201, 200, 72],
+            [200, 201, 200],
+            [72, 73],
+        ],
+    )
+    def test_agrees_with_full_predicate_while_reasoning(self, sequence):
+        """Stepping one token at a time must match the full-sequence answer
+        for every step up to the first one that ends reasoning."""
+        engine = _make_engine()
+        for end in range(1, len(sequence) + 1):
+            prefix = sequence[:end]
+            full = engine.is_reasoning_end(prefix)
+            assert (
+                engine.is_reasoning_end_streaming(prefix, [sequence[end - 1]]) == full
+            )
+            if full:
+                break

--- a/vllm/parser/engine/adapters.py
+++ b/vllm/parser/engine/adapters.py
@@ -10,7 +10,7 @@ any changes to the serving layer itself.
 
 from __future__ import annotations
 
-from collections.abc import Iterator, Sequence
+from collections.abc import Iterable, Iterator, Sequence
 from contextlib import contextmanager
 from typing import TYPE_CHECKING
 
@@ -59,6 +59,17 @@ class ParserEngineReasoningAdapter(ReasoningParser):
 
     def is_reasoning_end(self, input_ids: Sequence[int]) -> bool:
         return self._parser_engine.is_reasoning_end(list(input_ids))
+
+    def is_reasoning_end_streaming(
+        self, input_ids: Sequence[int], delta_ids: Iterable[int]
+    ) -> bool:
+        # Forward to the engine rather than falling through to
+        # ReasoningParser.is_reasoning_end_streaming, which re-scans the whole
+        # sequence via is_reasoning_end on every decode step. input_ids is not
+        # materialized here: the engine only needs it on the empty-delta path.
+        return self._parser_engine.is_reasoning_end_streaming(
+            input_ids, list(delta_ids)
+        )
 
     def adjust_initial_state_from_prompt(self, prompt_token_ids: Sequence[int]) -> None:
         self._parser_engine.adjust_initial_state_from_prompt(prompt_token_ids)

--- a/vllm/parser/engine/adapters.py
+++ b/vllm/parser/engine/adapters.py
@@ -10,7 +10,7 @@ any changes to the serving layer itself.
 
 from __future__ import annotations
 
-from collections.abc import Iterator, Sequence
+from collections.abc import Iterable, Iterator, Sequence
 from contextlib import contextmanager
 from typing import TYPE_CHECKING
 
@@ -64,6 +64,17 @@ class ParserEngineReasoningAdapter(ReasoningParser):
 
     def is_reasoning_end(self, input_ids: Sequence[int]) -> bool:
         return self._parser_engine.is_reasoning_end(list(input_ids))
+
+    def is_reasoning_end_streaming(
+        self, input_ids: Sequence[int], delta_ids: Iterable[int]
+    ) -> bool:
+        # Forward to the engine rather than falling through to
+        # ReasoningParser.is_reasoning_end_streaming, which re-scans the whole
+        # sequence via is_reasoning_end on every decode step. input_ids is not
+        # materialized here: the engine only needs it on the empty-delta path.
+        return self._parser_engine.is_reasoning_end_streaming(
+            input_ids, list(delta_ids)
+        )
 
     def adjust_initial_state_from_prompt(self, prompt_token_ids: Sequence[int]) -> None:
         self._parser_engine.adjust_initial_state_from_prompt(prompt_token_ids)

--- a/vllm/parser/engine/parser_engine.py
+++ b/vllm/parser/engine/parser_engine.py
@@ -609,6 +609,28 @@ class ParserEngine(Parser):
             return False
         return self._reasoning_ended
 
+    def is_reasoning_end_streaming(
+        self, input_ids: Sequence[int], delta_ids: Sequence[int]
+    ) -> bool:
+        """Reasoning-end check scoped to a single decode step.
+
+        The scheduler calls this once per structured-output request per decode
+        step while the request is still inside its reasoning block, so only the
+        tokens produced this step can change the verdict. The inherited default
+        re-scans the whole sequence, which makes the scheduler O(context) per
+        request per step.
+        """
+        end_id = self._reasoning_end_token_id
+        if end_id is None or not delta_ids:
+            return self.is_reasoning_end(list(input_ids))
+        start_id = self._reasoning_start_token_id
+        for token_id in reversed(delta_ids):
+            if token_id == end_id:
+                return True
+            if start_id is not None and token_id == start_id:
+                return False
+        return False
+
     def extract_content_ids(self, input_ids: list[int]) -> list[int]:
         end_id = self._reasoning_end_token_id
         if end_id is not None:

--- a/vllm/parser/engine/parser_engine.py
+++ b/vllm/parser/engine/parser_engine.py
@@ -628,6 +628,28 @@ class ParserEngine(Parser):
             return False
         return self._reasoning_ended
 
+    def is_reasoning_end_streaming(
+        self, input_ids: Sequence[int], delta_ids: Sequence[int]
+    ) -> bool:
+        """Reasoning-end check scoped to a single decode step.
+
+        The scheduler calls this once per structured-output request per decode
+        step while the request is still inside its reasoning block, so only the
+        tokens produced this step can change the verdict. The inherited default
+        re-scans the whole sequence, which makes the scheduler O(context) per
+        request per step.
+        """
+        end_id = self._reasoning_end_token_id
+        if end_id is None or not delta_ids:
+            return self.is_reasoning_end(list(input_ids))
+        start_id = self._reasoning_start_token_id
+        for token_id in reversed(delta_ids):
+            if token_id == end_id:
+                return True
+            if start_id is not None and token_id == start_id:
+                return False
+        return False
+
     def extract_content_ids(self, input_ids: list[int]) -> list[int]:
         end_id = self._reasoning_end_token_id
         if end_id is not None:

--- a/vllm/parser/gemma4.py
+++ b/vllm/parser/gemma4.py
@@ -479,6 +479,16 @@ class Gemma4Parser(ParserEngine):
                 return True
         return True
 
+    def is_reasoning_end_streaming(
+        self, input_ids: Sequence[int], delta_ids: Sequence[int]
+    ) -> bool:
+        # Deliberately keeps the full-sequence scan. Unlike the other engines,
+        # this predicate defaults to True when the sequence holds no marker at
+        # all, and <|turn>/<tool_response> flip meaning with _thinking_enabled,
+        # so a delta-scoped answer cannot tell "no marker yet in this step" from
+        # "no marker anywhere" without carrying state across steps.
+        return self.is_reasoning_end(list(input_ids))
+
     def _prompt_ends_in_open_reasoning(self, prompt_token_ids: Sequence[int]) -> bool:
         """Whether the prompt tail is inside an open ``<|channel>`` block.
 

--- a/vllm/parser/gemma4.py
+++ b/vllm/parser/gemma4.py
@@ -488,6 +488,16 @@ class Gemma4Parser(ParserEngine):
                 return True
         return True
 
+    def is_reasoning_end_streaming(
+        self, input_ids: Sequence[int], delta_ids: Sequence[int]
+    ) -> bool:
+        # Deliberately keeps the full-sequence scan. Unlike the other engines,
+        # this predicate defaults to True when the sequence holds no marker at
+        # all, and <|turn>/<tool_response> flip meaning with _thinking_enabled,
+        # so a delta-scoped answer cannot tell "no marker yet in this step" from
+        # "no marker anywhere" without carrying state across steps.
+        return self.is_reasoning_end(list(input_ids))
+
     def _prompt_ends_in_open_reasoning(self, prompt_token_ids: Sequence[int]) -> bool:
         """Whether the prompt tail is inside an open ``<|channel>`` block.
 

--- a/vllm/parser/glm47_moe.py
+++ b/vllm/parser/glm47_moe.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import functools
 import json
+from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
 import regex as re
@@ -210,6 +211,13 @@ class Glm47MoeParser(ParserEngine):
         if not self.thinking_enabled:
             return True
         return super().is_reasoning_end(input_ids)
+
+    def is_reasoning_end_streaming(
+        self, input_ids: Sequence[int], delta_ids: Sequence[int]
+    ) -> bool:
+        if not self.thinking_enabled:
+            return True
+        return super().is_reasoning_end_streaming(input_ids, delta_ids)
 
     def extract_content_ids(self, input_ids: list[int]) -> list[int]:
         if not self.thinking_enabled:

--- a/vllm/parser/inkling.py
+++ b/vllm/parser/inkling.py
@@ -349,6 +349,23 @@ class InklingParser(ParserEngine):
                 return True
         return False
 
+    def is_reasoning_end_streaming(
+        self, input_ids: Sequence[int], delta_ids: Sequence[int]
+    ) -> bool:
+        if not delta_ids:
+            return self.is_reasoning_end(list(input_ids))
+        vocab = self.vocab
+        thinking_id = vocab.get(CONTENT_THINKING)
+        text_id = vocab.get(CONTENT_TEXT)
+        model_id = vocab.get(MESSAGE_MODEL)
+        end_sampling_id = vocab.get(CONTENT_MODEL_END_SAMPLING)
+        for token_id in reversed(delta_ids):
+            if token_id in (thinking_id, model_id):
+                return False
+            if token_id in (text_id, end_sampling_id):
+                return True
+        return False
+
     def count_reasoning_tokens(self, token_ids: Sequence[int]) -> int:
         vocab = self.vocab
         thinking_id = vocab.get(CONTENT_THINKING)

--- a/vllm/parser/inkling.py
+++ b/vllm/parser/inkling.py
@@ -354,6 +354,23 @@ class InklingParser(ParserEngine):
                 return True
         return False
 
+    def is_reasoning_end_streaming(
+        self, input_ids: Sequence[int], delta_ids: Sequence[int]
+    ) -> bool:
+        if not delta_ids:
+            return self.is_reasoning_end(list(input_ids))
+        vocab = self.vocab
+        thinking_id = vocab.get(CONTENT_THINKING)
+        text_id = vocab.get(CONTENT_TEXT)
+        model_id = vocab.get(MESSAGE_MODEL)
+        end_sampling_id = vocab.get(CONTENT_MODEL_END_SAMPLING)
+        for token_id in reversed(delta_ids):
+            if token_id in (thinking_id, model_id):
+                return False
+            if token_id in (text_id, end_sampling_id):
+                return True
+        return False
+
     def count_reasoning_tokens(self, token_ids: Sequence[int]) -> int:
         vocab = self.vocab
         thinking_id = vocab.get(CONTENT_THINKING)

--- a/vllm/parser/kimi_k2.py
+++ b/vllm/parser/kimi_k2.py
@@ -254,6 +254,25 @@ class KimiK2Parser(ParserEngine):
                 return True
         return False
 
+    def is_reasoning_end_streaming(
+        self, input_ids: Sequence[int], delta_ids: Sequence[int]
+    ) -> bool:
+        if not self.thinking_enabled:
+            return True
+        if not delta_ids:
+            return self.is_reasoning_end(list(input_ids))
+        start_id = self._start_token_id
+        end_id = self._end_token_id
+        tool_section_id = self._tool_section_start_token_id
+        for token_id in reversed(delta_ids):
+            if start_id is not None and token_id == start_id:
+                return False
+            if end_id is not None and token_id == end_id:
+                return True
+            if tool_section_id is not None and token_id == tool_section_id:
+                return True
+        return False
+
     def extract_content_ids(self, input_ids: list[int]) -> list[int]:
         if not self.thinking_enabled:
             return input_ids

--- a/vllm/parser/mistral.py
+++ b/vllm/parser/mistral.py
@@ -909,6 +909,26 @@ class MistralParser(ParserEngine):
                     return True
         return False
 
+    def is_reasoning_end_streaming(
+        self, input_ids: Sequence[int], delta_ids: Sequence[int]
+    ) -> bool:
+        if self._reasoning_encoding == "none":
+            return True
+        if not delta_ids:
+            return self.is_reasoning_end(list(input_ids))
+        end_id = self._reasoning_end_token_id
+        start_id = self._reasoning_start_token_id
+        bot_id = self.bot_token_id
+        for token_id in reversed(delta_ids):
+            if end_id is not None and token_id == end_id:
+                return True
+            # [TOOL_CALLS] acts as an implicit reasoning-end marker
+            if bot_id is not None and token_id == bot_id:
+                return True
+            if start_id is not None and token_id == start_id:
+                return False
+        return False
+
     def extract_reasoning(
         self,
         model_output: str,

--- a/vllm/parser/qwen3.py
+++ b/vllm/parser/qwen3.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import functools
 import json
+from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
 import regex as re
@@ -273,4 +274,36 @@ class Qwen3Parser(ParserEngine):
                     ):
                         continue
                     return True
+        return False
+
+    def is_reasoning_end_streaming(
+        self, input_ids: Sequence[int], delta_ids: Sequence[int]
+    ) -> bool:
+        if not delta_ids:
+            return self.is_reasoning_end(list(input_ids))
+        end_id = self._reasoning_end_token_id
+        start_id = self._reasoning_start_token_id
+        tool_call_id = self._tool_call_token_id
+        tool_call_end_id = self._tool_call_end_token_id
+        for i in range(len(delta_ids) - 1, -1, -1):
+            token_id = delta_ids[i]
+            if end_id is not None and token_id == end_id:
+                return True
+            # An open <tool_call> ends reasoning; one already closed later in this
+            # step does not. Tokens after i within the step are all the sequence
+            # has past this point.
+            if (
+                tool_call_id is not None
+                and token_id == tool_call_id
+                and (
+                    tool_call_end_id is None
+                    or not any(
+                        delta_ids[j] == tool_call_end_id
+                        for j in range(i + 1, len(delta_ids))
+                    )
+                )
+            ):
+                return True
+            if start_id is not None and token_id == start_id:
+                return False
         return False

--- a/vllm/parser/qwen3.py
+++ b/vllm/parser/qwen3.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import functools
 import json
+from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
 import regex as re
@@ -281,4 +282,36 @@ class Qwen3Parser(ParserEngine):
                     ):
                         continue
                     return True
+        return False
+
+    def is_reasoning_end_streaming(
+        self, input_ids: Sequence[int], delta_ids: Sequence[int]
+    ) -> bool:
+        if not delta_ids:
+            return self.is_reasoning_end(list(input_ids))
+        end_id = self._reasoning_end_token_id
+        start_id = self._reasoning_start_token_id
+        tool_call_id = self._tool_call_token_id
+        tool_call_end_id = self._tool_call_end_token_id
+        for i in range(len(delta_ids) - 1, -1, -1):
+            token_id = delta_ids[i]
+            if end_id is not None and token_id == end_id:
+                return True
+            # An open <tool_call> ends reasoning; one already closed later in this
+            # step does not. Tokens after i within the step are all the sequence
+            # has past this point.
+            if (
+                tool_call_id is not None
+                and token_id == tool_call_id
+                and (
+                    tool_call_end_id is None
+                    or not any(
+                        delta_ids[j] == tool_call_end_id
+                        for j in range(i + 1, len(delta_ids))
+                    )
+                )
+            ):
+                return True
+            if start_id is not None and token_id == start_id:
+                return False
         return False


### PR DESCRIPTION
## Problem

`ParserEngineReasoningAdapter` forwards `is_reasoning_end` to its parser engine but not `is_reasoning_end_streaming`, so every parser-engine-backed reasoning parser falls through to `ReasoningParser`'s default:

```python
def is_reasoning_end_streaming(self, input_ids, delta_ids) -> bool:
    return self.is_reasoning_end(input_ids)
```

`should_advance` (`vllm/v1/structured_output/__init__.py:430`) calls this **once per structured-output request per decode step** while the request is still inside its reasoning block, so the scheduler re-scans the accumulated sequence every step. The adapter also did `list(input_ids)` on each call, materializing the whole prompt+output token sequence.

Resolving the MRO for the registered reasoning parsers, **17 of 30 inherit that default; 13 of them via this one adapter** — `qwen3`, `mistral`, `kimi_k2`, `minimax_m2`, `glm45`, `glm47`, `gemma4`, `deepseek_v4`, `inkling`, `ling3`, `mimo`, `nemotron_v3`, `seed_oss`.

## Measurement

Simulating exactly what `should_advance` does — `Qwen3ParserReasoningAdapter`, one call per decode step over a growing reasoning block, `all_token_ids` as a real `ConstantList`:

| reasoning tokens | before, µs/step | after, µs/step |
|---|---|---|
| 500 | 21.7 | 0.58 |
| 1000 | 46.7 | 0.56 |
| 2000 | 98.2 | 0.56 |
| 4000 | 202.2 | 0.56 |

Empirical exponent `log2(t(2n)/t(n))` goes from **2.04–2.10 to 1.00** — the per-step cost was growing linearly with the reasoning block and is now flat. With a 20k-token prompt in front (agentic multi-turn), the before figure starts at 118 µs/step and reaches 300 µs/step at 4k reasoning tokens, versus a flat 0.55 µs after; that floor was the `list(input_ids)` copy.

At 4k reasoning tokens that is ~200 µs of scheduler time per request per step, and the scheduler is on the critical path.

## Change

- `ParserEngine.is_reasoning_end_streaming` — same backward marker scan as `is_reasoning_end`, restricted to the tokens produced this step. Empty delta falls back to the full predicate.
- `ParserEngineReasoningAdapter.is_reasoning_end_streaming` — forwards to the engine, and does not materialize `input_ids` (the engine only needs it on the empty-delta path).
- Engines that extend the predicate with extra terminals get a matching delta-scoped override so none silently inherits narrower semantics: `qwen3` (`<tool_call>`), `mistral` (`[TOOL_CALLS]`), `kimi_k2` (tool-section), `inkling` (content markers), `glm47_moe` (thinking disabled).

`Gemma4Parser` **deliberately keeps the full scan**, with a comment saying why: its predicate returns `True` when the sequence holds no marker at all, and `<|turn>`/`<tool_response>` flip meaning with `_thinking_enabled`, so a delta-scoped answer cannot distinguish "no marker yet this step" from "no marker anywhere" without carrying state across steps. I measured the mismatch rather than assuming it — see below.

## Why this is not a duplicate

`gh pr list --state open --search "is_reasoning_end_streaming"` and searches for `ParserEngineReasoningAdapter` / reasoning-parser perf turn up nothing covering this. The two prior PRs of this shape are both **merged** and both single-parser:

- #35745 `[Performance] Add is_reasoning_end_streaming() override to GptOssReasoningParser`
- #50886 `[Bugfix][Reasoning] kimi_k3: O(delta) reasoning-end check on the decode path`

This generalizes the same fix to the parser-engine-backed parsers, which none of them touched. #50753 also touches `adapters.py` but for deepseek_v4 unterminated reasoning — no overlap.

## Correctness

No output change is intended, so instead of evals I verified behavioural equivalence directly. The contract the scheduler relies on is: for every decode step up to and including the first one where `is_reasoning_end(prefix)` flips to `True`, the delta-scoped answer must equal the full-sequence answer (after the first `True` the scheduler stops asking).

A differential steps random token streams through both predicates one decode step at a time, with marker vocabularies **derived from each engine's own `token_id_terminals`** rather than hand-written, and it fails loudly if an engine turns out to be delegating to the full scan — otherwise an "OK" would be vacuous. That guard is what caught Gemma4, and it also caught two mistakes in my own first attempt (hand-written vocabs that never resolved, and a Qwen3/Mistral delta scan that ignored their extra terminals).

Per engine, 3 seeds × ~12k in-contract comparisons each:

```
Qwen3Parser      OK          (12682 in-contract comparisons)
MistralParser    OK          (13190)
KimiK2Parser     OK          (11226)
InklingParser    OK          (12101)
Glm47MoeParser   OK          (15648)
Gemma4Parser     FALLBACK    delegates to the full-sequence scan (by design)
```

Before adding the per-engine overrides, that same differential reported `MISMATCH x1383` for Qwen3 and `x1528` for Mistral, and `x3349` for Gemma4 — which is why Gemma4 is excluded.

## Tests

```
$ pytest tests/parser tests/reasoning
4438 passed in 243.67s

$ pytest tests/tool_parsers
829 passed, 3 skipped, 34 xfailed, 15 errors in 252.07s

$ pytest tests/parser/engine/test_parser_engine.py -k IsReasoningEndStreaming
9 passed
```

All 15 errors are in `test_llama3_json_tool_parser.py` and are a `401 Unauthorized` fetching the gated `meta-llama` tokenizer from this machine — that file contains no reasoning-parser references.

New tests in `tests/parser/engine/test_parser_engine.py::TestIsReasoningEndStreaming`. `test_does_not_scan_the_whole_sequence` asserts the perf contract behaviourally — it passes a sequence that counts element reads and requires zero — and is the one that fails on `main`; the other eight pin the equivalence properties and hold either way.

`tests/reasoning/test_cohere_command_reasoning_parser.py` is excluded locally (needs the `cohere_melody` package).

Lint, on the changed files:

```
$ ruff check / ruff format --check     All checks passed! / 9 files already formatted
$ tools/pre_commit/mypy.py 3.12       2 errors, both pre-existing in mistral.py:437,445
```

Those two mypy errors are in `get_lark_for_json_schema` / `get_lark_from_jinja` argument types, untouched by this PR (my only change in that file starts at line 912).

## Caveats

- Local runs were on a CPU-only macOS box, so this is the unit-test and micro-benchmark level; I have not run it on a GPU serving setup. The benchmark drives the same call the scheduler makes, but an end-to-end throughput number on a real structured-output workload would be a useful confirmation and I am happy to fold in any numbers you want measured.
- The remaining `is_reasoning_end` full-sequence copy in the adapter is left alone: it is only called on prompt tokens at request setup (`structured_output/__init__.py:376`, `chat_completion/serving.py:341`), not per step.

---

AI assistance was used for this change (Claude Code): the MRO survey, the benchmark, and the equivalence differential were agent-driven, and I reviewed every changed line and ran everything reported above myself.
