### PR TITLE
[Docs] Fix markdownlint blank-line violations in committers.md

### DIFF
--- a/docs/governance/committers.md
+++ b/docs/governance/committers.md
@@ -9,6 +9,7 @@ You can also refer to the [CODEOWNERS](https://github.com/vllm-project/vllm/blob
 We try to summarize each committer's role in vLLM in a few words. In general, vLLM committers cover a wide range of areas and help each other in the maintenance process.
 Please refer to the later section about Area Owners for exact component ownership details.
 Sorted alphabetically by GitHub handle:
+
 - [@aarnphm](https://github.com/aarnphm): Structured output
 - [@AndreasKaratzas](https://github.com/AndreasKaratzas): ROCm / AMD GPU integration, CI
 - [@ApostaC](https://github.com/ApostaC): Connectors, offloading
@@ -68,6 +69,7 @@ Sorted alphabetically by GitHub handle:
 ### Emeritus Committers
 
 Committers who have contributed to vLLM significantly in the past (thank you!) but no longer active:
+
 - [@22quinn](https://github.com/22quinn): RL API
 - [@alexm-redhat](https://github.com/alexm-redhat): Performance
 - [@andoorve](https://github.com/andoorve): Pipeline parallelism


### PR DESCRIPTION
## Why
`docs/governance/committers.md` is currently missing blank lines after two list headers, which fails `markdownlint-cli2` under `pre-commit --all-files`. This causes the pre-commit CI check to fail on unrelated PRs (any PR triggers a full-repo lint run).

## What
Add the two missing blank lines so the file passes markdownlint.

## Test
`pre-commit run markdownlint-cli2 --files docs/governance/committers.md` — passes with 0 errors after the fix.

AI assistance was used to help draft this change.