### PR TITLE
[DSA] Optimize top-k response serialization

### DIFF
--- a/rust/src/chat/tests/chat.rs
+++ b/rust/src/chat/tests/chat.rs
@@ -57,6 +57,7 @@ fn request_output(
         trace_headers: None,
         prefill_stats: None,
         routed_experts: None,
+        indexer_topk: None,
         num_nans_in_logits: 0,
     }
 }
@@ -83,6 +84,7 @@ fn request_output_with_logprobs(
         trace_headers: None,
         prefill_stats: None,
         routed_experts: None,
+        indexer_topk: None,
         num_nans_in_logits: 0,
     }
 }

--- a/rust/src/engine-core-client/src/protocol/output.rs
+++ b/rust/src/engine-core-client/src/protocol/output.rs
@@ -76,7 +76,7 @@ pub struct EngineCoreEvent {
 /// Engine-core output for a single request.
 ///
 /// Original Python definition:
-/// <https://github.com/vllm-project/vllm/blob/d3af8c18317c0dc008d42e4367fbb9045cfb7bf6/vllm/v1/engine/__init__.py#L154-L184>
+/// <https://github.com/vllm-project/vllm/blob/main/vllm/v1/engine/__init__.py>
 #[derive(Debug, Clone, PartialEq, Serialize_tuple, Deserialize_tuple, DefaultFromSerde)]
 pub struct EngineCoreOutput {
     pub request_id: String,
@@ -109,6 +109,10 @@ pub struct EngineCoreOutput {
     pub prefill_stats: Option<PrefillStats>,
     #[serde(default)]
     pub routed_experts: Option<OpaqueValue>,
+    /// Per-token indexer topk indices (sparse-attention selected KV slots).
+    /// `None` when `enable_return_indexer_topk` is off.
+    #[serde(default)]
+    pub indexer_topk: Option<OpaqueValue>,
     /// Number of NaNs seen in logits. Values above zero indicate corruption.
     #[serde(default)]
     pub num_nans_in_logits: u32,
@@ -383,6 +387,7 @@ mod tests {
                 trace_headers: None,
                 prefill_stats: None,
                 routed_experts: None,
+                indexer_topk: None,
                 num_nans_in_logits: 0,
             }],
             finished_requests: Some(BTreeSet::from(["req-1".to_string()])),
@@ -436,6 +441,7 @@ mod tests {
                             trace_headers: None,
                             prefill_stats: None,
                             routed_experts: None,
+                            indexer_topk: None,
                             num_nans_in_logits: 0,
                         },
                     ],

--- a/rust/src/engine-core-client/src/tests/client.rs
+++ b/rust/src/engine-core-client/src/tests/client.rs
@@ -234,6 +234,7 @@ fn request_output(
         trace_headers: None,
         prefill_stats: None,
         routed_experts: None,
+        indexer_topk: None,
         num_nans_in_logits: 0,
     }
 }
@@ -2606,6 +2607,7 @@ fn python_msgpack_fixtures_match_rust_encoding() {
                         trace_headers: None,
                         prefill_stats: None,
                         routed_experts: None,
+                        indexer_topk: None,
                         num_nans_in_logits: 0,
                     },
                 ],

--- a/rust/src/engine-core-client/src/tests/python_compat.py
+++ b/rust/src/engine-core-client/src/tests/python_compat.py
@@ -96,6 +96,7 @@ class EngineCoreOutput(
     trace_headers: object | None = None
     prefill_stats: object | None = None
     routed_experts: object | None = None
+    indexer_topk: object | None = None
     num_nans_in_logits: int = 0
 
 

--- a/rust/src/llm/tests/generate.rs
+++ b/rust/src/llm/tests/generate.rs
@@ -58,6 +58,7 @@ fn request_output_with_events(
         trace_headers: None,
         prefill_stats: None,
         routed_experts: None,
+        indexer_topk: None,
         num_nans_in_logits: 0,
     }
 }
@@ -83,6 +84,7 @@ fn request_output_with_logprobs(
         trace_headers: None,
         prefill_stats: None,
         routed_experts: None,
+        indexer_topk: None,
         num_nans_in_logits: 0,
     }
 }
@@ -110,6 +112,7 @@ fn request_output_with_logprobs_and_kv(
         trace_headers: None,
         prefill_stats: None,
         routed_experts: None,
+        indexer_topk: None,
         num_nans_in_logits: 0,
     }
 }

--- a/rust/src/server/src/grpc/tests.rs
+++ b/rust/src/server/src/grpc/tests.rs
@@ -125,6 +125,7 @@ fn request_output(
         trace_headers: None,
         prefill_stats: None,
         routed_experts: None,
+        indexer_topk: None,
         num_nans_in_logits: 0,
     }
 }

--- a/rust/src/server/src/routes/http_client_tests.rs
+++ b/rust/src/server/src/routes/http_client_tests.rs
@@ -107,6 +107,7 @@ fn request_output(
         trace_headers: None,
         prefill_stats: None,
         routed_experts: None,
+        indexer_topk: None,
         num_nans_in_logits: 0,
     }
 }

--- a/rust/src/server/src/routes/tests.rs
+++ b/rust/src/server/src/routes/tests.rs
@@ -87,6 +87,7 @@ fn request_output_with_stop_reason(
         trace_headers: None,
         prefill_stats: None,
         routed_experts: None,
+        indexer_topk: None,
         num_nans_in_logits: 0,
     }
 }
@@ -113,6 +114,7 @@ fn request_output_with_logprobs(
         trace_headers: None,
         prefill_stats: None,
         routed_experts: None,
+        indexer_topk: None,
         num_nans_in_logits: 0,
     }
 }
@@ -141,6 +143,7 @@ fn request_output_with_logprobs_and_kv(
         trace_headers: None,
         prefill_stats: None,
         routed_experts: None,
+        indexer_topk: None,
         num_nans_in_logits: 0,
     }
 }

