### PR TITLE
[Bugfix][MRV2] Respect dynamic K=0 from scheduler in AutoRegressiveSpeculator

### DIFF
--- a/tests/v1/worker/test_gpu_autoregressive_speculator.py
+++ b/tests/v1/worker/test_gpu_autoregressive_speculator.py
@@ -377,6 +377,86 @@ def test_multi_step_decode_replays_captured_graph_as_expected(
     assert run_fullgraph.call_count == expected_graph_replays
 
 
+def test_propose_k0_runs_prefill_without_draft_decode(monkeypatch):
+    speculator = object.__new__(_TestSpeculator)
+    speculator.num_speculative_steps = 2
+    speculator.max_model_len = 32
+    speculator.max_num_reqs = 2
+    speculator.dp_size = 1
+    speculator.dp_rank = 0
+    speculator.supports_mm_inputs = False
+    speculator.hidden_states = torch.zeros(2, 3)
+    speculator.draft_tokens = torch.tensor([[11, 12], [21, 22]])
+    speculator.last_token_indices = torch.zeros(2, dtype=torch.int64)
+    speculator.current_draft_step = torch.tensor(0)
+    speculator.input_buffers = SimpleNamespace()
+    speculator.prefill_cudagraph_manager = None
+    speculator.decode_cudagraph_manager = None
+    speculator.use_fused_multi_step_decode = False
+    speculator._copy_request_inputs = Mock()
+    speculator._prepare_eplb_forward = Mock()
+    speculator.on_prefill_begin = Mock()
+    speculator.on_prefill_end = Mock()
+    speculator.on_multi_step_decode_begin = Mock()
+    speculator.on_multi_step_decode_end = Mock()
+    speculator._prefill = Mock()
+    speculator._multi_step_decode = Mock()
+    speculator._fused_multi_step_decode = Mock()
+
+    prepare_prefill = Mock()
+    prepare_decode = Mock()
+    monkeypatch.setattr(spec_module, "prepare_prefill_inputs", prepare_prefill)
+    monkeypatch.setattr(spec_module, "prepare_decode_inputs", prepare_decode)
+    monkeypatch.setattr(spec_module, "get_uniform_decode_token_count", Mock())
+    monkeypatch.setattr(
+        spec_module,
+        "dispatch_cg_and_sync_dp",
+        Mock(
+            return_value=(
+                BatchExecutionDescriptor(
+                    cg_mode=CUDAGraphMode.NONE,
+                    num_tokens=2,
+                    num_reqs=2,
+                ),
+                None,
+            )
+        ),
+    )
+
+    input_batch = SimpleNamespace(
+        num_tokens=2,
+        num_tokens_after_padding=2,
+        num_reqs=2,
+        num_scheduled_tokens=torch.ones(2, dtype=torch.int32),
+        seq_lens=torch.ones(2, dtype=torch.int32),
+        seq_lens_cpu_upper_bound=torch.ones(2, dtype=torch.int32),
+        idx_mapping=torch.arange(2),
+        has_prefill=False,
+    )
+    output = speculator.propose(
+        input_batch,
+        attn_metadata={},
+        slot_mappings={},
+        last_hidden_states=torch.ones(2, 3),
+        aux_hidden_states=None,
+        num_sampled=torch.ones(2, dtype=torch.int32),
+        num_rejected=torch.zeros(2, dtype=torch.int32),
+        last_sampled=torch.zeros(2, dtype=torch.int64),
+        next_prefill_tokens=torch.zeros(2, dtype=torch.int64),
+        temperature=torch.zeros(2),
+        seeds=torch.zeros(2, dtype=torch.int64),
+        num_speculative_tokens=0,
+    )
+
+    assert output.shape == (2, 0)
+    speculator._prefill.assert_called_once()
+    speculator.on_prefill_begin.assert_called_once_with(2)
+    speculator.on_prefill_end.assert_called_once_with(2)
+    prepare_decode.assert_not_called()
+    speculator._multi_step_decode.assert_not_called()
+    speculator._fused_multi_step_decode.assert_not_called()
+
+
 def test_update_draft_decode_metadata_updates_fa3_scheduler_metadata(
     monkeypatch,
 ):

--- a/tests/v1/worker/test_gpu_model_runner_v2_eplb.py
+++ b/tests/v1/worker/test_gpu_model_runner_v2_eplb.py
@@ -186,6 +186,8 @@ def test_v2_sample_tokens_runs_eplb_on_non_last_pp_rank(monkeypatch):
         ec_connector_output=None,
         routed_experts=None,
         cudagraph_stats=None,
+        num_tokens_across_dp=None,
+        num_spec_tokens_to_schedule=None,
     )
     runner.req_states = SimpleNamespace()
 

