### PR TITLE
[Core][V1] Add residual-aware SJF scheduling policy

### DIFF
--- a/docs/usage/v1_guide.md
+++ b/docs/usage/v1_guide.md
@@ -77,9 +77,20 @@ For each item, its support in vLLM V1 falls into one of the following states:
     and decode phases.
 
 The V1 scheduler supports multiple scheduling policies, including First-Come,
-First-Served (FCFS) and priority-based scheduling (where requests are processed
-based on assigned priority, with FCFS as a tie-breaker), configurable via the
-`--scheduling-policy` argument.
+First-Served (FCFS), priority-based scheduling (where requests are processed
+based on assigned priority, with FCFS as a tie-breaker), and `residual_sjf`.
+`residual_sjf` is for decoder-only text generation: it orders waiting requests
+by their remaining local prefill work after local prefix-cache hits. A
+request that waits for `--residual-sjf-max-wait-ms` (10,000 by default) is
+promoted in FCFS order. It does not query remote KV connectors while ranking
+candidates, so remote cache-transfer cost is not part of this policy. The exact
+dynamic ranking scans current waiting candidates on every admission; measure
+scheduler CPU overhead separately from model throughput for deep queues.
+
+The max-wait value controls the mean/tail tradeoff: smaller values behave
+closer to FCFS (flatter tail), larger values improve mean TTFT/E2E at the
+cost of P95/P99. Start at 1/2 to 1/3 of the target P95 wait and adjust
+after load testing against the P99 budget.
 
 ### Hardware
 

