### PR TITLE
[Metrics] Report CPU offload capacity in tokens

### DIFF
--- a/tests/v1/kv_offload/cpu/test_manager.py
+++ b/tests/v1/kv_offload/cpu/test_manager.py
@@ -37,6 +37,7 @@ _EMPTY_REQ_CTX = make_req_context()
 
 def make_cpu_manager(
     num_blocks: int = 4,
+    tokens_per_chunk: int = 0,
     cache_policy: str = "lru",
     cache_policy_module_path: str | None = None,
     enable_events: bool = False,
@@ -45,6 +46,7 @@ def make_cpu_manager(
 ) -> CPUOffloadingManager:
     return CPUOffloadingManager(
         num_blocks=num_blocks,
+        tokens_per_chunk=tokens_per_chunk,
         cache_policy=cache_policy,
         cache_policy_module_path=cache_policy_module_path,
         enable_events=enable_events,
@@ -271,6 +273,19 @@ def test_cpu_manager_reports_cache_usage_gauge():
     # and usage drops.
     manager.complete_store(to_keys([3, 4]), _EMPTY_REQ_CTX)
     check_usage_stats(manager, 0.0)
+
+
+def test_cpu_manager_reports_capacity_tokens_gauge():
+    manager = make_cpu_manager(num_blocks=4, tokens_per_chunk=64)
+    stats = manager.get_stats()
+    assert stats is not None
+    assert stats.reduce()[CPUOffloadingMetrics.CPU_CAPACITY_TOKENS] == 256
+
+    # An unknown token span leaves the capacity unreported.
+    manager = make_cpu_manager(num_blocks=4)
+    stats = manager.get_stats()
+    assert stats is not None
+    assert CPUOffloadingMetrics.CPU_CAPACITY_TOKENS not in stats.reduce()
 
 
 def test_cpu_manager_reports_allocation_size_histogram():

--- a/tests/v1/kv_offload/test_factory.py
+++ b/tests/v1/kv_offload/test_factory.py
@@ -21,6 +21,7 @@ from vllm.v1.kv_offload.config import (
     OffloadingModelConfig,
     OffloadingParallelConfig,
 )
+from vllm.v1.kv_offload.cpu.common import CPUOffloadingMetrics
 from vllm.v1.kv_offload.cpu.shared_offload_region import SharedOffloadRegion
 from vllm.v1.kv_offload.cpu.spec import CPUOffloadingSpec
 from vllm.v1.kv_offload.factory import OffloadingSpecFactory
@@ -153,6 +154,66 @@ def test_cpu_spec_sizes_normalized_worker_layout():
     assert spec.cpu_page_size_per_worker == 32
     assert spec.kv_bytes_per_chunk == alignment
     assert spec.num_blocks == 3
+
+
+def test_cpu_spec_reports_capacity_tokens_for_single_group():
+    alignment = SharedOffloadRegion.BLOCK_SIZE_ALIGNMENT
+    spec = _create_spec(
+        cpu_bytes_to_use=alignment * 3,
+        worker_kv_bytes_per_block=alignment // 2,
+        groups=(OffloadingGroupConfig(32, ("layer",)),),
+        blocks_per_chunk=2,
+    )
+
+    assert isinstance(spec, CPUOffloadingSpec)
+    assert spec.num_blocks == 3
+    stats = spec.get_manager().get_stats()
+    assert stats is not None
+    assert stats.reduce()[CPUOffloadingMetrics.CPU_CAPACITY_TOKENS] == 192
+
+
+def test_tiering_spec_reports_cpu_capacity_tokens(monkeypatch):
+    import vllm.v1.kv_offload.tiering.spec as tiering_spec_module
+
+    alignment = SharedOffloadRegion.BLOCK_SIZE_ALIGNMENT
+    monkeypatch.setattr(tiering_spec_module, "SharedOffloadRegion", MagicMock)
+    spec = _create_spec(
+        spec_name="TieringOffloadingSpec",
+        cpu_bytes_to_use=alignment * 3,
+        worker_kv_bytes_per_block=alignment // 2,
+        groups=(OffloadingGroupConfig(32, ("layer",)),),
+        blocks_per_chunk=2,
+    )
+
+    assert isinstance(spec, TieringOffloadingSpec)
+    stats = spec.get_manager().get_stats()
+    assert stats is not None
+    assert stats.reduce()[CPUOffloadingMetrics.CPU_CAPACITY_TOKENS] == 192
+
+
+@pytest.mark.parametrize(
+    "groups",
+    [
+        (
+            OffloadingGroupConfig(16, ("layer_0",)),
+            OffloadingGroupConfig(16, ("layer_1",)),
+        ),
+        (
+            OffloadingGroupConfig(16, ("layer_0",)),
+            OffloadingGroupConfig(32, ("layer_1",)),
+        ),
+    ],
+    ids=["equal-spans", "different-spans"],
+)
+def test_cpu_spec_omits_capacity_tokens_for_multiple_groups(
+    groups: tuple[OffloadingGroupConfig, ...],
+):
+    spec = _create_spec(groups=groups)
+
+    assert isinstance(spec, CPUOffloadingSpec)
+    stats = spec.get_manager().get_stats()
+    assert stats is not None
+    assert CPUOffloadingMetrics.CPU_CAPACITY_TOKENS not in stats.reduce()
 
 
 def test_cpu_spec_zero_worker_bytes_produces_empty_cache():

--- a/vllm/v1/kv_offload/cpu/common.py
+++ b/vllm/v1/kv_offload/cpu/common.py
@@ -9,6 +9,7 @@ class CPUOffloadingMetrics:
     CPU_ALLOCATION_SIZE = "vllm:kv_offload_cpu_allocation_size"
     CPU_CACHE_WRITE_USAGE_PERC = "vllm:kv_offload_cpu_cache_write_usage_perc"
     CPU_CACHE_READ_USAGE_PERC = "vllm:kv_offload_cpu_cache_read_usage_perc"
+    CPU_CAPACITY_TOKENS = "vllm:kv_offload_cpu_capacity_tokens"
 
 
 class CPULoadStoreSpec(BlockIDsLoadStoreSpec):

--- a/vllm/v1/kv_offload/cpu/manager.py
+++ b/vllm/v1/kv_offload/cpu/manager.py
@@ -47,9 +47,11 @@ class CPUOffloadingManager(OffloadingManager):
         enable_events: bool = False,
         store_threshold: int = 1,
         max_tracker_size: int = 64_000,
+        tokens_per_chunk: int = 0,
     ):
         self.medium: Medium = Medium.CPU
         self._num_blocks: int = num_blocks
+        self._tokens_per_chunk: int = tokens_per_chunk
         self._num_allocated_blocks: int = 0
         self._free_list: list[int] = []
         self.events: list[OffloadingEvent] | None = [] if enable_events else None
@@ -301,6 +303,12 @@ class CPUOffloadingManager(OffloadingManager):
         )
         usage = num_used / self._num_blocks if self._num_blocks > 0 else 0.0
         stats.set_gauge(CPUOffloadingMetrics.CPU_CACHE_USAGE_PERC, usage)
