### PR TITLE
Confine connector cache files to shared storage

### DIFF
--- a/tests/test_ec_example_connector_confinement.py
+++ b/tests/test_ec_example_connector_confinement.py
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from pathlib import Path
+
+import pytest
+import torch
+
+from vllm.distributed.ec_transfer.ec_connector.example_connector import (
+    ECExampleConnector,
+)
+
+pytestmark = [pytest.mark.cpu_test, pytest.mark.skip_global_cleanup]
+
+
+def _connector(storage_path: Path) -> ECExampleConnector:
+    connector = object.__new__(ECExampleConnector)
+    connector._storage_path = str(storage_path)
+    return connector
+
+
+@pytest.mark.parametrize("mm_hash", ["../escaped", "/tmp/escaped"])
+def test_mm_hash_cannot_escape_shared_storage_path(tmp_path: Path, mm_hash: str):
+    storage_path = tmp_path / "root"
+    connector = _connector(storage_path)
+
+    with pytest.raises(ValueError, match="escapes shared_storage_path"):
+        connector._generate_filename_debug(mm_hash)
+
+    assert not (tmp_path / "escaped").exists()
+
+
+def test_unsafe_mm_hash_is_cache_miss_without_creating_outside_path(tmp_path: Path):
+    storage_path = tmp_path / "root"
+    connector = _connector(storage_path)
+
+    assert connector.has_cache_item("../escaped") is False
+    assert not (tmp_path / "escaped").exists()
+
+
+def test_unsafe_mm_hash_save_is_skipped_without_creating_outside_path(tmp_path: Path):
+    storage_path = tmp_path / "root"
+    connector = _connector(storage_path)
+    connector._is_producer = True
+
+    connector.save_caches({"../escaped": torch.empty(0)}, "../escaped")
+
+    assert not (tmp_path / "escaped").exists()
+
+
+def test_safe_mm_hash_stays_inside_shared_storage_path(tmp_path: Path):
+    storage_path = tmp_path / "root"
+    connector = _connector(storage_path)
+
+    filename = Path(connector._generate_filename_debug("safe/hash"))
+
+    assert filename == storage_path / "safe" / "hash" / "encoder_cache.safetensors"
+    assert filename.parent.is_dir()

--- a/tests/test_hidden_states_connector_confinement.py
+++ b/tests/test_hidden_states_connector_confinement.py
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from pathlib import Path
+
+import pytest
+
+from vllm.distributed.kv_transfer.kv_connector.v1.example_hidden_states_connector import (  # noqa: E501
+    ExampleHiddenStatesConnector,
+)
+
+pytestmark = [pytest.mark.cpu_test, pytest.mark.skip_global_cleanup]
+
+
+def _connector(storage_path: Path) -> ExampleHiddenStatesConnector:
+    connector = object.__new__(ExampleHiddenStatesConnector)
+    connector._storage_path = str(storage_path)
+    return connector
+
+
+@pytest.mark.parametrize(
+    "req_id",
+    [
+        "x/../../outside",
+        "chatcmpl-x/../../outside-deadbeef",
+        "cmpl-x/../../outside-0-deadbeef",
+    ],
+)
+def test_default_hidden_states_path_rejects_request_id_escape(
+    tmp_path: Path, req_id: str
+):
+    connector = _connector(tmp_path / "root")
+
+    with pytest.raises(ValueError, match="escapes shared_storage_path"):
+        connector._generate_default_hidden_states_path(req_id)
+
+
+def test_default_hidden_states_path_stays_under_storage_root(tmp_path: Path):
+    connector = _connector(tmp_path / "root")
+
+    filename = Path(connector._generate_default_hidden_states_path("chatcmpl-safe"))
+
+    assert filename == tmp_path / "root" / "chatcmpl-safe.safetensors"

--- a/vllm/distributed/ec_transfer/ec_connector/example_connector.py
+++ b/vllm/distributed/ec_transfer/ec_connector/example_connector.py
@@ -114,7 +114,11 @@ class ECExampleConnector(ECConnectorBase):
         # Return if it is PD Instance
         if not self.is_producer:
             return
-        filename = self._generate_filename_debug(mm_hash)
+        try:
+            filename = self._generate_filename_debug(mm_hash)
+        except ValueError:
+            logger.warning("Skipping encoder cache save for unsafe mm_hash %r", mm_hash)
+            return
         ec_cache = encoder_cache[mm_hash]
         tensors = {"ec_cache": ec_cache.detach().cpu()}
         safetensors.torch.save_file(tensors, filename)
