### PR TITLE
[CI] Improve CI command reliability and rerun controls

### DIFF
--- a/.github/workflows/scripts/run_ci_command.py
+++ b/.github/workflows/scripts/run_ci_command.py
@@ -851,7 +851,14 @@ def run(
     comment_id = event["comment"]["id"]
     actor = event["comment"]["user"]["login"]
 
-    if is_already_handled(github, issue_number, comment_id):
+    try:
+        already_handled = is_already_handled(github, issue_number, comment_id)
+    except ApiError as error:
+        if error.status == 404:
+            print(f"Comment {comment_id} no longer exists.")
+            return
+        raise
+    if already_handled:
         print(f"Comment {comment_id} was already handled.")
         return
     add_reaction_safely(github, comment_id, "eyes")
@@ -912,8 +919,11 @@ def run(
                 github=github,
                 pr=pr,
             )
+        github.add_comment(
+            issue_number,
+            f"✅ {message}\n\n{command_comment_marker(comment_id)}",
+        )
         add_reaction_safely(github, comment_id, "rocket")
-        github.add_comment(issue_number, f"✅ {message}")
     except Exception:
         add_reaction_safely(github, comment_id, "confused")
         raise

--- a/.github/workflows/scripts/run_ci_command.py
+++ b/.github/workflows/scripts/run_ci_command.py
@@ -693,6 +693,7 @@ def resolve_workflow_run_pr(
 def handle_run_ci(
     *,
     actor: str,
+    allow_repeat_full_ci: bool,
     buildkite: BuildkiteClient,
     comment_id: int,
     command: str,
@@ -718,6 +719,13 @@ def handle_run_ci(
     )
     if active_build:
         return f"CI is already running for this commit: {active_build['web_url']}"
+
+    latest_build = select_latest_build(current_builds, pr["number"])
+    if latest_build and not allow_repeat_full_ci:
+        return (
+            f"CI already ran for this commit: {latest_build['web_url']}. "
+            "Use `/ci retry` to retry failed jobs."
+        )
 
     current_pr = github.get_pr(pr["number"])
     if current_pr["state"] != "open" or current_pr["head"]["sha"] != pr["head"]["sha"]:
@@ -905,6 +913,10 @@ def run(
         if command in RUN_CI_COMMAND_ENV:
             message = handle_run_ci(
                 actor=actor,
+                allow_repeat_full_ci=(
+                    is_trusted_permission(permission)
+                    or actor.casefold() in trusted_users
+                ),
                 buildkite=buildkite,
                 comment_id=comment_id,
                 command=command,

--- a/.github/workflows/scripts/run_ci_command.py
+++ b/.github/workflows/scripts/run_ci_command.py
@@ -721,7 +721,11 @@ def handle_run_ci(
         return f"CI is already running for this commit: {active_build['web_url']}"
 
     latest_build = select_latest_build(current_builds, pr["number"])
-    if latest_build and not allow_repeat_full_ci:
+    if (
+        latest_build
+        and latest_build.get("state") in {"failed", "passed"}
+        and not allow_repeat_full_ci
+    ):
         return (
             f"CI already ran for this commit: {latest_build['web_url']}. "
             "Use `/ci retry` to retry failed jobs."

--- a/.github/workflows/scripts/test_run_ci_command.py
+++ b/.github/workflows/scripts/test_run_ci_command.py
@@ -529,6 +529,24 @@ class RunCiCommandTest(unittest.TestCase):
 
         self.assertEqual(len(buildkite.created_builds), 1)
 
+    def test_delegated_author_can_rerun_after_canceled_build(self) -> None:
+        canceled_build = {
+            "created_at": "2026-01-01T00:00:00Z",
+            "number": 122,
+            "pull_request": {"id": 42},
+            "state": "canceled",
+            "web_url": "https://buildkite.example/builds/122",
+        }
+        github = FakeGitHub(
+            permission="read",
+            pr=make_pr(labels=[{"name": "ready"}]),
+        )
+        buildkite = FakeBuildkite([[], [canceled_build]])
+
+        run(make_event(COMMAND_RUN_CI, "author"), github, buildkite)
+
+        self.assertEqual(len(buildkite.created_builds), 1)
+
     def test_trusted_user_can_repeat_full_ci_for_commit(self) -> None:
         finished_build = {
             "created_at": "2026-01-01T00:00:00Z",

--- a/.github/workflows/scripts/test_run_ci_command.py
+++ b/.github/workflows/scripts/test_run_ci_command.py
@@ -19,6 +19,7 @@ from run_ci_command import (
     BuildkiteClient,
     HttpTransport,
     authorize,
+    command_comment_marker,
     create_build_payload,
     has_trusted_approval,
     is_active_build,
@@ -76,12 +77,19 @@ class FakeGitHub:
         comments: list[str] | None = None,
         pulls_for_commit: list[dict[str, Any]] | None = None,
         prs: dict[int, dict[str, Any]] | None = None,
+        comment_failures: int = 0,
+        reaction_failures: set[str] | None = None,
+        reaction_list_error: ApiError | None = None,
     ) -> None:
         self.comments = comments or []
+        self.comment_failures = comment_failures
+        self.operations: list[tuple[str, str]] = []
         self.permission = permission
         self.permissions = permissions or {}
         self.pr = pr or make_pr()
         self.reactions: list[str] = []
+        self.reaction_failures = reaction_failures or set()
+        self.reaction_list_error = reaction_list_error
         self.review_decision = review_decision
         self.reviews = reviews or []
         self.pulls_for_commit = pulls_for_commit or []
@@ -115,13 +123,28 @@ class FakeGitHub:
         ]
 
     def list_reactions(self, comment_id: int) -> list[dict[str, Any]]:
-        return []
+        if self.reaction_list_error is not None:
+            raise self.reaction_list_error
+        return [
+            {
+                "content": content,
+                "user": {"login": "github-actions[bot]"},
+            }
+            for content in self.reactions
+        ]
 
     def add_reaction(self, comment_id: int, content: str) -> None:
+        if content in self.reaction_failures:
+            raise ApiError(500, "Reaction failed")
         self.reactions.append(content)
+        self.operations.append(("reaction", content))
 
     def add_comment(self, issue_number: int, body: str) -> None:
+        if self.comment_failures:
+            self.comment_failures -= 1
+            raise ApiError(500, "Comment failed")
         self.comments.append(body)
+        self.operations.append(("comment", body))
 
 
 class FakeBuildkite:
@@ -452,8 +475,60 @@ class RunCiCommandTest(unittest.TestCase):
             "PR #42 /ci run by @reviewer",
         )
         self.assertEqual(github.reactions, ["eyes", "rocket"])
+        self.assertEqual(
+            [operation for operation, _ in github.operations],
+            ["reaction", "comment", "reaction"],
+        )
         self.assertTrue(github.comments[0].startswith("✅ "))
         self.assertIn("Buildkite CI #123", github.comments[0])
+        self.assertIn(command_comment_marker(99), github.comments[0])
+
+    def test_success_comment_marker_handles_rerun_when_rocket_fails(self) -> None:
+        github = FakeGitHub(reaction_failures={"rocket"})
+        buildkite = FakeBuildkite([[], []])
+
+        run(make_event(COMMAND_RUN_CI), github, buildkite)
+        run(make_event(COMMAND_RUN_CI), github, buildkite)
+
+        self.assertEqual(len(buildkite.created_builds), 1)
+        self.assertEqual(len(github.comments), 1)
+        self.assertIn(command_comment_marker(99), github.comments[0])
+        self.assertEqual(github.reactions, ["eyes"])
+
+    def test_comment_failure_does_not_mark_command_handled(self) -> None:
+        duplicate = {
+            "created_at": "2026-01-01T00:00:00Z",
+            "meta_data": {"github-pr-number": "42"},
+            "number": 123,
+            "pull_request": {"id": 42},
+            "web_url": "https://buildkite.example/builds/123",
+        }
+        github = FakeGitHub(comment_failures=1)
+        buildkite = FakeBuildkite([[], [], [duplicate]])
+
+        with self.assertRaisesRegex(ApiError, "Comment failed"):
+            run(make_event(COMMAND_RUN_CI), github, buildkite)
+
+        self.assertEqual(github.reactions, ["eyes", "confused"])
+        self.assertNotIn("rocket", github.reactions)
+
+        run(make_event(COMMAND_RUN_CI), github, buildkite)
+
+        self.assertEqual(len(buildkite.created_builds), 1)
+        self.assertEqual(len(github.comments), 1)
+        self.assertIn(command_comment_marker(99), github.comments[0])
+        self.assertEqual(github.reactions[-1], "rocket")
+
+    def test_deleted_command_comment_is_a_clean_noop(self) -> None:
+        github = FakeGitHub(
+            reaction_list_error=ApiError(404, "Comment not found"),
+        )
+        buildkite = FakeBuildkite()
+
+        run(make_event(COMMAND_RUN_CI), github, buildkite)
+
+        self.assertEqual(github.operations, [])
+        self.assertEqual(buildkite.list_calls, [])
 
     def test_run_all_sets_buildkite_environment(self) -> None:
         github = FakeGitHub()

--- a/.github/workflows/scripts/test_run_ci_command.py
+++ b/.github/workflows/scripts/test_run_ci_command.py
@@ -483,6 +483,72 @@ class RunCiCommandTest(unittest.TestCase):
         self.assertIn("Buildkite CI #123", github.comments[0])
         self.assertIn(command_comment_marker(99), github.comments[0])
 
+    def test_delegated_author_can_run_ci_on_new_commit(self) -> None:
+        github = FakeGitHub(
+            permission="read",
+            pr=make_pr(labels=[{"name": "ready"}]),
+        )
+        buildkite = FakeBuildkite([[], []])
+
+        run(make_event(COMMAND_RUN_CI, "author"), github, buildkite)
+
+        self.assertEqual(len(buildkite.created_builds), 1)
+
+    def test_delegated_author_uses_retry_after_ci_ran_for_commit(self) -> None:
+        finished_build = {
+            "created_at": "2026-01-01T00:00:00Z",
+            "number": 122,
+            "pull_request": {"id": 42},
+            "state": "failed",
+            "web_url": "https://buildkite.example/builds/122",
+        }
+        github = FakeGitHub(
+            permission="read",
+            pr=make_pr(labels=[{"name": "ready"}]),
+        )
+        buildkite = FakeBuildkite([[], [finished_build]])
+
+        run(make_event(COMMAND_RUN_CI, "author"), github, buildkite)
+
+        self.assertEqual(buildkite.created_builds, [])
+        self.assertIn("CI already ran for this commit", github.comments[0])
+        self.assertIn("Use `/ci retry`", github.comments[0])
+
+    def test_write_user_can_repeat_full_ci_for_commit(self) -> None:
+        finished_build = {
+            "created_at": "2026-01-01T00:00:00Z",
+            "number": 122,
+            "pull_request": {"id": 42},
+            "state": "failed",
+            "web_url": "https://buildkite.example/builds/122",
+        }
+        github = FakeGitHub()
+        buildkite = FakeBuildkite([[], [finished_build]])
+
+        run(make_event(COMMAND_RUN_CI), github, buildkite)
+
+        self.assertEqual(len(buildkite.created_builds), 1)
+
+    def test_trusted_user_can_repeat_full_ci_for_commit(self) -> None:
+        finished_build = {
+            "created_at": "2026-01-01T00:00:00Z",
+            "number": 122,
+            "pull_request": {"id": 42},
+            "state": "failed",
+            "web_url": "https://buildkite.example/builds/122",
+        }
+        github = FakeGitHub(permission="read")
+        buildkite = FakeBuildkite([[], [finished_build]])
+
+        run(
+            make_event(COMMAND_RUN_CI, "trusted"),
+            github,
+            buildkite,
+            trusted_users_value="trusted",
+        )
+
+        self.assertEqual(len(buildkite.created_builds), 1)
+
     def test_success_comment_marker_handles_rerun_when_rocket_fails(self) -> None:
         github = FakeGitHub(reaction_failures={"rocket"})
         buildkite = FakeBuildkite([[], []])


### PR DESCRIPTION
## Summary

- add the per-command marker to successful CI acknowledgement comments
- post the durable acknowledgement before adding the terminal rocket reaction
- treat a deleted command comment as a clean no-op instead of failing the workflow
- direct delegated PR authors to `/ci retry` after full CI has passed or failed on the current commit, while preserving repeat access for write and `CI_TRUSTED_USERS` users and allowing a fresh run after cancellation
- cover comment failures, reaction failures, manual reruns, and deleted comments with focused unit tests

## Root cause

The command broker treated the rocket reaction as terminal but added it before posting the acknowledgement comment. If the comment request failed after the reaction succeeded, a manual workflow rerun saw the rocket and exited without restoring the missing acknowledgement. Successful comments also lacked the hidden command marker that denied comments already used as a durable deduplication key.

Separately, a command comment deleted before processing caused the initial reaction lookup to return `404`, failing the workflow instead of respecting the removed request.

Delegated PR authors could also launch repeated full CI builds after an earlier build for the same commit finished. The existing same-commit Buildkite lookup already had enough information to prevent this without adding API requests.

## Duplicate check

I searched open PRs for `CI command idempotency`, `run_ci_command reaction marker`, `deleted comment CI command`, `repeat full CI same commit`, and `CI retry same head author`; no existing PR addresses these failure modes. The only textual match was an unrelated model bugfix.

## Test design

The broker's observable contract is GitHub comments and reactions plus Buildkite mutations. The tests use the existing fake clients to inject failures at those boundaries, verify that a rerun acknowledges an already-created build without creating a duplicate, and cover the delegated-versus-privileged repeat-build policy.

## Tests

- `uv run --no-project --python 3.12 .github/workflows/scripts/test_run_ci_command.py` — 43 tests passed
- `uv run --no-project --with pre-commit pre-commit run --files .github/workflows/scripts/run_ci_command.py .github/workflows/scripts/test_run_ci_command.py` — all applicable hooks passed, including Ruff and mypy
- `git diff --check` — passed

## Model evaluation

Not applicable; this change only affects CI command orchestration and rerun controls.

## AI assistance

OpenAI Codex assisted with diagnosis, implementation, and tests. This is a draft PR; the submitting human must review every changed line and understand the change before merge.
