### PR TITLE
[CI/Build] Fix strict docs build: annotate _to_serve_args parameter

### DIFF
--- a/vllm/benchmarks/throughput.py
+++ b/vllm/benchmarks/throughput.py
@@ -523,7 +523,7 @@ def save_to_pytorch_benchmark_format(
         write_to_json(pt_file, pt_records)
 
 
-def _to_serve_args(args) -> argparse.Namespace:
+def _to_serve_args(args: argparse.Namespace) -> argparse.Namespace:
     """Translate throughput args into a namespace the shared get_samples reads.
 
     ``get_samples`` (used by ``bench serve``) expects ~45 attributes; the


### PR DESCRIPTION
## Purpose

`mkdocs build --strict` is currently failing on `main`:

```
WARNING - griffe: vllm/benchmarks/throughput.py:535: No type or annotation for parameter 'args'
Aborted with 1 warnings in strict mode!
```

`_to_serve_args` documents `args` in its `Args:` section but leaves the parameter unannotated, so griffe (via mkdocstrings) can't resolve a type for it and emits a warning. Under `--strict` that single warning aborts the whole docs build.

It arrived with #50981 earlier today, which added the function.

## The fix

Annotate the parameter to match what the docstring already claims:

```diff
-def _to_serve_args(args) -> argparse.Namespace:
+def _to_serve_args(args: argparse.Namespace) -> argparse.Namespace:
```

`argparse` is already imported (line 5), the return type is annotated the same way, and the sole caller (`get_requests`, line 569) passes a parsed CLI namespace. No behaviour change.

The other unannotated functions in this file — `get_requests`, `filter_requests_for_dp`, `assign_loras`, `validate_args` — have no `Args:` docstring sections, so griffe does not flag them. That matches `Aborted with 1 warnings` (singular), and it's why this is a one-line change rather than a sweep.

## Test Plan

```bash
mkdocs build --strict
pre-commit run --files vllm/benchmarks/throughput.py
```

## Test Result

| | `mkdocs build --strict` |
|---|---|
| `main` unfixed | **exit 1** — `Aborted with 1 warnings`, the griffe warning above |
| with this fix | **exit 0** — 0 warnings |

`pre-commit` on the changed file: passed.

Note on the before-case: it was captured from a separate branch whose copy of `throughput.py` is byte-identical to `origin/main` (`git diff origin/main -- vllm/benchmarks/throughput.py` is empty), not from a second build of this branch with the fix reverted.

### Model evaluation

Not applicable — a type annotation on a benchmark helper. No runtime behaviour, accuracy, or serving path is affected.

### Duplicate check

```bash
gh pr list -R vllm-project/vllm --state open --search "throughput.py griffe"
gh pr list -R vllm-project/vllm --state open --search "mkdocs strict"
gh pr list -R vllm-project/vllm --state all --search "50981"
```

No open PR addresses this. #50981, which introduced it, is merged.

---

AI assistance was used in preparing this change. I reviewed the diff, confirmed the failure and the fix by running the strict build both ways myself, and checked that no sibling function in the file has the same docstring/annotation mismatch.
