### PR TITLE
[CI] Re-enable FI autotune in GSM8K config for Qwen3.5-35B-A3B

### DIFF
--- a/tests/evals/gsm8k/configs/Qwen3.5-35B-A3B-DEP2.yaml
+++ b/tests/evals/gsm8k/configs/Qwen3.5-35B-A3B-DEP2.yaml
@@ -7,4 +7,3 @@ server_args: >-
   --max-model-len 4096
   --data-parallel-size 2
   --enable-expert-parallel
-  --no-enable-flashinfer-autotune


### PR DESCRIPTION
## Purpose

Recently [[Bug]: GPU coredump during FlashInfer trtllm_bf16_moe autotune with Qwen3.5-35B-A3B on B200 (DP=2 + EP) #46083](https://github.com/vllm-project/vllm/issues/46083) found bug in FI MoE kernel autotuning. Because of this bug CI job `LM Eval Qwen3.5 Models (B200)` was failing. To fix CI job's failure [[Bugfix] fix qwen3.5 ep weight loading #45002](https://github.com/vllm-project/vllm/pull/45002) [disabled](https://github.com/vllm-project/vllm/pull/45002/changes#diff-1b06739ebf770bfaf311043c5ae02d8b4ce673d1ea445e8258f2d6733ee1fa2c) FI autotune in GSM8K config.

FI MoE autotuning bug was fixed. vLLM on commit `5fba75aefeedcf5b6cc27abf9bc145b6a49873a7` passes the reproduction test from bug report https://github.com/vllm-project/vllm/issues/46083. So, now it's time to re-enable FI autotuning for FI.

## Test Result

Reproduced testing from bug report https://github.com/vllm-project/vllm/issues/46083

```bash
cd tests && pytest -s -v evals/gsm8k/test_gsm8k_correctness.py \
  --config-list-file=configs/models-qwen35-blackwell.txt \
  -k Qwen3.5-35B-A3B-DEP2
```

**Result:** no failures

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>
