### PR TITLE
[Build] Skip precompiled wheel fetch during metadata hooks

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -78,6 +78,10 @@ def has_precompiled_rust_extensions() -> bool:
     return not get_missing_precompiled_rust_extension_modules()
 
 
+def is_metadata_only_build() -> bool:
+    return bool({"egg_info", "dist_info"}.intersection(sys.argv[1:]))
+
+
 if sys.platform.startswith("darwin") and VLLM_TARGET_DEVICE != "cpu":
     logger.warning("VLLM_TARGET_DEVICE automatically set to `cpu` due to macOS")
     VLLM_TARGET_DEVICE = "cpu"
@@ -1218,8 +1222,8 @@ def add_vllm_package_data(filename: str) -> None:
         vllm_files.append(filename)
 
 
-# If using precompiled artifacts, extract and patch package_data in advance.
-if USE_PRECOMPILED_RUST_FRONTEND:
+# PEP 517 invokes setup.py for metadata before invoking the actual build.
+if USE_PRECOMPILED_RUST_FRONTEND and not is_metadata_only_build():
     wheel_url, download_filename = precompiled_wheel_utils.determine_wheel_url()
     patch = precompiled_wheel_utils.extract_precompiled_and_patch_package(
         wheel_url,


### PR DESCRIPTION
## Purpose

`VLLM_USE_PRECOMPILED=1 uv pip install --editable .` invokes `setup.py` for `egg_info`, `dist_info`, and the actual editable build. Because precompiled-wheel setup ran at module scope, each phase could resolve, download, and extract the same wheel.

Skip precompiled artifact setup for the two metadata-only commands. The actual wheel build path is unchanged.

This does not duplicate an open PR. I searched open PRs for precompiled editable-wheel, metadata, and caching work. #50216 only fixes the `nightly` commit override.

AI assistance was used to profile and prepare this change. The submitter should review the one-file diff and validation before marking the PR ready.

## Test Plan

```bash
pre-commit run --files setup.py

env VLLM_USE_PRECOMPILED=1 \
  VLLM_PRECOMPILED_WHEEL_LOCATION=/tmp/vllm-precompiled-profile/fake-precompiled.whl \
  SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0 \
  uv pip install --python /tmp/vllm-precompiled-profile-isolated/venv/bin/python \
  --no-deps --editable /tmp/vllm-precompiled-profile-isolated -v
```

## Test Result

- All applicable pre-commit hooks passed.
- `uv` still invoked all three PEP 517 hooks, but wheel access and extraction dropped from three passes to one.
- The editable installation completed successfully.
- Model evaluation is not applicable because this only changes packaging behavior.
