### PR TITLE
[Bugfix] Fix common_broadcastable_dtype returning a lossy dtype

### DIFF
--- a/tests/utils_/test_torch_utils.py
+++ b/tests/utils_/test_torch_utils.py
@@ -72,6 +72,9 @@ def test_is_lossless_cast(src_dtype, tgt_dtype, expected_result):
         ([torch.bool, torch.int8], torch.int8),
         ([torch.bool, torch.int8, torch.float16], torch.float16),
         ([torch.bool, torch.int8, torch.float16, torch.complex32], torch.complex32),  # noqa: E501
+        # Neither input is a lossless cast target for the other
+        ([torch.float16, torch.bfloat16], torch.float32),
+        ([torch.bfloat16, torch.float16], torch.float32),
     ],
 )
 def test_common_broadcastable_dtype(dtypes, expected_result):

--- a/vllm/utils/torch_utils.py
+++ b/vllm/utils/torch_utils.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import contextlib
+import functools
 import importlib.metadata
 import os
 import random
@@ -374,10 +375,7 @@ def common_broadcastable_dtype(dtypes: Collection[torch.dtype]):
     Get the common `dtype` where all of the other `dtypes` can be
     cast to it without losing any information.
     """
-    return max(
-        dtypes,
-        key=lambda dtype: sum(is_lossless_cast(dt, dtype) for dt in dtypes),
-    )
+    return functools.reduce(torch.promote_types, dtypes)
 
 
 def _generate_random_fp8(


### PR DESCRIPTION
`common_broadcastable_dtype` is documented to return a dtype that every input
can be cast to without losing information. The implementation was

```python
max(dtypes, key=lambda dtype: sum(is_lossless_cast(dt, dtype) for dt in dtypes))
```

That is an argmax over the input collection, so it can only ever return a dtype
that was passed in. When no input is a valid target for all the others, it still
returns one of them, silently lossy.

`{float16, bfloat16}` is the case that matters in practice. Neither is a lossless
cast target for the other, so both score 1 and `max` returns whichever the
iterable yields first:

```
common_broadcastable_dtype([torch.float16, torch.bfloat16])  # torch.float16
common_broadcastable_dtype([torch.bfloat16, torch.float16])  # torch.bfloat16
```

The correct answer is `float32`, which is in neither input. The result also
depends on iteration order of the collection the caller passes in.

Fix is to use `torch.promote_types`, which is defined over the full dtype
lattice rather than only the inputs:

```python
functools.reduce(torch.promote_types, dtypes)
```

This returns `float32` for both orderings above and matches the previous
behaviour on the existing test cases.

Scope note: this does not make the function match its docstring in every case.
`torch.promote_types(torch.int64, torch.float16)` is `float16`, which loses
precision. That is pre-existing and left alone here.

Added the `[float16, bfloat16] -> float32` case to
`test_common_broadcastable_dtype`.

Test:
```
pytest tests/utils_/test_torch_utils.py --noconftest \
  -k "common_broadcastable_dtype or is_lossless_cast"
```
29 passed. Full-file collection fails in my environment on an unrelated missing
`xgrammar` import from the tests conftest.
