### PR TITLE
Bound request-controlled image and video geometry

### DIFF
--- a/tests/model_executor/test_glm4_1v_video.py
+++ b/tests/model_executor/test_glm4_1v_video.py
@@ -1,0 +1,65 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import builtins
+from types import SimpleNamespace
+
+from vllm.model_executor.models.glm4_1v import Glm4vProcessingInfo
+
+
+def _make_info():
+    info = object.__new__(Glm4vProcessingInfo)
+    info.get_video_processor = lambda: SimpleNamespace(
+        temporal_patch_size=1,
+        max_frames=640,
+    )
+    return info
+
+
+def _guard_large_range(monkeypatch):
+    original_range = builtins.range
+
+    def guarded_range(*args):
+        stop = args[0] if len(args) == 1 else args[1]
+        assert stop <= 640
+        return original_range(*args)
+
+    monkeypatch.setattr(
+        "vllm.model_executor.models.glm4_1v.range",
+        guarded_range,
+        raising=False,
+    )
+
+
+def test_glm46v_metadata_sampling_stays_bounded(monkeypatch):
+    _guard_large_range(monkeypatch)
+    info = _make_info()
+
+    result = info._get_video_second_idx_glm46v(
+        {
+            "fps": 1.0,
+            "duration": 100_000.0,
+            "total_num_frames": 100_000,
+            "do_sample_frames": True,
+        },
+        total_frames=1,
+    )
+
+    assert len(result) <= 640
+
+
+def test_glmga_metadata_sampling_stays_bounded(monkeypatch):
+    _guard_large_range(monkeypatch)
+    info = _make_info()
+
+    result = info._get_video_second_idx_glmga(
+        {
+            "fps": 1.0,
+            "duration": 100_000.0,
+            "total_num_frames": 100_000,
+            "do_sample_frames": True,
+        },
+        total_frames=1,
+    )
+
+    assert len(result) <= 640