--- a/tests/entrypoints/openai/test_return_indexer_topk.py
+++ b/tests/entrypoints/openai/test_return_indexer_topk.py
@@ -1,0 +1,209 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""End-to-end tests for ``--enable-return-indexer-topk``.
+
+Verifies that the OpenAI-compatible endpoints (``/v1/completions`` and
+``/v1/chat/completions``) return per-token sparse-attention indexer topk
+indices when the server is launched with ``--enable-return-indexer-topk``.
+
+The indices are base64-encoded ``.npy`` bytes; after decoding the ndarray
+has shape ``(num_tokens, num_indexer_layers, index_topk)`` and dtype
+``int32`` (see :class:`IndexerTopkManager`).
+
+Only models with :class:`SparseAttnIndexer` layers (DeepSeek-V32 / V4)
+emit indexer topk. To keep the test CI-friendly we launch
+``deepseek-ai/DeepSeek-V3.2`` with ``--load-format dummy`` (random weights)
+and shrink it via ``--hf-overrides`` to a tiny 2-layer / 128-hidden config.
+The GPU memory fraction can be tuned via ``VLLM_TEST_GPU_MEMORY_UTILIZATION``
+(defaults to 0.5).
+"""
+
+import io
+import os
+
+import numpy as np
+import pybase64 as base64
+import pytest
+
+from vllm.platforms import current_platform
+from vllm.utils.import_utils import has_deep_gemm
+
+from ...utils import RemoteOpenAIServer
+
+# DeepSeek-V3.2 carries a SparseAttnIndexer in every backbone layer when
+# ``index_topk`` is set. Shrink the model so it fits in CI:
+#   - 2 hidden layers  -> 2 indexer layers (default freq=1, offset=2
+#     still produces an indexer in every layer because
+#     max(layer_id - offset + 1, 0) % freq == 0 for all layer ids).
+#   - index_topk=128 keeps the per-token payload small (smallest value
+#     that still exercises multi-slot selection).
+#   - hidden_size=128 / intermediate=256 / 2 experts keeps memory tiny.
+#   - num_experts_per_tok=2 must be <= n_routed_experts.
+SMALL_V32_OVERRIDES = {
+    "num_hidden_layers": 2,
+    "hidden_size": 128,
+    "intermediate_size": 256,
+    "num_attention_heads": 4,
+    "num_key_value_heads": 1,
+    "n_routed_experts": 2,
+    "num_experts_per_tok": 2,
+    "index_topk": 128,
+}
+
+MODEL_NAME = "deepseek-ai/DeepSeek-V3.2"
+NUM_INDEXER_LAYERS = 2
+INDEX_TOPK = 128
+
+# Allow CI / developers to override the GPU memory fraction used by the
+# server. Default 0.5 is conservative enough for H100 80GB but small enough
+# to coexist with other GPU processes on smaller cards.
+DEFAULT_GPU_MEM_UTIL = float(os.environ.get("VLLM_TEST_GPU_MEMORY_UTILIZATION", "0.5"))
+
+# SparseAttnIndexer currently requires CUDA + DeepGEMM (Hopper+).
+pytestmark = pytest.mark.skipif(
+    not current_platform.is_cuda() or not has_deep_gemm(),
+    reason="indexer_topk e2e test requires CUDA with DeepGEMM (Hopper+).",
+)
+
+
+@pytest.fixture(scope="module")
+def server():
+    args = [
+        "--max-model-len",
+        "1024",
+        "--max-num-seqs",
+        "4",
+        "--enforce-eager",
+        "--load-format",
+        "dummy",
+        "--trust-remote-code",
+        "--enable-return-indexer-topk",
+        "--gpu-memory-utilization",
+        str(DEFAULT_GPU_MEM_UTIL),
+    ]
+    with RemoteOpenAIServer(
+        MODEL_NAME,
+        args,
+        override_hf_configs=SMALL_V32_OVERRIDES,
+    ) as remote_server:
+        yield remote_server
+
+
+def _decode_indexer_topk(b64: str) -> np.ndarray:
+    """Decode the base64 ``.npy`` payload returned by the server."""
+    return np.load(io.BytesIO(base64.b64decode(b64)))
+
+
+@pytest.mark.asyncio
+async def test_indexer_topk_completions(server):
+    """``/v1/completions`` returns base64 indexer_topk with valid shape."""
+    async with server.get_async_client() as client:
+        result = await client.completions.create(
+            model=MODEL_NAME,
+            prompt="Hello, world",
+            max_tokens=5,
+            temperature=0,
+            extra_body={
+                "return_token_ids": True,
+                # Request indexer topk for the full prompt + generated tokens
+                "indexer_topk_prompt_start": 0,
+            },
+        )
+
+        choice = result.model_dump()["choices"][0]
+
+        # Field must exist and be populated when the flag is enabled.
+        assert choice["indexer_topk"] is not None, (
+            "indexer_topk is None; ensure --enable-return-indexer-topk is set "
+            "and the model has SparseAttnIndexer layers."
+        )
+        assert choice["token_ids"] is not None
+
+        indexer_topk = _decode_indexer_topk(choice["indexer_topk"])
+
+        # Shape contract: (num_tokens, num_indexer_layers, index_topk).
+        assert indexer_topk.ndim == 3
+        num_tokens, num_indexer_layers, index_topk = indexer_topk.shape
+        # prompt (>=1) + generated tokens (5)
+        assert num_tokens > 0
+        assert num_indexer_layers == NUM_INDEXER_LAYERS
+        assert index_topk == INDEX_TOPK
+
+        # dtype is int32 (KV slot indices can exceed 65535).
+        assert indexer_topk.dtype == np.int32
+
+        # KV-slot indices are non-negative; -1 is the documented "no valid
+        # slot" sentinel used by the top-k kernels (see
+        # ``sparse_attn_indexer.py`` and ``dcp_indexer_cutedsl.py``). When the
+        # sequence is shorter than ``index_topk``, unfilled positions remain
+        # -1, so we require at least one valid index rather than all.
+        assert (indexer_topk >= 0).any(), (
+            "Expected at least one valid (non-negative) indexer_topk entry, "
+            "but all values are -1 sentinels."
+        )
+
+
+@pytest.mark.asyncio
+async def test_indexer_topk_chat_completions(server):
+    """``/v1/chat/completions`` also surfaces indexer_topk."""
+    async with server.get_async_client() as client:
+        result = await client.chat.completions.create(
+            model=MODEL_NAME,
+            messages=[{"role": "user", "content": "What is 2+2?"}],
+            max_tokens=5,
+            temperature=0,
+            extra_body={
+                "return_token_ids": True,
+                "indexer_topk_prompt_start": 0,
+            },
+        )
+
+        choice = result.model_dump()["choices"][0]
+        assert choice["indexer_topk"] is not None
+
+        indexer_topk = _decode_indexer_topk(choice["indexer_topk"])
+        assert indexer_topk.ndim == 3
+        assert indexer_topk.shape[0] > 0
+        assert indexer_topk.shape[1] == NUM_INDEXER_LAYERS
+        assert indexer_topk.shape[2] == INDEX_TOPK
+        assert indexer_topk.dtype == np.int32
+        # -1 is the expected sentinel for unfilled top-k positions.
+        assert (indexer_topk >= 0).any(), (
+            "Expected at least one valid (non-negative) indexer_topk entry."
+        )
+
+
+@pytest.mark.asyncio
+async def test_indexer_topk_prompt_start_offset(server):
+    """``indexer_topk_prompt_start`` trims the leading prompt tokens."""
+    prompt = "The quick brown fox jumps over the lazy dog."
+    prompt_start = 4
+
+    async with server.get_async_client() as client:
+        full = await client.completions.create(
+            model=MODEL_NAME,
+            prompt=prompt,
+            max_tokens=3,
+            temperature=0,
+            extra_body={"indexer_topk_prompt_start": 0},
+        )
+        trimmed = await client.completions.create(
+            model=MODEL_NAME,
+            prompt=prompt,
+            max_tokens=3,
+            temperature=0,
+            extra_body={"indexer_topk_prompt_start": prompt_start},
+        )
+
+        full_topk = _decode_indexer_topk(
+            full.model_dump()["choices"][0]["indexer_topk"]
+        )
+        trimmed_topk = _decode_indexer_topk(
+            trimmed.model_dump()["choices"][0]["indexer_topk"]
+        )
+
+        # The trimmed output should drop exactly `prompt_start` tokens
+        # from the leading prompt (same number of generated tokens).
+        assert full_topk.shape[0] - trimmed_topk.shape[0] == prompt_start
+        # Layer / index_topk dimensions are unaffected.
+        assert full_topk.shape[1:] == trimmed_topk.shape[1:]

--- a/tests/entrypoints/openai/test_return_indexer_topk.py
+++ b/tests/entrypoints/openai/test_return_indexer_topk.py
@@ -141,6 +141,7 @@ async def test_indexer_topk_completions(server):
             "Expected at least one valid (non-negative) indexer_topk entry, "
             "but all values are -1 sentinels."
         )
+        assert (indexer_topk < 0).any(), "Expected -1 padding sentinels."
 
 
 @pytest.mark.asyncio
@@ -171,6 +172,7 @@ async def test_indexer_topk_chat_completions(server):
         assert (indexer_topk >= 0).any(), (
             "Expected at least one valid (non-negative) indexer_topk entry."
         )
+        assert (indexer_topk < 0).any(), "Expected -1 padding sentinels."
 
 
 @pytest.mark.asyncio

--- a/tests/model_executor/test_sparse_attn_indexer_capture.py
+++ b/tests/model_executor/test_sparse_attn_indexer_capture.py
@@ -4,8 +4,13 @@
 import sys
 from types import ModuleType, SimpleNamespace
 
+import pytest
+import torch
+
 from vllm.model_executor.layers.sparse_attn_indexer_capturer import (
+    IndexerTopkCapturer,
     _get_num_indexer_layers,
+    get_indexer_shape,
     get_sparse_attn_indexers,
 )
 
@@ -38,3 +43,43 @@ def test_capture_discovers_target_indexers_only(monkeypatch):
 
     assert get_sparse_attn_indexers(target_model) == [target_indexer]
     assert draft_indexer in static_forward_context.values()
+
+
+def test_indexer_capture_requires_complete_and_matching_layers():
+    capturer = IndexerTopkCapturer(
+        max_num_batched_tokens=4,
+        num_indexer_layers=2,
+        index_topk=3,
+        device="cpu",
+    )
+    capturer.begin_step()
+    capturer.capture(0, torch.ones(2, 3, dtype=torch.int32))
+    with pytest.raises(RuntimeError, match="missed indexer layers"):
+        capturer.validate_step()
+
+    capturer.capture(1, torch.full((2, 3), 2, dtype=torch.int32))
+    capturer.validate_step()
+    torch.testing.assert_close(
+        capturer.get_device_buffer()[:2, 1],
+        torch.full((2, 3), 2, dtype=torch.int32),
+    )
+
+
+def test_indexer_capture_rejects_invalid_tensor_shape_and_layer():
+    capturer = IndexerTopkCapturer(4, 1, 3, "cpu")
+    with pytest.raises(IndexError):
+        capturer.capture(-1, torch.ones(1, 3, dtype=torch.int32))
+    with pytest.raises(ValueError, match="must have shape"):
+        capturer.capture(0, torch.ones(1, 2, dtype=torch.int32))
+
+
+def test_indexer_shape_requires_positive_config():
+    config = SimpleNamespace(
+        index_topk=0,
+        num_hidden_layers=4,
+        index_topk_pattern=None,
+        index_topk_freq=1,
+        index_skip_topk_offset=2,
+    )
+    with pytest.raises(ValueError, match="positive"):
+        get_indexer_shape(config)

--- a/tests/model_executor/test_sparse_attn_indexer_capture.py
+++ b/tests/model_executor/test_sparse_attn_indexer_capture.py
@@ -1,0 +1,40 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import sys
+from types import ModuleType, SimpleNamespace
+
+from vllm.model_executor.layers.sparse_attn_indexer_capturer import (
+    _get_num_indexer_layers,
+    get_sparse_attn_indexers,
+)
+
+
+def test_num_indexer_layers_with_short_pattern():
+    config = SimpleNamespace(
+        index_topk=128,
+        num_hidden_layers=4,
+        index_topk_pattern="SS",
+    )
+
+    assert _get_num_indexer_layers(config) == 2
+
+
+def test_capture_discovers_target_indexers_only(monkeypatch):
+    class DummyIndexer:
+        pass
+
+    target_indexer = DummyIndexer()
+    draft_indexer = DummyIndexer()
+    target_model = SimpleNamespace(modules=lambda: [target_indexer])
+    static_forward_context = {
+        "model.layers.0.indexer": target_indexer,
+        "mtp.layers.0.indexer": draft_indexer,
+    }
+
+    indexer_module = ModuleType("vllm.model_executor.layers.sparse_attn_indexer")
+    indexer_module.SparseAttnIndexer = DummyIndexer  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, indexer_module.__name__, indexer_module)
+
+    assert get_sparse_attn_indexers(target_model) == [target_indexer]
+    assert draft_indexer in static_forward_context.values()

--- a/tests/v1/core/test_async_scheduler.py
+++ b/tests/v1/core/test_async_scheduler.py
@@ -290,6 +290,8 @@ def test_abort_request_when_structured_output_fsm_cannot_advance():
     scheduler.vllm_config = Mock()
     scheduler.vllm_config.model_config.enable_return_routed_experts = False
     scheduler.enable_return_routed_experts = False
+    scheduler.vllm_config.model_config.enable_return_indexer_topk = False
+    scheduler.enable_return_indexer_topk = False
     scheduler.recompute_kv_load_failures = False
     scheduler.defer_block_free = False
     scheduler.make_stats = Mock(return_value=None)

--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -3255,6 +3255,8 @@ def test_abort_request_when_structured_output_fsm_cannot_advance():
     scheduler.vllm_config = Mock()
     scheduler.vllm_config.model_config.enable_return_routed_experts = False
     scheduler.enable_return_routed_experts = False
+    scheduler.vllm_config.model_config.enable_return_indexer_topk = False
+    scheduler.enable_return_indexer_topk = False
     scheduler.recompute_kv_load_failures = False
     scheduler.defer_block_free = False
     scheduler.make_stats = Mock(return_value=None)

--- a/tests/v1/executor/test_ray_utils.py
+++ b/tests/v1/executor/test_ray_utils.py
@@ -5,6 +5,7 @@ import numpy as np
 
 from vllm.v1.executor.ray_utils import detach_zero_copy_from_model_runner_output
 from vllm.v1.outputs import (
+    IndexerTopkLists,
     LogprobsLists,
     LogprobsTensors,
     ModelRunnerOutput,
@@ -81,4 +82,29 @@ def test_detach_zero_copy_routed_experts_without_logprobs():
     assert detached.routing_data.flags.writeable
     assert detached.slot_mapping.flags.writeable
     np.testing.assert_array_equal(detached.routing_data, original.routing_data)
+    np.testing.assert_array_equal(detached.slot_mapping, original.slot_mapping)
+
+
+def test_detach_zero_copy_indexer_topk_without_logprobs():
+    output = ModelRunnerOutput(
+        req_ids=["req-0"],
+        req_id_to_index={"req-0": 0},
+        indexer_topk=IndexerTopkLists(
+            topk_data=_make_readonly(np.arange(12, dtype=np.int32).reshape(2, 2, 3)),
+            slot_mapping=_make_readonly(np.array([7, 8], dtype=np.int64)),
+        ),
+    )
+    original = output.indexer_topk
+    assert output.logprobs is None
+
+    detach_zero_copy_from_model_runner_output(output)
+
+    detached = output.indexer_topk
+    assert detached is not None
+    assert detached is not original
+    assert detached.topk_data is not original.topk_data
+    assert detached.slot_mapping is not original.slot_mapping
+    assert detached.topk_data.flags.writeable
+    assert detached.slot_mapping.flags.writeable
+    np.testing.assert_array_equal(detached.topk_data, original.topk_data)
     np.testing.assert_array_equal(detached.slot_mapping, original.slot_mapping)

--- a/tests/v1/sample/test_logprobs.py
+++ b/tests/v1/sample/test_logprobs.py
@@ -524,6 +524,7 @@ def test_all_logprobs(example_prompts):
 
 
 @pytest.mark.parametrize("logprobs_mode", get_args(LogprobsMode))
+@large_gpu_mark(min_gb=4)
 def test_logprobs_mode(logprobs_mode: LogprobsMode):
     """Test with LLM engine with different logprobs_mode.
     For logprobs, we should have non-positive values.
@@ -564,6 +565,7 @@ def test_logprobs_mode(logprobs_mode: LogprobsMode):
         cleanup_dist_env_and_memory()
 
 