+
+        if self._tokens_per_chunk > 0:
+            stats.set_gauge(
+                CPUOffloadingMetrics.CPU_CAPACITY_TOKENS,
+                self._num_blocks * self._tokens_per_chunk,
+            )
 
         for allocation_size in self.allocation_sizes_in_current_batch:
             stats.observe_histogram(

--- a/vllm/v1/kv_offload/cpu/spec.py
+++ b/vllm/v1/kv_offload/cpu/spec.py
@@ -54,6 +54,13 @@ class CPUOffloadingSpec(OffloadingSpec):
                     "completed (0.0 = idle, 1.0 = saturated)."
                 ),
             ),
+            CPUOffloadingMetrics.CPU_CAPACITY_TOKENS: OffloadingGaugeMetadata(
+                documentation=(
+                    "Total capacity of the CPU KV cache in tokens. Each "
+                    "engine reports its own cache, so sum across engines "
+                    "for the capacity of the whole instance."
+                ),
+            ),
             CPUOffloadingMetrics.CPU_ALLOCATION_SIZE: OffloadingHistogramMetadata(
                 documentation=(
                     "Histogram of the number of CPU blocks requested by each "
@@ -109,6 +116,14 @@ class CPUOffloadingSpec(OffloadingSpec):
             # or |--- B0 (single copy) ---| *** maybe-pad *** |
             self.kv_bytes_per_chunk = aligned_kv_bytes_per_chunk
 
+        # Offload keys include the group index, so each group consumes a
+        # separate slot. num_blocks maps directly to tokens for one group only.
+        self.tokens_per_chunk = 0
+        if len(config.groups) == 1:
+            self.tokens_per_chunk = (
+                config.groups[0].tokens_per_block * self.blocks_per_chunk
+            )
+
         # scheduler-side
         self._manager: OffloadingManager | None = None
 
@@ -133,6 +148,7 @@ class CPUOffloadingSpec(OffloadingSpec):
 
             self._manager = CPUOffloadingManager(
                 num_blocks=self.num_blocks,
+                tokens_per_chunk=self.tokens_per_chunk,
                 cache_policy=self.eviction_policy,
                 cache_policy_module_path=self.cache_policy_module_path,
                 enable_events=self.kv_events_config.enable_kv_cache_events,

--- a/vllm/v1/kv_offload/tiering/manager.py
+++ b/vllm/v1/kv_offload/tiering/manager.py
@@ -98,9 +98,11 @@ class CPUPrimaryTierOffloadingManager(CPUOffloadingManager):
         cache_policy: str = "lru",
         cache_policy_module_path: str | None = None,
         enable_events: bool = False,
+        tokens_per_chunk: int = 0,
     ):
         super().__init__(
             num_blocks=num_blocks,
+            tokens_per_chunk=tokens_per_chunk,
             cache_policy=cache_policy,
             cache_policy_module_path=cache_policy_module_path,
             enable_events=enable_events,

--- a/vllm/v1/kv_offload/tiering/spec.py
+++ b/vllm/v1/kv_offload/tiering/spec.py
@@ -305,6 +305,7 @@ class TieringOffloadingSpec(CPUOffloadingSpec):
                 # Create primary tier (CPU-based)
                 primary_tier = CPUPrimaryTierOffloadingManager(
                     num_blocks=self.num_blocks,
+                    tokens_per_chunk=self.tokens_per_chunk,
                     cache_policy=self.eviction_policy,
                     cache_policy_module_path=self.cache_policy_module_path,
                     enable_events=self.kv_events_config.enable_kv_cache_events,


### PR DESCRIPTION
## Summary

- report `vllm:kv_offload_cpu_capacity_tokens` through the existing offloading connector stats path
- convert CPU offload chunks to tokens only when there is one KV-cache group
- propagate the capacity through the tiering CPU-primary path

## Motivation

Routers need the total cache capacity in tokens to model which prefixes are
likely to remain available on each endpoint. The CPU offload metrics expose a
usage fraction but not the total capacity behind that fraction.

`CPUOffloadingSpec.num_blocks` counts offload chunks, not GPU blocks. Each
chunk spans `blocks_per_chunk` blocks, so exposing only the chunk count requires
consumers to reproduce connector-specific conversion logic.

The direct conversion is exact only for a single KV-cache group. Offload keys
include the group index, so one logical token range consumes a separate CPU
slot for each group. This PR omits the metric for multi-group configurations
rather than overstate their capacity.

The concrete consumer is llm-d/llm-d-router#2292, which needs token capacity to
size its approximate per-endpoint cache and already consumes SGLang's host
capacity in tokens.

## Relation to #49307

#49307 exposes the complete static CPU-tier configuration at startup through a
new generic connector API. This PR is a narrower split: it exposes only the
router-facing token capacity, uses the existing connector-stats path, and does
not change engine, configuration, or global metrics APIs. The metric therefore
appears after the first scheduler step rather than at startup.

The separate scope and multi-group correctness requirement were described in
the #49307 discussion before opening this PR. This draft provides a concrete
implementation that can either land independently or be folded into #49307.

## Tests

```text
.venv/bin/python -m pytest \
  tests/v1/kv_offload/cpu/test_manager.py \
  tests/v1/kv_offload/test_factory.py -q

73 passed, 1 warning in 21.45s
```

The warning is the expected source-archive version-metadata warning:
`No module named 'vllm._version'`.

`git diff --check origin/main...HEAD` also passes.

Model evaluation is not applicable because this change only adds an
observability metric and does not affect model execution or outputs.

## AI assistance

AI assistance was used to develop and review the implementation, add tests,
and draft this description.