--- a/tests/v1/worker/test_gpu_model_runner_v2_eplb.py
+++ b/tests/v1/worker/test_gpu_model_runner_v2_eplb.py
@@ -4,6 +4,7 @@
 
 from types import SimpleNamespace
 from typing import Any
+from unittest.mock import Mock
 
 import torch
 
@@ -205,3 +206,74 @@ def test_v2_sample_tokens_runs_eplb_on_non_last_pp_rank(monkeypatch):
     output = mrv2.GPUModelRunner.sample_tokens(runner, None)
     assert output in (EMPTY_MODEL_RUNNER_OUTPUT, None)
     assert events == ["receive", "postprocess_num_computed_tokens", "eplb"]
+
+
+def test_v2_sample_tokens_propagates_k0_and_hides_stale_drafts(monkeypatch):
+    runner = _make_runner(num_speculative_steps=2, _draft_workspace_lane=0)
+    input_batch = SimpleNamespace(
+        num_reqs=2,
+        req_ids=["req-0", "req-1"],
+        idx_mapping=torch.arange(2),
+        query_start_loc=torch.arange(3),
+    )
+    runner.execute_model_state = SimpleNamespace(
+        input_batch=input_batch,
+        attn_metadata={},
+        slot_mappings_by_layer={},
+        hidden_states=torch.zeros(2, 3),
+        aux_hidden_states=None,
+        finished_req_ids=set(),
+        ec_connector_output=None,
+        routed_experts=None,
+        num_spec_tokens_to_schedule=0,
+    )
+    runner.pcp_manager = None
+    runner.pp_handler = None
+    runner.sample = Mock(
+        return_value=(
+            SimpleNamespace(sampled_token_ids=torch.zeros(2, dtype=torch.int64)),
+            torch.ones(2, dtype=torch.int32),
+            torch.zeros(2, dtype=torch.int32),
+        )
+    )
+    runner.prompt_logprobs_worker = SimpleNamespace(
+        compute_prompt_logprobs=Mock(return_value={})
+    )
+    runner.model = SimpleNamespace(compute_logits=Mock())
+    runner.req_states = SimpleNamespace(
+        all_token_ids=SimpleNamespace(gpu=torch.zeros(2, 1, dtype=torch.int64)),
+        num_computed_tokens=SimpleNamespace(gpu=torch.zeros(2, dtype=torch.int32)),
+        prompt_len=SimpleNamespace(np=None),
+        last_sampled_tokens=torch.zeros(2, dtype=torch.int64),
+        next_prefill_tokens=torch.zeros(2, dtype=torch.int64),
+        draft_tokens=torch.tensor([[91, 92], [93, 94]]),
+    )
+    runner.main_stream = None
+    runner.output_copy_stream = None
+    runner.check_ep_fault = False
+    runner.postprocess_sampled = Mock()
+    runner.sampler = SimpleNamespace(
+        sampling_states=SimpleNamespace(
+            temperature=SimpleNamespace(gpu=torch.zeros(2)),
+            seeds=SimpleNamespace(gpu=torch.zeros(2, dtype=torch.int64)),
+        )
+    )
+    runner.speculator = SimpleNamespace(
+        supports_mm_inputs=False,
+        propose=Mock(return_value=torch.empty((2, 0), dtype=torch.int64)),
+    )
+    runner.adaptive_verification = None
+    runner.draft_tokens_handler = SimpleNamespace(set_draft_tokens=Mock())
+
+    monkeypatch.setattr(
+        mrv2.pcp,
+        "maybe_restore_pcp_for_sampling",
+        lambda _, hidden_states, batch: (hidden_states, batch),
+    )
+    monkeypatch.setattr(mrv2, "AsyncOutput", lambda **kwargs: kwargs)
+
+    mrv2.GPUModelRunner.sample_tokens(runner, None)
+
+    assert runner.speculator.propose.call_args.kwargs["num_speculative_tokens"] == 0
+    handled_drafts = runner.draft_tokens_handler.set_draft_tokens.call_args.args[1]
+    assert handled_drafts.shape == (2, 0)

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -1832,6 +1832,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             ec_connector_output=ec_connector_output,
             routed_experts=routed_experts,
             cudagraph_stats=cudagraph_stats,
