### PR TITLE
[Frontend] Support allowed_tools in Rust chat requests

### DIFF
--- a/rust/src/server/src/routes/openai/chat_completions/convert.rs
+++ b/rust/src/server/src/routes/openai/chat_completions/convert.rs
@@ -14,7 +14,8 @@ use crate::error::{ApiError, bail_invalid_request, chat_submit_error};
 use crate::lora::LoraModelResolution;
 use crate::routes::openai::utils::structured_outputs::convert_from_response_format;
 use crate::routes::openai::utils::types::{
-    ChatMessage, ContentPart, MessageContent, Tool, ToolChoice, ToolChoiceValue, ToolReference,
+    AllowedTools, AllowedToolsMode, ChatMessage, ContentPart, MessageContent, Tool, ToolChoice,
+    ToolChoiceValue, ToolReference,
 };
 use crate::utils::{
     ResolvedRequestContext, convert_logit_bias, merge_ec_transfer_params, merge_kv_transfer_params,
@@ -82,7 +83,18 @@ pub(super) fn prepare_chat_request(
         .echo
         .then(|| extract_last_assistant_content(&request.messages))
         .flatten();
-    let messages: Vec<_> = request.messages.into_iter().map(convert_message).try_collect()?;
+    let allowed_tools = match request.tool_choice.as_ref() {
+        Some(ToolChoice::AllowedTools { allowed_tools, .. }) => Some(allowed_tools),
+        _ => None,
+    };
+    let tools = convert_tools(request.tools)?;
+    validate_allowed_tools(&tools, allowed_tools)?;
+    let tools = filter_allowed_tools(tools, allowed_tools);
+    let messages: Vec<_> = request
+        .messages
+        .into_iter()
+        .map(|message| convert_message_with_allowed_tools(message, allowed_tools))
+        .try_collect()?;
     let generation_prompt_mode = normalize_generation_prompt_mode(
         request.add_generation_prompt,
         request.continue_final_message,
@@ -132,7 +144,7 @@ pub(super) fn prepare_chat_request(
 
     let tool_context = ResolvedToolContext::new(
         &messages,
-        convert_tools(request.tools)?,
+        tools,
         request.tool_choice.as_ref().map(convert_tool_choice).transpose()?,
         request.parallel_tool_calls.unwrap_or(true),
     )
@@ -259,6 +271,13 @@ fn extract_last_assistant_content(messages: &[ChatMessage]) -> Option<String> {
 
 /// Lower one OpenAI chat message into the `vllm-chat` message shape.
 pub(crate) fn convert_message(message: ChatMessage) -> Result<VllmChatMessage, ApiError> {
+    convert_message_with_allowed_tools(message, None)
+}
+
+fn convert_message_with_allowed_tools(
+    message: ChatMessage,
+    allowed_tools: Option<&AllowedTools>,
+) -> Result<VllmChatMessage, ApiError> {
     match message {
         ChatMessage::System { content, .. } => {
             Ok(VllmChatMessage::system(convert_content(content)?))
@@ -306,7 +325,7 @@ pub(crate) fn convert_message(message: ChatMessage) -> Result<VllmChatMessage, A
             name: _,
         } => Ok(VllmChatMessage::developer(
             convert_content(content)?,
-            convert_message_tools(tools)?,
+            convert_message_tools(tools, allowed_tools)?,
         )),
     }
 }
@@ -400,8 +419,56 @@ pub(crate) fn convert_tools(tools: Option<Vec<Tool>>) -> Result<Vec<ChatTool>, A
         .collect()
 }
 
-fn convert_message_tools(tools: Option<Vec<Tool>>) -> Result<Option<Vec<ChatTool>>, ApiError> {
-    let tools = convert_tools(tools)?;
+fn filter_allowed_tools(
+    tools: Vec<ChatTool>,
+    allowed_tools: Option<&AllowedTools>,
+) -> Vec<ChatTool> {
+    let Some(allowed_tools) = allowed_tools else {
+        return tools;
+    };
+
+    tools
+        .into_iter()
+        .filter(|tool| {
+            allowed_tools.tools.iter().any(|allowed_tool| match allowed_tool {
+                ToolReference::Function { function } => tool.name == function.name,
+            })
+        })
+        .collect()
+}
+
+fn validate_allowed_tools(
+    tools: &[ChatTool],
+    allowed_tools: Option<&AllowedTools>,
+) -> Result<(), ApiError> {
+    let Some(allowed_tools) = allowed_tools else {
+        return Ok(());
+    };
+
+    if matches!(allowed_tools.mode, AllowedToolsMode::Required) && allowed_tools.tools.is_empty() {
+        bail_invalid_request!(
+            "Invalid value for 'tool_choice.allowed_tools.tools': 'required' mode requires at least one allowed function."
+        );
+    }
+
+    for tool_ref in &allowed_tools.tools {
+        let ToolReference::Function { function } = tool_ref;
+        if !tools.iter().any(|tool| tool.name == function.name) {
+            bail_invalid_request!(
+                "Invalid value for 'tool_choice.allowed_tools.tools': tool '{}' not found in 'tools'.",
+                function.name
+            );
+        }
+    }
+
+    Ok(())
+}
+
+fn convert_message_tools(
+    tools: Option<Vec<Tool>>,
+    allowed_tools: Option<&AllowedTools>,
+) -> Result<Option<Vec<ChatTool>>, ApiError> {
+    let tools = filter_allowed_tools(convert_tools(tools)?, allowed_tools);
     Ok((!tools.is_empty()).then_some(tools))
 }
 
@@ -416,10 +483,11 @@ fn convert_tool_choice(tool_choice: &ToolChoice) -> Result<ChatToolChoice, ApiEr
         } if tool_type == "function" => Ok(ChatToolChoice::Function {
             name: function.name.clone(),
         }),
-        ToolChoice::AllowedTools { tools, .. } => bail_invalid_request!(
-            "allowed_tools tool_choice is not supported yet: {}.",
-            tools.iter().map(ToolReference::identifier).join(", ")
-        ),
+        ToolChoice::AllowedTools { allowed_tools, .. } => match &allowed_tools.mode {
+            AllowedToolsMode::Auto if allowed_tools.tools.is_empty() => Ok(ChatToolChoice::None),
+            AllowedToolsMode::Auto => Ok(ChatToolChoice::Auto),
+            AllowedToolsMode::Required => Ok(ChatToolChoice::Required),
+        },
         _ => bail_invalid_request!("tool_choice={:?} is not supported yet.", tool_choice),
     }
 }
@@ -441,15 +509,16 @@ mod tests {
     use vllm_text::{Prompt, output::TextDecodeOptions};
     use vllm_tokenizer::{Tokenizer, test_utils::TestTokenizer};
 
-    use super::prepare_chat_request;
+    use super::{convert_message_with_allowed_tools, prepare_chat_request};
     use crate::lora::LoraModelResolution;
     use crate::routes::openai::chat_completions::types::{
         AssistantRole, ChatCompletionMessage, ChatCompletionRequest,
     };
     use crate::routes::openai::utils::structured_outputs::{JsonSchemaFormat, ResponseFormat};
     use crate::routes::openai::utils::types::{
-        AudioUrl, ChatMessage, ContentPart, Function, FunctionCallResponse, ImageUrl, InputAudio,
-        MessageContent, StreamOptions, Tool, ToolCall, ToolChoice, ToolChoiceValue, VideoUrl,
+        AllowedTools, AllowedToolsChoiceType, AllowedToolsMode, AudioUrl, ChatMessage, ContentPart,
+        Function, FunctionCallResponse, FunctionChoice, ImageUrl, InputAudio, MessageContent,
+        StreamOptions, Tool, ToolCall, ToolChoice, ToolChoiceValue, ToolReference, VideoUrl,
     };
     use crate::utils::{ResolvedRequestContext, resolve_request_context};
 
@@ -473,6 +542,35 @@ mod tests {
             }],
             stream: true,
             ..Default::default()
+        }
+    }
+
+    fn function_tool(name: &str) -> Tool {
+        Tool {
+            tool_type: "function".to_string(),
+            function: Function {
+                name: name.to_string(),
+                description: None,
+                parameters: json!({"type": "object"}),
+                strict: None,
+            },
+        }
+    }
+
+    fn allowed_tools_choice(mode: AllowedToolsMode, names: &[&str]) -> ToolChoice {
+        ToolChoice::AllowedTools {
+            tool_type: AllowedToolsChoiceType::AllowedTools,
+            allowed_tools: AllowedTools {
+                mode,
+                tools: names
+                    .iter()
+                    .map(|name| ToolReference::Function {
+                        function: FunctionChoice {
+                            name: (*name).to_string(),
+                        },
+                    })
+                    .collect(),
+            },
         }
     }
 
