### PR TITLE
[Model Loader] Add FastSafetensors sharded-state loader

### DIFF
--- a/docs/models/extensions/fastsafetensor.md
+++ b/docs/models/extensions/fastsafetensor.md
@@ -3,4 +3,37 @@ Loading model weights with fastsafetensors
 
 Using fastsafetensors library enables loading model weights to GPU memory by leveraging GPU direct storage. See [their GitHub repository](https://github.com/foundation-model-stack/fastsafetensors) for more details.
 
-To enable this feature, use the `--load-format fastsafetensors` command-line argument
+To enable this feature, use the `--load-format fastsafetensors` command-line argument.
+
+Loading pre-sharded checkpoints
+-------------------------------
+
+Use `fastsafetensors_sharded` when the checkpoint already contains one shard per
+tensor-parallel rank. Each worker loads only files matching its rank and copies
+all of that rank's parts to the GPU in one FastSafetensors transfer. This avoids
+the expensive cross-node weight distribution step required when every rank
+cannot read its final shard directly:
+
+```bash
+vllm serve /path/to/sharded/model \
+    --load-format fastsafetensors_sharded
+```
+
+The default filename pattern is
+`model-rank-{rank}-part-{part}.safetensors`, matching checkpoints created by
+[`save_sharded_state_offline.py`](../../../examples/features/sharded_state/save_sharded_state_offline.py).
+Set a custom pattern or tune FastSafetensors through
+`--model-loader-extra-config`:
+
+```bash
+vllm serve /path/to/sharded/model \
+    --load-format fastsafetensors_sharded \
+    --model-loader-extra-config \
+    '{"pattern":"rank-{rank}-{part}.safetensors","max_threads":16}'
+```
+
+Supported keys are `pattern`, `nogds`, `bbuf_size_kb`, `max_threads`,
+`max_copy_block_size`, and `debug_log`. When `nogds` is omitted, the loader
+tries GDS first and retries with `nogds=true` if GDS initialization fails before
+any tensor is copied. Set `nogds=false` to require GDS or `nogds=true` to skip
+GDS.

--- a/tests/model_executor/model_loader/test_sharded_state_loader.py
+++ b/tests/model_executor/model_loader/test_sharded_state_loader.py
@@ -5,13 +5,23 @@ import fnmatch
 import multiprocessing as mp
 import os
 import shutil
+import sys
+import types
 from tempfile import TemporaryDirectory
+from typing import Any
+from unittest.mock import MagicMock, patch
 
 import pytest
 import torch
 
 from vllm import LLM, SamplingParams
-from vllm.model_executor.model_loader import ShardedStateLoader
+from vllm.config.load import LoadConfig
+from vllm.model_executor.model_loader import (
+    FastSafetensorsShardedStateLoader,
+    ShardedStateLoader,
+    get_model_loader,
+)
+from vllm.platforms import current_platform
 from vllm.transformers_utils.repo_utils import hf_api
 
 prompts = [
@@ -47,6 +57,113 @@ def test_filter_subtensors():
     for key, tensor in filtered_state_dict.items():
         # NOTE: don't use `equal` here, as the tensor might contain NaNs
         assert tensor is state_dict[key]
+
+
+def _fastsafetensors_module(loader_factory):
+    module: Any = types.ModuleType("fastsafetensors")
+    module.SafeTensorsFileLoader = loader_factory
+    module.SingleGroup = MagicMock(return_value=object())
+    return module
+
+
+def test_fastsafetensors_sharded_loader_routes_and_validates_config():
+    loader = get_model_loader(
+        LoadConfig(
+            load_format="fastsafetensors_sharded",
+            model_loader_extra_config={
+                "pattern": "rank-{rank}-{part}.safetensors",
+                "nogds": True,
+                "bbuf_size_kb": 4096,
+                "max_threads": 4,
+                "max_copy_block_size": 1024,
+                "debug_log": True,
+            },
+        )
+    )
+    assert isinstance(loader, FastSafetensorsShardedStateLoader)
+    assert loader.pattern == "rank-{rank}-{part}.safetensors"
+    assert loader.nogds is True
+    assert loader.bbuf_size_kb == 4096
+    assert loader.max_threads == 4
+    assert loader.max_copy_block_size == 1024
+    assert loader.debug_log is True
+
+    with pytest.raises(ValueError, match="nogds must be a boolean or null"):
+        FastSafetensorsShardedStateLoader(
+            LoadConfig(
+                load_format="fastsafetensors_sharded",
+                model_loader_extra_config={"nogds": "true"},
+            )
+        )
+
+
+def test_fastsafetensors_sharded_loads_all_rank_files_together():
+    loader = FastSafetensorsShardedStateLoader(
+        LoadConfig(
+            load_format="fastsafetensors_sharded",
+            model_loader_extra_config={"nogds": True},
+        )
+    )
+    file_buffer = MagicMock()
+    file_buffer.key_to_rank_lidx = {"weight": None}
+    file_buffer.get_tensor.return_value = torch.ones(1)
+    fast_loader = MagicMock()
+    fast_loader.copy_files_to_device.return_value = file_buffer
+    module = _fastsafetensors_module(MagicMock(return_value=fast_loader))
+    stream = MagicMock()
+
+    with (
+        patch.dict(sys.modules, {"fastsafetensors": module}),
+        patch.object(current_platform, "is_cuda_alike", return_value=True),
+        patch.object(current_platform, "current_device", return_value=0),
+        patch("torch.accelerator.synchronize") as synchronize,
+        patch("torch.accelerator.current_stream", return_value=stream),
+    ):
+        tensors = list(loader.iterate_over_files(["part-1", "part-0"]))
+
+    assert tensors[0][0] == "weight"
+    fast_loader.add_filenames.assert_called_once_with({0: ["part-0", "part-1"]})
+    fast_loader.copy_files_to_device.assert_called_once_with(
+        max_copy_block_size=loader.max_copy_block_size
+    )
+    synchronize.assert_called_once_with(torch.device("cuda:0"))
+    stream.synchronize.assert_called_once()
+    file_buffer.close.assert_called_once()
+    fast_loader.close.assert_called_once()
+
+
+def test_fastsafetensors_sharded_retries_gds_failure_before_copy():
+    loader = FastSafetensorsShardedStateLoader(
+        LoadConfig(load_format="fastsafetensors_sharded")
+    )
+    file_buffer = MagicMock()
+    file_buffer.key_to_rank_lidx = {"weight": None}
+    file_buffer.get_tensor.return_value = torch.ones(1)
+    loaders = [MagicMock(), MagicMock()]
+    loaders[0].copy_files_to_device.side_effect = RuntimeError(
+        "cuFile GDS initialization failed"
+    )
+    loaders[1].copy_files_to_device.return_value = file_buffer
+    loader_factory = MagicMock(side_effect=loaders)
+    module = _fastsafetensors_module(loader_factory)
+
+    with (
+        patch.dict(sys.modules, {"fastsafetensors": module}),
+        patch.object(current_platform, "is_cuda_alike", return_value=True),
+        patch.object(current_platform, "current_device", return_value=0),
+        patch("torch.accelerator.synchronize"),
+        patch("torch.accelerator.current_stream", return_value=MagicMock()),
+    ):
+        tensors = list(loader.iterate_over_files(["part-0"]))
+
+    assert tensors[0][0] == "weight"
+    assert loader.nogds is True
+    assert [call.kwargs["nogds"] for call in loader_factory.call_args_list] == [
+        False,
+        True,
+    ]
+    for fast_loader in loaders:
+        fast_loader.close.assert_called_once()
 
 
 @pytest.fixture(scope="module")

--- a/vllm/config/load.py
+++ b/vllm/config/load.py
@@ -38,6 +38,8 @@ class LoadConfig:
     - "instanttensor" will load the Safetensors weights on CUDA devices using
       InstantTensor, which enables distributed loading with pipelined prefetching
       and fast direct I/O.
+    - "fastsafetensors_sharded" will load rank-local pre-sharded checkpoint
+      files with FastSafetensors.
     - "npcache" will load the weights in pytorch format and store a numpy cache
       to speed up the loading.
     - "dummy" will initialize the weights with random values, which is mainly

--- a/vllm/model_executor/model_loader/__init__.py
+++ b/vllm/model_executor/model_loader/__init__.py
@@ -17,7 +17,10 @@ from vllm.model_executor.model_loader.modelexpress_loader import (
 from vllm.model_executor.model_loader.runai_streamer_loader import (
     RunaiModelStreamerLoader,
 )
-from vllm.model_executor.model_loader.sharded_state_loader import ShardedStateLoader
+from vllm.model_executor.model_loader.sharded_state_loader import (
+    FastSafetensorsShardedStateLoader,
+    ShardedStateLoader,
+)
 from vllm.model_executor.model_loader.tensorizer_loader import TensorizerLoader
 from vllm.model_executor.model_loader.utils import (
     get_architecture_class_name,
@@ -34,6 +37,7 @@ LoadFormats = Literal[
     "hf",
     "dummy",
     "fastsafetensors",
+    "fastsafetensors_sharded",
     "instanttensor",
     "mistral",
     "modelexpress",
@@ -50,6 +54,7 @@ _LOAD_FORMAT_TO_MODEL_LOADER: dict[str, type[BaseModelLoader]] = {
     "hf": DefaultModelLoader,
     "dummy": DummyModelLoader,
     "fastsafetensors": DefaultModelLoader,
+    "fastsafetensors_sharded": FastSafetensorsShardedStateLoader,
     "instanttensor": DefaultModelLoader,
     "mistral": DefaultModelLoader,
     "modelexpress": ModelExpressModelLoader,
@@ -150,6 +155,7 @@ __all__ = [
     "ModelExpressModelLoader",
     "DefaultModelLoader",
     "DummyModelLoader",
+    "FastSafetensorsShardedStateLoader",
     "RunaiModelStreamerLoader",
     "ShardedStateLoader",
     "TensorizerLoader",

--- a/vllm/model_executor/model_loader/sharded_state_loader.py
+++ b/vllm/model_executor/model_loader/sharded_state_loader.py
@@ -6,6 +6,7 @@ import glob
 import os
 import time
 from collections.abc import Generator
+from contextlib import suppress
 from copy import copy
 from typing import Any
 
@@ -212,3 +213,125 @@ class ShardedStateLoader(BaseModelLoader):
                 state_dict_part,
                 os.path.join(path, filename),
             )
+
+
+class FastSafetensorsShardedStateLoader(ShardedStateLoader):
+    """Load rank-local sharded-state checkpoints with FastSafetensors."""
+
+    def __init__(self, load_config: LoadConfig):
+        BaseModelLoader.__init__(self, load_config)
+        extra_config = copy(load_config.model_loader_extra_config or {})
+
+        self.pattern = extra_config.pop("pattern", self.DEFAULT_PATTERN)
+        self.nogds = extra_config.pop("nogds", None)
+        self.bbuf_size_kb = self._positive_int(
+            extra_config.pop("bbuf_size_kb", 16 * 1024), "bbuf_size_kb"
+        )
+        self.max_threads = self._positive_int(
+            extra_config.pop("max_threads", 16), "max_threads"
+        )
+        self.max_copy_block_size = self._positive_int(
+            extra_config.pop("max_copy_block_size", 16 * 1024**3),
+            "max_copy_block_size",
+        )
+        self.debug_log = extra_config.pop("debug_log", False)
+
+        if self.nogds is not None and not isinstance(self.nogds, bool):
+            raise ValueError("nogds must be a boolean or null")
+        if not isinstance(self.debug_log, bool):
+            raise ValueError("debug_log must be a boolean")
+        if extra_config:
+            raise ValueError(
+                "Unexpected extra config keys for load format "
+                f"{load_config.load_format}: {tuple(extra_config)}"
+            )
+
+    @staticmethod
+    def _positive_int(value: Any, name: str) -> int:
+        if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+            raise ValueError(f"{name} must be a positive integer")
+        return value
+
+    @staticmethod
+    def _is_gds_error(error: BaseException) -> bool:
+        message = str(error).lower()
+        return any(marker in message for marker in ("gds", "cufile", "libcufile"))
+
+    def iterate_over_files(
+        self, paths
+    ) -> Generator[tuple[str, torch.Tensor], None, None]:
+        try:
+            from fastsafetensors import SafeTensorsFileLoader, SingleGroup
+        except ImportError as exc:
+            raise ImportError(
+                "fastsafetensors is required for load format "
+                "fastsafetensors_sharded; install it with "
+                "`pip install vllm[fastsafetensors]`"
+            ) from exc
+
+        from vllm.platforms import current_platform
+
+        if not current_platform.is_cuda_alike():
+            raise ValueError("fastsafetensors_sharded requires an NVIDIA or AMD GPU")
+
+        device = torch.device(f"cuda:{current_platform.current_device()}")
+        filepaths = sorted(str(path) for path in paths)
+        use_nogds = self.nogds is True
+
+        while True:
+            loader = None
+            file_buffer = None
+            copy_started = False
+            copy_synchronized = False
+            try:
+                loader = SafeTensorsFileLoader(
+                    SingleGroup(),
+                    str(device),
+                    bbuf_size_kb=self.bbuf_size_kb,
+                    max_threads=self.max_threads,
+                    nogds=use_nogds,
+                    disable_cache=True,
+                    debug_log=self.debug_log,
+                )
+                loader.add_filenames({0: filepaths})
+                file_buffer = loader.copy_files_to_device(
+                    max_copy_block_size=self.max_copy_block_size
+                )
+
+                # GDS completion must be visible before PyTorch consumes the
+                # returned device views.
+                torch.accelerator.synchronize(device)
+                for key in list(file_buffer.key_to_rank_lidx):
+                    tensor = file_buffer.get_tensor(key)
+                    copy_started = True
+                    yield key, tensor
+
+                # Destination copies may still be queued when the generator
+                # resumes. Keep the shared source allocation alive until they
+                # complete.
+                torch.accelerator.current_stream().synchronize()
+                copy_synchronized = True
+                return
+            except (RuntimeError, OSError) as exc:
+                can_fallback = (
+                    not copy_started
+                    and self.nogds is None
+                    and not use_nogds
+                    and self._is_gds_error(exc)
+                )
+                if not can_fallback:
+                    raise
+                logger.warning(
+                    "FastSafetensors GDS loading failed; retrying with nogds=True: %s",
+                    exc,
+                )
+                use_nogds = True
+                self.nogds = True
+            finally:
+                if copy_started and not copy_synchronized:
+                    with suppress(Exception):
+                        torch.cuda.current_stream(device).synchronize()
+                if file_buffer is not None:
+                    file_buffer.close()
+                if loader is not None:
+                    loader.close()


### PR DESCRIPTION
## Motivation

In multi-node tensor-parallel deployments, distributing or propagating model
weights across nodes can be a substantial part of startup cost. If a checkpoint
is already stored in each rank's final sharded layout, every worker should be
able to read only its rank-local files instead of loading weights elsewhere and
sending them over the interconnect.

vLLM already supports FastSafetensors and sharded-state checkpoints separately.
This PR combines those paths so a TP worker can submit all of its rank-local
shard files in one FastSafetensors device-copy operation, using GDS where
available or the buffered NoGDS path otherwise.

## What this PR changes

- Adds the `fastsafetensors_sharded` load format.
- Reuses the existing sharded-state filename pattern and rank selection.
- Loads all files for the current TP rank together with
  `SafeTensorsFileLoader(SingleGroup())`.
- Keeps FastSafetensors resources alive until parameter copies on the current
  accelerator stream have completed.
- Automatically retries with `nogds=true` when GDS initialization fails before
  any parameter copy begins; explicit `nogds=false` still makes GDS mandatory.
- Exposes `pattern`, `nogds`, `bbuf_size_kb`, `max_threads`,
  `max_copy_block_size`, and `debug_log` through
  `--model-loader-extra-config`.
- Adds focused unit tests and user documentation.

This is opt-in and does not change existing loader defaults. It currently
requires a CUDA-like platform, consistent with direct FastSafetensors GPU
loading.

## Performance and model validation

An end-to-end measurement of the original implementation on vLLM 0.15.1 used
Qwen3-14B with tensor parallelism 2 on a DCU system:

| Loader | Weight-loading time |
| --- | ---: |
| `sharded_state` | 8.83 s |
| `fastsafetensors_sharded` (GDS) | 6.42 s |
| `fastsafetensors_sharded` (`nogds=true`) | 6.96 s |

The generated output matched across these loading paths. Additional local
testing also showed `fastsafetensors_sharded` loading materially faster than
`runai_streamer_sharded`; the comparable raw RunAI timing was not retained, so
this PR intentionally does not claim a numeric ratio for that comparison.

The implementation in this PR was ported to current `main`; the loader-focused
tests below were rerun after the final rebase. A new main-branch end-to-end GPU
benchmark was not run in the current WSL environment.

## Validation

Run in WSL Ubuntu 24.04 with Python 3.12:

```bash
.venv/bin/python -m pytest \
  tests/model_executor/model_loader/test_sharded_state_loader.py \
  -k fastsafetensors_sharded -v

.venv/bin/pre-commit run --files \
  docs/models/extensions/fastsafetensor.md \
  tests/model_executor/model_loader/test_sharded_state_loader.py \
  vllm/config/load.py \
  vllm/model_executor/model_loader/__init__.py \
  vllm/model_executor/model_loader/sharded_state_loader.py
```

Results:

- Focused pytest: `3 passed, 5 deselected`.
- All applicable pre-commit hooks passed, including Ruff, markdownlint, mypy,
  SPDX, forbidden-import, accelerator API, and configuration validation.

The tests cover load-format routing and configuration validation, submitting all
rank-local files in one transfer, accelerator synchronization/resource lifetime,
and GDS-to-NoGDS fallback before the first parameter copy.

The branch is rebased on upstream `main` commit `1f7427bc0`. The rebase retains
the deterministic batching fix from #51736 in the shared sharded-state test.

## Duplicate check and related work

I searched the open vLLM PRs for `fastsafetensors sharded` and
`fastsafetensors_sharded` and found no duplicate read-side loader PR.

#51496 is related but complementary: it fixes saving the logical sharded state
before post-processing. This PR is intentionally limited to loading existing
rank-local sharded-state checkpoints and does not duplicate that save-side
change.

## AI assistance disclosure

OpenAI Codex was used to help port the older implementation, draft focused
tests and documentation, resolve the latest upstream conflict, update deprecated
CUDA-specific calls to the accelerator API, and run the reported checks. The
human submitter supplied the original implementation, benchmark results, and
requirements, requested this rebase, and will maintain the contribution and
respond to review feedback.
