### PR TITLE
[CI] Guard remote-code Transformers compatibility

### DIFF
--- a/tests/models/registry.py
+++ b/tests/models/registry.py
@@ -995,6 +995,13 @@ _MULTIMODAL_EXAMPLE_MODELS = {
     "InternS1ProForConditionalGeneration": _HfExamplesInfo(
         "internlm/Intern-S1-Pro",
         trust_remote_code=True,
+        max_transformers_version="5.14.1",
+        transformers_version_reason={
+            "vllm": (
+                "Remote video processor code imports "
+                "`BASE_VIDEO_PROCESSOR_DOCSTRING`, removed in Transformers 5.15."
+            )
+        },
     ),
     "InternS2MobiusForConditionalGeneration": _HfExamplesInfo(
         "internlm/Intern-S2-Mobius",


### PR DESCRIPTION
- Limit Intern-S1-Pro vLLM registry coverage to Transformers 5.14.1.

Intern-S1-Pro relies on external `trust_remote_code` whose video processor imports `BASE_VIDEO_PROCESSOR_DOCSTRING`, removed in Transformers 5.15. The failure is visible in build 11817's [initialization](https://buildkite.com/vllm/amd-ci/builds/11817/list?sid=019fdb73-afd4-450a-9e00-045a9280c346&tab=output) and [processing](https://buildkite.com/vllm/amd-ci/builds/11817/list?sid=019fdb73-afd5-495b-a696-94f749c68b71&tab=output) jobs.