### PR TITLE
[Bugfix] Gemma4 parser: decode JSON/Python string literals inside containers

### DIFF
--- a/tests/tool_parsers/test_gemma4_tool_parser.py
+++ b/tests/tool_parsers/test_gemma4_tool_parser.py
@@ -209,6 +209,47 @@ class TestParseGemma4Args:
         result = _parse_gemma4_args('name:"ds_152a4bfd"')
         assert result == {"name": "ds_152a4bfd"}
 
+    def test_equals_key_separator(self):
+        """A minority of emissions use ``key=value`` (issue #51284).
+
+        Previously the pair was swallowed into the next key, or dropped with
+        everything after it when no later ``:`` existed.
+        """
+        assert _parse_gemma4_args('data_refs=["ds_a"]') == {"data_refs": ["ds_a"]}
+
+    def test_equals_and_colon_mixed(self):
+        result = _parse_gemma4_args(
+            'code:<|"|>x<|"|>,data_refs=["ds_a"],note:<|"|>hi<|"|>'
+        )
+        assert result == {"code": "x", "data_refs": ["ds_a"], "note": "hi"}
+
+    def test_equals_separator_does_not_swallow_next_key(self):
+        result = _parse_gemma4_args('code:<|"|>x<|"|>,data_refs=["ds_a"]')
+        assert result == {"code": "x", "data_refs": ["ds_a"]}
+
+    def test_delimited_key_containing_separator(self):
+        """Delimited keys carry arbitrary characters, including separators.
+
+        Guards the `=` separator support against cutting inside a
+        ``STRING_DELIM``-wrapped key.
+        """
+        assert _parse_gemma4_args('<|"|>a=b<|"|>:v') == {"a=b": "v"}
+        assert _parse_gemma4_args('<|"|>a:b<|"|>:v') == {"a:b": "v"}
+
+    def test_quoted_key_containing_separator(self):
+        """A separator inside a quoted key must not split it."""
+        assert _parse_gemma4_args('"a:b":1') == {"a:b": "1"}
+        assert _parse_gemma4_args('"a=b":1') == {"a=b": "1"}
+
+    def test_closing_brace_inside_fallback_literal(self):
+        """A ``}`` inside a quoted literal must not close the object early."""
+        result = _parse_gemma4_args('opts:{"pattern":"a}b"}')
+        assert result == {"opts": {"pattern": "a}b"}}
+
+    def test_closing_bracket_inside_fallback_literal(self):
+        """A ``]`` inside a quoted literal must not close the array early."""
+        assert _parse_gemma4_args('xs:["a]b","c"]') == {"xs": ["a]b", "c"]}
+
     def test_json_object_with_nested_array(self):
         result = _parse_gemma4_args('opts:{"tags": ["a","b"], "n": 3}')
         assert result == {"opts": {"tags": ["a", "b"], "n": "3"}}
@@ -317,6 +358,11 @@ class TestParseGemma4Array:
     def test_quoted_element_keeps_string_type(self):
         """A quoted numeric stays a string; only bare tokens are coercible."""
         assert _parse_gemma4_array('"42"') == ["42"]
+
+    def test_python_escape_sequences_decoded(self):
+        """Python-spelled literals keep normal string semantics."""
+        assert _parse_gemma4_array(r"'a\nb'") == ["a\nb"]
+        assert _parse_gemma4_array(r'"a\u00e9b"') == ["a\u00e9b"]
 
     def test_mixed_delimited_and_json_elements(self):
         """The model can switch spellings inside one array."""

--- a/tests/tool_parsers/test_gemma4_tool_parser.py
+++ b/tests/tool_parsers/test_gemma4_tool_parser.py
@@ -196,6 +196,36 @@ class TestParseGemma4Args:
         result = _parse_gemma4_args('<|"|>name<|"|>:<|"|>Alice<|"|>,count:42')
         assert result == {"name": "Alice", "count": "42"}
 
