### PR TITLE
[Bugfix] Handle nested dicts in RoPE _make_hashable for caching

### DIFF
--- a/vllm/model_executor/layers/rotary_embedding/__init__.py
+++ b/vllm/model_executor/layers/rotary_embedding/__init__.py
@@ -30,6 +30,14 @@ from .yarn_scaling_rope import YaRNScalingRotaryEmbedding
 _ROPE_DICT: dict[tuple[Any, ...], RotaryEmbedding] = {}
 
 
+def _make_hashable(obj: Any) -> Any:
+    if isinstance(obj, dict):
+        return tuple(sorted((k, _make_hashable(v)) for k, v in obj.items()))
+    if isinstance(obj, (list, tuple)):
+        return tuple(_make_hashable(x) for x in obj)
+    return obj
+
+
 def get_rope(
     head_size: int,
     max_position: int,
@@ -41,12 +49,7 @@ def get_rope(
     if dtype is None:
         dtype = torch.get_default_dtype()
     if rope_parameters is not None:
-        # Transforms every value that is a list into a tuple for caching calls
-        rope_parameters_tuple = {
-            k: tuple(v) if isinstance(v, list) else v
-            for k, v in rope_parameters.items()
-        }
-        rope_parameters_args = tuple(rope_parameters_tuple.items())
+        rope_parameters_args = _make_hashable(rope_parameters)
     else:
         rope_parameters_args = None
 


### PR DESCRIPTION
## Summary
- Models with nested `rope_parameters` dicts (e.g. Laguna's `rope_parameters.long_factor`) crash with `TypeError: unhashable type: 'dict'` when `get_rope()` tries to use them as cache keys
- Replace the shallow `{k: tuple(v) if list}` comprehension with a recursive `_make_hashable()` that handles arbitrarily nested dicts/lists/tuples

## Test plan
- [ ] Verify `get_rope()` caching works with nested `rope_parameters` (e.g. Laguna-S-2.1)
- [ ] Verify existing models with flat `rope_parameters` still cache correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)