### PR TITLE
[Security] Include cache_salt in HF3FS external cache keys

### DIFF
--- a/tests/v1/kv_connector/unit/test_hf3fs_connector.py
+++ b/tests/v1/kv_connector/unit/test_hf3fs_connector.py
@@ -2,10 +2,12 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """
 Tests for HF3FS KV Connector high-level components:
-  - TestHf3fsMockClient      : file-backed mock client I/O correctness
-  - TestHF3FSKVConnectorStats: metric collection, aggregation, serialisation
+  - TestHf3fsMockClient            : file-backed mock client I/O correctness
+  - TestHF3FSKVConnectorStats      : metric collection, aggregation, serialisation
+  - TestHF3FSCacheSaltIsolation    : cache_salt isolation in block hashing
 """
 
+import hashlib
 import os
 from unittest.mock import MagicMock
 
@@ -228,3 +230,102 @@ class TestHF3FSKVConnectorStats:
         clone = hf3fs_stats.clone_and_reset()
         assert clone.data["num_transfer_task"] == 2
         assert hf3fs_stats.is_empty()
+
+
+# ===========================================================================
+# TestHF3FSCacheSaltIsolation
+# ===========================================================================
+
+
+def _compute_prefix_hash(
+    token_ids: list[int],
+    previous_hash: str = "",
+    cache_salt: str = "",
+) -> str:
+    """Standalone reimplementation matching HF3FSKVConnector._compute_prefix_hash."""
+    combined_string = f"{cache_salt}_{previous_hash}_{token_ids}"
+    return hashlib.md5(combined_string.encode()).hexdigest()
+
+
+def _generate_block_hashes(
+    token_ids: list[int],
+    block_size: int,
+    start_block_id: int = 0,
+    max_blocks_count: int | None = None,
+    cache_salt: str = "",
+) -> list[str]:
+    """Standalone reimplementation matching HF3FSKVConnector._generate_block_hashes."""
+    block_hashes = []
+    previous_hash = ""
+
+    for start_idx in range(0, len(token_ids), block_size):
+        if start_idx + block_size > len(token_ids):
+            break
+
+        end_idx = start_idx + block_size
+        salt = cache_salt if start_idx == 0 else ""
+        block_hash = _compute_prefix_hash(
+            token_ids[start_idx:end_idx], previous_hash, salt
+        )
+
+        block_index = start_idx // block_size
+        if block_index >= start_block_id:
+            block_hashes.append(block_hash)
+
+        if max_blocks_count and len(block_hashes) >= max_blocks_count:
+            break
+        previous_hash = block_hash
+
+    return block_hashes
+
+
+class TestHF3FSCacheSaltIsolation:
+    """Verify that cache_salt produces distinct external keys."""
+
+    BLOCK_SIZE = 16
+    TOKENS = list(range(32))
+
+    def test_different_salts_produce_different_hashes(self):
+        """Same tokens with different salts must yield different block hashes."""
+        hashes_a = _generate_block_hashes(
+            self.TOKENS, self.BLOCK_SIZE, cache_salt="salt-A"
+        )
+        hashes_b = _generate_block_hashes(
+            self.TOKENS, self.BLOCK_SIZE, cache_salt="salt-B"
+        )
+        assert len(hashes_a) == 2
+        assert len(hashes_b) == 2
+        assert hashes_a != hashes_b
+        assert hashes_a[0] != hashes_b[0], "First block must differ"
+        assert hashes_a[1] != hashes_b[1], "Second block must differ (chained)"
+
+    def test_empty_salt_matches_no_salt(self):
+        """Empty string salt and default (no salt) produce identical hashes."""
+        hashes_default = _generate_block_hashes(self.TOKENS, self.BLOCK_SIZE)
+        hashes_empty = _generate_block_hashes(
+            self.TOKENS, self.BLOCK_SIZE, cache_salt=""
+        )
+        assert hashes_default == hashes_empty
+
+    def test_same_salt_produces_same_hashes(self):
+        """Identical tokens + salt must be deterministic."""
+        hashes_1 = _generate_block_hashes(
+            self.TOKENS, self.BLOCK_SIZE, cache_salt="deterministic"
+        )
+        hashes_2 = _generate_block_hashes(
+            self.TOKENS, self.BLOCK_SIZE, cache_salt="deterministic"
+        )
+        assert hashes_1 == hashes_2
+
+    def test_salt_only_injected_into_first_block(self):
+        """Salt should affect the first block directly; subsequent blocks
+        diverge only through chaining."""
+        hash_no_salt = _compute_prefix_hash([1, 2, 3], previous_hash="prev")
+        hash_with_salt = _compute_prefix_hash(
+            [1, 2, 3], previous_hash="prev", cache_salt="x"
+        )
+        assert hash_no_salt != hash_with_salt
+
+        hash_no_salt_first = _compute_prefix_hash([1, 2, 3])
+        hash_salt_first = _compute_prefix_hash([1, 2, 3], cache_salt="tenant-1")
+        assert hash_no_salt_first != hash_salt_first

--- a/vllm/distributed/kv_transfer/kv_connector/v1/hf3fs/hf3fs_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/hf3fs/hf3fs_connector.py
@@ -628,7 +628,11 @@ class HF3FSKVConnector(KVConnectorBase_V1):
                 continue
 
             skip_blocks = request.save_block_op.skip_leading_blocks
