### PR TITLE
[Bugfix] Fix hybrid attention cache miss due to eagle drop

### DIFF
--- a/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
+++ b/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
@@ -1356,6 +1356,173 @@ def test_hybrid_partial_hit_with_eagle_stays_within_group_blocks():
     assert manager.allocate_slots(req1, 4, num_computed, computed_blocks) is not None
 
 
+def test_mamba_align_split_stops_below_eagle_proof_boundary():
+    """The chunk that registers the partial tail must end one hash unit below
+    the prompt's last hash boundary under Eagle, which drops one unit past the
+    candidate.
+    """
+    block_size = 1536
+    hash_block_size = 128
+    mock = SimpleNamespace(
+        cache_config=SimpleNamespace(block_size=block_size),
+        max_num_scheduled_tokens=8192,
+        scheduler_config=SimpleNamespace(long_prefill_token_threshold=0),
+        use_eagle=True,
+        hash_block_size=hash_block_size,
+        mamba_partial_cache_hit=True,
+    )
+    split = Scheduler._mamba_block_aligned_split
+
+    for prompt_len in (24576, 24577):
+        req = make_request("0", [0] * prompt_len, hash_block_size, sha256)
+        req.num_computed_tokens = 23040
+        assert (
+            split(self=mock, request=req, num_new_tokens=prompt_len - 23040)
+            == 24448 - 23040
+        )
+
+    # Without eagle the tail stays at the prompt's own last hash boundary.
+    mock.use_eagle = False
+    req = make_request("1", [0] * 24577, hash_block_size, sha256)
+    req.num_computed_tokens = 23040
+    assert split(self=mock, request=req, num_new_tokens=1537) == 24576 - 23040
+
+
+def test_mamba_partial_tail_hits_below_eagle_proof_boundary():
+    """Regression: a prompt whose last hash boundary coincides with its last
+    mamba block boundary registered its only fine-grained checkpoint at a
+    position Eagle can never resume from, collapsing the next turn to the
+    coarse block boundary (or, under sparse retention, to a full miss).
+    """
+    hash_block_size = 2
+    mamba_block_size = 2 * hash_block_size
+    kv_cache_config = KVCacheConfig(
+        num_blocks=32,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["full"],
+                FullAttentionSpec(
+                    block_size=hash_block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                ),
+            ),
+            KVCacheGroupSpec(
+                ["mamba"],
+                MambaSpec(
+                    block_size=mamba_block_size,
+                    shapes=(1, 1),
+                    dtypes=(torch.float32,),
+                    mamba_cache_mode="align",
+                ),
+            ),
+        ],
+    )
+    manager = make_kv_cache_manager(
+        kv_cache_config=kv_cache_config,
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=hash_block_size,
+        use_eagle=True,
+    )
+
+    # 9 tokens: the last hash boundary (8) is also a mamba block boundary, so
+    # the prompt's two checkpoints collapse. The reachable tail is 6.
+    req0 = make_request("0", [7] * 9, hash_block_size, sha256)
+    computed_blocks, num_computed, _ = manager.get_computed_blocks(req0)
+    assert num_computed == 0
+    assert manager.allocate_slots(req0, 6, num_computed, computed_blocks) is not None
+    req0.num_computed_tokens = 6
+    manager.new_step_starts()
+    assert manager.allocate_slots(req0, 3) is not None
+    req0.num_computed_tokens = 9
+    manager.new_step_starts()
+
+    partial_hash = req0.block_hashes[6 // hash_block_size - 1]
+    partial_block = manager.block_pool.get_cached_block(
+        partial_hash, kv_cache_group_ids=[1]
+    )
+    assert partial_block is not None
+    assert partial_block[0].block_hash_num_tokens == 6
+
+    # Full attention matches to 8 and drops one hash unit to 6, where the
+    # mamba tail now exists -- instead of falling back to the block boundary 4.
+    req1 = make_request("1", [7] * 9 + [9] * 4, hash_block_size, sha256)
+    _, num_computed, _ = manager.get_computed_blocks(req1)
+    assert num_computed == 6
+
+
+def test_mamba_coarse_checkpoint_retained_below_eagle_proof_boundary(monkeypatch):
+    """Without a prefix-match unit there is no partial tail, so the only
+    checkpoint comes from the retention mask. A prompt ending just past its
+    last block boundary pinned that checkpoint where eagle can never resume,
+    so under ``retention_interval=0`` the reachable block was masked out and
+    the next turn missed entirely.
+    """
+    monkeypatch.setenv("VLLM_PREFIX_CACHE_RETENTION_INTERVAL", "0")
+    block_size = 4
+    kv_cache_config = KVCacheConfig(
+        num_blocks=32,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["full"],
+                FullAttentionSpec(
+                    block_size=block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                ),
+            ),
+            KVCacheGroupSpec(
+                ["mamba"],
+                MambaSpec(
+                    block_size=block_size,
+                    shapes=(1, 1),
+                    dtypes=(torch.float32,),
+                    mamba_cache_mode="align",
+                ),
+            ),
+        ],
+    )
+    manager = make_kv_cache_manager(
+        kv_cache_config=kv_cache_config,
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=block_size,
+        use_eagle=True,
+    )
+
+    # 9 tokens: the last aligned boundary is 8, which eagle cannot resume
+    # from, so block 0 (ending at 4) must stay retained. Prefill in
+    # scheduler-split style -- Mamba keeps one rolling state, so a boundary is
+    # only materialized by a chunk that ends exactly on it.
+    req0 = make_request("0", [7] * 9, block_size, sha256)
+    computed_blocks, num_computed, _ = manager.get_computed_blocks(req0)
+    assert num_computed == 0
+    assert manager.allocate_slots(req0, 4, num_computed, computed_blocks) is not None
+    req0.num_computed_tokens = 4
+    manager.new_step_starts()
+    assert manager.allocate_slots(req0, 5) is not None
+    req0.num_computed_tokens = 9
+    manager.free(req0)
+    manager.new_step_starts()
+
+    # The reachable state (4) is retained; the unreachable one (8) is not.
+    assert (
+        manager.block_pool.get_cached_block(
+            req0.block_hashes[0], kv_cache_group_ids=[1]
+        )
+        is not None
+    )
+
+    req1 = make_request("1", [7] * 9 + [9] * 4, block_size, sha256)
+    _, num_computed, _ = manager.get_computed_blocks(req1)
+    assert num_computed == 4
+
+
 def test_hybrid_sliding_window_group_disables_partial_hash_hits():
     hash_block_size = 2
     sliding_window_block_size = 2 * hash_block_size

