### PR TITLE
fix(utils): preserve false values in YAML config

### DIFF
--- a/tests/utils_/test_argparse_utils.py
+++ b/tests/utils_/test_argparse_utils.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 # ruff: noqa
 
+import argparse
 import json
 import os
 
@@ -43,6 +44,9 @@ def parser_with_config():
     parser.add_argument("--port", type=int)
     parser.add_argument("--tensor-parallel-size", type=int)
     parser.add_argument("--trust-remote-code", action="store_true")
+    parser.add_argument(
+        "--nullable-toggle", action=argparse.BooleanOptionalAction, default=None
+    )
     return parser
 
 
@@ -124,6 +128,28 @@ def test_config_args(parser_with_config, cli_config_file):
     )
     assert args.tensor_parallel_size == 2
     assert args.trust_remote_code
+
+
+def test_config_false_preserves_boolean_optional_value(parser_with_config, tmp_path):
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text("nullable_toggle: false\n")
+
+    args = parser_with_config.parse_args(
+        ["serve", "mymodel", "--config", str(config_file)]
+    )
+
+    assert args.nullable_toggle is False
+
+
+def test_config_false_omits_store_true_flag(parser_with_config, tmp_path):
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text("trust-remote-code: false\n")
+
+    args = parser_with_config.parse_args(
+        ["serve", "mymodel", "--config", str(config_file)]
+    )
+
+    assert args.trust_remote_code is False
 
 
 def test_config_file(parser_with_config):

--- a/vllm/utils/argparse_utils.py
+++ b/vllm/utils/argparse_utils.py
@@ -573,6 +573,10 @@ class FlexibleArgumentParser(ArgumentParser):
             if isinstance(value, bool):
                 if value:
                     processed_args.append("--" + key)
+                else:
+                    normalized_key = key.replace("_", "-")
+                    if "--no-" + normalized_key in self._option_string_actions:
+                        processed_args.append("--no-" + normalized_key)
             elif isinstance(value, list):
                 if value:
                     processed_args.append("--" + key)


### PR DESCRIPTION
Fixes #51401.

## Summary

YAML boolean values were converted to CLI flags only when `true`. A YAML `false` was silently omitted, which incorrectly preserved later tri-state defaults for options such as `enable-flashinfer-autotune`.

This change emits `--no-<key>` only when the parser exposes that BooleanOptionalAction form. Existing `store_true` flags continue to omit `false`, preserving their current semantics.

## Testing

- Isolated parser regression checks pass for dash and underscore config keys.
- `python -m py_compile vllm/utils/argparse_utils.py tests/utils_/test_argparse_utils.py` passes using the review virtual environment.
- The targeted pytest file was attempted but the local environment lacks the vLLM/PyTorch test dependency stack; no GPU was available or required for this parser-only change.
- No model evaluation is applicable.

## Duplicate-work check

`gh issue view 51401` and open-PR searches for issue `51401` and the argparse/YAML area found no existing PR addressing this fix.

AI assistance was used for repository exploration and implementation; the changed lines and behavior have been reviewed manually.
