### PR TITLE
[Core] Report requests admitted while the scheduler is paused

### DIFF
--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -5734,22 +5734,105 @@ def test_hybrid_per_group_hit_divergence_fa_deeper_no_external():
     assert replay.num_tokens - num_scheduled == block_size
 
 
-def test_requests_admitted_while_paused_are_reported(caplog):
+@pytest.mark.parametrize("pause_state", [PauseState.PAUSED_NEW, PauseState.PAUSED_ALL])
+def test_requests_admitted_while_paused_are_reported(caplog, pause_state):
     """A request arriving during a pause is queued rather than rejected, and
     that must not be silent: it is invisible to the unfinished-request count,
     so nothing else would tell the caller it is being held."""
     scheduler = create_scheduler()
-    requests = create_requests(num_requests=2)
+    requests = create_requests(num_requests=3)
 
-    scheduler.set_pause_state(PauseState.PAUSED_NEW)
+    scheduler.set_pause_state(pause_state)
     with caplog.at_level(logging.WARNING):
         for request in requests:
             scheduler.add_request(request)
     assert requests[0].request_id in caplog.text
+    # One line per pause, not one per request.
+    assert caplog.text.count("was admitted while the scheduler is paused") == 1
 
     assert scheduler.get_num_unfinished_requests() == 0
 
     caplog.clear()
     with caplog.at_level(logging.WARNING):
         scheduler.set_pause_state(PauseState.UNPAUSED)
+    assert "3 request(s) admitted while paused" in caplog.text
+    assert scheduler.get_num_unfinished_requests() == 3
+
+
+def test_admitted_while_paused_survives_a_change_of_pause_state(caplog):
+    """`pause(abort)` followed by `sleep()` moves PAUSED_NEW -> PAUSED_ALL with
+    no resume in between. The tally must span the whole paused period rather
+    than restart, or the resume report undercounts what was held."""
+    scheduler = create_scheduler()
+    requests = create_requests(num_requests=2)
+
+    scheduler.set_pause_state(PauseState.PAUSED_NEW)
+    scheduler.add_request(requests[0])
+    scheduler.set_pause_state(PauseState.PAUSED_ALL)
+    scheduler.add_request(requests[1])
+
+    with caplog.at_level(logging.WARNING):
+        scheduler.set_pause_state(PauseState.UNPAUSED)
+    assert "2 request(s) admitted while paused" in caplog.text
+
+
+def test_admitted_while_paused_excludes_aborted_requests(caplog):
+    """The warning tells the caller to abort what it does not want. Having done
+    so, the resume report must not still claim those requests are schedulable.
+    """
+    scheduler = create_scheduler()
+    requests = create_requests(num_requests=3)
+
+    scheduler.set_pause_state(PauseState.PAUSED_NEW)
+    for request in requests:
+        scheduler.add_request(request)
+    scheduler.finish_requests(
+        [requests[0].request_id, requests[1].request_id],
+        RequestStatus.FINISHED_ABORTED,
+    )
+
+    with caplog.at_level(logging.WARNING):
+        scheduler.set_pause_state(PauseState.UNPAUSED)
+    assert "1 request(s) admitted while paused" in caplog.text
+    assert scheduler.get_num_unfinished_requests() == 1
+
+
+def test_admitted_while_paused_is_silent_when_nothing_was_held(caplog):
+    """Regression guard: the unpaused path must not log, and a pause that
+    admitted nothing (or whose requests were all aborted) must not report."""
+    scheduler = create_scheduler()
+    requests = create_requests(num_requests=2)
+
+    with caplog.at_level(logging.WARNING):
+        scheduler.add_request(requests[0])
+        scheduler.set_pause_state(PauseState.PAUSED_NEW)
+        scheduler.set_pause_state(PauseState.UNPAUSED)
+    assert "admitted while" not in caplog.text
+
+    scheduler.set_pause_state(PauseState.PAUSED_ALL)
+    scheduler.add_request(requests[1])
+    scheduler.finish_requests(requests[1].request_id, RequestStatus.FINISHED_ABORTED)
+    caplog.clear()
+    with caplog.at_level(logging.WARNING):
+        scheduler.set_pause_state(PauseState.UNPAUSED)
+    assert "admitted while paused" not in caplog.text
+
+
+def test_admitted_while_paused_reports_each_pause_episode(caplog):
+    """State must not leak across pauses: a second pause warns again, and
+    reports only its own requests."""
+    scheduler = create_scheduler()
+    requests = create_requests(num_requests=3)
+
+    scheduler.set_pause_state(PauseState.PAUSED_NEW)
+    scheduler.add_request(requests[0])
+    scheduler.set_pause_state(PauseState.UNPAUSED)
+
+    caplog.clear()
+    with caplog.at_level(logging.WARNING):
+        scheduler.set_pause_state(PauseState.PAUSED_NEW)
+        scheduler.add_request(requests[1])
+        scheduler.add_request(requests[2])
+        scheduler.set_pause_state(PauseState.UNPAUSED)
+    assert requests[1].request_id in caplog.text
     assert "2 request(s) admitted while paused" in caplog.text

