### PR TITLE
[Bugfix] Pin quack-kernels before FA4 AST regression

### DIFF
--- a/requirements/cuda.txt
+++ b/requirements/cuda.txt
@@ -26,7 +26,7 @@ fastsafetensors >= 0.3.3
 
 # QuACK and Cutlass DSL for FA4 (cute-DSL implementation)
 nvidia-cutlass-dsl[cu13]==4.6.0
-quack-kernels>=0.6.1  # Required for CUTLASS DSL 4.6 by MSA
+quack-kernels==0.6.1  # 0.6.2/0.6.3 break FA4 constexpr branches
 
 # Tokenspeed_MLA for faster mla with spec decode
 tokenspeed-mla==0.1.8; platform_system == "Linux"


### PR DESCRIPTION
Pin `quack-kernels` to 0.6.1 to restore FA4 compatibility.

  QuACK 0.6.2 and 0.6.3 install a process-wide CuTeDSL AST rewrite for mixed static/dynamic `constexpr` branches. With vLLM’s CUTLASS DSL 4.6.0 kernels, this produces `TYPE_UNSTABLE_JOIN` errors across the B200
  attention, Inkling, and batch-invariance suites.

  Version 0.6.2 cannot resolve with CUTLASS DSL 4.6.0, but 0.6.3 relaxed its dependency constraint and was selected by vLLM’s existing `quack-kernels>=0.6.1` requirement. Pinning 0.6.1 restores the dependency
  combination used by the previously passing CI image.

I used GPT 5.6 Sol