### PR TITLE
[ROCm][K3] Enable fp8 KV cache with DSpark speculative decoding and code-reorg

### DIFF
--- a/vllm/model_executor/models/registry.py
+++ b/vllm/model_executor/models/registry.py
@@ -621,10 +621,7 @@ _SPECULATIVE_DECODING_MODELS = {
     "DFlashDraftModel": ("qwen3_dflash", "DFlashQwen3ForCausalLM"),
     "DSparkDraftModel": ("vllm.models.deepseek_v4", "DSparkDeepseekV4ForCausalLM"),
     "Qwen3DSparkModel": ("qwen3_dspark", "Qwen3DSparkForCausalLM"),
-    "K3DSparkModel": (
-        "vllm.models.kimi_k3.nvidia.dspark_mla",
-        "K3DSparkForCausalLM",
-    ),
+    "K3DSparkModel": ("vllm.models.kimi_k3", "K3DSparkForCausalLM"),
     "DFlashLagunaForCausalLM": ("laguna_dflash", "DFlashLagunaForCausalLM"),
     "Gemma4DSparkModel": ("gemma4_dspark", "Gemma4DSparkForCausalLM"),
     "PEagleDraftModel": ("llama_eagle3", "Eagle3LlamaForCausalLM"),

--- a/vllm/models/kimi_k3/__init__.py
+++ b/vllm/models/kimi_k3/__init__.py
@@ -14,14 +14,17 @@ from vllm.platforms import current_platform
 # The NVIDIA branch is the static default that type-checkers see; the ROCm
 # branch overrides it at runtime (kept type-compatible via type: ignore).
 if TYPE_CHECKING or not current_platform.is_rocm():
+    from .nvidia.dspark_mla import K3DSparkForCausalLM
     from .nvidia.model import KimiK3ForConditionalGeneration, KimiLinearForCausalLM
     from .nvidia.mtp import KimiK3MTP
 else:
+    from .amd.dspark_mla import K3DSparkForCausalLM  # type: ignore[assignment]
     from .amd.linear import KimiLinearForCausalLM  # type: ignore[assignment]
     from .amd.model import KimiK3ForConditionalGeneration  # type: ignore[assignment]
     from .amd.mtp import KimiK3MTP  # type: ignore[assignment]
 
 __all__ = [
+    "K3DSparkForCausalLM",
     "KimiK3ForConditionalGeneration",
     "KimiK3MTP",
     "KimiLinearForCausalLM",

--- a/vllm/models/kimi_k3/amd/dspark_mla.py
+++ b/vllm/models/kimi_k3/amd/dspark_mla.py
@@ -1,0 +1,526 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""K3 dense MLA draft model for DSpark speculative decoding (ROCm).
+
+Duplicated from ``nvidia/dspark_mla.py``; uses the ROCm ``amd/mla.py``
+MultiHeadLatentAttention (fp8-KV query-dequant fallback for the
+TRITON_MLA draft backend) and the amd KimiMLP.
+"""
+
+from collections.abc import Iterable
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+import vllm._custom_ops as ops
+from vllm.config import VllmConfig
+from vllm.model_executor.layers.layernorm import RMSNorm
+from vllm.model_executor.layers.linear import ReplicatedLinear
+from vllm.model_executor.layers.logits_processor import LogitsProcessor
+from vllm.model_executor.models.qwen3_dspark import DSparkMarkovHead
+from vllm.model_executor.models.utils import (
+    AutoWeightsLoader,
+    WeightsMapper,
+    get_draft_quant_config,
+    maybe_prefix,
+)
+from vllm.models.common.ops.fused_allreduce_rms_norm import fused_allreduce_rms_norm
+from vllm.models.kimi_k3.amd.linear import KimiMLP
+from vllm.models.kimi_k3.amd.mla import MultiHeadLatentAttention
+from vllm.utils.torch_utils import is_quantized_kv_cache
+
+
+class K3DSparkDecoderLayer(nn.Module):
+    def __init__(
+        self,
+        *,
+        vllm_config: VllmConfig,
+        config,
+        layer_idx: int,
+        start_layer_id: int,
+        prefix: str,
+    ) -> None:
+        super().__init__()
+        quant_config = get_draft_quant_config(vllm_config)
+        self.self_attn = MultiHeadLatentAttention(
+            config=config,
+            hidden_size=config.hidden_size,
+            num_heads=config.num_attention_heads,
+            qk_nope_head_dim=config.qk_nope_head_dim,
+            qk_rope_head_dim=config.qk_rope_head_dim,
+            v_head_dim=config.v_head_dim,
+            q_lora_rank=config.q_lora_rank,
+            kv_lora_rank=config.kv_lora_rank,
+            cache_config=vllm_config.cache_config,
+            quant_config=quant_config,
+            prefix=maybe_prefix(
+                prefix, f"layers.{start_layer_id + layer_idx}.self_attn"
+            ),
+            use_rope=True,
+            non_causal_multi_token_decode=True,
+        )
+        # Both row-parallel outputs stay un-reduced; their all-reduces are fused
+        # into the RMSNorm that follows via fused_allreduce_rms_norm.
+        self.self_attn.o_proj.reduce_results = False
+        self.mlp = KimiMLP(
+            hidden_size=config.hidden_size,
+            intermediate_size=config.intermediate_size,
+            hidden_act=config.hidden_act,
+            quant_config=quant_config,
+            reduce_results=False,
+            prefix=maybe_prefix(prefix, f"layers.{start_layer_id + layer_idx}.mlp"),
+        )
+        self.input_layernorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.post_attention_layernorm = RMSNorm(
+            config.hidden_size, eps=config.rms_norm_eps
+        )
+
+    def forward(
+        self,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        residual: torch.Tensor | None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if residual is None:
+            # First layer: hidden_states is the (already reduced) embedding.
+            residual = hidden_states
+            hidden_states = self.input_layernorm(hidden_states)
+        else:
+            hidden_states, residual = fused_allreduce_rms_norm(
+                hidden_states, residual, self.input_layernorm
+            )
+
+        hidden_states = self.self_attn(
+            positions=positions,
+            hidden_states=hidden_states,
+        )
+        hidden_states, residual = fused_allreduce_rms_norm(
+            hidden_states, residual, self.post_attention_layernorm
+        )
+        # The MLP output is reduced by the next layer's input_layernorm (or by
+        # the model's final_norm).
+        hidden_states = self.mlp(hidden_states)
+        return hidden_states, residual
+
+
+class K3DSparkModel(nn.Module):
+    def __init__(
+        self,
+        *,
+        vllm_config: VllmConfig,
+        start_layer_id: int,
+        prefix: str,
+    ) -> None:
+        super().__init__()
+        assert vllm_config.speculative_config is not None
+        self.config = vllm_config.speculative_config.draft_model_config.hf_config
+        self.quant_config = get_draft_quant_config(vllm_config)
+
+        # The frozen target embedding is aliased after the draft checkpoint loads.
+        self.embed_tokens: nn.Module | None = None
+
+        self.context_proj = ReplicatedLinear(
+            self.config.target_hidden_size * self.config.num_target_layers,
+            self.config.hidden_size,
+            bias=False,
+            return_bias=False,
+            quant_config=self.quant_config,
+            prefix=maybe_prefix(prefix, "context_proj"),
+        )
+        self.context_norm = RMSNorm(
+            self.config.hidden_size, eps=self.config.rms_norm_eps
+        )
+
+        self.layers = nn.ModuleList(
+            [
+                K3DSparkDecoderLayer(
+                    vllm_config=vllm_config,
+                    config=self.config,
+                    layer_idx=layer_idx,
+                    start_layer_id=start_layer_id,
+                    prefix=prefix,
+                )
+                for layer_idx in range(self.config.num_hidden_layers)
+            ]
+        )
+        self.final_norm = RMSNorm(self.config.hidden_size, eps=self.config.rms_norm_eps)
+        self.markov_head = DSparkMarkovHead(
+            self.config.vocab_size,
+            self.config.draft_vocab_size,
+            self.config.markov_rank,
+            prefix=maybe_prefix(prefix, "markov_head"),
+        )
+        self._context_kv_fusion_available: bool | None = None
+        self._max_num_context_tokens = (
+            vllm_config.scheduler_config.max_num_batched_tokens
+        )
+
+    def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
+        assert self.embed_tokens is not None
+        return self.embed_tokens(input_ids)
+
+    def combine_hidden_states(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        return self.context_norm(self.context_proj(hidden_states))
+
+    @torch.inference_mode()
+    def precompute_and_store_context_kv(
+        self,
+        context_states: torch.Tensor,
+        context_positions: torch.Tensor,
+        context_slot_mapping: torch.Tensor | list[torch.Tensor | None] | None = None,
+    ) -> None:
+        """Project target-derived context into each draft layer's latent cache."""
+        if self._context_kv_fusion_available is None:
+            self._build_fused_context_kv_buffers()
+        if self._context_kv_fusion_available:
+            self._precompute_fused_context_kv(
+                context_states, context_positions, context_slot_mapping
+            )
+            return
+
+        # Quantized fallback. Directly invoking the projection modules preserves
+        # their quantization methods, at the cost of also computing unused Q rows.
+        for layer_idx, layer in enumerate(self.layers):
+            attn = layer.self_attn
+            assert attn.fused_qkv_a_proj is not None
+            assert attn.q_lora_rank is not None
+            assert attn.rotary_emb is not None
+            qkv_lora = attn.fused_qkv_a_proj(context_states)[0]
+            kv_lora = qkv_lora[..., attn.q_lora_rank :]
+            kv_c, k_pe = kv_lora.split(
+                [attn.kv_lora_rank, attn.qk_rope_head_dim], dim=-1
+            )
+            kv_c = attn.kv_a_layernorm(kv_c)
+            k_pe = k_pe.unsqueeze(1)
+            # DeepSeek YaRN's FlashInfer path requires paired Q/K tensors.
+            # The vLLM CUDA op supports rotating one tensor in place and
+            # consumes the same (possibly scaled fp32) cos/sin cache.
+            rotary_emb = attn.rotary_emb
+            ops.rotary_embedding(
+                context_positions,
+                k_pe,
+                None,
+                rotary_emb.head_size,
+                rotary_emb.cos_sin_cache,
+                rotary_emb.is_neox_style,
+            )
+
+            slot_mapping = (
+                context_slot_mapping[layer_idx]
+                if isinstance(context_slot_mapping, (list, tuple))
+                else context_slot_mapping
+            )
+            if slot_mapping is None:
+                continue
+            attn.impl.do_kv_cache_update(
+                kv_c,
+                k_pe,
+                attn.kv_cache,
+                slot_mapping,
+                attn.kv_cache_dtype,
+                attn._k_scale,
+            )
+
+    def _build_fused_context_kv_buffers(self) -> None:
+        """Build a cross-layer KV-only A projection after checkpoint loading."""
+        if self.quant_config is not None:
+            self._context_kv_fusion_available = False
+            return
+
+        attentions = [layer.self_attn for layer in self.layers]
+        if not attentions or any(
+            attn.fused_qkv_a_proj is None
+            or not hasattr(attn.fused_qkv_a_proj, "weight")
+            for attn in attentions
+        ):
+            self._context_kv_fusion_available = False
+            return
+
+        attn0 = attentions[0]
+        assert attn0.q_lora_rank is not None
+        kv_width = attn0.kv_lora_rank + attn0.qk_rope_head_dim
+        kv_weights = []
+        for attn in attentions:
+            assert attn.q_lora_rank is not None
+            assert (
+                attn.q_lora_rank == attn0.q_lora_rank
+                and attn.kv_lora_rank == attn0.kv_lora_rank
+                and attn.qk_rope_head_dim == attn0.qk_rope_head_dim
+                and attn.kv_a_layernorm.variance_epsilon
+                == attn0.kv_a_layernorm.variance_epsilon
+            ), "All MLA DSpark layers must share their latent KV geometry."
+            kv_weights.append(
+                attn.fused_qkv_a_proj.weight.detach().narrow(
+                    0, attn.q_lora_rank, kv_width
+                )
+            )
+
+        # [L * (kv_lora_rank + rope_dim), hidden_size]. The underlying fused
+        # A weights are replicated (`disable_tp=True`), so this is valid on
+        # every TP rank without communication.
+        self._fused_context_kv_weight = torch.cat(kv_weights, dim=0)
+        self._context_kv_norm_weights = torch.stack(
+            [attn.kv_a_layernorm.weight.detach() for attn in attentions], dim=0
+        ).contiguous()
+        self._num_context_layers = len(attentions)
+        self._context_kv_width = kv_width
+        self._context_kv_lora_rank = attn0.kv_lora_rank
+        self._context_rope_dim = attn0.qk_rope_head_dim
+        self._context_rms_norm_eps = attn0.kv_a_layernorm.variance_epsilon
+        self._context_positions_repeated = torch.empty(
+            self._num_context_layers * self._max_num_context_tokens,
+            dtype=torch.int64,
+            device=self._fused_context_kv_weight.device,
+        )
+        self._context_kv_fusion_available = True
+
+    def _precompute_fused_context_kv(
+        self,
+        context_states: torch.Tensor,
+        context_positions: torch.Tensor,
+        context_slot_mapping: torch.Tensor | list[torch.Tensor | None] | None,
+    ) -> None:
+        num_ctx = context_states.shape[0]
+        num_layers = self._num_context_layers
+
+        # One KV-only GEMM replaces five full Q+KV GEMMs. For K3 this projects
+        # 5*576 rows rather than 5*2112 rows (72.7% fewer A-projection FLOPs).
+        all_kv = F.linear(context_states, self._fused_context_kv_weight)
+        all_kv = all_kv.view(num_ctx, num_layers, self._context_kv_width)
+        all_kv_c = all_kv[..., : self._context_kv_lora_rank]
+        all_k_pe = all_kv[..., self._context_kv_lora_rank :]
+
+        # Layer-major layout lets the 2-D RMSNorm weights select a distinct row
+        # for each draft layer in one grouped kernel.
+        all_kv_c = all_kv_c.permute(1, 0, 2).contiguous()
+        all_kv_c_normed = torch.empty_like(all_kv_c)
+        ops.rms_norm(
+            all_kv_c_normed,
+            all_kv_c,
+            self._context_kv_norm_weights,
+            self._context_rms_norm_eps,
+        )
+
+        all_k_pe = all_k_pe.permute(1, 0, 2).contiguous()
+        all_k_pe_flat = all_k_pe.view(num_layers * num_ctx, 1, self._context_rope_dim)
+        repeated_positions = self._context_positions_repeated[: num_layers * num_ctx]
+        repeated_positions.view(num_layers, num_ctx).copy_(context_positions)
+        # Keep the single-tensor context RoPE on vLLM's optimized CUDA op;
+        # DeepSeek YaRN's FlashInfer wrapper assumes a non-null key tensor.
+        rotary_emb = self.layers[0].self_attn.rotary_emb
+        assert rotary_emb is not None
+        ops.rotary_embedding(
+            repeated_positions,
+            all_k_pe_flat,
+            None,
+            rotary_emb.head_size,
+            rotary_emb.cos_sin_cache,
+            rotary_emb.is_neox_style,
+        )
+        all_k_pe = all_k_pe_flat.view(num_layers, num_ctx, 1, self._context_rope_dim)
+
+        if context_slot_mapping is None:
+            return
+
+        cache_layers = [layer.self_attn for layer in self.layers]
+        if (
+            not is_quantized_kv_cache(cache_layers[0].kv_cache_dtype)
+            and self._has_uniform_block_layout(cache_layers)
+            and (
+                isinstance(context_slot_mapping, torch.Tensor)
+                or all(s is not None for s in context_slot_mapping)
+            )
+        ):
+            # Grouped context KV insert only supports unquantized (bf16) KV cache
+            # and assumes that all layers share the same block layout.
+
+            if isinstance(context_slot_mapping, (list, tuple)):
+                per_layer_slot_mappings = [
+                    s for s in context_slot_mapping if s is not None
+                ]
+                if len({s.data_ptr() for s in per_layer_slot_mappings}) == 1:
+                    # All rows alias to the same slot mapping.
+                    slot_mapping = (
+                        per_layer_slot_mappings[0].unsqueeze(0).expand(num_layers, -1)
+                    )
+                else:
+                    slot_mapping = torch.stack(per_layer_slot_mappings, dim=0)
+            else:
+                # Broadcast the single shared context_slot_mapping tensor.
+                slot_mapping = context_slot_mapping.unsqueeze(0).expand(num_layers, -1)
+
+            ref_cache = cache_layers[0].kv_cache
+            ops.concat_and_cache_mla_grouped(
+                all_kv_c_normed,
+                all_k_pe.squeeze(2),
+                self._get_context_kv_cache_ptrs(cache_layers),
+                slot_mapping,
+                ref_cache.size(1),
+                ref_cache.stride(0),
+                ref_cache.stride(1),
+            )
+            return
+
+        for layer_idx, layer in enumerate(self.layers):
+            slot_mapping = (
+                context_slot_mapping[layer_idx]
+                if isinstance(context_slot_mapping, (list, tuple))
+                else context_slot_mapping
+            )
+            if slot_mapping is None:
+                continue
+            attn = layer.self_attn
+            attn.impl.do_kv_cache_update(
+                all_kv_c_normed[layer_idx],
+                all_k_pe[layer_idx],
+                attn.kv_cache,
+                slot_mapping,
+                attn.kv_cache_dtype,
+                attn._k_scale,
+            )
+
+    def _has_uniform_block_layout(
+        self,
+        cache_layers: list[MultiHeadLatentAttention],
+    ) -> bool:
+        if not hasattr(self, "_layers_share_kv_block_layout"):
+            ref_cache = cache_layers[0].kv_cache
+            self._layers_share_kv_block_layout = all(
+                cl.kv_cache.size(1) == ref_cache.size(1)
+                and cl.kv_cache.stride(0) == ref_cache.stride(0)
+                and cl.kv_cache.stride(1) == ref_cache.stride(1)
+                for cl in cache_layers
+            )
+        return self._layers_share_kv_block_layout
+
+    def _get_context_kv_cache_ptrs(
+        self,
+        cache_layers: list[MultiHeadLatentAttention],
+    ) -> torch.Tensor:
+        # The per-layer KV cache base pointers are stable after allocation, so
+        # build the pointer array once and return it on every call.
+        if not hasattr(self, "_context_cache_ptrs"):
+            ref_cache = cache_layers[0].kv_cache
+            cache_ptrs = torch.tensor(
+                [cl.kv_cache.data_ptr() for cl in cache_layers],
+                dtype=torch.int64,
+                device=ref_cache.device,
+            )
+            self._context_cache_ptrs = cache_ptrs
+        return self._context_cache_ptrs
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        inputs_embeds: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        if inputs_embeds is None:
+            inputs_embeds = self.embed_input_ids(input_ids)
+
+        hidden_states = inputs_embeds
+        residual = None
+        for layer in self.layers:
+            hidden_states, residual = layer(
+                positions=positions,
+                hidden_states=hidden_states,
+                residual=residual,
+            )
+        hidden_states, _ = fused_allreduce_rms_norm(
+            hidden_states, residual, self.final_norm
+        )
+        return hidden_states
+
+
+class K3DSparkForCausalLM(nn.Module):
+    has_own_embed_tokens = False
+    has_own_lm_head = False
+    draft_id_to_target_id = None
+    checkpoint_skip_substrs = ("confidence_head", "embed_tokens", "lm_head")
+
+    hf_to_vllm_mapper = WeightsMapper(
+        orig_to_new_prefix={"": "model."},
+        orig_to_new_stacked={
+            ".gate_proj": (".gate_up_proj", 0),
+            ".up_proj": (".gate_up_proj", 1),
+            ".q_a_proj": (".fused_qkv_a_proj", 0),
+            ".kv_a_proj_with_mqa": (".fused_qkv_a_proj", 1),
+        },
+    )
+
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = "") -> None:
+        super().__init__()
+        assert vllm_config.speculative_config is not None
+        self.draft_model_config = vllm_config.speculative_config.draft_model_config
+        self.config = self.draft_model_config.hf_config
+        target_layer_num = vllm_config.model_config.get_num_layers(
+            vllm_config.parallel_config
+        )
+        self.model = K3DSparkModel(
+            vllm_config=vllm_config,
+            start_layer_id=target_layer_num,
+            prefix=maybe_prefix(prefix, "model"),
+        )
+
+        # Assigned by load_dspark_model from the target. Keeping no placeholder
+        # avoids a transient full-vocabulary allocation for this 163k-vocab model.
+        self.lm_head: nn.Module | None = None
+        logit_scale = getattr(self.config, "logit_scale", 1.0)
+        self.logits_processor = LogitsProcessor(
+            self.config.draft_vocab_size, scale=logit_scale
+        )
+
+    def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return self.model.embed_input_ids(input_ids)
+
+    def combine_hidden_states(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        return self.model.combine_hidden_states(hidden_states)
+
+    def get_draft_kv_cache_layer_names(self) -> list[str]:
+        return [layer.self_attn.layer_name for layer in self.model.layers]
+
+    def precompute_and_store_context_kv(
+        self,
+        context_states: torch.Tensor,
+        context_positions: torch.Tensor,
+        context_slot_mapping: torch.Tensor | list[torch.Tensor | None] | None = None,
+    ) -> None:
+        self.model.precompute_and_store_context_kv(
+            context_states, context_positions, context_slot_mapping
+        )
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        inputs_embeds: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        return self.model(input_ids, positions, inputs_embeds)
+
+    def compute_logits(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        assert self.lm_head is not None
+        return self.logits_processor(self.lm_head, hidden_states)
+
+    def compute_draft_logits(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        return self.compute_logits(hidden_states)
+
+    def map_draft_to_target(self, draft_ids: torch.Tensor) -> torch.Tensor:
+        return draft_ids
+
+    def markov_embed(self, token_ids: torch.Tensor) -> torch.Tensor:
+        return self.model.markov_head.embed(token_ids)
+
+    def markov_bias(self, markov_embed: torch.Tensor) -> torch.Tensor:
+        return self.model.markov_head.bias(markov_embed, self.logits_processor)
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        # confidence_head is training-only. The frozen target embedding and LM
+        # head are shared after this draft-specific checkpoint is loaded.
+        loader = AutoWeightsLoader(
+            self,
+            skip_substrs=list(self.checkpoint_skip_substrs),
+        )
+        loaded_weights = loader.load_weights(weights, mapper=self.hf_to_vllm_mapper)
+        self.model._build_fused_context_kv_buffers()
+        return loaded_weights

--- a/vllm/models/kimi_k3/amd/mla.py
+++ b/vllm/models/kimi_k3/amd/mla.py
@@ -1,0 +1,773 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Clean Multi-head Latent Attention for Kimi-K3 (ROCm).
+
+Duplicated from ``nvidia/mla.py``. Sole difference: ``_decode_concat_cache``
+dequantizes the fp8 query for backends without ``supports_quant_query_input``
+(the DSpark draft's TRITON_MLA) instead of asserting.
+
+This is a self-contained MLA layer that owns the full attention path:
+
+    hidden_states
+      -> fused pre-attention ops (fused_qkv_a_proj / norms / q_b_proj)
+      -> explicit prefill / decode split
+           prefill: fused key-concat + cache-insert kernel -> run_prefill_new_tokens
+                    (+ chunked-context merge); dispatched by cache dtype
+                    (bf16 / plain fp8 / fp8_ds_mla)
+           decode : W_UK absorb (BMM1) -> fused q-concat + cache-insert kernel
+                    -> impl.forward_mqa -> W_UV up-proj (MQA)
+      -> optional output gate
+      -> o_proj
+
+Unlike ``MultiHeadLatentAttentionWrapper`` (which delegates orchestration to
+``MLAAttention.forward``), this class *is* the ``AttentionLayerBase``: it selects
+the backend, builds the impl, registers itself in the forward context, owns the
+KV cache, and absorbs ``kv_b_proj`` into ``W_UK_T`` / ``W_UV`` -- mirroring the
+``DeepseekV4Attention`` structure.
+
+K3 specifics: optional rotary embedding (disabled for the target model's NoPE
+layers, enabled for DSpark) and an optional sigmoid output gate (``g_proj``).
+
+Out of scope (extension points, not wired here): context parallelism (DCP/PCP),
+sparse/indexer MLA, and the ROCm/aiter fp8/fp4 BMM fast paths.
+"""
+
+import math
+from typing import TYPE_CHECKING, cast
+
+import torch
+from torch import nn
+
+from vllm.compilation.breakable_cudagraph import eager_break_during_capture
+from vllm.config import CacheConfig, VllmConfig, get_current_vllm_config
+from vllm.distributed import get_tensor_model_parallel_world_size
+from vllm.forward_context import get_forward_context
+from vllm.logger import init_logger
+from vllm.model_executor.layers.attention.attention import (
+    _init_kv_cache_quant,
+    set_default_quant_scales,
+    should_load_quant_weights,
+)
+from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
+from vllm.model_executor.layers.layernorm import RMSNorm
+from vllm.model_executor.layers.linear import (
+    ColumnParallelLinear,
+    MergedColumnParallelLinear,
+    ReplicatedLinear,
+    RowParallelLinear,
+)
+from vllm.model_executor.layers.quantization import QuantizationConfig
+from vllm.model_executor.layers.quantization.utils.quant_utils import (
+    get_and_maybe_dequant_weights,
+)
+from vllm.model_executor.layers.rotary_embedding import RotaryEmbedding, get_rope
+from vllm.model_executor.utils import replace_parameter
+from vllm.models.common.ops import fused_q_kv_rmsnorm
+from vllm.models.kimi_k3.amd.ops.fused_mla_key_concat_kv_cache import (
+    fused_mla_decode_q_concat_kv_cache_insert,
+    fused_mla_key_concat_ds_mla_insert,
+    fused_mla_key_concat_kv_cache_insert,
+    fused_mla_qkv_quant_kv_cache_fp8_insert,
+)
+from vllm.platforms import current_platform
+from vllm.transformers_utils.configs.kimi_linear import KimiLinearConfig
+from vllm.utils.multi_stream_utils import maybe_execute_in_parallel
+from vllm.utils.torch_utils import (
+    is_quantized_kv_cache,
+    kv_cache_dtype_str_to_dtype,
+)
+from vllm.v1.attention.backend import (
+    AttentionBackend,
+    AttentionType,
+    MLAAttentionImpl,
+)
+from vllm.v1.attention.backends.mla.prefill import get_mla_prefill_backend
+from vllm.v1.attention.ops.merge_attn_states import merge_attn_states
+from vllm.v1.attention.selector import get_attn_backend
+from vllm.v1.kv_cache_interface import KVCacheSpec, MLAAttentionSpec, get_kv_quant_mode
+
+if TYPE_CHECKING:
+    from vllm.model_executor.layers.attention.mla_attention import MLACommonMetadata
+
+logger = init_logger(__name__)
+
+# Below this many tokens, overlap the g_proj GEMM on the aux stream with the
+# attention front-end (the GEMM is small and launch-bound, so the overlap
+# hides it); at or above it, run the gate on the main stream.
+_GATE_MULTI_STREAM_TOKEN_THRESHOLD = 512
+
+
+@torch.compile(backend=current_platform.simple_compile_backend)
+def _gate_sigmoid_mul(attn_out: torch.Tensor, gate: torch.Tensor) -> torch.Tensor:
+    """Apply the sigmoid output gate to a precomputed ``g_proj`` projection."""
+    return attn_out * gate.sigmoid()
+
+
+class MultiHeadLatentAttention(nn.Module, AttentionLayerBase):
+    """Kimi-K3 Multi-head Latent Attention with optional RoPE and output gate."""
+
+    def __init__(
+        self,
+        config: KimiLinearConfig,
+        hidden_size: int,
+        num_heads: int,
+        qk_nope_head_dim: int,
+        qk_rope_head_dim: int,
+        v_head_dim: int,
+        q_lora_rank: int | None,
+        kv_lora_rank: int,
+        use_output_gate: bool = False,
+        cache_config: CacheConfig | None = None,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
+        aux_stream: torch.cuda.Stream | None = None,
+        use_rope: bool = False,
+        non_causal_multi_token_decode: bool = False,
+    ) -> None:
+        super().__init__()
+        self.hidden_size = hidden_size
+        self.qk_nope_head_dim = qk_nope_head_dim
+        self.qk_rope_head_dim = qk_rope_head_dim
+        self.qk_head_dim = qk_nope_head_dim + qk_rope_head_dim
+        self.v_head_dim = v_head_dim
+        self.q_lora_rank = q_lora_rank
+        self.kv_lora_rank = kv_lora_rank
+        self.non_causal_multi_token_decode = non_causal_multi_token_decode
+        # Latent "head" seen by the attention kernel / KV cache.
+        self.head_size = kv_lora_rank + qk_rope_head_dim
+        self.scale = self.qk_head_dim**-0.5
+        self.rms_norm_eps = config.rms_norm_eps
+        self.layer_name = prefix
+
+        self.rotary_emb: RotaryEmbedding | None = None
+        if use_rope:
+            rope_parameters = dict(config.rope_parameters)
+            if rope_parameters["rope_type"] != "default":
+                rope_parameters["rope_type"] = (
+                    "deepseek_yarn"
+                    if rope_parameters.get("apply_yarn_scaling", True)
+                    else "deepseek_llama_scaling"
+                )
+            self.rotary_emb = get_rope(
+                qk_rope_head_dim,
+                max_position=config.max_position_embeddings,
+                rope_parameters=rope_parameters,
+                is_neox_style=False,
+                dtype=torch.float32,
+            )
+            if rope_parameters["rope_type"] == "deepseek_yarn":
+                mscale_all_dim = rope_parameters.get("mscale_all_dim", False)
+                scaling_factor = rope_parameters["factor"]
+                mscale = (
+                    1.0
+                    if scaling_factor <= 1
+                    else 0.1 * float(mscale_all_dim) * math.log(scaling_factor) + 1.0
+                )
+                self.scale *= mscale * mscale
+            # The fused epilogues read the cos/sin table directly in fp32 and run
+            # the RoPE math in fp32, so there is no per-forward dtype cast (and no
+            # precision loss). deepseek_yarn builds cos_sin_cache in fp32 already;
+            # dtype=torch.float32 above forces it for the default rope too (the
+            # DSpark draft, which has no yarn scaling).
+            assert self.rotary_emb.cos_sin_cache.dtype == torch.float32, (
+                "K3 fused MLA RoPE requires an fp32 cos/sin cache; got "
+                f"{self.rotary_emb.cos_sin_cache.dtype}."
+            )
+
+        tp_size = get_tensor_model_parallel_world_size()
+        assert num_heads % tp_size == 0
+        self.num_heads = num_heads
+        self.num_local_heads = num_heads // tp_size
+
+        # ---- Pre-attention projections (fusable front-end) ----
+        # Two query variants: a low-rank q-LoRA path (Kimi-K3) fused with the
+        # kv-down proj, or an uncompressed q path (Kimi-Linear, ``q_lora_rank``
+        # None) with a standalone ``q_proj`` and separate ``kv_a_proj_with_mqa``.
+        if self.q_lora_rank is not None:
+            # Fused q-down + kv-down projection. Replicated (disable_tp) because
+            # the low-rank latents are shared across TP ranks; TP splitting
+            # happens at q_b_proj / kv_b_proj. Checkpoint weights ``q_a_proj``
+            # and ``kv_a_proj_with_mqa`` map onto shards 0 and 1 respectively.
+            self.fused_qkv_a_proj = MergedColumnParallelLinear(
+                self.hidden_size,
+                [self.q_lora_rank, self.kv_lora_rank + self.qk_rope_head_dim],
+                bias=False,
+                quant_config=quant_config,
+                prefix=f"{prefix}.fused_qkv_a_proj",
+                disable_tp=True,
+            )
+            self.q_a_layernorm = RMSNorm(self.q_lora_rank, eps=config.rms_norm_eps)
+            self.q_b_proj = ColumnParallelLinear(
+                self.q_lora_rank,
+                self.num_heads * self.qk_head_dim,
+                bias=False,
+                quant_config=quant_config,
+                prefix=f"{prefix}.q_b_proj",
+            )
+        else:
+            # Uncompressed query: full-rank q_proj (TP-split over heads) plus a
+            # replicated kv-down projection (shared latent across TP ranks).
+            self.q_proj = ColumnParallelLinear(
+                self.hidden_size,
+                self.num_heads * self.qk_head_dim,
+                bias=False,
+                quant_config=quant_config,
+                prefix=f"{prefix}.q_proj",
+            )
+            self.kv_a_proj_with_mqa = ReplicatedLinear(
+                self.hidden_size,
+                self.kv_lora_rank + self.qk_rope_head_dim,
+                bias=False,
+                quant_config=quant_config,
+                prefix=f"{prefix}.kv_a_proj_with_mqa",
+            )
+        self.kv_a_layernorm = RMSNorm(self.kv_lora_rank, eps=config.rms_norm_eps)
+        self.kv_b_proj = ColumnParallelLinear(
+            self.kv_lora_rank,
+            self.num_heads * (self.qk_nope_head_dim + self.v_head_dim),
+            bias=False,
+            quant_config=quant_config,
+            prefix=f"{prefix}.kv_b_proj",
+        )
+
+        # ---- Post-attention projections ----
+        self.use_output_gate = use_output_gate
+        self.g_proj = (
+            ColumnParallelLinear(
+                self.hidden_size,
+                self.num_heads * self.v_head_dim,
+                bias=False,
+                quant_config=quant_config,
+                prefix=f"{prefix}.g_proj",
+            )
+            if use_output_gate
+            else None
+        )
+        # Aux stream (created at the model level, DeepseekV4 convention) for
+        # overlapping the g_proj GEMM with the attention front-end. None on
+        # ROCm/non-cuda -> maybe_execute_in_parallel falls back to sequential.
+        self.aux_stream = aux_stream
+        self._gate_events = (
+            [torch.cuda.Event(), torch.cuda.Event()]
+            if self.g_proj is not None and current_platform.is_cuda_alike()
+            else None
+        )
+        self.o_proj = RowParallelLinear(
+            self.num_heads * self.v_head_dim,
+            self.hidden_size,
+            bias=False,
+            quant_config=quant_config,
+            prefix=f"{prefix}.o_proj",
+        )
+
+        # ---- Attention backend / impl / KV cache ----
+        self.quant_config = quant_config
+        if cache_config is not None:
+            self.kv_cache_dtype = cache_config.cache_dtype
+        else:
+            self.kv_cache_dtype = "auto"
+
+        dtype = torch.get_default_dtype()
+        self.attn_backend = get_attn_backend(
+            self.head_size,
+            dtype,
+            self.kv_cache_dtype,
+            use_mla=True,
+            use_sparse=False,
+            num_heads=self.num_local_heads,
+        )
+        _init_kv_cache_quant(self, quant_config, prefix)
+        # Unit (1.0) scale for the fused fp8 prefill path: q/k/v are cast
+        # unscaled to match forward_mha (the prefill flash path does not
+        # dequantize); only the cache uses _k_scale.
+        self.register_buffer(
+            "_one_scale", torch.ones(1, dtype=torch.float32), persistent=False
+        )
+
+        impl_cls = cast(type[MLAAttentionImpl], self.attn_backend.get_impl_cls())
+        self.impl = impl_cls(  # type: ignore[assignment]
+            num_heads=self.num_local_heads,
+            head_size=self.head_size,
+            scale=self.scale,
+            num_kv_heads=1,
+            alibi_slopes=None,
+            sliding_window=None,
+            kv_cache_dtype=self.kv_cache_dtype,
+            logits_soft_cap=None,
+            attn_type=AttentionType.DECODER,
+            kv_sharing_target_layer_name=None,
+            q_lora_rank=self.q_lora_rank,
+            kv_lora_rank=self.kv_lora_rank,
+            qk_nope_head_dim=self.qk_nope_head_dim,
+            qk_rope_head_dim=self.qk_rope_head_dim,
+            qk_head_dim=self.qk_head_dim,
+            v_head_dim=self.v_head_dim,
+            kv_b_proj=self.kv_b_proj,
+            indexer=None,
+        )
+        if getattr(self.impl, "dcp_world_size", -1) < 1:
+            # FlashAttention requires the cp_world_size is positive and the cp_rank
+            # is non negative; manually set here if not set by caller (-1 is unset)
+            self.impl.dcp_world_size = 1
+            self.impl.dcp_rank = 0
+        self.q_pad_num_heads = getattr(self.impl, "q_pad_num_heads", None)
+
+        vllm_config = get_current_vllm_config()
+        parallel_config = vllm_config.parallel_config
+        assert (
+            parallel_config.decode_context_parallel_size <= 1
+            and parallel_config.prefill_context_parallel_size <= 1
+        ), "Kimi-K3 MultiHeadLatentAttention does not support context parallelism."
+        self.prefill_backend = get_mla_prefill_backend(vllm_config)(
+            num_heads=self.num_local_heads,
+            scale=self.scale,
+            kv_lora_rank=self.kv_lora_rank,
+            qk_nope_head_dim=self.qk_nope_head_dim,
+            qk_rope_head_dim=self.qk_rope_head_dim,
+            v_head_dim=self.v_head_dim,
+            vllm_config=vllm_config,
+        )
+
+        compilation_config = vllm_config.compilation_config
+        if prefix in compilation_config.static_forward_context:
+            raise ValueError(f"Duplicate layer name: {prefix}")
+        compilation_config.static_forward_context[prefix] = self
+        self.kv_cache = torch.tensor([])
+
+    # ------------------------------------------------------------------
+    # AttentionLayerBase interface
+    # ------------------------------------------------------------------
+    def get_attn_backend(self) -> type[AttentionBackend]:
+        return self.attn_backend
+
+    def get_kv_cache_spec(self, vllm_config: VllmConfig) -> KVCacheSpec:
+        kv_cache_dtype = kv_cache_dtype_str_to_dtype(
+            self.kv_cache_dtype, vllm_config.model_config
+        )
+        # TODO: Remove this mypy workaround once the K3 PR is fully merged.
+        return MLAAttentionSpec(  # type: ignore[call-arg]
+            block_size=vllm_config.cache_config.block_size,
+            num_kv_heads=1,
+            head_size=self.head_size,
+            dtype=kv_cache_dtype,
+            cache_dtype_str=self.kv_cache_dtype,
+            kv_quant_mode=get_kv_quant_mode(self.kv_cache_dtype),
+            non_causal_multi_token_decode=self.non_causal_multi_token_decode,
+        )
+
+    def process_weights_after_loading(self, act_dtype: torch.dtype) -> None:
+        """Absorb ``kv_b_proj`` into decode-time ``W_UK_T`` / ``W_UV`` bmm weights.
+
+        ``kv_b_proj`` produces ``[k_nope; v]`` per head from the ``kv_lora_rank``
+        latent. For the MQA decode path we pre-split it so that queries are
+        projected into latent space by ``W_UK_T`` and the attention output is
+        projected back to ``v`` by ``W_UV`` -- avoiding materializing full K/V.
+        """
+        kv_b_proj_weight = get_and_maybe_dequant_weights(
+            self.kv_b_proj, out_dtype=act_dtype
+        ).T
+        assert kv_b_proj_weight.shape == (
+            self.kv_lora_rank,
+            self.num_local_heads * (self.qk_nope_head_dim + self.v_head_dim),
+        ), f"{kv_b_proj_weight.shape=}"
+        kv_b_proj_weight = kv_b_proj_weight.view(
+            self.kv_lora_rank,
+            self.num_local_heads,
+            self.qk_nope_head_dim + self.v_head_dim,
+        )
+        W_UK, W_UV = kv_b_proj_weight.split(
+            [self.qk_nope_head_dim, self.v_head_dim], dim=-1
+        )
+        # (L, N, V) -> (N, L, V)
+        replace_parameter(self, "W_UV", W_UV.transpose(0, 1), prefer_copy=True)
+        # (L, N, P) -> (N, P, L)
+        replace_parameter(self, "W_UK_T", W_UK.permute(1, 2, 0), prefer_copy=True)
+
+        quant_method = (
+            self.quant_config.get_quant_method(self, prefix=self.layer_name)
+            if self.quant_config
+            else None
+        )
+        if not should_load_quant_weights(quant_method):
+            set_default_quant_scales(self, register_buffer=False)
+
+        # Precompute reciprocal scales once here (scales are final after load;
+        # K3 has no runtime calculate_kv_scales path) so the fp8 fused kernels
+        # in the decode/prefill hot path take a ready inverse instead of
+        # launching a per-step reciprocal kernel.
+        self.register_buffer(
+            "_q_scale_inv", self._q_scale.reciprocal().reshape(1), persistent=False
+        )
+        self.register_buffer(
+            "_k_scale_inv", self._k_scale.reciprocal().reshape(1), persistent=False
+        )
+
+    def _v_up_proj(self, x: torch.Tensor, out: torch.Tensor) -> None:
+        """Project latent attention output back to ``v`` via ``W_UV`` (bmm)."""
+        # (B, N, L) -> (N, B, L)
+        x = x.view(-1, self.num_local_heads, self.kv_lora_rank).transpose(0, 1)
+        out = out.view(-1, self.num_local_heads, self.v_head_dim)
+        # (N, B, L) x (N, L, V) -> (N, B, V) written transposed into (B, N, V)
+        torch.bmm(x, self.W_UV, out=out.transpose(0, 1))
+
+    def _attn_read_kv_cache(self) -> torch.Tensor:
+        """Latent cache as seen by the attention read kernels (decode / context).
+
+        A plain per-tensor fp8 cache is stored as ``uint8``; view it as fp8 so
+        the backend reads it as E4M3 rather than fp4/E2M1 -- the latter doubles
+        the perceived head dim (``head_size * 2``) and fails the kernel's
+        ``head_dim_k == head_dim_q`` check. Mirrors ``MLAAttention.forward``;
+        the fp8_ds_mla layout keeps its native uint8 view.
+        """
+        cache = self.kv_cache
+        if (
+            is_quantized_kv_cache(self.kv_cache_dtype)
+            and self.kv_cache_dtype != "fp8_ds_mla"
+        ):
+            return cache.view(current_platform.fp8_dtype())
+        return cache
+
+    # ------------------------------------------------------------------
+    # Forward
+    # ------------------------------------------------------------------
+    def _forward_attn(
+        self,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+    ) -> torch.Tensor:
+        """Attention front-end: fused qkv-a proj -> norms -> q_b -> attention.
+
+        Returns the pre-gate attention output ``[num_tokens,
+        num_local_heads * v_head_dim]``. On a profile/dummy run
+        it returns a zeroed buffer.
+        """
+        if self.q_lora_rank is not None:
+            qkv_lora = self.fused_qkv_a_proj(hidden_states)[0]
+            q_c, kv_c, k_pe = qkv_lora.split(
+                [self.q_lora_rank, self.kv_lora_rank, self.qk_rope_head_dim], dim=-1
+            )
+            q_c, kv_c_normed = fused_q_kv_rmsnorm(
+                q_c,
+                kv_c,
+                self.q_a_layernorm.weight.data,
+                self.kv_a_layernorm.weight.data,
+                self.rms_norm_eps,
+            )
+            q = self.q_b_proj(q_c)[0].view(-1, self.num_local_heads, self.qk_head_dim)
+        else:
+            # Uncompressed query: project directly (no q-LoRA, no q norm) and
+            # normalize only the kv latent.
+            q = self.q_proj(hidden_states)[0].view(
+                -1, self.num_local_heads, self.qk_head_dim
+            )
+            kv_lora = self.kv_a_proj_with_mqa(hidden_states)[0]
+            kv_c, k_pe = kv_lora.split(
+                [self.kv_lora_rank, self.qk_rope_head_dim], dim=-1
+            )
+            kv_c_normed = self.kv_a_layernorm(kv_c)
+        k_pe = k_pe.unsqueeze(1)
+
+        attn_out = torch.empty(
+            (hidden_states.shape[0], self.num_local_heads * self.v_head_dim),
+            dtype=hidden_states.dtype,
+            device=hidden_states.device,
+        )
+        self._attention(positions, q, kv_c_normed, k_pe, attn_out)
+        return attn_out
+
+    def forward(
+        self,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+    ) -> torch.Tensor:
+        # Both branches produce (attn_out, gate); they differ only in whether
+        # the g_proj GEMM is overlapped on the aux stream.
+        g_proj = self.g_proj
+        events = self._gate_events
+        if (
+            g_proj is not None
+            and events is not None
+            and self.aux_stream is not None
+            and hidden_states.shape[0] < _GATE_MULTI_STREAM_TOKEN_THRESHOLD
+        ):
+            attn_out, gate = maybe_execute_in_parallel(
+                lambda: self._forward_attn(positions, hidden_states),
+                lambda: g_proj(hidden_states)[0],
+                events[0],
+                events[1],
+                self.aux_stream,
+            )
+        else:
+            attn_out = self._forward_attn(positions, hidden_states)
+            gate = g_proj(hidden_states)[0] if g_proj is not None else None
+
+        if gate is not None:
+            attn_out = _gate_sigmoid_mul(attn_out, gate)
+
+        # ``o_proj`` (RowParallelLinear + out-of-place all-reduce) returns a
+        # fresh private tensor, so return it directly rather than copying into a
+        # caller buffer -- the previous ``output[:] = ...`` convention forced an
+        # extra [num_tokens, hidden] copy per layer.
+        return self.o_proj(attn_out)[0]
+
+    @eager_break_during_capture
+    def _attention(
+        self,
+        positions: torch.Tensor,
+        q: torch.Tensor,
+        kv_c_normed: torch.Tensor,
+        k_pe: torch.Tensor,
+        attn_out: torch.Tensor,
+    ) -> None:
+        forward_context = get_forward_context()
+        attn_metadata_by_layer = forward_context.attn_metadata
+        if attn_metadata_by_layer is None:
+            attn_out.zero_()
+            return
+        assert isinstance(attn_metadata_by_layer, dict)
+        attn_metadata = cast(
+            "MLACommonMetadata", attn_metadata_by_layer[self.layer_name]
+        )
+
+        num_actual_toks = attn_metadata.num_actual_tokens
+        slot_mapping_by_layer = forward_context.slot_mapping
+        assert isinstance(slot_mapping_by_layer, dict)
+        slot_mapping = slot_mapping_by_layer[self.layer_name]
+
+        q = q[:num_actual_toks]
+        kv_c_normed = kv_c_normed[:num_actual_toks]
+        k_pe = k_pe[:num_actual_toks]
+        positions = positions[:num_actual_toks]
+        attn_out = attn_out[:num_actual_toks]
+
+        cos_sin_cache = None
+        rope_positions = None
+        if self.rotary_emb is not None:
+            # Pass the fp32 cos/sin table straight to the fused epilogue (it reads
+            # fp32 and does the RoPE math in fp32) -- no per-forward dtype cast.
+            cos_sin_cache = self.rotary_emb.cos_sin_cache
+            rope_positions = positions
+
+        # Decode tokens are laid out first, prefill tokens after. The fused
+        # prefill covers every supported config (bf16 / plain-fp8 /
+        # fp8_ds_mla), so there is no dense-MHA (forward_mha) fallback.
+        num_mqa_tokens = attn_metadata.num_decode_tokens
+        num_mha_tokens = q.size(0) - num_mqa_tokens
+
+        # Both the prefill and decode fused epilogues write their own cache
+        # slice, so there is no separate do_kv_cache_update.
+
+        # ---- Prefill: fused key-concat + cache-insert + attention ----
+        if num_mha_tokens > 0:
+            self._forward_prefill_fused(
+                q[num_mqa_tokens:],
+                kv_c_normed[num_mqa_tokens:],
+                k_pe[num_mqa_tokens:],
+                rope_positions[num_mqa_tokens:] if rope_positions is not None else None,
+                cos_sin_cache,
+                slot_mapping[num_mqa_tokens:num_actual_toks],
+                attn_metadata,
+                attn_out[num_mqa_tokens:],
+            )
+
+        # ---- Decode: latent multi-query attention ----
+        if num_mqa_tokens > 0:
+            mqa_q_nope, mqa_q_pe = q[:num_mqa_tokens].split(
+                [self.qk_nope_head_dim, self.qk_rope_head_dim], dim=-1
+            )
+            # BMM1: absorb q_nope into latent space. (N,B,P) x (N,P,L) -> (B,N,L)
+            ql_nope = torch.bmm(mqa_q_nope.transpose(0, 1), self.W_UK_T).transpose(0, 1)
+            # Fused: concat mqa_q = [ql_nope | q_pe] and insert the decode-token
+            # latent into the paged cache (one launch, right before forward_mqa).
+            mqa_q = self._decode_concat_cache(
+                ql_nope,
+                mqa_q_pe,
+                kv_c_normed[:num_mqa_tokens],
+                k_pe[:num_mqa_tokens],
+                rope_positions[:num_mqa_tokens] if rope_positions is not None else None,
+                cos_sin_cache,
+                slot_mapping[:num_mqa_tokens],
+            )
+            latent_out, _lse = self.impl.forward_mqa(  # type: ignore[attr-defined]
+                mqa_q, self._attn_read_kv_cache(), attn_metadata, self
+            )
+            self._v_up_proj(latent_out, out=attn_out[:num_mqa_tokens])
+
+    def _decode_concat_cache(
+        self,
+        ql_nope: torch.Tensor,
+        q_pe: torch.Tensor,
+        kv_c_normed: torch.Tensor,
+        k_pe: torch.Tensor,
+        positions: torch.Tensor | None,
+        cos_sin_cache: torch.Tensor | None,
+        slot_mapping: torch.Tensor,
+    ) -> torch.Tensor:
+        """Fused decode query-concat + latent cache insert, dispatched by cache
+        dtype (same policy as prefill: fp8 cache -> fp8 query)."""
+        if self.kv_cache_dtype == "fp8_ds_mla":
+            cache = self.kv_cache
+            if cache.dtype != torch.uint8:
+                cache = cache.view(torch.uint8)
+            return fused_mla_decode_q_concat_kv_cache_insert(
+                ql_nope,
+                q_pe,
+                kv_c_normed,
+                k_pe,
+                cache,
+                slot_mapping,
+                ds_mla=True,
+                positions=positions,
+                cos_sin_cache=cos_sin_cache,
+            )
+        if is_quantized_kv_cache(self.kv_cache_dtype):
+            cache = self.kv_cache
+            if cache.dtype != torch.float8_e4m3fn:
+                cache = cache.view(torch.float8_e4m3fn)
+            mqa_q = fused_mla_decode_q_concat_kv_cache_insert(
+                ql_nope,
+                q_pe,
+                kv_c_normed,
+                k_pe,
+                cache,
+                slot_mapping,
+                q_scale_inv=self._q_scale_inv,
+                cache_scale_inv=self._k_scale_inv,
+                positions=positions,
+                cos_sin_cache=cos_sin_cache,
+            )
+            if not getattr(self.impl, "supports_quant_query_input", False):
+                # Backend dequantizes fp8 KV on load and takes a bf16 query
+                # (TRITON_MLA); undo the query quantization.
+                mqa_q = mqa_q.to(ql_nope.dtype) * self._q_scale
+            return mqa_q
+        return fused_mla_decode_q_concat_kv_cache_insert(
+            ql_nope,
+            q_pe,
+            kv_c_normed,
+            k_pe,
+            self.kv_cache,
+            slot_mapping,
+            positions=positions,
+            cos_sin_cache=cos_sin_cache,
+        )
+
+    def _forward_prefill_fused(
+        self,
+        q: torch.Tensor,
+        kv_c_normed: torch.Tensor,
+        k_pe: torch.Tensor,
+        positions: torch.Tensor | None,
+        cos_sin_cache: torch.Tensor | None,
+        slot_mapping: torch.Tensor,
+        attn_metadata,
+        out: torch.Tensor,
+    ) -> None:
+        """Prefill using the fused key-concat + cache-insert kernel.
+
+        Replaces ``_concat_k_nope_k_pe`` and the prefill cache write with one
+        fused kernel launch, dispatched by cache dtype. The chunked context
+        gather + online-softmax merge are delegated to the impl.
+
+        Supported configs (K3 fp8 policy):
+          - bf16 cache        -> bf16 prefill query
+          - plain fp8 cache   -> fp8 prefill query (unscaled q/k/v; cache _k_scale)
+          - fp8_ds_mla cache  -> bf16 prefill query (656B per-tile self-scaled)
+        """
+        prefill = attn_metadata.prefill
+        has_context = prefill.chunked_context is not None
+        fp8_prefill = prefill.q_data_type == current_platform.fp8_dtype()
+
+        kv_nope = self.kv_b_proj(kv_c_normed)[0].view(
+            -1, self.num_local_heads, self.qk_nope_head_dim + self.v_head_dim
+        )
+        k_nope, v = kv_nope.split([self.qk_nope_head_dim, self.v_head_dim], dim=-1)
+
+        if self.kv_cache_dtype == "fp8_ds_mla":
+            # fp8_ds_mla cache (656B, per-tile self-scaled); bf16 attention.
+            assert not fp8_prefill, (
+                "Kimi-K3 fp8_ds_mla uses a bf16 prefill query; fp8 prefill "
+                "query is not supported with fp8_ds_mla."
+            )
+            kv_cache = self.kv_cache
+            if kv_cache.dtype != torch.uint8:
+                kv_cache = kv_cache.view(torch.uint8)
+            k = fused_mla_key_concat_ds_mla_insert(
+                q,
+                k_nope,
+                k_pe,
+                kv_c_normed,
+                kv_cache,
+                slot_mapping,
+                positions,
+                cos_sin_cache,
+            )
+        elif is_quantized_kv_cache(self.kv_cache_dtype):
+            assert fp8_prefill, (
+                "Kimi-K3 fp8 KV cache requires an fp8 prefill query; enable "
+                "--attention-config '{\"use_prefill_query_quantization\": true}'."
+            )
+            # Plain per-tensor fp8: quant q/k/v (unscaled, matching forward_mha's
+            # unscaled `.to(fp8)`) and insert the fp8 latent (scaled by _k_scale).
+            kv_cache = self.kv_cache
+            if kv_cache.dtype != torch.float8_e4m3fn:
+                kv_cache = kv_cache.view(torch.float8_e4m3fn)
+            q, k, v = fused_mla_qkv_quant_kv_cache_fp8_insert(
+                q,
+                k_nope,
+                k_pe,
+                kv_c_normed,
+                v,
+                kv_cache,
+                slot_mapping,
+                self._one_scale,
+                self._one_scale,
+                self._one_scale,
+                self._k_scale_inv,
+                positions,
+                cos_sin_cache,
+            )
+        else:
+            # Concat full K = [k_nope | k_pe] and insert [kv_c_normed | k_pe]
+            # into the paged cache for these prefill tokens, in one launch.
+            k = fused_mla_key_concat_kv_cache_insert(
+                q,
+                k_nope,
+                k_pe,
+                kv_c_normed,
+                self.kv_cache,
+                slot_mapping,
+                positions,
+                cos_sin_cache,
+            )
+
+        # When there is no chunked context, backends that honor `out` write the
+        # attention result straight into it, avoiding a slice+flatten+copy.
+        writes_out = not has_context and prefill.prefill_backend.supports_out()
+        output_prefill = prefill.prefill_backend.run_prefill_new_tokens(
+            q=q,
+            k=k,
+            v=v,
+            return_softmax_lse=has_context,
+            out=(
+                out.view(-1, self.num_local_heads, self.v_head_dim)
+                if writes_out
+                else None
+            ),
+        )
+
+        if has_context:
+            context_output, context_lse = self.impl._compute_prefill_context(  # type: ignore[attr-defined]
+                q, self._attn_read_kv_cache(), attn_metadata, self._k_scale
+            )
+            suffix_output, suffix_lse = output_prefill
+            out = out.view(-1, self.num_local_heads, self.v_head_dim)
+            merge_attn_states(
+                output=out,
+                prefix_output=context_output[..., : self.v_head_dim],
+                prefix_lse=context_lse,
+                suffix_output=suffix_output[..., : self.v_head_dim],
+                suffix_lse=suffix_lse,
+            )
+        elif not writes_out:
+            out.copy_(output_prefill[..., : self.v_head_dim].flatten(start_dim=-2))

--- a/vllm/models/kimi_k3/amd/ops/fused_mla_key_concat_kv_cache.py
+++ b/vllm/models/kimi_k3/amd/ops/fused_mla_key_concat_kv_cache.py
@@ -1,0 +1,245 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# Provenance: mirror of vllm/models/kimi_k3/nvidia/ops/fused_mla_key_concat_kv_cache.py
+"""Fused MLA prefill and decode epilogues for Kimi-K3.
+
+Thin wrappers over the CUDA ops in
+``csrc/libtorch_stable/fused_kimi_k3_mla_key_concat_kv_cache_kernel.cu``, which
+mirror ``fused_deepseek_v4_qnorm_rope_kv_rope_full_cache_{bf16,fp8}_insert``.
+
+- ``fused_mla_key_concat_kv_cache_insert`` (bf16): optionally apply RoPE,
+  concat the full per-head key ``[k_nope | k_pe]`` into ``k_out``, and insert
+  the latent ``[kv_c_normed | k_pe]`` into the paged cache.
+- ``fused_mla_qkv_quant_kv_cache_fp8_insert`` (fp8): additionally quantize
+  ``q``/``k``/``v`` to E4M3 with ``q_scale`` / ``k_scale`` / ``v_scale`` (the
+  cache shares ``k_scale``, as in ``concat_and_cache_mla``).
+
+The optional ``positions`` / ``cos_sin_cache`` pair enables GPT-J-style RoPE
+inside the epilogue. Omitting both keeps the K3 NoPE fast path. The kernels use
+Programmatic Dependent Launch to overlap the tail of the producing GEMMs on
+sm_90+.
+"""
+
+import torch
+
+
+def fused_mla_key_concat_kv_cache_insert(
+    q: torch.Tensor,  # [Tp, H, qk_head_dim], RoPE is applied in place
+    k_nope: torch.Tensor,  # [Tp, H, qk_nope_head_dim]
+    k_pe: torch.Tensor,  # [Tp, qk_rope_head_dim] or [Tp, 1, qk_rope_head_dim]
+    kv_c_normed: torch.Tensor,  # [Tp, kv_lora_rank]
+    kv_cache: torch.Tensor,  # [num_blocks, block_size, kv_lora_rank + rope]
+    slot_mapping: torch.Tensor,  # [Tp] int64
+    positions: torch.Tensor | None = None,  # [Tp] int64
+    cos_sin_cache: torch.Tensor | None = None,  # [max_position, rope]
+) -> torch.Tensor:
+    """Apply optional RoPE, concat K, and insert the paged latent (bf16).
+
+    Returns the full key ``[Tp, H, qk_nope_head_dim + qk_rope_head_dim]``;
+    optionally rotates ``q`` and writes ``kv_cache`` in place.
+    """
+    k_pe = k_pe.reshape(k_pe.shape[0], -1)
+    tp, num_heads, qk_nope_head_dim = k_nope.shape
+    qk_head_dim = qk_nope_head_dim + k_pe.shape[1]
+    k_out = torch.empty(
+        (tp, num_heads, qk_head_dim), dtype=k_nope.dtype, device=k_nope.device
+    )
+    if tp == 0:
+        return k_out
+    torch.ops._C.fused_kimi_k3_mla_key_concat_kv_cache_insert(
+        q,
+        k_nope,
+        k_pe,
+        kv_c_normed,
+        k_out,
+        kv_cache,
+        slot_mapping,
+        kv_cache.shape[1],
+        positions,
+        cos_sin_cache,
+    )
+    return k_out
+
+
+def fused_mla_key_concat_ds_mla_insert(
+    q: torch.Tensor,  # [Tp, H, qk_head_dim], RoPE is applied in place
+    k_nope: torch.Tensor,  # [Tp, H, qk_nope_head_dim]
+    k_pe: torch.Tensor,  # [Tp, qk_rope_head_dim] or [Tp, 1, qk_rope_head_dim]
+    kv_c_normed: torch.Tensor,  # [Tp, kv_lora_rank]
+    kv_cache: torch.Tensor,  # [num_blocks, block_size, 656] uint8 (fp8_ds_mla)
+    slot_mapping: torch.Tensor,  # [Tp] int64
+    positions: torch.Tensor | None = None,  # [Tp] int64
+    cos_sin_cache: torch.Tensor | None = None,  # [max_position, rope]
+) -> torch.Tensor:
+    """Concat full K (bf16) and insert the latent in the fp8_ds_mla layout.
+
+    The cache uses DeepSeek's 656-byte block-scaled layout (NoPE in 4 tiles of
+    128 with per-tile dynamic fp8 scales, RoPE as bf16) -- self-scaling, so no
+    scale argument. Returns the bf16 full key; optionally rotates ``q`` and
+    writes ``kv_cache`` in place.
+    """
+    k_pe = k_pe.reshape(k_pe.shape[0], -1)
+    tp, num_heads, qk_nope_head_dim = k_nope.shape
+    qk_head_dim = qk_nope_head_dim + k_pe.shape[1]
+    k_out = torch.empty(
+        (tp, num_heads, qk_head_dim), dtype=k_nope.dtype, device=k_nope.device
+    )
+    if tp == 0:
+        return k_out
+    torch.ops._C.fused_kimi_k3_mla_key_concat_ds_mla_insert(
+        q,
+        k_nope,
+        k_pe,
+        kv_c_normed,
+        k_out,
+        kv_cache,
+        slot_mapping,
+        kv_cache.shape[1],
+        positions,
+        cos_sin_cache,
+    )
+    return k_out
+
+
+def fused_mla_qkv_quant_kv_cache_fp8_insert(
+    q: torch.Tensor,  # [Tp, H, qk_head_dim]
+    k_nope: torch.Tensor,  # [Tp, H, qk_nope_head_dim]
+    k_pe: torch.Tensor,  # [Tp, qk_rope_head_dim] or [Tp, 1, qk_rope_head_dim]
+    kv_c_normed: torch.Tensor,  # [Tp, kv_lora_rank]
+    v: torch.Tensor,  # [Tp, H, v_head_dim]
+    kv_cache: torch.Tensor,  # [num_blocks, block_size, kv_lora_rank + rope] fp8
+    slot_mapping: torch.Tensor,  # [Tp] int64
+    q_scale_inv: torch.Tensor,  # scalar fp32, 1 / q scale (attention query)
+    k_scale_inv: torch.Tensor,  # scalar fp32, 1 / k scale (attention key)
+    v_scale_inv: torch.Tensor,  # scalar fp32, 1 / v scale (attention value)
+    cache_scale_inv: torch.Tensor,  # scalar fp32, 1 / kv scale (cache latent)
+    positions: torch.Tensor | None = None,  # [Tp] int64
+    cos_sin_cache: torch.Tensor | None = None,  # [max_position, rope]
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Quantize q/k/v to fp8 and insert the fp8 latent into the paged cache.
+
+    The attention key ``k_fp8`` and the cache latent use *separate* scales
+    (``k_scale_inv`` vs ``cache_scale_inv``): the cache must be quantized with
+    ``_k_scale`` (read back by decode / context), while the prefill attention
+    q/k/v currently stay unscaled (the prefill flash path does not dequantize).
+
+    Returns ``(q_fp8, k_fp8, v_fp8)``; writes the fp8 ``kv_cache`` in place.
+    """
+    k_pe = k_pe.reshape(k_pe.shape[0], -1)
+    tp, num_heads, _ = q.shape
+    qk_head_dim = q.shape[2]
+    v_head_dim = v.shape[2]
+    fp8 = torch.float8_e4m3fn
+    q_fp8 = torch.empty((tp, num_heads, qk_head_dim), dtype=fp8, device=q.device)
+    k_fp8 = torch.empty((tp, num_heads, qk_head_dim), dtype=fp8, device=q.device)
+    v_fp8 = torch.empty((tp, num_heads, v_head_dim), dtype=fp8, device=q.device)
+    if tp == 0:
+        return q_fp8, k_fp8, v_fp8
+    torch.ops._C.fused_kimi_k3_mla_qkv_quant_kv_cache_fp8_insert(
+        q,
+        k_nope,
+        k_pe,
+        kv_c_normed,
+        v,
+        q_fp8,
+        k_fp8,
+        v_fp8,
+        kv_cache,
+        slot_mapping,
+        q_scale_inv,
+        k_scale_inv,
+        v_scale_inv,
+        cache_scale_inv,
+        kv_cache.shape[1],
+        positions,
+        cos_sin_cache,
+    )
+    return q_fp8, k_fp8, v_fp8
+
+
+def fused_mla_decode_q_concat_kv_cache_insert(
+    ql_nope: torch.Tensor,  # [B, H, kv_lora_rank]  (BMM1 output, absorbed q)
+    q_pe: torch.Tensor,  # [B, H, qk_rope_head_dim]
+    kv_c_normed: torch.Tensor,  # [B, kv_lora_rank]
+    k_pe: torch.Tensor,  # [B, qk_rope_head_dim] or [B, 1, qk_rope_head_dim]
+    kv_cache: torch.Tensor,  # [num_blocks, block_size, entry]
+    slot_mapping: torch.Tensor,  # [B] int64
+    *,
+    ds_mla: bool = False,
+    q_scale_inv: torch.Tensor | None = None,  # scalar fp32, 1 / q scale
+    cache_scale_inv: torch.Tensor | None = None,  # scalar fp32, 1 / kv scale
+    positions: torch.Tensor | None = None,  # [B] int64
+    cos_sin_cache: torch.Tensor | None = None,  # [max_position, rope]
+) -> torch.Tensor:
+    """Concat the latent decode query ``mqa_q = [ql_nope | q_pe]`` and insert the
+    latent ``[kv_c_normed | k_pe]`` into the paged cache, in one launch (runs
+    right before ``forward_mqa``).
+
+    Dispatched by cache format:
+      - bf16          -> bf16 mqa_q, bf16 cache
+      - plain fp8     -> fp8 mqa_q (q_scale_inv), fp8 cache (cache_scale_inv)
+      - fp8_ds_mla    -> bf16 mqa_q, 656B block-scaled cache
+
+    Returns ``mqa_q`` of shape ``[B, H, kv_lora_rank + qk_rope_head_dim]``;
+    writes ``kv_cache`` in place.
+    """
+    k_pe = k_pe.reshape(k_pe.shape[0], -1)
+    b, num_heads, kv_lora_rank = ql_nope.shape
+    entry = kv_lora_rank + q_pe.shape[-1]
+    fp8_q = q_scale_inv is not None
+    out_dtype = torch.float8_e4m3fn if fp8_q else ql_nope.dtype
+    mqa_q = torch.empty((b, num_heads, entry), dtype=out_dtype, device=ql_nope.device)
+    if b == 0:
+        return mqa_q
+
+    if ds_mla:
+        cache = (
+            kv_cache if kv_cache.dtype == torch.uint8 else kv_cache.view(torch.uint8)
+        )
+        torch.ops._C.fused_kimi_k3_mla_decode_q_concat_ds_mla_insert(
+            ql_nope,
+            q_pe,
+            kv_c_normed,
+            k_pe,
+            mqa_q,
+            cache,
+            slot_mapping,
+            cache.shape[1],
+            positions,
+            cos_sin_cache,
+        )
+    elif fp8_q:
+        assert cache_scale_inv is not None, "fp8 decode requires cache_scale_inv"
+        cache = (
+            kv_cache
+            if kv_cache.dtype == torch.float8_e4m3fn
+            else kv_cache.view(torch.float8_e4m3fn)
+        )
+        torch.ops._C.fused_kimi_k3_mla_decode_q_concat_kv_cache_fp8_insert(
+            ql_nope,
+            q_pe,
+            kv_c_normed,
+            k_pe,
+            mqa_q,
+            cache,
+            slot_mapping,
+            q_scale_inv,
+            cache_scale_inv,
+            cache.shape[1],
+            positions,
+            cos_sin_cache,
+        )
+    else:
+        torch.ops._C.fused_kimi_k3_mla_decode_q_concat_kv_cache_insert(
+            ql_nope,
+            q_pe,
+            kv_c_normed,
+            k_pe,
+            mqa_q,
+            kv_cache,
+            slot_mapping,
+            kv_cache.shape[1],
+            positions,
+            cos_sin_cache,
+        )
+    return mqa_q

--- a/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
+++ b/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
@@ -26,7 +26,7 @@ from vllm.v1.attention.backend import (
     CommonAttentionMetadata,
     MultipleOf,
 )
-from vllm.v1.kv_cache_interface import AttentionSpec
+from vllm.v1.kv_cache_interface import AttentionSpec, is_quantized_kv_cache
 
 logger = init_logger(__name__)
 
@@ -949,6 +949,9 @@ class AiterMLAImpl(MLACommonImpl[AiterMLAMetadata]):
         from aiter import flash_attn_varlen_func
 
         self.flash_attn_varlen_func = flash_attn_varlen_func
+
+        # The asm a8w8 decode kernels take a pre-quantized fp8 query + q_scale.
+        self.supports_quant_query_input = is_quantized_kv_cache(kv_cache_dtype)
 
         # FP8 MLA prefill kernel imports (lazy, only when enabled).
         # Auto-enabled on gfx950 when AITER ships the kernels.


### PR DESCRIPTION



## Purpose

The DSpark draft auto-selects TRITON_MLA, which dequantizes fp8 KV on
load and takes a bf16 query; Kimi-K3's _decode_concat_cache hard-asserted
supports_quant_query_input instead. Add a query-dequant fallback for such
backends, ROCm-side per the amd/ convention (amd/mla.py + amd/dspark_mla.py
duplicates, K3DSparkModel routed through the platform facade), and declare
supports_quant_query_input on AiterMLAImpl for quantized caches (the asm
a8w8 kernels take fp8 q natively).



## Test Plan
Stacks on #51011/#51040. 
Verified gfx950 x8 TP8
gsm8k eval and regression test. 
perf benchmarking

## Test Result

DSpark+fp8 asm 94.3-95.1%
gsm8k, 793.3 tok/s @ nspec 3 (aiter>=#4521), 
no-spec fp8 regression 95.8%.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