--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import dataclasses
+import logging
 from concurrent.futures import Future
 from unittest.mock import Mock
 
@@ -28,6 +29,7 @@ from vllm.utils.hashing import sha256
 from vllm.v1.core.encoder_cache_manager import EncoderCacheManager
 from vllm.v1.core.kv_cache_coordinator import HybridKVCacheCoordinator
 from vllm.v1.core.kv_cache_utils import get_request_block_hasher, init_none_hash
+from vllm.v1.core.sched.interface import PauseState
 from vllm.v1.core.sched.output import CachedRequestData, SchedulerOutput
 from vllm.v1.core.sched.scheduler import Scheduler
 from vllm.v1.core.single_type_kv_cache_manager import register_all_kvcache_specs
@@ -5730,3 +5732,24 @@ def test_hybrid_per_group_hit_divergence_fa_deeper_no_external():
     num_scheduled = output.num_scheduled_tokens[replay.request_id]
     # Must resume at the convergent boundary (block 0), not the deep FA hit.
     assert replay.num_tokens - num_scheduled == block_size
+
+
+def test_requests_admitted_while_paused_are_reported(caplog):
+    """A request arriving during a pause is queued rather than rejected, and
+    that must not be silent: it is invisible to the unfinished-request count,
+    so nothing else would tell the caller it is being held."""
+    scheduler = create_scheduler()
+    requests = create_requests(num_requests=2)
+
+    scheduler.set_pause_state(PauseState.PAUSED_NEW)
+    with caplog.at_level(logging.WARNING):
+        for request in requests:
+            scheduler.add_request(request)
+    assert requests[0].request_id in caplog.text
+
+    assert scheduler.get_num_unfinished_requests() == 0
+
+    caplog.clear()
+    with caplog.at_level(logging.WARNING):
+        scheduler.set_pause_state(PauseState.UNPAUSED)
+    assert "2 request(s) admitted while paused" in caplog.text

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -354,6 +354,7 @@ class Scheduler(SchedulerInterface):
             self._re_block_ids: dict[str, list[int]] = {}
 
         self._pause_state: PauseState = PauseState.UNPAUSED
+        self._num_admitted_while_paused = 0
 
         # In-flight requests still prefilling (prefill chunks + in-progress
         # async KV loads). Their remaining-block reservation gates async loads.
@@ -2229,6 +2230,16 @@ class Scheduler(SchedulerInterface):
                 request.streaming_queue = deque()
             self._enqueue_waiting_request(request)
             self.requests[request.request_id] = request
