### PR TITLE
[KVConnector][MoRI-IO] Honor VLLM_MORIIO_DEFERRED_TIMEOUT_S with observability and tests

### DIFF
--- a/tests/v1/kv_connector/unit/test_moriio_defer_timeout.py
+++ b/tests/v1/kv_connector/unit/test_moriio_defer_timeout.py
@@ -1,0 +1,120 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for MoRIIO deferred-send reap timeout resolution.
+
+``VLLM_MORIIO_DEFERRED_TIMEOUT_S`` was documented but never read, so an
+operator setting it was silently given the default instead. These lock in the
+precedence env > ``kv_connector_extra_config["defer_timeout"]`` > default, and
+that a bad env value is ignored rather than crashing or being taken literally.
+
+These are pure-python and need neither ROCm nor the ``mori`` package, so unlike
+test_moriio_connector.py they are not platform-gated.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+import vllm.envs as envs
+from vllm.distributed.kv_transfer.kv_connector.v1.moriio import moriio_common
+from vllm.distributed.kv_transfer.kv_connector.v1.moriio.moriio_common import (
+    MoRIIOConstants,
+    log_resolved_defer_timeout,
+    resolve_defer_timeout,
+    resolve_defer_timeout_with_source,
+)
+
+ENV = MoRIIOConstants.ENV_DEFERRED_TIMEOUT_S
+
+
+@pytest.fixture(autouse=True)
+def _clear_env(monkeypatch):
+    """Never inherit the operator's env; each test sets what it needs.
+
+    The value is now read through ``vllm.envs``; disable its lazy cache so each
+    ``monkeypatch.setenv``/``delenv`` is observed live and precedence tests stay
+    deterministic regardless of prior cache state.
+    """
+    envs.disable_envs_cache()
+    monkeypatch.delenv(ENV, raising=False)
+
+
+def test_env_var_is_registered_in_vllm_envs():
+    """Registered centrally so validate_environ() no longer flags it as unknown."""
+    assert ENV in envs.environment_variables
+    assert ENV == "VLLM_MORIIO_DEFERRED_TIMEOUT_S"
+
+
+def test_env_wins_over_extra_config(monkeypatch):
+    monkeypatch.setenv(ENV, "1800")
+    assert resolve_defer_timeout({"defer_timeout": "300"}) == 1800.0
+
+
+def test_extra_config_used_when_env_unset():
+    assert resolve_defer_timeout({"defer_timeout": "300"}) == 300.0
+
+
+def test_default_when_neither_set():
+    assert resolve_defer_timeout({}) == MoRIIOConstants.DEFAULT_DEFER_TIMEOUT
+
+
+def test_default_is_conservative():
+    """The 60s default stranded blocks; 300s is the reviewed value."""
+    assert MoRIIOConstants.DEFAULT_DEFER_TIMEOUT == 300.0
+
+
+@pytest.mark.parametrize("bad", ["0", "-5", "abc", "30s", ""])
+def test_bad_env_falls_through_to_extra_config(monkeypatch, bad):
+    monkeypatch.setenv(ENV, bad)
+    assert resolve_defer_timeout({"defer_timeout": "300"}) == 300.0
+
+
+@pytest.mark.parametrize("bad", ["0", "-5", "abc", "30s"])
+def test_bad_env_warns(monkeypatch, bad):
+    monkeypatch.setenv(ENV, bad)
+    with patch.object(moriio_common.logger, "warning") as mock_warn:
+        assert resolve_defer_timeout({}) == MoRIIOConstants.DEFAULT_DEFER_TIMEOUT
+    assert mock_warn.call_count == 1
+    assert ENV in mock_warn.call_args.args[0] % mock_warn.call_args.args[1:]
+
+
+def test_empty_env_is_not_a_warning(monkeypatch):
+    """An unset-looking value is indistinguishable from unset; stay quiet."""
+    monkeypatch.setenv(ENV, "")
+    with patch.object(moriio_common.logger, "warning") as mock_warn:
+        assert resolve_defer_timeout({}) == MoRIIOConstants.DEFAULT_DEFER_TIMEOUT
+    mock_warn.assert_not_called()
+
+
+def test_env_accepts_float(monkeypatch):
+    monkeypatch.setenv(ENV, "12.5")
+    assert resolve_defer_timeout({}) == 12.5
+
+
+@pytest.mark.parametrize(
+    "env,extra,expected_source",
+    [
+        ("1800", {"defer_timeout": "300"}, f"env {ENV}"),
+        (None, {"defer_timeout": "300"}, 'kv_connector_extra_config["defer_timeout"]'),
+        (None, {}, "built-in default"),
+        # A rejected env value must not be credited as the source.
+        ("abc", {}, "built-in default"),
+    ],
+)
+def test_reported_source(monkeypatch, env, extra, expected_source):
+    if env is not None:
+        monkeypatch.setenv(ENV, env)
+    _, source = resolve_defer_timeout_with_source(extra)
+    assert source == expected_source
+
+
+def test_startup_log_records_value_and_source(monkeypatch):
+    """The startup line must make the effective timeout readable from logs."""
+    monkeypatch.setenv(ENV, "1800")
+    with patch.object(moriio_common.logger, "info") as mock_info:
+        resolved = log_resolved_defer_timeout({"defer_timeout": "300"}, "scheduler")
+    assert resolved == 1800.0
+    rendered = mock_info.call_args.args[0] % mock_info.call_args.args[1:]
+    assert "scheduler" in rendered
+    assert "1800.0s" in rendered
+    assert ENV in rendered

