### PR TITLE
[Bugfix] Disable async scheduling when VLLM_BATCH_INVARIANT=1

### DIFF
--- a/docs/features/batch_invariance.md
+++ b/docs/features/batch_invariance.md
@@ -118,6 +118,18 @@ When batch invariance is enabled, vLLM:
 1. Uses deterministic kernel implementations for attention and other operations
 2. Ensures consistent numerical behavior across different batch sizes
 3. Disables certain optimizations that may introduce non-determinism (such as custom all-reduce operations in tensor parallel mode)
+4. Disables asynchronous scheduling, which is otherwise on by default
+
+!!! warning
+    Batch invariance pins the *kernels*, so a row's result no longer depends on batch
+    size or composition. It does not by itself control **which** batch the scheduler
+    places a request in. Asynchronous scheduling composes the next step's batch before
+    the current step has retired, so batch membership depends on wall-clock timing and
+    outputs are not reproducible.
+
+    vLLM therefore disables async scheduling automatically when
+    `VLLM_BATCH_INVARIANT=1`, and rejects the combination if you pass
+    `--async-scheduling` explicitly. Expect a small throughput cost for this.
 
 !!! note
     Enabling batch invariance may impact performance compared to the default non-deterministic mode. This trade-off is intentional to guarantee reproducibility.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -430,6 +430,35 @@ def test_draft_model_enables_async_scheduling_by_default():
     assert cfg.scheduler_config.async_scheduling is True
 
 
+def test_batch_invariance_disables_async_scheduling(monkeypatch):
+    monkeypatch.setattr(envs, "VLLM_BATCH_INVARIANT", True)
+    cfg = VllmConfig(
+        model_config=ModelConfig("Qwen/Qwen3-0.6B", max_model_len=2048),
+        scheduler_config=SchedulerConfig(
+            max_model_len=2048,
+            is_encoder_decoder=False,
+        ),
+        parallel_config=ParallelConfig(distributed_executor_backend="uni"),
+    )
+
+    assert cfg.scheduler_config.async_scheduling is False
+
+
+def test_batch_invariance_rejects_explicit_async_scheduling(monkeypatch):
+    monkeypatch.setattr(envs, "VLLM_BATCH_INVARIANT", True)
+
+    with pytest.raises(ValueError, match="VLLM_BATCH_INVARIANT"):
+        VllmConfig(
+            model_config=ModelConfig("Qwen/Qwen3-0.6B", max_model_len=2048),
+            scheduler_config=SchedulerConfig(
+                max_model_len=2048,
+                is_encoder_decoder=False,
+                async_scheduling=True,
+            ),
+            parallel_config=ParallelConfig(distributed_executor_backend="uni"),
+        )
+
+
 @dataclass
 class _TestConfigFields:
     a: int

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -1083,6 +1083,14 @@ class VllmConfig:
             # Async scheduling explicitly enabled, hard fail any incompatibilities.
             # Currently, async scheduling only support eagle speculative
             # decoding.
+            if envs.VLLM_BATCH_INVARIANT:
+                raise ValueError(
+                    "Async scheduling is not compatible with "
+                    "VLLM_BATCH_INVARIANT=1. Async scheduling composes the next "
+                    "step's batch before the current step retires, so batch "
+                    "composition depends on wall-clock timing and outputs are "
+                    "not reproducible. Please use --no-async-scheduling."
+                )
             if uses_rocm_deepep_ht_dbo:
                 raise ValueError(
                     "Async scheduling is not compatible with ROCm DeepEP "
@@ -1112,7 +1120,14 @@ class VllmConfig:
                 )
         elif self.scheduler_config.async_scheduling is None:
             # Enable async scheduling unless there is an incompatible option.
