### PR TITLE
[Bugfix][Frontend] Build parsers from the tools rendered into the prompt

### DIFF
--- a/tests/entrypoints/openai/responses/test_serving_responses.py
+++ b/tests/entrypoints/openai/responses/test_serving_responses.py
@@ -53,6 +53,7 @@ from vllm.inputs import tokens_input
 from vllm.outputs import CompletionOutput, RequestOutput
 from vllm.parser.harmony import Segment
 from vllm.sampling_params import SamplingParams
+from vllm.tool_parsers.abstract_tool_parser import ToolParser
 
 
 class MockConversationContext(ConversationContext):
@@ -349,6 +350,91 @@ class TestValidateGeneratorInput:
         assert isinstance(result, ErrorResponse)
 
 
+@pytest.mark.parametrize(
+    ("exclude_tools_when_tool_choice_none", "expects_tools"),
+    [(True, False), (False, True)],
+)
+def test_response_parser_uses_tools_rendered_in_prompt(
+    exclude_tools_when_tool_choice_none: bool,
+    expects_tools: bool,
+) -> None:
+    parser_cls = MagicMock()
+    serving = object.__new__(OpenAIServingResponses)
+    serving.parser = parser_cls
+    serving.model_config = MagicMock()
+    serving.online_renderer = MagicMock()
+    serving.online_renderer.exclude_tools_when_tool_choice_none = (
+        exclude_tools_when_tool_choice_none
+    )
+    serving.chat_template_kwargs = {}
+    request = ResponsesRequest(
+        input="hi",
+        tools=[
+            {
+                "type": "function",
+                "name": "get_weather",
+                "parameters": {"type": "object", "properties": {}},
+            }
+        ],
+        tool_choice="none",
+        reasoning={"effort": "none"},
+    )
+
+    serving._make_response_parser(
+        request,
+        MagicMock(),
+        {"reasoning_effort": "none"},
+        [],
+    )
+
+    parser_tools = parser_cls.call_args.args[1]
+    parser_kwargs = parser_cls.call_args.kwargs["chat_template_kwargs"]
+    if expects_tools:
+        assert parser_tools is request.tools
+        assert ToolParser(MagicMock(), parser_tools).tools == request.tools
+    else:
+        assert parser_tools is None
+    assert parser_kwargs["_vllm_prompt_has_tools"] is expects_tools
+
+
+@pytest.mark.parametrize(
+    "builtin_tool",
+    [
+        {"type": "web_search_preview"},
+        {"type": "code_interpreter", "container": {"type": "auto"}},
+        {"type": "mcp", "server_label": "test", "server_url": ""},
+    ],
+)
+def test_response_parser_marks_builtin_tools_as_not_rendered(
+    builtin_tool: dict,
+) -> None:
+    parser_cls = MagicMock()
+    serving = object.__new__(OpenAIServingResponses)
+    serving.parser = parser_cls
+    serving.model_config = MagicMock()
+    serving.online_renderer = MagicMock()
+    serving.online_renderer.exclude_tools_when_tool_choice_none = False
+    serving.chat_template_kwargs = {}
+    request = ResponsesRequest(
+        input="hi",
+        tools=[builtin_tool],
+        reasoning={"effort": "none"},
+    )
+
+    serving._make_response_parser(
+        request,
+        MagicMock(),
+        {"reasoning_effort": "none"},
+        [],
+    )
+
+    parser_tools = parser_cls.call_args.args[1]
+    parser_kwargs = parser_cls.call_args.kwargs["chat_template_kwargs"]
+    assert parser_tools is request.tools
+    assert ToolParser(MagicMock(), parser_tools).tools == []
+    assert parser_kwargs["_vllm_prompt_has_tools"] is False
+
+
 @pytest.mark.asyncio
 async def test_reasoning_tokens_counted_for_text_reasoning_model(monkeypatch):
     """Ensure reasoning_tokens usage is derived from thinking token spans."""
@@ -392,6 +478,7 @@ async def test_reasoning_tokens_counted_for_text_reasoning_model(monkeypatch):
         request,
         tokenizer,
         serving._effective_chat_template_kwargs(request),
+        [],
     )
 
     # Build a SimpleContext with thinking tokens in the output.

--- a/tests/parser/engine/test_inkling.py
+++ b/tests/parser/engine/test_inkling.py
@@ -24,6 +24,10 @@ from vllm.parser.engine.events import EventType
 from vllm.parser.engine.parser_engine_config import ParserState
 from vllm.parser.inkling import InklingParser, _inkling_arg_converter
 from vllm.parser.parser_manager import ParserManager
+from vllm.renderers.online_renderer import (
+    get_parser_chat_template_kwargs,
+    get_tools_for_prompt,
+)
 
 MSG_MODEL = "<|message_model|>"
 TEXT_START = "<|content_text|>"
@@ -735,6 +739,135 @@ class TestRegisteredAdapters:
         assert reasoning is None
         assert content is None
         assert tools[0].name == "get_weather"