--- a/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
+++ b/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
@@ -1181,3 +1181,170 @@ def test_hybrid_partial_hit_with_eagle_stays_within_group_blocks():
         len(group) * block_size >= num_computed for group in computed_blocks.blocks
     )
     assert manager.allocate_slots(req1, 4, num_computed, computed_blocks) is not None
+
+
+def test_mamba_align_split_stops_below_eagle_proof_boundary():
+    """The chunk that registers the partial tail must end one hash unit below
+    the prompt's last hash boundary under Eagle, which drops one unit past the
+    candidate.
+    """
+    block_size = 1536
+    hash_block_size = 128
+    mock = SimpleNamespace(
+        cache_config=SimpleNamespace(block_size=block_size),
+        max_num_scheduled_tokens=8192,
+        scheduler_config=SimpleNamespace(long_prefill_token_threshold=0),
+        use_eagle=True,
+        hash_block_size=hash_block_size,
+        mamba_partial_cache_hit=True,
+    )
+    split = Scheduler._mamba_block_aligned_split
+
+    for prompt_len in (24576, 24577):
+        req = make_request("0", [0] * prompt_len, hash_block_size, sha256)
+        req.num_computed_tokens = 23040
+        assert (
+            split(self=mock, request=req, num_new_tokens=prompt_len - 23040)
+            == 24448 - 23040
+        )
+
+    # Without eagle the tail stays at the prompt's own last hash boundary.
+    mock.use_eagle = False
+    req = make_request("1", [0] * 24577, hash_block_size, sha256)
+    req.num_computed_tokens = 23040
+    assert split(self=mock, request=req, num_new_tokens=1537) == 24576 - 23040
+
+
+def test_mamba_partial_tail_hits_below_eagle_proof_boundary():
+    """Regression: a prompt whose last hash boundary coincides with its last
+    mamba block boundary registered its only fine-grained checkpoint at a
+    position Eagle can never resume from, collapsing the next turn to the
+    coarse block boundary (or, under sparse retention, to a full miss).
+    """
+    hash_block_size = 2
+    mamba_block_size = 2 * hash_block_size
+    kv_cache_config = KVCacheConfig(
+        num_blocks=32,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["full"],
+                FullAttentionSpec(
+                    block_size=hash_block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                ),
+            ),
+            KVCacheGroupSpec(
+                ["mamba"],
+                MambaSpec(
+                    block_size=mamba_block_size,
+                    shapes=(1, 1),
+                    dtypes=(torch.float32,),
+                    mamba_cache_mode="align",
+                ),
+            ),
+        ],
+    )
+    manager = make_kv_cache_manager(
+        kv_cache_config=kv_cache_config,
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=hash_block_size,
+        use_eagle=True,
+    )
+
+    # 9 tokens: the last hash boundary (8) is also a mamba block boundary, so
+    # the prompt's two checkpoints collapse. The reachable tail is 6.
+    req0 = make_request("0", [7] * 9, hash_block_size, sha256)
+    computed_blocks, num_computed, _ = manager.get_computed_blocks(req0)
+    assert num_computed == 0
+    assert manager.allocate_slots(req0, 6, num_computed, computed_blocks) is not None
+    req0.num_computed_tokens = 6
+    manager.new_step_starts()
+    assert manager.allocate_slots(req0, 3) is not None
+    req0.num_computed_tokens = 9
+    manager.new_step_starts()
+
+    partial_hash = req0.block_hashes[6 // hash_block_size - 1]
+    partial_block = manager.block_pool.get_cached_block(
+        partial_hash, kv_cache_group_ids=[1]
+    )
+    assert partial_block is not None
+    assert partial_block[0].block_hash_num_tokens == 6
+
+    # Full attention matches to 8 and drops one hash unit to 6, where the
+    # mamba tail now exists -- instead of falling back to the block boundary 4.
+    req1 = make_request("1", [7] * 9 + [9] * 4, hash_block_size, sha256)
+    _, num_computed, _ = manager.get_computed_blocks(req1)
+    assert num_computed == 6
+
+
+def test_mamba_coarse_checkpoint_retained_below_eagle_proof_boundary(monkeypatch):
+    """Without a prefix-match unit there is no partial tail, so the only
+    checkpoint comes from the retention mask. A prompt ending just past its
+    last block boundary pinned that checkpoint where eagle can never resume,
+    so under ``retention_interval=0`` the reachable block was masked out and
+    the next turn missed entirely.
+    """
+    monkeypatch.setenv("VLLM_PREFIX_CACHE_RETENTION_INTERVAL", "0")
+    block_size = 4
+    kv_cache_config = KVCacheConfig(
+        num_blocks=32,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["full"],
+                FullAttentionSpec(
+                    block_size=block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                ),
+            ),
+            KVCacheGroupSpec(
+                ["mamba"],
+                MambaSpec(
+                    block_size=block_size,
+                    shapes=(1, 1),
+                    dtypes=(torch.float32,),
+                    mamba_cache_mode="align",
+                ),
+            ),
+        ],
+    )
+    manager = make_kv_cache_manager(
+        kv_cache_config=kv_cache_config,
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=block_size,
+        use_eagle=True,
+    )
+
+    # 9 tokens: the last aligned boundary is 8, which eagle cannot resume
+    # from, so block 0 (ending at 4) must stay retained. Prefill in
+    # scheduler-split style -- Mamba keeps one rolling state, so a boundary is
+    # only materialized by a chunk that ends exactly on it.
+    req0 = make_request("0", [7] * 9, block_size, sha256)
+    computed_blocks, num_computed, _ = manager.get_computed_blocks(req0)
+    assert num_computed == 0
+    assert manager.allocate_slots(req0, 4, num_computed, computed_blocks) is not None
+    req0.num_computed_tokens = 4
+    manager.new_step_starts()
+    assert manager.allocate_slots(req0, 5) is not None
+    req0.num_computed_tokens = 9
+    manager.free(req0)
+    manager.new_step_starts()
+
+    # The reachable state (4) is retained; the unreachable one (8) is not.
+    assert (
+        manager.block_pool.get_cached_block(
+            req0.block_hashes[0], kv_cache_group_ids=[1]
+        )
+        is not None
+    )
+
+    req1 = make_request("1", [7] * 9 + [9] * 4, block_size, sha256)
+    _, num_computed, _ = manager.get_computed_blocks(req1)
+    assert num_computed == 4

