### PR TITLE
[Bugfix][Model] Validate Kimi-K3 plain FP8 prefill support

### DIFF
--- a/tests/models/kimi_k3/test_mla.py
+++ b/tests/models/kimi_k3/test_mla.py
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from unittest.mock import patch
+
+import pytest
+
+from vllm.models.kimi_k3.nvidia.mla import _validate_plain_fp8_prefill_support
+
+
+@pytest.mark.parametrize("cache_dtype", ["fp8", "fp8_e4m3"])
+def test_plain_fp8_requires_quantization_capable_backend(cache_dtype: str):
+    with (
+        patch(
+            "vllm.models.kimi_k3.nvidia.mla."
+            "backend_supports_prefill_query_quantization",
+            return_value=False,
+        ),
+        pytest.raises(ValueError, match="--kv-cache-dtype bfloat16"),
+    ):
+        _validate_plain_fp8_prefill_support(
+            cache_dtype, use_prefill_query_quantization=True
+        )
+
+
+@pytest.mark.parametrize("cache_dtype", ["fp8", "fp8_e4m3"])
+def test_plain_fp8_requires_prefill_query_quantization(cache_dtype: str):
+    with (
+        patch(
+            "vllm.models.kimi_k3.nvidia.mla."
+            "backend_supports_prefill_query_quantization",
+            return_value=True,
+        ),
+        pytest.raises(ValueError, match="use_prefill_query_quantization"),
+    ):
+        _validate_plain_fp8_prefill_support(
+            cache_dtype, use_prefill_query_quantization=False
+        )
+
+
+@pytest.mark.parametrize("cache_dtype", ["fp8", "fp8_e4m3"])
+def test_plain_fp8_allowed_when_prefill_quantization_is_supported(cache_dtype: str):
+    with patch(
+        "vllm.models.kimi_k3.nvidia.mla.backend_supports_prefill_query_quantization",
+        return_value=True,
+    ):
+        _validate_plain_fp8_prefill_support(
+            cache_dtype, use_prefill_query_quantization=True
+        )
+
+
+@pytest.mark.parametrize("cache_dtype", ["auto", "bfloat16", "fp8_ds_mla"])
+def test_other_cache_dtypes_do_not_require_fp8_prefill(cache_dtype: str):
+    with patch(
+        "vllm.models.kimi_k3.nvidia.mla.backend_supports_prefill_query_quantization",
+        return_value=False,
+    ):
+        _validate_plain_fp8_prefill_support(
+            cache_dtype, use_prefill_query_quantization=False
+        )

--- a/tests/models/kimi_k3/test_mla.py
+++ b/tests/models/kimi_k3/test_mla.py
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from unittest.mock import patch
+
+import pytest
+
+from vllm.models.kimi_k3.nvidia.mla import _validate_plain_fp8_prefill_support
+
+
+@pytest.mark.parametrize("cache_dtype", ["fp8", "fp8_e4m3"])
+def test_plain_fp8_requires_prefill_query_quantization(cache_dtype: str):
+    with (
+        patch(
+            "vllm.models.kimi_k3.nvidia.mla."
+            "backend_supports_prefill_query_quantization",
+            return_value=False,
+        ),
+        pytest.raises(ValueError, match="--kv-cache-dtype fp8_ds_mla"),
+    ):
+        _validate_plain_fp8_prefill_support(cache_dtype)
+
+
+@pytest.mark.parametrize("cache_dtype", ["fp8", "fp8_e4m3"])
+def test_plain_fp8_allowed_when_prefill_quantization_is_supported(cache_dtype: str):
+    with patch(
+        "vllm.models.kimi_k3.nvidia.mla.backend_supports_prefill_query_quantization",
+        return_value=True,
+    ):
+        _validate_plain_fp8_prefill_support(cache_dtype)
+
+
+@pytest.mark.parametrize("cache_dtype", ["auto", "bfloat16", "fp8_ds_mla"])
+def test_other_cache_dtypes_do_not_require_fp8_prefill(cache_dtype: str):
+    with patch(
+        "vllm.models.kimi_k3.nvidia.mla.backend_supports_prefill_query_quantization",
+        return_value=False,
+    ):
+        _validate_plain_fp8_prefill_support(cache_dtype)

