### PR TITLE
[Kernel][ROCm] Use naive block assignment for WNA16 MoE

### DIFF
--- a/tests/kernels/moe/test_moe.py
+++ b/tests/kernels/moe/test_moe.py
@@ -41,6 +41,9 @@ from vllm.model_executor.layers.fused_moe.experts.marlin_moe import (
     batched_fused_marlin_moe,
     fused_marlin_moe,
 )
+from vllm.model_executor.layers.fused_moe.fused_moe import (
+    _prepare_expert_assignment,
+)
 from vllm.model_executor.layers.fused_moe.utils import (
     moe_use_td_hw_supported,
 )
@@ -220,6 +223,31 @@ FUSED_MOE_WN16_MNK_FACTORS = [
 ]
 
 vllm_config = VllmConfig()
+
+
+@pytest.mark.parametrize(
+    ("use_int4_w4a16", "use_int8_w8a16"),
+    [(True, False), (False, True)],
+)
+def test_quantized_naive_block_assignment(use_int4_w4a16, use_int8_w8a16):
+    topk_ids = torch.tensor([[3, 7]], dtype=torch.int64)
+
+    sorted_token_ids, expert_ids, num_tokens_post_padded = _prepare_expert_assignment(
+        topk_ids,
+        {"BLOCK_SIZE_M": 16},
+        num_tokens=1,
+        top_k_num=2,
+        global_num_experts=64,
+        expert_map=None,
+        use_int4_w4a16=use_int4_w4a16,
+        use_int8_w8a16=use_int8_w8a16,
+        block_shape=[0, 64],
+        allow_quantized_naive_block_assignment=True,
+    )
+
+    assert sorted_token_ids is None
+    assert torch.equal(expert_ids, topk_ids.view(-1))
+    assert num_tokens_post_padded.item() == 32
 
 
 def run_moe_test(

--- a/vllm/model_executor/layers/fused_moe/experts/triton_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/triton_moe.py
@@ -24,9 +24,6 @@ from vllm.model_executor.layers.fused_moe.fused_moe import (
     invoke_fused_moe_wna16_triton_kernel,
     try_get_optimal_moe_config,
 )
-from vllm.model_executor.layers.fused_moe.moe_align_block_size import (
-    moe_align_block_size,
-)
 from vllm.model_executor.layers.fused_moe.topk_weight_and_reduce import (
     TopKWeightAndReduceNoOP,
 )
@@ -683,8 +680,19 @@ class TritonWNA16Experts(TritonExperts):
         )
         intermediate_cache3 = _resize_cache(workspace2, (num_tokens, top_k_num, K))
 
