### PR TITLE
[CPU][MoE] Support DeepSeekV3 routing and group-size-32 INT4 checkpoints

### DIFF
--- a/vllm/model_executor/layers/fused_moe/experts/cpu_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/cpu_moe.py
@@ -32,6 +32,7 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
     kFp8Dynamic128Sym,
     kFp8Static128BlockSym,
     kInt4Static,
+    kInt4Static32,
     kInt8DynamicTokenSym,
     kInt8StaticChannelSym,
     kMxfp4Static,
@@ -900,6 +901,7 @@ class CPUExpertsInt4(mk.FusedMoEExpertsMonolithic):
     ) -> bool:
         SUPPORTED_W_A = [
             (kInt4Static, None),
+            (kInt4Static32, None),
         ]
         return (weight_key, activation_key) in SUPPORTED_W_A
 
@@ -911,6 +913,7 @@ class CPUExpertsInt4(mk.FusedMoEExpertsMonolithic):
     ) -> bool:
         return routing_method in [
             RoutingMethodType.Default,
+            RoutingMethodType.DeepSeekV3,
             RoutingMethodType.Renormalize,
             RoutingMethodType.RenormalizeNaive,
         ]
@@ -948,6 +951,8 @@ class CPUExpertsInt4(mk.FusedMoEExpertsMonolithic):
                 "apply_router_weight_on_input=True. "
             )
 
+        is_deepseek_v3 = self.moe_config.routing_method == RoutingMethodType.DeepSeekV3
+
         topk_weights, topk_ids = select_experts(
             hidden_states=hidden_states,
             router_logits=router_logits,
@@ -955,12 +960,13 @@ class CPUExpertsInt4(mk.FusedMoEExpertsMonolithic):
             top_k=self.moe_config.experts_per_token,
             renormalize=self.moe_config.routing_method
             in (
+                RoutingMethodType.DeepSeekV3,
                 RoutingMethodType.Renormalize,
                 RoutingMethodType.RenormalizeNaive,
             ),
             topk_group=topk_group,
             num_expert_group=num_expert_group,
-            scoring_func="softmax",
+            scoring_func="sigmoid" if is_deepseek_v3 else "softmax",
             routed_scaling_factor=(
                 routed_scaling_factor if routed_scaling_factor is not None else 1.0
             ),


### PR DESCRIPTION

This PR enables x86 AMX CPUExpertsInt4 to serve compressed-tensors INT4 MoE models that use group-size-32 quantization and DeepSeekV3-style noaux_tc routing, including Kimi-K2.5.
## Purpose
  Two capability checks prevented these models from using the existing CPU INT4 MoE kernel:

  1. Group-size-32 compressed-tensors weights produce the specific kInt4Static32 quantization key. The CPU kernel supported INT4 group quantization internally but only
     advertised the generic kInt4Static key.

  2. noaux_tc is represented as RoutingMethodType.DeepSeekV3. The CPU kernel’s routing implementation already accepts grouped top-k parameters and correction bias, but it only
     advertised softmax-based routing and always invoked select_experts with scoring_func="softmax".

  Consequently, backend selection failed with:

  NotImplementedError: No WNA16 MoE backend supports the deployment configuration.
## Test Plan
  Validated with a Kimi-K2.5-shaped configuration:

  - 384 routed experts
  - top-8 expert selection
  - hidden size 7168
  - MoE intermediate size 2048
  - BF16 activations
  - symmetric INT4 weights with group size 32
  - DeepSeekV3/noaux_tc routing
  - x86 AMX CPU backend
## Test Result
  - WNA16 backend selection chooses CPUExpertsInt4.
  - Selected expert IDs exactly match vLLM’s canonical DeepSeekV3 grouped router.
  - Maximum routing-weight difference: 1.49e-08.
  - Selected weights normalize to approximately 1.0.
  - Kimi-K2.5 proceeds through model loading and CPU INT4 post-processing.
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

