### PR TITLE
[Perf] Keep staged writes in NumPy chunks

### DIFF
--- a/tests/v1/worker/test_buffer_utils.py
+++ b/tests/v1/worker/test_buffer_utils.py
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import numpy as np
+import torch
+
+from vllm.v1.worker.gpu.buffer_utils import StagedWriteTensor
+
+
+def _make_staging_tensor(dtype: torch.dtype) -> StagedWriteTensor:
+    tensor = StagedWriteTensor.__new__(StagedWriteTensor)
+    tensor._staged_write_indices = []
+    tensor._staged_write_starts = []
+    tensor._staged_write_contents = []
+    tensor._staged_write_numel = 0
+    tensor._staged_write_cu_lens = []
+    tensor._staged_write_np_dtype = torch.empty(0, dtype=dtype).numpy().dtype
+    return tensor
+
+
+def test_staged_write_contents_preserve_order_and_dtype():
+    tensor = _make_staging_tensor(torch.int32)
+
+    tensor.stage_write(0, 0, np.asarray([1, 2], dtype=np.int64))
+    tensor.stage_write(1, 3, (value for value in [3, 4]))
+    tensor.stage_write_elem(2, 5)
+
+    contents = tensor._materialize_staged_write_contents()
+    assert contents.tolist() == [1, 2, 3, 4, 5]
+    assert contents.dtype == np.int32
+    assert tensor._staged_write_cu_lens == [2, 4, 5]
+
+
+def test_clear_staged_writes_resets_chunk_bookkeeping():
+    tensor = _make_staging_tensor(torch.float32)
+    tensor.stage_write(0, 0, [1.5, 2.5])
+
+    tensor.clear_staged_writes()
+
+    assert tensor._materialize_staged_write_contents().size == 0
+    assert tensor._staged_write_numel == 0
+    assert tensor._staged_write_cu_lens == []

--- a/vllm/v1/worker/gpu/buffer_utils.py
+++ b/vllm/v1/worker/gpu/buffer_utils.py
@@ -9,7 +9,6 @@ import torch
 from vllm.triton_utils import tl, triton
 from vllm.utils.platform_utils import is_uva_available
 from vllm.utils.torch_utils import (
-    async_tensor_h2d,
     get_accelerator_view_from_cpu_tensor,
 )
 
@@ -143,8 +142,10 @@ class StagedWriteTensor:
 
         self._staged_write_indices: list[int] = []
         self._staged_write_starts: list[int] = []
-        self._staged_write_contents: list[int | float] = []
+        self._staged_write_contents: list[np.ndarray] = []
+        self._staged_write_numel = 0
         self._staged_write_cu_lens: list[int] = []
+        self._staged_write_np_dtype = torch.empty(0, dtype=dtype).numpy().dtype
 
         new_buffer = partial(UvaBufferPool, max_concurrency=max_concurrency)
 
@@ -153,23 +154,43 @@ class StagedWriteTensor:
         self.write_cu_lens = new_buffer(self.num_rows, dtype=torch.int32)
 
     def stage_write(
-        self, index: int, start: int, x: Iterable[int] | Iterable[float]
+        self,
+        index: int,
+        start: int,
+        x: Iterable[int] | Iterable[float] | np.ndarray,
     ) -> None:
         assert index >= 0
         assert start >= 0
-        if not x:
+        if isinstance(x, np.ndarray):
+            contents = x.astype(self._staged_write_np_dtype, copy=False).reshape(-1)
+        elif isinstance(x, (list, tuple)):
+            contents = np.asarray(x, dtype=self._staged_write_np_dtype).reshape(-1)
+        else:
+            contents = np.fromiter(x, dtype=self._staged_write_np_dtype)
+        if contents.size == 0:
             return
         self._staged_write_indices.append(index)
         self._staged_write_starts.append(start)
-        self._staged_write_contents.extend(x)
-        self._staged_write_cu_lens.append(len(self._staged_write_contents))
+        self._staged_write_contents.append(contents)
+        self._staged_write_numel += contents.size
+        self._staged_write_cu_lens.append(self._staged_write_numel)
 
     def stage_write_elem(self, index: int, x: int) -> None:
         assert index >= 0
         self._staged_write_indices.append(index)
         self._staged_write_starts.append(0)
-        self._staged_write_contents.append(x)
-        self._staged_write_cu_lens.append(len(self._staged_write_contents))
+        self._staged_write_contents.append(
+            np.asarray([x], dtype=self._staged_write_np_dtype)
+        )
+        self._staged_write_numel += 1
+        self._staged_write_cu_lens.append(self._staged_write_numel)
+
+    def _materialize_staged_write_contents(self) -> np.ndarray:
+        if not self._staged_write_contents:
+            return np.empty(0, dtype=self._staged_write_np_dtype)
+        if len(self._staged_write_contents) == 1:
+            return self._staged_write_contents[0]
+        return np.concatenate(self._staged_write_contents)
 
     def apply_write(self) -> None:
         n = len(self._staged_write_indices)
@@ -181,8 +202,8 @@ class StagedWriteTensor:
         cu_lens_uva = self.write_cu_lens.copy_to_uva(self._staged_write_cu_lens)
 
         # Special handling for write_contents
