### PR TITLE
Add distributed LegoMem KV offload benchmark

### DIFF
--- a/csrc/legomem_kv_client.c
+++ b/csrc/legomem_kv_client.c
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: Apache-2.0
+// Thin opaque-handle wrapper around the Splash CXLMemSim client.
+
+#include "pgas/cxlmemsim_client.h"
+
+#include <pthread.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#define LEGOMEM_MAX_IO_LANES 16
+
+typedef struct {
+    cxlmemsim_ctx_t ctx[LEGOMEM_MAX_IO_LANES];
+    int num_lanes;
+} legomem_client_t;
+
+typedef struct {
+    cxlmemsim_ctx_t *ctx;
+    uint64_t address;
+    void *data;
+    size_t size;
+    int is_write;
+    int status;
+} legomem_io_t;
+
+static void *legomem_io_worker(void *opaque) {
+    legomem_io_t *io = opaque;
+    if (io->is_write) {
+        io->status = cxlmemsim_remote_store(io->ctx, io->address,
+                                            io->data, io->size);
+    } else {
+        io->status = cxlmemsim_remote_load(io->ctx, io->address,
+                                           io->data, io->size);
+    }
+    return NULL;
+}
+
+static int legomem_transfer(legomem_client_t *client, uint64_t address,
+                            void *data, size_t size, int is_write) {
+    size_t num_lines = (size + CXLMEMSIM_CACHELINE_SIZE - 1) /
+                       CXLMEMSIM_CACHELINE_SIZE;
+    int lanes = client->num_lanes;
+    if ((size_t)lanes > num_lines)
+        lanes = (int)num_lines;
+
+    pthread_t threads[LEGOMEM_MAX_IO_LANES];
+    legomem_io_t ios[LEGOMEM_MAX_IO_LANES];
+    int started[LEGOMEM_MAX_IO_LANES] = {0};
+
+    for (int lane = 0; lane < lanes; ++lane) {
+        size_t first_line = num_lines * (size_t)lane / (size_t)lanes;
+        size_t last_line = num_lines * (size_t)(lane + 1) / (size_t)lanes;
+        size_t offset = first_line * CXLMEMSIM_CACHELINE_SIZE;
+        size_t end = last_line * CXLMEMSIM_CACHELINE_SIZE;
+        if (end > size)
+            end = size;
+        ios[lane] = (legomem_io_t){
+            .ctx = &client->ctx[lane],
+            .address = address + offset,
+            .data = (uint8_t *)data + offset,
+            .size = end - offset,
+            .is_write = is_write,
+            .status = -1,
+        };
+        if (pthread_create(&threads[lane], NULL, legomem_io_worker,
+                           &ios[lane]) == 0) {
+            started[lane] = 1;
+        } else {
+            legomem_io_worker(&ios[lane]);
+        }
+    }
+
+    int status = 0;
+    for (int lane = 0; lane < lanes; ++lane) {
+        if (started[lane])
+            pthread_join(threads[lane], NULL);
+        if (ios[lane].status != 0)
+            status = ios[lane].status;
+    }
+    return status;
+}
+
+void *legomem_client_open(const char *host, int port) {
+    legomem_client_t *client = calloc(1, sizeof(*client));
+    if (!client)
+        return NULL;
+    /* One lane is fastest on the 2-vCPU r7i.large test nodes.  Larger hosts
+     * can opt into pipelining with LEGOMEM_IO_LANES. */
+    client->num_lanes = 1;
+    const char *lanes_env = getenv("LEGOMEM_IO_LANES");
+    if (lanes_env) {
+        long requested = strtol(lanes_env, NULL, 10);
+        if (requested >= 1 && requested <= LEGOMEM_MAX_IO_LANES)
+            client->num_lanes = (int)requested;
+    }
+    for (int lane = 0; lane < client->num_lanes; ++lane) {
+        if (cxlmemsim_init(&client->ctx[lane], host, port) != 0 ||
+            cxlmemsim_connect(&client->ctx[lane]) != 0) {
+            for (int initialized = 0; initialized <= lane; ++initialized)
+                cxlmemsim_finalize(&client->ctx[initialized]);
+            free(client);
+            return NULL;
+        }
+    }
+    return client;
+}
+
+int legomem_client_read(void *opaque, uint64_t address, void *data,
+                        size_t size) {
+    if (!opaque || !data || size == 0)
+        return -1;
+    legomem_client_t *client = opaque;
+    return legomem_transfer(client, address, data, size, 0);
+}
+
+int legomem_client_write(void *opaque, uint64_t address, const void *data,
+                         size_t size) {
+    if (!opaque || !data || size == 0)
+        return -1;
+    legomem_client_t *client = opaque;
+    return legomem_transfer(client, address, (void *)data, size, 1);
+}
+
+void legomem_client_close(void *opaque) {
+    if (!opaque)
+        return;
+    legomem_client_t *client = opaque;
+    for (int lane = 0; lane < client->num_lanes; ++lane)
+        cxlmemsim_finalize(&client->ctx[lane]);
+    free(client);
+}
+
+uint64_t legomem_client_bytes_read(void *opaque) {
+    if (!opaque)
+        return 0;
+    legomem_client_t *client = opaque;
+    uint64_t total = 0;
+    for (int lane = 0; lane < client->num_lanes; ++lane)
+        total += client->ctx[lane].total_bytes_read;
+    return total;
+}
+
+uint64_t legomem_client_bytes_written(void *opaque) {
+    if (!opaque)
+        return 0;
+    legomem_client_t *client = opaque;
+    uint64_t total = 0;
+    for (int lane = 0; lane < client->num_lanes; ++lane)
+        total += client->ctx[lane].total_bytes_written;
+    return total;
+}

