### PR TITLE
[Bugfix][Rust Frontend] Avoid abort on empty prompt logprobs

### DIFF
--- a/rust/src/text/src/output/decoded.rs
+++ b/rust/src/text/src/output/decoded.rs
@@ -143,6 +143,7 @@ pub async fn decoded_text_event_stream(
                     .map(|logprobs| {
                         decode_prompt_logprobs(
                             tokenizer.as_ref(),
+                            &request_id,
                             prompt_token_ids,
                             logprobs,
                             decode_options.skip_special_tokens,

--- a/rust/src/text/src/output/logprobs.rs
+++ b/rust/src/text/src/output/logprobs.rs
@@ -79,14 +79,15 @@ pub(super) fn decode_logprobs<T: Tokenizer + ?Sized>(
 /// vLLM's prompt-logprobs semantics.
 pub(super) fn decode_prompt_logprobs<T: Tokenizer + ?Sized>(
     tokenizer: &T,
+    request_id: &str,
     prompt_token_ids: &[u32],
     logprobs: &Logprobs,
     skip_special_tokens: bool,
 ) -> Result<DecodedPromptLogprobs, Error> {
-    let first_token_id = prompt_token_ids
-        .first()
-        .copied()
-        .expect("prompt logprobs require at least one prompt token");
+    let first_token_id =
+        prompt_token_ids.first().copied().ok_or_else(|| Error::EmptyPromptTokenIds {
+            request_id: request_id.to_string(),
+        })?;
     let first_token = tokenizer.decode(&[first_token_id], skip_special_tokens)?;
     let scored_positions = logprobs
         .positions
@@ -193,8 +194,14 @@ mod tests {
         };
 
         assert_eq!(
-            decode_prompt_logprobs(&tokenizer, &[b'p' as u32, b'x' as u32], &logprobs, false)
-                .unwrap(),
+            decode_prompt_logprobs(
+                &tokenizer,
+                "test-request",
+                &[b'p' as u32, b'x' as u32],
+                &logprobs,
+                false,
+            )
+            .unwrap(),
             DecodedPromptLogprobs {
                 first_token_id: b'p' as u32,
                 first_token: "p".to_string(),
@@ -208,5 +215,19 @@ mod tests {
                 }],
             }
         );
+    }
+
+    #[test]
+    fn decode_prompt_logprobs_rejects_empty_prompt() {
+        let tokenizer = TestTokenizer::new();
+        let logprobs = Logprobs { positions: vec![] };
+
+        let error = decode_prompt_logprobs(&tokenizer, "req-empty", &[], &logprobs, false)
+            .expect_err("empty prompts should return an error");
+
+        assert!(matches!(
+            error,
+            Error::EmptyPromptTokenIds { request_id } if request_id == "req-empty"
+        ));
     }
 }


### PR DESCRIPTION
## Purpose

Closes #51420.

`decode_prompt_logprobs` used `.expect()` when reading the first prompt token. If an empty prompt reached the Rust frontend with prompt logprobs, this panicked; the Rust workspace uses `panic = "abort"`, so a single request could terminate the frontend process.

This change propagates the existing `EmptyPromptTokenIds` request error instead. The request ID is passed into the decoder so the resulting error remains actionable.

I kept the fix at the decoding boundary because:

- it directly removes the process-abort path regardless of which request route produced the output;
- it reuses the existing empty-prompt validation semantics and server error mapping;
- it does not change tokenization, prompt rendering, or valid prompt-logprobs responses.

## Test plan and results

Regression test before the fix:

```text
cargo test -p vllm-text decode_prompt_logprobs_rejects_empty_prompt

thread 'output::logprobs::tests::decode_prompt_logprobs_rejects_empty_prompt' panicked:
prompt logprobs require at least one prompt token
test result: FAILED. 0 passed; 1 failed
```

The same command after the fix:

```text
test result: ok. 1 passed; 0 failed
```

Additional validation with Rust 1.95.0:

```text
cargo test -p vllm-text
test result: ok. 80 passed; 0 failed; 1 ignored

cargo fmt --manifest-path Cargo.toml --all -- --check
passed

cargo clippy -p vllm-text --all-targets --all-features --locked -- -D warnings
passed

git diff --check
passed
```

The Buildkite `Rust Frontend Cargo Tests` and `Rust Frontend Cargo Style + Clippy` jobs are routed by changes under `rust/`.

## Scope

- No behavior change for non-empty prompts.
- No new fallback or prompt-tokenization policy.
- No GPU or model dependency.

AI assistance: Trae was used for codebase navigation, test execution, and drafting. I reviewed and validated every changed line and own the change end to end.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR.
- [x] The test plan.
- [x] The test results.
- [x] AI assistance disclosure.

</details>
