### PR TITLE
[ROCm][Kimi-K3] Add opt-in gfx942 MXFP4-to-int4 conversion

### DIFF
--- a/tests/models/kimi_k3/test_gfx942_int4.py
+++ b/tests/models/kimi_k3/test_gfx942_int4.py
@@ -1,0 +1,104 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import sys
+from collections.abc import Callable
+from types import ModuleType, SimpleNamespace
+from unittest.mock import Mock, patch
+
+import pytest
+import torch
+
+from vllm.config.quantization import QuantizationConfigArgs
+from vllm.model_executor.layers.fused_moe import FusedMoEMethodBase
+from vllm.model_executor.layers.fused_moe.activation import MoEActivation
+from vllm.model_executor.layers.quantization.mxfp4 import (
+    Mxfp4MoEMethod,
+    _moe_weight_override_is_int4,
+    _use_k3_situ_int4_gfx942,
+)
+
+pytestmark = pytest.mark.cpu_test
+
+
+class _FakeRocmModule(ModuleType):
+    on_gfx942: Callable[[], bool]
+
+
+class _FakeAiterOpsModule(ModuleType):
+    rocm_aiter_ops: SimpleNamespace
+
+
+def _vllm_config(moe_weight: str | None):
+    quantization_config = (
+        None
+        if moe_weight is None
+        else QuantizationConfigArgs(moe={"weight": moe_weight})
+    )
+    return SimpleNamespace(
+        model_config=SimpleNamespace(quantization_config=quantization_config)
+    )
+
+
+@pytest.mark.parametrize(
+    ("moe_weight", "expected"),
+    [
+        (None, False),
+        ("mxfp4", False),
+        ("int4_per_group_32", True),
+    ],
+)
+def test_moe_weight_override_is_int4(monkeypatch, moe_weight, expected):
+    monkeypatch.setattr(
+        "vllm.config.get_current_vllm_config",
+        lambda: _vllm_config(moe_weight),
+    )
+    assert _moe_weight_override_is_int4() is expected
+
+
+@pytest.mark.parametrize("int4_requested", [False, True])
+def test_k3_situ_int4_gfx942_requires_explicit_override(int4_requested):
+    moe = SimpleNamespace(
+        activation=MoEActivation.SITU,
+        activation_situ_linear_beta=25.0,
+    )
+    fake_rocm = _FakeRocmModule("vllm.platforms.rocm")
+    fake_rocm.on_gfx942 = lambda: True
+    fake_aiter_ops = _FakeAiterOpsModule("vllm._aiter_ops")
+    fake_aiter_ops.rocm_aiter_ops = SimpleNamespace(is_fused_moe_enabled=lambda: True)
+    with (
+        patch("vllm.platforms.current_platform.is_rocm", return_value=True),
+        patch.dict(
+            sys.modules,
+            {
+                "vllm.platforms.rocm": fake_rocm,
+                "vllm._aiter_ops": fake_aiter_ops,
+            },
+        ),
+        patch(
+            "vllm.model_executor.layers.quantization.mxfp4."
+            "_moe_weight_override_is_int4",
+            return_value=int4_requested,
+        ),
+    ):
+        assert _use_k3_situ_int4_gfx942(moe) is int4_requested
+
+
+def test_gfx942_int4_preserves_native_k3_intermediate_size():
+    method = object.__new__(Mxfp4MoEMethod)
+    method.is_k3_situ_int4_gfx942 = True
+
+    with patch.object(
+        FusedMoEMethodBase,
+        "maybe_roundup_sizes",
+        return_value=(7168, 384),
+    ):
+        hidden_size, intermediate_size = method.maybe_roundup_sizes(
+            hidden_size=7168,
+            intermediate_size_per_partition=384,
+            act_dtype=torch.bfloat16,
+            moe_parallel_config=Mock(),
+        )
+
+    assert hidden_size == 7168
+    assert intermediate_size == 384

--- a/tests/models/kimi_k3/test_gfx942_int4.py
+++ b/tests/models/kimi_k3/test_gfx942_int4.py
@@ -4,16 +4,13 @@
 import sys
 from collections.abc import Callable
 from types import ModuleType, SimpleNamespace
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 import pytest
-import torch
 
 from vllm.config.quantization import QuantizationConfigArgs
-from vllm.model_executor.layers.fused_moe import FusedMoEMethodBase
 from vllm.model_executor.layers.fused_moe.activation import MoEActivation
 from vllm.model_executor.layers.quantization.mxfp4 import (
-    Mxfp4MoEMethod,
     _moe_weight_override_is_int4,
     _use_k3_situ_int4_gfx942,
 )
@@ -82,23 +79,3 @@ def test_k3_situ_int4_gfx942_requires_explicit_override(int4_requested):
         ),
     ):
         assert _use_k3_situ_int4_gfx942(moe) is int4_requested
-
-
-def test_gfx942_int4_preserves_native_k3_intermediate_size():
-    method = object.__new__(Mxfp4MoEMethod)
-    method.is_k3_situ_int4_gfx942 = True
-
-    with patch.object(
-        FusedMoEMethodBase,
-        "maybe_roundup_sizes",
-        return_value=(7168, 384),
-    ):
-        hidden_size, intermediate_size = method.maybe_roundup_sizes(
-            hidden_size=7168,
-            intermediate_size_per_partition=384,
-            act_dtype=torch.bfloat16,
-            moe_parallel_config=Mock(),
-        )
-
-    assert hidden_size == 7168
-    assert intermediate_size == 384

--- a/tests/quantization/test_quantization_config_args.py
+++ b/tests/quantization/test_quantization_config_args.py
@@ -15,6 +15,7 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
     kFp8DynamicTokenSym,
     kFp8Static128BlockSym,
     kFp8StaticTensorSym,
+    kInt4Static32,
     kInt8StaticChannelSym,
     kMxfp8Dynamic,
 )
@@ -31,6 +32,12 @@ def test_quant_spec_resolves_string_to_quant_key():
 def test_quant_spec_accepts_quant_key_directly():
     spec = QuantSpec(weight=kFp8StaticTensorSym)
     assert spec.weight is kFp8StaticTensorSym
+    assert spec.activation is None
+
+
+def test_quant_spec_resolves_groupwise_int4_weight():
+    spec = QuantSpec(weight="int4_per_group_32")
+    assert spec.weight == kInt4Static32
     assert spec.activation is None
 
 

--- a/tests/quantization/test_quantization_config_args.py
+++ b/tests/quantization/test_quantization_config_args.py
@@ -22,6 +22,7 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
     kFp8DynamicTokenSym,
     kFp8Static128BlockSym,
     kFp8StaticTensorSym,
+    kInt4Static32,
     kInt8StaticChannelSym,
     kMxfp8Dynamic,
 )
@@ -43,6 +44,12 @@ def test_quant_spec_accepts_quant_key_directly():
 
 def test_quant_spec_string_representation_uses_quantization_name():
     assert str(QuantSpec(weight="mxfp4")) == "mxfp4"
+
+
+def test_quant_spec_resolves_groupwise_int4_weight():
+    spec = QuantSpec(weight="int4_per_group_32")
+    assert spec.weight == kInt4Static32
+    assert spec.activation is None
 
 
 def test_quant_spec_rejects_unknown_name():

--- a/vllm/config/quantization.py
+++ b/vllm/config/quantization.py
@@ -15,6 +15,7 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
     kFp8Static128BlockSym,
     kFp8StaticChannelSym,
     kFp8StaticTensorSym,
+    kInt4Static32,
     kInt8StaticChannelSym,
     kMxfp4Dynamic,
     kMxfp8Dynamic,
@@ -32,6 +33,10 @@ QUANT_KEY_NAMES: dict[str, QuantKey] = {
     "mxfp8": kMxfp8Dynamic,
     "mxfp4": kMxfp4Dynamic,
     "int8_per_channel_static": kInt8StaticChannelSym,
+    # Groupwise int4 with a 32-element group. Used by the Kimi-K3 gfx942
+    # path, where MXFP4 experts are requantized so AITER's bf16 x int4
+    # kernels can run on hardware without a scaled MXFP4 MFMA.
+    "int4_per_group_32": kInt4Static32,
 }
 
 

--- a/vllm/config/quantization.py
+++ b/vllm/config/quantization.py
@@ -22,6 +22,7 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
     kFp8Static128BlockSym,
     kFp8StaticChannelSym,
     kFp8StaticTensorSym,
+    kInt4Static32,
     kInt8StaticChannelSym,
     kMxfp4Dynamic,
     kMxfp4Static,
@@ -40,6 +41,10 @@ QUANT_KEY_NAMES: dict[str, QuantKey] = {
     "mxfp8": kMxfp8Dynamic,
     "mxfp4": kMxfp4Dynamic,
     "int8_per_channel_static": kInt8StaticChannelSym,
+    # Groupwise int4 with a 32-element group. Used by the Kimi-K3 gfx942
+    # path, where MXFP4 experts are requantized so AITER's bf16 x int4
+    # kernels can run on hardware without a scaled MXFP4 MFMA.
+    "int4_per_group_32": kInt4Static32,
 }
 
 

