### PR TITLE
[CI] Bump CUTLASS DSL to 4.6.2

### DIFF
--- a/requirements/cuda.txt
+++ b/requirements/cuda.txt
@@ -25,8 +25,8 @@ nvtx==0.2.15
 fastsafetensors >= 0.3.3
 
 # QuACK and Cutlass DSL for FA4 (cute-DSL implementation)
-nvidia-cutlass-dsl[cu13]==4.6.0
-quack-kernels==0.6.1  # Required for CUTLASS DSL 4.6 by MSA
+nvidia-cutlass-dsl[cu13]==4.6.2
+quack-kernels==0.6.4  # Required for CUTLASS DSL 4.6 by MSA
 
 # Tokenspeed_MLA for faster mla with spec decode
 tokenspeed-mla==0.1.8; platform_system == "Linux"


### PR DESCRIPTION
## Summary

- bump `nvidia-cutlass-dsl[cu13]` from 4.6.0 to 4.6.2
- bump `quack-kernels` from 0.6.1 to 0.6.4, whose package metadata pins CUTLASS DSL 4.6.2
- replace the temporary QuACK downgrade with the CUTLASS DSL fix proposed in #51286

## Why

CUTLASS DSL 4.6.0 rejects the FA4 SM100 split-KV kernel with `TYPE_UNSTABLE_JOIN`, which can fail B200/B300 attention tests and Kimi-K3 startup during CuTeDSL warmup. CUTLASS DSL 4.6.2 accepts this kernel.

QuACK 0.6.1 requires CUTLASS DSL 4.6.0 exactly, so both packages must move together. QuACK 0.6.4 declares an exact dependency on CUTLASS DSL 4.6.2.

Fixes #51286.

## AI assistance

Codex was used to investigate the failure, update the dependency pins, run validation, and prepare this draft PR. The PR was reviewed by the submitter.
