### PR TITLE
[Bugfix][Spec Decode] Route DFlash fused context-KV projection through quant_method for quantized drafters

### DIFF
--- a/tests/v1/spec_decode/test_dflash_quantized_drafter.py
+++ b/tests/v1/spec_decode/test_dflash_quantized_drafter.py
@@ -1,0 +1,313 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Context-KV precompute for weight-quantized DFlash/DSpark drafters.
+
+The precompute fuses every layer's KV projection into one GEMM built by slicing
+raw ``.weight`` tensors, which is only meaningful while those projections are
+unquantized. These tests pin the gate that detects that, the per-layer fallback's
+output layout, and the fact that a quantized projection is never sliced.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.nn.functional as F
+from torch import nn
+
+from vllm import _custom_ops as ops
+from vllm.model_executor.layers.linear import (
+    LinearMethodBase,
+    UnquantizedLinearMethod,
+)
+from vllm.model_executor.models.gemma4_dspark import Gemma4DSparkModel
+from vllm.model_executor.models.laguna_dflash import DFlashLagunaModel
+from vllm.model_executor.models.qwen3_dflash import DFlashQwen3Model
+from vllm.platforms import current_platform
+
+pytestmark = pytest.mark.skip_global_cleanup
+
+HIDDEN = 32
+HEAD_DIM = 8
+NUM_HEADS = 4
+NUM_KV_HEADS = 2
+NUM_LAYERS = 3
+NUM_CTX = 5
+EPS = 1e-6
+
+Q_SIZE = NUM_HEADS * HEAD_DIM
+KV_SIZE = NUM_KV_HEADS * HEAD_DIM
+
+
+def _copy_norm(out: torch.Tensor, x: torch.Tensor, weight: torch.Tensor, eps: float):
+    """Stand-in for the fused RMSNorm kernel, which needs an accelerator.
+
+    Every assertion below compares two projection paths over the same normed
+    input, so the norm cancels out; copying keeps the comparison exact.
+    """
+    out.copy_(x)
+
+
+def _ints(*shape: int) -> torch.Tensor:
+    """Small integer-valued float32 data.
+
+    Sums of these are exact in float32 regardless of accumulation order, so the
+    fused GEMM and the per-layer GEMMs are comparable bit for bit.
+    """
+    return torch.randint(-3, 4, shape).float()
+
+
+class _PackedLinearMethod(LinearMethodBase):
+    """Stands in for any weight-quantized method.
+
+    The gate only asks whether a projection is unquantized, so the specific
+    scheme does not matter. ``apply`` avoids ``F.linear`` so tests can assert
+    the fused path's ``F.linear`` is never reached.
+    """
+
+    def create_weights(self, *args, **kwargs):
+        raise NotImplementedError
+
+    def apply(self, layer, x, bias=None):
+        out = torch.matmul(x, layer.unpacked_weight.t())
+        return out if bias is None else out + bias
+
+
+class _Projection(nn.Module):
+    """Stand-in for QKVParallelLinear / ColumnParallelLinear.
+
+    ``.weight`` raises while quantized, mirroring packed schemes (GPTQ/AWQ)
+    where the attribute does not exist at all.
+    """
+
+    def __init__(self, weight, bias, quant_method):
+        super().__init__()
+        self.unpacked_weight = weight
+        self.bias = bias
+        self.quant_method = quant_method
+        self.skip_bias_add = False
+        self.forward_calls = 0
+
+    @property
+    def weight(self):
+        if not isinstance(self.quant_method, UnquantizedLinearMethod):
+            raise AssertionError("fused precompute must not slice a quantized weight")
+        return self.unpacked_weight
+
+    def forward(self, x):
+        self.forward_calls += 1
+        return self.quant_method.apply(self, x, self.bias), None
+
+
+def _attn(proj, *, proj_attr: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        **{proj_attr: proj},
+        q_size=Q_SIZE,
+        kv_size=KV_SIZE,
+        head_dim=HEAD_DIM,
+        num_kv_heads=NUM_KV_HEADS,
+        k_norm=SimpleNamespace(weight=torch.ones(HEAD_DIM)),
+    )
+
+
+def _model(cls, layers_attn, *, has_bias: bool):
+    model = object.__new__(cls)
+    nn.Module.__init__(model)
+    model.hidden_norm = SimpleNamespace(weight=torch.ones(HIDDEN))
+    model._rms_norm_eps = EPS
+    model.layers = [
+        SimpleNamespace(input_layernorm=SimpleNamespace(weight=torch.ones(HIDDEN)))
+        for _ in layers_attn
+    ]
+    model._build_context_kv_buffers(layers_attn, has_bias)
+    return model
+
+
+def _project(model) -> tuple[torch.Tensor, torch.Tensor]:
+    return model._project_context_kv(
+        _ints(NUM_CTX, HIDDEN), NUM_CTX, NUM_LAYERS, NUM_KV_HEADS, HEAD_DIM
+    )
+
+
+def _build_qkv_case(quantized: bool, *, cls, has_bias: bool, seed: int = 0):
+    """Build a qwen3/laguna-shaped model over deterministic shared weights."""
+    torch.manual_seed(seed)
+    weights = [_ints(Q_SIZE + 2 * KV_SIZE, HIDDEN) for _ in range(NUM_LAYERS)]
+    biases = [
+        _ints(Q_SIZE + 2 * KV_SIZE) if has_bias else None for _ in range(NUM_LAYERS)
+    ]
+    method = _PackedLinearMethod() if quantized else UnquantizedLinearMethod()
+    projections = [_Projection(w, b, method) for w, b in zip(weights, biases)]
+    layers_attn = [_attn(p, proj_attr="qkv_proj") for p in projections]
+    return _model(cls, layers_attn, has_bias=has_bias), projections
+
+
+def _build_k_proj_case(quantized: bool, *, has_bias: bool, seed: int = 0):
+    """Build a gemma4_dspark-shaped model (k_proj only, V derived via k_eq_v)."""
+    torch.manual_seed(seed)
+    weights = [_ints(KV_SIZE, HIDDEN) for _ in range(NUM_LAYERS)]
+    biases = [_ints(KV_SIZE) if has_bias else None for _ in range(NUM_LAYERS)]
+    method = _PackedLinearMethod() if quantized else UnquantizedLinearMethod()
+    projections = [_Projection(w, b, method) for w, b in zip(weights, biases)]
+    layers_attn = [_attn(p, proj_attr="k_proj") for p in projections]
+    return _model(Gemma4DSparkModel, layers_attn, has_bias=has_bias), projections
+
+
+_CASES = {
+    "qwen3_dflash": lambda q, b: _build_qkv_case(q, cls=DFlashQwen3Model, has_bias=b),
+    "laguna_dflash": lambda q, b: _build_qkv_case(q, cls=DFlashLagunaModel, has_bias=b),
+    "gemma4_dspark": lambda q, b: _build_k_proj_case(q, has_bias=b),
+}
+
+
+@pytest.mark.parametrize("case", list(_CASES))
+@pytest.mark.parametrize("has_bias", [False, True])
+def test_per_layer_fallback_matches_fused_path(monkeypatch, case, has_bias):
+    """The fallback must reproduce the fused path exactly for unquantized weights."""
+    monkeypatch.setattr(ops, "rms_norm", _copy_norm)
+    build = _CASES[case]
+
+    fused_model, _ = build(False, has_bias)
+    fallback_model, projections = build(True, has_bias)
+
+    assert fused_model._fuse_context_kv is True
+    assert fallback_model._fuse_context_kv is False
+
+    torch.manual_seed(1234)
+    fused_k, fused_v = _project(fused_model)
+    torch.manual_seed(1234)
+    fallback_k, fallback_v = _project(fallback_model)
+
+    assert all(p.forward_calls == 1 for p in projections)
+    for fused, fallback in ((fused_k, fallback_k), (fused_v, fallback_v)):
+        assert fallback.shape == fused.shape
+        assert fallback.dtype == fused.dtype
+        assert fallback.is_contiguous()
+        assert torch.equal(fallback, fused)
+
+
+@pytest.mark.parametrize("case", list(_CASES))
+def test_quantized_projection_is_never_sliced(monkeypatch, case):
+    """Regression for #51581: a packed weight must not reach the fused GEMM.
+
+    Building the fused buffer used to read ``.weight`` and hand the packed
+    tensor to ``F.linear``, which raised at engine init.
+    """
+    monkeypatch.setattr(ops, "rms_norm", _copy_norm)
+    model, projections = _CASES[case](True, False)
+
+    assert model._fuse_context_kv is False
+    assert not hasattr(model, "_fused_kv_weight")
+    assert not hasattr(model, "_fused_k_weight")
+    assert not hasattr(model, "_kv_weights")
+
+    monkeypatch.setattr(
+        F, "linear", lambda *a, **kw: pytest.fail("F.linear reached a packed weight")
+    )
+    all_k, all_v = _project(model)
+
+    assert all(p.forward_calls == 1 for p in projections)
+    assert all_k.shape == (NUM_LAYERS, NUM_CTX, NUM_KV_HEADS, HEAD_DIM)
+    assert all_v.shape == all_k.shape
+
+
+def test_gate_ignores_layers_the_quant_config_left_unquantized():
+    """A drafter that quantizes only its MLP keeps the fused fast path."""
+    from vllm.model_executor.models.qwen3_dflash import _can_fuse_context_kv
+
+    unquantized = _Projection(_ints(4, 4), None, UnquantizedLinearMethod())
+    quantized = _Projection(_ints(4, 4), None, _PackedLinearMethod())
+
+    assert _can_fuse_context_kv([unquantized, unquantized]) is True
+    assert _can_fuse_context_kv([unquantized, quantized]) is False
+
+
+@pytest.mark.skipif(
+    not current_platform.is_cuda(), reason="fp8 weight quantization requires CUDA"
+)
+@pytest.mark.parametrize("case", ["qwen3_dflash", "gemma4_dspark"])
+def test_fp8_drafter_matches_dequantized_reference(
+    default_vllm_config, dist_init, case
+):
+    """Online-fp8 projections run cleanly and stay numerically sane.
+
+    Mirrors the issue's repro: ``{"quant_method": "fp8",
+    "activation_scheme": "dynamic"}``, which vLLM applies at load time.
+    """
+    from vllm.model_executor.layers.linear import (
+        ColumnParallelLinear,
+        QKVParallelLinear,
+    )
+    from vllm.model_executor.layers.quantization.fp8 import Fp8Config
+    from vllm.model_executor.layers.quantization.utils.quant_utils import (
+        get_and_maybe_dequant_weights,
+    )
+
+    dtype, device = torch.bfloat16, "cuda"
+    quant_config = Fp8Config(
+        is_checkpoint_fp8_serialized=False, activation_scheme="dynamic"
+    )
+    is_qkv = case == "qwen3_dflash"
+
+    def _make_projection() -> nn.Module:
+        if is_qkv:
+            proj = QKVParallelLinear(
+                hidden_size=HIDDEN,
+                head_size=HEAD_DIM,
+                total_num_heads=NUM_HEADS,
+                total_num_kv_heads=NUM_KV_HEADS,
+                bias=False,
+                params_dtype=dtype,
+                quant_config=quant_config,
+            )
+        else:
+            proj = ColumnParallelLinear(
+                input_size=HIDDEN,
+                output_size=KV_SIZE,
+                bias=False,
+                params_dtype=dtype,
+                quant_config=quant_config,
+            )
+        proj = proj.to(device)
+        if getattr(proj.quant_method, "use_marlin", False):
+            pytest.skip("fp8 marlin repacks weights; no dequant reference available")
+        proj.weight.data.normal_(std=0.1)
+        proj.quant_method.process_weights_after_loading(proj)
+        return proj
+
+    projections = [_make_projection() for _ in range(NUM_LAYERS)]
+    # The packed weight is exactly what the fused path used to slice.
+    assert all(p.weight.dtype == torch.float8_e4m3fn for p in projections)
+
+    layers_attn = [
+        _attn(p, proj_attr="qkv_proj" if is_qkv else "k_proj") for p in projections
+    ]
+    for attn in layers_attn:
+        attn.k_norm.weight = attn.k_norm.weight.to(device=device, dtype=dtype)
+
+    model_cls = DFlashQwen3Model if is_qkv else Gemma4DSparkModel
+    model = object.__new__(model_cls)
+    nn.Module.__init__(model)
+    model.hidden_norm = SimpleNamespace(
+        weight=torch.ones(HIDDEN, device=device, dtype=dtype)
+    )
+    model._rms_norm_eps = EPS
+    model.layers = list(layers_attn)
+    model._build_context_kv_buffers(layers_attn, False)
+    assert model._fuse_context_kv is False
+
+    context_states = torch.randn(NUM_CTX, HIDDEN, device=device, dtype=dtype)
+    all_k, all_v = model._project_context_kv(
+        context_states, NUM_CTX, NUM_LAYERS, NUM_KV_HEADS, HEAD_DIM
+    )
+
+    normed = torch.empty_like(context_states)
+    ops.rms_norm(normed, context_states, model.hidden_norm.weight, EPS)
+    for i, proj in enumerate(projections):
+        weight = get_and_maybe_dequant_weights(proj, out_dtype=torch.float32)
+        out = F.linear(normed.float(), weight[Q_SIZE:] if is_qkv else weight)
+        expected_k = out[:, :KV_SIZE].view(NUM_CTX, NUM_KV_HEADS, HEAD_DIM)
+        torch.testing.assert_close(all_k[i].float(), expected_k, rtol=0.1, atol=0.1)
+        if is_qkv:
+            expected_v = out[:, KV_SIZE:].view(NUM_CTX, NUM_KV_HEADS, HEAD_DIM)
+            torch.testing.assert_close(all_v[i].float(), expected_v, rtol=0.1, atol=0.1)

