### PR TITLE
[qwen3] correct linear_attn norm parameter dtype to F32

### DIFF
--- a/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
@@ -466,6 +466,7 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
             norm_before_gate=True,
             activation=output_gate_type,
             device=current_platform.current_device(),
+            dtype=torch.float32,  # 与 HF checkpoint 的 fp32 保持一致
         )
 
         self.out_proj = RowParallelLinear(


### PR DESCRIPTION



## Purpose
For Qwen 3.5 series (Gated Delta Net) models, the parameter `language_model.model.layers.{i}.linear_attn.norm.weight` is stored in **fp32** in the [HF checkpoint](https://huggingface.co/Qwen/Qwen3.5-27B/tree/main?show_file_info=model.safetensors.index.json), but vLLM currently allocates it in **bf16** (for bf16 models) and silently casts the loaded values into it. 
If this is used with offline sharded state, the pre-sharded chedckpoints norm layer will use bf16, so the sharded checkpoint deviates from the original fp32 weight.

However, Qwen 3.6 series, the linear_attn.norm weight is stored in `bf16`. 

We need to differentiates the two series and use the correct dtype.

## Test Plan
Tested manually with offline pre shard command:
```
python examples/features/sharded_state/save_sharded_state_offline.py --model ~/.cache/huggingface/hub/models--Qwen--Qwen3.6-27B/snapshots/6a9e13bd6fc8f0983b9b99948120bc37f49c13e9 --output /home/sharded_weigts --max-num-seqs 512 --tensor-parallel-size 2 --max-file-size 1073741824
```

the sharded output norm layer is F32.

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

