### PR TITLE
[Rust Frontend] Correctly report world size for dense DP

### DIFF
--- a/rust/src/engine-core-client/src/transport.rs
+++ b/rust/src/engine-core-client/src/transport.rs
@@ -493,7 +493,7 @@ async fn wait_for_input_registrations(
         ready_responses.insert(actual_id, ready_response);
     }
 
-    Ok(expected_engines
+    let engines = expected_engines
         .into_iter()
         .map(|engine_id| {
             let ready_response = ready_responses
@@ -504,7 +504,54 @@ async fn wait_for_input_registrations(
                 ready_response,
             }
         })
-        .collect())
+        .collect::<Vec<_>>();
+    validate_ready_responses(&engines)?;
+    Ok(engines)
+}
+
+fn validate_ready_responses(engines: &[ConnectedEngine]) -> Result<()> {
+    let Some(first_engine) = engines.first() else {
+        return Ok(());
+    };
+    let data_parallel_size = first_engine.ready_response.data_parallel_size;
+
+    for engine in engines {
+        let ready = &engine.ready_response;
+        if ready.data_parallel_size != data_parallel_size {
+            bail_unexpected_handshake_message!(
+                "engine id {:?} reported data_parallel_size {}, expected {}",
+                engine.engine_id,
+                ready.data_parallel_size,
+                data_parallel_size
+            );
+        }
+        if u64::from(ready.data_parallel_rank) >= data_parallel_size {
+            bail_unexpected_handshake_message!(
+                "engine id {:?} reported data_parallel_rank {} outside data_parallel_size {}",
+                engine.engine_id,
+                ready.data_parallel_rank,
+                data_parallel_size
+            );
+        }
+        if data_parallel_size > 1 {
+            let Some(engine_index) = engine.engine_id.engine_index() else {
+                bail_unexpected_handshake_message!(
+                    "engine id {:?} does not encode a Python-compatible engine index",
+                    engine.engine_id
+                );
+            };
+            if engine_index != ready.data_parallel_rank {
+                bail_unexpected_handshake_message!(
+                    "engine id {:?} encodes engine index {}, but reported data_parallel_rank {}",
+                    engine.engine_id,
+                    engine_index,
+                    ready.data_parallel_rank
+                );
+            }
+        }
+    }
+
+    Ok(())
 }
 
 /// Send an encoded message to the engine through the input socket.
