### PR TITLE
Fix ROCm architecture import on non-ROCm platforms

### DIFF
--- a/vllm/model_executor/layers/fused_moe/oracle/mxfp4.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/mxfp4.py
@@ -1286,7 +1286,11 @@ def convert_weight_to_mxfp4_moe_kernel_format(
 
     Supports DeepGEMM, FlashInfer, TRTLLM MXFP8, Triton and Marlin backends.
     """
-    from vllm.platforms.rocm import on_gfx1250
+    is_gfx1250 = False
+    if current_platform.is_rocm():
+        from vllm.platforms.rocm import on_gfx1250
+
+        is_gfx1250 = on_gfx1250()
 
     if mxfp4_backend == Mxfp4MoeBackend.DEEPGEMM_MXFP4:
         w13_weight_scale, w2_weight_scale = _pack_deepgemm_mxfp4_scales(
@@ -1459,7 +1463,7 @@ def convert_weight_to_mxfp4_moe_kernel_format(
             w2_bias,
         )
 
-    elif mxfp4_backend == Mxfp4MoeBackend.AITER_MXFP4_BF16 and not on_gfx1250():
+    elif mxfp4_backend == Mxfp4MoeBackend.AITER_MXFP4_BF16 and not is_gfx1250:
         # Initially introduced for DeepSeekV4
 
         if w13_bias is not None:
@@ -1520,7 +1524,7 @@ def convert_weight_to_mxfp4_moe_kernel_format(
         )
 
     elif mxfp4_backend in TRITON_BACKENDS or (
-        mxfp4_backend == Mxfp4MoeBackend.AITER_MXFP4_BF16 and on_gfx1250()
+        mxfp4_backend == Mxfp4MoeBackend.AITER_MXFP4_BF16 and is_gfx1250
     ):
         from triton_kernels.matmul_ogs import FlexCtx, PrecisionConfig
 

--- a/vllm/model_executor/layers/quantization/mxfp4.py
+++ b/vllm/model_executor/layers/quantization/mxfp4.py
@@ -739,10 +739,7 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
         # For TRITON backends, weights are wrapped tensors from triton_kernels
         # that don't support .detach(). Manually assign parameters.
         is_gfx1250 = False
-        if (
-            self.mxfp4_backend == Mxfp4MoeBackend.AITER_MXFP4_BF16
-            and current_platform.is_rocm()
-        ):
+        if current_platform.is_rocm():
             from vllm.platforms.rocm import on_gfx1250
 
             is_gfx1250 = on_gfx1250()
@@ -837,10 +834,7 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
         swiglu_limit = getattr(layer, "swiglu_limit", None)
 
         is_gfx1250 = False
-        if (
-            self.mxfp4_backend == Mxfp4MoeBackend.AITER_MXFP4_BF16
-            and current_platform.is_rocm()
-        ):
+        if current_platform.is_rocm():
             from vllm.platforms.rocm import on_gfx1250
 
             is_gfx1250 = on_gfx1250()

--- a/vllm/model_executor/layers/quantization/mxfp4.py
+++ b/vllm/model_executor/layers/quantization/mxfp4.py
@@ -39,6 +39,7 @@ from vllm.model_executor.layers.quantization.base_config import (
 )
 from vllm.model_executor.layers.quantization.utils.quant_utils import is_layer_skipped
 from vllm.model_executor.utils import replace_parameter, set_weight_attrs
+from vllm.platforms import current_platform
 
 logger = init_logger(__name__)
 
@@ -482,8 +483,6 @@ def _use_k3_situ_aiter(moe: FusedMoEConfig) -> bool:
     K3 is weight-only MXFP4 (W4A16) with SiTU activation, which the generic
     MXFP4 backend selector does not cover; route it to AITER on gfx950.
     """
-    from vllm.platforms import current_platform
-
     if not current_platform.is_rocm():
         return False
     from vllm._aiter_ops import rocm_aiter_ops
@@ -739,11 +738,16 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
 
         # For TRITON backends, weights are wrapped tensors from triton_kernels
         # that don't support .detach(). Manually assign parameters.
-        from vllm.platforms.rocm import on_gfx1250
+        is_gfx1250 = False
+        if (
+            self.mxfp4_backend == Mxfp4MoeBackend.AITER_MXFP4_BF16
+            and current_platform.is_rocm()
+        ):
+            from vllm.platforms.rocm import on_gfx1250
 
-        uses_triton_weight_format = self.mxfp4_backend in TRITON_BACKENDS or (
-            self.mxfp4_backend == Mxfp4MoeBackend.AITER_MXFP4_BF16 and on_gfx1250()
-        )
+            is_gfx1250 = on_gfx1250()
+
+        uses_triton_weight_format = self.mxfp4_backend in TRITON_BACKENDS or is_gfx1250
         if not uses_triton_weight_format:
             replace_parameter(layer, "w13_weight", w13)
             replace_parameter(layer, "w2_weight", w2)
@@ -830,11 +834,16 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
         w2_bias = getattr(layer, "w2_bias", None)
         swiglu_limit = getattr(layer, "swiglu_limit", None)
 
-        from vllm.platforms.rocm import on_gfx1250
-
-        if self.mxfp4_backend in TRITON_BACKENDS or (
-            self.mxfp4_backend == Mxfp4MoeBackend.AITER_MXFP4_BF16 and on_gfx1250()
+        is_gfx1250 = False
+        if (
+            self.mxfp4_backend == Mxfp4MoeBackend.AITER_MXFP4_BF16
+            and current_platform.is_rocm()
         ):
+            from vllm.platforms.rocm import on_gfx1250
+
+            is_gfx1250 = on_gfx1250()
+
+        if self.mxfp4_backend in TRITON_BACKENDS or is_gfx1250:
             # TRITON backends free w13/w2_weight_scale after swizzling; the
             # swizzled scales live inside the precision configs instead.
             assert self.w13_precision_config is not None

--- a/vllm/model_executor/layers/quantization/mxfp4.py
+++ b/vllm/model_executor/layers/quantization/mxfp4.py
@@ -747,7 +747,9 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
 
             is_gfx1250 = on_gfx1250()
 
-        uses_triton_weight_format = self.mxfp4_backend in TRITON_BACKENDS or is_gfx1250
+        uses_triton_weight_format = self.mxfp4_backend in TRITON_BACKENDS or (
+            self.mxfp4_backend == Mxfp4MoeBackend.AITER_MXFP4_BF16 and is_gfx1250()
+        )
         if not uses_triton_weight_format:
             replace_parameter(layer, "w13_weight", w13)
             replace_parameter(layer, "w2_weight", w2)

--- a/vllm/model_executor/layers/quantization/mxfp4.py
+++ b/vllm/model_executor/layers/quantization/mxfp4.py
@@ -748,7 +748,7 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
             is_gfx1250 = on_gfx1250()
 
         uses_triton_weight_format = self.mxfp4_backend in TRITON_BACKENDS or (
-            self.mxfp4_backend == Mxfp4MoeBackend.AITER_MXFP4_BF16 and is_gfx1250()
+            self.mxfp4_backend == Mxfp4MoeBackend.AITER_MXFP4_BF16 and is_gfx1250
         )
         if not uses_triton_weight_format:
             replace_parameter(layer, "w13_weight", w13)

--- a/vllm/model_executor/layers/quantization/mxfp4.py
+++ b/vllm/model_executor/layers/quantization/mxfp4.py
@@ -845,7 +845,9 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
 
             is_gfx1250 = on_gfx1250()
 
-        if self.mxfp4_backend in TRITON_BACKENDS or is_gfx1250:
+        if self.mxfp4_backend in TRITON_BACKENDS or (
+            self.mxfp4_backend == Mxfp4MoeBackend.AITER_MXFP4_BF16 and is_gfx1250
+        ):
             # TRITON backends free w13/w2_weight_scale after swizzling; the
             # swizzled scales live inside the precision configs instead.
             assert self.w13_precision_config is not None


### PR DESCRIPTION
## Summary

- guard the ROCm-only `on_gfx1250` import with `current_platform.is_rocm()`
- cache the architecture check for AITER backend selection
- prevent XPU model loading from initializing `torch.cuda` through the ROCm platform module

## Testing

- `pre-commit run --from-ref origin/main --to-ref HEAD`
- DeepSeek V4 loaded all 46 checkpoint shards and completed generation successfully on TP8 XPU
