### PR TITLE
[Bugfix] Size sparse-indexer prefill buffer by compress_ratio for DeepSeek-V4

### DIFF
--- a/tests/v1/attention/test_sparse_mla_backends.py
+++ b/tests/v1/attention/test_sparse_mla_backends.py
@@ -1250,6 +1250,49 @@ def test_split_indexer_prefill_chunks_single_request_overflow():
     assert out == expected
 
 
+@pytest.mark.parametrize("compress_ratio", [1, 4])
+def test_indexer_prefill_budget_matches_compressed_gather_buffer(compress_ratio):
+    """Builder prefill budget must equal the consumer K-gather buffer capacity."""
+    from vllm.v1.attention.backends.mla.indexer import (
+        DeepseekV32IndexerMetadataBuilder,
+        get_max_prefill_buffer_size,
+    )
+    from vllm.v1.kv_cache_interface import MLAAttentionSpec
+    from vllm.v1.worker.block_table import get_block_table_width
+
+    max_model_len = 1024
+    kv_cache_spec = MLAAttentionSpec(
+        block_size=256,
+        num_kv_heads=1,
+        head_size=128,
+        dtype=torch.bfloat16,
+        compress_ratio=compress_ratio,
+    )
+    vllm_config = create_vllm_config(max_model_len=max_model_len)
+    max_num_blocks = kv_cache_spec.max_num_blocks_per_req(vllm_config, max_model_len)
+    block_table_width = get_block_table_width(max_num_blocks, kv_cache_spec.block_size)
+    builder = DeepseekV32IndexerMetadataBuilder(
+        kv_cache_spec=kv_cache_spec,
+        layer_names=["dummy"],
+        vllm_config=vllm_config,
+        device=torch.device("cpu"),
+        block_table_width=block_table_width,
+    )
+
+    consumer_buffer_rows = get_max_prefill_buffer_size(vllm_config) // compress_ratio
+    assert builder.max_prefill_buffer_size == consumer_buffer_rows
+
+    compressed_seq_lens = torch.tensor([consumer_buffer_rows])
+    split_indexer_prefill_chunks(
+        compressed_seq_lens,
+        torch.tensor([1]),
+        builder.max_prefill_buffer_size,
+        10**15,
+    )
+    admitted_rows = int(compressed_seq_lens.sum().item())
+    assert admitted_rows <= consumer_buffer_rows
+
+
 def test_triton_convert_returns_valid_counts():
     """Test that return_valid_counts correctly counts non-negative indices."""
     device = torch.device(DEVICE_TYPE)

--- a/tests/v1/attention/test_sparse_mla_backends.py
+++ b/tests/v1/attention/test_sparse_mla_backends.py
@@ -1251,6 +1251,49 @@ def test_split_indexer_prefill_chunks_single_request_overflow():
     assert out == expected
 
 
+@pytest.mark.parametrize("compress_ratio", [1, 4])
+def test_indexer_prefill_budget_matches_compressed_gather_buffer(compress_ratio):
+    """Builder prefill budget must equal the consumer K-gather buffer capacity."""
+    from vllm.v1.attention.backends.mla.indexer import (
+        DeepseekV32IndexerMetadataBuilder,
+        get_max_prefill_buffer_size,
+    )
+    from vllm.v1.kv_cache_interface import MLAAttentionSpec
+    from vllm.v1.worker.block_table import get_block_table_width
+
+    max_model_len = 1024
+    kv_cache_spec = MLAAttentionSpec(
+        block_size=256,
+        num_kv_heads=1,
+        head_size=128,
+        dtype=torch.bfloat16,
+        tokens_per_state=compress_ratio,
+    )
+    vllm_config = create_vllm_config(max_model_len=max_model_len)
+    max_num_blocks = kv_cache_spec.max_num_blocks_per_req(vllm_config, max_model_len)
+    block_table_width = get_block_table_width(max_num_blocks, kv_cache_spec.block_size)
+    builder = DeepseekV32IndexerMetadataBuilder(
+        kv_cache_spec=kv_cache_spec,
+        layer_names=["dummy"],
+        vllm_config=vllm_config,
+        device=torch.device("cpu"),
+        block_table_width=block_table_width,
+    )
+
+    consumer_buffer_rows = get_max_prefill_buffer_size(vllm_config) // compress_ratio
+    assert builder.max_prefill_buffer_size == consumer_buffer_rows
+
+    compressed_seq_lens = torch.tensor([consumer_buffer_rows])
+    split_indexer_prefill_chunks(
+        compressed_seq_lens,
+        torch.tensor([1]),
+        builder.max_prefill_buffer_size,
+        10**15,
+    )
+    admitted_rows = int(compressed_seq_lens.sum().item())
+    assert admitted_rows <= consumer_buffer_rows
+
+
 # 384 is not a power of two, so it counts via the tiled atomic accumulation
 # rather than the single-tile path 128 takes.
 @pytest.mark.parametrize("num_topk_tokens", [128, 384])

