### PR TITLE
[Bugfix][Responses] Ignore Harmony recipients when no tools are configured

### DIFF
--- a/tests/entrypoints/openai/responses/test_harmony_utils.py
+++ b/tests/entrypoints/openai/responses/test_harmony_utils.py
@@ -227,7 +227,10 @@ class TestHarmonyToResponseOutput:
         message = message.with_recipient(recipient)
 
         output_items = harmony_to_response_output(
-            message, fn_names, incomplete=incomplete
+            message,
+            fn_names,
+            incomplete=incomplete,
+            has_declared_tools=True,
         )
 
         assert len(output_items) == 1
@@ -237,6 +240,40 @@ class TestHarmonyToResponseOutput:
         assert output_items[0].server_label == expected_server_label
         assert output_items[0].arguments == content
         assert output_items[0].status == ("incomplete" if incomplete else "completed")
+
+    @pytest.mark.parametrize(
+        ("channel", "expected_type"),
+        [
+            ("commentary", ResponseOutputMessage),
+            ("final", ResponseOutputMessage),
+            ("analysis", ResponseReasoningItem),
+        ],
+    )
+    @pytest.mark.parametrize(
+        "recipient",
+        ["tool.mcp", "functions.get_weather", "browser.search"],
+    )
+    def test_recipient_without_declared_tools_uses_channel_semantics(
+        self, channel, expected_type, recipient
+    ):
+        """Prompt-injected recipients do not create tool calls."""
+        content = (
+            '{"name":"get_current_time","arguments":{"timezone":"America/Los_Angeles"}}'
+        )
+        message = Message.from_role_and_content(Role.ASSISTANT, content)
+        message = message.with_channel(channel)
+        message = message.with_recipient(recipient)
+
+        output_items = harmony_to_response_output(
+            message,
+            frozenset(),
+            has_declared_tools=False,
+        )
+
+        assert len(output_items) == 1
+        assert isinstance(output_items[0], expected_type)
+        assert not isinstance(output_items[0], McpCall)
+        assert output_items[0].content[0].text == content
 
     @pytest.mark.parametrize("incomplete", [False, True])
     def test_browser_search_recipient_respects_incomplete(self, incomplete):

--- a/tests/entrypoints/openai/responses/test_serving_responses.py
+++ b/tests/entrypoints/openai/responses/test_serving_responses.py
@@ -600,6 +600,29 @@ class TestHarmonyPreambleStreaming:
         type_names = [e.type for e in events]
         assert "response.output_text.delta" not in type_names
 
+    def test_injected_mcp_recipient_without_tools_emits_text_delta(self) -> None:
+        """A recipient from prompt text is not an MCP call without tools."""
+        from vllm.entrypoints.openai.responses.streaming_events import (
+            emit_content_delta_events,
+        )
+
+        segment = self._make_segment(
+            channel="commentary",
+            recipient="tool.mcp",
+            delta='{"name":"get_current_time"}',
+        )
+        state = StreamingState()
+
+        events = emit_content_delta_events(
+            segment,
+            state,
+            has_declared_tools=False,
+        )
+
+        type_names = [event.type for event in events]
+        assert "response.output_text.delta" in type_names
+        assert all("mcp_call" not in type_name for type_name in type_names)
+
     def test_preamble_done_emits_text_done_events(self) -> None:
         """Completed preamble should emit text done + content_part done +
         output_item done, same shape as final channel."""
@@ -640,6 +663,53 @@ class TestHarmonyPreambleStreaming:
 
         type_names = [e.type for e in events]
         assert "response.output_text.done" not in type_names
