### PR TITLE
[ROCm] Portable Triton paged-MQA-logits kernel + vectorized torch fallbacks for the DeepSeek-V4 sparse indexer

### DIFF
--- a/tests/kernels/attention/test_portable_fp8_paged_mqa_logits.py
+++ b/tests/kernels/attention/test_portable_fp8_paged_mqa_logits.py
@@ -1,0 +1,86 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Portable (bf16-dequant) Triton paged-MQA-logits kernel vs torch reference.
+
+The portable kernel backs the DeepSeek-V4 sparse indexer on platforms whose
+Triton target cannot compile fp8 tl.dot (e.g. ROCm gfx1151 / RDNA3.5). It
+must produce the same logits as fp8_paged_mqa_logits_torch.
+"""
+import pytest
+import torch
+
+from vllm.platforms import current_platform
+
+
+@pytest.mark.parametrize(
+    "batch_size,next_n,ctx_lens",
+    [
+        (3, 1, [37, 811, 5120]),
+        (2, 6, [64, 1930]),
+        (1, 1, [1]),
+        (1, 6, [64]),
+    ],
+)
+def test_portable_fp8_paged_mqa_logits_matches_torch(
+    batch_size, next_n, ctx_lens
+):
+    if not torch.cuda.is_available():
+        pytest.skip("requires a GPU")
+    from vllm.v1.attention.ops.rocm_aiter_mla_sparse import (
+        fp8_paged_mqa_logits_torch,
+        portable_fp8_paged_mqa_logits,
+    )
+
+    torch.manual_seed(7)
+    device = "cuda"
+    fp8 = current_platform.fp8_dtype()
+    num_heads, dim, block_size, num_blocks = 64, 128, 64, 300
+    max_model_len = 8192
+
+    vals = (torch.randn(num_blocks, block_size, dim, device=device) * 0.25).to(fp8)
+    scales = torch.rand(num_blocks, block_size, device=device) * 1.5 + 0.25
+    flat = torch.empty(
+        num_blocks, block_size * (dim + 4), dtype=torch.uint8, device=device
+    )
+    flat[:, : block_size * dim] = vals.reshape(
+        num_blocks, block_size * dim
+    ).view(torch.uint8)
+    flat[:, block_size * dim :] = (
+        scales.contiguous().view(torch.uint8).reshape(num_blocks, block_size * 4)
+    )
+    kv_cache = flat.view(num_blocks, block_size, 1, dim + 4)
+
+    q = (
+        torch.randn(batch_size, next_n, num_heads, dim, device=device) * 0.3
+    ).to(fp8)
+    weights = torch.rand(batch_size * next_n, num_heads, device=device) * 0.2
+    context_lens = torch.tensor(ctx_lens, dtype=torch.int32, device=device)
+    block_tables = torch.randint(
+        0,
+        num_blocks,
+        (batch_size, max_model_len // block_size),
+        dtype=torch.int32,
+        device=device,
+    )
+
+    ref = fp8_paged_mqa_logits_torch(
+        q, kv_cache, weights, context_lens, block_tables, max_model_len
+    )
+    out = portable_fp8_paged_mqa_logits(
+        q, kv_cache, weights, context_lens, block_tables, max_model_len
+    )
+
+    ref_inf = torch.isinf(ref) & (ref < 0)
+    assert torch.equal(ref_inf, torch.isinf(out) & (out < 0))
+    finite = ~ref_inf
+    if finite.any():
+        r, o = ref[finite], out[finite]
+        rel = ((o - r).abs() / r.abs().clamp_min(1e-3)).max().item()
+        assert rel < 0.05
+        for i in range(ref.shape[0]):
+            k = min(64, int((~ref_inf[i]).sum().item()))
+            if k == 0:
+                continue
+            ti = set(torch.topk(ref[i], k).indices.tolist())
+            to = set(torch.topk(out[i], k).indices.tolist())
+            assert len(ti & to) / k > 0.93

--- a/vllm/v1/attention/ops/rocm_aiter_mla_sparse.py
+++ b/vllm/v1/attention/ops/rocm_aiter_mla_sparse.py
@@ -11,6 +11,7 @@ import torch.nn.functional as F
 import vllm.envs as envs
 from vllm.compilation.breakable_cudagraph import eager_break_during_capture
 from vllm.forward_context import get_forward_context
+from vllm.utils.math_utils import cdiv
 from vllm.platforms import current_platform
 from vllm.triton_utils import tl, triton
 from vllm.utils.torch_utils import LayerNameType
@@ -381,6 +382,114 @@ def paged_mqa_logits_module():
     return None
 
 
+
+_PORTABLE_MQA_TRITON_OK = [True]
+
+
+@triton.jit
+def _portable_fp8_paged_mqa_logits_kernel(
+    q_ptr, kv_ptr, ks_ptr, w_ptr, bt_ptr, qoff_ptr, lim_ptr, out_ptr,
+    kv_row_stride, ks_row_stride, bt_row_stride, out_row_stride,
+    num_blocks, max_len,
+    T: tl.constexpr, H: tl.constexpr, D: tl.constexpr, BS: tl.constexpr,
+):
+    """Paged-MQA logits with in-kernel fp8 -> bf16 dequantization.
+
+    Portable across Triton targets: the fp8 cache values are converted to
+    bf16 before tl.dot, so no fp8 MMA support is required (unlike the AITER
+    pa_mqa_logits kernels, whose fp8 tl.dot fails to compile on e.g.
+    gfx1151/RDNA3.5).
+
+    One program per (query token, KV page):
+        logits[bt, pos] = k_scale[pos]
+                          * sum_h(relu(k[pos] . q[bt, h]) * w[bt, h])
+    masked to pos < lim[bt] and pos <= qoff[bt]; `out` is pre-filled -inf.
+    """
+    pid_bt = tl.program_id(0)
+    pid_p = tl.program_id(1)
+    qoff = tl.load(qoff_ptr + pid_bt)
+    if pid_p * BS > qoff:
+        return
+    b = pid_bt // T
+    page = tl.load(bt_ptr + b * bt_row_stride + pid_p)
+    page = tl.minimum(tl.maximum(page, 0), num_blocks - 1)
+    offs = tl.arange(0, BS)
+    dd = tl.arange(0, D)
+    hh = tl.arange(0, H)
+    pos = pid_p * BS + offs
+    lim = tl.load(lim_ptr + pid_bt)
+    valid = (pos < lim) & (pos <= qoff)
+    qb = tl.load(q_ptr + pid_bt * H * D + hh[:, None] * D + dd[None, :])
+    kf = tl.load(kv_ptr + page * kv_row_stride + offs[:, None] * D + dd[None, :])
+    scores = tl.dot(kf.to(tl.bfloat16), tl.trans(qb))
+    scores = tl.maximum(scores, 0.0)
+    wv = tl.load(w_ptr + pid_bt * H + hh)
+    srow = tl.sum(scores * wv[None, :], axis=1)
+    ks = tl.load(ks_ptr + page * ks_row_stride + offs)
+    srow = srow * ks
+    srow = tl.where(valid, srow, float("-inf"))
+    tl.store(out_ptr + pid_bt * out_row_stride + pos, srow, mask=pos < max_len)
+
+
+def portable_fp8_paged_mqa_logits(
+    q: torch.Tensor,
+    kv_cache: torch.Tensor,
+    weights: torch.Tensor,
+    context_lens: torch.Tensor,
+    block_tables: torch.Tensor,
+    max_model_len: int,
+) -> torch.Tensor:
+    """Triton-backed equivalent of fp8_paged_mqa_logits_torch.
+
+    Same packed per-page cache layout and same outputs (see the unit test);
+    used when the AITER Triton kernels are unavailable for the platform.
+    """
+    batch_size, next_n, num_heads, dim = q.shape
+    num_blocks, block_size = kv_cache.shape[0], kv_cache.shape[1]
+    assert num_heads & (num_heads - 1) == 0 and dim & (dim - 1) == 0
+    assert block_size & (block_size - 1) == 0
+    flat = kv_cache.view(num_blocks, block_size * (dim + 4))
+    fp8_dtype = current_platform.fp8_dtype()
+    kv_vals = flat[:, : block_size * dim].view(dtype=fp8_dtype)
+    kv_scales = flat[:, block_size * dim :].view(dtype=torch.float32)
+    q_bf = (
+        q.to(torch.bfloat16)
+        .reshape(batch_size * next_n, num_heads, dim)
+        .contiguous()
+    )
+    w = (
+        weights.to(torch.float32)
+        .reshape(batch_size * next_n, num_heads)
+        .contiguous()
+    )
+    if context_lens.dim() == 1:
+        ctx = context_lens.to(device=q.device, dtype=torch.int32)
+        lim = ctx[:, None].expand(batch_size, next_n)
+        qoff = ctx[:, None] - next_n + torch.arange(
+            next_n, device=q.device, dtype=torch.int32
+        )[None, :]
+    else:
+        lim = context_lens.to(device=q.device, dtype=torch.int32)
+        qoff = lim - 1
+    lim = lim.reshape(-1).contiguous()
+    qoff = qoff.reshape(-1).contiguous()
+    np_ = min(cdiv(max_model_len, block_size), block_tables.shape[1])
+    out = torch.full(
+        [batch_size * next_n, max_model_len],
+        float("-inf"),
+        device=q.device,
+        dtype=torch.float32,
+    )
+    _portable_fp8_paged_mqa_logits_kernel[(batch_size * next_n, np_)](
+        q_bf, kv_vals, kv_scales, w, block_tables, qoff, lim, out,
+        kv_vals.stride(0), kv_scales.stride(0),
+        block_tables.stride(0), out.stride(0),
+        num_blocks, max_model_len,
+        T=next_n, H=num_heads, D=dim, BS=block_size,
+    )
+    return out
+
+
 def rocm_fp8_paged_mqa_logits(
     q_fp8: torch.Tensor,
     kv_cache_fp8: torch.Tensor,
@@ -465,6 +574,17 @@ def rocm_fp8_paged_mqa_logits(
         )
         return out_qk.sum(dim=0)
     else:
+        # No AITER Triton kernel for this platform: prefer the portable
+        # Triton kernel (bf16 dequant, no fp8 MMA requirement) and fall
+        # back to the torch reference if it ever fails to compile/run.
+        if _PORTABLE_MQA_TRITON_OK[0]:
+            try:
+                return portable_fp8_paged_mqa_logits(
+                    q_fp8, kv_cache_fp8, weights, context_lens,
+                    block_tables, max_model_len,
+                )
+            except Exception:
+                _PORTABLE_MQA_TRITON_OK[0] = False
         return fp8_paged_mqa_logits_torch(
             q_fp8, kv_cache_fp8, weights, context_lens, block_tables, max_model_len
         )

--- a/vllm/v1/attention/ops/rocm_aiter_mla_sparse.py
+++ b/vllm/v1/attention/ops/rocm_aiter_mla_sparse.py
@@ -274,92 +274,93 @@ def fp8_paged_mqa_logits_torch(
     fp8_dtype = current_platform.fp8_dtype()
     batch_size, next_n, _, dim = q.size()
     if next_n == 1:
+        # Vectorized decode path: no per-sequence python loop and no .item()
+        # host syncs (each sync stalls the pipeline once per layer).
         block_size = kv_cache.shape[1]
+        num_blocks = kv_cache.shape[0]
+        if context_lens.dim() > 1:
+            context_lens = context_lens.squeeze(-1)
+        kv_cache_flat = kv_cache.view(-1, block_size * (dim + 4))
+        np_ = min(cdiv(max_model_len, block_size), block_tables.shape[1])
+        n_tok = np_ * block_size
+        pages = block_tables[:, :np_].long().clamp_(0, num_blocks - 1)
+        cache = kv_cache_flat[pages]  # [B, NP, bs*(dim+4)]
+        scale_offset = block_size * dim
+        val = (
+            cache[..., :scale_offset]
+            .view(dtype=fp8_dtype)
+            .to(torch.float32)
+            .view(batch_size, n_tok, dim)
+        )
+        scl = (
+            cache[..., scale_offset:]
+            .view(dtype=torch.float32)
+            .reshape(batch_size, n_tok)
+        )
+        q_f = q[:, 0].to(torch.float32)  # [B, H, D]
+        score = torch.einsum("bnd,bhd->bnh", val, q_f)
+        score = F.relu(score) * weights.to(torch.float32)[:, None, :]
+        score = score.sum(dim=-1) * scl  # [B, n_tok]
+        pos = torch.arange(n_tok, device=q.device)
+        mask = pos[None, :] < context_lens.to(q.device)[:, None]
+        score = torch.where(mask, score, float("-inf"))
         logits = torch.full(
             [batch_size, max_model_len],
             float("-inf"),
             device=q.device,
             dtype=torch.float32,
         )
-        if context_lens.dim() > 1:
-            context_lens = context_lens.squeeze(-1)
-        kv_cache_flat = kv_cache.view(-1, block_size * (dim + 4))
-        for i in range(batch_size):
-            q_i = q[i, 0].to(torch.float32)
-            q_scale = weights[i]
-            seq_len = int(context_lens[i].item())
-            assert seq_len <= max_model_len
-            num_pages = cdiv(seq_len, block_size)
-            padded_seq_len = num_pages * block_size
-            pages = block_tables[i, :num_pages]
-            cache = kv_cache_flat[pages]
-            scale_offset = block_size * dim
-            cache_value = (
-                cache[..., :scale_offset].view(dtype=fp8_dtype).to(torch.float32)
-            )
-            cache_scale = (
-                cache[..., scale_offset:].view(dtype=torch.float32).contiguous()
-            )
-            cache_value = cache_value.view(padded_seq_len, dim)
-            cache_scale = cache_scale.view(padded_seq_len)
-            score = F.linear(cache_value, q_i)
-            score = F.relu(score)
-            score *= q_scale[None, :]
-            score = score.sum(dim=1)
-            score *= cache_scale
-            logits[i, :seq_len] = score[:seq_len]
+        w_cols = min(n_tok, max_model_len)
+        logits[:, :w_cols] = score[:, :w_cols]
         return logits
 
-    kv_cache, scale = kv_cache[..., :dim], kv_cache[..., dim:]
-    scale = scale.contiguous().view(torch.float)
-    q = q.float()
-    kv_cache = kv_cache.view(fp8_dtype).float() * scale
-    num_block, block_size, _, dim = kv_cache.size()
+    # Vectorized next_n > 1 (speculative verify) path: no per-sequence
+    # python loops, no .item() host syncs, no full-cache dequantization.
+    # Uses the same packed per-page cache layout as the next_n == 1 path.
+    num_blocks = kv_cache.shape[0]
+    block_size = kv_cache.shape[1]
+    kv_cache_flat = kv_cache.view(-1, block_size * (dim + 4))
+    np_ = min(cdiv(max_model_len, block_size), block_tables.shape[1])
+    n_tok = np_ * block_size
+    pages = block_tables[:, :np_].long().clamp_(0, num_blocks - 1)
+    cache = kv_cache_flat[pages]  # [B, NP, bs*(dim+4)]
+    scale_offset = block_size * dim
+    val = (
+        cache[..., :scale_offset]
+        .view(dtype=fp8_dtype)
+        .to(torch.float32)
+        .view(batch_size, n_tok, dim)
+    )
+    scl = (
+        cache[..., scale_offset:]
+        .view(dtype=torch.float32)
+        .reshape(batch_size, n_tok)
+    )
+    q_f = q.to(torch.float32)  # [B, T, H, D]
+    if context_lens.dim() == 1:
+        ctx = context_lens.to(device=q.device)[:, None]  # [B, 1]
+        context_limit = ctx.expand(batch_size, next_n)
+        q_offsets = ctx - next_n + torch.arange(next_n, device=q.device)[None, :]
+    else:
+        context_limit = context_lens.to(device=q.device)
+        q_offsets = context_limit - 1
+    score = torch.einsum("bnd,bthd->bthn", val, q_f)  # [B, T, H, N]
+    w = weights.to(torch.float32).view(batch_size, next_n, -1)  # [B, T, H]
+    score = F.relu(score) * w[..., None]
+    score = score.sum(dim=2) * scl[:, None, :]  # [B, T, N]
+    pos = torch.arange(n_tok, device=q.device)
+    mask = (pos[None, None, :] < context_limit[..., None]) & (
+        pos[None, None, :] <= q_offsets[..., None]
+    )
+    score = torch.where(mask, score, float("-inf"))
     logits = torch.full(
         [batch_size * next_n, max_model_len],
         float("-inf"),
         device=q.device,
         dtype=torch.float32,
     )
-    for i in range(batch_size):
-        context_len = context_lens[i]
-        if context_len.ndim == 0:
-            context_len_i = int(context_len.item())
-            q_offsets = torch.arange(
-                context_len_i - next_n, context_len_i, device=q.device
-            )
-            context_limit = torch.full(
-                (next_n,), context_len_i, dtype=torch.int32, device=q.device
-            )
-        else:
-            context_limit = context_len.to(device=q.device, dtype=torch.int32)
-            q_offsets = context_limit - 1
-        weight_slice = (
-            weights[i * next_n : (i + 1) * next_n, :].transpose(0, 1).contiguous()
-        )
-        max_context_len = int(context_limit.max().item())
-        for block_rk in range(cdiv(max_context_len, block_size)):
-            block_idx = block_tables[i][block_rk]
-            qx, kx = q[i], kv_cache[block_idx]
-            k_offsets = torch.arange(
-                block_rk * block_size, (block_rk + 1) * block_size, device=q.device
-            )
-            mask = (k_offsets[None, :] < context_limit[:, None]) & (
-                k_offsets[None, :] <= q_offsets[:, None]
-            )
-            s = torch.where(
-                mask[None, :, :],
-                (qx.transpose(0, 1) @ kx.transpose(0, 1).transpose(1, 2)).to(
-                    logits.dtype
-                ),
-                float("-inf"),
-            )
-            s = torch.relu(s) * weight_slice[..., None]
-            s = s.sum(dim=0)
-            logits[
-                i * next_n : (i + 1) * next_n,
-                block_rk * block_size : (block_rk + 1) * block_size,
-            ] = torch.where(k_offsets[None, :] <= q_offsets[:, None], s, float("-inf"))
+    w_cols = min(n_tok, max_model_len)
+    logits[:, :w_cols] = score.reshape(batch_size * next_n, n_tok)[:, :w_cols]
     return logits
 
 


### PR DESCRIPTION
## Purpose

The DeepSeek-V4 sparse indexer's paged-MQA logits currently have two tiers on ROCm: the AITER Triton kernels (fp8 `tl.dot`), or a pure-python torch reference. Platforms whose Triton target cannot compile fp8 `tl.dot` — e.g. gfx1151 / Strix Halo (RDNA3.5), `Unsupported lhs dtype fp8e4nv` — can only use the torch reference, which loops over sequences/KV blocks with an `.item()` host sync per iteration, stalling the pipeline once per layer.

Related discussion and full platform context: #51530.

Two commits:

1. **Vectorize both torch fallback branches** (`next_n == 1` decode and `next_n > 1` speculative verify): batched tensor ops, static shapes, no host syncs, no full-cache dequantization. This also unifies the packed-cache layout handling — the `next_n > 1` branch previously split values/scales per token while the `next_n == 1` branch uses a per-page split; the vectorized version follows the per-page layout. Reviewers may want to confirm per-page is the intended layout (it is the one that produces correct end-to-end results).
2. **Add `portable_fp8_paged_mqa_logits`**, a Triton kernel that dequantizes fp8 → bf16 in-kernel before `tl.dot` (the same pattern as the sparse-attention kernels already in this file), and prefer it over the torch reference in the existing no-AITER fallback branch. On any failure it latches off and falls back to the torch reference. Platforms where the AITER kernels are selected are unaffected.

## Test Plan

- New unit test `tests/kernels/attention/test_portable_fp8_paged_mqa_logits.py` (runs on any GPU, CUDA included): exact `-inf` mask equality, elementwise closeness, and top-k agreement vs `fp8_paged_mqa_logits_torch`, across decode (`next_n=1`), verify (`next_n=6`) and edge shapes.
- Hardware validation on 2× AMD Radeon 8060S (gfx1151, Strix Halo), TP=2 over Thunderbolt, serving DeepSeek-V4-Flash-0731.

## Test Result

- Unit test: max relative error 0.00000 and 100% top-64 overlap on all parametrizations (run on gfx1151; the kernel compiles in seconds there — no fp8-MMA requirement).
- End-to-end: greedy outputs byte-identical to the torch-fallback baseline while serving DeepSeek-V4-Flash-0731 on the 2-node gfx1151 cluster; the per-layer host syncs are gone from decode profiles.


