### PR TITLE
[KVConnector] Count async loads per request in MultiConnector

### DIFF
--- a/tests/v1/kv_connector/unit/test_multi_connector.py
+++ b/tests/v1/kv_connector/unit/test_multi_connector.py
@@ -23,6 +23,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.base import (
 from vllm.distributed.kv_transfer.kv_connector.v1.metrics import KVConnectorStats
 from vllm.distributed.kv_transfer.kv_connector.v1.multi_connector import (
     MultiConnector,
+    MultiKVConnectorMetadata,
     MultiKVConnectorStats,
     MultiKVConnectorWorkerMetadata,
 )
@@ -1151,3 +1152,83 @@ def test_multi_connector_mixed_hma_disables_hybrid_kv_cache(monkeypatch):
             assert mc._all_support_hma is False
         finally:
             llm.llm_engine.engine_core.shutdown()
+
+
+# ============================================================================
+# Async transfer completion accounting (`get_finished`)
+# ============================================================================
+
+
+def _bind_extra(
+    mc: MultiConnector,
+    *,
+    saves: dict[str, int] | None = None,
+    loads: dict[str, int] | None = None,
+) -> None:
+    """Deliver the scheduler-side counts to the worker-side connector."""
+    mc.bind_connector_metadata(
+        MultiKVConnectorMetadata(
+            metadata=tuple(MagicMock() for _ in mc._connectors),
+            extra_async_saves=saves,
+            extra_async_loads=loads,
+        )
+    )
+
+
+def _stub_finished(
+    mc: MultiConnector, results: list[tuple[set[str] | None, set[str] | None]]
+) -> None:
+    for connector, result in zip(mc._connectors, results):
+        connector.get_finished.return_value = result
+
+
+def test_get_finished_forwards_a_lone_reporter(mc: MultiConnector):
+    """With no extra count recorded, a single report is passed straight up."""
+    _stub_finished(mc, [({"req-0"}, {"req-1"}), (None, None)])
+
+    assert mc.get_finished(set()) == ({"req-0"}, {"req-1"})
+
+
+def test_get_finished_defers_recving_until_the_last_loader(mc: MultiConnector):
+    """Two connectors loading one request means two reports; the scheduler must
+    see exactly one. A second report moves an already-resumed request through
+    `assert RequestStatus.is_finished(req.status)` in
+    `Scheduler._update_from_kv_xfer_finished`, killing EngineCore."""
+    _bind_extra(mc, loads={"req-0": 1})
+
+    _stub_finished(mc, [(None, {"req-0"}), (None, None)])
+    assert mc.get_finished(set())[1] is None, "first of two loaders is not the load"
+
+    _stub_finished(mc, [(None, None), (None, {"req-0"})])
+    assert mc.get_finished(set())[1] == {"req-0"}
+    assert mc._extra_async_loads == {}
+
+
+def test_get_finished_defers_sending_until_the_last_saver(mc: MultiConnector):
+    """Same accounting on the save side: the blocks stay allocated until the
+    last connector saving the request is done with them."""
+    _bind_extra(mc, saves={"req-0": 1})
+
+    _stub_finished(mc, [({"req-0"}, None), (None, None)])
+    assert mc.get_finished(set())[0] is None, "first of two savers is not the save"
+
+    _stub_finished(mc, [(None, None), ({"req-0"}, None)])
+    assert mc.get_finished(set())[0] == {"req-0"}
+    assert mc._extra_async_saves == {}
+
+
+def test_extra_counts_ship_to_the_worker_once(mc: MultiConnector):
+    """The counts are computed scheduler-side and drained worker-side, so they
+    travel in the connector metadata, and only in the next one built."""
+    mc._extra_async_saves = {"req-0": 2}
+    mc._extra_async_loads = {"req-1": 1}
+
+    metadata = mc.build_connector_meta(MagicMock())
+
+    assert metadata.extra_async_saves == {"req-0": 2}
+    assert metadata.extra_async_loads == {"req-1": 1}
+    assert mc._extra_async_saves == {}
+    assert mc._extra_async_loads == {}
+    next_metadata = mc.build_connector_meta(MagicMock())
+    assert next_metadata.extra_async_saves is None
+    assert next_metadata.extra_async_loads is None

--- a/vllm/distributed/kv_transfer/kv_connector/v1/multi_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/multi_connector.py
@@ -46,6 +46,7 @@ logger = init_logger(__name__)
 class MultiKVConnectorMetadata(KVConnectorMetadata):
     metadata: tuple[KVConnectorMetadata, ...]
     extra_async_saves: dict[str, int] | None = None
+    extra_async_loads: dict[str, int] | None = None
 
 
 @dataclass
@@ -198,10 +199,15 @@ class MultiConnector(KVConnectorBase_V1, SupportsHMA):
         self._requests_to_connector: dict[str, int] = {}
 
         # Keeps track of *additional* remaining async saves (beyond 1) to be
-        # finished per request. Not needed for async loads since we only allow
-        # a single connector to load.
+        # finished per request.
         # Propagated from scheduler to worker side via the connector metadata.
         self._extra_async_saves: dict[str, int] = {}
+
+        # Same, for async loads, for when more than one connector loads a
+        # single request. Today only one connector is picked per request, so
+        # this stays empty; it is the accounting a multi-loader request needs.
+        # Propagated from scheduler to worker side via the connector metadata.
+        self._extra_async_loads: dict[str, int] = {}
 
     @property
     def supports_divergent_local_hybrid_hits(self) -> bool:
@@ -271,6 +277,8 @@ class MultiConnector(KVConnectorBase_V1, SupportsHMA):
         assert isinstance(connector_metadata, MultiKVConnectorMetadata)
         if connector_metadata.extra_async_saves:
             self._extra_async_saves.update(connector_metadata.extra_async_saves)
+        if connector_metadata.extra_async_loads:
+            self._extra_async_loads.update(connector_metadata.extra_async_loads)
         for c, cm in zip(self._connectors, connector_metadata.metadata):
             c.bind_connector_metadata(cm)
         super().bind_connector_metadata(connector_metadata)
@@ -327,23 +335,41 @@ class MultiConnector(KVConnectorBase_V1, SupportsHMA):
             sending, recving = c.get_finished(finished_req_ids)
             if not recving and not sending:
                 continue
-            # Aggregate finished recving request ids.
-            finished_recving.update(recving or ())
+            # Aggregate finished recving request ids - only include once we've
+            # drained the "extra" count, exactly as for sends below. When more
+            # than one connector loads a single request, the scheduler must not
+            # be told the load is complete until the last of them reports: the
+            # first report moves the request out of WAITING_FOR_REMOTE_KVS, so
+            # a second one would hit `assert RequestStatus.is_finished(...)` in
+            # `Scheduler._update_from_kv_xfer_finished` and kill EngineCore.
+            for req_id in recving or ():
+                if self._drain_extra(self._extra_async_loads, req_id):
+                    finished_recving.add(req_id)
             # Aggregate finished sending request ids - only include
             # once we've drained the "extra" count (for cases where
             # more than one connector is async-saving the same request).
             for req_id in sending or ():
-                extra_pending = self._extra_async_saves.get(req_id)
-                if extra_pending is None:
+                if self._drain_extra(self._extra_async_saves, req_id):
                     finished_sending.add(req_id)
-                    continue
-                assert extra_pending > 0
-                if extra_pending == 1:
-                    del self._extra_async_saves[req_id]
-                else:
-                    self._extra_async_saves[req_id] = extra_pending - 1
 
         return finished_sending or None, finished_recving or None
+
+    @staticmethod
+    def _drain_extra(extra: dict[str, int], req_id: str) -> bool:
+        """Whether this is the last connector to report `req_id`.
+
+        `extra` holds the number of reports still expected *beyond* this one.
+        A missing entry means no other connector is working on the request.
+        """
+        extra_pending = extra.get(req_id)
+        if extra_pending is None:
+            return True
+        assert extra_pending > 0
+        if extra_pending == 1:
+            del extra[req_id]
+        else:
+            extra[req_id] = extra_pending - 1
+        return False
 
     def get_block_ids_with_load_errors(self) -> set[int]:
         agg_block_ids: set[int] = set()
@@ -436,6 +462,9 @@ class MultiConnector(KVConnectorBase_V1, SupportsHMA):
         if self._extra_async_saves:
             metadata.extra_async_saves = self._extra_async_saves
             self._extra_async_saves = {}
+        if self._extra_async_loads:
+            metadata.extra_async_loads = self._extra_async_loads
+            self._extra_async_loads = {}
         return metadata
 
     def update_connector_output(self, connector_output: KVConnectorOutput):


### PR DESCRIPTION
## Purpose

`MultiConnector` already tracks how many sub-connectors are still async-**saving**
a request (`_extra_async_saves`) and only forwards `finished_sending` once the
last one has reported, so the scheduler frees the blocks exactly once.

`finished_recving` had no equivalent accounting — every sub-connector's report was
forwarded verbatim:

```python
# Aggregate finished recving request ids.
finished_recving.update(recving or ())
```

That holds while exactly one connector is picked to load a request, but it is the
load path's only guard. A second report for a request the scheduler has already
resumed out of `WAITING_FOR_REMOTE_KVS` trips
`assert RequestStatus.is_finished(req.status)` in
`Scheduler._update_from_kv_xfer_finished` and takes down EngineCore.

This PR mirrors the save-side accounting for loads:

- `_extra_async_loads` is computed scheduler-side and travels to the worker-side
  connector in `MultiKVConnectorMetadata`, like `extra_async_saves` does.
- `get_finished` forwards a `finished_recving` id only once that count is drained.
- The drain shared by both sides is factored into `_drain_extra`.

**Scope note:** on its own this is behaviour-neutral — nothing populates
`_extra_async_loads` until a request can be loaded by more than one sub-connector.
It is split out of #50546 (`compose_connectors`), which is the first caller, so
that the completion accounting can be reviewed independently of the hit-selection
change. It also brings the first unit coverage of the pre-existing save-side drain.

## Not a duplicate

Checked open PRs touching `MultiConnector` / KV-transfer completion:

- #50546 — the composition PR this is split out of (same author); it will be
  rebased onto this one.
- #46304 — skips stale KV-xfer finish notifications *in the scheduler*, for
  already-freed requests. Different layer and different case: this PR is about a
  single live request legitimately reported by several sub-connectors.
- #42841 — `MultiConnector` state corruption in P/D; touches request/connector
  bookkeeping, not `get_finished` completion counting.
- #46289, #42461, #43509 — aborted-recv block reclaim, per-block error handling,
  NIXL notification race. No overlap.

No open PR adds async-load accounting to `MultiConnector`.

## Testing

```bash
.venv/bin/python -m pytest tests/v1/kv_connector/unit/test_multi_connector.py -v
```

New tests in `tests/v1/kv_connector/unit/test_multi_connector.py`:

- `test_get_finished_forwards_a_lone_reporter` — unchanged path: a single report
  goes straight through.
- `test_get_finished_defers_recving_until_the_last_loader` — two loaders produce
  exactly one `finished_recving`.
- `test_get_finished_defers_sending_until_the_last_saver` — same on the save side
  (first coverage of the existing behaviour).
- `test_extra_counts_ship_to_the_worker_once` — both counts ride the connector
  metadata and are cleared after being handed off.

Results: **not yet run locally** — the dev environment for this branch is still
being set up, so the suite has not been executed by the submitter. Kept as a
draft until it has been. Lint is clean (`ruff check`, `ruff format --check`).

No model eval: this changes only when a completion signal is forwarded to the
scheduler, not what is computed or emitted.

## AI assistance

AI assistance (Claude Code) was used to write this change. Every changed line was
reviewed by the submitter, who understands and can defend the change end-to-end.
