### PR TITLE
[Bugfix] Use the V2 model runner for Gemma 4 MoE so MTP drafting works

### DIFF
--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -69,6 +69,14 @@ logger = init_logger(__name__)
 DEFAULT_V2_MODEL_RUNNER_ARCHITECTURES = frozenset(
     {
         "DeepseekV2ForCausalLM",
+        # Gemma 4 is V2-by-default for its dense variants (via the `not is_moe`
+        # branch below), but the MoE variant (26B A4B) would otherwise fall back
+        # to V1, where the Gemma4 MTP drafter is wired with the wrong input dim:
+        # pre_projection expects 2 * backbone_hidden but the V1 path feeds
+        # backbone_hidden + draft_hidden, so the engine dies with
+        # "a and b must have same reduction dim, but got [s, 3840] X [5632, 1024]".
+        # Listing the architecture keeps dense and MoE Gemma 4 on the same runner.
+        "Gemma4ForConditionalGeneration",
         "GraniteMoeForCausalLM",
         "InklingForCausalLM",
         "InklingForConditionalGeneration",


### PR DESCRIPTION


## Purpose

Gemma 4 dense variants get the V2 model runner through the `not is_moe` branch
of `_is_default_v2_model_runner_model`, but the MoE variant (26B A4B) falls
back to V1. On the V1 path the Gemma4 MTP drafter is fed the wrong input
dimension and engine initialization fails:

```
torch._dynamo.exc.TorchRuntimeError: RuntimeError when making fake tensor call
  Dynamo failed to run FX node with fake tensors: call_function <built-in
  function linear>(*(FakeTensor(..., size=(s47, 3840), dtype=torch.bfloat16),
  Parameter(FakeTensor(..., size=(1024, 5632), dtype=torch.bfloat16)), None)):
  got RuntimeError('a and b must have same reduction dim, but got
  [s47, 3840] X [5632, 1024]')
```

The checkpoint's `pre_projection.weight` is `[1024, 5632]` = `2 *
backbone_hidden` (2816), which matches the model definition in
`gemma4_mtp.py`:

```python
self.pre_projection = ColumnParallelLinear(
    2 * self.backbone_hidden_size, self.hidden_size, ...
)
```

The V1 path feeds `backbone_hidden + draft_hidden` = 2816 + 1024 = 3840
instead. 31B is unaffected because it is dense and therefore already runs on
V2 (its `pre_projection.weight` is `[1024, 10752]` = `2 * 5376`).

Adding the architecture to `DEFAULT_V2_MODEL_RUNNER_ARCHITECTURES` keeps dense
and MoE Gemma 4 on the same runner.

## Test Plan

Hardware: NVIDIA B200 (SM100), vLLM 0.26.0

```
vllm serve google/gemma-4-26B-A4B-it \
  --dtype bfloat16 --gpu-memory-utilization 0.85 --max-model-len 131072 \
  --speculative-config '{"method":"mtp","model":"google/gemma-4-26B-A4B-it-assistant","num_speculative_tokens":1}'
```

Note: on B200 this also needs `--kernel-config.moe_backend=triton` (or #51492),
otherwise the FlashInfer CUTLASS MoE kernel hangs before this code path is
reached.

Then a 400-token decode, repeated 3x, and a structured-output request.

## Test Result

**Before** — engine init fails with the shape mismatch above.

Confirmed the same command succeeds with `VLLM_USE_V2_MODEL_RUNNER=1`, which
isolates the runner selection as the cause.

**After** — starts on V2 and the drafter attaches to the target's KV cache:

```
INFO [gpu_worker.py:378] Using V2 Model Runner
INFO [speculative.py:1126] Overriding draft model max model len from 262144 to 131072
INFO [gemma4.py:335] Gemma4 MTP: draft layer 0 (sliding_attention) -> language_model.model.layers.28.self_attn.attn
INFO [gemma4.py:335] Gemma4 MTP: draft layer 3 (full_attention) -> language_model.model.layers.29.self_attn.attn
INFO [gpu_worker.py:560] Available KV cache memory: 98.7 GiB
INFO: Application startup complete.
```

Decode throughput (400 tokens, 3 runs): 290.3 tok/s average with the drafter,
versus 243.2 tok/s without it on the same machine.

Structured output (`response_format` JSON schema, xgrammar) still works:
valid JSON, `finish_reason=stop`, 0.64 s.

Dense Gemma 4 (31B) already used V2 and is unchanged.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>
