### PR TITLE
[Bugfix][Frontend] Lazy-import model_hosting_container_standards to prevent log suppression

### DIFF
--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -31,7 +31,6 @@ from vllm.entrypoints.openai.cli_args import make_arg_parser, validate_parsed_se
 from vllm.entrypoints.openai.models.protocol import BaseModelPath
 from vllm.entrypoints.openai.models.serving import OpenAIServingModels
 from vllm.entrypoints.serve.elastic_ep.middleware import ScalingMiddleware
-from vllm.entrypoints.serve.sagemaker.api_router import sagemaker_standards_bootstrap
 from vllm.entrypoints.serve.tokenize.serving import ServingTokenization
 from vllm.entrypoints.serve.utils.api_utils import (
     cli_env_setup,
@@ -347,6 +346,10 @@ def build_app(
             raise ValueError(
                 f"Invalid middleware {middleware}. Must be a function or a class."
             )
+
+    from vllm.entrypoints.serve.sagemaker.api_router import (
+        sagemaker_standards_bootstrap,
+    )
 
     app = sagemaker_standards_bootstrap(app)
     return app

--- a/vllm/entrypoints/serve/lora/api_router.py
+++ b/vllm/entrypoints/serve/lora/api_router.py
@@ -1,8 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import logging
 
-
-import model_hosting_container_standards.sagemaker as sagemaker_standards
 from fastapi import APIRouter, Depends, FastAPI, Request
 from fastapi.responses import JSONResponse, Response
 
@@ -27,6 +26,17 @@ def attach_router(app: FastAPI):
     if not envs.VLLM_ALLOW_RUNTIME_LORA_UPDATING:
         """If LoRA dynamic loading & unloading is not enabled, do nothing."""
         return
+
+    snapshot = [
+        (h, h.level)
+        for logger in (logging.getLogger(), logging.getLogger("vllm"))
+        for h in logger.handlers
+    ]
+    import model_hosting_container_standards.sagemaker as sagemaker_standards
+
+    for handler, level in snapshot:
+        handler.setLevel(level)
+
     logger.warning(
         "LoRA dynamic loading & unloading is enabled in the API server. "
         "This should ONLY be used for local development!"

--- a/vllm/entrypoints/serve/sagemaker/api_router.py
+++ b/vllm/entrypoints/serve/sagemaker/api_router.py
@@ -1,11 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import json
+import logging
 from collections.abc import Awaitable, Callable
 from http import HTTPStatus
 from typing import Any
 
-import model_hosting_container_standards.sagemaker as sagemaker_standards
 import pydantic
 from fastapi import APIRouter, Depends, FastAPI, HTTPException, Request
 from fastapi.responses import JSONResponse, Response
@@ -27,11 +27,39 @@ GetHandlerFn = Callable[[Request], BaseServing | None]
 EndpointFn = Callable[[RequestType, Request], Awaitable[Any]]
 
 
+def _snapshot_handler_levels() -> list[tuple[logging.Handler, int]]:
+    """Snapshot handler levels for loggers that may be affected by third-party
+    logging configuration side effects (e.g. model_hosting_container_standards
+    calling configure_root_logger() at import time)."""
+    loggers = [logging.getLogger(), logging.getLogger("vllm")]
+    seen: set[int] = set()
+    snapshot: list[tuple[logging.Handler, int]] = []
+    for logger in loggers:
+        for handler in logger.handlers:
+            if id(handler) not in seen:
+                seen.add(id(handler))
+                snapshot.append((handler, handler.level))
+    return snapshot
+
+
+def _restore_handler_levels(
+    snapshot: list[tuple[logging.Handler, int]],
+) -> None:
+    """Restore handler levels from a snapshot."""
+    for handler, level in snapshot:
+        handler.setLevel(level)
+
+
 def attach_router(
     app: FastAPI,
     supported_tasks: tuple["SupportedTask", ...],
     model_config: ModelConfig | None = None,
 ):
+    snapshot = _snapshot_handler_levels()
+    import model_hosting_container_standards.sagemaker as sagemaker_standards
+
+    _restore_handler_levels(snapshot)
+
     router = APIRouter()
 
     # NOTE: Construct the TypeAdapters only once
@@ -99,4 +127,9 @@ def attach_router(
 
 
 def sagemaker_standards_bootstrap(app: FastAPI) -> FastAPI:
+    snapshot = _snapshot_handler_levels()
+    import model_hosting_container_standards.sagemaker as sagemaker_standards
+
+    _restore_handler_levels(snapshot)
+
     return sagemaker_standards.bootstrap(app)


### PR DESCRIPTION
## Purpose

Fix [Bug #53655 ]: model_hosting_container_standards changes a shared root/vllm handler to ERROR and suppresses vLLM startup logs

importing `vllm.entrypoints.openai.api_server` triggers a
side effect where `model_hosting_container_standards.logging_config`
calls `configure_root_logger()` at module level, setting all root
handler levels to `ERROR`. When `VLLM_LOGGING_CONFIG_PATH` shares the
same handler object between root and `vllm` loggers, this silences
vLLM startup INFO/WARNING logs (e.g. chunked prefill diagnostics).

The fix defers the `sagemaker_standards_bootstrap` import from
module-level into `build_app()` where it is actually called, so the
side effect is avoided unless SageMaker integration is actively used.

## Test Plan

```bash
VLLM_LOGGING_CONFIG_PATH=/tmp/vllm-logging.json \
python - <<'PY'
import logging
from vllm.logger import init_logger
init_logger("vllm.repro")
vllm_logger = logging.getLogger("vllm")
root_logger = logging.getLogger()

import vllm.entrypoints.openai.api_server  # noqa: F401

# Both handlers should still be INFO (20), not ERROR (40)
assert vllm_logger.handlers[0].level == 20, \
    f"vllm handler level changed to {vllm_logger.handlers[0].level}"
assert root_logger.handlers[0].level == 20, \
    f"root handler level changed to {root_logger.handlers[0].level}"
print("PASS: handler levels unchanged")
PY
```

Test Result

Before: vllm handlers: [<StreamHandler <stdout> (ERROR)>]
After:  vllm handlers: [<StreamHandler <stdout> (INFO)>]

---<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating supported_models.md and examples for a new model.
</details>

