### PR TITLE
docs: clarify Metal quickstart model choice

### DIFF
--- a/docs/getting_started/quickstart.md
+++ b/docs/getting_started/quickstart.md
@@ -145,6 +145,14 @@ The [LLM][vllm.LLM] class initializes vLLM's engine and the [OPT-125M model](htt
 llm = LLM(model="facebook/opt-125m")
 ```
 
+!!! note "Apple Silicon"
+    If you are following this guide with [vLLM-Metal](https://github.com/vllm-project/vllm-metal), use an MLX-optimized model from the
+    [mlx-community](https://huggingface.co/mlx-community) organization instead of `facebook/opt-125m`. For example:
+
+    ```python
+    llm = LLM(model="mlx-community/Qwen2.5-0.5B-Instruct-4bit")
+    ```
+
 !!! note
     By default, vLLM downloads models from [Hugging Face](https://huggingface.co/). If you would like to use models from [ModelScope](https://www.modelscope.cn), set the environment variable `VLLM_USE_MODELSCOPE` before initializing the engine.
 


### PR DESCRIPTION
## Summary
- Add an Apple Silicon note near the offline inference quickstart model example.
- Point vLLM-Metal users to an MLX-optimized `mlx-community` model instead of `facebook/opt-125m`.

Fixes #50165

## Testing
- `git diff --check`

Docs build not run locally because `mkdocs` is not installed in this environment.