### PR TITLE
[Bugfix][Kimi-K3] Do not classify a stateless first chunk as a decode

### DIFF
--- a/tests/models/kimi_k3/test_kda_metadata.py
+++ b/tests/models/kimi_k3/test_kda_metadata.py
@@ -409,3 +409,155 @@ def test_aligned_block_table_matches_shared_gdn():
     )
 
     torch.testing.assert_close(actual, expected)
+
+
+def _build_non_spec(batch, is_prefilling, full_cuda_graph=False):
+    common_attn_metadata = create_common_attn_metadata(
+        batch, BLOCK_SIZE, DEVICE
+    ).replace(is_prefilling=torch.tensor(is_prefilling, dtype=torch.bool))
+    builder = _make_builder(
+        KimiK3KDAMetadataBuilder,
+        num_speculative_tokens=0,
+        full_cuda_graph=full_cuda_graph,
+    )
+    return builder, common_attn_metadata, builder.build(0, common_attn_metadata)
+
+
+def test_one_token_first_chunk_is_not_a_decode():
+    """A request being forwarded for the first time owns no KDA state, so its
+    one-token chunk must be a prefill: only the prefill path masks the state
+    slot with has_initial_state, and mamba blocks are not zeroed on reuse."""
+    _, _, actual = _build_non_spec(
+        BatchSpec(seq_lens=[100, 50, 1], query_lens=[1, 1, 1]),
+        is_prefilling=[False, False, True],
+    )
+
+    assert actual.num_prefills == 1
+    assert actual.num_prefill_tokens == 1
+    assert actual.num_decodes == 2
+    assert actual.num_decode_tokens == 2
+    assert actual.has_initial_state is not None
+    assert actual.has_initial_state.tolist() == [True, True, False]
+
+
+def test_one_token_extend_chunk_stays_a_decode():
+    """A one-token chunk that resumes a partially prefilled request does own
+    valid state, so it must stay on the decode path."""
+    _, _, actual = _build_non_spec(
+        BatchSpec(seq_lens=[100, 50, 65], query_lens=[1, 1, 1]),
+        is_prefilling=[False, False, True],
+    )
+
+    assert actual.num_decodes == 3
+    assert actual.num_decode_tokens == 3
+    assert actual.num_prefills == 0
+    assert actual.num_prefill_tokens == 0
+    assert actual.has_initial_state is None
+
+
+@pytest.mark.parametrize(
+    ("seq_lens", "is_prefilling"),
+    [
+        pytest.param([100, 50, 1], [False, False, True], id="first-token-chunk"),
+        pytest.param([100, 50, 20], [False, False, False], id="pure-decode"),
+    ],
+)
+def test_one_token_batch_stages_cudagraph_state_indices(seq_lens, is_prefilling):
+    """Decode-graph dispatch is shape based, so a one-token batch stages its
+    state indices even when a stateless first chunk makes it a prefill batch."""
+    builder, common_attn_metadata, actual = _build_non_spec(
+        BatchSpec(seq_lens=seq_lens, query_lens=[1, 1, 1]),
+        is_prefilling=is_prefilling,
+        full_cuda_graph=True,
+    )
+
+    staged = actual.non_spec_state_indices_tensor
+    assert staged is not None
+    assert staged.data_ptr() == builder.non_spec_state_indices_tensor.data_ptr()
+    torch.testing.assert_close(staged, common_attn_metadata.block_table_tensor[:, 0])
+
+
+def test_cudagraph_capture_batch_stays_decode_only():
+    """The dummy batch used for capture has seq_len == query_len for every row,
+    so classification must not promote it: the captured decode graph would
+    otherwise record the prefill kernels."""
+    batch = BatchSpec(seq_lens=[1] * 4, query_lens=[1] * 4)
+    common_attn_metadata = create_common_attn_metadata(
+        batch, BLOCK_SIZE, DEVICE
+    ).replace(is_prefilling=torch.zeros(4, dtype=torch.bool))
+    builder = _make_builder(
+        KimiK3KDAMetadataBuilder,
+        num_speculative_tokens=0,
+        full_cuda_graph=True,
+    )
+    actual = builder.build_for_cudagraph_capture(common_attn_metadata)
+
+    assert actual.num_prefills == 0
+    assert actual.num_decodes == 4
+    assert actual.has_initial_state is None
+
+
+def test_all_stateless_one_token_batch_stages_cudagraph_state_indices():
+    """A batch of nothing but first chunks has no decodes at all, and still has
+    to stage its state indices: decode-graph dispatch keys on shape."""
+    builder, common_attn_metadata, actual = _build_non_spec(
+        BatchSpec(seq_lens=[1, 1, 1], query_lens=[1, 1, 1]),
+        is_prefilling=[True, True, True],
+        full_cuda_graph=True,
+    )
+
+    assert actual.num_decodes == 0
+    assert actual.num_prefills == 3
+    staged = actual.non_spec_state_indices_tensor
+    assert staged is not None
+    assert staged.data_ptr() == builder.non_spec_state_indices_tensor.data_ptr()
+    torch.testing.assert_close(staged, common_attn_metadata.block_table_tensor[:, 0])
+
+
+def test_zero_length_padding_row_is_not_a_prefill():
+    """A padded row carries no query tokens, so it must never be promoted out of
+    the decode group even if the runner still marks it as prefilling."""
+    _, _, actual = _build_non_spec(
+        BatchSpec(seq_lens=[100, 50, 0], query_lens=[1, 1, 0]),
+        is_prefilling=[False, False, True],
+    )
+
+    assert actual.num_decodes == 3
+    assert actual.num_prefills == 0
+    assert actual.has_initial_state is None
+
+
+def test_first_chunk_without_prefill_flag_is_left_unclassified():
+    """Without the runner's prefill flag (the microbatch path builds metadata
+    with is_prefilling unset), the builder cannot tell a first chunk from a
+    resumed one-token chunk, so it leaves the base classification unchanged
+    rather than promote a possibly-dummy batch."""
+    common_attn_metadata = create_common_attn_metadata(
+        BatchSpec(seq_lens=[100, 50, 1], query_lens=[1, 1, 1]), BLOCK_SIZE, DEVICE
+    )
+    assert common_attn_metadata.is_prefilling is None
+    builder = _make_builder(
+        KimiK3KDAMetadataBuilder,
+        num_speculative_tokens=0,
+        full_cuda_graph=False,
+    )
+    actual = builder.build(0, common_attn_metadata)
+
+    assert actual.num_prefills == 0
+    assert actual.has_initial_state is None
+
+
+def test_multi_token_batch_does_not_stage_cudagraph_state_indices():
+    """A batch with a longer-than-one-token row is not a decode-graph batch, so
+    the staging guard must not fire even though it now keys on query length."""
+    builder, common_attn_metadata, actual = _build_non_spec(
+        BatchSpec(seq_lens=[100, 50], query_lens=[1, 2]),
+        is_prefilling=[False, False],
+        full_cuda_graph=True,
+    )
+
+    assert actual.num_prefills == 1
+    assert (
+        actual.non_spec_state_indices_tensor.data_ptr()
+        != builder.non_spec_state_indices_tensor.data_ptr()
+    )

