### PR TITLE
[Misc] Remove the dead cloudpickle branch for worker_cls

### DIFF
--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -5,7 +5,6 @@ from collections.abc import Callable, Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-import cloudpickle
 import torch.nn as nn
 from pydantic import ValidationError
 from tqdm.auto import tqdm
@@ -224,13 +223,6 @@ class LLM(BeamSearchOfflineMixin, PoolingOfflineMixin, OfflineInferenceMixin):
 
         if "disable_log_stats" not in kwargs:
             kwargs["disable_log_stats"] = True
-
-        if "worker_cls" in kwargs:
-            worker_cls = kwargs["worker_cls"]
-            # if the worker_cls is not qualified string name,
-            # we serialize it using cloudpickle to avoid pickling issues
-            if isinstance(worker_cls, type):
-                kwargs["worker_cls"] = cloudpickle.dumps(worker_cls)
 
         if "kv_transfer_config" in kwargs and isinstance(
             kwargs["kv_transfer_config"], dict


### PR DESCRIPTION
`LLM.__init__` replaces a class-valued `worker_cls` kwarg with `cloudpickle.dumps(...)` bytes, but nothing in the tree ever loads those bytes back, so the branch only fires for the narrow case of someone passing an actual class object. `ParallelConfig.worker_cls` is a plain `str` field, so the bytes fail pydantic validation with an opaque error before `v1/worker/worker_base.py` can raise its explicit "passing worker_cls is no longer supported" message, and the platform hooks comparing `worker_cls == "auto"` never match bytes either. This removes the branch and the now-unused `cloudpickle` import from `vllm/entrypoints/llm.py`.