+@large_gpu_mark(min_gb=4)
 def test_prompt_logprobs_mode():
     """prompt_logprobs must respect logprobs_mode: *_logits and *_logprobs
     must return different values. Prompt tokens skip sampling processors,

--- a/tests/v1/worker/test_gpu_model_runner_v2_eplb.py
+++ b/tests/v1/worker/test_gpu_model_runner_v2_eplb.py
@@ -181,6 +181,7 @@ def test_v2_sample_tokens_runs_eplb_on_non_last_pp_rank(monkeypatch):
         aux_hidden_states=None,
         finished_req_ids=set(),
         routed_experts=None,
+        indexer_topk=None,
         num_tokens_across_dp=None,
     )
     runner.req_states = SimpleNamespace()

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -241,6 +241,10 @@ class ModelConfig:
     flexibility."""
     enable_return_routed_experts: bool = False
     """Whether to return routed experts."""
+    enable_return_indexer_topk: bool = False
+    """Whether to return indexer topk indices (sparse-attention selected KV
+    slots) with responses. Only applicable to models with sparse attention
+    indexers (e.g. DeepSeek-V32/V4)."""
     max_logprobs: int = Field(default=20, ge=-1)
     """Maximum number of log probabilities to return when `logprobs` is
     specified in `SamplingParams`. The default value comes the default for the

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -1074,6 +1074,14 @@ class VllmConfig:
                     "pipeline parallelism (PP > 1)."
                 )
             if (
+                self.parallel_config.decode_context_parallel_size > 1
+                or self.parallel_config.prefill_context_parallel_size > 1
+            ):
+                raise ValueError(
+                    "--enable-return-indexer-topk is incompatible with "
+                    "context parallelism (DCP > 1 or PCP > 1)."
+                )
+            if (
                 self.kv_transfer_config is not None
                 and self.kv_transfer_config.is_kv_transfer_instance
             ):

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -622,6 +622,15 @@ class VllmConfig:
     @property
     def use_v2_model_runner(self) -> bool:
         use_v2_model_runner = envs.VLLM_USE_V2_MODEL_RUNNER
+        if (
+            self.model_config is not None
+            and self.model_config.enable_return_indexer_topk
+        ):
+            if use_v2_model_runner is False:
+                raise ValueError(
+                    "--enable-return-indexer-topk requires Model Runner V2."
+                )
+            return True
         if use_v2_model_runner is not None:
             return use_v2_model_runner
 
@@ -1052,6 +1061,24 @@ class VllmConfig:
             ):
                 raise ValueError(
                     "--enable-return-routed-experts is incompatible with KV "
+                    "connectors (PD disaggregation, KV cache offload)."
+                )
+
+        if (
+            self.model_config is not None
+            and self.model_config.enable_return_indexer_topk
+        ):
+            if self.parallel_config.pipeline_parallel_size > 1:
+                raise ValueError(
+                    "--enable-return-indexer-topk is incompatible with "
+                    "pipeline parallelism (PP > 1)."
+                )
+            if (
+                self.kv_transfer_config is not None
+                and self.kv_transfer_config.is_kv_transfer_instance
+            ):
+                raise ValueError(
+                    "--enable-return-indexer-topk is incompatible with KV "
                     "connectors (PD disaggregation, KV cache offload)."
                 )
 

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -425,6 +425,7 @@ class EngineArgs:
 
     model: str = ModelConfig.model
     enable_return_routed_experts: bool = ModelConfig.enable_return_routed_experts
+    enable_return_indexer_topk: bool = ModelConfig.enable_return_indexer_topk
     model_weights: str = ModelConfig.model_weights
     served_model_name: str | list[str] | None = ModelConfig.served_model_name
     tokenizer: str | None = ModelConfig.tokenizer
@@ -867,6 +868,10 @@ class EngineArgs:
         model_group.add_argument(
             "--enable-return-routed-experts",
             **model_kwargs["enable_return_routed_experts"],
+        )
+        model_group.add_argument(
+            "--enable-return-indexer-topk",
+            **model_kwargs["enable_return_indexer_topk"],
         )
         model_group.add_argument("--max-logprobs", **model_kwargs["max_logprobs"])
         model_group.add_argument("--logprobs-mode", **model_kwargs["logprobs_mode"])
@@ -1739,6 +1744,7 @@ class EngineArgs:
             allow_deprecated_quantization=self.allow_deprecated_quantization,
             enforce_eager=self.enforce_eager,
             enable_return_routed_experts=self.enable_return_routed_experts,
+            enable_return_indexer_topk=self.enable_return_indexer_topk,
             max_logprobs=self.max_logprobs,
             logprobs_mode=self.logprobs_mode,
             use_fp64_gumbel=self.use_fp64_gumbel,

--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -141,6 +141,9 @@ class LLM(BeamSearchOfflineMixin, PoolingOfflineMixin, OfflineInferenceMixin):
             disable CUDA graph and always execute the model in eager mode.
             If False, we will use CUDA graph and eager execution in hybrid.
         enable_return_routed_experts: Whether to return routed experts.
+        enable_return_indexer_topk: Whether to return indexer topk indices
+            (sparse-attention selected KV slots) with responses. Only
+            applicable to models with sparse attention indexers.
         disable_custom_all_reduce: See
             [ParallelConfig][vllm.config.ParallelConfig].
         hf_token: The token to use as HTTP bearer authorization for remote files
@@ -201,6 +204,7 @@ class LLM(BeamSearchOfflineMixin, PoolingOfflineMixin, OfflineInferenceMixin):
         offload_params: set[str] | None = None,
         enforce_eager: bool = False,
         enable_return_routed_experts: bool = False,
+        enable_return_indexer_topk: bool = False,
         disable_custom_all_reduce: bool = False,
         hf_token: bool | str | None = None,
         hf_overrides: HfOverrides | None = None,
@@ -317,6 +321,7 @@ class LLM(BeamSearchOfflineMixin, PoolingOfflineMixin, OfflineInferenceMixin):
             offload_params=offload_params or set(),
             enforce_eager=enforce_eager,
             enable_return_routed_experts=enable_return_routed_experts,
+            enable_return_indexer_topk=enable_return_indexer_topk,
             disable_custom_all_reduce=disable_custom_all_reduce,
             hf_token=hf_token,
             hf_overrides=hf_overrides,

--- a/vllm/entrypoints/openai/chat_completion/protocol.py
+++ b/vllm/entrypoints/openai/chat_completion/protocol.py
@@ -122,6 +122,15 @@ class ChatCompletionResponseChoice(OpenAIBaseModel):
     # or (b) ``enable_return_routed_experts`` is off server-side.
     routed_experts: str | None = None
 
+    # Per-token indexer topk indices (sparse-attention selected KV
+    # slots), base64-encoded ``.npy`` bytes. Shape after decode:
+    #   (num_tokens, num_indexer_layers, index_topk)  dtype int32
+    # Decode:
+    #   np.load(io.BytesIO(base64.b64decode(s)))
+    # ``None`` if (a) the request was aborted before any forward pass,
+    # or (b) ``enable_return_indexer_topk`` is off server-side.
+    indexer_topk: str | None = None
+
 
 class ChatCompletionResponse(OpenAIBaseModel):
     id: str = Field(default_factory=lambda: f"chatcmpl-{random_uuid()}")
@@ -419,6 +428,22 @@ class ChatCompletionRequest(OpenAIBaseModel):
             "only in the first chunk, and token_ids contains the delta tokens "
             "for each chunk. This is useful for debugging or when you "
             "need to map generated text back to input tokens."
+        ),
+    )
+    routed_experts_prompt_start: int = Field(
+        default=0,
+        ge=0,
+        description=(
+            "When enable_return_routed_experts is active, skip the first "
+            "N prompt tokens from the returned routing data."
+        ),
+    )
+    indexer_topk_prompt_start: int = Field(
+        default=0,
+        ge=0,
+        description=(
+            "When enable_return_indexer_topk is active, skip the first "
+            "N prompt tokens from the returned indexer topk indices."
         ),
     )
     return_token_offsets: bool | None = Field(
@@ -740,6 +765,8 @@ class ChatCompletionRequest(OpenAIBaseModel):
             extra_args=extra_args or None,
             skip_clone=True,  # Created fresh per request, safe to skip clone
             repetition_detection=self.repetition_detection,
+            routed_experts_prompt_start=self.routed_experts_prompt_start,
+            indexer_topk_prompt_start=self.indexer_topk_prompt_start,
         )
 
     @model_validator(mode="before")

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -1015,13 +1015,13 @@ class OpenAIServingChat(GenerateBaseServing):
             if output.routed_experts is not None:
                 buf = io.BytesIO()
                 np.save(buf, output.routed_experts)
-                routed_experts_b64 = base64.b64encode(buf.getvalue()).decode("ascii")
+                routed_experts_b64 = base64.b64encode(buf.getbuffer()).decode("ascii")
 
             indexer_topk_b64 = None
             if output.indexer_topk is not None:
                 buf = io.BytesIO()
                 np.save(buf, output.indexer_topk)
-                indexer_topk_b64 = base64.b64encode(buf.getvalue()).decode("ascii")
+                indexer_topk_b64 = base64.b64encode(buf.getbuffer()).decode("ascii")
 
             choice_data = ChatCompletionResponseChoice(
                 index=output.index,

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -1017,6 +1017,12 @@ class OpenAIServingChat(GenerateBaseServing):
                 np.save(buf, output.routed_experts)
                 routed_experts_b64 = base64.b64encode(buf.getvalue()).decode("ascii")
 
+            indexer_topk_b64 = None
+            if output.indexer_topk is not None:
+                buf = io.BytesIO()
+                np.save(buf, output.indexer_topk)
+                indexer_topk_b64 = base64.b64encode(buf.getvalue()).decode("ascii")
+
             choice_data = ChatCompletionResponseChoice(
                 index=output.index,
                 message=message,
@@ -1033,6 +1039,7 @@ class OpenAIServingChat(GenerateBaseServing):
                     else None
                 ),
                 routed_experts=routed_experts_b64,
+                indexer_topk=indexer_topk_b64,
             )
             choice_data = maybe_filter_parallel_tool_calls(choice_data, request)
 

--- a/vllm/entrypoints/openai/completion/protocol.py
+++ b/vllm/entrypoints/openai/completion/protocol.py
@@ -174,6 +174,22 @@ class CompletionRequest(OpenAIBaseModel):
             "need to map generated text back to input tokens."
         ),
     )
+    routed_experts_prompt_start: int = Field(
+        default=0,
+        ge=0,
+        description=(
+            "When enable_return_routed_experts is active, skip the first "
+            "N prompt tokens from the returned routing data."
+        ),
+    )
+    indexer_topk_prompt_start: int = Field(
+        default=0,
+        ge=0,
+        description=(
+            "When enable_return_indexer_topk is active, skip the first "
+            "N prompt tokens from the returned indexer topk indices."
+        ),
+    )
     return_token_offsets: bool | None = Field(
         default=False,
         description=(
@@ -393,6 +409,8 @@ class CompletionRequest(OpenAIBaseModel):
             skip_clone=True,  # Created fresh per request, safe to skip clone
             repetition_detection=self.repetition_detection,
             thinking_token_budget=self.thinking_token_budget,
+            routed_experts_prompt_start=self.routed_experts_prompt_start,
+            indexer_topk_prompt_start=self.indexer_topk_prompt_start,
         )
 
     @model_validator(mode="before")
@@ -618,6 +636,15 @@ class CompletionResponseChoice(OpenAIBaseModel):
     # ``None`` if (a) the request was aborted before any forward pass,
     # or (b) ``enable_return_routed_experts`` is off server-side.
     routed_experts: str | None = None
+
+    # Per-token indexer topk indices (sparse-attention selected KV
+    # slots), base64-encoded ``.npy`` bytes. Shape after decode:
+    #   (num_tokens, num_indexer_layers, index_topk)  dtype int32
+    # Decode:
+    #   np.load(io.BytesIO(base64.b64decode(s)))
+    # ``None`` if (a) the request was aborted before any forward pass,
+    # or (b) ``enable_return_indexer_topk`` is off server-side.
+    indexer_topk: str | None = None
 
 
 class CompletionResponse(OpenAIBaseModel):

--- a/vllm/entrypoints/openai/completion/serving.py
+++ b/vllm/entrypoints/openai/completion/serving.py
@@ -582,6 +582,12 @@ class OpenAIServingCompletion(GenerateBaseServing):
                         "ascii"
                     )
 
+                indexer_topk_b64 = None
+                if output.indexer_topk is not None:
+                    buf = io.BytesIO()
+                    np.save(buf, output.indexer_topk)
+                    indexer_topk_b64 = base64.b64encode(buf.getvalue()).decode("ascii")
+
                 choice_data = CompletionResponseChoice(
                     index=len(choices),
                     text=output_text,
@@ -596,6 +602,7 @@ class OpenAIServingCompletion(GenerateBaseServing):
                         as_list(output.token_ids) if request.return_token_ids else None
                     ),
                     routed_experts=routed_experts_b64,
+                    indexer_topk=indexer_topk_b64,
                 )
                 choices.append(choice_data)
 

--- a/vllm/entrypoints/openai/completion/serving.py
+++ b/vllm/entrypoints/openai/completion/serving.py
@@ -578,7 +578,7 @@ class OpenAIServingCompletion(GenerateBaseServing):
                 if output.routed_experts is not None:
                     buf = io.BytesIO()
                     np.save(buf, output.routed_experts)
-                    routed_experts_b64 = base64.b64encode(buf.getvalue()).decode(
+                    routed_experts_b64 = base64.b64encode(buf.getbuffer()).decode(
                         "ascii"
                     )
 
@@ -586,7 +586,7 @@ class OpenAIServingCompletion(GenerateBaseServing):
                 if output.indexer_topk is not None:
                     buf = io.BytesIO()
                     np.save(buf, output.indexer_topk)
-                    indexer_topk_b64 = base64.b64encode(buf.getvalue()).decode("ascii")
+                    indexer_topk_b64 = base64.b64encode(buf.getbuffer()).decode("ascii")
 
                 choice_data = CompletionResponseChoice(
                     index=len(choices),

--- a/vllm/model_executor/layers/sparse_attn_indexer.py
+++ b/vllm/model_executor/layers/sparse_attn_indexer.py
@@ -778,6 +778,15 @@ class SparseAttnIndexer(CustomOp):
                 "the current vLLM environment."
             )
 
+    def set_capture_fn(self, capture_fn: Callable[[torch.Tensor], None]) -> None:
+        """Set the callback used to export top-k indices after each forward."""
+        self.capture_fn = capture_fn
+
+    def dispatch_capture(self, num_tokens: int) -> None:
+        """Dispatch a capture for paths that call the kernel directly."""
+        if self.capture_fn is not None:
+            self.capture_fn(self.topk_indices_buffer[:num_tokens, : self.topk_tokens])
+
     def forward_native(
         self,
         hidden_states: torch.Tensor,
@@ -834,9 +843,7 @@ class SparseAttnIndexer(CustomOp):
         # Capture topk indices for return_indexer_topk if enabled.
         # The op writes into ``topk_indices_buffer[:num_tokens, :topk_tokens]``;
         # we slice to the actual token count and forward to the capturer.
-        if self.capture_fn is not None:
-            num_tokens = hidden_states.shape[0]
-            self.capture_fn(self.topk_indices_buffer[:num_tokens, : self.topk_tokens])
+        self.dispatch_capture(hidden_states.shape[0])
         return result
 
     def forward_xpu(
@@ -876,11 +883,7 @@ class SparseAttnIndexer(CustomOp):
                 self.topk_indices_buffer,
                 skip_k_cache_insert=self.skip_k_cache_insert,
             )
-            if self.capture_fn is not None:
-                num_tokens = hidden_states.shape[0]
-                self.capture_fn(
-                    self.topk_indices_buffer[:num_tokens, : self.topk_tokens]
-                )
+            self.dispatch_capture(hidden_states.shape[0])
             return result
         raise RuntimeError(
             "Sparse attention indexer ROCm path is only supported on AITER. "

--- a/vllm/model_executor/layers/sparse_attn_indexer.py
+++ b/vllm/model_executor/layers/sparse_attn_indexer.py
@@ -2,6 +2,8 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Custom Sparse Attention Indexer layers."""
 
