### PR TITLE
[CI] Stabilize DP supervisor lifecycle tests

### DIFF
--- a/tests/entrypoints/openai/test_dp_supervisor.py
+++ b/tests/entrypoints/openai/test_dp_supervisor.py
@@ -483,20 +483,19 @@ async def _await_supervisor_health(
 
 
 async def _poll_until_api_server_running(
-    port: int, retries: int = 10, use_ssl: bool = False
+    port: int, retries: int = 30, use_ssl: bool = False
 ) -> None:
     scheme = "https" if use_ssl else "http"
     url = f"{scheme}://127.0.0.1:{port}/health"
     async with aiohttp.ClientSession() as session:
         for _ in range(retries):
             try:
-                async with session.get(url, ssl=False if use_ssl else None) as resp:
-                    if resp.status != 200:
-                        return
-                await asyncio.sleep(1.0)
+                async with session.get(url, ssl=False if use_ssl else None):
+                    return
             except aiohttp.ClientError:
                 print("Test detected not started yet, sleeping for 1s")
                 await asyncio.sleep(1.0)
+    raise TimeoutError(f"API server on port {port} did not start")
 
 
 async def _set_healthy(port: int, use_ssl: bool = False) -> None:
@@ -528,8 +527,8 @@ async def _kill_server(port: int, use_ssl: bool = False) -> None:
             session.get(url, ssl=False if use_ssl else None) as resp,
         ):
             assert resp.status != 200
-    except Exception as e:
-        assert isinstance(e, aiohttp.ClientConnectorError)
+    except aiohttp.ClientConnectionError:
+        return
 
 
 @contextlib.asynccontextmanager

--- a/tests/entrypoints/openai/test_dp_supervisor.py
+++ b/tests/entrypoints/openai/test_dp_supervisor.py
@@ -483,19 +483,32 @@ async def _await_supervisor_health(
 
 
 async def _poll_until_api_server_running(
-    port: int, retries: int = 30, use_ssl: bool = False
+    port: int, timeout_s: float = 30.0, use_ssl: bool = False
 ) -> None:
+    """Return once the child accepts a request; it reports 503 until healthy."""
     scheme = "https" if use_ssl else "http"
     url = f"{scheme}://127.0.0.1:{port}/health"
+    deadline = time.monotonic() + timeout_s
+    last_exc: Exception | None = None
     async with aiohttp.ClientSession() as session:
-        for _ in range(retries):
+        while (remaining_s := deadline - time.monotonic()) > 0:
             try:
-                async with session.get(url, ssl=False if use_ssl else None):
+                request_timeout = aiohttp.ClientTimeout(total=min(2.0, remaining_s))
+                async with session.get(
+                    url,
+                    ssl=False if use_ssl else None,
+                    timeout=request_timeout,
+                ):
                     return
-            except aiohttp.ClientError:
+            except (aiohttp.ClientError, TimeoutError) as exc:
+                last_exc = exc
                 print("Test detected not started yet, sleeping for 1s")
-                await asyncio.sleep(1.0)
-    raise TimeoutError(f"API server on port {port} did not start")
+                remaining_s = deadline - time.monotonic()
+                if remaining_s > 0:
+                    await asyncio.sleep(min(1.0, remaining_s))
+    raise TimeoutError(
+        f"API server on port {port} did not start within {timeout_s}s"
+    ) from last_exc
 
 
 async def _set_healthy(port: int, use_ssl: bool = False) -> None:

--- a/tests/entrypoints/openai/test_dp_supervisor.py
+++ b/tests/entrypoints/openai/test_dp_supervisor.py
@@ -500,7 +500,7 @@ async def _poll_until_api_server_running(
                     timeout=request_timeout,
                 ):
                     return
-            except (aiohttp.ClientError, TimeoutError) as exc:
+            except (aiohttp.ClientError, asyncio.TimeoutError) as exc:
                 last_exc = exc
                 print("Test detected not started yet, sleeping for 1s")
                 remaining_s = deadline - time.monotonic()


### PR DESCRIPTION
## Purpose

Stabilize DP-supervisor lifecycle tests on loaded CI. The readiness helper silently exhausted a 10-second wait, and intentional shutdown rejected connection resets. No open PR fixes these helpers; #50916 only changed signal handling.

## Reproducer

Main [build 83054](https://buildkite.com/vllm/ci/builds/83054#019fe5eb-a9d3-4301-bd54-4cecd289254b): `test_basic_lifecycle` and `test_failed_startup` failed.

## Output on main / on branch

Main: `2 failed, 253 passed`; branch: `16 passed`.

## Test Plan

`.venv/bin/python -m pytest tests/entrypoints/openai/test_dp_supervisor.py -q`

No new CI cost. Model evals are not applicable.

## AI assistance disclosure

OpenAI Codex drafted the change. All lines were human-reviewed and tests human-run.
