### PR TITLE
refactor: encapsulate reasoning-grammar transition behind single entry points

### DIFF
--- a/tests/v1/core/test_async_scheduler.py
+++ b/tests/v1/core/test_async_scheduler.py
@@ -273,9 +273,9 @@ def test_abort_request_when_structured_output_fsm_cannot_advance():
     scheduler.perf_metrics = None
     scheduler.connector = None
     scheduler.structured_output_manager = Mock()
-    scheduler.structured_output_manager.should_advance.return_value = True
-    scheduler.structured_output_manager.trim_reasoning_for_advance.side_effect = (
-        lambda request, new_token_ids: new_token_ids
+    scheduler.structured_output_manager.advance_grammar.return_value = True
+    scheduler.structured_output_manager.filter_draft_tokens.side_effect = (
+        lambda request, spec_token_ids: spec_token_ids
     )
     scheduler.requests = {request.request_id: request}
     scheduler.running = [request]

--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -3238,9 +3238,9 @@ def test_abort_request_when_structured_output_fsm_cannot_advance():
     scheduler.perf_metrics = None
     scheduler.connector = None
     scheduler.structured_output_manager = Mock()
-    scheduler.structured_output_manager.should_advance.return_value = True
-    scheduler.structured_output_manager.trim_reasoning_for_advance.side_effect = (
-        lambda request, new_token_ids: new_token_ids
+    scheduler.structured_output_manager.advance_grammar.return_value = True
+    scheduler.structured_output_manager.filter_draft_tokens.side_effect = (
+        lambda request, spec_token_ids: spec_token_ids
     )
     scheduler.requests = {request.request_id: request}
     scheduler.running = [request]

--- a/tests/v1/spec_decode/test_mtp_structured_output.py
+++ b/tests/v1/spec_decode/test_mtp_structured_output.py
@@ -283,7 +283,7 @@ def _setup_boundary_request(backend: str):
     marker = tokenizer.encode("\n")[0]
     structured_req = request.structured_output_request
     # The grammar itself is JSON (cheap to build); only the key kind matters
-    # for the should_advance structural-tag branch, so pre-seed the cached
+    # for the advance_grammar structural-tag branch, so pre-seed the cached
     # property.
     structured_req.__dict__["structured_output_key"] = (
         StructuredOutputOptions.STRUCTURAL_TAG,
@@ -295,9 +295,9 @@ def _setup_boundary_request(backend: str):
     return tokenizer, manager, request, prompt, marker
 
 
-def test_should_advance_records_reasoning_end_index():
+def test_advance_grammar_records_reasoning_end_index():
     """Regression for #44006 on post-#42452 main: the boundary step must
-    record where reasoning ends so the scheduler can trim before advancing.
+    record where reasoning ends so advance_grammar can trim before advancing.
     """
     tokenizer, manager, request, prompt, marker = _setup_boundary_request("xgrammar")
     structured_req = request.structured_output_request
@@ -306,15 +306,16 @@ def test_should_advance_records_reasoning_end_index():
     post = tokenizer.encode("{")[0]
     request.append_output_token_ids([pre, marker, post])
 
-    assert manager.should_advance(request)
+    # advance_grammar returns True (accepted or no-op) and records boundary.
+    assert manager.advance_grammar(request, [pre, marker, post])
     assert structured_req.reasoning_ended
     # Marker sits at absolute index len(prompt) + 1.
     assert structured_req.reasoning_end_token_index == len(prompt) + 1
 
 
-def test_trim_reasoning_for_advance():
-    """trim drops the marker and everything before it; later steps and
-    requests without a recorded boundary pass through unchanged.
+def test_advance_grammar_trims_reasoning_prefix():
+    """advance_grammar drops the marker and everything before it before
+    calling accept_tokens; later steps pass through unchanged.
     """
     tokenizer, manager, request, prompt, marker = _setup_boundary_request("xgrammar")
     structured_req = request.structured_output_request
@@ -322,22 +323,16 @@ def test_trim_reasoning_for_advance():
     pre = tokenizer.encode(" ")[0]
     post = tokenizer.encode("{")[0]
 
-    # No boundary recorded yet: pass-through.
-    assert manager.trim_reasoning_for_advance(request, [pre]) == [pre]
+    # No boundary recorded yet: reasoning still active, grammar stays idle.
+    assert manager.advance_grammar(request, [pre]) is True
 
-    # Boundary step: marker mid-step keeps only the suffix.
+    # Boundary step: marker mid-step keeps only the suffix for accept_tokens.
     step_tokens = [pre, marker, post]
     request.append_output_token_ids(step_tokens)
-    assert manager.should_advance(request)
-    assert manager.trim_reasoning_for_advance(request, step_tokens) == [post]
-
-    # Boundary step variant: marker last (the #44006 crash shape
-    # [198, </think>]) trims to empty -> scheduler skips accept_tokens.
-    structured_req.reasoning_end_token_index = len(request.all_token_ids) - 1
-    assert manager.trim_reasoning_for_advance(request, step_tokens) == []
+    assert manager.advance_grammar(request, step_tokens) is True
+    assert structured_req.reasoning_end_token_index == len(prompt) + 1
 
     # Later steps: tokens are past the boundary, returned unchanged.
-    structured_req.reasoning_end_token_index = len(prompt) + 1
     next_step = [post, post]
     request.append_output_token_ids(next_step)
-    assert manager.trim_reasoning_for_advance(request, next_step) == next_step
+    assert manager.advance_grammar(request, next_step) is True

--- a/tests/v1/structured_output/test_reasoning_structured_output.py
+++ b/tests/v1/structured_output/test_reasoning_structured_output.py
@@ -157,126 +157,121 @@ class TestReasoningStructuredOutput:
             is not None
         )
 
-    def test_should_advance_with_enable_in_reasoning(
+    # ------------------------------------------------------------------
+    # advance_grammar — replaces the former should_advance tests.
+    # The scheduler now calls this single method instead of
+    # should_advance + trim_reasoning_for_advance + grammar.accept_tokens.
+    # ------------------------------------------------------------------
+
+    def test_advance_grammar_with_enable_in_reasoning(
         self,
         manager_with_reasoner,
         mock_request_with_structured_output,
     ):
-        """Test should_advance when enable_in_reasoning is True."""
-        # Enable enable_in_reasoning
+        """advance_grammar passes tokens directly when enable_in_reasoning."""
         manager_with_reasoner.enable_in_reasoning = True
+        grammar = mock_request_with_structured_output.structured_output_request.grammar
+        grammar.accept_tokens = Mock(return_value=True)
 
-        # Should always return True when enable_in_reasoning is enabled
-        result = manager_with_reasoner.should_advance(
-            mock_request_with_structured_output
+        new_tokens = [10, 20]
+        result = manager_with_reasoner.advance_grammar(
+            mock_request_with_structured_output, new_tokens
         )
         assert result is True
+        grammar.accept_tokens.assert_called_once_with("mock_req", new_tokens)
 
-    def test_should_advance_reasoning_not_ended(
+    def test_advance_grammar_reasoning_not_ended(
         self,
         manager_with_reasoner,
         mock_request_with_structured_output,
     ):
-        """Test should_advance when reasoning has not ended."""
-        # Set reasoning as not ended
-        (
-            mock_request_with_structured_output.structured_output_request
-        ).reasoning_ended = False
+        """advance_grammar skips FSM advancement while reasoning is active."""
+        structured_req = mock_request_with_structured_output.structured_output_request
+        structured_req.reasoning_ended = False
+        grammar = structured_req.grammar
+        grammar.accept_tokens = Mock(return_value=True)
 
-        result = manager_with_reasoner.should_advance(
-            mock_request_with_structured_output
+        result = manager_with_reasoner.advance_grammar(
+            mock_request_with_structured_output, [6, 7, 8]
         )
 
-        # Should return False since reasoning hasn't ended
-        assert result is False
+        # Grammar should NOT have been advanced.
+        grammar.accept_tokens.assert_not_called()
+        assert result is True  # no rejection
 
-    def test_should_advance_reasoning_just_ended(
+    def test_advance_grammar_reasoning_just_ended(
         self,
         manager_with_reasoner,
         mock_request_with_structured_output,
     ):
-        """Test should_advance when reasoning ends in current step."""
-        # Set reasoning as not ended initially, but ends in this step
-        (
-            mock_request_with_structured_output.structured_output_request
-        ).reasoning_ended = False
+        """advance_grammar detects reasoning-end mid-step and trims prefix."""
+        structured_req = mock_request_with_structured_output.structured_output_request
+        structured_req.reasoning_ended = False
+
         reasoner = MockReasoner(tokenizer=Mock())
         reasoner.is_reasoning_end_streaming.return_value = True
-        structured_req = mock_request_with_structured_output.structured_output_request
         structured_req.reasoner = reasoner
+        grammar = structured_req.grammar
+        grammar.accept_tokens = Mock(return_value=True)
 
-        result = manager_with_reasoner.should_advance(
-            mock_request_with_structured_output
+        result = manager_with_reasoner.advance_grammar(
+            mock_request_with_structured_output, [6, 7, 8]
         )
 
-        # The scheduler trims the reasoning prefix before advancing the grammar.
-        assert (
-            mock_request_with_structured_output.structured_output_request.reasoning_ended
-            is True
-        )
+        assert structured_req.reasoning_ended is True
         assert result is True
 
-    def test_should_advance_reasoning_already_ended(
+    def test_advance_grammar_reasoning_already_ended(
         self,
         manager_with_reasoner,
         mock_request_with_structured_output,
     ):
-        """Test should_advance when reasoning has already ended."""
-        # Set reasoning as already ended
-        (
-            mock_request_with_structured_output.structured_output_request
-        ).reasoning_ended = True
+        """advance_grammar advances directly when reasoning already ended."""
+        structured_req = mock_request_with_structured_output.structured_output_request
+        structured_req.reasoning_ended = True
+        structured_req.reasoning_end_token_index = None  # prior step
+        grammar = structured_req.grammar
+        grammar.accept_tokens = Mock(return_value=True)
 
-        result = manager_with_reasoner.should_advance(
-            mock_request_with_structured_output
+        new_tokens = [10, 20]
+        result = manager_with_reasoner.advance_grammar(
+            mock_request_with_structured_output, new_tokens
         )
 
-        # Should return True since reasoning has ended
         assert result is True
+        grammar.accept_tokens.assert_called_once_with("mock_req", new_tokens)
 
-    def test_should_advance_uses_new_token_ids_when_provided(
+    def test_advance_grammar_uses_new_token_ids_for_delta(
         self,
         manager_with_reasoner,
         mock_request_with_structured_output,
     ):
-        """Regression for #43388: when caller passes new_token_ids, the
-        reasoner sees the exact multi-token delta rather than the
-        placeholder-derived window.
+        """Regression for #43388: advance_grammar uses the exact multi-token
+        delta rather than a placeholder-derived window.
         """
         structured_req = mock_request_with_structured_output.structured_output_request
         structured_req.reasoning_ended = False
 
         end_token_id = 248069
-
         reasoner = MockReasoner(tokenizer=Mock())
-        # Detection mirrors the real Qwen3 parser: end token in the delta.
         reasoner.is_reasoning_end_streaming = Mock(
             side_effect=lambda input_ids, delta_ids: end_token_id in list(delta_ids)
         )
         structured_req.reasoner = reasoner
+        structured_req.grammar.accept_tokens = Mock(return_value=True)
 
-        # Scenario from #43388: async + spec decode K=4, 4 tokens accepted
-        # but only 1 placeholder remains (some drafts were rejected).
-        # The placeholder math would yield delta=[271] and miss </think>.
-        # Passing new_token_ids must override that.
         new_token_ids = [9, 198, end_token_id, 271]
         mock_request_with_structured_output.all_token_ids = [
-            1,
-            2,
-            3,
-            4,
-            5,
+            1, 2, 3, 4, 5,
         ] + new_token_ids
         mock_request_with_structured_output.num_computed_tokens = 9
         mock_request_with_structured_output.num_output_placeholders = 1
 
-        result = manager_with_reasoner.should_advance(
+        result = manager_with_reasoner.advance_grammar(
             mock_request_with_structured_output,
             new_token_ids=new_token_ids,
         )
 
-        # First call to is_reasoning_end_streaming was with the full
-        # new_token_ids (not the truncated placeholder window).
         first_call = reasoner.is_reasoning_end_streaming.call_args_list[0]
         _, called_delta = first_call.args
         assert list(called_delta) == new_token_ids
@@ -284,39 +279,14 @@ class TestReasoningStructuredOutput:
         assert structured_req.reasoning_ended is True
         assert result is True
 
-    def test_should_advance_without_new_token_ids_falls_back(
+    def test_advance_grammar_trims_reasoning_prefix_for_json(
         self,
         manager_with_reasoner,
         mock_request_with_structured_output,
     ):
-        """Backward compat: callers that don't pass new_token_ids keep
-        the original placeholder-derived delta window.
+        """advance_grammar trims the reasoning prefix before advancing the
+        FSM at the boundary, so the grammar only sees post-reasoning tokens.
         """
-        structured_req = mock_request_with_structured_output.structured_output_request
-        structured_req.reasoning_ended = False
-        reasoner = MockReasoner(tokenizer=Mock())
-        reasoner.is_reasoning_end_streaming.return_value = False
-        structured_req.reasoner = reasoner
-
-        mock_request_with_structured_output.all_token_ids = [1, 2, 3, 4, 5]
-        mock_request_with_structured_output.num_computed_tokens = 5
-        mock_request_with_structured_output.num_output_placeholders = 2
-
-        result = manager_with_reasoner.should_advance(
-            mock_request_with_structured_output
-        )
-
-        # placeholder window: start = 5 - 2 = 3, delta = [4, 5]
-        _, called_delta = reasoner.is_reasoning_end_streaming.call_args[0]
-        assert list(called_delta) == [4, 5]
-        assert result is False
-
-    def test_should_advance_trims_reasoning_prefix_for_json(
-        self,
-        manager_with_reasoner,
-        mock_request_with_structured_output,
-    ):
-        """JSON uses the common trim-then-advance path at the boundary."""
         structured_req = mock_request_with_structured_output.structured_output_request
         structured_req.reasoning_ended = False
         structured_req.structured_output_key = (
@@ -338,15 +308,77 @@ class TestReasoningStructuredOutput:
         new_token_ids = [9, 198, marker, 271, 5005]
         mock_request_with_structured_output.all_token_ids = [1, 2, 3] + new_token_ids
 
-        result = manager_with_reasoner.should_advance(
+        result = manager_with_reasoner.advance_grammar(
             mock_request_with_structured_output,
             new_token_ids=new_token_ids,
         )
 
-        structured_req.grammar.accept_tokens.assert_not_called()
+        # Grammar should have received only the trimmed suffix.
+        structured_req.grammar.accept_tokens.assert_called_once_with(
+            "mock_req", [271, 5005]
+        )
         assert structured_req.reasoning_ended is True
         assert result is True
         assert structured_req.reasoning_end_token_index == 5
-        assert manager_with_reasoner.trim_reasoning_for_advance(
-            mock_request_with_structured_output, new_token_ids
-        ) == [271, 5005]
+
+    # ------------------------------------------------------------------
+    # filter_draft_tokens — replaces should_advance + validate_tokens
+    # at the draft-token call sites.
+    # ------------------------------------------------------------------
+
+    def test_filter_draft_tokens_passthrough_while_reasoning(
+        self,
+        manager_with_reasoner,
+        mock_request_with_structured_output,
+    ):
+        """filter_draft_tokens returns drafts unchanged while reasoning
+        is still in progress.
+        """
+        structured_req = mock_request_with_structured_output.structured_output_request
+        structured_req.reasoning_ended = False
+        grammar = structured_req.grammar
+        grammar.validate_tokens = Mock(return_value=[1, 2, 3])
+
+        spec_tokens = [10, 20, 30]
+        result = manager_with_reasoner.filter_draft_tokens(
+            mock_request_with_structured_output, spec_tokens
+        )
+
+        assert result == spec_tokens
+        grammar.validate_tokens.assert_not_called()
+
+    def test_filter_draft_tokens_validates_after_reasoning(
+        self,
+        manager_with_reasoner,
+        mock_request_with_structured_output,
+    ):
+        """filter_draft_tokens delegates to grammar.validate_tokens once
+        reasoning has ended.
+        """
+        structured_req = mock_request_with_structured_output.structured_output_request
+        structured_req.reasoning_ended = True
+        grammar = structured_req.grammar
+        validated = [10, 20]
+        grammar.validate_tokens = Mock(return_value=validated)
+
+        result = manager_with_reasoner.filter_draft_tokens(
+            mock_request_with_structured_output, [10, 20, 30]
+        )
+
+        assert result == validated
+        grammar.validate_tokens.assert_called_once_with([10, 20, 30])
+
+    def test_filter_draft_tokens_no_reasoner(
+        self, mock_vllm_config, mock_request_with_structured_output
+    ):
+        """filter_draft_tokens validates when no reasoner is configured."""
+        manager = StructuredOutputManager(mock_vllm_config)
+        grammar = mock_request_with_structured_output.structured_output_request.grammar
+        grammar.validate_tokens = Mock(return_value=[10])
+
+        result = manager.filter_draft_tokens(
+            mock_request_with_structured_output, [10, 20]
+        )
+
+        assert result == [10]
+        grammar.validate_tokens.assert_called_once_with([10, 20])

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -60,7 +60,7 @@ from vllm.v1.outputs import DraftTokenIds, KVConnectorOutput, ModelRunnerOutput
 from vllm.v1.request import Request, RequestStatus, StreamingUpdate
 from vllm.v1.spec_decode.dynamic.utils import build_dynamic_sd_schedule_lookup
 from vllm.v1.spec_decode.metrics import SpecDecodingStats
-from vllm.v1.structured_output import StructuredOutputGrammar, StructuredOutputManager
+from vllm.v1.structured_output import StructuredOutputManager
 from vllm.v1.utils import record_function_or_nullcontext
 
 logger = init_logger(__name__)
@@ -1818,33 +1818,17 @@ class Scheduler(SchedulerInterface):
                 request.status = RequestStatus.FINISHED_STOPPED
                 stopped = True
 
-            if new_token_ids and self.structured_output_manager.should_advance(
-                request, new_token_ids=new_token_ids
+            if new_token_ids and not self.structured_output_manager.advance_grammar(
+                request, new_token_ids
             ):
-                struct_output_request = request.structured_output_request
-                assert struct_output_request is not None
-                grammar = struct_output_request.grammar
-                assert isinstance(grammar, StructuredOutputGrammar)
-                # new_token_ids can be a mixed block of reasoning content, then
-                # the reasoning end marker, then the start of the grammar content.
-                # Trim the reasoning content so the grammar only sees grammar content.
-                advance_token_ids = (
-                    self.structured_output_manager.trim_reasoning_for_advance(
-                        request, new_token_ids
-                    )
+                logger.error(
+                    "Unexpected: grammar rejected tokens for request %s. "
+                    "Terminating request.",
+                    req_id,
                 )
-                if advance_token_ids and not grammar.accept_tokens(
-                    req_id, advance_token_ids
-                ):
-                    logger.error(
-                        "Unexpected: grammar rejected tokens %s for request %s. "
-                        "Terminating request.",
-                        advance_token_ids,
-                        req_id,
-                    )
-                    request.status = RequestStatus.FINISHED_ERROR
-                    request.resumable = False
-                    stopped = True
+                request.status = RequestStatus.FINISHED_ERROR
+                request.resumable = False
+                stopped = True
 
             routed_experts = None
             if (
@@ -2163,10 +2147,11 @@ class Scheduler(SchedulerInterface):
                     request.spec_token_ids = []
                 continue
 
-            # Add newly generated spec token ids to the request.
-            if self.structured_output_manager.should_advance(request):
-                metadata = request.structured_output_request
-                spec_token_ids = metadata.grammar.validate_tokens(spec_token_ids)  # type: ignore[union-attr]
+            # Filter draft tokens through the grammar (no-op while
+            # reasoning is still in progress).
+            spec_token_ids = self.structured_output_manager.filter_draft_tokens(
+                request, spec_token_ids
+            )
             request.spec_token_ids = spec_token_ids
 
     def update_draft_token_ids_in_output(
@@ -2192,10 +2177,11 @@ class Scheduler(SchedulerInterface):
             # Trim drafts to scheduled number of spec tokens
             # (needed for chunked prefill case for example).
             del spec_token_ids[orig_num_spec_tokens:]
-            # Filter out spec tokens which do not adhere to the grammar.
-            if self.structured_output_manager.should_advance(request):
-                metadata = request.structured_output_request
-                spec_token_ids = metadata.grammar.validate_tokens(spec_token_ids)  # type: ignore[union-attr]
+            # Filter out spec tokens which do not adhere to the grammar
+            # (no-op while reasoning is still in progress).
+            spec_token_ids = self.structured_output_manager.filter_draft_tokens(
+                request, spec_token_ids
+            )
             # Pad to original number of spec tokens.
             num_invalid_tokens = orig_num_spec_tokens - len(spec_token_ids)
             if num_invalid_tokens:

--- a/vllm/v1/structured_output/__init__.py
+++ b/vllm/v1/structured_output/__init__.py
@@ -340,9 +340,8 @@ class StructuredOutputManager:
                     #   enable_in_reasoning).
                     # - apply_bitmask: reasoning ended mid-window in this
                     #   call and was flipped True after the marker;
-                    #   should_fill_bitmask still returns False here because
                     #   reasoning_ended is only persisted later by
-                    #   should_advance.
+                    #   advance_grammar.
                     bonus_apply = self.should_fill_bitmask(request) or apply_bitmask
                     self._fill_bitmasks(((grammar, cumulative_index, bonus_apply),))
                     cumulative_index += 1
@@ -378,65 +377,93 @@ class StructuredOutputManager:
             return request.structured_output_request.reasoning_ended
         return True
 
-    def should_advance(
+    def advance_grammar(
         self,
         request: "Request",
-        new_token_ids: list[int] | None = None,
+        new_token_ids: list[int],
     ) -> bool:
-        if not request.use_structured_output:
-            return False
+        """Commit accepted tokens to the grammar FSM.
 
-        # To determine whether we can advance the FSM.
-        # Supports thinking usage where we skip the reasoning components.
-        if TYPE_CHECKING:
-            assert request.structured_output_request is not None
-            assert request.structured_output_request.grammar is not None
-        # by default, we should always advance
-        # for cases that don't use thinking mode.
-        reasoner = self._get_reasoner(request)
-        if reasoner is None:
+        Encapsulates reasoning-end detection, reasoning-token trimming, and
+        FSM advancement behind a single entry point.  The scheduler never
+        needs to know whether the request is still in its reasoning phase;
+        this method figures that out from internal state.
+
+        Returns ``True`` when the grammar accepted the tokens (or when no
+        grammar advancement is needed yet).  Returns ``False`` when the
+        grammar explicitly rejects — the caller should terminate the request.
+        """
+        if not request.use_structured_output:
             return True
 
-        # if the model needs structured in reasoning, we should advance
-        if self.enable_in_reasoning:
+        reasoner = self._get_reasoner(request)
+
+        # No reasoner or enable_in_reasoning: always advance directly.
+        if reasoner is None or self.enable_in_reasoning:
+            structured_req = request.structured_output_request
+            assert structured_req is not None
+            grammar = structured_req.grammar
+            assert isinstance(grammar, StructuredOutputGrammar)
+            if new_token_ids:
+                return grammar.accept_tokens(request.request_id, new_token_ids)
             return True
 
         structured_req = request.structured_output_request
-        if structured_req.reasoning_ended:
-            return True
+        assert structured_req is not None
 
-        # Check if reasoning ends in *this* step.
-        # When the caller passes new_token_ids (the tokens that were just
-        # appended this step), use it directly as the delta window. The
-        # placeholder-derived fallback assumes num_output_placeholders ==
-        # len(new_token_ids), which breaks under async scheduling + spec
-        # decode when some drafts are rejected (#43388): the placeholder
-        # count remains > 0 after the step and the computed delta window
-        # starts past the reasoning-end marker.
-        all_token_ids = request.all_token_ids
-        if new_token_ids:
-            # The tokens were already appended this step, so the step window
-            # starts exactly len(new_token_ids) from the end.
+        if not structured_req.reasoning_ended:
+            # Check whether reasoning ends in *this* step's tokens.
+            all_token_ids = request.all_token_ids
             start = len(all_token_ids) - len(new_token_ids)
             delta_ids: Iterable[int] = new_token_ids
-        else:
-            delta_from = request.num_computed_tokens - request.num_output_placeholders
-            start = (
-                delta_from
-                if delta_from >= 0
-                else max(len(all_token_ids) + delta_from, 0)
-            )
-            delta_ids = itertools.islice(all_token_ids, start, None)
-        if reasoner.is_reasoning_end_streaming(all_token_ids, delta_ids):
-            structured_req.reasoning_ended = True
+            if reasoner.is_reasoning_end_streaming(all_token_ids, delta_ids):
+                structured_req.reasoning_ended = True
+                end_index = self._find_reasoning_end_index(
+                    reasoner, all_token_ids, start
+                )
+                structured_req.reasoning_end_token_index = end_index
+            else:
+                # Still reasoning — grammar stays idle.
+                return True
 
-            # Record the boundary so the scheduler can exclude reasoning tokens.
-            end_index = self._find_reasoning_end_index(reasoner, all_token_ids, start)
-
-            structured_req.reasoning_end_token_index = end_index
+        # Reasoning has ended (either now or in a prior step).
+        # Trim reasoning content from the token window before advancing.
+        advance_token_ids = self._trim_reasoning_tokens(
+            request, new_token_ids
+        )
+        if not advance_token_ids:
             return True
 
-        return False
+        grammar = structured_req.grammar
+        assert isinstance(grammar, StructuredOutputGrammar)
+        return grammar.accept_tokens(request.request_id, advance_token_ids)
+
+    def filter_draft_tokens(
+        self,
+        request: "Request",
+        spec_token_ids: list[int],
+    ) -> list[int]:
+        """Validate draft tokens against the grammar.
+
+        Returns the possibly-truncated token list.  When the request is
+        still in its reasoning phase the drafts are passed through
+        unchanged — the caller does not need to check reasoning state.
+        """
+        if not request.use_structured_output:
+            return spec_token_ids
+
+        reasoner = self._get_reasoner(request)
+        if reasoner is not None and not self.enable_in_reasoning:
+            structured_req = request.structured_output_request
+            assert structured_req is not None
+            if not structured_req.reasoning_ended:
+                return spec_token_ids
+
+        structured_req = request.structured_output_request
+        assert structured_req is not None
+        grammar = structured_req.grammar
+        assert isinstance(grammar, StructuredOutputGrammar)
+        return grammar.validate_tokens(spec_token_ids)
 
     @staticmethod
     def _find_reasoning_end_index(
@@ -459,15 +486,15 @@ class StructuredOutputManager:
                 return idx
         return len(all_token_ids) - 1
 
-    def trim_reasoning_for_advance(
+    def _trim_reasoning_tokens(
         self, request: "Request", new_token_ids: list[int]
     ) -> list[int]:
         """Drops reasoning content from tokens about to advance the grammar.
 
-        When reasoning ends mid-step (see should_advance), the step's output
-        still contains reasoning tokens up to and including the end marker.
-        Those are not grammar content: feeding them to accept_tokens makes
-        the grammar reject the marker and kills the request (#44006).
+        When reasoning ends mid-step, the step's output still contains
+        reasoning tokens up to and including the end marker.  Those are not
+        grammar content: feeding them to accept_tokens makes the grammar
+        reject the marker and kills the request (#44006).
 
         Returns:
             The suffix of ``new_token_ids`` that follows the reasoning-end


### PR DESCRIPTION
## Motivation

When speculative decoding, reasoning (thinking), and structured output (grammar) are all active, the scheduler needs to coordinate three concerns: (1) detecting when the reasoning-end marker (`</think>`) appears mid-batch in draft tokens, (2) trimming reasoning content before feeding tokens to the grammar FSM, and (3) applying/advancing the grammar correctly.

Currently the scheduler orchestrates this by calling `should_advance()`, `trim_reasoning_for_advance()`, and then directly calling `grammar.accept_tokens()` / `grammar.validate_tokens()` across **4 call sites** in `scheduler.py`. The reasoning boundary state leaks into the scheduler as a boolean return from `should_advance()`, and the scheduler must then branch on it and manually orchestrate the FSM.

PR #36138 attempted to fix this by adding **4 new functions called from 3 scheduler sites** — the reviewer (@njhill) said "too complex."

## Design

This PR encapsulates the entire reasoning↔grammar transition behind **two single-entry-point methods** on `StructuredOutputManager`, following the same architectural pattern used by gRPC's `MessageDeframer.deframe()`, Apache Arrow's `MessageDecoder.Consume()`, and Netty's `HttpServerCodec.upgradeFrom()`: the component that owns the validation rules owns the state transition, and the orchestrator calls one method without knowing about internal mode boundaries.

### Before (4 scheduler entry points into StructuredOutputManager)

```
scheduler.py:
  should_advance(request, new_token_ids)  →  bool     # site 1
  trim_reasoning_for_advance(request, tokens)  → list # site 2
  grammar.accept_tokens(req_id, tokens)  → bool       # direct FSM call
  should_advance(request)  →  bool                    # sites 3, 4
  grammar.validate_tokens(spec_tokens)  → list         # direct FSM call
```

### After (3 scheduler entry points)

```python
# site 1: update_from_output — commit accepted tokens
if not self.structured.advance_grammar(request, new_token_ids):
    request.status = FINISHED_ERROR

# site 2: update_draft_token_ids — validate drafts
spec_tokens = self.structured.filter_draft_tokens(request, spec_tokens)

# site 3: update_draft_token_ids_in_output — validate drafts
spec_tokens = self.structured.filter_draft_tokens(request, spec_tokens)
```

### What changed

**`StructuredOutputManager`:**
- **Added** `advance_grammar(request, new_token_ids) -> bool` — encapsulates reasoning-end detection + reasoning-token trimming + `grammar.accept_tokens()`. Returns `False` when grammar rejects (→ scheduler kills request).
- **Added** `filter_draft_tokens(request, spec_token_ids) -> list[int]` — encapsulates reasoning-state check + `grammar.validate_tokens()`. Returns drafts unchanged while reasoning is active.
- **Removed** `should_advance()` — logic absorbed into `advance_grammar` / `filter_draft_tokens`.
- **Renamed** `trim_reasoning_for_advance()` → `_trim_reasoning_tokens()` (now private).
- **`grammar_bitmask()`** — internal comment updated to reference `advance_grammar` instead of the removed `should_advance`.

**`scheduler.py`:**
- Removed direct `grammar.accept_tokens()` / `grammar.validate_tokens()` calls — the scheduler no longer touches the FSM directly.
- Removed `StructuredOutputGrammar` import (no longer used).
- 3 call sites each reduced to a single method call.

### Comparison

| | Before (main) | PR #36138 | This PR |
|---|---|---|---|
| Scheduler entry points | 4 methods | 4 new functions | **3 methods** |
| Scheduler FSM calls | 3 (accept/validate direct) | 0 | **0** |
| Scheduler knows reasoning state | Yes (`should_advance` bool) | No | **No** |
| New public methods | 0 | 4 | **2** |

## Test Plan

- [ ] `tests/v1/structured_output/test_reasoning_structured_output.py` — rewritten to test `advance_grammar` and `filter_draft_tokens`
- [ ] `tests/v1/spec_decode/test_mtp_structured_output.py` — boundary tests rewritten against `advance_grammar`
- [ ] `tests/v1/core/test_scheduler.py` — mock updated to new API
- [ ] `tests/v1/core/test_async_scheduler.py` — mock updated to new API
- [ ] Full CI suite