+    def test_json_object_keys_and_values_unquoted(self):
+        """JSON-syntax objects must not keep quotes on keys or values.
+
+        Regression for issue #51284: the object branch recurses into the
+        key:value parser, which previously stored '"mode"' / '"fast"'.
+        """
+        result = _parse_gemma4_args('opts:{"mode": "fast"}')
+        assert result == {"opts": {"mode": "fast"}}
+
+    def test_json_quoted_value_unquoted(self):
+        result = _parse_gemma4_args('name:"ds_152a4bfd"')
+        assert result == {"name": "ds_152a4bfd"}
+
+    def test_json_object_with_nested_array(self):
+        result = _parse_gemma4_args('opts:{"tags": ["a","b"], "n": 3}')
+        assert result == {"opts": {"tags": ["a", "b"], "n": "3"}}
+
+    def test_single_quoted_value_unquoted(self):
+        result = _parse_gemma4_args("name:'ds_152a4bfd'")
+        assert result == {"name": "ds_152a4bfd"}
+
+    def test_quoted_value_containing_separator(self):
+        """A comma inside a quoted literal must not end the value."""
+        result = _parse_gemma4_args('a:"x,y",b:1')
+        assert result == {"a": "x,y", "b": "1"}
+
+    def test_quoted_value_keeps_string_type(self):
+        result = _parse_gemma4_args('depth:"7"')
+        assert result == {"depth": "7"}
+
     def test_unterminated_string(self):
         """Unterminated strings should take everything after the delimiter."""
         result = _parse_gemma4_args('key:<|"|>unterminated')
@@ -267,6 +297,38 @@ class TestParseGemma4Array:
     def test_stray_closing_bracket(self):
         result = _parse_gemma4_array("42,]trailing")
         assert result == ["42"]
+
+    def test_json_quoted_elements_unquoted(self):
+        """Gemma4 also emits container values as plain JSON/Python literals.
+
+        The quote characters are syntax, not content, so they must not reach
+        the tool as part of the value (issue #51284).
+        """
+        assert _parse_gemma4_array('"ds_152a4bfd"') == ["ds_152a4bfd"]
+        assert _parse_gemma4_array("'DUPE_RESULTS','EVASION_RESULTS'") == [
+            "DUPE_RESULTS",
+            "EVASION_RESULTS",
+        ]
+
+    def test_quoted_element_containing_separator(self):
+        """A separator inside a quoted literal must not split the element."""
+        assert _parse_gemma4_array('"a,b","c"') == ["a,b", "c"]
+
+    def test_quoted_element_keeps_string_type(self):
+        """A quoted numeric stays a string; only bare tokens are coercible."""
+        assert _parse_gemma4_array('"42"') == ["42"]
+
+    def test_mixed_delimited_and_json_elements(self):
+        """The model can switch spellings inside one array."""
+        assert _parse_gemma4_array('<|"|>a<|"|>,"b",\'c\'') == ["a", "b", "c"]
+
+    def test_bare_values_still_untouched(self):
+        """Unquoted scalars are left for the engine layer to coerce."""
+        assert _parse_gemma4_array("42,true,null") == ["42", "true", "null"]
+
+    def test_unterminated_quote_partial_withheld(self):
+        """A literal whose closing quote has not arrived is withheld."""
+        assert _parse_gemma4_array('"abc', partial=True) == []
 
     def test_trailing_dot_float_partial_withheld(self):
         """Array elements with trailing dot withheld in partial mode."""

--- a/vllm/parser/gemma4.py
+++ b/vllm/parser/gemma4.py
@@ -12,6 +12,7 @@ state machine::
 
 from __future__ import annotations
 
+import ast
 import functools
 import json
 from collections.abc import Sequence
@@ -41,6 +42,9 @@ TOOL_CALL_START = "<|tool_call>"
 TOOL_CALL_END = "<tool_call|>"
 STRING_DELIM = '<|"|>'
 _DELIM_LEN = len(STRING_DELIM)
+# Gemma4 usually writes ``key:value``, but a minority of emissions use
+# ``key=value`` (python-call style). Both must key the same argument.
+_KEY_SEPARATORS = (":", "=")
 
 logger = init_logger(__name__)
 
@@ -63,6 +67,36 @@ def _strip_partial_delim(value: str) -> str:
         if value.endswith(suffix):
             return value[: -len(suffix)]
     return value