--- a/tests/v1/core/test_mamba_align_chunk_split.py
+++ b/tests/v1/core/test_mamba_align_chunk_split.py
@@ -222,7 +222,10 @@ def test_unaligned_resume_never_runs_past_its_block(
     """
     prompt_len = 3602
     (request,) = create_requests(1, num_tokens=prompt_len, block_size=ATTN_BLOCK_SIZE)
-    tail_boundary = prompt_len // ATTN_BLOCK_SIZE * ATTN_BLOCK_SIZE
+    # `_split` runs with eagle on, which puts the partial-tail stop one hash
+    # unit below the prompt's last hash boundary: eagle matches a unit past
+    # its candidate and drops it, so nothing proves that last boundary.
+    tail_stop = prompt_len // ATTN_BLOCK_SIZE * ATTN_BLOCK_SIZE - ATTN_BLOCK_SIZE
 
     pos, ends = resume_at, []
     while pos < prompt_len:
@@ -241,7 +244,7 @@ def test_unaligned_resume_never_runs_past_its_block(
 
     for end in ends[:-1]:
         aligned = end % MAMBA_BLOCK_SIZE == 0
-        assert aligned or (partial_hit and end == tail_boundary), (
+        assert aligned or (partial_hit and end == tail_stop), (
             f"intermediate chunk end {end} is neither block-aligned nor the "
-            f"partial-tail boundary"
+            f"partial-tail stop ({tail_stop})"
         )

--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -3431,9 +3431,10 @@ def test_hybrid_local_kv_retention_mtp_reuses_latest_boundary(monkeypatch):
         use_eagle=True,
     )
 
-    # 127 tokens: latest replay boundary is floor((127 - 1) / 32) * 32 = 96.
-    # The EAGLE/MTP SWA lookup group must cache the local tail ending at
-    # 104 tokens, and that tail is two 8-token blocks wide: hashes 11 and 12.
+    # 127 tokens: eagle proves a boundary only if an aligned unit exists past
+    # it, so the replay boundary rewinds one unit to
+    # floor(127 / 32) * 32 - 32 = 64. The SWA tail plus its proof block then
+    # ends at 72, two 8-token blocks wide: hashes 7 and 8.
     token_ids = [i for i in range(15) for _ in range(block_size)] + [15] * 7
     req0 = make_request("0", token_ids, block_size, sha256)
     computed_blocks, num_computed_tokens, _ = manager.get_computed_blocks(req0)
@@ -3447,7 +3448,7 @@ def test_hybrid_local_kv_retention_mtp_reuses_latest_boundary(monkeypatch):
     assert blocks is not None
 
     pool = manager.block_pool
-    expected_swa_cached = {11, 12}
+    expected_swa_cached = {7, 8}
     for i in range(15):
         cached = pool.get_cached_block(req0.block_hashes[i], kv_cache_group_ids=[1])
         if i in expected_swa_cached:
@@ -3459,8 +3460,8 @@ def test_hybrid_local_kv_retention_mtp_reuses_latest_boundary(monkeypatch):
 
     req1 = make_request("1", token_ids, block_size, sha256)
     computed_blocks, num_computed_tokens, _ = manager.get_computed_blocks(req1)
-    assert num_computed_tokens == 12 * block_size
-    assert [len(blocks) for blocks in computed_blocks.blocks] == [3, 12]
+    assert num_computed_tokens == 8 * block_size
+    assert [len(blocks) for blocks in computed_blocks.blocks] == [2, 8]
 
 
 def test_block_lookup_cache_single_block_per_key():

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/coordinator.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/coordinator.py
@@ -98,6 +98,19 @@ class MooncakeStoreCoordinator:
         )
         return length // alignment * alignment
 
+    def get_replay_boundary(self, num_prompt_tokens: int) -> int:
+        """Mirror of ``KVCacheCoordinator.get_replay_boundary``.
+
+        The store's retention must name the same position the engine resumes
+        at; if the two disagree the store keeps state where nothing can reach
+        it. Model-level for the same reason: a hit is the shortest hit across
+        groups, so an EAGLE group's drop caps every group.
+        """
+        if not self.eagle_group_ids:
+            return num_prompt_tokens - 1
+        aligned = num_prompt_tokens // self.lcm_block_size * self.lcm_block_size
+        return max(aligned - self.lcm_block_size, 0)
+
     def _verify_and_split_kv_cache_groups(self) -> None:
         """Mirrors KVCacheCoordinator.verify_and_split_kv_cache_groups but
         dispatches via spec_manager_map (we don't allocate managers).
@@ -240,6 +253,13 @@ class MooncakeStoreCoordinator:
             f"aligned_token_len ({aligned_token_len}) must be a multiple of "
             f"{mask_alignment}"
         )
+        # Model-level, so it is computed once and shared by every group (see
+        # KVCacheCoordinator.get_replay_boundary).
+        reachable_boundaries = (
+            ()
+            if num_prompt_tokens is None
+            else (self.get_replay_boundary(num_prompt_tokens),)
+        )
         masks: list[list[bool] | None] = []
         for g_idx, g in enumerate(self.kv_cache_groups):
             spec = _unwrap_spec(g.kv_cache_spec)
@@ -248,9 +268,6 @@ class MooncakeStoreCoordinator:
             manager_cls = KVCacheSpecRegistry.get_manager_class(spec)
             assert manager_cls is not None
             use_eagle = g_idx in self.eagle_group_ids
-            reachable_boundaries = (
-                () if num_prompt_tokens is None else (num_prompt_tokens - 1,)
-            )
             mask = manager_cls.reachable_block_mask(
                 start_block=start_chunk,
                 end_block=end_chunk,

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -270,6 +270,28 @@ class KVCacheCoordinator(ABC):
             for manager in self.single_type_managers
         )
 
+    def get_replay_boundary(self, request: Request) -> int:
+        """Return the position a later request replaying this prompt resumes at.
+
+        A cache hit is the shortest hit across all groups, so this is a
+        model-level position: every group has to retain state here, whether or
+        not it is the group that drops. Groups differ only in how much they
+        keep around it -- EAGLE groups also keep the block above, which they
+        match and drop back from (see ``reachable_block_mask``).
+
+        Under EAGLE that block must exist, so the boundary sits one alignment
+        unit below the prompt's last aligned position; every group's block size
+        divides the alignment, so the block above always fits in the prompt.
+        """
+        if not self.eagle_group_ids:
+            return request.num_prompt_tokens - 1
+        aligned = (
+            request.num_prompt_tokens
+            // self.scheduler_block_size
+            * self.scheduler_block_size
+        )
+        return max(aligned - self.scheduler_block_size, 0)
+
     def cache_blocks(self, request: Request, num_computed_tokens: int) -> None:
         """
         Cache the blocks for the request.
@@ -280,11 +302,13 @@ class KVCacheCoordinator(ABC):
                 that need to be cached
                 (including tokens that are already cached).
         """
+        replay_boundary = self.get_replay_boundary(request)
         for manager in self.single_type_managers:
             manager.cache_blocks(
                 request,
                 num_computed_tokens,
                 retention_interval=self.retention_interval,
+                replay_boundary=replay_boundary,
             )
 
     def free(self, request_id: str) -> None:
@@ -663,6 +687,7 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
                 // self.scheduler_block_size
                 * self.scheduler_block_size
             )