-        write_contents = async_tensor_h2d(
-            self._staged_write_contents, device=self.device, dtype=self.dtype
+        write_contents = async_copy_to_gpu(
+            self._materialize_staged_write_contents(), device=self.device
         )
 
         # Write diffs to the GPU buffer
@@ -204,6 +225,7 @@ class StagedWriteTensor:
         self._staged_write_indices.clear()
         self._staged_write_starts.clear()
         self._staged_write_contents.clear()
+        self._staged_write_numel = 0
         self._staged_write_cu_lens.clear()
 
 
@@ -232,7 +254,8 @@ class FusedStagedWriter:
         group_ids: list[int] = []
         indices: list[int] = []
         starts: list[int] = []
-        contents: list[int | float] = []
+        content_chunks: list[np.ndarray] = []
+        num_contents = 0
         cu_lens: list[int] = []
 
         for group_id, t in enumerate(tensors):
@@ -243,8 +266,9 @@ class FusedStagedWriter:
             group_ids.extend([group_id] * n)
             indices.extend(t._staged_write_indices)
             starts.extend(t._staged_write_starts)
-            content_base = len(contents)
-            contents.extend(t._staged_write_contents)
+            content_base = num_contents
+            content_chunks.extend(t._staged_write_contents)
+            num_contents += t._staged_write_numel
             cu_lens.extend(content_base + cu_len for cu_len in t._staged_write_cu_lens)
 
         if not group_ids:
@@ -254,7 +278,8 @@ class FusedStagedWriter:
         indices_uva = self.indices.copy_to_uva(indices)
         starts_uva = self.starts.copy_to_uva(starts)
         cu_lens_uva = self.cu_lens.copy_to_uva(cu_lens)
-        contents_gpu = async_tensor_h2d(contents, device=self.device, dtype=torch.int32)
+        contents = np.concatenate(content_chunks)
+        contents_gpu = async_copy_to_gpu(contents, device=self.device)
 
         _apply_write_kernel[(len(group_ids),)](
             output_ptrs,

--- a/vllm/v1/worker/gpu/mm/rope.py
+++ b/vllm/v1/worker/gpu/mm/rope.py
@@ -79,7 +79,7 @@ class RopeState:
             )
 
         for i in range(self.num_dims):
-            pos = prefill_positions[i].tolist()
+            pos = prefill_positions[i].numpy()
             self.prefill_positions.stage_write(self.num_dims * req_idx + i, 0, pos)
 
     def apply_staged_writes(self) -> None:


### PR DESCRIPTION
## Summary

- retain staged write payloads as typed NumPy chunks until transfer time
- concatenate chunks once for both standalone and fused writers
- pass M-RoPE position rows as NumPy views instead of Python lists
- cover mixed ndarray/generator/scalar staging, dtype conversion, ordering, and reset

## Why

The current path converts prompt-sized CPU tensors to boxed Python lists, extends another flat Python list, then rebuilds a tensor for host-to-device transfer. For multimodal prompts this includes three M-RoPE position rows plus prompt token IDs. In the originating high-batch profile, the M-RoPE `tolist()` alone accounted for about 1% of engine-thread samples and staged transfer construction accounted for another 1%.

All supported `StagedWriteTensor` dtypes have NumPy equivalents. Keeping typed chunks avoids per-element boxing for ndarray producers while preserving iterable inputs; materialization happens once immediately before transfer.

## Duplicate check

I searched open vLLM PRs for `StagedWriteTensor numpy staged writes` and `M-RoPE tolist positions`. I found no open PR addressing either path.

## Measured performance

The originating benchmark (`qwen35_execmodel_prep_2026-08-05.md`) measured prompt-sized staging on Qwen3.5 traffic:

- The staging-chain microbenchmark improved **267 µs → 5 µs per request (53x)** and matched stock staged state/contents across 50 randomized differential trials.
- In the 1,000-concurrency Nebius profile, the staging `async_tensor_h2d` leaf went **65 → 0 samples**. After the conv1d optimization, adding chunked staging reduced `execute_model_prep` a further **47.3% → 44.7%** (-2.6 percentage points).
- The combined conv1d+staging A/B/A was throughput-flat: at 500 concurrency every warmed arm was **126 steps/s** (10,444–10,465 output tok/s), and at 1,000 concurrency every arm was **71 steps/s** (11,898–11,935 output tok/s), with zero errors.

The benchmark used the originating chunked-staging implementation; this PR generalizes the same approach across standalone and fused writers. As with the conv1d change, the measured win is removal of engine-thread CPU/boxing overhead and additional headroom, not higher throughput on the tested GPU-floored B200 configuration.

### End to End Performance Benchmark

End to end performance improvement only happens when the EngineCore CPU is the bottleneck in the system. When it is not, there is no performance differences. This is also benchmarked on MRV2, I expect larger gains on Model Runner V1 where there is less latency hiding. 

| configuration | effect | 95% CI |
| --- | --- | --- |
| decode (256/2048), unstructured, 512c | +0.67% | ±3.7% |
| prefill (2048/128), unstructured, 512c | −0.28% | ±1.4%|
| **prefill, structured, 512c** | **+1.90% req/s** | ±0.96% after benchmarked twice|
| **prefill, structured, 1024c** | **+0.79% req/s** | ±0.68% after benchmarked twice|


The structured prefill benchmarks were run twice in order to get enough signal to noise to verify that there is a 
end to end tok/sec improvement. 

(See comment below for full setup)

## Validation

- `.venv/bin/python -m pytest tests/v1/worker/test_buffer_utils.py -q` — 2 passed
- `.venv/bin/python -m pytest tests/v1/worker/test_mrope_prompt_embeds.py --collect-only -q` — 3 tests collected
- targeted Ruff check and format hooks — passed
- commit-time pre-commit suite — passed

GPU execution is pending on Nebius. The planned run executes the staged-write and M-RoPE suites, compares Qwen3-VL position tensors and deterministic outputs, and profiles prompt-heavy A/B/A workloads for list conversion, staging time, and throughput.

## AI assistance

This change was prepared with OpenAI Codex assistance. The human submitter must review every changed line, understand and defend the transfer semantics, and run the listed Nebius GPU validation before marking the PR ready.
