### PR TITLE
feat: optimize MHC post + HC head + RMSNorm fusions for DeepSeek V4

### DIFF
--- a/benchmarks/kernels/benchmark_mhc_fusions.py
+++ b/benchmarks/kernels/benchmark_mhc_fusions.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Benchmark optimized MHC kernel fusions.
+
+This script measures the performance improvement of fused kernels
+compared to separate kernel calls.
+"""
+
+import argparse
+import time
+
+import torch
+
+from vllm.platforms import current_platform
+from vllm.utils.import_utils import has_tilelang
+
+if not has_tilelang() or not current_platform.is_cuda_alike():
+    raise RuntimeError("TileLang and CUDA required for MHC benchmarks")
+
+from vllm.model_executor.kernels.mhc.tilelang import (
+    hc_head_fused_kernel_tilelang,
+    mhc_post_tilelang,
+)
+from vllm.model_executor.kernels.mhc.optimized_wrappers import (
+    mhc_post_hc_head_fused,
+    mhc_post_hc_head_norm_fused,
+    mhc_post_mean_fused,
+)
+
+
+def create_test_inputs(num_tokens, hc_mult, hidden_size, device="cuda"):
+    """Create test inputs."""
+    x = torch.randn(num_tokens, hidden_size, device=device, dtype=torch.bfloat16)
+    residual = torch.randn(num_tokens, hc_mult, hidden_size, device=device, dtype=torch.bfloat16)
+    post_mix = torch.randn(num_tokens, hc_mult, 1, device=device, dtype=torch.float32)
+    comb_mix = torch.randn(num_tokens, hc_mult, hc_mult, device=device, dtype=torch.float32)
+    return x, residual, post_mix, comb_mix
+
+
+def create_hc_head_params(hc_mult, hidden_size, device="cuda"):
+    """Create HC head parameters."""
+    hc_dim = hc_mult * hidden_size
+    fn = torch.randn(hc_mult, hc_dim, device=device, dtype=torch.float32)
+    scale = torch.ones(1, device=device, dtype=torch.float32)
+    base = torch.randn(hc_mult, device=device, dtype=torch.float32)
+    return fn, scale, base
+
+
+def benchmark_kernel(func, inputs, num_warmup=10, num_iters=100):
+    """Benchmark a kernel function."""
+    # Warmup
+    for _ in range(num_warmup):
+        output = func(*inputs)
+        if isinstance(output, tuple):
+            for o in output:
+                _ = o
+
+    torch.cuda.synchronize()
+
+    # Benchmark
+    start_event = torch.cuda.Event(enable_timing=True)
+    end_event = torch.cuda.Event(enable_timing=True)
+
+    start_event.record()
+    for _ in range(num_iters):
+        output = func(*inputs)
+        if isinstance(output, tuple):
+            for o in output:
+                _ = o
+    end_event.record()
+
+    torch.cuda.synchronize()
+    elapsed_ms = start_event.elapsed_time(end_event)
+    avg_ms = elapsed_ms / num_iters
+
+    return avg_ms
+
+
+def benchmark_mhc_post_hc_head(num_tokens, hc_mult, hidden_size, num_iters=100):
+    """Benchmark mhc_post + hc_head fusion."""
+    print(f"\n{'='*80}")
+    print(f"Benchmark: MHC Post + HC Head Fusion")
+    print(f"Config: num_tokens={num_tokens}, hc_mult={hc_mult}, hidden_size={hidden_size}")
+    print(f"{'='*80}")
+
+    device = "cuda"
+    x, residual, post_mix, comb_mix = create_test_inputs(num_tokens, hc_mult, hidden_size, device)
+    fn, scale, base = create_hc_head_params(hc_mult, hidden_size, device)
+
+    rms_eps = 1e-6
+    hc_eps = 1e-3
+
+    # Benchmark original separate calls
+    def original_ops():
+        residual_out = mhc_post_tilelang(x, residual, post_mix, comb_mix)
+        return hc_head_fused_kernel_tilelang(residual_out, fn, scale, base, rms_eps, hc_eps)
+
+    orig_time = benchmark_kernel(original_ops, [], num_iters=num_iters)
+
+    # Benchmark fused kernel
+    def fused_ops():
+        return mhc_post_hc_head_fused(
+            x, residual, post_mix, comb_mix, fn, scale, base, rms_eps, hc_eps
+        )
+
+    fused_time = benchmark_kernel(fused_ops, [], num_iters=num_iters)
+
+    speedup = orig_time / fused_time
+    saved_ms = orig_time - fused_time
+
+    print(f"Original (separate):  {orig_time:.3f} ms")
+    print(f"Fused:                {fused_time:.3f} ms")
+    print(f"Speedup:              {speedup:.2f}x")
+    print(f"Time saved:           {saved_ms:.3f} ms ({saved_ms/orig_time*100:.1f}%)")
+
+    return {
+        "num_tokens": num_tokens,
+        "original_ms": orig_time,
+        "fused_ms": fused_time,
+        "speedup": speedup,
+    }
+
+
+def benchmark_mhc_post_hc_head_norm(num_tokens, hc_mult, hidden_size, num_iters=100):
+    """Benchmark mhc_post + hc_head + norm fusion."""
+    print(f"\n{'='*80}")
+    print(f"Benchmark: MHC Post + HC Head + RMSNorm Fusion")
+    print(f"Config: num_tokens={num_tokens}, hc_mult={hc_mult}, hidden_size={hidden_size}")
+    print(f"{'='*80}")
+
+    device = "cuda"
+    x, residual, post_mix, comb_mix = create_test_inputs(num_tokens, hc_mult, hidden_size, device)
+    fn, scale, base = create_hc_head_params(hc_mult, hidden_size, device)
+    norm_weight = torch.ones(hidden_size, device=device, dtype=torch.bfloat16)
+
+    rms_eps = 1e-6
+    hc_eps = 1e-3
+    norm_eps = 1e-5
+
+    # Benchmark original separate calls
+    def original_ops():
+        residual_out = mhc_post_tilelang(x, residual, post_mix, comb_mix)
+        hc_out = hc_head_fused_kernel_tilelang(residual_out, fn, scale, base, rms_eps, hc_eps)
+        # RMSNorm
+        variance = hc_out.float().pow(2).mean(-1, keepdim=True)
+        return hc_out * torch.rsqrt(variance + norm_eps) * norm_weight
+
+    orig_time = benchmark_kernel(original_ops, [], num_iters=num_iters)
+
+    # Benchmark fused kernel
+    def fused_ops():
+        return mhc_post_hc_head_norm_fused(
+            x, residual, post_mix, comb_mix, fn, scale, base,
+            norm_weight, rms_eps, hc_eps, norm_eps
+        )
+
+    fused_time = benchmark_kernel(fused_ops, [], num_iters=num_iters)
+
+    speedup = orig_time / fused_time
+    saved_ms = orig_time - fused_time
+
+    print(f"Original (separate):  {orig_time:.3f} ms")
+    print(f"Fused:                {fused_time:.3f} ms")
+    print(f"Speedup:              {speedup:.2f}x")
+    print(f"Time saved:           {saved_ms:.3f} ms ({saved_ms/orig_time*100:.1f}%)")
+
+    return {
+        "num_tokens": num_tokens,
+        "original_ms": orig_time,
+        "fused_ms": fused_time,
+        "speedup": speedup,
+    }
+
+
+def benchmark_mhc_post_mean(num_tokens, hc_mult, hidden_size, num_iters=100):
+    """Benchmark mhc_post + mean fusion."""
+    print(f"\n{'='*80}")
+    print(f"Benchmark: MHC Post + Mean Fusion")
+    print(f"Config: num_tokens={num_tokens}, hc_mult={hc_mult}, hidden_size={hidden_size}")
+    print(f"{'='*80}")
+
+    device = "cuda"
+    x, residual, post_mix, comb_mix = create_test_inputs(num_tokens, hc_mult, hidden_size, device)
+
+    # Benchmark original separate calls
+    def original_ops():
+        residual_out = mhc_post_tilelang(x, residual, post_mix, comb_mix)
+        mean_out = residual_out.mean(dim=1)
+        return residual_out, mean_out
+
+    orig_time = benchmark_kernel(original_ops, [], num_iters=num_iters)
+
+    # Benchmark fused kernel
+    def fused_ops():
+        return mhc_post_mean_fused(x, residual, post_mix, comb_mix)
+
+    fused_time = benchmark_kernel(fused_ops, [], num_iters=num_iters)
+
+    speedup = orig_time / fused_time
+    saved_ms = orig_time - fused_time
+
+    print(f"Original (separate):  {orig_time:.3f} ms")
+    print(f"Fused:                {fused_time:.3f} ms")
+    print(f"Speedup:              {speedup:.2f}x")
+    print(f"Time saved:           {saved_ms:.3f} ms ({saved_ms/orig_time*100:.1f}%)")
+
+    return {
+        "num_tokens": num_tokens,
+        "original_ms": orig_time,
+        "fused_ms": fused_time,
+        "speedup": speedup,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Benchmark MHC kernel fusions")
+    parser.add_argument("--num-tokens", type=int, nargs="+", default=[32, 64, 128, 256, 512, 1024],
+                        help="Token counts to benchmark")
+    parser.add_argument("--hc-mult", type=int, default=4, help="HC multiplier")
+    parser.add_argument("--hidden-size", type=int, default=2048, help="Hidden size")
+    parser.add_argument("--num-iters", type=int, default=100, help="Number of iterations")
+    args = parser.parse_args()
+
+    print(f"MHC Kernel Fusion Benchmarks")
+    print(f"Device: {torch.cuda.get_device_name()}")
+    print(f"Hidden size: {args.hidden_size}")
+    print(f"HC multiplier: {args.hc_mult}")
+
+    all_results = []
+
+    for num_tokens in args.num_tokens:
+        result = benchmark_mhc_post_hc_head(
+            num_tokens, args.hc_mult, args.hidden_size, args.num_iters
+        )
+        all_results.append(("mhc_post_hc_head", result))
+
+        result = benchmark_mhc_post_hc_head_norm(
+            num_tokens, args.hc_mult, args.hidden_size, args.num_iters
+        )
+        all_results.append(("mhc_post_hc_head_norm", result))
+
+        result = benchmark_mhc_post_mean(
+            num_tokens, args.hc_mult, args.hidden_size, args.num_iters
+        )
+        all_results.append(("mhc_post_mean", result))
+
+    # Print summary
+    print(f"\n{'='*80}")
+    print("SUMMARY")
+    print(f"{'='*80}")
+    print(f"{'Kernel':<30} {'Tokens':<10} {'Speedup':<10} {'Time Saved (ms)'}")
+    print(f"{'-'*80}")
+
+    for kernel_name, result in all_results:
+        saved_ms = result['original_ms'] - result['fused_ms']
+        print(f"{kernel_name:<30} {result['num_tokens']:<10} "
+              f"{result['speedup']:<10.2f} {saved_ms:.3f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/kernels/profile_mhc_fusions.py
+++ b/benchmarks/kernels/profile_mhc_fusions.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""
+NCU profiling script for MHC fusion kernels.
+Measures actual HBM traffic reduction.
+"""
+
+import torch
+import sys
+import os
+
+# Add vllm to path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../..')))
+
+from vllm.model_executor.kernels.mhc.optimized_wrappers import (
+    mhc_post_hc_head_fused,
+    mhc_post_hc_head_norm_fused,
+    mhc_post_mean_fused
+)
+
+
+def profile_mhc_post_hc_head():
+    """Profile MHC Post + HC Head fusion."""
+    print("=" * 80)
+    print("Profiling: MHC Post + HC Head Fusion")
+    print("=" * 80)
+
+    num_tokens = 256
+    hc_mult = 4
+    hidden_size = 2048
+
+    # Input tensors
+    x = torch.randn(num_tokens, hidden_size, dtype=torch.bfloat16, device='cuda')
+    residual = torch.randn(num_tokens, hc_mult, hidden_size, dtype=torch.bfloat16, device='cuda')
+    post_layer_mix = torch.randn(num_tokens, hc_mult, dtype=torch.float32, device='cuda')
+    comb_res_mix = torch.randn(num_tokens, hc_mult, hc_mult, dtype=torch.float32, device='cuda')
+    hc_head_fn = torch.randn(hc_mult, hc_mult * hidden_size, dtype=torch.float32, device='cuda')
+    hc_head_scale = torch.ones(1, dtype=torch.float32, device='cuda')
+    hc_head_base = torch.zeros(hc_mult, dtype=torch.float32, device='cuda')
+    rms_norm_eps = 1e-6
+    hc_eps = 1e-6
+
+    # Warm-up
+    for _ in range(10):
+        _ = mhc_post_hc_head_fused(x, residual, post_layer_mix, comb_res_mix,
+                                    hc_head_fn, hc_head_scale, hc_head_base,
+                                    rms_norm_eps, hc_eps)
+
+    torch.cuda.synchronize()
+
+    # Run for profiling
+    print("\nRunning fused kernel (profiling iteration)...")
+    result = mhc_post_hc_head_fused(x, residual, post_layer_mix, comb_res_mix,
+                                     hc_head_fn, hc_head_scale, hc_head_base,
+                                     rms_norm_eps, hc_eps)
+    torch.cuda.synchronize()
+
+    print(f"Input shapes: x={x.shape}, residual={residual.shape}")
+    print(f"Output shape: {result.shape}")
+    print("\nExpected HBM traffic reduction: ~50%")
+
+
+def profile_mhc_post_hc_head_norm():
+    """Profile MHC Post + HC Head + RMSNorm fusion."""
+    print("\n" + "=" * 80)
+    print("Profiling: MHC Post + HC Head + RMSNorm Fusion")
+    print("=" * 80)
+
+    num_tokens = 256
+    hc_mult = 4
+    hidden_size = 2048
+
+    # Input tensors
+    x = torch.randn(num_tokens, hidden_size, dtype=torch.bfloat16, device='cuda')
+    residual = torch.randn(num_tokens, hc_mult, hidden_size, dtype=torch.bfloat16, device='cuda')
+    post_layer_mix = torch.randn(num_tokens, hc_mult, dtype=torch.float32, device='cuda')
+    comb_res_mix = torch.randn(num_tokens, hc_mult, hc_mult, dtype=torch.float32, device='cuda')
+    hc_head_fn = torch.randn(hc_mult, hc_mult * hidden_size, dtype=torch.float32, device='cuda')
+    hc_head_scale = torch.ones(1, dtype=torch.float32, device='cuda')
+    hc_head_base = torch.zeros(hc_mult, dtype=torch.float32, device='cuda')
+    norm_weight = torch.randn(hidden_size, dtype=torch.bfloat16, device='cuda')
+    rms_norm_eps = 1e-6
+    hc_eps = 1e-6
+    norm_eps = 1e-6
+
+    # Warm-up
+    for _ in range(10):
+        _ = mhc_post_hc_head_norm_fused(x, residual, post_layer_mix, comb_res_mix,
+                                         hc_head_fn, hc_head_scale, hc_head_base,
+                                         norm_weight, rms_norm_eps, hc_eps, norm_eps)
+
+    torch.cuda.synchronize()
+
+    # Run for profiling
+    print("\nRunning fused kernel (profiling iteration)...")
+    result = mhc_post_hc_head_norm_fused(x, residual, post_layer_mix, comb_res_mix,
+                                          hc_head_fn, hc_head_scale, hc_head_base,
+                                          norm_weight, rms_norm_eps, hc_eps, norm_eps)
+    torch.cuda.synchronize()
+
+    print(f"Input shapes: x={x.shape}, residual={residual.shape}, norm_weight={norm_weight.shape}")
+    print(f"Output shape: {result.shape}")
+    print("\nExpected HBM traffic reduction: ~80%")
+
+
+def profile_mhc_post_mean():
+    """Profile MHC Post + Mean fusion."""
+    print("\n" + "=" * 80)
+    print("Profiling: MHC Post + Mean Fusion")
+    print("=" * 80)
+
+    num_tokens = 256
+    hc_mult = 4
+    hidden_size = 2048
+
+    # Input tensors
+    x = torch.randn(num_tokens, hidden_size, dtype=torch.bfloat16, device='cuda')
+    residual = torch.randn(num_tokens, hc_mult, hidden_size, dtype=torch.bfloat16, device='cuda')
+    post_layer_mix = torch.randn(num_tokens, hc_mult, dtype=torch.bfloat16, device='cuda')
+    comb_res_mix = torch.randn(num_tokens, hc_mult, hc_mult, dtype=torch.bfloat16, device='cuda')
+
+    # Warm-up
+    for _ in range(10):
+        _ = mhc_post_mean_fused(x, residual, post_layer_mix, comb_res_mix)
+
+    torch.cuda.synchronize()
+
+    # Run for profiling
+    print("\nRunning fused kernel (profiling iteration)...")
+    residual_out, mean_out = mhc_post_mean_fused(x, residual, post_layer_mix, comb_res_mix)
+    torch.cuda.synchronize()
+
+    print(f"Input shapes: x={x.shape}, residual={residual.shape}")
+    print(f"Output shapes: residual_out={residual_out.shape}, mean_out={mean_out.shape}")
+    print("\nExpected HBM traffic reduction: ~37.5%")
+
+
+if __name__ == "__main__":
+    import argparse
+    parser = argparse.ArgumentParser(description='Profile MHC fusion kernels')
+    parser.add_argument('--kernel', choices=['all', 'post_hc_head', 'post_hc_head_norm', 'post_mean'],
+                        default='all', help='Which kernel to profile')
+    args = parser.parse_args()
+
+    if args.kernel in ['all', 'post_hc_head']:
+        profile_mhc_post_hc_head()
+
+    if args.kernel in ['all', 'post_hc_head_norm']:
+        profile_mhc_post_hc_head_norm()
+
+    if args.kernel in ['all', 'post_mean']:
+        profile_mhc_post_mean()
+
+    print("\n" + "=" * 80)
+    print("Profiling complete. Use ncu to analyze HBM traffic.")
+    print("=" * 80)