@@ -585,7 +632,22 @@ pub async fn run_output_loop(
 
 #[cfg(test)]
 mod tests {
-    use super::bind_local_sockets;
+    use super::{ConnectedEngine, EngineId, bind_local_sockets, validate_ready_responses};
+    use crate::mock_engine::default_ready_response;
+
+    fn connected_engine(
+        engine_index: u32,
+        data_parallel_rank: u32,
+        data_parallel_size: u64,
+    ) -> ConnectedEngine {
+        let mut ready_response = default_ready_response();
+        ready_response.data_parallel_rank = data_parallel_rank;
+        ready_response.data_parallel_size = data_parallel_size;
+        ConnectedEngine {
+            engine_id: EngineId::from_engine_index(engine_index),
+            ready_response,
+        }
+    }
 
     #[tokio::test]
     async fn bind_local_sockets_resolves_zero_port_bindings() {
@@ -595,5 +657,44 @@ mod tests {
         assert!(input_address.starts_with("tcp://127.0.0.1:"));
         assert!(output_address.starts_with("tcp://127.0.0.1:"));
         assert_ne!(input_address, output_address);
+    }
+
+    #[test]
+    fn ready_responses_accept_consistent_data_parallel_topology() {
+        let engines = [connected_engine(0, 0, 2), connected_engine(1, 1, 2)];
+        validate_ready_responses(&engines).expect("valid ready responses");
+    }
+
+    #[test]
+    fn ready_responses_reject_inconsistent_data_parallel_size() {
+        let engines = [connected_engine(0, 0, 2), connected_engine(1, 1, 3)];
+        let error = validate_ready_responses(&engines).expect_err("inconsistent DP sizes");
+        expect_test::expect![["unexpected startup handshake message: engine id EngineId(0100) reported data_parallel_size 3, expected 2"]]
+            .assert_eq(&error.to_string());
+    }
+
+    #[test]
+    fn ready_responses_reject_rank_outside_data_parallel_size() {
+        let engines = [connected_engine(2, 2, 2)];
+        let error = validate_ready_responses(&engines).expect_err("out-of-range DP rank");
+        expect_test::expect![["unexpected startup handshake message: engine id EngineId(0200) reported data_parallel_rank 2 outside data_parallel_size 2"]]
+            .assert_eq(&error.to_string());
+    }
+
+    #[test]
+    fn ready_responses_reject_engine_index_rank_mismatch() {
+        let engines = [connected_engine(1, 0, 2)];
+        let error = validate_ready_responses(&engines).expect_err("engine index mismatch");
+        expect_test::expect![["unexpected startup handshake message: engine id EngineId(0100) encodes engine index 1, but reported data_parallel_rank 0"]]
+            .assert_eq(&error.to_string());
+    }
+
+    #[test]
+    fn ready_responses_reject_opaque_identity_for_data_parallel_engine() {
+        let mut engine = connected_engine(0, 0, 2);
+        engine.engine_id = EngineId::from(b"engine");
+        let error = validate_ready_responses(&[engine]).expect_err("opaque engine identity");
+        expect_test::expect![["unexpected startup handshake message: engine id EngineId(656e67696e65) does not encode a Python-compatible engine index"]]
+            .assert_eq(&error.to_string());
     }
 }

--- a/rust/src/server/src/routes/tests.rs
+++ b/rust/src/server/src/routes/tests.rs
@@ -706,7 +706,7 @@ async fn test_dev_mode_app_with_ready(
 ) -> (axum::Router, MockEngineTask) {
     let ipc = IpcNamespace::new().expect("create ipc namespace");
     let handshake_address = ipc.handshake_endpoint();
-    let engine_id = b"engine-world-size".to_vec();
+    let engine_id = EngineId::from_engine_index(ready_response.data_parallel_rank);
 
     let engine_task = MockEngineTask::new(spawn_mock_engine_task_with_ready(
         handshake_address.clone(),

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -402,6 +402,7 @@ def test_reconfigure_for_independent_dp_rank_on_multinode_dense_model():
     assert parallel_config.data_parallel_size_local == 1
     assert parallel_config.data_parallel_rank == 0
     assert parallel_config.data_parallel_index == 1
+    assert parallel_config.data_parallel_size_global == 2
     assert parallel_config.nnodes == 1
     assert parallel_config.node_rank == 0
     assert parallel_config.world_size == 8

--- a/tests/v1/distributed/test_internal_lb_dp.py
+++ b/tests/v1/distributed/test_internal_lb_dp.py
@@ -17,6 +17,7 @@ from tests.v1.utils import check_request_balancing
 from vllm.platforms import current_platform
 
 MODEL_NAME = "ibm-research/PowerMoE-3b"
+DENSE_MODEL_NAME = "Qwen/Qwen3-0.6B"
 
 # Number of data parallel ranks for multi-node internal LB testing
 DP_SIZE = int(os.getenv("DP_SIZE", "2"))
@@ -393,6 +394,32 @@ def default_server_args():
     ]
 
 
+@pytest.fixture(scope="module")
+def dense_dp_server(default_server_args):
+    server_args = [
+        *default_server_args,
+        "--data-parallel-size",
+        str(DP_SIZE),
+        "--data-parallel-size-local",
+        str(DP_SIZE),
+        "--tensor-parallel-size",
+        str(TP_SIZE),
+    ]
+    with RemoteOpenAIServer(
+        DENSE_MODEL_NAME,
+        server_args,
+        env_dict={
+            "VLLM_SERVER_DEV_MODE": "1",
+            **ROCM_ENV_OVERRIDES,
+            current_platform.device_control_env_var: ",".join(
+                str(current_platform.device_id_to_physical_device_id(i))
+                for i in range(DP_SIZE * TP_SIZE)
+            ),
+        },
+    ) as remote_server:
+        yield remote_server
+
+
 @pytest.fixture(scope="module", params=[1, 4])
 def server_manager(request, default_server_args):
     api_server_count = request.param
@@ -448,6 +475,18 @@ def _get_parallel_config(server: RemoteOpenAIServer):
 
     vllm_config = response.json()["vllm_config"]
     return vllm_config["parallel_config"]
+
+
+def test_dense_dp_world_size(dense_dp_server: RemoteOpenAIServer):
+    response = requests.get(dense_dp_server.url_for("get_world_size"))
+    response.raise_for_status()
+    assert response.json() == {"world_size": TP_SIZE * DP_SIZE}
+
+    response = requests.get(
+        dense_dp_server.url_for("get_world_size"), params={"include_dp": "false"}
+    )
+    response.raise_for_status()
+    assert response.json() == {"world_size": TP_SIZE}
 
 
 def test_multinode_dp_server_info(server_manager):

--- a/vllm/config/parallel.py
+++ b/vllm/config/parallel.py
@@ -376,6 +376,10 @@ class ParallelConfig:
     """Equal to the data parallel rank but not used for torch process groups
     and not overridden for dense models."""
 
+    data_parallel_size_global: int = Field(init=False)
+    """The global data parallel size. Preserved when dense-model ranks are
+    reconfigured as independent DP=1 engines."""
+
     _api_process_count: int = Field(default=1, gt=0)
     """
     The number of API processes initialized.
@@ -788,6 +792,7 @@ class ParallelConfig:
             "data_parallel_rank_local",
             "data_parallel_size_local",
             "data_parallel_index",
+            "data_parallel_size_global",
             "data_parallel_backend",
             "data_parallel_external_lb",
             "data_parallel_hybrid_lb",
@@ -903,6 +908,7 @@ class ParallelConfig:
                 )
 
         self.data_parallel_index = self.data_parallel_rank
+        self.data_parallel_size_global = self.data_parallel_size
 
         if self.distributed_executor_backend == "external_launcher":
             os.environ["VLLM_ENABLE_V1_MULTIPROCESSING"] = "0"

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -1621,7 +1621,7 @@ class EngineCoreProc(EngineCore):
             dtype=str(self.vllm_config.model_config.dtype).removeprefix("torch."),
             vllm_version=VLLM_VERSION,
             world_size=self.vllm_config.parallel_config.world_size,
-            data_parallel_size=parallel_config.data_parallel_size,
+            data_parallel_size=parallel_config.data_parallel_size_global,
             kv_cache_size_tokens=self.vllm_config.cache_config.kv_cache_size_tokens,
             kv_cache_max_concurrency=(
                 self.vllm_config.cache_config.kv_cache_max_concurrency


### PR DESCRIPTION
## Purpose

Fix Rust frontend world-size reporting for online dense data parallelism.

Reviewing #51178 exposed an existing topology-reporting gap. That PR needs the deployment-wide DP topology for explicit gRPC rank routing. Dense-model engine ranks call `reconfigure_for_independent_dp_rank()` and become independent DP=1 engines internally, so their Ready responses currently report `data_parallel_size=1`. The Rust frontend then calculates `TP * PP * 1`; for example, TP1 DP2 reports a world size of 1.

The design mirrors the existing `data_parallel_index` preservation pattern: that field retains the original global rank when a dense rank is reconfigured as an independent engine; `data_parallel_size_global` retains the corresponding deployment-wide size.

https://github.com/vllm-project/vllm/blob/2dfb8ba59098eb489197e1b4c643addffd51592e/vllm/config/parallel.py#L375-L377

This PR preserves the original deployment-wide size as `ParallelConfig.data_parallel_size_global`, alongside `data_parallel_index`, and reports it through the existing `EngineCoreReadyResponse.data_parallel_size` field. The Ready handshake also validates that engines agree on the global DP size, each rank is in range, and multi-rank engine identities encode the reported rank.

This PR carries the topology and world-size fix. #51178 continues to carry explicit gRPC rank routing.

## Test Plan

- Exercise the Python-supervised dense-DP startup path through the Rust Ready handshake and `/get_world_size` endpoint.
- Cover preservation of the global DP size when a dense rank is reconfigured as an independent engine.
- Cover valid and invalid Ready topology metadata in the Rust engine-core client.
- Run focused Rust route tests, clippy, and repository pre-commit hooks.

## Test Result

- Red E2E on the base revision with TP1 DP2: `/get_world_size` returned `{"world_size": 1}` and failed against the expected `{"world_size": 2}`.
- Green E2E on this branch: `tests/v1/distributed/test_internal_lb_dp.py::test_dense_dp_world_size` passed; the default result was 2 and `include_dp=false` returned 1.
- `pytest -q tests/test_config.py::test_reconfigure_for_independent_dp_rank_on_multinode_dense_model`: 1 passed.
- `cargo nextest run -p vllm-engine-core-client`: 102 passed.
- `cargo nextest run -p vllm-server world_size`: 3 passed.
- `cargo clippy -p vllm-engine-core-client --all-targets -- -D warnings`: passed.
- `pre-commit run --files ...`: passed, including ruff, mypy, config validation, Rust formatting, and whitespace checks.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose and root cause are described, with #51178 linked as the motivating PR.
- [x] The test plan is included.
- [x] Red and green E2E results are included.
- [x] Documentation impact is limited to the internal `ParallelConfig` field docstring.

</details>
