### PR TITLE
[Bugfix] Drop stale layer kwarg from online MXFP4 kernel creation (fix precommit)

### DIFF
--- a/vllm/model_executor/layers/quantization/online/mxfp4.py
+++ b/vllm/model_executor/layers/quantization/online/mxfp4.py
@@ -254,7 +254,6 @@ class Mxfp4OnlineMoEMethod(OnlineMoEMethodBase):
                 mxfp4_backend=self.mxfp4_backend,
                 experts_cls=self.experts_cls,
                 routing_tables=layer._expert_routing_tables(),
-                layer=layer,
             )
 
     def get_fused_moe_quant_config(


### PR DESCRIPTION
#49610 removed the layer parameter from make_mxfp4_moe_kernel, but #49347 landed concurrently with a call site still passing it.