-            block_hashes = self._generate_block_hashes(request.token_ids, skip_blocks)
+            block_hashes = self._generate_block_hashes(
+                request.token_ids,
+                skip_blocks,
+                cache_salt=request.cache_salt,
+            )
             block_ids = request.block_ids[skip_blocks : skip_blocks + len(block_hashes)]
 
             for i in range(0, len(block_ids), self._max_device_buffer_count):
@@ -651,7 +655,10 @@ class HF3FSKVConnector(KVConnectorBase_V1):
             load_op = request.load_block_op
             block_ids = request.block_ids[: load_op.num_blocks_to_load]
             block_hashes = self._generate_block_hashes(
-                request.token_ids, load_op.num_computed_blocks, len(block_ids)
+                request.token_ids,
+                load_op.num_computed_blocks,
+                len(block_ids),
+                cache_salt=request.cache_salt,
             )
 
             for i in range(0, len(block_ids), self._max_device_buffer_count):
@@ -699,6 +706,7 @@ class HF3FSKVConnector(KVConnectorBase_V1):
         try:
             state = self._get_or_create_scheduling_state(request.request_id)
             state.request = request
+            state.cache_salt = request.cache_salt or ""
             assert request.prompt_token_ids is not None
 
             num_tokens_to_check = self._align_to_block_size(
@@ -714,7 +722,9 @@ class HF3FSKVConnector(KVConnectorBase_V1):
                 return 0, False
 
             token_ids_to_check = request.prompt_token_ids[:num_tokens_to_check]
-            block_hashes = self._generate_block_hashes(token_ids_to_check, 0)
+            block_hashes = self._generate_block_hashes(
+                token_ids_to_check, 0, cache_salt=state.cache_salt
+            )
 
             # Check existence
             exists_results = self._metadata_client.batch_key_exists(block_hashes)
@@ -807,6 +817,8 @@ class HF3FSKVConnector(KVConnectorBase_V1):
             assert (
                 state.request is not None and state.request.prompt_token_ids is not None
             )
+            if not state.cache_salt and state.request.cache_salt:
+                state.cache_salt = state.request.cache_salt
             # Create load request metadata
             num_cached_blocks = (
                 state.load_op.num_computed_blocks + state.load_op.num_blocks_to_load
@@ -957,6 +969,7 @@ class HF3FSKVConnector(KVConnectorBase_V1):
         token_ids: list[int],
         start_block_id: int,
         max_blocks_count: int | None = None,
+        cache_salt: str = "",
     ) -> list[str]:
         """Generate block hashes for token sequence."""
         block_hashes = []
@@ -967,8 +980,9 @@ class HF3FSKVConnector(KVConnectorBase_V1):
                 break
 
             end_idx = start_idx + self._block_size
+            salt = cache_salt if start_idx == 0 else ""
             block_hash = self._compute_prefix_hash(
-                token_ids[start_idx:end_idx], previous_hash
+                token_ids[start_idx:end_idx], previous_hash, salt
             )
 
             block_index = start_idx // self._block_size
@@ -1005,10 +1019,13 @@ class HF3FSKVConnector(KVConnectorBase_V1):
                 )
 
     def _compute_prefix_hash(
-        self, token_ids: list[int], previous_hash: str = ""
+        self,
+        token_ids: list[int],
+        previous_hash: str = "",
+        cache_salt: str = "",
     ) -> str:
         """Compute prefix hash for token block."""
-        combined_string = f"{previous_hash}_{token_ids}"
+        combined_string = f"{cache_salt}_{previous_hash}_{token_ids}"
         return hashlib.md5(combined_string.encode()).hexdigest()
 
     def _align_to_block_size(self, num_tokens: int) -> int:

--- a/vllm/distributed/kv_transfer/kv_connector/v1/hf3fs/utils/common.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/hf3fs/utils/common.py
@@ -52,6 +52,7 @@ class RequestSchedulingState:
     token_ids: list[int] = field(default_factory=list)
     allocated_block_ids: list[int] = field(default_factory=list)
     num_saved_blocks: int = 0
+    cache_salt: str = ""
 
     # Load operation info
     load_op: LoadBlockInfo | None = None
@@ -94,6 +95,7 @@ class HF3FSRequestMetadata:
     request_id: str
     token_ids: list[int]
     block_ids: list[int]
+    cache_salt: str = ""
     load_block_op: LoadBlockInfo | None = None
     save_block_op: SaveBlockInfo | None = None
 
@@ -123,6 +125,7 @@ class HF3FSRequestMetadata:
             request_id=state.request_id,
             token_ids=state.token_ids,
             block_ids=state.allocated_block_ids,
+            cache_salt=state.cache_salt,
             load_block_op=load_op,
             save_block_op=SaveBlockInfo(skip_leading_blocks=skip_blocks),
         )


### PR DESCRIPTION
HF3FSKVConnector derived external cache keys from token IDs alone, omitting the per-request cache_salt. This allowed cross-salt cached-prefix membership inference when engines shared an HF3FS metadata service.

Thread cache_salt through RequestSchedulingState, HF3FSRequestMetadata, and into _generate_block_hashes / _compute_prefix_hash so the salt is injected into the first block hash and chained forward, matching the isolation guarantees of native prefix caching and the LMCache connector.
