### PR TITLE
[Quantization] Implement FP8 block padding for unaligned cases

### DIFF
--- a/tests/models/test_bailing_moe_v3_fp8.py
+++ b/tests/models/test_bailing_moe_v3_fp8.py
@@ -1,63 +1,48 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-from typing import cast
-
 import pytest
 import torch
 
-from vllm.model_executor.layers.quantization.base_config import QuantizationConfig
+from vllm.model_executor.layers.linear import LinearBase, UnquantizedLinearMethod
+from vllm.model_executor.layers.quantization import fp8 as fp8_quantization
 from vllm.model_executor.layers.quantization.fp8 import Fp8Config
-from vllm.model_executor.models import bailing_moe_v3
+from vllm.model_executor.model_loader.utils import configure_quant_config
+from vllm.model_executor.models import bailing_moe_v3, bailing_moe_v3_mtp
 
 
-class _FakeQuantConfig:
-    def __init__(
-        self,
-        *,
-        name: str = "fp8",
-        serialized: bool = True,
-        block_size: list[int] | None = None,
-        ignored_layers: list[str] | None = None,
-    ) -> None:
-        self.name = name
-        self.is_checkpoint_fp8_serialized = serialized
-        self.weight_block_size = block_size
-        self.ignored_layers = ignored_layers or []
-        self.packed_modules_mapping: dict[str, list[str]] = {}
-
-    def get_name(self) -> str:
-        return self.name
+def _block_fp8_config(
+    ignored_layers: list[str] | None = None,
+) -> Fp8Config:
+    quant_config = Fp8Config(
+        is_checkpoint_fp8_serialized=True,
+        weight_block_size=[128, 128],
+        ignored_layers=ignored_layers,
+    )
+    bailing_moe_v3._configure_ling_fp8_quant_config(quant_config)
+    return quant_config
 
 
-def _quant_config(**kwargs) -> QuantizationConfig:
-    return cast(QuantizationConfig, _FakeQuantConfig(**kwargs))
+class _StubLinear(LinearBase):
+    def __init__(self) -> None:
+        torch.nn.Module.__init__(self)
 
 
 @pytest.mark.parametrize(
-    ("prefix", "expected"),
+    "model_class",
     [
-        ("model.layers.5.self_attn.kv_b_proj", True),
-        ("model.layers.5.self_attn.g_proj", True),
-        ("model.layers.6.self_attn.g_proj", False),
-        ("model.layers.0.self_attn.b_proj", True),
-        ("model.layers.0.self_attn.q_proj", False),
+        bailing_moe_v3.BailingMoeV3ForCausalLM,
+        bailing_moe_v3_mtp.BailingMoeV3MTPModel,
     ],
 )
