### PR TITLE
Fix DCP write amplification: decouple namespace factor from put_step

### DIFF
--- a/tests/v1/kv_connector/unit/test_mooncake_store_worker.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_worker.py
@@ -2585,6 +2585,42 @@ def test_dcp_gqa_put_step_rank_wraps_within_put_step():
         assert expected_psr < 2, f"tp{tp} put_step_rank overflow"
 
 
+def test_dcp_mamba_no_phantom_namespaces():
+    """Mamba (factor=1) under DCP: rank_namespaces must produce exactly
+    tp_size entries (one per rank), not tp_size * dcp_size.  Phantom
+    namespaces would break the all()-based lookup."""
+    from vllm.v1.kv_cache_interface import (
+        KVCacheGroupSpec,
+        MambaSpec,
+    )
+
+    worker = _make_bare_worker(block_size=16)
+    worker.tp_size = 8
+    worker.num_kv_head = 1
+    worker.dcp_size = 2
+    mamba = MambaSpec(
+        block_size=16,
+        shapes=((1, 1),),
+        dtypes=(torch.float32,),
+        mamba_cache_mode="align",
+    )
+    worker._kv_cache_groups = [KVCacheGroupSpec(["mamba"], mamba)]
+    worker.token_dbs = [
+        ChunkedTokenDatabase(
+            KeyMetadata("test-model", 0, 0, 0, 0, group_id=0),
+            block_size=16,
+        )
+    ]
+    _refresh_group_tp_replication_factors(worker)
+
+    prefixes = worker._lookup_key_prefixes[0]
+    assert len(prefixes) == 8, f"Expected 8 Mamba namespaces, got {len(prefixes)}"
+    dcp_ranks = [p.split("@dcp")[1].split("@")[0] for p in prefixes]
+    assert sorted(dcp_ranks) == ["0", "0", "0", "0", "1", "1", "1", "1"], (
+        f"dcp_ranks should be 4×dcp0 + 4×dcp1, got {sorted(dcp_ranks)}"
+    )
+
+
 def test_lookup_partial_prefix_returns_first_hit_length():
     worker = _make_bare_worker()
     worker.store.batch_is_exist.return_value = [1, 1, 0]