--- a/tests/v1/core/test_residual_sjf.py
+++ b/tests/v1/core/test_residual_sjf.py
@@ -1,0 +1,237 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from unittest.mock import Mock
+
+import pytest
+
+from vllm.config import SchedulerConfig
+from vllm.engine.arg_utils import EngineArgs
+from vllm.utils.argparse_utils import FlexibleArgumentParser
+from vllm.v1.core.sched.request_queue import ResidualSJFRequestQueue
+from vllm.v1.outputs import ModelRunnerOutput
+from vllm.v1.request import RequestStatus
+
+from .utils import create_requests, create_scheduler, mock_kv
+
+pytestmark = [pytest.mark.cpu_test, pytest.mark.skip_global_cleanup]
+
+
+def _queue_requests() -> tuple[list, dict[str, int]]:
+    requests = create_requests(
+        num_requests=4,
+        req_ids=["recovery", "aged", "short", "same_cost"],
+    )
+    costs = {"recovery": 100, "aged": 100, "short": 1, "same_cost": 1}
+    return requests, costs
+
+
+def test_residual_sjf_queue_orders_recovery_aging_cost_and_ties():
+    requests, costs = _queue_requests()
+    recovery, aged, short, same_cost = requests
+    recovery.arrival_time = 95.0
+    recovery.num_computed_tokens = 1
+    aged.arrival_time = 90.0
+    short.arrival_time = 99.0
+    same_cost.arrival_time = 99.0
+
+    queue = ResidualSJFRequestQueue(
+        lambda request: costs[request.request_id], max_wait_ms=5_000, clock=lambda: 100
+    )
+    for request in requests:
+        queue.add_request(request)
+
+    assert queue.peek_request() is recovery
+    assert queue.pop_request() is recovery
+    assert queue.peek_request() is aged
+    assert queue.pop_request() is aged
+    assert queue.peek_request() is same_cost
+    assert queue.pop_request() is same_cost
+    assert queue.pop_request() is short
+
+
+def test_residual_sjf_queue_recomputes_cost_but_pins_peeked_request():
+    requests = create_requests(num_requests=2, req_ids=["a", "b"])
+    for request in requests:
+        request.arrival_time = 100.0
+    costs = {"a": 10, "b": 20}
+    queue = ResidualSJFRequestQueue(
+        lambda request: costs[request.request_id], max_wait_ms=60_000, clock=lambda: 100
+    )
+    for request in requests:
+        queue.add_request(request)
+
+    assert queue.peek_request() is requests[0]
+    costs["b"] = 1
+    assert queue.pop_request() is requests[0]
+    assert queue.peek_request() is requests[1]
+
+
+def test_residual_sjf_queue_supports_requeue_and_removal():
+    requests = create_requests(num_requests=3, req_ids=["a", "b", "c"])
+    costs = {"a": 3, "b": 2, "c": 1}
+    queue = ResidualSJFRequestQueue(
+        lambda request: costs[request.request_id], max_wait_ms=60_000, clock=lambda: 100
+    )
+    for request in requests:
+        queue.add_request(request)
+
+    assert list(queue) == [requests[2], requests[1], requests[0]]
+    queue.pin_request(requests[2])
+    queue.remove_request(requests[2])
+    assert queue.pop_request() is requests[1]
+    queue.prepend_request(requests[1])
+    queue.remove_requests([requests[0]])
+    assert queue.pop_request() is requests[1]
+
+
+def test_residual_sjf_prefers_warm_long_prompt_over_cold_short_prompt():
+    scheduler = create_scheduler(
+        scheduling_policy="residual_sjf",
+        enable_prefix_caching=True,
+        max_num_seqs=1,
+        max_num_batched_tokens=64,
+        block_size=16,
+    )
+    warm, cached = create_requests(
+        num_requests=2,
+        num_tokens=33,
+        same_prompt=True,
+        max_tokens=1,
+        req_ids=["warm", "cached"],
+    )
+    _, cold = create_requests(num_requests=2, num_tokens=18, req_ids=["unused", "cold"])
+
+    scheduler.add_request(warm)
+    output = scheduler.schedule()
+    scheduler.update_from_output(
+        output,
+        ModelRunnerOutput(
+            req_ids=[warm.request_id],
+            req_id_to_index={warm.request_id: 0},
+            sampled_token_ids=[[0]],
+            logprobs=None,
+            prompt_logprobs_dict={},
+            pooler_output=[],
+        ),
+    )
+
+    assert scheduler.kv_cache_manager.get_num_local_computed_tokens(cached) == 32
+    assert scheduler.kv_cache_manager.get_num_local_computed_tokens(cold) == 0
+    assert scheduler._get_residual_sjf_cost(cached) == 1
+    scheduler.add_request(cold)
+    scheduler.add_request(cached)
+
+    output = scheduler.schedule()
+    assert [request.req_id for request in output.scheduled_new_reqs] == ["cached"]
+
+
+@pytest.mark.parametrize("enable_prefix_caching", [False, True])
+def test_residual_sjf_zero_local_hit_uses_prompt_length(enable_prefix_caching: bool):
+    scheduler = create_scheduler(
+        scheduling_policy="residual_sjf", enable_prefix_caching=enable_prefix_caching
+    )
+    long_request, _ = create_requests(
+        num_requests=2, num_tokens=20, req_ids=["long", "unused"]
+    )
+    _, short_request = create_requests(
+        num_requests=2, num_tokens=10, req_ids=["unused", "short"]
+    )
+
+    assert scheduler._get_residual_sjf_cost(long_request) == 2
+    assert scheduler._get_residual_sjf_cost(short_request) == 1
+    short_request.skip_reading_prefix_cache = True
+    assert scheduler._get_residual_sjf_cost(short_request) == 1
+
+
+def test_residual_sjf_compares_waiting_and_skipped_waiting_globally():
+    scheduler = create_scheduler(scheduling_policy="residual_sjf")
+    waiting, skipped = create_requests(
+        num_requests=2, num_tokens=20, req_ids=["waiting", "skipped"]
+    )
+    skipped.prompt_token_ids = [1] * 10
+    skipped.all_token_ids = skipped.prompt_token_ids.copy()
+    skipped.status = RequestStatus.WAITING_FOR_REMOTE_KVS
+    waiting.arrival_time = 1.0
+    skipped.arrival_time = 0.0
+    scheduler.add_request(waiting)
+    scheduler.skipped_waiting.add_request(skipped)
+
+    selected_queue = scheduler._select_waiting_queue_for_scheduling()
+    assert selected_queue is scheduler.skipped_waiting
+    assert selected_queue.peek_request() is skipped
+
+
+def test_residual_sjf_does_not_probe_connector_while_ranking():
+    scheduler = create_scheduler(
+        scheduling_policy="residual_sjf",
+        enable_prefix_caching=True,
+        use_kv_connector=mock_kv(matched_tokens=0, is_async=False),
+    )
+    scheduler.connector.get_num_new_matched_tokens = Mock()
+    for request in create_requests(num_requests=2):
+        scheduler.add_request(request)
+
+    scheduler._select_waiting_queue_for_scheduling()
+    scheduler.connector.get_num_new_matched_tokens.assert_not_called()
+    stats = scheduler.kv_cache_manager.prefix_cache_stats
+    assert stats is not None
+    assert (stats.requests, stats.queries, stats.hits) == (0, 0, 0)
+
+
+def test_residual_sjf_config_and_cli_validation():
+    config = SchedulerConfig(
+        max_model_len=32,
+        max_num_batched_tokens=32,
+        max_num_seqs=1,
+        is_encoder_decoder=False,
+        policy="residual_sjf",
+    )
+    assert config.residual_sjf_max_wait_ms == 10_000
+
+    with pytest.raises(ValueError, match="residual_sjf"):
+        SchedulerConfig(
+            max_model_len=32,
+            max_num_batched_tokens=32,
+            max_num_seqs=1,
+            is_encoder_decoder=False,
+            is_multimodal_model=True,
+            policy="residual_sjf",
+        )
+    with pytest.raises(ValueError, match="residual_sjf"):
+        SchedulerConfig(
+            max_model_len=32,
+            max_num_batched_tokens=32,
+            max_num_seqs=1,
+            is_encoder_decoder=True,
+            policy="residual_sjf",
+        )
+    with pytest.raises(ValueError, match="residual_sjf"):
+        SchedulerConfig(
+            max_model_len=32,
+            max_num_batched_tokens=32,
+            max_num_seqs=1,
+            is_encoder_decoder=False,
+            runner_type="pooling",
+            policy="residual_sjf",
+        )
+    with pytest.raises(ValueError):
+        SchedulerConfig(
+            max_model_len=32,
+            max_num_batched_tokens=32,
+            max_num_seqs=1,
+            is_encoder_decoder=False,
+            residual_sjf_max_wait_ms=0,
+        )
+
+    parser = EngineArgs.add_cli_args(FlexibleArgumentParser())
+    args = parser.parse_args(
+        [
+            "--scheduling-policy",
+            "residual_sjf",
+            "--residual-sjf-max-wait-ms",
+            "1234",
+        ]
+    )
+    assert args.scheduling_policy == "residual_sjf"
+    assert args.residual_sjf_max_wait_ms == 1234

