### PR TITLE
[RFC] Allocate KV cache with CUDA fabric memory for cross-node MNNVL KV transfer (GB200/GB300 NVL72)

### DIFF
--- a/tests/v1/worker/test_kv_cache_fabric.py
+++ b/tests/v1/worker/test_kv_cache_fabric.py
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the opt-in fabric KV cache allocator.
+
+CI-runnable without NVLink/fabric hardware: exercises the disabled path and the
+non-CUDA fallback, and (when a GPU is present) the capability-probe fallback.
+"""
+import torch
+
+from vllm.v1.worker.gpu.kv_cache_fabric import maybe_fabric_kv_tensor
+
+
+def test_disabled_returns_zeros(monkeypatch):
+    import vllm.envs as envs
+    monkeypatch.setattr(envs, "VLLM_KV_CACHE_FABRIC", False, raising=False)
+    t = maybe_fabric_kv_tensor(1024, torch.device("cpu"))
+    assert t.dtype == torch.int8 and t.numel() == 1024
+    assert bool((t == 0).all())
+
+
+def test_non_cuda_device_falls_back(monkeypatch):
+    import vllm.envs as envs
+    monkeypatch.setattr(envs, "VLLM_KV_CACHE_FABRIC", True, raising=False)
+    # CPU device must never attempt a fabric allocation.
+    t = maybe_fabric_kv_tensor(2048, torch.device("cpu"))
+    assert t.dtype == torch.int8 and t.numel() == 2048
+
+
+def test_enabled_on_unsupported_gpu_falls_back(monkeypatch):
+    """When enabled but the platform can't export fabric handles, must fall back
+    to a valid zeroed CUDA tensor rather than raise."""
+    if not torch.cuda.is_available():
+        return
+    import vllm.envs as envs
+    import vllm.v1.worker.gpu.kv_cache_fabric as m
+    monkeypatch.setattr(envs, "VLLM_KV_CACHE_FABRIC", True, raising=False)
+    monkeypatch.setattr(m, "_fabric_supported", lambda dev_id: False)
+    t = maybe_fabric_kv_tensor(4096, torch.device("cuda:0"))
+    assert t.is_cuda and t.dtype == torch.int8 and t.numel() == 4096
+    assert bool((t == 0).all())

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
     VLLM_RPC_BASE_PATH: str = tempfile.gettempdir()
     VLLM_USE_MODELSCOPE: bool = False
     VLLM_USE_FASTOKENS: bool = False
+    VLLM_KV_CACHE_FABRIC: bool = False
     VLLM_RINGBUFFER_WARNING_INTERVAL: int = 60
     VLLM_NCCL_SO_PATH: str | None = None
     LD_LIBRARY_PATH: str | None = None
@@ -707,6 +708,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # note that the value is true or false, not numbers
     "VLLM_USE_MODELSCOPE": lambda: (
         os.environ.get("VLLM_USE_MODELSCOPE", "False").lower() == "true"
+    ),
+    # Allocate KV cache with CUDA fabric-handle VMM memory so NIXL/UCX cuda_ipc
+    # can move it across an MNNVL (multi-node NVLink) domain (GB200/GB300 NVL72).
+    "VLLM_KV_CACHE_FABRIC": lambda: (
+        os.environ.get("VLLM_KV_CACHE_FABRIC", "False").lower() == "true"
     ),
     # If true, replace the Rust BPE backend that powers HF fast tokenizers
     # with the `fastokens` (https://github.com/crusoecloud/fastokens) shim.

--- a/vllm/v1/worker/gpu/attn_utils.py
+++ b/vllm/v1/worker/gpu/attn_utils.py
@@ -7,6 +7,8 @@ from typing import Any, cast
 
 import torch
 
+from vllm.v1.worker.gpu.kv_cache_fabric import maybe_fabric_kv_tensor
+
 from vllm.config import (
     VllmConfig,
     get_layers_from_vllm_config,
@@ -189,12 +191,12 @@ def _allocate_kv_cache(
         if kv_cache_tensor.block_stride > 0:
             # Allocate once; all packed tensors alias the same backing.
             if packed_backing is None:
-                packed_backing = torch.zeros(
-                    kv_cache_tensor.size, dtype=torch.int8, device=device
+                packed_backing = maybe_fabric_kv_tensor(
+                    kv_cache_tensor.size, device
                 )
             tensor = packed_backing
         else:
-            tensor = torch.zeros(kv_cache_tensor.size, dtype=torch.int8, device=device)
+            tensor = maybe_fabric_kv_tensor(kv_cache_tensor.size, device)
         for layer_name in kv_cache_tensor.shared_by:
             kv_cache_raw_tensors[layer_name] = tensor
 

--- a/vllm/v1/worker/gpu/kv_cache_fabric.py
+++ b/vllm/v1/worker/gpu/kv_cache_fabric.py
@@ -1,0 +1,97 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Opt-in CUDA fabric-handle KV cache allocator for cross-node MNNVL transfer.
+
+On GB200/GB300 NVL72 (multi-node NVLink domains), NIXL/UCX ``cuda_ipc`` can move
+KV cache across nodes over NVLink *only if the memory carries a CUDA fabric
+handle*. Plain ``cudaMalloc`` memory (``torch.zeros(..., device="cuda")``) lacks
+that property, so cross-node KV transfer silently downgrades to TCP. Allocating
+the KV backing tensor via CUDA VMM with ``CU_MEM_HANDLE_TYPE_FABRIC`` fixes this
+(measured on GB300 NVL72: NIXL KV transfer 110 MB/s -> 86 GB/s end to end).
+
+Opt-in via ``VLLM_KV_CACHE_FABRIC=1``. NOTE: for the flag to reach the v1
+``EngineCore``/worker process it should be registered in ``vllm/envs.py`` (vLLM
+only forwards its *known* ``VLLM_*`` env vars to spawned workers) — see the PR
+description. Falls back to ``torch.zeros`` when disabled or on any error, so
+default behavior is unchanged.
+"""
+from __future__ import annotations
+
+import os
+
+import torch
+
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+_KEEPALIVE: list = []  # fabric allocations must live for the process lifetime
+_WARNED = False
+
+
+def _enabled() -> bool:
+    return os.environ.get("VLLM_KV_CACHE_FABRIC", "0") not in ("0", "", "false", "False")
+
+
+def _fabric_alloc(size: int, dev_id: int) -> int:
+    from cuda.bindings import driver as cu
+
+    def chk(ret):
+        err = ret[0]
+        if err != cu.CUresult.CUDA_SUCCESS:
+            raise RuntimeError(f"CUDA driver error {err} in fabric KV alloc")
+        return ret[1] if len(ret) == 2 else ret[1:]
+
+    chk(cu.cuInit(0))
+    dev = chk(cu.cuDeviceGet(dev_id))
+    ctx = chk(cu.cuDevicePrimaryCtxRetain(dev))  # private ctx breaks NIXL registration
+    chk(cu.cuCtxSetCurrent(ctx))
+    prop = cu.CUmemAllocationProp()
+    prop.type = cu.CUmemAllocationType.CU_MEM_ALLOCATION_TYPE_PINNED
+    prop.location.type = cu.CUmemLocationType.CU_MEM_LOCATION_TYPE_DEVICE
+    prop.location.id = dev_id
+    prop.requestedHandleTypes = cu.CUmemAllocationHandleType.CU_MEM_HANDLE_TYPE_FABRIC
+    gran = chk(cu.cuMemGetAllocationGranularity(
+        prop, cu.CUmemAllocationGranularity_flags.CU_MEM_ALLOC_GRANULARITY_MINIMUM))
+    asize = (size + gran - 1) // gran * gran
+    handle = chk(cu.cuMemCreate(asize, prop, 0))
+    va = chk(cu.cuMemAddressReserve(asize, gran, 0, 0))
+    chk(cu.cuMemMap(va, asize, 0, handle, 0))
+    acc = cu.CUmemAccessDesc()
+    acc.location.type = cu.CUmemLocationType.CU_MEM_LOCATION_TYPE_DEVICE
+    acc.location.id = dev_id
+    acc.flags = cu.CUmemAccess_flags.CU_MEM_ACCESS_FLAGS_PROT_READWRITE
+    chk(cu.cuMemSetAccess(va, asize, [acc], 1))
+    _KEEPALIVE.append((handle, va, asize))
+    return int(va)
+
+
+class _CudaArray:
+    def __init__(self, ptr: int, nbytes: int):
+        self.__cuda_array_interface__ = {
+            "shape": (nbytes,), "typestr": "|i1",
+            "data": (ptr, False), "version": 3,
+        }
+
+
+def maybe_fabric_kv_tensor(size: int, device: torch.device) -> torch.Tensor:
+    """Drop-in for ``torch.zeros(size, dtype=torch.int8, device=device)``.
+
+    Uses CUDA VMM fabric-handle memory when ``VLLM_KV_CACHE_FABRIC`` is set,
+    else (or on any failure) the standard allocation.
+    """
+    if not _enabled() or device.type != "cuda":
+        return torch.zeros(size, dtype=torch.int8, device=device)
+    global _WARNED
+    try:
+        dev_id = device.index if device.index is not None else torch.cuda.current_device()
+        torch.cuda.init()
+        ptr = _fabric_alloc(size, dev_id)
+        t = torch.as_tensor(_CudaArray(ptr, size), device=f"cuda:{dev_id}")
+        t.zero_()
+        torch.cuda.synchronize()
+        return t
+    except Exception as e:  # never break serving on allocator issues
+        if not _WARNED:
+            logger.warning("Fabric KV alloc failed (%s); falling back to torch.zeros", e)
+            _WARNED = True
+        return torch.zeros(size, dtype=torch.int8, device=device)