--- a/vllm/model_executor/models/gemma4_dspark.py
+++ b/vllm/model_executor/models/gemma4_dspark.py
@@ -22,7 +22,7 @@ from vllm.model_executor.layers.vocab_parallel_embedding import (
 from vllm.model_executor.model_loader.weight_utils import default_weight_loader
 
 from .gemma4_mtp import Gemma4MTPAttention, Gemma4MTPDecoderLayer
-from .qwen3_dflash import DFlashQwen3Model, _dflash_layer_causal
+from .qwen3_dflash import DFlashQwen3Model, _can_fuse_context_kv, _dflash_layer_causal
 from .qwen3_dspark import DSparkMarkovHead, Qwen3DSparkForCausalLM
 from .utils import extract_layer_index, maybe_prefix
 
@@ -212,10 +212,18 @@ class Gemma4DSparkModel(DFlashQwen3Model):
         self, layers_attn: list[nn.Module], has_bias: bool
     ) -> None:
         self._hidden_norm_weight = self.hidden_norm.weight.data
-        self._fused_k_weight = torch.cat([a.k_proj.weight for a in layers_attn], dim=0)
-        self._fused_k_bias: torch.Tensor | None = (
-            torch.cat([a.k_proj.bias for a in layers_attn], dim=0) if has_bias else None
-        )
+        self._fuse_context_kv = _can_fuse_context_kv(a.k_proj for a in layers_attn)
+        if self._fuse_context_kv:
+            self._fused_k_weight = torch.cat(
+                [a.k_proj.weight for a in layers_attn], dim=0
+            )
+            self._fused_k_bias: torch.Tensor | None = (
+                torch.cat([a.k_proj.bias for a in layers_attn], dim=0)
+                if has_bias
+                else None
+            )
+        else:
+            self._k_projections = [a.k_proj for a in layers_attn]
         self._k_norm_weights = torch.stack(
             [a.k_norm.weight.data for a in layers_attn], dim=0
         ).contiguous()
