### PR TITLE
[CI/Build] Use file rendezvous for local distributed tests

### DIFF
--- a/tests/compile/passes/distributed/test_async_tp.py
+++ b/tests/compile/passes/distributed/test_async_tp.py
@@ -29,7 +29,7 @@ from vllm.distributed.parallel_state import (
     initialize_model_parallel,
 )
 from vllm.platforms import current_platform
-from vllm.utils.network_utils import get_open_port
+from vllm.utils.network_utils import get_file_store_init_method
 from vllm.utils.system_utils import update_environment_variables
 from vllm.utils.torch_utils import set_random_seed
 
@@ -266,7 +266,7 @@ def test_async_tp_pass_replace(
     dynamic: bool,
 ):
     num_processes = 2
-    master_port = str(get_open_port())
+    distributed_init_method = get_file_store_init_method()
 
     def run_torch_spawn(fn, nprocs):
         # need to use torch.mp.spawn otherwise will have problems with
@@ -281,7 +281,7 @@ def test_async_tp_pass_replace(
                 hidden_size,
                 dtype,
                 dynamic,
-                master_port,
+                distributed_init_method,
             ),
             nprocs=nprocs,
         )
@@ -314,7 +314,7 @@ def async_tp_pass_on_test_model(
     hidden_size: int,
     dtype: torch.dtype,
     dynamic: bool,
-    master_port: str = "0",
+    distributed_init_method: str,
 ):
     set_random_seed(0)
 
@@ -328,13 +328,16 @@ def async_tp_pass_on_test_model(
             "RANK": str(local_rank),
             "LOCAL_RANK": str(local_rank),
             "WORLD_SIZE": str(world_size),
-            "MASTER_ADDR": "localhost",
-            "MASTER_PORT": master_port,
         }
     )
 
     # initialize distributed
-    init_distributed_environment()
+    init_distributed_environment(
+        world_size=world_size,
+        rank=local_rank,
+        distributed_init_method=distributed_init_method,
+        local_rank=local_rank,
+    )
 
     # configure vllm config for SequenceParallelismPass
     vllm_config = VllmConfig()

--- a/tests/distributed/test_dcp_a2a.py
+++ b/tests/distributed/test_dcp_a2a.py
@@ -17,7 +17,7 @@ import torch.distributed as dist
 
 import vllm.envs as envs
 from vllm.config.parallel import ParallelConfig
-from vllm.utils.network_utils import get_open_port
+from vllm.utils.network_utils import get_file_store_init_method
 from vllm.utils.system_utils import update_environment_variables
 
 mp.set_start_method("spawn", force=True)