--- a/vllm/model_executor/layers/fused_moe/experts/rocm_aiter_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/rocm_aiter_moe.py
@@ -472,10 +472,12 @@ class AiterExperts(mk.FusedMoEExpertsModular):
         ]
         if (weight_key, activation_key) not in SUPPORTED_W_A:
             return False
+        # CK MXFP4 MoE kernels are gfx950-only, but Kimi-K3's SiTU path runs
+        # via FlyDSL on gfx942 (MI325X) as well, so allow gfx942 here too.
         if weight_key == kMxfp4Static:
-            from vllm.platforms.rocm import on_gfx950, on_gfx1250
+            from vllm.platforms.rocm import on_gfx942, on_gfx950, on_gfx1250
 
-            if not on_gfx950() or on_gfx1250():
+            if not (on_gfx950() or on_gfx942()) or on_gfx1250():
                 return False
         return True
 
@@ -486,6 +488,7 @@ class AiterExperts(mk.FusedMoEExpertsModular):
             MoEActivation.GELU,
             MoEActivation.SWIGLUOAI,
             MoEActivation.SWIGLUOAI_UNINTERLEAVE,
+            MoEActivation.SITU,
         ]
 
     @staticmethod

--- a/vllm/model_executor/layers/fused_moe/experts/rocm_aiter_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/rocm_aiter_moe.py
@@ -494,10 +494,12 @@ class AiterExperts(mk.FusedMoEExpertsModular):
         ]
         if (weight_key, activation_key) not in SUPPORTED_W_A:
             return False
+        # CK MXFP4 MoE kernels are gfx950-only, but Kimi-K3's SiTU path runs
+        # via FlyDSL on gfx942 (MI325X) as well, so allow gfx942 here too.
         if weight_key == kMxfp4Static:
-            from vllm.platforms.rocm import on_gfx950, on_gfx1250
+            from vllm.platforms.rocm import on_gfx942, on_gfx950, on_gfx1250
 
-            if not on_gfx950() or on_gfx1250():
+            if not (on_gfx950() or on_gfx942()) or on_gfx1250():
                 return False
         return True
 
@@ -509,6 +511,7 @@ class AiterExperts(mk.FusedMoEExpertsModular):
             MoEActivation.SITU,
             MoEActivation.SWIGLUOAI,
             MoEActivation.SWIGLUOAI_UNINTERLEAVE,
+            MoEActivation.SITU,
         ]
 
     @staticmethod

--- a/vllm/model_executor/layers/fused_moe/experts/rocm_aiter_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/rocm_aiter_moe.py
@@ -511,7 +511,6 @@ class AiterExperts(mk.FusedMoEExpertsModular):
             MoEActivation.SITU,
             MoEActivation.SWIGLUOAI,
             MoEActivation.SWIGLUOAI_UNINTERLEAVE,
-            MoEActivation.SITU,
         ]
 
     @staticmethod

--- a/vllm/model_executor/layers/quantization/mxfp4.py
+++ b/vllm/model_executor/layers/quantization/mxfp4.py
@@ -511,7 +511,7 @@ def _use_k3_situ_int4_gfx942(moe: FusedMoEConfig) -> bool:
     there. Requantizing to groupwise int4 lets AITER's bf16 x int4 FlyDSL path
     serve the model, at the cost of a lossy weight conversion. That trade is the
     user's to make, so it is opt-in through
-    ``--quantization-config.moe.weight int4`` rather than inferred from the
+    ``--quantization-config.moe.weight int4_per_group_32`` rather than inferred from the
     hardware.
     """
     from vllm.platforms import current_platform
@@ -534,8 +534,8 @@ def _use_k3_situ_int4_gfx942(moe: FusedMoEConfig) -> bool:
 def _moe_weight_override_is_int4() -> bool:
     """True when the user asked for int4 MoE weights on the command line.
 
