### PR TITLE
[Bugfix] Install the weight offloader in the V2 model runner

### DIFF
--- a/tests/basic_correctness/test_cpu_offload.py
+++ b/tests/basic_correctness/test_cpu_offload.py
@@ -3,6 +3,14 @@
 
 import pytest
 
+from vllm import LLM
+from vllm.model_executor.offloader import (
+    NoopOffloader,
+    UVAOffloader,
+    get_offloader,
+    set_offloader,
+)
+
 from ..utils import compare_two_settings
 
 
@@ -27,3 +35,29 @@ def test_cpu_offload(disable_pin_memory, disable_uva):
         env1=None,
         env2=env_vars,
     )
+
+
+@pytest.mark.parametrize("use_v2_model_runner", ["0", "1"])
+def test_cpu_offload_is_applied(monkeypatch, use_v2_model_runner):
+    """--cpu-offload-gb must actually offload weights on both model runners.
+
+    The output comparison above cannot catch an offloader that is never
+    installed, since not offloading produces identical outputs.
+    """
+    monkeypatch.setenv("VLLM_ENABLE_V1_MULTIPROCESSING", "0")
+    monkeypatch.setenv("VLLM_USE_V2_MODEL_RUNNER", use_v2_model_runner)
+
+    # The offloader is a process-global, so reset it to the default first.
+    set_offloader(NoopOffloader())
+
+    LLM(
+        model="hmellor/tiny-random-LlamaForCausalLM",
+        cpu_offload_gb=1,
+        max_model_len=128,
+        gpu_memory_utilization=0.3,
+        enforce_eager=True,
+    )
+
+    offloader = get_offloader()
+    assert isinstance(offloader, UVAOffloader)
+    assert offloader.cpu_offload_bytes > 0

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -43,6 +43,11 @@ from vllm.model_executor.layers.mamba.ops.ssu_dispatch import (
     initialize_mamba_ssu_backend,
 )
 from vllm.model_executor.model_loader import get_model_loader
+from vllm.model_executor.offloader import (
+    create_offloader,
+    get_offloader,
+    set_offloader,
+)
 from vllm.multimodal import MULTIMODAL_REGISTRY
 from vllm.multimodal.encoder_budget import (
     MultiModalBudget,
@@ -280,6 +285,10 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         # Expert parallelism load balancer.
         self.eplb = EPLBController(self.parallel_config, self.device)
 
+        # Model weight offloader
+        # Make sure this is called before any get_offloader call
+        set_offloader(create_offloader(vllm_config.offload_config))
+
     def update_max_model_len(self, max_model_len: int) -> None:
         self.max_model_len = max_model_len
         self.req_states.max_model_len = max_model_len
@@ -397,6 +406,8 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                 dtype=self.model_config.dtype,
                 device=self.device,
             )
+
+        get_offloader().post_init()
 
     def get_model(self) -> nn.Module:
         return self.model


### PR DESCRIPTION
Fixes #50672

`set_offloader(create_offloader(...))` is only called from the V1 GPU model runner.
The V2 runner never installs an offloader, so `make_layers()` gets the process-global
default `NoopOffloader` and `--cpu-offload-gb` is silently a no-op.
`KimiK3ForConditionalGeneration` is in `DEFAULT_V2_MODEL_RUNNER_ARCHITECTURES`, and
`_is_default_v2_model_runner_model()` also returns True for any dense model, so this
hits Kimi K3 and most non-MoE models.

The fix mirrors the V1 wiring: create the offloader in `__init__` before the model is
built, and call `post_init()` at the end of `load_model()`. Nothing else was missing,
`vllm/v1/worker/gpu/cudagraph_utils.py` already calls `get_offloader().sync_prev_onload()`
and `join_after_forward()`.

The existing `test_cpu_offload` only compares outputs with and without offloading, and
not offloading produces identical outputs, so it passed vacuously on V2. Added
`test_cpu_offload_is_applied`, which asserts the offloader actually ran, parametrized
over both runners.

**Tested** on 8x A40 (sm_86), driver 560.35.03, built from source against CUDA 12.6 /
torch 2.13.0+cu129, TP=1:

- `test_cpu_offload_is_applied`: fails on `[1]` (V2, `NoopOffloader`) and passes on `[0]`
  (V1) without the patch; both pass with it.
- `tests/basic_correctness/test_cpu_offload.py::test_cpu_offload`: 4 passed. This now
  runs with real UVA offloading on V2, with and without CUDA graphs, and still matches
  the non-offloaded baseline.
- `tests/v1/streaming_input/test_gpu_model_runner_v2_streaming.py`: 2 passed.
- The patch also switches on the prefetch backend for V2, so I checked it by hand:
  `--offload-group-size 2 --offload-num-in-group 1` on V2 with CUDA graphs gives
  byte-identical greedy output to the baseline.
- `pre-commit run --files` on both touched files: all hooks pass, mypy included.

**Not verified:** Kimi K3 itself. It needs sm_90+ FP8 MegaMoE kernels and far more
memory than this box has, so the Kimi K3 part of the diagnosis is from reading
`vllm/config/vllm.py` and `vllm/models/kimi_k3/`, not from a run. Also untested here:
multi-GPU / TP / PP / EP, multimodal offload, `--cpu-offload-params`, and quantized
checkpoints (`tests/quantization/test_cpu_offload.py` needs FP8 or Marlin, which do
not run on sm_86).

The reporter's issue body was an empty template, so I could not reproduce their exact
run. I reproduced the defect its title describes. Thanks to @ee-redbull for filing it.

AI assistance was used to write this patch.