### PR TITLE
[Bugfix] Release ParentRequest state when an n>1 request is aborted

### DIFF
--- a/tests/v1/engine/test_output_processor.py
+++ b/tests/v1/engine/test_output_processor.py
@@ -32,6 +32,7 @@ from vllm.v1.engine.output_processor import (
     RequestOutputCollector,
     RequestState,
 )
+from vllm.v1.engine.parallel_sampling import ParentRequest
 from vllm.v1.metrics.stats import IterationStats, SchedulerStats
 
 
@@ -1448,3 +1449,56 @@ def test_abort_requests(runner: str, abort_by: str, dummy_test_vectors):
             output_processor.abort_requests([request.request_id], internal=True)
         else:
             output_processor.abort_requests([request.external_req_id], internal=False)
+
+
+@pytest.mark.parametrize("abort_by", ["internal", "external"])
+def test_abort_parallel_sampling_request(abort_by: str, dummy_test_vectors):
+    output_processor = OutputProcessor(dummy_test_vectors.tokenizer, log_stats=True)
+    n = 3
+    parent_request = EngineCoreRequest(
+        request_id="request-0",
+        external_req_id="external-0",
+        prompt_token_ids=dummy_test_vectors.prompt_tokens[0],
+        mm_features=None,
+        arrival_time=0,
+        lora_request=None,
+        cache_salt=None,
+        data_parallel_rank=None,
+        sampling_params=SamplingParams(n=n),
+        pooling_params=None,
+    )
+    parent_req = ParentRequest(parent_request)
+
+    child_req_ids = []
+    for idx in range(n):
+        child_req_id, child_params = parent_req.get_child_info(idx)
+        child_req_ids.append(child_req_id)
+        child_request = EngineCoreRequest(
+            request_id=child_req_id,
+            external_req_id="external-0",
+            prompt_token_ids=dummy_test_vectors.prompt_tokens[0],
+            mm_features=None,
+            arrival_time=0,
+            lora_request=None,
+            cache_salt=None,
+            data_parallel_rank=None,
+            sampling_params=child_params,
+            pooling_params=None,
+        )
+        queue = RequestOutputCollector(
+            output_kind=child_params.output_kind, request_id=child_req_id
+        )
+        output_processor.add_request(
+            child_request, None, parent_req=parent_req, request_index=idx, queue=queue
+        )
+
+    assert output_processor.parent_requests
+
+    if abort_by == "internal":
+        output_processor.abort_requests(child_req_ids, internal=True)
+    else:
+        output_processor.abort_requests(["external-0"], internal=False)
+
+    assert not output_processor.parent_requests
+    assert not output_processor.request_states
+    assert not output_processor.external_req_ids

--- a/vllm/v1/engine/output_processor.py
+++ b/vllm/v1/engine/output_processor.py
@@ -531,6 +531,11 @@ class OutputProcessor:
                     )
                 ):
                     req_state.queue.put(request_output)
+                # Remove parent request once all of its children are gone.
+                if (parent := req_state.parent_req) is not None:
+                    parent.child_requests.discard(request_id)
+                    if not parent.child_requests:
+                        self.parent_requests.pop(parent.request_id, None)
             elif parent := self.parent_requests.get(request_id):
                 # Abort children prior to removing the parent.
                 if parent.child_requests:


### PR DESCRIPTION
## What is broken

`OutputProcessor.abort_requests` never drops the `ParentRequest` when an `n>1`
request is aborted by its external id.

An external id maps to the child internal ids, so the abort loop finds a
`RequestState` for every child and takes the `if req_state is not None:` branch.
That branch pops the child from `self.request_states` but never touches
`self.parent_requests`. The parent cleanup lives in the `elif parent :=
self.parent_requests.get(request_id)` branch, which only runs when `req_state`
is `None`, so it never fires here. `_finish_request` cannot clean up either,
since the child states are already gone.

The result is one `ParentRequest` left in `self.parent_requests` for the life of
the engine, holding its `child_requests` set and its output aggregator.

This needs `n>1` plus an abort or a client disconnect. Normal completion and
`n=1` aborts are unaffected, so it is a slow leak on servers that see parallel
sampling with cancellations, not a leak on every request.

## Fix

In the `if req_state is not None:` branch, resolve the parent from the child's
own `req_state.parent_req`, discard the child, and pop the parent once its last
child is gone. This mirrors what `_finish_request` already does. The existing
`elif` branch is unchanged.

## Test

Added `test_abort_parallel_sampling_request` in
`tests/v1/engine/test_output_processor.py`. It builds an `n=3` request with a
`ParentRequest` and three children, aborts by internal ids and by external id,
and asserts `parent_requests`, `request_states` and `external_req_ids` are all
empty afterwards.

I could not run the test file on my machine: importing the test harness pulls in
`vllm.v1.engine.llm_engine` and the process dies with SIGBUS on macOS/CPU before
collection. I verified the fix with a standalone script driving `OutputProcessor`
directly with the same setup as the test. It fails on main with
`{'request-0': <ParentRequest>}` still in `parent_requests` and passes with this
change, for both the internal-id and external-id abort paths. CI should be the
judge of the pytest run.
