### PR TITLE
[Frontend] Exclude forced generation prefix from usage.prompt_tokens

### DIFF
--- a/tests/entrypoints/openai/chat_completion/test_usage_prompt_tokens.py
+++ b/tests/entrypoints/openai/chat_completion/test_usage_prompt_tokens.py
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import pytest
+
+from vllm.entrypoints.openai.chat_completion.serving import _usage_prompt_tokens
+
+
+@pytest.mark.parametrize(
+    ("prompt_token_ids", "generation_prefix_len", "encoder_ids", "expected"),
+    [
+        ([1, 2, 3, 4, 5], None, None, 5),
+        ([1, 2, 3, 4, 5], 0, None, 5),
+        ([1, 2, 3, 4, 5], 3, None, 2),
+        ([1, 2, 3], 3, None, 0),
+        ([1, 2, 3], 3, [9, 8], 2),
+        # Invalid prefix lengths are ignored (fall back to full prompt length).
+        ([1, 2, 3], -1, None, 3),
+        ([1, 2, 3], 4, None, 3),
+    ],
+)
+def test_usage_prompt_tokens(
+    prompt_token_ids: list[int],
+    generation_prefix_len: int | None,
+    encoder_ids: list[int] | None,
+    expected: int,
+):
+    assert (
+        _usage_prompt_tokens(
+            prompt_token_ids,
+            generation_prefix_len=generation_prefix_len,
+            encoder_prompt_token_ids=encoder_ids,
+        )
+        == expected
+    )

--- a/tests/renderers/test_kimi_k3.py
+++ b/tests/renderers/test_kimi_k3.py
@@ -20,15 +20,27 @@ class StubTokenizer:
     (git-LFS) tiktoken vocabulary.
     """
 
-    def __init__(self, token_ids: list[int]) -> None:
+    def __init__(
+        self,
+        token_ids: list[int],
+        *,
+        stub_encodings: dict[str, list[int]] | None = None,
+    ) -> None:
         self.token_ids = token_ids
         self.calls: list[dict[str, Any]] = []
         self.conversations: list[list[dict[str, Any]]] = []
+        self.stub_encodings = stub_encodings or {}
 
     def apply_chat_template(self, conversation, **kwargs) -> list[int]:
         self.conversations.append(conversation)
         self.calls.append(kwargs)
         return list(self.token_ids)
+
+    def encode(self, text: str, add_special_tokens: bool = True) -> list[int]:
+        if text in self.stub_encodings:
+            return list(self.stub_encodings[text])
+        # Unknown stubs → empty ids so generation_prefix_len stays unset.
+        return []
 
 
 @dataclass
@@ -351,3 +363,40 @@ async def test_render_messages_async_returns_token_prompt():
 
     assert prompt == {"prompt_token_ids": [4, 5]}
     assert conversation[0]["role"] == "user"
+
+
+def test_render_messages_sets_generation_prefix_len_for_channel_open_stub():
+    think_stub = [90, 91, 92]
+    tokenizer = StubTokenizer(
+        [1, 2, 3, *think_stub],
+        stub_encodings={
+            "<|open|>think<|sep|>": think_stub,
+            "<|open|>response<|sep|>": [93, 94, 95],
+        },
+    )
+    renderer = _make_renderer(tokenizer)
+
+    _, prompt = renderer.render_messages(
+        [{"role": "user", "content": "hi"}], ChatParams()
+    )
+
+    assert prompt["prompt_token_ids"] == [1, 2, 3, 90, 91, 92]
+    assert prompt["generation_prefix_len"] == 3
+
+
+def test_render_messages_omits_generation_prefix_len_without_stub():
+    tokenizer = StubTokenizer(
+        [1, 2, 3],
+        stub_encodings={
+            "<|open|>think<|sep|>": [90, 91, 92],
+            "<|open|>response<|sep|>": [93, 94, 95],
+        },
+    )
+    renderer = _make_renderer(tokenizer)
+
+    _, prompt = renderer.render_messages(
+        [{"role": "user", "content": "hi"}], ChatParams()
+    )
+
+    assert prompt == {"prompt_token_ids": [1, 2, 3]}
+    assert "generation_prefix_len" not in prompt

--- a/vllm/entrypoints/openai/chat_completion/batch_serving.py
+++ b/vllm/entrypoints/openai/chat_completion/batch_serving.py
@@ -15,7 +15,10 @@ from vllm.entrypoints.openai.chat_completion.protocol import (
     ChatCompletionResponseChoice,
     ChatMessage,
 )
-from vllm.entrypoints.openai.chat_completion.serving import OpenAIServingChat
+from vllm.entrypoints.openai.chat_completion.serving import (
+    OpenAIServingChat,
+    _usage_prompt_tokens,
+)
 from vllm.entrypoints.openai.engine.protocol import (
     ErrorResponse,
     RequestResponseMetadata,
@@ -242,9 +245,11 @@ class OpenAIServingChatBatch(OpenAIServingChat):
                 )
 
             assert final_res.prompt_token_ids is not None
-            num_prompt_tokens = len(final_res.prompt_token_ids)
-            if final_res.encoder_prompt_token_ids is not None:
-                num_prompt_tokens += len(final_res.encoder_prompt_token_ids)
+            num_prompt_tokens = _usage_prompt_tokens(
+                final_res.prompt_token_ids,
+                generation_prefix_len=final_res.generation_prefix_len,
+                encoder_prompt_token_ids=final_res.encoder_prompt_token_ids,
+            )
             total_prompt_tokens += num_prompt_tokens
             total_completion_tokens += sum(
                 len(output.token_ids) for output in final_res.outputs

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -68,6 +68,29 @@ from vllm.utils.collection_utils import as_list
 logger = init_logger(__name__)
 
 
+def _usage_prompt_tokens(
+    prompt_token_ids: list[int],
+    *,
+    generation_prefix_len: int | None = None,
+    encoder_prompt_token_ids: list[int] | None = None,
+) -> int:
+    """OpenAI ``usage.prompt_tokens``.
+
+    Engine ``prompt_token_ids`` may include a trailing forced generation prefix
+    (assistant preamble / channel-open stub). Those tokens remain in the engine
+    prompt; only the reported usage count excludes them when
+    ``generation_prefix_len`` is set by the renderer.
+    """
+    n = len(prompt_token_ids)
+    prefix = generation_prefix_len or 0
+    if prefix < 0 or prefix > n:
+        prefix = 0
+    n -= prefix
+    if encoder_prompt_token_ids is not None:
+        n += len(encoder_prompt_token_ids)
+    return n
+
+
 def _get_mm_token_counts(engine_input: EngineInput) -> dict[str, int]:
     """Sum per-modality placeholder tokens from ``mm_placeholders``.
 
