### PR TITLE
[v1][kv-transfer] Prioritize remote KV polling in scheduler

### DIFF
--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import itertools
+import os
 import time
 from collections import defaultdict, deque
 from collections.abc import Iterable
@@ -64,6 +65,9 @@ from vllm.v1.structured_output import StructuredOutputGrammar, StructuredOutputM
 from vllm.v1.utils import record_function_or_nullcontext
 
 logger = init_logger(__name__)
+KV_TRANSFER_PRIORITY_POLL = bool(
+    int(os.environ.get("VLLM_KV_TRANSFER_PRIORITY_POLL", "0"))
+)
 
 
 class Scheduler(SchedulerInterface):
@@ -189,6 +193,8 @@ class Scheduler(SchedulerInterface):
         # requests skipped in waiting flow due async deps or constraints.
         self.skipped_waiting = create_request_queue(self.policy)
         self.running: list[Request] = []
+
+        self._kv_transfer_priority_poll_logged = False
 
         # The request IDs that are finished in between the previous and the
         # current steps. This is used to notify the workers about the finished
@@ -437,6 +443,29 @@ class Scheduler(SchedulerInterface):
         end = min((s for s in stops if start < s < end), default=end)
         return max(end - start, 0)
 
+    def _should_prioritize_kv_transfer_poll(self) -> bool:
+        if (
+            not KV_TRANSFER_PRIORITY_POLL
+            or self.connector is None
+            or not self.running
+            or self._pause_state != PauseState.UNPAUSED
+        ):
+            return False
+
+        waiting_for_kv_transfer = itertools.chain(self.waiting, self.skipped_waiting)
+        return any(
+            self._is_kv_transfer_poll_candidate(request)
+            for request in waiting_for_kv_transfer
+        )
+
+    @staticmethod
+    def _is_kv_transfer_poll_candidate(request: Request) -> bool:
+        return request.kv_transfer_params is not None and request.status in (
+            RequestStatus.WAITING,
+            RequestStatus.PREEMPTED,
+            RequestStatus.WAITING_FOR_REMOTE_KVS,
+        )
+
     def schedule(self, throttle_prefills: bool = False) -> SchedulerOutput:
         self.current_step += 1
         # NOTE(woosuk) on the scheduling algorithm:
@@ -481,9 +510,21 @@ class Scheduler(SchedulerInterface):
             throttle_prefills and not self.prefill_capacity_bound
         ) and any(not r.is_prefill_chunk for r in self.running)
 
+        prioritize_kv_transfer_poll = self._should_prioritize_kv_transfer_poll()
+        if prioritize_kv_transfer_poll and not self._kv_transfer_priority_poll_logged:
+            logger.info(
+                "VLLM_KV_TRANSFER_PRIORITY_POLL=1: prioritizing remote KV "
+                "admission before running decode steps."
+            )
+            self._kv_transfer_priority_poll_logged = True
+
         # First, schedule the RUNNING requests.
         req_index = 0
-        while req_index < len(self.running) and token_budget > 0:
+        while (
+            not prioritize_kv_transfer_poll
+            and req_index < len(self.running)
+            and token_budget > 0
+        ):
             request = self.running[req_index]
 
             if (
@@ -705,6 +746,13 @@ class Scheduler(SchedulerInterface):
 
                 request = request_queue.peek_request()
                 request_id = request.request_id
+
+                if prioritize_kv_transfer_poll and not (
+                    self._is_kv_transfer_poll_candidate(request)
+                ):
+                    request_queue.pop_request()
+                    step_skipped_waiting.prepend_request(request)
+                    continue
 
                 # try to promote blocked statuses while traversing skipped queue.
                 if self._is_blocked_waiting_status(
@@ -1059,6 +1107,8 @@ class Scheduler(SchedulerInterface):
                                 num_computed_tokens,
                             )
                         )
+                    if prioritize_kv_transfer_poll:
+                        break
                     continue
 
                 self.running.append(request)


### PR DESCRIPTION
Add an experimental scheduler path to prioritize remote KV transfer admission and polling before scheduling regular decode work.

In disaggregated prefill/decode deployments, a decode request that needs remote KV blocks can sit behind already-running decode steps. Since the KV connector only starts or observes transfer progress when a scheduler step reaches the connector metadata path, this can inflate TTFT by one or more decode-step boundaries even when the actual NIXL transfer is short.

This change adds an opt-in environment flag,
VLLM_KV_TRANSFER_PRIORITY_POLL, that makes the scheduler run a KV-transfer focused step when all of the following hold:

- KV transfer is enabled for the scheduler.
- There is active decode work in the running queue.
- A waiting or skipped request has KV transfer parameters.
- The scheduler is not paused.

When enabled, the scheduler skips regular running-request decode scheduling for that step and scans waiting/skipped requests for remote KV transfer candidates. Non-KV candidates are preserved by moving them to the step-local skipped queue, while KV candidates may be admitted into WAITING_FOR_REMOTE_KVS so the connector can start or poll the remote load.

This is intentionally gated because it trades decode throughput for lower TTFT. In Qwen3-30B-A3B FP8 disaggregated tests, the policy reduced TTFT by roughly 13-19% for concurrency >= 2. The best observed point was concurrency=4, where TTFT improved by ~19% with negligible ITL impact and slightly higher system throughput. At higher concurrency, unthrottled priority polling increased ITL and reduced system throughput, indicating that follow-up work should add rate limiting or adaptive gating before making this policy a default.

The flag is off by default, preserving existing scheduling behavior.




## Purpose
This PR adds an opt-in scheduler policy for disaggregated KV transfer
workloads. When VLLM_KV_TRANSFER_PRIORITY_POLL=1, the V1 scheduler can
prioritize waiting requests that need remote KV transfer over regular
running decode work for a scheduler step. This helps reduce TTFT caused by
remote KV load admission/polling being delayed behind decode step
boundaries.

The behavior is disabled by default. Initial experiments show meaningful
TTFT improvements, but also reveal a throughput tradeoff at high
concurrency, so this is introduced as an experimental opt-in path rather
than a default policy.

## Test Plan

## Test Result
Observed Qwen3-30B-A3B FP8 disaggregated results:
- concurrency=2: TTFT avg 403.23ms -> 325.01ms, system TPS 45.73 -> 44.22
- concurrency=4: TTFT avg 412.68ms -> 332.75ms, system TPS 89.14 -> 90.93
- concurrency=8: TTFT avg 405.13ms -> 349.82ms, system TPS 174.47 -> 163.27
- concurrency=16: TTFT avg 413.99ms -> 346.66ms, system TPS 336.07 -> 309.06
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

