### PR TITLE
[ROCm][Bugfix] Restore AITER-compatible Triton 3.7 pin

### DIFF
--- a/docker/Dockerfile.rocm_base
+++ b/docker/Dockerfile.rocm_base
@@ -1,5 +1,5 @@
 ARG BASE_IMAGE=rocm/dev-ubuntu-22.04:7.2.3-complete
-ARG TRITON_BRANCH="89002410" # AITER v0.1.19 ROCm 7.2 wheel
+ARG TRITON_BRANCH="89002410dee054a1207a3d88cfbe1748dacfd819" # AITER v0.1.19 ROCm 7.2 wheel
 ARG TRITON_REPO="https://github.com/ROCm/triton.git"
 ARG PYTORCH_BRANCH="6bbd260" # release/2.12 as of 08/02
 ARG PYTORCH_REPO="https://github.com/ROCm/pytorch.git"
@@ -113,7 +113,8 @@ ARG TRITON_BRANCH
 ARG TRITON_REPO
 RUN git clone ${TRITON_REPO}
 RUN cd triton \
-    && git checkout ${TRITON_BRANCH} \
+    && git fetch --depth=1 origin ${TRITON_BRANCH} \
+    && git checkout --detach FETCH_HEAD \
     && git config --global user.email "you@example.com" && git config --global user.name "Your Name" \
     && if [ ! -f setup.py ]; then cd python; fi \
     && python3 setup.py bdist_wheel --dist-dir=dist \

--- a/docker/Dockerfile.rocm_base
+++ b/docker/Dockerfile.rocm_base
@@ -1,5 +1,5 @@
 ARG BASE_IMAGE=rocm/dev-ubuntu-22.04:7.2.3-complete
-ARG TRITON_BRANCH="0263a6a" # release/internal/3.7.x as of 08/02
+ARG TRITON_BRANCH="89002410" # AITER v0.1.19 ROCm 7.2 wheel
 ARG TRITON_REPO="https://github.com/ROCm/triton.git"
 ARG PYTORCH_BRANCH="6bbd260" # release/2.12 as of 08/02
 ARG PYTORCH_REPO="https://github.com/ROCm/pytorch.git"


### PR DESCRIPTION
## Purpose

Restore an AITER-compatible ROCm Triton 3.7 pin.