@@ -1179,7 +1277,7 @@ mod tests {
             }]),
             tool_choice: Some(ToolChoice::Function {
                 tool_type: "function".to_string(),
-                function: crate::routes::openai::utils::types::FunctionChoice {
+                function: FunctionChoice {
                     name: "get_weather".to_string(),
                 },
             }),
@@ -1200,6 +1298,340 @@ mod tests {
             }
         );
         assert!(prepared.options.is_named_tool_choice);
+    }
+
+    #[test]
+    fn prepare_chat_request_filters_allowed_tools_in_declaration_order() {
+        let request = ChatCompletionRequest {
+            messages: vec![ChatMessage::Developer {
+                content: MessageContent::Text("developer instructions".to_string()),
+                tools: Some(vec![
+                    function_tool("developer_news"),
+                    function_tool("developer_time"),
+                    function_tool("developer_weather"),
+                ]),
+                name: None,
+            }],
+            tools: Some(vec![
+                function_tool("get_weather"),
+                function_tool("get_news"),
+                function_tool("get_time"),
+            ]),
+            tool_choice: Some(allowed_tools_choice(
+                AllowedToolsMode::Auto,
+                &["get_time", "get_weather"],
+            )),
+            ..base_request()
+        };
+
+        let prepared = prepare_chat_request(
+            request,
+            &served(&["Qwen/Qwen1.5-0.5B-Chat"]),
+            ResolvedRequestContext::default(),
+        )
+        .expect("request is valid");
+
+        let initial_tool_names = prepared
+            .chat_request
+            .initial_tools()
+            .iter()
+            .map(|tool| tool.name.clone())
+            .collect::<Vec<_>>();
+        let effective_tool_names = prepared
+            .chat_request
+            .tools()
+            .iter()
+            .map(|tool| tool.name.clone())
+            .collect::<Vec<_>>();
+        expect![[r#"
+            (
+                [
+                    "get_weather",
+                    "get_time",
+                ],
+                [
+                    "get_weather",
+                    "get_time",
+                ],
+                Auto,
+                false,
+                [
+                    Developer {
+                        content: Text(
+                            "developer instructions",
+                        ),
+                        tools: None,
+                    },
+                ],
+            )
+        "#]]
+        .assert_debug_eq(&(
+            initial_tool_names,
+            effective_tool_names,
+            prepared.chat_request.tool_choice().clone(),
+            prepared.options.is_named_tool_choice,
+            prepared.chat_request.messages,
+        ));
+    }
+
+    #[test]
+    fn convert_developer_message_filters_allowed_tools_in_declaration_order() {
+        let allowed_tools = AllowedTools {
+            mode: AllowedToolsMode::Auto,
+            tools: vec![
+                ToolReference::Function {
+                    function: FunctionChoice {
+                        name: "keep_first".to_string(),
+                    },
+                },
+                ToolReference::Function {
+                    function: FunctionChoice {
+                        name: "keep_second".to_string(),
+                    },
+                },
+            ],
+        };
+        let message = ChatMessage::Developer {
+            content: MessageContent::Text("developer instructions".to_string()),
+            tools: Some(vec![
+                function_tool("keep_second"),
+                function_tool("drop"),
+                function_tool("keep_first"),
+            ]),
+            name: None,
+        };
+
+        let converted = convert_message_with_allowed_tools(message, Some(&allowed_tools))
+            .expect("developer tools are valid");
+
+        expect![[r#"
+            Developer {
+                content: Text(
+                    "developer instructions",
+                ),
+                tools: Some(
+                    [
+                        Tool {
+                            name: "keep_second",
+                            description: None,
+                            parameters: Object {
+                                "type": String("object"),
+                            },
+                            strict: None,
+                        },
+                        Tool {
+                            name: "keep_first",
+                            description: None,
+                            parameters: Object {
+                                "type": String("object"),
+                            },
+                            strict: None,
+                        },
+                    ],
+                ),
+            }
+        "#]]
+        .assert_debug_eq(&converted);
+    }
+
+    #[test]
+    fn prepare_chat_request_lowers_required_allowed_tools() {
+        let request = ChatCompletionRequest {
+            tools: Some(vec![
+                function_tool("get_weather"),
+                function_tool("get_time"),
+            ]),
+            tool_choice: Some(allowed_tools_choice(
+                AllowedToolsMode::Required,
+                &["get_time"],
+            )),
+            ..base_request()
+        };
+
+        let prepared = prepare_chat_request(
+            request,
+            &served(&["Qwen/Qwen1.5-0.5B-Chat"]),
+            ResolvedRequestContext::default(),
+        )
+        .expect("request is valid");
+
+        assert_eq!(
+            (
+                prepared
+                    .chat_request
+                    .initial_tools()
+                    .iter()
+                    .map(|tool| tool.name.as_str())
+                    .collect::<Vec<_>>(),
+                prepared.chat_request.tool_choice().clone(),
+                prepared.options.is_named_tool_choice,
+            ),
+            (vec!["get_time"], ChatToolChoice::Required, false)
+        );
+    }
+
+    #[test]
+    fn prepare_chat_request_rejects_developer_only_allowed_tools_entry() {
+        let request = ChatCompletionRequest {
+            messages: vec![ChatMessage::Developer {
+                content: MessageContent::Text("developer instructions".to_string()),
+                tools: Some(vec![function_tool("get_time")]),
+                name: None,
+            }],
+            tools: Some(vec![function_tool("get_weather")]),
+            tool_choice: Some(allowed_tools_choice(AllowedToolsMode::Auto, &["get_time"])),
+            ..base_request()
+        };
+
+        let error = prepare_chat_request(
+            request,
+            &served(&["Qwen/Qwen1.5-0.5B-Chat"]),
+            ResolvedRequestContext::default(),
+        )
+        .expect_err("developer-only tools cannot authorize an allowlist entry");
+
+        assert!(
+            error
+                .to_error_response()
+                .error
+                .message
+                .contains("tool 'get_time' not found in 'tools'")
+        );
+    }
+
+    #[test]
+    fn prepare_chat_request_rejects_unknown_allowed_tool_for_required_and_missing_catalog() {
+        let cases = [
+            (
+                "required mode",
+                Some(vec![function_tool("get_weather")]),
+                AllowedToolsMode::Required,
+            ),
+            ("missing tools catalog", None, AllowedToolsMode::Auto),
+        ];
+
+        for (case, tools, mode) in cases {
+            let request = ChatCompletionRequest {
+                tools,
+                tool_choice: Some(allowed_tools_choice(mode, &["get_time"])),
+                ..base_request()
+            };
+
+            let error = prepare_chat_request(
+                request,
+                &served(&["Qwen/Qwen1.5-0.5B-Chat"]),
+                ResolvedRequestContext::default(),
+            )
+            .expect_err(case);
+
+            assert!(
+                error
+                    .to_error_response()
+                    .error
+                    .message
+                    .contains("tool 'get_time' not found in 'tools'"),
+                "{case}"
+            );
+        }
+    }
+
+    #[test]
+    fn allowed_tools_filter_does_not_hide_unsupported_tool_types() {
+        let unsupported_tool = Tool {
+            tool_type: "custom".to_string(),
+            function: Function {
+                name: "unsupported".to_string(),
+                description: None,
+                parameters: json!({"type": "object"}),
+                strict: None,
+            },
+        };
+        let cases = [
+            (
+                "top-level tool",
+                vec![ChatMessage::User {
+                    content: MessageContent::Text("hello".to_string()),
+                    name: None,
+                }],
+                Some(vec![unsupported_tool.clone()]),
+            ),
+            (
+                "developer tool",
+                vec![ChatMessage::Developer {
+                    content: MessageContent::Text("developer instructions".to_string()),
+                    tools: Some(vec![unsupported_tool]),
+                    name: None,
+                }],
+                None,
+            ),
+        ];
+
+        for (case, messages, tools) in cases {
+            let request = ChatCompletionRequest {
+                messages,
+                tools,
+                tool_choice: Some(allowed_tools_choice(AllowedToolsMode::Auto, &[])),
+                ..base_request()
+            };
+
+            let error = prepare_chat_request(
+                request,
+                &served(&["Qwen/Qwen1.5-0.5B-Chat"]),
+                ResolvedRequestContext::default(),
+            )
+            .expect_err(case);
+
+            assert!(
+                error
+                    .to_error_response()
+                    .error
+                    .message
+                    .contains("Only function tools are supported"),
+                "{case}"
+            );
+        }
+    }
+
+    #[test]
+    fn prepare_chat_request_treats_empty_auto_allowed_tools_as_no_tools() {
+        let request = ChatCompletionRequest {
+            messages: vec![ChatMessage::Developer {
+                content: MessageContent::Text("developer instructions".to_string()),
+                tools: Some(vec![
+                    function_tool("get_weather"),
+                    function_tool("get_time"),
+                ]),
+                name: None,
+            }],
+            tools: Some(vec![
+                function_tool("get_weather"),
+                function_tool("get_time"),
+            ]),
+            tool_choice: Some(allowed_tools_choice(AllowedToolsMode::Auto, &[])),
+            ..base_request()
+        };
+
+        let prepared = prepare_chat_request(
+            request,
+            &served(&["Qwen/Qwen1.5-0.5B-Chat"]),
+            ResolvedRequestContext::default(),
+        )
+        .expect("request is valid");
+
+        assert_eq!(
+            (
+                prepared.chat_request.initial_tools().to_vec(),
+                prepared.chat_request.tool_choice().clone(),
+                prepared.options.is_named_tool_choice,
+                prepared.chat_request.messages,
+            ),
+            (
+                Vec::new(),
+                ChatToolChoice::None,
+                false,
+                vec![VllmChatMessage::developer("developer instructions", None)],
+            )
+        );
     }
 
     #[test]

--- a/rust/src/server/src/routes/openai/chat_completions/types.rs
+++ b/rust/src/server/src/routes/openai/chat_completions/types.rs
@@ -481,3 +481,131 @@ fn validate_chat_cross_parameters(
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use serde_json::{Value, json};
+
+    use super::ChatCompletionRequest;
+
+    fn function_tool(name: &str) -> Value {
+        json!({
+            "type": "function",
+            "function": {
+                "name": name,
+                "parameters": {"type": "object"},
+            },
+        })
+    }
+
+    fn request_with_tool_choice(tool_choice: Value, tools: Option<Vec<Value>>) -> Value {
+        json!({
+            "model": "Qwen/Qwen1.5-0.5B-Chat",
+            "messages": [{"role": "user", "content": "hello"}],
+            "tools": tools,
+            "tool_choice": tool_choice,
+        })
+    }
+
+    #[test]
+    fn allowed_tools_wire_shape_round_trips() {
+        let tool_choice = json!({
+            "type": "allowed_tools",
+            "allowed_tools": {
+                "mode": "auto",
+                "tools": [{
+                    "type": "function",
+                    "function": {"name": "get_weather"},
+                }],
+            },
+        });
+        let request: ChatCompletionRequest = serde_json::from_value(request_with_tool_choice(
+            tool_choice.clone(),
+            Some(vec![function_tool("get_weather")]),
+        ))
+        .expect("allowed_tools wire shape deserializes");
+
+        assert_eq!(
+            serde_json::to_value(request.tool_choice.as_ref().expect("tool choice is present"))
+                .expect("tool choice serializes"),
+            tool_choice
+        );
+    }
+
+    #[test]
+    fn allowed_tools_rejects_invalid_outer_discriminator() {
+        assert!(
+            serde_json::from_value::<ChatCompletionRequest>(request_with_tool_choice(
+                json!({
+                    "type": "not_allowed_tools",
+                    "allowed_tools": {"mode": "auto", "tools": []},
+                }),
+                Some(vec![function_tool("get_weather")]),
+            ))
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn allowed_tools_rejects_legacy_flat_shape() {
+        assert!(
+            serde_json::from_value::<ChatCompletionRequest>(request_with_tool_choice(
+                json!({
+                    "type": "allowed_tools",
+                    "mode": "auto",
+                    "tools": [{"type": "function", "name": "get_weather"}],
+                }),
+                Some(vec![function_tool("get_weather")]),
+            ))
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn allowed_tools_rejects_invalid_mode() {
+        assert!(
+            serde_json::from_value::<ChatCompletionRequest>(request_with_tool_choice(
+                json!({
+                    "type": "allowed_tools",
+                    "allowed_tools": {"mode": "sometimes", "tools": []},
+                }),
+                Some(vec![function_tool("get_weather")]),
+            ))
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn allowed_tools_rejects_unsupported_reference_type() {
+        assert!(
+            serde_json::from_value::<ChatCompletionRequest>(request_with_tool_choice(
+                json!({
+                    "type": "allowed_tools",
+                    "allowed_tools": {
+                        "mode": "auto",
+                        "tools": [{"type": "mcp"}],
+                    },
+                }),
+                Some(vec![function_tool("get_weather")]),
+            ))
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn allowed_tools_rejects_missing_function_name() {
+        assert!(
+            serde_json::from_value::<ChatCompletionRequest>(request_with_tool_choice(
+                json!({
+                    "type": "allowed_tools",
+                    "allowed_tools": {
+                        "mode": "auto",
+                        "tools": [{"type": "function", "function": {}}],
+                    },
+                }),
+                Some(vec![function_tool("get_weather")]),
+            ))
+            .is_err()
+        );
+    }
+}

--- a/rust/src/server/src/routes/openai/utils/types.rs
+++ b/rust/src/server/src/routes/openai/utils/types.rs
@@ -268,9 +268,8 @@ pub enum ToolChoice {
     },
     AllowedTools {
         #[serde(rename = "type")]
-        tool_type: String,
-        mode: String,
-        tools: Vec<ToolReference>,
+        tool_type: AllowedToolsChoiceType,
+        allowed_tools: AllowedTools,
     },
 }
 
@@ -281,56 +280,39 @@ impl Default for ToolChoice {
 }
 
 /// Function choice specification for `ToolChoice::Function`.
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 pub struct FunctionChoice {
     pub name: String,
 }
 
-/// Tool reference for `ToolChoice::AllowedTools`.
-#[derive(Debug, Clone, Deserialize, Serialize)]
-#[serde(tag = "type")]
-#[serde(rename_all = "snake_case")]
-pub enum ToolReference {
-    #[serde(rename = "function")]
-    Function { name: String },
-    #[serde(rename = "mcp")]
-    Mcp {
-        server_label: String,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        name: Option<String>,
-    },
-    #[serde(rename = "file_search")]
-    FileSearch,
-    #[serde(rename = "web_search_preview")]
-    WebSearchPreview,
-    #[serde(rename = "computer_use_preview")]
-    ComputerUsePreview,
-    #[serde(rename = "code_interpreter")]
-    CodeInterpreter,
-    #[serde(rename = "image_generation")]
-    ImageGeneration,
+/// Discriminator for an allowed-tools choice.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub enum AllowedToolsChoiceType {
+    #[serde(rename = "allowed_tools")]
+    AllowedTools,
 }
 
-impl ToolReference {
-    /// Get a unique identifier for this tool reference.
-    pub fn identifier(&self) -> String {
-        match self {
-            ToolReference::Function { name } => format!("function:{name}"),
-            ToolReference::Mcp {
-                server_label,
-                name: Some(n),
-            } => format!("mcp:{server_label}:{n}"),
-            ToolReference::Mcp {
-                server_label,
-                name: _,
-            } => format!("mcp:{server_label}"),
-            ToolReference::FileSearch => "file_search".to_string(),
-            ToolReference::WebSearchPreview => "web_search_preview".to_string(),
-            ToolReference::ComputerUsePreview => "computer_use_preview".to_string(),
-            ToolReference::CodeInterpreter => "code_interpreter".to_string(),
-            ToolReference::ImageGeneration => "image_generation".to_string(),
-        }
-    }
+/// Allowed function tools and their invocation mode.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct AllowedTools {
+    pub mode: AllowedToolsMode,
+    pub tools: Vec<ToolReference>,
+}
+
+/// Invocation mode for an allowed-tools choice.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AllowedToolsMode {
+    Auto,
+    Required,
+}
+
+/// Tool reference for `ToolChoice::AllowedTools`.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(tag = "type")]
+pub enum ToolReference {
+    #[serde(rename = "function")]
+    Function { function: FunctionChoice },
 }
 
 // ============================================================================

--- a/rust/src/server/src/routes/tests.rs
+++ b/rust/src/server/src/routes/tests.rs
@@ -23,8 +23,8 @@ use serial_test::serial;
 use tower::{Service as _, ServiceExt as _};
 use vllm_chat::{
     ChatBackend, ChatContent, ChatContentPart, ChatLlm, ChatMessage, ChatRenderer, ChatRequest,
-    ChatRequestProcessor, ChatTextBackend, DefaultChatOutputProcessor, DynChatOutputProcessor,
-    DynChatRenderer, NewChatOutputProcessorOptions, ParserSelection,
+    ChatRequestProcessor, ChatTextBackend, ChatToolChoice, DefaultChatOutputProcessor,
+    DynChatOutputProcessor, DynChatRenderer, NewChatOutputProcessorOptions, ParserSelection,
 };
 use vllm_engine_core_client::mock_engine::default_ready_response;
 use vllm_engine_core_client::protocol::decode_value;
@@ -434,10 +434,13 @@ async fn recv_engine_message(dealer: &mut DealerSocket) -> Vec<Bytes> {
     dealer.recv().await.expect("recv engine message").into_vec()
 }
 
+type ChatRequestCheck = Arc<dyn Fn(&ChatRequest) + Send + Sync>;
+
 #[derive(Clone)]
 struct FakeChatBackend {
     model_id: String,
     multimodal_model_info: Option<vllm_chat::multimodal::MultimodalModelInfo>,
+    request_check: Option<ChatRequestCheck>,
 }
 
 /// Synthetic BOS id used when `add_special_tokens` is true in tests.
@@ -462,6 +465,7 @@ impl FakeChatBackend {
         Self {
             model_id: "test-model".to_string(),
             multimodal_model_info: None,
+            request_check: None,
         }
     }
 
@@ -469,6 +473,7 @@ impl FakeChatBackend {
         Self {
             model_id: model_id.into(),
             multimodal_model_info: None,
+            request_check: None,
         }
     }
 
@@ -478,7 +483,13 @@ impl FakeChatBackend {
         Self {
             model_id: "test-model".to_string(),
             multimodal_model_info: Some(multimodal_model_info),
+            request_check: None,
         }
+    }
+
+    fn with_request_check(mut self, check: impl Fn(&ChatRequest) + Send + Sync + 'static) -> Self {
+        self.request_check = Some(Arc::new(check));
+        self
     }
 }
 
@@ -514,6 +525,9 @@ impl ChatBackend for FakeChatBackend {
         request: &mut ChatRequest,
         options: NewChatOutputProcessorOptions<'_>,
     ) -> vllm_chat::Result<DynChatOutputProcessor> {
+        if let Some(check) = &self.request_check {
+            check(request);
+        }
         Ok(Box::new(DefaultChatOutputProcessor::new(
             request,
             &self.model_id,
@@ -2453,6 +2467,273 @@ async fn non_stream_chat_returns_json_response() {
     }
     // ...except `tool_calls`, which Python pops from the payload when empty.
     assert!(!message.contains_key("tool_calls"), "{json}");
+}
+
+struct AllowedToolsHttpCase<'a> {
+    mode: &'a str,
+    allowed_names: &'a [&'a str],
+    expected_choice: ChatToolChoice,
+    expected_tools: &'a [&'a str],
+}
+
+async fn assert_allowed_tools_http(case: AllowedToolsHttpCase<'_>) {
+    let expected_tools =
+        case.expected_tools.iter().map(|name| (*name).to_string()).collect::<Vec<_>>();
+    let expected_choice = case.expected_choice;
+    let backend =
+        FakeChatBackend::with_model_id("Qwen/Qwen3-0.6B").with_request_check(move |request| {
+            let top_level_tools =
+                request.initial_tools().iter().map(|tool| tool.name.clone()).collect::<Vec<_>>();
+            let model_visible_tools =
+                request.tools().iter().map(|tool| tool.name.clone()).collect::<Vec<_>>();
+            let developer_tools = request.messages.iter().find_map(|message| match message {
+                ChatMessage::Developer { tools, .. } => tools
+                    .as_ref()
+                    .map(|tools| tools.iter().map(|tool| tool.name.clone()).collect::<Vec<_>>()),
+                _ => None,
+            });
+
+            assert_eq!(
+                (
+                    top_level_tools,
+                    model_visible_tools,
+                    request.tool_choice().clone(),
+                    developer_tools
+                ),
+                (
+                    expected_tools.clone(),
+                    expected_tools.clone(),
+                    expected_choice.clone(),
+                    None,
+                )
+            );
+        });
+    let (app, engine_task) = test_app_with_backend_and_stream_output_specs(
+        Arc::new(backend),
+        default_stream_output_specs(),
+    )
+    .await;
+    let allowed_tools = case
+        .allowed_names
+        .iter()
+        .map(|name| json!({"type": "function", "function": {"name": name}}))
+        .collect::<Vec<_>>();
+    let response = app
+        .clone()
+        .call(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/chat/completions")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "model": "Qwen/Qwen1.5-0.5B-Chat",
+                        "stream": false,
+                        "messages": [
+                            {
+                                "role": "developer",
+                                "content": "developer instructions",
+                                "tools": [
+                                    {
+                                        "type": "function",
+                                        "function": {
+                                            "name": "developer_news",
+                                            "parameters": {"type": "object"},
+                                        },
+                                    },
+                                    {
+                                        "type": "function",
+                                        "function": {
+                                            "name": "developer_time",
+                                            "parameters": {"type": "object"},
+                                        },
+                                    },
+                                    {
+                                        "type": "function",
+                                        "function": {
+                                            "name": "developer_weather",
+                                            "parameters": {"type": "object"},
+                                        },
+                                    },
+                                ],
+                            },
+                            {"role": "user", "content": "hello"},
+                        ],
+                        "tools": [
+                            {
+                                "type": "function",
+                                "function": {
+                                    "name": "get_weather",
+                                    "parameters": {"type": "object"},
+                                },
+                            },
+                            {
+                                "type": "function",
+                                "function": {
+                                    "name": "get_news",
+                                    "parameters": {"type": "object"},
+                                },
+                            },
+                            {
+                                "type": "function",
+                                "function": {
+                                    "name": "get_time",
+                                    "parameters": {"type": "object"},
+                                },
+                            },
+                        ],
+                        "tool_choice": {
+                            "type": "allowed_tools",
+                            "allowed_tools": {
+                                "mode": case.mode,
+                                "tools": allowed_tools,
+                            },
+                        },
+                    })
+                    .to_string(),
+                ))
+                .expect("build request"),
+        )
+        .await
+        .expect("call app");
+
+    let status = response.status();
+    let body = to_bytes(response.into_body(), usize::MAX).await.expect("read body");
+    assert_eq!(status, StatusCode::OK, "{}", String::from_utf8_lossy(&body));
+    engine_task.await.expect("mock engine task");
+    let json: serde_json::Value = serde_json::from_slice(&body).expect("decode json");
+    assert_eq!(json["choices"][0]["message"]["content"], "hi");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn chat_completions_auto_allowed_tools_filters_model_visible_tools() {
+    assert_allowed_tools_http(AllowedToolsHttpCase {
+        mode: "auto",
+        allowed_names: &["get_time", "get_weather"],
+        expected_choice: ChatToolChoice::Auto,
+        expected_tools: &["get_weather", "get_time"],
+    })
+    .await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn chat_completions_required_allowed_tools_reaches_model() {
+    assert_allowed_tools_http(AllowedToolsHttpCase {
+        mode: "required",
+        allowed_names: &["get_time"],
+        expected_choice: ChatToolChoice::Required,
+        expected_tools: &["get_time"],
+    })
+    .await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn chat_completions_empty_auto_allowed_tools_removes_all_tools() {
+    assert_allowed_tools_http(AllowedToolsHttpCase {
+        mode: "auto",
+        allowed_names: &[],
+        expected_choice: ChatToolChoice::None,
+        expected_tools: &[],
+    })
+    .await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn chat_completions_invalid_allowed_tools_semantics_return_specific_400_errors() {
+    let cases = [
+        (
+            "missing tool",
+            json!({
+                "type": "allowed_tools",
+                "allowed_tools": {
+                    "mode": "auto",
+                    "tools": [{
+                        "type": "function",
+                        "function": {"name": "get_time"},
+                    }],
+                },
+            }),
+            &["get_time", "not found in 'tools'"][..],
+        ),
+        (
+            "empty required list",
+            json!({
+                "type": "allowed_tools",
+                "allowed_tools": {"mode": "required", "tools": []},
+            }),
+            &["required", "at least one allowed function"][..],
+        ),
+    ];
+    let mut app = test_app().await;
+
+    for (case, tool_choice, expected_message_parts) in cases {
+        let (status, json) = post_json(
+            &mut app,
+            "/v1/chat/completions",
+            json!({
+                "model": "Qwen/Qwen1.5-0.5B-Chat",
+                "stream": false,
+                "messages": [{"role": "user", "content": "hello"}],
+                "tools": [{
+                    "type": "function",
+                    "function": {
+                        "name": "get_weather",
+                        "parameters": {"type": "object"},
+                    },
+                }],
+                "tool_choice": tool_choice,
+            }),
+        )
+        .await;
+        let message = json["error"]["message"].as_str().unwrap_or_default();
+
+        assert_eq!(status, StatusCode::BAD_REQUEST, "{case}: {json}");
+        assert_eq!(
+            json["error"]["type"].as_str(),
+            Some("invalid_request_error"),
+            "{case}: {json}"
+        );
+        assert!(
+            expected_message_parts.iter().all(|part| message.contains(part)),
+            "{case}: expected {expected_message_parts:?} in {message:?}"
+        );
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn chat_completions_malformed_allowed_tools_returns_openai_400() {
+    let mut app = test_app().await;
+    let (status, json) = post_json(
+        &mut app,
+        "/v1/chat/completions",
+        json!({
+            "model": "Qwen/Qwen1.5-0.5B-Chat",
+            "stream": false,
+            "messages": [{"role": "user", "content": "hello"}],
+            "tools": [{
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "parameters": {"type": "object"},
+                },
+            }],
+            "tool_choice": {
+                "type": "allowed_tools",
+                "mode": "auto",
+                "tools": [{"type": "function", "name": "get_weather"}],
+            },
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{json}");
+    assert_eq!(json["error"]["type"], "invalid_request_error");
+    assert_eq!(json["error"]["code"], "json_parse_error");
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]


### PR DESCRIPTION
## Purpose

The Rust frontend does not accept the Chat Completions wire shape for `tool_choice.allowed_tools`. The request type currently models `mode` and `tools` as flat fields, while clients send both fields under `allowed_tools`.

For example:

```bash
curl http://localhost:8000/v1/chat/completions \
  -H 'Content-Type: application/json' \
  -d '{
    "model": "served-model",
    "messages": [{"role": "user", "content": "What time is it?"}],
    "tools": [
      {
        "type": "function",
        "function": {
          "name": "get_time",
          "parameters": {"type": "object"}
        }
      },
      {
        "type": "function",
        "function": {
          "name": "get_weather",
          "parameters": {"type": "object"}
        }
      }
    ],
    "tool_choice": {
      "type": "allowed_tools",
      "allowed_tools": {
        "mode": "required",
        "tools": [
          {"type": "function", "function": {"name": "get_time"}}
        ]
      }
    }
  }'
```

On current `main`, this request is rejected during JSON deserialization. This change accepts the nested shape and sends only `get_time` to the chat renderer. The previous flat Rust shape was not a working compatibility path: request conversion rejected it as unsupported.

The implementation:

- requires the exact `allowed_tools` and `function` discriminators;
- converts and validates declared tools before filtering, so an unsupported tool type cannot be hidden by the allowlist;
- checks that every allowed function exists in the request's top-level `tools` list;
- filters top-level tools and developer-message tools by function name while preserving their declaration order;
- maps `auto` and `required` to the existing internal tool-choice modes;
- treats an empty `auto` list as no available tools and rejects an empty `required` list.

The filtered messages and tools feed the existing `ResolvedToolContext`, so its duplicate-name, effective-tool, default-choice, and named-choice validation remains the single source of truth. Filtering happens before rendering; renderer and parser interfaces are unchanged, and the model never sees a disallowed function as callable. Allowed names come from the top-level `tools` list, so a developer-message-local declaration cannot authorize an otherwise undeclared tool.

This is the `tool_choice.allowed_tools` item in #44280. The proposed scope was posted in https://github.com/vllm-project/vllm/issues/44280#issuecomment-5229310963 before implementation.

This does not duplicate an open PR. I checked the roadmap issue and searched open PRs for `44280`, `allowed_tools Rust frontend`, and `tool_choice allowed_tools Rust chat`. The roadmap-number search returned other Rust frontend work, but no Chat Completions `allowed_tools` implementation. #45512 changes MCP enforcement in the Python Responses API, which is a different request path.

AI assistance was used during implementation and review. I reviewed every changed line and the test evidence, and I understand and can defend the change.

## Test plan

```bash
cd rust
cargo fmt --all -- --check
cargo nextest run -p vllm-server --lib
cargo clippy -p vllm-server --all-targets -- -D warnings
cargo check --workspace --all-targets

cd ..
uvx pre-commit run typos --files \
  rust/src/server/src/routes/openai/chat_completions/convert.rs \
  rust/src/server/src/routes/openai/chat_completions/types.rs \
  rust/src/server/src/routes/openai/utils/types.rs \
  rust/src/server/src/routes/tests.rs
uvx pre-commit run check-spdx-header --files \
  rust/src/server/src/routes/openai/chat_completions/convert.rs \
  rust/src/server/src/routes/openai/chat_completions/types.rs \
  rust/src/server/src/routes/openai/utils/types.rs \
  rust/src/server/src/routes/tests.rs
uvx pre-commit run rust-cargo-fmt --files \
  rust/src/server/src/routes/openai/chat_completions/convert.rs \
  rust/src/server/src/routes/openai/chat_completions/types.rs \
  rust/src/server/src/routes/openai/utils/types.rs \
  rust/src/server/src/routes/tests.rs
uvx pre-commit run check-filenames --files \
  rust/src/server/src/routes/openai/chat_completions/convert.rs \
  rust/src/server/src/routes/openai/chat_completions/types.rs \
  rust/src/server/src/routes/openai/utils/types.rs \
  rust/src/server/src/routes/tests.rs
git diff --check
```

Tests cover the nested serde shape and strict discriminators; conversion, validation, subset filtering, and declaration order; `ResolvedToolContext` integration; top-level authorization of developer tools; `auto`, `required`, and empty-`auto` HTTP success; specific HTTP 400 errors for missing and unsatisfiable allowed tools; malformed-shape HTTP normalization; missing top-level catalogs; and unsupported top-level or developer tool types.

## Test results

- `cargo nextest run -p vllm-server --lib`: 358 passed, 0 skipped.
- `cargo fmt --all -- --check`: passed.
- `cargo clippy -p vllm-server --all-targets -- -D warnings`: passed.
- `cargo check --workspace --all-targets`: passed.
- Applicable pre-commit hooks: passed.
- `git diff --check`: passed.

A full `pre-commit run --files ...` could not complete locally because pre-commit failed while building the unrelated `actionlint` hook environment due to a Go tool/compiler version mismatch. This PR does not modify workflow files. I ran every hook applicable to the four changed Rust files individually, and all passed.

No live-model evaluation was run. This patch changes the model-visible tool list only for requests using the previously unsupported `allowed_tools` field. It does not modify model weights, sampling, token generation, or engine behavior. Deterministic conversion tests assert the exact tool context passed to rendering, and mock-engine HTTP tests cover the request path.

No documentation update is included. This implements the existing Rust frontend roadmap item, and the request example above documents the supported Chat Completions wire shape.
