### PR TITLE
[Bugfix][Model] Add missing fused_qkv_a_proj to Kimi-Linear packed_modules_mapping

### DIFF
--- a/vllm/models/kimi_k3/nvidia/model.py
+++ b/vllm/models/kimi_k3/nvidia/model.py
@@ -1014,6 +1014,7 @@ class KimiLinearModel(nn.Module, EagleModelMixin, SupportsQuant):
         "gate_up_proj": ["gate_proj", "up_proj"],
         "in_proj_qkvgfab": ["q_proj", "k_proj", "v_proj", "b_proj", "f_a_proj"],
         "conv1d": ["q_conv1d", "k_conv1d", "v_conv1d"],
+        "fused_qkv_a_proj": ["q_a_proj", "kv_a_proj_with_mqa"],
     }
 
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):


### PR DESCRIPTION
## Summary
While testing a Kimi-K3 W4A8 quantized checkpoint, we noticed that several `Linear` layers in the checkpoint are intentionally left unquantized (bf16) rather than packed as W4A8 — attention projections among them. Digging into why one of those bf16 layers was being treated as quantized led to this bug.

`KimiLinearModel.packed_modules_mapping` (added in #50500) lists the fused params for MoE/dense MLP and KDA linear-attention layers (`gate_up_proj`, `in_proj_qkvgfab`, `conv1d`), but is missing the MLA attention fusion `fused_qkv_a_proj` -> `[q_a_proj, kv_a_proj_with_mqa]`, used when `q_lora_rank` is set (see `MultiHeadLatentAttention` in `mla.py`).

Without this entry, compressed-tensors' `should_ignore_layer()` can't map `fused_qkv_a_proj` back to the unfused checkpoint names. So a quantized checkpoint that explicitly keeps `q_a_proj`/`kv_a_proj_with_mqa` unquantized ends up having `fused_qkv_a_proj` picked up by the default quantization target instead — either silently mis-quantizing an attention layer that should stay full precision, or failing kernel selection outright.

## Test plan
- Verified against a real Kimi-K3 W4A8 (RTN) checkpoint whose `compression_config.ignore` list contains the unfused `q_a_proj`/`kv_a_proj_with_mqa` names per-layer.
- Confirmed `should_ignore_layer()` now correctly resolves `fused_qkv_a_proj` to "ignored" (bf16) with this mapping, matching the checkpoint's intent, whereas without it the layer was incorrectly routed to the default quantized `Linear` target and failed kernel selection.