### PR TITLE
[Attention] Allow num_splits > 1 on FA2 for speculative decode

### DIFF
--- a/vllm/vllm_flash_attn/flash_attn_interface.py
+++ b/vllm/vllm_flash_attn/flash_attn_interface.py
@@ -308,8 +308,6 @@ def flash_attn_varlen_func(
             )
         if s_aux is not None:
             raise NotImplementedError("FA2 does not support s_aux")
-        if num_splits > 1:
-            raise NotImplementedError("FA2 does not support num_splits > 1")
         if mask_mod is not None:
             raise NotImplementedError("FA2 does not support mask_mod")
         if aux_tensors is not None:


### PR DESCRIPTION
> **DRAFT — blocked on [vllm-project/flash-attention#176](https://github.com/vllm-project/flash-attention/pull/176).**
> Do not merge until that lands **and** `GIT_TAG` in `cmake/external_projects/vllm_flash_attn.cmake` is bumped past it. Merging earlier replaces a clean `NotImplementedError` with a `RuntimeError` raised from the unpatched `.so` — strictly worse for users.

## What this removes

```python
if num_splits > 1:
    raise NotImplementedError("FA2 does not support num_splits > 1")
```

Two lines, `vllm/vllm_flash_attn/flash_attn_interface.py`.

## Why it exists, and why it can go

It mirrors the C++ `TORCH_CHECK(num_splits <= 1, "not supported for varlen paged KV")`. That check is real: the FA2 combine kernel addressed O and LSE through `o_batch_stride`, which is **0** in a true varlen call, so it folded every sequence onto sequence 0. Correct at batch 1, silently wrong above it.

flash-attention#176 addresses O and LSE through `cu_seqlens_q` and skips rows past `actual_seqlen_q`, so the restriction no longer holds.

## Why this matters

`set_params_splitkv` is gated on `seqlenq_ngroups_swapped`, which requires `max_seqlen_q == 1`. Speculative decoding makes the verify pass carry `q_len = K+1`, so **split-K is silently disabled for every spec-decode step** — MTP, EAGLE, Medusa, draft-model and n-gram alike. The decode-attention grid collapses from 172 to 12 blocks: 12 of 128 SMs get work, ~3.5% of DRAM peak.

Measured end to end on RTX 4090 sm_89, Qwen3.6-27B-AWQ-INT4, TP2, MTP K=5, batch 1, ISL 16384, bf16 KV, clocks locked:

| arm | tok/s | TPOT ms | accept_len | step ms |
|---|---|---|---|---|
| base (x3) | 70.0 | 14.28 | 3.11 | 44.42 |
| patched (x2) | **108.9** | **9.19** | **3.20** | **29.41** |

**+55.4% tok/s, −35.6% TPOT**, noise ±0.07%, TTFT flat. Acceptance length rises slightly because split-K lands closer to an fp64 oracle. Full correctness matrix (96 cases incl. batch > 1 and non-uniform query lengths, red-before-green against unpatched vs patched `.so`) is in flash-attention#176.

## Not a duplicate

No open PR in this repo touches this guard; searched for `num_splits`/spec-decode/flash-attention combinations.

## AI assistance

**AI assistance (Claude) was used for this change.** The change and all measurements above were produced with AI assistance and reviewed by the human submitter.