### PR TITLE
[V1][Scheduler] Apply Mamba alignment before encoder caps

### DIFF
--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -3610,6 +3610,59 @@ def test_scheduler_no_ec_connector_by_default():
     assert scheduler.ec_connector is None
 
 
+def test_mamba_align_encoder_cache_cap_makes_progress():
+    """Two individually cacheable images must not deadlock Mamba alignment."""
+    block_size = 768
+    encoder_cache_size = 600
+    scheduler = create_scheduler(
+        max_num_batched_tokens=8192,
+        block_size=block_size,
+        enable_prefix_caching=True,
+    )
+    scheduler.need_mamba_block_aligned_split = True
+    scheduler.max_num_encoder_input_tokens = encoder_cache_size
+    scheduler.encoder_cache_manager = EncoderCacheManager(cache_size=encoder_cache_size)
+
+    first_image_end = 510
+    request = create_requests(
+        num_requests=1,
+        num_tokens=1010,
+        mm_positions=[
+            [
+                PlaceholderRange(offset=0, length=500),
+                PlaceholderRange(offset=first_image_end, length=500),
+            ]
+        ],
+        max_tokens=1,
+        block_size=block_size,
+        req_ids=["req"],
+    )[0]
+    scheduler.add_request(request)
+
+    output = scheduler.schedule()
+    assert output.num_scheduled_tokens[request.request_id] == first_image_end
+    assert output.scheduled_encoder_inputs[request.request_id] == [0]
+
+    scheduler.update_from_output(
+        output,
+        ModelRunnerOutput(
+            req_ids=[request.request_id],
+            req_id_to_index={request.request_id: 0},
+            sampled_token_ids=[[]],
+            logprobs=None,
+            prompt_logprobs_dict={},
+            pooler_output=[],
+        ),
+    )
+
+    output = scheduler.schedule()
+    next_block_boundary = block_size
+    assert output.num_scheduled_tokens[request.request_id] == (
+        next_block_boundary - first_image_end
+    )
+    assert output.scheduled_encoder_inputs[request.request_id] == [1]
+
+
 @pytest.mark.parametrize("use_kv_connector", [False, True])
 def test_ec_connector_text_only_request(use_kv_connector):
     """Test text-only requests don't allocate encoder cache."""

--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -3663,6 +3663,36 @@ def test_mamba_align_encoder_cache_cap_makes_progress():
     assert output.scheduled_encoder_inputs[request.request_id] == [1]
 
 
+def test_mamba_align_eagle_schedules_encoder_at_boundary():
+    """EAGLE lookahead at an aligned MM boundary requires encoder cache."""
+    block_size = 512
+    scheduler = create_scheduler(
+        max_num_batched_tokens=700,
+        max_model_len=2048,
+        block_size=block_size,
+        enable_prefix_caching=True,
+    )
+    scheduler.need_mamba_block_aligned_split = True
+    scheduler.use_eagle = True
+    scheduler.max_num_encoder_input_tokens = 2048
+    scheduler.encoder_cache_manager = EncoderCacheManager(cache_size=2048)
+
+    request = create_requests(
+        num_requests=1,
+        num_tokens=1200,
+        mm_positions=[[PlaceholderRange(offset=block_size, length=100)]],
+        max_tokens=1,
+        block_size=block_size,
+        req_ids=["req"],
+    )[0]
+    scheduler.add_request(request)
+
+    output = scheduler.schedule()
+
+    assert output.num_scheduled_tokens[request.request_id] == block_size
+    assert output.scheduled_encoder_inputs[request.request_id] == [0]
+
+
 @pytest.mark.parametrize("use_kv_connector", [False, True])
 def test_ec_connector_text_only_request(use_kv_connector):
     """Test text-only requests don't allocate encoder cache."""

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1502,10 +1502,13 @@ class Scheduler(SchedulerInterface):
         mm_hashes_to_schedule = set()
         num_embeds_to_schedule = 0
 
+        encoder_window_end = (
+            num_computed_tokens + num_new_tokens + shift_computed_tokens
+        )
         lo, hi = get_mm_features_in_window(
             mm_features,
             start=num_computed_tokens,
-            end=num_computed_tokens + num_new_tokens + shift_computed_tokens,
+            end=encoder_window_end,
         )
         # For encoder-decoder, all inputs sit at start_pos=0, so lo=0 always.
         if self.is_encoder_decoder:
@@ -1587,9 +1590,7 @@ class Scheduler(SchedulerInterface):
             # Calculate the number of embeddings to schedule in the current range
             # of scheduled encoder placeholder tokens.
             start_idx_rel = max(0, num_computed_tokens - start_pos)
-            end_idx_rel = min(
-                num_encoder_tokens, num_computed_tokens + num_new_tokens - start_pos
-            )
+            end_idx_rel = min(num_encoder_tokens, encoder_window_end - start_pos)
             curr_embeds_start, curr_embeds_end = (
                 mm_feature.mm_position.get_embeds_indices_in_range(
                     start_idx_rel, end_idx_rel

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -530,6 +530,12 @@ class Scheduler(SchedulerInterface):
                 - self.num_sampled_tokens_per_step,
             )
 
+            # Apply Mamba alignment before encoder caps.
+            if self.need_mamba_block_aligned_split:
+                num_new_tokens = self._mamba_block_aligned_split(
+                    request, num_new_tokens
+                )
+
             # Schedule encoder inputs.
             encoder_inputs_to_schedule = None
             external_load_encoder_input: list[int] = []
@@ -546,11 +552,6 @@ class Scheduler(SchedulerInterface):
                     num_new_tokens,
                     encoder_compute_budget,
                     shift_computed_tokens=1 if self.use_eagle else 0,
-                )
-
-            if self.need_mamba_block_aligned_split:
-                num_new_tokens = self._mamba_block_aligned_split(
-                    request, num_new_tokens
                 )
 
             if num_new_tokens == 0:
@@ -906,6 +907,17 @@ class Scheduler(SchedulerInterface):
                     num_new_tokens = min(num_new_tokens, token_budget)
                     assert num_new_tokens > 0
 
+                    # Apply Mamba alignment before encoder caps.
+                    if self.need_mamba_block_aligned_split:
+                        num_new_tokens = self._mamba_block_aligned_split(
+                            request,
+                            num_new_tokens,
+                            num_new_local_computed_tokens,
+                            num_external_computed_tokens,
+                        )
+                        if num_new_tokens == 0:
+                            break
+
                     # Schedule encoder inputs.
                     if request.has_encoder_inputs:
                         (
@@ -923,17 +935,6 @@ class Scheduler(SchedulerInterface):
                         if num_new_tokens == 0:
                             # The request cannot be scheduled.
                             break
-
-                # Skip block alignment when setting up async receive (no local work).
-                if self.need_mamba_block_aligned_split and not load_kv_async:
-                    num_new_tokens = self._mamba_block_aligned_split(
-                        request,
-                        num_new_tokens,
-                        num_new_local_computed_tokens,
-                        num_external_computed_tokens,
-                    )
-                    if num_new_tokens == 0:
-                        break
 
                 # During async KV load, no forward pass is run yet.
                 # Allocate speculative lookahead slots later to avoid


### PR DESCRIPTION
## Summary

- Apply Mamba block alignment before multimodal encoder scheduling can cap a prefill chunk.
- Use EAGLE's shifted encoder window consistently when calculating the overlapping embedding range.
- Preserve the existing align-mode policy that waits for a fresh scheduler budget when a complete Mamba block normally fits in one step.
- Add a scheduler-level regression for two images that each fit the encoder cache individually but do not fit together.

## Root cause

Encoder scheduling could repeatedly truncate a chunk to the next multimodal item's start position before Mamba alignment ran. When that encoder boundary was inside a Mamba block, alignment floored the chunk back to zero. The same encoder cap was then reapplied on every scheduler step, so the request never advanced.

Choosing the Mamba endpoint first lets encoder scheduling safely shorten it when cache pressure requires. The request makes private sub-block progress to the encoder boundary, then the next scheduler step stops at `next_block_boundary` and restores Mamba alignment.

## Concrete failure example

Assume:

- Mamba block size: 8 tokens.
- Scheduler prefill budget: at least 8 tokens, so a full Mamba block normally fits.
- Encoder cache capacity: 6 embeddings.
- Image A occupies prompt positions `[0, 5)` and image B occupies `[6, 11)`, with one text token between them.
- Each image needs 5 encoder-cache slots, so either image fits by itself, but both need 10 slots and cannot coexist.

Before this change:

1. The scheduler proposes all 11 prompt tokens.
2. Encoder scheduling admits image A, cannot admit image B while A is resident, and caps the chunk at B's start: `11 -> 6`.
3. Mamba alignment floors endpoint 6 to the previous block boundary: `6 -> 0`.
4. The scheduler runs 0 tokens. No state changes, so every later step repeats `11 -> 6 -> 0` and the request livelocks.

After this change:

1. Mamba alignment selects endpoint 8 first.
2. Encoder scheduling applies the same cache constraint afterward and shortens it to 6: `11 -> 8 -> 6`.
3. The scheduler advances 6 tokens, allowing image A's cache entry to be released.
4. The next step starts inside the Mamba block at position 6, advances 2 tokens to boundary 8, and schedules image B. Alignment is restored without weakening the normal full-block budget policy.

## Existing PRs

This addresses the same user-visible deadlock as #47771, #40757, and #40709, but uses a materially different scheduling rule. Those PRs preserve a sub-block chunk whenever alignment would produce zero. This PR leaves `_mamba_block_aligned_split` semantics unchanged and instead applies encoder caps after alignment, so `test_mamba_align_split_when_block_exceeds_scheduling_budget` continues to enforce waiting for a fresh budget when a full Mamba block normally fits.

Akshat Anand, the author of #47771, is credited as a co-author for the encoder-cache contention reproducer and prior investigation.

Fixes #47738.

## Validation

- `source .venv/bin/activate && python -m pytest tests/v1/core/test_scheduler.py tests/v1/core/test_prefix_caching.py tests/v1/core/prefix_cache -q` — 266 passed.
- `source .venv/bin/activate && python -m pytest tests/v1/core/test_scheduler.py::test_mamba_align_eagle_schedules_encoder_at_boundary tests/v1/core/test_scheduler.py::test_eagle3_mm_encoder_cache_with_shift tests/v1/core/test_scheduler.py::test_mamba_align_encoder_cache_cap_makes_progress tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py::test_mamba_align_split_when_block_exceeds_scheduling_budget -q` — 4 passed.
- All staged-file pre-commit hooks passed, including Ruff, formatting, typos, mypy, and SPDX checks.

Model evaluation was not run because this changes scheduler liveness and chunk boundaries, not model output or accuracy semantics; the scheduler and prefix-cache regression suites cover the affected behavior.

## AI assistance

OpenAI Codex was used to investigate the scheduler interaction, port the change, and run validation. The human maintainer reviewed the changed lines, scheduling rationale, and test results.