### PR TITLE
[Perf] Cache streaming parser drop metadata

### DIFF
--- a/tests/parser/engine/test_engine.py
+++ b/tests/parser/engine/test_engine.py
@@ -18,7 +18,10 @@ from vllm.parser.engine.parser_engine_config import (
     ParserState,
     Transition,
 )
-from vllm.parser.engine.streaming_parser_engine import StreamingParserEngine
+from vllm.parser.engine.streaming_parser_engine import (
+    StreamingParserEngine,
+    _build_drop_info_cached,
+)
 
 
 def _hermes_config() -> ParserEngineConfig:
@@ -69,6 +72,21 @@ def _think_config() -> ParserEngineConfig:
             ),
         },
     )
+
+
+def test_drop_info_is_reused_across_requests():
+    """Equivalent per-request parser configs reuse immutable lexer metadata."""
+    tokenizer = _make_think_tokenizer()
+    tokenizer.all_special_tokens = ["<think>", "</think>", "<unused>"]
+    tokenizer.all_special_ids = [_START_ID, _END_ID, 99]
+    _build_drop_info_cached.cache_clear()
+
+    StreamingParserEngine(_think_config(), tokenizer)
+    StreamingParserEngine(_think_config(), tokenizer)
+
+    cache_info = _build_drop_info_cached.cache_info()
+    assert cache_info.misses == 1
+    assert cache_info.hits == 1
 
 
 class TestNonStreaming:

--- a/vllm/parser/engine/streaming_parser_engine.py
+++ b/vllm/parser/engine/streaming_parser_engine.py
@@ -5,6 +5,7 @@ incremental lexing, and state-machine-driven semantic event emission."""
 
 from __future__ import annotations
 
+import functools
 from collections.abc import Sequence
 from dataclasses import dataclass
 
@@ -15,6 +16,7 @@ from vllm.parser.engine.incremental_lexer import (
     LexerShape,
     LexToken,
     TerminalDef,
+    terminals_from_literals,
 )
 from vllm.parser.engine.parser_engine_config import (
     ParserEngineConfig,
@@ -36,28 +38,25 @@ class _DropInfo:
     extra_token_ids: dict[int, str]
 
 
-def _build_drop_info(
-    config: ParserEngineConfig,
-    tokenizer,
+@functools.lru_cache(maxsize=64)
+def _build_drop_info_cached(
+    terminals: tuple[tuple[str, str], ...],
+    configured_token_texts: frozenset[str],
+    preserve_tokens: frozenset[str],
+    special_tokens: tuple[tuple[str, int], ...],
 ) -> _DropInfo | None:
-    try:
-        special_tokens: list[str] = list(tokenizer.all_special_tokens)
-        special_ids: list[int] = list(tokenizer.all_special_ids)
-    except (AttributeError, NotImplementedError):
-        return None
-
     if not special_tokens:
         return None
 
     configured_texts = (
-        set(config.token_id_terminals.values())
-        | set(config.terminals.values())
-        | config.preserve_tokens
+        configured_token_texts
+        | frozenset(text for _, text in terminals)
+        | preserve_tokens
     )
 
     extra_token_ids: dict[int, str] = {}
     drop_texts: set[str] = set()
-    for text, tid in zip(special_tokens, special_ids):
+    for text, tid in special_tokens:
         if text not in configured_texts:
             extra_token_ids[tid] = DROP_TERMINAL
             drop_texts.add(text)
@@ -77,12 +76,31 @@ def _build_drop_info(
         for text in drop_texts
     ]
 
-    all_terminal_defs = list(config.terminal_defs) + drop_terminal_defs
+    all_terminal_defs = terminals_from_literals(dict(terminals)) + drop_terminal_defs
     lexer_shape = LexerShape(all_terminal_defs)
 
     return _DropInfo(
         lexer_shape=lexer_shape,
         extra_token_ids=extra_token_ids,
+    )
+
+
+def _build_drop_info(
+    config: ParserEngineConfig,
+    tokenizer,
+) -> _DropInfo | None:
+    try:
+        special_tokens = tuple(
+            zip(tokenizer.all_special_tokens, tokenizer.all_special_ids)
+        )
+    except (AttributeError, NotImplementedError):
+        return None
+
+    return _build_drop_info_cached(
+        tuple(config.terminals.items()),
+        frozenset(config.token_id_terminals.values()),
+        config.preserve_tokens,
+        special_tokens,
     )
 
 


### PR DESCRIPTION
## Summary

- cache immutable special-token drop metadata used by streaming parser engines
- key the bounded cache by the config and tokenizer content the builder actually reads
- verify equivalent per-request parser configs hit the cache

## Why

`StreamingParserEngine` is created per request, while its config and tokenizer contents are effectively engine-wide. Each construction currently recompiles escaped special-token regexes and rebuilds the same immutable `LexerShape`. In the originating B200 profile at a batch around 975, parser construction accounted for 1.9% of engine-thread samples, primarily in this builder.

The cache is content-keyed rather than object-identity-keyed, so equivalent config instances share an entry and tokenizer special-token changes naturally miss. It is capped at 64 entries.

## Duplicate check

I searched open vLLM PRs for `build drop info reasoning parser cache` and `_build_drop_info`. I found no open PR changing or caching this path; the broad search results were unrelated model, parser-regression, and kernel work.

## Measured performance

A pinned-hardware Nebius B200 A/B (`qwen35_per_request_patch_ab_2026-08-06.md`) used an Intel Xeon Platinum 8580 host, structured mode, 1,000 concurrency, and 180-second unprofiled runs:

- Output throughput was **11,857 → 11,890 tok/s (+0.28%)**, inside the independently measured **0.32% noise floor**; both arms had zero errors.
- In separate py-spy captures, `_build_drop_info` fell **1.5% → 0 samples** of the EngineCore main thread. Its `_get_reasoner` parent fell **1.9% → 0.4%**.
- `scheduler.schedule` fell **33.5% → 32.0%**, while `gpu_wait` rose **9.7% → 12.1%**, consistent with the removed CPU work becoming main-thread slack on an already GPU-saturated workload.

The benchmark used the SafetyKit memo implementation rather than this bounded `lru_cache`, but it memoized the same pure `_build_drop_info` result. The unambiguous result is removal of the targeted parser-construction work; the +0.28% throughput delta is noise, not a claimed serving-throughput win.

## Validation

- `.venv/bin/python -m pytest tests/parser/engine/test_engine.py -q` — 38 passed
- `.venv/bin/python -m pytest tests/parser/engine -q` — 3,738 passed
- targeted Ruff check and format hooks — passed
- commit-time pre-commit suite — passed

The planned Nebius validation adds a serving-level reasoning/tool-call corpus comparison and an A/B/A high-concurrency profile to confirm output identity and reduced parser initialization samples.

## AI assistance

This change was prepared with OpenAI Codex assistance. The human submitter must review every changed line, understand and defend the implementation, and run the listed Nebius validation before marking the PR ready.
