### PR TITLE
[Perf] Batch xgrammar bitmask fills

### DIFF
--- a/tests/v1/structured_output/test_utils.py
+++ b/tests/v1/structured_output/test_utils.py
@@ -1,13 +1,76 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-import pytest
+import threading
+from types import SimpleNamespace
+from unittest.mock import MagicMock
 
+import pytest
+import torch
+
+import vllm.v1.structured_output as structured_output
+from vllm.v1.structured_output import StructuredOutputManager
+from vllm.v1.structured_output.backend_types import StructuredOutputGrammar
 from vllm.v1.structured_output.backend_xgrammar import (
+    XgrammarGrammar,
     has_xgrammar_unsupported_json_features,
 )
 
 pytestmark = pytest.mark.cpu_test
+
+
+class _FallbackGrammar(StructuredOutputGrammar):
+    def accept_tokens(self, request_id: str, tokens: list[int]) -> bool:
+        raise NotImplementedError
+
+    def validate_tokens(self, tokens: list[int]) -> list[int]:
+        raise NotImplementedError
+
+    def rollback(self, num_tokens: int) -> None:
+        raise NotImplementedError
+
+    def fill_bitmask(self, bitmask: torch.Tensor, batch_index: int) -> None:
+        bitmask[batch_index].fill_(7)
+
+    def is_terminated(self) -> bool:
+        return False
+
+    def reset(self):
+        raise NotImplementedError
+
+
+def test_fill_bitmasks_batches_xgrammar_and_preserves_fallback(monkeypatch):
+    manager = StructuredOutputManager.__new__(StructuredOutputManager)
+    manager._grammar_bitmask = torch.zeros((4, 2), dtype=torch.int32)
+    manager._full_mask = torch.tensor(-1, dtype=torch.int32)
+    manager._xgr_batch_filler_local = threading.local()
+
+    batch_filler = MagicMock()
+    monkeypatch.setattr(
+        structured_output,
+        "xgr",
+        SimpleNamespace(BatchGrammarMatcher=MagicMock(return_value=batch_filler)),
+    )
+    matcher = object()
+    xgrammar = XgrammarGrammar(vocab_size=64, matcher=matcher, ctx=object())
+    terminated = XgrammarGrammar(vocab_size=64, matcher=object(), ctx=object())
+    terminated._is_terminated = True
+
+    manager._fill_bitmasks(
+        [
+            (xgrammar, 0, True),
+            (_FallbackGrammar(), 1, True),
+            (terminated, 2, True),
+            (xgrammar, 3, False),
+        ]
+    )
+
+    batch_filler.batch_fill_next_token_bitmask.assert_called_once_with(
+        [matcher], manager._grammar_bitmask, [0]
+    )
+    assert manager._grammar_bitmask[1].tolist() == [7, 7]
+    assert manager._grammar_bitmask[2].tolist() == [-1, -1]
+    assert manager._grammar_bitmask[3].tolist() == [-1, -1]
 
 
 @pytest.fixture

--- a/vllm/v1/structured_output/__init__.py
+++ b/vllm/v1/structured_output/__init__.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import itertools
 import multiprocessing
+import threading
 from collections.abc import Iterable, Sequence
 from concurrent.futures import Future, ThreadPoolExecutor
 from typing import TYPE_CHECKING
@@ -16,7 +17,11 @@ from vllm.v1.structured_output.backend_types import (
     StructuredOutputBackend,
     StructuredOutputGrammar,
 )
-from vllm.v1.structured_output.backend_xgrammar import XgrammarBackend
+from vllm.v1.structured_output.backend_xgrammar import (
+    XgrammarBackend,
+    XgrammarGrammar,
+    xgr,
+)
 
 if TYPE_CHECKING:
     import numpy as np
@@ -56,6 +61,7 @@ class StructuredOutputManager:
 
         self._grammar_bitmask: torch.Tensor | None = None
         self._full_mask = torch.tensor(-1, dtype=torch.int32)
+        self._xgr_batch_filler_local = threading.local()
 
         max_batch_size = self.vllm_config.scheduler_config.max_num_seqs
         self.fill_bitmask_parallel_threshold = 128