[vLLM #50607](https://github.com/vllm-project/vllm/pull/50607) moved the ROCm image to Triton `0263a6a` from `release/internal/3.7.x`. That revision rejects the `DistributedLinearLayout` offsets produced by AITER's CDNA4 Gluon MLA kernel:

```text
expected offsets type layout to be BlockedLayout or SliceLayout
```

The Kimi-K3 DSpark K=7 stress reproducer reaches this path during piecewise graph capture because the draft verifies eight query tokens across 12 local heads. Pinning ROCm Triton to `89002410` restores the distributed-layout lowering used by AITER without changing vLLM or AITER runtime code. The production InferenceX configuration uses K=2 and is tested separately below.

This restores compilation and execution of AITER's actual Gluon MLA kernel; it does not disable Gluon or route the workload to a different attention backend.

At the package-version level, this is a compatibility rollback from Triton 3.7.1 to the validated 3.7.0 revision. The commits are on divergent branches, so this is not a linear Git revert. A corrected internal 3.7.x revision can replace this pin after the complete layout support is backported and validated.

[AITER v0.1.19's default installer](https://github.com/ROCm/aiter/blob/v0.1.19/.github/scripts/install_triton.sh#L77-L83) pins `triton==3.7.0`. On AITER's ROCm 7.2 package index, that resolves to `triton-3.7.0+amd.rocm7.2.0.git89002410`, so this change matches AITER's production wheel exactly. AITER's older `756afc06` pin is used only by its opt-in source-build CI path.

I searched open vLLM, AITER, and ROCm Triton issues and pull requests for the error, the two Triton revisions, and the AITER MLA layout. I found no existing fix. [Triton #9513](https://github.com/triton-lang/triton/pull/9513) is related: cherry-picking only its relaxed `DistributedLayout` type check onto ROCm Triton's `release/internal/3.7.x` branch at the exact vLLM-pinned base commit [`0263a6a6203cf27c441c57a6c808ea87ffb8f654`](https://github.com/ROCm/triton/commit/0263a6a6203cf27c441c57a6c808ea87ffb8f654) made the exact Kimi-K3 shape compile, but the default two-split path still produced nondeterministic incorrect output. In a deterministic seed sweep from 0 through 15, seeds 7, 10, 14, and 15 failed at `atol=rtol=0.01`; seeds 7 and 10 had about 10.3% mismatching elements with maximum absolute errors of 3.67 and 3.84. Repeated seed-7 runs used identical input and reference hashes but produced different GPU output hashes, with mismatches confined to query position 2 across all 12 heads. Forcing one split on the same inputs passed with maximum absolute error `0.00390625`, isolating the remaining problem to the multi-split Stage-1/Stage-2 dependency rather than the frontend layout check. Therefore the isolated #9513 backport is not sufficient; the validated `89002410` revision is used instead.

AI assistance was used for root-cause investigation and drafting. The submitter reviewed the Dockerfile changes and test evidence before opening this pull request.

## Test Plan

### 1. Docker build

Build the same stage changed by this PR:

```bash
docker build \
  -f docker/Dockerfile.rocm_base \
  --target build_triton \
  -t vllm-rocm-build-triton:89002410 .
```

The stage must fetch the full immutable commit, complete the Triton build, and produce a `triton-3.7.0+git89002410` wheel.

### 2. AITER MLA operator reproducer

Compare the immutable ROCm nightly image `sha256:726321b39e1dbbe24d2735160be54d679496ef5d2a8479a264394f7296908617` with only its Triton package changed from `0263a6a` to `89002410`.

Run the AITER MLA operator at the Kimi-K3 DSpark verification shape:

```bash
python3 op_tests/test_mla.py -c 128 -b 1 -n 12,8 \
  -k 512 -qn 512 -qr 64 -vh 512 -blk 1 \
  -d bf16 -kvd bf16 --causal
```

Also run context length 256 while forcing the one- and two-split reduction paths.

### 3. TP8 endpoint smoke test

Build a new ROCm base image directly from this PR's `docker/Dockerfile.rocm_base`. Then build the runnable vLLM server image from the same PR checkout using that base. Do not install or copy Triton into an existing nightly image.

```bash
git rev-parse HEAD
# 2d1bb40fb4a07e65706749b77c1701eed771695a

DOCKER_BUILDKIT=1 docker build \
  --progress=plain \
  -f docker/Dockerfile.rocm_base \
  -t rocm/vllm-dev:pr51291-base .

DOCKER_BUILDKIT=1 docker build \
  --progress=plain \
  -f docker/Dockerfile.rocm \
  --build-arg BASE_IMAGE=rocm/vllm-dev:pr51291-base \
  -t vllm/vllm-openai-rocm:pr51291-source .
```

Verify that the runnable image contains the PR source revision and the Triton wheel produced by the base-image build:

```bash
docker run --rm --entrypoint /bin/bash \
  vllm/vllm-openai-rocm:pr51291-source -lc '
    cat /app/versions.txt
    python3 - <<"PY"
from importlib.metadata import version
import triton
import vllm
print("vLLM:", vllm.__version__)
print("AITER:", version("amd-aiter"))
print("Triton:", triton.__version__)
PY
  '
```

`/app/versions.txt` must contain `TRITON_BRANCH: 89002410dee054a1207a3d88cfbe1748dacfd819`, and the installed Triton version must be `3.7.0+git89002410`.

Start Kimi-K3 and DSpark on 8x MI355X. This uses InferenceX's production DSpark level 2 and its token-aligned capture sizes: with K=2, each sequence has a decode width of three tokens, so the capture list is `3,6,...,48` for `max_num_seqs=16`.

This validation fixes both the model and KV cache to BF16. The command uses `--kv-cache-dtype bfloat16` explicitly rather than relying on dtype inference.

```bash
docker run -d --name vllm-kimi-k3-pr51291-source-k2-ix \
  --network host --ipc host \
  --device /dev/kfd --device /dev/dri --group-add video \
  --cap-add SYS_PTRACE \
  --security-opt seccomp=unconfined --security-opt label=disable \
  -v /data/huggingface/Kimi-K3:/model:ro \
  -v /data/huggingface/Kimi-K3-DSpark:/draft:ro \
  -e HIP_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 \
  -e ROCR_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 \
  -e AITER_ROCM_ARCH=gfx950 \
  -e VLLM_ROCM_USE_AITER=1 \
  -e VLLM_ROCM_USE_AITER_FP4BMM=1 \
  -e SAFETENSORS_FAST_GPU=1 \
  -e AITER_SITUV2_A8W4=1 \
  -e AITER_BF16_FP8_MOE_BOUND=0 \
  -e VLLM_USE_BREAKABLE_CUDAGRAPH=0 \
  --entrypoint vllm \
  vllm/vllm-openai-rocm:pr51291-source \
  serve /model \
  --served-model-name moonshotai/Kimi-K3 \
  --host 0.0.0.0 --port 8000 \
  --tensor-parallel-size 8 \
  --distributed-executor-backend mp \
  --trust-remote-code \
  --load-format auto --moe-backend auto \
  --gpu-memory-utilization 0.95 \
  --kv-cache-memory-bytes 51539607552 \
  --kv-cache-dtype bfloat16 \
  --mm-encoder-tp-mode data \
  --max-num-seqs 16 \
  --max-num-batched-tokens 4096 \
  --max-model-len 1048576 \
  --enable-prefix-caching \
  --enable-auto-tool-choice \
  --tool-call-parser kimi_k3 \
  --reasoning-parser kimi_k3 \
  --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY","custom_ops":["+fused_rms_norm_gated"],"cudagraph_capture_sizes":[3,6,9,12,15,18,21,24,27,30,33,36,39,42,45,48]}' \
  --speculative-config '{"method":"dspark","model":"/draft","num_speculative_tokens":2,"attention_backend":"TRITON_MLA","draft_sample_method":"probabilistic","rejection_sample_method":"block"}'
```

Wait for readiness and send a chat smoke request:

```bash
until curl --fail --silent http://127.0.0.1:8000/health; do
  test "$(docker inspect -f '{{.State.Status}}' vllm-kimi-k3-pr51291-source-k2-ix 2>/dev/null)" = running || {
    docker logs vllm-kimi-k3-pr51291-source-k2-ix
    exit 1
  }
  sleep 30
done

curl --fail --silent --show-error \
  http://127.0.0.1:8000/v1/chat/completions \
  -H 'Content-Type: application/json' \
  -d '{"model":"moonshotai/Kimi-K3","messages":[{"role":"user","content":"Reply with one short word."}],"temperature":0,"max_tokens":16}'
```

### 4. Repository checks

```bash
pre-commit run --files docker/Dockerfile.rocm_base
```

## Test Result

### Docker build

The `build_triton` target fetched and checked out `89002410dee054a1207a3d88cfbe1748dacfd819`, completed all 503 compilation steps, and generated the `triton-3.7.0+git89002410` wheel.

### Operator result

MI355X, TP8 system, BF16 inputs and KV cache:

```bash
# Context 128, automatic split selection.
python3 op_tests/test_mla.py -c 128 -b 1 -n 12,8 \
  -k 512 -qn 512 -qr 64 -vh 512 -blk 1 \
  -d bf16 -kvd bf16 --causal

# Context 256, force the single-split path.
python3 op_tests/test_mla.py -c 256 -b 1 -n 12,8 \
  -k 512 -qn 512 -qr 64 -vh 512 -blk 1 \
  -d bf16 -kvd bf16 --causal --gluon-num-kv-splits 1

# Context 256, force the two-split Stage-1/Stage-2 path.
python3 op_tests/test_mla.py -c 256 -b 1 -n 12,8 \
  -k 512 -qn 512 -qr 64 -vh 512 -blk 1 \
  -d bf16 -kvd bf16 --causal --gluon-num-kv-splits 2
```

| Test | `0263a6a` | `89002410` |
|---|---|---|
| MLA, context 128, automatic two splits | compile error | pass, 10.30 us |
| MLA, context 256, forced one split | compile error | pass, 10.64 us |
| MLA, context 256, forced two splits | compile error | pass, 10.80 us |

All passing operator cases matched the PyTorch reference with maximum absolute error `0.00390625` at `atol=rtol=0.01` and zero failing elements. These tests executed `aiter.ops.triton.gluon.mla_gluon`, including the Kimi-K3 12-head, eight-query-token verification shape.

### TP8 endpoint result

The image build and endpoint smoke were run with images built from this PR's source tree and Dockerfiles; no package was replaced in an existing nightly image. No other vLLM pull request or AITER overlay was included. Explicit BF16 KV startup was reconfirmed on 2026-08-07.

- Base image: `rocm/vllm-dev:pr51291-base` (`sha256:a53d6c7dae565b2c7df3e530c2eeec496b259d22195e3115ed4ca82737aa4a3b`)
- Runnable image: `vllm/vllm-openai-rocm:pr51291-source` (`sha256:4212a65ac86027e370b18ba2ad8acbb53e0f9d72c6d8a64ddf611bf75abf061b`)
- Runtime versions: vLLM `0.1.dev19627+g2d1bb40fb.d20260806`, Triton distribution `3.7.0+git89002410`, AITER `0.1.19`, PyTorch `2.12.0+git6bbd260`
- Hardware: 8x MI355X (`gfx950`), TP8
- KV cache: BF16, selected explicitly with `--kv-cache-dtype bfloat16`
- Target backend: `ROCM_AITER_MLA`; DSpark draft backend: `TRITON_MLA`
- With K=2 and the explicit InferenceX token-aligned capture list, piecewise graph capture completed for all 16 capture sizes on all eight ranks in 66 seconds.
- `/health` returned HTTP 200. A chat-completions smoke request returned HTTP 200 with 16 completion tokens.
- Speculative decoding was active: the K=2 smoke metrics recorded 11 drafts, 22 draft tokens, and four accepted tokens; both draft positions recorded at least one accepted token.

The chat request is an endpoint/runtime smoke test, not an accuracy evaluation.

All pre-commit hooks applicable to `docker/Dockerfile.rocm_base` passed.