--- a/tests/model_executor/test_qwen2_5_omni.py
+++ b/tests/model_executor/test_qwen2_5_omni.py
@@ -1,0 +1,286 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from unittest.mock import Mock
+
+import pytest
+import torch
+from transformers import PretrainedConfig
+
+from vllm.model_executor.models import qwen2_5_omni_thinker
+from vllm.model_executor.models.qwen2_5_omni_thinker import (
+    Qwen2_5OmniThinkerMultiModalProcessor,
+)
+from vllm.multimodal.parse import MultiModalDataItems, VideoProcessorItems
+from vllm.multimodal.processing import ProcessorInputs, TimingContext
+from vllm.multimodal.processing.processor import BaseMultiModalProcessor
+
+
+@pytest.fixture
+def mock_qwen2_5_omni_config() -> PretrainedConfig:
+    config = Mock(spec=PretrainedConfig)
+    config.audio_token_index = 151646
+    config.video_token_index = 151656
+    config.audio_start_token_id = 151647
+    config.audio_end_token_id = 151648
+    config.seconds_per_chunk = 1.0
+
+    vision_config = Mock()
+    vision_config.spatial_merge_size = 2
+    vision_config.tokens_per_second = 25
+    config.vision_config = vision_config
+    return config
+
+
+def _historical_dense_updates(
+    thinker_config: PretrainedConfig,
+    audio_len: int,
+    video_grid_thw: list[int],
+    video_second_per_grid_t: float,
+) -> list[int]:
+    audio_token_id = thinker_config.audio_token_index
+    video_token_id = thinker_config.video_token_index
+    audio_start_token_id = thinker_config.audio_start_token_id
+    audio_end_token_id = thinker_config.audio_end_token_id
+    seconds_per_chunk = thinker_config.seconds_per_chunk
+    spatial_merge_size = thinker_config.vision_config.spatial_merge_size
+    tokens_per_second = thinker_config.vision_config.tokens_per_second
+
+    grid_t, grid_h, grid_w = video_grid_thw
+    t_ntoken_per_chunk = int(tokens_per_second * seconds_per_chunk)
+    t_index = (
+        torch.arange(grid_t) * video_second_per_grid_t * tokens_per_second
+    ).long()
+    t_index_split_chunk: list[list[torch.Tensor]] = [
+        [] for _ in range((max(t_index) // t_ntoken_per_chunk) + 1)
+    ]
+    for num in t_index:
+        t_index_split_chunk[num // t_ntoken_per_chunk].append(num)
+
+    updates = [audio_start_token_id]
+    added_audio_len = 0
+    for t_chunk in t_index_split_chunk:
+        vision_ntoken_per_chunk = (
+            len(t_chunk) * grid_h * grid_w // (spatial_merge_size**2)
+        )
+        updates.extend([video_token_id] * vision_ntoken_per_chunk)
+
+        audio_chunk_size = min(t_ntoken_per_chunk, audio_len - added_audio_len)
+        updates.extend(audio_chunk_size * [audio_token_id])
+        added_audio_len += audio_chunk_size
+    if added_audio_len < audio_len:
+        updates.extend((audio_len - added_audio_len) * [audio_token_id])
+    updates.extend([audio_end_token_id])
+    return updates
+
+
+def test_qwen2_5_omni_sparse_gap_does_not_call_dense_split(
+    monkeypatch: pytest.MonkeyPatch,
+    mock_qwen2_5_omni_config: PretrainedConfig,
+) -> None:
+    def fail_dense_split(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("dense empty-bucket allocation was called")
+
+    monkeypatch.setattr(
+        qwen2_5_omni_thinker,
+        "split_list_into_ranges",
+        fail_dense_split,
+        raising=False,
+    )
+
+    updates = Qwen2_5OmniThinkerMultiModalProcessor.omni_get_updates_use_audio_in_video(
+        thinker_config=mock_qwen2_5_omni_config,
+        audio_len=50,
+        video_grid_thw=[2, 4, 4],
+        video_second_per_grid_t=100000.0,
+    )
+
+    assert updates == (
+        [mock_qwen2_5_omni_config.audio_start_token_id]
+        + [mock_qwen2_5_omni_config.video_token_index] * 4
+        + [mock_qwen2_5_omni_config.audio_token_index] * 50
+        + [mock_qwen2_5_omni_config.video_token_index] * 4
+        + [mock_qwen2_5_omni_config.audio_end_token_id]
+    )
+
+
+def test_qwen2_5_omni_sparse_gap_matches_historical_dense_behavior(
+    mock_qwen2_5_omni_config: PretrainedConfig,
+) -> None:
+    kwargs = {
+        "thinker_config": mock_qwen2_5_omni_config,
+        "audio_len": 85,
+        "video_grid_thw": [6, 4, 4],
+        "video_second_per_grid_t": 2.0,
+    }
+
+    assert Qwen2_5OmniThinkerMultiModalProcessor.omni_get_updates_use_audio_in_video(
+        **kwargs
+    ) == _historical_dense_updates(**kwargs)
+
+
+@pytest.mark.parametrize(
+    "second_per_grid_ts",
+    [
+        None,
+        1.0,
+        "1.0",
+        [float("inf")],
+        [float("nan")],
+        [10**400],
+        [0.0],
+        [-1.0],
+        [],
+        [1.0, 2.0],
+    ],
+)
+def test_qwen2_5_omni_rejects_invalid_second_per_grid_ts_before_processor_lookup(
+    second_per_grid_ts: object,
+) -> None:
+    processor = Qwen2_5OmniThinkerMultiModalProcessor.__new__(
+        Qwen2_5OmniThinkerMultiModalProcessor
+    )
+    processor.info = Mock()
+    processor.info.get_hf_processor.side_effect = AssertionError(
+        "processor lookup must not run for invalid second_per_grid_ts"
+    )
+    mm_items = MultiModalDataItems({"video": VideoProcessorItems([None])})
+
+    with pytest.raises(ValueError, match="second_per_grid_ts"):
+        processor._get_prompt_updates(
+            mm_items=mm_items,
+            hf_processor_mm_kwargs={
+                "use_audio_in_video": True,
+                "second_per_grid_ts": second_per_grid_ts,
+            },
+            out_mm_kwargs=Mock(),
+        )
+
+
+def test_qwen2_5_omni_cached_path_rejects_invalid_explicit_timing_before_processing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail_cached_apply(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("base cached processor path must not run")
+
+    monkeypatch.setattr(
+        BaseMultiModalProcessor,
+        "_cached_apply_hf_processor",
+        fail_cached_apply,
+    )
+    processor = Qwen2_5OmniThinkerMultiModalProcessor.__new__(
+        Qwen2_5OmniThinkerMultiModalProcessor
+    )
+    processor._apply_hf_processor = Mock(
+        side_effect=AssertionError("HF processor work must not run")
+    )
+    inputs = ProcessorInputs(
+        prompt=[],
+        mm_data_items=MultiModalDataItems({"video": VideoProcessorItems([None])}),
+        hf_processor_mm_kwargs={
+            "use_audio_in_video": True,
+            "second_per_grid_ts": [float("inf")],
+        },
+    )
+
+    with pytest.raises(ValueError, match="second_per_grid_ts"):
+        processor._cached_apply_hf_processor(inputs, TimingContext(enabled=False))
+
+    processor._apply_hf_processor.assert_not_called()
+
+
+def test_qwen2_5_omni_explicit_second_per_grid_ts_bypasses_processor_cache(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail_cached_apply(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("base cached processor path must not run")
+
+    monkeypatch.setattr(
+        BaseMultiModalProcessor,
+        "_cached_apply_hf_processor",
+        fail_cached_apply,
+    )
+    processor = Qwen2_5OmniThinkerMultiModalProcessor.__new__(
+        Qwen2_5OmniThinkerMultiModalProcessor
+    )
+    expected = ([1], Mock(), False)
+    processor._apply_hf_processor = Mock(return_value=expected)
+    inputs = ProcessorInputs(
+        prompt=[],
+        mm_data_items=MultiModalDataItems({"video": VideoProcessorItems([None])}),
+        hf_processor_mm_kwargs={
+            "use_audio_in_video": True,
+            "second_per_grid_ts": [1.0],
+        },
+    )
+    timing_ctx = TimingContext(enabled=False)
+
+    assert processor._cached_apply_hf_processor(inputs, timing_ctx) == expected
+    processor._apply_hf_processor.assert_called_once_with(inputs, timing_ctx)
+
+
+def test_qwen2_5_omni_prompt_only_timing_is_not_processor_init_kwarg() -> None:
+    info = qwen2_5_omni_thinker.Qwen2_5OmniThinkerProcessingInfo.__new__(
+        qwen2_5_omni_thinker.Qwen2_5OmniThinkerProcessingInfo
+    )
+    info.ctx = Mock()
+    expected = Mock()
+    info.ctx.get_hf_processor.return_value = expected
+
+    assert (
+        info.get_hf_processor(
+            use_fast=False,
+            use_audio_in_video=True,
+            second_per_grid_ts=[2.0],
+        )
+        is expected
+    )
+
+    info.ctx.get_hf_processor.assert_called_once_with(
+        qwen2_5_omni_thinker.Qwen2_5OmniProcessor,
+        use_fast=False,
+        use_audio_in_video=True,
+    )
+
+
+def test_qwen2_5_omni_omitted_second_per_grid_ts_uses_base_cached_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    expected = ([1], Mock(), False)
+    calls = []
+
+    def base_cached_apply(
+        self: BaseMultiModalProcessor,
+        inputs: ProcessorInputs,
+        timing_ctx: TimingContext,
+    ) -> tuple[list[int], object, bool]:
+        calls.append((self, inputs, timing_ctx))
+        return expected
+
+    monkeypatch.setattr(
+        BaseMultiModalProcessor,
+        "_cached_apply_hf_processor",
+        base_cached_apply,
+    )
+    processor = Qwen2_5OmniThinkerMultiModalProcessor.__new__(
+        Qwen2_5OmniThinkerMultiModalProcessor
+    )
+    processor._apply_hf_processor = Mock(
+        side_effect=AssertionError("uncached processor path must not run")
+    )
+    inputs = ProcessorInputs(
+        prompt=[],
+        mm_data_items=MultiModalDataItems({"video": VideoProcessorItems([None])}),
+        hf_processor_mm_kwargs={"use_audio_in_video": True},
+    )
+    timing_ctx = TimingContext(enabled=False)
+
+    assert processor._cached_apply_hf_processor(inputs, timing_ctx) == expected
+    assert calls == [(processor, inputs, timing_ctx)]
+    processor._apply_hf_processor.assert_not_called()
+
+
+def test_qwen2_5_omni_omitted_second_per_grid_ts_defaults_to_one() -> None:
+    assert Qwen2_5OmniThinkerMultiModalProcessor._normalize_second_per_grid_ts(
+        num_videos=2,
+    ) == [1.0, 1.0]

--- a/tests/models/multimodal/processing/test_audio_in_video.py
+++ b/tests/models/multimodal/processing/test_audio_in_video.py
@@ -115,6 +115,47 @@ def test_audio_in_video_cache_correctness(model_id: str, num_videos: int) -> Non
     )
 
 
+def test_qwen2_5_omni_explicit_timing_mixed_cache_matches_baseline() -> None:
+    """Explicit per-video timing must retain positions across mixed cache hits."""
+    ctx = build_model_context(
+        "Qwen/Qwen2.5-Omni-3B",
+        limit_mm_per_prompt={"audio": 2, "image": 0, "video": 2},
+        mm_processor_cache_gb=1,
+    )
+
+    baseline_processor = MULTIMODAL_REGISTRY.create_processor(
+        ctx.model_config, cache=None
+    )
+    sender_cache = MultiModalProcessorSenderCache(ctx.model_config)
+    cached_processor = MULTIMODAL_REGISTRY.create_processor(
+        ctx.model_config, cache=sender_cache
+    )
+
+    video_token_id = baseline_processor.info.get_hf_config().video_token_id
+    all_mm_data = create_mm_data(3)
+    hf_processor_mm_kwargs = {
+        "use_audio_in_video": True,
+        "second_per_grid_ts": [1.0, 2.0],
+    }
+
+    def run(processor, indices: list[int]) -> list[int]:
+        mm_data = {
+            "video": [all_mm_data["video"][index] for index in indices],
+            "audio": [all_mm_data["audio"][index] for index in indices],
+        }
+        return processor(
+            [video_token_id] * len(indices),
+            mm_items=baseline_processor.info.parse_mm_data(mm_data),
+            hf_processor_mm_kwargs=hf_processor_mm_kwargs,
+        )["prompt_token_ids"]
+
+    run(cached_processor, [0, 1])
+    baseline_second_ids = run(baseline_processor, [0, 2])
+    cached_second_ids = run(cached_processor, [0, 2])
+
+    assert cached_second_ids == baseline_second_ids
+
+
 @pytest.mark.parametrize("model_id", MODELS)
 def test_use_audio_in_video_without_audio_track(model_id: str) -> None:
     """

--- a/tests/models/multimodal/processing/test_deepseek_ocr.py
+++ b/tests/models/multimodal/processing/test_deepseek_ocr.py
@@ -13,14 +13,275 @@ Run with:
   pytest tests/models/multimodal/processing/test_deepseek_ocr.py -v
 """
 
+from dataclasses import dataclass
+
 import pytest
 from PIL import Image
 from transformers import AutoTokenizer
 
-from vllm.model_executor.models.deepseek_ocr import DeepseekOCRImagePixelInputs
-from vllm.transformers_utils.processors.deepseek_ocr import DeepseekOCRProcessor
+from vllm.model_executor.models.deepseek_ocr import (
+    IMAGE_SIZE as DEEPSEEK_OCR_IMAGE_SIZE,
+)
+from vllm.model_executor.models.deepseek_ocr import (
+    DeepseekOCRImagePixelInputs,
+    DeepseekOCRProcessingInfo,
+)
+from vllm.model_executor.models.deepseek_ocr2 import (
+    IMAGE_SIZE as DEEPSEEK_OCR2_IMAGE_SIZE,
+)
+from vllm.model_executor.models.deepseek_ocr2 import (
+    DeepseekOCR2ProcessingInfo,
+)
+from vllm.model_executor.models.unlimited_ocr import UnlimitedOCRProcessingInfo
+from vllm.transformers_utils.processors.deepseek_ocr import (
+    BASE_SIZE,
+    CROP_MODE,
+    MAX_CROPS,
+    DeepseekOCRProcessor,
+)
+from vllm.transformers_utils.processors.unlimited_ocr import UnlimitedOCRProcessor
 
 MODEL_ID = "deepseek-ai/DeepSeek-OCR"
+UNLIMITED_OCR_MAX_CROPS = 32
+
+
+@dataclass
+class _MMConfig:
+    mm_processor_kwargs: dict[str, object] | None = None
+
+
+class _ProcessorContext:
+    def __init__(self, mm_processor_kwargs: dict[str, object] | None = None):
+        self.mm_processor_kwargs = mm_processor_kwargs
+        self.calls: list[tuple[type[object], dict[str, object]]] = []
+
+    def get_mm_config(self) -> _MMConfig:
+        return _MMConfig(self.mm_processor_kwargs)
+
+    def get_hf_processor(
+        self,
+        processor_type: type[object],
+        **kwargs: object,
+    ) -> dict[str, object]:
+        merged_kwargs = {**(self.mm_processor_kwargs or {}), **kwargs}
+        self.calls.append((processor_type, merged_kwargs))
+        return merged_kwargs
+
+
+@pytest.mark.parametrize(
+    ("info_cls", "unsafe_kwargs"),
+    [
+        pytest.param(
+            DeepseekOCRProcessingInfo,
+            {"image_size": DEEPSEEK_OCR_IMAGE_SIZE + 1},
+            id="v1-image-size",
+        ),
+        pytest.param(
+            DeepseekOCRProcessingInfo,
+            {"base_size": BASE_SIZE + 1},
+            id="v1-base-size",
+        ),
+        pytest.param(
+            DeepseekOCRProcessingInfo,
+            {"crop_mode": not CROP_MODE},
+            id="v1-crop-mode",
+        ),
+        pytest.param(
+            DeepseekOCRProcessingInfo,
+            {"strategy": "v2"},
+            id="v1-strategy",
+        ),
+        pytest.param(
+            DeepseekOCRProcessingInfo,
+            {"max_crops": MAX_CROPS + 1},
+            id="v1-max-crops",
+        ),
+        pytest.param(
+            DeepseekOCR2ProcessingInfo,
+            {"image_size": DEEPSEEK_OCR2_IMAGE_SIZE + 1},
+            id="v2-image-size",
+        ),
+        pytest.param(
+            DeepseekOCR2ProcessingInfo,
+            {"base_size": BASE_SIZE + 1},
+            id="v2-base-size",
+        ),
+        pytest.param(
+            DeepseekOCR2ProcessingInfo,
+            {"crop_mode": not CROP_MODE},
+            id="v2-crop-mode",
+        ),
+        pytest.param(
+            DeepseekOCR2ProcessingInfo,
+            {"strategy": "v1"},
+            id="v2-strategy",
+        ),
+        pytest.param(
+            DeepseekOCR2ProcessingInfo,
+            {"max_crops": MAX_CROPS + 1},
+            id="v2-max-crops",
+        ),
+        pytest.param(
+            UnlimitedOCRProcessingInfo,
+            {"image_size": DEEPSEEK_OCR_IMAGE_SIZE + 1},
+            id="unlimited-image-size",
+        ),
+        pytest.param(
+            UnlimitedOCRProcessingInfo,
+            {"base_size": BASE_SIZE + 1},
+            id="unlimited-base-size",
+        ),
+        pytest.param(
+            UnlimitedOCRProcessingInfo,
+            {"crop_mode": not CROP_MODE},
+            id="unlimited-crop-mode",
+        ),
+        pytest.param(
+            UnlimitedOCRProcessingInfo,
+            {"strategy": "v2"},
+            id="unlimited-strategy",
+        ),
+        pytest.param(
+            UnlimitedOCRProcessingInfo,
+            {"max_crops": UNLIMITED_OCR_MAX_CROPS + 1},
+            id="unlimited-max-crops",
+        ),
+    ],
+)
+def test_processing_info_rejects_request_processor_overrides(
+    info_cls: type[
+        DeepseekOCRProcessingInfo
+        | DeepseekOCR2ProcessingInfo
+        | UnlimitedOCRProcessingInfo
+    ],
+    unsafe_kwargs: dict[str, object],
+):
+    ctx = _ProcessorContext()
+    info = info_cls(ctx)  # type: ignore[arg-type]
+
+    with pytest.raises(
+        ValueError,
+        match="must match the deployed DeepSeek OCR configuration",
+    ):
+        info.get_hf_processor(**unsafe_kwargs)
+
+    assert ctx.calls == []
+
+
+@pytest.mark.parametrize(
+    ("info_cls", "trusted_config"),
+    [
+        pytest.param(
+            DeepseekOCRProcessingInfo,
+            {
+                "image_size": DEEPSEEK_OCR_IMAGE_SIZE,
+                "base_size": BASE_SIZE,
+                "crop_mode": CROP_MODE,
+                "strategy": "v1",
+            },
+            id="v1",
+        ),
+        pytest.param(
+            DeepseekOCR2ProcessingInfo,
+            {
+                "image_size": DEEPSEEK_OCR2_IMAGE_SIZE,
+                "base_size": BASE_SIZE,
+                "crop_mode": CROP_MODE,
+                "strategy": "v2",
+            },
+            id="v2",
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    ("server_kwargs", "request_kwargs", "expected_max_crops"),
+    [
+        pytest.param(None, {"normalize": False}, MAX_CROPS, id="default"),
+        pytest.param(
+            {"max_crops": 20},
+            {"normalize": False},
+            MAX_CROPS,
+            id="ignores-server-max-crops",
+        ),
+        pytest.param(
+            None,
+            {"max_crops": MAX_CROPS, "normalize": False},
+            MAX_CROPS,
+            id="request-repeats-fixed",
+        ),
+    ],
+)
+def test_processing_info_binds_fixed_processor_config(
+    info_cls: type[DeepseekOCRProcessingInfo | DeepseekOCR2ProcessingInfo],
+    trusted_config: dict[str, object],
+    server_kwargs: dict[str, object] | None,
+    request_kwargs: dict[str, object],
+    expected_max_crops: int,
+):
+    ctx = _ProcessorContext(server_kwargs)
+    info = info_cls(ctx)  # type: ignore[arg-type]
+
+    result = info.get_hf_processor(**request_kwargs)
+    expected_kwargs = {
+        **trusted_config,
+        "max_crops": expected_max_crops,
+        "normalize": False,
+    }
+
+    assert result == expected_kwargs
+    assert ctx.calls == [(DeepseekOCRProcessor, expected_kwargs)]
+
+
+@pytest.mark.parametrize(
+    "info_cls",
+    [
+        pytest.param(DeepseekOCRProcessingInfo, id="v1"),
+        pytest.param(DeepseekOCR2ProcessingInfo, id="v2"),
+    ],
+)
+def test_processing_info_rejects_request_max_crops_even_when_server_matches(
+    info_cls: type[DeepseekOCRProcessingInfo | DeepseekOCR2ProcessingInfo],
+):
+    ctx = _ProcessorContext({"max_crops": 20})
+    info = info_cls(ctx)  # type: ignore[arg-type]
+
+    with pytest.raises(
+        ValueError,
+        match="must match the deployed DeepSeek OCR configuration",
+    ):
+        info.get_hf_processor(max_crops=20)
+
+    assert ctx.calls == []
+
+
+@pytest.mark.parametrize(
+    "request_kwargs",
+    [
+        pytest.param({"normalize": False}, id="omitted"),
+        pytest.param(
+            {"max_crops": UNLIMITED_OCR_MAX_CROPS, "normalize": False},
+            id="request-repeats-fixed",
+        ),
+    ],
+)
+def test_unlimited_ocr_processing_info_binds_fixed_processor_config(
+    request_kwargs: dict[str, object],
+):
+    ctx = _ProcessorContext({"max_crops": 20})
+    info = UnlimitedOCRProcessingInfo(ctx)  # type: ignore[arg-type]
+
+    result = info.get_hf_processor(**request_kwargs)
+    expected_kwargs = {
+        "image_size": DEEPSEEK_OCR_IMAGE_SIZE,
+        "base_size": BASE_SIZE,
+        "crop_mode": CROP_MODE,
+        "strategy": "v1",
+        "max_crops": UNLIMITED_OCR_MAX_CROPS,
+        "normalize": False,
+    }
+
+    assert result == expected_kwargs
+    assert ctx.calls == [(UnlimitedOCRProcessor, expected_kwargs)]
 
 
 @pytest.fixture(scope="module")

--- a/tests/models/multimodal/processing/test_gemma3_pan_scan.py
+++ b/tests/models/multimodal/processing/test_gemma3_pan_scan.py
@@ -1,0 +1,186 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import pytest
+from transformers import BatchFeature, Gemma3Processor
+from transformers.models.gemma3.image_processing_gemma3 import Gemma3ImageProcessor
+from transformers.models.gemma3.processing_gemma3 import Gemma3ProcessorKwargs
+
+from vllm.model_executor.models.gemma3_mm import (
+    Gemma3MultiModalProcessor,
+    Gemma3ProcessingInfo,
+)
+from vllm.multimodal.parse import ImageSize
+from vllm.multimodal.processing.processor import BaseMultiModalProcessor
+
+
+class _Gemma3MMConfig:
+    def __init__(self, mm_processor_kwargs: dict[str, object] | None = None):
+        self.mm_processor_kwargs = mm_processor_kwargs or {}
+
+    def merge_mm_processor_kwargs(
+        self, inference_kwargs: dict[str, object]
+    ) -> dict[str, object]:
+        return self.mm_processor_kwargs | dict(inference_kwargs)
+
+
+class _Gemma3ProcessingContext:
+    def __init__(self, mm_processor_kwargs: dict[str, object] | None = None):
+        self._mm_config = _Gemma3MMConfig(mm_processor_kwargs)
+
+    def get_merged_mm_kwargs(self, kwargs: dict[str, object]) -> dict[str, object]:
+        return self._mm_config.merge_mm_processor_kwargs(kwargs)
+
+    def get_hf_processor(self, typ, **kwargs: object):
+        assert typ is Gemma3Processor
+        return _build_hf_processor(self.get_merged_mm_kwargs(dict(kwargs)))
+
+
+def _build_hf_processor(mm_kwargs: dict[str, object]) -> Gemma3Processor:
+    processor = object.__new__(Gemma3Processor)
+    processor.tokenizer = SimpleNamespace(init_kwargs={})
+    processor.image_processor = Gemma3ImageProcessor()
+    images_kwargs = processor._merge_kwargs(
+        Gemma3ProcessorKwargs,
+        tokenizer_init_kwargs=processor.tokenizer.init_kwargs,
+        **mm_kwargs,
+    )["images_kwargs"]
+    processor.image_processor = Gemma3ImageProcessor(**images_kwargs)
+    return processor
+
+
+def _get_num_crops(
+    *,
+    deployment_kwargs: dict[str, object] | None = None,
+    request_kwargs: dict[str, object] | None = None,
+    image_width: int = 65536,
+    image_height: int = 512,
+) -> int:
+    info = Gemma3ProcessingInfo(_Gemma3ProcessingContext(deployment_kwargs))
+    request_kwargs = request_kwargs or {}
+    processor = info.get_hf_processor(**request_kwargs)
+    return info.get_num_crops(
+        image_width=image_width,
+        image_height=image_height,
+        processor=processor,
+        mm_kwargs=request_kwargs,
+    )
+
+
+@pytest.mark.parametrize(
+    "request_kwargs",
+    [
+        {"pan_and_scan_max_num_crops": 128},
+        {"images_kwargs": {"pan_and_scan_max_num_crops": 128}},
+    ],
+)
+def test_rejects_crop_fanout_above_deployment_ceiling(
+    request_kwargs: dict[str, object],
+):
+    with pytest.raises(ValueError, match="exceeds the deployed limit"):
+        _get_num_crops(
+            deployment_kwargs={"do_pan_and_scan": True},
+            request_kwargs=request_kwargs,
+        )
+
+
+def test_accepts_crop_fanout_at_operator_selected_ceiling():
+    assert (
+        _get_num_crops(
+            deployment_kwargs={
+                "do_pan_and_scan": True,
+                "pan_and_scan_max_num_crops": 8,
+            },
+            request_kwargs={"pan_and_scan_max_num_crops": 8},
+        )
+        == 8
+    )
+
+
+def test_accepts_high_named_cap_when_geometry_stays_within_ceiling():
+    assert (
+        _get_num_crops(
+            deployment_kwargs={"do_pan_and_scan": True},
+            request_kwargs={"pan_and_scan_max_num_crops": 128},
+            image_width=1024,
+            image_height=512,
+        )
+        == 2
+    )
+
+
+@pytest.mark.parametrize(
+    "request_kwargs",
+    [
+        {"pan_and_scan_min_crop_size": 0},
+        {"pan_and_scan_max_num_crops": 0},
+    ],
+)
+def test_rejects_non_positive_crop_arithmetic_inputs(
+    request_kwargs: dict[str, object],
+):
+    with pytest.raises(ValueError, match="must be a positive integer"):
+        _get_num_crops(
+            deployment_kwargs={"do_pan_and_scan": True},
+            request_kwargs=request_kwargs,
+        )
+
+
+class _FakeParsedImages:
+    def __len__(self) -> int:
+        return 1
+
+    def get_image_size(self, item_idx: int) -> ImageSize:
+        assert item_idx == 0
+        return ImageSize(width=65536, height=512)
+
+
+class _FakeMMItems:
+    def get_items(self, modality: str, item_type):
+        assert modality == "image"
+        return _FakeParsedImages()
+
+
+class _RejectingInfo:
+    def parse_mm_data(self, mm_data, validate=False):
+        del mm_data, validate
+        return _FakeMMItems()
+
+    def get_hf_processor(self, **mm_kwargs: object):
+        del mm_kwargs
+        return object()
+
+    def get_num_crops(self, **kwargs: object) -> int:
+        del kwargs
+        raise ValueError("Gemma3 pan-and-scan crop count exceeds the deployed limit")
+
+
+def test_rejects_before_hf_preprocessing(monkeypatch: pytest.MonkeyPatch):
+    hf_called = False
+
+    def fake_call_hf_processor(self, prompt, mm_data, mm_kwargs, tok_kwargs):
+        nonlocal hf_called
+        del self, prompt, mm_data, mm_kwargs, tok_kwargs
+        hf_called = True
+        return BatchFeature({})
+
+    monkeypatch.setattr(
+        BaseMultiModalProcessor,
+        "_call_hf_processor",
+        fake_call_hf_processor,
+    )
+
+    processor = object.__new__(Gemma3MultiModalProcessor)
+    processor.info = _RejectingInfo()
+
+    with pytest.raises(ValueError, match="exceeds the deployed limit"):
+        processor._call_hf_processor(
+            "prompt",
+            {"images": [object()]},
+            {},
+            {},
+        )
+
+    assert not hf_called

--- a/tests/models/multimodal/processing/test_idefics3_longest_edge.py
+++ b/tests/models/multimodal/processing/test_idefics3_longest_edge.py
@@ -1,0 +1,497 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import pytest
+
+from vllm.model_executor.models.idefics3 import (
+    Idefics3MultiModalProcessor,
+    Idefics3ProcessingInfo,
+)
+from vllm.model_executor.models.smolvlm import SmolVLMProcessingInfo
+from vllm.multimodal.parse import MultiModalDataItems
+from vllm.multimodal.processing import BaseMultiModalProcessor, TimingContext
+
+
+class _MMConfig:
+    def __init__(self, mm_processor_kwargs: dict[str, object]) -> None:
+        self.mm_processor_kwargs = mm_processor_kwargs
+
+    def merge_mm_processor_kwargs(
+        self, inference_kwargs: dict[str, object]
+    ) -> dict[str, object]:
+        return self.mm_processor_kwargs | dict(inference_kwargs)
+
+
+class _ModelConfig:
+    def __init__(self, trusted_longest_edge: int) -> None:
+        self.model = "test-model"
+        mm_processor_kwargs: dict[str, object] = (
+            {}
+            if trusted_longest_edge == 2048
+            else {"size": {"longest_edge": trusted_longest_edge}}
+        )
+        self.multimodal_config = _MMConfig(mm_processor_kwargs)
+
+    def get_multimodal_config(self) -> _MMConfig:
+        return self.multimodal_config
+
+
+class _ImageProcessor:
+    class valid_kwargs:
+        size: object
+        max_image_size: object
+        do_resize: object
+        do_image_splitting: object
+        return_tensors: object
+
+    do_resize = True
+    do_image_splitting = True
+
+    def __init__(
+        self,
+        *,
+        size: dict[str, object],
+        max_image_size: dict[str, object] | None = None,
+    ) -> None:
+        self.size = size
+        self.max_image_size = max_image_size
+
+    def get_number_of_image_patches(
+        self,
+        image_height: int,
+        image_width: int,
+        images_kwargs: dict[str, object],
+    ) -> tuple[int, int, int]:
+        del image_height, image_width
+        size = images_kwargs.get("size", self.size)
+        assert isinstance(size, dict)
+        longest_edge = size["longest_edge"]
+        assert isinstance(longest_edge, int)
+        return max(1, longest_edge // 128), 1, 1
+
+
+class _Processor:
+    image_seq_len = 1
+
+    def __init__(
+        self,
+        *,
+        size: dict[str, object],
+        max_image_size: dict[str, object] | None = None,
+    ) -> None:
+        self.image_processor = _ImageProcessor(
+            size=size,
+            max_image_size=max_image_size,
+        )
+        self.tokenizer = SimpleNamespace(init_kwargs={})
+
+    def _merge_kwargs(
+        self,
+        _processor_kwargs_cls,
+        *,
+        tokenizer_init_kwargs: dict[str, object],
+        **kwargs: object,
+    ) -> dict[str, dict[str, object]]:
+        del _processor_kwargs_cls, tokenizer_init_kwargs
+
+        images_kwargs: dict[str, object] = {}
+        common_kwargs = kwargs.get("common_kwargs")
+        if common_kwargs is not None:
+            assert isinstance(common_kwargs, dict)
+            images_kwargs.update(common_kwargs)
+
+        nested_images_kwargs = kwargs.get("images_kwargs")
+        if nested_images_kwargs is not None:
+            assert isinstance(nested_images_kwargs, dict)
+            images_kwargs.update(nested_images_kwargs)
+
+        for name in ("size", "max_image_size", "do_resize", "do_image_splitting"):
+            if name in kwargs:
+                if name in images_kwargs:
+                    raise ValueError(f"Keyword argument {name} was passed two times")
+                images_kwargs[name] = kwargs[name]
+
+        return {"images_kwargs": images_kwargs}
+
+
+class _ProcessingContext:
+    def __init__(self, trusted_longest_edge: int = 2048) -> None:
+        self.model_config = _ModelConfig(trusted_longest_edge)
+        self.processor_calls: list[dict[str, object]] = []
+
+    def get_tokenizer(self) -> SimpleNamespace:
+        return SimpleNamespace(encode=lambda _prompt: [1])
+
+    def get_merged_mm_kwargs(
+        self, kwargs: dict[str, object] | None = None
+    ) -> dict[str, object]:
+        return self.model_config.get_multimodal_config().merge_mm_processor_kwargs(
+            kwargs or {}
+        )
+
+    def get_hf_processor(self, _processor_cls, **kwargs: object) -> _Processor:
+        self.processor_calls.append(dict(kwargs))
+        return _Processor(size={"longest_edge": 2048})
+
+
+@pytest.mark.parametrize(
+    "info_cls",
+    [Idefics3ProcessingInfo, SmolVLMProcessingInfo],
+)
+def test_rejects_request_size_longest_edge_above_deployment_limit(info_cls) -> None:
+    info = info_cls(_ProcessingContext(trusted_longest_edge=2048))
+
+    with pytest.raises(ValueError, match="size.longest_edge"):
+        info.get_hf_processor(size={"longest_edge": 4096})
+
+
+@pytest.mark.parametrize(
+    "info_cls",
+    [Idefics3ProcessingInfo, SmolVLMProcessingInfo],
+)
+@pytest.mark.parametrize("request_longest_edge", [1024, 2048])
+def test_allows_request_size_longest_edge_at_or_below_deployment_limit(
+    info_cls, request_longest_edge: int
+) -> None:
+    info = info_cls(_ProcessingContext(trusted_longest_edge=2048))
+
+    processor = info.get_hf_processor(size={"longest_edge": request_longest_edge})
+
+    assert processor.image_processor.size == {"longest_edge": 2048}
+
+
+@pytest.mark.parametrize(
+    "info_cls",
+    [Idefics3ProcessingInfo, SmolVLMProcessingInfo],
+)
+@pytest.mark.parametrize(
+    "request_size",
+    [
+        364,
+        [364, 364],
+        (364, 364),
+        {"longest_edge": 2048, "shortest_edge": 1},
+        {"height": 364, "width": 364},
+        {"height": 2048, "width": 2048},
+    ],
+)
+def test_allows_request_size_variants_at_or_below_deployment_limit(
+    info_cls,
+    request_size: object,
+) -> None:
+    info = info_cls(_ProcessingContext(trusted_longest_edge=2048))
+
+    processor = info.get_hf_processor(
+        size=request_size,
+        do_image_splitting=False,
+    )
+
+    assert processor.image_processor.size == {"longest_edge": 2048}
+
+
+@pytest.mark.parametrize(
+    "info_cls",
+    [Idefics3ProcessingInfo, SmolVLMProcessingInfo],
+)
+@pytest.mark.parametrize(
+    "request_size",
+    [4096, [2048, 4096], (2048, 4096), {"height": 2048, "width": 4096}],
+)
+def test_rejects_request_size_variants_above_deployment_limit(
+    info_cls,
+    request_size: object,
+) -> None:
+    info = info_cls(_ProcessingContext(trusted_longest_edge=2048))
+
+    with pytest.raises(ValueError, match="exceeds the deployed limit"):
+        info.get_hf_processor(
+            size=request_size,
+            do_image_splitting=False,
+        )
+
+
+def test_rejects_mixed_request_size_shape_before_hf_preprocessing() -> None:
+    info = Idefics3ProcessingInfo(_ProcessingContext(trusted_longest_edge=2048))
+
+    with pytest.raises(ValueError, match="Request `size`"):
+        info.get_hf_processor(
+            size={
+                "longest_edge": 1024,
+                "height": 4096,
+                "width": 4096,
+            }
+        )
+
+
+def test_allows_operator_selected_higher_deployment_limit() -> None:
+    info = Idefics3ProcessingInfo(_ProcessingContext(trusted_longest_edge=4096))
+
+    processor = info.get_hf_processor(size={"longest_edge": 4096})
+
+    assert processor.image_processor.size == {"longest_edge": 2048}
+
+
+def test_rejects_nested_images_kwargs_size_longest_edge_above_deployment_limit() -> (
+    None
+):
+    info = Idefics3ProcessingInfo(_ProcessingContext(trusted_longest_edge=2048))
+
+    with pytest.raises(ValueError, match="size.longest_edge"):
+        info.get_hf_processor(images_kwargs={"size": {"longest_edge": 4096}})
+
+
+def test_rejects_nested_common_kwargs_size_longest_edge_above_deployment_limit() -> (
+    None
+):
+    info = Idefics3ProcessingInfo(_ProcessingContext(trusted_longest_edge=2048))
+
+    with pytest.raises(ValueError, match="size.longest_edge"):
+        info.get_hf_processor(common_kwargs={"size": {"longest_edge": 4096}})
+
+
+@pytest.mark.parametrize("invalid_value", [0, -1, True, 2048.0])
+def test_rejects_invalid_request_size_longest_edge(invalid_value: object) -> None:
+    info = Idefics3ProcessingInfo(_ProcessingContext(trusted_longest_edge=2048))
+
+    with pytest.raises(ValueError, match="size.longest_edge"):
+        info.get_hf_processor(size={"longest_edge": invalid_value})
+
+
+def test_smolvlm_max_image_size_override_remains_supported() -> None:
+    info = SmolVLMProcessingInfo(_ProcessingContext(trusted_longest_edge=2048))
+
+    processor = info.get_hf_processor(max_image_size={"longest_edge": 768})
+
+    assert processor.image_processor.max_image_size is None
+
+
+def test_patch_count_path_reuses_size_validation() -> None:
+    info = Idefics3ProcessingInfo(_ProcessingContext(trusted_longest_edge=2048))
+    processor = info.get_hf_processor()
+
+    with pytest.raises(ValueError, match="size.longest_edge"):
+        info.get_num_patches(
+            image_width=4096,
+            image_height=4096,
+            processor=processor,
+            mm_kwargs={"size": {"longest_edge": 4096}},
+        )
+
+
+@pytest.mark.parametrize("do_resize", [False, None])
+def test_patch_count_path_rejects_disabled_resize_while_splitting_enabled(
+    do_resize: object,
+) -> None:
+    info = Idefics3ProcessingInfo(_ProcessingContext(trusted_longest_edge=2048))
+    processor = info.get_hf_processor()
+
+    with pytest.raises(ValueError, match="do_resize"):
+        info.get_num_patches(
+            image_width=2048,
+            image_height=2048,
+            processor=processor,
+            mm_kwargs={"do_resize": do_resize},
+        )
+
+
+def test_rejects_oversized_request_before_hf_preprocessing(monkeypatch) -> None:
+    info = Idefics3ProcessingInfo(_ProcessingContext(trusted_longest_edge=2048))
+    processor = Idefics3MultiModalProcessor.__new__(Idefics3MultiModalProcessor)
+    processor.info = info
+
+    def _unexpected_hf_call(*args, **kwargs):
+        del args, kwargs
+        pytest.fail("HF preprocessing ran before size.longest_edge validation")
+
+    monkeypatch.setattr(
+        BaseMultiModalProcessor,
+        "_call_hf_processor",
+        _unexpected_hf_call,
+    )
+
+    with pytest.raises(ValueError, match="size.longest_edge"):
+        processor._call_hf_processor(
+            "prompt",
+            {"images": [SimpleNamespace()]},
+            {"size": {"longest_edge": 4096}},
+            {},
+        )
+
+
+@pytest.mark.parametrize("do_resize", [False, None])
+def test_rejects_disabled_resize_while_splitting_enabled_before_hf_preprocessing(
+    monkeypatch,
+    do_resize: object,
+) -> None:
+    info = Idefics3ProcessingInfo(_ProcessingContext(trusted_longest_edge=2048))
+    processor = Idefics3MultiModalProcessor.__new__(Idefics3MultiModalProcessor)
+    processor.info = info
+
+    def _unexpected_hf_call(*args, **kwargs):
+        del args, kwargs
+        pytest.fail("HF preprocessing ran before do_resize validation")
+
+    monkeypatch.setattr(
+        BaseMultiModalProcessor,
+        "_call_hf_processor",
+        _unexpected_hf_call,
+    )
+
+    with pytest.raises(ValueError, match="do_resize"):
+        processor._call_hf_processor(
+            "prompt",
+            {"images": [SimpleNamespace()]},
+            {"do_resize": do_resize},
+            {},
+        )
+
+
+def test_allows_disabled_resize_when_image_splitting_is_disabled() -> None:
+    info = Idefics3ProcessingInfo(_ProcessingContext(trusted_longest_edge=2048))
+
+    processor = info.get_hf_processor(
+        do_resize=False,
+        do_image_splitting=False,
+    )
+
+    assert processor.image_processor.size == {"longest_edge": 2048}
+
+
+@pytest.mark.parametrize(
+    "tokenization_kwargs",
+    [
+        {"size": {"longest_edge": 4096}},
+        {"do_resize": False},
+        {"do_image_splitting": False},
+        {"max_image_size": {"longest_edge": 91}},
+        {"images_kwargs": {"size": {"longest_edge": 4096}}},
+        {"images_kwargs": {"do_image_splitting": False}},
+        {"common_kwargs": {"size": {"longest_edge": 4096}}},
+        {"common_kwargs": {"max_image_size": {"longest_edge": 91}}},
+        {"common_kwargs": [["size", {"longest_edge": 4096}]]},
+        {"common_kwargs": [["do_resize", False]]},
+        {"common_kwargs": [["max_image_size", {"longest_edge": 91}]]},
+    ],
+)
+def test_rejects_image_processing_kwargs_in_tokenization_kwargs_before_hf_preprocessing(
+    monkeypatch,
+    tokenization_kwargs: dict[str, object],
+) -> None:
+    info = Idefics3ProcessingInfo(_ProcessingContext(trusted_longest_edge=2048))
+    processor = Idefics3MultiModalProcessor.__new__(Idefics3MultiModalProcessor)
+    processor.info = info
+
+    def _unexpected_hf_call(*args, **kwargs):
+        del args, kwargs
+        pytest.fail("HF preprocessing ran before tokenization_kwargs validation")
+
+    monkeypatch.setattr(
+        BaseMultiModalProcessor,
+        "_call_hf_processor",
+        _unexpected_hf_call,
+    )
+
+    with pytest.raises(ValueError, match="tokenization_kwargs"):
+        processor._call_hf_processor(
+            "prompt",
+            {"images": [SimpleNamespace()]},
+            {},
+            tokenization_kwargs,
+        )
+
+
+def test_rejects_image_processing_tokenization_kwargs_on_text_only_fast_path() -> None:
+    info = Idefics3ProcessingInfo(_ProcessingContext(trusted_longest_edge=2048))
+    processor = Idefics3MultiModalProcessor.__new__(Idefics3MultiModalProcessor)
+    processor.info = info
+
+    with pytest.raises(ValueError, match="tokenization_kwargs"):
+        processor._call_hf_processor(
+            "prompt",
+            {},
+            {},
+            {"do_image_splitting": False},
+        )
+
+
+@pytest.mark.parametrize(
+    "tokenization_kwargs",
+    [
+        {"add_special_tokens": False, "truncation": False},
+        {"image_seq_len": 999},
+        {"return_tensors": "pt"},
+        {"images_kwargs": {"return_tensors": "pt"}},
+        {"common_kwargs": {"return_tensors": "pt"}},
+        {"common_kwargs": [["return_tensors", "pt"]]},
+    ],
+)
+def test_allows_non_image_processing_tokenization_kwargs_on_text_only_fast_path(
+    tokenization_kwargs: dict[str, object],
+) -> None:
+    info = Idefics3ProcessingInfo(_ProcessingContext(trusted_longest_edge=2048))
+    processor = Idefics3MultiModalProcessor.__new__(Idefics3MultiModalProcessor)
+    processor.info = info
+
+    output = processor._call_hf_processor(
+        "prompt",
+        {},
+        {},
+        tokenization_kwargs,
+    )
+
+    assert output["input_ids"].tolist() == [[1]]
+
+
+@pytest.mark.parametrize(
+    "tokenization_kwargs",
+    [
+        {"do_image_splitting": False},
+        {"max_image_size": {"longest_edge": 91}},
+    ],
+)
+def test_rejects_image_processing_kwargs_in_tokenization_kwargs_on_all_cache_hit_path(
+    monkeypatch,
+    tokenization_kwargs: dict[str, object],
+) -> None:
+    info = Idefics3ProcessingInfo(_ProcessingContext(trusted_longest_edge=2048))
+    processor = Idefics3MultiModalProcessor.__new__(Idefics3MultiModalProcessor)
+    processor.info = info
+    processor.dummy_inputs = SimpleNamespace(get_dummy_text=lambda _mm_counts: "prompt")
+
+    class _Cache:
+        def touch_sender_cache_item(self, _item_hash: str) -> None:
+            return None
+
+        def get_and_update_item(self, _item, _item_hash: str):
+            return {}, []
+
+    processor.cache = _Cache()
+
+    class _CachedImageItems:
+        def get_processor_data(self) -> dict[str, object]:
+            return {}
+
+        def get_passthrough_data(self) -> dict[str, object]:
+            return {}
+
+    inputs = SimpleNamespace(
+        prompt="prompt",
+        mm_data_items=MultiModalDataItems({"image": _CachedImageItems()}),
+        hf_processor_mm_kwargs={},
+        tokenization_kwargs=tokenization_kwargs,
+        get_mm_hashes=lambda _model_id: {"image": ["cached-image"]},
+    )
+
+    def _all_cache_hit(**_kwargs):
+        return {"image": [True]}, MultiModalDataItems({})
+
+    monkeypatch.setattr(processor, "_get_cache_missing_items", _all_cache_hit)
+    monkeypatch.setattr(processor, "_get_mm_prompt_updates", lambda *_args: {})
+
+    with pytest.raises(ValueError, match="tokenization_kwargs"):
+        processor._cached_apply_hf_processor(
+            inputs,
+            TimingContext(enabled=False),
+        )

--- a/tests/models/multimodal/processing/test_internvl.py
+++ b/tests/models/multimodal/processing/test_internvl.py
@@ -3,17 +3,37 @@
 """Tests for InternVL's multimodal preprocessing kwargs."""
 
 from collections.abc import Mapping
+from types import SimpleNamespace
 
 import pytest
 from PIL import Image
 from transformers import PretrainedConfig
 
+from vllm.model_executor.models.internvl import InternVLProcessingInfo
 from vllm.multimodal import MULTIMODAL_REGISTRY
 from vllm.multimodal.image import rescale_image_size
 from vllm.multimodal.processing import BaseMultiModalProcessor
 
 from ....conftest import ImageTestAssets
 from ...utils import build_model_context
+
+
+class _FakeInternVLProcessingContext:
+    def __init__(self, mm_processor_kwargs: Mapping[str, object] | None = None) -> None:
+        self._mm_processor_kwargs = dict(mm_processor_kwargs or {})
+        self._config = SimpleNamespace(
+            vision_config=SimpleNamespace(image_size=448),
+            min_dynamic_patch=1,
+            max_dynamic_patch=12,
+            dynamic_image_size=True,
+            use_thumbnail=True,
+        )
+
+    def get_hf_config(self):
+        return self._config
+
+    def get_merged_mm_kwargs(self, kwargs: Mapping[str, object]) -> dict[str, object]:
+        return self._mm_processor_kwargs | dict(kwargs)
 
 
 def _get_expected_num_patches(
@@ -79,6 +99,42 @@ def _run_check(
 
     assert img_tok_count == 256 * total_expected_num_patches
     assert pixel_shape[0] == total_expected_num_patches
+
+
+@pytest.mark.cpu_test
+@pytest.mark.parametrize(
+    ("operator_kwargs", "request_max_dynamic_patch", "ceiling"),
+    [
+        ({}, 13, 12),
+        ({"max_dynamic_patch": 4}, 5, 4),
+    ],
+)
+def test_request_max_dynamic_patch_cannot_raise_trusted_ceiling(
+    operator_kwargs: Mapping[str, object],
+    request_max_dynamic_patch: int,
+    ceiling: int,
+) -> None:
+    info = InternVLProcessingInfo(_FakeInternVLProcessingContext(operator_kwargs))
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            rf"max_dynamic_patch={request_max_dynamic_patch} "
+            rf"cannot exceed.*{ceiling}"
+        ),
+    ):
+        info.get_image_processor(max_dynamic_patch=request_max_dynamic_patch)
+
+
+@pytest.mark.cpu_test
+def test_request_max_dynamic_patch_can_lower_trusted_ceiling() -> None:
+    info = InternVLProcessingInfo(
+        _FakeInternVLProcessingContext({"max_dynamic_patch": 4})
+    )
+
+    image_processor = info.get_image_processor(max_dynamic_patch=2)
+
+    assert image_processor.max_dynamic_patch == 2
 
 
 @pytest.mark.parametrize("model_id", ["OpenGVLab/InternVL2-2B"])

--- a/tests/models/multimodal/processing/test_isaac.py
+++ b/tests/models/multimodal/processing/test_isaac.py
@@ -1,0 +1,251 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for Isaac multimodal processor geometry ownership."""
+
+from collections.abc import Mapping
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+import regex as re
+import torch
+from PIL import Image
+
+from vllm.model_executor.models.isaac import IsaacProcessingInfo
+from vllm.transformers_utils.processors import isaac as isaac_processors
+from vllm.transformers_utils.processors.isaac import (
+    IsaacImageProcessor,
+    IsaacProcessor,
+)
+
+
+class _FakeIsaacProcessingContext:
+    def __init__(
+        self,
+        *,
+        video_patch_size: int = 16,
+        vision_max_num_patches: int = 6144,
+        vision_min_num_patches: int | None = 256,
+        pixel_shuffle_scale: int = 2,
+        mm_processor_kwargs: Mapping[str, object] | None = None,
+    ) -> None:
+        self._config = SimpleNamespace(
+            vision_config=None,
+            video_patch_size=video_patch_size,
+            vision_max_num_patches=vision_max_num_patches,
+            vision_min_num_patches=vision_min_num_patches,
+            pixel_shuffle_scale=pixel_shuffle_scale,
+            max_sequence_length=16384,
+            vision_token="<image>",
+            vision_attn_implementation=None,
+        )
+        self._mm_processor_kwargs = dict(mm_processor_kwargs or {})
+
+    def get_hf_config(self) -> SimpleNamespace:
+        return self._config
+
+    def get_merged_mm_kwargs(self, kwargs: Mapping[str, object]) -> dict[str, object]:
+        return self._mm_processor_kwargs | dict(kwargs)
+
+
+class _FakeTokenizer:
+    init_kwargs: dict[str, object] = {}
+
+
+@pytest.mark.cpu_test
+def test_get_image_processor_uses_model_patch_size_by_default() -> None:
+    info = IsaacProcessingInfo(_FakeIsaacProcessingContext(video_patch_size=32))
+
+    image_processor = info.get_image_processor()
+
+    assert image_processor.patch_size == 32
+
+
+@pytest.mark.cpu_test
+def test_get_image_processor_uses_model_geometry_by_default() -> None:
+    info = IsaacProcessingInfo(
+        _FakeIsaacProcessingContext(
+            vision_max_num_patches=128,
+            vision_min_num_patches=64,
+            pixel_shuffle_scale=4,
+        )
+    )
+
+    image_processor = info.get_image_processor()
+
+    assert image_processor.vision_max_num_patches == 128
+    assert image_processor.vision_min_num_patches == 64
+    assert image_processor.pixel_shuffle_scale == 4
+
+
+@pytest.mark.cpu_test
+@pytest.mark.parametrize(
+    ("patch_size", "expected_error"),
+    [
+        (0, "patch_size=0"),
+        (-1, "patch_size=-1"),
+        (16.0, "patch_size=16.0"),
+        (4096, "patch_size=4096"),
+        (2**63, "patch_size=9223372036854775808"),
+    ],
+)
+def test_get_image_processor_rejects_mismatched_request_patch_size(
+    patch_size: object,
+    expected_error: str,
+) -> None:
+    info = IsaacProcessingInfo(_FakeIsaacProcessingContext(video_patch_size=16))
+
+    with pytest.raises(
+        ValueError,
+        match=rf"{re.escape(expected_error)} must match the configured Isaac "
+        r"patch size of 16",
+    ):
+        info.get_image_processor(patch_size=patch_size)
+
+
+@pytest.mark.cpu_test
+def test_get_image_processor_allows_request_patch_size_that_matches_model() -> None:
+    info = IsaacProcessingInfo(_FakeIsaacProcessingContext(video_patch_size=16))
+
+    image_processor = info.get_image_processor(patch_size=16)
+
+    assert image_processor.patch_size == 16
+
+
+@pytest.mark.cpu_test
+@pytest.mark.parametrize(
+    ("kwargs", "expected_error"),
+    [
+        (
+            {"vision_max_num_patches": 999999},
+            "vision_max_num_patches=999999",
+        ),
+        (
+            {"vision_min_num_patches": 999999},
+            "vision_min_num_patches=999999",
+        ),
+        (
+            {"pixel_shuffle_scale": 4096},
+            "pixel_shuffle_scale=4096",
+        ),
+    ],
+)
+def test_get_image_processor_rejects_request_geometry_that_differs_from_model(
+    kwargs: dict[str, object],
+    expected_error: str,
+) -> None:
+    info = IsaacProcessingInfo(_FakeIsaacProcessingContext())
+
+    with pytest.raises(ValueError, match=expected_error):
+        info.get_image_processor(**kwargs)
+
+
+@pytest.mark.cpu_test
+@pytest.mark.parametrize(
+    ("images_kwargs", "expected_error"),
+    [
+        ({"patch_size": 4096}, "patch_size=4096"),
+        ({"max_num_patches": 999999}, "max_num_patches=999999"),
+        ({"min_num_patches": 999999}, "min_num_patches=999999"),
+        ({"pixel_shuffle_scale": 4096}, "pixel_shuffle_scale=4096"),
+    ],
+)
+def test_nested_geometry_is_rejected_before_patchification(
+    monkeypatch: pytest.MonkeyPatch,
+    images_kwargs: dict[str, object],
+    expected_error: str,
+) -> None:
+    patchify_called = False
+
+    def fake_process_vision_for_patches(
+        _image: torch.Tensor,
+        *,
+        patch_size: int,
+        max_num_patches: int,
+        min_num_patches: int | None,
+        pixel_shuffle_scale: int,
+    ) -> tuple[torch.Tensor, list[int]]:
+        nonlocal patchify_called
+        patchify_called = True
+        return torch.zeros((1, 1, 1, 3)), [1, 1, 1]
+
+    monkeypatch.setattr(
+        isaac_processors,
+        "process_vision_for_patches",
+        fake_process_vision_for_patches,
+    )
+
+    processor = IsaacProcessor(
+        IsaacImageProcessor(patch_size=16),
+        cast(Any, _FakeTokenizer()),
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=expected_error,
+    ):
+        processor(
+            images=Image.new("RGB", (1, 1), color="white"),
+            images_kwargs=images_kwargs,
+        )
+
+    assert not patchify_called
+
+
+@pytest.mark.cpu_test
+def test_nested_geometry_that_matches_model_reaches_patchification(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    patchify_kwargs: dict[str, object] = {}
+
+    def fake_process_vision_for_patches(
+        _image: torch.Tensor,
+        *,
+        patch_size: int,
+        max_num_patches: int,
+        min_num_patches: int | None,
+        pixel_shuffle_scale: int,
+    ) -> tuple[torch.Tensor, list[int]]:
+        patchify_kwargs.update(
+            {
+                "patch_size": patch_size,
+                "max_num_patches": max_num_patches,
+                "min_num_patches": min_num_patches,
+                "pixel_shuffle_scale": pixel_shuffle_scale,
+            }
+        )
+        return torch.zeros((1, 1, 1, 3)), [1, 1, 1]
+
+    monkeypatch.setattr(
+        isaac_processors,
+        "process_vision_for_patches",
+        fake_process_vision_for_patches,
+    )
+
+    processor = IsaacProcessor(
+        IsaacImageProcessor(
+            patch_size=16,
+            vision_max_num_patches=6144,
+            vision_min_num_patches=256,
+            pixel_shuffle_scale=2,
+        ),
+        cast(Any, _FakeTokenizer()),
+    )
+
+    output = processor(
+        images=Image.new("RGB", (1, 1), color="white"),
+        images_kwargs={
+            "patch_size": 16,
+            "max_num_patches": 6144,
+            "min_num_patches": 256,
+            "pixel_shuffle_scale": 2,
+        },
+    )
+
+    assert patchify_kwargs == {
+        "patch_size": 16,
+        "max_num_patches": 6144,
+        "min_num_patches": 256,
+        "pixel_shuffle_scale": 2,
+    }
+    assert output["pixel_values"].shape == torch.Size([1, 3])

--- a/tests/models/multimodal/processing/test_lfm2_vl.py
+++ b/tests/models/multimodal/processing/test_lfm2_vl.py
@@ -1,0 +1,96 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for LFM2-VL multimodal processor request bounds."""
+
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+
+from vllm.model_executor.models.lfm2_vl import Lfm2VLMultiModalProcessor
+from vllm.multimodal.processing import (
+    BaseMultiModalProcessor,
+    ProcessorInputs,
+    TimingContext,
+)
+
+
+class _FakeLfm2Info:
+    def __init__(self, max_tiles: int) -> None:
+        self._max_tiles = max_tiles
+
+    def get_image_processor(self) -> SimpleNamespace:
+        return SimpleNamespace(max_tiles=self._max_tiles)
+
+
+def _make_processor(max_tiles: int) -> Lfm2VLMultiModalProcessor:
+    processor = object.__new__(Lfm2VLMultiModalProcessor)
+    processor.info = cast(Any, _FakeLfm2Info(max_tiles))
+    return processor
+
+
+@pytest.mark.parametrize(
+    "hf_processor_mm_kwargs",
+    [
+        {"max_tiles": 700},
+        {"images_kwargs": {"max_tiles": 700}},
+        {"min_tiles": -1},
+        {"images_kwargs": {"min_tiles": -1}},
+    ],
+)
+def test_lfm2_rejects_unsafe_request_tile_bounds_before_base_processing(
+    monkeypatch: pytest.MonkeyPatch,
+    hf_processor_mm_kwargs: dict[str, object],
+) -> None:
+    processor = _make_processor(max_tiles=10)
+    base_apply_called = False
+
+    def fake_base_apply(
+        _self: BaseMultiModalProcessor,
+        _inputs: ProcessorInputs,
+        _timing_ctx: TimingContext,
+    ) -> object:
+        nonlocal base_apply_called
+        base_apply_called = True
+        return object()
+
+    monkeypatch.setattr(BaseMultiModalProcessor, "apply", fake_base_apply)
+
+    inputs = ProcessorInputs(
+        prompt="",
+        mm_data_items=cast(Any, {}),
+        hf_processor_mm_kwargs=hf_processor_mm_kwargs,
+    )
+
+    with pytest.raises(ValueError, match="LFM2-VL request"):
+        processor.apply(inputs, TimingContext(enabled=False))
+
+    assert not base_apply_called
+
+
+def test_lfm2_allows_request_tile_bounds_within_operator_ceiling(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    processor = _make_processor(max_tiles=12)
+    expected = object()
+    base_apply_called = False
+
+    def fake_base_apply(
+        _self: BaseMultiModalProcessor,
+        _inputs: ProcessorInputs,
+        _timing_ctx: TimingContext,
+    ) -> object:
+        nonlocal base_apply_called
+        base_apply_called = True
+        return expected
+
+    monkeypatch.setattr(BaseMultiModalProcessor, "apply", fake_base_apply)
+
+    inputs = ProcessorInputs(
+        prompt="",
+        mm_data_items=cast(Any, {}),
+        hf_processor_mm_kwargs={"min_tiles": 1, "max_tiles": 12},
+    )
+
+    assert processor.apply(inputs, TimingContext(enabled=False)) is expected
+    assert base_apply_called

--- a/tests/models/multimodal/processing/test_llava_onevision2.py
+++ b/tests/models/multimodal/processing/test_llava_onevision2.py
@@ -20,10 +20,15 @@ import types
 
 import numpy as np
 import pytest
+import torch
 
 from vllm.model_executor.models.llava_onevision2 import (
     _CODEC_VIDEO_MARKER,
+    _IMAGE_MARKER,
+    _VIDEO_MARKER,
+    LlavaOnevision2MultiModalProcessor,
     LlavaOnevision2VideoBackend,
+    _expand_video_markers_in_prompt,
     _extract_codec_video_paths,
     _frame_video_to_pil_and_timestamps,
     _validate_video_source,
@@ -250,6 +255,139 @@ def test_frame_video_to_pil_and_timestamps_rejects_non_tuple():
     plain = np.zeros((4, 8, 8, 3), dtype=np.uint8)
     with pytest.raises(ValueError):
         _frame_video_to_pil_and_timestamps(plain)
+
+
+@pytest.mark.parametrize("timestamp_decimals", [-1, 50000, -0.5, 6.9, True, None])
+def test_expand_video_markers_rejects_out_of_range_timestamp_decimals(
+    timestamp_decimals,
+):
+    with pytest.raises(
+        ValueError,
+        match="LlavaOneVision2 timestamp_decimals must be an integer between 0 and 6",
+    ):
+        _expand_video_markers_in_prompt(
+            _VIDEO_MARKER,
+            [[0.0]],
+            timestamp_decimals=timestamp_decimals,
+        )
+
+
+@pytest.mark.parametrize(
+    ("timestamp_decimals", "expected_prefix"),
+    [
+        (0, "<0 seconds>"),
+        (1, "<0.0 seconds>"),
+        (6, "<0.000000 seconds>"),
+    ],
+)
+def test_expand_video_markers_accepts_bounded_timestamp_decimals(
+    timestamp_decimals,
+    expected_prefix,
+):
+    expanded = _expand_video_markers_in_prompt(
+        _VIDEO_MARKER,
+        [[0.0]],
+        timestamp_decimals=timestamp_decimals,
+    )
+
+    assert expanded == f"{expected_prefix}{_IMAGE_MARKER}"
+
+
+def test_prompt_updates_reject_oversized_timestamp_decimals_before_processor_lookup():
+    class _UnexpectedInfo:
+        def get_image_processor(self, **kwargs):
+            raise AssertionError(f"unexpected processor lookup: {kwargs}")
+
+    processor = LlavaOnevision2MultiModalProcessor.__new__(
+        LlavaOnevision2MultiModalProcessor
+    )
+    processor.info = _UnexpectedInfo()
+
+    with pytest.raises(
+        ValueError,
+        match="LlavaOneVision2 timestamp_decimals must be an integer between 0 and 6",
+    ):
+        processor._get_prompt_updates(
+            mm_items=None,
+            hf_processor_mm_kwargs={"timestamp_decimals": 50000},
+            out_mm_kwargs=None,
+        )
+
+
+def test_hf_processor_call_rejects_oversized_timestamp_decimals_early():
+    class _UnexpectedInfo:
+        def get_hf_processor(self, **kwargs):
+            raise AssertionError(f"unexpected processor lookup: {kwargs}")
+
+    processor = LlavaOnevision2MultiModalProcessor.__new__(
+        LlavaOnevision2MultiModalProcessor
+    )
+    processor.info = _UnexpectedInfo()
+
+    with pytest.raises(
+        ValueError,
+        match="LlavaOneVision2 timestamp_decimals must be an integer between 0 and 6",
+    ):
+        processor._call_hf_processor(
+            prompt=_VIDEO_MARKER,
+            mm_data={"videos": [object()]},
+            mm_kwargs={"timestamp_decimals": 50000},
+            tok_kwargs={},
+        )
+
+
+@pytest.mark.parametrize("hf_processor_mm_kwargs", [{}, {"timestamp_decimals": 1}])
+def test_prompt_updates_preserve_default_one_decimal_timestamp(
+    hf_processor_mm_kwargs,
+):
+    class _FakeImageProcessor:
+        merge_size = 1
+
+    class _FakeTokenizer:
+        def get_vocab(self):
+            return {
+                "<|image_pad|>": 1,
+                "<|video_pad|>": 2,
+                "<|vision_start|>": 3,
+                "<|vision_end|>": 4,
+            }
+
+        def encode(self, text, add_special_tokens=False):
+            assert add_special_tokens is False
+            if text == "\n":
+                return [5]
+            assert text == "<0.0 seconds>"
+            return [6]
+
+    class _Info:
+        def get_image_processor(self, **kwargs):
+            assert kwargs == hf_processor_mm_kwargs
+            return _FakeImageProcessor()
+
+        def get_tokenizer(self):
+            return _FakeTokenizer()
+
+    processor = LlavaOnevision2MultiModalProcessor.__new__(
+        LlavaOnevision2MultiModalProcessor
+    )
+    processor.info = _Info()
+    out_mm_kwargs = {
+        "video": [
+            {
+                "video_grid_thw": types.SimpleNamespace(data=torch.tensor([[1, 1, 1]])),
+                "frame_timestamps": types.SimpleNamespace(data=torch.tensor([0.0])),
+            }
+        ]
+    }
+
+    updates = processor._get_prompt_updates(
+        mm_items=None,
+        hf_processor_mm_kwargs=hf_processor_mm_kwargs,
+        out_mm_kwargs=out_mm_kwargs,
+    )
+    video_update = next(update for update in updates if update.modality == "video")
+
+    assert video_update.resolve(0).content.full == [6, 3, 1, 4]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/models/multimodal/processing/test_minicpmv.py
+++ b/tests/models/multimodal/processing/test_minicpmv.py
@@ -3,9 +3,15 @@
 
 """Tests for MiniCPMV's multimodal preprocessing."""
 
+from types import SimpleNamespace
+
 import numpy as np
 import pytest
+import torch
 
+from vllm.model_executor.models.minicpmo import MiniCPMOMultiModalProcessor
+from vllm.model_executor.models.minicpmv import MiniCPMVMultiModalProcessor
+from vllm.model_executor.models.minicpmv4_6 import MiniCPMV4_6MultiModalProcessor
 from vllm.multimodal import MULTIMODAL_REGISTRY
 
 from ...utils import build_model_context
@@ -72,3 +78,178 @@ def test_prompt_has_dif_BPE_boundaries_in_context(model_id: str):
     image_placeholders = processed["mm_placeholders"].get("image", [])
     assert len(image_placeholders) == 1
     assert image_placeholders[0].length > 0
+
+
+class _ParsedMMItems:
+    def get_items(self, modality, item_types):
+        del modality, item_types
+        return ["image"]
+
+
+class _ImageProcessor:
+    patch_size = 1
+
+    def __init__(self, max_slice_nums: int):
+        self.max_slice_nums = max_slice_nums
+        self.calls: list[tuple[list[str], dict[str, object]]] = []
+
+    def __call__(self, images, **kwargs):
+        self.calls.append((images, kwargs))
+        return {
+            "pixel_values": torch.ones((1, 3, 1, 1)),
+            "target_sizes": torch.tensor([[1, 1]]),
+        }
+
+
+class _ProcessingInfo:
+    image_pattern = "<image>"
+
+    def __init__(self, max_slice_nums: int):
+        self.max_slice_nums = max_slice_nums
+        self.image_processor = _ImageProcessor(max_slice_nums)
+        self.hf_config = SimpleNamespace(insert_layer_id=-1)
+
+    def parse_mm_data(self, data, validate=False):
+        assert data == {"image": ["image"]}
+        assert validate is False
+        return _ParsedMMItems()
+
+    def get_image_processor(self):
+        return self.image_processor
+
+    def get_image_processor_max_slice_num(self) -> int:
+        return self.max_slice_nums
+
+    def _get_downsample_mode(self) -> str:
+        return "16x"
+
+    def get_hf_config(self):
+        return self.hf_config
+
+
+def _build_shared_processor(processor_cls, max_slice_nums: int):
+    processor = object.__new__(processor_cls)
+    processor.info = _ProcessingInfo(max_slice_nums)
+    processor.hf_calls = []
+
+    def _base_call_hf_processor(*, mm_kwargs, **kwargs):
+        del kwargs
+        processor.hf_calls.append(dict(mm_kwargs))
+        return {}
+
+    processor._base_call_hf_processor = _base_call_hf_processor
+    return processor
+
+
+def _build_v46_processor(max_slice_nums: int):
+    processor = object.__new__(MiniCPMV4_6MultiModalProcessor)
+    processor.info = _ProcessingInfo(max_slice_nums)
+    return processor
+
+
+@pytest.mark.parametrize(
+    "processor_cls",
+    [
+        pytest.param(MiniCPMVMultiModalProcessor, id="minicpmv"),
+        pytest.param(MiniCPMOMultiModalProcessor, id="minicpmo"),
+    ],
+)
+@pytest.mark.parametrize("request_max_slice_nums", [8, 10, 9.0])
+def test_shared_minicpm_image_paths_reject_request_max_slice_nums_mismatch(
+    processor_cls,
+    request_max_slice_nums: object,
+):
+    processor = _build_shared_processor(processor_cls, max_slice_nums=9)
+
+    with pytest.raises(
+        ValueError,
+        match="must match the deployed MiniCPM image processor configuration",
+    ):
+        processor.process_images(
+            {"images": ["image"]},
+            {"max_slice_nums": request_max_slice_nums},
+            {},
+        )
+
+    assert processor.hf_calls == []
+
+
+@pytest.mark.parametrize(
+    "processor_cls",
+    [
+        pytest.param(MiniCPMVMultiModalProcessor, id="minicpmv"),
+        pytest.param(MiniCPMOMultiModalProcessor, id="minicpmo"),
+    ],
+)
+def test_shared_minicpm_image_paths_allow_deployed_max_slice_nums(processor_cls):
+    processor = _build_shared_processor(processor_cls, max_slice_nums=4)
+
+    processor.process_images(
+        {"images": ["image"]},
+        {"max_slice_nums": 4, "do_pad": False},
+        {},
+    )
+
+    assert processor.hf_calls == [{"max_slice_nums": 4, "do_pad": False}]
+
+
+@pytest.mark.parametrize(
+    "mm_kwargs",
+    [
+        pytest.param({}, id="omitted"),
+        pytest.param({"max_slice_nums": None}, id="explicit-none"),
+    ],
+)
+def test_shared_minicpm_image_paths_allow_unset_max_slice_nums(mm_kwargs):
+    processor = _build_shared_processor(MiniCPMVMultiModalProcessor, max_slice_nums=4)
+
+    processor.process_images({"images": ["image"]}, mm_kwargs, {})
+
+    assert len(processor.hf_calls) == 1
+
+
+@pytest.mark.parametrize("request_max_slice_nums", [8, 10, 9.0])
+def test_minicpmv46_image_path_rejects_request_max_slice_nums_mismatch(
+    request_max_slice_nums: object,
+):
+    processor = _build_v46_processor(max_slice_nums=9)
+
+    with pytest.raises(
+        ValueError,
+        match="must match the deployed MiniCPM image processor configuration",
+    ):
+        processor.process_images(
+            {"images": ["image"]},
+            {"max_slice_nums": request_max_slice_nums},
+            {},
+        )
+
+    assert processor.info.image_processor.calls == []
+
+
+def test_minicpmv46_image_path_allows_deployed_max_slice_nums():
+    processor = _build_v46_processor(max_slice_nums=4)
+
+    result = processor.process_images(
+        {"images": ["image"]},
+        {"max_slice_nums": 4},
+        {},
+    )
+
+    assert processor.info.image_processor.calls == [(["image"], {"max_slice_nums": 4})]
+    assert result["pixel_values"][0].shape == (1, 3, 1, 1)
+
+
+@pytest.mark.parametrize(
+    "mm_kwargs",
+    [
+        pytest.param({}, id="omitted"),
+        pytest.param({"max_slice_nums": None}, id="explicit-none"),
+    ],
+)
+def test_minicpmv46_image_path_allows_unset_max_slice_nums(mm_kwargs):
+    processor = _build_v46_processor(max_slice_nums=4)
+
+    processor.process_images({"images": ["image"]}, mm_kwargs, {})
+
+    assert len(processor.info.image_processor.calls) == 1

--- a/tests/models/multimodal/processing/test_moondream3.py
+++ b/tests/models/multimodal/processing/test_moondream3.py
@@ -25,6 +25,7 @@ EXPECTED_IMAGE_TOKENS = 730
 CROP_SIZE = 378
 PATCH_SIZE = 14
 MAX_CROPS = 12
+OVERLAP_MARGIN = 4
 
 
 @pytest.mark.parametrize("model_id", [MOONDREAM3_MODEL_ID])
@@ -102,6 +103,108 @@ def test_processor_pixel_values(
     assert pixel_values.shape[2] == 3  # RGB channels
     assert pixel_values.shape[3] == 378  # crop height
     assert pixel_values.shape[4] == 378  # crop width
+
+
+@pytest.mark.parametrize(
+    "mm_processor_kwargs",
+    [
+        pytest.param({"crop_size": CROP_SIZE * 2}, id="flat-crop-size"),
+        pytest.param(
+            {"images_kwargs": {"crop_size": CROP_SIZE * 2}},
+            id="images-kwargs-crop-size",
+        ),
+        pytest.param(
+            {"common_kwargs": {"crop_size": CROP_SIZE * 2}},
+            id="common-kwargs-crop-size",
+        ),
+        pytest.param({"max_crops": MAX_CROPS + 1}, id="flat-max-crops"),
+        pytest.param(
+            {"images_kwargs": {"max_crops": MAX_CROPS + 1}},
+            id="images-kwargs-max-crops",
+        ),
+        pytest.param(
+            {"common_kwargs": {"max_crops": MAX_CROPS + 1}},
+            id="common-kwargs-max-crops",
+        ),
+        pytest.param({"patch_size": PATCH_SIZE * 2}, id="flat-patch-size"),
+        pytest.param(
+            {"images_kwargs": {"patch_size": PATCH_SIZE * 2}},
+            id="images-kwargs-patch-size",
+        ),
+        pytest.param(
+            {"common_kwargs": {"patch_size": PATCH_SIZE * 2}},
+            id="common-kwargs-patch-size",
+        ),
+        pytest.param(
+            {"overlap_margin": OVERLAP_MARGIN + 1},
+            id="flat-overlap-margin",
+        ),
+        pytest.param(
+            {"images_kwargs": {"overlap_margin": OVERLAP_MARGIN + 1}},
+            id="images-kwargs-overlap-margin",
+        ),
+        pytest.param(
+            {"common_kwargs": {"overlap_margin": OVERLAP_MARGIN + 1}},
+            id="common-kwargs-overlap-margin",
+        ),
+    ],
+)
+@pytest.mark.parametrize("model_id", [MOONDREAM3_MODEL_ID])
+def test_processor_rejects_request_geometry_overrides(
+    image_assets: ImageTestAssets,
+    mm_processor_kwargs: dict[str, object],
+    model_id: str,
+):
+    ctx = build_model_context(
+        model_id,
+        limit_mm_per_prompt={"image": 1},
+    )
+    processor = MULTIMODAL_REGISTRY.create_processor(ctx.model_config)
+
+    prompt = "<|endoftext|><image><|md_reserved_0|>query<|md_reserved_1|>What is this?<|md_reserved_2|>"  # noqa: E501
+    mm_data = {"image": [image_assets[0].pil_image]}
+
+    with pytest.raises(
+        ValueError,
+        match="must match the deployed vision configuration",
+    ):
+        processor(
+            prompt,
+            mm_items=processor.info.parse_mm_data(mm_data),
+            hf_processor_mm_kwargs=mm_processor_kwargs,
+        )
+
+
+@pytest.mark.parametrize("model_id", [MOONDREAM3_MODEL_ID])
+def test_processor_accepts_trusted_geometry_overrides(
+    image_assets: ImageTestAssets,
+    model_id: str,
+):
+    ctx = build_model_context(
+        model_id,
+        limit_mm_per_prompt={"image": 1},
+    )
+    processor = MULTIMODAL_REGISTRY.create_processor(ctx.model_config)
+
+    prompt = "<|endoftext|><image><|md_reserved_0|>query<|md_reserved_1|>What is this?<|md_reserved_2|>"  # noqa: E501
+    mm_data = {"image": [image_assets[0].pil_image]}
+    mm_processor_kwargs = {
+        "images_kwargs": {
+            "crop_size": CROP_SIZE,
+            "max_crops": MAX_CROPS,
+            "overlap_margin": OVERLAP_MARGIN,
+            "patch_size": PATCH_SIZE,
+        }
+    }
+
+    processed_inputs = processor(
+        prompt,
+        mm_items=processor.info.parse_mm_data(mm_data),
+        hf_processor_mm_kwargs=mm_processor_kwargs,
+    )
+
+    mm_kwargs = processed_inputs["mm_kwargs"].get_data()
+    assert mm_kwargs["pixel_values"].shape[2:] == (3, CROP_SIZE, CROP_SIZE)
 
 
 @pytest.mark.parametrize("model_id", [MOONDREAM3_MODEL_ID])

--- a/tests/models/multimodal/processing/test_phi4mm_dynamic_hd.py
+++ b/tests/models/multimodal/processing/test_phi4mm_dynamic_hd.py
@@ -1,0 +1,270 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import math
+from types import SimpleNamespace
+
+import pytest
+from PIL import Image
+from transformers import BatchFeature
+
+from vllm.model_executor.models.phi4mm import (
+    Phi4MMMultiModalProcessor,
+    Phi4MMProcessingInfo,
+)
+from vllm.multimodal.parse import ImageSize
+from vllm.multimodal.processing.processor import BaseMultiModalProcessor
+
+
+class _FakeImageProcessor:
+    def __init__(self, dynamic_hd: object):
+        self.dynamic_hd = dynamic_hd
+
+    def find_closest_aspect_ratio(
+        self,
+        aspect_ratio: float,
+        target_ratios: list[tuple[int, int]],
+        width: int,
+        height: int,
+        image_size: int,
+    ) -> tuple[int, int]:
+        best_ratio_diff = float("inf")
+        best_ratio = (1, 1)
+        area = width * height
+        for ratio in target_ratios:
+            ratio_diff = abs(aspect_ratio - ratio[0] / ratio[1])
+            if ratio_diff < best_ratio_diff:
+                best_ratio_diff = ratio_diff
+                best_ratio = ratio
+            elif ratio_diff == best_ratio_diff:
+                if area > 0.5 * image_size * image_size * ratio[0] * ratio[1]:
+                    best_ratio = ratio
+
+        return best_ratio
+
+
+class _Phi4MMProcessingContext:
+    def __init__(self, dynamic_hd: object = 36):
+        self.dynamic_hd = dynamic_hd
+
+    def get_hf_config(self) -> SimpleNamespace:
+        return SimpleNamespace(img_processor=None)
+
+    def get_hf_processor(self, **kwargs: object) -> SimpleNamespace:
+        dynamic_hd = kwargs.get("dynamic_hd", self.dynamic_hd)
+        return SimpleNamespace(
+            image_processor=_FakeImageProcessor(dynamic_hd),
+            audio_processor=SimpleNamespace(sampling_rate=16000),
+        )
+
+
+def _get_num_image_tokens(
+    *,
+    deployment_dynamic_hd: object = 36,
+    request_dynamic_hd: object = 36,
+    image_width: int = 448 * 128,
+    image_height: int = 448,
+) -> int:
+    info = Phi4MMProcessingInfo(_Phi4MMProcessingContext(deployment_dynamic_hd))
+    processor = info.get_hf_processor(dynamic_hd=request_dynamic_hd)
+    return info.get_num_image_tokens(
+        image_width=image_width,
+        image_height=image_height,
+        processor=processor,
+    )
+
+
+def test_rejects_crop_fanout_above_deployment_ceiling():
+    with pytest.raises(ValueError, match="exceeds the deployed limit"):
+        _get_num_image_tokens(request_dynamic_hd=128)
+
+
+def test_accepts_operator_selected_higher_trusted_ceiling():
+    assert (
+        _get_num_image_tokens(
+            deployment_dynamic_hd=128,
+            request_dynamic_hd=128,
+        )
+        > 0
+    )
+
+
+def test_accepts_high_named_cap_when_geometry_stays_within_ceiling():
+    assert _get_num_image_tokens(
+        request_dynamic_hd=128,
+        image_width=448,
+        image_height=448,
+    ) == _get_num_image_tokens(
+        request_dynamic_hd=36,
+        image_width=448,
+        image_height=448,
+    )
+
+
+def test_accepts_high_named_cap_when_search_result_stays_within_ceiling():
+    assert _get_num_image_tokens(
+        request_dynamic_hd=37,
+        image_width=448 * 2,
+        image_height=448 * 19,
+    ) == _get_num_image_tokens(
+        request_dynamic_hd=36,
+        image_width=448 * 2,
+        image_height=448 * 19,
+    )
+
+
+def test_ratio_search_candidate_count_is_sublinear_in_dynamic_hd(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    info = Phi4MMProcessingInfo(_Phi4MMProcessingContext())
+    candidate_counts: list[int] = []
+    original = _FakeImageProcessor.find_closest_aspect_ratio
+
+    def capture_candidate_count(
+        self: _FakeImageProcessor,
+        aspect_ratio: float,
+        target_ratios: list[tuple[int, int]],
+        width: int,
+        height: int,
+        image_size: int,
+    ) -> tuple[int, int]:
+        candidate_counts.append(len(target_ratios))
+        return original(self, aspect_ratio, target_ratios, width, height, image_size)
+
+    monkeypatch.setattr(
+        _FakeImageProcessor,
+        "find_closest_aspect_ratio",
+        capture_candidate_count,
+    )
+
+    info._find_target_aspect_ratio(
+        448 * 129,
+        448,
+        448,
+        128,
+        min_num=1,
+    )
+
+    assert candidate_counts
+    assert candidate_counts[0] <= 4 * math.isqrt(128)
+
+
+@pytest.mark.parametrize("dynamic_hd", [0, -1, True, False, 1.5])
+def test_rejects_invalid_dynamic_hd(dynamic_hd: object):
+    with pytest.raises(ValueError, match="must be a positive integer"):
+        _get_num_image_tokens(
+            request_dynamic_hd=dynamic_hd,
+            image_width=448,
+            image_height=448,
+        )
+
+
+class _FakeParsedImages:
+    def __init__(self, image_size: ImageSize | None = None):
+        self.image_size = image_size or ImageSize(width=448 * 128, height=448)
+
+    def __len__(self) -> int:
+        return 1
+
+    def get_image_size(self, item_idx: int) -> ImageSize:
+        assert item_idx == 0
+        return self.image_size
+
+
+class _FakeMMItems:
+    def __init__(self, image_size: ImageSize | None = None):
+        self.image_size = image_size
+
+    def get_items(self, modality: str, item_type):
+        assert modality == "image"
+        return _FakeParsedImages(self.image_size)
+
+
+class _RejectingInfo:
+    def parse_mm_data(self, mm_data, validate=False):
+        del mm_data, validate
+        return _FakeMMItems()
+
+    def get_hf_processor(self, **mm_kwargs: object):
+        del mm_kwargs
+        return object()
+
+    def get_feature_extractor(self, **mm_kwargs: object):
+        del mm_kwargs
+        return SimpleNamespace(sampling_rate=16000)
+
+    def get_num_image_tokens(self, **kwargs: object) -> int:
+        del kwargs
+        raise ValueError("Phi4MM local HD crop count exceeds the deployed limit")
+
+
+def test_rejects_before_hf_preprocessing(monkeypatch: pytest.MonkeyPatch):
+    hf_called = False
+
+    def fake_call_hf_processor(self, prompt, mm_data, mm_kwargs, tok_kwargs):
+        nonlocal hf_called
+        del self, prompt, mm_data, mm_kwargs, tok_kwargs
+        hf_called = True
+        return BatchFeature(
+            {
+                "image_sizes": [[448 * 128, 448]],
+                "input_audio_embeds": [],
+            }
+        )
+
+    monkeypatch.setattr(
+        BaseMultiModalProcessor,
+        "_call_hf_processor",
+        fake_call_hf_processor,
+    )
+
+    processor = object.__new__(Phi4MMMultiModalProcessor)
+    processor.info = _RejectingInfo()
+
+    with pytest.raises(ValueError, match="exceeds the deployed limit"):
+        processor._call_hf_processor(
+            "prompt",
+            {"images": [object()]},
+            {},
+            {},
+        )
+
+    assert not hf_called
+
+
+def test_high_named_cap_is_canonicalized_before_hf_preprocessing(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    captured_mm_kwargs: dict[str, object] = {}
+
+    def fake_call_hf_processor(self, prompt, mm_data, mm_kwargs, tok_kwargs):
+        del self, prompt, mm_data, tok_kwargs
+        captured_mm_kwargs.update(mm_kwargs)
+        return BatchFeature(
+            {
+                "image_sizes": [[448, 448]],
+                "input_audio_embeds": [],
+            }
+        )
+
+    monkeypatch.setattr(
+        BaseMultiModalProcessor,
+        "_call_hf_processor",
+        fake_call_hf_processor,
+    )
+
+    processor = object.__new__(Phi4MMMultiModalProcessor)
+    processor.info = Phi4MMProcessingInfo(_Phi4MMProcessingContext())
+    monkeypatch.setattr(
+        processor.info,
+        "parse_mm_data",
+        lambda mm_data, validate=False: _FakeMMItems(ImageSize(width=448, height=448)),
+    )
+    processor._call_hf_processor(
+        "prompt",
+        {"images": [Image.new("RGB", (448, 448))]},
+        {"dynamic_hd": 128},
+        {},
+    )
+
+    assert captured_mm_kwargs == {"dynamic_hd": 36}

--- a/tests/models/multimodal/processing/test_qwen2_vl.py
+++ b/tests/models/multimodal/processing/test_qwen2_vl.py
@@ -1,16 +1,86 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from types import SimpleNamespace
+
 import pytest
 import torch
 from packaging.version import Version
 from transformers import __version__ as TRANSFORMERS_VERSION
 
+from vllm.model_executor.models.qwen2_vl import (
+    Qwen2VLMultiModalProcessor,
+    Qwen2VLProcessingInfo,
+)
 from vllm.model_executor.models.vision import FusedInputNorm
 from vllm.multimodal import MULTIMODAL_REGISTRY
+from vllm.multimodal.parse import MultiModalDataItems
+from vllm.multimodal.processing import BaseMultiModalProcessor, ProcessorInputs
+from vllm.multimodal.processing.context import TimingContext
 
 from ....conftest import ImageTestAssets
 from ...utils import build_model_context
+
+
+@pytest.mark.parametrize(
+    "request_kwargs",
+    [
+        {"max_pixels": 1025},
+        {"size": {"longest_edge": 1025}},
+        {"min_pixels": 1025},
+        {"size": {"shortest_edge": 1025}},
+    ],
+)
+def test_request_cannot_raise_qwen2vl_pixel_ceiling(
+    monkeypatch: pytest.MonkeyPatch,
+    request_kwargs: dict[str, object],
+):
+    info = object.__new__(Qwen2VLProcessingInfo)
+    monkeypatch.setattr(
+        info,
+        "get_image_processor",
+        lambda: SimpleNamespace(size={"longest_edge": 1024}),
+    )
+
+    processor = object.__new__(Qwen2VLMultiModalProcessor)
+    processor.info = info
+    monkeypatch.setattr(BaseMultiModalProcessor, "apply", lambda *_args: object())
+
+    with pytest.raises(ValueError, match="configured max_pixels ceiling"):
+        processor.apply(
+            ProcessorInputs(
+                "",
+                MultiModalDataItems({}),
+                hf_processor_mm_kwargs=request_kwargs,
+            ),
+            TimingContext(enabled=False),
+        )
+
+
+def test_request_can_lower_qwen2vl_pixel_ceiling(monkeypatch: pytest.MonkeyPatch):
+    info = object.__new__(Qwen2VLProcessingInfo)
+    monkeypatch.setattr(
+        info,
+        "get_image_processor",
+        lambda: SimpleNamespace(size={"longest_edge": 1024}),
+    )
+
+    processor = object.__new__(Qwen2VLMultiModalProcessor)
+    processor.info = info
+    sentinel = object()
+    monkeypatch.setattr(BaseMultiModalProcessor, "apply", lambda *_args: sentinel)
+
+    assert (
+        processor.apply(
+            ProcessorInputs(
+                "",
+                MultiModalDataItems({}),
+                hf_processor_mm_kwargs={"max_pixels": 1023},
+            ),
+            TimingContext(enabled=False),
+        )
+        is sentinel
+    )
 
 
 @pytest.mark.parametrize("model_id", ["Qwen/Qwen2-VL-2B-Instruct"])

--- a/tests/multimodal/media/test_video.py
+++ b/tests/multimodal/media/test_video.py
@@ -21,6 +21,7 @@ from vllm.multimodal.video import (
     VIDEO_LOADER_REGISTRY,
     VideoLoader,
 )
+from vllm.renderers.params import ChatParams
 
 from ..utils import cosine_similarity, create_video_from_image, normalize_image
 
@@ -272,6 +273,27 @@ def _make_jpeg_b64_frames(n: int, width: int = 8, height: int = 8) -> list[str]:
     return frames
 
 
+def _load_request_jpeg_frames(
+    runtime_video_kwargs: dict[str, object],
+    *,
+    default_video_kwargs: dict[str, object] | None = None,
+    sent_frames: int = 40,
+) -> tuple[npt.NDArray, dict[str, object]]:
+    chat_params = ChatParams(
+        media_io_kwargs={"video": runtime_video_kwargs},
+    ).with_defaults(
+        default_media_io_kwargs=(
+            None if default_video_kwargs is None else {"video": default_video_kwargs}
+        ),
+    )
+
+    assert chat_params.media_io_kwargs is not None
+    videoio = VideoMediaIO(ImageMediaIO(), **chat_params.media_io_kwargs["video"])
+    return videoio.load_base64(
+        "video/jpeg", ",".join(_make_jpeg_b64_frames(sent_frames))
+    )
+
+
 def test_load_base64_jpeg_returns_metadata():
     """Regression test: load_base64 with video/jpeg must return metadata.
 
@@ -361,6 +383,79 @@ def test_load_base64_jpeg_raises_on_zero_num_frames():
 
     with pytest.raises(ValueError, match="num_frames must be greater than 0 or -1"):
         videoio.load_base64("video/jpeg", data)
+
+
+@pytest.mark.parametrize("runtime_num_frames", [-1, 64])
+def test_request_num_frames_cannot_raise_builtin_cap_without_operator_defaults(
+    runtime_num_frames: int,
+):
+    frames, metadata = _load_request_jpeg_frames({"num_frames": runtime_num_frames})
+
+    assert frames.shape[0] == 32
+    assert metadata["total_num_frames"] == 32
+
+
+@pytest.mark.parametrize("runtime_num_frames", [-1, 8])
+def test_request_num_frames_cannot_raise_finite_operator_cap(
+    runtime_num_frames: int,
+):
+    frames, metadata = _load_request_jpeg_frames(
+        {"num_frames": runtime_num_frames},
+        default_video_kwargs={"num_frames": 4},
+    )
+
+    assert frames.shape[0] == 4
+    assert metadata["total_num_frames"] == 4
+
+
+def test_request_fps_preserves_finite_operator_num_frames_cap():
+    frames, metadata = _load_request_jpeg_frames(
+        {"fps": 2.0},
+        default_video_kwargs={"num_frames": 4},
+    )
+
+    assert frames.shape[0] == 4
+    assert metadata["total_num_frames"] == 4
+
+
+def test_request_num_frames_can_reduce_finite_operator_cap():
+    frames, metadata = _load_request_jpeg_frames(
+        {"num_frames": 2},
+        default_video_kwargs={"num_frames": 4},
+    )
+
+    assert frames.shape[0] == 2
+    assert metadata["total_num_frames"] == 2
+
+
+def test_trusted_unlimited_operator_num_frames_remains_opt_in():
+    frames, metadata = _load_request_jpeg_frames(
+        {"num_frames": -1},
+        default_video_kwargs={"num_frames": -1},
+    )
+
+    assert frames.shape[0] == 40
+    assert metadata["total_num_frames"] == 40
+
+
+def test_trusted_unlimited_operator_num_frames_survives_fps_override():
+    result = VideoMediaIO.merge_kwargs(
+        default_kwargs={"num_frames": -1},
+        runtime_kwargs={"fps": 2.0},
+    )
+
+    assert result == {"num_frames": -1, "fps": 2.0}
+
+
+@pytest.mark.parametrize("runtime_num_frames", [-2, -1.0, True])
+def test_request_num_frames_rejects_invalid_unbounded_values(
+    runtime_num_frames: object,
+):
+    with pytest.raises(ValueError, match="num_frames must be greater than 0 or -1"):
+        VideoMediaIO.merge_kwargs(
+            default_kwargs=None,
+            runtime_kwargs={"num_frames": runtime_num_frames},
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/multimodal/test_video.py
+++ b/tests/multimodal/test_video.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import builtins
 import itertools
 import sys
 import threading
@@ -1069,6 +1070,69 @@ def test_video_loader_frames_sampling(
     assert frames.ndim == 4
     assert frames.shape[3] == 3  # RGB
     assert frames.shape[0] == expected_num_frames
+
+
+def test_dynamic_video_sampling_work_is_bounded_by_source_frames(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    source = VideoSourceMetadata(
+        total_frames_num=30,
+        original_fps=30.0,
+        duration=1.0,
+    )
+    target = VideoTargetMetadata(num_frames=-1, fps=1_000_000.0, max_duration=10.0)
+    range_stops: list[int] = []
+
+    def recording_range(*args: int):
+        stop = args[0] if len(args) == 1 else args[1]
+        range_stops.append(stop)
+        return builtins.range(*args)
+
+    monkeypatch.setattr("vllm.multimodal.video.range", recording_range, raising=False)
+
+    indices = DynamicVideoBackend.compute_frames_index_to_sample(source, target)
+
+    assert indices == list(range(source.total_frames_num))
+    assert max(range_stops) <= source.total_frames_num
+
+
+@pytest.mark.parametrize(
+    "source, target, expected",
+    [
+        pytest.param(
+            VideoSourceMetadata(30, 30.0, 1.0),
+            VideoTargetMetadata(-1, 2.0, 10.0),
+            [0, 15],
+            id="downsample",
+        ),
+        pytest.param(
+            VideoSourceMetadata(30, 30.0, 1.0),
+            VideoTargetMetadata(-1, 30.0, 10.0),
+            list(range(30)),
+            id="exact-rate",
+        ),
+        pytest.param(
+            VideoSourceMetadata(30, 30.0, 1.0),
+            VideoTargetMetadata(-1, 60.0, 10.0),
+            list(range(30)),
+            id="upsample-deduplicates",
+        ),
+        pytest.param(
+            VideoSourceMetadata(30, 30.0, 100.0),
+            VideoTargetMetadata(-1, 2.0, 100.0),
+            [0, 15, 29],
+            id="tail-clamps-to-last-frame",
+        ),
+    ],
+)
+def test_dynamic_video_sampling_preserves_index_semantics(
+    source: VideoSourceMetadata,
+    target: VideoTargetMetadata,
+    expected: list[int],
+):
+    assert (
+        DynamicVideoBackend.compute_frames_index_to_sample(source, target) == expected
+    )
 
 
 # ============================================================================

--- a/tests/test_internvl_max_dynamic_patch.py
+++ b/tests/test_internvl_max_dynamic_patch.py
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+from PIL import Image
+
+from vllm.transformers_utils.processors.internvl import InternVLImageProcessor
+
+pytestmark = pytest.mark.skip_global_cleanup
+
+
+def _make_processor(
+    *,
+    image_size: int = 448,
+    image_size_limit: int | None = None,
+    max_dynamic_patch: int = 12,
+    max_dynamic_patch_limit: int | None = None,
+) -> InternVLImageProcessor:
+    return InternVLImageProcessor(
+        image_size=image_size,
+        min_dynamic_patch=1,
+        max_dynamic_patch=max_dynamic_patch,
+        dynamic_image_size=True,
+        use_thumbnail=True,
+        image_size_limit=image_size_limit,
+        max_dynamic_patch_limit=max_dynamic_patch_limit,
+    )
+
+
+def test_request_max_dynamic_patch_cannot_exceed_processor_limit():
+    processor = _make_processor()
+
+    assert processor.resolve_min_max_num(max_dynamic_patch=12) == (1, 13)
+    assert processor.resolve_min_max_num(max_dynamic_patch=4) == (1, 5)
+
+    with pytest.raises(ValueError, match="cannot exceed the configured limit"):
+        processor.resolve_min_max_num(max_dynamic_patch=13)
+
+    with pytest.raises(ValueError, match="cannot exceed the configured limit"):
+        processor(Image.new("RGB", (1, 1)), max_dynamic_patch=13)
+
+
+def test_trusted_limit_is_kept_separate_from_merged_request_value():
+    with pytest.raises(ValueError, match="cannot exceed the configured limit"):
+        _make_processor(max_dynamic_patch=17, max_dynamic_patch_limit=16)
+
+    processor = _make_processor(
+        max_dynamic_patch=16,
+        max_dynamic_patch_limit=16,
+    )
+    assert processor.resolve_min_max_num(max_dynamic_patch=16) == (1, 17)
+
+
+def test_request_image_size_cannot_exceed_processor_limit():
+    with pytest.raises(ValueError, match="cannot exceed the configured limit"):
+        _make_processor(image_size=896, image_size_limit=448)
+
+    processor = _make_processor(image_size=448, image_size_limit=448)
+    assert processor.image_size == 448

--- a/vllm/model_executor/models/deepseek_ocr.py
+++ b/vllm/model_executor/models/deepseek_ocr.py
@@ -54,6 +54,7 @@ from vllm.transformers_utils.processors.deepseek_ocr import (
     BASE_SIZE,
     CROP_MODE,
     IMAGE_SIZE,
+    MAX_CROPS,
     DeepseekOCRProcessor,
     count_tiles,
 )
@@ -75,6 +76,24 @@ from .deepseek_vl2 import MlpProjector
 
 # The image token id may be various
 _IMAGE_TOKEN = "<image>"
+
+
+def _bind_deepseek_ocr_processor_kwargs(
+    processor_config: Mapping[str, object],
+    kwargs: Mapping[str, object],
+) -> dict[str, object]:
+    trusted_config = dict(processor_config)
+    bound_kwargs = dict(kwargs)
+    for field, trusted_value in trusted_config.items():
+        if field in bound_kwargs and bound_kwargs[field] != trusted_value:
+            raise ValueError(
+                "DeepSeek OCR processor argument "
+                f"{field!r} must match the deployed DeepSeek OCR configuration "
+                f"({trusted_value!r}), got {bound_kwargs[field]!r}."
+            )
+        bound_kwargs[field] = trusted_value
+
+    return bound_kwargs
 
 
 class DeepseekOCRImagePixelInputs(TensorSchema):
@@ -203,11 +222,16 @@ class DeepseekOCRProcessingInfo(BaseProcessingInfo):
             base_size=BASE_SIZE,
             crop_mode=CROP_MODE,
             strategy="v1",
+            max_crops=MAX_CROPS,
+        )
+        processor_kwargs = _bind_deepseek_ocr_processor_kwargs(
+            v1_processor_config,
+            kwargs,
         )
 
         return self.ctx.get_hf_processor(
             DeepseekOCRProcessor,
-            **{**v1_processor_config, **kwargs},
+            **processor_kwargs,
         )
 
     def get_supported_mm_limits(self) -> Mapping[str, int | None]:

--- a/vllm/model_executor/models/deepseek_ocr2.py
+++ b/vllm/model_executor/models/deepseek_ocr2.py
@@ -51,13 +51,17 @@ from vllm.transformers_utils.configs.deepseek_vl2 import DeepseekVLV2Config
 from vllm.transformers_utils.processors.deepseek_ocr import (
     BASE_SIZE,
     CROP_MODE,
+    MAX_CROPS,
     DeepseekOCRProcessor,
 )
 
 from ...transformers_utils.processors.deepseek_ocr import count_tiles
 from .deepencoder import ImageEncoderViT
 from .deepencoder2 import build_qwen2_decoder_as_encoder
-from .deepseek_ocr import DeepseekOCRImagePixelInputs
+from .deepseek_ocr import (
+    DeepseekOCRImagePixelInputs,
+    _bind_deepseek_ocr_processor_kwargs,
+)
 from .deepseek_vl2 import MlpProjector
 
 # The image token id may be various
@@ -75,11 +79,16 @@ class DeepseekOCR2ProcessingInfo(BaseProcessingInfo):
             base_size=BASE_SIZE,
             crop_mode=CROP_MODE,
             strategy="v2",
+            max_crops=MAX_CROPS,
+        )
+        processor_kwargs = _bind_deepseek_ocr_processor_kwargs(
+            v2_processor_config,
+            kwargs,
         )
 
         return self.ctx.get_hf_processor(
             DeepseekOCRProcessor,
-            **{**v2_processor_config, **kwargs},
+            **processor_kwargs,
         )
 
     def get_supported_mm_limits(self) -> Mapping[str, int | None]:

--- a/vllm/model_executor/models/eagle2_5_vl.py
+++ b/vllm/model_executor/models/eagle2_5_vl.py
@@ -75,7 +75,9 @@ class Eagle2_5_VLProcessingInfo(BaseInternVLProcessingInfo):
         config = self.get_hf_config()
         vision_config = config.vision_config
 
-        kwargs = self.ctx.get_merged_mm_kwargs(kwargs)
+        kwargs = self._merge_image_processor_kwargs(
+            kwargs, max_dynamic_patch=config.max_dynamic_patch
+        )
         kwargs.setdefault(
             "image_size", config.force_image_size or vision_config.image_size
         )

--- a/vllm/model_executor/models/gemma3_mm.py
+++ b/vllm/model_executor/models/gemma3_mm.py
@@ -86,6 +86,35 @@ class Gemma3ProcessingInfo(BaseProcessingInfo):
     def get_supported_mm_limits(self) -> Mapping[str, int | None]:
         return {"image": None}
 
+    def _get_images_kwargs(
+        self,
+        *,
+        processor: Gemma3Processor,
+        mm_kwargs: Mapping[str, object],
+    ) -> Mapping[str, object]:
+        return processor._merge_kwargs(
+            Gemma3ProcessorKwargs,
+            tokenizer_init_kwargs=processor.tokenizer.init_kwargs,
+            **self.ctx.get_merged_mm_kwargs(mm_kwargs),
+        )["images_kwargs"]
+
+    @staticmethod
+    def _get_positive_int(name: str, value: object) -> int:
+        if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+            raise ValueError(f"`{name}` must be a positive integer.")
+
+        return value
+
+    def _get_trusted_pan_and_scan_max_num_crops(self) -> int:
+        processor = self.get_hf_processor()
+        image_processor: Gemma3ImageProcessor = processor.image_processor
+        images_kwargs = self._get_images_kwargs(processor=processor, mm_kwargs={})
+        value = images_kwargs.get(
+            "pan_and_scan_max_num_crops",
+            image_processor.pan_and_scan_max_num_crops,
+        )
+        return self._get_positive_int("pan_and_scan_max_num_crops", value)
+
     def get_num_crops(
         self,
         *,
@@ -96,28 +125,34 @@ class Gemma3ProcessingInfo(BaseProcessingInfo):
     ) -> int:
         image_processor: Gemma3ImageProcessor = processor.image_processor
 
-        images_kwargs = processor._merge_kwargs(
-            Gemma3ProcessorKwargs,
-            tokenizer_init_kwargs=processor.tokenizer.init_kwargs,
-            **self.ctx.get_merged_mm_kwargs(mm_kwargs),
-        )["images_kwargs"]
+        images_kwargs = self._get_images_kwargs(
+            processor=processor,
+            mm_kwargs=mm_kwargs,
+        )
 
         do_pan_and_scan = images_kwargs.get(
             "do_pan_and_scan", image_processor.do_pan_and_scan
         )
-        pan_and_scan_min_crop_size = images_kwargs.get(
-            "pan_and_scan_min_crop_size", image_processor.pan_and_scan_min_crop_size
+        if not do_pan_and_scan:
+            return 0
+
+        pan_and_scan_min_crop_size = self._get_positive_int(
+            "pan_and_scan_min_crop_size",
+            images_kwargs.get(
+                "pan_and_scan_min_crop_size", image_processor.pan_and_scan_min_crop_size
+            ),
         )
-        pan_and_scan_max_num_crops = images_kwargs.get(
-            "pan_and_scan_max_num_crops", image_processor.pan_and_scan_max_num_crops
+        pan_and_scan_max_num_crops = self._get_positive_int(
+            "pan_and_scan_max_num_crops",
+            images_kwargs.get(
+                "pan_and_scan_max_num_crops",
+                image_processor.pan_and_scan_max_num_crops,
+            ),
         )
         pan_and_scan_min_ratio_to_activate = images_kwargs.get(
             "pan_and_scan_min_ratio_to_activate",
             image_processor.pan_and_scan_min_ratio_to_activate,
         )
-
-        if not do_pan_and_scan:
-            return 0
 
         logger.warning_once(
             "`do_pan_and_scan=True` has suboptimal results on V1 "
@@ -156,7 +191,16 @@ class Gemma3ProcessingInfo(BaseProcessingInfo):
         if min(crop_size_w, crop_size_h) < pan_and_scan_min_crop_size:
             return 0
 
-        return num_crops_w * num_crops_h
+        num_crops = num_crops_w * num_crops_h
+        trusted_max_num_crops = self._get_trusted_pan_and_scan_max_num_crops()
+        if num_crops > trusted_max_num_crops:
+            raise ValueError(
+                "Gemma3 pan-and-scan crop count "
+                f"{num_crops} exceeds the deployed limit of "
+                f"{trusted_max_num_crops}."
+            )
+
+        return num_crops
 
     def get_image_repl(
         self,
@@ -268,14 +312,7 @@ class Gemma3MultiModalProcessor(BaseMultiModalProcessor[Gemma3ProcessingInfo]):
         mm_kwargs: Mapping[str, object],
         tok_kwargs: Mapping[str, object],
     ) -> BatchFeature:
-        processed_outputs = super()._call_hf_processor(
-            prompt,
-            mm_data,
-            mm_kwargs,
-            tok_kwargs,
-        )
-
-        # HF processor pops the `num_crops` kwarg, which is needed by vLLM
+        num_crops: list[int] | None = None
         if (images := mm_data.get("images")) is not None:
             mm_items = self.info.parse_mm_data({"image": images}, validate=False)
             parsed_images = mm_items.get_items("image", ImageProcessorItems)
@@ -293,6 +330,16 @@ class Gemma3MultiModalProcessor(BaseMultiModalProcessor[Gemma3ProcessingInfo]):
                 )
                 for size in image_sizes
             ]
+
+        processed_outputs = super()._call_hf_processor(
+            prompt,
+            mm_data,
+            mm_kwargs,
+            tok_kwargs,
+        )
+
+        # HF processor pops the `num_crops` kwarg, which is needed by vLLM
+        if num_crops is not None:
             processed_outputs["num_patches"] = torch.tensor(num_crops) + 1
 
         return processed_outputs

--- a/vllm/model_executor/models/glm4_1v.py
+++ b/vllm/model_executor/models/glm4_1v.py
@@ -1285,24 +1285,24 @@ class Glm4vProcessingInfo(BaseProcessingInfo):
             extract_t = int(effective_duration * target_fps * temporal_patch_size)
             extract_t = min(extract_t, MAX_FRAME_COUNT_DYNAMIC)
 
-            duration_per_frame = 1 / video_fps
-            timestamps = [i * duration_per_frame for i in range(meta_frames)]
-            max_second = int(duration)
-
-            if meta_frames < extract_t:
+            if meta_frames < extract_t or duration > effective_duration:
                 frame_indices = np.linspace(
                     0, meta_frames - 1, extract_t, dtype=int
                 ).tolist()
             else:
-                frame_indices = []
-                current_second = 0.0
-                inv_fps = 1 / (temporal_patch_size * target_fps)
-                for frame_index in range(meta_frames):
-                    if timestamps[frame_index] >= current_second:
-                        current_second += inv_fps
-                        frame_indices.append(frame_index)
-                        if current_second >= max_second:
-                            break
+                frame_indices = [
+                    min(
+                        max_frame_idx,
+                        int(
+                            math.ceil(
+                                frame_idx
+                                * video_fps
+                                / (temporal_patch_size * target_fps)
+                            )
+                        ),
+                    )
+                    for frame_idx in range(extract_t)
+                ]
 
             if len(frame_indices) < extract_t:
                 if len(frame_indices) == 0:
@@ -1360,23 +1360,22 @@ class Glm4vProcessingInfo(BaseProcessingInfo):
             extract_t = int(duration * target_fps)
             extract_t = min(extract_t, max_frames)
 
-            duration_per_frame = 1 / video_fps
-            timestamps = [i * duration_per_frame for i in range(meta_frames)]
-
             if meta_frames < extract_t:
                 frame_indices = [
                     math.floor(i * meta_frames / extract_t) for i in range(extract_t)
                 ]
+            elif int(duration * target_fps) > max_frames:
+                frame_indices = np.linspace(
+                    0, meta_frames - 1, extract_t, dtype=int
+                ).tolist()
             else:
-                frame_indices = []
-                current_second = 0.0
-                inv_fps = 1 / target_fps
-                for frame_index in range(meta_frames):
-                    if timestamps[frame_index] >= current_second:
-                        current_second += inv_fps
-                        frame_indices.append(frame_index)
-                        if current_second >= duration - inv_fps:
-                            break
+                frame_indices = [
+                    min(
+                        max_frame_idx,
+                        int(math.ceil(frame_idx * video_fps / target_fps)),
+                    )
+                    for frame_idx in range(extract_t)
+                ]
 
             if len(frame_indices) < extract_t:
                 if len(frame_indices) == 0:

--- a/vllm/model_executor/models/h2ovl.py
+++ b/vllm/model_executor/models/h2ovl.py
@@ -42,7 +42,9 @@ class H2OVLProcessingInfo(BaseInternVLProcessingInfo):
         config = self.get_hf_config()
         vision_config = config.vision_config
 
-        kwargs = self.ctx.get_merged_mm_kwargs(kwargs)
+        kwargs = self._merge_image_processor_kwargs(
+            kwargs, max_dynamic_patch=config.max_dynamic_patch
+        )
         kwargs.setdefault("image_size", vision_config.image_size)
         kwargs.setdefault("min_dynamic_patch", config.min_dynamic_patch)
         kwargs.setdefault("max_dynamic_patch", config.max_dynamic_patch)

--- a/vllm/model_executor/models/idefics3.py
+++ b/vllm/model_executor/models/idefics3.py
@@ -17,6 +17,7 @@
 """Inference-only Idefics3 model compatible with HuggingFace weights."""
 
 from collections.abc import Iterable, Mapping, Sequence
+from functools import cached_property
 from typing import Annotated, Literal, TypeAlias
 
 import torch
@@ -27,6 +28,7 @@ from transformers import (
     Idefics3ImageProcessor,
     Idefics3Processor,
 )
+from transformers.image_processing_utils import get_size_dict
 
 from vllm.config import VllmConfig
 from vllm.config.multimodal import BaseDummyOptions
@@ -51,6 +53,7 @@ from vllm.multimodal.processing import (
     PromptUpdateDetails,
 )
 from vllm.sequence import IntermediateTensors
+from vllm.transformers_utils.processor import get_processor_kwargs_type
 from vllm.utils.tensor_schema import TensorSchema, TensorShape
 
 from .idefics2_vision_model import (
@@ -97,8 +100,234 @@ ImageInputs: TypeAlias = Idefics3ImagePixelInputs | Idefics3ImageEmbeddingInputs
 
 
 class Idefics3ProcessingInfo(BaseProcessingInfo):
-    def get_hf_processor(self, **kwargs: object) -> Idefics3Processor:
+    @staticmethod
+    def _get_kwarg_names(kwargs_cls: type[dict]) -> frozenset[str]:
+        names = set[str]()
+        for base in reversed(kwargs_cls.__mro__):
+            names.update(getattr(base, "__annotations__", {}))
+        return frozenset(names)
+
+    @classmethod
+    def _get_modality_kwarg_names(
+        cls,
+        kwargs_cls: type[dict],
+        modality_name: str,
+    ) -> frozenset[str]:
+        for base in kwargs_cls.__mro__:
+            modality_kwargs_cls = getattr(base, "__annotations__", {}).get(
+                modality_name
+            )
+            if isinstance(modality_kwargs_cls, type):
+                return cls._get_kwarg_names(modality_kwargs_cls)
+
+        return frozenset()
+
+    @cached_property
+    def image_processor_kwarg_names(self) -> frozenset[str]:
+        processor = self._get_hf_processor_unchecked()
+        return self._get_kwarg_names(processor.image_processor.valid_kwargs)
+
+    @cached_property
+    def image_only_processor_kwarg_names(self) -> frozenset[str]:
+        processor = self._get_hf_processor_unchecked()
+        text_kwarg_names = self._get_modality_kwarg_names(
+            get_processor_kwargs_type(processor),
+            "text_kwargs",
+        )
+        return self.image_processor_kwarg_names - text_kwarg_names
+
+    @staticmethod
+    def _get_size_value(size: object, name: str) -> object:
+        return (
+            size.get(name) if isinstance(size, Mapping) else getattr(size, name, None)
+        )
+
+    @staticmethod
+    def _get_positive_size_value(
+        value: object,
+        *,
+        label: str,
+        source: str,
+    ) -> int:
+        if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+            raise ValueError(f"{source} `{label}` must be a positive integer.")
+
+        return value
+
+    @classmethod
+    def _get_size_max_edge(
+        cls,
+        size: object,
+        *,
+        default_to_square: bool | None,
+        source: str,
+    ) -> tuple[str, int]:
+        try:
+            normalized_size = get_size_dict(
+                size=size,
+                default_to_square=default_to_square,
+            )
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                f"{source} `size` must use a supported Hugging Face size form."
+            ) from exc
+
+        if normalized_size.get("longest_edge") is None and (
+            normalized_size.get("height") is None
+            or normalized_size.get("width") is None
+        ):
+            raise ValueError(
+                f"{source} `size` must include `longest_edge` "
+                "or both `height` and `width`."
+            )
+
+        if isinstance(size, int) and not isinstance(size, bool):
+            return (
+                "size",
+                cls._get_positive_size_value(
+                    size,
+                    label="size",
+                    source=source,
+                ),
+            )
+
+        if isinstance(size, Sequence) and not isinstance(
+            size,
+            (str, bytes, bytearray),
+        ):
+            if len(size) != 2:
+                raise ValueError(
+                    f"{source} `size` sequence must contain exactly two items."
+                )
+
+            return (
+                "size.height/width",
+                max(
+                    cls._get_positive_size_value(
+                        size[0],
+                        label="size[0]",
+                        source=source,
+                    ),
+                    cls._get_positive_size_value(
+                        size[1],
+                        label="size[1]",
+                        source=source,
+                    ),
+                ),
+            )
+
+        if cls._get_size_value(size, "longest_edge") is not None:
+            return (
+                "size.longest_edge",
+                cls._get_positive_size_value(
+                    cls._get_size_value(size, "longest_edge"),
+                    label="size.longest_edge",
+                    source=source,
+                ),
+            )
+
+        if (
+            cls._get_size_value(size, "height") is None
+            or cls._get_size_value(size, "width") is None
+        ):
+            raise ValueError(
+                f"{source} `size` must include `longest_edge` "
+                "or both `height` and `width`."
+            )
+
+        return (
+            "size.height/width",
+            max(
+                cls._get_positive_size_value(
+                    cls._get_size_value(size, "height"),
+                    label="size.height",
+                    source=source,
+                ),
+                cls._get_positive_size_value(
+                    cls._get_size_value(size, "width"),
+                    label="size.width",
+                    source=source,
+                ),
+            ),
+        )
+
+    def _get_hf_processor_unchecked(self, **kwargs: object) -> Idefics3Processor:
         return self.ctx.get_hf_processor(Idefics3Processor, **kwargs)
+
+    # Dynamic HF processor kwargs are routed per call, not stored on the
+    # cached processor instance. Resolve the same effective image kwargs here.
+    def _get_effective_images_kwargs(
+        self,
+        processor: Idefics3Processor,
+        mm_kwargs: Mapping[str, object],
+    ) -> dict[str, object]:
+        return processor._merge_kwargs(
+            get_processor_kwargs_type(processor),
+            tokenizer_init_kwargs=processor.tokenizer.init_kwargs,
+            **self.ctx.get_merged_mm_kwargs(mm_kwargs),
+        )["images_kwargs"]
+
+    def _validate_size_limit(
+        self,
+        processor: Idefics3Processor,
+        mm_kwargs: Mapping[str, object],
+    ) -> dict[str, object]:
+        trusted_processor = self._get_hf_processor_unchecked()
+        trusted_images_kwargs = self._get_effective_images_kwargs(
+            trusted_processor,
+            {},
+        )
+        _, trusted_max_edge = self._get_size_max_edge(
+            trusted_images_kwargs.get(
+                "size",
+                trusted_processor.image_processor.size,
+            ),
+            default_to_square=trusted_images_kwargs.get(
+                "default_to_square",
+                getattr(trusted_processor.image_processor, "default_to_square", True),
+            ),
+            source="Deployment",
+        )
+        request_images_kwargs = self._get_effective_images_kwargs(
+            processor,
+            mm_kwargs,
+        )
+        request_do_resize = request_images_kwargs.get(
+            "do_resize",
+            getattr(processor.image_processor, "do_resize", True),
+        )
+        request_do_image_splitting = request_images_kwargs.get(
+            "do_image_splitting",
+            getattr(processor.image_processor, "do_image_splitting", True),
+        )
+        if not request_do_resize and request_do_image_splitting:
+            raise ValueError(
+                "Effective `do_resize` must remain enabled while "
+                "`do_image_splitting` is enabled so image patch accounting "
+                "matches preprocessing."
+            )
+
+        request_size_label, request_max_edge = self._get_size_max_edge(
+            request_images_kwargs.get("size", processor.image_processor.size),
+            default_to_square=request_images_kwargs.get(
+                "default_to_square",
+                getattr(processor.image_processor, "default_to_square", True),
+            ),
+            source="Request",
+        )
+        if request_max_edge > trusted_max_edge:
+            raise ValueError(
+                f"Request `{request_size_label}` "
+                f"{request_max_edge} exceeds the deployed limit of "
+                f"{trusted_max_edge}."
+            )
+
+        return request_images_kwargs
+
+    def get_hf_processor(self, **kwargs: object) -> Idefics3Processor:
+        processor = self._get_hf_processor_unchecked(**kwargs)
+        self._validate_size_limit(processor, kwargs)
+        return processor
 
     def get_supported_mm_limits(self) -> Mapping[str, int | None]:
         return {"image": None}
@@ -112,11 +341,12 @@ class Idefics3ProcessingInfo(BaseProcessingInfo):
         mm_kwargs: Mapping[str, object],
     ) -> tuple[int, int, int]:
         image_processor: Idefics3ImageProcessor = processor.image_processor
+        images_kwargs = self._validate_size_limit(processor, mm_kwargs)
 
         return image_processor.get_number_of_image_patches(
             image_height,
             image_width,
-            self.ctx.get_merged_mm_kwargs(mm_kwargs),
+            images_kwargs,
         )
 
     def get_num_patches(
@@ -238,6 +468,65 @@ class Idefics3DummyInputsBuilder(BaseDummyInputsBuilder[Idefics3ProcessingInfo])
 
 
 class Idefics3MultiModalProcessor(BaseMultiModalProcessor[Idefics3ProcessingInfo]):
+    @staticmethod
+    def _normalize_tokenization_kwargs(
+        tok_kwargs: Mapping[str, object],
+    ) -> dict[str, object]:
+        normalized_tok_kwargs = dict(tok_kwargs)
+        common_kwargs = tok_kwargs.get("common_kwargs")
+        if common_kwargs is None or isinstance(common_kwargs, Mapping):
+            return normalized_tok_kwargs
+
+        try:
+            normalized_tok_kwargs["common_kwargs"] = dict(common_kwargs)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                "`common_kwargs` in `tokenization_kwargs` must be a mapping "
+                "or iterable of key/value pairs."
+            ) from exc
+
+        return normalized_tok_kwargs
+
+    def _validate_tokenization_kwargs(
+        self,
+        tok_kwargs: Mapping[str, object],
+    ) -> dict[str, object]:
+        tok_kwargs = self._normalize_tokenization_kwargs(tok_kwargs)
+        if not tok_kwargs:
+            return tok_kwargs
+
+        image_only_kwarg_names = self.info.image_only_processor_kwarg_names
+
+        if invalid_name := next(
+            (name for name in sorted(image_only_kwarg_names) if name in tok_kwargs),
+            None,
+        ):
+            raise ValueError(
+                f"`{invalid_name}` must be passed via `mm_processor_kwargs`, "
+                "not `tokenization_kwargs`."
+            )
+
+        for container_name in ("images_kwargs", "common_kwargs"):
+            nested_kwargs = tok_kwargs.get(container_name)
+            if not isinstance(nested_kwargs, Mapping):
+                continue
+
+            if invalid_name := next(
+                (
+                    name
+                    for name in sorted(image_only_kwarg_names)
+                    if name in nested_kwargs
+                ),
+                None,
+            ):
+                raise ValueError(
+                    f"`{container_name}.{invalid_name}` must be passed via "
+                    "`mm_processor_kwargs`, "
+                    "not `tokenization_kwargs`."
+                )
+
+        return tok_kwargs
+
     def _call_hf_processor(
         self,
         prompt: str,
@@ -245,6 +534,8 @@ class Idefics3MultiModalProcessor(BaseMultiModalProcessor[Idefics3ProcessingInfo
         mm_kwargs: Mapping[str, object],
         tok_kwargs: Mapping[str, object],
     ) -> BatchFeature:
+        tok_kwargs = self._validate_tokenization_kwargs(tok_kwargs)
+
         # Text-only input not supported in composite processor
         if not (images := mm_data.get("images", [])):
             prompt_ids = self.info.get_tokenizer().encode(prompt)
@@ -255,6 +546,7 @@ class Idefics3MultiModalProcessor(BaseMultiModalProcessor[Idefics3ProcessingInfo
         if getattr(image_processor, "backend", "pil") == "pil":
             mm_kwargs = {"input_data_format": "channels_last", **mm_kwargs}
 
+        hf_processor = self.info.get_hf_processor(**mm_kwargs)
         processed_outputs = super()._call_hf_processor(
             prompt,
             mm_data,
@@ -267,7 +559,6 @@ class Idefics3MultiModalProcessor(BaseMultiModalProcessor[Idefics3ProcessingInfo
         image_sizes = [
             parsed_images.get_image_size(i) for i in range(len(parsed_images))
         ]
-        hf_processor = self.info.get_hf_processor(**mm_kwargs)
 
         num_patches = [
             self.info.get_num_patches(

--- a/vllm/model_executor/models/internvl.py
+++ b/vllm/model_executor/models/internvl.py
@@ -129,6 +129,33 @@ class BaseInternVLProcessingInfo(BaseProcessingInfo):
     def get_hf_processor(self, **kwargs: object) -> InternVLProcessor:
         raise NotImplementedError
 
+    def _merge_image_processor_kwargs(
+        self,
+        kwargs: Mapping[str, object],
+        *,
+        max_dynamic_patch: int,
+    ) -> dict[str, object]:
+        trusted_kwargs = self.ctx.get_merged_mm_kwargs({})
+        max_dynamic_patch_ceiling = trusted_kwargs.get(
+            "max_dynamic_patch", max_dynamic_patch
+        )
+        if not isinstance(max_dynamic_patch_ceiling, int):
+            raise ValueError("Configured max_dynamic_patch must be an integer")
+
+        merged_kwargs = self.ctx.get_merged_mm_kwargs(kwargs)
+        request_max_dynamic_patch = merged_kwargs.get("max_dynamic_patch")
+        if request_max_dynamic_patch is None:
+            return merged_kwargs
+        if not isinstance(request_max_dynamic_patch, int):
+            raise ValueError("max_dynamic_patch must be an integer")
+        if request_max_dynamic_patch > max_dynamic_patch_ceiling:
+            raise ValueError(
+                f"max_dynamic_patch={request_max_dynamic_patch} cannot exceed "
+                f"the configured maximum of {max_dynamic_patch_ceiling}"
+            )
+
+        return merged_kwargs
+
     def get_supported_mm_limits(self) -> Mapping[str, int | None]:
         return {"image": None}
 
@@ -326,7 +353,9 @@ class InternVLProcessingInfo(BaseInternVLProcessingInfo):
         config = self.get_hf_config()
         vision_config = config.vision_config
 
-        kwargs = self.ctx.get_merged_mm_kwargs(kwargs)
+        kwargs = self._merge_image_processor_kwargs(
+            kwargs, max_dynamic_patch=config.max_dynamic_patch
+        )
         kwargs.setdefault("image_size", vision_config.image_size)
         kwargs.setdefault("min_dynamic_patch", config.min_dynamic_patch)
         kwargs.setdefault("max_dynamic_patch", config.max_dynamic_patch)

--- a/vllm/model_executor/models/internvl.py
+++ b/vllm/model_executor/models/internvl.py
@@ -353,6 +353,11 @@ class InternVLProcessingInfo(BaseInternVLProcessingInfo):
         config = self.get_hf_config()
         vision_config = config.vision_config
 
+        trusted_kwargs = self.ctx.get_merged_mm_kwargs({})
+        image_size_limit = trusted_kwargs.get("image_size", vision_config.image_size)
+        max_dynamic_patch_limit = trusted_kwargs.get(
+            "max_dynamic_patch", config.max_dynamic_patch
+        )
         kwargs = self._merge_image_processor_kwargs(
             kwargs, max_dynamic_patch=config.max_dynamic_patch
         )
@@ -361,6 +366,8 @@ class InternVLProcessingInfo(BaseInternVLProcessingInfo):
         kwargs.setdefault("max_dynamic_patch", config.max_dynamic_patch)
         kwargs.setdefault("dynamic_image_size", config.dynamic_image_size)
         kwargs.setdefault("use_thumbnail", config.use_thumbnail)
+        kwargs["image_size_limit"] = image_size_limit
+        kwargs["max_dynamic_patch_limit"] = max_dynamic_patch_limit
 
         return InternVLImageProcessor(**kwargs)
 
@@ -368,8 +375,11 @@ class InternVLProcessingInfo(BaseInternVLProcessingInfo):
         config = self.get_hf_config()
         vision_config = config.vision_config
 
+        trusted_kwargs = self.ctx.get_merged_mm_kwargs({})
+        image_size_limit = trusted_kwargs.get("image_size", vision_config.image_size)
         kwargs = self.ctx.get_merged_mm_kwargs(kwargs)
         kwargs.setdefault("image_size", vision_config.image_size)
+        kwargs["image_size_limit"] = image_size_limit
 
         return InternVLVideoProcessor(**kwargs)
 

--- a/vllm/model_executor/models/isaac.py
+++ b/vllm/model_executor/models/isaac.py
@@ -66,6 +66,7 @@ from vllm.transformers_utils.processors.isaac import (
     IsaacImageProcessor,
     IsaacProcessor,
     get_image_size_for_max_num_patches,
+    validate_isaac_geometry_value,
 )
 from vllm.utils.tensor_schema import TensorSchema, TensorShape
 
@@ -331,6 +332,23 @@ class IsaacProcessingInfo(BaseProcessingInfo):
         return IsaacConfig()
 
     def get_image_processor(self, **kwargs) -> IsaacImageProcessor:
+        hf_config = self.get_hf_config()
+        configured_geometry = {
+            "patch_size": hf_config.video_patch_size,
+            "vision_max_num_patches": hf_config.vision_max_num_patches,
+            "vision_min_num_patches": hf_config.vision_min_num_patches,
+            "pixel_shuffle_scale": hf_config.pixel_shuffle_scale,
+        }
+        for name, configured_value in configured_geometry.items():
+            if name in kwargs:
+                validate_isaac_geometry_value(
+                    name,
+                    kwargs[name],
+                    configured_value,
+                )
+            else:
+                kwargs[name] = configured_value
+
         return IsaacImageProcessor(**kwargs)
 
     def get_hf_processor(self, **kwargs) -> IsaacProcessor:

--- a/vllm/model_executor/models/lfm2_vl.py
+++ b/vllm/model_executor/models/lfm2_vl.py
@@ -21,7 +21,7 @@ from transformers.models.lfm2_vl.image_processing_lfm2_vl_fast import (
 from vllm.config import VllmConfig
 from vllm.config.multimodal import BaseDummyOptions
 from vllm.forward_context import set_forward_context
-from vllm.inputs import MultiModalDataDict
+from vllm.inputs import MultiModalDataDict, MultiModalInput
 from vllm.model_executor.layers.mamba.mamba_utils import (
     MambaStateCopyFunc,
     MambaStateCopyFuncCalculator,
@@ -39,8 +39,10 @@ from vllm.multimodal.processing import (
     BaseDummyInputsBuilder,
     BaseMultiModalProcessor,
     BaseProcessingInfo,
+    ProcessorInputs,
     PromptReplacement,
     PromptUpdateDetails,
+    TimingContext,
 )
 from vllm.renderers import TokenizeParams
 from vllm.sequence import IntermediateTensors
@@ -392,6 +394,40 @@ class Lfm2VLDummyInputsBuilder(BaseDummyInputsBuilder[Lfm2VLProcessingInfo]):
 
 
 class Lfm2VLMultiModalProcessor(BaseMultiModalProcessor[Lfm2VLProcessingInfo]):
+    @staticmethod
+    def _iter_request_tile_bounds(
+        mm_kwargs: Mapping[str, object],
+    ) -> Iterable[tuple[str, object]]:
+        for key in ("min_tiles", "max_tiles"):
+            if key in mm_kwargs:
+                yield key, mm_kwargs[key]
+
+        images_kwargs = mm_kwargs.get("images_kwargs")
+        if isinstance(images_kwargs, Mapping):
+            for key in ("min_tiles", "max_tiles"):
+                if key in images_kwargs:
+                    yield f"images_kwargs.{key}", images_kwargs[key]
+
+    def _validate_request_tile_bounds(
+        self,
+        mm_kwargs: Mapping[str, object],
+    ) -> None:
+        configured_max_tiles = self.info.get_image_processor().max_tiles
+        for key, value in self._iter_request_tile_bounds(mm_kwargs):
+            if isinstance(value, int) and not 1 <= value <= configured_max_tiles:
+                raise ValueError(
+                    f"LFM2-VL request {key} must be between 1 and the configured "
+                    f"max_tiles ({configured_max_tiles}), got {value}."
+                )
+
+    def apply(
+        self,
+        inputs: ProcessorInputs,
+        timing_ctx: TimingContext,
+    ) -> MultiModalInput:
+        self._validate_request_tile_bounds(inputs.hf_processor_mm_kwargs)
+        return super().apply(inputs, timing_ctx)
+
     def _call_hf_processor(
         self,
         prompt: str,

--- a/vllm/model_executor/models/llava_onevision2.py
+++ b/vllm/model_executor/models/llava_onevision2.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import hashlib
 import importlib
+import operator
 from collections.abc import Callable, Iterable, Mapping, Sequence
 from functools import lru_cache
 from typing import (
@@ -470,6 +471,7 @@ def _create_field_factory(
 # ``vllm_hf_chat`` adapter, and empirically scores higher on Video-MME than
 # OV2's native VideoProcessor frame extractor.
 _DEFAULT_TIMESTAMP_DECIMALS = 1
+_MAX_TIMESTAMP_DECIMALS = 6
 _DEFAULT_FPS = 1.0
 _DEFAULT_MAX_FRAMES = 32
 # OV2 vision tower has spatial_merge_size=2 -> temporal frame count must be
@@ -481,6 +483,27 @@ _TEMPORAL_MERGE_SIZE = 2
 # (timestamp + image_pad block).
 _VIDEO_MARKER = "<|vision_start|><|video_pad|><|vision_end|>"
 _IMAGE_MARKER = "<|vision_start|><|image_pad|><|vision_end|>"
+
+
+def _validate_timestamp_decimals(timestamp_decimals: object) -> int:
+    if isinstance(timestamp_decimals, bool):
+        raise ValueError(
+            "LlavaOneVision2 timestamp_decimals must be an integer "
+            f"between 0 and {_MAX_TIMESTAMP_DECIMALS}."
+        )
+    try:
+        decimals = operator.index(timestamp_decimals)
+    except TypeError as exc:
+        raise ValueError(
+            "LlavaOneVision2 timestamp_decimals must be an integer "
+            f"between 0 and {_MAX_TIMESTAMP_DECIMALS}."
+        ) from exc
+    if not 0 <= decimals <= _MAX_TIMESTAMP_DECIMALS:
+        raise ValueError(
+            "LlavaOneVision2 timestamp_decimals must be an integer between "
+            f"0 and {_MAX_TIMESTAMP_DECIMALS}."
+        )
+    return decimals
 
 
 def _frame_video_to_pil_and_timestamps(
@@ -557,6 +580,7 @@ def _expand_video_markers_in_prompt(
     Replacement is positional: the *i*-th marker consumes
     ``per_video_timestamps[i]``.
     """
+    timestamp_decimals = _validate_timestamp_decimals(timestamp_decimals)
     parts: list[str] = []
     cursor = 0
     idx = 0
@@ -1546,6 +1570,16 @@ class LlavaOnevision2MultiModalProcessor(
         mm_kwargs: Mapping[str, object],
         tok_kwargs: Mapping[str, object],
     ) -> BatchFeature:
+        _videos = mm_data.get("videos")
+        videos_present = _videos is not None and len(_videos) > 0
+        timestamp_decimals = (
+            _validate_timestamp_decimals(
+                mm_kwargs.get("timestamp_decimals", _DEFAULT_TIMESTAMP_DECIMALS)
+            )
+            if videos_present
+            else _DEFAULT_TIMESTAMP_DECIMALS
+        )
+
         # The wrapped OV2 processor is a bare custom class without the standard
         # ProcessorMixin ``_merge_kwargs`` machinery, so vLLM's default path
         # fails; overriding this method routes the base class to call us
@@ -1574,8 +1608,6 @@ class LlavaOnevision2MultiModalProcessor(
         # Explicit None + length checks: ``mm_data[...]`` may be a list, numpy
         # array, or tensor, and ``and <array>`` would raise on the ambiguous
         # truth value of a multi-element array.
-        _videos = mm_data.get("videos")
-        videos_present = _videos is not None and len(_videos) > 0
 
         codec_video_paths = (
             _extract_codec_video_paths(mm_data["videos"]) if videos_present else None
@@ -1652,10 +1684,6 @@ class LlavaOnevision2MultiModalProcessor(
         # provided by the backend's ``compute_frames_index_to_sample``; SSRF /
         # local-file gating is enforced by the connector before decoding.
         if videos_present:
-            timestamp_decimals = int(
-                mm_kwargs.get("timestamp_decimals", _DEFAULT_TIMESTAMP_DECIMALS)
-            )
-
             per_video_frames: list[list[Image.Image]] = []
             per_video_timestamps: list[list[float]] = []
             for item in mm_data["videos"]:
@@ -1870,6 +1898,11 @@ class LlavaOnevision2MultiModalProcessor(
         hf_processor_mm_kwargs: Mapping[str, Any],
         out_mm_kwargs: MultiModalKwargsItems,
     ) -> Sequence[PromptUpdate]:
+        decimals = _validate_timestamp_decimals(
+            hf_processor_mm_kwargs.get(
+                "timestamp_decimals", _DEFAULT_TIMESTAMP_DECIMALS
+            )
+        )
         image_processor = self.info.get_image_processor(**hf_processor_mm_kwargs)
         tokenizer = self.info.get_tokenizer()
         vocab = tokenizer.get_vocab()
@@ -1879,7 +1912,6 @@ class LlavaOnevision2MultiModalProcessor(
         vision_end_id = vocab["<|vision_end|>"]
         newline_ids = tokenizer.encode("\n", add_special_tokens=False)
         merge_length = image_processor.merge_size**2
-        decimals = int(hf_processor_mm_kwargs.get("timestamp_decimals", 1))
 
         def get_image_replacement(item_idx: int):
             out_item = out_mm_kwargs["image"][item_idx]

--- a/vllm/model_executor/models/minicpmv.py
+++ b/vllm/model_executor/models/minicpmv.py
@@ -110,6 +110,33 @@ from .utils import AutoWeightsLoader, flatten_bn, maybe_prefix
 _MAX_FRAMES_PER_VIDEO = 16
 
 
+def _validate_minicpm_image_processor_kwargs(
+    trusted_max_slice_nums: int,
+    kwargs: Mapping[str, object],
+) -> dict[str, object]:
+    bound_kwargs = dict(kwargs)
+    if "max_slice_nums" not in bound_kwargs:
+        return bound_kwargs
+
+    requested_max_slice_nums = bound_kwargs["max_slice_nums"]
+    if requested_max_slice_nums is None:
+        bound_kwargs.pop("max_slice_nums")
+        return bound_kwargs
+
+    if (
+        not isinstance(requested_max_slice_nums, int)
+        or isinstance(requested_max_slice_nums, bool)
+        or requested_max_slice_nums != trusted_max_slice_nums
+    ):
+        raise ValueError(
+            "MiniCPM image processor argument 'max_slice_nums' must match "
+            "the deployed MiniCPM image processor configuration "
+            f"({trusted_max_slice_nums!r}), got {requested_max_slice_nums!r}."
+        )
+
+    return bound_kwargs
+
+
 class MiniCPMVImagePixelInputs(TensorSchema):
     """
     Dimensions:
@@ -728,6 +755,13 @@ class MiniCPMVProcessingInfo(BaseProcessingInfo):
     def get_image_max_slice_num(self) -> int:
         return getattr(self.get_hf_config(), "max_slice_num", 9)
 
+    def get_image_processor_max_slice_num(self) -> int:
+        image_processor = self.get_image_processor()
+        max_slice_nums = getattr(image_processor, "max_slice_nums", None)
+        if max_slice_nums is None:
+            return self.get_image_max_slice_num()
+        return int(max_slice_nums)
+
     def get_image_size_with_most_features(self) -> ImageSize:
         image_size = getattr(self.get_hf_config(), "image_size", 448)
         max_slice_num = self.get_image_max_slice_num()
@@ -857,6 +891,10 @@ class MiniCPMVMultiModalProcessor(BaseMultiModalProcessor[_I]):
         if (images := mm_data.get("images")) is None:
             return {}
 
+        image_mm_kwargs = _validate_minicpm_image_processor_kwargs(
+            self.info.get_image_processor_max_slice_num(),
+            mm_kwargs,
+        )
         mm_items = self.info.parse_mm_data({"image": images}, validate=False)
         parsed_images = mm_items.get_items(
             "image", (MiniCPMVImageEmbeddingItems, ImageProcessorItems)
@@ -868,7 +906,7 @@ class MiniCPMVMultiModalProcessor(BaseMultiModalProcessor[_I]):
             image_inputs = self._base_call_hf_processor(
                 prompts=[self.info.image_pattern] * len(parsed_images),
                 mm_data={"images": [[image] for image in parsed_images]},
-                mm_kwargs=mm_kwargs,
+                mm_kwargs=image_mm_kwargs,
                 tok_kwargs=tok_kwargs,
                 out_keys={"pixel_values", "image_sizes", "tgt_sizes"},
             )

--- a/vllm/model_executor/models/minicpmv4_6.py
+++ b/vllm/model_executor/models/minicpmv4_6.py
@@ -59,6 +59,7 @@ from .minicpmv import (
     MiniCPMVMultiModalProcessor,
     MiniCPMVProcessingInfo,
     MiniCPMVVideoEmbeddingItems,
+    _validate_minicpm_image_processor_kwargs,
 )
 from .module_mapping import MultiModelKeys
 from .qwen3_5 import Qwen3_5ForCausalLM
@@ -157,6 +158,10 @@ class MiniCPMV4_6MultiModalProcessor(MiniCPMVMultiModalProcessor):
         if (images := mm_data.get("images")) is None:
             return {}
 
+        image_mm_kwargs = _validate_minicpm_image_processor_kwargs(
+            self.info.get_image_processor_max_slice_num(),
+            mm_kwargs,
+        )
         mm_items = self.info.parse_mm_data({"image": images}, validate=False)
         parsed_images = mm_items.get_items(
             "image", (MiniCPMVImageEmbeddingItems, ImageProcessorItems)
@@ -175,7 +180,7 @@ class MiniCPMV4_6MultiModalProcessor(MiniCPMVMultiModalProcessor):
         per_image_pixel_values: list[torch.Tensor] = []
         per_image_tgt_sizes: list[torch.Tensor] = []
         for image in parsed_images:
-            ip_out = image_processor([image], **mm_kwargs)
+            ip_out = image_processor([image], **image_mm_kwargs)
             pv = ip_out["pixel_values"]  # (1, C, P, sum_W)
             ts = ip_out["target_sizes"]  # (n_slices, 2)
             if pv.ndim == 4 and pv.shape[0] == 1:
@@ -203,7 +208,7 @@ class MiniCPMV4_6MultiModalProcessor(MiniCPMVMultiModalProcessor):
             "tgt_sizes": per_image_tgt_sizes,
         }
 
-        ds_mode = self._resolve_downsample_mode(mm_kwargs)
+        ds_mode = self._resolve_downsample_mode(image_mm_kwargs)
         insert_layer_id = getattr(
             self.info.get_hf_config(),
             "insert_layer_id",

--- a/vllm/model_executor/models/moondream3.py
+++ b/vllm/model_executor/models/moondream3.py
@@ -942,6 +942,63 @@ class Moondream3MultiModalProcessor(BaseMultiModalProcessor[Moondream3Processing
     image_placeholder: str = "<image>"
     bos_image_placeholder: str = "<|endoftext|><image>"
 
+    @staticmethod
+    def _validate_processor_geometry(
+        field: str,
+        received_value: object,
+        trusted_value: int,
+    ) -> None:
+        if received_value != trusted_value:
+            raise ValueError(
+                "Moondream3 processor argument "
+                f"{field!r} must match the deployed vision configuration "
+                f"({trusted_value!r}), got {received_value!r}."
+            )
+
+    def _bind_processor_geometry(
+        self,
+        mm_kwargs: Mapping[str, object],
+    ) -> dict[str, object]:
+        vision_config = self.info.get_hf_config().vision_config
+        trusted_geometry = {
+            "crop_size": vision_config.crop_size,
+            "max_crops": vision_config.max_crops,
+            "overlap_margin": vision_config.overlap_margin,
+            "patch_size": vision_config.enc_patch_size,
+        }
+        bound_kwargs = dict(mm_kwargs)
+
+        for container_name in ("images_kwargs", "common_kwargs"):
+            nested_kwargs = bound_kwargs.get(container_name)
+            if not isinstance(nested_kwargs, Mapping):
+                continue
+
+            nested_kwargs = dict(nested_kwargs)
+            for field, trusted_value in trusted_geometry.items():
+                if field not in nested_kwargs:
+                    continue
+                self._validate_processor_geometry(
+                    field,
+                    nested_kwargs.pop(field),
+                    trusted_value,
+                )
+
+            if nested_kwargs or container_name == "images_kwargs":
+                bound_kwargs[container_name] = nested_kwargs
+            else:
+                bound_kwargs.pop(container_name)
+
+        for field, trusted_value in trusted_geometry.items():
+            if field in bound_kwargs:
+                self._validate_processor_geometry(
+                    field,
+                    bound_kwargs[field],
+                    trusted_value,
+                )
+            bound_kwargs[field] = trusted_value
+
+        return bound_kwargs
+
     def _call_hf_processor(
         self,
         prompt: str,
@@ -951,6 +1008,7 @@ class Moondream3MultiModalProcessor(BaseMultiModalProcessor[Moondream3Processing
     ) -> BatchFeature:
         # Moondream3's processor handles images directly rather than exposing a
         # separate `image_processor`, so keep the cache path on text+MM calls.
+        mm_kwargs = self._bind_processor_geometry(mm_kwargs)
         return super()._call_hf_processor(prompt, mm_data, mm_kwargs, tok_kwargs)
 
     @cached_property

--- a/vllm/model_executor/models/nemotron_vl.py
+++ b/vllm/model_executor/models/nemotron_vl.py
@@ -53,7 +53,12 @@ class NemotronVLProcessingInfo(BaseInternVLProcessingInfo):
     """Processing info for Nemotron VL models."""
 
     def get_image_processor(self, **kwargs: object):
-        kwargs = self.ctx.get_merged_mm_kwargs(kwargs)
+        trusted_orig_processor = cached_image_processor_from_config(
+            self.ctx.model_config, **self.ctx.get_merged_mm_kwargs({})
+        )
+        kwargs = self._merge_image_processor_kwargs(
+            kwargs, max_dynamic_patch=trusted_orig_processor.max_num_tiles
+        )
         orig_processor = cached_image_processor_from_config(
             self.ctx.model_config, **kwargs
         )
@@ -432,7 +437,9 @@ class LlamaNemotronVLEmbedProcessingInfo(BaseInternVLProcessingInfo):
             getattr(config, "dynamic_image_size", True),
         )
 
-        kwargs = self.ctx.get_merged_mm_kwargs(kwargs)
+        kwargs = self._merge_image_processor_kwargs(
+            kwargs, max_dynamic_patch=max_dynamic_patch
+        )
         kwargs.setdefault("image_size", config.force_image_size)
         kwargs.setdefault("min_dynamic_patch", min_dynamic_patch)
         kwargs.setdefault("max_dynamic_patch", max_dynamic_patch)

--- a/vllm/model_executor/models/nvlm_d.py
+++ b/vllm/model_executor/models/nvlm_d.py
@@ -44,7 +44,9 @@ class NVLMProcessingInfo(BaseInternVLProcessingInfo):
         config = self.get_hf_config()
         vision_config = config.vision_config
 
-        kwargs = self.ctx.get_merged_mm_kwargs(kwargs)
+        kwargs = self._merge_image_processor_kwargs(
+            kwargs, max_dynamic_patch=config.max_dynamic_patch
+        )
         kwargs.setdefault("image_size", vision_config.image_size)
         kwargs.setdefault("min_dynamic_patch", config.min_dynamic_patch)
         kwargs.setdefault("max_dynamic_patch", config.max_dynamic_patch)

--- a/vllm/model_executor/models/phi4mm.py
+++ b/vllm/model_executor/models/phi4mm.py
@@ -570,6 +570,125 @@ class Phi4MMProcessingInfo(BaseProcessingInfo):
         image_processor = processor.image_processor
         return image_processor.dynamic_hd
 
+    @staticmethod
+    def _get_positive_int(name: str, value: object) -> int:
+        if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+            raise ValueError(f"`{name}` must be a positive integer.")
+
+        return value
+
+    def _get_trusted_dynamic_hd(self) -> int:
+        processor = self.get_hf_processor()
+        return self._get_positive_int(
+            "dynamic_hd",
+            self.get_dynamic_hd(processor=processor),
+        )
+
+    def _get_num_local_hd_crops(
+        self,
+        *,
+        image_width: int,
+        image_height: int,
+        dynamic_hd_size: int,
+        vit_image_size: int,
+    ) -> int:
+        target_aspect_ratio, _, _ = self._find_target_aspect_ratio(
+            image_width,
+            image_height,
+            vit_image_size,
+            dynamic_hd_size,
+            min_num=1,
+        )
+        return target_aspect_ratio[0] * target_aspect_ratio[1]
+
+    @staticmethod
+    def _add_nearest_target_ratios(
+        target_ratios: set[tuple[int, int]],
+        *,
+        fixed_value: int,
+        ideal_value: float,
+        lower_bound: int,
+        upper_bound: int,
+        variable_is_width: bool,
+    ) -> None:
+        if lower_bound > upper_bound:
+            return
+
+        for candidate in (math.floor(ideal_value), math.ceil(ideal_value)):
+            bounded_candidate = min(max(candidate, lower_bound), upper_bound)
+            if variable_is_width:
+                target_ratios.add((bounded_candidate, fixed_value))
+            else:
+                target_ratios.add((fixed_value, bounded_candidate))
+
+    @classmethod
+    def _get_target_ratios(
+        cls,
+        *,
+        aspect_ratio: float,
+        max_num: int,
+        min_num: int,
+    ) -> list[tuple[int, int]]:
+        target_ratios: set[tuple[int, int]] = set()
+        for smaller_side in range(1, math.isqrt(max_num) + 1):
+            lower_bound = max(
+                smaller_side,
+                (min_num + smaller_side - 1) // smaller_side,
+            )
+            upper_bound = max_num // smaller_side
+
+            # For one fixed side, only the integers nearest the ideal ratio can
+            # win. This preserves the remote processor's selection while
+            # avoiding the full max_num x max_num enumeration.
+            cls._add_nearest_target_ratios(
+                target_ratios,
+                fixed_value=smaller_side,
+                ideal_value=aspect_ratio * smaller_side,
+                lower_bound=lower_bound,
+                upper_bound=upper_bound,
+                variable_is_width=True,
+            )
+            cls._add_nearest_target_ratios(
+                target_ratios,
+                fixed_value=smaller_side,
+                ideal_value=smaller_side / aspect_ratio,
+                lower_bound=lower_bound,
+                upper_bound=upper_bound,
+                variable_is_width=False,
+            )
+
+        return sorted(target_ratios, key=lambda x: x[0] * x[1])
+
+    def _get_effective_dynamic_hd(
+        self,
+        *,
+        image_width: int,
+        image_height: int,
+        processor: ProcessorMixin,
+        vit_image_size: int,
+    ) -> int:
+        dynamic_hd_size = self._get_positive_int(
+            "dynamic_hd",
+            self.get_dynamic_hd(processor=processor),
+        )
+        trusted_dynamic_hd = self._get_trusted_dynamic_hd()
+        num_local_hd_crops = self._get_num_local_hd_crops(
+            image_width=image_width,
+            image_height=image_height,
+            dynamic_hd_size=dynamic_hd_size,
+            vit_image_size=vit_image_size,
+        )
+        if num_local_hd_crops > trusted_dynamic_hd:
+            raise ValueError(
+                "Phi4MM local HD crop count "
+                f"{num_local_hd_crops} exceeds the deployed limit of "
+                f"{trusted_dynamic_hd}."
+            )
+
+        # If a higher request cap still selects an in-budget ratio, the trusted
+        # cap selects the same ratio from the smaller candidate set.
+        return min(dynamic_hd_size, trusted_dynamic_hd)
+
     def get_feature_extractor(self, **kwargs: object) -> SequenceFeatureExtractor:
         return self.get_hf_processor(**kwargs).audio_processor
 
@@ -598,14 +717,11 @@ class Phi4MMProcessingInfo(BaseProcessingInfo):
         if w_crop_num * h_crop_num > max_num:
             aspect_ratio = orig_width / orig_height
 
-            # calculate the existing image aspect ratio
-            target_ratios = set(
-                (i, j)
-                for i in range(1, max_num + 1)
-                for j in range(1, max_num + 1)
-                if i * j <= max_num and i * j >= min_num
+            target_ratios = self._get_target_ratios(
+                aspect_ratio=aspect_ratio,
+                max_num=max_num,
+                min_num=min_num,
             )
-            target_ratios = sorted(target_ratios, key=lambda x: x[0] * x[1])
 
             # find the closest aspect ratio to the target
             image_processor = self.get_hf_processor().image_processor
@@ -731,7 +847,12 @@ class Phi4MMProcessingInfo(BaseProcessingInfo):
         vit_patch_size = prepro_config["vit_patch_size"]
         token_compression_factor = prepro_config["token_compression_factor"]
 
-        dynamic_hd_size = self.get_dynamic_hd(processor=processor)
+        dynamic_hd_size = self._get_effective_dynamic_hd(
+            image_width=image_width,
+            image_height=image_height,
+            processor=processor,
+            vit_image_size=vit_image_size,
+        )
 
         image_num_tokens = self._compute_num_image_tokens(
             image_width,
@@ -857,6 +978,40 @@ class Phi4MMDummyInputsBuilder(BaseDummyInputsBuilder[Phi4MMProcessingInfo]):
 
 
 class Phi4MMMultiModalProcessor(BaseMultiModalProcessor[Phi4MMProcessingInfo]):
+    def _get_effective_mm_kwargs(
+        self,
+        *,
+        mm_data: Mapping[str, object],
+        mm_kwargs: Mapping[str, object],
+    ) -> Mapping[str, object]:
+        images = mm_data.get("images")
+        if images is None:
+            return mm_kwargs
+
+        mm_items = self.info.parse_mm_data({"image": images}, validate=False)
+        parsed_images = mm_items.get_items("image", ImageProcessorItems)
+        if len(parsed_images) == 0:
+            return mm_kwargs
+
+        hf_processor = self.info.get_hf_processor(**mm_kwargs)
+        for item_idx in range(len(parsed_images)):
+            image_size = parsed_images.get_image_size(item_idx)
+            self.info.get_num_image_tokens(
+                image_width=image_size.width,
+                image_height=image_size.height,
+                processor=hf_processor,
+            )
+
+        dynamic_hd_size = self.info._get_positive_int(
+            "dynamic_hd",
+            self.info.get_dynamic_hd(processor=hf_processor),
+        )
+        trusted_dynamic_hd = self.info._get_trusted_dynamic_hd()
+        if dynamic_hd_size <= trusted_dynamic_hd:
+            return mm_kwargs
+
+        return dict(mm_kwargs, dynamic_hd=trusted_dynamic_hd)
+
     def _call_hf_processor(
         self,
         prompt: str,
@@ -868,6 +1023,11 @@ class Phi4MMMultiModalProcessor(BaseMultiModalProcessor[Phi4MMProcessingInfo]):
             prompt_ids = self.info.get_tokenizer().encode(prompt)
             prompt_ids = self._apply_hf_processor_tokens_only(prompt_ids)
             return BatchFeature(dict(input_ids=[prompt_ids]), tensor_type="pt")
+
+        mm_kwargs = self._get_effective_mm_kwargs(
+            mm_data=mm_data,
+            mm_kwargs=mm_kwargs,
+        )
 
         sr = self.info.get_feature_extractor(**mm_kwargs).sampling_rate
         if audio_data := mm_data.get("audios", []):

--- a/vllm/model_executor/models/qianfan_ocr.py
+++ b/vllm/model_executor/models/qianfan_ocr.py
@@ -30,7 +30,9 @@ class QianfanOCRProcessingInfo(BaseInternVLProcessingInfo):
         config = self.get_hf_config()
         vision_config = config.vision_config
 
-        kwargs = self.ctx.get_merged_mm_kwargs(kwargs)
+        kwargs = self._merge_image_processor_kwargs(
+            kwargs, max_dynamic_patch=config.max_dynamic_patch
+        )
         kwargs.setdefault("image_size", vision_config.image_size)
         kwargs.setdefault("min_dynamic_patch", config.min_dynamic_patch)
         kwargs.setdefault("max_dynamic_patch", config.max_dynamic_patch)

--- a/vllm/model_executor/models/qwen2_5_omni_thinker.py
+++ b/vllm/model_executor/models/qwen2_5_omni_thinker.py
@@ -22,6 +22,7 @@
 # limitations under the License.
 """Inference-only Qwen2.5-Omni model (thinker part)."""
 
+import math
 from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
 from functools import partial
 from typing import Annotated, Any, Literal
@@ -77,16 +78,17 @@ from vllm.multimodal.parse import (
     ModalityDataItems,
     MultiModalDataItems,
 )
-from vllm.multimodal.processing import (
-    BaseDummyInputsBuilder,
-)
+from vllm.multimodal.processing import BaseDummyInputsBuilder
 from vllm.multimodal.processing.processor import (
     BaseMultiModalProcessor,
+    MultiModalProcessingInfo,
     MultiModalPromptUpdates,
     PlaceholderFeaturesInfo,
+    ProcessorInputs,
     PromptReplacement,
     PromptUpdate,
     PromptUpdateDetails,
+    TimingContext,
 )
 from vllm.sequence import IntermediateTensors
 from vllm.utils.tensor_schema import TensorSchema, TensorShape
@@ -103,7 +105,6 @@ from .utils import (
     WeightsMapper,
     init_vllm_registered_model,
     maybe_prefix,
-    split_list_into_ranges,
 )
 
 try:
@@ -112,6 +113,7 @@ except (ImportError, ModuleNotFoundError):
     flash_attn = None
 
 logger = init_logger(__name__)
+_MISSING_SECOND_PER_GRID_TS = object()
 
 
 def unpad_and_flat_audio_features(
@@ -352,6 +354,9 @@ class Qwen2_5OmniThinkerProcessingInfo(
         return self.ctx.get_hf_config(Qwen2_5OmniConfig).thinker_config
 
     def get_hf_processor(self, **kwargs: object) -> Qwen2_5OmniProcessor:
+        # Prompt-update timing is not a processor init kwarg and must not
+        # create one cached processor instance per request value.
+        kwargs.pop("second_per_grid_ts", None)
         return self.ctx.get_hf_processor(
             Qwen2_5OmniProcessor,
             use_fast=kwargs.pop("use_fast", True),
@@ -492,6 +497,24 @@ class Qwen2_5OmniThinkerDummyInputsBuilder(
 class Qwen2_5OmniThinkerMultiModalProcessor(
     BaseMultiModalProcessor[Qwen2_5OmniThinkerProcessingInfo]
 ):
+    def _cached_apply_hf_processor(
+        self,
+        inputs: ProcessorInputs,
+        timing_ctx: TimingContext,
+    ) -> tuple[list[int], MultiModalProcessingInfo, bool]:
+        hf_processor_mm_kwargs = inputs.hf_processor_mm_kwargs
+        if (
+            bool(hf_processor_mm_kwargs.get("use_audio_in_video", False))
+            and "second_per_grid_ts" in hf_processor_mm_kwargs
+        ):
+            self._normalize_second_per_grid_ts(
+                hf_processor_mm_kwargs["second_per_grid_ts"],
+                num_videos=inputs.mm_data_items.get_count("video", strict=False),
+            )
+            return self._apply_hf_processor(inputs, timing_ctx)
+
+        return super()._cached_apply_hf_processor(inputs, timing_ctx)
+
     def _call_hf_processor(
         self,
         prompt: str,
@@ -747,24 +770,103 @@ class Qwen2_5OmniThinkerMultiModalProcessor(
         t_index = (
             torch.arange(grid_t) * video_second_per_grid_t * tokens_per_second
         ).long()
-        t_index_split_chunk = split_list_into_ranges(t_index, t_ntoken_per_chunk)
+        chunk_ids = torch.div(t_index, t_ntoken_per_chunk, rounding_mode="floor")
+        occupied_chunk_ids, occupied_chunk_sizes = torch.unique_consecutive(
+            chunk_ids, return_counts=True
+        )
 
         updates = [audio_start_token_id]
         added_audio_len = 0
-        for t_chunk in t_index_split_chunk:
+        previous_chunk_id = -1
+        for chunk_id, chunk_size in zip(
+            occupied_chunk_ids.tolist(),
+            occupied_chunk_sizes.tolist(),
+        ):
+            empty_chunk_count = chunk_id - previous_chunk_id - 1
+            if empty_chunk_count > 0 and added_audio_len < audio_len:
+                audio_gap_size = min(
+                    empty_chunk_count * t_ntoken_per_chunk,
+                    audio_len - added_audio_len,
+                )
+                updates.extend([audio_token_id] * audio_gap_size)
+                added_audio_len += audio_gap_size
+
             vision_ntoken_per_chunk = (
-                len(t_chunk) * grid_h * grid_w // (spatial_merge_size**2)
+                chunk_size * grid_h * grid_w // (spatial_merge_size**2)
             )
             updates.extend([video_token_id] * vision_ntoken_per_chunk)
 
             audio_chunk_size = min(t_ntoken_per_chunk, audio_len - added_audio_len)
             updates.extend(audio_chunk_size * [audio_token_id])
             added_audio_len += audio_chunk_size
+            previous_chunk_id = chunk_id
         if added_audio_len < audio_len:
             updates.extend((audio_len - added_audio_len) * [audio_token_id])
         updates.extend([audio_end_token_id])
 
         return updates
+
+    @staticmethod
+    def _normalize_second_per_grid_ts(
+        second_per_grid_ts: object = _MISSING_SECOND_PER_GRID_TS,
+        *,
+        num_videos: int,
+    ) -> list[float]:
+        if second_per_grid_ts is _MISSING_SECOND_PER_GRID_TS:
+            return [1.0] * num_videos
+
+        if isinstance(second_per_grid_ts, (torch.Tensor, np.ndarray)):
+            if second_per_grid_ts.ndim != 1:
+                raise ValueError(
+                    "second_per_grid_ts must be a finite positive sequence "
+                    "with one value per video when use_audio_in_video=True"
+                )
+            values = second_per_grid_ts.tolist()
+        elif isinstance(second_per_grid_ts, Sequence) and not isinstance(
+            second_per_grid_ts, (str, bytes, bytearray)
+        ):
+            values = list(second_per_grid_ts)
+        else:
+            raise ValueError(
+                "second_per_grid_ts must be a finite positive sequence "
+                "with one value per video when use_audio_in_video=True"
+            )
+
+        if len(values) != num_videos:
+            raise ValueError(
+                "second_per_grid_ts must contain one finite positive value per "
+                "video when use_audio_in_video=True; "
+                f"got {len(values)} values for {num_videos} videos"
+            )
+
+        normalized = []
+        for item_idx, value in enumerate(values):
+            if isinstance(value, (bool, np.bool_, str, bytes, bytearray)):
+                raise ValueError(
+                    "second_per_grid_ts must contain only finite positive "
+                    "numbers when use_audio_in_video=True; "
+                    f"invalid value at index {item_idx}: {value!r}"
+                )
+
+            try:
+                value = float(value)
+            except (OverflowError, TypeError, ValueError) as exc:
+                raise ValueError(
+                    "second_per_grid_ts must contain only finite positive "
+                    "numbers when use_audio_in_video=True; "
+                    f"invalid value at index {item_idx}: {value!r}"
+                ) from exc
+
+            if not math.isfinite(value) or value <= 0:
+                raise ValueError(
+                    "second_per_grid_ts must contain only finite positive "
+                    "numbers when use_audio_in_video=True; "
+                    f"invalid value at index {item_idx}: {value!r}"
+                )
+
+            normalized.append(value)
+
+        return normalized
 
     def _get_prompt_updates(
         self,
@@ -772,6 +874,19 @@ class Qwen2_5OmniThinkerMultiModalProcessor(
         hf_processor_mm_kwargs: Mapping[str, Any],
         out_mm_kwargs: MultiModalKwargsItems,
     ) -> Sequence[PromptUpdate]:
+        use_audio_in_video = bool(
+            hf_processor_mm_kwargs.get("use_audio_in_video", False)
+        )
+        second_per_grid_ts = None
+        if use_audio_in_video:
+            second_per_grid_ts = self._normalize_second_per_grid_ts(
+                hf_processor_mm_kwargs.get(
+                    "second_per_grid_ts",
+                    _MISSING_SECOND_PER_GRID_TS,
+                ),
+                num_videos=mm_items.get_count("video", strict=False),
+            )
+
         processor = self.info.get_hf_processor(**hf_processor_mm_kwargs)
         tokenizer = self.info.get_tokenizer()
         image_processor = self.info.get_image_processor(**hf_processor_mm_kwargs)
@@ -826,7 +941,6 @@ class Qwen2_5OmniThinkerMultiModalProcessor(
             token_id = image_token_id if modality == "image" else video_token_id
             return [token_id] * (int(grid_thw.prod()) // merge_length)
 
-        use_audio_in_video = hf_processor_mm_kwargs.get("use_audio_in_video", False)
         thinker_config = self.info.get_hf_config()
 
         def get_replacement_qwen2_use_audio_in_video(item_idx: int):
@@ -837,11 +951,8 @@ class Qwen2_5OmniThinkerMultiModalProcessor(
 
             audio_in_video_item_idx += 1
 
-            second_per_grid_ts = hf_processor_mm_kwargs.get("second_per_grid_ts", None)
-            if second_per_grid_ts:
-                video_second_per_grid_t = second_per_grid_ts[item_idx]
-            else:
-                video_second_per_grid_t = 1.0
+            assert second_per_grid_ts is not None
+            video_second_per_grid_t = second_per_grid_ts[item_idx]
 
             updates = self.omni_get_updates_use_audio_in_video(
                 thinker_config=thinker_config,

--- a/vllm/model_executor/models/qwen2_vl.py
+++ b/vllm/model_executor/models/qwen2_vl.py
@@ -46,7 +46,7 @@ from vllm.config import VllmConfig
 from vllm.config.multimodal import BaseDummyOptions
 from vllm.distributed import parallel_state, tensor_model_parallel_all_gather
 from vllm.distributed import utils as dist_utils
-from vllm.inputs import ModalityData, MultiModalDataDict
+from vllm.inputs import ModalityData, MultiModalDataDict, MultiModalInput
 from vllm.logger import init_logger
 from vllm.model_executor.layers.activation import QuickGELU
 from vllm.model_executor.layers.attention import MMEncoderAttention
@@ -80,8 +80,10 @@ from vllm.multimodal.processing import (
     BaseDummyInputsBuilder,
     BaseMultiModalProcessor,
     BaseProcessingInfo,
+    ProcessorInputs,
     PromptReplacement,
     PromptUpdate,
+    TimingContext,
 )
 from vllm.sequence import IntermediateTensors
 from vllm.utils.tensor_schema import TensorSchema, TensorShape
@@ -853,6 +855,42 @@ class Qwen2VLProcessingInfo(BaseProcessingInfo):
     def get_image_processor(self, **kwargs: object) -> Qwen2VLImageProcessor:
         return self.get_hf_processor(**kwargs).image_processor
 
+    @staticmethod
+    def _validate_pixels_override(
+        key: str,
+        value: object,
+        max_pixels_ceiling: int,
+    ) -> None:
+        if isinstance(value, (int, float)) and value > max_pixels_ceiling:
+            raise ValueError(
+                f"Qwen2-VL request {key}={value} exceeds the configured "
+                f"max_pixels ceiling of {max_pixels_ceiling}."
+            )
+
+    def _validate_request_mm_processor_kwargs(
+        self,
+        mm_kwargs: Mapping[str, object],
+    ) -> None:
+        size = mm_kwargs.get("size")
+        overrides: list[tuple[str, object]] = [
+            ("max_pixels", mm_kwargs.get("max_pixels")),
+            ("min_pixels", mm_kwargs.get("min_pixels")),
+        ]
+        if isinstance(size, Mapping):
+            overrides.extend(
+                [
+                    ("size.longest_edge", size.get("longest_edge")),
+                    ("size.shortest_edge", size.get("shortest_edge")),
+                ]
+            )
+
+        if all(value is None for _, value in overrides):
+            return
+
+        max_pixels_ceiling = self.get_image_processor().size["longest_edge"]
+        for key, value in overrides:
+            self._validate_pixels_override(key, value, max_pixels_ceiling)
+
     def get_data_parser(self):
         return Qwen2VLMultiModalDataParser(
             self.get_hf_config().vision_config.spatial_merge_size,
@@ -1122,6 +1160,14 @@ class Qwen2VLDummyInputsBuilder(BaseDummyInputsBuilder[Qwen2VLProcessingInfo]):
 
 
 class Qwen2VLMultiModalProcessor(BaseMultiModalProcessor[Qwen2VLProcessingInfo]):
+    def apply(
+        self,
+        inputs: ProcessorInputs,
+        timing_ctx: TimingContext,
+    ) -> MultiModalInput:
+        self.info._validate_request_mm_processor_kwargs(inputs.hf_processor_mm_kwargs)
+        return super().apply(inputs, timing_ctx)
+
     def _get_prompt_updates(
         self,
         mm_items: MultiModalDataItems,

--- a/vllm/model_executor/models/skyworkr1v.py
+++ b/vllm/model_executor/models/skyworkr1v.py
@@ -88,7 +88,9 @@ class SkyworkR1VProcessingInfo(BaseInternVLProcessingInfo):
         config = self.get_hf_config()
         vision_config = config.vision_config
 
-        kwargs = self.ctx.get_merged_mm_kwargs(kwargs)
+        kwargs = self._merge_image_processor_kwargs(
+            kwargs, max_dynamic_patch=config.max_dynamic_patch
+        )
         kwargs.setdefault("image_size", vision_config.image_size)
         kwargs.setdefault("min_dynamic_patch", config.min_dynamic_patch)
         kwargs.setdefault("max_dynamic_patch", config.max_dynamic_patch)

--- a/vllm/model_executor/models/smolvlm.py
+++ b/vllm/model_executor/models/smolvlm.py
@@ -13,8 +13,13 @@ from .idefics3 import Idefics3MultiModalProcessor as SmolVLMMultiModalProcessor
 
 
 class SmolVLMProcessingInfo(Idefics3ProcessingInfo):
-    def get_hf_processor(self, **kwargs: object) -> SmolVLMProcessor:
+    def _get_hf_processor_unchecked(self, **kwargs: object) -> SmolVLMProcessor:
         return self.ctx.get_hf_processor(SmolVLMProcessor, **kwargs)
+
+    def get_hf_processor(self, **kwargs: object) -> SmolVLMProcessor:
+        processor = self._get_hf_processor_unchecked(**kwargs)
+        self._validate_size_limit(processor, kwargs)
+        return processor
 
     def _get_image_token(self, processor: SmolVLMProcessor) -> tuple[str, str, str]:
         image_token = processor.image_token

--- a/vllm/model_executor/models/unlimited_ocr.py
+++ b/vllm/model_executor/models/unlimited_ocr.py
@@ -89,6 +89,7 @@ from .deepseek_ocr import (
     DeepseekOCRMultiModalProcessor,
     DeepseekOCRProcessingInfo,
     NGramPerReqLogitsProcessor,
+    _bind_deepseek_ocr_processor_kwargs,
 )
 
 __all__ = [
@@ -123,9 +124,13 @@ class UnlimitedOCRProcessingInfo(DeepseekOCRProcessingInfo):
             strategy="v1",
             max_crops=_UNLIMITED_OCR_MAX_CROPS,
         )
+        processor_kwargs = _bind_deepseek_ocr_processor_kwargs(
+            v1_processor_config,
+            kwargs,
+        )
         return self.ctx.get_hf_processor(
             UnlimitedOCRProcessor,
-            **{**v1_processor_config, **kwargs},
+            **processor_kwargs,
         )
 
     def get_num_image_tokens(

--- a/vllm/multimodal/media/video.py
+++ b/vllm/multimodal/media/video.py
@@ -18,6 +18,9 @@ from .image import ImageMediaIO
 
 logger = init_logger(__name__)
 
+_DEFAULT_NUM_FRAMES = 32
+_INVALID_NUM_FRAMES_MESSAGE = "num_frames must be greater than 0 or -1"
+
 
 class VideoMediaIO(MediaIO[MediaWithBytes[tuple[npt.NDArray, dict[str, Any]]]]):
     """Configuration values can be user-provided either by --media-io-kwargs or
@@ -31,6 +34,10 @@ class VideoMediaIO(MediaIO[MediaWithBytes[tuple[npt.NDArray, dict[str, Any]]]]):
         default_kwargs: dict[str, Any] | None,
         runtime_kwargs: dict[str, Any] | None,
     ) -> dict[str, Any]:
+        runtime_kwargs = cls._enforce_runtime_num_frames_policy(
+            default_kwargs,
+            runtime_kwargs,
+        )
         if runtime_kwargs:
             # Decoder GPU memory is reserved from the startup value.
             runtime_kwargs = dict(runtime_kwargs)
@@ -55,20 +62,62 @@ class VideoMediaIO(MediaIO[MediaWithBytes[tuple[npt.NDArray, dict[str, Any]]]]):
                         }
 
         merged = super().merge_kwargs(default_kwargs, runtime_kwargs)
-        # fps and num_frames interact with each other, so if either is
-        # overridden at request time, wipe the other from defaults to
-        # avoid unintuitive cross-field interactions.
-        if runtime_kwargs:
-            if "num_frames" in runtime_kwargs and "fps" not in runtime_kwargs:
-                merged.pop("fps", None)
-            elif "fps" in runtime_kwargs and "num_frames" not in runtime_kwargs:
-                merged.pop("num_frames", None)
+        # A request num_frames override replaces a default fps because it is
+        # a complete frame-count selection. An fps-only request must retain
+        # num_frames because that field is also the frame ceiling.
+        if (
+            runtime_kwargs
+            and "num_frames" in runtime_kwargs
+            and "fps" not in runtime_kwargs
+        ):
+            merged.pop("fps", None)
         return merged
+
+    @classmethod
+    def _enforce_runtime_num_frames_policy(
+        cls,
+        default_kwargs: dict[str, Any] | None,
+        runtime_kwargs: dict[str, Any] | None,
+    ) -> dict[str, Any] | None:
+        if not runtime_kwargs or "num_frames" not in runtime_kwargs:
+            return runtime_kwargs
+
+        requested_num_frames = cls._validate_num_frames(runtime_kwargs["num_frames"])
+        num_frames_cap = cls._get_finite_num_frames_cap(default_kwargs)
+        if num_frames_cap is None or 0 < requested_num_frames <= num_frames_cap:
+            return runtime_kwargs
+
+        logger.warning_once(
+            "Clamping request-level num_frames=%r to finite video frame cap %d.",
+            requested_num_frames,
+            num_frames_cap,
+        )
+        return {**runtime_kwargs, "num_frames": num_frames_cap}
+
+    @classmethod
+    def _get_finite_num_frames_cap(
+        cls,
+        default_kwargs: dict[str, Any] | None,
+    ) -> int | None:
+        configured_num_frames = (default_kwargs or {}).get(
+            "num_frames",
+            _DEFAULT_NUM_FRAMES,
+        )
+        configured_num_frames = cls._validate_num_frames(configured_num_frames)
+        if configured_num_frames == -1:
+            return None
+        return configured_num_frames
+
+    @staticmethod
+    def _validate_num_frames(num_frames: Any) -> int:
+        if type(num_frames) is not int or num_frames == 0 or num_frames < -1:
+            raise ValueError(_INVALID_NUM_FRAMES_MESSAGE)
+        return num_frames
 
     def __init__(
         self,
         image_io: ImageMediaIO,
-        num_frames: int = 32,
+        num_frames: int = _DEFAULT_NUM_FRAMES,
         **kwargs,
     ) -> None:
         super().__init__()
@@ -112,7 +161,7 @@ class VideoMediaIO(MediaIO[MediaWithBytes[tuple[npt.NDArray, dict[str, Any]]]]):
             if self.num_frames > 0:
                 frame_parts = data.split(",", self.num_frames)[: self.num_frames]
             elif self.num_frames == 0:
-                raise ValueError("num_frames must be greater than 0 or -1")
+                raise ValueError(_INVALID_NUM_FRAMES_MESSAGE)
             else:
                 frame_parts = data.split(",")
 

--- a/vllm/multimodal/video.py
+++ b/vllm/multimodal/video.py
@@ -1373,6 +1373,39 @@ class DynamicVideoBackend(VideoBackend):
             source.total_frames_num, source.original_fps, duration
         )
 
+    @staticmethod
+    def _compute_indices_within_duration(
+        total_frames_num: int,
+        duration: float,
+        original_fps: float,
+        fps: float,
+    ) -> list[int]:
+        num_samples = int(math.floor(duration * fps))
+        if num_samples <= 0 or total_frames_num <= 0:
+            return []
+        if original_fps <= 0:
+            return [0]
+
+        max_frame_idx = total_frames_num - 1
+        frame_indices_list: list[int] = []
+        # Invert the original target-tick loop: each source frame only needs
+        # the first target sample that could select it.
+        for frame_idx in range(total_frames_num):
+            if frame_idx == 0:
+                sample_idx = 0
+            else:
+                sample_idx = math.floor((frame_idx - 1) * fps / original_fps) + 1
+            if sample_idx >= num_samples:
+                break
+
+            sampled_frame_idx = min(
+                max_frame_idx,
+                int(math.ceil(sample_idx * original_fps / fps)),
+            )
+            if sampled_frame_idx == frame_idx:
+                frame_indices_list.append(frame_idx)
+        return frame_indices_list
+
     @classmethod
     def compute_frames_index_to_sample(
         cls,
@@ -1391,12 +1424,11 @@ class DynamicVideoBackend(VideoBackend):
         # https://github.com/huggingface/transformers/blob/v4.55.4/src/transformers/models/glm4v/video_processing_glm4v.py#L103-L140
         frame_indices_list: list[int]
         if duration <= max_duration:
-            n = int(math.floor(duration * fps))
-            frame_indices_list = sorted(
-                {
-                    min(max_frame_idx, int(math.ceil(i * original_fps / fps)))
-                    for i in range(n)
-                }
+            frame_indices_list = cls._compute_indices_within_duration(
+                total_frames_num=total_frames_num,
+                duration=duration,
+                original_fps=original_fps,
+                fps=fps,
             )
         else:
             num_samples = int(max_duration * fps)

--- a/vllm/renderers/params.py
+++ b/vllm/renderers/params.py
@@ -106,6 +106,7 @@ class ChatParams:
             not default_chat_template_kwargs
             and not default_media_io_kwargs
             and not default_mm_processor_kwargs
+            and not self.media_io_kwargs
         ):
             return self
 

--- a/vllm/transformers_utils/processors/internvl.py
+++ b/vllm/transformers_utils/processors/internvl.py
@@ -28,6 +28,69 @@ IMAGENET_MEAN = (0.485, 0.456, 0.406)
 IMAGENET_STD = (0.229, 0.224, 0.225)
 
 
+def validate_internvl_max_dynamic_patch_override(
+    max_dynamic_patch: object,
+    *,
+    max_allowed_dynamic_patch: object,
+) -> None:
+    if (
+        isinstance(max_allowed_dynamic_patch, bool)
+        or not isinstance(max_allowed_dynamic_patch, int)
+        or max_allowed_dynamic_patch < 1
+    ):
+        raise ValueError(
+            "Configured `max_dynamic_patch` must be a positive integer, "
+            f"got {max_allowed_dynamic_patch!r}."
+        )
+
+    if (
+        isinstance(max_dynamic_patch, bool)
+        or not isinstance(max_dynamic_patch, int)
+        or max_dynamic_patch < 1
+    ):
+        raise ValueError(
+            "`max_dynamic_patch` must be a positive integer, "
+            f"got {max_dynamic_patch!r}."
+        )
+
+    if max_dynamic_patch > max_allowed_dynamic_patch:
+        raise ValueError(
+            "`max_dynamic_patch` cannot exceed the configured limit of "
+            f"{max_allowed_dynamic_patch}, got {max_dynamic_patch}."
+        )
+
+
+def validate_internvl_image_size_override(
+    image_size: object,
+    *,
+    max_allowed_image_size: object,
+) -> None:
+    if (
+        isinstance(max_allowed_image_size, bool)
+        or not isinstance(max_allowed_image_size, int)
+        or max_allowed_image_size < 1
+    ):
+        raise ValueError(
+            "Configured `image_size` must be a positive integer, "
+            f"got {max_allowed_image_size!r}."
+        )
+
+    if (
+        isinstance(image_size, bool)
+        or not isinstance(image_size, int)
+        or image_size < 1
+    ):
+        raise ValueError(
+            f"`image_size` must be a positive integer, got {image_size!r}."
+        )
+
+    if image_size > max_allowed_image_size:
+        raise ValueError(
+            "`image_size` cannot exceed the configured limit of "
+            f"{max_allowed_image_size}, got {image_size}."
+        )
+
+
 # adapted from https://huggingface.co/OpenGVLab/InternVL2-1B
 def build_transform(input_size: int):
     MEAN, STD = IMAGENET_MEAN, IMAGENET_STD
@@ -228,10 +291,28 @@ class InternVLImageProcessor(ImageProcessingMixin):
         max_dynamic_patch: int,
         dynamic_image_size: bool,
         use_thumbnail: bool,
+        max_dynamic_patch_limit: int | None = None,
+        image_size_limit: int | None = None,
     ) -> None:
+        if max_dynamic_patch_limit is None:
+            max_dynamic_patch_limit = max_dynamic_patch
+        if image_size_limit is None:
+            image_size_limit = image_size
+
+        validate_internvl_max_dynamic_patch_override(
+            max_dynamic_patch,
+            max_allowed_dynamic_patch=max_dynamic_patch_limit,
+        )
+        validate_internvl_image_size_override(
+            image_size,
+            max_allowed_image_size=image_size_limit,
+        )
+
         self.image_size = image_size
+        self.image_size_limit = image_size_limit
         self.min_dynamic_patch = min_dynamic_patch
         self.max_dynamic_patch = max_dynamic_patch
+        self.max_dynamic_patch_limit = max_dynamic_patch_limit
         self.dynamic_image_size = dynamic_image_size
         self.use_thumbnail = use_thumbnail
 
@@ -251,6 +332,11 @@ class InternVLImageProcessor(ImageProcessingMixin):
             dynamic_image_size = self.dynamic_image_size
         if use_thumbnail is None:
             use_thumbnail = self.use_thumbnail
+
+        validate_internvl_max_dynamic_patch_override(
+            max_dynamic_patch,
+            max_allowed_dynamic_patch=self.max_dynamic_patch_limit,
+        )
 
         return resolve_internvl_min_max_num(
             min_dynamic_patch=min_dynamic_patch,
@@ -273,7 +359,7 @@ class InternVLImageProcessor(ImageProcessingMixin):
         if dynamic_image_size is None:
             dynamic_image_size = self.dynamic_image_size
 
-        min_num, max_num = resolve_internvl_min_max_num(
+        min_num, max_num = self.resolve_min_max_num(
             min_dynamic_patch=min_dynamic_patch,
             max_dynamic_patch=max_dynamic_patch,
             dynamic_image_size=dynamic_image_size,
@@ -321,8 +407,16 @@ class InternVLVideoProcessor(BaseVideoProcessor):
     def __init__(
         self,
         image_size: int,
+        image_size_limit: int | None = None,
     ) -> None:
+        if image_size_limit is None:
+            image_size_limit = image_size
+        validate_internvl_image_size_override(
+            image_size,
+            max_allowed_image_size=image_size_limit,
+        )
         self.image_size = image_size
+        self.image_size_limit = image_size_limit
 
     def _videos_to_pixel_values_lst(
         self,

--- a/vllm/transformers_utils/processors/isaac.py
+++ b/vllm/transformers_utils/processors/isaac.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import math
+from collections.abc import Mapping
 from typing import Any, TypedDict
 
 import numpy as np
@@ -315,7 +316,7 @@ def process_vision_for_patches(
 class IsaacImagesKwargs(TypedDict, total=False):
     patch_size: int
     max_num_patches: int
-    min_num_patches: int
+    min_num_patches: int | None
     pixel_shuffle_scale: int
 
 
@@ -327,14 +328,43 @@ class IsaacProcessorKwargs(ProcessingKwargs, total=False):  # type: ignore[call-
     }
 
 
+def validate_isaac_geometry_value(
+    name: str,
+    value: object,
+    configured_value: object,
+) -> None:
+    """Reject Isaac geometry values that differ from trusted configuration."""
+    if type(value) is not type(configured_value) or value != configured_value:
+        label = name.replace("_", " ")
+        raise ValueError(
+            f"{name}={value} must match the configured Isaac "
+            f"{label} of {configured_value}"
+        )
+
+
 class IsaacImageProcessor(ImageProcessingMixin):
     model_input_names = ["pixel_values", "image_grid_thw"]
+
+    def _validate_geometry_kwargs(self, kwargs: Mapping[str, object]) -> None:
+        configured_geometry = (
+            ("patch_size", self.patch_size),
+            ("max_num_patches", self.vision_max_num_patches),
+            ("min_num_patches", self.vision_min_num_patches),
+            ("pixel_shuffle_scale", self.pixel_shuffle_scale),
+        )
+        for name, configured_value in configured_geometry:
+            if name in kwargs:
+                validate_isaac_geometry_value(
+                    name,
+                    kwargs[name],
+                    configured_value,
+                )
 
     def __init__(
         self,
         patch_size: int = 16,
         vision_max_num_patches: int = 6144,
-        vision_min_num_patches: int = 256,
+        vision_min_num_patches: int | None = 256,
         pixel_shuffle_scale: int = 2,
     ) -> None:
         self.patch_size = patch_size
@@ -354,22 +384,17 @@ class IsaacImageProcessor(ImageProcessingMixin):
 
         all_pixel_values: list[torch.Tensor] = []
         all_image_grids: list[torch.Tensor] = []
+        self._validate_geometry_kwargs(kwargs)
 
         for image in images:
             image_tensor = extract_image_pil(image)
 
             patches, dims_virtual = process_vision_for_patches(
                 image_tensor,
-                patch_size=kwargs.get("patch_size", self.patch_size),
-                max_num_patches=kwargs.get(
-                    "max_num_patches", self.vision_max_num_patches
-                ),
-                min_num_patches=kwargs.get(
-                    "min_num_patches", self.vision_min_num_patches
-                ),
-                pixel_shuffle_scale=kwargs.get(
-                    "pixel_shuffle_scale", self.pixel_shuffle_scale
-                ),
+                patch_size=self.patch_size,
+                max_num_patches=self.vision_max_num_patches,
+                min_num_patches=self.vision_min_num_patches,
+                pixel_shuffle_scale=self.pixel_shuffle_scale,
             )
 
             # Isaac packs a dummy temporal dim for images

--- a/vllm/transformers_utils/processors/moondream3.py
+++ b/vllm/transformers_utils/processors/moondream3.py
@@ -9,7 +9,12 @@ import torch
 from PIL import Image
 from transformers import AutoProcessor, BatchFeature
 from transformers.image_utils import ImageInput
-from transformers.processing_utils import ProcessingKwargs, ProcessorMixin, Unpack
+from transformers.processing_utils import (
+    ImagesKwargs,
+    ProcessingKwargs,
+    ProcessorMixin,
+    Unpack,
+)
 from transformers.tokenization_utils_base import (
     PreTokenizedInput,
     PreTrainedTokenizerBase,
@@ -21,7 +26,16 @@ from vllm.multimodal.image import convert_image_mode
 __all__ = ["Moondream3Processor"]
 
 
+class Moondream3ImagesKwargs(ImagesKwargs, total=False):  # type: ignore[call-arg]
+    max_crops: int
+    overlap_margin: int
+    patch_size: int
+    convert_to_rgb: bool
+
+
 class Moondream3ProcessorKwargs(ProcessingKwargs, total=False):  # type: ignore[call-arg]
+    images_kwargs: Moondream3ImagesKwargs
+
     _defaults = {
         "text_kwargs": {
             "padding": False,


### PR DESCRIPTION
# Bound request-controlled image and video geometry

## What this fixes

Several multimodal processors accepted request-level pixel, crop, tile, frame, or timestamp values
that were larger than the model's configured limits. They performed the expensive resize or
expansion before the prompt-length check that would eventually reject the request.

For example, a client can send a 28×28 Qwen2-VL image with:

```json
{"mm_processor_kwargs":{"max_pixels":10000000}}
```

Before this change, vLLM enlarged that tiny image to the caller's pixel budget. In the measured
case, a 404-byte request grew the image tensor from `(16, 1176)` to `(51076, 1176)` and increased
frontend memory by about 700 MiB before returning HTTP 400. After this change, a request may lower
a model limit but cannot raise it. Equivalent checks run before allocation for the other affected
image and video processors.

## Why it matters

A client able to reach an affected multimodal endpoint could consume hundreds of megabytes or
several gigabytes of frontend memory and CPU with one small image or video. Repeated requests could
crash the render or API process. Some affected paths also generated very large token or timestamp
lists. The issue is resource exhaustion before inference, not access to another user's data.

## The change

| Commit | Site | What now happens |
|---|---|---|
| `ef2aa83` | PTP-VLLM-036 — video `num_frames` | Request merging preserves the configured frame ceiling and rejects invalid negative values. |
| `25a0b28` | PTP-VLLM-051 — Qwen2-VL `max_pixels` | A request cannot raise the configured pixel limit. |
| `f088aa0` | PTP-VLLM-052 — InternVL `max_dynamic_patch` | Patch fanout cannot exceed the model setting. |
| `f8aaa81` | PTP-VLLM-053 — LFM2-VL `max_tiles` | Tile counts are checked before candidate sizes are enumerated. |
| `5af58d7` | PTP-VLLM-054 — Isaac `patch_size` | Patch geometry remains tied to the model configuration. |
| `c19ead5` | PTP-VLLM-063 — Moondream3 `crop_size` | Requests cannot replace the configured crop geometry. |
| `415c0c3` | PTP-VLLM-065 — DeepSeek-OCR `max_crops` | Crop count is capped before crop tensors are built. |
| `849f02a` | PTP-VLLM-066 — MiniCPM `max_slice_nums` | Slice count cannot exceed the configured limit. |
| `b22c9db` | PTP-VLLM-067 — Gemma 3 pan-and-scan | Crop fanout is bounded before images are materialized. |
| `bc240b9` | PTP-VLLM-068 — Phi-4 `dynamic_hd` | Dynamic-HD crop count is bounded by trusted configuration. |
| `1e604b1` | PTP-VLLM-069 — Idefics3/SmolVLM `longest_edge` | A request cannot raise the configured image edge limit. |
| `12f3a24` | PTP-VLLM-072 — GLM-4.6V `total_num_frames` | Timestamp work is limited by the real, bounded frame count. |
| `60be29d` | PTP-VLLM-073 — Llava-OneVision2 `timestamp_decimals` | Timestamp precision is capped before prompt strings are built. |
| `04afe95` | PTP-VLLM-074 — Qwen2.5-Omni `second_per_grid_ts` | Video timing expansion is bounded before list construction. |
| `06c7dca` | PTP-VLLM-088 — InternVL `image_size` | Processor geometry overrides are validated before token runs are emitted. |
| `e602932` | PTP-VLLM-151 — dynamic video `fps` | Sampling work is bounded by the source frame count rather than caller-created ticks. |

## How it was tested

Every focused suite failed against the code without its guard and passed with the guard:

| Site | Without the fix | With the fix |
|---|---:|---:|
| PTP-VLLM-036 | 9 failed, 28 passed | 37 passed |
| PTP-VLLM-051 | 4 failed, 1 passed, 16 deselected | 5 passed, 16 deselected |
| PTP-VLLM-052 | 2 failed, 1 passed, 96 deselected | 3 passed, 96 deselected |
| PTP-VLLM-053 | 4 failed, 1 passed | 5 passed |
| PTP-VLLM-054 | 14 failed, 2 passed | 16 passed |
| PTP-VLLM-063 | 12 failed, 1 passed, 29 deselected | 13 passed, 29 deselected |
| PTP-VLLM-065 | 21 failed, 4 passed, 3 deselected | 25 passed, 3 deselected |
| PTP-VLLM-066 | 9 failed, 7 passed | 16 passed |
| PTP-VLLM-067 | 5 failed, 2 passed | 7 passed |
| PTP-VLLM-068 | 9 failed, 3 passed | 12 passed |
| PTP-VLLM-069 | 37 failed, 25 passed | 62 passed |
| PTP-VLLM-072 | 2 failed | 2 passed |
| PTP-VLLM-073 | 8 failed, 5 passed, 25 deselected | 13 passed, 25 deselected |
| PTP-VLLM-074 | 16 failed, 2 passed, 4 deselected | 18 passed, 4 deselected |
| PTP-VLLM-088 | 3 failed | 3 passed |
| PTP-VLLM-151 | 1 failed, 4 passed, 55 deselected | 5 passed, 55 deselected |

The tests cover the limit itself, one value over the limit, invalid negative values where
applicable, and safe values below the configured ceiling.

## Reference

Advisory: GHSA-54mv-hpc3-xcf6

Track B: this is a public PR against `vllm-project/vllm@main`.

## Credit

- @KernelClint (Clinton Thomas) and @dhalf (Lucas Bourtoule)
- Patch the Planet (Trail of Bits + OpenAI collaboration); discovered using GPT-5.5-Cyber

All commits include DCO `Signed-off-by` trailers.
