### PR TITLE
[Bugfix][Rust Frontend] Return an error instead of panicking on empty-prompt logprobs

### DIFF
--- a/rust/src/text/src/output/decoded.rs
+++ b/rust/src/text/src/output/decoded.rs
@@ -142,6 +142,7 @@ pub async fn decoded_text_event_stream(
                     .prompt_logprobs()
                     .map(|logprobs| {
                         decode_prompt_logprobs(
+                            &request_id,
                             tokenizer.as_ref(),
                             prompt_token_ids,
                             logprobs,

--- a/rust/src/text/src/output/logprobs.rs
+++ b/rust/src/text/src/output/logprobs.rs
@@ -78,15 +78,16 @@ pub(super) fn decode_logprobs<T: Tokenizer + ?Sized>(
 /// the remaining scored prompt positions into `scored_positions`, matching
 /// vLLM's prompt-logprobs semantics.
 pub(super) fn decode_prompt_logprobs<T: Tokenizer + ?Sized>(
+    request_id: &str,
     tokenizer: &T,
     prompt_token_ids: &[u32],
     logprobs: &Logprobs,
     skip_special_tokens: bool,
 ) -> Result<DecodedPromptLogprobs, Error> {
-    let first_token_id = prompt_token_ids
-        .first()
-        .copied()
-        .expect("prompt logprobs require at least one prompt token");
+    let first_token_id =
+        prompt_token_ids.first().copied().ok_or_else(|| Error::EmptyPromptTokenIds {
+            request_id: request_id.to_string(),
+        })?;
     let first_token = tokenizer.decode(&[first_token_id], skip_special_tokens)?;
     let scored_positions = logprobs
         .positions
@@ -193,8 +194,14 @@ mod tests {
         };
 
         assert_eq!(
-            decode_prompt_logprobs(&tokenizer, &[b'p' as u32, b'x' as u32], &logprobs, false)
-                .unwrap(),
+            decode_prompt_logprobs(
+                "test",
+                &tokenizer,
+                &[b'p' as u32, b'x' as u32],
+                &logprobs,
+                false
+            )
+            .unwrap(),
             DecodedPromptLogprobs {
                 first_token_id: b'p' as u32,
                 first_token: "p".to_string(),
@@ -208,5 +215,19 @@ mod tests {
                 }],
             }
         );
+    }
+
+    #[test]
+    fn decode_prompt_logprobs_rejects_empty_prompt_token_ids() {
+        let tokenizer = TestTokenizer::new();
+        let logprobs = Logprobs {
+            positions: vec![PositionLogprobs { entries: vec![] }],
+        };
+
+        let error = decode_prompt_logprobs("req-1", &tokenizer, &[], &logprobs, false).unwrap_err();
+        assert!(matches!(
+            error,
+            Error::EmptyPromptTokenIds { request_id } if request_id == "req-1"
+        ));
     }
 }


### PR DESCRIPTION
## Purpose

Fixes #51420.

`decode_prompt_logprobs` in `rust/src/text/src/output/logprobs.rs` used
`.expect()` to assert that the prompt has at least one token:

```rust
let first_token_id = prompt_token_ids
    .first()
    .copied()
    .expect("prompt logprobs require at least one prompt token");
```

Because the Rust workspace builds with `panic = "abort"`, if an engine
output ever carries prompt logprobs for a zero-token prompt, this
`.expect()` aborts the whole process instead of failing just that one
request. The panic cannot be contained by `catch_unwind` or a tower
`CatchPanicLayer` — the process terminates, taking every other
in-flight request on that server down with it.

**Fix:** replace the `.expect()` with the existing
`Error::EmptyPromptTokenIds { request_id }` variant, threading
`request_id` (already available at the call site in
`decoded_text_event_stream`) into `decode_prompt_logprobs`. The caller
already propagates `Result`, so this now surfaces as a normal decode
error instead of an abort, and is already classified by
`Error::is_request_validation_error` the same way the existing
pre-tokenization empty-prompt check is.

**Why this does not duplicate existing PRs:** I checked
`gh pr list --repo vllm-project/vllm --state open --search "logprobs.rs"`
and `--search "decode_prompt_logprobs"` / `"empty prompt logprobs"` /
`"51420 in:body"`. The only Rust-frontend logprobs PR in flight is
#51026 (`[Bugfix][Rust Frontend] Tolerate NaN-corrupted logprobs in
engine-core`), which fixes a NaN-corrupted sampled-rank issue in
`vllm-engine-core-client`'s `PositionLogprobs::from_decoded_row` — a
different file, different crate, and a different failure mode. It
does not touch `decode_prompt_logprobs` or this panic.

## Test Plan

```bash
cd rust
cargo test -p vllm-text output::logprobs
```

Added `decode_prompt_logprobs_rejects_empty_prompt_token_ids`, which
calls `decode_prompt_logprobs` with an empty `prompt_token_ids` slice
and asserts it returns `Err(Error::EmptyPromptTokenIds { .. })`
instead of panicking.

Confirmed the test fails (panics) without the fix by temporarily
reverting the `.expect()` change and re-running:

```
thread '...decode_prompt_logprobs_rejects_empty_prompt_token_ids' panicked at src/text/src/output/logprobs.rs:90:10:
prompt logprobs require at least one prompt token
test result: FAILED. 2 passed; 1 failed; 0 ignored; 0 measured; 78 filtered out; finished in 0.00s
```

## Test Result

With the fix applied, the full `vllm-text` crate test suite passes:

```
test result: ok. 80 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 2.49s
```

`cargo fmt -p vllm-text -- --check` and
`cargo clippy -p vllm-text --all-targets` are both clean.

`cargo check -p vllm-chat` also passes (downstream consumer of this
module). `cargo check -p vllm-server` fails in this sandbox with a
pre-existing, unrelated `protoc` toolchain error
(`Could not find 'protoc'`); confirmed this failure is identical on
unmodified `upstream/main`, so it is an environment issue and not
caused by this change.

Model evaluation: N/A — this only changes error handling on a decode
path, not model output.

## AI assistance disclosure

AI assistance (Claude) was used to draft this fix and its test. I
have reviewed every changed line and run the test commands above
myself.
