### PR TITLE
[ROCm][CI][Bugfix] Do not microbatch a step that splits a prefix from its writer

### DIFF
--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -3977,6 +3977,51 @@ class GPUModelRunner(
             else force_uniform_decode
         )
 
+    def _allow_microbatching(
+        self, num_reqs: int, num_scheduled_tokens_np: np.ndarray
+    ) -> bool:
+        """Refuse to microbatch a step that splits a prefix from its writer.
+
+        A request can be admitted on a prefix cache hit against blocks another
+        request in the same batch is only computing now. Run whole, the step
+        issues every KV cache write before any attention read and the hit
+        holds; split, a reader in the first half would attend over blocks the
+        writer in the second half has not filled in yet. Vetoing on one rank
+        settles it for all, since ranks agree on microbatching collectively.
+        """
+        if not self.parallel_config.use_ubatching or num_reqs < 2:
+            return True
+        computed = self.input_batch.num_computed_tokens_cpu[:num_reqs]
+        query_lens = num_scheduled_tokens_np[:num_reqs]
+        # A decode reads nothing it was not already given in an earlier step.
+        readers = np.flatnonzero(
+            (query_lens > (self.reorder_batch_threshold or 1)) & (computed > 0)
+        )
+        if readers.size == 0:
+            return True
+
+        for block_table in self.input_batch.block_table.block_tables:
+            block_size = block_table.block_size
+            table = block_table.get_numpy_array()
+            start = computed // block_size
+            stop = (computed + query_lens + block_size - 1) // block_size
+            span = int((stop - start).max())
+            columns = start[:, None] + np.arange(span)[None, :]
+            written = np.unique(
+                np.take_along_axis(
+                    table[:num_reqs],
+                    np.minimum(columns, table.shape[1] - 1),
+                    axis=1,
+                )[columns < stop[:, None]]
+            )
+            for reader in readers:
+                # Whole blocks only: a reader ends inside a partly filled one,
+                # which is private to it and which it fills before reading.
+                whole = computed[reader] // block_size
+                if np.isin(table[reader, :whole], written).any():
+                    return False
+        return True
+
     def _determine_batch_execution_and_padding(
         self,
         num_tokens: int,
@@ -4320,6 +4365,9 @@ class GPUModelRunner(
                 max_num_scheduled_tokens=max_num_scheduled_tokens,
                 use_cascade_attn=cascade_attn_prefix_lens is not None,
                 num_encoder_reqs=len(scheduler_output.scheduled_encoder_inputs),
+                allow_microbatching=self._allow_microbatching(
+                    num_reqs, num_scheduled_tokens_np
+                ),
             )
 
             logger.debug(


### PR DESCRIPTION
## Purpose

`tests/v1/distributed/test_dbo.py::test_dbo_dp_ep_gsm8k[deepep_high_throughput]` fails in AMD CI
roughly every other run. It is not a noisy measurement:
the outcome is decided when the server starts and then holds for its life, either around 0.65 on
GSM8K or around 0.60, with nothing in between. A degraded server truncates part of its generations
after four to six tokens, as if those requests never saw the few-shot examples.

They never did. A request can be admitted on a prefix cache hit against blocks that another request
in the same batch is only computing now, since those blocks are hashed and handed out while that
other request is being scheduled. Run whole, the step issues every KV cache write before any
attention read and the hit holds. Microbatching runs the two halves one after the other, so when
the writer sits in the second half the readers in the first half attend over blocks that are still
zero. In this test the first step of every evaluation is exactly that batch: one request computing
the shared 5-shot preamble of 672 tokens next to requests holding a cache hit on it. Which half the
writer lands in is fixed by arrival order at startup, which is why the verdict is fixed too.

## The change

Refuse to microbatch a step in which one request reads blocks another request writes in that same
step, and run it whole instead, through the `allow_microbatching` hook that already exists.
Everything else keeps microbatching, and decode steps leave the check before touching a block
table. The condition is not specific to a backend or a vendor, so the check is not gated on either;
the same symptom is tracked on Blackwell in
[#29913](https://github.com/vllm-project/vllm/pull/29913), where the test is marked xfail. Vetoing
on one rank settles it for all, since ranks agree on microbatching collectively.

## Evidence

An audit in the KV cache update op, which runs before a half writes anything, recorded per half the
blocks it writes, the blocks it reads as computed context, how many of those are still empty right
then and how many change afterwards. In the deciding step the first half reads 42 blocks, the
preamble at a block size of 16, finds all 42 empty, and all 42 change later. How many of those 42
the second half is the one to write predicts the outcome over eight starts without exception: the
five starts where it owned all 42 are the five that failed, and the three where it owned fewer or
none are the three that passed.

## Test Plan

DP=2 with EP, `deepseek-ai/DeepSeek-V2-Lite-Chat`, GSM8K with 256 questions and 5 shots, exactly as
the test runs it. Because the outcome is decided per server start, everything is repeated across
restarts rather than within one server, counting answers shorter than 12 tokens alongside accuracy.

## Test Result

Unpatched on current main, of six server starts one fails outright at 0.570 with 22 truncated
answers and one scrapes past at 0.625 with 3, while the other four are clean.

With this change, `pytest tests/v1/distributed/test_dbo.py -k high_throughput` passes 10 of 10 runs
and takes as long as it did unpatched. Across eight restarts no start comes back with a truncated
answer, where unpatched starts reach 22, and the audit reports no half left reading a block the
other half owns.


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

