### PR TITLE
[Perf] Avoid a per-prefill-step GPU->CPU sync in the KDA chunk kernels

### DIFF
--- a/tests/models/kimi_k3/test_kda_metadata.py
+++ b/tests/models/kimi_k3/test_kda_metadata.py
@@ -42,6 +42,9 @@ PRUNED_METADATA_FIELDS = {
     "prefill_has_initial_state",
     "spec_sequence_masks",
 }
+# Only the KDA chunk kernels consume these, so the shared GDN builder
+# leaves them unset.
+KDA_ONLY_METADATA_FIELDS = {"non_spec_chunk_indices"}
 
 
 def _assert_matches_shared_gdn(reference, actual: KimiK3KDAMetadata):
@@ -50,6 +53,10 @@ def _assert_matches_shared_gdn(reference, actual: KimiK3KDAMetadata):
         expected_value = getattr(reference, field.name)
         if field.name in PRUNED_METADATA_FIELDS:
             assert actual_value is None
+            continue
+        if field.name in KDA_ONLY_METADATA_FIELDS:
+            assert expected_value is None
+            assert (actual_value is not None) == (actual.num_prefills > 0)
             continue
         if (
             field.name in {"spec_token_indx", "non_spec_token_indx"}

--- a/vllm/model_executor/layers/mamba/gdn/kimi_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/kimi_gdn_linear_attn.py
@@ -23,7 +23,12 @@ from vllm.model_executor.utils import set_weight_attrs
 from vllm.platforms import current_platform
 from vllm.third_party.flash_linear_attention.ops.kda import FusedRMSNormGated
 from vllm.transformers_utils.configs.kimi_linear import KimiLinearConfig
-from vllm.v1.attention.backends.gdn_attn import GDNAttentionMetadata
+from vllm.v1.attention.backend import AttentionBackend
+from vllm.v1.attention.backends.gdn_attn import (
+    GDNAttentionBackend,
+    GDNAttentionMetadata,
+    GDNAttentionMetadataBuilder,
+)
 
 from ...linear import (
     ColumnParallelLinear,
@@ -151,8 +156,28 @@ class _KimiGDNMergedColumnParallelLinear(MergedColumnParallelLinear):
                 param.tp_rank = param_tp_rank
 
 
+class KimiGDNMetadataBuilder(GDNAttentionMetadataBuilder):
+    """GDN metadata for Kimi-Linear, whose prefill runs the KDA chunk kernels
+    over the whole non-spec batch."""
+
+    builds_non_spec_chunk_indices = True
+
+
+class KimiGDNAttentionBackend(GDNAttentionBackend):
+    @staticmethod
+    def get_name() -> str:
+        return "KIMI_GDN"
+
+    @staticmethod
+    def get_builder_cls() -> type[KimiGDNMetadataBuilder]:
+        return KimiGDNMetadataBuilder
+
+
 @PluggableLayer.register("kimi_gated_delta_net_attention")
 class KimiGatedDeltaNetAttention(GatedDeltaNetAttention):
+    def get_attn_backend(self) -> type[AttentionBackend]:
+        return KimiGDNAttentionBackend
+
     def get_state_dtype(
         self,
     ) -> tuple[torch.dtype, torch.dtype]:
@@ -577,6 +602,7 @@ class KimiGatedDeltaNetAttention(GatedDeltaNetAttention):
                     output_final_state=True,
                     use_qk_l2norm_in_kernel=True,
                     cu_seqlens=non_spec_query_start_loc,
+                    chunk_indices=m.non_spec_chunk_indices,
                 )
                 # Init cache
                 recurrent_state[non_spec_state_indices_tensor] = last_recurrent_state

--- a/vllm/models/kimi_k3/amd/ops/third_party/kda/chunk.py
+++ b/vllm/models/kimi_k3/amd/ops/third_party/kda/chunk.py
@@ -711,13 +711,13 @@ def chunk_kda_with_fused_gate_fwd(
     output_final_state: bool,
     lower_bound: float | None = None,
     cu_seqlens: torch.Tensor | None = None,
+    chunk_indices: torch.Tensor | None = None,
 ):
     chunk_size = FLA_CHUNK_SIZE
-    chunk_indices = (
-        prepare_chunk_indices(cu_seqlens, chunk_size)
-        if cu_seqlens is not None
-        else None
-    )
+    # Deriving these from `cu_seqlens` reads it back to the host; callers that
+    # have the segmentation already (see GDNAttentionMetadata) pass it in.
+    if chunk_indices is None and cu_seqlens is not None:
+        chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size)
     g, beta = fused_kda_gate_chunk_cumsum(
         raw_g,
         raw_beta=raw_beta,
@@ -792,6 +792,7 @@ def chunk_kda_with_fused_gate(
     lower_bound: float | None = None,
     use_qk_l2norm_in_kernel: bool = False,
     cu_seqlens: torch.Tensor | None = None,
+    chunk_indices: torch.Tensor | None = None,
     **kwargs,
 ):
     """Run chunk KDA from raw gate and beta projections."""
@@ -815,6 +816,7 @@ def chunk_kda_with_fused_gate(
         output_final_state=output_final_state,
         lower_bound=lower_bound,
         cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
     )
     return o, final_state
 

--- a/vllm/models/kimi_k3/nvidia/kda.py
+++ b/vllm/models/kimi_k3/nvidia/kda.py
@@ -728,6 +728,7 @@ class KimiK3DeltaAttention(GatedDeltaNetAttention):
                         output_final_state=True,
                         use_qk_l2norm_in_kernel=True,
                         cu_seqlens=non_spec_query_start_loc,
+                        chunk_indices=m.non_spec_chunk_indices,
                     )
                 recurrent_state[non_spec_state_indices_tensor] = last_recurrent_state
             else:

--- a/vllm/models/kimi_k3/nvidia/kda_metadata.py
+++ b/vllm/models/kimi_k3/nvidia/kda_metadata.py
@@ -411,17 +411,16 @@ class KimiK3KDAMetadataBuilder(GDNAttentionMetadataBuilder):
             has_initial_state = m.compute_num_computed_tokens() > 0
             if spec_sequence_masks_cpu is not None:
                 has_initial_state = has_initial_state[active_non_spec_mask_cpu]
-                assert non_spec_query_start_loc_cpu is not None
+            assert non_spec_query_start_loc_cpu is not None
             nums_dict, batch_ptr, token_chunk_offset_ptr = (
                 compute_causal_conv1d_metadata(
                     non_spec_query_start_loc_cpu, device=query_start_loc.device
                 )
             )
-            if non_spec_query_start_loc_cpu is not None:
-                non_spec_chunk_indices = async_tensor_h2d(
-                    prepare_chunk_indices(non_spec_query_start_loc_cpu, FLA_CHUNK_SIZE),
-                    device=query_start_loc.device,
-                )
+            non_spec_chunk_indices = async_tensor_h2d(
+                prepare_chunk_indices(non_spec_query_start_loc_cpu, FLA_CHUNK_SIZE),
+                device=query_start_loc.device,
+            )
         else:
             has_initial_state = None
 

--- a/vllm/models/kimi_k3/nvidia/kda_metadata.py
+++ b/vllm/models/kimi_k3/nvidia/kda_metadata.py
@@ -14,6 +14,8 @@ from functools import cache
 import torch
 
 from vllm.platforms import current_platform
+from vllm.third_party.flash_linear_attention.ops.index import prepare_chunk_indices
+from vllm.third_party.flash_linear_attention.ops.utils import FLA_CHUNK_SIZE
 from vllm.triton_utils import tl, triton
 from vllm.utils.torch_utils import async_tensor_h2d
 from vllm.v1.attention.backend import CommonAttentionMetadata
@@ -400,9 +402,11 @@ class KimiK3KDAMetadataBuilder(GDNAttentionMetadataBuilder):
 
                 num_accepted_tokens = num_accepted_tokens[spec_sequence_masks_cpu]
 
-        # Unlike the shared GDN layer, Kimi-K3's prefill KDA wrapper prepares
-        # its own chunk indices. Only causal-convolution metadata is needed here.
+        # The KDA chunk kernels segment the whole non-spec batch, so their
+        # chunk metadata is derived from `non_spec_query_start_loc`. Compute it
+        # on the host and copy it across to avoid D2H sync.
         nums_dict, batch_ptr, token_chunk_offset_ptr = None, None, None