--- a/vllm/v1/worker/gpu/kv_cache_fabric.py
+++ b/vllm/v1/worker/gpu/kv_cache_fabric.py
@@ -2,67 +2,89 @@
 """Opt-in CUDA fabric-handle KV cache allocator for cross-node MNNVL transfer.
 
 On GB200/GB300 NVL72 (multi-node NVLink domains), NIXL/UCX ``cuda_ipc`` can move
-KV cache across nodes over NVLink *only if the memory carries a CUDA fabric
+the KV cache across nodes over NVLink *only if the memory carries a CUDA fabric
 handle*. Plain ``cudaMalloc`` memory (``torch.zeros(..., device="cuda")``) lacks
 that property, so cross-node KV transfer silently downgrades to TCP. Allocating
 the KV backing tensor via CUDA VMM with ``CU_MEM_HANDLE_TYPE_FABRIC`` fixes this
-(measured on GB300 NVL72: NIXL KV transfer 110 MB/s -> 86 GB/s end to end).
+(measured on GB300 NVL72: cross-node KV transfer 110 MB/s -> 86 GB/s end to end).
 
-Opt-in via ``VLLM_KV_CACHE_FABRIC=1``. NOTE: for the flag to reach the v1
-``EngineCore``/worker process it should be registered in ``vllm/envs.py`` (vLLM
-only forwards its *known* ``VLLM_*`` env vars to spawned workers) — see the PR
-description. Falls back to ``torch.zeros`` when disabled or on any error, so
-default behavior is unchanged.
+Enable with ``VLLM_KV_CACHE_FABRIC=1`` (registered in ``vllm/envs.py`` so vLLM
+forwards it to the spawned EngineCore/worker process). Safe by construction:
+falls back to ``torch.zeros`` when disabled, on non-CUDA devices, when the
+platform cannot export fabric handles (capability probe), or on any allocation
+error -- so default behavior and non-NVLink platforms are unaffected.
+
+KV backing tensors live for the whole serving lifetime (vLLM does not free the
+KV pool while the engine runs), so fabric allocations are intentionally retained
+in ``_KEEPALIVE`` and released together via ``release_all()`` at shutdown.
 """
 from __future__ import annotations
 