+
+
+def _decode_literal(raw: str, quote: str) -> str:
+    """Decode a complete quoted literal, preserving escape sequences.
+
+    JSON decoding is tried first for double-quoted tokens; ``literal_eval``
+    covers the python-source spelling (and JSON escapes JSON itself rejects).
+    Falls back to dropping the outer quotes if neither decoder accepts it.
+    """
+    decoders = (json.loads, ast.literal_eval) if quote == '"' else (ast.literal_eval,)
+    for decode in decoders:
+        try:
+            decoded = decode(raw)
+        except (ValueError, SyntaxError, MemoryError, RecursionError):
+            continue
+        if isinstance(decoded, str):
+            return decoded
+    return raw[1:-1]
+
+
+def _skip_fallback_literal(src: str, i: int) -> int | None:
+    """Return the index just past a complete quoted literal at ``src[i]``.
+
+    Used by the nested-container scans so that a ``}`` or ``]`` *inside* a
+    fallback literal does not close the container early. ``None`` means no
+    complete literal starts here, and the caller should treat the character
+    as structural.
+    """
+    literal = _read_fallback_string(src, i)
+    return None if literal is None else literal[1]
 
 
 def _read_fallback_string(src: str, i: int) -> tuple[str, int] | None:
@@ -94,31 +128,9 @@ def _read_fallback_string(src: str, i: int) -> tuple[str, int] | None:
             j += 2
             continue
         if c == quote:
-            raw = src[i : j + 1]
-            if quote == '"':
-                try:
-                    decoded = json.loads(raw)
-                except ValueError:
-                    decoded = raw[1:-1]
-                if not isinstance(decoded, str):
-                    decoded = raw[1:-1]
-            else:
-                decoded = raw[1:-1].replace("\\'", "'").replace('\\"', '"')
-            return decoded, j + 1
+            return _decode_literal(src[i : j + 1], quote), j + 1
         j += 1
     return None
-
-
-def _unquote_fallback(raw: str) -> str:
-    """Strip one matching pair of JSON/Python quotes from an already-cut token.
-
-    Used for object keys, which are cut at ``:`` before this runs. Values go
-    through :func:`_read_fallback_string` instead.
-    """
-    literal = _read_fallback_string(raw, 0) if raw else None
-    if literal is not None and literal[1] == len(raw):
-        return literal[0]
-    return raw
 
 
 def _parse_gemma4_args(args_str: str, *, partial: bool = False) -> dict:
@@ -153,17 +165,32 @@ def _parse_gemma4_args(args_str: str, *, partial: bool = False) -> dict:
         if i >= n:
             break
 
-        key_start = i
-        while i < n and args_str[i] != ":":
-            i += 1
-        if i >= n:
-            break
-        key = args_str[key_start:i].strip()
-        if key.startswith(STRING_DELIM) and key.endswith(STRING_DELIM):
-            key = key[_DELIM_LEN:-_DELIM_LEN]
+        # Resolve a bounded key before looking for the separator, so that a
+        # separator *inside* the key cannot split it. Delimited keys exist
+        # precisely to carry arbitrary characters.
+        key = None
+        if args_str[i : i + _DELIM_LEN] == STRING_DELIM:
+            key_end = args_str.find(STRING_DELIM, i + _DELIM_LEN)
+            if key_end == -1:
+                break
+            key = args_str[i + _DELIM_LEN : key_end]
+            i = key_end + _DELIM_LEN
         else:
-            # Objects written in JSON syntax carry quoted keys.
-            key = _unquote_fallback(key)
+            key_literal = _read_fallback_string(args_str, i)
+            if key_literal is not None:
+                key, i = key_literal
+        if key is not None:
+            while i < n and args_str[i] in (" ", "\n", "\t"):
+                i += 1
+            if i >= n or args_str[i] not in _KEY_SEPARATORS:
+                break
+        else:
+            key_start = i
+            while i < n and args_str[i] not in _KEY_SEPARATORS:
+                i += 1
+            if i >= n:
+                break
+            key = args_str[key_start:i].strip()
         i += 1
 
         if i >= n:
@@ -203,6 +230,11 @@ def _parse_gemma4_args(args_str: str, *, partial: bool = False) -> dict:
                     next_delim = args_str.find(STRING_DELIM, i)
                     i = n if next_delim == -1 else next_delim + _DELIM_LEN
                     continue
+                if args_str[i] in ('"', "'"):
+                    after = _skip_fallback_literal(args_str, i)
+                    if after is not None:
+                        i = after
+                        continue
                 if args_str[i] == "{":
                     depth += 1
                 elif args_str[i] == "}":