+        non_spec_chunk_indices = None
         if num_prefills > 0:
             has_initial_state = m.compute_num_computed_tokens() > 0
             if spec_sequence_masks_cpu is not None:
@@ -410,10 +414,14 @@ class KimiK3KDAMetadataBuilder(GDNAttentionMetadataBuilder):
                 assert non_spec_query_start_loc_cpu is not None
             nums_dict, batch_ptr, token_chunk_offset_ptr = (
                 compute_causal_conv1d_metadata(
-                    non_spec_query_start_loc_cpu,
-                    device=query_start_loc.device,
+                    non_spec_query_start_loc_cpu, device=query_start_loc.device
                 )
             )
+            if non_spec_query_start_loc_cpu is not None:
+                non_spec_chunk_indices = async_tensor_h2d(
+                    prepare_chunk_indices(non_spec_query_start_loc_cpu, FLA_CHUNK_SIZE),
+                    device=query_start_loc.device,
+                )
         else:
             has_initial_state = None
 
@@ -483,6 +491,7 @@ class KimiK3KDAMetadataBuilder(GDNAttentionMetadataBuilder):
             nums_dict=nums_dict,
             batch_ptr=batch_ptr,
             token_chunk_offset_ptr=token_chunk_offset_ptr,
+            non_spec_chunk_indices=non_spec_chunk_indices,
         )
 
 

--- a/vllm/models/kimi_k3/nvidia/ops/third_party/kda/chunk.py
+++ b/vllm/models/kimi_k3/nvidia/ops/third_party/kda/chunk.py
@@ -706,13 +706,13 @@ def chunk_kda_with_fused_gate_fwd(
     output_final_state: bool,
     lower_bound: float | None = None,
     cu_seqlens: torch.Tensor | None = None,
+    chunk_indices: torch.Tensor | None = None,
 ):
     chunk_size = FLA_CHUNK_SIZE
-    chunk_indices = (
-        prepare_chunk_indices(cu_seqlens, chunk_size)
-        if cu_seqlens is not None
-        else None
-    )
+    # Deriving these from `cu_seqlens` reads it back to the host; callers that
+    # have the segmentation already (see GDNAttentionMetadata) pass it in.
+    if chunk_indices is None and cu_seqlens is not None:
+        chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size)
     g, beta = fused_kda_gate_chunk_cumsum(
         raw_g,
         raw_beta=raw_beta,
@@ -787,6 +787,7 @@ def chunk_kda_with_fused_gate(
     lower_bound: float | None = None,
     use_qk_l2norm_in_kernel: bool = False,
     cu_seqlens: torch.Tensor | None = None,
+    chunk_indices: torch.Tensor | None = None,
     **kwargs,
 ):
     """Run chunk KDA from raw gate and beta projections."""
@@ -810,6 +811,7 @@ def chunk_kda_with_fused_gate(
         output_final_state=output_final_state,
         lower_bound=lower_bound,
         cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
     )
     return o, final_state
 

--- a/vllm/third_party/flash_linear_attention/ops/index.py
+++ b/vllm/third_party/flash_linear_attention/ops/index.py
@@ -21,12 +21,8 @@ def prepare_lens(cu_seqlens: torch.Tensor) -> torch.Tensor:
 
 @tensor_cache
 def prepare_chunk_indices(cu_seqlens: torch.Tensor, chunk_size: int) -> torch.Tensor:
-    indices = torch.cat(
-        [
-            torch.arange(n)
-            for n in triton.cdiv(prepare_lens(cu_seqlens), chunk_size).tolist()
-        ]
-    )
+    chunk_counts = triton.cdiv(prepare_lens(cu_seqlens), chunk_size).tolist()
+    indices = torch.cat([torch.arange(n) for n in chunk_counts])
     return torch.stack([indices.eq(0).cumsum(0) - 1, indices], 1).to(cu_seqlens)
 
 

--- a/vllm/v1/attention/backends/gdn_attn.py
+++ b/vllm/v1/attention/backends/gdn_attn.py
@@ -68,6 +68,7 @@ class GDNAttentionMetadata:
     # Pre-computed FLA chunk metadata (avoids GPU->CPU sync in prepare_chunk_indices)
     chunk_indices: torch.Tensor | None = None
     chunk_offsets: torch.Tensor | None = None
+    non_spec_chunk_indices: torch.Tensor | None = None
     # Chunk-kernel inputs for prefill
     prefill_query_start_loc: torch.Tensor | None = None
     prefill_state_indices: torch.Tensor | None = None
@@ -82,6 +83,9 @@ class GDNAttentionMetadata:
 class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]):
     kv_cache_spec: MambaSpec
     _cudagraph_support = AttentionCGSupport.UNIFORM_BATCH
