### PR TITLE
[Model Loader][Perf] Auto-prefetch VirtioFS checkpoints

### DIFF
--- a/tests/model_executor/model_loader/test_weight_utils.py
+++ b/tests/model_executor/model_loader/test_weight_utils.py
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+from safetensors.torch import save_file
+
+from vllm.config.load import (
+    DEFAULT_SAFETENSORS_PREFETCH_BLOCK_SIZE,
+    DEFAULT_SAFETENSORS_PREFETCH_NUM_THREADS,
+)
+from vllm.model_executor.model_loader import weight_utils
+
+
+@pytest.mark.parametrize(
+    ("fs_type", "strategy", "available_ram_multiplier", "should_prefetch"),
+    [
+        pytest.param("virtiofs", None, 2, True, id="virtiofs"),
+        pytest.param("virtiofs", None, 1, False, id="virtiofs-low-ram"),
+        pytest.param("virtiofs", "lazy", 2, False, id="virtiofs-explicit-lazy"),
+        pytest.param("ext4", None, 2, False, id="ext4"),
+    ],
+)
+def test_auto_prefetch_selection(
+    tmp_path,
+    monkeypatch,
+    fs_type,
+    strategy,
+    available_ram_multiplier,
+    should_prefetch,
+):
+    checkpoint = tmp_path / "model.safetensors"
+    save_file({"weight": torch.ones(2)}, checkpoint)
+
+    monkeypatch.setattr(weight_utils, "_get_fs_type", lambda _: fs_type)
+    monkeypatch.setattr(
+        weight_utils,
+        "_get_available_ram_bytes",
+        lambda: checkpoint.stat().st_size * available_ram_multiplier,
+    )
+    prefetch_calls = []
+    monkeypatch.setattr(
+        weight_utils,
+        "_prefetch_all_checkpoints",
+        lambda *args, **kwargs: prefetch_calls.append((args, kwargs)),
+    )
+
+    weights = dict(
+        weight_utils.safetensors_weights_iterator(
+            [str(checkpoint)],
+            use_tqdm_on_load=False,
+            safetensors_load_strategy=strategy,
+        )
+    )
+
+    assert torch.equal(weights["weight"], torch.ones(2))
+    assert bool(prefetch_calls) is should_prefetch
+    if should_prefetch:
+        assert prefetch_calls == [
+            (
+                ([str(checkpoint)],),
+                {
+                    "num_prefetch_threads": (DEFAULT_SAFETENSORS_PREFETCH_NUM_THREADS),
+                    "block_size": DEFAULT_SAFETENSORS_PREFETCH_BLOCK_SIZE,
+                },
+            )
+        ]

--- a/tests/model_executor/model_loader/test_weight_utils.py
+++ b/tests/model_executor/model_loader/test_weight_utils.py
@@ -29,6 +29,7 @@ def test_auto_prefetch_selection(
     available_ram_multiplier,
     should_prefetch,
 ):
+    """Auto-prefetch respects filesystem, RAM, and explicit lazy settings."""
     checkpoint = tmp_path / "model.safetensors"
     save_file({"weight": torch.ones(2)}, checkpoint)
 

--- a/vllm/config/load.py
+++ b/vllm/config/load.py
@@ -64,16 +64,17 @@ class LoadConfig:
     """
     Specifies the loading strategy for safetensors weights.
 
-    - None (default): Uses memory-mapped (lazy) loading. When an NFS
-      filesystem is detected and the total checkpoint size fits within 90%%
-      of available RAM, prefetching is enabled automatically.
+    - None (default): Uses memory-mapped (lazy) loading. When an NFS, Lustre,
+      or VirtioFS filesystem is detected and the total checkpoint size fits
+      within 90%% of available RAM, prefetching is enabled automatically.
     - "lazy": Weights are memory-mapped from the file. This enables
       on-demand loading and is highly efficient for models on local storage.
-      Unlike the default (None), auto-prefetch on NFS is not performed.
+      Unlike the default (None), automatic prefetching is not performed.
     - "eager": The entire file is read into CPU memory upfront before loading.
-      This is recommended for models on network filesystems (e.g., Lustre, NFS)
-      as it avoids inefficient random reads, significantly speeding up model
-      initialization. However, it uses more CPU RAM.
+      This is recommended for models on network or shared filesystems (e.g.,
+      NFS, Lustre, VirtioFS) as it avoids inefficient random reads,
+      significantly speeding up model initialization. However, it uses more
+      CPU RAM.
     - "prefetch": Checkpoint files are read into the OS page cache before
       workers load them, speeding up the model loading phase. Useful on
       network or high-latency storage.

--- a/vllm/config/load.py
+++ b/vllm/config/load.py
@@ -63,16 +63,17 @@ class LoadConfig:
     """
     Specifies the loading strategy for safetensors weights.
 