+
+    def test_plain_text_mode_uses_tools_rendered_in_prompt(
+        self, mock_tokenizer, mock_request
+    ):
+        request = ChatCompletionRequest(
+            model="test",
+            messages=[{"role": "user", "content": "hello"}],
+            tools=[
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "get_weather",
+                        "parameters": {"type": "object", "properties": {}},
+                    },
+                }
+            ],
+            tool_choice="none",
+        )
+        parser = _make_delegating_parser(
+            mock_tokenizer,
+            get_tools_for_prompt(request, exclude_tools_when_tool_choice_none=True),
+        )
+        results = _stream_delegating(parser, mock_request, f"answer{END_MESSAGE}")
+
+        assert "".join(result.content for result in results if result) == "answer"
+
+    def test_developer_message_tools_disable_plain_text_mode(
+        self, mock_tokenizer, mock_request
+    ):
+        developer_tool = {
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+        request = ChatCompletionRequest(
+            model="test",
+            messages=[
+                {
+                    "role": "developer",
+                    "content": "Use the weather tool.",
+                    "tools": [developer_tool],
+                },
+                {"role": "user", "content": "Weather?"},
+            ],
+            reasoning_effort="none",
+        )
+        parser_chat_template_kwargs = get_parser_chat_template_kwargs(
+            request,
+            {"reasoning_effort": "none"},
+            get_tools_for_prompt(request, False),
+            messages=request.messages,
+        )
+        parser_cls = ParserManager.get_parser(
+            tool_parser_name="inkling",
+            reasoning_parser_name="inkling",
+            enable_auto_tools=True,
+        )
+        assert parser_cls is not None
+        parser = parser_cls(
+            mock_tokenizer,
+            None,
+            chat_template_kwargs=parser_chat_template_kwargs,
+        )
+
+        reasoning, content, tools = parser.parse(
+            "get_weather" + _tool_block("get_weather", '{"city":"SF"}'),
+            mock_request,
+            enable_auto_tools=True,
+        )
+
+        assert reasoning is None
+        assert content is None
+        assert tools[0].name == "get_weather"
+
+        streaming_parser = parser_cls(
+            mock_tokenizer,
+            None,
+            chat_template_kwargs=parser_chat_template_kwargs,
+        )
+        results = _stream_delegating(
+            streaming_parser,
+            mock_request,
+            "get_weather" + _tool_block("get_weather", '{"city":"SF"}'),
+        )
+
+        # No-thinking streaming tool handoff is handled separately. This
+        # regression verifies that developer tools do not select plain-text
+        # mode and expose the leading function-name header as content.
+        assert not "".join(
+            result.content or "" for result in results if result
+        ).startswith("get_weather")
+
+    @pytest.mark.parametrize(
+        ("request_kwargs", "prompt_tools", "default_kwargs", "expects_tools"),
+        [
+            (
+                {"tools": []},
+                [{"name": "request"}],
+                {"tools": [{"name": "default"}]},
+                False,
+            ),
+            (None, [{"name": "request"}], {"tools": [{"name": "default"}]}, True),
+            (None, None, {"tools": [{"name": "default"}]}, True),
+        ],
+    )
+    def test_parser_tools_follow_chat_template_precedence(
+        self,
+        request_kwargs,
+        prompt_tools,
+        default_kwargs,
+        expects_tools,
+    ):
+        request = ChatCompletionRequest(
+            model="test",
+            messages=[{"role": "user", "content": "hello"}],
+            chat_template_kwargs=request_kwargs,
+        )
+
+        parser_kwargs = get_parser_chat_template_kwargs(
+            request,
+            {},
+            prompt_tools,
+            default_kwargs,
+            request.messages,
+        )
+
+        assert parser_kwargs["_vllm_prompt_has_tools"] is expects_tools
 
     def test_skip_tool_transition_clears_message_header(self, mock_tokenizer):
         parser = InklingParser(

--- a/tests/parser/engine/test_inkling.py
+++ b/tests/parser/engine/test_inkling.py
@@ -756,3 +756,130 @@ class TestRegisteredAdapters:
             )
             == "second"
         )
+
+
+def _delegating_content(parser, request, text: str) -> str:
+    """Non-streaming content through the serving layer's entry point."""
+    _, content, _ = parser.parse(
+        text,
+        request,
+        enable_auto_tools=True,
+        model_output_token_ids=[token_id for token_id, _ in _tokenize(text)],
+    )
+    return content or ""
+
+
+def _streamed_content(results) -> str:
+    return "".join(result.content or "" for result in results if result)
+
+
+def _delegating_stream_content(parser, request, text: str) -> str:
+    return _streamed_content(_stream_delegating(parser, request, text))
+
+
+def _chat_request(reasoning_effort, tools=None):
+    """A real request: `tool_choice` defaults to "none" without tools and
+    "auto" with them, and that default selects the tool-extraction branch."""
+    return ChatCompletionRequest(
+        model="inkling-small",
+        messages=[{"role": "user", "content": "hi"}],
+        reasoning_effort=reasoning_effort,
+        tools=tools,
+    )
+
+
+class TestBlockEndMarkerNotLeaked:
+    """Regression tests for https://github.com/vllm-project/vllm/issues/49865.
+
+    The serving config that reports it is ``--reasoning-parser inkling``
+    plus ``--tool-call-parser inkling``, i.e. DelegatingParser: the reasoning
+    pass runs with ``skip_tool_parsing`` and deliberately passes block-end
+    markers through as text so the tool pass can see them. Whenever that
+    second pass does not get to run, or its stripped result is discarded, the
+    literal ``<|end_message|>`` reaches the client.
+    """
+
+    @pytest.fixture(
+        params=[_delegating_content, _delegating_stream_content],
+        ids=["non_streaming", "streaming"],
+    )
+    def run(self, request):
+        return request.param
+
+    @pytest.mark.parametrize("reasoning_effort", ["none", "minimal"])
+    @pytest.mark.parametrize("suffix", [END_MESSAGE, END_SAMPLING])
+    def test_bare_text_without_tools(
+        self, mock_tokenizer, run, reasoning_effort, suffix
+    ):
+        request = _chat_request(reasoning_effort)
+        parser = _make_delegating_parser(
+            mock_tokenizer, reasoning_effort=reasoning_effort
+        )
+
+        assert run(parser, request, f"answer{suffix}") == "answer"
+
+    @pytest.mark.parametrize("reasoning_effort", ["none", "minimal"])
+    def test_text_block_without_tools(self, mock_tokenizer, run, reasoning_effort):
+        request = _chat_request(reasoning_effort)
+        parser = _make_delegating_parser(
+            mock_tokenizer, reasoning_effort=reasoning_effort
+        )
+
+        assert run(parser, request, f"{TEXT_START}answer{END_MESSAGE}") == "answer"
+
+    @pytest.mark.parametrize("reasoning_effort", ["none", "minimal", "high"])
+    def test_text_block_with_tools_and_no_tool_call(
+        self, mock_tokenizer, run, reasoning_effort
+    ):
+        """Agent clients declare tools on every turn, so ``tool_choice`` is
+        "auto" even when the model answers in plain text."""
+        tools = [{"type": "function", "function": {"name": "get_weather"}}]
+        request = _chat_request(reasoning_effort, tools)
+        assert request.tool_choice == "auto"
+        parser = _make_delegating_parser(
+            mock_tokenizer, tools, reasoning_effort=reasoning_effort
+        )
+
+        assert run(parser, request, f"{TEXT_START}answer{END_MESSAGE}") == "answer"
+
+    @pytest.mark.parametrize("opener", [TOOL_TEXT, TOOL_ERROR])
+    def test_raw_and_error_tool_blocks_with_tools(self, mock_tokenizer, run, opener):
+        """Raw and error tool blocks also render as visible content, so they
+        end reasoning for the same reason a text block does."""
+        tools = [{"type": "function", "function": {"name": "get_weather"}}]
+        request = _chat_request("none", tools)
+        parser = _make_delegating_parser(mock_tokenizer, tools)
+
+        assert run(parser, request, f"{opener}answer{END_MESSAGE}") == "answer"
+
+    @pytest.mark.parametrize(
+        "tools",
+        [None, [{"type": "function", "function": {"name": "get_weather"}}]],
+        ids=["without_tools", "with_tools"],
+    )
+    def test_thinking_then_text_block(self, mock_tokenizer, run, tools):
+        request = _chat_request("high", tools)
+        parser = _make_delegating_parser(mock_tokenizer, tools, reasoning_effort="high")
+        text = (
+            f"{THINK_START}pondering{END_MESSAGE}"
+            f"{MSG_MODEL}{TEXT_START}answer{END_MESSAGE}"
+        )
+
+        assert run(parser, request, text) == "answer"
+
+    def test_tool_call_still_parsed_with_tools(self, mock_tokenizer):
+        """The stripped-content path must not swallow real tool calls."""
+        tools = [{"type": "function", "function": {"name": "get_weather"}}]
+        request = _chat_request("none", tools)
+        parser = _make_delegating_parser(mock_tokenizer, tools)
+
+        reasoning, content, tool_calls = parser.parse(
+            "get_weather" + _tool_block("get_weather", '{"city":"SF"}'),
+            request,
+            enable_auto_tools=True,
+        )
+
+        assert reasoning is None
+        assert not content
+        assert tool_calls[0].name == "get_weather"
+        assert json.loads(tool_calls[0].arguments) == {"city": "SF"}

