### PR TITLE
[Bugfix][GDN] Fall back to recurrent prefill for float32 inputs

### DIFF
--- a/tests/kernels/test_fused_sigmoid_gating_delta_rule.py
+++ b/tests/kernels/test_fused_sigmoid_gating_delta_rule.py
@@ -5,6 +5,9 @@ import pytest
 import torch
 import torch.nn.functional as F
 
+from vllm.model_executor.layers.mamba.gdn.qwen_gdn_linear_attn import (
+    ChunkGatedDeltaRule,
+)
 from vllm.platforms import current_platform
 from vllm.third_party.flash_linear_attention.ops import (
     fused_recurrent_gated_delta_rule,
@@ -13,6 +16,65 @@ from vllm.third_party.flash_linear_attention.ops import (
 from vllm.utils.torch_utils import set_random_seed
 
 DEVICE = current_platform.device_type
+
+
+@pytest.mark.parametrize(
+    "forward_method", ["forward_cuda", "forward_native", "forward_cutedsl"]
+)
+def test_float32_gdn_prefill_uses_recurrent_fallback(forward_method: str) -> None:
+    torch.set_default_device(DEVICE)
+    set_random_seed(0)
+
+    cu_seqlens = torch.tensor([0, 5, 8], dtype=torch.int32)
+    num_tokens = int(cu_seqlens[-1].item())
+    q = torch.randn(1, num_tokens, 2, 16, dtype=torch.float32)
+    k = torch.randn_like(q)
+    v = torch.randn(1, num_tokens, 4, 16, dtype=torch.float32)
+    g = torch.randn(1, num_tokens, 4, dtype=torch.float32)
+    beta = torch.sigmoid(torch.randn_like(g))
+    initial_state = torch.randn(2, 4, 16, 16, dtype=torch.float32)
+
+    expected_output = torch.empty_like(v)
+    expected_state = torch.empty_like(initial_state)
+    qk_repeat = v.shape[2] // q.shape[2]
+    scale = q.shape[-1] ** -0.5
+    for seq_idx in range(2):
+        start = int(cu_seqlens[seq_idx].item())
+        end = int(cu_seqlens[seq_idx + 1].item())
+        state = initial_state[seq_idx].clone()
+        for token_idx in range(start, end):
+            q_t = q[0, token_idx].repeat_interleave(qk_repeat, dim=0)
+            k_t = k[0, token_idx].repeat_interleave(qk_repeat, dim=0)
+            state = state * g[0, token_idx].exp()[:, None, None]
+            state_value = (state * k_t[:, None, :]).sum(dim=-1)
+            delta = (v[0, token_idx] - state_value) * beta[0, token_idx, :, None]
+            state = state + delta[:, :, None] * k_t[:, None, :]
+            expected_output[0, token_idx] = (state * (q_t * scale)[:, None, :]).sum(
+                dim=-1
+            )
+        expected_state[seq_idx] = state
+
+    layer = object.__new__(ChunkGatedDeltaRule)
+    torch.nn.Module.__init__(layer)
+    core_attn_out = torch.empty_like(v.squeeze(0))
+    output, final_state = getattr(layer, forward_method)(
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        beta=beta,
+        initial_state=initial_state,
+        output_final_state=True,
+        cu_seqlens=cu_seqlens,
+        use_qk_l2norm_in_kernel=False,
+        core_attn_out=core_attn_out,
+    )
+
+    torch.testing.assert_close(output, expected_output, atol=1e-5, rtol=1e-5)
+    torch.testing.assert_close(final_state, expected_state, atol=1e-5, rtol=1e-5)
+    torch.testing.assert_close(
+        core_attn_out, expected_output.squeeze(0), atol=1e-5, rtol=1e-5
+    )
 
 
 @pytest.mark.parametrize("tp_size", [1])

--- a/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
@@ -50,6 +50,7 @@ from vllm.third_party.flash_linear_attention.ops import (
 )
 from vllm.third_party.flash_linear_attention.ops import (
     fused_post_conv_prep,
+    fused_recurrent_gated_delta_rule,
     fused_recurrent_gated_delta_rule_packed_decode,
     fused_sigmoid_gating_delta_rule_update,
 )
@@ -212,6 +213,55 @@ def fi_chunk_gated_delta_rule(
         return result.unsqueeze(0), None
 
 
+def _recurrent_gdn_prefill(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    initial_state: torch.Tensor,
+    output_final_state: bool,
+    cu_seqlens: torch.Tensor | None = None,
+    use_qk_l2norm_in_kernel: bool = True,
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    """Run GDN prefill with the recurrent kernel.
+
+    The in-place kernel stores a state after every token. Repeating each pool
+    index across a row makes those stores update one state slot per sequence.
+    """
+    num_sequences = q.shape[0] if cu_seqlens is None else cu_seqlens.shape[0] - 1
+    if initial_state.shape[0] != num_sequences:
+        raise ValueError(
+            f"Expected {num_sequences} initial states, got {initial_state.shape[0]}."
+        )
+    state_pool = torch.cat((torch.empty_like(initial_state[:1]), initial_state), dim=0)
+    state_indices = (
+        torch.arange(
+            1,
+            num_sequences + 1,
+            dtype=torch.int32,
+            device=initial_state.device,
+        )
+        .unsqueeze(1)
+        .expand(-1, q.shape[1])
+        .contiguous()
+    )
+    output, state_pool = fused_recurrent_gated_delta_rule(
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        beta=beta,
+        initial_state=state_pool,
+        inplace_final_state=True,
+        cu_seqlens=cu_seqlens,
+        ssm_state_indices=state_indices,
+        use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
+    )
+    final_state = state_pool[1:] if output_final_state else None
+    return output, final_state
+
+
 @CustomOp.register("chunk_gated_delta_rule")
 class ChunkGatedDeltaRule(CustomOp):
     def __init__(self) -> None:
@@ -235,6 +285,42 @@ class ChunkGatedDeltaRule(CustomOp):
         else:
             self._forward_method = self.forward_native
 
+    def _forward_float32(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        g: torch.Tensor,
+        beta: torch.Tensor,
+        initial_state: torch.Tensor,
+        output_final_state: bool,
+        cu_seqlens: torch.Tensor | None,
+        use_qk_l2norm_in_kernel: bool,
+        core_attn_out: torch.Tensor | None,
+    ) -> tuple[torch.Tensor, torch.Tensor | None] | None:
+        if q.dtype != torch.float32:
+            return None
+
+        logger.warning_once(
+            "Chunked GDN prefill kernels do not support torch.float32. "
+            "Falling back to the slower recurrent GDN prefill kernel."
+        )
+        output, final_state = _recurrent_gdn_prefill(
+            q=q,
+            k=k,
+            v=v,
+            g=g,
+            beta=beta,
+            initial_state=initial_state,
+            output_final_state=output_final_state,
+            cu_seqlens=cu_seqlens,
+            use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
+        )
+        if core_attn_out is not None:
+            output_flat = output.squeeze(0).reshape(-1)
+            core_attn_out.reshape(-1)[: output_flat.numel()].copy_(output_flat)
+        return output, final_state
+
     def forward_cuda(
         self,
         q: torch.Tensor,
@@ -250,6 +336,21 @@ class ChunkGatedDeltaRule(CustomOp):
         use_qk_l2norm_in_kernel: bool = True,
         core_attn_out: torch.Tensor | None = None,
     ):
+        float32_output = self._forward_float32(
+            q,
+            k,
+            v,
+            g,
+            beta,
+            initial_state,
+            output_final_state,
+            cu_seqlens,
+            use_qk_l2norm_in_kernel,
+            core_attn_out,
+        )
+        if float32_output is not None:
+            return float32_output
+
         o, final_state = fi_chunk_gated_delta_rule(
             q=q,
             k=k,
@@ -282,6 +383,21 @@ class ChunkGatedDeltaRule(CustomOp):
         use_qk_l2norm_in_kernel: bool = True,
         core_attn_out: torch.Tensor | None = None,
     ):
+        float32_output = self._forward_float32(
+            q,
+            k,
+            v,
+            g,
+            beta,
+            initial_state,
+            output_final_state,
+            cu_seqlens,
+            use_qk_l2norm_in_kernel,
+            core_attn_out,
+        )
+        if float32_output is not None:
+            return float32_output
+
         return fla_chunk_gated_delta_rule(
             q=q,
             k=k,
@@ -312,6 +428,21 @@ class ChunkGatedDeltaRule(CustomOp):
         use_qk_l2norm_in_kernel: bool = True,
         core_attn_out: torch.Tensor | None = None,
     ):
+        float32_output = self._forward_float32(
+            q,
+            k,
+            v,
+            g,
+            beta,
+            initial_state,
+            output_final_state,
+            cu_seqlens,
+            use_qk_l2norm_in_kernel,
+            core_attn_out,
+        )
+        if float32_output is not None:
+            return float32_output
+
         from vllm.model_executor.layers.mamba.ops.gdn_chunk_cutedsl import (
             chunk_gated_delta_rule_cutedsl,
         )


### PR DESCRIPTION
## Summary

Fixes #51305.

Qwen3.5 models currently fail during GDN prefill when served with `dtype=torch.float32`. On Hopper, automatic backend selection chooses the FlashInfer GDN chunk-prefill kernel, whose SM90 DSL implementation only supports FP16 and BF16 inputs.

This change routes FP32 GDN prefill through vLLM's existing recurrent Triton GDN kernel. The recurrent implementation supports FP32 inputs, recurrent states, and outputs, so this fallback preserves the requested precision instead of silently downcasting inputs.

FP16 and BF16 inputs continue to use their existing optimized chunk-prefill backends.

## Root cause

On CUDA SM90, `_resolve_gdn_prefill_backend()` selects FlashInfer for both `auto` and explicitly requested `flashinfer` configurations. The selected call chain is:

```text
ChunkGatedDeltaRule.forward_cuda
  -> fi_chunk_gated_delta_rule
    -> flashinfer.gdn_prefill.chunk_gated_delta_rule
      -> delta_rule_prefill_dsl_sm90
```

The FlashInfer SM90 DSL kernel rejects FP32 inputs with:

```text
RuntimeError: DSL kernel only supports fp16/bf16 inputs, got torch.float32
```

Switching to the in-tree FLA chunk backend is not sufficient because that implementation also explicitly rejects FP32 inputs. The existing recurrent GDN kernel already supports FP32 and is also used by the decode paths.

## Changes

- Add a recurrent GDN prefill wrapper for FP32 inputs.
- Preserve variable-length sequence semantics and per-sequence initial/final states.
- Reserve state-pool index zero because the recurrent kernel treats it as the null block ID.
- Repeat each sequence's state index across its tokens so the kernel's in-place per-token state stores leave the final state in the correct pool slot.
- Preserve `output_final_state=False` behavior.
- Preserve writes to the optional preallocated `core_attn_out` buffer.
- Apply the FP32 fallback consistently to the FlashInfer, FLA/Triton chunk, and CuteDSL chunk entry points because none of those chunk-prefill implementations currently supports FP32.
- Keep all FP16/BF16 fast paths unchanged.
- Emit a one-time warning explaining that FP32 uses the slower recurrent prefill implementation.

## Performance impact

This is a correctness fallback, not a new high-performance FP32 chunk kernel.

The recurrent implementation preserves FP32 precision but has less prefill parallelism than the chunk implementations, so FP32 prefill is expected to be slower. FP16 and BF16 serving performance is unaffected because those dtypes continue to use the existing chunk-prefill kernels.

A future FlashInfer change could add a tuned native FP32 SM90 chunk kernel. If that becomes available, vLLM can prefer it over this recurrent fallback.

## Duplicate-work check

The following duplicate-work searches were performed before preparing this PR:

- Open PRs referencing #51305: none.
- Open PRs matching Qwen3.5 GDN float32: no PR addressing this failure.
- Open PRs matching GDN prefill dtype and DSL kernel fp16 bf16: no duplicate fix found.

One contributor commented on the issue that they were interested in working on it, but there was no open PR or published implementation at the time this PR was prepared.

This PR is therefore not duplicating an existing open fix.

## Tests

### Kernel regression tests

The kernel regression tests were run on an NVIDIA H20-3e GPU (SM90):

```bash
python -m pytest \
  tests/kernels/test_fused_sigmoid_gating_delta_rule.py -v
```

Result:

```text
21 passed, 14 warnings in 6.94s
```

The added regression test covers all three chunk-prefill entry points:

- `forward_cuda`
- `forward_native`
- `forward_cutedsl`

For FP32 inputs, it verifies:

- Output values against an independent recurrent reference.
- Final states for multiple variable-length sequences.
- GQA with different query/key and value head counts.
- Writes to a preallocated `core_attn_out` buffer.

The existing FP32 and BF16 decode tests in the same file also continue to pass.

### Original failure reproduction

Environment:

```text
GPU: NVIDIA H20-3e (SM90)
PyTorch: 2.13.0+cu132
FlashInfer: 0.6.15.post1
vLLM base: 62a86318de3655f970baf7c2ff89c81a72c1a1b3
```

The reproducer used the actual Qwen3.5-4B GDN dimensions:

```text
num_k_heads = 16
num_v_heads = 32
head_k_dim = 128
head_v_dim = 128
prefill length = 64
dtype = torch.float32
```

Before the change, it failed with:

```text
RuntimeError: DSL kernel only supports fp16/bf16 inputs, got torch.float32
```

With this change, the same shape completes through the recurrent FP32 fallback.

### Qwen3.5-4B serving validation

The complete `Qwen/Qwen3.5-4B` checkpoint was tested on one H20 with:

```text
dtype=float32
language_model_only=True
tensor_parallel_size=1
max_model_len=128
```

#### Eager mode

The engine completed model loading, GDN warmup, KV-cache initialization, prefill, recurrent decode, and a 16-token greedy generation.

Example result:

```text
TOKEN_IDS:
[271, 248068, 198, 90700, 8340, 25, 271, 16, 13, 220, 2972, 2014, 53983, 279, 5952, 64700]

TEXT:
"\n\n<think>\nThinking Process:\n\n1.  **Analyze the Request:**"
```

#### Default compiled mode

The same checkpoint was also tested without `enforce_eager`, exercising:

- vLLM `torch.compile`
- Dynamic compile ranges
- Mixed prefill/decode piecewise CUDA Graph capture
- Full decode CUDA Graph capture
- FP32 prefill fallback
- Recurrent FP32 decode

Result:

```text
torch.compile: passed
CUDA Graph capture: passed
Engine initialization: passed
Greedy generation: passed

TOKEN_IDS:
[11, 353, 2688, 4313]

TEXT:
", I'm trying"
```

#### Dummy-weight architecture validation

The same Qwen3.5-4B architecture was additionally run with `load_format="dummy"` and FP32. Engine initialization and a four-token prefill/decode generation completed successfully.

### Formatting and static checks

```bash
uvx --from ruff==0.14.0 ruff check \
  vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py \
  tests/kernels/test_fused_sigmoid_gating_delta_rule.py
```

Result:

```text
All checks passed!
```

```bash
uvx --from ruff==0.14.0 ruff format --check \
  vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py \
  tests/kernels/test_fused_sigmoid_gating_delta_rule.py
```

Result:

```text
2 files already formatted
```

```bash
git diff --check
```

Result:

```text
passed
```

The pre-commit wrapper could not finish creating its isolated Ruff environment because building `ruff-pre-commit` repeatedly failed with `Errno 524`. The same pinned Ruff version used by the hook (`0.14.0`) was therefore run directly through `uvx`, as shown above.