### PR TITLE
[RL] Allow custom weight transfer backend

### DIFF
--- a/vllm/config/weight_transfer.py
+++ b/vllm/config/weight_transfer.py
@@ -4,12 +4,16 @@ from typing import Literal
 
 from vllm.config.utils import config
 
+WeightTransferMethods = Literal["nccl", "ipc", "sparse_nccl"]
+
 
 @config
 class WeightTransferConfig:
     """Configuration for weight transfer during RL training."""
 
-    backend: Literal["nccl", "ipc", "sparse_nccl"] | str = "nccl"
-    """The backend to use for weight transfer. Validated against the
-    `WeightTransferEngineFactory` registry at engine creation time.
+    backend: WeightTransferMethods | str = "nccl"
+    """The backend to use for weight transfer. Built-in options are ``"nccl"``,
+    ``"ipc"``, and ``"sparse_nccl"``. Custom backends registered by external
+    plugins are also accepted. Validated against the
+    ``WeightTransferEngineFactory`` registry at engine creation time.
     """


### PR DESCRIPTION



## Purpose
vLLM support register custom  `WeightTransferEngine` and `WeightTransferTrainer` via `register_engine` api. While once the new one is registered, there is no way to use it with vLLM. It because that the input pydantic check fail.

This PR allow pass the custom backend to WeightTransferConfig to fix the bug.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

