### PR TITLE
[RFC][Reload] Replace layerwise weight transfer with modelwise transactions

### DIFF
--- a/docs/design/model_load_weights_reload_experiment.md
+++ b/docs/design/model_load_weights_reload_experiment.md
@@ -1,0 +1,320 @@
+# `model.load_weights()` 直接 Reload 可行性实验
+
+## 1. 问题定义
+
+本文只回答一个问题：
+
+> 模型完成首次加载和 PWAL、已经进入 serving 状态后，是否可以只调用一次
+> `model.load_weights(checkpoint_weights)` 完成权重更新？
+
+这里的“直接调用”严格指：
+
+```python
+model.load_weights(checkpoint_weights)
+```
+
+并且**不执行**：
+
+- checkpoint schema 恢复；
+- layerwise/modelwise reload prepare；
+- `process_weights_after_loading`（PWAL）；
+- runtime storage copy-back；
+- derived state 重建。
+
+这个定义非常重要。此前名称为 `direct_reload_smoke.py` 的脚本实际调用的是：
+
+```python
+self.model_runner.reload_weights(weights_path=path)
+```
+
+它走了完整 reload 流程，并不是直接调用运行态模型的
+`model.load_weights()`。因此不能把该脚本的成功结果当作“直接 load_weights
+成功”的证据。
+
+## 2. 总结
+
+| 模型运行态 | 只调用运行态 `model.load_weights()` | 结论 |
+|---|---:|---|
+| 普通 BF16 dense，运行态 schema 未被改变 | 理论上可以 | 尚无独立端到端实验结果 |
+| 普通 BF16 MoE，运行态 expert schema 未被改变 | 理论上可以 | 尚无独立端到端实验结果 |
+| BF16 MLA | 不完整 | checkpoint 参数会更新，但 MLA 派生权重不会自动重建 |
+| 在线 FP8/INT8/MXFP8 | 不可以 | runtime 权重已经量化，shape/dtype/loader 语义不是 BF16 checkpoint schema |
+| GPTQ/AWQ/Marlin 等需要 repack 的 checkpoint 量化 | 通常不可以 | 首次 PWAL 后参数已转换为 kernel layout |
+| compressed-tensors 等带 packed/scale 派生状态的量化 | 通常不可以 | 运行态 schema 与 checkpoint schema 不同，且需要重新 PWAL |
+| 已经是最终 runtime/kernel format 的权重 | 可以原位更新 | 应走按 runtime tensor 名称的 `copy_`，不是 checkpoint `model.load_weights()` |
+
+截至 2026-08-07，已有端到端实验真正证明的是：
+
+> 恢复 checkpoint schema 后，可以使用一次或多次 `model.load_weights()` 加载
+> checkpoint 权重，再统一执行 PWAL 并提交回原 runtime storage。
+
+实验没有证明所有模型都能对**已经完成 PWAL 的运行态模型**只调用
+`model.load_weights()`。
+
+## 3. 判断标准
+
+直接 reload 是否成立，不应简单按“量化/非量化”划分，而应检查下面三个条件。
+
+### 3.1 当前 Parameter/Buffer 是否仍是 checkpoint schema
+
+`model.load_weights()` 的职责是：
+
+- checkpoint 名称映射；
+- TP/EP shard；
+- QKV 和 gate/up fusion；
+- 调用 parameter 的 `weight_loader`；
+- 将输入权重写入模型当前暴露的加载目标。
+
+如果首次加载和 PWAL 没有改变 Parameter/Buffer 的 shape、dtype、layout 和 loader
+语义，那么直接再次调用 `model.load_weights()` 有可能成立。
+
+如果 PWAL 已经把 BF16 checkpoint 参数替换为 FP8、INT8、INT4、Marlin packed
+权重或 scale，那么当前模型不再是 checkpoint schema，直接加载就不成立。
+
+### 3.2 Forward 是否只读取 Parameter/Buffer
+
+有些模型在 PWAL 中根据 checkpoint 参数生成普通 tensor attribute 或其他派生状态。
+这些对象不一定出现在：
+
+```python
+model.named_parameters()
+model.named_buffers()
+model.state_dict()
+```
+
+再次调用 `model.load_weights()` 只会更新加载目标，不会自动刷新这些派生状态。
+
+### 3.3 更新后是否还需要 PWAL
+
+如果 forward 使用的权重需要量化、repack、transpose、scale 生成或模型级派生，
+那么 `model.load_weights()` 只是“加载 checkpoint”的中间步骤，不是完整 reload。
+
+## 4. 各类流程分析
+
+### 4.1 普通 BF16 Dense
+
+候选流程：
+
+```text
+BF16 checkpoint
+    -> model.load_weights()
+    -> BF16 fused/sharded Parameter
+    -> forward
+```
+
+如果模型首次加载后：
+
+- 参数仍为 BF16；
+- 参数 shape 和 loader 没有被 PWAL 改变；
+- forward 不依赖额外派生权重；
+
+那么 `model.load_weights()` 可通过现有 weight loader 覆盖 QKV fusion、gate/up
+fusion 和 TP shard 对应的目标切片，理论上不需要 quant PWAL。
+
+**实验状态：未形成有效的独立直接调用实验结论。**
+
+此前安排过 Qwen dense BF16 的直接验证，但任务在模型测试启动前被中断，没有生成
+模型加载日志、pytest 结果或推理对比。因此目前应标为“候选支持”，而不是“已验证
+通过”。
+
+### 4.2 普通 BF16 MoE
+
+候选流程：
+
+```text
+BF16 expert checkpoint tensors
+    -> model.load_weights()
+    -> fused expert Parameter slices
+    -> forward
+```
+
+MoE 的 expert 名称映射、EP shard 和 fused expert slice 本来就由模型
+`load_weights()`/expert weight loader 负责。如果首次加载后 expert Parameter schema
+没有改变，直接调用理论上可以覆盖目标 slice。
+
+但以下情况仍需要额外处理：
+
+- expert kernel 在 PWAL 中生成新的 packed layout；
+- scale、transpose 或 workspace tensor 由首次加载派生；
+- forward 使用不在 named parameters/buffers 中的派生 tensor。
+
+**实验状态：未形成有效的独立直接调用实验结论。**
+
+此前 MoE 直接验证尚未启动，因此不能将完整 `reload_weights()` 的成功结果归因于
+直接 `model.load_weights()`。
+
+### 4.3 BF16 MLA
+
+直接调用不完整。
+
+MLA 在 `process_weights_after_loading()` 中会从 `kv_b_proj` 等权重派生 forward
+使用的运行时 tensor，例如：
+
+```text
+W_UK_T
+W_UV
+```
+
+某些实现还会生成复制、聚合或 backend 专用状态。这些状态可能只是普通 tensor
+attribute，而不是 checkpoint Parameter/Buffer。
+
+直接再次调用：
+
+```python
+model.load_weights(new_checkpoint)
+```
+
+可以更新 `kv_b_proj`，但不会自动重建已经存在的 `W_UK_T/W_UV`。forward 仍可能
+读取旧派生权重。
+
+因此 BF16 并不保证可以直接 reload；MLA 至少还需要模型级 post-load hook。
+
+### 4.4 在线 FP8、INT8 和 MXFP8
+
+直接调用不可以。
+
+以 BF16 checkpoint 到在线 FP8 为例，首次加载是：
+
+```text
+BF16 checkpoint Parameter
+    -> model.load_weights()
+    -> FP8 PWAL
+    -> FP8 weight + scale + kernel runtime layout
+```
+
+完成 PWAL 后，运行态模型暴露的是 FP8 权重及 scale，而 trainer 发送的是 BF16
+checkpoint tensor。二者可能存在：
+
+- dtype 不一致；
+- shape 或 padding 不一致；
+- Parameter 已被替换；
+- 原 checkpoint weight loader 已被转换或解包；
+- scale 和 packed tensor 尚未生成。
+
+所以不能把 BF16 checkpoint 直接加载进当前 FP8 runtime Parameter。正确流程必须
+先恢复 BF16 checkpoint schema，再调用 `model.load_weights()`，最后重新运行 PWAL。
+
+在线 `fp8_per_tensor`、`fp8_per_block`、`fp8_per_channel`、
+`int8_per_channel_weight_only` 和在线 `mxfp8` 都属于这一类。
+
+### 4.5 GPTQ、AWQ、Marlin 和 Compressed Tensors
+
+这些格式通常也不能保证对运行态模型直接调用 `model.load_weights()`。
+
+原因不是它们都采用同一种量化方式，而是首次加载后可能执行：
+
+```text
+checkpoint qweight/scales/zeros
+    -> shard/fuse
+    -> repack/transpose/padding
+    -> Marlin 或其他 kernel layout
+    -> runtime Parameter/Buffer
+```
+
+再次输入的是 checkpoint-format tensor，而加载目标已经是 kernel-format tensor。
+如果没有恢复 checkpoint schema并重新执行 PWAL/repack，就可能发生：
+
+- shape/dtype 不匹配；
+- loader 找不到原 checkpoint 目标；
+- checkpoint 数据被写入错误 layout；
+- weight 更新但 scale/zero/derived packed state 仍是旧值。
+
+我们验证过 GPTQ、GPTQ-Marlin、compressed-tensors FP8/W4A16/W4A8 的完整
+modelwise reload 能通过，但这证明的是“恢复 schema + load_weights + PWAL”有效，
+不是“直接 load_weights”有效。
+
+### 4.6 Runtime/Kernel Format 更新
+
+如果发送侧提供的已经是 receiver 当前使用的最终 tensor：
+
+```text
+名称一致 + shape 一致 + dtype 一致 + layout 一致
+```
+
+则可以直接：
+
+```python
+runtime_tensor.copy_(received_tensor)
+```
+
+这种路径无需 checkpoint `model.load_weights()`，也无需重新量化。但发送侧必须准确
+生成各 rank 的 TP/EP shard、fused layout、packed weight 和 scale，通用性较差。
+
+## 5. 实际通过的实验是什么
+
+已有实验使用的是下列流程，而不是裸 `model.load_weights()`：
+
+```text
+start
+    -> 保存 runtime Parameter/Buffer 与 storage
+    -> 恢复 checkpoint schema
+
+update(chunk) × N
+    -> model.load_weights(chunk)
+    -> 不运行 PWAL
+    -> 不使用 numel 判断完成
+
+finish
+    -> 全模型 PWAL
+    -> 校验 runtime shape/dtype
+    -> copy 回原 runtime storage
+    -> 恢复原 binding
+    -> 清空 prefix cache
+```
+
+以下量化流程通过了该完整 modelwise reload：
+
+| 流程 | 完整 modelwise reload 结果 | 为什么不能据此声称裸 `load_weights()` 可用 |
+|---|---:|---|
+| 在线 FP8 per-tensor | Pass | 实验先恢复 BF16 schema，finish 时重新量化 |
+| 在线 FP8 per-block | Pass | 同上 |
+| 在线 FP8 per-channel | Pass | 同上 |
+| 在线 INT8 weight-only | Pass | finish 时重新生成 INT8 runtime 权重 |
+| 在线 MXFP8 | Pass | finish 时重新生成 runtime 格式 |
+| compressed-tensors FP8 block | Pass | 重新执行 checkpoint load 和 PWAL |
+| compressed-tensors W4A16 | Pass | 重新执行 packed/quant post-processing |
+| compressed-tensors W4A8 MoE | Pass | 重新执行 expert quant post-processing |
+| GPTQ/AutoGPTQ/GPTQ-Marlin | Pass | 恢复 checkpoint schema 后重新 repack |
+| experts INT8 MoE | Pass | 恢复 BF16 expert schema后重新量化 |
+
+在线 FP8 per-tensor 还通过了以下传输实验：
+
+| 后端 | 分块方式 | 结果 |
+|---|---|---:|
+| CUDA IPC | 四次 partial update | Pass |
+| NCCL | 四次 partial update | Pass |
+| CUDA IPC | 384 MiB packed buffer，三个 chunks | Pass |
+| NCCL | 一次 update API，内部三个 packed chunks | Pass |
+
+四组实验都在 finish 前保持 BF16 checkpoint schema，只在 finish 执行一次 PWAL，
+最终推理 token 与冷加载一致，且 runtime storage identity 不变。
+
+## 6. 失败或受限的量化项
+
+以下结果也不能解释为 reload 本身失败：
+
+| 项目 | 状态 | 原因 |
+|---|---|---|
+| 较老 TinyLlama compressed-tensors W4A8 | 初始加载失败 | checkpoint 含未注册的 `weight_chan_scale` 目标 |
+| Humming | 环境受限 | 初始 PWAL 的 NVRTC 编译失败 |
+| bitsandbytes | 未测试 | 当前离线环境没有依赖，未下载或安装 |
+| TorchAO | 未测试 | 当前离线环境没有依赖，未下载或安装 |
+| ModelOpt/Quark | 未测试 | 没有兼容的本地 checkpoint |
+| MXFP4/GPT-OSS MXFP4 | 环境受限 | FlashInfer JIT 缺少 `cublasLt.h` |
+| FP-Quant | 硬件不支持 | 要求 Blackwell，H200 compute capability 不满足 |
+
+这些项目没有到达“对运行态模型直接调用 `model.load_weights()`”的实验阶段。
+
+## 7. 最终结论
+
+最准确的结论不是“量化模型不支持 `model.load_weights()`”，而是：
+
+1. `model.load_weights()` 只负责把 checkpoint tensor 写入**当前模型结构**。
+2. 如果当前运行态结构仍等于 checkpoint schema，并且没有派生状态，直接调用可能
+   足够；普通 BF16 dense/MoE 属于候选，但尚缺独立端到端验证。
+3. 如果首次 PWAL 改变了权重 dtype、shape、layout 或生成了派生 tensor，直接调用
+   不足；在线量化、repack 量化和 MLA 属于这一类。
+4. 已验证的通用方案是由 `ModelwiseReloadSession` 恢复 checkpoint schema，然后
+   调用一次或多次 `model.load_weights()`，最后统一 PWAL 并原位提交。
+5. packed chunk、partial update 和 tensor `numel` 都不应被当作模型更新完成边界；
+   `finish_weight_update()` 才是唯一提交信号。

--- a/docs/design/modelwise_reload.md
+++ b/docs/design/modelwise_reload.md
@@ -1,0 +1,931 @@
+# Modelwise Weight Reload 完整方案
+
+## 1. 背景与目标
+
+vLLM 的 checkpoint 权重与 serving 时 kernel 实际使用的权重不一定是同一种表示。
+一次初始加载可能经过：
+
+```text
+checkpoint tensor
+    -> 模型名称映射
+    -> TP/EP shard
+    -> QKV、gate/up、expert fusion
+    -> padding、transpose、layout conversion
+    -> quantization、scale 生成、repack
+    -> MLA/Attention/HPC 派生状态生成
+    -> runtime/kernel tensor
+```
+
+因此，在线 reload 不能简单地把新的 checkpoint tensor `copy_` 到当前 runtime
+Parameter。尤其是在线 FP8、INT8、GPTQ-Marlin、compressed-tensors 和 MLA：
+
+- checkpoint 与 runtime 的 shape、dtype 或 layout 可能不同；
+- PWAL 可能替换 Parameter/Buffer；
+- forward 可能读取由 PWAL 生成的普通 tensor attribute；
+- CUDA Graph 和 kernel 可能要求 runtime storage 地址保持不变。
+
+旧 layerwise reload 将上述转换按 layer 分割，并通过 tensor 数量或 `numel` 推断
+每层何时加载完成。这导致正确性依赖：
+
+- checkpoint 顺序；
+- layer 边界；
+- fused tensor 的计数方式；
+- padding 和 shard 后的元素数；
+- 一个 layer 是否包含额外的 derived state；
+- packed buffer 是否恰好跨越 layer 边界。
+
+Modelwise Reload 的目标是：
+
+1. 继续使用每个模型原生的 `model.load_weights()`。
+2. 将 checkpoint 到 runtime 的转换作为一个模型级事务。
+3. 支持一次或多次 partial/packed weight update。
+4. 只以显式 `finish` 作为完成边界，不使用 `numel`。
+5. 统一执行 quant、Attention、MLA 和 HPC 的 PWAL。
+6. commit 后保持原 runtime Parameter、Buffer 和 storage 地址不变。
+7. 接收失败时恢复旧模型，不提交半成品权重。
+
+## 2. 核心设计
+
+Modelwise Reload 同时维护两套 tensor schema：
+
+```text
+Checkpoint schema
+    model.load_weights() 能够加载的原始 Parameter/Buffer 结构
+
+Runtime schema
+    PWAL 后 serving kernel 实际读取的 Parameter/Buffer 结构
+```
+
+模型初始化后、首次 checkpoint 加载前记录 checkpoint schema。执行 reload 时：
+
+```text
+1. 保存当前 runtime bindings。
+2. 临时恢复 checkpoint bindings。
+3. 一次或多次调用 model.load_weights(chunk)。
+4. 显式 finish 时执行全模型 PWAL。
+5. 校验处理后的 runtime schema。
+6. 将处理结果 copy 回原 runtime storage。
+7. 恢复原 runtime bindings。
+```
+
+Modelwise Reload 不尝试让运行态模型直接接收 checkpoint 权重，而是临时把模型恢复
+为 `model.load_weights()` 所期望的结构。
+
+## 3. 总体架构
+
+```mermaid
+flowchart TD
+    A[initialize_model] --> B[构造 checkpoint schema]
+    B --> C[record_modelwise_reload_metadata]
+    C --> D[首次 model.load_weights]
+    D --> E[首次 PWAL]
+    E --> F[Serving runtime schema]
+
+    F --> G[start / ModelwiseReloadSession.start]
+    G --> H[保存 runtime bindings]
+    H --> I[恢复并 materialize checkpoint bindings]
+    I --> J[update chunk 0]
+    J --> K[model.load_weights]
+    K --> L{还有 chunk?}
+    L -- 是 --> M[update chunk N]
+    M --> K
+    L -- 否 --> N[finish]
+    N --> O[全模型 PWAL force=True]
+    O --> P[捕获 processed runtime schema]
+    P --> Q[校验 shape/dtype]
+    Q --> R[copy 到旧 runtime storage]
+    R --> S[恢复原 runtime bindings]
+    S --> T[清空 prefix/MM/encoder cache]
+    T --> F
+```
+
+### 3.1 数据平面与控制平面
+
+```text
+控制平面
+LLM / AsyncLLM
+    -> GPUWorker
+        -> WeightTransferEngine
+            -> ModelwiseReloadSession
+
+数据平面
+filesystem / NCCL / CUDA IPC
+    -> Iterable[(checkpoint_name, tensor)]
+        -> ModelwiseReloadSession.load_weights()
+            -> model.load_weights()
+                -> Parameter.weight_loader()
+```
+
+传输后端只负责产生 checkpoint tensor；模型仍负责名称映射、分片和融合。
+
+## 4. 模块介绍
+
+### 4.1 `record_modelwise_reload_metadata`
+
+位置：
+
+```text
+vllm/model_executor/model_loader/reload/modelwise.py
+```
+
+调用时机：
+
+```text
+模型构造完成
+    -> 首次 checkpoint load 之前
+    -> 首次 PWAL 之前
+```
+
+入口位于 `initialize_model()`：
+
+```python
+model = model_class(...)
+record_modelwise_reload_metadata(model)
+return model
+```
+
+它记录的是 checkpoint tensor binding graph，而不是 tensor 数值。每个 entry 包含：
+
+- module path；
+- attribute name；
+- Parameter 或 Buffer 类型；
+- `None` slot；
+- shape、stride、dtype、device-independent meta representation；
+- tensor subclass；
+- `weight_loader` 及自定义属性；
+- tied/shared tensor alias；
+- Buffer persistence。
+
+真实权重被转换为 meta tensor，避免永久保留一份 BF16 checkpoint 权重。
+
+#### 非持久 Buffer
+
+非持久 Buffer 不属于 checkpoint，不记录也不替换，例如：
+
+```text
+rotary_emb.cos_sin_cache
+```
+
+这类 Buffer 在整个 reload 中保持原 binding。否则构造阶段的未初始化 cache 可能覆盖
+当前有效 runtime cache，造成权重 checksum 正确但推理错误。
+
+#### Alias
+
+通过原 tensor identity 去重：
+
+```text
+embed_tokens.weight ─┐
+                     ├─ 同一个 metadata entry
+lm_head.weight ──────┘
+```
+
+恢复 checkpoint schema 时仍会注册同一个 Parameter 对象。
+
+#### Metadata 生命周期
+
+metadata 保存于：
+
+```python
+WeakKeyDictionary[model, _ModelMetadata]
+```
+
+模型被销毁后 metadata 可自动释放，不形成全局强引用。
+
+### 4.2 `_ModelMetadata`
+
+描述 checkpoint schema：
+
+```python
+@dataclass(frozen=True)
+class _ModelMetadata:
+    parameters: dict[(module_path, name), _TensorMetadata]
+    buffers: dict[(module_path, name), _TensorMetadata]
+    restore_device: torch.device
+```
+
+其中 `_TensorMetadata.tensor` 是 meta tensor 或 `None`。
+
+### 4.3 `_RuntimeBindings`
+
+描述事务开始时 serving 模型的当前 binding：
+
+```python
+@dataclass(frozen=True)
+class _RuntimeBindings:
+    parameters: dict[(module_path, name), Tensor | None]
+    buffers: dict[(module_path, name), Tensor | None]
+    buffer_persistence: dict[(module_path, name), bool]
+```
+
+这里保存真实 runtime 对象的强引用，保证 reload 期间：
+
+- runtime tensor 不被释放；
+- finish 后能够恢复原 Python object；
+- 能够向原 storage 原位提交；
+- CUDA Graph/kernel 持有的地址仍然有效。
+
+### 4.4 `_restore_checkpoint_bindings`
+
+职责：将模型从 runtime schema 临时重绑为 checkpoint schema。
+
+```mermaid
+flowchart LR
+    A[FP8 runtime weight] --> B[保存到 RuntimeBindings]
+    C[FP32 runtime scale] --> B
+    B --> D[清除当前 Parameter/持久 Buffer binding]
+    E[Checkpoint metadata] --> F[克隆 meta Parameter/Buffer]
+    F --> G[恢复 tied alias]
+    G --> H[移除 online_process_loader wrapper]
+    H --> I[register_parameter/register_buffer]
+    D --> I
+    I --> J[BF16 checkpoint schema]
+```
+
+具体步骤：
+
+1. 建立 `module_path -> module` 索引。
+2. 删除当前 runtime Parameter 和持久 Buffer binding。
+3. 保留 non-persistent runtime Buffer。
+4. 从 metadata 克隆 checkpoint meta tensor。
+5. 恢复共享 Parameter/Buffer alias。
+6. 将 `online_process_loader` 解包为原 checkpoint loader。
+7. 重新执行 `register_parameter()`/`register_buffer()`。
+
+此阶段不加载权重值，也不运行 PWAL。
+
+### 4.5 `_materialize_checkpoint_bindings`
+
+metadata 中的 tensor 位于 meta device，没有实际 storage。该模块在 reload start 时按
+目标 device 分配临时 checkpoint storage：
+
+```text
+BF16 meta Parameter
+    -> BF16 CUDA/CPU Parameter with storage
+```
+
+共享 tensor 只 materialize 一次，所有 alias 继续指向同一个对象。
+
+### 4.6 `ModelwiseReloadSession`
+
+这是核心事务对象，状态机为：
+
+```mermaid
+stateDiagram-v2
+    [*] --> Inactive
+    Inactive --> Loading: start()
+    Loading --> Loading: load_weights(chunk)
+    Loading --> Committing: finish()
+    Committing --> Inactive: PWAL + validate + copy-back + restore
+    Loading --> Inactive: abort()
+    Loading --> Inactive: receive/load exception -> abort()
+```
+
+#### `start()`
+
+执行：
+
+```text
+检查没有活动事务
+    -> 获取 checkpoint metadata
+    -> capture runtime bindings
+    -> 禁止 TorchAO 特殊 reload 分支
+    -> restore checkpoint bindings
+    -> materialize checkpoint tensors
+```
+
+start 完成后，serving runtime tensor 仍被 `_RuntimeBindings` 持有，但 model tree 当前
+暴露的是 checkpoint tensor。
+
+事务期间必须暂停或隔离推理，因为 forward 不能消费尚未 PWAL 的 checkpoint schema。
+
+#### `load_weights(weights)`
+
+直接调用：
+
+```python
+loaded = self.model.load_weights(weights)
+```
+
+允许执行任意次数：
+
+```python
+session.load_weights(chunk_0)
+session.load_weights(chunk_1)
+session.load_weights(chunk_2)
+```
+
+该阶段：
+
+- 不运行 PWAL；
+- 不进行 layer finalization；
+- 不统计 `numel`；
+- 不假设 tensor 顺序；
+- 不把 packed buffer 边界视为完成边界。
+
+返回的 loaded name 仅用于日志和诊断，不用于决定事务是否完成。
+
+#### `finish()`
+
+执行一次模型级 commit：
+
+```text
+process_weights_after_loading(force=True)
+    -> capture processed bindings
+    -> validate processed schema against runtime schema
+    -> copy processed values to old runtime storage
+    -> restore old runtime bindings
+```
+
+无论 PWAL、校验还是 copy 是否抛异常，`finally` 都会恢复 runtime binding。
+
+#### `abort()`
+
+不运行 PWAL、不 copy-back，只恢复事务开始时的 runtime binding。因此接收失败不会
+提交临时 checkpoint tensor。
+
+### 4.7 `ModelwiseReloader`
+
+提供单次文件系统 reload 的便捷封装：
+
+```python
+session.start()
+try:
+    session.load_weights(weights)
+    session.finish()
+except:
+    session.abort()
+    raise
+```
+
+调用点位于 `GPUModelRunner.reload_weights()` 的 checkpoint-format 分支。
+
+### 4.8 `process_weights_after_loading(force=True)`
+
+finish 阶段统一处理三类 post-load 状态：
+
+```text
+第一阶段：QuantizeMethodBase
+    FP8/INT8 quantization
+    GPTQ/Marlin/compressed-tensors repack
+    scale、zero、packed layout 生成
+
+第二阶段：Attention/MLAAttention/MMEncoderAttention
+    Attention 后处理
+    MLA derived weights
+    encoder attention runtime state
+
+第三阶段：HpcModule
+    HpcRopeNorm 等模型/后端专用状态
+```
+
+`force=True` 会移除首次加载留下的 “already processed” 标志，使 PWAL 可以安全重新
+执行。
+
+每个模块的 PWAL 仍在其 reload arena scope 中运行，以便派生 tensor 复用稳定的
+arena storage。
+
+### 4.9 `_validate_copy_back`
+
+commit 前对完整 runtime schema 做预检查：
+
+```text
+旧 runtime tensor shape/dtype
+        ==
+新 processed tensor shape/dtype
+```
+
+先完成全量校验，再开始 copy，避免发现第 N 个 tensor 不兼容时，前 N-1 个 tensor
+已经被提交。
+
+当前允许 processed schema 中缺失旧 Buffer，因为某些 runtime-only Buffer 不属于
+本次 checkpoint commit；Parameter 缺失则视为错误。
+
+### 4.10 `_copy_back` 与 `_restore_runtime_bindings`
+
+`_copy_back` 不替换 runtime object：
+
+```python
+old_runtime_tensor.data.copy_(processed_tensor)
+```
+
+然后 `_restore_runtime_bindings` 把 model tree 重新指向旧对象：
+
+```text
+module.weight is original_runtime_weight
+storage.data_ptr() == original_data_ptr
+```
+
+这保证 graph-visible storage identity 稳定。
+
+### 4.11 `reload_storage_guard`
+
+Modelwise Reload 外层仍由 storage guard 包围，用于校验：
+
+- reload arena identity；
+- 模块级 graph-visible storage；
+- 全局 storage manifest。
+
+Modelwise 自身负责 Parameter/Buffer schema 和 copy-back；storage guard 负责更广泛的
+graph-visible runtime 状态验证，两者职责不同。
+
+### 4.12 NCCL 与 CUDA IPC Engine
+
+两个 backend 都持有：
+
+```python
+self.reload_session: ModelwiseReloadSession | None
+```
+
+生命周期映射：
+
+| Weight transfer API | Modelwise 操作 |
+|---|---|
+| `start_weight_update()` | 创建 session 并执行 `start()` |
+| `update_weights()` | 接收一个或多个 chunk，执行 `session.load_weights()` |
+| `finish_weight_update()` | 执行 `session.finish()` |
+| `abort_weight_update()` | 执行 `session.abort()` |
+
+#### Unpacked NCCL
+
+```text
+receive tensor
+    -> session.load_weights([(name, tensor)])
+```
+
+每个 tensor 可以单独进入 `model.load_weights()`，但不会触发 PWAL。
+
+#### Packed NCCL
+
+```text
+packed buffer 0 -> unpack -> session.load_weights(chunk 0)
+packed buffer 1 -> unpack -> session.load_weights(chunk 1)
+packed buffer 2 -> unpack -> session.load_weights(chunk 2)
+```
+
+一次上层 update API 可以包含多个内部 buffer，PWAL 仍只由 finish 触发。
+
+#### CUDA IPC
+
+IPC handle 被重建为 receiver device tensor，组成一个 chunk 后传入
+`session.load_weights()`。packed 模式可多次回调 update，但它们共享同一个 session。
+
+### 4.13 `GPUWorker`
+
+Worker 负责控制事务合法性：
+
+- 不允许嵌套 start；
+- 没有 start 时拒绝 update/finish；
+- update 接收失败时自动 abort；
+- finish 无论成功失败都清除 active 标志。
+
+Worker 不管理 layer 状态，也不判断权重完成数量。
+
+### 4.14 `LLM` 与 `AsyncLLM`
+
+控制器调用顺序：
+
+```python
+llm.start_weight_update()
+llm.update_weights(chunk_0)
+llm.update_weights(chunk_1)
+llm.finish_weight_update()
+```
+
+finish 成功后清空 prefix cache。文件系统 reload 还会清空 encoder/MM cache，避免继续
+消费旧权重生成的缓存状态。
+
+## 5. 完整数据流
+
+### 5.1 初始化数据流
+
+```mermaid
+sequenceDiagram
+    participant Init as initialize_model
+    participant Model
+    participant Meta as Metadata Recorder
+    participant Loader as Initial Model Loader
+    participant PWAL
+
+    Init->>Model: construct()
+    Init->>Meta: record_modelwise_reload_metadata(model)
+    Meta->>Meta: tensor -> meta schema
+    Meta->>Meta: preserve alias/loader/persistence
+    Init->>Loader: get checkpoint weights
+    Loader->>Model: model.load_weights(weights)
+    Init->>PWAL: process_weights_after_loading(model)
+    PWAL->>Model: create runtime/kernel schema
+```
+
+### 5.2 文件系统 Reload 数据流
+
+```mermaid
+sequenceDiagram
+    participant Runner as GPUModelRunner
+    participant Loader as ModelLoader
+    participant Reloader as ModelwiseReloader
+    participant Session as ModelwiseReloadSession
+    participant Model
+
+    Runner->>Loader: get_all_weights(path)
+    Runner->>Reloader: reload(iterator)
+    Reloader->>Session: start()
+    Session->>Model: replace runtime bindings with checkpoint bindings
+    Reloader->>Session: load_weights(iterator)
+    Session->>Model: model.load_weights(iterator)
+    Reloader->>Session: finish()
+    Session->>Model: model-wide PWAL
+    Session->>Model: copy to old runtime storage
+    Session->>Model: restore old bindings
+    Runner->>Runner: reset encoder/MM cache
+```
+
+### 5.3 NCCL/IPC Streaming 数据流
+
+```mermaid
+sequenceDiagram
+    participant Trainer
+    participant API as LLM/AsyncLLM
+    participant Worker as GPUWorker
+    participant Engine as NCCL/IPC Engine
+    participant Session as ModelwiseReloadSession
+    participant Model
+
+    API->>Worker: start_weight_update
+    Worker->>Engine: start_weight_update
+    Engine->>Session: start
+    Session->>Model: restore checkpoint schema
+
+    loop arbitrary partial or packed chunks
+        Trainer->>Engine: checkpoint tensor chunk
+        API->>Worker: update_weights
+        Worker->>Engine: receive/update
+        Engine->>Session: load_weights(chunk)
+        Session->>Model: model.load_weights(chunk)
+    end
+
+    API->>Worker: finish_weight_update
+    Worker->>Engine: finish_weight_update
+    Engine->>Session: finish
+    Session->>Model: PWAL once
+    Session->>Model: validate and copy-back
+    Session->>Model: restore runtime bindings
+    API->>API: reset prefix cache
+```
+
+### 5.4 Tensor 状态变化示例
+
+以 BF16 checkpoint 到在线 FP8 runtime 为例：
+
+```text
+Serving 前
+module.weight       -> FP8 runtime Parameter Rw
+module.weight_scale -> FP32 runtime Buffer Rs
+
+start
+RuntimeBindings = {weight: Rw, weight_scale: Rs}
+module.weight       -> BF16 temporary checkpoint Parameter Cw
+module.weight_scale -> checkpoint schema 对应的临时状态
+
+update × N
+model.load_weights() 将 BF16 值写入 Cw
+
+finish / PWAL
+Cw -> FP8 processed Parameter Pw
+   -> FP32 processed scale Ps
+
+commit
+Rw.copy_(Pw)
+Rs.copy_(Ps)
+
+restore
+module.weight       is Rw
+module.weight_scale is Rs
+```
+
+## 6. 如何替代 Layerwise Reload
+
+### 6.1 Layerwise 的旧职责
+
+旧流程大致为：
+
+```text
+record_metadata_for_reloading
+    -> initialize_layerwise_reload
+        -> 为每层恢复 checkpoint tensor
+        -> 包装 weight_loader
+        -> 统计每层应加载的 numel
+    -> model.load_weights
+        -> 每收到 tensor 更新 layer 计数
+        -> 猜测 layer 是否完成
+        -> 逐层 PWAL/copy-back
+    -> finalize_layerwise_reload
+```
+
+它将 completion 与 layer/tensor 数量绑定。
+
+### 6.2 Modelwise 的职责映射
+
+| Layerwise 组件/职责 | Modelwise 替代 |
+|---|---|
+| `record_metadata_for_reloading()` | `record_modelwise_reload_metadata()` |
+| `initialize_layerwise_reload()` | `ModelwiseReloadSession.start()` |
+| 每层 loader wrapper | 删除；恢复原 checkpoint loader |
+| layer `load_numel`/`load_numel_total` | 删除 |
+| tensor 到齐自动 finalize layer | 删除 |
+| deferred attention processing | 统一进入 model-wide PWAL |
+| `finalize_layerwise_processing()` | `process_weights_after_loading(force=True)` |
+| `finalize_layerwise_reload()` | `session.finish()` |
+| layer 异常清理 | `session.abort()` |
+
+### 6.3 新文件系统路径
+
+```python
+if is_checkpoint_format:
+    loaded_weights = ModelwiseReloader(
+        model,
+        model_config,
+        device,
+    ).reload(weights_iterator)
+else:
+    # 已是最终 runtime/kernel format
+    for name, weight in weights_iterator:
+        model.get_parameter(name).copy_(weight)
+```
+
+checkpoint-format 与 runtime-format 的边界保持明确：
+
+- checkpoint format：Modelwise + `model.load_weights()` + PWAL；
+- runtime format：shape/dtype/layout 已匹配时直接原位 copy。
+
+### 6.4 新 Weight Transfer 路径
+
+旧方式可能在每个 update 或每层达到 `numel` 后执行 PWAL。新方式必须使用：
+
+```text
+start
+    -> update × N
+    -> finish
+```
+
+传输协议不需要携带：
+
+- layer completion；
+- expected layer numel；
+- total loaded numel；
+- packed chunk 是否为最后一块。
+
+控制器的 finish 请求就是权威事务边界。
+
+### 6.5 迁移步骤
+
+建议按以下顺序完全移除 layerwise：
+
+1. 初始化阶段同时记录 layerwise 和 modelwise metadata。
+2. 文件系统 checkpoint reload 切换到 `ModelwiseReloader`。
+3. NCCL/IPC 切换到 `ModelwiseReloadSession`。
+4. 验证量化矩阵、MLA、MoE、partial 和 packed update。
+5. 确认代码中不再引用：
+
+   ```text
+   initialize_layerwise_reload
+   finalize_layerwise_reload
+   finalize_layerwise_processing
+   load_numel
+   load_numel_total
+   ```
+
+6. 删除传输路径中的 layerwise completion metadata。
+7. 删除 `record_metadata_for_reloading()` 的调用。
+8. 删除 `reload/layerwise.py` 和仅供 layerwise 使用的 helper。
+9. 更新 `reload/__init__.py` 的导出和模块说明。
+
+当前工作树中 checkpoint filesystem、NCCL 和 IPC 已切换到 modelwise，但为了兼容或
+过渡，`reload/__init__.py` 与初始化路径仍保留旧 layerwise metadata/API。完全替代时
+应完成步骤 6–9。
+
+## 7. 正确性不变量
+
+### 7.1 事务边界
+
+```text
+start 之前：模型只能处于 runtime schema
+start 到 finish/abort：模型处于 checkpoint/loading schema，不允许 serving
+finish 之后：模型恢复 runtime schema
+abort 之后：模型恢复事务开始前的 runtime schema
+```
+
+### 7.2 完成条件
+
+唯一完成条件：
+
+```text
+显式 finish_weight_update()
+```
+
+以下都不是完成条件：
+
+- 收到某个 tensor；
+- 收到某个 layer 的所有 tensor；
+- `loaded_numel == expected_numel`；
+- packed buffer 用满；
+- packed producer 没有更多当前 buffer；
+- 单次 `update_weights()` 返回。
+
+### 7.3 Storage Identity
+
+成功 commit 后，对所有已有 runtime Parameter/Buffer：
+
+```python
+new_binding is old_binding
+new_binding.untyped_storage().data_ptr() == old_data_ptr
+```
+
+若 PWAL 产生与旧 runtime 不兼容的 shape/dtype，则拒绝 commit。
+
+### 7.4 Runtime-only State
+
+non-persistent Buffer 不参与 checkpoint 恢复。模型或 backend 产生的普通 derived
+tensor 应由 model-wide PWAL/reload arena 更新，而不是通过 checkpoint binding
+恢复。
+
+### 7.5 Cache Consistency
+
+权重版本提交后必须失效旧权重产生的缓存：
+
+- prefix cache；
+- encoder cache；
+- multimodal cache；
+- 外部 KV connector cache（如部署启用，应由更高层控制器处理）。
+
+## 8. 异常与回滚
+
+### 8.1 Start 失败
+
+checkpoint binding 恢复或 materialize 失败：
+
+```text
+立即恢复 runtime bindings
+    -> 恢复 TorchAO 状态
+    -> session 保持 inactive
+```
+
+### 8.2 Receive/Load 失败
+
+Worker 捕获异常并调用：
+
+```python
+weight_transfer_engine.abort_weight_update()
+```
+
+临时 checkpoint tensor 被丢弃，旧 runtime storage 未被写入。
+
+### 8.3 PWAL 或校验失败
+
+`finish()` 的 `finally` 会恢复 runtime bindings。因为 copy-back 前先全量验证，PWAL
+和 schema validation 失败不会提交临时值。
+
+### 8.4 Copy-back 中途失败
+
+copy-back 是原位写操作；如果底层 `copy_` 在部分 tensor 已提交后失败，事务无法完全
+回滚。该情况应 fail closed，worker 不应继续 serving，应重启或重新完整加载模型。
+
+## 9. 内存与性能
+
+### 9.1 峰值显存
+
+Modelwise start 会同时持有：
+
+```text
+完整 runtime schema
++ 完整临时 checkpoint schema
++ PWAL 临时 workspace
+```
+
+峰值显存高于 layerwise。Modelwise 以简化正确性和完整模型 post-load 语义换取 reload
+期间的额外显存。
+
+部署可通过以下方式预留空间：
+
+- 减少 KV cache；
+- reload 前释放或缩小 cache；
+- 使用 CPU/UVA offloading；
+- 在请求 drain 后执行 reload；
+- 将 checkpoint staging 放在容量更大的 device/host memory。
+
+### 9.2 Packed Chunk 不降低 Staging 峰值
+
+packed NCCL/IPC 减少传输 buffer 峰值，但当前 modelwise 仍 materialize 完整 checkpoint
+schema。因此：
+
+```text
+传输分块 != checkpoint staging 分层释放
+```
+
+若未来需要降低 staging 峰值，应设计显式 model reload state 或可释放的 checkpoint
+tensor arena，而不是重新引入 `numel` completion。
+
+### 9.3 PWAL 次数
+
+无论有多少 partial 或 packed chunks，一个成功事务只执行一次 model-wide PWAL，避免
+重复量化/repack，并确保跨层或模型级 derived state 看到一致的权重版本。
+
+## 10. 已验证场景
+
+### 10.1 文件系统 Reload
+
+已验证的完整 modelwise reload 包括：
+
+- 在线 FP8 per-tensor、per-block、per-channel；
+- 在线 INT8 weight-only；
+- 在线 MXFP8；
+- compressed-tensors FP8 block、W4A16、W4A8 MoE；
+- GPTQ、AutoGPTQ、GPTQ-Marlin；
+- experts INT8 MoE。
+
+### 10.2 NCCL/IPC
+
+H200 上使用本地 Qwen3-0.6B、BF16 trainer 权重和在线 FP8 runtime 验证：
+
+| Backend | 模式 | 结果 |
+|---|---|---:|
+| CUDA IPC | 四次 partial update | Pass |
+| NCCL | 四次 partial update | Pass |
+| CUDA IPC | 384 MiB buffer，三个 packed chunks | Pass |
+| NCCL | 一次 API update，内部三个 packed chunks | Pass |
+
+所有场景均满足：
+
+- finish 前保持 BF16 checkpoint schema；
+- finish 前不执行 PWAL；
+- 推理 token 与冷加载一致；
+- runtime Parameter/Buffer identity change count 为 0；
+- NCCL/IPC 不使用 `load_numel` completion。
+
+### 10.3 自动化测试
+
+单元测试覆盖：
+
+- processed value copy 回原 runtime storage；
+- multiple chunks；
+- explicit finish 是唯一 PWAL 边界；
+- abort；
+- tied parameter alias；
+- non-persistent Buffer；
+- receive failure 自动 abort；
+- finish 状态清理；
+- prefix cache invalidation。
+
+## 11. 限制与后续工作
+
+### 11.1 当前限制
+
+1. reload 期间模型 tree 暂时是 checkpoint schema，不能同时 serving。
+2. 峰值显存约为 runtime + checkpoint staging + PWAL workspace。
+3. processed tensor 必须与原 runtime tensor shape/dtype 一致。
+4. 普通 tensor attribute 必须由 PWAL 或 reload arena 正确刷新。
+5. copy-back 中途的硬件错误不能完整回滚。
+6. 部分 checkpoint update 的完整性目前由调用者/协议保证，loaded name 只用于诊断。
+
+### 11.2 推荐演进方向
+
+长期可以为模型和 quant method 引入显式接口：
+
+```python
+reload_state = model.create_checkpoint_reload_state()
+model.load_weights_into(reload_state, chunks)
+processed_state = model.process_reload_state(reload_state)
+model.commit_reload_state(processed_state)
+```
+
+这能逐步替代当前对 `_parameters/_buffers` 的通用反射恢复，并让模型显式声明：
+
+- checkpoint destinations；
+- runtime destinations；
+- derived tensor；
+- commit/abort 行为；
+- staging 内存策略。
+
+在该接口普及前，Modelwise Reload 提供了无需修改所有模型类、同时兼容量化和模型专用
+PWAL 的统一方案。
+
+## 12. 结论
+
+Modelwise Reload 将 reload 的核心抽象从：
+
+```text
+逐层接收 + numel 猜测完成 + 逐层 PWAL
+```
+
+替换为：
+
+```text
+模型级显式事务
+    -> 恢复 checkpoint schema
+    -> model.load_weights(chunk) × N
+    -> finish 时统一 PWAL
+    -> 校验并原位提交到旧 runtime storage
+```
+
+它保留模型原有 weight loader 的名称映射、分片和融合能力，删除 layer completion
+推断，统一处理 quant/MLA/HPC derived state，并使 NCCL、IPC、文件系统 reload 使用
+同一套生命周期。

--- a/docs/design/modelwise_reload_quantization_matrix.md
+++ b/docs/design/modelwise_reload_quantization_matrix.md
@@ -1,0 +1,65 @@
+# Quantized weight-update validation matrix
+
+This matrix records validation of quantized weight updates on an NVIDIA H200
+without downloading models. It distinguishes aliases and online shorthands from
+checkpoint formats, and does not treat an initialization failure as a reload
+failure.
+
+## Weight-update paths
+
+| Path | Quantization | Transport | Result | Evidence |
+|---|---|---|---|---|
+| `reload_weights` | online FP8 per-tensor | filesystem | Pass | BF16 checkpoint to dummy FP8 runtime; 451 parameter/buffer bindings retained |
+| `reload_weights` | online FP8 per-block | filesystem | Pass | 451 bindings retained and inference completed |
+| `reload_weights` | online FP8 per-channel | filesystem | Pass | 451 bindings retained and inference completed |
+| `reload_weights` | online INT8 weight-only | filesystem | Pass | 339 bindings retained and inference completed |
+| `reload_weights` | online MXFP8 | filesystem | Pass | 451 bindings retained and inference completed |
+| `reload_weights` | compressed-tensors FP8 block | filesystem | Pass | Reloaded add checkpoint to multiply checkpoint; 451 bindings retained |
+| `reload_weights` | compressed-tensors W4A16 | filesystem | Pass | Reloaded add checkpoint to multiply checkpoint; 563 bindings retained |
+| `reload_weights` | compressed-tensors W4A8 MoE | filesystem | Pass | 54 bindings retained and inference completed |
+| `reload_weights` | GPTQ / AutoGPTQ / GPTQ-Marlin | filesystem | Pass | 555 bindings retained for each explicit entry point |
+| `reload_weights` | experts INT8 MoE | filesystem | Pass | BF16 checkpoint to dummy INT8-expert runtime; 34 bindings retained |
+| weight transfer | online FP8 per-tensor | packed CUDA IPC | Pass | BF16 Transformers trainer to dummy FP8 runtime; 451 bindings retained; cold-load tokens matched |
+| weight transfer | online FP8 per-tensor | packed NCCL | Pass | GPU trainer to vLLM receiver through real PyNccl communicator; 451 bindings retained |
+| weight transfer | unquantized recorder | unpacked NCCL | Pass | Cross-process Ray integration test |
+| weight transfer | unquantized recorder | unpacked CUDA IPC, Ray and HTTP metadata paths | Pass | Cross-process Ray integration tests |
+| sparse weight update | unquantized parameter patch | sparse NCCL | Pass | Cross-process Ray integration test updated only selected entries |
+
+Every binding count above includes named parameters and named buffers. The
+checks compare both Python object identity and underlying storage address.
+
+## Registered quantization names
+
+| Registered name | Effective family | H200 result |
+|---|---|---|
+| `fp8` | FP8 checkpoint / legacy online FP8 | Pass for checkpoint FP8 and BF16-to-FP8 reload |
+| `online` | Configurable online quantization | Covered through all registered online shorthands |
+| `fp8_per_tensor` | Online FP8 | Pass |
+| `fp8_per_block` | Online FP8 | Pass |
+| `fp8_per_channel` | Online FP8 | Pass |
+| `int8_per_channel_weight_only` | Online INT8 | Pass |
+| `mxfp8` | Online shorthand or ModelOpt checkpoint format | Pass for online shorthand; no local ModelOpt MXFP8 checkpoint |
+| `compressed-tensors` | Multiple checkpoint schemes | Pass for FP8 block, W4A16, and W4A8 MoE formats; one older TinyLlama W4A8 checkpoint fails initial load because it contains an unregistered `weight_chan_scale` |
+| `gptq` | AutoGPTQ implementation | Pass |
+| `auto_gptq` | AutoGPTQ implementation | Pass |
+| `gptq_marlin` | AutoGPTQ implementation with Marlin selection | Pass |
+| `experts_int8` | Online INT8 MoE experts | Pass |
+| `awq`, `auto_awq`, `awq_marlin` | AutoAWQ implementation | Not runtime-tested: no local AWQ checkpoint |
+| `moe_wna16` | GPTQ/AWQ MoE WNA16 | Not runtime-tested with a compatible MoE checkpoint; the local dense GPTQ checkpoint fails initial load with missing `g_idx` destination |
+| `humming` | Humming checkpoint conversion | Environment-limited: Humming NVRTC compilation fails during initial post-load processing |
+| `bitsandbytes` | bitsandbytes | Dependency unavailable in the existing environment; not installed per offline/no-download constraint |
+| `torchao` | TorchAO | Dependency unavailable in the existing environment; not installed per offline/no-download constraint |
+| `modelopt`, `modelopt_fp4`, `modelopt_mxfp8`, `modelopt_mixed` | TensorRT ModelOpt formats | No compatible local checkpoint; not runtime-tested |
+| `quark` | AMD Quark formats | No compatible local checkpoint; not runtime-tested |
+| `inc` | Intel Neural Compressor format | No compatible local checkpoint; not runtime-tested |
+| `mxfp4`, `gpt_oss_mxfp4` | MXFP4 | Environment-limited: local GPT-OSS checkpoint reaches FlashInfer JIT, which fails because the H200 image lacks `cublasLt.h` |
+| `deepseek_v4_fp8` | DeepSeek V4 FP8 | No compatible local FP8 checkpoint; not runtime-tested |
+| `fbgemm_fp8` | Deprecated FBGEMM FP8 | No compatible local checkpoint; not runtime-tested |
+| `fp_quant` | Blackwell FP4/FP8 | Not supported by H200 (minimum compute capability 10.0) |
+
+## Interpretation
+
+`Pass` means the complete load/update lifecycle and inference executed on H200,
+and runtime tensor storage remained stable. `Not runtime-tested` is deliberately
+not a support claim. Environment and checkpoint limitations are recorded
+separately from failures reached after reload begins.

--- a/docs/design/reload_arena.md
+++ b/docs/design/reload_arena.md
@@ -687,6 +687,14 @@ shadow slots, or a shadow model. A strict failure prevents the reload from
 being reported as successful, but callers must treat the worker as unsafe for
 continued serving and recover according to the surrounding reload protocol.
 
+`reload_storage_guard` also runs arena and global-manifest verification when
+the reload body itself raises. Findings on that path are diagnostic: they are
+logged without replacing the original load exception. The original exception
+is annotated, when supported by the Python runtime, to state that mutation may
+have started and the worker must be restarted. A clean identity check does not
+make a failed reload safe, because parameters or value-bearing slots may
+already have been partially updated without changing addresses.
+
 ### Graph visibility discovery
 
 The arena is an explicit declaration mechanism, not an automatic proof that

--- a/docs/design/reload_arena.md
+++ b/docs/design/reload_arena.md
@@ -319,6 +319,56 @@ with arena_scope(get_reload_arena(layer)):
     kernel = make_moe_kernel(...)
 ```
 
+All framework-owned PWAL entry points open this scope, including initial
+loading, layerwise reload, attention finalization, attention-scale reload,
+and dummy loading:
+
+```python
+with arena_scope(get_reload_arena(layer)):
+    quant_method.process_weights_after_loading(layer)
+```
+
+This is an intentional PWAL boundary, rather than a statement that every
+quantization method needs arena storage. A quantization method can construct
+several layers of transient objects:
+
+```text
+quant_method.process_weights_after_loading(layer)
+  -> select a kernel backend
+  -> construct an expert or kernel object
+  -> allocate graph-visible constants or scratch
+```
+
+The deepest constructor may know the runtime tensor but not the persistent
+layer that owns it. Passing the layer or arena through every quantization,
+kernel, and expert interface would couple those interfaces to reload. The
+ambient scope instead makes the layer's arena available only while that
+layer's PWAL call is running. Deep code can opt in with `current_arena()`.
+
+Using the same boundary for every PWAL call is important for three reasons:
+
+1. Initial load and reload execute backend selection through the same arena
+   context. Initial PWAL creates the slot before graph capture; later PWAL
+   reacquires it.
+2. Correctness does not depend on a central list of quantization methods that
+   happen to allocate graph-visible runtime tensors today. A newly introduced
+   backend can use the existing boundary without changing every caller.
+3. The scope has a precise lifetime. It is absent during normal inference, so
+   one layer cannot accidentally acquire storage from another layer's PWAL.
+
+Opening a scope does **not** automatically register tensors created during
+PWAL. Registration remains explicit: deep code must call `current_arena()`
+and publish through `put()` or `get_or_alloc()`. Methods that do not opt in
+simply enter and leave the context.
+
+The current boundary eagerly calls `get_reload_arena(layer)`, so a module
+whose PWAL never uses the arena may retain an empty arena. This is a small
+bookkeeping cost, not a device allocation: no tensor storage is allocated
+until a slot is acquired. If empty arenas become significant, the boundary
+can be changed to retain only an owner and lazily create its arena on the
+first deep acquisition. Such an optimization must preserve the uniform PWAL
+boundary and the initial-load/reload symmetry above.
+
 The constructor may resolve and retain the current arena:
 
 ```python

--- a/docs/design/reload_arena.md
+++ b/docs/design/reload_arena.md
@@ -60,6 +60,100 @@ The arena does not make an arbitrary tensor safe merely by retaining it. The
 consumer must use the tensor returned by the arena, and every rebuild path
 must acquire the same slot.
 
+## Weight updates and arena updates are different
+
+Layerwise weight reload and arena refresh use intentionally different update
+paths.
+
+### Checkpoint weights use deferred staging and copy-back
+
+Parameters and registered buffers participate in the layerwise reload
+transaction:
+
+```text
+incoming checkpoint tensors
+  → buffer weight-loader arguments for one layer
+  → materialize a temporary checkpoint-format layer
+  → replay the buffered weight loaders
+  → run PWAL on the temporary state
+  → copy processed parameters and buffers back to original kernel storage
+```
+
+The original parameter and buffer storage is retained in
+`LayerReloadingInfo.kernel_tensors`. Incoming checkpoint values and PWAL
+results can therefore be staged on temporary storage. Only after the layer
+has loaded and processed its required weights does
+`_copy_and_restore_kernel_tensors` publish the result into the storage already
+used by serving kernels and captured graphs.
+
+This delayed copy-back is possible because parameters and registered buffers
+have an enumerable target set, and their processed values exist by the end of
+the layer's PWAL call.
+
+### Arena slots update their stable destination directly
+
+Arena slots do not have a second staging/copy-back phase:
+
+```text
+PWAL or first forward
+  → acquire the layer-owned slot
+  → initialize or copy directly into that stable slot
+  → rebuilt kernel/expert object uses the slot immediately
+```
+
+For a derived tensor, `arena.put()` performs `copy_` into the stable slot
+during PWAL. For workspace, `arena.get_or_alloc()` returns the stable slot
+itself. The arena is therefore the destination, not a temporary source whose
+contents are committed later.
+
+The ordering inside `_layerwise_process` is:
+
+```text
+replay buffered checkpoint loaders
+  → process_weights_after_loading
+      → arena writes happen here
+  → copy processed parameters/buffers back to kernel_tensors
+  → verify arena identities
+```
+
+Arena updates happen before parameter/buffer copy-back because PWAL both
+computes arena values and constructs objects that must immediately bind to
+the stable tensors returned by the arena.
+
+### Why arena updates cannot use the weight staging mechanism
+
+Arena-backed storage has more than one initialization lifetime:
+
+1. **Eager derived state.** MLA and similar PWAL paths compute the complete
+   runtime value during PWAL. `put()` must immediately refresh the stable
+   slot and return it to the rebuilt attention or kernel object.
+2. **Eager allocation with later writes.** Some PWAL paths allocate scratch
+   storage, but its contents are not meaningful until a kernel invocation.
+3. **Lazy allocation and initialization.** MoE implementations may construct
+   the expert object during PWAL but allocate permute scratch only on the
+   first real forward. The runtime call, not PWAL or reload finalization,
+   determines when and how the memory is initialized.
+
+Consequently, reload does not have a complete set of arena values that could
+be held in a temporary buffer and copied back at one final commit point.
+Some slots do not exist yet, some contain scratch with no persistent value,
+and some must be returned to a newly constructed object before reload
+finalization. Attempting to stage them like checkpoint weights would either:
+
+- allocate a second address and let the rebuilt object retain the wrong one;
+- require backend-specific knowledge of when scratch becomes initialized;
+- copy uninitialized or semantically meaningless workspace contents;
+- miss slots created lazily after PWAL.
+
+The arena instead preserves the destination address continuously. Eager
+values are copied into it when computed, and lazy users retain the arena so
+their eventual allocation resolves to that same layer-owned destination.
+
+This also means arena refresh is not an atomic value transaction. If a later
+reload step fails, an arena slot may already contain a newly computed value.
+The arena guarantees storage identity and provides a place to refresh values;
+it does not provide shadow storage or rollback.
+
 ## Lifecycle
 
 ### Initial model load
@@ -110,7 +204,7 @@ rebuilt.
 PWAL reacquires the existing slots:
 
 - `get_or_alloc` returns the original storage;
-- `put` copies a recomputed value into the original storage.
+- `put` immediately copies a recomputed value into the original storage.
 
 After reload, the model-wide commit gate verifies all slots captured before
 mutation:
@@ -389,9 +483,11 @@ Stable identity does not prove that contents were refreshed correctly:
 
 ### Transaction rollback
 
-The arena gate detects identity violations after mutation. It does not provide
-rollback or a shadow model. A strict failure prevents the reload from being
-reported as successful, but callers must treat the worker as unsafe for
+The arena gate detects identity violations after mutation. Arena values may
+already have been refreshed during PWAL, before parameter/buffer copy-back or
+model-wide verification completes. The arena does not provide rollback,
+shadow slots, or a shadow model. A strict failure prevents the reload from
+being reported as successful, but callers must treat the worker as unsafe for
 continued serving and recover according to the surrounding reload protocol.
 
 ### Graph visibility discovery

--- a/docs/design/reload_arena.md
+++ b/docs/design/reload_arena.md
@@ -1,0 +1,444 @@
+# ReloadArena
+
+## Overview
+
+`ReloadArena` preserves the storage identity of runtime tensors that remain
+visible to an accelerator graph across an in-place weight reload.
+
+An in-place reload changes model values without rebuilding the serving
+process. During the reload,
+`process_weights_after_loading` (PWAL) may rebuild quantization methods,
+kernel objects, expert objects, workspaces, or derived tensors. Replacing one
+of those tensors is unsafe when a previously captured graph still contains
+its device address:
+
+```text
+graph capture                       reload
+-------------                       ------
+kernel records address A            PWAL creates tensor at address B
+graph keeps address A               Python state now points to B
+```
+
+The old graph may then read stale values from address A, reference freed
+storage, or fail with an illegal memory access.
+
+The arena changes the storage owner. Storage belongs to the persistent layer,
+not to a transient kernel or quantization object:
+
+```text
+layer
+  └── ReloadArena
+        └── named stable storage
+              ↑
+       transient objects borrow it
+```
+
+PWAL may rebuild transient objects, but acquiring the same arena slot returns
+the same storage. Newly derived values are copied into that storage rather
+than published by rebinding a tensor.
+
+## Scope
+
+The arena protects tensors that satisfy all of the following:
+
+1. their device address can outlive the Python object that created them;
+2. they are owned logically by one persistent `nn.Module`;
+3. their shape, dtype, device, and layout remain invariant across an in-place
+   reload;
+4. they are not checkpoint state and should not participate in parameter or
+   buffer loading.
+
+Examples include:
+
+- kernel workspaces and scratch buffers;
+- activation permutations derived during PWAL;
+- quantization scales or transformed values derived from loaded weights;
+- tensors stored in transient kernel, expert, or quantization objects;
+- buffers allocated lazily on the first forward and reused by later forwards.
+
+The arena does not make an arbitrary tensor safe merely by retaining it. The
+consumer must use the tensor returned by the arena, and every rebuild path
+must acquire the same slot.
+
+## Lifecycle
+
+### Initial model load
+
+During initial PWAL, graph-visible runtime tensors are published through the
+layer's arena:
+
+```text
+load checkpoint weights
+  → process_weights_after_loading
+  → acquire or publish arena slots
+  → warm up model
+  → capture accelerator graphs
+```
+
+The graph therefore captures addresses owned by the layer's arena.
+
+For lazily allocated storage, a constructor must retain the arena selected
+during PWAL. The first forward may create the slot, after which the slot is
+owned by the layer for the remainder of its lifetime.
+
+### Reload
+
+`GPUModelRunner.reload_weights` takes a model-wide arena snapshot before
+mutation:
+
+```python
+arena_snaps = snapshot_model_arenas(model)
+```
+
+For checkpoint-format layerwise reload, each layer also snapshots its arena
+before the layer is restored to meta:
+
+```text
+save kernel tensors
+snapshot layer arena
+restore checkpoint state to meta
+buffer and load checkpoint tensors
+rerun PWAL
+copy processed state back
+verify layer arena
+```
+
+Arena tensors are deliberately not restored to meta. They are runtime state,
+not checkpoint state, and their storage must remain alive while PWAL is
+rebuilt.
+
+PWAL reacquires the existing slots:
+
+- `get_or_alloc` returns the original storage;
+- `put` copies a recomputed value into the original storage.
+
+After reload, the model-wide commit gate verifies all slots captured before
+mutation:
+
+```python
+problems = verify_model_arenas(model, arena_snaps)
+```
+
+A moved, missing, or respecified slot fails closed by default. This check is
+necessary even for an identity reload: output equality cannot detect a graph
+that still reads an old allocation containing the same values.
+
+### New slots
+
+A slot created after a snapshot is allowed. This is required for legitimate
+first-forward lazy allocation. Once that slot exists, a subsequent reload
+snapshot includes it and requires it to remain stable.
+
+## API
+
+### Obtaining an arena
+
+Use the layer that logically owns the runtime tensor:
+
+```python
+from vllm.model_executor.reload_arena import get_reload_arena
+
+arena = get_reload_arena(layer)
+```
+
+The arena is stored as the plain attribute `_reload_arena`. It is
+intentionally not an `nn.Module`, and its tensors are intentionally not
+registered as parameters or buffers. This prevents checkpoint loading,
+state-dict handling, meta restoration, and copy-back logic from treating
+runtime storage as model state.
+
+Use `peek_reload_arena(layer)` when inspection must not create an arena.
+
+### Publishing a derived value
+
+Use `put` when PWAL recomputes a value:
+
+```python
+perm = torch.argsort(layer.g_idx).to(torch.int)
+layer.act_perm = get_reload_arena(layer).put("act_perm", perm)
+```
+
+On first use, `put` stores a detached, contiguous clone. On later calls, it
+copies the new value into the existing slot and returns the existing tensor.
+
+Always bind the consumer to the return value:
+
+```python
+# Correct
+layer.act_perm = arena.put("act_perm", recomputed)
+
+# Incorrect: the arena is populated, but the consumer uses transient storage.
+arena.put("act_perm", recomputed)
+layer.act_perm = recomputed
+```
+
+`put` provides both:
+
+- stable storage identity;
+- refreshed derived values after every PWAL run.
+
+### Allocating workspace or scratch
+
+Use `get_or_alloc` when only stable storage is required:
+
+```python
+from vllm.model_executor.reload_arena import InitPolicy
+
+layer.workspace = get_reload_arena(layer).get_or_alloc(
+    "decode_workspace",
+    shape=(max_tokens, hidden_size),
+    dtype=layer.weight.dtype,
+    device=layer.weight.device,
+    init=InitPolicy.PRESERVE,
+)
+```
+
+Initialization policies are:
+
+| Policy | First acquisition | Later acquisition |
+|---|---|---|
+| `EMPTY` | `torch.empty` | preserve existing contents |
+| `PRESERVE` | `torch.empty` | preserve existing contents |
+| `ZERO` | `torch.zeros` | zero the existing tensor |
+
+`EMPTY` and `PRESERVE` currently have the same implementation. Use
+`PRESERVE` when retained contents are intentional or the caller overwrites
+the storage before reading it. Use `ZERO` only when every acquisition must
+clear the workspace.
+
+The arena does not enforce use-before-initialization. A caller using
+`EMPTY` or `PRESERVE` must fully initialize the relevant region before a
+kernel reads it.
+
+### Deep construction chains
+
+Some kernel or expert constructors cannot receive the layer directly. Open an
+ambient scope at the PWAL site:
+
+```python
+from vllm.model_executor.reload_arena import (
+    arena_scope,
+    get_reload_arena,
+)
+
+with arena_scope(get_reload_arena(layer)):
+    kernel = make_moe_kernel(...)
+```
+
+The constructor may resolve and retain the current arena:
+
+```python
+from vllm.model_executor.reload_arena import current_arena
+
+class Experts:
+    def __init__(self):
+        self._reload_arena = current_arena()
+```
+
+For a lazy first-forward allocation, use the retained arena:
+
+```python
+if self._scratch is None:
+    if self._reload_arena is None:
+        self._scratch = torch.empty(spec)
+    else:
+        self._scratch = self._reload_arena.get_or_alloc(
+            "experts_scratch", shape, dtype, device
+        )
+```
+
+Do not call `current_arena()` for the first time during forward. The scope is
+opened during construction/PWAL and is normally absent during inference.
+
+`arena_scope` uses a `ContextVar`, so nested construction restores the prior
+scope and concurrent contexts do not share a process-global mutable pointer.
+
+## Slot contract
+
+A slot name identifies one stable storage specification for the lifetime of
+its owning layer.
+
+Later acquisitions must use the same:
+
+- shape;
+- dtype;
+- device.
+
+Verification additionally protects:
+
+- `data_ptr`;
+- stride/layout.
+
+An incompatible acquisition raises instead of reallocating:
+
+```text
+A shape-changing reload is not an in-place update; it requires a cold restart.
+```
+
+Unindexed accelerator devices such as `"cuda"` are canonicalized to the
+device on which PyTorch would allocate, such as `cuda:0`. CPU remains
+unindexed. This avoids false mismatches while preserving device-specific
+ownership.
+
+Slot names must be:
+
+- stable across initial load and reload;
+- unique within the owning layer;
+- semantic rather than based on object identity or allocation order.
+
+Good names:
+
+```text
+machete_act_perm
+rdna3_w1_buf
+cutlass_ab_strides1
+```
+
+Unsafe names:
+
+```text
+slot_{id(kernel)}
+workspace_{allocation_counter}
+```
+
+## Verification and failure policy
+
+`snapshot()` records each slot's pointer and layout. `verify()` reports:
+
+| Violation | Meaning |
+|---|---|
+| `moved` | the slot now has a different `data_ptr` |
+| `gone` | a previously snapshotted slot disappeared |
+| `respecified` | shape, stride, or dtype changed |
+
+Model-wide verification is authoritative. Per-layer verification runs closer
+to PWAL and is compared against the model-wide result to detect coverage
+gaps.
+
+`VLLM_RELOAD_GATE` controls the model-wide gate:
+
+| Value | Behavior |
+|---|---|
+| `strict` or unset | raise and refuse to serve the reload |
+| `warn` | log the violation and continue, which is unsafe |
+| `off` | suppress the gate, which is unsafe |
+
+Production use should retain the default strict behavior.
+
+## Relationship to the global storage manifest
+
+Not every graph-visible tensor has a layer owner. Module-level caches and
+registries are outside the model walk:
+
+```python
+_workspace_by_device: dict[torch.device, torch.Tensor]
+```
+
+These are covered separately by
+`vllm.model_executor.reload_manifest.GlobalStorageManifest`.
+
+Use:
+
+- `ReloadArena` when a persistent layer can own and reuse the storage;
+- the global manifest to detect movement of module-level state that cannot be
+  placed in a layer arena.
+
+The global manifest detects and reports movement but does not stabilize
+storage. It defaults to warning through
+`VLLM_RELOAD_GLOBAL_MANIFEST=warn`; it is not a replacement for arena
+ownership.
+
+## Boundaries and non-goals
+
+### Shape-changing updates
+
+The arena supports in-place value updates, not architecture changes. Changes
+to hidden size, expert layout, quantization layout, tensor shape, dtype,
+device, or stride require a cold model rebuild and graph recapture.
+
+### Parameter and buffer identity
+
+The arena is for non-checkpoint runtime storage. Parameters and registered
+buffers remain the responsibility of the model loader and layerwise copy-back
+flow. Moving ordinary model state into the arena to bypass those mechanisms
+is unsupported.
+
+### Arbitrary Python aliases and closures
+
+The arena cannot repair a consumer that retains the wrong tensor object. For
+example, a callable that closes over a transient PWAL tensor continues using
+that object even if an arena slot with the same value exists.
+
+Resolve arena-backed tensors from the persistent layer at call time, or bind
+the returned arena tensor into the rebuilt object.
+
+### Opaque external allocations
+
+Storage allocated internally by a third-party extension cannot be stabilized
+unless its allocation path accepts or reuses arena-owned tensors. Reflective
+walking can detect only some such state and cannot transfer ownership.
+
+### Value correctness
+
+Stable identity does not prove that contents were refreshed correctly:
+
+- `put` refreshes values because it performs `copy_`;
+- `get_or_alloc` only controls allocation and initialization policy;
+- scratch users must overwrite or clear the required region;
+- semantic correctness still requires kernel/model tests.
+
+### Transaction rollback
+
+The arena gate detects identity violations after mutation. It does not provide
+rollback or a shadow model. A strict failure prevents the reload from being
+reported as successful, but callers must treat the worker as unsafe for
+continued serving and recover according to the surrounding reload protocol.
+
+### Graph visibility discovery
+
+The arena is an explicit declaration mechanism, not an automatic proof that
+every graph-visible tensor has been registered. CI discovery and backend
+audits are still required to find new workspaces, lazy caches, closure-held
+tensors, and third-party allocations.
+
+## Integration checklist
+
+When adding an arena-backed tensor:
+
+1. Confirm that a graph or long-lived kernel can retain its device address.
+2. Select the persistent layer that logically owns it.
+3. Choose `put` for recomputed values or `get_or_alloc` for workspace.
+4. Define a stable, layer-local slot name.
+5. Rebind every consumer to the tensor returned by the arena.
+6. Ensure every PWAL/backend branch reacquires the same slot.
+7. For lazy allocation, capture the arena during construction rather than
+   resolving the ambient scope during forward.
+8. Verify that shape, dtype, device, and layout cannot change during an
+   in-place reload.
+9. Test at least two PWAL/reload passes and assert stable `data_ptr`.
+10. Test that values are refreshed or scratch is initialized as required.
+11. Exercise the real graph-capture backend when possible; CPU identity tests
+    alone do not establish graph visibility.
+
+## Testing
+
+Focused tests live under:
+
+```text
+tests/model_executor/model_loader/test_reload_arena.py
+tests/model_executor/model_loader/test_reload_arena_perlayer.py
+tests/model_executor/model_loader/test_reload_lazy_storage.py
+tests/model_executor/model_loader/test_reload_manifest.py
+tests/model_executor/model_loader/test_reload_rdna3_buffers.py
+tests/model_executor/model_loader/test_post_load_storage_stability.py
+tests/model_executor/model_loader/test_moe_experts_storage_stability.py
+```
+
+Tests should distinguish:
+
+- pointer stability from value equality;
+- initial allocation from reacquisition;
+- direct layer access from scoped deep construction;
+- PWAL allocation from first-forward lazy allocation;
+- layer-owned arena state from module-level manifest state;
+- expected cold-start slot growth from illegal movement of existing slots.

--- a/docs/design/reload_arena.md
+++ b/docs/design/reload_arena.md
@@ -154,6 +154,90 @@ reload step fails, an arena slot may already contain a newly computed value.
 The arena guarantees storage identity and provides a place to refresh values;
 it does not provide shadow storage or rollback.
 
+### Proposed staged publication for value-bearing slots
+
+The direct-update rule above is the current implementation. A future version
+can provide a stronger publication boundary by separating arena slots into two
+categories, using the acquisition API as the declaration:
+
+- `put()` declares value-bearing derived state whose contents must be
+  refreshed from the newly loaded layer;
+- `get_or_alloc()` declares workspace or scratch whose address matters but
+  whose contents have no checkpoint-like value to commit.
+
+Workspace and scratch should remain direct. Clearing, preserving, or lazily
+initializing them is part of the consumer's runtime protocol, and copying a
+shadow workspace back would add memory traffic without publishing meaningful
+state.
+
+Value-bearing `put()` slots can instead stage their newly derived contents in
+a per-layer shadow:
+
+```text
+replay buffered checkpoint loaders for layer L
+  → run PWAL for layer L
+      → put(slot, value) records value in L's shadow
+      → rebuilt consumers bind the existing live slot
+  → publish processed parameters and buffers for L
+  → copy L's value-bearing shadows into their live arena slots
+  → verify L's arena identities
+  → release L's shadows
+```
+
+The publication point should be the existing layer copy-back boundary, not a
+single model-wide commit. Keeping shadows only for the layer currently being
+processed bounds peak memory to that layer's value-bearing arena state. A
+model-wide shadow would retain derived tensors for every layer until reload
+completion and could require gigabytes for large models.
+
+Staged `put()` has an important return-value constraint. It must still return
+the **live** arena tensor so a rebuilt kernel, expert, or attention object
+binds the address already captured by the accelerator graph:
+
+```python
+live = arena.put("W_UV", newly_derived)  # newly_derived is staged
+kernel.W_UV = live                       # captured address remains stable
+```
+
+Until layer copy-back publishes the shadow, `live` contains the old value.
+PWAL must therefore not use the tensor returned by a staged `put()` as the
+source for another value derived in the same pass. Follow-on values must be
+computed from the fresh local source:
+
+```python
+# Correct under staged put.
+fresh_alpha = derive_alpha(loaded_scale)
+live_alpha = arena.put("alpha", fresh_alpha)
+live_c = arena.put("scale_c", derive_scale_c(fresh_alpha))
+
+# Incorrect: live_alpha remains stale until layer publication.
+live_alpha = arena.put("alpha", derive_alpha(loaded_scale))
+live_c = arena.put("scale_c", derive_scale_c(live_alpha))
+```
+
+The layer transaction would need explicit arena operations analogous to:
+
+```text
+begin_layer_update()
+publish_layer_update()
+discard_layer_update()
+```
+
+`publish_layer_update()` copies staged values into existing live slots; it
+must never rebind those slots. `discard_layer_update()` drops shadows when
+PWAL or parameter copy-back fails before publication. This prevents a failed
+layer from partially publishing value-bearing arena contents, but it is not a
+model-wide rollback: layers published earlier in the reload may already hold
+new parameters and arena values. Full model-level atomicity still requires a
+shadow model or a worker recovery protocol.
+
+Before enabling staged `put()`, every current caller must be audited for
+same-pass data dependencies on the returned tensor. Tests must cover both the
+pre-publication behavior (live value remains old) and the publication behavior
+(pointer unchanged, new value visible), as well as failure before publication.
+Until that audit and transaction API exist, `put()` continues to update the
+live slot immediately as documented above.
+
 ## Lifecycle
 
 ### Initial model load

--- a/docs/design/reload_arena.md
+++ b/docs/design/reload_arena.md
@@ -55,6 +55,7 @@ Examples include:
 - quantization scales or transformed values derived from loaded weights;
 - tensors stored in transient kernel, expert, or quantization objects;
 - buffers allocated lazily on the first forward and reused by later forwards.
+- runtime wrappers that own private graph-visible storage internally.
 
 The arena does not make an arbitrary tensor safe merely by retaining it. The
 consumer must use the tensor returned by the arena, and every rebuild path
@@ -481,6 +482,67 @@ opened during construction/PWAL and is normally absent during inference.
 `arena_scope` uses a `ContextVar`, so nested construction restores the prior
 scope and concurrent contexts do not share a process-global mutable pointer.
 
+### Third-party wrappers with private graph storage
+
+Some runtime objects allocate graph-visible workspaces internally and do not
+expose those tensors for `put()` or `get_or_alloc()`. For these narrowly scoped
+runtime owners, the arena provides an object slot:
+
+```python
+rebuilt_backend._wrapper = arena.get_or_create_object(
+    "backend.wrapper", build_wrapper
+)
+```
+
+The first acquisition calls the factory and stores the result. Later
+acquisitions return the same object without calling the factory again. Because
+the arena belongs to the persistent layer, transient kernels or experts can be
+rebuilt while continuing to borrow the original wrapper. Any private workspace
+whose lifetime matches the wrapper's lifetime remains stable.
+
+`FlashInferB12xExperts` uses this pattern for `B12xMoEWrapper`. The flow follows
+the ownership fix demonstrated and validated on SM120 in
+[vLLM PR #50538](https://github.com/vllm-project/vllm/pull/50538): create the
+wrapper during the first PWAL, retain it on the persistent layer side, and bind
+every rebuilt experts object to the retained wrapper. This implementation
+stores it in the routed-experts arena as `flashinfer_b12x.wrapper`. Later PWAL
+passes reacquire the same wrapper, preserving its private routing workspaces
+and output buffer. The wrapper's tensor arguments are protected separately by
+parameter copy-back or arena tensor slots.
+
+Object slots deliberately do not accept a device or construction spec. They
+follow the same in-place reload boundary as the owning layer: architecture,
+backend, dtype, and device cannot change during a legal reload. For B12x, the
+wrapper factory follows FlashInfer's default `device="cuda"`, which resolves to
+the current device already selected for the worker/rank running PWAL.
+
+This pattern is valid only when:
+
+- the wrapper construction spec cannot change during a legal in-place reload;
+- the wrapper does not retain the transient experts object;
+- weight and scale addresses retained by the wrapper are independently stable;
+- the third-party wrapper does not reallocate captured internal storage while
+  the object remains alive.
+
+Object slots participate in the same snapshot and verification gate as tensor
+slots. A snapshot retains the original Python object, and verification reports:
+
+| Violation | Object-slot meaning |
+|---|---|
+| `moved` | the slot now refers to a different Python object |
+| `gone` | the object slot disappeared |
+
+Holding the original object in the snapshot prevents Python identity reuse
+from hiding a replacement during the reload window. New object slots created
+after a snapshot remain legal, matching the existing rule for lazy tensor
+slots. Verification proves the outer wrapper identity, not that third-party
+code avoided reallocating storage internally while keeping the same wrapper.
+
+Object slots are not a general cache for arbitrary modules or PWAL objects. If
+any construction input can change, the backend must use a separate explicit
+check and require a cold rebuild rather than silently reusing an incompatible
+object.
+
 ## Slot contract
 
 A slot name identifies one stable storage specification for the lifetime of
@@ -603,8 +665,9 @@ the returned arena tensor into the rebuilt object.
 ### Opaque external allocations
 
 Storage allocated internally by a third-party extension cannot be stabilized
-unless its allocation path accepts or reuses arena-owned tensors. Reflective
-walking can detect only some such state and cannot transfer ownership.
+unless its allocation path accepts arena-owned tensors or the object owning
+that storage can itself persist on the layer. Reflective walking can detect
+only some such state and cannot transfer ownership.
 
 ### Value correctness
 

--- a/tests/distributed/test_weight_transfer.py
+++ b/tests/distributed/test_weight_transfer.py
@@ -510,6 +510,11 @@ def inference_receive_tensor(
     vllm_config.model_config = MagicMock()
 
     recorder = Recorder()
+    from vllm.model_executor.model_loader.reload import (
+        record_modelwise_reload_metadata,
+    )
+
+    record_modelwise_reload_metadata(recorder)
     engine = NCCLWeightTransferEngine(
         config, vllm_config, torch.device("cuda"), recorder
     )
@@ -527,6 +532,7 @@ def inference_receive_tensor(
         world_size=world_size,
     )
     engine.init_transfer_engine(init_info)
+    engine.start_weight_update()
 
     update_info = NCCLWeightTransferUpdateInfo(
         names=["test.weight"],
@@ -535,6 +541,7 @@ def inference_receive_tensor(
     )
     engine.receive_weights(update_info)
     torch.accelerator.synchronize()
+    engine.finish_weight_update()
 
     # Verify we received the tensor
     success = False
@@ -1087,6 +1094,11 @@ def inference_receive_ipc_tensor(
     vllm_config.model_config = MagicMock()
 
     recorder = Recorder()
+    from vllm.model_executor.model_loader.reload import (
+        record_modelwise_reload_metadata,
+    )
+
+    record_modelwise_reload_metadata(recorder)
     engine = IPCWeightTransferEngine(
         config, vllm_config, _get_ray_assigned_device(), recorder
     )
@@ -1098,6 +1110,7 @@ def inference_receive_ipc_tensor(
 
     init_info = IPCWeightTransferInitInfo()
     engine.init_transfer_engine(init_info)
+    engine.start_weight_update()
 
     ipc_handles = [{ipc_handle_dict["gpu_uuid"]: ipc_handle_dict["ipc_handle"]}]
 
@@ -1122,6 +1135,7 @@ def inference_receive_ipc_tensor(
     update_info = engine.parse_update_info(update_dict)
     engine.receive_weights(update_info)
     torch.accelerator.synchronize()
+    engine.finish_weight_update()
 
     success = False
     received_shape = None

--- a/tests/entrypoints/weight_transfer/test_weight_transfer_llm.py
+++ b/tests/entrypoints/weight_transfer/test_weight_transfer_llm.py
@@ -9,7 +9,7 @@ actual NCCL communication.
 
 import os
 from dataclasses import dataclass
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 import torch
@@ -28,6 +28,16 @@ from ...utils import create_new_process_for_each_test
 
 # Use a tiny model for fast testing
 MODEL_NAME = "hmellor/tiny-random-LlamaForCausalLM"
+
+
+def test_finish_weight_update_invalidates_prefix_cache():
+    llm = object.__new__(LLM)
+    llm.llm_engine = MagicMock()
+
+    LLM.finish_weight_update(llm)
+
+    llm.llm_engine.collective_rpc.assert_called_once_with("finish_weight_update")
+    llm.llm_engine.reset_prefix_cache.assert_called_once_with()
 
 
 # --- Mock Weight Transfer Engine ---

--- a/tests/model_executor/model_loader/test_modelwise_reload.py
+++ b/tests/model_executor/model_loader/test_modelwise_reload.py
@@ -1,0 +1,207 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from unittest.mock import Mock
+
+import pytest
+import torch
+
+from vllm.model_executor.layers.quantization.base_config import QuantizeMethodBase
+from vllm.model_executor.model_loader.reload.modelwise import (
+    ModelwiseReloader,
+    ModelwiseReloadSession,
+    record_modelwise_reload_metadata,
+)
+from vllm.model_executor.model_loader.utils import process_weights_after_loading
+
+
+class _Int8Method(QuantizeMethodBase):
+    def create_weights(self, layer: torch.nn.Module, *args, **kwargs) -> None:
+        raise NotImplementedError
+
+    def apply(self, layer: torch.nn.Module, *args, **kwargs) -> torch.Tensor:
+        raise NotImplementedError
+
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        source = layer.weight.detach()
+        layer.weight_scale = source.abs().max().reshape(1)
+        value = source.round().to(torch.int8)
+        layer.weight = torch.nn.Parameter(value, requires_grad=False)
+
+
+class _ReloadableQuantModel(torch.nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.layer = torch.nn.Module()
+        self.layer.weight = torch.nn.Parameter(torch.empty(2))
+        self.layer.register_parameter("bias", None)
+        self.layer.register_buffer("weight_scale", torch.empty(1))
+        self.layer.register_buffer(
+            "runtime_cache", torch.tensor([11.0]), persistent=False
+        )
+        self.layer.quant_method = _Int8Method()
+
+    def load_weights(self, weights):
+        loaded = set()
+        for name, value in weights:
+            self.get_parameter(name).data.copy_(value)
+            loaded.add(name)
+        return loaded
+
+
+def _make_runtime_model() -> _ReloadableQuantModel:
+    model = _ReloadableQuantModel()
+    record_modelwise_reload_metadata(model)
+    model.load_weights([("layer.weight", torch.tensor([1.0, 2.0]))])
+    process_weights_after_loading(model, Mock(), torch.device("cpu"))
+    return model
+
+
+def test_modelwise_reload_copies_processed_values_to_runtime_storage() -> None:
+    model = _make_runtime_model()
+    runtime_weight = model.layer.weight
+    runtime_ptr = runtime_weight.untyped_storage().data_ptr()
+    runtime_scale = model.layer.weight_scale
+    runtime_scale_ptr = runtime_scale.untyped_storage().data_ptr()
+
+    loaded = ModelwiseReloader(model, Mock(), torch.device("cpu")).reload(
+        [("layer.weight", torch.tensor([3.0, 4.0]))]
+    )
+
+    assert loaded == {"layer.weight"}
+    assert model.layer.weight is runtime_weight
+    assert model.layer.weight.untyped_storage().data_ptr() == runtime_ptr
+    assert torch.equal(model.layer.weight, torch.tensor([3, 4], dtype=torch.int8))
+    assert model.layer.weight_scale is runtime_scale
+    assert model.layer.weight_scale.untyped_storage().data_ptr() == runtime_scale_ptr
+    assert torch.equal(model.layer.weight_scale, torch.tensor([4.0]))
+    assert model.layer.bias is None
+
+
+def test_modelwise_reload_restores_runtime_bindings_after_load_failure() -> None:
+    model = _make_runtime_model()
+    runtime_weight = model.layer.weight
+    original = runtime_weight.clone()
+
+    def fail_after_write(weights):
+        for name, value in weights:
+            model.get_parameter(name).data.copy_(value)
+            raise RuntimeError("load failed")
+
+    model.load_weights = fail_after_write
+
+    with pytest.raises(RuntimeError, match="load failed"):
+        ModelwiseReloader(model, Mock(), torch.device("cpu")).reload(
+            [("layer.weight", torch.tensor([9.0, 9.0]))]
+        )
+
+    assert model.layer.weight is runtime_weight
+    assert torch.equal(model.layer.weight, original)
+
+
+def test_modelwise_reload_preserves_tied_parameter_aliases() -> None:
+    class TiedModel(torch.nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.left = torch.nn.Module()
+            self.right = torch.nn.Module()
+            weight = torch.nn.Parameter(torch.zeros(2))
+            self.left.weight = weight
+            self.right.weight = weight
+
+        def load_weights(self, weights):
+            loaded = set()
+            for name, value in weights:
+                self.get_parameter(name).data.copy_(value)
+                loaded.add(name)
+            return loaded
+
+    model = TiedModel()
+    record_modelwise_reload_metadata(model)
+    runtime_weight = model.left.weight
+
+    ModelwiseReloader(model, Mock(), torch.device("cpu")).reload(
+        [("left.weight", torch.tensor([5.0, 6.0]))]
+    )
+
+    assert model.left.weight is runtime_weight
+    assert model.right.weight is runtime_weight
+    assert torch.equal(runtime_weight, torch.tensor([5.0, 6.0]))
+
+
+def test_modelwise_session_processes_only_at_explicit_finish() -> None:
+    model = _make_runtime_model()
+    runtime_weight = model.layer.weight
+    runtime_scale = model.layer.weight_scale
+    runtime_cache = model.layer.runtime_cache
+    session = ModelwiseReloadSession(model, Mock(), torch.device("cpu"))
+
+    session.start()
+    session.load_weights([("layer.weight", torch.tensor([7.0, 8.0]))])
+
+    # The serving tensors remain detached while checkpoint chunks are loaded,
+    # and quantization/PWAL has not run merely because a tensor was received.
+    assert model.layer.weight is not runtime_weight
+    assert model.layer.weight.dtype == torch.float32
+    assert model.layer.weight_scale is not runtime_scale
+    assert model.layer.runtime_cache is runtime_cache
+    assert torch.equal(model.layer.runtime_cache, torch.tensor([11.0]))
+
+    loaded = session.finish()
+
+    assert loaded == {"layer.weight"}
+    assert model.layer.weight is runtime_weight
+    assert model.layer.weight_scale is runtime_scale
+    assert model.layer.runtime_cache is runtime_cache
+    assert torch.equal(runtime_weight, torch.tensor([7, 8], dtype=torch.int8))
+    assert torch.equal(runtime_scale, torch.tensor([8.0]))
+
+
+def test_modelwise_session_accepts_multiple_chunks_without_numel_completion() -> None:
+    class TwoWeightModel(torch.nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.first = torch.nn.Parameter(torch.zeros(1))
+            self.second = torch.nn.Parameter(torch.zeros(3))
+            self.pwal_calls = 0
+
+        def load_weights(self, weights):
+            loaded = set()
+            for name, value in weights:
+                self.get_parameter(name).data.copy_(value)
+                loaded.add(name)
+            return loaded
+
+    model = TwoWeightModel()
+    record_modelwise_reload_metadata(model)
+    first = model.first
+    second = model.second
+    session = ModelwiseReloadSession(model, Mock(), torch.device("cpu"))
+    session.start()
+
+    # Different tensor sizes and arbitrary chunk boundaries do not trigger a
+    # completion heuristic. The caller's finish signal is the only boundary.
+    session.load_weights([("second", torch.tensor([2.0, 3.0, 4.0]))])
+    session.load_weights([("first", torch.tensor([1.0]))])
+    assert model.first is not first
+    assert model.second is not second
+
+    assert session.finish() == {"first", "second"}
+    assert model.first is first
+    assert model.second is second
+    assert torch.equal(first, torch.tensor([1.0]))
+    assert torch.equal(second, torch.tensor([2.0, 3.0, 4.0]))
+
+
+def test_modelwise_session_abort_discards_received_weights() -> None:
+    model = _make_runtime_model()
+    runtime_weight = model.layer.weight
+    original = runtime_weight.clone()
+    session = ModelwiseReloadSession(model, Mock(), torch.device("cpu"))
+    session.start()
+    session.load_weights([("layer.weight", torch.tensor([9.0, 9.0]))])
+
+    session.abort()
+
+    assert model.layer.weight is runtime_weight
+    assert torch.equal(runtime_weight, original)

--- a/tests/model_executor/model_loader/test_moe_experts_storage_stability.py
+++ b/tests/model_executor/model_loader/test_moe_experts_storage_stability.py
@@ -1,0 +1,333 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Registry-wide storage stability for MoE experts backends.
+
+``test_post_load_storage_stability.py`` sweeps mixed-precision *linear*
+kernels off ``_POSSIBLE_KERNELS``. The MoE experts backends -- FlashInfer,
+TRT-LLM, NVFP4, CUTLASS fp8/w4a8, B12x -- are selected through an entirely
+separate mechanism (the ``fused_moe/oracle/*`` modules), so the linear
+sweep never touches them. This is the MoE analogue, and it is the
+enumeration that must name every unmigrated MoE backend.
+
+Two layers, because each answers a different question and has a different
+dependency:
+
+  enumeration + static classification (no hardware, always runs)
+      Walk every oracle's ``Backend`` enum through ``backend_to_kernel_cls``
+      to collect every experts class any MoE path can select. For each,
+      inspect whether its constructor (and any lazy-scratch getter) routes
+      graph-visible allocations through the reload arena or allocates raw.
+      A raw allocator that is not arena-routed is a worklist entry. This is
+      hardware-independent: it lists SM100 / SM120 / ROCm backends that
+      cannot be constructed here.
+
+  dynamic construct-twice census (needs a constructible class)
+      For classes that build with a synthetic fp8 config, construct twice
+      under the same layer's arena scope -- the rebuild a reload performs --
+      and assert the storage allocated in ``__init__`` is reused. Proves the
+      migrated CUTLASS families green; skips (by name, so still enumerated)
+      the hardware-gated ones.
+
+The static layer can misjudge an exotic allocation idiom, so it is advisory
+(``xfail``/report), never the sole gate; the dynamic layer is ground truth
+where it runs.
+"""
+
+import inspect
+
+import pytest
+import torch
+
+from vllm.platforms import current_platform
+
+# ---------------------------------------------------------------------------
+# Enumeration: every experts class every oracle can return.
+# ---------------------------------------------------------------------------
+
+# (oracle module, Backend enum attr, backend_to_kernel_cls attr). Kept
+# explicit rather than globbed so a newly added oracle is a visible,
+# reviewed addition rather than a silent omission.
+_ORACLES = [
+    ("vllm.model_executor.layers.fused_moe.oracle.fp8",
+     "Fp8MoeBackend", "backend_to_kernel_cls"),
+    ("vllm.model_executor.layers.fused_moe.oracle.nvfp4",
+     "NvFp4MoeBackend", "backend_to_kernel_cls"),
+    ("vllm.model_executor.layers.fused_moe.oracle.int_wna16",
+     "WNA16MoEBackend", "backend_to_kernel_cls"),
+    ("vllm.model_executor.layers.fused_moe.oracle.unquantized",
+     "UnquantizedMoeBackend", "backend_to_kernel_cls"),
+    ("vllm.model_executor.layers.fused_moe.oracle.w4a8",
+     "W4A8MoeBackend", "backend_to_kernel_cls"),
+    ("vllm.model_executor.layers.fused_moe.oracle.w4a8_int8",
+     "W4A8Int8MoeBackend", "backend_to_kernel_cls"),
+    ("vllm.model_executor.layers.fused_moe.oracle.int8",
+     "Int8MoeBackend", "backend_to_kernel_cls"),
+]
+
+
+def _import(mod_name):
+    import importlib
+    try:
+        return importlib.import_module(mod_name)
+    except Exception:
+        return None
+
+
+def enumerate_experts_classes() -> dict[str, type]:
+    """Map class name -> experts class across every oracle.
+
+    Backend members whose ``backend_to_kernel_cls`` raises (an optional
+    dependency missing at import) are skipped for that member, not for the
+    whole oracle: the goal is the widest set the registry can name.
+    """
+    seen: dict[str, type] = {}
+    for mod_name, enum_attr, fn_attr in _ORACLES:
+        module = _import(mod_name)
+        if module is None:
+            continue
+        fn = getattr(module, fn_attr, None)
+        enum_cls = getattr(module, enum_attr, None) if enum_attr else None
+        members = list(enum_cls) if enum_cls is not None else []
+        for member in members:
+            try:
+                result = fn(member)
+            except Exception:
+                continue
+            classes = result if isinstance(result, (list, tuple)) else [result]
+            for cls in classes:
+                if isinstance(cls, type):
+                    seen.setdefault(cls.__name__, cls)
+    return seen
+
+
+# ---------------------------------------------------------------------------
+# Static classification: does the class route allocations through the arena?
+# ---------------------------------------------------------------------------
+
+_RAW_ALLOC = ("torch.empty", "torch.zeros", "torch.full", "torch.arange",
+              "torch.tensor", "torch.ones", "torch.randn")
+_ARENA_MARKERS = ("current_arena", "get_reload_arena", "reload_arena",
+                  "arena.put", "arena.get_or_alloc", "_stable(", "arena=")
+
+# Classes with no graph-visible runtime tensors of their own, verified by
+# reading them: they delegate to sub-experts or hold only references to
+# already-managed parameters. Listed so the static layer does not flag them
+# and so the exemption is reviewable.
+_KNOWN_NO_RUNTIME_TENSORS = {
+    "TritonExperts", "BatchedTritonExperts", "TritonOrDeepGemmExperts",
+    "BatchedDeepGemmExperts", "MarlinExperts", "CPUExpertsFp8",
+    "TritonOrCutlassExperts",  # thin wrapper; inner class is swept separately
+}
+
+
+def _sources(cls) -> str:
+    """__init__ plus any lazy-scratch getter, concatenated."""
+    chunks = []
+    for name in ("__init__", "_get_permute_scratch", "process_weights_"
+                 "after_loading"):
+        fn = getattr(cls, name, None)
+        if fn is None:
+            continue
+        try:
+            chunks.append(inspect.getsource(fn))
+        except (OSError, TypeError):
+            pass
+    return "\n".join(chunks)
+
+
+def classify(cls) -> str:
+    """'no-runtime' | 'arena' | 'raw' | 'unknown'."""
+    if cls.__name__ in _KNOWN_NO_RUNTIME_TENSORS:
+        return "no-runtime"
+    src = _sources(cls)
+    if not src:
+        return "unknown"
+    allocates = any(marker in src for marker in _RAW_ALLOC)
+    arena_routed = any(marker in src for marker in _ARENA_MARKERS)
+    if not allocates:
+        return "no-runtime"
+    return "arena" if arena_routed else "raw"
+
+
+# The migrated CUTLASS families as the registry actually surfaces them.
+# The plain CutlassExpertsFp8 is not returned directly -- VLLM_CUTLASS
+# resolves to the TritonOrCutlassExperts wrapper, which constructs it
+# internally -- but its sibling CutlassBatchedExpertsFp8 and the w4a8 class
+# are surfaced, and all three share the migrated CutlassExpertsFp8Base.
+_MIGRATED_CUTLASS = ("CutlassBatchedExpertsFp8", "CutlassExpertsW4A8Fp8")
+
+
+def test_registry_enumerates_the_known_moe_backends():
+    """Guards the enumeration itself: if this drops to a handful, the sweep
+    below is silently covering almost nothing."""
+    classes = enumerate_experts_classes()
+    assert len(classes) >= 8, sorted(classes)
+    # a migrated family must be present, or the green proof is empty
+    assert any(name in classes for name in _MIGRATED_CUTLASS), sorted(classes)
+
+
+def test_report_moe_experts_worklist(capsys):
+    """Print the classification of every enumerated experts class. This is
+    the worklist artifact: 'raw' entries are unmigrated backends that own
+    graph-visible storage."""
+    classes = enumerate_experts_classes()
+    buckets: dict[str, list[str]] = {"arena": [], "raw": [],
+                                     "no-runtime": [], "unknown": []}
+    for name, cls in sorted(classes.items()):
+        buckets[classify(cls)].append(name)
+
+    with capsys.disabled():
+        print("\n=== MoE experts storage classification ===")
+        for kind in ("raw", "arena", "no-runtime", "unknown"):
+            print(f"  {kind} ({len(buckets[kind])}): {buckets[kind]}")
+
+    # A migrated family is the proof the 'arena' bucket is real.
+    assert any(name in buckets["arena"] for name in _MIGRATED_CUTLASS), \
+        buckets["arena"]
+
+
+# The unmigrated backends we already know own graph-visible storage but
+# cannot fix without their hardware. Recorded as expected-raw so a
+# regression (one silently disappearing from the registry, or being
+# mislabeled arena without a real migration) is visible, and so the debt is
+# explicit rather than buried in a print.
+_KNOWN_RAW_WORKLIST = {
+    "FlashInferExperts",           # gemm1_alpha/beta/clamp_limit constants
+    "TrtLlmFp8ExpertsModular",     # SM100 expert constants
+    "TrtLlmFp8ExpertsMonolithic",
+}
+
+
+@pytest.mark.parametrize("cls_name", sorted(_KNOWN_RAW_WORKLIST))
+def test_known_worklist_backends_are_still_flagged(cls_name):
+    classes = enumerate_experts_classes()
+    if cls_name not in classes:
+        pytest.skip(f"{cls_name} not selectable in this build")
+    kind = classify(classes[cls_name])
+    assert kind == "raw", (
+        f"{cls_name} classified '{kind}', expected 'raw'. If it was migrated "
+        "to the arena, move it off the worklist; if the classifier now "
+        "misreads it, tighten the heuristic.")
+
+
+# ---------------------------------------------------------------------------
+# Dynamic ground truth: construct twice under an arena scope, census storage.
+# ---------------------------------------------------------------------------
+
+DEVICE = torch.device("cuda" if current_platform.is_cuda_alike() else "cpu")
+
+
+def _fp8_moe_config():
+    from vllm.model_executor.layers.fused_moe.config import (
+        FusedMoEConfig, FusedMoEParallelConfig, RoutingMethodType)
+    from vllm.model_executor.layers.fused_moe.activation import MoEActivation
+
+    return FusedMoEConfig(
+        num_experts=8, experts_per_token=2, hidden_dim=256,
+        intermediate_size=256, num_local_experts=8, num_logical_experts=8,
+        activation=MoEActivation.SILU, device=str(DEVICE),
+        moe_parallel_config=FusedMoEParallelConfig.make_no_parallel(),
+        in_dtype=torch.bfloat16, routing_method=RoutingMethodType.TopK,
+        intermediate_size_per_partition=256,
+    )
+
+
+def _census(obj) -> dict[str, int]:
+    out = {}
+    for name, value in vars(obj).items():
+        if isinstance(value, torch.Tensor) and value.numel():
+            out[name] = value.data_ptr()
+    return out
+
+
+@pytest.mark.skipif(not current_platform.is_cuda_alike(),
+                    reason="stride allocation needs an accelerator")
+@pytest.mark.parametrize("cls_name", list(_MIGRATED_CUTLASS))
+def test_migrated_experts_reuse_storage_across_rebuild(cls_name, dist_init):
+    """The migrated families must reuse the stride storage they allocate in
+    __init__ when the experts object is rebuilt, which is what PWAL does on
+    reload.
+
+    The stride tensors depend only on moe_config (num_experts / hidden /
+    intermediate), not on the quant config, so a minimal quant config is
+    enough to reach the allocation under test. Full end-to-end construction
+    of these classes is additionally covered on real models by the
+    cat1_cutlass_fp8 / cat1_w4a8_scratch reproductions and by
+    test_reload_lazy_storage.py.
+    """
+    from vllm.model_executor.layers.fused_moe.config import (
+        FusedMoEQuantConfig)
+    from vllm.model_executor.reload_arena import (arena_scope,
+                                                  get_reload_arena)
+    classes = enumerate_experts_classes()
+    if cls_name not in classes:
+        pytest.skip(f"{cls_name} not selectable in this build")
+    cls = classes[cls_name]
+
+    moe_config = _fp8_moe_config()
+    try:
+        quant_config = FusedMoEQuantConfig.make(
+            quant_dtype=torch.float8_e4m3fn,
+            per_act_token_quant=True,
+            per_out_ch_quant=True,
+        )
+    except Exception as e:
+        pytest.skip(f"cannot build a minimal quant config: {e}")
+
+    layer = torch.nn.Module()
+    arena = get_reload_arena(layer)
+
+    def build():
+        try:
+            with arena_scope(arena):
+                if cls_name == "CutlassExpertsW4A8Fp8":
+                    e = moe_config.num_local_experts
+                    strides = torch.full((e,), 256, dtype=torch.int64,
+                                         device=DEVICE)
+                    return cls(moe_config, quant_config, strides, strides, 128)
+                # Batched format requires an explicit token/dispatcher count.
+                return cls(moe_config, quant_config, max_num_tokens=64,
+                           num_dispatchers=1)
+        except (RuntimeError, AssertionError, NotImplementedError,
+                ImportError, TypeError, ValueError) as e:
+            pytest.skip(f"{cls_name} not constructible here: {e}")
+
+    first = build()
+    before = _census(first)
+    if not before:
+        pytest.skip(f"{cls_name} allocated no stride tensors in __init__")
+
+    del first
+    second = build()  # the rebuild
+    after = _census(second)
+
+    drifted = sorted(k for k, ptr in before.items() if after.get(k) != ptr)
+    assert not drifted, (
+        f"{cls_name} rebound {drifted} across a rebuild; captured graphs "
+        "hold the previous addresses despite the arena scope")
+
+
+@pytest.fixture(scope="module")
+def dist_init():
+    import os
+    import tempfile
+    from vllm.config import VllmConfig, set_current_vllm_config
+    from vllm.distributed import (cleanup_dist_env_and_memory,
+                                  init_distributed_environment,
+                                  initialize_model_parallel)
+
+    fd, temp_file = tempfile.mkstemp()
+    os.close(fd)
+    try:
+        with set_current_vllm_config(VllmConfig()):
+            init_distributed_environment(
+                world_size=1, rank=0,
+                distributed_init_method=f"file://{temp_file}",
+                local_rank=0,
+                backend="nccl" if current_platform.is_cuda_alike() else "gloo")
+            initialize_model_parallel(1, 1)
+            yield
+        cleanup_dist_env_and_memory()
+    finally:
+        if os.path.exists(temp_file):
+            os.unlink(temp_file)

--- a/tests/model_executor/model_loader/test_moe_experts_storage_stability.py
+++ b/tests/model_executor/model_loader/test_moe_experts_storage_stability.py
@@ -52,6 +52,8 @@ _ORACLES = [
      "Fp8MoeBackend", "backend_to_kernel_cls"),
     ("vllm.model_executor.layers.fused_moe.oracle.nvfp4",
      "NvFp4MoeBackend", "backend_to_kernel_cls"),
+    ("vllm.model_executor.layers.fused_moe.oracle.mxfp4",
+     "Mxfp4MoeBackend", "backend_to_kernel_cls"),
     ("vllm.model_executor.layers.fused_moe.oracle.int_wna16",
      "WNA16MoEBackend", "backend_to_kernel_cls"),
     ("vllm.model_executor.layers.fused_moe.oracle.unquantized",
@@ -117,6 +119,9 @@ _KNOWN_NO_RUNTIME_TENSORS = {
     "TritonExperts", "BatchedTritonExperts", "TritonOrDeepGemmExperts",
     "BatchedDeepGemmExperts", "MarlinExperts", "CPUExpertsFp8",
     "TritonOrCutlassExperts",  # thin wrapper; inner class is swept separately
+    # Constructor temporaries are promoted to registered layer parameters by
+    # PWAL before graph capture, so reload copy-back owns their final storage.
+    "TrtLlmNvFp4ExpertsModular", "TrtLlmNvFp4ExpertsMonolithic",
 }
 
 
@@ -191,23 +196,12 @@ def test_report_moe_experts_worklist(capsys):
 # regression (one silently disappearing from the registry, or being
 # mislabeled arena without a real migration) is visible, and so the debt is
 # explicit rather than buried in a print.
-_KNOWN_RAW_WORKLIST = {
-    "FlashInferExperts",           # gemm1_alpha/beta/clamp_limit constants
-    "TrtLlmFp8ExpertsModular",     # SM100 expert constants
-    "TrtLlmFp8ExpertsMonolithic",
-}
-
-
-@pytest.mark.parametrize("cls_name", sorted(_KNOWN_RAW_WORKLIST))
-def test_known_worklist_backends_are_still_flagged(cls_name):
+def test_no_enumerated_moe_backend_has_raw_runtime_allocations():
     classes = enumerate_experts_classes()
-    if cls_name not in classes:
-        pytest.skip(f"{cls_name} not selectable in this build")
-    kind = classify(classes[cls_name])
-    assert kind == "raw", (
-        f"{cls_name} classified '{kind}', expected 'raw'. If it was migrated "
-        "to the arena, move it off the worklist; if the classifier now "
-        "misreads it, tighten the heuristic.")
+    raw = sorted(name for name, cls in classes.items() if classify(cls) == "raw")
+    assert not raw, (
+        "MoE backends allocate graph-visible runtime tensors without the "
+        f"reload arena: {raw}")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/model_executor/model_loader/test_post_load_storage_stability.py
+++ b/tests/model_executor/model_loader/test_post_load_storage_stability.py
@@ -1,0 +1,318 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Registry-wide post-load storage stability.
+
+Weight reload reruns ``process_weights_after_loading`` (PWAL). Registered
+parameters and buffers are protected by copy-back; anything else a PWAL
+pass binds -- kernel attributes, bare layer attributes, tensors captured
+inside callables -- can be silently rebound, leaving captured CUDA graphs
+pointing at freed or stale memory (#48312 category 1).
+
+The unit of that bug is PWAL idempotency, not reload. A reload is
+restore-to-meta -> load -> PWAL -> copy-back, and only PWAL rebinds runtime
+storage. So running PWAL twice over a synthetic layer reproduces the
+rebinding **without a checkpoint, an engine, or a second weight load** --
+which is what makes this affordable as a per-commit check rather than a
+production gate.
+
+Coverage is driven off the kernel registry, so a newly registered backend
+is checked the day it lands: nothing to implement, nothing to declare, it
+simply must not drift.
+
+Known scope limits, deliberately not papered over:
+  * Storage allocated on the FIRST FORWARD rather than during post-load is
+    invisible here. The MoE permute scratch that produced a reproduced
+    illegal-memory-access on H200 is exactly that shape; see
+    ``test_reload_lazy_storage.py`` for the variant that covers it.
+  * Bugs arising from the copy-back interaction (parameter-alias buffers,
+    unloaded non-persistent buffers) need the real layerwise path and are
+    not modelled by a synthetic layer.
+  * ``object.__new__`` bypasses ``can_implement``, so a pass says the
+    post-load path is stable, not that the kernel is deployable in that
+    configuration.
+"""
+
+import functools
+import os
+import tempfile
+
+import pytest
+import torch
+
+from vllm.model_executor.kernels.linear import _POSSIBLE_KERNELS
+from vllm.model_executor.kernels.linear.mixed_precision.MPLinearKernel import (
+    MPLinearKernel, MPLinearLayerConfig)
+from vllm.model_executor.parameter import (BasevLLMParameter,
+                                           GroupQuantScaleParameter,
+                                           PackedvLLMParameter)
+from vllm.platforms import current_platform
+from vllm.scalar_type import scalar_types
+
+DEVICE = torch.device("cuda" if current_platform.is_cuda_alike() else "cpu")
+SIZE_K = 256
+SIZE_N = 256
+GROUP_SIZE = 128
+PACK_FACTOR = 8
+
+
+@pytest.fixture(scope="module")
+def dist_init():
+    """Single-rank parallel state.
+
+    vLLM's weight parameter classes query the TP group at construction, so
+    the synthetic layer cannot be built without it. Defined locally rather
+    than taken from tests/conftest.py so this file also runs against an
+    installed wheel, where the repo-root conftest chain is not importable.
+    """
+    from vllm.config import VllmConfig, set_current_vllm_config
+    from vllm.distributed import (cleanup_dist_env_and_memory,
+                                  init_distributed_environment,
+                                  initialize_model_parallel)
+
+    fd, temp_file = tempfile.mkstemp()
+    os.close(fd)  # FileStore opens the path itself; leaving this open leaks
+    try:
+        with set_current_vllm_config(VllmConfig()):
+            init_distributed_environment(
+                world_size=1,
+                rank=0,
+                distributed_init_method=f"file://{temp_file}",
+                local_rank=0,
+                backend="nccl" if current_platform.is_cuda_alike() else "gloo",
+            )
+            initialize_model_parallel(1, 1)
+            yield
+        cleanup_dist_env_and_memory()
+    finally:
+        if os.path.exists(temp_file):
+            os.unlink(temp_file)
+
+
+def _collect(value, path: str, out: dict[str, int], depth: int) -> None:
+    """data_ptr census over attributes, containers, partial bindings and
+    closure cells -- the four ways a rebindable tensor hides."""
+    if depth < 0:
+        return
+    if isinstance(value, torch.Tensor):
+        if value.numel():
+            out[path] = value.data_ptr()
+        return
+    if isinstance(value, functools.partial):
+        for i, arg in enumerate(value.args):
+            _collect(arg, f"{path}.args[{i}]", out, depth - 1)
+        for key, arg in (value.keywords or {}).items():
+            _collect(arg, f"{path}.kw[{key}]", out, depth - 1)
+        return
+    if callable(value) and getattr(value, "__closure__", None):
+        for i, cell in enumerate(value.__closure__):
+            try:
+                contents = cell.cell_contents
+            except ValueError:
+                continue
+            _collect(contents, f"{path}.closure[{i}]", out, depth - 1)
+        return
+    if isinstance(value, (list, tuple)):
+        for i, item in enumerate(value):
+            _collect(item, f"{path}[{i}]", out, depth - 1)
+        return
+    if isinstance(value, dict):
+        for key, item in value.items():
+            _collect(item, f"{path}[{key!r}]", out, depth - 1)
+
+
+# nn.Module's own registries. Registered parameters and buffers are exactly
+# what reload copy-back restores, so they are out of scope here: this test
+# is about the storage that escapes that protection. Walking them would
+# also report the synthetic reload's fresh parameters as drift.
+_MANAGED_CONTAINERS = ("_parameters", "_buffers", "_modules",
+                       "_non_persistent_buffers_set")
+
+
+def tensor_slots(*holders, depth: int = 3) -> dict[str, int]:
+    out: dict[str, int] = {}
+    for holder in holders:
+        tag = type(holder).__name__
+        for name, value in list(vars(holder).items()):
+            if name.startswith("__") or name in _MANAGED_CONTAINERS:
+                continue
+            _collect(value, f"{tag}.{name}", out, depth)
+    return out
+
+
+def _drifted(before: dict[str, int], after: dict[str, int]) -> list[str]:
+    return sorted(path for path, ptr in before.items()
+                  if after.get(path) != ptr)
+
+
+def make_config(has_g_idx: bool) -> MPLinearLayerConfig:
+    return MPLinearLayerConfig(
+        full_weight_shape=(SIZE_K, SIZE_N),
+        partition_weight_shape=(SIZE_K, SIZE_N),
+        weight_type=scalar_types.uint4b8,
+        act_type=torch.float16,
+        group_size=GROUP_SIZE,
+        zero_points=False,
+        has_g_idx=has_g_idx,
+    )
+
+
+def build_layer(has_g_idx: bool) -> torch.nn.Module:
+    layer = torch.nn.Module()
+    layer.input_size = SIZE_K
+    layer.input_size_per_partition = SIZE_K
+    layer.output_size = SIZE_N
+    layer.output_size_per_partition = SIZE_N
+    layer.output_partition_sizes = [SIZE_N]
+    layer.params_dtype = torch.float16
+    layer.has_bias = False
+    return layer
+
+
+def load_weights(layer: torch.nn.Module, has_g_idx: bool, seed: int) -> None:
+    """Bind checkpoint-format parameters, as a real load would.
+
+    Called before each PWAL pass with a different seed: the second pass is
+    the reload, and different values make sure a stability pass is not an
+    identity no-op.
+    """
+    gen = torch.Generator(device="cpu").manual_seed(seed)
+    num_groups = SIZE_K // GROUP_SIZE
+
+    qweight = PackedvLLMParameter(
+        data=torch.randint(-(2**31), 2**31 - 1,
+                           (SIZE_K // PACK_FACTOR, SIZE_N),
+                           dtype=torch.int32, generator=gen).to(DEVICE),
+        input_dim=0, output_dim=1, packed_dim=0, packed_factor=PACK_FACTOR,
+        weight_loader=lambda *a, **k: None,
+    )
+    scales = GroupQuantScaleParameter(
+        data=torch.rand((num_groups, SIZE_N), dtype=torch.float16,
+                        generator=gen).to(DEVICE) + 0.01,
+        input_dim=0, output_dim=1,
+        weight_loader=lambda *a, **k: None,
+    )
+    layer.register_parameter("qweight", qweight)
+    layer.register_parameter("scales", scales)
+
+    if has_g_idx:
+        g_idx = BasevLLMParameter(
+            data=(torch.arange(SIZE_K, dtype=torch.int32) // GROUP_SIZE
+                  ).to(DEVICE),
+            weight_loader=lambda *a, **k: None,
+        )
+        layer.register_parameter("g_idx", g_idx)
+
+
+def registry_kernels() -> list[type[MPLinearKernel]]:
+    """Every kernel any platform can select. Driving off the registry is
+    what makes coverage automatic for backends added later."""
+    seen: dict[str, type[MPLinearKernel]] = {}
+    for kernels in _POSSIBLE_KERNELS.values():
+        for kernel_cls in kernels:
+            seen.setdefault(kernel_cls.__name__, kernel_cls)
+    return sorted(seen.values(), key=lambda k: k.__name__)
+
+
+@pytest.mark.parametrize("has_g_idx", [False, True],
+                         ids=["plain", "act_order"])
+@pytest.mark.parametrize("kernel_cls", registry_kernels(),
+                         ids=lambda k: k.__name__)
+def test_post_load_runtime_storage_is_stable(kernel_cls, has_g_idx,
+                                             dist_init):
+    config = make_config(has_g_idx)
+
+    ok, reason = kernel_cls.can_implement(config)
+    if not ok:
+        pytest.skip(f"can_implement: {reason}")
+    kernel = kernel_cls(config, "qweight", "scales", None,
+                        "g_idx" if has_g_idx else None)
+
+    layer = build_layer(has_g_idx)
+
+    def post_load(seed: int):
+        load_weights(layer, has_g_idx, seed)
+        try:
+            kernel.process_weights_after_loading(layer)
+        except (RuntimeError, NotImplementedError, AssertionError,
+                OSError, AttributeError) as e:
+            pytest.skip(f"post-load needs unavailable device support: {e}")
+
+    post_load(seed=0)
+    before = tensor_slots(layer, kernel)
+    post_load(seed=1)  # the reload
+    after = tensor_slots(layer, kernel)
+
+    drifted = _drifted(before, after)
+    assert not drifted, (
+        f"{kernel_cls.__name__} rebound runtime storage across a second "
+        f"post-load pass: {drifted}. Captured graphs hold the previous "
+        "addresses. Allocate through the layer's ReloadArena "
+        "(vllm/model_executor/reload_arena.py) so the storage is reused."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Canaries. A sweep that only ever passes is indistinguishable from a sweep
+# that cannot fail, so both directions are pinned here: the census must go
+# red on a kernel that rebinds, and green on the same kernel once it
+# allocates through the arena.
+# ---------------------------------------------------------------------------
+
+
+class _DriftingKernel:
+    """Post-load that reallocates its workspace every pass -- the shape of
+    the reproduced Marlin livelock and CUTLASS stride failures."""
+
+    def process_weights_after_loading(self, layer):
+        self.workspace = torch.zeros(16, dtype=torch.int32, device=DEVICE)
+        layer.sort_indices = torch.arange(8, dtype=torch.int32, device=DEVICE)
+
+
+class _ArenaKernel:
+    """Same allocations, routed through the layer's arena."""
+
+    def process_weights_after_loading(self, layer):
+        from vllm.model_executor.reload_arena import get_reload_arena
+        arena = get_reload_arena(layer)
+        self.workspace = arena.put(
+            "workspace", torch.zeros(16, dtype=torch.int32, device=DEVICE))
+        layer.sort_indices = arena.put(
+            "sort_indices",
+            torch.arange(8, dtype=torch.int32, device=DEVICE))
+
+
+class _ClosureDriftingKernel:
+    """Rebinding hidden inside a kernel-held callable: invisible to a plain
+    attribute comparison, which is how the Machete act_perm bug escaped."""
+
+    def process_weights_after_loading(self, layer):
+        perm = torch.arange(8, dtype=torch.int32, device=DEVICE)
+        self.apply_perm = lambda x: x[:, perm]
+
+
+def test_canary_census_catches_a_rebinding_kernel():
+    layer, kernel = torch.nn.Module(), _DriftingKernel()
+    kernel.process_weights_after_loading(layer)
+    before = tensor_slots(layer, kernel)
+    kernel.process_weights_after_loading(layer)
+    drifted = _drifted(before, tensor_slots(layer, kernel))
+    assert len(drifted) == 2, drifted
+    assert any("workspace" in p for p in drifted)
+    assert any("sort_indices" in p for p in drifted)
+
+
+def test_canary_census_catches_a_closure_captured_rebind():
+    layer, kernel = torch.nn.Module(), _ClosureDriftingKernel()
+    kernel.process_weights_after_loading(layer)
+    before = tensor_slots(layer, kernel)
+    kernel.process_weights_after_loading(layer)
+    drifted = _drifted(before, tensor_slots(layer, kernel))
+    assert drifted and all("closure" in p for p in drifted), drifted
+
+
+def test_canary_arena_backed_kernel_is_stable():
+    layer, kernel = torch.nn.Module(), _ArenaKernel()
+    kernel.process_weights_after_loading(layer)
+    before = tensor_slots(layer, kernel)
+    kernel.process_weights_after_loading(layer)
+    assert _drifted(before, tensor_slots(layer, kernel)) == []

--- a/tests/model_executor/model_loader/test_reload_arena.py
+++ b/tests/model_executor/model_loader/test_reload_arena.py
@@ -57,6 +57,18 @@ class TestGetOrAlloc:
         with pytest.raises(ValueError, match="incompatible spec"):
             arena.get_or_alloc("ws", (8, ), torch.int32, "cpu")
 
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="needs cuda")
+    def test_unindexed_cuda_device_matches_indexed(self):
+        # observed live: config-level "cuda" vs slot tensor's "cuda:0"
+        # must not be treated as a respecification -- the mismatch aborted
+        # the first post-reload forward
+        arena = ReloadArena("layer")
+        a = arena.get_or_alloc("s", (4, ), torch.int32, "cuda")
+        b = arena.get_or_alloc("s", (4, ), torch.int32, "cuda:0")
+        c = arena.get_or_alloc("s", (4, ), torch.int32,
+                               torch.device("cuda"))
+        assert a.data_ptr() == b.data_ptr() == c.data_ptr()
+
 
 class TestPut:
 

--- a/tests/model_executor/model_loader/test_reload_arena.py
+++ b/tests/model_executor/model_loader/test_reload_arena.py
@@ -11,8 +11,9 @@ import torch
 from torch import nn
 
 from vllm.model_executor.reload_arena import (
-    InitPolicy, ReloadArena, arena_scope, current_arena, get_reload_arena,
-    peek_reload_arena, snapshot_model_arenas, verify_model_arenas)
+    InitPolicy, ReloadArena, _canonical_device, arena_scope, current_arena,
+    get_reload_arena, peek_reload_arena, snapshot_model_arenas,
+    verify_model_arenas)
 
 
 class TestGetOrAlloc:
@@ -58,7 +59,7 @@ class TestGetOrAlloc:
             arena.get_or_alloc("ws", (8, ), torch.int32, "cpu")
 
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="needs cuda")
-    def test_unindexed_cuda_device_matches_indexed(self):
+    def test_unindexed_accelerator_device_matches_indexed(self):
         # observed live: config-level "cuda" vs slot tensor's "cuda:0"
         # must not be treated as a respecification -- the mismatch aborted
         # the first post-reload forward
@@ -68,6 +69,48 @@ class TestGetOrAlloc:
         c = arena.get_or_alloc("s", (4, ), torch.int32,
                                torch.device("cuda"))
         assert a.data_ptr() == b.data_ptr() == c.data_ptr()
+
+
+class TestDeviceCanonicalization:
+    """Device resolution must not be CUDA-specific: the same unindexed-vs-
+    indexed mismatch would otherwise recur on every other accelerator."""
+
+    def test_cpu_is_not_given_an_index(self):
+        # CPU tensors report a bare "cpu"; canonicalizing to cpu:0 would
+        # manufacture the mismatch this function exists to prevent
+        assert _canonical_device("cpu") == torch.device("cpu")
+        assert _canonical_device(torch.device("cpu")) == torch.device("cpu")
+        arena = ReloadArena("layer")
+        a = arena.get_or_alloc("s", (4, ), torch.int32, "cpu")
+        b = arena.get_or_alloc("s", (4, ), torch.int32, torch.device("cpu"))
+        assert a.data_ptr() == b.data_ptr()
+
+    def test_explicit_index_is_left_alone(self):
+        assert _canonical_device("cuda:3") == torch.device("cuda", 3)
+        assert _canonical_device("xpu:2") == torch.device("xpu", 2)
+
+    def test_unavailable_backend_left_as_given(self):
+        # no guessing for a backend torch cannot resolve; a later spec
+        # mismatch is loud and safe, a wrong guess is not
+        assert _canonical_device("xpu").type == "xpu"
+
+    def test_resolution_is_generic_over_device_type(self, monkeypatch):
+        """Any torch-registered accelerator resolves through its own device
+        module -- this is what keeps the fix from being CUDA-only."""
+
+        class FakeModule:
+            @staticmethod
+            def is_available():
+                return True
+
+            @staticmethod
+            def current_device():
+                return 7
+
+        monkeypatch.setattr(torch, "get_device_module",
+                            lambda t: FakeModule if t == "xpu"
+                            else torch.get_device_module(t))
+        assert _canonical_device("xpu") == torch.device("xpu", 7)
 
 
 class TestPut:

--- a/tests/model_executor/model_loader/test_reload_arena.py
+++ b/tests/model_executor/model_loader/test_reload_arena.py
@@ -154,6 +154,98 @@ class TestPut:
             arena.put("d", torch.ones(4))
 
 
+@pytest.mark.parametrize("quant_mode", ["mxfp4", "fp8"])
+def test_mla_quantized_decode_weights_reuse_arena_storage(
+    monkeypatch, quant_mode
+):
+    """Cover AITER-only MLA PWAL branches without requiring ROCm hardware."""
+    import vllm.model_executor.layers.attention.mla_attention as mla_mod
+
+    layer = mla_mod.MLAAttention.__new__(mla_mod.MLAAttention)
+    nn.Module.__init__(layer)
+    layer.kv_lora_rank = 2
+    layer.num_heads = 2
+    layer.qk_nope_head_dim = 3
+    layer.v_head_dim = 4
+    layer.kv_b_proj = object()
+    layer.quant_config = None
+    layer.is_aiter_triton_fp4_bmm_enabled = quant_mode == "mxfp4"
+    layer.is_aiter_triton_fp8_bmm_enabled = quant_mode == "fp8"
+
+    source = torch.arange(28, dtype=torch.float32).reshape(14, 2)
+    monkeypatch.setattr(
+        mla_mod,
+        "get_and_maybe_dequant_weights",
+        lambda *_args, **_kwargs: source,
+    )
+    monkeypatch.setattr(mla_mod, "should_load_quant_weights", lambda _method: True)
+
+    def fake_quant(value, **_kwargs):
+        return value.contiguous() + 1, torch.full(
+            value.shape[:-1] + (1,), 2.0, dtype=torch.float32
+        )
+
+    if quant_mode == "mxfp4":
+        from vllm.model_executor.layers.quantization.quark import (
+            utils as quark_utils,
+        )
+
+        monkeypatch.setattr(
+            quark_utils, "quark_quantize_weight_to_mxfp4", fake_quant
+        )
+    else:
+        monkeypatch.setattr(mla_mod, "dynamic_per_batched_tensor_quant", fake_quant)
+        monkeypatch.setattr(mla_mod, "is_global_first_rank", lambda: False)
+        monkeypatch.setattr(
+            mla_mod.rocm_aiter_ops,
+            "triton_fp8_bmm",
+            lambda *_args, **_kwargs: None,
+        )
+
+    layer.process_weights_after_loading(torch.float32)
+    names = ("W_K", "W_K_scale", "W_V", "W_V_scale")
+    before = {name: getattr(layer, name).data_ptr() for name in names}
+
+    source.add_(100)
+    layer.process_weights_after_loading(torch.float32)
+    after = {name: getattr(layer, name).data_ptr() for name in names}
+
+    assert after == before
+    assert torch.all(layer.W_K > 50)
+
+
+def test_wna8o8_detached_activation_scales_reuse_arena_storage():
+    from vllm.model_executor.layers.quantization.compressed_tensors.schemes import (
+        compressed_tensors_wNa8o8 as wna8o8,
+    )
+
+    class NoopKernel:
+        def process_weights_after_loading(self, _layer):
+            return None
+
+    cls = wna8o8.CompressedTensorsWNA8O8Int
+    scheme = cls.__new__(cls)
+    scheme.is_int_quantized = False
+    scheme.kernel = NoopKernel()
+    layer = nn.Module()
+
+    def load_scales(input_value, output_value):
+        layer.input_scale = nn.Parameter(torch.tensor([input_value]))
+        layer.output_scale = nn.Parameter(torch.tensor([output_value]))
+
+    load_scales(1.0, 2.0)
+    scheme.process_weights_after_loading(layer)
+    before = (scheme._input_scale.data_ptr(), scheme._output_scale.data_ptr())
+
+    load_scales(3.0, 4.0)
+    scheme.process_weights_after_loading(layer)
+    after = (scheme._input_scale.data_ptr(), scheme._output_scale.data_ptr())
+
+    assert after == before
+    assert scheme._input_scale.item() == 3.0
+    assert scheme._output_scale.item() == 4.0
+
+
 class TestSnapshotVerify:
 
     def test_clean_roundtrip(self):

--- a/tests/model_executor/model_loader/test_reload_arena.py
+++ b/tests/model_executor/model_loader/test_reload_arena.py
@@ -269,6 +269,46 @@ def test_wna8o8_detached_activation_scales_reuse_arena_storage():
     assert scheme._output_scale.item() == 4.0
 
 
+def test_b12x_experts_rebuild_reuses_arena_object_slot(monkeypatch):
+    from vllm.model_executor.layers.fused_moe.experts.flashinfer_b12x_moe import (
+        FlashInferB12xExperts,
+    )
+
+    arena = ReloadArena("routed_experts")
+    build_calls = []
+
+    def make_experts():
+        experts = FlashInferB12xExperts.__new__(FlashInferB12xExperts)
+        experts._wrapper = None
+        monkeypatch.setattr(
+            experts,
+            "_build_wrapper",
+            lambda: build_calls.append(1) or object(),
+        )
+        return experts
+
+    first = make_experts()
+    first._bind_arena_wrapper(arena)
+    snap = arena.snapshot()
+    rebuilt = make_experts()
+    rebuilt._bind_arena_wrapper(arena)
+
+    assert rebuilt._wrapper is first._wrapper
+    assert rebuilt._wrapper is arena.objects()["flashinfer_b12x.wrapper"]
+    assert len(build_calls) == 1
+    assert arena.verify(snap) == []
+
+    arena._object_slots["flashinfer_b12x.wrapper"] = object()
+    violations = arena.verify(snap)
+    assert len(violations) == 1
+    assert violations[0].kind == "moved"
+
+    del arena._object_slots["flashinfer_b12x.wrapper"]
+    violations = arena.verify(snap)
+    assert len(violations) == 1
+    assert violations[0].kind == "gone"
+
+
 @pytest.mark.parametrize(
     "backend_name", ["FLASHINFER_CUTLASS", "VLLM_CUTLASS"]
 )
@@ -419,6 +459,18 @@ class TestModelHelpers:
         arena._slots["ws"] = torch.empty(4)  # simulate rebind bug
         problems = verify_model_arenas(model, snaps)
         assert len(problems) == 1 and "moved" in problems[0]
+
+    def test_snapshot_verify_object_slot_across_model(self):
+        model = self._model()
+        arena = get_reload_arena(model.layer)
+        arena.get_or_create_object("wrapper", object)
+        snaps = snapshot_model_arenas(model)
+        arena._object_slots["wrapper"] = object()
+
+        problems = verify_model_arenas(model, snaps)
+        assert len(problems) == 1
+        assert "layer" in problems[0] and "wrapper" in problems[0]
+        assert "moved" in problems[0]
 
     def test_peek_does_not_create(self):
         model = self._model()

--- a/tests/model_executor/model_loader/test_reload_arena.py
+++ b/tests/model_executor/model_loader/test_reload_arena.py
@@ -147,6 +147,29 @@ class TestPut:
         assert runtime2.data_ptr() == runtime.data_ptr()
         assert torch.equal(runtime, source.to(torch.float32))
 
+    def test_flashinfer_sinks_use_attention_layer_arena(self):
+        from vllm.v1.attention.backends.flashinfer import FlashInferImpl
+
+        layer = nn.Module()
+        first_impl = FlashInferImpl.__new__(FlashInferImpl)
+        first_impl._sinks_source = torch.arange(4, dtype=torch.bfloat16)
+
+        with arena_scope(get_reload_arena(layer)):
+            first_impl.process_weights_after_loading(torch.bfloat16)
+        snap = snapshot_model_arenas(layer)
+        first_ptr = first_impl.sinks.data_ptr()
+
+        rebuilt_impl = FlashInferImpl.__new__(FlashInferImpl)
+        rebuilt_impl._sinks_source = torch.arange(
+            4, dtype=torch.bfloat16) + 10
+        with arena_scope(get_reload_arena(layer)):
+            rebuilt_impl.process_weights_after_loading(torch.bfloat16)
+
+        assert rebuilt_impl.sinks.data_ptr() == first_ptr
+        assert torch.equal(
+            rebuilt_impl.sinks, rebuilt_impl._sinks_source.to(torch.float32))
+        assert verify_model_arenas(layer, snap) == []
+
     def test_put_shape_mismatch_raises(self):
         arena = ReloadArena("layer")
         arena.put("d", torch.ones(3))
@@ -244,6 +267,53 @@ def test_wna8o8_detached_activation_scales_reuse_arena_storage():
     assert after == before
     assert scheme._input_scale.item() == 3.0
     assert scheme._output_scale.item() == 4.0
+
+
+@pytest.mark.parametrize(
+    "backend_name", ["FLASHINFER_CUTLASS", "VLLM_CUTLASS"]
+)
+def test_nvfp4_cutlass_quant_config_scales_reuse_arena_storage(backend_name):
+    from vllm.model_executor.layers.fused_moe.oracle.nvfp4 import (
+        NvFp4MoeBackend,
+        make_nvfp4_moe_quant_config,
+    )
+
+    layer = nn.Module()
+
+    def make_config(weight_global_scale, input_scale):
+        return make_nvfp4_moe_quant_config(
+            backend=NvFp4MoeBackend[backend_name],
+            w13_scale=torch.ones(1),
+            w2_scale=torch.ones(1),
+            w13_scale_2=torch.tensor([weight_global_scale]),
+            w2_scale_2=torch.tensor([weight_global_scale + 1]),
+            a13_scale=torch.tensor([input_scale]),
+            a2_scale=torch.tensor([input_scale * 2]),
+            layer=layer,
+        )
+
+    with arena_scope(get_reload_arena(layer)):
+        first = make_config(2.0, 0.25)
+    before = {
+        name: getattr(first, name).data_ptr()
+        for name in ("g1_alphas", "g2_alphas", "a1_gscale", "a2_gscale")
+    }
+
+    # Model the in-place fusion performed by CutlassExpertsFp4. The next
+    # PWAL must refresh the slot from newly derived source values first.
+    layer.w13_weight_scale_2.mul_(0.25)
+    with arena_scope(get_reload_arena(layer)):
+        second = make_config(3.0, 0.5)
+
+    after = {
+        name: getattr(second, name).data_ptr()
+        for name in ("g1_alphas", "g2_alphas", "a1_gscale", "a2_gscale")
+    }
+    assert after == before
+    assert layer.w13_weight_scale_2 is second.g1_alphas
+    assert layer.w2_weight_scale_2 is second.g2_alphas
+    assert second.g1_alphas.item() == 3.0
+    assert second.a1_gscale.item() == 2.0
 
 
 class TestSnapshotVerify:

--- a/tests/model_executor/model_loader/test_reload_arena.py
+++ b/tests/model_executor/model_loader/test_reload_arena.py
@@ -1,0 +1,210 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""ReloadArena semantics.
+
+Each test encodes one property a reproduced #48312 failure violated; the
+matching case name from the H200 repro suite is noted inline.
+"""
+
+import pytest
+import torch
+from torch import nn
+
+from vllm.model_executor.reload_arena import (
+    InitPolicy, ReloadArena, arena_scope, current_arena, get_reload_arena,
+    peek_reload_arena, snapshot_model_arenas, verify_model_arenas)
+
+
+class TestGetOrAlloc:
+
+    def test_same_slot_same_storage_across_rebuilds(self):
+        # cat1_cutlass_fp8 / cat1_marlin: rebuilt objects must reacquire
+        # the same storage, not allocate fresh
+        arena = ReloadArena("layer")
+        a = arena.get_or_alloc("ws", (8, ), torch.int64, "cpu")
+        b = arena.get_or_alloc("ws", (8, ), torch.int64, "cpu")
+        assert a.data_ptr() == b.data_ptr()
+        assert a is b
+
+    def test_zero_policy_zeroes_on_reacquire(self):
+        # marlin workspace semantics: reuse + zero (the #48438 existing=)
+        arena = ReloadArena("layer")
+        a = arena.get_or_alloc("ws", (4, ), torch.float32, "cpu",
+                               init=InitPolicy.ZERO)
+        a.fill_(7.0)
+        b = arena.get_or_alloc("ws", (4, ), torch.float32, "cpu",
+                               init=InitPolicy.ZERO)
+        assert b.data_ptr() == a.data_ptr()
+        assert torch.all(b == 0)
+
+    def test_preserve_policy_keeps_contents(self):
+        # permute-scratch semantics: contents carried across reload
+        # (probe B on H200: pinning old scratch made the fault vanish)
+        arena = ReloadArena("layer")
+        a = arena.get_or_alloc("scratch", (4, ), torch.int32, "cpu",
+                               init=InitPolicy.PRESERVE)
+        a.fill_(3)
+        b = arena.get_or_alloc("scratch", (4, ), torch.int32, "cpu",
+                               init=InitPolicy.PRESERVE)
+        assert b.data_ptr() == a.data_ptr()
+        assert torch.all(b == 3)
+
+    def test_spec_mismatch_raises_never_reallocates(self):
+        arena = ReloadArena("layer")
+        arena.get_or_alloc("ws", (8, ), torch.int64, "cpu")
+        with pytest.raises(ValueError, match="incompatible spec"):
+            arena.get_or_alloc("ws", (16, ), torch.int64, "cpu")
+        with pytest.raises(ValueError, match="incompatible spec"):
+            arena.get_or_alloc("ws", (8, ), torch.int32, "cpu")
+
+
+class TestPut:
+
+    def test_first_put_adopts_private_storage(self):
+        # cat1_mla: W_UV may be a view of a live parameter; the published
+        # tensor must own private storage
+        arena = ReloadArena("layer")
+        base = torch.arange(12, dtype=torch.float32).reshape(3, 4)
+        view = base.t()
+        stable = arena.put("W_UV", view)
+        assert stable.data_ptr() != base.data_ptr()
+        assert torch.equal(stable, view)
+        assert stable.is_contiguous()
+
+    def test_second_put_copies_into_same_storage(self):
+        # cat1_mla + cat2_sinks in one property: address stable, value fresh
+        arena = ReloadArena("layer")
+        s1 = arena.put("W_UV", torch.ones(3, 4))
+        p1 = s1.data_ptr()
+        s2 = arena.put("W_UV", torch.full((3, 4), 2.0))
+        assert s2.data_ptr() == p1
+        assert torch.all(s2 == 2.0)
+        assert torch.all(s1 == 2.0)  # same storage
+
+    def test_put_value_refresh_from_updated_source(self):
+        # cat2_sinks: recompute-from-source must land in place. The stock
+        # bug was `if dtype != fp32: convert` -- a no-op second pass.
+        arena = ReloadArena("layer")
+        source = torch.arange(4, dtype=torch.bfloat16)
+        runtime = arena.put("sinks_f32", source.to(torch.float32))
+        source.copy_(torch.arange(4, dtype=torch.bfloat16) * 3 + 1)
+        runtime2 = arena.put("sinks_f32", source.to(torch.float32))
+        assert runtime2.data_ptr() == runtime.data_ptr()
+        assert torch.equal(runtime, source.to(torch.float32))
+
+    def test_put_shape_mismatch_raises(self):
+        arena = ReloadArena("layer")
+        arena.put("d", torch.ones(3))
+        with pytest.raises(ValueError, match="incompatible spec"):
+            arena.put("d", torch.ones(4))
+
+
+class TestSnapshotVerify:
+
+    def test_clean_roundtrip(self):
+        arena = ReloadArena("layer")
+        arena.get_or_alloc("ws", (8, ), torch.int64, "cpu")
+        arena.put("d", torch.ones(3))
+        snap = arena.snapshot()
+        arena.get_or_alloc("ws", (8, ), torch.int64, "cpu")
+        arena.put("d", torch.zeros(3))
+        assert arena.verify(snap) == []
+
+    def test_moved_detected(self):
+        arena = ReloadArena("layer")
+        arena.get_or_alloc("ws", (8, ), torch.int64, "cpu")
+        snap = arena.snapshot()
+        arena._slots["ws"] = torch.empty(8, dtype=torch.int64)  # simulate bug
+        v = arena.verify(snap)
+        assert len(v) == 1 and v[0].kind == "moved"
+
+    def test_gone_detected(self):
+        # the tolerated_gone lesson: gone is NEVER clean
+        arena = ReloadArena("layer")
+        arena.get_or_alloc("scratch", (8, ), torch.int32, "cpu")
+        snap = arena.snapshot()
+        del arena._slots["scratch"]
+        v = arena.verify(snap)
+        assert len(v) == 1 and v[0].kind == "gone"
+
+    def test_new_lazy_slot_after_snapshot_is_clean(self):
+        arena = ReloadArena("layer")
+        snap = arena.snapshot()
+        arena.get_or_alloc("late", (4, ), torch.int32, "cpu")
+        assert arena.verify(snap) == []
+
+
+class TestAmbientScope:
+
+    def test_scope_resolution_and_reset(self):
+        arena = ReloadArena("layer")
+        assert current_arena() is None
+        with arena_scope(arena) as a:
+            assert a is arena
+            assert current_arena() is arena
+        assert current_arena() is None
+
+    def test_constructor_captures_arena_for_lazy_alloc(self):
+        # the permute-scratch pattern: capture at construction, allocate
+        # at first forward (outside any scope)
+        class Experts:
+            def __init__(self):
+                self.arena = current_arena()
+                self.scratch = None
+
+            def forward_alloc(self):
+                if self.scratch is None:
+                    if self.arena is not None:
+                        self.scratch = self.arena.get_or_alloc(
+                            "scratch", (4, ), torch.int32, "cpu",
+                            init=InitPolicy.PRESERVE)
+                    else:
+                        self.scratch = torch.empty(4, dtype=torch.int32)
+                return self.scratch
+
+        arena = ReloadArena("layer")
+        with arena_scope(arena):
+            e1 = Experts()
+        s1 = e1.forward_alloc()  # lazy alloc outside the scope
+        with arena_scope(arena):
+            e2 = Experts()  # PWAL rebuild
+        s2 = e2.forward_alloc()
+        assert s2.data_ptr() == s1.data_ptr()
+
+
+class TestModelHelpers:
+
+    def _model(self):
+        class Layer(nn.Module):
+            pass
+
+        class Model(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.layer = Layer()
+
+        return Model()
+
+    def test_arena_not_in_state_dict_or_buffers(self):
+        model = self._model()
+        arena = get_reload_arena(model.layer)
+        arena.get_or_alloc("ws", (4, ), torch.float32, "cpu")
+        assert "layer.ws" not in model.state_dict()
+        assert list(model.layer.buffers()) == []
+        assert list(model.layer.parameters()) == []
+
+    def test_snapshot_verify_across_model(self):
+        model = self._model()
+        arena = get_reload_arena(model.layer)
+        arena.get_or_alloc("ws", (4, ), torch.float32, "cpu")
+        snaps = snapshot_model_arenas(model)
+        assert verify_model_arenas(model, snaps) == []
+        arena._slots["ws"] = torch.empty(4)  # simulate rebind bug
+        problems = verify_model_arenas(model, snaps)
+        assert len(problems) == 1 and "moved" in problems[0]
+
+    def test_peek_does_not_create(self):
+        model = self._model()
+        assert peek_reload_arena(model.layer) is None
+        get_reload_arena(model.layer)
+        assert peek_reload_arena(model.layer) is not None

--- a/tests/model_executor/model_loader/test_reload_arena_perlayer.py
+++ b/tests/model_executor/model_loader/test_reload_arena_perlayer.py
@@ -23,7 +23,9 @@ from vllm.model_executor.model_loader.reload.layerwise import (
     finalize_layerwise_reload, get_layer_arena_findings,
     initialize_layerwise_reload, record_metadata_for_reloading)
 from vllm.model_executor.model_loader.weight_utils import default_weight_loader
-from vllm.model_executor.reload_arena import InitPolicy, get_reload_arena
+from vllm.model_executor.reload_arena import (
+    InitPolicy, get_reload_arena, snapshot_model_arenas,
+    verify_model_arenas)
 
 
 class _ArenaLayer(nn.Module):
@@ -132,7 +134,16 @@ def test_rebinding_arena_is_caught_per_layer():
     findings = get_layer_arena_findings()
     assert findings, "per-layer verify missed a rebinding arena"
     assert any("scratch" in f or "derived" in f for f in findings)
-    assert all("_ArenaLayer" in f for f in findings)
+    assert all(f.startswith("layer:") for f in findings)
+
+
+def test_per_layer_findings_match_model_level_finding_set():
+    model = _Model(drift=True)
+    snaps = snapshot_model_arenas(model)
+    _reload(model)
+
+    assert set(get_layer_arena_findings()) == set(
+        verify_model_arenas(model, snaps))
 
 
 def test_findings_cleared_between_reloads():

--- a/tests/model_executor/model_loader/test_reload_arena_perlayer.py
+++ b/tests/model_executor/model_loader/test_reload_arena_perlayer.py
@@ -1,0 +1,216 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Per-layer arena verification inside the layerwise reload pipeline.
+
+The arena's storage-identity check used to run only at the model level, in
+`reload_weights`. It now also runs per layer via
+`LayerReloadingInfo.arena_snapshot`: snapshotted in
+`initialize_layerwise_reload`, verified as each layer's PWAL re-runs, and
+reset with the rest of the per-layer info. This exercises that path over the
+real reload machinery on a synthetic layer -- no GPU, no checkpoint.
+
+The field is VERIFY-ONLY: unlike `kernel_tensors`, arena slots are never
+restored-to-meta or copied back. The tests pin both that a stable arena
+passes and that a rebinding arena is caught.
+"""
+
+import torch
+from torch import nn
+
+from vllm.model_executor.layers.quantization.base_config import (
+    QuantizeMethodBase)
+from vllm.model_executor.model_loader.reload.layerwise import (
+    finalize_layerwise_reload, get_layer_arena_findings,
+    initialize_layerwise_reload, record_metadata_for_reloading)
+from vllm.model_executor.model_loader.weight_utils import default_weight_loader
+from vllm.model_executor.reload_arena import InitPolicy, get_reload_arena
+
+
+class _ArenaLayer(nn.Module):
+    """A layer that owns a checkpoint param plus arena storage rebuilt in
+    process_weights_after_loading -- the migrated-backend shape."""
+
+    def __init__(self, drift: bool):
+        super().__init__()
+        self.weight = nn.Parameter(torch.zeros(4, 4))
+        self._drift = drift
+        self._materialize_scratch()
+
+    def _materialize_scratch(self):
+        # stands in for a first-forward lazy allocation
+        arena = get_reload_arena(self)
+        self.scratch = arena.get_or_alloc(
+            "scratch", (8,), torch.int32, "cpu", init=InitPolicy.PRESERVE)
+        self.derived = arena.put("derived", self.weight.detach().sum().view(1))
+
+    class _QM(QuantizeMethodBase):
+        def __init__(self, outer):
+            self.outer = outer
+
+        def create_weights(self, *a, **k):
+            pass
+
+        def apply(self, *a, **k):
+            pass
+
+        def process_weights_after_loading(self, layer):
+            arena = get_reload_arena(layer)
+            if layer._drift:
+                # The arena's own slot storage moves between snapshot and
+                # verify -- the shape verify is a tripwire for (e.g. an
+                # experts object rebuilt with freshly-allocated scratch that
+                # replaced the arena slot). This is what the check catches;
+                # a backend that bypasses the arena entirely (rebinds only
+                # the attribute) is NOT caught here -- see
+                # test_bypassing_the_arena_is_a_known_blind_spot.
+                arena._slots["scratch"] = torch.empty(8, dtype=torch.int32)
+                arena._slots["derived"] = torch.zeros(1)
+            else:
+                layer.scratch = arena.get_or_alloc(
+                    "scratch", (8,), torch.int32, "cpu",
+                    init=InitPolicy.PRESERVE)
+                layer.derived = arena.put(
+                    "derived", layer.weight.detach().sum().view(1))
+
+    @property
+    def quant_method(self):
+        return _ArenaLayer._QM(self)
+
+
+class _Model(nn.Module):
+    def __init__(self, drift: bool):
+        super().__init__()
+        self.layer = _ArenaLayer(drift)
+
+    def load_weights(self, weights):
+        params = dict(self.named_parameters())
+        loaded = set()
+        for name, w in weights:
+            p = params[name]
+            getattr(p, "weight_loader", default_weight_loader)(p, w)
+            loaded.add(name)
+        return loaded
+
+
+class _Cfg:
+    model = "synthetic"
+    dtype = torch.float32
+
+
+def _reload(model):
+    record_metadata_for_reloading(model)
+    initialize_layerwise_reload(model)
+    model.load_weights([("layer.weight", torch.ones(4, 4))])
+    finalize_layerwise_reload(model, _Cfg())
+
+
+def test_snapshot_taken_and_reset():
+    """arena_snapshot is populated at initialize and cleared by reset."""
+    from vllm.model_executor.model_loader.reload.layerwise import (
+        get_layerwise_info)
+    model = _Model(drift=False)
+    record_metadata_for_reloading(model)
+    initialize_layerwise_reload(model)
+    info = get_layerwise_info(model.layer)
+    assert info.arena_snapshot is not None
+    assert set(info.arena_snapshot) == {"scratch", "derived"}
+    model.load_weights([("layer.weight", torch.ones(4, 4))])
+    finalize_layerwise_reload(model, _Cfg())
+    # reset after finalize
+    assert get_layerwise_info(model.layer).arena_snapshot is None
+
+
+def test_stable_arena_reports_no_findings():
+    model = _Model(drift=False)
+    _reload(model)
+    assert get_layer_arena_findings() == []
+
+
+def test_rebinding_arena_is_caught_per_layer():
+    model = _Model(drift=True)
+    _reload(model)
+    findings = get_layer_arena_findings()
+    assert findings, "per-layer verify missed a rebinding arena"
+    assert any("scratch" in f or "derived" in f for f in findings)
+    assert all("_ArenaLayer" in f for f in findings)
+
+
+def test_findings_cleared_between_reloads():
+    model = _Model(drift=True)
+    _reload(model)
+    assert get_layer_arena_findings()          # dirty
+    clean = _Model(drift=False)
+    _reload(clean)
+    assert get_layer_arena_findings() == []     # fresh reload cleared them
+
+
+def test_bypassing_the_arena_is_a_known_blind_spot():
+    """Honest scope: the runtime arena verify checks the ARENA's slots, so a
+    backend that rebinds a layer attribute to non-arena storage without
+    touching the arena is NOT caught here. That failure mode is the CI
+    sweep's job (test_post_load_storage_stability censuses layer attributes,
+    not arena slots). This test pins the boundary so a future reader does
+    not assume the runtime check covers it."""
+
+    class _BypassLayer(_ArenaLayer):
+        class _QM(QuantizeMethodBase):
+            def __init__(self, outer):
+                self.outer = outer
+
+            def create_weights(self, *a, **k):
+                pass
+
+            def apply(self, *a, **k):
+                pass
+
+            def process_weights_after_loading(self, layer):
+                # bypass: fresh storage on the attribute, arena untouched
+                layer.scratch = torch.empty(8, dtype=torch.int32)
+
+        @property
+        def quant_method(self):
+            return _BypassLayer._QM(self)
+
+    class M(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.layer = _BypassLayer(drift=False)
+
+        def load_weights(self, weights):
+            p = self.layer.weight
+            for name, w in weights:
+                getattr(p, "weight_loader", default_weight_loader)(p, w)
+            return {n for n, _ in weights}
+
+    m = M()
+    _reload(m)
+    # arena slots never moved, so the runtime verify is (correctly) silent
+    assert get_layer_arena_findings() == []
+
+
+def test_layer_without_arena_is_a_noop():
+    class Plain(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.weight = nn.Parameter(torch.zeros(4, 4))
+
+        def load_weights(self, weights):
+            for name, w in weights:
+                dict(self.named_parameters())[name].data.copy_(w)
+            return {n for n, _ in weights}
+
+    class M(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.layer = Plain()
+
+        def load_weights(self, weights):
+            return self.layer.load_weights(
+                [(n.split(".", 1)[1], w) for n, w in weights])
+
+    m = M()
+    record_metadata_for_reloading(m)
+    initialize_layerwise_reload(m)
+    model_load = m.load_weights([("layer.weight", torch.ones(4, 4))])  # noqa
+    finalize_layerwise_reload(m, _Cfg())
+    assert get_layer_arena_findings() == []

--- a/tests/model_executor/model_loader/test_reload_dispatch_audit.py
+++ b/tests/model_executor/model_loader/test_reload_dispatch_audit.py
@@ -1,0 +1,220 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tier 3: dataflow discovery of storage no path can reach.
+
+The reload arena covers storage a layer owns (tier 1). The module-level
+manifest covers globals reachable by scanning loaded modules (tier 2,
+``vllm/model_executor/reload_manifest.py``). Neither can see a tensor that
+is referenced from nowhere addressable -- held only in a closure a walk
+does not descend into, a container under an unscanned module, or an object
+graph the walk bottoms out on -- yet a captured graph bakes its address
+just the same.
+
+``TorchDispatchMode`` finds those by dataflow rather than reachability:
+anything that flows through an op gets recorded, regardless of who owns it.
+That is strictly more discovery power than a walk, at the cost of
+intercepting every op, which is why this lives in the test tree and is
+deliberately not importable from the serving path. RFC #48312 draws the
+same boundary: production does not use dispatch discovery.
+
+Its job is to produce a worklist. Storage it records that tiers 1 and 2 do
+not account for is an undeclared site -- either migrate it to the arena or
+waive it with a reason.
+
+The recorder cannot compute ``moved``: its paths are op-and-position
+counters, not re-resolvable slots. Liveness (``expired``) is all it
+offers, which is why it complements the manifest rather than replacing it.
+"""
+
+import sys
+import types
+
+import pytest
+import torch
+from torch.multiprocessing.reductions import StorageWeakRef
+from torch.utils._python_dispatch import TorchDispatchMode
+from torch.utils._pytree import tree_flatten
+
+from vllm.model_executor.reload_manifest import collect_module_level_tensors
+from vllm.platforms import current_platform
+
+
+class DispatchRecorder(TorchDispatchMode):
+    """Records the storage of every tensor argument flowing through any op.
+
+    Keyed by storage pointer so one tensor seen by many ops is one entry;
+    the first op to touch it is kept as a provenance hint for triage.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.seen: dict[int, tuple[str, StorageWeakRef]] = {}
+
+    def __torch_dispatch__(self, func, types, args=(), kwargs=None):
+        flat, _ = tree_flatten((args, kwargs or {}))
+        for value in flat:
+            if isinstance(value, torch.Tensor) and value.numel():
+                storage = value.untyped_storage()
+                self.seen.setdefault(
+                    storage.data_ptr(),
+                    (str(func), StorageWeakRef(storage)))
+        return func(*args, **(kwargs or {}))
+
+    def expired(self) -> list[str]:
+        """Recorded storage that has since been freed: a captured address
+        pointing at it now dangles."""
+        return [op for _, (op, ref) in self.seen.items() if ref.expired()]
+
+    def residual(self, *, accounted: set[int]) -> dict[int, str]:
+        """Storage seen flowing through ops that no tier accounts for.
+
+        This is the worklist: each entry is a site that must be migrated to
+        the arena or explicitly waived.
+        """
+        return {ptr: op for ptr, (op, _) in self.seen.items()
+                if ptr not in accounted}
+
+
+PREFIX = "vllm.model_executor.fake_dispatch_holder"
+
+
+@pytest.fixture
+def fake_module():
+    module = types.ModuleType(PREFIX)
+    sys.modules[PREFIX] = module
+    yield module
+    sys.modules.pop(PREFIX, None)
+
+
+def test_records_a_tensor_that_no_walk_can_reach():
+    """A tensor held only in a closure over a local: invisible to any
+    attribute walk of the model, but its address is in the graph."""
+    hidden = torch.randn(4)
+
+    class Toy(torch.nn.Module):
+        def forward(self, x):
+            return x * hidden
+
+    model = Toy()
+    assert not list(model.parameters())
+    assert not list(model.buffers())
+    assert not any(isinstance(v, torch.Tensor) for v in vars(model).values())
+
+    recorder = DispatchRecorder()
+    with recorder:
+        model(torch.ones(4))
+
+    assert hidden.untyped_storage().data_ptr() in recorder.seen
+
+
+def test_expired_fires_when_recorded_storage_is_freed(fake_module):
+    fake_module.registry = {"scale": torch.randn(4)}
+
+    def forward():
+        return torch.ones(4) * fake_module.registry["scale"]
+
+    recorder = DispatchRecorder()
+    with recorder:
+        forward()
+
+    fake_module.registry["scale"] = torch.randn(4)  # rebind; old storage dies
+    assert recorder.expired()
+
+
+def test_residual_excludes_what_the_other_tiers_account_for(fake_module):
+    """The worklist is what dispatch sees minus what tiers 1 and 2 own --
+    otherwise every weight in the model would be reported."""
+    fake_module.registry = {"scale": torch.randn(4)}
+    x = torch.ones(4)
+
+    recorder = DispatchRecorder()
+    with recorder:
+        x * fake_module.registry["scale"]
+
+    tier2 = {t.untyped_storage().data_ptr() for t in
+             collect_module_level_tensors((PREFIX, ),
+                                          require_cuda=False).values()}
+    assert tier2, "tier 2 should see the module-level registry"
+
+    # with tier 2 accounted for, the registry tensor drops out of the
+    # residual; the un-owned operands remain as the worklist
+    residual = recorder.residual(accounted=tier2)
+    assert fake_module.registry["scale"].untyped_storage().data_ptr() \
+        not in residual
+    assert x.untyped_storage().data_ptr() in residual
+
+
+def test_recorder_does_not_perturb_results():
+    """Discovery must not change what it observes."""
+    a, b = torch.randn(8), torch.randn(8)
+    baseline = a * b + a.sum()
+    with DispatchRecorder():
+        under_mode = a * b + a.sum()
+    assert torch.equal(baseline, under_mode)
+
+
+# ---------------------------------------------------------------------------
+# The open question: does dispatch recording compose with real CUDA graph
+# capture? The upstream prototype validates on CPU only and says so. If it
+# does not compose, dispatch discovery has to run in a separate warmup
+# forward rather than at capture -- which changes how it would be wired.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not current_platform.is_cuda_alike(),
+                    reason="needs an accelerator")
+def test_dispatch_recording_during_cudagraph_capture():
+    static_in = torch.ones(8, device="cuda")
+    weight = torch.randn(8, device="cuda")
+
+    # cudagraph capture requires a warmup on a side stream
+    side = torch.cuda.Stream()
+    side.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(side):
+        for _ in range(3):
+            static_in * weight
+    torch.cuda.current_stream().wait_stream(side)
+
+    recorder = DispatchRecorder()
+    graph = torch.cuda.CUDAGraph()
+    captured_under_mode = None
+    error = None
+    try:
+        with recorder:
+            with torch.cuda.graph(graph):
+                static_out = static_in * weight  # noqa: F841
+        captured_under_mode = len(recorder.seen)
+    except Exception as e:  # noqa: BLE001 - the finding IS whether it raises
+        error = f"{type(e).__name__}: {e}"
+
+    # Whatever the outcome, record it explicitly: a silent zero would be
+    # indistinguishable from "composes fine but saw nothing".
+    print(f"\ncudagraph capture under dispatch mode: "
+          f"error={error!r} storages_seen={captured_under_mode}")
+
+    if error is not None:
+        pytest.skip(
+            "TorchDispatchMode does not compose with cudagraph capture on "
+            f"this build ({error}); dispatch discovery must run in a "
+            "separate warmup forward instead of at capture")
+
+    assert captured_under_mode, (
+        "dispatch mode composed with capture but recorded nothing, so it "
+        "cannot be used to discover graph-visible storage at capture time")
+    assert weight.untyped_storage().data_ptr() in recorder.seen
+
+
+@pytest.mark.skipif(not current_platform.is_cuda_alike(),
+                    reason="needs an accelerator")
+def test_warmup_forward_discovery_is_a_viable_fallback():
+    """Independent of the capture question: recording a warmup forward on
+    the same tensors finds the same storage a capture would bake."""
+    static_in = torch.ones(8, device="cuda")
+    weight = torch.randn(8, device="cuda")
+
+    recorder = DispatchRecorder()
+    with recorder:
+        static_in * weight
+
+    assert weight.untyped_storage().data_ptr() in recorder.seen
+    assert static_in.untyped_storage().data_ptr() in recorder.seen

--- a/tests/model_executor/model_loader/test_reload_lazy_storage.py
+++ b/tests/model_executor/model_loader/test_reload_lazy_storage.py
@@ -1,0 +1,201 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Storage allocated on the first forward, not during post-load.
+
+``test_post_load_storage_stability.py`` runs post-load twice and compares
+storage. That is blind to anything allocated later: the MoE permute scratch
+is created on the FIRST FORWARD, so a post-load-only sweep never touches
+it and reports clean.
+
+It is not a hypothetical gap. On stock 0.25.1 with 2xH200, an identity
+reload of Qwen3-30B-A3B-W4A8 freed the scratch with the experts object it
+belonged to; the next forward reallocated elsewhere while captured graphs
+still held the old addresses, and replay died with an illegal memory
+access. Re-attaching the pre-reload scratch made the fault disappear with
+byte-identical addresses, which is what identified it.
+
+So the lifecycle under test here is the real one:
+
+    build -> post-load -> allocate lazily -> REBUILD -> allocate again
+
+with the rebuild standing in for what a reload does to the owning object.
+The property is that the second allocation returns the first one's storage.
+"""
+
+import pytest
+import torch
+
+from vllm.model_executor.reload_arena import (InitPolicy, ReloadArena,
+                                              arena_scope, current_arena,
+                                              get_reload_arena)
+from vllm.platforms import current_platform
+
+DEVICE = torch.device("cuda" if current_platform.is_cuda_alike() else "cpu")
+
+
+class _LazyExperts:
+    """The CutlassExperts shape: the arena is captured at construction
+    because no scope is open at forward time, and the scratch is allocated
+    on first use."""
+
+    def __init__(self, arena_backed: bool = True):
+        self._arena = current_arena() if arena_backed else None
+        self._scratch: dict[str, torch.Tensor] | None = None
+
+    def _alloc(self, slot: str, shape) -> torch.Tensor:
+        if self._arena is not None:
+            return self._arena.get_or_alloc(f"scratch.{slot}", shape,
+                                            torch.int32, DEVICE,
+                                            init=InitPolicy.PRESERVE)
+        return torch.empty(shape, dtype=torch.int32, device=DEVICE)
+
+    def forward(self) -> dict[str, torch.Tensor]:
+        """Lazy allocation, exactly like _get_permute_scratch()."""
+        if self._scratch is None:
+            self._scratch = {
+                name: self._alloc(name, (32, ))
+                for name in ("permuted_idx", "inv_permuted_idx",
+                             "sort_workspace")
+            }
+        return self._scratch
+
+
+def _ptrs(scratch: dict[str, torch.Tensor]) -> dict[str, int]:
+    return {k: v.data_ptr() for k, v in scratch.items()}
+
+
+class TestLazyStorageSurvivesRebuild:
+
+    def test_arena_backed_scratch_survives_the_owning_object_rebuild(self):
+        """The property the reproduced W4A8 crash violated."""
+        layer = torch.nn.Module()
+        arena = get_reload_arena(layer)
+
+        with arena_scope(arena):
+            experts = _LazyExperts()
+        before = _ptrs(experts.forward())  # first forward: lazy alloc
+
+        with arena_scope(arena):  # what post-load does on reload
+            rebuilt = _LazyExperts()
+        after = _ptrs(rebuilt.forward())
+
+        assert after == before, (
+            "lazily-allocated scratch moved across the owning object's "
+            "rebuild; captured graphs hold the previous addresses")
+
+    def test_unmanaged_scratch_moves_and_is_detected(self):
+        """Canary: without the arena the storage does move, so a green
+        result above is a real property and not an inert assertion."""
+        with arena_scope(ReloadArena("unused")):
+            experts = _LazyExperts(arena_backed=False)
+        before = _ptrs(experts.forward())
+        rebuilt = _LazyExperts(arena_backed=False)
+        after = _ptrs(rebuilt.forward())
+        assert after != before
+
+    def test_old_object_freed_after_rebuild_still_leaves_storage_valid(self):
+        """Dropping the pre-reload owner must not free the storage: that is
+        precisely what turned the W4A8 case into an illegal access."""
+        layer = torch.nn.Module()
+        arena = get_reload_arena(layer)
+
+        with arena_scope(arena):
+            experts = _LazyExperts()
+        before = _ptrs(experts.forward())
+
+        del experts  # reload drops the previous experts object
+        with arena_scope(arena):
+            rebuilt = _LazyExperts()
+        after = _ptrs(rebuilt.forward())
+
+        assert after == before
+        # storage is genuinely alive, not merely a recycled address
+        for name, tensor in rebuilt.forward().items():
+            tensor.fill_(7)
+            assert int(tensor[0]) == 7, name
+
+    def test_scratch_is_visible_to_the_commit_gate(self):
+        """Lazy allocation happens after capture-time snapshots are taken,
+        so the gate must treat a slot that appears later as clean while
+        still verifying it on subsequent reloads."""
+        layer = torch.nn.Module()
+        arena = get_reload_arena(layer)
+
+        snap_before_forward = arena.snapshot()
+        with arena_scope(arena):
+            experts = _LazyExperts()
+        experts.forward()
+
+        # new slots after the snapshot are legitimate, not violations
+        assert arena.verify(snap_before_forward) == []
+
+        # but from now on they are covered
+        snap = arena.snapshot()
+        assert len(snap) == 3
+        with arena_scope(arena):
+            _LazyExperts().forward()
+        assert arena.verify(snap) == []
+
+    def test_shape_change_fails_closed(self):
+        """A rebuild asking for a different scratch geometry is not an
+        in-place update; refusing beats silently replacing storage."""
+        layer = torch.nn.Module()
+        arena = get_reload_arena(layer)
+        with arena_scope(arena):
+            _LazyExperts().forward()
+        with pytest.raises(ValueError, match="incompatible spec"):
+            arena.get_or_alloc("scratch.permuted_idx", (64, ), torch.int32,
+                               DEVICE, init=InitPolicy.PRESERVE)
+
+
+@pytest.mark.skipif(not current_platform.is_cuda_alike(),
+                    reason="needs an accelerator")
+def test_real_permute_scratch_reuses_storage_across_rebuild():
+    """Drive the production MoEPermuteScratch rather than a stand-in, so
+    this tracks the real allocation list instead of a copy of it."""
+    from vllm.model_executor.layers.fused_moe.moe_permute_unpermute import (
+        MoEPermuteScratch)
+
+    layer = torch.nn.Module()
+    arena = get_reload_arena(layer)
+
+    def build():
+        return MoEPermuteScratch(
+            max_num_tokens=8, topk=2, num_experts=4, num_local_experts=4,
+            device=DEVICE, arena=arena,
+        )
+
+    first = build()
+    before = {k: v.data_ptr() for k, v in vars(first).items()
+              if hasattr(v, "data_ptr")}
+    assert before, "no scratch tensors discovered"
+
+    del first
+    second = build()  # the reload's rebuild
+    after = {k: v.data_ptr() for k, v in vars(second).items()
+             if hasattr(v, "data_ptr")}
+
+    moved = sorted(k for k, ptr in before.items() if after.get(k) != ptr)
+    assert not moved, f"permute scratch moved across rebuild: {moved}"
+
+
+@pytest.mark.skipif(not current_platform.is_cuda_alike(),
+                    reason="needs an accelerator")
+def test_real_permute_scratch_without_arena_moves():
+    """Canary for the above: unmanaged, the production class does move."""
+    from vllm.model_executor.layers.fused_moe.moe_permute_unpermute import (
+        MoEPermuteScratch)
+
+    def build():
+        return MoEPermuteScratch(
+            max_num_tokens=8, topk=2, num_experts=4, num_local_experts=4,
+            device=DEVICE, arena=None,
+        )
+
+    first = build()
+    before = {k: v.data_ptr() for k, v in vars(first).items()
+              if hasattr(v, "data_ptr")}
+    second = build()
+    after = {k: v.data_ptr() for k, v in vars(second).items()
+             if hasattr(v, "data_ptr")}
+    assert any(after.get(k) != ptr for k, ptr in before.items())

--- a/tests/model_executor/model_loader/test_reload_manifest.py
+++ b/tests/model_executor/model_loader/test_reload_manifest.py
@@ -1,0 +1,163 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Module-level (global) storage manifest.
+
+Globals are the escape route neither copy-back nor the reload arena covers:
+no walk rooted at the model reaches them, yet a captured graph bakes their
+addresses. Both signals are exercised here, because each misses what the
+other catches -- ``expired`` needs the old storage to actually die, and the
+Machete reproduction on H200 showed 88/88 tensors rebound with 0/88
+storages freed.
+
+Runs on CPU: storage lifetime and identity are device-independent even
+though the consumer (graph replay) is not.
+"""
+
+import sys
+import types
+
+import torch
+
+from vllm.model_executor.reload_manifest import (
+    GlobalStorageManifest, collect_module_level_tensors)
+
+PREFIX = "vllm.model_executor.fake_global_holder"
+
+
+def _install(**attrs) -> types.ModuleType:
+    """A throwaway module under a scanned prefix, standing in for e.g.
+    tokenspeed_mla's ``_g_workspace``."""
+    module = types.ModuleType(PREFIX)
+    for k, v in attrs.items():
+        setattr(module, k, v)
+    sys.modules[PREFIX] = module
+    return module
+
+
+def _record(**kwargs) -> GlobalStorageManifest:
+    manifest = GlobalStorageManifest()
+    manifest.record(prefixes=(PREFIX, ), require_cuda=False, **kwargs)
+    return manifest
+
+
+def _cleanup():
+    sys.modules.pop(PREFIX, None)
+
+
+class TestCollection:
+
+    def teardown_method(self):
+        _cleanup()
+
+    def test_finds_bare_module_attribute(self):
+        _install(_G_TENSOR=torch.ones(4))
+        found = collect_module_level_tensors((PREFIX, ), require_cuda=False)
+        assert f"{PREFIX}._G_TENSOR" in found
+
+    def test_finds_tensors_inside_a_cache_dict(self):
+        # the _g_workspace / _TRITON_BUFFER_CACHE shape
+        _install(_CACHE={"cuda:0": torch.ones(4), "cuda:1": torch.ones(4)})
+        found = collect_module_level_tensors((PREFIX, ), require_cuda=False)
+        assert f"{PREFIX}._CACHE['cuda:0']" in found
+        assert f"{PREFIX}._CACHE['cuda:1']" in found
+
+    def test_paths_are_stable_across_scans(self):
+        """`moved` is only computable if a path re-resolves to the same
+        logical slot on the second scan."""
+        _install(_CACHE={"k": torch.ones(4)}, _LIST=[torch.ones(2)])
+        first = set(collect_module_level_tensors((PREFIX, ),
+                                                 require_cuda=False))
+        second = set(collect_module_level_tensors((PREFIX, ),
+                                                  require_cuda=False))
+        assert first == second
+
+    def test_skips_classes_and_callables(self):
+        class Holder:
+            pass
+
+        _install(SomeClass=Holder, some_fn=lambda: None,
+                 _G_TENSOR=torch.ones(4))
+        found = collect_module_level_tensors((PREFIX, ), require_cuda=False)
+        assert list(found) == [f"{PREFIX}._G_TENSOR"]
+
+    def test_require_cuda_filters_host_tensors(self):
+        _install(_G_TENSOR=torch.ones(4))
+        assert collect_module_level_tensors((PREFIX, ),
+                                            require_cuda=True) == {}
+
+    def test_reload_machinery_is_not_self_reported(self):
+        found = collect_module_level_tensors(require_cuda=False)
+        assert not any("reload_arena" in p or "reload_manifest" in p
+                       for p in found)
+
+
+class TestCheck:
+
+    def teardown_method(self):
+        _cleanup()
+
+    def test_clean_when_nothing_changes(self):
+        _install(_CACHE={"k": torch.ones(4)})
+        manifest = _record()
+        assert len(manifest) == 1
+        report = manifest.check()
+        assert report.is_clean
+        assert report.checked == 1
+
+    def test_expired_when_old_storage_is_freed(self):
+        """A cache that repopulates and drops its last reference: the
+        captured address is dangling."""
+        module = _install(_CACHE={"k": torch.ones(4)})
+        manifest = _record()
+        module._CACHE["k"] = torch.ones(4)  # old storage loses its referent
+        report = manifest.check()
+        assert report.expired and not report.is_clean
+
+    def test_moved_when_rebound_but_old_storage_kept_alive(self):
+        """The Machete shape: rebound while a capture artifact still holds
+        the previous storage, so expiry never fires and the model reads
+        stale values in silence."""
+        module = _install(_CACHE={"k": torch.ones(4)})
+        manifest = _record()
+        keepalive = module._CACHE["k"]  # noqa: F841 - stands in for a capture artifact
+        module._CACHE["k"] = torch.ones(4)
+        report = manifest.check()
+        assert not report.expired, "old storage should still be alive"
+        assert report.moved and not report.is_clean
+
+    def test_grow_in_place_is_clean(self):
+        """A cache hit that reuses its buffer must not be flagged."""
+        module = _install(_CACHE={"k": torch.ones(4)})
+        manifest = _record()
+        module._CACHE["k"].fill_(7.0)  # same storage, new contents
+        assert manifest.check().is_clean
+
+    def test_growth_reallocation_is_caught(self):
+        """The `_g_workspace` pattern: `if existing.numel() < needed:
+        reallocate` silently rebinds under any graph that captured it."""
+        module = _install(_CACHE={"k": torch.ones(4)})
+        manifest = _record()
+        module._CACHE["k"] = torch.ones(64)  # grown
+        report = manifest.check()
+        assert not report.is_clean
+
+    def test_vanished_path_with_live_storage_is_not_a_violation(self):
+        module = _install(_CACHE={"k": torch.ones(4)})
+        manifest = _record()
+        keepalive = module._CACHE.pop("k")  # noqa: F841
+        report = manifest.check()
+        assert report.vanished and report.is_clean
+
+    def test_new_entries_after_capture_are_ignored(self):
+        module = _install(_CACHE={"k": torch.ones(4)})
+        manifest = _record()
+        module._CACHE["fresh"] = torch.ones(4)
+        assert manifest.check().is_clean
+
+    def test_report_names_the_offending_path(self):
+        module = _install(_CACHE={"k": torch.ones(4)})
+        manifest = _record()
+        keepalive = module._CACHE["k"]  # noqa: F841
+        module._CACHE["k"] = torch.ones(4)
+        text = manifest.check().format()
+        assert "_CACHE['k']" in text and "moved" in text

--- a/tests/model_executor/model_loader/test_reload_marlin_quant_storage.py
+++ b/tests/model_executor/model_loader/test_reload_marlin_quant_storage.py
@@ -57,11 +57,13 @@ def test_fp4_marlin_workspace_is_stable_across_pwal(nvfp4):
     _load_fp4_checkpoint(layer, nvfp4=nvfp4)
     prepare_fp4_layer_for_marlin(layer)
     before = layer.workspace.data_ptr()
+    layer.workspace.fill_(7)
 
     _load_fp4_checkpoint(layer, nvfp4=nvfp4)
     prepare_fp4_layer_for_marlin(layer)
 
     assert layer.workspace.data_ptr() == before
+    assert torch.count_nonzero(layer.workspace) == 0
 
 
 def _load_mxfp8_checkpoint(layer: torch.nn.Module) -> None:
@@ -80,8 +82,10 @@ def test_mxfp8_marlin_workspace_is_stable_across_pwal():
     _load_mxfp8_checkpoint(layer)
     prepare_mxfp8_layer_for_marlin(layer)
     before = layer.workspace.data_ptr()
+    layer.workspace.fill_(7)
 
     _load_mxfp8_checkpoint(layer)
     prepare_mxfp8_layer_for_marlin(layer)
 
     assert layer.workspace.data_ptr() == before
+    assert torch.count_nonzero(layer.workspace) == 0

--- a/tests/model_executor/model_loader/test_reload_marlin_quant_storage.py
+++ b/tests/model_executor/model_loader/test_reload_marlin_quant_storage.py
@@ -1,0 +1,87 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Arena coverage for Marlin workspaces outside the WNA16 kernel registry."""
+
+import pytest
+import torch
+
+from vllm.model_executor.layers.quantization.utils.marlin_utils_fp4 import (
+    prepare_fp4_layer_for_marlin,
+)
+from vllm.model_executor.layers.quantization.utils.marlin_utils_fp8 import (
+    prepare_mxfp8_layer_for_marlin,
+)
+from vllm.platforms import current_platform
+
+
+pytestmark = pytest.mark.skipif(
+    not current_platform.is_cuda_alike(), reason="Marlin repack needs an accelerator"
+)
+
+N = 256
+K = 256
+
+
+def _base_layer() -> torch.nn.Module:
+    layer = torch.nn.Module()
+    layer.output_size_per_partition = N
+    layer.input_size_per_partition = K
+    layer.params_dtype = torch.float16
+    layer.bias = None
+    return layer
+
+
+def _load_fp4_checkpoint(layer: torch.nn.Module, *, nvfp4: bool) -> None:
+    layer.weight = torch.nn.Parameter(
+        torch.randint(0, 255, (N, K // 2), dtype=torch.uint8, device="cuda"),
+        requires_grad=False,
+    )
+    group_size = 16 if nvfp4 else 32
+    scale_dtype = torch.float8_e4m3fn if nvfp4 else torch.uint8
+    layer.weight_scale = torch.nn.Parameter(
+        torch.ones((N, K // group_size), dtype=scale_dtype, device="cuda"),
+        requires_grad=False,
+    )
+    if nvfp4:
+        layer.weight_global_scale = torch.nn.Parameter(
+            torch.ones((), dtype=torch.float32, device="cuda"),
+            requires_grad=False,
+        )
+    elif hasattr(layer, "weight_global_scale"):
+        delattr(layer, "weight_global_scale")
+
+
+@pytest.mark.parametrize("nvfp4", [False, True], ids=["mxfp4", "nvfp4"])
+def test_fp4_marlin_workspace_is_stable_across_pwal(nvfp4):
+    layer = _base_layer()
+    _load_fp4_checkpoint(layer, nvfp4=nvfp4)
+    prepare_fp4_layer_for_marlin(layer)
+    before = layer.workspace.data_ptr()
+
+    _load_fp4_checkpoint(layer, nvfp4=nvfp4)
+    prepare_fp4_layer_for_marlin(layer)
+
+    assert layer.workspace.data_ptr() == before
+
+
+def _load_mxfp8_checkpoint(layer: torch.nn.Module) -> None:
+    layer.weight = torch.nn.Parameter(
+        torch.ones((N, K), dtype=torch.float8_e4m3fn, device="cuda"),
+        requires_grad=False,
+    )
+    layer.weight_scale = torch.nn.Parameter(
+        torch.ones((N, K // 32), dtype=torch.uint8, device="cuda"),
+        requires_grad=False,
+    )
+
+
+def test_mxfp8_marlin_workspace_is_stable_across_pwal():
+    layer = _base_layer()
+    _load_mxfp8_checkpoint(layer)
+    prepare_mxfp8_layer_for_marlin(layer)
+    before = layer.workspace.data_ptr()
+
+    _load_mxfp8_checkpoint(layer)
+    prepare_mxfp8_layer_for_marlin(layer)
+
+    assert layer.workspace.data_ptr() == before

--- a/tests/model_executor/model_loader/test_reload_rdna3_buffers.py
+++ b/tests/model_executor/model_loader/test_reload_rdna3_buffers.py
@@ -1,0 +1,98 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""RDNA3 WNA16 MoE decode-scratch buffers survive a second post-load pass.
+
+RFC #48312 lists these under category 1 (storage identity): they are plain
+layer attributes passed straight to the fused HIP kernel, so reload
+copy-back never sees them, and post-load processing re-runs on every
+reload.
+
+gfx1100 is not available here, so this covers the allocation contract only
+-- the buffer geometry helper is deliberately separated from the HIP path
+so it can be driven on CPU. Graph-replay validation on RDNA3 hardware is
+still outstanding.
+"""
+
+import pytest
+import torch
+from torch import nn
+
+rdna3 = pytest.importorskip(
+    "vllm.model_executor.layers.quantization.compressed_tensors"
+    ".compressed_tensors_moe.compressed_tensors_moe_wna16_rdna3")
+
+from vllm.model_executor.reload_arena import peek_reload_arena  # noqa: E402
+
+BUFFERS = ("rdna3_w1_buf", "rdna3_act_buf", "rdna3_out_buf",
+           "rdna3_empty_tw")
+
+GEOMETRY = dict(n_gate_up=64, hidden_size=32, act_dtype=torch.float32,
+                device=torch.device("cpu"))
+
+
+def _allocate(layer):
+    rdna3.allocate_rdna3_decode_buffers(layer, **GEOMETRY)
+
+
+def test_second_post_load_pass_reuses_storage():
+    """The bug: a reload's post-load pass rebinds every buffer, leaving any
+    graph captured earlier pointing at freed memory."""
+    layer = nn.Module()
+    _allocate(layer)
+    first = {name: getattr(layer, name).data_ptr() for name in BUFFERS}
+
+    _allocate(layer)  # what reload triggers
+    second = {name: getattr(layer, name).data_ptr() for name in BUFFERS}
+
+    assert second == first
+
+
+def test_buffers_stay_out_of_state_dict():
+    """Arena slots must not become parameters or buffers: they are not
+    checkpoint state and must not be touched by load/copy-back machinery."""
+    layer = nn.Module()
+    _allocate(layer)
+    assert layer.state_dict() == {}
+    assert list(layer.parameters()) == []
+    assert list(layer.buffers()) == []
+
+
+def test_buffers_are_declared_to_the_arena():
+    """The commit gate can only verify storage the arena knows about."""
+    layer = nn.Module()
+    _allocate(layer)
+    arena = peek_reload_arena(layer)
+    assert arena is not None
+    assert set(arena.slots()) == set(BUFFERS)
+
+
+def test_commit_gate_sees_a_clean_reload():
+    layer = nn.Module()
+    _allocate(layer)
+    arena = peek_reload_arena(layer)
+    snap = arena.snapshot()
+    _allocate(layer)
+    assert arena.verify(snap) == []
+
+
+def test_geometry_matches_the_apply_path():
+    """apply() slices w1_buf by total_tokens and feeds act_buf to the gated
+    activation, so the two must agree on rows and halve on columns."""
+    layer = nn.Module()
+    _allocate(layer)
+    w1, act = layer.rdna3_w1_buf, layer.rdna3_act_buf
+    assert w1.shape[0] == act.shape[0]
+    assert w1.shape[1] == GEOMETRY["n_gate_up"]
+    assert act.shape[1] == GEOMETRY["n_gate_up"] // 2
+    assert layer.rdna3_out_buf.shape[1] == GEOMETRY["hidden_size"]
+    assert layer.rdna3_empty_tw.numel() == 0
+
+
+def test_incompatible_geometry_fails_closed():
+    """A shape-changing reload is not an in-place update; refusing beats
+    silently replacing storage a captured graph may hold."""
+    layer = nn.Module()
+    _allocate(layer)
+    with pytest.raises(ValueError, match="incompatible spec"):
+        rdna3.allocate_rdna3_decode_buffers(
+            layer, **{**GEOMETRY, "n_gate_up": 128})

--- a/tests/model_executor/model_loader/test_reload_validation.py
+++ b/tests/model_executor/model_loader/test_reload_validation.py
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+from torch import nn
+
+from vllm.model_executor.model_loader.reload.validation import (
+    reload_storage_guard,
+)
+from vllm.model_executor.reload_arena import get_reload_arena
+
+
+def _model_with_arena() -> tuple[nn.Module, nn.Module]:
+    model = nn.Module()
+    model.layer = nn.Module()
+    get_reload_arena(model.layer).get_or_alloc(
+        "workspace", (4,), torch.float32, "cpu"
+    )
+    return model, model.layer
+
+
+def test_reload_storage_guard_accepts_stable_slots(monkeypatch):
+    monkeypatch.setenv("VLLM_RELOAD_GLOBAL_MANIFEST", "off")
+    model, _ = _model_with_arena()
+
+    with reload_storage_guard(model):
+        pass
+
+
+def test_reload_storage_guard_rejects_moved_slots(monkeypatch):
+    monkeypatch.setenv("VLLM_RELOAD_GLOBAL_MANIFEST", "off")
+    model, layer = _model_with_arena()
+
+    with pytest.raises(RuntimeError, match="graph-visible storage identity"):
+        with reload_storage_guard(model):
+            get_reload_arena(layer)._slots["workspace"] = torch.empty(4)

--- a/tests/model_executor/model_loader/test_reload_validation.py
+++ b/tests/model_executor/model_loader/test_reload_validation.py
@@ -5,6 +5,7 @@ import pytest
 import torch
 from torch import nn
 
+import vllm.model_executor.model_loader.reload.validation as validation
 from vllm.model_executor.model_loader.reload.validation import (
     reload_storage_guard,
 )
@@ -35,3 +36,46 @@ def test_reload_storage_guard_rejects_moved_slots(monkeypatch):
     with pytest.raises(RuntimeError, match="graph-visible storage identity"):
         with reload_storage_guard(model):
             get_reload_arena(layer)._slots["workspace"] = torch.empty(4)
+
+
+def test_reload_storage_guard_verifies_after_body_failure(monkeypatch):
+    monkeypatch.setenv("VLLM_RELOAD_GLOBAL_MANIFEST", "off")
+    model, layer = _model_with_arena()
+    original_verify = validation.verify_model_arenas
+    verify_calls = 0
+
+    def tracked_verify(*args, **kwargs):
+        nonlocal verify_calls
+        verify_calls += 1
+        return original_verify(*args, **kwargs)
+
+    monkeypatch.setattr(validation, "verify_model_arenas", tracked_verify)
+
+    with pytest.raises(ValueError, match="load failed") as exc_info:
+        with reload_storage_guard(model):
+            get_reload_arena(layer)._slots["workspace"] = torch.empty(4)
+            raise ValueError("load failed")
+
+    assert verify_calls == 1
+    assert any(
+        "must not continue serving" in note
+        for note in getattr(exc_info.value, "__notes__", [])
+    )
+
+
+def test_reload_failure_is_not_masked_by_validation_failure(monkeypatch):
+    monkeypatch.setenv("VLLM_RELOAD_GLOBAL_MANIFEST", "off")
+    model, _ = _model_with_arena()
+
+    def fail_validation(*_args, **_kwargs):
+        raise RuntimeError("validation failed")
+
+    monkeypatch.setattr(validation, "verify_model_arenas", fail_validation)
+
+    with pytest.raises(ValueError, match="load failed") as exc_info:
+        with reload_storage_guard(model):
+            raise ValueError("load failed")
+
+    notes = getattr(exc_info.value, "__notes__", [])
+    assert any("validation failed" in note for note in notes)
+    assert any("must not continue serving" in note for note in notes)

--- a/tests/v1/worker/test_gpu_model_runner.py
+++ b/tests/v1/worker/test_gpu_model_runner.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from contextlib import nullcontext
 from types import SimpleNamespace
 from unittest.mock import Mock
 
@@ -827,6 +828,42 @@ def test_load_model_weights_inplace(dist_init, model_runner, model_runner_2):
 def test_reload_weights_before_load_model(model_runner):
     with pytest.raises(ValueError):
         model_runner.reload_weights()
+
+
+def test_checkpoint_reload_uses_modelwise_reloader(monkeypatch):
+    class ReloadableModel(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.weight = torch.nn.Parameter(torch.zeros(2))
+
+        def load_weights(self, weights):
+            loaded = set()
+            for name, value in weights:
+                self.get_parameter(name).data.copy_(value)
+                loaded.add(name)
+            return loaded
+
+    model = ReloadableModel()
+    runner = object.__new__(GPUModelRunner)
+    runner.model_config = SimpleNamespace(quantization="fp8")
+    runner.vllm_config = get_vllm_config()
+    runner.device = torch.device("cpu")
+    runner.get_model = Mock(return_value=model)
+    runner.reset_encoder_cache = Mock()
+    runner.reset_mm_cache = Mock()
+
+    reloader = Mock()
+    reloader.return_value.reload.return_value = {"weight"}
+    monkeypatch.setattr(gpu_model_runner_module, "ModelwiseReloader", reloader)
+    monkeypatch.setattr(
+        "vllm.model_executor.model_loader.reload.validation.reload_storage_guard",
+        lambda _model: nullcontext(),
+    )
+
+    runner.reload_weights(weights_iterator=[("weight", torch.ones(2))])
+
+    reloader.assert_called_once_with(model, runner.model_config, runner.device)
+    reloader.return_value.reload.assert_called_once()
 
 
 def test_sample_passes_reordered_draft_probs_to_rejection_sampler():

--- a/tests/v1/worker/test_gpu_worker_weight_transfer.py
+++ b/tests/v1/worker/test_gpu_worker_weight_transfer.py
@@ -15,10 +15,16 @@ from vllm.v1.worker.gpu_worker import Worker
 class _RecordingEngine:
     """Minimal stand-in for a weight transfer engine."""
 
-    def __init__(self, raise_on_update: bool = False):
+    def __init__(
+        self,
+        raise_on_update: bool = False,
+        raise_on_finish: bool = False,
+    ):
         self.raise_on_update = raise_on_update
+        self.raise_on_finish = raise_on_finish
         self.started = False
         self.finished = False
+        self.aborted = False
         self.update_calls: list[dict] = []
 
     def start_weight_update(self) -> None:
@@ -31,6 +37,11 @@ class _RecordingEngine:
 
     def finish_weight_update(self) -> None:
         self.finished = True
+        if self.raise_on_finish:
+            raise ValueError("finish boom")
+
+    def abort_weight_update(self) -> None:
+        self.aborted = True
 
 
 def _make_worker(engine: _RecordingEngine | None) -> Worker:
@@ -85,6 +96,18 @@ def test_update_resets_active_on_error():
         Worker.update_weights(worker, {"names": ["w"]})
 
     # A failed update ends the session so the next start is clean.
+    assert worker._weight_update_active is False
+    assert engine.aborted is True
+
+
+def test_finish_resets_active_on_error():
+    engine = _RecordingEngine(raise_on_finish=True)
+    worker = _make_worker(engine)
+    Worker.start_weight_update(worker)
+
+    with pytest.raises(ValueError, match="finish boom"):
+        Worker.finish_weight_update(worker)
+
     assert worker._weight_update_active is False
 
 

--- a/vllm/distributed/weight_transfer/base.py
+++ b/vllm/distributed/weight_transfer/base.py
@@ -59,10 +59,10 @@ class WeightTransferEngine(ABC, Generic[TInitInfo, TUpdateInfo]):
     plugged in.
 
     Each engine owns its full weight-update lifecycle: `start_weight_update`,
-    `update_weights`, and `finish_weight_update`. Layerwise reloading (used by
-    checkpoint-format engines) is opted into per engine by running it inside
-    `start_weight_update`/`finish_weight_update`. Engines that apply weights in
-    place (e.g. sparse patches) leave those methods as no-ops.
+    `update_weights`, and `finish_weight_update`. Checkpoint-format engines use
+    this explicit boundary to defer model-wide post-load processing until the
+    trainer declares the update complete. Engines that apply weights in place
+    (e.g. sparse patches) leave those methods as no-ops.
 
     Subclasses should define:
         init_info_cls: Type of backend-specific initialization info
@@ -167,6 +167,9 @@ class WeightTransferEngine(ABC, Generic[TInitInfo, TUpdateInfo]):
         that apply weights in place leave this as a no-op.
         """
         raise NotImplementedError
+
+    def abort_weight_update(self) -> None:
+        """Abort an active update and restore the serving model if needed."""
 
     def update_weights(self, update_info: dict[str, Any]) -> None:
         """

--- a/vllm/distributed/weight_transfer/ipc_engine.py
+++ b/vllm/distributed/weight_transfer/ipc_engine.py
@@ -14,6 +14,7 @@ import torch
 from torch.multiprocessing.reductions import rebuild_cuda_tensor, reduce_tensor
 
 from vllm import envs
+from vllm.config import set_current_vllm_config
 from vllm.config.weight_transfer import WeightTransferConfig
 from vllm.distributed.weight_transfer.base import (
     WeightTransferEngine,
@@ -23,6 +24,7 @@ from vllm.distributed.weight_transfer.base import (
 
 if TYPE_CHECKING:
     from vllm.config import VllmConfig
+    from vllm.model_executor.model_loader.reload import ModelwiseReloadSession
 from vllm.distributed.weight_transfer.packed_tensor import (
     DEFAULT_PACKED_BUFFER_SIZE_BYTES,
     packed_ipc_consumer,
@@ -164,6 +166,7 @@ class IPCWeightTransferEngine(
             model: The local model instance which will receive the weights
         """
         super().__init__(config, vllm_config, device, model)
+        self.reload_session: ModelwiseReloadSession | None = None
 
     def parse_update_info(
         self, update_dict: dict[str, Any]
@@ -207,20 +210,33 @@ class IPCWeightTransferEngine(
         pass
 
     def start_weight_update(self) -> None:
-        """Initialize layerwise reloading for the incoming checkpoint weights."""
+        """Open a model-wide transaction for incoming checkpoint weights."""
         from vllm.model_executor.model_loader.reload import (
-            initialize_layerwise_reload,
+            ModelwiseReloadSession,
         )
 
-        initialize_layerwise_reload(self.model)
+        session = ModelwiseReloadSession(
+            self.model,
+            self.model_config,
+            self.device,
+        )
+        session.start()
+        self.reload_session = session
 
     def finish_weight_update(self) -> None:
-        """Finalize layerwise reloading after all weights have been received."""
-        from vllm.model_executor.model_loader.reload import (
-            finalize_layerwise_reload,
-        )
+        """Run model-wide post-load processing and commit the update."""
+        session = self.reload_session
+        if session is None:
+            raise RuntimeError("IPC weight update session is not active")
+        self.reload_session = None
+        with set_current_vllm_config(self.vllm_config):
+            session.finish()
 
-        finalize_layerwise_reload(self.model, self.model_config)
+    def abort_weight_update(self) -> None:
+        session = self.reload_session
+        self.reload_session = None
+        if session is not None:
+            session.abort()
 
     def receive_weights(self, update_info: IPCWeightTransferUpdateInfo) -> None:
         """
@@ -274,10 +290,16 @@ class IPCWeightTransferEngine(
                 weight = rebuild_cuda_tensor(*list_args)
                 weights.append((name, weight))
 
-        self.model.load_weights(weights)
+        if self.reload_session is None:
+            raise RuntimeError(
+                "IPC weight update session is not active. "
+                "Call start_weight_update() first."
+            )
+        with set_current_vllm_config(self.vllm_config):
+            self.reload_session.load_weights(weights)
 
     def shutdown(self) -> None:
-        pass
+        self.abort_weight_update()
 
     @staticmethod
     def trainer_send_weights(

--- a/vllm/distributed/weight_transfer/nccl_engine.py
+++ b/vllm/distributed/weight_transfer/nccl_engine.py
@@ -8,9 +8,12 @@ from typing import TYPE_CHECKING, Any
 
 import torch
 
+from vllm.config import set_current_vllm_config
+
 if TYPE_CHECKING:
     from vllm.config import VllmConfig
     from vllm.distributed.device_communicators.pynccl import PyNcclCommunicator
+    from vllm.model_executor.model_loader.reload import ModelwiseReloadSession
 
 from vllm.config.weight_transfer import WeightTransferConfig
 from vllm.distributed.weight_transfer.base import (
@@ -121,6 +124,7 @@ class NCCLWeightTransferEngine(
     ) -> None:
         super().__init__(config, vllm_config, device, model)
         self.model_update_group: PyNcclCommunicator | None = None
+        self.reload_session: ModelwiseReloadSession | None = None
 
     def init_transfer_engine(self, init_info: NCCLWeightTransferInitInfo) -> None:
         """
@@ -135,20 +139,33 @@ class NCCLWeightTransferEngine(
         )
 
     def start_weight_update(self) -> None:
-        """Initialize layerwise reloading for the incoming checkpoint weights."""
+        """Open a model-wide transaction for incoming checkpoint weights."""
         from vllm.model_executor.model_loader.reload import (
-            initialize_layerwise_reload,
+            ModelwiseReloadSession,
         )
 
-        initialize_layerwise_reload(self.model)
+        session = ModelwiseReloadSession(
+            self.model,
+            self.model_config,
+            self.device,
+        )
+        session.start()
+        self.reload_session = session
 
     def finish_weight_update(self) -> None:
-        """Finalize layerwise reloading after all weights have been received."""
-        from vllm.model_executor.model_loader.reload import (
-            finalize_layerwise_reload,
-        )
+        """Run model-wide post-load processing and commit the update."""
+        session = self.reload_session
+        if session is None:
+            raise RuntimeError("NCCL weight update session is not active")
+        self.reload_session = None
+        with set_current_vllm_config(self.vllm_config):
+            session.finish()
 
-        finalize_layerwise_reload(self.model, self.model_config)
+    def abort_weight_update(self) -> None:
+        session = self.reload_session
+        self.reload_session = None
+        if session is not None:
+            session.abort()
 
     def receive_weights(self, update_info: NCCLWeightTransferUpdateInfo) -> None:
         """
@@ -167,39 +184,46 @@ class NCCLWeightTransferEngine(
                 "NCCL weight transfer not initialized. "
                 "Call init_transfer_engine() first."
             )
+        if self.reload_session is None:
+            raise RuntimeError(
+                "NCCL weight update session is not active. "
+                "Call start_weight_update() first."
+            )
 
-        if update_info.packed:
-            # Build iterator of (name, (shape, dtype)) from update_info
-            def state_dict_info_iterator():
+        with set_current_vllm_config(self.vllm_config):
+            if update_info.packed:
+                # Build iterator of (name, (shape, dtype)) from update_info
+                def state_dict_info_iterator():
+                    for name, dtype_name, shape in zip(
+                        update_info.names, update_info.dtype_names, update_info.shapes
+                    ):
+                        dtype = getattr(torch, dtype_name)
+                        yield (name, (shape, dtype))
+
+                packed_nccl_broadcast_consumer(
+                    iterator=state_dict_info_iterator(),
+                    group=self.model_update_group,
+                    src=0,
+                    post_unpack_func=self.reload_session.load_weights,
+                    buffer_size_bytes=update_info.packed_buffer_size_bytes,
+                    num_buffers=update_info.packed_num_buffers,
+                    device=self.device,
+                )
+            else:
+                # Use simple one-by-one broadcasting
                 for name, dtype_name, shape in zip(
                     update_info.names, update_info.dtype_names, update_info.shapes
                 ):
                     dtype = getattr(torch, dtype_name)
-                    yield (name, (shape, dtype))
-
-            packed_nccl_broadcast_consumer(
-                iterator=state_dict_info_iterator(),
-                group=self.model_update_group,
-                src=0,
-                post_unpack_func=self.model.load_weights,
-                buffer_size_bytes=update_info.packed_buffer_size_bytes,
-                num_buffers=update_info.packed_num_buffers,
-                device=self.device,
-            )
-        else:
-            # Use simple one-by-one broadcasting
-            for name, dtype_name, shape in zip(
-                update_info.names, update_info.dtype_names, update_info.shapes
-            ):
-                dtype = getattr(torch, dtype_name)
-                weight = torch.empty(shape, dtype=dtype, device=self.device)
-                self.model_update_group.broadcast(
-                    weight, src=0, stream=torch.cuda.current_stream()
-                )
-                self.model.load_weights([(name, weight)])
-                del weight
+                    weight = torch.empty(shape, dtype=dtype, device=self.device)
+                    self.model_update_group.broadcast(
+                        weight, src=0, stream=torch.cuda.current_stream()
+                    )
+                    self.reload_session.load_weights([(name, weight)])
+                    del weight
 
     def shutdown(self) -> None:
+        self.abort_weight_update()
         if self.model_update_group is not None:
             # Clean up the communicator by removing the reference
             self.model_update_group = None

--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -895,6 +895,7 @@ class LLM(BeamSearchOfflineMixin, PoolingOfflineMixin, OfflineInferenceMixin):
     def finish_weight_update(self) -> None:
         """Finish the current weight update."""
         self.llm_engine.collective_rpc("finish_weight_update")
+        self.llm_engine.reset_prefix_cache()
 
     def __repr__(self) -> str:
         """Return a transformers-style hierarchical view of the model."""

--- a/vllm/model_executor/kernels/linear/mixed_precision/machete.py
+++ b/vllm/model_executor/kernels/linear/mixed_precision/machete.py
@@ -1,9 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-from functools import partial
 
 import torch
+
+from vllm.model_executor.reload_arena import get_reload_arena
 
 from vllm import _custom_ops as ops
 from vllm.model_executor.layers.quantization.utils.machete_utils import (
@@ -72,15 +73,23 @@ class MacheteLinearKernel(MPLinearKernel):
 
         if c.has_g_idx:
             assert self.w_gidx_name is not None
-            perm = torch.argsort(getattr(layer, self.w_gidx_name)).to(torch.int)
+            perm = get_reload_arena(layer).put(
+                "machete_act_perm",
+                torch.argsort(getattr(layer, self.w_gidx_name)).to(torch.int))
 
-            self.act_perm = lambda x: x[:, perm]
+            # Resolved through the layer at CALL time, never captured in a
+            # kernel-held callable: a closure binds the tensor object alive
+            # at PWAL time, which is exactly the object each reload
+            # replaces -- captured graphs then permute activations with the
+            # OLD model's act order. (A registered-param variant that still
+            # closed over the tensor failed live validation for this
+            # reason.) The arena keeps the storage itself stable.
+            layer.machete_act_perm = perm
             # use `ops.permute_cols` if possible
-            if (
+            self.use_permute_cols = (
                 c.act_type in [torch.float16, torch.bfloat16]
                 and c.partition_weight_shape[0] % 8 == 0
-            ):
-                self.act_perm = partial(ops.permute_cols, perm=perm)
+            )
 
         def transform_w_q(x):
             assert isinstance(x, BasevLLMParameter)
@@ -137,7 +146,11 @@ class MacheteLinearKernel(MPLinearKernel):
         out_shape = x.shape[:-1] + (c.partition_weight_shape[1],)
 
         if c.has_g_idx:
-            x_2d = self.act_perm(x_2d)
+            perm = layer.machete_act_perm
+            if self.use_permute_cols:
+                x_2d = ops.permute_cols(x_2d, perm)
+            else:
+                x_2d = x_2d[:, perm]
 
         if c.zero_points:
             assert w_zp is not None

--- a/vllm/model_executor/kernels/linear/mixed_precision/marlin.py
+++ b/vllm/model_executor/kernels/linear/mixed_precision/marlin.py
@@ -5,6 +5,7 @@
 import torch
 
 from vllm import _custom_ops as ops
+from vllm.model_executor.reload_arena import get_reload_arena
 from vllm.model_executor.layers.quantization.utils.marlin_utils import (
     MARLIN_SUPPORTED_GROUP_SIZES,
     apply_gptq_marlin_linear,
@@ -111,8 +112,13 @@ class MarlinLinearKernel(MPLinearKernel):
         else:
             padded_n, padded_k = marlin_padded_nk(size_n, size_k, c.group_size)
 
-        # Allocate marlin workspace.
-        self.workspace = marlin_make_workspace_new(device)
+        # Allocate marlin workspace through the layer's reload arena: the
+        # workspace address is baked into captured graphs, and it holds sync
+        # counters -- a rebind on reload leaves replay spinning on freed
+        # memory (livelock). put() adopts on first PWAL and copies the fresh
+        # zeros into the SAME storage on re-runs.
+        self.workspace = get_reload_arena(layer).put(
+            "marlin_workspace", marlin_make_workspace_new(device))
 
         # Default names since marlin requires empty parameters for these,
         # TODO: remove this requirement from marlin (allow optional tensors)
@@ -174,7 +180,10 @@ class MarlinLinearKernel(MPLinearKernel):
                 getattr(layer, self.w_gidx_name)
             )
             self._transform_param(layer, self.w_gidx_name, lambda _: g_idx)
-            layer.g_idx_sort_indices = g_idx_sort_indices
+            # Bare attribute read by every act-order kernel launch; publish
+            # at a stable address so graph replay keeps a valid pointer.
+            layer.g_idx_sort_indices = get_reload_arena(layer).put(
+                "g_idx_sort_indices", g_idx_sort_indices)
         else:
             setattr(layer, self.w_gidx_name, marlin_make_empty_g_idx(device))
             layer.g_idx_sort_indices = marlin_make_empty_g_idx(device)

--- a/vllm/model_executor/kernels/linear/mixed_precision/marlin.py
+++ b/vllm/model_executor/kernels/linear/mixed_precision/marlin.py
@@ -5,7 +5,6 @@
 import torch
 
 from vllm import _custom_ops as ops
-from vllm.model_executor.reload_arena import get_reload_arena
 from vllm.model_executor.layers.quantization.utils.marlin_utils import (
     MARLIN_SUPPORTED_GROUP_SIZES,
     apply_gptq_marlin_linear,
@@ -13,7 +12,7 @@ from vllm.model_executor.layers.quantization.utils.marlin_utils import (
     marlin_act_int8_process_scales,
     marlin_is_k_full,
     marlin_make_empty_g_idx,
-    marlin_make_workspace_new,
+    marlin_get_workspace,
     marlin_pad_dim,
     marlin_pad_qweight,
     marlin_pad_scales,
@@ -26,6 +25,7 @@ from vllm.model_executor.layers.quantization.utils.marlin_utils import (
     unpack_cols,
 )
 from vllm.model_executor.parameter import BasevLLMParameter, permute_param_layout_
+from vllm.model_executor.reload_arena import get_reload_arena
 from vllm.platforms import current_platform
 from vllm.scalar_type import scalar_types
 
@@ -115,10 +115,9 @@ class MarlinLinearKernel(MPLinearKernel):
         # Allocate marlin workspace through the layer's reload arena: the
         # workspace address is baked into captured graphs, and it holds sync
         # counters -- a rebind on reload leaves replay spinning on freed
-        # memory (livelock). put() adopts on first PWAL and copies the fresh
-        # zeros into the SAME storage on re-runs.
-        self.workspace = get_reload_arena(layer).put(
-            "marlin_workspace", marlin_make_workspace_new(device))
+        # memory (livelock). Reacquisition keeps the address and clears the
+        # counters without allocating a throwaway workspace.
+        self.workspace = marlin_get_workspace(layer, device)
 
         # Default names since marlin requires empty parameters for these,
         # TODO: remove this requirement from marlin (allow optional tensors)

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -194,6 +194,8 @@ from enum import Enum
 from typing import ClassVar, Generic, TypeVar, cast
 
 import torch
+
+from vllm.model_executor.reload_arena import get_reload_arena
 import torch.nn as nn
 from tqdm import tqdm
 
@@ -956,10 +958,17 @@ class MLAAttention(nn.Module, AttentionLayerBase):
                     x, self.W_V, self.W_V_scale, group_size=128, transpose_bm=True
                 )
         else:
+            # Publish through the reload arena: these derived decode weights
+            # are read by graph-captured BMMs, and a bare rebind on each
+            # post-load pass leaves captured graphs holding the previous
+            # storage. put() adopts once and copies re-derived values into
+            # the same storage on reload, so the address stays valid and the
+            # value refreshes.
+            arena = get_reload_arena(self)
             # Convert from (L, N, V) to (N, L, V)
-            self.W_UV = W_UV.transpose(0, 1)
+            self.W_UV = arena.put("W_UV", W_UV.transpose(0, 1))
             # Convert from (L, N, P) to (N, P, L)
-            self.W_UK_T = W_UK.permute(1, 2, 0)
+            self.W_UK_T = arena.put("W_UK_T", W_UK.permute(1, 2, 0))
 
         # If we should not load quant weights, we initialize the scales to 1.0
         # as the default value. See [Note: Register q/k/v/prob scales in state dict]

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -194,8 +194,6 @@ from enum import Enum
 from typing import ClassVar, Generic, TypeVar, cast
 
 import torch
-
-from vllm.model_executor.reload_arena import get_reload_arena
 import torch.nn as nn
 from tqdm import tqdm
 
@@ -242,6 +240,7 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
     kFp8StaticTensorSym,
     kNvfp4Dynamic,
 )
+from vllm.model_executor.reload_arena import get_reload_arena
 from vllm.platforms import current_platform
 from vllm.utils.flashinfer import has_flashinfer
 from vllm.utils.math_utils import cdiv, round_down
@@ -901,6 +900,7 @@ class MLAAttention(nn.Module, AttentionLayerBase):
         W_UK, W_UV = kv_b_proj_weight.split(
             [self.qk_nope_head_dim, self.v_head_dim], dim=-1
         )
+        arena = get_reload_arena(self)
 
         # If kv_b_proj_weight is unquantized, quantize it to mxfp4 if supported
         if self.is_aiter_triton_fp4_bmm_enabled:
@@ -910,12 +910,16 @@ class MLAAttention(nn.Module, AttentionLayerBase):
 
             self.W_K, self.W_K_scale = quark_quantize_weight_to_mxfp4(W_UK)
             # Convert from (L, N, P) to (N, L, P)
-            self.W_K = self.W_K.transpose(0, 1)
-            self.W_K_scale = self.W_K_scale.transpose(0, 1)
+            self.W_K = arena.put("W_K", self.W_K.transpose(0, 1))
+            self.W_K_scale = arena.put(
+                "W_K_scale", self.W_K_scale.transpose(0, 1)
+            )
 
             self.W_V, self.W_V_scale = quark_quantize_weight_to_mxfp4(
                 W_UV.permute(1, 2, 0)
             )
+            self.W_V = arena.put("W_V", self.W_V)
+            self.W_V_scale = arena.put("W_V_scale", self.W_V_scale)
         elif self.is_aiter_triton_fp8_bmm_enabled:
             W_K = W_UK.transpose(0, 1)  # 16 512 128
             W_V = W_UV.permute(1, 2, 0)  # 16 128 512
@@ -925,6 +929,10 @@ class MLAAttention(nn.Module, AttentionLayerBase):
             self.W_V, self.W_V_scale = dynamic_per_batched_tensor_quant(
                 W_V, dtype=current_platform.fp8_dtype()
             )
+            self.W_K = arena.put("W_K", self.W_K)
+            self.W_K_scale = arena.put("W_K_scale", self.W_K_scale)
+            self.W_V = arena.put("W_V", self.W_V)
+            self.W_V_scale = arena.put("W_V_scale", self.W_V_scale)
 
             # The kernel operates on non-padded inputs. Hence, pre-compiling
             # triton kernel to avoid runtime compilation for unseen batch sizes
@@ -964,7 +972,6 @@ class MLAAttention(nn.Module, AttentionLayerBase):
             # storage. put() adopts once and copies re-derived values into
             # the same storage on reload, so the address stays valid and the
             # value refreshes.
-            arena = get_reload_arena(self)
             # Convert from (L, N, V) to (N, L, V)
             self.W_UV = arena.put("W_UV", W_UV.transpose(0, 1))
             # Convert from (L, N, P) to (N, P, L)

--- a/vllm/model_executor/layers/fused_moe/experts/cutlass_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/cutlass_moe.py
@@ -29,6 +29,7 @@ from vllm.model_executor.layers.fused_moe.topk_weight_and_reduce import (
 from vllm.model_executor.layers.fused_moe.utils import (
     _resize_cache,
 )
+from vllm.model_executor.reload_arena import current_arena
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     QuantKey,
     kFp8DynamicTensorSym,
@@ -286,9 +287,28 @@ class CutlassExpertsFp8Base(mk.FusedMoEExpertsModular):
         n = moe_config.intermediate_size_per_partition
         k = moe_config.hidden_dim
         device = moe_config.device
-        ab_strides1_c_strides2 = torch.full((e,), k, device=device, dtype=torch.int64)
-        ab_strides2 = torch.full((e,), n, device=device, dtype=torch.int64)
-        c_strides1 = torch.full((e,), 2 * n, device=device, dtype=torch.int64)
+
+        # Stride tensors are passed to every grouped-GEMM launch, so their
+        # addresses live inside captured graphs; this object is rebuilt by
+        # every post-load pass. Publish them through the layer's reload
+        # arena (ambient during PWAL) so the rebuild reuses the same
+        # storage. Captured here as well for the lazily-built scratch.
+        self._reload_arena = current_arena()
+
+        def _stable(slot: str, t: torch.Tensor) -> torch.Tensor:
+            if self._reload_arena is not None:
+                return self._reload_arena.put(f"cutlass_fp8.{slot}", t)
+            return t
+
+        ab_strides1_c_strides2 = _stable(
+            "ab_strides1_c_strides2",
+            torch.full((e,), k, device=device, dtype=torch.int64))
+        ab_strides2 = _stable(
+            "ab_strides2", torch.full((e,), n, device=device,
+                                      dtype=torch.int64))
+        c_strides1 = _stable(
+            "c_strides1", torch.full((e,), 2 * n, device=device,
+                                     dtype=torch.int64))
 
         self.out_dtype = moe_config.in_dtype
         self.ab_strides1 = ab_strides1_c_strides2
@@ -338,6 +358,7 @@ class CutlassExpertsFp8Base(mk.FusedMoEExpertsModular):
                 num_experts=self.moe_config.num_experts,
                 num_local_experts=self.moe_config.num_local_experts,
                 device=torch.device(self.moe_config.device),
+                arena=self._reload_arena,
             )
         return self._permute_scratch
 
@@ -1265,20 +1286,37 @@ class CutlassExpertsW4A8Fp8(mk.FusedMoEExpertsModular):
 
         self.out_dtype = moe_config.in_dtype
 
-        a_strides1_c_strides2 = torch.full((e,), k, device=device, dtype=torch.int64)
+        # Same rationale as CutlassExpertsFp8Base: stride addresses are
+        # graph-captured, this object is rebuilt per post-load pass.
+        self._reload_arena = current_arena()
+
+        def _stable(slot: str, t: torch.Tensor) -> torch.Tensor:
+            if self._reload_arena is not None:
+                return self._reload_arena.put(f"cutlass_w4a8.{slot}", t)
+            return t
+
+        a_strides1_c_strides2 = _stable(
+            "a_strides1_c_strides2",
+            torch.full((e,), k, device=device, dtype=torch.int64))
         self.a_strides1 = a_strides1_c_strides2
-        self.a_strides2 = torch.full((e,), n, device=device, dtype=torch.int64)
-        self.c_strides1 = torch.full((e,), 2 * n, device=device, dtype=torch.int64)
+        self.a_strides2 = _stable(
+            "a_strides2", torch.full((e,), n, device=device,
+                                     dtype=torch.int64))
+        self.c_strides1 = _stable(
+            "c_strides1", torch.full((e,), 2 * n, device=device,
+                                     dtype=torch.int64))
         self.c_strides2 = a_strides1_c_strides2
 
-        self.b_strides1 = b_strides1
-        self.b_strides2 = b_strides2
+        self.b_strides1 = _stable("b_strides1", b_strides1)
+        self.b_strides2 = _stable("b_strides2", b_strides2)
 
         # sizeof(StrideS) = 16 bytes, encoded as 2xint64.
-        self.s_strides1 = torch.zeros((e, 2), device=device, dtype=torch.int64)
-        self.s_strides1[:, 0] = 2 * n
-        self.s_strides2 = torch.zeros((e, 2), device=device, dtype=torch.int64)
-        self.s_strides2[:, 0] = k
+        s_strides1 = torch.zeros((e, 2), device=device, dtype=torch.int64)
+        s_strides1[:, 0] = 2 * n
+        self.s_strides1 = _stable("s_strides1", s_strides1)
+        s_strides2 = torch.zeros((e, 2), device=device, dtype=torch.int64)
+        s_strides2[:, 0] = k
+        self.s_strides2 = _stable("s_strides2", s_strides2)
 
         self.group_size = group_size
         self._permute_scratch: MoEPermuteScratch | None = None
@@ -1351,6 +1389,7 @@ class CutlassExpertsW4A8Fp8(mk.FusedMoEExpertsModular):
                 num_experts=self.moe_config.num_experts,
                 num_local_experts=self.moe_config.num_local_experts,
                 device=torch.device(self.moe_config.device),
+                arena=self._reload_arena,
             )
         return self._permute_scratch
 

--- a/vllm/model_executor/layers/fused_moe/experts/flashinfer_b12x_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/flashinfer_b12x_moe.py
@@ -20,7 +20,7 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
     kNvfp4Dynamic,
     kNvfp4Static,
 )
-from vllm.model_executor.reload_arena import get_reload_arena
+from vllm.model_executor.reload_arena import ReloadArena, get_reload_arena
 from vllm.platforms import current_platform
 from vllm.utils.flashinfer import (
     flashinfer_convert_sf_to_mma_layout,
@@ -167,6 +167,11 @@ class FlashInferB12xExperts(mk.FusedMoEExpertsModular):
             ),
         )
 
+        # The wrapper owns private CUDA-graph workspaces that the arena cannot
+        # adopt individually. Persist the wrapper in an object slot so a
+        # rebuilt experts object borrows the same wrapper.
+        self._bind_arena_wrapper(arena)
+
     @staticmethod
     def activation_format() -> mk.FusedMoEActivationFormat:
         return mk.FusedMoEActivationFormat.Standard
@@ -238,14 +243,10 @@ class FlashInferB12xExperts(mk.FusedMoEExpertsModular):
         # from pre-quantizing activations.
         return True
 
-    def _ensure_wrapper(self) -> None:
-        """Lazily create B12xMoEWrapper on first use."""
-        if self._wrapper is not None:
-            return
-
+    def _build_wrapper(self) -> Any:
         from flashinfer.fused_moe import B12xMoEWrapper
 
-        self._wrapper = B12xMoEWrapper(
+        return B12xMoEWrapper(
             num_experts=self.global_num_experts,
             top_k=self.topk,
             hidden_size=self.hidden_dim,
@@ -255,6 +256,16 @@ class FlashInferB12xExperts(mk.FusedMoEExpertsModular):
             num_local_experts=self.num_local_experts,
             activation=self._activation_str,
         )
+
+    def _bind_arena_wrapper(self, arena: ReloadArena) -> None:
+        self._wrapper = arena.get_or_create_object(
+            "flashinfer_b12x.wrapper", self._build_wrapper
+        )
+
+    def _ensure_wrapper(self) -> None:
+        """Build a wrapper for direct use without layer PWAL."""
+        if self._wrapper is None:
+            self._wrapper = self._build_wrapper()
 
     def apply(
         self,

--- a/vllm/model_executor/layers/fused_moe/experts/flashinfer_b12x_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/flashinfer_b12x_moe.py
@@ -20,6 +20,7 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
     kNvfp4Dynamic,
     kNvfp4Static,
 )
+from vllm.model_executor.reload_arena import get_reload_arena
 from vllm.platforms import current_platform
 from vllm.utils.flashinfer import (
     flashinfer_convert_sf_to_mma_layout,
@@ -91,6 +92,7 @@ class FlashInferB12xExperts(mk.FusedMoEExpertsModular):
         self.w2_sf_mma: torch.Tensor | None = None
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        arena = get_reload_arena(layer)
         # Normalise block scales to absorb the per-expert weight global scale
         # (w_gs).  vLLM's NVFP4 convention stores:
         #   block_scale = max_abs * w_gs / fp4_max,  g1_alphas = 1/w_gs
@@ -128,10 +130,13 @@ class FlashInferB12xExperts(mk.FusedMoEExpertsModular):
             # 1.0 scale per expert is equivalent to the bake-in above for
             # static-quant checkpoints. Allocate once here so apply() stays
             # alloc-free.
-            self._fc2_input_scale = torch.ones(
-                self.num_local_experts,
-                device=layer.w13_weight.device,
-                dtype=torch.float32,
+            self._fc2_input_scale = arena.put(
+                "flashinfer_b12x.fc2_input_scale",
+                torch.ones(
+                    self.num_local_experts,
+                    device=layer.w13_weight.device,
+                    dtype=torch.float32,
+                ),
             )
 
         # Precompute MMA-layout views of the weight scale factors once here
@@ -139,21 +144,27 @@ class FlashInferB12xExperts(mk.FusedMoEExpertsModular):
         assert self.w1_scale is not None
         num_experts_w1, m1, k1_sf = self.w1_scale.shape
         k1 = k1_sf * 16
-        self.w1_sf_mma = flashinfer_convert_sf_to_mma_layout(
-            self.w1_scale.reshape(num_experts_w1 * m1, k1_sf),
-            m=m1,
-            k=k1,
-            num_groups=num_experts_w1,
+        self.w1_sf_mma = arena.put(
+            "flashinfer_b12x.w1_sf_mma",
+            flashinfer_convert_sf_to_mma_layout(
+                self.w1_scale.reshape(num_experts_w1 * m1, k1_sf),
+                m=m1,
+                k=k1,
+                num_groups=num_experts_w1,
+            ),
         )
 
         assert self.w2_scale is not None
         num_experts_w2, m2, k2_sf = self.w2_scale.shape
         k2 = k2_sf * 16
-        self.w2_sf_mma = flashinfer_convert_sf_to_mma_layout(
-            self.w2_scale.reshape(num_experts_w2 * m2, k2_sf),
-            m=m2,
-            k=k2,
-            num_groups=num_experts_w2,
+        self.w2_sf_mma = arena.put(
+            "flashinfer_b12x.w2_sf_mma",
+            flashinfer_convert_sf_to_mma_layout(
+                self.w2_scale.reshape(num_experts_w2 * m2, k2_sf),
+                m=m2,
+                k=k2,
+                num_groups=num_experts_w2,
+            ),
         )
 
     @staticmethod

--- a/vllm/model_executor/layers/fused_moe/experts/flashinfer_cutlass_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/flashinfer_cutlass_moe.py
@@ -23,6 +23,7 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
     kNvfp4Dynamic,
     kNvfp4Static,
 )
+from vllm.model_executor.reload_arena import current_arena
 from vllm.platforms import current_platform
 from vllm.utils.flashinfer import (
     flashinfer_cutlass_fused_moe,
@@ -93,34 +94,60 @@ class FlashInferExperts(mk.FusedMoEExpertsModular):
         # - pass per-block weight scales to the kernel
         # - skip input activation quantization (kernel applies scaling)
         self.use_deepseek_fp8_block_scale = quant_config.is_block_quantized
+        arena = current_arena()
+
+        def stable(slot: str, value: torch.Tensor) -> torch.Tensor:
+            if arena is None:
+                return value
+            return arena.put(f"flashinfer_experts.{slot}", value)
+
         self.gemm1_clamp_limit: torch.Tensor | None = None
         if quant_config.gemm1_clamp_limit is not None:
-            self.gemm1_clamp_limit = torch.tensor(
-                [quant_config.gemm1_clamp_limit] * self.num_experts,
-                dtype=torch.float32,
-                device=self.device,
+            self.gemm1_clamp_limit = stable(
+                "gemm1_clamp_limit",
+                torch.tensor(
+                    [quant_config.gemm1_clamp_limit] * self.num_experts,
+                    dtype=torch.float32,
+                    device=self.device,
+                ),
             )
 
         if quant_config.weight_quant_dtype == "mxfp4":
             # This value is used specifically for gpt-oss,
             # Need to revisit this for other models
-            self.gemm1_alpha = torch.tensor(
-                [1.702] * self.num_experts, dtype=torch.float32, device=self.device
+            self.gemm1_alpha = stable(
+                "gemm1_alpha",
+                torch.tensor(
+                    [1.702] * self.num_experts,
+                    dtype=torch.float32,
+                    device=self.device,
+                ),
             )
-            self.gemm1_beta = torch.tensor(
-                [1.0] * self.num_experts, dtype=torch.float32, device=self.device
+            self.gemm1_beta = stable(
+                "gemm1_beta",
+                torch.tensor(
+                    [1.0] * self.num_experts,
+                    dtype=torch.float32,
+                    device=self.device,
+                ),
             )
             if self.gemm1_clamp_limit is None:
-                self.gemm1_clamp_limit = torch.tensor(
-                    [7.0] * self.num_experts,
-                    dtype=torch.float32,
-                    device=self.device,
+                self.gemm1_clamp_limit = stable(
+                    "gemm1_clamp_limit",
+                    torch.tensor(
+                        [7.0] * self.num_experts,
+                        dtype=torch.float32,
+                        device=self.device,
+                    ),
                 )
             if quant_config.quant_dtype == "mxfp8":
-                self.fake_input_scale = torch.ones(
-                    self.num_experts,
-                    device=self.device,
-                    dtype=torch.float32,
+                self.fake_input_scale = stable(
+                    "fake_input_scale",
+                    torch.ones(
+                        self.num_experts,
+                        device=self.device,
+                        dtype=torch.float32,
+                    ),
                 )
 
     @property

--- a/vllm/model_executor/layers/fused_moe/experts/trtllm_fp8_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/trtllm_fp8_moe.py
@@ -27,6 +27,7 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
     kMxfp8Dynamic,
     kMxfp8Static,
 )
+from vllm.model_executor.reload_arena import current_arena
 from vllm.platforms import current_platform
 from vllm.utils.flashinfer import has_flashinfer_trtllm_fused_moe
 
@@ -58,29 +59,45 @@ class TrtLlmFp8ExpertsBase:
 
         # Per-expert SwiGLU parameters from quant_config (MXFP8 + Swiglu only).
         device = torch.accelerator.current_device_index()
+        arena = current_arena()
+
+        def stable(slot: str, value: torch.Tensor) -> torch.Tensor:
+            if arena is None:
+                return value
+            return arena.put(f"trtllm_fp8.{slot}", value)
+
         if quant_config.gemm1_alpha is not None:
-            self.gemm1_alpha = torch.tensor(
-                [quant_config.gemm1_alpha] * self.local_num_experts,
-                dtype=torch.float32,
-                device=device,
+            self.gemm1_alpha = stable(
+                "gemm1_alpha",
+                torch.tensor(
+                    [quant_config.gemm1_alpha] * self.local_num_experts,
+                    dtype=torch.float32,
+                    device=device,
+                ),
             )
         else:
             self.gemm1_alpha = None
 
         if quant_config.gemm1_beta is not None:
-            self.gemm1_beta = torch.tensor(
-                [quant_config.gemm1_beta] * self.local_num_experts,
-                dtype=torch.float32,
-                device=device,
+            self.gemm1_beta = stable(
+                "gemm1_beta",
+                torch.tensor(
+                    [quant_config.gemm1_beta] * self.local_num_experts,
+                    dtype=torch.float32,
+                    device=device,
+                ),
             )
         else:
             self.gemm1_beta = None
 
         if quant_config.gemm1_clamp_limit is not None:
-            self.gemm1_clamp_limit = torch.tensor(
-                [quant_config.gemm1_clamp_limit] * self.local_num_experts,
-                dtype=torch.float32,
-                device=device,
+            self.gemm1_clamp_limit = stable(
+                "gemm1_clamp_limit",
+                torch.tensor(
+                    [quant_config.gemm1_clamp_limit] * self.local_num_experts,
+                    dtype=torch.float32,
+                    device=device,
+                ),
             )
         else:
             self.gemm1_clamp_limit = None
@@ -284,6 +301,17 @@ class TrtLlmFp8ExpertsMonolithic(TrtLlmFp8ExpertsBase, mk.FusedMoEExpertsMonolit
                 if moe_config.is_act_and_mul
                 else torch.ones_like(self._g1_alphas) / self.quant_config.a2_scale
             )
+            arena = current_arena()
+            if arena is not None:
+                self._g1_alphas = arena.put(
+                    "trtllm_fp8.g1_alphas", self._g1_alphas
+                )
+                self._g2_alphas = arena.put(
+                    "trtllm_fp8.g2_alphas", self._g2_alphas
+                )
+                self._g1_scale_c = arena.put(
+                    "trtllm_fp8.g1_scale_c", self._g1_scale_c
+                )
 
     @staticmethod
     def _supports_quant_scheme(

--- a/vllm/model_executor/layers/fused_moe/experts/trtllm_mxfp4_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/trtllm_mxfp4_moe.py
@@ -20,6 +20,7 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
     kMxfp4Static,
     kMxfp8Dynamic,
 )
+from vllm.model_executor.reload_arena import current_arena
 from vllm.platforms import current_platform
 from vllm.utils.flashinfer import has_flashinfer
 
@@ -52,29 +53,45 @@ class TrtLlmMxfp4ExpertsBase:
 
         # MXFP4-specific TRTLLM parameters from quant_config
         device = torch.accelerator.current_device_index()
+        arena = current_arena()
+
+        def stable(slot: str, value: torch.Tensor) -> torch.Tensor:
+            if arena is None:
+                return value
+            return arena.put(f"trtllm_mxfp4.{slot}", value)
+
         if quant_config.gemm1_alpha is not None:
-            self.gemm1_alpha = torch.tensor(
-                [quant_config.gemm1_alpha] * self.local_num_experts,
-                dtype=torch.float32,
-                device=device,
+            self.gemm1_alpha = stable(
+                "gemm1_alpha",
+                torch.tensor(
+                    [quant_config.gemm1_alpha] * self.local_num_experts,
+                    dtype=torch.float32,
+                    device=device,
+                ),
             )
         else:
             self.gemm1_alpha = None
 
         if quant_config.gemm1_beta is not None:
-            self.gemm1_beta = torch.tensor(
-                [quant_config.gemm1_beta] * self.local_num_experts,
-                dtype=torch.float32,
-                device=device,
+            self.gemm1_beta = stable(
+                "gemm1_beta",
+                torch.tensor(
+                    [quant_config.gemm1_beta] * self.local_num_experts,
+                    dtype=torch.float32,
+                    device=device,
+                ),
             )
         else:
             self.gemm1_beta = None
 
         if quant_config.gemm1_clamp_limit is not None:
-            self.gemm1_clamp_limit = torch.tensor(
-                [quant_config.gemm1_clamp_limit] * self.local_num_experts,
-                dtype=torch.float32,
-                device=device,
+            self.gemm1_clamp_limit = stable(
+                "gemm1_clamp_limit",
+                torch.tensor(
+                    [quant_config.gemm1_clamp_limit] * self.local_num_experts,
+                    dtype=torch.float32,
+                    device=device,
+                ),
             )
         else:
             self.gemm1_clamp_limit = None

--- a/vllm/model_executor/layers/fused_moe/moe_permute_unpermute.py
+++ b/vllm/model_executor/layers/fused_moe/moe_permute_unpermute.py
@@ -2,13 +2,25 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
 
 import torch
+
+if TYPE_CHECKING:
+    from vllm.model_executor.reload_arena import ReloadArena
 
 
 @dataclass
 class MoEPermuteScratch:
     # Reused metadata buffers for repeated grouped-MoE permutes.
+    #
+    # These are allocated on the FIRST FORWARD, so they are live when CUDA
+    # graphs capture and their addresses are baked into the graphs. When a
+    # reload rebuilds the owning experts object, a scratch allocated with
+    # plain torch.empty dies with it and the next forward reallocates
+    # elsewhere -- graph replay then reads freed memory (reproduced as an
+    # illegal memory access on H200). Passing the layer's ReloadArena makes
+    # every buffer here a stable slot that survives the rebuild.
     max_num_tokens: int
     topk: int
     num_experts: int
@@ -16,6 +28,7 @@ class MoEPermuteScratch:
     device: torch.device
     hidden_size: int | None = None
     hidden_dtype: torch.dtype | None = None
+    arena: "ReloadArena | None" = None
     token_expert_indices: torch.Tensor = field(init=False)
     expert_first_token_offset: torch.Tensor = field(init=False)
     permuted_idx: torch.Tensor = field(init=False)
@@ -28,6 +41,16 @@ class MoEPermuteScratch:
     topk_ids_for_sort: torch.Tensor = field(init=False)
     max_expanded_rows: int = field(init=False)
 
+    def _alloc(self, slot: str, shape, dtype: torch.dtype) -> torch.Tensor:
+        """Scratch contents never survive a forward, so PRESERVE-on-reuse is
+        safe; what must survive is the ADDRESS."""
+        if self.arena is not None:
+            from vllm.model_executor.reload_arena import InitPolicy
+            return self.arena.get_or_alloc(
+                f"permute_scratch.{slot}", shape, dtype, self.device,
+                init=InitPolicy.PRESERVE)
+        return torch.empty(shape, dtype=dtype, device=self.device)
+
     def __post_init__(self) -> None:
         assert self.max_num_tokens > 0
         assert self.topk > 0
@@ -39,41 +62,35 @@ class MoEPermuteScratch:
             assert self.hidden_dtype is not None
 
         self.max_expanded_rows = self.max_num_tokens * self.topk
-        self.token_expert_indices = torch.arange(
-            self.max_expanded_rows, dtype=torch.int32, device=self.device
-        )
-        self.expert_first_token_offset = torch.empty(
-            self.num_local_experts + 1, dtype=torch.int64, device=self.device
-        )
-        self.permuted_idx = torch.empty(
-            self.max_expanded_rows, dtype=torch.int32, device=self.device
-        )
-        self.inv_permuted_idx = torch.empty(
-            self.max_expanded_rows, dtype=torch.int32, device=self.device
-        )
+        self.token_expert_indices = self._alloc(
+            "token_expert_indices", (self.max_expanded_rows,), torch.int32)
+        torch.arange(self.max_expanded_rows, dtype=torch.int32,
+                     device=self.token_expert_indices.device,
+                     out=self.token_expert_indices)
+        self.expert_first_token_offset = self._alloc(
+            "expert_first_token_offset", (self.num_local_experts + 1,),
+            torch.int64)
+        self.permuted_idx = self._alloc(
+            "permuted_idx", (self.max_expanded_rows,), torch.int32)
+        self.inv_permuted_idx = self._alloc(
+            "inv_permuted_idx", (self.max_expanded_rows,), torch.int32)
         if self.hidden_size is not None:
             hidden_numel = self.max_expanded_rows * self.hidden_size
-            self.permuted_hidden_states = torch.empty(
-                hidden_numel, dtype=self.hidden_dtype, device=self.device
-            )
-        self.permuted_experts_id = torch.empty(
-            self.max_expanded_rows, dtype=torch.int32, device=self.device
-        )
-        self.sorted_row_idx = torch.empty(
-            self.max_expanded_rows, dtype=torch.int32, device=self.device
-        )
-        self.topk_ids_int32 = torch.empty(
-            self.max_expanded_rows, dtype=torch.int32, device=self.device
-        )
-        self.topk_ids_for_sort = torch.empty(
-            self.max_expanded_rows, dtype=torch.int32, device=self.device
-        )
+            self.permuted_hidden_states = self._alloc(
+                "permuted_hidden_states", (hidden_numel,), self.hidden_dtype)
+        self.permuted_experts_id = self._alloc(
+            "permuted_experts_id", (self.max_expanded_rows,), torch.int32)
+        self.sorted_row_idx = self._alloc(
+            "sorted_row_idx", (self.max_expanded_rows,), torch.int32)
+        self.topk_ids_int32 = self._alloc(
+            "topk_ids_int32", (self.max_expanded_rows,), torch.int32)
+        self.topk_ids_for_sort = self._alloc(
+            "topk_ids_for_sort", (self.max_expanded_rows,), torch.int32)
         sorter_size = torch.ops._moe_C.moe_permute_sort_workspace_size(
             self.max_expanded_rows, self.num_experts
         )
-        self.sort_workspace = torch.empty(
-            sorter_size, dtype=torch.int8, device=self.device
-        )
+        self.sort_workspace = self._alloc(
+            "sort_workspace", (sorter_size,), torch.int8)
         # torch.device("cuda") in config, after initialized,
         # will be changed to cuda:{index}, so we need to refresh here.
         self.device = self.token_expert_indices.device

--- a/vllm/model_executor/layers/fused_moe/oracle/nvfp4.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/nvfp4.py
@@ -31,6 +31,7 @@ from vllm.model_executor.layers.quantization.utils.nvfp4_emulation_utils import 
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     QuantKey,
 )
+from vllm.model_executor.reload_arena import current_arena
 
 logger = init_logger(__name__)
 
@@ -501,11 +502,32 @@ def make_nvfp4_moe_quant_config(
     # The expert's process_weights_after_loading will fuse activation
     # scales in-place. Since the quant config references the same tensor
     # as the registered parameter, EPLB rearrangement stays in sync.
+    g1_alphas = w13_scale_2
+    g2_alphas = w2_scale_2
+    a1_gscale = 1.0 / a13_scale
+    a2_gscale = 1.0 / a2_scale
+
+    arena = current_arena()
+    if arena is not None and backend in (
+        NvFp4MoeBackend.FLASHINFER_CUTLASS,
+        NvFp4MoeBackend.VLLM_CUTLASS,
+    ):
+        g1_alphas = arena.put("nvfp4.g1_alphas", g1_alphas)
+        g2_alphas = arena.put("nvfp4.g2_alphas", g2_alphas)
+        a1_gscale = arena.put("nvfp4.a1_gscale", a1_gscale)
+        a2_gscale = arena.put("nvfp4.a2_gscale", a2_gscale)
+
+        # CUTLASS fuses activation scales through these layer aliases. Keep
+        # them bound to the same stable tensors retained by the quant config.
+        if layer is not None:
+            layer.w13_weight_scale_2 = g1_alphas
+            layer.w2_weight_scale_2 = g2_alphas
+
     return nvfp4_moe_quant_config(
-        g1_alphas=w13_scale_2,
-        g2_alphas=w2_scale_2,
-        a1_gscale=(1.0 / a13_scale),
-        a2_gscale=(1.0 / a2_scale),
+        g1_alphas=g1_alphas,
+        g2_alphas=g2_alphas,
+        a1_gscale=a1_gscale,
+        a2_gscale=a2_gscale,
         w1_scale=w13_scale,
         w2_scale=w2_scale,
         # NOTE(rob): this is a hack until the MoE kernels

--- a/vllm/model_executor/layers/quantization/auto_awq.py
+++ b/vllm/model_executor/layers/quantization/auto_awq.py
@@ -48,7 +48,7 @@ from vllm.model_executor.layers.quantization.utils.marlin_utils import (
     check_marlin_supports_layer,
     check_moe_marlin_supports_layer,
     get_marlin_input_dtype,
-    marlin_make_workspace_new,
+    marlin_get_workspace,
     verify_marlin_supported,
 )
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
@@ -60,7 +60,6 @@ from vllm.model_executor.parameter import (
     GroupQuantScaleParameter,
     PackedvLLMParameter,
 )
-from vllm.model_executor.reload_arena import get_reload_arena
 from vllm.platforms import current_platform
 from vllm.scalar_type import scalar_types
 from vllm.transformers_utils.config import get_safetensors_params_metadata
@@ -662,9 +661,7 @@ class AutoAWQMoEMethod(FusedMoEMethodBase):
         set_weight_attrs(w2_qzeros, extra_weight_attrs)
 
         device = layer.w13_qweight.device
-        layer.workspace = get_reload_arena(layer).put(
-            "marlin.workspace", marlin_make_workspace_new(device, 4)
-        )
+        layer.workspace = marlin_get_workspace(layer, device, 4)
 
     def process_weights_after_loading(self, layer: RoutedExperts) -> None:
         converted = convert_to_wna16_moe_kernel_format(

--- a/vllm/model_executor/layers/quantization/auto_awq.py
+++ b/vllm/model_executor/layers/quantization/auto_awq.py
@@ -60,6 +60,7 @@ from vllm.model_executor.parameter import (
     GroupQuantScaleParameter,
     PackedvLLMParameter,
 )
+from vllm.model_executor.reload_arena import get_reload_arena
 from vllm.platforms import current_platform
 from vllm.scalar_type import scalar_types
 from vllm.transformers_utils.config import get_safetensors_params_metadata
@@ -661,7 +662,9 @@ class AutoAWQMoEMethod(FusedMoEMethodBase):
         set_weight_attrs(w2_qzeros, extra_weight_attrs)
 
         device = layer.w13_qweight.device
-        layer.workspace = marlin_make_workspace_new(device, 4)
+        layer.workspace = get_reload_arena(layer).put(
+            "marlin.workspace", marlin_make_workspace_new(device, 4)
+        )
 
     def process_weights_after_loading(self, layer: RoutedExperts) -> None:
         converted = convert_to_wna16_moe_kernel_format(

--- a/vllm/model_executor/layers/quantization/auto_gptq.py
+++ b/vllm/model_executor/layers/quantization/auto_gptq.py
@@ -61,6 +61,7 @@ from vllm.model_executor.parameter import (
     PackedvLLMParameter,
     RowvLLMParameter,
 )
+from vllm.model_executor.reload_arena import get_reload_arena
 from vllm.scalar_type import scalar_types
 from vllm.transformers_utils.config import get_safetensors_params_metadata
 from vllm.utils.collection_utils import is_list_of
@@ -648,7 +649,9 @@ class AutoGPTQMoEMethod(FusedMoEMethodBase):
             self.experts_cls, FusedMoEExpertsModular
         ):
             device = layer.w13_qweight.device
-            layer.workspace = marlin_make_workspace_new(device, 4)
+            layer.workspace = get_reload_arena(layer).put(
+                "marlin.workspace", marlin_make_workspace_new(device, 4)
+            )
 
     def process_weights_after_loading(self, layer: RoutedExperts) -> None:
         is_a_8bit = self.input_dtype is not None and self.input_dtype.itemsize == 1

--- a/vllm/model_executor/layers/quantization/auto_gptq.py
+++ b/vllm/model_executor/layers/quantization/auto_gptq.py
@@ -45,7 +45,7 @@ from vllm.model_executor.layers.quantization.utils.gptq_utils import (
 from vllm.model_executor.layers.quantization.utils.marlin_utils import (
     check_moe_marlin_supports_layer,
     get_marlin_input_dtype,
-    marlin_make_workspace_new,
+    marlin_get_workspace,
     marlin_repeat_scales_on_all_ranks,
     verify_marlin_supported,
 )
@@ -61,7 +61,6 @@ from vllm.model_executor.parameter import (
     PackedvLLMParameter,
     RowvLLMParameter,
 )
-from vllm.model_executor.reload_arena import get_reload_arena
 from vllm.scalar_type import scalar_types
 from vllm.transformers_utils.config import get_safetensors_params_metadata
 from vllm.utils.collection_utils import is_list_of
@@ -649,9 +648,7 @@ class AutoGPTQMoEMethod(FusedMoEMethodBase):
             self.experts_cls, FusedMoEExpertsModular
         ):
             device = layer.w13_qweight.device
-            layer.workspace = get_reload_arena(layer).put(
-                "marlin.workspace", marlin_make_workspace_new(device, 4)
-            )
+            layer.workspace = marlin_get_workspace(layer, device, 4)
 
     def process_weights_after_loading(self, layer: RoutedExperts) -> None:
         is_a_8bit = self.input_dtype is not None and self.input_dtype.itemsize == 1

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_w4a8_fp8.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_w4a8_fp8.py
@@ -3,6 +3,9 @@
 
 
 import torch
+
+from vllm.model_executor.reload_arena import (arena_scope,
+                                               get_reload_arena)
 from compressed_tensors.quantization import (
     QuantizationArgs,
 )
@@ -194,15 +197,19 @@ class CompressedTensorsW4A8Fp8MoEMethod(CompressedTensorsMoEMethod):
         self.moe_quant_config = self.get_fused_moe_quant_config(layer)
         if self.moe_quant_config is not None:
             assert self.experts_cls is not None
-            self.moe_kernel = make_w4a8_moe_kernel(
-                moe_quant_config=self.moe_quant_config,
-                moe_config=self.moe,
-                experts_cls=self.experts_cls,
-                b_strides1=self.b_strides1,
-                b_strides2=self.b_strides2,
-                group_size=self.group_size,
-                routing_tables=layer._expert_routing_tables(),
-            )
+            # The kernel rebuild replaces the experts object; graph-visible
+            # tensors it allocates (strides, permute scratch) must land in
+            # the layer's arena so the rebuilt object reuses their storage.
+            with arena_scope(get_reload_arena(layer)):
+                self.moe_kernel = make_w4a8_moe_kernel(
+                    moe_quant_config=self.moe_quant_config,
+                    moe_config=self.moe,
+                    experts_cls=self.experts_cls,
+                    b_strides1=self.b_strides1,
+                    b_strides2=self.b_strides2,
+                    group_size=self.group_size,
+                    routing_tables=layer._expert_routing_tables(),
+                )
 
     def get_fused_moe_quant_config(self, layer: torch.nn.Module) -> FusedMoEQuantConfig:
         return make_w4a8_moe_quant_config(

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_w8a8_fp8.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_w8a8_fp8.py
@@ -3,6 +3,9 @@
 
 
 import torch
+
+from vllm.model_executor.reload_arena import (arena_scope,
+                                               get_reload_arena)
 from compressed_tensors.quantization import (
     QuantizationArgs,
     QuantizationStrategy,
@@ -332,14 +335,18 @@ class CompressedTensorsW8A8Fp8MoEMethod(CompressedTensorsMoEMethod):
         self.moe_quant_config = self.get_fused_moe_quant_config(layer)
         if self.moe_quant_config:
             assert self.experts_cls is not None
-            self.moe_kernel = make_fp8_moe_kernel(
-                moe_quant_config=self.moe_quant_config,
-                moe_config=self.moe,
-                fp8_backend=self.fp8_backend,
-                experts_cls=self.experts_cls,
-                routing_tables=layer._expert_routing_tables(),
-                layer=layer,
-            )
+            # The kernel rebuild replaces the experts object; graph-visible
+            # tensors it allocates (strides, permute scratch) must land in
+            # the layer's arena so the rebuilt object reuses their storage.
+            with arena_scope(get_reload_arena(layer)):
+                self.moe_kernel = make_fp8_moe_kernel(
+                    moe_quant_config=self.moe_quant_config,
+                    moe_config=self.moe,
+                    fp8_backend=self.fp8_backend,
+                    experts_cls=self.experts_cls,
+                    routing_tables=layer._expert_routing_tables(),
+                    layer=layer,
+                )
 
     def maybe_make_prepare_finalize(
         self,

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_wna16_marlin.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_wna16_marlin.py
@@ -34,7 +34,7 @@ from vllm.model_executor.layers.quantization.compressed_tensors.schemes.compress
 )
 from vllm.model_executor.layers.quantization.utils.marlin_utils import (
     get_marlin_input_dtype,
-    marlin_make_workspace_new,
+    marlin_get_workspace,
 )
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     QuantKey,
@@ -42,7 +42,6 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
     kInt4StaticGroupScale,
     kInt8StaticGroupScale,
 )
-from vllm.model_executor.reload_arena import get_reload_arena
 from vllm.model_executor.utils import replace_parameter, set_weight_attrs
 
 logger = init_logger(__name__)
@@ -488,9 +487,8 @@ class CompressedTensorsWNA16MarlinMoEMethod(CompressedTensorsMoEMethod):
             if self.experts_cls is not None and issubclass(
                 self.experts_cls, FusedMoEExpertsModular
             ):
-                layer.workspace = get_reload_arena(layer).put(
-                    "marlin.workspace",
-                    marlin_make_workspace_new(layer.w13_weight_g_idx.device, 4),
+                layer.workspace = marlin_get_workspace(
+                    layer, layer.w13_weight_g_idx.device, 4
                 )
 
         # Alias packed weights to w13_weight/w2_weight for the modular kernel interface

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_wna16_marlin.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_wna16_marlin.py
@@ -42,6 +42,7 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
     kInt4StaticGroupScale,
     kInt8StaticGroupScale,
 )
+from vllm.model_executor.reload_arena import get_reload_arena
 from vllm.model_executor.utils import replace_parameter, set_weight_attrs
 
 logger = init_logger(__name__)
@@ -487,8 +488,9 @@ class CompressedTensorsWNA16MarlinMoEMethod(CompressedTensorsMoEMethod):
             if self.experts_cls is not None and issubclass(
                 self.experts_cls, FusedMoEExpertsModular
             ):
-                layer.workspace = marlin_make_workspace_new(
-                    layer.w13_weight_g_idx.device, 4
+                layer.workspace = get_reload_arena(layer).put(
+                    "marlin.workspace",
+                    marlin_make_workspace_new(layer.w13_weight_g_idx.device, 4),
                 )
 
         # Alias packed weights to w13_weight/w2_weight for the modular kernel interface

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_wna16_rdna3.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_wna16_rdna3.py
@@ -32,6 +32,7 @@ from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tenso
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     pack_quantized_values_into_int32,
 )
+from vllm.model_executor.reload_arena import InitPolicy, get_reload_arena
 from vllm.scalar_type import scalar_types
 
 logger = init_logger(__name__)
@@ -52,6 +53,64 @@ def _synthesize_qzeros(
         device=device,
     )
     return pack_quantized_values_into_int32(zeros, scalar_types.uint4b8, packed_dim=1)
+
+
+# Decode-path buffer geometry. Sized for the common decode shape; the apply
+# path falls back to a fresh allocation when a batch exceeds it.
+_MAX_DECODE_TOKENS = 16
+_CONSERVATIVE_TOP_K = 8
+
+
+def allocate_rdna3_decode_buffers(
+    layer: torch.nn.Module,
+    *,
+    n_gate_up: int,
+    hidden_size: int,
+    act_dtype: torch.dtype,
+    device: torch.device,
+) -> None:
+    """Bind the decode scratch buffers the fused HIP kernel reads.
+
+    These are plain layer attributes, not parameters or buffers, so reload
+    copy-back never sees them -- and ``process_weights_after_loading`` runs
+    again on every reload. Allocating them fresh there leaves any HIP graph
+    captured before the reload pointing at freed storage (RFC #48312
+    category 1: the same shape as the Marlin workspace and CUTLASS stride
+    failures reproduced on CUDA hardware).
+
+    Going through the layer's reload arena keeps one storage per slot for
+    the layer's lifetime, so a second post-load pass rebinds the attributes
+    to the same memory. PRESERVE is the right policy because contents never
+    have to survive: ``rdna3_w1_buf`` is explicitly zeroed at its use site
+    and ``rdna3_act_buf`` is fully overwritten by the activation. What must
+    survive is the address.
+    """
+    arena = get_reload_arena(layer)
+    intermediate = n_gate_up // 2  # gated activation
+    buf_size = _MAX_DECODE_TOKENS * _CONSERVATIVE_TOP_K
+
+    layer.rdna3_w1_buf = arena.get_or_alloc(
+        "rdna3_w1_buf", (buf_size, n_gate_up), act_dtype, device,
+        init=InitPolicy.PRESERVE,
+    )
+    layer.rdna3_act_buf = arena.get_or_alloc(
+        "rdna3_act_buf", (buf_size, intermediate), act_dtype, device,
+        init=InitPolicy.PRESERVE,
+    )
+    # No reader today, but it is bound on the layer and would be captured
+    # the moment one appears; treat it like the rest rather than leaving a
+    # rebinding attribute behind.
+    layer.rdna3_out_buf = arena.get_or_alloc(
+        "rdna3_out_buf", (_MAX_DECODE_TOKENS, hidden_size), act_dtype,
+        device, init=InitPolicy.PRESERVE,
+    )
+    # dtype deliberately left at the ambient default, matching the original
+    # `torch.empty(0, device=device)`: this stands in for the float32
+    # `topk_w_float` argument, and changing it is not part of this fix.
+    layer.rdna3_empty_tw = arena.get_or_alloc(
+        "rdna3_empty_tw", (0,), torch.get_default_dtype(), device,
+        init=InitPolicy.PRESERVE,
+    )
 
 
 class CompressedTensorsWNA16RDNA3MoEMethod(CompressedTensorsWNA16MoEMethod):
@@ -104,24 +163,13 @@ class CompressedTensorsWNA16RDNA3MoEMethod(CompressedTensorsWNA16MoEMethod):
             requires_grad=False,
         )
 
-        # Pre-allocate reusable buffers for decode (sizes based on top_k=8)
-        N_gate_up = w13_N
-        hidden_size = w2_N
-        intermediate = N_gate_up // 2  # gated activation
-        # Max tokens we expect in decode; prefill will re-allocate if needed
-        max_decode_tokens = 16
-        top_k = 8  # conservative default
-        buf_size = max_decode_tokens * top_k
-        layer.rdna3_w1_buf = torch.zeros(
-            buf_size, N_gate_up, dtype=act_dtype, device=device
+        allocate_rdna3_decode_buffers(
+            layer,
+            n_gate_up=w13_N,
+            hidden_size=w2_N,
+            act_dtype=act_dtype,
+            device=device,
         )
-        layer.rdna3_act_buf = torch.empty(
-            buf_size, intermediate, dtype=act_dtype, device=device
-        )
-        layer.rdna3_out_buf = torch.zeros(
-            max_decode_tokens, hidden_size, dtype=act_dtype, device=device
-        )
-        layer.rdna3_empty_tw = torch.empty(0, device=device)
 
     def apply(
         self,

--- a/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_wNa8o8.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_wNa8o8.py
@@ -31,6 +31,7 @@ from vllm.model_executor.parameter import (
     ModelWeightParameter,
     PackedvLLMParameter,
 )
+from vllm.model_executor.reload_arena import get_reload_arena
 from vllm.scalar_type import scalar_types
 
 __all__ = ["CompressedTensorsWNA8O8Int", "fake_quant_static_int8"]
@@ -202,6 +203,13 @@ class CompressedTensorsWNA8O8Int(CompressedTensorsScheme):
         # the kernel only sees weight tensors. Drop uncalibrated (zero) scales.
         self._input_scale = self._take_act_scale(layer, "input_scale")
         self._output_scale = self._take_act_scale(layer, "output_scale")
+        arena = get_reload_arena(layer)
+        if self._input_scale is not None:
+            self._input_scale = arena.put("wna8o8.input_scale", self._input_scale)
+        if self._output_scale is not None:
+            self._output_scale = arena.put(
+                "wna8o8.output_scale", self._output_scale
+            )
         self.has_input_act = self._input_scale is not None
         self.has_output_act = self._output_scale is not None
 

--- a/vllm/model_executor/layers/quantization/utils/marlin_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/marlin_utils.py
@@ -18,6 +18,7 @@ from vllm.model_executor.layers.quantization.utils.int8_utils import (
     per_token_quant_int8,
 )
 from vllm.model_executor.layers.quantization.utils.quant_utils import GroupShape
+from vllm.model_executor.reload_arena import InitPolicy, get_reload_arena
 from vllm.platforms import current_platform
 from vllm.scalar_type import ScalarType, scalar_types
 from vllm.utils.math_utils import round_up
@@ -404,6 +405,22 @@ def marlin_make_workspace_new(
     sms = num_compute_units(device.index)
     return torch.zeros(
         sms * max_blocks_per_sm, dtype=torch.int, device=device, requires_grad=False
+    )
+
+
+def marlin_get_workspace(
+    layer: torch.nn.Module,
+    device: torch.device,
+    max_blocks_per_sm: int = 1,
+) -> torch.Tensor:
+    """Return the layer-owned, zeroed Marlin workspace."""
+    sms = num_compute_units(device.index)
+    return get_reload_arena(layer).get_or_alloc(
+        "marlin.workspace",
+        (sms * max_blocks_per_sm,),
+        torch.int,
+        device,
+        init=InitPolicy.ZERO,
     )
 
 

--- a/vllm/model_executor/layers/quantization/utils/marlin_utils_fp4.py
+++ b/vllm/model_executor/layers/quantization/utils/marlin_utils_fp4.py
@@ -22,6 +22,7 @@ from vllm.model_executor.layers.quantization.utils.marlin_utils import (
     marlin_unpad_output,
     should_use_atomic_add_reduce,
 )
+from vllm.model_executor.reload_arena import get_reload_arena
 from vllm.platforms import current_platform
 from vllm.scalar_type import scalar_types
 from vllm.utils.math_utils import round_up
@@ -240,7 +241,9 @@ def prepare_fp4_layer_for_marlin(
     device = layer.weight.device
 
     # WORKSPACE
-    layer.workspace = marlin_make_workspace_new(device)
+    layer.workspace = get_reload_arena(layer).put(
+        "marlin.workspace", marlin_make_workspace_new(device)
+    )
 
     # WEIGHT
     # Repack weights to marlin format
@@ -365,7 +368,9 @@ def prepare_nvfp4_moe_layer_for_marlin(
     is_a_8bit = input_dtype is not None and input_dtype.itemsize == 1
 
     # WORKSPACE
-    layer.workspace = marlin_make_workspace_new(device, 4)
+    layer.workspace = get_reload_arena(layer).put(
+        "marlin.workspace", marlin_make_workspace_new(device, 4)
+    )
     perm = torch.empty(0, dtype=torch.int, device=device)
 
     # WEIGHT
@@ -464,7 +469,9 @@ def prepare_moe_fp4_layer_for_marlin(
     # WORKSPACE
     device = layer.w13_weight.device
     param_dtype = layer.params_dtype
-    layer.workspace = marlin_make_workspace_new(device, 4)
+    layer.workspace = get_reload_arena(layer).put(
+        "marlin.workspace", marlin_make_workspace_new(device, 4)
+    )
     perm = torch.empty(0, dtype=torch.int, device=device)
     is_a_8bit = input_dtype is not None and input_dtype.itemsize == 1
 

--- a/vllm/model_executor/layers/quantization/utils/marlin_utils_fp4.py
+++ b/vllm/model_executor/layers/quantization/utils/marlin_utils_fp4.py
@@ -10,7 +10,7 @@ from vllm.model_executor.layers.fused_moe.routed_experts import RoutedExperts
 from vllm.model_executor.layers.quantization.utils.marlin_utils import (
     USE_FP32_REDUCE_DEFAULT,
     get_marlin_input_dtype,
-    marlin_make_workspace_new,
+    marlin_get_workspace,
     marlin_pad_dim,
     marlin_pad_qweight,
     marlin_pad_scales,
@@ -22,7 +22,6 @@ from vllm.model_executor.layers.quantization.utils.marlin_utils import (
     marlin_unpad_output,
     should_use_atomic_add_reduce,
 )
-from vllm.model_executor.reload_arena import get_reload_arena
 from vllm.platforms import current_platform
 from vllm.scalar_type import scalar_types
 from vllm.utils.math_utils import round_up
@@ -241,9 +240,7 @@ def prepare_fp4_layer_for_marlin(
     device = layer.weight.device
 
     # WORKSPACE
-    layer.workspace = get_reload_arena(layer).put(
-        "marlin.workspace", marlin_make_workspace_new(device)
-    )
+    layer.workspace = marlin_get_workspace(layer, device)
 
     # WEIGHT
     # Repack weights to marlin format
@@ -368,9 +365,7 @@ def prepare_nvfp4_moe_layer_for_marlin(
     is_a_8bit = input_dtype is not None and input_dtype.itemsize == 1
 
     # WORKSPACE
-    layer.workspace = get_reload_arena(layer).put(
-        "marlin.workspace", marlin_make_workspace_new(device, 4)
-    )
+    layer.workspace = marlin_get_workspace(layer, device, 4)
     perm = torch.empty(0, dtype=torch.int, device=device)
 
     # WEIGHT
@@ -469,9 +464,7 @@ def prepare_moe_fp4_layer_for_marlin(
     # WORKSPACE
     device = layer.w13_weight.device
     param_dtype = layer.params_dtype
-    layer.workspace = get_reload_arena(layer).put(
-        "marlin.workspace", marlin_make_workspace_new(device, 4)
-    )
+    layer.workspace = marlin_get_workspace(layer, device, 4)
     perm = torch.empty(0, dtype=torch.int, device=device)
     is_a_8bit = input_dtype is not None and input_dtype.itemsize == 1
 

--- a/vllm/model_executor/layers/quantization/utils/marlin_utils_fp8.py
+++ b/vllm/model_executor/layers/quantization/utils/marlin_utils_fp8.py
@@ -9,7 +9,7 @@ from vllm.logger import init_logger
 from vllm.model_executor.layers.quantization.utils.marlin_utils import (
     USE_FP32_REDUCE_DEFAULT,
     get_marlin_input_dtype,
-    marlin_make_workspace_new,
+    marlin_get_workspace,
     marlin_moe_padded_intermediate,
     marlin_pad_dim,
     marlin_pad_qweight,
@@ -21,7 +21,6 @@ from vllm.model_executor.layers.quantization.utils.marlin_utils import (
     marlin_unpad_output,
     should_use_atomic_add_reduce,
 )
-from vllm.model_executor.reload_arena import get_reload_arena
 from vllm.model_executor.utils import replace_parameter
 from vllm.platforms import current_platform
 from vllm.scalar_type import scalar_types
@@ -133,9 +132,7 @@ def prepare_fp8_layer_for_marlin(
     device = layer.weight.device
 
     # WORKSPACE
-    layer.workspace = get_reload_arena(layer).put(
-        "marlin.workspace", marlin_make_workspace_new(device)
-    )
+    layer.workspace = marlin_get_workspace(layer, device)
 
     # WEIGHT
     # Repack weights to marlin format
@@ -282,9 +279,7 @@ def prepare_fp8_moe_layer_for_marlin(
     # WORKSPACE
     device = layer.w13_weight.device
     # Keep the graph-visible workspace address stable across PWAL reruns.
-    layer.workspace = get_reload_arena(layer).put(
-        "marlin.workspace", marlin_make_workspace_new(device, 4)
-    )
+    layer.workspace = marlin_get_workspace(layer, device, 4)
     perm = torch.empty(0, dtype=torch.int, device=device)
 
     # WEIGHT
@@ -467,9 +462,7 @@ def prepare_mxfp8_layer_for_marlin(layer: torch.nn.Module) -> None:
     device = layer.weight.device
 
     # WORKSPACE
-    layer.workspace = get_reload_arena(layer).put(
-        "marlin.workspace", marlin_make_workspace_new(device)
-    )
+    layer.workspace = marlin_get_workspace(layer, device)
 
     # WEIGHT - repack FP8 weights to Marlin format
     perm = torch.empty(0, dtype=torch.int, device=device)
@@ -555,9 +548,7 @@ def prepare_mxfp8_moe_layer_for_marlin(
     param_dtype = torch.get_default_dtype()
     perm = torch.empty(0, dtype=torch.int, device=device)
 
-    layer.workspace = get_reload_arena(layer).put(
-        "marlin.workspace", marlin_make_workspace_new(device, 4)
-    )
+    layer.workspace = marlin_get_workspace(layer, device, 4)
 
     def repack_weight(weight: torch.Tensor, name: str) -> torch.Tensor:
         if "w13" in name:

--- a/vllm/model_executor/layers/quantization/utils/marlin_utils_fp8.py
+++ b/vllm/model_executor/layers/quantization/utils/marlin_utils_fp8.py
@@ -21,6 +21,7 @@ from vllm.model_executor.layers.quantization.utils.marlin_utils import (
     marlin_unpad_output,
     should_use_atomic_add_reduce,
 )
+from vllm.model_executor.reload_arena import get_reload_arena
 from vllm.model_executor.utils import replace_parameter
 from vllm.platforms import current_platform
 from vllm.scalar_type import scalar_types
@@ -132,7 +133,9 @@ def prepare_fp8_layer_for_marlin(
     device = layer.weight.device
 
     # WORKSPACE
-    layer.workspace = marlin_make_workspace_new(device)
+    layer.workspace = get_reload_arena(layer).put(
+        "marlin.workspace", marlin_make_workspace_new(device)
+    )
 
     # WEIGHT
     # Repack weights to marlin format
@@ -278,9 +281,10 @@ def prepare_fp8_moe_layer_for_marlin(
 
     # WORKSPACE
     device = layer.w13_weight.device
-    # NOTE(rob): we do not need to register the workspace as a param
-    # because it is not used as part of the weight reloading process.
-    layer.workspace = marlin_make_workspace_new(device, 4)
+    # Keep the graph-visible workspace address stable across PWAL reruns.
+    layer.workspace = get_reload_arena(layer).put(
+        "marlin.workspace", marlin_make_workspace_new(device, 4)
+    )
     perm = torch.empty(0, dtype=torch.int, device=device)
 
     # WEIGHT
@@ -463,7 +467,9 @@ def prepare_mxfp8_layer_for_marlin(layer: torch.nn.Module) -> None:
     device = layer.weight.device
 
     # WORKSPACE
-    layer.workspace = marlin_make_workspace_new(device)
+    layer.workspace = get_reload_arena(layer).put(
+        "marlin.workspace", marlin_make_workspace_new(device)
+    )
 
     # WEIGHT - repack FP8 weights to Marlin format
     perm = torch.empty(0, dtype=torch.int, device=device)
@@ -549,7 +555,9 @@ def prepare_mxfp8_moe_layer_for_marlin(
     param_dtype = torch.get_default_dtype()
     perm = torch.empty(0, dtype=torch.int, device=device)
 
-    layer.workspace = marlin_make_workspace_new(device, 4)
+    layer.workspace = get_reload_arena(layer).put(
+        "marlin.workspace", marlin_make_workspace_new(device, 4)
+    )
 
     def repack_weight(weight: torch.Tensor, name: str) -> torch.Tensor:
         if "w13" in name:

--- a/vllm/model_executor/model_loader/dummy_loader.py
+++ b/vllm/model_executor/model_loader/dummy_loader.py
@@ -17,6 +17,7 @@ from vllm.model_executor.model_loader.weight_utils import (
     initialize_dummy_weights,
     initialize_single_dummy_weight,
 )
+from vllm.model_executor.reload_arena import arena_scope, get_reload_arena
 
 
 class DummyModelLoader(BaseModelLoader):
@@ -59,6 +60,7 @@ class DummyModelLoader(BaseModelLoader):
 
         quant_method = getattr(layer, "quant_method", None)
         if isinstance(quant_method, QuantizeMethodBase):
-            quant_method.process_weights_after_loading(layer)
+            with arena_scope(get_reload_arena(layer)):
+                quant_method.process_weights_after_loading(layer)
 
         info.reset()

--- a/vllm/model_executor/model_loader/reload/__init__.py
+++ b/vllm/model_executor/model_loader/reload/__init__.py
@@ -22,6 +22,9 @@ __all__ = [
     "initialize_layerwise_reload",
     "finalize_layerwise_processing",
     "finalize_layerwise_reload",
+    "ModelwiseReloader",
+    "ModelwiseReloadSession",
+    "record_modelwise_reload_metadata",
     "set_torchao_reload_attrs",
     "support_quantized_model_reload_from_hp_weights",
 ]
@@ -31,6 +34,11 @@ from .layerwise import (
     finalize_layerwise_reload,
     initialize_layerwise_reload,
     record_metadata_for_reloading,
+)
+from .modelwise import (
+    ModelwiseReloader,
+    ModelwiseReloadSession,
+    record_modelwise_reload_metadata,
 )
 from .torchao_decorator import (
     set_torchao_reload_attrs,

--- a/vllm/model_executor/model_loader/reload/arena.py
+++ b/vllm/model_executor/model_loader/reload/arena.py
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Re-export of the reload arena.
+
+The implementation lives at ``vllm.model_executor.reload_arena`` so that leaf
+kernel modules can import it without pulling in this package's __init__
+chain (layerwise -> attention stack). Import from here when you are already
+inside the reload machinery; import the light path from kernels/experts.
+"""
+from vllm.model_executor.reload_arena import (  # noqa: F401
+    InitPolicy, ReloadArena, SlotViolation, arena_scope, current_arena,
+    get_reload_arena, peek_reload_arena, snapshot_model_arenas,
+    verify_model_arenas)

--- a/vllm/model_executor/model_loader/reload/layerwise.py
+++ b/vllm/model_executor/model_loader/reload/layerwise.py
@@ -12,6 +12,11 @@ from vllm.logger import init_logger
 from vllm.model_executor.layers.attention import Attention, MLAAttention
 from vllm.model_executor.layers.quantization.base_config import QuantizeMethodBase
 from vllm.model_executor.model_loader.weight_utils import default_weight_loader
+from vllm.model_executor.reload_arena import (
+    arena_scope,
+    get_reload_arena,
+    peek_reload_arena,
+)
 
 from .meta import (
     SKIP_TENSORS,
@@ -20,7 +25,6 @@ from .meta import (
     materialize_layer,
     restore_layer_on_meta,
 )
-from vllm.model_executor.reload_arena import peek_reload_arena
 from .types import LayerReloadingInfo
 from .utils import (
     get_info_size,
@@ -357,7 +361,8 @@ def _finalize_attention_layer(
         )
     else:
         _place_kernel_tensors(layer, info)
-    layer.process_weights_after_loading(model_config.dtype)
+    with arena_scope(get_reload_arena(layer)):
+        layer.process_weights_after_loading(model_config.dtype)
     # Attention arena slots (e.g. MLA W_UV/W_UK_T) — verify after PWAL,
     # before the caller resets info.
     _verify_layer_arena(layer, info)
@@ -383,7 +388,8 @@ def _reload_attention_scales(layer: torch.nn.Module, info: LayerReloadingInfo) -
         args.arguments["param"] = param
         _get_weight_loader(param)(*args.args, **args.kwargs)
 
-    quant_method.process_weights_after_loading(layer)
+    with arena_scope(get_reload_arena(layer)):
+        quant_method.process_weights_after_loading(layer)
 
     _copy_and_restore_kernel_tensors(layer, info)
 
@@ -419,7 +425,8 @@ def _layerwise_process(layer: torch.nn.Module, info: LayerReloadingInfo):
     # Process weights (quantization, repacking, etc.)
     quant_method = getattr(layer, "quant_method", None)
     if isinstance(quant_method, QuantizeMethodBase):
-        quant_method.process_weights_after_loading(layer)
+        with arena_scope(get_reload_arena(layer)):
+            quant_method.process_weights_after_loading(layer)
 
     # Copy processed values into original tensor storage (preserves cudagraph refs)
     # this code is a no-op if not reloading (because kernel tensors is empty)

--- a/vllm/model_executor/model_loader/reload/layerwise.py
+++ b/vllm/model_executor/model_loader/reload/layerwise.py
@@ -20,6 +20,7 @@ from .meta import (
     materialize_layer,
     restore_layer_on_meta,
 )
+from vllm.model_executor.reload_arena import peek_reload_arena
 from .types import LayerReloadingInfo
 from .utils import (
     get_info_size,
@@ -37,6 +38,7 @@ __all__ = [
     "initialize_layerwise_reload",
     "finalize_layerwise_processing",
     "finalize_layerwise_reload",
+    "get_layer_arena_findings",
 ]
 
 
@@ -51,6 +53,41 @@ LAYERWISE_INFO: WeakKeyDictionary[torch.nn.Module, LayerReloadingInfo] = (
 
 # Global set used to track loading for logging purposes only
 LOADING_LAYERS: WeakSet[torch.nn.Module] = WeakSet()
+
+# Per-layer arena drift found during the current reload, accumulated as each
+# layer's PWAL re-runs (that is where the per-layer info -- and its
+# arena_snapshot -- is still alive; it is reset immediately after). Cleared at
+# the start of each reload, read after finalize. Verify-only, see
+# LayerReloadingInfo.arena_snapshot.
+_LAYER_ARENA_FINDINGS: list[str] = []
+
+
+def get_layer_arena_findings() -> list[str]:
+    """Arena drift the per-layer verification found during the last reload."""
+    return list(_LAYER_ARENA_FINDINGS)
+
+
+def _verify_layer_arena(layer: torch.nn.Module, info: LayerReloadingInfo) -> None:
+    """Check this layer's arena slots against the snapshot taken at initialize.
+
+    Called after the layer's process_weights_after_loading has re-run (which
+    repopulates the arena) and before info.reset() clears the snapshot. A slot
+    that moved / vanished / changed layout means the PWAL rebuild did not reuse
+    the arena's storage, so a captured graph now points at stale memory.
+    """
+    snap = info.arena_snapshot
+    if snap is None:
+        return
+    arena = peek_reload_arena(layer)
+    if arena is None:
+        # The arena vanished with the layer: every snapshotted slot is gone.
+        if snap:
+            _LAYER_ARENA_FINDINGS.append(
+                f"{layer.__class__.__name__}: arena vanished across reload "
+                f"({len(snap)} slot(s))")
+        return
+    for violation in arena.verify(snap):
+        _LAYER_ARENA_FINDINGS.append(f"{layer.__class__.__name__}: {violation}")
 
 
 def get_layerwise_info(layer: torch.nn.Module) -> LayerReloadingInfo:
@@ -100,6 +137,13 @@ def initialize_layerwise_reload(model: torch.nn.Module):
     model._original_do_torchao_reload = getattr(model, "_do_torchao_reload", False)
     model._do_torchao_reload = False
 
+    # Fresh reload: drop any arena drift from a prior one. Guarded by
+    # can_load() below so a nested initialize (e.g. via a wrapped
+    # load_weights) does not clear findings mid-reload -- only the outermost
+    # initialize, which finds no layer already loadable, reaches here first.
+    if not any(get_layerwise_info(m).can_load() for m in model.modules()):
+        _LAYER_ARENA_FINDINGS.clear()
+
     for layer in model.modules():
         info = get_layerwise_info(layer)
 
@@ -109,6 +153,15 @@ def initialize_layerwise_reload(model: torch.nn.Module):
 
         # Save current tensors for later copying
         info.kernel_tensors = get_layer_params_buffers(layer)
+
+        # Snapshot this layer's arena storage identities for verification at
+        # finalize. Verify-only: arena slots are NOT restored-to-meta below,
+        # because the arena already keeps their storage stable across the PWAL
+        # rebuild. The model has been serving before a reload, so lazily
+        # allocated slots (e.g. MoE permute scratch) already exist and are
+        # captured here.
+        arena = peek_reload_arena(layer)
+        info.arena_snapshot = arena.snapshot() if arena is not None else None
 
         # Restore layer parameters/buffers onto meta device
         restore_layer_on_meta(layer, info)
@@ -272,6 +325,10 @@ def finalize_layerwise_processing(model: torch.nn.Module, model_config: ModelCon
             logger.debug("%s: Delayed processing", layer.__class__.__name__)
             _layerwise_process(layer, info)
 
+        # Covers the fallback branch above (no PWAL re-ran, so no drift is
+        # possible, but keep it uniform); a no-op when _layerwise_process
+        # already verified and reset the snapshot.
+        _verify_layer_arena(layer, info)
         info.reset()
 
     # Process attention layers after all other layers are done
@@ -301,6 +358,9 @@ def _finalize_attention_layer(
     else:
         _place_kernel_tensors(layer, info)
     layer.process_weights_after_loading(model_config.dtype)
+    # Attention arena slots (e.g. MLA W_UV/W_UK_T) — verify after PWAL,
+    # before the caller resets info.
+    _verify_layer_arena(layer, info)
 
 
 def _reload_attention_scales(layer: torch.nn.Module, info: LayerReloadingInfo) -> None:
@@ -365,6 +425,11 @@ def _layerwise_process(layer: torch.nn.Module, info: LayerReloadingInfo):
     # this code is a no-op if not reloading (because kernel tensors is empty)
     if info.kernel_tensors is not None:
         _copy_and_restore_kernel_tensors(layer, info)
+
+    # Verify arena slots survived the PWAL rebuild (symmetric to the copy-back
+    # above: params/buffers are restored, arena slots are checked). Must run
+    # before reset() clears the snapshot.
+    _verify_layer_arena(layer, info)
 
     info.reset()
     logger.debug("%s: Processed", layer.__class__.__name__)

--- a/vllm/model_executor/model_loader/reload/layerwise.py
+++ b/vllm/model_executor/model_loader/reload/layerwise.py
@@ -64,6 +64,7 @@ LOADING_LAYERS: WeakSet[torch.nn.Module] = WeakSet()
 # the start of each reload, read after finalize. Verify-only, see
 # LayerReloadingInfo.arena_snapshot.
 _LAYER_ARENA_FINDINGS: list[str] = []
+_LAYER_ARENA_PATHS: WeakKeyDictionary[torch.nn.Module, str] = WeakKeyDictionary()
 
 
 def get_layer_arena_findings() -> list[str]:
@@ -83,15 +84,15 @@ def _verify_layer_arena(layer: torch.nn.Module, info: LayerReloadingInfo) -> Non
     if snap is None:
         return
     arena = peek_reload_arena(layer)
+    layer_name = _LAYER_ARENA_PATHS.get(layer, layer.__class__.__name__)
     if arena is None:
         # The arena vanished with the layer: every snapshotted slot is gone.
         if snap:
             _LAYER_ARENA_FINDINGS.append(
-                f"{layer.__class__.__name__}: arena vanished across reload "
-                f"({len(snap)} slot(s))")
+                f"{layer_name}: arena vanished across reload")
         return
     for violation in arena.verify(snap):
-        _LAYER_ARENA_FINDINGS.append(f"{layer.__class__.__name__}: {violation}")
+        _LAYER_ARENA_FINDINGS.append(f"{layer_name}: {violation}")
 
 
 def get_layerwise_info(layer: torch.nn.Module) -> LayerReloadingInfo:
@@ -147,13 +148,16 @@ def initialize_layerwise_reload(model: torch.nn.Module):
     # initialize, which finds no layer already loadable, reaches here first.
     if not any(get_layerwise_info(m).can_load() for m in model.modules()):
         _LAYER_ARENA_FINDINGS.clear()
+        _LAYER_ARENA_PATHS.clear()
 
-    for layer in model.modules():
+    for layer_name, layer in model.named_modules():
         info = get_layerwise_info(layer)
 
         # Skip if the layer has already been initialized
         if info.can_load():
             continue
+
+        _LAYER_ARENA_PATHS[layer] = layer_name
 
         # Save current tensors for later copying
         info.kernel_tensors = get_layer_params_buffers(layer)

--- a/vllm/model_executor/model_loader/reload/modelwise.py
+++ b/vllm/model_executor/model_loader/reload/modelwise.py
@@ -1,0 +1,421 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Whole-model checkpoint reload with tensor-level copy-back."""
+
+from collections.abc import Iterable, Iterator
+from dataclasses import dataclass
+from weakref import WeakKeyDictionary
+
+import torch
+
+from vllm.config import ModelConfig
+from vllm.model_executor.model_loader.reload.meta import (
+    SKIP_MODULES,
+    SKIP_TENSORS,
+    materialize_meta_tensor,
+    to_meta_tensor,
+)
+from vllm.model_executor.model_loader.reload.sanitize import (
+    restore_layer_refs,
+    sanitize_layer_refs,
+)
+
+__all__ = [
+    "ModelwiseReloader",
+    "ModelwiseReloadSession",
+    "record_modelwise_reload_metadata",
+]
+
+
+@dataclass(frozen=True)
+class _TensorMetadata:
+    tensor: torch.Tensor | None
+    persistent: bool = True
+
+
+@dataclass(frozen=True)
+class _ModelMetadata:
+    parameters: dict[tuple[str, str], _TensorMetadata]
+    buffers: dict[tuple[str, str], _TensorMetadata]
+    restore_device: torch.device
+
+
+@dataclass(frozen=True)
+class _RuntimeBindings:
+    parameters: dict[tuple[str, str], torch.Tensor | None]
+    buffers: dict[tuple[str, str], torch.Tensor | None]
+    buffer_persistence: dict[tuple[str, str], bool]
+
+
+_MODEL_METADATA: WeakKeyDictionary[torch.nn.Module, _ModelMetadata] = (
+    WeakKeyDictionary()
+)
+
+
+def _modules(model: torch.nn.Module) -> dict[str, torch.nn.Module]:
+    return dict(model.named_modules())
+
+
+def _iter_direct_tensors(
+    model: torch.nn.Module,
+) -> Iterator[tuple[str, torch.nn.Module, str, str, torch.Tensor]]:
+    for module_name, module in model.named_modules():
+        for name, tensor in module._parameters.items():
+            if tensor is not None:
+                yield module_name, module, "parameter", name, tensor
+        for name, tensor in module._buffers.items():
+            if tensor is not None:
+                yield module_name, module, "buffer", name, tensor
+
+
+def _clone_metadata(tensor: torch.Tensor, module: torch.nn.Module) -> torch.Tensor:
+    clone = to_meta_tensor(tensor)
+    return restore_layer_refs(clone, module)
+
+
+def _original_weight_loader(tensor: torch.Tensor):
+    loader = getattr(tensor, "weight_loader", None)
+    while loader is not None and getattr(loader, "__name__", "") == (
+        "online_process_loader"
+    ):
+        loader = loader.__wrapped__
+    return loader
+
+
+def _strip_online_loader(tensor: torch.Tensor) -> None:
+    loader = _original_weight_loader(tensor)
+    if loader is not None:
+        tensor.weight_loader = loader
+
+
+def record_modelwise_reload_metadata(model: torch.nn.Module) -> None:
+    """Record checkpoint-format tensor bindings for whole-model reload.
+
+    This is captured after model construction and before the initial checkpoint
+    load or post-load processing changes parameter layouts.
+    """
+    parameters: dict[tuple[str, str], _TensorMetadata] = {}
+    buffers: dict[tuple[str, str], _TensorMetadata] = {}
+    captured: dict[int, _TensorMetadata] = {}
+
+    for module_name, module in model.named_modules():
+        if module.__class__.__name__ in SKIP_MODULES:
+            continue
+        for name, tensor in module._parameters.items():
+            if name in SKIP_TENSORS:
+                continue
+            key = (module_name, name)
+            if tensor is None:
+                parameters[key] = _TensorMetadata(None)
+            else:
+                entry = captured.get(id(tensor))
+                if entry is None:
+                    entry = _TensorMetadata(
+                        sanitize_layer_refs(to_meta_tensor(tensor), module)
+                    )
+                    captured[id(tensor)] = entry
+                parameters[key] = entry
+        for name, tensor in module._buffers.items():
+            if name in SKIP_TENSORS:
+                continue
+            key = (module_name, name)
+            persistent = name not in module._non_persistent_buffers_set
+            # Non-persistent buffers are runtime state, not checkpoint state.
+            # Keep them bound throughout a reload instead of restoring an
+            # uninitialized construction-time snapshot over live caches such
+            # as rotary ``cos_sin_cache``.
+            if not persistent:
+                continue
+            if tensor is None:
+                buffers[key] = _TensorMetadata(None, persistent)
+                continue
+            entry = captured.get(id(tensor))
+            if entry is None:
+                entry = _TensorMetadata(
+                    sanitize_layer_refs(to_meta_tensor(tensor), module), persistent
+                )
+                captured[id(tensor)] = entry
+            buffers[key] = entry
+
+    _MODEL_METADATA[model] = _ModelMetadata(
+        parameters=parameters,
+        buffers=buffers,
+        restore_device=torch.get_default_device(),
+    )
+
+
+def _capture_runtime_bindings(model: torch.nn.Module) -> _RuntimeBindings:
+    parameters = {}
+    buffers = {}
+    buffer_persistence = {}
+    for module_name, module in model.named_modules():
+        for name, tensor in module._parameters.items():
+            parameters[(module_name, name)] = tensor
+        for name, tensor in module._buffers.items():
+            key = (module_name, name)
+            buffers[key] = tensor
+            buffer_persistence[key] = name not in module._non_persistent_buffers_set
+    return _RuntimeBindings(parameters, buffers, buffer_persistence)
+
+
+def _clear_tensor_bindings(
+    model: torch.nn.Module,
+    *,
+    preserve_nonpersistent_buffers: bool = False,
+) -> None:
+    for _, module in model.named_modules():
+        if module.__class__.__name__ in SKIP_MODULES:
+            continue
+        for name in tuple(module._parameters):
+            if name not in SKIP_TENSORS:
+                delattr(module, name)
+        for name in tuple(module._buffers):
+            if name not in SKIP_TENSORS:
+                if (
+                    preserve_nonpersistent_buffers
+                    and name in module._non_persistent_buffers_set
+                ):
+                    continue
+                delattr(module, name)
+
+
+def _restore_checkpoint_bindings(
+    model: torch.nn.Module, metadata: _ModelMetadata
+) -> None:
+    modules = _modules(model)
+    _clear_tensor_bindings(model, preserve_nonpersistent_buffers=True)
+    restored: dict[int, torch.Tensor] = {}
+    for (module_name, name), entry in metadata.parameters.items():
+        module = modules[module_name]
+        if entry.tensor is None:
+            module.register_parameter(name, None)
+            continue
+        tensor = restored.get(id(entry))
+        if tensor is None:
+            tensor = _clone_metadata(entry.tensor, module)
+            restored[id(entry)] = tensor
+        _strip_online_loader(tensor)
+        module.register_parameter(name, tensor)
+    for (module_name, name), entry in metadata.buffers.items():
+        module = modules[module_name]
+        if entry.tensor is None:
+            module.register_buffer(name, None, persistent=entry.persistent)
+            continue
+        tensor = restored.get(id(entry))
+        if tensor is None:
+            tensor = _clone_metadata(entry.tensor, module)
+            restored[id(entry)] = tensor
+        _strip_online_loader(tensor)
+        module.register_buffer(name, tensor, persistent=entry.persistent)
+
+
+def _materialize_checkpoint_bindings(
+    model: torch.nn.Module, device: torch.device
+) -> None:
+    materialized: dict[int, torch.Tensor] = {}
+    with device:
+        for _, module, _, name, tensor in _iter_direct_tensors(model):
+            if tensor.is_meta:
+                value = materialized.get(id(tensor))
+                if value is None:
+                    value = materialize_meta_tensor(tensor)
+                    materialized[id(tensor)] = value
+                setattr(module, name, value)
+
+
+def _restore_runtime_bindings(
+    model: torch.nn.Module, runtime: _RuntimeBindings
+) -> None:
+    modules = _modules(model)
+    _clear_tensor_bindings(model)
+    for (module_name, name), tensor in runtime.parameters.items():
+        modules[module_name].register_parameter(name, tensor)
+    for (module_name, name), tensor in runtime.buffers.items():
+        module = modules[module_name]
+        persistent = runtime.buffer_persistence[(module_name, name)]
+        module.register_buffer(name, tensor, persistent=persistent)
+
+
+def _validate_copy_back(processed: _RuntimeBindings, runtime: _RuntimeBindings) -> None:
+    findings = []
+    for kind, old_bindings, new_bindings in (
+        ("parameter", runtime.parameters, processed.parameters),
+        ("buffer", runtime.buffers, processed.buffers),
+    ):
+        for key, old in old_bindings.items():
+            new = new_bindings.get(key)
+            if old is None:
+                if new is not None:
+                    findings.append(f"materialized runtime {kind} {key}")
+                continue
+            if new is None:
+                if kind == "parameter":
+                    findings.append(f"missing runtime {kind} {key}")
+                continue
+            if old.shape != new.shape or old.dtype != new.dtype:
+                findings.append(
+                    f"incompatible runtime {kind} {key}: "
+                    f"{tuple(old.shape)}/{old.dtype} -> "
+                    f"{tuple(new.shape)}/{new.dtype}"
+                )
+    if findings:
+        raise ValueError(
+            "Whole-model reload changed the runtime tensor schema:\n  "
+            + "\n  ".join(findings[:20])
+        )
+
+
+def _copy_back(processed: _RuntimeBindings, runtime: _RuntimeBindings) -> None:
+    for old_bindings, new_bindings in (
+        (runtime.parameters, processed.parameters),
+        (runtime.buffers, processed.buffers),
+    ):
+        for key, old in old_bindings.items():
+            new = new_bindings.get(key)
+            if old is not None and new is not None:
+                old.data.copy_(new)
+
+
+class ModelwiseReloadSession:
+    """Explicit model-wide checkpoint reload transaction.
+
+    ``start`` restores the checkpoint-format tensor schema, any number of
+    ``load_weights`` calls may then stream checkpoint tensors into the model,
+    and ``finish`` runs model-wide post-load processing before copying values
+    into the original runtime storages. The transaction boundary, rather than
+    tensor element counts, determines when post-load processing runs.
+    """
+
+    def __init__(
+        self,
+        model: torch.nn.Module,
+        model_config: ModelConfig,
+        target_device: torch.device,
+    ) -> None:
+        self.model = model
+        self.model_config = model_config
+        self.target_device = target_device
+        self._runtime: _RuntimeBindings | None = None
+        self._original_torchao = False
+        self._loaded_weights: set[str] = set()
+        self._loaded_weights_unknown = False
+
+    @property
+    def active(self) -> bool:
+        return self._runtime is not None
+
+    @torch.no_grad()
+    def start(self) -> None:
+        if self.active:
+            raise RuntimeError("Model-wise reload session is already active")
+
+        metadata = _MODEL_METADATA.get(self.model)
+        if metadata is None:
+            raise RuntimeError(
+                "Whole-model reload metadata was not recorded during model "
+                "initialization"
+            )
+
+        runtime = _capture_runtime_bindings(self.model)
+        self._original_torchao = getattr(self.model, "_do_torchao_reload", False)
+        self.model._do_torchao_reload = False
+        try:
+            _restore_checkpoint_bindings(self.model, metadata)
+            _materialize_checkpoint_bindings(self.model, metadata.restore_device)
+        except BaseException:
+            _restore_runtime_bindings(self.model, runtime)
+            self.model._do_torchao_reload = self._original_torchao
+            raise
+
+        self._runtime = runtime
+        self._loaded_weights.clear()
+        self._loaded_weights_unknown = False
+
+    @torch.no_grad()
+    def load_weights(
+        self, weights: Iterable[tuple[str, torch.Tensor]]
+    ) -> set[str] | None:
+        if not self.active:
+            raise RuntimeError("Model-wise reload session is not active")
+
+        loaded = self.model.load_weights(weights)
+        if loaded is None:
+            self._loaded_weights_unknown = True
+        else:
+            self._loaded_weights.update(loaded)
+        return loaded
+
+    def _restore_runtime(self) -> None:
+        runtime = self._runtime
+        if runtime is None:
+            return
+        _restore_runtime_bindings(self.model, runtime)
+        self.model._do_torchao_reload = self._original_torchao
+        self._runtime = None
+
+    @torch.no_grad()
+    def finish(self) -> set[str] | None:
+        runtime = self._runtime
+        if runtime is None:
+            raise RuntimeError("Model-wise reload session is not active")
+
+        try:
+            from vllm.model_executor.model_loader.utils import (
+                process_weights_after_loading,
+            )
+
+            process_weights_after_loading(
+                self.model,
+                self.model_config,
+                self.target_device,
+                force=True,
+            )
+            processed = _capture_runtime_bindings(self.model)
+            _validate_copy_back(processed, runtime)
+            _copy_back(processed, runtime)
+        finally:
+            self._restore_runtime()
+
+        if self._loaded_weights_unknown:
+            return None
+        return set(self._loaded_weights)
+
+    @torch.no_grad()
+    def abort(self) -> None:
+        """Restore serving bindings without committing received weights."""
+        self._restore_runtime()
+
+
+class ModelwiseReloader:
+    """Reload checkpoint weights as one model-wide transaction.
+
+    The serving model is temporarily rebound to its checkpoint-format tensor
+    schema, loaded normally, and post-processed once at model scope. Processed
+    values are then copied into the original runtime parameter and buffer
+    storages. No per-layer load accounting or layerwise finalization is used.
+    """
+
+    def __init__(
+        self,
+        model: torch.nn.Module,
+        model_config: ModelConfig,
+        target_device: torch.device,
+    ) -> None:
+        self.model = model
+        self.model_config = model_config
+        self.target_device = target_device
+
+    @torch.no_grad()
+    def reload(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str] | None:
+        session = ModelwiseReloadSession(
+            self.model,
+            self.model_config,
+            self.target_device,
+        )
+        session.start()
+        try:
+            session.load_weights(weights)
+            return session.finish()
+        except BaseException:
+            session.abort()
+            raise

--- a/vllm/model_executor/model_loader/reload/types.py
+++ b/vllm/model_executor/model_loader/reload/types.py
@@ -2,8 +2,12 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 from dataclasses import dataclass, field
 from inspect import BoundArguments
+from typing import TYPE_CHECKING
 
 import torch
+
+if TYPE_CHECKING:
+    from vllm.model_executor.reload_arena import SlotIdentity
 
 __all__ = ["LayerTensors", "LayerReloadingInfo"]
 
@@ -28,6 +32,16 @@ class LayerReloadingInfo:
 
     # kernel formatted tensors, copied into by `_layerwise_process` when reloading
     kernel_tensors: LayerTensors | None = None
+
+    # Per-layer arena storage identities snapshotted at the start of a reload,
+    # verified at finalize. VERIFY-ONLY: unlike kernel_tensors, these are never
+    # restored-to-meta or copied back. Arena slots already keep their storage
+    # stable across the PWAL rebuild by construction (the arena reuses the same
+    # buffer); this field only records what those addresses were so finalize
+    # can prove none drifted. reset() clearing it each reload is correct -- the
+    # arena, not this field, owns the storage, and a fresh snapshot is taken at
+    # the next reload's initialize.
+    arena_snapshot: "dict[str, SlotIdentity] | None" = None
 
     def reset(self):
         self.__init__(  # type: ignore[misc]

--- a/vllm/model_executor/model_loader/reload/types.py
+++ b/vllm/model_executor/model_loader/reload/types.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 import torch
 
 if TYPE_CHECKING:
-    from vllm.model_executor.reload_arena import SlotIdentity
+    from vllm.model_executor.reload_arena import ArenaIdentity
 
 __all__ = ["LayerTensors", "LayerReloadingInfo"]
 
@@ -41,7 +41,7 @@ class LayerReloadingInfo:
     # can prove none drifted. reset() clearing it each reload is correct -- the
     # arena, not this field, owns the storage, and a fresh snapshot is taken at
     # the next reload's initialize.
-    arena_snapshot: "dict[str, SlotIdentity] | None" = None
+    arena_snapshot: "dict[str, ArenaIdentity] | None" = None
 
     def reset(self):
         self.__init__(  # type: ignore[misc]

--- a/vllm/model_executor/model_loader/reload/validation.py
+++ b/vllm/model_executor/model_loader/reload/validation.py
@@ -1,0 +1,79 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Commit-time validation for graph-visible storage across weight reload."""
+
+import contextlib
+import os
+from collections.abc import Iterator
+
+import torch
+
+from vllm.logger import init_logger
+from vllm.model_executor.reload_arena import (
+    snapshot_model_arenas,
+    verify_model_arenas,
+)
+from vllm.model_executor.reload_manifest import check_global_storage
+
+from .layerwise import get_layer_arena_findings
+
+logger = init_logger(__name__)
+
+
+@contextlib.contextmanager
+def reload_storage_guard(model: torch.nn.Module) -> Iterator[None]:
+    """Validate graph-visible storage after an in-place weight reload."""
+    arena_snapshots = snapshot_model_arenas(model)
+    yield
+
+    arena_problems = verify_model_arenas(model, arena_snapshots)
+    per_layer = get_layer_arena_findings()
+    model_finding_set = frozenset(arena_problems)
+    layer_finding_set = frozenset(per_layer)
+    if model_finding_set != layer_finding_set:
+        missing_per_layer = sorted(model_finding_set - layer_finding_set)
+        extra_per_layer = sorted(layer_finding_set - model_finding_set)
+        logger.warning(
+            "Reload arena verification mismatch: per-layer missed %s "
+            "and additionally found %s. Model-level: %s | Per-layer: %s",
+            missing_per_layer[:10],
+            extra_per_layer[:10],
+            arena_problems[:10],
+            per_layer[:10],
+        )
+
+    if arena_problems:
+        gate = os.environ.get("VLLM_RELOAD_GATE", "strict")
+        msg = (
+            "Reload violated graph-visible storage identity on "
+            f"{len(arena_problems)} slot(s):\n  "
+            + "\n  ".join(arena_problems[:20])
+        )
+        if gate == "warn":
+            logger.warning(msg)
+        elif gate != "off":
+            raise RuntimeError(
+                msg
+                + "\nCaptured CUDA graphs may reference freed or stale "
+                "storage; serving would risk corruption or an illegal memory "
+                "access. Set VLLM_RELOAD_GATE=warn to downgrade (unsafe)."
+            )
+
+    manifest_gate = os.environ.get("VLLM_RELOAD_GLOBAL_MANIFEST", "warn")
+    if manifest_gate == "off":
+        return
+
+    report = check_global_storage()
+    if report is not None and not report.is_clean:
+        msg = (
+            "Reload rebound module-level storage that was live when graphs "
+            "were captured:\n" + report.format()
+        )
+        if manifest_gate == "strict":
+            raise RuntimeError(
+                msg
+                + "\nSet VLLM_RELOAD_GLOBAL_MANIFEST=warn to downgrade."
+            )
+        logger.warning(msg)
+    elif report is not None:
+        logger.debug("Global storage manifest clean (%d checked)", report.checked)

--- a/vllm/model_executor/model_loader/reload/validation.py
+++ b/vllm/model_executor/model_loader/reload/validation.py
@@ -10,6 +10,7 @@ import torch
 
 from vllm.logger import init_logger
 from vllm.model_executor.reload_arena import (
+    ArenaIdentity,
     snapshot_model_arenas,
     verify_model_arenas,
 )
@@ -20,12 +21,12 @@ from .layerwise import get_layer_arena_findings
 logger = init_logger(__name__)
 
 
-@contextlib.contextmanager
-def reload_storage_guard(model: torch.nn.Module) -> Iterator[None]:
-    """Validate graph-visible storage after an in-place weight reload."""
-    arena_snapshots = snapshot_model_arenas(model)
-    yield
-
+def _validate_reload_storage(
+    model: torch.nn.Module,
+    arena_snapshots: dict[str, dict[str, ArenaIdentity]],
+    *,
+    enforce_gate: bool,
+) -> None:
     arena_problems = verify_model_arenas(model, arena_snapshots)
     per_layer = get_layer_arena_findings()
     model_finding_set = frozenset(arena_problems)
@@ -43,13 +44,15 @@ def reload_storage_guard(model: torch.nn.Module) -> Iterator[None]:
         )
 
     if arena_problems:
-        gate = os.environ.get("VLLM_RELOAD_GATE", "strict")
         msg = (
             "Reload violated graph-visible storage identity on "
             f"{len(arena_problems)} slot(s):\n  "
             + "\n  ".join(arena_problems[:20])
         )
-        if gate == "warn":
+        gate = os.environ.get("VLLM_RELOAD_GATE", "strict")
+        if not enforce_gate:
+            logger.error(msg)
+        elif gate == "warn":
             logger.warning(msg)
         elif gate != "off":
             raise RuntimeError(
@@ -60,7 +63,7 @@ def reload_storage_guard(model: torch.nn.Module) -> Iterator[None]:
             )
 
     manifest_gate = os.environ.get("VLLM_RELOAD_GLOBAL_MANIFEST", "warn")
-    if manifest_gate == "off":
+    if enforce_gate and manifest_gate == "off":
         return
 
     report = check_global_storage()
@@ -69,7 +72,9 @@ def reload_storage_guard(model: torch.nn.Module) -> Iterator[None]:
             "Reload rebound module-level storage that was live when graphs "
             "were captured:\n" + report.format()
         )
-        if manifest_gate == "strict":
+        if not enforce_gate:
+            logger.error(msg)
+        elif manifest_gate == "strict":
             raise RuntimeError(
                 msg
                 + "\nSet VLLM_RELOAD_GLOBAL_MANIFEST=warn to downgrade."
@@ -77,3 +82,45 @@ def reload_storage_guard(model: torch.nn.Module) -> Iterator[None]:
         logger.warning(msg)
     elif report is not None:
         logger.debug("Global storage manifest clean (%d checked)", report.checked)
+
+
+@contextlib.contextmanager
+def reload_storage_guard(model: torch.nn.Module) -> Iterator[None]:
+    """Validate graph-visible storage after an in-place weight reload."""
+    arena_snapshots = snapshot_model_arenas(model)
+    try:
+        yield
+    except BaseException as reload_error:
+        add_note = getattr(reload_error, "add_note", None)
+        try:
+            _validate_reload_storage(
+                model,
+                arena_snapshots,
+                enforce_gate=False,
+            )
+        except Exception as validation_error:
+            logger.exception(
+                "Storage validation also failed after weight reload failed"
+            )
+            if add_note is not None:
+                add_note(
+                    "Post-failure storage validation raised "
+                    f"{type(validation_error).__name__}: {validation_error}"
+                )
+
+        if add_note is not None:
+            add_note(
+                "The in-place reload may have partially mutated the model. "
+                "This worker must not continue serving and should be restarted."
+            )
+        logger.error(
+            "In-place weight reload failed after mutation may have started; "
+            "the worker must be restarted before serving more requests."
+        )
+        raise
+    else:
+        _validate_reload_storage(
+            model,
+            arena_snapshots,
+            enforce_gate=True,
+        )

--- a/vllm/model_executor/model_loader/utils.py
+++ b/vllm/model_executor/model_loader/utils.py
@@ -27,6 +27,7 @@ from vllm.model_executor.layers.quantization.base_config import (
 )
 from vllm.model_executor.model_loader.reload import (
     record_metadata_for_reloading,
+    record_modelwise_reload_metadata,
     set_torchao_reload_attrs,
 )
 from vllm.model_executor.models.interfaces import SupportsQuant
@@ -63,6 +64,7 @@ def initialize_model(
         with set_current_vllm_config(vllm_config, check_compile=True, prefix=prefix):
             model = model_class(vllm_config=vllm_config, prefix=prefix)
             record_metadata_for_reloading(model)
+            record_modelwise_reload_metadata(model)
             return model
 
     msg = (
@@ -95,16 +97,25 @@ def initialize_model(
     with set_current_vllm_config(vllm_config, check_compile=True, prefix=prefix):
         model = model_class(**kwargs)
         record_metadata_for_reloading(model)
+        record_modelwise_reload_metadata(model)
 
     return model
 
 
 def process_weights_after_loading(
-    model: nn.Module, model_config: ModelConfig, target_device: torch.device
+    model: nn.Module,
+    model_config: ModelConfig,
+    target_device: torch.device,
+    *,
+    force: bool = False,
 ) -> None:
     for _, module in model.named_modules():
         quant_method = getattr(module, "quant_method", None)
         if isinstance(quant_method, QuantizeMethodBase):
+            if force and hasattr(
+                module, "_already_called_process_weights_after_loading"
+            ):
+                delattr(module, "_already_called_process_weights_after_loading")
             # When quant methods need to process weights after loading
             # (for repacking, quantizing, etc), they expect parameters
             # to be on the global target device. This scope is for the

--- a/vllm/model_executor/model_loader/utils.py
+++ b/vllm/model_executor/model_loader/utils.py
@@ -30,6 +30,7 @@ from vllm.model_executor.model_loader.reload import (
     set_torchao_reload_attrs,
 )
 from vllm.model_executor.models.interfaces import SupportsQuant
+from vllm.model_executor.reload_arena import arena_scope, get_reload_arena
 from vllm.tracing import instrument
 from vllm.utils.mem_utils import release_device_memory_under_pressure
 from vllm.utils.platform_utils import is_pin_memory_available
@@ -109,7 +110,10 @@ def process_weights_after_loading(
             # to be on the global target device. This scope is for the
             # case where cpu offloading is used, where we will move the
             # parameters onto device for processing and back off after.
-            with device_loading_context(module, target_device):
+            with (
+                device_loading_context(module, target_device),
+                arena_scope(get_reload_arena(module)),
+            ):
                 quant_method.process_weights_after_loading(module)
             # Repacking transients above can leave large amounts of memory in
             # the caching allocator, which starves the OS on UMA devices.
@@ -123,7 +127,10 @@ def process_weights_after_loading(
         ) and hasattr(module, "process_weights_after_loading"):
             # TODO(lucas): see if there is a way to unify the signatures
             # of process_weights_after_loading
-            with device_loading_context(module, target_device):
+            with (
+                device_loading_context(module, target_device),
+                arena_scope(get_reload_arena(module)),
+            ):
                 module.process_weights_after_loading(model_config.dtype)
 
     # Process HPC modules (HpcRopeNorm, etc.) that rely on

--- a/vllm/model_executor/reload_arena.py
+++ b/vllm/model_executor/reload_arena.py
@@ -105,18 +105,48 @@ def _identity(t: torch.Tensor) -> SlotIdentity:
 
 
 def _canonical_device(device) -> torch.device:
-    """Resolve an unindexed accelerator device to its concrete index.
+    """Resolve an unindexed accelerator device to the one torch would
+    actually allocate on.
 
-    Callers commonly pass the config-level ``"cuda"`` while the tensor a
-    slot holds reports ``cuda:0``; comparing them literally makes a
-    re-acquire after reload fail spuriously (observed live: the mismatch
-    aborted the first post-reload forward mid-capture).
+    Callers commonly pass a config-level ``"cuda"``/``"xpu"`` while the
+    tensor a slot holds reports ``cuda:0``; comparing them literally makes
+    a re-acquire after reload fail spuriously (observed live on CUDA: the
+    mismatch aborted the first post-reload forward mid-capture).
+
+    Resolution goes through torch's per-type device module rather than
+    ``current_platform``, for two reasons. The argument being canonicalized
+    is a specific device, not necessarily the platform vLLM is running on
+    (a CPU slot on a CUDA platform is legitimate), so the current platform
+    is not the right question to ask. And ``torch.get_device_module``
+    covers any backend registered with torch, including out-of-tree ones,
+    which the platform enum does not. This mirrors what vLLM's own
+    platform code does per device type, e.g. XpuPlatform's
+    ``device.index if device.index is not None else torch.xpu.current_device()``.
+
+    CPU is deliberately excluded: CPU tensors report a bare ``cpu`` with no
+    index, so canonicalizing to ``cpu:0`` would introduce the very mismatch
+    this exists to prevent.
     """
     device = torch.device(device)
-    if device.type == "cuda" and device.index is None and \
-            torch.cuda.is_available():
-        return torch.device("cuda", torch.cuda.current_device())
-    return device
+    if device.index is not None or device.type == "cpu":
+        return device
+
+    get_device_module = getattr(torch, "get_device_module", None)
+    if get_device_module is None:
+        return device
+    try:
+        module = get_device_module(device.type)
+        if not (module.is_available() and hasattr(module, "current_device")):
+            return device
+        index = module.current_device()
+    except Exception:
+        # Unknown/unavailable backend: leave the device as given rather
+        # than guessing. Worst case the caller sees a spec mismatch, which
+        # is loud and safe.
+        return device
+    if not isinstance(index, int):
+        return device
+    return torch.device(device.type, index)
 
 
 class ReloadArena:

--- a/vllm/model_executor/reload_arena.py
+++ b/vllm/model_executor/reload_arena.py
@@ -15,7 +15,7 @@ arena for the same slot returns the same storage, so every address a graph
 captured stays valid, and every derived value lands back in the storage the
 graph reads.
 
-Two acquisition idioms cover the reproduced failure shapes:
+Three acquisition idioms cover the reproduced failure shapes:
 
 ``get_or_alloc``
     For workspaces and scratch (Marlin ``workspace``, CUTLASS
@@ -35,6 +35,10 @@ Two acquisition idioms cover the reproduced failure shapes:
     from one call, because PWAL re-runs recompute the value and ``put``
     lands it in place.
 
+``get_or_create_object``
+    For runtime wrappers that own graph-visible storage internally: the first
+    call constructs the object and later PWAL rebuilds borrow the same object.
+
 The arena is also the declaration registry: ``snapshot``/``verify`` give the
 reload commit gate an exact inventory of graph-visible runtime storage, with
 no reflective walking (closures, lazy allocations, and config-embedded
@@ -42,10 +46,11 @@ tensors all evade walks -- each escape was reproduced live on H200).
 """
 
 import contextlib
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from contextvars import ContextVar
 from dataclasses import dataclass
 from enum import Enum
+from typing import TypeVar, cast
 
 import torch
 from torch import nn
@@ -53,6 +58,8 @@ from torch import nn
 from vllm.logger import init_logger
 
 logger = init_logger(__name__)
+
+T = TypeVar("T")
 
 __all__ = [
     "InitPolicy",
@@ -82,6 +89,14 @@ class SlotIdentity:
     stride: tuple[int, ...]
     dtype: torch.dtype
     device: str
+
+
+@dataclass(frozen=True)
+class ObjectIdentity:
+    value: object
+
+
+ArenaIdentity = SlotIdentity | ObjectIdentity
 
 
 @dataclass(frozen=True)
@@ -150,7 +165,7 @@ def _canonical_device(device) -> torch.device:
 
 
 class ReloadArena:
-    """Stable storage slots owned by one layer.
+    """Stable tensor storage and runtime object slots owned by one layer.
 
     Not an ``nn.Module``: slot tensors must not appear as parameters or
     buffers (they are not checkpoint state and must not be touched by
@@ -160,15 +175,19 @@ class ReloadArena:
     def __init__(self, owner_name: str = "") -> None:
         self._owner_name = owner_name
         self._slots: dict[str, torch.Tensor] = {}
+        self._object_slots: dict[str, object] = {}
 
     def __contains__(self, slot: str) -> bool:
-        return slot in self._slots
+        return slot in self._slots or slot in self._object_slots
 
     def __len__(self) -> int:
-        return len(self._slots)
+        return len(self._slots) + len(self._object_slots)
 
     def slots(self) -> dict[str, torch.Tensor]:
         return dict(self._slots)
+
+    def objects(self) -> dict[str, object]:
+        return dict(self._object_slots)
 
     def _check_spec(self, slot: str, existing: torch.Tensor,
                     shape: tuple[int, ...], dtype: torch.dtype,
@@ -202,6 +221,11 @@ class ReloadArena:
         """
         shape = tuple(shape)
         device = _canonical_device(device)
+        if slot in self._object_slots:
+            raise ValueError(
+                f"ReloadArena[{self._owner_name}] slot '{slot}' is already "
+                "used by a persistent object"
+            )
         existing = self._slots.get(slot)
         if existing is not None:
             self._check_spec(slot, existing, shape, dtype, device)
@@ -224,6 +248,11 @@ class ReloadArena:
         Callers must rebind their attribute to the RETURNED tensor, not to
         ``value``.
         """
+        if slot in self._object_slots:
+            raise ValueError(
+                f"ReloadArena[{self._owner_name}] slot '{slot}' is already "
+                "used by a persistent object"
+            )
         existing = self._slots.get(slot)
         if existing is None:
             stable = value.detach().contiguous().clone()
@@ -235,10 +264,37 @@ class ReloadArena:
         existing.copy_(value.detach())
         return existing
 
-    def snapshot(self) -> dict[str, SlotIdentity]:
-        return {name: _identity(t) for name, t in self._slots.items()}
+    def get_or_create_object(
+        self,
+        slot: str,
+        factory: Callable[[], T],
+    ) -> T:
+        """Return a layer-owned runtime object, creating it once."""
+        if slot in self._slots:
+            raise ValueError(
+                f"ReloadArena[{self._owner_name}] slot '{slot}' is already "
+                "used by a tensor"
+            )
+        if slot in self._object_slots:
+            return cast(T, self._object_slots[slot])
 
-    def verify(self, snap: dict[str, SlotIdentity]) -> list[SlotViolation]:
+        value = factory()
+        self._object_slots[slot] = value
+        return value
+
+    def snapshot(self) -> dict[str, ArenaIdentity]:
+        snapshot: dict[str, ArenaIdentity] = {
+            name: _identity(t) for name, t in self._slots.items()
+        }
+        snapshot.update(
+            {
+                name: ObjectIdentity(value)
+                for name, value in self._object_slots.items()
+            }
+        )
+        return snapshot
+
+    def verify(self, snap: dict[str, ArenaIdentity]) -> list[SlotViolation]:
         """Compare current slots against a snapshot.
 
         New slots since the snapshot are fine (first forward after a cold
@@ -248,6 +304,21 @@ class ReloadArena:
         """
         out: list[SlotViolation] = []
         for name, ident in snap.items():
+            if isinstance(ident, ObjectIdentity):
+                if name not in self._object_slots:
+                    out.append(
+                        SlotViolation(name, "gone", "persistent object vanished")
+                    )
+                elif self._object_slots[name] is not ident.value:
+                    out.append(
+                        SlotViolation(
+                            name,
+                            "moved",
+                            "persistent object identity changed",
+                        )
+                    )
+                continue
+
             cur = self._slots.get(name)
             if cur is None:
                 out.append(
@@ -324,8 +395,8 @@ def current_arena() -> "ReloadArena | None":
 
 
 def snapshot_model_arenas(
-        model: nn.Module) -> dict[str, dict[str, SlotIdentity]]:
-    out: dict[str, dict[str, SlotIdentity]] = {}
+        model: nn.Module) -> dict[str, dict[str, ArenaIdentity]]:
+    out: dict[str, dict[str, ArenaIdentity]] = {}
     for name, module in model.named_modules():
         arena = peek_reload_arena(module)
         if arena is not None and len(arena):
@@ -335,7 +406,7 @@ def snapshot_model_arenas(
 
 def verify_model_arenas(
         model: nn.Module,
-        snaps: dict[str, dict[str, SlotIdentity]]) -> list[str]:
+        snaps: dict[str, dict[str, ArenaIdentity]]) -> list[str]:
     """Flat, human-readable violation list across the whole model."""
     problems: list[str] = []
     modules = dict(model.named_modules())

--- a/vllm/model_executor/reload_arena.py
+++ b/vllm/model_executor/reload_arena.py
@@ -1,0 +1,305 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Layer-owned stable storage for runtime tensors that must survive reload.
+
+Every confirmed category-1 failure in RFC #48312 has the same structure: a
+tensor whose device address is baked into a captured CUDA graph is owned by a
+TRANSIENT object -- a kernel, experts, or quant-config object that
+``process_weights_after_loading`` rebuilds from scratch on every run. The
+graph outlives the rebuild; the storage does not.
+
+The arena inverts the ownership: storage belongs to the layer (an
+``nn.Module`` that survives reload), and transient objects merely borrow it
+by slot name. Rebuild the kernel object as often as you like -- asking the
+arena for the same slot returns the same storage, so every address a graph
+captured stays valid, and every derived value lands back in the storage the
+graph reads.
+
+Two acquisition idioms cover the reproduced failure shapes:
+
+``get_or_alloc``
+    For workspaces and scratch (Marlin ``workspace``, CUTLASS
+    ``ab_strides*``, MoE permute scratch): the caller wants storage of a
+    given spec and does not care about prior contents (or wants them
+    zeroed). First call allocates; later calls return the SAME tensor.
+    This also covers lazily-allocated buffers -- the first-forward
+    allocation goes through the arena, so it survives the next reload even
+    though no reload machinery ever sees it.
+
+``put``
+    For derived values computed by post-load processing (MLA ``W_UV``,
+    fp32 sinks copies): the caller has just recomputed the value and wants
+    it published at a stable address. First call adopts a private
+    contiguous copy; later calls ``copy_`` into that same storage. This
+    gives storage identity (category 1) and value refresh (category 2)
+    from one call, because PWAL re-runs recompute the value and ``put``
+    lands it in place.
+
+The arena is also the declaration registry: ``snapshot``/``verify`` give the
+reload commit gate an exact inventory of graph-visible runtime storage, with
+no reflective walking (closures, lazy allocations, and config-embedded
+tensors all evade walks -- each escape was reproduced live on H200).
+"""
+
+import contextlib
+from collections.abc import Iterator
+from contextvars import ContextVar
+from dataclasses import dataclass
+from enum import Enum
+
+import torch
+from torch import nn
+
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+__all__ = [
+    "InitPolicy",
+    "SlotViolation",
+    "ReloadArena",
+    "get_reload_arena",
+    "peek_reload_arena",
+    "arena_scope",
+    "current_arena",
+    "snapshot_model_arenas",
+    "verify_model_arenas",
+]
+
+
+class InitPolicy(Enum):
+    """Contents policy when ``get_or_alloc`` returns an existing slot."""
+
+    EMPTY = "empty"  # first alloc uninitialized; re-acquire keeps contents
+    ZERO = "zero"  # zeroed on first alloc AND on every re-acquire
+    PRESERVE = "preserve"  # first alloc uninitialized; re-acquire keeps
+
+
+@dataclass(frozen=True)
+class SlotIdentity:
+    data_ptr: int
+    shape: tuple[int, ...]
+    stride: tuple[int, ...]
+    dtype: torch.dtype
+    device: str
+
+
+@dataclass(frozen=True)
+class SlotViolation:
+    slot: str
+    kind: str  # "moved" | "gone" | "respecified"
+    detail: str
+
+    def __str__(self) -> str:
+        return f"[{self.kind}] {self.slot}: {self.detail}"
+
+
+def _identity(t: torch.Tensor) -> SlotIdentity:
+    return SlotIdentity(
+        data_ptr=t.data_ptr(),
+        shape=tuple(t.shape),
+        stride=tuple(t.stride()),
+        dtype=t.dtype,
+        device=str(t.device),
+    )
+
+
+class ReloadArena:
+    """Stable storage slots owned by one layer.
+
+    Not an ``nn.Module``: slot tensors must not appear as parameters or
+    buffers (they are not checkpoint state and must not be touched by
+    load/copy-back machinery). The arena itself IS their reload contract.
+    """
+
+    def __init__(self, owner_name: str = "") -> None:
+        self._owner_name = owner_name
+        self._slots: dict[str, torch.Tensor] = {}
+
+    def __contains__(self, slot: str) -> bool:
+        return slot in self._slots
+
+    def __len__(self) -> int:
+        return len(self._slots)
+
+    def slots(self) -> dict[str, torch.Tensor]:
+        return dict(self._slots)
+
+    def _check_spec(self, slot: str, existing: torch.Tensor,
+                    shape: tuple[int, ...], dtype: torch.dtype,
+                    device: torch.device) -> None:
+        if (tuple(existing.shape) != tuple(shape)
+                or existing.dtype != dtype
+                or existing.device != torch.device(device)):
+            raise ValueError(
+                f"ReloadArena[{self._owner_name}] slot '{slot}' re-acquired "
+                f"with an incompatible spec: have "
+                f"{tuple(existing.shape)}/{existing.dtype}/{existing.device}, "
+                f"asked {tuple(shape)}/{dtype}/{device}. A shape-changing "
+                "reload is not an in-place update; it requires a cold "
+                "restart. Refusing to silently replace storage a captured "
+                "graph may hold.")
+
+    def get_or_alloc(
+        self,
+        slot: str,
+        shape,
+        dtype: torch.dtype,
+        device,
+        *,
+        init: InitPolicy = InitPolicy.EMPTY,
+    ) -> torch.Tensor:
+        """Return the slot's tensor, allocating on first use.
+
+        Later calls with the same slot return the SAME tensor (same
+        storage), regardless of which object asks. Spec mismatch raises --
+        never silently reallocates.
+        """
+        shape = tuple(shape)
+        device = torch.device(device)
+        existing = self._slots.get(slot)
+        if existing is not None:
+            self._check_spec(slot, existing, shape, dtype, device)
+            if init is InitPolicy.ZERO:
+                existing.zero_()
+            return existing
+
+        if init is InitPolicy.ZERO:
+            t = torch.zeros(shape, dtype=dtype, device=device)
+        else:
+            t = torch.empty(shape, dtype=dtype, device=device)
+        self._slots[slot] = t
+        return t
+
+    def put(self, slot: str, value: torch.Tensor) -> torch.Tensor:
+        """Publish a freshly-computed derived value at a stable address.
+
+        First call adopts a private contiguous copy of ``value``; later
+        calls copy the new value into that same storage and return it.
+        Callers must rebind their attribute to the RETURNED tensor, not to
+        ``value``.
+        """
+        existing = self._slots.get(slot)
+        if existing is None:
+            stable = value.detach().contiguous().clone()
+            self._slots[slot] = stable
+            return stable
+        self._check_spec(slot, existing, tuple(value.shape), value.dtype,
+                         value.device)
+        # detach: value may be a view of a live parameter
+        existing.copy_(value.detach())
+        return existing
+
+    def snapshot(self) -> dict[str, SlotIdentity]:
+        return {name: _identity(t) for name, t in self._slots.items()}
+
+    def verify(self, snap: dict[str, SlotIdentity]) -> list[SlotViolation]:
+        """Compare current slots against a snapshot.
+
+        New slots since the snapshot are fine (first forward after a cold
+        start legitimately adds lazy slots). A snapshotted slot that moved,
+        vanished, or changed layout is a violation: some address consumer
+        (a captured graph) may still hold the old identity.
+        """
+        out: list[SlotViolation] = []
+        for name, ident in snap.items():
+            cur = self._slots.get(name)
+            if cur is None:
+                out.append(
+                    SlotViolation(name, "gone",
+                                  f"slot vanished (was {ident.shape} "
+                                  f"{ident.dtype} @ {hex(ident.data_ptr)})"))
+                continue
+            cur_ident = _identity(cur)
+            if cur_ident.data_ptr != ident.data_ptr:
+                out.append(
+                    SlotViolation(
+                        name, "moved",
+                        f"{hex(ident.data_ptr)} -> {hex(cur_ident.data_ptr)}"))
+            elif (cur_ident.shape != ident.shape
+                  or cur_ident.stride != ident.stride
+                  or cur_ident.dtype != ident.dtype):
+                out.append(
+                    SlotViolation(
+                        name, "respecified",
+                        f"{ident.shape}/{ident.dtype} -> "
+                        f"{cur_ident.shape}/{cur_ident.dtype}"))
+        return out
+
+
+_ARENA_ATTR = "_reload_arena"
+
+
+def get_reload_arena(module: nn.Module) -> ReloadArena:
+    """The module's arena, created on first use.
+
+    Stored as a plain attribute: the arena's tensors must stay out of
+    ``_parameters``/``_buffers`` (see ``ReloadArena`` docstring).
+    """
+    arena = getattr(module, _ARENA_ATTR, None)
+    if arena is None:
+        arena = ReloadArena(owner_name=type(module).__name__)
+        setattr(module, _ARENA_ATTR, arena)
+    return arena
+
+
+def peek_reload_arena(module: nn.Module) -> "ReloadArena | None":
+    return getattr(module, _ARENA_ATTR, None)
+
+
+# Ambient arena for construction chains that never see the layer.
+#
+# Kernel/experts objects are built deep inside make_*_moe_kernel() calls whose
+# signatures do not carry the layer. Rather than threading a parameter through
+# every factory, the PWAL site (which HAS the layer) opens a scope:
+#
+#     with arena_scope(get_reload_arena(layer)):
+#         self.moe_kernel = make_fp8_moe_kernel(...)
+#
+# and constructors resolve current_arena(). Outside any scope current_arena()
+# is None and callers fall back to plain allocation -- unit tests and
+# non-reloadable uses are unaffected. Constructors that allocate lazily (first
+# forward) must CAPTURE the arena at construction time, not resolve it at
+# forward time (no scope is open during forward).
+_current_arena: ContextVar["ReloadArena | None"] = ContextVar(
+    "vllm_reload_arena", default=None)
+
+
+@contextlib.contextmanager
+def arena_scope(arena: ReloadArena) -> Iterator[ReloadArena]:
+    token = _current_arena.set(arena)
+    try:
+        yield arena
+    finally:
+        _current_arena.reset(token)
+
+
+def current_arena() -> "ReloadArena | None":
+    return _current_arena.get()
+
+
+def snapshot_model_arenas(
+        model: nn.Module) -> dict[str, dict[str, SlotIdentity]]:
+    out: dict[str, dict[str, SlotIdentity]] = {}
+    for name, module in model.named_modules():
+        arena = peek_reload_arena(module)
+        if arena is not None and len(arena):
+            out[name] = arena.snapshot()
+    return out
+
+
+def verify_model_arenas(
+        model: nn.Module,
+        snaps: dict[str, dict[str, SlotIdentity]]) -> list[str]:
+    """Flat, human-readable violation list across the whole model."""
+    problems: list[str] = []
+    modules = dict(model.named_modules())
+    for mod_name, snap in snaps.items():
+        module = modules.get(mod_name)
+        arena = peek_reload_arena(module) if module is not None else None
+        if arena is None:
+            problems.append(f"{mod_name}: arena vanished across reload")
+            continue
+        for v in arena.verify(snap):
+            problems.append(f"{mod_name}: {v}")
+    return problems

--- a/vllm/model_executor/reload_arena.py
+++ b/vllm/model_executor/reload_arena.py
@@ -104,6 +104,21 @@ def _identity(t: torch.Tensor) -> SlotIdentity:
     )
 
 
+def _canonical_device(device) -> torch.device:
+    """Resolve an unindexed accelerator device to its concrete index.
+
+    Callers commonly pass the config-level ``"cuda"`` while the tensor a
+    slot holds reports ``cuda:0``; comparing them literally makes a
+    re-acquire after reload fail spuriously (observed live: the mismatch
+    aborted the first post-reload forward mid-capture).
+    """
+    device = torch.device(device)
+    if device.type == "cuda" and device.index is None and \
+            torch.cuda.is_available():
+        return torch.device("cuda", torch.cuda.current_device())
+    return device
+
+
 class ReloadArena:
     """Stable storage slots owned by one layer.
 
@@ -130,7 +145,7 @@ class ReloadArena:
                     device: torch.device) -> None:
         if (tuple(existing.shape) != tuple(shape)
                 or existing.dtype != dtype
-                or existing.device != torch.device(device)):
+                or existing.device != _canonical_device(device)):
             raise ValueError(
                 f"ReloadArena[{self._owner_name}] slot '{slot}' re-acquired "
                 f"with an incompatible spec: have "
@@ -156,7 +171,7 @@ class ReloadArena:
         never silently reallocates.
         """
         shape = tuple(shape)
-        device = torch.device(device)
+        device = _canonical_device(device)
         existing = self._slots.get(slot)
         if existing is not None:
             self._check_spec(slot, existing, shape, dtype, device)

--- a/vllm/model_executor/reload_manifest.py
+++ b/vllm/model_executor/reload_manifest.py
@@ -1,0 +1,257 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Capture-time manifest for module-level (global) tensor storage.
+
+The reload arena covers storage a layer owns. Some graph-visible tensors
+have no owning layer at all: they live in module-level caches and
+registries, e.g. ``_g_workspace: dict[torch.device, torch.Tensor]`` in the
+tokenspeed MLA backend, or the Triton sampler's buffer caches. No walk
+rooted at the model reaches them, and no copy-back protects them -- but a
+captured graph bakes their addresses just the same, and a cache that grows
+or is repopulated rebinds them silently.
+
+This module records those storages when graphs are captured and verifies
+them at reload commit. Two independent signals, because neither alone is
+sufficient:
+
+``expired``
+    The recorded storage was freed. Any graph holding that address is
+    dangling. Detected with a weak reference, so it needs no path and no
+    owner -- it works even for a tensor nothing can reach anymore.
+
+``moved``
+    The path still resolves, but to different storage, while the old
+    storage is still alive (typically retained by a capture artifact).
+    This is the silent-stale-read case: replay keeps using the previous
+    values and nothing crashes. Measured live on H200 for the Machete
+    act-order permutation -- 88/88 tensors rebound with 0/88 storages
+    freed -- which is why an expiry-only check is not enough.
+
+Module-level state is enumerated by scanning loaded modules rather than by
+dataflow tracing. That keeps paths stable and re-resolvable (so ``moved``
+is computable, which a ``TorchDispatchMode`` recorder's positional paths
+are not) and keeps the production path free of op interception. Discovering
+storage that this scan cannot see is a CI concern, not a serving one.
+"""
+
+import sys
+from dataclasses import dataclass, field
+
+import torch
+from torch.multiprocessing.reductions import StorageWeakRef
+
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+__all__ = [
+    "GlobalStorageManifest",
+    "ManifestReport",
+    "collect_module_level_tensors",
+    "record_global_storage",
+    "check_global_storage",
+    "reset_global_storage",
+]
+
+# Only vLLM's own modules are scanned. Third-party module state is out of
+# reach for a fix anyway, and scanning all of sys.modules is both slow and
+# noisy.
+DEFAULT_MODULE_PREFIXES = (
+    "vllm.model_executor",
+    "vllm.attention",
+    "vllm.v1.attention",
+    "vllm.v1.sample",
+    "vllm.v1.worker",
+    "vllm.distributed",
+)
+
+# This package's own bookkeeping would otherwise be reported as findings.
+_SELF_EXCLUDED = (
+    "vllm.model_executor.reload_manifest",
+    "vllm.model_executor.reload_arena",
+    "vllm.model_executor.model_loader.reload",
+)
+
+
+@dataclass(frozen=True)
+class _Slot:
+    ref: StorageWeakRef
+    data_ptr: int
+    shape: tuple[int, ...]
+    dtype: torch.dtype
+
+
+@dataclass
+class ManifestReport:
+    """Outcome of checking the manifest after a reload."""
+
+    expired: list[str] = field(default_factory=list)
+    moved: list[str] = field(default_factory=list)
+    # Path no longer resolves but its storage is alive: something else holds
+    # it, so no captured address dangles. Informational, not a violation.
+    vanished: list[str] = field(default_factory=list)
+    checked: int = 0
+
+    @property
+    def is_clean(self) -> bool:
+        return not self.expired and not self.moved
+
+    def format(self, max_items: int = 10) -> str:
+        lines = [
+            f"global storage: checked={self.checked} "
+            f"expired={len(self.expired)} moved={len(self.moved)} "
+            f"vanished={len(self.vanished)}"
+        ]
+        for label, paths in (("expired (captured address freed)", self.expired),
+                             ("moved (stale read risk)", self.moved)):
+            if paths:
+                lines.append(f"  {label}:")
+                lines.extend(f"    {p}" for p in paths[:max_items])
+                if len(paths) > max_items:
+                    lines.append(f"    ... and {len(paths) - max_items} more")
+        return "\n".join(lines)
+
+
+def _walk(value, path: str, depth: int, out: dict[str, torch.Tensor],
+          require_cuda: bool) -> None:
+    if depth < 0:
+        return
+    if isinstance(value, torch.Tensor):
+        if not require_cuda or value.is_cuda:
+            out[path] = value
+        return
+    if isinstance(value, (list, tuple)):
+        for i, item in enumerate(value):
+            _walk(item, f"{path}[{i}]", depth - 1, out, require_cuda)
+        return
+    if isinstance(value, dict):
+        for key, item in value.items():
+            # Keys must render stably or the path is not re-resolvable
+            # across the reload; skip anything that cannot.
+            try:
+                rendered = repr(key)
+            except Exception:
+                continue
+            _walk(item, f"{path}[{rendered}]", depth - 1, out, require_cuda)
+
+
+def collect_module_level_tensors(
+    prefixes: tuple[str, ...] = DEFAULT_MODULE_PREFIXES,
+    max_depth: int = 3,
+    require_cuda: bool = True,
+) -> dict[str, torch.Tensor]:
+    """Tensors held in module-level state, keyed by a re-resolvable path.
+
+    Args:
+        require_cuda: only device tensors can have an address baked into a
+            graph. Tests set this False to exercise the logic on CPU.
+    """
+    out: dict[str, torch.Tensor] = {}
+    # Snapshot the module table: importing on another thread would
+    # otherwise mutate it mid-iteration.
+    for mod_name, module in list(sys.modules.items()):
+        if module is None or not mod_name.startswith(prefixes):
+            continue
+        if mod_name.startswith(_SELF_EXCLUDED):
+            continue
+        try:
+            members = list(vars(module).items())
+        except Exception:
+            continue
+        for attr, value in members:
+            if attr.startswith("__"):
+                continue
+            # Only module-level *state*, not re-exported classes/functions
+            # (those carry their own module's tensors, found under that
+            # module's own name).
+            if isinstance(value, type) or callable(value):
+                continue
+            _walk(value, f"{mod_name}.{attr}", max_depth, out, require_cuda)
+    return out
+
+
+class GlobalStorageManifest:
+    """Records module-level storage at capture; verifies it after reload."""
+
+    def __init__(self) -> None:
+        self._slots: dict[str, _Slot] = {}
+        self._prefixes = DEFAULT_MODULE_PREFIXES
+        self._max_depth = 3
+        self._require_cuda = True
+
+    def __len__(self) -> int:
+        return len(self._slots)
+
+    def paths(self) -> list[str]:
+        return sorted(self._slots)
+
+    def record(
+        self,
+        prefixes: tuple[str, ...] = DEFAULT_MODULE_PREFIXES,
+        max_depth: int = 3,
+        require_cuda: bool = True,
+    ) -> int:
+        self._prefixes = prefixes
+        self._max_depth = max_depth
+        self._require_cuda = require_cuda
+        self._slots = {
+            path: _Slot(
+                ref=StorageWeakRef(t.untyped_storage()),
+                data_ptr=t.data_ptr(),
+                shape=tuple(t.shape),
+                dtype=t.dtype,
+            )
+            for path, t in collect_module_level_tensors(
+                prefixes, max_depth, require_cuda).items()
+        }
+        return len(self._slots)
+
+    def check(self) -> ManifestReport:
+        report = ManifestReport(checked=len(self._slots))
+        if not self._slots:
+            return report
+
+        current = collect_module_level_tensors(
+            self._prefixes, self._max_depth, self._require_cuda)
+
+        for path, slot in self._slots.items():
+            if slot.ref.expired():
+                # Freed: any captured address is dangling regardless of
+                # whether the path still resolves.
+                report.expired.append(
+                    f"{path} (was {slot.shape} {slot.dtype})")
+                continue
+            now = current.get(path)
+            if now is None:
+                report.vanished.append(path)
+            elif now.data_ptr() != slot.data_ptr:
+                report.moved.append(
+                    f"{path} ({hex(slot.data_ptr)} -> {hex(now.data_ptr())})")
+        return report
+
+
+# Process-scoped: module-level storage is process-scoped too. Holds only
+# weak references and integers, so it pins nothing alive.
+_MANIFEST: GlobalStorageManifest | None = None
+
+
+def record_global_storage(**kwargs) -> int:
+    """Record module-level storage as it stands at graph-capture time."""
+    global _MANIFEST
+    _MANIFEST = GlobalStorageManifest()
+    count = _MANIFEST.record(**kwargs)
+    logger.debug("Recorded %d module-level tensor storages for reload "
+                 "verification", count)
+    return count
+
+
+def check_global_storage() -> ManifestReport | None:
+    """Verify recorded storage. None if nothing was ever recorded."""
+    if _MANIFEST is None:
+        return None
+    return _MANIFEST.check()
+
+
+def reset_global_storage() -> None:
+    global _MANIFEST
+    _MANIFEST = None

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -9,6 +9,8 @@ from typing import ClassVar
 
 import numpy as np
 import torch
+
+from vllm.model_executor.reload_arena import ReloadArena
 from flashinfer import (
     BatchDecodeWithPagedKVCacheWrapper,
     BatchPrefillWithPagedKVCacheWrapper,
@@ -1502,6 +1504,13 @@ class FlashInferImpl(AttentionImpl):
             )
 
         self.sinks: torch.Tensor | None = None
+        # Keep the checkpoint-backed source separately: post-load processing
+        # publishes a runtime fp32 copy into self.sinks, and a reload
+        # refreshes that copy FROM this source. Without the source
+        # reference, the second post-load pass has nothing to recompute
+        # from and the runtime copy silently keeps pre-reload values.
+        self._sinks_source: torch.Tensor | None = None
+        self._sinks_arena = ReloadArena("FlashInferImpl")
         if sinks is not None:
             if sinks.shape[0] != num_heads:
                 raise ValueError(
@@ -1510,6 +1519,7 @@ class FlashInferImpl(AttentionImpl):
                     f"{sinks.shape[0]}."
                 )
             self.sinks = sinks
+            self._sinks_source = sinks
 
         self.supports_xqa_or_trtllm_gen_decode = can_use_trtllm_attention(
             num_heads, num_kv_heads, is_prefill=False
@@ -1562,8 +1572,13 @@ class FlashInferImpl(AttentionImpl):
 
     # FlashInfer requires attention sinks to be float32
     def process_weights_after_loading(self, act_dtype: torch.dtype):
-        if self.sinks is not None and self.sinks.dtype != torch.float32:
-            self.sinks = self.sinks.to(torch.float32)
+        # Recompute the runtime fp32 copy from the source UNCONDITIONALLY.
+        # The old dtype guard made the second pass a no-op (already fp32),
+        # so a reload never refreshed the runtime copy. The arena keeps the
+        # copy's address stable for any capture that read it.
+        if self._sinks_source is not None:
+            self.sinks = self._sinks_arena.put(
+                "sinks_f32", self._sinks_source.to(torch.float32))
 
     def get_xqa_bmm1_scale(self, layer: torch.nn.Module, q_data_type: torch.dtype):
         bmm1_scale = self.scale

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -10,7 +10,6 @@ from typing import ClassVar
 import numpy as np
 import torch
 
-from vllm.model_executor.reload_arena import ReloadArena
 from flashinfer import (
     BatchDecodeWithPagedKVCacheWrapper,
     BatchPrefillWithPagedKVCacheWrapper,
@@ -37,6 +36,7 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
     kFp8StaticTensorSym,
     kNvfp4Dynamic,
 )
+from vllm.model_executor.reload_arena import current_arena
 from vllm.platforms import current_platform
 from vllm.platforms.interface import DeviceCapability
 from vllm.triton_utils import tl, triton
@@ -1510,7 +1510,6 @@ class FlashInferImpl(AttentionImpl):
         # reference, the second post-load pass has nothing to recompute
         # from and the runtime copy silently keeps pre-reload values.
         self._sinks_source: torch.Tensor | None = None
-        self._sinks_arena = ReloadArena("FlashInferImpl")
         if sinks is not None:
             if sinks.shape[0] != num_heads:
                 raise ValueError(
@@ -1577,8 +1576,13 @@ class FlashInferImpl(AttentionImpl):
         # so a reload never refreshed the runtime copy. The arena keeps the
         # copy's address stable for any capture that read it.
         if self._sinks_source is not None:
-            self.sinks = self._sinks_arena.put(
-                "sinks_f32", self._sinks_source.to(torch.float32))
+            sinks_f32 = self._sinks_source.to(torch.float32)
+            arena = current_arena()
+            self.sinks = (
+                arena.put("flashinfer.sinks_f32", sinks_f32)
+                if arena is not None
+                else sinks_f32
+            )
 
     def get_xqa_bmm1_scale(self, layer: torch.nn.Module, q_data_type: torch.dtype):
         bmm1_scale = self.scale

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -1106,3 +1106,4 @@ class AsyncLLM(EngineClient):
     async def finish_weight_update(self) -> None:
         """Finish the current weight update."""
         await self.collective_rpc("finish_weight_update")
+        await self.engine_core.reset_prefix_cache_async()

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -70,10 +70,7 @@ from vllm.model_executor.layers.rotary_embedding import (
     XDRotaryEmbedding,
 )
 from vllm.model_executor.model_loader import get_model_loader
-from vllm.model_executor.model_loader.reload import (
-    finalize_layerwise_reload,
-    initialize_layerwise_reload,
-)
+from vllm.model_executor.model_loader.reload import ModelwiseReloader
 from vllm.model_executor.models.interfaces import (
     MixtureOfExperts,
     MultiModalEmbeddings,
@@ -5492,13 +5489,17 @@ class GPUModelRunner(
         # and reload runs outside the startup context that initial loading
         # had. Boundary-wide context rather than per-field snapshots so new
         # config consumers stay covered.
-        with reload_storage_guard(model):
-            with set_current_vllm_config(self.vllm_config):
+        with (
+            reload_storage_guard(model),
+            set_current_vllm_config(self.vllm_config),
+        ):
                 if is_checkpoint_format:
                     # load weights from checkpoint/ original model format
-                    initialize_layerwise_reload(model)
-                    loaded_weights = model.load_weights(weights_iterator)
-                    finalize_layerwise_reload(model, self.model_config)
+                    loaded_weights = ModelwiseReloader(
+                        model,
+                        self.model_config,
+                        self.device,
+                    ).reload(weights_iterator)
 
                 else:
                     # load weights from kernel format
@@ -6727,8 +6728,7 @@ class GPUModelRunner(
         # arena covers them; the manifest is what lets a reload notice if a
         # global cache rebinds an address a graph baked in.
         if os.environ.get("VLLM_RELOAD_GLOBAL_MANIFEST", "warn") != "off":
-            from vllm.model_executor.reload_manifest import (
-                record_global_storage)
+            from vllm.model_executor.reload_manifest import record_global_storage
             record_global_storage()
 
         return cuda_graph_size

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -5518,6 +5518,25 @@ class GPUModelRunner(
         # catch this (stale allocations stay bit-identical until reclaimed),
         # so identity is checked directly and failure is closed.
         arena_problems = verify_model_arenas(model, arena_snaps)
+
+        # Dual-run transition: the per-layer verification inside the layerwise
+        # pipeline (LayerReloadingInfo.arena_snapshot) now checks the same
+        # invariant closer to where each PWAL re-runs. While both run, compare
+        # them: the per-layer pass must not be narrower than this model-level
+        # one. A mismatch means the per-layer coverage has a hole (e.g. a
+        # module whose arena the layerwise walk does not reach), so keep the
+        # model-level gate authoritative and log the discrepancy rather than
+        # trusting the newer path prematurely.
+        from vllm.model_executor.model_loader.reload.layerwise import (
+            get_layer_arena_findings)
+        per_layer = get_layer_arena_findings()
+        if len(per_layer) != len(arena_problems):
+            logger.warning(
+                "Reload arena verification mismatch: model-level found %d, "
+                "per-layer found %d. Model-level: %s | Per-layer: %s",
+                len(arena_problems), len(per_layer),
+                arena_problems[:10], per_layer[:10])
+
         if arena_problems:
             gate = os.environ.get("VLLM_RELOAD_GATE", "strict")
             msg = ("Reload violated graph-visible storage identity on "

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -5484,6 +5484,7 @@ class GPUModelRunner(
         # Commit-gate snapshot: every arena slot a captured graph may hold.
         from vllm.model_executor.reload_arena import (
             snapshot_model_arenas, verify_model_arenas)
+        from vllm.model_executor.reload_manifest import check_global_storage
         arena_snaps = snapshot_model_arenas(model)
 
         # begin loading weights
@@ -5532,6 +5533,25 @@ class GPUModelRunner(
                     "stale storage; serving would risk corruption or an "
                     "illegal memory access. Set VLLM_RELOAD_GATE=warn to "
                     "downgrade (unsafe).")
+
+        # Module-level storage the arena cannot own. Defaults to warn rather
+        # than strict: unlike the arena check this has no field data yet, and
+        # a new gate whose false-positive rate is unknown gets switched off
+        # wholesale the first time it misfires.
+        manifest_gate = os.environ.get("VLLM_RELOAD_GLOBAL_MANIFEST", "warn")
+        if manifest_gate != "off":
+            report = check_global_storage()
+            if report is not None and not report.is_clean:
+                msg = ("Reload rebound module-level storage that was live "
+                       "when graphs were captured:\n" + report.format())
+                if manifest_gate == "strict":
+                    raise RuntimeError(
+                        msg + "\nSet VLLM_RELOAD_GLOBAL_MANIFEST=warn to "
+                        "downgrade.")
+                logger.warning(msg)
+            elif report is not None:
+                logger.debug("Global storage manifest clean (%d checked)",
+                             report.checked)
 
         # logging and validation
         counter_after_reloading = time.perf_counter()
@@ -6742,6 +6762,16 @@ class GPUModelRunner(
             elapsed_time,
             cuda_graph_size / (1 << 30),
         )
+
+        # Record module-level tensor storage as the graphs just captured it.
+        # These have no owning layer, so neither copy-back nor the reload
+        # arena covers them; the manifest is what lets a reload notice if a
+        # global cache rebinds an address a graph baked in.
+        if os.environ.get("VLLM_RELOAD_GLOBAL_MANIFEST", "warn") != "off":
+            from vllm.model_executor.reload_manifest import (
+                record_global_storage)
+            record_global_storage()
+
         return cuda_graph_size
 
     def _warmup_and_capture(

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -5481,11 +5481,9 @@ class GPUModelRunner(
                 Iterable[tuple[str, torch.Tensor]], weights_iterator
             )
 
-        # Commit-gate snapshot: every arena slot a captured graph may hold.
-        from vllm.model_executor.reload_arena import (
-            snapshot_model_arenas, verify_model_arenas)
-        from vllm.model_executor.reload_manifest import check_global_storage
-        arena_snaps = snapshot_model_arenas(model)
+        from vllm.model_executor.model_loader.reload.validation import (
+            reload_storage_guard,
+        )
 
         # begin loading weights
         logger.info_once("Reloading weights inplace...")
@@ -5494,83 +5492,25 @@ class GPUModelRunner(
         # and reload runs outside the startup context that initial loading
         # had. Boundary-wide context rather than per-field snapshots so new
         # config consumers stay covered.
-        with set_current_vllm_config(self.vllm_config):
-            if is_checkpoint_format:
-                # load weights from checkpoint/ original model format
-                initialize_layerwise_reload(model)
-                loaded_weights = model.load_weights(weights_iterator)
-                finalize_layerwise_reload(model, self.model_config)
+        with reload_storage_guard(model):
+            with set_current_vllm_config(self.vllm_config):
+                if is_checkpoint_format:
+                    # load weights from checkpoint/ original model format
+                    initialize_layerwise_reload(model)
+                    loaded_weights = model.load_weights(weights_iterator)
+                    finalize_layerwise_reload(model, self.model_config)
 
-            else:
-                # load weights from kernel format
-                logger.warning_once(
-                    "Reloading with `is_checkpoint_format=True` requires that "
-                    "weights be in kernel format and already sharded",
-                )
-                loaded_weights = set()
-                for name, loaded_weight in weights_iterator:
-                    param = model.get_parameter(name)  # TODO: buffers?
-                    param.copy_(loaded_weight)
-                    loaded_weights.add(name)
-
-        # Commit gate: refuse to serve if any graph-visible slot moved,
-        # vanished, or changed layout. Same-weights output checks cannot
-        # catch this (stale allocations stay bit-identical until reclaimed),
-        # so identity is checked directly and failure is closed.
-        arena_problems = verify_model_arenas(model, arena_snaps)
-
-        # Dual-run transition: the per-layer verification inside the layerwise
-        # pipeline (LayerReloadingInfo.arena_snapshot) now checks the same
-        # invariant closer to where each PWAL re-runs. While both run, compare
-        # them: the per-layer pass must not be narrower than this model-level
-        # one. A mismatch means the per-layer coverage has a hole (e.g. a
-        # module whose arena the layerwise walk does not reach), so keep the
-        # model-level gate authoritative and log the discrepancy rather than
-        # trusting the newer path prematurely.
-        from vllm.model_executor.model_loader.reload.layerwise import (
-            get_layer_arena_findings)
-        per_layer = get_layer_arena_findings()
-        if len(per_layer) != len(arena_problems):
-            logger.warning(
-                "Reload arena verification mismatch: model-level found %d, "
-                "per-layer found %d. Model-level: %s | Per-layer: %s",
-                len(arena_problems), len(per_layer),
-                arena_problems[:10], per_layer[:10])
-
-        if arena_problems:
-            gate = os.environ.get("VLLM_RELOAD_GATE", "strict")
-            msg = ("Reload violated graph-visible storage identity on "
-                   f"{len(arena_problems)} slot(s):\n  " +
-                   "\n  ".join(arena_problems[:20]))
-            if gate == "off":
-                pass
-            elif gate == "warn":
-                logger.warning(msg)
-            else:
-                raise RuntimeError(
-                    msg + "\nCaptured CUDA graphs may reference freed or "
-                    "stale storage; serving would risk corruption or an "
-                    "illegal memory access. Set VLLM_RELOAD_GATE=warn to "
-                    "downgrade (unsafe).")
-
-        # Module-level storage the arena cannot own. Defaults to warn rather
-        # than strict: unlike the arena check this has no field data yet, and
-        # a new gate whose false-positive rate is unknown gets switched off
-        # wholesale the first time it misfires.
-        manifest_gate = os.environ.get("VLLM_RELOAD_GLOBAL_MANIFEST", "warn")
-        if manifest_gate != "off":
-            report = check_global_storage()
-            if report is not None and not report.is_clean:
-                msg = ("Reload rebound module-level storage that was live "
-                       "when graphs were captured:\n" + report.format())
-                if manifest_gate == "strict":
-                    raise RuntimeError(
-                        msg + "\nSet VLLM_RELOAD_GLOBAL_MANIFEST=warn to "
-                        "downgrade.")
-                logger.warning(msg)
-            elif report is not None:
-                logger.debug("Global storage manifest clean (%d checked)",
-                             report.checked)
+                else:
+                    # load weights from kernel format
+                    logger.warning_once(
+                        "Reloading with `is_checkpoint_format=True` requires that "
+                        "weights be in kernel format and already sharded",
+                    )
+                    loaded_weights = set()
+                    for name, loaded_weight in weights_iterator:
+                        param = model.get_parameter(name)  # TODO: buffers?
+                        param.copy_(loaded_weight)
+                        loaded_weights.add(name)
 
         # logging and validation
         counter_after_reloading = time.perf_counter()

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -4,6 +4,7 @@
 import functools
 import gc
 import itertools
+import os
 import threading
 import time
 from collections import defaultdict
@@ -5480,25 +5481,57 @@ class GPUModelRunner(
                 Iterable[tuple[str, torch.Tensor]], weights_iterator
             )
 
+        # Commit-gate snapshot: every arena slot a captured graph may hold.
+        from vllm.model_executor.reload_arena import (
+            snapshot_model_arenas, verify_model_arenas)
+        arena_snaps = snapshot_model_arenas(model)
+
         # begin loading weights
         logger.info_once("Reloading weights inplace...")
-        if is_checkpoint_format:
-            # load weights from checkpoint/ original model format
-            initialize_layerwise_reload(model)
-            loaded_weights = model.load_weights(weights_iterator)
-            finalize_layerwise_reload(model, self.model_config)
+        # The config context must span post-load processing: PWAL rebuild
+        # paths (e.g. QuantFP8 CustomOp construction) read the global config,
+        # and reload runs outside the startup context that initial loading
+        # had. Boundary-wide context rather than per-field snapshots so new
+        # config consumers stay covered.
+        with set_current_vllm_config(self.vllm_config):
+            if is_checkpoint_format:
+                # load weights from checkpoint/ original model format
+                initialize_layerwise_reload(model)
+                loaded_weights = model.load_weights(weights_iterator)
+                finalize_layerwise_reload(model, self.model_config)
 
-        else:
-            # load weights from kernel format
-            logger.warning_once(
-                "Reloading with `is_checkpoint_format=True` requires that "
-                "weights be in kernel format and already sharded",
-            )
-            loaded_weights = set()
-            for name, loaded_weight in weights_iterator:
-                param = model.get_parameter(name)  # TODO: buffers?
-                param.copy_(loaded_weight)
-                loaded_weights.add(name)
+            else:
+                # load weights from kernel format
+                logger.warning_once(
+                    "Reloading with `is_checkpoint_format=True` requires that "
+                    "weights be in kernel format and already sharded",
+                )
+                loaded_weights = set()
+                for name, loaded_weight in weights_iterator:
+                    param = model.get_parameter(name)  # TODO: buffers?
+                    param.copy_(loaded_weight)
+                    loaded_weights.add(name)
+
+        # Commit gate: refuse to serve if any graph-visible slot moved,
+        # vanished, or changed layout. Same-weights output checks cannot
+        # catch this (stale allocations stay bit-identical until reclaimed),
+        # so identity is checked directly and failure is closed.
+        arena_problems = verify_model_arenas(model, arena_snaps)
+        if arena_problems:
+            gate = os.environ.get("VLLM_RELOAD_GATE", "strict")
+            msg = ("Reload violated graph-visible storage identity on "
+                   f"{len(arena_problems)} slot(s):\n  " +
+                   "\n  ".join(arena_problems[:20]))
+            if gate == "off":
+                pass
+            elif gate == "warn":
+                logger.warning(msg)
+            else:
+                raise RuntimeError(
+                    msg + "\nCaptured CUDA graphs may reference freed or "
+                    "stale storage; serving would risk corruption or an "
+                    "illegal memory access. Set VLLM_RELOAD_GATE=warn to "
+                    "downgrade (unsafe).")
 
         # logging and validation
         counter_after_reloading = time.perf_counter()

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -1202,6 +1202,10 @@ class Worker(WorkerBase):
         try:
             self.weight_transfer_engine.update_weights(update_info)
         except BaseException:
+            try:
+                self.weight_transfer_engine.abort_weight_update()
+            except BaseException:
+                logger.exception("Failed to abort weight update after receive failure")
             self._weight_update_active = False
             raise
 
@@ -1215,8 +1219,10 @@ class Worker(WorkerBase):
                 "finish_weight_update called without a matching start_weight_update."
             )
 
-        self.weight_transfer_engine.finish_weight_update()
-        self._weight_update_active = False
+        try:
+            self.weight_transfer_engine.finish_weight_update()
+        finally:
+            self._weight_update_active = False
 
     def shutdown(self) -> None:
         gc.unfreeze()


### PR DESCRIPTION
## Summary

This draft introduces a model-wide checkpoint reload transaction and switches filesystem checkpoint reload plus NCCL/CUDA IPC weight transfer away from layerwise completion accounting.

The lifecycle is:

```text
start
  -> retain serving Parameter/Buffer bindings and storage
  -> restore checkpoint-format bindings
update(chunk) x N
  -> model.load_weights(chunk)
  -> no PWAL and no numel-based completion
finish
  -> run model-wide process_weights_after_loading(force=True)
  -> validate the complete runtime tensor schema
  -> copy processed values into the original runtime storage
  -> restore serving bindings
```

`finish_weight_update()` is the only completion boundary. Partial updates and packed-buffer chunks can call `model.load_weights()` an arbitrary number of times within the same transaction.

## Motivation

Layerwise reload couples correctness to layer boundaries, loader wrapping, checkpoint order, and per-layer element-count accounting. That becomes fragile for fused/sharded parameters, packed transfer buffers, online quantization, MoE, and model-wide derived state.

The modelwise path keeps routing model-owned: existing `model.load_weights()` implementations still perform checkpoint-name mapping, TP/EP sharding, fused QKV/gate-up/expert loading, and custom weight-loader dispatch. Post-load conversion is deferred to one explicit model-wide commit.

## Design

- Record checkpoint-format Parameter/Buffer metadata after construction and before initial loading/PWAL.
- Preserve tied tensor aliases and original checkpoint weight loaders.
- Skip non-persistent buffers, which are runtime state rather than checkpoint state. This is required for caches such as RoPE `cos_sin_cache`.
- Retain all serving runtime bindings during the transaction.
- Restore and materialize temporary checkpoint-format bindings at `start()`.
- Accept multiple unpacked or packed chunks through repeated `model.load_weights()` calls.
- At `finish()`, rerun quantization, Attention/MLA, and HPC post-load hooks once.
- Validate shape/dtype before commit, then copy into the original runtime storages.
- Abort and restore old bindings after receive/load failures.
- Invalidate prefix cache after a successful synchronous or asynchronous transfer update.

The existing kernel/runtime-format path remains a direct in-place copy path when tensors are already processed and sharded.

## NCCL and IPC

Both engines now own a `ModelwiseReloadSession`:

- `start_weight_update()` opens the transaction;
- `update_weights()` only receives/unpacks and loads checkpoint chunks;
- `finish_weight_update()` performs PWAL and commits;
- `abort_weight_update()` discards temporary checkpoint state.

No NCCL/IPC code uses `load_numel`, `load_numel_total`, or packed-buffer boundaries to infer model completion.

## Correctness details

- Runtime Parameter/Buffer Python identity and storage addresses remain stable.
- Tied Parameter aliases remain tied.
- Non-persistent buffers remain bound throughout reload.
- Quantization/model-specific derived state is rebuilt by the normal model-wide PWAL sequence.
- Receive failures abort the active session.
- Prefix cache is reset after the new weight version is committed.

## Validation

### Local focused tests

```text
20 passed, 33 deselected
```

Covered modelwise transaction behavior, multiple arbitrary chunks, explicit-finish PWAL, abort, tied aliases, non-persistent buffers, worker failure cleanup, storage identity, and cache invalidation.

Additional checks:

```text
ruff: passed
git diff --check: passed
```

### H200 end-to-end BF16 -> online FP8

Used the existing local Qwen3-0.6B checkpoint in offline mode; no model was downloaded.

| Backend | Transfer mode | Result |
|---|---|---|
| CUDA IPC | four partial update calls | Pass |
| CUDA IPC | 384 MiB packed buffers, three chunks | Pass |
| NCCL | four partial update calls | Pass |
| NCCL | one API update, three internal packed chunks | Pass |

For all four cases:

- intermediate model state remained the BF16 checkpoint schema;
- PWAL ran only at explicit finish;
- runtime identity change count was zero;
- updated inference tokens exactly matched a cold-loaded FP8 model (`[16, 3]`).

The broader validation matrix also covered online FP8 per-tensor/block/channel, online INT8 weight-only, online MXFP8, compressed-tensors FP8/W4A16/W4A8 MoE, GPTQ/AutoGPTQ/GPTQ-Marlin, and INT8 MoE experts through filesystem modelwise reload.

## Relationship to open work / duplicate check

This is not intended to duplicate the following open PRs:

- #49201 introduces a broad `WeightLoadSession` lifecycle across initial loading and reload paths. This draft is narrower in API scope but materially different in implementation: it restores a whole-model checkpoint binding graph, removes layerwise/numel completion from NCCL and IPC, and commits processed values into retained runtime storage.
- #42823 makes direct post-init `model.load_weights()` safe by wrapping it in the existing layerwise pipeline. This draft instead keeps `model.load_weights()` checkpoint-focused and places reload transaction semantics in a separate modelwise reloader.
- #49459 adds a direct fast path for layout-identical tensors while retaining layerwise fallback. This draft targets checkpoint/runtime-layout-changing updates and replaces the fallback lifecycle for the covered paths.
- #49789 provides the ReloadArena/storage-identity foundation used by this branch. This draft is stacked on that work and should be rebased or retargeted after its review outcome.

The implementation also relates to RFC #48312. Issue comments and open PRs were checked before opening this draft.

## Dependency and base

This branch is currently stacked on #49789 and uses the same `releases/v0.25.1` base to keep the prototype executable against that reload-arena implementation. The draft therefore temporarily includes the dependency commits. It is not ready to merge as-is; the final branch must be rebased after the dependency and overlapping lifecycle discussions are resolved.

## Scope still under discussion

- Whether modelwise metadata reflection should become an explicit model/quantization reload-state interface.
- Peak memory: modelwise reload temporarily holds the serving runtime schema, checkpoint staging schema, and PWAL workspace.
- Whether full/partial checkpoint completeness manifests should be validated at finish.
- Final removal of legacy layerwise metadata and exports after migration coverage is complete.

## AI assistance

AI assistance was used to analyze the reload lifecycle, implement the prototype, write tests and documentation, and run the reported checks. The human submitter is responsible for reviewing every changed line, reproducing the tests, and defending the design end-to-end before this draft is marked ready for review.