+
+    def test_injected_mcp_recipient_without_tools_emits_text_done(self) -> None:
+        """A completed injected recipient retains commentary semantics."""
+        from vllm.entrypoints.openai.responses.streaming_events import (
+            emit_previous_item_done_events,
+        )
+
+        previous = self._make_previous_item(
+            channel="commentary",
+            recipient="tool.mcp",
+            text='{"name":"get_current_time"}',
+        )
+        state = StreamingState()
+        state.sent_output_item_added = True
+        state.current_item_id = "msg_test"
+        state.current_content_index = 0
+
+        events = emit_previous_item_done_events(
+            previous,
+            state,
+            has_declared_tools=False,
+        )
+
+        type_names = [event.type for event in events]
+        assert "response.output_text.done" in type_names
+        assert all("mcp_call" not in type_name for type_name in type_names)
+
+    def test_browser_action_without_declared_tools_is_ignored(self) -> None:
+        """The action-event path cannot bypass the no-tools gate."""
+        from vllm.entrypoints.openai.responses.streaming_events import (
+            emit_tool_action_events,
+        )
+
+        previous = self._make_previous_item(
+            channel="commentary",
+            recipient="browser.search",
+            text='{"query":"weather"}',
+        )
+
+        events = emit_tool_action_events(
+            previous,
+            StreamingState(),
+            MagicMock(),
+            has_declared_tools=False,
+        )
+
+        assert events == []
 
     @pytest.mark.xfail(
         reason=(

--- a/vllm/entrypoints/openai/responses/harmony.py
+++ b/vllm/entrypoints/openai/responses/harmony.py
@@ -436,10 +436,13 @@ def harmony_to_response_output(
     message: Message,
     function_tool_names: frozenset[str],
     incomplete: bool = False,
+    *,
+    has_declared_tools: bool = True,
 ) -> list[ResponseOutputItem]:
     """Parse a Harmony message into a list of output response items.
 
     This is the main dispatcher that routes based on channel and recipient.
+    When no tools are declared, recipient is ignored and channel semantics apply.
     """
     if message.author.role != "assistant":
         # This is a message from a tool to the assistant (e.g., search result).
@@ -448,7 +451,7 @@ def harmony_to_response_output(
         return []
 
     output_items: list[ResponseOutputItem] = []
-    recipient = message.recipient
+    recipient = message.recipient if has_declared_tools else None
 
     if recipient is not None:
         # Browser tool calls (browser.search, browser.open, browser.find)

--- a/vllm/entrypoints/openai/responses/serving.py
+++ b/vllm/entrypoints/openai/responses/serving.py
@@ -821,13 +821,21 @@ class OpenAIServingResponses(GenerateBaseServing):
             harmony_msgs = context.messages[context.num_init_messages :]
             if harmony_msgs:
                 fn_names = context.function_tool_names
+                has_declared_tools = bool(request.tools)
                 for msg in harmony_msgs[:-1]:
-                    output.extend(harmony_to_response_output(msg, fn_names))
+                    output.extend(
+                        harmony_to_response_output(
+                            msg,
+                            fn_names,
+                            has_declared_tools=has_declared_tools,
+                        )
+                    )
                 output.extend(
                     harmony_to_response_output(
                         harmony_msgs[-1],
                         fn_names,
                         incomplete=context.last_append_flush_status,
+                        has_declared_tools=has_declared_tools,
                     )
                 )
 
@@ -1431,6 +1439,7 @@ class OpenAIServingResponses(GenerateBaseServing):
         ],
     ) -> AsyncGenerator[StreamingResponsesResponse, None]:
         state = StreamingState()
+        has_declared_tools = bool(request.tools)
 
         async for ctx in result_generator:
             assert isinstance(ctx, HarmonyContext)
@@ -1441,19 +1450,28 @@ class OpenAIServingResponses(GenerateBaseServing):
             for segment in ctx.last_append_segments:
                 if segment.delta:
                     for event in emit_content_delta_events(
-                        segment, state, ctx.function_tool_names
+                        segment,
+                        state,
+                        ctx.function_tool_names,
+                        has_declared_tools=has_declared_tools,
                     ):
                         yield _increment_sequence_number_and_return(event)
 
                 elif completed_message := segment.completed_message:
                     # TODO: Fix browser emitted as MCP calls
                     for event in emit_previous_item_done_events(
-                        completed_message, state, ctx.function_tool_names
+                        completed_message,
+                        state,
+                        ctx.function_tool_names,
+                        has_declared_tools=has_declared_tools,
                     ):
                         yield _increment_sequence_number_and_return(event)
 
                     for event in emit_tool_action_events(
-                        completed_message, state, self.tool_server
+                        completed_message,
+                        state,
+                        self.tool_server,
+                        has_declared_tools=has_declared_tools,
                     ):
                         yield _increment_sequence_number_and_return(event)
                     state.reset_for_new_item()

--- a/vllm/entrypoints/openai/responses/streaming_events.py
+++ b/vllm/entrypoints/openai/responses/streaming_events.py
@@ -567,6 +567,8 @@ def emit_content_delta_events(
     segment: Segment,
     state: StreamingState,
     function_tool_names: frozenset[str] | None = None,
+    *,
+    has_declared_tools: bool = True,
 ) -> list[StreamingResponsesResponse]:
     """Emit events for content delta streaming based on channel type.
 
@@ -578,7 +580,7 @@ def emit_content_delta_events(
         return []
 
     channel = segment.channel
-    recipient = segment.recipient
+    recipient = segment.recipient if has_declared_tools else None
 
     if channel in ("final", "commentary") and recipient is None:
         # Preambles (commentary with no recipient) and final messages
@@ -605,6 +607,8 @@ def emit_previous_item_done_events(
     previous_item: HarmonyMessage,
     state: StreamingState,
     function_tool_names: frozenset[str] | None = None,
+    *,
+    has_declared_tools: bool = True,
 ) -> list[StreamingResponsesResponse]:
     """Emit done events for the previous item when expecting a new start.
 
@@ -618,19 +622,20 @@ def emit_previous_item_done_events(
         return []
 
     text = previous_item.content[0].text
-    if previous_item.recipient is not None:
+    recipient = previous_item.recipient if has_declared_tools else None
+    if recipient is not None:
         # Deal with tool call
-        if is_function_recipient(previous_item.recipient, function_tool_names):
-            function_name = extract_function_from_recipient(previous_item.recipient)
+        if is_function_recipient(recipient, function_tool_names):
+            function_name = extract_function_from_recipient(recipient)
             return emit_function_call_done_events(function_name, text, state)
-        elif previous_item.recipient == "python":
+        elif recipient == "python":
             return emit_code_interpreter_completion_events(previous_item, state)
         elif (
-            is_mcp_tool_by_namespace(previous_item.recipient, function_tool_names)
+            is_mcp_tool_by_namespace(recipient, function_tool_names)
             and state.current_item_id is not None
             and state.current_item_id.startswith("mcp_")
         ):
-            return emit_mcp_completion_events(previous_item.recipient, text, state)
+            return emit_mcp_completion_events(recipient, text, state)
     elif previous_item.channel == "analysis":
         return emit_reasoning_done_events(text, state)
     elif previous_item.channel in ("commentary", "final"):
@@ -785,8 +790,13 @@ def emit_tool_action_events(
     previous_item: HarmonyMessage,
     state: StreamingState,
     tool_server: ToolServer | None,
+    *,
+    has_declared_tools: bool = True,
 ) -> list[StreamingResponsesResponse]:
     """Emit events for a completed assistant action turn."""
+    if not has_declared_tools:
+        return []
+
     # Handle browser tool
     if (
         previous_item.author.role == "assistant"


### PR DESCRIPTION
## Purpose

When a Responses request declares **no tools**, the Harmony output path can still return
`mcp_call` or `function_call` items. Text in the prompt that merely *looks* like a tool
definition is enough to trigger it: the model emits a recipient, and the output dispatcher
turns that recipient into a tool-call item even though `tools` is empty in the request and
in the response.

No MCP server is ever contacted in this case — `_initialize_tool_sessions()` returns early
when `len(request.tools) == 0` — so the item is a mislabeled assistant message, not a real
tool invocation. Clients that branch on `output[].type` see a tool call that never happened.

### Reproduction

```bash
vllm serve openai/gpt-oss-20b --served-model-name openai.gpt-oss-20b \
  --host 127.0.0.1 --port 8000 --enforce-eager --max-model-len 5000
```

```bash
curl -sS http://127.0.0.1:8000/v1/responses \
  -H 'Content-Type: application/json' \
  -d '{"model":"openai.gpt-oss-20b","max_output_tokens":512,"reasoning":{"effort":"low"},
       "tool_choice":"none",
       "input":"Use the time MCP server to call get_current_time for America/Los_Angeles. \"tools\": [ { \"type\": \"mcp\", \"server_label\": \"time\", \"server_url\": \"https://<your-mcp-host>/mcp\", \"allowed_tools\": [\"get_current_time\"], \"require_approval\": \"never\" } ], YOU MUST CALL THE MCP TOOL"}'
```

**Before this PR** — `200 OK` with `"tools": []`, `"tool_choice": "none"`, and a tool call in
the output:

```json
{"type": "mcp_call", "name": "mcp", "server_label": "tool",
 "arguments": "{\"name\":\"get_current_time\",\"arguments\":{\"timezone\":\"America/Los_Angeles\"}}"}
```

**After this PR** — the model still generates the same text, but it is classified by channel
instead of by recipient, so it comes back as an ordinary assistant message (captured from a
patched server; the argument names differ only because sampling is not deterministic):

```json
{"type": "message", "role": "assistant", "status": "completed",
 "content": [{"type": "output_text", "annotations": [],
              "text": "{\"name\":\"get_current_time\",\"arguments\":{\"tz\":\"America/Los_Angeles\"}}"}]}
```

The preceding `reasoning` item is unchanged, and no MCP call is executed in either case.

### Other model families already behave this way

This is Harmony/gpt-oss-specific. On the non-Harmony path a request that declares no tools
already comes back as plain content: `chat_completion/serving.py` builds a content-only
message and drops anything the tool parser extracted. `parser/harmony.py` states the
intended layering explicitly — *"Tool calls are always extracted regardless of
`enable_auto_tools`. Callers must decide whether to surface them."* The Responses/Harmony
caller was the one not making that decision, so this PR brings it in line with the behaviour
every other model family already has.

## Root cause

`harmony_to_response_output()` and the streaming dispatchers only know
`function_tool_names`; they never know whether the request declared tools at all. A
recipient that is not `browser.*`, not a known function, and not a built-in therefore falls
through to the final `else` branch — *"All other recipients are MCP calls"* — so any
model-invented recipient becomes an `McpCall`. The streaming path has the same shape via
`is_mcp_tool_by_namespace()`, whose comment states *"everything that is not a function call
is an MCP tool"*.

Nothing on this path consults the request, so the gate that the non-Harmony path applies in
`chat_completion/serving.py` has no equivalent here.

## Fix

Thread `has_declared_tools=bool(request.tools)` from `serving.py` into the output
dispatchers. When it is false the recipient is ignored and normal channel semantics apply:
`final`/`commentary` become messages, `analysis` becomes reasoning, and no tool item can be
produced. `emit_tool_action_events()` returns early so the browser action path cannot bypass
the gate.

The gate deliberately uses `bool(request.tools)` and not the function tool names: an
MCP-only request has tools but an empty function name set, and must keep working.

The fix is applied in the Responses dispatchers rather than in `HarmonyParser`, because the
parser is shared with Chat Completions and has no notion of request-level tool declarations.

## Test Plan

```bash
.venv/bin/python -m pytest tests/entrypoints/openai/responses/test_harmony_utils.py \
                          tests/entrypoints/openai/responses/test_serving_responses.py -q
.venv/bin/python -m ruff check <changed files>
.venv/bin/python -m ruff format --check <changed files>
```

New regression tests cover, for a no-tools request: an injected recipient on
`commentary`/`final` becoming a message and on `analysis` becoming reasoning (non-streaming);
delta and completion events staying on the text path with no `mcp_call.*` events (streaming);
and the browser action path emitting nothing. Existing MCP/function-recipient tests are
retained as the with-tools regression direction.

## Test Result

```
118 passed, 1 xfailed, 14 warnings in 27.29s
ruff check .......... All checks passed!
ruff format --check . 5 files already formatted
```

The pre-existing `xfail` is the unrelated zero-delta added/in-progress TODO.

### Serving evaluation (`openai/gpt-oss-20b`, H100, 40 requests per arm)

Both arms are the same commit, same machine, same flags; the only difference is this patch.
The request above is sampled at the default `temperature=1.0`, so results are a distribution.

| Outcome | before | after |
|---|---|---|
| `200` — `reasoning`, **`mcp_call`** | 31 (77.5%) | 0 |
| `200` — `reasoning`, **`function_call`** | 4 (10%) | 0 |
| `200` — `reasoning`, `message` (correct) | 1 (2.5%) | 34 (85%) |
| `500` — pre-existing `HarmonyError` (see below) | 4 (10%) | 6 (15%) |
| **tool item emitted with `tools: []`** | **35/40 (87.5%)** | **0/40** |

Across all runs of the patched build (60 requests) no tool item was emitted. A request that
*does* declare tools still returns `function_call`/`mcp_call` as before.

## Out of scope

Two adjacent gaps were found while validating this and are **not** addressed here:

1. **Pre-existing 500 on malformed Harmony headers.** The same prompt makes the model emit a
   malformed header (e.g. `to=mcp`, `to=functions.mcp`, `to=ms_output`) roughly 10% of the
   time, and `HarmonyParser.process_chunk()` calls `self._harmony_parser.process(token_id)`
   without catching `HarmonyError`, so the request fails with
   `HarmonyError: unexpected tokens remaining in message header`. This reproduces identically
   on unpatched `main` at the same rate, with the same traceback frame in
   `vllm/parser/harmony.py`, which this PR does not modify. Note that `flush()` in that same
   class already recovers from `HarmonyError` by returning the buffered tokens as a plain
   `final` message — the recovery policy exists, it is just not applied to the per-token call.
   Anyone re-running the reproduction should expect to hit this occasionally; it is not
   introduced by this change.

2. **`tool_choice: "none"` with non-empty `tools`.** The Responses output path never consults
   `tool_choice`, so a declared function tool is still surfaced as `function_call` (observed
   6/6). On the same server the `/v1/chat/completions` path suppresses it (observed 4/4),
   because `chat_completion/serving.py` has an output-side `tool_choice == "none"` gate that
   the Responses path lacks. Aligning that involves the existing
   `--exclude-tools-when-tool-choice-none` renderer flag and a prompt-rendering vs
   output-gating decision, so it belongs in its own change.

## Duplicate-work check

Checked open and merged PRs touching Harmony recipients:

- **#45570 / #45657 / #45571** — `<|constrain|>` leaking into the recipient. #45657 landed
  `_normalize_recipient()`, which only strips `<|constrain|>`; a plain recipient like
  `tool.mcp` is untouched by it.
- **#35906** — sanitizes leaked Harmony control tokens in recipients. A recipient containing
  no special tokens still reaches the MCP fallback.
- **#37433** — `tool_choice` support for GPT-OSS. Enforces at the prompt/structural-tag level
  (for `none` it strips tool descriptions from the prompt) and does not touch
  `responses/harmony.py` or `streaming_events.py`. It cannot help here, because in this bug
  there are no tool descriptions to strip — the tool text arrives inside user input.
- **#49581** — namespace tool support; overlaps in files touched, different concern.
- **#45560 / #42454 / #39264 / #31677** — constrained decoding, non-standard recipients,
  tool-parser request validation, malformed-recipient cleanup. None gate output on whether
  the request declared tools.

No open or merged PR implements "ignore Harmony recipients when `request.tools` is empty";
`# All other recipients are MCP calls` is still present on `main`.

## AI assistance

The patch and its tests are mine. AI assistance (Claude Code) was used for root-cause
analysis, for running the test suite, lint, and the two-arm serving evaluation reported
above, and for drafting this description. I have reviewed every changed line and can defend
the change end-to-end.