-    Set with ``--quantization-config.moe.weight int4``. The requantization is
-    lossy, so it never happens unless it was requested.
+    Set with ``--quantization-config.moe.weight int4_per_group_32``. The
+    requantization is lossy, so it never happens unless it was requested.
     """
     from vllm.config import get_current_vllm_config
 
@@ -545,7 +545,13 @@ def _moe_weight_override_is_int4() -> bool:
     quant_args = getattr(vllm_config.model_config, "quantization_config", None)
     moe_spec = getattr(quant_args, "moe", None)
     weight = getattr(moe_spec, "weight", None)
-    return str(weight) == "int4"
+    if weight is None:
+        return False
+    from vllm.model_executor.layers.quantization.utils.quant_utils import (
+        kInt4Static32,
+    )
+
+    return weight == kInt4Static32
 
 
 class Mxfp4MoEMethod(FusedMoEMethodBase):

--- a/vllm/model_executor/layers/quantization/mxfp4.py
+++ b/vllm/model_executor/layers/quantization/mxfp4.py
@@ -628,13 +628,6 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
             act_dtype=act_dtype,
             moe_parallel_config=moe_parallel_config,
         )
-        if self.is_k3_situ_int4_gfx942:
-            # K3's AITER A16W4 kernel handles K3's native intermediate size
-            # (moe_intermediate 3072; e.g. 384/partition at TP8); the generic
-            # 256 round-up would inflate weights and OOM. AITER's
-            # resolve_flydsl_stage1_tile_n() already downgrades tile_n 256->128
-            # for such shapes, so 384 is served natively.
-            return hidden_size, intermediate_size_per_partition
         return mxfp4_round_up_hidden_size_and_intermediate_size(
             self.mxfp4_backend,
             hidden_size,
@@ -883,24 +876,6 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
         )
         w2_scale = e8m0_shuffle(w2_scale_raw.view(-1, w2_scale_raw.shape[-1]))
         return w13, w2, w13_scale, w2_scale
-
-        replace_parameter(layer, "w13_weight", w13)
-        replace_parameter(layer, "w2_weight", w2)
-        replace_parameter(layer, "w13_weight_scale", w13_scale)
-        replace_parameter(layer, "w2_weight_scale", w2_scale)
-        layer.w13_weight.is_shuffled = True
-        layer.w2_weight.is_shuffled = True
-
-        self.moe_quant_config = self.get_fused_moe_quant_config(layer)
-        if self.moe_quant_config is not None and self.experts_cls is not None:
-            self.moe_kernel = make_mxfp4_moe_kernel(
-                moe_quant_config=self.moe_quant_config,
-                moe_config=self.moe,
-                mxfp4_backend=self.mxfp4_backend,
-                experts_cls=self.experts_cls,
-                routing_tables=layer._expert_routing_tables(),
-                layer=layer,
-            )
 
     def _setup_kernel_k3_situ_gfx942(self, layer: RoutedExperts) -> None:
         # gfx942 has no native MXFP4 matmul. Convert the weights to groupwise

--- a/vllm/model_executor/layers/quantization/mxfp4.py
+++ b/vllm/model_executor/layers/quantization/mxfp4.py
@@ -504,6 +504,50 @@ def _use_k3_situ_aiter(moe: FusedMoEConfig) -> bool:
     )
 
 
+def _use_k3_situ_int4_gfx942(moe: FusedMoEConfig) -> bool:
+    """Whether Kimi-K3's SiTU MXFP4 experts should be requantized to int4 on gfx942.
+
+    gfx942 has no scaled MXFP4 MFMA, so the native MXFP4 kernels do not compile
+    there. Requantizing to groupwise int4 lets AITER's bf16 x int4 FlyDSL path
+    serve the model, at the cost of a lossy weight conversion. That trade is the
+    user's to make, so it is opt-in through
+    ``--quantization-config.moe.weight int4`` rather than inferred from the
+    hardware.
+    """
+    from vllm.platforms import current_platform
+
+    if not current_platform.is_rocm():
+        return False
+    from vllm._aiter_ops import rocm_aiter_ops
+    from vllm.model_executor.layers.fused_moe.activation import MoEActivation
+    from vllm.platforms.rocm import on_gfx942
+
+    return (
+        rocm_aiter_ops.is_fused_moe_enabled()
+        and on_gfx942()
+        and moe.activation == MoEActivation.SITU
+        and moe.activation_situ_linear_beta is not None
+        and _moe_weight_override_is_int4()
+    )
+
+
+def _moe_weight_override_is_int4() -> bool:
+    """True when the user asked for int4 MoE weights on the command line.
+
+    Set with ``--quantization-config.moe.weight int4``. The requantization is
+    lossy, so it never happens unless it was requested.
+    """
+    from vllm.config import get_current_vllm_config
+
+    vllm_config = get_current_vllm_config()
+    if vllm_config is None:
+        return False
+    quant_args = getattr(vllm_config.model_config, "quantization_config", None)
+    moe_spec = getattr(quant_args, "moe", None)
+    weight = getattr(moe_spec, "weight", None)
+    return str(weight) == "int4"
+
+
 class Mxfp4MoEMethod(FusedMoEMethodBase):
     """MXFP4 MoE quantization method."""
 
@@ -511,8 +555,9 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
         super().__init__(moe)
         self.weight_dtype = "mxfp4"
         self.is_k3_situ_aiter = _use_k3_situ_aiter(moe)
+        self.is_k3_situ_int4_gfx942 = _use_k3_situ_int4_gfx942(moe)
         self.experts_cls: type[mk.FusedMoEExperts] | None
-        if self.is_k3_situ_aiter:
+        if self.is_k3_situ_aiter or self.is_k3_situ_int4_gfx942:
             self.mxfp4_backend = Mxfp4MoeBackend.AITER_MXFP4_BF16
             self.experts_cls = backend_to_kernel_cls(self.mxfp4_backend)[0]
             logger.info_once("Using AITER_MXFP4_BF16 for Kimi-K3 SiTU MXFP4 MoE.")
@@ -818,7 +863,99 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
         w2_scale = e8m0_shuffle(w2_scale_raw.view(-1, w2_scale_raw.shape[-1]))
         return w13, w2, w13_scale, w2_scale
 
+    def _setup_kernel_k3_situ_gfx942(self, layer: RoutedExperts) -> None:
+        # gfx942 has no native MXFP4 matmul. Convert the weights to groupwise
+        # int4 once at load time for AITER's existing bf16 x int4 FlyDSL path.
+        import inspect
+
+        from aiter.ops.flydsl.kernels.moe_gemm_2stage import compile_moe_gemm1
+
+        # Before ROCm/aiter#4471 the packed-int4 stage1 dropped the requested
+        # activation and hardcoded SiLU, so K3 served fluent text while
+        # computing the wrong function. Refuse instead of repeating that.
+        if "act" not in inspect.signature(compile_moe_gemm1).parameters:
+            raise RuntimeError(
+                "This AITER build ignores the SiTUv2 activation on the "
+                "packed-int4 MoE path and would silently compute SiLU. "
+                "Rebuild with an AITER that includes ROCm/aiter#4471."
+            )
+
+        from aiter import dtypes as aiter_dtypes
+        from aiter.ops.quant import per_1x32_i4_quant
+        from aiter.ops.shuffle import (
+            pack_int8_to_packed_int4,
+            shuffle_scale_for_int4,
+            shuffle_weight,
+        )
+        from aiter.utility import fp4_utils
+
+        fp4_dtype = torch.float4_e2m1fn_x2
+        e8m0_dtype = torch.float8_e8m0fnu
+
+        def convert(
+            weight: torch.nn.Parameter,
+            scale: torch.nn.Parameter,
+        ) -> tuple[torch.Tensor, torch.Tensor]:
+            weight_f32 = fp4_utils.mxfp4_to_f32(weight.data.view(fp4_dtype))
+            scale_f32 = fp4_utils.e8m0_to_f32(scale.data.view(e8m0_dtype))
+            num_experts, output_size, input_size = weight_f32.shape
+            weight_bf16 = (
+                (
+                    weight_f32.view(
+                        num_experts, output_size, input_size // 32, 32
+                    )
+                    * scale_f32.view(
+                        num_experts, output_size, input_size // 32, 1
+                    )
+                )
+                .view(num_experts, output_size, input_size)
+                .to(torch.bfloat16)
+            )
+            del weight_f32, scale_f32
+
+            weight_int4, weight_scale = per_1x32_i4_quant(weight_bf16)
+            del weight_bf16
+            weight_int4 = weight_int4.view(aiter_dtypes.i4x2).view(
+                num_experts, output_size, input_size
+            )
+            weight_packed = pack_int8_to_packed_int4(
+                shuffle_weight(weight_int4.view(aiter_dtypes.i8), (16, 16))
+            )
+            weight_packed = weight_packed.view(
+                num_experts, output_size, input_size // 2
+            ).view(aiter_dtypes.i4x2)
+            weight_scale = (
+                shuffle_scale_for_int4(weight_scale, group_size=32)
+                .view(-1)
+                .contiguous()
+            )
+            return weight_packed, weight_scale
+
+        w13, w13_scale = convert(layer.w13_weight, layer.w13_weight_scale)
+        w2, w2_scale = convert(layer.w2_weight, layer.w2_weight_scale)
+        replace_parameter(layer, "w13_weight", w13)
+        replace_parameter(layer, "w2_weight", w2)
+        replace_parameter(layer, "w13_weight_scale", w13_scale)
+        replace_parameter(layer, "w2_weight_scale", w2_scale)
+        layer.w13_weight.is_shuffled = True
+        layer.w2_weight.is_shuffled = True
+
+        self.moe_quant_config = self.get_fused_moe_quant_config(layer)
+        if self.moe_quant_config is not None and self.experts_cls is not None:
+            self.moe_kernel = make_mxfp4_moe_kernel(
+                moe_quant_config=self.moe_quant_config,
+                moe_config=self.moe,
+                mxfp4_backend=self.mxfp4_backend,
+                experts_cls=self.experts_cls,
+                routing_tables=layer._expert_routing_tables(),
+                layer=layer,
+            )
+
     def process_weights_after_loading(self, layer):
+        if self.is_k3_situ_int4_gfx942:
+            self._setup_kernel_k3_situ_gfx942(layer)
+            return
+
         w13 = layer.w13_weight
         w2 = layer.w2_weight
         w13_scale = layer.w13_weight_scale

--- a/vllm/model_executor/layers/quantization/mxfp4.py
+++ b/vllm/model_executor/layers/quantization/mxfp4.py
@@ -566,7 +566,15 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
         if self.is_k3_situ_aiter or self.is_k3_situ_int4_gfx942:
             self.mxfp4_backend = Mxfp4MoeBackend.AITER_MXFP4_BF16
             self.experts_cls = backend_to_kernel_cls(self.mxfp4_backend)[0]
-            logger.info_once("Using AITER_MXFP4_BF16 for Kimi-K3 SiTU MXFP4 MoE.")
+            if self.is_k3_situ_int4_gfx942:
+                logger.warning_once(
+                    "Requantizing Kimi-K3 MXFP4 experts to groupwise int4 "
+                    "for gfx942. This conversion is lossy and was explicitly "
+                    "enabled by --quantization-config.moe.weight "
+                    "int4_per_group_32."
+                )
+            else:
+                logger.info_once("Using AITER_MXFP4_BF16 for Kimi-K3 SiTU MXFP4 MoE.")
             from vllm._aiter_ops import rocm_aiter_ops
 
             if rocm_aiter_ops.is_fused_moe_situv2_a8w4_enabled():
@@ -1003,17 +1011,21 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
                         dtype=chunk_scale.dtype,
                         device=chunk_scale.device,
                     )
+                assert out_packed is not None
+                assert out_scale is not None
                 out_packed[lo:hi].copy_(chunk_packed)
                 out_scale[lo * scale_stride : hi * scale_stride].copy_(chunk_scale)
                 del weight_packed, weight_scale, chunk_packed, chunk_scale
-                torch.cuda.empty_cache()
+                torch.accelerator.empty_cache()
 
             # Every chunk has been read, so let the source storage go before
             # the caller converts the next tensor.
             del w_all, s_all
+            assert out_packed is not None
+            assert out_scale is not None
             weight.data = torch.empty(0, dtype=torch.uint8, device=out_packed.device)
             scale.data = torch.empty(0, dtype=torch.uint8, device=out_packed.device)
-            torch.cuda.empty_cache()
+            torch.accelerator.empty_cache()
             return out_packed, out_scale
 
         # Install each result before converting the next tensor so only one
@@ -1022,13 +1034,13 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
         replace_parameter(layer, "w13_weight", w13)
         replace_parameter(layer, "w13_weight_scale", w13_scale)
         del w13, w13_scale
-        torch.cuda.empty_cache()
+        torch.accelerator.empty_cache()
 
         w2, w2_scale = convert(layer.w2_weight, layer.w2_weight_scale)
         replace_parameter(layer, "w2_weight", w2)
         replace_parameter(layer, "w2_weight_scale", w2_scale)
         del w2, w2_scale
-        torch.cuda.empty_cache()
+        torch.accelerator.empty_cache()
         layer.w13_weight.is_shuffled = True
         layer.w2_weight.is_shuffled = True
 

--- a/vllm/model_executor/layers/quantization/mxfp4.py
+++ b/vllm/model_executor/layers/quantization/mxfp4.py
@@ -916,51 +916,112 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
         fp4_dtype = torch.float4_e2m1fn_x2
         e8m0_dtype = torch.float8_e8m0fnu
 
+        # The dequant chain cannot run in place: mxfp4_to_f32 does a
+        # repeat_interleave to split the packed nibbles, then an f32 LUT
+        # gather, so the working tensor grows 8x over the packed weight
+        # before per_1x32_i4_quant shrinks it again. Materializing that for
+        # a whole expert tensor peaks well above 20 GiB per rank, which does
+        # not fit once the weights are resident. Convert a slice of experts
+        # at a time and free each slice before the next, so the transient is
+        # bounded by _CONVERT_CHUNK / num_experts of the full tensor.
+        _CONVERT_CHUNK = 8
+
         def convert(
             weight: torch.nn.Parameter,
             scale: torch.nn.Parameter,
         ) -> tuple[torch.Tensor, torch.Tensor]:
-            weight_f32 = fp4_utils.mxfp4_to_f32(weight.data.view(fp4_dtype))
-            scale_f32 = fp4_utils.e8m0_to_f32(scale.data.view(e8m0_dtype))
-            num_experts, output_size, input_size = weight_f32.shape
-            weight_bf16 = (
-                (
-                    weight_f32.view(
-                        num_experts, output_size, input_size // 32, 32
+            # Releases its source parameter before returning: the packed int4
+            # output is the same size as the packed MXFP4 source, so holding
+            # both doubles the expert footprint. Under expert parallel each
+            # rank owns 1/ep_size of the experts and both fit, but under pure
+            # tensor parallel every rank holds all experts and the second copy
+            # does not. The caller must install each result before converting
+            # the next tensor.
+            w_all = weight.data.view(fp4_dtype)
+            s_all = scale.data.view(e8m0_dtype)
+            num_experts = w_all.shape[0]
+
+            # Preallocate the outputs and write each chunk into its slice.
+            # Accumulating chunks in a list and torch.cat-ing at the end holds
+            # the whole result twice at the join, which is what the transient
+            # chunking was meant to avoid in the first place.
+            out_packed: torch.Tensor | None = None
+            out_scale: torch.Tensor | None = None
+            scale_stride = 0
+            for lo in range(0, num_experts, _CONVERT_CHUNK):
+                hi = min(lo + _CONVERT_CHUNK, num_experts)
+                weight_f32 = fp4_utils.mxfp4_to_f32(w_all[lo:hi])
+                scale_f32 = fp4_utils.e8m0_to_f32(s_all[lo:hi])
+                chunk_experts, output_size, input_size = weight_f32.shape
+                weight_bf16 = (
+                    (
+                        weight_f32.view(
+                            chunk_experts, output_size, input_size // 32, 32
+                        )
+                        * scale_f32.view(
+                            chunk_experts, output_size, input_size // 32, 1
+                        )
                     )
-                    * scale_f32.view(
-                        num_experts, output_size, input_size // 32, 1
-                    )
+                    .view(chunk_experts, output_size, input_size)
+                    .to(torch.bfloat16)
                 )
-                .view(num_experts, output_size, input_size)
-                .to(torch.bfloat16)
-            )
-            del weight_f32, scale_f32
+                del weight_f32, scale_f32
 
-            weight_int4, weight_scale = per_1x32_i4_quant(weight_bf16)
-            del weight_bf16
-            weight_int4 = weight_int4.view(aiter_dtypes.i4x2).view(
-                num_experts, output_size, input_size
-            )
-            weight_packed = pack_int8_to_packed_int4(
-                shuffle_weight(weight_int4.view(aiter_dtypes.i8), (16, 16))
-            )
-            weight_packed = weight_packed.view(
-                num_experts, output_size, input_size // 2
-            ).view(aiter_dtypes.i4x2)
-            weight_scale = (
-                shuffle_scale_for_int4(weight_scale, group_size=32)
-                .view(-1)
-                .contiguous()
-            )
-            return weight_packed, weight_scale
+                weight_int4, weight_scale = per_1x32_i4_quant(weight_bf16)
+                del weight_bf16
+                weight_int4 = weight_int4.view(aiter_dtypes.i4x2).view(
+                    chunk_experts, output_size, input_size
+                )
+                weight_packed = pack_int8_to_packed_int4(
+                    shuffle_weight(weight_int4.view(aiter_dtypes.i8), (16, 16))
+                )
+                del weight_int4
+                chunk_packed = weight_packed.view(
+                    chunk_experts, output_size, input_size // 2
+                ).view(aiter_dtypes.i4x2)
+                chunk_scale = (
+                    shuffle_scale_for_int4(weight_scale, group_size=32)
+                    .view(-1)
+                    .contiguous()
+                )
+                if out_packed is None:
+                    out_packed = torch.empty(
+                        (num_experts,) + tuple(chunk_packed.shape[1:]),
+                        dtype=chunk_packed.dtype,
+                        device=chunk_packed.device,
+                    )
+                    scale_stride = chunk_scale.numel() // chunk_experts
+                    out_scale = torch.empty(
+                        num_experts * scale_stride,
+                        dtype=chunk_scale.dtype,
+                        device=chunk_scale.device,
+                    )
+                out_packed[lo:hi].copy_(chunk_packed)
+                out_scale[lo * scale_stride : hi * scale_stride].copy_(chunk_scale)
+                del weight_packed, weight_scale, chunk_packed, chunk_scale
+                torch.cuda.empty_cache()
 
+            # Every chunk has been read, so let the source storage go before
+            # the caller converts the next tensor.
+            del w_all, s_all
+            weight.data = torch.empty(0, dtype=torch.uint8, device=out_packed.device)
+            scale.data = torch.empty(0, dtype=torch.uint8, device=out_packed.device)
+            torch.cuda.empty_cache()
+            return out_packed, out_scale
+
+        # Install each result before converting the next tensor so only one
+        # source is ever live alongside its output.
         w13, w13_scale = convert(layer.w13_weight, layer.w13_weight_scale)
-        w2, w2_scale = convert(layer.w2_weight, layer.w2_weight_scale)
         replace_parameter(layer, "w13_weight", w13)
-        replace_parameter(layer, "w2_weight", w2)
         replace_parameter(layer, "w13_weight_scale", w13_scale)
+        del w13, w13_scale
+        torch.cuda.empty_cache()
+
+        w2, w2_scale = convert(layer.w2_weight, layer.w2_weight_scale)
+        replace_parameter(layer, "w2_weight", w2)
         replace_parameter(layer, "w2_weight_scale", w2_scale)
+        del w2, w2_scale
+        torch.cuda.empty_cache()
         layer.w13_weight.is_shuffled = True
         layer.w2_weight.is_shuffled = True
 

--- a/vllm/model_executor/layers/quantization/mxfp4.py
+++ b/vllm/model_executor/layers/quantization/mxfp4.py
@@ -863,6 +863,24 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
         w2_scale = e8m0_shuffle(w2_scale_raw.view(-1, w2_scale_raw.shape[-1]))
         return w13, w2, w13_scale, w2_scale
 
+        replace_parameter(layer, "w13_weight", w13)
+        replace_parameter(layer, "w2_weight", w2)
+        replace_parameter(layer, "w13_weight_scale", w13_scale)
+        replace_parameter(layer, "w2_weight_scale", w2_scale)
+        layer.w13_weight.is_shuffled = True
+        layer.w2_weight.is_shuffled = True
+
+        self.moe_quant_config = self.get_fused_moe_quant_config(layer)
+        if self.moe_quant_config is not None and self.experts_cls is not None:
+            self.moe_kernel = make_mxfp4_moe_kernel(
+                moe_quant_config=self.moe_quant_config,
+                moe_config=self.moe,
+                mxfp4_backend=self.mxfp4_backend,
+                experts_cls=self.experts_cls,
+                routing_tables=layer._expert_routing_tables(),
+                layer=layer,
+            )
+
     def _setup_kernel_k3_situ_gfx942(self, layer: RoutedExperts) -> None:
         # gfx942 has no native MXFP4 matmul. Convert the weights to groupwise
         # int4 once at load time for AITER's existing bf16 x int4 FlyDSL path.

--- a/vllm/model_executor/layers/quantization/mxfp4.py
+++ b/vllm/model_executor/layers/quantization/mxfp4.py
@@ -620,6 +620,13 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
             act_dtype=act_dtype,
             moe_parallel_config=moe_parallel_config,
         )
+        if self.is_k3_situ_int4_gfx942:
+            # K3's AITER A16W4 kernel handles K3's native intermediate size
+            # (moe_intermediate 3072; e.g. 384/partition at TP8); the generic
+            # 256 round-up would inflate weights and OOM. AITER's
+            # resolve_flydsl_stage1_tile_n() already downgrades tile_n 256->128
+            # for such shapes, so 384 is served natively.
+            return hidden_size, intermediate_size_per_partition
         return mxfp4_round_up_hidden_size_and_intermediate_size(
             self.mxfp4_backend,
             hidden_size,

--- a/vllm/model_executor/layers/quantization/mxfp4.py
+++ b/vllm/model_executor/layers/quantization/mxfp4.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import os
+
 import torch
 
 from vllm.logger import init_logger
@@ -21,6 +23,7 @@ from vllm.model_executor.layers.fused_moe.moe_output import UnfinalizedMoEOutput
 from vllm.model_executor.layers.fused_moe.oracle.mxfp4 import (
     TRITON_BACKENDS,
     Mxfp4MoeBackend,
+    backend_to_kernel_cls,
     convert_gpt_oss_weight_to_mxfp4_moe_kernel_format,
     convert_weight_to_mxfp4_moe_kernel_format,
     make_mxfp4_moe_kernel,

--- a/vllm/model_executor/layers/quantization/mxfp4.py
+++ b/vllm/model_executor/layers/quantization/mxfp4.py
@@ -880,20 +880,21 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
             self.moe_kernel.fused_experts.process_weights_after_loading(layer)
 
     def _setup_kernel_k3_situ_gfx942(self, layer: RoutedExperts) -> None:
-        # gfx942 has no native MXFP4 matmul. Convert the weights to groupwise
-        # int4 once at load time for AITER's existing bf16 x int4 FlyDSL path.
+        # Convert the weights to groupwise int4 once at load time for AITER's
+        # replacement bf16 x int4 FlyDSL path.
         import inspect
 
-        from aiter.ops.flydsl.kernels.moe_gemm_2stage import compile_moe_gemm1
+        from aiter.ops.flydsl.kernels.moe_2stage_a16wmix import (
+            flydsl_a16w4_gemm1,
+        )
 
-        # Before ROCm/aiter#4471 the packed-int4 stage1 dropped the requested
-        # activation and hardcoded SiLU, so K3 served fluent text while
-        # computing the wrong function. Refuse instead of repeating that.
-        if "act" not in inspect.signature(compile_moe_gemm1).parameters:
+        # Refuse any AITER build whose replacement int4 stage1 cannot apply the
+        # requested SiTUv2 activation.
+        if "act" not in inspect.signature(flydsl_a16w4_gemm1).parameters:
             raise RuntimeError(
                 "This AITER build ignores the SiTUv2 activation on the "
-                "packed-int4 MoE path and would silently compute SiLU. "
-                "Rebuild with an AITER that includes ROCm/aiter#4471."
+                "replacement packed-int4 MoE path and would silently compute "
+                "SiLU. Rebuild with the replacement A16W4/int4 pipeline."
             )
 
         from aiter import dtypes as aiter_dtypes

--- a/vllm/model_executor/layers/quantization/mxfp4.py
+++ b/vllm/model_executor/layers/quantization/mxfp4.py
@@ -475,6 +475,73 @@ class GptOssMxfp4MoEMethod(FusedMoEMethodBase):
         )
 
 
+def _use_k3_situ_aiter(moe: FusedMoEConfig) -> bool:
+    """Whether Kimi-K3's SiTU MXFP4 MoE should use the AITER A16W4 kernel.
+
+    K3 is weight-only MXFP4 (W4A16) with SiTU activation, which the generic
+    MXFP4 backend selector does not cover; route it to AITER on gfx950.
+    """
+    from vllm.platforms import current_platform
+
+    if not current_platform.is_rocm():
+        return False
+    from vllm._aiter_ops import rocm_aiter_ops
+    from vllm.model_executor.layers.fused_moe.activation import MoEActivation
+    from vllm.platforms.rocm import on_gfx950
+
+    return (
+        rocm_aiter_ops.is_fused_moe_enabled()
+        and on_gfx950()
+        and moe.activation == MoEActivation.SITU
+        and moe.activation_situ_linear_beta is not None
+        and rocm_aiter_ops.get_aiter_activation_type("situ") is not None
+    )
+
+
+def _use_k3_situ_int4_gfx942(moe: FusedMoEConfig) -> bool:
+    """Whether Kimi-K3's SiTU MXFP4 experts should be requantized to int4 on gfx942.
+
+    gfx942 has no scaled MXFP4 MFMA, so the native MXFP4 kernels do not compile
+    there. Requantizing to groupwise int4 lets AITER's bf16 x int4 FlyDSL path
+    serve the model, at the cost of a lossy weight conversion. That trade is the
+    user's to make, so it is opt-in through
+    ``--quantization-config.moe.weight int4`` rather than inferred from the
+    hardware.
+    """
+    from vllm.platforms import current_platform
+
+    if not current_platform.is_rocm():
+        return False
+    from vllm._aiter_ops import rocm_aiter_ops
+    from vllm.model_executor.layers.fused_moe.activation import MoEActivation
+    from vllm.platforms.rocm import on_gfx942
+
+    return (
+        rocm_aiter_ops.is_fused_moe_enabled()
+        and on_gfx942()
+        and moe.activation == MoEActivation.SITU
+        and moe.activation_situ_linear_beta is not None
+        and _moe_weight_override_is_int4()
+    )
+
+
+def _moe_weight_override_is_int4() -> bool:
+    """True when the user asked for int4 MoE weights on the command line.
+
+    Set with ``--quantization-config.moe.weight int4``. The requantization is
+    lossy, so it never happens unless it was requested.
+    """
+    from vllm.config import get_current_vllm_config
+
+    vllm_config = get_current_vllm_config()
+    if vllm_config is None:
+        return False
+    quant_args = getattr(vllm_config.model_config, "quantization_config", None)
+    moe_spec = getattr(quant_args, "moe", None)
+    weight = getattr(moe_spec, "weight", None)
+    return str(weight) == "int4"
+
+
 class Mxfp4MoEMethod(FusedMoEMethodBase):
     """MXFP4 MoE quantization method."""
 
@@ -482,9 +549,26 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
 
     def __init__(self, moe: FusedMoEConfig):
         super().__init__(moe)
-
         self.weight_dtype = "mxfp4"
-        self.mxfp4_backend, self.experts_cls = select_deepseek_v4_mxfp4_moe_backend(moe)
+        self.is_k3_situ_aiter = _use_k3_situ_aiter(moe)
+        self.is_k3_situ_int4_gfx942 = _use_k3_situ_int4_gfx942(moe)
+        self.experts_cls: type[mk.FusedMoEExperts] | None
+        if self.is_k3_situ_aiter or self.is_k3_situ_int4_gfx942:
+            self.mxfp4_backend = Mxfp4MoeBackend.AITER_MXFP4_BF16
+            self.experts_cls = backend_to_kernel_cls(self.mxfp4_backend)[0]
+            logger.info_once("Using AITER_MXFP4_BF16 for Kimi-K3 SiTU MXFP4 MoE.")
+            from vllm._aiter_ops import rocm_aiter_ops
+
+            if rocm_aiter_ops.is_fused_moe_situv2_a8w4_enabled():
+                # AITER keeps bf16 activations below this token count, which
+                # would not match the fp8 a8w4 kernels the interleaved SiTU
+                # path is tuned for. The a16w4 path never reads it.
+                # TODO: Remove once AITER takes this as a kernel argument.
+                os.environ["AITER_BF16_FP8_MOE_BOUND"] = "0"
+        else:
+            self.mxfp4_backend, self.experts_cls = select_deepseek_v4_mxfp4_moe_backend(
+                moe
+            )
 
         self.max_capture_size = moe.max_capture_size
 
@@ -781,6 +865,94 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
             )
             self.moe_kernel.fused_experts.process_weights_after_loading(layer)
 
+    def _setup_kernel_k3_situ_gfx942(self, layer: RoutedExperts) -> None:
+        # gfx942 has no native MXFP4 matmul. Convert the weights to groupwise
+        # int4 once at load time for AITER's existing bf16 x int4 FlyDSL path.
+        import inspect
+
+        from aiter.ops.flydsl.kernels.moe_gemm_2stage import compile_moe_gemm1
+
+        # Before ROCm/aiter#4471 the packed-int4 stage1 dropped the requested
+        # activation and hardcoded SiLU, so K3 served fluent text while
+        # computing the wrong function. Refuse instead of repeating that.
+        if "act" not in inspect.signature(compile_moe_gemm1).parameters:
+            raise RuntimeError(
+                "This AITER build ignores the SiTUv2 activation on the "
+                "packed-int4 MoE path and would silently compute SiLU. "
+                "Rebuild with an AITER that includes ROCm/aiter#4471."
+            )
+
+        from aiter import dtypes as aiter_dtypes
+        from aiter.ops.quant import per_1x32_i4_quant
+        from aiter.ops.shuffle import (
+            pack_int8_to_packed_int4,
+            shuffle_scale_for_int4,
+            shuffle_weight,
+        )
+        from aiter.utility import fp4_utils
+
+        fp4_dtype = torch.float4_e2m1fn_x2
+        e8m0_dtype = torch.float8_e8m0fnu
+
+        def convert(
+            weight: torch.nn.Parameter,
+            scale: torch.nn.Parameter,
+        ) -> tuple[torch.Tensor, torch.Tensor]:
+            weight_f32 = fp4_utils.mxfp4_to_f32(weight.data.view(fp4_dtype))
+            scale_f32 = fp4_utils.e8m0_to_f32(scale.data.view(e8m0_dtype))
+            num_experts, output_size, input_size = weight_f32.shape
+            weight_bf16 = (
+                (
+                    weight_f32.view(
+                        num_experts, output_size, input_size // 32, 32
+                    )
+                    * scale_f32.view(
+                        num_experts, output_size, input_size // 32, 1
+                    )
+                )
+                .view(num_experts, output_size, input_size)
+                .to(torch.bfloat16)
+            )
+            del weight_f32, scale_f32
+
+            weight_int4, weight_scale = per_1x32_i4_quant(weight_bf16)
+            del weight_bf16
+            weight_int4 = weight_int4.view(aiter_dtypes.i4x2).view(
+                num_experts, output_size, input_size
+            )
+            weight_packed = pack_int8_to_packed_int4(
+                shuffle_weight(weight_int4.view(aiter_dtypes.i8), (16, 16))
+            )
+            weight_packed = weight_packed.view(
+                num_experts, output_size, input_size // 2
+            ).view(aiter_dtypes.i4x2)
+            weight_scale = (
+                shuffle_scale_for_int4(weight_scale, group_size=32)
+                .view(-1)
+                .contiguous()
+            )
+            return weight_packed, weight_scale
+
+        w13, w13_scale = convert(layer.w13_weight, layer.w13_weight_scale)
+        w2, w2_scale = convert(layer.w2_weight, layer.w2_weight_scale)
+        replace_parameter(layer, "w13_weight", w13)
+        replace_parameter(layer, "w2_weight", w2)
+        replace_parameter(layer, "w13_weight_scale", w13_scale)
+        replace_parameter(layer, "w2_weight_scale", w2_scale)
+        layer.w13_weight.is_shuffled = True
+        layer.w2_weight.is_shuffled = True
+
+        self.moe_quant_config = self.get_fused_moe_quant_config(layer)
+        if self.moe_quant_config is not None and self.experts_cls is not None:
+            self.moe_kernel = make_mxfp4_moe_kernel(
+                moe_quant_config=self.moe_quant_config,
+                moe_config=self.moe,
+                mxfp4_backend=self.mxfp4_backend,
+                experts_cls=self.experts_cls,
+                routing_tables=layer._expert_routing_tables(),
+                layer=layer,
+            )
+
     def process_weights_after_loading(self, layer):
         if self.mxfp4_backend == Mxfp4MoeBackend.NONE:
             return
@@ -792,6 +964,10 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
                     f"moe backend, got {self.mxfp4_backend}"
                 )
             self._build_moe_kernel(layer)
+            return
+
+        if self.is_k3_situ_int4_gfx942:
+            self._setup_kernel_k3_situ_gfx942(layer)
             return
 
         w13 = layer.w13_weight

--- a/vllm/model_executor/layers/quantization/mxfp4.py
+++ b/vllm/model_executor/layers/quantization/mxfp4.py
@@ -865,6 +865,24 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
             )
             self.moe_kernel.fused_experts.process_weights_after_loading(layer)
 
+        replace_parameter(layer, "w13_weight", w13)
+        replace_parameter(layer, "w2_weight", w2)
+        replace_parameter(layer, "w13_weight_scale", w13_scale)
+        replace_parameter(layer, "w2_weight_scale", w2_scale)
+        layer.w13_weight.is_shuffled = True
+        layer.w2_weight.is_shuffled = True
+
+        self.moe_quant_config = self.get_fused_moe_quant_config(layer)
+        if self.moe_quant_config is not None and self.experts_cls is not None:
+            self.moe_kernel = make_mxfp4_moe_kernel(
+                moe_quant_config=self.moe_quant_config,
+                moe_config=self.moe,
+                mxfp4_backend=self.mxfp4_backend,
+                experts_cls=self.experts_cls,
+                routing_tables=layer._expert_routing_tables(),
+                layer=layer,
+            )
+
     def _setup_kernel_k3_situ_gfx942(self, layer: RoutedExperts) -> None:
         # gfx942 has no native MXFP4 matmul. Convert the weights to groupwise
         # int4 once at load time for AITER's existing bf16 x int4 FlyDSL path.

--- a/vllm/model_executor/layers/quantization/mxfp4.py
+++ b/vllm/model_executor/layers/quantization/mxfp4.py
@@ -616,6 +616,13 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
             act_dtype=act_dtype,
             moe_parallel_config=moe_parallel_config,
         )
+        if self.is_k3_situ_int4_gfx942:
+            # K3's AITER A16W4 kernel handles K3's native intermediate size
+            # (moe_intermediate 3072; e.g. 384/partition at TP8); the generic
+            # 256 round-up would inflate weights and OOM. AITER's
+            # resolve_flydsl_stage1_tile_n() already downgrades tile_n 256->128
+            # for such shapes, so 384 is served natively.
+            return hidden_size, intermediate_size_per_partition
         return mxfp4_round_up_hidden_size_and_intermediate_size(
             self.mxfp4_backend,
             hidden_size,

--- a/vllm/model_executor/layers/quantization/mxfp4.py
+++ b/vllm/model_executor/layers/quantization/mxfp4.py
@@ -918,51 +918,112 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
         fp4_dtype = torch.float4_e2m1fn_x2
         e8m0_dtype = torch.float8_e8m0fnu
 
+        # The dequant chain cannot run in place: mxfp4_to_f32 does a
+        # repeat_interleave to split the packed nibbles, then an f32 LUT
+        # gather, so the working tensor grows 8x over the packed weight
+        # before per_1x32_i4_quant shrinks it again. Materializing that for
+        # a whole expert tensor peaks well above 20 GiB per rank, which does
+        # not fit once the weights are resident. Convert a slice of experts
+        # at a time and free each slice before the next, so the transient is
+        # bounded by _CONVERT_CHUNK / num_experts of the full tensor.
+        _CONVERT_CHUNK = 8
+
         def convert(
             weight: torch.nn.Parameter,
             scale: torch.nn.Parameter,
         ) -> tuple[torch.Tensor, torch.Tensor]:
-            weight_f32 = fp4_utils.mxfp4_to_f32(weight.data.view(fp4_dtype))
-            scale_f32 = fp4_utils.e8m0_to_f32(scale.data.view(e8m0_dtype))
-            num_experts, output_size, input_size = weight_f32.shape
-            weight_bf16 = (
-                (
-                    weight_f32.view(
-                        num_experts, output_size, input_size // 32, 32
+            # Releases its source parameter before returning: the packed int4
+            # output is the same size as the packed MXFP4 source, so holding
+            # both doubles the expert footprint. Under expert parallel each
+            # rank owns 1/ep_size of the experts and both fit, but under pure
+            # tensor parallel every rank holds all experts and the second copy
+            # does not. The caller must install each result before converting
+            # the next tensor.
+            w_all = weight.data.view(fp4_dtype)
+            s_all = scale.data.view(e8m0_dtype)
+            num_experts = w_all.shape[0]
+
+            # Preallocate the outputs and write each chunk into its slice.
+            # Accumulating chunks in a list and torch.cat-ing at the end holds
+            # the whole result twice at the join, which is what the transient
+            # chunking was meant to avoid in the first place.
+            out_packed: torch.Tensor | None = None
+            out_scale: torch.Tensor | None = None
+            scale_stride = 0
+            for lo in range(0, num_experts, _CONVERT_CHUNK):
+                hi = min(lo + _CONVERT_CHUNK, num_experts)
+                weight_f32 = fp4_utils.mxfp4_to_f32(w_all[lo:hi])
+                scale_f32 = fp4_utils.e8m0_to_f32(s_all[lo:hi])
+                chunk_experts, output_size, input_size = weight_f32.shape
+                weight_bf16 = (
+                    (
+                        weight_f32.view(
+                            chunk_experts, output_size, input_size // 32, 32
+                        )
+                        * scale_f32.view(
+                            chunk_experts, output_size, input_size // 32, 1
+                        )
                     )
-                    * scale_f32.view(
-                        num_experts, output_size, input_size // 32, 1
-                    )
+                    .view(chunk_experts, output_size, input_size)
+                    .to(torch.bfloat16)
                 )
-                .view(num_experts, output_size, input_size)
-                .to(torch.bfloat16)
-            )
-            del weight_f32, scale_f32
+                del weight_f32, scale_f32
 
-            weight_int4, weight_scale = per_1x32_i4_quant(weight_bf16)
-            del weight_bf16
-            weight_int4 = weight_int4.view(aiter_dtypes.i4x2).view(
-                num_experts, output_size, input_size
-            )
-            weight_packed = pack_int8_to_packed_int4(
-                shuffle_weight(weight_int4.view(aiter_dtypes.i8), (16, 16))
-            )
-            weight_packed = weight_packed.view(
-                num_experts, output_size, input_size // 2
-            ).view(aiter_dtypes.i4x2)
-            weight_scale = (
-                shuffle_scale_for_int4(weight_scale, group_size=32)
-                .view(-1)
-                .contiguous()
-            )
-            return weight_packed, weight_scale
+                weight_int4, weight_scale = per_1x32_i4_quant(weight_bf16)
+                del weight_bf16
+                weight_int4 = weight_int4.view(aiter_dtypes.i4x2).view(
+                    chunk_experts, output_size, input_size
+                )
+                weight_packed = pack_int8_to_packed_int4(
+                    shuffle_weight(weight_int4.view(aiter_dtypes.i8), (16, 16))
+                )
+                del weight_int4
+                chunk_packed = weight_packed.view(
+                    chunk_experts, output_size, input_size // 2
+                ).view(aiter_dtypes.i4x2)
+                chunk_scale = (
+                    shuffle_scale_for_int4(weight_scale, group_size=32)
+                    .view(-1)
+                    .contiguous()
+                )
+                if out_packed is None:
+                    out_packed = torch.empty(
+                        (num_experts,) + tuple(chunk_packed.shape[1:]),
+                        dtype=chunk_packed.dtype,
+                        device=chunk_packed.device,
+                    )
+                    scale_stride = chunk_scale.numel() // chunk_experts
+                    out_scale = torch.empty(
+                        num_experts * scale_stride,
+                        dtype=chunk_scale.dtype,
+                        device=chunk_scale.device,
+                    )
+                out_packed[lo:hi].copy_(chunk_packed)
+                out_scale[lo * scale_stride : hi * scale_stride].copy_(chunk_scale)
+                del weight_packed, weight_scale, chunk_packed, chunk_scale
+                torch.cuda.empty_cache()
 
+            # Every chunk has been read, so let the source storage go before
+            # the caller converts the next tensor.
+            del w_all, s_all
+            weight.data = torch.empty(0, dtype=torch.uint8, device=out_packed.device)
+            scale.data = torch.empty(0, dtype=torch.uint8, device=out_packed.device)
+            torch.cuda.empty_cache()
+            return out_packed, out_scale
+
+        # Install each result before converting the next tensor so only one
+        # source is ever live alongside its output.
         w13, w13_scale = convert(layer.w13_weight, layer.w13_weight_scale)
-        w2, w2_scale = convert(layer.w2_weight, layer.w2_weight_scale)
         replace_parameter(layer, "w13_weight", w13)
-        replace_parameter(layer, "w2_weight", w2)
         replace_parameter(layer, "w13_weight_scale", w13_scale)
+        del w13, w13_scale
+        torch.cuda.empty_cache()
+
+        w2, w2_scale = convert(layer.w2_weight, layer.w2_weight_scale)
+        replace_parameter(layer, "w2_weight", w2)
         replace_parameter(layer, "w2_weight_scale", w2_scale)
+        del w2, w2_scale
+        torch.cuda.empty_cache()
         layer.w13_weight.is_shuffled = True
         layer.w2_weight.is_shuffled = True
 

--- a/vllm/model_executor/layers/quantization/mxfp4.py
+++ b/vllm/model_executor/layers/quantization/mxfp4.py
@@ -562,7 +562,15 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
         if self.is_k3_situ_aiter or self.is_k3_situ_int4_gfx942:
             self.mxfp4_backend = Mxfp4MoeBackend.AITER_MXFP4_BF16
             self.experts_cls = backend_to_kernel_cls(self.mxfp4_backend)[0]
-            logger.info_once("Using AITER_MXFP4_BF16 for Kimi-K3 SiTU MXFP4 MoE.")
+            if self.is_k3_situ_int4_gfx942:
+                logger.warning_once(
+                    "Requantizing Kimi-K3 MXFP4 experts to groupwise int4 "
+                    "for gfx942. This conversion is lossy and was explicitly "
+                    "enabled by --quantization-config.moe.weight "
+                    "int4_per_group_32."
+                )
+            else:
+                logger.info_once("Using AITER_MXFP4_BF16 for Kimi-K3 SiTU MXFP4 MoE.")
             from vllm._aiter_ops import rocm_aiter_ops
 
             if rocm_aiter_ops.is_fused_moe_situv2_a8w4_enabled():
@@ -1005,17 +1013,21 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
                         dtype=chunk_scale.dtype,
                         device=chunk_scale.device,
                     )
+                assert out_packed is not None
+                assert out_scale is not None
                 out_packed[lo:hi].copy_(chunk_packed)
                 out_scale[lo * scale_stride : hi * scale_stride].copy_(chunk_scale)
                 del weight_packed, weight_scale, chunk_packed, chunk_scale
-                torch.cuda.empty_cache()
+                torch.accelerator.empty_cache()
 
             # Every chunk has been read, so let the source storage go before
             # the caller converts the next tensor.
             del w_all, s_all
+            assert out_packed is not None
+            assert out_scale is not None
             weight.data = torch.empty(0, dtype=torch.uint8, device=out_packed.device)
             scale.data = torch.empty(0, dtype=torch.uint8, device=out_packed.device)
-            torch.cuda.empty_cache()
+            torch.accelerator.empty_cache()
             return out_packed, out_scale
 
         # Install each result before converting the next tensor so only one
@@ -1024,13 +1036,13 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
         replace_parameter(layer, "w13_weight", w13)
         replace_parameter(layer, "w13_weight_scale", w13_scale)
         del w13, w13_scale
-        torch.cuda.empty_cache()
+        torch.accelerator.empty_cache()
 
         w2, w2_scale = convert(layer.w2_weight, layer.w2_weight_scale)
         replace_parameter(layer, "w2_weight", w2)
         replace_parameter(layer, "w2_weight_scale", w2_scale)
         del w2, w2_scale
-        torch.cuda.empty_cache()
+        torch.accelerator.empty_cache()
         layer.w13_weight.is_shuffled = True
         layer.w2_weight.is_shuffled = True
 

--- a/vllm/model_executor/layers/quantization/mxfp4.py
+++ b/vllm/model_executor/layers/quantization/mxfp4.py
@@ -1030,7 +1030,6 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
                 mxfp4_backend=self.mxfp4_backend,
                 experts_cls=self.experts_cls,
                 routing_tables=layer._expert_routing_tables(),
-                layer=layer,
             )
 
     def process_weights_after_loading(self, layer):

--- a/vllm/model_executor/layers/quantization/mxfp4.py
+++ b/vllm/model_executor/layers/quantization/mxfp4.py
@@ -624,13 +624,6 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
             act_dtype=act_dtype,
             moe_parallel_config=moe_parallel_config,
         )
-        if self.is_k3_situ_int4_gfx942:
-            # K3's AITER A16W4 kernel handles K3's native intermediate size
-            # (moe_intermediate 3072; e.g. 384/partition at TP8); the generic
-            # 256 round-up would inflate weights and OOM. AITER's
-            # resolve_flydsl_stage1_tile_n() already downgrades tile_n 256->128
-            # for such shapes, so 384 is served natively.
-            return hidden_size, intermediate_size_per_partition
         return mxfp4_round_up_hidden_size_and_intermediate_size(
             self.mxfp4_backend,
             hidden_size,
@@ -885,24 +878,6 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
                 routing_tables=layer._expert_routing_tables(),
             )
             self.moe_kernel.fused_experts.process_weights_after_loading(layer)
-
-        replace_parameter(layer, "w13_weight", w13)
-        replace_parameter(layer, "w2_weight", w2)
-        replace_parameter(layer, "w13_weight_scale", w13_scale)
-        replace_parameter(layer, "w2_weight_scale", w2_scale)
-        layer.w13_weight.is_shuffled = True
-        layer.w2_weight.is_shuffled = True
-
-        self.moe_quant_config = self.get_fused_moe_quant_config(layer)
-        if self.moe_quant_config is not None and self.experts_cls is not None:
-            self.moe_kernel = make_mxfp4_moe_kernel(
-                moe_quant_config=self.moe_quant_config,
-                moe_config=self.moe,
-                mxfp4_backend=self.mxfp4_backend,
-                experts_cls=self.experts_cls,
-                routing_tables=layer._expert_routing_tables(),
-                layer=layer,
-            )
 
     def _setup_kernel_k3_situ_gfx942(self, layer: RoutedExperts) -> None:
         # gfx942 has no native MXFP4 matmul. Convert the weights to groupwise

--- a/vllm/model_executor/layers/quantization/mxfp4.py
+++ b/vllm/model_executor/layers/quantization/mxfp4.py
@@ -505,7 +505,7 @@ def _use_k3_situ_int4_gfx942(moe: FusedMoEConfig) -> bool:
     there. Requantizing to groupwise int4 lets AITER's bf16 x int4 FlyDSL path
     serve the model, at the cost of a lossy weight conversion. That trade is the
     user's to make, so it is opt-in through
-    ``--quantization-config.moe.weight int4`` rather than inferred from the
+    ``--quantization-config.moe.weight int4_per_group_32`` rather than inferred from the
     hardware.
     """
     from vllm.platforms import current_platform
