### PR TITLE
[Kimi K3][Structured Output] Fix `tool_open` special token leakage into response text content

### DIFF
--- a/tests/tool_parsers/test_structural_tag_registry.py
+++ b/tests/tool_parsers/test_structural_tag_registry.py
@@ -357,6 +357,34 @@ def test_kimi_k3_auto_strict_allows_response_only(sample_tools_strict):
     assert _is_grammar_accept_string(grammar, _k3_response("Just answering."))
 
 
+# The response body must not be able to host channel markers or the terminator:
+# an unbounded any_text turns tool_choice="required" into a no-op (the model can
+# type the tool call as prose and stop). See _k3_response_prefix.
+@pytest.mark.parametrize(
+    "body",
+    [
+        # tools-open marker typed as response text, response never closed
+        _K3_RESPONSE_OPEN
+        + "I will call the tool."
+        + _k3_tools(_k3_call("get_weather", _k3_arg("city", "string", "Paris"))),
+        # tools-open marker as prose, then a well-formed call
+        _K3_RESPONSE_OPEN
+        + "calling "
+        + _K3_TOOLS_OPEN
+        + _K3_RESPONSE_CLOSE
+        + _k3_tools(_k3_call("get_weather", _k3_arg("city", "string", "Paris"))),
+        # end-of-message token typed as response text
+        _K3_RESPONSE_OPEN + "bye<|end_of_msg|>",
+        # turn trailer smuggled into the body
+        _K3_RESPONSE_OPEN + "done<|close|>message<|sep|>",
+    ],
+)
+def test_kimi_k3_response_body_rejects_channel_markers(body: str):
+    assert not _is_grammar_accept_string(
+        _k3_grammar("required"), body, require_termination=False
+    )
+
+
 @pytest.mark.parametrize("model", sorted(XGRAMMAR_BUILTIN_STRUCTURAL_TAG_MODELS))
 def test_get_model_structural_tag_supports_named_tool_choice(
     model: str,

--- a/tests/tool_use/test_kimi_k3_tool_parser.py
+++ b/tests/tool_use/test_kimi_k3_tool_parser.py
@@ -604,3 +604,48 @@ def test_chat_params_keeps_template_tool_choice_when_api_auto():
 
     assert chat_params.chat_template_kwargs["tool_choice"] == "required"
     assert chat_params.tool_choice == "auto"
+
+
+# A tools marker can appear inside the response channel (the model typing it, or
+# an echo from the prompt). The real call must still be found, and the marker
+# must not surface as user-visible content.
+def test_extract_skips_marker_in_response_body_and_finds_real_call():
+    parser = KimiK3ToolParser(DummyTokenizer())
+    output = (
+        "<|open|>response<|sep|>Let me check.<|open|>tools<|sep|><|close|>tools<|sep|>"
+        "<|close|>response<|sep|>"
+        '<|open|>tools<|sep|><|open|>call tool="get_weather" index="1"<|sep|>'
+        '<|open|>argument key="city" type="string"<|sep|>Paris<|close|>argument<|sep|>'
+        "<|close|>call<|sep|><|close|>tools<|sep|>"
+    )
+
+    result = parser.extract_tool_calls(output, _request())
+
+    assert result.tools_called
+    assert [tc.function.name for tc in result.tool_calls] == ["get_weather"]
+    assert result.content == "Let me check."
+
+
+def test_extract_keeps_content_that_merely_looks_like_a_marker_start():
+    # A trailing "<" is content, not a truncated marker: an end-to-end probe
+    # showed an answer of "3 <" losing its last character.
+    parser = KimiK3ToolParser(DummyTokenizer())
+
+    for body in ("3 <", "a < b", "compare 5 <"):
+        result = parser.extract_tool_calls(
+            f"<|open|>response<|sep|>{body}<|close|>response<|sep|>", _request()
+        )
+        assert result.content == body
+
+
+def test_extract_does_not_leak_a_dangling_marker_into_content():
+    # Generation stopped mid-marker inside the response channel: the partial
+    # marker is held back, like the streaming path does.
+    parser = KimiK3ToolParser(DummyTokenizer())
+
+    result = parser.extract_tool_calls(
+        "<|open|>response<|sep|>Let me check.<|open|>tools", _request()
+    )
+
+    assert not result.tools_called
+    assert result.content == "Let me check."

--- a/tests/v1/structured_output/test_xgrammar_stop_tokens.py
+++ b/tests/v1/structured_output/test_xgrammar_stop_tokens.py
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""The grammar must guard every token the engine stops on.
+
+Kimi K3's tokenizer eos is ``[EOS]`` while the model ends a turn with
+``<|end_of_msg|>`` (``generation_config.json``). Guarding only the tokenizer's
+id lets the real terminator be matched as ordinary text, so a grammar that is
+not satisfied yet cannot hold generation back.
+"""
+
+from types import SimpleNamespace
+
+from vllm.v1.structured_output.backend_xgrammar import engine_stop_token_ids
+
+
+def _config(hf_eos, generation_eos, raises=False):
+    def try_get_generation_config():
+        if raises:
+            raise RuntimeError("no generation config")
+        return {} if generation_eos is None else {"eos_token_id": generation_eos}
+
+    model_config = SimpleNamespace(
+        hf_text_config=SimpleNamespace(eos_token_id=hf_eos),
+        hf_config=SimpleNamespace(eos_token_id=hf_eos),
+        try_get_generation_config=try_get_generation_config,
+    )
+    return SimpleNamespace(model_config=model_config)
+
+
+def test_union_of_tokenizer_and_model_eos():
+    # K3 shape: tokenizer says [EOS]=163585, the model ends turns with 163586.
+    ids = engine_stop_token_ids(
+        _config(163586, 163586), SimpleNamespace(eos_token_id=163585)
+    )
+    assert ids == [163585, 163586]
+
+
+def test_generation_config_eos_list_is_included():
+    ids = engine_stop_token_ids(_config(None, [7, 9]), SimpleNamespace(eos_token_id=1))
+    assert ids == [1, 7, 9]
+
+
+def test_single_eos_is_unchanged():
+    ids = engine_stop_token_ids(_config(2, 2), SimpleNamespace(eos_token_id=2))
+    assert ids == [2]
+
+
+def test_unreadable_generation_config_is_not_fatal():
+    ids = engine_stop_token_ids(
+        _config(5, None, raises=True), SimpleNamespace(eos_token_id=4)
+    )
+    assert ids == [4, 5]

--- a/vllm/tool_parsers/kimi_k3_tool_parser.py
+++ b/vllm/tool_parsers/kimi_k3_tool_parser.py
@@ -264,9 +264,28 @@ class KimiK3ToolParser(ToolParser):
     def _content(self, model_output: str, before: str) -> str | None:
         # prefer the unwrapped response channel; else the text before the tools
         m = self._response_re.search(model_output)
-        if m is not None:
-            return m["c"] or None
-        return self._strip_response_content(before)
+        body = m["c"] if m is not None else self._strip_response_content(before)
+        return self._trim_channel_markers(body)
+
+    def _trim_channel_markers(self, body: str | None) -> str | None:
+        """Drop a tools channel (or a dangling partial marker) from the body.
+
+        The response body is returned raw, so a marker the model typed inside
+        the channel would otherwise surface as user-visible content. Streaming
+        already stops at the tools marker and holds back partial markers
+        (see ``_extract_response_content``); do the same here.
+        """
+        if not body:
+            return None
+        m_tools = self._tools_open_re.search(body)
+        if m_tools is not None:
+            body = body[: m_tools.start()]
+        # Only hold back a marker the model actually started: a lone "<" is far
+        # more likely to be content than a truncated channel marker.
+        overlap = _partial_tag_overlap(body, self.tools_open)
+        if overlap > 1:
+            body = body[: len(body) - overlap]
+        return body or None
 
     def _extract_response_content(self, current_text: str) -> str | None:
         # Streaming response text is computed from the accumulated text. This is
@@ -320,20 +339,28 @@ class KimiK3ToolParser(ToolParser):
                 content=self._content(model_output, model_output),
             )
         try:
+            # A tools marker can also show up as response text (the model
+            # typing it, or an echo of it in the prompt). Anchoring blindly on
+            # the first one drops the real call that follows, so scan the
+            # sections in order and keep the first one that carries a call.
             before = model_output[: m_open.start()]
-            start = m_open.end()
-            m_close = self._tools_close_re.search(model_output, start)
-            section = (
-                model_output[start:]
-                if m_close is None
-                else model_output[start : m_close.start()]
-            )
-
-            tool_calls = [
-                tc
-                for m in self._call_re.finditer(section)
-                if (tc := self._decode_call(m["attrs"], m["body"])) is not None
-            ]
+            tool_calls: list[ToolCall] = []
+            for m_open in self._tools_open_re.finditer(model_output):
+                start = m_open.end()
+                m_close = self._tools_close_re.search(model_output, start)
+                section = (
+                    model_output[start:]
+                    if m_close is None
+                    else model_output[start : m_close.start()]
+                )
+                tool_calls = [
+                    tc
+                    for m in self._call_re.finditer(section)
+                    if (tc := self._decode_call(m["attrs"], m["body"])) is not None
+                ]
+                if tool_calls:
+                    before = model_output[: m_open.start()]
+                    break
             if not tool_calls:
                 return ExtractedToolCallInformation(
                     tools_called=False,

--- a/vllm/tool_parsers/structural_tag_registry.py
+++ b/vllm/tool_parsers/structural_tag_registry.py
@@ -376,6 +376,7 @@ _K3_ARG_CLOSE = f"{_K3_CLOSE}argument{_K3_SEP}"
 # the end-of-message token. It is generated (not part of the prompt prefix), so
 # the tag must permit it or the FSM would mask the model's natural terminator.
 _K3_MESSAGE_CLOSE = f"{_K3_CLOSE}message{_K3_SEP}"
+_K3_END_OF_MSG = "<|end_of_msg|>"
 
 # JSON-schema type -> K3 XTML ``type=`` attribute value. Mirrors
 # ``encoding_k3._xtml_type`` (integer collapses onto number).
@@ -558,10 +559,27 @@ def _k3_response_prefix() -> list[Any]:
     ``<|open|>think<|sep|>``) but is part of the generation prefix in
     non-thinking mode, so its open marker is optional. The body is bounded by
     the response close marker.
+
+    The body must exclude the channel markers and the end-of-message token:
+    an unbounded ``any_text`` would let the model type ``<|open|>tools<|sep|>``
+    (or terminate) inside the response, which makes the whole constraint a
+    no-op -- ``tool_choice="required"`` would no longer pin generation to the
+    tool-call channel.
     """
     return [
         OptionalFormat(content=ConstStringFormat(value=_K3_RESPONSE_OPEN)),
-        TagFormat(begin="", content=AnyTextFormat(), end=_K3_RESPONSE_CLOSE),
+        TagFormat(
+            begin="",
+            content=AnyTextFormat(
+                excludes=[
+                    _K3_RESPONSE_CLOSE,
+                    _K3_TOOLS_OPEN,
+                    _K3_MESSAGE_CLOSE,
+                    _K3_END_OF_MSG,
+                ]
+            ),
+            end=_K3_RESPONSE_CLOSE,
+        ),
     ]
 
 

--- a/vllm/v1/structured_output/backend_xgrammar.py
+++ b/vllm/v1/structured_output/backend_xgrammar.py
@@ -26,10 +26,50 @@ from vllm.v1.structured_output.utils import (
 
 if TYPE_CHECKING:
     import xgrammar as xgr
+
+    from vllm.config import VllmConfig
 else:
     xgr = LazyLoader("xgr", globals(), "xgrammar")
 
 logger = init_logger(__name__)
+
+
+def _as_token_id_list(value: Any) -> list[int]:
+    if isinstance(value, int):
+        return [value]
+    if isinstance(value, (list, tuple, set)):
+        return [v for v in value if isinstance(v, int)]
+    return []
+
+
+def engine_stop_token_ids(vllm_config: "VllmConfig", tokenizer: Any) -> list[int]:
+    """Stop tokens the engine actually stops on, for xgrammar to guard.
+
+    xgrammar infers its stop token from the tokenizer, but the engine stops on
+    the model's ``eos_token_id`` (``generation_config.json`` / ``config.json``),
+    which can be a different token: Kimi K3 has ``eos_token`` ``[EOS]`` while
+    the model terminates the turn with ``<|end_of_msg|>``. When the two
+    disagree, the grammar guards the wrong id -- the real terminator is then
+    matched as ordinary text (so a grammar that is not yet satisfied cannot
+    hold generation back) while the engine's terminator stays masked at
+    completion. Guard the union so neither id can end a request mid-grammar.
+    """
+    stop_token_ids = set(_as_token_id_list(getattr(tokenizer, "eos_token_id", None)))
+    model_config = vllm_config.model_config
+    for hf_config in (
+        getattr(model_config, "hf_text_config", None),
+        getattr(model_config, "hf_config", None),
+    ):
+        stop_token_ids.update(
+            _as_token_id_list(getattr(hf_config, "eos_token_id", None))
+        )
+    try:
+        generation_config = model_config.try_get_generation_config()
+    except Exception:
+        logger.warning("Could not read the generation config for stop token ids.")
+    else:
+        stop_token_ids.update(_as_token_id_list(generation_config.get("eos_token_id")))
+    return sorted(stop_token_ids)
 
 
 @dataclass
@@ -61,6 +101,7 @@ class XgrammarBackend(StructuredOutputBackend):
             tokenizer_info = xgr.TokenizerInfo.from_huggingface(
                 self.tokenizer,
                 vocab_size=self.vocab_size,
+                stop_token_ids=engine_stop_token_ids(self.vllm_config, self.tokenizer),
             )
         self.compiler = xgr.GrammarCompiler(
             tokenizer_info,


### PR DESCRIPTION
## Summary

Constrained tool calling for `moonshotai/Kimi-K3` does not actually constrain: with `tool_choice="required"` the model can write its tool call as prose inside the response channel and end the turn there, so the response comes back with `<|open|>tools` visible in `content`, no `tool_calls`, and `finish_reason=stop`. It reproduces only occasionally, because it needs the model to sample the turn terminator mid-response.

Three independent causes, one per area:

1. **The response channel is unconstrained** — `_k3_response_prefix()` in `vllm/tool_parsers/structural_tag_registry.py` builds the body as `TagFormat(begin="", content=AnyTextFormat(), end=<|close|>response<|sep|>)`, with no `excludes`.
2. **xgrammar guards the wrong stop token** — `XgrammarBackend` calls `TokenizerInfo.from_huggingface()` without `stop_token_ids`, so xgrammar guards `tokenizer.eos_token_id` while the engine stops on the model's `eos_token_id`. Model-agnostic.
3. **The K3 XTML parser anchors on the first tools marker it sees**, wherever it is, and gives up if that section holds no call.

## 1. The response channel (`structural_tag_registry.py:564`)

With empty `excludes`, the body legalises everything except the tag's own end marker. Measured with the real xgrammar matcher and the Kimi-K3 tokenizer, the mid-response mask allowed **163839 / 163840** tokens — including `<|open|>`, `<|close|>`, `<|sep|>` and the model's `<|end_of_msg|>` (163586), for which `accept_token()` succeeded with `is_terminated()` still `False`. `required` therefore only requires that *if* the model ever writes `<|close|>response<|sep|>`, a tools block must follow.

The fix excludes the markers the model could use to fake a channel transition the tag cares about: response close, tools open, turn trailer, end-of-message. That is the set the Rust builder in this repo already uses (`rust/src/parser/src/unified/kimi_k3/structural_tag.rs`), and `:564` was the only unguarded `AnyTextFormat` in a builder that already passes `excludes` for its argument bodies (`:478`, `:500`).

Verified with the real tokenizer on xgrammar 0.2.3 and 0.2.4, `required` and `auto`:

| generated shape | before | after |
|---|---|---|
| marker as prose, response never closed | accepted | rejected |
| marker as prose, then a real call | accepted | rejected |
| `<\|end_of_msg\|>` spelled out in the body | accepted | rejected |
| well-formed response + tool call | accepted | accepted |
| response only, no tool call | terminates (`auto`) | unchanged |

## 2. The stop token xgrammar guards (`backend_xgrammar.py`)

`TokenizerInfo.from_huggingface(tokenizer, vocab_size=...)` infers the stop id from the tokenizer. For Kimi-K3 that is `[EOS]` (163585) — a base-LM terminator the chat template never emits — while a turn ends with `<|end_of_msg|>` (163586) per `config.json` and `generation_config.json`, and `update_from_generation_config` folds that id into the request's stop set. Both directions break:

| grammar state | before | after |
|---|---|---|
| mid-grammar, not satisfied | 163586 matched as ordinary text → the grammar cannot hold generation back | masked |
| grammar completable | 163586 masked; allowed set was exactly `{'<', 163585, '<\|close\|>'}` → the model is pushed onto a token it does not end turns with | allowed |

The `is_terminated()` shortcut in `_fill_bitmasks` cannot compensate, since it is sourced from xgrammar's own stop token. The fix passes the union of the tokenizer's and the model's eos ids — `[163585, 163586]` for this checkpoint, a no-op where the two agree.

Known limitation: `TokenizerInfo` is built once per engine, so per-request `stop_token_ids` still cannot be guarded this way. Related xgrammar work on the "grammar masks the terminator" half: mlc-ai/xgrammar#701 and #710 — those only help ids xgrammar already knows about, so this change is a precondition for them to matter here.

This also closes the one route the excludes miss on xgrammar ≤ 0.2.3, where exclusion stops being enforced while another excluded marker is partially matched (fixed upstream in 0.2.4, mlc-ai/xgrammar#697, but `requirements/common.txt` allows `>= 0.2.1` and the 0.2.4/0.2.5 wheel matrix does not cover every interpreter, so installs can still land on 0.2.3).

## 3. Tool-call extraction (`kimi_k3_tool_parser.py:311`, `:264`)

`extract_tool_calls` takes the first `<|open|>tools<|sep|>` anywhere in the output, slices to the first `<|close|>tools<|sep|>`, and returns `tools_called=False` if that section holds no complete call — so a well-formed call later in the output is never examined, and `_content` hands back the response body verbatim, marker included. Now the sections are scanned in order and the first one carrying a call wins, which is what the hermes parser already does with `findall`. The returned body is cut at the tools marker and a partial marker the model started is held back, matching the streaming path; the holdback must be longer than one character, or an answer of `3 <` comes back as `3 ` because `<` is the one-character prefix of the response-close marker.

This part matters outside constrained decoding as well: plain `tool_choice="auto"` without a strict tool builds no grammar, so the parser is the only line of defence there.

| model output | before | after |
|---|---|---|
| marker in the body, then a real call | `tools_called=False`, markers in `content` | `tools_called=True`, `content='Let me check.'` |
| generation stopped mid-marker in the body | `content='Let me check.<\|open\|>tools'` | `content='Let me check.'` |
| well-formed call (control) | `tools_called=True` | unchanged |

## Testing

```
tests/tool_parsers/test_structural_tag_registry.py
tests/tool_use/test_kimi_k3_tool_parser.py
tests/v1/structured_output/test_xgrammar_stop_tokens.py
tests/reasoning/test_kimi_k3_reasoning_parser.py     -> 154 passed
```

New cases: the leak shapes rejected by the `required` grammar; the misanchored tools section, the dangling marker and the `3 <` case for the parser; four unit tests for the stop-token union (differing ids, list-valued eos, agreeing ids, unreadable generation config). `ruff check` and `ruff format` clean on the changed files.

**End-to-end**, two servers from the same build on the same checkpoint, differing only by this patch, 280 requests each at `tool_choice="required"`, temperature 1.0, prompts that push the model to write channel markers into its answer:

| | without patch | with patch |
|---|---|---|
| exact `<\|open\|>tools<\|sep\|>` in `content` | **105 / 280** | **0 / 280** |
| inert near-miss variants only | 1 | 17 |
| `required` violations (no tool call) | 0 | 0 |
| `finish_reason` | `tool_calls` 280 | `tool_calls` 280 |

The 17 residual hits are the constraint working: the model reaches for the marker, the completing token is masked, and it settles for something the parser cannot mistake for a channel (`<|open|>tools<|sep| >`, `<|open|>tools<|sep|)`, an escaped form). A separate set of 15 behavioural probes per side (plain chat, strict tool with and without a needed call, `required` with an uncooperative prompt, thinking off, streaming, multi-arg, two tools, unconstrained `auto`, multi-turn with reasoning history) showed no probe turning into `finish_reason=length` and no tool call lost; the `3 <` regression above was found there and is fixed.

One deliberate behaviour change worth knowing: with a strict tool attached, the assistant can no longer quote a K3 channel marker verbatim in its answer — asking it to echo `<|open|>tools<|sep|>` returns empty content. That is inherent to excluding the string, and the Rust builder excludes the same set. Without tools no tag is built, so the unconstrained path is unaffected.

## Notes

- Left as follow-ups: schema-`required` properties can still legally appear zero times (the argument block is `star`; the Rust builder's `plus` is closer but still does not pin the required key), and the parser is string-level, so a marker spelled out of ordinary text is indistinguishable from the control tokens.
- AI assistance (Claude) was used for the investigation and implementation; every measurement above was run against a live deployment and every changed line was reviewed by me.