--- a/tests/models/kimi_k3/test_kda_metadata.py
+++ b/tests/models/kimi_k3/test_kda_metadata.py
@@ -600,3 +600,155 @@ def test_aligned_block_table_matches_shared_gdn():
     )
 
     torch.testing.assert_close(actual, expected)
+
+
+def _build_non_spec(batch, is_prefilling, full_cuda_graph=False):
+    common_attn_metadata = create_common_attn_metadata(
+        batch, BLOCK_SIZE, DEVICE
+    ).replace(is_prefilling=torch.tensor(is_prefilling, dtype=torch.bool))
+    builder = _make_builder(
+        KimiK3KDAMetadataBuilder,
+        num_speculative_tokens=0,
+        full_cuda_graph=full_cuda_graph,
+    )
+    return builder, common_attn_metadata, builder.build(0, common_attn_metadata)
+
+
+def test_one_token_first_chunk_is_not_a_decode():
+    """A request being forwarded for the first time owns no KDA state, so its
+    one-token chunk must be a prefill: only the prefill path masks the state
+    slot with has_initial_state, and mamba blocks are not zeroed on reuse."""
+    _, _, actual = _build_non_spec(
+        BatchSpec(seq_lens=[100, 50, 1], query_lens=[1, 1, 1]),
+        is_prefilling=[False, False, True],
+    )
+
+    assert actual.num_prefills == 1
+    assert actual.num_prefill_tokens == 1
+    assert actual.num_decodes == 2
+    assert actual.num_decode_tokens == 2
+    assert actual.has_initial_state is not None
+    assert actual.has_initial_state.tolist() == [True, True, False]
+
+
+def test_one_token_extend_chunk_stays_a_decode():
+    """A one-token chunk that resumes a partially prefilled request does own
+    valid state, so it must stay on the decode path."""
+    _, _, actual = _build_non_spec(
+        BatchSpec(seq_lens=[100, 50, 65], query_lens=[1, 1, 1]),
+        is_prefilling=[False, False, True],
+    )
+
+    assert actual.num_decodes == 3
+    assert actual.num_decode_tokens == 3
+    assert actual.num_prefills == 0
+    assert actual.num_prefill_tokens == 0
+    assert actual.has_initial_state is None
+
+
+@pytest.mark.parametrize(
+    ("seq_lens", "is_prefilling"),
+    [
+        pytest.param([100, 50, 1], [False, False, True], id="first-token-chunk"),
+        pytest.param([100, 50, 20], [False, False, False], id="pure-decode"),
+    ],
+)
+def test_one_token_batch_stages_cudagraph_state_indices(seq_lens, is_prefilling):
+    """Decode-graph dispatch is shape based, so a one-token batch stages its
+    state indices even when a stateless first chunk makes it a prefill batch."""
+    builder, common_attn_metadata, actual = _build_non_spec(
+        BatchSpec(seq_lens=seq_lens, query_lens=[1, 1, 1]),
+        is_prefilling=is_prefilling,
+        full_cuda_graph=True,
+    )
+
+    staged = actual.non_spec_state_indices_tensor
+    assert staged is not None
+    assert staged.data_ptr() == builder.non_spec_state_indices_tensor.data_ptr()
+    torch.testing.assert_close(staged, common_attn_metadata.block_table_tensor[:, 0])
+
+
+def test_cudagraph_capture_batch_stays_decode_only():
+    """The dummy batch used for capture has seq_len == query_len for every row,
+    so classification must not promote it: the captured decode graph would
+    otherwise record the prefill kernels."""
+    batch = BatchSpec(seq_lens=[1] * 4, query_lens=[1] * 4)
+    common_attn_metadata = create_common_attn_metadata(
+        batch, BLOCK_SIZE, DEVICE
+    ).replace(is_prefilling=torch.zeros(4, dtype=torch.bool))
+    builder = _make_builder(
+        KimiK3KDAMetadataBuilder,
+        num_speculative_tokens=0,
+        full_cuda_graph=True,
+    )
+    actual = builder.build_for_cudagraph_capture(common_attn_metadata)
+
+    assert actual.num_prefills == 0
+    assert actual.num_decodes == 4
+    assert actual.has_initial_state is None
+
+
+def test_all_stateless_one_token_batch_stages_cudagraph_state_indices():
+    """A batch of nothing but first chunks has no decodes at all, and still has
+    to stage its state indices: decode-graph dispatch keys on shape."""
+    builder, common_attn_metadata, actual = _build_non_spec(
+        BatchSpec(seq_lens=[1, 1, 1], query_lens=[1, 1, 1]),
+        is_prefilling=[True, True, True],
+        full_cuda_graph=True,
+    )
+
+    assert actual.num_decodes == 0
+    assert actual.num_prefills == 3
+    staged = actual.non_spec_state_indices_tensor
+    assert staged is not None
+    assert staged.data_ptr() == builder.non_spec_state_indices_tensor.data_ptr()
+    torch.testing.assert_close(staged, common_attn_metadata.block_table_tensor[:, 0])
+
+
+def test_zero_length_padding_row_is_not_a_prefill():
+    """A padded row carries no query tokens, so it must never be promoted out of
+    the decode group even if the runner still marks it as prefilling."""
+    _, _, actual = _build_non_spec(
+        BatchSpec(seq_lens=[100, 50, 0], query_lens=[1, 1, 0]),
+        is_prefilling=[False, False, True],
+    )
+
+    assert actual.num_decodes == 3
+    assert actual.num_prefills == 0
+    assert actual.has_initial_state is None
+
+
+def test_first_chunk_without_prefill_flag_is_left_unclassified():
+    """Without the runner's prefill flag (the microbatch path builds metadata
+    with is_prefilling unset), the builder cannot tell a first chunk from a
+    resumed one-token chunk, so it leaves the base classification unchanged
+    rather than promote a possibly-dummy batch."""
+    common_attn_metadata = create_common_attn_metadata(
+        BatchSpec(seq_lens=[100, 50, 1], query_lens=[1, 1, 1]), BLOCK_SIZE, DEVICE
+    )
+    assert common_attn_metadata.is_prefilling is None
+    builder = _make_builder(
+        KimiK3KDAMetadataBuilder,
+        num_speculative_tokens=0,
+        full_cuda_graph=False,
+    )
+    actual = builder.build(0, common_attn_metadata)
+
+    assert actual.num_prefills == 0
+    assert actual.has_initial_state is None
+
+
+def test_multi_token_batch_does_not_stage_cudagraph_state_indices():
+    """A batch with a longer-than-one-token row is not a decode-graph batch, so
+    the staging guard must not fire even though it now keys on query length."""
+    builder, common_attn_metadata, actual = _build_non_spec(
+        BatchSpec(seq_lens=[100, 50], query_lens=[1, 2]),
+        is_prefilling=[False, False],
+        full_cuda_graph=True,
+    )
+
+    assert actual.num_prefills == 1
+    assert (
+        actual.non_spec_state_indices_tensor.data_ptr()
+        != builder.non_spec_state_indices_tensor.data_ptr()
+    )

