### PR TITLE
[LoRA] Fix lm_head delta silently dropped from prompt_logprobs (#51594)

### DIFF
--- a/vllm/lora/model_manager.py
+++ b/vllm/lora/model_manager.py
@@ -726,6 +726,13 @@ class LoRAModelManager:
 
         return None
 
+    def get_lm_punica_wrapper(self) -> PunicaWrapperBase:
+        """Return the punica wrapper for the language model component."""
+        if not self.supports_mm:
+            return self.punica_wrapper_mapping[DEFAULT_LANGUAGE_WRAPPER_KEY]
+        lm_prefix = self.mm_mapping.language_model[0]
+        return self.punica_wrapper_mapping[lm_prefix]
+
     def _register_packed_modules(self, module_full_name: str) -> None:
         parts = module_full_name.split(".")
         module_name = parts[-1]

--- a/vllm/lora/worker_manager.py
+++ b/vllm/lora/worker_manager.py
@@ -201,6 +201,9 @@ class WorkerLoRAManager:
             and self._adapter_manager.supports_tower_connector_lora
         )
 
+    def get_lm_punica_wrapper(self):
+        return self._adapter_manager.get_lm_punica_wrapper()
+
     def _apply_adapters(self, adapter_requests: set[Any]) -> None:
         existing_adapters = self.list_adapters()
         models_map = {

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -5709,6 +5709,17 @@ class GPUModelRunner(
 
         prompt_logprobs_dict: dict[str, LogprobsTensors | None] = {}
 
+        # When LoRA targets lm_head, add_lora_logits uses prompt_mapping_meta
+        # (one entry per sequence). For prompt_logprobs we have one hidden-state
+        # row per prompt token, so the per-sequence mapping is wrong and the
+        # lm_head delta is silently dropped. Cache the wrapper here and swap the
+        # metadata to per-token indices around each compute_logits call.
+        lm_wrapper = None
+        if self.lora_config:
+            lm_wrapper = self.lora_manager.get_lm_punica_wrapper()
+            if not hasattr(lm_wrapper, "prompt_mapping_meta"):
+                lm_wrapper = None
+
         # Since prompt logprobs are a rare feature, prioritize simple,
         # maintainable loop over optimal performance.
         completed_prefill_reqs = []
@@ -5767,7 +5778,18 @@ class GPUModelRunner(
             req_idx = self.input_batch.req_id_to_index[req_id]
             offset = self.query_start_loc.np[req_idx].item()
             prompt_hidden_states = hidden_states[offset : offset + num_logits]
-            logits = self.model.compute_logits(prompt_hidden_states)
+            if lm_wrapper is not None:
+                token_slice = lm_wrapper.token_lora_indices[
+                    offset : offset + num_logits
+                ]
+                lm_wrapper.prompt_mapping_meta.prepare_tensors(token_slice)
+            try:
+                logits = self.model.compute_logits(prompt_hidden_states)
+            finally:
+                if lm_wrapper is not None:
+                    lm_wrapper.prompt_mapping_meta.prepare_tensors(
+                        lm_wrapper.sampler_indices
+                    )
 
             # Get the "target" tokens for each index. For prompt at index i,
             # the token at prompt index i+1 is the "sampled" token we want


### PR DESCRIPTION
## Summary

Fixes #51594.

When a LoRA adapter targets `lm_head`, `prompt_logprobs` silently returns wrong values — the lm_head delta is not applied. Generation logprobs are correct; only the prompt-logprobs path is broken.

**Root cause**: `add_lora_logits` in `punica_gpu.py` uses `prompt_mapping_meta`, which holds one entry per *sequence* (built from `sampler_indices`). But `_get_prompt_logprobs_dict` calls `compute_logits` with one hidden-state row per prompt *token*, so the per-sequence mapping misaligns and the delta is never applied.

**Fix**: Before each `compute_logits` call in the prompt-logprobs loop, temporarily remap `prompt_mapping_meta` to the per-token LoRA indices for the relevant token slice (`token_lora_indices[offset:offset+num_logits]`), then restore it in a `finally` block. A new `get_lm_punica_wrapper()` helper correctly resolves the language-model punica wrapper for both standard and multimodal models — avoiding the `None`-return issue that made a prior attempted fix silently no-op on multimodal models.

**Changes**:
- `vllm/lora/model_manager.py` — add `get_lm_punica_wrapper()` to `LoRAModelManager`
- `vllm/lora/worker_manager.py` — expose via `WorkerLoRAManager`
- `vllm/v1/worker/gpu_model_runner.py` — swap `prompt_mapping_meta` around `compute_logits` in `_get_prompt_logprobs_dict`

## Why this is not a duplicate PR

No existing open PR addresses this. Checked via:
```
gh pr list --repo vllm-project/vllm --state open --search "51594 in:body"
gh pr list --repo vllm-project/vllm --state open --search "prompt_logprobs lora lm_head"
```

## Test plan

- [ ] I do not have access to the required hardware (2× B300, TP=2, LoRA with `lm_head` in `target_modules`). The issue author (@XiaohanZhangCMU) has offered to test candidate patches and has a reproducible setup. Requesting validation of the numbers in the issue (generation logprobs and `prompt_logprobs` should agree, and stripping lm_head tensors from the adapter should change `prompt_logprobs`).
- [ ] All pre-commit hooks (ruff, mypy, typos, SPDX, etc.) pass locally.

## AI assistance

This fix was developed with Claude (claude-sonnet-4-6). All changed lines have been reviewed by the human submitter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)