--- a/tests/v1/core/utils.py
+++ b/tests/v1/core/utils.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from typing import Literal
+
 import torch
 
 import vllm.envs as envs
@@ -52,6 +54,8 @@ def create_scheduler(
     max_num_batched_tokens: int = 8192,
     enable_chunked_prefill: bool = True,
     enable_prefix_caching: bool = False,
+    scheduling_policy: Literal["fcfs", "priority", "residual_sjf"] = "fcfs",
+    residual_sjf_max_wait_ms: int = 10_000,
     long_prefill_token_threshold: int = 0,
     disable_chunked_mm_input: bool = False,
     use_kv_connector: None | bool | str | MockKVConfig = None,
@@ -102,6 +106,8 @@ def create_scheduler(
         enable_chunked_prefill=enable_chunked_prefill,
         async_scheduling=async_scheduling,
         is_encoder_decoder=model_config.is_encoder_decoder,
+        policy=scheduling_policy,
+        residual_sjf_max_wait_ms=residual_sjf_max_wait_ms,
         # Ensure admission/preemption mechanics are deterministic
         watermark=0.0,
     )

--- a/vllm/config/scheduler.py
+++ b/vllm/config/scheduler.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
 logger = init_logger(__name__)
 
 RunnerType = Literal["generate", "pooling", "draft"]
-SchedulerPolicy = Literal["fcfs", "priority"]
+SchedulerPolicy = Literal["fcfs", "priority", "residual_sjf"]
 
 
 @config
@@ -102,7 +102,17 @@ class SchedulerConfig:
     - "fcfs" means first come first served, i.e. requests are handled in order 
       of arrival.
     - "priority" means requests are handled based on given priority (lower
-      value means earlier handling) and time of arrival deciding any ties)."""
+      value means earlier handling) and time of arrival deciding any ties).
+    - "residual_sjf" means decoder-only text requests are handled by their
+      remaining local prefill work, with FCFS max-wait aging."""
+
+    residual_sjf_max_wait_ms: int = Field(default=10_000, gt=0)
+    """Maximum wait before a residual-SJF request receives FCFS priority.
+
+    This value controls the mean/tail tradeoff: smaller values make the policy
+    behave closer to FCFS with a flatter tail; larger values improve mean
+    TTFT/E2E at the cost of P95/P99. Start at 1/2 to 1/3 of the target P95 wait
+    and adjust after load testing against the P99 budget."""
 
     disable_chunked_mm_input: bool = False
     """If set to true and chunked prefill is enabled, we do not want to
@@ -225,6 +235,18 @@ class SchedulerConfig:
         return None if value is None else handler(value)
 
     def __post_init__(self, max_model_len: int, is_encoder_decoder: bool) -> None:
+        if self.policy == "residual_sjf" and (
+            self.is_multimodal_model or is_encoder_decoder
+        ):
+            raise ValueError(
+                "residual_sjf supports decoder-only text generation models only."
+            )
+        if self.policy == "residual_sjf" and self.runner_type != "generate":
+            raise ValueError(
+                "residual_sjf requires the generate runner; "
+                f"runner_type={self.runner_type} is not supported."
+            )
+
         if is_encoder_decoder:
             # Chunked prefill should be disabled for encoder-decoder models.
             self.disable_chunked_mm_input = True

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -666,6 +666,7 @@ class EngineArgs:
     jit_monitor_verbose: bool = ObservabilityConfig.jit_monitor_verbose
     enable_mm_processor_stats: bool = ObservabilityConfig.enable_mm_processor_stats
     scheduling_policy: SchedulerPolicy = SchedulerConfig.policy
+    residual_sjf_max_wait_ms: int = SchedulerConfig.residual_sjf_max_wait_ms
     scheduler_cls: str | type[object] | None = SchedulerConfig.scheduler_cls
 
     pooler_config: PoolerConfig | None = ModelConfig.pooler_config
@@ -1526,6 +1527,10 @@ class EngineArgs:
             "--scheduling-policy", **scheduler_kwargs["policy"]
         )
         scheduler_group.add_argument(
+            "--residual-sjf-max-wait-ms",
+            **scheduler_kwargs["residual_sjf_max_wait_ms"],
+        )
+        scheduler_group.add_argument(
             "--enable-chunked-prefill",
             **{
                 **scheduler_kwargs["enable_chunked_prefill"],
@@ -2309,6 +2314,7 @@ class EngineArgs:
             is_multimodal_model=model_config.is_multimodal_model,
             is_encoder_decoder=model_config.is_encoder_decoder,
             policy=self.scheduling_policy,
+            residual_sjf_max_wait_ms=self.residual_sjf_max_wait_ms,
             scheduler_cls=self.scheduler_cls,
             long_prefill_token_threshold=self.long_prefill_token_threshold,
             scheduler_reserve_full_isl=self.scheduler_reserve_full_isl,

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -215,6 +215,24 @@ class KVCacheManager:
         """Whether a local prefix cache lookup may be run for this request."""
         return self.enable_caching and not request.skip_reading_prefix_cache
 
+    def _find_longest_local_cache_hit(
+        self, request: Request
+    ) -> tuple[tuple[list[KVCacheBlock], ...], int, int] | None:
+        """Find a local cache hit without creating blocks or emitting events."""
+        if not self.prefix_cache_lookup_enabled(request):
+            return None
+        return self.coordinator.find_longest_cache_hit(
+            request.block_hashes, request.num_tokens - 1
+        )
+
+    def get_num_local_computed_tokens(self, request: Request) -> int:
+        """Return the number of locally cached KV tokens without mutating state."""
+        cache_hit = self._find_longest_local_cache_hit(request)
+        if cache_hit is None:
+            return 0
+        _, hit_length, _ = cache_hit
+        return hit_length
+
     def record_prefix_cache_stats(self, request: Request, num_hits: int) -> None:
         # Don't count a request that skipped the cache lookup.
         if not self.log_stats or not self.prefix_cache_lookup_enabled(request):
@@ -243,11 +261,8 @@ class KVCacheManager:
                   Pinned so ``VLLM_PREFIX_CACHE_RETENTION_INTERVAL`` does not drop
                   the junction and defeat cross-request reuse.
         """
