### PR TITLE
[Misc] Remove stale level reference from CompilationConfig validator

### DIFF
--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -887,7 +887,6 @@ class CompilationConfig:
         return value
 
     @field_validator(
-        "level",
         "mode",
         "cudagraph_mode",
         "max_cudagraph_capture_size",
@@ -1078,7 +1077,7 @@ class CompilationConfig:
         if self.mode is None:
             raise ValueError(
                 "No compilation mode is set. This method should only be "
-                "called via vllm config where the level is set if none is "
+                "called via vllm config where the mode is set if none is "
                 "provided."
             )
         if self.mode == CompilationMode.NONE:


### PR DESCRIPTION
`CompilationConfig.level` was renamed to `mode`, but two references to the old name were left behind:

- `_skip_none_validation` still lists `"level"` in its `@field_validator` field list. The field no longer exists on the class, so the entry is dead. Pydantic ignores a validator naming an unknown field on a dataclass, so this is not a runtime error today, just a stale reference that is misleading to read.
- The `ValueError` raised when `mode` is unset still says "where the level is set".

This drops the dead entry and corrects the message to say `mode`. No behaviour change.
