### PR TITLE
[BugFix] Reject invalid data-parallel RPC ports

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -380,6 +380,21 @@ def test_async_scheduling_with_pipeline_parallelism_is_allowed():
     assert cfg.scheduler_config.async_scheduling is True
 
 
+def test_data_parallel_rpc_port_has_fixed_default():
+    assert ParallelConfig().data_parallel_rpc_port == 29550
+
+
+@pytest.mark.parametrize("port", [1, 29550, 65535])
+def test_data_parallel_rpc_port_accepts_valid_ports(port: int):
+    assert ParallelConfig(data_parallel_rpc_port=port).data_parallel_rpc_port == port
+
+
+@pytest.mark.parametrize("port", [-1, 0, 65536])
+def test_data_parallel_rpc_port_rejects_invalid_ports(port: int):
+    with pytest.raises(ValidationError):
+        ParallelConfig(data_parallel_rpc_port=port)
+
+
 def test_reconfigure_for_independent_dp_rank_on_multinode_dense_model():
     parallel_config = ParallelConfig(
         tensor_parallel_size=8,

--- a/vllm/config/parallel.py
+++ b/vllm/config/parallel.py
@@ -140,8 +140,8 @@ class ParallelConfig:
     """Local rank of the data parallel group, set only in SPMD mode."""
     data_parallel_master_ip: str = "127.0.0.1"
     """IP of the data parallel master."""
-    data_parallel_rpc_port: int = 29550
-    """Port for data parallel messaging."""
+    data_parallel_rpc_port: int = Field(default=29550, ge=1, le=65535)
+    """Fixed port for data parallel messaging, shared by all nodes."""
     data_parallel_master_port: int = 29500
     """Port of the data parallel master."""
     data_parallel_backend: DataParallelBackend = "mp"

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -1100,7 +1100,8 @@ class EngineArgs:
             "--data-parallel-rpc-port",
             "-dpp",
             type=int,
-            help="Port for data parallel RPC communication.",
+            help="Fixed port for data parallel RPC communication. All nodes "
+            "must use the same port.",
         )
         parallel_group.add_argument(
             "--data-parallel-backend",

--- a/vllm/v1/engine/utils.py
+++ b/vllm/v1/engine/utils.py
@@ -1165,11 +1165,11 @@ def launch_core_engines(
     if parallel_config.enable_elastic_ep:
         handshake_local_only = False
 
-    # Preserve "port=0 means auto-pick" for the handshake address, which
-    # is consumed by engines spawned in this process and so cannot defer
-    # port resolution to bind time.
-    rpc_port = parallel_config.data_parallel_rpc_port or get_open_port()
-    handshake_address = get_engine_client_zmq_addr(handshake_local_only, host, rpc_port)
+    handshake_address = get_engine_client_zmq_addr(
+        handshake_local_only,
+        host,
+        parallel_config.data_parallel_rpc_port,
+    )
 
     if local_engines_only and dp_rank > 0:
         assert not handshake_local_only


### PR DESCRIPTION
## Purpose

`data_parallel_rpc_port` is a fixed bootstrap endpoint shared by independently launched nodes in native MP data parallelism. It defaults to `29550`.

The previous code treated an explicit value of `0` as an automatic-port request:

```python
rpc_port = parallel_config.data_parallel_rpc_port or get_open_port()
handshake_address = get_engine_client_zmq_addr(
    handshake_local_only, host, rpc_port
)
```

A producer-to-consumer audit shows two different outcomes. Neither provides a usable `port=0` contract.

## Scope: native MP EngineCore startup

This path is selected by `parallel_config.data_parallel_backend`, not by the executor used inside each EngineCore.

```text
EngineCore management: data_parallel_backend = mp / ray
Worker executor inside each EngineCore: distributed_executor_backend = uni / mp / ray
```

Ray DP returns earlier from `launch_core_engines()`. Ray serializes the already prepared `EngineZmqAddresses` into each actor constructor, and `EngineCoreActorMixin._perform_handshakes()` simply yields those addresses. Therefore, Ray DP does not use this RPC-port handshake.

The code below is the native MP path.

## Case 1: all EngineCores are local

The transport decision is:

```python
handshake_local_only = offline_mode or local_engine_count == dp_size

if parallel_config.enable_elastic_ep:
    handshake_local_only = False
```

For ordinary single-node serving, including DP=1 and single-node DP>1, `local_engine_count == dp_size`, so `handshake_local_only=True`.

With an explicit `data_parallel_rpc_port=0`, the old path did this:

```text
data_parallel_rpc_port = 0
        |
        v
0 or get_open_port()
        |
        v
temporary TCP port p is selected and immediately released
        |
        v
get_engine_client_zmq_addr(local_only=True, host, p)
        |
        | host and p are ignored
        v
ipc:///tmp/...
        |
        v
ZMQ ROUTER binds IPC
```

`get_engine_client_zmq_addr()` returns `get_open_zmq_ipc_path()` whenever `local_only=True`. No component later binds `tcp://host:p`; the selected port is discarded.

This is dead computation, not a TCP port race. It also makes `0` appear supported only because the local topology does not use the field.

Typical configurations in this case include:

| Configuration | EngineCore executor | Result |
|---|---|---|
| DP=1, TP=1 | uni | Local IPC; selected TCP port is discarded |
| DP=1, TP>1 on one node | mp | Local IPC; selected TCP port is discarded |
| DP>1 with every DP replica on one node | uni or mp | Local IPC; selected TCP port is discarded |

## Case 2: native MP DP replicas span nodes

Consider the documented shape where the primary node runs the API server and some DP ranks, while another command launches headless DP ranks:

```bash
# Primary
vllm serve $MODEL --data-parallel-size 2 --data-parallel-size-local 1 \
  --data-parallel-address 10.0.0.1 --data-parallel-rpc-port 0

# Secondary
vllm serve $MODEL --headless --data-parallel-size 2 \
  --data-parallel-size-local 1 --data-parallel-start-rank 1 \
  --data-parallel-address 10.0.0.1 --data-parallel-rpc-port 0
```

On the primary:

```text
local_engine_count = 1, dp_size = 2
        |
        v
handshake_local_only = False
        |
        v
get_open_port() selects p, for example 43127
        |
        v
ROUTER binds tcp://10.0.0.1:43127
```

On the independently launched headless secondary, `run_headless()` does not call `get_open_port()`:

```python
host = parallel_config.data_parallel_master_ip
port = parallel_config.data_parallel_rpc_port
handshake_address = get_tcp_uri(host, port)
```

It therefore constructs `tcp://10.0.0.1:0` and passes that address to its EngineCore processes:

```text
Primary                                  Headless secondary
-------                                  ------------------
ROUTER bind                              DEALER connect
tcp://10.0.0.1:43127                     tcp://10.0.0.1:0
        ^                                        |
        +------------- never connects -----------+
```

The two commands have no earlier store, broker, Ray RPC, shared file, or established control connection that can publish `43127`. This handshake is itself the first connection, so it cannot be used to discover its own endpoint.

ZMQ `connect()` is asynchronous, so the secondary may not fail immediately. It can queue `HELLO` for `host:0` and later time out waiting for the frontend initialization message, while the primary waits for the missing remote EngineCore. The deployment is broken even if no other process ever claims `43127`.

## Why the previous bind-first approach was incorrect

The earlier version of this PR modeled the site as a probe-then-bind race and let the primary ROUTER bind `:0`. Its deterministic test mocked the remote consumer, so it proved only that the local ROUTER could own an ephemeral port. It did not prove that an independently launched headless node could learn that port.

The limiting issue is not how safely the primary chooses `p`; it is the absence of a discovery channel that communicates `p` to the secondary.

## Fix

This PR makes the existing fixed-port contract explicit:

- Validate `data_parallel_rpc_port` as `1..65535` in `ParallelConfig`.
- Remove the `or get_open_port()` fallback from EngineCore startup.
- Use the validated configured port directly.
- State in CLI help that every node must use the same port.

```text
option omitted
  -> AsyncEngineArgs: None
  -> ParallelConfig default: 29550

valid explicit port
  -> preserved and shared by every native MP node

0 / negative / >65535
  -> configuration error before engine startup
```

There is no behavior change for valid configured ports. Local IPC and Ray DP do not consume this TCP endpoint, but invalid explicit values are rejected consistently instead of being topology-dependent.

## Why this is not duplicate work

- #50960 and related RFC fixes cover dynamic endpoints whose final binder can publish the result through an existing channel.
- #51033 covers Rust/Ray frontend endpoint publication.
- Required searches for `51275`, `data parallel rpc port`, and `engine handshake rpc_port` found no other open PR validating this fixed endpoint.

## Tests

Added configuration tests for:

- the fixed default `29550`;
- accepted values `1`, `29550`, and `65535`;
- rejected values `-1`, `0`, and `65536`.

Results:

- Direct `ParallelConfig` behavior check — **passed**.
- `pre-commit run --files tests/test_config.py vllm/config/parallel.py vllm/engine/arg_utils.py vllm/v1/engine/utils.py` — **passed**.
- `pre-commit run mypy-3.12 --all-files --hook-stage manual` — **passed**.
- `.venv/bin/python -m pytest tests/test_config.py -k data_parallel_rpc_port -q` — **not run locally** because test collection imports the unavailable compiled CUDA flash-attention extension (`_vllm_fa2_C` or `_vllm_fa3_C`). The failure occurs during collection, before these tests execute.
- Model evaluation — **not applicable**; this only changes startup configuration validation.

## AI disclosure

AI assistance (OpenAI Codex) was used for investigation, implementation, tests, and drafting. The human submitter must review every changed line and understand and defend the change end-to-end before requesting maintainer review.