-    - None (default): Uses memory-mapped (lazy) loading. When an NFS
-      filesystem is detected and the total checkpoint size fits within 90%%
-      of available RAM, prefetching is enabled automatically.
+    - None (default): Uses memory-mapped (lazy) loading. When an NFS, Lustre,
+      or VirtioFS filesystem is detected and the total checkpoint size fits
+      within 90%% of available RAM, prefetching is enabled automatically.
     - "lazy": Weights are memory-mapped from the file. This enables
       on-demand loading and is highly efficient for models on local storage.
-      Unlike the default (None), auto-prefetch on NFS is not performed.
+      Unlike the default (None), automatic prefetching is not performed.
     - "eager": The entire file is read into CPU memory upfront before loading.
-      This is recommended for models on network filesystems (e.g., Lustre, NFS)
-      as it avoids inefficient random reads, significantly speeding up model
-      initialization. However, it uses more CPU RAM.
+      This is recommended for models on network or shared filesystems (e.g.,
+      NFS, Lustre, VirtioFS) as it avoids inefficient random reads,
+      significantly speeding up model initialization. However, it uses more
+      CPU RAM.
     - "prefetch": Checkpoint files are read into the OS page cache before
       workers load them, speeding up the model loading phase. Useful on
       network or high-latency storage.

--- a/vllm/model_executor/model_loader/weight_utils.py
+++ b/vllm/model_executor/model_loader/weight_utils.py
@@ -64,6 +64,8 @@ from vllm.model_executor.layers.quantization.torchao import torchao_version_at_l
 
 logger = init_logger(__name__)
 
+_AUTO_PREFETCH_FS_TYPES = frozenset({"nfs", "nfs4", "lustre", "virtiofs"})
+
 # use system-level temp directory for file locks, so that multiple users
 # can share the same lock without error.
 # lock files in the temp directory will be automatically deleted when the
