### PR TITLE
[Perf] Narrow DeepSeek V3.2 eager CUDA graph region

### DIFF
--- a/vllm/models/deepseek_v32/amd/rocm.py
+++ b/vllm/models/deepseek_v32/amd/rocm.py
@@ -66,6 +66,35 @@ class DeepseekV32MLAAttention(DeepseekV32Attention):
         self._fp8_kv = is_quantized_kv_cache(self.kv_cache_dtype)
         self._fp8_kv_needs_view = self._fp8_kv and self.kv_cache_dtype != "fp8_ds_mla"
 
+    def forward(  # type: ignore[override]
+        self,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+    ) -> torch.Tensor:
+        qkv_lora = self.fused_qkv_a_proj(hidden_states)[0]
+        q_c, kv_c, k_pe = qkv_lora.split(
+            [self.q_lora_rank, self.kv_lora_rank, self.qk_rope_head_dim], dim=-1
+        )
+
+        if self.indexer is not None and not self.skip_topk:
+            kw = self.indexer.wk_weights_proj(hidden_states)[0]
+            index_k = kw[:, : self.indexer.head_dim]
+            index_weights = kw[:, self.indexer.head_dim :]
+        else:
+            index_k = None
+            index_weights = None
+
+        num_tokens = hidden_states.shape[0]
+        output = torch.empty(
+            (num_tokens, self.num_local_heads * self.v_head_dim),
+            dtype=hidden_states.dtype,
+            device=hidden_states.device,
+        )
+        self._fused_attention(
+            positions, q_c, kv_c, k_pe, index_k, index_weights, output
+        )
+        return self.o_proj(output)[0]
+
     def _compute_ql_nope(self, q_c: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
         q = self.q_b_proj(q_c)[0].view(-1, self.num_local_heads, self.qk_head_dim)
         q_nope, q_pe = q.split([self.qk_nope_head_dim, self.qk_rope_head_dim], dim=-1)

--- a/vllm/models/deepseek_v32/attention.py
+++ b/vllm/models/deepseek_v32/attention.py
@@ -343,22 +343,6 @@ class DeepseekV32Attention(MLAAttention):
             dtype=hidden_states.dtype,
             device=hidden_states.device,
         )
-        self._fused_attention(
-            positions, q_c, kv_c, k_pe, index_k, index_weights, output
-        )
-        return self.o_proj(output)[0]
-
-    @eager_break_during_capture
-    def _fused_attention(
-        self,
-        positions: torch.Tensor,
-        q_c: torch.Tensor,
-        kv_c: torch.Tensor,
-        k_pe: torch.Tensor,
-        index_k: torch.Tensor | None,
-        index_weights: torch.Tensor | None,
-        output: torch.Tensor,
-    ) -> None:
         forward_context = get_forward_context()
         attn_metadata_raw = forward_context.attn_metadata
         if isinstance(attn_metadata_raw, dict):
@@ -452,6 +436,26 @@ class DeepseekV32Attention(MLAAttention):
             quantize_mqa=self._fp8_query,
         )
 
+        self._sparse_indexer_and_attn(
+            q_c,
+            index_q_fp8,
+            index_weights_out,
+            ql_nope,
+            mqa_q,
+            output,
+        )
+        return self.o_proj(output)[0]
+
+    @eager_break_during_capture
+    def _sparse_indexer_and_attn(
+        self,
+        q_c: torch.Tensor,
+        index_q_fp8: torch.Tensor | None,
+        index_weights_out: torch.Tensor | None,
+        ql_nope: torch.Tensor,
+        mqa_q: torch.Tensor,
+        output: torch.Tensor,
+    ) -> None:
         if self.indexer is not None and not self.skip_topk:
             sparse_attn_indexer(
                 q_c,
@@ -476,6 +480,14 @@ class DeepseekV32Attention(MLAAttention):
                 skip_topk_buffer_clear=True,
             )
 
+        attn_metadata_raw = get_forward_context().attn_metadata
+        if isinstance(attn_metadata_raw, dict):
+            attn_metadata = attn_metadata_raw.get(self.layer_name)
+        elif isinstance(attn_metadata_raw, list):
+            attn_metadata = attn_metadata_raw[0].get(self.layer_name)
+        else:
+            attn_metadata = attn_metadata_raw
+
         if attn_metadata is None:
             output.zero_()
             return