--- a/tests/legomem_backend_smoke.py
+++ b/tests/legomem_backend_smoke.py
@@ -1,0 +1,39 @@
+import os
+
+import torch
+
+from vllm.v1.simple_kv_offload.legomem_backend import LegoMemBackend
+
+
+def main() -> None:
+    rank = int(os.environ.get("RANK", os.environ.get("OMPI_COMM_WORLD_RANK", "0")))
+    active = torch.arange(512, dtype=torch.int16).view(4, 128)
+    expected = active[2].clone()
+    backend = LegoMemBackend()
+    backend.init(
+        {"kv": active},
+        "/home/ubuntu/legomem/lib/liblegomem_kv.so",
+        "127.0.0.1",
+        9999,
+        rank,
+        16,
+        256 * 1024 * 1024,
+        256 * 1024 * 1024 - 64,
+    )
+    events = []
+    backend.launch_copy([2], [7], True, 1, events)
+    active[2].zero_()
+    backend.launch_copy([7], [2], False, 2, events)
+    passed = torch.equal(active[2], expected)
+    print(
+        f"LEGOMEM_BACKEND_ROUNDTRIP={'PASS' if passed else 'FAIL'} "
+        f"rank={rank} target={(rank + 1) % 16} "
+        f"bytes_written={backend.bytes_written} bytes_read={backend.bytes_read}"
+    )
+    backend.shutdown()
+    if not passed:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/torch_mpi_smoke.py
+++ b/tests/torch_mpi_smoke.py
@@ -1,0 +1,22 @@
+import os
+
+import torch
+import torch.distributed as dist
+
+os.environ["RANK"] = os.environ["OMPI_COMM_WORLD_RANK"]
+os.environ["WORLD_SIZE"] = os.environ["OMPI_COMM_WORLD_SIZE"]
+os.environ["LOCAL_RANK"] = "0"
+os.environ.setdefault("MASTER_ADDR", "172.31.12.228")
+os.environ.setdefault("MASTER_PORT", "29599")
+os.environ.setdefault("GLOO_SOCKET_IFNAME", "enp39s0")
+
+dist.init_process_group("gloo", init_method="env://")
+value = torch.tensor([dist.get_rank() + 1], dtype=torch.int64)
+dist.all_reduce(value)
+if dist.get_rank() == 0:
+    expected = dist.get_world_size() * (dist.get_world_size() + 1) // 2
+    print(
+        f"MPI_GLOO_SMOKE={'PASS' if value.item() == expected else 'FAIL'} "
+        f"world_size={dist.get_world_size()} sum={value.item()} expected={expected}"
+    )
+dist.destroy_process_group()

--- a/tests/vllm_mpi_kv_bench.py
+++ b/tests/vllm_mpi_kv_bench.py
@@ -22,6 +22,13 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--mode", choices=("baseline", "dram", "legomem"), required=True)
     parser.add_argument("--tp", type=int, default=16)
     parser.add_argument("--input-tokens", type=int, default=512)
+    parser.add_argument(
+        "--cases",
+        help=(
+            "comma-separated INPUT_TOKENS:DISTRACTORS cases "
+            "(for example 128:8,256:4,512:2)"
+        ),
+    )
     parser.add_argument("--output-tokens", type=int, default=1)
     parser.add_argument("--distractors", type=int, default=8)
     parser.add_argument("--kv-cache-mib", type=int, default=32)
@@ -33,6 +40,24 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--dtype", default="bfloat16")
     parser.add_argument("--require-amx", action="store_true")
     return parser.parse_args()
+
+
+def parse_cases(args: argparse.Namespace) -> list[tuple[int, int]]:
+    if not args.cases:
+        return [(args.input_tokens, args.distractors)]
+    cases = []
+    for item in args.cases.split(","):
+        input_tokens_text, separator, distractors_text = item.partition(":")
+        if not separator:
+            raise ValueError(
+                f"invalid benchmark case {item!r}; expected TOKENS:DISTRACTORS"
+            )
+        input_tokens = int(input_tokens_text)
+        distractors = int(distractors_text)
+        if input_tokens <= 0 or distractors < 0:
+            raise ValueError(f"invalid benchmark case {item!r}")
+        cases.append((input_tokens, distractors))
+    return cases
 
 
 def timed_generate(
@@ -63,6 +88,8 @@ def make_prompt(seed: int, length: int, vocab_size: int) -> list[int]:
 
 def main() -> None:
     args = parse_args()
+    cases = parse_cases(args)
+    max_input_tokens = max(input_tokens for input_tokens, _ in cases)
     rank = int(os.environ.get("RANK", os.environ.get("OMPI_COMM_WORLD_RANK", "0")))
     world_size = int(os.environ.get("WORLD_SIZE", os.environ.get("OMPI_COMM_WORLD_SIZE", "1")))
     if world_size != args.tp:
@@ -115,8 +142,8 @@ def main() -> None:
         dtype=args.dtype,
         tensor_parallel_size=args.tp,
         distributed_executor_backend="external_launcher",
-        max_model_len=args.input_tokens + args.output_tokens,
-        max_num_batched_tokens=args.input_tokens + args.output_tokens,
+        max_model_len=max_input_tokens + args.output_tokens,
+        max_num_batched_tokens=max_input_tokens + args.output_tokens,
         max_num_seqs=1,
         kv_cache_memory_bytes=args.kv_cache_mib * MIB,
         block_size=args.block_size,
@@ -135,45 +162,58 @@ def main() -> None:
     )
 
     # Warm kernels without polluting the measured cache state.
-    timed_generate(llm, make_prompt(9001, min(32, args.input_tokens), vocab_size), params)
-    if not llm.reset_prefix_cache(reset_connector=True):
-        raise RuntimeError("failed to reset vLLM prefix caches before measurement")
+    timed_generate(
+        llm, make_prompt(9001, min(32, max_input_tokens), vocab_size), params
+    )
 
-    target = make_prompt(1, args.input_tokens, vocab_size)
-    cold_seconds, cold_cached_tokens = timed_generate(llm, target, params)
+    for case_index, (input_tokens, distractors) in enumerate(cases):
+        if not llm.reset_prefix_cache(reset_connector=True):
+            raise RuntimeError("failed to reset vLLM prefix caches before measurement")
 