--- a/tests/parser/engine/test_inkling.py
+++ b/tests/parser/engine/test_inkling.py
@@ -19,6 +19,8 @@ from tests.parser.engine.streaming_helpers import (
     collect_function_name,
     collect_tool_arguments,
 )
+from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
+from vllm.parser.engine.events import EventType
 from vllm.parser.engine.parser_engine_config import ParserState
 from vllm.parser.inkling import InklingParser, _inkling_arg_converter
 from vllm.parser.parser_manager import ParserManager
@@ -134,6 +136,50 @@ def _stream_text_only(parser, request, text: str, chunk_size: int):
     if finish is not None:
         results.append((finish, text))
     return results
+
+
+def _stream_delegating(parser, request, text: str):
+    tokens = _tokenize(text)
+    results = []
+    prompt_token_ids = [_TML_VOCAB[END_MESSAGE], _TML_VOCAB[MSG_MODEL]]
+    for i, (token_id, token_text) in enumerate(tokens):
+        results.append(
+            parser.parse_delta(
+                token_text,
+                [token_id],
+                request,
+                prompt_token_ids=prompt_token_ids if i == 0 else None,
+                finished=i == len(tokens) - 1,
+            )
+        )
+    return results
+
+
+def _make_delegating_parser(
+    mock_tokenizer,
+    tools=None,
+    reasoning_effort="none",
+):
+    parser_cls = ParserManager.get_parser(
+        tool_parser_name="inkling",
+        reasoning_parser_name="inkling",
+        enable_auto_tools=True,
+    )
+    return parser_cls(
+        mock_tokenizer,
+        tools,
+        chat_template_kwargs={"reasoning_effort": reasoning_effort},
+    )
+
+
+def _make_reasoning_only_parser(mock_tokenizer, reasoning_effort="none"):
+    parser_cls = ParserManager.get_parser(
+        reasoning_parser_name="inkling",
+    )
+    return parser_cls(
+        mock_tokenizer,
+        chat_template_kwargs={"reasoning_effort": reasoning_effort},
+    )
 
 
 def _collect_reasoning(results) -> str:
@@ -515,11 +561,19 @@ class TestToolCallFiltering:
 
 class TestRegisteredAdapters:
     def test_adapters_resolve(self):
+        from vllm.parser.engine.adapters import (
+            ParserEngineReasoningAdapter,
+            ParserEngineToolAdapter,
+        )
         from vllm.reasoning import ReasoningParserManager
         from vllm.tool_parsers import ToolParserManager
 
         reasoning_cls = ReasoningParserManager.get_reasoning_parser("inkling")
         tool_cls = ToolParserManager.get_tool_parser("inkling")
+        assert ParserEngineReasoningAdapter.forward_delegating_context is False
+        assert ParserEngineToolAdapter.forward_delegating_context is False
+        assert reasoning_cls.forward_delegating_context is True
+        assert tool_cls.forward_delegating_context is True
         assert reasoning_cls._parser_engine_cls is InklingParser
         assert tool_cls._parser_engine_cls is InklingParser
         assert tool_cls.supports_required_and_named is False
@@ -533,3 +587,172 @@ class TestRegisteredAdapters:
         assert result.tools_called
         assert result.tool_calls[0].function.name == "f"
         assert json.loads(result.tool_calls[0].function.arguments) == {"a": 1}
