### PR TITLE
[Bugfix] Save logical sharded state before postprocessing

### DIFF
--- a/examples/features/sharded_state/save_sharded_state_offline.py
+++ b/examples/features/sharded_state/save_sharded_state_offline.py
@@ -58,15 +58,13 @@ def main(args):
     model_path = engine_args.model
     if not Path(model_path).is_dir():
         raise ValueError("model path must be a local directory")
-    # Create LLM instance from arguments
-    llm = LLM.from_engine_args(engine_args)
     # Prepare output directory
-    Path(args.output).mkdir(exist_ok=True)
-    # Dump worker states to output directory
-
-    llm.llm_engine.engine_core.save_sharded_state(
-        path=args.output, pattern=args.file_pattern, max_size=args.max_file_size
-    )
+    Path(args.output).mkdir(parents=True, exist_ok=True)
+    engine_args.save_sharded_state_path = args.output
+    engine_args.save_sharded_state_pattern = args.file_pattern
+    engine_args.save_sharded_state_max_size = args.max_file_size
+    # Save logical worker states before kernel-specific weight post-processing.
+    LLM.from_engine_args(engine_args)
 
     # Copy metadata files to output directory
     for file in os.listdir(model_path):

--- a/tests/model_executor/model_loader/test_sharded_state_loader.py
+++ b/tests/model_executor/model_loader/test_sharded_state_loader.py
@@ -6,12 +6,15 @@ import multiprocessing as mp
 import os
 import shutil
 from tempfile import TemporaryDirectory
+from types import SimpleNamespace
 
 import pytest
 import torch
 
 from vllm import LLM, SamplingParams
+from vllm.config import LoadConfig
 from vllm.model_executor.model_loader import ShardedStateLoader