@@ -494,6 +506,10 @@ class DeepseekV32Attention(MLAAttention):
         attn_out, _ = self.impl.forward_mqa(  # type: ignore[attr-defined]
             mqa_q_arg, kv_cache, attn_metadata, self
         )
+
+        # NOTE(woosuk): While the below does not need to be in the eager region,
+        # we put it here to avoid copying the attention output. Move this back to the
+        # captured region once forward_mqa supports `out` argument.
         x = attn_out.view(
             num_actual, self.num_local_heads, self.kv_lora_rank
         ).transpose(0, 1)


### PR DESCRIPTION
## Purpose

The portable DeepSeek-V3.2 attention path currently decorates the entire fused attention method with `eager_break_during_capture`. Only the sparse indexer and backend `forward_mqa` call require that eager boundary, so query preparation, fused norm/RoPE, and other graph-safe work are replayed as direct launches on every layer.

This change:

- inlines the graph-safe part of `_fused_attention` into `forward`;
- narrows the eager region to `_sparse_indexer_and_attn`;
- keeps the UV projection in the eager region so it can consume the backend-owned attention output without an extra copy;
- preserves the existing broad eager path for the ROCm subclass.

A one-request kernel trace showed 333 fewer direct launches while retaining 79 CUDA graph launches. The launches moved into graphs were 78 fused norm/RoPE kernels, 78 W_UK BMMs, 99 query/indexer GEMMs, and 78 fused-Q kernels.

### Non-duplication

I searched open PRs for DeepSeek-V3.2/GLM CUDA graph, sparse-indexer, and `eager_break_during_capture` changes. Related PRs such as #50005 (NVIDIA DCP correctness), #47355 (indexer side-stream overlap), and #47335 (ROCm fused indexer-Q) address different paths or concerns. None narrows the eager-break boundary in the portable DeepSeek-V3.2 attention implementation.

## Test Plan

- Run the focused breakable-CUDA-graph tests.
- Run all applicable pre-commit hooks on both changed files.
- Serve GLM-5.2-NVFP4 with dummy weights through the portable model override and Rust frontend using TP4/EP4, FP8 KV cache, prefix caching disabled, and the default CUDA graph mode.
- Measure TTFT with 256 sequential requests after 8 warmups, each with an 8-token prompt and one output token.
- Profile the kernel launch trace.
- Compare the no-copy implementation against an alternative that copies the backend attention output into a static buffer and captures the UV BMM.

## Test Result

```text
.venv/bin/python -m pytest tests/v1/cudagraph/test_breakable_cudagraph.py -q
14 passed, 18 warnings in 5.90s

pre-commit run --files \
  vllm/models/deepseek_v32/attention.py \
  vllm/models/deepseek_v32/amd/rocm.py
All applicable hooks passed.
```

GLM-5.2 TTFT, Rust frontend, dummy weights, TP4/EP4, concurrency 1, prefix caching disabled:

| Variant | Mean TTFT | Median TTFT | p99 TTFT | Throughput |
| --- | ---: | ---: | ---: | ---: |
| Current main | 57.42 ms | 56.99 ms | 60.89 ms | 17.39 req/s |
| This change | 28.72 ms | 28.65 ms | 30.76 ms | 34.74 req/s |

All 256 requests completed successfully in both runs.

An explicit PIECEWISE-only comparison found that copying the attention output and capturing the UV BMM was another 7.43% faster than the no-copy form (26.51 ms versus 28.64 ms mean TTFT). However, that variant failed with OOM during the FULL capture phase of the default `FULL_AND_PIECEWISE` initialization. This PR retains the no-copy form, which successfully initializes in the default mode and does not require backend output-buffer support.

The refactor does not change the attention equations or checkpoint loading, so no model-quality evaluation was required.

## AI assistance

OpenAI Codex assisted with implementation, kernel-trace analysis, benchmarking, validation orchestration, and drafting this description. The human submitter must review every changed line and be able to explain and defend the eager-boundary and backend-output trade-offs before marking this PR ready for review.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR is described.
- [x] The test plan is provided.
- [x] The test results and before/after comparison are provided.
- [x] No documentation update is needed for this internal execution-path refactor.
</details>