-            if (
+            if envs.VLLM_BATCH_INVARIANT:
+                logger.warning_once(
+                    "Disabling asynchronous scheduling when VLLM_BATCH_INVARIANT "
+                    "is enabled. Async scheduling makes batch composition depend "
+                    "on wall-clock timing, which defeats batch invariance."
+                )
+                self.scheduler_config.async_scheduling = False
+            elif (
                 self.model_config is not None
                 and self.model_config.runner_type == "pooling"
             ):


### PR DESCRIPTION
## Purpose

`VLLM_BATCH_INVARIANT=1` pins the *kernels* so a row's result no longer depends on batch size or composition. It does nothing about **which batch the scheduler puts a request in**.

Async scheduling is enabled by default (`SchedulerConfig.async_scheduling = None` -> `True`) and composes the next step's batch before the current step has retired, so batch membership depends on wall-clock timing. Timing jitter therefore reaches the numerics again, and the flag does not deliver what it promises.

There is no guard, no warning, and nothing in the docs. The server boots, serves, and quietly is not reproducible. `--no-async-scheduling` fixes it, at roughly 3% throughput.

This is not a corner case for the flag's intended users: batch invariance exists so research and regulated workloads can reproduce results, and those are exactly the workloads running large batches of long, variable-length requests.

This PR treats `VLLM_BATCH_INVARIANT` as an async-scheduling incompatibility, following the existing structure in `VllmConfig.__post_init__`:

- **explicitly enabled** (`--async-scheduling`): `ValueError` pointing at `--no-async-scheduling`, matching the ROCm DeepEP DBO and unsupported-executor cases.
- **unset** (the default): disabled with `warning_once`, matching the pooling-model, spec-decode and ROCm DBO cases.

The closest precedent is ROCm DeepEP high-throughput DBO, disabled "because that combination can corrupt DP+EP generation accuracy", which is the same argument. vLLM already auto-disables cascade attention and custom all-reduce under this same flag.

Also documents the interaction in `docs/features/batch_invariance.md`, which currently says nothing about scheduler configuration.

Related: #27433.

## Test Plan

### 1. Config tests (CPU only)

Added to `tests/test_config.py`, next to the existing `test_draft_model_enables_async_scheduling_by_default`:

- `test_batch_invariance_disables_async_scheduling`: with the flag set, `async_scheduling` resolves to `False`.
- `test_batch_invariance_rejects_explicit_async_scheduling`: with the flag set and `async_scheduling=True` passed explicitly, `VllmConfig` raises.

### 2. End to end

Serve, before this patch, once per row:

```bash
# A: default, async scheduling on
VLLM_BATCH_INVARIANT=1 vllm serve $MODEL --no-enable-prefix-caching

# B: the fix
VLLM_BATCH_INVARIANT=1 vllm serve $MODEL --no-enable-prefix-caching --no-async-scheduling
```

Against each, run:

```python
# pip install openai
import concurrent.futures as cf, hashlib, sys
from openai import OpenAI

MODEL, BATCHES, REPEATS = sys.argv[1], (1, 5, 10, 50), 3
client = OpenAI(base_url="http://localhost:8000/v1", api_key="EMPTY")

WORDS = ("market revenue guidance segment margin pipeline capacity demand headwind "
         "backlog utilization cadence inventory logistics currency hedging").split()

def text(n, shift=0):
    return " ".join(WORDS[(i + shift) % len(WORDS)] for i in range(n))

PROBE = "Summarize this in detail, listing every theme you find.\n\n" + text(9000)

def answer(prompt, limit):
    m = client.chat.completions.create(
        model=MODEL, messages=[{"role": "user", "content": prompt}],
        temperature=0, max_tokens=limit).choices[0].message
    return (getattr(m, "reasoning_content", "") or "") + (m.content or "")

def probe_hash(batch):
    jobs = [(PROBE, 600)] + [(text(3000, i), 400 + i % 8 * 150) for i in range(batch - 1)]
    with cf.ThreadPoolExecutor(batch) as pool:
        probe = list(pool.map(lambda j: answer(*j), jobs))[0]
    return hashlib.sha256(probe.encode()).hexdigest()[:12]

hashes = {}
for rep in range(REPEATS):
    for batch in BATCHES:
        h = probe_hash(batch)
        hashes.setdefault(h, []).append(f"rep{rep} batch{batch}")
        print(f"rep{rep} batch{batch:>3}  {h}")

print("PASS" if len(hashes) == 1 else f"FAIL  {len(hashes)} outputs for one input")
```

Two properties of that script are load-bearing. The **probe is long**: short prompts are reproducible even on a badly broken config. The **fillers use staggered `max_tokens`**: they retire at different decode steps, so batch composition churns while the probe is still generating. Drop either one and this passes on a server that is not batch invariant, which is exactly why the existing tests miss it (below).

After this patch, A and B are the same run: async scheduling is off by default under the flag, and the extra argument is no longer needed.

## Test Result

Measured on `openai/gpt-oss-120b`, single A100-80GB (sm80), `TRITON_ATTN`, temperature 0.

| | probe reproducible |
|---|---|
| A, default (async scheduling on) | **9/10**, one request flips between runs |
| B, `--no-async-scheduling` | **10/10** |

Throughput cost of B: roughly 3%.

The flipping request is stable when run alone (6/6 identical), so this needs co-residency: it is batch composition, not the request itself. It bites inputs sitting on a near-tie. In one case the same prompt produced either a long answer or an essentially empty one, a sub-ULP difference selecting between "emit content" and "emit nothing".

### Why the existing determinism tests do not catch this

`tests/v1/determinism/test_batch_invariance.py` passes on a configuration where the above is failing. Two structural blind spots:

1. **`needle_prompt = "There once was a "`**: the request whose output is *checked* is 7 characters, and only the fillers are long. Short prompts are reproducible even when the config is broken.
2. **`max_tokens = 128` for every request**: all requests decode the same number of steps and retire *together*, so decode batch composition is constant for the whole test.

The condition that breaks is batch composition **changing mid-decode**, not batch size.

### Caveat

The end-to-end numbers were taken on v0.23.0 with #46639's Marlin MoE kernel back-ported and compiled for sm80, since MXFP4 MoE has no batch-invariant kernel on sm80 otherwise. The config change here is architecture independent and covered by the CPU-only tests. A maintainer re-running the determinism suite on a natively supported configuration would be worth doing before merge.

The serve configuration, the build recipe for that sm80 kernel, and a fuller version of the test script above are at https://github.com/GiesDSRS/batch-invariant-vllm-a100.