+        replay_boundary = self.get_replay_boundary(request)
         for manager in self.single_type_managers:
             num_tokens_to_cache = aligned_num_computed_tokens
             # EAGLE groups match one block past each aligned boundary and drop
@@ -680,6 +705,7 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
                 request,
                 num_tokens_to_cache,
                 retention_interval=self.retention_interval,
+                replay_boundary=replay_boundary,
             )
 
     def find_longest_cache_hit(

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -275,6 +275,28 @@ class KVCacheCoordinator(ABC):
             for manager in self.single_type_managers
         )
 
+    def get_replay_boundary(self, request: Request) -> int:
+        """Return the position a later request replaying this prompt resumes at.
+
+        A cache hit is the shortest hit across all groups, so this is a
+        model-level position: every group has to retain state here, whether or
+        not it is the group that drops. Groups differ only in how much they
+        keep around it -- EAGLE groups also keep the block above, which they
+        match and drop back from (see ``reachable_block_mask``).
+
+        Under EAGLE that block must exist, so the boundary sits one alignment
+        unit below the prompt's last aligned position; every group's block size
+        divides the alignment, so the block above always fits in the prompt.
+        """
+        if not self.eagle_group_ids:
+            return request.num_prompt_tokens - 1
+        aligned = (
+            request.num_prompt_tokens
+            // self.scheduler_block_size
+            * self.scheduler_block_size
+        )
+        return max(aligned - self.scheduler_block_size, 0)
+
     def cache_blocks(self, request: Request, num_computed_tokens: int) -> None:
         """
         Cache the blocks for the request.
@@ -285,11 +307,13 @@ class KVCacheCoordinator(ABC):
                 that need to be cached
                 (including tokens that are already cached).
         """
