### PR TITLE
[Core] cached blocks that never hit should be evicted first

### DIFF
--- a/vllm/v1/core/block_pool.py
+++ b/vllm/v1/core/block_pool.py
@@ -713,6 +713,7 @@ class BlockPool:
             if block.ref_cnt == 0 and not block.is_null:
                 self.free_block_queue.remove(block)
             block.ref_cnt += 1
+            block._ref_cnt += 1
             if self.metrics_collector:
                 self.metrics_collector.on_block_accessed(block)
 
@@ -726,20 +727,26 @@ class BlockPool:
         """
         # Identify blocks with hash (LRU cache) and without it (never match APC)
         blocks_with_hash = []
+        blocks_with_hash_hit = []
         blocks_without_hash = []
         for block in ordered_blocks:
             block.ref_cnt -= 1
             if block.ref_cnt == 0 and not block.is_null:
                 # When caching is disabled we always append for better
                 # GPU cache locality from reusing recently used blocks
-                if block.block_hash is None and self.enable_caching:
+                if not self.enable_caching:
+                    blocks_with_hash_hit.append(block)
+                elif block.block_hash is None:
                     blocks_without_hash.append(block)
-                else:
+                elif block._ref_cnt == 0:
                     blocks_with_hash.append(block)
+                else:
+                    blocks_with_hash_hit.append(block)
 
         # Blocks without hash get evicted first - prepend them last to the tail
         self.free_block_queue.prepend_n(blocks_without_hash)
         self.free_block_queue.append_n(blocks_with_hash)
+        self.free_block_queue.append_n(blocks_with_hash_hit)
 
     def evict_blocks(self, block_ids: set[int]) -> None:
         """evict blocks from the prefix cache by their block IDs.

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -122,6 +122,8 @@ class KVCacheBlock:
     block_id: int
     # Reference count.
     ref_cnt: int = 0
+    # only cumulative reference count for cached block hit.
+    _ref_cnt: int = 0
     # The hash key (block hash + group id) of the block, only available
     # when the block is full and cached.
     _block_hash: BlockHashWithGroupId | None = None
@@ -160,6 +162,7 @@ class KVCacheBlock:
         """Reset the block hash when the block is evicted."""
         self._block_hash = None
         self._block_hash_num_tokens = None
+        self._ref_cnt = 0
 
     def __repr__(self) -> str:
         # Use block_id instead of KVCacheBlock object to avoid calling __repr__
