### PR TITLE
[CI][XPU] Work around intermittent segfault in Intel XPU CI with VLLM_DISABLE_COMPILE_CACHE=1

### DIFF
--- a/.buildkite/intel_jobs/basic_correctness.yaml
+++ b/.buildkite/intel_jobs/basic_correctness.yaml
@@ -18,10 +18,11 @@ steps:
   source_file_dependencies:
   - vllm/
   - tests/basic_correctness/test_cumem.py
+  # Remove VLLM_DISABLE_COMPILE_CACHE=1 once intel/intel-xpu-backend-for-triton#7682 is fixed
   commands:
     - >-
       bash .buildkite/scripts/hardware_ci/run-intel-test.sh
       'cd tests &&
       export VLLM_WORKER_MULTIPROC_METHOD=spawn &&
-      pytest -v -s basic_correctness/test_cpu_offload.py &&
+      VLLM_DISABLE_COMPILE_CACHE=1 pytest -v -s basic_correctness/test_cpu_offload.py &&
       pytest -v -s basic_correctness/test_mem.py::test_end_to_end'

--- a/.buildkite/intel_jobs/model_executor_intel.yaml
+++ b/.buildkite/intel_jobs/model_executor_intel.yaml
@@ -21,6 +21,7 @@ steps:
   - vllm/config/model.py
   - vllm/model_executor
   - tests/model_executor
+  # Remove VLLM_DISABLE_COMPILE_CACHE=1 once intel/intel-xpu-backend-for-triton#7682 is fixed
   commands:
     - >-
       bash .buildkite/scripts/hardware_ci/run-intel-test.sh
@@ -30,4 +31,4 @@ steps:
       export VLLM_WORKER_MULTIPROC_METHOD=spawn &&
       export PYTHONFAULTHANDLER=1 &&
       cd tests &&
-      pytest -v -s model_executor -m "not slow_test" --ignore="model_executor/layers/test_rocm_unquantized_gemm.py" --deselect="tests/model_executor/model_loader/test_reload.py::test_kv_scale_reload"'
+      VLLM_DISABLE_COMPILE_CACHE=1 pytest -v -s model_executor -m "not slow_test" --ignore="model_executor/layers/test_rocm_unquantized_gemm.py" --deselect="tests/model_executor/model_loader/test_reload.py::test_kv_scale_reload"'

--- a/.buildkite/intel_jobs/model_runner_v2_intel.yaml
+++ b/.buildkite/intel_jobs/model_runner_v2_intel.yaml
@@ -22,13 +22,14 @@ steps:
     - vllm/v1/attention/
     - tests/v1/engine/test_llm_engine.py
     - tests/v1/e2e/
+  # Remove VLLM_DISABLE_COMPILE_CACHE=1 once intel/intel-xpu-backend-for-triton#7682 is fixed
   commands:
     - >-
       bash .buildkite/scripts/hardware_ci/run-intel-test.sh
       'export VLLM_USE_V2_MODEL_RUNNER=1 &&
       cd tests &&
       pytest -v -s v1/engine/test_llm_engine.py -k "not test_engine_metrics" &&
-      pytest -v -s v1/e2e/general/test_context_length.py &&
+      VLLM_DISABLE_COMPILE_CACHE=1 pytest -v -s v1/e2e/general/test_context_length.py &&
       ENFORCE_EAGER=1 pytest -v -s v1/e2e/general/test_async_scheduling.py -k "not ngram" &&
       pytest -v -s entrypoints/llm/test_struct_output_generate.py -k "xgrammar and not speculative_config6 and not speculative_config7 and not speculative_config8 and not speculative_config0" &&
       pytest -v -s v1/e2e/general/test_min_tokens.py'

--- a/.buildkite/intel_jobs/models_distributed_intel.yaml
+++ b/.buildkite/intel_jobs/models_distributed_intel.yaml
@@ -20,8 +20,9 @@ steps:
   - vllm/model_executor/model_loader/sharded_state_loader.py
   - vllm/model_executor/models/
   - tests/model_executor/model_loader/test_sharded_state_loader.py
+  # Remove VLLM_DISABLE_COMPILE_CACHE=1 once intel/intel-xpu-backend-for-triton#7682 is fixed
   commands:
     - >-
       bash .buildkite/scripts/hardware_ci/run-intel-test.sh
       'cd tests &&
-      pytest -v -s model_executor/model_loader/test_sharded_state_loader.py -m "not slow_test"'
+      VLLM_DISABLE_COMPILE_CACHE=1 pytest -v -s model_executor/model_loader/test_sharded_state_loader.py -m "not slow_test"'

--- a/.buildkite/intel_jobs/samplers_intel.yaml
+++ b/.buildkite/intel_jobs/samplers_intel.yaml
@@ -22,8 +22,9 @@ steps:
   - tests/samplers
   - tests/conftest.py
   - vllm/entrypoints/generate/beam_search
+  # Remove VLLM_DISABLE_COMPILE_CACHE=1 once intel/intel-xpu-backend-for-triton#7682 is fixed
   commands:
     - >-
       bash .buildkite/scripts/hardware_ci/run-intel-test.sh
       'cd tests &&
-      VLLM_XPU_USE_SAMPLER_KERNEL=1 pytest -v -s samplers'
+      VLLM_XPU_USE_SAMPLER_KERNEL=1 VLLM_DISABLE_COMPILE_CACHE=1 pytest -v -s samplers'


### PR DESCRIPTION
## Purpose

Certain Intel XPU CI jobs set VLLM_DISABLE_COMPILE_CACHE=1 to mitigate an intermittent segfault in the Intel Triton XPU backend.

Upstream issue: https://github.com/intel/intel-xpu-backend-for-triton/issues/7682
 