### PR TITLE
[Core] cached blocks that never hit should be evicted first

### DIFF
--- a/vllm/v1/core/block_pool.py
+++ b/vllm/v1/core/block_pool.py
@@ -713,6 +713,7 @@ class BlockPool:
             if block.ref_cnt == 0 and not block.is_null:
                 self.free_block_queue.remove(block)
             block.ref_cnt += 1
+            block._ref_cnt += 1
             if self.metrics_collector:
                 self.metrics_collector.on_block_accessed(block)
 
@@ -726,20 +727,26 @@ class BlockPool:
         """
         # Identify blocks with hash (LRU cache) and without it (never match APC)
         blocks_with_hash = []
+        blocks_with_hash_hit = []
         blocks_without_hash = []
         for block in ordered_blocks:
             block.ref_cnt -= 1
             if block.ref_cnt == 0 and not block.is_null:
                 # When caching is disabled we always append for better
                 # GPU cache locality from reusing recently used blocks
-                if block.block_hash is None and self.enable_caching:
+                if not self.enable_caching:
+                    blocks_with_hash_hit.append(block)
+                elif block.block_hash is None:
                     blocks_without_hash.append(block)
-                else:
+                elif block._ref_cnt == 0:
                     blocks_with_hash.append(block)
+                else:
+                    blocks_with_hash_hit.append(block)
 
         # Blocks without hash get evicted first - prepend them last to the tail
         self.free_block_queue.prepend_n(blocks_without_hash)
         self.free_block_queue.append_n(blocks_with_hash)
+        self.free_block_queue.append_n(blocks_with_hash_hit)
 
     def evict_blocks(self, block_ids: set[int]) -> None:
         """evict blocks from the prefix cache by their block IDs.

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -122,6 +122,8 @@ class KVCacheBlock:
     block_id: int
     # Reference count.
     ref_cnt: int = 0
+    # only cumulative reference count for cached block hit.
+    _ref_cnt: int = 0
     # The hash key (block hash + group id) of the block, only available
     # when the block is full and cached.
     _block_hash: BlockHashWithGroupId | None = None
@@ -160,6 +162,7 @@ class KVCacheBlock:
         """Reset the block hash when the block is evicted."""
         self._block_hash = None
         self._block_hash_num_tokens = None
+        self._ref_cnt = 0
 
     def __repr__(self) -> str:
         # Use block_id instead of KVCacheBlock object to avoid calling __repr__
@@ -169,6 +172,7 @@ class KVCacheBlock:
         return (
             f"KVCacheBlock(block_id={self.block_id}, "
             f"ref_cnt={self.ref_cnt}, "
+            f"_ref_cnt={self._ref_cnt}, "
             f"_block_hash={self._block_hash!r}, "
             f"_block_hash_num_tokens={self._block_hash_num_tokens}, "
             f"prev_free_block={prev_block_id}, "


### PR DESCRIPTION





## Purpose
    Most cached blocks with block_hash that never hit.
    Now they are appended to the free list mixed with
    fewer hit blocks. We should differentiate the both
    cases because of the non-hit blocks amount that is
    huge and far greater than hit blocks. So we should
    append the non-hit blocks first and then append the
    hit blocks so that non-hit blocks are allocated first
    in free list and keep alive for hit blocks.
## Test Plan
python -m pytest tests/v1/core/test_kv_cache_utils.py -v
python -m pytest tests/v1/core/test_prefix_caching.py -v
python -m pytest tests/v1/core/test_single_type_kv_cache_manager.py -v
## Test Result
python -m pytest tests/v1/core/test_kv_cache_utils.py -v

================================================= 76 passed, 14 warnings in 54.41s =================================================

python -m pytest tests/v1/core/test_prefix_caching.py -v
================================================= 89 passed, 14 warnings in 20.60s =================================================

python -m pytest tests/v1/core/test_single_type_kv_cache_manager.py -v
================================================== 9 passed, 14 warnings in 2.60s ==================================================
---