+from collections.abc import Callable
+
 import torch
 
 import vllm.envs as envs
@@ -14,9 +16,7 @@ from vllm.forward_context import get_forward_context
 from vllm.logger import init_logger
 from vllm.model_executor.custom_op import CustomOp
 from vllm.model_executor.layers.attention.pcp import maybe_gather_indexer_k
-from vllm.model_executor.layers.quantization.utils.quant_utils import (
-    get_fp8_min_max,
-)
+from vllm.model_executor.layers.quantization.utils.quant_utils import get_fp8_min_max
 from vllm.platforms import current_platform
 from vllm.triton_utils import tl, triton
 from vllm.utils.deep_gemm import (
@@ -31,9 +31,7 @@ from vllm.utils.torch_utils import (
     _resolve_layer_name,
     direct_register_custom_op,
 )
-from vllm.v1.attention.backends.mla.indexer import (
-    DeepseekV32IndexerMetadata,
-)
+from vllm.v1.attention.backends.mla.indexer import DeepseekV32IndexerMetadata
 from vllm.v1.attention.ops.common import pack_seq_triton, unpack_seq_triton
 from vllm.v1.worker.workspace import current_workspace_manager
 
@@ -761,6 +759,10 @@ class SparseAttnIndexer(CustomOp):
         self.topk_indices_buffer = topk_indices_buffer
         self.skip_k_cache_insert = skip_k_cache_insert
         self.use_fp4_cache = use_fp4_cache
+        # Optional capture callback set by GPUModelRunner when
+        # ``enable_return_indexer_topk`` is active. Called with the
+        # topk-indices slice after each forward.
+        self.capture_fn: Callable[[torch.Tensor], None] | None = None
         self.dense_mha_metadata_layer_name = ""
         # DCP scalars are constant for the run; resolve them here (config is set
         # during model construction) and pass them into the custom op, rather
@@ -806,7 +808,7 @@ class SparseAttnIndexer(CustomOp):
             q_values, q_scale = q_quant
         else:
             q_values, q_scale = q_quant, None
-        return torch.ops.vllm.sparse_attn_indexer(
+        result = torch.ops.vllm.sparse_attn_indexer(
             hidden_states,
             _encode_layer_name(self.k_cache.prefix),
             self.k_cache.kv_cache,
@@ -829,6 +831,13 @@ class SparseAttnIndexer(CustomOp):
             self.dcp_world_size,
             self.cp_kv_cache_interleave_size,
         )
+        # Capture topk indices for return_indexer_topk if enabled.
+        # The op writes into ``topk_indices_buffer[:num_tokens, :topk_tokens]``;
+        # we slice to the actual token count and forward to the capturer.
+        if self.capture_fn is not None:
+            num_tokens = hidden_states.shape[0]
+            self.capture_fn(self.topk_indices_buffer[:num_tokens, : self.topk_tokens])
+        return result
 
     def forward_xpu(
         self,
@@ -851,7 +860,7 @@ class SparseAttnIndexer(CustomOp):
             "AMD sparse_attn_indexer expects a single FP8 q_quant tensor"
         )
         if rocm_aiter_ops.is_enabled() or rocm_aiter_ops.is_rdna_aiter_enabled():
-            return torch.ops.vllm.rocm_aiter_sparse_attn_indexer(
+            result = torch.ops.vllm.rocm_aiter_sparse_attn_indexer(
                 hidden_states,
                 _encode_layer_name(self.k_cache.prefix),
                 self.k_cache.kv_cache,
@@ -867,6 +876,12 @@ class SparseAttnIndexer(CustomOp):
                 self.topk_indices_buffer,
                 skip_k_cache_insert=self.skip_k_cache_insert,
             )
+            if self.capture_fn is not None:
+                num_tokens = hidden_states.shape[0]
+                self.capture_fn(
+                    self.topk_indices_buffer[:num_tokens, : self.topk_tokens]
+                )
+            return result
         raise RuntimeError(
             "Sparse attention indexer ROCm path is only supported on AITER. "
             "Please enable aiter with VLLM_ROCM_USE_AITER=1"

--- a/vllm/model_executor/layers/sparse_attn_indexer_capturer.py
+++ b/vllm/model_executor/layers/sparse_attn_indexer_capturer.py
@@ -45,7 +45,8 @@ def _get_index_topk(hf_config) -> int:
     DeepSeek-V32 and V4 store the sparse-attention topk under
     ``index_topk``. Returns 0 when the model has no indexer.
     """
-    return getattr(hf_config, "index_topk", 0)
+    index_topk = getattr(hf_config, "index_topk", 0)
+    return index_topk if isinstance(index_topk, int) else 0
 
 
 def _get_num_indexer_layers(hf_config) -> int:
@@ -66,6 +67,10 @@ def _get_num_indexer_layers(hf_config) -> int:
     pattern = getattr(hf_config, "index_topk_pattern", None)
     skip_offset = getattr(hf_config, "index_skip_topk_offset", 2)
 
+    if not isinstance(freq, int) or freq <= 0:
+        return 0
+    if pattern is not None and not isinstance(pattern, str):
+        return 0
     if pattern is not None:
         # The model only applies the pattern where it has an entry. Layers
         # beyond a short pattern still build an indexer.
@@ -79,6 +84,18 @@ def _get_num_indexer_layers(hf_config) -> int:
         if max(layer_id - skip_offset + 1, 0) % freq == 0:
             count += 1
     return count
+
+
+def get_indexer_shape(hf_config) -> tuple[int, int]:
+    """Return the canonical ``(num_indexer_layers, index_topk)`` shape."""
+    num_indexer_layers = _get_num_indexer_layers(hf_config)
+    index_topk = _get_index_topk(hf_config)
+    if num_indexer_layers <= 0 or index_topk <= 0:
+        raise ValueError(
+            "Indexer top-k capture requires positive indexer layer and top-k "
+            f"counts, got {num_indexer_layers=}, {index_topk=}."
+        )
+    return num_indexer_layers, index_topk
 
 
 def get_sparse_attn_indexers(
@@ -120,8 +137,9 @@ class IndexerTopkCapturer:
     Invariants:
         - One instance per worker; shape is fixed at init and covers the
           worst-case step (``max_num_batched_tokens`` tokens).
-        - :meth:`clear_buffer` is called at the start of every step, so
-          unused slots stay zero.
+        - Every configured indexer layer overwrites the current step's token
+          rows before the buffer is consumed. Rows beyond the current step
+          are never read.
         - ``device_buffer.dtype`` is ``torch.int32``.
     """
 
@@ -143,6 +161,11 @@ class IndexerTopkCapturer:
             dtype=torch.int32,
             device=device,
         )
+        self._captured_layers = [False] * num_indexer_layers
+
+    def begin_step(self) -> None:
+        """Reset the small per-step callback completeness tracker."""
+        self._captured_layers[:] = [False] * self.num_indexer_layers
 
     def capture(self, compact_layer_id: int, topk_indices: torch.Tensor) -> None:
         """Capture topk indices for a specific indexer layer.
@@ -152,17 +175,37 @@ class IndexerTopkCapturer:
                 assigned at bind time, NOT the model layer_id.
             topk_indices: Tensor of shape (batch_size, index_topk).
         """
-        batch_size = topk_indices.shape[0]
-        if compact_layer_id >= self.device_buffer.shape[1]:
+        if compact_layer_id < 0 or compact_layer_id >= self.device_buffer.shape[1]:
             raise IndexError(
                 f"indexer capture layer {compact_layer_id} exceeds buffer "
                 f"layer dim {self.device_buffer.shape[1]}"
             )
+        if topk_indices.ndim != 2 or topk_indices.shape[1] != self.index_topk:
+            raise ValueError(
+                "Indexer capture tensor must have shape "
+                f"(batch, {self.index_topk}), got {tuple(topk_indices.shape)}."
+            )
+        batch_size = topk_indices.shape[0]
+        if batch_size > self.device_buffer.shape[0]:
+            raise ValueError(
+                f"Indexer capture batch {batch_size} exceeds buffer capacity "
+                f"{self.device_buffer.shape[0]}."
+            )
         self.device_buffer[:batch_size, compact_layer_id, :] = topk_indices
+        self._captured_layers[compact_layer_id] = True
 
-    def clear_buffer(self) -> None:
-        """Zero the device buffer. Called at the start of every step."""
-        self.device_buffer.zero_()
+    def validate_step(self) -> None:
+        """Fail closed when a model path skipped an indexer callback."""
+        missing = [
+            layer_id
+            for layer_id, captured in enumerate(self._captured_layers)
+            if not captured
+        ]
+        if missing:
+            raise RuntimeError(
+                "Indexer top-k capture missed indexer layers "
+                f"{missing}; refusing to return stale device-buffer data."
+            )
 
     def get_device_buffer(self) -> torch.Tensor:
         """Return the underlying device buffer for D2H copy."""
@@ -196,8 +239,7 @@ class IndexerTopkManager:
         self.block_size = attn_group.kv_cache_spec.block_size
 
         hf_config = vllm_config.model_config.hf_text_config
-        self.num_indexer_layers = _get_num_indexer_layers(hf_config)
-        self.index_topk = _get_index_topk(hf_config)
+        self.num_indexer_layers, self.index_topk = get_indexer_shape(hf_config)
         max_num_slots = kv_cache_config.num_blocks * self.block_size
         self.indexer_topk_by_slot = np.zeros(
             (
@@ -221,6 +263,25 @@ class IndexerTopkManager:
 
         Equivalent to ``slot_buffer[slot_mapping] = data``.
         """
+        if data.ndim != 3 or data.shape[1:] != (
+            self.num_indexer_layers,
+            self.index_topk,
+        ):
+            raise ValueError(
+                "Indexer top-k data shape does not match the configured shape: "
+                f"got {data.shape}, expected (*, {self.num_indexer_layers}, "
+                f"{self.index_topk})."
+            )
+        if slot_mapping.ndim != 1 or data.shape[0] != slot_mapping.shape[0]:
+            raise ValueError(
+                "Indexer top-k data and slot mapping must have matching leading "
+                f"dimensions, got {data.shape[0]} and {slot_mapping.shape}."
+            )
+        if slot_mapping.size and (
+            np.any(slot_mapping < 0)
+            or np.any(slot_mapping >= self.indexer_topk_by_slot.shape[0])
+        ):
+            raise ValueError("Indexer top-k slot mapping contains an invalid slot.")
         self.indexer_topk_by_slot[slot_mapping] = data
 
     def get(

--- a/vllm/model_executor/layers/sparse_attn_indexer_capturer.py
+++ b/vllm/model_executor/layers/sparse_attn_indexer_capturer.py
@@ -1,0 +1,229 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Worker-side capturer and scheduler-side manager for indexer topk indices.
+
+Mirrors the architecture of :mod:`routed_experts_capturer`: the worker
+captures per-layer sparse-attention topk indices into a device buffer
+during the forward pass, D2H-copies them into a pinned CPU buffer, and
+hands them to the scheduler via :class:`IndexerTopkLists`. The scheduler
+persists them into a slot-indexed CPU buffer keyed by the physical KV-cache
+block layout, and returns the per-request slice when the request finishes.
+
+Key differences from routed_experts:
+  - Capture source is :class:`SparseAttnIndexer` (not MoE router).
+  - Only indexer layers capture (compact layer dimension, not
+    ``num_hidden_layers``).
+  - ``topk_size`` is ``index_topk`` (typically 512+), much larger than
+    ``num_experts_per_tok`` (4-8).
+  - dtype is ``int32`` (KV slot indices can exceed 65535).
+"""
+
+from __future__ import annotations
+
+import logging
+
+import numpy as np
+import torch
+
+from vllm.config import VllmConfig
+from vllm.v1.kv_cache_interface import (
+    KVCacheConfig,
+    KVCacheSpecKind,
+    get_kv_cache_spec_kind,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _get_index_topk(hf_config) -> int:
+    """Resolve ``index_topk`` from the HF config.
+
+    DeepSeek-V32 and V4 store the sparse-attention topk under
+    ``index_topk``. Returns 0 when the model has no indexer.
+    """
+    return getattr(hf_config, "index_topk", 0)
+
+
+def _get_num_indexer_layers(hf_config) -> int:
+    """Count the number of backbone layers that build an indexer.
+
+    Mirrors the skip logic in
+    :func:`vllm.model_executor.models.deepseek_v2.DeepseekV32Attention.__init__`:
+    when ``index_topk_pattern`` is ``None``, layer ``i`` builds an indexer
+    iff ``max(i - index_skip_topk_offset + 1, 0) % index_topk_freq == 0``;
+    otherwise the per-layer pattern string ``"S"`` means skip.
+    """
+    if not hasattr(hf_config, "index_topk"):
+        return 0
+    num_hidden_layers = hf_config.num_hidden_layers
+    if not isinstance(num_hidden_layers, int):
+        return 0
+    freq = getattr(hf_config, "index_topk_freq", 1)
+    pattern = getattr(hf_config, "index_topk_pattern", None)
+    skip_offset = getattr(hf_config, "index_skip_topk_offset", 2)
+
+    if pattern is not None:
+        return sum(
+            1 for i in range(min(len(pattern), num_hidden_layers)) if pattern[i] != "S"
+        )
+    count = 0
+    for layer_id in range(num_hidden_layers):
+        if max(layer_id - skip_offset + 1, 0) % freq == 0:
+            count += 1
+    return count
+
+
+def get_indexer_attn_group_id(kv_cache_config: KVCacheConfig) -> int:
+    """Return the full-attention KV-cache group used by the indexer."""
+    full_attention_kinds = {
+        KVCacheSpecKind.FULL_ATTENTION,
+        KVCacheSpecKind.MLA_ATTENTION,
+        KVCacheSpecKind.SINK_FULL_ATTENTION,
+    }
+    for gid, group in enumerate(kv_cache_config.kv_cache_groups):
+        if get_kv_cache_spec_kind(group.kv_cache_spec) in full_attention_kinds:
+            return gid
+    raise ValueError(
+        "--enable-return-indexer-topk requires a full-attention KV cache group."
+    )
+
+
+class IndexerTopkCapturer:
+    """Worker-side capturer for indexer topk indices, lives on GPU.
+
+    :class:`SparseAttnIndexer` calls :meth:`capture` from inside its
+    forward pass with the per-layer topk-indices tensor. The tensor is
+    written into a preallocated device buffer indexed by a compact
+    layer id. At the end of the step, :class:`GPUModelRunner` reads the
+    device buffer, issues a D2H copy into a pinned CPU buffer, and hands
+    the result to the scheduler via :class:`IndexerTopkLists`.
+
+    Invariants:
+        - One instance per worker; shape is fixed at init and covers the
+          worst-case step (``max_num_batched_tokens`` tokens).
+        - :meth:`clear_buffer` is called at the start of every step, so
+          unused slots stay zero.
+        - ``device_buffer.dtype`` is ``torch.int32``.
+    """
+
+    def __init__(
+        self,
+        max_num_batched_tokens: int,
+        num_indexer_layers: int,
+        index_topk: int,
+        device: str,
+    ) -> None:
+        self.num_indexer_layers = num_indexer_layers
+        self.index_topk = index_topk
+        self.device_buffer = torch.zeros(
+            (
+                max_num_batched_tokens,
+                num_indexer_layers,
+                index_topk,
+            ),
+            dtype=torch.int32,
+            device=device,
+        )
+
+    def capture(self, compact_layer_id: int, topk_indices: torch.Tensor) -> None:
+        """Capture topk indices for a specific indexer layer.
+
+        Args:
+            compact_layer_id: The compact index (0..num_indexer_layers-1)
+                assigned at bind time, NOT the model layer_id.
+            topk_indices: Tensor of shape (batch_size, index_topk).
+        """
+        batch_size = topk_indices.shape[0]
+        if compact_layer_id >= self.device_buffer.shape[1]:
+            return
+        self.device_buffer[:batch_size, compact_layer_id, :] = topk_indices
+
+    def clear_buffer(self) -> None:
+        """Zero the device buffer. Called at the start of every step."""
+        self.device_buffer.zero_()
+
+    def get_device_buffer(self) -> torch.Tensor:
+        """Return the underlying device buffer for D2H copy."""
+        return self.device_buffer
+
+
+class IndexerTopkManager:
+    """Scheduler-side slot-indexed buffer for indexer topk indices.
+
+    Lives on CPU in the scheduler process. Each slot corresponds to
+    ``block_id * block_size + offset_in_block``, tying topk data to
+    physical KV-cache blocks (same layout as :class:`RoutedExpertsManager`).
+
+    Data flow per step:
+      1. Worker D2Hs its device capture buffer into
+         :class:`IndexerTopkLists` and returns it via
+         :class:`ModelRunnerOutput`.
+      2. Scheduler calls :meth:`store_batch` with that step's
+         ``(topk_data, slot_mapping)``.
+      3. On request completion, the scheduler calls :meth:`get` with the
+         request's block IDs to recover the full per-token topk.
+    """
+
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        kv_cache_config: KVCacheConfig,
+    ) -> None:
+        self.attn_gid = get_indexer_attn_group_id(kv_cache_config)
+        attn_group = kv_cache_config.kv_cache_groups[self.attn_gid]
+        self.block_size = attn_group.kv_cache_spec.block_size
+
+        hf_config = vllm_config.model_config.hf_text_config
+        self.num_indexer_layers = _get_num_indexer_layers(hf_config)
+        self.index_topk = _get_index_topk(hf_config)
+        max_num_slots = kv_cache_config.num_blocks * self.block_size
+        self.indexer_topk_by_slot = np.zeros(
+            (
+                max_num_slots,
+                self.num_indexer_layers,
+                self.index_topk,
+            ),
+            dtype=np.int32,
+        )
+        logger.info(
+            "IndexerTopkManager CPU buffer: %.2f GB "
+            "(slots=%d, indexer_layers=%d, index_topk=%d)",
+            self.indexer_topk_by_slot.nbytes / 1e9,
+            max_num_slots,
+            self.num_indexer_layers,
+            self.index_topk,
+        )
+
+    def store_batch(self, data: np.ndarray, slot_mapping: np.ndarray) -> None:
+        """Persist one step's indexer topk into the slot buffer.
+
+        Equivalent to ``slot_buffer[slot_mapping] = data``.
+        """
+        self.indexer_topk_by_slot[slot_mapping] = data
+
+    def get(
+        self,
+        block_ids: list[int],
+        num_tokens: int,
+        token_start: int = 0,
+    ) -> np.ndarray:
+        """Read indexer topk for a completed / preempted request.
+
+        Args:
+            block_ids: Block IDs from the attention KV-cache group.
+            num_tokens: Number of tokens that have gone through a forward
+                pass (typically ``request.num_tokens - 1``).
+            token_start: Skip the first ``token_start`` tokens.
+
+        Returns:
+            Array of shape (num_tokens - token_start, num_indexer_layers,
+            index_topk).
+        """
+        bs = self.block_size
+        block_ids_array = np.array(block_ids, dtype=np.int32)
+        block_offsets = np.arange(bs)
+        slot_mapping = (
+            block_ids_array.reshape(-1, 1) * bs + block_offsets.reshape(1, -1)
+        ).flatten()[:num_tokens]
+        slot_mapping = slot_mapping[token_start:]
+        return self.indexer_topk_by_slot[slot_mapping]

--- a/vllm/model_executor/layers/sparse_attn_indexer_capturer.py
+++ b/vllm/model_executor/layers/sparse_attn_indexer_capturer.py
@@ -21,6 +21,7 @@ Key differences from routed_experts:
 from __future__ import annotations
 
 import logging
+from typing import TYPE_CHECKING
 
 import numpy as np
 import torch
@@ -33,6 +34,9 @@ from vllm.v1.kv_cache_interface import (
 )
 
 logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from vllm.model_executor.layers.sparse_attn_indexer import SparseAttnIndexer
 
 
 def _get_index_topk(hf_config) -> int:
@@ -63,14 +67,29 @@ def _get_num_indexer_layers(hf_config) -> int:
     skip_offset = getattr(hf_config, "index_skip_topk_offset", 2)
 
     if pattern is not None:
+        # The model only applies the pattern where it has an entry. Layers
+        # beyond a short pattern still build an indexer.
         return sum(
-            1 for i in range(min(len(pattern), num_hidden_layers)) if pattern[i] != "S"
+            1
+            for i in range(num_hidden_layers)
+            if i >= len(pattern) or pattern[i] != "S"
         )
     count = 0
     for layer_id in range(num_hidden_layers):
         if max(layer_id - skip_offset + 1, 0) % freq == 0:
             count += 1
     return count
+
+
+def get_sparse_attn_indexers(
+    model: torch.nn.Module,
+) -> list[SparseAttnIndexer]:
+    """Return indexers owned by the target model only."""
+    from vllm.model_executor.layers.sparse_attn_indexer import SparseAttnIndexer
+
+    return [
+        module for module in model.modules() if isinstance(module, SparseAttnIndexer)
+    ]
 
 
 def get_indexer_attn_group_id(kv_cache_config: KVCacheConfig) -> int:
@@ -135,7 +154,10 @@ class IndexerTopkCapturer:
         """
         batch_size = topk_indices.shape[0]
         if compact_layer_id >= self.device_buffer.shape[1]:
-            return
+            raise IndexError(
+                f"indexer capture layer {compact_layer_id} exceeds buffer "
+                f"layer dim {self.device_buffer.shape[1]}"
+            )
         self.device_buffer[:batch_size, compact_layer_id, :] = topk_indices
 
     def clear_buffer(self) -> None:

--- a/vllm/models/deepseek_v32/attention.py
+++ b/vllm/models/deepseek_v32/attention.py
@@ -489,6 +489,7 @@ class DeepseekV32Attention(MLAAttention):
                 # fused_norm_rope already cleared the topk buffer this forward.
                 skip_topk_buffer_clear=True,
             )
+            self.indexer.indexer_op.dispatch_capture(q_c.shape[0])
 
         attn_metadata_raw = get_forward_context().attn_metadata
         if isinstance(attn_metadata_raw, dict):

--- a/vllm/models/deepseek_v4/attention.py
+++ b/vllm/models/deepseek_v4/attention.py
@@ -860,6 +860,7 @@ class DeepseekV4Indexer(nn.Module):
                         PADDED_TOP_K=triton.next_power_of_2(self.topk_tokens),
                         num_warps=8,
                     )
+                self.indexer_op.dispatch_capture(num_tokens)
                 return self.topk_indices_buffer
 
         def wq_b_and_q_quant():

--- a/vllm/outputs.py
+++ b/vllm/outputs.py
@@ -43,6 +43,8 @@ class CompletionOutput:
     cumulative_logprob: float | None
     logprobs: SampleLogprobs | None
     routed_experts: np.ndarray | None = None  # [seq_len,layer_num,topk]
+    # [seq_len, num_indexer_layers, index_topk]
+    indexer_topk: np.ndarray | None = None
     finish_reason: str | None = None
     stop_reason: int | str | None = None
     lora_request: LoRARequest | None = None
@@ -56,6 +58,7 @@ class CompletionOutput:
             f"text={self.text!r}, "
             f"token_ids={self.token_ids}, "
             f"routed_experts={self.routed_experts}, "
+            f"indexer_topk={self.indexer_topk}, "
             f"cumulative_logprob={self.cumulative_logprob}, "
             f"logprobs={self.logprobs}, "
             f"finish_reason={self.finish_reason}, "

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -337,6 +337,10 @@ class SamplingParams(
     already-returned prefix to avoid duplicating routing for prompt tokens
     covered by earlier turns. Default 0 returns routing for all prompt
     tokens."""
+    indexer_topk_prompt_start: int = 0
+    """When enable_return_indexer_topk is active, skip the first
+    indexer_topk_prompt_start prompt tokens from the returned topk
+    indices. Same semantics as routed_experts_prompt_start."""
 
     # Fields used for bad words
     bad_words: list[str] | None = None
@@ -390,6 +394,8 @@ class SamplingParams(
         skip_clone: bool = False,
         repetition_detection: RepetitionDetectionParams | None = None,
         logprob_token_ids: list[int] | None = None,
+        routed_experts_prompt_start: int = 0,
+        indexer_topk_prompt_start: int = 0,
     ) -> "SamplingParams":
         if logit_bias is not None:
             # Fast path uses a dict comprehension; on failure we iterate once
@@ -452,6 +458,8 @@ class SamplingParams(
             extra_args=extra_args,
             skip_clone=skip_clone,
             repetition_detection=repetition_detection,
+            routed_experts_prompt_start=routed_experts_prompt_start,
+            indexer_topk_prompt_start=indexer_topk_prompt_start,
         )
 
     def __post_init__(self) -> None:

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -28,6 +28,9 @@ from vllm.logger import init_logger
 from vllm.model_executor.layers.fused_moe.routed_experts_capturer import (
     RoutedExpertsManager,
 )
+from vllm.model_executor.layers.sparse_attn_indexer_capturer import (
+    IndexerTopkManager,
+)
 from vllm.multimodal import MULTIMODAL_REGISTRY, MultiModalRegistry
 from vllm.multimodal.encoder_budget import MultiModalBudget
 from vllm.multimodal.utils import get_mm_features_in_window
@@ -339,6 +342,17 @@ class Scheduler(SchedulerInterface):
             # so update_from_output can read slot data even if a later
             # schedule() frees the blocks (async scheduling race).
             self._re_block_ids: dict[str, list[int]] = {}
+
+        self.enable_return_indexer_topk = (
+            vllm_config.model_config.enable_return_indexer_topk
+        )
+
+        if self.enable_return_indexer_topk:
+            self.indexer_topk_mgr = IndexerTopkManager(
+                vllm_config=vllm_config,
+                kv_cache_config=kv_cache_config,
+            )
+            self._it_block_ids: dict[str, list[int]] = {}
 
         self._pause_state: PauseState = PauseState.UNPAUSED
 
@@ -1353,9 +1367,18 @@ class Scheduler(SchedulerInterface):
                 }
             )
 
-        # Clear the finished and preempted request IDs.
-        # NOTE: We shouldn't just clear() here because it will also affect
-        # the scheduler output.
+        if self.enable_return_indexer_topk:
+            gid = self.indexer_topk_mgr.attn_gid
+            self._it_block_ids.update(
+                {
+                    rid: self.kv_cache_manager.get_blocks(rid).get_block_ids()[gid]
+                    for rid in num_scheduled_tokens
+                }
+            )
+
+        # Clear the finished request IDs.
+        # NOTE: We shouldn't do self.finished_req_ids.clear() here because
+        # it will also affect the scheduler output.
         self.finished_req_ids = set()
         self.reset_preempted_req_ids = set()
 
@@ -1720,6 +1743,17 @@ class Scheduler(SchedulerInterface):
                 routing_offsets[rid] = offset
                 offset += num_scheduled_tokens[rid]
 
+        indexer_topk_data = None
+        indexer_topk_offsets: dict[str, int] = {}
+        if model_runner_output.indexer_topk is not None:
+            it = model_runner_output.indexer_topk
+            self.indexer_topk_mgr.store_batch(it.topk_data, it.slot_mapping)
+            indexer_topk_data = it.topk_data
+            offset = 0
+            for rid in model_runner_output.req_ids:
+                indexer_topk_offsets[rid] = offset
+                offset += num_scheduled_tokens[rid]
+
         # NOTE(woosuk): As len(num_scheduled_tokens) can be up to 1K or more,
         # the below loop can be a performance bottleneck. We should do our best
         # to avoid expensive operations inside the loop.
@@ -1898,6 +1932,36 @@ class Scheduler(SchedulerInterface):
                         self.kv_cache_manager.estimate_cached_tokens(request)
                     )
 
+            indexer_topk = None
+            if (
+                self.enable_return_indexer_topk
+                and indexer_topk_data is not None
+                and new_token_ids
+            ):
+                req_offset = indexer_topk_offsets[req_id]
+                end = req_offset + num_tokens_scheduled
+                block_ids = self._it_block_ids.pop(req_id, [])
+                if num_output_tokens_before == 0:
+                    # Prefill completed: read full prompt topk from slot
+                    # buffer using the block-ID snapshot taken at
+                    # schedule time (immune to async preemption).
+                    if request.sampling_params is not None:
+                        prompt_start = request.sampling_params.indexer_topk_prompt_start
+                        assert prompt_start < request.num_prompt_tokens
+                    else:
+                        prompt_start = 0
+                    indexer_topk = self.indexer_topk_mgr.get(
+                        block_ids,
+                        request.num_prompt_tokens,
+                        token_start=prompt_start,
+                    )
+                elif scheduled_spec_token_ids:
+                    indexer_topk = indexer_topk_data[
+                        req_offset : req_offset + len(new_token_ids)
+                    ]
+                else:
+                    indexer_topk = indexer_topk_data[end - len(new_token_ids) : end]
+
             finish_reason = None
             if stopped:
                 # Capture finish_reason BEFORE _handle_stopped_request, which may
@@ -1942,6 +2006,7 @@ class Scheduler(SchedulerInterface):
                         ec_transfer_params=ec_transfer_params,
                         trace_headers=request.trace_headers,
                         routed_experts=routed_experts,
+                        indexer_topk=indexer_topk,
                         num_nans_in_logits=request.num_nans_in_logits,
                     )
                 )

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1940,14 +1940,23 @@ class Scheduler(SchedulerInterface):
             ):
                 req_offset = indexer_topk_offsets[req_id]
                 end = req_offset + num_tokens_scheduled