+
+    @pytest.mark.parametrize("suffix", [END_MESSAGE, END_SAMPLING])
+    @pytest.mark.parametrize(
+        ("text", "expected_reasoning", "expected_content"),
+        [
+            ("plain response", "", "plain response"),
+            (f"{THINK_START}brief thought", "brief thought", ""),
+        ],
+    )
+    def test_reasoning_only_strips_block_end_non_streaming(
+        self,
+        mock_tokenizer,
+        mock_request,
+        suffix,
+        text,
+        expected_reasoning,
+        expected_content,
+    ):
+        parser = _make_reasoning_only_parser(mock_tokenizer)
+
+        reasoning, content, tools = parser.parse(text + suffix, mock_request)
+
+        assert (reasoning or "") == expected_reasoning
+        assert (content or "") == expected_content
+        assert not tools
+
+    @pytest.mark.parametrize("suffix", [END_MESSAGE, END_SAMPLING])
+    @pytest.mark.parametrize(
+        ("text", "expected_reasoning", "expected_content"),
+        [
+            ("plain response", "", "plain response"),
+            (f"{THINK_START}brief thought", "brief thought", ""),
+        ],
+    )
+    def test_reasoning_only_strips_block_end_streaming(
+        self,
+        mock_tokenizer,
+        mock_request,
+        suffix,
+        text,
+        expected_reasoning,
+        expected_content,
+    ):
+        parser = _make_reasoning_only_parser(mock_tokenizer)
+
+        results = _stream_delegating(parser, mock_request, text + suffix)
+
+        reasoning = "".join(
+            result.reasoning or "" for result in results if result is not None
+        )
+        content = "".join(
+            result.content or "" for result in results if result is not None
+        )
+        assert reasoning == expected_reasoning
+        assert content == expected_content
+
+    @pytest.mark.parametrize(
+        "reasoning_effort",
+        ["none", "minimal", 0, 0.0, 0.004, 0.099, 0.1],
+    )
+    @pytest.mark.parametrize("suffix", [END_MESSAGE, ""])
+    def test_plain_text_mode_streams_with_or_without_end_marker(
+        self, mock_tokenizer, mock_request, reasoning_effort, suffix
+    ):
+        parser = _make_delegating_parser(
+            mock_tokenizer,
+            reasoning_effort=reasoning_effort,
+        )
+        content = "plain response"
+        results = _stream_delegating(parser, mock_request, content + suffix)
+
+        assert [result.content for result in results if result] == list(content)
+
+    @pytest.mark.parametrize(
+        "reasoning_effort",
+        [
+            False,
+            -0.004,
+            0.994,
+            -(10**400),
+            10**400,
+            float("nan"),
+            float("inf"),
+        ],
+    )
+    def test_invalid_reasoning_effort_does_not_enable_plain_text_mode(
+        self, mock_tokenizer, reasoning_effort
+    ):
+        parser = InklingParser(
+            mock_tokenizer,
+            chat_template_kwargs={"reasoning_effort": reasoning_effort},
+        )
+
+        assert parser.parser_engine_config.initial_state == ParserState.MESSAGE_HEADER
+
+    @pytest.mark.parametrize("reasoning_effort", [0.004, 0.099])
+    def test_rounded_plain_text_mode_non_streaming(
+        self, mock_tokenizer, mock_request, reasoning_effort
+    ):
+        parser = _make_delegating_parser(
+            mock_tokenizer,
+            reasoning_effort=reasoning_effort,
+        )
+
+        reasoning, content, tools = parser.parse("plain response", mock_request)
+
+        assert reasoning is None
+        assert content == "plain response"
+        assert not tools
+
+    @pytest.mark.parametrize("suffix", [END_MESSAGE, ""])
+    def test_plain_text_after_reasoning(self, mock_tokenizer, mock_request, suffix):
+        parser = _make_delegating_parser(
+            mock_tokenizer,
+            reasoning_effort="minimal",
+        )
+        text = f"{THINK_START}brief thought{END_MESSAGE}{MSG_MODEL}final answer{suffix}"
+        results = _stream_delegating(parser, mock_request, text)
+
+        assert (
+            "".join(
+                result.reasoning for result in results if result and result.reasoning
+            )
+            == "brief thought"
+        )
+        assert (
+            "".join(result.content for result in results if result and result.content)
+            == "final answer"
+        )
+
+    def test_plain_text_mode_stays_disabled_with_tools(
+        self, mock_tokenizer, mock_request
+    ):
+        configured_tools = [{"type": "function", "function": {"name": "get_weather"}}]
+        parser = _make_delegating_parser(
+            mock_tokenizer,
+            configured_tools,
+        )
+        text = "get_weather" + _tool_block("get_weather", '{"city":"SF"}')
+        reasoning, content, tools = parser.parse(
+            text,
+            mock_request,
+            enable_auto_tools=True,
+        )
+
+        assert reasoning is None
+        assert content is None
+        assert tools[0].name == "get_weather"
+
+    def test_skip_tool_transition_clears_message_header(self, mock_tokenizer):
+        parser = InklingParser(
+            mock_tokenizer,
+            chat_template_kwargs={"reasoning_effort": "high"},
+            _delegating_tool_parser_enabled=False,
+        )
+        parser.skip_tool_parsing = True
+
+        events = parser._engine.feed(
+            f"first{END_MESSAGE}{MSG_MODEL}second",
+            [],
+        )
+        events.extend(parser._engine.finish())
+
+        assert (
+            "".join(
+                event.value for event in events if event.type == EventType.TEXT_CHUNK
+            )
+            == "second"
+        )

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -60,7 +60,11 @@ from vllm.logprobs import Logprob
 from vllm.outputs import RequestOutput
 from vllm.parser import ParserManager
 from vllm.parser.abstract_parser import Parser
-from vllm.renderers.online_renderer import OnlineRenderer
+from vllm.renderers.online_renderer import (
+    OnlineRenderer,
+    get_parser_chat_template_kwargs,
+    get_tools_for_prompt,
+)
 from vllm.sampling_params import BeamSearchParams, SamplingParams
 from vllm.tokenizers import TokenizerLike
 from vllm.utils.collection_utils import as_list
@@ -243,10 +247,20 @@ class OpenAIServingChat(GenerateBaseServing):
         chat_template_kwargs = self._effective_chat_template_kwargs(request)
         parser: Parser | None = None
         if self.parser_cls is not None:
+            parser_tools = get_tools_for_prompt(
+                request, self.exclude_tools_when_tool_choice_none
+            )
+            parser_chat_template_kwargs = get_parser_chat_template_kwargs(
+                request,
+                chat_template_kwargs,
+                parser_tools,
+                self.default_chat_template_kwargs,
+                request.messages,
+            )
             parser = self.parser_cls(
                 tokenizer,
-                request.tools,
-                chat_template_kwargs=chat_template_kwargs,
+                parser_tools,
+                chat_template_kwargs=parser_chat_template_kwargs,
                 model_config=self.model_config,
             )
         result = await self.render_chat_request(request)
@@ -460,11 +474,21 @@ class OpenAIServingChat(GenerateBaseServing):
                     raise ValueError(
                         "Tokenizer not available when `skip_tokenizer_init=True`"
                     )
+                parser_tools = get_tools_for_prompt(
+                    request, self.exclude_tools_when_tool_choice_none
+                )
+                parser_chat_template_kwargs = get_parser_chat_template_kwargs(
+                    request,
+                    chat_template_kwargs,
+                    parser_tools,
+                    self.default_chat_template_kwargs,
+                    request.messages,
+                )
                 parsers: list[Parser | None] = [
                     self.parser_cls(
                         tokenizer,
-                        request.tools,
-                        chat_template_kwargs=chat_template_kwargs,
+                        parser_tools,
+                        chat_template_kwargs=parser_chat_template_kwargs,
                         model_config=self.model_config,
                     )
                     for _ in range(num_choices)

--- a/vllm/entrypoints/openai/responses/serving.py
+++ b/vllm/entrypoints/openai/responses/serving.py
@@ -99,7 +99,11 @@ from vllm.logprobs import SampleLogprobs
 from vllm.lora.request import LoRARequest
 from vllm.outputs import CompletionOutput
 from vllm.parser import Parser, ParserManager
-from vllm.renderers.online_renderer import OnlineRenderer
+from vllm.renderers.online_renderer import (
+    OnlineRenderer,
+    get_parser_chat_template_kwargs,
+    get_tools_for_prompt,
+)
 from vllm.sampling_params import SamplingParams, StructuredOutputsParams
 from vllm.tokenizers import TokenizerLike
 from vllm.utils import random_uuid
@@ -259,13 +263,32 @@ class OpenAIServingResponses(GenerateBaseServing):
         request: ResponsesRequest,
         tokenizer: TokenizerLike,
         chat_template_kwargs: dict[str, Any],
+        messages: Sequence[Any],
     ) -> Parser | None:
         if self.parser is None:
             return None
