### PR TITLE
[Bugfix] Fix LFM2 ShortConv prefix breaking quant ignore list

### DIFF
--- a/vllm/model_executor/models/lfm2.py
+++ b/vllm/model_executor/models/lfm2.py
@@ -258,7 +258,7 @@ class Lfm2ShortConvDecoderLayer(nn.Module):
             model_config=model_config,
             cache_config=cache_config,
             quant_config=quant_config,
-            prefix=f"{prefix}.conv",
+            prefix=f"{prefix}.short_conv",
         )
 
         self.feed_forward = Lfm2MLP(

--- a/vllm/model_executor/models/lfm2_moe.py
+++ b/vllm/model_executor/models/lfm2_moe.py
@@ -354,7 +354,7 @@ class Lfm2MoeShortConvDecoderLayer(nn.Module):
             model_config=model_config,
             cache_config=cache_config,
             quant_config=quant_config,
-            prefix=f"{prefix}.conv",
+            prefix=f"{prefix}.short_conv",
         )
 
         if layer_idx < config.num_dense_layers:


### PR DESCRIPTION
ShortConv is stored on the attribute `short_conv` but was constructed with `prefix=f"{prefix}.conv"`. The quantization config's ignore list is rewritten through hf_to_vllm_mapper (".conv." -> ".short_conv."), so ignored conv projections never match the layer prefix and get built with a quantized linear method, failing to load unquantized weights.




## Purpose

`ShortConv` is stored on the attribute `short_conv` in the LFM2 and LFM2-MoE decoder layers, but was constructed with `prefix=f"{prefix}.conv"`.

`SupportsQuant._maybe_apply_model_mapping` rewrites the quantization config's `targets` / `ignore` entries through the model's `hf_to_vllm_mapper`, which maps `".conv."` to `".short_conv."`. An ignore entry such as `model.layers.0.conv.in_proj` therefore becomes `model.layers.0.short_conv.in_proj`, while the layer still reports its prefix as `model.layers.0.conv.in_proj`. The two never match, `should_ignore_layer()` returns `False`, and conv projections that the checkpoint left unquantized are built with a quantized linear method.

Loading then fails, because the layer only holds `weight_packed` / `weight_scale` / `weight_shape` and the plain `weight` in the checkpoint matches no parameter:

```
File "vllm/model_executor/layers/linear.py", line 754, in weight_loader
    param_data = param.data
AttributeError: 'MergedColumnParallelLinear' object has no attribute 'data'
```

This affects compressed-tensors LFM2 checkpoints that list the conv projections in `ignore`.

## Test Plan

```bash
vllm serve cyankiwi/LFM2.5-8B-A1B-AWQ-INT4 \
  --max-model-len 4096 \
  --enforce-eager

curl -s localhost:8000/v1/completions -H 'Content-Type: application/json' \
  -d '{"model": "cyankiwi/LFM2.5-8B-A1B-AWQ-INT4",
       "prompt": "The capital of France is", "max_tokens": 20}'
```

## Test Result

Before — fails during weight loading:

```
Loading safetensors checkpoint shards:   0% Completed | 0/2 [00:00<?, ?it/s]
AttributeError: 'MergedColumnParallelLinear' object has no attribute 'data'
RuntimeError: Engine core initialization failed. See root cause above.
```

After — loads and serves, with no missing or unexpected weights reported:

```
Loading safetensors checkpoint shards: 100% Completed | 2/2 [00:03<00:00,  1.62s/it]
Loading weights took 3.24 seconds
Using CompressedTensorsWNA16MoEMethod
Using 'MARLIN' WNA16 MoE backend
Model loading took 5.18 GiB memory and 3.819604 seconds
GPU KV cache size: 53,842 tokens
Application startup complete.
```

Generation:

```json
{"choices":[{"text":" Paris.  \nThe Eiffel Tower, located in Paris, was completed in 1889 as","finish_reason":"length"}]}
```