### PR TITLE
[MM][CG][WIP] Encoder CUDA graph support for HunyuanVL

### DIFF
--- a/docs/design/cuda_graphs_multimodal.md
+++ b/docs/design/cuda_graphs_multimodal.md
@@ -26,6 +26,7 @@ For two-tower vision encoders (e.g., DeepSeek-OCR's SAM + CLIP with dynamic tili
 | `Gemma3ForConditionalGeneration` | `Gemma3` | ✅︎ | ❌︎ | ❌︎ |
 | `Glm4vForConditionalGeneration` | `GLM-4.1V, GLM-4.6V-Flash` | ✅︎ | ✅︎ | ❌︎ |
 | `Gemma4ForConditionalGeneration` | `Gemma-4` | ✅︎ | ✅︎ | ❌︎ |
+| `HunYuanVLForConditionalGeneration` | `HunyuanOCR` | ✅︎ | ❌︎ | ❌︎ |
 | `InternVLChatModel` | `InternVL3.5`, `InternVL3`, `InternVL2.5`, `InternVL2` | ✅︎ | ✅︎ | ❌︎ |
 | `KimiVLForConditionalGeneration` | `Kimi-VL` | ✅︎ | ❌︎ | ❌︎ |
 | `Llama4ForConditionalGeneration` | `Llama 4` | ✅︎ | ❌︎ | ❌︎ |
@@ -45,6 +46,7 @@ For two-tower vision encoders (e.g., DeepSeek-OCR's SAM + CLIP with dynamic tili
 | `Gemma3ForConditionalGeneration` | ✅︎ | ✅︎ | ❔ | ✅︎ |
 | `Glm4vForConditionalGeneration` | ✅︎ | ✅︎ | ❔ | ✅︎ |
 | `Gemma4ForConditionalGeneration` | ✅︎ | ✅︎ | ❔ | ✅︎ |
+| `HunYuanVLForConditionalGeneration` | ❔ | ✅︎ | ❔ | ❔ |
 | `InternVLChatModel` | ✅︎ | ✅︎ | ❔ | ✅︎ |
 | `KimiVLForConditionalGeneration` | ✅︎ | ✅︎ | ❔ | ✅︎ |
 | `Llama4ForConditionalGeneration` | ✅︎ | ✅︎ | ❔ | ✅︎ |

--- a/tests/models/multimodal/generation/test_vit_cudagraph.py
+++ b/tests/models/multimodal/generation/test_vit_cudagraph.py
@@ -48,6 +48,12 @@ def internvl_chat_template(content: str) -> str:
     return f"<|im_start|>user\n{content}<|im_end|>\n<|im_start|>assistant\n"
 
 
+def hunyuan_vl_chat_template(content: str) -> str:
+    # Matches examples/generate/multimodal/vision_language_offline.py's
+    # run_hunyuan_vl().
+    return f"<｜hy_begin▁of▁sentence｜>{content}<｜hy_User｜>"
+
+
 def kimi_vl_chat_template(content: str) -> str:
     return (
         f"<|im_user|>user<|im_middle|>{content}<|im_end|>"
@@ -191,6 +197,35 @@ MODEL_CONFIGS: dict[str, VitCudagraphTestConfig] = {
         ),
         needs_video_metadata=False,
         vllm_runner_kwargs={"trust_remote_code": True},
+        marks=[pytest.mark.core_model],
+    ),
+    "hunyuan_vl": VitCudagraphTestConfig(
+        model="tencent/HunyuanOCR",
+        modalities=["image"],  # video is not yet supported by this model
+        image_prompt=hunyuan_vl_chat_template(
+            "<｜hy_place▁holder▁no▁100｜><｜hy_place▁holder▁no▁102｜>"
+            "<｜hy_place▁holder▁no▁101｜>What is in this image?"
+        ),
+        needs_video_metadata=False,
+        # Single bucket sized to comfortably cover the test images' raw
+        # patch count. Unlike Qwen2-VL/Qwen3-VL, the encoder CUDA graph
+        # here only captures the transformer layers (pre-merge token
+        # count == raw patch count, not the smaller merged token count),
+        # so this needs to be generous. TODO: tighten once run on GPU.
+        compilation_config_overrides={
+            "encoder_cudagraph_token_budgets": [4096],
+        },
+        # Shrink to 1 text + 1 vision layer with random weights so the
+        # test runs on any CI GPU and skips the multi-GiB weight download.
+        # The test only validates encoder CG capture/replay functions
+        # correctly, not output quality.
+        vllm_runner_kwargs={
+            "load_format": "dummy",
+            "hf_overrides": partial(
+                dummy_hf_overrides,
+                model_arch="HunYuanVLForConditionalGeneration",
+            ),
+        },
         marks=[pytest.mark.core_model],
     ),
     "step3_vl": VitCudagraphTestConfig(
@@ -413,3 +448,43 @@ def test_vit_cudagraph_video(model_id, vllm_runner, video_assets):
 
         # Ensure the output is a string
         assert isinstance(output_text, str)
+
+
+@pytest.mark.parametrize("model_id", ["hunyuan_vl"])
+@pytest.mark.skipif(not current_platform.is_cuda(), reason="Requires CUDA")
+def test_vit_cudagraph_matches_eager_greedy_decode(model_id, vllm_runner, image_assets):
+    """Greedy-decode parity: cudagraph_mm_encoder on vs off must produce
+    identical output token ids, not just similar text. Greedy decoding is
+    deterministic, so any divergence means the graph replay path computed
+    something different from eager.
+    """
+    config = MODEL_CONFIGS[model_id]
+
+    image_prompts = IMAGE_ASSETS.prompts(
+        {
+            "stop_sign": config.image_prompt,  # type: ignore[typeddict-item]
+            "cherry_blossom": config.image_prompt,  # type: ignore[typeddict-item]
+        }
+    )
+    images = [[asset.pil_image] for asset in image_assets]
+
+    outputs_by_cudagraph: dict[bool, list] = {}
+    for use_cudagraph in (False, True):
+        compilation_config = {**get_compilation_config(config)}
+        compilation_config["cudagraph_mm_encoder"] = use_cudagraph
+        with vllm_runner(
+            config.model,
+            dtype=config.dtype,
+            max_model_len=config.max_model_len,
+            max_num_seqs=config.max_num_seqs,
+            limit_mm_per_prompt={"image": 1},
+            compilation_config=compilation_config,
+            **config.vllm_runner_kwargs,
+        ) as vllm_model:
+            outputs_by_cudagraph[use_cudagraph] = vllm_model.generate_greedy(
+                image_prompts, config.max_tokens, images=images
+            )
+
+    eager_ids = [output_ids for output_ids, _ in outputs_by_cudagraph[False]]
+    cudagraph_ids = [output_ids for output_ids, _ in outputs_by_cudagraph[True]]
+    assert eager_ids == cudagraph_ids

--- a/tests/v1/cudagraph/test_encoder_cudagraph.py
+++ b/tests/v1/cudagraph/test_encoder_cudagraph.py
@@ -521,6 +521,49 @@ class TestEncoderCudaGraphCaptureReplay:
         assert result[0].shape == (4, _HIDDEN)
         assert result[1].shape == (16, _HIDDEN)
 
+    # --- correctness vs eager ---
+
+    def test_cudagraph_matches_eager_single_image(self):
+        grid_thw = [[1, 4, 4]]
+        mm_kwargs = _make_mm_kwargs(grid_thw, self.device, self.dtype)
+        graph_out = self.mgr.execute(mm_kwargs)
+        eager_out = self.model.encoder_eager_forward(mm_kwargs)
+        torch.testing.assert_close(graph_out[0], eager_out, atol=1e-2, rtol=1e-2)
+
+    def test_cudagraph_matches_eager_multiple_images_different_resolutions(self):
+        # Different resolutions packed into one graph replay — verifies the
+        # cu_seqlens-scoped attention doesn't leak across image boundaries.
+        grid_thw = [[1, 4, 4], [1, 8, 8]]
+        mm_kwargs = _make_mm_kwargs(grid_thw, self.device, self.dtype)
+        graph_out = self.mgr.execute(mm_kwargs)
+
+        for i, g in enumerate(grid_thw):
+            single_mm_kwargs = _make_mm_kwargs([g], self.device, self.dtype)
+            single_mm_kwargs["pixel_values"] = (
+                self.model.select_encoder_cudagraph_items(mm_kwargs, [i])[
+                    "pixel_values"
+                ]
+            )
+            eager_out = self.model.encoder_eager_forward(single_mm_kwargs)
+            torch.testing.assert_close(graph_out[i], eager_out, atol=1e-2, rtol=1e-2)
+
+    def test_cudagraph_matches_eager_at_budget_boundary(self):
+        # [1,8,8] -> 1*(8//2)*(8//2) = 16 output tokens == smallest
+        # captured budget exactly.
+        grid_thw = [[1, 8, 8]]
+        mm_kwargs = _make_mm_kwargs(grid_thw, self.device, self.dtype)
+        graph_out = self.mgr.execute(mm_kwargs)
+        eager_out = self.model.encoder_eager_forward(mm_kwargs)
+        torch.testing.assert_close(graph_out[0], eager_out, atol=1e-2, rtol=1e-2)
+
+    def test_eager_fallback_matches_eager_forward(self):
+        # 81 tokens exceeds every captured budget -> genuine eager fallback.
+        grid_thw = [[1, 18, 18]]
+        mm_kwargs = _make_mm_kwargs(grid_thw, self.device, self.dtype)
+        graph_out = self.mgr.execute(mm_kwargs)
+        eager_out = self.model.encoder_eager_forward(mm_kwargs)
+        torch.testing.assert_close(graph_out[0], eager_out, atol=1e-2, rtol=1e-2)
+
     # --- budget fallback ---
 
     def test_eager_fallback_when_tokens_exceed_all_budgets(self):

--- a/vllm/model_executor/models/hunyuan_vision.py
+++ b/vllm/model_executor/models/hunyuan_vision.py
@@ -244,10 +244,12 @@ class HunYuanVisionAttention(nn.Module):
     def forward(
         self,
         x: torch.Tensor,
+        cu_seqlens: torch.Tensor | None = None,
+        max_seqlen: torch.Tensor | None = None,
     ) -> torch.Tensor:
         qkv, _ = self.qkv(x)
         q, k, v = qkv.chunk(3, dim=-1)
-        out = self.attn(q, k, v)
+        out = self.attn(q, k, v, cu_seqlens=cu_seqlens, max_seqlen=max_seqlen)
         output, _ = self.o_proj(out)
         return output
 
@@ -287,8 +289,12 @@ class HunYuanVisionBlock(nn.Module):
     def forward(
         self,
         x: torch.Tensor,
+        cu_seqlens: torch.Tensor | None = None,
+        max_seqlen: torch.Tensor | None = None,
     ) -> torch.Tensor:
-        x = x + self.self_attn(self.input_layernorm(x))
+        x = x + self.self_attn(
+            self.input_layernorm(x), cu_seqlens=cu_seqlens, max_seqlen=max_seqlen
+        )
         x = x + self.mlp(self.post_attention_layernorm(x))
         return x
 
@@ -491,41 +497,87 @@ class HunYuanVisionTransformer(nn.Module):
     def device(self) -> torch.device:
         return self.embeddings.patch_embedding.weight.device
 
+    def prepare_encoder_metadata(
+        self,
+        grid_thw: list[list[int]],
+        *,
+        max_batch_size: int | None = None,
+        max_seqlen_override: int | None = None,
+        device: torch.device | None = None,
+    ) -> dict[str, torch.Tensor]:
+        if device is None:
+            device = self.device
+
+        # NOTE: matches the legacy per-image split lengths, which use h * w
+        # only (video, i.e. t > 1, is not yet supported by this model).
+        lengths = [int(h) * int(w) for (_, h, w) in grid_thw]
+        cu_seqlens = torch.tensor([0, *lengths], dtype=torch.int32)
+        cu_seqlens = torch.cumsum(cu_seqlens, dim=0, dtype=torch.int32)
+
+        # Keep cu_seqlens shape stable across CUDA graph capture/replay.
+        if max_batch_size is not None:
+            num_seqs = len(cu_seqlens) - 1
+            if num_seqs < max_batch_size:
+                cu_seqlens = torch.cat(
+                    (
+                        cu_seqlens,
+                        torch.full(
+                            (max_batch_size - num_seqs,),
+                            cu_seqlens[-1],
+                            dtype=cu_seqlens.dtype,
+                        ),
+                    )
+                )
+
+        if max_seqlen_override is None:
+            max_seqlen = (
+                (cu_seqlens[1:] - cu_seqlens[:-1]).max()
+                if len(cu_seqlens) > 1
+                else torch.tensor(0, dtype=torch.int32)
+            )
+        else:
+            max_seqlen = torch.tensor(max_seqlen_override, dtype=torch.int32)
+
+        return {
+            "cu_seqlens": cu_seqlens.to(device=device, non_blocking=True),
+            "max_seqlen": max_seqlen,
+        }
+
     def forward(
         self,
         x: torch.Tensor,
-        grid_thw: list[list[int]],
+        grid_thw: list[list[int]] | None,
+        *,
+        encoder_metadata: dict[str, torch.Tensor] | None = None,
     ) -> torch.Tensor:
         # patchify
         seq_len = x.size(0)
-        cu_seqlens: list = [0]
 
         hidden_states = x.to(device=self.device, dtype=self.dtype)
         # embeddings = patch_embeds + patch_pos_embed
+        assert grid_thw is not None, (
+            "grid_thw is required to compute patch position embeddings"
+        )
         hidden_states = self.embeddings(hidden_states, grid_thw)
 
-        for t, h, w in grid_thw:
-            t, h, w = int(t), int(h), int(w)
-            cu_seqlens.append(h * w)
-
-        cu_seqlens = torch.tensor(cu_seqlens, dtype=torch.int32)
-        cu_seqlens = torch.cumsum(cu_seqlens, dim=0, dtype=torch.int32)
-
-        cu_seqlens = cu_seqlens.to(device=self.device, non_blocking=True)
+        if encoder_metadata is None:
+            encoder_metadata = self.prepare_encoder_metadata(grid_thw)
+        cu_seqlens = encoder_metadata["cu_seqlens"]
+        max_seqlen = encoder_metadata["max_seqlen"]
 
         hidden_states = hidden_states.reshape(seq_len, -1)
         hidden_states = hidden_states.unsqueeze(0)
 
-        # build per-image lengths once
-        split_lengths = [int(h) * int(w) for (_, h, w) in grid_thw]
+        # hidden_states: (1, T_total, D), packed across all images in the
+        # batch. cu_seqlens keeps attention scoped to each image.
         for layer in self.layers:
-            # hidden_states: (1, T_total, D)
-            parts = hidden_states.split(split_lengths, dim=1)  # list of (1, L_i, D)
-            parts = [layer(p) for p in parts]
-            hidden_states = torch.cat(parts, dim=1)
+            hidden_states = layer(
+                hidden_states, cu_seqlens=cu_seqlens, max_seqlen=max_seqlen
+            )
 
-        # adapter
-        split_lengths = (cu_seqlens[1:] - cu_seqlens[:-1]).tolist()
+        # adapter: the conv-based merger still operates per-image, since it
+        # needs each image's (h, w) spatial layout to insert newline tokens.
+        split_lengths = [int(h) * int(w) for (_, h, w) in grid_thw]
         split_items = hidden_states.split(split_lengths, dim=1)
         image_embeds_list = []
         for grid, split_item in zip(grid_thw, split_items):

--- a/vllm/model_executor/models/hunyuan_vision.py
+++ b/vllm/model_executor/models/hunyuan_vision.py
@@ -81,6 +81,7 @@ from vllm.transformers_utils.configs.hunyuan_vl import (
     HunYuanVLVisionConfig,
 )
 from vllm.utils.tensor_schema import TensorSchema, TensorShape
+from vllm.utils.torch_utils import async_tensor_h2d
 
 from .interfaces import (
     MultiModalEmbeddings,
@@ -540,7 +541,10 @@ class HunYuanVisionTransformer(nn.Module):
             max_seqlen = torch.tensor(max_seqlen_override, dtype=torch.int32)
 
         return {
-            "cu_seqlens": cu_seqlens.to(device=device, non_blocking=True),
+            # async_tensor_h2d pins the source first; a plain
+            # .to(non_blocking=True) from pageable memory silently
+            # degrades to a blocking copy.
+            "cu_seqlens": async_tensor_h2d(cu_seqlens, device),
             "max_seqlen": max_seqlen,
         }
 
@@ -554,11 +558,12 @@ class HunYuanVisionTransformer(nn.Module):
         per-image (needs each image's real (h, w)), so this step is not
         CUDA-graph capturable.
         """
-        seq_len = x.size(0)
-        hidden_states = x.to(device=self.device, dtype=self.dtype)
-        # embeddings = patch_embeds + patch_pos_embed
-        hidden_states = self.embeddings(hidden_states, grid_thw)
-        return hidden_states.reshape(seq_len, -1)
+        with torch.cuda.nvtx.range("hyvl_vit_embed"):
+            seq_len = x.size(0)
+            hidden_states = x.to(device=self.device, dtype=self.dtype)
+            # embeddings = patch_embeds + patch_pos_embed
+            hidden_states = self.embeddings(hidden_states, grid_thw)
+            return hidden_states.reshape(seq_len, -1)
 
     def run_layers(
         self,
@@ -570,14 +575,19 @@ class HunYuanVisionTransformer(nn.Module):
         pure function of the total packed token count (no per-image Python
         control flow), so this is the CUDA-graph-capturable portion.
         """
-        # hidden_states: (1, T_total, D), packed across all images in the
-        # batch. cu_seqlens keeps attention scoped to each image.
-        hidden_states = embeddings.unsqueeze(0)
-        for layer in self.layers:
-            hidden_states = layer(
-                hidden_states, cu_seqlens=cu_seqlens, max_seqlen=max_seqlen
-            )
-        return hidden_states.squeeze(0)
+        # NOTE: this range only shows up in eager mode and during graph
+        # capture. On the cudagraph path the replay is a single
+        # cudaGraphLaunch, so this Python body never runs -- which is
+        # exactly how you tell the two apart in a profile.
+        with torch.cuda.nvtx.range("hyvl_vit_run_layers"):
+            # hidden_states: (1, T_total, D), packed across all images in the
+            # batch. cu_seqlens keeps attention scoped to each image.
+            hidden_states = embeddings.unsqueeze(0)
+            for layer in self.layers:
+                hidden_states = layer(
+                    hidden_states, cu_seqlens=cu_seqlens, max_seqlen=max_seqlen
+                )
+            return hidden_states.squeeze(0)
 
     def merge(
         self,
@@ -588,6 +598,14 @@ class HunYuanVisionTransformer(nn.Module):
         each image's real (h, w) spatial layout, so this always runs
         eagerly outside the CUDA graph.
         """
+        with torch.cuda.nvtx.range("hyvl_vit_merge"):
+            return self._merge_impl(hidden_states, grid_thw)
+
+    def _merge_impl(
+        self,
+        hidden_states: torch.Tensor,
+        grid_thw: list[list[int]],
+    ) -> list[torch.Tensor]:
         split_lengths = [int(h) * int(w) for (_, h, w) in grid_thw]
         split_items = hidden_states.split(split_lengths, dim=0)
         return [

--- a/vllm/model_executor/models/hunyuan_vision.py
+++ b/vllm/model_executor/models/hunyuan_vision.py
@@ -558,12 +558,11 @@ class HunYuanVisionTransformer(nn.Module):
         per-image (needs each image's real (h, w)), so this step is not
         CUDA-graph capturable.
         """
-        with torch.cuda.nvtx.range("hyvl_vit_embed"):
-            seq_len = x.size(0)
-            hidden_states = x.to(device=self.device, dtype=self.dtype)
-            # embeddings = patch_embeds + patch_pos_embed
-            hidden_states = self.embeddings(hidden_states, grid_thw)
-            return hidden_states.reshape(seq_len, -1)
+        seq_len = x.size(0)
+        hidden_states = x.to(device=self.device, dtype=self.dtype)
+        # embeddings = patch_embeds + patch_pos_embed
+        hidden_states = self.embeddings(hidden_states, grid_thw)
+        return hidden_states.reshape(seq_len, -1)
 
     def run_layers(
         self,
@@ -575,19 +574,14 @@ class HunYuanVisionTransformer(nn.Module):
         pure function of the total packed token count (no per-image Python
         control flow), so this is the CUDA-graph-capturable portion.
         """
-        # NOTE: this range only shows up in eager mode and during graph
-        # capture. On the cudagraph path the replay is a single
-        # cudaGraphLaunch, so this Python body never runs -- which is
-        # exactly how you tell the two apart in a profile.
-        with torch.cuda.nvtx.range("hyvl_vit_run_layers"):
-            # hidden_states: (1, T_total, D), packed across all images in the
-            # batch. cu_seqlens keeps attention scoped to each image.
-            hidden_states = embeddings.unsqueeze(0)
-            for layer in self.layers:
-                hidden_states = layer(
-                    hidden_states, cu_seqlens=cu_seqlens, max_seqlen=max_seqlen
-                )
-            return hidden_states.squeeze(0)
+        # hidden_states: (1, T_total, D), packed across all images in the
+        # batch. cu_seqlens keeps attention scoped to each image.
+        hidden_states = embeddings.unsqueeze(0)
+        for layer in self.layers:
+            hidden_states = layer(
+                hidden_states, cu_seqlens=cu_seqlens, max_seqlen=max_seqlen
+            )
+        return hidden_states.squeeze(0)
 
     def merge(
         self,
@@ -598,14 +592,6 @@ class HunYuanVisionTransformer(nn.Module):
         each image's real (h, w) spatial layout, so this always runs
         eagerly outside the CUDA graph.
         """
-        with torch.cuda.nvtx.range("hyvl_vit_merge"):
-            return self._merge_impl(hidden_states, grid_thw)
-
-    def _merge_impl(
-        self,
-        hidden_states: torch.Tensor,
-        grid_thw: list[list[int]],
-    ) -> list[torch.Tensor]:
         split_lengths = [int(h) * int(w) for (_, h, w) in grid_thw]
         split_items = hidden_states.split(split_lengths, dim=0)
         return [

--- a/vllm/model_executor/models/hunyuan_vision.py
+++ b/vllm/model_executor/models/hunyuan_vision.py
@@ -541,9 +541,6 @@ class HunYuanVisionTransformer(nn.Module):
             max_seqlen = torch.tensor(max_seqlen_override, dtype=torch.int32)
 
         return {
-            # async_tensor_h2d pins the source first; a plain
-            # .to(non_blocking=True) from pageable memory silently
-            # degrades to a blocking copy.
             "cu_seqlens": async_tensor_h2d(cu_seqlens, device),
             "max_seqlen": max_seqlen,
         }

--- a/vllm/model_executor/models/hunyuan_vision.py
+++ b/vllm/model_executor/models/hunyuan_vision.py
@@ -86,6 +86,7 @@ from .interfaces import (
     MultiModalEmbeddings,
     SupportsEagle,
     SupportsEagle3,
+    SupportsEncoderCudaGraph,
     SupportsLoRA,
     SupportsMultiModal,
     SupportsPP,
@@ -543,6 +544,59 @@ class HunYuanVisionTransformer(nn.Module):
             "max_seqlen": max_seqlen,
         }
 
+    def embed(
+        self,
+        x: torch.Tensor,
+        grid_thw: list[list[int]],
+    ) -> torch.Tensor:
+        """Patch-embed pixel values and add interpolated positional
+        embeddings. Runs eagerly: the positional-embedding interpolation is
+        per-image (needs each image's real (h, w)), so this step is not
+        CUDA-graph capturable.
+        """
+        seq_len = x.size(0)
+        hidden_states = x.to(device=self.device, dtype=self.dtype)
+        # embeddings = patch_embeds + patch_pos_embed
+        hidden_states = self.embeddings(hidden_states, grid_thw)
+        return hidden_states.reshape(seq_len, -1)
+
+    def run_layers(
+        self,
+        embeddings: torch.Tensor,
+        cu_seqlens: torch.Tensor,
+        max_seqlen: torch.Tensor,
+    ) -> torch.Tensor:
+        """Packed cu_seqlens-scoped transformer stack. Output shape is a
+        pure function of the total packed token count (no per-image Python
+        control flow), so this is the CUDA-graph-capturable portion.
+        """
+        # hidden_states: (1, T_total, D), packed across all images in the
+        # batch. cu_seqlens keeps attention scoped to each image.
+        hidden_states = embeddings.unsqueeze(0)
+        for layer in self.layers:
+            hidden_states = layer(
+                hidden_states, cu_seqlens=cu_seqlens, max_seqlen=max_seqlen
+            )
+        return hidden_states.squeeze(0)
+
+    def merge(
+        self,
+        hidden_states: torch.Tensor,
+        grid_thw: list[list[int]],
+    ) -> list[torch.Tensor]:
+        """Per-image conv-based merge with newline/begin/end tokens. Needs
+        each image's real (h, w) spatial layout, so this always runs
+        eagerly outside the CUDA graph.
+        """
+        split_lengths = [int(h) * int(w) for (_, h, w) in grid_thw]
+        split_items = hidden_states.split(split_lengths, dim=0)
+        return [
+            self.perceive(split_item.unsqueeze(0).contiguous(), size=grid[1:]).squeeze(
+                0
+            )
+            for grid, split_item in zip(grid_thw, split_items)
+        ]
+
     def forward(
         self,
         x: torch.Tensor,
@@ -550,42 +604,19 @@ class HunYuanVisionTransformer(nn.Module):
         *,
         encoder_metadata: dict[str, torch.Tensor] | None = None,
     ) -> torch.Tensor:
-        # patchify
-        seq_len = x.size(0)
-
-        hidden_states = x.to(device=self.device, dtype=self.dtype)
-        # embeddings = patch_embeds + patch_pos_embed
         assert grid_thw is not None, (
             "grid_thw is required to compute patch position embeddings"
         )
-        hidden_states = self.embeddings(hidden_states, grid_thw)
+        embeddings = self.embed(x, grid_thw)
 
         if encoder_metadata is None:
             encoder_metadata = self.prepare_encoder_metadata(grid_thw)
         cu_seqlens = encoder_metadata["cu_seqlens"]
         max_seqlen = encoder_metadata["max_seqlen"]
 
-        hidden_states = hidden_states.reshape(seq_len, -1)
-        hidden_states = hidden_states.unsqueeze(0)
+        hidden_states = self.run_layers(embeddings, cu_seqlens, max_seqlen)
 
-        # hidden_states: (1, T_total, D), packed across all images in the
-        # batch. cu_seqlens keeps attention scoped to each image.
-        for layer in self.layers:
-            hidden_states = layer(
-                hidden_states, cu_seqlens=cu_seqlens, max_seqlen=max_seqlen
-            )
-
-        # adapter: the conv-based merger still operates per-image, since it
-        # needs each image's (h, w) spatial layout to insert newline tokens.
-        split_lengths = [int(h) * int(w) for (_, h, w) in grid_thw]
-        split_items = hidden_states.split(split_lengths, dim=1)
-        image_embeds_list = []
-        for grid, split_item in zip(grid_thw, split_items):
-            image_embeds_list.append(
-                self.perceive(split_item.contiguous(), size=grid[1:]).squeeze(0)
-            )
-
-        return image_embeds_list
+        return self.merge(hidden_states, grid_thw)
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
         loader = AutoWeightsLoader(self)
@@ -868,6 +899,7 @@ class HunYuanVLMultiModalProcessor(BaseMultiModalProcessor[HunYuanVLProcessingIn
 class HunYuanVLForConditionalGeneration(
     nn.Module,
     SupportsMultiModal,
+    SupportsEncoderCudaGraph,
     SupportsLoRA,
     SupportsPP,
     SupportsQuant,
@@ -977,6 +1009,182 @@ class HunYuanVLForConditionalGeneration(
         self.make_empty_intermediate_tensors = (
             self.language_model.make_empty_intermediate_tensors
         )
+
+    # -- SupportsEncoderCudaGraph protocol methods --
+    #
+    # Only HunYuanVisionTransformer.run_layers (the packed cu_seqlens
+    # transformer stack) is CUDA-graph-capturable. Patch-embed positional
+    # interpolation (embed) and the conv-based merger (merge) both need
+    # each image's real (h, w) and stay eager, per-item — see `merge` in
+    # postprocess_encoder_output below. Both are O(num_images), not
+    # O(num_layers * num_images), so they were never what the graph needs
+    # to eliminate.
+
+    def _get_grid_thw_list(self, mm_kwargs: dict[str, Any]) -> list[list[int]]:
+        grid_thw = mm_kwargs["image_grid_thw"]
+        if not isinstance(grid_thw, list):
+            grid_thw = grid_thw.tolist()
+        return grid_thw
+
+    def get_encoder_cudagraph_config(self):
+        from vllm.v1.worker.encoder_cudagraph_defs import EncoderCudaGraphConfig
+
+        return EncoderCudaGraphConfig(
+            modalities=["image"],
+            buffer_keys=["embeddings", "cu_seqlens", "max_seqlen"],
+            out_hidden_size=self.config.vision_config.out_hidden_size,
+        )
+
+    def get_encoder_cudagraph_budget_range(
+        self,
+        vllm_config: VllmConfig,
+    ) -> tuple[int, int]:
+        min_budget = 64
+        max_budget = min(
+            vllm_config.scheduler_config.max_num_batched_tokens,
+            vllm_config.model_config.max_model_len,
+        )
+        return (min_budget, max_budget)
+
+    def get_encoder_cudagraph_item_specs(self, mm_kwargs: dict[str, Any]):
+        from vllm.v1.worker.encoder_cudagraph_defs import EncoderItemSpec
+
+        grid_thw = self._get_grid_thw_list(mm_kwargs)
+        return [
+            # The graph only runs the transformer layers, which don't
+            # change token count, so input_size == output_tokens here.
+            EncoderItemSpec(input_size=h * w, output_tokens=h * w)
+            for _, h, w in grid_thw
+        ]
+
+    def select_encoder_cudagraph_items(
+        self,
+        mm_kwargs: dict[str, Any],
+        indices: list[int],
+    ) -> dict[str, Any]:
+        grid_thw = self._get_grid_thw_list(mm_kwargs)
+        pixel_values = mm_kwargs["pixel_values"]
+
+        if len(indices) == 0:
+            return {"pixel_values": pixel_values[:0], "image_grid_thw": []}
+
+        patches_per_item = [t * h * w for t, h, w in grid_thw]
+        cum_patches = [0]
+        for p in patches_per_item:
+            cum_patches.append(cum_patches[-1] + p)
+
+        selected_pv = torch.cat(
+            [pixel_values[cum_patches[i] : cum_patches[i + 1]] for i in indices]
+        )
+        selected_grid = [grid_thw[i] for i in indices]
+        return {"pixel_values": selected_pv, "image_grid_thw": selected_grid}
+
+    def prepare_encoder_cudagraph_capture_inputs(
+        self,
+        token_budget: int,
+        max_batch_size: int,
+        max_frames_per_batch: int,
+        device: torch.device,
+        dtype: torch.dtype,
+        path: str = "default",
+    ):
+        from vllm.v1.worker.encoder_cudagraph_defs import (
+            EncoderCudaGraphCaptureInputs,
+        )
+
+        # Aspect ratio is irrelevant here: embed/merge never run inside the
+        # graph, so a dummy 1xN grid per item is enough to size the buffers.
+        per_item_patches = (token_budget + max_batch_size - 1) // max_batch_size
+        grid_config = [[1, 1, per_item_patches] for _ in range(max_batch_size)]
+        total_patches = sum(t * h * w for t, h, w in grid_config)
+
+        dummy_embeddings = torch.randn(
+            total_patches,
+            self.visual.hidden_size,
+            device=device,
+            dtype=dtype,
+        )
+
+        metadata = self.visual.prepare_encoder_metadata(
+            grid_config,
+            max_batch_size=max_batch_size,
+            max_seqlen_override=token_budget,
+            device=device,
+        )
+
+        values = {"embeddings": dummy_embeddings, **metadata}
+        return EncoderCudaGraphCaptureInputs(values=values)
+
+    def prepare_encoder_cudagraph_replay_buffers(
+        self,
+        mm_kwargs: dict[str, Any],
+        max_batch_size: int,
+        max_frames_per_batch: int,
+        path: str = "default",
+    ):
+        from vllm.v1.worker.encoder_cudagraph_defs import (
+            EncoderCudaGraphReplayBuffers,
+        )
+
+        grid_thw = self._get_grid_thw_list(mm_kwargs)
+        embeddings = self.visual.embed(mm_kwargs["pixel_values"], grid_thw)
+        metadata = self.visual.prepare_encoder_metadata(
+            grid_thw, max_batch_size=max_batch_size
+        )
+
+        values = {"embeddings": embeddings, **metadata}
+        return EncoderCudaGraphReplayBuffers(values=values)
+
+    def encoder_cudagraph_forward(
+        self,
+        values: dict[str, torch.Tensor],
+        path: str = "default",
+    ) -> torch.Tensor:
+        return self.visual.run_layers(
+            values["embeddings"], values["cu_seqlens"], values["max_seqlen"]
+        )
+
+    def encoder_eager_forward(
+        self,
+        mm_kwargs: dict[str, Any],
+        path: str = "default",
+    ) -> torch.Tensor:
+        grid_thw = self._get_grid_thw_list(mm_kwargs)
+        embeddings = self.visual.embed(mm_kwargs["pixel_values"], grid_thw)
+        metadata = self.visual.prepare_encoder_metadata(grid_thw)
+        return self.visual.run_layers(
+            embeddings, metadata["cu_seqlens"], metadata["max_seqlen"]
+        )
+
+    def postprocess_encoder_output(
+        self,
+        outputs: dict[str, torch.Tensor],
+        indices: list[int],
+        per_item_out_tokens: list[int],
+        dest: dict[int, torch.Tensor] | list[torch.Tensor | None],
+        clone: bool = False,
+        batch_mm_kwargs: dict[str, Any] | None = None,
+    ) -> None:
+        """CPU-side per-item merge after graph replay.
+
+        ``outputs["default"]`` holds raw, pre-merge hidden states (the
+        transformer layers don't change token count). The conv-based
+        merger needs each image's real (h, w), so it runs here, eagerly,
+        per item — mirrors Step3-VL's dynamic-patch-count merge.
+        """
+        assert batch_mm_kwargs is not None
+        grid_thw = self._get_grid_thw_list(batch_mm_kwargs)
+        total_patches = sum(h * w for _, h, w in grid_thw)
+
+        # outputs["default"] is the full captured-buffer capacity (real data
+        # packed at the front, padding at the tail); trim to the real total
+        # before splitting per-item, since Tensor.split requires split sizes
+        # to sum exactly to the input length.
+        hidden_states = outputs["default"][:total_patches]
+
+        merged = self.visual.merge(hidden_states, grid_thw)
+        for idx, item in zip(indices, merged):
+            dest[idx] = item.clone() if clone else item
 
     def _parse_and_validate_image_input(
         self, **kwargs: object


### PR DESCRIPTION
## Summary

Encoder CUDA graph support for HunYuanVL (`HunYuanVLForConditionalGeneration`), tracked in #38175.

This PR has two parts:

1. **Prerequisite refactor**: `HunYuanVisionTransformer` previously processed images by splitting the batch into a Python list and running each image through every layer separately (`O(num_layers * num_images)` split/cat calls). This packs all images into a single sequence and uses `cu_seqlens`-scoped attention instead, matching the pattern used by Qwen2-VL/Qwen3-VL. Standalone perf win and a prerequisite for graph capture (a per-image Python loop across layers isn't graph-friendly).

2. **`SupportsEncoderCudaGraph` wiring**: HunyuanVL's patch merger reshapes tokens into an explicit `(h, w)` spatial grid per image before a Conv2d-based merge step (per-row newline tokens, begin/end/sep tokens) — it needs the real aspect ratio, not just the token budget, so the "uniform dummy shape per token budget" trick used for Qwen2-VL/Qwen3-VL doesn't directly apply. Resolved by splitting the encoder into two phases: `run_layers` (the packed, `O(num_layers)` transformer stack — a pure function of total token count, no per-image control flow) is what gets captured/replayed; `embed` (positional-embedding interpolation) and `merge` (the conv-based merger) both need each image's real `(h, w)` and stay eager, outside the graph, always. This is a narrower fix than the "secondary capture axis / per-shape graph pool" I originally expected to need — instead of trying to make the shape-sensitive part graph-friendly, it just stays out of the graph entirely, since it's `O(num_images)` rather than `O(num_layers * num_images)` and was never the expensive part.

## Why this isn't a duplicate

Checked #38175's checklist and comments, `gh pr list --search "hunyuan"` — no open PR or issue comment claims HunyuanVL for encoder CUDA graph work as of this PR.

## Test plan

- [x] `ruff check` / `ruff format --check` pass on the changed file
- [x] Standalone (non-vLLM) PyTorch script confirming packed `cu_seqlens`-masked SDPA attention is numerically equivalent to the old per-image split-attention loop (max abs diff ~1.8e-7)
- [x] Unit tests: `tests/v1/cudagraph/test_encoder_cudagraph.py -k "TestEncoderCudaGraphCaptureReplay or TestEncoderCudaGraphVideoReplay"` — 20 passed
- [x] E2E: `tests/models/multimodal/generation/test_vit_cudagraph.py -k hunyuan_vl` — image test + eager-vs-cudagraph greedy-decode parity both pass (deterministic token-id match), video skipped (model has no video mode)
- [x] Nsight Systems profiling: cudagraph reduces wall time by ~6-8% on the encoder path; see comment below for full methodology and numbers

All run on an A100 (driver 570.124.06, CUDA 12.8) with `tencent/HunyuanOCR` (`load_format=dummy` weights, so no download needed to reproduce).

## AI assistance disclosure

Portions of this PR (the refactor, the CUDA graph wiring, this description, and the GPU verification/profiling in the comment below) were written and run with AI assistance (Claude). I've reviewed the diff and run the tests and profiling myself.