@@ -857,7 +859,7 @@ def safetensors_weights_iterator(
     sorted_files = sorted(hf_weights_files, key=_natural_sort_key)
 
     fs_type = _get_fs_type(sorted_files)
-    is_net_fs = fs_type in ("nfs", "nfs4", "lustre")
+    is_auto_prefetch_fs = fs_type in _AUTO_PREFETCH_FS_TYPES
     total_bytes = _get_checkpoints_size_bytes(sorted_files)
     avail_bytes = _get_available_ram_bytes()
     ram_threshold_pct = 90
@@ -874,11 +876,11 @@ def safetensors_weights_iterator(
 
     should_prefetch = safetensors_load_strategy == "prefetch"
     if safetensors_load_strategy is None:
-        if is_net_fs and fits_in_ram:
+        if is_auto_prefetch_fs and fits_in_ram:
             should_prefetch = True
-        elif is_net_fs and not fits_in_ram:
+        elif is_auto_prefetch_fs and not fits_in_ram:
             logger.warning_once(
-                "Network filesystem (%s) detected but checkpoint total size "
+                "Auto-prefetch filesystem (%s) detected but checkpoint total size "
                 "(%.2f GiB) exceeds %d%% of available RAM (%.2f GiB). "
                 "Skipping auto-prefetch.",
                 fs_name,
@@ -886,17 +888,18 @@ def safetensors_weights_iterator(
                 ram_threshold_pct,
                 avail_bytes / 1024**3,
             )
-        elif not is_net_fs and fits_in_ram:
+        elif not is_auto_prefetch_fs and fits_in_ram:
             logger.info_once(
                 "Auto-prefetch is disabled because the filesystem (%s) is not a "
-                "recognized network FS (NFS/Lustre). If you want to force "
+                "recognized auto-prefetch FS (NFS/Lustre/VirtioFS). To force "
                 "prefetching, start vLLM with --safetensors-load-strategy=prefetch.",
                 fs_name,
             )
-        elif not is_net_fs and not fits_in_ram:
+        elif not is_auto_prefetch_fs and not fits_in_ram:
             logger.info_once(
                 "Auto-prefetch is disabled because the filesystem (%s) is not a "
-                "recognized network FS (NFS/Lustre) and the checkpoint size "
+                "recognized auto-prefetch FS (NFS/Lustre/VirtioFS) and the "
+                "checkpoint size "
                 "(%.2f GiB) exceeds %d%% of available RAM (%.2f GiB).",
                 fs_name,
                 total_bytes / 1024**3,

--- a/vllm/model_executor/model_loader/weight_utils.py
+++ b/vllm/model_executor/model_loader/weight_utils.py
@@ -64,6 +64,8 @@ from vllm.model_executor.layers.quantization.torchao import torchao_version_at_l
 
 logger = init_logger(__name__)
 
+_AUTO_PREFETCH_FS_TYPES = frozenset({"nfs", "nfs4", "lustre", "virtiofs"})
+
 # use system-level temp directory for file locks, so that multiple users
 # can share the same lock without error.
 # lock files in the temp directory will be automatically deleted when the
@@ -853,7 +855,7 @@ def safetensors_weights_iterator(
     sorted_files = sorted(hf_weights_files, key=_natural_sort_key)
 
     fs_type = _get_fs_type(sorted_files)
-    is_net_fs = fs_type in ("nfs", "nfs4", "lustre")
+    is_auto_prefetch_fs = fs_type in _AUTO_PREFETCH_FS_TYPES
     total_bytes = _get_checkpoints_size_bytes(sorted_files)
     avail_bytes = _get_available_ram_bytes()
     ram_threshold_pct = 90
@@ -870,11 +872,11 @@ def safetensors_weights_iterator(
 
     should_prefetch = safetensors_load_strategy == "prefetch"
     if safetensors_load_strategy is None:
-        if is_net_fs and fits_in_ram:
+        if is_auto_prefetch_fs and fits_in_ram:
             should_prefetch = True
-        elif is_net_fs and not fits_in_ram:
+        elif is_auto_prefetch_fs and not fits_in_ram:
             logger.warning_once(
-                "Network filesystem (%s) detected but checkpoint total size "
+                "Auto-prefetch filesystem (%s) detected but checkpoint total size "
                 "(%.2f GiB) exceeds %d%% of available RAM (%.2f GiB). "
                 "Skipping auto-prefetch.",
                 fs_name,
@@ -882,17 +884,18 @@ def safetensors_weights_iterator(
                 ram_threshold_pct,
                 avail_bytes / 1024**3,
             )
-        elif not is_net_fs and fits_in_ram:
+        elif not is_auto_prefetch_fs and fits_in_ram:
             logger.info_once(
                 "Auto-prefetch is disabled because the filesystem (%s) is not a "
-                "recognized network FS (NFS/Lustre). If you want to force "
+                "recognized auto-prefetch FS (NFS/Lustre/VirtioFS). To force "
                 "prefetching, start vLLM with --safetensors-load-strategy=prefetch.",
                 fs_name,
             )
-        elif not is_net_fs and not fits_in_ram:
+        elif not is_auto_prefetch_fs and not fits_in_ram:
             logger.info_once(
                 "Auto-prefetch is disabled because the filesystem (%s) is not a "
-                "recognized network FS (NFS/Lustre) and the checkpoint size "
+                "recognized auto-prefetch FS (NFS/Lustre/VirtioFS) and the "
+                "checkpoint size "
                 "(%.2f GiB) exceeds %d%% of available RAM (%.2f GiB).",
                 fs_name,
                 total_bytes / 1024**3,


### PR DESCRIPTION
## Purpose

Enable RAM-guarded safetensors auto-prefetch when the checkpoint filesystem is reported as `virtiofs`.

The default loading mode currently detects `VIRTIOFS` but leaves prefetch disabled because the automatic allowlist contains only NFS, NFS4, and Lustre. With a 1403.19 GiB GLM-5.2 checkpoint that fit within available RAM, explicit prefetch reduced model loading from 1597.0 seconds to 70.7 seconds, about 22.6x.

This change:

- adds VirtioFS to the existing automatic prefetch set;
- renames the internal network-filesystem classification because VirtioFS is a host/guest shared filesystem, not a network filesystem;
- documents default and explicit-lazy behavior;
- adds behavior coverage for VirtioFS, the RAM guard, explicit `lazy`, and a local filesystem.

### Safety and scope

Automatic prefetch still activates only when `safetensors_load_strategy` is unset and total checkpoint size is at most 90% of available RAM. Explicit `lazy` remains an opt-out.

VirtioFS backing storage, cache policy, and DAX configuration vary. The filesystem type alone does not prove that storage is high latency or that prefetched guest pages will be retained. 

This changes startup I/O scheduling only. Loaded tensor values and model outputs are unchanged.

### Duplicate check

Exact VirtioFS issue and PR searches returned no results. #47412 proposes CephFS support through the same mechanism, but only for the separate `ceph` filesystem type. This PR does not include CephFS and can rebase around #47412 if it lands first.

## Test Plan

```bash
.venv/bin/python -m pytest tests/model_executor/model_loader/test_weight_utils.py -v
.venv/bin/python -m pytest tests/test_config.py -k safetensors_load_strategy -v
.venv/bin/pre-commit run --files \
  vllm/config/load.py \
  vllm/model_executor/model_loader/weight_utils.py \
  tests/model_executor/model_loader/test_weight_utils.py
```

## Test Result

- Revalidated after rebasing onto `2a336d8239`: all five focused loader/config tests passed on CPU.
- The full CI command, `pre-commit run --all-files --hook-stage manual`, passed, including dependency lockfiles, lint, and mypy for Python 3.10, 3.11, 3.12, and 3.13.
- The runtime measurements below are from the original GLM-5.2 run; they were not repeated during this CPU-only review.
- GLM-5.2 runtime validation on VirtioFS:
  - default auto path: `VIRTIOFS` detected, auto-prefetch disabled, model loading took 1596.998607 seconds;
  - explicit `prefetch`: `VIRTIOFS` detected, model loading took 70.675506 seconds and application startup completed.

AI assistance was used for research, implementation, tests, and PR drafting. I reviewed every changed line and ran the commands above.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, including why it does not duplicate existing work.
- [x] The test plan.
- [x] The test results and runtime comparison.
- [x] Documentation updated.
</details>

