### PR TITLE
[Bugfix][Kernel] Hoist tensor-descriptor build out of unified-attention TD ti…

### DIFF
--- a/vllm/v1/attention/ops/triton_unified_attention.py
+++ b/vllm/v1/attention/ops/triton_unified_attention.py
@@ -15,6 +15,7 @@ import vllm.envs as envs
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
 from vllm.triton_utils import tl, triton
+from vllm.triton_utils.allocation import set_triton_allocator
 from vllm.v1.attention.ops.triton_attention_helpers import (
     apply_alibi_to_score,
     apply_softcap,
@@ -29,6 +30,10 @@ from vllm.v1.attention.ops.triton_attention_helpers import (
     store_segm_reduce_scalars,
 )
 from vllm.v1.kv_cache_interface import KVQuantMode
+
+# Devices already registered with set_triton_allocator(); avoids a redundant
+# call on every unified_attention() forward pass when USE_TD is on.
+_TD_ALLOCATOR_DEVICES: set[torch.device] = set()
 
 logger = init_logger(__name__)
 is_batch_invariant = envs.VLLM_BATCH_INVARIANT
@@ -105,41 +110,6 @@ def _load_q_td(
         block_shape=(BLOCK_Q, num_queries_per_kv * HEAD_SIZE_PADDED),
     )
     return q_desc.load([0, 0]).reshape(BLOCK_M, HEAD_SIZE_PADDED)
-
-
-@triton.jit
-def _load_kv_tile_td(
-    cache_ptr,
-    physical_block_idx_scalar,
-    kv_head_idx,
-    offset_in_block,
-    stride_cache_0: tl.int64,
-    stride_cache_1: tl.int64,
-    stride_cache_2: tl.int64,
-    stride_cache_3: tl.constexpr,
-    BLOCK_SIZE: tl.constexpr,
-    TILE_SIZE: tl.constexpr,
-    HEAD_SIZE: tl.constexpr,
-    HEAD_SIZE_PADDED: tl.constexpr,
-):
-    """Load a KV cache tile via tensor descriptor.
-
-    Returns shape (TILE_SIZE, HEAD_SIZE_PADDED). Caller transposes for K.
-    Tensor descriptors zero-pad reads beyond the shape boundary, so
-    ``HEAD_SIZE_PADDED > HEAD_SIZE`` is handled correctly.
-    """
-    base = (
-        cache_ptr
-        + physical_block_idx_scalar * stride_cache_0
-        + kv_head_idx * stride_cache_2
-    )
-    desc = tl.make_tensor_descriptor(
-        base=base,
-        shape=(BLOCK_SIZE, HEAD_SIZE),
-        strides=(stride_cache_1, stride_cache_3),
-        block_shape=(TILE_SIZE, HEAD_SIZE_PADDED),
-    )
-    return desc.load([offset_in_block, 0])
 
 
 @triton.jit
@@ -232,6 +202,10 @@ def kernel_unified_attention(
     stride_v_cache_1: tl.int64,  # int
     stride_v_cache_2: tl.int64,  # int
     stride_v_cache_3: tl.constexpr,  # int
+    # Block-table dim of the KV cache (``key_cache.shape[0]``). Only read
+    # when ``USE_TD`` — needed as the outer shape dim of the hoisted
+    # tensor descriptor built once before the tile loop.
+    num_kv_blocks,
     query_start_len_ptr,
     BLOCK_Q: tl.constexpr,
     num_seqs: tl.int32,
@@ -416,6 +390,23 @@ def kernel_unified_attention(
         CHUNK_SIZE,
     )
 
+    if USE_TD:
+        # Built once, outside the tile loop: must stay loop-invariant for
+        # the pipeliner to overlap iterations. Per-tile block is addressed
+        # via a load() coordinate rather than baked into the base.
+        k_tile_desc = tl.make_tensor_descriptor(
+            base=key_cache_ptr + kv_head_idx.to(tl.int64) * stride_k_cache_2,
+            shape=(num_kv_blocks, BLOCK_SIZE, HEAD_SIZE),
+            strides=(stride_k_cache_0, stride_k_cache_1, stride_k_cache_3),
+            block_shape=(1, TILE_SIZE, HEAD_SIZE_PADDED),
+        )
+        v_tile_desc = tl.make_tensor_descriptor(
+            base=value_cache_ptr + kv_head_idx.to(tl.int64) * stride_v_cache_2,
+            shape=(num_kv_blocks, BLOCK_SIZE, HEAD_SIZE),
+            strides=(stride_v_cache_0, stride_v_cache_1, stride_v_cache_3),
+            block_shape=(1, TILE_SIZE, HEAD_SIZE_PADDED),
+        )
+
     # iterate through tiles (now limited to the sliding window range)
     for j in range(loop_lo, loop_hi):
         seq_offset = j * TILE_SIZE + offs_t
@@ -429,41 +420,22 @@ def kernel_unified_attention(
             # All TILE_SIZE slots within a single KV tile map to one
             # physical block (guaranteed by ``BLOCK_SIZE % TILE_SIZE == 0``
             # from the static_assert above), so load the block index as
-            # a scalar instead of a broadcast reduction.
+            # a scalar instead of a broadcast reduction. Descriptor load
+            # coordinates must be int32.
             offset_in_block = (j * TILE_SIZE) % BLOCK_SIZE
             physical_block_scalar = tl.load(
                 block_tables_ptr + block_table_offset + (j * TILE_SIZE) // BLOCK_SIZE
-            ).to(tl.int64)
+            ).to(tl.int32)
             # K : (HEAD_SIZE, TILE_SIZE)
-            K_load = _load_kv_tile_td(
-                key_cache_ptr,
-                physical_block_scalar,
-                kv_head_idx,
-                offset_in_block,
-                stride_k_cache_0,
-                stride_k_cache_1,
-                stride_k_cache_2,
-                stride_k_cache_3,
-                BLOCK_SIZE,
-                TILE_SIZE,
-                HEAD_SIZE,
-                HEAD_SIZE_PADDED,
-            ).T
-            # V : (TILE_SIZE, HEAD_SIZE)
-            V_load = _load_kv_tile_td(
-                value_cache_ptr,
-                physical_block_scalar,
-                kv_head_idx,
-                offset_in_block,
-                stride_v_cache_0,
-                stride_v_cache_1,
-                stride_v_cache_2,
-                stride_v_cache_3,
-                BLOCK_SIZE,
-                TILE_SIZE,
-                HEAD_SIZE,
-                HEAD_SIZE_PADDED,
+            K_load = (
+                k_tile_desc.load([physical_block_scalar, offset_in_block, 0])
+                .reshape(TILE_SIZE, HEAD_SIZE_PADDED)
+                .T
             )
+            # V : (TILE_SIZE, HEAD_SIZE)
+            V_load = v_tile_desc.load(
+                [physical_block_scalar, offset_in_block, 0]
+            ).reshape(TILE_SIZE, HEAD_SIZE_PADDED)
         else:
             v_offset = (
                 physical_block_idx[:, None] * stride_v_cache_0
@@ -1087,6 +1059,15 @@ def unified_attention(
     if launch_num_stages is not None:
         launch_kwargs["num_stages"] = launch_num_stages
 
+    if (use_td or use_td_qo) and q.device not in _TD_ALLOCATOR_DEVICES:
+        # The hoisted 3D descriptor requires a PyTorch-backed scratch
+        # allocator to be registered (Triton raises "no allocator was
+        # set" otherwise on sm_100/sm_120). Same pattern as fused_moe /
+        # GDN / LoRA's TD paths; cached per device like the newer
+        # triton_scaled_mm TD path, since this call site is per-forward-pass.
+        set_triton_allocator(q.device)
+        _TD_ALLOCATOR_DEVICES.add(q.device)
+
     kernel_unified_attention[grid](
         output_ptr=out,
         segm_output_ptr=segm_output_ptr,
@@ -1143,6 +1124,7 @@ def unified_attention(
         stride_v_cache_1=v.stride(1),
         stride_v_cache_2=v.stride(2),
         stride_v_cache_3=v.stride(3),
+        num_kv_blocks=k.shape[0],
         stride_ks_blk=ks_blk,
         stride_ks_slot=ks_slot,
         stride_ks_head=ks_head,


### PR DESCRIPTION
## Summary

Part of the TD adoption strategy proposed in #42545. `USE_TD`'s K/V tile loader rebuilt the tensor descriptor every tile iteration, since the descriptor's `base` baked in the per-tile physical block index. That forces a `tensormap_create` per iteration, which the pipeliner can't predicate:



- On Hopper (sm_90), this only compiles at `num_stages=1`, costing roughly 50% throughput vs the raw-pointer default.
- On sm_100/sm_120, it fails to compile at all: `'ttng.tensormap_create' op pipeliner doesn't know how to predicate this op`.

## Fix

Move the loop-invariant `kv_head_idx` into the descriptor base and build one descriptor per K/V cache before the tile loop, addressing the per-tile physical block via a `load()` coordinate instead. This makes the descriptor loop-invariant, restoring `num_stages > 1` compilation on Hopper and fixing the sm_100/sm_120 compile failure outright.

The hoisted 3D descriptor also needs a registered scratch allocator on sm_100/sm_120 (`Kernel requires a runtime memory allocation, but no allocator was set` otherwise). Wired up `set_triton_allocator()`, matching the existing pattern in `fused_moe` / GDN / LoRA's TD paths, cached per device to avoid a redundant call on every forward pass.

## Testing

### Correctness

```
pytest tests/kernels/attention/test_triton_unified_attention.py -k use_td
```
`290 passed` on H100/H200.

### Throughput

`vllm bench throughput`, Qwen3-4B bf16, TRITON_ATTN, H100/H200:

| Workload | in/out | raw ptr | TD hoisted | hoisted/raw |
|---|---|---|---|---|
| prefill_heavy | 2048/128 | 17.57 req/s | 15.85 req/s | 0.90x |
| decode_heavy | 128/1024 | TBD | TBD | TBD |
| balanced | 1024/256 | 28.25 req/s | 25.13 req/s | 0.89x |

Repro:
```
COMMON="--model Qwen/Qwen3-4B --dtype bfloat16 --attention-config '{\"backend\":\"TRITON_ATTN\"}' --max-model-len 4096 --gpu-memory-utilization 0.85 --seed 42"
VLLM_TRITON_USE_TD=0 vllm bench throughput $COMMON --dataset-name random --random-input-len 2048 --random-output-len 128 --num-prompts 200
VLLM_TRITON_USE_TD=1 vllm bench throughput $COMMON --dataset-name random --random-input-len 2048 --random-output-len 128 --num-prompts 200
```

B200 (sm_100), same model/backend/workloads:

| Workload | in/out | raw ptr | TD hoisted | hoisted/raw |
|---|---|---|---|---|
| prefill_heavy | 2048/128 | 26.01 req/s | 22.05 req/s | 0.85x |
| decode_heavy | 128/1024 | 23.25 req/s | 17.98 req/s | 0.77x |
| balanced | 1024/256 | 40.22 req/s | 32.34 req/s | 0.80x |

Correctness on B200: `290 passed` as well, same suite. 

---

Note : triton-lang/triton#10281 (still open/unmerged upstream) fixes the underlying pipeliner predication issue directly. Tested whether that changes anything here, on stock Triton and on #10281's own Triton build, across all three architectures:

| GPU | raw pointer | hoisted TD | hoisted/raw |
|---|---|---|---|
| H200 (sm_90) | 29.35 [27.27, 29.36] | 26.20 [25.02, 26.26] | 0.893x |
| B200 (sm_100) | 44.61 [41.87, 44.62] | 33.87 [32.73, 34.19] | 0.759x |

Matches the baseline above, on SM120  hoisted TD still beats loop-local by 2.0%-16.7% even with #10281's fix, reaching 98.7%-99.7% of raw-pointer. 

---

cc: joint effort with @oonyshch @BabyDrangoner,coauthored the repro and root cause on H200/b200