-        # We skip finding the prefix cache hit when prefix caching is
-        # disabled or the request is marked as skipping kv cache read
-        # (which happens when the request requires prompt logprobs
-        # or calls a pooling model with all pooling).
-        if not self.prefix_cache_lookup_enabled(request):
+        cache_hit = self._find_longest_local_cache_hit(request)
+        if cache_hit is None:
             return self.empty_kv_cache_blocks, 0, 0
 
         # NOTE: When all tokens hit the cache, we must recompute the last token
@@ -256,12 +271,7 @@ class KVCacheManager:
         # the single last token, because allocate_slots() requires
         # num_computed_tokens to be block-size aligned. Removing this limitation
         # could slightly improve performance in the future.
-        max_cache_hit_length = request.num_tokens - 1
-        computed_blocks, num_new_computed_tokens, num_uncached = (
-            self.coordinator.find_longest_cache_hit(
-                request.block_hashes, max_cache_hit_length
-            )
-        )
+        computed_blocks, num_new_computed_tokens, num_uncached = cache_hit
 
         # When kv_cache_report_mode is "full", emit BlockStored events
         # for the reused prefix cache blocks so that external consumers

--- a/vllm/v1/core/sched/request_queue.py
+++ b/vllm/v1/core/sched/request_queue.py
@@ -2,19 +2,25 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import heapq
+import time
 from abc import ABC, abstractmethod
 from collections import deque