@@ -241,7 +249,12 @@ class Gemma4DSparkModel(DFlashQwen3Model):
         ops.rms_norm(
             normed, context_states, self._hidden_norm_weight, self._rms_norm_eps
         )
-        all_k_flat = F.linear(normed, self._fused_k_weight, self._fused_k_bias)
+        if self._fuse_context_kv:
+            all_k_flat = F.linear(normed, self._fused_k_weight, self._fused_k_bias)
+        else:
+            all_k_flat = torch.cat(
+                [proj(normed)[0] for proj in self._k_projections], dim=-1
+            )
         all_k = (
             all_k_flat.view(num_ctx, num_layers, num_kv_heads, head_dim)
             .permute(1, 0, 2, 3)

--- a/vllm/model_executor/models/laguna_dflash.py
+++ b/vllm/model_executor/models/laguna_dflash.py
@@ -31,7 +31,7 @@ from vllm.model_executor.models.interfaces import EagleModelMixin, SupportsEagle
 from vllm.multimodal.inputs import NestedTensors
 
 from .laguna import LagunaDecoderLayer
-from .qwen3_dflash import DFlashQwen3Model
+from .qwen3_dflash import DFlashQwen3Model, _can_fuse_context_kv
 from .utils import (
     AutoWeightsLoader,
     get_draft_quant_config,
@@ -155,15 +155,19 @@ class DFlashLagunaModel(DFlashQwen3Model, EagleModelMixin):
         layers_attn: list[nn.Module],
         has_bias: bool,
     ) -> None:
-        self._kv_weights = torch.stack(
-            [a.qkv_proj.weight[a.q_size :] for a in layers_attn], dim=0
-        ).contiguous()
-        if has_bias:
-            self._kv_biases: torch.Tensor | None = torch.stack(
-                [a.qkv_proj.bias[a.q_size :] for a in layers_attn], dim=0
+        self._fuse_context_kv = _can_fuse_context_kv(a.qkv_proj for a in layers_attn)
+        if self._fuse_context_kv:
+            self._kv_weights = torch.stack(
+                [a.qkv_proj.weight[a.q_size :] for a in layers_attn], dim=0
             ).contiguous()
+            if has_bias:
+                self._kv_biases: torch.Tensor | None = torch.stack(
+                    [a.qkv_proj.bias[a.q_size :] for a in layers_attn], dim=0
+                ).contiguous()
+            else:
+                self._kv_biases = None
         else:
-            self._kv_biases = None
+            self._kv_projections = [(a.qkv_proj, a.q_size) for a in layers_attn]
         self._input_layernorm_weights = torch.stack(
             [layer.input_layernorm.weight.data for layer in self.layers], dim=0
         ).contiguous()
@@ -190,12 +194,22 @@ class DFlashLagunaModel(DFlashQwen3Model, EagleModelMixin):
             self._input_layernorm_weights,
             self._rms_norm_eps,
         )
-        all_kv_flat = torch.bmm(
-            normed_context_states,
-            self._kv_weights.transpose(1, 2),
-        )
-        if self._kv_biases is not None:
-            all_kv_flat += self._kv_biases[:, None, :]
+        if self._fuse_context_kv:
+            all_kv_flat = torch.bmm(
+                normed_context_states,
+                self._kv_weights.transpose(1, 2),
+            )
+            if self._kv_biases is not None:
+                all_kv_flat += self._kv_biases[:, None, :]
+        else:
+            # Each layer norms its own context states, so project them per layer.
+            all_kv_flat = torch.stack(
+                [
+                    proj(normed_context_states[i])[0][..., q_size:]
+                    for i, (proj, q_size) in enumerate(self._kv_projections)
+                ],
+                dim=0,
+            )
         all_kv = (
             all_kv_flat.view(num_layers, num_ctx, 2, num_kv_heads, head_dim)
             .permute(2, 0, 1, 3, 4)

--- a/vllm/model_executor/models/qwen3_dflash.py
+++ b/vllm/model_executor/models/qwen3_dflash.py
@@ -23,6 +23,7 @@ from vllm.model_executor.layers.linear import (
     QKVParallelLinear,
     ReplicatedLinear,
     RowParallelLinear,
+    UnquantizedLinearMethod,
 )
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
 from vllm.model_executor.layers.quantization.base_config import QuantizationConfig
@@ -70,6 +71,24 @@ def dflash_has_any_non_causal(config: Qwen3Config) -> bool:
     return not all(
         _dflash_layer_causal(config, i) for i in range(config.num_hidden_layers)
     )
+
+
+def _can_fuse_context_kv(projections: Iterable[nn.Module]) -> bool:
+    """Whether context-KV precompute may slice raw ``.weight`` into one fused GEMM.
+
+    Only unquantized projections can: a quantized ``.weight`` is packed, carries
+    no scales, and for 4-bit schemes does not exist at all, so those must run
+    through the module's own ``quant_method`` instead.
+    """
+    projections = list(projections)
+    if all(isinstance(p.quant_method, UnquantizedLinearMethod) for p in projections):
+        return True
+    # The per-layer path consumes each module's output, so bias has to be applied
+    # inside the module rather than handed back to the caller.
+    assert not any(p.skip_bias_add for p in projections), (
+        "DFlash context-KV precompute requires projections that apply their own bias"
+    )
+    return False
 
 
 def _get_dflash_fc_input_size(vllm_config: VllmConfig) -> int:
@@ -444,14 +463,18 @@ class DFlashQwen3Model(nn.Module):
     ) -> None:
         self._hidden_norm_weight = self.hidden_norm.weight.data
 
-        # KV projection weights: [num_layers * 2 * kv_size, hidden_size]
-        kv_weights = [a.qkv_proj.weight[a.q_size :] for a in layers_attn]
-        self._fused_kv_weight = torch.cat(kv_weights, dim=0)
-        if has_bias:
-            kv_biases = [a.qkv_proj.bias[a.q_size :] for a in layers_attn]
-            self._fused_kv_bias: torch.Tensor | None = torch.cat(kv_biases, dim=0)
+        self._fuse_context_kv = _can_fuse_context_kv(a.qkv_proj for a in layers_attn)
+        if self._fuse_context_kv:
+            # KV projection weights: [num_layers * 2 * kv_size, hidden_size]
+            kv_weights = [a.qkv_proj.weight[a.q_size :] for a in layers_attn]
+            self._fused_kv_weight = torch.cat(kv_weights, dim=0)
+            if has_bias:
+                kv_biases = [a.qkv_proj.bias[a.q_size :] for a in layers_attn]
+                self._fused_kv_bias: torch.Tensor | None = torch.cat(kv_biases, dim=0)
+            else:
+                self._fused_kv_bias = None
         else:
-            self._fused_kv_bias = None
+            self._kv_projections = [(a.qkv_proj, a.q_size) for a in layers_attn]
 
         # K-norm weights stacked into one contiguous [num_layers, head_dim]
         # tensor so the per-layer K-norm runs as a single grouped kernel.
@@ -502,6 +525,19 @@ class DFlashQwen3Model(nn.Module):
         # References to inner Attention layers for direct cache writes
         self._attn_layers = [layer.self_attn.attn for layer in self.layers]
 
+    def _project_context_kv_per_layer(self, normed: torch.Tensor) -> torch.Tensor:
+        """Quantized fallback producing the fused GEMM's exact output layout.
+
+        Q is projected and discarded; this runs once per prefill rather than in
+        the decode loop, so the waste is not on the hot path.
+        """
+        # TODO: fuse the quantized KV projections into a single GEMM (stacked
+        # quantized weights + per-row scales) to drop the discarded Q compute.
+        return torch.cat(
+            [proj(normed)[0][..., q_size:] for proj, q_size in self._kv_projections],
+            dim=-1,
+        )
+
     def _project_context_kv(
         self,
         context_states: torch.Tensor,
@@ -510,7 +546,7 @@ class DFlashQwen3Model(nn.Module):
         num_kv_heads: int,
         head_dim: int,
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        # --- Fused KV projection (one GEMM for all layers) ---
+        # --- KV projection (one fused GEMM for all layers when unquantized) ---
         normed_context_states = torch.empty_like(context_states)
         ops.rms_norm(
             normed_context_states,
@@ -518,9 +554,12 @@ class DFlashQwen3Model(nn.Module):
             self._hidden_norm_weight,
             self._rms_norm_eps,
         )
-        all_kv_flat = F.linear(
-            normed_context_states, self._fused_kv_weight, self._fused_kv_bias
-        )
+        if self._fuse_context_kv:
+            all_kv_flat = F.linear(
+                normed_context_states, self._fused_kv_weight, self._fused_kv_bias
+            )
+        else:
+            all_kv_flat = self._project_context_kv_per_layer(normed_context_states)
         # Single contiguous copy that separates K/V and transposes to
         # layer-major layout.  Result: [2, L, num_ctx, nkv, hd] contiguous.
         # Indexing dim-0 gives contiguous [L, num_ctx, nkv, hd] for K and V.


### PR DESCRIPTION
﻿## Purpose

`FIX #51581`

DFlash-family draft models precompute the context K/V once per prefill using a
single fused GEMM. That GEMM is assembled by slicing the **raw `.weight`
tensors** off each attention projection and calling `F.linear` on the result,
which bypasses the module's `quant_method` entirely:

```python
# vllm/model_executor/models/qwen3_dflash.py (before)
kv_weights = [a.qkv_proj.weight[a.q_size :] for a in layers_attn]
self._fused_kv_weight = torch.cat(kv_weights, dim=0)
...
all_kv_flat = F.linear(normed_context_states, self._fused_kv_weight, self._fused_kv_bias)
```

For a weight-quantized drafter `.weight` is the packed tensor, so this is wrong
in three different ways depending on the scheme:

| Scheme | Symptom |
| --- | --- |
| FP8 (E4M3) | `RuntimeError: expected mat1 and mat2 to have the same dtype, but got: c10::BFloat16 != c10::Float8_e4m3fn` at engine init |
| Any scheme whose dtypes happen to line up | **Silent numeric corruption** — `weight_scale` is dropped, so the drafter proposes from wrong numbers. Speculative decoding never surfaces this as an error, only as degraded acceptance |
| Packed 4-bit (GPTQ / AWQ) | `AttributeError` — `.weight` does not exist; those methods register `qweight` / `weight_packed` |

The same pattern is present in three files, so a fix confined to
`qwen3_dflash.py` would leave two model families broken:

- `qwen3_dflash.py` — sliced fused `qkv_proj`, single shared `hidden_norm`
- `laguna_dflash.py` — stacked per-layer variant (`torch.bmm`), norms per layer
  with `input_layernorm`
- `gemma4_dspark.py` — `k_proj.weight`, no slicing, V derived from the same
  projection (`k_eq_v`)
- `qwen3_dspark.py` — inherits `DFlashQwen3Model`, fixed transitively

### Approach

Detect quantization **before** touching `.weight`, per projection:

```python
def _can_fuse_context_kv(projections: Iterable[nn.Module]) -> bool:
    ...
    if all(isinstance(p.quant_method, UnquantizedLinearMethod) for p in projections):
        return True
```

- **All projections unquantized** → build the fused buffers exactly as today.
  The fast path is byte-for-byte unchanged; it is not restructured.
- **Any projection quantized** → skip the raw-weight buffers entirely, keep
  module references, and in `_project_context_kv` loop over layers calling each
  module's own forward (`qkv_proj(normed)` then slicing the **output** at
  `q_size`; `k_proj(normed)` for gemma4). The results are assembled into exactly
  the layout, shape, dtype and contiguity the fused GEMM produced, so every
  downstream stage (K-norm, RoPE, KV-cache write) is untouched.

The gate is deliberately **per projection**, not `quant_config is not None`.
Models that quantize only the MLP and leave attention in BF16 are common, and
`get_quant_method()` also returns `UnquantizedLinearMethod` for layers a config
explicitly ignores; both keep the fused fast path.

### Notes

- **The unquantized fast path is unchanged**, and this is guarded by a test that
  runs both paths over the same weights and asserts bitwise equality.
- **The fallback's cost is amortized at prefill.** Q is projected and discarded
  in the fallback, but `precompute_and_store_context_kv` runs on the prefill
  side, not in the per-step decode loop, and is explicitly outside any
  torch.compile / CUDA-graph region (its docstring already notes this). A `TODO`
  is left for a genuinely fused quantized path (stacked quantized weights plus
  per-row scales), which would remove the discarded Q compute.
- vLLM linear layers return `(output, output_bias)`. The fused path concatenated
  raw `.bias`; the module forward applies bias itself when `skip_bias_add` is
  `False`, which is the case for every projection these models construct. An
  assertion pins that invariant so a future `skip_bias_add=True` cannot silently
  reintroduce a numeric difference.
- **TP**: the existing code slices with the layer-local `a.q_size`, and the
  fallback slices module output with the same attribute, so shard layout is
  consistent by construction.
- The `ignored_layers` observation in the issue (listing
  `layers.{N}.self_attn.qkv_proj` did not exempt the module) is a **separate
  bug** and is not addressed here; see the issue comment suggesting it be split
  out.
- This **supersedes the stalled #40425**, which covered `qwen3_dflash.py` only,
  has been merge-conflicted since 2026-05-23, and gated on
  `self.quant_config is not None` — the exact check @benchislett flagged as too
  narrow in review. Its two other changes (propagating `quant_config` into
  `DFlashQwen3DecoderLayer`, and routing `DFlashQwen3Attention.forward` through
  `qkv_proj`) have since landed on `main` independently.

## Test Plan

New: `tests/v1/spec_decode/test_dflash_quantized_drafter.py`, parametrized over
all three shapes (`qwen3_dflash`, `laguna_dflash`, `gemma4_dspark`) and over
bias / no-bias.

1. **Refactor guard** — `test_per_layer_fallback_matches_fused_path`: builds the
   same random weights twice, once unquantized (fused) and once behind a
   quantized method (fallback), and asserts the two outputs are **exactly**
   equal, plus matching shape, dtype and contiguity. Integer-valued weights are
   used so the comparison can honestly be exact: a fused GEMM and N per-layer
   GEMMs are *not* bitwise identical for arbitrary float32 inputs, because BLAS
   blocks the reduction differently.
2. **Regression for #51581** — `test_quantized_projection_is_never_sliced`: the
   stand-in projection raises on any `.weight` read while quantized, the fused
   buffers are asserted absent, and `F.linear` is patched to fail the test if
   reached. This is the unit-level form of the reported engine-init crash.
3. **Gate precision** — `test_gate_ignores_layers_the_quant_config_left_unquantized`:
   an MLP-only-quantized drafter keeps the fused fast path.
4. **FP8 numerics (GPU)** — `test_fp8_drafter_matches_dequantized_reference`:
   real `QKVParallelLinear` / `ColumnParallelLinear` carrying `Fp8Config(
   is_checkpoint_fp8_serialized=False, activation_scheme="dynamic")` — i.e.
   exactly what the issue's `config.json` produces via online quantization —
   quantized through `process_weights_after_loading`. Asserts the packed weight
   is `float8_e4m3fn` (what the old path used to slice), that buffer build and
   `_project_context_kv` run cleanly, and that the output matches an independent
   reference built from `get_and_maybe_dequant_weights` within fp8 tolerance.

End-to-end reproduction steps are in `REPRO.md`.

## Test Result

```
tests/v1/spec_decode/test_dflash_quantized_drafter.py .......... 10 passed, 2 skipped
```

Before/after check on the same test file:

- against unpatched `main` (`b22afe45`): **10 failed, 2 skipped**
- with this change: **10 passed, 2 skipped**

The 2 skipped are the FP8 test, which is `skipif`-guarded on
`current_platform.is_cuda()`.

Existing suites, unchanged by this PR:

```
tests/v1/spec_decode/test_dflash_causality.py   10 passed
tests/v1/spec_decode/test_dspark_topk.py         2 passed
```

`pre-commit run --files <the four changed files>` passes (ruff, ruff format,
mypy, SPDX, forbidden-imports and the rest).

`tests/v1/spec_decode/test_dflash_lookahead.py` and the FP8 test need a real
accelerator to construct `VllmConfig`, so they were not exercised locally.


---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