@@ -488,9 +511,11 @@ class OpenAIServingChat(GenerateBaseServing):
             async for res in result_generator:
                 last_res = res
                 if res.prompt_token_ids is not None:
-                    num_prompt_tokens = len(res.prompt_token_ids)
-                    if res.encoder_prompt_token_ids is not None:
-                        num_prompt_tokens += len(res.encoder_prompt_token_ids)
+                    num_prompt_tokens = _usage_prompt_tokens(
+                        res.prompt_token_ids,
+                        generation_prefix_len=res.generation_prefix_len,
+                        encoder_prompt_token_ids=res.encoder_prompt_token_ids,
+                    )
 
                 # We need to do it here, because if there are exceptions in
                 # the result_generator, it needs to be sent as the FIRST
@@ -1054,9 +1079,11 @@ class OpenAIServingChat(GenerateBaseServing):
                 choice.message.content = full_message
 
         assert final_res.prompt_token_ids is not None
-        num_prompt_tokens = len(final_res.prompt_token_ids)
-        if final_res.encoder_prompt_token_ids is not None:
-            num_prompt_tokens += len(final_res.encoder_prompt_token_ids)
+        num_prompt_tokens = _usage_prompt_tokens(
+            final_res.prompt_token_ids,
+            generation_prefix_len=final_res.generation_prefix_len,
+            encoder_prompt_token_ids=final_res.encoder_prompt_token_ids,
+        )
         num_generated_tokens = sum(
             len(output.token_ids) for output in final_res.outputs
         )

--- a/vllm/inputs/engine.py
+++ b/vllm/inputs/engine.py
@@ -27,6 +27,9 @@ class _InputOptions(TypedDict):
     cache_salt: NotRequired[str]
     """Optional cache salt to be used for prefix caching."""
 
+    generation_prefix_len: NotRequired[int]
+    """Trailing forced generation-prefix length; see TokensPrompt."""
+
 
 class TokensInput(_InputOptions):
     """Represents token-based input to the engine."""