-from collections.abc import Iterable, Iterator
+from collections.abc import Callable, Iterable, Iterator
 from enum import Enum
+
+from vllm.logger import init_logger
 
 from vllm.v1.request import Request
 
+
+logger = init_logger(__name__)
 
 class SchedulingPolicy(Enum):
     """Enum for scheduling policies."""
 
     FCFS = "fcfs"
     PRIORITY = "priority"
+    RESIDUAL_SJF = "residual_sjf"
 
 
 class RequestQueue(ABC):
@@ -198,11 +204,143 @@ class PriorityRequestQueue(RequestQueue):
             yield heapq.heappop(heap_copy)
 
 
-def create_request_queue(policy: SchedulingPolicy) -> RequestQueue:
+class ResidualSJFRequestQueue(RequestQueue):
+    """A dynamic queue ordered by local prefill work and bounded aging."""
+
+    def __init__(
+        self,
+        residual_cost_fn: Callable[[Request], int],
+        max_wait_ms: int,
+        clock: Callable[[], float] = time.time,
+    ) -> None:
+        self._requests: list[Request] = []
+        self._residual_cost_fn = residual_cost_fn
+        self._max_wait_seconds = max_wait_ms / 1000
+        self._clock = clock
+        self._selected_request: Request | None = None
+
+    @staticmethod
+    def _is_recovery_request(request: Request) -> bool:
+        return request.num_preemptions > 0 or request.num_computed_tokens > 0
+
+    def _selection_key(
+        self, request: Request, now: float
+    ) -> tuple[int, int, float, str]:
+        if self._is_recovery_request(request):
+            return 0, 0, request.arrival_time, request.request_id
+        if now - request.arrival_time >= self._max_wait_seconds:
+            return 1, 0, request.arrival_time, request.request_id
+        return (
+            2,
+            self._residual_cost_fn(request),
+            request.arrival_time,
+            request.request_id,
+        )
+
+    def get_best_request(
+        self, now: float | None = None
+    ) -> tuple[Request, tuple[int, int, float, str]]:
+        """Return the best current request without changing queue state."""
+        if not self._requests:
+            raise IndexError("peek from an empty queue")
+        now = self._clock() if now is None else now
+        return min(
+            (
+                (request, self._selection_key(request, now))
+                for request in self._requests
+            ),
+            key=lambda item: item[1],
+        )
+
+    def pin_request(self, request: Request) -> None:
+        """Pin a previously selected request until it is popped or removed."""
+        if request not in self._requests:
+            raise ValueError("Cannot pin a request that is not in the queue")
+        self._selected_request = request
+
+    def _clear_selection(self) -> None:
+        self._selected_request = None
+
+    def add_request(self, request: Request) -> None:
+        self._clear_selection()
+        self._requests.append(request)
+
+    def pop_request(self) -> Request:
+        if not self._requests:
+            raise IndexError("pop from an empty queue")
+        request = self._selected_request
+        if request is None:
+            request, _ = self.get_best_request()
+        self._requests.remove(request)
+        self._clear_selection()
+        return request
+
+    def peek_request(self) -> Request:
+        if self._selected_request is None:
+            request, _ = self.get_best_request()
+            self._selected_request = request
+        return self._selected_request
+
+    def prepend_request(self, request: Request) -> None:
+        self._clear_selection()
+        self._requests.insert(0, request)
+
+    def prepend_requests(self, requests: RequestQueue) -> None:
+        self._clear_selection()
+        for request in requests:
+            self._requests.insert(0, request)
+
+    def remove_request(self, request: Request) -> None:
+        self._requests.remove(request)
+        if self._selected_request is request:
+            self._clear_selection()
+
+    def remove_requests(self, requests: Iterable[Request]) -> None:
+        requests_to_remove = set(requests)
+        self._requests = [
+            request for request in self._requests if request not in requests_to_remove
+        ]
+        if self._selected_request in requests_to_remove:
+            self._clear_selection()
+
+    def __bool__(self) -> bool:
+        return bool(self._requests)
+
+    def __len__(self) -> int:
+        return len(self._requests)
+
+    def __iter__(self) -> Iterator[Request]:
+        now = self._clock()
+        return iter(
+            sorted(
+                self._requests, key=lambda request: self._selection_key(request, now)
+            )
+        )
+
+
+def create_request_queue(
+    policy: SchedulingPolicy,
+    residual_cost_fn: Callable[[Request], int] | None = None,
+    residual_sjf_max_wait_ms: int = 10_000,
+) -> RequestQueue:
     """Create request queue based on scheduling policy."""
     if policy == SchedulingPolicy.PRIORITY:
         return PriorityRequestQueue()
     elif policy == SchedulingPolicy.FCFS:
         return FCFSRequestQueue()