@@ -195,14 +201,28 @@ class StructuredOutputManager:
         self, batch: Iterable[tuple[StructuredOutputGrammar, int, bool]]
     ) -> None:
         assert self._grammar_bitmask is not None
+        xgr_matchers = []
+        xgr_indices = []
         for grammar, index, apply_bitmask in batch:
             if apply_bitmask and not grammar.is_terminated():
-                grammar.fill_bitmask(self._grammar_bitmask, index)
+                if isinstance(grammar, XgrammarGrammar):
+                    xgr_matchers.append(grammar.matcher)
+                    xgr_indices.append(index)
+                else:
+                    grammar.fill_bitmask(self._grammar_bitmask, index)
             else:
                 # Note that for thinking support, we will need to
                 # reset the relevant part of the bitmask for consequent
                 # requests here.
                 self._grammar_bitmask[index].fill_(self._full_mask)
+        if xgr_matchers:
+            batch_filler = getattr(self._xgr_batch_filler_local, "value", None)
+            if batch_filler is None:
+                batch_filler = xgr.BatchGrammarMatcher(max_threads=1)
+                self._xgr_batch_filler_local.value = batch_filler
+            batch_filler.batch_fill_next_token_bitmask(
+                xgr_matchers, self._grammar_bitmask, xgr_indices
+            )
 
     def _async_submit_fill_bitmask(
         self, batch: list[tuple[StructuredOutputGrammar, int, bool]]


### PR DESCRIPTION
## Summary

- fill each xgrammar chunk through `BatchGrammarMatcher`
- retain per-grammar filling for other structured-output backends
- keep one single-threaded batch matcher per executor thread
- cover mixed xgrammar, fallback, terminated, and disabled-mask rows

## Why

Large structured-output batches currently make one Python-to-FFI call per active request. At roughly 1,000 running structured requests in the originating profile, wrapper/GIL overhead accounted for about 25% of engine-thread wait time and did not improve by changing pool width. Xgrammar already exposes a batch fill API, allowing each existing executor chunk to cross the FFI boundary once.

The implementation preserves the existing chunk size and thread-pool scheduling. A thread-local batch matcher avoids sharing a matcher helper concurrently and uses `max_threads=1` because the outer executor already provides chunk parallelism.

## Duplicate check

I searched open vLLM PRs for `BatchGrammarMatcher bitmask` and `xgrammar batch fill bitmask`. No exact match was found. The broader results concern xgrammar termination-state correctness, llguidance jump decoding, and unrelated model work.

## Measured performance

The originating structured-output A/B on B200 GPUs on AMD CPUs 180-second runs, and zero errors:

- At 500 concurrency: **109 → 125 steps/s (+15%)** and **8,664 → 10,278 output tok/s (+19%)**.
- At 1,000 concurrency: **61 → 72 steps/s (+18%)** and **10,214 → 11,626 output tok/s (+14%)**.
- In separate 1,000-concurrency py-spy captures, `fill_bitmask_wait` fell **24.6% → 9.8%** of the EngineCore main thread.
- Per-fill Python/FFI leaf samples in Pyspy fell from **7,337** `fill_next_token_bitmask` samples to **456** `batch_fill_next_token_bitmask` samples.

That experiment used 64-row chunks. This PR deliberately retains upstream's 16-row chunk size; a follow-up comparison found chunk 16 only **2–3% below chunk 64**, while whole-batch xgrammar-internal threading was 5–7% worse. Therefore the +15–18% steps/s result demonstrates the batch-FFI opportunity, but it is not a direct benchmark of this exact chunk-size/thread-local implementation.

## Validation

- `.venv/bin/python -m pytest tests/v1/structured_output/test_utils.py -q` — 7 passed
- `.venv/bin/python -m pytest tests/v1/structured_output -q` — 43 passed
- targeted Ruff check and format hooks — passed
- commit-time pre-commit suite — passed

## AI assistance

This change was prepared with OpenAI Codex assistance. The human submitter must review every changed line, understand and defend the implementation, and run the listed Nebius validation before marking the PR ready.
