### PR TITLE
[LoRA] Add fixed-weight routed LoRA reference path

### DIFF
--- a/tests/lora/test_lora_routing.py
+++ b/tests/lora/test_lora_routing.py
@@ -1,0 +1,1035 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import numpy as np
+import pytest
+import torch
+import torch.nn.functional as F
+
+from vllm.config.lora import LoRAConfig
+from vllm.lora.layers import (
+    ColumnParallelLinearWithShardedLoRA,
+    LoRARouteMapping,
+    MergedQKVParallelLinearWithLoRA,
+    MergedQKVParallelLinearWithShardedLoRA,
+    ReplicatedLinearWithLoRA,
+    RowParallelLinearWithShardedLoRA,
+)
+from vllm.lora.punica_wrapper.punica_cpu import PunicaWrapperCPU
+from vllm.lora.punica_wrapper.utils import convert_route_mapping
+from vllm.lora.request import (
+    LoRARequest,
+    LoRARoutingRequest,
+    iter_lora_int_ids,
+    iter_lora_requests,
+)
+from vllm.lora.routing_utils import add_lora_request, remove_lora_request
+from vllm.model_executor.layers.linear import (
+    ColumnParallelLinear,
+    LinearBase,
+    LinearMethodBase,
+    QKVParallelLinear,
+    ReplicatedLinear,
+    RowParallelLinear,
+)
+from vllm.model_executor.layers.quantization import QuantizationMethods
+from vllm.model_executor.layers.quantization.base_config import QuantizationConfig
+from vllm.model_executor.parameter import ModelWeightParameter
+from vllm.model_executor.utils import set_weight_attrs
+from vllm.v1.worker.gpu.lora_utils import LoraState
+
+pytestmark = pytest.mark.skip_global_cleanup
+
+
+def fake_quantize_activation(x: torch.Tensor, num_bits: int) -> torch.Tensor:
+    max_int = 2 ** (num_bits - 1) - 1
+    min_int = -(2 ** (num_bits - 1))
+    scale = torch.amax(torch.abs(x), dim=-1, keepdim=True) / max_int
+    scale = torch.clamp(scale, min=torch.finfo(x.dtype).eps)
+    quantized_x = torch.clamp(torch.round(x / scale), min_int, max_int)
+    return quantized_x * scale
+
+
+class FakeQuantLinearMethod(LinearMethodBase):
+    def __init__(self, num_bits: int) -> None:
+        self.num_bits = num_bits
+
+    def create_weights(
+        self,
+        layer: torch.nn.Module,
+        input_size_per_partition: int,
+        output_partition_sizes: list[int],
+        input_size: int,
+        output_size: int,
+        params_dtype: torch.dtype,
+        **extra_weight_attrs,
+    ) -> None:
+        del input_size, output_size
+        weight_loader = extra_weight_attrs.pop("weight_loader")
+        weight = ModelWeightParameter(
+            data=torch.empty(
+                sum(output_partition_sizes),
+                input_size_per_partition,
+                dtype=params_dtype,
+            ),
+            input_dim=1,
+            output_dim=0,
+            weight_loader=weight_loader,
+        )
+        layer.register_parameter("weight", weight)
+        set_weight_attrs(weight, extra_weight_attrs)
+
+    def apply(
+        self,
+        layer: torch.nn.Module,
+        x: torch.Tensor,
+        bias: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        return F.linear(fake_quantize_activation(x, self.num_bits), layer.weight, bias)
+
+
+class FakeQuantConfig(QuantizationConfig):
+    def __init__(self, num_bits: int = 4) -> None:
+        super().__init__()
+        self.num_bits = num_bits
+
+    def get_name(self) -> QuantizationMethods:
+        return "custom_quant"
+
+    def get_supported_act_dtypes(self) -> list[torch.dtype]:
+        return [torch.float32]
+
+    @classmethod
+    def get_min_capability(cls) -> int:
+        return -1
+
+    @staticmethod
+    def get_config_filenames() -> list[str]:
+        return []
+
+    @classmethod
+    def from_config(cls, config: dict) -> "FakeQuantConfig":
+        return cls(num_bits=config.get("num_bits", 4))
+
+    def get_quant_method(
+        self,
+        layer: torch.nn.Module,
+        prefix: str,
+    ) -> FakeQuantLinearMethod | None:
+        if isinstance(layer, LinearBase):
+            return FakeQuantLinearMethod(self.num_bits)
+        return None
+
+
+def make_lora_request(lora_id: int) -> LoRARequest:
+    return LoRARequest(
+        lora_name=f"lora_{lora_id}",
+        lora_int_id=lora_id,
+        lora_path="/tmp/lora",
+    )
+
+
+def make_routing_request(
+    lora_requests: tuple[LoRARequest, ...],
+    lora_weights: tuple[float, ...],
+) -> LoRARoutingRequest:
+    return LoRARoutingRequest(
+        routing_name="routed",
+        routing_int_id=100,
+        lora_requests=lora_requests,
+        lora_weights=lora_weights,
+    )
+
+
+def set_tp_rank(
+    monkeypatch: pytest.MonkeyPatch,
+    rank: int,
+    tp_size: int,
+) -> None:
+    monkeypatch.setattr(
+        "vllm.model_executor.layers.linear.get_tensor_model_parallel_rank",
+        lambda: rank,
+    )
+    monkeypatch.setattr(
+        "vllm.model_executor.layers.linear.get_tensor_model_parallel_world_size",
+        lambda: tp_size,
+    )
+    monkeypatch.setattr(
+        "vllm.model_executor.parameter.get_tensor_model_parallel_rank",
+        lambda: rank,
+    )
+    monkeypatch.setattr(
+        "vllm.model_executor.parameter.get_tensor_model_parallel_world_size",
+        lambda: tp_size,
+    )
+
+
+def set_routed_mapping(
+    lora_linear,
+    route_mapping: LoRARouteMapping,
+    lora_config: LoRAConfig,
+) -> PunicaWrapperCPU:
+    punica_wrapper = PunicaWrapperCPU(
+        max_num_batched_tokens=8,
+        max_batches=4,
+        device=torch.device("cpu"),
+    )
+    lora_linear.set_mapping(punica_wrapper)
+    punica_wrapper.update_metadata(
+        route_mapping,
+        lora_index_to_id=[11, 12, None, None],
+        max_loras=lora_config.max_loras,
+        vocab_size=128,
+    )
+    return punica_wrapper
+
+
+def make_weight(start: int, rows: int, cols: int) -> torch.Tensor:
+    values = torch.arange(start, start + rows * cols, dtype=torch.float32)
+    return ((values % 17) - 8).reshape(rows, cols) / 10
+
+
+def build_column_gather_calls(lora_layers, x: torch.Tensor):
+    route_mapping = lora_layers[0].punica_wrapper.lora_route_mapping
+    token_lora_indices, token_lora_weights = route_mapping
+    calls = []
+    for slice_idx in range(lora_layers[0].n_slices):
+        for lora_idx, token_mask, _ in lora_layers[0]._iter_lora_route_groups(
+            token_lora_indices, token_lora_weights
+        ):
+            local_shrinks = []
+            for lora_layer in lora_layers:
+                lora_a = lora_layer.lora_a_stacked[slice_idx]
+                local_shrinks.append(
+                    x[token_mask].to(dtype=lora_a.dtype) @ lora_a[lora_idx, 0].T
+                )
+            calls.append((local_shrinks, torch.cat(local_shrinks, dim=-1)))
+    return calls
+
+
+def build_row_reduce_calls(lora_layers, x_shards: list[torch.Tensor]):
+    route_mapping = lora_layers[0].punica_wrapper.lora_route_mapping
+    token_lora_indices, token_lora_weights = route_mapping
+    calls = []
+    for lora_idx, token_mask, _ in lora_layers[0]._iter_lora_route_groups(
+        token_lora_indices, token_lora_weights
+    ):
+        local_shrinks = []
+        for lora_layer, x_shard in zip(lora_layers, x_shards):
+            lora_a = lora_layer.lora_a_stacked[0]
+            local_shrinks.append(
+                x_shard[token_mask].to(dtype=lora_a.dtype) @ lora_a[lora_idx, 0].T
+            )
+        calls.append((local_shrinks, torch.stack(local_shrinks).sum(dim=0)))
+    return calls
+
+
+def apply_routed_delta(
+    expected: torch.Tensor,
+    x: torch.Tensor,
+    lora_as: tuple[torch.Tensor, ...],
+    lora_bs: tuple[torch.Tensor, ...],
+    route_weights: tuple[tuple[float, ...], ...],
+    delta_slice: slice | None = None,
+) -> torch.Tensor:
+    for token_idx in range(x.shape[0]):
+        for route_idx, (lora_a, lora_b) in enumerate(zip(lora_as, lora_bs)):
+            delta = x[token_idx] @ lora_a.T @ lora_b.T
+            if delta_slice is not None:
+                delta = delta[delta_slice]
+            expected[token_idx] += route_weights[token_idx][route_idx] * delta
+    return expected
+
+
+def test_lora_routing_request_validates_adapters_and_weights():
+    lora_1 = make_lora_request(1)
+    lora_2 = make_lora_request(2)
+
+    request = make_routing_request((lora_1, lora_2), (0.7, 0.3))
+
+    assert request.top_k == 2
+    assert request.lora_name == "routed"
+    assert request.adapter_id == 100
+
+    with pytest.raises(ValueError, match="cannot be empty"):
+        make_routing_request((), ())
+
+    with pytest.raises(ValueError, match="same length"):
+        make_routing_request((lora_1, lora_2), (1.0,))
+
+    with pytest.raises(ValueError, match="duplicate"):
+        make_routing_request((lora_1, lora_1), (0.5, 0.5))
+
+    with pytest.raises(ValueError, match="finite"):
+        make_routing_request((lora_1,), (float("nan"),))
+
+    with pytest.raises(ValueError, match="non-negative"):
+        make_routing_request((lora_1,), (-1.0,))
+
+    with pytest.raises(ValueError, match="positive"):
+        make_routing_request((lora_1,), (0.0,))
+
+
+def test_lora_request_helpers_return_concrete_adapters():
+    lora_1 = make_lora_request(1)
+    lora_2 = make_lora_request(2)
+    routed_request = make_routing_request((lora_1, lora_2), (0.25, 0.75))
+
+    assert iter_lora_requests(None) == ()
+    assert iter_lora_requests(lora_1) == (lora_1,)
+    assert iter_lora_requests(routed_request) == (lora_1, lora_2)
+    assert iter_lora_int_ids(None) == ()
+    assert iter_lora_int_ids(lora_1) == (1,)
+    assert iter_lora_int_ids(routed_request) == (1, 2)
+
+
+def test_lora_routing_utils_track_indexed_requests():
+    lora_1 = make_lora_request(1)
+    lora_2 = make_lora_request(2)
+    lora_3 = make_lora_request(3)
+    routed_request = make_routing_request((lora_1, lora_2), (0.25, 0.75))
+    request_lora_mapping = np.zeros(3, dtype=np.int64)
+    request_lora_requests = {}
+    lora_id_to_request_ids = {}
+    lora_id_to_lora_request = {}
+
+    add_lora_request(
+        request_lora_mapping,
+        request_lora_requests,
+        lora_id_to_request_ids,
+        lora_id_to_lora_request,
+        req_index=0,
+        req_id="req_0",
+        lora_request=routed_request,
+    )
+    add_lora_request(
+        request_lora_mapping,
+        request_lora_requests,
+        lora_id_to_request_ids,
+        lora_id_to_lora_request,
+        req_index=1,
+        req_id="req_1",
+        lora_request=lora_3,
+    )
+
+    assert tuple(request_lora_mapping) == (0, 3, 0)
+    assert request_lora_requests == {0: routed_request, 1: lora_3}
+    assert lora_id_to_request_ids == {
+        1: {"req_0"},
+        2: {"req_0"},
+        3: {"req_1"},
+    }
+    assert lora_id_to_lora_request == {1: lora_1, 2: lora_2, 3: lora_3}
+
+    remove_lora_request(
+        request_lora_mapping,
+        request_lora_requests,
+        lora_id_to_request_ids,
+        lora_id_to_lora_request,
+        req_index=0,
+        req_id="req_0",
+    )
+
+    assert tuple(request_lora_mapping) == (0, 3, 0)
+    assert request_lora_requests == {1: lora_3}
+    assert lora_id_to_request_ids == {3: {"req_1"}}
+    assert lora_id_to_lora_request == {3: lora_3}
+
+
+def test_convert_route_mapping_rejects_unloaded_lora_id():
+    route_mapping = LoRARouteMapping(
+        token_lora_ids=((11, 12),),
+        token_lora_weights=((0.7, 0.3),),
+        prompt_mapping=(0,),
+    )
+
+    with pytest.raises(ValueError, match=r"unloaded LoRA ids: \[12\]"):
+        convert_route_mapping(
+            route_mapping,
+            lora_index_to_id=[11, None],
+            device=torch.device("cpu"),
+        )
+
+
+def test_scalar_lora_state_does_not_build_route_mapping():
+    lora_1 = make_lora_request(1)
+    lora_2 = make_lora_request(2)
+    state = LoraState(max_num_reqs=3)
+    state.add_request("req_0", 0, lora_1)
+    state.add_request("req_1", 1, None)
+    state.add_request("req_2", 2, lora_2)
+
+    prompt_mapping, token_mapping, active_loras, route_mapping = state.make_lora_inputs(
+        req_ids=["req_0", "req_1", "req_2"],
+        idx_mapping=np.array([0, 1, 2]),
+        num_scheduled_tokens=np.array([2, 0, 1], dtype=np.int32),
+    )
+
+    assert prompt_mapping == (1, 0, 2)
+    assert token_mapping == (1, 1, 2)
+    assert {request.lora_int_id for request in active_loras} == {1, 2}
+    assert route_mapping is None
+
+
+def test_lora_state_builds_flattened_route_mapping_for_mixed_batch():
+    lora_1 = make_lora_request(1)
+    lora_2 = make_lora_request(2)
+    lora_3 = make_lora_request(3)
+    routed_request = make_routing_request((lora_1, lora_2), (0.6, 0.4))
+    state = LoraState(max_num_reqs=3)
+    state.add_request("req_0", 0, routed_request)
+    state.add_request("req_1", 1, lora_3)
+    state.add_request("req_2", 2, None)
+
+    prompt_mapping, token_mapping, active_loras, route_mapping = state.make_lora_inputs(
+        req_ids=["req_0", "req_1", "req_2"],
+        idx_mapping=np.array([0, 1, 2]),
+        num_scheduled_tokens=np.array([2, 1, 1], dtype=np.int32),
+    )
+
+    assert prompt_mapping == (0, 0, 0)
+    assert token_mapping == (0, 0, 0, 0)
+    assert {request.lora_int_id for request in active_loras} == {1, 2, 3}
+    assert route_mapping is not None
+    assert route_mapping.token_lora_ids == ((1, 2), (1, 2), (3, 0), (0, 0))
+    assert route_mapping.token_lora_weights == (
+        (0.6, 0.4),
+        (0.6, 0.4),
+        (1.0, 0.0),
+        (0.0, 0.0),
+    )
+
+
+@torch.inference_mode()
+@pytest.mark.parametrize("fully_sharded_loras", [False, True])
+def test_routed_lora_reference_linear_matches_oracle(
+    monkeypatch: pytest.MonkeyPatch,
+    fully_sharded_loras: bool,
+):
+    monkeypatch.setattr(
+        "vllm.model_executor.parameter.get_tensor_model_parallel_rank",
+        lambda: 0,
+    )
+    monkeypatch.setattr(
+        "vllm.model_executor.parameter.get_tensor_model_parallel_world_size",
+        lambda: 1,
+    )
+
+    device = torch.device("cpu")
+    lora_config = LoRAConfig(
+        max_loras=4,
+        max_lora_rank=8,
+        fully_sharded_loras=fully_sharded_loras,
+        lora_dtype=torch.float32,
+    )
+    linear = ReplicatedLinear(
+        4,
+        3,
+        bias=False,
+        params_dtype=torch.float32,
+        prefix="routed_lora_test",
+        disable_tp=True,
+    )
+    linear.weight.data = torch.tensor(
+        [
+            [0.2, 0.1, -0.3, 0.4],
+            [0.5, -0.2, 0.6, 0.1],
+            [-0.4, 0.3, 0.2, -0.1],
+        ],
+        dtype=torch.float32,
+    )
+    lora_linear = ReplicatedLinearWithLoRA(linear)
+    lora_linear.create_lora_weights(lora_config.max_loras, lora_config)
+    punica_wrapper = PunicaWrapperCPU(
+        max_num_batched_tokens=8,
+        max_batches=4,
+        device=device,
+    )
+    lora_linear.set_mapping(punica_wrapper)
+
+    lora_1_a = torch.tensor(
+        [[0.1, 0.0, 0.2, -0.1], [0.0, 0.3, -0.2, 0.4]],
+        dtype=torch.float32,
+    )
+    lora_1_b = torch.tensor(
+        [[0.2, -0.1], [0.4, 0.3], [-0.3, 0.1]],
+        dtype=torch.float32,
+    )
+    lora_2_a = torch.tensor(
+        [[-0.2, 0.5, 0.1, 0.0], [0.3, -0.1, 0.0, 0.2]],
+        dtype=torch.float32,
+    )
+    lora_2_b = torch.tensor(
+        [[0.1, 0.2], [-0.2, 0.5], [0.3, -0.4]],
+        dtype=torch.float32,
+    )
+    lora_linear.set_lora(0, lora_1_a, lora_1_b)
+    lora_linear.set_lora(1, lora_2_a, lora_2_b)
+
+    route_mapping = LoRARouteMapping(
+        token_lora_ids=((11, 12), (11, 12), (12, 0)),
+        token_lora_weights=((0.7, 0.3), (0.25, 0.75), (1.0, 0.0)),
+        prompt_mapping=(0,),
+        is_prefill=True,
+    )
+    punica_wrapper.update_metadata(
+        route_mapping,
+        lora_index_to_id=[11, 12, None, None],
+        max_loras=lora_config.max_loras,
+        vocab_size=128,
+    )
+
+    x = torch.tensor(
+        [
+            [1.0, 0.5, -0.5, 2.0],
+            [-1.0, 1.5, 0.25, -0.75],
+            [0.2, -0.4, 0.6, 0.8],
+        ],
+        dtype=torch.float32,
+    )
+
+    result = lora_linear(x)[0]
+    base = linear(x)[0]
+    lora_1_delta = x @ lora_1_a.T @ lora_1_b.T
+    lora_2_delta = x @ lora_2_a.T @ lora_2_b.T
+    expected = base.clone()
+    expected[0] += 0.7 * lora_1_delta[0] + 0.3 * lora_2_delta[0]
+    expected[1] += 0.25 * lora_1_delta[1] + 0.75 * lora_2_delta[1]
+    expected[2] += lora_2_delta[2]
+
+    torch.testing.assert_close(result, expected)
+
+
+@torch.inference_mode()
+def test_routed_lora_reference_quantized_linear_matches_oracle(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(
+        "vllm.model_executor.parameter.get_tensor_model_parallel_rank",
+        lambda: 0,
+    )
+    monkeypatch.setattr(
+        "vllm.model_executor.parameter.get_tensor_model_parallel_world_size",
+        lambda: 1,
+    )
+
+    device = torch.device("cpu")
+    lora_config = LoRAConfig(
+        max_loras=4,
+        max_lora_rank=8,
+        lora_dtype=torch.float32,
+    )
+    linear = ReplicatedLinear(
+        4,
+        2,
+        bias=False,
+        params_dtype=torch.float32,
+        quant_config=FakeQuantConfig(num_bits=4),
+        prefix="routed_lora_quantized_test",
+        disable_tp=True,
+    )
+    assert isinstance(linear.quant_method, FakeQuantLinearMethod)
+    linear.weight.data = torch.tensor(
+        [
+            [0.2, -0.3, 0.5, 0.1],
+            [-0.4, 0.6, 0.2, -0.2],
+        ],
+        dtype=torch.float32,
+    )
+    lora_linear = ReplicatedLinearWithLoRA(linear)
+    lora_linear.create_lora_weights(lora_config.max_loras, lora_config)
+    punica_wrapper = PunicaWrapperCPU(
+        max_num_batched_tokens=8,
+        max_batches=4,
+        device=device,
+    )
+    lora_linear.set_mapping(punica_wrapper)
+
+    lora_1_a = torch.tensor(
+        [[0.1, -0.2, 0.3, 0.0], [0.4, 0.1, -0.1, 0.2]],
+        dtype=torch.float32,
+    )
+    lora_1_b = torch.tensor(
+        [[0.2, -0.4], [0.5, 0.1]],
+        dtype=torch.float32,
+    )
+    lora_2_a = torch.tensor(
+        [[-0.3, 0.2, 0.0, 0.5], [0.1, 0.4, -0.2, 0.3]],
+        dtype=torch.float32,
+    )
+    lora_2_b = torch.tensor(
+        [[-0.1, 0.3], [0.4, -0.2]],
+        dtype=torch.float32,
+    )
+    lora_linear.set_lora(0, lora_1_a, lora_1_b)
+    lora_linear.set_lora(1, lora_2_a, lora_2_b)
+
+    route_mapping = LoRARouteMapping(
+        token_lora_ids=((11, 12), (12, 0)),
+        token_lora_weights=((0.4, 0.6), (1.0, 0.0)),
+        prompt_mapping=(0,),
+        is_prefill=True,
+    )
+    punica_wrapper.update_metadata(
+        route_mapping,
+        lora_index_to_id=[11, 12, None, None],
+        max_loras=lora_config.max_loras,
+        vocab_size=128,
+    )
+
+    x = torch.tensor(
+        [
+            [1.25, -0.5, 0.2, 2.0],
+            [-0.7, 1.1, -0.3, 0.5],
+        ],
+        dtype=torch.float32,
+    )
+
+    result = lora_linear(x)[0]
+    quantized_base = F.linear(fake_quantize_activation(x, 4), linear.weight)
+    unquantized_base = F.linear(x, linear.weight)
+    assert not torch.allclose(quantized_base, unquantized_base)
+
+    lora_1_delta = x @ lora_1_a.T @ lora_1_b.T
+    lora_2_delta = x @ lora_2_a.T @ lora_2_b.T
+    expected = quantized_base.clone()
+    expected[0] += 0.4 * lora_1_delta[0] + 0.6 * lora_2_delta[0]
+    expected[1] += lora_2_delta[1]
+
+    torch.testing.assert_close(result, expected)
+
+
+@torch.inference_mode()
+def test_routed_lora_reference_fully_sharded_column_parallel_matches_oracle(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    tp_size = 2
+    lora_config = LoRAConfig(
+        max_loras=4,
+        max_lora_rank=8,
+        fully_sharded_loras=True,
+        lora_dtype=torch.float32,
+    )
+    full_weight = torch.tensor(
+        [
+            [0.2, -0.1, 0.3, 0.4],
+            [-0.4, 0.5, 0.1, -0.2],
+            [0.6, 0.2, -0.5, 0.1],
+            [0.3, -0.3, 0.4, 0.2],
+        ],
+        dtype=torch.float32,
+    )
+    lora_1_a = make_weight(20, 8, 4)
+    lora_1_b = make_weight(60, 4, 8)
+    lora_2_a = make_weight(100, 8, 4)
+    lora_2_b = make_weight(140, 4, 8)
+    route_weights = ((0.7, 0.3), (0.25, 0.75), (0.0, 1.0))
+    route_mapping = LoRARouteMapping(
+        token_lora_ids=((11, 12), (11, 12), (0, 12)),
+        token_lora_weights=route_weights,
+        prompt_mapping=(0,),
+        is_prefill=True,
+    )
+    x = torch.tensor(
+        [
+            [1.0, 0.5, -0.5, 2.0],
+            [-1.0, 1.5, 0.25, -0.75],
+            [0.2, -0.4, 0.6, 0.8],
+        ],
+        dtype=torch.float32,
+    )
+
+    lora_layers = []
+    for rank in range(tp_size):
+        set_tp_rank(monkeypatch, rank, tp_size)
+        linear = ColumnParallelLinear(
+            4,
+            4,
+            bias=False,
+            params_dtype=torch.float32,
+            prefix=f"routed_column_sharded_lora_test_{rank}",
+            tp_rank=rank,
+            tp_size=tp_size,
+        )
+        output_shard = full_weight.shape[0] // tp_size
+        linear.weight.data = full_weight[
+            rank * output_shard : (rank + 1) * output_shard
+        ]
+        lora_linear = ColumnParallelLinearWithShardedLoRA(linear)
+        lora_linear.create_lora_weights(lora_config.max_loras, lora_config)
+        lora_linear.set_lora(0, lora_1_a, lora_1_b)
+        lora_linear.set_lora(1, lora_2_a, lora_2_b)
+        set_routed_mapping(lora_linear, route_mapping, lora_config)
+        lora_layers.append(lora_linear)
+
+    gather_calls = build_column_gather_calls(lora_layers, x)
+    state = {"rank": 0, "call_idx": 0}
+
+    def fake_all_gather(tensor: torch.Tensor, dim: int = -1) -> torch.Tensor:
+        local_shrinks, gathered = gather_calls[state["call_idx"]]
+        torch.testing.assert_close(tensor, local_shrinks[state["rank"]])
+        state["call_idx"] += 1
+        return gathered
+
+    import vllm.lora.layers.column_parallel_linear as column_linear
+
+    monkeypatch.setattr(
+        column_linear, "tensor_model_parallel_all_gather", fake_all_gather
+    )
+
+    for rank, lora_layer in enumerate(lora_layers):
+        state["rank"] = rank
+        state["call_idx"] = 0
+        result = lora_layer.apply(x)
+        assert state["call_idx"] == len(gather_calls)
+
+        output_shard = full_weight.shape[0] // tp_size
+        output_slice = slice(rank * output_shard, (rank + 1) * output_shard)
+        expected = x @ full_weight[output_slice].T
+        expected = apply_routed_delta(
+            expected,
+            x,
+            (lora_1_a, lora_2_a),
+            (lora_1_b, lora_2_b),
+            route_weights,
+            delta_slice=output_slice,
+        )
+        torch.testing.assert_close(result, expected)
+
+
+@torch.inference_mode()
+def test_routed_lora_reference_fully_sharded_row_parallel_matches_oracle(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    tp_size = 2
+    lora_config = LoRAConfig(
+        max_loras=4,
+        max_lora_rank=8,
+        fully_sharded_loras=True,
+        lora_dtype=torch.float32,
+    )
+    full_weight = make_weight(1, 4, 4)
+    lora_1_a = make_weight(20, 8, 4)
+    lora_1_b = make_weight(60, 4, 8)
+    lora_2_a = make_weight(100, 8, 4)
+    lora_2_b = make_weight(140, 4, 8)
+    route_weights = ((0.6, 0.4), (0.25, 0.75), (0.0, 1.0))
+    route_mapping = LoRARouteMapping(
+        token_lora_ids=((11, 12), (11, 12), (0, 12)),
+        token_lora_weights=route_weights,
+        prompt_mapping=(0,),
+        is_prefill=True,
+    )
+    x = make_weight(100, 3, 4)
+    input_shard_size = x.shape[1] // tp_size
+    output_shard_size = full_weight.shape[0] // tp_size
+    x_shards = [
+        x[:, rank * input_shard_size : (rank + 1) * input_shard_size]
+        for rank in range(tp_size)
+    ]
+
+    lora_layers = []
+    for rank in range(tp_size):
+        set_tp_rank(monkeypatch, rank, tp_size)
+        linear = RowParallelLinear(
+            4,
+            4,
+            bias=False,
+            input_is_parallel=True,
+            reduce_results=False,
+            params_dtype=torch.float32,
+            prefix=f"routed_row_sharded_lora_test_{rank}",
+        )
+        input_slice = slice(rank * input_shard_size, (rank + 1) * input_shard_size)
+        linear.weight.data = full_weight[:, input_slice]
+        lora_linear = RowParallelLinearWithShardedLoRA(linear)
+        lora_linear.create_lora_weights(lora_config.max_loras, lora_config)
+        lora_linear.set_lora(0, lora_1_a, lora_1_b)
+        lora_linear.set_lora(1, lora_2_a, lora_2_b)
+        set_routed_mapping(lora_linear, route_mapping, lora_config)
+        lora_layers.append(lora_linear)
+
+    reduce_calls = build_row_reduce_calls(lora_layers, x_shards)
+    state = {"rank": 0, "call_idx": 0}
+
+    def fake_all_reduce(tensor: torch.Tensor) -> torch.Tensor:
+        local_shrinks, reduced = reduce_calls[state["call_idx"]]
+        torch.testing.assert_close(tensor, local_shrinks[state["rank"]])
+        state["call_idx"] += 1
+        return reduced
+
+    import vllm.lora.layers.row_parallel_linear as row_linear
+
+    monkeypatch.setattr(row_linear, "tensor_model_parallel_all_reduce", fake_all_reduce)
+
+    routed_delta = apply_routed_delta(
+        torch.zeros(x.shape[0], full_weight.shape[0], dtype=torch.float32),
+        x,
+        (lora_1_a, lora_2_a),
+        (lora_1_b, lora_2_b),
+        route_weights,
+    )
+    rank_outputs = []
+    for rank, (lora_layer, x_shard) in enumerate(zip(lora_layers, x_shards)):
+        state["rank"] = rank
+        state["call_idx"] = 0
+        result = lora_layer.apply(x_shard)
+        assert state["call_idx"] == len(reduce_calls)
+
+        input_slice = slice(rank * input_shard_size, (rank + 1) * input_shard_size)
+        output_slice = slice(rank * output_shard_size, (rank + 1) * output_shard_size)
+        expected = x_shard @ full_weight[:, input_slice].T
+        expected[:, output_slice] += routed_delta[:, output_slice]
+        torch.testing.assert_close(result, expected)
+        rank_outputs.append(result)
+
+    full_expected = x @ full_weight.T + routed_delta
+    torch.testing.assert_close(torch.stack(rank_outputs).sum(dim=0), full_expected)
+
+
+@torch.inference_mode()
+@pytest.mark.parametrize("quantized_base", [False, True])
+def test_routed_lora_reference_qkv_parallel_matches_oracle(
+    monkeypatch: pytest.MonkeyPatch,
+    quantized_base: bool,
+):
+    monkeypatch.setattr(
+        "vllm.model_executor.parameter.get_tensor_model_parallel_rank",
+        lambda: 0,
+    )
+    monkeypatch.setattr(
+        "vllm.model_executor.parameter.get_tensor_model_parallel_world_size",
+        lambda: 1,
+    )
+
+    device = torch.device("cpu")
+    lora_config = LoRAConfig(
+        max_loras=4,
+        max_lora_rank=8,
+        lora_dtype=torch.float32,
+    )
+    linear = QKVParallelLinear(
+        hidden_size=4,
+        head_size=2,
+        total_num_heads=2,
+        total_num_kv_heads=1,
+        bias=False,
+        params_dtype=torch.float32,
+        quant_config=FakeQuantConfig(num_bits=4) if quantized_base else None,
+        prefix="routed_qkv_lora_test",
+        disable_tp=True,
+    )
+    if quantized_base:
+        assert isinstance(linear.quant_method, FakeQuantLinearMethod)
+    linear.weight.data = torch.tensor(
+        [
+            [0.2, -0.1, 0.3, 0.4],
+            [-0.4, 0.5, 0.1, -0.2],
+            [0.6, 0.2, -0.5, 0.1],
+            [0.3, -0.3, 0.4, 0.2],
+            [-0.2, 0.7, 0.1, 0.5],
+            [0.4, -0.6, 0.2, -0.1],
+            [0.5, 0.1, -0.4, 0.3],
+            [-0.1, 0.2, 0.6, -0.5],
+        ],
+        dtype=torch.float32,
+    )
+    lora_linear = MergedQKVParallelLinearWithLoRA(linear)
+    lora_linear.create_lora_weights(lora_config.max_loras, lora_config)
+    punica_wrapper = PunicaWrapperCPU(
+        max_num_batched_tokens=8,
+        max_batches=4,
+        device=device,
+    )
+    lora_linear.set_mapping(punica_wrapper)
+
+    lora_1_a = [
+        torch.tensor(
+            [[0.1, 0.2, -0.1, 0.0], [0.3, -0.2, 0.4, 0.1]],
+            dtype=torch.float32,
+        ),
+        torch.tensor(
+            [[-0.2, 0.1, 0.3, 0.4], [0.0, 0.5, -0.1, 0.2]],
+            dtype=torch.float32,
+        ),
+        torch.tensor(
+            [[0.4, -0.1, 0.2, 0.3], [-0.3, 0.2, 0.1, 0.0]],
+            dtype=torch.float32,
+        ),
+    ]
+    lora_1_b = [
+        torch.tensor(
+            [[0.2, -0.1], [0.3, 0.4], [-0.2, 0.5], [0.1, 0.2]],
+            dtype=torch.float32,
+        ),
+        torch.tensor([[0.5, -0.3], [0.2, 0.1]], dtype=torch.float32),
+        torch.tensor([[-0.4, 0.2], [0.3, 0.6]], dtype=torch.float32),
+    ]
+    lora_2_a = [
+        torch.tensor(
+            [[-0.1, 0.3, 0.2, 0.1], [0.5, 0.0, -0.2, 0.4]],
+            dtype=torch.float32,
+        ),
+        torch.tensor(
+            [[0.2, -0.4, 0.1, 0.5], [0.3, 0.1, 0.0, -0.2]],
+            dtype=torch.float32,
+        ),
+        torch.tensor(
+            [[0.0, 0.2, -0.3, 0.4], [0.1, -0.5, 0.3, 0.2]],
+            dtype=torch.float32,
+        ),
+    ]
+    lora_2_b = [
+        torch.tensor(
+            [[0.1, 0.3], [-0.5, 0.2], [0.4, -0.1], [0.2, 0.5]],
+            dtype=torch.float32,
+        ),
+        torch.tensor([[0.3, 0.4], [-0.2, 0.6]], dtype=torch.float32),
+        torch.tensor([[0.5, -0.1], [0.2, -0.3]], dtype=torch.float32),
+    ]
+    lora_linear.set_lora(0, lora_1_a, lora_1_b)
+    lora_linear.set_lora(1, lora_2_a, lora_2_b)
+
+    route_mapping = LoRARouteMapping(
+        token_lora_ids=((11, 12), (11, 12), (12, 0)),
+        token_lora_weights=((0.7, 0.3), (0.25, 0.75), (1.0, 0.0)),
+        prompt_mapping=(0,),
+        is_prefill=True,
+    )
+    punica_wrapper.update_metadata(
+        route_mapping,
+        lora_index_to_id=[11, 12, None, None],
+        max_loras=lora_config.max_loras,
+        vocab_size=128,
+    )
+
+    x = torch.tensor(
+        [
+            [1.0, 0.5, -0.5, 2.0],
+            [-1.0, 1.5, 0.25, -0.75],
+            [0.2, -0.4, 0.6, 0.8],
+        ],
+        dtype=torch.float32,
+    )
+
+    result = lora_linear(x)[0]
+    if quantized_base:
+        expected = F.linear(fake_quantize_activation(x, 4), linear.weight)
+        unquantized_base = F.linear(x, linear.weight)
+        assert not torch.allclose(expected, unquantized_base)
+    else:
+        expected = linear(x)[0]
+    expected = expected.clone()
+    route_weights = ((0.7, 0.3), (0.25, 0.75), (0.0, 1.0))
+    slot_loras = ((lora_1_a, lora_1_b), (lora_2_a, lora_2_b))
+    offset = 0
+    for slice_idx, output_slice in enumerate(lora_linear.output_slices):
+        for token_idx in range(x.shape[0]):
+            for route_idx, (lora_a, lora_b) in enumerate(slot_loras):
+                delta = x[token_idx] @ lora_a[slice_idx].T @ lora_b[slice_idx].T
+                expected[token_idx, offset : offset + output_slice] += (
+                    route_weights[token_idx][route_idx] * delta
+                )
+        offset += output_slice
+
+    torch.testing.assert_close(result, expected)
+
+
+@torch.inference_mode()
+def test_routed_lora_reference_fully_sharded_qkv_parallel_matches_oracle(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    tp_size = 2
+    local_qkv_size = 2
+    lora_config = LoRAConfig(
+        max_loras=4,
+        max_lora_rank=8,
+        fully_sharded_loras=True,
+        lora_dtype=torch.float32,
+    )
+    full_weight = make_weight(1, 12, 4)
+    lora_1_a = [make_weight(60 + idx * 40, 8, 4) for idx in range(3)]
+    lora_1_b = [make_weight(180 + idx * 40, 4, 8) for idx in range(3)]
+    lora_2_a = [make_weight(300 + idx * 40, 8, 4) for idx in range(3)]
+    lora_2_b = [make_weight(420 + idx * 40, 4, 8) for idx in range(3)]
+    route_weights = ((0.7, 0.3), (0.25, 0.75), (0.0, 1.0))
+    route_mapping = LoRARouteMapping(
+        token_lora_ids=((11, 12), (11, 12), (0, 12)),
+        token_lora_weights=route_weights,
+        prompt_mapping=(0,),
+        is_prefill=True,
+    )
+    x = make_weight(300, 3, 4)
+
+    lora_layers = []
+    for rank in range(tp_size):
+        set_tp_rank(monkeypatch, rank, tp_size)
+        linear = QKVParallelLinear(
+            hidden_size=4,
+            head_size=2,
+            total_num_heads=2,
+            total_num_kv_heads=2,
+            bias=False,
+            params_dtype=torch.float32,
+            prefix=f"routed_qkv_sharded_lora_test_{rank}",
+            disable_tp=False,
+        )
+        local_q = full_weight[rank * local_qkv_size : (rank + 1) * local_qkv_size]
+        local_k = full_weight[
+            4 + rank * local_qkv_size : 4 + (rank + 1) * local_qkv_size
+        ]
+        local_v = full_weight[
+            8 + rank * local_qkv_size : 8 + (rank + 1) * local_qkv_size
+        ]
+        linear.weight.data = torch.cat([local_q, local_k, local_v], dim=0)
+        lora_linear = MergedQKVParallelLinearWithShardedLoRA(linear)
+        lora_linear.create_lora_weights(lora_config.max_loras, lora_config)
+        lora_linear.set_lora(0, lora_1_a, lora_1_b)
+        lora_linear.set_lora(1, lora_2_a, lora_2_b)
+        set_routed_mapping(lora_linear, route_mapping, lora_config)
+        lora_layers.append(lora_linear)
+
+    gather_calls = build_column_gather_calls(lora_layers, x)
+    state = {"rank": 0, "call_idx": 0}
+
+    def fake_all_gather(tensor: torch.Tensor, dim: int = -1) -> torch.Tensor:
+        del dim
+        local_shrinks, gathered = gather_calls[state["call_idx"]]
+        torch.testing.assert_close(tensor, local_shrinks[state["rank"]])
+        state["call_idx"] += 1
+        return gathered
+
+    import vllm.lora.layers.column_parallel_linear as column_linear
+
+    monkeypatch.setattr(
+        column_linear, "tensor_model_parallel_all_gather", fake_all_gather
+    )
+
+    slot_loras = ((lora_1_a, lora_1_b), (lora_2_a, lora_2_b))
+    for rank, lora_layer in enumerate(lora_layers):
+        state["rank"] = rank
+        state["call_idx"] = 0
+        result = lora_layer.apply(x)
+        assert state["call_idx"] == len(gather_calls)
+
+        local_rows = []
+        for full_offset in (0, 4, 8):
+            local_rows.append(
+                full_weight[
+                    full_offset + rank * local_qkv_size : full_offset
+                    + (rank + 1) * local_qkv_size
+                ]
+            )
+        expected = x @ torch.cat(local_rows, dim=0).T
+        rank_delta_slice = slice(rank * local_qkv_size, (rank + 1) * local_qkv_size)
+        local_offset = 0
+        for slice_idx, output_slice in enumerate(lora_layer.output_slices):
+            for token_idx in range(x.shape[0]):
+                for route_idx, (lora_a, lora_b) in enumerate(slot_loras):
+                    delta = x[token_idx] @ lora_a[slice_idx].T @ lora_b[slice_idx].T
+                    expected[token_idx, local_offset : local_offset + output_slice] += (
+                        route_weights[token_idx][route_idx] * delta[rank_delta_slice]
+                    )
+            local_offset += output_slice
+
+        torch.testing.assert_close(result, expected)

--- a/vllm/lora/layers/__init__.py
+++ b/vllm/lora/layers/__init__.py
@@ -19,7 +19,7 @@ from vllm.lora.layers.row_parallel_linear import (
     RowParallelLinearWithLoRA,
     RowParallelLinearWithShardedLoRA,
 )
-from vllm.lora.layers.utils import LoRAMapping, LoRAMappingType
+from vllm.lora.layers.utils import LoRAMapping, LoRAMappingType, LoRARouteMapping
 from vllm.lora.layers.vocal_parallel_embedding import VocabParallelEmbeddingWithLoRA
 
 __all__ = [
@@ -40,6 +40,7 @@ __all__ = [
     "ReplicatedLinearWithLoRA",
     "LoRAMapping",
     "LoRAMappingType",
+    "LoRARouteMapping",
     "FusedMoEWithLoRA",
     "FusedMoE3DWithLoRA",
 ]

--- a/vllm/lora/layers/base_linear.py
+++ b/vllm/lora/layers/base_linear.py
@@ -2,6 +2,8 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 
+from collections.abc import Iterator
+
 import torch
 from transformers import PretrainedConfig
 
@@ -224,11 +226,20 @@ class BaseLinearLayerWithLoRA(BaseLayerWithLoRA):
             output = output.flatten(0, 1)
             x = x.flatten(0, 1)
 
-        lora_output: torch.Tensor | None = self.punica_wrapper.add_lora_linear(
-            output, x, self.lora_a_stacked, self.lora_b_stacked, 1.0, self.output_slices
-        )
-        if not current_platform.can_update_inplace():
-            output = lora_output
+        route_mapping = self.punica_wrapper.lora_route_mapping
+        if route_mapping is not None:
+            output = self._apply_routed_lora_to_output(x, output, route_mapping)
+        else:
+            lora_output: torch.Tensor | None = self.punica_wrapper.add_lora_linear(
+                output,
+                x,
+                self.lora_a_stacked,
+                self.lora_b_stacked,
+                1.0,
+                self.output_slices,
+            )
+            if not current_platform.can_update_inplace():
+                output = lora_output
 
         # Reshape the flattened output back to its original shape,
         # as some MM encoders cannot handle flattened inputs.
@@ -236,6 +247,74 @@ class BaseLinearLayerWithLoRA(BaseLayerWithLoRA):
             output = output.reshape(original_shape)
 
         return output
+
+    def _apply_routed_lora_to_output(
+        self,
+        x: torch.Tensor,
+        output: torch.Tensor,
+        route_mapping: tuple[torch.Tensor, torch.Tensor],
+    ) -> torch.Tensor:
+        token_lora_indices, token_lora_weights = self._validate_routed_lora_mapping(
+            x, route_mapping
+        )
+
+        offset = 0
+        for slice_idx, output_slice in enumerate(self.output_slices):
+            lora_a = self.lora_a_stacked[slice_idx]
+            lora_b = self.lora_b_stacked[slice_idx]
+            output_view = output[:, offset : offset + output_slice]
+
+            for lora_idx, token_mask, route_weights in self._iter_lora_route_groups(
+                token_lora_indices, token_lora_weights
+            ):
+                routed_x = x[token_mask].to(dtype=lora_a.dtype)
+                delta = routed_x @ lora_a[lora_idx, 0].T
+                delta = delta @ lora_b[lora_idx, 0].T
+                weights = route_weights.to(dtype=delta.dtype)
+                output_view[token_mask] += (
+                    delta.to(dtype=output_view.dtype) * weights[:, None]
+                )
+
+            offset += output_slice
+
+        return output
+
+    @staticmethod
+    def _validate_routed_lora_mapping(
+        x: torch.Tensor,
+        route_mapping: tuple[torch.Tensor, torch.Tensor],
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        token_lora_indices, token_lora_weights = route_mapping
+        if token_lora_indices.ndim != 2 or token_lora_weights.ndim != 2:
+            raise ValueError("Routed LoRA indices and weights must be 2D tensors")
+        if token_lora_indices.shape != token_lora_weights.shape:
+            raise ValueError(
+                "Routed LoRA indices and weights must have matching shapes"
+            )
+        if token_lora_indices.shape[0] != x.shape[0]:
+            raise ValueError(
+                "Routed LoRA token count must match the linear input token count"
+            )
+        return token_lora_indices, token_lora_weights
+
+    @staticmethod
+    def _iter_lora_route_groups(
+        token_lora_indices: torch.Tensor,
+        token_lora_weights: torch.Tensor,
+    ) -> Iterator[tuple[int, torch.Tensor, torch.Tensor]]:
+        for route_idx in range(token_lora_indices.shape[1]):
+            route_lora_indices = token_lora_indices[:, route_idx]
+            route_lora_weights = token_lora_weights[:, route_idx]
+            for lora_idx in torch.unique(route_lora_indices):
+                lora_idx_int = int(lora_idx.item())
+                if lora_idx_int < 0:
+                    continue
+
+                token_mask = route_lora_indices == lora_idx_int
+                if not torch.any(token_mask):
+                    continue
+
+                yield lora_idx_int, token_mask, route_lora_weights[token_mask]
 
     def _apply_async_impl(
         self, x: torch.Tensor, bias: torch.Tensor | None = None

--- a/vllm/lora/layers/column_parallel_linear.py
+++ b/vllm/lora/layers/column_parallel_linear.py
@@ -34,6 +34,9 @@ def _mcp_apply(x, bias, layer: "ColumnParallelLinearWithLoRA"):
     )
 
     output = layer._get_quant_method().apply(layer.base_layer, x, bias)
+    route_mapping = layer.punica_wrapper.lora_route_mapping
+    if route_mapping is not None:
+        return _mcp_apply_routed(x, output, layer, route_mapping)
 
     x = x.view(-1, x.shape[-1])
     output, out_orig_shape = output.view(-1, output.shape[-1]), output.shape
@@ -80,6 +83,42 @@ def _mcp_apply(x, bias, layer: "ColumnParallelLinearWithLoRA"):
     output = output.view(*out_orig_shape)
     # now have column partitioned and packed output
     return output
+
+
+def _mcp_apply_routed(
+    x: torch.Tensor,
+    output: torch.Tensor,
+    layer: "ColumnParallelLinearWithLoRA",
+    route_mapping: tuple[torch.Tensor, torch.Tensor],
+) -> torch.Tensor:
+    x = x.view(-1, x.shape[-1])
+    output, out_orig_shape = output.view(-1, output.shape[-1]), output.shape
+    token_lora_indices, token_lora_weights = layer._validate_routed_lora_mapping(
+        x, route_mapping
+    )
+
+    offset = 0
+    for slice_idx, output_slice in enumerate(layer.output_slices):
+        lora_a = layer.lora_a_stacked[slice_idx]
+        lora_b = layer.lora_b_stacked[slice_idx]
+        output_view = output[:, offset : offset + output_slice]
+
+        for lora_idx, token_mask, route_weights in layer._iter_lora_route_groups(
+            token_lora_indices, token_lora_weights
+        ):
+            routed_x = x[token_mask].to(dtype=lora_a.dtype)
+            shrink = routed_x @ lora_a[lora_idx, 0].T
+            if layer.tp_size > 1:
+                shrink = tensor_model_parallel_all_gather(shrink)
+            delta = shrink.to(dtype=lora_b.dtype) @ lora_b[lora_idx, 0].T
+            weights = route_weights.to(dtype=delta.dtype)
+            output_view[token_mask] += (
+                delta.to(dtype=output_view.dtype) * weights[:, None]
+            )
+
+        offset += output_slice
+
+    return output.view(*out_orig_shape)
 
 
 class ColumnParallelLinearWithLoRA(BaseLinearLayerWithLoRA):

--- a/vllm/lora/layers/logits_processor.py
+++ b/vllm/lora/layers/logits_processor.py
@@ -194,6 +194,11 @@ class LogitsProcessorWithLoRA(BaseLayerWithLoRA):
             # token_id: [0, 1, 2, 3, 4, 5, -1, -1]
             logits = logits[:, self.sharded_to_full_mapping_gpu]
 
+        if self.punica_wrapper.lora_route_mapping is not None:
+            raise NotImplementedError(
+                "Routed LoRA reference execution does not support logits."
+            )
+
         lora_output: torch.Tensor | None = self.punica_wrapper.add_lora_logits(
             logits, hidden_states, self.lora_a_stacked, self.lora_b_stacked, 1.0
         )

--- a/vllm/lora/layers/row_parallel_linear.py
+++ b/vllm/lora/layers/row_parallel_linear.py
@@ -120,6 +120,11 @@ class RowParallelLinearWithShardedLoRA(RowParallelLinearWithLoRA):
 
         x = x.view(-1, x.shape[-1])
         output, out_orig_shape = output.view(-1, output.shape[-1]), output.shape
+        route_mapping = self.punica_wrapper.lora_route_mapping
+        if route_mapping is not None:
+            output = self._apply_routed_sharded_lora_to_output(x, output, route_mapping)
+            return output.view(*out_orig_shape)
+
         buffer = torch.zeros(
             (self.n_slices, x.shape[0], self.lora_a_stacked[0].shape[2]),
             dtype=torch.float32,
@@ -156,6 +161,36 @@ class RowParallelLinearWithShardedLoRA(RowParallelLinearWithLoRA):
             output = lora_output
 
         output = output.view(*out_orig_shape)
+        return output
+
+    def _apply_routed_sharded_lora_to_output(
+        self,
+        x: torch.Tensor,
+        output: torch.Tensor,
+        route_mapping: tuple[torch.Tensor, torch.Tensor],
+    ) -> torch.Tensor:
+        token_lora_indices, token_lora_weights = self._validate_routed_lora_mapping(
+            x, route_mapping
+        )
+        shard_size = self.lora_b_stacked[0].shape[2]
+        offset_start = self.tp_rank * shard_size
+        output_view = output[:, offset_start : offset_start + shard_size]
+        lora_a = self.lora_a_stacked[0]
+        lora_b = self.lora_b_stacked[0]
+
+        for lora_idx, token_mask, route_weights in self._iter_lora_route_groups(
+            token_lora_indices, token_lora_weights
+        ):
+            routed_x = x[token_mask].to(dtype=lora_a.dtype)
+            shrink = routed_x @ lora_a[lora_idx, 0].T
+            if self.tp_size > 1:
+                shrink = tensor_model_parallel_all_reduce(shrink)
+            delta = shrink.to(dtype=lora_b.dtype) @ lora_b[lora_idx, 0].T
+            weights = route_weights.to(dtype=delta.dtype)
+            output_view[token_mask] += (
+                delta.to(dtype=output_view.dtype) * weights[:, None]
+            )
+
         return output
 
     @classmethod

--- a/vllm/lora/layers/utils.py
+++ b/vllm/lora/layers/utils.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import math
 from dataclasses import dataclass
 from enum import Enum
 
@@ -40,6 +41,61 @@ class LoRAMapping:
     def __post_init__(self):
         self.index_mapping = tuple(self.index_mapping)
         self.prompt_mapping = tuple(self.prompt_mapping)
+
+
+@dataclass
+class LoRARouteMapping:
+    token_lora_ids: tuple[tuple[int, ...], ...]
+    token_lora_weights: tuple[tuple[float, ...], ...]
+    prompt_mapping: tuple[int, ...]
+    is_prefill: bool = False
+    type: LoRAMappingType = LoRAMappingType.LANGUAGE
+
+    def __post_init__(self):
+        self.token_lora_ids = tuple(
+            tuple(token_lora_ids) for token_lora_ids in self.token_lora_ids
+        )
+        self.token_lora_weights = tuple(
+            tuple(token_lora_weights) for token_lora_weights in self.token_lora_weights
+        )
+        self.prompt_mapping = tuple(self.prompt_mapping)
+
+        if len(self.token_lora_ids) != len(self.token_lora_weights):
+            raise ValueError(
+                "token_lora_ids and token_lora_weights must have the same length"
+            )
+        if not self.token_lora_ids:
+            raise ValueError("token_lora_ids cannot be empty")
+
+        route_k = len(self.token_lora_ids[0])
+        if route_k == 0:
+            raise ValueError("route_k must be greater than 0")
+
+        for token_lora_ids, token_lora_weights in zip(
+            self.token_lora_ids, self.token_lora_weights
+        ):
+            if len(token_lora_ids) != route_k:
+                raise ValueError("token_lora_ids must have a fixed route_k")
+            if len(token_lora_weights) != route_k:
+                raise ValueError("token_lora_weights must have a fixed route_k")
+            if any(lora_id < 0 for lora_id in token_lora_ids):
+                raise ValueError("token_lora_ids must use non-negative LoRA ids")
+            if any(not math.isfinite(weight) for weight in token_lora_weights):
+                raise ValueError("token_lora_weights must be finite")
+            if any(weight < 0 for weight in token_lora_weights):
+                raise ValueError("token_lora_weights must be non-negative")
+
+    @property
+    def route_k(self) -> int:
+        return len(self.token_lora_ids[0])
+
+    def scalar_fallback_mapping(self) -> LoRAMapping:
+        return LoRAMapping(
+            index_mapping=(0,) * len(self.token_lora_ids),
+            prompt_mapping=self.prompt_mapping,
+            is_prefill=self.is_prefill,
+            type=self.type,
+        )
 
 
 def _get_lora_device(base_layer: nn.Module) -> torch.device:

--- a/vllm/lora/layers/vocal_parallel_embedding.py
+++ b/vllm/lora/layers/vocal_parallel_embedding.py
@@ -97,6 +97,11 @@ class VocabParallelEmbeddingWithLoRA(BaseLayerWithLoRA):
         )
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
+        if self.punica_wrapper.lora_route_mapping is not None:
+            raise NotImplementedError(
+                "Routed LoRA reference execution does not support embeddings."
+            )
+
         # NB: Don't use torch.narrow here. torch.narrow triggers some
         # Dynamic Shape specialization in torch.compile
         num_tokens = x.shape[0]

--- a/vllm/lora/model_manager.py
+++ b/vllm/lora/model_manager.py
@@ -17,6 +17,7 @@ from vllm.lora.layers import (
     FusedMoEWithLoRA,
     LoRAMapping,
     LoRAMappingType,
+    LoRARouteMapping,
 )
 from vllm.lora.lora_model import LoRAModel, MoEEPLoadSpec
 from vllm.lora.lora_weights import LoRALayerWeights, PackedLoRALayerWeights
@@ -357,7 +358,7 @@ class LoRAModelManager:
             "Use LRUCacheLoRAModelManager for pinning"
         )  # type: ignore
 
-    def _set_adapter_mapping(self, mapping: LoRAMapping) -> None:
+    def _set_adapter_mapping(self, mapping: LoRAMapping | LoRARouteMapping) -> None:
         # Default to the main language model wrapper
         if not (self.supports_mm and self.supports_tower_connector_lora):
             target_prefix = (

--- a/vllm/lora/punica_wrapper/punica_base.py
+++ b/vllm/lora/punica_wrapper/punica_base.py
@@ -12,11 +12,11 @@ from typing import TYPE_CHECKING
 
 import torch
 
-from .utils import compute_meta, convert_mapping
+from .utils import compute_meta, convert_mapping, convert_route_mapping
 
 if TYPE_CHECKING:
     # avoid circuit import
-    from vllm.lora.layers import LoRAMapping
+    from vllm.lora.layers import LoRAMapping, LoRARouteMapping
 
 
 class PunicaWrapperABC(ABC):
@@ -27,7 +27,7 @@ class PunicaWrapperABC(ABC):
     @abstractmethod
     def update_metadata(
         self,
-        mapping: "LoRAMapping",
+        mapping: "LoRAMapping | LoRARouteMapping",
         lora_index_to_id: list[int | None],
         max_loras: int,
         vocab_size: int,
@@ -164,6 +164,8 @@ class PunicaWrapperBase(PunicaWrapperABC):
         self.batch_size: int = -1
         self.is_prefill = False
         self.no_lora = False
+        self._lora_route_indices: torch.Tensor | None = None
+        self._lora_route_weights: torch.Tensor | None = None
 
     def _update_base_metadata(
         self,
@@ -281,14 +283,31 @@ class PunicaWrapperBase(PunicaWrapperABC):
         embeddings_indices_len = self.indices_len[3]
         return self._embeddings_indices[:, :embeddings_indices_len]
 
+    @property
+    def lora_route_mapping(self) -> tuple[torch.Tensor, torch.Tensor] | None:
+        if self._lora_route_indices is None or self._lora_route_weights is None:
+            return None
+        return self._lora_route_indices, self._lora_route_weights
+
     def update_metadata(
         self,
-        mapping: "LoRAMapping",
+        mapping: "LoRAMapping | LoRARouteMapping",
         lora_index_to_id: list[int | None],
         max_loras: int,
         vocab_size: int,
         **kwargs,
     ):
+        from vllm.lora.layers import LoRARouteMapping
+
+        if isinstance(mapping, LoRARouteMapping):
+            self._lora_route_indices, self._lora_route_weights = convert_route_mapping(
+                mapping, lora_index_to_id, self.device
+            )
+            mapping = mapping.scalar_fallback_mapping()
+        else:
+            self._lora_route_indices = None
+            self._lora_route_weights = None
+
         self._update_base_metadata(mapping, lora_index_to_id, max_loras, vocab_size)
 
         if mapping.is_prefill:

--- a/vllm/lora/punica_wrapper/punica_gpu.py
+++ b/vllm/lora/punica_wrapper/punica_gpu.py
@@ -11,7 +11,7 @@ from typing import final
 
 import torch
 
-from vllm.lora.layers import LoRAMapping
+from vllm.lora.layers import LoRAMapping, LoRARouteMapping
 from vllm.lora.utils import get_captured_lora_counts
 from vllm.triton_utils import HAS_TRITON, triton
 from vllm.utils.math_utils import round_up
@@ -74,14 +74,13 @@ class PunicaWrapperGPU(PunicaWrapperBase):
 
     def update_metadata(
         self,
-        mapping: LoRAMapping,
+        mapping: LoRAMapping | LoRARouteMapping,
         lora_index_to_id: list[int | None],
         max_loras: int,
         vocab_size: int,
         **kwargs,
     ):
-        self.is_prefill = mapping.is_prefill
-        self._update_base_metadata(mapping, lora_index_to_id, max_loras, vocab_size)
+        super().update_metadata(mapping, lora_index_to_id, max_loras, vocab_size)
 
         # Prepare cuda kernel metadata tensors
         self.token_mapping_meta.prepare_tensors(self.token_lora_indices)

--- a/vllm/lora/punica_wrapper/punica_xpu.py
+++ b/vllm/lora/punica_wrapper/punica_xpu.py
@@ -12,7 +12,7 @@ from typing import final
 import torch
 
 from vllm import _custom_ops as ops
-from vllm.lora.layers import LoRAMapping
+from vllm.lora.layers import LoRAMapping, LoRARouteMapping
 from vllm.lora.ops.xpu_ops import bgmv_expand, bgmv_expand_slice, bgmv_shrink
 from vllm.lora.utils import get_captured_lora_counts
 from vllm.triton_utils import HAS_TRITON, triton
@@ -75,14 +75,13 @@ class PunicaWrapperXPU(PunicaWrapperBase):
 
     def update_metadata(
         self,
-        mapping: LoRAMapping,
+        mapping: LoRAMapping | LoRARouteMapping,
         lora_index_to_id: list[int | None],
         max_loras: int,
         vocab_size: int,
         **kwargs,
     ):
-        self.is_prefill = mapping.is_prefill
-        self._update_base_metadata(mapping, lora_index_to_id, max_loras, vocab_size)
+        super().update_metadata(mapping, lora_index_to_id, max_loras, vocab_size)
 
         # Prepare kernel metadata tensors
         self.token_mapping_meta.prepare_tensors(self.token_lora_indices)

--- a/vllm/lora/punica_wrapper/utils.py
+++ b/vllm/lora/punica_wrapper/utils.py
@@ -9,7 +9,7 @@ from vllm.utils.torch_utils import async_tensor_h2d
 
 if TYPE_CHECKING:
     # avoid circuit import
-    from vllm.lora.layers import LoRAMapping
+    from vllm.lora.layers import LoRAMapping, LoRARouteMapping
 
 
 def compute_meta(
@@ -57,7 +57,7 @@ def convert_mapping(
     max_loras: int,
     vocab_size: int,
     extra_vocab_size: int,
-    device: torch.device,
+    device: torch.device | str,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, list[int]]:
     """Converts LoRAMapping to index tensors.
 
@@ -88,6 +88,7 @@ def convert_mapping(
                 (base_indices, sampler_indices, sampler_indices_padded,
                 embeddings_indices).
     """
+    device = torch.device(device)
     index_mapping_indices: list[int] = list(mapping.index_mapping).copy()
     embedding_indices = index_mapping_indices.copy()
     lora_indices = index_mapping_indices.copy()
@@ -120,10 +121,16 @@ def convert_mapping(
         embedding_indices,
     ]
 
-    indices = async_tensor_h2d(indices_list, dtype=torch.long, device=device)
-    prompt_mapping_tensor = async_tensor_h2d(
-        prompt_mapping, dtype=torch.long, device=device
-    )
+    if device.type == "cpu":
+        indices = torch.tensor(indices_list, dtype=torch.long, device=device)
+        prompt_mapping_tensor = torch.tensor(
+            prompt_mapping, dtype=torch.long, device=device
+        )
+    else:
+        indices = async_tensor_h2d(indices_list, dtype=torch.long, device=device)
+        prompt_mapping_tensor = async_tensor_h2d(
+            prompt_mapping, dtype=torch.long, device=device
+        )
     embeddings_indices = torch.stack(
         [
             indices[2] * extra_vocab_size,
@@ -158,3 +165,54 @@ def convert_mapping(
         embeddings_indices,
         indices_len,
     )
+
+
+def convert_route_mapping(
+    mapping: "LoRARouteMapping",
+    lora_index_to_id: list[int | None],
+    device: torch.device | str,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Converts routed LoRA ids to GPU slot indices."""
+    device = torch.device(device)
+    lora_id_to_index = {
+        lora_id: index
+        for index, lora_id in enumerate(lora_index_to_id)
+        if lora_id is not None
+    }
+    missing_lora_ids = sorted(
+        {
+            lora_id
+            for token_lora_ids in mapping.token_lora_ids
+            for lora_id in token_lora_ids
+            if lora_id > 0 and lora_id not in lora_id_to_index
+        }
+    )
+    if missing_lora_ids:
+        raise ValueError(
+            f"Routed LoRA mapping references unloaded LoRA ids: {missing_lora_ids}"
+        )
+
+    token_lora_indices: list[list[int]] = []
+    for token_lora_ids in mapping.token_lora_ids:
+        token_lora_indices.append(
+            [
+                lora_id_to_index[lora_id] if lora_id > 0 else -1
+                for lora_id in token_lora_ids
+            ]
+        )
+
+    if device.type == "cpu":
+        token_lora_indices_tensor = torch.tensor(
+            token_lora_indices, dtype=torch.long, device=device
+        )
+        token_lora_weights_tensor = torch.tensor(
+            list(mapping.token_lora_weights), dtype=torch.float32, device=device
+        )
+    else:
+        token_lora_indices_tensor = async_tensor_h2d(
+            token_lora_indices, dtype=torch.long, device=device
+        )
+        token_lora_weights_tensor = async_tensor_h2d(
+            list(mapping.token_lora_weights), dtype=torch.float32, device=device
+        )
+    return token_lora_indices_tensor, token_lora_weights_tensor

--- a/vllm/lora/request.py
+++ b/vllm/lora/request.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-
+import math
+from typing import TypeAlias
 
 import msgspec
 
@@ -71,3 +72,95 @@ class LoRARequest(
         identified by their names across engines.
         """
         return hash(self.lora_name)
+
+
+class LoRARoutingRequest(
+    msgspec.Struct,
+    omit_defaults=True,  # type: ignore[call-arg]
+    array_like=True,
+):  # type: ignore[call-arg]
+    """Internal request for fixed-weight routed mixtures of LoRA adapters."""
+
+    routing_name: str
+    routing_int_id: int
+    lora_requests: tuple[LoRARequest, ...]
+    lora_weights: tuple[float, ...]
+    routing_strategy: str = "fixed"
+
+    def __post_init__(self):
+        self.lora_requests = tuple(self.lora_requests)
+        self.lora_weights = tuple(self.lora_weights)
+
+        if self.routing_int_id < 1:
+            raise ValueError(f"id must be > 0, got {self.routing_int_id}")
+        if not self.routing_name:
+            raise ValueError("routing_name cannot be empty")
+        if self.routing_strategy != "fixed":
+            raise ValueError(
+                "Only fixed-weight routed LoRA requests are supported for now."
+            )
+        if not self.lora_requests:
+            raise ValueError("lora_requests cannot be empty")
+        if len(self.lora_requests) != len(self.lora_weights):
+            raise ValueError("lora_requests and lora_weights must have the same length")
+
+        lora_ids = [request.lora_int_id for request in self.lora_requests]
+        if len(lora_ids) != len(set(lora_ids)):
+            raise ValueError("lora_requests cannot contain duplicate lora_int_id")
+
+        if any(not math.isfinite(weight) for weight in self.lora_weights):
+            raise ValueError("lora_weights must be finite")
+        if any(weight < 0 for weight in self.lora_weights):
+            raise ValueError("lora_weights must be non-negative")
+        if sum(self.lora_weights) <= 0:
+            raise ValueError("At least one lora weight must be positive")
+
+    @property
+    def adapter_id(self):
+        return self.routing_int_id
+
+    @property
+    def name(self):
+        return self.routing_name
+
+    @property
+    def lora_name(self):
+        return self.routing_name
+
+    @property
+    def top_k(self):
+        return len(self.lora_requests)
+
+    def __eq__(self, value: object) -> bool:
+        return (
+            isinstance(value, self.__class__)
+            and self.routing_name == value.routing_name
+        )
+
+    def __hash__(self) -> int:
+        return hash(self.routing_name)
+
+
+def is_routed_lora_request(
+    lora_request: LoRARequest | LoRARoutingRequest | None,
+) -> bool:
+    return isinstance(lora_request, LoRARoutingRequest)
+
+
+def iter_lora_requests(
+    lora_request: LoRARequest | LoRARoutingRequest | None,
+) -> tuple[LoRARequest, ...]:
+    if lora_request is None:
+        return ()
+    if isinstance(lora_request, LoRARoutingRequest):
+        return lora_request.lora_requests
+    return (lora_request,)
+
+
+def iter_lora_int_ids(
+    lora_request: LoRARequest | LoRARoutingRequest | None,
+) -> tuple[int, ...]:
+    return tuple(request.lora_int_id for request in iter_lora_requests(lora_request))
+
+
+LoRARequestLike: TypeAlias = LoRARequest | LoRARoutingRequest

--- a/vllm/lora/routing_utils.py
+++ b/vllm/lora/routing_utils.py
@@ -1,0 +1,141 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from collections.abc import Iterable, MutableMapping
+from typing import Protocol
+
+from vllm.lora.layers.utils import LoRARouteMapping
+from vllm.lora.request import (
+    LoRARequest,
+    LoRARequestLike,
+    LoRARoutingRequest,
+    is_routed_lora_request,
+    iter_lora_requests,
+)
+
+NO_LORA_ID = 0
+
+
+class LoRARequestMapping(Protocol):
+    def __setitem__(self, index: int, value: int, /) -> None: ...
+
+
+def has_routed_lora(
+    lora_requests: Iterable[LoRARequestLike | None],
+) -> bool:
+    return any(is_routed_lora_request(lora_request) for lora_request in lora_requests)
+
+
+def get_lora_route(
+    lora_request: LoRARequestLike | None,
+    route_k: int,
+) -> tuple[tuple[int, ...], tuple[float, ...]]:
+    if route_k < 1:
+        raise ValueError("route_k must be greater than 0")
+
+    if isinstance(lora_request, LoRARoutingRequest):
+        lora_ids = [request.lora_int_id for request in lora_request.lora_requests]
+        lora_weights = list(lora_request.lora_weights)
+    else:
+        concrete_lora_requests = iter_lora_requests(lora_request)
+        lora_ids = [request.lora_int_id for request in concrete_lora_requests]
+        lora_weights = [1.0] * len(lora_ids)
+
+    padding = route_k - len(lora_ids)
+    if padding < 0:
+        raise ValueError("route_k cannot be smaller than the route length")
+
+    lora_ids.extend([NO_LORA_ID] * padding)
+    lora_weights.extend([0.0] * padding)
+    return tuple(lora_ids), tuple(lora_weights)
+
+
+def get_lora_route_k(
+    lora_requests: Iterable[LoRARequestLike | None],
+) -> int:
+    route_k = 1
+    for lora_request in lora_requests:
+        route_k = max(route_k, len(iter_lora_requests(lora_request)))
+    return route_k
+
+
+def make_lora_route_mapping(
+    lora_requests: Iterable[LoRARequestLike | None],
+    num_scheduled_tokens: Iterable[int],
+    prompt_mapping: tuple[int, ...],
+    is_prefill: bool = True,
+) -> LoRARouteMapping | None:
+    lora_requests = tuple(lora_requests)
+    num_scheduled_tokens = tuple(int(num_tokens) for num_tokens in num_scheduled_tokens)
+    if len(lora_requests) != len(num_scheduled_tokens):
+        raise ValueError(
+            "lora_requests and num_scheduled_tokens must have the same length"
+        )
+    if sum(num_scheduled_tokens) == 0:
+        return None
+
+    route_k = get_lora_route_k(lora_requests)
+    token_lora_ids: list[tuple[int, ...]] = []
+    token_lora_weights: list[tuple[float, ...]] = []
+
+    for lora_request, num_tokens in zip(lora_requests, num_scheduled_tokens):
+        lora_ids, lora_weights = get_lora_route(lora_request, route_k)
+        token_lora_ids.extend([lora_ids] * num_tokens)
+        token_lora_weights.extend([lora_weights] * num_tokens)
+
+    return LoRARouteMapping(
+        token_lora_ids=tuple(token_lora_ids),
+        token_lora_weights=tuple(token_lora_weights),
+        prompt_mapping=prompt_mapping,
+        is_prefill=is_prefill,
+    )
+
+
+def add_lora_request(
+    request_lora_mapping: LoRARequestMapping,
+    request_lora_requests: MutableMapping[int, LoRARequestLike],
+    lora_id_to_request_ids: MutableMapping[int, set[str]],
+    lora_id_to_lora_request: MutableMapping[int, LoRARequest],
+    req_index: int,
+    req_id: str,
+    lora_request: LoRARequestLike | None,
+) -> None:
+    if lora_request is None:
+        request_lora_mapping[req_index] = NO_LORA_ID
+        return
+
+    request_lora_requests[req_index] = lora_request
+    if isinstance(lora_request, LoRARequest):
+        request_lora_mapping[req_index] = lora_request.lora_int_id
+    else:
+        request_lora_mapping[req_index] = NO_LORA_ID
+
+    for concrete_lora_request in iter_lora_requests(lora_request):
+        lora_id = concrete_lora_request.lora_int_id
+        lora_req_ids = lora_id_to_request_ids.setdefault(lora_id, set())
+        lora_req_ids.add(req_id)
+        lora_id_to_lora_request[lora_id] = concrete_lora_request
+
+
+def remove_lora_request(
+    request_lora_mapping: LoRARequestMapping,
+    request_lora_requests: MutableMapping[int, LoRARequestLike],
+    lora_id_to_request_ids: MutableMapping[int, set[str]],
+    lora_id_to_lora_request: MutableMapping[int, LoRARequest],
+    req_index: int,
+    req_id: str,
+) -> None:
+    lora_request = request_lora_requests.pop(req_index, None)
+    if lora_request is None:
+        request_lora_mapping[req_index] = NO_LORA_ID
+        return
+
+    for concrete_lora_request in iter_lora_requests(lora_request):
+        lora_id = concrete_lora_request.lora_int_id
+        lora_req_ids = lora_id_to_request_ids[lora_id]
+        lora_req_ids.discard(req_id)
+        if not lora_req_ids:
+            del lora_id_to_request_ids[lora_id]
+            del lora_id_to_lora_request[lora_id]
+
+    request_lora_mapping[req_index] = NO_LORA_ID

--- a/vllm/v1/core/sched/output.py
+++ b/vllm/v1/core/sched/output.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 
     from vllm.distributed.ec_transfer.ec_connector.base import ECConnectorMetadata
     from vllm.distributed.kv_transfer.kv_connector.v1.base import KVConnectorMetadata
-    from vllm.lora.request import LoRARequest
+    from vllm.lora.request import LoRARequestLike
     from vllm.multimodal.inputs import MultiModalFeatureSpec
     from vllm.pooling_params import PoolingParams
     from vllm.sampling_params import SamplingParams
@@ -24,7 +24,7 @@ else:
     ECConnectorMetadata = object
     KVConnectorMetadata = object
     KVCacheBlockCopy = object
-    LoRARequest = object
+    LoRARequestLike = object
     MultiModalFeatureSpec = object
     PoolingParams = object
     SamplingParams = object
@@ -40,7 +40,7 @@ class NewRequestData:
     pooling_params: PoolingParams | None
     block_ids: tuple[list[int], ...]
     num_computed_tokens: int
-    lora_request: LoRARequest | None
+    lora_request: LoRARequestLike | None
     prompt_embeds: "torch.Tensor | None" = None
     prompt_is_token_ids: list[bool] | None = None
 

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -25,6 +25,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1 import (
 from vllm.distributed.kv_transfer.kv_connector.v1.base import KVConnectorMetadata
 from vllm.distributed.kv_transfer.kv_connector.v1.metrics import KVConnectorStats
 from vllm.logger import init_logger
+from vllm.lora.request import iter_lora_int_ids
 from vllm.model_executor.layers.fused_moe.routed_experts_capturer import (
     RoutedExpertsManager,
 )
@@ -675,9 +676,10 @@ class Scheduler(SchedulerInterface):
         scheduled_loras: set[int] = set()
         if self.lora_config:
             scheduled_loras = set(
-                req.lora_request.lora_int_id
+                lora_int_id
                 for req in scheduled_running_reqs
-                if req.lora_request and req.lora_request.lora_int_id > 0
+                for lora_int_id in iter_lora_int_ids(req.lora_request)
+                if lora_int_id > 0
             )
             assert len(scheduled_loras) <= self.lora_config.max_loras
 
@@ -724,13 +726,12 @@ class Scheduler(SchedulerInterface):
 
                 # Check that adding the request still respects the max_loras
                 # constraint.
+                request_loras = set(iter_lora_int_ids(request.lora_request))
                 if (
                     self.lora_config
-                    and request.lora_request
-                    and (
-                        len(scheduled_loras) == self.lora_config.max_loras
-                        and request.lora_request.lora_int_id not in scheduled_loras
-                    )
+                    and request_loras
+                    and len(scheduled_loras | request_loras)
+                    > self.lora_config.max_loras
                 ):
                     # Scheduling would exceed max_loras, skip.
                     request_queue.pop_request()
@@ -1066,7 +1067,7 @@ class Scheduler(SchedulerInterface):
                     raise RuntimeError(f"Invalid request status: {request.status}")
 
                 if self.lora_config and request.lora_request:
-                    scheduled_loras.add(request.lora_request.lora_int_id)
+                    scheduled_loras.update(iter_lora_int_ids(request.lora_request))
                 req_to_new_blocks[request_id] = self.kv_cache_manager.get_blocks(
                     request_id
                 )

--- a/vllm/v1/engine/input_processor.py
+++ b/vllm/v1/engine/input_processor.py
@@ -16,7 +16,7 @@ from vllm.inputs import (
 )
 from vllm.inputs.preprocess import InputPreprocessor
 from vllm.logger import init_logger
-from vllm.lora.request import LoRARequest
+from vllm.lora.request import LoRARequest, LoRARequestLike
 from vllm.multimodal import MULTIMODAL_REGISTRY, MultiModalRegistry
 from vllm.multimodal.encoder_budget import MultiModalBudget
 from vllm.multimodal.inputs import MultiModalFeatureSpec
@@ -152,7 +152,7 @@ class InputProcessor:
                 f"but got {type(params).__name__}"
             )
 
-    def _validate_lora(self, lora_request: LoRARequest | None) -> None:
+    def _validate_lora(self, lora_request: LoRARequestLike | None) -> None:
         if lora_request is None:
             return
 
@@ -174,7 +174,7 @@ class InputProcessor:
     def _get_mm_identifier(
         self,
         mm_hash: str,
-        lora_request: LoRARequest | None,
+        lora_request: LoRARequestLike | None,
     ) -> str:
         """
         When enable_tower_connector_lora is True, multi-modal embeddings

--- a/vllm/v1/engine/output_processor.py
+++ b/vllm/v1/engine/output_processor.py
@@ -10,7 +10,7 @@ from typing import Any, cast
 import numpy as np
 import torch
 
-from vllm.lora.request import LoRARequest
+from vllm.lora.request import LoRARequestLike
 from vllm.outputs import (
     STREAM_FINISHED,
     CompletionOutput,
@@ -133,7 +133,7 @@ class RequestState:
         external_req_id: str,
         parent_req: ParentRequest | None,
         request_index: int,
-        lora_request: LoRARequest | None,
+        lora_request: LoRARequestLike | None,
         output_kind: RequestOutputKind,
         prompt: str | None,
         prompt_token_ids: list[int] | None,

--- a/vllm/v1/request.py
+++ b/vllm/v1/request.py
@@ -25,7 +25,7 @@ from vllm.v1.structured_output.request import StructuredOutputRequest
 from vllm.v1.utils import ConstantList
 
 if TYPE_CHECKING:
-    from vllm.lora.request import LoRARequest
+    from vllm.lora.request import LoRARequestLike
     from vllm.v1.core.kv_cache_utils import BlockHash
 
 
@@ -68,7 +68,7 @@ class Request:
         prompt_embeds: torch.Tensor | None = None,
         prompt_is_token_ids: list[bool] | None = None,
         mm_features: list[MultiModalFeatureSpec] | None = None,
-        lora_request: "LoRARequest | None" = None,
+        lora_request: "LoRARequestLike | None" = None,
         cache_salt: str | None = None,
         priority: int = 0,
         trace_headers: Mapping[str, str] | None = None,

--- a/vllm/v1/worker/gpu/lora_utils.py
+++ b/vllm/v1/worker/gpu/lora_utils.py
@@ -7,14 +7,22 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
-from vllm.lora.request import LoRARequest
+from vllm.lora.layers import LoRARouteMapping
+from vllm.lora.request import (
+    LoRARequest,
+    LoRARequestLike,
+    iter_lora_requests,
+)
+from vllm.lora.routing_utils import (
+    NO_LORA_ID,
+    has_routed_lora,
+    make_lora_route_mapping,
+)
 from vllm.lora.utils import get_captured_lora_counts
 
 if TYPE_CHECKING:
     from vllm.config.compilation import CompilationConfig
     from vllm.config.lora import LoRAConfig
-
-NO_LORA_ID = 0
 
 
 def get_lora_capture_cases(
@@ -78,14 +86,18 @@ class LoraState:
         self.lora_ids = np.zeros(max_num_reqs, dtype=np.int32)
         self.lora_ids.fill(NO_LORA_ID)
         # req_id -> lora_request
-        self.lora_requests: dict[str, LoRARequest] = {}
+        self.lora_requests: dict[str, LoRARequestLike] = {}
 
     def add_request(
-        self, req_id: str, req_index: int, lora_request: LoRARequest | None
+        self, req_id: str, req_index: int, lora_request: LoRARequestLike | None
     ) -> None:
         if lora_request is not None:
             self.lora_requests[req_id] = lora_request
-            self.lora_ids[req_index] = lora_request.lora_int_id
+            self.lora_ids[req_index] = (
+                lora_request.lora_int_id
+                if isinstance(lora_request, LoRARequest)
+                else NO_LORA_ID
+            )
         else:
             self.lora_ids[req_index] = NO_LORA_ID
 
@@ -97,17 +109,39 @@ class LoraState:
         req_ids: list[str],
         idx_mapping: np.ndarray,
         num_scheduled_tokens: np.ndarray,
-    ) -> tuple[tuple[int, ...], tuple[int, ...], set[LoRARequest]]:
-        lora_ids = self.lora_ids[idx_mapping]
-        prompt_lora_mapping = tuple(lora_ids)
-        token_lora_mapping = tuple(lora_ids.repeat(num_scheduled_tokens))
+    ) -> tuple[
+        tuple[int, ...],
+        tuple[int, ...],
+        set[LoRARequest],
+        LoRARouteMapping | None,
+    ]:
+        lora_requests = tuple(self.lora_requests.get(req_id) for req_id in req_ids)
+        if has_routed_lora(lora_requests):
+            prompt_lora_mapping = tuple(NO_LORA_ID for _ in req_ids)
+            token_lora_mapping = tuple(
+                NO_LORA_ID for _ in range(int(num_scheduled_tokens.sum()))
+            )
+            lora_route_mapping = make_lora_route_mapping(
+                lora_requests,
+                num_scheduled_tokens,
+                prompt_lora_mapping,
+            )
+        else:
+            lora_ids = self.lora_ids[idx_mapping]
+            prompt_lora_mapping = tuple(lora_ids)
+            token_lora_mapping = tuple(lora_ids.repeat(num_scheduled_tokens))
+            lora_route_mapping = None
         active_lora_requests: set[LoRARequest] = self.get_activate_loras(req_ids)
-        return prompt_lora_mapping, token_lora_mapping, active_lora_requests
+        return (
+            prompt_lora_mapping,
+            token_lora_mapping,
+            active_lora_requests,
+            lora_route_mapping,
+        )
 
     def get_activate_loras(self, req_ids: list[str]) -> set[LoRARequest]:
         active_lora_requests: set[LoRARequest] = set()
         for req_id in req_ids:
             lora_request = self.lora_requests.get(req_id)
-            if lora_request is not None:
-                active_lora_requests.add(lora_request)
+            active_lora_requests.update(iter_lora_requests(lora_request))
         return active_lora_requests

--- a/vllm/v1/worker/gpu_input_batch.py
+++ b/vllm/v1/worker/gpu_input_batch.py
@@ -9,7 +9,15 @@ import numpy as np
 import torch
 
 from vllm.config.reasoning import ReasoningConfig
-from vllm.lora.request import LoRARequest
+from vllm.lora.layers import LoRARouteMapping
+from vllm.lora.request import LoRARequest, LoRARequestLike
+from vllm.lora.routing_utils import (
+    NO_LORA_ID,
+    add_lora_request,
+    has_routed_lora,
+    make_lora_route_mapping,
+    remove_lora_request,
+)
 from vllm.multimodal.inputs import MultiModalFeatureSpec
 from vllm.pooling_params import PoolingParams
 from vllm.sampling_params import SamplingParams, SamplingType
@@ -48,7 +56,7 @@ class CachedRequestState:
 
     xdrope_positions: torch.Tensor | None = None
 
-    lora_request: LoRARequest | None = None
+    lora_request: LoRARequestLike | None = None
     prompt_embeds: torch.Tensor | None = None
     # To accumulate prompt logprobs tensor chunks across prefill steps.
     in_progress_prompt_logprobs_cpu: LogprobsTensors | None = None
@@ -258,6 +266,7 @@ class InputBatch:
 
         # lora related
         self.request_lora_mapping = np.zeros((self.max_num_reqs,), dtype=np.int64)
+        self.request_lora_requests: dict[int, LoRARequestLike] = {}
         self.lora_id_to_request_ids: dict[int, set[str]] = {}
         self.lora_id_to_lora_request: dict[int, LoRARequest] = {}
 
@@ -485,20 +494,25 @@ class InputBatch:
         # Speculative decoding: by default 1 token is generated.
         self.num_accepted_tokens_cpu[req_index] = 1
 
-        # Add request lora ID
-        if request.lora_request:
-            lora_id = request.lora_request.lora_int_id
-            if lora_id not in self.lora_id_to_request_ids:
-                self.lora_id_to_request_ids[lora_id] = set()
-
-            self.request_lora_mapping[req_index] = lora_id
-            self.lora_id_to_request_ids[lora_id].add(request.req_id)
-            self.lora_id_to_lora_request[lora_id] = request.lora_request
-        else:
-            # No LoRA
-            self.request_lora_mapping[req_index] = 0
+        self._add_lora_request(req_index, request.req_id, request.lora_request)
 
         return req_index
+
+    def _add_lora_request(
+        self,
+        req_index: int,
+        req_id: str,
+        lora_request: LoRARequestLike | None,
+    ) -> None:
+        add_lora_request(
+            self.request_lora_mapping,
+            self.request_lora_requests,
+            self.lora_id_to_request_ids,
+            self.lora_id_to_lora_request,
+            req_index,
+            req_id,
+            lora_request,
+        )
 
     def update_req_spec_token_ids(
         self, request: CachedRequestState, scheduled_spec_tokens: dict[str, list[int]]
@@ -547,15 +561,7 @@ class InputBatch:
         self.spec_token_ids[req_index].clear()
         self.block_table.clear_row(req_index)
 
-        # LoRA
-        lora_id = self.request_lora_mapping[req_index]
-        if lora_id != 0:
-            lora_req_ids = self.lora_id_to_request_ids[lora_id]
-            lora_req_ids.discard(req_id)
-            if not lora_req_ids:
-                del self.lora_id_to_request_ids[lora_id]
-                del self.lora_id_to_lora_request[lora_id]
-            self.request_lora_mapping[req_index] = 0
+        self._remove_lora_request(req_index, req_id)
 
         if self.is_pooling_model:
             self.pooling_params.pop(req_id, None)
@@ -582,6 +588,16 @@ class InputBatch:
         self.bad_words_token_ids.pop(req_index, None)
         self.thinking_token_budget_reqs.discard(req_id)
         return req_index
+
+    def _remove_lora_request(self, req_index: int, req_id: str) -> None:
+        remove_lora_request(
+            self.request_lora_mapping,
+            self.request_lora_requests,
+            self.lora_id_to_request_ids,
+            self.lora_id_to_lora_request,
+            req_index,
+            req_id,
+        )
 
     def swap_states(self, i1: int, i2: int) -> None:
         old_id_i1 = self._req_ids[i1]
@@ -656,6 +672,7 @@ class InputBatch:
             self.request_lora_mapping[i2],
             self.request_lora_mapping[i1],
         )
+        swap_dict_values(self.request_lora_requests, i1, i2)
 
         if self.is_pooling_model:
             # Sampling and logits parameters don't apply to pooling models.
@@ -788,6 +805,12 @@ class InputBatch:
             self.request_lora_mapping[empty_index] = self.request_lora_mapping[
                 last_req_index
             ]
+            if last_req_index in self.request_lora_requests:
+                self.request_lora_requests[empty_index] = (
+                    self.request_lora_requests.pop(last_req_index)
+                )
+            else:
+                self.request_lora_requests.pop(empty_index, None)
 
             if self.is_pooling_model:
                 last_req_index -= 1
@@ -1004,7 +1027,12 @@ class InputBatch:
 
     def make_lora_inputs(
         self, num_scheduled_tokens: np.ndarray, num_sampled_tokens: np.ndarray
-    ) -> tuple[tuple[int, ...], tuple[int, ...], set[LoRARequest]]:
+    ) -> tuple[
+        tuple[int, ...],
+        tuple[int, ...],
+        set[LoRARequest],
+        LoRARouteMapping | None,
+    ]:
         """
         Given the num_scheduled_tokens for each request in the batch, return
         datastructures used to activate the current LoRAs.
@@ -1015,17 +1043,43 @@ class InputBatch:
             2. token_lora_mapping: A tuple of size np.sum(num_scheduled_tokens)
                where, token_lora_mapping[i] is the LoRA id to use for ith token.
             3. lora_requests: Set of relevant LoRA requests.
+            4. lora_route_mapping: Optional routed mapping for multi-adapter
+               LoRA execution.
         """
 
         req_lora_mapping = self.request_lora_mapping[: self.num_reqs]
-        prompt_lora_mapping = tuple(req_lora_mapping.repeat(num_sampled_tokens))
-        token_lora_mapping = tuple(req_lora_mapping.repeat(num_scheduled_tokens))
+        lora_requests = tuple(
+            self.request_lora_requests.get(req_index)
+            for req_index in range(self.num_reqs)
+        )
+
+        if has_routed_lora(lora_requests):
+            prompt_lora_mapping = tuple(
+                NO_LORA_ID for _ in range(int(num_sampled_tokens.sum()))
+            )
+            token_lora_mapping = tuple(
+                NO_LORA_ID for _ in range(int(num_scheduled_tokens.sum()))
+            )
+            lora_route_mapping = make_lora_route_mapping(
+                lora_requests,
+                num_scheduled_tokens[: self.num_reqs],
+                prompt_lora_mapping,
+            )
+        else:
+            prompt_lora_mapping = tuple(req_lora_mapping.repeat(num_sampled_tokens))
+            token_lora_mapping = tuple(req_lora_mapping.repeat(num_scheduled_tokens))
+            lora_route_mapping = None
 
         active_lora_requests: set[LoRARequest] = set(
             self.lora_id_to_lora_request.values()
         )
 
-        return prompt_lora_mapping, token_lora_mapping, active_lora_requests
+        return (
+            prompt_lora_mapping,
+            token_lora_mapping,
+            active_lora_requests,
+            lora_route_mapping,
+        )
 
     def set_async_sampled_token_ids(
         self,

--- a/vllm/v1/worker/lora_model_runner_mixin.py
+++ b/vllm/v1/worker/lora_model_runner_mixin.py
@@ -15,7 +15,7 @@ import torch.nn as nn
 from vllm.config import VllmConfig
 from vllm.config.lora import LoRAConfig
 from vllm.logger import init_logger
-from vllm.lora.layers import LoRAMapping, LoRAMappingType
+from vllm.lora.layers import LoRAMapping, LoRAMappingType, LoRARouteMapping
 from vllm.lora.request import LoRARequest
 from vllm.lora.worker_manager import LRUCacheWorkerLoRAManager
 from vllm.model_executor.models import supports_lora
@@ -66,6 +66,7 @@ class LoRAModelRunnerMixin:
         prompt_lora_mapping: tuple[int, ...],
         token_lora_mapping: tuple[int, ...],
         lora_requests: set[LoRARequest],
+        lora_route_mapping: LoRARouteMapping | None = None,
         mapping_type: LoRAMappingType = LoRAMappingType.LANGUAGE,
     ) -> None:
         self._ensure_lora_enabled()
@@ -74,12 +75,21 @@ class LoRAModelRunnerMixin:
         # non-cuda platforms.
         # On cuda platforms we use the same kernels for prefill and
         # decode and this flag is generally ignored.
-        lora_mapping = LoRAMapping(
-            token_lora_mapping,
-            prompt_lora_mapping,
-            is_prefill=True,
-            type=mapping_type,
-        )
+        if lora_route_mapping is None:
+            lora_mapping = LoRAMapping(
+                token_lora_mapping,
+                prompt_lora_mapping,
+                is_prefill=True,
+                type=mapping_type,
+            )
+        else:
+            lora_mapping = LoRARouteMapping(
+                token_lora_ids=lora_route_mapping.token_lora_ids,
+                token_lora_weights=lora_route_mapping.token_lora_weights,
+                prompt_mapping=prompt_lora_mapping,
+                is_prefill=True,
+                type=mapping_type,
+            )
         self.lora_manager.set_active_adapters(lora_requests, lora_mapping)
 
     def _ensure_lora_enabled(self) -> None:
@@ -99,11 +109,16 @@ class LoRAModelRunnerMixin:
         prompt_lora_mapping: tuple[int, ...]  # of size np.sum(num_sampled_tokens)
         token_lora_mapping: tuple[int, ...]  # of size np.sum(num_scheduled_tokens)
         lora_requests: set[LoRARequest]
-        prompt_lora_mapping, token_lora_mapping, lora_requests = (
+        lora_route_mapping: LoRARouteMapping | None
+        prompt_lora_mapping, token_lora_mapping, lora_requests, lora_route_mapping = (
             input_batch.make_lora_inputs(num_scheduled_tokens, num_sampled_tokens)
         )
         return self._set_active_loras(
-            prompt_lora_mapping, token_lora_mapping, lora_requests, mapping_type
+            prompt_lora_mapping,
+            token_lora_mapping,
+            lora_requests,
+            lora_route_mapping,
+            mapping_type,
         )
 
     @contextmanager
@@ -244,7 +259,7 @@ class LoRAModelRunnerMixin:
                 tuple(sample_lora_mapping),
                 tuple(token_lora_mapping),
                 lora_requests,
-                mapping_type,
+                mapping_type=mapping_type,
             )
 
             yield

--- a/vllm/v1/worker/tpu_input_batch.py
+++ b/vllm/v1/worker/tpu_input_batch.py
@@ -7,7 +7,15 @@ from typing import cast
 import numpy as np
 import torch
 
-from vllm.lora.request import LoRARequest
+from vllm.lora.layers import LoRARouteMapping
+from vllm.lora.request import LoRARequest, LoRARequestLike
+from vllm.lora.routing_utils import (
+    NO_LORA_ID,
+    add_lora_request,
+    has_routed_lora,
+    make_lora_route_mapping,
+    remove_lora_request,
+)
 from vllm.sampling_params import SamplingType
 from vllm.utils import length_from_prompt_token_ids_or_embeds
 from vllm.utils.collection_utils import swap_dict_values
@@ -140,6 +148,7 @@ class InputBatch:
 
         # lora related
         self.request_lora_mapping = np.zeros((self.max_num_reqs,), dtype=np.int64)
+        self.request_lora_requests: dict[int, LoRARequestLike] = {}
         self.lora_id_to_request_ids: dict[int, set[str]] = {}
         self.lora_id_to_lora_request: dict[int, LoRARequest] = {}
 
@@ -276,18 +285,23 @@ class InputBatch:
         if sampling_params.bad_words_token_ids:
             self.bad_words_token_ids[req_index] = sampling_params.bad_words_token_ids
 
-        # Add request lora ID
-        if request.lora_request:
-            lora_id = request.lora_request.lora_int_id
-            if lora_id not in self.lora_id_to_request_ids:
-                self.lora_id_to_request_ids[lora_id] = set()
+        self._add_lora_request(req_index, request.req_id, request.lora_request)
 
-            self.request_lora_mapping[req_index] = lora_id
-            self.lora_id_to_request_ids[lora_id].add(request.req_id)
-            self.lora_id_to_lora_request[lora_id] = request.lora_request
-        else:
-            # No LoRA
-            self.request_lora_mapping[req_index] = 0
+    def _add_lora_request(
+        self,
+        req_index: int,
+        req_id: str,
+        lora_request: LoRARequestLike | None,
+    ) -> None:
+        add_lora_request(
+            self.request_lora_mapping,
+            self.request_lora_requests,
+            self.lora_id_to_request_ids,
+            self.lora_id_to_lora_request,
+            req_index,
+            req_id,
+            lora_request,
+        )
 
     def remove_request(self, req_id: str) -> int | None:
         """This method must always be followed by a call to condense()."""
@@ -311,14 +325,7 @@ class InputBatch:
         self.num_logprobs.pop(req_id, None)
         self.in_progress_prompt_logprobs_cpu.pop(req_id, None)
 
-        # LoRA
-        lora_id = self.request_lora_mapping[req_index]
-        if lora_id != 0:
-            self.lora_id_to_request_ids[lora_id].discard(req_id)
-            if len(self.lora_id_to_request_ids[lora_id]) == 0:
-                self.lora_id_to_request_ids.pop(lora_id)
-                self.lora_id_to_lora_request.pop(lora_id)
-            self.request_lora_mapping[req_index] = 0
+        self._remove_lora_request(req_index, req_id)
 
         self.logit_bias[req_index] = None
         self.has_allowed_token_ids.discard(req_id)
@@ -327,6 +334,16 @@ class InputBatch:
             self.allowed_token_ids_mask_cpu_tensor[req_index].fill_(False)
         self.bad_words_token_ids.pop(req_index, None)
         return req_index
+
+    def _remove_lora_request(self, req_index: int, req_id: str) -> None:
+        remove_lora_request(
+            self.request_lora_mapping,
+            self.request_lora_requests,
+            self.lora_id_to_request_ids,
+            self.lora_id_to_lora_request,
+            req_index,
+            req_id,
+        )
 
     def swap_states(self, i1: int, i2: int) -> None:
         old_id_i1 = self._req_ids[i1]
@@ -390,6 +407,7 @@ class InputBatch:
             self.request_lora_mapping[i2],
             self.request_lora_mapping[i1],
         )
+        swap_dict_values(self.request_lora_requests, i1, i2)
         self.logit_bias[i1], self.logit_bias[i2] = (
             self.logit_bias[i2],
             self.logit_bias[i1],
@@ -477,6 +495,12 @@ class InputBatch:
             self.request_lora_mapping[empty_index] = self.request_lora_mapping[
                 last_req_index
             ]
+            if last_req_index in self.request_lora_requests:
+                self.request_lora_requests[empty_index] = (
+                    self.request_lora_requests.pop(last_req_index)
+                )
+            else:
+                self.request_lora_requests.pop(empty_index, None)
 
             self.logit_bias[empty_index] = self.logit_bias[last_req_index]
 
@@ -497,7 +521,12 @@ class InputBatch:
 
     def make_lora_inputs(
         self, num_scheduled_tokens: np.ndarray, num_sampled_tokens: np.ndarray
-    ) -> tuple[tuple[int, ...], tuple[int, ...], set[LoRARequest]]:
+    ) -> tuple[
+        tuple[int, ...],
+        tuple[int, ...],
+        set[LoRARequest],
+        LoRARouteMapping | None,
+    ]:
         """
         Given the num_scheduled_tokens for each request in the batch, return
         datastructures used to activate the current LoRAs.
@@ -507,16 +536,39 @@ class InputBatch:
             2. token_lora_mapping: A tuple of size np.sum(num_scheduled_tokens)
                where, token_lora_mapping[i] is the LoRA id to use for ith token.
             3. lora_requests: Set of relevant LoRA requests.
+            4. lora_route_mapping: Optional routed mapping for multi-adapter
+               LoRA execution.
         """
 
         req_lora_mapping = self.request_lora_mapping[: self.num_reqs]
-        prompt_lora_mapping = tuple(req_lora_mapping)
-        token_lora_mapping = tuple(req_lora_mapping.repeat(num_scheduled_tokens))
+        lora_requests = tuple(
+            self.request_lora_requests.get(req_index)
+            for req_index in range(self.num_reqs)
+        )
+        if has_routed_lora(lora_requests):
+            prompt_lora_mapping = tuple(NO_LORA_ID for _ in range(self.num_reqs))
+            token_lora_mapping = tuple(
+                NO_LORA_ID for _ in range(int(num_scheduled_tokens.sum()))
+            )
+            lora_route_mapping = make_lora_route_mapping(
+                lora_requests,
+                num_scheduled_tokens[: self.num_reqs],
+                prompt_lora_mapping,
+            )
+        else:
+            prompt_lora_mapping = tuple(req_lora_mapping)
+            token_lora_mapping = tuple(req_lora_mapping.repeat(num_scheduled_tokens))
+            lora_route_mapping = None
         active_lora_requests: set[LoRARequest] = set(
             self.lora_id_to_lora_request.values()
         )
 
-        return prompt_lora_mapping, token_lora_mapping, active_lora_requests
+        return (
+            prompt_lora_mapping,
+            token_lora_mapping,
+            active_lora_requests,
+            lora_route_mapping,
+        )
 
     @property
     def num_reqs(self) -> int:


### PR DESCRIPTION
## Purpose

Foundational implementation for #49705.

This PR adds fixed-weight routed LoRA support for requests of the form:

`base(x) + sum_i w_i * LoRA_i(x)`

The goal is to make vLLM capable of carrying and applying multiple LoRA adapters per token before adding learned/router-based MoE-LoRA routing in follow-up work.

This PR includes:
- `LoRARoutingRequest` for grouping multiple concrete `LoRARequest`s.
- `LoRARouteMapping` for per-token adapter slots and weights.
- Shared route-building helpers for v1 GPU/TPU input paths.
- Routed LoRA metadata conversion in the Punica wrapper.
- Reference routed LoRA execution for linear layers.
- Coverage for replicated, column-parallel, row-parallel, QKV, quantized base layers, and fully sharded LoRA.
- Fail-closed behavior for embeddings/logits, which are not supported in this PR.

This PR intentionally does not add:
- learned/router-based MoE-LoRA gates,
- per-layer dynamic routing,
- optimized routed Punica/Triton kernels,
- embedding/logits routed LoRA support.

Those are planned as follow-up work under #49705.

Duplicate-work check:
- Checked RFC #49705 comments.
- Checked open PRs referencing `49705 in:body`; none found.
- Checked open PRs for routed/MoE LoRA keywords. Related PRs #46772 and #39230 are adjacent work, but neither implements routed mixtures of multiple LoRA adapters per request/token.

AI assistance was used while developing this PR. I reviewed the resulting changes and tests.

## Test Plan

- Unit tests for routed request validation and helper behavior.
- Unit tests for v1 routed LoRA state/mapping construction.
- Reference-output tests comparing routed LoRA layer outputs against explicit PyTorch oracles.
- Coverage includes replicated linear, quantized base linear, QKV, fully sharded column/row/QKV paths.

## Test Result

```bash
.venv/bin/python -m pytest tests/lora/test_lora_routing.py tests/lora/
test_layers_utils.py -q
# 18 passed

.venv/bin/pre-commit run ruff-check --files <changed files>
# Passed

.venv/bin/pre-commit run ruff-format --files <changed files>
# Passed

.venv/bin/python -m py_compile vllm/lora/layers/base_linear.py vllm/lora/
layers/column_parallel_linear.py vllm/lora/layers/row_parallel_linear.py
tests/lora/test_lora_routing.py vllm/lora/routing_utils.py
# Passed

git diff --check origin/main..HEAD
# Passed

No model evals were run because this PR adds infrastructure/reference execution tests and does not change default model behavior unless routed LoRA requests are explicitly used.