### PR TITLE
[Perf] Reduce prefix cache bookkeeping overhead

### DIFF
--- a/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
+++ b/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
@@ -5,11 +5,15 @@
 on partial hits, and same-step deferral."""
 
 from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import pytest
 import torch
 
-from tests.v1.core.test_prefix_caching import make_kv_cache_manager, make_request
+from tests.v1.core.test_prefix_caching import (
+    make_kv_cache_manager,
+    make_request,
+)
 from vllm.utils.hashing import sha256
 from vllm.v1.core.kv_cache_utils import (
     KVCacheBlockCopy,
@@ -75,6 +79,60 @@ def test_mamba_align_split_partial_tail_schedule():
     assert split(self=mock, request=req2, num_new_tokens=2016) == 256
     req2.num_computed_tokens = 10240
     assert split(self=mock, request=req2, num_new_tokens=1000) == 512
+
+
+def test_full_attention_partial_tail_registration_is_memoized(monkeypatch):
+    hash_block_size = 2
+    block_size = 6
+    kv_cache_config = KVCacheConfig(
+        num_blocks=8,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["full"],
+                FullAttentionSpec(
+                    block_size=block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                ),
+            ),
+            KVCacheGroupSpec(
+                ["mamba"],
+                MambaSpec(
+                    block_size=hash_block_size,
+                    shapes=(1, 1),
+                    dtypes=(torch.float32,),
+                    mamba_cache_mode="align",
+                ),
+            ),
+        ],
+    )
+    manager = make_kv_cache_manager(
+        kv_cache_config,
+        max_model_len=128,
+        enable_caching=True,
+        hash_block_size=hash_block_size,
+    )
+    request = make_request("memo", list(range(10)), hash_block_size, sha256)
+    computed_blocks, num_computed, _ = manager.get_computed_blocks(request)
+    assert (
+        manager.allocate_slots(
+            request, request.num_tokens, num_computed, computed_blocks
+        )
+        is not None
+    )
+
+    cache_partial_block = MagicMock(wraps=manager.block_pool.cache_partial_block)
+    monkeypatch.setattr(manager.block_pool, "cache_partial_block", cache_partial_block)
+
+    manager.cache_blocks(request, request.num_tokens)
+    manager.cache_blocks(request, request.num_tokens)
+    cache_partial_block.assert_not_called()
+
+    request.append_output_token_ids([10, 11])
+    manager.cache_blocks(request, request.num_tokens)
+    cache_partial_block.assert_called_once()
 
 
 def test_mamba_align_split_when_block_exceeds_scheduling_budget():

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -115,6 +115,9 @@ class SingleTypeKVCacheManager(ABC):
         # managers (full attention, mamba "align"); harmlessly empty elsewhere.
         self._partial_hit_reqs: dict[str, tuple[int, KVCacheBlock]] = {}
         self._pending_cow_copies: list[tuple[KVCacheBlock, KVCacheBlock]] = []
+        self._registered_partial_tails: dict[
+            str, dict[int, tuple[int, BlockHashWithGroupId | None]]
+        ] = {}
         # Partial-tail offload hand-off for external KV connectors: when a
         # producer registers its last-prompt-boundary partial tail and the
         # durable boundary block is not on the append-only request block table
@@ -220,8 +223,12 @@ class SingleTypeKVCacheManager(ABC):
         # If a computed block is an eviction candidate (in the free queue and
         # ref_cnt == 0), it will be removed from the free queue when touched by
         # the allocated request, so we must count it in the free-capacity check.
-        num_evictable_blocks = self._get_num_evictable_blocks(
-            new_computed_blocks[num_skipped_new_computed_blocks:]
+        num_evictable_blocks = (
+            self._get_num_evictable_blocks(
+                new_computed_blocks[num_skipped_new_computed_blocks:]
+            )
+            if len(new_computed_blocks) > num_skipped_new_computed_blocks
+            else 0
         )
         if self._has_partial_local_hit(new_computed_blocks, num_local_computed_tokens):
             # Reserve the extra block that allocate_new_blocks pulls for the
@@ -514,6 +521,7 @@ class SingleTypeKVCacheManager(ABC):
         req_blocks = self.req_to_blocks.pop(request_id, [])
         self.num_cached_block.pop(request_id, None)
         self._partial_hit_reqs.pop(request_id, None)
+        self._registered_partial_tails.pop(request_id, None)
         return req_blocks
 
     def free(self, request_id: str) -> None:
@@ -810,13 +818,18 @@ class FullAttentionManager(SingleTypeKVCacheManager):
         block_idx = boundary_tokens // self.block_size
         if block_idx >= len(blocks):
             return
+        block = blocks[block_idx]
+        registered = self._registered_partial_tails.setdefault(request.request_id, {})
+        if registered.get(boundary_tokens) == (block.block_id, block.block_hash):
+            return
         self.block_pool.cache_partial_block(
             request=request,
-            block=blocks[block_idx],
+            block=block,
             num_tokens=boundary_tokens,
             kv_cache_group_id=self.kv_cache_group_id,
             block_size=self.block_size,
         )
+        registered[boundary_tokens] = (block.block_id, block.block_hash)
 
     def get_num_common_prefix_blocks(self, running_request_id: str) -> int:
         blocks = self.req_to_blocks[running_request_id]
@@ -1524,10 +1537,9 @@ class MambaManager(SingleTypeKVCacheManager):
                         1 + self.num_speculative_blocks + int(has_partial_hit)
                     )
 
-            num_evictable_computed_blocks = self._get_num_evictable_blocks(
-                new_computed_blocks
-            )
-            return num_new_blocks + num_evictable_computed_blocks
+            if not new_computed_blocks:
+                return num_new_blocks
+            return num_new_blocks + self._get_num_evictable_blocks(new_computed_blocks)
 
     def allocate_new_blocks(
         self, request_id: str, num_tokens: int, num_tokens_main_model: int


### PR DESCRIPTION
## Summary

- memoize full-attention partial-tail registration while its owning block/hash is unchanged
- invalidate request-local memo state when request blocks are released
- skip empty evictable-block scans at two hot allocation sites
- test repeated registration suppression and re-registration after partial-to-full promotion

## Why

Fine-grained prefix caching currently re-enters `cache_partial_block` for the same prompt-tail boundary on every decode step. In the originating B200 profile at roughly 900 running requests, this path consumed about 2.2 ms of a 23 ms engine step (9.4% of the step and 29% of scheduler-phase CPU). The prompt boundary is constant; registration only needs to repeat when the owning block or its primary hash changes.

The memo records `(block_id, block_hash)` per request and boundary. Promotion, copy-on-write hash movement, preemption/reallocation, and request release all invalidate that state. The test also verifies that a partial-to-full promotion re-enters registration so the partial alias remains available.

The empty evictable-block guards bundle two smaller per-request allocation costs measured at about 1% of engine-thread samples.

## Duplicate check

I searched open vLLM PRs for `partial tail cache_blocks scheduler overhead` and `evictable blocks prefix cache performance`. The only broad result was unrelated DeepSeek V4 model work; I found no open PR implementing either optimization.

## Measured performance

Two benchmark notes cover the components in this PR.

The partial-tail experiment (`qwen35_partial_tail_memo_2026-08-05.md`) measured the originating memo **plus an additional async-scheduler call-site guard that this PR intentionally omits**:

- At 500 concurrency, output throughput was **10,285 → 10,401 tok/s (+1.1%)**.
- At 1,000 concurrency, it was **11,580 → 11,698 tok/s (+1.0%)**.
- `scheduler.schedule` plus output update fell **42.4% → 36.7%** (-5.7 points, **-13% relative**), `cache_partial_block` frames disappeared, and `gpu_wait` rose **2.2% → 3.4%**.
- All runs had zero errors.

Because the omitted call-site guard produced much of that reduction, those numbers are an upper bound/context for this PR's narrower memo rather than a direct result for the exact diff.

The evictable-block guard was isolated on a pinned Nebius B200/Intel 8580 host (`qwen35_per_request_patch_ab_2026-08-06.md`):

- Output throughput was **11,895 → 11,885 tok/s (-0.08%)**, well inside a **0.32% noise floor**.
- `_get_num_evictable_blocks` fell from **0.6% of main-thread samples to zero**.
- `scheduler.schedule` fell **31.2% → 28.8%** and `gpu_wait` rose **8.9% → 11.9%**; both arms had zero errors.

The demonstrated value is lower per-request scheduler CPU and more main-thread headroom at batch ~970. Only the broader originating partial-tail variant showed a ~1% throughput increase.

## Validation

- `.venv/bin/python -m pytest tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py -q` — 20 passed
- `.venv/bin/python -m pytest tests/v1/core/prefix_cache -q` — 30 passed
- targeted Ruff check and format hooks — passed
- commit-time pre-commit suite — passed

The planned Nebius A/B/A run uses a Qwen3.5 hybrid model with fine-grained prefix caching, compares deterministic outputs and partial-prefix hit behavior, and measures `cache_partial_block`, `_get_num_evictable_blocks`, scheduler CPU, and end-to-end throughput at high batch.

## AI assistance

This change was prepared with OpenAI Codex assistance. The human submitter must review every changed line, understand and defend the invalidation argument, and run the listed Nebius validation before marking the PR ready.
