### PR TITLE
[Bugfix][SM120] Round DSpark SWA index width up to a dispatchable decode topk

### DIFF
--- a/vllm/v1/attention/backends/mla/sparse_swa.py
+++ b/vllm/v1/attention/backends/mla/sparse_swa.py
@@ -480,15 +480,26 @@ class DeepseekSparseSWAMetadataBuilder(AttentionMetadataBuilder):
 
         # DSpark draft: the block is non-causal (every query attends to the
         # trailing window of context PLUS all query tokens, including future ones),
-        # so its per-token index list is wider than `window_size`. The kernel pads
-        # the q-head count to B_TOPK (64/128), which requires the index width to be
-        # a multiple of 128.
+        # so its per-token index list is wider than `window_size`.
+        #
+        # SM120: the FlashInfer sparse-MLA decode kernel only dispatches for
+        # topk in {128, 512, 1024} (_DECODE_DSV4_DISPATCH in
+        # flashinfer/mla/_sparse_mla_sm120.py). The natural width
+        # cdiv(window + spec, 128) * 128 (= 256 for window 128) is not
+        # instantiated, so the call falls through to the paged/prefill kernel,
+        # which asserts num_tokens > 64 and crashes every small DSpark decode
+        # batch. Round the width up to the nearest dispatchable topk; the
+        # extra slots are masked via swa_topk_lens (correct, small extra
+        # compute).
         self.is_dspark = spec_config is not None and spec_config.use_dspark()
-        self.noncausal_index_width = (
-            cdiv(self.window_size + self.num_speculative_tokens, 128) * 128
-            if self.is_dspark
-            else 0
-        )
+        if self.is_dspark:
+            _needed = self.window_size + self.num_speculative_tokens
+            _supported_topk = (128, 512, 1024)
+            self.noncausal_index_width = next(
+                (t for t in _supported_topk if t >= _needed), 2048
+            )
+        else:
+            self.noncausal_index_width = 0
         self.decode_swa_indices_noncausal: torch.Tensor | None = None
         self._max_tokens = max_tokens
 


### PR DESCRIPTION
## Problem

On SM120 (consumer Blackwell — RTX PRO 6000 / RTX 5090), serving DeepSeek-V4-Flash with DSpark speculative decoding crashes at warmup on every small decode batch:

```
tvm.error.InternalError: Check failed: num_tokens > 64 (7 vs. 64):
Decode (num_tokens <= 64) must go through sparse_mla_sm120_decode_dsv3_2
or sparse_mla_sm120_decode_dsv4; got num_tokens=7
```

## Cause

`sparse_swa.py` sizes the DSpark non-causal SWA index width as
`cdiv(window_size + num_speculative_tokens, 128) * 128`, which evaluates to **256** for
DeepSeek-V4-Flash (`sliding_window=128`, nspec ≤ 128). FlashInfer's SM120 sparse-MLA
**decode** kernel is only instantiated for `topk ∈ {128, 512, 1024}`
(`_DECODE_DSV4_DISPATCH` in `flashinfer/mla/_sparse_mla_sm120.py`), so a width of 256 is
not dispatchable — the call falls through to the paged/prefill kernel, which hard-asserts
`num_tokens > 64` and kills every DSpark decode step.

## Fix

Round the width up to the nearest dispatchable topk. The extra index slots are masked via
`swa_topk_lens`, so results are unchanged (small extra compute on the SWA gather only).

A cleaner long-term shape would be a `supported_decode_topk()` query exposed by FlashInfer
(or extending `_DECODE_DSV4_DISPATCH` with 256); happy to rework in that direction if
preferred.

## Verification

2× RTX PRO 6000 Blackwell (TP=2), DeepSeek-V4-Flash-0731, `--speculative-config
'{"method":"dspark","num_speculative_tokens":6,"draft_sample_method":"greedy"}'`,
block_size 256, 1M max-model-len:

- Before: 100% reproducible crash at warmup (stock v0.26.0 and current main have the same sizing).
- After: warmup, cudagraph capture and serving complete; ~200–215 tok/s batch=1; draft
  acceptance ~3.3/6; internal 10-case LLM-judge regression gate passes with no change vs
  the non-speculative baseline; long-context needle retrieval verified at 99k and 695k tokens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)