### PR TITLE
fix: prevent NIXL Decode worker crash from multi-prompt completions

### DIFF
--- a/tests/entrypoints/openai/completion/test_completion_error.py
+++ b/tests/entrypoints/openai/completion/test_completion_error.py
@@ -612,6 +612,87 @@ class TestCompletionPromptListLimit:
         assert len(request.prompt_embeds) == 5
 
 
+@pytest.mark.asyncio
+async def test_multi_prompt_with_kv_transfer_params_rejected():
+    """Multi-prompt completions with kv_transfer_params must be rejected
+    to prevent NIXL Decode worker crashes (GHSA-6vh8-5j8f-m4vf)."""
+    mock_engine = MagicMock(spec=AsyncLLM)
+    mock_engine.errored = False
+    mock_engine.model_config = MockModelConfig()
+    mock_engine.input_processor = MagicMock()
+    mock_engine.renderer = _build_renderer(mock_engine.model_config)
+
+    serving_completion = _build_serving_completion(mock_engine)
+    serving_completion.online_renderer.preprocess_completion = AsyncMock(
+        return_value=[
+            {"prompt_token_ids": [1, 2, 3]},
+            {"prompt_token_ids": [4, 5, 6]},
+        ]
+    )
+
+    request = CompletionRequest(
+        model=MODEL_NAME,
+        prompt=["prompt one", "prompt two"],
+        max_tokens=10,
+        kv_transfer_params={"some": "params"},
+    )
+
+    from vllm.entrypoints.openai.engine.protocol import ErrorResponse
+
+    result = await serving_completion._create_completion(request)
+    assert isinstance(result, ErrorResponse)
+    assert "Multi-prompt" in result.error.message
+
+
+@pytest.mark.asyncio
+async def test_single_prompt_with_kv_transfer_params_allowed():
+    """A single-prompt request with kv_transfer_params must not be rejected."""
+    mock_engine = MagicMock(spec=AsyncLLM)
+    mock_engine.errored = False
+    mock_engine.model_config = MockModelConfig()
+    mock_engine.input_processor = MagicMock()
+    mock_engine.renderer = _build_renderer(mock_engine.model_config)
+
+    serving_completion = _build_serving_completion(mock_engine)
+    serving_completion.online_renderer.preprocess_completion = AsyncMock(
+        return_value=[{"prompt_token_ids": [1, 2, 3]}]
+    )
+
+    request = CompletionRequest(
+        model=MODEL_NAME,
+        prompt="single prompt",
+        max_tokens=10,
+        kv_transfer_params={"some": "params"},
+    )
+
+    async def mock_generate(*args, **kwargs):
+        yield RequestOutput(
+            request_id="test-id",
+            prompt="single prompt",
+            prompt_token_ids=[1, 2, 3],
+            prompt_logprobs=None,
+            outputs=[
+                CompletionOutput(
+                    index=0,
+                    text="Hello",
+                    token_ids=[100],
+                    cumulative_logprob=None,
+                    logprobs=None,
+                    finish_reason="stop",
+                )
+            ],
+            finished=True,
+            metrics=_PER_REQUEST_STATS,
+        )
+
+    mock_engine.generate = MagicMock(side_effect=mock_generate)
+
+    from vllm.entrypoints.openai.engine.protocol import ErrorResponse
+
+    result = await serving_completion._create_completion(request)
+    assert not isinstance(result, ErrorResponse)
+
+
 @pytest.mark.parametrize("field_name", ["prompt_logprobs", "logprobs"])
 def test_non_numeric_logprobs_rejected(field_name):
     """A non-numeric logprobs value must be a clean 400 validation error, not a

--- a/tests/v1/kv_connector/unit/test_nixl_connector_hma.py
+++ b/tests/v1/kv_connector/unit/test_nixl_connector_hma.py
@@ -446,10 +446,27 @@ def test_apply_prefix_caching_ssm_unpairable_slots_rejected():
     worker._group_spec_types = (FullAttentionSpec, MambaSpec)
     worker.kv_cache_config = make_kv_cache_config(block_size=16, mamba_enabled=True)
 
-    with pytest.raises(AssertionError, match="unpairable SSM state slots"):
+    with pytest.raises(ValueError, match="unpairable SSM state slots"):
         worker._apply_prefix_caching(
             [list(range(10)), [4, 5, 6, 7]], [list(range(10)), [8, 9]], 10, 10
         )
+
+
+@pytest.mark.cpu_test
+def test_apply_prefix_caching_non_mamba_block_mismatch():
+    """When decode has more blocks than prefill in a non-Mamba model,
+    _apply_prefix_caching must raise ValueError (not AssertionError)."""
+    from vllm.distributed.kv_transfer.kv_connector.v1.nixl.worker import (
+        NixlConnectorWorker,
+    )
+
+    worker = object.__new__(NixlConnectorWorker)
+    worker._has_mamba = False
+    worker._physical_blocks_per_logical_kv_block = 1
+    worker.kv_cache_config = make_kv_cache_config(block_size=16)
+
+    with pytest.raises(ValueError, match="decode has .* blocks but prefill"):
+        worker._apply_prefix_caching([list(range(10))], [list(range(5))], 1, 1)
 
 
 @pytest.mark.cpu_test

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_worker.py
@@ -2427,7 +2427,12 @@ class NixlBaseConnectorWorker:
         if not self._has_mamba:
             for i, prefill_group in enumerate(prefill_block_ids):
                 num_decode_blocks = len(decode_block_ids[i])
-                assert num_decode_blocks <= len(prefill_group)
+                if num_decode_blocks > len(prefill_group):
+                    raise ValueError(
+                        f"Group {i}: decode has {num_decode_blocks} "
+                        f"blocks but prefill has only "
+                        f"{len(prefill_group)}"
+                    )
                 if num_decode_blocks < len(prefill_group):
                     prefill_block_ids[i] = prefill_group[-num_decode_blocks:]
         else:
@@ -2459,10 +2464,12 @@ class NixlBaseConnectorWorker:
                     # already has (prefix hit) -> take its tail; a longer decode
                     # list holds the position D recomputes itself, which gets
                     # no prefill state.
-                    assert num_decode_blocks - num_prefill_blocks <= 1, (
-                        f"Group {i}: unpairable SSM state slots, "
-                        f"decode={num_decode_blocks} prefill={num_prefill_blocks}"
-                    )
+                    if num_decode_blocks - num_prefill_blocks > 1:
+                        raise ValueError(
+                            f"Group {i}: unpairable SSM state slots, "
+                            f"decode={num_decode_blocks} "
+                            f"prefill={num_prefill_blocks}"
+                        )
                     num_blocks = min(num_decode_blocks, num_prefill_blocks)
                     if num_decode_blocks < num_prefill_blocks:
                         prefill_block_ids[i] = prefill_group[-num_blocks:]
@@ -2484,10 +2491,11 @@ class NixlBaseConnectorWorker:
                     max_padding = (
                         decode_physical_per_logical + prefill_physical_per_logical
                     )
-                    assert abs(num_decode_blocks - num_prefill_blocks) <= max_padding, (
-                        f"Group {i}: |{num_decode_blocks} - "
-                        f"{num_prefill_blocks}| > {max_padding}"
-                    )
+                    if abs(num_decode_blocks - num_prefill_blocks) > max_padding:
+                        raise ValueError(
+                            f"Group {i}: |{num_decode_blocks} - "
+                            f"{num_prefill_blocks}| > {max_padding}"
+                        )
                     num_blocks = min(num_decode_blocks, num_prefill_blocks)
                     decode_block_ids[i] = decode_block_ids[i][:num_blocks]
                     prefill_block_ids[i] = prefill_group[:num_blocks]

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/pull_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/pull_worker.py
@@ -289,12 +289,23 @@ class NixlPullConnectorWorker(NixlBaseConnectorWorker):
             == len(local_block_ids)
             == len(self.kv_cache_config.kv_cache_groups)
         )
-        local_block_ids, remote_block_ids = self._apply_prefix_caching(
-            decode_block_ids=local_block_ids,
-            prefill_block_ids=remote_block_ids,
-            decode_physical_per_logical=self._physical_blocks_per_logical_kv_block,
-            prefill_physical_per_logical=remote_info.remote_physical_blocks_per_logical,
-        )
+        try:
+            local_block_ids, remote_block_ids = self._apply_prefix_caching(
+                decode_block_ids=local_block_ids,
+                prefill_block_ids=remote_block_ids,
+                decode_physical_per_logical=self._physical_blocks_per_logical_kv_block,
+                prefill_physical_per_logical=remote_info.remote_physical_blocks_per_logical,
+            )
+        except ValueError as e:
+            self._log_failure(
+                failure_type="block_validation_failed",
+                req_id=request_id,
+                msg="Remote/local block count mismatch",
+                error=e,
+                dst_engine_id=dst_engine_id,
+            )
+            self._handle_failed_transfer(request_id, None)
+            return
 
         # NOTE (nicolo) With homogeneous TP, each TP worker loads KV from
         # corresponding rank. With heterogeneous TP, fixing D>P, the D tp

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/push_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/push_worker.py
@@ -628,12 +628,23 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
         # Prefix caching: D allocated only uncached blocks, so on a partial hit it
         # sends fewer than P's. End-trim P's blocks to that same suffix so we WRITE only
         # the uncomputed tail into D's slots. Runs on kernel ids, post-expansion.
-        remote_block_ids, local_block_ids = self._apply_prefix_caching(
-            decode_block_ids=remote_block_ids,
-            prefill_block_ids=local_block_ids,
-            decode_physical_per_logical=remote_info.remote_physical_blocks_per_logical,
-            prefill_physical_per_logical=self._physical_blocks_per_logical_kv_block,
-        )
+        try:
+            remote_block_ids, local_block_ids = self._apply_prefix_caching(
+                decode_block_ids=remote_block_ids,
+                prefill_block_ids=local_block_ids,
+                decode_physical_per_logical=remote_info.remote_physical_blocks_per_logical,
+                prefill_physical_per_logical=self._physical_blocks_per_logical_kv_block,
+            )
+        except ValueError as e:
+            self._log_failure(
+                failure_type="block_validation_failed",
+                req_id=request_id,
+                msg="Remote/local block count mismatch",
+                error=e,
+                dst_engine_id=dst_engine_id,
+            )
+            self.xfer_stats.record_failed_transfer()
+            return None
 
         local_block_ids = list(local_block_ids)
         remote_block_ids = list(remote_block_ids)

--- a/vllm/entrypoints/openai/completion/serving.py
+++ b/vllm/entrypoints/openai/completion/serving.py
@@ -144,6 +144,13 @@ class OpenAIServingCompletion(GenerateBaseServing):
 
         engine_inputs = result
 
+        if len(engine_inputs) > 1 and request.kv_transfer_params:
+            return self.create_error_response(
+                "Multi-prompt completion requests are not supported "
+                "with disaggregated serving (kv_transfer_params). "
+                "Submit one prompt per request."
+            )
+
         request_id = f"cmpl-{self._base_request_id(raw_request, request.request_id)}"
         created_time = int(time.time())
 


### PR DESCRIPTION
## Summary

- **API guard:** Reject multi-prompt `/v1/completions` requests carrying `kv_transfer_params` with HTTP 400, preventing them from reaching the NIXL Decode worker where a block-count mismatch would crash the process (GHSA-6vh8-5j8f-m4vf).
- **Graceful error handling:** Replace 3 bare `assert` statements in `_apply_prefix_caching` with `ValueError` raises, and catch them in both `pull_worker._read_blocks` and `push_worker._xfer_blocks` to fail the individual request gracefully instead of terminating the worker.
- **Tests:** Updated existing SSM unpairable-slots test to expect `ValueError`, added a non-Mamba block-mismatch test, and added two API-guard tests (rejection + single-prompt allowed).

## Test plan

- [x] All 27 tests in `tests/entrypoints/openai/completion/test_completion_error.py` pass
- [x] All 64 non-network-dependent tests in `tests/v1/kv_connector/unit/test_nixl_connector_hma.py` pass
- [x] All pre-commit hooks pass (ruff, mypy, typos, markdownlint)


Made with [Cursor](https://cursor.com)