+        replay_boundary = self.get_replay_boundary(request)
         for manager in self.single_type_managers:
             manager.cache_blocks(
                 request,
                 num_computed_tokens,
                 retention_interval=self.retention_interval,
+                replay_boundary=replay_boundary,
             )
 
     def free(self, request_id: str) -> None:
@@ -683,6 +707,7 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
                 // self.scheduler_block_size
                 * self.scheduler_block_size
             )
+        replay_boundary = self.get_replay_boundary(request)
         for manager in self.single_type_managers:
             num_tokens_to_cache = aligned_num_computed_tokens
             # EAGLE groups match one block past each aligned boundary and drop
@@ -700,6 +725,7 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
                 request,
                 num_tokens_to_cache,
                 retention_interval=self.retention_interval,
+                replay_boundary=replay_boundary,
             )
 
     def find_longest_cache_hit(

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -415,6 +415,11 @@ class Scheduler(SchedulerInterface):
             if self.mamba_partial_cache_hit
             else 0
         )
+        if tail_boundary and self.use_eagle:
+            # Eagle matches one hash unit past the candidate and drops it, so
+            # nothing proves the prompt's own last hash boundary. Materialize
+            # the state one unit lower, where the hit can actually land.
+            tail_boundary = max(tail_boundary - self.hash_block_size, 0)
         stops = (
             # Same invariant: a chunk starting mid-block stops at the boundary
             # rather than running past it.

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -404,6 +404,11 @@ class Scheduler(SchedulerInterface):
             if self.mamba_partial_cache_hit
             else 0
         )
