### PR TITLE
[Bugfix][MRv1] Decouple async Mamba align D2H counts from InputBatch row shifts (#51571)

### DIFF
--- a/tests/v1/worker/test_gpu_model_runner.py
+++ b/tests/v1/worker/test_gpu_model_runner.py
@@ -4,7 +4,7 @@
 import gc
 from contextlib import nullcontext
 from types import SimpleNamespace
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import numpy as np
 import pytest
@@ -1823,3 +1823,107 @@ def test_mamba_cache_raises_when_max_num_seqs_exceeds_blocks():
 
         with pytest.raises(ValueError, match="max_num_seqs"):
             runner.initialize_kv_cache(kv_cache_config)
+
+
+class TestSyncNumAcceptedTokens:
+    """Test GPUModelRunner._sync_num_accepted_tokens() behavior
+    for async and non-async modes."""
+
+    def test_async_mamba_align_accepted_counts_race(self):
+        num_reqs = 3
+        runner = Mock(spec=GPUModelRunner)
+        runner.use_async_scheduling = True
+        runner.num_accepted_tokens = SimpleNamespace(
+            np=np.array([4, 3, 2, 0, 0], dtype=np.int32),
+        )
+        runner.input_batch = SimpleNamespace(
+            num_accepted_tokens_cpu=np.array([9, 9, 9, 0, 0], dtype=np.int32)
+        )
+        runner.prev_positions = SimpleNamespace(np=np.array([0, 2, -1], dtype=np.int32))
+
+        GPUModelRunner._sync_num_accepted_tokens(
+            runner, num_reqs, {"req_a": 0, "req_c": 2}
+        )
+        expected = np.array([4, 2, 1], dtype=np.int32)
+        np.testing.assert_array_equal(
+            runner.num_accepted_tokens.np[:num_reqs], expected
+        )
+        np.testing.assert_array_equal(
+            runner.input_batch.num_accepted_tokens_cpu[:num_reqs], expected
+        )
+
+    def test_async_initial_step_empty_prev_index(self):
+        num_reqs = 2
+        runner = Mock(spec=GPUModelRunner)
+        runner.use_async_scheduling = True
+        runner.num_accepted_tokens = SimpleNamespace(np=np.zeros(5, dtype=np.int32))
+        runner.input_batch = SimpleNamespace(
+            num_accepted_tokens_cpu=np.zeros(5, dtype=np.int32)
+        )
+
+        GPUModelRunner._sync_num_accepted_tokens(runner, num_reqs, {})
+        expected = np.array([1, 1], dtype=np.int32)
+        np.testing.assert_array_equal(
+            runner.num_accepted_tokens.np[:num_reqs], expected
+        )
+        np.testing.assert_array_equal(
+            runner.input_batch.num_accepted_tokens_cpu[:num_reqs], expected
+        )
+
+    def test_non_async_mode_direct_copy(self):
+        num_reqs = 2
+        runner = Mock(spec=GPUModelRunner)
+        runner.use_async_scheduling = False
+        runner.num_accepted_tokens = SimpleNamespace(
+            np=np.array([5, 4, 0, 0, 0], dtype=np.int32)
+        )
+        runner.input_batch = SimpleNamespace(
+            num_accepted_tokens_cpu=np.zeros(5, dtype=np.int32)
+        )
+
+        GPUModelRunner._sync_num_accepted_tokens(runner, num_reqs, None)
+        expected = np.array([5, 4], dtype=np.int32)
+        np.testing.assert_array_equal(
+            runner.num_accepted_tokens.np[:num_reqs], expected
+        )
+        np.testing.assert_array_equal(
+            runner.input_batch.num_accepted_tokens_cpu[:num_reqs], expected
+        )
+
+    @patch("vllm.v1.worker.gpu_model_runner.mamba_utils.postprocess_mamba_align_gpu")
+    def test_d2h_target_is_runner_buffer(self, mock_postprocess):
+        """Verify _update_states_after_model_execute passes
+        runner.num_accepted_tokens.cpu to postprocess_mamba_align_gpu
+        instead of input_batch's tensor.
+        """
+        runner = Mock(spec=GPUModelRunner)
+        runner.speculative_config = Mock()
+        runner.model_config = SimpleNamespace(is_hybrid=True)
+        runner.cache_config = SimpleNamespace(mamba_cache_mode="align")
+        runner.num_accepted_tokens = SimpleNamespace(
+            cpu=Mock(), gpu=torch.zeros(5, dtype=torch.int64)
+        )
+        runner.input_batch = SimpleNamespace(num_accepted_tokens_cpu_tensor=Mock())
+        runner._get_mamba_bufs = Mock(return_value=Mock())
+        runner.kv_cache_config = Mock()
+        runner.compilation_config = SimpleNamespace(static_forward_context=Mock())
+        runner.model = SimpleNamespace(
+            get_mamba_state_copy_func=Mock(return_value=Mock())
+        )
+        runner.num_accepted_tokens_event = Mock()
+
+        GPUModelRunner._update_states_after_model_execute(
+            runner,
+            output_token_ids=torch.tensor([[1, 2, -1], [1, -1, -1]]),
+            scheduler_output=Mock(),
+        )
+
+        mock_postprocess.assert_called_once()
+        _, kwargs = mock_postprocess.call_args
+        assert (
+            kwargs["num_accepted_tokens_cpu_tensor"] is runner.num_accepted_tokens.cpu
+        )
+        assert (
+            kwargs["num_accepted_tokens_cpu_tensor"]
+            is not runner.input_batch.num_accepted_tokens_cpu_tensor
+        )

--- a/tests/v1/worker/test_gpu_model_runner.py
+++ b/tests/v1/worker/test_gpu_model_runner.py
@@ -1830,6 +1830,7 @@ class TestSyncNumAcceptedTokens:
     for async and non-async modes."""
 
     def test_async_mamba_align_accepted_counts_race(self):
+        """Verify async mode remaps accepted counts when row indices shift."""
         num_reqs = 3
         runner = Mock(spec=GPUModelRunner)
         runner.use_async_scheduling = True
@@ -1853,6 +1854,7 @@ class TestSyncNumAcceptedTokens:
         )
 
     def test_async_initial_step_empty_prev_index(self):
+        """Verify async mode defaults counts to 1 on initial step with empty index."""
         num_reqs = 2
         runner = Mock(spec=GPUModelRunner)
         runner.use_async_scheduling = True
@@ -1871,6 +1873,7 @@ class TestSyncNumAcceptedTokens:
         )
 
     def test_non_async_mode_direct_copy(self):
+        """Verify non-async mode directly writes back accepted counts 1:1."""
         num_reqs = 2
         runner = Mock(spec=GPUModelRunner)
         runner.use_async_scheduling = False
@@ -1929,6 +1932,9 @@ class TestSyncNumAcceptedTokens:
         )
 
     def test_d2h_target_is_runner_buffer_non_align(self):
+        """Verify non-align mode D2H copy targets runner.num_accepted_tokens.cpu
+        rather than input_batch's tensor.
+        """
         runner = Mock(spec=GPUModelRunner)
         runner.speculative_config = Mock()
         runner.model_config = SimpleNamespace(is_hybrid=True)

--- a/tests/v1/worker/test_gpu_model_runner.py
+++ b/tests/v1/worker/test_gpu_model_runner.py
@@ -1927,3 +1927,34 @@ class TestSyncNumAcceptedTokens:
             kwargs["num_accepted_tokens_cpu_tensor"]
             is not runner.input_batch.num_accepted_tokens_cpu_tensor
         )
+
+    def test_d2h_target_is_runner_buffer_non_align(self):
+        runner = Mock(spec=GPUModelRunner)
+        runner.speculative_config = Mock()
+        runner.model_config = SimpleNamespace(is_hybrid=True)
+        runner.cache_config = SimpleNamespace(mamba_cache_mode="none")
+        runner.num_accepted_tokens = SimpleNamespace(
+            cpu=torch.zeros(5, dtype=torch.int32),
+            gpu=torch.zeros(5, dtype=torch.int32),
+        )
+        runner.input_batch = SimpleNamespace(
+            num_accepted_tokens_cpu_tensor=torch.zeros(5, dtype=torch.int32)
+        )
+        runner.kv_cache_config = Mock()
+        runner.num_accepted_tokens_event = Mock()
+
+        GPUModelRunner._update_states_after_model_execute(
+            runner,
+            output_token_ids=torch.tensor([[1, 2, -1], [1, -1, -1]]),
+            scheduler_output=Mock(),
+        )
+
+        assert runner.num_accepted_tokens_event.record.called
+        torch.testing.assert_close(
+            runner.num_accepted_tokens.cpu[:2],
+            torch.tensor([2, 1], dtype=torch.int32),
+        )
+        torch.testing.assert_close(
+            runner.input_batch.num_accepted_tokens_cpu_tensor[:2],
+            torch.tensor([0, 0], dtype=torch.int32),
+        )

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1606,9 +1606,7 @@ class GPUModelRunner(
                 bufs=self._get_mamba_bufs(),
                 num_reqs=num_reqs,
                 num_accepted_tokens_gpu=self.num_accepted_tokens.gpu,
-                num_accepted_tokens_cpu_tensor=(
-                    self.input_batch.num_accepted_tokens_cpu_tensor
-                ),
+                num_accepted_tokens_cpu_tensor=self.num_accepted_tokens.cpu,
                 input_batch=self.input_batch,
                 kv_cache_config=self.kv_cache_config,
                 forward_context=self.compilation_config.static_forward_context,
@@ -1974,6 +1972,31 @@ class GPUModelRunner(
 
         return encoder_seq_lens, encoder_seq_lens_cpu
 
+    def _sync_num_accepted_tokens(
+        self, num_reqs: int, prev_req_id_to_index: dict[str, int] | None
+    ) -> None:
+        if self.use_async_scheduling:
+            if prev_req_id_to_index:
+                # Remap the previous-iteration runner snapshot through prev_positions.
+                prev_idx = self.prev_positions.np[:num_reqs]
+                new_mask = prev_idx < 0
+                self.num_accepted_tokens.np[:num_reqs] = self.num_accepted_tokens.np[
+                    np.where(new_mask, 0, prev_idx)
+                ]
+                self.num_accepted_tokens.np[:num_reqs][new_mask] = 1
+                self.input_batch.num_accepted_tokens_cpu[:num_reqs] = (
+                    self.num_accepted_tokens.np[:num_reqs]
+                )
+            else:
+                # Initial step or all-chunked-prefill step
+                self.num_accepted_tokens.np[:num_reqs].fill(1)
+                self.input_batch.num_accepted_tokens_cpu[:num_reqs].fill(1)
+        else:
+            # Non-async mode: write back 1:1 to input_batch
+            self.input_batch.num_accepted_tokens_cpu[:num_reqs] = (
+                self.num_accepted_tokens.np[:num_reqs]
+            )
+
     def _prepare_inputs(
         self,
         scheduler_output: "SchedulerOutput",
@@ -2132,24 +2155,7 @@ class GPUModelRunner(
         if needs_cpu_accepted_counts:
             assert self.num_accepted_tokens_event is not None
             self.num_accepted_tokens_event.synchronize()
-            # Async mode: condense() reordered indices, use prev_positions mapping
-            if self.use_async_scheduling and prev_req_id_to_index:
-                prev_idx = self.prev_positions.np[:num_reqs]
-                new_mask = prev_idx < 0
-                self.num_accepted_tokens.np[:num_reqs] = (
-                    self.input_batch.num_accepted_tokens_cpu[
-                        np.where(new_mask, 0, prev_idx)
-                    ]
-                )
-                self.num_accepted_tokens.np[:num_reqs][new_mask] = 1
-                self.input_batch.num_accepted_tokens_cpu[:num_reqs] = (
-                    self.num_accepted_tokens.np[:num_reqs]
-                )
-            else:
-                # Non-async mode: use values directly
-                self.num_accepted_tokens.np[:num_reqs] = (
-                    self.input_batch.num_accepted_tokens_cpu[:num_reqs]
-                )
+            self._sync_num_accepted_tokens(num_reqs, prev_req_id_to_index)
             self.num_accepted_tokens.np[num_reqs:].fill(1)
             self.num_accepted_tokens.copy_to_gpu()
         else:

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1616,7 +1616,7 @@ class GPUModelRunner(
             assert self.num_accepted_tokens_event is not None
             self.num_accepted_tokens_event.record()
         else:
-            self.input_batch.num_accepted_tokens_cpu_tensor[:num_reqs].copy_(
+            self.num_accepted_tokens.cpu[:num_reqs].copy_(
                 self.num_accepted_tokens.gpu[:num_reqs], non_blocking=True
             )
             assert self.num_accepted_tokens_event is not None

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1975,6 +1975,12 @@ class GPUModelRunner(
     def _sync_num_accepted_tokens(
         self, num_reqs: int, prev_req_id_to_index: dict[str, int] | None
     ) -> None:
+        """Synchronize and remap accepted token counts into input_batch.
+
+        In async scheduling mode, remaps counts from runner.num_accepted_tokens.np
+        through prev_positions to account for row shifts from InputBatch.condense().
+        In sync mode, performs a direct write-back to input_batch.
+        """
         if self.use_async_scheduling:
             if prev_req_id_to_index:
                 # Remap the previous-iteration runner snapshot through prev_positions.


### PR DESCRIPTION
### Target Issue
Closes #51571

### Description
When running speculative decoding / MTP with `use_async_scheduling=True`, `GPUModelRunner._update_states_after_model_execute()` was passing `input_batch.num_accepted_tokens_cpu_tensor` directly as the D2H copy target (both in `postprocess_mamba_align_gpu()` for `align` mode and in the non-align D2H `copy_()`).

While the non-blocking D2H copy is in flight on the CUDA stream, the CPU thread prepares the next step and calls `InputBatch.condense()`. This compacts finished requests and shifts row indices in `input_batch` *before* `num_accepted_tokens_event` is synchronized in `_prepare_inputs()`. When `_prepare_inputs()` later gathers from `input_batch.num_accepted_tokens_cpu`, it reads shifted/corrupted counts, causing Mamba hidden state copy offsets to misalign for shifted requests.

To fix this race hazard and ensure `input_batch` is never an asynchronous DMA target:

1. **Unconditional D2H target isolation:** In both `align` mode (`postprocess_mamba_align_gpu`) and non-align mode (`else:` branch copy_), the D2H transfer targets `self.num_accepted_tokens.cpu` unconditionally, isolating `input_batch` host memory from in-flight CUDA stream transfers.
2. **Synchronized remapping & write-back:** `_sync_num_accepted_tokens()` handles both modes after `num_accepted_tokens_event` synchronization:
   - In async mode, it remaps historical counts from `self.num_accepted_tokens.np` through `prev_positions` and populates `input_batch.num_accepted_tokens_cpu`.
   - In sync mode, it writes back `self.num_accepted_tokens.np` 1:1 into `input_batch.num_accepted_tokens_cpu`.
3. **Empty `prev_req_id_to_index` handling:** When `prev_req_id_to_index` is empty (on initial steps or all-chunked-prefill steps where all previous requests were discarded), counts default to `1` (`accept_token_bias = 0`), avoiding invalid reads from host buffers.
4. **Unit test suite:** 5 unit tests in `TestSyncNumAcceptedTokens` in `tests/v1/worker/test_gpu_model_runner.py` covering async remapping, empty prev-index fallback, sync mode direct write-back, align D2H target isolation, and non-align D2H target isolation.

### Test Plan
- Unit tests: `pytest tests/v1/worker/test_gpu_model_runner.py -k TestSyncNumAcceptedTokens` (5/5 passed).
- Verification: Tested host buffer coherency against late DMA arrivals; verified on RTX 5090 and A100.
- Formatting & Lint: `ruff check` and `ruff format --check` (clean).
 
---
*AI assistance was used for code inspection, unit test setup, and documentation for this PR.*