-                block_ids = self._it_block_ids.pop(req_id, [])
+                block_ids = self._it_block_ids.get(req_id, [])
                 if num_output_tokens_before == 0:
                     # Prefill completed: read full prompt topk from slot
                     # buffer using the block-ID snapshot taken at
                     # schedule time (immune to async preemption).
                     if request.sampling_params is not None:
                         prompt_start = request.sampling_params.indexer_topk_prompt_start
-                        assert prompt_start < request.num_prompt_tokens
+                        if (
+                            prompt_start < 0
+                            or prompt_start >= request.num_prompt_tokens
+                        ):
+                            raise ValueError(
+                                "indexer_topk_prompt_start "
+                                f"({prompt_start}) must be >= 0 and "
+                                "< num_prompt_tokens "
+                                f"({request.num_prompt_tokens})"
+                            )
                     else:
                         prompt_start = 0
                     indexer_topk = self.indexer_topk_mgr.get(
@@ -2374,6 +2383,8 @@ class Scheduler(SchedulerInterface):
         assert request.is_finished()
 
         self._inflight_prefills.discard(request)
+        if self.enable_return_indexer_topk:
+            self._it_block_ids.pop(request.request_id, None)
         connector_delay_free_blocks, kv_xfer_params = self._connector_finished(request)
 
         # EC Connector: mirror the KV hook. The contract requires firing

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1745,7 +1745,10 @@ class Scheduler(SchedulerInterface):
 
         indexer_topk_data = None
         indexer_topk_offsets: dict[str, int] = {}
-        if model_runner_output.indexer_topk is not None:
+        if (
+            self.enable_return_indexer_topk
+            and model_runner_output.indexer_topk is not None
+        ):
             it = model_runner_output.indexer_topk
             self.indexer_topk_mgr.store_batch(it.topk_data, it.slot_mapping)
             indexer_topk_data = it.topk_data
@@ -1947,14 +1950,11 @@ class Scheduler(SchedulerInterface):
                     # schedule time (immune to async preemption).
                     if request.sampling_params is not None:
                         prompt_start = request.sampling_params.indexer_topk_prompt_start
-                        if (
-                            prompt_start < 0
-                            or prompt_start >= request.num_prompt_tokens
-                        ):
+                        if prompt_start < 0 or prompt_start > request.num_prompt_tokens:
                             raise ValueError(
                                 "indexer_topk_prompt_start "
                                 f"({prompt_start}) must be >= 0 and "
-                                "< num_prompt_tokens "
+                                "<= num_prompt_tokens "
                                 f"({request.num_prompt_tokens})"
                             )
                     else:
@@ -1964,6 +1964,7 @@ class Scheduler(SchedulerInterface):
                         request.num_prompt_tokens,
                         token_start=prompt_start,
                     )
