### PR TITLE
[Bugfix][Frontend] Reject unsupported named tool_choice for Gemma 4

### DIFF
--- a/tests/tool_parsers/test_gemma4_named_tool_choice.py
+++ b/tests/tool_parsers/test_gemma4_named_tool_choice.py
@@ -1,0 +1,88 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Named tool choice for Gemma 4 must be rejected: the parser cannot force a
+specific function without JSON guided decoding, which conflicts with native
+``<|tool_call>`` syntax.
+"""
+
+import pytest
+
+from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
+from vllm.exceptions import VLLMValidationError
+from vllm.tool_parsers.gemma4_engine_tool_parser import Gemma4EngineToolParser
+
+
+class _DummyTokenizer:
+    _VOCAB = {
+        "<|tool_call>": 256_000,
+        "<tool_call|>": 256_001,
+        "<|channel>": 256_002,
+        "<channel|>": 256_003,
+    }
+
+    def get_vocab(self):
+        return dict(self._VOCAB)
+
+    @property
+    def all_special_tokens(self) -> list[str]:
+        return list(self._VOCAB.keys())
+
+    @property
+    def all_special_ids(self) -> list[int]:
+        return list(self._VOCAB.values())
+
+
+def _named_request() -> ChatCompletionRequest:
+    return ChatCompletionRequest(
+        model="gemma4",
+        messages=[{"role": "user", "content": "hi"}],
+        tools=[
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"city": {"type": "string"}},
+                        "required": ["city"],
+                    },
+                },
+            }
+        ],
+        tool_choice={"type": "function", "function": {"name": "get_weather"}},
+    )
+
+
+def _required_request() -> ChatCompletionRequest:
+    return ChatCompletionRequest(
+        model="gemma4",
+        messages=[{"role": "user", "content": "hi"}],
+        tools=[
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"city": {"type": "string"}},
+                        "required": ["city"],
+                    },
+                },
+            }
+        ],
+        tool_choice="required",
+    )
+
+
+def test_named_choice_rejected():
+    parser = Gemma4EngineToolParser(_DummyTokenizer())
+    with pytest.raises(VLLMValidationError, match="Named tool choice") as exc_info:
+        parser.adjust_request(_named_request())
+    assert exc_info.value.parameter == "tool_choice"
+
+
+def test_required_choice_still_skips_structured_outputs():
+    parser = Gemma4EngineToolParser(_DummyTokenizer())
+    req = parser.adjust_request(_required_request())
+    assert req.structured_outputs is None
+    assert req.skip_special_tokens is False

--- a/tests/tool_use/test_gemma4_responses_adjust_request.py
+++ b/tests/tool_use/test_gemma4_responses_adjust_request.py
@@ -22,21 +22,23 @@ calling for parsers relying on special-token delimiters (Gemma4):
    wrong-purpose string ``"Response format for tool calling"``.
 
 3. :class:`Gemma4EngineToolParser` (the engine-based parser, #45588) sets
-   ``supports_required_and_named=False`` but did not skip the forced
-   ``structured_outputs`` JSON for ``required``/named tool choice. The model
-   was constrained to JSON the native parser cannot read, so the call leaked
-   as content with empty ``tool_calls``. ``adjust_request`` now skips that
-   constraint so Gemma4 emits its native ``<|tool_call>`` syntax.
+   ``supports_required_and_named=False`` and skips the forced
+   ``structured_outputs`` JSON for ``required`` tool choice so Gemma4 emits
+   its native ``<|tool_call>`` syntax. Named tool choice cannot be enforced
+   without that JSON path, so ``adjust_request`` rejects it instead of
+   silently falling back to auto parsing (#50477).
 """
 
 from __future__ import annotations
 
 from typing import Any
 
+import pytest
 from openai.types.responses.tool_param import FunctionToolParam
 
 from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
 from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
