### PR TITLE
[Bugfix][ROCm] Disable skinny GEMM on gfx1151

### DIFF
--- a/tests/model_executor/layers/test_rocm_unquantized_gemm.py
+++ b/tests/model_executor/layers/test_rocm_unquantized_gemm.py
@@ -25,6 +25,7 @@ def test_rocm_unquantized_gemm_gfx1x_wvsplitk_path(monkeypatch):
     monkeypatch.setattr(utils.envs, "VLLM_ROCM_USE_SKINNY_GEMM", True)
     monkeypatch.setattr("vllm.platforms.rocm.on_gfx1x", lambda: True)
     monkeypatch.setattr("vllm.platforms.rocm.on_gfx9", lambda: False)
+    monkeypatch.setattr("vllm.platforms.rocm.on_gfx1151", lambda: False)
     monkeypatch.setattr("vllm.platforms.rocm.on_gfx950", lambda: False)
     monkeypatch.setattr("vllm.platforms.rocm.on_gfx1250", lambda: False)
     monkeypatch.setattr(utils, "num_compute_units", lambda: 120)
@@ -42,6 +43,36 @@ def test_rocm_unquantized_gemm_gfx1x_wvsplitk_path(monkeypatch):
     assert torch.allclose(out, ref, atol=1e-3, rtol=1e-3)
 
 
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_rocm_unquantized_gemm_gfx1151_falls_back(monkeypatch, dtype):
+    x = torch.randn(2, 64, dtype=dtype)
+    weight = torch.randn(128, 64, dtype=dtype)
+    ref = torch.nn.functional.linear(x, weight, None)
+
+    monkeypatch.setattr(utils, "use_aiter_triton_gemm", lambda *args: False)
+    monkeypatch.setattr(utils.envs, "VLLM_ROCM_USE_SKINNY_GEMM", True)
+    monkeypatch.setattr("vllm.platforms.rocm.on_gfx1x", lambda: True)
+    monkeypatch.setattr("vllm.platforms.rocm.on_gfx9", lambda: False)
+    monkeypatch.setattr("vllm.platforms.rocm.on_gfx1151", lambda: True)
+    monkeypatch.setattr("vllm.platforms.rocm.on_gfx950", lambda: False)
+    monkeypatch.setattr("vllm.platforms.rocm.on_gfx1250", lambda: False)
+    monkeypatch.setattr(utils, "num_compute_units", lambda: 120)
+
+    wvsplitk_mock = MagicMock(side_effect=lambda w, x_view, _, __: x_view @ w.t())
+    monkeypatch.setattr(utils.ops, "wvSplitK", wvsplitk_mock)
+    llmm1_mock = MagicMock(side_effect=lambda w, x_view, _: x_view @ w.t())
+    monkeypatch.setattr(utils.ops, "LLMM1", llmm1_mock)
+    linear_mock = MagicMock(side_effect=torch.nn.functional.linear)
+    monkeypatch.setattr(torch.nn.functional, "linear", linear_mock)
+
+    out = utils.rocm_unquantized_gemm_impl(x, weight, None)
+
+    wvsplitk_mock.assert_not_called()
+    llmm1_mock.assert_not_called()
+    linear_mock.assert_called_once()
+    assert torch.allclose(out, ref, atol=1e-3, rtol=1e-3)
+
+
 def test_rocm_unquantized_gemm_gfx1x_n_gt_5_falls_back(monkeypatch):
     # wvSplitK skinny GEMM handles n in [1, 5] (see PR #40687); n > 5 must
     # fall back to torch.nn.functional.linear.
@@ -52,6 +83,7 @@ def test_rocm_unquantized_gemm_gfx1x_n_gt_5_falls_back(monkeypatch):
     monkeypatch.setattr(utils.envs, "VLLM_ROCM_USE_SKINNY_GEMM", True)
     monkeypatch.setattr("vllm.platforms.rocm.on_gfx1x", lambda: True)
     monkeypatch.setattr("vllm.platforms.rocm.on_gfx9", lambda: False)
+    monkeypatch.setattr("vllm.platforms.rocm.on_gfx1151", lambda: False)
     monkeypatch.setattr("vllm.platforms.rocm.on_gfx950", lambda: False)
     monkeypatch.setattr("vllm.platforms.rocm.on_gfx1250", lambda: False)
     monkeypatch.setattr(utils, "num_compute_units", lambda: 120)
@@ -77,6 +109,7 @@ def test_rocm_unquantized_gemm_gfx950_wvsplitkrc_path(monkeypatch):
     monkeypatch.setattr(utils.envs, "VLLM_ROCM_USE_SKINNY_GEMM", True)
     monkeypatch.setattr("vllm.platforms.rocm.on_gfx1x", lambda: False)
     monkeypatch.setattr("vllm.platforms.rocm.on_gfx9", lambda: False)
+    monkeypatch.setattr("vllm.platforms.rocm.on_gfx1151", lambda: False)
     monkeypatch.setattr("vllm.platforms.rocm.on_gfx950", lambda: True)
     monkeypatch.setattr("vllm.platforms.rocm.on_gfx1250", lambda: True)
     monkeypatch.setattr(utils, "num_compute_units", lambda: 120)

--- a/vllm/model_executor/layers/utils.py
+++ b/vllm/model_executor/layers/utils.py
@@ -116,7 +116,13 @@ def use_aiter_triton_gemm(n, m, k, dtype):
 def rocm_unquantized_gemm_impl(
     x: torch.Tensor, weight: torch.Tensor, bias: torch.Tensor | None = None
 ) -> torch.Tensor:
-    from vllm.platforms.rocm import on_gfx1x, on_gfx9, on_gfx950, on_gfx1250
+    from vllm.platforms.rocm import (
+        on_gfx1x,
+        on_gfx9,
+        on_gfx950,
+        on_gfx1151,
+        on_gfx1250,
+    )
 
     n = x.numel() // x.size(-1)
     m = weight.shape[0]
@@ -170,7 +176,10 @@ def rocm_unquantized_gemm_impl(
     use_skinny = (
         envs.VLLM_ROCM_USE_SKINNY_GEMM
         and (on_gfx9() or on_gfx1x())
-        # build (gfx9/gfx11 ISA); fall back to torch GEMM there.
+        # gfx1151's wvSplitK route is pathologically slow; use torch GEMM.
+        and not on_gfx1151()
+        # gfx1250 lacks a compatible skinny GEMM build (gfx9/gfx11 ISA);
+        # fall back to torch GEMM there.
         # TODO GFX1250: Include once skinny GEMM is supported on gfx1250
         and x.dtype in [torch.float16, torch.bfloat16]
         and k % 8 == 0


### PR DESCRIPTION
## Purpose

ROCm's unquantized GEMM selector currently treats `gfx1151` as a generic
`gfx1x` target and selects `wvSplitK`/`LLMM1` for tiny-token FP16/BF16 GEMMs.
On Strix Halo this route is functionally correct but pathologically slow.

A fresh matched current-main A/B on an AMD Radeon 8060S compared upstream
`75231eff2` with this PR's `27a0ca2c0`. Both processes used
`VLLM_ROCM_USE_SKINNY_GEMM=1`; the source root was the only candidate delta.
Decode throughput improved from 0.266948 to 9.535182 tok/s (**35.719x**).
Response text, prompt/completion counts, and finish reason were identical.
CPU isolation passed at 86.73% and 85.83% idle, respectively, and the logs
showed no JIT/autotuning after either measured interval began.

An earlier matched discriminator independently improved from 0.268944 to
7.572491 tok/s (28.156x) when only `VLLM_ROCM_USE_SKINNY_GEMM=0` changed.
A five-step profile attributed 18.530975 seconds across 1,265 `wvSplitK`
calls, 97.7933% of active kernel time.

A short current-main hardware discriminator on the model's exact BF16 KDA
projection shape (`m=4096`, `k=2560`) corroborated the end-to-end result. With
seven timed repetitions, median `wvSplitK` latency was 12.1266 ms versus
0.044678 ms for `torch.linear` at `n=1` (271.42x), and 23.1280 ms versus
0.134596 ms at `n=2` (171.83x). The patched selector made zero `wvSplitK`
calls and matched `torch.linear` exactly. The live server reported zero running
or waiting requests immediately before and after this 9.1-second check.

This change makes the selector apply that known quirk automatically on exact
`gfx1151`. gfx9, other gfx1x, gfx950, gfx1250, CUDA, and non-ROCm behavior are
unchanged.

Duplicate search: GitHub issue/PR searches for `gfx1151 skinny GEMM`,
`gfx1151 wvSplitK`, and `skinny GEMM gfx11` returned no matching issue or PR on
August 8, 2026.

The fresh current-main base and patched measurements ran from
14:31:15.972–14:31:44.929 and 14:33:33.326–14:33:34.311 EDT, respectively, on
August 8. The earlier end-to-end measurement was completed on August 6 EDT,
and the direct hardware discriminator ran from 14:16:50.974 to 14:17:00.105
EDT on August 8. None overlaps the documented August 7 host-contamination
window.

## Test Plan

```bash
uv run --with tblib pytest -q \
  tests/model_executor/layers/test_rocm_unquantized_gemm.py

uv tool run --from ruff==0.14.0 ruff check \
  vllm/model_executor/layers/utils.py \
  tests/model_executor/layers/test_rocm_unquantized_gemm.py

uv tool run --from ruff==0.14.0 ruff format --check \
  vllm/model_executor/layers/utils.py \
  tests/model_executor/layers/test_rocm_unquantized_gemm.py
```

## Test Result

```text
5 passed, 14 warnings in 2.36s
All checks passed!
2 files already formatted
git diff --check: passed
pre-commit ruff-check: passed
pre-commit ruff-format: passed
pre-commit typos: passed
pre-commit mypy-3.10: passed
pre-commit check-spdx-header: passed
pre-commit check-root-lazy-imports: passed

current-main matched A/B:
  base 75231eff2: 0.266948 tok/s
  PR   27a0ca2c0: 9.535182 tok/s
  speedup: 35.719x
  response text and usage: identical
  CPU isolation: passed
  measured JIT/autotuning: none
```

The aggregate pre-commit command could not finish bootstrapping its unrelated
Markdown/Node environment because the host's Python CA chain rejected the Node
download. Every hook applicable to the two changed Python files was then run
individually and passed; certificate verification was not disabled.

The new test covers both FP16 and BF16. It verifies that exact `gfx1151`
bypasses `wvSplitK` and `LLMM1`, calls `torch.nn.functional.linear`, and matches
the reference result. Existing gfx1x `wvSplitK`, `n > 5` fallback, and gfx950
`wvSplitKrc` tests remain green.

## AI assistance

AI-assisted. The human submitter reviewed and understands every changed line
before this PR was marked ready. The reported tests and measurements were run
on CIRU. CIRU remains the sole author and DCO signatory.

---

<details>
<summary>Essential Elements of an Effective PR Description Checklist</summary>

- [x] Purpose and duplicate search included.
- [x] Focused test commands included.
- [x] Current unit-test and lint results included.
- [x] Current-main exact-shape hardware discriminator completed.
- [x] Current-main end-to-end hardware A/B completed.
- [x] Human line-by-line review completed.
</details>

