### PR TITLE
[KV Connector][NIXL] Support prefix caching with heterogeneous P/D logical block sizes

### DIFF
--- a/tests/v1/kv_connector/unit/test_nixl_connector_hma.py
+++ b/tests/v1/kv_connector/unit/test_nixl_connector_hma.py
@@ -455,62 +455,106 @@ def test_apply_prefix_caching_ssm_unpairable_slots_rejected():
 @pytest.mark.cpu_test
 @pytest.mark.parametrize(
     "local_physical_per_logical,remote_physical_per_logical,"
-    "remote_fa_blocks,local_fa_blocks,ssm_blocks,"
-    "correct_remote_fa,correct_local_fa",
+    "hit_tokens,total_tokens,"
+    "remote_fa_blocks,local_fa_blocks,"
+    "expected_remote_fa,expected_local_fa",
     [
-        # 10 kernel blocks of data (640 tokens).
+        # Kernel block = 64 tokens throughout. 640 tokens of data.
         # remote physical_per_logical=10 → 1 logical → 10 kernel [0..9]
         # local  physical_per_logical=6  → 2 logical → 12 kernel [0..11]
-        # 1st local logical block cached → suffix [6..11]
-        # Correct: transfer only uncached suffix tokens (384-639)
-        #   = remote [6,7,8,9] → local [6,7,8,9].
-        # Actual (front-trim): remote[:6]=[0..5] → local [6..11]. Wrong.
+        # 1st local logical block (384 tokens) cached → suffix [6..11].
+        # Transfer only the uncached suffix (tokens 384-639):
+        #   remote [6,7,8,9] → local [6,7,8,9].
         pytest.param(
             6,
             10,
-            [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+            384,
+            640,
+            list(range(10)),
             [6, 7, 8, 9, 10, 11],
-            [42],
             [6, 7, 8, 9],
             [6, 7, 8, 9],
-            id="local6_remote10_fail",
+            id="local6_remote10_hit",
         ),
-        # 15 kernel blocks of data (960 tokens).
+        # 960 tokens of data.
         # remote physical_per_logical=6  → 3 logical → 18 kernel [0..17]
         # local  physical_per_logical=10 → 2 logical → 20 kernel [0..19]
-        # 1st local logical block cached → suffix [10..19]
-        # Correct: transfer only uncached suffix tokens (640-959)
-        #   = remote [10,11,12,13,14] → local [10,11,12,13,14].
-        # Actual (front-trim): remote[:10]=[0..9] → local [10..19]. Wrong.
+        # 1st local logical block (640 tokens) cached → suffix [10..19].
+        # Transfer only tokens 640-959: remote [10..14] → local [10..14].
         pytest.param(
             10,
             6,
+            640,
+            960,
             list(range(18)),
             list(range(10, 20)),
-            [42],
             [10, 11, 12, 13, 14],
             [10, 11, 12, 13, 14],
-            id="local10_remote6_fail",
+            id="local10_remote6_hit",
+        ),
+        # No hit: the window starts at 0 and is capped to the actual data
+        # (640 tokens = 10 kernel blocks), not to list lengths.
+        pytest.param(
+            6,
+            10,
+            0,
+            640,
+            list(range(10)),
+            list(range(12)),
+            list(range(10)),
+            list(range(10)),
+            id="no_hit_data_cap",
+        ),
+        # Equal ppl with a hit but num_local >= num_remote (extra local
+        # allocation for the recomputed last token): the equal-ppl end-trim
+        # branch does not apply, and the legacy front-trim would silently
+        # pair remote prefix blocks with local suffix slots. 1280 tokens,
+        # 640 cached locally.
+        pytest.param(
+            10,
+            10,
+            640,
+            1280,
+            list(range(20)),
+            list(range(10, 30)),
+            list(range(10, 20)),
+            list(range(10, 20)),
+            id="equal_ppl_hit_extra_local_alloc",
+        ),
+        # Equal ppl with a hit and num_local < num_remote: the window
+        # takes precedence over the legacy end-trim and produces the same
+        # pairing when both sides allocated for the same token count.
+        pytest.param(
+            10,
+            10,
+            640,
+            1280,
+            list(range(20)),
+            list(range(10, 20)),
+            list(range(10, 20)),
+            list(range(10, 20)),
+            id="equal_ppl_hit_window_matches_end_trim",
         ),
     ],
 )
-def test_mismatched_physical_per_logical_fails_with_prefix_caching(
+def test_apply_prefix_caching_hetero_ppl_token_window(
     local_physical_per_logical,
     remote_physical_per_logical,
+    hit_tokens,
+    total_tokens,
     remote_fa_blocks,
     local_fa_blocks,
-    ssm_blocks,
-    correct_remote_fa,
-    correct_local_fa,
+    expected_remote_fa,
+    expected_local_fa,
 ):
-    """Demonstrate that _apply_prefix_caching front-trims ([:N])
-    in the Mamba hybrid path, which fails when prefix caching produces
-    suffix-only local blocks.
+    """FA kernel blocks are paired by token offset when the request's token
+    window is known, so a local prefix hit transfers only the uncached
+    suffix even when P and D logical block sizes differ.
 
-    Prefix caching operates at logical block granularity. When a logical
+    Prefix caching operates at logical block granularity: when a logical
     block is cached locally, the decode side only allocates kernel blocks
-    for the uncached suffix. The front-trim pairs remote prefix blocks
-    with local suffix slots — a silent data corruption.
+    for the uncached suffix, so the local list starts at the hit boundary
+    while the remote list starts at token 0.
     """
     from vllm.distributed.kv_transfer.kv_connector.v1.nixl.worker import (
         NixlConnectorWorker,
@@ -518,6 +562,7 @@ def test_mismatched_physical_per_logical_fails_with_prefix_caching(
 
     worker = object.__new__(NixlConnectorWorker)
     worker._physical_blocks_per_logical_kv_block = local_physical_per_logical
+    worker.block_size = 64  # kernel block size
     worker.kv_cache_config = make_kv_cache_config(
         block_size=16,
         mamba_enabled=True,
@@ -527,6 +572,7 @@ def test_mismatched_physical_per_logical_fails_with_prefix_caching(
         type(g.kv_cache_spec) for g in worker.kv_cache_config.kv_cache_groups
     )
 
+    ssm_blocks = [42]
     local_block_ids = (local_fa_blocks, ssm_blocks)
     remote_block_ids = (remote_fa_blocks, ssm_blocks)
 
@@ -535,16 +581,106 @@ def test_mismatched_physical_per_logical_fails_with_prefix_caching(
         remote_block_ids,
         local_physical_per_logical,
         remote_physical_per_logical,
+        num_local_computed_tokens=hit_tokens,
+        num_total_tokens=total_tokens,
     )
 
-    assert (
-        aligned_remote[0] != correct_remote_fa or aligned_local[0] != correct_local_fa
-    ), (
-        f"Prefix caching with mismatched physical_per_logical should not "
-        f"produce correct transfer ids: "
-        f"remote={aligned_remote[0]}, local={aligned_local[0]}, "
-        f"correct_remote={correct_remote_fa}, correct_local={correct_local_fa}"
+    assert aligned_remote[0] == expected_remote_fa, (
+        f"Expected remote {expected_remote_fa}, got {aligned_remote[0]}"
     )
+    assert aligned_local[0] == expected_local_fa, (
+        f"Expected local {expected_local_fa}, got {aligned_local[0]}"
+    )
+    # SSM slots pair positionally and are untouched by the FA window.
+    assert aligned_local[1] == ssm_blocks and aligned_remote[1] == ssm_blocks
+
+
+@pytest.mark.cpu_test
+def test_hetero_ppl_kernel_window_math():
+    """Window math: start at the kernel-aligned hit, span exactly the data;
+    lists that cannot cover the window or misaligned hits fail loudly
+    rather than silently shrinking the transfer."""
+    from vllm.distributed.kv_transfer.kv_connector.v1.nixl.worker import (
+        NixlConnectorWorker,
+    )
+
+    worker = object.__new__(NixlConnectorWorker)
+    worker.block_size = 64
+
+    # 640 data tokens, 384 cached: remote [6, 10), local [0, 4).
+    assert worker._hetero_ppl_kernel_window(6, 10, 384, 640) == (6, 4)
+    # Data cap: last remote logical block is rounding padding.
+    assert worker._hetero_ppl_kernel_window(12, 12, 0, 640) == (0, 10)
+    # Hit >= total: nothing to transfer.
+    assert worker._hetero_ppl_kernel_window(10, 10, 640, 640) == (10, 0)
+    # Remote list shorter than the data claims: the scheduler accounted
+    # for tokens the transfer would skip, so fail instead of clamping.
+    with pytest.raises(AssertionError, match="not covered"):
+        worker._hetero_ppl_kernel_window(10, 8, 0, 640)
+    # Same for a local list shorter than the data.
+    with pytest.raises(AssertionError, match="not covered"):
+        worker._hetero_ppl_kernel_window(8, 10, 0, 640)
+    # Hit must be kernel-block aligned.
+    with pytest.raises(AssertionError, match="kernel-block aligned"):
+        worker._hetero_ppl_kernel_window(10, 10, 100, 640)
+
+
+@pytest.mark.cpu_test
+def test_apply_prefix_caching_rank_sliced_empty_groups():
+    """Per-rank ReadSpecs zero out groups a source rank doesn't serve
+    (replicated MLA is read from one rank while SSM reads span all ranks);
+    the token window must skip such groups, not assert coverage."""
+    from vllm.distributed.kv_transfer.kv_connector.v1.nixl.worker import (
+        NixlConnectorWorker,
+    )
+    from vllm.v1.kv_cache_interface import FullAttentionSpec, MambaSpec
+
+    worker = object.__new__(NixlConnectorWorker)
+    worker._has_mamba = True
+    worker._physical_blocks_per_logical_kv_block = 96
+    worker.block_size = 64
+    worker._group_spec_types = (FullAttentionSpec, MambaSpec)
+
+    aligned_local, aligned_remote = worker._apply_prefix_caching(
+        ([], [7]),
+        ([], [3]),
+        96,
+        24,
+        num_local_computed_tokens=0,
+        num_total_tokens=960,
+    )
+    assert aligned_local == [[], [7]]
+    assert aligned_remote == [[], [3]]
+
+
+@pytest.mark.cpu_test
+def test_apply_prefix_caching_sw_group_skips_token_window():
+    """Sliding-window group lists are window-clipped and do not start at
+    token 0, so they must not take the token-offset pairing; they keep the
+    legacy end-trim."""
+    from vllm.distributed.kv_transfer.kv_connector.v1.nixl.worker import (
+        NixlConnectorWorker,
+    )
+    from vllm.v1.kv_cache_interface import MambaSpec, SlidingWindowSpec
+
+    worker = object.__new__(NixlConnectorWorker)
+    worker._has_mamba = True
+    worker._physical_blocks_per_logical_kv_block = 10
+    worker.block_size = 64
+    worker._group_spec_types = (SlidingWindowSpec, MambaSpec)
+
+    # Token window (0, 640) would select remote [0, 10); the SW group must
+    # instead end-trim to the local count.
+    aligned_local, aligned_remote = worker._apply_prefix_caching(
+        ([20, 21, 22, 23, 24], [42]),
+        (list(range(10)), [42]),
+        10,
+        10,
+        num_local_computed_tokens=0,
+        num_total_tokens=640,
+    )
+    assert aligned_local[0] == [20, 21, 22, 23, 24]
+    assert aligned_remote[0] == [5, 6, 7, 8, 9]
 
 
 @pytest.mark.parametrize("model_name, sw_size", [("google/gemma-3-1b-it", 512)])

--- a/tests/v1/kv_connector/unit/test_nixl_connector_hma.py
+++ b/tests/v1/kv_connector/unit/test_nixl_connector_hma.py
@@ -3,7 +3,7 @@
 """Unit tests for NixlConnectorScheduler with HMA and Mamba N-1 prefill."""
 
 import gc
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 import torch
@@ -1162,6 +1162,43 @@ def test_mamba_n1_d_side(has_mamba, is_hma_required, expected_count):
     count, is_async = sched.get_num_new_matched_tokens(req, num_computed_tokens=0)
     assert count == expected_count
     assert is_async is True
+
+
+@pytest.mark.cpu_test
+def test_pull_scheduler_propagates_prefix_token_window():
+    """The scheduler carries the block-aligned local hit and remote match
+    endpoint through connector metadata consumed by the pull worker."""
+
+    class FakeBlocks:
+        def get_unhashed_block_ids_all_groups(self):
+            return ([7, 8], [9])
+
+    sched = make_nixl_scheduler(
+        has_mamba=True,
+        is_hma_required=False,
+        heartbeat=True,
+    )
+    req = create_request(
+        num_tokens=65,
+        do_remote_prefill=True,
+        num_remote_blocks=4,
+    )
+    assert req.kv_transfer_params is not None
+    req.kv_transfer_params["remote_block_ids"] = ([1, 2], [3])
+
+    external_tokens, is_async = sched.get_num_new_matched_tokens(
+        req, num_computed_tokens=32
+    )
+    assert (external_tokens, is_async) == (32, True)
+
+    sched.update_state_after_alloc(req, FakeBlocks(), external_tokens)
+    metadata = sched.build_connector_meta(MagicMock())
+    req_meta = metadata.reqs_to_recv[req.request_id]
+
+    assert req_meta.num_local_computed_tokens == 32
+    assert req_meta.num_total_tokens == 64
+    assert req_meta.local_block_ids == ([7, 8], [9])
+    assert req.request_id not in sched._local_hit_tokens
 
 
 @pytest.mark.cpu_test

--- a/tests/v1/kv_connector/unit/test_nixl_desc_geometry.py
+++ b/tests/v1/kv_connector/unit/test_nixl_desc_geometry.py
@@ -98,7 +98,12 @@ class _RecordingNixl:
         pass
 
 
-def _make_mla_hybrid_worker(local_block_size, kernel_block_size, num_logical_blocks):
+def _make_mla_hybrid_worker(
+    local_block_size,
+    kernel_block_size,
+    num_logical_blocks,
+    enable_prefix_caching=False,
+):
     """Build a real pull worker with a hybrid MLA + 2xKDA HMA layout."""
     from vllm.distributed.kv_transfer.kv_connector.v1.nixl import (
         base_worker as bw,
@@ -146,7 +151,7 @@ def _make_mla_hybrid_worker(local_block_size, kernel_block_size, num_logical_blo
     )
 
     vllm_config = create_vllm_config(block_size=local_block_size)
-    vllm_config.cache_config.enable_prefix_caching = False
+    vllm_config.cache_config.enable_prefix_caching = enable_prefix_caching
     # kv_buffer_device defaults to the *real* platform's device type, which on
     # a CPU-only test host would make this a host-buffer worker: host xfer
     # buffers are per-layer, so the HMA shared-tensor regions this test builds
@@ -363,7 +368,13 @@ def _resolve(
 
 
 def _run_hetero_case(
-    local_block, kernel, remote_block, num_tokens, tp_size=2, remote_kernel=None
+    local_block,
+    kernel,
+    remote_block,
+    num_tokens,
+    tp_size=2,
+    remote_kernel=None,
+    hit_tokens=0,
 ):
     """Full pull-path run for one geometry; returns pairing records.
 
@@ -378,13 +389,15 @@ def _run_hetero_case(
     block_size_ratio = kernel // remote_kernel
     remote_ppl = remote_block // remote_kernel
     matched = num_tokens - 1  # mamba N-1 rule
-    n_local = -(-num_tokens // local_block)
+    assert hit_tokens % local_block == 0
+    n_local = -(-num_tokens // local_block) - hit_tokens // local_block
     n_remote = -(-matched // remote_block)
 
     worker = _make_mla_hybrid_worker(
         local_block_size=local_block,
         kernel_block_size=kernel,
         num_logical_blocks=max(2 * n_local + 4, 8),
+        enable_prefix_caching=hit_tokens > 0,
     )
     # Local KDA state pages are (48, 64) bytes; the remote holds 1/tp_size
     # shards of each.
@@ -416,6 +429,8 @@ def _run_hetero_case(
             "remote_port": 1234,
             "tp_size": tp_size,
         },
+        num_local_computed_tokens=hit_tokens,
+        num_total_tokens=matched,
     )
     meta = metadata.reqs_to_recv["req-b"]
     meta.local_physical_block_ids = worker._logical_to_kernel_block_ids(
@@ -476,17 +491,25 @@ def _run_hetero_case(
                 f"tokens {ltok} vs {rtok}"
             )
             if lkind == "attn":
-                assert ltok == rtok, (
+                assert hit_tokens + ltok == rtok, (
                     f"TOKEN MISALIGNMENT: local sub-block holds tokens "
-                    f"[{ltok}..) but receives remote tokens [{rtok}..) "
+                    f"[{hit_tokens + ltok}..) but receives remote tokens "
+                    f"[{rtok}..) "
                     f"(geometry local_block={local_block}, "
                     f"remote_block={remote_block}, N={num_tokens})"
                 )
-                covered_tokens.add(ltok)
+                covered_tokens.add(rtok)
 
     # Invariant 3: full coverage of the matched tokens, at the finest
     # transfer granularity (the remote kernel block).
-    needed = {t for t in range(0, matched - matched % remote_kernel, remote_kernel)}
+    needed = {
+        t
+        for t in range(
+            hit_tokens,
+            matched - matched % remote_kernel,
+            remote_kernel,
+        )
+    }
     missing = needed - covered_tokens
     assert not missing, (
         f"tokens never transferred: {sorted(missing)[:8]} "
@@ -511,7 +534,7 @@ def _run_hetero_case(
                     break
     done_sending, done_recving = worker.get_finished()
     assert "req-b" in done_recving
-    n_excluded = -(-matched // local_block)
+    n_excluded = -(-matched // local_block) - hit_tokens // local_block
     stale = []
     for b in local_attn[:n_excluded]:
         for region, t in enumerate(worker._test_tensors):
@@ -524,6 +547,28 @@ def _run_hetero_case(
         f"blocks (region, block, bytes): {stale} "
         f"(geometry local_block={local_block}, remote_block={remote_block}, "
         f"N={num_tokens}, matched={matched})"
+    )
+
+
+@pytest.mark.cpu_test
+@pytest.mark.parametrize(
+    "local_block,remote_block,num_tokens,hit_tokens",
+    [
+        (24, 40, 65, 24),
+        (40, 24, 97, 40),
+    ],
+)
+def test_hetero_ppl_partial_prefix_hit_end_to_end(
+    local_block, remote_block, num_tokens, hit_tokens
+):
+    """A block-aligned local hit selects the matching remote suffix, writes
+    only within the newly allocated local blocks, and zeroes their padding."""
+    _run_hetero_case(
+        local_block=local_block,
+        kernel=4,
+        remote_block=remote_block,
+        num_tokens=num_tokens,
+        hit_tokens=hit_tokens,
     )
 
 

--- a/tests/v1/kv_connector/unit/utils.py
+++ b/tests/v1/kv_connector/unit/utils.py
@@ -514,6 +514,7 @@ def make_nixl_scheduler(
     sched = object.__new__(NixlConnectorScheduler)
     sched._has_mamba = has_mamba
     sched._is_hma_required = is_hma_required
+    sched._local_hit_tokens = {}
 
     if heartbeat:
         sched._heartbeat_by_engine = {}

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_scheduler.py
@@ -104,7 +104,10 @@ class NixlBaseConnectorScheduler:
         # Requests that need to start recv/send.
         # New requests are added by update_state_after_alloc in
         # the scheduler. Used to make metadata passed to Worker.
-        self._reqs_need_recv: dict[ReqId, tuple[Request, BlockIds]] = {}
+        # req -> (request, local_block_ids, local_hit_tokens, total_tokens);
+        # the token window aligns kernel blocks when P/D logical block
+        # sizes differ; (0, 0) = unknown.
+        self._reqs_need_recv: dict[ReqId, tuple[Request, BlockIds, int, int]] = {}
         self._reqs_need_save: dict[ReqId, Request] = {}
         # Reqs to send and their expiration time
         self._reqs_need_send: dict[ReqId, float] = {}
@@ -441,12 +444,19 @@ class NixlBaseConnectorScheduler:
         meta = NixlConnectorMetadata()
 
         # Loop through scheduled reqs and convert to ReqMeta.
-        for req_id, (req, block_ids) in self._reqs_need_recv.items():
+        for req_id, (
+            req,
+            block_ids,
+            hit_tokens,
+            total_tokens,
+        ) in self._reqs_need_recv.items():
             assert req.kv_transfer_params is not None
             meta.add_new_req_to_recv(
                 request_id=req_id,
                 local_block_ids=block_ids,
                 kv_transfer_params=req.kv_transfer_params,
+                num_local_computed_tokens=hit_tokens,
+                num_total_tokens=total_tokens,
             )
 
         if self.use_host_buffer:

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_worker.py
@@ -48,6 +48,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.nixl.stats import (
 from vllm.distributed.kv_transfer.kv_connector.v1.nixl.tp_mapping import (
     TPMapping,
     _is_attention_spec,
+    _is_full_attention_spec,
     _is_ssm_spec,
     compute_tp_mapping,
 )
@@ -67,6 +68,7 @@ from vllm.distributed.parallel_state import (
 )
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
+from vllm.utils.math_utils import cdiv
 from vllm.utils.network_utils import make_zmq_path
 from vllm.utils.torch_utils import async_tensor_h2d
 from vllm.v1.attention.backends.utils import get_kv_cache_layout
@@ -89,6 +91,11 @@ logger = init_logger(__name__)
 
 class NixlBaseConnectorWorker:
     """Base implementation of Worker side methods shared by pull and push."""
+
+    # Whether the transfer path pairs FA kernel blocks by token offset when
+    # P/D logical block sizes differ (pull READ path only), enabling prefix
+    # caching with heterogeneous physical_blocks_per_logical.
+    _supports_hetero_ppl_prefix_caching = False
 
     def _compute_desc_ids(
         self,
@@ -1729,13 +1736,48 @@ class NixlBaseConnectorWorker:
             != self._physical_blocks_per_logical_kv_block
             and self.vllm_config.cache_config.enable_prefix_caching
         ):
-            raise RuntimeError(
+            # Supported on the pull path: FA transfers pair kernel blocks by
+            # token offset (_apply_prefix_caching), so P and D only need the
+            # same kernel block size, and SSM state positions must align.
+            base_err = (
                 "Prefix caching with heterogeneous physical_blocks_per_logical "
-                "is not supported for Mamba hybrid models. "
-                f"Local: {self._physical_blocks_per_logical_kv_block}, "
-                f"Remote: {remote_physical_per_logical}. "
-                "Disable prefix caching with --no-enable-prefix-caching."
+                f"(local: {self._physical_blocks_per_logical_kv_block}, "
+                f"remote: {remote_physical_per_logical}) "
             )
+            if not self._supports_hetero_ppl_prefix_caching or self.use_host_buffer:
+                raise RuntimeError(
+                    base_err + "is only supported by the pull-mode NIXL "
+                    "connector without a host buffer. Disable prefix caching "
+                    "with --no-enable-prefix-caching."
+                )
+            if block_size_ratio != 1:
+                raise RuntimeError(
+                    base_err + "requires matching kernel block sizes. "
+                    f"Local: {self.block_size}, "
+                    f"remote: {nixl_agent_meta.block_size}."
+                )
+            if any(
+                _is_attention_spec(t) and not _is_full_attention_spec(t)
+                for t in self._group_spec_types
+            ):
+                # SW group block lists are window-clipped and don't start at
+                # token 0, which the offset pairing assumes.
+                raise RuntimeError(
+                    base_err + "is not supported with sliding-window attention groups."
+                )
+            if self.vllm_config.cache_config.mamba_cache_mode == "all":
+                # "all" keeps local positional state slots at
+                # mamba_block_size (== logical block size) granularity,
+                # which differs between P and D here, so position-wise slot
+                # pairing would mismatch. Only the puller's own mode
+                # matters: a positional remote tail-pairs correctly onto a
+                # single-state local slot (its last slot is the running
+                # state), so the remote mode needs no validation.
+                raise RuntimeError(
+                    base_err + "requires a single-state local mamba cache "
+                    "mode ('align' or 'none'); 'all' keeps positional "
+                    "state slots."
+                )
 
         if block_size_ratio != 1:
             # Heterogeneous block sizes transfer at remote-block granularity;
@@ -2096,8 +2138,8 @@ class NixlBaseConnectorWorker:
             # transfer clipped. The latter happens either at remote-block
             # granularity (block_size_ratio > 1) or at kernel-block
             # granularity, when equal kernel pages meet differing logical
-            # block sizes and _apply_prefix_caching front-trims to the
-            # minimum count (hybrid heterogeneous TP).
+            # block sizes and _apply_prefix_caching pairs an offset window
+            # (or legacy-front-trims to the minimum count).
             remote_info = self.transfer_topo.get_engine_info(meta.remote.engine_id)
             block_size_ratio = self.transfer_topo.block_size_ratio(
                 remote_info.remote_block_size
@@ -2106,16 +2148,33 @@ class NixlBaseConnectorWorker:
                 remote_info.remote_physical_blocks_per_logical
                 != self._physical_blocks_per_logical_kv_block
             )
-            if block_size_ratio > 1 or self.enable_permute_local_kv or hetero_ppl:
+            windowed = (
+                self._has_mamba and meta.num_total_tokens > 0 and block_size_ratio == 1
+            )
+            if (
+                block_size_ratio > 1
+                or self.enable_permute_local_kv
+                or hetero_ppl
+                or windowed
+            ):
                 for g, local_group in enumerate(meta.local_physical_block_ids):
                     if not local_group or _is_ssm_spec(self._group_spec_types[g]):
                         continue
                     # Number of remote-sized sub-blocks the transfer covered;
                     # everything past this was clipped and must be zeroed.
-                    covered_sub_blocks = min(
-                        len(local_group) * block_size_ratio,
-                        len(meta.remote.block_ids[g]),
-                    )
+                    # Must mirror the pairing in _apply_prefix_caching.
+                    if windowed and _is_full_attention_spec(self._group_spec_types[g]):
+                        _, covered_sub_blocks = self._hetero_ppl_kernel_window(
+                            len(local_group),
+                            len(meta.remote.block_ids[g]),
+                            meta.num_local_computed_tokens,
+                            meta.num_total_tokens,
+                        )
+                    else:
+                        covered_sub_blocks = min(
+                            len(local_group) * block_size_ratio,
+                            len(meta.remote.block_ids[g]),
+                        )
                     block_ids_for_blocksize_post_process[block_size_ratio].append(
                         (local_group, covered_sub_blocks)
                     )
@@ -2395,12 +2454,48 @@ class NixlBaseConnectorWorker:
                 )
         return physical_block_ids
 
+    def _hetero_ppl_kernel_window(
+        self,
+        num_local_blocks: int,
+        num_remote_blocks: int,
+        num_local_computed_tokens: int,
+        num_total_tokens: int,
+    ) -> tuple[int, int]:
+        """Kernel-block window for a full-attention group when P/D logical
+        block sizes differ but the kernel block size matches (enforced at
+        handshake).
+
+        Local blocks start at the logical-block-aligned local prefix hit;
+        remote blocks start at token 0. Returns (start, count): remote
+        kernel blocks [start, start+count) pair 1:1 with local kernel
+        blocks [0, count). Both lists must cover the window: silently
+        transferring less than the scheduler accounted for would leave
+        holes in the KV cache.
+        """
+        assert num_local_computed_tokens % self.block_size == 0, (
+            f"Local prefix hit ({num_local_computed_tokens}) must be "
+            f"kernel-block aligned (kernel block size {self.block_size})"
+        )
+        start = num_local_computed_tokens // self.block_size
+        count = max(cdiv(num_total_tokens, self.block_size) - start, 0)
+        assert count == 0 or (
+            num_local_blocks >= count and num_remote_blocks >= start + count
+        ), (
+            f"Transfer window [{start}, {start + count}) not covered by "
+            f"block lists (local={num_local_blocks}, "
+            f"remote={num_remote_blocks})"
+        )
+        return start, count
+
     def _apply_prefix_caching(
         self,
         decode_block_ids: BlockIds,
         prefill_block_ids: BlockIds,
         decode_physical_per_logical: int,
         prefill_physical_per_logical: int,
+        num_local_computed_tokens: int = 0,
+        num_total_tokens: int = 0,
+        block_size_ratio: int = 1,
     ) -> tuple[BlockIds, BlockIds]:
         """Trim block ID lists so only the uncomputed suffix is transferred.
 
@@ -2416,9 +2511,14 @@ class NixlBaseConnectorWorker:
         For non-Mamba models: end-trim ``prefill`` to match ``decode`` count, so
         already-cached prefix blocks are skipped in the transfer.
 
-        For Mamba hybrid: SSM groups pair state slots by position and FA
-        groups end-trim to the uncomputed suffix when physical-per-logical
-        matches.
+        For Mamba hybrid: full-attention groups pair kernel blocks by token
+        offset when the request's token window is known
+        (num_total_tokens > 0), which supports partial local prefix hits
+        with heterogeneous P/D logical block sizes. Sliding-window groups
+        and legacy metadata keep the older heuristics: end-trim prefill on an
+        equal-ppl partial hit, else front-trim both to the minimum count
+        (which only handles kernel block count discrepancies from logical
+        block rounding in heterogeneous TP).
         """
         # Partial prefix cache hit: just transfer uncomputed blocks.
         # Skip mamba groups — their blocks represent full state (conv+ssm),
@@ -2449,6 +2549,11 @@ class NixlBaseConnectorWorker:
             for i, prefill_group in enumerate(prefill_block_ids):
                 num_decode_blocks = len(decode_block_ids[i])
                 num_prefill_blocks = len(prefill_group)
+                if num_decode_blocks == 0 and num_prefill_blocks == 0:
+                    # Per-rank ReadSpecs zero out groups this source rank
+                    # doesn't serve (e.g. the replicated MLA group is read
+                    # from a single rank while SSM reads span all ranks).
+                    continue
                 if _is_ssm_spec(self._group_spec_types[i]):
                     if num_decode_blocks == num_prefill_blocks:
                         continue
@@ -2469,18 +2574,40 @@ class NixlBaseConnectorWorker:
                     else:
                         decode_block_ids[i] = decode_block_ids[i][:num_blocks]
                 elif (
+                    num_total_tokens > 0
+                    and block_size_ratio == 1
+                    and _is_full_attention_spec(self._group_spec_types[i])
+                ):
+                    # Pair kernel blocks by token offset: decode blocks start
+                    # at the local prefix hit, prefill blocks at token 0.
+                    # Full attention only: SW group lists are window-clipped
+                    # and do not start at token 0. Handles heterogeneous
+                    # logical block sizes, and subsumes the end-trim below —
+                    # which mispairs whenever P and D allocated for
+                    # different token counts (turn-2 readback).
+                    start, count = self._hetero_ppl_kernel_window(
+                        num_decode_blocks,
+                        num_prefill_blocks,
+                        num_local_computed_tokens,
+                        num_total_tokens,
+                    )
+                    decode_block_ids[i] = decode_block_ids[i][:count]
+                    prefill_block_ids[i] = prefill_group[start : start + count]
+                elif (
                     decode_physical_per_logical == prefill_physical_per_logical
                     and num_decode_blocks < num_prefill_blocks
                 ):
-                    # Partial prefix cache hit for FA group.
+                    # Partial prefix cache hit for FA group (legacy metadata
+                    # without a token window, or non-full-attention group).
                     prefill_block_ids[i] = prefill_group[-num_decode_blocks:]
                 else:
-                    # TODO Handle prefix caching with different block_sizes
-                    # Allocation rounding legitimately leaves up to
-                    # ppl - 1 trailing dead kernel blocks per side (plus one
-                    # extra decode block for the recomputed final token), so
-                    # the counts may differ by up to the sum of the two
-                    # ratios; anything larger indicates mismatched lists.
+                    # Legacy front-trim (no token window in metadata): only
+                    # correct with no local prefix hit. Allocation rounding
+                    # legitimately leaves up to ppl - 1 trailing dead kernel
+                    # blocks per side (plus one extra decode block for the
+                    # recomputed final token), so the counts may differ by up
+                    # to the sum of the two ratios; anything larger indicates
+                    # mismatched lists.
                     max_padding = (
                         decode_physical_per_logical + prefill_physical_per_logical
                     )

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/metadata.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/metadata.py
@@ -219,6 +219,13 @@ class ReqMeta:
     remote_block_size: int | None = None
     # Remote producer pipeline-parallel size (push mode, D side).
     pp_size: int = 1
+    # Pull-mode token window: tokens [0, num_local_computed_tokens) are
+    # already cached locally (logical-block aligned local prefix hit);
+    # tokens [num_local_computed_tokens, num_total_tokens) are loaded
+    # from the remote. The worker uses these to align kernel-block
+    # windows when P and D logical block sizes differ. 0 = unknown.
+    num_local_computed_tokens: int = 0
+    num_total_tokens: int = 0
 
 
 class NixlConnectorMetadata(KVConnectorMetadata):
@@ -272,8 +279,12 @@ class NixlConnectorMetadata(KVConnectorMetadata):
         request_id: ReqId,
         local_block_ids: BlockIds,
         kv_transfer_params: dict[str, Any],
+        num_local_computed_tokens: int = 0,
+        num_total_tokens: int = 0,
     ):
         req = self._add_new_req(local_block_ids, kv_transfer_params)
+        req.num_local_computed_tokens = num_local_computed_tokens
+        req.num_total_tokens = num_total_tokens
         req.remote = RemoteMeta(
             block_ids=kv_transfer_params["remote_block_ids"],
             engine_id=kv_transfer_params["remote_engine_id"],

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/pull_scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/pull_scheduler.py
@@ -30,6 +30,11 @@ class NixlPullConnectorScheduler(NixlBaseConnectorScheduler):
         kv_cache_config: "KVCacheConfig",
     ):
         super().__init__(vllm_config, engine_id, kv_cache_config)
+        # Block-aligned local prefix hit per request, recorded in
+        # get_num_new_matched_tokens and consumed in
+        # update_state_after_alloc. The worker needs it to align
+        # kernel-block windows when P and D logical block sizes differ.
+        self._local_hit_tokens: dict[str, int] = {}
 
     def get_num_new_matched_tokens(
         self, request: "Request", num_computed_tokens: int
@@ -56,6 +61,8 @@ class NixlPullConnectorScheduler(NixlBaseConnectorScheduler):
             num_computed_tokens,
             params,
         )
+        if params:
+            self._local_hit_tokens[request.request_id] = num_computed_tokens
 
         if params is not None and params.get("do_remote_prefill"):
             # Remote prefill: get all prompt blocks from remote.
@@ -119,6 +126,7 @@ class NixlPullConnectorScheduler(NixlBaseConnectorScheduler):
             num_external_tokens,
             params,
         )
+        local_hit_tokens = self._local_hit_tokens.pop(request.request_id, 0)
 
         if not params:
             return
@@ -164,6 +172,8 @@ class NixlPullConnectorScheduler(NixlBaseConnectorScheduler):
                     self._reqs_need_recv[request.request_id] = (
                         request,
                         local_block_ids,
+                        local_hit_tokens,
+                        local_hit_tokens + num_external_tokens,
                     )
 
                 else:
@@ -197,6 +207,8 @@ class NixlPullConnectorScheduler(NixlBaseConnectorScheduler):
             request.status,
             params,
         )
+        # Requests aborted before allocation never consumed their stash.
+        self._local_hit_tokens.pop(request.request_id, None)
         if not params:
             return False, None
 
@@ -216,7 +228,7 @@ class NixlPullConnectorScheduler(NixlBaseConnectorScheduler):
             # To avoid stranding the prefill blocks in the prefill instance,
             # we must add empty block_ids to _reqs_need_recv so that our
             # worker side will notify and free blocks in the prefill instance.
-            self._reqs_need_recv[request.request_id] = (request, [])
+            self._reqs_need_recv[request.request_id] = (request, [], 0, 0)
             params["do_remote_prefill"] = False
             return False, None
 

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/pull_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/pull_worker.py
@@ -31,6 +31,8 @@ _KV_BLOCKS_EXPIRY_SAFETY_MARGIN = 5.0
 class NixlPullConnectorWorker(NixlBaseConnectorWorker):
     """Pull-specific (READ) worker logic."""
 
+    _supports_hetero_ppl_prefix_caching = True
+
     def __init__(
         self,
         vllm_config: "VllmConfig",
@@ -211,6 +213,8 @@ class NixlPullConnectorWorker(NixlBaseConnectorWorker):
                 remote_request_id=meta.remote.request_id,
                 local_xfer_side_handle=local_xfer_side_handle,
                 remote_xfer_side_handle=remote_xfer_side_handle,
+                num_local_computed_tokens=meta.num_local_computed_tokens,
+                num_total_tokens=meta.num_total_tokens,
             )
 
         if self.use_mla and tp_ratio < 0 and len(read_specs) == 1:
@@ -230,6 +234,8 @@ class NixlPullConnectorWorker(NixlBaseConnectorWorker):
         remote_request_id: str,
         local_xfer_side_handle: int,
         remote_xfer_side_handle: int,
+        num_local_computed_tokens: int = 0,
+        num_total_tokens: int = 0,
     ):
         """
         Post a READ point-to-point xfer request from a single local worker to
@@ -294,6 +300,9 @@ class NixlPullConnectorWorker(NixlBaseConnectorWorker):
             prefill_block_ids=remote_block_ids,
             decode_physical_per_logical=self._physical_blocks_per_logical_kv_block,
             prefill_physical_per_logical=remote_info.remote_physical_blocks_per_logical,
+            num_local_computed_tokens=num_local_computed_tokens,
+            num_total_tokens=num_total_tokens,
+            block_size_ratio=block_size_ratio,
         )
 
         # NOTE (nicolo) With homogeneous TP, each TP worker loads KV from

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/push_scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/push_scheduler.py
@@ -199,7 +199,7 @@ class NixlPushConnectorScheduler(NixlBaseConnectorScheduler):
         # ReqMeta without a KeyError — the actual remote block IDs are
         # learned by P over the NIXL handshake at WRITE time.
         params["remote_block_ids"] = ()
-        self._reqs_need_recv[request.request_id] = (request, local_block_ids)
+        self._reqs_need_recv[request.request_id] = (request, local_block_ids, 0, 0)
 
         # Mark as processed so a re-entry (e.g. preemption + reschedule)
         # doesn't re-stage the registration.
@@ -241,7 +241,7 @@ class NixlPushConnectorScheduler(NixlBaseConnectorScheduler):
             # recv so the worker emits a notif that lets P free them.
             # Seed remote_block_ids so add_new_req_to_recv won't KeyError.
             params["remote_block_ids"] = ()
-            self._reqs_need_recv[request.request_id] = (request, [])
+            self._reqs_need_recv[request.request_id] = (request, [], 0, 0)
             params["do_remote_prefill"] = False
             return False, None
 

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/tp_mapping.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/tp_mapping.py
@@ -12,7 +12,12 @@ from vllm.distributed.kv_transfer.kv_connector.utils import (
     BlockIds,
     TransferTopology,
 )
-from vllm.v1.kv_cache_interface import AttentionSpec, KVCacheSpec, MambaSpec
+from vllm.v1.kv_cache_interface import (
+    AttentionSpec,
+    FullAttentionSpec,
+    KVCacheSpec,
+    MambaSpec,
+)
 
 # ======================================================================
 # Data structures
@@ -30,6 +35,10 @@ class ReadSpec:
 
 def _is_attention_spec(spec_type: type[KVCacheSpec]) -> bool:
     return issubclass(spec_type, AttentionSpec)
+
+
+def _is_full_attention_spec(spec_type: type[KVCacheSpec]) -> bool:
+    return issubclass(spec_type, FullAttentionSpec)
 
 
 def _is_ssm_spec(spec_type: type[KVCacheSpec]) -> bool:


### PR DESCRIPTION
## Summary

- Support pull-mode NIXL prefix caching for hybrid Mamba/MLA deployments whose P/D logical block sizes differ but kernel block sizes match.
- Align full-attention transfers by token offset, zero untransferred tails, and keep unsupported push, host-buffer, sliding-window, kernel-mismatch, and positional-Mamba cases fail-closed.

## Validation

- `test_nixl_desc_geometry.py`: 199 passed
- `test_nixl_connector_hma.py`: 70 passed, 1 GPU test deselected
- `test_nixl_push_connector.py`: 41 passed
- Changed-file pre-commit hooks and Python 3.12 mypy passed
- Model evaluation: pending; this draft must not be marked ready until the heterogeneous K3 P/D evaluation is complete.

## Duplicate check

Open-PR searches found no implementation of this NIXL alignment fix. #45804 is complementary: it changes core per-group prefix-hit accounting, while this PR changes NIXL descriptor pairing and handshake behavior for heterogeneous P/D logical pages; the diffs do not overlap.

## AI assistance

AI assistance was used for implementation, tests, review, and documentation. The human submitter is responsible for reviewing every changed line and defending the change end-to-end.