+from vllm.model_executor.model_loader.base_loader import BaseModelLoader
 from vllm.transformers_utils.repo_utils import hf_api
 
 prompts = [
@@ -47,6 +50,46 @@ def test_filter_subtensors():
     for key, tensor in filtered_state_dict.items():
         # NOTE: don't use `equal` here, as the tensor might contain NaNs
         assert tensor is state_dict[key]
+
+
+def test_save_sharded_state_before_weight_postprocessing(tmp_path, monkeypatch):
+    from safetensors.torch import load_file
+
+    import vllm.distributed
+    import vllm.model_executor.model_loader.base_loader as base_loader
+
+    class TestModelLoader(BaseModelLoader):
+        def download_model(self, model_config):
+            pass
+
+        def load_weights(self, model, model_config):
+            values = torch.arange(4, dtype=model.weight.dtype).reshape(2, 2)
+            model.weight.data.copy_(values)
+
+    model = torch.nn.Linear(2, 2, bias=False)
+    save_path = tmp_path / "sharded_state"
+    load_config = LoadConfig(save_sharded_state_path=str(save_path))
+    vllm_config = SimpleNamespace(
+        device_config=SimpleNamespace(device="cpu"),
+        load_config=load_config,
+    )
+    model_config = SimpleNamespace(dtype=torch.float32)
+
+    monkeypatch.setattr(base_loader, "initialize_model", lambda **kwargs: model)
+
+    def reshape_weight(model, model_config, target_device):
+        model.weight = torch.nn.Parameter(model.weight.reshape(1, 4))
+
+    monkeypatch.setattr(base_loader, "process_weights_after_loading", reshape_weight)
+    monkeypatch.setattr(vllm.distributed, "get_tensor_model_parallel_rank", lambda: 0)
+
+    loaded_model = TestModelLoader(load_config).load_model(vllm_config, model_config)
+
+    saved = load_file(
+        save_path / ShardedStateLoader.DEFAULT_PATTERN.format(rank=0, part=0)
+    )
+    assert saved["weight"].shape == (2, 2)
+    assert loaded_model.weight.shape == (1, 4)
 
 
 @pytest.fixture(scope="module")

--- a/vllm/config/load.py
+++ b/vllm/config/load.py
@@ -102,6 +102,17 @@ class LoadConfig:
     use_tqdm_on_load: bool = True
     """Whether to enable tqdm for showing progress bar when loading model
     weights."""
+    save_sharded_state_path: str | None = None
+    """Directory where each worker saves its logical model state after loading
+    weights and before kernel-specific post-processing. This checkpoint can be
+    loaded with ``load_format="sharded_state"``. Online quantization is not
+    supported when this option is set."""
+    save_sharded_state_pattern: str | None = None
+    """Filename pattern used when ``save_sharded_state_path`` is set. The
+    pattern must contain ``{rank}`` and ``{part}`` placeholders."""
+    save_sharded_state_max_size: int | None = Field(default=None, gt=0)
+    """Maximum size in bytes of each file saved to
+    ``save_sharded_state_path``."""
     pt_load_map_location: str | dict[str, str] = "cpu"
     """
     The map location for loading pytorch checkpoint, to support loading

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -620,6 +620,11 @@ class EngineArgs:
     num_gpu_blocks_override: int | None = CacheConfig.num_gpu_blocks_override
     model_loader_extra_config: dict = get_field(LoadConfig, "model_loader_extra_config")
     ignore_patterns: str | list[str] = get_field(LoadConfig, "ignore_patterns")
+    save_sharded_state_path: str | None = LoadConfig.save_sharded_state_path
+    save_sharded_state_pattern: str | None = LoadConfig.save_sharded_state_pattern
+    save_sharded_state_max_size: int | None = get_field(
+        LoadConfig, "save_sharded_state_max_size"
+    )
 
     enable_chunked_prefill: bool | None = None
     disable_chunked_mm_input: bool = SchedulerConfig.disable_chunked_mm_input
@@ -955,6 +960,18 @@ class EngineArgs:
         )
         load_group.add_argument("--ignore-patterns", **load_kwargs["ignore_patterns"])
         load_group.add_argument("--use-tqdm-on-load", **load_kwargs["use_tqdm_on_load"])
+        load_group.add_argument(
+            "--save-sharded-state-path",
+            **load_kwargs["save_sharded_state_path"],
+        )
+        load_group.add_argument(
+            "--save-sharded-state-pattern",
+            **load_kwargs["save_sharded_state_pattern"],
+        )
+        load_group.add_argument(
+            "--save-sharded-state-max-size",
+            **load_kwargs["save_sharded_state_max_size"],
+        )
         load_group.add_argument(
             "--pt-load-map-location", **load_kwargs["pt_load_map_location"]
         )
@@ -1829,6 +1846,9 @@ class EngineArgs:
             model_loader_extra_config=self.model_loader_extra_config,
             ignore_patterns=self.ignore_patterns,
             use_tqdm_on_load=self.use_tqdm_on_load,
+            save_sharded_state_path=self.save_sharded_state_path,
+            save_sharded_state_pattern=self.save_sharded_state_pattern,
+            save_sharded_state_max_size=self.save_sharded_state_max_size,
             pt_load_map_location=self.pt_load_map_location,
         )
 

--- a/vllm/model_executor/model_loader/base_loader.py
+++ b/vllm/model_executor/model_loader/base_loader.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import os
 from abc import ABC, abstractmethod
 
 import torch
@@ -72,6 +73,8 @@ class BaseModelLoader(ABC):
                     format_gib(peak_memory),
                 )
 
+            self._save_sharded_state(model)
+
             # Process weights into kernel format. Note that when using online
             # quantization, weights are (typically) quantized as they are loaded.
             if _has_online_quant(model):
@@ -80,6 +83,31 @@ class BaseModelLoader(ABC):
             process_weights_after_loading(model, model_config, target_device)
 
         return model.eval()
+
+    def _save_sharded_state(self, model: nn.Module) -> None:
+        path = self.load_config.save_sharded_state_path
+        if path is None:
+            return
+        if _has_online_quant(model):
+            raise ValueError(
+                "Saving sharded state during online quantization is not supported"
+            )
+
+        from vllm.model_executor.model_loader.sharded_state_loader import (
+            ShardedStateLoader,
+        )
+
+        os.makedirs(path, exist_ok=True)
+        logger.info(
+            "Saving logical sharded state before weight post-processing to %s",
+            path,
+        )
+        ShardedStateLoader.save_model(
+            model,
+            path,
+            pattern=self.load_config.save_sharded_state_pattern,
+            max_size=self.load_config.save_sharded_state_max_size,
+        )
 
 
 def log_model_inspection(model: nn.Module) -> None:


### PR DESCRIPTION
## Purpose

The offline sharded-state example currently saves worker state after model
construction has completed. By that point,
`process_weights_after_loading()` may have converted parameters to a
kernel-specific layout. For example, FusedMoE can reshape a logical Qwen3
`w13` shard from `[128, 384, 4096]` to `[128, 256, 6144]`. Saving that runtime
layout produces a checkpoint that does not match the logical parameter shape
expected by `load_format="sharded_state"`.

This PR:

- adds optional sharded-state save settings to `LoadConfig` / `EngineArgs`;
- saves the logical worker state immediately after `load_weights()` and before
  online-quantization finalization or kernel-specific post-processing;
- updates the offline example to use this pre-postprocess save path;
- rejects this path for online quantization, whose logical state is not
  finalized at that point; and
- adds a regression test proving that the saved tensor retains its logical
  shape even when post-processing reshapes the live parameter.

This is not a duplicate. Searches for open PRs using `sharded state save`,
`FusedMoE sharded state`, `save_sharded_state_offline`, and
`process_weights_after_loading sharded` found no PR addressing save timing or
kernel-layout serialization. Existing sharded-state PRs concern FP8 alias keys
or model-specific loading behavior.

AI assistance (OpenAI Codex) was used to inspect current upstream, implement
the change, and run the checks. The human submitter supplied the original
failure report, root-cause analysis, proposed fix, and reproduction history,
and directed the implementation and validation.

## Test Plan

### Regression test

```bash
uv venv --python 3.12
uv pip install --python .venv/bin/python -r requirements/common.txt pytest tblib --torch-backend=auto
uv pip install --python .venv/bin/python -r requirements/lint.txt
.venv/bin/python -m pytest tests/model_executor/model_loader/test_sharded_state_loader.py \
  -k save_sharded_state_before_weight_postprocessing -v
.venv/bin/pre-commit run --files \
  examples/features/sharded_state/save_sharded_state_offline.py \
  tests/model_executor/model_loader/test_sharded_state_loader.py \
  vllm/config/load.py \
  vllm/engine/arg_utils.py \
  vllm/model_executor/model_loader/base_loader.py
```

### Qwen3-235B end-to-end reproduction

The original mismatch was observed with vLLM 0.15 and a local Qwen3-235B
checkpoint. A machine with the model weights and sufficient multi-GPU memory
can reproduce and verify it with:

```bash
MODEL=/path/to/Qwen3-235B-A22B
SHARDED=/path/to/qwen3-235b-sharded

.venv/bin/python examples/features/sharded_state/save_sharded_state_offline.py \
  --model "$MODEL" \
  --tensor-parallel-size 8 \
  --output "$SHARDED"

.venv/bin/python examples/features/sharded_state/load_sharded_state_offline.py \
  --model "$SHARDED" \
  --load-format sharded_state \
  --tensor-parallel-size 8 \
  --prompt "Hello, my name is" \
  --max-tokens 16
```

Before this change, the save step can serialize the FusedMoE runtime layout
and the load step then reports a parameter shape mismatch. After this change,
the checkpoint is written before the FusedMoE conversion and loads with the
logical shapes.

## Test Result

- Focused pytest on WSL Ubuntu 24.04, Python 3.12.13: `1 passed, 5 deselected`.
- Pre-commit on all five changed files: all applicable hooks passed, including
  Ruff, mypy, SPDX, forbidden-import, CUDA API, and configuration validation.
- Qwen3-235B end-to-end: not rerun because the current environment does not
  have the 235B weights or the required multi-GPU capacity. The failure was
  previously observed on vLLM 0.15; the commands above document reproduction.
- Model evaluation: not applicable. This changes checkpoint serialization
  timing only and does not alter inference kernels, numerical output, or model
  accuracy.

