### PR TITLE
[Bugfix][Frontend] Give each batched conversation its own parser

### DIFF
--- a/tests/entrypoints/openai/chat_completion/test_serving_chat.py
+++ b/tests/entrypoints/openai/chat_completion/test_serving_chat.py
@@ -21,7 +21,11 @@ from tests.utils import RemoteOpenAIServer
 from vllm._aiter_ops import is_aiter_found_and_supported
 from vllm.config import MultiModalConfig
 from vllm.entrypoints.generate.base.serving import build_per_request_timing_metrics
+from vllm.entrypoints.openai.chat_completion.batch_serving import (
+    OpenAIServingChatBatch,
+)
 from vllm.entrypoints.openai.chat_completion.protocol import (
+    BatchChatCompletionRequest,
     ChatCompletionRequest,
     ChatCompletionResponse,
 )
@@ -63,6 +67,69 @@ _PER_REQUEST_STATS = RequestStateStats(
     last_token_ts=3.0,
     num_generation_tokens=2,
 )
+
+
+@pytest.mark.asyncio
+async def test_batch_parsers_receive_per_conversation_request():
+    serving = object.__new__(OpenAIServingChatBatch)
+    serving.response_role = "assistant"
+    serving.system_fingerprint = None
+    serving._raise_if_error = MagicMock()
+
+    request = BatchChatCompletionRequest(
+        messages=[
+            [{"role": "user", "content": "first"}],
+            [{"role": "user", "content": "second"}],
+        ],
+    )
+    single_requests = [
+        request.to_chat_completion_request(messages) for messages in request.messages
+    ]
+    parsers = [MagicMock(), MagicMock()]
+    for parser in parsers:
+        parser.parse.return_value = (None, "parsed", None)
+
+    async def result_generator(prompt_idx: int):
+        yield RequestOutput(
+            request_id=f"test-{prompt_idx}",
+            prompt="test",
+            prompt_token_ids=[1],
+            prompt_logprobs=None,
+            outputs=[
+                CompletionOutput(
+                    index=0,
+                    text="output",
+                    token_ids=[2],
+                    cumulative_logprob=0.0,
+                    logprobs=None,
+                    finish_reason="stop",
+                )
+            ],
+            finished=True,
+        )
+
+    generators = [result_generator(0), result_generator(1)]
+    metadata = RequestResponseMetadata(request_id="test")
+
+    response = await serving.chat_completion_full_generator_batch(
+        request,
+        single_requests,
+        generators,
+        "test",
+        "model",
+        [list(messages) for messages in request.messages],
+        MagicMock(),
+        metadata,
+        parsers,
+    )
+
+    assert isinstance(response, ChatCompletionResponse)
+    for parser, single_request in zip(parsers, single_requests):
+        parser.parse.assert_called_once_with(
+            "output",
+            request=single_request,
+            model_output_token_ids=[2],
+        )
 
 
 @pytest.fixture(scope="module")

--- a/vllm/entrypoints/openai/chat_completion/batch_serving.py
+++ b/vllm/entrypoints/openai/chat_completion/batch_serving.py
@@ -11,6 +11,7 @@ from fastapi import Request
 from vllm.entrypoints.chat_utils import ConversationMessage
 from vllm.entrypoints.openai.chat_completion.protocol import (
     BatchChatCompletionRequest,
+    ChatCompletionRequest,
     ChatCompletionResponse,
     ChatCompletionResponseChoice,
     ChatMessage,
@@ -119,16 +120,20 @@ class OpenAIServingChatBatch(OpenAIServingChat):
             for messages in request.messages
         ]
 
-        parser: Parser | None = None
+        # One parser per conversation: parser state and request-derived
+        # configuration are per-conversation, not per-batch.
+        parsers: list[Parser | None] = [None] * len(single_requests)
         if self.parser_cls is not None:
-            chat_template_kwargs = self._effective_chat_template_kwargs(
-                single_requests[0]
-            )
-            parser = self.parser_cls(
-                tokenizer,
-                None,  # tools
-                chat_template_kwargs=chat_template_kwargs,
-            )
+            parsers = [
+                self.parser_cls(
+                    tokenizer,
+                    None,  # tools
+                    chat_template_kwargs=self._effective_chat_template_kwargs(
+                        single_request
+                    ),
+                )
+                for single_request in single_requests
+            ]
 
         render_result = await self.render_batch_chat_request(request)
         if isinstance(render_result, ErrorResponse):
