### PR TITLE
[Profiler] Stamp vLLM version/commit into torch profiler trace metadata

### DIFF
--- a/vllm/profiler/wrapper.py
+++ b/vllm/profiler/wrapper.py
@@ -237,11 +237,6 @@ class TorchProfilerWrapper(WorkerProfiler):
             profiler_config.wait_iterations + profiler_config.warmup_iterations - 1,
             0,
         )
-        # Whether the vLLM version metadata has been stamped into the trace.
-        # With a schedule, profiler.start() begins in the WAIT phase where
-        # Kineto is not yet initialized and add_metadata_json is silently
-        # dropped, so stamping is deferred until Kineto is live (see
-        # _maybe_add_version_metadata).
         self._version_metadata_added = False
 
     def _build_profiler_table(
@@ -267,21 +262,14 @@ class TorchProfilerWrapper(WorkerProfiler):
                 print(table, file=f)
 
     def _maybe_add_version_metadata(self) -> None:
-        """Stamp the vLLM version into the trace metadata once Kineto is live.
+        """Stamp the vLLM version (which embeds the git commit) into the trace.
 
-        The setuptools_scm version string embeds the git commit for source
-        installs, so the source locations reported in "Call stack" frames can
-        be pinned to the exact commit that produced the trace.
-
-        add_metadata_json is a no-op until the underlying Kineto profiler is
-        initialized. With a schedule this only happens after the WAIT phase,
-        so this is called every step and stamps exactly once, as soon as the
-        profiler leaves WAIT.
+        add_metadata_json is a no-op until Kineto is initialized, which with a
+        schedule only happens after the WAIT phase, so stamp once it's live.
         """
         if self._version_metadata_added:
             return
-        # self.profiler.profiler is the underlying _KinetoProfile; it is None
-        # while the schedule is still in the WAIT phase.
+        # None while the schedule is still in the WAIT phase.
         if self.profiler.profiler is None:
             return
         try:
@@ -294,15 +282,14 @@ class TorchProfilerWrapper(WorkerProfiler):
             )
         except Exception as e:
             logger.warning("Failed to add vLLM version to profiler metadata: %s", e)
-        # Mark done regardless: on failure, retrying every step would just spam.
+        # Mark done even on failure, to avoid retrying every step.
         self._version_metadata_added = True
 
     @override
     def _start(self) -> None:
         self.profiler.start()
-        # Covers the no-schedule case, where Kineto is live immediately after
-        # start(). With a schedule this is a no-op until WAIT ends and the
-        # per-step call in _profiler_step stamps the metadata.
+        # No-schedule case: Kineto is live immediately. With a schedule this
+        # no-ops and _profiler_step stamps it once WAIT ends.
         self._maybe_add_version_metadata()
 
     @override
@@ -339,8 +326,7 @@ class TorchProfilerWrapper(WorkerProfiler):
         """
         if self._uses_schedule:
             self.profiler.step()
-            # Kineto becomes initialized once the schedule leaves the WAIT
-            # phase; stamp the version metadata as soon as that happens.
+            # Stamp once the schedule leaves WAIT and Kineto is live.
             self._maybe_add_version_metadata()
             # Track warmup steps - only count active steps toward max_iterations
             if self._warmup_steps_remaining > 0:

--- a/vllm/profiler/wrapper.py
+++ b/vllm/profiler/wrapper.py
@@ -237,6 +237,12 @@ class TorchProfilerWrapper(WorkerProfiler):
             profiler_config.wait_iterations + profiler_config.warmup_iterations - 1,
             0,
         )
