### PR TITLE
[Kernel] Cover sliding window in mixed per-sequence causal attention tests

### DIFF
--- a/tests/kernels/attention/test_mixed_causal_attn.py
+++ b/tests/kernels/attention/test_mixed_causal_attn.py
@@ -5,6 +5,12 @@
 Validates that both triton and flash-attention backends correctly handle
 batches where some sequences use causal masking and others use non-causal
 (bidirectional) masking — needed by DiffusionGemma.
+
+Covers both full attention and sliding-window layers. The sliding-window
+cases guard the per-sequence semantics fixed in
+vllm-project/flash-attention#154: causal sequences keep a one-sided window
+over the past while bidirectional sequences in the same batch use a
+symmetric window.
 """
 
 import pytest
@@ -68,14 +74,16 @@ def ref_paged_attn(
             mask = torch.zeros(query_len, kv_len, device=attn.device).bool()
 
         if sliding_window is not None:
-            sw_mask = (
-                torch.triu(
-                    torch.ones(query_len, kv_len, device=attn.device),
-                    diagonal=kv_len - (query_len + sliding_window) + 1,
-                )
-                .bool()
-                .logical_not()
-            )
+            # Per-sequence sliding-window semantics shared by both kernels
+            # (dist = query_abs_pos - key_pos): a causal sequence keeps a
+            # one-sided window over the past, a bidirectional sequence uses
+            # a symmetric window.
+            q_pos = torch.arange(kv_len - query_len, kv_len, device=attn.device)
+            k_pos = torch.arange(kv_len, device=attn.device)
+            dist = q_pos[:, None] - k_pos[None, :]
+            sw_mask = dist >= sliding_window
+            if not per_seq_causal[i]:
+                sw_mask |= dist <= -sliding_window
             mask |= sw_mask
 
         attn.masked_fill_(mask, float("-inf"))
@@ -96,12 +104,13 @@ def ref_paged_attn(
 )
 @pytest.mark.parametrize(
     "seq_lens",
-    [[(1, 128), (5, 64), (1, 256)]],
+    [[(1, 128), (5, 64), (1, 256)], [(129, 256), (5, 64), (65, 128)]],
 )
 @pytest.mark.parametrize(
     "per_seq_causal",
     [[True, False, True], [False, True, False], [True, True, False]],
 )
+@pytest.mark.parametrize("sliding_window", [None, 64])
 @pytest.mark.parametrize("num_heads", NUM_HEADS)
 @pytest.mark.parametrize("head_size", HEAD_SIZES)
 @pytest.mark.parametrize("block_size", BLOCK_SIZES)
@@ -110,6 +119,7 @@ def ref_paged_attn(
 def test_triton_mixed_causal(
     seq_lens: list[tuple[int, int]],
     per_seq_causal: list[bool],
+    sliding_window: int | None,
     num_heads: tuple[int, int],
     head_size: int,
     dtype: torch.dtype,
@@ -176,7 +186,9 @@ def test_triton_mixed_causal(
         max_seqlen_k=max_seqlen_k,
         softmax_scale=scale,
         causal=causal_tensor,
-        window_size=(-1, -1),
+        # Decoder layers hand the kernel a causal-shaped window; the kernel
+        # resolves the per-sequence (a)symmetry internally.
+        window_size=(sliding_window - 1, 0) if sliding_window is not None else (-1, -1),
         block_table=block_tables,
         softcap=0.0,
         q_descale=None,
@@ -193,6 +205,7 @@ def test_triton_mixed_causal(
         block_tables,
         scale,
         per_seq_causal,
+        sliding_window=sliding_window,
     )
 
     torch.testing.assert_close(output, ref_output, atol=1e-2, rtol=1e-2)
@@ -207,12 +220,13 @@ def test_triton_mixed_causal(
 )
 @pytest.mark.parametrize(
     "seq_lens",
-    [[(1, 128), (5, 64), (1, 256)]],
+    [[(1, 128), (5, 64), (1, 256)], [(129, 256), (5, 64), (65, 128)]],
 )
 @pytest.mark.parametrize(
     "per_seq_causal",
     [[True, False, True], [False, True, False]],
 )
+@pytest.mark.parametrize("sliding_window", [None, 64])
 @pytest.mark.parametrize("num_heads", NUM_HEADS)
 @pytest.mark.parametrize("head_size", HEAD_SIZES)
 @pytest.mark.parametrize("block_size", BLOCK_SIZES)
@@ -221,6 +235,7 @@ def test_triton_mixed_causal(
 def test_flash_attn4_mixed_causal(
     seq_lens: list[tuple[int, int]],
     per_seq_causal: list[bool],
+    sliding_window: int | None,
     num_heads: tuple[int, int],
     head_size: int,
     dtype: torch.dtype,
@@ -294,7 +309,21 @@ def test_flash_attn4_mixed_causal(
         block_tables,
         scale,
         per_seq_causal,
+        sliding_window=sliding_window,
     )
+
+    # Mirror FlashAttentionImpl.forward: full-attention layers compile the
+    # kernel causal (dynamic_causal is read in the causal branch); sliding
+    # window layers symmetrize the window (_maybe_symmetrize_window) and
+    # compile the kernel local (causal=False), relying on dynamic_causal to
+    # restore the one-sided window for causal sequences
+    # (vllm-project/flash-attention#154).
+    if sliding_window is None:
+        causal = True
+        window_size = None
+    else:
+        causal = False
+        window_size = [sliding_window - 1, sliding_window - 1]
 
     output = torch.empty_like(query)
     flash_attn_varlen_func(
@@ -307,8 +336,8 @@ def test_flash_attn4_mixed_causal(
         seqused_k=seqused_k,
         max_seqlen_k=max(kv_lens),
         softmax_scale=scale,
-        # The kernel must be compiled causal for `dynamic_causal` to take effect.
-        causal=True,
+        causal=causal,
+        window_size=window_size,
         block_table=block_tables,
         softcap=0.0,
         dynamic_causal=per_seq_causal_tensor,


### PR DESCRIPTION


## Purpose

Close the test gap around per-sequence causal (`dynamic_causal`) × sliding-window attention.

`tests/kernels/attention/test_mixed_causal_attn.py` currently exercises mixed causal/bidirectional batches only for **full attention** layers (`window_size=(-1, -1)` on the Triton path, `causal=True` with no window on the FA4 path). The interaction with sliding windows has zero coverage anywhere — `ref_paged_attn` even ships a `sliding_window` parameter that no test uses — even though this exact combination silently corrupted outputs on SM90 until vllm-project/flash-attention#154:

- For sliding-window layers, `FlashAttentionImpl.forward` symmetrizes the window to `(w, w)` and compiles the kernel local (`causal = not has_window`, #46659), relying on `dynamic_causal` to restore the one-sided window for causal sequences.
- Before FA#154, the FA4 CuTe `AttentionMask.apply_mask` Local branch never read `dynamic_causal`, so causal sequences could attend up to `w` tokens into the **future** on every windowed layer. No crash, no warning — output stays fluent.

Real-world impact we measured on an H800 with a DiffusionGemma-style block-diffusion model (25/30 layers sliding-window, `sliding_window=1024`) running vLLM v0.25.1 — whose vllm-flash-attn pin (`2c839c3`) predates FA#154 while already containing the `dynamic_causal` API:

| Metric (200 samples, same inputs/sampler) | FA4 broken local mask | FA4 with per-seq local mask | TRITON_ATTN |
|---|---|---|---|
| ROUGE-1 | 0.5556 | 0.8403 | 0.8436 |
| Repetition collapse (8-gram repeat > 0.3) | 29/200 | 0 | 0 |
| Denoising steps per canvas | 33.7 | 17.5 | 18.4 |

The kernel fix is already in the current pin (`28e862d` contains FA#154), so today's `main` computes this correctly on both backends — but nothing guards it against regressions, and this PR would have caught the original bug.

Changes:

- Parametrize both `test_triton_mixed_causal` and `test_flash_attn4_mixed_causal` over `sliding_window`, mirroring each backend's forward conventions:
  - Triton: causal-shaped `(w-1, 0)` window; the kernel resolves per-sequence (a)symmetry internally (`compute_kv_seq_mask`).
  - FA4: symmetrized `(w-1, w-1)` window with `causal=False` + `dynamic_causal`, exactly what `FlashAttentionImpl.forward` emits for windowed layers.
- Teach `ref_paged_attn`'s previously-unused `sliding_window` argument the shared per-sequence semantics (causal sequence: one-sided window over the past; bidirectional: symmetric window).
- Add a multi-block `seq_lens` case (`[(129, 256), (5, 64), (65, 128)]`) so queries span multiple tiles and both window bounds, the masked boundary tiles, and the unmasked middle tiles are all exercised.

## Test Plan

On SM90:

```
pytest tests/kernels/attention/test_mixed_causal_attn.py -v
```

## Test Result

- Reference-implementation math validated on CPU against an independent per-token brute-force implementation of the Triton kernel formula (`dist < W` / `(dist < W) & (dist > -W)`): 36 parameter combinations (both `seq_lens` cases × 3 causal patterns × windows {None, 64, 16} × both head configs) match to 2e-5.
- `ruff check` / `ruff format` clean.
- H800 (SM90) run of the new parametrizations: in progress, will post the pytest output in a comment.

The end-to-end behavior the new cases pin down was verified on H800 with the production model above: FA4 with per-sequence-aware local masking matches TRITON_ATTN within sampling noise (ΔROUGE-1 ≤ 0.003) and is ~40% faster end-to-end.