@@ -191,25 +196,27 @@ class OpenAIServingChatBatch(OpenAIServingChat):
 
         return await self.chat_completion_full_generator_batch(
             request,  # type: ignore[arg-type]
+            single_requests,
             generators,
             request_id,
             model_name,
             all_conversations,
             tokenizer,
             request_metadata,
-            parser,
+            parsers,
         )
 
     async def chat_completion_full_generator_batch(
         self,
         request: BatchChatCompletionRequest,  # type: ignore[override]
+        single_requests: list[ChatCompletionRequest],
         generators: list[AsyncGenerator[RequestOutput, None]],
         request_id: str,
         model_name: str,
         all_conversations: list[list[ConversationMessage]],
         tokenizer: TokenizerLike,
         request_metadata: RequestResponseMetadata,
-        parser: Parser | None = None,
+        parsers: list[Parser | None],
     ) -> ErrorResponse | ChatCompletionResponse:
         """Handle batched (non-streaming) chat completions.
 
@@ -268,10 +275,11 @@ class OpenAIServingChatBatch(OpenAIServingChat):
                 else:
                     logprobs = None
 
+                parser = parsers[prompt_idx]
                 if parser is not None:
                     reasoning, content, _ = parser.parse(
                         output.text,
-                        request=request,  # type: ignore[arg-type]
+                        request=single_requests[prompt_idx],
                         model_output_token_ids=output.token_ids,
                     )
                     if not request.include_reasoning:


### PR DESCRIPTION
## Purpose

`OpenAIServingChatBatch` builds one parser from `single_requests[0]` and reuses
it for every conversation in the batch, then passes the outer
`BatchChatCompletionRequest` to `parse()` instead of the conversation's own
request:

```python
parser: Parser | None = None
if self.parser_cls is not None:
    chat_template_kwargs = self._effective_chat_template_kwargs(single_requests[0])
    parser = self.parser_cls(tokenizer, None, chat_template_kwargs=chat_template_kwargs)
```

**This is a latent defect, not a reproduction.** I could not make it misbehave
on current main, and it is worth being explicit about why:

- the non-streaming `parse()` path resets between calls, so sharing the parser
  object across conversations does not in fact corrupt later ones — I checked
  this directly, including the worst case where one conversation ends
  mid-tool-call and the next is plain text;
- the only consumer of the per-conversation request that reads `messages` is
  `_initialize_history_tool_call_cnt()`, and it returns early unless the
  parser's `tool_call_id_type` is `kimi_k2`, which comes from a `model_config`
  that this call site never passes;
- the sub-requests otherwise differ only in `messages`, since
  `to_chat_completion_request()` copies every other field from the batch
  request.

What makes it worth fixing is how narrow that margin is, and how it fails when
it goes. Passing `model_config` here — which every other serving path already
does, and which is the obvious next change anyone would make to this function —
makes the history-count path live immediately. `BatchChatCompletionRequest` is
not a `ChatCompletionRequest`, so `count_history_tool_calls()` treats it as a
`ResponsesRequest` and reads the nonexistent `request.input`, failing every
batch completion on such a server with an `AttributeError`.

Independently of that, any per-request parser configuration silently follows
only the first conversation in the batch, which is not a property this endpoint
should have.

If you would rather not carry a change without a failing case on main, that is
a reasonable call and I am happy to close it — but the shape of the current
code is what would make the `model_config` change unsafe to land later.

## Modification

Build one parser per conversation and parse each output against the request it
came from. `chat_completion_full_generator_batch` takes the per-conversation
requests and the parser list instead of a single parser.

Deliberately minimal: the parsers are still constructed with the same arguments
as before (`tools=None`, no `model_config`), so this changes only how many
parsers there are and which request each output is parsed against.

## Test Plan

`tests/entrypoints/openai/chat_completion/test_serving_chat.py` adds
`test_batch_parsers_receive_per_conversation_request`: it drives
`chat_completion_full_generator_batch` with two conversations and two mock
parsers, and asserts each parser is called exactly once with its own
`ChatCompletionRequest`.

It fails on the pre-fix code, where both outputs go through one parser and both
`parse()` calls receive the batch request. It is a structural assertion — it
pins the contract rather than reproducing a user-visible failure, for the
reasons above.

## Test Result

Not run locally: `tests/entrypoints` pulls in the model executor and compiled
extensions, so it needs a full vLLM build. Left to CI.

`ruff check` and `ruff format --check` are clean on both changed files.

## AI assistance

The human submitter selected and claimed the underlying issue, controlled the
scope, reviewed the root cause and implementation, reviewed every changed line,
and approved publication. AI-assisted tooling supported implementation,
regression-test authoring, and validation orchestration.