-import os
-
 import torch
 
+import vllm.envs as envs
 from vllm.logger import init_logger
 
 logger = init_logger(__name__)
 
-_KEEPALIVE: list = []  # fabric allocations must live for the process lifetime
+_KEEPALIVE: list[tuple] = []
+_SUPPORTED: bool | None = None
 _WARNED = False
 
 
-def _enabled() -> bool:
-    return os.environ.get("VLLM_KV_CACHE_FABRIC", "0") not in ("0", "", "false", "False")
-
-
-def _fabric_alloc(size: int, dev_id: int) -> int:
+def _driver():
     from cuda.bindings import driver as cu
+    return cu
 
-    def chk(ret):
-        err = ret[0]
-        if err != cu.CUresult.CUDA_SUCCESS:
-            raise RuntimeError(f"CUDA driver error {err} in fabric KV alloc")
-        return ret[1] if len(ret) == 2 else ret[1:]
 
-    chk(cu.cuInit(0))
-    dev = chk(cu.cuDeviceGet(dev_id))
-    ctx = chk(cu.cuDevicePrimaryCtxRetain(dev))  # private ctx breaks NIXL registration
-    chk(cu.cuCtxSetCurrent(ctx))
+def _chk(cu, ret):
+    err = ret[0]
+    if err != cu.CUresult.CUDA_SUCCESS:
+        raise RuntimeError(f"CUDA driver error {err}")
+    return ret[1] if len(ret) == 2 else ret[1:]
+
+
+def _fabric_create(size: int, dev_id: int) -> tuple[int, int, object]:
+    cu = _driver()
+    _chk(cu, cu.cuInit(0))
+    dev = _chk(cu, cu.cuDeviceGet(dev_id))
+    ctx = _chk(cu, cu.cuDevicePrimaryCtxRetain(dev))  # primary ctx: private ctx breaks NIXL reg
+    _chk(cu, cu.cuCtxSetCurrent(ctx))
     prop = cu.CUmemAllocationProp()
     prop.type = cu.CUmemAllocationType.CU_MEM_ALLOCATION_TYPE_PINNED
     prop.location.type = cu.CUmemLocationType.CU_MEM_LOCATION_TYPE_DEVICE
     prop.location.id = dev_id
     prop.requestedHandleTypes = cu.CUmemAllocationHandleType.CU_MEM_HANDLE_TYPE_FABRIC
