### PR TITLE
[V1][Scheduler] Fix Mamba-align livelock when an encoder cap lands mid-block

### DIFF
--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -3610,6 +3610,60 @@ def test_scheduler_no_ec_connector_by_default():
     assert scheduler.ec_connector is None
 
 
+def test_mamba_align_encoder_cache_cap_makes_progress():
+    """An encoder boundary inside a Mamba block must remain schedulable."""
+    block_size = 1536
+    scheduler = create_scheduler(
+        max_num_batched_tokens=32768,
+        max_model_len=40000,
+        block_size=block_size,
+        enable_prefix_caching=True,
+    )
+    scheduler.need_mamba_block_aligned_split = True
+    scheduler.max_model_len = 40000
+    scheduler.max_num_encoder_input_tokens = 32768
+    scheduler.encoder_cache_manager = EncoderCacheManager(cache_size=32768)
+
+    first_image_end = 16619
+    request = create_requests(
+        num_requests=1,
+        num_tokens=33243,
+        mm_positions=[
+            [
+                PlaceholderRange(offset=32, length=16587),
+                PlaceholderRange(offset=first_image_end, length=16587),
+            ]
+        ],
+        max_tokens=1,
+        block_size=block_size,
+        req_ids=["req"],
+    )[0]
+    scheduler.add_request(request)
+
+    output = scheduler.schedule()
+    assert output.num_scheduled_tokens[request.request_id] == first_image_end
+    assert output.scheduled_encoder_inputs[request.request_id] == [0]
+
+    scheduler.update_from_output(
+        output,
+        ModelRunnerOutput(
+            req_ids=[request.request_id],
+            req_id_to_index={request.request_id: 0},
+            sampled_token_ids=[[]],
+            logprobs=None,
+            prompt_logprobs_dict={},
+            pooler_output=[],
+        ),
+    )
+
+    output = scheduler.schedule()
+    next_block_boundary = 16896
+    assert output.num_scheduled_tokens[request.request_id] == (
+        next_block_boundary - first_image_end
+    )
+    assert output.scheduled_encoder_inputs[request.request_id] == [1]
+
+
 @pytest.mark.parametrize("use_kv_connector", [False, True])
 def test_ec_connector_text_only_request(use_kv_connector):
     """Test text-only requests don't allocate encoder cache."""

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -518,6 +518,14 @@ class Scheduler(SchedulerInterface):
                 - self.num_sampled_tokens_per_step,
             )
 
+            # Apply Mamba alignment before encoder caps: an encoder cap that
+            # lands mid-block would otherwise floor back to the chunk start
+            # and livelock the request.
+            if self.need_mamba_block_aligned_split:
+                num_new_tokens = self._mamba_block_aligned_split(
+                    request, num_new_tokens
+                )
+
             # Schedule encoder inputs.
             encoder_inputs_to_schedule = None
             external_load_encoder_input: list[int] = []
@@ -534,11 +542,6 @@ class Scheduler(SchedulerInterface):
                     num_new_tokens,
                     encoder_compute_budget,
                     shift_computed_tokens=1 if self.use_eagle else 0,
-                )
-
-            if self.need_mamba_block_aligned_split:
-                num_new_tokens = self._mamba_block_aligned_split(
-                    request, num_new_tokens
                 )
 
             if num_new_tokens == 0:
@@ -908,6 +911,19 @@ class Scheduler(SchedulerInterface):
                     num_new_tokens = min(num_new_tokens, token_budget)
                     assert num_new_tokens > 0
 
