### PR TITLE
[Bugfix][Spec Decode] Fix DSD K-lookup to count sampling-only requests, preventing K thrashing at batch boundaries

### DIFF
--- a/tests/v1/spec_decode/test_dynamic_sd_decode_only_k.py
+++ b/tests/v1/spec_decode/test_dynamic_sd_decode_only_k.py
@@ -1,0 +1,107 @@
+"""Tests for dynamic SD scheduler K-lookup using sampling-request count.
+
+Regression test for #49548: dynamic speculative decoding K-lookup should
+count only requests that will sample this step (decode or final-prefill
+that reaches sampling), not mid-prefill requests that temporarily inflate
+the batch size and cause K to thrash.
+"""
+
+
+class FakeRequest:
+    """Minimal stand-in for Request to test the sampling predicate."""
+
+    def __init__(self, num_computed_tokens, num_tokens,
+                 num_output_placeholders=0):
+        self.num_computed_tokens = num_computed_tokens
+        self.num_tokens = num_tokens
+        self.num_output_placeholders = num_output_placeholders
+
+
+def _is_sampling_request(req, num_scheduled):
+    """Replicates the predicate in scheduler.schedule()."""
+    return (req.num_computed_tokens + num_scheduled
+            >= req.num_tokens + req.num_output_placeholders)
+
+
+def test_dynamic_sd_sampling_only_k_lookup():
+    """Verify that only sampling requests are counted for DSD K lookup."""
+
+    # Build a lookup table for schedule [[1, 2, 2], [3, 16, 0]]
+    # batch 1-2 -> K=2, batch 3-16 -> K=0
+    dynamic_sd_lookup = [0] * 17  # index 0 unused (1-indexed)
+    for i in range(1, 17):
+        dynamic_sd_lookup[i] = 2 if i <= 2 else 0
+
+    # Case 1: 4 pure decode requests -> decode_count=4 -> K=0
+    reqs = {"r0": FakeRequest(100, 100), "r1": FakeRequest(50, 50),
+            "r2": FakeRequest(80, 80), "r3": FakeRequest(60, 60)}
+    tokens = {"r0": 1, "r1": 1, "r2": 1, "r3": 1}
+    dc = sum(1 for rid, n in tokens.items() if _is_sampling_request(reqs[rid], n))
+    assert dc == 4, f"Expected 4 sampling, got {dc}"
+    k = dynamic_sd_lookup[dc]
+    assert k == 0, f"Expected K=0 for 4 decode, got K={k}"
+
+    # Case 2: 2 decode + 1 mid-prefill -> decode_count=2 -> K=2
+    # OLD behavior (total count=3 -> K=0) would thrash!
+    reqs = {"r0": FakeRequest(100, 100), "r1": FakeRequest(50, 50),
+            "r2": FakeRequest(10, 1024)}
+    tokens = {"r0": 1, "r1": 1, "r2": 512}
+    dc = sum(1 for rid, n in tokens.items() if _is_sampling_request(reqs[rid], n))
+    assert dc == 2, f"Expected 2 sampling, got {dc}"
+    k = dynamic_sd_lookup[dc]
+    assert k == 2, f"Expected K=2 for 2 decode + 1 prefill, got K={k}"
+
+    # Case 3: 1 decode + 1 full prefill (all tokens fit in one chunk)
+    # Both reach sampling in the same step -> decode_count=2 -> K=2
+    reqs = {"r0": FakeRequest(100, 100), "r1": FakeRequest(0, 1024)}
+    tokens = {"r0": 1, "r1": 1024}
+    dc = sum(1 for rid, n in tokens.items() if _is_sampling_request(reqs[rid], n))
+    assert dc == 2, f"Expected 2 sampling (decode + full prefill), got {dc}"
+    k = dynamic_sd_lookup[dc]
+    assert k == 2, f"Expected K=2 for decode + full prefill, got K={k}"
+
+    # Case 4: all full-prefill (each request's tokens fit in one chunk)
+    # Both reach sampling -> decode_count=2 -> K=2
+    reqs = {"r0": FakeRequest(0, 512), "r1": FakeRequest(0, 1024)}
+    tokens = {"r0": 512, "r1": 1024}
+    dc = sum(1 for rid, n in tokens.items() if _is_sampling_request(reqs[rid], n))
+    assert dc == 2, f"Expected 2 sampling (both full prefills), got {dc}"
+    lookup_count = dc if dc > 0 else len(tokens)
+    k = dynamic_sd_lookup[lookup_count]
+    assert k == 2, f"Expected K=2 for 2 full prefills, got K={k}"
+
+    # Case 5: single decode (batch=1) -> K=2
+    reqs = {"r0": FakeRequest(100, 100)}
+    tokens = {"r0": 1}
+    dc = sum(1 for rid, n in tokens.items() if _is_sampling_request(reqs[rid], n))
+    assert dc == 1, f"Expected 1 sampling, got {dc}"
+    k = dynamic_sd_lookup[dc]
+    assert k == 2, f"Expected K=2 for single decode, got K={k}"
+
+    # Case 6: final prefill chunk that reaches sampling (1024 computed + 1 token = 1025 total)
+    # This request WILL sample, so should be counted
+    reqs = {"r0": FakeRequest(1024, 1025), "r1": FakeRequest(100, 100)}
+    tokens = {"r0": 1, "r1": 1}
+    dc = sum(1 for rid, n in tokens.items() if _is_sampling_request(reqs[rid], n))
+    assert dc == 2, f"Expected 2 sampling (final chunk + decode), got {dc}"
+    k = dynamic_sd_lookup[dc]
+    assert k == 2, f"Expected K=2 for final-chunk + decode, got K={k}"
+
+    # Case 7: 1-token mid-prefill chunk (Codex's edge case)
+    # Request has 1024 tokens, only 1 scheduled, but computed + 1 < total
+    reqs = {"r0": FakeRequest(0, 1024), "r1": FakeRequest(100, 100)}
+    tokens = {"r0": 1, "r1": 1}
+    dc = sum(1 for rid, n in tokens.items() if _is_sampling_request(reqs[rid], n))
+    assert dc == 1, f"Expected 1 sampling (1-token prefill chunk excluded), got {dc}"
+    k = dynamic_sd_lookup[dc]
+    assert k == 2, f"Expected K=2 for 1-token-prefill + decode, got K={k}"
+
+    # Case 8: all mid-prefill chunks (nobody reaches sampling) -> fallback
+    # This is the only case where fallback to len() is used
+    reqs = {"r0": FakeRequest(0, 4096), "r1": FakeRequest(0, 8192)}
+    tokens = {"r0": 1024, "r1": 1024}
+    dc = sum(1 for rid, n in tokens.items() if _is_sampling_request(reqs[rid], n))
+    assert dc == 0, f"Expected 0 sampling (both mid-prefill), got {dc}"
+    lookup_count = dc if dc > 0 else len(tokens)
+    k = dynamic_sd_lookup[lookup_count]
+    assert k == 2, f"Expected K=2 for mid-prefill fallback (count=2), got K={k}"

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1201,8 +1201,29 @@ class Scheduler(SchedulerInterface):
         # Dynamic speculative decoding: compute optimal K
         num_spec_tokens_to_schedule = self.num_spec_tokens
         if self.dynamic_sd_lookup is not None and len(num_scheduled_tokens) > 0:
+            # Count only requests that will sample this step (decode or
+            # final-prefill-chunk that reaches sampling).  Including mid-prefill
+            # requests in the count causes K to thrash at batch boundaries.
+            # See #49548.
+            decode_request_count = 0
+            for req_id, num_tokens in num_scheduled_tokens.items():
+                req = self.requests[req_id]
+                if (req.num_computed_tokens + num_tokens
+                        >= req.num_tokens
+                        + req.num_output_placeholders):
+                    decode_request_count += 1
+            # Fall back to total count if no requests reach sampling
+            # (e.g. all-prefill step).
+            lookup_count = (
+                decode_request_count
+                if decode_request_count > 0
+                else len(num_scheduled_tokens)
+            )
+            # Clamp to lookup table bounds (should not exceed, but guard
+            # against edge cases with async output placeholders).
+            lookup_count = min(lookup_count, len(self.dynamic_sd_lookup) - 1)
             num_spec_tokens_to_schedule = self.dynamic_sd_lookup[
-                len(num_scheduled_tokens)
+                lookup_count
             ]
 
         scheduled_encoder_input_stats = None


### PR DESCRIPTION
> [!IMPORTANT]
> **Withdrawn after controlled follow-up (2026-08-13).** This PR correctly
> demonstrates that total-request and sampling-request lookup can choose
> different K values, but I had not established that sampling-only was the
> correct policy or that it reduced K thrashing. A later 25-pair controlled
> experiment found no target workload meeting the predeclared benefit bar,
> heavy-prefill workloads favored the existing total-count policy in every
> pair, and complete-trace K transitions were 50 with sampling-only versus 40
> with total-count. I am closing the PR and retaining the original description
> below as historical context. See the closure comment for details.


