### PR TITLE
[Benchmark] Use sliding windows for peak serving metrics

### DIFF
--- a/tests/benchmarks/test_serve_metrics.py
+++ b/tests/benchmarks/test_serve_metrics.py
@@ -1,0 +1,87 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+
+from vllm.benchmarks.lib.endpoint_request_func import RequestFuncOutput
+from vllm.benchmarks.serve import (
+    _calculate_peak_concurrency,
+    _calculate_peak_output_tokens_per_s_approx,
+    calculate_metrics,
+)
+
+
+def test_sliding_window_finds_peak_across_fixed_bucket_boundary():
+    outputs = [
+        RequestFuncOutput(success=True, start_time=0.0, ttft=0.6),
+        RequestFuncOutput(success=True, start_time=0.0, ttft=1.4),
+    ]
+
+    peak, event_times, rolling_rates = _calculate_peak_output_tokens_per_s_approx(
+        outputs
+    )
+
+    assert peak == 2.0
+    assert event_times == pytest.approx([0.6, 1.4, 1.6, 2.4])
+    assert rolling_rates == pytest.approx([1.0, 2.0, 1.0, 0.0])
+
+
+def test_calculate_metrics_uses_sliding_window_peak():
+    outputs = [
+        RequestFuncOutput(
+            success=True,
+            start_time=0.0,
+            latency=2.0,
+            ttft=0.6,
+            output_tokens=1,
+        ),
+        RequestFuncOutput(
+            success=True,
+            start_time=0.0,
+            latency=2.0,
+            ttft=1.4,
+            output_tokens=1,
+        ),
+    ]
+
+    metrics, _ = calculate_metrics(
+        input_requests=[],
+        outputs=outputs,
+        dur_s=2.0,
+        tokenizer=None,
+        selected_percentiles=[99],
+        goodput_config_dict={},
+    )
+
+    assert metrics.max_output_tokens_per_s == 2.0
+    assert metrics.max_concurrent_requests == 2
+
+
+def test_sliding_window_excludes_chunk_at_exact_window_boundary():
+    outputs = [
+        RequestFuncOutput(success=True, start_time=0.0, ttft=0.5),
+        RequestFuncOutput(success=True, start_time=0.0, ttft=1.5),
+    ]
+
+    peak, event_times, rolling_rates = _calculate_peak_output_tokens_per_s_approx(
+        outputs
+    )
+
+    assert peak == 1.0
+    assert event_times == pytest.approx([0.5, 1.5, 2.5])
+    assert rolling_rates == pytest.approx([1.0, 1.0, 0.0])
+
+
+def test_peak_concurrency_uses_half_open_request_intervals():
+    outputs = [
+        RequestFuncOutput(start_time=0.0, latency=1.0),
+        RequestFuncOutput(start_time=1.0, latency=1.0),
+        RequestFuncOutput(start_time=0.5, latency=1.0),
+        RequestFuncOutput(start_time=0.0, latency=0.0),
+    ]
+
+    peak, event_times, concurrency = _calculate_peak_concurrency(outputs)
+
+    assert peak == 2
+    assert event_times == pytest.approx([0.0, 0.5, 1.0, 1.5, 2.0])
+    assert concurrency == [1, 2, 2, 1, 0]

--- a/vllm/benchmarks/serve.py
+++ b/vllm/benchmarks/serve.py
@@ -34,6 +34,7 @@ from collections.abc import AsyncGenerator, Iterable, Iterator
 from dataclasses import dataclass, replace
 from datetime import datetime
 from enum import Enum
+from itertools import groupby
 from pathlib import Path
 from typing import Any, Literal
 
@@ -57,6 +58,7 @@ from vllm.utils.gc_utils import freeze_gc_heap
 from vllm.utils.network_utils import join_host_port
 
 MILLISECONDS_TO_SECONDS_CONVERSION = 1000
+PEAK_TOKEN_THROUGHPUT_WINDOW_SECONDS = 1.0
 
 
 def _merge_overrides(base: dict | None, override: dict | None) -> dict | None:
@@ -365,6 +367,79 @@ class EmbedBenchmarkMetrics:
     percentiles_e2el_ms: list[tuple[float, float]]
 
 
