### PR TITLE
[Test] Extend shared tool-parser parity suite to 6 more parsers

### DIFF
--- a/tests/tool_parsers/common_tests.py
+++ b/tests/tool_parsers/common_tests.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import json
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from types import NoneType
 from typing import Any
@@ -87,6 +88,50 @@ class ToolParserTestConfig:
     supports_typed_arguments: bool = True
 
 
+def pythonic_style_test_config(
+    parser_name: str,
+    render: Callable[[list[str]], str],
+    **overrides: Any,
+) -> ToolParserTestConfig:
+    """Build a config for parsers that emit Python-literal call syntax.
+
+    Args:
+        parser_name: Name used with ToolParserManager.
+        render: Turns a list of ``fn(args)`` strings into one model output,
+            applying whatever delimiters the parser expects.
+        **overrides: Passed through to ToolParserTestConfig.
+    """
+    escaped = (
+        "test_function(quoted='He said \"hello\"', "
+        "backslash='C:\\\\Users\\\\test', "
+        "newline='line1\\nline2')"
+    )
+    types = (
+        "test_function(string_field='hello', int_field=42, float_field=3.14, "
+        "bool_field=True, null_field=None, array_field=['a', 'b', 'c'], "
+        "object_field={'nested': 'value'}, empty_array=[], empty_object={})"
+    )
+    single = "get_weather(city='Tokyo')"
+    config_kwargs: dict[str, Any] = dict(
+        parser_name=parser_name,
+        no_tool_calls_output="How can I help you today?",
+        single_tool_call_output=render([single]),
+        parallel_tool_calls_output=render([single, "get_time(timezone='Asia/Tokyo')"]),
+        various_data_types_output=render([types]),
+        empty_arguments_output=render(["refresh()"]),
+        surrounding_text_output=f"Let me check.\n{render([single])}\nAll done.",
+        escaped_strings_output=render([escaped]),
+        malformed_input_outputs=[
+            render(["get_weather(city='Tokyo'"]),
+            render(["get_weather(city=)"]),
+            render(["1_not_an_identifier()"]),
+            "plain text that is not a call at all",
+        ],
+    )
+    config_kwargs.update(overrides)
+    return ToolParserTestConfig(**config_kwargs)
+
+
 class ToolParserTests:
     """Mixin class providing common test suite for tool parsers.
 
@@ -125,8 +170,20 @@ class ToolParserTests:
         return default_tokenizer
 
     @pytest.fixture
-    def tool_parser(self, test_config: ToolParserTestConfig, tokenizer: TokenizerLike):
-        return ToolParserManager.get_tool_parser(test_config.parser_name)(tokenizer)
+    def make_tool_parser(
+        self, test_config: ToolParserTestConfig, tokenizer: TokenizerLike
+    ):
+        """Factory for fresh parser instances.
+
+        vLLM builds a new parser per request, so tests that exercise more than
+        one extraction must not share a single (stateful) instance.
+        """
+        parser_cls = ToolParserManager.get_tool_parser(test_config.parser_name)
+        return lambda: parser_cls(tokenizer)
+
+    @pytest.fixture
+    def tool_parser(self, make_tool_parser):
+        return make_tool_parser()
 
     @pytest.fixture(params=[True, False])
     def streaming(self, request: pytest.FixtureRequest) -> bool:
@@ -341,7 +398,7 @@ class ToolParserTests:
     def test_streaming_reconstruction(
         self,
         request: pytest.FixtureRequest,
-        tool_parser: Any,
+        make_tool_parser: Any,
         test_config: ToolParserTestConfig,
     ):
         """Verify streaming produces same result as non-streaming."""
@@ -350,14 +407,13 @@ class ToolParserTests:
 
         test_output = test_config.single_tool_call_output
 
-        # Non-streaming result
+        # A fresh parser per mode, mirroring the per-request parser in serving.
         content_non, tools_non = run_tool_extraction(
-            tool_parser, test_output, streaming=False
+            make_tool_parser(), test_output, streaming=False
         )
 
-        # Streaming result
         content_stream, tools_stream = run_tool_extraction(
-            tool_parser, test_output, streaming=True
+            make_tool_parser(), test_output, streaming=True
         )
 
         # Compare results

--- a/tests/tool_parsers/test_hermes_tool_parser.py
+++ b/tests/tool_parsers/test_hermes_tool_parser.py
@@ -5,6 +5,7 @@ import json
 
 import pytest
 
+from tests.tool_parsers.common_tests import ToolParserTestConfig, ToolParserTests
 from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
 from vllm.tokenizers import TokenizerLike
 from vllm.tool_parsers.abstract_tool_parser import ToolParser
@@ -412,3 +413,78 @@ def test_hermes_streaming_content_and_tool_call_in_single_chunk(
     assert tool_parts[0].function.name == "f"
     args_str = "".join(tc.function.arguments or "" for tc in tool_parts)
     assert json.loads(args_str) == {"x": 1}
+
+
+def _hermes_config(parser_name: str) -> ToolParserTestConfig:
+    """Shared config for the `<tool_call>{json}</tool_call>` wire format."""
+    return ToolParserTestConfig(
+        parser_name=parser_name,
+        no_tool_calls_output="This is a regular response without any tool calls.",
+        single_tool_call_output=(
+            '<tool_call>\n{"name": "get_weather", '
+            '"arguments": {"city": "Tokyo"}}\n</tool_call>'
+        ),
+        parallel_tool_calls_output=(
+            '<tool_call>\n{"name": "get_weather", '
+            '"arguments": {"city": "Tokyo"}}\n</tool_call>\n'
+            '<tool_call>\n{"name": "get_time", '
+            '"arguments": {"timezone": "Asia/Tokyo"}}\n</tool_call>'
+        ),
+        various_data_types_output=(
+            '<tool_call>\n{"name": "test_function", "arguments": {'
+            '"string_field": "hello", '
+            '"int_field": 42, '
+            '"float_field": 3.14, '
+            '"bool_field": true, '
+            '"null_field": null, '
+            '"array_field": ["a", "b", "c"], '
+            '"object_field": {"nested": "value"}, '
+            '"empty_array": [], '
+            '"empty_object": {}}}\n</tool_call>'
+        ),
+        empty_arguments_output=(
+            '<tool_call>\n{"name": "refresh", "arguments": {}}\n</tool_call>'
+        ),
+        surrounding_text_output=(
+            "Let me check the weather for you.\n"
+            '<tool_call>\n{"name": "get_weather", '
+            '"arguments": {"city": "Tokyo"}}\n</tool_call>\n'
+            "I'll get that information."
+        ),
+        escaped_strings_output=(
+            '<tool_call>\n{"name": "test_function", "arguments": {'
+            '"quoted": "He said \\"hello\\"", '
+            '"backslash": "C:\\\\Users\\\\test", '
+            '"newline": "line1\\nline2"}}\n</tool_call>'
+        ),
+        malformed_input_outputs=[
+            '<tool_call>\n{"name": "broken", "arguments": {invalid}}\n</tool_call>',
+            '<tool_call>\n{"name": "unterminated", "arguments": {"a": 1}\n',
+            "<tool_call>\n\n</tool_call>",
+            '<tool_call>{"arguments": {"a": 1}}</tool_call>',
+        ],
+    )
+
+
+class TestHermesToolParser(ToolParserTests):
+    """Common parity suite for the Hermes 2 Pro `<tool_call>` format."""
+
+    @pytest.fixture
+    def tokenizer(self, qwen_tokenizer: TokenizerLike) -> TokenizerLike:
+        return qwen_tokenizer
+
+    @pytest.fixture
+    def test_config(self) -> ToolParserTestConfig:
+        return _hermes_config("hermes")
+
+
+class TestGranite4ToolParser(ToolParserTests):
+    """Granite 4 reuses the Hermes `<tool_call>` wire format."""
+
+    @pytest.fixture
+    def tokenizer(self, qwen_tokenizer: TokenizerLike) -> TokenizerLike:
+        return qwen_tokenizer
+
+    @pytest.fixture
+    def test_config(self) -> ToolParserTestConfig:
+        return _hermes_config("granite4")

--- a/tests/tool_parsers/test_llama4_pythonic_tool_parser.py
+++ b/tests/tool_parsers/test_llama4_pythonic_tool_parser.py
@@ -5,6 +5,11 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from tests.tool_parsers.common_tests import (
+    ToolParserTestConfig,
+    ToolParserTests,
+    pythonic_style_test_config,
+)
 from tests.tool_parsers.utils import (
     run_tool_extraction,
     run_tool_extraction_streaming,
@@ -267,3 +272,29 @@ def test_regex_timeout_handling(streaming: bool, default_tokenizer: TokenizerLik
         assert content == fake_problematic_input
         assert len(tool_calls) == 0
         mock_regex.match.assert_called_once()
+
+
+class TestLlama4PythonicToolParser(ToolParserTests):
+    """Llama 4 wraps the pythonic call list in python_start/end markers."""
+
+    @pytest.fixture
+    def test_config(self) -> ToolParserTestConfig:
+        return pythonic_style_test_config(
+            "llama4_pythonic",
+            lambda calls: (f"<|python_start|>[{', '.join(calls)}]<|python_end|>"),
+            xfail_streaming={
+                "test_surrounding_text": (
+                    "pythonic format has no content/call delimiter"
+                ),
+                # Streaming emits the partial marker "<|python_start|" as
+                # content before recognising it; non-streaming returns None.
+                "test_streaming_reconstruction": (
+                    "streaming leaks a partial <|python_start| marker as content"
+                ),
+            },
+            xfail_nonstreaming={
+                "test_surrounding_text": (
+                    "pythonic format has no content/call delimiter"
+                ),
+            },
+        )

--- a/tests/tool_parsers/test_minimax_m2_tool_parser.py
+++ b/tests/tool_parsers/test_minimax_m2_tool_parser.py
@@ -5,6 +5,7 @@ import json
 
 import pytest
 
+from tests.tool_parsers.common_tests import ToolParserTestConfig, ToolParserTests
 from vllm.entrypoints.openai.chat_completion.protocol import (
     ChatCompletionToolsParam,
     FunctionDefinition,
@@ -601,3 +602,68 @@ class TestParameterWhitespace:
         assert json.loads(tc[0]["arguments"]) == {
             "content": "    def foo():\n        return 1\n"
         }
+
+
+def _invoke(name: str, params: list[tuple[str, str]]) -> str:
+    body = "".join(f'<parameter name="{k}">{v}</parameter>' for k, v in params)
+    return f'<invoke name="{name}">{body}</invoke>'
+
+
+def _tool_call(*invokes: str) -> str:
+    return f"<minimax:tool_call>{''.join(invokes)}</minimax:tool_call>"
+
+
+class TestMinimaxM2ToolParser(ToolParserTests):
+    """Common parity suite for the MiniMax M2 XML wire format."""
+
+    @pytest.fixture
+    def test_config(self) -> ToolParserTestConfig:
+        return ToolParserTestConfig(
+            parser_name="minimax_m2",
+            no_tool_calls_output="How can I help you today?",
+            single_tool_call_output=_tool_call(
+                _invoke("get_weather", [("city", "Tokyo")])
+            ),
+            parallel_tool_calls_output=_tool_call(
+                _invoke("get_weather", [("city", "Tokyo")]),
+                _invoke("get_time", [("timezone", "Asia/Tokyo")]),
+            ),
+            various_data_types_output=_tool_call(
+                _invoke(
+                    "test_function",
+                    [
+                        ("string_field", "hello"),
+                        ("int_field", "42"),
+                        ("float_field", "3.14"),
+                        ("bool_field", "true"),
+                        ("null_field", "null"),
+                        ("array_field", '["a", "b", "c"]'),
+                        ("object_field", '{"nested": "value"}'),
+                    ],
+                )
+            ),
+            empty_arguments_output=_tool_call(_invoke("refresh", [])),
+            surrounding_text_output=(
+                "Let me check the weather for you.\n"
+                + _tool_call(_invoke("get_weather", [("city", "Tokyo")]))
+                + "\nI'll get that information."
+            ),
+            escaped_strings_output=_tool_call(
+                _invoke(
+                    "test_function",
+                    [
+                        ("quoted", 'He said "hello"'),
+                        ("backslash", "C:\\Users\\test"),
+                        ("newline", "line1\nline2"),
+                    ],
+                )
+            ),
+            malformed_input_outputs=[
+                '<minimax:tool_call><invoke name="broken">',
+                _tool_call('<invoke><parameter name="a">1</parameter></invoke>'),
+                "<minimax:tool_call></minimax:tool_call>",
+            ],
+            # Parameter values arrive as XML text; without a tool schema on the
+            # request they stay strings rather than being coerced to JSON types.
+            supports_typed_arguments=False,
+        )

--- a/tests/tool_parsers/test_olmo3_tool_parser.py
+++ b/tests/tool_parsers/test_olmo3_tool_parser.py
@@ -5,6 +5,11 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from tests.tool_parsers.common_tests import (
+    ToolParserTestConfig,
+    ToolParserTests,
+    pythonic_style_test_config,
+)
 from tests.tool_parsers.utils import (
     run_tool_extraction,
     run_tool_extraction_streaming,
@@ -249,3 +254,22 @@ def test_regex_timeout_handling(streaming: bool, default_tokenizer: TokenizerLik
         assert content == fake_problematic_input
         assert len(tool_calls) == 0
         mock_regex.match.assert_called_once()
+
+
+class TestOlmo3ToolParser(ToolParserTests):
+    """Olmo 3 emits newline-separated calls inside `<function_calls>`."""
+
+    @pytest.fixture
+    def test_config(self) -> ToolParserTestConfig:
+        return pythonic_style_test_config(
+            "olmo3",
+            lambda calls: f"<function_calls>{chr(10).join(calls)}</function_calls>",
+            # Non-streaming extracts the call and drops the prose; streaming
+            # never leaves content mode, so it returns the whole output as
+            # content and reports no tool calls.
+            xfail_streaming={
+                "test_surrounding_text": (
+                    "streaming misses <function_calls> preceded by content"
+                ),
+            },
+        )

--- a/tests/tool_parsers/test_pythonic_tool_parser.py
+++ b/tests/tool_parsers/test_pythonic_tool_parser.py
@@ -5,6 +5,11 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from tests.tool_parsers.common_tests import (
+    ToolParserTestConfig,
+    ToolParserTests,
+    pythonic_style_test_config,
+)
 from tests.tool_parsers.utils import (
     run_tool_extraction,
     run_tool_extraction_streaming,
@@ -229,3 +234,22 @@ def test_regex_timeout_handling(streaming: bool, default_tokenizer: TokenizerLik
         assert content == fake_problematic_input
         assert len(tool_calls) == 0
         mock_regex.match.assert_called_once()
+
+
+class TestPythonicToolParser(ToolParserTests):
+    """Common parity suite for the `[fn(arg=...)]` wire format."""
+
+    @pytest.fixture
+    def test_config(self) -> ToolParserTestConfig:
+        return pythonic_style_test_config(
+            "pythonic",
+            lambda calls: f"[{', '.join(calls)}]",
+            # The parser requires the whole output to be a single call list, so
+            # prose around it is returned verbatim as content. Both modes agree.
+            xfail_streaming={
+                "test_surrounding_text": "pythonic format has no content/call delimiter"
+            },
+            xfail_nonstreaming={
+                "test_surrounding_text": "pythonic format has no content/call delimiter"
+            },
+        )


### PR DESCRIPTION


## Purpose

`ToolParserTests` (`tests/tool_parsers/common_tests.py`) is the shared suite that pins
streaming vs non-streaming parity for tool parsers, but only **7 of the 46** registered
parsers had opted into it. This PR adds configs for six more: `hermes`, `granite4`,
`pythonic`, `llama4_pythonic`, `olmo3` and `minimax_m2` — taking coverage to 13/46.

Adopting the suite surfaced **two real streaming/non-streaming divergences**. They are
recorded as `strict=True` xfails rather than silently skipped, so they fail loudly the
moment someone fixes the underlying parser:

- **`llama4_pythonic`** emits a partial `<|python_start|` marker as content before
  recognising it; non-streaming returns no content.
- **`olmo3`** misses a `<function_calls>` block preceded by content in streaming,
  returning the whole output as content, while non-streaming extracts the call.

A third xfail (`pythonic` / `test_surrounding_text`) is deliberately **not** a bug report:
both modes agree, the format simply has no delimiter separating prose from the call list.

### Fix required to make the suite adoptable

`test_streaming_reconstruction` reused a single parser instance for both the non-streaming
and the streaming extraction. Parsers that keep per-request state were poisoned by the
first call and could not adopt the suite — `granite4` trips
`assert self.current_tool_id + 1 == len(self.prev_tool_call_arr)` on the second pass and
reports zero tool calls.

This is a defect in the test, not in the parser: `OpenAIServingChat` constructs a fresh
parser per request (`vllm/entrypoints/openai/chat_completion/serving.py`), so sharing one
instance across two extractions models something that never happens in serving. The test
now mirrors production via a `make_tool_parser` factory fixture. The existing
`tool_parser` fixture simply calls that factory, so every other test is unchanged.

### Not a duplicate

Checked open PRs and issues touching the tool-parser and streaming-parity area before
starting. The nearby active work is on **runtime parser behaviour** — #47562 (#47137),
#47963 (#47903), #47512 (#47504), #47955 (#47907), #48706 (#48702). None of them touch
`tests/tool_parsers/common_tests.py` or add parsers to the shared suite, and this PR
changes no parser or serving code, so there is no overlap in files or intent.

### Note on AI assistance

AI assistance was used to write these tests and to run the differential
streaming/non-streaming probe that found the two divergences above. Every changed line was
reviewed by me, and the test runs below were executed locally.

## Test Plan

Python-only build (no kernels needed — this PR touches tests only):

```bash
uv venv --python 3.12
VLLM_TARGET_DEVICE=empty uv pip install -e .
uv pip install -r requirements/lint.txt

# Full tool-parser suite, before and after the change
pytest tests/tool_parsers/

# Just the newly added parity coverage
pytest tests/tool_parsers/ -k "TestHermesToolParser or TestGranite4ToolParser or \
TestPythonicToolParser or TestLlama4PythonicToolParser or TestOlmo3ToolParser or \
TestMinimaxM2ToolParser"

# Lint exactly as CI runs it
pre-commit run --files tests/tool_parsers/common_tests.py \
  tests/tool_parsers/test_hermes_tool_parser.py \
  tests/tool_parsers/test_pythonic_tool_parser.py \
  tests/tool_parsers/test_llama4_pythonic_tool_parser.py \
  tests/tool_parsers/test_olmo3_tool_parser.py \
  tests/tool_parsers/test_minimax_m2_tool_parser.py
```

No model evaluation is included: this PR adds test coverage and changes no parser,
sampling or serving code, so it cannot affect model output or accuracy.

## Test Result

`pytest tests/tool_parsers/`

| | before (clean `main`) | after |
|---|---|---|
| passed | 829 | **925** (+96) |
| skipped | 3 | 3 |
| xfailed | 34 | **40** (+6) |
| errors | 15 | 15 (unchanged) |

The 6 new test classes contribute 102 tests (96 passing, 6 strict xfail), which accounts
for the full delta — no existing test changed status.

The 15 errors are **pre-existing and unrelated**. They are all in
`test_llama3_json_tool_parser.py` and reproduce identically on an unmodified tree; they
come from the gated `meta-llama/Llama-3.2-1B-Instruct` tokenizer repo returning 401
without an authenticated HF token:

```
huggingface_hub.errors.GatedRepoError: 401 Client Error.
Cannot access gated repo for url
https://huggingface.co/meta-llama/Llama-3.2-1B-Instruct/resolve/main/config.json
```

Newly added coverage in isolation:

```
96 passed, 2 skipped, 879 deselected, 6 xfailed
```

`pre-commit` passes on all six changed files, `mypy` included.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. — N/A, no user-facing behaviour or model support changes.
</details>