+from vllm.exceptions import VLLMValidationError
 from vllm.tool_parsers.abstract_tool_parser import ToolParser
 from vllm.tool_parsers.gemma4_engine_tool_parser import (
     Gemma4EngineToolParser as Gemma4ToolParser,
@@ -186,19 +188,19 @@ def test_gemma4_required_skips_structured_outputs_chatcompletion() -> None:
     assert request.skip_special_tokens is False
 
 
-def test_gemma4_named_skips_structured_outputs_chatcompletion() -> None:
-    """named + ChatCompletion: the forced single-function JSON schema must be
-    skipped, same as ``required``.
+def test_gemma4_named_rejected_chatcompletion() -> None:
+    """named + ChatCompletion: Gemma4 cannot force a specific function, so
+    named tool_choice must fail loudly instead of silently returning prose.
     """
     parser = Gemma4ToolParser(_StubTokenizer())
     request = _build_chat_request(
         tool_choice={"type": "function", "function": {"name": "get_weather"}}
     )
 
-    parser.adjust_request(request)
+    with pytest.raises(VLLMValidationError, match="Named tool choice") as exc_info:
+        parser.adjust_request(request)
 
-    assert request.structured_outputs is None
-    assert request.skip_special_tokens is False
+    assert exc_info.value.parameter == "tool_choice"
 
 
 def test_gemma4_required_skips_structured_outputs_responses() -> None:
@@ -214,19 +216,19 @@ def test_gemma4_required_skips_structured_outputs_responses() -> None:
     assert request.skip_special_tokens is False
 
 
-def test_gemma4_named_skips_structured_outputs_responses() -> None:
-    """named (``ToolChoiceFunction``) + Responses: the forced single-function
-    JSON schema must be skipped.
+def test_gemma4_named_rejected_responses() -> None:
+    """named (``ToolChoiceFunction``) + Responses: reject instead of
+    silently ignoring the forced contract.
     """
     parser = Gemma4ToolParser(_StubTokenizer())
     request = _build_responses_request(
         tool_choice={"type": "function", "name": "get_weather"}
     )
 
-    parser.adjust_request(request)
+    with pytest.raises(VLLMValidationError, match="Named tool choice") as exc_info:
+        parser.adjust_request(request)
 
-    assert request.text is None
-    assert request.skip_special_tokens is False
+    assert exc_info.value.parameter == "tool_choice"
 
 
 def test_gemma4_keeps_special_tokens_with_tools_thinking_disabled() -> None:

--- a/vllm/tool_parsers/gemma4_engine_tool_parser.py
+++ b/vllm/tool_parsers/gemma4_engine_tool_parser.py
@@ -8,6 +8,7 @@ from vllm.entrypoints.openai.chat_completion.protocol import (
     ChatCompletionRequest,
 )
 from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
+from vllm.exceptions import VLLMValidationError
 from vllm.parser.engine.registered_adapters import Gemma4ParserToolAdapter
 
 
@@ -17,7 +18,7 @@ class Gemma4EngineToolParser(Gemma4ParserToolAdapter):  # type: ignore[valid-typ
     def adjust_request(
         self, request: ChatCompletionRequest | ResponsesRequest
     ) -> ChatCompletionRequest | ResponsesRequest:
-        """Skip structured-output JSON for required/named tool choice.
+        """Skip structured-output JSON for required tool choice.
 
         Gemma4 emits its native ``<|tool_call>call:...`` syntax, which the
         parser extracts directly. The base ``ToolParser.adjust_request`` would
@@ -25,12 +26,25 @@ class Gemma4EngineToolParser(Gemma4ParserToolAdapter):  # type: ignore[valid-typ
         decoding, conflicting with that native syntax (it leaks as content and
         crashes EngineCore under speculative decoding). Skip it so the model
         emits its native format (mirrors the GLM4 parser).
+
+        Named tool choice cannot be enforced without that JSON constraint (and
+        Gemma4 has no structural-tag equivalent), so reject it instead of
+        silently falling back to auto parsing.
         """
         if request.tools:
             tc = request.tool_choice
-            if tc == "required" or isinstance(
+            is_named = isinstance(
                 tc, (ChatCompletionNamedToolChoiceParam, ToolChoiceFunction)
-            ):
+            )
+            if is_named:
+                raise VLLMValidationError(
+                    "Named tool choice is not supported for the Gemma 4 tool "
+                    "parser because it cannot force a specific function call. "
+                    'Use `tool_choice` set to "auto", "required", or "none".',
+                    parameter="tool_choice",
+                    value=tc,
+                )
+            if tc == "required":
                 request.skip_special_tokens = False
                 return request
         return super().adjust_request(request)


### PR DESCRIPTION
## Purpose

Fixes #50477.

On v0.26.0, Chat Completions requests with a **named** forced `tool_choice` against `--tool-call-parser gemma4` return HTTP 200 with ordinary prose (`finish_reason: "stop"`, `tool_calls: null`). The forced contract is accepted and then silently not enforced.

`Gemma4EngineToolParser` sets `supports_required_and_named = False` and skips JSON guided decoding for forced tool choice (native `<|tool_call>` syntax conflicts with that path). Named choice then falls back to auto parsing with no way to force a specific function. This PR rejects named `tool_choice` with a clear `VLLMValidationError` (HTTP 400) instead of silently ignoring it — same pattern as Kimi K3 named-choice rejection.

`tool_choice: "required" | "auto" | "none"` is unchanged.

## Why this is not duplicating an existing PR

- No open/closed/merged PRs reference `#50477`.
- `#49785` rejects unsupported forced tool choice on the **Responses** API path for parsers with `supports_required_and_named=False`. This PR is Gemma4-specific on the shared `adjust_request` path (Chat Completions + Responses) and only rejects **named** choice, leaving working `required` behavior alone as reported in the issue.
- `#47512` / `#50180` skip generic JSON constraints for native parsers; they do not fail loud for unsupported named choice.

## Test Plan

```bash
.venv/bin/python -m pytest \
  tests/tool_parsers/test_gemma4_named_tool_choice.py \
  tests/tool_use/test_gemma4_responses_adjust_request.py \
  -v --tb=short --noconftest
```

Result: **10 passed**.

Also ran `ruff check` / `ruff format --check` on the touched files — clean.

No model eval required: this is request-validation only (rejects unsupported named `tool_choice` before generation); it does not change model outputs for accepted requests.

## AI assistance

AI assistance was used to implement and test this change. The submitting human reviewed every changed line and ran the tests above.