### PR TITLE
[Bugfix][Mooncake] Save exact Mamba boundary states

### DIFF
--- a/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
+++ b/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
@@ -31,6 +31,19 @@ def _auto_init_hash_fn():
     init_none_hash(sha256)
 
 
+def drain_boundary_state_offloads(manager):
+    """Drain exact boundary-state block ids offered to a connector."""
+    return manager.take_boundary_state_offloads()
+
+
+def _free_block_ids(manager):
+    """Block ids the pool would hand out to the next allocation."""
+    return {
+        block.block_id
+        for block in manager.block_pool.free_block_queue.get_all_free_blocks()
+    }
+
+
 def test_mamba_align_split_partial_tail_schedule():
     """Chunk ends with partial hits on: block-aligned chunks, one extra stop
     at the prompt's last hash boundary (registering the partial tail), then
@@ -297,7 +310,7 @@ def test_hybrid_mamba_partial_tail_owner_uses_cow_on_continue():
     assert moved[0].block_hash_num_tokens == 6
 
 
-def test_take_partial_tail_offloads_returns_cow_target():
+def test_boundary_state_offloads_returns_cow_target():
     """The connector offload hand-off exposes the mamba CoW *target* block Y
     (the durable boundary state), not the overwritten source X, and only at
     the CoW step."""
@@ -338,8 +351,10 @@ def test_take_partial_tail_offloads_returns_cow_target():
     computed_blocks, num_computed, _ = manager.get_computed_blocks(req0)
     assert manager.allocate_slots(req0, 6, num_computed, computed_blocks) is not None
 
-    # Step A registered the partial tail but has not CoW'd yet: no offload.
-    assert manager.take_partial_tail_offloads() == {}
+    # Step A registered the partial tail but has not CoW'd yet, and the 4-token
+    # boundary state was never materialized (align mode nulls block 0 for a
+    # 6-token prompt): nothing to hand off.
+    assert drain_boundary_state_offloads(manager) == {}
 
     partial_mamba_hash = req0.block_hashes[6 // hash_block_size - 1]
     source_block = manager.block_pool.get_cached_block(
@@ -353,34 +368,27 @@ def test_take_partial_tail_offloads_returns_cow_target():
     req0.append_output_token_ids([3])
     assert manager.allocate_slots(req0, 1) is not None
 
-    offloads = manager.take_partial_tail_offloads()
+    offloads = drain_boundary_state_offloads(manager)
     assert list(offloads.keys()) == ["0"]
     assert len(offloads["0"]) == 1
     group_id, block_id, boundary_tokens = offloads["0"][0]
     assert group_id == 1  # the mamba group
     assert boundary_tokens == 6
-    copies, _ = manager.take_kv_cache_block_copies()
+    copies, retained = manager.take_kv_cache_block_copies()
     cow_copy = next(c for c in copies if c.src_block_id == source_block_id)
     # The offload points at the durable CoW target Y, not the overwritten X.
     assert block_id == cow_copy.dst_block_id
     assert block_id != source_block_id
     # Draining clears it.
-    assert manager.take_partial_tail_offloads() == {}
+    assert manager.take_boundary_state_offloads() == {}
 
-    # The hand-off pinned Y (its CoW retention is released after this step,
-    # and Y is off the request block table); freeing the request unpins it.
-    cow_block = manager.block_pool.blocks[block_id]
-    pinned_ref = cow_block.ref_cnt
-    assert pinned_ref >= 1
+    manager.block_pool.free_blocks(retained)
     manager.free(req0)
-    assert cow_block.ref_cnt == pinned_ref - 1
 
 
-def test_partial_tail_pin_survives_released_cow_retention():
-    """If the CoW retention is released before the hand-off is drained
-    (immediate-free mode), the drain must rescue the cow block from the free
-    queue: a raw ref increment would leave a ref>0 block allocatable, and the
-    next allocation would pop it and assert."""
+def test_block_pool_touch_pins_released_cow_target():
+    """The connector can rescue an offered CoW target after its step-scoped
+    retention is released by using the bound BlockPool's touch method."""
     hash_block_size = 2
     block_size = 2 * hash_block_size
     kv_cache_config = KVCacheConfig(
@@ -424,13 +432,18 @@ def test_partial_tail_pin_survives_released_cow_retention():
     _copies, retained = manager.take_kv_cache_block_copies()
     manager.block_pool.free_blocks(retained)
 
-    offloads = manager.take_partial_tail_offloads()
+    offloads = drain_boundary_state_offloads(manager)
     ((_group_id, block_id, boundary_tokens),) = offloads["0"]
     assert boundary_tokens == 6
     cow_block = manager.block_pool.blocks[block_id]
-    assert cow_block.ref_cnt == 1
+    assert cow_block.ref_cnt == 0
+    assert block_id in _free_block_ids(manager)
 
-    # The pinned block is out of the free queue: draining every free block
+    manager.block_pool.touch([cow_block])
+    assert cow_block.ref_cnt == 1
+    assert block_id not in _free_block_ids(manager)
+
+    # The connector-pinned block is out of the free queue: draining every free block
     # neither trips the allocator's ref_cnt assert nor hands it out.
     new_blocks = manager.block_pool.get_new_blocks(
         manager.block_pool.get_num_free_blocks()
@@ -438,7 +451,7 @@ def test_partial_tail_pin_survives_released_cow_retention():
     assert block_id not in {b.block_id for b in new_blocks}
 
 
-def test_partial_tail_offload_dropped_when_request_freed_before_drain():
+def test_boundary_state_offload_dropped_when_request_freed_before_drain():
     """A hand-off recorded in the same scheduling pass as the request's death
     must not be drained: its release hook has already run, so draining would
     leak a pinned block."""
@@ -483,12 +496,12 @@ def test_partial_tail_offload_dropped_when_request_freed_before_drain():
 
     # The request dies (preempt/abort) before the scheduler drains.
     manager.block_pool.free_blocks(manager.pop_blocks_for_free(req0))
-    assert manager.take_partial_tail_offloads() == {}
+    assert manager.take_boundary_state_offloads() == {}
 
 
-def test_take_partial_tail_offloads_empty_without_partial_tail():
-    """A prompt ending on a block boundary registers no partial tail, so there
-    is nothing to offload."""
+def test_boundary_state_offloads_block_aligned_prompt():
+    """A prompt ending on a block boundary registers no CoW partial tail; its
+    boundary state block is handed off as a snapshot instead (once)."""
     hash_block_size = 2
     block_size = 2 * hash_block_size
     kv_cache_config = KVCacheConfig(
@@ -526,12 +539,17 @@ def test_take_partial_tail_offloads_empty_without_partial_tail():
     req0 = make_request("0", [0, 0, 1, 1], hash_block_size, sha256)
     computed_blocks, num_computed, _ = manager.get_computed_blocks(req0)
     assert manager.allocate_slots(req0, 4, num_computed, computed_blocks) is not None
-    assert manager.take_partial_tail_offloads() == {}
+    mamba_blocks = manager.coordinator.single_type_managers[1].req_to_blocks["0"]
+    ((group_id, block_id, boundary),) = drain_boundary_state_offloads(manager)["0"]
+    assert group_id == 1
+    assert boundary == block_size
+    assert block_id == mamba_blocks[0].block_id
 
     req0.num_computed_tokens = 4
     req0.append_output_token_ids([2])
     assert manager.allocate_slots(req0, 1) is not None
-    assert manager.take_partial_tail_offloads() == {}
+    # The boundary was already handed off; decoding emits nothing new.
+    assert manager.take_boundary_state_offloads() == {}
 
 
 def test_truncate_computed_blocks_preserves_sparse_prefix_positions():
@@ -1181,3 +1199,213 @@ def test_hybrid_partial_hit_with_eagle_stays_within_group_blocks():
         len(group) * block_size >= num_computed for group in computed_blocks.blocks
     )
     assert manager.allocate_slots(req1, 4, num_computed, computed_blocks) is not None
+
+
+def _snapshot_offload_kv_cache_config(
+    hash_block_size: int, block_size: int, num_blocks: int = 24
+):
+    return KVCacheConfig(
+        num_blocks=num_blocks,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["full"],
+                FullAttentionSpec(
+                    block_size=hash_block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                ),
+            ),
+            KVCacheGroupSpec(
+                ["mamba"],
+                MambaSpec(
+                    block_size=block_size,
+                    shapes=(1, 1),
+                    dtypes=(torch.float32,),
+                    mamba_cache_mode="align",
+                ),
+            ),
+        ],
+    )
+
+
+def test_retention_snapshots_handed_off_with_exact_block_ids():
+    """Under sparse retention, each retained mamba boundary state block is
+    handed to the connector with its exact block id. Connectors must not resolve
+    align-mode state blocks positionally because the block table is not
+    append-only."""
+    hash_block_size = 2
+    block_size = 4
+    manager = make_kv_cache_manager(
+        kv_cache_config=_snapshot_offload_kv_cache_config(hash_block_size, block_size),
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=hash_block_size,
+    )
+    manager.coordinator.retention_interval = 2 * block_size
+
+    req0 = make_request("0", [0] * 16, hash_block_size, sha256)
+    computed_blocks, num_computed, _ = manager.get_computed_blocks(req0)
+    assert manager.allocate_slots(req0, 8, num_computed, computed_blocks) is not None
+
+    mamba_blocks = manager.coordinator.single_type_managers[1].req_to_blocks["0"]
+    offloads = drain_boundary_state_offloads(manager)
+    ((group_id, block_id, boundary),) = offloads["0"]
+    assert group_id == 1
+    assert boundary == 2 * block_size
+    assert block_id == mamba_blocks[1].block_id
+
+    req0.num_computed_tokens = 8
+    manager.new_step_starts()
+    assert manager.allocate_slots(req0, 8) is not None
+
+    offloads = drain_boundary_state_offloads(manager)
+    ((group_id, block_id2, boundary2),) = offloads["0"]
+    assert group_id == 1
+    assert boundary2 == 4 * block_size
+    assert block_id2 == mamba_blocks[3].block_id
+    # Interior align-mode positions stay null and are never handed off.
+    assert mamba_blocks[0].is_null and mamba_blocks[2].is_null
+
+    manager.free(req0)
+
+
+def test_snapshot_handoff_dense_default_retention():
+    """With dense (default) retention, every materialized mamba boundary
+    state block is handed off — regular mamba-align + prefix-match-unit
+    deployments get store-able boundary snapshots without setting
+    VLLM_PREFIX_CACHE_RETENTION_INTERVAL."""
+    hash_block_size = 2
+    block_size = 4
+    manager = make_kv_cache_manager(
+        kv_cache_config=_snapshot_offload_kv_cache_config(hash_block_size, block_size),
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=hash_block_size,
+    )
+    assert manager.coordinator.retention_interval is None
+
+    req0 = make_request("0", [0] * 16, hash_block_size, sha256)
+    computed_blocks, num_computed, _ = manager.get_computed_blocks(req0)
+    assert manager.allocate_slots(req0, 8, num_computed, computed_blocks) is not None
+
+    mamba_blocks = manager.coordinator.single_type_managers[1].req_to_blocks["0"]
+    ((group_id, block_id, boundary),) = drain_boundary_state_offloads(manager)["0"]
+    assert group_id == 1
+    assert boundary == 2 * block_size
+    assert block_id == mamba_blocks[1].block_id
+
+    req0.num_computed_tokens = 8
+    manager.new_step_starts()
+    assert manager.allocate_slots(req0, 8) is not None
+    ((group_id, block_id2, boundary2),) = drain_boundary_state_offloads(manager)["0"]
+    assert group_id == 1
+    assert boundary2 == 4 * block_size
+    assert block_id2 == mamba_blocks[3].block_id
+
+
+def _run_chunked_prefill(manager, req, chunk_size, num_chunks):
+    """Prefill ``req`` one ``chunk_size`` chunk per scheduler step, yielding the
+    boundary-state hand-offs offered (and claimed) at each step."""
+    computed_blocks, num_computed, _ = manager.get_computed_blocks(req)
+    for step in range(num_chunks):
+        manager.new_step_starts()
+        req.num_computed_tokens = step * chunk_size
+        if step == 0:
+            allocated = manager.allocate_slots(
+                req, chunk_size, num_computed, computed_blocks
+            )
+        else:
+            allocated = manager.allocate_slots(req, chunk_size)
+        assert allocated is not None
+        yield drain_boundary_state_offloads(manager).get(req.request_id, [])
+
+
+def test_boundary_state_offer_includes_more_mamba_groups_than_two():
+    """One offer batch carries one exact block entry per mamba group."""
+    block_size = 8
+    num_mamba_groups = 3
+    manager = make_kv_cache_manager(
+        kv_cache_config=KVCacheConfig(
+            num_blocks=200,
+            kv_cache_tensors=[],
+            kv_cache_groups=[
+                KVCacheGroupSpec(
+                    ["full"],
+                    FullAttentionSpec(
+                        block_size=block_size,
+                        num_kv_heads=1,
+                        head_size=1,
+                        dtype=torch.float32,
+                    ),
+                ),
+                *(
+                    KVCacheGroupSpec(
+                        [f"mamba{i}"],
+                        MambaSpec(
+                            block_size=block_size,
+                            shapes=(1, 1),
+                            dtypes=(torch.float32,),
+                            mamba_cache_mode="align",
+                        ),
+                    )
+                    for i in range(num_mamba_groups)
+                ),
+            ],
+        ),
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=block_size,
+    )
+
+    req0 = make_request("0", [0] * (2 * block_size), block_size, sha256)
+    entries = next(_run_chunked_prefill(manager, req0, block_size, 1))
+
+    assert [group_id for group_id, _, _ in entries] == [1, 2, 3]
+    assert {boundary for _, _, boundary in entries} == {block_size}
+
+
+def test_boundary_states_offered_past_prompt_for_resumed_prefill():
+    """The core offers every committed boundary, including past
+    ``num_prompt_tokens``. A resumed request re-prefills its generated tokens
+    and every group re-saves them, so filtering on the original prompt length
+    would silently strip the mamba key for boundaries full attention still
+    stores; only the connector knows where its save window ends."""
+    block_size = 8
+    prompt_len = block_size
+    manager = make_kv_cache_manager(
+        kv_cache_config=_snapshot_offload_kv_cache_config(
+            hash_block_size=block_size, block_size=block_size, num_blocks=200
+        ),
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=block_size,
+    )
+
+    req0 = make_request("0", [0] * prompt_len, block_size, sha256)
+    assert [
+        boundary
+        for entries in _run_chunked_prefill(manager, req0, block_size, 1)
+        for _, _, boundary in entries
+    ] == [prompt_len]
+
+    # Generate past the next mamba boundary, then replay it as a resumed
+    # prefill: its committed boundary is offered even though it is past the
+    # prompt, matching what full attention saves for the same range.
+    for i in range(block_size):
+        manager.new_step_starts()
+        req0.num_computed_tokens = prompt_len + i
+        req0.append_output_token_ids([1])
+        assert manager.allocate_slots(req0, 1) is not None
+        drain_boundary_state_offloads(manager)
+    assert req0.num_tokens == 2 * block_size
+
+    manager.free(req0)
+    manager.new_step_starts()
+    req0.num_computed_tokens = 0
+    computed_blocks, num_computed, _ = manager.get_computed_blocks(req0)
+    assert manager.allocate_slots(req0, req0.num_tokens - num_computed, num_computed)
+    offered = [b for _, _, b in drain_boundary_state_offloads(manager).get("0", [])]
+    assert 2 * block_size in offered
+    assert req0.num_prompt_tokens < 2 * block_size

--- a/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
+++ b/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
@@ -937,6 +937,70 @@ def test_truncate_computed_blocks_preserves_sparse_prefix_positions():
     assert [len(group) for group in blocks.blocks] == [3, 2]
 
 
+def test_truncate_computed_blocks_allows_short_mamba_group_only():
+    """External state may replace a short Mamba hit, but other groups must
+    cover the aligned local endpoint."""
+    hash_block_size = 2
+    kv_cache_config = KVCacheConfig(
+        num_blocks=24,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["full"],
+                FullAttentionSpec(
+                    block_size=hash_block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                ),
+            ),
+            KVCacheGroupSpec(
+                ["mamba"],
+                MambaSpec(
+                    block_size=2 * hash_block_size,
+                    shapes=(1, 1),
+                    dtypes=(torch.float32,),
+                    mamba_cache_mode="align",
+                ),
+            ),
+        ],
+    )
+    manager = make_kv_cache_manager(
+        kv_cache_config=kv_cache_config,
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=hash_block_size,
+    )
+    producer = make_request("producer", [0, 0, 1, 1, 2, 2], hash_block_size, sha256)
+    blocks, num_computed, _ = manager.get_computed_blocks(producer)
+    assert manager.allocate_slots(producer, 6, num_computed, blocks) is not None
+    manager.free(producer)
+    manager.new_step_starts()
+
+    consumer = make_request(
+        "consumer", [0, 0, 1, 1, 2, 2, 3, 3], hash_block_size, sha256
+    )
+    blocks, num_computed, _ = manager.get_computed_blocks(consumer)
+    assert num_computed == 6
+    assert [len(group) for group in blocks.blocks] == [3, 2]
+
+    short_mamba = manager.create_kv_cache_blocks((list(blocks.blocks[0]), []))
+    truncated = manager.truncate_computed_blocks(short_mamba, 4)
+    assert [len(group) for group in truncated.blocks] == [2, 0]
+
+    short_full_attention = manager.create_kv_cache_blocks(
+        (list(blocks.blocks[0][:1]), list(blocks.blocks[1]))
+    )
+    with pytest.raises(AssertionError):
+        manager.truncate_computed_blocks(short_full_attention, 4)
+
+    with pytest.raises(AssertionError):
+        manager.truncate_computed_blocks(blocks, 6)
+
+    # The lookup result itself is never mutated.
+    assert [len(group) for group in blocks.blocks] == [3, 2]
+
+
 def test_hybrid_mamba_partial_tail_owner_continue_preserves_later_hit():
     hash_block_size = 2
     block_size = 2 * hash_block_size

--- a/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
+++ b/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
@@ -69,6 +69,19 @@ def test_capable_connector_uses_divergent_partial_hit_lookup():
     manager.get_computed_blocks.assert_not_called()
 
 