-def test_ling_block_fp8_exclusion_aliases(prefix: str, expected: bool):
-    quant_config = _quant_config(
-        block_size=[128, 128],
-        ignored_layers=[
-            "kv_b_proj",
-            "b_proj",
-            "5.attention.g_proj",
-        ],
+def test_ling_block_fp8_maps_checkpoint_exclusions(model_class):
+    assert (
+        model_class.hf_to_vllm_mapper._map_name(
+            "model.layers.5.attention.g_proj.weight"
+        )
+        == "model.layers.5.self_attn.g_proj.weight"
     )
 
-    assert bailing_moe_v3._is_fp8_module_excluded(quant_config, prefix) is expected
-
-
-def test_ling_block_fp8_uses_checkpoint_modules_to_not_convert():
     quant_config = Fp8Config.from_config(
         {
             "quant_method": "fp8",
@@ -66,52 +51,65 @@ def test_ling_block_fp8_uses_checkpoint_modules_to_not_convert():
             "modules_to_not_convert": ["b_proj", "5.attention.g_proj"],
         }
     )
+    configure_quant_config(quant_config, model_class)
 
-    assert bailing_moe_v3._is_fp8_module_excluded(
-        quant_config, "model.layers.0.self_attn.b_proj"
+    assert quant_config.ignored_layers == ["b_proj", "5.self_attn.g_proj"]
+    assert quant_config.ignored_layers_match_mode == "exact"
+
+    bailing_moe_v3._configure_ling_fp8_quant_config(quant_config)
+    assert quant_config.ignored_layers_match_mode == "suffix"
+
+
+def test_ling_block_fp8_dispatches_excluded_linear(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    quant_config = _block_fp8_config(ignored_layers=["b_proj"])
+
+    class _StubFp8LinearMethod:
+        pass
+
+    fp8_method = _StubFp8LinearMethod()
+    linear = _StubLinear()
+    # Keep this dispatch test independent of platform-specific FP8 kernels.
+    monkeypatch.setattr(
+        fp8_quantization,
+        "Fp8LinearMethod",
+        lambda _: fp8_method,
     )
-    assert bailing_moe_v3._is_fp8_module_excluded(
-        quant_config, "model.layers.5.self_attn.g_proj"
+    assert isinstance(
+        quant_config.get_quant_method(linear, "model.layers.0.self_attn.b_proj"),
+        UnquantizedLinearMethod,
     )
-
-
-def test_ling_fp8_exclusions_do_not_change_other_precision_paths():
-    quant_config = _quant_config(
-        name="some_other_quantization",
-        block_size=[128, 128],
-        ignored_layers=["kv_b_proj"],
-    )
-
     assert (
-        bailing_moe_v3._get_linear_quant_config(
-            quant_config, "model.layers.5.self_attn.kv_b_proj"
-        )
-        is quant_config
-    )
-    assert (
-        bailing_moe_v3._get_linear_quant_config(
-            None, "model.layers.5.self_attn.kv_b_proj"
-        )
-        is None
+        quant_config.get_quant_method(linear, "model.layers.0.self_attn.q_b_proj")
+        is fp8_method
     )
 
 
 @pytest.mark.parametrize(
-    ("serialized", "block_size"),
-    [(False, [128, 128]), (True, None)],
+    "quant_config",
+    [
+        pytest.param(None, id="bf16"),
+        pytest.param(Fp8Config(), id="online-fp8"),
+        pytest.param(
+            Fp8Config(is_checkpoint_fp8_serialized=True),
+            id="serialized-per-tensor-fp8",
+        ),
+    ],
 )
-def test_ling_kda_split_requires_serialized_block_fp8(
-    serialized: bool,
-    block_size: list[int] | None,
-):
-    quant_config = _quant_config(
-        serialized=serialized,
-        block_size=block_size,
-        ignored_layers=["b_proj"],
-    )
+def test_ling_non_block_fp8_paths_unchanged(quant_config: Fp8Config | None):
+    bailing_moe_v3._configure_ling_fp8_quant_config(quant_config)
+    if quant_config is not None:
+        assert quant_config.ignored_layers_match_mode == "exact"
 
     assert not bailing_moe_v3._is_fp8_module_excluded(
         quant_config, "model.layers.0.self_attn.b_proj"
+    )
+    assert (
+        bailing_moe_v3._get_block_fp8_mlp_padded_intermediate_size(
+            quant_config, 768, "model.layers.2.mlp.shared_experts"
+        )
+        == 768
     )
 
 
@@ -141,7 +139,7 @@ def test_ling_block_fp8_shared_expert_padding(
         "get_tensor_model_parallel_world_size",
         lambda: tp_size,
     )
-    quant_config = _quant_config(block_size=[128, 128])
+    quant_config = _block_fp8_config()
     prefix = "model.layers.2.mlp.shared_experts"
 
     assert (
@@ -150,24 +148,20 @@ def test_ling_block_fp8_shared_expert_padding(
         )
         == expected
     )
-    assert (
-        bailing_moe_v3._get_block_fp8_mlp_padded_intermediate_size(None, 768, prefix)
-        == 768
-    )
-    online_quant_config = _quant_config(
-        serialized=False,
-        block_size=[128, 128],
-    )
-    assert (
-        bailing_moe_v3._get_block_fp8_mlp_padded_intermediate_size(
-            online_quant_config, 768, prefix
-        )
-        == 768
-    )
 
 
+@pytest.mark.parametrize(
+    ("ignored_layers", "expected"),
+    [
+        (["gate_up_proj", "down_proj"], 768),
+        (["gate_up_proj"], 1024),
+        (["down_proj"], 1024),
+    ],
+)
 def test_ling_shared_expert_padding_requires_an_fp8_projection(
     monkeypatch: pytest.MonkeyPatch,
+    ignored_layers: list[str],
+    expected: int,
 ):
     monkeypatch.setattr(
         bailing_moe_v3,
@@ -175,38 +169,12 @@ def test_ling_shared_expert_padding_requires_an_fp8_projection(
         lambda: 4,
     )
     prefix = "model.layers.2.mlp.shared_experts"
-    quant_config = _quant_config(
-        block_size=[128, 128],
-        ignored_layers=["gate_up_proj", "down_proj"],
-    )
-
+    quant_config = _block_fp8_config(ignored_layers=ignored_layers)
     assert (
         bailing_moe_v3._get_block_fp8_mlp_padded_intermediate_size(
             quant_config, 768, prefix
         )
-        == 768
-    )
-
-    quant_config = _quant_config(
-        block_size=[128, 128],
-        ignored_layers=["gate_up_proj"],
-    )
-    assert (
-        bailing_moe_v3._get_block_fp8_mlp_padded_intermediate_size(
-            quant_config, 768, prefix
-        )
-        == 1024
-    )
-
-    quant_config = _quant_config(
-        block_size=[128, 128],
-        ignored_layers=["down_proj"],
-    )
-    assert (
-        bailing_moe_v3._get_block_fp8_mlp_padded_intermediate_size(
-            quant_config, 768, prefix
-        )
-        == 1024
+        == expected
     )
 
 
@@ -225,7 +193,7 @@ def test_ling_pad_block_fp8_shared_expert_checkpoint_tensor(
     expected_shape: tuple[int, ...],
     dim: int,
 ):
-    quant_config = _quant_config(block_size=[128, 128])
+    quant_config = _block_fp8_config()
     loaded_weight = torch.ones(shape)
 
     padded = bailing_moe_v3._pad_block_fp8_mlp_checkpoint_tensor(
@@ -255,7 +223,7 @@ def test_ling_pad_fused_gate_up_checkpoint_tensor_between_logical_shards(
     shard_size: int,
     padded_shard_size: int,
 ):
-    quant_config = _quant_config(block_size=[128, 128])
+    quant_config = _block_fp8_config()
     loaded_weight = torch.cat(
         [torch.ones(shard_size, 2), torch.full((shard_size, 2), 2.0)]
     )
@@ -286,7 +254,7 @@ def test_ling_shared_expert_checkpoint_padding_handles_mtp_layer_name(
         "get_tensor_model_parallel_world_size",
         lambda: 4,
     )
-    quant_config = _quant_config(block_size=[128, 128])
+    quant_config = _block_fp8_config()
 
     class _FakeBailingConfig:
         moe_shared_expert_intermediate_size = 768
@@ -305,23 +273,33 @@ def test_ling_shared_expert_checkpoint_padding_handles_mtp_layer_name(
     assert torch.count_nonzero(padded[6:]) == 0
 
 
-def test_ling_shared_expert_padding_keeps_down_bias_unchanged():
-    quant_config = _quant_config(block_size=[128, 128])
-    loaded_bias = torch.ones(2)
+@pytest.mark.parametrize(
+    ("name", "shape"),
+    [
+        ("shared_experts.down_proj.bias", (2,)),
+        ("shared_experts.gate_proj.weight", (1024, 2)),
+    ],
+)
+def test_ling_shared_expert_padding_keeps_unchanged_tensors(
+    name: str,
+    shape: tuple[int, ...],
+):
+    quant_config = _block_fp8_config()
+    loaded_weight = torch.ones(shape)
 
     padded = bailing_moe_v3._pad_block_fp8_mlp_checkpoint_tensor(
         quant_config,
-        "shared_experts.down_proj.bias",
-        loaded_bias,
+        name,
+        loaded_weight,
         intermediate_size=768,
         padded_intermediate_size=1024,
     )
 
-    assert padded is loaded_bias
+    assert padded is loaded_weight
 
 
 def test_ling_shared_expert_padding_rejects_wrong_checkpoint_shape():
-    quant_config = _quant_config(block_size=[128, 128])
+    quant_config = _block_fp8_config()
 
     with pytest.raises(ValueError, match="expected each logical intermediate"):
         bailing_moe_v3._pad_block_fp8_mlp_checkpoint_tensor(
@@ -331,18 +309,3 @@ def test_ling_shared_expert_padding_rejects_wrong_checkpoint_shape():
             intermediate_size=768,
             padded_intermediate_size=1024,
         )
-
-
-def test_ling_shared_expert_padding_accepts_already_padded_checkpoint():
-    quant_config = _quant_config(block_size=[128, 128])
-    loaded_weight = torch.ones(1024, 2)
-
-    padded = bailing_moe_v3._pad_block_fp8_mlp_checkpoint_tensor(
-        quant_config,
-        "shared_experts.gate_proj.weight",
-        loaded_weight,
-        intermediate_size=768,
-        padded_intermediate_size=1024,
-    )
-
-    assert padded is loaded_weight

--- a/tests/models/test_bailing_moe_v3_fp8.py
+++ b/tests/models/test_bailing_moe_v3_fp8.py
@@ -1,0 +1,348 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from typing import cast
+
+import pytest
+import torch
+
+from vllm.model_executor.layers.quantization.base_config import QuantizationConfig
+from vllm.model_executor.layers.quantization.fp8 import Fp8Config
+from vllm.model_executor.models import bailing_moe_v3
+
+
+class _FakeQuantConfig:
+    def __init__(
+        self,
+        *,
+        name: str = "fp8",
+        serialized: bool = True,
+        block_size: list[int] | None = None,
+        ignored_layers: list[str] | None = None,
+    ) -> None:
+        self.name = name
+        self.is_checkpoint_fp8_serialized = serialized
+        self.weight_block_size = block_size
+        self.ignored_layers = ignored_layers or []
+        self.packed_modules_mapping: dict[str, list[str]] = {}
+
+    def get_name(self) -> str:
+        return self.name
+
+
+def _quant_config(**kwargs) -> QuantizationConfig:
+    return cast(QuantizationConfig, _FakeQuantConfig(**kwargs))
+
+
+@pytest.mark.parametrize(
+    ("prefix", "expected"),
+    [
+        ("model.layers.5.self_attn.kv_b_proj", True),
+        ("model.layers.5.self_attn.g_proj", True),
+        ("model.layers.6.self_attn.g_proj", False),
+        ("model.layers.0.self_attn.b_proj", True),
+        ("model.layers.0.self_attn.q_proj", False),
+    ],
+)
+def test_ling_block_fp8_exclusion_aliases(prefix: str, expected: bool):
+    quant_config = _quant_config(
+        block_size=[128, 128],
+        ignored_layers=[
+            "kv_b_proj",
+            "b_proj",
+            "5.attention.g_proj",
+        ],
+    )
+
+    assert bailing_moe_v3._is_fp8_module_excluded(quant_config, prefix) is expected
+
+
+def test_ling_block_fp8_uses_checkpoint_modules_to_not_convert():
+    quant_config = Fp8Config.from_config(
+        {
+            "quant_method": "fp8",
+            "activation_scheme": "dynamic",
+            "weight_block_size": [128, 128],
+            "modules_to_not_convert": ["b_proj", "5.attention.g_proj"],
+        }
+    )
+
+    assert bailing_moe_v3._is_fp8_module_excluded(
+        quant_config, "model.layers.0.self_attn.b_proj"
+    )
+    assert bailing_moe_v3._is_fp8_module_excluded(
+        quant_config, "model.layers.5.self_attn.g_proj"
+    )
+
+
+def test_ling_fp8_exclusions_do_not_change_other_precision_paths():
+    quant_config = _quant_config(
+        name="some_other_quantization",
+        block_size=[128, 128],
+        ignored_layers=["kv_b_proj"],
+    )
+
+    assert (
+        bailing_moe_v3._get_linear_quant_config(
+            quant_config, "model.layers.5.self_attn.kv_b_proj"
+        )
+        is quant_config
+    )
+    assert (
+        bailing_moe_v3._get_linear_quant_config(
+            None, "model.layers.5.self_attn.kv_b_proj"
+        )
+        is None
+    )
+
+
+@pytest.mark.parametrize(
+    ("serialized", "block_size"),
+    [(False, [128, 128]), (True, None)],
+)
+def test_ling_kda_split_requires_serialized_block_fp8(
+    serialized: bool,
+    block_size: list[int] | None,
+):
+    quant_config = _quant_config(
+        serialized=serialized,
+        block_size=block_size,
+        ignored_layers=["b_proj"],
+    )
+
+    assert not bailing_moe_v3._is_fp8_module_excluded(
+        quant_config, "model.layers.0.self_attn.b_proj"
+    )
+
+
+def test_ling_kda_keeps_bf16_and_fp8_packed_mappings():
+    packed_mapping = bailing_moe_v3.BailingMoeV3ForCausalLM.packed_modules_mapping
+
+    assert packed_mapping["qkv_proj"] == ["q_proj", "k_proj", "v_proj"]
+    assert packed_mapping["qkvb_proj"] == [
+        "q_proj",
+        "k_proj",
+        "v_proj",
+        "b_proj",
+    ]
+
+
+@pytest.mark.parametrize(
+    ("tp_size", "expected"),
+    [(1, 768), (2, 768), (4, 1024), (8, 1024)],
+)
+def test_ling_block_fp8_shared_expert_padding(
+    monkeypatch: pytest.MonkeyPatch,
+    tp_size: int,
+    expected: int,
+):
+    monkeypatch.setattr(
+        bailing_moe_v3,
+        "get_tensor_model_parallel_world_size",
+        lambda: tp_size,
+    )
+    quant_config = _quant_config(block_size=[128, 128])
+    prefix = "model.layers.2.mlp.shared_experts"
+
+    assert (
+        bailing_moe_v3._get_block_fp8_mlp_padded_intermediate_size(
+            quant_config, 768, prefix
+        )
+        == expected
+    )
+    assert (
+        bailing_moe_v3._get_block_fp8_mlp_padded_intermediate_size(None, 768, prefix)
+        == 768
+    )
+    online_quant_config = _quant_config(
+        serialized=False,
+        block_size=[128, 128],
+    )
+    assert (
+        bailing_moe_v3._get_block_fp8_mlp_padded_intermediate_size(
+            online_quant_config, 768, prefix
+        )
+        == 768
+    )
+
+
+def test_ling_shared_expert_padding_requires_an_fp8_projection(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(
+        bailing_moe_v3,
+        "get_tensor_model_parallel_world_size",
+        lambda: 4,
+    )
+    prefix = "model.layers.2.mlp.shared_experts"
+    quant_config = _quant_config(
+        block_size=[128, 128],
+        ignored_layers=["gate_up_proj", "down_proj"],
+    )
+
+    assert (
+        bailing_moe_v3._get_block_fp8_mlp_padded_intermediate_size(
+            quant_config, 768, prefix
+        )
+        == 768
+    )
+
+    quant_config = _quant_config(
+        block_size=[128, 128],
+        ignored_layers=["gate_up_proj"],
+    )
+    assert (
+        bailing_moe_v3._get_block_fp8_mlp_padded_intermediate_size(
+            quant_config, 768, prefix
+        )
+        == 1024
+    )
+
+    quant_config = _quant_config(
+        block_size=[128, 128],
+        ignored_layers=["down_proj"],
+    )
+    assert (
+        bailing_moe_v3._get_block_fp8_mlp_padded_intermediate_size(
+            quant_config, 768, prefix
+        )
+        == 1024
+    )
+
+
+@pytest.mark.parametrize(
+    ("name", "shape", "expected_shape", "dim"),
+    [
+        ("shared_experts.gate_proj.weight", (768, 2), (1024, 2), 0),
+        ("shared_experts.up_proj.weight_scale_inv", (6, 2), (8, 2), 0),
+        ("shared_experts.down_proj.weight", (2, 768), (2, 1024), 1),
+        ("shared_experts.down_proj.weight_scale_inv", (2, 6), (2, 8), 1),
+    ],
+)
+def test_ling_pad_block_fp8_shared_expert_checkpoint_tensor(
+    name: str,
+    shape: tuple[int, ...],
+    expected_shape: tuple[int, ...],
+    dim: int,
+):
+    quant_config = _quant_config(block_size=[128, 128])
+    loaded_weight = torch.ones(shape)
+
+    padded = bailing_moe_v3._pad_block_fp8_mlp_checkpoint_tensor(
+        quant_config,
+        name,
+        loaded_weight,
+        intermediate_size=768,
+        padded_intermediate_size=1024,
+    )
+
+    assert padded.shape == expected_shape
+    assert torch.equal(padded.narrow(dim, 0, shape[dim]), loaded_weight)
+    assert (
+        torch.count_nonzero(
+            padded.narrow(dim, shape[dim], expected_shape[dim] - shape[dim])
+        )
+        == 0
+    )
+
+
+@pytest.mark.parametrize(
+    ("suffix", "shard_size", "padded_shard_size"),
+    [("weight", 768, 1024), ("weight_scale_inv", 6, 8)],
+)
+def test_ling_pad_fused_gate_up_checkpoint_tensor_between_logical_shards(
+    suffix: str,
+    shard_size: int,
+    padded_shard_size: int,
+):
+    quant_config = _quant_config(block_size=[128, 128])
+    loaded_weight = torch.cat(
+        [torch.ones(shard_size, 2), torch.full((shard_size, 2), 2.0)]
+    )
+
+    padded = bailing_moe_v3._pad_block_fp8_mlp_checkpoint_tensor(
+        quant_config,
+        f"shared_experts.gate_up_proj.{suffix}",
+        loaded_weight,
+        intermediate_size=768,
+        padded_intermediate_size=1024,
+    )
+
+    assert padded.shape == (2 * padded_shard_size, 2)
+    assert torch.equal(padded[:shard_size], loaded_weight[:shard_size])
+    assert torch.count_nonzero(padded[shard_size:padded_shard_size]) == 0
+    assert torch.equal(
+        padded[padded_shard_size : padded_shard_size + shard_size],
+        loaded_weight[shard_size:],
+    )
+    assert torch.count_nonzero(padded[padded_shard_size + shard_size :]) == 0
+
+
+def test_ling_shared_expert_checkpoint_padding_handles_mtp_layer_name(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(
+        bailing_moe_v3,
+        "get_tensor_model_parallel_world_size",
+        lambda: 4,
+    )
+    quant_config = _quant_config(block_size=[128, 128])
+
+    class _FakeBailingConfig:
+        moe_shared_expert_intermediate_size = 768
+        num_shared_experts = 1
+
+    loaded_scale = torch.ones(6, 2)
+    padded = bailing_moe_v3._maybe_pad_block_fp8_shared_expert_checkpoint_tensor(
+        quant_config,
+        _FakeBailingConfig(),  # type: ignore[arg-type]
+        "model.layers.42.mlp.shared_experts.gate_proj.weight_scale_inv",
+        loaded_scale,
+    )
+
+    assert padded.shape == (8, 2)
+    assert torch.equal(padded[:6], loaded_scale)
+    assert torch.count_nonzero(padded[6:]) == 0
+
+
+def test_ling_shared_expert_padding_keeps_down_bias_unchanged():
+    quant_config = _quant_config(block_size=[128, 128])
+    loaded_bias = torch.ones(2)
+
+    padded = bailing_moe_v3._pad_block_fp8_mlp_checkpoint_tensor(
+        quant_config,
+        "shared_experts.down_proj.bias",
+        loaded_bias,
+        intermediate_size=768,
+        padded_intermediate_size=1024,
+    )
+
+    assert padded is loaded_bias
+
+
+def test_ling_shared_expert_padding_rejects_wrong_checkpoint_shape():
+    quant_config = _quant_config(block_size=[128, 128])
+
+    with pytest.raises(ValueError, match="expected each logical intermediate"):
+        bailing_moe_v3._pad_block_fp8_mlp_checkpoint_tensor(
+            quant_config,
+            "shared_experts.gate_proj.weight",
+            torch.ones(640, 2),
+            intermediate_size=768,
+            padded_intermediate_size=1024,
+        )
+
+
+def test_ling_shared_expert_padding_accepts_already_padded_checkpoint():
+    quant_config = _quant_config(block_size=[128, 128])
+    loaded_weight = torch.ones(1024, 2)
+
+    padded = bailing_moe_v3._pad_block_fp8_mlp_checkpoint_tensor(
+        quant_config,
+        "shared_experts.gate_proj.weight",
+        loaded_weight,
+        intermediate_size=768,
+        padded_intermediate_size=1024,
+    )
+
+    assert padded is loaded_weight

--- a/tests/quantization/test_quark.py
+++ b/tests/quantization/test_quark.py
@@ -604,11 +604,32 @@ def test_non_fused_layer_unaffected():
 
 
 def test_substr_match_on_fused_name():
-    # skip_with_substr=True path: fused-name substring match should also
+    # Substring matching: a fused-name match should also
     # short-circuit before shard expansion.
     assert is_layer_skipped(
         prefix="model.layers.0.self_attn.qkv_proj",
         ignored_layers=["self_attn.qkv_proj"],
         fused_mapping=FUSED_MAPPING,
-        skip_with_substr=True,
+        match_mode="substring",
+    )
+
+
+@pytest.mark.parametrize(
+    ("prefix", "ignored_layer", "expected"),
+    [
+        ("model.layers.0.self_attn.b_proj", "b_proj", True),
+        ("model.layers.0.self_attn.q_b_proj", "b_proj", False),
+        ("model.layers.0.self_attn.kv_b_proj", "b_proj", False),
+        ("model.layers.5.self_attn.g_proj", "5.self_attn.g_proj", True),
+        ("model.layers.6.self_attn.g_proj", "5.self_attn.g_proj", False),
+    ],
+)
+def test_suffix_match_at_module_boundary(prefix, ignored_layer, expected):
+    assert (
+        is_layer_skipped(
+            prefix=prefix,
+            ignored_layers=[ignored_layer],
+            match_mode="suffix",
+        )
+        is expected
     )

--- a/vllm/model_executor/layers/quantization/auto_awq.py
+++ b/vllm/model_executor/layers/quantization/auto_awq.py
@@ -292,7 +292,7 @@ class AutoAWQConfig(QuantizationConfig):
                 prefix,
                 self.modules_to_not_convert,
                 self.packed_modules_mapping,
-                skip_with_substr=True,
+                match_mode="substring",
             ):
                 return UnquantizedLinearMethod()
 
@@ -335,7 +335,7 @@ class AutoAWQConfig(QuantizationConfig):
             if is_layer_skipped(
                 prefix,
                 getattr(self, "modules_to_not_convert", []),
-                skip_with_substr=True,
+                match_mode="substring",
             ):
                 return UnquantizedFusedMoEMethod(layer.moe_config)
 

--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 import torch
 
@@ -108,6 +108,9 @@ class Fp8Config(QuantizationConfig):
             raise ValueError(f"Unsupported activation scheme {activation_scheme}")
         self.activation_scheme = activation_scheme
         self.ignored_layers = ignored_layers or []
+        self.ignored_layers_match_mode: Literal["exact", "substring", "suffix"] = (
+            "exact"
+        )
         self.store_dtype = store_dtype
         if weight_block_size is not None:
             if not is_checkpoint_fp8_serialized:
@@ -177,6 +180,7 @@ class Fp8Config(QuantizationConfig):
                 prefix=prefix,
                 ignored_layers=self.ignored_layers,
                 fused_mapping=self.packed_modules_mapping,
+                match_mode=self.ignored_layers_match_mode,
             ):
                 return UnquantizedLinearMethod()
             if not self.is_checkpoint_fp8_serialized:
@@ -196,6 +200,7 @@ class Fp8Config(QuantizationConfig):
                 prefix=prefix,
                 ignored_layers=self.ignored_layers,
                 fused_mapping=self.packed_modules_mapping,
+                match_mode=self.ignored_layers_match_mode,
             ):
                 return UnquantizedFusedMoEMethod(layer.moe_config)
             if self.store_dtype == "mxfp4":

--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -1,9 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from functools import partial
 from typing import TYPE_CHECKING, Any, Literal
 
 import torch
+import torch.nn.functional as F
 
 import vllm.envs as envs
 from vllm.config import get_current_vllm_config
@@ -80,6 +82,7 @@ from vllm.platforms import current_platform
 from vllm.utils.deep_gemm import (
     is_deep_gemm_supported,
 )
+from vllm.utils.math_utils import round_up
 
 if TYPE_CHECKING:
     from vllm.model_executor.models.utils import WeightsMapper
@@ -87,6 +90,104 @@ if TYPE_CHECKING:
 ACTIVATION_SCHEMES = ["static", "dynamic"]
 
 logger = init_logger(__name__)
+
+
+def _fp8_block_shard(
+    size: int,
+    block_size: int,
+    tp_rank: int,
+    is_tp_split: bool,
+) -> tuple[int, int, int]:
+    start = tp_rank * size if is_tp_split else 0
+    offset = start % block_size if is_tp_split else 0
+    padded_size = round_up(offset + size, block_size)
+    return start, offset, padded_size
+
+
+def _load_padded_fp8_block_parameter(
+    param: torch.nn.Parameter,
+    loaded_weight: torch.Tensor,
+    loaded_shard_id: tuple[int, ...] | int | None = None,
+    *,
+    layer: torch.nn.Module,
+    block_size: tuple[int, int],
+    is_scale: bool = False,
+) -> None:
+    block_n, block_k = block_size
+    output_dim = param.output_dim
+    input_dim = param.input_dim
+    tp_size = layer.tp_size
+    tp_rank = layer.tp_rank
+    output_is_tp_split = tp_size > 1 and layer.output_size == (
+        sum(layer.output_partition_sizes) * tp_size
+    )
+    input_is_tp_split = tp_size > 1 and layer.input_size == (
+        layer.input_size_per_partition * tp_size
+    )
+    global_output_sizes = getattr(layer, "output_sizes", [layer.output_size])
+    output_spans = [
+        _fp8_block_shard(size, block_n, tp_rank, output_is_tp_split)
+        for size in layer.output_partition_sizes
+    ]
+    input_start, input_offset, padded_input_size = _fp8_block_shard(
+        layer.input_size_per_partition,
+        block_k,
+        tp_rank,
+        input_is_tp_split,
+    )
+
+    if is_scale:
+        source_output_sizes = [
+            round_up(size, block_n) // block_n for size in global_output_sizes
+        ]
+        target_output_sizes = [
+            round_up(span[2], block_n) // block_n for span in output_spans
+        ]
+        input_source_start = input_start // block_k
+        input_target_start = 0
+        input_count = round_up(padded_input_size, block_k) // block_k
+    else:
+        source_output_sizes = global_output_sizes
+        target_output_sizes = [span[2] for span in output_spans]
+        input_source_start = input_start
+        input_target_start = input_offset
+        input_count = layer.input_size_per_partition
+
+    shard_ids = (
+        tuple(range(len(source_output_sizes)))
+        if loaded_shard_id is None
+        else (
+            loaded_shard_id
+            if isinstance(loaded_shard_id, tuple)
+            else (loaded_shard_id,)
+        )
+    )
+
+    source_offset = 0
+    target_offsets = [0]
+    for size in target_output_sizes:
+        target_offsets.append(target_offsets[-1] + size)
+
+    for shard_id in shard_ids:
+        source_size = source_output_sizes[shard_id]
+        source = loaded_weight.narrow(output_dim, source_offset, source_size)
+        source_offset += source_size
+        output_start, output_offset, _ = output_spans[shard_id]
+        if is_scale:
+            output_start //= block_n
+            output_offset = 0
+            output_count = target_output_sizes[shard_id]
+        else:
+            output_count = layer.output_partition_sizes[shard_id]
+        target = param.data.narrow(
+            output_dim,
+            target_offsets[shard_id] + output_offset,
+            output_count,
+        ).narrow(input_dim, input_target_start, input_count)
+        source = source.narrow(output_dim, output_start, output_count).narrow(
+            input_dim, input_source_start, input_count
+        )
+        target.copy_(source)
 
 
 class Fp8Config(QuantizationConfig):
@@ -308,22 +409,67 @@ class Fp8LinearMethod(LinearMethodBase):
         layer.output_size_per_partition = output_size_per_partition
         layer.orig_dtype = params_dtype
         layer.weight_block_size = None
+        block_padding = False
+        padded_input_size = input_size_per_partition
+        padded_output_partition_sizes = output_partition_sizes
 
         if self.block_quant:
             assert self.weight_block_size is not None
             layer.weight_block_size = self.weight_block_size
+            block_n, block_k = self.weight_block_size
+            tp_size = getattr(layer, "tp_size", 1)
+            input_is_tp_split = (
+                tp_size > 1 and input_size == input_size_per_partition * tp_size
+            )
+            output_is_tp_split = tp_size > 1 and output_size == (
+                output_size_per_partition * tp_size
+            )
+            _, _, padded_input_size = _fp8_block_shard(
+                input_size_per_partition,
+                block_k,
+                layer.tp_rank,
+                input_is_tp_split,
+            )
+            padded_output_partition_sizes = [
+                _fp8_block_shard(
+                    size,
+                    block_n,
+                    layer.tp_rank,
+                    output_is_tp_split,
+                )[2]
+                for size in output_partition_sizes
+            ]
+            block_padding = (
+                padded_input_size != input_size_per_partition
+                or padded_output_partition_sizes != output_partition_sizes
+            )
+            layer.fp8_block_padding = block_padding
             validate_fp8_block_shape(
                 layer,
-                input_size,
-                output_size,
-                input_size_per_partition,
-                output_partition_sizes,
+                padded_input_size * tp_size if input_is_tp_split else input_size,
+                (
+                    sum(padded_output_partition_sizes) * tp_size
+                    if output_is_tp_split
+                    else output_size
+                ),
+                padded_input_size,
+                padded_output_partition_sizes,
                 self.weight_block_size,
             )
 
+        if block_padding:
+            weight_loader = partial(
+                _load_padded_fp8_block_parameter,
+                layer=layer,
+                block_size=tuple(self.weight_block_size),
+            )
         weight = create_fp8_weight_parameter(
-            output_size_per_partition, input_size_per_partition, weight_loader
+            sum(padded_output_partition_sizes),
+            padded_input_size,
+            weight_loader,
         )
+        if block_padding:
+            weight.data.zero_()
         layer.register_parameter("weight", weight)
 
         # WEIGHT SCALE
@@ -339,14 +485,24 @@ class Fp8LinearMethod(LinearMethodBase):
         else:
             assert not self.act_q_static
             assert self.weight_block_size is not None
+            scale_loader = weight_loader
+            if block_padding:
+                scale_loader = partial(
+                    _load_padded_fp8_block_parameter,
+                    layer=layer,
+                    block_size=tuple(self.weight_block_size),
+                    is_scale=True,
+                )
             scale = create_fp8_scale_parameter(
                 BlockQuantScaleParameter,
-                output_partition_sizes,
-                input_size_per_partition,
+                padded_output_partition_sizes,
+                padded_input_size,
                 self.weight_block_size,
-                weight_loader,
+                scale_loader,
                 scale_dtype=(torch.float8_e8m0fnu if self.is_scale_e8m0 else None),
             )
+            if block_padding:
+                scale.data.fill_(1)
             # The weight_scale_inv name is intentional for deepseekv3
             layer.register_parameter("weight_scale_inv", scale)
 
@@ -421,44 +577,95 @@ class Fp8LinearMethod(LinearMethodBase):
         x: torch.Tensor,
         bias: torch.Tensor | None = None,
     ) -> torch.Tensor:
+        block_padding = getattr(layer, "fp8_block_padding", False)
+        padded_output_sizes = layer.output_partition_sizes
+        output_offsets = [0] * len(padded_output_sizes)
+        kernel_bias = bias
+        if block_padding:
+            assert self.weight_block_size is not None
+            block_n, block_k = self.weight_block_size
+            tp_size = layer.tp_size
+            input_is_tp_split = tp_size > 1 and layer.input_size == (
+                layer.input_size_per_partition * tp_size
+            )
+            output_is_tp_split = tp_size > 1 and layer.output_size == (
+                sum(layer.output_partition_sizes) * tp_size
+            )
+            _, input_offset, padded_input_size = _fp8_block_shard(
+                layer.input_size_per_partition,
+                block_k,
+                layer.tp_rank,
+                input_is_tp_split,
+            )
+            if padded_input_size != layer.input_size_per_partition:
+                x = F.pad(
+                    x,
+                    (
+                        input_offset,
+                        padded_input_size
+                        - input_offset
+                        - layer.input_size_per_partition,
+                    ),
+                )
+            output_spans = [
+                _fp8_block_shard(
+                    size,
+                    block_n,
+                    layer.tp_rank,
+                    output_is_tp_split,
+                )
+                for size in layer.output_partition_sizes
+            ]
+            output_offsets = [span[1] for span in output_spans]
+            padded_output_sizes = [span[2] for span in output_spans]
+            if padded_output_sizes != layer.output_partition_sizes:
+                kernel_bias = None
+
         # if batch invariant mode is enabled, prefer direct FP8 path
         # we will use BF16 dequant when direct FP8 is not supported.
-        if envs.VLLM_BATCH_INVARIANT:
-            if self.block_quant:
-                assert self.weight_block_size is not None
-                return self.fp8_linear.apply_weights(
-                    layer,
-                    x,
-                    bias,
-                )
+        if envs.VLLM_BATCH_INVARIANT and not self.block_quant:
+            if isinstance(self.fp8_linear, CutlassFP8ScaledMMLinearKernel):
+                return self.fp8_linear.apply_weights(layer, x, bias)
+
+            # per-tensor/channel: dequant to BF16 and run GEMM
+            weight_fp8 = layer.weight.to(torch.bfloat16)
+            weight_scale = layer.weight_scale.to(torch.bfloat16)
+            if weight_scale.numel() == 1:
+                # Per-tensor: simple scalar multiplication
+                weight_bf16 = weight_fp8 * weight_scale
             else:
-                if isinstance(self.fp8_linear, CutlassFP8ScaledMMLinearKernel):
-                    return self.fp8_linear.apply_weights(layer, x, bias)
-
-                # per-tensor/channel: dequant to BF16 and run GEMM
-                weight_fp8 = layer.weight.to(torch.bfloat16)
-                weight_scale = layer.weight_scale.to(torch.bfloat16)
-                if weight_scale.numel() == 1:
-                    # Per-tensor: simple scalar multiplication
-                    weight_bf16 = weight_fp8 * weight_scale
+                # Multiple scales (fused modules like QKV)
+                # Try to infer correct broadcasting
+                # weight is [K, N], scale could be [num_logical_weights]
+                # Need to figure out how to broadcast - for now just try
+                # direct multiplication
+                if (
+                    weight_scale.dim() == 1
+                    and weight_scale.shape[0] == weight_fp8.shape[0]
+                ):
+                    # Per-row scaling
+                    weight_bf16 = weight_fp8 * weight_scale.unsqueeze(1)
                 else:
-                    # Multiple scales (fused modules like QKV)
-                    # Try to infer correct broadcasting
-                    # weight is [K, N], scale could be [num_logical_weights]
-                    # Need to figure out how to broadcast - for now just try
-                    # direct multiplication
-                    if (
-                        weight_scale.dim() == 1
-                        and weight_scale.shape[0] == weight_fp8.shape[0]
-                    ):
-                        # Per-row scaling
-                        weight_bf16 = weight_fp8 * weight_scale.unsqueeze(1)
-                    else:
-                        # Fallback
-                        weight_bf16 = weight_fp8 * weight_scale
-                return torch.nn.functional.linear(x, weight_bf16.t(), bias)
+                    # Fallback
+                    weight_bf16 = weight_fp8 * weight_scale
+            return torch.nn.functional.linear(x, weight_bf16.t(), bias)
 
-        return self.fp8_linear.apply_weights(layer, x, bias)
+        output = self.fp8_linear.apply_weights(layer, x, kernel_bias)
+        if padded_output_sizes != layer.output_partition_sizes:
+            output = torch.cat(
+                [
+                    shard[..., offset : offset + size]
+                    for shard, offset, size in zip(
+                        output.split(padded_output_sizes, dim=-1),
+                        output_offsets,
+                        layer.output_partition_sizes,
+                    )
+                ],
+                dim=-1,
+            )
+            if bias is not None:
+                output = output + bias
+        return output
 
 
 class Fp8MoEMethod(FusedMoEMethodBase):

--- a/vllm/model_executor/layers/quantization/utils/quant_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/quant_utils.py
@@ -5,7 +5,7 @@
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from types import MappingProxyType
-from typing import TYPE_CHECKING, ClassVar, NamedTuple
+from typing import TYPE_CHECKING, ClassVar, Literal, NamedTuple
 
 import numpy
 import torch
@@ -582,7 +582,7 @@ def is_layer_skipped(
     ignored_layers: list[str],
     fused_mapping: Mapping[str, list[str]] = MappingProxyType({}),
     *,
-    skip_with_substr: bool = False,
+    match_mode: Literal["exact", "substring", "suffix"] = "exact",
 ) -> bool:
     def prefix_full_match(prefix: str, ignored_layers: list[str]) -> bool:
         return prefix in ignored_layers
@@ -591,7 +591,22 @@ def is_layer_skipped(
     def substr_match(prefix: str, ignored_layers: list[str]) -> bool:
         return any(layer in prefix for layer in ignored_layers)
 
-    match_func = substr_match if skip_with_substr else prefix_full_match
+    # Match abbreviated module paths at a component boundary. For example,
+    # ``b_proj`` matches ``model.layers.0.self_attn.b_proj`` but not
+    # ``model.layers.0.self_attn.q_b_proj``.
+    def suffix_match(prefix: str, ignored_layers: list[str]) -> bool:
+        return any(
+            prefix == layer or prefix.endswith(f".{layer}") for layer in ignored_layers
+        )
+
+    if match_mode == "exact":
+        match_func = prefix_full_match
+    elif match_mode == "substring":
+        match_func = substr_match
+    elif match_mode == "suffix":
+        match_func = suffix_match
+    else:
+        raise ValueError(f"Unsupported layer skip match mode: {match_mode}")
 
     # prefix: model.layers.0.self_attn.q_proj
     # proj_name: q_proj
@@ -627,14 +642,11 @@ def is_layer_skipped(
                     "are quantized. All shards of fused layers "
                     "to have the same precision."
                 )
-    elif "experts" in prefix and not skip_with_substr:
+    elif "experts" in prefix and match_mode == "exact":
         expert_ignore_layers = filter(
             lambda layer_name: "experts" in layer_name, ignored_layers
         )
-        return any(
-            prefix in layer_name if not skip_with_substr else layer_name in prefix
-            for layer_name in expert_ignore_layers
-        )
+        return any(prefix in layer_name for layer_name in expert_ignore_layers)
     else:
         is_skipped = match_func(prefix, ignored_layers)
 

--- a/vllm/model_executor/models/bailing_moe_v3.py
+++ b/vllm/model_executor/models/bailing_moe_v3.py
@@ -10,7 +10,6 @@ vLLM's parallel linear layers, MLA kernel, KDA kernel and fused MoE loader.
 
 import copy
 from collections.abc import Callable, Iterable
-from math import lcm
 from typing import TypeGuard
 
 import torch
@@ -232,123 +231,6 @@ def _is_fp8_module_excluded(
         ignored_layers=quant_config.ignored_layers,
         fused_mapping=quant_config.packed_modules_mapping,
         match_mode=quant_config.ignored_layers_match_mode,
-    )
-
-
-def _get_block_fp8_mlp_padded_intermediate_size(
-    quant_config: QuantizationConfig | None,
-    intermediate_size: int,
-    prefix: str,
-) -> int:
-    """Pad a block-FP8 MLP so each TP shard contains whole quant blocks."""
-    if not _is_block_fp8_config(quant_config):
-        return intermediate_size
-    block_size = quant_config.weight_block_size
-    assert block_size is not None
-
-    alignments: list[int] = []
-    if not _is_fp8_module_excluded(quant_config, f"{prefix}.gate_up_proj"):
-        alignments.append(int(block_size[0]))
-    if not _is_fp8_module_excluded(quant_config, f"{prefix}.down_proj"):
-        alignments.append(int(block_size[1]))
-    if not alignments:
-        return intermediate_size
-
-    tp_size = get_tensor_model_parallel_world_size()
-    tp_alignment = tp_size * lcm(*alignments)
-    return (intermediate_size + tp_alignment - 1) // tp_alignment * tp_alignment
-
-
-def _pad_block_fp8_mlp_checkpoint_tensor(
-    quant_config: QuantizationConfig,
-    name: str,
-    loaded_weight: torch.Tensor,
-    intermediate_size: int,
-    padded_intermediate_size: int,
-) -> torch.Tensor:
-    """Zero-pad an MLP checkpoint tensor on its intermediate dimension."""
-    if padded_intermediate_size == intermediate_size:
-        return loaded_weight
-
-    block_size = getattr(quant_config, "weight_block_size", None)
-    assert block_size is not None
-
-    if ".down_proj." in name:
-        if name.endswith(".bias"):
-            return loaded_weight
-        dim = 1
-        block = int(block_size[1])
-        logical_shards = 1
-    elif any(
-        projection in name
-        for projection in (".gate_proj.", ".up_proj.", ".gate_up_proj.")
-    ):
-        dim = 0
-        block = int(block_size[0])
-        logical_shards = 2 if ".gate_up_proj." in name else 1
-    else:
-        return loaded_weight
-
-    if name.endswith(".weight_scale_inv"):
-        expected_shard_size = (intermediate_size + block - 1) // block
-        target_shard_size = (padded_intermediate_size + block - 1) // block
-    elif name.endswith((".weight", ".bias")):
-        expected_shard_size = intermediate_size
-        target_shard_size = padded_intermediate_size
-    else:
-        return loaded_weight
-
-    current_size = loaded_weight.shape[dim]
-    if current_size % logical_shards != 0:
-        raise ValueError(
-            f"Cannot split {name} dimension {current_size} into "
-            f"{logical_shards} logical shards."
-        )
-    current_shard_size = current_size // logical_shards
-    if current_shard_size == target_shard_size:
-        return loaded_weight
-    if current_shard_size != expected_shard_size:
-        raise ValueError(
-            f"Cannot pad {name}: expected each logical intermediate dimension "
-            f"to be {expected_shard_size}, but got {current_shard_size}."
-        )
-
-    padded_shards: list[torch.Tensor] = []
-    for shard in loaded_weight.split(current_shard_size, dim=dim):
-        pad_shape = list(shard.shape)
-        pad_shape[dim] = target_shard_size - current_shard_size
-        padded_shards.extend([shard, shard.new_zeros(pad_shape)])
-    return torch.cat(padded_shards, dim=dim)
-
-
-def _maybe_pad_block_fp8_shared_expert_checkpoint_tensor(
-    quant_config: QuantizationConfig | None,
-    config: PretrainedConfig,
-    name: str,
-    loaded_weight: torch.Tensor,
-) -> torch.Tensor:
-    if ".mlp.shared_experts." not in name:
-        return loaded_weight
-
-    shared_prefix = name.split(".shared_experts.", 1)[0] + ".shared_experts"
-    shared_intermediate = (
-        config.moe_shared_expert_intermediate_size * config.num_shared_experts
-    )
-    padded_shared_intermediate = _get_block_fp8_mlp_padded_intermediate_size(
-        quant_config,
-        shared_intermediate,
-        shared_prefix,
-    )
-    if padded_shared_intermediate == shared_intermediate:
-        return loaded_weight
-
-    assert quant_config is not None
-    return _pad_block_fp8_mlp_checkpoint_tensor(
-        quant_config,
-        name,
-        loaded_weight,
-        shared_intermediate,
-        padded_shared_intermediate,
     )
 
 
@@ -1114,9 +996,7 @@ class BailingMoeV3MoE(nn.Module):
             config.moe_shared_expert_intermediate_size * config.num_shared_experts
         )
         self.shared_experts = BailingMoeV3MLP(
-            intermediate_size=_get_block_fp8_mlp_padded_intermediate_size(
-                quant_config, shared_intermediate, f"{prefix}.shared_experts"
-            ),
+            intermediate_size=shared_intermediate,
             config=config,
             quant_config=quant_config,
             reduce_results=False,
@@ -1467,12 +1347,6 @@ class BailingMoeV3ForCausalLM(nn.Module, HasInnerState, IsHybrid, SupportsPP):
             name = normalize_name(orig_name)
             if name is None:
                 continue
-            weight = _maybe_pad_block_fp8_shared_expert_checkpoint_tensor(
-                self.quant_config,
-                self.config,
-                name,
-                weight,
-            )
             loaded = False
             for param_suf, weight_suf, stacked_shard_id in stacked_mappings:
                 if weight_suf in name:

--- a/vllm/model_executor/models/bailing_moe_v3.py
+++ b/vllm/model_executor/models/bailing_moe_v3.py
@@ -10,6 +10,7 @@ vLLM's parallel linear layers, MLA kernel, KDA kernel and fused MoE loader.
 
 import copy
 from collections.abc import Callable, Iterable
+from math import lcm
 
 import torch
 import torch.nn as nn
@@ -55,6 +56,7 @@ from vllm.model_executor.layers.mla import (
     MultiHeadLatentAttentionWrapper,
 )
 from vllm.model_executor.layers.quantization.base_config import QuantizationConfig
+from vllm.model_executor.layers.quantization.utils.quant_utils import is_layer_skipped
 from vllm.model_executor.layers.rotary_embedding import get_rope
 from vllm.model_executor.layers.vocab_parallel_embedding import (
     ParallelLMHead,
@@ -193,6 +195,176 @@ def _load_a_log(param: torch.nn.Parameter, loaded_weight: torch.Tensor) -> None:
         sharded_weight_loader(2)(param, loaded_weight)
 
 
+def _is_serialized_block_fp8(
+    quant_config: QuantizationConfig | None,
+) -> bool:
+    return bool(
+        quant_config is not None
+        and quant_config.get_name() == "fp8"
+        and getattr(quant_config, "is_checkpoint_fp8_serialized", False)
+        and getattr(quant_config, "weight_block_size", None)
+    )
+
+
+def _is_fp8_module_excluded(
+    quant_config: QuantizationConfig | None,
+    prefix: str,
+) -> bool:
+    """Match Ling's abbreviated FP8 exclusion names against vLLM prefixes."""
+    if not _is_serialized_block_fp8(quant_config):
+        return False
+
+    ignored_layers = getattr(quant_config, "ignored_layers", None) or []
+    checkpoint_prefix = prefix.replace(".self_attn.", ".attention.")
+    return any(
+        checkpoint_prefix == ignored or checkpoint_prefix.endswith(f".{ignored}")
+        for ignored in ignored_layers
+    )
+
+
+def _get_linear_quant_config(
+    quant_config: QuantizationConfig | None,
+    prefix: str,
+) -> QuantizationConfig | None:
+    if _is_fp8_module_excluded(quant_config, prefix):
+        return None
+    return quant_config
+
+
+def _uses_serialized_block_fp8_linear(
+    quant_config: QuantizationConfig | None,
+    prefix: str,
+) -> bool:
+    if not _is_serialized_block_fp8(quant_config):
+        return False
+    assert quant_config is not None
+    if _is_fp8_module_excluded(quant_config, prefix):
+        return False
+    return not is_layer_skipped(
+        prefix=prefix,
+        ignored_layers=getattr(quant_config, "ignored_layers", None) or [],
+        fused_mapping=getattr(quant_config, "packed_modules_mapping", {}),
+    )
+
+
+def _get_block_fp8_mlp_padded_intermediate_size(
+    quant_config: QuantizationConfig | None,
+    intermediate_size: int,
+    prefix: str,
+) -> int:
+    """Pad a block-FP8 MLP so each TP shard contains whole quant blocks."""
+    if not _is_serialized_block_fp8(quant_config):
+        return intermediate_size
+    assert quant_config is not None
+    block_size = getattr(quant_config, "weight_block_size", None)
+    assert block_size is not None
+
+    alignments: list[int] = []
+    if _uses_serialized_block_fp8_linear(quant_config, f"{prefix}.gate_up_proj"):
+        alignments.append(int(block_size[0]))
+    if _uses_serialized_block_fp8_linear(quant_config, f"{prefix}.down_proj"):
+        alignments.append(int(block_size[1]))
+    if not alignments:
+        return intermediate_size
+
+    tp_size = get_tensor_model_parallel_world_size()
+    tp_alignment = tp_size * lcm(*alignments)
+    return (intermediate_size + tp_alignment - 1) // tp_alignment * tp_alignment
+
+
+def _pad_block_fp8_mlp_checkpoint_tensor(
+    quant_config: QuantizationConfig,
+    name: str,
+    loaded_weight: torch.Tensor,
+    intermediate_size: int,
+    padded_intermediate_size: int,
+) -> torch.Tensor:
+    """Zero-pad an MLP checkpoint tensor on its intermediate dimension."""
+    if padded_intermediate_size == intermediate_size:
+        return loaded_weight
+
+    block_size = getattr(quant_config, "weight_block_size", None)
+    assert block_size is not None
+
+    if ".down_proj." in name:
+        if name.endswith(".bias"):
+            return loaded_weight
+        dim = 1
+        block = int(block_size[1])
+        logical_shards = 1
+    elif any(
+        projection in name
+        for projection in (".gate_proj.", ".up_proj.", ".gate_up_proj.")
+    ):
+        dim = 0
+        block = int(block_size[0])
+        logical_shards = 2 if ".gate_up_proj." in name else 1
+    else:
+        return loaded_weight
+
+    if name.endswith(".weight_scale_inv"):
+        expected_shard_size = (intermediate_size + block - 1) // block
+        target_shard_size = (padded_intermediate_size + block - 1) // block
+    elif name.endswith((".weight", ".bias")):
+        expected_shard_size = intermediate_size
+        target_shard_size = padded_intermediate_size
+    else:
+        return loaded_weight
+
+    current_size = loaded_weight.shape[dim]
+    if current_size % logical_shards != 0:
+        raise ValueError(
+            f"Cannot split {name} dimension {current_size} into "
+            f"{logical_shards} logical shards."
+        )
+    current_shard_size = current_size // logical_shards
+    if current_shard_size == target_shard_size:
+        return loaded_weight
+    if current_shard_size != expected_shard_size:
+        raise ValueError(
+            f"Cannot pad {name}: expected each logical intermediate dimension "
+            f"to be {expected_shard_size}, but got {current_shard_size}."
+        )
+
+    padded_shards: list[torch.Tensor] = []
+    for shard in loaded_weight.split(current_shard_size, dim=dim):
+        pad_shape = list(shard.shape)
+        pad_shape[dim] = target_shard_size - current_shard_size
+        padded_shards.extend([shard, shard.new_zeros(pad_shape)])
+    return torch.cat(padded_shards, dim=dim)
+
+
+def _maybe_pad_block_fp8_shared_expert_checkpoint_tensor(
+    quant_config: QuantizationConfig | None,
+    config: PretrainedConfig,
+    name: str,
+    loaded_weight: torch.Tensor,
+) -> torch.Tensor:
+    if ".mlp.shared_experts." not in name:
+        return loaded_weight
+
+    shared_prefix = name.split(".shared_experts.", 1)[0] + ".shared_experts"
+    shared_intermediate = (
+        config.moe_shared_expert_intermediate_size * config.num_shared_experts
+    )
+    padded_shared_intermediate = _get_block_fp8_mlp_padded_intermediate_size(
+        quant_config,
+        shared_intermediate,
+        shared_prefix,
+    )
+    if padded_shared_intermediate == shared_intermediate:
+        return loaded_weight
+
+    assert quant_config is not None
+    return _pad_block_fp8_mlp_checkpoint_tensor(
+        quant_config,
+        name,
+        loaded_weight,
+        shared_intermediate,
+        padded_shared_intermediate,
+    )
+
+
 class _IdentityProjection(nn.Module):
     def forward(self, x: torch.Tensor) -> tuple[torch.Tensor, None]:
         return x, None
@@ -209,20 +381,22 @@ class BailingMoeV3MLP(nn.Module):
         swiglu_limit: float | None = None,
     ) -> None:
         super().__init__()
+        gate_up_prefix = f"{prefix}.gate_up_proj"
         self.gate_up_proj = MergedColumnParallelLinear(
             config.hidden_size,
             [intermediate_size] * 2,
             bias=config.use_bias,
-            quant_config=quant_config,
-            prefix=f"{prefix}.gate_up_proj",
+            quant_config=_get_linear_quant_config(quant_config, gate_up_prefix),
+            prefix=gate_up_prefix,
         )
+        down_prefix = f"{prefix}.down_proj"
         self.down_proj = RowParallelLinear(
             intermediate_size,
             config.hidden_size,
             bias=config.use_bias,
-            quant_config=quant_config,
+            quant_config=_get_linear_quant_config(quant_config, down_prefix),
             reduce_results=reduce_results,
-            prefix=f"{prefix}.down_proj",
+            prefix=down_prefix,
         )
         self.act_fn = (
             SwigluStepAndMul(limit=swiglu_limit) if swiglu_limit else SiluAndMul()
@@ -264,50 +438,55 @@ class BailingMoeV3MLAAttention(nn.Module):
         self.q_proj: ColumnParallelLinear | None
         self.kv_a_proj_with_mqa: ReplicatedLinear | None
         if self.q_lora_rank is None:
+            q_prefix = f"{prefix}.q_proj"
             self.q_proj = ColumnParallelLinear(
                 self.hidden_size,
                 self.num_heads * self.qk_head_dim,
                 bias=False,
-                quant_config=quant_config,
-                prefix=f"{prefix}.q_proj",
+                quant_config=_get_linear_quant_config(quant_config, q_prefix),
+                prefix=q_prefix,
             )
             self.fused_qkv_a_proj = None
             self.q_a_layernorm = None
             self.q_b_proj = None
+            kv_a_prefix = f"{prefix}.kv_a_proj_with_mqa"
             self.kv_a_proj_with_mqa = ReplicatedLinear(
                 self.hidden_size,
                 self.kv_lora_rank + self.qk_rope_head_dim,
                 bias=False,
-                quant_config=quant_config,
-                prefix=f"{prefix}.kv_a_proj_with_mqa",
+                quant_config=_get_linear_quant_config(quant_config, kv_a_prefix),
+                prefix=kv_a_prefix,
             )
         else:
+            fused_qkv_a_prefix = f"{prefix}.fused_qkv_a_proj"
             self.fused_qkv_a_proj = MergedColumnParallelLinear(
                 self.hidden_size,
                 [self.q_lora_rank, self.kv_lora_rank + self.qk_rope_head_dim],
                 bias=False,
-                quant_config=quant_config,
-                prefix=f"{prefix}.fused_qkv_a_proj",
+                quant_config=_get_linear_quant_config(quant_config, fused_qkv_a_prefix),
+                prefix=fused_qkv_a_prefix,
                 disable_tp=True,
             )
             self.q_a_layernorm = RMSNorm(self.q_lora_rank, eps=config.rms_norm_eps)
+            q_b_prefix = f"{prefix}.q_b_proj"
             self.q_b_proj = ColumnParallelLinear(
                 self.q_lora_rank,
                 self.num_heads * self.qk_head_dim,
                 bias=False,
-                quant_config=quant_config,
-                prefix=f"{prefix}.q_b_proj",
+                quant_config=_get_linear_quant_config(quant_config, q_b_prefix),
+                prefix=q_b_prefix,
             )
             self.q_proj = None
             self.kv_a_proj_with_mqa = None
 
         self.kv_a_layernorm = RMSNorm(self.kv_lora_rank, eps=config.rms_norm_eps)
+        kv_b_prefix = f"{prefix}.kv_b_proj"
         self.kv_b_proj = ColumnParallelLinear(
             self.kv_lora_rank,
             self.num_heads * (self.qk_nope_head_dim + self.v_head_dim),
             bias=False,
-            quant_config=quant_config,
-            prefix=f"{prefix}.kv_b_proj",
+            quant_config=_get_linear_quant_config(quant_config, kv_b_prefix),
+            prefix=kv_b_prefix,
         )
         self.gated_attention_proj_granularity_type = getattr(
             config, "gated_attention_proj_granularity_type", None
@@ -318,23 +497,25 @@ class BailingMoeV3MLAAttention(nn.Module):
             g_out = self.num_heads * self.v_head_dim
         else:
             g_out = 0
+        g_prefix = f"{prefix}.g_proj"
         self.g_proj = (
             ColumnParallelLinear(
                 self.hidden_size,
                 g_out,
                 bias=False,
-                quant_config=quant_config,
-                prefix=f"{prefix}.g_proj",
+                quant_config=_get_linear_quant_config(quant_config, g_prefix),
+                prefix=g_prefix,
             )
             if g_out > 0
             else None
         )
+        dense_prefix = f"{prefix}.dense"
         self.dense = RowParallelLinear(
             self.num_heads * self.v_head_dim,
             self.hidden_size,
             bias=False,
-            quant_config=quant_config,
-            prefix=f"{prefix}.dense",
+            quant_config=_get_linear_quant_config(quant_config, dense_prefix),
+            prefix=dense_prefix,
         )
 
         self.rotary_emb = get_rope(
@@ -446,19 +627,43 @@ class BailingMoeV3KimiDeltaAttention(PluggableLayer, MambaBase):
 
         projection_size = self.head_dim * self.num_heads
         self.projection_size_per_partition = projection_size // self.tp_size
-        self.qkvb_proj = MergedColumnParallelLinear(
-            self.hidden_size,
-            [projection_size, projection_size, projection_size, self.num_heads],
-            bias=False,
-            quant_config=quant_config,
-            prefix=f"{prefix}.qkvb_proj",
-        )
+        self.separate_b_proj = _is_fp8_module_excluded(quant_config, f"{prefix}.b_proj")
+        if self.separate_b_proj:
+            qkv_prefix = f"{prefix}.qkv_proj"
+            self.qkv_proj = MergedColumnParallelLinear(
+                self.hidden_size,
+                [projection_size, projection_size, projection_size],
+                bias=False,
+                quant_config=_get_linear_quant_config(quant_config, qkv_prefix),
+                prefix=qkv_prefix,
+            )
+            b_prefix = f"{prefix}.b_proj"
+            self.b_proj = ColumnParallelLinear(
+                self.hidden_size,
+                self.num_heads,
+                bias=False,
+                quant_config=_get_linear_quant_config(quant_config, b_prefix),
+                prefix=b_prefix,
+            )
+            self.qkvb_proj = None
+        else:
+            qkvb_prefix = f"{prefix}.qkvb_proj"
+            self.qkvb_proj = MergedColumnParallelLinear(
+                self.hidden_size,
+                [projection_size, projection_size, projection_size, self.num_heads],
+                bias=False,
+                quant_config=quant_config,
+                prefix=qkvb_prefix,
+            )
+            self.qkv_proj = None
+            self.b_proj = None
+        f_prefix = f"{prefix}.f_proj"
         self.f_proj = ColumnParallelLinear(
             self.hidden_size,
             projection_size,
             bias=False,
-            quant_config=quant_config,
-            prefix=f"{prefix}.f_proj",
+            quant_config=_get_linear_quant_config(quant_config, f_prefix),
+            prefix=f_prefix,
         )
         self.dt_bias = nn.Parameter(
             torch.empty(projection_size // self.tp_size, dtype=torch.float32)
@@ -495,22 +700,24 @@ class BailingMoeV3KimiDeltaAttention(PluggableLayer, MambaBase):
         )
         set_weight_attrs(self.A_log, {"weight_loader": _load_a_log})
 
+        g_prefix = f"{prefix}.g_proj"
         self.g_proj = ColumnParallelLinear(
             self.hidden_size,
             projection_size,
             bias=False,
-            quant_config=quant_config,
-            prefix=f"{prefix}.g_proj",
+            quant_config=_get_linear_quant_config(quant_config, g_prefix),
+            prefix=g_prefix,
         )
         self.o_norm = FusedRMSNormGated(
             self.head_dim, eps=config.rms_norm_eps, activation="sigmoid"
         )
+        o_prefix = f"{prefix}.o_proj"
         self.o_proj = RowParallelLinear(
             projection_size,
             self.hidden_size,
             bias=False,
-            quant_config=quant_config,
-            prefix=f"{prefix}.o_proj",
+            quant_config=_get_linear_quant_config(quant_config, o_prefix),
+            prefix=o_prefix,
         )
 
         compilation_config = get_current_vllm_config().compilation_config
@@ -532,16 +739,23 @@ class BailingMoeV3KimiDeltaAttention(PluggableLayer, MambaBase):
     ) -> None:
         del positions
         num_tokens = hidden_states.size(0)
-        qkvb = self.qkvb_proj(hidden_states)[0]
-        q, k, v, beta_logits = qkvb.split(
-            [
-                self.projection_size_per_partition,
-                self.projection_size_per_partition,
-                self.projection_size_per_partition,
-                self.local_num_heads,
-            ],
-            dim=-1,
-        )
+        if self.separate_b_proj:
+            assert self.qkv_proj is not None and self.b_proj is not None
+            qkv = self.qkv_proj(hidden_states)[0]
+            q, k, v = qkv.split(self.projection_size_per_partition, dim=-1)
+            beta_logits = self.b_proj(hidden_states)[0]
+        else:
+            assert self.qkvb_proj is not None
+            qkvb = self.qkvb_proj(hidden_states)[0]
+            q, k, v, beta_logits = qkvb.split(
+                [
+                    self.projection_size_per_partition,
+                    self.projection_size_per_partition,
+                    self.projection_size_per_partition,
+                    self.local_num_heads,
+                ],
+                dim=-1,
+            )
         beta = beta_logits.float().sigmoid().unsqueeze(0)
         g1 = self.f_proj(hidden_states)[0]
         g1 = fused_kda_gate(
@@ -910,7 +1124,6 @@ class BailingMoeV3MoE(nn.Module):
         prefix: str = "",
     ) -> None:
         super().__init__()
-        self.tp_size = get_tensor_model_parallel_world_size()
         self.num_experts = config.num_experts
         self.top_k = config.num_experts_per_tok
         self.hidden_size = config.hidden_size
@@ -925,12 +1138,16 @@ class BailingMoeV3MoE(nn.Module):
         shared_intermediate = (
             config.moe_shared_expert_intermediate_size * config.num_shared_experts
         )
+        shared_prefix = f"{prefix}.shared_experts"
+        padded_shared_intermediate = _get_block_fp8_mlp_padded_intermediate_size(
+            quant_config, shared_intermediate, shared_prefix
+        )
         self.shared_experts = BailingMoeV3MLP(
-            intermediate_size=shared_intermediate,
+            intermediate_size=padded_shared_intermediate,
             config=config,
             quant_config=quant_config,
             reduce_results=False,
-            prefix=f"{prefix}.shared_experts",
+            prefix=shared_prefix,
             swiglu_limit=self.share_expert_swiglu_limit,
         )
         self.experts = FusedMoEFactory(
@@ -1151,6 +1368,7 @@ class BailingMoeV3Model(nn.Module):
 class BailingMoeV3ForCausalLM(nn.Module, HasInnerState, IsHybrid, SupportsPP):
     packed_modules_mapping = {
         "gate_up_proj": ["gate_proj", "up_proj"],
+        "qkv_proj": ["q_proj", "k_proj", "v_proj"],
         "qkvb_proj": ["q_proj", "k_proj", "v_proj", "b_proj"],
     }
 
@@ -1231,6 +1449,9 @@ class BailingMoeV3ForCausalLM(nn.Module, HasInnerState, IsHybrid, SupportsPP):
         stacked_mappings = [
             (".gate_up_proj", ".gate_proj", 0),
             (".gate_up_proj", ".up_proj", 1),
+            (".qkv_proj", ".q_proj", 0),
+            (".qkv_proj", ".k_proj", 1),
+            (".qkv_proj", ".v_proj", 2),
             (".qkvb_proj", ".q_proj", 0),
             (".qkvb_proj", ".k_proj", 1),
             (".qkvb_proj", ".v_proj", 2),
@@ -1270,6 +1491,12 @@ class BailingMoeV3ForCausalLM(nn.Module, HasInnerState, IsHybrid, SupportsPP):
             name = normalize_name(orig_name)
             if name is None:
                 continue
+            weight = _maybe_pad_block_fp8_shared_expert_checkpoint_tensor(
+                self.quant_config,
+                self.config,
+                name,
+                weight,
+            )
             loaded = False
             for param_suf, weight_suf, stacked_shard_id in stacked_mappings:
                 if weight_suf in name:

--- a/vllm/model_executor/models/bailing_moe_v3.py
+++ b/vllm/model_executor/models/bailing_moe_v3.py
@@ -11,6 +11,7 @@ vLLM's parallel linear layers, MLA kernel, KDA kernel and fused MoE loader.
 import copy
 from collections.abc import Callable, Iterable
 from math import lcm
+from typing import TypeGuard
 
 import torch
 import torch.nn as nn
@@ -56,6 +57,7 @@ from vllm.model_executor.layers.mla import (
     MultiHeadLatentAttentionWrapper,
 )
 from vllm.model_executor.layers.quantization.base_config import QuantizationConfig
+from vllm.model_executor.layers.quantization.fp8 import Fp8Config
 from vllm.model_executor.layers.quantization.utils.quant_utils import is_layer_skipped
 from vllm.model_executor.layers.rotary_embedding import get_rope
 from vllm.model_executor.layers.vocab_parallel_embedding import (
@@ -81,7 +83,13 @@ from vllm.v1.attention.backends.gdn_attn import GDNAttentionMetadata
 from vllm.v1.attention.backends.registry import MambaAttentionBackendEnum
 
 from .interfaces import HasInnerState, IsHybrid, SupportsPP
-from .utils import PPMissingLayer, is_pp_missing_parameter, make_layers, maybe_prefix
+from .utils import (
+    PPMissingLayer,
+    WeightsMapper,
+    is_pp_missing_parameter,
+    make_layers,
+    maybe_prefix,
+)
 
 
 def bailing_v3_kda_attention(
@@ -195,55 +203,35 @@ def _load_a_log(param: torch.nn.Parameter, loaded_weight: torch.Tensor) -> None:
         sharded_weight_loader(2)(param, loaded_weight)
 
 
-def _is_serialized_block_fp8(
+def _is_block_fp8_config(
     quant_config: QuantizationConfig | None,
-) -> bool:
-    return bool(
-        quant_config is not None
-        and quant_config.get_name() == "fp8"
-        and getattr(quant_config, "is_checkpoint_fp8_serialized", False)
-        and getattr(quant_config, "weight_block_size", None)
+) -> TypeGuard[Fp8Config]:
+    return (
+        isinstance(quant_config, Fp8Config)
+        and quant_config.weight_block_size is not None
     )
+
+
+def _configure_ling_fp8_quant_config(
+    quant_config: QuantizationConfig | None,
+) -> None:
+    if _is_block_fp8_config(quant_config):
+        quant_config.ignored_layers_match_mode = "suffix"
 
 
 def _is_fp8_module_excluded(
     quant_config: QuantizationConfig | None,
     prefix: str,
 ) -> bool:
-    """Match Ling's abbreviated FP8 exclusion names against vLLM prefixes."""
-    if not _is_serialized_block_fp8(quant_config):
+    """Match Ling's abbreviated FP8 exclusions against mapped vLLM prefixes."""
+    if not _is_block_fp8_config(quant_config):
         return False
 
-    ignored_layers = getattr(quant_config, "ignored_layers", None) or []
-    checkpoint_prefix = prefix.replace(".self_attn.", ".attention.")
-    return any(
-        checkpoint_prefix == ignored or checkpoint_prefix.endswith(f".{ignored}")
-        for ignored in ignored_layers
-    )
-
-
-def _get_linear_quant_config(
-    quant_config: QuantizationConfig | None,
-    prefix: str,
-) -> QuantizationConfig | None:
-    if _is_fp8_module_excluded(quant_config, prefix):
-        return None
-    return quant_config
-
-
-def _uses_serialized_block_fp8_linear(
-    quant_config: QuantizationConfig | None,
-    prefix: str,
-) -> bool:
-    if not _is_serialized_block_fp8(quant_config):
-        return False
-    assert quant_config is not None
-    if _is_fp8_module_excluded(quant_config, prefix):
-        return False
-    return not is_layer_skipped(
+    return is_layer_skipped(
         prefix=prefix,
-        ignored_layers=getattr(quant_config, "ignored_layers", None) or [],
-        fused_mapping=getattr(quant_config, "packed_modules_mapping", {}),
+        ignored_layers=quant_config.ignored_layers,
+        fused_mapping=quant_config.packed_modules_mapping,
+        match_mode=quant_config.ignored_layers_match_mode,
     )
 
 
@@ -253,16 +241,15 @@ def _get_block_fp8_mlp_padded_intermediate_size(
     prefix: str,
 ) -> int:
     """Pad a block-FP8 MLP so each TP shard contains whole quant blocks."""
-    if not _is_serialized_block_fp8(quant_config):
+    if not _is_block_fp8_config(quant_config):
         return intermediate_size
-    assert quant_config is not None
-    block_size = getattr(quant_config, "weight_block_size", None)
+    block_size = quant_config.weight_block_size
     assert block_size is not None
 
     alignments: list[int] = []
-    if _uses_serialized_block_fp8_linear(quant_config, f"{prefix}.gate_up_proj"):
+    if not _is_fp8_module_excluded(quant_config, f"{prefix}.gate_up_proj"):
         alignments.append(int(block_size[0]))
-    if _uses_serialized_block_fp8_linear(quant_config, f"{prefix}.down_proj"):
+    if not _is_fp8_module_excluded(quant_config, f"{prefix}.down_proj"):
         alignments.append(int(block_size[1]))
     if not alignments:
         return intermediate_size
@@ -381,22 +368,20 @@ class BailingMoeV3MLP(nn.Module):
         swiglu_limit: float | None = None,
     ) -> None:
         super().__init__()
-        gate_up_prefix = f"{prefix}.gate_up_proj"
         self.gate_up_proj = MergedColumnParallelLinear(
             config.hidden_size,
             [intermediate_size] * 2,
             bias=config.use_bias,
-            quant_config=_get_linear_quant_config(quant_config, gate_up_prefix),
-            prefix=gate_up_prefix,
+            quant_config=quant_config,
+            prefix=f"{prefix}.gate_up_proj",
         )
-        down_prefix = f"{prefix}.down_proj"
         self.down_proj = RowParallelLinear(
             intermediate_size,
             config.hidden_size,
             bias=config.use_bias,
-            quant_config=_get_linear_quant_config(quant_config, down_prefix),
+            quant_config=quant_config,
             reduce_results=reduce_results,
-            prefix=down_prefix,
+            prefix=f"{prefix}.down_proj",
         )
         self.act_fn = (
             SwigluStepAndMul(limit=swiglu_limit) if swiglu_limit else SiluAndMul()
@@ -438,55 +423,50 @@ class BailingMoeV3MLAAttention(nn.Module):
         self.q_proj: ColumnParallelLinear | None
         self.kv_a_proj_with_mqa: ReplicatedLinear | None
         if self.q_lora_rank is None:
-            q_prefix = f"{prefix}.q_proj"
             self.q_proj = ColumnParallelLinear(
                 self.hidden_size,
                 self.num_heads * self.qk_head_dim,
                 bias=False,
-                quant_config=_get_linear_quant_config(quant_config, q_prefix),
-                prefix=q_prefix,
+                quant_config=quant_config,
+                prefix=f"{prefix}.q_proj",
             )
             self.fused_qkv_a_proj = None
             self.q_a_layernorm = None
             self.q_b_proj = None
-            kv_a_prefix = f"{prefix}.kv_a_proj_with_mqa"
             self.kv_a_proj_with_mqa = ReplicatedLinear(
                 self.hidden_size,
                 self.kv_lora_rank + self.qk_rope_head_dim,
                 bias=False,
-                quant_config=_get_linear_quant_config(quant_config, kv_a_prefix),
-                prefix=kv_a_prefix,
+                quant_config=quant_config,
+                prefix=f"{prefix}.kv_a_proj_with_mqa",
             )
         else:
-            fused_qkv_a_prefix = f"{prefix}.fused_qkv_a_proj"
             self.fused_qkv_a_proj = MergedColumnParallelLinear(
                 self.hidden_size,
                 [self.q_lora_rank, self.kv_lora_rank + self.qk_rope_head_dim],
                 bias=False,
-                quant_config=_get_linear_quant_config(quant_config, fused_qkv_a_prefix),
-                prefix=fused_qkv_a_prefix,
+                quant_config=quant_config,
+                prefix=f"{prefix}.fused_qkv_a_proj",
                 disable_tp=True,
             )
             self.q_a_layernorm = RMSNorm(self.q_lora_rank, eps=config.rms_norm_eps)
-            q_b_prefix = f"{prefix}.q_b_proj"
             self.q_b_proj = ColumnParallelLinear(
                 self.q_lora_rank,
                 self.num_heads * self.qk_head_dim,
                 bias=False,
-                quant_config=_get_linear_quant_config(quant_config, q_b_prefix),
-                prefix=q_b_prefix,
+                quant_config=quant_config,
+                prefix=f"{prefix}.q_b_proj",
             )
             self.q_proj = None
             self.kv_a_proj_with_mqa = None
 
         self.kv_a_layernorm = RMSNorm(self.kv_lora_rank, eps=config.rms_norm_eps)
-        kv_b_prefix = f"{prefix}.kv_b_proj"
         self.kv_b_proj = ColumnParallelLinear(
             self.kv_lora_rank,
             self.num_heads * (self.qk_nope_head_dim + self.v_head_dim),
             bias=False,
-            quant_config=_get_linear_quant_config(quant_config, kv_b_prefix),
-            prefix=kv_b_prefix,
+            quant_config=quant_config,
+            prefix=f"{prefix}.kv_b_proj",
         )
         self.gated_attention_proj_granularity_type = getattr(
             config, "gated_attention_proj_granularity_type", None
@@ -497,25 +477,23 @@ class BailingMoeV3MLAAttention(nn.Module):
             g_out = self.num_heads * self.v_head_dim
         else:
             g_out = 0
-        g_prefix = f"{prefix}.g_proj"
         self.g_proj = (
             ColumnParallelLinear(
                 self.hidden_size,
                 g_out,
                 bias=False,
-                quant_config=_get_linear_quant_config(quant_config, g_prefix),
-                prefix=g_prefix,
+                quant_config=quant_config,
+                prefix=f"{prefix}.g_proj",
             )
             if g_out > 0
             else None
         )
-        dense_prefix = f"{prefix}.dense"
         self.dense = RowParallelLinear(
             self.num_heads * self.v_head_dim,
             self.hidden_size,
             bias=False,
-            quant_config=_get_linear_quant_config(quant_config, dense_prefix),
-            prefix=dense_prefix,
+            quant_config=quant_config,
+            prefix=f"{prefix}.dense",
         )
 
         self.rotary_emb = get_rope(
@@ -628,42 +606,41 @@ class BailingMoeV3KimiDeltaAttention(PluggableLayer, MambaBase):
         projection_size = self.head_dim * self.num_heads
         self.projection_size_per_partition = projection_size // self.tp_size
         self.separate_b_proj = _is_fp8_module_excluded(quant_config, f"{prefix}.b_proj")
+        self.qkv_proj: MergedColumnParallelLinear | None
+        self.b_proj: ColumnParallelLinear | None
+        self.qkvb_proj: MergedColumnParallelLinear | None
         if self.separate_b_proj:
-            qkv_prefix = f"{prefix}.qkv_proj"
             self.qkv_proj = MergedColumnParallelLinear(
                 self.hidden_size,
                 [projection_size, projection_size, projection_size],
                 bias=False,
-                quant_config=_get_linear_quant_config(quant_config, qkv_prefix),
-                prefix=qkv_prefix,
+                quant_config=quant_config,
+                prefix=f"{prefix}.qkv_proj",
             )
-            b_prefix = f"{prefix}.b_proj"
             self.b_proj = ColumnParallelLinear(
                 self.hidden_size,
                 self.num_heads,
                 bias=False,
-                quant_config=_get_linear_quant_config(quant_config, b_prefix),
-                prefix=b_prefix,
+                quant_config=quant_config,
+                prefix=f"{prefix}.b_proj",
             )
             self.qkvb_proj = None
         else:
-            qkvb_prefix = f"{prefix}.qkvb_proj"
             self.qkvb_proj = MergedColumnParallelLinear(
                 self.hidden_size,
                 [projection_size, projection_size, projection_size, self.num_heads],
                 bias=False,
                 quant_config=quant_config,
-                prefix=qkvb_prefix,
+                prefix=f"{prefix}.qkvb_proj",
             )
             self.qkv_proj = None
             self.b_proj = None
-        f_prefix = f"{prefix}.f_proj"
         self.f_proj = ColumnParallelLinear(
             self.hidden_size,
             projection_size,
             bias=False,
-            quant_config=_get_linear_quant_config(quant_config, f_prefix),
-            prefix=f_prefix,
+            quant_config=quant_config,
+            prefix=f"{prefix}.f_proj",
         )
         self.dt_bias = nn.Parameter(
             torch.empty(projection_size // self.tp_size, dtype=torch.float32)
@@ -700,24 +677,22 @@ class BailingMoeV3KimiDeltaAttention(PluggableLayer, MambaBase):
         )
         set_weight_attrs(self.A_log, {"weight_loader": _load_a_log})
 
-        g_prefix = f"{prefix}.g_proj"
         self.g_proj = ColumnParallelLinear(
             self.hidden_size,
             projection_size,
             bias=False,
-            quant_config=_get_linear_quant_config(quant_config, g_prefix),
-            prefix=g_prefix,
+            quant_config=quant_config,
+            prefix=f"{prefix}.g_proj",
         )
         self.o_norm = FusedRMSNormGated(
             self.head_dim, eps=config.rms_norm_eps, activation="sigmoid"
         )
-        o_prefix = f"{prefix}.o_proj"
         self.o_proj = RowParallelLinear(
             projection_size,
             self.hidden_size,
             bias=False,
-            quant_config=_get_linear_quant_config(quant_config, o_prefix),
-            prefix=o_prefix,
+            quant_config=quant_config,
+            prefix=f"{prefix}.o_proj",
         )
 
         compilation_config = get_current_vllm_config().compilation_config
@@ -1138,16 +1113,14 @@ class BailingMoeV3MoE(nn.Module):
         shared_intermediate = (
             config.moe_shared_expert_intermediate_size * config.num_shared_experts
         )
-        shared_prefix = f"{prefix}.shared_experts"
-        padded_shared_intermediate = _get_block_fp8_mlp_padded_intermediate_size(
-            quant_config, shared_intermediate, shared_prefix
-        )
         self.shared_experts = BailingMoeV3MLP(
-            intermediate_size=padded_shared_intermediate,
+            intermediate_size=_get_block_fp8_mlp_padded_intermediate_size(
+                quant_config, shared_intermediate, f"{prefix}.shared_experts"
+            ),
             config=config,
             quant_config=quant_config,
             reduce_results=False,
-            prefix=shared_prefix,
+            prefix=f"{prefix}.shared_experts",
             swiglu_limit=self.share_expert_swiglu_limit,
         )
         self.experts = FusedMoEFactory(
@@ -1366,6 +1339,8 @@ class BailingMoeV3Model(nn.Module):
 
 
 class BailingMoeV3ForCausalLM(nn.Module, HasInnerState, IsHybrid, SupportsPP):
+    hf_to_vllm_mapper = WeightsMapper(orig_to_new_substr={".attention.": ".self_attn."})
+
     packed_modules_mapping = {
         "gate_up_proj": ["gate_proj", "up_proj"],
         "qkv_proj": ["q_proj", "k_proj", "v_proj"],
@@ -1376,6 +1351,7 @@ class BailingMoeV3ForCausalLM(nn.Module, HasInnerState, IsHybrid, SupportsPP):
         super().__init__()
         config = vllm_config.model_config.hf_config
         quant_config = vllm_config.quant_config
+        _configure_ling_fp8_quant_config(quant_config)
         self.config = config
         self.quant_config = quant_config
         self.model = BailingMoeV3Model(
@@ -1444,6 +1420,7 @@ class BailingMoeV3ForCausalLM(nn.Module, HasInnerState, IsHybrid, SupportsPP):
         return self.model.get_expert_mapping()
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        weights = self.hf_to_vllm_mapper.apply(weights)
         params_dict = dict(self.named_parameters(remove_duplicate=False))
         loaded_params: set[str] = set()
         stacked_mappings = [
@@ -1484,7 +1461,6 @@ class BailingMoeV3ForCausalLM(nn.Module, HasInnerState, IsHybrid, SupportsPP):
                 layer_idx = int(name.split("model.layers.")[1].split(".")[0])
                 if layer_idx >= self.config.num_hidden_layers:
                     return None
-            name = name.replace("attention.", "self_attn.")
             return maybe_remap_kv_scale_name(name, params_dict)
 
         for orig_name, weight in weights:

--- a/vllm/model_executor/models/bailing_moe_v3_mtp.py
+++ b/vllm/model_executor/models/bailing_moe_v3_mtp.py
@@ -15,6 +15,7 @@ from vllm.model_executor.layers.fused_moe import (
     fused_moe_make_expert_params_mapping,
 )
 from vllm.model_executor.layers.layernorm import RMSNorm
+from vllm.model_executor.layers.linear import ReplicatedLinear
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
 from vllm.model_executor.layers.vocab_parallel_embedding import (
     ParallelLMHead,
@@ -27,6 +28,9 @@ from vllm.model_executor.model_loader.weight_utils import (
 from vllm.model_executor.models.bailing_moe_v3 import (
     BailingMoeV3MLAAttention,
     BailingMoeV3MoE,
+    _get_linear_quant_config,
+    _is_serialized_block_fp8,
+    _maybe_pad_block_fp8_shared_expert_checkpoint_tensor,
 )
 from vllm.model_executor.models.interfaces import SupportsPP
 from vllm.model_executor.models.utils import (
@@ -79,7 +83,22 @@ class BailingMoeV3MultiTokenPredictorLayer(nn.Module):
         self.layer_id = layer_id
         self.enorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.hnorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
-        self.eh_proj = nn.Linear(config.hidden_size * 2, config.hidden_size, bias=False)
+        eh_prefix = maybe_prefix(prefix, "eh_proj")
+        eh_quant_config = _get_linear_quant_config(vllm_config.quant_config, eh_prefix)
+        if _is_serialized_block_fp8(eh_quant_config):
+            self.eh_proj = ReplicatedLinear(
+                config.hidden_size * 2,
+                config.hidden_size,
+                bias=False,
+                quant_config=eh_quant_config,
+                prefix=eh_prefix,
+                return_bias=False,
+            )
+        else:
+            # Keep the BF16 module and weight-loading path unchanged.
+            self.eh_proj = nn.Linear(
+                config.hidden_size * 2, config.hidden_size, bias=False
+            )
         self.input_layernorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.self_attn = BailingMoeV3MLAAttention(
             config,
@@ -217,6 +236,7 @@ class BailingMoeV3MTPModel(nn.Module, SupportsPP):
     ) -> None:
         super().__init__()
         self.config = _get_draft_hf_config(vllm_config)
+        self.quant_config = vllm_config.quant_config
         self.model = BailingMoeV3MultiTokenPredictor(
             vllm_config=vllm_config,
             prefix=maybe_prefix(prefix, "model"),
@@ -349,6 +369,12 @@ class BailingMoeV3MTPModel(nn.Module, SupportsPP):
             if spec_layer is None:
                 continue
             name = normalize_name(name)
+            loaded_weight = _maybe_pad_block_fp8_shared_expert_checkpoint_tensor(
+                self.quant_config,
+                self.config,
+                name,
+                loaded_weight,
+            )
 
             loaded = False
             for param_name, weight_name, stacked_shard_id in stacked_params_mapping:

--- a/vllm/model_executor/models/bailing_moe_v3_mtp.py
+++ b/vllm/model_executor/models/bailing_moe_v3_mtp.py
@@ -26,10 +26,10 @@ from vllm.model_executor.model_loader.weight_utils import (
     maybe_remap_kv_scale_name,
 )
 from vllm.model_executor.models.bailing_moe_v3 import (
+    BailingMoeV3ForCausalLM,
     BailingMoeV3MLAAttention,
     BailingMoeV3MoE,
-    _get_linear_quant_config,
-    _is_serialized_block_fp8,
+    _configure_ling_fp8_quant_config,
     _maybe_pad_block_fp8_shared_expert_checkpoint_tensor,
 )
 from vllm.model_executor.models.interfaces import SupportsPP
@@ -83,22 +83,14 @@ class BailingMoeV3MultiTokenPredictorLayer(nn.Module):
         self.layer_id = layer_id
         self.enorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.hnorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
-        eh_prefix = maybe_prefix(prefix, "eh_proj")
-        eh_quant_config = _get_linear_quant_config(vllm_config.quant_config, eh_prefix)
-        if _is_serialized_block_fp8(eh_quant_config):
-            self.eh_proj = ReplicatedLinear(
-                config.hidden_size * 2,
-                config.hidden_size,
-                bias=False,
-                quant_config=eh_quant_config,
-                prefix=eh_prefix,
-                return_bias=False,
-            )
-        else:
-            # Keep the BF16 module and weight-loading path unchanged.
-            self.eh_proj = nn.Linear(
-                config.hidden_size * 2, config.hidden_size, bias=False
-            )
+        self.eh_proj = ReplicatedLinear(
+            config.hidden_size * 2,
+            config.hidden_size,
+            bias=False,
+            quant_config=vllm_config.quant_config,
+            prefix=maybe_prefix(prefix, "eh_proj"),
+            return_bias=False,
+        )
         self.input_layernorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.self_attn = BailingMoeV3MLAAttention(
             config,
@@ -223,6 +215,8 @@ class BailingMoeV3MultiTokenPredictor(nn.Module):
 
 @support_torch_compile
 class BailingMoeV3MTPModel(nn.Module, SupportsPP):
+    hf_to_vllm_mapper = BailingMoeV3ForCausalLM.hf_to_vllm_mapper
+
     packed_modules_mapping = {
         "gate_up_proj": ["gate_proj", "up_proj"],
         "fused_qkv_a_proj": ["q_a_proj", "kv_a_proj_with_mqa"],
@@ -237,6 +231,7 @@ class BailingMoeV3MTPModel(nn.Module, SupportsPP):
         super().__init__()
         self.config = _get_draft_hf_config(vllm_config)
         self.quant_config = vllm_config.quant_config
+        _configure_ling_fp8_quant_config(self.quant_config)
         self.model = BailingMoeV3MultiTokenPredictor(
             vllm_config=vllm_config,
             prefix=maybe_prefix(prefix, "model"),
@@ -285,6 +280,7 @@ class BailingMoeV3MTPModel(nn.Module, SupportsPP):
         )
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        weights = self.hf_to_vllm_mapper.apply(weights)
         stacked_params_mapping = [
             (".fused_qkv_a_proj", ".q_a_proj", 0),
             (".fused_qkv_a_proj", ".kv_a_proj_with_mqa", 1),
@@ -340,7 +336,6 @@ class BailingMoeV3MTPModel(nn.Module, SupportsPP):
             return None
 
         def normalize_name(name: str) -> str:
-            name = name.replace(".attention.", ".self_attn.")
             return name.replace(
                 "mlp.gate.e_score_correction_bias",
                 "mlp.gate.expert_bias",

--- a/vllm/model_executor/models/bailing_moe_v3_mtp.py
+++ b/vllm/model_executor/models/bailing_moe_v3_mtp.py
@@ -30,7 +30,6 @@ from vllm.model_executor.models.bailing_moe_v3 import (
     BailingMoeV3MLAAttention,
     BailingMoeV3MoE,
     _configure_ling_fp8_quant_config,
-    _maybe_pad_block_fp8_shared_expert_checkpoint_tensor,
 )
 from vllm.model_executor.models.interfaces import SupportsPP
 from vllm.model_executor.models.utils import (
@@ -364,12 +363,6 @@ class BailingMoeV3MTPModel(nn.Module, SupportsPP):
             if spec_layer is None:
                 continue
             name = normalize_name(name)
-            loaded_weight = _maybe_pad_block_fp8_shared_expert_checkpoint_tensor(
-                self.quant_config,
-                self.config,
-                name,
-                loaded_weight,
-            )
 
             loaded = False
             for param_name, weight_name, stacked_shard_id in stacked_params_mapping:


### PR DESCRIPTION



## Purpose
- Refine https://github.com/vllm-project/vllm/pull/51265
- Since there're some edge cases for MoE's share experts that can't have aligned block size for FP8-block, it's better to implement a workaround in quantization side instead of model side.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

