### PR TITLE
[CI] Fix stale Buildkite source dependencies

### DIFF
--- a/.buildkite/test_areas/engine.yaml
+++ b/.buildkite/test_areas/engine.yaml
@@ -10,7 +10,6 @@ steps:
   - vllm/compilation/
   - vllm/config/
   - vllm/engine/
-  - vllm/entrypoints/logger.py
   - vllm/envs.py
   - vllm/logger.py
   - vllm/logging_utils/

--- a/.buildkite/test_areas/kernels.yaml
+++ b/.buildkite/test_areas/kernels.yaml
@@ -33,10 +33,10 @@ steps:
   num_devices: 2
   device: h100
   source_file_dependencies:
-  - csrc/minimax_reduce_rms_kernel.cu
-  - csrc/minimax_reduce_rms_kernel.h
-  - vllm/model_executor/layers/mamba/linear_attn.py
-  - vllm/model_executor/layers/mamba/lamport_workspace.py
+  - csrc/libtorch_stable/minimax_reduce_rms_kernel.cu
+  - csrc/libtorch_stable/minimax_reduce_rms_kernel.h
+  - vllm/model_executor/layers/minimax_rms_norm/rms_norm_tp.py
+  - vllm/model_executor/layers/minimax_rms_norm/lamport_workspace.py
   - tests/kernels/core/test_minimax_reduce_rms.py
   commands:
     - pytest -v -s kernels/core/test_minimax_reduce_rms.py
@@ -46,7 +46,7 @@ steps:
   timeout_in_minutes: 30
   device: h100
   source_file_dependencies:
-  - csrc/fused_deepseek_v4_qnorm_rope_kv_insert_kernel.cu
+  - csrc/libtorch_stable/fused_deepseek_v4_qnorm_rope_kv_insert_kernel.cu
   - vllm/models/deepseek_v4/common/ops/
   - tests/kernels/test_fused_deepseek_v4_qnorm_rope_kv_insert.py
   - tests/kernels/test_top_k_per_row.py # it runs on Blackwell too - some kernels have arch-specific optimizations
@@ -59,7 +59,7 @@ steps:
   timeout_in_minutes: 20
   device: b200-k8s
   source_file_dependencies:
-  - csrc/fused_deepseek_v4_qnorm_rope_kv_insert_kernel.cu
+  - csrc/libtorch_stable/fused_deepseek_v4_qnorm_rope_kv_insert_kernel.cu
   - vllm/models/deepseek_v4/common/ops/
   - vllm/models/deepseek_v4/nvidia/
   - tests/kernels/test_fused_deepseek_v4_qnorm_rope_kv_insert.py
@@ -151,8 +151,6 @@ steps:
   source_file_dependencies:
   - cmake/external_projects/flashmla.cmake
   - vllm/v1/attention/ops/flashmla.py
-  - vllm/v1/attention/backends/mla/flashmla.py
-  - vllm/v1/attention/backends/mla/flashmla_sparse.py
   - tests/kernels/attention/test_flashmla.py
   - tests/kernels/attention/test_flashmla_sparse.py
   - tests/kernels/attention/test_mla_cross_layer_kernel_equivalence.py
@@ -226,7 +224,7 @@ steps:
   key: kernels-mamba-test
   timeout_in_minutes: 40
   source_file_dependencies:
-  - csrc/mamba/
+  - csrc/libtorch_stable/mamba/
   - tests/kernels/mamba
   - vllm/model_executor/layers/mamba/ops
   commands:

--- a/.buildkite/test_areas/samplers.yaml
+++ b/.buildkite/test_areas/samplers.yaml
@@ -8,7 +8,7 @@ steps:
   timeout_in_minutes: 40
   source_file_dependencies:
   - vllm/model_executor/layers
-  - vllm/sampling_metadata.py
+  - vllm/v1/sample/
   - tests/samplers
   - tests/conftest.py
   - vllm/entrypoints/generate/beam_search
@@ -25,7 +25,6 @@ steps:
       - image-build-amd
       source_file_dependencies:
       - vllm/model_executor/layers
-      - vllm/sampling_metadata.py
       - vllm/v1/sample/
       - vllm/entrypoints/generate/beam_search/
       - tests/samplers


### PR DESCRIPTION
## Summary

- update MiniMax, DeepSeek V4, and Mamba source dependencies after their native sources moved under `csrc/libtorch_stable/`
- point MiniMax and sampler dependencies at their current Python modules, and remove the deleted Engine request-logger path
- remove the two FlashMLA backend triggers from the H100 kernel job because its commands exercise only the low-level FlashMLA operator tests; retain `flashmla.cmake`, the operator implementation, and all three executed test files

## Why

Several `source_file_dependencies` entries no longer exist, so they cannot express ownership of the jobs they are attached to. The global `csrc/` run-all rule masks the native-path problem today, but the per-job metadata remains incorrect and would become a false-negative risk if that catch-all is narrowed.

Dynamic Python coverage of the FlashMLA H100 commands did not import or execute `mla/flashmla.py` or `mla/flashmla_sparse.py`. Keeping those triggers would claim backend validation that this low-level kernel job does not perform. Static build tracing did confirm that `cmake/external_projects/flashmla.cmake` builds the observed `_flashmla_C` extension, so that dependency remains.

## Duplicate-work check

- inspected #51225 and its comments
- `gh pr list --repo vllm-project/vllm --state open --search "51225 in:body"`: no matches
- `gh pr list --repo vllm-project/vllm --state open --search "source_file_dependencies libtorch_stable"`: no matches
- `gh pr list --repo vllm-project/vllm --state open --search "FlashMLA Buildkite dependencies"`: no matches

#51225 covers the native stable-ABI subset and is assigned. This PR intentionally includes those corrections as part of a broader dependency audit that also repairs stale Python paths and removes misleading FlashMLA backend ownership.

## Validation

- parsed all three modified files with PyYAML
- verified every replacement path exists and every removed stale path does not
- `git diff --check`
- `SKIP=actionlint .venv/bin/pre-commit run --files .buildkite/test_areas/kernels.yaml .buildkite/test_areas/engine.yaml .buildkite/test_areas/samplers.yaml`
  - all applicable hooks passed; `actionlint` is limited to GitHub Actions workflows and does not apply to these Buildkite files

The dependency audit also executed the affected FlashMLA, DeepSeek V4, MiniMax, Mamba, Engine, and Samplers jobs under coverage on H200 hardware. This PR changes only CI selection metadata, so model evaluation is not applicable.

## AI assistance

OpenAI Codex was used for dependency tracing, preparing the patch, and drafting this description. This draft must be reviewed line by line by the human submitter before it is marked ready.