@@ -225,6 +257,11 @@ def _parse_gemma4_args(args_str: str, *, partial: bool = False) -> dict:
                     next_delim = args_str.find(STRING_DELIM, i)
                     i = n if next_delim == -1 else next_delim + _DELIM_LEN
                     continue
+                if args_str[i] in ('"', "'"):
+                    after = _skip_fallback_literal(args_str, i)
+                    if after is not None:
+                        i = after
+                        continue
                 if args_str[i] == "[":
                     depth += 1
                 elif args_str[i] == "]":
@@ -295,6 +332,11 @@ def _parse_gemma4_array(arr_str: str, *, partial: bool = False) -> list:
                     nd = arr_str.find(STRING_DELIM, i)
                     i = nd + _DELIM_LEN if nd != -1 else n
                     continue
+                if arr_str[i] in ('"', "'"):
+                    after = _skip_fallback_literal(arr_str, i)
+                    if after is not None:
+                        i = after
+                        continue
                 if arr_str[i] == "{":
                     depth += 1
                 elif arr_str[i] == "}":
@@ -315,6 +357,11 @@ def _parse_gemma4_array(arr_str: str, *, partial: bool = False) -> list:
                     nd = arr_str.find(STRING_DELIM, i)
                     i = nd + _DELIM_LEN if nd != -1 else n
                     continue
+                if arr_str[i] in ('"', "'"):
+                    after = _skip_fallback_literal(arr_str, i)
+                    if after is not None:
+                        i = after
+                        continue
                 if arr_str[i] == "[":
                     depth += 1
                 elif arr_str[i] == "]":
@@ -444,7 +491,7 @@ def gemma4_config() -> ParserEngineConfig:
         },
         arg_converter=_gemma4_arg_converter,
         tool_args_json=False,
-        arg_structural_chars=frozenset(",:{}[]<"),
+        arg_structural_chars=frozenset(",:={}[]<"),
         preserve_tokens=frozenset({STRING_DELIM}),
     )
 

--- a/vllm/parser/gemma4.py
+++ b/vllm/parser/gemma4.py
@@ -65,6 +65,62 @@ def _strip_partial_delim(value: str) -> str:
     return value
 
 
