### PR TITLE
[Metrics] Report vllm:iteration_tokens_total for each chunked prefill

### DIFF
--- a/docs/usage/metrics.md
+++ b/docs/usage/metrics.md
@@ -17,7 +17,7 @@ Then query the endpoint to get the latest metrics from the server:
     ```console
     $ curl http://0.0.0.0:8000/metrics
 
-    # HELP vllm:iteration_tokens_total Histogram of number of tokens per engine_step.
+    # HELP vllm:iteration_tokens_total Histogram of model input tokens scheduled per model execution.
     # TYPE vllm:iteration_tokens_total histogram
     vllm:iteration_tokens_total_sum{model_name="unsloth/Llama-3.2-1B-Instruct"} 0.0
     vllm:iteration_tokens_total_bucket{le="1.0",model_name="unsloth/Llama-3.2-1B-Instruct"} 3.0

--- a/tests/entrypoints/serve/instrumentator/test_metrics.py
+++ b/tests/entrypoints/serve/instrumentator/test_metrics.py
@@ -101,7 +101,7 @@ def _get_expected_values(num_requests: int, prompt_ids: list[int], max_tokens: i
         "vllm:iteration_tokens_total": [
             (
                 "_sum",
-                num_requests * (num_prompt_tokens + max_tokens),
+                num_requests * (num_prompt_tokens + max_tokens - 1),
             ),
             ("_count", num_requests * max_tokens),
         ],

--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -195,8 +195,47 @@ def test_scheduler_stats_route_to_existing_output_client():
     engine_core_outputs = scheduler.update_from_output(scheduler_output, model_output)
 
     assert 0 not in engine_core_outputs
-    assert engine_core_outputs[1].scheduler_stats is not None
+    stats = engine_core_outputs[1].scheduler_stats
+    assert stats is not None
+    assert stats.num_iteration_tokens == scheduler_output.total_num_scheduled_tokens
     assert len(engine_core_outputs[1].outputs) == 1
+
+
+def test_iteration_tokens_track_scheduled_tokens_for_chunked_prefill():
+    """Record every scheduler batch, including prefill-only iterations."""
+    scheduler = create_scheduler(
+        max_num_seqs=1, max_num_batched_tokens=4, max_model_len=16
+    )
+    request = create_requests(num_requests=1, num_tokens=10, max_tokens=2)[0]
+    scheduler.add_request(request)
+
+    iteration_tokens: list[int] = []
+    sampled_token_ids_per_step: list[list[list[int]]] = [
+        [[]],
+        [[]],
+        [[1000]],
+        [[1001]],
+    ]
+    for sampled_token_ids in sampled_token_ids_per_step:
+        scheduler_output = scheduler.schedule()
+        model_output = ModelRunnerOutput(
+            req_ids=[request.request_id],
+            req_id_to_index={request.request_id: 0},
+            sampled_token_ids=sampled_token_ids,
+            logprobs=None,
+            prompt_logprobs_dict={},
+            pooler_output=[],
+        )
+
+        engine_core_outputs = scheduler.update_from_output(
+            scheduler_output, model_output
+        )
+        stats = next(iter(engine_core_outputs.values())).scheduler_stats
+        assert stats is not None
+        assert stats.num_iteration_tokens is not None
+        iteration_tokens.append(stats.num_iteration_tokens)
+
+    assert iteration_tokens == [4, 4, 2, 1]
 
 
 def test_schedule_multimodal_requests():

--- a/tests/v1/engine/test_llm_engine.py
+++ b/tests/v1/engine/test_llm_engine.py
@@ -2,12 +2,17 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import random
 from typing import TYPE_CHECKING
+from unittest.mock import Mock
 
 import pytest
 
 from vllm import LLM
 from vllm.sampling_params import SamplingParams, StructuredOutputsParams
+from vllm.v1.engine import EngineCoreOutputs
+from vllm.v1.engine.llm_engine import LLMEngine
+from vllm.v1.engine.output_processor import OutputProcessorOutput
 from vllm.v1.metrics.reader import Counter, Gauge, Histogram, Metric, Vector
+from vllm.v1.metrics.stats import IterationStats, SchedulerStats
 
 if TYPE_CHECKING:
     from tests.conftest import VllmRunner
@@ -103,6 +108,30 @@ def _get_test_sampling_params(
         )
         for n in n_list
     ], n_list
+
+
+def test_stats_only_step_is_logged():
+    engine = object.__new__(LLMEngine)
+    engine.should_execute_dummy_batch = False
+    engine.log_stats = True
+    engine.engine_core = Mock()
+    engine.output_processor = Mock()
+    engine.logger_manager = Mock()
+    engine.renderer = Mock()
+    engine.do_log_stats_with_interval = Mock()
+
+    scheduler_stats = SchedulerStats(num_iteration_tokens=4)
+    engine.engine_core.get_output.return_value = EngineCoreOutputs(
+        scheduler_stats=scheduler_stats
+    )
+    engine.output_processor.process_outputs.return_value = OutputProcessorOutput([], [])
+
+    assert engine.step() == []
+
+    engine.logger_manager.record.assert_called_once()
+    call_kwargs = engine.logger_manager.record.call_args.kwargs
+    assert call_kwargs["scheduler_stats"] is scheduler_stats
+    assert isinstance(call_kwargs["iteration_stats"], IterationStats)
 
 
 def test_compatibility_with_skip_tokenizer_init(

--- a/tests/v1/metrics/test_stats.py
+++ b/tests/v1/metrics/test_stats.py
@@ -1,7 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from unittest.mock import Mock
+
 from vllm.v1.core.sched.output import ScheduledEncoderInputStats, SchedulerOutput
 from vllm.v1.engine import EngineCoreOutputs, FinishReason
+from vllm.v1.metrics.loggers import PrometheusStatLogger
 from vllm.v1.metrics.stats import (
     IterationStats,
     PrefillStats,
@@ -34,6 +37,7 @@ def test_scheduler_iteration_details_serialization():
         scheduler_stats=SchedulerStats(
             kv_cache_usage=0.5,
             iteration_details=iteration_details,
+            num_iteration_tokens=8,
         )
     )
 
@@ -43,6 +47,7 @@ def test_scheduler_iteration_details_serialization():
     assert decoded.scheduler_stats is not None
     assert decoded.scheduler_stats.kv_cache_usage == 0.5
     assert decoded.scheduler_stats.iteration_details == iteration_details
+    assert decoded.scheduler_stats.num_iteration_tokens == 8
 
 
 def test_compute_iteration_details_includes_encoder_stats():
@@ -56,6 +61,35 @@ def test_compute_iteration_details_includes_encoder_stats():
 
     assert iteration_details.num_encoder_inputs == 2
     assert iteration_details.num_encoder_output_tokens == 392
+
+
+def test_prometheus_iteration_tokens_use_scheduler_stats():
+    logger = object.__new__(PrometheusStatLogger)
+    logger.gauge_scheduler_running = {0: Mock()}
+    logger.gauge_scheduler_waiting = {0: Mock()}
+    logger.gauge_waiting_by_reason = {
+        "capacity": {0: Mock()},
+        "deferred": {0: Mock()},
+    }
+    logger.gauge_kv_cache_usage = {0: Mock()}
+    logger.counter_prefix_cache_queries = {0: Mock()}
+    logger.counter_prefix_cache_hits = {0: Mock()}
+    logger.histogram_iteration_tokens = {0: Mock()}
+    logger.kv_cache_metrics_enabled = False
+    logger.gauge_lora_info = None
+
+    logger.record(
+        scheduler_stats=SchedulerStats(num_iteration_tokens=7),
+        iteration_stats=None,
+    )
+    logger.histogram_iteration_tokens[0].observe.assert_called_once_with(7)
+
+    logger.record(
+        scheduler_stats=SchedulerStats(num_iteration_tokens=0),
+        iteration_stats=None,
+    )
+    logger.record(scheduler_stats=SchedulerStats(), iteration_stats=None)
+    logger.histogram_iteration_tokens[0].observe.assert_called_once_with(7)
 
 
 def test_prefill_kv_computed_with_cache():

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -2050,6 +2050,7 @@ class Scheduler(SchedulerInterface):
                 perf_stats,
             )
         ) is not None:
+            stats.num_iteration_tokens = scheduler_output.total_num_scheduled_tokens
             # Return stats to only one of the front-ends.
             if (eco := next(iter(engine_core_outputs.values()), None)) is None:
                 # We must return the stats even if there are no request

--- a/vllm/v1/engine/llm_engine.py
+++ b/vllm/v1/engine/llm_engine.py
@@ -321,11 +321,7 @@ class LLMEngine:
 
         # 4) Record stats
         with record_function_or_nullcontext("llm_engine step: record_stats"):
-            if (
-                self.logger_manager is not None
-                and outputs.scheduler_stats is not None
-                and len(outputs.outputs) > 0
-            ):
+            if self.logger_manager is not None and outputs.scheduler_stats is not None:
                 self.logger_manager.record(
                     scheduler_stats=outputs.scheduler_stats,
                     iteration_stats=iteration_stats,

--- a/vllm/v1/metrics/loggers.py
+++ b/vllm/v1/metrics/loggers.py
@@ -752,7 +752,9 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
         # See: https://github.com/vllm-project/vllm/pull/18053
         histogram_iteration_tokens = self._histogram_cls(
             name="vllm:iteration_tokens_total",
-            documentation="Histogram of number of tokens per engine_step.",
+            documentation=(
+                "Histogram of model input tokens scheduled per model execution."
+            ),
             buckets=[1, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384],
             labelnames=labelnames,
         )
@@ -1122,6 +1124,11 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
             )
             self.gauge_kv_cache_usage[engine_idx].set(scheduler_stats.kv_cache_usage)
 
+            if scheduler_stats.num_iteration_tokens:
+                self.histogram_iteration_tokens[engine_idx].observe(
+                    scheduler_stats.num_iteration_tokens
+                )
+
             self.counter_prefix_cache_queries[engine_idx].inc(
                 scheduler_stats.prefix_cache_stats.queries
             )
@@ -1201,10 +1208,6 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
         self.counter_prompt_tokens_cached[engine_idx].inc(pts.cached_tokens)
         self.counter_generation_tokens[engine_idx].inc(
             iteration_stats.num_generation_tokens
-        )
-        self.histogram_iteration_tokens[engine_idx].observe(
-            iteration_stats.prompt_token_stats.computed
-            + iteration_stats.num_generation_tokens
         )
 
         for max_gen_tokens in iteration_stats.max_num_generation_tokens_iter:

--- a/vllm/v1/metrics/stats.py
+++ b/vllm/v1/metrics/stats.py
@@ -197,6 +197,8 @@ class SchedulerStats:
 
     kv_cache_usage: float = 0.0
     iteration_details: SchedulerIterationDetails | None = None
+    # Number of model input tokens scheduled in this engine iteration.
+    num_iteration_tokens: int | None = None
 
     prefix_cache_stats: PrefixCacheStats = field(default_factory=PrefixCacheStats)
     connector_prefix_cache_stats: PrefixCacheStats | None = None


### PR DESCRIPTION

## Purpose

Fix `vllm:iteration_tokens_total` reporting for chunked prefill.

The V1 implementation currently records this histogram from frontend
`IterationStats`. Prefill-only chunks do not produce request outputs, so those
model executions are not observed. When the final prefill chunk produces the
first output token, the frontend reports all computed prompt tokens together in
that iteration.

For example, a request with a 10-token prompt, `max_tokens=2`, and a 4-token
chunk limit is currently represented approximately as:

```text
[11, 1]
```

The first sample combines all 10 prompt tokens with the first generated token,
even though the prompt was processed over three separate model executions.

This PR moves iteration-token accounting to scheduler stats, where the actual
number of input tokens in every model batch is available. The same request is
then reported as:

```text
[4, 4, 2, 1]
```

This intentionally defines each histogram sample as the number of model input
tokens scheduled for one model execution:

- Each chunked-prefill execution is reported when it occurs.
- The first generated token is an output of the final prefill execution, not an
  additional input to that execution.
- A generated token is counted when it is fed back into a subsequent decode
  execution.
- The final generated token is never fed back and is therefore not counted as
  model input.
- Zero-token scheduler steps are excluded because they do not execute a model
  batch.

As a result, the histogram now represents the actual per-execution batch-size
distribution instead of frontend-visible prompt plus generation token
accounting. The metric name, type, labels, and buckets remain unchanged, but
V1 `_sum`, `_count`, and histogram distributions can change to reflect the
correct model-execution batches.

The HELP text is updated to make this definition explicit.

Duplicate-work checks were performed using `iteration_tokens_total`,
`num_iteration_tokens`, and `"iteration tokens" metrics`. No open PR implements
this fix. In particular:

- #46666 changes API `cached_tokens` accounting for disaggregated KV transfer.
- #35469 adds an OTLP metrics exporter.
- #48866 consolidates histogram bucket definitions.
- #48292 adds result-wait timing to iteration-detail logs.

## Test Plan

Run the scheduler, frontend, serialization, and Prometheus unit tests:

```bash
.venv/bin/python -m pytest tests/v1/metrics/test_stats.py -q