--- a/benchmarks/kernels/run_ncu_profile.sh
+++ b/benchmarks/kernels/run_ncu_profile.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# NCU profiling wrapper script for MHC fusion kernels.
+# Usage: ./run_ncu_profile.sh [kernel_name]
+#   kernel_name: all, post_hc_head, post_hc_head_norm, post_mean (default: all)
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+VLLM_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+cd "$VLLM_DIR" || exit 1
+
+export PYTHONPATH="$VLLM_DIR:$PYTHONPATH"
+
+sudo -E /usr/local/cuda/bin/ncu \
+    --metrics dram__bytes.sum \
+    --target-processes all \
+    python3 benchmarks/kernels/profile_mhc_fusions.py --kernel "${1:-all}"

--- a/tests/kernels/test_mhc_optimized_fusions.py
+++ b/tests/kernels/test_mhc_optimized_fusions.py
@@ -1,0 +1,179 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for optimized MHC kernel fusions.
+
+These tests verify correctness by comparing optimized fused kernels
+against the original separate kernel calls.
+"""
+
+import pytest
+import torch
+
+from vllm.platforms import current_platform
+from vllm.utils.import_utils import has_tilelang
+
+if not has_tilelang() or not current_platform.is_cuda_alike():
+    pytest.skip("TileLang required for MHC tests", allow_module_level=True)
+
+from vllm.model_executor.kernels.mhc.tilelang import (
+    hc_head_fused_kernel_tilelang,
+    mhc_post_tilelang,
+)
+from vllm.model_executor.kernels.mhc.optimized_wrappers import (
+    mhc_post_hc_head_fused,
+    mhc_post_hc_head_norm_fused,
+    mhc_post_mean_fused,
+)
+
+
+def create_test_inputs(num_tokens, hc_mult, hidden_size, device="cuda", dtype=torch.bfloat16):
+    """Create test inputs for MHC operations."""
+    x = torch.randn(num_tokens, hidden_size, device=device, dtype=dtype)
+    residual = torch.randn(num_tokens, hc_mult, hidden_size, device=device, dtype=dtype)
+    post_mix = torch.randn(num_tokens, hc_mult, device=device, dtype=torch.float32)
+    comb_mix = torch.randn(num_tokens, hc_mult, hc_mult, device=device, dtype=torch.float32)
+
+    # Normalize mixing weights to avoid numerical overflow
+    post_mix = torch.sigmoid(post_mix) * 2.0
+    comb_mix = torch.softmax(comb_mix, dim=-1)
+
+    return x, residual, post_mix, comb_mix
+
+
+def create_hc_head_params(hc_mult, hidden_size, device="cuda"):
+    """Create HC head parameters."""
+    hc_dim = hc_mult * hidden_size
+    fn = torch.randn(hc_mult, hc_dim, device=device, dtype=torch.float32) * 0.01
+    scale = torch.ones(1, device=device, dtype=torch.float32)
+    base = torch.randn(hc_mult, device=device, dtype=torch.float32) * 0.1
+    return fn, scale, base
+
+
+@pytest.mark.parametrize("num_tokens", [1, 8, 64, 256])
+@pytest.mark.parametrize("hc_mult", [4])
+@pytest.mark.parametrize("hidden_size", [512, 1024, 2048])
+def test_mhc_post_hc_head_fused_correctness(num_tokens, hc_mult, hidden_size):
+    """Test that fused mhc_post + hc_head matches separate calls."""
+    device = "cuda"
+    torch.manual_seed(42)
+
+    # Create inputs
+    x, residual, post_mix, comb_mix = create_test_inputs(num_tokens, hc_mult, hidden_size, device)
+    fn, scale, base = create_hc_head_params(hc_mult, hidden_size, device)
+
+    rms_eps = 1e-6
+    hc_eps = 1e-3
+
+    # Original separate operations
+    residual_out_orig = mhc_post_tilelang(
+        x, residual, post_mix.unsqueeze(-1), comb_mix
+    )
+    output_orig = hc_head_fused_kernel_tilelang(
+        residual_out_orig, fn, scale, base, rms_eps, hc_eps
+    )
+
+    # Optimized fused operation
+    output_fused = mhc_post_hc_head_fused(
+        x, residual, post_mix.unsqueeze(-1), comb_mix,
+        fn, scale, base, rms_eps, hc_eps
+    )
+
+    # Check results match
+    torch.testing.assert_close(
+        output_fused, output_orig,
+        rtol=1e-2, atol=1e-2,
+        msg=f"Fused kernel output mismatch for {num_tokens=}, {hc_mult=}, {hidden_size=}"
+    )
+
+
+@pytest.mark.parametrize("num_tokens", [1, 8, 64])
+@pytest.mark.parametrize("hc_mult", [4])
+@pytest.mark.parametrize("hidden_size", [512, 1024])
+def test_mhc_post_hc_head_norm_fused_correctness(num_tokens, hc_mult, hidden_size):
+    """Test that fused mhc_post + hc_head + norm matches separate calls."""
+    device = "cuda"
+    torch.manual_seed(42)
+
+    # Create inputs
+    x, residual, post_mix, comb_mix = create_test_inputs(num_tokens, hc_mult, hidden_size, device)
+    fn, scale, base = create_hc_head_params(hc_mult, hidden_size, device)
+    norm_weight = torch.ones(hidden_size, device=device, dtype=torch.bfloat16)
+
+    rms_eps = 1e-6
+    hc_eps = 1e-3
+    norm_eps = 1e-5
+
+    # Original separate operations
+    residual_out_orig = mhc_post_tilelang(
+        x, residual, post_mix.unsqueeze(-1), comb_mix
+    )
+    hc_out_orig = hc_head_fused_kernel_tilelang(
+        residual_out_orig, fn, scale, base, rms_eps, hc_eps
+    )
+    # RMSNorm
+    variance = hc_out_orig.float().pow(2).mean(-1, keepdim=True)
+    output_orig = (hc_out_orig * torch.rsqrt(variance + norm_eps) * norm_weight).bfloat16()
+
+    # Optimized fused operation
+    output_fused = mhc_post_hc_head_norm_fused(
+        x, residual, post_mix.unsqueeze(-1), comb_mix,
+        fn, scale, base, norm_weight, rms_eps, hc_eps, norm_eps
+    )
+
+    # Check results match
+    torch.testing.assert_close(
+        output_fused, output_orig,
+        rtol=1e-2, atol=1e-2,
+        msg=f"Fused kernel with norm output mismatch for {num_tokens=}, {hc_mult=}, {hidden_size=}"
+    )
+
+
+@pytest.mark.parametrize("num_tokens", [1, 8, 64, 256])
+@pytest.mark.parametrize("hc_mult", [4])
+@pytest.mark.parametrize("hidden_size", [512, 1024])
+def test_mhc_post_mean_fused_correctness(num_tokens, hc_mult, hidden_size):
+    """Test that fused mhc_post + mean matches separate calls."""
+    device = "cuda"
+    torch.manual_seed(42)
+
+    # Create inputs
+    x, residual, post_mix, comb_mix = create_test_inputs(num_tokens, hc_mult, hidden_size, device)
+
+    # Original separate operations
+    residual_out_orig = mhc_post_tilelang(
+        x, residual, post_mix.unsqueeze(-1), comb_mix
+    )
+    mean_out_orig = residual_out_orig.mean(dim=1)
+
+    # Optimized fused operation
+    residual_out_fused, mean_out_fused = mhc_post_mean_fused(
+        x, residual, post_mix.unsqueeze(-1), comb_mix
+    )
+
+    # Check both outputs match
+    torch.testing.assert_close(
+        residual_out_fused, residual_out_orig,
+        rtol=1e-3, atol=1e-3,
+        msg=f"Fused kernel residual output mismatch for {num_tokens=}, {hc_mult=}, {hidden_size=}"
+    )
+
+    torch.testing.assert_close(
+        mean_out_fused, mean_out_orig,
+        rtol=2e-2, atol=2e-2,
+        msg=f"Fused kernel mean output mismatch for {num_tokens=}, {hc_mult=}, {hidden_size=}"
+    )
+
+
+if __name__ == "__main__":
+    # Quick smoke test
+    print("Running MHC optimized fusion tests...")
+    test_mhc_post_hc_head_fused_correctness(64, 4, 1024)
+    print("✓ mhc_post_hc_head_fused correctness test passed")
+
+    test_mhc_post_hc_head_norm_fused_correctness(64, 4, 1024)
+    print("✓ mhc_post_hc_head_norm_fused correctness test passed")
+
+    test_mhc_post_mean_fused_correctness(64, 4, 1024)
+    print("✓ mhc_post_mean_fused correctness test passed")
+
+    print("\nAll tests passed!")

--- a/tests/kernels/test_mhc_optimized_fusions.py
+++ b/tests/kernels/test_mhc_optimized_fusions.py
@@ -1,0 +1,314 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for optimized MHC kernel fusions.
+
+These tests verify correctness by comparing optimized fused kernels
+against the original separate kernel calls.
+"""
+
+import pytest
+import torch
+
+from vllm.platforms import current_platform
+from vllm.utils.import_utils import has_tilelang
+
+if not has_tilelang() or not current_platform.is_cuda_alike():
+    pytest.skip("TileLang required for MHC tests", allow_module_level=True)
+
+from vllm.model_executor.kernels.mhc.tilelang import (
+    hc_head_fused_kernel_tilelang,
+    mhc_post_tilelang,
+)
+from vllm.model_executor.kernels.mhc.optimized_wrappers import (
+    mhc_post_hc_head_fused,
+    mhc_post_hc_head_norm_fused,
+    mhc_post_mean_fused,
+)
+
+
+def create_test_inputs(num_tokens, hc_mult, hidden_size, device="cuda", dtype=torch.bfloat16):
+    """Create test inputs for MHC operations."""
+    x = torch.randn(num_tokens, hidden_size, device=device, dtype=dtype)
+    residual = torch.randn(num_tokens, hc_mult, hidden_size, device=device, dtype=dtype)
+    post_mix = torch.randn(num_tokens, hc_mult, device=device, dtype=torch.float32)
+    comb_mix = torch.randn(num_tokens, hc_mult, hc_mult, device=device, dtype=torch.float32)
+
+    # Normalize mixing weights to avoid numerical overflow
+    post_mix = torch.sigmoid(post_mix) * 2.0
+    comb_mix = torch.softmax(comb_mix, dim=-1)
+
+    return x, residual, post_mix, comb_mix
+
+
+def create_hc_head_params(hc_mult, hidden_size, device="cuda"):
+    """Create HC head parameters."""
+    hc_dim = hc_mult * hidden_size
+    fn = torch.randn(hc_mult, hc_dim, device=device, dtype=torch.float32) * 0.01
+    scale = torch.ones(1, device=device, dtype=torch.float32)
+    base = torch.randn(hc_mult, device=device, dtype=torch.float32) * 0.1
+    return fn, scale, base
+
+
+@pytest.mark.parametrize("num_tokens", [1, 8, 64, 256])
+@pytest.mark.parametrize("hc_mult", [4])
+@pytest.mark.parametrize("hidden_size", [512, 1024])
+def test_mhc_post_hc_head_norm_fused_mtp_stash(num_tokens, hc_mult, hidden_size):
+    """The MTP variant must stash the pre-hc_head residual unchanged.
+
+    The 3-way fused kernel with MTP runs when ``mtp_buffer`` is provided. The
+    buffer contract from the model is: ``mtp_buffer[:num_tokens]`` holds
+    ``mhc_post(...).flatten(1)`` in the global token order. This test feeds a
+    buffer that is pre-filled with a sentinel and checks the kernel overwrites
+    the leading rows with the exact pre-hc_head residual, leaving the tail
+    untouched.
+    """
+    device = "cuda"
+    torch.manual_seed(42)
+
+    x, residual, post_mix, comb_mix = create_test_inputs(
+        num_tokens, hc_mult, hidden_size, device
+    )
+    fn, scale, base = create_hc_head_params(hc_mult, hidden_size, device)
+    norm_weight = torch.ones(hidden_size, device=device, dtype=torch.bfloat16)
+    norm_eps = 1e-5
+
+    # Reference: the unfused chain produces the stashed residual.
+    residual_out = mhc_post_tilelang(
+        x, residual, post_mix.unsqueeze(-1), comb_mix
+    )
+    expected_stash = residual_out.flatten(1)
+
+    # Pre-fill the buffer so a missed write is detectable.
+    buffer = torch.full(
+        (2 * num_tokens, hc_mult * hidden_size),
+        7.0,
+        device=device,
+        dtype=torch.bfloat16,
+    )
+    output_fused = mhc_post_hc_head_norm_fused(
+        x,
+        residual,
+        post_mix.unsqueeze(-1),
+        comb_mix,
+        fn,
+        scale,
+        base,
+        norm_weight,
+        1e-6,
+        1e-3,
+        norm_eps,
+        mtp_buffer=buffer,
+    )
+
+    # Stash must match the unfused pre-hc_head, and only the first rows.
+    torch.testing.assert_close(
+        buffer[:num_tokens],
+        expected_stash,
+        rtol=1e-2,
+        atol=1e-2,
+        msg="MTP stash mismatch for {num_tokens=}, {hidden_size=}",
+    )
+    assert torch.all(buffer[num_tokens:] == 7.0), "MTP stash overflowed the buffer"
+
+    # The merged output must also match the unfused hc_head + RMSNorm chain.
+    hc_out = hc_head_fused_kernel_tilelang(
+        residual_out, fn, scale, base, 1e-6, 1e-3
+    )
+    variance = hc_out.float().pow(2).mean(-1, keepdim=True)
+    expected_out = (
+        hc_out * torch.rsqrt(variance + norm_eps) * norm_weight
+    ).bfloat16()
+    torch.testing.assert_close(
+        output_fused,
+        expected_out,
+        rtol=1e-2,
+        atol=1e-2,
+        msg="Fused norm output mismatch with MTP stash for {num_tokens=}",
+    )
+
+
+@pytest.mark.parametrize("num_tokens", [1, 8, 64, 256])
+@pytest.mark.parametrize("hc_mult", [4])
+@pytest.mark.parametrize("hidden_size", [512, 1024])
+def test_mhc_post_hc_head_norm_fused_cmp_mtp_vanilla(num_tokens, hc_mult, hidden_size):
+    """The MTP and non-MTP variants must produce identical outputs.
+
+    Besides exercising both kernel paths, this protects the model's fused
+    branch against accidental divergence between the two variants.
+    """
+    device = "cuda"
+    torch.manual_seed(42)
+
+    x, residual, post_mix, comb_mix = create_test_inputs(
+        num_tokens, hc_mult, hidden_size, device
+    )
+    fn, scale, base = create_hc_head_params(hc_mult, hidden_size, device)
+    norm_weight = torch.ones(hidden_size, device=device, dtype=torch.bfloat16)
+
+    output_vanilla = mhc_post_hc_head_norm_fused(
+        x,
+        residual,
+        post_mix.unsqueeze(-1),
+        comb_mix,
+        fn,
+        scale,
+        base,
+        norm_weight,
+        1e-6,
+        1e-3,
+        1e-5,
+    )
+    buffer = torch.empty(
+        num_tokens, hc_mult * hidden_size, device=device, dtype=torch.bfloat16
+    )
+    output_mtp = mhc_post_hc_head_norm_fused(
+        x,
+        residual,
+        post_mix.unsqueeze(-1),
+        comb_mix,
+        fn,
+        scale,
+        base,
+        norm_weight,
+        1e-6,
+        1e-3,
+        1e-5,
+        mtp_buffer=buffer,
+    )
+    torch.testing.assert_close(
+        output_mtp,
+        output_vanilla,
+        rtol=1e-2,
+        atol=1e-2,
+        msg="MTP and vanilla fused variants diverge for {num_tokens=}",
+    )
+
+
+@pytest.mark.parametrize("num_tokens", [1, 8, 64, 256])
+@pytest.mark.parametrize("hc_mult", [4])
+@pytest.mark.parametrize("hidden_size", [512, 1024, 2048])
+def test_mhc_post_hc_head_fused_correctness(num_tokens, hc_mult, hidden_size):
+    """Test that fused mhc_post + hc_head matches separate calls."""
+    device = "cuda"
+    torch.manual_seed(42)
+
+    # Create inputs
+    x, residual, post_mix, comb_mix = create_test_inputs(num_tokens, hc_mult, hidden_size, device)
+    fn, scale, base = create_hc_head_params(hc_mult, hidden_size, device)
+
+    rms_eps = 1e-6
+    hc_eps = 1e-3
+
+    # Original separate operations
+    residual_out_orig = mhc_post_tilelang(
+        x, residual, post_mix.unsqueeze(-1), comb_mix
+    )
+    output_orig = hc_head_fused_kernel_tilelang(
+        residual_out_orig, fn, scale, base, rms_eps, hc_eps
+    )
+
+    # Optimized fused operation
+    output_fused = mhc_post_hc_head_fused(
+        x, residual, post_mix.unsqueeze(-1), comb_mix,
+        fn, scale, base, rms_eps, hc_eps
+    )
+
+    # Check results match
+    torch.testing.assert_close(
+        output_fused, output_orig,
+        rtol=1e-2, atol=1e-2,
+        msg=f"Fused kernel output mismatch for {num_tokens=}, {hc_mult=}, {hidden_size=}"
+    )
+
+
+@pytest.mark.parametrize("num_tokens", [1, 8, 64])
+@pytest.mark.parametrize("hc_mult", [4])
+@pytest.mark.parametrize("hidden_size", [512, 1024])
+def test_mhc_post_hc_head_norm_fused_correctness(num_tokens, hc_mult, hidden_size):
+    """Test that fused mhc_post + hc_head + norm matches separate calls."""
+    device = "cuda"
+    torch.manual_seed(42)
+
+    # Create inputs
+    x, residual, post_mix, comb_mix = create_test_inputs(num_tokens, hc_mult, hidden_size, device)
+    fn, scale, base = create_hc_head_params(hc_mult, hidden_size, device)
+    norm_weight = torch.ones(hidden_size, device=device, dtype=torch.bfloat16)
+
+    rms_eps = 1e-6
+    hc_eps = 1e-3
+    norm_eps = 1e-5
+
+    # Original separate operations
+    residual_out_orig = mhc_post_tilelang(
+        x, residual, post_mix.unsqueeze(-1), comb_mix
+    )
+    hc_out_orig = hc_head_fused_kernel_tilelang(
+        residual_out_orig, fn, scale, base, rms_eps, hc_eps
+    )
+    # RMSNorm
+    variance = hc_out_orig.float().pow(2).mean(-1, keepdim=True)
+    output_orig = (hc_out_orig * torch.rsqrt(variance + norm_eps) * norm_weight).bfloat16()
+
+    # Optimized fused operation
+    output_fused = mhc_post_hc_head_norm_fused(
+        x, residual, post_mix.unsqueeze(-1), comb_mix,
+        fn, scale, base, norm_weight, rms_eps, hc_eps, norm_eps
+    )
+
+    # Check results match
+    torch.testing.assert_close(
+        output_fused, output_orig,
+        rtol=1e-2, atol=1e-2,
+        msg=f"Fused kernel with norm output mismatch for {num_tokens=}, {hc_mult=}, {hidden_size=}"
+    )
+
+
+@pytest.mark.parametrize("num_tokens", [1, 8, 64, 256])
+@pytest.mark.parametrize("hc_mult", [4])
+@pytest.mark.parametrize("hidden_size", [512, 1024])
+def test_mhc_post_mean_fused_correctness(num_tokens, hc_mult, hidden_size):
+    """Test that fused mhc_post + mean matches separate calls."""
+    device = "cuda"
+    torch.manual_seed(42)
+
+    # Create inputs
+    x, residual, post_mix, comb_mix = create_test_inputs(num_tokens, hc_mult, hidden_size, device)
+
+    # Original separate operations
+    residual_out_orig = mhc_post_tilelang(
+        x, residual, post_mix.unsqueeze(-1), comb_mix
+    )
+    mean_out_orig = residual_out_orig.mean(dim=1)
+
+    # Optimized fused operation
+    residual_out_fused, mean_out_fused = mhc_post_mean_fused(
+        x, residual, post_mix.unsqueeze(-1), comb_mix
+    )
+
+    # Check both outputs match
+    torch.testing.assert_close(
+        residual_out_fused, residual_out_orig,
+        rtol=1e-3, atol=1e-3,
+        msg=f"Fused kernel residual output mismatch for {num_tokens=}, {hc_mult=}, {hidden_size=}"
+    )
+
+    torch.testing.assert_close(
+        mean_out_fused, mean_out_orig,
+        rtol=2e-2, atol=2e-2,
+        msg=f"Fused kernel mean output mismatch for {num_tokens=}, {hc_mult=}, {hidden_size=}"
+    )
+
+
+if __name__ == "__main__":
+    # Quick smoke test
+    print("Running MHC optimized fusion tests...")
+    test_mhc_post_hc_head_fused_correctness(64, 4, 1024)
+    print("✓ mhc_post_hc_head_fused correctness test passed")
+
+    test_mhc_post_hc_head_norm_fused_correctness(64, 4, 1024)
+    print("✓ mhc_post_hc_head_norm_fused correctness test passed")
+
+    test_mhc_post_mean_fused_correctness(64, 4, 1024)
+    print("✓ mhc_post_mean_fused correctness test passed")
+
+    print("\nAll tests passed!")