+def _calculate_peak_concurrency(
+    outputs: list[RequestFuncOutput],
+) -> tuple[int, list[float], list[int]]:
+    """Return exact peak concurrency and its event-based step series.
+
+    Each request occupies the half-open interval ``[start_time, end_time)``.
+    Outputs without a positive measured latency cannot define an interval and
+    are ignored.
+    """
+    events: list[tuple[float, int]] = []
+    for output in outputs:
+        if output.latency <= 0:
+            continue
+        events.append((output.start_time, 1))
+        events.append((output.start_time + output.latency, -1))
+
+    events.sort(key=lambda event: (event[0], event[1]))
+
+    concurrent = 0
+    peak = 0
+    event_times: list[float] = []
+    concurrency: list[int] = []
+    for event_time, grouped_events in groupby(events, key=lambda event: event[0]):
+        concurrent += sum(delta for _, delta in grouped_events)
+        peak = max(peak, concurrent)
+        event_times.append(event_time)
+        concurrency.append(concurrent)
+
+    return peak, event_times, concurrency
+
+
+def _calculate_peak_output_tokens_per_s_approx(
+    outputs: list[RequestFuncOutput],
+    window_seconds: float = PEAK_TOKEN_THROUGHPUT_WINDOW_SECONDS,
+) -> tuple[float, list[float], list[float]]:
+    """Return approximate output throughput over a sliding window.
+
+    ``RequestFuncOutput.itl`` measures intervals between streamed response
+    chunks, not individual tokens. This calculation assumes one stream chunk
+    equals one output token. Each chunk contributes to the half-open interval
+    ``[chunk_time, chunk_time + window_seconds)`` in the returned step series.
+    """
+    if window_seconds <= 0:
+        raise ValueError("window_seconds must be positive")
+
+    events: list[tuple[float, int]] = []
+    for output in outputs:
+        if not output.success:
+            continue
+
+        chunk_time = output.start_time + output.ttft
+        events.append((chunk_time, 1))
+        events.append((chunk_time + window_seconds, -1))
+        for itl_value in output.itl:
+            chunk_time += itl_value
+            events.append((chunk_time, 1))
+            events.append((chunk_time + window_seconds, -1))
+
+    events.sort(key=lambda event: (event[0], event[1]))
+
+    chunks_in_window = 0
+    peak_chunks = 0
+    event_times: list[float] = []
+    rolling_rates: list[float] = []
+    for event_time, grouped_events in groupby(events, key=lambda event: event[0]):
+        chunks_in_window += sum(delta for _, delta in grouped_events)
+        peak_chunks = max(peak_chunks, chunks_in_window)
+        event_times.append(event_time)
+        rolling_rates.append(chunks_in_window / window_seconds)
+
+    return peak_chunks / window_seconds, event_times, rolling_rates
+
+
 def _get_current_request_rate(
     ramp_up_strategy: Literal["linear", "exponential"] | None,
     ramp_up_start_rps: int | None,
@@ -651,11 +726,6 @@ def calculate_metrics(
             stacklevel=2,
         )
 
-    # Calculate max output tokens per second metric
-    max_output_tokens_per_s = 0.0
-    max_concurrent_requests = 0
-
-    # Find the time range across all successful requests
     successful_outputs = [output for output in outputs if output.success]
     failed_outputs = [output for output in outputs if not output.success]
 
@@ -664,61 +734,36 @@ def calculate_metrics(
         for i, err in enumerate(failed_outputs[:10]):
             print(f"Error {i}: {err.error}")
 
+    max_output_tokens_per_s, throughput_times, rolling_throughput = (
+        _calculate_peak_output_tokens_per_s_approx(successful_outputs)
+    )
+    max_concurrent_requests, concurrency_times, concurrency = (
+        _calculate_peak_concurrency(successful_outputs)
+    )
+
     if successful_outputs:
-        min_start_time = min(output.start_time for output in successful_outputs)
-        max_end_time = max(
-            output.start_time + output.latency for output in successful_outputs
-        )
-
-        # Create second buckets (ceiling to ensure we capture all time)
-        duration_seconds = int(np.ceil(max_end_time - min_start_time)) + 1
-        tokens_per_second = np.zeros(duration_seconds)
-        concurrent_requests_per_second = np.zeros(duration_seconds)
-
-        for i, output in enumerate(successful_outputs):
-            # Calculate token generation timestamp using
-            # start_time, ttft, and itl
-            token_times = [output.start_time + output.ttft]
-            current_time = token_times[0]
-            for itl_value in output.itl:
-                current_time += itl_value
-                token_times.append(current_time)
-
-            # Add tokens to second buckets
-            for token_time in token_times:
-                second_bucket = int(token_time - min_start_time)
-                if 0 <= second_bucket < duration_seconds:
-                    tokens_per_second[second_bucket] += 1
-
-            # Track concurrent requests for each second this request was active
-            request_start_second = int(output.start_time - min_start_time)
-            request_end_second = int(
-                (output.start_time + output.latency) - min_start_time
-            )
-
-            for second in range(request_start_second, request_end_second + 1):
-                concurrent_requests_per_second[second] += 1
-
-        # Find the maximum tokens per second and corresponding
-        # concurrent requests
-        if len(tokens_per_second) > 0:
-            max_output_tokens_per_s = float(np.max(tokens_per_second))
-            max_concurrent_requests = int(np.max(concurrent_requests_per_second))
-
         if TERM_PLOTLIB_AVAILABLE:
             import termplotlib as tpl
 
+            min_start_time = min(output.start_time for output in successful_outputs)
             fig = tpl.figure()
             fig.plot(
-                np.arange(len(tokens_per_second)),
-                tokens_per_second,
-                title="Output tokens per second",
+                [timestamp - min_start_time for timestamp in throughput_times],
+                rolling_throughput,
+                title="Output tokens per second (1s sliding window)",
+                xlabel="Time since first request (s)",
+                ylim=(0, max_output_tokens_per_s + 0.5),
+                plot_command="plot '-' with steps",
             )
-            fig.plot(
-                np.arange(len(concurrent_requests_per_second)),
-                concurrent_requests_per_second,
-                title="Concurrent requests per second",
-            )
+            if concurrency_times:
+                fig.plot(
+                    [timestamp - min_start_time for timestamp in concurrency_times],
+                    concurrency,
+                    title="Concurrent requests",
+                    xlabel="Time since first request (s)",
+                    ylim=(0, max_concurrent_requests + 0.5),
+                    plot_command="plot '-' with steps",
+                )
             fig.show()
         else:
             print("tip: install termplotlib and gnuplot to plot the metrics")


### PR DESCRIPTION


## Purpose

`vllm bench serve` reports peak output throughput in tokens per second. The existing algorithm divides the benchmark timeline into fixed one-second buckets and assigns each SSE chunk to the bucket containing its arrival time.

This approach can underestimate a peak when a one-second burst crosses a bucket boundary. This PR replaces the fixed-bucket calculation with a one-second sliding-window algorithm, removing its dependency on the arbitrary bucket alignment.

For example, consider two chunks arriving at 0.6 seconds and 1.4 seconds. Since they arrive less than one second apart, the peak throughput should be 2 tokens/s, assuming each SSE chunk contains one output token.

The previous bucket-based algorithm assigns the first chunk to the `[0, 1)` bucket and the second chunk to the `[1, 2)` bucket. Each bucket therefore contains only one chunk, resulting in a reported peak of 1 token/s.

The sliding-window algorithm instead evaluates the interval from 0.6 to 1.6 seconds. Both chunks fall within that interval, so it correctly reports a peak throughput of 2 tokens/s.

This PR also:

- Calculates peak concurrency using request start and end events, treating each request as the half-open interval `[start_time, end_time)`.
- Produces event-based step series for both throughput and concurrency.
- Renders the terminal plots as step plots instead of interpolated lines.
- Adds vertical-axis padding so peak values do not overlap the plot border.

The existing assumption that one SSE chunk represents one output token is intentionally unchanged by this PR.

## Test Plan

Run the newly added tests:

```bash
.venv/bin/python -m pytest tests/benchmarks/test_serve_metrics.py -s -q
```

The tests cover:

- Detecting a peak that crosses a fixed bucket boundary.
- Excluding an event exactly one window length outside the sliding window.
- Half-open request interval semantics for concurrency.
- Integration with `calculate_metrics()`.

## Test Result

All tests passed:

```text
4 passed
```

Ruff formatting, Ruff linting, and mypy for Python 3.12 also passed.

Model evaluation is not applicable because this change only affects benchmark metric calculation and visualization; it does not affect model execution or generated output.

For the test scenario in which two chunks arrive at 0.6 seconds and 1.4 seconds, the fixed-bucket algorithm produces the following plot:

```text
                             Output tokens per second
      +---------------------------------------------------------------------+
  1.4 |                                                                     |
      |                                                                     |
      |                                                                     |
  1.2 |                                                                     |
      |                                                                     |
    1 |************************************                                 |
      |                                    ***                              |
      |                                       **                            |
  0.8 |                                         ***                         |
      |                                            ***                      |
  0.6 |                                               **                    |
      |                                                 ***                 |
      |                                                    ***              |
  0.4 |                                                       **            |
      |                                                         ***         |
  0.2 |                                                            ***      |
      |                                                               **    |
      |                                                                 *** |
    0 +---------------------------------------------------------------------+
      0                0.5               1                1.5               2
```

After this change, the sliding-window algorithm correctly identifies the peak throughput of 2 tokens/s:

```text
                   Output tokens per second (1s sliding window)
  2.5 +---------------------------------------------------------------------+
      |                                                                     |
      |                                                                     |
      |                                                                     |
    2 |                                  ********                           |
      |                                  *      *                           |
      |                                  *      *                           |
  1.5 |                                  *      *                           |
      |                                  *      *                           |
      |                                  *      *                           |
      |                                  *      *                           |
    1 |      *****************************      ****************************|
      |                                                                     |
      |                                                                     |
  0.5 |                                                                     |
      |                                                                     |
      |                                                                     |
      |                                                                     |
    0 +---------------------------------------------------------------------+
     0.4    0.6    0.8     1     1.2    1.4    1.6    1.8     2     2.2    2.4
```

## AI Assistance

AI assistance was used while developing this change. I reviewed every changed line and ran the tests and checks listed above.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