+            num_spec_tokens_to_schedule=scheduler_output.num_spec_tokens_to_schedule,
         )
 
         if not self.is_last_pp_rank:
@@ -1858,6 +1859,9 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         ec_connector_output = self.execute_model_state.ec_connector_output
         routed_experts = self.execute_model_state.routed_experts
         cudagraph_stats = self.execute_model_state.cudagraph_stats
+        num_spec_tokens_to_schedule = (
+            self.execute_model_state.num_spec_tokens_to_schedule
+        )
         self.execute_model_state = None
 
         if not self.is_last_pp_rank:
@@ -1979,8 +1983,11 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                     self.sampler.sampling_states.seeds.gpu,
                     dp_sync=dp_sync,
                     mm_inputs=mm_inputs,
+                    num_speculative_tokens=num_spec_tokens_to_schedule,
                 )
-            self.req_states.draft_tokens[input_batch.idx_mapping] = draft_tokens
+            self.req_states.draft_tokens[
+                input_batch.idx_mapping, : draft_tokens.shape[1]
+            ] = draft_tokens
             if self.adaptive_verification is not None:
                 self.adaptive_verification.record_confidences(
                     self.speculator.draft_token_confidence_probs, input_batch
@@ -1989,9 +1996,17 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         if self.num_speculative_steps > 0:
             # Spec-decode and diffusion LLMs both use draft tokens but the latter does
             # not have a speculator (i.e. self.speculator is None)
+            # When the speculator produced a narrow width (e.g. DSD K=0),
+            # only pass the active-width slice to the handler — stale columns
+            # in the persistent buffer would create phantom draft slots.
+            active_width = (
+                draft_tokens.shape[1]
+                if self.speculator is not None
+                else self.num_speculative_steps
+            )
             self.draft_tokens_handler.set_draft_tokens(
                 input_batch,
-                self.req_states.draft_tokens[input_batch.idx_mapping],
+                self.req_states.draft_tokens[input_batch.idx_mapping, :active_width],
             )
 
         # Post-step KV connector related operations.
@@ -2133,6 +2148,7 @@ class ExecuteModelState(NamedTuple):
     ec_connector_output: ECConnectorOutput | None
     routed_experts: RoutedExpertsTensors | None
     cudagraph_stats: CUDAGraphStat | None
+    num_spec_tokens_to_schedule: int | None = None
 
 
 class BatchReqState(NamedTuple):

--- a/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
@@ -227,6 +227,7 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
         skip_attn_for_dummy_run: bool = False,
         mm_inputs: tuple[list[torch.Tensor], torch.Tensor] | None = None,
         is_profile: bool = False,
+        num_speculative_tokens: int | None = None,
     ) -> torch.Tensor:
         num_tokens = input_batch.num_tokens
         num_tokens_padded = input_batch.num_tokens_after_padding
@@ -320,6 +321,10 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
             )
         self.on_prefill_end(num_reqs)
 
+        # DSD K=0: prefill has been run to keep draft KV cache in sync with
+        # the target, but no speculative decode steps are needed.
+        if num_speculative_tokens is not None and num_speculative_tokens == 0:
+            return self.draft_tokens[:num_reqs, :0]
         if self.num_speculative_steps == 1:
             # Early exit.
             return self.draft_tokens[:num_reqs, :1]

--- a/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
@@ -330,6 +330,7 @@ class DFlashSpeculator(DraftModelSpeculator):
         skip_attn_for_dummy_run: bool = False,
         mm_inputs: tuple[list[torch.Tensor], torch.Tensor] | None = None,
         is_profile: bool = False,
+        num_speculative_tokens: int | None = None,
     ) -> torch.Tensor:
         num_reqs = input_batch.num_reqs
         num_target_tokens = input_batch.num_tokens

--- a/vllm/v1/worker/gpu/spec_decode/multi_module_mtp/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/multi_module_mtp/speculator.py
@@ -155,6 +155,7 @@ class MultiModuleMTPSpeculator(DraftModelSpeculator):
         skip_attn_for_dummy_run: bool = False,
         mm_inputs: tuple[list[torch.Tensor], torch.Tensor] | None = None,
         is_profile: bool = False,
