### PR TITLE
[Bugfix] Fix DeepSeek V4 mHC broadcast buffer for dummy load

### DIFF
--- a/tests/kernels/test_mhc_kernels.py
+++ b/tests/kernels/test_mhc_kernels.py
@@ -1,7 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from types import SimpleNamespace
+
 import pytest
 import torch
+import torch.nn as nn
 
 import vllm.model_executor.kernels.mhc  # noqa: F401
 from vllm.model_executor.kernels.mhc.tilelang import (
@@ -9,6 +12,10 @@ from vllm.model_executor.kernels.mhc.tilelang import (
     _torch_hc_prenorm_gemm,
 )
 from vllm.model_executor.layers.mhc import HAS_TILELANG_MHC
+from vllm.models.deepseek_v4.nvidia.model import (
+    DeepseekV4DecoderLayer,
+    DeepseekV4Model,
+)
 from vllm.platforms import current_platform
 from vllm.utils.torch_utils import set_random_seed
 
@@ -355,3 +362,57 @@ def test_hc_head_tilelang(num_tokens, hidden_size, hc_mult):
 
     out_ref = hc_head_ref(residual, fn, hc_scale, hc_base, rms_eps, hc_eps)
     torch.testing.assert_close(out, out_ref, atol=5e-2, rtol=1e-2)
+
+
+def _make_mhc_decoder_layer(hc_mult: int, hidden_size: int) -> DeepseekV4DecoderLayer:
+    layer = DeepseekV4DecoderLayer.__new__(DeepseekV4DecoderLayer)
+    nn.Module.__init__(layer)
+    layer.hc_mult = hc_mult
+    layer.hidden_size = hidden_size
+    mix_hc = (2 + hc_mult) * hc_mult
+    layer.hc_attn_fn = nn.Parameter(
+        torch.randn(mix_hc, hc_mult * hidden_size, dtype=torch.float32),
+        requires_grad=False,
+    )
+    layer.hc_attn_fn_broadcast = None
+    return layer
+
+
+def _patch_first_rank_pp_group(monkeypatch):
+    monkeypatch.setattr(
+        "vllm.models.deepseek_v4.nvidia.model.get_pp_group",
+        lambda: SimpleNamespace(is_first_rank=True),
+    )
+
+
+def test_deepseek_v4_mhc_broadcast_finalize_sums_hc_streams(monkeypatch):
+    """First finalize (run at __init__ so dummy load has a valid buffer)
+    allocates hc_attn_fn_broadcast as hc_attn_fn summed over hc streams."""
+    _patch_first_rank_pp_group(monkeypatch)
+    layer = _make_mhc_decoder_layer(hc_mult=2, hidden_size=8)
+    model = SimpleNamespace(start_layer=0, end_layer=1, layers=[layer])
+
+    DeepseekV4Model.finalize_mhc_broadcast_weights(model)
+
+    assert layer.hc_attn_fn_broadcast is not None
+    expected = layer.hc_attn_fn.detach().view(-1, 2, 8).sum(dim=1)
+    assert torch.equal(layer.hc_attn_fn_broadcast, expected)
+
+
+def test_deepseek_v4_mhc_broadcast_refit_refreshes_in_place(monkeypatch):
+    """Re-finalizing after load_weights (e.g. dummy init then refit) must
+    copy into the existing broadcast tensor so its address stays stable for
+    captured CUDA graphs, while picking up the new hc_attn_fn values."""
+    _patch_first_rank_pp_group(monkeypatch)
+    layer = _make_mhc_decoder_layer(hc_mult=2, hidden_size=8)
+    model = SimpleNamespace(start_layer=0, end_layer=1, layers=[layer])
+
+    DeepseekV4Model.finalize_mhc_broadcast_weights(model)
+    buffer = layer.hc_attn_fn_broadcast
+
+    layer.hc_attn_fn.add_(1.0)
+    DeepseekV4Model.finalize_mhc_broadcast_weights(model)
+
+    assert layer.hc_attn_fn_broadcast is buffer
+    expected = layer.hc_attn_fn.detach().view(-1, 2, 8).sum(dim=1)
+    assert torch.equal(layer.hc_attn_fn_broadcast, expected)

--- a/tests/models/test_deepseek_v4_mega_moe.py
+++ b/tests/models/test_deepseek_v4_mega_moe.py
@@ -9,10 +9,13 @@ import torch
 from vllm.model_executor.layers.fused_moe.routed_experts_capturer import (
     bind_routed_experts_capturer,
 )
+from vllm.models.deepseek_v4.nvidia.dspark import DSparkDeepseekV4ForCausalLM
 from vllm.models.deepseek_v4.nvidia.model import (
+    DeepseekV4ForCausalLM,
     DeepseekV4MegaMoEExperts,
     make_deepseek_v4_expert_params_mapping,
 )
+from vllm.models.deepseek_v4.nvidia.mtp import DeepSeekV4MTP
 from vllm.models.deepseek_v4.nvidia.ops.prepare_megamoe import prepare_megamoe_inputs
 from vllm.platforms import current_platform
 
@@ -241,6 +244,37 @@ def test_deepseek_v4_mega_moe_fused_input_staging_is_bitwise_exact():
         fused_topk_weights.view(torch.uint8),
         ref_topk_weights.view(torch.uint8),
     )
