### PR TITLE
[Bugfix] Fix structured outputs on the V2 CPU model runner

### DIFF
--- a/tests/v1/worker/test_structured_outputs.py
+++ b/tests/v1/worker/test_structured_outputs.py
@@ -1,0 +1,40 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import torch
+
+from vllm.v1.worker.gpu.structured_outputs import StructuredOutputsWorker
+
+pytestmark = pytest.mark.cpu_test
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+def test_structured_outputs_worker_applies_cpu_bitmask(monkeypatch, dtype):
+    def fail_if_cuda_stream_is_created():
+        pytest.fail("CPU structured outputs must not create a CUDA stream")
+
+    monkeypatch.setattr(torch.cuda, "Stream", fail_if_cuda_stream_is_created)
+
+    worker = StructuredOutputsWorker(
+        max_num_logits=3, vocab_size=64, device=torch.device("cpu")
+    )
+    input_batch = SimpleNamespace(
+        req_ids=["unconstrained", "structured"],
+        cu_num_logits_np=np.array([0, 1, 3], dtype=np.int32),
+    )
+    logits = torch.zeros((3, 64), dtype=dtype)
+    grammar_bitmask = np.zeros((2, 2), dtype=np.int32)
+
+    worker.apply_grammar_bitmask(
+        logits,
+        input_batch,
+        grammar_req_ids=["structured"],
+        grammar_bitmask=grammar_bitmask,
+    )
+
+    assert torch.isfinite(logits[0]).all()
+    assert torch.isneginf(logits[1:]).all()

--- a/vllm/v1/structured_output/utils.py
+++ b/vllm/v1/structured_output/utils.py
@@ -45,6 +45,20 @@ _T = TypeVar("_T")
 CACHE = None
 
 