+                    self._it_block_ids.pop(req_id, None)
                 elif scheduled_spec_token_ids:
                     indexer_topk = indexer_topk_data[
                         req_offset : req_offset + len(new_token_ids)

--- a/vllm/v1/engine/__init__.py
+++ b/vllm/v1/engine/__init__.py
@@ -208,6 +208,9 @@ class EngineCoreOutput(
     prefill_stats: PrefillStats | None = None
 
     routed_experts: np.ndarray | None = None
+    # Per-token indexer topk indices (sparse-attention selected KV slots).
+    # Shape: (num_tokens, num_indexer_layers, index_topk), dtype int32.
+    indexer_topk: np.ndarray | None = None
     # The number of NaNs in logits.
     # A value greater than 0 indicates that the output is corrupted.
     num_nans_in_logits: int = 0

--- a/vllm/v1/engine/output_processor.py
+++ b/vllm/v1/engine/output_processor.py
@@ -178,6 +178,7 @@ class RequestState:
 
         # Routed experts accumulation (prompt + sample chunks)
         self.routed_experts_chunks: list[np.ndarray] = []
+        self.indexer_topk_chunks: list[np.ndarray] = []
 
         # Stream Interval
         self.stream_interval = stream_interval
@@ -411,11 +412,17 @@ class RequestState:
         if finished and self.routed_experts_chunks:
             routed_experts = np.concatenate(self.routed_experts_chunks, axis=0)
 
+        # Concatenate indexer topk on finish
+        indexer_topk = None
+        if finished and self.indexer_topk_chunks:
+            indexer_topk = np.concatenate(self.indexer_topk_chunks, axis=0)
+
         return CompletionOutput(
             index=self.request_index,
             text=text,
             token_ids=token_ids,
             routed_experts=routed_experts,
+            indexer_topk=indexer_topk,
             logprobs=logprobs,
             cumulative_logprob=self.logprobs_processor.cumulative_logprob,
             finish_reason=str(finish_reason) if finished else None,
@@ -638,6 +645,9 @@ class OutputProcessor:
                 req_state.routed_experts_chunks.append(
                     engine_core_output.routed_experts
                 )
+
+            if engine_core_output.indexer_topk is not None:
+                req_state.indexer_topk_chunks.append(engine_core_output.indexer_topk)
 
             if req_state.is_prefilling:
                 if engine_core_output.prefill_stats is not None:

--- a/vllm/v1/executor/ray_utils.py
+++ b/vllm/v1/executor/ray_utils.py
@@ -246,6 +246,13 @@ def detach_zero_copy_from_model_runner_output(output: "ModelRunnerOutput") -> No
                 routing_data_c, slot_mapping_c
             )
 
+    if output.indexer_topk is not None:
+        topk_data, slot_mapping = output.indexer_topk
+        topk_data_c = _copy_if_readonly(topk_data)
+        slot_mapping_c = _copy_if_readonly(slot_mapping)
+        if topk_data_c is not topk_data or slot_mapping_c is not slot_mapping:
+            output.indexer_topk = type(output.indexer_topk)(topk_data_c, slot_mapping_c)
+
 
 class FutureWrapper(Future):
     """A wrapper around Ray output reference to meet the interface

--- a/vllm/v1/outputs.py
+++ b/vllm/v1/outputs.py
@@ -204,6 +204,44 @@ class RoutedExpertsLists(NamedTuple):
     slot_mapping: np.ndarray
 
 
+class IndexerTopkTensors(NamedTuple):
+    """Device-side snapshot of indexer topk indices, pending async D2H.
+
+    Mirrors :class:`RoutedExpertsTensors` but for sparse-attention topk
+    indices. Shape:
+      - ``topk_data``: (num_scheduled_tokens, num_indexer_layers, index_topk)
+      - ``slot_mapping``: (num_scheduled_tokens,)
+    """
+
+    topk_data: torch.Tensor
+    slot_mapping: torch.Tensor
+
+    def to_cpu_nonblocking(self) -> "IndexerTopkTensors":
+        if self.topk_data.device.type == "cpu":
+            return self
+        return IndexerTopkTensors(
+            self.topk_data.to("cpu", non_blocking=True),
+            self.slot_mapping.to("cpu", non_blocking=True),
+        )
+
+    def tolists(self) -> "IndexerTopkLists":
+        return IndexerTopkLists(
+            self.topk_data.cpu().numpy(),
+            self.slot_mapping.cpu().numpy(),
+        )
+
+
+class IndexerTopkLists(NamedTuple):
+    """CPU-side indexer topk, the form :meth:`IndexerTopkManager.store_batch`
+    consumes.
+    """
+
+    # (num_scheduled_tokens, num_indexer_layers, index_topk)
+    topk_data: np.ndarray
+    # (num_scheduled_tokens,)
+    slot_mapping: np.ndarray
+
+
 # [num_reqs, <dynamic>]
 # The shape of each element depends on the pooler used
 PoolerOutput: TypeAlias = torch.Tensor | list[torch.Tensor] | list[torch.Tensor | None]
@@ -306,6 +344,10 @@ class ModelRunnerOutput:
     # its slot buffer via ``slot_buffer[slot_mapping] = routing_data``.
     # ``None`` when ``enable_return_routed_experts`` is off.
     routed_experts: RoutedExpertsLists | None = None
+
+    # Per-token indexer topk indices (sparse-attention selected KV slots).
+    # ``None`` when ``enable_return_indexer_topk`` is off.
+    indexer_topk: IndexerTopkLists | None = None
 
     @staticmethod
     def with_kv_conn_output_only(

--- a/vllm/v1/outputs.py
+++ b/vllm/v1/outputs.py
@@ -219,9 +219,15 @@ class IndexerTopkTensors(NamedTuple):
     def to_cpu_nonblocking(self) -> "IndexerTopkTensors":
         if self.topk_data.device.type == "cpu":
             return self
+        topk_data = torch.empty_like(self.topk_data, device="cpu", pin_memory=True)
+        slot_mapping = torch.empty_like(
+            self.slot_mapping, device="cpu", pin_memory=True
+        )
+        topk_data.copy_(self.topk_data, non_blocking=True)
+        slot_mapping.copy_(self.slot_mapping, non_blocking=True)
         return IndexerTopkTensors(
-            self.topk_data.to("cpu", non_blocking=True),
-            self.slot_mapping.to("cpu", non_blocking=True),
+            topk_data,
+            slot_mapping,
         )
 
     def tolists(self) -> "IndexerTopkLists":

--- a/vllm/v1/worker/gpu/async_utils.py
+++ b/vllm/v1/worker/gpu/async_utils.py
@@ -9,6 +9,7 @@ import vllm.envs as envs
 from vllm.model_executor.layers.fused_moe.all2all_utils import get_ep_all2all_manager
 from vllm.v1.outputs import (
     AsyncModelRunnerOutput,
+    IndexerTopkTensors,
     LogprobsTensors,
     ModelRunnerOutput,
     PoolerOutput,
@@ -28,6 +29,7 @@ class AsyncOutput(AsyncModelRunnerOutput):
         copy_stream: torch.cuda.Stream,
         check_ep_fault: bool = False,
         routed_experts: RoutedExpertsTensors | None = None,
+        indexer_topk: IndexerTopkTensors | None = None,
     ):
         # NOTE(woosuk): We must retain references to the GPU tensors,
         # as the copy operations are performed on a different CUDA stream than
@@ -36,6 +38,7 @@ class AsyncOutput(AsyncModelRunnerOutput):
         self.sampler_output = sampler_output
         self.num_sampled_tokens = num_sampled_tokens
         self.routed_experts = routed_experts
+        self.indexer_topk = indexer_topk
         # Blocking (sleep) event to avoid busy-polling the CUDA driver lock.
         self.copy_event = torch.cuda.Event(blocking=True)
         self._has_fault: torch.Tensor | None = None
@@ -60,6 +63,9 @@ class AsyncOutput(AsyncModelRunnerOutput):
                 k: v.to_cpu_nonblocking() if v is not None else None
                 for k, v in self.model_runner_output.prompt_logprobs_dict.items()
             }
+            self.indexer_topk_cpu = (
+                indexer_topk.to_cpu_nonblocking() if indexer_topk is not None else None
+            )
             if check_ep_fault:
                 has_fault = get_ep_all2all_manager().query_fault()
                 self._has_fault = has_fault.to("cpu", non_blocking=True)
@@ -90,6 +96,10 @@ class AsyncOutput(AsyncModelRunnerOutput):
         self.model_runner_output.prompt_logprobs_dict = self.prompt_logprobs_dict
         if self.routed_experts_cpu is not None:
             self.model_runner_output.routed_experts = self.routed_experts_cpu.tolists()
+
+        if self.indexer_topk_cpu is not None:
+            self.model_runner_output.indexer_topk = self.indexer_topk_cpu.tolists()
+        self.indexer_topk = None
 
         if self._has_fault is not None and self._has_fault.item():
             mask = get_ep_all2all_manager().query_active_mask()

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -48,6 +48,7 @@ from vllm.model_executor.layers.mamba.ops.ssu_dispatch import (
 from vllm.model_executor.layers.sparse_attn_indexer_capturer import (
     IndexerTopkCapturer,
     get_indexer_attn_group_id,
+    get_indexer_shape,
     get_sparse_attn_indexers,
 )
 from vllm.model_executor.model_loader import get_model_loader
@@ -321,16 +322,41 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         bind_routed_experts_capturer(self.model, self.routed_experts_capturer)
 
     def init_indexer_topk_capturer(self) -> None:
+        expected_layers, expected_topk = get_indexer_shape(
+            self.model_config.hf_text_config
+        )
         indexers = get_sparse_attn_indexers(self.model)
-        if not indexers:
+        if len(indexers) != expected_layers:
             raise RuntimeError(
-                "--enable-return-indexer-topk requires SparseAttnIndexer layers."
+                "Indexer layer count does not match the model config: "
+                f"discovered {len(indexers)}, expected {expected_layers}."
             )
+        topk_sizes = {indexer.topk_tokens for indexer in indexers}
+        if topk_sizes != {expected_topk}:
+            raise RuntimeError(
+                "Indexer top-k size does not match the model config: "
+                f"discovered {sorted(topk_sizes)}, expected {expected_topk}."
+            )
+        max_tokens = self.scheduler_config.max_num_batched_tokens
+        for indexer in indexers:
+            buffer = indexer.topk_indices_buffer
+            if (
+                buffer is None
+                or buffer.dtype != torch.int32
+                or buffer.ndim != 2
+                or buffer.shape[0] < max_tokens
+                or buffer.shape[1] != expected_topk
+            ):
+                raise RuntimeError(
+                    "Indexer top-k buffer is incompatible with capture: "
+                    f"got {None if buffer is None else (buffer.shape, buffer.dtype)}, "
+                    f"expected (* >= {max_tokens}, {expected_topk}) int32."
+                )
 
         capturer = IndexerTopkCapturer(
             max_num_batched_tokens=self.scheduler_config.max_num_batched_tokens,
-            num_indexer_layers=len(indexers),
-            index_topk=indexers[0].topk_tokens,
+            num_indexer_layers=expected_layers,
+            index_topk=expected_topk,
             device=self.device,
         )
         for layer_id, indexer in enumerate(indexers):
@@ -341,7 +367,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             ) -> None:
                 capturer.capture(compact_layer_id, topk_indices)
 
-            indexer.capture_fn = capture_fn
+            indexer.set_capture_fn(capture_fn)
 
         self.indexer_topk_capturer = capturer
         self.indexer_topk_attn_group_id = get_indexer_attn_group_id(
@@ -1289,8 +1315,8 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         skip_attn_for_dummy_run: bool = False,
         is_profile: bool = False,
     ) -> ModelRunnerOutput | IntermediateTensors | None:
-        if self.indexer_topk_capturer is not None:
-            self.indexer_topk_capturer.clear_buffer()
+        if self.indexer_topk_capturer is not None and not dummy_run:
+            self.indexer_topk_capturer.begin_step()
         if not dummy_run:
             # Update the request states.
             self.update_pp_decode_requests()
@@ -1539,6 +1565,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         indexer_topk = None
         if self.indexer_topk_capturer is not None and not dummy_run:
             assert slot_mappings is not None
+            self.indexer_topk_capturer.validate_step()
             indexer_topk = IndexerTopkTensors(
                 topk_data=self.indexer_topk_capturer.get_device_buffer()[
                     :num_toks

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -45,10 +45,10 @@ from vllm.model_executor.layers.fused_moe.routed_experts_capturer import (
 from vllm.model_executor.layers.mamba.ops.ssu_dispatch import (
     initialize_mamba_ssu_backend,
 )
-from vllm.model_executor.layers.sparse_attn_indexer import SparseAttnIndexer
 from vllm.model_executor.layers.sparse_attn_indexer_capturer import (
     IndexerTopkCapturer,
     get_indexer_attn_group_id,
+    get_sparse_attn_indexers,
 )
 from vllm.model_executor.model_loader import get_model_loader
 from vllm.model_executor.offloader import (
@@ -321,11 +321,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         bind_routed_experts_capturer(self.model, self.routed_experts_capturer)
 
     def init_indexer_topk_capturer(self) -> None:
-        indexers = [
-            module
-            for module in self.model.modules()
-            if isinstance(module, SparseAttnIndexer)
-        ]
+        indexers = get_sparse_attn_indexers(self.model)
         if not indexers:
             raise RuntimeError(
                 "--enable-return-indexer-topk requires SparseAttnIndexer layers."

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -45,6 +45,11 @@ from vllm.model_executor.layers.fused_moe.routed_experts_capturer import (
 from vllm.model_executor.layers.mamba.ops.ssu_dispatch import (
     initialize_mamba_ssu_backend,
 )
+from vllm.model_executor.layers.sparse_attn_indexer import SparseAttnIndexer
+from vllm.model_executor.layers.sparse_attn_indexer_capturer import (
+    IndexerTopkCapturer,
+    get_indexer_attn_group_id,
+)
 from vllm.model_executor.model_loader import get_model_loader
 from vllm.model_executor.offloader import (
     create_offloader,
@@ -65,6 +70,7 @@ from vllm.v1.core.sched.output import GrammarOutput, SchedulerOutput
 from vllm.v1.kv_cache_interface import KVCacheConfig, MambaSpec
 from vllm.v1.outputs import (
     DraftTokenIds,
+    IndexerTopkTensors,
     ModelRunnerOutput,
     RoutedExpertsTensors,
     make_empty_encoder_model_runner_output,
@@ -296,6 +302,8 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         # Expert parallelism load balancer.
         self.eplb = EPLBController(self.parallel_config, self.device)
         self.routed_experts_capturer: RoutedExpertsCapturer | None = None
+        self.indexer_topk_capturer: IndexerTopkCapturer | None = None
+        self.indexer_topk_attn_group_id = -1
 
         set_offloader(create_offloader(self.vllm_config.offload_config))
 
@@ -311,6 +319,38 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             kv_cache_config=self.kv_cache_config,
         )
         bind_routed_experts_capturer(self.model, self.routed_experts_capturer)
+
+    def init_indexer_topk_capturer(self) -> None:
+        indexers = [
+            module
+            for module in self.model.modules()
+            if isinstance(module, SparseAttnIndexer)
+        ]
+        if not indexers:
+            raise RuntimeError(
+                "--enable-return-indexer-topk requires SparseAttnIndexer layers."
+            )
+
+        capturer = IndexerTopkCapturer(
+            max_num_batched_tokens=self.scheduler_config.max_num_batched_tokens,
+            num_indexer_layers=len(indexers),
+            index_topk=indexers[0].topk_tokens,
+            device=self.device,
+        )
+        for layer_id, indexer in enumerate(indexers):
+
+            def capture_fn(
+                topk_indices: torch.Tensor,
+                compact_layer_id: int = layer_id,
+            ) -> None:
+                capturer.capture(compact_layer_id, topk_indices)
+
+            indexer.capture_fn = capture_fn
+
+        self.indexer_topk_capturer = capturer
+        self.indexer_topk_attn_group_id = get_indexer_attn_group_id(
+            self.kv_cache_config
+        )
 
     def get_supported_tasks(self) -> tuple[SupportedTask, ...]:
         tasks: list[SupportedTask] = []
@@ -1253,6 +1293,8 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         skip_attn_for_dummy_run: bool = False,
         is_profile: bool = False,
     ) -> ModelRunnerOutput | IntermediateTensors | None:
+        if self.indexer_topk_capturer is not None:
+            self.indexer_topk_capturer.clear_buffer()
         if not dummy_run:
             # Update the request states.
             self.update_pp_decode_requests()
@@ -1498,6 +1540,18 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             assert slot_mappings is not None
             routed_experts = capturer.get_routed_experts(slot_mappings, num_toks)
 
+        indexer_topk = None
+        if self.indexer_topk_capturer is not None and not dummy_run:
+            assert slot_mappings is not None
+            indexer_topk = IndexerTopkTensors(
+                topk_data=self.indexer_topk_capturer.get_device_buffer()[
+                    :num_toks
+                ].clone(),
+                slot_mapping=slot_mappings[self.indexer_topk_attn_group_id][
+                    :num_toks
+                ].clone(),
+            )
+
         finished_req_ids = scheduler_output.finished_req_ids
         self.execute_model_state = ExecuteModelState(
             input_batch=input_batch,
@@ -1507,6 +1561,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             aux_hidden_states=aux_hidden_states,
             finished_req_ids=finished_req_ids,
             routed_experts=routed_experts,
+            indexer_topk=indexer_topk,
         )
 
         if not self.is_last_pp_rank:
@@ -1530,6 +1585,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         aux_hidden_states = self.execute_model_state.aux_hidden_states
         finished_req_ids = self.execute_model_state.finished_req_ids
         routed_experts = self.execute_model_state.routed_experts
+        indexer_topk = self.execute_model_state.indexer_topk
         self.execute_model_state = None
 
         if not self.is_last_pp_rank:
@@ -1596,6 +1652,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             copy_stream=self.output_copy_stream,
             check_ep_fault=self.check_ep_fault,
             routed_experts=routed_experts,
+            indexer_topk=indexer_topk,
         )
 
         mm_inputs: tuple[list[torch.Tensor], torch.Tensor] | None = None
@@ -1782,6 +1839,7 @@ class ExecuteModelState(NamedTuple):
     aux_hidden_states: list[torch.Tensor] | None
     finished_req_ids: set[str]
     routed_experts: RoutedExpertsTensors | None
+    indexer_topk: IndexerTopkTensors | None
 
 
 def sort_batch_req_ids(

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -9,7 +9,7 @@ from collections.abc import Callable
 from contextlib import AbstractContextManager, contextmanager, nullcontext
 from datetime import timedelta
 from types import NoneType
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 import numpy as np
 import regex as re
@@ -90,6 +90,7 @@ logger = init_logger(__name__)
 if TYPE_CHECKING:
     from vllm.device_allocator.sleep_mode_backend import SleepModeBackend
     from vllm.model_executor.model_loader.tensorizer import TensorizerConfig
+    from vllm.v1.worker.gpu.model_runner import GPUModelRunner as GPUModelRunnerV2
     from vllm.v1.worker.gpu_model_runner import GPUModelRunner
 
 
@@ -667,6 +668,10 @@ class Worker(WorkerBase):
 
         if self.model_config.enable_return_routed_experts:
             self.model_runner.init_routed_experts_capturer()
+
+        if self.model_config.enable_return_indexer_topk:
+            assert self.use_v2_model_runner
+            cast("GPUModelRunnerV2", self.model_runner).init_indexer_topk_capturer()
 
         # Build KV-zero metadata outside the CuMem pool so the bookkeeping
         # GPU tensors (seg_addrs, block-id buffers) use the standard PyTorch


### PR DESCRIPTION
What changed:

- Switch top-k response serialization to `BytesIO.getbuffer()` to avoid an extra copy before base64 encoding.



Checks: `git diff --check`, `python -m py_compile` on the touched serving files.
