### PR TITLE
[Bugfix][GDN] Fix stateless first-chunk classification

### DIFF
--- a/tests/v1/attention/test_gdn_metadata_builder.py
+++ b/tests/v1/attention/test_gdn_metadata_builder.py
@@ -278,6 +278,37 @@ def test_one_token_prefill_batch_stages_cudagraph_metadata(
     torch.testing.assert_close(meta.non_spec_query_start_loc, common.query_start_loc)
 
 
+def test_one_token_prefill_excludes_cudagraph_padding():
+    """Padding rows must not enter the prefill chunk metadata."""
+    builder = _create_gdn_builder(full_cuda_graph=True)
+    batch = BatchSpec(seq_lens=[100, 50, 1, 0], query_lens=[1, 1, 1, 0])
+    common = create_common_attn_metadata(batch, BLOCK_SIZE, DEVICE).replace(
+        is_prefilling=torch.tensor([False, False, True, False]),
+        num_actual_tokens=4,
+    )
+    meta = builder.build(0, common)
+
+    assert meta.num_decodes == 2
+    assert meta.num_decode_tokens == 2
+    assert meta.num_prefills == 1
+    assert meta.num_prefill_tokens == 1
+    assert meta.has_initial_state is not None
+    assert meta.has_initial_state.tolist() == [True, True, False]
+    assert meta.prefill_query_start_loc is not None
+    assert meta.prefill_query_start_loc.tolist() == [0, 1]
+    assert meta.prefill_state_indices is not None
+    assert meta.prefill_state_indices.shape == (1,)
+    assert meta.prefill_has_initial_state is not None
+    assert meta.prefill_has_initial_state.tolist() == [False]
+    assert meta.non_spec_state_indices_tensor is not None
+    assert meta.non_spec_state_indices_tensor.shape == (4,)
+    torch.testing.assert_close(
+        meta.non_spec_state_indices_tensor, common.block_table_tensor[:, 0]
+    )
+    assert meta.non_spec_query_start_loc is not None
+    torch.testing.assert_close(meta.non_spec_query_start_loc, common.query_start_loc)
+
+
 def test_multi_token_prefill_batch_does_not_stage_cudagraph_metadata():
     """A non-uniform batch cannot replay the captured uniform-decode graph."""
     builder = _create_gdn_builder(full_cuda_graph=True)

--- a/tests/v1/attention/test_gdn_metadata_builder.py
+++ b/tests/v1/attention/test_gdn_metadata_builder.py
@@ -155,9 +155,14 @@ def _build(
     builder: GDNAttentionMetadataBuilder,
     batch_spec: BatchSpec,
     num_decode_draft_tokens: list[int] | None = None,
+    is_prefilling: list[bool] | None = None,
 ) -> GDNAttentionMetadata:
     """Build GDN attention metadata, optionally with spec-decode kwargs."""
     common = create_common_attn_metadata(batch_spec, BLOCK_SIZE, DEVICE)
+    if is_prefilling is not None:
+        common = common.replace(
+            is_prefilling=torch.tensor(is_prefilling, dtype=torch.bool)
+        )
     kwargs: dict = {}
     if num_decode_draft_tokens is not None:
         kwargs["num_decode_draft_tokens_cpu"] = torch.tensor(
@@ -196,6 +201,108 @@ def test_has_initial_state_after_reclassification():
     assert meta.has_initial_state is not None
     # req0 has context_lens = 65 - 1 = 64 > 0, so has_initial_state[0] = True
     assert meta.has_initial_state[0].item() is True
+
+
+def test_one_token_first_chunk_is_prefill():
+    """A first chunk has no recurrent state for the decode path to read."""
+    builder = _create_gdn_builder()
+    batch = BatchSpec(seq_lens=[100, 50, 1], query_lens=[1, 1, 1])
+    meta = _build(builder, batch, is_prefilling=[False, False, True])
+
+    assert meta.num_decodes == 2
+    assert meta.num_decode_tokens == 2
+    assert meta.num_prefills == 1
+    assert meta.num_prefill_tokens == 1
+    assert meta.has_initial_state is not None
+    assert meta.has_initial_state.tolist() == [True, True, False]
+    assert meta.prefill_has_initial_state is not None
+    assert meta.prefill_has_initial_state.tolist() == [False]
+
+
+def test_one_token_resumed_prefill_stays_decode():
+    """A one-token chunk with prior recurrent state can use the decode path."""
+    builder = _create_gdn_builder()
+    batch = BatchSpec(seq_lens=[100, 50, 65], query_lens=[1, 1, 1])
+    meta = _build(builder, batch, is_prefilling=[False, False, True])
+
+    assert meta.num_decodes == 3
+    assert meta.num_prefills == 0
+    assert meta.has_initial_state is None
+
+
+def test_cudagraph_capture_batch_stays_decode_only():
+    """Capture dummies look stateless but are not real prefill requests."""
+    builder = _create_gdn_builder(full_cuda_graph=True)
+    batch = BatchSpec(seq_lens=[1] * 4, query_lens=[1] * 4)
+    common = create_common_attn_metadata(batch, BLOCK_SIZE, DEVICE).replace(
+        is_prefilling=torch.zeros(4, dtype=torch.bool)
+    )
+    meta = builder.build_for_cudagraph_capture(common)
+
+    assert meta.num_decodes == 4
+    assert meta.num_prefills == 0
+    assert meta.has_initial_state is None
+
+
+@pytest.mark.parametrize(
+    ("seq_lens", "is_prefilling", "expected_num_prefills"),
+    [
+        pytest.param([100, 50, 1], [False, False, True], 1, id="mixed-with-decodes"),
+        pytest.param([1, 1, 1], [True, True, True], 3, id="all-stateless"),
+    ],
+)
+def test_one_token_prefill_batch_stages_cudagraph_metadata(
+    seq_lens: list[int],
+    is_prefilling: list[bool],
+    expected_num_prefills: int,
+):
+    """FULL-graph dispatch is shape-based, so uniform metadata must be staged."""
+    builder = _create_gdn_builder(full_cuda_graph=True)
+    batch = BatchSpec(seq_lens=seq_lens, query_lens=[1, 1, 1])
+    common = create_common_attn_metadata(batch, BLOCK_SIZE, DEVICE).replace(
+        is_prefilling=torch.tensor(is_prefilling)
+    )
+    meta = builder.build(0, common)
+
+    assert meta.num_prefills == expected_num_prefills
+    assert meta.non_spec_state_indices_tensor is not None
+    assert meta.non_spec_query_start_loc is not None
+    assert (
+        meta.non_spec_state_indices_tensor.data_ptr()
+        == builder.non_spec_state_indices_tensor.data_ptr()
+    )
+    assert (
+        meta.non_spec_query_start_loc.data_ptr()
+        == builder.non_spec_query_start_loc.data_ptr()
+    )
+    torch.testing.assert_close(meta.non_spec_query_start_loc, common.query_start_loc)
+
+
+def test_multi_token_prefill_batch_does_not_stage_cudagraph_metadata():
+    """A non-uniform batch cannot replay the captured uniform-decode graph."""
+    builder = _create_gdn_builder(full_cuda_graph=True)
+    batch = BatchSpec(seq_lens=[100, 50], query_lens=[1, 2])
+    common = create_common_attn_metadata(batch, BLOCK_SIZE, DEVICE).replace(
+        is_prefilling=torch.tensor([False, True])
+    )
+    meta = builder.build(0, common)
+
+    assert meta.non_spec_state_indices_tensor is not None
+    assert (
+        meta.non_spec_state_indices_tensor.data_ptr()
+        != builder.non_spec_state_indices_tensor.data_ptr()
+    )
+
+
+def test_first_chunk_without_prefill_flag_keeps_length_classification():
+    """Without the runner flag, capture-shaped metadata is ambiguous."""
+    builder = _create_gdn_builder()
+    batch = BatchSpec(seq_lens=[1], query_lens=[1])
+    meta = _build(builder, batch)
+
+    assert meta.num_decodes == 1
+    assert meta.num_prefills == 0
+    assert meta.has_initial_state is None
 
 
 def test_full_cudagraph_spec_metadata_uses_request_count():

--- a/vllm/v1/attention/backends/gdn_attn.py
+++ b/vllm/v1/attention/backends/gdn_attn.py
@@ -209,8 +209,26 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
                 )
 
         if spec_sequence_masks is None:
+            # A one-token first chunk has no GDN state and must take the
+            # prefill path, which masks recycled state pages. Resumed short
+            # prefills already own state and can stay on the decode path.
+            assert m.seq_lens_cpu_upper_bound is not None
+            query_lens_cpu = query_start_loc_cpu.diff()
+            no_prior_state = (query_lens_cpu > 0) & (
+                m.seq_lens_cpu_upper_bound <= query_lens_cpu
+            )
+            if m.is_prefilling is not None:
+                no_prior_state &= m.is_prefilling
+            else:
+                # Metadata without this runner flag is indistinguishable from
+                # the dummy batch used for cudagraph capture.
+                no_prior_state = torch.zeros_like(no_prior_state)
             num_decodes, num_prefills, num_decode_tokens, num_prefill_tokens = (
-                split_decodes_and_prefills(m, decode_threshold=1)
+                split_decodes_and_prefills(
+                    m.replace(is_prefilling=no_prior_state),
+                    decode_threshold=1,
+                    treat_short_extends_as_decodes=False,
+                )
             )
             num_spec_decode_tokens = 0
             spec_token_indx = None
@@ -463,26 +481,25 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
             num_accepted_tokens = self.num_accepted_tokens[:batch_size]
             num_accepted_tokens[num_spec_decodes:].fill_(1)
 
+        # FULL-graph dispatch is shape-based, so stage uniform one-token
+        # metadata even when a stateless row was classified as a prefill.
         if (
             self.use_full_cuda_graph
-            and num_prefills == 0
             and num_spec_decodes == 0
-            and num_decodes <= self.decode_cudagraph_max_bs
+            and m.max_query_len <= 1
+            and batch_size <= self.decode_cudagraph_max_bs
         ):
-            self.non_spec_state_indices_tensor[:num_decodes].copy_(
+            self.non_spec_state_indices_tensor[:batch_size].copy_(
                 non_spec_state_indices_tensor, non_blocking=True
             )
             non_spec_state_indices_tensor = self.non_spec_state_indices_tensor[
                 :batch_size
             ]
-            non_spec_state_indices_tensor[num_decodes:].fill_(NULL_BLOCK_ID)
 
-            self.non_spec_query_start_loc[: num_decodes + 1].copy_(
+            self.non_spec_query_start_loc[: batch_size + 1].copy_(
                 non_spec_query_start_loc, non_blocking=True
             )
-            non_spec_num_query_tokens = non_spec_query_start_loc[-1]  # type: ignore[index]
             non_spec_query_start_loc = self.non_spec_query_start_loc[: batch_size + 1]
-            non_spec_query_start_loc[num_decodes + 1 :].fill_(non_spec_num_query_tokens)
 
         attn_metadata = GDNAttentionMetadata(
             num_prefills=num_prefills,

--- a/vllm/v1/attention/backends/gdn_attn.py
+++ b/vllm/v1/attention/backends/gdn_attn.py
@@ -230,14 +230,22 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
                     treat_short_extends_as_decodes=False,
                 )
             )
+            if num_prefills > 0:
+                num_padding_reqs = (query_lens_cpu[num_decodes:] == 0).sum().item()
+                num_prefills -= num_padding_reqs
+                num_prefill_tokens = (
+                    query_start_loc_cpu[num_decodes + num_prefills].item()
+                    - num_decode_tokens
+                )
             num_spec_decode_tokens = 0
             spec_token_indx = None
             non_spec_token_indx = None
             spec_state_indices_tensor = None
-            non_spec_state_indices_tensor = block_table_tensor[:, 0]
+            num_non_spec_reqs = num_decodes + num_prefills
+            non_spec_state_indices_tensor = block_table_tensor[:num_non_spec_reqs, 0]
             spec_query_start_loc = None
-            non_spec_query_start_loc = query_start_loc
-            non_spec_query_start_loc_cpu = query_start_loc_cpu
+            non_spec_query_start_loc = query_start_loc[: num_non_spec_reqs + 1]
+            non_spec_query_start_loc_cpu = query_start_loc_cpu[: num_non_spec_reqs + 1]
             num_accepted_tokens = None
         else:
             query_lens = query_start_loc[1:] - query_start_loc[:-1]
@@ -411,6 +419,8 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
             if spec_sequence_masks_cpu is not None:
                 has_initial_state = has_initial_state[~spec_sequence_masks_cpu]
                 assert non_spec_query_start_loc_cpu is not None
+            else:
+                has_initial_state = has_initial_state[: num_decodes + num_prefills]
             nums_dict, batch_ptr, token_chunk_offset_ptr = (
                 compute_causal_conv1d_metadata(
                     non_spec_query_start_loc_cpu,
@@ -490,14 +500,14 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
             and batch_size <= self.decode_cudagraph_max_bs
         ):
             self.non_spec_state_indices_tensor[:batch_size].copy_(
-                non_spec_state_indices_tensor, non_blocking=True
+                block_table_tensor[:, 0], non_blocking=True
             )
             non_spec_state_indices_tensor = self.non_spec_state_indices_tensor[
                 :batch_size
             ]
 
             self.non_spec_query_start_loc[: batch_size + 1].copy_(
-                non_spec_query_start_loc, non_blocking=True
+                query_start_loc, non_blocking=True
             )
             non_spec_query_start_loc = self.non_spec_query_start_loc[: batch_size + 1]
 


### PR DESCRIPTION
## Purpose

Fixes #51562.

`GDNMetadataBuilder.build()` passed `decode_threshold=1` to
`split_decodes_and_prefills()` while leaving
`treat_short_extends_as_decodes=True`. As a result, every one-token sequence was
classified as a decode, including the first chunk of a request with no prior GDN
state. The decode path then reads recurrent and convolution state unconditionally;
because Mamba-style state pages can be reused without being zeroed, that first token
could consume stale state from a previous request.

This change:

- classifies non-speculative one-token chunks from state availability
  (`seq_len <= query_len`) and the runner's `is_prefilling` signal;
- keeps resumed one-token chunks and CUDA graph capture dummy batches on the decode
  path;
- stages FULL CUDA graph metadata based on graph-compatible shape rather than the
  derived prefill/decode split, so mixed and all-stateless batches use persistent
  buffers correctly; and
- adds regression coverage for stateless first chunks, resumed one-token chunks,
  capture dummy metadata, and CUDA graph staging.

The fix lives in the shared GDN metadata builder and therefore covers its Qwen,
OLMo, InternS2, Bailing, and standalone Kimi-Linear users. Runner-level FULL CUDA
graph selection is a separate concern tracked by #47123; this PR does not duplicate
that broader runner change.

Duplicate-work check (2026-08-09): issue #51562 has no comments, and searches for
open PRs referencing `51562` or matching `GatedDeltaNet metadata stateless decode`
returned no results. Related PR #51483 changes the Kimi K3 subclass rather than this
shared builder.

AI assistance was used to inspect the issue, identify the root cause.  I reviewed the final diff and the test results below.The submitting author reviewed every changed line in the final diff.

## Test Plan

1. Run the GDN metadata builder unit tests.
2. Run Ruff lint and formatting checks on both changed files.
3. Before marking the PR ready, run an end-to-end affected-model evaluation with a
   freshly allocated/reused GDN state page and a one-token first chunk.

## Test Result

- Before the fix, the new stateless-first-chunk regression observed 3 decodes and 0
  prefills instead of 2 decodes and 1 prefill.
- `tests/v1/attention/test_gdn_metadata_builder.py`: **16 passed**, 14 existing
  PyTorch JIT deprecation warnings.