--- a/vllm/models/kimi_k3/nvidia/mla.py
+++ b/vllm/models/kimi_k3/nvidia/mla.py
@@ -44,6 +44,9 @@ from vllm.model_executor.layers.attention.attention import (
     set_default_quant_scales,
     should_load_quant_weights,
 )
+from vllm.model_executor.layers.attention.mla_attention import (
+    backend_supports_prefill_query_quantization,
+)
 from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
 from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.model_executor.layers.linear import (
@@ -91,6 +94,20 @@ logger = init_logger(__name__)
 # attention front-end (the GEMM is small and launch-bound, so the overlap
 # hides it); at or above it, run the gate on the main stream.
 _GATE_MULTI_STREAM_TOKEN_THRESHOLD = 512
+
+
+def _validate_plain_fp8_prefill_support(cache_dtype: str) -> None:
+    if (
+        cache_dtype in ("fp8", "fp8_e4m3")
+        and not backend_supports_prefill_query_quantization()
+    ):
+        raise ValueError(
+            "Kimi-K3 plain FP8 KV cache requires FP8 prefill query "
+            "quantization, which is only supported on device capability 100 "
+            "with a compatible MLA prefill backend. Use "
+            "--kv-cache-dtype fp8_ds_mla on Hopper or with other unsupported "
+            "prefill backends."
+        )
 
 
 @torch.compile(backend=current_platform.simple_compile_backend)
@@ -262,6 +279,7 @@ class MultiHeadLatentAttention(nn.Module, AttentionLayerBase):
             self.kv_cache_dtype = cache_config.cache_dtype
         else:
             self.kv_cache_dtype = "auto"
+        _validate_plain_fp8_prefill_support(self.kv_cache_dtype)
 
         dtype = torch.get_default_dtype()
         self.attn_backend = get_attn_backend(

--- a/vllm/models/kimi_k3/nvidia/mla.py
+++ b/vllm/models/kimi_k3/nvidia/mla.py
@@ -53,6 +53,7 @@ from vllm.model_executor.layers.attention.attention import (
 from vllm.model_executor.layers.attention.mla_attention import (
     _get_kv_b_proj_input_dtype,
     accumulate_mla_context_chunk,
+    backend_supports_prefill_query_quantization,
     init_mla_context_partial,
     neutralize_empty_context_partials,
 )
@@ -106,6 +107,29 @@ logger = init_logger(__name__)
 # attention front-end (the GEMM is small and launch-bound, so the overlap
 # hides it); at or above it, run the gate on the main stream.
 _GATE_MULTI_STREAM_TOKEN_THRESHOLD = 512
+
+
+def _validate_plain_fp8_prefill_support(
+    cache_dtype: str, use_prefill_query_quantization: bool
+) -> None:
+    if cache_dtype not in ("fp8", "fp8_e4m3"):
+        return
+    if not use_prefill_query_quantization:
+        raise ValueError(
+            "Kimi-K3 plain FP8 KV cache requires FP8 prefill query "
+            "quantization. Enable --attention-config "
+            "'{\"use_prefill_query_quantization\": true}' on a supported "
+            "Blackwell device and MLA prefill backend, or use an unquantized "
+            "KV cache such as --kv-cache-dtype bfloat16."
+        )
+    if not backend_supports_prefill_query_quantization():
+        raise ValueError(
+            "Kimi-K3 plain FP8 KV cache requires FP8 prefill query "
+            "quantization, which is not supported on this device or with the "
+            "selected MLA prefill backend. Plain FP8 requires device "
+            "capability 100 and a compatible prefill backend; otherwise use "
+            "an unquantized KV cache such as --kv-cache-dtype bfloat16."
+        )
 
 
 @torch.compile(backend=current_platform.simple_compile_backend)
@@ -288,6 +312,11 @@ class MultiHeadLatentAttention(nn.Module, AttentionLayerBase):
             self.kv_cache_dtype = cache_config.cache_dtype
         else:
             self.kv_cache_dtype = "auto"
+        vllm_config = get_current_vllm_config()
+        _validate_plain_fp8_prefill_support(
+            self.kv_cache_dtype,
+            vllm_config.attention_config.use_prefill_query_quantization,
+        )
 
         dtype = torch.get_default_dtype()
         self.attn_backend = get_attn_backend(
@@ -334,7 +363,6 @@ class MultiHeadLatentAttention(nn.Module, AttentionLayerBase):
             self.impl.dcp_rank = 0
         self.q_pad_num_heads = getattr(self.impl, "q_pad_num_heads", None)
 
-        vllm_config = get_current_vllm_config()
         parallel_config = vllm_config.parallel_config
         assert parallel_config.prefill_context_parallel_size == 1, (
             "Kimi-K3 MultiHeadLatentAttention does not support prefill context "


### PR DESCRIPTION
## Purpose

Fixes #51313.

Kimi-K3 plain FP8 KV cache requires an FP8 prefill query. Previously, an
unsupported configuration reached the first prefill and failed with an
assertion that always recommended enabling `use_prefill_query_quantization`.
That advice is ineffective on Hopper or with an incompatible MLA prefill
backend, and it is incomplete when the setting was never enabled.

This change validates both requirements during model initialization:

- `use_prefill_query_quantization` must be enabled.
- The current device and MLA prefill backend must support FP8 queries.

Unsupported configurations now fail before serving starts and recommend an
unquantized KV cache such as `--kv-cache-dtype bfloat16`.

Following feedback on #51313, this PR no longer recommends
`--kv-cache-dtype fp8_ds_mla`: Kimi-K3 uses dense MLA decode backends, which do
not currently accept that cache layout.

## Duplicate Check

I re-ran the required searches for #51313 and Kimi-K3 FP8 prefill support.
PR #50181 is related but complementary: it changes shared MLA prefill backend
selection so a supported Blackwell configuration can honor requested query
quantization. It does not add Kimi-K3 model validation for unsupported devices,
unsupported backends, or a missing query-quantization setting. PRs #51040 and
#51551 cover ROCm FP8 prefill kernel paths rather than this NVIDIA validation.

## Test Plan

- Reject `fp8` and `fp8_e4m3` when prefill query quantization is disabled.
- Reject them when the selected device or prefill backend cannot quantize the
  query.
- Keep supported plain FP8 configurations valid.
- Do not apply the plain-FP8 requirement to other cache dtypes.

## Test Result

- `.venv/bin/python -m pytest --confcutdir=tests/models/kimi_k3 tests/models/kimi_k3/test_mla.py -q`
  -> `9 passed`.
- `ruff-check`, `ruff-format`, `typos`, Python 3.12 `mypy`, `compileall`, and
  `git diff --check` passed for the changed files.
- The branch is rebased onto current `main`.

Model evaluation is not applicable because this changes startup validation for
unsupported configurations; model execution and output are unchanged.

## Impact

- Unsupported Kimi-K3 plain FP8 configurations fail during model
  initialization instead of during the first prefill.
- The affected path is Kimi-K3 NVIDIA MLA only.
- Supported Blackwell plain FP8 configurations remain unchanged.

## AI Assistance

TRAE assisted with implementation, conflict resolution, and testing. I reviewed
every changed line, verified the failure modes and supported configuration
matrix, and approved this update.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose and linked issue are provided.
- [x] Related open PRs and the scope difference are documented.
- [x] Exact tests and results are included.
- [x] AI assistance is disclosed.

</details>
