### PR TITLE
Bound DeepSeek OCR no-repeat scanning

### DIFF
--- a/tests/test_deepseek_ocr_logits_processor_limits.py
+++ b/tests/test_deepseek_ocr_logits_processor_limits.py
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+
+from vllm.model_executor.models.deepseek_ocr import (
+    MAX_NGRAM_SIZE,
+    MAX_NGRAM_WINDOW_SIZE,
+    NGramPerReqLogitsProcessor,
+    NoRepeatNGramLogitsProcessor,
+)
+from vllm.sampling_params import SamplingParams
+
+pytestmark = pytest.mark.skip_global_cleanup
+
+
+def test_ngram_processor_rejects_attacker_sized_scan_parameters():
+    with pytest.raises(ValueError, match="ngram_size"):
+        NGramPerReqLogitsProcessor.validate_params(
+            SamplingParams(extra_args={"ngram_size": MAX_NGRAM_SIZE + 1})
+        )
+
+    with pytest.raises(ValueError, match="window_size"):
+        NGramPerReqLogitsProcessor.validate_params(
+            SamplingParams(
+                extra_args={
+                    "ngram_size": 2,
+                    "window_size": MAX_NGRAM_WINDOW_SIZE + 1,
+                }
+            )
+        )
+
+
+def test_unigram_processor_only_scans_the_bounded_window():
+    processor = NoRepeatNGramLogitsProcessor(ngram_size=1, window_size=2)
+    logits = torch.zeros(5)
+
+    result = processor([0, 1, 2], logits)
+
+    assert result[0] == 0
+    assert result[1] == -float("inf")
+    assert result[2] == -float("inf")

--- a/vllm/model_executor/models/deepseek_ocr.py
+++ b/vllm/model_executor/models/deepseek_ocr.py
@@ -75,6 +75,8 @@ from .deepseek_vl2 import MlpProjector
 
 # The image token id may be various
 _IMAGE_TOKEN = "<image>"
+MAX_NGRAM_SIZE = 128
+MAX_NGRAM_WINDOW_SIZE = 1024
 
 
 class DeepseekOCRImagePixelInputs(TensorSchema):
@@ -118,9 +120,15 @@ class NoRepeatNGramLogitsProcessor:
         if len(output_ids) < self.ngram_size:
             return logits
 
-        current_prefix = tuple(output_ids[-(self.ngram_size - 1) :])
-
         search_start = max(0, len(output_ids) - self.window_size)
+        if self.ngram_size == 1:
+            banned_tokens = set(output_ids[search_start:])
+            banned_tokens -= self.whitelist_token_ids
+            if banned_tokens:
+                logits[list(banned_tokens)] = -float("inf")
+            return logits
+
+        current_prefix = tuple(output_ids[-(self.ngram_size - 1) :])
         search_end = len(output_ids) - self.ngram_size + 1
 
         banned_tokens = set()
@@ -157,10 +165,18 @@ class NGramPerReqLogitsProcessor(AdapterLogitsProcessor):
             raise ValueError(
                 f"`ngram_size` has to be a strictly positive integer, got {ngram_size}."
             )
+        if ngram_size > MAX_NGRAM_SIZE:
+            raise ValueError(
+                f"`ngram_size` must be <= {MAX_NGRAM_SIZE}, got {ngram_size}."
+            )
         if not isinstance(window_size, int) or window_size <= 0:
             raise ValueError(
                 "`window_size` has to be a strictly positive integer, "
                 f"got {window_size}."
+            )
+        if window_size > MAX_NGRAM_WINDOW_SIZE:
+            raise ValueError(
+                f"`window_size` must be <= {MAX_NGRAM_WINDOW_SIZE}, got {window_size}."
             )
         if whitelist_token_ids is not None and not isinstance(
             whitelist_token_ids, Iterable


### PR DESCRIPTION
# Bound DeepSeek OCR no-repeat scanning

## What this fixes

Deployments that enable the DeepSeek-OCR no-repeat processor accepted arbitrary
`vllm_xargs.ngram_size` and `window_size`. Those values controlled how much prior output
the processor copied and rescanned after every generated token.

For example:

```json
{"vllm_xargs":{"ngram_size":1024,"window_size":2048},"max_tokens":2048}
```

Before this change, that small pair of integers made the processor repeatedly build
large tuples over the growing completion. Measured scan time grew from about 0.46 seconds
at 1,024 tokens to 29.49 seconds at 4,096 tokens. After this change, n-grams are limited
to 128 tokens, windows to 1,024 tokens, and the one-token case uses a bounded direct
scan instead of copying the entire output.

## Why it matters

An authenticated client could consume excessive decode CPU and reduce throughput for
other users without increasing the prompt or changing the model. This affects only
deployments that enable the documented DeepSeek-OCR processor.

## The change

Parameter validation now rejects values above `MAX_NGRAM_SIZE=128` and
`MAX_NGRAM_WINDOW_SIZE=1024` before constructing the per-request processor. The
`ngram_size == 1` path scans only the bounded window.

## How it was tested

On the unpatched tree, the guarding suite could not collect because the new limit symbols
did not exist. With the branch applied, both focused tests passed. They cover oversized
values and the bounded one-token fast path. The live pre-fix HTTP comparison also showed
the same 2,048-token output taking about 20.7 seconds normally and 23.2 seconds with only
the two request values changed.

## Reference

Advisory: GHSA-4jj7-2w2g-6q68

Track B: this is a public PR against `vllm-project/vllm@main`.

## Credit

- @KernelClint (Clinton Thomas) and @dhalf (Lucas Bourtoule)
- Patch the Planet (Trail of Bits + OpenAI collaboration); discovered using GPT-5.5-Cyber

All commits include DCO `Signed-off-by` trailers.
