### PR TITLE
[Bugfix] LoRA: normalize fused lora_a/lora_b in merged set_lora

### DIFF
--- a/tests/lora/test_layers.py
+++ b/tests/lora/test_layers.py
@@ -1077,6 +1077,74 @@ def test_merged_column_parallel_variable_slice(
         torch.testing.assert_close(lora_result, expected_result, rtol=rtol, atol=atol)
 
 
+@torch.inference_mode()
+@pytest.mark.parametrize("repeats", [2, 3])
+@pytest.mark.parametrize("fully_shard", [True, False])
+@pytest.mark.parametrize("device", DEVICES)
+def test_column_parallel_packed_single_tensor_lora_a(
+    default_vllm_config, dist_init, repeats, fully_shard, device
+) -> None:
+    """A fused source (e.g. Megatron, which stores QKV as one linear) hands
+    set_lora a single lora_a shared by every slice, rather than the per-slice
+    list an ordinary PEFT checkpoint produces. It must be replicated per slice,
+    not indexed row-wise -- lora_a[i] on a 2-D [rank, input] tensor yields a
+    1-D row and blows up downstream.
+    """
+    if current_platform.is_cuda_alike() or current_platform.is_xpu():
+        torch.accelerator.set_device_index(device)
+
+    max_loras = 1
+    rank = 8
+    torch.set_default_device(device)
+    lora_config = LoRAConfig(
+        max_loras=max_loras,
+        max_lora_rank=rank,
+        fully_sharded_loras=fully_shard,
+        lora_dtype=torch.float16,
+    )
+
+    if repeats == 2:
+        linear = MergedColumnParallelLinear(
+            4096, [4096] * repeats, bias=False, params_dtype=torch.float16
+        )
+        lora_linear = (
+            MergedColumnParallelLinearWithShardedLoRA(linear)
+            if fully_shard
+            else MergedColumnParallelLinearWithLoRA(linear)
+        )
+    else:
+        linear = QKVParallelLinear(4096, 64, 32, bias=False, params_dtype=torch.float16)
+        lora_linear = (
+            MergedQKVParallelLinearWithShardedLoRA(linear)
+            if fully_shard
+            else MergedQKVParallelLinearWithLoRA(linear)
+        )
+    lora_linear.create_lora_weights(max_loras, lora_config)
+
+    # slice_lora_a() -- where the fully-sharded variants index lora_a -- sits
+    # behind `if self.tp_size > 1`, so a single-process test would skip it.
+    # Force the branch: tp_rank stays 0 and the buffers were sized for tp=1,
+    # so both slice_lora_a() and slice_lora_b() select the full width and the
+    # expected values below are unchanged.
+    lora_linear.tp_size = 2
+
+    lora_a = torch.rand(rank, 4096, dtype=torch.float16, device=device)
+    lora_b = [
+        torch.rand(size, rank, dtype=torch.float16, device=device)
+        for size in lora_linear.output_slices
+    ]
+    lora_linear.set_lora(0, lora_a, lora_b)
+
+    # The shared lora_a must land intact in every slice's stacked buffer.
+    for i in range(lora_linear.n_slices):
+        torch.testing.assert_close(
+            lora_linear.lora_a_stacked[i][0, 0, :rank, :4096], lora_a
+        )
+        torch.testing.assert_close(
+            lora_linear.lora_b_stacked[i][0, 0, : lora_b[i].shape[0], :rank], lora_b[i]
+        )
+
+
 @pytest.mark.parametrize("tp_size", [1, 2, 4, 8])
 @pytest.mark.parametrize(
     "seed", list(range(VOCAB_PARALLEL_EMBEDDING_TEST_NUM_RANDOM_SEEDS))

--- a/tests/lora/test_layers.py
+++ b/tests/lora/test_layers.py
@@ -1082,6 +1082,83 @@ def test_merged_column_parallel_variable_slice(
         torch.testing.assert_close(lora_result, expected_result, rtol=rtol, atol=atol)
 
 
+@torch.inference_mode()
+@pytest.mark.parametrize("repeats", [2, 3])
+@pytest.mark.parametrize("fully_shard", [True, False])
+@pytest.mark.parametrize("single_a", [True, False])
+@pytest.mark.parametrize("single_b", [True, False])
+@pytest.mark.parametrize("device", DEVICES)
+def test_column_parallel_packed_fused_lora_weights(
+    default_vllm_config, dist_init, repeats, fully_shard, single_a, single_b, device
+) -> None:
+    """set_lora must accept fused (single-tensor) lora_a and/or lora_b.
+
+    An ordinary PEFT checkpoint stores q/k/v separately and the loader
+    assembles per-slice lists. A *fused* source -- e.g. Megatron, which stores
+    QKV as one linear -- produces one lora_a of shape [rank, input_size] shared
+    by every slice, and one lora_b of shape [sum(output_sizes), rank] covering
+    all of them. Both are declared inputs; indexing them as if they were
+    per-slice lists yields a 1-D row and raises IndexError.
+    """
+    if current_platform.is_cuda_alike() or current_platform.is_xpu():
+        torch.accelerator.set_device_index(device)
+
+    max_loras = 1
+    rank = 8
+    torch.set_default_device(device)
+    lora_config = LoRAConfig(
+        max_loras=max_loras,
+        max_lora_rank=rank,
+        fully_sharded_loras=fully_shard,
+        lora_dtype=torch.float16,
+    )
+
+    if repeats == 2:
+        linear = MergedColumnParallelLinear(
+            4096, [4096] * repeats, bias=False, params_dtype=torch.float16
+        )
+        lora_linear = (
+            MergedColumnParallelLinearWithShardedLoRA(linear)
+            if fully_shard
+            else MergedColumnParallelLinearWithLoRA(linear)
+        )
+    else:
+        linear = QKVParallelLinear(4096, 64, 32, bias=False, params_dtype=torch.float16)
+        lora_linear = (
+            MergedQKVParallelLinearWithShardedLoRA(linear)
+            if fully_shard
+            else MergedQKVParallelLinearWithLoRA(linear)
+        )
+    lora_linear.create_lora_weights(max_loras, lora_config)
+
+    # slice_lora_a()/slice_lora_b() sit behind `if self.tp_size > 1`, so a
+    # single-process test would skip them. Force the branch: tp_rank stays 0
+    # and the buffers were sized for tp=1, so both select the full width and
+    # the expected values below are unchanged.
+    lora_linear.tp_size = 2
+
+    output_sizes = lora_linear.output_sizes
+    a = torch.rand(rank, 4096, dtype=torch.float16, device=device)
+    lora_a = a if single_a else [a.clone() for _ in range(lora_linear.n_slices)]
+
+    b_slices = [
+        torch.rand(size, rank, dtype=torch.float16, device=device)
+        for size in output_sizes
+    ]
+    lora_b = torch.cat(b_slices, dim=0) if single_b else b_slices
+
+    lora_linear.set_lora(0, lora_a, lora_b)
+
+    # The shared lora_a lands intact in every slice; lora_b is split per slice.
+    for i in range(lora_linear.n_slices):
+        torch.testing.assert_close(
+            lora_linear.lora_a_stacked[i][0, 0, :rank, :4096], a
+        )
+        torch.testing.assert_close(
+            lora_linear.lora_b_stacked[i][0, 0, : output_sizes[i], :rank], b_slices[i]
+        )
+
+
 @pytest.mark.parametrize("tp_size", [1, 2, 4, 8])
 @pytest.mark.parametrize(
     "seed", list(range(VOCAB_PARALLEL_EMBEDDING_TEST_NUM_RANDOM_SEEDS))

--- a/vllm/lora/layers/column_parallel_linear.py
+++ b/vllm/lora/layers/column_parallel_linear.py
@@ -307,6 +307,13 @@ class MergedColumnParallelLinearWithLoRA(ColumnParallelLinearWithLoRA):
     ):
         self.reset_lora(index)
 
+        # A fused source (e.g. Megatron, which stores QKV as one linear) hands
+        # over a single lora_a shared by every slice. Replicate it so the code
+        # below -- and expand_packed_lora's zip -- see one entry per group.
+        if isinstance(lora_a, torch.Tensor):
+            n = len(lora_b) if isinstance(lora_b, list) else self.n_slices
+            lora_a = [lora_a] * n
+
         # Expand packed adapter groups when they don't match n_slices.
         # E.g. in_proj_qkv (covers Q+K+V) + in_proj_z as 2 groups for a
         # 4-slice layer: split b_qkv by output_sizes and replicate a_qkv.

--- a/vllm/lora/layers/column_parallel_linear.py
+++ b/vllm/lora/layers/column_parallel_linear.py
@@ -326,6 +326,21 @@ class MergedColumnParallelLinearWithLoRA(ColumnParallelLinearWithLoRA):
     ):
         self.reset_lora(index)
 
+        # A fused source (e.g. Megatron, which stores QKV as one linear) hands
+        # over a single lora_a shared by every slice and a single lora_b
+        # covering all of them. Split b by output_sizes and replicate a -- the
+        # same normalization MergedColumnParallelLinearVariableSliceWithLoRA
+        # already applies. Normalize b first so the a count below matches.
+        if isinstance(lora_b, torch.Tensor):
+            split_b, start = [], 0
+            for size in self.output_sizes:
+                split_b.append(lora_b[start : start + size])
+                start += size
+            lora_b = split_b
+        if isinstance(lora_a, torch.Tensor):
+            n = len(lora_b) if isinstance(lora_b, list) else self.n_slices
+            lora_a = [lora_a] * n
+
         # Expand packed adapter groups when they don't match n_slices.
         # E.g. in_proj_qkv (covers Q+K+V) + in_proj_z as 2 groups for a
         # 4-slice layer: split b_qkv by output_sizes and replicate a_qkv.


### PR DESCRIPTION
## Purpose

Fixes #51409.

> **AI assistance disclosure** (per the [contributing guide](https://docs.vllm.ai/en/latest/contributing/)): this PR includes AI-generated code. The fix and the regression test were drafted with Claude Code; the reproduction, the before/after test runs, and the environment collection were carried out and reviewed under my direction. The commit carries a `Co-authored-by: Claude` trailer.

`MergedColumnParallelLinearWithLoRA.set_lora()` declares both weights as `torch.Tensor | list[torch.Tensor]` but normalizes neither into per-slice lists. A **fused** source — e.g. Megatron, which stores QKV as one linear — produces:

- one `lora_a` of shape `[rank, input_size]`, shared by every slice
- one `lora_b` of shape `[sum(output_sizes), rank]`, covering all slices

Indexing either as if it were a per-slice list yields a 1-D **row**, so `slice_lora_a`, `slice_lora_b` and the `set_lora` copy loop all raise `IndexError`.

### Measured scope

On `0.28.1rc1.dev388+g8a728663c` at real tp=2, **12 of 16** combinations of
`{fused QKV, gate_up} × {fully_sharded_loras T/F} × {lora_a fused/list} × {lora_b fused/list}` fail:

```
[FAIL] a=single b=list    -> slice_lora_a   too many indices for tensor of dimension 1
[FAIL] a=list   b=single  -> slice_lora_b   too many indices for tensor of dimension 1
[FAIL] a=single b=single  -> slice_lora_a   too many indices for tensor of dimension 1
[PASS] a=list   b=list
```

The two defects are **independent**: a fused `lora_b` fails on its own, even with a well-formed per-slice `lora_a`. That was previously masked because `slice_lora_a` runs first and crashed before `slice_lora_b` was reached. Thanks to @linitra24 for catching this — an earlier revision of this PR normalized only `lora_a` and left 8 of 16 still failing.

Note two of the crash sites are outside the `if self.tp_size > 1` guard, so **TP=1 is affected too**.

### How fused weights reach `set_lora`

An ordinary PEFT checkpoint stores q/k/v separately and the loader assembles per-slice lists — which is why this is unseen in normal serving. Adapters loaded **from disk cannot reach it at all**: `worker_manager._load_adapter()` builds `expected_lora_modules` by expanding packed modules into their constituents, so a checkpoint targeting the fused name (`qkv_proj`) is rejected by `check_unexpected_modules()` with a clean `ValueError`. I verified that separately.

The route is the **in-memory** path: an RL trainer pushes weights via `add_lora`, bypassing the loader. verl monkey-patches `_load_adapter` and calls `LoRAModel.from_lora_tensors(...)` directly, so none of that validation applies. Syncing a Megatron actor there kills the rollout worker on the first weight sync.

## Fix

Split `lora_b` by `output_sizes` and replicate `lora_a` — the same normalization `MergedColumnParallelLinearVariableSliceWithLoRA.set_lora()` already applies in this file, under the comment *"Override to handle single tensor weights"*.

Two details:
- `lora_b` is normalized **first**, so the `lora_a` count matches in both the fused and packed-group cases.
- the count is `len(lora_b)`, **not** `n_slices` — `expand_packed_lora()` zips `lora_a` against `lora_b`'s *groups*, so expanding to `n_slices` first would mis-pair A with B on layers like `in_proj_qkv` + `in_proj_z` (silently wrong weights rather than a crash).

**This cannot regress the list path.** It engages only when a weight arrives as a bare tensor, which raises `IndexError` unconditionally today.

Distinct from #37019, which generalizes `slice_lora_a` to arbitrary N but does not touch the base class's `set_lora`.

## Test Plan

All runs on the official nightly image `vllm/vllm-openai:nightly-aarch64` (vLLM `0.28.1rc1.dev388+g8a728663c`, 4× GB300, driver 620.16).

1. Standalone repro at real TP=2 over the 16-combination matrix above. Builds the linear layers plus the LoRA wrapper and calls `set_lora`; loads no model, runs no kernel.
2. `tests/lora/test_layers.py`, before and after, including the new parametrized regression test.

## Test Result

Standalone matrix at tp=2: **12/16 fail before, 0/16 fail after.**

New regression test `test_column_parallel_packed_fused_lora_weights` (32 params on 2 GPUs, 16 on one):

| | Before | After |
|---|---|---|
| failed | 24 | 0 |
| passed | 8 | 32 |

The 8 passing before are exactly the `a=list b=list` controls.

Full `tests/lora/test_layers.py` with the fix: **195 passed, 144 skipped, 0 failed.**

The test is parametrized over `single_a` × `single_b` and asserts the contents of both `lora_a_stacked` and `lora_b_stacked`, so it catches an incorrect *split* as well as a crash. The fully-sharded sites live behind `if self.tp_size > 1`, so the test forces that branch by setting `tp_size = 2` on the layer; `tp_rank` stays 0 and the buffers are sized for tp=1, so both slice functions select the full width and the assertions are unchanged. This is commented in the test.
