### PR TITLE
Fix missing q_scale fallback for FP8 KV cache

### DIFF
--- a/vllm/model_executor/layers/quantization/kv_cache.py
+++ b/vllm/model_executor/layers/quantization/kv_cache.py
@@ -96,6 +96,7 @@ class BaseKVCacheMethod(QuantizeMethodBase):
         # regardless whether the kv-scale is available in the checkpoint.
         # No need to process kv scales after loading if we are going to
         # calculate them on the fly.
+        fallback_q_scale: float | None = None
         if is_quantized_kv_cache(layer.kv_cache_dtype):
             if layer.k_scale > 0.0 and layer.v_scale > 0.0:
                 # We prefer to use separate k_scale and v_scale if present
@@ -132,8 +133,7 @@ class BaseKVCacheMethod(QuantizeMethodBase):
                     "Setting it to k_scale. This only matters for "
                     "FP8 Attention backends (flash-attn or flashinfer)."
                 )
-                layer._q_scale.copy_(k_scale)
-                layer._q_scale_float = k_scale
+                fallback_q_scale = k_scale
 
             # These are used in the final Attention.forward()
             layer._k_scale.copy_(k_scale)
@@ -154,6 +154,8 @@ class BaseKVCacheMethod(QuantizeMethodBase):
             q_scale = layer.q_scale
             if current_platform.is_fp8_fnuz():
                 q_scale *= 2
+        elif fallback_q_scale is not None:
+            q_scale = fallback_q_scale
         else:
             q_scale = 1.0
         if layer.prob_scale > 0.0:


### PR DESCRIPTION
## Purpose

Fix the missing `q_scale` fallback for quantized KV caches.

When a checkpoint provides `k_scale` and `v_scale` but omits `q_scale`, `process_weights_after_loading()` logs that it will use `k_scale`. The method previously wrote that fallback directly to `layer._q_scale`, then later recomputed `q_scale` from the still-invalid `layer.q_scale` parameter and overwrote the fallback with `1.0`.

This change preserves `k_scale` as a local fallback and applies it during the method's final, canonical `q_scale` assignment. This matters for FP8 attention backends such as FlashAttention and FlashInfer.

## Test Plan

- Run a minimal `BaseKVCacheMethod` probe on an NVIDIA GeForce RTX 4090 against vLLM main `f8d03e77416bf90c49acbe50e233275722f02c4b` with `k_scale=0.25`, `v_scale=0.5`, and an omitted `q_scale`.
- Run Ruff on the modified production file.
- Compile the modified Python file.

## Test Result

Before:

```text
expected q_scale: 0.25
final q_scale:    1.0
fallback overwritten: true
```

After:

```text
expected q_scale: 0.25
final q_scale:    0.25
fallback overwritten: false
```

Additional checks:

```text
uvx ruff check vllm/model_executor/layers/quantization/kv_cache.py
All checks passed!

python3 -m compileall -q vllm/model_executor/layers/quantization/kv_cache.py
passed
```
