### PR TITLE
[Bugfix][EPLB] Transport E8M0 expert state as byte views

### DIFF
--- a/tests/distributed/test_eplb_execute.py
+++ b/tests/distributed/test_eplb_execute.py
@@ -19,10 +19,67 @@ from vllm.distributed.eplb.rebalance_execute import (
 )
 from vllm.distributed.parallel_state import (
     ensure_model_parallel_initialized,
+    get_eplb_group,
     get_tp_group,
 )
+from vllm.model_executor.models.interfaces import MixtureOfExperts
 
 from .eplb_utils import distributed_run, set_env_vars_and_device
+
+
+class _E8M0TestMoELayer:
+    def __init__(self, expert_weights: list[torch.Tensor]) -> None:
+        self.expert_weights = expert_weights
+
+    def get_expert_weights(self) -> list[torch.Tensor]:
+        return self.expert_weights
+
+    def set_eplb_state(self, **_: object) -> None:
+        pass
+
+
+class _E8M0TestMoEModel(MixtureOfExperts):
+    def __init__(self, layer: _E8M0TestMoELayer) -> None:
+        self.moe_layers = [layer]  # type: ignore[assignment]
+
+
+def _register_e8m0_test_layer(
+    layer: _E8M0TestMoELayer,
+) -> _E8M0TestMoEModel:
+    model = _E8M0TestMoEModel(layer)
+    empty = torch.empty(0, dtype=torch.int32)
+    model.set_eplb_state(empty, empty, empty)
+    return model
+
+
+def _e8m0_expert_values(
+    logical_expert_ids: torch.Tensor,
+    device: torch.device,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    expert_ids = logical_expert_ids.to(device).unsqueeze(1)
+    packed_weight = (expert_ids * 100 + torch.arange(8, device=device)).to(torch.int32)
+    scale_bytes = (expert_ids * 17 + torch.arange(16, device=device)).to(torch.uint8)
+    return packed_weight, scale_bytes
+
+
+def test_set_eplb_state_registers_e8m0_scale_as_byte_view() -> None:
+    raw_storage = torch.arange(264, dtype=torch.int16).to(torch.uint8)
+    scale = raw_storage[4:260].reshape(2, 128).view(torch.float8_e8m0fnu)
+    packed_weight = torch.arange(16, dtype=torch.int32).reshape(2, 8)
+    model = _register_e8m0_test_layer(_E8M0TestMoELayer([packed_weight, scale]))
+    registered_weight, registered_scale = model.expert_weights[0]
+
+    assert registered_weight is packed_weight
+    assert registered_scale.dtype == torch.uint8
+    assert scale.dtype == torch.float8_e8m0fnu
+    assert registered_scale.shape == scale.shape
+    assert registered_scale.stride() == scale.stride()
+    assert registered_scale.storage_offset() == scale.storage_offset()
+    assert registered_scale.data_ptr() == scale.data_ptr()
+    assert torch.equal(registered_scale, scale.view(torch.uint8))
+
+    registered_scale[0, 0] = 255
+    assert int(scale.view(torch.uint8)[0, 0]) == 255
 
 
 def create_expert_indices_with_redundancy(
@@ -291,6 +348,106 @@ def create_eplb_communicator_or_raise(
         raise RuntimeError(
             f"Failed to create EPLB communicator for backend={backend}: {exc}"
         ) from exc
+
+
+def _test_e8m0_transport_worker(
+    env,
+    world_size: int,
+) -> None:
+    set_env_vars_and_device(env)
+    assert world_size == 2
+
+    vllm_config = VllmConfig()
+    vllm_config.parallel_config.tensor_parallel_size = world_size
+    vllm_config.parallel_config.enable_expert_parallel = True
+    vllm_config.parallel_config.enable_eplb = True
+
+    with set_current_vllm_config(vllm_config):
+        ensure_model_parallel_initialized(
+            tensor_model_parallel_size=world_size,
+            pipeline_model_parallel_size=1,
+        )
+
+        ep_group_coordinator = get_eplb_group()
+        ep_group = ep_group_coordinator.device_group
+        ep_rank = ep_group_coordinator.rank_in_group
+        device = torch.device(f"cuda:{ep_rank}")
+        num_local_experts = 2
+        old_indices = torch.tensor([[0, 1, 2, 3]], dtype=torch.long)
+        new_indices = torch.tensor([[2, 3, 0, 1]], dtype=torch.long)
+        local_slice = slice(
+            ep_rank * num_local_experts,
+            (ep_rank + 1) * num_local_experts,
+        )
+        packed_weight, scale_bytes = _e8m0_expert_values(
+            old_indices[0, local_slice],
+            device,
+        )
+        weight_scale = scale_bytes.view(torch.float8_e8m0fnu)
+        model = _register_e8m0_test_layer(
+            _E8M0TestMoELayer([packed_weight, weight_scale])
+        )
+        expert_weights = model.expert_weights
+        registered_scale = expert_weights[0][1]
+        assert registered_scale.dtype == torch.uint8
+        assert registered_scale.data_ptr() == weight_scale.data_ptr()
+
+        expert_buffer = [torch.empty_like(w) for w in expert_weights[0]]
+        communicator = create_eplb_communicator_or_raise(
+            group_coordinator=ep_group_coordinator,
+            backend="torch_gloo",
+            expert_weights=expert_weights,
+            expert_buffer=expert_buffer,
+        )
+        assert communicator.needs_profile_buffer_reservation
+        original_weights = [weight.clone() for weight in expert_weights[0]]
+
+        rearrange_expert_weights_inplace(
+            old_indices,
+            new_indices,
+            expert_weights,
+            expert_buffer,
+            ep_group,
+            communicator,
+            is_profile=True,
+        )
+        assert all(
+            torch.equal(weight, original_weight)
+            for weight, original_weight in zip(
+                expert_weights[0],
+                original_weights,
+            )
+        )
+
+        rearrange_expert_weights_inplace(
+            old_indices,
+            new_indices,
+            expert_weights,
+            expert_buffer,
+            ep_group,
+            communicator,
+        )
+
+    expected_weight, expected_scale = _e8m0_expert_values(
+        new_indices[0, local_slice],
+        device,
+    )
+    local_ok = torch.equal(packed_weight, expected_weight) and torch.equal(
+        weight_scale.view(torch.uint8),
+        expected_scale,
+    )
+
+    assert_verification_synced(
+        local_ok,
+        "E8M0 EPLB transport verification failed on at least one rank.",
+    )
+
+
+def test_e8m0_transport_profile_and_rearrangement() -> None:
+    world_size = 2
+    if torch.accelerator.device_count() < world_size:
+        pytest.skip(f"Need at least {world_size} GPUs to run the test")
+    distributed_run(_test_e8m0_transport_worker, world_size)
 
 
 def _test_async_transfer_layer_without_mtp_worker(

--- a/vllm/model_executor/models/interfaces.py
+++ b/vllm/model_executor/models/interfaces.py
@@ -985,6 +985,13 @@ def is_hybrid(
     return getattr(model, "is_hybrid", False)
 
 
+def _to_eplb_transport_view(weight: Tensor) -> Tensor:
+    """Expose E8M0 expert state as a storage-preserving byte view for EPLB."""
+    if weight.dtype == torch.float8_e8m0fnu:
+        return weight.view(torch.uint8)
+    return weight
+
+
 @runtime_checkable
 class MixtureOfExperts(Protocol):
     """
@@ -1051,7 +1058,12 @@ class MixtureOfExperts(Protocol):
         self.expert_weights = []
         for layer_idx, layer in enumerate(self.moe_layers):
             # Register the expert weights.
-            self.expert_weights.append(list(layer.get_expert_weights()))
+            self.expert_weights.append(
+                [
+                    _to_eplb_transport_view(weight)
+                    for weight in layer.get_expert_weights()
+                ]
+            )
             layer.set_eplb_state(
                 moe_layer_idx=layer_idx,
                 expert_load_view=expert_load_view,


### PR DESCRIPTION
## Purpose

Fixes #51567.

EPLB currently registers kernel-formatted expert tensors using their
numerical dtypes. MXFP4 and MXFP8 Marlin experts can store their weight
scales as `torch.float8_e8m0fnu`.

During startup profiling, `rearrange_expert_weights_inplace()` performs a
dummy device-group all-gather over those tensors to reserve communication
buffers. PyTorch NCCL does not support E8M0, so engine initialization fails
with:

```text
TypeError: Input tensor data type is not supported for NCCL process group:
Float8_e8m0fnu
```

The runtime Torch NCCL, Gloo-staged, and PyNCCL transports have the same
underlying dtype limitation.

This PR exposes E8M0 expert state to EPLB as storage-preserving `uint8`
views at the common `MixtureOfExperts.set_eplb_state()` registration
boundary:

```python
if weight.dtype == torch.float8_e8m0fnu:
    return weight.view(torch.uint8)
```

E8M0 and `uint8` are both one byte per element. The view therefore preserves
the tensor's shape, stride, storage offset, byte count, data pointer, and
underlying storage. EPLB moves the exact scale bytes, while the inference
kernel continues to read the original E8M0 parameter.

This intentionally uses `view(torch.uint8)`, not `to(torch.uint8)`. `to()`
would numerically convert the scale and allocate separate storage, so a
rearrangement would either corrupt the scale representation or fail to update
the tensor read by the kernel. Non-E8M0 expert tensors are returned unchanged.

### Why the fix is at the registration boundary

Converting only inside an EPLB communicator would be too late:

- receive buffers are constructed from `model.expert_weights` before the
  communicator is created;
- startup profiling directly calls `all_gather` and bypasses communicator
  send/receive methods;
- local copies, asynchronous EPLB, elastic EPLB, and NIXL all consume the same
  registered expert-state list.

The common registration boundary gives all EPLB paths the same
storage-preserving transport representation without adding backend- or
device-specific checks.

### Scope

H20 with DeepSeek-V4-Flash and MXFP4 Marlin is the verified reproducer, but
the fix is not H20- or model-specific. It applies whenever a MoE backend
registers E8M0 expert-local state with EPLB, including MXFP4 Marlin and
MXFP8 Marlin.

### Duplicate-work check

I searched open and closed issues and open PRs on 2026-08-09 for:

- `EPLB E8M0`
- `EPLB float8_e8m0fnu`
- `EPLB byte transport`
- `MXFP4 EPLB unsupported dtype`
- `51567 in:body`

No existing PR addresses this transport failure. Related work is not
duplicative:

- #47588 keeps converted Quark/AITER MXFP4 expert weights visible to EPLB. It
  addresses missing expert parameters and silent weight/scale mismatch; it
  does not change E8M0 communication.
- #49573 adds CPU expert-backup byte-region and descriptor primitives. It does
  not modify live EPLB profiling or expert rearrangement transport.
- #41834 and #50392 were keyword-search matches, but neither changes the
  common EPLB expert registration or rearrangement transport paths.

## Test Plan

The tests extend the existing `tests/distributed/test_eplb_execute.py` suite.

The CPU test exercises the public EPLB registration behavior and verifies
that E8M0 is registered as a storage-aliasing `uint8` view while non-E8M0
packed weights retain object identity.

```bash
.venv/bin/python -m pytest \
  tests/distributed/test_eplb_execute.py::test_set_eplb_state_registers_e8m0_scale_as_byte_view \
  -q
```

The two-GPU test uses a dedicated EPLB process group and mixed
`int32 + E8M0` expert state. It first executes the startup profile all-gather
and then performs an all-remote expert exchange through the Gloo-staged
runtime communicator. Final assertions read the original kernel-visible
E8M0 tensor, not only the temporary transport buffer.

```bash
.venv/bin/python -m pytest \
  tests/distributed/test_eplb_execute.py::test_e8m0_transport_profile_and_rearrangement \
  -q
```

Relevant existing regressions:

```bash
.venv/bin/python -m pytest \
  'tests/distributed/test_eplb_execute.py::test_rearrange_expert_weights_profile_mode[2]' \
  'tests/distributed/test_eplb_execute.py::test_rearrange_expert_weights_with_redundancy[torch_gloo-2-1-2-3]' \
  -q
```

Static checks:

```bash
uvx --from ruff==0.14.0 ruff format --check \
  vllm/model_executor/models/interfaces.py \
  tests/distributed/test_eplb_execute.py

uvx --from ruff==0.14.0 ruff check \
  vllm/model_executor/models/interfaces.py \
  tests/distributed/test_eplb_execute.py

uvx --from mypy==1.20.2 mypy \
  --python-version 3.12 \
  --follow-imports skip \
  tests/distributed/test_eplb_execute.py

uvx --from typos==1.43.5 typos --force-exclude \
  vllm/model_executor/models/interfaces.py \
  tests/distributed/test_eplb_execute.py

.venv/bin/python -m py_compile \
  vllm/model_executor/models/interfaces.py \
  tests/distributed/test_eplb_execute.py

git diff --check
```

### Model-level validation

The model-level validation used:

- `deepseek-ai/DeepSeek-V4-Flash-0731`;
- 2x NVIDIA H20;
- TP=2 and EP=2;
- MXFP4 Marlin experts;
- FP8 KV cache;
- synchronous Gloo EPLB;
- deterministic greedy one-token generation;
- EPLB profile followed by a real expert rearrangement.

The same deterministic inputs were evaluated before and after the
rearrangement.

## Test Result

- CPU registration/storage-alias test: **1 passed**.
- New two-H20 distributed profile and rearrangement test:
  **1 passed in 23.79 seconds**.
- Existing profile and Gloo-rearrangement regressions:
  **2 passed in 44.38 seconds**.
- Ruff format and check: **passed**.
- Mypy: **passed**.
- Typos: **passed**.
- Python compilation: **passed**.
- SPDX, forbidden-import, torch-CUDA, lazy-import, and config validation
  checks: **passed**.
- `git diff --check`: **passed**.

### Model result

On the real DeepSeek-V4-Flash configuration:

- EPLB profile rearrangement completed in 0.99 seconds;
- actual cross-rank expert rearrangement completed in 14.24 seconds;
- the 4K deterministic input produced token `98` before and after
  rearrangement;
- the 8K deterministic input produced token `1230` before and after
  rearrangement;
- overall result: `token_parity=true`.

The local source checkout expected a newer FlashInfer autotuner API than the
installed environment provided. The model-level validation therefore used
the supported `enable_flashinfer_autotune=False` option. This skips optional
FlashInfer autotuning and does not change the EPLB or MoE execution path.

### Pre-commit environment note

The complete `pre-commit run` could not initialize its hook environment
because the shared filesystem returned `Errno 524` while building the
Ruff-pre-commit wheel. The equivalent checks were run directly with the exact
tool versions listed above and passed. The commit hook was bypassed only after
that infrastructure failure was reproduced. Full pre-commit should be retried
before this draft is marked ready for review.

### AI assistance

AI assistance was used for code exploration, test design, implementation,
review support, test execution, and drafting this description. The human
submitter reviewed every changed line, understands the change end-to-end,
accepted the reported validation, and authorized publication with this
disclosure.