--- a/vllm/v1/attention/backends/mla/indexer.py
+++ b/vllm/v1/attention/backends/mla/indexer.py
@@ -484,8 +484,15 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
                 f"cp_kv_cache_interleave_size=1 (got "
                 f"{self.cp_kv_cache_interleave_size})."
             )
+        # Resolved before the prefill budget below because the chunker feeds it
+        # compressed seq_lens and must be sized in the same units.
+        self.compress_ratio = 1
+        if isinstance(self.kv_cache_spec, MLAAttentionSpec):
+            self.compress_ratio = self.kv_cache_spec.compress_ratio
         # NOTE(Chen):an estimated max size of flattened_kv. Need to double check.
-        self.max_prefill_buffer_size = get_max_prefill_buffer_size(self.vllm_config)
+        self.max_prefill_buffer_size = (
+            get_max_prefill_buffer_size(self.vllm_config) // self.compress_ratio
+        )
         self.num_speculative_tokens = (
             self.vllm_config.speculative_config.num_speculative_tokens
             if self.vllm_config.speculative_config
@@ -566,11 +573,7 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
             (self.num_sms + 1, 2), dtype=torch.int32, device=self.device
         )
 
-        # KV compression. Default to 1 for no compression.
-        self.compress_ratio = 1
-        # Get compress_ratio for DeepseekV4 support
-        if isinstance(self.kv_cache_spec, MLAAttentionSpec):
-            self.compress_ratio = self.kv_cache_spec.compress_ratio
+        # compress_ratio is resolved earlier (used to size the prefill budget).
         if self.dcp_world_size > 1 and self.compress_ratio > 1:
             raise NotImplementedError(
                 "DCP is not supported with sparse indexer KV compression "

--- a/vllm/v1/attention/backends/mla/indexer.py
+++ b/vllm/v1/attention/backends/mla/indexer.py
@@ -546,8 +546,20 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
                 f"cp_kv_cache_interleave_size=1 (got "
                 f"{self.cp_kv_cache_interleave_size})."
             )
+        # Resolved before the prefill budget below because the chunker feeds it
+        # compressed seq_lens and must be sized in the same units.
+        # KV compression. Default to 1 for no compression.
+        self.compress_ratio = 1
+        # Get compress_ratio for DeepseekV4 support
+        if isinstance(self.kv_cache_spec, MLAAttentionSpec):
+            # MLA compression is a whole number of tokens per state (fractions
+            # are whisper block pooling and never reach MLA).
+            assert isinstance(self.kv_cache_spec.tokens_per_state, int)
+            self.compress_ratio = self.kv_cache_spec.tokens_per_state
         # NOTE(Chen):an estimated max size of flattened_kv. Need to double check.