+    elif policy == SchedulingPolicy.RESIDUAL_SJF:
+        if residual_cost_fn is None:
+            raise ValueError("residual_sjf requires a residual cost function")
+        logger.warning_once(
+            "residual_sjf is enabled with residual_sjf_max_wait_ms=%d. "
+            "This value controls the mean/tail tradeoff: smaller values "
+            "behave closer to FCFS (flatter tail), larger values improve "
+            "mean latency at the cost of P95/P99. Start at 1/2 to 1/3 of "
+            "the target P95 wait and tune after load testing.",
+            residual_sjf_max_wait_ms,
+        )
+        return ResidualSJFRequestQueue(
+            residual_cost_fn, residual_sjf_max_wait_ms
+        )
     else:
         raise ValueError(f"Unknown scheduling policy: {policy}")

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -47,6 +47,7 @@ from vllm.v1.core.sched.output import (
     SchedulerOutput,
 )
 from vllm.v1.core.sched.request_queue import (
+    ResidualSJFRequestQueue,
     RequestQueue,
     SchedulingPolicy,
     create_request_queue,
@@ -184,10 +185,10 @@ class Scheduler(SchedulerInterface):
             raise ValueError(
                 f"Unknown scheduling policy: {self.scheduler_config.policy}"
             ) from e
-        # Priority queues for requests.
-        self.waiting = create_request_queue(self.policy)
+        # Waiting queues for requests.
+        self.waiting = self._create_waiting_request_queue()
         # requests skipped in waiting flow due async deps or constraints.
-        self.skipped_waiting = create_request_queue(self.policy)
+        self.skipped_waiting = self._create_waiting_request_queue()
         self.running: list[Request] = []
 
         # The request IDs that are finished in between the previous and the
@@ -691,7 +692,7 @@ class Scheduler(SchedulerInterface):
 
         # Next, schedule the WAITING requests.
         if not preempted_reqs and self._pause_state == PauseState.UNPAUSED:
-            step_skipped_waiting = create_request_queue(self.policy)
+            step_skipped_waiting = self._create_waiting_request_queue()
 
             while (self.waiting or self.skipped_waiting) and token_budget > 0:
                 # Paused streaming sessions (WAITING_FOR_STREAMING_REQ) are not
@@ -2081,9 +2082,49 @@ class Scheduler(SchedulerInterface):
         else:
             self.waiting.add_request(request)
 
+    def _create_waiting_request_queue(self) -> RequestQueue:
+        return create_request_queue(
+            self.policy,
+            residual_cost_fn=self._get_residual_sjf_cost,
+            residual_sjf_max_wait_ms=self.scheduler_config.residual_sjf_max_wait_ms,
+        )
+
+    def _get_residual_sjf_cost(self, request: Request) -> int:
+        # Measure cached work in tokens (the coordinator's hit length) so the
+        # cost stays consistent across KV cache groups with different block
+        # sizes, then quantize to scheduler blocks for stable tie-breaking.
+        num_computed_tokens = self.kv_cache_manager.get_num_local_computed_tokens(
+            request
+        )
+        num_computed_blocks = (
+            num_computed_tokens + self.block_size - 1
+        ) // self.block_size
+        num_total_blocks = (request.num_tokens + self.block_size - 1) // self.block_size
+        return max(0, num_total_blocks - num_computed_blocks)
+
     def _select_waiting_queue_for_scheduling(self) -> RequestQueue | None:
         if self.policy == SchedulingPolicy.FCFS:
             return self.skipped_waiting or self.waiting or None
+
+        if self.policy == SchedulingPolicy.RESIDUAL_SJF:
+            queues = [queue for queue in (self.waiting, self.skipped_waiting) if queue]
+            if not queues:
+                return None
+
+            now = time.time()
+            selected_queue, (selected_request, _) = min(
+                (
+                    (
+                        queue,
+                        self._get_residual_sjf_best_request(queue, now),
+                    )
+                    for queue in queues
+                ),
+                key=lambda item: item[1][1],
+            )
+            assert isinstance(selected_queue, ResidualSJFRequestQueue)
+            selected_queue.pin_request(selected_request)
+            return selected_queue
 
         # PRIORITY mode: compare queue heads when both queues are non-empty.
         if self.waiting and self.skipped_waiting:
@@ -2092,6 +2133,13 @@ class Scheduler(SchedulerInterface):
             return self.waiting if waiting_req < skipped_req else self.skipped_waiting
 
         return self.waiting or self.skipped_waiting or None
+
+    @staticmethod
+    def _get_residual_sjf_best_request(
+        queue: RequestQueue, now: float
+    ) -> tuple[Request, tuple[int, int, float, str]]:
+        assert isinstance(queue, ResidualSJFRequestQueue)
+        return queue.get_best_request(now)
 
     def _handle_stopped_request(self, request: Request) -> bool:
         """Return True if finished (can be False for resumable requests)."""


### PR DESCRIPTION
## Summary

Sort waiting prefill requests by remaining local prefill cost (num_tokens minus local cached tokens) instead of raw prompt length, so cache-warm long prompts are not misclassified as expensive. Recovery requests stay first; max-wait aging promotes stragglers in FCFS order.

Residual cost is quantized to KV blocks so requests with the same remaining block count tie-break by arrival time, stabilizing decode arrivals and TPOT variance. Add `residual_sjf_max_wait_ms` to configure the aging threshold.

Raw-length cost mode is kept as an uncommitted test-only ablation switch and is not part of this change.

This PR is the main-branch port of the same change previously developed on a v0.23.0-based branch, cherry-picked onto current `main` (commit `3378b45b4`). The only adaptation: the local cache-hit lookup now consumes the coordinator's 3-tuple return (blocks, hit length, uncached shared-prefix boundary) introduced by the sparse-retention (Mamba/APC) work; scheduler semantics are unchanged.

## Why This Is Not a Duplicate

- RFC #29406 proposed SJF, and PR #29366 (closed) implemented raw-length SJF at the RequestQueue level; EWSJF (PR #33392) sorts by raw prompt length with dynamic partitioning. None of them is cache-aware: a cache-warm long prompt is still treated as expensive. This change sorts by exact local residual prefill, which no existing open PR covers.
- Checked open PRs for "sjf" / "shortest job first" before opening; no open PR implements residual/cache-aware SJF. The CacheAffinityScheduler RFC (#42185) is complementary (cache affinity as an inner ordering key) and is intentionally out of scope here.

## Purpose

FCFS head-of-line blocking delays short interactive prefills behind long ones, and raw-length SJF misclassifies cache-warm long prompts (a 10K-token prompt with 9K local cache hit has only ~1K remaining prefill). This policy orders waiting requests by actual remaining local prefill work (quantized to KV blocks), with:

- recovery requests first (no wasted prefill work),
- max-wait aging (FCFS promotion) to bound starvation,
- block-level cost granularity for stable decode arrivals.

New configuration: `--scheduling-policy residual_sjf`, `--residual-sjf-max-wait-ms` (default 10000, controls the mean/tail tradeoff).

## Test Plan

Unit tests (included in this PR):
```
pytest tests/v1/core/test_residual_sjf.py -v
```

Runtime validation (lab harness; vLLM v0.23.0-based fork of this change — same policy semantics as this port; single-node P/D with Mooncake KV transfer, Qwen2.5-7B-Instruct, Open-SWE 160-session pool, Poisson rate 6 req/s, 720 requests/round, 2 rounds per config): FCFS vs residual_sjf mw10 vs residual_sjf mw20, plus a raw-length SJF ablation baseline (mw20) that is not part of this change. Metrics from the client (TTFT/E2E) and engine `/metrics` (queue wait, TPOT: sum/count means plus histogram bucket ranges).

## Test Result

Unit tests (run on the v0.23.0-based checkout where this change originated; the same test file is included in this port — re-run on main is in progress):

```
$ pytest tests/v1/core/test_residual_sjf.py -v
tests/v1/core/test_residual_sjf.py::test_residual_sjf_queue_orders_recovery_aging_cost_and_ties PASSED
tests/v1/core/test_residual_sjf.py::test_residual_sjf_queue_recomputes_cost_but_pins_peeked_request PASSED
tests/v1/core/test_residual_sjf.py::test_residual_sjf_queue_supports_requeue_and_removal PASSED
tests/v1/core/test_residual_sjf.py::test_residual_sjf_prefers_warm_long_prompt_over_cold_short_prompt PASSED
tests/v1/core/test_residual_sjf.py::test_residual_sjf_zero_local_hit_uses_prompt_length[False] PASSED
tests/v1/core/test_residual_sjf.py::test_residual_sjf_zero_local_hit_uses_prompt_length[True] PASSED
tests/v1/core/test_residual_sjf.py::test_residual_sjf_compares_waiting_and_skipped_waiting_globally PASSED
tests/v1/core/test_residual_sjf.py::test_residual_sjf_does_not_probe_connector_while_ranking PASSED
tests/v1/core/test_residual_sjf.py::test_residual_sjf_config_and_cli_validation PASSED
======================= 9 passed, 16 warnings in 14.03s ========================
```

Runtime (2-round means, relative to FCFS; measured on the v0.23.0-based validation harness, not yet re-measured on this main port):

| config | TTFT mean | E2E mean | req/s | TTFT P95 | server TPOT mean | server queue wait mean |
|---|---|---|---|---|---|---|
| FCFS | 12410 ms | 14861 ms | 3.94 | 16928 ms | 32.2 ms | 9691 ms |
| residual_sjf mw10 | 10101 (-18.6%) | 12618 (-15.1%) | 4.27 (+8.4%) | 16682 (-1.5%) | 33.1 (+2.8%) | 7296 (-24.7%) |
| residual_sjf mw20 | 6572 (-47.1%) | 9181 (-38.2%) | 5.15 (+30.9%) | 22066 (+30.3%) | 34.4 (+6.7%) | 4416 (-54.4%) |
| raw-length SJF mw20 (ablation, not part of this change) | 11359 (-8.5%) | 13748 (-7.5%) | 4.06 (+3.2%) | 22363 (+32.1%) | 31.4 (-2.5%) | 8624 (-11.0%) |

Notes:

- Numbers are 2-round means on one workload and are scenario-specific, not universal guarantees. `max_wait` controls the mean/tail tradeoff (documented in `docs/usage/v1_guide.md`).
- Tail (TTFT/E2E P95/P99) grows with `max_wait`; mw10 keeps the tail flat, mw20 trades ~30% P95/P99 for roughly double the mean gain.

## Documentation

- `docs/usage/v1_guide.md` updated (policy description + max-wait tradeoff guidance).

## AI Assistance

AI assistance (Codex) was used for implementation, porting, and data analysis. The submitting human reviewed every changed line and ran/confirmed the validation.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>