@@ -528,8 +528,8 @@ def _use_k3_situ_int4_gfx942(moe: FusedMoEConfig) -> bool:
 def _moe_weight_override_is_int4() -> bool:
     """True when the user asked for int4 MoE weights on the command line.
 
-    Set with ``--quantization-config.moe.weight int4``. The requantization is
-    lossy, so it never happens unless it was requested.
+    Set with ``--quantization-config.moe.weight int4_per_group_32``. The
+    requantization is lossy, so it never happens unless it was requested.
     """
     from vllm.config import get_current_vllm_config
 
@@ -539,7 +539,13 @@ def _moe_weight_override_is_int4() -> bool:
     quant_args = getattr(vllm_config.model_config, "quantization_config", None)
     moe_spec = getattr(quant_args, "moe", None)
     weight = getattr(moe_spec, "weight", None)
-    return str(weight) == "int4"
+    if weight is None:
+        return False
+    from vllm.model_executor.layers.quantization.utils.quant_utils import (
+        kInt4Static32,
+    )
+
+    return weight == kInt4Static32
 
 
 class Mxfp4MoEMethod(FusedMoEMethodBase):

--- a/vllm/v1/sample/ops/topk_topp_sampler.py
+++ b/vllm/v1/sample/ops/topk_topp_sampler.py
@@ -25,20 +25,6 @@ def _skip_aiter_sampler_on_gfx1250() -> bool:
     return on_gfx1250()
 
 