+                    # Apply Mamba alignment before encoder caps: an encoder
+                    # cap that lands mid-block would otherwise floor back to
+                    # the chunk start and livelock the request.
+                    if self.need_mamba_block_aligned_split:
+                        num_new_tokens = self._mamba_block_aligned_split(
+                            request,
+                            num_new_tokens,
+                            num_new_local_computed_tokens,
+                            num_external_computed_tokens,
+                        )
+                        if num_new_tokens == 0:
+                            break
+
                     # Schedule encoder inputs.
                     if request.has_encoder_inputs:
                         (
@@ -925,17 +941,6 @@ class Scheduler(SchedulerInterface):
                         if num_new_tokens == 0:
                             # The request cannot be scheduled.
                             break
-
-                # Skip block alignment when setting up async receive (no local work).
-                if self.need_mamba_block_aligned_split and not load_kv_async:
-                    num_new_tokens = self._mamba_block_aligned_split(
-                        request,
-                        num_new_tokens,
-                        num_new_local_computed_tokens,
-                        num_external_computed_tokens,
-                    )
-                    if num_new_tokens == 0:
-                        break
 
                 # During async KV load, no forward pass is run yet.
                 # Allocate speculative lookahead slots later to avoid


### PR DESCRIPTION
## Purpose

A multimodal request can wedge the V1 scheduler forever, silently. Health checks keep passing while every queued request is head-of-line blocked behind it.

This affects hybrid models running with Mamba cache mode `align` (the default when prefix caching is enabled) that serve multiple large multimodal inputs whose combined encoder embeddings exceed the encoder cache.

Root cause: two boundary rules with no common solution.

1. `_try_schedule_encoder_inputs` cannot fit a multimodal item in the encoder cache, so it truncates the chunk to end exactly at that item's `start_pos`.
2. `_mamba_block_aligned_split` then floors the chunk end to the previous `block_size` multiple.

If `start_pos` lies inside the current Mamba block, `aligned_end` floors straight back to `start`, the split returns 0, and the caller skips the request (running queue) or breaks out of the loop (waiting queue). The encoder re-applies exactly the same cap on the next step, so it never resolves. Nothing logs and nothing raises.

The guard in `_mamba_block_aligned_split`:

```python
if aligned_end > start or block_size <= max_prefill_tokens:
    end = aligned_end
```

`block_size <= max_prefill_tokens` encodes the assumption that "a whole block fits in a prefill chunk, so a later, larger chunk will reach the next boundary." That assumption is false when something else has already capped the chunk end below the boundary and will keep capping it identically.

**Fix:** apply Mamba block alignment *before* the encoder caps in both the running- and waiting-queue paths. After the capped chunk ends mid-block at the item's `start_pos`, the next chunk starts mid-block and the alignment's existing `next_block_boundary` stop moves it forward to the next block boundary, so the request makes progress while chunk ends stay block-aligned wherever possible. In the waiting path the alignment moves inside the non-`load_kv_async` branch, so the previous `not load_kv_async` guard is preserved by construction.

Concrete repro shape: `--max-num-batched-tokens 32768` with `block_size 1536`; two images of 16,587 embeddings each cannot share the 32,768-entry encoder cache. The encoder truncates to the second image's `start_pos` 16,619, which floors to 15,360 — exactly `num_computed_tokens` — and the request is skipped every step.

## Duplicate-work check

- #47771, #40709, and #40757 address the same zero-collapse livelock, but by relaxing the guard inside `_mamba_block_aligned_split` (keep the sub-block chunk when flooring would return 0). This PR takes a materially different approach: it fixes the *ordering* — align first, then apply encoder caps — so the alignment invariant itself is untouched and chunk ends remain block-aligned except at mandatory encoder boundaries. Those PRs have been inactive for several weeks; happy to rebase or close if one of them lands first.
- No existing issue is fixed wholesale by this PR; it is the scheduler-side complement to that family of reports.

## Test plan

- New regression test `test_mamba_align_encoder_cache_cap_makes_progress` in `tests/v1/core/test_scheduler.py`:
  - Without the fix: fails (the request is skipped forever after the first chunk).
  - With the fix: passes (first chunk ends at the encoder boundary 16,619; the next chunk advances to the next block boundary 16,896).
- `.venv/bin/python -m pytest tests/v1/core/test_scheduler.py -q` — 108 passed; the 34 remaining failures are pre-existing on clean `main` in this local environment (missing `torchvision`, model-config inspection failures) with an identical failure set before and after the change.
- `pre-commit run --files vllm/v1/core/sched/scheduler.py tests/v1/core/test_scheduler.py` — all hooks pass, including ruff and mypy.
- No model-output-affecting change: scheduling order of caps only; no numerical behavior changes, so no evals run.

## AI disclosure

AI assistance (Kimi Code) was used to port and validate this fix. The human submitter reviewed every changed line and the test results.