+
+    # Only the KDA chunk kernels consume `non_spec_chunk_indices`.
+    builds_non_spec_chunk_indices: bool = False
 
     reorder_batch_threshold: int = 1
 
@@ -330,7 +334,12 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
         prefill_query_start_loc: torch.Tensor | None = None
         prefill_state_indices: torch.Tensor | None = None
         prefill_has_initial_state: torch.Tensor | None = None
+        non_spec_chunk_indices: torch.Tensor | None = None
         if num_prefills > 0:
+            from vllm.third_party.flash_linear_attention.ops.index import (
+                prepare_chunk_indices,
+                prepare_chunk_offsets,
+            )
             from vllm.third_party.flash_linear_attention.ops.utils import (
                 FLA_CHUNK_SIZE,
             )
@@ -373,11 +382,6 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
                 # Only prefill batches use FLA chunk ops.
                 # Pre-compute on CPU and async-copy to GPU to avoid
                 # GPU→CPU sync (.tolist()) in prepare_chunk_indices.
-                from vllm.third_party.flash_linear_attention.ops.index import (
-                    prepare_chunk_indices,
-                    prepare_chunk_offsets,
-                )
-
                 assert prefill_query_start_loc_cpu is not None
                 chunk_indices = async_tensor_h2d(
                     prepare_chunk_indices(prefill_query_start_loc_cpu, FLA_CHUNK_SIZE),
@@ -387,6 +391,24 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
                     prepare_chunk_offsets(prefill_query_start_loc_cpu, FLA_CHUNK_SIZE),
                     device=gpu_device,
                 )
+
+            # The KDA chunk kernels segment the whole non-spec batch rather
+            # than the peeled prefill slice, and never take the cutedsl path.
+            if self.builds_non_spec_chunk_indices:
+                assert non_spec_query_start_loc_cpu is not None
+                if (
+                    self.gdn_prefill_backend != "cutedsl"
+                    and prefill_query_start_loc_cpu is non_spec_query_start_loc_cpu
+                ):
+                    # Nothing was peeled off, so the segmentations coincide.
+                    non_spec_chunk_indices = chunk_indices
+                else:
+                    non_spec_chunk_indices = async_tensor_h2d(
+                        prepare_chunk_indices(
+                            non_spec_query_start_loc_cpu, FLA_CHUNK_SIZE
+                        ),
+                        device=query_start_loc.device,
+                    )
 
         if num_prefills > 0:
             has_initial_state = context_lens_tensor > 0
@@ -493,6 +515,7 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
             num_spec_decode_tokens=num_spec_decode_tokens,
             num_actual_tokens=m.num_actual_tokens,
             has_initial_state=has_initial_state,
+            non_spec_chunk_indices=non_spec_chunk_indices,
             chunk_indices=chunk_indices,
             chunk_offsets=chunk_offsets,
             prefill_query_start_loc=prefill_query_start_loc,


### PR DESCRIPTION
`prepare_chunk_indices` derives per-sequence chunk counts with `.tolist()`, so passing it a device `cu_seqlens` blocks the caller. The count also fixes the Triton grid, so it has to reach the host either way; compute it from the host-side cu_seqlens we already have and copy the result across, as `gdn_attn` already does for its own prefill slice.

Models from `vllm/models/kimi_k3` using FLA hit this on prefill batches, on NVIDIA and ROCm. The existing `chunk_indices` describes the decode-peeled `prefill_query_start_loc`, so add `non_spec_chunk_indices` alongside it and thread an optional `chunk_indices` through `chunk_kda_with_fused_gate`. It defaults to None and falls back to deriving on device, so other callers are unaffected.

Verified host- and device-derived indices match in value, dtype and length. Not run on Kimi hardware.

Note this applies to Kimi Linear but **not** Kimi K3 with cuda since the latter uses FlashKDA rather than FLA.

Claude was used for this.