-    eviction_seconds = 0.0
-    for index in range(args.distractors):
-        distractor_seconds, _ = timed_generate(
-            llm, make_prompt(100 + index, args.input_tokens, vocab_size), params
-        )
-        eviction_seconds += distractor_seconds
+        target = make_prompt(1, input_tokens, vocab_size)
+        cold_seconds, cold_cached_tokens = timed_generate(llm, target, params)
 
-    replay_seconds, replay_cached_tokens = timed_generate(llm, target, params)
-    result = {
-        "model": args.model,
-        "mode": args.mode,
-        "ranks": world_size,
-        "input_tokens": args.input_tokens,
-        "output_tokens": args.output_tokens,
-        "distractors": args.distractors,
-        "kv_cache_mib_per_rank": args.kv_cache_mib,
-        "block_size": args.block_size,
-        "offload_mib_per_rank": 0 if args.mode == "baseline" else args.offload_mib,
-        "offload_policy": args.offload_policy if args.mode != "baseline" else "none",
-        "cold_seconds": cold_seconds,
-        "cold_cached_tokens": cold_cached_tokens,
-        "eviction_seconds": eviction_seconds,
-        "replay_seconds": replay_seconds,
-        "replay_cached_tokens": replay_cached_tokens,
-        "replay_speedup_vs_cold": cold_seconds / replay_seconds,
-        "estimated_ttft_seconds": replay_seconds,
-        "amx_required": args.require_amx,
-        "amx_tile_supported": amx_supported,
-        "vllm_cpu_int4_w4a8": int4_w4a8_enabled,
-    }
-    if rank == 0:
-        print("VLLM_MPI_KV_RESULT=" + json.dumps(result, sort_keys=True), flush=True)
+        eviction_seconds = 0.0
+        for index in range(distractors):
+            distractor_seconds, _ = timed_generate(
+                llm, make_prompt(100 + index, input_tokens, vocab_size), params
+            )
+            eviction_seconds += distractor_seconds
+
+        replay_seconds, replay_cached_tokens = timed_generate(llm, target, params)
+        result = {
+            "model": args.model,
+            "mode": args.mode,
+            "ranks": world_size,
+            "case_index": case_index,
+            "case_count": len(cases),
+            "input_tokens": input_tokens,
+            "output_tokens": args.output_tokens,
+            "distractors": distractors,
+            "kv_cache_mib_per_rank": args.kv_cache_mib,
+            "block_size": args.block_size,
+            "offload_mib_per_rank": (
+                0 if args.mode == "baseline" else args.offload_mib
+            ),
+            "offload_policy": (
+                args.offload_policy if args.mode != "baseline" else "none"
+            ),
+            "cold_seconds": cold_seconds,
+            "cold_cached_tokens": cold_cached_tokens,
+            "eviction_seconds": eviction_seconds,
+            "replay_seconds": replay_seconds,
+            "replay_cached_tokens": replay_cached_tokens,
+            "replay_speedup_vs_cold": cold_seconds / replay_seconds,
+            "estimated_ttft_seconds": replay_seconds,
+            "amx_required": args.require_amx,
+            "amx_tile_supported": amx_supported,
+            "vllm_cpu_int4_w4a8": int4_w4a8_enabled,
+        }
+        if rank == 0:
+            print(
+                "VLLM_MPI_KV_RESULT=" + json.dumps(result, sort_keys=True),
+                flush=True,
+            )
 
 
 if __name__ == "__main__":

