### PR TITLE
[Perf][Frontend] Optimize DecodeStream priming with a bounded prompt tail

### DIFF
--- a/vllm/v1/engine/detokenizer.py
+++ b/vllm/v1/engine/detokenizer.py
@@ -27,6 +27,11 @@ USE_FAST_DETOKENIZER = version.parse(tokenizers.__version__) >= version.parse("0
 # Error string from https://github.com/huggingface/tokenizers/blob/909fdde2a4ffedd9295206f705eb612be2a91b12/tokenizers/src/tokenizer/mod.rs#L1042
 INVALID_PREFIX_ERR_MSG = "Invalid prefix encountered"
 
+# Number of prompt token ids used to prime the DecodeStream. Incremental
+# decoding only needs bounded left context, so priming with the full prompt
+# does O(prompt_len) work per request for no benefit.
+DETOKENIZATION_OFFSET = 32
+
 
 class IncrementalDetokenizer:
     def __init__(self):
@@ -177,12 +182,17 @@ class FastIncrementalDetokenizer(BaseIncrementalDetokenizer):
 
         self.tokenizer: Tokenizer = tokenizer._tokenizer
 
-        # Use native prefill to prime the decode stream with prompt tokens.
+        # Use the prompt's tail tokens to prime the decode stream.
         # Look up DecodeStream on the module so backend patches (e.g. the
         # fastokens shim that replaces ``tokenizers.decoders.DecodeStream``)
         # are honored regardless of import order.
+        tail_ids = (
+            request.prompt_token_ids[-DETOKENIZATION_OFFSET:]
+            if request.prompt_token_ids
+            else None
+        )
         self.stream = tokenizers.decoders.DecodeStream(
-            ids=request.prompt_token_ids,
+            ids=tail_ids,
             skip_special_tokens=self.skip_special_tokens,
         )
 

--- a/vllm/v1/engine/detokenizer.py
+++ b/vllm/v1/engine/detokenizer.py
@@ -27,10 +27,10 @@ USE_FAST_DETOKENIZER = version.parse(tokenizers.__version__) >= version.parse("0
 # Error string from https://github.com/huggingface/tokenizers/blob/909fdde2a4ffedd9295206f705eb612be2a91b12/tokenizers/src/tokenizer/mod.rs#L1042
 INVALID_PREFIX_ERR_MSG = "Invalid prefix encountered"
 
-# Number of prompt token ids used to prime the DecodeStream. Incremental
-# decoding only needs bounded left context, so priming with the full prompt
-# does O(prompt_len) work per request for no benefit.
-DETOKENIZATION_OFFSET = 32
+# Number of trailing prompt token ids used to prime the DecodeStream.
+# Incremental decoding only needs bounded left context, so priming with the
+# whole prompt does O(prompt_len) work per request for no benefit.
+DETOKENIZATION_PRIME_LEN = 32
 
 
 class IncrementalDetokenizer:
@@ -182,17 +182,24 @@ class FastIncrementalDetokenizer(BaseIncrementalDetokenizer):
 
         self.tokenizer: Tokenizer = tokenizer._tokenizer
 
-        # Use the prompt's tail tokens to prime the decode stream.
+        # Prime the decode stream with the tail of the prompt. A tail that
+        # starts inside a multi-token character (e.g. a byte-fallback run that
+        # reaches the end of the prompt) decodes to U+FFFD and would corrupt
+        # the first delta, so widen it until it decodes cleanly.
+        prime_ids = None
+        if prompt_token_ids := request.prompt_token_ids:
+            n = DETOKENIZATION_PRIME_LEN
+            prime_ids = prompt_token_ids[-n:]
+            while len(prime_ids) < len(prompt_token_ids) and "\ufffd" in (
+                self.tokenizer.decode(prime_ids, self.skip_special_tokens)
+            ):
+                n *= 2
+                prime_ids = prompt_token_ids[-n:]
         # Look up DecodeStream on the module so backend patches (e.g. the
         # fastokens shim that replaces ``tokenizers.decoders.DecodeStream``)
         # are honored regardless of import order.
-        tail_ids = (
-            request.prompt_token_ids[-DETOKENIZATION_OFFSET:]
-            if request.prompt_token_ids
-            else None
-        )
         self.stream = tokenizers.decoders.DecodeStream(
-            ids=tail_ids,
+            ids=prime_ids,
             skip_special_tokens=self.skip_special_tokens,
         )
 


### PR DESCRIPTION
## TD;LR
Simple but highly impactful 1-line change optimization for the detokenizer. Until this PR the first `step()` - which runs at the moment the first generated token arrives - **detokenizes the entire prompt so far**.
**The fix** - prime only with the tail of prompt ids (`ids=prompt_token_ids[-32:]`) instead of the entire prompt.

In agentic usage this is a large overhead that directly affects TTFT.

## Purpose

`FastIncrementalDetokenizer.__init__` primes its `DecodeStream` with the **entire prompt**
(`ids=request.prompt_token_ids`). The native prefill does O(prompt_len) work per request
(~0.5–1.5 µs/token: ~3 ms `5K` ids, ~9 ms `15K`, ~12 ms `20K`, measured with tokenizers
0.22.2, whose Rust binding defers the decode to the first `step()` call). That work runs
on the API-server event loop, so it:

- lands verbatim in that request's streaming TTFT, and
- head-of-line blocks the SSE deltas of every other active stream on the same event
  loop (p99 contamination).

The cost scales with prompt length, so it hits hardest exactly where GPU-side TTFT is
otherwise best: long warm-prefix prompts (agents, RAG) served with prefix caching.

Incremental detokenization only needs bounded left context: the primed prefix exists
solely to be subtracted from the first delta, a byte-fallback run spans at most a few
ids, and space-marker handling only requires the stream not to be at sequence start.
This PR primes with the last **32** prompt ids (`DETOKENIZATION_OFFSET`) instead of all
of them. (`prompt_token_ids` may be `None` on the prompt-embeds path, hence the guard.)

Surprisingly, bounded-tail priming is actually an established design in vllm and sglang:

- vLLM's own slow path has always primed with the last **7** ids —
  [`convert_prompt_ids_to_tokens`](https://github.com/vllm-project/vllm/blob/main/vllm/tokenizers/detokenizer_utils.py#L119-L137):
  "We do not need to convert the whole prompt to tokens."
- SGLang has always primed with the last **5** ids —
  [`init_incremental_detokenize`](https://github.com/sgl-project/sglang/blob/b3cdd016baebc6b61787ffc196115986460ba981/python/sglang/srt/managers/schedule_batch.py#L1374-L1394),
  whose source comment attributes the scheme to
  [vLLM's pre-V1 detokenizer](https://github.com/vllm-project/vllm/blob/7a64d24aad69e4d2548aa0bf528d9fe63428ab01/vllm/transformers_utils/detokenizer.py#L194-L313).
- The invalid-prefix recovery path in this same file already reconstructs a
  `DecodeStream` with no ids at all.

32 is >4× the slow path's long-standing bound; the tail prime decodes once per request
in ~7 µs.

Not duplicating existing work: searched open PRs touching DecodeStream/detokenizer —
#46723 (Rust frontend, redundant decode per token) and #48854 (prompt text leak on
mid-UTF-8 prompt end) address different issues.

## Test Plan

- Differential decode, bounded-tail vs full-prompt priming (tokenizers 0.22.2):
  7,155 structured cases + 58,320 steps on a production SentencePiece-BPE tokenizer —
  Hebrew/Arabic/Greek/emoji (incl. niqqud and ZWJ sequences), special-token tails,
  byte-fallback shapes, spec-decode burst shapes, both `skip_special_tokens` modes —
  plus a GPT-2 byte-level BPE differential.
- End-to-end greedy replay of 32 real streaming chat requests (incl. tool calls):
  byte-compare of `prompt_tokens`, `content`, `tool_calls` vs an unpatched server.
- Serving A/B on a production-shaped agent workload.

## Test Result

- **0 text mismatches** across all differential corpora; end-to-end replay
  byte-identical 32/32.
- Serving A/B: API-server event-loop time spent in `DecodeStream.step` **25.5 s →
  0.8 s** per 180 s window (py-spy). Steady-state streaming TTFT p50 by prompt-length
  bucket: 6–9K tokens **−12.3 ms**, 9–12K **−17.3 ms**, 12–30K **−21.5 ms** — TTFT
  becomes nearly flat in prompt length where it previously climbed steeply. ~68K
  requests served on the fix, 0 failures.
- Common path unaffected: steady-state per-delta step cost is 2.6–3.9 µs before and
  after (this change only bounds the one-time prime).

## AI assistance disclosure

Developed with AI assistance (Claude Code); all changed (this is basically a 1-line change...) lines human-reviewed and all measurements above are from internal experiments runs.