+def drain_boundary_state_offloads(manager):
+    """Drain exact boundary-state block ids offered to a connector."""
+    return manager.take_boundary_state_offloads()
+
+
+def _free_block_ids(manager):
+    """Block ids the pool would hand out to the next allocation."""
+    return {
+        block.block_id
+        for block in manager.block_pool.free_block_queue.get_all_free_blocks()
+    }
+
+
 def make_full_mamba_manager(
     *,
     dcp_world_size: int,
@@ -618,10 +631,9 @@ def test_external_mamba_hit_same_block_uses_running_cow_on_continue():
     assert moved[0].block_id == cow_copy.dst_block_id
 
 
-def test_take_partial_tail_offloads_returns_cow_target():
-    """The connector offload hand-off exposes the mamba CoW *target* block Y
-    (the durable boundary state), not the overwritten source X, and only at
-    the CoW step."""
+def test_boundary_state_offloads_returns_cow_target():
+    """Boundary hand-offs expose aligned snapshots and the partial-tail CoW
+    target, never the overwritten CoW source."""
     hash_block_size = 2
     block_size = 2 * hash_block_size
     kv_cache_config = KVCacheConfig(
@@ -660,8 +672,18 @@ def test_take_partial_tail_offloads_returns_cow_target():
     computed_blocks, num_computed, _ = manager.get_computed_blocks(req0)
     assert manager.allocate_slots(req0, 6, num_computed, computed_blocks) is not None
 
-    # Step A registered the partial tail but has not CoW'd yet: no offload.
-    assert manager.take_partial_tail_offloads() == {}
+    # Step A offers the materialized aligned checkpoint immediately.
+    ((group_id, block_id, boundary_tokens),) = drain_boundary_state_offloads(manager)[
+        "0"
+    ]
+    assert group_id == 1
+    assert boundary_tokens == 4
+    aligned_hash = req0.block_hashes[4 // hash_block_size - 1]
+    aligned_block = manager.block_pool.get_cached_block(
+        aligned_hash, kv_cache_group_ids=[1]
+    )
+    assert aligned_block is not None
+    assert block_id == aligned_block[0].block_id
 
     partial_mamba_hash = req0.block_hashes[6 // hash_block_size - 1]
     source_block = manager.block_pool.get_cached_block(
@@ -675,34 +697,27 @@ def test_take_partial_tail_offloads_returns_cow_target():
     req0.append_output_token_ids([3])
     assert manager.allocate_slots(req0, 1) is not None
 
-    offloads = manager.take_partial_tail_offloads()
+    offloads = drain_boundary_state_offloads(manager)
     assert list(offloads.keys()) == ["0"]
     assert len(offloads["0"]) == 1
     group_id, block_id, boundary_tokens = offloads["0"][0]
     assert group_id == 1  # the mamba group
     assert boundary_tokens == 6
-    copies, _ = manager.take_kv_cache_block_copies()
+    copies, retained = manager.take_kv_cache_block_copies()
     cow_copy = next(c for c in copies if c.src_block_id == source_block_id)
     # The offload points at the durable CoW target Y, not the overwritten X.
     assert block_id == cow_copy.dst_block_id
     assert block_id != source_block_id
     # Draining clears it.
-    assert manager.take_partial_tail_offloads() == {}
+    assert manager.take_boundary_state_offloads() == {}
 
-    # The hand-off pinned Y (its CoW retention is released after this step,
-    # and Y is off the request block table); freeing the request unpins it.
-    cow_block = manager.block_pool.blocks[block_id]
-    pinned_ref = cow_block.ref_cnt
-    assert pinned_ref >= 1
+    manager.block_pool.free_blocks(retained)
     manager.free(req0)
-    assert cow_block.ref_cnt == pinned_ref - 1
 
 
-def test_partial_tail_pin_survives_released_cow_retention():
-    """If the CoW retention is released before the hand-off is drained
-    (immediate-free mode), the drain must rescue the cow block from the free
-    queue: a raw ref increment would leave a ref>0 block allocatable, and the
-    next allocation would pop it and assert."""
+def test_block_pool_touch_pins_released_cow_target():
+    """The connector can rescue an offered CoW target after its step-scoped
+    retention is released by using the bound BlockPool's touch method."""
     hash_block_size = 2
     block_size = 2 * hash_block_size
     kv_cache_config = KVCacheConfig(
@@ -746,13 +761,18 @@ def test_partial_tail_pin_survives_released_cow_retention():
     _copies, retained = manager.take_kv_cache_block_copies()
     manager.block_pool.free_blocks(retained)
 
-    offloads = manager.take_partial_tail_offloads()
+    offloads = drain_boundary_state_offloads(manager)
     ((_group_id, block_id, boundary_tokens),) = offloads["0"]
     assert boundary_tokens == 6
     cow_block = manager.block_pool.blocks[block_id]
-    assert cow_block.ref_cnt == 1
+    assert cow_block.ref_cnt == 0
+    assert block_id in _free_block_ids(manager)
 
-    # The pinned block is out of the free queue: draining every free block
+    manager.block_pool.touch([cow_block])
+    assert cow_block.ref_cnt == 1
+    assert block_id not in _free_block_ids(manager)
+
+    # The connector-pinned block is out of the free queue: draining every free block
     # neither trips the allocator's ref_cnt assert nor hands it out.
     new_blocks = manager.block_pool.get_new_blocks(
         manager.block_pool.get_num_free_blocks()
@@ -760,7 +780,7 @@ def test_partial_tail_pin_survives_released_cow_retention():
     assert block_id not in {b.block_id for b in new_blocks}
 
 
-def test_partial_tail_offload_dropped_when_request_freed_before_drain():
+def test_boundary_state_offload_dropped_when_request_freed_before_drain():
     """A hand-off recorded in the same scheduling pass as the request's death
     must not be drained: its release hook has already run, so draining would
     leak a pinned block."""
@@ -805,12 +825,12 @@ def test_partial_tail_offload_dropped_when_request_freed_before_drain():
 
     # The request dies (preempt/abort) before the scheduler drains.
     manager.block_pool.free_blocks(manager.pop_blocks_for_free(req0))
-    assert manager.take_partial_tail_offloads() == {}
+    assert manager.take_boundary_state_offloads() == {}
 
 
-def test_take_partial_tail_offloads_empty_without_partial_tail():
-    """A prompt ending on a block boundary registers no partial tail, so there
-    is nothing to offload."""
+def test_boundary_state_offloads_block_aligned_prompt():
+    """A prompt ending on a block boundary registers no CoW partial tail; its
+    boundary state block is handed off as a snapshot instead (once)."""
     hash_block_size = 2
     block_size = 2 * hash_block_size
     kv_cache_config = KVCacheConfig(
@@ -848,12 +868,17 @@ def test_take_partial_tail_offloads_empty_without_partial_tail():
     req0 = make_request("0", [0, 0, 1, 1], hash_block_size, sha256)
     computed_blocks, num_computed, _ = manager.get_computed_blocks(req0)
     assert manager.allocate_slots(req0, 4, num_computed, computed_blocks) is not None
-    assert manager.take_partial_tail_offloads() == {}
+    mamba_blocks = manager.coordinator.single_type_managers[1].req_to_blocks["0"]
+    ((group_id, block_id, boundary),) = drain_boundary_state_offloads(manager)["0"]
+    assert group_id == 1
+    assert boundary == block_size
+    assert block_id == mamba_blocks[0].block_id
 
     req0.num_computed_tokens = 4
     req0.append_output_token_ids([2])
     assert manager.allocate_slots(req0, 1) is not None
-    assert manager.take_partial_tail_offloads() == {}
+    # The boundary was already handed off; decoding emits nothing new.
+    assert manager.take_boundary_state_offloads() == {}
 
 
 def test_truncate_computed_blocks_preserves_sparse_prefix_positions():
@@ -909,70 +934,6 @@ def test_truncate_computed_blocks_preserves_sparse_prefix_positions():
 
     assert [len(group) for group in truncated.blocks] == [2, 1]
     assert truncated.blocks[1][0].is_null
-    assert [len(group) for group in blocks.blocks] == [3, 2]
-
-
-def test_truncate_computed_blocks_allows_short_mamba_group_only():
-    """External state may replace a short Mamba hit, but other groups must
-    cover the aligned local endpoint."""
-    hash_block_size = 2
-    kv_cache_config = KVCacheConfig(
-        num_blocks=24,
-        kv_cache_tensors=[],
-        kv_cache_groups=[
-            KVCacheGroupSpec(
-                ["full"],
-                FullAttentionSpec(
-                    block_size=hash_block_size,
-                    num_kv_heads=1,
-                    head_size=1,
-                    dtype=torch.float32,
-                ),
-            ),
-            KVCacheGroupSpec(
-                ["mamba"],
-                MambaSpec(
-                    block_size=2 * hash_block_size,
-                    shapes=(1, 1),
-                    dtypes=(torch.float32,),
-                    mamba_cache_mode="align",
-                ),
-            ),
-        ],
-    )
-    manager = make_kv_cache_manager(
-        kv_cache_config=kv_cache_config,
-        max_model_len=8192,
-        enable_caching=True,
-        hash_block_size=hash_block_size,
-    )
-    producer = make_request("producer", [0, 0, 1, 1, 2, 2], hash_block_size, sha256)
-    blocks, num_computed, _ = manager.get_computed_blocks(producer)
-    assert manager.allocate_slots(producer, 6, num_computed, blocks) is not None
-    manager.free(producer)
-    manager.new_step_starts()
-
-    consumer = make_request(
-        "consumer", [0, 0, 1, 1, 2, 2, 3, 3], hash_block_size, sha256
-    )
-    blocks, num_computed, _ = manager.get_computed_blocks(consumer)
-    assert num_computed == 6
-    assert [len(group) for group in blocks.blocks] == [3, 2]
-
-    short_mamba = manager.create_kv_cache_blocks((list(blocks.blocks[0]), []))
-    truncated = manager.truncate_computed_blocks(short_mamba, 4)
-    assert [len(group) for group in truncated.blocks] == [2, 0]
-
-    short_full_attention = manager.create_kv_cache_blocks(
-        (list(blocks.blocks[0][:1]), list(blocks.blocks[1]))
-    )
-    with pytest.raises(AssertionError):
-        manager.truncate_computed_blocks(short_full_attention, 4)
-
-    with pytest.raises(AssertionError):
-        manager.truncate_computed_blocks(blocks, 6)
-
-    # The lookup result itself is never mutated.
     assert [len(group) for group in blocks.blocks] == [3, 2]
 
 
@@ -1786,3 +1747,213 @@ def test_dcp_partial_hit_with_eagle_rewinds_one_hash_unit():
     assert num_computed == 4
     assert [len(group) for group in computed_blocks.blocks] == [1, 1]
     assert manager.allocate_slots(req1, 4, num_computed, computed_blocks) is not None
+
+
+def _snapshot_offload_kv_cache_config(
+    hash_block_size: int, block_size: int, num_blocks: int = 24
+):
+    return KVCacheConfig(
+        num_blocks=num_blocks,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["full"],
+                FullAttentionSpec(
+                    block_size=hash_block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                ),
+            ),
+            KVCacheGroupSpec(
+                ["mamba"],
+                MambaSpec(
+                    block_size=block_size,
+                    shapes=(1, 1),
+                    dtypes=(torch.float32,),
+                    mamba_cache_mode="align",
+                ),
+            ),
+        ],
+    )
+
+
+def test_retention_snapshots_handed_off_with_exact_block_ids():
+    """Under sparse retention, each retained mamba boundary state block is
+    handed to the connector with its exact block id. Connectors must not resolve
+    align-mode state blocks positionally because the block table is not
+    append-only."""
+    hash_block_size = 2
+    block_size = 4
+    manager = make_kv_cache_manager(
+        kv_cache_config=_snapshot_offload_kv_cache_config(hash_block_size, block_size),
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=hash_block_size,
+    )
+    manager.coordinator.retention_interval = 2 * block_size
+
+    req0 = make_request("0", [0] * 16, hash_block_size, sha256)
+    computed_blocks, num_computed, _ = manager.get_computed_blocks(req0)
+    assert manager.allocate_slots(req0, 8, num_computed, computed_blocks) is not None
+
+    mamba_blocks = manager.coordinator.single_type_managers[1].req_to_blocks["0"]
+    offloads = drain_boundary_state_offloads(manager)
+    ((group_id, block_id, boundary),) = offloads["0"]
+    assert group_id == 1
+    assert boundary == 2 * block_size
+    assert block_id == mamba_blocks[1].block_id
+
+    req0.num_computed_tokens = 8
+    manager.new_step_starts()
+    assert manager.allocate_slots(req0, 8) is not None
+
+    offloads = drain_boundary_state_offloads(manager)
+    ((group_id, block_id2, boundary2),) = offloads["0"]
+    assert group_id == 1
+    assert boundary2 == 4 * block_size
+    assert block_id2 == mamba_blocks[3].block_id
+    # Interior align-mode positions stay null and are never handed off.
+    assert mamba_blocks[0].is_null and mamba_blocks[2].is_null
+
+    manager.free(req0)
+
+
+def test_snapshot_handoff_dense_default_retention():
+    """With dense (default) retention, every materialized mamba boundary
+    state block is handed off — regular mamba-align + prefix-match-unit
+    deployments get store-able boundary snapshots without setting
+    VLLM_PREFIX_CACHE_RETENTION_INTERVAL."""
+    hash_block_size = 2
+    block_size = 4
+    manager = make_kv_cache_manager(
+        kv_cache_config=_snapshot_offload_kv_cache_config(hash_block_size, block_size),
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=hash_block_size,
+    )
+    assert manager.coordinator.retention_interval is None
+
+    req0 = make_request("0", [0] * 16, hash_block_size, sha256)
+    computed_blocks, num_computed, _ = manager.get_computed_blocks(req0)
+    assert manager.allocate_slots(req0, 8, num_computed, computed_blocks) is not None
+
+    mamba_blocks = manager.coordinator.single_type_managers[1].req_to_blocks["0"]
+    ((group_id, block_id, boundary),) = drain_boundary_state_offloads(manager)["0"]
+    assert group_id == 1
+    assert boundary == 2 * block_size
+    assert block_id == mamba_blocks[1].block_id
+
+    req0.num_computed_tokens = 8
+    manager.new_step_starts()
+    assert manager.allocate_slots(req0, 8) is not None
+    ((group_id, block_id2, boundary2),) = drain_boundary_state_offloads(manager)["0"]
+    assert group_id == 1
+    assert boundary2 == 4 * block_size
+    assert block_id2 == mamba_blocks[3].block_id
+
+
+def _run_chunked_prefill(manager, req, chunk_size, num_chunks):
+    """Prefill ``req`` one ``chunk_size`` chunk per scheduler step, yielding the
+    boundary-state hand-offs offered (and claimed) at each step."""
+    computed_blocks, num_computed, _ = manager.get_computed_blocks(req)
+    for step in range(num_chunks):
+        manager.new_step_starts()
+        req.num_computed_tokens = step * chunk_size
+        if step == 0:
+            allocated = manager.allocate_slots(
+                req, chunk_size, num_computed, computed_blocks
+            )
+        else:
+            allocated = manager.allocate_slots(req, chunk_size)
+        assert allocated is not None
+        yield drain_boundary_state_offloads(manager).get(req.request_id, [])
+
+
+def test_boundary_state_offer_includes_more_mamba_groups_than_two():
+    """One offer batch carries one exact block entry per mamba group."""
+    block_size = 8
+    num_mamba_groups = 3
+    manager = make_kv_cache_manager(
+        kv_cache_config=KVCacheConfig(
+            num_blocks=200,
+            kv_cache_tensors=[],
+            kv_cache_groups=[
+                KVCacheGroupSpec(
+                    ["full"],
+                    FullAttentionSpec(
+                        block_size=block_size,
+                        num_kv_heads=1,
+                        head_size=1,
+                        dtype=torch.float32,
+                    ),
+                ),
+                *(
+                    KVCacheGroupSpec(
+                        [f"mamba{i}"],
+                        MambaSpec(
+                            block_size=block_size,
+                            shapes=(1, 1),
+                            dtypes=(torch.float32,),
+                            mamba_cache_mode="align",
+                        ),
+                    )
+                    for i in range(num_mamba_groups)
+                ),
+            ],
+        ),
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=block_size,
+    )
+
+    req0 = make_request("0", [0] * (2 * block_size), block_size, sha256)
+    entries = next(_run_chunked_prefill(manager, req0, block_size, 1))
+
+    assert [group_id for group_id, _, _ in entries] == [1, 2, 3]
+    assert {boundary for _, _, boundary in entries} == {block_size}
+
+
+def test_boundary_states_offered_past_prompt_for_resumed_prefill():
+    """The core offers every committed boundary, including past
+    ``num_prompt_tokens``. A resumed request re-prefills its generated tokens
+    and every group re-saves them, so filtering on the original prompt length
+    would silently strip the mamba key for boundaries full attention still
+    stores; only the connector knows where its save window ends."""
+    block_size = 8
+    prompt_len = block_size
+    manager = make_kv_cache_manager(
+        kv_cache_config=_snapshot_offload_kv_cache_config(
+            hash_block_size=block_size, block_size=block_size, num_blocks=200
+        ),
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=block_size,
+    )
+
+    req0 = make_request("0", [0] * prompt_len, block_size, sha256)
+    assert [
+        boundary
+        for entries in _run_chunked_prefill(manager, req0, block_size, 1)
+        for _, _, boundary in entries
+    ] == [prompt_len]
+
+    # Generate past the next mamba boundary, then replay it as a resumed
+    # prefill: its committed boundary is offered even though it is past the
+    # prompt, matching what full attention saves for the same range.
+    for i in range(block_size):
+        manager.new_step_starts()
+        req0.num_computed_tokens = prompt_len + i
+        req0.append_output_token_ids([1])
+        assert manager.allocate_slots(req0, 1) is not None
+        drain_boundary_state_offloads(manager)
+    assert req0.num_tokens == 2 * block_size
+
+    manager.free(req0)
+    manager.new_step_starts()
+    req0.num_computed_tokens = 0
+    computed_blocks, num_computed, _ = manager.get_computed_blocks(req0)
+    assert manager.allocate_slots(req0, req0.num_tokens - num_computed, num_computed)
+    offered = [b for _, _, b in drain_boundary_state_offloads(manager).get("0", [])]
+    assert 2 * block_size in offered
+    assert req0.num_prompt_tokens < 2 * block_size

--- a/tests/v1/core/test_single_type_kv_cache_manager.py
+++ b/tests/v1/core/test_single_type_kv_cache_manager.py
@@ -14,16 +14,48 @@ from vllm.v1.core.kv_cache_utils import (
 )
 from vllm.v1.core.single_type_kv_cache_manager import (
     ChunkedLocalAttentionManager,
+    MambaManager,
     RSWAManager,
     SlidingWindowManager,
 )
 from vllm.v1.kv_cache_interface import (
     ChunkedLocalAttentionSpec,
+    MambaSpec,
     RSWASpec,
     SlidingWindowSpec,
 )
 
 pytestmark = pytest.mark.cpu_test
+
+
+def test_mamba_speculative_block_relocation_requires_exclusive_ownership():
+    spec = MambaSpec(
+        block_size=4,
+        shapes=((1, 1),),
+        dtypes=(torch.float32,),
+        mamba_cache_mode="align",
+        num_speculative_blocks=1,
+    )
+    block_pool = BlockPool(num_gpu_blocks=4, enable_caching=True, hash_block_size=4)
+    manager = MambaManager(
+        spec,
+        block_pool=block_pool,
+        enable_caching=True,
+        kv_cache_group_id=0,
+        scheduler_block_size=4,
+    )
+    block = block_pool.get_new_blocks(1)[0]
+    blocks = [block]
+
+    manager._relocate_speculative_block(blocks, 0)
+
+    assert blocks == [block_pool.null_block, block]
+    assert block.ref_cnt == 1
+
+    pinned_block = block_pool.get_new_blocks(1)[0]
+    block_pool.touch((pinned_block,))
+    with pytest.raises(AssertionError, match="exclusively owned and unhashed"):
+        manager._relocate_speculative_block([pinned_block], 0)
 
 
 def get_sliding_window_manager(sliding_window_spec, block_pool, enable_caching=True):

--- a/tests/v1/core/test_single_type_kv_cache_manager.py
+++ b/tests/v1/core/test_single_type_kv_cache_manager.py
@@ -15,12 +15,14 @@ from vllm.v1.core.kv_cache_utils import (
 from vllm.v1.core.single_type_kv_cache_manager import (
     ChunkedLocalAttentionManager,
     FullAttentionManager,
+    MambaManager,
     RSWAManager,
     SlidingWindowManager,
 )
 from vllm.v1.kv_cache_interface import (
     ChunkedLocalAttentionSpec,
     FullAttentionSpec,
+    MambaSpec,
     RSWASpec,
     SlidingWindowSpec,
 )
@@ -67,6 +69,36 @@ def test_external_computed_blocks_do_not_corrupt_free_pool():
 
     assert block_pool.get_num_free_blocks() == num_free_blocks
     assert len(manager.req_to_blocks[request_id]) == 3
+
+
+def test_mamba_speculative_block_relocation_requires_exclusive_ownership():
+    spec = MambaSpec(
+        block_size=4,
+        shapes=((1, 1),),
+        dtypes=(torch.float32,),
+        mamba_cache_mode="align",
+        num_speculative_blocks=1,
+    )
+    block_pool = BlockPool(num_gpu_blocks=4, enable_caching=True, hash_block_size=4)
+    manager = MambaManager(
+        spec,
+        block_pool=block_pool,
+        enable_caching=True,
+        kv_cache_group_id=0,
+        scheduler_block_size=4,
+    )
+    block = block_pool.get_new_blocks(1)[0]
+    blocks = [block]
+
+    manager._relocate_speculative_block(blocks, 0)
+
+    assert blocks == [block_pool.null_block, block]
+    assert block.ref_cnt == 1
+
+    pinned_block = block_pool.get_new_blocks(1)[0]
+    block_pool.touch((pinned_block,))
+    with pytest.raises(AssertionError, match="exclusively owned and unhashed"):
+        manager._relocate_speculative_block([pinned_block], 0)
 
 
 def get_sliding_window_manager(

--- a/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
+++ b/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
@@ -34,7 +34,8 @@ from vllm.distributed.kv_transfer.kv_connector.v1.offloading.scheduler import (
     is_store_reachable_swa_chunk,
 )
 from vllm.v1.core.kv_cache_manager import KVCacheBlocks
-from vllm.v1.core.kv_cache_utils import BlockHash, KVCacheBlock
+from vllm.v1.core.kv_cache_utils import BlockHash, KVCacheBlock, KVCacheBlockCopy
+from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
     KVCacheGroupSpec,
@@ -103,7 +104,7 @@ def test_partial_tail_store_uses_attention_and_recurrent_cow_sources():
         lambda keys, req_context: generate_store_output(keys)
     )
 
-    output = SimpleNamespace(partial_tail_offloads={"req": [(1, 99, 28)]})
+    output = SimpleNamespace(boundary_state_offloads={"req": [(1, 99, 28)]})
     jobs = scheduler._build_partial_tail_store_jobs(output)
 
     assert len(jobs) == 1
@@ -117,6 +118,77 @@ def test_partial_tail_store_uses_attention_and_recurrent_cow_sources():
         12: {job_id},
         99: {job_id},
     }
+
+
+def test_aligned_boundary_store_uses_exact_source_with_partial_tail():
+    scheduler = _make_partial_tail_scheduler()
+    _make_partial_tail_request(scheduler)
+    req_status = scheduler._req_status["req"]
+    req_status.group_states[0].block_ids[:] = [11, 12]
+    req_status.group_states[1].block_ids[:] = [0, 21]
+    scheduler.manager.prepare_store.side_effect = (
+        lambda keys, req_context: generate_store_output(keys)
+    )
+
+    output = SimpleNamespace(
+        boundary_state_offloads={"req": [(1, 98, 16), (1, 99, 28)]}
+    )
+    jobs = scheduler._build_partial_tail_store_jobs(output)
+
+    assert len(jobs) == 2
+    src_spec = next(
+        job.src_spec for job in jobs.values() if len(job.src_spec.block_ids) == 1
+    )
+    assert isinstance(src_spec, GPULoadStoreSpec)
+    assert src_spec.block_ids.tolist() == [98]
+    assert src_spec.group_sizes == [0, 1]
+    assert src_spec.block_indices == [0, 0]
+
+
+def test_aligned_boundary_store_flushes_before_cow_destination_reuse():
+    scheduler = _make_partial_tail_scheduler()
+    _make_partial_tail_request(scheduler)
+    scheduler.manager.prepare_store.side_effect = (
+        lambda keys, req_context: generate_store_output(keys)
+    )
+
+    output = SchedulerOutput.make_empty()
+    output.boundary_state_offloads = {"req": [(1, 99, 16)]}
+    meta = scheduler.build_connector_meta(output)
+    [job_id] = meta.store_jobs
+
+    output = SchedulerOutput.make_empty()
+    output.kv_cache_block_copies = [KVCacheBlockCopy(98, 99)]
+    meta = scheduler.build_connector_meta(output)
+
+    assert meta.jobs_to_flush == {job_id}
+
+
+def test_normal_store_excludes_align_mode_mamba_sources():
+    scheduler = _make_partial_tail_scheduler()
+    request = _make_partial_tail_request(scheduler)
+    request.num_computed_tokens = 0
+    request.status = RequestStatus.RUNNING
+    req_status = scheduler._req_status["req"]
+    req_status.group_states[0].block_ids[:] = [11]
+    req_status.group_states[1].block_ids[:] = [99]
+    req_status.update_offload_keys()
+    scheduler.manager.prepare_store.side_effect = (
+        lambda keys, req_context: generate_store_output(keys)
+    )
+
+    output = SimpleNamespace(
+        num_scheduled_tokens={"req": 16},
+        finished_req_ids=set(),
+    )
+    jobs = scheduler._build_store_jobs(output)
+
+    assert len(jobs) == 1
+    [job] = jobs.values()
+    src_spec = job.src_spec
+    assert isinstance(src_spec, GPULoadStoreSpec)
+    assert src_spec.block_ids.tolist() == [11]
+    assert src_spec.group_sizes == [1, 0]
 
 
 def test_partial_lookup_returns_exact_boundary_and_group_load_keys():

--- a/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
+++ b/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
@@ -37,7 +37,10 @@ from vllm.distributed.kv_transfer.kv_connector.v1.offloading.scheduler import (
 )
 from vllm.v1.core.kv_cache_manager import KVCacheBlocks
 from vllm.v1.core.kv_cache_utils import BlockHash, KVCacheBlock, KVCacheBlockCopy
-from vllm.v1.core.sched.output import SchedulerOutput
+from vllm.v1.core.sched.output import (
+    KVConnectorBlockState,
+    SchedulerOutput,
+)
 from vllm.v1.kv_cache_interface import (
     ChunkedLocalAttentionSpec,
     FullAttentionSpec,
@@ -112,7 +115,12 @@ def test_partial_tail_store_uses_attention_and_recurrent_cow_sources():
         generate_store_output(keys)
     )
 
-    output = SimpleNamespace(boundary_state_offloads={"req": [(1, 99, 28)]})
+    output = SimpleNamespace(
+        kv_connector_block_state=KVConnectorBlockState(
+            block_ids={},
+            boundary_state_offloads={"req": [(1, 99, 28)]},
+        )
+    )
     jobs = scheduler._build_partial_tail_store_jobs(output)
 
     assert len(jobs) == 1
@@ -167,7 +175,10 @@ def test_aligned_boundary_store_uses_exact_source_with_partial_tail():
     )
 
     output = SimpleNamespace(
-        boundary_state_offloads={"req": [(1, 98, 16), (1, 99, 28)]}
+        kv_connector_block_state=KVConnectorBlockState(
+            block_ids={},
+            boundary_state_offloads={"req": [(1, 98, 16), (1, 99, 28)]},
+        )
     )
     jobs = scheduler._build_partial_tail_store_jobs(output)
 
@@ -189,7 +200,10 @@ def test_aligned_boundary_store_flushes_before_cow_destination_reuse():
     )
 
     output = SchedulerOutput.make_empty()
-    output.boundary_state_offloads = {"req": [(1, 99, 16)]}
+    output.kv_connector_block_state = KVConnectorBlockState(
+        block_ids={},
+        boundary_state_offloads={"req": [(1, 99, 16)]},
+    )
     meta = scheduler.build_connector_meta(output)
     [job_id] = meta.store_jobs
 

--- a/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
+++ b/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
@@ -36,7 +36,8 @@ from vllm.distributed.kv_transfer.kv_connector.v1.offloading.scheduler import (
     is_store_reachable_swa_chunk,
 )
 from vllm.v1.core.kv_cache_manager import KVCacheBlocks
-from vllm.v1.core.kv_cache_utils import BlockHash, KVCacheBlock
+from vllm.v1.core.kv_cache_utils import BlockHash, KVCacheBlock, KVCacheBlockCopy
+from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.v1.kv_cache_interface import (
     ChunkedLocalAttentionSpec,
     FullAttentionSpec,
@@ -107,11 +108,11 @@ def test_partial_tail_store_uses_attention_and_recurrent_cow_sources():
     req_status = scheduler._req_status["req"]
     req_status.group_states[0].block_ids[:] = [11, 12]
     req_status.group_states[1].block_ids[:] = [0, 21]
-    scheduler.manager.prepare_store.side_effect = (
-        lambda keys, req_context: generate_store_output(keys)
+    scheduler.manager.prepare_store.side_effect = lambda keys, req_context: (
+        generate_store_output(keys)
     )
 
-    output = SimpleNamespace(partial_tail_offloads={"req": [(1, 99, 28)]})
+    output = SimpleNamespace(boundary_state_offloads={"req": [(1, 99, 28)]})
     jobs = scheduler._build_partial_tail_store_jobs(output)
 
     assert len(jobs) == 1
@@ -153,6 +154,77 @@ def test_partial_tail_store_uses_attention_and_recurrent_cow_sources():
     assert recurrent_event.token_ids == []
     assert len(recurrent_event.block_hashes) == 1
     assert recurrent_event.parent_block_hash is None
+
+
+def test_aligned_boundary_store_uses_exact_source_with_partial_tail():
+    scheduler = _make_partial_tail_scheduler()
+    _make_partial_tail_request(scheduler)
+    req_status = scheduler._req_status["req"]
+    req_status.group_states[0].block_ids[:] = [11, 12]
+    req_status.group_states[1].block_ids[:] = [0, 21]
+    scheduler.manager.prepare_store.side_effect = lambda keys, req_context: (
+        generate_store_output(keys)
+    )
+
+    output = SimpleNamespace(
+        boundary_state_offloads={"req": [(1, 98, 16), (1, 99, 28)]}
+    )
+    jobs = scheduler._build_partial_tail_store_jobs(output)
+
+    assert len(jobs) == 2
+    src_spec = next(
+        job.src_spec for job in jobs.values() if len(job.src_spec.block_ids) == 1
+    )
+    assert isinstance(src_spec, GPULoadStoreSpec)
+    assert src_spec.block_ids.tolist() == [98]
+    assert src_spec.group_sizes == [0, 1]
+    assert src_spec.block_indices == [0, 0]
+
+
+def test_aligned_boundary_store_flushes_before_cow_destination_reuse():
+    scheduler = _make_partial_tail_scheduler()
+    _make_partial_tail_request(scheduler)
+    scheduler.manager.prepare_store.side_effect = lambda keys, req_context: (
+        generate_store_output(keys)
+    )
+
+    output = SchedulerOutput.make_empty()
+    output.boundary_state_offloads = {"req": [(1, 99, 16)]}
+    meta = scheduler.build_connector_meta(output)
+    [job_id] = meta.store_jobs
+
+    output = SchedulerOutput.make_empty()
+    output.kv_cache_block_copies = [KVCacheBlockCopy(98, 99)]
+    meta = scheduler.build_connector_meta(output)
+
+    assert meta.jobs_to_flush == {job_id}
+
+
+def test_normal_store_excludes_align_mode_mamba_sources():
+    scheduler = _make_partial_tail_scheduler()
+    request = _make_partial_tail_request(scheduler)
+    request.num_computed_tokens = 0
+    request.status = RequestStatus.RUNNING
+    req_status = scheduler._req_status["req"]
+    req_status.group_states[0].block_ids[:] = [11]
+    req_status.group_states[1].block_ids[:] = [99]
+    req_status.update_offload_keys()
+    scheduler.manager.prepare_store.side_effect = lambda keys, req_context: (
+        generate_store_output(keys)
+    )
+
+    output = SimpleNamespace(
+        num_scheduled_tokens={"req": 16},
+        finished_req_ids=set(),
+    )
+    jobs = scheduler._build_store_jobs(output)
+
+    assert len(jobs) == 1
+    [job] = jobs.values()
+    src_spec = job.src_spec
+    assert isinstance(src_spec, GPULoadStoreSpec)
+    assert src_spec.block_ids.tolist() == [11]
+    assert src_spec.group_sizes == [1, 0]
 
 
 def test_partial_lookup_returns_exact_boundary_and_group_load_keys():

--- a/tests/v1/kv_connector/unit/test_mooncake_store_connector.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_connector.py
@@ -20,6 +20,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store import (
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.data import (
     MooncakeStoreConnectorMetadata,
+    MooncakeStoreWorkerMetadata,
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.metrics import (
     MooncakeStoreConnectorStats,
@@ -88,6 +89,10 @@ def test_scheduler_role_initializes_store_scheduler_only():
     mock_worker.assert_not_called()
     assert connector.connector_scheduler is mock_scheduler.return_value
     assert connector.connector_worker is None
+    block_pool = MagicMock()
+
+    connector.bind_gpu_block_pool(block_pool)
+    mock_scheduler.return_value.bind_gpu_block_pool.assert_called_once_with(block_pool)
 
 
 def test_worker_methods_delegate_to_store_worker():
@@ -291,6 +296,44 @@ def test_update_connector_output_and_take_events():
     assert connector._kv_cache_events is kv_events
     assert list(connector.take_events()) == [event]
     assert connector._kv_cache_events is None
+
+
+def test_boundary_handoff_watermark_aggregates_across_ranks():
+    """A hand-off may only be unpinned once *every* rank has finished sending
+    it, so per-rank watermarks aggregate with ``min``."""
+    rank0 = MooncakeStoreWorkerMetadata(boundary_handoff_watermark=7)
+    rank1 = MooncakeStoreWorkerMetadata(boundary_handoff_watermark=4)
+
+    assert rank0.aggregate(rank1).boundary_handoff_watermark == 4
+    assert rank1.aggregate(rank0).boundary_handoff_watermark == 4
+
+
+def test_update_connector_output_forwards_handoff_watermark():
+    vllm_config = _make_vllm_config()
+    kv_cache_config = _make_kv_cache_config()
+
+    with (
+        set_current_vllm_config(vllm_config),
+        patch(
+            "vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store."
+            "connector.MooncakeStoreScheduler"
+        ),
+    ):
+        connector = mooncake_store_connector.MooncakeStoreConnector(
+            vllm_config, KVConnectorRole.SCHEDULER, kv_cache_config
+        )
+
+    connector.update_connector_output(
+        KVConnectorOutput(
+            kv_connector_worker_meta=MooncakeStoreWorkerMetadata(
+                boundary_handoff_watermark=11
+            )
+        )
+    )
+
+    connector.connector_scheduler.update_boundary_handoff_watermark.assert_called_once_with(
+        11
+    )
 
 
 # ============================================================

--- a/tests/v1/kv_connector/unit/test_mooncake_store_connector.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_connector.py
@@ -5,6 +5,9 @@ import threading
 import time
 from unittest.mock import MagicMock, patch
 
+import pytest
+import torch
+
 from vllm.config import set_current_vllm_config
 from vllm.distributed.kv_events import BlockStored
 from vllm.distributed.kv_transfer.kv_connector.v1.base import (
@@ -18,7 +21,9 @@ from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store import (
     scheduler,
     worker,
 )
-from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.data import MooncakeStoreConnectorMetadata
+from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.data import (
+    MooncakeStoreConnectorMetadata,
+)
 from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.metrics import (
     MooncakeStoreConnectorStats,
 )
@@ -27,6 +32,7 @@ from vllm.v1.kv_cache_interface import (
     KVCacheConfig,
     KVCacheGroupSpec,
     KVCacheTensor,
+    MambaSpec,
 )
 from vllm.v1.outputs import KVConnectorOutput
 
@@ -56,6 +62,30 @@ def _make_kv_cache_config() -> KVCacheConfig:
         ],
         kv_cache_groups=[KVCacheGroupSpec(["layer0"], spec)],
     )
+
+
+def test_scheduler_requires_align_mode_for_mamba():
+    vllm_config = _make_vllm_config()
+    mamba_spec = MambaSpec(
+        block_size=16,
+        shapes=((1, 1),),
+        dtypes=(torch.float32,),
+        mamba_cache_mode="none",
+    )
+    kv_cache_config = KVCacheConfig(
+        num_blocks=4,
+        kv_cache_tensors=[],
+        kv_cache_groups=[KVCacheGroupSpec(["mamba"], mamba_spec)],
+    )
+
+    with (
+        patch(
+            "vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store."
+            "scheduler.LookupKeyClient"
+        ),
+        pytest.raises(AssertionError, match="requires mamba_cache_mode='align'"),
+    ):
+        scheduler.MooncakeStoreScheduler(vllm_config, kv_cache_config)
 
 
 def _make_block_stored() -> BlockStored:
@@ -241,7 +271,9 @@ def test_update_connector_output_and_take_events():
     connector.update_connector_output(output)
 
     assert connector._kv_cache_events is kv_events
-    connector.connector_scheduler.update_connector_output.assert_called_once_with(output)
+    connector.connector_scheduler.update_connector_output.assert_called_once_with(
+        output
+    )
     assert list(connector.take_events()) == [event]
     assert connector._kv_cache_events is None
 

--- a/tests/v1/kv_connector/unit/test_mooncake_store_connector.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_connector.py
@@ -18,9 +18,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store import (
     scheduler,
     worker,
 )
-from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.data import (
-    MooncakeStoreConnectorMetadata,
-)
+from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.data import MooncakeStoreConnectorMetadata
 from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.metrics import (
     MooncakeStoreConnectorStats,
 )
@@ -95,6 +93,10 @@ def test_scheduler_role_initializes_store_scheduler_only():
     mock_worker.assert_not_called()
     assert connector.connector_scheduler is mock_scheduler.return_value
     assert connector.connector_worker is None
+    block_pool = MagicMock()
+
+    connector.bind_gpu_block_pool(block_pool)
+    mock_scheduler.return_value.bind_gpu_block_pool.assert_called_once_with(block_pool)
 
 
 def test_worker_methods_delegate_to_store_worker():
@@ -235,9 +237,11 @@ def test_update_connector_output_and_take_events():
 
     kv_events = mooncake_store_connector.MooncakeStoreKVEvents(num_workers=1)
     kv_events.add_events([event])
-    connector.update_connector_output(KVConnectorOutput(kv_cache_events=kv_events))
+    output = KVConnectorOutput(kv_cache_events=kv_events)
+    connector.update_connector_output(output)
 
     assert connector._kv_cache_events is kv_events
+    connector.connector_scheduler.update_connector_output.assert_called_once_with(output)
     assert list(connector.take_events()) == [event]
     assert connector._kv_cache_events is None
 

--- a/tests/v1/kv_connector/unit/test_mooncake_store_coordinator.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_coordinator.py
@@ -451,6 +451,27 @@ def test_store_mask_retention_prefix_stable_as_aligned_length_grows():
     assert longer[: len(shorter)] == shorter
 
 
+def test_store_mask_excludes_mamba_groups_lookup_unaffected():
+    """Align-mode mamba block tables are not append-only (interior states are
+    nulled/freed; speculative blocks relocate), so the positional normal save
+    must never cover mamba chunks — regardless of retention. Lookups still
+    probe mamba boundaries: their keys come from the pinned snapshot/CoW
+    hand-off path instead."""
+    groups = [
+        KVCacheGroupSpec(["L0"], _full(16)),
+        KVCacheGroupSpec(["L1"], _mamba_align(16)),
+    ]
+    coord = _make_coord(groups, hash_block_size=16)
+    masks = coord.store_mask(64)
+    assert masks[0] is None  # full attn stays dense
+    assert masks[1] == [False] * 4
+
+    coord = _make_coord(groups, hash_block_size=16, retention_interval=32)
+    assert coord.store_mask(64)[1] == [False] * 4
+
+    assert coord.lookup_mask(64)[1] is None
+
+
 # ----- Eagle / MTP interaction with load_mask -----
 
 

--- a/tests/v1/kv_connector/unit/test_mooncake_store_hma_e2e.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_hma_e2e.py
@@ -222,10 +222,11 @@ def test_e2e_swa_plus_full_save_then_lookup_hits():
     )
 
     hs = [BlockHash(bytes([i + 1]) * 4) for i in range(4)]
+    # 1-based: block 0 is the reserved null block and the save skips it.
     save_req = ReqMeta(
         req_id="r0",
         token_len_chunk=64,
-        block_ids=([0, 1, 2, 3], [0, 1, 2, 3]),
+        block_ids=([1, 2, 3, 4], [1, 2, 3, 4]),
         block_hashes=hs,
         can_save=True,
     )
@@ -427,10 +428,10 @@ def test_sub_block_partial_tail_offload_reads_cow_block():
         block_hashes=hs,
         can_save=True,
         num_prompt_tokens=20,
-        partial_tail_offloads=[(1, mamba_cow_block, 12)],
+        boundary_state_offloads=[(1, 1, mamba_cow_block, 12)],
     )
 
-    send._maybe_offload_partial_tail(req)
+    send._maybe_offload_boundary_states(req)
 
     # boundary = 12 // 4 * 4 = 12 -> keyed by hs[12 // 4 - 1] = hs[2].
     partial_hash = hs[2]
@@ -498,7 +499,7 @@ def test_offload_syncs_event_before_put():
         block_hashes=hs,
         can_save=True,
         num_prompt_tokens=12,
-        partial_tail_offloads=[(1, 7, 12)],
+        boundary_state_offloads=[(1, 1, 7, 12)],
     )
     req.current_event = event
     send.add_stored_request("r1")
@@ -575,10 +576,10 @@ def test_sub_block_partial_tail_offload_covers_smaller_group_blocks():
         block_hashes=hs,
         can_save=True,
         num_prompt_tokens=12,
-        partial_tail_offloads=[(1, mamba_cow_block, 12)],
+        boundary_state_offloads=[(1, 1, mamba_cow_block, 12)],
     )
 
-    send._maybe_offload_partial_tail(req)
+    send._maybe_offload_boundary_states(req)
 
     # FA (block 4): full blocks ending at 4, 8 and 12, keyed by their normal
     # block-end hashes; mamba (block 16): the partial boundary block under

--- a/tests/v1/kv_connector/unit/test_mooncake_store_hma_e2e.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_hma_e2e.py
@@ -236,6 +236,7 @@ def test_e2e_swa_plus_full_save_then_lookup_hits():
     )
 
     hs = [BlockHash(bytes([i + 1]) * 4) for i in range(4)]
+    # 1-based: block 0 is the reserved null block and the save skips it.
     save_req = ReqMeta(
         req_id="r0",
         token_len_chunk=64,
@@ -441,10 +442,10 @@ def test_sub_block_partial_tail_offload_reads_cow_block():
         block_hashes=hs,
         can_save=True,
         num_prompt_tokens=20,
-        partial_tail_offloads=[(1, mamba_cow_block, 12)],
+        boundary_state_offloads=[(1, mamba_cow_block, 12)],
     )
 
-    send._maybe_offload_partial_tail(req)
+    send._maybe_offload_boundary_states(req)
 
     # boundary = 12 // 4 * 4 = 12 -> keyed by hs[12 // 4 - 1] = hs[2].
     partial_hash = hs[2]
@@ -512,8 +513,8 @@ def test_offload_syncs_event_before_put():
         block_hashes=hs,
         can_save=True,
         num_prompt_tokens=12,
-        partial_tail_offloads=[(1, 7, 12)],
         store_job_id=1,
+        boundary_state_offloads=[(1, 7, 12)],
     )
     req.current_event = event
 
@@ -589,10 +590,10 @@ def test_sub_block_partial_tail_offload_covers_smaller_group_blocks():
         block_hashes=hs,
         can_save=True,
         num_prompt_tokens=12,
-        partial_tail_offloads=[(1, mamba_cow_block, 12)],
+        boundary_state_offloads=[(1, mamba_cow_block, 12)],
     )
 
-    send._maybe_offload_partial_tail(req)
+    send._maybe_offload_boundary_states(req)
 
     # FA (block 4): full blocks ending at 4, 8 and 12, keyed by their normal
     # block-end hashes; mamba (block 16): the partial boundary block under

--- a/tests/v1/kv_connector/unit/test_mooncake_store_scheduler.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_scheduler.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import itertools
 from types import SimpleNamespace
 
 from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.data import (
@@ -13,8 +14,24 @@ from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.scheduler impor
 )
 
 
+class _FakeBlockPool:
+    def __init__(self, num_blocks: int = 32):
+        self.blocks = [SimpleNamespace(block_id=i) for i in range(num_blocks)]
+        self.touched: list[SimpleNamespace] = []
+        self.freed: list[SimpleNamespace] = []
+
+    def touch(self, blocks):
+        self.touched.extend(blocks)
+
+    def free_blocks(self, blocks):
+        self.freed.extend(blocks)
+
+
 def _make_bare_scheduler(
-    *, hash_block_size: int = 16, enable_partial_hash_hits: bool = False
+    *,
+    hash_block_size: int = 16,
+    enable_partial_hash_hits: bool = False,
+    max_inflight_handoffs: int = 8,
 ) -> MooncakeStoreScheduler:
     scheduler = object.__new__(MooncakeStoreScheduler)
     scheduler.kv_role = "kv_both"
@@ -27,6 +44,10 @@ def _make_bare_scheduler(
     scheduler._unfinished_request_ids = {"req-0"}
     scheduler._unfinished_requests = {}
     scheduler._request_trackers = {}
+    scheduler._gpu_block_pool = _FakeBlockPool()
+    scheduler._boundary_handoff_ids = itertools.count(1)
+    scheduler._inflight_handoffs = {}
+    scheduler._max_inflight_handoffs = max_inflight_handoffs
     return scheduler
 
 
@@ -661,9 +682,9 @@ def test_disabled_lookup_reports_no_hit_without_querying_client():
     assert scheduler.load_specs == {}
 
 
-def test_pending_partial_tail_emits_offload_only_reqmeta():
-    # A sub-block prompt never produces a block-aligned save, so the partial-
-    # tail offload arriving this step is emitted as an offload-only ReqMeta
+def test_pending_boundary_state_emits_offload_only_reqmeta():
+    # A sub-block prompt never produces a block-aligned save, so the boundary-
+    # state offload arriving this step is emitted as an offload-only ReqMeta
     # (can_save=True so it takes the normal enqueue path, token_len_chunk=0 so
     # the worker skips the normal save). Pending-offload state delays the free
     # without advancing the normal-save watermark before the put succeeds.
@@ -696,7 +717,7 @@ def test_pending_partial_tail_emits_offload_only_reqmeta():
         ),
         num_scheduled_tokens={},
         scheduled_spec_decode_tokens={},
-        partial_tail_offloads={"req-0": [(1, 7, 12)]},
+        boundary_state_offloads={"req-0": [(1, 7, 12)]},
     )
 
     meta = scheduler.build_connector_meta(out)