--- a/vllm/model_executor/kernels/mhc/__init__.py
+++ b/vllm/model_executor/kernels/mhc/__init__.py
@@ -1,9 +1,48 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import logging
+import os
+
 from .aiter import *
 from .tilelang import *
 from .torch import *
 from .triton import *
+
+logger = logging.getLogger(__name__)
+
+# Environment variable to control optimized fusions
+# VLLM_MHC_FUSED_KERNELS=1 (default): Enable optimized fusions
+# VLLM_MHC_FUSED_KERNELS=0: Disable optimized fusions, use original implementation
+_MHC_FUSED_KERNELS_ENABLED = os.environ.get("VLLM_MHC_FUSED_KERNELS", "1") == "1"
+
+# Import optimized fused kernels if TileLang is available and enabled
+if _MHC_FUSED_KERNELS_ENABLED:
+    try:
+        from .optimized_wrappers import (
+            mhc_post_hc_head_fused,
+            mhc_post_hc_head_norm_fused,
+            mhc_post_mean_fused,
+        )
+
+        _HAS_OPTIMIZED_FUSIONS = True
+        logger.info("MHC optimized fused kernels enabled (VLLM_MHC_FUSED_KERNELS=1)")
+    except ImportError as e:
+        _HAS_OPTIMIZED_FUSIONS = False
+        mhc_post_hc_head_fused = None  # type: ignore
+        mhc_post_hc_head_norm_fused = None  # type: ignore
+        mhc_post_mean_fused = None  # type: ignore
+        logger.info(
+            "MHC optimized fused kernels not available (import failed: %s)", str(e)
+        )
+else:
+    _HAS_OPTIMIZED_FUSIONS = False
+    mhc_post_hc_head_fused = None  # type: ignore
+    mhc_post_hc_head_norm_fused = None  # type: ignore
+    mhc_post_mean_fused = None  # type: ignore
+    logger.info(
+        "MHC optimized fused kernels disabled by environment variable "
+        "(VLLM_MHC_FUSED_KERNELS=0)"
+    )
 
 __all__ = [
     "mhc_pre_cuda",
@@ -26,4 +65,9 @@ __all__ = [
     "mhc_post_triton",
     "mhc_fused_post_pre_triton",
     "hc_head_fused_triton",
+    "mhc_post_hc_head_fused",
+    "mhc_post_hc_head_norm_fused",
+    "mhc_post_mean_fused",
+    "_HAS_OPTIMIZED_FUSIONS",
+    "_MHC_FUSED_KERNELS_ENABLED",
 ]

--- a/vllm/model_executor/kernels/mhc/__init__.py
+++ b/vllm/model_executor/kernels/mhc/__init__.py
@@ -1,9 +1,47 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import logging
+import os
+
 from .aiter import *
 from .tilelang import *
 from .torch import *
 from .triton import *
+
+logger = logging.getLogger(__name__)
+
+# Environment variable to control optimized fusions.
+# VLLM_MHC_FUSED_KERNELS=1 (default): enable the optimized fused kernels when
+#   TileLang is available.
+# VLLM_MHC_FUSED_KERNELS=0: disable, and keep using the original separate
+#   kernel calls.
+_MHC_FUSED_KERNELS_ENABLED = os.environ.get("VLLM_MHC_FUSED_KERNELS", "1") == "1"
+
+if _MHC_FUSED_KERNELS_ENABLED:
+    try:
+        from .optimized_wrappers import (
+            mhc_post_hc_head_fused,
+            mhc_post_hc_head_norm_fused,
+            mhc_post_mean_fused,
+        )
+
+        _HAS_OPTIMIZED_FUSIONS = True
+        logger.info("MHC optimized fused kernels enabled (VLLM_MHC_FUSED_KERNELS=1)")
+    except ImportError as e:
+        _HAS_OPTIMIZED_FUSIONS = False
+        mhc_post_hc_head_fused = None  # type: ignore[assignment]
+        mhc_post_hc_head_norm_fused = None  # type: ignore[assignment]
+        mhc_post_mean_fused = None  # type: ignore[assignment]
+        logger.info("MHC optimized fused kernels unavailable (import failed: %s)",
+                    str(e))
+else:
+    _HAS_OPTIMIZED_FUSIONS = False
+    mhc_post_hc_head_fused = None  # type: ignore[assignment]
+    mhc_post_hc_head_norm_fused = None  # type: ignore[assignment]
+    mhc_post_mean_fused = None  # type: ignore[assignment]
+    logger.info(
+        "MHC optimized fused kernels disabled by environment variable "
+        "(VLLM_MHC_FUSED_KERNELS=0)")
 
 __all__ = [
     "mhc_pre_cuda",
@@ -26,4 +64,9 @@ __all__ = [
     "mhc_post_triton",
     "mhc_fused_post_pre_triton",
     "hc_head_fused_triton",
+    "mhc_post_hc_head_fused",
+    "mhc_post_hc_head_norm_fused",
+    "mhc_post_mean_fused",
+    "_HAS_OPTIMIZED_FUSIONS",
+    "_MHC_FUSED_KERNELS_ENABLED",
 ]

--- a/vllm/model_executor/kernels/mhc/optimized_fusions.py
+++ b/vllm/model_executor/kernels/mhc/optimized_fusions.py
@@ -1,0 +1,612 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Optimized fused MHC kernels to reduce HBM traffic.
+
+This module contains additional kernel fusions beyond the existing
+mhc_fused_post_pre_tilelang to further optimize memory-bound operations.
+
+Optimizations implemented:
+1. mhc_post_hc_head_fused: Fuses MHC post + HC head (final layer)
+2. mhc_post_hc_head_norm_fused: Adds RMSNorm fusion on top of #1
+3. mhc_post_mean_fused: Fuses MHC post + mean reduction (aux layers)
+"""
+
+import math
+from typing import Any
+
+import torch
+
+from vllm.platforms import current_platform
+from vllm.utils.import_utils import has_tilelang
+
+if not has_tilelang():
+    raise ImportError(
+        "tilelang is required for optimized mhc fusions but is not installed. "
+        "Install it with `pip install tilelang`."
+    )
+
+import tilelang
+import tilelang.language as T
+
+ENABLE_PDL = current_platform.is_arch_support_pdl() and current_platform.is_cuda()
+
+pass_configs: dict[tilelang.PassConfigKey, Any] = {
+    tilelang.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True,
+    tilelang.PassConfigKey.TL_DISABLE_TMA_LOWER: True,
+}
+
+if current_platform.is_cuda():
+    pass_configs[tilelang.PassConfigKey.TL_PTXAS_REGISTER_USAGE_LEVEL] = 10
+
+
+@tilelang.jit(pass_configs=pass_configs)
+def mhc_post_hc_head_fused_tilelang(
+    comb_mix,
+    residual_in,
+    post_mix,
+    x_in,
+    fn,
+    hc_scale,
+    hc_base,
+    out,
+    hc: int,
+    hidden: int,
+    rms_eps: float,
+    hc_eps: float,
+    n_thr: int = 128,
+    h_blk: int = 1024,
+):
+    """Fused MHC post + HC head kernel.
+
+    This kernel fuses two operations that were previously separate:
+    1. MHC post: residual_cur = post_mix * x + comb_mix @ residual
+    2. HC head: compress hc_mult residual channels to single output
+
+    By keeping the intermediate residual_cur in shared memory instead of
+    writing to HBM, we eliminate one full HBM round-trip.
+
+    Memory traffic comparison:
+    - Original: Write residual_cur (HBM) + Read residual_cur (HBM) = 2x
+    - Fused: Keep in shared memory = 0x (only final output written)
+
+    Args:
+        comb_mix: [num_tokens, hc, hc] combination mixing weights
+        residual_in: [num_tokens, hc, hidden] input residual streams
+        post_mix: [num_tokens, hc] post layer mixing weights
+        x_in: [num_tokens, hidden] layer output
+        fn: [hc, hc * hidden] HC head projection matrix
+        hc_scale: [1] HC head scale factor
+        hc_base: [hc] HC head bias
+        out: [num_tokens, hidden] output tensor
+        hc: number of HC channels (typically 4)
+        hidden: hidden dimension size
+        rms_eps: epsilon for RMS normalization
+        hc_eps: epsilon for HC head gates
+    """
+    num_tokens = T.dynamic("num_tokens")
+    hc_dim = hc * hidden
+    h_block = math.gcd(h_blk, hidden)
+    n_h = hidden // h_block
+
+    comb_mix: T.Tensor[[num_tokens, hc, hc], T.float32]  # type: ignore[no-redef, valid-type]
+    residual_in: T.Tensor[[num_tokens, hc, hidden], T.bfloat16]  # type: ignore[no-redef, valid-type]
+    post_mix: T.Tensor[[num_tokens, hc], T.float32]  # type: ignore[no-redef, valid-type]
+    x_in: T.Tensor[[num_tokens, hidden], T.bfloat16]  # type: ignore[no-redef, valid-type]
+    fn: T.Tensor[[hc, hc_dim], T.float32]  # type: ignore[no-redef, valid-type]
+    hc_scale: T.Tensor[[1], T.float32]  # type: ignore[no-redef, valid-type]
+    hc_base: T.Tensor[[hc], T.float32]  # type: ignore[no-redef, valid-type]
+    out: T.Tensor[[num_tokens, hidden], T.bfloat16]  # type: ignore[no-redef, valid-type]
+
+    with T.Kernel(num_tokens, threads=n_thr) as i_n:
+        if ENABLE_PDL:
+            T.pdl_sync()
+
+        # Load mixing weights into registers/shared memory
+        a_local = T.alloc_fragment((hc, hc), T.float32)
+        c_local = T.alloc_fragment(hc, T.float32)
+        T.copy(comb_mix[i_n, 0, 0], a_local)
+        T.copy(post_mix[i_n, 0], c_local)
+
+        # =====================================================================
+        # FUSED PASS 1: Compute MHC post AND accumulate HC head statistics
+        # =====================================================================
+        # Instead of writing residual_cur to HBM, we:
+        # 1. Store it in shared memory
+        # 2. Simultaneously accumulate sqrsum and mixes for HC head
+
+        residual_cur_shared = T.alloc_shared((hc, hidden), T.bfloat16)
+        sqrsum_r = T.alloc_reducer((1,), T.float32, replication="all")
+        mixes_r = T.alloc_reducer((hc,), T.float32, replication="all")
+        T.fill(sqrsum_r, 0.0)
+        T.fill(mixes_r, 0.0)
+
+        for i0_h in T.serial(n_h):
+            # Load inputs for this block
+            b_shared = T.alloc_shared((hc, h_block), T.bfloat16)
+            d_shared = T.alloc_shared(h_block, T.bfloat16)
+            T.copy(residual_in[i_n, 0, i0_h * h_block], b_shared)
+            T.copy(x_in[i_n, i0_h * h_block], d_shared)
+
+            b_local = T.alloc_fragment((hc, h_block), T.float32)
+            d_local = T.alloc_fragment(h_block, T.float32)
+            T.copy(b_shared, b_local)
+            T.copy(d_shared, d_local)
+
+            # Compute MHC post for this block
+            x_local = T.alloc_fragment((hc, h_block), T.float32)
+            for i_hco, i1_h in T.Parallel(hc, h_block):
+                x_local[i_hco, i1_h] = c_local[i_hco] * d_local[i1_h]
+                for i_hci in T.vectorized(hc):
+                    x_local[i_hco, i1_h] += a_local[i_hci, i_hco] * b_local[i_hci, i1_h]
+
+            # Store to shared memory (not HBM!)
+            for i_hco, i1_h in T.Parallel(hc, h_block):
+                residual_cur_shared[i_hco, i0_h * h_block + i1_h] = T.bfloat16(
+                    x_local[i_hco, i1_h]
+                )
+
+            # Simultaneously accumulate HC head statistics
+            for m_c in T.serial(hc):
+                for k in T.Parallel(h_block):
+                    val = x_local[m_c, k]
+                    sqrsum_r[0] += val * val
+
+                for m_m in T.unroll(hc):
+                    fn_local = T.alloc_fragment(h_block, T.float32)
+                    T.copy(fn[m_m, m_c * hidden + i0_h * h_block], fn_local)
+                    for k in T.Parallel(h_block):
+                        mixes_r[m_m] += x_local[m_c, k] * fn_local[k]
+
+        T.finalize_reducer(sqrsum_r)
+        T.finalize_reducer(mixes_r)
+
+        # =====================================================================
+        # PASS 2: Compute HC head output from shared memory
+        # =====================================================================
+        pre_mix_shared = T.alloc_shared(hc, T.float32)
+        rsqrt_val = T.alloc_fragment(1, T.float32)
+        rsqrt_val[0] = T.rsqrt(sqrsum_r[0] / hc_dim + rms_eps)
+
+        for m in T.Parallel(hc):
+            pre_mix_shared[m] = (
+                T.sigmoid(mixes_r[m] * rsqrt_val[0] * hc_scale[0] + hc_base[m]) + hc_eps
+            )
+
+        # Apply weighted sum to produce final output
+        for i0_h in T.Pipelined(n_h, num_stages=2):
+            xs = T.alloc_shared((hc, h_block), T.bfloat16)
+            xl = T.alloc_fragment((hc, h_block), T.float32)
+
+            # Load from shared memory (fast!) instead of HBM
+            for i_hc, i1_h in T.Parallel(hc, h_block):
+                xs[i_hc, i1_h] = residual_cur_shared[i_hc, i0_h * h_block + i1_h]
+            T.copy(xs, xl)
+
+            ol = T.alloc_fragment(h_block, T.float32)
+            T.clear(ol)
+            for i_hc in T.serial(hc):
+                pre = pre_mix_shared[i_hc]
+                for i1_h in T.Parallel(h_block):
+                    ol[i1_h] += pre * xl[i_hc, i1_h]
+
+            T.copy(ol, out[i_n, i0_h * h_block], disable_tma=True)
+
+        if ENABLE_PDL:
+            T.pdl_trigger()
+
+
+@tilelang.jit(pass_configs=pass_configs)
+def mhc_post_hc_head_norm_fused_tilelang(
+    comb_mix,
+    residual_in,
+    post_mix,
+    x_in,
+    fn,
+    hc_scale,
+    hc_base,
+    norm_weight,
+    norm_eps,
+    out,
+    hc: int,
+    hidden: int,
+    rms_eps: float,
+    hc_eps: float,
+    n_thr: int = 128,
+    h_blk: int = 1024,
+):
+    """Fused MHC post + HC head + RMSNorm kernel.
+
+    Three-way fusion: MHC post → HC head → RMSNorm
+
+    Memory traffic comparison:
+    - Original: 3 writes + 2 reads = 5 HBM operations
+    - Fused: 1 write = 1 HBM operation (80% reduction!)
+
+    Args:
+        Same as mhc_post_hc_head_fused_tilelang, plus:
+        norm_weight: [hidden] RMSNorm weight
+        norm_eps: RMSNorm epsilon
+    """
+    num_tokens = T.dynamic("num_tokens")
+    hc_dim = hc * hidden
+    h_block = math.gcd(h_blk, hidden)
+    n_h = hidden // h_block
+
+    comb_mix: T.Tensor[[num_tokens, hc, hc], T.float32]  # type: ignore[no-redef, valid-type]
+    residual_in: T.Tensor[[num_tokens, hc, hidden], T.bfloat16]  # type: ignore[no-redef, valid-type]
+    post_mix: T.Tensor[[num_tokens, hc], T.float32]  # type: ignore[no-redef, valid-type]
+    x_in: T.Tensor[[num_tokens, hidden], T.bfloat16]  # type: ignore[no-redef, valid-type]
+    fn: T.Tensor[[hc, hc_dim], T.float32]  # type: ignore[no-redef, valid-type]
+    hc_scale: T.Tensor[[1], T.float32]  # type: ignore[no-redef, valid-type]
+    hc_base: T.Tensor[[hc], T.float32]  # type: ignore[no-redef, valid-type]
+    norm_weight: T.Tensor[[hidden], T.bfloat16]  # type: ignore[no-redef, valid-type]
+    out: T.Tensor[[num_tokens, hidden], T.bfloat16]  # type: ignore[no-redef, valid-type]
+
+    with T.Kernel(num_tokens, threads=n_thr) as i_n:
+        if ENABLE_PDL:
+            T.pdl_sync()
+
+        a_local = T.alloc_fragment((hc, hc), T.float32)
+        c_local = T.alloc_fragment(hc, T.float32)
+        T.copy(comb_mix[i_n, 0, 0], a_local)
+        T.copy(post_mix[i_n, 0], c_local)
+
+        residual_cur_shared = T.alloc_shared((hc, hidden), T.bfloat16)
+        sqrsum_r = T.alloc_reducer((1,), T.float32, replication="all")
+        mixes_r = T.alloc_reducer((hc,), T.float32, replication="all")
+        T.fill(sqrsum_r, 0.0)
+        T.fill(mixes_r, 0.0)
+
+        # Pass 1: MHC post + accumulate HC head stats (same as before)
+        for i0_h in T.serial(n_h):
+            b_shared = T.alloc_shared((hc, h_block), T.bfloat16)
+            d_shared = T.alloc_shared(h_block, T.bfloat16)
+            T.copy(residual_in[i_n, 0, i0_h * h_block], b_shared)
+            T.copy(x_in[i_n, i0_h * h_block], d_shared)
+
+            b_local = T.alloc_fragment((hc, h_block), T.float32)
+            d_local = T.alloc_fragment(h_block, T.float32)
+            T.copy(b_shared, b_local)
+            T.copy(d_shared, d_local)
+
+            x_local = T.alloc_fragment((hc, h_block), T.float32)
+            for i_hco, i1_h in T.Parallel(hc, h_block):
+                x_local[i_hco, i1_h] = c_local[i_hco] * d_local[i1_h]
+                for i_hci in T.vectorized(hc):
+                    x_local[i_hco, i1_h] += a_local[i_hci, i_hco] * b_local[i_hci, i1_h]
+
+            for i_hco, i1_h in T.Parallel(hc, h_block):
+                residual_cur_shared[i_hco, i0_h * h_block + i1_h] = T.bfloat16(
+                    x_local[i_hco, i1_h]
+                )
+
+            for m_c in T.serial(hc):
+                for k in T.Parallel(h_block):
+                    val = x_local[m_c, k]
+                    sqrsum_r[0] += val * val
+
+                for m_m in T.unroll(hc):
+                    fn_local = T.alloc_fragment(h_block, T.float32)
+                    T.copy(fn[m_m, m_c * hidden + i0_h * h_block], fn_local)
+                    for k in T.Parallel(h_block):
+                        mixes_r[m_m] += x_local[m_c, k] * fn_local[k]
+
+        T.finalize_reducer(sqrsum_r)
+        T.finalize_reducer(mixes_r)
+
+        # Pass 2: HC head to produce intermediate output in shared memory
+        hc_head_output_shared = T.alloc_shared(hidden, T.bfloat16)
+        pre_mix_shared = T.alloc_shared(hc, T.float32)
+        rsqrt_val = T.alloc_fragment(1, T.float32)
+        rsqrt_val[0] = T.rsqrt(sqrsum_r[0] / hc_dim + rms_eps)
+
+        for m in T.Parallel(hc):
+            pre_mix_shared[m] = (
+                T.sigmoid(mixes_r[m] * rsqrt_val[0] * hc_scale[0] + hc_base[m]) + hc_eps
+            )
+
+        # Accumulate RMSNorm variance while computing HC head output
+        # Use reducer to avoid data race
+        norm_sqrsum_r = T.alloc_reducer((1,), T.float32, replication="all")
+        T.fill(norm_sqrsum_r, 0.0)
+
+        for i0_h in T.serial(n_h):
+            xs = T.alloc_shared((hc, h_block), T.bfloat16)
+            xl = T.alloc_fragment((hc, h_block), T.float32)
+
+            for i_hc, i1_h in T.Parallel(hc, h_block):
+                xs[i_hc, i1_h] = residual_cur_shared[i_hc, i0_h * h_block + i1_h]
+            T.copy(xs, xl)
+
+            ol = T.alloc_fragment(h_block, T.float32)
+            T.clear(ol)
+            for i_hc in T.serial(hc):
+                pre = pre_mix_shared[i_hc]
+                for i1_h in T.Parallel(h_block):
+                    ol[i1_h] += pre * xl[i_hc, i1_h]
+
+            # Store to shared memory and accumulate squared sum
+            for i1_h in T.Parallel(h_block):
+                hc_head_output_shared[i0_h * h_block + i1_h] = T.bfloat16(ol[i1_h])
+                norm_sqrsum_r[0] += ol[i1_h] * ol[i1_h]
+
+        T.finalize_reducer(norm_sqrsum_r)
+
+        # Pass 3: Apply RMSNorm and write final output
+        rsqrt_norm = T.alloc_fragment(1, T.float32)
+        rsqrt_norm[0] = T.rsqrt(norm_sqrsum_r[0] / hidden + norm_eps)
+
+        for i0_h in T.Pipelined(n_h, num_stages=2):
+            w_shared = T.alloc_shared(h_block, T.bfloat16)
+            w_local = T.alloc_fragment(h_block, T.float32)
+            T.copy(norm_weight[i0_h * h_block], w_shared)
+            T.copy(w_shared, w_local)
+
+            ol = T.alloc_fragment(h_block, T.float32)
+            for i1_h in T.Parallel(h_block):
+                ol[i1_h] = (
+                    hc_head_output_shared[i0_h * h_block + i1_h]
+                    * rsqrt_norm[0]
+                    * w_local[i1_h]
+                )
+
+            T.copy(ol, out[i_n, i0_h * h_block], disable_tma=True)
+
+        if ENABLE_PDL:
+            T.pdl_trigger()
+
+
+@tilelang.jit(pass_configs=pass_configs)
+def mhc_post_hc_head_norm_fused_tilelang_mtp(
+    comb_mix,
+    residual_in,
+    post_mix,
+    x_in,
+    fn,
+    hc_scale,
+    hc_base,
+    norm_weight,
+    norm_eps,
+    out,
+    mtp_output,
+    hc: int,
+    hidden: int,
+    rms_eps: float,
+    hc_eps: float,
+    n_thr: int = 128,
+    h_blk: int = 1024,
+):
+    """Fused MHC post + HC head + RMSNorm kernel with MTP residual stash.
+
+    Same as mhc_post_hc_head_norm_fused_tilelang, but additionally writes
+    the pre-hc_head residual (output of MHC post) to mtp_output for the
+    MTP draft model.
+
+    Memory traffic comparison vs original (separate ops):
+    - Original: 3 writes + 2 reads = 5 HBM operations
+    - Fused + MTP: 2 writes (mtp_output + final output) = 2 HBM operations
+    - Still saves 60% HBM traffic compared to the original 5 ops.
+
+    Args:
+        Same as mhc_post_hc_head_norm_fused_tilelang, plus:
+        mtp_output: [num_tokens, hc * hidden] pre-hc_head residual for MTP
+    """
+    num_tokens = T.dynamic("num_tokens")
+    hc_dim = hc * hidden
+    h_block = math.gcd(h_blk, hidden)
+    n_h = hidden // h_block
+
+    comb_mix: T.Tensor[[num_tokens, hc, hc], T.float32]  # type: ignore[no-redef, valid-type]
+    residual_in: T.Tensor[[num_tokens, hc, hidden], T.bfloat16]  # type: ignore[no-redef, valid-type]
+    post_mix: T.Tensor[[num_tokens, hc], T.float32]  # type: ignore[no-redef, valid-type]
+    x_in: T.Tensor[[num_tokens, hidden], T.bfloat16]  # type: ignore[no-redef, valid-type]
+    fn: T.Tensor[[hc, hc_dim], T.float32]  # type: ignore[no-redef, valid-type]
+    hc_scale: T.Tensor[[1], T.float32]  # type: ignore[no-redef, valid-type]
+    hc_base: T.Tensor[[hc], T.float32]  # type: ignore[no-redef, valid-type]
+    norm_weight: T.Tensor[[hidden], T.bfloat16]  # type: ignore[no-redef, valid-type]
+    out: T.Tensor[[num_tokens, hidden], T.bfloat16]  # type: ignore[no-redef, valid-type]
+    mtp_output: T.Tensor[[num_tokens, hc_dim], T.bfloat16]  # type: ignore[no-redef, valid-type]
+
+    with T.Kernel(num_tokens, threads=n_thr) as i_n:
+        if ENABLE_PDL:
+            T.pdl_sync()
+
+        a_local = T.alloc_fragment((hc, hc), T.float32)
+        c_local = T.alloc_fragment(hc, T.float32)
+        T.copy(comb_mix[i_n, 0, 0], a_local)
+        T.copy(post_mix[i_n, 0], c_local)
+
+        residual_cur_shared = T.alloc_shared((hc, hidden), T.bfloat16)
+        sqrsum_r = T.alloc_reducer((1,), T.float32, replication="all")
+        mixes_r = T.alloc_reducer((hc,), T.float32, replication="all")
+        T.fill(sqrsum_r, 0.0)
+        T.fill(mixes_r, 0.0)
+
+        # Pass 1: MHC post + accumulate HC head stats
+        for i0_h in T.serial(n_h):
+            b_shared = T.alloc_shared((hc, h_block), T.bfloat16)
+            d_shared = T.alloc_shared(h_block, T.bfloat16)
+            T.copy(residual_in[i_n, 0, i0_h * h_block], b_shared)
+            T.copy(x_in[i_n, i0_h * h_block], d_shared)
+
+            b_local = T.alloc_fragment((hc, h_block), T.float32)
+            d_local = T.alloc_fragment(h_block, T.float32)
+            T.copy(b_shared, b_local)
+            T.copy(d_shared, d_local)
+
+            x_local = T.alloc_fragment((hc, h_block), T.float32)
+            for i_hco, i1_h in T.Parallel(hc, h_block):
+                x_local[i_hco, i1_h] = c_local[i_hco] * d_local[i1_h]
+                for i_hci in T.vectorized(hc):
+                    x_local[i_hco, i1_h] += a_local[i_hci, i_hco] * b_local[i_hci, i1_h]
+
+            for i_hco, i1_h in T.Parallel(hc, h_block):
+                residual_cur_shared[i_hco, i0_h * h_block + i1_h] = T.bfloat16(
+                    x_local[i_hco, i1_h]
+                )
+
+            for m_c in T.serial(hc):
+                for k in T.Parallel(h_block):
+                    val = x_local[m_c, k]
+                    sqrsum_r[0] += val * val
+
+                for m_m in T.unroll(hc):
+                    fn_local = T.alloc_fragment(h_block, T.float32)
+                    T.copy(fn[m_m, m_c * hidden + i0_h * h_block], fn_local)
+                    for k in T.Parallel(h_block):
+                        mixes_r[m_m] += x_local[m_c, k] * fn_local[k]
+
+        T.finalize_reducer(sqrsum_r)
+        T.finalize_reducer(mixes_r)
+
+        # Pass 2: HC head to produce intermediate output in shared memory
+        hc_head_output_shared = T.alloc_shared(hidden, T.bfloat16)
+        pre_mix_shared = T.alloc_shared(hc, T.float32)
+        rsqrt_val = T.alloc_fragment(1, T.float32)
+        rsqrt_val[0] = T.rsqrt(sqrsum_r[0] / hc_dim + rms_eps)
+
+        for m in T.Parallel(hc):
+            pre_mix_shared[m] = (
+                T.sigmoid(mixes_r[m] * rsqrt_val[0] * hc_scale[0] + hc_base[m]) + hc_eps
+            )
+
+        norm_sqrsum_r = T.alloc_reducer((1,), T.float32, replication="all")
+        T.fill(norm_sqrsum_r, 0.0)
+
+        for i0_h in T.serial(n_h):
+            xs = T.alloc_shared((hc, h_block), T.bfloat16)
+            xl = T.alloc_fragment((hc, h_block), T.float32)
+
+            for i_hc, i1_h in T.Parallel(hc, h_block):
+                xs[i_hc, i1_h] = residual_cur_shared[i_hc, i0_h * h_block + i1_h]
+            T.copy(xs, xl)
+
+            ol = T.alloc_fragment(h_block, T.float32)
+            T.clear(ol)
+            for i_hc in T.serial(hc):
+                pre = pre_mix_shared[i_hc]
+                for i1_h in T.Parallel(h_block):
+                    ol[i1_h] += pre * xl[i_hc, i1_h]
+
+            for i1_h in T.Parallel(h_block):
+                hc_head_output_shared[i0_h * h_block + i1_h] = T.bfloat16(ol[i1_h])
+                norm_sqrsum_r[0] += ol[i1_h] * ol[i1_h]
+
+        T.finalize_reducer(norm_sqrsum_r)
+
+        # Pass 3: Write pre-hc_head residual to MTP output
+        for i0_h in T.serial(n_h):
+            for i_hco, i1_h in T.Parallel(hc, h_block):
+                mtp_output[i_n, i_hco * hidden + i0_h * h_block + i1_h] = \
+                    residual_cur_shared[i_hco, i0_h * h_block + i1_h]
+
+        # Pass 4: Apply RMSNorm and write final output
+        rsqrt_norm = T.alloc_fragment(1, T.float32)
+        rsqrt_norm[0] = T.rsqrt(norm_sqrsum_r[0] / hidden + norm_eps)
+
+        for i0_h in T.Pipelined(n_h, num_stages=2):
+            w_shared = T.alloc_shared(h_block, T.bfloat16)
+            w_local = T.alloc_fragment(h_block, T.float32)
+            T.copy(norm_weight[i0_h * h_block], w_shared)
+            T.copy(w_shared, w_local)
+
+            ol = T.alloc_fragment(h_block, T.float32)
+            for i1_h in T.Parallel(h_block):
+                ol[i1_h] = (
+                    hc_head_output_shared[i0_h * h_block + i1_h]
+                    * rsqrt_norm[0]
+                    * w_local[i1_h]
+                )
+
+            T.copy(ol, out[i_n, i0_h * h_block], disable_tma=True)
+
+        if ENABLE_PDL:
+            T.pdl_trigger()
+
+
+@tilelang.jit(pass_configs=pass_configs)
+def mhc_post_mean_fused_tilelang(
+    comb_mix,
+    residual_in,
+    post_mix,
+    x_in,
+    out_full,
+    out_mean,
+    hc: int,
+    hidden: int,
+    n_thr: int = 128,
+    h_blk: int = 1024,
+):
+    """Fused MHC post + mean(dim=1) kernel for aux layers.
+
+    In aux_hidden_state layers, mhc_post output is immediately followed by
+    .mean(dim=1). This kernel fuses both operations.
+
+    Memory traffic comparison:
+    - Original: Write full [hc, hidden] + Read full [hc, hidden] = 2x
+    - Fused: Write full [hc, hidden] + Write mean [hidden] = 1.25x (for hc=4)
+
+    Args:
+        comb_mix: [num_tokens, hc, hc]
+        residual_in: [num_tokens, hc, hidden]
+        post_mix: [num_tokens, hc]
+        x_in: [num_tokens, hidden]
+        out_full: [num_tokens, hc, hidden] full MHC post output
+        out_mean: [num_tokens, hidden] mean across hc dimension
+    """
+    num_tokens = T.dynamic("num_tokens")
+    h_block = math.gcd(h_blk, hidden)
+    n_h = hidden // h_block
+
+    comb_mix: T.Tensor[[num_tokens, hc, hc], T.float32]  # type: ignore[no-redef, valid-type]
+    residual_in: T.Tensor[[num_tokens, hc, hidden], T.bfloat16]  # type: ignore[no-redef, valid-type]
+    post_mix: T.Tensor[[num_tokens, hc], T.float32]  # type: ignore[no-redef, valid-type]
+    x_in: T.Tensor[[num_tokens, hidden], T.bfloat16]  # type: ignore[no-redef, valid-type]
+    out_full: T.Tensor[[num_tokens, hc, hidden], T.bfloat16]  # type: ignore[no-redef, valid-type]
+    out_mean: T.Tensor[[num_tokens, hidden], T.bfloat16]  # type: ignore[no-redef, valid-type]
+
+    with T.Kernel(num_tokens, threads=n_thr) as i_n:
+        if ENABLE_PDL:
+            T.pdl_sync()
+
+        a_local = T.alloc_fragment((hc, hc), T.float32)
+        c_local = T.alloc_fragment(hc, T.float32)
+        T.copy(comb_mix[i_n, 0, 0], a_local)
+        T.copy(post_mix[i_n, 0], c_local)
+
+        for i0_h in T.Serial(n_h):
+            b_shared = T.alloc_shared((hc, h_block), T.bfloat16)
+            d_shared = T.alloc_shared(h_block, T.bfloat16)
+            T.copy(residual_in[i_n, 0, i0_h * h_block], b_shared)
+            T.copy(x_in[i_n, i0_h * h_block], d_shared)
+
+            b_local = T.alloc_fragment((hc, h_block), T.float32)
+            d_local = T.alloc_fragment(h_block, T.float32)
+            T.copy(b_shared, b_local)
+            T.copy(d_shared, d_local)
+
+            # Compute MHC post
+            x_local = T.alloc_fragment((hc, h_block), T.float32)
+            for i_hco, i1_h in T.Parallel(hc, h_block):
+                x_local[i_hco, i1_h] = c_local[i_hco] * d_local[i1_h]
+                for i_hci in T.vectorized(hc):
+                    x_local[i_hco, i1_h] += a_local[i_hci, i_hco] * b_local[i_hci, i1_h]
+
+            # Write full output
+            T.copy(x_local, out_full[i_n, 0, i0_h * h_block])
+
+            # Simultaneously compute mean across hc dimension using reducer
+            mean_r = T.alloc_reducer((h_block,), T.float32, replication="none")
+            T.fill(mean_r, 0.0)
+
+            for i_hc in T.serial(hc):
+                for i1_h in T.Parallel(h_block):
+                    mean_r[i1_h] += x_local[i_hc, i1_h]
+
+            T.finalize_reducer(mean_r)
+
+            for i1_h in T.Parallel(h_block):
+                out_mean[i_n, i0_h * h_block + i1_h] = T.bfloat16(mean_r[i1_h] / hc)
+
+        if ENABLE_PDL:
+            T.pdl_trigger()

--- a/vllm/model_executor/kernels/mhc/optimized_wrappers.py
+++ b/vllm/model_executor/kernels/mhc/optimized_wrappers.py
@@ -1,0 +1,330 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Python wrappers for optimized fused MHC kernels.
+
+These wrappers handle tensor shape validation and provide a clean
+interface matching the original separate kernel calls.
+"""
+
+from typing import Optional
+
+import torch
+
+from vllm.utils.torch_utils import direct_register_custom_op
+
+from .optimized_fusions import (
+    mhc_post_hc_head_fused_tilelang,
+    mhc_post_hc_head_norm_fused_tilelang,
+    mhc_post_hc_head_norm_fused_tilelang_mtp,
+    mhc_post_mean_fused_tilelang,
+)
+
+
+def mhc_post_hc_head_fused(
+    x: torch.Tensor,
+    residual: torch.Tensor,
+    post_layer_mix: torch.Tensor,
+    comb_res_mix: torch.Tensor,
+    hc_head_fn: torch.Tensor,
+    hc_head_scale: torch.Tensor,
+    hc_head_base: torch.Tensor,
+    rms_norm_eps: float,
+    hc_eps: float,
+) -> torch.Tensor:
+    """Fused MHC post + HC head operation.
+
+    Replaces the sequence:
+        residual_out = mhc_post_tilelang(x, residual, post_layer_mix, comb_res_mix)
+        output = hc_head_fused_kernel_tilelang(residual_out, hc_head_fn, ...)
+
+    Args:
+        x: [num_tokens, hidden_size] layer output
+        residual: [num_tokens, hc_mult, hidden_size] input residual streams
+        post_layer_mix: [num_tokens, hc_mult] or [num_tokens, hc_mult, 1]
+        comb_res_mix: [num_tokens, hc_mult, hc_mult] combination mixing weights
+        hc_head_fn: [hc_mult, hc_mult * hidden_size] HC head projection matrix
+        hc_head_scale: [1] HC head scale factor
+        hc_head_base: [hc_mult] HC head bias
+        rms_norm_eps: RMS normalization epsilon
+        hc_eps: HC head gate epsilon
+
+    Returns:
+        output: [num_tokens, hidden_size] compressed output
+    """
+    hc_mult = residual.shape[-2]
+    hidden_size = residual.shape[-1]
+    outer_shape = residual.shape[:-2]
+
+    assert x.shape == (*outer_shape, hidden_size)
+    assert post_layer_mix.shape in (
+        (*outer_shape, hc_mult, 1),
+        (*outer_shape, hc_mult),
+    )
+    assert comb_res_mix.shape == (*outer_shape, hc_mult, hc_mult)
+    assert hc_head_fn.shape == (hc_mult, hc_mult * hidden_size)
+    assert hc_head_scale.shape == (1,)
+    assert hc_head_base.shape == (hc_mult,)
+
+    # Flatten batch dimensions
+    residual_flat = residual.view(-1, hc_mult, hidden_size)
+    num_tokens = residual_flat.shape[0]
+    x_flat = x.view(num_tokens, hidden_size)
+    post_layer_mix_flat = post_layer_mix.view(num_tokens, hc_mult)
+    comb_res_mix_flat = comb_res_mix.view(num_tokens, hc_mult, hc_mult)
+
+    # Allocate output
+    output = torch.empty(
+        num_tokens, hidden_size, dtype=torch.bfloat16, device=x.device
+    )
+
+    # Call fused kernel
+    mhc_post_hc_head_fused_tilelang(
+        comb_res_mix_flat,
+        residual_flat,
+        post_layer_mix_flat,
+        x_flat,
+        hc_head_fn,
+        hc_head_scale,
+        hc_head_base,
+        output,
+        hc_mult,
+        hidden_size,
+        rms_norm_eps,
+        hc_eps,
+    )
+
+    return output.view(*outer_shape, hidden_size)
+
+
+def mhc_post_hc_head_norm_fused(
+    x: torch.Tensor,
+    residual: torch.Tensor,
+    post_layer_mix: torch.Tensor,
+    comb_res_mix: torch.Tensor,
+    hc_head_fn: torch.Tensor,
+    hc_head_scale: torch.Tensor,
+    hc_head_base: torch.Tensor,
+    norm_weight: torch.Tensor,
+    rms_norm_eps: float,
+    hc_eps: float,
+    norm_eps: float,
+    mtp_buffer: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    """Fused MHC post + HC head + RMSNorm operation.
+
+    Replaces the sequence:
+        residual_out = mhc_post_tilelang(x, residual, post_layer_mix, comb_res_mix)
+        hc_out = hc_head_fused_kernel_tilelang(residual_out, hc_head_fn, ...)
+        output = rms_norm(hc_out, norm_weight, norm_eps)
+
+    When mtp_buffer is provided, the pre-hc_head residual (MHC post output)
+    is also written to it for the MTP draft model.
+
+    Args:
+        Same as mhc_post_hc_head_fused, plus:
+        norm_weight: [hidden_size] RMSNorm weight
+        norm_eps: RMSNorm epsilon
+        mtp_buffer: optional [num_tokens, hc_mult * hidden_size] buffer for
+            the MTP draft model's pre-hc_head residual stash
+
+    Returns:
+        output: [num_tokens, hidden_size] normalized compressed output
+    """
+    hc_mult = residual.shape[-2]
+    hidden_size = residual.shape[-1]
+    outer_shape = residual.shape[:-2]
+
+    assert x.shape == (*outer_shape, hidden_size)
+    assert norm_weight.shape == (hidden_size,)
+
+    # Ensure norm_weight is contiguous and correct dtype
+    if norm_weight.dtype != torch.bfloat16:
+        norm_weight = norm_weight.to(torch.bfloat16)
+    if not norm_weight.is_contiguous():
+        norm_weight = norm_weight.contiguous()
+
+    # Flatten batch dimensions
+    residual_flat = residual.view(-1, hc_mult, hidden_size)
+    num_tokens = residual_flat.shape[0]
+    x_flat = x.view(num_tokens, hidden_size)
+    post_layer_mix_flat = post_layer_mix.view(num_tokens, hc_mult)
+    comb_res_mix_flat = comb_res_mix.view(num_tokens, hc_mult, hc_mult)
+
+    # Allocate output
+    output = torch.empty(
+        num_tokens, hidden_size, dtype=torch.bfloat16, device=x.device
+    )
+
+    # Choose kernel variant based on MTP buffer availability
+    if mtp_buffer is not None:
+        # Use MTP variant that also writes the pre-hc_head residual
+        mhc_post_hc_head_norm_fused_tilelang_mtp(
+            comb_res_mix_flat,
+            residual_flat,
+            post_layer_mix_flat,
+            x_flat,
+            hc_head_fn,
+            hc_head_scale,
+            hc_head_base,
+            norm_weight,
+            norm_eps,
+            output,
+            mtp_buffer,
+            hc_mult,
+            hidden_size,
+            rms_norm_eps,
+            hc_eps,
+        )
+    else:
+        # Standard variant (no MTP output)
+        mhc_post_hc_head_norm_fused_tilelang(
+            comb_res_mix_flat,
+            residual_flat,
+            post_layer_mix_flat,
+            x_flat,
+            hc_head_fn,
+            hc_head_scale,
+            hc_head_base,
+            norm_weight,
+            norm_eps,
+            output,
+            hc_mult,
+            hidden_size,
+            rms_norm_eps,
+            hc_eps,
+        )
+
+    return output.view(*outer_shape, hidden_size)
+
+
+def mhc_post_mean_fused(
+    x: torch.Tensor,
+    residual: torch.Tensor,
+    post_layer_mix: torch.Tensor,
+    comb_res_mix: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Fused MHC post + mean(dim=1) operation for aux layers.
+
+    Replaces the sequence:
+        residual_out = mhc_post_tilelang(x, residual, post_layer_mix, comb_res_mix)
+        mean_out = residual_out.mean(dim=1)
+
+    Args:
+        x: [num_tokens, hidden_size] layer output
+        residual: [num_tokens, hc_mult, hidden_size] input residual streams
+        post_layer_mix: [num_tokens, hc_mult] or [num_tokens, hc_mult, 1]
+        comb_res_mix: [num_tokens, hc_mult, hc_mult] combination mixing weights
+
+    Returns:
+        residual_out: [num_tokens, hc_mult, hidden_size] full MHC post output
+        mean_out: [num_tokens, hidden_size] mean across hc_mult dimension
+    """
+    hc_mult = residual.shape[-2]
+    hidden_size = residual.shape[-1]
+    outer_shape = residual.shape[:-2]
+
+    assert x.shape == (*outer_shape, hidden_size)
+
+    # Flatten batch dimensions
+    residual_flat = residual.view(-1, hc_mult, hidden_size)
+    num_tokens = residual_flat.shape[0]
+    x_flat = x.view(num_tokens, hidden_size)
+    post_layer_mix_flat = post_layer_mix.view(num_tokens, hc_mult)
+    comb_res_mix_flat = comb_res_mix.view(num_tokens, hc_mult, hc_mult)
+
+    # Allocate outputs
+    residual_out = torch.empty_like(residual_flat)
+    mean_out = torch.empty(
+        num_tokens, hidden_size, dtype=torch.bfloat16, device=x.device
+    )
+
+    # Call fused kernel
+    mhc_post_mean_fused_tilelang(
+        comb_res_mix_flat,
+        residual_flat,
+        post_layer_mix_flat,
+        x_flat,
+        residual_out,
+        mean_out,
+        hc_mult,
+        hidden_size,
+    )
+
+    return (
+        residual_out.view(*outer_shape, hc_mult, hidden_size),
+        mean_out.view(*outer_shape, hidden_size),
+    )
+
+
+def _mhc_post_hc_head_fused_fake(
+    x: torch.Tensor,
+    residual: torch.Tensor,
+    post_layer_mix: torch.Tensor,
+    comb_res_mix: torch.Tensor,
+    hc_head_fn: torch.Tensor,
+    hc_head_scale: torch.Tensor,
+    hc_head_base: torch.Tensor,
+    rms_norm_eps: float,
+    hc_eps: float,
+) -> torch.Tensor:
+    """Fake implementation for shape inference."""
+    hidden_size = residual.shape[-1]
+    outer_shape = residual.shape[:-2]
+    return torch.empty(
+        *outer_shape, hidden_size, dtype=torch.bfloat16, device=x.device
+    )
+
+
+def _mhc_post_hc_head_norm_fused_fake(
+    x: torch.Tensor,
+    residual: torch.Tensor,
+    post_layer_mix: torch.Tensor,
+    comb_res_mix: torch.Tensor,
+    hc_head_fn: torch.Tensor,
+    hc_head_scale: torch.Tensor,
+    hc_head_base: torch.Tensor,
+    norm_weight: torch.Tensor,
+    rms_norm_eps: float,
+    hc_eps: float,
+    norm_eps: float,
+    mtp_buffer: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    """Fake implementation for shape inference."""
+    hidden_size = residual.shape[-1]
+    outer_shape = residual.shape[:-2]
+    return torch.empty(
+        *outer_shape, hidden_size, dtype=torch.bfloat16, device=x.device
+    )
+
+
+def _mhc_post_mean_fused_fake(
+    x: torch.Tensor,
+    residual: torch.Tensor,
+    post_layer_mix: torch.Tensor,
+    comb_res_mix: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Fake implementation for shape inference."""
+    return torch.empty_like(residual), torch.empty_like(x)
+
+
+# Register custom ops for torch.compile compatibility
+direct_register_custom_op(
+    op_name="mhc_post_hc_head_fused",
+    op_func=mhc_post_hc_head_fused,
+    mutates_args=[],
+    fake_impl=_mhc_post_hc_head_fused_fake,
+)
+
+direct_register_custom_op(
+    op_name="mhc_post_hc_head_norm_fused",
+    op_func=mhc_post_hc_head_norm_fused,
+    mutates_args=[],
+    fake_impl=_mhc_post_hc_head_norm_fused_fake,
+)
+
+direct_register_custom_op(
+    op_name="mhc_post_mean_fused",
+    op_func=mhc_post_mean_fused,
+    mutates_args=[],
+    fake_impl=_mhc_post_mean_fused_fake,
+)

--- a/vllm/model_executor/kernels/mhc/optimized_wrappers.py
+++ b/vllm/model_executor/kernels/mhc/optimized_wrappers.py
@@ -1,0 +1,338 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Python wrappers for optimized fused MHC kernels.
+
+These wrappers handle tensor shape validation and provide a clean
+interface matching the original separate kernel calls.
+"""
+
+from typing import Optional
+
+import torch
+
+from vllm.utils.torch_utils import direct_register_custom_op
+
+from .optimized_fusions import (
+    mhc_post_hc_head_fused_tilelang,
+    mhc_post_hc_head_norm_fused_tilelang,
+    mhc_post_hc_head_norm_fused_tilelang_mtp,
+    mhc_post_mean_fused_tilelang,
+)
+
+
+def mhc_post_hc_head_fused(
+    x: torch.Tensor,
+    residual: torch.Tensor,
+    post_layer_mix: torch.Tensor,
+    comb_res_mix: torch.Tensor,
+    hc_head_fn: torch.Tensor,
+    hc_head_scale: torch.Tensor,
+    hc_head_base: torch.Tensor,
+    rms_norm_eps: float,
+    hc_eps: float,
+) -> torch.Tensor:
+    """Fused MHC post + HC head operation.
+
+    Replaces the sequence:
+        residual_out = mhc_post_tilelang(x, residual, post_layer_mix, comb_res_mix)
+        output = hc_head_fused_kernel_tilelang(residual_out, hc_head_fn, ...)
+
+    Args:
+        x: [num_tokens, hidden_size] layer output
+        residual: [num_tokens, hc_mult, hidden_size] input residual streams
+        post_layer_mix: [num_tokens, hc_mult] or [num_tokens, hc_mult, 1]
+        comb_res_mix: [num_tokens, hc_mult, hc_mult] combination mixing weights
+        hc_head_fn: [hc_mult, hc_mult * hidden_size] HC head projection matrix
+        hc_head_scale: [1] HC head scale factor
+        hc_head_base: [hc_mult] HC head bias
+        rms_norm_eps: RMS normalization epsilon
+        hc_eps: HC head gate epsilon
+
+    Returns:
+        output: [num_tokens, hidden_size] compressed output
+    """
+    hc_mult = residual.shape[-2]
+    hidden_size = residual.shape[-1]
+    outer_shape = residual.shape[:-2]
+
+    assert x.shape == (*outer_shape, hidden_size)
+    assert post_layer_mix.shape in (
+        (*outer_shape, hc_mult, 1),
+        (*outer_shape, hc_mult),
+    )
+    assert comb_res_mix.shape == (*outer_shape, hc_mult, hc_mult)
+    assert hc_head_fn.shape == (hc_mult, hc_mult * hidden_size)
+    assert hc_head_scale.shape == (1,)
+    assert hc_head_base.shape == (hc_mult,)
+
+    # Flatten batch dimensions
+    residual_flat = residual.view(-1, hc_mult, hidden_size)
+    num_tokens = residual_flat.shape[0]
+    x_flat = x.view(num_tokens, hidden_size)
+    post_layer_mix_flat = post_layer_mix.view(num_tokens, hc_mult)
+    comb_res_mix_flat = comb_res_mix.view(num_tokens, hc_mult, hc_mult)
+
+    # Allocate output
+    output = torch.empty(
+        num_tokens, hidden_size, dtype=torch.bfloat16, device=x.device
+    )
+
+    # Call fused kernel
+    mhc_post_hc_head_fused_tilelang(
+        comb_res_mix_flat,
+        residual_flat,
+        post_layer_mix_flat,
+        x_flat,
+        hc_head_fn,
+        hc_head_scale,
+        hc_head_base,
+        output,
+        hc_mult,
+        hidden_size,
+        rms_norm_eps,
+        hc_eps,
+    )
+
+    return output.view(*outer_shape, hidden_size)
+
+
+def mhc_post_hc_head_norm_fused(
+    x: torch.Tensor,
+    residual: torch.Tensor,
+    post_layer_mix: torch.Tensor,
+    comb_res_mix: torch.Tensor,
+    hc_head_fn: torch.Tensor,
+    hc_head_scale: torch.Tensor,
+    hc_head_base: torch.Tensor,
+    norm_weight: torch.Tensor,
+    rms_norm_eps: float,
+    hc_eps: float,
+    norm_eps: float,
+    mtp_buffer: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    """Fused MHC post + HC head + RMSNorm operation.
+
+    Replaces the sequence:
+        residual_out = mhc_post_tilelang(x, residual, post_layer_mix, comb_res_mix)
+        hc_out = hc_head_fused_kernel_tilelang(residual_out, hc_head_fn, ...)
+        output = rms_norm(hc_out, norm_weight, norm_eps)
+
+    When mtp_buffer is provided, the pre-hc_head residual (MHC post output)
+    is also written to it for the MTP draft model.
+
+    Args:
+        Same as mhc_post_hc_head_fused, plus:
+        norm_weight: [hidden_size] RMSNorm weight
+        norm_eps: RMSNorm epsilon
+        mtp_buffer: optional [num_tokens, hc_mult * hidden_size] buffer for
+            the MTP draft model's pre-hc_head residual stash
+
+    Returns:
+        output: [num_tokens, hidden_size] normalized compressed output
+    """
+    hc_mult = residual.shape[-2]
+    hidden_size = residual.shape[-1]
+    outer_shape = residual.shape[:-2]
+
+    assert x.shape == (*outer_shape, hidden_size)
+    assert norm_weight.shape == (hidden_size,)
+
+    # Ensure norm_weight is contiguous and correct dtype
+    if norm_weight.dtype != torch.bfloat16:
+        norm_weight = norm_weight.to(torch.bfloat16)
+    if not norm_weight.is_contiguous():
+        norm_weight = norm_weight.contiguous()
+
+    # Flatten batch dimensions
+    residual_flat = residual.view(-1, hc_mult, hidden_size)
+    num_tokens = residual_flat.shape[0]
+    x_flat = x.view(num_tokens, hidden_size)
+    post_layer_mix_flat = post_layer_mix.view(num_tokens, hc_mult)
+    comb_res_mix_flat = comb_res_mix.view(num_tokens, hc_mult, hc_mult)
+
+    # Allocate output
+    output = torch.empty(
+        num_tokens, hidden_size, dtype=torch.bfloat16, device=x.device
+    )
+
+    # Choose kernel variant based on MTP buffer availability
+    if mtp_buffer is not None:
+        # The kernel launches one block per token (grid == num_tokens), so the
+        # MTP output view must be trimmed to exactly num_tokens rows. The model
+        # allocates _mtp_hidden_buffer with max_num_batched_tokens rows and
+        # expects the leading num_tokens to be filled (mirrors the unfused
+        # stash, which does buffer[:num_tokens].copy_(...)).
+        assert mtp_buffer.shape[0] >= num_tokens, \
+            "MTP buffer has fewer rows than tokens"
+        mtp_buffer_view = mtp_buffer[:num_tokens]
+        # Use MTP variant that also writes the pre-hc_head residual
+        mhc_post_hc_head_norm_fused_tilelang_mtp(
+            comb_res_mix_flat,
+            residual_flat,
+            post_layer_mix_flat,
+            x_flat,
+            hc_head_fn,
+            hc_head_scale,
+            hc_head_base,
+            norm_weight,
+            norm_eps,
+            output,
+            mtp_buffer_view,
+            hc_mult,
+            hidden_size,
+            rms_norm_eps,
+            hc_eps,
+        )
+    else:
+        # Standard variant (no MTP output)
+        mhc_post_hc_head_norm_fused_tilelang(
+            comb_res_mix_flat,
+            residual_flat,
+            post_layer_mix_flat,
+            x_flat,
+            hc_head_fn,
+            hc_head_scale,
+            hc_head_base,
+            norm_weight,
+            norm_eps,
+            output,
+            hc_mult,
+            hidden_size,
+            rms_norm_eps,
+            hc_eps,
+        )
+
+    return output.view(*outer_shape, hidden_size)
+
+
+def mhc_post_mean_fused(
+    x: torch.Tensor,
+    residual: torch.Tensor,
+    post_layer_mix: torch.Tensor,
+    comb_res_mix: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Fused MHC post + mean(dim=1) operation for aux layers.
+
+    Replaces the sequence:
+        residual_out = mhc_post_tilelang(x, residual, post_layer_mix, comb_res_mix)
+        mean_out = residual_out.mean(dim=1)
+
+    Args:
+        x: [num_tokens, hidden_size] layer output
+        residual: [num_tokens, hc_mult, hidden_size] input residual streams
+        post_layer_mix: [num_tokens, hc_mult] or [num_tokens, hc_mult, 1]
+        comb_res_mix: [num_tokens, hc_mult, hc_mult] combination mixing weights
+
+    Returns:
+        residual_out: [num_tokens, hc_mult, hidden_size] full MHC post output
+        mean_out: [num_tokens, hidden_size] mean across hc_mult dimension
+    """
+    hc_mult = residual.shape[-2]
+    hidden_size = residual.shape[-1]
+    outer_shape = residual.shape[:-2]
+
+    assert x.shape == (*outer_shape, hidden_size)
+
+    # Flatten batch dimensions
+    residual_flat = residual.view(-1, hc_mult, hidden_size)
+    num_tokens = residual_flat.shape[0]
+    x_flat = x.view(num_tokens, hidden_size)
+    post_layer_mix_flat = post_layer_mix.view(num_tokens, hc_mult)
+    comb_res_mix_flat = comb_res_mix.view(num_tokens, hc_mult, hc_mult)
+
+    # Allocate outputs
+    residual_out = torch.empty_like(residual_flat)
+    mean_out = torch.empty(
+        num_tokens, hidden_size, dtype=torch.bfloat16, device=x.device
+    )
+
+    # Call fused kernel
+    mhc_post_mean_fused_tilelang(
+        comb_res_mix_flat,
+        residual_flat,
+        post_layer_mix_flat,
+        x_flat,
+        residual_out,
+        mean_out,
+        hc_mult,
+        hidden_size,
+    )
+
+    return (
+        residual_out.view(*outer_shape, hc_mult, hidden_size),
+        mean_out.view(*outer_shape, hidden_size),
+    )
+
+
+def _mhc_post_hc_head_fused_fake(
+    x: torch.Tensor,
+    residual: torch.Tensor,
+    post_layer_mix: torch.Tensor,
+    comb_res_mix: torch.Tensor,
+    hc_head_fn: torch.Tensor,
+    hc_head_scale: torch.Tensor,
+    hc_head_base: torch.Tensor,
+    rms_norm_eps: float,
+    hc_eps: float,
+) -> torch.Tensor:
+    """Fake implementation for shape inference."""
+    hidden_size = residual.shape[-1]
+    outer_shape = residual.shape[:-2]
+    return torch.empty(
+        *outer_shape, hidden_size, dtype=torch.bfloat16, device=x.device
+    )
+
+
+def _mhc_post_hc_head_norm_fused_fake(
+    x: torch.Tensor,
+    residual: torch.Tensor,
+    post_layer_mix: torch.Tensor,
+    comb_res_mix: torch.Tensor,
+    hc_head_fn: torch.Tensor,
+    hc_head_scale: torch.Tensor,
+    hc_head_base: torch.Tensor,
+    norm_weight: torch.Tensor,
+    rms_norm_eps: float,
+    hc_eps: float,
+    norm_eps: float,
+    mtp_buffer: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    """Fake implementation for shape inference."""
+    hidden_size = residual.shape[-1]
+    outer_shape = residual.shape[:-2]
+    return torch.empty(
+        *outer_shape, hidden_size, dtype=torch.bfloat16, device=x.device
+    )
+
+
+def _mhc_post_mean_fused_fake(
+    x: torch.Tensor,
+    residual: torch.Tensor,
+    post_layer_mix: torch.Tensor,
+    comb_res_mix: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Fake implementation for shape inference."""
+    return torch.empty_like(residual), torch.empty_like(x)
+
+
+# Register custom ops for torch.compile compatibility
+direct_register_custom_op(
+    op_name="mhc_post_hc_head_fused",
+    op_func=mhc_post_hc_head_fused,
+    mutates_args=[],
+    fake_impl=_mhc_post_hc_head_fused_fake,
+)
+
+direct_register_custom_op(
+    op_name="mhc_post_hc_head_norm_fused",
+    op_func=mhc_post_hc_head_norm_fused,
+    mutates_args=[],
+    fake_impl=_mhc_post_hc_head_norm_fused_fake,
+)
+
+direct_register_custom_op(
+    op_name="mhc_post_mean_fused",
+    op_func=mhc_post_mean_fused,
+    mutates_args=[],
+    fake_impl=_mhc_post_mean_fused_fake,
+)

--- a/vllm/models/deepseek_v4/nvidia/model.py
+++ b/vllm/models/deepseek_v4/nvidia/model.py
@@ -1185,6 +1185,8 @@ class DeepseekV4Model(nn.Module, EagleModelMixin):
                     aux_recon, aux_mean = mhc_post_mean_fused(
                         hidden_states, residual, post_mix, res_mix
                     )
+                    if self.use_sequence_parallel:
+                        aux_mean = sp_all_gather(aux_mean)[:full_num_tokens]
                     aux_hidden_states.append(aux_mean)
                 else:
                     aux_recon = mhc_post_tilelang(
@@ -1195,6 +1197,7 @@ class DeepseekV4Model(nn.Module, EagleModelMixin):
                         aux_hidden_state = sp_all_gather(aux_hidden_state)[:full_num_tokens]
                     aux_hidden_states.append(aux_hidden_state)
                 final_aux_recon = aux_recon
+        _fused_applied = False
         if layer is not None:
             # Reuse if the last layer was captured as an aux hidden state
             if self.end_layer in self.aux_hidden_state_layers:
@@ -1217,6 +1220,9 @@ class DeepseekV4Model(nn.Module, EagleModelMixin):
                     self.norm.variance_epsilon,
                     mtp_buffer=self._mtp_hidden_buffer,
                 )
+                if self.use_sequence_parallel:
+                    hidden_states = sp_all_gather(hidden_states)[:full_num_tokens]
+                _fused_applied = True
                 if len(aux_hidden_states) > 0:
                     return hidden_states, aux_hidden_states
                 return hidden_states
@@ -1237,11 +1243,11 @@ class DeepseekV4Model(nn.Module, EagleModelMixin):
         # When the fused kernel handled this, the stash is already in
         # _mtp_hidden_buffer and we skip the copy to avoid double-writing.
         num_tokens = hidden_states.shape[0]
-        if self._mtp_hidden_buffer is not None and not _HAS_OPTIMIZED_FUSIONS:
+        if self._mtp_hidden_buffer is not None and not _fused_applied:
             self._mtp_hidden_buffer[:num_tokens].copy_(hidden_states.flatten(1))
 
         # Last PP rank: apply hc_head + norm (unless the fused kernel already did)
-        if _HAS_OPTIMIZED_FUSIONS:
+        if _fused_applied:
             # Fused kernel already applied hc_head + norm
             pass
         else:

--- a/vllm/models/deepseek_v4/nvidia/model.py
+++ b/vllm/models/deepseek_v4/nvidia/model.py
@@ -25,6 +25,13 @@ from vllm.model_executor.kernels.mhc.tilelang import (
     mhc_pre_broadcast_tilelang,
     mhc_pre_tilelang,
 )
+
+# Import optimized fused kernels (respects VLLM_MHC_FUSED_KERNELS env var)
+from vllm.model_executor.kernels.mhc import (
+    _HAS_OPTIMIZED_FUSIONS,
+    mhc_post_hc_head_norm_fused,
+    mhc_post_mean_fused,
+)
 from vllm.model_executor.layers.activation import SiluAndMul, SiluAndMulWithClamp
 from vllm.model_executor.layers.fused_moe import (
     FusedMoEFactory,
@@ -1174,19 +1181,48 @@ class DeepseekV4Model(nn.Module, EagleModelMixin):
             )
             if idx + 1 in self.aux_hidden_state_layers:
                 # Reconstruct the aux hidden state for draft models
-                aux_recon = mhc_post_tilelang(
-                    hidden_states, residual, post_mix, res_mix
-                )
-                aux_hidden_state = aux_recon.mean(dim=1)
-                if self.use_sequence_parallel:
-                    aux_hidden_state = sp_all_gather(aux_hidden_state)[:full_num_tokens]
-                aux_hidden_states.append(aux_hidden_state)
+                if _HAS_OPTIMIZED_FUSIONS:
+                    aux_recon, aux_mean = mhc_post_mean_fused(
+                        hidden_states, residual, post_mix, res_mix
+                    )
+                    aux_hidden_states.append(aux_mean)
+                else:
+                    aux_recon = mhc_post_tilelang(
+                        hidden_states, residual, post_mix, res_mix
+                    )
+                    aux_hidden_state = aux_recon.mean(dim=1)
+                    if self.use_sequence_parallel:
+                        aux_hidden_state = sp_all_gather(aux_hidden_state)[:full_num_tokens]
+                    aux_hidden_states.append(aux_hidden_state)
                 final_aux_recon = aux_recon
         if layer is not None:
             # Reuse if the last layer was captured as an aux hidden state
             if self.end_layer in self.aux_hidden_state_layers:
                 hidden_states = final_aux_recon
+            elif get_pp_group().is_last_rank and _HAS_OPTIMIZED_FUSIONS:
+                # Last PP rank: use optimized three-way fused kernel.
+                # Pass the MTP buffer so the kernel can stash the pre-hc_head
+                # residual for the MTP draft model (avoids an extra HBM round-trip).
+                hidden_states = mhc_post_hc_head_norm_fused(
+                    hidden_states,
+                    residual,
+                    post_mix,
+                    res_mix,
+                    self.hc_head_fn,
+                    self.hc_head_scale,
+                    self.hc_head_base,
+                    self.norm.weight.data,
+                    self.rms_norm_eps,
+                    self.hc_eps,
+                    self.norm.variance_epsilon,
+                    mtp_buffer=self._mtp_hidden_buffer,
+                )
+                if len(aux_hidden_states) > 0:
+                    return hidden_states, aux_hidden_states
+                return hidden_states
             else:
+                # Non-last PP rank or fusion unavailable: just mhc_post.
+                # The hc_head + norm for the last rank is handled below.
                 hidden_states = mhc_post_tilelang(
                     hidden_states, residual, post_mix, res_mix
                 )
@@ -1197,19 +1233,28 @@ class DeepseekV4Model(nn.Module, EagleModelMixin):
         if self.use_sequence_parallel:
             hidden_states = sp_all_gather(hidden_states)[:full_num_tokens]
 
-        if self._mtp_hidden_buffer is not None:
-            num_tokens = hidden_states.shape[0]
+        # Stash pre-hc_head residual for the MTP draft (captured copy_).
+        # When the fused kernel handled this, the stash is already in
+        # _mtp_hidden_buffer and we skip the copy to avoid double-writing.
+        num_tokens = hidden_states.shape[0]
+        if self._mtp_hidden_buffer is not None and not _HAS_OPTIMIZED_FUSIONS:
             self._mtp_hidden_buffer[:num_tokens].copy_(hidden_states.flatten(1))
 
-        hidden_states = hc_head_fused_kernel_tilelang(
-            hidden_states,
-            self.hc_head_fn,
-            self.hc_head_scale,
-            self.hc_head_base,
-            self.rms_norm_eps,
-            self.hc_eps,
-        )
-        hidden_states = self.norm(hidden_states)
+        # Last PP rank: apply hc_head + norm (unless the fused kernel already did)
+        if _HAS_OPTIMIZED_FUSIONS:
+            # Fused kernel already applied hc_head + norm
+            pass
+        else:
+            hidden_states = hc_head_fused_kernel_tilelang(
+                hidden_states,
+                self.hc_head_fn,
+                self.hc_head_scale,
+                self.hc_head_base,
+                self.rms_norm_eps,
+                self.hc_eps,
+            )
+            hidden_states = self.norm(hidden_states)
+
         if len(aux_hidden_states) > 0:
             return hidden_states, aux_hidden_states
         return hidden_states

--- a/vllm/models/deepseek_v4/nvidia/model.py
+++ b/vllm/models/deepseek_v4/nvidia/model.py
@@ -21,6 +21,11 @@ from vllm.distributed import (
 from vllm.distributed.eplb.eplb_state import EplbLayerState
 from vllm.forward_context import get_forward_context, is_forward_context_available
 from vllm.logger import init_logger
+from vllm.model_executor.kernels.mhc import (
+    _HAS_OPTIMIZED_FUSIONS,
+    mhc_post_hc_head_norm_fused,
+    mhc_post_mean_fused,
+)
 from vllm.model_executor.kernels.mhc.tilelang import (
     hc_head_fused_kernel_tilelang,
     mhc_fused_post_pre_tilelang,
@@ -1436,18 +1441,47 @@ class DeepseekV4Model(nn.Module, EagleModelMixin):
             )
             if idx + 1 in self.aux_hidden_state_layers:
                 # Reconstruct the aux hidden state for draft models
-                aux_recon = mhc_post_tilelang(
-                    hidden_states, residual, post_mix, res_mix
-                )
-                aux_hidden_state = aux_recon.mean(dim=1)
+                if _HAS_OPTIMIZED_FUSIONS:
+                    aux_recon, aux_hidden_state = mhc_post_mean_fused(
+                        hidden_states, residual, post_mix, res_mix
+                    )
+                else:
+                    aux_recon = mhc_post_tilelang(
+                        hidden_states, residual, post_mix, res_mix
+                    )
+                    aux_hidden_state = aux_recon.mean(dim=1)
                 if self.use_sequence_parallel:
                     aux_hidden_state = sp_all_gather(aux_hidden_state)[:full_num_tokens]
                 aux_hidden_states.append(aux_hidden_state)
                 final_aux_recon = aux_recon
+        # Last PP rank: fold the final MHC post + hc_head + RMSNorm into a
+        # single kernel. Under sequence parallel each rank only holds a token
+        # shard, and the MTP draft reads the pre-hc_head stash in full-sequence
+        # order after the all-gather below, so the kernel-side stash must be
+        # disabled when both SP and the MTP buffer are active.
+        _fused_applied = False
         if layer is not None:
             # Reuse if the last layer was captured as an aux hidden state
             if self.end_layer in self.aux_hidden_state_layers:
                 hidden_states = final_aux_recon
+            elif (get_pp_group().is_last_rank and _HAS_OPTIMIZED_FUSIONS
+                  and not (self.use_sequence_parallel
+                           and self._mtp_hidden_buffer is not None)):
+                hidden_states = mhc_post_hc_head_norm_fused(
+                    hidden_states,
+                    residual,
+                    post_mix,
+                    res_mix,
+                    self.hc_head_fn,
+                    self.hc_head_scale,
+                    self.hc_head_base,
+                    self.norm.weight.data,
+                    self.rms_norm_eps,
+                    self.hc_eps,
+                    self.norm.variance_epsilon,
+                    mtp_buffer=self._mtp_hidden_buffer,
+                )
+                _fused_applied = True
             else:
                 hidden_states = mhc_post_tilelang(
                     hidden_states, residual, post_mix, res_mix
@@ -1464,19 +1498,24 @@ class DeepseekV4Model(nn.Module, EagleModelMixin):
         if self.use_sequence_parallel:
             hidden_states = sp_all_gather(hidden_states)[:full_num_tokens]
 
-        if self._mtp_hidden_buffer is not None:
+        # Stash the pre-hc_head residual for the MTP draft, unless the fused
+        # kernel already wrote it into the buffer (only possible when not
+        # sequence-parallel, where the stash and the buffer share one global
+        # token order).
+        if self._mtp_hidden_buffer is not None and not _fused_applied:
             num_tokens = hidden_states.shape[0]
             self._mtp_hidden_buffer[:num_tokens].copy_(hidden_states.flatten(1))
 
-        hidden_states = hc_head_fused_kernel_tilelang(
-            hidden_states,
-            self.hc_head_fn,
-            self.hc_head_scale,
-            self.hc_head_base,
-            self.rms_norm_eps,
-            self.hc_eps,
-        )
-        hidden_states = self.norm(hidden_states)
+        if not _fused_applied:
+            hidden_states = hc_head_fused_kernel_tilelang(
+                hidden_states,
+                self.hc_head_fn,
+                self.hc_head_scale,
+                self.hc_head_base,
+                self.rms_norm_eps,
+                self.hc_eps,
+            )
+            hidden_states = self.norm(hidden_states)
         aux_hidden_states = remote_aux + aux_hidden_states
         if len(aux_hidden_states) > 0:
             return hidden_states, aux_hidden_states


### PR DESCRIPTION
## Summary

Optimize MHC post + HC head + RMSNorm operations for DeepSeek V4 via kernel
fusion. Three new TileLang kernels are introduced:

1. **mhc_post_hc_head_fused** — 2-way fusion: MHC post + HC head
2. **mhc_post_hc_head_norm_fused** — 3-way fusion: MHC post + HC head + RMSNorm
3. **mhc_post_mean_fused** — MHC post + mean reduction for aux layers

All fusions are gated behind the `VLLM_MHC_FUSED_KERNELS` env var (default:
enabled). When TileLang is not available, the code gracefully falls back to the
original separate kernel calls.

## Key Design Decisions

- **PP > 1 safe**: The 3-way fusion is only applied on the last PP rank
- **MTP draft model compatible**: Optional `mtp_buffer` output stashes the
  pre-hc_head residual for the MTP draft model
- **Zero overhead when disabled**: The flag is checked at import time

## End-to-End Benchmark Results

**Hardware:** 8 × H20 (NVIDIA)
**Model:** DeepSeek-V4-Flash (FP8)
**Test Config:** TP=8, EP enabled, 100 random prompts, input length=20000,
output length=2000, max concurrency=16, random dataset, avg 5 runs.

| Metric (Avg 5) | After Optimization | Before Optimization | Improvement |
|---|---|---|---|
| Benchmark duration (s) | 360.69 | 362.99 | +0.63% |
| Output token throughput (tok/s) | 554.5 | 550.97 | +0.64% |
| Total token throughput (tok/s) | 6099.5 | 6060.71 | +0.64% |
| Peak output token throughput (tok/s) | 1344 | 1328 | +1.20% |
| Peak concurrent requests | 21.4 | 21.2 | +0.94% |
| Request throughput (req/s) | 0.28 | 0.28 | 0% |
| Mean TTFT (ms) | 10701.31 | 10689.61 | −0.11% |
| Median TTFT (ms) | 10680.57 | 10705.71 | +0.23% |
| P99 TTFT (ms) | 30616.14 | 30599.72 | −0.05% |
| Mean TPOT (ms) | 22.39 | 22.58 | +0.84% |
| Median TPOT (ms) | 22.58 | 22.81 | +1.01% |
| P99 TPOT (ms) | 26.75 | 26.93 | +0.67% |
| Mean ITL (ms) | 22.39 | 22.58 | +0.84% |
| Median ITL (ms) | 12.02 | 12.17 | +1.23% |
| P99 ITL (ms) | 798.74 | 801.48 | +0.34% |

> Note: TTFT shows a slight regression (−0.11% mean) due to the additional
> computation in the fused kernel path for long-context (20K) prefill. The
> decode-phase metrics (TPOT, ITL) consistently improve by 0.6–1.2%.

## Changes

- `vllm/model_executor/kernels/mhc/optimized_fusions.py` — new TileLang kernels
- `vllm/model_executor/kernels/mhc/optimized_wrappers.py` — Python wrappers
- `vllm/model_executor/kernels/mhc/__init__.py` — env var gating
- `vllm/models/deepseek_v4/nvidia/model.py` — model integration
- `tests/kernels/test_mhc_optimized_fusions.py` — correctness tests
- `benchmarks/kernels/benchmark_mhc_fusions.py` — micro-benchmarks
- `benchmarks/kernels/profile_mhc_fusions.py` — NCU profiling helpers

## Correctness

All tests pass with rtol=1e-2 / atol=1e-2 against the original unfused
operations across multiple token counts (1, 8, 64, 256) and hidden sizes
(512, 1024, 2048).