+        if tail_boundary and self.use_eagle:
+            # Eagle matches one hash unit past the candidate and drops it, so
+            # nothing proves the prompt's own last hash boundary. Materialize
+            # the state one unit lower, where the hit can actually land.
+            tail_boundary = max(tail_boundary - self.hash_block_size, 0)
         stops = (
             # Same invariant: a chunk starting mid-block stops at the boundary
             # rather than running past it.

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -110,7 +110,6 @@ class SingleTypeKVCacheManager(ABC):
         # aligned segment (SWA). Initialized lazily by the coordinator after
         # determining the attention groups.
         self.use_eagle = False
-
         # Partial-hit copy-on-write bookkeeping. Populated only by fine-grained
         # managers (full attention, mamba "align"); harmlessly empty elsewhere.
         self._partial_hit_reqs: dict[str, tuple[int, KVCacheBlock]] = {}
@@ -429,6 +428,7 @@ class SingleTypeKVCacheManager(ABC):
         request: Request,
         num_tokens: int,
         retention_interval: int | None = None,
+        replay_boundary: int = 0,
     ) -> None:
         """
         Cache the blocks for the request.
@@ -451,20 +451,6 @@ class SingleTypeKVCacheManager(ABC):
         # Token boundaries whose reachable tail must be retained under sparse
         # retention: the replay boundary (``num_prompt - 1``, capped by
         # ``get_computed_blocks``) and any detected shared-prefix junction.
-        if self.use_eagle:
-            # Eagle proves a boundary by matching one aligned unit past it and
-            # dropping back, so a boundary is only reachable when that unit
-            # exists. Rewind one unit unconditionally to avoid retaining a 
-            # boundary that eagle cannot reach.
-            replay_boundary = max(
-                request.num_prompt_tokens
-                // self.scheduler_block_size
-                * self.scheduler_block_size
-                - self.scheduler_block_size,
-                0,
-            )
-        else:
-            replay_boundary = request.num_prompt_tokens - 1
         reachable_boundaries = [replay_boundary]
         if request.shared_prefix_boundary:
             reachable_boundaries.append(request.shared_prefix_boundary)
@@ -795,8 +781,14 @@ class FullAttentionManager(SingleTypeKVCacheManager):
         request: Request,
         num_tokens: int,
         retention_interval: int | None = None,
+        replay_boundary: int = 0,
     ) -> None:
-        super().cache_blocks(request, num_tokens, retention_interval=retention_interval)
+        super().cache_blocks(
+            request,
+            num_tokens,
+            retention_interval=retention_interval,
+            replay_boundary=replay_boundary,
+        )
         hash_block_size = self.block_pool.hash_block_size
         if self.block_size == hash_block_size:
             return
@@ -1691,9 +1683,15 @@ class MambaManager(SingleTypeKVCacheManager):
         request: Request,
         num_tokens: int,
         retention_interval: int | None = None,
+        replay_boundary: int = 0,
     ) -> None:
         num_cached_blocks_before = self.num_cached_block.get(request.request_id, 0)
-        super().cache_blocks(request, num_tokens, retention_interval=retention_interval)
+        super().cache_blocks(
+            request,
+            num_tokens,
+            retention_interval=retention_interval,
+            replay_boundary=replay_boundary,
+        )
         num_cached_blocks_after = self.num_cached_block.get(request.request_id, 0)
         if self.mamba_cache_mode == "align":
             partial_hash = self._cache_partial_tail_block(request, num_tokens)
@@ -1792,6 +1790,7 @@ class CrossAttentionManager(SingleTypeKVCacheManager):
         request: Request,
         num_tokens: int,
         retention_interval: int | None = None,
+        replay_boundary: int = 0,
     ) -> None:
         # We do not cache blocks for cross-attention to be shared between
         # requests, so this method is not relevant.

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -451,17 +451,27 @@ class SingleTypeKVCacheManager(ABC):
         # Token boundaries whose reachable tail must be retained under sparse
         # retention: the replay boundary (``num_prompt - 1``, capped by
         # ``get_computed_blocks``) and any detected shared-prefix junction.
-        replay_boundary = request.num_prompt_tokens - 1
         if self.use_eagle:
-            aligned = (
-                replay_boundary // self.scheduler_block_size * self.scheduler_block_size
+            # Eagle proves a boundary by matching one aligned unit past it and
+            # dropping back, so a boundary is only reachable when that unit
+            # exists. A prompt ending within one unit of its last aligned
+            # boundary cannot supply it -- SWA's `shift` block falls outside
+            # the prompt, and mamba has no shift at all (draft models have no
+            # recurrent layers), leaving nothing to prove it. Rewind one unit
+            # unconditionally rather than detect the case per group: it costs
+            # one unit of hit length when the unit does exist, and avoids
+            # retaining a boundary that nothing can reach. Mirrors
+            # `last_cache_position` in Scheduler._mamba_block_aligned_split,
+            # which is where these states get materialized.
+            replay_boundary = max(
+                request.num_prompt_tokens
+                // self.scheduler_block_size
+                * self.scheduler_block_size
+                - self.scheduler_block_size,
+                0,
             )
-            # Eagle matches one block past the boundary and drops it back, so
-            # the boundary is only reachable when that lookahead block fits in
-            # the prompt, so back off one unit to a state that is reachable.
-            if aligned + self.block_size > request.num_prompt_tokens:
-                aligned = max(aligned - self.scheduler_block_size, 0)
-            replay_boundary = aligned
+        else:
+            replay_boundary = request.num_prompt_tokens - 1
         reachable_boundaries = [replay_boundary]
         if request.shared_prefix_boundary:
             reachable_boundaries.append(request.shared_prefix_boundary)

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -428,7 +428,8 @@ class SingleTypeKVCacheManager(ABC):
         request: Request,
         num_tokens: int,
         retention_interval: int | None = None,
-        replay_boundary: int = 0,
+        *,
+        replay_boundary: int,
     ) -> None:
         """
         Cache the blocks for the request.