@@ -706,14 +727,186 @@ def test_pending_partial_tail_emits_offload_only_reqmeta():
     assert req_meta.req_id == "req-0"
     assert req_meta.can_save is True
     assert req_meta.token_len_chunk == 0
-    assert req_meta.partial_tail_offloads == [(1, 7, 12)]
+    assert req_meta.boundary_state_offloads == [(1, 1, 7, 12)]
     assert req_meta.num_prompt_tokens == 12
     assert req_meta.block_ids == ([0],)
+    assert [block.block_id for block in scheduler._gpu_block_pool.touched] == [7]
+    assert set(scheduler._inflight_handoffs) == {1}
     tracker = scheduler._request_trackers["req-0"]
     assert tracker.num_saved_tokens == 0
     assert tracker.has_pending_offload is True
     request = SimpleNamespace(request_id="req-0")
     assert scheduler.request_finished(request, ([0],)) == (True, None)
+
+
+def test_decode_boundary_state_offload_dropped_unclaimed():
+    # A hand-off past the prefill end can never complete a joint hybrid hit
+    # (every other group stops saving there), so it is neither transferred nor
+    # claimed — leaving the core free to release the block immediately.
+    scheduler = _make_bare_scheduler(hash_block_size=4, enable_partial_hash_hits=True)
+    request = SimpleNamespace(
+        all_token_ids=list(range(24)),
+        block_hashes=[b"h0", b"h1", b"h2", b"h3", b"h4", b"h5"],
+        num_output_placeholders=0,
+        num_prompt_tokens=12,
+    )
+    scheduler._unfinished_requests["req-0"] = (request, ([0],))
+    scheduler._request_trackers["req-0"] = RequestTracker(
+        req_id="req-0",
+        token_len=12,
+        allocated_block_ids=([0],),
+        num_saved_tokens=12,
+        token_ids=list(range(12)),
+        prefill_end_tokens=12,
+    )
+
+    out = SimpleNamespace(
+        finished_req_ids=set(),
+        preempted_req_ids=set(),
+        scheduled_new_reqs=[],
+        scheduled_cached_reqs=SimpleNamespace(
+            req_ids=[],
+            new_block_ids=[],
+            num_computed_tokens=[],
+            resumed_req_ids=set(),
+        ),
+        num_scheduled_tokens={},
+        scheduled_spec_decode_tokens={},
+        # Boundary 16 is a decode boundary for a 12-token prefill.
+        boundary_state_offloads={"req-0": [(1, 7, 16)]},
+    )
+
+    meta = scheduler.build_connector_meta(out)
+
+    assert meta.requests == []
+    assert scheduler._gpu_block_pool.touched == []
+    assert scheduler._request_trackers["req-0"].has_pending_offload is False
+
+
+def _register_offload_request(scheduler, *, prefill_end_tokens, num_prompt_tokens):
+    request = SimpleNamespace(
+        all_token_ids=list(range(64)),
+        block_hashes=[bytes([i]) for i in range(16)],
+        num_output_placeholders=0,
+        num_prompt_tokens=num_prompt_tokens,
+    )
+    scheduler._unfinished_requests["req-0"] = (request, ([0],))
+    scheduler._request_trackers["req-0"] = RequestTracker(
+        req_id="req-0",
+        token_len=prefill_end_tokens,
+        allocated_block_ids=([0],),
+        num_saved_tokens=prefill_end_tokens,
+        token_ids=list(range(prefill_end_tokens)),
+        prefill_end_tokens=prefill_end_tokens,
+    )
+
+
+def _make_offload_only_output(entries):
+    return SimpleNamespace(
+        finished_req_ids=set(),
+        preempted_req_ids=set(),
+        scheduled_new_reqs=[],
+        scheduled_cached_reqs=SimpleNamespace(
+            req_ids=[],
+            new_block_ids=[],
+            num_computed_tokens=[],
+            resumed_req_ids=set(),
+        ),
+        num_scheduled_tokens={},
+        scheduled_spec_decode_tokens={},
+        boundary_state_offloads={"req-0": entries},
+    )
+
+
+def test_resumed_prefill_claims_boundaries_past_prompt_length():
+    # A resumed request re-prefills its previously generated tokens, so its
+    # save window (`prefill_end_tokens`) extends past `num_prompt_tokens`.
+    # Boundaries in that range must still be claimed, or the mamba key would be
+    # missing for boundaries full attention does store and no joint hit could
+    # complete there.
+    scheduler = _make_bare_scheduler(hash_block_size=4, enable_partial_hash_hits=True)
+    _register_offload_request(scheduler, prefill_end_tokens=20, num_prompt_tokens=12)
+    out = _make_offload_only_output([(1, 7, 16), (1, 9, 20), (1, 11, 24)])
+
+    meta = scheduler.build_connector_meta(out)
+
+    # 16 and 20 are inside the resumed prefill; 24 is past it.
+    assert meta.requests[0].boundary_state_offloads == [(1, 1, 7, 16), (2, 1, 9, 20)]
+    assert [block.block_id for block in scheduler._gpu_block_pool.touched] == [7, 9]
+    assert set(scheduler._inflight_handoffs) == {1, 2}
+
+
+def test_boundary_state_claims_stop_at_inflight_limit():
+    # Each claim pins a mamba state block, so past the cap the remaining
+    # hand-offs are simply not claimed: a lost cache-save opportunity, never an
+    # early release of a block whose transfer is still queued.
+    scheduler = _make_bare_scheduler(
+        hash_block_size=4, enable_partial_hash_hits=True, max_inflight_handoffs=2
+    )
+    _register_offload_request(scheduler, prefill_end_tokens=64, num_prompt_tokens=64)
+    out = _make_offload_only_output([(1, 7, 16), (1, 8, 32), (1, 9, 48)])
+
+    meta = scheduler.build_connector_meta(out)
+
+    assert meta.requests[0].boundary_state_offloads == [(1, 1, 7, 16), (2, 1, 8, 32)]
+    assert [block.block_id for block in scheduler._gpu_block_pool.touched] == [7, 8]
+    assert set(scheduler._inflight_handoffs) == {1, 2}
+
+    # Still saturated on the next step, so nothing new is claimed...
+    out = _make_offload_only_output([(1, 10, 48)])
+    assert scheduler.build_connector_meta(out).requests == []
+    assert [block.block_id for block in scheduler._gpu_block_pool.touched] == [7, 8]
+
+    # ...until the worker reports both sends done, which releases both pins.
+    scheduler.update_boundary_handoff_watermark(2)
+    assert [block.block_id for block in scheduler._gpu_block_pool.freed] == [7, 8]
+    out = _make_offload_only_output([(1, 10, 48)])
+    meta = scheduler.build_connector_meta(out)
+    assert meta.requests[0].boundary_state_offloads == [(3, 1, 10, 48)]
+    assert set(scheduler._inflight_handoffs) == {3}
+
+
+def test_boundary_state_release_is_per_entry():
+    # The watermark releases exactly the entries the worker has finished with;
+    # a later, still-queued hand-off keeps its pin.
+    scheduler = _make_bare_scheduler(hash_block_size=4, enable_partial_hash_hits=True)
+    _register_offload_request(scheduler, prefill_end_tokens=64, num_prompt_tokens=64)
+    scheduler.build_connector_meta(_make_offload_only_output([(1, 7, 16), (1, 8, 32)]))
+
+    scheduler.update_boundary_handoff_watermark(1)
+    assert [block.block_id for block in scheduler._gpu_block_pool.freed] == [7]
+    assert set(scheduler._inflight_handoffs) == {2}
+
+
+def test_preemption_and_request_id_reuse_do_not_release_inflight_pin():
+    scheduler = _make_bare_scheduler(hash_block_size=4, enable_partial_hash_hits=True)
+    _register_offload_request(scheduler, prefill_end_tokens=64, num_prompt_tokens=64)
+    scheduler.build_connector_meta(_make_offload_only_output([(1, 7, 16)]))
+
+    scheduler.build_connector_meta(_make_preemption_scheduler_output())
+    assert scheduler._gpu_block_pool.freed == []
+    assert set(scheduler._inflight_handoffs) == {1}
+
+    _register_offload_request(scheduler, prefill_end_tokens=64, num_prompt_tokens=64)
+    meta = scheduler.build_connector_meta(_make_offload_only_output([(1, 8, 32)]))
+    assert meta.requests[0].boundary_state_offloads == [(2, 1, 8, 32)]
+
+    scheduler.update_boundary_handoff_watermark(1)
+    assert [block.block_id for block in scheduler._gpu_block_pool.freed] == [7]
+    assert set(scheduler._inflight_handoffs) == {2}
+
+
+def test_boundary_state_never_claimed_without_a_send_thread():
+    # kv_consumer has no send thread to acknowledge a hand-off, so claiming one
+    # would pin a state block until the request's blocks are freed.
+    scheduler = _make_bare_scheduler(hash_block_size=4, enable_partial_hash_hits=True)
+    scheduler.kv_role = "kv_consumer"
+    _register_offload_request(scheduler, prefill_end_tokens=64, num_prompt_tokens=64)
+    out = _make_offload_only_output([(1, 7, 16)])
+
+    assert scheduler.build_connector_meta(out).requests == []
+    assert scheduler._gpu_block_pool.touched == []
+    assert scheduler._inflight_handoffs == {}
 
 
 def test_resumed_partial_tail_uses_handoff_boundary():
@@ -747,13 +940,13 @@ def test_resumed_partial_tail_uses_handoff_boundary():
         ),
         num_scheduled_tokens={},
         scheduled_spec_decode_tokens={},
-        partial_tail_offloads={"req-0": [(1, 7, 12)]},
+        boundary_state_offloads={"req-0": [(1, 7, 12)]},
     )
 
     meta = scheduler.build_connector_meta(out)
 
     assert len(meta.requests) == 1
-    assert meta.requests[0].partial_tail_offloads == [(1, 7, 12)]
+    assert meta.requests[0].boundary_state_offloads == [(1, 1, 7, 12)]
     # Ordinary metadata retains the full resumed prefill range.
     assert meta.requests[0].num_prompt_tokens == 20
     tracker = scheduler._request_trackers["req-0"]
@@ -779,13 +972,13 @@ def test_resumed_partial_tail_attached_to_save_keeps_handoff_boundary():
         prefill_end_tokens=48,
     )
     out = _make_scheduler_output(scheduled_spec_tokens=None)
-    out.partial_tail_offloads = {"req-0": [(0, 7, 36)]}
+    out.boundary_state_offloads = {"req-0": [(0, 7, 36)]}
 
     meta = scheduler.build_connector_meta(out)
 
     assert len(meta.requests) == 1
     assert meta.requests[0].can_save is True
-    assert meta.requests[0].partial_tail_offloads == [(0, 7, 36)]
+    assert meta.requests[0].boundary_state_offloads == [(1, 0, 7, 36)]
     assert meta.requests[0].num_prompt_tokens == 48
     # Ordinary saving still covers the full resumed prefill range.
     tracker = scheduler._request_trackers["req-0"]

--- a/tests/v1/kv_connector/unit/test_mooncake_store_scheduler.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_scheduler.py
@@ -15,6 +15,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.scheduler impor
     MooncakeStoreScheduler,
 )
 from vllm.v1.core.block_pool import BlockPool
+from vllm.v1.core.sched.output import KVConnectorBlockState
 
 
 def _make_bare_scheduler(
@@ -50,6 +51,16 @@ def _make_bare_scheduler(
     return scheduler
 
 
+def _make_connector_block_state(
+    block_ids: tuple[list[int], ...] | None = None,
+    offloads: list[tuple[int, int, int]] | None = None,
+) -> KVConnectorBlockState:
+    return KVConnectorBlockState(
+        block_ids={} if block_ids is None else {"req-0": block_ids},
+        boundary_state_offloads=({} if offloads is None else {"req-0": offloads}),
+    )
+
+
 def _make_scheduler_output(*, scheduled_spec_tokens: list[int] | None):
     return SimpleNamespace(
         finished_req_ids=set(),
@@ -65,6 +76,7 @@ def _make_scheduler_output(*, scheduled_spec_tokens: list[int] | None):
         scheduled_spec_decode_tokens=(
             {"req-0": scheduled_spec_tokens} if scheduled_spec_tokens else {}
         ),
+        kv_connector_block_state=_make_connector_block_state(block_ids=([0, 1, 2],)),
     )
 
 
@@ -84,6 +96,7 @@ def _make_decode_scheduler_output(
         ),
         num_scheduled_tokens={"req-0": num_scheduled_tokens},
         scheduled_spec_decode_tokens={},
+        kv_connector_block_state=_make_connector_block_state(block_ids=([0, 1, 2],)),
     )
 
 
@@ -109,6 +122,7 @@ def _make_new_scheduler_output() -> SimpleNamespace:
         ),
         num_scheduled_tokens={"req-0": 32},
         scheduled_spec_decode_tokens={},
+        kv_connector_block_state=_make_connector_block_state(block_ids=([0, 1],)),
     )
 
 
@@ -491,6 +505,7 @@ def _make_resumed_scheduler_output(*, num_scheduled_tokens: int) -> SimpleNamesp
         ),
         num_scheduled_tokens={"req-0": num_scheduled_tokens},
         scheduled_spec_decode_tokens={},
+        kv_connector_block_state=_make_connector_block_state(block_ids=([0, 1, 2],)),
     )
 
 
@@ -915,7 +930,10 @@ def _add_pending_partial_tail_request(
         ),
         num_scheduled_tokens={},
         scheduled_spec_decode_tokens={},
-        boundary_state_offloads={"req-0": [(1, 7, 12)]},
+        kv_connector_block_state=_make_connector_block_state(
+            block_ids=block_ids,
+            offloads=[(1, 7, 12)],
+        ),
     )
 
 
@@ -944,7 +962,8 @@ def test_pending_partial_tail_emits_offload_only_reqmeta():
     assert req_meta.num_prompt_tokens == 12
     assert req_meta.block_ids == ([0],)
     store_job_id = req_meta.store_job_id
-    assert scheduler._pinned_saves[store_job_id][0] == [7, 0]
+    assert scheduler._pinned_saves[store_job_id][0] == [7]
+    assert scheduler._gpu_block_pool.blocks[0].ref_cnt == 0
     assert scheduler._gpu_block_pool.blocks[7].ref_cnt == 1
     tracker = scheduler._request_trackers["req-0"]
     assert tracker.num_saved_tokens == 0
@@ -985,7 +1004,7 @@ def test_decode_boundary_state_offload_dropped_unclaimed():
         num_scheduled_tokens={},
         scheduled_spec_decode_tokens={},
         # Boundary 16 is a decode boundary for a 12-token prefill.
-        boundary_state_offloads={"req-0": [(1, 7, 16)]},
+        kv_connector_block_state=_make_connector_block_state(offloads=[(1, 7, 16)]),
     )
 
     meta = scheduler.build_connector_meta(out)
@@ -1014,7 +1033,7 @@ def _register_offload_request(scheduler, *, prefill_end_tokens, num_prompt_token
     )
 
 
-def _make_offload_only_output(entries):
+def _make_offload_only_output(entries, block_ids=([0],)):
     return SimpleNamespace(
         finished_req_ids=set(),
         preempted_req_ids=set(),
@@ -1027,7 +1046,10 @@ def _make_offload_only_output(entries):
         ),
         num_scheduled_tokens={},
         scheduled_spec_decode_tokens={},
-        boundary_state_offloads={"req-0": entries},
+        kv_connector_block_state=_make_connector_block_state(
+            block_ids=block_ids,
+            offloads=entries,
+        ),
     )
 
 
@@ -1046,14 +1068,16 @@ def test_resumed_prefill_claims_boundaries_past_prompt_length():
     # 16 and 20 are inside the resumed prefill; 24 is past it.
     assert meta.requests[0].boundary_state_offloads == [(1, 7, 16), (1, 9, 20)]
     store_job_id = meta.requests[0].store_job_id
-    assert scheduler._pinned_saves[store_job_id][0] == [7, 9, 0]
+    assert scheduler._pinned_saves[store_job_id][0] == [7, 9]
 
 
 def test_boundary_state_job_pins_exact_blocks_once():
     scheduler = _make_bare_scheduler(hash_block_size=4, enable_partial_hash_hits=True)
     _register_offload_request(scheduler, prefill_end_tokens=64, num_prompt_tokens=64)
     scheduler._request_trackers["req-0"].allocated_block_ids = ([7],)
-    out = _make_offload_only_output([(1, 7, 16), (1, 8, 32), (1, 9, 48)])
+    out = _make_offload_only_output(
+        [(1, 7, 16), (1, 8, 32), (1, 9, 48)], block_ids=([7],)
+    )
 
     meta = scheduler.build_connector_meta(out)
 
@@ -1077,6 +1101,67 @@ def test_boundary_state_job_pins_exact_blocks_once():
         0,
         0,
     ]
+
+
+def test_store_job_pins_current_non_null_non_mamba_blocks():
+    scheduler = _make_bare_scheduler(hash_block_size=4, enable_partial_hash_hits=True)
+    request = SimpleNamespace(
+        all_token_ids=list(range(48)),
+        block_hashes=[bytes([i]) for i in range(12)],
+        num_output_placeholders=0,
+    )
+    scheduler._unfinished_requests["req-0"] = (request, ([7, 2, 0], [21, 0, 22]))
+    scheduler._request_trackers["req-0"] = RequestTracker(
+        req_id="req-0",
+        token_len=44,
+        allocated_block_ids=([7, 2, 0], [21, 0, 22]),
+        num_saved_tokens=32,
+        token_ids=list(range(44)),
+        prefill_end_tokens=48,
+    )
+    stale_block_ids = ([7, 2, 0, 5], [21, 0, 22, 23])
+    current_block_ids = ([7, 2, 0, 6], [24, 0, 25, 26])
+    out = SimpleNamespace(
+        finished_req_ids=set(),
+        preempted_req_ids=set(),
+        scheduled_new_reqs=[],
+        scheduled_cached_reqs=SimpleNamespace(
+            req_ids=["req-0"],
+            new_block_ids=[([5], [23])],
+            num_computed_tokens=[44],
+            resumed_req_ids=set(),
+        ),
+        num_scheduled_tokens={"req-0": 4},
+        scheduled_spec_decode_tokens={},
+        kv_connector_block_state=_make_connector_block_state(
+            block_ids=current_block_ids,
+            offloads=[(1, 8, 16)],
+        ),
+    )
+    pool = scheduler._gpu_block_pool
+
+    meta = scheduler.build_connector_meta(out)
+
+    assert scheduler._request_trackers["req-0"].allocated_block_ids == stale_block_ids
+    req_meta = meta.requests[0]
+    assert req_meta.block_ids == current_block_ids
+    store_job_id = req_meta.store_job_id
+    assert scheduler._pinned_saves[store_job_id][0] == [8, 7, 2, 6]
+    assert pool.blocks[0].ref_cnt == 0
+    assert pool.blocks[5].ref_cnt == 0
+    assert [pool.blocks[i].ref_cnt for i in (21, 22, 23, 24, 25, 26)] == [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+    ]
+    assert [pool.blocks[i].ref_cnt for i in (8, 7, 2, 6)] == [1, 1, 1, 1]
+
+    scheduler.update_connector_output(_make_worker_output({store_job_id: 1}))
+
+    assert [pool.blocks[i].ref_cnt for i in (8, 7, 2, 6)] == [0, 0, 0, 0]
 
 
 def test_boundary_state_release_is_per_store_job():
@@ -1168,7 +1253,7 @@ def test_resumed_partial_tail_attached_to_save_keeps_exact_boundary():
         prefill_end_tokens=48,
     )
     out = _make_scheduler_output(scheduled_spec_tokens=None)
-    out.boundary_state_offloads = {"req-0": [(0, 7, 36)]}
+    out.kv_connector_block_state.boundary_state_offloads = {"req-0": [(0, 7, 36)]}
 
     meta = scheduler.build_connector_meta(out)
 
@@ -1200,7 +1285,8 @@ def test_partial_tail_cow_block_is_referenced_for_the_job():
     store_job_id = meta.requests[0].store_job_id
     # It leads the list, as in `pop_blocks_for_free`, so that the reversed free
     # puts it last in eviction priority.
-    assert scheduler._pinned_saves[store_job_id][0] == [7, 0]
+    assert scheduler._pinned_saves[store_job_id][0] == [7]
+    assert pool.blocks[0].ref_cnt == 0
     assert pool.blocks[7].ref_cnt == 1
 
     scheduler.update_connector_output(_make_worker_output({store_job_id: 1}))

--- a/tests/v1/kv_connector/unit/test_mooncake_store_scheduler.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_scheduler.py
@@ -914,7 +914,7 @@ def _add_pending_partial_tail_request(
         ),
         num_scheduled_tokens={},
         scheduled_spec_decode_tokens={},
-        partial_tail_offloads={"req-0": [(1, 7, 12)]},
+        boundary_state_offloads={"req-0": [(1, 7, 12)]},
     )
 
 
@@ -939,15 +939,195 @@ def test_pending_partial_tail_emits_offload_only_reqmeta():
     assert req_meta.req_id == "req-0"
     assert req_meta.can_save is True
     assert req_meta.token_len_chunk == 0
-    assert req_meta.partial_tail_offloads == [(1, 7, 12)]
+    assert req_meta.boundary_state_offloads == [(1, 7, 12)]
     assert req_meta.num_prompt_tokens == 12
     assert req_meta.block_ids == ([0],)
+    store_job_id = req_meta.store_job_id
+    assert scheduler._pinned_saves[store_job_id][0] == [7, 0]
+    assert scheduler._gpu_block_pool.blocks[7].ref_cnt == 1
     tracker = scheduler._request_trackers["req-0"]
     assert tracker.num_saved_tokens == 0
     assert tracker.has_pending_offload is True
 
 