+def _read_fallback_string(src: str, i: int) -> tuple[str, int] | None:
+    """Read a JSON/Python string literal starting at ``src[i]``, if any.
+
+    Gemma4 delimits strings with ``STRING_DELIM``, but for keys and values
+    *inside a container* the model regularly falls back to plain JSON or
+    Python source syntax instead::
+
+        data_refs:["ds_152a4bfd"]      data_refs:['ds_152a4bfd']
+        opts:{"mode": "fast"}
+
+    Those quotes are syntax, not content. Consuming the whole literal here --
+    rather than scanning to the next ``,`` and stripping afterwards -- also
+    keeps separator characters *inside* the literal from splitting the value.
+
+    Returns ``(value, index_after_literal)``, or ``None`` when no terminated
+    literal starts at ``i`` (including the streaming case where the closing
+    quote has not arrived yet), leaving the caller's bare-value scan in charge.
+    """
+    quote = src[i]
+    if quote not in ('"', "'"):
+        return None
+    n = len(src)
+    j = i + 1
+    while j < n:
+        c = src[j]
+        if c == "\\" and j + 1 < n:
+            j += 2
+            continue
+        if c == quote:
+            raw = src[i : j + 1]
+            if quote == '"':
+                try:
+                    decoded = json.loads(raw)
+                except ValueError:
+                    decoded = raw[1:-1]
+                if not isinstance(decoded, str):
+                    decoded = raw[1:-1]
+            else:
+                decoded = raw[1:-1].replace("\\'", "'").replace('\\"', '"')
+            return decoded, j + 1
+        j += 1
+    return None
+
+
+def _unquote_fallback(raw: str) -> str:
+    """Strip one matching pair of JSON/Python quotes from an already-cut token.
+
+    Used for object keys, which are cut at ``:`` before this runs. Values go
+    through :func:`_read_fallback_string` instead.
+    """
+    literal = _read_fallback_string(raw, 0) if raw else None
+    if literal is not None and literal[1] == len(raw):
+        return literal[0]
+    return raw
+
+
 def _parse_gemma4_args(args_str: str, *, partial: bool = False) -> dict:
     """Parse Gemma4's custom key:value format into a Python dict.
 
@@ -105,6 +161,9 @@ def _parse_gemma4_args(args_str: str, *, partial: bool = False) -> dict:
         key = args_str[key_start:i].strip()
         if key.startswith(STRING_DELIM) and key.endswith(STRING_DELIM):
             key = key[_DELIM_LEN:-_DELIM_LEN]
+        else:
+            # Objects written in JSON syntax carry quoted keys.
+            key = _unquote_fallback(key)
         i += 1
 
         if i >= n:
@@ -177,6 +236,11 @@ def _parse_gemma4_args(args_str: str, *, partial: bool = False) -> dict:
                 result[key] = _parse_gemma4_array(args_str[arr_start : i - 1])
 
         else:
+            literal = _read_fallback_string(args_str, i)
+            if literal is not None:
+                value, i = literal
+                result[key] = value
+                continue
             val_start = i
             while i < n and args_str[i] not in (",", "}", "]"):
                 i += 1
@@ -262,6 +326,11 @@ def _parse_gemma4_array(arr_str: str, *, partial: bool = False) -> list:
                 items.append(_parse_gemma4_array(arr_str[sub_start : i - 1]))
 
         else:
+            literal = _read_fallback_string(arr_str, i)
+            if literal is not None:
+                value, i = literal
+                items.append(value)
+                continue
             val_start = i
             while i < n and arr_str[i] not in (",", "]"):
                 i += 1


### PR DESCRIPTION
Fixes #51284

## Purpose

Gemma-4 delimits strings with `<|"|>`, but for keys and values **inside a container** it regularly falls back to plain JSON / Python source syntax instead:

```
data_refs:[<|"|>ds_152a4bfd<|"|>]     # what the grammar defines
data_refs:["ds_152a4bfd"]            # what the model also emits
data_refs:['ds_152a4bfd']
opts:{"mode": "fast"}
```

#51284 documents a second emission variant too: `=` rather than `:` as the key separator (`data_refs=["ds_a"]`). The key scan is `while args_str[i] != ":"`, so such a pair is swallowed into the following key's name, or — when no later `:` exists — dropped along with everything after it, silently.

`_parse_gemma4_array` only takes its `STRING_DELIM` branch when an element *starts with* `<|"|>`; otherwise it copies the raw text up to the next `,` / `]` verbatim, because that same branch also carries numbers, booleans and null. `_parse_gemma4_args` does the same for values, and its key scan strips only `STRING_DELIM`. So the quote characters are treated as content:

```json
{"data_refs": ["\"ds_152a4bfd\""],
 "return_vars": ["'DUPE_RESULTS'"],
 "opts": {"\"mode\"": "\"fast\""}}
```

The tool then receives a string one character longer at each end than the one the model meant, the lookup fails, and the model cannot see the difference — so it retries the identical call.

**Nothing downstream can repair this.** Type coercion happens above the parser in `ParserEngine._fix_arg_types`, which delegates to `coerce_to_schema_type`. For a declared-`string` property that function does `return value` (`vllm/tool_parsers/utils.py:731`) ahead of every branch that would parse. So the repair layer rescues every non-string type and structurally cannot rescue strings. Credit to @troymroberts for pinning that down in the issue.

## Fix

Read the literal where the value is bounded, instead of scanning to the separator and stripping afterwards.

`_read_fallback_string(src, i)` consumes a complete JSON/Python string literal at `src[i]` and returns `(value, index_after_literal)`, or `None` when no terminated literal starts there. Both bare-value branches try it before their existing scan.

Keys are resolved as bounded tokens before any separator scan — delimited, then quoted literal, then bare — so a separator inside a key cannot split it. `=` is accepted as an alternative key separator and added to `arg_structural_chars` so streaming re-converts at that boundary. The four nested-container depth scans skip complete fallback literals, so a `}` or `]` *inside* a literal no longer closes the container early; they previously skipped `STRING_DELIM` only. Literals decode via `json.loads` then `ast.literal_eval` (literals only, no execution), so escapes survive in both spellings.

Consequences of decoding at the boundary rather than post-stripping:

- A separator **inside** a literal no longer splits the value: `["a,b"]` parses as one element.
- Double-quoted literals go through `json.loads`, so escapes survive.
- An unterminated literal returns `None`, so streaming keeps its existing withhold-on-partial behaviour rather than emitting half a token.
- Quoted tokens stay strings: `depth:"7"` is `"7"`, not `7`. Only bare tokens remain coercible.
- An array may mix both spellings — `[<|"|>a<|"|>,"b",'c']` parses as `["a", "b", "c"]`.
- `<|"|>a:b<|"|>:v` now parses as `{"a:b": "v"}`; `main` mis-parses it today.

## Test Plan

20 tests added to the existing classes in `tests/tool_parsers/test_gemma4_tool_parser.py` — 18 regression, 2 neutrality guards:

```
pytest tests/parser/ tests/tool_parsers/          ->  4900 passed, 1 skipped, 34 xfailed
pytest <the two gemma4 suites>                    ->  131 passed
the 10 tests added in 66852601d9, vs main         ->   10 failed
the  8 tests added in 9ea8cfba, vs 66852601d9     ->    8 failed
```

The 2 guards (`test_bare_values_still_untouched`, `test_unterminated_quote_partial_withheld`) pass either way by design — they pin behaviour this change must *not* alter.

**Independent end-to-end verification by @troymroberts** (comment below), on a different checkpoint and hardware: `gemma-4-26B-A4B-it-qat-AWQ-INT4`, TP=2, 262K context, payloads captured at the wire via `/tokenize` + `/completions` with `skip_special_tokens: false` so the parser was out of the path.

```
stock main (8d9b52f7c2):  4/4 complete tool calls lose 3 of 4 arguments
these parser hunks:       4/4 fully recovered
```

Those captures also exercise the escape handling (a value with escaped interior double quotes plus a nested single-quoted clause), and 3.8 kB `code` arguments with 16–18 triple-quoted blocks survive intact.

`pre-commit run --files <changed>`: all hooks pass.

## Relationship to #47909

- **#47909** (`_parse_gemma4_value`) coerces *bare* scalars — `true`/`false`/`null`, then `int`/`float` — and returns anything else unchanged, so quoted tokens fall straight through it. The two fixes compose in the right order: this PR decodes the literal and returns a string; #47909 coerces what remains bare. Both touch the same two bare-value branches, so whichever lands second needs a small rebase — happy to do that if this one is second.
- **#48678** was closed by its author on 2026-08-07: across 12 raw captures an interior `<|"|>` never appeared (0/12), and the damage it targeted is the failure fixed here.

## Not a duplicate

Checked before writing any code:

- `gh pr list --state open --search "51284 in:body"` — no PR references the issue.
- Keyword sweeps over open PRs for `gemma4 parser quote`, `gemma4 tool parser array`, `gemma4 container quoted value` — the only hits in this file were #47909 and #48678 (the latter now closed). (Searching by issue number alone is not sufficient here: a PR opened *before* an issue cannot cite it, which is how #47909 relates to #47906.)
- Same sweeps over **merged** PRs: `_parse_gemma4_array` was last changed by #41991 (infinite loop / array boundaries) and #42128 (streaming float corruption); neither touches the quoted-container fallback.
- The four nearby issues are different symptoms and all closed: #39069 (string values truncated), #44715 (`STRING_DELIM` not stripped), #45449 (intermittently missing `function.name`), #42696 (streaming mode). #47906 is open and is the bare-value sibling handled by #47909.
- Verified the defect on `main` at `7b9f2dad89`, not only on the reporter's v0.26.0: `items.append(raw_val)` in `_parse_gemma4_array` and `result[key] = raw_val` in `_parse_gemma4_args` still store the token verbatim, and the key scan still strips only `STRING_DELIM`.

@troymroberts also ran their own search before filing and reached the same conclusion.

## Known tradeoff

The colon-in-key limitation noted in the first revision is fixed — keys are now resolved before the separator scan.

Remaining: skipping literals during the depth scans means two stray apostrophes inside an *unquoted* value within a container will skip the span between them. Bare values in this grammar are numbers, booleans and null, so this seemed acceptable, but it is a behaviour change on malformed input rather than a strict improvement. Happy to gate it more narrowly.

## AI assistance

AI assistance (Claude Code) was used to localize this and draft the change. I reviewed every line, and ran the tests, the reverted-parser comparison, and the lint hooks myself.

