### PR TITLE
docs: Add source-level docstrings for NIXL stats and metrics (issue #…

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/metrics.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/metrics.py
@@ -20,8 +20,20 @@ class KVConnectorStats:
     """
     Base class for KV Connector Stats, a container for transfer performance
     metrics or otherwise important telemetry from the connector.
+
     All sub-classes need to be serializable as stats are sent from worker to
-    logger process.
+    logger process via IPC.
+
+    The stats pipeline works as follows:
+    1. **Worker (observe)**: Each TP rank records per-transfer telemetry via
+       connector-specific `record_*()` methods (e.g., `NixlKVConnectorStats.record_transfer()`).
+    2. **Worker → Logger (aggregate)**: Stats are serialized and sent to the logger.
+       The logger calls `aggregate()` to concatenate observations from all ranks
+       into a combined pool (using `list.extend()`).
+    3. **Logger (reduce)**: The logger periodically calls `reduce()` to compute
+       summary statistics (averages, percentiles, throughput) over the combined
+       pool for CLI logging and Prometheus metric emission.
+    4. **Logger (log)**: `KVConnectorLogging.log()` formats and emits the metrics.
     """
 
     data: dict[str, Any] = field(default_factory=dict)
@@ -33,24 +45,52 @@ class KVConnectorStats:
     def aggregate(self, other: "KVConnectorStats") -> "KVConnectorStats":
         """
         Aggregate stats with another `KVConnectorStats` object.
+
+        Combines observations from another instance (typically a different TP rank)
+        into this instance's observation pool. Subclasses should implement
+        concatenation logic (e.g., `list.extend()`).
         """
         raise NotImplementedError
 
     def reduce(self) -> dict[str, int | float]:
         """
         Reduce the observations collected during a time interval to one or
-        more representative values (eg avg/median/sum of the series).
+        more representative values (e.g., avg/median/sum of the series).
+
         This is meant to be called by the logger to produce a summary of the
-        stats for the last time interval.
+        stats for the last time interval. The summary is used for CLI logging
+        and Prometheus metric emission.
+
+        Subclasses should implement the specific reduction logic.
         """
         raise NotImplementedError
 
     def is_empty(self) -> bool:
-        """Return True if the stats are empty."""
+        """Return True if the stats are empty (no observations to report)."""
         raise NotImplementedError
 
 
 class KVConnectorLogging:
+    """
+    Handles the observe → aggregate → reduce → log pipeline for KV connector metrics.
+
+    This class manages the periodic logging of transfer metrics from the connector
+    to the logger process. It accumulates stats across logging intervals and
+    emits them via a configurable log function.
+
+    Pipeline:
+    1. **observe()**: Called periodically when the connector syncs with the scheduler.
+       Receives stats data already aggregated across all workers/ranks.
+       Creates/updates the internal `transfer_stats_accumulator` by aggregating
+       with the new data.
+    2. **log()**: Called periodically (on a separate logging interval) to emit
+       the accumulated metrics. Calls `reduce()` on the accumulator to produce
+       summary statistics, logs them, then resets for the next interval.
+
+    The stats data passed to `observe()` is expected to be pre-aggregated across
+    all TP ranks (i.e., the worker sends concatenated observations from all ranks).
+    """
+
     def __init__(self, kv_transfer_config: KVTransferConfig | None):
         # Instantiate the connector's stats class.
         if kv_transfer_config and kv_transfer_config.kv_connector:
@@ -108,8 +148,18 @@ class KVConnectorLogging:
 
 class KVConnectorPromMetrics:
     """
-    A base class for per-connector Prometheus metric registration
-    and recording.
+    A base class for per-connector Prometheus metric registration and recording.
+
+    Subclasses implement `observe()` to record transfer statistics to Prometheus
+    metrics (Gauge, Counter, Histogram). Metrics are registered per-engine
+    (using the 'engine' label) to support multi-engine deployments.
+
+    The metrics pipeline:
+    1. **Registration**: Connector-specific subclasses create metric instances
+       in `__init__` using `_gauge_cls`, `_counter_cls`, `_histogram_cls`.
+    2. **Recording**: `observe()` is called with transfer stats data and engine_idx
+       to update the appropriate metric instances.
+    3. **Scraping**: Prometheus scrapes metrics via the standard HTTP endpoint.
     """
 
     def __init__(
@@ -128,10 +178,15 @@ class KVConnectorPromMetrics:
 
     def observe(self, transfer_stats_data: dict[str, Any], engine_idx: int = 0):
         """
-        Record the supplied transfer statistics to Prometheus metrics. These
-        statistics are engine-specific, and should be recorded to a metric
+        Record the supplied transfer statistics to Prometheus metrics.
+
+        These statistics are engine-specific, and should be recorded to a metric
         with the appropriate 'engine' label. These metric instances can be
         created using the create_metric_per_engine() helper method.
+
+        Args:
+            transfer_stats_data: Aggregated stats data from all TP ranks.
+            engine_idx: Engine index for labeling metrics in multi-engine deployments.
         """
         raise NotImplementedError
 

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/stats.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/stats.py
@@ -23,7 +23,33 @@ if TYPE_CHECKING:
 
 @dataclass
 class NixlKVConnectorStats(KVConnectorStats):
-    """Container for transfer performance metrics"""
+    """
+    Container for NIXL KV cache transfer performance metrics.
+
+    This class collects per-transfer telemetry from each TP rank and aggregates
+    them for periodic logging and Prometheus metric emission.
+
+    IMPORTANT: Metrics Aggregation Semantics (Multi-Rank / TP > 1)
+    ---------------------------------------------------------------
+    In tensor-parallel deployments (TP > 1), each TP rank independently records
+    its own transfer telemetry via `record_transfer()`. The stats from all ranks
+    are then concatenated (via `aggregate()` using `list.extend()`) into a single
+    observation pool. The `reduce()` method computes summary statistics (averages,
+    percentiles, throughput) over this **combined pool of observations from all
+    ranks**.
+
+    This means the logged metrics represent **per-rank averages over the combined
+    observation pool**, NOT per-engine totals or aggregate system throughput.
+    Specifically:
+    - "Num successful transfers" = total count across all TP ranks
+    - "Avg MB per transfer" = average over all individual rank-level transfers
+    - "Throughput (MB/s)" = total_MB_all_ranks / total_time_all_ranks
+      (effectively an average per-rank throughput)
+    - Percentiles (P90) = computed over the combined distribution of all ranks
+
+    This design uses fire-and-forget reporting from workers; the logger receives
+    pre-aggregated stats and computes final summaries.
+    """
 
     def __post_init__(self):
         if not self.data:
@@ -31,18 +57,24 @@ class NixlKVConnectorStats(KVConnectorStats):
             self.reset()
 
     def reset(self):
-        # Must be serializable
+        # Must be serializable for IPC transmission from worker to logger.
         self.data: dict[str, list[float | int]] = {
-            "transfer_duration": [],
-            "post_duration": [],
-            "bytes_transferred": [],
-            "num_descriptors": [],
-            "num_failed_transfers": [],
-            "num_failed_notifications": [],
-            "num_kv_expired_reqs": [],
+            "transfer_duration": [],      # seconds; async data movement time (xferDuration)
+            "post_duration": [],          # seconds; RDMA post/submit time (postDuration)
+            "bytes_transferred": [],      # bytes; total bytes moved per transfer
+            "num_descriptors": [],        # count; RDMA work request descriptors used
+            "num_failed_transfers": [],   # count; failed transfer operations
+            "num_failed_notifications": [],  # count; failed send_notif calls
+            "num_kv_expired_reqs": [],    # count; requests with expired KV blocks (tracked on P)
         }
 
     def record_transfer(self, res: "nixlXferTelemetry"):
+        """Record a successful NIXL transfer's telemetry.
+
+        Args:
+            res: NIXL transfer telemetry containing duration, bytes, and descriptors.
+                 Time units are converted from microseconds to seconds for consistency.
+        """
         # Keep metrics units consistent with rest of the code: time us->s
         self.data["transfer_duration"].append(res.xferDuration / 1e6)
         self.data["post_duration"].append(res.postDuration / 1e6)
@@ -50,15 +82,19 @@ class NixlKVConnectorStats(KVConnectorStats):
         self.data["num_descriptors"].append(res.descCount)
 
     def record_failed_transfer(self):
-        """Record a failed NIXL transfer operation."""
+        """Record a failed NIXL transfer operation (data movement failure)."""
         self.data["num_failed_transfers"].append(1)
 
     def record_failed_notification(self):
-        """Record a failed NIXL notification (send_notif)."""
+        """Record a failed NIXL notification (send_notif failure, pre-transfer)."""
         self.data["num_failed_notifications"].append(1)
 
     def record_kv_expired_req(self):
-        """Record a request that had its KV blocks expire."""
+        """Record a request that had its KV blocks expire (lease timeout).
+
+        Tracked on the prefiller (P) instance when KV blocks are evicted before
+        the decoder can consume them.
+        """
         self.data["num_kv_expired_reqs"].append(1)
 
     def clone_and_reset(self) -> "NixlKVConnectorStats":
@@ -76,6 +112,12 @@ class NixlKVConnectorStats(KVConnectorStats):
         )
 
     def aggregate(self, other: KVConnectorStats) -> KVConnectorStats:
+        """
+        Aggregate stats from another instance (typically from a different TP rank).
+
+        Uses `list.extend()` to concatenate observations, building a combined pool
+        across all ranks. Called by the logger when collecting stats from workers.
+        """
         if not other.is_empty():
             for k, v in other.data.items():
                 accumulator = self.data[k]
@@ -84,6 +126,25 @@ class NixlKVConnectorStats(KVConnectorStats):
         return self
 
     def reduce(self) -> dict[str, int | float]:
+        """
+        Reduce collected observations to summary statistics for CLI logging.
+
+        Computes averages, percentiles, and throughput over the **combined pool
+        of observations from all TP ranks**. The returned dict represents
+        per-rank averages over the aggregated observation pool, NOT per-engine
+        totals or aggregate system throughput.
+
+        Returns:
+            Dict with keys:
+            - "Num successful transfers": total count across all ranks
+            - "Avg xfer time (ms)": mean transfer duration in milliseconds
+            - "P90 xfer time (ms)": 90th percentile transfer duration
+            - "Avg post time (ms)": mean RDMA post/submit time
+            - "P90 post time (ms)": 90th percentile post time
+            - "Avg MB per transfer": mean bytes per transfer (converted to MB)
+            - "Throughput (MB/s)": total_MB / total_time_seconds (per-rank average)
+            - "Avg number of descriptors": mean RDMA descriptors per transfer
+        """
         # Compute compact representative stats suitable for CLI logging
         if self.num_successful_transfers == 0:
             # CLI logging only reports successful transfers stats. If all requests in
@@ -130,6 +191,22 @@ class NixlKVConnectorStats(KVConnectorStats):
 
 
 class NixlPromMetrics(KVConnectorPromMetrics):
+    """
+    Prometheus metrics implementation for the NIXL KV connector.
+
+    Registers the following metrics (all per-engine via 'engine' label):
+    - vllm:nixl_xfer_time_seconds (Histogram): Transfer duration (async data movement)
+    - vllm:nixl_post_time_seconds (Histogram): RDMA post/submit time
+    - vllm:nixl_bytes_transferred (Histogram): Bytes moved per transfer
+    - vllm:nixl_num_descriptors (Histogram): RDMA work request descriptors per transfer
+    - vllm:nixl_num_failed_transfers (Counter): Failed transfer operations
+    - vllm:nixl_num_failed_notifications (Counter): Failed send_notif calls
+    - vllm:nixl_num_kv_expired_reqs (Counter): Requests with expired KV blocks (P instance)
+
+    Metrics are recorded from pre-aggregated stats data (combined across all TP ranks).
+    The observe() method processes each observation in the aggregated lists.
+    """
+
     def __init__(
         self,
         vllm_config: VllmConfig,
@@ -238,6 +315,19 @@ class NixlPromMetrics(KVConnectorPromMetrics):
         )
 
     def observe(self, transfer_stats_data: dict[str, Any], engine_idx: int = 0):
+        """
+        Record NIXL transfer statistics to Prometheus metrics.
+
+        Processes pre-aggregated stats data (combined across all TP ranks) and
+        updates the corresponding histograms and counters for the given engine.
+
+        Args:
+            transfer_stats_data: Dictionary containing lists of observations from
+                all TP ranks (keys: transfer_duration, post_duration,
+                bytes_transferred, num_descriptors, num_failed_transfers,
+                num_failed_notifications, num_kv_expired_reqs).
+            engine_idx: Engine index for multi-engine deployments (default 0).
+        """
         for prom_obj, list_item_key in zip(
             [
                 self.nixl_histogram_xfer_time,


### PR DESCRIPTION
…41230)

- NixlKVConnectorStats: Add comprehensive class docstring explaining metrics aggregation semantics for TP>1 deployments
- NixlKVConnectorStats: Document all methods with args, return values, and aggregation behavior
- NixlKVConnectorStats.reduce(): Explain per-rank average semantics vs system throughput
- KVConnectorStats: Add pipeline overview (observe → aggregate → reduce → log)
- KVConnectorLogging: Document observe/aggregate/reduce/log pipeline and pre-aggregated data expectation
- KVConnectorPromMetrics: Document Prometheus metrics pipeline and registration/recording
- NixlPromMetrics: Document all 7 metrics with types and descriptions
- NixlPromMetrics.observe(): Document pre-aggregated data processing

Addresses items 1-3 of #41230 (item 4 docs page already merged via #44055)




## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