-        self.max_prefill_buffer_size = get_max_prefill_buffer_size(self.vllm_config)
+        self.max_prefill_buffer_size = (
+            get_max_prefill_buffer_size(self.vllm_config) // self.compress_ratio
+        )
         self.num_speculative_tokens = (
             self.vllm_config.speculative_config.num_speculative_tokens
             if self.vllm_config.speculative_config
@@ -618,14 +630,7 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
             (self.num_sms + 1, 2), dtype=torch.int32, device=self.device
         )
 
-        # KV compression. Default to 1 for no compression.
-        self.compress_ratio = 1
-        # Get compress_ratio for DeepseekV4 support
-        if isinstance(self.kv_cache_spec, MLAAttentionSpec):
-            # MLA compression is a whole number of tokens per state (fractions
-            # are whisper block pooling and never reach MLA).
-            assert isinstance(self.kv_cache_spec.tokens_per_state, int)
-            self.compress_ratio = self.kv_cache_spec.tokens_per_state
+        # compress_ratio is resolved earlier (used to size the prefill budget).
         if self.dcp_world_size > 1 and self.compress_ratio > 1:
             raise NotImplementedError(
                 "DCP is not supported with sparse indexer KV compression "


### PR DESCRIPTION
## The bug

The prefill chunker in `DeepseekV32IndexerMetadataBuilder` budgets against `max_prefill_buffer_size` and is fed compressed seq_lens (`seq_lens // compress_ratio`). The consumer allocates the K-gather workspace at `get_max_prefill_buffer_size() // compress_ratio` rows (`vllm/models/deepseek_v4/attention.py:778`). For DeepSeek-V4 (`compress_ratio > 1`) the two disagree by a factor of `compress_ratio`, and the chunker's workspace guard admits a chunk up to `compress_ratio`× larger than the buffer that receives it. V3.2 (`compress_ratio == 1`) is unaffected.

The `cp_gather` kernel guards each write on `token_idx < num_tokens` (`csrc/libtorch_stable/cache_kernels.cu:707-710`), so it doesn't write out of bounds — it silently skips the tail rows and leaves them uninitialized. `cu_seqlen_ks`/`ke` still reference those rows, so the downstream `fp8_fp4_mqa_logits` reads uninitialized K and produces wrong logits and top-k on the affected queries. Silent correctness bug, not a crash.

## Measured

I drove the real `split_indexer_prefill_chunks` on upstream `2dfb8ba59` across 10 realistic V4 shapes (`max_model_len` ∈ {4K, 8K, 32K, 163840}, `compress_ratio` ∈ {2, 4}, batch ∈ {48, 80, 100, 200}, `query_len = 1` — the chunked-prefill / prefix-cache-hit shape where the workspace gate is the only binding limit). 9 of 10 admitted a chunk larger than the consumer buffer. Example: `mml=32K`, `cr=4`, 48 requests × 32K context — chunker admits 393216 compressed rows into a buffer that holds 109226. A direct kernel replay with an undersized `dst` and adjacent canaries confirmed `cp_gather` stops writing at `dst_k.size(0)` and canaries stay intact.


## The fix

Resolve `self.compress_ratio` before the budget assignment and divide the budget by it. `max_prefill_buffer_size` is used only at the `split_indexer_prefill_chunks` call site (`vllm/v1/attention/backends/mla/indexer.py:844`), so the divide has no collateral scope. This restores the chunker's existing `new_n <= workspace_size` guard to validate the right (compressed) unit instead of introducing a new assert.

## Verified

With the fix, `builder.max_prefill_buffer_size == get_max_prefill_buffer_size(cfg) // compress_ratio` for `cr ∈ {1, 4}`. Re-running the 10-shape sweep against the fixed budget keeps every admitted chunk within the buffer.


## Test plan

- `pytest tests/v1/attention/test_sparse_mla_backends.py::test_indexer_prefill_budget_matches_compressed_gather_buffer` — 2 passed
- `ruff check vllm/v1/attention/backends/mla/indexer.py tests/v1/attention/test_sparse_mla_backends.py` — passed
- `ruff format --check vllm/v1/attention/backends/mla/indexer.py tests/v1/attention/test_sparse_mla_backends.py` — passed