-def _aiter_topk_topp_unsupported_on_gfx942() -> bool:
-    """AITER's ``top_k_top_p_sampling_from_probs`` is a gfx950-only prebuilt.
-
-    It segfaults on gfx942 (MI325X / MI300X), so callers must fall back to the
-    native torch sampler on that architecture.
-    """
-    try:
-        from vllm.platforms.rocm import on_gfx942
-
-        return on_gfx942()
-    except Exception:  # noqa: BLE001
-        return False
-
-
 def flashinfer_sampler_supported() -> bool:
     """Decide whether FlashInfer's top-p/top-k sampler can be used.
 
@@ -132,7 +118,6 @@ class TopKTopPSampler(nn.Module):
             logprobs_mode not in PROCESSED_LOGPROBS_MODES
             and rocm_aiter_ops.is_enabled()
             and not _skip_aiter_sampler_on_gfx1250()  # TODO (JPVILLAM): Enable
-            and not _aiter_topk_topp_unsupported_on_gfx942()
         ):
             self.aiter_ops = None
             self._aiter_ops_import_failed = False

--- a/vllm/v1/sample/ops/topk_topp_sampler.py
+++ b/vllm/v1/sample/ops/topk_topp_sampler.py
@@ -24,6 +24,7 @@ def _skip_aiter_sampler_on_gfx1250() -> bool:
 
     return on_gfx1250()
 
+
 def _aiter_topk_topp_unsupported_on_gfx942() -> bool:
     """AITER's ``top_k_top_p_sampling_from_probs`` is a gfx950-only prebuilt.
 