@@ -781,7 +782,8 @@ class FullAttentionManager(SingleTypeKVCacheManager):
         request: Request,
         num_tokens: int,
         retention_interval: int | None = None,
-        replay_boundary: int = 0,
+        *,
+        replay_boundary: int,
     ) -> None:
         super().cache_blocks(
             request,
@@ -1683,7 +1685,8 @@ class MambaManager(SingleTypeKVCacheManager):
         request: Request,
         num_tokens: int,
         retention_interval: int | None = None,
-        replay_boundary: int = 0,
+        *,
+        replay_boundary: int,
     ) -> None:
         num_cached_blocks_before = self.num_cached_block.get(request.request_id, 0)
         super().cache_blocks(
@@ -1790,7 +1793,8 @@ class CrossAttentionManager(SingleTypeKVCacheManager):
         request: Request,
         num_tokens: int,
         retention_interval: int | None = None,
-        replay_boundary: int = 0,
+        *,
+        replay_boundary: int,
     ) -> None:
         # We do not cache blocks for cross-attention to be shared between
         # requests, so this method is not relevant.

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -454,15 +454,8 @@ class SingleTypeKVCacheManager(ABC):
         if self.use_eagle:
             # Eagle proves a boundary by matching one aligned unit past it and
             # dropping back, so a boundary is only reachable when that unit