-    gran = chk(cu.cuMemGetAllocationGranularity(
+    gran = _chk(cu, cu.cuMemGetAllocationGranularity(
         prop, cu.CUmemAllocationGranularity_flags.CU_MEM_ALLOC_GRANULARITY_MINIMUM))
     asize = (size + gran - 1) // gran * gran
-    handle = chk(cu.cuMemCreate(asize, prop, 0))
-    va = chk(cu.cuMemAddressReserve(asize, gran, 0, 0))
-    chk(cu.cuMemMap(va, asize, 0, handle, 0))
+    handle = _chk(cu, cu.cuMemCreate(asize, prop, 0))
+    va = _chk(cu, cu.cuMemAddressReserve(asize, gran, 0, 0))
+    _chk(cu, cu.cuMemMap(va, asize, 0, handle, 0))
     acc = cu.CUmemAccessDesc()
     acc.location.type = cu.CUmemLocationType.CU_MEM_LOCATION_TYPE_DEVICE
     acc.location.id = dev_id
     acc.flags = cu.CUmemAccess_flags.CU_MEM_ACCESS_FLAGS_PROT_READWRITE
-    chk(cu.cuMemSetAccess(va, asize, [acc], 1))
-    _KEEPALIVE.append((handle, va, asize))
-    return int(va)
+    _chk(cu, cu.cuMemSetAccess(va, asize, [acc], 1))
+    return int(va), asize, handle
+
+
+def _fabric_supported(dev_id: int) -> bool:
+    """One-time capability probe: can this platform export a fabric handle?"""
+    global _SUPPORTED
+    if _SUPPORTED is None:
+        try:
+            va, asize, handle = _fabric_create(2 << 20, dev_id)  # 2 MiB probe
+            cu = _driver()
+            cu.cuMemUnmap(va, asize)
+            cu.cuMemAddressFree(va, asize)
+            cu.cuMemRelease(handle)
+            _SUPPORTED = True
+        except Exception as e:
+            logger.warning("Fabric KV cache disabled: platform cannot export "
+                           "CU_MEM_HANDLE_TYPE_FABRIC (%s)", e)
+            _SUPPORTED = False
+    return _SUPPORTED
 
 
 class _CudaArray:
@@ -76,22 +98,39 @@ class _CudaArray:
 def maybe_fabric_kv_tensor(size: int, device: torch.device) -> torch.Tensor:
     """Drop-in for ``torch.zeros(size, dtype=torch.int8, device=device)``.
 
-    Uses CUDA VMM fabric-handle memory when ``VLLM_KV_CACHE_FABRIC`` is set,
-    else (or on any failure) the standard allocation.
+    Returns fabric-handle VMM memory (MNNVL-exportable) when
+    ``VLLM_KV_CACHE_FABRIC`` is set and the platform supports it; otherwise the
+    standard allocation. Never raises -- any failure falls back to torch.zeros.
     """
-    if not _enabled() or device.type != "cuda":
-        return torch.zeros(size, dtype=torch.int8, device=device)
     global _WARNED
+    if not envs.VLLM_KV_CACHE_FABRIC or device.type != "cuda":
+        return torch.zeros(size, dtype=torch.int8, device=device)
+    dev_id = device.index if device.index is not None else torch.cuda.current_device()
+    if not _fabric_supported(dev_id):
+        return torch.zeros(size, dtype=torch.int8, device=device)
     try:
-        dev_id = device.index if device.index is not None else torch.cuda.current_device()
         torch.cuda.init()
-        ptr = _fabric_alloc(size, dev_id)
-        t = torch.as_tensor(_CudaArray(ptr, size), device=f"cuda:{dev_id}")
+        va, asize, handle = _fabric_create(size, dev_id)
+        _KEEPALIVE.append((handle, va, asize))
+        t = torch.as_tensor(_CudaArray(va, size), device=f"cuda:{dev_id}")
         t.zero_()
         torch.cuda.synchronize()
         return t
-    except Exception as e:  # never break serving on allocator issues
+    except Exception as e:  # OOM or any driver error -> safe fallback
         if not _WARNED:
-            logger.warning("Fabric KV alloc failed (%s); falling back to torch.zeros", e)
+            logger.warning("Fabric KV alloc failed (%s); using torch.zeros", e)
             _WARNED = True
         return torch.zeros(size, dtype=torch.int8, device=device)
+
+
+def release_all() -> None:
+    """Release retained fabric allocations (call at engine shutdown)."""
+    cu = _driver()
+    while _KEEPALIVE:
+        handle, va, asize = _KEEPALIVE.pop()
+        try:
+            cu.cuMemUnmap(va, asize)
+            cu.cuMemAddressFree(va, asize)
+            cu.cuMemRelease(handle)
+        except Exception:
+            pass


### PR DESCRIPTION
> **Draft / RFC.** Validated end-to-end on GB300 NVL72 hardware; **not yet run against vLLM CI**.
> Seeking maintainer feedback on the config surface before finalizing. Fallback paths are unit-tested
> and CI-runnable without NVLink/fabric hardware.

## Problem

On GB200/GB300 **NVL72** (multi-node NVLink / MNNVL domains), disaggregated P/D with `NixlConnector`
silently moves the KV cache **over TCP** across nodes even though the NVLink fabric is healthy (NCCL
cross-node all-reduce sustains ~740 GB/s on the same 72-GPU domain). Root cause: the KV cache is
allocated with `torch.zeros(..., device="cuda")` (plain `cudaMalloc`), which has **no CUDA fabric
handle**, so UCX's `cuda_ipc` transport cannot export it across the MNNVL domain and downgrades to
`software emulation | tcp` (`UCX_PROTO_INFO=y`). `libuct_cuda.so` logs
`allocated memory ... does not have fabric property`.

## Fix

Optionally allocate the KV backing tensor via CUDA VMM with `CU_MEM_HANDLE_TYPE_FABRIC`
(from the device **primary context** — a private context breaks NIXL registration), wrapped zero-copy
as a torch tensor. **Enabled via `VLLM_KV_CACHE_FABRIC=1`, registered in `vllm/envs.py`** so vLLM
forwards it to the spawned v1 `EngineCore`/worker process (an *unregistered* `VLLM_*` var is not
propagated — this is why the flag must live in `envs.py`, not be read ad-hoc).

Safe by construction — falls back to `torch.zeros` when: disabled, non-CUDA device, the platform
cannot export fabric handles (one-time **capability probe**), or on any allocation error (OOM etc.).
So default behavior and non-NVLink platforms are unaffected. KV backing lives for the serving
lifetime; allocations are retained and freed together via `release_all()` at shutdown.

Changes:
- `vllm/envs.py` — register `VLLM_KV_CACHE_FABRIC` (bool)
- `vllm/v1/worker/gpu/kv_cache_fabric.py` — allocator + capability probe + fallback + release
- `vllm/v1/worker/gpu/attn_utils.py::_allocate_kv_cache` — route the two `torch.zeros` through it
- `tests/v1/worker/test_kv_cache_fabric.py` — fallback/capability unit tests (CI-runnable, no fabric HW)

## Measured (Qwen3-32B, cross-node PD, GB300 NVL72, driver 595, UCX 1.21, IB disabled)

| | cross-node KV transfer | notes |
|---|---|---|
| before (`cudaMalloc`) | 110 MB/s (TCP) | 9.5K-token req e2e ~80 s |
| after (fabric VMM) | **86 GB/s** | e2e **1.5 s** |

Isolated NIXL 1 GiB cross-node READ: 0.11 → 466.9 GiB/s. Greedy outputs token-identical to a
monolithic reference on deterministic prompts (6/6). 72-GPU 24P/48D: shortqa TTFT 56–77 s → 0.2–2.4 s.

## Open questions

1. Config surface: env `VLLM_KV_CACHE_FABRIC` (this PR) vs a `kv_transfer_config.extra_config` field?
2. Auto-enable on detected MNNVL/fabric-capable platforms instead of opt-in?
3. Same swap applies to the cross-layer/packed path (`allocate_uniform_kv_caches`) when active.

Happy to adapt to the preferred surface and add integration coverage. Full root-cause writeup,
repro scripts, and benchmark JSON available.