--- a/tests/models/kimi_k3/test_kda_metadata.py
+++ b/tests/models/kimi_k3/test_kda_metadata.py
@@ -614,6 +614,25 @@ def _build_non_spec(batch, is_prefilling, full_cuda_graph=False):
     return builder, common_attn_metadata, builder.build(0, common_attn_metadata)
 
 
+def test_one_token_first_chunk_excludes_trailing_padding():
+    """Trailing cudagraph padding must not be counted as prefill requests.
+
+    `split_decodes_and_prefills` counts the whole suffix after the first
+    prefill, so once a stateless first chunk promotes a row, zero-length
+    padding rows behind it would otherwise inflate `num_prefills`."""
+    # Two real rows (a resuming decode, then a stateless first chunk) followed
+    # by two zero-length cudagraph padding rows.
+    _, _, actual = _build_non_spec(
+        BatchSpec(seq_lens=[100, 1, 0, 0], query_lens=[1, 1, 0, 0]),
+        is_prefilling=[False, True, False, False],
+    )
+
+    assert actual.num_decodes == 1
+    assert actual.num_prefills == 1, "padding rows counted as prefills"
+    assert actual.num_prefill_tokens == 1
+    assert actual.num_decode_tokens == 1
+
+
 def test_one_token_first_chunk_is_not_a_decode():
     """A request being forwarded for the first time owns no KDA state, so its
     one-token chunk must be a prefill: only the prefill path masks the state

--- a/tests/models/kimi_k3/test_kda_metadata.py
+++ b/tests/models/kimi_k3/test_kda_metadata.py
@@ -614,6 +614,30 @@ def _build_non_spec(batch, is_prefilling, full_cuda_graph=False):
     return builder, common_attn_metadata, builder.build(0, common_attn_metadata)
 
 
+def test_one_token_first_chunk_excludes_padded_tokens():
+    """`num_prefill_tokens` must exclude cudagraph token padding.
+
+    It inherits `num_actual_tokens`, which a full cudagraph pads past the last
+    real token, so it has to be recomputed from the real query boundary."""
+    common = create_common_attn_metadata(
+        BatchSpec(seq_lens=[100, 50, 1, 0], query_lens=[1, 1, 1, 0]),
+        BLOCK_SIZE,
+        DEVICE,
+    ).replace(
+        is_prefilling=torch.tensor([False, False, True, False], dtype=torch.bool),
+        num_actual_tokens=4,
+    )
+    builder = _make_builder(
+        KimiK3KDAMetadataBuilder, num_speculative_tokens=0, full_cuda_graph=False
+    )
+    actual = builder.build(0, common)
+
+    assert actual.num_decodes == 2
+    assert actual.num_prefills == 1
+    assert actual.num_decode_tokens == 2
+    assert actual.num_prefill_tokens == 1, "padded token counted as a prefill token"
+
+
 def test_one_token_first_chunk_excludes_trailing_padding():
     """Trailing cudagraph padding must not be counted as prefill requests.
 