-        sorted_token_ids, expert_ids, num_tokens_post_padded = moe_align_block_size(
-            topk_ids, config["BLOCK_SIZE_M"], global_num_experts, expert_map
+        sorted_token_ids, expert_ids, num_tokens_post_padded = (
+            _prepare_expert_assignment(
+                topk_ids,
+                config,
+                num_tokens,
+                top_k_num,
+                global_num_experts,
+                expert_map,
+                use_int8_w8a16=self.quant_config.use_int8_w8a16,
+                use_int4_w4a16=self.quant_config.use_int4_w4a16,
+                block_shape=self.block_shape,
+                allow_quantized_naive_block_assignment=current_platform.is_rocm(),
+            )
         )
 
         invoke_fused_moe_wna16_triton_kernel(

--- a/vllm/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe.py
@@ -97,6 +97,7 @@ def fused_moe_kernel_gptq_awq(
     stride_bzn,
     block_k_diviable: tl.constexpr,
     group_size: tl.constexpr,
+    naive_block_assignment: tl.constexpr,
     # Meta-parameters
     BLOCK_SIZE_M: tl.constexpr,
     BLOCK_SIZE_N: tl.constexpr,
@@ -155,12 +156,17 @@ def fused_moe_kernel_gptq_awq(
     # and accumulate
     # `a_ptrs` is a block of [BLOCK_SIZE_M, BLOCK_SIZE_K] pointers
     # `b_ptrs` is a block of [BLOCK_SIZE_K, BLOCK_SIZE_N] pointers
-    num_tokens_post_padded = tl.load(num_tokens_post_padded_ptr)
-    if pid_m * BLOCK_SIZE_M >= num_tokens_post_padded:
-        return
-    offs_token_id = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M).to(tl.int64)
+    offs = tl.arange(0, BLOCK_SIZE_M).to(tl.int64)
+    if naive_block_assignment:
+        offs_token = tl.where(offs == 0, pid_m, num_valid_tokens)
+    else:
+        num_tokens_post_padded = tl.load(num_tokens_post_padded_ptr)
+        if pid_m * BLOCK_SIZE_M >= num_tokens_post_padded:
+            return
+        offs_token_id = pid_m * BLOCK_SIZE_M + offs
+        offs_token = tl.load(sorted_token_ids_ptr + offs_token_id)
     # Cast to int64 to prevent overflow in stride*offset products
-    offs_token = tl.load(sorted_token_ids_ptr + offs_token_id).to(tl.int64)
+    offs_token = offs_token.to(tl.int64)
     token_mask = offs_token < num_valid_tokens
 
     off_experts = tl.load(expert_ids_ptr + pid_m).to(tl.int64)
@@ -677,7 +683,7 @@ def invoke_fused_moe_wna16_triton_kernel(
     B_scale: torch.Tensor | None,
     B_zp: torch.Tensor | None,
     topk_weights: torch.Tensor | None,
-    sorted_token_ids: torch.Tensor,
+    sorted_token_ids: torch.Tensor | None,
     expert_ids: torch.Tensor,
     num_tokens_post_padded: torch.Tensor,
     mul_routed_weight: bool,
@@ -695,8 +701,11 @@ def invoke_fused_moe_wna16_triton_kernel(
     M = A.size(0)
     num_tokens = M * top_k
 
-    EM = sorted_token_ids.size(0)
-    if A.size(0) < config["BLOCK_SIZE_M"]:
+    if sorted_token_ids is None:
+        EM = num_tokens * config["BLOCK_SIZE_M"]
+    else:
+        EM = sorted_token_ids.size(0)
+    if sorted_token_ids is not None and A.size(0) < config["BLOCK_SIZE_M"]:
         # optimize for small batch_size.
         # We assume that top_ids of each token is unique,
         # so num_valid_experts <= batch_size <= BLOCK_SIZE_M,
@@ -756,6 +765,7 @@ def invoke_fused_moe_wna16_triton_kernel(
         has_zp=B_zp is not None,
         use_int4_w4a16=use_int4_w4a16,
         use_int8_w8a16=use_int8_w8a16,
+        naive_block_assignment=sorted_token_ids is None,
         **config,
     )
 
@@ -1547,6 +1557,7 @@ def _prepare_expert_assignment(
     use_int4_w4a16: bool = False,
     block_shape: list[int] | None = None,
     ignore_invalid_experts: bool = False,
+    allow_quantized_naive_block_assignment: bool = False,
 ) -> tuple[torch.Tensor | None, torch.Tensor, torch.Tensor]:
     """Prepare expert assignments for the aligned and low-latency Triton paths."""
     # SPARSITY_FACTOR is a heuristic margin ensuring tokens_in_chunk * top_k
@@ -1556,10 +1567,13 @@ def _prepare_expert_assignment(
     naive_block_assignment = (
         expert_map is None
         and num_tokens * top_k_num * 4 <= global_num_experts
-        and not (
-            (use_int8_w8a16 or use_int4_w4a16)
-            and block_shape is not None
-            and block_shape[1] > 0
+        and (
+            allow_quantized_naive_block_assignment
+            or not (
+                (use_int8_w8a16 or use_int4_w4a16)
+                and block_shape is not None
+                and block_shape[1] > 0
+            )
         )
     )
 


### PR DESCRIPTION
## Summary

ROCm GPTQ/AWQ WNA16 MoE currently always calls `moe_align_block_size`, even
when a very small decode batch activates only a sparse fraction of the expert
pool. vLLM's unquantized Triton MoE path already avoids that overhead with a
naive assignment mode in this regime.

This PR:

- enables the same existing sparsity heuristic for the ROCm WNA16 Triton path;
- adds direct route-list handling to `fused_moe_kernel_gptq_awq`;
- keeps CUDA, expert-parallel mappings, and non-sparse cases on the existing
  aligned path; and
- adds focused INT4 and INT8 routing coverage.

In naive mode, each program handles one routed token/expert pair. Lane zero is
valid and the remaining `BLOCK_SIZE_M - 1` lanes are masked. The change is
model-agnostic: it does not dispatch on model name, hidden size, expert count,
or other Ling-specific geometry.

## Performance evidence

A fresh matched current-main A/B on AMD Radeon 8060S / Strix Halo (`gfx1151`)
compared upstream `75231eff2` with this PR's `df4c60d38`. Three 32-token decode
rows per side improved median throughput from 9.212774 to 10.363958 tok/s
(**+12.50%**). Response text and usage were identical across all six rows.
The CPU-isolation gates were 92.026% and 92.029% idle, respectively.

Both servers used `VLLM_ROCM_USE_SKINNY_GEMM=0` to prevent the separate known
gfx1151 skinny-GEMM issue from obscuring this assignment-only comparison. JIT
warnings ended before either measured interval; no post-warmup JIT/autotuning,
preemption, HSA fault, device fault, or engine fault was observed.

The base and candidate intervals ran from 15:54:39.381–15:54:50.521 and
15:56:39.219–15:56:49.120 EDT, respectively, on August 8, 2026. They do not
overlap the documented August 7 host-contamination window.

Earlier matched Ling 3.0 Flash INT4/BF16 evidence changed only the assignment
route and improved median TG32 from 13.841172 to 17.000919 tok/s (+22.83%).
Seeded packed-INT4 W1/W2 fixtures were bitwise identical for unique and
duplicate expert IDs. The historical control has one retained row versus four
candidate rows, so the fresh current-main +12.50% result above is the primary
performance claim. A later 19.713926 tok/s result also included a separate
finalize-reduction change and is intentionally excluded from this PR's gain.

## Duplicate search

GitHub issue/PR searches on August 8, 2026 for `WNA16 naive block assignment`,
`WNA16 small token MoE`, and `fused_moe_kernel_gptq_awq alignment` found no
direct duplicate. Adjacent work includes the merged generic unquantized naive
assignment PR #29354, the gfx1100-only native HIP W4A16 PR #44075, and CUDA
small-batch alignment PR #44167. None enables this ROCm Triton WNA16 route.

## Tests

Current-main base: `75231eff2f3873e2bce7cc9558bb5227ea70b808`.

AMD Radeon 8060S / Strix Halo (`gfx1151`), ROCm 7.15, Triton 3.8:

```text
test_quantized_naive_block_assignment
  2 passed

test_fused_moe_wn16 focused GPU cases
  INT4 naive route: passed
  INT8 naive route: passed
  INT4 zero-point naive route: passed
  aligned fallback route: passed

pre-commit ruff-check: passed
pre-commit ruff-format: passed
pre-commit typos: passed
pre-commit mypy-3.10: passed
pre-commit check-spdx-header: passed
pre-commit check-root-lazy-imports: passed
pre-commit check-filenames: passed
pre-commit check-forbidden-imports: passed
pre-commit check-torch-cuda-call: passed
git diff --check: passed

fresh matched current-main A/B
  base 75231eff2:      9.212774 tok/s median
  candidate df4c60d38: 10.363958 tok/s median
  improvement:        +12.50%
  response text and usage: identical
  CPU isolation: passed
  measured JIT/autotuning: none
```

The aggregate pre-commit command could not bootstrap its unrelated
Markdown/Node environment because the host Python CA chain rejected the Node
download. Every hook applicable to the changed Python files was run
individually and passed; certificate verification was not disabled.

## Model evaluation

The patch changes assignment mechanics, not routing decisions, weights, or
numerics. Focused INT4, INT8, zero-point, and aligned-fallback GPU tests match
the existing reference path, and the retained full-model A/B produced
identical outputs.

## AI assistance

AI-assisted. The human submitter reviewed and understands every changed line.
CIRU is the sole author, committer, and DCO signatory.

<details>
<summary>PR readiness checklist</summary>

- [x] Purpose and platform scope documented.
- [x] Duplicate search completed.
- [x] Focused routing and `gfx1151` GPU tests completed.
- [x] Applicable Python pre-commit hooks completed.
- [x] Human line-by-line review completed.
- [x] Fresh matched current-main end-to-end A/B completed.

</details>
