### PR TITLE
[CI/Build][BugFix][The Rock] Apply upstream torchao fix for python 3.14 compatibility to torchao

### DIFF
--- a/.buildkite/test-amd.yaml
+++ b/.buildkite/test-amd.yaml
@@ -2419,7 +2419,8 @@ steps:
   # https://github.com/pytorch/ao/issues/2919, we'll have to skip new torchao tests for now
   # we can only upgrade after this is resolved
   # TODO(jerryzh168): resolve the above comment
-  - uv pip install --system torchao==0.18.0
+  - uv pip install --system torchao==0.17.0
+  - curl -sL https://github.com/pytorch/ao/commit/5e92da482ba8f2e3aa64d74fbfa7131c259b693d.patch | patch -d $(python3 -c "import site;print(site.getsitepackages()[0])") -p1
   - uv pip install --system conch-triton-kernels
   - VLLM_TEST_FORCE_LOAD_FORMAT=auto pytest -v -s quantization/ --ignore quantization/test_blackwell_moe.py
 
@@ -3628,7 +3629,8 @@ steps:
   - vllm/_aiter_ops.py
   - vllm/platforms/rocm.py
   commands:
-  - uv pip install --system torchao==0.18.0
+  - uv pip install --system torchao==0.17.0
+  - curl -sL https://github.com/pytorch/ao/commit/5e92da482ba8f2e3aa64d74fbfa7131c259b693d.patch | patch -d $(python3 -c "import site;print(site.getsitepackages()[0])") -p1
   - uv pip install --system conch-triton-kernels
   - VLLM_TEST_FORCE_LOAD_FORMAT=auto pytest -v -s quantization/ --ignore quantization/test_blackwell_moe.py
 

--- a/.buildkite/test-amd.yaml
+++ b/.buildkite/test-amd.yaml
@@ -2419,7 +2419,7 @@ steps:
   # https://github.com/pytorch/ao/issues/2919, we'll have to skip new torchao tests for now
   # we can only upgrade after this is resolved
   # TODO(jerryzh168): resolve the above comment
-  - uv pip install --system torchao==0.17.0
+  - uv pip install --system torchao==0.18.0
   - uv pip install --system conch-triton-kernels
   - VLLM_TEST_FORCE_LOAD_FORMAT=auto pytest -v -s quantization/ --ignore quantization/test_blackwell_moe.py
 
@@ -3628,7 +3628,7 @@ steps:
   - vllm/_aiter_ops.py
   - vllm/platforms/rocm.py
   commands:
-  - uv pip install --system torchao==0.17.0
+  - uv pip install --system torchao==0.18.0
   - uv pip install --system conch-triton-kernels
   - VLLM_TEST_FORCE_LOAD_FORMAT=auto pytest -v -s quantization/ --ignore quantization/test_blackwell_moe.py
 

--- a/tests/quantization/test_online.py
+++ b/tests/quantization/test_online.py
@@ -88,6 +88,9 @@ def test_online_quantization(
 
     if use_rocm_aiter:
         monkeypatch.setenv("VLLM_ROCM_USE_AITER", "1")
+        from vllm._aiter_ops import rocm_aiter_ops
+
+        rocm_aiter_ops.refresh_env_variables()
 
     if current_platform.is_xpu() and quant_scheme == "fp8_per_block":
         pytest.skip("Skip test for online fp8_per_block on XPU platform.")


### PR DESCRIPTION
<!-- markdownlint-disable -->
## Purpose
This PR applies an upstream fix to `torchao `in` test-amd.yaml` to for Python 3.14 compatibility.  The `0.17.`0 assigns to `__module__ `attribute of a `Union `object which is not allowed in Python 3.14.   This results in an error in the `mi300_1:Quantization` test group:

`ERROR quantization/test_quark.py - AttributeError: 'typing.Union' object has no attribute '__module__' and no __dict__ for setting new attributes. Did you mean: '__reduce__'?`

The `0.18.0` version fixes this issue, but it is not backwards compatible.  I tried applying:  `https://github.com/pytorch/ao/commit/5e92da482ba8f2e3aa64d74fbfa7131c259b693d.patch`
which also fixes the issue.

## Test Plan
`VLLM_TEST_FORCE_LOAD_FORMAT=auto pytest -v -s quantization/ --ignore quantization/test_blackwell_moe.py`
## Test Result
== 4 passed, 2 skipped, 154 warnings in 1067.05s (0:17:47) ===

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ X] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ X] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://docs.vllm.ai/en/latest/contributing>** (anything written below this line will be removed by GitHub Actions)