--- a/vllm/models/kimi_k3/nvidia/kda_metadata.py
+++ b/vllm/models/kimi_k3/nvidia/kda_metadata.py
@@ -272,9 +272,32 @@ class KimiK3KDAMetadataBuilder(GDNAttentionMetadataBuilder):
                 num_spec_decodes = spec_sequence_masks_cpu.sum().item()
 
         if num_spec_decodes == 0:
-            # The runner orders ordinary decodes before prefills.
+            # The runner orders ordinary decodes before prefills. Query length
+            # alone cannot distinguish a true decode from a one-token prefill
+            # chunk, so classify by state instead: a chunk that resumes a
+            # partially prefilled request owns valid KDA state and stays a
+            # decode, while a *first* chunk owns none and must be a prefill.
+            # The decode route below reads its conv/recurrent slot
+            # unconditionally, and mamba blocks are not zeroed on reallocation;
+            # only the prefill route masks the slot with `has_initial_state`.
+            # The dummy batch used for cudagraph capture also has
+            # seq_len == query_len, so require the runner's prefill flag as
+            # well and only ever demote a row the runner is still prefilling.
+            assert m.seq_lens_cpu_upper_bound is not None
+            query_lens_cpu = query_start_loc_cpu.diff()
+            no_prior_state = (query_lens_cpu > 0) & (
+                m.seq_lens_cpu_upper_bound <= query_lens_cpu
+            )
+            if m.is_prefilling is not None:
+                no_prior_state &= m.is_prefilling
+            else:
+                no_prior_state = torch.zeros_like(no_prior_state)
             num_decodes, num_prefills, num_decode_tokens, num_prefill_tokens = (
-                split_decodes_and_prefills(m, decode_threshold=1)
+                split_decodes_and_prefills(
+                    m.replace(is_prefilling=no_prior_state),
+                    decode_threshold=1,
+                    treat_short_extends_as_decodes=False,
+                )
             )
             num_spec_decode_tokens = 0
             spec_token_indx = None