+        prompt_tools = construct_tool_dicts(
+            request.tools,
+            request.tool_choice,
+            exclude_tools_when_tool_choice_none=(
+                self.online_renderer.exclude_tools_when_tool_choice_none
+            ),
+        )
+        parser_tools = get_tools_for_prompt(
+            request,
+            self.online_renderer.exclude_tools_when_tool_choice_none,
+        )
+        parser_chat_template_kwargs = get_parser_chat_template_kwargs(
+            request,
+            chat_template_kwargs,
+            prompt_tools,
+            self.chat_template_kwargs,
+            messages,
+        )
         return self.parser(
             tokenizer,
-            request.tools,
-            chat_template_kwargs=chat_template_kwargs,
+            parser_tools,
+            chat_template_kwargs=parser_chat_template_kwargs,
             model_config=self.model_config,
         )
 
@@ -455,7 +478,7 @@ class OpenAIServingResponses(GenerateBaseServing):
 
             chat_template_kwargs = self._effective_chat_template_kwargs(request)
             response_parser = self._make_response_parser(
-                request, tokenizer, chat_template_kwargs
+                request, tokenizer, chat_template_kwargs, messages
             )
 
             context: ConversationContext

--- a/vllm/parser/abstract_parser.py
+++ b/vllm/parser/abstract_parser.py
@@ -523,6 +523,15 @@ class DelegatingParser(Parser):
                     or (isinstance(content, str) and not content.strip())
                 ):
                     return [], None
+                if self._engine_based and tool_call_info is not None:
+                    # Engine-backed parsers route content extraction through
+                    # extract_tool_calls, so the structural markers the
+                    # reasoning pass preserved for us are only stripped in
+                    # its result -- same reasoning as the tool_choice="none"
+                    # branch above. Keeping the raw content here would leak
+                    # block-end markers whenever the model answers in plain
+                    # text while tools are declared.
+                    return None, tool_call_info.content
                 return None, content
 
         return tool_calls, content

--- a/vllm/parser/abstract_parser.py
+++ b/vllm/parser/abstract_parser.py
@@ -121,11 +121,30 @@ class Parser:
         self._reasoning_parser: ReasoningParser | None = None
         self._tool_parser: ToolParser | None = None
         if self.__class__.reasoning_parser_cls is not None:
-            self._reasoning_parser = self.__class__.reasoning_parser_cls(
-                tokenizer, *args, model_config=model_config, **kwargs
-            )
+            reasoning_parser_cls = self.__class__.reasoning_parser_cls
+            if getattr(reasoning_parser_cls, "forward_delegating_context", False):
+                # Engine adapters may preserve structural markers for a
+                # downstream tool-parsing pass when one is configured.
+                self._reasoning_parser = reasoning_parser_cls(
+                    tokenizer,
+                    *args,
+                    tools=tools,
+                    model_config=model_config,
+                    _delegating_tool_parser_enabled=(
+                        self.__class__.tool_parser_cls is not None
+                    ),
+                    **kwargs,
+                )
+            else:
+                self._reasoning_parser = reasoning_parser_cls(
+                    tokenizer, *args, model_config=model_config, **kwargs
+                )
         if self.__class__.tool_parser_cls is not None:
