### PR TITLE
[Bugfix][NIXL] Allow heterogeneous non-MLA KV region sizes

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_worker.py
@@ -1170,9 +1170,22 @@ class NixlBaseConnectorWorker:
             if not is_mla_region:
                 if tensor_size_bytes is None:
                     tensor_size_bytes = curr_tensor_size_bytes
-                assert tensor_size_bytes == curr_tensor_size_bytes, (
-                    "All non-MLA kv cache tensors must have the same size"
-                )
+                elif tensor_size_bytes != curr_tensor_size_bytes:
+                    # Hybrid models can have legitimately heterogeneous
+                    # non-MLA regions (e.g. MiniMax M3: lightning-attention
+                    # KV, full-attention KV and the sparse-indexer cache).
+                    # Registration is already per-region (caches_data uses
+                    # curr_tensor_size_bytes, block_len_per_layer is
+                    # per-layer) and the NIXL compatibility hash still
+                    # guards genuine P/D mismatches.
+                    logger.warning_once(
+                        "Heterogeneous non-MLA kv cache tensor sizes: "
+                        "%s vs %s (layer %s) - proceeding with per-region "
+                        "registration.",
+                        tensor_size_bytes,
+                        curr_tensor_size_bytes,
+                        layer_name,
+                    )
 
             # When there's a mismatch between kbs<>bs, we rely on HMA to ensure
             # caches are either [NB, PS] or [NB*r, PS/r] where r is bs/kbs.


### PR DESCRIPTION
## Purpose

`register_kv_caches()` asserts that all non-MLA KV cache tensors have the same size, but hybrid models violate that legitimately: MiniMax M3 registers lightning-attention KV, full-attention KV and the sparse-indexer cache as separate non-MLA regions whose sizes differ by more than an order of magnitude, so every worker dies during KV cache registration under disaggregated serving. The equality is not required — registration is already per-region (`caches_data` uses `curr_tensor_size_bytes`, `block_len_per_layer` is per-layer), prefill and decode run identical builds so layouts stay symmetric, and the NIXL compatibility hash still rejects genuine P/D mismatches — so this downgrades the assert to `warning_once`.

## Test Plan

Serve MiniMax-M3-NVFP4 disaggregated on B200 (1 prefill TP2 + 1 decode DP2+EP, NixlConnector over RDMA) and issue a chat completion request.

## Test Result

Before, both workers aborted in `register_kv_caches` with `AssertionError: All non-MLA kv cache tensors must have the same size`. After, they start normally, KV transfer across the P/D boundary works, and the warning keeps the size difference visible:

```
WARNING base_worker.py Heterogeneous non-MLA kv cache tensor sizes:
        290979840 vs 4655677440 (layer model.layers.60.self_attn.attn)
```