## Description

The dynamic speculative decoding (DSD) K-lookup in `scheduler.py` uses `len(num_scheduled_tokens)` to index into `dynamic_sd_lookup`. This counts **all** scheduled requests, including mid-prefill/chunked-prefill requests. When prefills are mixed with decodes, they temporarily inflate the batch size and cause K to thrash between values as requests enter and leave prefill — a contributing factor to the catastrophic aggregate-throughput collapse reported in #49548.

### Example

With schedule `[[1, 2, 2], [3, 16, 0]]` (K=2 for batch ≤ 2, K=0 for batch ≥ 3):

| Step | Requests | Old count | Old K | New count | New K |
|---|---|---|---|---|---|
| 2 decode + 1 prefill (512 tok) | 3 | 3 | **0** | 2 (decode-only) | **2** |
| 2 decode + 1 prefill (1 tok chunk) | 3 | 3 | **0** | 2 (sampling-only) | **2** |

The old code flips K from 2→0 every time a prefill joins 2 decodes, then back to 2 when it leaves. Each flip changes the verify-token count, forward shape, and CUDA graph dispatch.

### Fix

Count only requests that will **sample this step** (decode or final-prefill-chunk that reaches sampling), using the same phase-transition predicate the scheduler uses elsewhere:

```python
req.num_computed_tokens + num_tokens >= req.num_tokens + req.num_output_placeholders
```

This correctly handles:
- Pure decode requests
- Mid-prefill chunked requests (excluded — will not sample)
- Final prefill chunks that reach sampling (included — will sample)
- 1-token prefill chunks that are NOT final (excluded)
- Spec-padded decode requests (impossible in DSD mode — spec padding is gated on `dynamic_sd_lookup is None`)

If no requests reach sampling (all mid-prefill), falls back to `len(num_scheduled_tokens)` to preserve original behavior.

## Benchmark

Dual RTX 5090, TP=2, Qwen3.6-35B-A3B-Uncensored-FP8, MTP k=2, `VLLM_USE_V2_MODEL_RUNNER=1` + #49652 to preserve FULL CUDA graphs.

| Scenario | Before (±stdev) | After (±stdev) | Δ |
|---|---|---|---|
| 4-session × 256 tok | 195 ± 164 t/s | **190 ± 49 t/s** | Variance −70% |
| 8-session × 256 tok | 308 ± 67 t/s | **412 ± 163 t/s** | +34% mean |
| Single-stream 32k | 285 ± 3 t/s | **289 ± 1 t/s** | Unchanged |

The variance reduction confirms K thrashing is eliminated. The multi-session mean remains below no-spec baseline under long context — the cause is under investigation (see our correction comments on #49986 and #49548). The gap is context-length dependent and its root cause has not yet been identified.

## Complementary to #49652

This fix targets the scheduler-side K-selection pathology (#49548 H3). PR #49652 fixes the worker-side MRV2 CUDA graph capture crash (#48494). Both are needed for functional DSD with FULL CUDA graphs on MRV2.

## Test

- `py_compile vllm/v1/core/sched/scheduler.py` — PASS
- `pytest test_dynamic_sd_sampling_only_k_lookup` — 1 passed (8/8 edge cases)
- Live runtime verified on dual RTX 5090 with Qwen3.6-35B-A3B FP8 + MTP + MRV2 + DSD

Note: vLLM native scheduler tests require full dev install (`pip install -e .`). The standalone test validates the core predicate logic.

Fixes part of #49548.

## AI Assistance Disclosure

AI tools (codex CLI) were used in the development of this PR. All changes were reviewed and tested by the human submitter (Greg Weyer).