### PR TITLE
[Bugfix] Pad assertion error in truncate_computed_blocks due to lagging mamba lookup

### DIFF
--- a/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
+++ b/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
@@ -11,6 +11,7 @@ import torch
 
 from tests.v1.core.test_prefix_caching import make_kv_cache_manager, make_request
 from vllm.utils.hashing import sha256
+from vllm.v1.core.kv_cache_manager import KVCacheBlocks
 from vllm.v1.core.kv_cache_utils import (
     KVCacheBlockCopy,
     get_block_hash,
@@ -588,6 +589,65 @@ def test_truncate_computed_blocks_preserves_sparse_prefix_positions():
     assert [len(group) for group in truncated.blocks] == [2, 1]
     assert truncated.blocks[1][0].is_null
     assert [len(group) for group in blocks.blocks] == [3, 2]
+
+
+def test_truncate_computed_blocks_pads_lagging_mamba_align_group():
+    """A connector's external hit can reach past what the mamba "align" lookup
+    returned, leaving that group with fewer blocks than the truncation point
+    needs. The missing recurrent positions become null placeholders (the
+    connector allocates and fills the final state slot) instead of tripping an
+    assert and killing the engine."""
+    hash_block_size = 2
+    kv_cache_config = KVCacheConfig(
+        num_blocks=24,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["full"],
+                FullAttentionSpec(
+                    block_size=hash_block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                ),
+            ),
+            KVCacheGroupSpec(
+                ["mamba"],
+                MambaSpec(
+                    block_size=2 * hash_block_size,
+                    shapes=(1, 1),
+                    dtypes=(torch.float32,),
+                    mamba_cache_mode="align",
+                ),
+            ),
+        ],
+    )
+    manager = make_kv_cache_manager(
+        kv_cache_config=kv_cache_config,
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=hash_block_size,
+    )
+    producer = make_request("producer", [0, 0, 1, 1, 2, 2], hash_block_size, sha256)
+    blocks, num_computed, _ = manager.get_computed_blocks(producer)
+    assert manager.allocate_slots(producer, 6, num_computed, blocks) is not None
+    manager.free(producer)
+    manager.new_step_starts()
+
+    consumer = make_request(
+        "consumer", [0, 0, 1, 1, 2, 2, 3, 3], hash_block_size, sha256
+    )
+    blocks, num_computed, _ = manager.get_computed_blocks(consumer)
+    assert num_computed == 6
+
+    # The mamba group lags the full-attention hit the connector reported.
+    lagging = KVCacheBlocks((blocks.blocks[0], ()))
+    truncated = manager.truncate_computed_blocks(lagging, 4)
+
+    assert [len(group) for group in truncated.blocks] == [2, 1]
+    assert truncated.blocks[1][0].is_null
+    # Pure view: the caller's groups are not mutated.
+    assert [len(group) for group in lagging.blocks] == [3, 0]
 
 
 def test_hybrid_mamba_partial_tail_owner_continue_preserves_later_hit():

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -20,6 +20,7 @@ from vllm.v1.kv_cache_interface import (
     CrossAttentionSpec,
     EncoderOnlyAttentionSpec,
     KVCacheConfig,
+    MambaSpec,
     get_kv_cache_spec_kind,
     get_kv_cache_spec_sliding_window,
 )
@@ -779,7 +780,10 @@ class KVCacheManager:
     ) -> KVCacheBlocks:
         """Return a lookup-result view truncated at an aligned token endpoint.
 
-        Pure slicing: refcounts are untouched and ``blocks`` is not mutated.
+        Mamba align lookups can lag the full-attention hit used by a connector.
+        Missing recurrent positions are represented by null placeholders; the
+        connector allocates and fills the final state slot. Refcounts are
+        untouched and ``blocks`` is not mutated.
         """
         truncated: list[list[KVCacheBlock]] = []
         for group_blocks, manager in zip(
@@ -789,8 +793,15 @@ class KVCacheManager:
         ):
             assert num_computed_tokens % manager.block_size == 0
             num_blocks = num_computed_tokens // manager.block_size
-            assert num_blocks <= len(group_blocks)
-            truncated.append(list(group_blocks[:num_blocks]))
+            if num_blocks <= len(group_blocks):
+                truncated.append(list(group_blocks[:num_blocks]))
+                continue
+
+            spec = manager.kv_cache_spec
+            assert isinstance(spec, MambaSpec) and spec.mamba_cache_mode == "align"
+            padded = list(group_blocks)
+            padded.extend([self.block_pool.null_block] * (num_blocks - len(padded)))
+            truncated.append(padded)
         return self.create_kv_cache_blocks(tuple(truncated))
 
     def take_new_block_ids(self) -> list[int]:


### PR DESCRIPTION
## Purpose
Fix assertion error `assert num_blocks <= len(group_blocks)` when running Mamba with KV offloading, in which Mamba align lookups can lag the full-attention hit used by a connector.
```
 ERROR 08-07 08:40:11 [core.py:1345] EngineCore encountered a fatal error.
 ERROR 08-07 08:40:11 [core.py:1345] Traceback (most recent call last):
 ERROR 08-07 08:40:11 [core.py:1345]   File "/vllm/v1/engine/core.py", line 1336, in run_engine_core
 ERROR 08-07 08:40:11 [core.py:1345]     engine_core.run_busy_loop()
 ERROR 08-07 08:40:11 [core.py:1345]   File "/vllm/v1/fault_tolerance/engine_core_sentinel.py", line 179, in run_with_fault_tolerance
 ERROR 08-07 08:40:11 [core.py:1345]     busy_loop_func(self)
 ERROR 08-07 08:40:11 [core.py:1345]   File "/vllm/v1/engine/core.py", line 1380, in run_busy_loop
 ERROR 08-07 08:40:11 [core.py:1345]     self._process_engine_step()
 ERROR 08-07 08:40:11 [core.py:1345]   File "/vllm/v1/engine/core.py", line 1433, in _process_engine_step
 ERROR 08-07 08:40:11 [core.py:1345]     outputs, model_executed = self.step_fn()
 ERROR 08-07 08:40:11 [core.py:1345]                               ^^^^^^^^^^^^^^
 ERROR 08-07 08:40:11 [core.py:1345]   File "/vllm/v1/engine/core.py", line 649, in step_with_batch_queue
 ERROR 08-07 08:40:11 [core.py:1345]     scheduler_output = self.scheduler.schedule(self._should_throttle_prefills())
 ERROR 08-07 08:40:11 [core.py:1345]                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ERROR 08-07 08:40:11 [core.py:1345]   File "/vllm/v1/core/sched/scheduler.py", line 806, in schedule
 ERROR 08-07 08:40:11 [core.py:1345]     self.kv_cache_manager.truncate_computed_blocks(
 ERROR 08-07 08:40:11 [core.py:1345]   File "/vllm/v1/core/kv_cache_manager.py", line 792, in truncate_computed_blocks
 ERROR 08-07 08:40:11 [core.py:1345]     assert num_blocks <= len(group_blocks)
 ERROR 08-07 08:40:11 [core.py:1345]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ERROR 08-07 08:40:11 [core.py:1345] AssertionError
```

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