@@ -76,7 +76,7 @@ def _assert_packed_a2a_close(
 
 
 def _distributed_run(fn, world_size: int, extra_env: dict[str, str]) -> None:
-    port = str(get_open_port())
+    distributed_init_method = get_file_store_init_method()
     processes: list[mp.Process] = []
     for rank in range(world_size):
         env = {
@@ -84,8 +84,7 @@ def _distributed_run(fn, world_size: int, extra_env: dict[str, str]) -> None:
             "LOCAL_RANK": str(rank),
             "WORLD_SIZE": str(world_size),
             "LOCAL_WORLD_SIZE": str(world_size),
-            "MASTER_ADDR": "localhost",
-            "MASTER_PORT": port,
+            "DISTRIBUTED_INIT_METHOD": distributed_init_method,
             **extra_env,
         }
         process = mp.Process(target=fn, args=(env,))
@@ -483,14 +482,23 @@ class TestPackedA2AKernels:
 def _distributed_packed_a2a_worker(env: dict[str, str]) -> None:
     update_environment_variables(env)
     local_rank = int(env["LOCAL_RANK"])
+    world_size = int(env["WORLD_SIZE"])
     torch.accelerator.set_device_index(local_rank)
     if envs.VLLM_DISTRIBUTED_USE_SPLIT_GROUP:
         dist.init_process_group(
             backend="cpu:gloo,cuda:nccl",
             device_id=torch.device(f"cuda:{local_rank}"),
+            init_method=env["DISTRIBUTED_INIT_METHOD"],
+            rank=local_rank,
+            world_size=world_size,
         )
     else:
-        dist.init_process_group(backend="nccl")
+        dist.init_process_group(
+            backend="nccl",
+            init_method=env["DISTRIBUTED_INIT_METHOD"],
+            rank=local_rank,
+            world_size=world_size,
+        )
     use_workspace = env.get("USE_WORKSPACE") == "1"
     if use_workspace:
         from vllm.v1.worker.workspace import init_workspace_manager

--- a/tests/utils_/test_network_utils.py
+++ b/tests/utils_/test_network_utils.py
@@ -8,6 +8,7 @@ import zmq
 
 from vllm.utils import network_utils
 from vllm.utils.network_utils import (
+    get_file_store_init_method,
     get_open_port,
     get_open_ports_list,
     get_tcp_uri,
@@ -17,6 +18,13 @@ from vllm.utils.network_utils import (
     split_host_port,
     split_zmq_path,
 )
+
+
+def test_get_file_store_init_method_is_unique():
+    init_methods = {get_file_store_init_method() for _ in range(2)}
+
+    assert len(init_methods) == 2
+    assert all(method.startswith("file://") for method in init_methods)
 
 
 def _call_with_timeout(func, timeout: float = 10.0):


### PR DESCRIPTION
## Purpose

Continue the test-only follow-up identified in #51275 by removing probe-then-bind TCP rendezvous from two single-node distributed test launchers.

`get_open_port()` releases its probe socket before the spawned workers initialize their real process group. Under parallel CI, another process can claim that port during the gap and make an otherwise-correct test fail with `EADDRINUSE`.

This PR:

- switches the DCP A2A multiprocessing launcher to one unique `file://` rendezvous shared by its local workers;
- switches the CUDA Async-TP spawn test to an explicit FileStore init method and rank/world-size arguments;
- adds focused coverage that FileStore init methods are unique.

This is intentionally limited to parent-spawned, single-node tests whose rendezvous does not need to be externally reachable. AITER/custom-all-reduce paths requiring `TCPStore`, HTTP server ports, `StatelessProcessGroup`, and multi-node launchers remain out of scope.

## Duplicate-work check

Immediately before submission, searches for open PRs combining `test_dcp_a2a.py` or `test_async_tp.py` with `get_file_store_init_method`, plus race-free distributed-test rendezvous keywords, found no PR covering these changes. The production executor change in #50999 and its ROCm compatibility follow-up #51635 do not modify these test launchers.

## Test Plan

- Run the network utility unit tests on Python 3.12 with CPU PyTorch.
- Run all pre-commit hooks applicable to the three changed files.
- Run the manual Python 3.12 mypy hook.
- Exercise a two-process Gloo FileStore rendezvous on macOS ARM and Linux x86_64.
- Leave the 2/4-GPU DCP and Async-TP cases to upstream CI because no local GPU was available.

## Test Result

- `pytest --confcutdir=tests/utils_ tests/utils_/test_network_utils.py -q` — **21 passed**.
- `pre-commit run --files tests/distributed/test_dcp_a2a.py tests/compile/passes/distributed/test_async_tp.py tests/utils_/test_network_utils.py` — **all applicable hooks passed**, including Python 3.10 mypy.
- `pre-commit run mypy-3.12 --hook-stage manual --files tests/distributed/test_dcp_a2a.py tests/compile/passes/distributed/test_async_tp.py tests/utils_/test_network_utils.py` — **passed**.
- Two-process Gloo + FileStore smoke on macOS ARM with PyTorch 2.13.0 — **passed**.
- Two-process Gloo + FileStore smoke in a Linux x86_64 container with PyTorch 2.13.0+cpu — **passed**.
- GPU DCP/Async-TP tests — **not run locally; no GPU available**.

## AI Assistance

OpenAI Codex was used for investigation, implementation, test execution, and drafting. The human submitter reviewed every changed line, confirmed the bounded scope, and understands the change end-to-end before submission.