-            self._tool_parser = self.__class__.tool_parser_cls(tokenizer, tools)
+            tool_parser_cls = self.__class__.tool_parser_cls
+            if getattr(tool_parser_cls, "forward_delegating_context", False):
+                self._tool_parser = tool_parser_cls(tokenizer, tools, **kwargs)
+            else:
+                self._tool_parser = tool_parser_cls(tokenizer, tools)
 
         self._engine_based = (
             self._reasoning_parser is None

--- a/vllm/parser/engine/adapters.py
+++ b/vllm/parser/engine/adapters.py
@@ -43,6 +43,7 @@ class ParserEngineReasoningAdapter(ReasoningParser):
 
     _parser_engine_cls: type[ParserEngine]
     engine_based_streaming: bool = True
+    forward_delegating_context: bool = False
 
     def __init__(self, tokenizer: TokenizerLike, *args, **kwargs) -> None:
         super().__init__(tokenizer, *args, **kwargs)
@@ -138,6 +139,7 @@ class ParserEngineToolAdapter(ToolParser):
 
     _parser_engine_cls: type[ParserEngine]
     engine_based_streaming: bool = True
+    forward_delegating_context: bool = False
 
     def __init__(
         self,
@@ -192,16 +194,24 @@ class ParserEngineToolAdapter(ToolParser):
 
 def make_adapters(
     parser_engine_cls: type[ParserEngine],
+    *,
+    forward_delegating_context: bool = False,
 ) -> tuple[type[ParserEngineReasoningAdapter], type[ParserEngineToolAdapter]]:
     reasoning_adapter = type(
         f"{parser_engine_cls.__name__}ReasoningAdapter",
         (ParserEngineReasoningAdapter,),
-        {"_parser_engine_cls": parser_engine_cls},
+        {
+            "_parser_engine_cls": parser_engine_cls,
+            "forward_delegating_context": forward_delegating_context,
+        },
     )
     tool_adapter = type(
         f"{parser_engine_cls.__name__}ToolAdapter",
         (ParserEngineToolAdapter,),
-        {"_parser_engine_cls": parser_engine_cls},
+        {
+            "_parser_engine_cls": parser_engine_cls,
+            "forward_delegating_context": forward_delegating_context,
+        },
     )
     # Let the serving layer find the adapters and call adjust_request(),
     # which sets skip_special_tokens=False for the detokenizer.

--- a/vllm/parser/engine/parser_engine_config.py
+++ b/vllm/parser/engine/parser_engine_config.py
@@ -40,6 +40,8 @@ class Transition:
     next_state: ParserState
     events: tuple[EventType, ...] = field(default_factory=tuple)
     skip_in_token_id_mode: bool = False
+    # Preserve structural marker text for a downstream tool-parsing pass.
+    passthrough_terminal_when_skipping_tools: bool = True
 
 
 @dataclass(frozen=True)

--- a/vllm/parser/engine/registered_adapters.py
+++ b/vllm/parser/engine/registered_adapters.py
@@ -68,7 +68,7 @@ from vllm.parser.seed_oss import SeedOssParser
 (
     InklingParserReasoningAdapter,
     InklingParserToolAdapter,
-) = make_adapters(InklingParser)
+) = make_adapters(InklingParser, forward_delegating_context=True)
 
 (
     MistralParserReasoningAdapter,

--- a/vllm/parser/engine/streaming_parser_engine.py
+++ b/vllm/parser/engine/streaming_parser_engine.py
@@ -319,6 +319,12 @@ class StreamingParserEngine:
             return self._emit_for_state(value)
 
         if self.skip_tool_parsing and terminal in self._tool_terminals:
+            if not transition.passthrough_terminal_when_skipping_tools:
+                return [
+                    event
+                    for event in self._apply_transition(transition, value)
+                    if event.type != EventType.TEXT_CHUNK
+                ]
             if self.state == ParserState.MESSAGE_HEADER:
                 self.state = ParserState.CONTENT
                 self._message_header_buffer = ""

--- a/vllm/parser/inkling.py
+++ b/vllm/parser/inkling.py
@@ -196,9 +196,13 @@ def inkling_config(
             message_start_state,
             (),
         ),
+        # Any block that renders as visible content proves no reasoning is
+        # still open. Confirming that here (not only in plain-text mode) is
+        # what lets DelegatingParser hand the block to the tool pass, which
+        # is the only place block-end markers get stripped while streaming.
         (ParserState.CONTENT, "TEXT_START"): Transition(
             ParserState.CONTENT,
-            (EventType.REASONING_END,) if plain_text_mode else (),
+            (EventType.REASONING_END,),
         ),
         (ParserState.CONTENT, "THINK_START"): Transition(
             ParserState.REASONING,
@@ -211,11 +215,11 @@ def inkling_config(
         # Raw / error tool blocks render as visible text.
         (ParserState.CONTENT, "TOOL_TEXT"): Transition(
             ParserState.CONTENT,
-            (),
+            (EventType.REASONING_END,),
         ),
         (ParserState.CONTENT, "TOOL_ERROR"): Transition(
             ParserState.CONTENT,
-            (),
+            (EventType.REASONING_END,),
         ),
         # The optional function name between the model-role and content-kind
         # markers is metadata, not visible assistant content.
@@ -225,7 +229,7 @@ def inkling_config(
         ),
         (ParserState.MESSAGE_HEADER, "TEXT_START"): Transition(
             ParserState.CONTENT,
-            (),
+            (EventType.REASONING_END,),
         ),
         (ParserState.MESSAGE_HEADER, "THINK_START"): Transition(
             ParserState.REASONING,
@@ -237,11 +241,11 @@ def inkling_config(
         ),
         (ParserState.MESSAGE_HEADER, "TOOL_TEXT"): Transition(
             ParserState.CONTENT,
-            (),
+            (EventType.REASONING_END,),
         ),
         (ParserState.MESSAGE_HEADER, "TOOL_ERROR"): Transition(
             ParserState.CONTENT,
-            (),
+            (EventType.REASONING_END,),
         ),
         # ── Inside a thinking block ───────────────────────────────────
         (ParserState.REASONING, "THINK_START"): Transition(

--- a/vllm/parser/inkling.py
+++ b/vllm/parser/inkling.py
@@ -172,7 +172,11 @@ def _inkling_arg_converter(raw_args: str, partial: bool) -> str:
 
 
 @functools.cache
-def inkling_config() -> ParserEngineConfig:
+def inkling_config(
+    *,
+    plain_text_mode: bool = False,
+    preserve_block_end_for_tool_parser: bool = True,
+) -> ParserEngineConfig:
     terminals = {
         "MSG_MODEL": MESSAGE_MODEL,
         "TEXT_START": CONTENT_TEXT,
@@ -183,15 +187,18 @@ def inkling_config() -> ParserEngineConfig:
         "TOOL_TEXT": CONTENT_INVOKE_TOOL_TEXT,
         "TOOL_ERROR": CONTENT_TOOL_ERROR,
     }
+    message_start_state = (
+        ParserState.CONTENT if plain_text_mode else ParserState.MESSAGE_HEADER
+    )
     transitions: dict[tuple[ParserState, str], Transition] = {
         # ── Between blocks / inside a text block ──────────────────────
         (ParserState.CONTENT, "MSG_MODEL"): Transition(
-            ParserState.MESSAGE_HEADER,
+            message_start_state,
             (),
         ),
         (ParserState.CONTENT, "TEXT_START"): Transition(
             ParserState.CONTENT,
-            (),
+            (EventType.REASONING_END,) if plain_text_mode else (),
         ),
         (ParserState.CONTENT, "THINK_START"): Transition(
             ParserState.REASONING,
@@ -213,7 +220,7 @@ def inkling_config() -> ParserEngineConfig:
         # The optional function name between the model-role and content-kind
         # markers is metadata, not visible assistant content.
         (ParserState.MESSAGE_HEADER, "MSG_MODEL"): Transition(
-            ParserState.MESSAGE_HEADER,
+            message_start_state,
             (),
         ),
         (ParserState.MESSAGE_HEADER, "TEXT_START"): Transition(
@@ -256,11 +263,17 @@ def inkling_config() -> ParserEngineConfig:
     for end in ("THINK_END", "END_SAMPLING"):
         transitions[(ParserState.CONTENT, end)] = Transition(
             ParserState.CONTENT,
-            (),
+            (EventType.REASONING_END,) if plain_text_mode else (),
+            passthrough_terminal_when_skipping_tools=(
+                preserve_block_end_for_tool_parser
+            ),
         )
         transitions[(ParserState.REASONING, end)] = Transition(
             ParserState.CONTENT,
             (EventType.REASONING_END,),
+            passthrough_terminal_when_skipping_tools=(
+                preserve_block_end_for_tool_parser
+            ),
         )
         transitions[(ParserState.TOOL_ARGS, end)] = Transition(
             ParserState.CONTENT,
@@ -269,14 +282,20 @@ def inkling_config() -> ParserEngineConfig:
         transitions[(ParserState.MESSAGE_HEADER, end)] = Transition(
             ParserState.CONTENT,
             (EventType.TEXT_CHUNK,),
+            passthrough_terminal_when_skipping_tools=(
+                preserve_block_end_for_tool_parser
+            ),
         )
 
     return ParserEngineConfig(
         name="inkling",
         # Normal generation continues after a prompt-prefilled
-        # `<|message_model|>`. Non-streaming parsing receives only the generated
-        # suffix, so begin in the corresponding message-header state as well.
-        initial_state=ParserState.MESSAGE_HEADER,
+        # `<|message_model|>`. With tools disabled, none/minimal reasoning emits
+        # untyped text directly; otherwise the suffix starts in the message
+        # header where an optional function name must remain hidden.
+        initial_state=(
+            ParserState.CONTENT if plain_text_mode else ParserState.MESSAGE_HEADER
+        ),
         terminals=terminals,
         # Inkling content-kind markers are the grammar. When the engine is
         # used through DelegatingParser, the reasoning pass can hand the tool
@@ -304,7 +323,41 @@ class InklingParser(ParserEngine):
         tools: list[Tool] | None = None,
         **kwargs,
     ) -> None:
-        kwargs.setdefault("parser_engine_config", inkling_config())
+        chat_kwargs = kwargs.get("chat_template_kwargs", {}) or {}
+        reasoning_effort = chat_kwargs.get("reasoning_effort")
+        prompt_has_tools = chat_kwargs.get("_vllm_prompt_has_tools", bool(tools))
+        normalized_effort: object
+        if reasoning_effort == "none":
+            normalized_effort = 0.0
+        elif reasoning_effort == "minimal":
+            normalized_effort = 0.1
+        elif (
+            not isinstance(reasoning_effort, bool)
+            and isinstance(reasoning_effort, (int, float))
+            and 0.0 <= reasoning_effort <= 0.99
+        ):
+            # Match the model-visible value rendered by
+            # ``inkling_encoding._thinking_effort_text``.
+            normalized_effort = float(f"{float(reasoning_effort):.2f}")
+        else:
+            normalized_effort = reasoning_effort
+        self._plain_text_mode = (
+            not prompt_has_tools
+            and not isinstance(normalized_effort, bool)
+            and isinstance(normalized_effort, (int, float))
+            and normalized_effort in (0.0, 0.1)
+        )
+        preserve_block_end_for_tool_parser = kwargs.pop(
+            "_delegating_tool_parser_enabled",
+            True,
+        )
+        kwargs.setdefault(
+            "parser_engine_config",
+            inkling_config(
+                plain_text_mode=self._plain_text_mode,
+                preserve_block_end_for_tool_parser=(preserve_block_end_for_tool_parser),
+            ),
+        )
         super().__init__(tokenizer, tools, **kwargs)
 
     def adjust_initial_state_from_prompt(self, prompt_token_ids: Sequence[int]) -> None:
@@ -330,7 +383,12 @@ class InklingParser(ParserEngine):
                 self._streaming_initialized = True
                 return
             if token_id == model_id:
-                self._engine.reset(initial_state=ParserState.MESSAGE_HEADER)
+                initial_state = (
+                    ParserState.CONTENT
+                    if self._plain_text_mode
+                    else ParserState.MESSAGE_HEADER
+                )
+                self._engine.reset(initial_state=initial_state)
                 self._streaming_initialized = True
                 return
             if token_id in special_ids:

--- a/vllm/renderers/online_derenderer.py
+++ b/vllm/renderers/online_derenderer.py
@@ -31,6 +31,10 @@ from vllm.entrypoints.serve.utils.request_logger import RequestLogger
 from vllm.logger import init_logger
 from vllm.parser import Parser, ParserManager
 from vllm.renderers import BaseRenderer
+from vllm.renderers.online_renderer import (
+    get_parser_chat_template_kwargs,
+    get_tools_for_prompt,
+)
 from vllm.tokenizers import TokenizerLike
 from vllm.tokenizers.detokenizer_utils import detokenize_incrementally
 from vllm.utils import random_uuid
@@ -137,10 +141,20 @@ class OnlineDerenderer:
                         .chat_template_kwargs
                     )
 
+                parser_tools = get_tools_for_prompt(
+                    chat_request, self.exclude_tools_when_tool_choice_none
+                )
+                parser_chat_template_kwargs = get_parser_chat_template_kwargs(
+                    chat_request,
+                    chat_template_kwargs,
+                    parser_tools,
+                    self.default_chat_template_kwargs,
+                    chat_request.messages,
+                )
                 parser = self.parser(
                     tokenizer,
-                    chat_request.tools,
-                    chat_template_kwargs=chat_template_kwargs,
+                    parser_tools,
+                    chat_template_kwargs=parser_chat_template_kwargs,
                 )
                 reasoning, content, tool_calls = parser.parse(
                     decoded_text,

--- a/vllm/renderers/online_renderer.py
+++ b/vllm/renderers/online_renderer.py
@@ -2,8 +2,9 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 from collections.abc import Sequence
 from http import HTTPStatus
-from typing import Any
+from typing import Any, overload
 
+from openai.types.responses.tool import Tool as ResponsesTool
 from openai_harmony import Message as OpenAIMessage
 
 from vllm.config import ModelConfig
@@ -14,6 +15,7 @@ from vllm.entrypoints.chat_utils import (
 from vllm.entrypoints.openai.chat_completion.protocol import (
     ChatCompletionNamedToolChoiceParam,
     ChatCompletionRequest,
+    ChatCompletionToolsParam,
 )
 from vllm.entrypoints.openai.completion.protocol import (
     CompletionRequest,
@@ -58,6 +60,71 @@ def _reused_prompt_token_ids(request: Any) -> list[int] | None:
     if not isinstance(kv, dict):
         return None
     return kv.pop("prompt_token_ids", None) or None
+
+
+@overload
+def get_tools_for_prompt(
+    request: ChatCompletionRequest,
+    exclude_tools_when_tool_choice_none: bool,
+) -> list[ChatCompletionToolsParam] | None: ...
+
+
+@overload
+def get_tools_for_prompt(
+    request: ResponsesRequest,
+    exclude_tools_when_tool_choice_none: bool,
+) -> list[ResponsesTool] | None: ...
+
+
+def get_tools_for_prompt(
+    request: ChatCompletionRequest | ResponsesRequest,
+    exclude_tools_when_tool_choice_none: bool,
+) -> list[ChatCompletionToolsParam] | list[ResponsesTool] | None:
+    if request.tools is None or (
+        request.tool_choice == "none" and exclude_tools_when_tool_choice_none
+    ):
+        return None
+    return request.tools
+
+
+def get_parser_chat_template_kwargs(
+    request: ChatCompletionRequest | ResponsesRequest,
+    chat_template_kwargs: dict[str, Any] | None,
+    prompt_tools: Sequence[Any] | None,
+    default_chat_template_kwargs: dict[str, Any] | None = None,
+    messages: Sequence[Any] | None = None,
+) -> dict[str, Any]:
+    """Attach the rendered prompt's tool context for parser construction.
+
+    ``prompt_tools`` is the request-level tool list after API-specific
+    filtering/conversion. Chat-template kwargs follow the same precedence as
+    :meth:`ChatParams.with_defaults`: a request override wins, otherwise the
+    request-level prompt tools win when present, then the server default is
+    used. Inkling additionally declares tools attached to developer messages.
+
+    The private flag is carried only in the parser's copy of the template
+    kwargs, so renderer-specific message tools do not alter other tool
+    parsers' configured tool lists or leak into chat-template rendering.
+    """
+    request_kwargs = request.chat_template_kwargs or {}
+    request_override = request_kwargs.get("tools")
+    if "tools" in request_kwargs and request_override not in (None, "auto"):
+        effective_tools = request_override
+    elif prompt_tools is not None:
+        effective_tools = prompt_tools
+    else:
+        effective_tools = (default_chat_template_kwargs or {}).get("tools")
+        if effective_tools == "auto":
+            effective_tools = None
+
+    prompt_has_tools = bool(effective_tools)
+    for message in messages or ():
+        if isinstance(message, dict) and message.get("role") == "developer":
+            prompt_has_tools = prompt_has_tools or bool(message.get("tools"))
+
+    parser_kwargs = dict(chat_template_kwargs or {})
+    parser_kwargs["_vllm_prompt_has_tools"] = prompt_has_tools
+    return parser_kwargs
 
 
 class OnlineRenderer:
@@ -172,12 +239,14 @@ class OnlineRenderer:
                     "--tool-call-parser to be set"
                 )
 
-        if request.tools is None or (
-            request.tool_choice == "none" and self.exclude_tools_when_tool_choice_none
-        ):
-            tool_dicts = None
-        else:
-            tool_dicts = [tool.model_dump() for tool in request.tools]
+        prompt_tools = get_tools_for_prompt(
+            request, self.exclude_tools_when_tool_choice_none
+        )
+        tool_dicts = (
+            None
+            if prompt_tools is None
+            else [tool.model_dump() for tool in prompt_tools]
+        )
 
         if not self.use_harmony:
             # Common case.


### PR DESCRIPTION
> **Depends on #49876** and is branched on top of it, so the commit list here
> includes that PR's three commits. Only one commit belongs to this one:
>
> - `fix: construct parsers from the tools rendered into the prompt`
>
> Happy to rebase onto `main` once #49876 lands.
>
> A second, unrelated fix that previously rode along in this PR — batched chat
> completions sharing one parser across conversations — has been split out into
> #51501, which is based directly on `main` and does not depend on either PR.

## Purpose

Parsers on the serving paths were constructed from `request.tools`, which is
not always what the chat template actually rendered into the prompt. This is
not specific to Inkling; it was found while fixing #49865 and split out of that
PR so it can stay a focused parser fix.

The chat, Responses, and derender paths all passed `request.tools` when
constructing the parser:

- with `--exclude-tools-when-tool-choice-none` and `tool_choice="none"`, the
  prompt carries no tools while `request.tools` is still populated, so the
  parser was configured for a prompt the model never saw;
- tools attached to a developer message are rendered into the prompt but are
  not in `request.tools`, so the parser could not see them at all.

Adds `get_tools_for_prompt` and `get_parser_chat_template_kwargs` in
`vllm/renderers/online_renderer.py` so the renderer, the chat and Responses
serving paths, and the derenderer agree on the effective tool selection. The
`_vllm_prompt_has_tools` flag is carried only in the parser's copy of the
template kwargs, so it cannot alter other tool parsers' configured tool lists
or leak into chat-template rendering.

## Test Plan

- `tests/entrypoints/openai/responses/test_serving_responses.py`: the Responses
  parser is constructed from the tools rendered into the prompt, and built-in
  tools are marked as not rendered.
- `tests/parser/engine/test_inkling.py`: three cases covering chat-template
  kwargs precedence, developer-message tools, and tools rendered under
  `tool_choice="none"`.

## Test Result

`tests/parser/engine/test_inkling.py`: **118 passed**.
`tests/parser` + `tests/reasoning`: **4555 passed**.

`tests/entrypoints`, run against a full CUDA build and compared with the merge
base (`main` @ 652ba5922) on the same machine:

| | base | measured branch |
|---|---|---|
| `test_serving_responses.py` | 21 passed, 1 xfailed | **26 passed**, 1 xfailed |

Two caveats on that number, both worth stating plainly:

- It was measured on an earlier revision of this branch that also carried the
  batched-parser fix. That fix and its tests have since been split out, but
  they touched `test_serving_chat.py` only — the five added
  `test_serving_responses.py` cases and the source changes behind them are
  unchanged, so the row above still describes this branch.
- The same run also covered `test_serving_chat.py` (34 → 37 passed, 10 errors
  on both sides). All three added cases there belonged to the split-out fix, so
  that file is no longer modified by this PR. It is still downstream of the
  `chat_completion/serving.py` change here and has not been re-run since the
  split; it is left to CI.

The 10 errors seen on both sides come from the `gptoss_server` fixture, which
starts a real server for `gpt-oss-20b` and fails at fixture setup in that
environment before any test body runs.

Those `tests/entrypoints` numbers predate this branch being rebased onto `main`
@ 5eaa70dac. The rebase touched four files that had also changed upstream and
merged without conflicts; afterwards the parser suites above still pass,
`ruff check` is clean, and every modified serving/renderer module imports
successfully against the new base. The entrypoints files themselves have not
been re-run since the rebase and are left to CI.

## AI assistance

The human submitter selected and claimed the underlying issue, controlled the
scope, reviewed the root cause and implementation, reviewed every changed line,
and approved publication. AI-assisted tooling supported implementation,
regression-test authoring, and validation orchestration.