--- a/tests/v1/kv_connector/unit/test_mooncake_store_worker.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_worker.py
@@ -2184,6 +2184,7 @@ def _refresh_group_tp_replication_factors(
     worker._group_tp_replication_factors = (
         worker._compute_group_tp_replication_factors()
     )
+    worker._group_put_steps = worker._compute_group_put_steps()
     worker._init_lookup_key_prefixes()
 
 
@@ -2266,9 +2267,9 @@ def test_lookup_key_prefixes_cover_dcp_rank_namespaces():
 
     assert worker._lookup_key_prefixes[0] == (
         "test-model@tp_rank:0@pcp0@dcp0@pp_rank:0@group:0",
-        "test-model@tp_rank:1@pcp0@dcp1@pp_rank:0@group:0",
-        "test-model@tp_rank:2@pcp0@dcp2@pp_rank:0@group:0",
-        "test-model@tp_rank:3@pcp0@dcp3@pp_rank:0@group:0",
+        "test-model@tp_rank:0@pcp0@dcp1@pp_rank:0@group:0",
+        "test-model@tp_rank:0@pcp0@dcp2@pp_rank:0@group:0",
+        "test-model@tp_rank:0@pcp0@dcp3@pp_rank:0@group:0",
     )
 
 
@@ -2471,10 +2472,85 @@ def test_lookup_requires_all_dcp_rank_namespaces():
     assert worker.lookup(16, [b"a0"]) == 0
     assert worker.store.batch_is_exist.call_args.args[0] == [
         "test-model@tp_rank:0@pcp0@dcp0@pp_rank:0@group:0@6130",
-        "test-model@tp_rank:1@pcp0@dcp1@pp_rank:0@group:0@6130",
-        "test-model@tp_rank:2@pcp0@dcp2@pp_rank:0@group:0@6130",
-        "test-model@tp_rank:3@pcp0@dcp3@pp_rank:0@group:0@6130",
+        "test-model@tp_rank:0@pcp0@dcp1@pp_rank:0@group:0@6130",
+        "test-model@tp_rank:0@pcp0@dcp2@pp_rank:0@group:0@6130",
+        "test-model@tp_rank:0@pcp0@dcp3@pp_rank:0@group:0@6130",
     ]
+
+
+def test_dcp_put_step_decouples_factor_from_namespace():
+    """Under DCP, put_step = factor // dcp_size (not tp_size // dcp_size).
+
+    MLA: factor=tp_size → put_step=tp_size//dcp_size (chunks distributed
+    within segment).  Mamba: factor=1 → put_step=1 (each rank independent).
+    GQA: factor=tp_size//num_kv_head → put_step=factor//dcp_size.
+    """
+    from vllm.v1.kv_cache_interface import (
+        FullAttentionSpec,
+        KVCacheGroupSpec,
+        MambaSpec,
+        MLAAttentionSpec,
+    )
+
+    worker = _make_bare_worker(block_size=16)
+    worker.tp_size = 8
+    worker.num_kv_head = 4
+    worker.dcp_size = 2
+    mla = MLAAttentionSpec(block_size=16, num_kv_heads=1, head_size=64, dtype=None)
+    gqa = FullAttentionSpec(block_size=16, num_kv_heads=4, head_size=64, dtype=None)
+    mamba = MambaSpec(
+        block_size=16, shapes=((1, 1),), dtypes=(torch.float32,),
+        mamba_cache_mode="align",
+    )
+    worker._kv_cache_groups = [
+        KVCacheGroupSpec(["mla"], mla),
+        KVCacheGroupSpec(["gqa"], gqa),
+        KVCacheGroupSpec(["mamba"], mamba),
+    ]
+    worker.token_dbs = [
+        ChunkedTokenDatabase(
+            KeyMetadata("test-model", g, 0, 0, 0, group_id=g), block_size=16
+        )
+        for g in range(3)
+    ]
+    _refresh_group_tp_replication_factors(worker)
+
+    assert worker._group_tp_replication_factors == (8, 2, 1)
+    assert worker._group_put_steps == (4, 1, 1)
+
+
+def test_dcp_namespace_shares_within_segment():
+    """Under DCP+MLA, all same-segment ranks share one namespace (tp_rank:0).
+    The dcp_rank field distinguishes segments."""
+    from vllm.v1.kv_cache_interface import (
+        KVCacheGroupSpec,
+        MLAAttentionSpec,
+    )
+
+    worker = _make_bare_worker(block_size=16)
+    worker.tp_size = 8
+    worker.num_kv_head = 1
+    worker.dcp_size = 2
+    mla = MLAAttentionSpec(block_size=16, num_kv_heads=1, head_size=64, dtype=None)
+    worker._kv_cache_groups = [KVCacheGroupSpec(["mla"], mla)]
+    worker.token_dbs = [
+        ChunkedTokenDatabase(
+            KeyMetadata("test-model", 0, 0, 0, 0, group_id=0), block_size=16
+        )
+    ]
+    _refresh_group_tp_replication_factors(worker)
+
+    assert worker._lookup_key_prefixes[0] == (
+        "test-model@tp_rank:0@pcp0@dcp0@pp_rank:0@group:0",
+        "test-model@tp_rank:0@pcp0@dcp1@pp_rank:0@group:0",
+    )
+
+
+def test_pressure_codes_include_transfer_fail():
+    """-800 (TRANSFER_FAIL) triggers pressure skipping alongside -200."""
+    assert worker.MOONCAKE_TRANSFER_FAIL == -800
+    assert worker.MOONCAKE_TRANSFER_FAIL in worker._PRESSURE_CODES
+    assert worker.MOONCAKE_NO_AVAILABLE_HANDLE in worker._PRESSURE_CODES
 
 
 def test_lookup_partial_prefix_returns_first_hit_length():

--- a/tests/v1/kv_connector/unit/test_mooncake_store_worker.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_worker.py
@@ -2499,7 +2499,9 @@ def test_dcp_put_step_decouples_factor_from_namespace():
     mla = MLAAttentionSpec(block_size=16, num_kv_heads=1, head_size=64, dtype=None)
     gqa = FullAttentionSpec(block_size=16, num_kv_heads=4, head_size=64, dtype=None)
     mamba = MambaSpec(
-        block_size=16, shapes=((1, 1),), dtypes=(torch.float32,),
+        block_size=16,
+        shapes=((1, 1),),
+        dtypes=(torch.float32,),
         mamba_cache_mode="align",
     )
     worker._kv_cache_groups = [
@@ -2551,6 +2553,36 @@ def test_pressure_codes_include_transfer_fail():
     assert worker.MOONCAKE_TRANSFER_FAIL == -800
     assert worker.MOONCAKE_TRANSFER_FAIL in worker._PRESSURE_CODES
     assert worker.MOONCAKE_NO_AVAILABLE_HANDLE in worker._PRESSURE_CODES
+
+
+def test_dcp_gqa_put_step_rank_wraps_within_put_step():
+    """GQA (factor < tp_size) under DCP: put_step_rank must wrap with
+    % put_step so every namespace gets full chunk coverage."""
+    from vllm.v1.kv_cache_interface import (
+        FullAttentionSpec,
+        KVCacheGroupSpec,
+    )
+
+    worker = _make_bare_worker(block_size=16)
+    worker.tp_size = 8
+    worker.num_kv_head = 2  # factor = 8 // 2 = 4
+    worker.dcp_size = 2  # put_step = 4 // 2 = 2
+    gqa = FullAttentionSpec(block_size=16, num_kv_heads=2, head_size=64, dtype=None)
+    worker._kv_cache_groups = [KVCacheGroupSpec(["gqa"], gqa)]
+    worker.token_dbs = [
+        ChunkedTokenDatabase(
+            KeyMetadata("test-model", 0, 0, 0, 0, group_id=0), block_size=16
+        )
+    ]
+    _refresh_group_tp_replication_factors(worker)
+
+    assert worker._group_tp_replication_factors == (4,)
+    assert worker._group_put_steps == (2,)
+    # tp4 and tp6 have tp_rank//dcp_size = 2 and 3, which exceed put_step=2.
+    # Without % put_step they would skip all chunks.
+    for tp in (0, 2, 4, 6):
+        expected_psr = (tp // 2) % 2
+        assert expected_psr < 2, f"tp{tp} put_step_rank overflow"
 
 
 def test_lookup_partial_prefix_returns_first_hit_length():

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
@@ -1466,12 +1466,19 @@ class MooncakeStoreWorker:
 
     def _init_lookup_key_prefixes(self) -> None:
         def rank_namespaces(factor: int) -> tuple[tuple[int, int, int, int], ...]:
-            if self.dcp_size > 1:
+            if self.dcp_size > 1 and factor > 1:
                 return tuple(
                     (shard_rank, pcp_rank, dcp_rank, pp_rank)
                     for pcp_rank in range(self.pcp_size)
                     for shard_rank in range(self.tp_size // factor)
                     for dcp_rank in range(self.dcp_size)
+                    for pp_rank in range(self.pp_size)
+                )
+            if self.dcp_size > 1:
+                return tuple(
+                    (shard_rank, pcp_rank, shard_rank % self.dcp_size, pp_rank)
+                    for pcp_rank in range(self.pcp_size)
+                    for shard_rank in range(self.tp_size // factor)
                     for pp_rank in range(self.pp_size)
                 )
             return tuple(

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
@@ -82,6 +82,10 @@ DEFAULT_GLOBAL_SEGMENT_SIZE = 4 * 1024 * 1024 * 1024  # 4 GiB
 DEFAULT_LOCAL_BUFFER_SIZE = 4 * 1024 * 1024 * 1024  # 4 GiB
 
 MOONCAKE_NO_AVAILABLE_HANDLE = -200
+MOONCAKE_TRANSFER_FAIL = -800
+_PRESSURE_CODES = frozenset(
+    (MOONCAKE_NO_AVAILABLE_HANDLE, MOONCAKE_TRANSFER_FAIL)
+)
 _T = TypeVar("_T")
 
 
@@ -477,6 +481,7 @@ class KVCacheStoreSendingThread(KVTransferThread):
         replicate_config: Any = None,
         enable_group_semantics: bool = False,
         supports_group_ids: bool = False,
+        dcp_size: int = 1,
         record_operation: Callable[..., None] | None = None,
     ):
         super().__init__(
@@ -490,6 +495,7 @@ class KVCacheStoreSendingThread(KVTransferThread):
         )
         # Only ranks with identical group bytes may stripe PUTs (e.g., MLA).
         self.group_put_steps = group_put_steps
+        self.dcp_size = dcp_size
         self.coord = coord
         self.kv_role = kv_role
         self.stored_requests: defaultdict[str, int] = defaultdict(int)
@@ -595,7 +601,10 @@ class KVCacheStoreSendingThread(KVTransferThread):
             group_blocks = req_meta.block_ids[g_idx]
             # Distribute across ranks by the same rule as normal chunks.
             put_step = self.group_put_steps[g_idx]
-            put_step_rank = (self.tp_rank + g_idx) % put_step
+            if self.dcp_size > 1 and put_step > 1:
+                put_step_rank = self.tp_rank // self.dcp_size
+            else:
+                put_step_rank = (self.tp_rank + g_idx) % put_step
             # Always include the boundary block: its sub-hash key is written
             # only here, even if normal saves already advanced past it.
             last_block = cdiv(boundary, db.block_size) - 1
@@ -712,7 +721,7 @@ class KVCacheStoreSendingThread(KVTransferThread):
                 len(keys),
                 failed_codes,
             )
-            if MOONCAKE_NO_AVAILABLE_HANDLE in failed_codes:
+            if _PRESSURE_CODES & set(failed_codes):
                 self._mark_request_skipped_for_pressure(req_meta.req_id)
             return False
 
@@ -777,7 +786,10 @@ class KVCacheStoreSendingThread(KVTransferThread):
             for g_idx, db in enumerate(self.token_databases):
                 # Rotate the stride phase per group to balance load across ranks.
                 put_step = self.group_put_steps[g_idx]
-                put_step_rank = (self.tp_rank + g_idx) % put_step
+                if self.dcp_size > 1 and put_step > 1:
+                    put_step_rank = self.tp_rank // self.dcp_size
+                else:
+                    put_step_rank = (self.tp_rank + g_idx) % put_step
                 for start, end, block_hash in db.process_tokens(
                     token_len,
                     req_meta.block_hashes,
@@ -939,7 +951,7 @@ class KVCacheStoreSendingThread(KVTransferThread):
                         keys[0] if keys else "N/A",
                     )
                     if (
-                        MOONCAKE_NO_AVAILABLE_HANDLE in failed_codes
+                        _PRESSURE_CODES & set(failed_codes)
                         and not self._mark_request_skipped_for_pressure(req_id)
                     ):
                         logger.warning(
@@ -1393,6 +1405,9 @@ class MooncakeStoreWorker:
         self._group_tp_replication_factors: tuple[int, ...] = (
             self._compute_group_tp_replication_factors()
         )
+        self._group_put_steps: tuple[int, ...] = (
+            self._compute_group_put_steps()
+        )
         self.token_dbs = [
             ChunkedTokenDatabase(
                 dataclasses.replace(
@@ -1408,8 +1423,6 @@ class MooncakeStoreWorker:
         self._init_lookup_key_prefixes()
 
     def _spec_tp_replication_factor(self, spec: KVCacheSpec) -> int:
-        if self.dcp_size > 1:
-            return 1
         inner_specs = (
             tuple(spec.kv_cache_specs.values())
             if isinstance(spec, UniformTypeKVCacheSpecs)
@@ -1429,22 +1442,42 @@ class MooncakeStoreWorker:
     def _compute_group_tp_replication_factors(self) -> tuple[int, ...]:
         """Return the number of byte-identical TP replicas per cache group.
 
-        DCP and Mamba use 1; MLA uses ``tp_size``; GQA uses
-        ``tp_size // num_kv_head``.
+        MLA uses ``tp_size``; GQA uses ``tp_size // num_kv_head``;
+        Mamba uses 1.  Under DCP the ``dcp_rank`` key field distinguishes
+        segments, so MLA ranks within the same segment still share one
+        namespace.
         """
         return tuple(
             self._spec_tp_replication_factor(group.kv_cache_spec)
             for group in self._kv_cache_groups
         )
 
+    def _spec_put_step(self, spec: KVCacheSpec) -> int:
+        """Chunk-distribution stride for the save thread.
+
+        Under DCP, ranks from different segments hold disjoint token ranges,
+        so ``put_step`` must be ``factor // dcp_size`` to distribute chunks
+        only within a segment.  For Mamba (factor 1) put_step stays 1.
+        """
+        factor = self._spec_tp_replication_factor(spec)
+        if self.dcp_size > 1 and factor > 1:
+            return factor // self.dcp_size
+        return factor
+
+    def _compute_group_put_steps(self) -> tuple[int, ...]:
+        return tuple(
+            self._spec_put_step(group.kv_cache_spec)
+            for group in self._kv_cache_groups
+        )
+
     def _init_lookup_key_prefixes(self) -> None:
         def rank_namespaces(factor: int) -> tuple[tuple[int, int, int, int], ...]:
             if self.dcp_size > 1:
-                # DCP is a TP subdivision: dcp_rank == tp_rank % dcp_size.
                 return tuple(
-                    (tp_rank, pcp_rank, tp_rank % self.dcp_size, pp_rank)
+                    (shard_rank, pcp_rank, dcp_rank, pp_rank)
                     for pcp_rank in range(self.pcp_size)
-                    for tp_rank in range(self.tp_size)
+                    for shard_rank in range(self.tp_size // factor)
+                    for dcp_rank in range(self.dcp_size)
                     for pp_rank in range(self.pp_size)
                 )
             return tuple(
@@ -1563,13 +1596,14 @@ class MooncakeStoreWorker:
                 self.token_dbs,
                 self.block_size,
                 self.tp_rank,
-                self._group_tp_replication_factors,
+                self._group_put_steps,
                 self.kv_role,
                 ready_event_sending,
                 self.enable_kv_events,
                 self.store_replicate_config,
                 enable_group_semantics=self.enable_group_semantics,
                 supports_group_ids=self._supports_group_ids,
+                dcp_size=self.dcp_size,
                 record_operation=self._record_kv_connector_operation,
             )
             self.kv_send_thread.start()

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
@@ -83,9 +83,7 @@ DEFAULT_LOCAL_BUFFER_SIZE = 4 * 1024 * 1024 * 1024  # 4 GiB
 
 MOONCAKE_NO_AVAILABLE_HANDLE = -200
 MOONCAKE_TRANSFER_FAIL = -800
-_PRESSURE_CODES = frozenset(
-    (MOONCAKE_NO_AVAILABLE_HANDLE, MOONCAKE_TRANSFER_FAIL)
-)
+_PRESSURE_CODES = frozenset((MOONCAKE_NO_AVAILABLE_HANDLE, MOONCAKE_TRANSFER_FAIL))
 _T = TypeVar("_T")
 
 
@@ -602,7 +600,7 @@ class KVCacheStoreSendingThread(KVTransferThread):
             # Distribute across ranks by the same rule as normal chunks.
             put_step = self.group_put_steps[g_idx]
             if self.dcp_size > 1 and put_step > 1:
-                put_step_rank = self.tp_rank // self.dcp_size
+                put_step_rank = (self.tp_rank // self.dcp_size) % put_step
             else:
                 put_step_rank = (self.tp_rank + g_idx) % put_step
             # Always include the boundary block: its sub-hash key is written
@@ -787,7 +785,7 @@ class KVCacheStoreSendingThread(KVTransferThread):
                 # Rotate the stride phase per group to balance load across ranks.
                 put_step = self.group_put_steps[g_idx]
                 if self.dcp_size > 1 and put_step > 1:
-                    put_step_rank = self.tp_rank // self.dcp_size
+                    put_step_rank = (self.tp_rank // self.dcp_size) % put_step
                 else:
                     put_step_rank = (self.tp_rank + g_idx) % put_step
                 for start, end, block_hash in db.process_tokens(
@@ -950,10 +948,9 @@ class KVCacheStoreSendingThread(KVTransferThread):
                         len(keys),
                         keys[0] if keys else "N/A",
                     )
-                    if (
-                        _PRESSURE_CODES & set(failed_codes)
-                        and not self._mark_request_skipped_for_pressure(req_id)
-                    ):
+                    if _PRESSURE_CODES & set(
+                        failed_codes
+                    ) and not self._mark_request_skipped_for_pressure(req_id):
                         logger.warning(
                             "Detected Mooncake CPU/disk offloading pressure "
                             "(NO_AVAILABLE_HANDLE); skipping future store "
@@ -1405,9 +1402,7 @@ class MooncakeStoreWorker:
         self._group_tp_replication_factors: tuple[int, ...] = (
             self._compute_group_tp_replication_factors()
         )
-        self._group_put_steps: tuple[int, ...] = (
-            self._compute_group_put_steps()
-        )
+        self._group_put_steps: tuple[int, ...] = self._compute_group_put_steps()
         self.token_dbs = [
             ChunkedTokenDatabase(
                 dataclasses.replace(
@@ -1466,8 +1461,7 @@ class MooncakeStoreWorker:
 
     def _compute_group_put_steps(self) -> tuple[int, ...]:
         return tuple(
-            self._spec_put_step(group.kv_cache_spec)
-            for group in self._kv_cache_groups
+            self._spec_put_step(group.kv_cache_spec) for group in self._kv_cache_groups
         )
 
     def _init_lookup_key_prefixes(self) -> None:


### PR DESCRIPTION
## Purpose

Fix #51386 — `MooncakeStoreConnector` under DCP produces N× write amplification for MLA models (N = `tp_size / dcp_size`).

PR #45371 disabled TP put-striding when `dcp_size > 1` by short-circuiting `_spec_tp_replication_factor` to `return 1` for all groups. This fixed `-704` load failures but introduced a side effect: every rank in the same DCP segment writes identical KV to its own Mooncake namespace, with no chunk distribution (`put_step = 1`). For TP8+DCP2 that's 4 redundant copies of every block.

This PR decouples the two roles that `replication_factor` played:

- **Namespace sharing** (factor): restored to `tp_size` for MLA under DCP — same as non-DCP. The `dcp_rank` field in the key already distinguishes segments.
- **Chunk distribution** (put_step): new `_spec_put_step` returns `factor // dcp_size`, distributing chunks only within a DCP segment.
- **put_step_rank**: `tp_rank // dcp_size` for DCP (segment-local rank index), preserving the original `(tp_rank + g_idx) % put_step` for non-DCP.
- **rank_namespaces**: DCP branch now iterates `(shard_rank × dcp_rank)` instead of all `tp_size` ranks, producing `tp_size // factor × dcp_size` namespaces (2 for MLA under TP8+DCP2).

Also adds `-800` (TRANSFER_FAIL) to the pressure detection set alongside the existing `-200` (NO_AVAILABLE_HANDLE), so transient store pressure skips the batch instead of retrying with a 5-second timeout.

Mamba groups are unaffected — `factor = 1` and `put_step = 1` are preserved via the existing `MambaSpec` check.

## Test Plan

Unit tests in `test_mooncake_store_worker.py`:

```bash
.venv/bin/python -m pytest tests/distributed/kv_transfer/kv_connector/v1/mooncake/store/test_mooncake_store_worker.py -v
```

Updated 2 existing DCP tests to match the new namespace scheme (`tp_rank:0@dcpN` instead of `tp_rank:N@dcpN`). Added 3 new tests:

- `test_dcp_put_step_decouples_factor_from_namespace` — verifies `put_step = factor // dcp_size` while `factor = tp_size` for MLA
- `test_dcp_namespace_shares_within_segment` — verifies same-segment ranks share one namespace
- `test_pressure_codes_include_transfer_fail` — verifies `-800` triggers pressure skip

Production validation on GLM-5.2 (TP8, DCP2, MTP-5, MooncakeStoreConnector `kv_both`, 3× standalone-store pods, 720 GB master):

## Test Result

| Metric | Before | After |
|---|---|---|
| Master memory | 589 GB / 720 GB (82%) | 44–48 GB (6–7%) |
| Eviction cycles | 533 (1 M keys, 2.66 TB) | 0 |
| External prefix cache hit rate | 0% | 43–45% |
| save\_put avg latency | 5014 ms | 85–411 ms |
| save\_put failure rate | 53–99% | 0–3% |
| Write amplification | 4× | 1× |

`ruff check` and `python -m py_compile` pass. Full pytest suite requires GPU + NCCL; ran locally on the target cluster.