+        num_speculative_tokens: int | None = None,
     ) -> torch.Tensor:
         num_reqs = input_batch.num_reqs
         seq_lens_cpu_upper_bound = input_batch.seq_lens_cpu_upper_bound

--- a/vllm/v1/worker/gpu/spec_decode/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/speculator.py
@@ -81,6 +81,7 @@ class BaseSpeculator(ABC):
         skip_attn_for_dummy_run: bool = False,
         mm_inputs: tuple[list[torch.Tensor], torch.Tensor] | None = None,
         is_profile: bool = False,
+        num_speculative_tokens: int | None = None,
     ) -> torch.Tensor:
         pass
 


### PR DESCRIPTION
## Problem

When Dynamic Speculative Decoding (DSD) selects K=0 at higher batch sizes,
`AutoRegressiveSpeculator` ignores the scheduler's runtime K and executes the
configured maximum number of draft steps. Those drafts are not used, so this
wastes GPU work.

The scheduler already publishes the selected K in
`SchedulerOutput.num_spec_tokens_to_schedule`; MRV2 did not propagate that
value to proposal execution.

Fixes #51510.

## Solution

- Propagate `num_spec_tokens_to_schedule` through `ExecuteModelState` into
  `speculator.propose()`.
- For K=0, run draft prefill to keep the draft KV cache synchronized, then
  return an empty-width draft tensor without running draft decode.
- Pass only the returned draft width to `DraftTokensHandler`, preventing stale
  columns in the reusable draft buffer from becoming phantom draft slots.
- Preserve prior behavior when the runtime K is `None` or positive. Other
  speculator implementations accept the optional argument but do not act on it.

## Related work / duplicate check

Searches for #51510 and MRV2 dynamic-K fixes found no other PR addressing this
bug.

#49652 is complementary, not duplicate. It fixes CUDA graph capture-shape
derivation for autoregressive draft decode under dynamic SD. This PR carries
the scheduler's runtime K into proposal execution and skips draft decode when
that K is zero. A deployment using FULL CUDA graphs needs #49652's capture fix
as well as this runtime behavior fix.

## Tests

```bash
.venv/bin/python -m pytest \
  tests/v1/worker/test_gpu_autoregressive_speculator.py \
  tests/v1/worker/test_gpu_model_runner_v2_eplb.py -q
```

Result: `23 passed`.

The new regression tests verify that:

- K=0 still runs draft prefill but does not prepare or execute draft decode;
- the K=0 proposal has shape `(num_requests, 0)`;
- the scheduler-selected K reaches `speculator.propose()`; and
- stale columns in the persistent draft buffer do not reach
  `DraftTokensHandler`.

As a red/green check, removing the K=0 early return and active-width slice made
the two new tests fail with width 2 instead of 0. Restoring the fix made them
pass.

```bash
uvx pre-commit run --files \
  tests/v1/worker/test_gpu_autoregressive_speculator.py \
  tests/v1/worker/test_gpu_model_runner_v2_eplb.py \
  vllm/v1/worker/gpu/model_runner.py \
  vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py \
  vllm/v1/worker/gpu/spec_decode/dflash/speculator.py \
  vllm/v1/worker/gpu/spec_decode/multi_module_mtp/speculator.py \
  vllm/v1/worker/gpu/spec_decode/speculator.py
```

Result: all applicable hooks passed. `git diff --check` passed.

## Benchmark

2× RTX 5090, ThinkingCap-Qwen3.6-27B-FP8, MRV2, TP=2,
`FULL_AND_PIECEWISE` CUDA graphs, and DSD
`[[1,2,2],[3,16,0]]`:

| Sessions | Before | After | Change | No-spec reference |
|---:|---:|---:|---:|---:|
| 1 | 107 t/s | 108 t/s | +1% | 107 t/s |
| 4 | 193 t/s | 211 t/s | +9% | 209 t/s |
| 8 | 364 t/s | 399 t/s | +10% | 393 t/s |

At one session the schedule selects K=2, so no K=0 improvement is expected.
At four and eight sessions, K=0 is active. Instrumentation showed that the
unpatched path spent approximately 7 ms on two unused draft-decode passes per
K=0 step.

## AI assistance

OpenAI Codex assisted with analysis, code drafting, and test drafting. I
reviewed the changes and validation results and can explain and maintain the
patch.
