### PR TITLE
[Core] Declare EAGLE cache-peek capability for KV cache managers

### DIFF
--- a/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
+++ b/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
@@ -1332,6 +1332,7 @@ def test_hybrid_partial_hit_with_eagle_stays_within_group_blocks():
         hash_block_size=hash_block_size,
         use_eagle=True,
     )
+    assert manager.coordinator.eagle_group_ids == {0}
 
     # The owner prefills in scheduler-split style: stop at the block boundary
     # (4), then at the prompt's last hash boundary (6, partial entries).

--- a/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
+++ b/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
@@ -1160,6 +1160,7 @@ def test_hybrid_partial_hit_with_eagle_stays_within_group_blocks():
         hash_block_size=hash_block_size,
         use_eagle=True,
     )
+    assert manager.coordinator.eagle_group_ids == {0}
 
     # The owner prefills in scheduler-split style: stop at the block boundary
     # (4), then at the prompt's last hash boundary (6, partial entries).

--- a/tests/v1/core/test_single_type_kv_cache_manager.py
+++ b/tests/v1/core/test_single_type_kv_cache_manager.py
@@ -14,6 +14,9 @@ from vllm.v1.core.kv_cache_utils import (
 )
 from vllm.v1.core.single_type_kv_cache_manager import (
     ChunkedLocalAttentionManager,
+    CrossAttentionManager,
+    FullAttentionManager,
+    MambaManager,
     RSWAManager,
     SlidingWindowManager,
 )
@@ -24,6 +27,20 @@ from vllm.v1.kv_cache_interface import (
 )
 
 pytestmark = pytest.mark.cpu_test
+
+
+@pytest.mark.parametrize(
+    ("manager", "expected"),
+    [
+        (FullAttentionManager, True),
+        (SlidingWindowManager, True),
+        (ChunkedLocalAttentionManager, False),
+        (MambaManager, False),
+        (CrossAttentionManager, False),
+    ],
+)
+def test_manager_declares_eagle_cache_peek_capability(manager, expected):
+    assert manager.supports_eagle_cache_peek is expected
 
 
 def get_sliding_window_manager(sliding_window_spec, block_pool, enable_caching=True):

--- a/tests/v1/core/test_single_type_kv_cache_manager.py
+++ b/tests/v1/core/test_single_type_kv_cache_manager.py
@@ -14,6 +14,9 @@ from vllm.v1.core.kv_cache_utils import (
 )
 from vllm.v1.core.single_type_kv_cache_manager import (
     ChunkedLocalAttentionManager,
+    CrossAttentionManager,
+    FullAttentionManager,
+    MambaManager,
     RSWAManager,
     SlidingWindowManager,
 )
@@ -24,6 +27,20 @@ from vllm.v1.kv_cache_interface import (
 )
 
 pytestmark = pytest.mark.cpu_test
+
+
+@pytest.mark.parametrize(
+    ("manager", "expected"),
+    [
+        (FullAttentionManager, True),
+        (SlidingWindowManager, True),
+        (ChunkedLocalAttentionManager, False),
+        (MambaManager, False),
+        (CrossAttentionManager, False),
+    ],
+)
+def test_manager_declares_eagle_cache_peek_capability(manager, expected):
+    assert manager.supports_eagle_cache_peek is expected
 
 
 def get_sliding_window_manager(

--- a/tests/v1/kv_connector/unit/offloading_connector/test_config.py
+++ b/tests/v1/kv_connector/unit/offloading_connector/test_config.py
@@ -326,6 +326,21 @@ def test_dcp_scales_attention_but_not_mamba_group_blocks():
     ] == [1, 3]
 
 
+def test_eagle_fallback_excludes_mamba_offload_group():
+    config = _make_vllm_config()
+    config.speculative_config = MagicMock()
+    config.speculative_config.use_eagle.return_value = True
+    kv_cache_config = _make_mamba_hybrid_kv_cache_config()
+    offloading_config = build_offloading_config(config, kv_cache_config)
+
+    scheduler_config = SchedulerOffloadConfig.from_spec(
+        MockOffloadingSpec(offloading_config), config, kv_cache_config
+    )
+
+    assert scheduler_config.kv_group_configs[0].is_eagle_group
+    assert not scheduler_config.kv_group_configs[1].is_eagle_group
+
+
 def test_preserves_data_parallel_index():
     config = _make_vllm_config()
     config.parallel_config.data_parallel_index = 2

