### PR TITLE
fix(layers): parenthesize implicit string concatenations in tuple returns to fix ISC004 warnings

### DIFF
--- a/vllm/model_executor/layers/quantization/utils/allspark_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/allspark_utils.py
@@ -27,16 +27,20 @@ def check_allspark_supported_dtype_shape(
         if group_size != -1:
             return (
                 False,
-                "For Ampere GPU, AllSpark does not support group_size "
-                f"= {group_size}. Only group_size = -1 are supported.",
+                (
+                    "For Ampere GPU, AllSpark does not support group_size "
+                    f"= {group_size}. Only group_size = -1 are supported."
+                ),
             )
 
         if weight_dtype not in ALLSPARK_SUPPORTED_QUANT_TYPES:
             return (
                 False,
-                "For Ampere GPU, AllSpark does not support "
-                f"quant type ({weight_dtype}). Only quant type "
-                f"({ALLSPARK_SUPPORTED_QUANT_TYPES}) are supported.",
+                (
+                    "For Ampere GPU, AllSpark does not support "
+                    f"quant type ({weight_dtype}). Only quant type "
+                    f"({ALLSPARK_SUPPORTED_QUANT_TYPES}) are supported."
+                ),
             )
 
         if (
@@ -45,23 +49,29 @@ def check_allspark_supported_dtype_shape(
         ):
             return (
                 False,
-                "AllSpark needs input_size_per_partition % "
-                f"{ALLSPARK_AMPERE_K_ALIGN} = 0 and "
-                f"output_size_per_partition % {ALLSPARK_AMPERE_N_ALIGN} = 0 "
-                "for Ampere GPU optimized kernels.",
+                (
+                    "AllSpark needs input_size_per_partition % "
+                    f"{ALLSPARK_AMPERE_K_ALIGN} = 0 and "
+                    f"output_size_per_partition % {ALLSPARK_AMPERE_N_ALIGN} = 0 "
+                    "for Ampere GPU optimized kernels."
+                ),
             )
 
         if act_dtype != torch.float16 and act_dtype != torch.bfloat16:
             return (
                 False,
-                "AllSpark only supports act_dtype = float16 or bfloat16,"
-                f"for Ampere GPU, but got act_dtype = {act_dtype}.",
+                (
+                    "AllSpark only supports act_dtype = float16 or bfloat16,"
+                    f"for Ampere GPU, but got act_dtype = {act_dtype}."
+                ),
             )
     else:
         return (
             False,
-            "AllSpark currently does not support "
-            f"device_capability = {device_capability}.",
+            (
+                "AllSpark currently does not support "
+                f"device_capability = {device_capability}."
+            ),
         )
 
     return True, None

--- a/vllm/model_executor/layers/quantization/utils/machete_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/machete_utils.py
@@ -40,13 +40,17 @@ def check_machete_supports_shape(
     if in_features % MACHETE_PREPACKED_BLOCK_SHAPE[0] != 0:
         return (
             False,
-            "Input features size must be divisible by "
-            f"{MACHETE_PREPACKED_BLOCK_SHAPE[0]}",
+            (
+                "Input features size must be divisible by "
+                f"{MACHETE_PREPACKED_BLOCK_SHAPE[0]}"
+            ),
         )
     if out_features % MACHETE_PREPACKED_BLOCK_SHAPE[1] != 0:
         return (
             False,
-            "Output features size must be divisible by "
-            f"{MACHETE_PREPACKED_BLOCK_SHAPE[1]}",
+            (
+                "Output features size must be divisible by "
+                f"{MACHETE_PREPACKED_BLOCK_SHAPE[1]}"
+            ),
         )
     return True, None

--- a/vllm/model_executor/layers/quantization/utils/marlin_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/marlin_utils.py
@@ -134,17 +134,21 @@ def _check_marlin_supported(
     if quant_type not in supported_types:
         return (
             False,
-            f"Marlin does not support weight_bits = {quant_type}. "
-            f"Only types = {supported_types} "
-            f"are supported (for group_size = {group_size}, "
-            f"device_capability = {device_capability}, zp = {has_zp}).",
+            (
+                f"Marlin does not support weight_bits = {quant_type}. "
+                f"Only types = {supported_types} "
+                f"are supported (for group_size = {group_size}, "
+                f"device_capability = {device_capability}, zp = {has_zp})."
+            ),
         )
     if group_size is None or group_size not in MARLIN_SUPPORTED_GROUP_SIZES:
         return (
             False,
-            f"Marlin does not support group_size = {group_size}. "
-            f"Only group_sizes = {MARLIN_SUPPORTED_GROUP_SIZES} "
-            "are supported.",
+            (
+                f"Marlin does not support group_size = {group_size}. "
+                f"Only group_sizes = {MARLIN_SUPPORTED_GROUP_SIZES} "
+                "are supported."
+            ),
         )
 
     return True, None

--- a/vllm/v1/attention/ops/flashmla.py
+++ b/vllm/v1/attention/ops/flashmla.py
@@ -34,15 +34,19 @@ def _is_flashmla_available() -> tuple[bool, str | None]:
     if not _flashmla_C_AVAILABLE:
         return (
             False,
-            "vllm._flashmla_C is not available, likely was not "
-            "compiled due to insufficient nvcc version or a supported arch "
-            "was not in the list of target arches to compile for.",
+            (
+                "vllm._flashmla_C is not available, likely was not "
+                "compiled due to insufficient nvcc version or a supported arch "
+                "was not in the list of target arches to compile for."
+            ),
         )
     if not _flashmla_extension_C_AVAILABLE:
         return (
             False,
-            "vllm._flashmla_extension_C is not available, likely "
-            "was not compiled due to a build error.",
+            (
+                "vllm._flashmla_extension_C is not available, likely "
+                "was not compiled due to a build error."
+            ),
         )
 
     return True, None


### PR DESCRIPTION
### Summary
Fixes ISC004 (unparenthesized implicit string concatenation in collection) linter warnings across vllm quantization utilities and attention ops.

### Key Changes
1. vllm/model_executor/layers/quantization/utils/ (allspark_utils.py, machete_utils.py, marlin_utils.py):
   - Parenthesized multi-line implicit string concatenations inside returned tuples.
2. vllm/v1/attention/ops/flashmla.py:
   - Parenthesized multi-line implicit string concatenations in _is_flashmla_available tuple returns.

### Validation
- ruff check on target files -> All checks passed!