### PR TITLE
[K3] Allow tpu to import kimi_k3.common

### DIFF
--- a/vllm/models/kimi_k3/__init__.py
+++ b/vllm/models/kimi_k3/__init__.py
@@ -13,13 +13,20 @@ from vllm.platforms import current_platform
 
 # The NVIDIA branch is the static default that type-checkers see; the ROCm
 # branch overrides it at runtime (kept type-compatible via type: ignore).
-if TYPE_CHECKING or not current_platform.is_rocm():
+# TPU plugins import the shared ``common`` modules through this package, but
+# register their own model classes. Do not eagerly import a GPU implementation.
+if TYPE_CHECKING:
     from .nvidia.model import KimiK3ForConditionalGeneration, KimiLinearForCausalLM
     from .nvidia.mtp import KimiK3MTP
-else:
+elif current_platform.device_type == "tpu":
+    pass
+elif current_platform.is_rocm():
     from .amd.linear import KimiLinearForCausalLM  # type: ignore[assignment]
     from .amd.model import KimiK3ForConditionalGeneration  # type: ignore[assignment]
     from .amd.mtp import KimiK3MTP  # type: ignore[assignment]
+else:
+    from .nvidia.model import KimiK3ForConditionalGeneration, KimiLinearForCausalLM
+    from .nvidia.mtp import KimiK3MTP
 
 __all__ = [
     "KimiK3ForConditionalGeneration",


### PR DESCRIPTION
## Purpose

TPU platform plugins reuse Kimi K3's shared multimodal preprocessing while
registering their own model implementations. Avoid eagerly importing a GPU
implementation when the active platform's device type is TPU.

CUDA and ROCm model selection remains unchanged.

## Not a duplicate

PR #51196 disables dynamic `torch.compile` for the Kimi vision encoder on TPU;
it does not address eager GPU model imports from the Kimi K3 package. Searches
for open PRs covering Kimi K3 TPU package imports found no duplicate.

## Testing

```text
uvx --from 'pre-commit>=4.5.1' pre-commit run --files vllm/models/kimi_k3/__init__.py
All applicable hooks passed.

git diff --check
Passed.
```

A TPU import smoke test confirmed that shared Kimi K3 preprocessing can be
imported without loading the NVIDIA or AMD model packages.

## AI assistance

AI assistance was used to review the change and prepare this description. I
reviewed every changed line and can explain and defend the change end-to-end.