--- a/tests/vllm_mpi_kv_bench.py
+++ b/tests/vllm_mpi_kv_bench.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""MPI/external-launcher vLLM KV-cache benchmark."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import time
+
+import torch
+import torch.distributed as dist
+
+from vllm import LLM, SamplingParams, envs
+
+MIB = 1024 * 1024
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--mode", choices=("baseline", "dram", "legomem"), required=True)
+    parser.add_argument("--tp", type=int, default=16)
+    parser.add_argument("--input-tokens", type=int, default=512)
+    parser.add_argument("--output-tokens", type=int, default=1)
+    parser.add_argument("--distractors", type=int, default=8)
+    parser.add_argument("--kv-cache-mib", type=int, default=32)
+    parser.add_argument("--offload-mib", type=int, default=255)
+    parser.add_argument("--dtype", default="bfloat16")
+    parser.add_argument("--require-amx", action="store_true")
+    return parser.parse_args()
+
+
+def timed_generate(
+    llm: LLM, prompt: list[int], params: SamplingParams
+) -> tuple[float, int]:
+    if dist.is_initialized():
+        dist.barrier()
+    start = time.perf_counter()
+    outputs = llm.generate([prompt], sampling_params=params, use_tqdm=False)
+    if dist.is_initialized():
+        dist.barrier()
+    elapsed = torch.tensor([time.perf_counter() - start], dtype=torch.float64)
+    if dist.is_initialized():
+        dist.all_reduce(elapsed, op=dist.ReduceOp.MAX)
+    cached = torch.tensor(
+        [int(outputs[0].num_cached_tokens or 0)], dtype=torch.int64
+    )
+    if dist.is_initialized():
+        dist.all_reduce(cached, op=dist.ReduceOp.MIN)
+    return float(elapsed.item()), int(cached.item())
+
+
+def make_prompt(seed: int, length: int, vocab_size: int) -> list[int]:
+    # Avoid low-numbered special tokens while producing disjoint block hashes.
+    usable = max(1, vocab_size - 1024)
+    return [1024 + ((seed * 7919 + i * 104729) % usable) for i in range(length)]
+
+
+def main() -> None:
+    args = parse_args()
+    rank = int(os.environ.get("RANK", os.environ.get("OMPI_COMM_WORLD_RANK", "0")))
+    world_size = int(os.environ.get("WORLD_SIZE", os.environ.get("OMPI_COMM_WORLD_SIZE", "1")))
+    if world_size != args.tp:
+        raise ValueError(f"MPI world size {world_size} != tensor parallel size {args.tp}")
+
+    amx_supported = bool(torch.cpu._is_amx_tile_supported())
+    int4_w4a8_enabled = bool(envs.VLLM_CPU_INT4_W4A8)
+    if args.require_amx and not amx_supported:
+        raise RuntimeError(f"rank {rank} does not expose AMX tile support")
+    if args.require_amx and not int4_w4a8_enabled:
+        raise RuntimeError("VLLM_CPU_INT4_W4A8 must be enabled for the AMX run")
+    print(
+        "VLLM_AMX_AUDIT="
+        + json.dumps(
+            {
+                "rank": rank,
+                "amx_tile_supported": amx_supported,
+                "vllm_cpu_int4_w4a8": int4_w4a8_enabled,
+                "dtype": args.dtype,
+            },
+            sort_keys=True,
+        ),
+        flush=True,
+    )
+
+    connector = None
+    if args.mode != "baseline":
+        per_rank_bytes = args.offload_mib * MIB
+        connector = {
+            "kv_connector": "SimpleCPUOffloadConnector",
+            "kv_role": "kv_both",
+            "kv_connector_extra_config": {
+                "cpu_bytes_to_use": per_rank_bytes * world_size,
+                "cpu_bytes_to_use_per_rank": per_rank_bytes,
+                # Offload completed prefix blocks as they approach eviction.
+                # This matches an inference-service workload where prefixes
+                # survive request completion and are reused by later calls.
+                "lazy_offload": True,
+                "kv_offload_backend": "cpu" if args.mode == "dram" else "legomem",
+                "legomem_library_path": "/home/ubuntu/legomem/lib/liblegomem_kv.so",
+                "legomem_host": "127.0.0.1",
+                "legomem_port": 9999,
+                "legomem_num_nodes": world_size,
+                "legomem_node_capacity_bytes": 256 * MIB,
+            },
+        }
+
+    llm = LLM(
+        model=args.model,
+        dtype=args.dtype,
+        tensor_parallel_size=args.tp,
+        distributed_executor_backend="external_launcher",
+        max_model_len=args.input_tokens + args.output_tokens,
+        max_num_batched_tokens=args.input_tokens + args.output_tokens,
+        max_num_seqs=1,
+        kv_cache_memory_bytes=args.kv_cache_mib * MIB,
+        enable_prefix_caching=True,
+        kv_transfer_config=connector,
+        enforce_eager=True,
+        disable_log_stats=False,
+    )
+    tokenizer = llm.get_tokenizer()
+    vocab_size = int(getattr(tokenizer, "vocab_size", 32000))
+    params = SamplingParams(
+        temperature=0,
+        max_tokens=args.output_tokens,
+        ignore_eos=True,
+        detokenize=False,
+    )
+
+    # Warm kernels without polluting the measured cache state.
+    timed_generate(llm, make_prompt(9001, min(32, args.input_tokens), vocab_size), params)
+    if not llm.reset_prefix_cache(reset_connector=True):
+        raise RuntimeError("failed to reset vLLM prefix caches before measurement")
+
+    target = make_prompt(1, args.input_tokens, vocab_size)
+    cold_seconds, cold_cached_tokens = timed_generate(llm, target, params)
+
+    eviction_seconds = 0.0
+    for index in range(args.distractors):
+        distractor_seconds, _ = timed_generate(
+            llm, make_prompt(100 + index, args.input_tokens, vocab_size), params
+        )
+        eviction_seconds += distractor_seconds
+
+    replay_seconds, replay_cached_tokens = timed_generate(llm, target, params)
+    result = {
+        "model": args.model,
+        "mode": args.mode,
+        "ranks": world_size,
+        "input_tokens": args.input_tokens,
+        "output_tokens": args.output_tokens,
+        "distractors": args.distractors,
+        "kv_cache_mib_per_rank": args.kv_cache_mib,
+        "offload_mib_per_rank": 0 if args.mode == "baseline" else args.offload_mib,
+        "cold_seconds": cold_seconds,
+        "cold_cached_tokens": cold_cached_tokens,
+        "eviction_seconds": eviction_seconds,
+        "replay_seconds": replay_seconds,
+        "replay_cached_tokens": replay_cached_tokens,
+        "replay_speedup_vs_cold": cold_seconds / replay_seconds,
+        "estimated_ttft_seconds": replay_seconds,
+        "amx_required": args.require_amx,
+        "amx_tile_supported": amx_supported,
+        "vllm_cpu_int4_w4a8": int4_w4a8_enabled,
+    }
+    if rank == 0:
+        print("VLLM_MPI_KV_RESULT=" + json.dumps(result, sort_keys=True), flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/vllm_mpi_kv_bench.py
+++ b/tests/vllm_mpi_kv_bench.py
@@ -25,7 +25,11 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--output-tokens", type=int, default=1)
     parser.add_argument("--distractors", type=int, default=8)
     parser.add_argument("--kv-cache-mib", type=int, default=32)
+    parser.add_argument("--block-size", type=int, default=128)
     parser.add_argument("--offload-mib", type=int, default=255)
+    parser.add_argument(
+        "--offload-policy", choices=("lazy", "eager"), default="lazy"
+    )
     parser.add_argument("--dtype", default="bfloat16")
     parser.add_argument("--require-amx", action="store_true")
     return parser.parse_args()
@@ -96,7 +100,7 @@ def main() -> None:
                 # Offload completed prefix blocks as they approach eviction.
                 # This matches an inference-service workload where prefixes
                 # survive request completion and are reused by later calls.
-                "lazy_offload": True,
+                "lazy_offload": args.offload_policy == "lazy",
                 "kv_offload_backend": "cpu" if args.mode == "dram" else "legomem",
                 "legomem_library_path": "/home/ubuntu/legomem/lib/liblegomem_kv.so",
                 "legomem_host": "127.0.0.1",
@@ -115,6 +119,7 @@ def main() -> None:
         max_num_batched_tokens=args.input_tokens + args.output_tokens,
         max_num_seqs=1,
         kv_cache_memory_bytes=args.kv_cache_mib * MIB,
+        block_size=args.block_size,
         enable_prefix_caching=True,
         kv_transfer_config=connector,
         enforce_eager=True,
@@ -153,7 +158,9 @@ def main() -> None:
         "output_tokens": args.output_tokens,
         "distractors": args.distractors,
         "kv_cache_mib_per_rank": args.kv_cache_mib,
+        "block_size": args.block_size,
         "offload_mib_per_rank": 0 if args.mode == "baseline" else args.offload_mib,
+        "offload_policy": args.offload_policy if args.mode != "baseline" else "none",
         "cold_seconds": cold_seconds,
         "cold_cached_tokens": cold_cached_tokens,
         "eviction_seconds": eviction_seconds,

--- a/tests/vllm_mpi_rank.sh
+++ b/tests/vllm_mpi_rank.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export RANK=${OMPI_COMM_WORLD_RANK:?}
+export WORLD_SIZE=${OMPI_COMM_WORLD_SIZE:?}
+export LOCAL_RANK=0
+export MASTER_ADDR=${VLLM_MPI_MASTER_ADDR:-172.31.12.228}
+export MASTER_PORT=${VLLM_MPI_MASTER_PORT:-29600}
+export GLOO_SOCKET_IFNAME=${GLOO_SOCKET_IFNAME:-enp39s0}
+export VLLM_HOST_IP=${VLLM_HOST_IP:-$(hostname -I | awk '{print $1}')}
+export VLLM_ENABLE_V1_MULTIPROCESSING=0
+export VLLM_CPU_OMP_THREADS_BIND=0-1
+export VLLM_CPU_INT4_W4A8=1
+export ONEDNN_MAX_CPU_ISA=AVX512_CORE_AMX
+export OMP_NUM_THREADS=2
+export LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libtcmalloc_minimal.so.4:/home/ubuntu/vllm-venv/lib/libiomp5.so
+
+exec /home/ubuntu/vllm-venv/bin/python /home/ubuntu/legomem/vllm_mpi_kv_bench.py "$@"

--- a/vllm/distributed/device_communicators/cpu_communicator.py
+++ b/vllm/distributed/device_communicators/cpu_communicator.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import os
+import socket
 from typing import Any
 
 import torch
@@ -70,17 +71,24 @@ class CpuCommunicator(DeviceCommunicatorBase):
 
     def _all_group_ranks_share_shm_group_name(self) -> bool:
         """
-        CPUSHM requires all ranks in this group to agree on one SHM group name.
-        This is a lightweight consistency check for VLLM_DIST_IDENT/name inputs.
+        CPUSHM is a same-host optimization and supports at most eight ranks.
+
+        VLLM_DIST_IDENT is intentionally identical across an externally launched
+        multi-node job, so comparing only the generated SHM name incorrectly
+        enables CPUSHM on distinct hosts.  Include the hostname to ensure that
+        every rank actually shares the same /dev/shm namespace.
         """
+        if self.world_size > 8:
+            return False
         local_name = _CPUSHMDistributed.make_group_name(self)
-        names: list[str] = [""] * self.world_size
+        local_identity = (socket.gethostname(), local_name)
+        identities: list[tuple[str, str] | None] = [None] * self.world_size
         torch.distributed.all_gather_object(
-            names,
-            local_name,
+            identities,
+            local_identity,
             group=self.device_group,
         )
-        return len(set(names)) == 1
+        return len(set(identities)) == 1
 
     def all_reduce(self, input_):
         self.dist_module.all_reduce(input_, group=self.device_group)

--- a/vllm/distributed/kv_transfer/kv_connector/v1/simple_cpu_offload_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/simple_cpu_offload_connector.py
@@ -41,7 +41,7 @@ logger = init_logger(__name__)
 # Default CPU capacity: 8 GB
 DEFAULT_CPU_CAPACITY_BYTES = 8 * (1024**3)
 
-VALID_KV_OFFLOAD_BACKENDS = ("cpu", "disk")
+VALID_KV_OFFLOAD_BACKENDS = ("cpu", "disk", "legomem")
 # Keys that only apply to the disk backend, warned about under "cpu".
 _DISK_ONLY_KEYS = (
     "disk_path",
@@ -115,8 +115,9 @@ class SimpleCPUOffloadConnector(KVConnectorBase_V1, SupportsHMA):
             ignored = [k for k in _DISK_ONLY_KEYS if k in extra_config]
             if ignored:
                 logger.warning(
-                    'kv_offload_backend is "cpu", ignoring disk-only config: %s. '
+                    'kv_offload_backend is "%s", ignoring disk-only config: %s. '
                     'Set kv_offload_backend="disk" to enable the disk backend.',
+                    kv_offload_backend,
                     ", ".join(ignored),
                 )
             disk_path = None
@@ -168,6 +169,18 @@ class SimpleCPUOffloadConnector(KVConnectorBase_V1, SupportsHMA):
                 disk_capacity_bytes=disk_capacity_bytes,
                 disk_buffer_slots=disk_buffer_slots,
                 use_page_cache=use_page_cache,
+                legomem_library_path=str(
+                    extra_config.get(
+                        "legomem_library_path",
+                        "/home/ubuntu/legomem/lib/liblegomem_kv.so",
+                    )
+                ),
+                legomem_host=str(extra_config.get("legomem_host", "127.0.0.1")),
+                legomem_port=int(extra_config.get("legomem_port", 9999)),
+                legomem_num_nodes=int(extra_config.get("legomem_num_nodes", 16)),
+                legomem_node_capacity_bytes=int(
+                    extra_config.get("legomem_node_capacity_bytes", 256 * 1024**2)
+                ),
             )
 
     # --- Worker-side methods ---

--- a/vllm/v1/simple_kv_offload/cpu_copy_backend.py
+++ b/vllm/v1/simple_kv_offload/cpu_copy_backend.py
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Synchronous CPU-to-CPU block copy backend."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+
+
+class ImmediateEvent:
+    """torch.Event-compatible completion marker for synchronous CPU I/O."""
+
+    def query(self) -> bool:
+        return True
+
+    def synchronize(self) -> None:
+        return None
+
+
+class CpuCopyBackend:
+    def __init__(self) -> None:
+        self._active: dict[str, torch.Tensor] = {}
+        self._offload: dict[str, torch.Tensor] = {}
+
+    def init(
+        self,
+        active_caches: dict[str, torch.Tensor],
+        offload_caches: dict[str, torch.Tensor],
+    ) -> None:
+        self._active = active_caches
+        self._offload = offload_caches
+
+    def launch_copy(
+        self,
+        src_blocks: list[int],
+        dst_blocks: list[int],
+        is_store: bool,
+        event_idx: int,
+        events_list: list[tuple[int, Any]],
+        wait_event: Any | None = None,
+    ) -> None:
+        del wait_event
+        source = self._active if is_store else self._offload
+        target = self._offload if is_store else self._active
+        for src_block, dst_block in zip(src_blocks, dst_blocks, strict=True):
+            for name in source:
+                target[name][dst_block].copy_(source[name][src_block])
+        events_list.append((event_idx, ImmediateEvent()))
+
+    def shutdown(self) -> None:
+        return None

--- a/vllm/v1/simple_kv_offload/legomem_backend.py
+++ b/vllm/v1/simple_kv_offload/legomem_backend.py
@@ -1,0 +1,165 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CXLMemSim/LegoMem backend for vLLM KV cache blocks."""
+
+from __future__ import annotations
+
+import ctypes
+import os
+from typing import Any
+
+import torch
+
+from vllm.logger import init_logger
+from vllm.v1.simple_kv_offload.cpu_copy_backend import ImmediateEvent
+
+logger = init_logger(__name__)
+
+
+class LegoMemBackend:
+    """Synchronously stage vLLM CPU KV blocks through CXLMemSim.
+
+    Each model-parallel rank owns the usable data area of the next distributed
+    CXLMemSim node in a ring. This guarantees that every KV store/load crosses
+    Soft-RoCE instead of being satisfied from the frontend node's local DRAM.
+    The nominal node stride is retained because the final cache line of every
+    node contains CXLMemSim's backing-store header.
+    """
+
+    def __init__(self) -> None:
+        self._active: dict[str, torch.Tensor] = {}
+        self._buffer: torch.Tensor | None = None
+        self._block_bytes = 0
+        self._segment_base = 0
+        self._segment_bytes = 0
+        self._handle: int | None = None
+        self._lib: ctypes.CDLL | None = None
+        self.bytes_read = 0
+        self.bytes_written = 0
+
+    def init(
+        self,
+        active_caches: dict[str, torch.Tensor],
+        library_path: str,
+        host: str,
+        port: int,
+        rank: int,
+        num_nodes: int,
+        node_capacity_bytes: int,
+        usable_bytes_per_rank: int,
+    ) -> None:
+        if not active_caches:
+            raise ValueError("LegoMemBackend requires at least one KV tensor")
+        if any(t.device.type != "cpu" for t in active_caches.values()):
+            raise ValueError("LegoMemBackend currently requires CPU KV tensors")
+        if not 0 <= rank < num_nodes:
+            raise ValueError(f"rank {rank} is outside the {num_nodes}-node pool")
+        if usable_bytes_per_rank > node_capacity_bytes - 64:
+            raise ValueError("usable rank capacity overlaps the CXLMemSim header line")
+
+        self._active = active_caches
+        self._block_bytes = sum(t[0].numel() * t.element_size() for t in active_caches.values())
+        self._buffer = torch.empty(self._block_bytes, dtype=torch.uint8, device="cpu")
+        target_node = (rank + 1) % num_nodes
+        self._segment_base = target_node * node_capacity_bytes
+        self._segment_bytes = usable_bytes_per_rank
+
+        self._lib = ctypes.CDLL(os.path.expanduser(library_path))
+        self._lib.legomem_client_open.argtypes = [ctypes.c_char_p, ctypes.c_int]
+        self._lib.legomem_client_open.restype = ctypes.c_void_p
+        self._lib.legomem_client_read.argtypes = [
+            ctypes.c_void_p,
+            ctypes.c_uint64,
+            ctypes.c_void_p,
+            ctypes.c_size_t,
+        ]
+        self._lib.legomem_client_read.restype = ctypes.c_int
+        self._lib.legomem_client_write.argtypes = [
+            ctypes.c_void_p,
+            ctypes.c_uint64,
+            ctypes.c_void_p,
+            ctypes.c_size_t,
+        ]
+        self._lib.legomem_client_write.restype = ctypes.c_int
+        self._lib.legomem_client_close.argtypes = [ctypes.c_void_p]
+        self._lib.legomem_client_close.restype = None
+
+        handle = self._lib.legomem_client_open(host.encode(), port)
+        if not handle:
+            raise ConnectionError(f"cannot connect LegoMem client to {host}:{port}")
+        self._handle = int(handle)
+        logger.info(
+            "LegoMem KV backend connected: rank=%d/%d target_node=%d segment=[%d,%d) "
+            "block_bytes=%d slots=%d",
+            rank,
+            num_nodes,
+            target_node,
+            self._segment_base,
+            self._segment_base + self._segment_bytes,
+            self._block_bytes,
+            self._segment_bytes // self._block_bytes,
+        )
+
+    def _address(self, slot: int) -> int:
+        address = self._segment_base + slot * self._block_bytes
+        if slot < 0 or address + self._block_bytes > self._segment_base + self._segment_bytes:
+            raise IndexError(f"LegoMem KV slot {slot} exceeds rank segment")
+        return address
+
+    def _pack(self, block: int) -> None:
+        assert self._buffer is not None
+        offset = 0
+        for tensor in self._active.values():
+            row = tensor[block].view(torch.uint8).reshape(-1)
+            size = row.numel()
+            self._buffer[offset : offset + size].copy_(row)
+            offset += size
+
+    def _unpack(self, block: int) -> None:
+        assert self._buffer is not None
+        offset = 0
+        for tensor in self._active.values():
+            row = tensor[block].view(torch.uint8).reshape(-1)
+            size = row.numel()
+            row.copy_(self._buffer[offset : offset + size])
+            offset += size
+
+    def launch_copy(
+        self,
+        src_blocks: list[int],
+        dst_blocks: list[int],
+        is_store: bool,
+        event_idx: int,
+        events_list: list[tuple[int, Any]],
+        wait_event: Any | None = None,
+    ) -> None:
+        del wait_event
+        assert self._lib is not None and self._handle is not None and self._buffer is not None
+        pointer = ctypes.c_void_p(self._buffer.data_ptr())
+        handle = ctypes.c_void_p(self._handle)
+        for src_block, dst_block in zip(src_blocks, dst_blocks, strict=True):
+            if is_store:
+                self._pack(src_block)
+                status = self._lib.legomem_client_write(
+                    handle, self._address(dst_block), pointer, self._block_bytes
+                )
+                self.bytes_written += self._block_bytes
+            else:
+                status = self._lib.legomem_client_read(
+                    handle, self._address(src_block), pointer, self._block_bytes
+                )
+                self._unpack(dst_block)
+                self.bytes_read += self._block_bytes
+            if status != 0:
+                operation = "write" if is_store else "read"
+                raise OSError(f"LegoMem KV {operation} failed with status {status}")
+        events_list.append((event_idx, ImmediateEvent()))
+
+    def shutdown(self) -> None:
+        if self._lib is not None and self._handle is not None:
+            logger.info(
+                "LegoMem KV backend closing: bytes_written=%d bytes_read=%d",
+                self.bytes_written,
+                self.bytes_read,
+            )
+            self._lib.legomem_client_close(ctypes.c_void_p(self._handle))
+            self._handle = None

--- a/vllm/v1/simple_kv_offload/manager.py
+++ b/vllm/v1/simple_kv_offload/manager.py
@@ -180,7 +180,16 @@ class SimpleCPUOffloadScheduler:
 
         # For TP/PP: track partial store completions across steps.
         # Events must be reported by all world_size workers before considered complete.
-        self._expected_worker_count = vllm_config.parallel_config.world_size
+        # With external_launcher every MPI rank owns an engine/scheduler and
+        # reports only its colocated worker's completion.  Waiting for the
+        # global TP world size in each scheduler leaves every store forever
+        # unpublished.  mp/ray use one scheduler for all workers instead.
+        self._expected_worker_count = (
+            1
+            if vllm_config.parallel_config.distributed_executor_backend
+            == "external_launcher"
+            else vllm_config.parallel_config.world_size
+        )
         self._store_event_pending_counts: dict[int, int] = {}
 
     @staticmethod

--- a/vllm/v1/simple_kv_offload/worker.py
+++ b/vllm/v1/simple_kv_offload/worker.py
@@ -2,7 +2,8 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Worker-side handler for SimpleCPUOffloadConnector."""
 
-from typing import TYPE_CHECKING
+import os
+from typing import TYPE_CHECKING, Any
 
 import torch
 
@@ -10,8 +11,10 @@ from vllm.config import VllmConfig
 from vllm.logger import init_logger
 from vllm.utils.torch_utils import PIN_MEMORY
 from vllm.v1.simple_kv_offload.copy_backend import DmaCopyBackend
+from vllm.v1.simple_kv_offload.cpu_copy_backend import CpuCopyBackend
 from vllm.v1.simple_kv_offload.cuda_mem_ops import pin_tensor
 from vllm.v1.simple_kv_offload.disk_backend import DiskBackend
+from vllm.v1.simple_kv_offload.legomem_backend import LegoMemBackend
 from vllm.v1.simple_kv_offload.metadata import (
     SimpleCPUOffloadMetadata,
     SimpleCPUOffloadWorkerMetadata,
@@ -36,6 +39,11 @@ class SimpleCPUOffloadWorker:
         disk_capacity_bytes: int = 0,
         disk_buffer_slots: int = 2,
         use_page_cache: bool = False,
+        legomem_library_path: str = "/home/ubuntu/legomem/lib/liblegomem_kv.so",
+        legomem_host: str = "127.0.0.1",
+        legomem_port: int = 9999,
+        legomem_num_nodes: int = 16,
+        legomem_node_capacity_bytes: int = 256 * 1024**2,
     ):
         self.vllm_config = vllm_config
         self.kv_cache_config = kv_cache_config
@@ -44,7 +52,13 @@ class SimpleCPUOffloadWorker:
         self.disk_capacity_bytes = disk_capacity_bytes
         self.disk_buffer_slots = disk_buffer_slots
         self.use_page_cache = use_page_cache
+        self.kv_offload_backend = kv_offload_backend
         self.disk_mode = kv_offload_backend == "disk"
+        self.legomem_library_path = legomem_library_path
+        self.legomem_host = legomem_host
+        self.legomem_port = legomem_port
+        self.legomem_num_nodes = legomem_num_nodes
+        self.legomem_node_capacity_bytes = legomem_node_capacity_bytes
 
         self.gpu_kv_caches: dict[str, torch.Tensor] | None = None
         self.cpu_kv_caches: dict[str, torch.Tensor] | None = None
@@ -55,11 +69,13 @@ class SimpleCPUOffloadWorker:
         self.load_stream: torch.cuda.Stream | None = None
         self.store_stream: torch.cuda.Stream | None = None
 
-        self._backend: DmaCopyBackend | DiskBackend | None = None
+        self._backend: (
+            DmaCopyBackend | CpuCopyBackend | DiskBackend | LegoMemBackend | None
+        ) = None
 
         # Ordered (event_idx, Event). Events pre-allocated on main thread.
-        self._load_events: list[tuple[int, torch.Event]] = []
-        self._store_events: list[tuple[int, torch.Event]] = []
+        self._load_events: list[tuple[int, Any]] = []
+        self._store_events: list[tuple[int, Any]] = []
         # High-water marks: highest event_idx completed per stream.
         # When the event list is empty, the hwm covers all prior events.
         self._load_hwm: int = -1
@@ -156,12 +172,44 @@ class SimpleCPUOffloadWorker:
 
         self.num_cpu_blocks = max(1, self.cpu_capacity_bytes // total_bytes_per_block)
 
-        # Use lowest priority so KV cache I/O yields to compute streams.
-        low_pri, _ = torch.cuda.Stream.priority_range()
-        self.load_stream = torch.cuda.Stream(priority=low_pri)
-        self.store_stream = torch.cuda.Stream(priority=low_pri)
-
         self.gpu_kv_caches = unique_gpu_caches
+
+        if self.kv_offload_backend == "legomem":
+            if self.device.type != "cpu":
+                raise ValueError("The LegoMem KV backend currently requires CPU KV tensors")
+            rank = int(
+                os.environ.get("RANK", os.environ.get("OMPI_COMM_WORLD_RANK", "0"))
+            )
+            logger.info(
+                "SimpleCPUOffloadWorker [LEGOMEM]: %d tensors, "
+                "%d blocks (%.2f GB), rank=%d",
+                len(unique_gpu_caches),
+                self.num_cpu_blocks,
+                (self.num_cpu_blocks * total_bytes_per_block) / (1024**3),
+                rank,
+            )
+            backend = LegoMemBackend()
+            backend.init(
+                unique_gpu_caches,
+                self.legomem_library_path,
+                self.legomem_host,
+                self.legomem_port,
+                rank,
+                self.legomem_num_nodes,
+                self.legomem_node_capacity_bytes,
+                self.cpu_capacity_bytes,
+            )
+            self._backend = backend
+            return
+
+        if self.device.type == "cpu" and self.disk_mode:
+            raise ValueError("The disk KV backend currently requires a CUDA device")
+
+        if self.device.type != "cpu":
+            # Use lowest priority so KV cache I/O yields to compute streams.
+            low_pri, _ = torch.cuda.Stream.priority_range()
+            self.load_stream = torch.cuda.Stream(priority=low_pri)
+            self.store_stream = torch.cuda.Stream(priority=low_pri)
 
         if self.disk_mode:
             self._init_disk_mode(unique_gpu_caches, total_bytes_per_block, self.device)
@@ -225,9 +273,15 @@ class SimpleCPUOffloadWorker:
             # bypass PyTorch's CUDACachingHostAllocator which rounds up to
             # the next power of 2 (e.g. 100 GB -> 128 GB).
             tensor = torch.zeros(cpu_shape, dtype=gpu_tensor.dtype, device="cpu")
-            if pin_memory:
+            if pin_memory and device.type != "cpu":
                 pin_tensor(tensor)
             self.cpu_kv_caches[name] = tensor
+
+        if device.type == "cpu":
+            backend = CpuCopyBackend()
+            backend.init(unique_gpu_caches, self.cpu_kv_caches)
+            self._backend = backend
+            return
 
         self._backend = DmaCopyBackend()
         self._backend.init(
@@ -288,16 +342,19 @@ class SimpleCPUOffloadWorker:
                     events_list=self._load_events,
                 )
             if metadata.store_gpu_blocks:
-                if self._store_compute_done is None:
-                    self._store_compute_done = torch.Event()
-                self._store_compute_done.record(torch.cuda.current_stream())
+                wait_event = None
+                if self.device is not None and self.device.type != "cpu":
+                    if self._store_compute_done is None:
+                        self._store_compute_done = torch.Event()
+                    self._store_compute_done.record(torch.cuda.current_stream())
+                    wait_event = self._store_compute_done
                 backend.launch_copy(
                     metadata.store_gpu_blocks,
                     metadata.store_cpu_blocks,
                     is_store=True,
                     event_idx=metadata.store_event,
                     events_list=self._store_events,
-                    wait_event=self._store_compute_done,
+                    wait_event=wait_event,
                 )
 
         # (2) Track completed transfer events


### PR DESCRIPTION
## What changed

- add an experimental CXLMemSim/LegoMem backend to the V1 simple CPU KV offload connector
- map each tensor-parallel rank to a different remote node in one distributed 16-node memory pool
- make the CPU communicator fall back safely outside a same-host shared-memory group
- add a C client wrapper, CPU copy backend, MPI external-launcher benchmark, AMX audit, and smoke tests
- parameterize the benchmark's KV block size, lazy/eager offload policy, and multiple prompt-length cases per model load

## Why

This enables controlled comparison of vLLM with and without distributed KV-cache offload over the CXLMemSim Soft-RoCE transport. The existing standard CPU offload path cannot directly target this distributed memory simulator, and the CPU shared-memory communicator assumed a same-host topology and a maximum of eight participants.

## User impact

The new backend is opt-in through the connector extra configuration. Existing connector behavior remains unchanged unless `kv_offload_backend=legomem` is selected.

## Validation

- `python -m py_compile tests/vllm_mpi_kv_bench.py`
- `bash -n tests/vllm_mpi_rank.sh`
- `git diff --check`
- 16-rank PyTorch/Gloo external-launcher smoke test
- 16-node vLLM tensor-parallel TinyLlama tests
- 16-node Llama 3.1 70B AWQ INT4 inference tests
- strict AMX A/B: all 16 ranks reported AMX tile support and W4A8 enabled
- strict block-size-16 No-LegoMem replay: 7.141 s, 0 cached tokens
- strict block-size-16 LegoMem bulk Soft-RoCE replays: 2.263/2.225 s, 240 cached tokens in both trials
- measured median speedup: 3.182x with a 68.57% replay-latency reduction
- prompt-length matrix at block size 16: 2.184x (128 tokens), 3.029x (256), and 2.061x (512)
- block-size matrix at 256 tokens: 3.029x (16), 3.136x (32), 1.416x (64), and 1.392x (128)
- the 16-node directed ring retained one outbound and one inbound inter-server RC QP per node

## Notes

This is an experimental integration. The positive result is a fixed shared-prefix replay microbenchmark; online service throughput and tail latency still require a separate concurrent-load evaluation.