@@ -55,6 +58,7 @@ def tokens_input(
     *,
     prompt: str | None = None,
     cache_salt: str | None = None,
+    generation_prefix_len: int | None = None,
 ) -> TokensInput:
     """
     Construct [`TokensInput`][vllm.inputs.engine.TokensInput]
@@ -66,6 +70,8 @@ def tokens_input(
         inputs["prompt"] = prompt
     if cache_salt is not None:
         inputs["cache_salt"] = cache_salt
+    if generation_prefix_len is not None:
+        inputs["generation_prefix_len"] = generation_prefix_len
 
     return inputs
 

--- a/vllm/inputs/llm.py
+++ b/vllm/inputs/llm.py
@@ -95,6 +95,13 @@ class _PromptOptions(TypedDict):
     Optional cache salt to be used for prefix caching.
     """
 
+    generation_prefix_len: NotRequired[int]
+    """
+    Number of trailing tokens that are a forced generation/decode prefix
+    (e.g. an XTML channel-open stub). Included in ``prompt_token_ids`` for the
+    engine, but subtracted from OpenAI ``usage.prompt_tokens``.
+    """
+
 
 class TextPrompt(_PromptOptions):
     """Schema for a text prompt."""

--- a/vllm/outputs.py
+++ b/vllm/outputs.py
@@ -105,6 +105,9 @@ class RequestOutput:
         num_cached_tokens: The number of tokens with prefix cache hit.
         num_cache_creation_tokens: Prompt tokens currently counted as local
             prefix-cache writes for this request.
