### PR TITLE
[CI] Run basic fullgraph correctness on one GPU

### DIFF
--- a/.buildkite/test_areas/distributed.yaml
+++ b/.buildkite/test_areas/distributed.yaml
@@ -68,14 +68,12 @@ steps:
   - vllm/worker/worker_base.py
   - vllm/v1/engine/
   - vllm/v1/worker/
-  - tests/compile/fullgraph/test_basic_correctness.py
   - tests/compile/test_wrapper.py
   - tests/entrypoints/llm/test_collective_rpc.py
   commands:
   # https://github.com/NVIDIA/nccl/issues/1838
   - export NCCL_CUMEM_HOST_ENABLE=0
   - pytest -v -s entrypoints/llm/test_collective_rpc.py
-  - pytest -v -s ./compile/fullgraph/test_basic_correctness.py
   - pytest -v -s ./compile/test_wrapper.py
 
 - label: Distributed Torchrun + Shutdown Tests (2 GPUs)
@@ -163,13 +161,11 @@ steps:
   - vllm/distributed/
   - tests/distributed/test_pynccl
   - tests/distributed/test_events
-  - tests/compile/fullgraph/test_basic_correctness.py
   - tests/distributed/test_symm_mem_allreduce.py
   - tests/distributed/test_multiproc_executor.py
   commands:
   # https://github.com/NVIDIA/nccl/issues/1838
   - export NCCL_CUMEM_HOST_ENABLE=0
-  - pytest -v -s compile/fullgraph/test_basic_correctness.py
   - pytest -v -s distributed/test_pynccl.py
   - pytest -v -s distributed/test_events.py
   - pytest -v -s distributed/test_symm_mem_allreduce.py

--- a/tests/compile/fullgraph/test_basic_correctness.py
+++ b/tests/compile/fullgraph/test_basic_correctness.py
@@ -27,15 +27,6 @@ class TestSetting:
 @pytest.mark.parametrize(
     "test_setting",
     [
-        # basic llama model
-        TestSetting(
-            model="meta-llama/Llama-3.2-1B-Instruct",
-            model_args=["--max-model-len", "2048"],
-            pp_size=2,
-            tp_size=2,
-            attn_backend=ATTN_BACKEND,
-            method="generate",
-        ),
         # MoE model
         TestSetting(
             model="ibm-granite/granite-3.0-1b-a400m-instruct",
@@ -68,21 +59,12 @@ class TestSetting:
 def test_compile_correctness(
     test_setting: TestSetting,
 ):
-    # this test is run under multiple suits, with different GPUs.
-    # make sure we only run the test with correct CUDA devices.
-    # don't use "<", as it will duplicate the tests.
     model = test_setting.model
     model_args = test_setting.model_args
     pp_size = test_setting.pp_size
     tp_size = test_setting.tp_size
     attn_backend = test_setting.attn_backend
     method = test_setting.method
-    if current_platform.device_count() < pp_size * tp_size:
-        pytest.skip(
-            f"Need at least {pp_size}*{tp_size} CUDA gpus but got "
-            f"{current_platform.device_count()}"
-        )
-
     final_args = [
         *model_args,
         "-pp",


### PR DESCRIPTION
## Summary

- remove `test_basic_correctness.py` from the 2-GPU and 4-GPU distributed Buildkite steps
- remove the remaining PP=2, TP=2 parameter from that file
- keep the Granite and embedding coverage in the 1-GPU H200 fullgraph suite

## Why

PR #51074 replaced the only 2-GPU model in this test with a TP=1 Granite model. The test's permissive GPU-count check then caused the TP=1 cases to run redundantly in the 2-GPU and 4-GPU suites. The same Granite dummy-weight comparison fails on those workers because equal top-5 logprobs can select a different token at the cutoff, while the intended 1-GPU H200 suite passes.

This removes redundant multi-GPU execution instead of weakening the shared correctness comparator.

## Duplicate work

Searched open pull requests for `test_basic_correctness distributed compile`; no matching PR was found.

## Test plan

- `.venv/bin/pre-commit run --files tests/compile/fullgraph/test_basic_correctness.py .buildkite/test_areas/distributed.yaml` — passed
- `git diff --check` — passed
- `.venv/bin/python -m pytest tests/compile/fullgraph/test_basic_correctness.py --collect-only -q` — passed in the original checkout with 2 tests collected
- The fresh worktree's copied virtualenv could not repeat collection because its cached layer was missing `py` and then `typing_extensions`; no test code executed in that failed attempt

Model evaluation is not applicable because this only changes CI test selection.

AI assistance was used to investigate the CI overlap, prepare the change, and draft this PR.