### PR TITLE
[Perf] Vectorize causal conv1d metadata indices

### DIFF
--- a/tests/v1/attention/test_gdn_metadata_builder.py
+++ b/tests/v1/attention/test_gdn_metadata_builder.py
@@ -21,10 +21,32 @@ from vllm.v1.attention.backends.gdn_attn import (
     GDNAttentionMetadata,
     GDNAttentionMetadataBuilder,
 )
+from vllm.v1.attention.backends.utils import compute_causal_conv1d_metadata
 from vllm.v1.kv_cache_interface import MambaSpec
 
 BLOCK_SIZE = 16
 DEVICE = torch.device("cpu")
+
+
+@pytest.mark.parametrize(
+    "query_start_loc, expected_batch, expected_offset",
+    [
+        ([0, 1, 9, 26], [0, 1, 2, 2, 2], [0, 0, 0, 1, 2]),
+        ([0, 0, 8, 24], [1, 2, 2], [0, 0, 1]),
+    ],
+)
+def test_causal_conv1d_metadata_indices(
+    query_start_loc: list[int],
+    expected_batch: list[int],
+    expected_offset: list[int],
+):
+    """Vectorized program indices preserve the per-sequence ordering."""
+    metadata, _, _ = compute_causal_conv1d_metadata(
+        torch.tensor(query_start_loc, dtype=torch.int32), device=DEVICE
+    )
+
+    assert metadata[8]["mlist"].tolist() == expected_batch
+    assert metadata[8]["offsetlist"].tolist() == expected_offset
 
 
 @dataclass

--- a/vllm/v1/attention/backends/utils.py
+++ b/vllm/v1/attention/backends/utils.py
@@ -17,7 +17,7 @@ from typing_extensions import runtime_checkable
 
 from vllm.config import VllmConfig, get_layers_from_vllm_config
 from vllm.utils.math_utils import cdiv
-from vllm.utils.torch_utils import PIN_MEMORY, async_tensor_h2d, np_to_pinned_tensor
+from vllm.utils.torch_utils import async_tensor_h2d, np_to_pinned_tensor
 from vllm.v1.kv_cache_interface import KVCacheSpec, MambaSpec
 
 if TYPE_CHECKING:
@@ -917,18 +917,21 @@ def compute_causal_conv1d_metadata(
     token_chunk_offset_ptr = None
     for BLOCK_M in [8]:  # cover all BLOCK_M values
         nums = -(-seqlens // BLOCK_M)
+        nums_np = nums.numpy()
         nums_dict[BLOCK_M] = {}
         nums_dict[BLOCK_M]["nums"] = nums
-        nums_dict[BLOCK_M]["tot"] = nums.sum().item()
-        mlist = np_to_pinned_tensor(np.repeat(np.arange(len(nums)), nums))
+        nums_dict[BLOCK_M]["tot"] = int(nums_np.sum())
+        mlist = np_to_pinned_tensor(np.repeat(np.arange(len(nums_np)), nums_np))
         nums_dict[BLOCK_M]["mlist"] = mlist
         mlist_len = len(nums_dict[BLOCK_M]["mlist"])
         nums_dict[BLOCK_M]["mlist_len"] = mlist_len
         MAX_NUM_PROGRAMS = max(1024, mlist_len) * 2
-        offsetlist = []  # type: ignore
-        for idx, num in enumerate(nums):
-            offsetlist.extend(range(num))
-        offsetlist = torch.tensor(offsetlist, dtype=torch.int32, pin_memory=PIN_MEMORY)
+        starts = np.cumsum(nums_np) - nums_np
+        offsetlist = np_to_pinned_tensor(
+            (np.arange(mlist_len, dtype=np.int64) - np.repeat(starts, nums_np)).astype(
+                np.int32
+            )
+        )
         nums_dict[BLOCK_M]["offsetlist"] = offsetlist
 
         if batch_ptr is None:


### PR DESCRIPTION
## Summary

- build causal-conv1d program indices with NumPy vector operations.
- avoid iterating over scalar tensors (`tensor.__iter__`) which has high call overhead

## Why

Running Qwen on a B200, `compute_causal_conv1d_metadata` runs on the engine thread for GDN models. At a batch around 975, the scalar-tensor iteration accounted for 4.5% of engine-thread samples. The full function accounted for about 6.4%. The vectorized construction was about 19x faster in the originating microbenchmark and preserves the same per-sequence program ordering.

## Duplicate check

I searched open vLLM PRs for `causal conv1d metadata vectorize` and `compute_causal_conv1d_metadata`. PR #35166 mentions the function but implements block-table update support; it does not replace this index-building loop. I found no open PR implementing this change.

## Measured performance

The originating benchmark (`qwen35_execmodel_prep_2026-08-05.md`) measured this path on Qwen3.5 structured-output traffic:

- The index-construction microbenchmark improved **129 µs → 7 µs (19x)** and was bit-identical over 200 randomized batches.
- In a 1,000-concurrency B200 profile, `Tensor.__iter__` went **186 → 0 samples** and `compute_causal_conv1d_metadata` went **76 → 0**. The `execute_model_prep` share fell **48.9% → 47.3%** (-1.6 percentage points).
In steady state in our benchmarking setup, we are currently GPU compute constrained so this doesn't show up as a win, but can be useful for smaller models such as the Qwen 3.5 0.8B that is being benchmarked for MRV2. 

## Validation

- `.venv/bin/python -m pytest tests/v1/attention/test_gdn_metadata_builder.py -q` — 11 passed
- `.venv/bin/pre-commit run ruff-check --files vllm/v1/attention/backends/utils.py tests/v1/attention/test_gdn_metadata_builder.py` — passed
- `.venv/bin/pre-commit run ruff-format --files vllm/v1/attention/backends/utils.py tests/v1/attention/test_gdn_metadata_builder.py` — passed
- commit-time pre-commit suite — passed

## AI assistance

This change was prepared with OpenAI Codex  and Claude Code assistance.
I, John have reviewed every line (though I would want feedback on if the additional test is considered useful).  