@@ -133,7 +137,13 @@ class ECExampleConnector(ECConnectorBase):
         Returns:
             Bool indicate that media exists in cache or not
         """
-        return self._found_match_for_mm_data(identifier)
+        try:
+            return self._found_match_for_mm_data(identifier)
+        except ValueError:
+            logger.warning(
+                "Skipping encoder cache lookup for unsafe mm_hash %r", identifier
+            )
+            return False
 
     def update_state_after_alloc(
         self,
@@ -251,7 +261,10 @@ class ECExampleConnector(ECConnectorBase):
         If `create_folder` is True (default) the directory is created
         recursively the first time it is needed.
         """
-        foldername = os.path.join(self._storage_path, mm_hash)
+        storage_root = os.path.realpath(self._storage_path)
+        foldername = os.path.realpath(os.path.join(storage_root, mm_hash))
+        if os.path.commonpath((storage_root, foldername)) != storage_root:
+            raise ValueError(f"mm_hash escapes shared_storage_path: {mm_hash!r}")
         if create_folder:
             os.makedirs(foldername, exist_ok=True)
         return foldername

--- a/vllm/distributed/kv_transfer/kv_connector/v1/example_hidden_states_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/example_hidden_states_connector.py
@@ -484,9 +484,7 @@ class ExampleHiddenStatesConnector(KVConnectorBase_V1, SupportsHMA):
         # Resolve save paths for new requests and tell the worker so it can
         # pre-create lock files before the client receives the output path.
         for new_req in scheduler_output.scheduled_new_reqs:
-            default_path = os.path.join(
-                self._storage_path, f"{new_req.req_id}.safetensors"
-            )
+            default_path = self._generate_default_hidden_states_path(new_req.req_id)
             kv_params = (
                 new_req.sampling_params.extra_args.get("kv_transfer_params")
                 if new_req.sampling_params and new_req.sampling_params.extra_args
@@ -506,6 +504,13 @@ class ExampleHiddenStatesConnector(KVConnectorBase_V1, SupportsHMA):
             meta.new_req_filenames[new_req.req_id] = filename
 
         return meta
+
+    def _generate_default_hidden_states_path(self, req_id: str) -> str:
+        storage_root = os.path.realpath(self._storage_path)
+        filename = os.path.realpath(os.path.join(storage_root, f"{req_id}.safetensors"))
+        if os.path.commonpath((storage_root, filename)) != storage_root:
+            raise ValueError(f"request id escapes shared_storage_path: {req_id!r}")
+        return filename
 
     def request_finished(
         self,


### PR DESCRIPTION
# Confine connector cache files to shared storage

## What this fixes

The two example connectors used request-derived identifiers as part of a file path without first
checking where the resulting path pointed.

For example, a scale-out request could provide an identifier such as `../escaped`. Before this
change, the encoder-cache connector could turn it into a path like
`<shared-storage>/../escaped/encoder_cache.safetensors`, while the hidden-state connector could
produce `<shared-storage>/../escaped.safetensors`. Both paths leave the configured storage
directory. Saving a cache entry could therefore create or replace a file elsewhere on a writable
filesystem.

After this change, each connector resolves the final path and verifies that it remains below the
configured shared-storage root. Unsafe identifiers are rejected or treated as cache misses, so no
file is created outside that root. A normal identifier such as `safe/hash` still works.

## Why it matters

An authenticated client of a deployment using either example connector could make the vLLM
process write a connector-controlled cache file outside the directory selected by the operator.
The write is limited by the vLLM process's filesystem permissions, but it could overwrite another
writable file, corrupt shared state, or interfere with other workloads using that filesystem.

## The change

| Site | What now happens |
|---|---|
| PTP-VLLM-122 — encoder-cache multimodal hash | The resolved cache directory must remain below `shared_storage_path`; unsafe saves are skipped and unsafe lookups are cache misses. |
| PTP-VLLM-123 — hidden-state request ID | The resolved `.safetensors` path must remain below `shared_storage_path` or the request is rejected. |

Both checks use resolved paths rather than text-prefix checks, so `..` components and absolute
paths cannot escape through path normalization.

## How it was tested

The encoder-cache tests changed from 4 failures and 1 pass without the fix to all 5 passing with
it. The hidden-state tests changed from 4 failures to all 4 passing. They cover `../escaped`, an
absolute path, safe nested identifiers, rejected saves, and cache misses that create no outside
file.

## Reference

Advisory: GHSA-52f5-44xf-4mch

Track B: this is a public PR against `vllm-project/vllm@main`.

## Credit

- @KernelClint (Clinton Thomas) and @dhalf (Lucas Bourtoule)
- Patch the Planet (Trail of Bits + OpenAI collaboration); discovered using GPT-5.5-Cyber

All commits include DCO `Signed-off-by` trailers.
