### PR TITLE
[3/N] Share HiSparse host cache across TP ranks

### DIFF
--- a/docs/design/hisparse.md
+++ b/docs/design/hisparse.md
@@ -51,6 +51,12 @@ sees only device pools.
 The source group has `block_pool_id=None`; device-pool consumers must narrow it
 before indexing, so host ownership cannot masquerade as a numeric GPU pool.
 
+For single-node MP tensor parallelism, every TP worker maps the same pinned host
+pool and uses the same block and layer offsets. MLA source KV is replicated
+across TP ranks, so this stores one physical copy instead of one copy per rank.
+Each rank still submits its own identical DMA to preserve its local CUDA stream
+ordering. Other executor and parallel layouts retain private per-rank pools.
+
 ## Code boundary
 
 ```text

--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -70,6 +70,19 @@ from vllm.v1.request import Request
 pytestmark = pytest.mark.cpu_test
 
 
+def _private_hisparse_parallel_config():
+    return SimpleNamespace(
+        tensor_parallel_size=1,
+        pipeline_parallel_size=1,
+        prefill_context_parallel_size=1,
+        decode_context_parallel_size=1,
+        world_size=1,
+        distributed_executor_backend="uni",
+        nnodes_within_dp=1,
+        data_parallel_index=0,
+    )
+
+
 def test_hisparse_memory_usage_keeps_indexer_source_on_host():
     class FixedMemorySpec:
         def __init__(self, size: int):
@@ -131,6 +144,7 @@ def test_hisparse_hma_uses_backend_gpu_block_size(
         ),
         model_config=SimpleNamespace(hf_config=SimpleNamespace(index_topk=128)),
         cache_config=SimpleNamespace(num_gpu_blocks_override=7),
+        parallel_config=_private_hisparse_parallel_config(),
     )
 
     cache_config = kv_cache_utils._get_hisparse_hma_config(
@@ -204,6 +218,7 @@ def test_hisparse_hma_rejects_mixed_hot_page_sizes():
         ),
         model_config=SimpleNamespace(hf_config=SimpleNamespace(index_topk=128)),
         cache_config=SimpleNamespace(num_gpu_blocks_override=7),
+        parallel_config=_private_hisparse_parallel_config(),
     )
 
     with pytest.raises(ValueError, match="require one page size"):
@@ -280,6 +295,7 @@ def test_hisparse_hma_offloads_only_deepseek_v4_c4_layers():
         ),
         model_config=SimpleNamespace(hf_config=SimpleNamespace(index_topk=512)),
         cache_config=SimpleNamespace(num_gpu_blocks_override=7),
+        parallel_config=_private_hisparse_parallel_config(),
     )
 
     cache_config = kv_cache_utils._get_hisparse_hma_config(

--- a/tests/v1/kv_offload/cpu/test_shared_offload_region.py
+++ b/tests/v1/kv_offload/cpu/test_shared_offload_region.py
@@ -607,6 +607,22 @@ def test_multi_worker_race_shared_memory_visible(iid):
         _cleanup_file(regions[0].mmap_path)
 
 
+def test_replicated_workers_share_the_same_slot(iid):
+    creator = _make_region(iid, rank=0)
+    joiner = _make_region(iid, rank=0)
+    creator_view = creator.create_next_view(PAGE_SIZE)
+    joiner_view = joiner.create_next_view(PAGE_SIZE)
+    try:
+        creator_view[2].fill_(37)
+
+        assert joiner_view[2].tolist() == [37] * PAGE_SIZE
+    finally:
+        del creator_view, joiner_view
+        joiner.cleanup()
+        creator.cleanup()
+        _cleanup_file(creator.mmap_path)
+
+
 def test_multiprocess_race_construct_and_write(iid):
     """N processes race to construct the same SharedOffloadRegion, each writes
     fill_value = rank+1 into their slot; parent verifies interleaved layout."""

--- a/tests/v1/worker/test_attn_utils.py
+++ b/tests/v1/worker/test_attn_utils.py
@@ -36,6 +36,45 @@ class FakeHNDFlashAttentionBackend(FakeFlashAttentionBackend):
         return (0, 1, 3, 2, 4)
 
 
+def test_reshape_kv_cache_preserves_shared_host_row_stride():
+    num_blocks = 3
+    spec = FullAttentionSpec(
+        block_size=2,
+        num_kv_heads=1,
+        head_size=2,
+        dtype=torch.float32,
+    )
+    row_stride = spec.page_size_bytes + 32
+    backing = torch.zeros(num_blocks * row_stride, dtype=torch.int8)
+    raw_tensors = {
+        "layer": torch.as_strided(
+            backing,
+            size=(num_blocks, spec.page_size_bytes),
+            stride=(row_stride, 1),
+        )
+    }
+    attn_groups = [
+        AttentionGroup(
+            backend=FakeFlashAttentionBackend,
+            layer_names=["layer"],
+            kv_cache_spec=spec,
+            kv_cache_group_id=0,
+        )
+    ]
+
+    kv_cache = _reshape_kv_cache(
+        attn_groups,
+        raw_tensors,
+        "auto",
+        [spec.block_size],
+        {},
+    )["layer"]
+
+    assert kv_cache.shape == (num_blocks, 2, 2, 1, 2)
+    assert kv_cache.stride(0) == row_stride // spec.dtype.itemsize
+    assert kv_cache[1].storage_offset() == row_stride // spec.dtype.itemsize
+
+
 def test_reshape_padded_flash_attention_kv_cache_strides_by_page():
     num_blocks = 3
     spec = FullAttentionSpec(

--- a/tests/v1/worker/test_utils.py
+++ b/tests/v1/worker/test_utils.py
@@ -22,6 +22,104 @@ from vllm.v1.metrics.stats import HiSparseStats
 from vllm.v1.worker.utils import bind_kv_cache, copy_kv_cache_blocks_inplace
 
 
+def _hisparse_parallel_config(**overrides):
+    values = {
+        "tensor_parallel_size": 2,
+        "pipeline_parallel_size": 1,
+        "prefill_context_parallel_size": 1,
+        "decode_context_parallel_size": 1,
+        "world_size": 2,
+        "distributed_executor_backend": "mp",
+        "nnodes_within_dp": 1,
+        "data_parallel_index": 3,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def test_hisparse_shares_host_pool_only_for_local_tp(monkeypatch):
+    monkeypatch.setattr(
+        hisparse_runtime_module.current_platform, "is_cuda_alike", lambda: True
+    )
+    config = SimpleNamespace(parallel_config=_hisparse_parallel_config())
+
+    assert hisparse_runtime_module.use_shared_hisparse_host_pool(config)
+
+    unsupported = (
+        {"tensor_parallel_size": 1, "world_size": 1},
+        {"pipeline_parallel_size": 2, "world_size": 4},
+        {"prefill_context_parallel_size": 2, "world_size": 4},
+        {"decode_context_parallel_size": 2},
+        {"world_size": 4},
+        {"distributed_executor_backend": "ray"},
+        {"nnodes_within_dp": 2},
+    )
+    for overrides in unsupported:
+        config.parallel_config = _hisparse_parallel_config(**overrides)
+        assert not hisparse_runtime_module.use_shared_hisparse_host_pool(config)
+
+
+def test_hisparse_shared_host_pool_uses_one_replicated_mmap(monkeypatch):
+    class FakeSharedOffloadRegion:
+        BLOCK_SIZE_ALIGNMENT = 4096
+
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+            self.total_size_bytes = kwargs["num_blocks"] * kwargs["kv_bytes_per_block"]
+            self.base_tensor = torch.empty(self.total_size_bytes, dtype=torch.int8)
+            self.is_pinned = False
+            self.view_sizes = []
+            self.offset = 0
+
+        def create_next_view(self, size):
+            self.view_sizes.append(size)
+            view = torch.as_strided(
+                self.base_tensor,
+                size=(self.kwargs["num_blocks"], size),
+                stride=(self.kwargs["kv_bytes_per_block"], 1),
+                storage_offset=self.offset,
+            )
+            self.offset += size
+            return view
+
+        def cleanup(self):
+            pass
+
+    monkeypatch.setattr(
+        hisparse_runtime_module.current_platform, "is_cuda_alike", lambda: True
+    )
+    monkeypatch.setattr(
+        hisparse_runtime_module, "SharedOffloadRegion", FakeSharedOffloadRegion
+    )
+    pinned: list[torch.Tensor] = []
+    monkeypatch.setattr(hisparse_runtime_module, "pin_tensor", pinned.append)
+    config = SimpleNamespace(
+        instance_id="instance",
+        parallel_config=_hisparse_parallel_config(),
+    )
+
+    pools, region = hisparse_runtime_module.allocate_hisparse_host_pools(
+        config, [24, 40], num_blocks=4
+    )
+
+    assert region is not None
+    assert region.kwargs == {
+        "engine_id": "hisparse_instance_dp3",
+        "num_blocks": 4,
+        "rank": 0,
+        "kv_bytes_per_block": 4096,
+        "cpu_page_size": 16,
+    }
+    assert region.view_sizes == [6, 10]
+    assert [pool.shape for pool in pools] == [(4, 6), (4, 10)]
+    assert pinned == [region.base_tensor]
+    assert region.is_pinned
+    assert hisparse_runtime_module._covers_registered_host_range(
+        pools[1].data_ptr(), pools[1].nbytes
+    )
+    hisparse_runtime_module._SHARED_HOST_REGIONS.remove(region)
+
+
 def test_copy_cpu_kv_cache_logical_blocks_ignores_storage_padding(monkeypatch):
     waited_for_host_writes = False
 
@@ -326,11 +424,13 @@ def test_hisparse_worker_reports_each_completed_transfer_once():
 def test_hisparse_worker_shutdown_releases_pinned_state(monkeypatch):
     worker = object.__new__(HiSparseWorker)
     worker.cache_handles = []
+    worker.shared_host_region = object()
     released = False
 
-    def release_pinned_state(runtimes):
+    def release_pinned_state(runtimes, shared_host_region):
         nonlocal released
         assert runtimes == []
+        assert shared_host_region is worker.shared_host_region
         released = True
 
     monkeypatch.setattr(

--- a/vllm/config/attention.py
+++ b/vllm/config/attention.py
@@ -19,7 +19,10 @@ class HiSparseConfig:
     """Configuration for HiSparse sparse-MLA decode."""
 
     host_pool_gib: float = Field(gt=0)
-    """Per-rank pinned host pool size in GiB."""
+    """Pinned host pool size in GiB.
+
+    Single-node tensor-parallel workers share one physical pool when supported.
+    """
 
     device_buffer_size: int | None = Field(default=None, gt=0)
     """Total per-request GPU hot-buffer rows, including the newest-token slot.

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -39,7 +39,10 @@ from vllm.v1.kv_cache_interface import (
     UniformTypeKVCacheSpecs,
 )
 from vllm.v1.kv_cache_spec_registry import KVCacheSpecRegistry
-from vllm.v1.kv_offload.sparse.hisparse_runtime import ResolvedHiSparseConfig
+from vllm.v1.kv_offload.sparse.hisparse_runtime import (
+    ResolvedHiSparseConfig,
+    get_hisparse_host_block_stride,
+)
 from vllm.v1.request import Request
 from vllm.v1.utils import tensor_data
 
@@ -1358,7 +1361,7 @@ def _get_kv_cache_config_packed(
 
 
 def _hisparse_host_pool_bytes(vllm_config: VllmConfig) -> int | None:
-    """Return the HiSparse per-rank pinned host budget."""
+    """Return the HiSparse pinned host budget."""
     config = vllm_config.attention_config.hisparse_config
     if config is None:
         return None
@@ -1616,7 +1619,8 @@ def _get_hisparse_hma_config(
     )
     gpu_stride = round_up(gpu_stride, hot_page_alignment)
     host_page = sum(spec.page_size_bytes for spec in source_specs.values())
-    host_num_blocks = host_budget // host_page
+    host_block_stride = get_hisparse_host_block_stride(vllm_config, host_page)
+    host_num_blocks = host_budget // host_block_stride
     gpu_num_blocks = available_memory // gpu_stride
     override = vllm_config.cache_config.num_gpu_blocks_override
     if override is not None:

--- a/vllm/v1/kv_offload/cpu/shared_offload_region.py
+++ b/vllm/v1/kv_offload/cpu/shared_offload_region.py
@@ -169,6 +169,12 @@ class SharedOffloadRegion:
         self._views: list[torch.Tensor] = []
         self.is_pinned: bool = False
 
+    @property
+    def base_tensor(self) -> torch.Tensor:
+        if self._base is None:
+            raise RuntimeError("Shared offload region has been released.")
+        return self._base
+
     def create_next_view(self, tensor_page_size: int) -> torch.Tensor:
         """Allocate a strided int8 view for this worker, one canonical tensor.
 

--- a/vllm/v1/kv_offload/sparse/hisparse_runtime.py
+++ b/vllm/v1/kv_offload/sparse/hisparse_runtime.py
@@ -22,6 +22,7 @@ from vllm.utils.math_utils import round_up
 from vllm.v1.attention.backends.mla.sparse_utils import (
     triton_convert_req_index_to_global_index,
 )
+from vllm.v1.kv_offload.cpu.shared_offload_region import SharedOffloadRegion
 from vllm.v1.simple_kv_offload.cuda_mem_ops import pin_tensor
 
 logger = init_logger(__name__)
@@ -180,12 +181,12 @@ class ResolvedHiSparseConfig:
         )
 
 
-def check_hisparse_host_memory(rank_bytes: int) -> None:
-    """Fail fast when this rank's pinned host pool cannot fit in RAM."""
+def check_hisparse_host_memory(pool_bytes: int) -> None:
+    """Fail fast when the pinned host pool cannot fit in RAM."""
     mem = psutil.virtual_memory()
-    if rank_bytes > mem.available * 0.95:
+    if pool_bytes > mem.available * 0.95:
         raise ValueError(
-            f"HiSparse pinned host pool needs ~{rank_bytes / 2**30:.0f} GiB "
+            f"HiSparse pinned host pool needs ~{pool_bytes / 2**30:.0f} GiB "
             f"but only {mem.available / 2**30:.0f} GiB of RAM is available. "
             "Lower hisparse_config.host_pool_gib or leave headroom for co-tenants."
         )
@@ -201,6 +202,69 @@ def allocate_pinned_host_pool(size: int) -> torch.Tensor:
     pin_tensor(registered)
     _PINNED_HOST_POOLS.append(registered)
     return registered[:size]
+
+
+def use_shared_hisparse_host_pool(vllm_config: VllmConfig) -> bool:
+    """Whether replicated MLA host KV can share one local mmap."""
+    parallel = vllm_config.parallel_config
+    return (
+        current_platform.is_cuda_alike()
+        and parallel.tensor_parallel_size > 1
+        and parallel.pipeline_parallel_size == 1
+        and parallel.prefill_context_parallel_size == 1
+        and parallel.decode_context_parallel_size == 1
+        and parallel.world_size == parallel.tensor_parallel_size
+        and parallel.distributed_executor_backend == "mp"
+        and parallel.nnodes_within_dp == 1
+    )
+
+
+def get_hisparse_host_block_stride(
+    vllm_config: VllmConfig, page_size_bytes: int
+) -> int:
+    if use_shared_hisparse_host_pool(vllm_config):
+        return round_up(page_size_bytes, SharedOffloadRegion.BLOCK_SIZE_ALIGNMENT)
+    return page_size_bytes
+
+
+def allocate_hisparse_host_pools(
+    vllm_config: VllmConfig,
+    tensor_sizes: list[int],
+    num_blocks: int,
+) -> tuple[list[torch.Tensor], SharedOffloadRegion | None]:
+    """Allocate private host tensors or one mmap shared by local TP ranks."""
+    if not use_shared_hisparse_host_pool(vllm_config):
+        check_hisparse_host_memory(sum(tensor_sizes))
+        return [allocate_pinned_host_pool(size) for size in tensor_sizes], None
+
+    page_sizes = []
+    for size in tensor_sizes:
+        if size % num_blocks:
+            raise ValueError(
+                f"HiSparse host tensor size {size} is not divisible by "
+                f"{num_blocks} blocks."
+            )
+        page_sizes.append(size // num_blocks)
+    page_size = sum(page_sizes)
+    region = SharedOffloadRegion(
+        engine_id=(
+            f"hisparse_{vllm_config.instance_id}_"
+            f"dp{vllm_config.parallel_config.data_parallel_index}"
+        ),
+        num_blocks=num_blocks,
+        rank=0,
+        kv_bytes_per_block=get_hisparse_host_block_stride(vllm_config, page_size),
+        cpu_page_size=page_size,
+    )
+    try:
+        pin_tensor(region.base_tensor)
+        region.is_pinned = True
+        pools = [region.create_next_view(page_size) for page_size in page_sizes]
+    except Exception:
+        region.cleanup()
+        raise
+    _SHARED_HOST_REGIONS.append(region)
+    return pools, region
 
 
 def register_indexer_source(
@@ -219,15 +283,28 @@ def _covers_registered_host_range(ptr: int, nbytes: int) -> bool:
     return any(
         pool.data_ptr() <= ptr and ptr + nbytes <= pool.data_ptr() + pool.nbytes
         for pool in _PINNED_HOST_POOLS
+    ) or any(
+        region.is_pinned
+        and region.base_tensor.data_ptr() <= ptr
+        and ptr + nbytes <= region.base_tensor.data_ptr() + region.total_size_bytes
+        for region in _SHARED_HOST_REGIONS
     )
 
 
-def release_pinned_state(runtimes: list[HiSparseRuntime]) -> None:
+def release_pinned_state(
+    runtimes: list[HiSparseRuntime],
+    shared_host_region: SharedOffloadRegion | None = None,
+) -> None:
     """Synchronize, unregister host KV pools, and drop global state."""
     global _CURRENT_INDEX_GROUP
 
     _CURRENT_INDEX_GROUP = None
-    if _PINNED_HOST_POOLS:
+    shared_regions = (
+        [shared_host_region]
+        if shared_host_region is not None
+        else list(_SHARED_HOST_REGIONS)
+    )
+    if _PINNED_HOST_POOLS or shared_regions:
         try:
             torch.accelerator.synchronize()
         except RuntimeError as e:
@@ -235,7 +312,7 @@ def release_pinned_state(runtimes: list[HiSparseRuntime]) -> None:
                 "HiSparse: CUDA context unusable at teardown (%s); leaving "
                 "%d host-pool tensors pinned for kernel exit reclaim.",
                 e,
-                len(_PINNED_HOST_POOLS),
+                len(_PINNED_HOST_POOLS) + len(shared_regions),
             )
             return
 
@@ -265,12 +342,16 @@ def release_pinned_state(runtimes: list[HiSparseRuntime]) -> None:
 
     for runtime in runtimes:
         runtime._host_cache = None
+    _INDEXER_SOURCES.clear()
+    for region in shared_regions:
+        if region in _SHARED_HOST_REGIONS:
+            _SHARED_HOST_REGIONS.remove(region)
+        region.cleanup()
     _get_group_plan.cache_clear()
     _get_copy_stream.cache_clear()
     _HOST_WRITE_EVENTS.clear()
     with suppress(RuntimeError):
         torch._C._host_emptyCache()
-    _INDEXER_SOURCES.clear()
 
 
 def wait_for_hisparse_host_writes() -> None:
@@ -360,6 +441,7 @@ class _GroupPlan:
 
 
 _PINNED_HOST_POOLS: list[torch.Tensor] = []
+_SHARED_HOST_REGIONS: list[SharedOffloadRegion] = []
 _INDEXER_SOURCES: dict[str, tuple[torch.Tensor, torch.Tensor]] = {}
 _HOST_WRITE_EVENTS: dict[str, torch.Event] = {}
 _CURRENT_INDEX_GROUP: tuple[object, HiSparseRuntime | None] | None = None

--- a/vllm/v1/kv_offload/sparse/hisparse_worker.py
+++ b/vllm/v1/kv_offload/sparse/hisparse_worker.py
@@ -38,6 +38,7 @@ from vllm.v1.metrics.stats import HiSparseStats
 
 if TYPE_CHECKING:
     from vllm.v1.core.sched.output import SchedulerOutput
+    from vllm.v1.kv_offload.cpu.shared_offload_region import SharedOffloadRegion
     from vllm.v1.worker.gpu.block_table import BlockTables
 
 
@@ -76,8 +77,10 @@ class HiSparseWorker:
         max_concurrent_batches: int,
         blocks_per_kv_block: int,
         device: torch.device,
+        shared_host_region: SharedOffloadRegion | None = None,
     ) -> None:
         self.cache_pairs = cache_pairs
+        self.shared_host_region = shared_host_region
         kernel_block_size = cache_pairs[0][0].shape[1]
         self.kernel_block_size = kernel_block_size
         self.blocks_per_kv_block = blocks_per_kv_block
@@ -364,7 +367,10 @@ class HiSparseWorker:
         return completed or None
 
     def shutdown(self) -> None:
-        release_pinned_state([cache.runtime for cache in self.cache_handles])
+        release_pinned_state(
+            [cache.runtime for cache in self.cache_handles],
+            self.shared_host_region,
+        )
 
     def restore_prefix(self, scheduler_output: SchedulerOutput) -> None:
         src = self.src_cpu.numpy()
@@ -430,6 +436,7 @@ def init_hisparse_worker(
     max_model_len: int,
     max_concurrent_batches: int,
     device: torch.device,
+    shared_host_region: SharedOffloadRegion | None,
 ) -> HiSparseWorker:
     tensor_configs = {
         name: tensor_config
@@ -462,15 +469,24 @@ def init_hisparse_worker(
         source_block_size = source_spec.storage_block_size
         assert source_block_size % kernel_block_size == 0
         blocks_per_kv_block = source_block_size // kernel_block_size
+        raw_tensor = raw_tensors[cache_name]
+        source_block_stride = source_spec.page_size_bytes
+        if raw_tensor.ndim == 2:
+            if blocks_per_kv_block != 1:
+                raise ValueError(
+                    "Shared HiSparse host pools require one kernel page per "
+                    "scheduler block."
+                )
+            source_block_stride = raw_tensor.stride(0) * raw_tensor.element_size()
         source_cache = torch.as_strided(
-            raw_tensors[cache_name].view(source_spec.dtype),
+            raw_tensor.view(source_spec.dtype),
             size=(
                 host_num_blocks * blocks_per_kv_block,
                 kernel_block_size,
                 source_spec.head_size,
             ),
             stride=(
-                source_spec.page_size_bytes // source_spec.dtype.itemsize,
+                source_block_stride // source_spec.dtype.itemsize,
                 source_spec.head_size,
                 1,
             ),
@@ -557,4 +573,5 @@ def init_hisparse_worker(
         max_concurrent_batches,
         block_size // indexer_block_size,
         device,
+        shared_host_region,
     )

--- a/vllm/v1/worker/gpu/attn_utils.py
+++ b/vllm/v1/worker/gpu/attn_utils.py
@@ -32,8 +32,7 @@ from vllm.v1.kv_cache_interface import (
     UniformTypeKVCacheSpecs,
 )
 from vllm.v1.kv_offload.sparse.hisparse_runtime import (
-    allocate_pinned_host_pool,
-    check_hisparse_host_memory,
+    allocate_hisparse_host_pools,
 )
 from vllm.v1.kv_offload.sparse.hisparse_worker import (
     HiSparseWorker,
@@ -48,6 +47,7 @@ from vllm.v1.worker.utils import (
 )
 
 if TYPE_CHECKING:
+    from vllm.v1.kv_offload.cpu.shared_offload_region import SharedOffloadRegion
     from vllm.v1.worker.gpu.block_table import BlockTables
 
 logger = init_logger(__name__)
@@ -209,20 +209,28 @@ def _allocate_kv_cache(
     kv_cache_config: KVCacheConfig,
     shared_layers: dict[str, str],
     device: torch.device,
-):
-    host_bytes = sum(
-        tensor.size
-        for tensor in kv_cache_config.kv_cache_tensors
-        if tensor.host_resident
-    )
-    if host_bytes:
-        check_hisparse_host_memory(host_bytes)
+    vllm_config: VllmConfig,
+) -> tuple[dict[str, torch.Tensor], "SharedOffloadRegion | None"]:
+    host_tensor_configs = [
+        tensor for tensor in kv_cache_config.kv_cache_tensors if tensor.host_resident
+    ]
+    shared_host_region = None
+    host_tensors: list[torch.Tensor] = []
+    if host_tensor_configs:
+        host_num_blocks = kv_cache_config.hisparse_host_num_blocks
+        assert host_num_blocks is not None
+        host_tensors, shared_host_region = allocate_hisparse_host_pools(
+            vllm_config,
+            [tensor.size for tensor in host_tensor_configs],
+            host_num_blocks,
+        )
+    host_tensor_iter = iter(host_tensors)
 
     kv_cache_raw_tensors: dict[str, torch.Tensor] = {}
     packed_backings: dict[int, torch.Tensor] = {}
     for kv_cache_tensor in kv_cache_config.kv_cache_tensors:
         if kv_cache_tensor.host_resident:
-            tensor = allocate_pinned_host_pool(kv_cache_tensor.size)
+            tensor = next(host_tensor_iter)
         elif kv_cache_tensor.block_stride > 0:
             assert kv_cache_tensor.block_pool_id is not None
             # Allocate once; all packed tensors alias the same backing.
@@ -245,7 +253,7 @@ def _allocate_kv_cache(
     assert layer_names == (kv_cache_raw_tensors.keys() | shared_layers.keys()), (
         "Some layers are not correctly initialized"
     )
-    return kv_cache_raw_tensors
+    return kv_cache_raw_tensors, shared_host_region
 
 
 def _reshape_attention_kv_cache(
@@ -503,8 +511,8 @@ def init_kv_cache(
     block_tables: "BlockTables",
 ) -> tuple[dict[str, Any], "HiSparseWorker | None"]:
     shared_kv_cache_layers = get_shared_kv_cache_layers(vllm_config)
-    kv_cache_raw_tensors = _allocate_kv_cache(
-        kv_cache_config, shared_kv_cache_layers, device
+    kv_cache_raw_tensors, shared_host_region = _allocate_kv_cache(
+        kv_cache_config, shared_kv_cache_layers, device, vllm_config
     )
     flattened_attn_groups = list(group for groups in attn_groups for group in groups)
     kv_caches = _reshape_kv_cache(
@@ -527,6 +535,7 @@ def init_kv_cache(
             max_model_len=vllm_config.model_config.max_model_len,
             max_concurrent_batches=vllm_config.max_concurrent_batches,
             device=device,
+            shared_host_region=shared_host_region,
         )
     # Dual-attention models (e.g. LongCat-Flash) put two Attention modules per
     # decoder layer, so a layer name carries two integers (layer + module index).


### PR DESCRIPTION
## Summary

Map replicated MLA host KV into one pinned shared-memory region for eligible single-node MP tensor-parallel workers. This removes TP-fold host RAM duplication while preserving each rank's DMA submission and CUDA stream ordering.

## Stack

Stacked on #51335, which is stacked on #51323.

## Duplicate check

This integrates HiSparse with the general shared offload substrate from #48414; it does not duplicate that layout work.

## Tests

- 141 CPU and multiprocess tests passed
- 32 CUDA offload tests passed
- Pre-commit hooks passed

No model evaluation was required because the stored bytes and attention results are unchanged.

AI assistance was used for implementation and review.
