### PR TITLE
[Bugfix] Skip fetching revision for model when model and weights_model are different

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1773,25 +1773,16 @@ def test_load_config_rejects_non_string_load_format(bad_load_format):
         LoadConfig(load_format=bad_load_format)
 
 
-@patch("vllm.config.model.resolve_revision", return_value="main")
+@patch("vllm.transformers_utils.repo_utils.resolve_revision", return_value="abc123")
 def test_revision_not_resolved_when_weights_differ_from_model(mock_resolve):
-    """When model_weights points to a different repo than model (e.g.
-    GGUF, where model is redirected to the base repo for config), the shared
-    revision must stay unresolved, or the config repo's commit hash would
-    leak into the weights download and 404 against the weights repo."""
-    config = ModelConfig(
-        "Qwen/Qwen3-0.6B",
-        model_weights="unsloth/Qwen3-0.6B-GGUF:Q8_0",
-    )
-
+    model_weights = "unsloth/Qwen3-0.6B-GGUF:Q8_0"
+    config = ModelConfig("Qwen/Qwen3-0.6B", model_weights=model_weights)
     assert config.revision is None
 
 
-@patch("vllm.config.model.resolve_revision", return_value="main")
+@patch("vllm.transformers_utils.repo_utils.resolve_revision", return_value="abc123")
 def test_revision_resolved_when_weights_match_model(mock_resolve):
-    """Normal case: weights come from model, so the shared revision is
-    resolved once against that repo."""
-    config = ModelConfig("Qwen/Qwen3-0.6B")
-
-    assert config.revision == "main"
-    mock_resolve.assert_any_call("Qwen/Qwen3-0.6B", None, config.hf_token)
+    model = "Qwen/Qwen3-0.6B"
+    config = ModelConfig(model)
+    assert config.revision == "abc123"
+    mock_resolve.assert_any_call(model, None, config.hf_token)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1771,3 +1771,27 @@ def test_load_config_rejects_invalid_safetensors_load_strategy():
 def test_load_config_rejects_non_string_load_format(bad_load_format):
     with pytest.raises(pydantic.ValidationError):
         LoadConfig(load_format=bad_load_format)
+
+
+@patch("vllm.config.model.resolve_revision", return_value="main")
+def test_revision_not_resolved_when_weights_differ_from_model(mock_resolve):
+    """When model_weights points to a different repo than model (e.g.
+    GGUF, where model is redirected to the base repo for config), the shared
+    revision must stay unresolved, or the config repo's commit hash would
+    leak into the weights download and 404 against the weights repo."""
+    config = ModelConfig(
+        "Qwen/Qwen3-0.6B",
+        model_weights="unsloth/Qwen3-0.6B-GGUF:Q8_0",
+    )
+
+    assert config.revision is None
+
+
+@patch("vllm.config.model.resolve_revision", return_value="main")
+def test_revision_resolved_when_weights_match_model(mock_resolve):
+    """Normal case: weights come from model, so the shared revision is
+    resolved once against that repo."""
+    config = ModelConfig("Qwen/Qwen3-0.6B")
+
+    assert config.revision == "main"
+    mock_resolve.assert_any_call("Qwen/Qwen3-0.6B", None, config.hf_token)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -9,6 +9,7 @@ from unittest.mock import patch
 
 import pydantic
 import pytest
+from huggingface_hub import ResolvedRevision
 from pydantic import ValidationError
 
 import vllm.config.vllm as vllm_config_module
@@ -29,10 +30,7 @@ from vllm.config.compilation import CompilationMode, CUDAGraphMode
 from vllm.config.kernel import IrOpPriorityConfig
 from vllm.config.load import LoadConfig
 from vllm.config.utils import get_field
-from vllm.config.vllm import (
-    OPTIMIZATION_LEVEL_TO_CONFIG,
-    OptimizationLevel,
-)
+from vllm.config.vllm import OPTIMIZATION_LEVEL_TO_CONFIG, OptimizationLevel
 from vllm.platforms import current_platform
 from vllm.v1.attention.backend import AttentionCGSupport
 
@@ -1773,16 +1771,21 @@ def test_load_config_rejects_non_string_load_format(bad_load_format):
         LoadConfig(load_format=bad_load_format)
 
 
-@patch("vllm.transformers_utils.repo_utils.resolve_revision", return_value="abc123")
+# A real Qwen3-0.6B model revision that is used in the tests below.
+REVISION = "c1899de289a04d12100db370d81485cdf75e47ca"
+
+
+@patch("vllm.config.model.resolve_revision", return_value=ResolvedRevision(REVISION))
 def test_revision_not_resolved_when_weights_differ_from_model(mock_resolve):
     model_weights = "unsloth/Qwen3-0.6B-GGUF:Q8_0"
     config = ModelConfig("Qwen/Qwen3-0.6B", model_weights=model_weights)
     assert config.revision is None
 
 
