### PR TITLE
[Bugfix][models_multimodal] Remote HF python code misses importing class

### DIFF
--- a/tests/models/multimodal/conftest.py
+++ b/tests/models/multimodal/conftest.py
@@ -6,8 +6,17 @@ import os
 import warnings
 
 import torch
+import torch.nn.functional as F
 
 from vllm.platforms import current_platform
+
+# openbmb/MiniCPM-Llama3-V-2_5's remote ``resampler.py`` annotates with ``List``
+# without importing it, relying on the alias leaking from
+# ``from torch.nn.functional import *``. Recent torch uses builtin generics and no
+# longer re-exports the typing aliases, so executing that module raises NameError.
+# TODO: Remove once the checkpoint fixes its imports.
+if not hasattr(F, "List"):
+    F.List = list
 
 
 def pytest_configure(config):


### PR DESCRIPTION
## Purpose
Merging of https://github.com/vllm-project/vllm/pull/48413 introduced two independent runtime errors in the Multi-Modal Models (Extended Generation 3) test group [(CI 11817).](https://buildkite.com/vllm/amd-ci/builds/11817/list?sid=019fdb73-af39-413d-b679-96797be923e1&tab=output): 

1. **NameError**: name 'List' is not defined
2. **AttributeError**: 'MiniCPMV' object has no attribute 'all_tied_weights_keys'

This PR aims to resolve the first one. The other bug will be fixed in another PR.

The root cause was that a remote HF python file [resampler.py](https://huggingface.co/openbmb/MiniCPM-Llama3-V-2_5/blob/main/resampler.py) defined a function with a returning value of a List without importing that class into the module.

## Test Plan

pytest -v -s "models/multimodal/generation/test_common.py::test_single_image_models[minicpmv_25-test_case100]"
pytest -v -s "models/multimodal/generation/test_common.py::test_single_image_models[minicpmv_25-test_case101]"
pytest -v -s "models/multimodal/generation/test_common.py::test_single_image_models[minicpmv_25-test_case102]"

## Test Result

**Before**:

FAILED models/multimodal/generation/test_common.py::test_single_image_models[minicpmv_25-test_case100] - NameError: name 'List' is not defined
FAILED models/multimodal/generation/test_common.py::test_single_image_models[minicpmv_25-test_case101] - NameError: name 'List' is not defined
FAILED models/multimodal/generation/test_common.py::test_single_image_models[minicpmv_25-test_case102] - NameError: name 'List' is not defined

**After**:
Passed

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>