+
+
+def test_deepseek_v4_pwal_hook_finalizes_mega_moe_and_mhc_broadcast():
+    """The loader invokes the model-level PWAL hook for every load format,
+    so it must finalize megamoe + mhc broadcast weights to cover dummy
+    load, which skips load_weights()."""
+    calls = []
+    stub = SimpleNamespace(
+        model=SimpleNamespace(
+            finalize_mega_moe_weights=lambda: calls.append("mega_moe"),
+            finalize_mhc_broadcast_weights=lambda: calls.append("mhc"),
+        )
+    )
+
+    DeepseekV4ForCausalLM.process_weights_after_loading(stub)
+
+    assert calls == ["mega_moe", "mhc"]
+
+
+def test_deepseek_v4_drafter_pwal_hooks_finalize_mega_moe():
+    """MTP/DSpark drafters load as their own top-level models, so each needs
+    its own PWAL hook now that the megamoe forward no longer finalizes
+    weights lazily on first use."""
+    calls = []
+    mtp = SimpleNamespace(finalize_mega_moe_weights=lambda: calls.append("mtp"))
+    DeepSeekV4MTP.process_weights_after_loading(mtp)
+
+    dspark = SimpleNamespace(_finalize_moe=lambda: calls.append("dspark"))
+    DSparkDeepseekV4ForCausalLM.process_weights_after_loading(dspark)
+
+    assert calls == ["mtp", "dspark"]
 
 
 @pytest.mark.skipif(

--- a/tests/models/test_deepseek_v4_mega_moe.py
+++ b/tests/models/test_deepseek_v4_mega_moe.py
@@ -247,9 +247,9 @@ def test_deepseek_v4_mega_moe_fused_input_staging_is_bitwise_exact():
 
 
 def test_deepseek_v4_pwal_hook_finalizes_mega_moe_and_mhc_broadcast():
-    """The loader invokes the model-level PWAL hook for every load format,
-    so it must finalize megamoe + mhc broadcast weights to cover dummy
-    load, which skips load_weights()."""
+    """The PWAL hook is the sole finalize point: load_weights() no longer
+    finalizes, and the loader invokes this hook for every load format
+    (weight sync runs it via the loader's PWAL utility)."""
     calls = []
     stub = SimpleNamespace(
         model=SimpleNamespace(
@@ -265,8 +265,8 @@ def test_deepseek_v4_pwal_hook_finalizes_mega_moe_and_mhc_broadcast():
 
 def test_deepseek_v4_drafter_pwal_hooks_finalize_mega_moe():
     """MTP/DSpark drafters load as their own top-level models, so each needs
-    its own PWAL hook now that the megamoe forward no longer finalizes
-    weights lazily on first use."""
+    its own PWAL hook: neither their load_weights() nor the megamoe forward
+    finalizes weights anymore."""
     calls = []
     mtp = SimpleNamespace(finalize_mega_moe_weights=lambda: calls.append("mtp"))
     DeepSeekV4MTP.process_weights_after_loading(mtp)

--- a/tests/models/test_deepseek_v4_mega_moe.py
+++ b/tests/models/test_deepseek_v4_mega_moe.py
@@ -247,9 +247,9 @@ def test_deepseek_v4_mega_moe_fused_input_staging_is_bitwise_exact():
 
 
 def test_deepseek_v4_pwal_hook_finalizes_mega_moe_and_mhc_broadcast():
-    """The PWAL hook is the sole finalize point: load_weights() no longer
-    finalizes, and the loader invokes this hook for every load format
-    (weight sync runs it via the loader's PWAL utility)."""
+    """The loader invokes the model-level PWAL hook for every load format,
+    so it must finalize megamoe + mhc broadcast weights to cover dummy
+    load, which skips load_weights()."""
     calls = []
     stub = SimpleNamespace(
         model=SimpleNamespace(
@@ -265,8 +265,8 @@ def test_deepseek_v4_pwal_hook_finalizes_mega_moe_and_mhc_broadcast():
 
 def test_deepseek_v4_drafter_pwal_hooks_finalize_mega_moe():
     """MTP/DSpark drafters load as their own top-level models, so each needs
-    its own PWAL hook: neither their load_weights() nor the megamoe forward
-    finalizes weights anymore."""
+    its own PWAL hook now that the megamoe forward no longer finalizes
+    weights lazily on first use."""
     calls = []
     mtp = SimpleNamespace(finalize_mega_moe_weights=lambda: calls.append("mtp"))
     DeepSeekV4MTP.process_weights_after_loading(mtp)

--- a/vllm/models/deepseek_v4/nvidia/dspark.py
+++ b/vllm/models/deepseek_v4/nvidia/dspark.py
@@ -506,6 +506,7 @@ class DSparkDeepseekV4ForCausalLM(nn.Module):
 
         if self.model.confidence_head is not None and not loaded_confidence_head:
             self.model.confidence_head = None
+        self.process_weights_after_loading()
         logger.info_once("DSpark draft model loaded: %d params", len(loaded_params))
         return loaded_params
 

--- a/vllm/models/deepseek_v4/nvidia/dspark.py
+++ b/vllm/models/deepseek_v4/nvidia/dspark.py
@@ -504,7 +504,6 @@ class DSparkDeepseekV4ForCausalLM(nn.Module):
                 weight_loader(param, loaded_weight)
                 loaded_params.add(name)
 
-        self._finalize_moe()
         if self.model.confidence_head is not None and not loaded_confidence_head:
             self.model.confidence_head = None
         logger.info_once("DSpark draft model loaded: %d params", len(loaded_params))
@@ -515,7 +514,6 @@ class DSparkDeepseekV4ForCausalLM(nn.Module):
             layer.ffn.finalize_mega_moe_weights()
 
     def process_weights_after_loading(self) -> None:
-        # Finalize megamoe weights for dummy load, which skips load_weights().
         self._finalize_moe()
 
     def _remap_dspark_name(self, name: str) -> str | None:

--- a/vllm/models/deepseek_v4/nvidia/dspark.py
+++ b/vllm/models/deepseek_v4/nvidia/dspark.py
@@ -514,6 +514,10 @@ class DSparkDeepseekV4ForCausalLM(nn.Module):
         for layer in self.model.layers:
             layer.ffn.finalize_mega_moe_weights()
 
+    def process_weights_after_loading(self) -> None:
+        # Finalize megamoe weights for dummy load, which skips load_weights().
+        self._finalize_moe()
+
     def _remap_dspark_name(self, name: str) -> str | None:
         """Map a checkpoint ``mtp.{i}.*`` name to this model's parameter path.
 

--- a/vllm/models/deepseek_v4/nvidia/model.py
+++ b/vllm/models/deepseek_v4/nvidia/model.py
@@ -1105,6 +1105,9 @@ class DeepseekV4Model(nn.Module, EagleModelMixin):
         else:
             self._mtp_hidden_buffer = None
 
+        # Populate hc_attn_fn_broadcast for dummy load (load_weights is skipped).
+        self.finalize_mhc_broadcast_weights()
+
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.embed_tokens(input_ids)
 
@@ -1373,11 +1376,15 @@ class DeepseekV4Model(nn.Module, EagleModelMixin):
             return
         layer = self.layers[self.start_layer]
         if isinstance(layer, DeepseekV4DecoderLayer):
-            layer.hc_attn_fn_broadcast = (
+            broadcast = (
                 layer.hc_attn_fn.detach()
                 .view(-1, layer.hc_mult, layer.hidden_size)
                 .sum(dim=1)
             )
+            if layer.hc_attn_fn_broadcast is None:
+                layer.hc_attn_fn_broadcast = broadcast
+            else:
+                layer.hc_attn_fn_broadcast.copy_(broadcast)
 
 
 def _make_deepseek_v4_weights_mapper(expert_dtype: str) -> WeightsMapper:

--- a/vllm/models/deepseek_v4/nvidia/model.py
+++ b/vllm/models/deepseek_v4/nvidia/model.py
@@ -1538,14 +1538,9 @@ class DeepseekV4ForCausalLM(
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
         loader = AutoWeightsLoader(self, skip_substrs=["mtp."])
-        loaded_params = loader.load_weights(weights, mapper=self.hf_to_vllm_mapper)
-        self.model.finalize_mega_moe_weights()
-        self.model.finalize_mhc_broadcast_weights()
-        return loaded_params
+        return loader.load_weights(weights, mapper=self.hf_to_vllm_mapper)
 
     def process_weights_after_loading(self) -> None:
-        # Finalize megamoe + mhc broadcast weights for dummy load, which
-        # skips load_weights().
         self.model.finalize_mega_moe_weights()
         self.model.finalize_mhc_broadcast_weights()
 

--- a/vllm/models/deepseek_v4/nvidia/model.py
+++ b/vllm/models/deepseek_v4/nvidia/model.py
@@ -504,10 +504,6 @@ class DeepseekV4MegaMoEExperts(nn.Module):
             is_padding=is_padding,
         )
 
-        # This method must have been already called during the weight loading phase.
-        # We call it again here to cover the dummy weight loading case.
-        self.finalize_weights()
-
         assert self._transformed_l1_weights is not None
         assert self._transformed_l2_weights is not None
         deep_gemm.fp8_fp4_mega_moe(
@@ -1546,6 +1542,12 @@ class DeepseekV4ForCausalLM(
         self.model.finalize_mega_moe_weights()
         self.model.finalize_mhc_broadcast_weights()
         return loaded_params
+
+    def process_weights_after_loading(self) -> None:
+        # Finalize megamoe + mhc broadcast weights for dummy load, which
+        # skips load_weights().
+        self.model.finalize_mega_moe_weights()
+        self.model.finalize_mhc_broadcast_weights()
 
     def get_expert_mapping(self) -> list[tuple[str, str, int, str]]:
         return self.model.get_expert_mapping()

--- a/vllm/models/deepseek_v4/nvidia/model.py
+++ b/vllm/models/deepseek_v4/nvidia/model.py
@@ -1538,7 +1538,9 @@ class DeepseekV4ForCausalLM(
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
         loader = AutoWeightsLoader(self, skip_substrs=["mtp."])
-        return loader.load_weights(weights, mapper=self.hf_to_vllm_mapper)
+        loaded_params = loader.load_weights(weights, mapper=self.hf_to_vllm_mapper)
+        self.process_weights_after_loading()
+        return loaded_params
 
     def process_weights_after_loading(self) -> None:
         self.model.finalize_mega_moe_weights()

--- a/vllm/models/deepseek_v4/nvidia/mtp.py
+++ b/vllm/models/deepseek_v4/nvidia/mtp.py
@@ -502,7 +502,6 @@ class DeepSeekV4MTP(nn.Module):
                     f"Use a checkpoint that includes MTP layer weights, "
                     f"or disable speculative decoding."
                 )
-        self.finalize_mega_moe_weights()
         logger.info_once("MTP draft model loaded: %d params", len(loaded_params))
         return loaded_params
 
@@ -511,7 +510,6 @@ class DeepSeekV4MTP(nn.Module):
             layer.mtp_block.ffn.finalize_mega_moe_weights()
 
     def process_weights_after_loading(self) -> None:
-        # Finalize megamoe weights for dummy load, which skips load_weights().
         self.finalize_mega_moe_weights()
 
     def _rewrite_spec_layer_name(self, spec_layer: int, name: str) -> str:

--- a/vllm/models/deepseek_v4/nvidia/mtp.py
+++ b/vllm/models/deepseek_v4/nvidia/mtp.py
@@ -510,6 +510,10 @@ class DeepSeekV4MTP(nn.Module):
         for layer in self.model.layers.values():
             layer.mtp_block.ffn.finalize_mega_moe_weights()
 
+    def process_weights_after_loading(self) -> None:
+        # Finalize megamoe weights for dummy load, which skips load_weights().
+        self.finalize_mega_moe_weights()
+
     def _rewrite_spec_layer_name(self, spec_layer: int, name: str) -> str:
         """
         Rewrite the weight name to match the format of the original model.

--- a/vllm/models/deepseek_v4/nvidia/mtp.py
+++ b/vllm/models/deepseek_v4/nvidia/mtp.py
@@ -502,6 +502,7 @@ class DeepSeekV4MTP(nn.Module):
                     f"Use a checkpoint that includes MTP layer weights, "
                     f"or disable speculative decoding."
                 )
+        self.process_weights_after_loading()
         logger.info_once("MTP draft model loaded: %d params", len(loaded_params))
         return loaded_params
 


### PR DESCRIPTION
## Purpose

With `--load-format dummy`, `load_weights()` is skipped, so
`hc_attn_fn_broadcast` stays `None` and the first decoder layer's 2-D
broadcast path fails at `assert self.hc_attn_fn_broadcast is not None`.

Fix: define a model-level `process_weights_after_loading()` on
`DeepseekV4ForCausalLM`. The loader invokes this hook for every load
format — including dummy load — so the broadcast buffer is always
populated before the first forward.

The hook also finalizes MegaMoE weights, replacing
the lazy `finalize_weights()` call in the MegaMoE forward that existed only
to cover dummy load. This takes the branch out of the forward hot path and
moves the heavy weight repack (which also frees the original params) out of
the first forward, so profiling sees steady-state memory. The EPLB-side
guard call in `get_expert_mapping` is unchanged.

Because the MTP and DSpark drafters load as their own top-level models
(registry → `get_model` → loader → PWAL), each gets a matching hook —
the removed forward-time call was their only finalize path under dummy
load.

The companion fix for weight refit (in-place `copy_()` refresh so the
buffer address stays stable for captured CUDA graphs) is split into a
separate PR.

## Test Plan

## Purpose

With `--load-format dummy`, `load_weights()` is skipped, so
`hc_attn_fn_broadcast` stays `None` and the first decoder layer's 2-D
broadcast path fails at `assert self.hc_attn_fn_broadcast is not None`.

Fix: define a model-level `process_weights_after_loading()` on
`DeepseekV4ForCausalLM`. The loader invokes this hook for every load
format — including dummy load — so the broadcast buffer is always
populated before the first forward.

Per review (@aoshen02), the hook also finalizes MegaMoE weights, replacing
the lazy `finalize_weights()` call in the MegaMoE forward that existed only
to cover dummy load. This takes the branch out of the forward hot path and
moves the heavy weight repack (which also frees the original params) out of
the first forward, so profiling sees steady-state memory. The EPLB-side
guard call in `get_expert_mapping` is unchanged.

Because the MTP and DSpark drafters load as their own top-level models
(registry → `get_model` → loader → PWAL), each gets a matching hook —
the removed forward-time call was their only finalize path under dummy
load.

The companion fix for weight refit (in-place `copy_()` refresh so the
buffer address stays stable for captured CUDA graphs) is split into a
separate PR.

## Not a duplicate

Searched open PRs for this area: #50645 guards the broadcast kernel on
DeepGEMM support, #49707 fixes mHC warmup coverage (consumes the buffer,
doesn't populate it), #47807 streamlines warmup on the kernel side. None
touch load-time weight finalization or MegaMoE finalize placement.

## Test Plan

Two unit tests added to `tests/models/test_deepseek_v4_mega_moe.py`:
- `test_deepseek_v4_pwal_hook_finalizes_mega_moe_and_mhc_broadcast` — the
  target model's hook runs both finalizes.
- `test_deepseek_v4_drafter_pwal_hooks_finalize_mega_moe` — the MTP and
  DSpark hooks delegate to their MegaMoE finalize.

End to end tests on verl side with DSV4 training

## Test Result

- New tests: **2 passed**; full file: **9 passed** (GPU).
- Mutation check: with the three model files reverted to base, both new
  tests fail — they pin the hooks, not incidentals.
- `ruff check` + `ruff format --check` clean.

End to end tests on verl side with DSV4 training returned to normal training inference mismatch.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [X] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [X] The test plan, such as providing test command.
- [X] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