+            if self._pause_state != PauseState.UNPAUSED:
+                self._num_admitted_while_paused += 1
+                if self._num_admitted_while_paused == 1:
+                    logger.warning(
+                        "Request %s was admitted while the scheduler is paused "
+                        "(%s). It is queued and will not be scheduled until "
+                        "resume; abort it if the pause is a generation boundary.",
+                        request.request_id,
+                        self._pause_state.name,
+                    )
             if self.connector is not None:
                 self.connector.on_new_request(request)
             if self.log_stats:
@@ -2336,6 +2347,12 @@ class Scheduler(SchedulerInterface):
         return self._pause_state
 
     def set_pause_state(self, pause_state: PauseState) -> None:
+        if pause_state == PauseState.UNPAUSED and self._num_admitted_while_paused:
+            logger.warning(
+                "%d request(s) admitted while paused are now schedulable.",
+                self._num_admitted_while_paused,
+            )
+        self._num_admitted_while_paused = 0
         self._pause_state = pause_state
 
     def _free_request_blocks(self, request: Request):

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -354,7 +354,7 @@ class Scheduler(SchedulerInterface):
             self._re_block_ids: dict[str, list[int]] = {}
 
         self._pause_state: PauseState = PauseState.UNPAUSED
-        self._num_admitted_while_paused = 0
+        self._admitted_while_paused: set[str] = set()
 
         # In-flight requests still prefilling (prefill chunks + in-progress
         # async KV loads). Their remaining-block reservation gates async loads.
@@ -2231,8 +2231,7 @@ class Scheduler(SchedulerInterface):
             self._enqueue_waiting_request(request)
             self.requests[request.request_id] = request
             if self._pause_state != PauseState.UNPAUSED:
-                self._num_admitted_while_paused += 1
-                if self._num_admitted_while_paused == 1:
+                if not self._admitted_while_paused:
                     logger.warning(
                         "Request %s was admitted while the scheduler is paused "
                         "(%s). It is queued and will not be scheduled until "
@@ -2240,6 +2239,7 @@ class Scheduler(SchedulerInterface):
                         request.request_id,
                         self._pause_state.name,
                     )
+                self._admitted_while_paused.add(request.request_id)
             if self.connector is not None:
                 self.connector.on_new_request(request)
             if self.log_stats:
@@ -2347,12 +2347,22 @@ class Scheduler(SchedulerInterface):
         return self._pause_state
 
     def set_pause_state(self, pause_state: PauseState) -> None:
-        if pause_state == PauseState.UNPAUSED and self._num_admitted_while_paused:
-            logger.warning(
-                "%d request(s) admitted while paused are now schedulable.",
-                self._num_admitted_while_paused,
+        # Tracked by id rather than by count so that moving between pause
+        # states does not lose the tally, and so that requests aborted during
+        # the pause are not reported as becoming schedulable.
+        if pause_state == PauseState.UNPAUSED:
+            num_live = sum(
+                1
+                for req_id in self._admitted_while_paused
+                if (req := self.requests.get(req_id)) is not None
+                and not req.is_finished()
             )
-        self._num_admitted_while_paused = 0
+            if num_live:
+                logger.warning(
+                    "%d request(s) admitted while paused are now schedulable.",
+                    num_live,
+                )
+            self._admitted_while_paused.clear()
         self._pause_state = pause_state
 
     def _free_request_blocks(self, request: Request):


### PR DESCRIPTION
Addresses the second problem described in #51476, in its conservative form: this PR does not change admission, only makes it observable.

## Purpose

A request that arrives while the scheduler is paused is accepted and queued. Nothing rejects it, and nothing reports it — and the two signals a caller would normally use are both blind to it by construction ([scheduler.py:2402](https://github.com/vllm-project/vllm/blob/main/vllm/v1/core/sched/scheduler.py#L2402)):

```python
def get_num_unfinished_requests(self) -> int:
    if self._pause_state == PauseState.PAUSED_ALL:
        return 0
    if self._pause_state == PauseState.PAUSED_NEW:
        return len(self.running)   # queued requests are excluded
```

So the request exists but is invisible: unfinished-request metrics say zero, a drain check believes the engine is clean, and no log line mentions it. It becomes schedulable again only at `resume`.

That matters when the pause is a generation boundary rather than a hiccup. A caller that pauses to swap weights or rescale gets requests that were admitted under the old intent and are then served by the new state. In an RL rollout that silently corrupts the batch.

`pause_generation(mode="abort")` aborts what is already in flight, but says nothing about what arrives afterwards, so the caller has no way to notice the difference.

## Change

Leave the behaviour exactly as it is — the request is still accepted, still queued, still scheduled on resume — and make it visible:

- one `logger.warning` naming the first request admitted during a pause, and the pause state it landed in;
- one `logger.warning` at resume with the number of such requests that are about to become schedulable.

The first line is per pause, not per request, so a busy front-end does not flood the log.

Admissions are tracked by request id rather than by a counter. That is what makes the resume line correct in two cases a counter gets wrong:

- **Moving between pause states.** `pause_generation(mode="abort")` followed by `sleep()` goes `PAUSED_NEW` → `PAUSED_ALL` with no resume in between. A counter reset on every state change undercounts the paused period.
- **Aborting during the pause.** The warning tells the caller to abort what it does not want; having done so, the resume line must not still claim those requests are becoming schedulable. Ids are checked against `self.requests` at resume, so aborted requests drop out and a pause whose admissions were all aborted reports nothing at all.

The set is cleared at resume, so it holds at most the requests admitted during one pause.

## Test Plan

`tests/v1/core/test_scheduler.py`, six cases driving the scheduler directly:

| test | what it pins |
|---|---|
| `..._are_reported[PAUSED_NEW]` / `[PAUSED_ALL]` | both pause states warn; three requests produce exactly one warning line |
| `..._survives_a_change_of_pause_state` | `PAUSED_NEW` → `PAUSED_ALL` keeps the tally |
| `..._excludes_aborted_requests` | requests aborted during the pause are not reported as schedulable |
| `..._is_silent_when_nothing_was_held` | the unpaused path logs nothing, and a pause whose admissions were all aborted reports nothing |
| `..._reports_each_pause_episode` | no state leaks across pauses; a second pause warns again and counts only its own |

Plus an end-to-end run against a real engine — `pause(mode="abort")` → three requests admitted → two aborted → `resume` — checking that the warning reaches the engine log, that the resume line counts only the survivor, and that the survivor then runs.

## Test Result

Run in `vllm/vllm-openai:nightly`, both arms printing which implementation they loaded. `before` is the counter implementation, `after` is the id-set one; the tests are identical in both arms.

| suite | before | after |
|---|---|---|
| the six cases above | **3 failed** / 3 passed | **6 passed** |
| `tests/v1/core/test_scheduler.py` (full, 143 cases) | 4 failed / 139 passed | **1 failed** / 142 passed |

The three `before` failures are exactly the id-tracking cases. The one failure common to both arms is `test_async_scheduling_pp_allows_rescheduling_with_output_placeholders`, which is unrelated to pausing and fails identically with and without this change.

The end-to-end run, on the patched image:

```
RESULT is_paused=True
(EngineCore) WARNING [scheduler.py] Request held-0-9f9f4cb4 was admitted while the scheduler
             is paused (PAUSED_NEW). It is queued and will not be scheduled until resume;
             abort it if the pause is a generation boundary.
MARK resume
(EngineCore) WARNING [scheduler.py] 1 request(s) admitted while paused are now schedulable.
RESULT survivor_completed=True
```

Three requests admitted, one warning line; two aborted, and the resume line reports one rather than three; the survivor completes after resume.

## Essential Elements

- Not a duplicate: no open PR reports admissions during a pause. Filed as part of #51476, alongside #51481.
- Logging only; no effect on scheduling or on model output, so no eval run is included.
- AI assistance was used. The submitter has reviewed each changed line and the runs above.