+def apply_token_bitmask_cpu(
+    logits: torch.Tensor,
+    grammar_bitmask: torch.Tensor,
+    indices: list[int] | None,
+) -> None:
+    """Apply a grammar bitmask to CPU logits."""
+    if logits.dtype != torch.float32:
+        logits_fp32 = logits.to(torch.float32)
+        xgr.apply_token_bitmask_inplace(logits_fp32, grammar_bitmask, indices=indices)
+        logits.copy_(logits_fp32.to(logits.dtype))
+    else:
+        xgr.apply_token_bitmask_inplace(logits, grammar_bitmask, indices=indices)
+
+
 def compile_regex_with_timeout(fn: Callable[[str], _T], pattern: str) -> _T:
     """Run a regex compilation callable with a timeout.
 
@@ -163,16 +177,7 @@ def apply_grammar_bitmask(
 
     # CPU case, use list for indices.
     indices = None if skip_out_indices else out_indices
-    # Handle dtype conversion for CPU (older xgrammar CPU kernels require float32)
-    # See: https://github.com/vllm-project/vllm/issues/31901
-    if logits.dtype != torch.float32:
-        # Convert to float32, apply bitmask, then convert back
-        logits_fp32 = logits.to(torch.float32)
-        xgr.apply_token_bitmask_inplace(logits_fp32, grammar_bitmask, indices=indices)
-        # Copy the modified values back to the original tensor
-        logits.copy_(logits_fp32.to(logits.dtype))
-    else:
-        xgr.apply_token_bitmask_inplace(logits, grammar_bitmask, indices=indices)
+    apply_token_bitmask_cpu(logits, grammar_bitmask, indices)
 
 
 class OutlinesVocabulary:

--- a/vllm/v1/worker/gpu/structured_outputs.py
+++ b/vllm/v1/worker/gpu/structured_outputs.py
@@ -5,19 +5,26 @@ import torch
 
 from vllm.triton_utils import tl, triton
 from vllm.utils.math_utils import cdiv
+from vllm.v1.structured_output.utils import apply_token_bitmask_cpu
 from vllm.v1.worker.gpu.buffer_utils import async_copy_to_gpu
 from vllm.v1.worker.gpu.input_batch import InputBatch
 
 
 class StructuredOutputsWorker:
     def __init__(self, max_num_logits: int, vocab_size: int, device: torch.device):
+        self.device = device
+        if device.type == "cpu":
+            self.logits_indices = None
+            self.grammar_bitmask = None
+            self.copy_stream = None
+            return
+
         self.logits_indices = torch.zeros(
             max_num_logits, dtype=torch.int32, device=device
         )
         self.grammar_bitmask = torch.zeros(
             (max_num_logits, cdiv(vocab_size, 32)), dtype=torch.int32, device=device
         )
-        self.device = device
         self.copy_stream = torch.cuda.Stream()
 
     def apply_grammar_bitmask(
@@ -30,12 +37,6 @@ class StructuredOutputsWorker:
         if not grammar_req_ids:
             return
 
-        # Asynchronously copy the bitmask to GPU.
-        with torch.cuda.stream(self.copy_stream):
-            bitmask = async_copy_to_gpu(
-                grammar_bitmask, out=self.grammar_bitmask[: grammar_bitmask.shape[0]]
-            )
-
         # Construct bitmask -> logits mapping
         mapping: list[int] = []
         req_ids = input_batch.req_ids
@@ -46,6 +47,35 @@ class StructuredOutputsWorker:
             logits_start_idx = cu_num_logits[req_idx]
             logits_end_idx = cu_num_logits[req_idx + 1]
             mapping.extend(range(logits_start_idx, logits_end_idx))
+
+        num_masks = grammar_bitmask.shape[0]
+        assert num_masks == len(mapping)
+
+        if self.device.type == "cpu":
+            compact_bitmask = torch.from_numpy(grammar_bitmask)
+            if mapping == list(range(logits.shape[0])):
+                bitmask = compact_bitmask
+                indices = None
+            else:
+                bitmask = torch.full(
+                    (logits.shape[0], compact_bitmask.shape[1]),
+                    -1,
+                    dtype=compact_bitmask.dtype,
+                )
+                bitmask[mapping] = compact_bitmask
+                indices = mapping
+            apply_token_bitmask_cpu(logits, bitmask, indices)
+            return
+
+        assert self.grammar_bitmask is not None
+        assert self.logits_indices is not None
+        assert self.copy_stream is not None
+
+        # Asynchronously copy the bitmask to GPU.
+        with torch.cuda.stream(self.copy_stream):
+            bitmask = async_copy_to_gpu(
+                grammar_bitmask, out=self.grammar_bitmask[:num_masks]
+            )
 
         # Asynchronously copy the mapping to GPU.
         with torch.cuda.stream(self.copy_stream):
@@ -60,8 +90,6 @@ class StructuredOutputsWorker:
         current_stream = torch.cuda.current_stream()
         current_stream.wait_stream(self.copy_stream)
 
-        num_masks = bitmask.shape[0]
-        assert num_masks == len(mapping)
         vocab_size = logits.shape[-1]
         BLOCK_SIZE = 8192
         grid = (num_masks, triton.cdiv(vocab_size, BLOCK_SIZE))


### PR DESCRIPTION
## Purpose

Fixes #51283.

The V2 CPU model runner inherits `StructuredOutputsWorker`, whose structured-output path assumed CUDA was available. It created a CUDA stream, allocated pinned memory, and invoked a Triton kernel, causing structured-output requests on CPU-only deployments to terminate the engine.

This change:

- Avoids CUDA stream and GPU buffer initialization for CPU workers.
- Applies grammar masks through xgrammar's CPU implementation.
- Aligns compact V2 grammar masks with their absolute logits rows before calling xgrammar.
- Preserves the existing float32 conversion fallback for CPU logits such as bfloat16.
- Leaves the optimized CUDA path unchanged.

Duplicate-work checks were performed immediately before pushing. There were no open PRs referencing #51283 or matching the CPU structured-output fix.