### PR TITLE
[Frontend][Bugfix] Preserve MCP tool result semantics

### DIFF
--- a/tests/entrypoints/openai/responses/test_mcp_tools.py
+++ b/tests/entrypoints/openai/responses/test_mcp_tools.py
@@ -4,12 +4,17 @@
 
 from __future__ import annotations
 
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
 import pytest
 import pytest_asyncio
 from openai import OpenAI
 from openai_harmony import Message, ToolDescription, ToolNamespaceConfig
 
 from tests.utils import RemoteOpenAIServer
+from vllm.entrypoints.mcp.result import MCPClientSessionAdapter, normalize_tool_result
 from vllm.entrypoints.mcp.tool_server import MCPToolServer
 
 from .conftest import (
@@ -108,6 +113,123 @@ class TestMCPToolServerUnit:
             f"BUILTIN_TOOL_TO_MCP_SERVER_LABEL values "
             f"{set(BUILTIN_TOOL_TO_MCP_SERVER_LABEL.values())}"
         )
+
+    @pytest.mark.asyncio
+    async def test_duplicate_server_name_keeps_first_server(self, monkeypatch):
+        responses = iter(
+            [
+                (
+                    SimpleNamespace(
+                        serverInfo=SimpleNamespace(name="duplicate"),
+                        instructions="first server",
+                    ),
+                    SimpleNamespace(tools=[]),
+                ),
+                (
+                    SimpleNamespace(
+                        serverInfo=SimpleNamespace(name="duplicate"),
+                        instructions="second server",
+                    ),
+                    SimpleNamespace(tools=[]),
+                ),
+            ]
+        )
+
+        async def mock_list_server_and_tools(_url):
+            return next(responses)
+
+        monkeypatch.setattr(
+            "vllm.entrypoints.mcp.tool_server.list_server_and_tools",
+            mock_list_server_and_tools,
+        )
+
+        server = MCPToolServer.__new__(MCPToolServer)
+        await server.add_tool_server("first:8000,second:8000")
+
+        description = server.get_tool_description("duplicate")
+        assert description is not None
+        assert description.description == "first server"
+        assert server.urls["duplicate"] == "http://first:8000/sse"
+
+
+class TestMCPToolResultNormalization:
+    def test_plain_text_result_is_unchanged(self):
+        from mcp.types import CallToolResult, TextContent
+
+        result = CallToolResult(content=[TextContent(text="plain output")])
+
+        assert normalize_tool_result(result) is result
+
+    @pytest.mark.parametrize(
+        "result_kwargs",
+        [
+            {"content": []},
+            {
+                "content": [
+                    {"type": "text", "text": "first"},
+                    {"type": "text", "text": "second"},
+                ]
+            },
+            {
+                "content": [{"type": "text", "text": "invalid input"}],
+                "isError": True,
+            },
+            {
+                "content": [{"type": "text", "text": "summary"}],
+                "structuredContent": {"answer": 42},
+            },
+            {
+                "content": [
+                    {"type": "image", "data": "aW1hZ2U=", "mimeType": "image/png"}
+                ]
+            },
+        ],
+        ids=["empty", "multiple", "error", "structured", "image"],
+    )
+    def test_rich_result_preserves_mcp_fields_as_json(self, result_kwargs):
+        from mcp.types import CallToolResult
+
+        result = CallToolResult.model_validate(result_kwargs)
+        normalized = normalize_tool_result(result)
+
+        assert len(normalized.content) == 1
+        assert normalized.content[0].type == "text"
+        payload = json.loads(normalized.content[0].text)
+        expected = result.model_dump(mode="json", by_alias=True, exclude_none=True)
+        if result.content and result.content[0].type == "image":
+            expected["content"][0]["data"] = "<omitted 8 base64 characters>"
+        assert payload == expected
+
+    def test_transport_metadata_is_not_exposed_to_model(self):
+        from mcp.types import CallToolResult, TextContent
+
+        result = CallToolResult(
+            content=[TextContent(text="output", _meta={"content-secret": "value"})],
+            _meta={"result-secret": "value"},
+            isError=True,
+        )
+
+        payload = json.loads(normalize_tool_result(result).content[0].text)
+
+        assert "_meta" not in payload
+        assert "_meta" not in payload["content"][0]
+
+    @pytest.mark.asyncio
+    async def test_session_adapter_normalizes_call_tool_result(self):
+        from mcp.types import CallToolResult, TextContent
+
+        result = CallToolResult(
+            content=[TextContent(text="failed")],
+            isError=True,
+        )
+        session = SimpleNamespace(call_tool=AsyncMock(return_value=result))
+
+        normalized = await MCPClientSessionAdapter(session).call_tool(
+            "search", {"query": "vLLM"}
+        )
+
+        session.call_tool.assert_awaited_once_with("search", {"query": "vLLM"})
+        assert json.loads(normalized.content[0].text)["isError"] is True
 
 
 class TestMCPEnabled:

