### PR TITLE
[ROCm] [Bugfix] Fix Triton fused shared expert alignment

### DIFF
--- a/tests/kernels/moe/test_moe.py
+++ b/tests/kernels/moe/test_moe.py
@@ -418,6 +418,50 @@ def test_fused_moe(
         )
 
 
+def test_fused_shared_expert_alignment(workspace_init):
+    set_random_seed(7)
+    m, n, k = 4, 64, 128
+    routed_experts = 8
+    physical_experts = routed_experts + 1
+    dtype = torch.bfloat16
+
+    a = torch.randn((m, k), device=DEVICE_TYPE, dtype=dtype) / 10
+    w1 = torch.randn((physical_experts, 2 * n, k), device=DEVICE_TYPE, dtype=dtype) / 10
+    w2 = torch.randn((physical_experts, k, n), device=DEVICE_TYPE, dtype=dtype) / 10
+    topk_ids = torch.tensor(
+        [[0, 8], [1, 8], [2, 8], [3, 8]], device=DEVICE_TYPE, dtype=torch.int32
+    )
+    topk_weights = torch.tensor(
+        [[0.5, 1.0]] * m, device=DEVICE_TYPE, dtype=torch.float32
+    )
+
+    moe_config = make_dummy_moe_config(
+        num_experts=physical_experts,
+        experts_per_token=2,
+        hidden_dim=k,
+        intermediate_size=n,
+        in_dtype=dtype,
+        max_num_tokens=m,
+    )
+    modular_moe = modular_triton_fused_moe(moe_config, FUSED_MOE_UNQUANTIZED_CONFIG)
+
+    with set_current_vllm_config(vllm_config):
+        expected = torch_experts(a, w1, w2, topk_weights, topk_ids)
+        actual = modular_moe.apply(
+            hidden_states=a,
+            w1=w1,
+            w2=w2,
+            topk_weights=topk_weights,
+            topk_ids=topk_ids,
+            activation=MoEActivation.SILU,
+            global_num_experts=routed_experts,
+            expert_map=None,
+            apply_router_weight_on_input=False,
+        )
+
+    torch.testing.assert_close(actual, expected, atol=2e-2, rtol=0)
+
+
 def test_fused_moe_int64_overflow(workspace_init):
     """Regression test for int32 overflow in stride*offset products.
 

--- a/vllm/model_executor/layers/fused_moe/experts/triton_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/triton_moe.py
@@ -313,13 +313,15 @@ class TritonExperts(LoRAExpertsMixin, mk.FusedMoEExpertsModular):
         )
         intermediate_cache3 = _resize_cache(workspace2, (num_tokens, top_k_num, K))
 
+        # Include fused shared-expert rows while preserving EP remapping.
+        num_align_experts = w1.shape[0] if expert_map is None else global_num_experts
         sorted_token_ids, expert_ids, num_tokens_post_padded = (
             _prepare_expert_assignment(
                 topk_ids,
                 config,
                 num_tokens,
                 top_k_num,
-                global_num_experts,
+                num_align_experts,
                 expert_map,
                 use_int8_w8a16=self.quant_config.use_int8_w8a16,
                 use_int4_w4a16=self.quant_config.use_int4_w4a16,
@@ -683,8 +685,10 @@ class TritonWNA16Experts(TritonExperts):
         )
         intermediate_cache3 = _resize_cache(workspace2, (num_tokens, top_k_num, K))
 
+        # Include fused shared-expert rows while preserving EP remapping.
+        num_align_experts = w1.shape[0] if expert_map is None else global_num_experts
         sorted_token_ids, expert_ids, num_tokens_post_padded = moe_align_block_size(
-            topk_ids, config["BLOCK_SIZE_M"], global_num_experts, expert_map
+            topk_ids, config["BLOCK_SIZE_M"], num_align_experts, expert_map
         )
 
         invoke_fused_moe_wna16_triton_kernel(


### PR DESCRIPTION
## Motivation

MoE models using fused shared experts with the Triton backend can produce corrupted outputs and suffer from severe accuracy loss. Fused shared experts append extra expert IDs and weight rows, while `global_num_experts` continues to represent only the routed experts. Triton uses this smaller count during token alignment, causing the appended shared expert IDs to be treated as invalid. Since the separate shared expert path is disabled when fusion is enabled, its contribution is lost.

This affects MoE models using Triton fused shared experts without an expert map. `EmbeddedLLM/MiniMax-M3-FP8-dynamic` on ROCm gfx942 is one such example.


## Suggested Fix

Use the physical expert row count from `w1.shape[0]` when no expert map is present. Continue using `global_num_experts` with expert parallelism because the IDs must be remapped through `expert_map`.

Apply the same correction to `TritonExperts` and `TritonWNA16Experts`. This matches the existing handling in the native MXFP8 path.

## Tests

Added a focused case to the existing Triton MoE test suite. Before the fix, 134 of 512 output elements differed from the reference, with a maximum difference of 2.515625. The test passes after the fix.
GSM8K 8-shot smoke evaluation with 128 samples on 4 MI325X GPUs:
| Configuration | Flexible exact match | Strict exact match |
|---|---:|---:|
| FSE enabled, before fix | 0.00% | 0.00% |
| FSE enabled, after fix | 94.53% | 89.06% |
| FSE disabled | 94.53% | 89.84% |

The patched TP4 server selected Triton FP8 MoE with 129 physical experts, completed CUDA graph capture, and returned a successful chat completion.

<details>
<summary>Reproduction command</summary>

Container image:

```text
vllm/vllm-openai-rocm:nightly-c810e5ee9976ad86b81d1277b53e76d0ee639414
```

```bash
export HIP_VISIBLE_DEVICES=0,1,2,3
export VLLM_ROCM_USE_AITER=1
export VLLM_USE_BREAKABLE_CUDAGRAPH=0
export VLLM_ROCM_USE_AITER_MOE=0
export VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS=1

vllm serve EmbeddedLLM/MiniMax-M3-FP8-dynamic \
  --served-model-name minimax-m3 \
  --tensor-parallel-size 4 \
  --block-size 128 \
  --max-model-len 262144 \
  --gpu-memory-utilization 0.92 \
  --enable-chunked-prefill \
  --max-num-batched-tokens 32768 \
  --max-num-seqs 32 \
  --no-enable-prefix-caching \
  --async-scheduling \
  --tool-call-parser minimax_m3 \
  --enable-auto-tool-choice \
  --reasoning-parser minimax_m3 \
  --kv-cache-dtype fp8 \
  --language-model-only \
  --port 8000 \
  --attention-backend ROCM_AITER_UNIFIED_ATTN
```

</details>
