### PR TITLE
[Bugfix][Core] Emit --no-{key} for false BooleanOptionalAction flags in YAML config

### DIFF
--- a/tests/utils_/test_argparse_utils.py
+++ b/tests/utils_/test_argparse_utils.py
@@ -379,7 +379,50 @@ def test_load_config_file(tmp_path):
     os.remove(str(config_file_path))
 
 
-def test_load_config_file_nested(tmp_path):
+def test_load_config_file_false_boolean_optional(tmp_path):
+    """False values for BooleanOptionalAction flags produce --no-{key}."""
+    import argparse
+
+    config_data = {
+        "enable-autotune": False,
+        "port": 8000,
+    }
+
+    config_file_path = tmp_path / "config.yaml"
+    with open(config_file_path, "w") as config_file:
+        yaml.dump(config_data, config_file)
+
+    parser = FlexibleArgumentParser()
+    parser.add_argument("--enable-autotune", action=argparse.BooleanOptionalAction)
+    parser.add_argument("--port", type=int)
+
+    processed_args = parser.load_config_file(str(config_file_path))
+
+    assert "--no-enable-autotune" in processed_args
+    assert "--enable-autotune" not in processed_args
+    assert "--port" in processed_args
+
+
+def test_load_config_file_false_store_true_dropped(tmp_path):
+    """False values for store_true flags are silently dropped (correct)."""
+    config_data = {
+        "enable-feature": False,
+        "port": 8000,
+    }
+
+    config_file_path = tmp_path / "config.yaml"
+    with open(config_file_path, "w") as config_file:
+        yaml.dump(config_data, config_file)
+
+    parser = FlexibleArgumentParser()
+    parser.add_argument("--enable-feature", action="store_true")
+    parser.add_argument("--port", type=int)
+
+    processed_args = parser.load_config_file(str(config_file_path))
+
+    assert "--enable-feature" not in processed_args
+    assert "--no-enable-feature" not in processed_args
+    assert "--port" in processed_args
     """Test that nested dicts in YAML config are converted to JSON strings."""
     config_data = {
         "port": 8000,

--- a/tests/utils_/test_argparse_utils.py
+++ b/tests/utils_/test_argparse_utils.py
@@ -379,30 +379,6 @@ def test_load_config_file(tmp_path):
     os.remove(str(config_file_path))
 
 
-def test_load_config_file_false_boolean_optional(tmp_path):
-    """False values for BooleanOptionalAction flags produce --no-{key}."""
-    import argparse
-
-    config_data = {
-        "enable-autotune": False,
-        "port": 8000,
-    }
-
-    config_file_path = tmp_path / "config.yaml"
-    with open(config_file_path, "w") as config_file:
-        yaml.dump(config_data, config_file)
-
-    parser = FlexibleArgumentParser()
-    parser.add_argument("--enable-autotune", action=argparse.BooleanOptionalAction)
-    parser.add_argument("--port", type=int)
-
-    processed_args = parser.load_config_file(str(config_file_path))
-
-    assert "--no-enable-autotune" in processed_args
-    assert "--enable-autotune" not in processed_args
-    assert "--port" in processed_args
-
-
 def test_load_config_file_false_store_true_dropped(tmp_path):
     """False values for store_true flags are silently dropped (correct)."""
     config_data = {
@@ -415,7 +391,7 @@ def test_load_config_file_false_store_true_dropped(tmp_path):
         yaml.dump(config_data, config_file)
 
     parser = FlexibleArgumentParser()
-    parser.add_argument("--enable-feature", action="store_true")
+    parser.add_argument("--enable-feature", action=argparse.BooleanOptionalAction)
     parser.add_argument("--port", type=int)
 
     processed_args = parser.load_config_file(str(config_file_path))
@@ -423,6 +399,9 @@ def test_load_config_file_false_store_true_dropped(tmp_path):
     assert "--enable-feature" not in processed_args
     assert "--no-enable-feature" not in processed_args
     assert "--port" in processed_args
+
+
+def test_load_config_file_nested(tmp_path):
     """Test that nested dicts in YAML config are converted to JSON strings."""
     config_data = {
         "port": 8000,

--- a/tests/utils_/test_argparse_utils.py
+++ b/tests/utils_/test_argparse_utils.py
@@ -398,8 +398,7 @@ def test_load_config_file_false_store_true_dropped(tmp_path):
     processed_args = parser.load_config_file(str(config_file_path))
 
     assert "--enable-feature" not in processed_args
-    assert "--no-enable-feature" not in processed_args
-    assert "--port" in processed_args
+    assert "--no-enable-feature" in processed_args
 
 
 def test_load_config_file_nested(tmp_path):

--- a/tests/utils_/test_argparse_utils.py
+++ b/tests/utils_/test_argparse_utils.py
@@ -4,6 +4,7 @@
 
 import json
 import os
+from argparse import BooleanOptionalAction
 
 import pytest
 import yaml
@@ -391,7 +392,7 @@ def test_load_config_file_false_store_true_dropped(tmp_path):
         yaml.dump(config_data, config_file)
 
     parser = FlexibleArgumentParser()
-    parser.add_argument("--enable-feature", action=argparse.BooleanOptionalAction)
+    parser.add_argument("--enable-feature", action=BooleanOptionalAction)
     parser.add_argument("--port", type=int)
 
     processed_args = parser.load_config_file(str(config_file_path))

--- a/vllm/utils/argparse_utils.py
+++ b/vllm/utils/argparse_utils.py
@@ -573,8 +573,8 @@ class FlexibleArgumentParser(ArgumentParser):
             if isinstance(value, bool):
                 if value:
                     processed_args.append("--" + key)
-                elif "--no-" + key in self._option_string_actions:
-                    processed_args.append("--no-" + key)
+                elif (no_key := f"--no-{key}") in self._option_string_actions:
+                    processed_args.append(no_key)
             elif isinstance(value, list):
                 if value:
                     processed_args.append("--" + key)

--- a/vllm/utils/argparse_utils.py
+++ b/vllm/utils/argparse_utils.py
@@ -573,6 +573,8 @@ class FlexibleArgumentParser(ArgumentParser):
             if isinstance(value, bool):
                 if value:
                     processed_args.append("--" + key)
+                elif "--no-" + key in self._option_string_actions:
+                    processed_args.append("--no-" + key)
             elif isinstance(value, list):
                 if value:
                     processed_args.append("--" + key)


### PR DESCRIPTION
## Summary

Fixes #51401

`--config` YAML files silently drop `false` boolean values. For `BooleanOptionalAction` flags (e.g. `--enable-flashinfer-autotune`) whose default is `None` and gets resolved later by optimization-level logic, the user's explicit `false` was lost — causing unexpected behavior (OOM in the reported case, as flashinfer autotune warmup ran despite being explicitly disabled).

## Root Cause

In `FlexibleArgumentParser.load_config_file()`, the YAML-to-argv conversion only appends `--{key}` when value is `True`, and does nothing for `False`:

```python
if isinstance(value, bool):
    if value:
        processed_args.append("--" + key)
    # else: silently dropped
```

This is correct for `store_true` flags (default is already False), but wrong for `BooleanOptionalAction` flags where `False` needs explicit `--no-{key}`.

## Fix

When value is `False`, check if `--no-{key}` is a registered option string (which is true for `BooleanOptionalAction`). If so, emit it. `store_true` flags don't register `--no-{key}`, so they retain the existing drop behavior.

```python
elif "--no-" + key in self._option_string_actions:
    processed_args.append("--no-" + key)
```

## Test Plan

```bash
pytest tests/utils_/test_argparse_utils.py::test_load_config_file_false_boolean_optional -v
pytest tests/utils_/test_argparse_utils.py::test_load_config_file_false_store_true_dropped -v
```

cc @hmellor