@@ -447,17 +470,19 @@ class KimiK3KDAMetadataBuilder(GDNAttentionMetadataBuilder):
             spec_query_start_loc = self.spec_query_start_loc[: batch_size + 1]
             num_accepted_tokens = self.num_accepted_tokens[:batch_size]
 
+        # Decode-graph dispatch is shape-based, so a one-token batch can replay
+        # the captured decode graph even when a stateless first chunk made it a
+        # prefill batch above. Stage on the same condition the dispatcher uses,
+        # otherwise the replay would read state indices from an earlier step.
+        # `block_table_tensor` already holds NULL_BLOCK_ID for padded requests.
         if (
             self.use_full_cuda_graph
-            and num_prefills == 0
             and num_spec_decodes == 0
-            and num_decodes <= self.decode_cudagraph_max_bs
+            and m.max_query_len <= 1
+            and batch_size <= self.decode_cudagraph_max_bs
         ):
-            self.non_spec_state_indices_tensor[:num_decodes].copy_(
+            self.non_spec_state_indices_tensor[:batch_size].copy_(
                 non_spec_state_indices_tensor, non_blocking=True
-            )
-            self.non_spec_state_indices_tensor[num_decodes:batch_size].fill_(
-                NULL_BLOCK_ID
             )
             non_spec_state_indices_tensor = self.non_spec_state_indices_tensor[
                 :batch_size

--- a/vllm/models/kimi_k3/nvidia/kda_metadata.py
+++ b/vllm/models/kimi_k3/nvidia/kda_metadata.py
@@ -400,9 +400,32 @@ class KimiK3KDAMetadataBuilder(GDNAttentionMetadataBuilder):
 
         spec_request_indices = None
         if num_spec_decodes == 0:
-            # The runner orders ordinary decodes before prefills.
+            # The runner orders ordinary decodes before prefills. Query length
+            # alone cannot distinguish a true decode from a one-token prefill
+            # chunk, so classify by state instead: a chunk that resumes a
+            # partially prefilled request owns valid KDA state and stays a
+            # decode, while a *first* chunk owns none and must be a prefill.
+            # The decode route below reads its conv/recurrent slot
+            # unconditionally, and mamba blocks are not zeroed on reallocation;
+            # only the prefill route masks the slot with `has_initial_state`.
+            # The dummy batch used for cudagraph capture also has
+            # seq_len == query_len, so require the runner's prefill flag as
+            # well and only ever demote a row the runner is still prefilling.
+            assert m.seq_lens_cpu_upper_bound is not None
+            query_lens_cpu = query_start_loc_cpu.diff()
+            no_prior_state = (query_lens_cpu > 0) & (
+                m.seq_lens_cpu_upper_bound <= query_lens_cpu
+            )
+            if m.is_prefilling is not None:
+                no_prior_state &= m.is_prefilling
+            else:
+                no_prior_state = torch.zeros_like(no_prior_state)
             num_decodes, num_prefills, num_decode_tokens, num_prefill_tokens = (
-                split_decodes_and_prefills(m, decode_threshold=1)
+                split_decodes_and_prefills(
+                    m.replace(is_prefilling=no_prior_state),
+                    decode_threshold=1,
+                    treat_short_extends_as_decodes=False,
+                )
             )
             num_spec_decode_tokens = 0
             spec_token_indx = None
@@ -653,17 +676,19 @@ class KimiK3KDAMetadataBuilder(GDNAttentionMetadataBuilder):
             spec_query_start_loc = self.spec_query_start_loc[: batch_size + 1]
             num_accepted_tokens = self.num_accepted_tokens[:batch_size]
 
+        # Decode-graph dispatch is shape-based, so a one-token batch can replay
+        # the captured decode graph even when a stateless first chunk made it a
+        # prefill batch above. Stage on the same condition the dispatcher uses,
+        # otherwise the replay would read state indices from an earlier step.
+        # `block_table_tensor` already holds NULL_BLOCK_ID for padded requests.
         if (
             self.use_full_cuda_graph
-            and num_prefills == 0
             and num_spec_decodes == 0
-            and num_decodes <= self.decode_cudagraph_max_bs
+            and m.max_query_len <= 1
+            and batch_size <= self.decode_cudagraph_max_bs
         ):
-            self.non_spec_state_indices_tensor[:num_decodes].copy_(
+            self.non_spec_state_indices_tensor[:batch_size].copy_(
                 non_spec_state_indices_tensor, non_blocking=True
-            )
-            self.non_spec_state_indices_tensor[num_decodes:batch_size].fill_(
-                NULL_BLOCK_ID
             )
             non_spec_state_indices_tensor = self.non_spec_state_indices_tensor[
                 :batch_size

--- a/vllm/models/kimi_k3/nvidia/kda_metadata.py
+++ b/vllm/models/kimi_k3/nvidia/kda_metadata.py
@@ -427,6 +427,13 @@ class KimiK3KDAMetadataBuilder(GDNAttentionMetadataBuilder):
                     treat_short_extends_as_decodes=False,
                 )
             )
+            # `split_decodes_and_prefills` counts the whole suffix after the
+            # first prefill, so trailing cudagraph padding lands in
+            # `num_prefills` once a stateless first chunk promotes a row ahead
+            # of it. The padding rows carry no tokens, so only the request
+            # count needs correcting.
+            if num_prefills:
+                num_prefills -= int((query_lens_cpu[num_decodes:] == 0).sum())
             num_spec_decode_tokens = 0
             spec_token_indx = None
             non_spec_token_indx = None

--- a/vllm/models/kimi_k3/nvidia/kda_metadata.py
+++ b/vllm/models/kimi_k3/nvidia/kda_metadata.py
@@ -430,10 +430,16 @@ class KimiK3KDAMetadataBuilder(GDNAttentionMetadataBuilder):
             # `split_decodes_and_prefills` counts the whole suffix after the
             # first prefill, so trailing cudagraph padding lands in
             # `num_prefills` once a stateless first chunk promotes a row ahead
-            # of it. The padding rows carry no tokens, so only the request
-            # count needs correcting.
+            # of it. `num_prefill_tokens` is inflated separately: it inherits
+            # `num_actual_tokens`, which a full cudagraph pads past the last
+            # real token. Padding rows only ever trail the batch, so dropping
+            # them from the request count also gives the real token boundary.
             if num_prefills:
                 num_prefills -= int((query_lens_cpu[num_decodes:] == 0).sum())
+                num_prefill_tokens = (
+                    int(query_start_loc_cpu[num_decodes + num_prefills])
+                    - num_decode_tokens
+                )
             num_spec_decode_tokens = 0
             spec_token_indx = None
             non_spec_token_indx = None


### PR DESCRIPTION

## Purpose

Related to #51039.

A request being forwarded for the first time owns no KDA state, but the non-spec branch of the
Kimi-K3 KDA metadata builder classified any one-token row as a decode
(`split_decodes_and_prefills(m, decode_threshold=1)` with the default
`treat_short_extends_as_decodes=True`, `nvidia/kda_metadata.py:405`). When every row in a batch is one
token, `num_prefills` is 0, `has_initial_state` is never computed, and `kda.py` takes the
pure-decode route, which reads `conv_state[slot]` and `recurrent_state[slot]` unconditionally.
`gather_initial_states` is the only thing that masks a stateless slot, and it lives on the
prefill route. Mamba blocks are not zeroed on reallocation
(`single_type_kv_cache_manager.py:86` restricts zero-on-allocate to the attention specs), so
such a request silently continues whatever KDA state the previous owner of its recycled block
left behind.

This builder already applies the correct rule on its spec path
(`nvidia/kda_metadata.py:439-447`, "Query length alone cannot distinguish a true decode from a
one-token prefill chunk"), and the Mamba2 builder does the same at `mamba_attn.py:459-481`
("First-token prefills have no prior Mamba state and must stay prefills").

Reachable on stock flags: a one-token prompt scheduled alongside ordinary decodes. Also
reachable when a request's first chunk is clipped to one token by the remaining token budget
(`scheduler.py:990`). Under the default `mamba_cache_mode="align"`,
`Scheduler._mamba_block_aligned_split` often clips that chunk to zero and drops the request from
the step instead. Two cases get through: a block-aligned chunk when the mamba spec carries
prefill checkpoint blocks and no Eagle drafter is configured, which is how Kimi-K3 runs under
the FlashKDA prefill backend (`nvidia/kda.py:598`), and any chunk when the mamba block size
exceeds the prefill budget (`scheduler.py:419-436`). A batch containing any row longer than one
token is unaffected, since `nvidia/kda.py:824` then routes everything through the packed prefill
with the correct `has_initial_state`.

**Three changes:**

1. Classify by state rather than by query length. `no_prior_state` is computed from
   `seq_lens_cpu_upper_bound <= query_lens_cpu`, which identifies rows with no computed tokens
   (the bound is documented as precise for prefill rows and optimistic only for async spec
   decode rows, `backend.py:422-426`; an optimistic bound can only miss a stateless row, never
   promote a real decode), and it is additionally masked with the runner's `is_prefilling` flag.
   The dummy batch used for cudagraph capture also has `seq_len == query_len` for every row,
   and without that mask the captured decode graph would record the prefill kernels.

   One-token chunks that resume a partially prefilled request own valid state and keep the
   decode path, so `treat_short_extends_as_decodes=False` alone would be wrong: it would move a
   whole decode batch onto `chunk_kda_with_fused_gate` whenever a chunked prefill ends on a
   one-token chunk.

2. Re-key the cudagraph staging guard. Decode-graph dispatch is shape based
   (`_is_uniform_decode` decides from token counts before `build()` runs), so a one-token batch
   can replay the captured decode graph even when a stateless first chunk makes it a prefill batch. Keyed on
   `num_prefills == 0` the guard would go false, staging would be skipped, and the replay would
   read state indices staged in an earlier step. The new condition is the one the dispatcher
   uses. On base this is a strict no-op: `num_prefills == 0` and `max_query_len <= 1` are
   equivalent there, and the removed `fill_(NULL_BLOCK_ID)` is dead because entering the guard
   implied `num_decodes == batch_size` (NULL padding still comes from the runner's block table).

3. Exclude cudagraph padding from `num_prefills`. `split_decodes_and_prefills` returns
   `num_reqs - num_decodes`, the whole suffix after the first prefill, so trailing zero-length
   padding rows are counted as prefill requests once a stateless first chunk promotes a row ahead
   of them. The value is only ever compared against zero downstream and never crosses zero, so no
   routing decision changes. `num_prefill_tokens` is inflated separately, since it inherits
   `num_actual_tokens`, which a full cudagraph pads past the last real token; it is recomputed
   from the same real query boundary, and nothing on the KDA execution path reads it. The shared GDN
   builder has all three defects, and #51565 makes the same changes there.

Note on blast radius: `kda.py` does not split the non-spec group, so once `num_prefills > 0` the
whole non-spec batch takes the prefill route for that step. A single freshly admitted request
therefore moves an otherwise all-decode batch off `ops.fused_kda_decode` in eager, `PIECEWISE`,
and uncaptured sizes. Both prefill backends handle all-length-1 `cu_seqlens` correctly.

**What this does not do.** It corrects the metadata, not the dispatch. With the default
`FULL_AND_PIECEWISE` an all-one-token batch is still dispatched to the captured decode graph on
shape alone, so a replayed graph is unchanged; Mamba2 has the same residual gap. Closing it needs
either worker-side zeroing of mamba pages on reallocation or making the dispatcher decline the
full graph when a mamba group has a stateless row, both core-runner scope, and I am happy to
follow up on either.

It is also a no-op on batches whose metadata carries no `is_prefilling` flag, which is the
microbatching and context-parallel path (`ubatch_utils._make_metadata_with_slice`,
`cp_utils.py`): without the flag the builder cannot tell a first chunk from a resumed one-token
chunk, so it conservatively keeps the base classification there rather than promote a
capture-shaped batch by mistake.

On #51039 specifically: this is a correctness bug that needs no NaN, and it is also one way a
poisoned state block can be inherited by a brand-new request. It does not explain the origin of
the first NaN at 240K, so I am not claiming it resolves that incident.

Coordination: #50855 (draft) touches the same two files and adds an `all_initial_states_fresh`
flag computed from the same fresh-versus-resumed distinction this changes. Whoever lands second should re-check that flag against the new classification.

Line references above are against `d9fbe526c`, main at the time of writing.

## Test Plan

Ten tests in `tests/models/kimi_k3/test_kda_metadata.py`, driving the real builder:

- `test_one_token_first_chunk_is_not_a_decode`: `seq_lens=[100, 50, 1]`, all query lengths 1,
  expects 2 decodes, 1 prefill, `has_initial_state == [True, True, False]`.
- `test_one_token_extend_chunk_stays_a_decode`: `seq_lens=[100, 50, 65]`, all query lengths 1,
  expects 3 decodes and no prefill, so the change cannot regress mid-prefill one-token chunks.
- `test_zero_length_padding_row_is_not_a_prefill`: a padded row is never promoted.
- `test_one_token_first_chunk_excludes_trailing_padding`: two real rows (an ordinary decode,
  then a stateless first chunk) followed by two zero-length padding rows, expects 1 decode and
  1 prefill, 1 token each.
- `test_one_token_first_chunk_excludes_padded_tokens`: the same batch with `num_actual_tokens`
  forced to 4, expects 2 decodes, 1 prefill, 1 prefill token.
- `test_cudagraph_capture_batch_stays_decode_only`: drives `build_for_cudagraph_capture` on a
  uniform dummy batch and asserts it stays decode-only.
- `test_one_token_batch_stages_cudagraph_state_indices`, parametrized over a first-token chunk
  and a pure decode, and `test_all_stateless_one_token_batch_stages_cudagraph_state_indices`
  for the `num_decodes == 0` case: assert the returned tensor is the builder's persistent
  staging buffer and equals `block_table_tensor[:, 0]`.
- `test_multi_token_batch_does_not_stage_cudagraph_state_indices`: a batch with a longer row is
  not a decode-graph batch, so the staging guard must not fire.
- `test_first_chunk_without_prefill_flag_is_left_unclassified`: with no `is_prefilling` flag the
  builder keeps the base classification rather than promote a possibly capture-shaped batch.

## Test Result

- `test_one_token_first_chunk_is_not_a_decode` fails on unpatched main and passes with the
  change.
- Each guard is pinned by mutation. Removing the `is_prefilling` mask fails the capture test;
  keying the staging guard on `num_decodes > 0` fails the all-stateless test; dropping the
  `and m.max_query_len <= 1` clause fails the multi-token staging test; dropping the
  `query_lens > 0` clause fails the zero-length padding test; removing the padding subtraction
  fails the trailing-padding test; dropping the `num_prefill_tokens` recompute fails the
  padded-token test. Making the flag-less fallback a no-op fails the unclassified
  test, and reverting the classification entirely fails three tests.
- `tests/models/kimi_k3/test_kda_metadata.py`: 29 passed.
- `tests/models/kimi_k3/` (excluding `test_latent_moe_tail.py`, which needs `ray`, absent in my
  environment): 139 passed, 9 failed, 38 skipped, against 128 passed, 9 failed, 38 skipped on
  the same base (`a3561ef8e`). The difference is the eleven new cases. The nine failures are in
  `test_mla_prefill_context.py` and are present on the unmodified base.
- `ruff check` and `ruff format --check` clean on both changed files.
- Environment: RTX 5050 (sm_120), torch 2.13.0+cu130.

## Tool assistance

Claude Code was used for the investigation, for reviewing this change, and for drafting this
description. All code was reviewed by me, and every claim above was verified against the tree
and by running the tests reported here.