--- a/tests/v1/kv_connector/unit/offloading_connector/test_config.py
+++ b/tests/v1/kv_connector/unit/offloading_connector/test_config.py
@@ -323,6 +323,21 @@ def test_dcp_scales_attention_but_not_mamba_group_blocks():
     ] == [1, 3]
 
 
+def test_eagle_fallback_excludes_mamba_offload_group():
+    config = _make_vllm_config()
+    config.speculative_config = MagicMock()
+    config.speculative_config.use_eagle.return_value = True
+    kv_cache_config = _make_mamba_hybrid_kv_cache_config()
+    offloading_config = build_offloading_config(config, kv_cache_config)
+
+    scheduler_config = SchedulerOffloadConfig.from_spec(
+        MockOffloadingSpec(offloading_config), config, kv_cache_config
+    )
+
+    assert scheduler_config.kv_group_configs[0].is_eagle_group
+    assert not scheduler_config.kv_group_configs[1].is_eagle_group
+
+
 def test_preserves_data_parallel_index():
     config = _make_vllm_config()
     config.parallel_config.data_parallel_index = 2

--- a/tests/v1/kv_connector/unit/test_mooncake_store_coordinator.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_coordinator.py
@@ -3,6 +3,7 @@
 
 from math import lcm
 
+import pytest
 import torch
 
 from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.coordinator import (  # noqa: E501
@@ -545,13 +546,13 @@ def _mamba(block_size=16):
 def test_lookup_with_eagle_hybrid_full_plus_mamba_no_overrun():
     """Full+Mamba with eagle must not overrun the attention-verified hit.
 
-    ``MambaManager`` ignores ``drop_eagle_block`` (a Mamba block at position
+    ``MambaManager`` cannot honor ``drop_eagle_block`` (a Mamba block at position
     p IS the recurrent state after (p + 1) * block_size tokens; there is
     nothing to recompute), so granting the Mamba group the one-block eagle
     peek margin lets it match one block PAST the eagle-pruned full-attention
     hit, and adopting that length resumes the recurrent state ahead of the
-    verified token prefix (#43559). Gating the margin on ``not
-    isinstance(spec, MambaSpec)`` pins the hit to the attention-verified 48.
+    verified token prefix (#43559). Gating the margin on the manager capability
+    pins the hit to the attention-verified 48.
     """
     groups = [
         KVCacheGroupSpec(["L0"], _full(16)),
@@ -567,6 +568,24 @@ def test_lookup_with_eagle_hybrid_full_plus_mamba_no_overrun():
     # FullAttn matches 4 blocks, eagle pops 1 -> 48 verified tokens. The
     # Mamba group must serve its state@48 snapshot, not peek to state@64.
     assert hit == 48
+
+
+def test_eagle_fallback_excludes_manager_without_cache_peek_support():
+    groups = [
+        KVCacheGroupSpec(["L0"], _full(16)),
+        KVCacheGroupSpec(["L1"], _mamba(16)),
+    ]
+
+    coord = _make_coord(groups, hash_block_size=16, use_eagle=True)
+
+    assert coord.eagle_group_ids == {0}
+
+
+def test_explicit_eagle_group_without_cache_peek_support_fails_closed():
+    groups = [KVCacheGroupSpec(["L0"], _mamba(16), is_eagle_group=True)]
+
+    with pytest.raises(ValueError, match=r"not supported for KV cache groups \[0\]"):
+        _make_coord(groups, hash_block_size=16, use_eagle=True)
 
 
 def test_eagle_flag_propagates_to_all_merged_swa_groups():

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/coordinator.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/coordinator.py
@@ -102,6 +102,9 @@ class MooncakeStoreCoordinator:
         """Mirrors KVCacheCoordinator.verify_and_split_kv_cache_groups but
         dispatches via spec_manager_map (we don't allocate managers).
         """
+        eagle_group_ids = KVCacheSpecRegistry.get_eagle_cache_peek_group_ids(
+            self.kv_cache_groups, self.use_eagle
+        )
         attention_groups: list[SpecGroup] = []
         for i, g in enumerate(self.kv_cache_groups):
             spec = _unwrap_spec(g.kv_cache_spec)
@@ -113,18 +116,15 @@ class MooncakeStoreCoordinator:
                 if group.spec == spec:
                     assert manager_cls is group.manager_cls
                     group.group_ids.append(i)
-                    if g.is_eagle_group and not group.use_eagle:
+                    if i in eagle_group_ids and not group.use_eagle:
                         attention_groups[idx] = group._replace(use_eagle=True)
                     break
             else:
                 attention_groups.append(
-                    SpecGroup(spec, [i], manager_cls, g.is_eagle_group)
+                    SpecGroup(spec, [i], manager_cls, i in eagle_group_ids)
                 )
         # Full attention first (matches upstream convergence ordering).
         attention_groups.sort(key=lambda g: not isinstance(g.spec, FullAttentionSpec))
-        # Conservatively flag all groups when use_eagle is set but none is flagged.
-        if self.use_eagle and not any(g.use_eagle for g in attention_groups):
-            attention_groups = [g._replace(use_eagle=True) for g in attention_groups]
         self.attention_groups = attention_groups
         # Per-group eagle bits. SpecGroup carries use_eagle for the whole
         # merged spec group, so the per-group store/lookup masks agree with
@@ -337,10 +337,9 @@ class MooncakeStoreCoordinator:
                     apply_eagle and group_eagle and idx not in eagle_verified
                 )
                 _max_length = curr_hit_length
-                # No eagle peek margin for a recurrent (Mamba) group: its finder
-                # never drops a block, so a widened bound would match past the
-                # attention-verified hit and resume from speculative state (#43559).
-                if drop_eagle_block and not isinstance(spec, MambaSpec):
+                # Only widen managers that can drop back to the verified
+                # candidate boundary.
+                if drop_eagle_block and manager_cls.supports_eagle_cache_peek:
                     eagle_margin = (
                         self.hash_block_size
                         if self.enable_partial_hash_hits

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
@@ -38,6 +38,7 @@ from vllm.v1.kv_cache_interface import (
     MambaSpec,
     SlidingWindowSpec,
 )
+from vllm.v1.kv_cache_spec_registry import KVCacheSpecRegistry
 from vllm.v1.kv_offload.base import (
     GPULoadStoreSpec,
     Locality,
@@ -217,18 +218,13 @@ class SchedulerOffloadConfig(NamedTuple):
                 return None
             return per_segment
 
-        eagle_groups = {
-            idx
-            for idx, g in enumerate(kv_cache_config.kv_cache_groups)
-            if g.is_eagle_group
-        }
-
         use_eagle = (
             vllm_config.speculative_config is not None
             and vllm_config.speculative_config.use_eagle()
         )
-        if use_eagle and not eagle_groups:
-            eagle_groups = set(range(len(kv_cache_config.kv_cache_groups)))
+        eagle_groups = KVCacheSpecRegistry.get_eagle_cache_peek_group_ids(
+            kv_cache_config.kv_cache_groups, use_eagle
+        )
 
         if eagle_groups:
             logger.info(

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
@@ -37,6 +37,7 @@ from vllm.v1.kv_cache_interface import (
     MambaSpec,
     SlidingWindowSpec,
 )
+from vllm.v1.kv_cache_spec_registry import KVCacheSpecRegistry
 from vllm.v1.kv_offload.base import (
     GPULoadStoreSpec,
     Locality,
@@ -208,18 +209,13 @@ class SchedulerOffloadConfig(NamedTuple):
                 return None
             return per_segment
 
-        eagle_groups = {
-            idx
-            for idx, g in enumerate(kv_cache_config.kv_cache_groups)
-            if g.is_eagle_group
-        }
-
         use_eagle = (
             vllm_config.speculative_config is not None
             and vllm_config.speculative_config.use_eagle()
         )
-        if use_eagle and not eagle_groups:
-            eagle_groups = set(range(len(kv_cache_config.kv_cache_groups)))
+        eagle_groups = KVCacheSpecRegistry.get_eagle_cache_peek_group_ids(
+            kv_cache_config.kv_cache_groups, use_eagle
+        )
 
         if eagle_groups:
             logger.info(

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -24,6 +24,7 @@ from vllm.v1.kv_cache_interface import (
     MambaSpec,
     SlidingWindowSpec,
 )
+from vllm.v1.kv_cache_spec_registry import KVCacheSpecRegistry
 from vllm.v1.request import Request
 
 
@@ -96,12 +97,9 @@ class KVCacheCoordinator(ABC):
         )
 
         # KV cache group indices that get the EAGLE last-block drop.
-        self.eagle_group_ids: set[int] = {
-            i for i, g in enumerate(kv_cache_config.kv_cache_groups) if g.is_eagle_group
-        }
-        # Conservatively fall back to flag all groups when no group is flagged.
-        if use_eagle and not self.eagle_group_ids:
-            self.eagle_group_ids = set(range(len(kv_cache_config.kv_cache_groups)))
+        self.eagle_group_ids = KVCacheSpecRegistry.get_eagle_cache_peek_group_ids(
+            kv_cache_config.kv_cache_groups, use_eagle
+        )
 
         self.single_type_managers = tuple(
             get_manager_for_kv_cache_spec(
@@ -749,10 +747,9 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
                 _max_length = curr_hit_length
                 # Eagle matches one extra drop unit (one hash unit for
                 # fine-grained managers, else one cache block) and then drops
-                # it, landing back at the candidate length. No margin for
-                # mamba: its finder never drops (draft models have no mamba
-                # layers), so the hit would grow past the candidate.
-                if drop_eagle_block and not isinstance(spec, MambaSpec):
+                # it, landing back at the candidate length. Managers that
+                # cannot rewind recurrent state must not receive that margin.
+                if drop_eagle_block and manager_cls.supports_eagle_cache_peek:
                     eagle_margin = (
                         self.hash_block_size
                         if self.enable_partial_hash_hits

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -40,6 +40,7 @@ class SingleTypeKVCacheManager(ABC):
     """
 
     supports_fine_grained_hash_lookup: ClassVar[bool] = False
+    supports_eagle_cache_peek: ClassVar[bool] = False
 
     def __init__(
         self,
@@ -677,6 +678,7 @@ class SingleTypeKVCacheManager(ABC):
 
 class FullAttentionManager(SingleTypeKVCacheManager):
     supports_fine_grained_hash_lookup: ClassVar[bool] = True
+    supports_eagle_cache_peek: ClassVar[bool] = True
 
     @classmethod
     def find_longest_cache_hit(
@@ -876,6 +878,8 @@ class RSWAManager(FullAttentionManager):
 
 
 class SlidingWindowManager(SingleTypeKVCacheManager):
+    supports_eagle_cache_peek: ClassVar[bool] = True
+
     def __init__(self, kv_cache_spec: SlidingWindowSpec, **kwargs) -> None:
         super().__init__(kv_cache_spec, **kwargs)
         self.sliding_window = kv_cache_spec.sliding_window
@@ -1291,6 +1295,9 @@ class MambaManager(SingleTypeKVCacheManager):
     ) -> tuple[tuple[list[KVCacheBlock], ...], int]:
         assert isinstance(kv_cache_spec, MambaSpec), (
             "MambaManager can only be used for mamba groups"
+        )
+        assert not drop_eagle_block, (
+            "MambaManager cannot drop an EAGLE/MTP cache-peek state"
         )
         assert dcp_world_size == 1, "DCP not support mamba now."
         assert pcp_world_size == 1, "PCP not support mamba now."

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -41,6 +41,7 @@ class SingleTypeKVCacheManager(ABC):
     """
 
     supports_fine_grained_hash_lookup: ClassVar[bool] = False
+    supports_eagle_cache_peek: ClassVar[bool] = False
 
     def __init__(
         self,
@@ -675,6 +676,7 @@ class SingleTypeKVCacheManager(ABC):
 
 class FullAttentionManager(SingleTypeKVCacheManager):
     supports_fine_grained_hash_lookup: ClassVar[bool] = True
+    supports_eagle_cache_peek: ClassVar[bool] = True
 
     @classmethod
     def find_longest_cache_hit(
@@ -874,6 +876,8 @@ class RSWAManager(FullAttentionManager):
 
 
 class SlidingWindowManager(SingleTypeKVCacheManager):
+    supports_eagle_cache_peek: ClassVar[bool] = True
+
     def __init__(self, kv_cache_spec: SlidingWindowSpec, **kwargs) -> None:
         super().__init__(kv_cache_spec, **kwargs)
         self.sliding_window = kv_cache_spec.sliding_window
@@ -1289,6 +1293,9 @@ class MambaManager(SingleTypeKVCacheManager):
     ) -> tuple[tuple[list[KVCacheBlock], ...], int]:
         assert isinstance(kv_cache_spec, MambaSpec), (
             "MambaManager can only be used for mamba groups"
+        )
+        assert not drop_eagle_block, (
+            "MambaManager cannot drop an EAGLE/MTP cache-peek state"
         )
         assert dcp_world_size == 1, "DCP not support mamba now."
         assert pcp_world_size == 1, "PCP not support mamba now."

--- a/vllm/v1/kv_cache_spec_registry.py
+++ b/vllm/v1/kv_cache_spec_registry.py
@@ -9,6 +9,7 @@ subclasses without modifying vLLM core code. Out-of-tree platforms can define
 custom specs and managers by using the @register_kv_cache_spec decorator.
 """
 
+from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -18,7 +19,7 @@ logger = init_logger(__name__)
 
 if TYPE_CHECKING:
     from vllm.v1.core.single_type_kv_cache_manager import SingleTypeKVCacheManager
-    from vllm.v1.kv_cache_interface import KVCacheSpec
+    from vllm.v1.kv_cache_interface import KVCacheGroupSpec, KVCacheSpec
 
 
 @dataclass(frozen=True)
@@ -124,6 +125,39 @@ class KVCacheSpecRegistry:
                 return _REGISTRY_KVCACHESPEC_LIST[base].manager_class
 
         return None
+
+    @classmethod
+    def get_eagle_cache_peek_group_ids(
+        cls,
+        kv_cache_groups: Sequence["KVCacheGroupSpec"],
+        use_eagle: bool,
+    ) -> set[int]:
+        """Resolve EAGLE groups without granting unsupported cache peeks."""
+        group_ids = {
+            i for i, group in enumerate(kv_cache_groups) if group.is_eagle_group
+        }
+        if not use_eagle:
+            return group_ids
+
+        unsupported_group_ids = []
+        for i in group_ids:
+            manager_cls = cls.get_manager_class(kv_cache_groups[i].kv_cache_spec)
+            if manager_cls is not None and not manager_cls.supports_eagle_cache_peek:
+                unsupported_group_ids.append(i)
+        if unsupported_group_ids:
+            raise ValueError(
+                "EAGLE/MTP cache peek is not supported for KV cache groups "
+                f"{unsupported_group_ids}"
+            )
+        if group_ids:
+            return group_ids
+
+        capable_group_ids = set()
+        for i, group in enumerate(kv_cache_groups):
+            manager_cls = cls.get_manager_class(group.kv_cache_spec)
+            if manager_cls is not None and manager_cls.supports_eagle_cache_peek:
+                capable_group_ids.add(i)
+        return capable_group_ids
 
     @classmethod
     def get_uniform_type_base_spec(


### PR DESCRIPTION
## Summary

- declare whether each KV cache manager can safely peek past an EAGLE/MTP candidate boundary
- resolve EAGLE cache-peek groups through the shared KV cache spec registry
- exclude recurrent and otherwise unsupported cache managers from the fallback
- fail closed when an unsupported group is explicitly annotated
- apply the shared capability in the core, Mooncake store, and offloading paths

Fixes #50630.

## Root cause

When no KV cache group was explicitly annotated for EAGLE, several paths
conservatively treated every group as an EAGLE group. This is safe only for
managers that can drop the extra matched cache unit. Recurrent Mamba state
cannot be rewound this way, so each caller had to exclude Mamba manually.

The new manager capability makes this invariant explicit and defaults to
unsupported. Full-attention and sliding-window managers opt in.

## Duplicate-work check

Before opening this PR, issue #50630 and its comments were checked. Open PR
searches by issue number and by the EAGLE/cache-peek/Mamba area found no PR
addressing the same change.

## Tests

Linux, Python 3.10.12:

- Focused regression tests: `10 passed, 14 warnings in 2.71s`
- Related test files: `109 passed, 14 warnings in 21.33s`
- `ruff check`: passed
- `ruff format --check`: 9 files already formatted
- `git diff --check`: passed

The warnings are existing PyTorch `torch.jit.script_method` deprecation
warnings.

No model evaluation or GPU benchmark was run because this is a control-plane
KV-cache capability and boundary-selection change covered by unit tests.

## AI assistance

AI assistance was used for test design, and PR drafting. The human submitter reviewed the changes and ran the reported tests.