### PR TITLE
[Bugfix] Do not select Model Runner V2 when weight offloading is enabled

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -68,6 +68,24 @@ def test_v2_model_runner_env_tri_state(monkeypatch, env_value, expected):
     assert envs.VLLM_USE_V2_MODEL_RUNNER is expected
 
 
+def test_v2_model_runner_unsupported_with_weight_offloading():
+    """Weight offloading is not wired in the V2 model runner; it must be
+    reported as unsupported so config selection falls back to V1 (or raises
+    when V2 is forced) instead of silently not offloading."""
+    config = VllmConfig()
+    baseline = config._get_v2_model_runner_unsupported_features()
+    assert not any("offload" in feature for feature in baseline)
+
+    config.offload_config.uva.cpu_offload_gb = 4
+    unsupported = config._get_v2_model_runner_unsupported_features()
+    assert any("offload" in feature for feature in unsupported)
+
+    config.offload_config.uva.cpu_offload_gb = 0
+    config.offload_config.prefetch.offload_group_size = 8
+    unsupported = config._get_v2_model_runner_unsupported_features()
+    assert any("offload" in feature for feature in unsupported)
+
+
 @pytest.mark.parametrize(
     ("use_v2_model_runner", "expected_capture_sizes"),
     [

--- a/vllm/config/offload.py
+++ b/vllm/config/offload.py
@@ -94,6 +94,21 @@ class OffloadConfig:
     prefetch: PrefetchOffloadConfig = Field(default_factory=PrefetchOffloadConfig)
     """Parameters for prefetch offloading backend."""
 
+    def is_enabled(self) -> bool:
+        """Whether any weight offloading is requested.
+
+        Mirrors the backend selection in
+        `vllm.model_executor.offloader.base.create_offloader`: a config is
+        considered enabled iff `create_offloader` would return a non-noop
+        offloader that can actually offload weights.
+        """
+        if self.offload_backend == "auto":
+            return self.prefetch.offload_group_size > 0 or self.uva.cpu_offload_gb > 0
+        if self.offload_backend == "uva":
+            return self.uva.cpu_offload_gb > 0
+        # "prefetch"
+        return self.prefetch.offload_group_size > 0
+
     @model_validator(mode="after")
     def validate_offload_config(self) -> "OffloadConfig":
         """Validate offload configuration constraints."""

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -2298,6 +2298,16 @@ class VllmConfig:
         if self.compilation_config.mode == CompilationMode.STOCK_TORCH_COMPILE:
             unsupported.append("stock torch.compile")
 
+        # The V2 model runner never installs the weight offloader
+        # (set_offloader/create_offloader are only wired in the V1
+        # GPUModelRunner), so offload settings would silently no-op:
+        # the model loads fully on-GPU and typically OOMs. Fall back to
+        # V1 (or raise if V2 is forced) instead.
+        if self.offload_config.is_enabled():
+            unsupported.append(
+                "model weight CPU offloading (--cpu-offload-gb / prefetch offloading)"
+            )
+
         if (
             self.compilation_config.pass_config.enable_sp
             and self.parallel_config.tensor_parallel_size > 1


### PR DESCRIPTION
## Purpose

Fix the silent no-op of model weight CPU offloading (`--cpu-offload-gb`, prefetch offload) when the V2 GPU model runner is selected. Fixes #51396.

The offloader singleton defaults to `NoopOffloader` and only the V1 runner installs a real one (`vllm/v1/worker/gpu_model_runner.py:980`); the V2 runner never calls `set_offloader`, so `make_layers()` wraps layers with the noop and nothing is offloaded — no log line, no warning. For workloads that need offloading (model bigger than VRAM) the result is an OOM whose message suggests unrelated remedies. Several architectures now default to V2 (`DeepseekV2ForCausalLM`, `Qwen2MoeForCausalLM`, …), so plain `vllm serve deepseek-ai/DeepSeek-V2-Lite-Chat --cpu-offload-gb 12` hits this with no V2 flag involved.

This PR takes the conservative route: declare weight offloading unsupported by V2 in `_get_v2_model_runner_unsupported_features()` (plus an `OffloadConfig.is_enabled()` helper mirroring `create_offloader`'s backend selection), so that:

- default model-runner selection **falls back to V1** (where offloading works), with the existing "Model Runner V2 does not yet support …" warning;
- forcing `VLLM_USE_V2_MODEL_RUNNER=1` (or configs that force V2: dspark, PCP, diffusion) **raises a clear error** instead of silently not offloading. For those forced-V2 configs offloading genuinely does not work today, so a loud error is strictly better than the current silent no-op followed by OOM.

Wiring the offloader into V2 (parity with V1) is the better end state — the V2 cudagraph utilities already call `get_offloader().sync_prev_onload()` hooks — but that deserves its own validated change; this PR stops the silent failure now. Happy to follow up with the V2 wiring (and can test it on SM120 hardware) if that direction is preferred.

## Test Plan

- New unit test `test_v2_model_runner_unsupported_with_weight_offloading` (UVA and prefetch variants; asserts no offload entry in the baseline feature list).
- `pytest tests/test_config.py -k "offload or v2_model_runner"`.
- GPU before/after on RTX 5090 (32 GB, SM120, driver 610.57.04): DeepSeek-V2-Lite-Chat BF16 (29.26 GiB checkpoint), `cpu_offload_gb=12`, `enforce_eager`, default runner selection.

## Test Result

- `22 passed` for `pytest tests/test_config.py -k "offload or v2_model_runner"`.
- Before (main `8d9b52f7c2`): `Using V2 Model Runner` → `Model loading took 29.35 GiB` → no "Total CPU offloaded parameters" line → OOM (does not fit).
- After (this PR, same command): `WARNING … Model Runner V2 does not yet support model weight CPU offloading (--cpu-offload-gb / prefetch offloading); using the V1 model runner instead.` → `Total CPU offloaded parameters: 12.13` → `Model loading took 17.21 GiB`.
- Control on an unmodified recent build (Qwen3.5-4B-FP8, `cpu_offload_gb=2`): V2 loads 5.35 GiB with no offload line; V1 loads 3.29 GiB with `Total CPU offloaded parameters: 2.01` — confirming the underlying no-op this PR guards against.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DmTegASpyEG2T8zB5BZYTw