-@patch("vllm.transformers_utils.repo_utils.resolve_revision", return_value="abc123")
+@patch("vllm.config.model.resolve_revision", return_value=ResolvedRevision(REVISION))
 def test_revision_resolved_when_weights_match_model(mock_resolve):
     model = "Qwen/Qwen3-0.6B"
     config = ModelConfig(model)
-    assert config.revision == "abc123"
+    assert isinstance(config.revision, ResolvedRevision)
+    assert config.revision.resolved == REVISION
     mock_resolve.assert_any_call(model, None, config.hf_token)

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -567,15 +567,11 @@ class ModelConfig:
 
         # If loading model/tokenizer from HF Hub, resolve the revision once
         # to prevent resolving it multiple times downstream.
-        # Only resolve the shared revision against self.model when the
-        # weights are loaded from that same repo. When model_weights points
-        # elsewhere (e.g. GGUF, where model is redirected to the base repo
-        # for config), pinning revision to the config repo's commit hash
-        # would leak an invalid revision into the weights download.
-        weights_match_model = not self.model_weights or self.model_weights == self.model
-        can_resolve_model_revision = (
-            self.hf_config_path is None or self.hf_config_path == self.model
-        ) and weights_match_model
+        # If the weights come from a different repo, we cannot eagerly resolve revision
+        weights_from_model = not self.model_weights or self.model_weights == self.model
+        # If the config comes from a different repo, we cannot eagerly resolve revision
+        config_from_model = not self.hf_config_path or self.hf_config_path == self.model
+        can_resolve_model_revision = config_from_model and weights_from_model
         if can_resolve_model_revision:
             self.revision = resolve_revision(
                 self.model,

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -567,9 +567,15 @@ class ModelConfig:
 
         # If loading model/tokenizer from HF Hub, resolve the revision once
         # to prevent resolving it multiple times downstream.
+        # Only resolve the shared revision against self.model when the
+        # weights are loaded from that same repo. When model_weights points
+        # elsewhere (e.g. GGUF, where model is redirected to the base repo
+        # for config), pinning revision to the config repo's commit hash
+        # would leak an invalid revision into the weights download.
+        weights_match_model = not self.model_weights or self.model_weights == self.model
         can_resolve_model_revision = (
             self.hf_config_path is None or self.hf_config_path == self.model
-        )
+        ) and weights_match_model
         if can_resolve_model_revision:
             self.revision = resolve_revision(
                 self.model,


### PR DESCRIPTION
## Purpose

After PR #49990, two gguf tests soft failed on the nightly https://buildkite.com/vllm/ci/builds/82629/list?sid=019fd5a9-db3f-42ba-9b21-993c983b2c7d&tab=output
- plugins_tests/gguf/test_gguf_plugin_generate.py::test_models[1-8-32-bfloat16-model0]
- plugins_tests/gguf/test_gguf_plugin_generate.py::test_models[1-8-32-bfloat16-model1] 
with the following error:
```
(EngineCore pid=4804)   File "/usr/local/lib/python3.12/dist-packages/huggingface_hub/utils/_http.py", line 811, in hf_raise_for_status
(EngineCore pid=4804)     raise _format(RevisionNotFoundError, message, response, repo_type=repo_type, repo_id=repo_id) from e
(EngineCore pid=4804) huggingface_hub.errors.RevisionNotFoundError: 404 Client Error. (Request ID: Root=1-6a7458a2-4c53f152377c40525f02539b;bbb6ea76-c273-4cc6-8a9d-f476cecea6a0)
(EngineCore pid=4804) 
(EngineCore pid=4804) Revision Not Found for url: https://huggingface.co/api/models/unsloth/Qwen3-0.6B-GGUF/tree/c1899de289a04d12100db370d81485cdf75e47ca?recursive=true&expand=false.
(EngineCore pid=4804) Invalid rev id: c1899de289a04d12100db370d81485cdf75e47ca
```

### Root cause

ModelConfig can load config and weights from different repos. The GGUF plugin redirects model to the base repo (Qwen/Qwen3-0.6B) for config while keeping the GGUF weights repo (unsloth/Qwen3-0.6B-GGUF) in model_weights.

Currently revision is resolved against self.model unconditionally
```
self.revision = resolve_revision(self.model, self.revision, self.hf_token)
```

Because revision is a single field shared by all repos, this base-repo hash is then handed to snapshot_download for the weights repo. huggingface_hub sees an already-resolved revision, skips re-resolving, and requests the base repo's commit from the weights repo. Previously revision stayed None, so snapshot_download resolved main against the weights repo correctly.

This PR only resolves the shared revision against self.model when the weights actually come from the same repo.

## Test Plan

```
pytest -v -s "plugins_tests/gguf/test_gguf_plugin_generate.py::test_models[1-8-32-bfloat16-model0]" "plugins_tests/gguf/test_gguf_plugin_generate.py::test_models[1-8-32-bfloat16-model1]"
```

## Test Result

Previously both tests failed with the aforementioned error, now they pass