-def test_resumed_partial_tail_uses_handoff_boundary():
+def test_decode_boundary_state_offload_dropped_unclaimed():
+    # A hand-off past the prefill end can never complete a joint hybrid hit
+    # (every other group stops saving there), so it is neither transferred nor
+    # claimed — leaving the core free to release the block immediately.
+    scheduler = _make_bare_scheduler(hash_block_size=4, enable_partial_hash_hits=True)
+    request = SimpleNamespace(
+        all_token_ids=list(range(24)),
+        block_hashes=[b"h0", b"h1", b"h2", b"h3", b"h4", b"h5"],
+        num_output_placeholders=0,
+        num_prompt_tokens=12,
+    )
+    scheduler._unfinished_requests["req-0"] = (request, ([0],))
+    scheduler._request_trackers["req-0"] = RequestTracker(
+        req_id="req-0",
+        token_len=12,
+        allocated_block_ids=([0],),
+        num_saved_tokens=12,
+        token_ids=list(range(12)),
+        prefill_end_tokens=12,
+    )
+
+    out = SimpleNamespace(
+        finished_req_ids=set(),
+        preempted_req_ids=set(),
+        scheduled_new_reqs=[],
+        scheduled_cached_reqs=SimpleNamespace(
+            req_ids=[],
+            new_block_ids=[],
+            num_computed_tokens=[],
+            resumed_req_ids=set(),
+        ),
+        num_scheduled_tokens={},
+        scheduled_spec_decode_tokens={},
+        # Boundary 16 is a decode boundary for a 12-token prefill.
+        boundary_state_offloads={"req-0": [(1, 7, 16)]},
+    )
+
+    meta = scheduler.build_connector_meta(out)
+
+    assert meta.requests == []
+    assert scheduler._pinned_saves == {}
+    assert scheduler._gpu_block_pool.blocks[7].ref_cnt == 0
+    assert scheduler._request_trackers["req-0"].has_pending_offload is False
+
+
+def _register_offload_request(scheduler, *, prefill_end_tokens, num_prompt_tokens):
+    request = SimpleNamespace(
+        all_token_ids=list(range(64)),
+        block_hashes=[bytes([i]) for i in range(16)],
+        num_output_placeholders=0,
+        num_prompt_tokens=num_prompt_tokens,
+    )
+    scheduler._unfinished_requests["req-0"] = (request, ([0],))
+    scheduler._request_trackers["req-0"] = RequestTracker(
+        req_id="req-0",
+        token_len=prefill_end_tokens,
+        allocated_block_ids=([0],),
+        num_saved_tokens=prefill_end_tokens,
+        token_ids=list(range(prefill_end_tokens)),
+        prefill_end_tokens=prefill_end_tokens,
+    )
+
+
+def _make_offload_only_output(entries):
+    return SimpleNamespace(
+        finished_req_ids=set(),
+        preempted_req_ids=set(),
+        scheduled_new_reqs=[],
+        scheduled_cached_reqs=SimpleNamespace(
+            req_ids=[],
+            new_block_ids=[],
+            num_computed_tokens=[],
+            resumed_req_ids=set(),
+        ),
+        num_scheduled_tokens={},
+        scheduled_spec_decode_tokens={},
+        boundary_state_offloads={"req-0": entries},
+    )
+
+
+def test_resumed_prefill_claims_boundaries_past_prompt_length():
+    # A resumed request re-prefills its previously generated tokens, so its
+    # save window (`prefill_end_tokens`) extends past `num_prompt_tokens`.
+    # Boundaries in that range must still be claimed, or the mamba key would be
+    # missing for boundaries full attention does store and no joint hit could
+    # complete there.
+    scheduler = _make_bare_scheduler(hash_block_size=4, enable_partial_hash_hits=True)
+    _register_offload_request(scheduler, prefill_end_tokens=20, num_prompt_tokens=12)
+    out = _make_offload_only_output([(1, 7, 16), (1, 9, 20), (1, 11, 24)])
+
+    meta = scheduler.build_connector_meta(out)
+
+    # 16 and 20 are inside the resumed prefill; 24 is past it.
+    assert meta.requests[0].boundary_state_offloads == [(1, 7, 16), (1, 9, 20)]
+    store_job_id = meta.requests[0].store_job_id
+    assert scheduler._pinned_saves[store_job_id][0] == [7, 9, 0]
+
+
+def test_boundary_state_job_pins_exact_blocks_once():
+    scheduler = _make_bare_scheduler(hash_block_size=4, enable_partial_hash_hits=True)
+    _register_offload_request(scheduler, prefill_end_tokens=64, num_prompt_tokens=64)
+    scheduler._request_trackers["req-0"].allocated_block_ids = ([7],)
+    out = _make_offload_only_output([(1, 7, 16), (1, 8, 32), (1, 9, 48)])
+
+    meta = scheduler.build_connector_meta(out)
+
+    req_meta = meta.requests[0]
+    assert req_meta.boundary_state_offloads == [
+        (1, 7, 16),
+        (1, 8, 32),
+        (1, 9, 48),
+    ]
+    store_job_id = req_meta.store_job_id
+    assert scheduler._pinned_saves[store_job_id][0] == [7, 8, 9]
+    assert [scheduler._gpu_block_pool.blocks[i].ref_cnt for i in (7, 8, 9)] == [
+        1,
+        1,
+        1,
+    ]
+
+    scheduler.update_connector_output(_make_worker_output({store_job_id: 1}))
+    assert [scheduler._gpu_block_pool.blocks[i].ref_cnt for i in (7, 8, 9)] == [
+        0,
+        0,
+        0,
+    ]
+
+
+def test_boundary_state_release_is_per_store_job():
+    scheduler = _make_bare_scheduler(hash_block_size=4, enable_partial_hash_hits=True)
+    _register_offload_request(scheduler, prefill_end_tokens=64, num_prompt_tokens=64)
+    first = scheduler.build_connector_meta(_make_offload_only_output([(1, 7, 16)]))
+    second = scheduler.build_connector_meta(_make_offload_only_output([(1, 8, 32)]))
+    first_job_id = first.requests[0].store_job_id
+    second_job_id = second.requests[0].store_job_id
+
+    scheduler.update_connector_output(_make_worker_output({first_job_id: 1}))
+
+    assert scheduler._gpu_block_pool.blocks[7].ref_cnt == 0
+    assert scheduler._gpu_block_pool.blocks[8].ref_cnt == 1
+    assert first_job_id not in scheduler._pinned_saves
+    assert second_job_id in scheduler._pinned_saves
+
+
+def test_preemption_and_request_id_reuse_do_not_release_inflight_job():
+    scheduler = _make_bare_scheduler(hash_block_size=4, enable_partial_hash_hits=True)
+    _register_offload_request(scheduler, prefill_end_tokens=64, num_prompt_tokens=64)
+    first = scheduler.build_connector_meta(_make_offload_only_output([(1, 7, 16)]))
+    first_job_id = first.requests[0].store_job_id
+
+    scheduler.build_connector_meta(_make_preemption_scheduler_output())
+    assert scheduler._gpu_block_pool.blocks[7].ref_cnt == 1
+    assert first_job_id in scheduler._pinned_saves
+
+    _register_offload_request(scheduler, prefill_end_tokens=64, num_prompt_tokens=64)
+    second = scheduler.build_connector_meta(_make_offload_only_output([(1, 8, 32)]))
+    second_job_id = second.requests[0].store_job_id
+    assert second.requests[0].boundary_state_offloads == [(1, 8, 32)]
+
+    scheduler.update_connector_output(_make_worker_output({first_job_id: 1}))
+    assert scheduler._gpu_block_pool.blocks[7].ref_cnt == 0
+    assert scheduler._gpu_block_pool.blocks[8].ref_cnt == 1
+    assert second_job_id in scheduler._pinned_saves
+
+
+def test_boundary_state_never_claimed_without_a_send_thread():
+    # A kv_consumer has no store job that can acknowledge the block reference.
+    scheduler = _make_bare_scheduler(hash_block_size=4, enable_partial_hash_hits=True)
+    scheduler.kv_role = "kv_consumer"
+    _register_offload_request(scheduler, prefill_end_tokens=64, num_prompt_tokens=64)
+    out = _make_offload_only_output([(1, 7, 16)])
+
+    assert scheduler.build_connector_meta(out).requests == []
+    assert scheduler._pinned_saves == {}
+    assert scheduler._gpu_block_pool.blocks[7].ref_cnt == 0
+
+
+def test_resumed_partial_tail_uses_exact_boundary():
     scheduler = _make_bare_scheduler(hash_block_size=4, enable_partial_hash_hits=True)
     # Resumption replays prompt + previously generated tokens.
     out = _add_pending_partial_tail_request(
@@ -960,7 +1140,7 @@ def test_resumed_partial_tail_uses_handoff_boundary():
     meta = scheduler.build_connector_meta(out)
 
     assert len(meta.requests) == 1
-    assert meta.requests[0].partial_tail_offloads == [(1, 7, 12)]
+    assert meta.requests[0].boundary_state_offloads == [(1, 7, 12)]
     # Ordinary metadata retains the full resumed prefill range.
     assert meta.requests[0].num_prompt_tokens == 20
     tracker = scheduler._request_trackers["req-0"]
@@ -968,7 +1148,7 @@ def test_resumed_partial_tail_uses_handoff_boundary():
     assert tracker.has_pending_offload is True
 
 
-def test_resumed_partial_tail_attached_to_save_keeps_handoff_boundary():
+def test_resumed_partial_tail_attached_to_save_keeps_exact_boundary():
     scheduler = _make_bare_scheduler(hash_block_size=4, enable_partial_hash_hits=True)
     request = SimpleNamespace(
         all_token_ids=list(range(48)),
@@ -986,13 +1166,13 @@ def test_resumed_partial_tail_attached_to_save_keeps_handoff_boundary():
         prefill_end_tokens=48,
     )
     out = _make_scheduler_output(scheduled_spec_tokens=None)
-    out.partial_tail_offloads = {"req-0": [(0, 7, 36)]}
+    out.boundary_state_offloads = {"req-0": [(0, 7, 36)]}
 
     meta = scheduler.build_connector_meta(out)
 
     assert len(meta.requests) == 1
     assert meta.requests[0].can_save is True
-    assert meta.requests[0].partial_tail_offloads == [(0, 7, 36)]
+    assert meta.requests[0].boundary_state_offloads == [(0, 7, 36)]
     assert meta.requests[0].num_prompt_tokens == 48
     # Ordinary saving still covers the full resumed prefill range.
     tracker = scheduler._request_trackers["req-0"]

--- a/tests/v1/kv_connector/unit/test_mooncake_store_scheduler.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_scheduler.py
@@ -46,6 +46,7 @@ def _make_bare_scheduler(
     scheduler._num_workers = 1
     scheduler._next_store_job_id = 0
     scheduler._pinned_saves = {}
+    scheduler._boundary_state_group_ids = frozenset({1})
     return scheduler
 
 
@@ -1150,6 +1151,7 @@ def test_resumed_partial_tail_uses_exact_boundary():
 
 def test_resumed_partial_tail_attached_to_save_keeps_exact_boundary():
     scheduler = _make_bare_scheduler(hash_block_size=4, enable_partial_hash_hits=True)
+    scheduler._boundary_state_group_ids = frozenset({0})
     request = SimpleNamespace(
         all_token_ids=list(range(48)),
         block_hashes=[b"h0", b"h1", b"h2"],

--- a/tests/v1/kv_connector/unit/test_mooncake_store_worker.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_worker.py
@@ -34,6 +34,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.data import (
 from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.metrics import (
     MooncakeStoreConnectorStats,
 )
+from vllm.v1.attention.backends.utils import NULL_BLOCK_ID
 from vllm.v1.core.kv_cache_utils import BlockHash
 
 
@@ -157,10 +158,11 @@ def _make_load_req(
 
 
 def _make_store_req(req_id: str, block_hashes: list[bytes]) -> ReqMeta:
+    # 1-based: block 0 is the reserved null block and the save skips it.
     return ReqMeta(
         req_id=req_id,
         token_len_chunk=32,
-        block_ids=([0, 1],),
+        block_ids=([1, 2],),
         block_hashes=block_hashes,
         can_save=True,
     )
@@ -170,7 +172,7 @@ def _make_multi_group_store_req(req_id: str, block_hashes: list[bytes]) -> ReqMe
     return ReqMeta(
         req_id=req_id,
         token_len_chunk=32,
-        block_ids=([0, 1], [2, 3]),
+        block_ids=([1, 2], [3, 4]),
         block_hashes=block_hashes,
         can_save=True,
     )
@@ -503,7 +505,7 @@ def test_store_sending_thread_delta_saves_only_new_full_attention_chunks():
         ReqMeta(
             req_id="req-a",
             token_len_chunk=64,
-            block_ids=([0, 1, 2, 3],),
+            block_ids=([1, 2, 3, 4],),
             block_hashes=[b"a0", b"a1", b"a2", b"a3"],
             can_save=True,
         )
@@ -529,7 +531,7 @@ def test_store_sending_thread_delta_strides_with_local_phase():
         ReqMeta(
             req_id="req-a",
             token_len_chunk=64,
-            block_ids=([0, 1, 2, 3],),
+            block_ids=([1, 2, 3, 4],),
             block_hashes=[b"a0", b"a1", b"a2", b"a3"],
             can_save=True,
         )
@@ -555,7 +557,7 @@ def test_tp_sharded_group_saves_every_block_on_every_rank():
         ReqMeta(
             req_id="req-a",
             token_len_chunk=64,
-            block_ids=([0, 1, 2, 3],),
+            block_ids=([1, 2, 3, 4],),
             block_hashes=[b"a0", b"a1", b"a2", b"a3"],
             can_save=True,
         )
@@ -581,7 +583,7 @@ def test_store_sending_thread_retries_skipped_range_after_pressure():
         ReqMeta(
             req_id="req-a",
             token_len_chunk=16,
-            block_ids=([0],),
+            block_ids=([1],),
             block_hashes=[b"a0"],
             can_save=True,
         )
@@ -600,7 +602,7 @@ def test_store_sending_thread_retries_skipped_range_after_pressure():
         ReqMeta(
             req_id="req-a",
             token_len_chunk=64,
-            block_ids=([0, 1, 2, 3],),
+            block_ids=([1, 2, 3, 4],),
             block_hashes=[b"a0", b"a1", b"a2", b"a3"],
             can_save=True,
         )
@@ -633,10 +635,18 @@ def _make_partial_tail_send_thread(
     )
     db.set_kv_caches_base_addr([0x1000])
     db.set_block_len([256])
+    # Group 1 models the mamba "align" group the hand-offs reference.
+    db_mamba = ChunkedTokenDatabase(
+        KeyMetadata("test-model", 0, 0, 0, 0, group_id=1),
+        block_size=16,
+        hash_block_size=4,
+    )
+    db_mamba.set_kv_caches_base_addr([0x2000])
+    db_mamba.set_block_len([256])
     return _make_store_sending_thread(
         store,
         coord=coord,
-        token_databases=[db],
+        token_databases=[db, db_mamba],
         replicate_config=replicate_config,
         enable_group_semantics=enable_group_semantics,
         supports_group_ids=supports_group_ids,
@@ -647,20 +657,20 @@ def _make_partial_tail_req(block_ids: list[int]) -> ReqMeta:
     return ReqMeta(
         req_id="req-a",
         token_len_chunk=0,
-        block_ids=(block_ids,),
+        block_ids=(block_ids, [1]),
         block_hashes=[b"a0", b"a1", b"a2"],
         can_save=True,
-        partial_tail_offloads=[(1, 7, 12)],
+        boundary_state_offloads=[(1, 1, 7, 12)],
     )
 
 
 def test_partial_tail_offload_skips_null_source_blocks():
     store = MagicMock()
     store.batch_is_exist.side_effect = lambda keys: [0] * len(keys)
-    store.batch_put_from_multi_buffers.return_value = [256, 256]
+    store.batch_put_from_multi_buffers.side_effect = lambda keys, *a: [256] * len(keys)
     thread = _make_partial_tail_send_thread(store)
 
-    assert thread._maybe_offload_partial_tail(_make_partial_tail_req([0, 2, 3]))
+    assert thread._maybe_offload_boundary_states(_make_partial_tail_req([0, 2, 3]))
 
     keys, addrs, _sizes, _replicate_config = (
         store.batch_put_from_multi_buffers.call_args.args
@@ -668,14 +678,21 @@ def test_partial_tail_offload_skips_null_source_blocks():
     assert keys == [
         "test-model@tp_rank:0@pcp0@dcp0@pp_rank:0@group:0@6131",
         "test-model@tp_rank:0@pcp0@dcp0@pp_rank:0@group:0@6132",
+        "test-model@tp_rank:0@pcp0@dcp0@pp_rank:0@group:1@6132",
     ]
-    assert addrs == [[0x1000 + 2 * 256], [0x1000 + 3 * 256]]
+    # FA reads blocks 2 and 3 (block 0 is null and skipped); the mamba
+    # boundary block reads the core-provided CoW block 7, not block_ids.
+    assert addrs == [
+        [0x1000 + 2 * 256],
+        [0x1000 + 3 * 256],
+        [0x2000 + 7 * 256],
+    ]
 
 
 def test_partial_tail_offload_replaces_stale_group_ids_after_filtering():
     store = MagicMock()
-    store.batch_is_exist.return_value = [1, 0, 0]
-    store.batch_put_from_multi_buffers.return_value = [256, 256]
+    store.batch_is_exist.return_value = [1, 0, 0, 0]
+    store.batch_put_from_multi_buffers.return_value = [256, 256, 256]
     replicate_config = SimpleNamespace(group_ids=["stale"])
     thread = _make_partial_tail_send_thread(
         store,
@@ -684,16 +701,18 @@ def test_partial_tail_offload_replaces_stale_group_ids_after_filtering():
         supports_group_ids=True,
     )
 
-    assert thread._maybe_offload_partial_tail(_make_partial_tail_req([1, 2, 3]))
+    assert thread._maybe_offload_boundary_states(_make_partial_tail_req([1, 2, 3]))
 
     keys, _addrs, _sizes, config = store.batch_put_from_multi_buffers.call_args.args
     assert keys == [
         "test-model@tp_rank:0@pcp0@dcp0@pp_rank:0@group:0@6131",
         "test-model@tp_rank:0@pcp0@dcp0@pp_rank:0@group:0@6132",
+        "test-model@tp_rank:0@pcp0@dcp0@pp_rank:0@group:1@6132",
     ]
     assert config is replicate_config
     assert config.group_ids == [
         "vllm-mooncake-store:test-model@6131",
+        "vllm-mooncake-store:test-model@6132",
         "vllm-mooncake-store:test-model@6132",
     ]
 
@@ -731,6 +750,249 @@ def test_partial_tail_put_failure_activates_pressure_gate():
     assert store.batch_put_from_multi_buffers.call_count == 1
 
 
+def test_normal_save_excludes_mamba_group_and_null_blocks():
+    """The positional normal save must never cover mamba chunks (align-mode
+    block tables are not append-only) and must skip chunks whose block is the
+    reserved null block, for any group."""
+    from vllm.v1.kv_cache_interface import (
+        FullAttentionSpec,
+        KVCacheGroupSpec,
+        MambaSpec,
+    )
+
+    store = MagicMock()
+    store.batch_is_exist.side_effect = lambda keys: [0] * len(keys)
+    store.batch_put_from_multi_buffers.side_effect = lambda keys, *a: [256] * len(keys)
+
+    full_spec = FullAttentionSpec(
+        block_size=16, num_kv_heads=8, head_size=64, dtype=None
+    )
+    mamba_spec = MambaSpec(
+        block_size=16,
+        shapes=((1, 1),),
+        dtypes=(torch.float32,),
+        mamba_cache_mode="align",
+    )
+    coord = mooncake_store_worker.MooncakeStoreCoordinator(
+        [KVCacheGroupSpec(["L0"], full_spec), KVCacheGroupSpec(["L1"], mamba_spec)],
+        scheduler_block_size=16,
+        hash_block_size=16,
+    )
+    db_full = ChunkedTokenDatabase(
+        KeyMetadata("test-model", 0, 0, 0, 0, group_id=0), block_size=16
+    )
+    db_full.set_kv_caches_base_addr([0x1000])
+    db_full.set_block_len([256])
+    db_mamba = ChunkedTokenDatabase(
+        KeyMetadata("test-model", 0, 0, 0, 0, group_id=1), block_size=16
+    )
+    db_mamba.set_kv_caches_base_addr([0x2000])
+    db_mamba.set_block_len([256])
+    thread = _make_store_sending_thread(
+        store, coord=coord, token_databases=[db_full, db_mamba]
+    )
+
+    thread.add_stored_request("r0")
+    thread._handle_request(
+        ReqMeta(
+            req_id="r0",
+            token_len_chunk=64,
+            # FA has a null at chunk 1; the mamba table is align-mode shaped
+            # (interior nulls + one state block) and must not be read at all.
+            block_ids=([1, 0, 3, 4], [0, 0, 0, 9]),
+            block_hashes=[b"a0", b"a1", b"a2", b"a3"],
+            can_save=True,
+        )
+    )
+
+    keys, addrs, _sizes, _ = store.batch_put_from_multi_buffers.call_args.args
+    assert all("@group:0@" in k for k in keys)
+    assert [k.rsplit("@", 1)[-1] for k in keys] == ["6130", "6132", "6133"]
+    assert addrs == [[0x1000 + 256], [0x1000 + 3 * 256], [0x1000 + 4 * 256]]
+
+
+def test_block_aligned_snapshot_offload_uses_provided_block():
+    """A block-aligned hand-off (sparse-retention mamba checkpoint) uploads
+    exactly the core-pinned block under the boundary-end hash key; the
+    positional block table entry for that chunk must be ignored."""
+    store = MagicMock()
+    store.batch_is_exist.side_effect = lambda keys: [0] * len(keys)
+    store.batch_put_from_multi_buffers.side_effect = lambda keys, *a: [256] * len(keys)
+    thread = _make_partial_tail_send_thread(store)
+
+    hs = [bytes([i + 1]) * 4 for i in range(8)]  # 8 hash units = 32 tokens
+    req = ReqMeta(
+        req_id="req-a",
+        token_len_chunk=0,
+        block_ids=([1, 2, 3], [5]),
+        block_hashes=hs,
+        can_save=True,
+        boundary_state_offloads=[(1, 1, 7, 32)],
+    )
+    assert thread._maybe_offload_boundary_states(req)
+
+    keys, addrs, _sizes, _ = store.batch_put_from_multi_buffers.call_args.args
+    # boundary 32 is block-aligned for the mamba group (block 16): one key,
+    # keyed by hs[32 // 4 - 1], read from the handed-off block 7 — not from
+    # block_ids[1] and with no FA gap coverage.
+    assert keys == [thread.token_databases[1].key_for(BlockHash(hs[7]))]
+    assert addrs == [[0x2000 + 7 * 256]]
+
+
+def test_mixed_snapshot_and_sub_block_offloads():
+    """A retention snapshot and the prompt-end sub-block CoW tail can arrive
+    in one hand-off; the sub-block path covers FA gap blocks but reads the
+    mamba boundary only from the CoW block, never positionally."""
+    store = MagicMock()
+    store.batch_is_exist.side_effect = lambda keys: [0] * len(keys)
+    store.batch_put_from_multi_buffers.side_effect = lambda keys, *a: [256] * len(keys)
+    thread = _make_partial_tail_send_thread(store)
+
+    hs = [bytes([i + 1]) * 4 for i in range(11)]  # 11 hash units = 44 tokens
+    req = ReqMeta(
+        req_id="req-a",
+        token_len_chunk=0,
+        block_ids=([1, 2, 3], [0, 0, 0]),
+        block_hashes=hs,
+        can_save=True,
+        boundary_state_offloads=[(1, 1, 9, 32), (2, 1, 7, 44)],
+    )
+    assert thread._maybe_offload_boundary_states(req)
+
+    keys, addrs, _sizes, _ = store.batch_put_from_multi_buffers.call_args.args
+    db_full, db_mamba = thread.token_databases
+    assert keys == [
+        # Aligned snapshot: boundary 32 from the handed-off block 9.
+        db_mamba.key_for(BlockHash(hs[7])),
+        # Sub-block boundary 44: FA gap blocks ending at 4, 8, 12.
+        db_full.key_for(BlockHash(hs[0])),
+        db_full.key_for(BlockHash(hs[1])),
+        db_full.key_for(BlockHash(hs[2])),
+        # Mamba boundary block from the CoW hand-off (block 7).
+        db_mamba.key_for(BlockHash(hs[10])),
+    ]
+    assert addrs == [
+        [0x2000 + 9 * 256],
+        [0x1000 + 1 * 256],
+        [0x1000 + 2 * 256],
+        [0x1000 + 3 * 256],
+        [0x2000 + 7 * 256],
+    ]
+
+
+def test_snapshot_offload_skips_null_handoff_block():
+    """A hand-off the core could not materialize (null block) carries no
+    committed state; persisting it would poison the boundary key."""
+    store = MagicMock()
+    thread = _make_partial_tail_send_thread(store)
+
+    hs = [bytes([i + 1]) * 4 for i in range(8)]
+    assert thread._maybe_offload_boundary_states(
+        ReqMeta(
+            req_id="req-a",
+            token_len_chunk=0,
+            block_ids=([1, 2, 3], [5]),
+            block_hashes=hs,
+            can_save=True,
+            boundary_state_offloads=[(1, 1, NULL_BLOCK_ID, 32)],
+        )
+    )
+    store.batch_is_exist.assert_not_called()
+    store.batch_put_from_multi_buffers.assert_not_called()
+
+
+def _handoff_req(req_id: str, entries: list[tuple[int, int, int, int]]) -> ReqMeta:
+    return ReqMeta(
+        req_id=req_id,
+        token_len_chunk=0,
+        block_ids=([1, 2, 3], [5]),
+        block_hashes=[bytes([i + 1]) * 4 for i in range(8)],
+        can_save=True,
+        boundary_state_offloads=entries,
+    )
+
+
+@pytest.mark.parametrize(
+    "put_result,exists",
+    [
+        ([256], 0),  # successful put
+        ([-1], 0),  # terminal put failure
+        (None, 1),  # dedup: already in the store, no put
+    ],
+)
+def test_handoff_watermark_advances_on_every_terminal_outcome(put_result, exists):
+    """The core unpins a state block when the watermark reaches its id, so the
+    id must be reported exactly once the block has been read or given up on —
+    whether the put succeeded, was deduped away, or failed for good."""
+    store = MagicMock()
+    store.batch_is_exist.side_effect = lambda keys: [exists] * len(keys)
+    store.batch_put_from_multi_buffers.side_effect = lambda keys, *a: put_result
+    thread = _make_partial_tail_send_thread(store)
+
+    req = _handoff_req("req-a", [(4, 1, 7, 32)])
+    thread.note_pending_handoffs([4])
+    thread.add_stored_request("req-a")
+    # Still queued: reporting 4 here would let the core reuse the block.
+    assert thread.handoff_watermark() == 3
+
+    thread._handle_request(req)
+
+    assert thread.handoff_watermark() == 4
+
+
+def test_handoff_watermark_advances_for_cancelled_request():
+    """A request finished/preempted before its turn never has its blocks read,
+    so its hand-offs are terminal and the core must be told to unpin them."""
+    thread = _make_partial_tail_send_thread(MagicMock())
+
+    thread.note_pending_handoffs([9])
+    # No add_stored_request(): the request was cancelled before its turn.
+    thread._handle_request(_handoff_req("req-a", [(9, 1, 7, 32)]))
+
+    assert thread.handoff_watermark() == 9
+
+
+def test_handoff_watermark_blocks_on_the_oldest_pending_handoff():
+    """Ids can be enqueued out of numeric order across requests, so the
+    watermark is the oldest still-pending id minus one — never the newest
+    completed one."""
+    store = MagicMock()
+    store.batch_is_exist.side_effect = lambda keys: [1] * len(keys)
+    thread = _make_partial_tail_send_thread(store)
+
+    thread.note_pending_handoffs([5, 6])
+    thread.add_stored_request("req-b")
+    thread._handle_request(_handoff_req("req-b", [(6, 1, 7, 32)]))
+
+    assert thread.handoff_watermark() == 4
+
+    thread.add_stored_request("req-a")
+    thread._handle_request(_handoff_req("req-a", [(5, 1, 7, 32)]))
+
+    assert thread.handoff_watermark() == 6
+
+
+def test_worker_meta_reports_zero_while_first_handoff_is_pending():
+    """A lagging rank must participate in min aggregation with watermark zero."""
+    send_thread = _make_partial_tail_send_thread(MagicMock())
+    send_thread.note_pending_handoffs([1])
+    store_worker = object.__new__(mooncake_store_worker.MooncakeStoreWorker)
+    store_worker.kv_send_thread = send_thread
+
+    metadata = store_worker.build_connector_worker_meta()
+
+    assert metadata is not None
+    assert metadata.boundary_handoff_watermark == 0
+
+
+def test_worker_meta_is_absent_before_any_handoff():
+    send_thread = _make_partial_tail_send_thread(MagicMock())
+    store_worker = object.__new__(mooncake_store_worker.MooncakeStoreWorker)
+    store_worker.kv_send_thread = send_thread
+
+    assert store_worker.build_connector_worker_meta() is None
+
+
 def test_store_sending_thread_delta_start_rank_saves_second_local_chunk():
     store = MagicMock()
     store.batch_is_exist.side_effect = lambda keys: [0] * len(keys)
@@ -743,7 +1005,7 @@ def test_store_sending_thread_delta_start_rank_saves_second_local_chunk():
         ReqMeta(
             req_id="req-a",
             token_len_chunk=64,
-            block_ids=([0, 1, 2, 3],),
+            block_ids=([1, 2, 3, 4],),
             block_hashes=[b"a0", b"a1", b"a2", b"a3"],
             can_save=True,
         )
@@ -850,7 +1112,7 @@ def test_store_sending_thread_prepares_missing_chunks_once_per_group():
         ReqMeta(
             req_id="req-a",
             token_len_chunk=48,
-            block_ids=([0, 1, 2], [2, 1, 0]),
+            block_ids=([1, 2, 3], [3, 2, 1]),
             block_hashes=[b"a0", b"a1", b"a2"],
             can_save=True,
         )
@@ -858,8 +1120,8 @@ def test_store_sending_thread_prepares_missing_chunks_once_per_group():
 
     db0.prepare_value.assert_not_called()
     db1.prepare_value.assert_not_called()
-    db0.prepare_values.assert_called_once_with([(0, 16), (32, 48)], [0, 1, 2])
-    db1.prepare_values.assert_called_once_with([(16, 32), (32, 48)], [2, 1, 0])
+    db0.prepare_values.assert_called_once_with([(0, 16), (32, 48)], [1, 2, 3])
+    db1.prepare_values.assert_called_once_with([(16, 32), (32, 48)], [3, 2, 1])
 
     keys, addrs, sizes, _ = store.batch_put_from_multi_buffers.call_args.args
     assert [key.rsplit("@", 1)[-1] for key in keys] == [
@@ -868,7 +1130,7 @@ def test_store_sending_thread_prepares_missing_chunks_once_per_group():
         "6131",
         "6132",
     ]
-    assert addrs == [[0x1000], [0x1200], [0x2200], [0x2000]]
+    assert addrs == [[0x1100], [0x1300], [0x2400], [0x2200]]
     assert sizes == [[256], [256], [512], [512]]
 
 
@@ -1218,7 +1480,7 @@ def test_store_sending_thread_multiple_segments_share_logical_group_id():
         "test-model@tp_rank:0@pcp0@dcp0@pp_rank:0@group:0@6130",
         "test-model@tp_rank:0@pcp0@dcp0@pp_rank:0@group:0@6131",
     ]
-    assert addrs == [[0x1000, 0x2000], [0x1100, 0x2100]]
+    assert addrs == [[0x1100, 0x2100], [0x1200, 0x2200]]
     assert sizes == [[256, 256], [256, 256]]
     assert config.group_ids == [
         "vllm-mooncake-store:test-model@6130",
@@ -1270,7 +1532,7 @@ def test_store_sending_thread_group_ids_share_across_kv_cache_groups():
         "test-model@tp_rank:0@pcp0@dcp0@pp_rank:0@group:1@6130",
         "test-model@tp_rank:0@pcp0@dcp0@pp_rank:0@group:1@6131",
     ]
-    assert addrs == [[0x1000], [0x1100], [0x3200], [0x3300]]
+    assert addrs == [[0x1100], [0x1200], [0x3300], [0x3400]]
     assert sizes == [[256], [256], [256], [256]]
     # Different vLLM KV cache groups for the same prefix chunk share the
     # same Mooncake lifecycle group id.
@@ -1871,7 +2133,7 @@ def test_store_sending_thread_clamps_token_len_to_lcm():
         ReqMeta(
             req_id="r0",
             token_len_chunk=33,
-            block_ids=([0, 1, 2],),
+            block_ids=([1, 2, 3],),
             block_hashes=[b"a0", b"a1", b"a2"],
             can_save=True,
         )
@@ -1910,7 +2172,7 @@ def test_store_sending_thread_skips_when_token_len_below_lcm():
         ReqMeta(
             req_id="r0",
             token_len_chunk=32,
-            block_ids=([0, 1],),
+            block_ids=([1, 2],),
             block_hashes=[b"a0", b"a1"],
             can_save=True,
         )
@@ -1987,7 +2249,7 @@ def test_store_sending_thread_only_stores_swa_blocks_in_window():
         ReqMeta(
             req_id="r0",
             token_len_chunk=64,
-            block_ids=([0, 1], list(range(8))),
+            block_ids=([1, 2], list(range(1, 9))),
             block_hashes=hs,
             can_save=True,
         )
@@ -2063,7 +2325,7 @@ def test_store_sending_thread_delta_saves_only_new_swa_boundary_chunks():
         ReqMeta(
             req_id="r0",
             token_len_chunk=64,
-            block_ids=([0, 1], list(range(8))),
+            block_ids=([1, 2], list(range(1, 9))),
             block_hashes=hs,
             can_save=True,
         )
@@ -2133,7 +2395,7 @@ def test_store_sending_thread_kv_events_use_group_chunk_metadata():
         ReqMeta(
             req_id="r0",
             token_len_chunk=32,
-            block_ids=([0], list(range(4))),
+            block_ids=([1], list(range(1, 5))),
             block_hashes=hs,
             can_save=True,
             token_ids=list(range(32)),

--- a/tests/v1/kv_connector/unit/test_mooncake_store_worker.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_worker.py
@@ -627,6 +627,7 @@ def _make_partial_tail_send_thread(
         enable_partial_hash_hits=True,
         hash_block_size=4,
         lcm_block_size=16,
+        mamba_group_ids={1},
     )
     db = ChunkedTokenDatabase(
         KeyMetadata("test-model", 0, 0, 0, 0),
@@ -687,6 +688,77 @@ def test_partial_tail_offload_skips_null_source_blocks():
         [0x1000 + 3 * 256],
         [0x2000 + 7 * 256],
     ]
+
+
+def test_partial_tail_offload_skips_cap_omitted_mamba_group():
+    """A Mamba group omitted by the handoff cap must not fall back to the
+    connector's positional block table."""
+    from vllm.v1.kv_cache_interface import (
+        FullAttentionSpec,
+        KVCacheGroupSpec,
+        MambaSpec,
+    )
+
+    store = MagicMock()
+    store.batch_is_exist.side_effect = lambda keys: [0] * len(keys)
+    store.batch_put_from_multi_buffers.side_effect = lambda keys, *a: [256] * len(keys)
+
+    full_spec = FullAttentionSpec(
+        block_size=4, num_kv_heads=8, head_size=64, dtype=torch.float32
+    )
+    mamba_spec = MambaSpec(
+        block_size=16,
+        shapes=((1, 1),),
+        dtypes=(torch.float32,),
+        mamba_cache_mode="align",
+    )
+    coord = mooncake_store_worker.MooncakeStoreCoordinator(
+        [
+            KVCacheGroupSpec(["full"], full_spec),
+            KVCacheGroupSpec(["mamba-1"], mamba_spec),
+            KVCacheGroupSpec(["mamba-2"], mamba_spec),
+        ],
+        scheduler_block_size=16,
+        hash_block_size=4,
+    )
+
+    def make_db(group_id: int, block_size: int, base_addr: int):
+        db = ChunkedTokenDatabase(
+            KeyMetadata("test-model", 0, 0, 0, 0, group_id=group_id),
+            block_size=block_size,
+            hash_block_size=4,
+        )
+        db.set_kv_caches_base_addr([base_addr])
+        db.set_block_len([256])
+        return db
+
+    db_full = make_db(0, 4, 0x1000)
+    db_mamba_1 = make_db(1, 16, 0x2000)
+    db_mamba_2 = make_db(2, 16, 0x3000)
+    thread = _make_store_sending_thread(
+        store,
+        coord=coord,
+        token_databases=[db_full, db_mamba_1, db_mamba_2],
+    )
+
+    req = ReqMeta(
+        req_id="req-a",
+        token_len_chunk=0,
+        block_ids=([1, 2, 3], [5], [9]),
+        block_hashes=[b"a0", b"a1", b"a2"],
+        can_save=True,
+        # The scheduler's cap accepted group 1 and omitted group 2 at boundary 12.
+        boundary_state_offloads=[(1, 1, 7, 12)],
+    )
+    assert thread._maybe_offload_boundary_states(req)
+
+    keys, addrs, _sizes, _replicate_config = (
+        store.batch_put_from_multi_buffers.call_args.args
+    )
+    puts = list(zip(keys, addrs, strict=True))
+    boundary_hash = BlockHash(b"a2")
+    assert (db_mamba_1.key_for(boundary_hash), [0x2000 + 7 * 256]) in puts
+    assert (db_mamba_2.key_for(boundary_hash), [0x3000 + 9 * 256]) not in puts
 
 
 def test_partial_tail_offload_replaces_stale_group_ids_after_filtering():

--- a/tests/v1/kv_connector/unit/test_mooncake_store_worker.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_worker.py
@@ -177,6 +177,7 @@ def _run_store_req(thread, req_meta: ReqMeta) -> None:
 
 
 def _make_store_req(req_id: str, block_hashes: list[bytes]) -> ReqMeta:
+    # 1-based: block 0 is the reserved null block and the save skips it.
     return ReqMeta(
         req_id=req_id,
         token_len_chunk=32,
@@ -654,10 +655,18 @@ def _make_partial_tail_send_thread(
     )
     db.set_kv_caches_base_addr([0x1000])
     db.set_block_len([256])
+    # Group 1 models the mamba "align" group the hand-offs reference.
+    db_mamba = ChunkedTokenDatabase(
+        KeyMetadata("test-model", 0, 0, 0, 0, group_id=1),
+        block_size=16,
+        hash_block_size=4,
+    )
+    db_mamba.set_kv_caches_base_addr([0x2000])
+    db_mamba.set_block_len([256])
     return _make_store_sending_thread(
         store,
         coord=coord,
-        token_databases=[db],
+        token_databases=[db, db_mamba],
         replicate_config=replicate_config,
         enable_group_semantics=enable_group_semantics,
         supports_group_ids=supports_group_ids,
@@ -668,20 +677,20 @@ def _make_partial_tail_req(block_ids: list[int]) -> ReqMeta:
     return ReqMeta(
         req_id="req-a",
         token_len_chunk=0,
-        block_ids=(block_ids,),
+        block_ids=(block_ids, [1]),
         block_hashes=[b"a0", b"a1", b"a2"],
         can_save=True,
-        partial_tail_offloads=[(1, 7, 12)],
+        boundary_state_offloads=[(1, 7, 12)],
     )
 
 
 def test_partial_tail_offload_skips_null_source_blocks():
     store = MagicMock()
     store.batch_is_exist.side_effect = lambda keys: [0] * len(keys)
-    store.batch_put_from_multi_buffers.return_value = [256, 256]
+    store.batch_put_from_multi_buffers.side_effect = lambda keys, *a: [256] * len(keys)
     thread = _make_partial_tail_send_thread(store)
 
-    assert thread._maybe_offload_partial_tail(_make_partial_tail_req([0, 2, 3]))
+    assert thread._maybe_offload_boundary_states(_make_partial_tail_req([0, 2, 3]))
 
     keys, addrs, _sizes, _replicate_config = (
         store.batch_put_from_multi_buffers.call_args.args
@@ -689,15 +698,21 @@ def test_partial_tail_offload_skips_null_source_blocks():
     assert keys == [
         "test-model@tp_rank:0@pcp0@dcp0@pp_rank:0@group:0@6131",
         "test-model@tp_rank:0@pcp0@dcp0@pp_rank:0@group:0@6132",
+        "test-model@tp_rank:0@pcp0@dcp0@pp_rank:0@group:1@6132",
     ]
-    assert addrs == [[0x1000 + 2 * 256], [0x1000 + 3 * 256]]
+    # FA reads blocks 2 and 3 (block 0 is null and skipped); the mamba
+    # boundary block reads the core-provided CoW block 7, not block_ids.
+    assert addrs == [
+        [0x1000 + 2 * 256],
+        [0x1000 + 3 * 256],
+        [0x2000 + 7 * 256],
+    ]
 
 
 def test_store_sending_thread_skips_null_sparse_group_blocks():
     from vllm.v1.kv_cache_interface import (
         FullAttentionSpec,
         KVCacheGroupSpec,
-        MambaSpec,
     )
 
     store = MagicMock()
@@ -706,16 +721,11 @@ def test_store_sending_thread_skips_null_sparse_group_blocks():
         lambda keys, addrs, sizes, replicate_config: [256] * len(keys)
     )
     full = FullAttentionSpec(block_size=16, num_kv_heads=8, head_size=64, dtype=None)
-    mamba = MambaSpec(
-        block_size=16,
-        shapes=((1, 1),),
-        dtypes=(torch.float32,),
-        mamba_cache_mode="align",
-    )
+    sparse = FullAttentionSpec(block_size=16, num_kv_heads=8, head_size=64, dtype=None)
     coord = mooncake_store_worker.MooncakeStoreCoordinator(
         [
             KVCacheGroupSpec(["full"], full),
-            KVCacheGroupSpec(["mamba"], mamba),
+            KVCacheGroupSpec(["sparse"], sparse),
         ],
         scheduler_block_size=16,
         hash_block_size=16,
@@ -727,17 +737,17 @@ def test_store_sending_thread_skips_null_sparse_group_blocks():
     )
     db_full.set_kv_caches_base_addr([0x1000])
     db_full.set_block_len([256])
-    db_mamba = ChunkedTokenDatabase(
+    db_sparse = ChunkedTokenDatabase(
         KeyMetadata("test-model", 0, 0, 0, 0, group_id=1),
         block_size=16,
     )
-    db_mamba.set_kv_caches_base_addr([0x2000])
-    db_mamba.set_block_len([512])
+    db_sparse.set_kv_caches_base_addr([0x2000])
+    db_sparse.set_block_len([512])
 
     thread = _make_store_sending_thread(
         store,
         coord=coord,
-        token_databases=[db_full, db_mamba],
+        token_databases=[db_full, db_sparse],
     )
     _run_store_req(
         thread,
@@ -751,15 +761,15 @@ def test_store_sending_thread_skips_null_sparse_group_blocks():
     )
 
     keys, addrs, _, _ = store.batch_put_from_multi_buffers.call_args.args
-    mamba_keys = [key for key in keys if "@group:1" in key]
-    assert [key.rsplit("@", 1)[-1] for key in mamba_keys] == [b"a1".hex()]
+    sparse_keys = [key for key in keys if "@group:1" in key]
+    assert [key.rsplit("@", 1)[-1] for key in sparse_keys] == [b"a1".hex()]
     assert all(addr[0] >= 0x2000 for key, addr in zip(keys, addrs) if "@group:1" in key)
 
 
 def test_partial_tail_offload_replaces_stale_group_ids_after_filtering():
     store = MagicMock()
-    store.batch_is_exist.return_value = [1, 0, 0]
-    store.batch_put_from_multi_buffers.return_value = [256, 256]
+    store.batch_is_exist.return_value = [1, 0, 0, 0]
+    store.batch_put_from_multi_buffers.return_value = [256, 256, 256]
     replicate_config = SimpleNamespace(group_ids=["stale"])
     thread = _make_partial_tail_send_thread(
         store,
@@ -768,16 +778,18 @@ def test_partial_tail_offload_replaces_stale_group_ids_after_filtering():
         supports_group_ids=True,
     )
 
-    assert thread._maybe_offload_partial_tail(_make_partial_tail_req([1, 2, 3]))
+    assert thread._maybe_offload_boundary_states(_make_partial_tail_req([1, 2, 3]))
 
     keys, _addrs, _sizes, config = store.batch_put_from_multi_buffers.call_args.args
     assert keys == [
         "test-model@tp_rank:0@pcp0@dcp0@pp_rank:0@group:0@6131",
         "test-model@tp_rank:0@pcp0@dcp0@pp_rank:0@group:0@6132",
+        "test-model@tp_rank:0@pcp0@dcp0@pp_rank:0@group:1@6132",
     ]
     assert config is replicate_config
     assert config.group_ids == [
         "vllm-mooncake-store:test-model@6131",
+        "vllm-mooncake-store:test-model@6132",
         "vllm-mooncake-store:test-model@6132",
     ]
 
@@ -808,6 +820,165 @@ def test_partial_tail_put_failure_activates_pressure_gate():
 
     _run_store_req(thread, _make_partial_tail_req([1, 2, 3]))
     assert store.batch_put_from_multi_buffers.call_count == 1
+
+
+def test_normal_save_excludes_mamba_group_and_null_blocks():
+    """The positional normal save must never cover mamba chunks (align-mode
+    block tables are not append-only) and must skip chunks whose block is the
+    reserved null block, for any group."""
+    from vllm.v1.kv_cache_interface import (
+        FullAttentionSpec,
+        KVCacheGroupSpec,
+        MambaSpec,
+    )
+
+    store = MagicMock()
+    store.batch_is_exist.side_effect = lambda keys: [0] * len(keys)
+    store.batch_put_from_multi_buffers.side_effect = lambda keys, *a: [256] * len(keys)
+
+    full_spec = FullAttentionSpec(
+        block_size=16, num_kv_heads=8, head_size=64, dtype=None
+    )
+    mamba_spec = MambaSpec(
+        block_size=16,
+        shapes=((1, 1),),
+        dtypes=(torch.float32,),
+        mamba_cache_mode="align",
+    )
+    coord = mooncake_store_worker.MooncakeStoreCoordinator(
+        [KVCacheGroupSpec(["L0"], full_spec), KVCacheGroupSpec(["L1"], mamba_spec)],
+        scheduler_block_size=16,
+        hash_block_size=16,
+    )
+    db_full = ChunkedTokenDatabase(
+        KeyMetadata("test-model", 0, 0, 0, 0, group_id=0), block_size=16
+    )
+    db_full.set_kv_caches_base_addr([0x1000])
+    db_full.set_block_len([256])
+    db_mamba = ChunkedTokenDatabase(
+        KeyMetadata("test-model", 0, 0, 0, 0, group_id=1), block_size=16
+    )
+    db_mamba.set_kv_caches_base_addr([0x2000])
+    db_mamba.set_block_len([256])
+    thread = _make_store_sending_thread(
+        store, coord=coord, token_databases=[db_full, db_mamba]
+    )
+
+    _run_store_req(
+        thread,
+        ReqMeta(
+            req_id="r0",
+            token_len_chunk=64,
+            # FA has a null at chunk 1; the mamba table is align-mode shaped
+            # (interior nulls + one state block) and must not be read at all.
+            block_ids=([1, 0, 3, 4], [0, 0, 0, 9]),
+            block_hashes=[b"a0", b"a1", b"a2", b"a3"],
+            can_save=True,
+        ),
+    )
+
+    keys, addrs, _sizes, _ = store.batch_put_from_multi_buffers.call_args.args
+    assert all("@group:0@" in k for k in keys)
+    assert [k.rsplit("@", 1)[-1] for k in keys] == ["6130", "6132", "6133"]
+    assert addrs == [[0x1000 + 256], [0x1000 + 3 * 256], [0x1000 + 4 * 256]]
+
+
+def test_block_aligned_snapshot_offload_uses_provided_block():
+    """A block-aligned hand-off (sparse-retention mamba checkpoint) uploads
+    exactly the core-pinned block under the boundary-end hash key; the
+    positional block table entry for that chunk must be ignored."""
+    store = MagicMock()
+    store.batch_is_exist.side_effect = lambda keys: [0] * len(keys)
+    store.batch_put_from_multi_buffers.side_effect = lambda keys, *a: [256] * len(keys)
+    thread = _make_partial_tail_send_thread(store)
+
+    hs = [bytes([i + 1]) * 4 for i in range(8)]  # 8 hash units = 32 tokens
+    req = ReqMeta(
+        req_id="req-a",
+        token_len_chunk=0,
+        block_ids=([1, 2, 3], [5]),
+        block_hashes=hs,
+        can_save=True,
+        boundary_state_offloads=[(1, 7, 32)],
+    )
+    assert thread._maybe_offload_boundary_states(req)
+
+    keys, addrs, _sizes, _ = store.batch_put_from_multi_buffers.call_args.args
+    # boundary 32 is block-aligned for the mamba group (block 16): one key,
+    # keyed by hs[32 // 4 - 1], read from the handed-off block 7 — not from
+    # block_ids[1] and with no FA gap coverage.
+    assert keys == [thread.token_databases[1].key_for(BlockHash(hs[7]))]
+    assert addrs == [[0x2000 + 7 * 256]]
+
+
+def test_mixed_snapshot_and_sub_block_offloads():
+    """A retention snapshot and the prompt-end sub-block CoW tail can arrive
+    in one hand-off; the sub-block path covers FA gap blocks but reads the
+    mamba boundary only from the CoW block, never positionally."""
+    store = MagicMock()
+    store.batch_is_exist.side_effect = lambda keys: [0] * len(keys)
+    store.batch_put_from_multi_buffers.side_effect = lambda keys, *a: [256] * len(keys)
+    thread = _make_partial_tail_send_thread(store)
+
+    hs = [bytes([i + 1]) * 4 for i in range(11)]  # 11 hash units = 44 tokens
+    req = ReqMeta(
+        req_id="req-a",
+        token_len_chunk=0,
+        block_ids=([1, 2, 3], [0, 0, 0]),
+        block_hashes=hs,
+        can_save=True,
+        boundary_state_offloads=[(1, 9, 32), (1, 7, 44)],
+    )
+    assert thread._maybe_offload_boundary_states(req)
+
+    keys, addrs, _sizes, _ = store.batch_put_from_multi_buffers.call_args.args
+    db_full, db_mamba = thread.token_databases
+    assert keys == [
+        # Aligned snapshot: boundary 32 from the handed-off block 9.
+        db_mamba.key_for(BlockHash(hs[7])),
+        # Sub-block boundary 44: FA gap blocks ending at 4, 8, 12.
+        db_full.key_for(BlockHash(hs[0])),
+        db_full.key_for(BlockHash(hs[1])),
+        db_full.key_for(BlockHash(hs[2])),
+        # Mamba boundary block from the CoW hand-off (block 7).
+        db_mamba.key_for(BlockHash(hs[10])),
+    ]
+    assert addrs == [
+        [0x2000 + 9 * 256],
+        [0x1000 + 1 * 256],
+        [0x1000 + 2 * 256],
+        [0x1000 + 3 * 256],
+        [0x2000 + 7 * 256],
+    ]
+
+
+def test_snapshot_offload_skips_null_handoff_block():
+    """A hand-off the core could not materialize (null block) carries no
+    committed state; persisting it would poison the boundary key."""
+    store = MagicMock()
+    thread = _make_partial_tail_send_thread(store)
+
+    hs = [bytes([i + 1]) * 4 for i in range(8)]
+    assert thread._maybe_offload_boundary_states(
+        ReqMeta(
+            req_id="req-a",
+            token_len_chunk=0,
+            block_ids=([1, 2, 3], [5]),
+            block_hashes=hs,
+            can_save=True,
+            boundary_state_offloads=[(1, NULL_BLOCK_ID, 32)],
+        )
+    )
+    store.batch_is_exist.assert_not_called()
+    store.batch_put_from_multi_buffers.assert_not_called()
+
+
+def test_worker_meta_is_absent_before_any_completed_job():
+    send_thread = _make_partial_tail_send_thread(MagicMock())
+    store_worker = object.__new__(mooncake_store_worker.MooncakeStoreWorker)
+    store_worker.kv_send_thread = send_thread
+
+    assert store_worker.build_connector_worker_meta() is None
 
 
 def test_store_sending_thread_delta_start_rank_saves_second_local_chunk():

--- a/tests/v1/kv_connector/unit/test_mooncake_store_worker.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_worker.py
@@ -647,6 +647,7 @@ def _make_partial_tail_send_thread(
         enable_partial_hash_hits=True,
         hash_block_size=4,
         lcm_block_size=16,
+        mamba_group_ids={1},
     )
     db = ChunkedTokenDatabase(
         KeyMetadata("test-model", 0, 0, 0, 0),
@@ -764,6 +765,77 @@ def test_store_sending_thread_skips_null_sparse_group_blocks():
     sparse_keys = [key for key in keys if "@group:1" in key]
     assert [key.rsplit("@", 1)[-1] for key in sparse_keys] == [b"a1".hex()]
     assert all(addr[0] >= 0x2000 for key, addr in zip(keys, addrs) if "@group:1" in key)
+
+
+def test_partial_tail_offload_skips_cap_omitted_mamba_group():
+    """A Mamba group omitted by the handoff cap must not fall back to the
+    connector's positional block table."""
+    from vllm.v1.kv_cache_interface import (
+        FullAttentionSpec,
+        KVCacheGroupSpec,
+        MambaSpec,
+    )
+
+    store = MagicMock()
+    store.batch_is_exist.side_effect = lambda keys: [0] * len(keys)
+    store.batch_put_from_multi_buffers.side_effect = lambda keys, *a: [256] * len(keys)
+
+    full_spec = FullAttentionSpec(
+        block_size=4, num_kv_heads=8, head_size=64, dtype=torch.float32
+    )
+    mamba_spec = MambaSpec(
+        block_size=16,
+        shapes=((1, 1),),
+        dtypes=(torch.float32,),
+        mamba_cache_mode="align",
+    )
+    coord = mooncake_store_worker.MooncakeStoreCoordinator(
+        [
+            KVCacheGroupSpec(["full"], full_spec),
+            KVCacheGroupSpec(["mamba-1"], mamba_spec),
+            KVCacheGroupSpec(["mamba-2"], mamba_spec),
+        ],
+        scheduler_block_size=16,
+        hash_block_size=4,
+    )
+
+    def make_db(group_id: int, block_size: int, base_addr: int):
+        db = ChunkedTokenDatabase(
+            KeyMetadata("test-model", 0, 0, 0, 0, group_id=group_id),
+            block_size=block_size,
+            hash_block_size=4,
+        )
+        db.set_kv_caches_base_addr([base_addr])
+        db.set_block_len([256])
+        return db
+
+    db_full = make_db(0, 4, 0x1000)
+    db_mamba_1 = make_db(1, 16, 0x2000)
+    db_mamba_2 = make_db(2, 16, 0x3000)
+    thread = _make_store_sending_thread(
+        store,
+        coord=coord,
+        token_databases=[db_full, db_mamba_1, db_mamba_2],
+    )
+
+    req = ReqMeta(
+        req_id="req-a",
+        token_len_chunk=0,
+        block_ids=([1, 2, 3], [5], [9]),
+        block_hashes=[b"a0", b"a1", b"a2"],
+        can_save=True,
+        # The scheduler accepted group 1 and omitted group 2 at boundary 12.
+        boundary_state_offloads=[(1, 7, 12)],
+    )
+    assert thread._maybe_offload_boundary_states(req)
+
+    keys, addrs, _sizes, _replicate_config = (
+        store.batch_put_from_multi_buffers.call_args.args
+    )
+    puts = list(zip(keys, addrs, strict=True))
+    boundary_hash = BlockHash(b"a2")
+    assert (db_mamba_1.key_for(boundary_hash), [0x2000 + 7 * 256]) in puts
+    assert (db_mamba_2.key_for(boundary_hash), [0x3000 + 9 * 256]) not in puts
 
 
 def test_partial_tail_offload_replaces_stale_group_ids_after_filtering():

--- a/tests/v1/kv_connector/unit/test_offloading_connector.py
+++ b/tests/v1/kv_connector/unit/test_offloading_connector.py
@@ -212,12 +212,21 @@ def _accuracy_test(llm: LLM, subscriber: MockSubscriber | None):
     if subscriber is not None:
         subscriber.get_new_cpu_stored_events()
 
-    # Pad prompt so its token count is a multiple of cpu_block_size.
-    # Use the tokenizer directly to avoid expensive llm.generate() calls.
+    # Align the reusable prefix; the final token must be recomputed for logits.
     tokenizer = llm.get_tokenizer()
-    prompt = "Let's count to 10. One, two, three, four,"
-    while len(tokenizer.encode(prompt)) % cpu_block_size != 0:
-        prompt = ". " + prompt
+    prompt_token_ids = tokenizer.encode("Let's count to 10. One, two, three, four,")
+    reusable_prefix = prompt_token_ids[:-1]
+    final_token = prompt_token_ids[-1:]
+
+    [padding_token_id] = tokenizer.encode(".", add_special_tokens=False)
+    padding = [padding_token_id] * (-len(reusable_prefix) % cpu_block_size)
+    insert_at = int(reusable_prefix[0] == tokenizer.bos_token_id)
+    reusable_prefix[insert_at:insert_at] = padding
+    assert len(reusable_prefix) % cpu_block_size == 0
+
+    prompt = TokensPrompt(
+        prompt_token_ids=reusable_prefix + final_token,
+    )
 
     # Seed the CPU cache with the prompt.
     llm.generate(prompt, sampling_params, use_tqdm=False)

--- a/tests/v1/kv_connector/unit/test_scheduler_kv_connector_override.py
+++ b/tests/v1/kv_connector/unit/test_scheduler_kv_connector_override.py
@@ -22,8 +22,13 @@ from vllm.v1.request import Request
 
 
 class DummyConnectorMetadata(KVConnectorMetadata):
-    def __init__(self, block_hashes_by_req: dict[str, list[BlockHash]]):
+    def __init__(
+        self,
+        block_hashes_by_req: dict[str, list[BlockHash]],
+        block_ids_by_req: dict[str, tuple[list[int], ...]],
+    ):
         self.block_hashes_by_req = block_hashes_by_req
+        self.block_ids_by_req = block_ids_by_req
 
 
 class DummyKVConnector(KVConnectorBase_V1):
@@ -47,8 +52,12 @@ class DummyKVConnector(KVConnectorBase_V1):
         assert block_hashes_by_req is not None, (
             "DummyKVConnector expected 'block_hashes_by_req' on scheduler_output"
         )
+        block_state = scheduler_output.kv_connector_block_state
+        assert block_state is not None
+        block_ids_by_req = block_state.block_ids
         return DummyConnectorMetadata(
             block_hashes_by_req=block_hashes_by_req,
+            block_ids_by_req=block_ids_by_req,
         )
 
     def start_load_kv(self, kv_caches, finished_req_ids):
@@ -129,3 +138,9 @@ def test_connector_receives_block_hashes(_load_plugin):
             num_tokens // block_size
         )
         assert meta.block_hashes_by_req[req.request_id] == req.block_hashes
+
+    expected_block_ids = {
+        req.req_id: req.block_ids for req in output.scheduled_new_reqs
+    }
+    assert meta.block_ids_by_req == expected_block_ids
+    assert output.kv_connector_block_state is None

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/connector.py
@@ -37,13 +37,14 @@ from vllm.distributed.kv_transfer.kv_connector.v1.metrics import (
 from vllm.forward_context import ForwardContext
 from vllm.logger import init_logger
 from vllm.v1.attention.backend import AttentionMetadata
+from vllm.v1.core.block_pool import BlockPool
 from vllm.v1.core.kv_cache_manager import KVCacheBlocks
 from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.v1.kv_cache_interface import KVCacheConfig
 from vllm.v1.outputs import KVConnectorOutput
 from vllm.v1.request import Request
 
-from .data import MooncakeStoreConnectorMetadata
+from .data import MooncakeStoreConnectorMetadata, MooncakeStoreWorkerMetadata
 from .metrics import MooncakeStoreConnectorStats, MooncakeStorePromMetrics
 from .scheduler import MooncakeStoreScheduler
 from .worker import MooncakeStoreWorker
@@ -180,6 +181,10 @@ class MooncakeStoreConnector(KVConnectorBase_V1, SupportsHMA):
     # Scheduler-side methods
     # ============================================================
 
+    def bind_gpu_block_pool(self, gpu_block_pool: BlockPool) -> None:
+        assert self.connector_scheduler is not None
+        self.connector_scheduler.bind_gpu_block_pool(gpu_block_pool)
+
     def get_num_new_matched_tokens(
         self,
         request: Request,
@@ -241,6 +246,13 @@ class MooncakeStoreConnector(KVConnectorBase_V1, SupportsHMA):
         return None
 
     def update_connector_output(self, connector_output: KVConnectorOutput):
+        worker_meta = connector_output.kv_connector_worker_meta
+        if isinstance(worker_meta, MooncakeStoreWorkerMetadata):
+            assert self.connector_scheduler is not None
+            self.connector_scheduler.update_boundary_handoff_watermark(
+                worker_meta.boundary_handoff_watermark
+            )
+
         kv_cache_events = connector_output.kv_cache_events
         if not kv_cache_events or not isinstance(
             kv_cache_events, MooncakeStoreKVEvents
@@ -313,6 +325,10 @@ class MooncakeStoreConnector(KVConnectorBase_V1, SupportsHMA):
     def get_block_ids_with_load_errors(self) -> set[int]:
         assert self.connector_worker is not None
         return self.connector_worker.get_block_ids_with_load_errors()
+
+    def build_connector_worker_meta(self) -> MooncakeStoreWorkerMetadata | None:
+        assert self.connector_worker is not None
+        return self.connector_worker.build_connector_worker_meta()
 
     def get_kv_connector_kv_cache_events(
         self,

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/coordinator.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/coordinator.py
@@ -198,12 +198,22 @@ class MooncakeStoreCoordinator:
 
         Reuses the engine's ``SingleTypeKVCacheManager.reachable_block_mask``
         so the store retains exactly the blocks the local prefix cache would.
+
+        Mamba groups are always all-False: the normal save resolves blocks
+        positionally from the connector's append-only block-ID snapshot, but
+        an align-mode mamba block table is not append-only (interior state
+        blocks are nulled/freed, and speculative decoding relocates the spec
+        blocks in place), so a positional read may hit a null, freed, or live
+        speculative-state block and persist wrong bytes under a valid prefix
+        hash. Mamba state is persisted only through the connector-pinned exact
+        block hand-off path (``SchedulerOutput.boundary_state_offloads``).
         """
         return self._reachable_masks(
             aligned_token_len,
             start_token,
             retention_interval=self.retention_interval,
             num_prompt_tokens=num_prompt_tokens,
+            exclude_mamba=True,
         )
 
     def lookup_mask(
@@ -230,6 +240,7 @@ class MooncakeStoreCoordinator:
         *,
         retention_interval: int | None,
         num_prompt_tokens: int | None,
+        exclude_mamba: bool = False,
     ) -> tuple[list[bool] | None, ...]:
         mask_alignment = (
             self.hash_block_size
@@ -245,6 +256,9 @@ class MooncakeStoreCoordinator:
             spec = _unwrap_spec(g.kv_cache_spec)
             end_chunk = aligned_token_len // spec.block_size
             start_chunk = min(end_chunk, max(0, cdiv(start_token, spec.block_size)))
+            if exclude_mamba and isinstance(spec, MambaSpec):
+                masks.append([False] * (end_chunk - start_chunk))
+                continue
             manager_cls = KVCacheSpecRegistry.get_manager_class(spec)
             assert manager_cls is not None
             use_eagle = g_idx in self.eagle_group_ids

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/coordinator.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/coordinator.py
@@ -80,6 +80,11 @@ class MooncakeStoreCoordinator:
             for g in kv_cache_groups
         ), "scheduler_block_size must be a multiple of each group's block_size"
         self.kv_cache_groups = kv_cache_groups
+        self.mamba_group_ids = {
+            group_id
+            for group_id, group in enumerate(kv_cache_groups)
+            if isinstance(_unwrap_spec(group.kv_cache_spec), MambaSpec)
+        }
         self.hash_block_size = hash_block_size
         self.lcm_block_size = scheduler_block_size
         self.enable_partial_hash_hits = partial_hash_hits_enabled(

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/coordinator.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/coordinator.py
@@ -211,7 +211,8 @@ class MooncakeStoreCoordinator:
         blocks in place), so a positional read may hit a null, freed, or live
         speculative-state block and persist wrong bytes under a valid prefix
         hash. Mamba state is persisted only through the connector-pinned exact
-        block hand-off path (``SchedulerOutput.boundary_state_offloads``).
+        block hand-off path
+        (``SchedulerOutput.kv_connector_block_state.boundary_state_offloads``).
         """
         return self._reachable_masks(
             aligned_token_len,

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/data.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/data.py
@@ -14,6 +14,7 @@ import torch
 
 from vllm.distributed.kv_transfer.kv_connector.v1.base import (
     KVConnectorMetadata,
+    KVConnectorWorkerMetadata,
 )
 from vllm.logger import init_logger
 from vllm.utils.math_utils import cdiv
@@ -366,11 +367,14 @@ class ReqMeta:
 
     token_ids: list[int] | None = None
     num_prompt_tokens: int | None = None
-    # Core-provided per-mamba-group
-    # (group_id, cow_block_id, boundary_tokens) for this request's partial tail.
-    # Present only on the producer's CoW step; drives the connector's offload
-    # (the FA group's block is derived from block_ids and boundary_tokens).
-    partial_tail_offloads: list[tuple[int, int, int]] | None = None
+    # Connector-pinned (handoff_id, group_id, block_id, boundary_tokens) mamba
+    # "align" boundary states for this request. An entry
+    # whose boundary is block-aligned for its group is a committed boundary-state
+    # snapshot; a non-aligned one is the sub-block CoW partial tail (whose other
+    # groups' blocks are derived from block_ids and boundary_tokens). Either way
+    # the mamba block must be read via the provided block_id, never resolved
+    # positionally. The pin is held until the worker acknowledges handoff_id.
+    boundary_state_offloads: list[tuple[int, int, int, int]] | None = None
 
     @staticmethod
     def from_request_tracker(
@@ -448,3 +452,26 @@ class MooncakeStoreConnectorMetadata(KVConnectorMetadata):
 
     def add_request(self, req_meta: ReqMeta) -> None:
         self.requests.append(req_meta)
+
+
+@dataclass
+class MooncakeStoreWorkerMetadata(KVConnectorWorkerMetadata):
+    """Metadata passed back from worker to scheduler.
+
+    ``boundary_handoff_watermark`` is the highest connector hand-off id for which
+    this rank has finished *every* hand-off it received up to and including
+    that id — its single send thread makes the outcome per-id exact. Ranks
+    receive identical hand-off sets, so aggregating with ``min`` yields the
+    watermark that holds on every rank; the scheduler releases the connector's
+    BlockPool refs up to it.
+    """
+
+    boundary_handoff_watermark: int
+
+    def aggregate(self, other: KVConnectorWorkerMetadata) -> KVConnectorWorkerMetadata:
+        assert isinstance(other, MooncakeStoreWorkerMetadata)
+        return MooncakeStoreWorkerMetadata(
+            boundary_handoff_watermark=min(
+                self.boundary_handoff_watermark, other.boundary_handoff_watermark
+            )
+        )

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/data.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/data.py
@@ -372,11 +372,11 @@ class ReqMeta:
     # serve that purpose: it is reused once a preempted request resumes, so it
     # would release the wrong job's blocks.
     store_job_id: int | None = None
-    # Core-provided per-mamba-group
-    # (group_id, cow_block_id, boundary_tokens) for this request's partial tail.
-    # Present only on the producer's CoW step; drives the connector's offload
-    # (the FA group's block is derived from block_ids and boundary_tokens).
-    partial_tail_offloads: list[tuple[int, int, int]] | None = None
+    # Core-provided (group_id, block_id, boundary_tokens) mamba "align"
+    # boundary states. A block-aligned entry is a committed boundary snapshot;
+    # a non-aligned entry is the sub-block CoW tail. The store-job reference
+    # keeps each exact block alive until every worker rank finishes the job.
+    boundary_state_offloads: list[tuple[int, int, int]] | None = None
 
     @staticmethod
     def from_request_tracker(

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/scheduler.py
@@ -5,6 +5,7 @@
 # (vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/).
 """Scheduler-side logic for MooncakeStoreConnector."""
 
+import itertools
 from typing import Any
 
 from vllm.config import VllmConfig
@@ -24,8 +25,10 @@ from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.worker import (
     LookupKeyClient,
 )
 from vllm.logger import init_logger
+from vllm.v1.attention.backends.utils import NULL_BLOCK_ID
+from vllm.v1.core.block_pool import BlockPool
 from vllm.v1.core.kv_cache_manager import KVCacheBlocks
-from vllm.v1.core.kv_cache_utils import resolve_kv_cache_block_sizes
+from vllm.v1.core.kv_cache_utils import KVCacheBlock, resolve_kv_cache_block_sizes
 from vllm.v1.core.sched.output import NewRequestData, SchedulerOutput
 from vllm.v1.kv_cache_interface import KVCacheConfig
 from vllm.v1.request import Request
@@ -72,11 +75,24 @@ class MooncakeStoreScheduler:
             kv_cache_config.kv_cache_groups, self._hash_block_size
         )
 
+        self._gpu_block_pool: BlockPool | None = None
+        self._boundary_handoff_ids = itertools.count(1)
+        # Each accepted handoff owns one BlockPool ref until every worker rank
+        # reports it terminal. The cap bounds retained refs if acknowledgements
+        # stop; new optional saves are dropped instead of risking stale reads.
+        self._inflight_handoffs: dict[int, KVCacheBlock] = {}
+        self._max_inflight_handoffs = int(
+            kvc_extra_config.get("max_inflight_boundary_state_offloads", 8)
+        )
+
         # Per-request state
         self.load_specs: dict[str, LoadSpec] = {}  # to be loaded
         self._request_trackers: dict[str, RequestTracker] = {}  # scheduled new requests
         self._unfinished_requests: dict[str, tuple[Request, tuple[list[int], ...]]] = {}
         self._unfinished_request_ids: set[str] = set()
+
+    def bind_gpu_block_pool(self, gpu_block_pool: BlockPool) -> None:
+        self._gpu_block_pool = gpu_block_pool
 
     def get_num_new_matched_tokens(
         self,
@@ -354,45 +370,87 @@ class MooncakeStoreScheduler:
                 if req_meta is not None:
                     meta.add_request(req_meta)
 
-        # Flush partial-tail offloads in the step they arrive: the CoW copy is
-        # enqueued before the connector event records, so this step's event
-        # fences the cow block. Ride the request's save meta when present, else
-        # emit an offload-only ReqMeta (token_len_chunk=0 skips the normal
-        # save; can_save=True takes the normal enqueue path).
-        step_partial_tails = getattr(scheduler_output, "partial_tail_offloads", None)
-        if step_partial_tails and not force_skip_save:
-            pending = dict(step_partial_tails)
-            for req_meta in meta.requests:
-                if req_meta.can_save:
-                    groups = pending.pop(req_meta.req_id, None)
-                    if groups:
-                        req_meta.partial_tail_offloads = groups
-                        tracker = self._request_trackers.get(req_meta.req_id)
-                        if tracker is not None:
-                            tracker.has_pending_offload = True
-            for req_id, groups in pending.items():
-                tracker = self._request_trackers.get(req_id)
-                req_tuple = self._unfinished_requests.get(req_id)
-                if tracker is None or req_tuple is None:
-                    # Request finished/preempted within this step; its blocks
-                    # are going away, so the offload is conservatively dropped.
-                    logger.debug("Dropping partial-tail offload for request %s", req_id)
-                    continue
-                assert len({boundary for _, _, boundary in groups}) == 1
-                tracker.has_pending_offload = True
-                meta.add_request(
-                    ReqMeta(
-                        req_id=req_id,
-                        token_len_chunk=0,
-                        block_ids=tracker.allocated_block_ids,
-                        block_hashes=req_tuple[0].block_hashes,
-                        can_save=True,
-                        num_prompt_tokens=tracker.prefill_end_tokens,
-                        partial_tail_offloads=groups,
-                    )
-                )
+        offloads = getattr(scheduler_output, "boundary_state_offloads", None)
+        if offloads and not force_skip_save:
+            self._handle_boundary_state_offloads(offloads, meta)
 
         return meta
+
+    def _handle_boundary_state_offloads(
+        self,
+        offloads: dict[str, list[tuple[int, int, int]]],
+        meta: MooncakeStoreConnectorMetadata,
+    ) -> None:
+        """Pin and enqueue exact boundary-state blocks for this step.
+
+        Flushed in the step they arrive: the CoW copy is enqueued before the
+        connector event records, so this step's event fences the handed-off
+        block. Entries ride the request's save meta when present, else an
+        offload-only ReqMeta (``token_len_chunk=0`` skips the normal save,
+        ``can_save=True`` takes the normal enqueue path).
+        """
+        assert self._gpu_block_pool is not None
+        save_metas = {m.req_id: m for m in meta.requests if m.can_save}
+        for req_id, entries in offloads.items():
+            tracker = self._request_trackers.get(req_id)
+            req_tuple = self._unfinished_requests.get(req_id)
+            if tracker is None or req_tuple is None:
+                # Request finished/preempted within this step; its blocks are
+                # going away, so the offload is conservatively dropped.
+                logger.debug("Dropping boundary-state offload for request %s", req_id)
+                continue
+            accepted = []
+            for group_id, block_id, boundary_tokens in entries:
+                # Every other group stops saving at the end of this prefill, so
+                # a mamba-only key past it can never complete a joint hybrid
+                # hit. `prefill_end_tokens` — not the original prompt length —
+                # is the boundary: a resumed request re-prefills and re-saves
+                # its previously generated tokens for every group.
+                if boundary_tokens > tracker.prefill_end_tokens:
+                    continue
+                if block_id == NULL_BLOCK_ID:
+                    continue
+                if len(self._inflight_handoffs) >= self._max_inflight_handoffs:
+                    logger.debug(
+                        "Dropping boundary-state offload: %d hand-offs in flight",
+                        len(self._inflight_handoffs),
+                    )
+                    break
+                handoff_id = next(self._boundary_handoff_ids)
+                block = self._gpu_block_pool.blocks[block_id]
+                self._gpu_block_pool.touch((block,))
+                self._inflight_handoffs[handoff_id] = block
+                accepted.append((handoff_id, group_id, block_id, boundary_tokens))
+            if not accepted:
+                continue
+            tracker.has_pending_offload = True
+            if (req_meta := save_metas.get(req_id)) is not None:
+                req_meta.boundary_state_offloads = accepted
+                continue
+            meta.add_request(
+                ReqMeta(
+                    req_id=req_id,
+                    token_len_chunk=0,
+                    block_ids=tracker.allocated_block_ids,
+                    block_hashes=req_tuple[0].block_hashes,
+                    can_save=True,
+                    num_prompt_tokens=tracker.prefill_end_tokens,
+                    boundary_state_offloads=accepted,
+                )
+            )
+
+    def update_boundary_handoff_watermark(self, watermark: int) -> None:
+        """Release exact block refs completed by every worker rank."""
+        completed = [
+            handoff_id
+            for handoff_id in self._inflight_handoffs
+            if handoff_id <= watermark
+        ]
+        if not completed:
+            return
+        blocks = [self._inflight_handoffs.pop(i) for i in completed]
+        assert self._gpu_block_pool is not None
+        self._gpu_block_pool.free_blocks(blocks)
 
     def request_finished(
         self,

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/scheduler.py
@@ -28,7 +28,7 @@ from vllm.v1.core.block_pool import BlockPool
 from vllm.v1.core.kv_cache_manager import KVCacheBlocks
 from vllm.v1.core.kv_cache_utils import resolve_kv_cache_block_sizes
 from vllm.v1.core.sched.output import NewRequestData, SchedulerOutput
-from vllm.v1.kv_cache_interface import KVCacheConfig
+from vllm.v1.kv_cache_interface import KVCacheConfig, MambaSpec
 from vllm.v1.outputs import KVConnectorOutput
 from vllm.v1.request import Request
 
@@ -79,6 +79,15 @@ class MooncakeStoreScheduler:
         self.enable_partial_hash_hits = partial_hash_hits_enabled(
             kv_cache_config.kv_cache_groups, self._hash_block_size
         )
+        mamba_groups = {
+            group_id: group.kv_cache_spec
+            for group_id, group in enumerate(kv_cache_config.kv_cache_groups)
+            if isinstance(group.kv_cache_spec, MambaSpec)
+        }
+        assert all(
+            spec.mamba_cache_mode == "align" for spec in mamba_groups.values()
+        ), "MooncakeStoreScheduler requires mamba_cache_mode='align'"
+        self._boundary_state_group_ids = frozenset(mamba_groups)
 
         self._gpu_block_pool: BlockPool | None = None
         self._num_workers = vllm_config.parallel_config.world_size
@@ -404,8 +413,7 @@ class MooncakeStoreScheduler:
             block_ids: list[int] = []
             if req_meta.boundary_state_offloads:
                 block_ids.extend(
-                    block_id
-                    for _, block_id, _ in req_meta.boundary_state_offloads
+                    block_id for _, block_id, _ in req_meta.boundary_state_offloads
                 )
             # Every allocated block is referenced, not just the ones covering
             # this job's token range: a rank resumes from its own last
@@ -454,6 +462,8 @@ class MooncakeStoreScheduler:
                 if boundary_tokens > tracker.prefill_end_tokens:
                     continue
                 if block_id == NULL_BLOCK_ID:
+                    continue
+                if group_id not in self._boundary_state_group_ids:
                     continue
                 accepted.append((group_id, block_id, boundary_tokens))
             if not accepted:

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/scheduler.py
@@ -387,12 +387,40 @@ class MooncakeStoreScheduler:
                 if req_meta is not None:
                     meta.add_request(req_meta)
 
-        offloads = getattr(scheduler_output, "boundary_state_offloads", None)
-        if offloads and not is_consumer:
-            self._handle_boundary_state_offloads(offloads, meta)
+        block_state = getattr(scheduler_output, "kv_connector_block_state", None)
+        if (
+            block_state is not None
+            and block_state.boundary_state_offloads
+            and not is_consumer
+        ):
+            self._handle_boundary_state_offloads(
+                block_state.boundary_state_offloads, meta
+            )
 
+        self._apply_current_save_block_ids(meta, scheduler_output)
         self._reference_save_blocks(meta)
         return meta
+
+    def _apply_current_save_block_ids(
+        self,
+        meta: MooncakeStoreConnectorMetadata,
+        scheduler_output: SchedulerOutput,
+    ) -> None:
+        """Replace append-only mirrors with the core's current block tables."""
+        save_metas = [req_meta for req_meta in meta.requests if req_meta.can_save]
+        if not save_metas:
+            return
+
+        block_state = scheduler_output.kv_connector_block_state
+        assert block_state is not None, (
+            "Current block tables are required for Mooncake store jobs"
+        )
+        for req_meta in save_metas:
+            block_ids = block_state.block_ids.get(req_meta.req_id)
+            assert block_ids is not None, (
+                f"Missing current block table for store request {req_meta.req_id}"
+            )
+            req_meta.block_ids = block_ids
 
     def _reference_save_blocks(self, meta: MooncakeStoreConnectorMetadata) -> None:
         """Take a GPU block reference for every store job this step emits.
@@ -415,16 +443,24 @@ class MooncakeStoreScheduler:
                 block_ids.extend(
                     block_id for _, block_id, _ in req_meta.boundary_state_offloads
                 )
+            assert NULL_BLOCK_ID not in block_ids, (
+                "A null block cannot back a boundary-state offload"
+            )
             # Every allocated block is referenced, not just the ones covering
             # this job's token range: a rank resumes from its own last
             # successful offset, which lags the scheduler's whenever a save was
             # skipped or failed, so it may read anywhere below the range.
             block_ids.extend(
-                block_id for group in req_meta.block_ids for block_id in group
+                block_id
+                for group_id, group in enumerate(req_meta.block_ids)
+                if group_id not in self._boundary_state_group_ids
+                for block_id in group
+                if block_id != NULL_BLOCK_ID
             )
             # An aligned boundary block may also be present in the request's
             # block table. Take and release exactly one reference per block.
             block_ids = list(dict.fromkeys(block_ids))
+            assert NULL_BLOCK_ID not in block_ids
             if not block_ids:
                 continue
             self._pinned_saves[store_job_id] = (block_ids, self._num_workers)

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/scheduler.py
@@ -23,6 +23,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.worker import (
     LookupKeyClient,
 )
 from vllm.logger import init_logger
+from vllm.v1.attention.backends.utils import NULL_BLOCK_ID
 from vllm.v1.core.block_pool import BlockPool
 from vllm.v1.core.kv_cache_manager import KVCacheBlocks
 from vllm.v1.core.kv_cache_utils import resolve_kv_cache_block_sizes
@@ -79,17 +80,17 @@ class MooncakeStoreScheduler:
             kv_cache_config.kv_cache_groups, self._hash_block_size
         )
 
-        # Per-request state
-        self.load_specs: dict[str, LoadSpec] = {}  # to be loaded
-        self._request_trackers: dict[str, RequestTracker] = {}  # scheduled new requests
-        self._unfinished_requests: dict[str, tuple[Request, tuple[list[int], ...]]] = {}
-        self._unfinished_request_ids: set[str] = set()
-
         self._gpu_block_pool: BlockPool | None = None
         self._num_workers = vllm_config.parallel_config.world_size
         self._next_store_job_id = 0
         # store_job_id -> (referenced block ids, ranks yet to report completion)
         self._pinned_saves: dict[int, tuple[list[int], int]] = {}
+
+        # Per-request state
+        self.load_specs: dict[str, LoadSpec] = {}  # to be loaded
+        self._request_trackers: dict[str, RequestTracker] = {}  # scheduled new requests
+        self._unfinished_requests: dict[str, tuple[Request, tuple[list[int], ...]]] = {}
+        self._unfinished_request_ids: set[str] = set()
 
     def bind_gpu_block_pool(self, gpu_block_pool: BlockPool) -> None:
         self._gpu_block_pool = gpu_block_pool
@@ -377,43 +378,9 @@ class MooncakeStoreScheduler:
                 if req_meta is not None:
                     meta.add_request(req_meta)
 
-        # Flush partial-tail offloads in the step they arrive: the CoW copy is
-        # enqueued before the connector event records, so this step's event
-        # fences the cow block. Ride the request's save meta when present, else
-        # emit an offload-only ReqMeta (token_len_chunk=0 skips the normal
-        # save; can_save=True takes the normal enqueue path).
-        step_partial_tails = getattr(scheduler_output, "partial_tail_offloads", None)
-        if step_partial_tails and not is_consumer:
-            pending = dict(step_partial_tails)
-            for req_meta in meta.requests:
-                if req_meta.can_save:
-                    groups = pending.pop(req_meta.req_id, None)
-                    if groups:
-                        req_meta.partial_tail_offloads = groups
-                        tracker = self._request_trackers.get(req_meta.req_id)
-                        if tracker is not None:
-                            tracker.has_pending_offload = True
-            for req_id, groups in pending.items():
-                tracker = self._request_trackers.get(req_id)
-                req_tuple = self._unfinished_requests.get(req_id)
-                if tracker is None or req_tuple is None:
-                    # Request finished/preempted within this step; its blocks
-                    # are going away, so the offload is conservatively dropped.
-                    logger.debug("Dropping partial-tail offload for request %s", req_id)
-                    continue
-                assert len({boundary for _, _, boundary in groups}) == 1
-                tracker.has_pending_offload = True
-                meta.add_request(
-                    ReqMeta(
-                        req_id=req_id,
-                        token_len_chunk=0,
-                        block_ids=tracker.allocated_block_ids,
-                        block_hashes=req_tuple[0].block_hashes,
-                        can_save=True,
-                        num_prompt_tokens=tracker.prefill_end_tokens,
-                        partial_tail_offloads=groups,
-                    )
-                )
+        offloads = getattr(scheduler_output, "boundary_state_offloads", None)
+        if offloads and not is_consumer:
+            self._handle_boundary_state_offloads(offloads, meta)
 
         self._reference_save_blocks(meta)
         return meta
@@ -435,21 +402,77 @@ class MooncakeStoreScheduler:
             req_meta.store_job_id = store_job_id = self._next_store_job_id
             self._next_store_job_id += 1
             block_ids: list[int] = []
-            if req_meta.partial_tail_offloads:
-                # A partial-tail CoW block is deliberately kept out of the
-                # request's block table, so it is absent from `block_ids` even
-                # though the worker DMAs out of it just as asynchronously.
-                # It leads the list, as in `pop_blocks_for_free`.
-                block_ids += [bid for _, bid, _ in req_meta.partial_tail_offloads]
+            if req_meta.boundary_state_offloads:
+                block_ids.extend(
+                    block_id
+                    for _, block_id, _ in req_meta.boundary_state_offloads
+                )
             # Every allocated block is referenced, not just the ones covering
             # this job's token range: a rank resumes from its own last
             # successful offset, which lags the scheduler's whenever a save was
             # skipped or failed, so it may read anywhere below the range.
-            block_ids += [bid for group in req_meta.block_ids for bid in group]
+            block_ids.extend(
+                block_id for group in req_meta.block_ids for block_id in group
+            )
+            # An aligned boundary block may also be present in the request's
+            # block table. Take and release exactly one reference per block.
+            block_ids = list(dict.fromkeys(block_ids))
             if not block_ids:
                 continue
             self._pinned_saves[store_job_id] = (block_ids, self._num_workers)
-            pool.touch([pool.blocks[bid] for bid in block_ids])
+            pool.touch([pool.blocks[block_id] for block_id in block_ids])
+
+    def _handle_boundary_state_offloads(
+        self,
+        offloads: dict[str, list[tuple[int, int, int]]],
+        meta: MooncakeStoreConnectorMetadata,
+    ) -> None:
+        """Attach exact boundary-state blocks to store jobs for this step.
+
+        Flushed in the step they arrive: the CoW copy is enqueued before the
+        connector event records, so this step's event fences the exact block.
+        Entries ride the request's save meta when present, else an
+        offload-only ReqMeta (``token_len_chunk=0`` skips the normal save,
+        ``can_save=True`` takes the normal enqueue and store-job pinning path).
+        """
+        save_metas = {m.req_id: m for m in meta.requests if m.can_save}
+        for req_id, entries in offloads.items():
+            tracker = self._request_trackers.get(req_id)
+            req_tuple = self._unfinished_requests.get(req_id)
+            if tracker is None or req_tuple is None:
+                # Request finished/preempted within this step; its blocks are
+                # going away, so the offload is conservatively dropped.
+                logger.debug("Dropping boundary-state offload for request %s", req_id)
+                continue
+            accepted: list[tuple[int, int, int]] = []
+            for group_id, block_id, boundary_tokens in entries:
+                # Every other group stops saving at the end of this prefill, so
+                # a mamba-only key past it can never complete a joint hybrid
+                # hit. `prefill_end_tokens` — not the original prompt length —
+                # is the boundary: a resumed request re-prefills and re-saves
+                # its previously generated tokens for every group.
+                if boundary_tokens > tracker.prefill_end_tokens:
+                    continue
+                if block_id == NULL_BLOCK_ID:
+                    continue
+                accepted.append((group_id, block_id, boundary_tokens))
+            if not accepted:
+                continue
+            tracker.has_pending_offload = True
+            if (req_meta := save_metas.get(req_id)) is not None:
+                req_meta.boundary_state_offloads = accepted
+                continue
+            meta.add_request(
+                ReqMeta(
+                    req_id=req_id,
+                    token_len_chunk=0,
+                    block_ids=tracker.allocated_block_ids,
+                    block_hashes=req_tuple[0].block_hashes,
+                    can_save=True,
+                    num_prompt_tokens=tracker.prefill_end_tokens,
+                    boundary_state_offloads=accepted,
+                )
+            )
 
     def update_connector_output(self, connector_output: KVConnectorOutput) -> None:
         """Drop the block references of store jobs every rank has finished."""

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
@@ -691,6 +691,8 @@ class KVCacheStoreSendingThread(KVTransferThread):
                         # persisted, from the core-provided hand-off.
                         continue
                     block_id = mamba_offloads[g_idx]
+                elif g_idx in self.coord.mamba_group_ids:
+                    continue
                 elif block_idx < len(group_blocks):
                     block_id = group_blocks[block_idx]
                 else:

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
@@ -18,7 +18,7 @@ import socket
 import threading
 import time
 from collections import defaultdict
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Iterable, Sequence
 from concurrent.futures import Future, ThreadPoolExecutor
 from dataclasses import dataclass
 from typing import Any, Literal, TypeVar
@@ -46,6 +46,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.data import (  
     ChunkedTokenDatabase,
     KeyMetadata,
     MooncakeStoreConnectorMetadata,
+    MooncakeStoreWorkerMetadata,
     PoolKey,
     ReqMeta,
 )
@@ -522,6 +523,40 @@ class KVCacheStoreSendingThread(KVTransferThread):
         # batch resumes here, so pressure-skipped or failed ranges are retried.
         self._saved_offset: dict[str, int] = {}
 
+        # Core boundary-state hand-offs handed to this thread but not yet
+        # dequeued, and the highest id ever handed to it. Each pins a GPU state
+        # block in the core until the watermark below reaches it.
+        self._pending_handoffs: set[int] = set()
+        self._max_seen_handoff = 0
+
+    def note_pending_handoffs(self, handoff_ids: Iterable[int]) -> None:
+        """Register hand-offs being enqueued. Must run before ``add_request``."""
+        with self.done_task_lock:
+            for handoff_id in handoff_ids:
+                self._pending_handoffs.add(handoff_id)
+                self._max_seen_handoff = max(self._max_seen_handoff, handoff_id)
+
+    def handoff_watermark(self) -> int | None:
+        """Highest id whose hand-off — and every earlier one — is terminal.
+
+        A hand-off is terminal once its request is dequeued here, whatever the
+        outcome: dedup/no-put, a successful put, or a dropped batch (pressure
+        skip, cancelled request, failed exists/put). The core may then reuse the
+        block, so the id must not be reported before that. Returns ``None`` only
+        when this rank has never received a hand-off.
+        """
+        with self.done_task_lock:
+            if self._pending_handoffs:
+                return min(self._pending_handoffs) - 1
+            return self._max_seen_handoff or None
+
+    def _complete_handoffs(self, req_meta: ReqMeta) -> None:
+        if not req_meta.boundary_state_offloads:
+            return
+        with self.done_task_lock:
+            for entry in req_meta.boundary_state_offloads:
+                self._pending_handoffs.discard(entry[0])
+
     def add_stored_request(self, req_id: str):
         with self.done_task_lock:
             self.stored_requests[req_id] += 1
@@ -563,48 +598,76 @@ class KVCacheStoreSendingThread(KVTransferThread):
             self._skip_store_requests.clear()
         return True
 
-    def _maybe_offload_partial_tail(self, req_meta: ReqMeta) -> bool:
-        """Offload the request's sub-block partial tail (its last prompt hash
-        boundary) so a later request can hit the sub-block prefix.
+    def _boundary_snapshot_puts(
+        self, req_meta: ReqMeta, entries: list[tuple[int, int, int]]
+    ) -> list[tuple[str, list[int], list[int], KeyMetadata]]:
+        """Puts for committed mamba "align" boundary-state snapshots.
 
-        Covers every block from the normal save's lcm floor to the boundary:
-        the normal save floors to ``lcm_block_size``, so a smaller-block
-        group's full blocks in that gap are never persisted elsewhere, and
-        the consumer's lookup needs every group at every probed boundary.
-        Full blocks are keyed by their block-end hash, the partial boundary
-        block by the boundary sub-hash; the mamba "align" boundary block is
-        the core-provided CoW block. All keys are deduped against the store.
+        These are block-aligned boundaries, i.e. exactly what the normal save
+        would key — but ``store_mask`` masks mamba groups out of it entirely, so
+        this is their *only* writer. The exclusion is not an optimization: the
+        normal save resolves a chunk's address as
+        ``req_meta.block_ids[g][start // block_size]``, and ``block_ids`` is the
+        connector's append-only mirror of the core's per-group table. An
+        align-mode table is mutated in place (a superseded state block is freed
+        and nulled; speculative blocks relocate), and the connector is never
+        told, so a stale mirror entry is indistinguishable from a live one — a
+        retry of a failed or pressure-skipped chunk would read a block that now
+        belongs to another request.
 
-        Returns:
-            True when no put is needed or every put succeeds, False otherwise.
+        Each entry's handed-off block *is* the boundary state and is pinned by
+        the core, so it is uploaded under its boundary-end hash key and never
+        resolved positionally.
         """
-        if not self.coord.enable_partial_hash_hits or not req_meta.block_hashes:
-            return True
-        partial_tail_offloads = req_meta.partial_tail_offloads
-        if not partial_tail_offloads:
-            return True
         hash_block_size = self.coord.hash_block_size
-        boundaries = {boundary for _, _, boundary in partial_tail_offloads}
+        puts: list[tuple[str, list[int], list[int], KeyMetadata]] = []
+        for group_id, block_id, boundary in entries:
+            if boundary == 0 or block_id == NULL_BLOCK_ID:
+                continue
+            hash_idx = boundary // hash_block_size - 1
+            if hash_idx >= len(req_meta.block_hashes):
+                continue
+            db = self.token_databases[group_id]
+            # Distribute across ranks by the same rule as normal chunks.
+            put_step = self.group_put_steps[group_id]
+            put_step_rank = (self.tp_rank + group_id) % put_step
+            if (boundary // db.block_size - 1) % put_step != put_step_rank:
+                continue
+            addr, size = db.prepare_value_for_block(block_id)
+            puts.append(
+                (db.key_for(req_meta.block_hashes[hash_idx]), addr, size, db.metadata)
+            )
+        return puts
+
+    def _sub_block_tail_puts(
+        self, req_meta: ReqMeta, entries: list[tuple[int, int, int]]
+    ) -> list[tuple[str, list[int], list[int], KeyMetadata]]:
+        """Puts for the request's sub-block partial tail (its last prompt hash
+        boundary), so a later request can hit the sub-block prefix.
+
+        Covers every group's blocks from the normal save's lcm floor to the
+        boundary: the normal save floors to ``lcm_block_size``, so a
+        smaller-block group's full blocks in that gap are never persisted
+        elsewhere, and the consumer's lookup needs every group at every probed
+        boundary. Full blocks are keyed by their block-end hash and the partial
+        boundary block by the boundary sub-hash; a mamba "align" group
+        contributes only its boundary block, from the core-provided CoW block.
+        """
+        boundaries = {boundary for _, _, boundary in entries}
         if len(boundaries) != 1:
             raise ValueError(
-                "Partial-tail offloads for one request must share a boundary"
+                "Sub-block partial-tail offloads for one request must share a boundary"
             )
         boundary = boundaries.pop()
-        if boundary == 0:
-            return True
-        if boundary // hash_block_size - 1 >= len(req_meta.block_hashes):
-            return True
-        mamba_offloads = {
-            group_id: block_id for group_id, block_id, _ in partial_tail_offloads
-        }
+        hash_block_size = self.coord.hash_block_size
+        if boundary == 0 or boundary // hash_block_size - 1 >= len(
+            req_meta.block_hashes
+        ):
+            return []
 
-        keys: list[str] = []
-        addrs: list[list[int]] = []
-        sizes: list[list[int]] = []
-        group_ids: list[str] | None = (
-            [] if self.enable_group_semantics and self.supports_group_ids else None
-        )
+        mamba_offloads = {group_id: block_id for group_id, block_id, _ in entries}
         saved = self._saved_offset.get(req_meta.req_id, 0)
+        puts: list[tuple[str, list[int], list[int], KeyMetadata]] = []
         for g_idx, db in enumerate(self.token_databases):
             group_blocks = req_meta.block_ids[g_idx]
             # Distribute across ranks by the same rule as normal chunks.
@@ -620,16 +683,18 @@ class KVCacheStoreSendingThread(KVTransferThread):
                     continue
                 valid_end = min((block_idx + 1) * db.block_size, boundary)
                 key_hash = req_meta.block_hashes[valid_end // hash_block_size - 1]
-                if (
-                    g_idx in mamba_offloads
-                    and valid_end == boundary
-                    and boundary % db.block_size != 0
-                ):
-                    block_id = mamba_offloads[g_idx]
-                else:
-                    if block_idx >= len(group_blocks):
+                if g_idx in mamba_offloads:
+                    if valid_end != boundary:
+                        # Interior align-mode state positions are null or
+                        # stale (the block table is not append-only) and never
+                        # valid gap content; only the boundary block is
+                        # persisted, from the core-provided hand-off.
                         continue
+                    block_id = mamba_offloads[g_idx]
+                elif block_idx < len(group_blocks):
                     block_id = group_blocks[block_idx]
+                else:
+                    continue
                 if block_id == NULL_BLOCK_ID:
                     logger.debug(
                         "Skipping unavailable partial-tail source block "
@@ -640,20 +705,58 @@ class KVCacheStoreSendingThread(KVTransferThread):
                     )
                     continue
                 addr, size = db.prepare_value_for_block(block_id)
-                key = db.key_for(key_hash)
-                keys.append(key)
-                addrs.append(addr)
-                sizes.append(size)
-                if group_ids is not None:
-                    group_ids.append(
-                        _make_mooncake_group_id(
-                            db.metadata,
-                            key.rsplit("@", 1)[-1],
-                        )
-                    )
+                puts.append((db.key_for(key_hash), addr, size, db.metadata))
+        return puts
 
-        if not keys:
+    def _maybe_offload_boundary_states(self, req_meta: ReqMeta) -> bool:
+        """Persist connector-pinned mamba "align" boundary states handed off
+        for this request, deduped against the store.
+
+        This is every mamba key the connector writes — ``store_mask`` excludes
+        mamba groups from the positional normal save, aligned boundaries
+        included (see :meth:`_boundary_snapshot_puts`).
+
+        The two entry kinds are keyed and sourced differently, so they are
+        prepared separately and put in one batch:
+
+        - block-aligned for its group: a committed boundary-state snapshot,
+          the handed-off block itself;
+        - not block-aligned: the sub-block CoW partial tail, which also has to
+          cover the other groups' blocks in the normal save's lcm gap.
+
+        Returns:
+            True when no put is needed or every put succeeds, False otherwise.
+        """
+        offloads = req_meta.boundary_state_offloads
+        if not offloads or not req_meta.block_hashes:
             return True
+
+        snapshots: list[tuple[int, int, int]] = []
+        sub_block: list[tuple[int, int, int]] = []
+        for _handoff_id, group_id, block_id, boundary in offloads:
+            entry = (group_id, block_id, boundary)
+            if boundary % self.token_databases[group_id].block_size == 0:
+                snapshots.append(entry)
+            else:
+                sub_block.append(entry)
+
+        puts = self._boundary_snapshot_puts(req_meta, snapshots)
+        if sub_block and self.coord.enable_partial_hash_hits:
+            puts.extend(self._sub_block_tail_puts(req_meta, sub_block))
+
+        if not puts:
+            return True
+        keys = [key for key, _, _, _ in puts]
+        addrs = [addr for _, addr, _, _ in puts]
+        sizes = [size for _, _, size, _ in puts]
+        group_ids: list[str] | None = (
+            [
+                _make_mooncake_group_id(metadata, key.rsplit("@", 1)[-1])
+                for key, _, _, metadata in puts
+            ]
+            if self.enable_group_semantics and self.supports_group_ids
+            else None
+        )
         exists_start = time.perf_counter()
         try:
             exists = self.store.batch_is_exist(keys)
@@ -666,7 +769,7 @@ class KVCacheStoreSendingThread(KVTransferThread):
                 num_failed_keys=len(keys),
             )
             logger.error(
-                "Failed to check partial-tail keys for request %s: %s",
+                "Failed to check boundary-state keys for request %s: %s",
                 req_meta.req_id,
                 e,
             )
@@ -702,7 +805,7 @@ class KVCacheStoreSendingThread(KVTransferThread):
                 num_failed_keys=len(keys),
             )
             logger.error(
-                "Failed to put partial-tail keys for request %s: %s",
+                "Failed to put boundary-state keys for request %s: %s",
                 req_meta.req_id,
                 e,
             )
@@ -720,7 +823,8 @@ class KVCacheStoreSendingThread(KVTransferThread):
         if failed:
             failed_codes = {res[i] for i in failed}
             logger.warning(
-                "Partial-tail put failed for request %s: %d/%d keys failed (codes=%s)",
+                "Boundary-state put failed for request %s: %d/%d keys failed "
+                "(codes=%s)",
                 req_meta.req_id,
                 len(failed),
                 len(keys),
@@ -733,7 +837,7 @@ class KVCacheStoreSendingThread(KVTransferThread):
         if self._clear_store_pressure():
             logger.info(
                 "Mooncake CPU/disk offloading pressure cleared after a "
-                "successful partial-tail batch"
+                "successful boundary-state batch"
             )
         return True
 
@@ -747,12 +851,16 @@ class KVCacheStoreSendingThread(KVTransferThread):
         current_event = req_meta.current_event
 
         if req_id not in self.stored_requests:
+            # Cancelled (finished/preempted) before its turn: its hand-offs are
+            # terminal, so let the scheduler connector release their refs.
+            self._complete_handoffs(req_meta)
             self.request_queue.task_done()
             return
 
-        # Decrement the in-flight counter and signal task_done() in `finally`
-        # so the scheduler can release the GPU blocks it pinned for this
-        # request (via `delay_free_blocks`) even when the store path raises.
+        # Complete the hand-offs, decrement the in-flight counter and signal
+        # task_done() in `finally` so the scheduler connector can release its
+        # handed-off state refs and the scheduler can release the request blocks
+        # it retained via `delay_free_blocks` even when the store path raises.
         try:
             if self._should_skip_request(req_id):
                 logger.debug(
@@ -762,10 +870,10 @@ class KVCacheStoreSendingThread(KVTransferThread):
                 )
                 return
 
-            # Offload the sub-block partial tail (independent of the normal
-            # block-aligned save, which may be skipped this step).
-            if req_meta.partial_tail_offloads is not None and not (
-                self._maybe_offload_partial_tail(req_meta)
+            # Offload the handed-off mamba boundary states (independent of the
+            # normal positional save, which may be skipped this step).
+            if req_meta.boundary_state_offloads is not None and not (
+                self._maybe_offload_boundary_states(req_meta)
             ):
                 return
 
@@ -792,6 +900,7 @@ class KVCacheStoreSendingThread(KVTransferThread):
                 # Rotate the stride phase per group to balance load across ranks.
                 put_step = self.group_put_steps[g_idx]
                 put_step_rank = (self.tp_rank + g_idx) % put_step
+                group_blocks = block_ids_per_group[g_idx]
                 for start, end, block_hash in db.process_tokens(
                     token_len,
                     req_meta.block_hashes,
@@ -800,6 +909,15 @@ class KVCacheStoreSendingThread(KVTransferThread):
                     put_step=put_step,
                     put_step_rank=put_step_rank,
                 ):
+                    # A chunk backed by a null (or missing) block holds no
+                    # committed KV for this group; persisting it would poison
+                    # the key with reserved-block bytes.
+                    block_idx = start // db.block_size
+                    if (
+                        block_idx >= len(group_blocks)
+                        or group_blocks[block_idx] == NULL_BLOCK_ID
+                    ):
+                        continue
                     starts.append(start)
                     ends.append(end)
                     keys.append(db.key_for(block_hash))
@@ -985,6 +1103,7 @@ class KVCacheStoreSendingThread(KVTransferThread):
                 self.update_kv_event(stored_events)
         finally:
             self.dec_stored_request(req_id)
+            self._complete_handoffs(req_meta)
             self.request_queue.task_done()
 
 
@@ -1670,6 +1789,12 @@ class MooncakeStoreWorker:
                     continue
                 request.current_event = current_event
                 assert self.kv_send_thread is not None
+                if request.boundary_state_offloads:
+                    # Registered before enqueueing so the send thread cannot
+                    # report these ids done before they are known to be pending.
+                    self.kv_send_thread.note_pending_handoffs(
+                        entry[0] for entry in request.boundary_state_offloads
+                    )
                 self.kv_send_thread.add_stored_request(request.req_id)
                 self.kv_send_thread.add_request(request)
 
@@ -1698,6 +1823,21 @@ class MooncakeStoreWorker:
         for recv_thread in self.kv_recv_threads:
             block_ids |= recv_thread.get_and_clear_block_ids_with_load_errors()
         return block_ids
+
+    def build_connector_worker_meta(self) -> MooncakeStoreWorkerMetadata | None:
+        """Report how far this rank's boundary-state hand-offs have drained.
+
+        Once this rank has received a hand-off, zero is reported while its first
+        hand-off is still pending. This ensures cross-rank aggregation includes
+        lagging ranks. Deployments without mamba "align" hand-offs report no
+        metadata.
+        """
+        if self.kv_send_thread is None:
+            return None
+        watermark = self.kv_send_thread.handoff_watermark()
+        if watermark is None:
+            return None
+        return MooncakeStoreWorkerMetadata(boundary_handoff_watermark=watermark)
 
     def _record_kv_connector_operation(
         self,

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
@@ -737,6 +737,8 @@ class KVCacheStoreSendingThread(KVTransferThread):
                         # persisted, from the core-provided hand-off.
                         continue
                     block_id = mamba_offloads[g_idx]
+                elif g_idx in self.coord.mamba_group_ids:
+                    continue
                 elif block_idx < len(group_blocks):
                     block_id = group_blocks[block_idx]
                 else:

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
@@ -644,48 +644,76 @@ class KVCacheStoreSendingThread(KVTransferThread):
             self._skip_store_requests.clear()
         return True
 
-    def _maybe_offload_partial_tail(self, req_meta: ReqMeta) -> bool:
-        """Offload the request's sub-block partial tail (its last prompt hash
-        boundary) so a later request can hit the sub-block prefix.
+    def _boundary_snapshot_puts(
+        self, req_meta: ReqMeta, entries: list[tuple[int, int, int]]
+    ) -> list[tuple[str, list[int], list[int], KeyMetadata]]:
+        """Puts for committed mamba "align" boundary-state snapshots.
 
-        Covers every block from the normal save's lcm floor to the boundary:
-        the normal save floors to ``lcm_block_size``, so a smaller-block
-        group's full blocks in that gap are never persisted elsewhere, and
-        the consumer's lookup needs every group at every probed boundary.
-        Full blocks are keyed by their block-end hash, the partial boundary
-        block by the boundary sub-hash; the mamba "align" boundary block is
-        the core-provided CoW block. All keys are deduped against the store.
+        These are block-aligned boundaries, i.e. exactly what the normal save
+        would key — but ``store_mask`` masks mamba groups out of it entirely, so
+        this is their *only* writer. The exclusion is not an optimization: the
+        normal save resolves a chunk's address as
+        ``req_meta.block_ids[g][start // block_size]``, and ``block_ids`` is the
+        connector's append-only mirror of the core's per-group table. An
+        align-mode table is mutated in place (a superseded state block is freed
+        and nulled; speculative blocks relocate), and the connector is never
+        told, so a stale mirror entry is indistinguishable from a live one — a
+        retry of a failed or pressure-skipped chunk would read a block that now
+        belongs to another request.
 
-        Returns:
-            True when no put is needed or every put succeeds, False otherwise.
+        Each entry's handed-off block *is* the boundary state and is pinned by
+        the core, so it is uploaded under its boundary-end hash key and never
+        resolved positionally.
         """
-        if not self.coord.enable_partial_hash_hits or not req_meta.block_hashes:
-            return True
-        partial_tail_offloads = req_meta.partial_tail_offloads
-        if not partial_tail_offloads:
-            return True
         hash_block_size = self.coord.hash_block_size
-        boundaries = {boundary for _, _, boundary in partial_tail_offloads}
+        puts: list[tuple[str, list[int], list[int], KeyMetadata]] = []
+        for group_id, block_id, boundary in entries:
+            if boundary == 0 or block_id == NULL_BLOCK_ID:
+                continue
+            hash_idx = boundary // hash_block_size - 1
+            if hash_idx >= len(req_meta.block_hashes):
+                continue
+            db = self.token_databases[group_id]
+            # Distribute across ranks by the same rule as normal chunks.
+            put_step = self.group_put_steps[group_id]
+            put_step_rank = (self.tp_rank + group_id) % put_step
+            if (boundary // db.block_size - 1) % put_step != put_step_rank:
+                continue
+            addr, size = db.prepare_value_for_block(block_id)
+            puts.append(
+                (db.key_for(req_meta.block_hashes[hash_idx]), addr, size, db.metadata)
+            )
+        return puts
+
+    def _sub_block_tail_puts(
+        self, req_meta: ReqMeta, entries: list[tuple[int, int, int]]
+    ) -> list[tuple[str, list[int], list[int], KeyMetadata]]:
+        """Puts for the request's sub-block partial tail (its last prompt hash
+        boundary), so a later request can hit the sub-block prefix.
+
+        Covers every group's blocks from the normal save's lcm floor to the
+        boundary: the normal save floors to ``lcm_block_size``, so a
+        smaller-block group's full blocks in that gap are never persisted
+        elsewhere, and the consumer's lookup needs every group at every probed
+        boundary. Full blocks are keyed by their block-end hash and the partial
+        boundary block by the boundary sub-hash; a mamba "align" group
+        contributes only its boundary block, from the core-provided CoW block.
+        """
+        boundaries = {boundary for _, _, boundary in entries}
         if len(boundaries) != 1:
             raise ValueError(
-                "Partial-tail offloads for one request must share a boundary"
+                "Sub-block partial-tail offloads for one request must share a boundary"
             )
         boundary = boundaries.pop()
-        if boundary == 0:
-            return True
-        if boundary // hash_block_size - 1 >= len(req_meta.block_hashes):
-            return True
-        mamba_offloads = {
-            group_id: block_id for group_id, block_id, _ in partial_tail_offloads
-        }
+        hash_block_size = self.coord.hash_block_size
+        if boundary == 0 or boundary // hash_block_size - 1 >= len(
+            req_meta.block_hashes
+        ):
+            return []
 
-        keys: list[str] = []
-        addrs: list[list[int]] = []
-        sizes: list[list[int]] = []
-        group_ids: list[str] | None = (
-            [] if self.enable_group_semantics and self.supports_group_ids else None
-        )
+        mamba_offloads = {group_id: block_id for group_id, block_id, _ in entries}
         saved = self._saved_offset.get(req_meta.req_id, 0)
+        puts: list[tuple[str, list[int], list[int], KeyMetadata]] = []
         for g_idx, db in enumerate(self.token_databases):
             group_blocks = req_meta.block_ids[g_idx]
             # Distribute across ranks by the same rule as normal chunks.
@@ -701,16 +729,18 @@ class KVCacheStoreSendingThread(KVTransferThread):
                     continue
                 valid_end = min((block_idx + 1) * db.block_size, boundary)
                 key_hash = req_meta.block_hashes[valid_end // hash_block_size - 1]
-                if (
-                    g_idx in mamba_offloads
-                    and valid_end == boundary
-                    and boundary % db.block_size != 0
-                ):
-                    block_id = mamba_offloads[g_idx]
-                else:
-                    if block_idx >= len(group_blocks):
+                if g_idx in mamba_offloads:
+                    if valid_end != boundary:
+                        # Interior align-mode state positions are null or
+                        # stale (the block table is not append-only) and never
+                        # valid gap content; only the boundary block is
+                        # persisted, from the core-provided hand-off.
                         continue
+                    block_id = mamba_offloads[g_idx]
+                elif block_idx < len(group_blocks):
                     block_id = group_blocks[block_idx]
+                else:
+                    continue
                 if block_id == NULL_BLOCK_ID:
                     logger.debug(
                         "Skipping unavailable partial-tail source block "
@@ -721,20 +751,58 @@ class KVCacheStoreSendingThread(KVTransferThread):
                     )
                     continue
                 addr, size = db.prepare_value_for_block(block_id)
-                key = db.key_for(key_hash)
-                keys.append(key)
-                addrs.append(addr)
-                sizes.append(size)
-                if group_ids is not None:
-                    group_ids.append(
-                        _make_mooncake_group_id(
-                            db.metadata,
-                            key.rsplit("@", 1)[-1],
-                        )
-                    )
+                puts.append((db.key_for(key_hash), addr, size, db.metadata))
+        return puts
 
-        if not keys:
+    def _maybe_offload_boundary_states(self, req_meta: ReqMeta) -> bool:
+        """Persist connector-pinned mamba "align" boundary states handed off
+        for this request, deduped against the store.
+
+        This is every mamba key the connector writes — ``store_mask`` excludes
+        mamba groups from the positional normal save, aligned boundaries
+        included (see :meth:`_boundary_snapshot_puts`).
+
+        The two entry kinds are keyed and sourced differently, so they are
+        prepared separately and put in one batch:
+
+        - block-aligned for its group: a committed boundary-state snapshot,
+          the handed-off block itself;
+        - not block-aligned: the sub-block CoW partial tail, which also has to
+          cover the other groups' blocks in the normal save's lcm gap.
+
+        Returns:
+            True when no put is needed or every put succeeds, False otherwise.
+        """
+        offloads = req_meta.boundary_state_offloads
+        if not offloads or not req_meta.block_hashes:
             return True
+
+        snapshots: list[tuple[int, int, int]] = []
+        sub_block: list[tuple[int, int, int]] = []
+        for group_id, block_id, boundary in offloads:
+            entry = (group_id, block_id, boundary)
+            if boundary % self.token_databases[group_id].block_size == 0:
+                snapshots.append(entry)
+            else:
+                sub_block.append(entry)
+
+        puts = self._boundary_snapshot_puts(req_meta, snapshots)
+        if sub_block and self.coord.enable_partial_hash_hits:
+            puts.extend(self._sub_block_tail_puts(req_meta, sub_block))
+
+        if not puts:
+            return True
+        keys = [key for key, _, _, _ in puts]
+        addrs = [addr for _, addr, _, _ in puts]
+        sizes = [size for _, _, size, _ in puts]
+        group_ids: list[str] | None = (
+            [
+                _make_mooncake_group_id(metadata, key.rsplit("@", 1)[-1])
+                for key, _, _, metadata in puts
+            ]
+            if self.enable_group_semantics and self.supports_group_ids
+            else None
+        )
         exists_start = time.perf_counter()
         try:
             exists = self.store.batch_is_exist(keys)
@@ -747,7 +815,7 @@ class KVCacheStoreSendingThread(KVTransferThread):
                 num_failed_keys=len(keys),
             )
             logger.error(
-                "Failed to check partial-tail keys for request %s: %s",
+                "Failed to check boundary-state keys for request %s: %s",
                 req_meta.req_id,
                 e,
             )
@@ -783,7 +851,7 @@ class KVCacheStoreSendingThread(KVTransferThread):
                 num_failed_keys=len(keys),
             )
             logger.error(
-                "Failed to put partial-tail keys for request %s: %s",
+                "Failed to put boundary-state keys for request %s: %s",
                 req_meta.req_id,
                 e,
             )
@@ -801,7 +869,8 @@ class KVCacheStoreSendingThread(KVTransferThread):
         if failed:
             failed_codes = {res[i] for i in failed}
             logger.warning(
-                "Partial-tail put failed for request %s: %d/%d keys failed (codes=%s)",
+                "Boundary-state put failed for request %s: %d/%d keys failed "
+                "(codes=%s)",
                 req_meta.req_id,
                 len(failed),
                 len(keys),
@@ -814,7 +883,7 @@ class KVCacheStoreSendingThread(KVTransferThread):
         if self._clear_store_pressure():
             logger.info(
                 "Mooncake CPU/disk offloading pressure cleared after a "
-                "successful partial-tail batch"
+                "successful boundary-state batch"
             )
         return True
 
@@ -853,10 +922,10 @@ class KVCacheStoreSendingThread(KVTransferThread):
                 )
                 return
 
-            # Offload the sub-block partial tail (independent of the normal
-            # block-aligned save, which may be skipped this step).
-            if req_meta.partial_tail_offloads is not None and not (
-                self._maybe_offload_partial_tail(req_meta)
+            # Offload the handed-off mamba boundary states (independent of the
+            # normal positional save, which may be skipped this step).
+            if req_meta.boundary_state_offloads is not None and not (
+                self._maybe_offload_boundary_states(req_meta)
             ):
                 return
 
@@ -883,6 +952,7 @@ class KVCacheStoreSendingThread(KVTransferThread):
                 # Rotate the stride phase per group to balance load across ranks.
                 put_step = self.group_put_steps[g_idx]
                 put_step_rank = (self.tp_rank + g_idx) % put_step
+                group_blocks = block_ids_per_group[g_idx]
                 for start, end, block_hash in db.process_tokens(
                     token_len,
                     req_meta.block_hashes,

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
@@ -1120,6 +1120,9 @@ class OffloadingConnectorScheduler:
                         if bid != 0:
                             self._current_batch_allocated_block_ids.add(bid)
 
+        for copy in scheduler_output.kv_cache_block_copies or ():
+            self._current_batch_allocated_block_ids.add(copy.dst_block_id)
+
         # Zero out stale block_ids in sliding window groups' pending-store
         # positions. Only sliding window groups can have stale entries (blocks
         # freed by remove_skipped_blocks then reallocated). Only positions in
@@ -1141,18 +1144,88 @@ class OffloadingConnectorScheduler:
                         ):
                             group_state.block_ids[j] = 0
 
+    def _build_aligned_boundary_store_jobs(
+        self, handoffs: dict[str, list[tuple[int, int, int]]]
+    ) -> dict[int, TransferJob]:
+        store_jobs: dict[int, TransferJob] = {}
+        num_groups = len(self.config.kv_group_configs)
+        for req_id, entries in handoffs.items():
+            req_status = self._req_status.get(req_id)
+            if req_status is None:
+                continue
+            req = req_status.req
+            max_boundary = self._calc_num_offloadable_tokens(req_status, req.num_tokens)
+            for group_idx, block_id, boundary in entries:
+                group_config = self.config.kv_group_configs[group_idx]
+                if (
+                    block_id == 0
+                    or boundary > max_boundary
+                    or boundary % group_config.tokens_per_chunk != 0
+                ):
+                    continue
+
+                key = self._make_boundary_key(req, group_idx, boundary)
+                store_output = self.manager.prepare_store([key], req_status.req_context)
+                if store_output is None:
+                    self._connector_stats.increase_counter(
+                        _ConnectorMetricName.ALLOCATION_FAILURE
+                    )
+                    continue
+                if not store_output.keys_to_store:
+                    continue
+
+                job_id = self._generate_job_id()
+                req_status.transfer_jobs.add(job_id)
+                self._block_id_to_pending_jobs.setdefault(block_id, set()).add(job_id)
+                self._jobs[job_id] = TransferJobStatus(
+                    req_id=req_id,
+                    pending_count=self.config.num_workers,
+                    keys={key},
+                    is_store=True,
+                    fenced_block_ids=[block_id],
+                )
+                group_sizes = [0] * num_groups
+                group_sizes[group_idx] = 1
+                block_indices = [0] * num_groups
+                block_indices[group_idx] = boundary // group_config.tokens_per_block - 1
+                store_jobs[job_id] = TransferJob(
+                    req_id=req_id,
+                    src_spec=GPULoadStoreSpec(
+                        [block_id],
+                        group_sizes=group_sizes,
+                        block_indices=block_indices,
+                    ),
+                    dst_spec=store_output.store_spec,
+                )
+                self._events_tracker.record_store(
+                    req,
+                    group_config,
+                    boundary // group_config.tokens_per_chunk - 1,
+                    key,
+                )
+        return store_jobs
+
     def _build_partial_tail_store_jobs(
         self, scheduler_output: SchedulerOutput
     ) -> dict[int, TransferJob]:
-        handoffs = scheduler_output.partial_tail_offloads
-        if not self.config.supports_partial_tail or not handoffs:
+        handoffs = scheduler_output.boundary_state_offloads
+        if not handoffs:
             return {}
 
-        store_jobs: dict[int, TransferJob] = {}
+        store_jobs = self._build_aligned_boundary_store_jobs(handoffs)
+        if not self.config.supports_partial_tail:
+            return store_jobs
+
         for req_id, entries in handoffs.items():
+            entries = [
+                entry
+                for entry in entries
+                if entry[2] % self._partial_tail_block_size != 0
+            ]
+            if not entries:
+                continue
             req_status = self._req_status.get(req_id)
             assert req_status is not None
-            assert entries
             boundaries = {boundary for _, _, boundary in entries}
             assert len(boundaries) == 1
             boundary = boundaries.pop()
@@ -1265,6 +1338,9 @@ class OffloadingConnectorScheduler:
                 num_chunks = req_status.storable_chunks(
                     group_config, group_state, num_offloadable_tokens
                 )
+
+                if group_config.requires_cow_source:
+                    continue
 
                 start_chunk_idx = group_state.next_stored_chunk_idx
                 if num_chunks <= start_chunk_idx:

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
@@ -1130,6 +1130,9 @@ class OffloadingConnectorScheduler:
                         if bid != 0:
                             self._current_batch_allocated_block_ids.add(bid)
 
+        for copy in scheduler_output.kv_cache_block_copies or ():
+            self._current_batch_allocated_block_ids.add(copy.dst_block_id)
+
         # Zero out stale block_ids in sliding window groups' pending-store
         # positions. Only sliding window groups can have stale entries (blocks
         # freed by remove_skipped_blocks then reallocated). Only positions in
@@ -1151,18 +1154,88 @@ class OffloadingConnectorScheduler:
                         ):
                             group_state.block_ids[j] = 0
 
+    def _build_aligned_boundary_store_jobs(
+        self, handoffs: dict[str, list[tuple[int, int, int]]]
+    ) -> dict[int, TransferJob]:
+        store_jobs: dict[int, TransferJob] = {}
+        num_groups = len(self.config.kv_group_configs)
+        for req_id, entries in handoffs.items():
+            req_status = self._req_status.get(req_id)
+            if req_status is None:
+                continue
+            req = req_status.req
+            max_boundary = self._calc_num_offloadable_tokens(req_status, req.num_tokens)
+            for group_idx, block_id, boundary in entries:
+                group_config = self.config.kv_group_configs[group_idx]
+                if (
+                    block_id == 0
+                    or boundary > max_boundary
+                    or boundary % group_config.tokens_per_chunk != 0
+                ):
+                    continue
+
+                key = self._make_boundary_key(req, group_idx, boundary)
+                store_output = self.manager.prepare_store([key], req_status.req_context)
+                if store_output is None:
+                    self._connector_stats.increase_counter(
+                        _ConnectorMetricName.ALLOCATION_FAILURE
+                    )
+                    continue
+                if not store_output.keys_to_store:
+                    continue
+
+                job_id = self._generate_job_id()
+                req_status.transfer_jobs.add(job_id)
+                self._block_id_to_pending_jobs.setdefault(block_id, set()).add(job_id)
+                self._jobs[job_id] = TransferJobStatus(
+                    req_id=req_id,
+                    pending_count=self.config.num_workers,
+                    keys={key},
+                    is_store=True,
+                    fenced_block_ids=[block_id],
+                )
+                group_sizes = [0] * num_groups
+                group_sizes[group_idx] = 1
+                block_indices = [0] * num_groups
+                block_indices[group_idx] = boundary // group_config.tokens_per_block - 1
+                store_jobs[job_id] = TransferJob(
+                    req_id=req_id,
+                    src_spec=GPULoadStoreSpec(
+                        [block_id],
+                        group_sizes=group_sizes,
+                        block_indices=block_indices,
+                    ),
+                    dst_spec=store_output.store_spec,
+                )
+                self._events_tracker.record_store(
+                    req,
+                    group_config,
+                    boundary // group_config.tokens_per_chunk - 1,
+                    key,
+                )
+        return store_jobs
+
     def _build_partial_tail_store_jobs(
         self, scheduler_output: SchedulerOutput
     ) -> dict[int, TransferJob]:
-        handoffs = scheduler_output.partial_tail_offloads
-        if not self.config.supports_partial_tail or not handoffs:
+        handoffs = scheduler_output.boundary_state_offloads
+        if not handoffs:
             return {}
 
-        store_jobs: dict[int, TransferJob] = {}
+        store_jobs = self._build_aligned_boundary_store_jobs(handoffs)
+        if not self.config.supports_partial_tail:
+            return store_jobs
+
         for req_id, entries in handoffs.items():
+            entries = [
+                entry
+                for entry in entries
+                if entry[2] % self._partial_tail_block_size != 0
+            ]
+            if not entries:
+                continue
             req_status = self._req_status.get(req_id)
             assert req_status is not None
-            assert entries
             boundaries = {boundary for _, _, boundary in entries}
             assert len(boundaries) == 1
             boundary = boundaries.pop()
@@ -1281,6 +1354,9 @@ class OffloadingConnectorScheduler:
                 num_chunks = req_status.storable_chunks(
                     group_config, group_state, num_offloadable_tokens
                 )
+
+                if group_config.requires_cow_source:
+                    continue
 
                 start_chunk_idx = group_state.next_stored_chunk_idx
                 if num_chunks <= start_chunk_idx:

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
@@ -1218,7 +1218,8 @@ class OffloadingConnectorScheduler:
     def _build_partial_tail_store_jobs(
         self, scheduler_output: SchedulerOutput
     ) -> dict[int, TransferJob]:
-        handoffs = scheduler_output.boundary_state_offloads
+        block_state = scheduler_output.kv_connector_block_state
+        handoffs = block_state.boundary_state_offloads if block_state else None
         if not handoffs:
             return {}
 

--- a/vllm/v1/core/block_pool.py
+++ b/vllm/v1/core/block_pool.py
@@ -716,6 +716,10 @@ class BlockPool:
             if self.metrics_collector:
                 self.metrics_collector.on_block_accessed(block)
 
+    def is_block_writable(self, block: KVCacheBlock) -> bool:
+        """Return whether a block can be mutated by its sole owner."""
+        return not block.is_null and block.ref_cnt == 1 and block.block_hash is None
+
     def free_blocks(self, ordered_blocks: Iterable[KVCacheBlock]) -> None:
         """Free a list of blocks. The blocks should be ordered by their
         eviction priority, where the first block will be evicted first.

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -186,10 +186,6 @@ class KVCacheManager:
             tuple(() for _ in range(self.num_kv_cache_groups))
         )
 
-        # Off-table cow blocks handed to a KV connector for partial-tail
-        # offload; pinned until the request's blocks are freed.
-        self._partial_tail_pins: dict[str, list[KVCacheBlock]] = {}
-
     @property
     def usage(self) -> float:
         """Get the KV cache usage.
@@ -572,9 +568,6 @@ class KVCacheManager:
         Args:
             request: The request to free the blocks.
         """
-        pins = self._partial_tail_pins.pop(request.request_id, None)
-        if pins:
-            self.block_pool.free_blocks(pins)
         self.coordinator.free(request.request_id)
 
     def remove_skipped_blocks(
@@ -607,14 +600,7 @@ class KVCacheManager:
         Returns:
             The request's blocks in allocation order.
         """
-        blocks = self.coordinator.pop_blocks_for_free(request.request_id)
-        # Pins ride the same (possibly deferred) free as the request blocks.
-        # Preemption may release a pin under a still-queued offload — the same
-        # exposure normal saves of table blocks already have.
-        pins = self._partial_tail_pins.pop(request.request_id, None)
-        if pins:
-            blocks = pins + blocks
-        return blocks
+        return self.coordinator.pop_blocks_for_free(request.request_id)
 
     def evict_blocks(self, block_ids: set[int]) -> None:
         """evict blocks from the prefix cache by their block IDs.
@@ -845,18 +831,18 @@ class KVCacheManager:
         retained_blocks = [block for pair in pending_copies for block in pair]
         return copies, retained_blocks
 
-    def take_partial_tail_offloads(self) -> dict[str, list[tuple[int, int, int]]]:
-        """Drain producer partial-tail offload hand-offs per request.
+    def take_boundary_state_offloads(
+        self,
+    ) -> dict[str, list[tuple[int, int, int]]]:
+        """Drain this step's boundary-state hand-offs for a KV connector.
 
         Returns ``{request_id: [(group_id, block_id, boundary_tokens), ...]}``
-        for the durable boundary blocks of producers' last-prompt-boundary
-        partial tails. Only mamba "align" groups contribute; empty otherwise.
-        A KV connector reads the referenced blocks and offloads them so a later
-        request can hit the sub-block prefix.
-
-        Each handed-off block lives off the request block table, so it is
-        pinned here and unpinned when the request's blocks are freed — for a
-        producer with saved tokens, after the connector reports sends done.
+        for mamba "align" boundary states: the
+        request's committed boundary-state snapshots and, on a sub-block partial
+        hit, the CoW copy of its last-prompt-boundary state. Only mamba "align"
+        groups contribute; empty otherwise. A connector reads the referenced
+        blocks — never resolving them positionally — and offloads them so a
+        later request can hit that prefix.
         """
         offloads: dict[str, list[tuple[int, int, int]]] = {}
         for mgr in self.coordinator.single_type_managers:
@@ -865,9 +851,7 @@ class KVCacheManager:
                 group_id,
                 block,
                 boundary_tokens,
-            ) in mgr.take_pending_partial_tail_offloads():
-                self.block_pool.touch((block,))
-                self._partial_tail_pins.setdefault(req_id, []).append(block)
+            ) in mgr.take_pending_boundary_state_offloads():
                 offloads.setdefault(req_id, []).append(
                     (group_id, block.block_id, boundary_tokens)
                 )

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -189,10 +189,6 @@ class KVCacheManager:
             tuple(() for _ in range(self.num_kv_cache_groups))
         )
 
-        # Off-table cow blocks handed to a KV connector for partial-tail
-        # offload; pinned until the request's blocks are freed.
-        self._partial_tail_pins: dict[str, list[KVCacheBlock]] = {}
-
     @property
     def usage(self) -> float:
         """Get the KV cache usage.
@@ -575,9 +571,6 @@ class KVCacheManager:
         Args:
             request: The request to free the blocks.
         """
-        pins = self._partial_tail_pins.pop(request.request_id, None)
-        if pins:
-            self.block_pool.free_blocks(pins)
         self.coordinator.free(request.request_id)
 
     def remove_skipped_blocks(
@@ -610,14 +603,7 @@ class KVCacheManager:
         Returns:
             The request's blocks in allocation order.
         """
-        blocks = self.coordinator.pop_blocks_for_free(request.request_id)
-        # Pins ride the same (possibly deferred) free as the request blocks.
-        # Preemption may release a pin under a still-queued offload — the same
-        # exposure normal saves of table blocks already have.
-        pins = self._partial_tail_pins.pop(request.request_id, None)
-        if pins:
-            blocks = pins + blocks
-        return blocks
+        return self.coordinator.pop_blocks_for_free(request.request_id)
 
     def evict_blocks(self, block_ids: set[int]) -> None:
         """evict blocks from the prefix cache by their block IDs.
@@ -854,18 +840,18 @@ class KVCacheManager:
         retained_blocks = [block for pair in pending_copies for block in pair]
         return copies, retained_blocks
 
-    def take_partial_tail_offloads(self) -> dict[str, list[tuple[int, int, int]]]:
-        """Drain producer partial-tail offload hand-offs per request.
+    def take_boundary_state_offloads(
+        self,
+    ) -> dict[str, list[tuple[int, int, int]]]:
+        """Drain this step's boundary-state hand-offs for a KV connector.
 
         Returns ``{request_id: [(group_id, block_id, boundary_tokens), ...]}``
-        for the durable boundary blocks of producers' last-prompt-boundary
-        partial tails. Only mamba "align" groups contribute; empty otherwise.
-        A KV connector reads the referenced blocks and offloads them so a later
-        request can hit the sub-block prefix.
-
-        Each handed-off block lives off the request block table, so it is
-        pinned here and unpinned when the request's blocks are freed — for a
-        producer with saved tokens, after the connector reports sends done.
+        for mamba "align" boundary states: the
+        request's committed boundary-state snapshots and, on a sub-block partial
+        hit, the CoW copy of its last-prompt-boundary state. Only mamba "align"
+        groups contribute; empty otherwise. A connector reads the referenced
+        blocks — never resolving them positionally — and offloads them so a
+        later request can hit that prefix.
         """
         offloads: dict[str, list[tuple[int, int, int]]] = {}
         for mgr in self.coordinator.single_type_managers:
@@ -874,9 +860,7 @@ class KVCacheManager:
                 group_id,
                 block,
                 boundary_tokens,
-            ) in mgr.take_pending_partial_tail_offloads():
-                self.block_pool.touch((block,))
-                self._partial_tail_pins.setdefault(req_id, []).append(block)
+            ) in mgr.take_pending_boundary_state_offloads():
                 offloads.setdefault(req_id, []).append(
                     (group_id, block.block_id, boundary_tokens)
                 )

--- a/vllm/v1/core/sched/output.py
+++ b/vllm/v1/core/sched/output.py
@@ -258,11 +258,9 @@ class SchedulerOutput:
     # CoW copies to apply after zeroing new blocks and before forward.
     kv_cache_block_copies: list[KVCacheBlockCopy] | None = None
 
-    # Producer partial-tail offload hand-off for external KV connectors:
-    # {request_id: [(group_id, block_id, boundary_tokens), ...]} pointing at
-    # the durable boundary block of a producer's last-prompt-boundary partial
-    # tail (mamba "align" CoW target). None unless partial hash hits are active.
-    partial_tail_offloads: dict[str, list[tuple[int, int, int]]] | None = None
+    # Mamba "align" boundary-state hand-off offered to a producer-side KV
+    # connector. Scheduler-local; always None by the time this reaches a worker.
+    boundary_state_offloads: dict[str, list[tuple[int, int, int]]] | None = None
 
     # Dynamic speculative decoding: optimal K chosen by scheduler.
     # Number of spec tokens to schedule for the next step.

--- a/vllm/v1/core/sched/output.py
+++ b/vllm/v1/core/sched/output.py
@@ -206,6 +206,16 @@ class ScheduledEncoderInputStats:
 
 
 @dataclass
+class KVConnectorBlockState:
+    """Scheduler-local block state offered to a producer-side KV connector."""
+
+    # Authoritative current block-table snapshots.
+    block_ids: dict[str, tuple[list[int], ...]]
+    # Exact Mamba "align" boundary-state hand-offs.
+    boundary_state_offloads: dict[str, list[tuple[int, int, int]]]
+
+
+@dataclass
 class SchedulerOutput:
     # list of the requests that are scheduled for the first time.
     # We cache the request's data in each worker process, so that we don't
@@ -278,9 +288,8 @@ class SchedulerOutput:
     # CoW copies to apply after zeroing new blocks and before forward.
     kv_cache_block_copies: list[KVCacheBlockCopy] | None = None
 
-    # Mamba "align" boundary-state hand-off offered to a producer-side KV
-    # connector. Scheduler-local; always None by the time this reaches a worker.
-    boundary_state_offloads: dict[str, list[tuple[int, int, int]]] | None = None
+    # Scheduler-local; always None by the time this reaches a worker.
+    kv_connector_block_state: KVConnectorBlockState | None = None
 
     # Dynamic speculative decoding: optimal K chosen by scheduler.
     # Number of spec tokens to schedule for the next step.

--- a/vllm/v1/core/sched/output.py
+++ b/vllm/v1/core/sched/output.py
@@ -278,11 +278,9 @@ class SchedulerOutput:
     # CoW copies to apply after zeroing new blocks and before forward.
     kv_cache_block_copies: list[KVCacheBlockCopy] | None = None
 
-    # Producer partial-tail offload hand-off for external KV connectors:
-    # {request_id: [(group_id, block_id, boundary_tokens), ...]} pointing at
-    # the durable boundary block of a producer's last-prompt-boundary partial
-    # tail (mamba "align" CoW target). None unless partial hash hits are active.
-    partial_tail_offloads: dict[str, list[tuple[int, int, int]]] | None = None
+    # Mamba "align" boundary-state hand-off offered to a producer-side KV
+    # connector. Scheduler-local; always None by the time this reaches a worker.
+    boundary_state_offloads: dict[str, list[tuple[int, int, int]]] | None = None
 
     # Dynamic speculative decoding: optimal K chosen by scheduler.
     # Number of spec tokens to schedule for the next step.

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1171,21 +1171,10 @@ class Scheduler(SchedulerInterface):
             self.prev_step_scheduled_req_ids.clear()
             self.prev_step_scheduled_req_ids.update(num_scheduled_tokens.keys())
 
-        # Producer partial-tail hand-off for external KV connectors. Drained
-        # before the CoW retentions are released below, so the pin lands while
-        # the cow block still holds a retention ref. Without a producer-side
-        # connector nothing consumes the hand-off, so skip the drain (and its
-        # pin); the manager drops stale entries when the request's blocks are
-        # popped for free.
-        pending_partial_tail_offloads = None
-        if (
-            self.connector is not None
-            and self.vllm_config.kv_transfer_config is not None
-            and self.vllm_config.kv_transfer_config.is_kv_producer
-        ):
-            pending_partial_tail_offloads = (
-                self.kv_cache_manager.take_partial_tail_offloads() or None
-            )
+        # Mamba "align" boundary states must be handed off with exact block ids;
+        # they cannot be reconstructed from a connector's append-only block
+        # table. Drained every step so stale offers cannot accumulate.
+        boundary_state_offloads = self.kv_cache_manager.take_boundary_state_offloads()
 
         kv_cache_block_copies, cow_retained_blocks = (
             self.kv_cache_manager.take_kv_cache_block_copies()
@@ -1232,7 +1221,9 @@ class Scheduler(SchedulerInterface):
             free_encoder_mm_hashes=self.encoder_cache_manager.get_freed_mm_hashes(),
             new_block_ids_to_zero=self._get_new_block_ids_to_zero(),
             kv_cache_block_copies=pending_kv_cache_block_copies,
-            partial_tail_offloads=pending_partial_tail_offloads,
+            boundary_state_offloads=(
+                boundary_state_offloads if self.connector is not None else None
+            ),
             num_spec_tokens_to_schedule=num_spec_tokens_to_schedule,
             ec_manager_metadata=self.encoder_cache_manager.get_manager_metadata(),
         )
@@ -1251,6 +1242,9 @@ class Scheduler(SchedulerInterface):
                 scheduler_output
             )
             scheduler_output.ec_connector_metadata = ec_meta
+
+        # Boundary-state offers are scheduler-local.
+        scheduler_output.boundary_state_offloads = None
 
         # Advance the fence only for non-empty steps (those that actually
         # write KV and have their output processed later in update_from_output).

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1263,21 +1263,10 @@ class Scheduler(SchedulerInterface):
             self.prev_step_scheduled_req_ids.clear()
             self.prev_step_scheduled_req_ids.update(num_scheduled_tokens.keys())
 
-        # Producer partial-tail hand-off for external KV connectors. Drained
-        # before the CoW retentions are released below, so the pin lands while
-        # the cow block still holds a retention ref. Without a producer-side
-        # connector nothing consumes the hand-off, so skip the drain (and its
-        # pin); the manager drops stale entries when the request's blocks are
-        # popped for free.
-        pending_partial_tail_offloads = None
-        if (
-            self.connector is not None
-            and self.vllm_config.kv_transfer_config is not None
-            and self.vllm_config.kv_transfer_config.is_kv_producer
-        ):
-            pending_partial_tail_offloads = (
-                self.kv_cache_manager.take_partial_tail_offloads() or None
-            )
+        # Mamba "align" boundary states must be handed off with exact block ids;
+        # they cannot be reconstructed from a connector's append-only block
+        # table. Drained every step so stale offers cannot accumulate.
+        boundary_state_offloads = self.kv_cache_manager.take_boundary_state_offloads()
 
         kv_cache_block_copies, cow_retained_blocks = (
             self.kv_cache_manager.take_kv_cache_block_copies()
@@ -1325,7 +1314,9 @@ class Scheduler(SchedulerInterface):
             new_block_ids_to_zero=self._get_new_block_ids_to_zero(),
             has_sync_kv_loads=has_sync_kv_loads,
             kv_cache_block_copies=pending_kv_cache_block_copies,
-            partial_tail_offloads=pending_partial_tail_offloads,
+            boundary_state_offloads=(
+                boundary_state_offloads if self.connector is not None else None
+            ),
             num_spec_tokens_to_schedule=num_spec_tokens_to_schedule,
             ec_manager_metadata=self.encoder_cache_manager.get_manager_metadata(),
         )
@@ -1344,6 +1335,9 @@ class Scheduler(SchedulerInterface):
                 scheduler_output
             )
             scheduler_output.ec_connector_metadata = ec_meta
+
+        # Boundary-state offers are scheduler-local.
+        scheduler_output.boundary_state_offloads = None
 
         # Advance the fence only for non-empty steps (those that actually
         # write KV and have their output processed later in update_from_output).

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -42,6 +42,7 @@ from vllm.v1.core.sched.interface import PauseState, SchedulerInterface
 from vllm.v1.core.sched.output import (
     CachedRequestData,
     GrammarOutput,
+    KVConnectorBlockState,
     NewRequestData,
     ScheduledEncoderInputStats,
     SchedulerOutput,
@@ -1268,6 +1269,29 @@ class Scheduler(SchedulerInterface):
         # table. Drained every step so stale offers cannot accumulate.
         boundary_state_offloads = self.kv_cache_manager.take_boundary_state_offloads()
 
+        kv_connector_block_state = None
+        if self.connector is not None:
+            snapshot_req_ids = {req.req_id for req in new_reqs_data}
+            snapshot_req_ids.update(
+                req_id
+                for req_id, block_ids in zip(
+                    cached_reqs_data.req_ids,
+                    cached_reqs_data.new_block_ids,
+                    strict=True,
+                )
+                if block_ids
+            )
+            snapshot_req_ids.update(
+                req_id for req_id in boundary_state_offloads if req_id in self.requests
+            )
+            kv_connector_block_state = KVConnectorBlockState(
+                block_ids={
+                    req_id: self.kv_cache_manager.get_block_ids(req_id)
+                    for req_id in snapshot_req_ids
+                },
+                boundary_state_offloads=boundary_state_offloads,
+            )
+
         kv_cache_block_copies, cow_retained_blocks = (
             self.kv_cache_manager.take_kv_cache_block_copies()
         )
@@ -1314,9 +1338,7 @@ class Scheduler(SchedulerInterface):
             new_block_ids_to_zero=self._get_new_block_ids_to_zero(),
             has_sync_kv_loads=has_sync_kv_loads,
             kv_cache_block_copies=pending_kv_cache_block_copies,
-            boundary_state_offloads=(
-                boundary_state_offloads if self.connector is not None else None
-            ),
+            kv_connector_block_state=kv_connector_block_state,
             num_spec_tokens_to_schedule=num_spec_tokens_to_schedule,
             ec_manager_metadata=self.encoder_cache_manager.get_manager_metadata(),
         )
@@ -1336,8 +1358,8 @@ class Scheduler(SchedulerInterface):
             )
             scheduler_output.ec_connector_metadata = ec_meta
 
-        # Boundary-state offers are scheduler-local.
-        scheduler_output.boundary_state_offloads = None
+        # Connector-only block state must not be dispatched to workers.
+        scheduler_output.kv_connector_block_state = None
 
         # Advance the fence only for non-empty steps (those that actually
         # write KV and have their output processed later in update_from_output).

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -115,13 +115,14 @@ class SingleTypeKVCacheManager(ABC):
         # managers (full attention, mamba "align"); harmlessly empty elsewhere.
         self._partial_hit_reqs: dict[str, tuple[int, KVCacheBlock]] = {}
         self._pending_cow_copies: list[tuple[KVCacheBlock, KVCacheBlock]] = []
-        # Partial-tail offload hand-off for external KV connectors: when a
-        # producer registers its last-prompt-boundary partial tail and the
-        # durable boundary block is not on the append-only request block table
-        # (mamba "align" CoW target), record the request, group, block, and
-        # exact token boundary so a connector can offload it under the right
-        # hash. Populated only by mamba "align".
-        self._pending_partial_tail_offloads: list[
+        # Boundary-state offload hand-off for external KV connectors. A mamba
+        # "align" block table is not append-only (interior states are
+        # nulled/freed and speculative blocks relocate in place), so a
+        # connector cannot resolve its state blocks positionally. Record
+        # (request, group, block, exact token boundary) for each committed
+        # boundary state so a connector can offload the right block under the
+        # right hash. Populated only by mamba "align".
+        self._pending_boundary_state_offloads: list[
             tuple[str, int, KVCacheBlock, int]
         ] = []
 
@@ -387,19 +388,19 @@ class SingleTypeKVCacheManager(ABC):
         self._pending_cow_copies = []
         return pending_copies
 
-    def take_pending_partial_tail_offloads(
+    def take_pending_boundary_state_offloads(
         self,
     ) -> list[tuple[str, int, KVCacheBlock, int]]:
-        """Drain producer partial-tail hand-offs.
+        """Drain producer boundary-state hand-offs.
 
         Entries are ``(req_id, group_id, block, boundary_tokens)``.
 
-        Only mamba "align" populates this. The block lives off the request
-        block table, so the caller must pin it until the connector has read
-        it — nothing else keeps it alive once the CoW retention is released.
+        Only mamba "align" populates this. The blocks are not kept alive by
+        the request block table for the whole request, so a caller that reads
+        them asynchronously must pin them first.
         """
-        pending = self._pending_partial_tail_offloads
-        self._pending_partial_tail_offloads = []
+        pending = self._pending_boundary_state_offloads
+        self._pending_boundary_state_offloads = []
         return pending
 
     def _apply_cow(
@@ -1273,7 +1274,7 @@ class MambaManager(SingleTypeKVCacheManager):
             # Requests that registered their own last-prompt-boundary partial
             # tail (producers). On the next step's CoW the boundary state moves
             # into a private cow_block; we record that block for connector
-            # offload (see _pending_partial_tail_offloads).
+            # offload (see _pending_boundary_state_offloads).
             self._producer_partial_tail_reqs: dict[str, int] = {}
 
     @classmethod
@@ -1629,7 +1630,7 @@ class MambaManager(SingleTypeKVCacheManager):
                             # This CoW preserved a producer's own boundary
                             # state in cow_block; hand it to the connector for
                             # partial-tail offload once the copy has run.
-                            self._pending_partial_tail_offloads.append(
+                            self._pending_boundary_state_offloads.append(
                                 (
                                     request_id,
                                     self.kv_cache_group_id,
@@ -1655,11 +1656,14 @@ class MambaManager(SingleTypeKVCacheManager):
             self._allocated_block_reqs.discard(request_id)
             self.last_state_block_idx.pop(request_id, None)
             self._producer_partial_tail_reqs.pop(request_id, None)
-            # A hand-off whose request died in this same scheduling pass must
-            # not reach the connector: its unpin hook (free) has already run.
-            self._pending_partial_tail_offloads = [
+            # An offer is only guaranteed to hold committed bytes until the end
+            # of the pass that made it. This request's blocks are going back to
+            # the pool now, so drop its not-yet-offered hand-offs rather than
+            # let a connector claim a block another request may already have
+            # been handed.
+            self._pending_boundary_state_offloads = [
                 entry
-                for entry in self._pending_partial_tail_offloads
+                for entry in self._pending_boundary_state_offloads
                 if entry[0] != request_id
             ]
         return super().pop_blocks_for_free(request_id)
@@ -1686,9 +1690,9 @@ class MambaManager(SingleTypeKVCacheManager):
             if partial_hash is not None:
                 self.cached_blocks_this_step.add(partial_hash)
         if num_cached_blocks_after > num_cached_blocks_before:
-            for block in self.req_to_blocks[request.request_id][
-                num_cached_blocks_before:num_cached_blocks_after
-            ]:
+            blocks = self.req_to_blocks[request.request_id]
+            for idx in range(num_cached_blocks_before, num_cached_blocks_after):
+                block = blocks[idx]
                 # Skip null blocks (align-mode skipped states) and blocks that
                 # were not cached this step — with sparse retention
                 # (reachable_block_mask) the intermediate state snapshots carry
@@ -1696,6 +1700,29 @@ class MambaManager(SingleTypeKVCacheManager):
                 if block.is_null or block.block_hash is None:
                     continue
                 self.cached_blocks_this_step.add(block.block_hash)
+                if self.mamba_cache_mode == "align":
+                    # Hand the committed boundary state to a producer-side KV
+                    # connector, which cannot resolve align-mode state blocks
+                    # positionally. Emission follows the retention mask via the
+                    # blocks super().cache_blocks actually hashed: all
+                    # materialized boundaries under dense (default) retention,
+                    # sparse checkpoints otherwise. Skipped positions hold the
+                    # null block and are filtered above, which is also what
+                    # keeps unreachable eagle/speculative tails out.
+                    #
+                    # Every boundary is offered. Which ones are worth storing is
+                    # the connector's call: only it knows how far its own save
+                    # window reaches, and on a resumed prefill that window ends
+                    # past `num_prompt_tokens` (the replayed output tokens are
+                    # re-prefilled and saved for every other group too).
+                    self._pending_boundary_state_offloads.append(
+                        (
+                            request.request_id,
+                            self.kv_cache_group_id,
+                            block,
+                            (idx + 1) * self.block_size,
+                        )
+                    )
 
     def new_step_starts(self) -> None:
         self.cached_blocks_this_step.clear()

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -1589,13 +1589,12 @@ class MambaManager(SingleTypeKVCacheManager):
                     )
 
                 if blocks_allocated:
-                    # reuse previous speculative blocks in this step
+                    # Relocate exclusively owned speculative scratch blocks.
                     for block_idx in range(
                         prev_block_len - self.num_speculative_blocks, prev_block_len
                     ):
                         if block_idx < num_skipped_blocks:
-                            req_blocks.append(req_blocks[block_idx])
-                            req_blocks[block_idx] = self._null_block
+                            self._relocate_speculative_block(req_blocks, block_idx)
                         else:
                             break
                 num_new_blocks = num_required_blocks - len(req_blocks)
@@ -1650,6 +1649,17 @@ class MambaManager(SingleTypeKVCacheManager):
                 self._partial_hit_reqs.pop(request_id, None)
                 returned_blocks.extend(new_blocks)
                 return returned_blocks
+
+    def _relocate_speculative_block(
+        self, req_blocks: list[KVCacheBlock], block_idx: int
+    ) -> None:
+        block = req_blocks[block_idx]
+        assert self.block_pool.is_block_writable(block), (
+            "Speculative Mamba blocks must be exclusively owned and unhashed "
+            "before relocation"
+        )
+        req_blocks.append(block)
+        req_blocks[block_idx] = self._null_block
 
     def pop_blocks_for_free(self, request_id: str) -> list[KVCacheBlock]:
         if self.mamba_cache_mode == "align":

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -112,13 +112,14 @@ class SingleTypeKVCacheManager(ABC):
         # managers (full attention, mamba "align"); harmlessly empty elsewhere.
         self._partial_hit_reqs: dict[str, tuple[int, KVCacheBlock]] = {}
         self._pending_cow_copies: list[tuple[KVCacheBlock, KVCacheBlock]] = []
-        # Partial-tail offload hand-off for external KV connectors: when a
-        # producer registers its last-prompt-boundary partial tail and the
-        # durable boundary block is not on the append-only request block table
-        # (mamba "align" CoW target), record the request, group, block, and
-        # exact token boundary so a connector can offload it under the right
-        # hash. Populated only by mamba "align".
-        self._pending_partial_tail_offloads: list[
+        # Boundary-state offload hand-off for external KV connectors. A mamba
+        # "align" block table is not append-only (interior states are
+        # nulled/freed and speculative blocks relocate in place), so a
+        # connector cannot resolve its state blocks positionally. Record
+        # (request, group, block, exact token boundary) for each committed
+        # boundary state so a connector can offload the right block under the
+        # right hash. Populated only by mamba "align".
+        self._pending_boundary_state_offloads: list[
             tuple[str, int, KVCacheBlock, int]
         ] = []
 
@@ -385,19 +386,19 @@ class SingleTypeKVCacheManager(ABC):
         self._pending_cow_copies = []
         return pending_copies
 
-    def take_pending_partial_tail_offloads(
+    def take_pending_boundary_state_offloads(
         self,
     ) -> list[tuple[str, int, KVCacheBlock, int]]:
-        """Drain producer partial-tail hand-offs.
+        """Drain producer boundary-state hand-offs.
 
         Entries are ``(req_id, group_id, block, boundary_tokens)``.
 
-        Only mamba "align" populates this. The block lives off the request
-        block table, so the caller must pin it until the connector has read
-        it — nothing else keeps it alive once the CoW retention is released.
+        Only mamba "align" populates this. The blocks are not kept alive by
+        the request block table for the whole request, so a caller that reads
+        them asynchronously must pin them first.
         """
-        pending = self._pending_partial_tail_offloads
-        self._pending_partial_tail_offloads = []
+        pending = self._pending_boundary_state_offloads
+        self._pending_boundary_state_offloads = []
         return pending
 
     def _apply_cow(
@@ -1292,7 +1293,7 @@ class MambaManager(SingleTypeKVCacheManager):
             # Requests that registered their own last-prompt-boundary partial
             # tail (producers). On the next step's CoW the boundary state moves
             # into a private cow_block; we record that block for connector
-            # offload (see _pending_partial_tail_offloads).
+            # offload (see _pending_boundary_state_offloads).
             self._producer_partial_tail_reqs: dict[str, int] = {}
 
     @classmethod
@@ -1664,7 +1665,7 @@ class MambaManager(SingleTypeKVCacheManager):
                             # This CoW preserved a producer's own boundary
                             # state in cow_block; hand it to the connector for
                             # partial-tail offload once the copy has run.
-                            self._pending_partial_tail_offloads.append(
+                            self._pending_boundary_state_offloads.append(
                                 (
                                     request_id,
                                     self.kv_cache_group_id,
@@ -1691,11 +1692,14 @@ class MambaManager(SingleTypeKVCacheManager):
             self.last_state_block_idx.pop(request_id, None)
             self._num_checkpoint_blocks.pop(request_id, None)
             self._producer_partial_tail_reqs.pop(request_id, None)
-            # A hand-off whose request died in this same scheduling pass must
-            # not reach the connector: its unpin hook (free) has already run.
-            self._pending_partial_tail_offloads = [
+            # An offer is only guaranteed to hold committed bytes until the end
+            # of the pass that made it. This request's blocks are going back to
+            # the pool now, so drop its not-yet-offered hand-offs rather than
+            # let a connector claim a block another request may already have
+            # been handed.
+            self._pending_boundary_state_offloads = [
                 entry
-                for entry in self._pending_partial_tail_offloads
+                for entry in self._pending_boundary_state_offloads
                 if entry[0] != request_id
             ]
         return super().pop_blocks_for_free(request_id)
@@ -1722,9 +1726,9 @@ class MambaManager(SingleTypeKVCacheManager):
             if partial_hash is not None:
                 self.cached_blocks_this_step.add(partial_hash)
         if num_cached_blocks_after > num_cached_blocks_before:
-            for block in self.req_to_blocks[request.request_id][
-                num_cached_blocks_before:num_cached_blocks_after
-            ]:
+            blocks = self.req_to_blocks[request.request_id]
+            for idx in range(num_cached_blocks_before, num_cached_blocks_after):
+                block = blocks[idx]
                 # Skip null blocks (align-mode skipped states) and blocks that
                 # were not cached this step — with sparse retention
                 # (reachable_block_mask) the intermediate state snapshots carry
@@ -1732,6 +1736,18 @@ class MambaManager(SingleTypeKVCacheManager):
                 if block.is_null or block.block_hash is None:
                     continue
                 self.cached_blocks_this_step.add(block.block_hash)
+                if self.mamba_cache_mode == "align":
+                    # Offer every retained boundary with its exact block.
+                    # The connector filters against its save window, which may
+                    # extend past the original prompt during resumed prefill.
+                    self._pending_boundary_state_offloads.append(
+                        (
+                            request.request_id,
+                            self.kv_cache_group_id,
+                            block,
+                            (idx + 1) * self.block_size,
+                        )
+                    )
 
     def new_step_starts(self) -> None:
         self.cached_blocks_this_step.clear()

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -1626,13 +1626,12 @@ class MambaManager(SingleTypeKVCacheManager):
                     )
 
                 if blocks_allocated:
-                    # reuse previous speculative blocks in this step
+                    # Relocate exclusively owned speculative scratch blocks.
                     for block_idx in range(
                         prev_block_len - self.num_speculative_blocks, prev_block_len
                     ):
                         if block_idx < num_skipped_blocks:
-                            req_blocks.append(req_blocks[block_idx])
-                            req_blocks[block_idx] = self._null_block
+                            self._relocate_speculative_block(req_blocks, block_idx)
                         else:
                             break
                 num_new_blocks = num_required_blocks - len(req_blocks)
@@ -1685,6 +1684,17 @@ class MambaManager(SingleTypeKVCacheManager):
                 self._partial_hit_reqs.pop(request_id, None)
                 returned_blocks.extend(new_blocks)
                 return returned_blocks
+
+    def _relocate_speculative_block(
+        self, req_blocks: list[KVCacheBlock], block_idx: int
+    ) -> None:
+        block = req_blocks[block_idx]
+        assert self.block_pool.is_block_writable(block), (
+            "Speculative Mamba blocks must be exclusively owned and unhashed "
+            "before relocation"
+        )
+        req_blocks.append(block)
+        req_blocks[block_idx] = self._null_block
 
     def pop_blocks_for_free(self, request_id: str) -> list[KVCacheBlock]:
         if self.mamba_cache_mode == "align":


### PR DESCRIPTION
## Summary

Fix Mooncake Store persistence for Mamba `align` mode by saving the exact core-selected boundary-state blocks and keeping those physical blocks alive until every worker rank has finished the asynchronous store attempt.

This fixes a correctness bug that could persist null, stale/reassigned, or live speculative Mamba state under a valid prefix hash. A later external prefix hit could then restore poisoned recurrent state and produce garbled or runaway output.

## Root cause

Mooncake's normal save path resolved each group's source block positionally from a worker-side snapshot of the request's block IDs. That is valid for append-only attention block tables, but a Mamba `align` table is sparse and mutable:

- superseded state positions are replaced by the null block and their physical blocks are freed;
- speculative scratch blocks are relocated to different logical positions;
- the connector's block-ID mirror is append-only and does not observe those in-place changes.

Consequently, a positional Mamba save could interpret `NULL_BLOCK_ID` as a physical source, or read a block that had already been freed, reassigned, or was still speculative, while using the correct chained prefix hash as its key. Mooncake's `batch_is_exist` deduplication could then preserve the bad value and prevent a later correct save from replacing it.

The production symptom was exposed by the DSpark/EAGLE lookup path landing on an affected interior key. Without that path, a later valid CoW boundary key could win and mask the corruption.

## Design

- Core emits exact `(group_id, block_id, boundary_tokens)` entries for committed Mamba `align` boundary states, including the CoW target for a sub-block partial tail. The connector never reconstructs these source IDs positionally.
- Mooncake excludes Mamba groups from the normal positional `store_mask`; exact boundary handoffs are the only Mamba writer. The normal path also skips null or missing source IDs for every group as a defense-in-depth guard.
- The scheduler claims each accepted physical block with `BlockPool.touch()` before it can be recycled. Consumer-only roles are gated before claiming or queueing handoffs.
- Each claimed block receives a monotonic handoff ID. A one-ID/one-pin mapping makes reference release and the bounded in-flight capacity exact, even though a request-level batch ID could work while all entries in a request complete together.
- Workers report a cross-rank completion watermark. After seeing its first handoff, a rank reports watermark `0` while that handoff is pending rather than omitting metadata; this prevents aggregation from ignoring a lagging rank and releasing a block early. Dedup, successful upload, pressure drop, cancellation, and store failure are all terminal outcomes for lifetime purposes.
- The scheduler releases the connector-owned refs only through `BlockPool.free_blocks()` after the aggregated watermark says every rank is terminal. The configurable in-flight cap bounds pinned GPU blocks if acknowledgements stop; saves beyond the cap remain best-effort and are dropped.
- Resumed prefills use the tracked prefill/save boundary, not the request's original prompt length, so replayed generated tokens retain the same cross-group save coverage.
- Mamba speculative scratch relocation remains an in-table move, but now fails closed unless `BlockPool.is_block_writable()` confirms the block is non-null, exclusively owned (`ref_cnt == 1`), and unhashed. If shared or pinned speculative blocks become valid in the future, this path must use CoW instead of relocating them.

This implementation is intentionally limited to Mamba `align` mode. Mooncake Store's configuration validation rejects incompatible non-align/`all` Mamba layouts; this PR does not add `all`-mode support.

## Retention semantics

`VLLM_PREFIX_CACHE_RETENTION_INTERVAL` remains effective even though Mooncake's positional `store_mask` is false for Mamba:

1. Core `MambaManager.cache_blocks()` applies the retention policy first.
2. Only retained/materialized states receive a block hash.
3. Handoff emission skips null or unhashed blocks.
4. Mooncake stores the exact retained states from those handoffs.

Therefore dense default retention, sparse interval checkpoints, and replay-boundary behavior are preserved. External persistence is still best-effort: an eligible checkpoint may be absent if the handoff cap is reached or the store operation fails.

## Scope and overlap

This is not duplicate work:

- #50359 validates external lookup boundaries.
- #46896 and #46906 concern Mamba all-mode support and retention policy.
- #51362 independently adds the same defensive null/missing-block check to Mooncake's normal save loop. That check is included here, but this PR also removes unsafe positional Mamba saving and fixes exact source selection, asynchronous lifetime, retention-aware handoff, partial-tail handling, and speculative ownership. In that sense, this PR subsumes #51362's behavior rather than relying on it.

## Validation

Focused Mooncake Store and prefix-cache suites were run through the final design, including exact block-ID handoff, dense and sparse retention, partial tails, resumed prefills, more than two Mamba groups, null/missing sources, consumer skip-save behavior, cross-rank watermarking, bounded pins, failure paths, and exclusive speculative ownership.

```bash
.venv/bin/python -m pytest -q \
  tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py \
  tests/v1/kv_connector/unit/test_mooncake_store_connector.py \
  tests/v1/kv_connector/unit/test_mooncake_store_coordinator.py \
  tests/v1/kv_connector/unit/test_mooncake_store_scheduler.py \
  tests/v1/kv_connector/unit/test_mooncake_store_worker.py \
  tests/v1/kv_connector/unit/test_mooncake_store_hma_e2e.py
```

Result: 183 passed. Additional focused reruns after the watermark, save-gate, and ownership-invariant changes passed (195 tests), and a broader Mooncake Store + prefix-cache run in the k3-debug container on a GB300 worker passed (219 tests). Ruff and `git diff --check` also passed.

Serving/model evaluation on `k3-pd-mooncake aa-lcr`:

- post-fix: 0/200 garbled responses;
- `llm_judge`: approximately 0.77/0.76;
- external prefix hit rate: approximately 91–98%;
- pre-fix baseline: garbled/runaway outputs, with `llm_judge` approximately 0.76/0.78.

No model kernels or numerical computation were changed.

AI assistance was used. The human submitter reviewed the changes and is responsible for understanding, testing, and defending the final submission.