### PR TITLE
[MM][CG][BugFix] Fix Ernie-4.5-VL encoder CG postprocess for multi-path outputs

### DIFF
--- a/vllm/model_executor/models/ernie45_vl.py
+++ b/vllm/model_executor/models/ernie45_vl.py
@@ -1721,7 +1721,7 @@ class Ernie4_5_VLMoeForConditionalGeneration(
 
     def postprocess_encoder_output(
         self,
-        output: torch.Tensor,
+        outputs: dict[str, torch.Tensor],
         indices: list[int],
         per_item_out_tokens: list[int],
         dest,
@@ -1731,6 +1731,8 @@ class Ernie4_5_VLMoeForConditionalGeneration(
         # The graph output is the raw ViT features (pre-merge), padded to the
         # token budget. Run the resampler eagerly on the valid portion using
         # the actual batch grid_thw, then scatter the post-merge embeddings.
+        # Ernie only uses the single "default" encoder path.
+        output = outputs["default"]
         grid_thw = batch_mm_kwargs["image_grid_thw"].to(output.device)
         num_valid = int((grid_thw[:, 0] * grid_thw[:, 1] * grid_thw[:, 2]).sum())
         image_embeds = self.resampler_model(output[:num_valid], grid_thw)


### PR DESCRIPTION
## Purpose

Fix-forward for the crash that prompted #51263 (revert of #45254), instead of reverting.

`SupportsEncoderCudaGraph.postprocess_encoder_output` now receives `outputs: dict[str, torch.Tensor]` keyed by encoder path (multi-path graph support), but `Ernie4_5_VLMoeForConditionalGeneration`'s override still treated
the first arg as a single tensor:
`File "vllm/model_executor/models/ernie45_vl.py", line 1734, in postprocess_encoder_output
    grid_thw = batch_mm_kwargs["image_grid_thw"].to(output.device)
AttributeError: 'dict' object has no attribute 'device'`

`#45254` and the multi-path framework change merged around the same time, so each was green independently but the combination broke encoder CUDA-graph replay for Ernie-4.5-VL on `main`.

## Test

`pytest tests/models/multimodal/generation/test_vit_cudagraph.py::test_vit_cudagraph_image[ernie45_vl]`
— the same case reported in #51263 (build 82629).

Closes #51263 by fixing forward