### PR TITLE
[Bugfix] Demote FlashInfer CUTLASS unquantized MoE when intermediate size is not 128-aligned

### DIFF
--- a/vllm/model_executor/layers/fused_moe/oracle/unquantized.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/unquantized.py
@@ -84,6 +84,18 @@ def _get_priority_backends(moe_config: FusedMoEConfig) -> list[UnquantizedMoeBac
         if moe_config.moe_parallel_config.dp_size > 1:
             _move_to_back(_AVAILABLE_BACKENDS, UnquantizedMoeBackend.FLASHINFER_CUTLASS)
 
+        # HACK: the unquantized FlashInfer CUTLASS MoE kernel hangs in the first
+        # forward pass when the per-partition intermediate size is not a multiple
+        # of 128. Observed on SM100 (B200) with Gemma 4 26B A4B, whose
+        # moe_intermediate_size is 704 (704 % 128 == 64): the engine never
+        # reaches the profiling/warmup run and the process spins on CPU forever.
+        # FLASHINFER_TRTLLM already declines this shape (see the % 128 check in
+        # _trtllm_bf16_lora_supported), but CUTLASS has no equivalent guard, so
+        # it gets selected and hangs. Demote it and let Triton take over.
+        # Same demotion pattern as the Qwen3.5/dp_size hack above.
+        if moe_config.intermediate_size_per_partition % 128 != 0:
+            _move_to_back(_AVAILABLE_BACKENDS, UnquantizedMoeBackend.FLASHINFER_CUTLASS)
+
         # HACK: unquantized FlashInfer aliases SWIGLUOAI to plain Swiglu
         # (swiglu_alpha/limit only set on the MXFP4 branch). Route to
         # Triton's swigluoai_and_mul until that's plumbed through. Same


### PR DESCRIPTION


## Purpose

Serving Gemma 4 26B A4B on SM100 (B200) hangs during engine initialization.
The last log line is `torch.compile took N s in total`; `Initial
profiling/warmup run` is never reached, and the EngineCore process spins at
~56% CPU indefinitely with no traceback or error.

Root cause: `_get_priority_backends` ranks `FLASHINFER_CUTLASS` ahead of
`TRITON` on CUDA. `FLASHINFER_TRTLLM` declines non-128-aligned intermediate
sizes (the `% 128` check in `_trtllm_bf16_lora_supported`), but
`FLASHINFER_CUTLASS` has no equivalent guard, so the oracle selects it and the
kernel hangs.

Gemma 4 26B A4B has `moe_intermediate_size=704`, and `704 % 128 == 64`.

This patch demotes `FLASHINFER_CUTLASS` when the per-partition intermediate
size is not a multiple of 128, following the existing demotion pattern in the
same function (the Qwen3.5/dp_size and SWIGLUOAI hacks). It does not attempt to
fix the kernel itself — happy to move the check into
`FlashInferExperts.is_supported_config` instead if that is preferred.

## Test Plan

Hardware: NVIDIA B200 (SM100), 183 GB, vLLM 0.26.0, CUDA 13.0

```
vllm serve google/gemma-4-26B-A4B-it \
  --dtype bfloat16 \
  --gpu-memory-utilization 0.85 \
  --max-model-len 131072
```

Then a 400-token decode, repeated 3x:

```
curl http://localhost:8000/v1/chat/completions -H 'Content-Type: application/json' -d '{
  "model": "google/gemma-4-26B-A4B-it",
  "messages": [{"role": "user", "content": "Explain the HAZOP procedure in 3 steps."}],
  "temperature": 0.2, "max_tokens": 400, "seed": 3407
}'
```

Also verified that the existing workaround `--kernel-config.moe_backend=triton`
produces the same result, and that structured output (`response_format` with a
JSON schema, xgrammar backend) still works.

## Test Result

**Before** — engine never starts:

```
INFO [unquantized.py:302] Using FlashInfer CUTLASS Unquantized MoE backend out of potential backends: ['FlashInfer TRTLLM', 'FlashInfer CUTLASS', 'TRITON', 'BATCHED_TRITON'].
INFO [unquantized.py:375] Using FlashInferExperts MoE backend
INFO [monitor.py:53] torch.compile took 26.50 s in total
<hangs here; killed after 8 minutes>
RuntimeError: Engine core initialization failed. Failed core proc(s): {}
```

**After** — starts normally:

```
INFO [unquantized.py:302] Using TRITON Unquantized MoE backend out of potential backends: ['FlashInfer TRTLLM', ...]
INFO [unquantized.py:375] Using TritonExperts MoE backend
INFO [gpu_worker.py:560] Available KV cache memory: 101.08 GiB
INFO [kv_cache_utils.py:2177] GPU KV cache size: 2,275,069 tokens
INFO: Application startup complete.
```

Decode throughput (400 tokens, 3 runs): 243.0 / 243.2 / 243.3 tok/s.
Structured output: valid JSON, `finish_reason=stop`, 0.70 s.

Identical to the `--kernel-config.moe_backend=triton` workaround, so the patch
only changes which backend the oracle picks.

Dense Gemma 4 (31B) is unaffected — it has no MoE layers, so this branch is
never reached.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>
