### PR TITLE
[Bugfix] Add missing dflash_config to DSpark speculators config

### DIFF
--- a/vllm/transformers_utils/configs/speculators/algos.py
+++ b/vllm/transformers_utils/configs/speculators/algos.py
@@ -161,13 +161,18 @@ def update_dspark(config_dict: dict, pre_trained_config: dict) -> None:
 
     aux_layer_ids = config_dict["aux_hidden_state_layer_ids"]
     pre_trained_config["eagle_aux_hidden_state_layer_ids"] = aux_layer_ids
-    # DSpark indexes target layers as aux_id - 1 (matches the dense configs).
-    pre_trained_config["target_layer_ids"] = [i - 1 for i in aux_layer_ids]
+    target_layer_ids = [i - 1 for i in aux_layer_ids]
+    pre_trained_config["target_layer_ids"] = target_layer_ids
+
+    pre_trained_config["dflash_config"] = {
+        "mask_token_id": config_dict["mask_token_id"],
+        "target_layer_ids": target_layer_ids,
+        "causal": not config_dict.get("sliding_window_non_causal", True),
+    }
 
     for key in (
         "draft_vocab_size",
         "target_hidden_size",
-        "mask_token_id",
         "markov_rank",
         "markov_head_type",
         "block_size",


### PR DESCRIPTION
## Summary
- DSpark checkpoints need a `dflash_config` dict (with `mask_token_id`, `target_layer_ids`, `causal`) during config loading — DFlash's `update_dflash()` already sets this, but `update_dspark()` was missing it
- Without `dflash_config`, DSpark models fail at runtime when DFlash-style masking and layer extraction kicks in
- Also moves `mask_token_id` out of the generic key copy loop since it's now set inside `dflash_config`

## Test plan
- [ ] Load a DSpark checkpoint (e.g. `dspark_qwen3_8b_block7`) and verify `dflash_config` is present in the resolved config
- [ ] Run speculative decoding with a DSpark model end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)