@@ -169,6 +172,7 @@ class KVCacheBlock:
         return (
             f"KVCacheBlock(block_id={self.block_id}, "
             f"ref_cnt={self.ref_cnt}, "
+            f"_ref_cnt={self._ref_cnt}, "
             f"_block_hash={self._block_hash!r}, "
             f"_block_hash_num_tokens={self._block_hash_num_tokens}, "
             f"prev_free_block={prev_block_id}, "


### PR DESCRIPTION



## Purpose

Most cached blocks with block hash that never hit. Now they are appended to the free list mixed with
fewer hit blocks. We should differentiate the both cases because of the non-hit blocks amount that is
huge and far greater than hit blocks. So we should append the non-hit blocks first and then append
the hit blocks so that non-hit blocks are allocated first in free list and keep living for hit blocks.

## Test Plan

1. python -m pytest tests/v1/core/test_kv_cache_utils.py -v
2. python -m pytest tests/v1/core/test_prefix_caching.py -v
3. python -m pytest tests/v1/core/test_single_type_kv_cache_manager.py -v

## Test Result

1. python -m pytest tests/v1/core/test_kv_cache_utils.py -v

======================================================= test session starts ========================================================
platform linux -- Python 3.12.13, pytest-9.1.1, pluggy-1.6.0 -- /usr/bin/python
cachedir: .pytest_cache
rootdir: /data/hf/vllm
configfile: pyproject.toml
plugins: asyncio-1.4.0, anyio-4.14.2
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 76 items                                                                                                                 

tests/v1/core/test_kv_cache_utils.py::test_none_hash[sha256] PASSED                                                          [  1%]
tests/v1/core/test_kv_cache_utils.py::test_none_hash[sha256_cbor] PASSED                                                     [  2%]
tests/v1/core/test_kv_cache_utils.py::test_kv_cache_block PASSED                                                             [  3%]
tests/v1/core/test_kv_cache_utils.py::test_kv_cache_block_uses_slots PASSED                                                  [  5%]
tests/v1/core/test_kv_cache_utils.py::test_free_kv_cache_block_queue_initialization PASSED                                   [  6%]
tests/v1/core/test_kv_cache_utils.py::test_free_kv_cache_block_queue_operations PASSED                                       [  7%]
tests/v1/core/test_kv_cache_utils.py::test_free_kv_cache_block_queue_append_n PASSED                                         [  9%]
tests/v1/core/test_kv_cache_utils.py::test_free_kv_cache_block_queue_prepend_n PASSED                                        [ 10%]
tests/v1/core/test_kv_cache_utils.py::test_free_kv_cache_block_queue_popleft_n PASSED                                        [ 11%]
tests/v1/core/test_kv_cache_utils.py::test_free_kv_cache_block_queue_get_all_free_blocks PASSED                              [ 13%]
tests/v1/core/test_kv_cache_utils.py::test_generate_block_hash_extra_keys PASSED                                             [ 14%]
tests/v1/core/test_kv_cache_utils.py::test_generate_block_hash_extra_keys_no_mm_inputs PASSED                                [ 15%]
tests/v1/core/test_kv_cache_utils.py::test_generate_block_hash_extra_keys_cache_salt PASSED                                  [ 17%]
tests/v1/core/test_kv_cache_utils.py::test_generate_block_hash_extra_keys_prompt_embeds PASSED                               [ 18%]
tests/v1/core/test_kv_cache_utils.py::test_generate_block_hash_extra_keys_prompt_embeds_cached PASSED                        [ 19%]
tests/v1/core/test_kv_cache_utils.py::test_generate_block_hash_extra_keys_different_prompt_embeds PASSED                     [ 21%]
tests/v1/core/test_kv_cache_utils.py::test_generate_block_hash_extra_keys_lora PASSED                                        [ 22%]
tests/v1/core/test_kv_cache_utils.py::test_hash_block_tokens[sha256] PASSED                                                  [ 23%]
tests/v1/core/test_kv_cache_utils.py::test_hash_block_tokens[sha256_cbor] PASSED                                             [ 25%]
tests/v1/core/test_kv_cache_utils.py::test_request_block_hasher[sha256] PASSED                                               [ 26%]
tests/v1/core/test_kv_cache_utils.py::test_request_block_hasher[sha256_cbor] PASSED                                          [ 27%]
tests/v1/core/test_kv_cache_utils.py::test_hash_tokens_different_mm_input[sha256] PASSED                                     [ 28%]
tests/v1/core/test_kv_cache_utils.py::test_hash_tokens_different_mm_input[sha256_cbor] PASSED                                [ 30%]
tests/v1/core/test_kv_cache_utils.py::test_hash_request_tokens_no_mm_inputs[sha256] PASSED                                   [ 31%]
tests/v1/core/test_kv_cache_utils.py::test_hash_request_tokens_no_mm_inputs[sha256_cbor] PASSED                              [ 32%]
tests/v1/core/test_kv_cache_utils.py::test_metrics PASSED                                                                    [ 34%]
tests/v1/core/test_kv_cache_utils.py::test_metrics_empty_stats PASSED                                                        [ 35%]
tests/v1/core/test_kv_cache_utils.py::test_get_kv_cache_configs_multiple_workers PASSED                                      [ 36%]
tests/v1/core/test_kv_cache_utils.py::test_get_kv_cache_configs_pp_sharding[symmetric] PASSED                                [ 38%]
tests/v1/core/test_kv_cache_utils.py::test_get_kv_cache_configs_pp_sharding[asymmetric] PASSED                               [ 39%]
tests/v1/core/test_kv_cache_utils.py::test_project_kv_cache_groups_to_worker PASSED                                          [ 40%]
tests/v1/core/test_kv_cache_utils.py::test_uniform_type_spec_block_table_width_matches_layer_spec[mla-1-64] PASSED           [ 42%]
tests/v1/core/test_kv_cache_utils.py::test_uniform_type_spec_block_table_width_matches_layer_spec[mla-2-32] PASSED           [ 43%]
tests/v1/core/test_kv_cache_utils.py::test_uniform_type_spec_block_table_width_matches_layer_spec[mamba-2-3] PASSED          [ 44%]
tests/v1/core/test_kv_cache_utils.py::test_merge_kv_cache_spec PASSED                                                        [ 46%]
tests/v1/core/test_kv_cache_utils.py::test_is_kv_cache_spec_uniform PASSED                                                   [ 47%]
tests/v1/core/test_kv_cache_utils.py::test_estimate_max_model_len[Qwen/Qwen1.5-7B-16385-16384] PASSED                        [ 48%]
tests/v1/core/test_kv_cache_utils.py::test_estimate_max_model_len[Qwen/Qwen1.5-7B-16383-16383] PASSED                        [ 50%]
tests/v1/core/test_kv_cache_utils.py::test_get_max_concurrency_for_kv_cache_config PASSED                                    [ 51%]
tests/v1/core/test_kv_cache_utils.py::test_get_max_concurrency_packed_kv_cache_config PASSED                                 [ 52%]
tests/v1/core/test_kv_cache_utils.py::test_allocate_with_lookahead PASSED                                                    [ 53%]
tests/v1/core/test_kv_cache_utils.py::test_get_kv_cache_config_one_worker PASSED                                             [ 55%]
tests/v1/core/test_kv_cache_utils.py::test_get_kv_cache_configs_attention_free PASSED                                        [ 56%]
tests/v1/core/test_kv_cache_utils.py::test_generate_uniform_type_kv_cache_specs PASSED                                       [ 57%]
tests/v1/core/test_kv_cache_utils.py::test_generate_scheduler_kv_cache_config PASSED                                         [ 59%]
tests/v1/core/test_kv_cache_utils.py::test_mixed_precision_kv_cache_with_uniform_type_specs PASSED                           [ 60%]
tests/v1/core/test_kv_cache_utils.py::test_group_and_unify_kv_cache_specs_no_swa_mla_returns_none PASSED                     [ 61%]
tests/v1/core/test_kv_cache_utils.py::test_group_and_unify_kv_cache_specs_uniform_page_size_returns_none PASSED              [ 63%]
tests/v1/core/test_kv_cache_utils.py::test_group_and_unify_kv_cache_specs_mixed_page_size_groups PASSED                      [ 64%]
tests/v1/core/test_kv_cache_utils.py::test_mla_draft_prefers_standard_layout_when_pages_can_be_unified PASSED                [ 65%]
tests/v1/core/test_kv_cache_utils.py::test_mla_with_incompatible_swa_uses_one_full_allocation_group PASSED                   [ 67%]
tests/v1/core/test_kv_cache_utils.py::test_get_kv_cache_spec_kind_prefers_specific_attention_subclasses PASSED               [ 68%]
tests/v1/core/test_kv_cache_utils.py::test_get_kv_cache_spec_kind_unwraps_uniform_type_specs PASSED                          [ 69%]
tests/v1/core/test_kv_cache_utils.py::test_get_kv_cache_spec_kind_unknown_for_mixed_uniform_type_specs PASSED                [ 71%]
tests/v1/core/test_kv_cache_utils.py::test_get_kv_cache_spec_sliding_window_reads_windowed_specs PASSED                      [ 72%]
tests/v1/core/test_kv_cache_utils.py::test_get_kv_cache_spec_sliding_window_unwraps_uniform_type_specs PASSED                [ 73%]
tests/v1/core/test_kv_cache_utils.py::test_merge_mla_spec PASSED                                                             [ 75%]
tests/v1/core/test_kv_cache_utils.py::test_request_block_hasher_with_prompt_embeds[sha256] PASSED                            [ 76%]
tests/v1/core/test_kv_cache_utils.py::test_request_block_hasher_with_prompt_embeds[sha256_cbor] PASSED                       [ 77%]
tests/v1/core/test_kv_cache_utils.py::test_request_with_prompt_embeds_and_mm_inputs[sha256] PASSED                           [ 78%]
tests/v1/core/test_kv_cache_utils.py::test_request_with_prompt_embeds_and_mm_inputs[sha256_cbor] PASSED                      [ 80%]
tests/v1/core/test_kv_cache_utils.py::test_auto_fit_max_model_len PASSED                                                     [ 81%]
tests/v1/core/test_kv_cache_utils.py::test_auto_fit_max_model_len_with_hybrid PASSED                                         [ 82%]
tests/v1/core/test_kv_cache_utils.py::test_auto_fit_max_model_len_not_triggered PASSED                                       [ 84%]
tests/v1/core/test_kv_cache_utils.py::test_auto_fit_max_model_len_respects_num_gpu_blocks_override PASSED                    [ 85%]
tests/v1/core/test_kv_cache_utils.py::test_check_enough_kv_cache_memory_respects_num_gpu_blocks_override PASSED              [ 86%]
tests/v1/core/test_kv_cache_utils.py::test_unify_kv_cache_page_size_uses_padding_for_non_divisible_sizes PASSED              [ 88%]
tests/v1/core/test_kv_cache_utils.py::test_unify_kv_cache_page_size_padding_requires_backend_support PASSED                  [ 89%]
tests/v1/core/test_kv_cache_utils.py::test_unpadded_page_size_without_quant_matches_real_page PASSED                         [ 90%]
tests/v1/core/test_kv_cache_utils.py::test_unpadded_page_size_includes_per_token_head_scales PASSED                          [ 92%]
tests/v1/core/test_kv_cache_utils.py::test_page_size_padded_wins PASSED                                                      [ 93%]
tests/v1/core/test_kv_cache_utils.py::test_unify_hybrid_kv_cache_specs PASSED                                                [ 94%]
tests/v1/core/test_kv_cache_utils.py::test_unify_kv_cache_spec_page_size_mamba PASSED                                        [ 96%]
tests/v1/core/test_kv_cache_utils.py::test_hma_not_disabled_when_kv_events_enabled PASSED                                    [ 97%]
tests/v1/core/test_kv_cache_utils.py::test_resolve_block_hashes_gate PASSED                                                  [ 98%]
tests/v1/core/test_kv_cache_utils.py::test_resolve_block_hashes_rejects_mismatched_view PASSED                               [100%]

_========================================================= warnings summary =========================================================
tests/v1/core/test_kv_cache_utils.py: 14 warnings
  /usr/local/lib/python3.12/dist-packages/torch/jit/_script.py:365: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================= **_76 passed, 14 warnings in 54.41s_** =================================================


2. python -m pytest tests/v1/core/test_prefix_caching.py -v

======================================================= test session starts ========================================================
platform linux -- Python 3.12.13, pytest-9.1.1, pluggy-1.6.0 -- /usr/bin/python
cachedir: .pytest_cache
rootdir: /data/hf/vllm
configfile: pyproject.toml
plugins: asyncio-1.4.0, anyio-4.14.2
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 89 items                                                                                                                 

tests/v1/core/test_prefix_caching.py::test_prefill[sha256] PASSED                                                            [  1%]
tests/v1/core/test_prefix_caching.py::test_prefill[sha256_cbor] PASSED                                                       [  2%]
tests/v1/core/test_prefix_caching.py::test_prefill_hybrid_model PASSED                                                       [  3%]
tests/v1/core/test_prefix_caching.py::test_prefill_hybrid_model_eagle PASSED                                                 [  4%]
tests/v1/core/test_prefix_caching.py::test_prefill_hybrid_model_combinations[2g-full+sw] PASSED                              [  5%]
tests/v1/core/test_prefix_caching.py::test_prefill_hybrid_model_combinations[2g-full+mamba] PASSED                           [  6%]
tests/v1/core/test_prefix_caching.py::test_prefill_hybrid_model_combinations[2g-sw+mamba] PASSED                             [  7%]
tests/v1/core/test_prefix_caching.py::test_prefill_hybrid_model_combinations[2g-sw+sw_large] PASSED                          [  8%]
tests/v1/core/test_prefix_caching.py::test_prefill_hybrid_model_combinations[3g-full+2sw] PASSED                             [ 10%]
tests/v1/core/test_prefix_caching.py::test_prefill_hybrid_model_combinations[3g-full+2mamba] PASSED                          [ 11%]
tests/v1/core/test_prefix_caching.py::test_prefill_hybrid_model_combinations[3g-full+sw+mamba] PASSED                        [ 12%]
tests/v1/core/test_prefix_caching.py::test_prefill_hybrid_model_combinations[3g-full+sw+sw_large] PASSED                     [ 13%]
tests/v1/core/test_prefix_caching.py::test_prefill_hybrid_model_combinations[3g-2full+sw] PASSED                             [ 14%]
tests/v1/core/test_prefix_caching.py::test_prefill_hybrid_model_combinations[3g-2full+mamba] PASSED                          [ 15%]
tests/v1/core/test_prefix_caching.py::test_prefill_hybrid_model_combinations[4g-interleaved-full+sw+sw_large] PASSED         [ 16%]
tests/v1/core/test_prefix_caching.py::test_prefill_hybrid_model_combinations[4g-interleaved-full+mamba] PASSED               [ 17%]
tests/v1/core/test_prefix_caching.py::test_prefill_hybrid_model_combinations[4g-interleaved-full+sw_mixed] PASSED            [ 19%]
tests/v1/core/test_prefix_caching.py::test_prefill_hybrid_model_combinations[4g-sw+mamba+sw_large+mamba] PASSED              [ 20%]
tests/v1/core/test_prefix_caching.py::test_prefill_hybrid_model_combinations[4g-2full+sw+mamba] PASSED                       [ 21%]
tests/v1/core/test_prefix_caching.py::test_prefill_hybrid_model_combinations_eagle[2g-full+sw] PASSED                        [ 22%]
tests/v1/core/test_prefix_caching.py::test_prefill_hybrid_model_mamba_align PASSED                                           [ 23%]
tests/v1/core/test_prefix_caching.py::test_hybrid_cache_mamba_align_shared_prefix_detection PASSED                           [ 24%]
tests/v1/core/test_prefix_caching.py::test_hybrid_model_mamba_align_with_dynamic_draft_tokens PASSED                         [ 25%]
tests/v1/core/test_prefix_caching.py::test_prefill_plp PASSED                                                                [ 26%]
tests/v1/core/test_prefix_caching.py::test_decode PASSED                                                                     [ 28%]
tests/v1/core/test_prefix_caching.py::test_evict PASSED                                                                      [ 29%]
tests/v1/core/test_prefix_caching.py::test_hash_block_correct_reuse PASSED                                                   [ 30%]
tests/v1/core/test_prefix_caching.py::test_computed_blocks_not_evicted PASSED                                                [ 31%]
tests/v1/core/test_prefix_caching.py::test_basic_prefix_caching_disabled PASSED                                              [ 32%]
tests/v1/core/test_prefix_caching.py::test_cache_blocks[sha256] PASSED                                                       [ 33%]
tests/v1/core/test_prefix_caching.py::test_cache_blocks[sha256_cbor] PASSED                                                  [ 34%]
tests/v1/core/test_prefix_caching.py::test_cache_blocks_multi_group PASSED                                                   [ 35%]
tests/v1/core/test_prefix_caching.py::test_mm_prefix_caching PASSED                                                          [ 37%]
tests/v1/core/test_prefix_caching.py::test_cache_key_salting PASSED                                                          [ 38%]
tests/v1/core/test_prefix_caching.py::test_prefill_not_enough_free_blocks_with_computed_blocks PASSED                        [ 39%]
tests/v1/core/test_prefix_caching.py::test_reset_prefix_cache PASSED                                                         [ 40%]
tests/v1/core/test_prefix_caching.py::test_prefix_cache_stats_disabled PASSED                                                [ 41%]
tests/v1/core/test_prefix_caching.py::test_maybe_evict_cached_block PASSED                                                   [ 42%]
tests/v1/core/test_prefix_caching.py::test_kv_cache_events[2] PASSED                                                         [ 43%]
tests/v1/core/test_prefix_caching.py::test_kv_cache_events[3] PASSED                                                         [ 44%]
tests/v1/core/test_prefix_caching.py::test_kv_cache_events[10] PASSED                                                        [ 46%]
tests/v1/core/test_prefix_caching.py::test_null_parent_block_hash PASSED                                                     [ 47%]
tests/v1/core/test_prefix_caching.py::test_kv_cache_events_with_lora[2] PASSED                                               [ 48%]
tests/v1/core/test_prefix_caching.py::test_kv_cache_events_with_lora[3] PASSED                                               [ 49%]
tests/v1/core/test_prefix_caching.py::test_kv_cache_events_with_lora[10] PASSED                                              [ 50%]
tests/v1/core/test_prefix_caching.py::test_block_stored_event_group_idx[0] PASSED                                            [ 51%]
tests/v1/core/test_prefix_caching.py::test_block_stored_event_group_idx[1] PASSED                                            [ 52%]
tests/v1/core/test_prefix_caching.py::test_block_stored_event_group_idx[2] PASSED                                            [ 53%]
tests/v1/core/test_prefix_caching.py::test_block_stored_event_group_idx_multiple_groups PASSED                               [ 55%]
tests/v1/core/test_prefix_caching.py::test_block_stored_event_group_idx_out_of_bounds PASSED                                 [ 56%]
tests/v1/core/test_prefix_caching.py::test_block_removed_event_group_idx[0] PASSED                                           [ 57%]
tests/v1/core/test_prefix_caching.py::test_block_removed_event_group_idx[1] PASSED                                           [ 58%]
tests/v1/core/test_prefix_caching.py::test_block_removed_event_group_idx[2] PASSED                                           [ 59%]
tests/v1/core/test_prefix_caching.py::test_emit_cached_block_events PASSED                                                   [ 60%]
tests/v1/core/test_prefix_caching.py::test_emit_cached_block_events_disabled PASSED                                          [ 61%]
tests/v1/core/test_prefix_caching.py::test_emit_cached_block_events_zero_cached PASSED                                       [ 62%]
tests/v1/core/test_prefix_caching.py::test_eagle_enabled_removes_last_block PASSED                                           [ 64%]
tests/v1/core/test_prefix_caching.py::test_eagle_with_partial_blocks PASSED                                                  [ 65%]
tests/v1/core/test_prefix_caching.py::test_eagle_with_sliding_window PASSED                                                  [ 66%]
tests/v1/core/test_prefix_caching.py::test_eagle_swa_alignment_caches_extra_block PASSED                                     [ 67%]
tests/v1/core/test_prefix_caching.py::test_eagle_swa_boundary_caches_post_boundary_block PASSED                              [ 68%]
tests/v1/core/test_prefix_caching.py::test_eagle_grouped_swa_siblings_use_same_cache_mask PASSED                             [ 69%]
tests/v1/core/test_prefix_caching.py::test_different_block_size PASSED                                                       [ 70%]
tests/v1/core/test_prefix_caching.py::test_hybrid_cache_blocks_swa_tail_window_only PASSED                                   [ 71%]
tests/v1/core/test_prefix_caching.py::test_hybrid_cache_blocks_clamped_to_lcm PASSED                                         [ 73%]
tests/v1/core/test_prefix_caching.py::test_hybrid_local_kv_retention_interval_aligns_in_manager PASSED                       [ 74%]
tests/v1/core/test_prefix_caching.py::test_hybrid_local_kv_retention_interval_rejects_invalid[33-multiple of scheduler_block_size] PASSED [ 75%]
tests/v1/core/test_prefix_caching.py::test_hybrid_local_kv_retention_interval_rejects_invalid[-32-non-negative] PASSED       [ 76%]
tests/v1/core/test_prefix_caching.py::test_hybrid_local_kv_retention_interval_survives_recycling PASSED                      [ 77%]
tests/v1/core/test_prefix_caching.py::test_hybrid_local_kv_retention_latest_only_reuses_replay_boundary PASSED               [ 78%]
tests/v1/core/test_prefix_caching.py::test_hybrid_local_kv_retention_mtp_reuses_latest_boundary PASSED                       [ 79%]
tests/v1/core/test_prefix_caching.py::test_block_lookup_cache_single_block_per_key PASSED                                    [ 80%]
tests/v1/core/test_prefix_caching.py::test_block_lookup_cache_multi_blocks_per_key PASSED                                    [ 82%]
tests/v1/core/test_prefix_caching.py::test_can_fit_full_sequence_swa_cap_admits_long_prompt PASSED                           [ 83%]
tests/v1/core/test_prefix_caching.py::test_can_fit_full_sequence_full_attention_still_gates_oversized PASSED                 [ 84%]
tests/v1/core/test_prefix_caching.py::test_cache_hit_local_and_external PASSED                                               [ 85%]
tests/v1/core/test_prefix_caching.py::test_cache_hit_local_and_external_three_groups PASSED                                  [ 86%]
tests/v1/core/test_prefix_caching.py::test_cache_hit_local_and_external_three_groups_preempt_and_reallocate PASSED           [ 87%]
tests/v1/core/test_prefix_caching.py::test_cache_hit_local_and_external_two_groups_preempt_and_reallocate PASSED             [ 88%]
tests/v1/core/test_prefix_caching.py::test_swa_free_split_keeps_cached_tail_ahead_of_scratch PASSED                          [ 89%]
tests/v1/core/test_prefix_caching.py::test_pure_swa_retention_interval_caches_sparse_tails PASSED                            [ 91%]
tests/v1/core/test_prefix_caching.py::test_pure_swa_retention_latest_only PASSED                                             [ 92%]
tests/v1/core/test_prefix_caching.py::test_pure_swa_retention_dense_default_caches_all PASSED                                [ 93%]
tests/v1/core/test_prefix_caching.py::test_mamba_reachable_block_mask_sparsifies_retention PASSED                            [ 94%]
tests/v1/core/test_prefix_caching.py::test_mamba_reachable_block_mask_pins_shared_prefix PASSED                              [ 95%]
tests/v1/core/test_prefix_caching.py::test_mamba_shared_prefix_survives_zero_retention PASSED                                [ 96%]
tests/v1/core/test_prefix_caching.py::test_mamba_shared_prefix_reuse_under_zero_retention PASSED                             [ 97%]
tests/v1/core/test_prefix_caching.py::test_swa_reachable_block_mask_pins_shared_prefix PASSED                                [ 98%]
tests/v1/core/test_prefix_caching.py::test_swa_shared_prefix_reuse_under_zero_retention PASSED                               [100%]

========================================================= warnings summary =========================================================
../../../usr/local/lib/python3.12/dist-packages/torch/jit/_script.py:365: 14 warnings
  /usr/local/lib/python3.12/dist-packages/torch/jit/_script.py:365: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================= **_89 passed, 14 warnings in 20.60s_** =================================================

3. python -m pytest tests/v1/core/test_single_type_kv_cache_manager.py -v

======================================================= test session starts ========================================================
platform linux -- Python 3.12.13, pytest-9.1.1, pluggy-1.6.0 -- /usr/bin/python
cachedir: .pytest_cache
rootdir: /data/hf/vllm
configfile: pyproject.toml
plugins: asyncio-1.4.0, anyio-4.14.2
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 9 items                                                                                                                  

tests/v1/core/test_single_type_kv_cache_manager.py::test_chunked_local_attention_possible_cached_prefix PASSED               [ 11%]
tests/v1/core/test_single_type_kv_cache_manager.py::test_sliding_window_possible_cached_prefix PASSED                        [ 22%]
tests/v1/core/test_single_type_kv_cache_manager.py::test_chunked_local_attention_remove_skipped_blocks PASSED                [ 33%]
tests/v1/core/test_single_type_kv_cache_manager.py::test_sliding_window_remove_skipped_blocks PASSED                         [ 44%]
tests/v1/core/test_single_type_kv_cache_manager.py::test_rswa_remove_skipped_blocks_gap_range PASSED                         [ 55%]
tests/v1/core/test_single_type_kv_cache_manager.py::test_get_num_blocks_to_allocate PASSED                                   [ 66%]
tests/v1/core/test_single_type_kv_cache_manager.py::test_evictable_cached_blocks_not_double_allocated PASSED                 [ 77%]
tests/v1/core/test_single_type_kv_cache_manager.py::test_chunked_local_attention_get_num_blocks_to_allocate PASSED           [ 88%]
tests/v1/core/test_single_type_kv_cache_manager.py::test_predictor_matches_allocator_blocks_calculation_with_admission_cap PASSED [100%]

========================================================= warnings summary =========================================================
tests/v1/core/test_single_type_kv_cache_manager.py: 14 warnings
  /usr/local/lib/python3.12/dist-packages/torch/jit/_script.py:365: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================== **_9 passed, 14 warnings in 2.60s_** ==================================================