-            # exists. A prompt ending within one unit of its last aligned
-            # boundary cannot supply it -- SWA's `shift` block falls outside
-            # the prompt, and mamba has no shift at all (draft models have no
-            # recurrent layers), leaving nothing to prove it. Rewind one unit
-            # unconditionally rather than detect the case per group: it costs
-            # one unit of hit length when the unit does exist, and avoids
-            # retaining a boundary that nothing can reach. Mirrors
-            # `last_cache_position` in Scheduler._mamba_block_aligned_split,
-            # which is where these states get materialized.
+            # exists. Rewind one unit unconditionally to avoid retaining a 
+            # boundary that eagle cannot reach.
             replay_boundary = max(
                 request.num_prompt_tokens
                 // self.scheduler_block_size

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -451,7 +451,18 @@ class SingleTypeKVCacheManager(ABC):
         # Token boundaries whose reachable tail must be retained under sparse
         # retention: the replay boundary (``num_prompt - 1``, capped by
         # ``get_computed_blocks``) and any detected shared-prefix junction.
-        reachable_boundaries = [request.num_prompt_tokens - 1]
+        replay_boundary = request.num_prompt_tokens - 1
+        if self.use_eagle:
+            aligned = (
+                replay_boundary // self.scheduler_block_size * self.scheduler_block_size
+            )
+            # Eagle matches one block past the boundary and drops it back, so
+            # the boundary is only reachable when that lookahead block fits in
+            # the prompt, so back off one unit to a state that is reachable.
+            if aligned + self.block_size > request.num_prompt_tokens:
+                aligned = max(aligned - self.scheduler_block_size, 0)
+            replay_boundary = aligned
+        reachable_boundaries = [replay_boundary]
         if request.shared_prefix_boundary:
             reachable_boundaries.append(request.shared_prefix_boundary)
 
@@ -1715,6 +1726,12 @@ class MambaManager(SingleTypeKVCacheManager):
         latest_prompt_hash_boundary = (
             request.num_prompt_tokens // hash_block_size
         ) * hash_block_size
+        if self.use_eagle:
+            # Eagle groups match one hash unit past the candidate and drop it,
+            # so register the tail one unit lower.
+            latest_prompt_hash_boundary = max(
+                latest_prompt_hash_boundary - hash_block_size, 0
+            )
         if num_tokens != latest_prompt_hash_boundary:
             return None
 

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -108,7 +108,6 @@ class SingleTypeKVCacheManager(ABC):
         # aligned segment (SWA). Initialized lazily by the coordinator after
         # determining the attention groups.
         self.use_eagle = False
-
         # Partial-hit copy-on-write bookkeeping. Populated only by fine-grained
         # managers (full attention, mamba "align"); harmlessly empty elsewhere.
         self._partial_hit_reqs: dict[str, tuple[int, KVCacheBlock]] = {}
@@ -427,6 +426,8 @@ class SingleTypeKVCacheManager(ABC):
         request: Request,
         num_tokens: int,
         retention_interval: int | None = None,
+        *,
+        replay_boundary: int,
     ) -> None:
         """
         Cache the blocks for the request.
@@ -449,7 +450,7 @@ class SingleTypeKVCacheManager(ABC):
         # Token boundaries whose reachable tail must be retained under sparse
         # retention: the replay boundary (``num_prompt - 1``, capped by
         # ``get_computed_blocks``) and any detected shared-prefix junction.
-        reachable_boundaries = [request.num_prompt_tokens - 1]
+        reachable_boundaries = [replay_boundary]
         if request.shared_prefix_boundary:
             reachable_boundaries.append(request.shared_prefix_boundary)
 
@@ -779,8 +780,15 @@ class FullAttentionManager(SingleTypeKVCacheManager):
         request: Request,
         num_tokens: int,
         retention_interval: int | None = None,
+        *,
+        replay_boundary: int,
     ) -> None:
-        super().cache_blocks(request, num_tokens, retention_interval=retention_interval)
+        super().cache_blocks(
+            request,
+            num_tokens,
+            retention_interval=retention_interval,
+            replay_boundary=replay_boundary,
+        )
         hash_block_size = self.block_pool.hash_block_size
         if self.block_size == hash_block_size:
             return
@@ -1676,9 +1684,16 @@ class MambaManager(SingleTypeKVCacheManager):
         request: Request,
         num_tokens: int,
         retention_interval: int | None = None,
+        *,
+        replay_boundary: int,
     ) -> None:
         num_cached_blocks_before = self.num_cached_block.get(request.request_id, 0)
-        super().cache_blocks(request, num_tokens, retention_interval=retention_interval)
+        super().cache_blocks(
+            request,
+            num_tokens,
+            retention_interval=retention_interval,
+            replay_boundary=replay_boundary,
+        )
         num_cached_blocks_after = self.num_cached_block.get(request.request_id, 0)
         if self.mamba_cache_mode == "align":
             partial_hash = self._cache_partial_tail_block(request, num_tokens)
@@ -1714,6 +1729,12 @@ class MambaManager(SingleTypeKVCacheManager):
         latest_prompt_hash_boundary = (
             request.num_prompt_tokens // hash_block_size
         ) * hash_block_size
+        if self.use_eagle:
+            # Eagle groups match one hash unit past the candidate and drop it,
+            # so register the tail one unit lower.
+            latest_prompt_hash_boundary = max(
+                latest_prompt_hash_boundary - hash_block_size, 0
+            )
         if num_tokens != latest_prompt_hash_boundary:
             return None
 
@@ -1771,6 +1792,8 @@ class CrossAttentionManager(SingleTypeKVCacheManager):
         request: Request,
         num_tokens: int,
         retention_interval: int | None = None,
+        *,
+        replay_boundary: int,
     ) -> None:
         # We do not cache blocks for cross-attention to be shared between
         # requests, so this method is not relevant.


### PR DESCRIPTION
## Purpose
This PR fixes an unexpected prefix cache miss bug in hybrid sparse attention models.

## Bug

Setup:
- Kimi K3, TP8 B300
- Block size: 1536
- Prefix-match unit (PMU): 128
- Cache retention interval: 0 (only cache at prompt boundary)

Turn 1: prompt_length=24576, cache_hit_length=0      [expected]
Turn 2: prompt_length=50000, cache_hit_length=23040  [expected]

Turn 1: prompt_length=24577, cache_hit_length=0      [expected]
Turn 2: prompt_length=50000, cache_hit_length=0      [unexpected - full miss]

The cause:

Mamba caches state at two prompt-boundary positions:
- the last block-aligned position for `prompt_length - 1`; and
- the last PMU-aligned position, registered as a partial block entry.

With `prompt_length=24576` those are 23040 and 24576.
With `prompt_length=24577` both collapse to 24576.

Full attention is cached up to 24576. The current prefix cache implementation requires Eagle to match one block (128 in this case) past the candidate and then dropping it. The `23040` mamba checkpoint in case 1 satisfies a cache hit where `23040 + 128` is cached in full attention. But in case 2 there is no mamba checkpoint that can satisfy it, and thus leads to a full miss.

## Fix

The PR fixes by moving the mamba/SWA cache state position forward when using eagle so that it can match an extra unit/block of full attention cache to drop.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://docs.vllm.ai/en/latest/contributing>** (anything written below this line will be removed by GitHub Actions)
