### PR TITLE
[ROCm][CI] Do not microbatch a prefill batch of mixed cache state

### DIFF
--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -3977,6 +3977,36 @@ class GPUModelRunner(
             else force_uniform_decode
         )
 
+    def _allow_microbatching(
+        self, num_reqs: int, num_scheduled_tokens_np: np.ndarray
+    ) -> bool:
+        """Refuse to microbatch a prefill batch of mixed cache state.
+
+        Splitting a step that mixes extends, which read a cached prefix, with
+        prefills that start from nothing corrupts the generations of every
+        request in the first microbatch, which is what fails
+        test_dbo_dp_ep_gsm8k[deepep_high_throughput] with prefix caching on.
+        The defect itself is not found yet, so run such a step whole; they are
+        rare enough that this costs nothing measurable.
+
+        Vetoing on one rank is safe, since microbatching is agreed collectively
+        across data-parallel ranks and any rank refusing settles it for all.
+        """
+        if self.parallel_config.all2all_backend != "deepep_high_throughput":
+            return True
+        # Extends and prefills in the sense `split_decodes_and_prefills` gives
+        # them: both are longer than a decode, and an extend is the one whose
+        # sequence outruns its query, which here means it has computed tokens.
+        query_lens = num_scheduled_tokens_np[:num_reqs]
+        is_extend_or_prefill = query_lens > (self.reorder_batch_threshold or 1)
+        if not is_extend_or_prefill.any():
+            return True
+        computed = self.input_batch.num_computed_tokens_cpu[:num_reqs]
+        return not (
+            (is_extend_or_prefill & (computed > 0)).any()
+            and (is_extend_or_prefill & (computed == 0)).any()
+        )
+
     def _determine_batch_execution_and_padding(
         self,
         num_tokens: int,
@@ -4320,6 +4350,9 @@ class GPUModelRunner(
                 max_num_scheduled_tokens=max_num_scheduled_tokens,
                 use_cascade_attn=cascade_attn_prefix_lens is not None,
                 num_encoder_reqs=len(scheduler_output.scheduled_encoder_inputs),
+                allow_microbatching=self._allow_microbatching(
+                    num_reqs, num_scheduled_tokens_np
+                ),
             )
 
             logger.debug(


### PR DESCRIPTION
## Purpose

`tests/v1/distributed/test_dbo.py::test_dbo_dp_ep_gsm8k[deepep_high_throughput]` fails in AMD CI
roughly every other run, for example in https://buildkite.com/vllm/amd-ci/builds/11764/list?sid=019fd64e-263c-4898-be6b-e7bebb19af37&tab=output.  It is not a noisy measurement: the outcome is decided when the server starts and then holds for its life, either around 0.65 on GSM8K or around 0.60, with nothing in between. A degraded server truncates part of its generations after four to six tokens, as if those requests never saw the few-shot examples.

The step that decides it is a microbatched prefill that mixes extends, which read a cached prefix,
with a prefill that starts from nothing. Over 31 server starts every degraded start had such a step
and no clean start did. Tagging each question and logging which requests each microbatch holds puts
the damage entirely in the first half of that one step: 22 of 22 and 21 of 21 truncated answers over
two degraded servers, none in the second half and none anywhere else.

This PR runs such a step whole instead of splitting it, and only under the high-throughput backend.
DBO keeps microbatching everything else, both the prefill and the decode path keep overlapping, and
these steps are rare enough that the evaluation does not measurably slow down. Vetoing on one rank is
safe, since ranks agree on microbatching collectively.

**This is a mitigation with a measured trigger, not a fix.** The next section says where the defect
looks to be, and what the measurements already exclude.

## Where the defect looks to be

What is left is state shared per layer between the two microbatches, written during the forward pass
and sized by the longest request in the step, which the first microbatch still needs when the second
overwrites it. Serializing the two with a host-side drain at every phase switch does not help, and
that fits: draining buys ordering, not exclusivity.

Ruled out by measurement, so that nobody repeats it: DeepEP's workspace, since one `deep_ep.Buffer`
per microbatch leaves 4 of 8 starts degraded, and its kernels, since
[ROCm/DeepEP#18](https://github.com/ROCm/DeepEP/pull/18) leaves 5 of 8; contention, since the
host-side drain above was proven on the hot path by counter and 8 against 20 communication CUs give
91 against 90 truncated answers; the cached prefix itself, since per-block KV fingerprints agree
between clean and degraded servers; and MLA attention, since replaying the exact step offline, whole
against split, gives bit-identical KV and outputs within one bf16 ulp, including when the split cuts
inside the long request. The obvious shared scratch is already guarded in-tree as well: metadata
builders are created per ubatch, each clones the prefill backend, and `WorkspaceManager` keeps one
buffer per ubatch slot.

## Test Plan

MI355X (`gfx950`), ROCm 7.2.3, DP=2 with EP, `deepseek-ai/DeepSeek-V2-Lite-Chat`, GSM8K with 256
questions and 5 shots, exactly as the test runs it. Because the outcome is decided per server start,
everything is repeated across restarts rather than within one server, counting answers shorter than
12 tokens alongside accuracy.

## Test Result

Unpatched on current main, of six server starts one fails outright at 0.570 with 22 truncated
answers and one scrapes past at 0.625 with 3, while the other four are clean with none.

With this change, `pytest tests/v1/distributed/test_dbo.py -k high_throughput` passes 10 runs in a
row, 110 to 116 seconds each, which is what the test took before the change. A harness that restarts
the server and records one entry per question adds that no start comes back with a truncated answer
at all, where unpatched starts reach 22.


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