+        # Whether the vLLM version metadata has been stamped into the trace.
+        # With a schedule, profiler.start() begins in the WAIT phase where
+        # Kineto is not yet initialized and add_metadata_json is silently
+        # dropped, so stamping is deferred until Kineto is live (see
+        # _maybe_add_version_metadata).
+        self._version_metadata_added = False
 
     def _build_profiler_table(
         self,
@@ -260,13 +266,24 @@ class TorchProfilerWrapper(WorkerProfiler):
             with open(profiler_out_file, "w") as f:
                 print(table, file=f)
 
-    @override
-    def _start(self) -> None:
-        self.profiler.start()
-        # Stamp the vLLM version (setuptools_scm string embeds the git commit
-        # for source installs) into the trace metadata so the source locations
-        # in "Call stack" frames can be pinned to the exact commit that
-        # produced the trace.
+    def _maybe_add_version_metadata(self) -> None:
+        """Stamp the vLLM version into the trace metadata once Kineto is live.
+
+        The setuptools_scm version string embeds the git commit for source
+        installs, so the source locations reported in "Call stack" frames can
+        be pinned to the exact commit that produced the trace.
+
+        add_metadata_json is a no-op until the underlying Kineto profiler is
+        initialized. With a schedule this only happens after the WAIT phase,
+        so this is called every step and stamps exactly once, as soon as the
+        profiler leaves WAIT.
+        """
+        if self._version_metadata_added:
+            return
+        # self.profiler.profiler is the underlying _KinetoProfile; it is None
+        # while the schedule is still in the WAIT phase.
+        if self.profiler.profiler is None:
+            return
         try:
             self.profiler.add_metadata_json(
                 "vllm_version", json.dumps(vllm.version.__version__)
@@ -277,6 +294,16 @@ class TorchProfilerWrapper(WorkerProfiler):
             )
         except Exception as e:
             logger.warning("Failed to add vLLM version to profiler metadata: %s", e)
+        # Mark done regardless: on failure, retrying every step would just spam.
+        self._version_metadata_added = True
+
+    @override
+    def _start(self) -> None:
+        self.profiler.start()
+        # Covers the no-schedule case, where Kineto is live immediately after
+        # start(). With a schedule this is a no-op until WAIT ends and the
+        # per-step call in _profiler_step stamps the metadata.
+        self._maybe_add_version_metadata()
 
     @override
     def _stop(self) -> None:
@@ -312,6 +339,9 @@ class TorchProfilerWrapper(WorkerProfiler):
         """
         if self._uses_schedule:
             self.profiler.step()
+            # Kineto becomes initialized once the schedule leaves the WAIT
+            # phase; stamp the version metadata as soon as that happens.
+            self._maybe_add_version_metadata()
             # Track warmup steps - only count active steps toward max_iterations
             if self._warmup_steps_remaining > 0:
                 self._warmup_steps_remaining -= 1

--- a/vllm/profiler/wrapper.py
+++ b/vllm/profiler/wrapper.py
@@ -11,7 +11,6 @@ import torch
 from typing_extensions import override
 
 import vllm.version
-
 from vllm.config import ProfilerConfig
 from vllm.config.profiler import _is_uri_path
 from vllm.logger import init_logger

--- a/vllm/profiler/wrapper.py
+++ b/vllm/profiler/wrapper.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import json
 from abc import ABC, abstractmethod
 from collections.abc import Callable
 from contextlib import nullcontext
@@ -8,6 +9,8 @@ from typing import Literal
 
 import torch
 from typing_extensions import override
+
+import vllm.version
 
 from vllm.config import ProfilerConfig
 from vllm.config.profiler import _is_uri_path
@@ -261,6 +264,20 @@ class TorchProfilerWrapper(WorkerProfiler):
     @override
     def _start(self) -> None:
         self.profiler.start()
+        # Stamp the vLLM version (setuptools_scm string embeds the git commit
+        # for source installs) into the trace metadata so the source locations
+        # in "Call stack" frames can be pinned to the exact commit that
+        # produced the trace.
+        try:
+            self.profiler.add_metadata_json(
+                "vllm_version", json.dumps(vllm.version.__version__)
+            )
+            self.profiler.add_metadata_json(
+                "vllm_version_tuple",
+                json.dumps([str(p) for p in vllm.version.__version_tuple__]),
+            )
+        except Exception as e:
+            logger.warning("Failed to add vLLM version to profiler metadata: %s", e)
 
     @override
     def _stop(self) -> None:


### PR DESCRIPTION
## Summary

Stamps the vLLM version (and version tuple) into the torch profiler trace metadata via `torch.profiler.profile.add_metadata_json`, written right after `profiler.start()` in `TorchProfilerWrapper._start`.

For source installs the setuptools_scm version string embeds the git commit hash, so this effectively records **which commit produced the trace**. Trace consumers can then pin the `file:line` source locations reported in the `"Call stack"` frames (emitted when `with_stack=True`) to the exact vLLM checkout, instead of guessing.

## Details

- Added under `_start()` so it applies to every profiling run, including delayed/scheduled starts.
- Wrapped in a `try/except` that logs a warning — a failure to read the version can never break profiling.
- Values are JSON-encoded as required by `add_metadata_json`.

## Test Plan

- Run a profiling session and inspect the resulting Chrome/Perfetto trace JSON; confirm the top-level metadata contains `vllm_version` and `vllm_version_tuple`.