--- a/vllm/v1/sample/ops/topk_topp_sampler.py
+++ b/vllm/v1/sample/ops/topk_topp_sampler.py
@@ -24,6 +24,19 @@ def _skip_aiter_sampler_on_gfx1250() -> bool:
 
     return on_gfx1250()
 
+def _aiter_topk_topp_unsupported_on_gfx942() -> bool:
+    """AITER's ``top_k_top_p_sampling_from_probs`` is a gfx950-only prebuilt.
+
+    It segfaults on gfx942 (MI325X / MI300X), so callers must fall back to the
+    native torch sampler on that architecture.
+    """
+    try:
+        from vllm.platforms.rocm import on_gfx942
+
+        return on_gfx942()
+    except Exception:  # noqa: BLE001
+        return False
+
 
 def flashinfer_sampler_supported() -> bool:
     """Decide whether FlashInfer's top-p/top-k sampler can be used.
@@ -118,6 +131,7 @@ class TopKTopPSampler(nn.Module):
             logprobs_mode not in PROCESSED_LOGPROBS_MODES
             and rocm_aiter_ops.is_enabled()
             and not _skip_aiter_sampler_on_gfx1250()  # TODO (JPVILLAM): Enable
+            and not _aiter_topk_topp_unsupported_on_gfx942()
         ):
             self.aiter_ops = None
             self._aiter_ops_import_failed = False


### PR DESCRIPTION
## Summary

Add an explicit `int4_per_group_32` MoE override for Kimi-K3 on gfx942. When selected, the MXFP4 expert weights are requantized once at load time and served through AITER's replacement BF16 x packed-int4 FlyDSL path.

The conversion is lossy and never happens by architecture alone. The default MXFP4 path is unchanged.

## Why

gfx942 does not support the scaled FP4 conversion instructions used by the native MXFP4 path. This opt-in path pays the conversion cost once during model loading and then uses the replacement packed-int4 kernels from [ROCm/aiter#4646](https://github.com/ROCm/aiter/pull/4646).

## Changes

- Register `int4_per_group_32` as a MoE weight quantization key.
- Require the explicit `--quantization-config.moe.weight int4_per_group_32` override on gfx942.
- Require the replacement A16W4/int4 AITER entry point and fail closed unless it supports SiTUv2.
- Convert eight experts at a time and release each source tensor before converting the next one, bounding transient memory during load.
- Log a warning that the selected conversion is lossy.
- Leave `int4_per_group_32` out of the online MoE table so `Mxfp4MoEMethod` can convert at load time (`3db224c`).
- Keep expert parallel off for non-MoE drafts such as DSpark when the target uses `--enable-expert-parallel` (`f55575f`).

## Validation

Unit tests:

```text
tests/quantization/test_quantization_config_args.py
tests/models/kimi_k3/test_gfx942_int4.py
tests/config/test_speculative_draft_hf_overrides.py
```

Strict AITER comparison against the torch reference passed for the production EP shape:

```text
model_dim=3584
intermediate_dim=3072
local_experts=112
topk=15
tokens=1,4,7,16,32
activation=SiTUv2
beta=4.0
linear_beta=25.0
```

Re-checked on 8x MI325X with TP8, expert parallelism, Triton RMSNorm, Triton MLA, AITER fused MoE, and full plus piecewise graph capture. Image: `vllm/vllm-openai-rocm:nightly-dc36fcce902a63eab06c1b93a5c4a5ee178a0c56` (AITER v0.1.21.post2, picked up in #55968). Serving used the replacement packed-int4 path from ROCm/aiter#4646. Current FlyDSL 0.3.2 `gemm2` cannot select `BUFFER_ATOMIC_FADD` of `v2bf16` on gfx942, so those runs used the `moe_2stage_a16wmix` kernels from ROCm/aiter#4646 on top of AITER v0.1.21.post2.

Validation ran on `2770748` plus the two follow-up commits now on this branch (`3db224c`, `f55575f`). Current head is `58c2a374` after merging `main`.

- The int4 path was FlyDSL A16W4 SiTUv2 (`ActivationType.Situv2`, `torch.int4`, `QuantType.per_1x32`, `flydsl_moe1_abf16_wint4_*`). Untuned `a16wi4` is still this path. Graph capture completed. MXFP4 native and emulation were not used.
- Chat completions returned coherent answers, including a Fibonacci Python snippet.
- 1M NIAH passed at 131072, 524288, and 1047552 tokens.
- DSpark k=7 (`Inferact/Kimi-K3-DSpark`) at 262K answered Paris, completed random chat through 250000 tokens, and passed NIAH at 65536, 131072, and 250000 with 512 output tokens. After GSM8K, 104973 of 241563 draft tokens were accepted (43.45%).
- Five-shot GSM8K through `lm_eval` `local-completions` (`num_fewshot=5`, `temperature=0.0`, `max_gen_toks=512`) scored 0.9598 strict-match and 0.9598 flexible-extract on all 1,319 questions, stderr 0.0054. That is within noise of the 0.9560 A16W4 baseline (stderr 0.0056) on the same 1,319 questions. The DSpark GSM8K run matched that 0.9598 number.
- The matched non-DSpark 262K NIAH passed the same three 512-token needles.
- `vllm bench serve` 1K input / 128 output completed 10/10 requests at concurrency 1 and 160/160 requests at concurrency 16, with no server errors. Those serving runs used the untuned FlyDSL a16w4 fallback, so they are a functional check, not a tuned peak.

## Dependency and scope

ROCm/aiter#4646 is in AITER v0.1.21.post2. vLLM picked that tag up in #55968, so this branch is no longer blocked on the AITER release.

The conversion is an explicit opt-in for deployments that accept a lossy one-time weight conversion. It does not change the default checkpoint path.

A follow-up can add `Mxfp4MoeBackend.AITER_INT4_BF16`. This PR stays on the measured FlyDSL SiTU path. It does not wait on #55684.

## Test plan

- [x] Quantization key and opt-in selection unit tests.
- [x] Strict production-shape comparison against the torch reference.
- [x] Full 1,319-question GSM8K after ROCm/aiter#4646.
- [x] Target-only graph capture and serving sanity.
- [x] Long-context and DSpark validation against the AITER release containing ROCm/aiter#4646.
- [ ] ROCm CI on the rebased branch.