+        generation_prefix_len: Trailing forced generation-prefix length included
+            in ``prompt_token_ids`` but excluded from OpenAI
+            ``usage.prompt_tokens`` when set.
         kv_transfer_params: The params for remote K/V transfer.
         ec_transfer_params: The params for remote encoder-cache transfer.
     """
@@ -123,6 +126,7 @@ class RequestOutput:
         encoder_prompt_token_ids: list[int] | None = None,
         num_cached_tokens: int | None = None,
         num_cache_creation_tokens: int | None = None,
+        generation_prefix_len: int | None = None,
         *,
         kv_transfer_params: dict[str, Any] | None = None,
         ec_transfer_params: dict[str, Any] | None = None,
@@ -146,6 +150,7 @@ class RequestOutput:
         self.encoder_prompt_token_ids = encoder_prompt_token_ids
         self.num_cached_tokens = num_cached_tokens
         self.num_cache_creation_tokens = num_cache_creation_tokens
+        self.generation_prefix_len = generation_prefix_len
         self.kv_transfer_params = kv_transfer_params
         self.ec_transfer_params = ec_transfer_params
 

--- a/vllm/renderers/base.py
+++ b/vllm/renderers/base.py
@@ -794,6 +794,8 @@ class BaseRenderer(ABC, Generic[_T]):
             engine_input["prompt"] = prompt_text
         if cache_salt := prompt.get("cache_salt"):
             engine_input["cache_salt"] = cache_salt
+        if (generation_prefix_len := prompt.get("generation_prefix_len")) is not None:
+            engine_input["generation_prefix_len"] = generation_prefix_len
         # Narrow the union — `prompt_token_offsets` is only on TokensInput.
         if engine_input["type"] == "token" and (
             (offsets := prompt.get("prompt_token_offsets")) is not None
@@ -857,6 +859,8 @@ class BaseRenderer(ABC, Generic[_T]):
             engine_input["prompt"] = prompt_text
         if cache_salt := prompt.get("cache_salt"):
             engine_input["cache_salt"] = cache_salt
+        if (generation_prefix_len := prompt.get("generation_prefix_len")) is not None:
+            engine_input["generation_prefix_len"] = generation_prefix_len
         # Narrow the union — `prompt_token_offsets` is only on TokensInput.
         if engine_input["type"] == "token" and (
             (offsets := prompt.get("prompt_token_offsets")) is not None

--- a/vllm/renderers/kimi_k3.py
+++ b/vllm/renderers/kimi_k3.py
@@ -15,7 +15,7 @@ from vllm.tokenizers.hf import HfTokenizer
 from vllm.utils.async_utils import make_async
 
 from .base import BaseRenderer
-from .inputs import DictPrompt
+from .inputs import DecoderOnlyDictPrompt, DictPrompt
 from .inputs.preprocess import parse_dec_only_prompt
 from .params import ChatParams
 
@@ -25,11 +25,38 @@ from .params import ChatParams
 _K3_MEDIA_IO_DEFAULTS: dict[str, dict[str, Any]] = {"image": {"image_mode": None}}
 _K3_THINKING_EFFORTS = ("low", "high", "max")
 
+# XTML channel-open stubs that encoding_k3 may append as a generation prefix.
+# Engine keeps these ids; API usage.prompt_tokens excludes them when set below.
+_K3_CHANNEL_OPEN_STUBS = (
+    "<|open|>think<|sep|>",
+    "<|open|>response<|sep|>",
+)
+
 
 def _merge_k3_media_io_kwargs(
     media_io_kwargs: dict[str, dict[str, Any]] | None,
 ) -> dict[str, dict[str, Any]] | None:
     return merge_media_io_kwargs(_K3_MEDIA_IO_DEFAULTS, media_io_kwargs)
+
+
+def _k3_generation_prefix_len(tokenizer: HfTokenizer, token_ids: list[int]) -> int:
+    """Return length of a trailing channel-open stub, else 0."""
+    for stub in _K3_CHANNEL_OPEN_STUBS:
+        stub_ids = tokenizer.encode(stub, add_special_tokens=False)
+        n = len(stub_ids)
+        if n and len(token_ids) >= n and token_ids[-n:] == stub_ids:
+            return n
+    return 0
+
+
+def _prompt_with_generation_prefix_len(
+    tokenizer: HfTokenizer, token_ids: list[int]
+) -> DecoderOnlyDictPrompt:
+    prompt = parse_dec_only_prompt(token_ids)
+    prefix_len = _k3_generation_prefix_len(tokenizer, token_ids)
+    if prefix_len:
+        prompt["generation_prefix_len"] = prefix_len
+    return prompt
 
 
 def _dump_k3_template_value(value: Any) -> Any:
@@ -186,9 +213,8 @@ class KimiK3Renderer(BaseRenderer[HfTokenizer]):
         )
 
         rendered_conversation = _normalize_k3_tool_messages(conversation)
-        prompt = parse_dec_only_prompt(
-            self._apply_chat_template(rendered_conversation, params)
-        )
+        token_ids = self._apply_chat_template(rendered_conversation, params)
+        prompt = _prompt_with_generation_prefix_len(self.get_tokenizer(), token_ids)
         if mm_data is not None:
             prompt["multi_modal_data"] = mm_data
         if mm_uuids is not None:
@@ -211,7 +237,7 @@ class KimiK3Renderer(BaseRenderer[HfTokenizer]):
 
         rendered_conversation = _normalize_k3_tool_messages(conversation)
         token_ids = await self._apply_chat_template_async(rendered_conversation, params)
-        prompt = parse_dec_only_prompt(token_ids)
+        prompt = _prompt_with_generation_prefix_len(self.get_tokenizer(), token_ids)
         if mm_data is not None:
             prompt["multi_modal_data"] = mm_data
         if mm_uuids is not None:

--- a/vllm/v1/engine/__init__.py
+++ b/vllm/v1/engine/__init__.py
@@ -110,6 +110,8 @@ class EngineCoreRequest(
     cache_salt: str | None
     data_parallel_rank: int | None
     prompt_embeds: torch.Tensor | None = None
+    # Trailing forced generation-prefix length; see TokensPrompt.
+    generation_prefix_len: int | None = None
 
     # Per-position mask for mixed-mode inputs (e.g chat completion with
     # prompt_embeds content parts). `True` means the position is a real

--- a/vllm/v1/engine/input_processor.py
+++ b/vllm/v1/engine/input_processor.py
@@ -388,6 +388,7 @@ class InputProcessor:
             arrival_time=arrival_time,
             lora_request=lora_request,
             cache_salt=decoder_inputs.get("cache_salt"),
+            generation_prefix_len=decoder_inputs.get("generation_prefix_len"),
             priority=priority,
             data_parallel_rank=data_parallel_rank,
             trace_headers=trace_headers,

--- a/vllm/v1/engine/output_processor.py
+++ b/vllm/v1/engine/output_processor.py
@@ -149,6 +149,7 @@ class RequestState:
         n: int | None = None,
         temperature: float | None = None,
         stream_input: bool = False,
+        generation_prefix_len: int | None = None,
     ):
         self.request_id = request_id
         self.external_req_id = external_req_id
@@ -173,6 +174,7 @@ class RequestState:
         self.queue = queue
         self.num_cached_tokens = 0
         self.num_cache_creation_tokens = 0
+        self.generation_prefix_len = generation_prefix_len
 
         self.stats = RequestStateStats(arrival_time=arrival_time) if log_stats else None
 
@@ -271,6 +273,7 @@ class RequestState:
             log_stats=log_stats,
             stream_interval=stream_interval,
             stream_input=request.resumable,
+            generation_prefix_len=request.generation_prefix_len,
         )
 
     def make_request_output(
@@ -382,6 +385,7 @@ class RequestState:
             ec_transfer_params=ec_transfer_params,
             num_cached_tokens=self.num_cached_tokens,
             num_cache_creation_tokens=self.num_cache_creation_tokens,
+            generation_prefix_len=self.generation_prefix_len,
             metrics=self.stats,
         )
 

--- a/vllm/v1/request.py
+++ b/vllm/v1/request.py
@@ -70,6 +70,7 @@ class Request:
         mm_features: list[MultiModalFeatureSpec] | None = None,
         lora_request: "LoRARequest | None" = None,
         cache_salt: str | None = None,
+        generation_prefix_len: int | None = None,
         priority: int = 0,
         trace_headers: Mapping[str, str] | None = None,
         block_hasher: Callable[["Request"], list["BlockHash"]] | None = None,
@@ -173,6 +174,7 @@ class Request:
         self.spec_token_ids: list[int] = []
         self.num_computed_tokens = 0
         self.cache_salt: str | None = cache_salt
+        self.generation_prefix_len: int | None = generation_prefix_len
 
         # Multi-modal related
         self.mm_features = mm_features or []
@@ -239,6 +241,7 @@ class Request:
             arrival_time=request.arrival_time,
             lora_request=request.lora_request,
             cache_salt=request.cache_salt,
+            generation_prefix_len=request.generation_prefix_len,
             priority=request.priority,
             trace_headers=request.trace_headers,
             block_hasher=block_hasher,


### PR DESCRIPTION
Hey everyone this is my first every commit so pretty excited! hopefully i didn't miss any key steps during this process. thank you!

Tl;dr Engine prompt_token_ids may include a trailing decode stub (e.g. Kimi K3 channel-open markers). Add optional generation_prefix_len so OpenAI usage.prompt_tokens reports len(ids) - prefix when a renderer opts in.

## Purpose

Fix OpenAI `usage.prompt_tokens` over-counting when the engine prompt includes a
trailing forced generation / decode prefix (e.g. Kimi K3 XTML channel-open stubs
`<|open|>think<|sep|>` / `<|open|>response<|sep|>`, typically 3 tokens).
Vendor-style billing counts user-provided prompt tokens only
(`len(encoded_prompt) - pending`). vLLM previously reported the full engine
`prompt_token_ids` length (stub included), causing a systematic `+3` drift.
This PR adds optional `generation_prefix_len`, plumbed from the renderer through
the engine request/output path. Chat completion serving reports:
`usage.prompt_tokens = len(prompt_token_ids) - generation_prefix_len (+ encoder)`
- Default / unset → behavior unchanged
- Engine still conditions on the full `prompt_token_ids`
- `KimiK3Renderer` opts in when a trailing channel-open stub matches
Out of scope: proxy thinking-effort mapping, tool-choice/tool-shape prompt diffs,
and other non-+3 billing buckets.
No duplicate open PR found for this approach (`generation_prefix_len` / billed
prompt usage accounting).

## Test Plan
```bash
.venv/bin/python -m pytest \
  tests/entrypoints/openai/chat_completion/test_usage_prompt_tokens.py \
  tests/renderers/test_kimi_k3.py -v
pre-commit run
```
## Test Result
pre-commit passed on commit (ruff, mypy-3.10, SPDX, DCO sign-off).
tests/renderers/test_kimi_k3.py passed locally, including new generation_prefix_len stub-detection cases.
test_usage_prompt_tokens.py covers helper math (None/0 unchanged; valid prefix subtracted; invalid prefix ignored; encoder tokens still added).
Built image smoke-check confirmed _usage_prompt_tokens, _K3_CHANNEL_OPEN_STUBS, and K3 opt-in call sites are present.

### Optional e2e testing
created an image built from this branch and run vendor prompt-token groundtruth cases; residual +3 cases should clear when the stub is present.


#### Sample Request
```
POST /v1/chat/completions
{
  "model": "<model>",
  "messages": [
    {"role": "user", "content": "Hello, how are you?"}
  ],
  "max_tokens": 16,
  "stream": true,
  "stream_options": {"include_usage": true}
}
```

#### Before
Output:
```
{
  "usage": {
    "prompt_tokens": 102,
    "completion_tokens": 16,
    "total_tokens": 118
  }
}
```

#### After 

Output
```
{
  "usage": {
    "prompt_tokens": 99, # note the -3 tokens
    "completion_tokens": 16,
    "total_tokens": 115
  }
}
```

No docs update required beyond field docstrings.

AI assistance: Cursor. @smurthy024 reviewed all changed lines and owns the change end-to-end.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