--- a/vllm/entrypoints/mcp/result.py
+++ b/vllm/entrypoints/mcp/result.py
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import json
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from mcp.types import CallToolResult
+
+
+def _model_visible_result(result: "CallToolResult") -> str:
+    payload = result.model_dump(mode="json", by_alias=True, exclude_none=True)
+    payload.pop("_meta", None)
+    for block in payload["content"]:
+        block.pop("_meta", None)
+        if block["type"] in ("image", "audio"):
+            block["data"] = f"<omitted {len(block['data'])} base64 characters>"
+        elif block["type"] == "resource":
+            block["resource"].pop("_meta", None)
+            if blob := block["resource"].get("blob"):
+                block["resource"]["blob"] = f"<omitted {len(blob)} base64 characters>"
+    return json.dumps(payload, ensure_ascii=False, separators=(",", ":"))
+
+
+def normalize_tool_result(result: "CallToolResult") -> "CallToolResult":
+    """Convert rich MCP results into model-readable text."""
+    if (
+        len(result.content) == 1
+        and result.content[0].type == "text"
+        and result.structured_content is None
+        and not result.is_error
+        and getattr(result, "result_type", "complete") == "complete"
+    ):
+        return result
+
+    from mcp.types import TextContent
+
+    content = _model_visible_result(result)
+    return result.model_copy(update={"content": [TextContent(text=content)]})
+
+
+class MCPClientSessionAdapter:
+    """Preserve MCP result semantics for text-only model input paths."""
+
+    def __init__(self, session: Any) -> None:
+        self._session = session
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._session, name)
+
+    async def call_tool(self, *args: Any, **kwargs: Any) -> "CallToolResult":
+        result = await self._session.call_tool(*args, **kwargs)
+        return normalize_tool_result(result)

--- a/vllm/entrypoints/mcp/tool_server.py
+++ b/vllm/entrypoints/mcp/tool_server.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any
 
 from openai_harmony import ToolDescription, ToolNamespaceConfig
 
+from vllm.entrypoints.mcp.result import MCPClientSessionAdapter
 from vllm.entrypoints.mcp.tool import HarmonyBrowserTool, HarmonyPythonTool, Tool
 from vllm.logger import init_logger
 
@@ -132,15 +133,15 @@ class MCPToolServer(ToolServer):
                     for tool in list_tools_response.tools
                 ],
             )
-            self.harmony_tool_descriptions[tool_from_mcp.name] = tool_from_mcp
-            if tool_from_mcp.name not in self.urls:
-                self.urls[tool_from_mcp.name] = url
-            else:
+            if tool_from_mcp.name in self.urls:
                 logger.warning(
                     "Tool %s already exists. Ignoring duplicate tool server %s",
                     tool_from_mcp.name,
                     url,
                 )
+                continue
+            self.harmony_tool_descriptions[tool_from_mcp.name] = tool_from_mcp
+            self.urls[tool_from_mcp.name] = url
         logger.info(
             "MCPToolServer initialized with tools: %s",
             list(self.harmony_tool_descriptions.keys()),
@@ -191,7 +192,7 @@ class MCPToolServer(ToolServer):
             ClientSession(*streams) as session,
         ):
             await session.initialize()
-            yield session
+            yield MCPClientSessionAdapter(session)
 
 
 class DemoToolServer(ToolServer):


### PR DESCRIPTION
## Purpose

Preserve the semantics of rich MCP `CallToolResult` values returned to
multi-turn agents.

Previously, MCP results were reduced to `result.content[0].text`. This dropped
additional content blocks, `structuredContent`, and the `isError` flag. It could
also fail when the result had no content. As a result, an agent could lose tool
output or be unable to distinguish a successful result from an MCP tool error.

This PR:

- Keeps the existing plain-text output for a single text content block.
- Serializes multi-block, structured, empty, and error results into a
  model-readable JSON representation.
- Represents image, audio, and binary resource payloads using type and size
  metadata instead of injecting their complete base64 data into model context.
- Excludes MCP `_meta` data from model-visible output.
- Makes duplicate MCP namespace registration atomic, so the first configured
  server remains authoritative and later duplicate namespaces are skipped with
  a warning.
- Adds focused tests for plain text, empty results, multiple content blocks,
  structured content, errors, images, metadata exclusion, and duplicate
  namespaces.

### Non-duplication

I searched the open vLLM PRs for `MCP tool result`, `CallToolResult`,
`structuredContent`, `duplicate MCP server`, and `MCP namespace`.

The potentially related open PRs do not implement this change:

- #38225 prevents `IndexError` when Harmony message or tool content is empty.
  It does not preserve structured, multi-block, or error MCP result semantics.
- #46784 and #49581 handle flattening and unflattening Responses API namespace
  tool names.
- #43335 handles assistant preamble text before a tool call.
- #47213 adds browser backend configuration.

None of these PRs modify MCP result normalization or duplicate MCP server
registration.

## Test Plan

```bash
.venv/bin/python -m pytest \
  tests/entrypoints/openai/responses/test_mcp_tools.py -v

pre-commit run ruff-check --files \
  vllm/entrypoints/mcp/result.py \
  vllm/entrypoints/mcp/tool_server.py \
  tests/entrypoints/openai/responses/test_mcp_tools.py

pre-commit run ruff-format --files \
  vllm/entrypoints/mcp/result.py \
  vllm/entrypoints/mcp/tool_server.py \
  tests/entrypoints/openai/responses/test_mcp_tools.py

git diff --check upstream/main...HEAD
```

## Test Result

- Ruff check: passed.
- Ruff format check: passed.
- Python compilation check: passed.
- `git diff --check`: passed.
- Focused MCP result-adapter behavior checks: passed.
- The pytest suite could not complete in the local Windows environment because
  `uvloop` is unavailable during test collection. The focused pytest command
  still needs to be run in a supported Linux environment.

No model evaluation has been run yet. This change does not modify model weights,
sampling, or generated logits, but it does change the tool-result context
observed by multi-turn agents. A Linux multi-turn agent evaluation should be
reported before merge.

## AI Assistance

OpenAI Codex was used to help investigate the issue, implement the change,
write tests, and prepare this PR. I reviewed the changed code and can explain
and maintain the implementation.