### PR TITLE
[CI] fix docs on `main`

### DIFF
--- a/vllm/benchmarks/throughput.py
+++ b/vllm/benchmarks/throughput.py
@@ -523,7 +523,7 @@ def save_to_pytorch_benchmark_format(
         write_to_json(pt_file, pt_records)
 
 
-def _to_serve_args(args) -> argparse.Namespace:
+def _to_serve_args(args: argparse.Namespace) -> argparse.Namespace:
     """Translate throughput args into a namespace the shared get_samples reads.
 
     ``get_samples`` (used by ``bench serve``) expects ~45 attributes; the

--- a/vllm/multimodal/video.py
+++ b/vllm/multimodal/video.py
@@ -637,7 +637,7 @@ class TorchCodecVideoBackendMixin:
         return batch.data.numpy(), list(frame_indices)
 
 
-def _pynvvc_frames_to_nhwc(frames):
+def _pynvvc_frames_to_nhwc(frames: torch.Tensor) -> torch.Tensor:
     """Return a stacked PyNvVideoCodec frame batch as contiguous NHWC.
 
     PyNvVideoCodec's per-frame layout has varied across versions (HWC vs CHW),


### PR DESCRIPTION
Fixes:

```
WARNING -  griffe: vllm/benchmarks/throughput.py:535: No type or annotation for parameter 'args' 
WARNING -  griffe: vllm/multimodal/video.py:648: No type or annotation for parameter 'frames'
WARNING -  griffe: vllm/multimodal/video.py:651: No type or annotation for returned value 1
```