### PR TITLE
[Bugfix][CPU] Make the Apple Silicon BF16 probe fall back instead of raising

### DIFF
--- a/vllm/platforms/cpu.py
+++ b/vllm/platforms/cpu.py
@@ -54,12 +54,15 @@ class CpuPlatform(Platform):
         elif self.get_cpu_architecture() == CpuArchEnum.ARM and sys.platform.startswith(
             "darwin"
         ):
-            if (
-                subprocess.check_output(
-                    ["sysctl -n hw.optional.arm.FEAT_BF16"], shell=True
-                ).strip()
+            # sysctl exits non-zero when the OID is absent, so check_output would
+            # raise instead of letting the fp16/fp32 fallback below run.
+            bf16 = (
+                subprocess.run(
+                    ["sysctl", "-n", "hw.optional.arm.FEAT_BF16"], capture_output=True
+                ).stdout.strip()
                 == b"1"
-            ):
+            )
+            if bf16:
                 return [torch.bfloat16, torch.float16, torch.float32]
             return [torch.float16, torch.float32]
         elif self.get_cpu_architecture() == CpuArchEnum.RISCV:


### PR DESCRIPTION
## Problem

In `CpuPlatform.supported_dtypes`, the macOS arm64 branch probes for BF16 with:

```python
if (
    subprocess.check_output(
        ["sysctl -n hw.optional.arm.FEAT_BF16"], shell=True
    ).strip()
    == b"1"
):
    return [torch.bfloat16, torch.float16, torch.float32]
return [torch.float16, torch.float32]
```

macOS does not publish the `hw.optional.arm.FEAT_BF16` OID when the CPU does not
have the feature. `sysctl` then prints `unknown oid` to stderr and exits 1.
`check_output` raises `CalledProcessError` on a nonzero exit, so it never returns
a value other than `b"1"`, and the `return [torch.float16, torch.float32]` line
below it cannot be reached whenever the OID is absent. That fallback is the
fp16/fp32 baseline the Apple docs describe: "Currently the CPU implementation for
macOS supports FP32 and FP16 datatypes"
(`docs/getting_started/installation/cpu.apple.inc.md`).

`supported_dtypes` is read during startup from `vllm/config/model.py`, so the
exception would propagate out of config resolution rather than selecting fp16.

I do not have hardware without `FEAT_BF16` to confirm which specific machines and
macOS versions omit the OID, so this is reported as an unreachable branch rather
than as a reproduced crash on any particular model.

## Fix

Use `subprocess.run` without `check=True`, so a nonzero exit returns normally and
falls through to fp16/fp32:

```python
bf16 = (
    subprocess.run(
        ["sysctl", "-n", "hw.optional.arm.FEAT_BF16"], capture_output=True
    ).stdout.strip()
    == b"1"
)
```

This also drops `shell=True` on a single-element list, which was passing the whole
command string as one argv element and relying on the shell to split it.

## Testing

Checked the two subprocess calls directly on macOS 15 arm64:

- absent OID (`hw.optional.arm.FEAT_NOPE`): `check_output` raises
  `CalledProcessError`; `run` returns `returncode=1` with empty stdout, so the
  comparison is `False` and the fp16/fp32 branch is taken.
- present OID (`hw.optional.arm.FEAT_BF16`): `returncode=0`, stdout `b"1"`, so the
  bf16 branch is taken.

`CpuPlatform().supported_dtypes` on this machine returns
`[torch.bfloat16, torch.float16, torch.float32]`, unchanged from before.
