### PR TITLE
[Bugfix] Align deepseek v4 parser thinking default with tokenizer

### DIFF
--- a/tests/parser/engine/test_deepseek_v4.py
+++ b/tests/parser/engine/test_deepseek_v4.py
@@ -852,9 +852,7 @@ class TestDelegatingParserLargeDelta:
         args = json.loads(output.tool_calls[0]["arguments"])
         assert args == {"location": "Berlin", "units": "celsius"}
 
-    def test_default_thinking_extracts_tool_call_without_think_end(
-        self, dsv4_tokens
-    ):
+    def test_default_thinking_extracts_tool_call_without_think_end(self, dsv4_tokens):
         tokens = [
             token
             for token in dsv4_tokens

--- a/tests/parser/engine/test_deepseek_v4.py
+++ b/tests/parser/engine/test_deepseek_v4.py
@@ -243,15 +243,29 @@ class TestThinkingModeConfig:
         cfg = deepseek_v4_config(thinking=False)
         assert cfg.initial_state.name == "CONTENT"
 
-    def test_enable_thinking_kwarg(self, mock_tokenizer):
-        p = DeepSeekV4Parser(
-            mock_tokenizer, chat_template_kwargs={"enable_thinking": True}
+    @pytest.mark.parametrize(
+        ("chat_template_kwargs", "expected_state"),
+        [
+            ({}, "REASONING"),
+            ({"thinking": True}, "REASONING"),
+            ({"enable_thinking": True}, "REASONING"),
+            ({"reasoning_effort": "high"}, "REASONING"),
+            ({"thinking": False}, "CONTENT"),
+            ({"enable_thinking": False}, "CONTENT"),
+            (
+                {"enable_thinking": True, "reasoning_effort": "none"},
+                "CONTENT",
+            ),
+        ],
+    )
+    def test_parser_thinking_mode_matches_tokenizer_default(
+        self, mock_tokenizer, chat_template_kwargs, expected_state
+    ):
+        parser = DeepSeekV4Parser(
+            mock_tokenizer,
+            chat_template_kwargs=chat_template_kwargs,
         )
-        assert p.parser_engine_config.initial_state.name == "REASONING"
-
-    def test_no_thinking_kwarg_defaults_to_content(self, mock_tokenizer):
-        p = DeepSeekV4Parser(mock_tokenizer)
-        assert p.parser_engine_config.initial_state.name == "CONTENT"
+        assert parser.parser_engine_config.initial_state.name == expected_state
 
     def test_thinking_mode_reasoning_without_tags(self, mock_tokenizer):
         parser = DeepSeekV4Parser(
@@ -834,6 +848,37 @@ class TestDelegatingParserLargeDelta:
             f"Expected 1 tool call but got {len(output.tool_calls)}; "
             f"reasoning={output.reasoning!r}, content={output.content!r}"
         )
+        assert output.tool_calls[0]["name"] == "get_weather"
+        args = json.loads(output.tool_calls[0]["arguments"])
+        assert args == {"location": "Berlin", "units": "celsius"}
+
+    def test_default_thinking_extracts_tool_call_without_think_end(
+        self, dsv4_tokens
+    ):
+        tokens = [
+            token
+            for token in dsv4_tokens
+            if token[0] != _DSV4_FULL_VOCAB[DSML_THINK_END]
+        ]
+        tokenizer = MockTokenizer(
+            vocab=dict(_DSV4_FULL_VOCAB),
+            tokens=tokens,
+        )
+        parser = _DeepSeekV4Delegating(tokenizer)
+
+        deltas = replay_streaming(
+            parser,
+            tokens,
+            chunk_size=1,
+            finished_on_last=True,
+            tools=DUMMY_TOOLS,
+            prompt_token_ids=[_DSV4_FULL_VOCAB[DSML_THINK_START]],
+        )
+        output = collect_output(deltas)
+
+        assert "The user wants" in output.reasoning
+        assert output.content == ""
+        assert len(output.tool_calls) == 1
         assert output.tool_calls[0]["name"] == "get_weather"
         args = json.loads(output.tool_calls[0]["arguments"])
         assert args == {"location": "Berlin", "units": "celsius"}

--- a/tests/parser/engine/trace_builder.py
+++ b/tests/parser/engine/trace_builder.py
@@ -722,7 +722,7 @@ def _dsv4_segments(scenario: Scenario, thinking: bool) -> list[tuple[str, bool]]
 
 def _build_deepseek_v4(scenario: Scenario, validate: bool = True) -> Sample:
     thinking = scenario.reasoning is not None
-    chat_kwargs = {"thinking": True} if thinking else None
+    chat_kwargs = {"thinking": thinking}
 
     if thinking:
         expected_reasoning: str | None = scenario.reasoning or ""

--- a/vllm/parser/deepseek_v4.py
+++ b/vllm/parser/deepseek_v4.py
@@ -217,10 +217,12 @@ class DeepSeekV4Parser(ParserEngine):
         **kwargs,
     ) -> None:
         chat_kwargs = kwargs.pop("chat_template_kwargs", None) or {}
-        thinking = (
-            bool(chat_kwargs.get("thinking") or chat_kwargs.get("enable_thinking"))
-            and chat_kwargs.get("reasoning_effort") != "none"
+        thinking = bool(
+            chat_kwargs.get("thinking") or chat_kwargs.get("enable_thinking")
         )
+        if "thinking" not in chat_kwargs and "enable_thinking" not in chat_kwargs:
+            thinking = True
+        thinking = thinking and chat_kwargs.get("reasoning_effort") != "none"
         super().__init__(
             tokenizer,
             tools,


### PR DESCRIPTION
## Purpose
DeepSeek V4’s tokenizer defaults to thinking mode when neither thinking nor enable_thinking is specified. The parser defaulted to content mode, causing reasoning and DSML tool-call markup to leak into content instead of producing structured reasoning_content and tool_calls. The mismatch was introduced by PR #50580.

### This PR
This PR aligns the parser with the tokenizer while preserving explicit opt-out through thinking=false, enable_thinking=false, or reasoning_effort="none". 

## Test Plan
I tested with opencode hooked up to vllm server, without the PR, all tool calls are leaked into content, after the PR it's fixed.