.venv/bin/python -m pytest \
  tests/v1/engine/test_llm_engine.py::test_stats_only_step_is_logged \
  tests/v1/core/test_scheduler.py::test_scheduler_stats_route_to_existing_output_client \
  tests/v1/core/test_scheduler.py::test_iteration_tokens_track_scheduled_tokens_for_chunked_prefill \
  -q
```

Run the existing service-level metrics test with and without explicit chunked
prefill:

```bash
CUDA_VISIBLE_DEVICES=1 PATH="$PWD/.venv/bin:$PATH" \
  .venv/bin/python -m pytest \
  'tests/entrypoints/serve/instrumentator/test_metrics.py::test_metrics_counts[-text]' \
  'tests/entrypoints/serve/instrumentator/test_metrics.py::test_metrics_counts[--enable-chunked-prefill-text]' \
  -q
```

Run repository checks:

```bash
.venv/bin/pre-commit run
git diff --cached --check
```

Model evaluation is not applicable because this change only affects metrics
reporting and does not alter model output, accuracy, or serving behavior.

## Test Result

Unit tests:

```text
tests/v1/metrics/test_stats.py
13 passed
```

```text
LLMEngine and scheduler focused tests
3 passed
```

Service-level metrics tests on an NVIDIA B300:

```text
2 passed, 14 warnings in 81.15s
```

Repository checks:

```text
pre-commit: all hooks passed
git diff --cached --check: passed
```



## AI Assistance

OpenAI Codex was used to inspect history commits of this metric.