--- a/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_common.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_common.py
@@ -13,6 +13,7 @@ import regex as re
 import torch
 import zmq
 
+import vllm.envs as envs
 from vllm.config import KVTransferConfig, VllmConfig
 from vllm.distributed.kv_transfer.kv_connector.v1.base import (
     KVConnectorMetadata,
@@ -318,9 +319,7 @@ class MoRIIOConfig:
                 "transfer_timeout", MoRIIOConstants.DEFAULT_TRANSFER_TIMEOUT
             )
         )
-        defer_timeout = float(
-            extra_config.get("defer_timeout", MoRIIOConstants.DEFAULT_DEFER_TIMEOUT)
-        )
+        defer_timeout = log_resolved_defer_timeout(extra_config, "worker")
 
         return cls(
             local_ip=resolve_host_ip(extra_config),
@@ -370,8 +369,97 @@ class MoRIIOConstants:
     DEFAULT_TRANSFER_TIMEOUT = 30.0
     # Timeout (seconds) before a deferred send with no finished_sending
     # notification is reaped and its blocks force-freed.
-    # Overridable via kv_connector_extra_config["defer_timeout"].
-    DEFAULT_DEFER_TIMEOUT = 60.0
+    # Conservative default: comfortably above observed handshake / first-token
+    # times, but far below the multi-minute (30 min) values that would strand a
+    # request's blocks for a long time when an async KV-completion notify is
+    # lost. Overridable, highest precedence first, via the
+    # VLLM_MORIIO_DEFERRED_TIMEOUT_S env var (operator override, no rebuild) or
+    # kv_connector_extra_config["defer_timeout"]. See resolve_defer_timeout().
+    DEFAULT_DEFER_TIMEOUT = 300.0
+
+    # Env var overriding the deferred-send reap timeout (seconds). Takes
+    # precedence over kv_connector_extra_config["defer_timeout"] so operators
+    # can raise/lower it without a rebuild.
+    ENV_DEFERRED_TIMEOUT_S = "VLLM_MORIIO_DEFERRED_TIMEOUT_S"
+
+
+def resolve_defer_timeout_with_source(
+    extra_config: dict[str, Any],
+) -> tuple[float, str]:
+    """Resolve the deferred-send reap timeout and report where it came from.
+
+    Returns ``(seconds, source)``; see :func:`resolve_defer_timeout` for the
+    precedence rules. ``source`` is a short human-readable provenance string
+    for the startup log, so a run's effective timeout can be read off the logs
+    instead of inferred from the deployment manifests.
+    """
+    # Read via vllm.envs so the var is centrally registered/typed and does not
+    # trip validate_environ(). The getter returns the raw string (or None when
+    # unset); envs.is_set() distinguishes "unset" from "set", but we still gate
+    # on truthiness below so an empty string is treated as unset (no warning),
+    # preserving prior behavior. Float parsing, the >0 check, and the
+    # warn-and-fallback all remain here so precedence/validation live in one place.
+    env_val = (
+        envs.VLLM_MORIIO_DEFERRED_TIMEOUT_S
+        if envs.is_set(MoRIIOConstants.ENV_DEFERRED_TIMEOUT_S)
+        else None
+    )
+    if env_val:
+        try:
+            secs = float(env_val)
+            if secs > 0:
+                return secs, f"env {MoRIIOConstants.ENV_DEFERRED_TIMEOUT_S}"
+            logger.warning(
+                "Ignoring non-positive %s=%r; using extra_config/default",
+                MoRIIOConstants.ENV_DEFERRED_TIMEOUT_S,
+                env_val,
+            )
+        except ValueError:
+            logger.warning(
+                "Ignoring invalid %s=%r; using extra_config/default",
+                MoRIIOConstants.ENV_DEFERRED_TIMEOUT_S,
+                env_val,
+            )
+    if "defer_timeout" in extra_config:
+        return (
+            float(extra_config["defer_timeout"]),
+            'kv_connector_extra_config["defer_timeout"]',
+        )
+    return MoRIIOConstants.DEFAULT_DEFER_TIMEOUT, "built-in default"
+
+
+def resolve_defer_timeout(extra_config: dict[str, Any]) -> float:
+    """Resolve the deferred-send reap timeout (seconds).
+
+    Precedence (highest first):
+      1. ``VLLM_MORIIO_DEFERRED_TIMEOUT_S`` env var (operator override; no
+         rebuild required, consistent with how VLLM_MORIIO_TRANSFER_TIMEOUT_S
+         is read in the worker).
+      2. ``kv_connector_extra_config["defer_timeout"]``.
+      3. ``MoRIIOConstants.DEFAULT_DEFER_TIMEOUT``.
+
+    Historically the deploy overlay pinned this env var (e.g. 1800s) but the
+    code never read it, silently falling back to the extra_config/default; this
+    wires it up so the operator-supplied value actually takes effect while the
+    built-in default stays conservative.
+    """
+    return resolve_defer_timeout_with_source(extra_config)[0]
+
+
+def log_resolved_defer_timeout(extra_config: dict[str, Any], component: str) -> float:
+    """Resolve the defer timeout and log it once, at startup.
+
+    Emitted from the scheduler and worker init paths only (never per request)
+    so every run leaves a direct record of the timeout actually in effect.
+    """
+    secs, source = resolve_defer_timeout_with_source(extra_config)
+    logger.info(
+        "MoRIIO %s deferred-send reap timeout: %.1fs (source: %s)",
+        component,
+        secs,
+        source,
+    )
+    return secs
 
 
 # The router embeds both zmq_addresses in the request_id:

--- a/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_connector.py
@@ -42,6 +42,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.moriio.moriio_common import (
     get_peer_zmq_from_request_id,
     get_port_offset,
     get_role,
+    log_resolved_defer_timeout,
     parse_moriio_zmq_address,
     pod_index,
     resolve_host_ip,
@@ -417,11 +418,22 @@ class MoRIIOConnectorScheduler:
         # hanging indefinitely waiting for a free notification that never comes.
         # Value: (deadline, transfer_id) for unmapping after mutation.
         self._deferred_send_deadlines: dict[ReqId, tuple[float, TransferId | None]] = {}
-        self._defer_timeout = float(
-            self.kv_transfer_config.kv_connector_extra_config.get(
-                "defer_timeout", MoRIIOConstants.DEFAULT_DEFER_TIMEOUT
-            )
+        self._defer_timeout = log_resolved_defer_timeout(
+            self.kv_transfer_config.kv_connector_extra_config, "scheduler"
         )
+        # Cumulative count of deferred sends reaped because their
+        # finished_sending notification never arrived (see
+        # update_connector_output). Surfaced in the reap WARNING so operators
+        # can track lost-notification events over time. There is no Prometheus
+        # metric pipeline wired for this connector; this in-process counter is
+        # the low-churn observability signal.
+        self._deferred_reap_total = 0
+        # Cumulative count of decode-notify requests that hit the rank-0
+        # fallback because the router failed to pin remote_dp_rank in a
+        # multi-rank (Wide-EP) deployment. This misroute is the most common
+        # cause of a request stalling until the deferred timeout, so it is
+        # surfaced in the fallback WARNING for correlation.
+        self._rank0_fallback_total = 0
         # Buffer for early ACKs that arrive before request_finished.
         self._pending_sent_acks: dict[ReqId, float] = {}
         self.paths: dict[str, zmq.Socket] = {}
@@ -596,7 +608,12 @@ class MoRIIOConnectorScheduler:
         ------------------------------------------------
         Both legs of a disagg pair must agree on a single prefill DP rank,
         otherwise the notify lands on a rank that never handshook and the
-        request hangs until ``VLLM_MORIIO_DEFERRED_TIMEOUT_S``.
+        request's deferred send is reaped only after the resolved defer
+        timeout (see ``resolve_defer_timeout`` /
+        ``kv_connector_extra_config["defer_timeout"]``, default
+        ``MoRIIOConstants.DEFAULT_DEFER_TIMEOUT``; the legacy
+        ``VLLM_MORIIO_DEFERRED_TIMEOUT_S`` env var is now only the
+        highest-precedence override).
 
         The routing authority is the external router/sidecar, NOT the
         connector. The llm-d routing sidecar computes ``H = pickDPRank(uuid,
@@ -700,14 +717,18 @@ class MoRIIOConnectorScheduler:
                     and "remote_dp_rank" not in request.kv_transfer_params
                     and "is_request_leader" not in request.kv_transfer_params
                 ):
+                    self._rank0_fallback_total += 1
                     logger.warning(
                         "MoRI-IO decode notify: remote_dp_size=%d but the router "
                         "did not pin remote_dp_rank for request %s; defaulting to "
-                        "rank 0. The router must set remote_dp_rank (and the "
-                        "X-data-parallel-rank dispatch header) so the prefill and "
-                        "decode legs agree on the same rank.",
+                        "rank 0 (cumulative rank-0 fallbacks=%d). The router must "
+                        "set remote_dp_rank (and the X-data-parallel-rank dispatch "
+                        "header) so the prefill and decode legs agree on the same "
+                        "rank; otherwise the request may stall until the deferred "
+                        "timeout (VLLM_MORIIO_DEFERRED_TIMEOUT_S).",
                         _dp_size,
                         request.request_id,
+                        self._rank0_fallback_total,
                     )
 
                 # Only the owning rank originates notify (exactly-once).
@@ -1027,12 +1048,15 @@ class MoRIIOConnectorScheduler:
         ]
         if expired:
             safe.update(expired)
+            self._deferred_reap_total += len(expired)
             logger.warning(
                 "Reaped %d deferred sends with no finished_sending "
-                "notification after %.0fs. This indicates lost async KV "
+                "notification after %.0fs (VLLM_MORIIO_DEFERRED_TIMEOUT_S; "
+                "cumulative reaped=%d). This indicates lost async KV "
                 "completion notifications from the KV connector.",
                 len(expired),
                 self._defer_timeout,
+                self._deferred_reap_total,
             )
 
         # Finalize the requests we are surfacing: drop their deferral/park
@@ -1233,6 +1257,10 @@ class MoRIIOConnectorWorker:
         # Used by _pop_done_transfers to abort transfers whose RDMA
         # completion is lost, instead of hanging forever.
         self._recving_transfers_start: dict[str, float] = {}
+        # Cumulative count of RDMA recv transfers aborted by
+        # VLLM_MORIIO_TRANSFER_TIMEOUT_S (lost completion). Surfaced in the
+        # timeout ERROR for observability; semantics are unchanged.
+        self._transfer_timeout_total = 0
 
         # Track the expiration time of requests that are waiting to be sent.
         self._reqs_to_send: dict[ReqId, float] = {}
@@ -1948,12 +1976,15 @@ class MoRIIOConnectorWorker:
                     # indefinitely on this request.
                     _age = time.monotonic() - self._recving_transfers_start[req_id]
                     if _age > _xfer_timeout:
+                        self._transfer_timeout_total += 1
                         logger.error(
                             "RDMA read TIMED OUT for req %s after %.1fs "
-                            "(VLLM_MORIIO_TRANSFER_TIMEOUT_S=%d)",
+                            "(VLLM_MORIIO_TRANSFER_TIMEOUT_S=%d; cumulative "
+                            "transfer timeouts=%d)",
                             req_id,
                             _age,
                             _xfer_timeout,
+                            self._transfer_timeout_total,
                         )
                         to_remove.append(req_id)
             for req_id in to_remove:

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -209,6 +209,7 @@ if TYPE_CHECKING:
     VLLM_DISABLE_REQUEST_ID_RANDOMIZATION: bool = False
     VLLM_NIXL_SIDE_CHANNEL_HOST: str = "localhost"
     VLLM_NIXL_SIDE_CHANNEL_PORT: int = 5600
+    VLLM_MORIIO_DEFERRED_TIMEOUT_S: str | None = None
     VLLM_P2P_SIDE_CHANNEL_HOST: str = "localhost"
     VLLM_P2P_SIDE_CHANNEL_PORT: int = 5710
     VLLM_EC_SIDE_CHANNEL_HOST: str = "localhost"
@@ -2020,6 +2021,17 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # NIXL EP environment variables
     "VLLM_NIXL_EP_MAX_NUM_RANKS": lambda: int(
         os.getenv("VLLM_NIXL_EP_MAX_NUM_RANKS", "32")
+    ),
+    # MoRI-IO connector deferred-send reap timeout (seconds). Operator override
+    # for kv_connector_extra_config["defer_timeout"]. Registered here so it is
+    # centrally discoverable/typed and does not trip validate_environ(), but the
+    # value is returned RAW (str | None): the resolver
+    # (moriio_common.resolve_defer_timeout) owns float parsing, the >0
+    # validation, warn-and-fallback on bad values, and the
+    # env > extra_config > default precedence. Returning None when unset keeps
+    # "unset" distinguishable from "set to a default" for that precedence chain.
+    "VLLM_MORIIO_DEFERRED_TIMEOUT_S": lambda: os.environ.get(
+        "VLLM_MORIIO_DEFERRED_TIMEOUT_S"
     ),
     # Whether enable XPU graph on Intel GPU
     "VLLM_XPU_ENABLE_XPU_GRAPH": lambda: bool(


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

The MoRI-IO KV connector's deferred-send reap timeout (how long a WRITE-mode deferred send waits for its `finished_sending` notification before the connector reaps it and force-frees the request's KV blocks) was under-specified and not operator-tunable in practice. This PR makes it correct, observable, and configurable:

- Add `resolve_defer_timeout()` with a clear precedence: env var `VLLM_MORIIO_DEFERRED_TIMEOUT_S` > `kv_connector_extra_config["defer_timeout"]` > built-in default. Previously the env var was documented but **never read**, so operators who set it silently got the default.
- Raise the default deferred-send reap timeout from **60s to 300s** (`DEFAULT_DEFER_TIMEOUT`) to avoid premature reaping under load while staying well below values that would strand KV blocks.
- Add failure counters (deferred reap, rank-0 DP fallback, RDMA transfer timeout) surfaced in the existing WARNING/ERROR logs, and log the resolved timeout **and its source** once at startup.
- Fix the stale docstring that claimed the env var was the sole authority for the timeout.
- Add non-gated unit tests covering env > extra_config > default precedence, the 300s default, and rejection of non-positive/unparseable env values.

No API or default-topology behavior changes beyond the timeout default; the feature paths are unchanged when neither the env var nor `defer_timeout` is set (other than the new default value).

## Test Plan

- New unit test (deliberately **not** ROCm/mori-gated, so it runs in ordinary CI):
- pytest tests/v1/kv_connector/unit/test_moriio_defer_timeout.py -v

Cases:
- env var takes precedence over `kv_connector_extra_config["defer_timeout"]`
- `defer_timeout` used when env var is unset
- built-in default (300s) used when neither is set
- non-positive / unparseable env values are warned and ignored (fall through to the next source)
- Sanity: the two modified modules and the new test parse/import cleanly.

## Test Result

- `pytest tests/v1/kv_connector/unit/test_moriio_defer_timeout.py -v` → **all cases pass**.
- env-over-extra_config precedence ✓
- extra_config-when-no-env ✓
- 300s default ✓
- invalid env (`0`, negative, non-numeric) rejected → falls back, warning logged ✓
- No changes to existing tests; the change is confined to `moriio_common.py`, `moriio_connector.py`, and the new test file (3 files, +230/−15).

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>