### PR TITLE
[Core] Configure custom encoder cache managers from VllmConfig

### DIFF
--- a/vllm/config/ec_manager_config.py
+++ b/vllm/config/ec_manager_config.py
@@ -2,6 +2,8 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 from abc import ABC
+from dataclasses import field
+from typing import Any
 
 from vllm.config.utils import config
 from vllm.utils.import_utils import resolve_obj_by_qualname
@@ -10,8 +12,16 @@ from vllm.utils.import_utils import resolve_obj_by_qualname
 @config
 class EncoderCacheManagerConfig:
     encoder_cache_manager_cls: str | None = None
-    """The qualified class name of the custom encoder cache manager.
-        """
+    """Fully qualified class name of the custom encoder cache manager."""
+
+    manager_config: dict[str, Any] = field(default_factory=dict)
+    """Opaque configuration interpreted by the custom cache manager."""
+
+    def __post_init__(self) -> None:
+        if self.encoder_cache_manager_cls is None and self.manager_config:
+            raise ValueError(
+                "manager_config requires encoder_cache_manager_cls to be set."
+            )
 
     def get_encoder_cache_manager_obj(self):
         cls_path = self.encoder_cache_manager_cls

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -41,6 +41,7 @@ from vllm.config import (
     DeviceConfig,
     DiffusionConfig,
     ECTransferConfig,
+    EncoderCacheManagerConfig,
     EPLBConfig,
     FaultToleranceConfig,
     KernelConfig,
@@ -683,6 +684,9 @@ class EngineArgs:
     kv_events_config: KVEventsConfig | None = None
 
     ec_transfer_config: ECTransferConfig | None = None
+    ec_manager_config: EncoderCacheManagerConfig = get_field(
+        VllmConfig, "ec_manager_config"
+    )
     reasoning_config: ReasoningConfig = get_field(VllmConfig, "reasoning_config")
 
     generation_config: str = ModelConfig.generation_config
@@ -763,6 +767,8 @@ class EngineArgs:
             self.mamba_config = MambaConfig(**self.mamba_config)
         if isinstance(self.kernel_config, dict):
             self.kernel_config = KernelConfig(**self.kernel_config)
+        if isinstance(self.ec_manager_config, dict):
+            self.ec_manager_config = EncoderCacheManagerConfig(**self.ec_manager_config)
         if isinstance(self.eplb_config, dict):
             self.eplb_config = EPLBConfig(**self.eplb_config)
         if isinstance(self.weight_transfer_config, dict):
@@ -1589,6 +1595,9 @@ class EngineArgs:
         vllm_group.add_argument("--kv-events-config", **vllm_kwargs["kv_events_config"])
         vllm_group.add_argument(
             "--ec-transfer-config", **vllm_kwargs["ec_transfer_config"]
+        )
+        vllm_group.add_argument(
+            "--ec-manager-config", **vllm_kwargs["ec_manager_config"]
         )
         vllm_group.add_argument(
             "--compilation-config", "-cc", **vllm_kwargs["compilation_config"]
@@ -2476,6 +2485,7 @@ class EngineArgs:
             kv_transfer_config=self.kv_transfer_config,
             kv_events_config=self.kv_events_config,
             ec_transfer_config=self.ec_transfer_config,
+            ec_manager_config=self.ec_manager_config,
             reasoning_config=self.reasoning_config,
             profiler_config=self.profiler_config,
             additional_config=self.additional_config,

--- a/vllm/v1/core/encoder_cache_manager.py
+++ b/vllm/v1/core/encoder_cache_manager.py
@@ -10,7 +10,7 @@ from vllm.logger import init_logger
 from vllm.v1.request import Request
 
 if TYPE_CHECKING:
-    from vllm.config import SchedulerConfig
+    from vllm.config import SchedulerConfig, VllmConfig
 
 logger = init_logger(__name__)
 
@@ -78,6 +78,15 @@ class EncoderCacheManager:
         # mm_hash of mm_data => num_encoder_embeds of the mm_data
         self.freeable: OrderedDict[str, int] = OrderedDict()
         self.freed: list[str] = []
+
+    @classmethod
+    def from_vllm_config(
+        cls,
+        *,
+        cache_size: int,
+        vllm_config: "VllmConfig",
+    ) -> "EncoderCacheManager":
+        return cls(cache_size=cache_size)
 
     def reset(self) -> None:
         """Reset the encoder cache to its initial state.

--- a/vllm/v1/core/encoder_cache_manager.py
+++ b/vllm/v1/core/encoder_cache_manager.py
@@ -65,7 +65,7 @@ class EncoderCacheManager:
         freed: List of mm_hash strings that were actually evicted since the
             last call to get_freed_mm_hashes(). This list is cleared on return.
     """
-    
+
     @classmethod
     def create_manager(
         cls, *, cache_size: int, vllm_config: "VllmConfig"

--- a/vllm/v1/core/encoder_cache_manager.py
+++ b/vllm/v1/core/encoder_cache_manager.py
@@ -5,6 +5,7 @@ from collections import OrderedDict
 from collections.abc import Mapping
 from typing import TYPE_CHECKING
 
+from vllm.config import VllmConfig
 from vllm.config.ec_manager_config import EncoderCacheManagerMetadata
 from vllm.logger import init_logger
 from vllm.v1.request import Request
@@ -64,6 +65,9 @@ class EncoderCacheManager:
         freed: List of mm_hash strings that were actually evicted since the
             last call to get_freed_mm_hashes(). This list is cleared on return.
     """
+    @classmethod
+    def create_manager(cls, *, cache_size: int, vllm_config: "VllmConfig") -> "EncoderCacheManager":
+        return cls(cache_size=cache_size)
 
     def __init__(self, cache_size: int):
         self.cache_size = cache_size

--- a/vllm/v1/core/encoder_cache_manager.py
+++ b/vllm/v1/core/encoder_cache_manager.py
@@ -10,7 +10,7 @@ from vllm.logger import init_logger
 from vllm.v1.request import Request
 
 if TYPE_CHECKING:
-    from vllm.config import SchedulerConfig, VllmConfig
+    from vllm.config import SchedulerConfig
 
 logger = init_logger(__name__)
 
@@ -78,15 +78,6 @@ class EncoderCacheManager:
         # mm_hash of mm_data => num_encoder_embeds of the mm_data
         self.freeable: OrderedDict[str, int] = OrderedDict()
         self.freed: list[str] = []
-
-    @classmethod
-    def from_vllm_config(
-        cls,
-        *,
-        cache_size: int,
-        vllm_config: "VllmConfig",
-    ) -> "EncoderCacheManager":
-        return cls(cache_size=cache_size)
 
     def reset(self) -> None:
         """Reset the encoder cache to its initial state.

--- a/vllm/v1/core/encoder_cache_manager.py
+++ b/vllm/v1/core/encoder_cache_manager.py
@@ -65,6 +65,7 @@ class EncoderCacheManager:
         freed: List of mm_hash strings that were actually evicted since the
             last call to get_freed_mm_hashes(). This list is cleared on return.
     """
+    
     @classmethod
     def create_manager(
         cls, *, cache_size: int, vllm_config: "VllmConfig"

--- a/vllm/v1/core/encoder_cache_manager.py
+++ b/vllm/v1/core/encoder_cache_manager.py
@@ -66,7 +66,9 @@ class EncoderCacheManager:
             last call to get_freed_mm_hashes(). This list is cleared on return.
     """
     @classmethod
-    def create_manager(cls, *, cache_size: int, vllm_config: "VllmConfig") -> "EncoderCacheManager":
+    def create_manager(
+        cls, *, cache_size: int, vllm_config: "VllmConfig"
+    ) -> "EncoderCacheManager":
         return cls(cache_size=cache_size)
 
     def __init__(self, cache_size: int):

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -234,17 +234,16 @@ class Scheduler(SchedulerInterface):
         )
         encoder_cache_size = mm_budget.encoder_cache_size if mm_budget else 0
         manager_cls_obj = vllm_config.ec_manager_config.get_encoder_cache_manager_obj()
-        if manager_cls_obj is not None:
-            self.encoder_cache_manager = manager_cls_obj.create_manager(
-                cache_size=encoder_cache_size,
-                vllm_config=vllm_config
-            )
-        else:
-            self.encoder_cache_manager = (
-                EncoderDecoderCacheManager(cache_size=encoder_cache_size)
+        if manager_cls_obj is None:
+            manager_cls_obj = (
+                EncoderDecoderCacheManager
                 if self.is_encoder_decoder
-                else EncoderCacheManager(cache_size=encoder_cache_size)
+                else EncoderCacheManager
             )
+        self.encoder_cache_manager = manager_cls_obj.create_manager(
+            cache_size=encoder_cache_size,
+            vllm_config=vllm_config
+        )
         speculative_config = vllm_config.speculative_config
         self.use_eagle = False
         self.num_spec_tokens = vllm_config.num_speculative_tokens

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -233,15 +233,17 @@ class Scheduler(SchedulerInterface):
             mm_budget.encoder_compute_budget if mm_budget else 0
         )
         encoder_cache_size = mm_budget.encoder_cache_size if mm_budget else 0
-        manager_cls_obj = vllm_config.ec_manager_config.get_encoder_cache_manager_obj()
-        if manager_cls_obj is not None:
-            self.encoder_cache_manager = manager_cls_obj(cache_size=encoder_cache_size)
-        else:
-            self.encoder_cache_manager = (
-                EncoderDecoderCacheManager(cache_size=encoder_cache_size)
+        manager_cls = vllm_config.ec_manager_config.get_encoder_cache_manager_obj()
+        if manager_cls is None:
+            manager_cls = (
+                EncoderDecoderCacheManager
                 if self.is_encoder_decoder
-                else EncoderCacheManager(cache_size=encoder_cache_size)
+                else EncoderCacheManager
             )
+        self.encoder_cache_manager = manager_cls.from_vllm_config(
+            cache_size=encoder_cache_size,
+            vllm_config=vllm_config,
+        )
         speculative_config = vllm_config.speculative_config
         self.use_eagle = False
         self.num_spec_tokens = vllm_config.num_speculative_tokens

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -233,17 +233,24 @@ class Scheduler(SchedulerInterface):
             mm_budget.encoder_compute_budget if mm_budget else 0
         )
         encoder_cache_size = mm_budget.encoder_cache_size if mm_budget else 0
-        manager_cls = vllm_config.ec_manager_config.get_encoder_cache_manager_obj()
-        if manager_cls is None:
-            manager_cls = (
-                EncoderDecoderCacheManager
+        manager_cls_obj = vllm_config.ec_manager_config.get_encoder_cache_manager_obj()
+        if manager_cls_obj is not None:
+            from_vllm_config = getattr(manager_cls_obj, "from_vllm_config", None)
+            if from_vllm_config is not None:
+                self.encoder_cache_manager = from_vllm_config(
+                    cache_size=encoder_cache_size,
+                    vllm_config=vllm_config,
+                )
+            else:
+                self.encoder_cache_manager = manager_cls_obj(
+                    cache_size=encoder_cache_size
+                )
+        else:
+            self.encoder_cache_manager = (
+                EncoderDecoderCacheManager(cache_size=encoder_cache_size)
                 if self.is_encoder_decoder
-                else EncoderCacheManager
+                else EncoderCacheManager(cache_size=encoder_cache_size)
             )
-        self.encoder_cache_manager = manager_cls.from_vllm_config(
-            cache_size=encoder_cache_size,
-            vllm_config=vllm_config,
-        )
         speculative_config = vllm_config.speculative_config
         self.use_eagle = False
         self.num_spec_tokens = vllm_config.num_speculative_tokens

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -235,16 +235,10 @@ class Scheduler(SchedulerInterface):
         encoder_cache_size = mm_budget.encoder_cache_size if mm_budget else 0
         manager_cls_obj = vllm_config.ec_manager_config.get_encoder_cache_manager_obj()
         if manager_cls_obj is not None:
-            from_vllm_config = getattr(manager_cls_obj, "from_vllm_config", None)
-            if from_vllm_config is not None:
-                self.encoder_cache_manager = from_vllm_config(
-                    cache_size=encoder_cache_size,
-                    vllm_config=vllm_config,
-                )
-            else:
-                self.encoder_cache_manager = manager_cls_obj(
-                    cache_size=encoder_cache_size
-                )
+            self.encoder_cache_manager = manager_cls_obj.create_manager(
+                cache_size=encoder_cache_size,
+                vllm_config=vllm_config
+            )
         else:
             self.encoder_cache_manager = (
                 EncoderDecoderCacheManager(cache_size=encoder_cache_size)

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -241,8 +241,7 @@ class Scheduler(SchedulerInterface):
                 else EncoderCacheManager
             )
         self.encoder_cache_manager = manager_cls_obj.create_manager(
-            cache_size=encoder_cache_size,
-            vllm_config=vllm_config
+            cache_size=encoder_cache_size, vllm_config=vllm_config
         )
         speculative_config = vllm_config.speculative_config
         self.use_eagle = False


### PR DESCRIPTION
## Purpose

Expose custom encoder cache manager configuration through `VllmConfig` for both online and offline inference.

Custom encoder cache managers may require policy-specific parameters in addition to the encoder cache size. This PR provides a generic configuration path while preserving compatibility with existing built-in and constructor-only cache managers.

## Changes

This PR:

- Adds an opaque `manager_config` field to `EncoderCacheManagerConfig`.
  Its contents are interpreted by the selected custom cache manager.
- Exposes `ec_manager_config` through `EngineArgs`.
- Adds the `--ec-manager-config` CLI option for online serving.
- Supports the same configuration through `LLM(ec_manager_config=...)` for offline inference.
- Resolves custom encoder cache managers using fully qualified class names.
- Allows custom managers that need the complete `VllmConfig` to optionally implement:

  ```python
  @classmethod
  def from_vllm_config(
      cls,
      *,
      cache_size: int,
      vllm_config: VllmConfig,
  ):
      ...
  ```

- Preserves compatibility with constructor-only custom managers:

  ```python
  manager_cls(cache_size=cache_size)
  ```

- Keeps the existing construction paths of built-in `EncoderCacheManager` and `EncoderDecoderCacheManager` unchanged.

A custom manager is not required to inherit from `EncoderCacheManager` or implement `from_vllm_config`, as long as it satisfies the interfaces consumed by the scheduler and model runner.

## Relationship to #48218

This PR is a follow-up to #48218, which was merged as commit `833483f`.

#48218 introduced the generic encoder cache manager extension foundation, including:

- selecting a custom encoder cache manager by fully qualified class name;
- passing `EncoderCacheManagerMetadata` from the scheduler to workers;
- overridable model-runner hooks for encoder cache lookup, storage, eviction, and request cleanup.

However, custom managers were still constructed using only `cache_size`, and the encoder cache manager configuration was not consistently exposed through online and offline `EngineArgs`.

This PR completes the configuration path without changing the lifecycle hooks introduced by #48218. Hardware-specific cache policies remain implemented in their corresponding platform plugins.

## Usage

### Online inference

```bash
vllm serve MODEL \
  --ec-manager-config '{
    "encoder_cache_manager_cls":
      "vllm_ascend.ec_manager.score_ec_manager.ScoreEncoderCacheManager",
    "manager_config": {
      "cpu_cache_slots": 100000,
      "max_clock": 15,
      "clock_decay_every": 64,
      "watermark": 0.2,
      "promote_percentile": 0.2
    }
  }'
```

### Offline inference

```python
from vllm import LLM

llm = LLM(
    model="MODEL",
    ec_manager_config={
        "encoder_cache_manager_cls": (
            "vllm_ascend.ec_manager.score_ec_manager."
            "ScoreEncoderCacheManager"
        ),
        "manager_config": {
            "cpu_cache_slots": 100000,
            "max_clock": 15,
            "clock_decay_every": 64,
            "watermark": 0.2,
            "promote_percentile": 0.2,
        },
    },
)
```

`manager_config` is intentionally opaque to vLLM. Validation and interpretation of manager-specific fields are owned by the selected custom manager.

Specifying a non-empty `manager_config` without `encoder_cache_manager_cls` raises a configuration error.