### PR TITLE
[Refactor] move moe sequence parallel boundaries into parallel linear layers

### DIFF
--- a/tests/model_executor/layers/test_linear_sequence_parallel.py
+++ b/tests/model_executor/layers/test_linear_sequence_parallel.py
@@ -1,0 +1,172 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from unittest.mock import Mock
+
+import torch
+from torch import nn
+
+from vllm.distributed import communication_op
+from vllm.lora.layers.column_parallel_linear import ColumnParallelLinearWithLoRA
+from vllm.lora.layers.row_parallel_linear import RowParallelLinearWithLoRA
+from vllm.model_executor.layers import linear as linear_module
+from vllm.model_executor.layers.linear import (
+    ColumnParallelLinear,
+    RowParallelLinear,
+)
+
+
+def _column_layer() -> ColumnParallelLinear:
+    layer = object.__new__(ColumnParallelLinear)
+    nn.Module.__init__(layer)
+    layer.bias = None
+    layer.gather_output = False
+    layer.quant_method = Mock()
+    layer.return_bias = False
+    layer.sequence_parallel = True
+    layer.skip_bias_add = False
+    layer.tp_size = 2
+    return layer
+
+
+def _row_layer() -> RowParallelLinear:
+    layer = object.__new__(RowParallelLinear)
+    nn.Module.__init__(layer)
+    layer.bias = None
+    layer.input_is_parallel = True
+    layer.quant_method = Mock()
+    layer.reduce_results = True
+    layer.return_bias = False
+    layer.sequence_parallel = True
+    layer.skip_bias_add = False
+    layer.tp_rank = 0
+    layer.tp_size = 2
+    return layer
+
+
+def test_column_parallel_linear_gathers_sequence_shards(monkeypatch):
+    local_input = torch.arange(4, dtype=torch.float32).view(2, 2)
+    gathered_input = torch.cat([local_input, local_input + 4])
+    output_parallel = gathered_input[:, :1]
+    all_gather = Mock(return_value=gathered_input)
+    monkeypatch.setattr(linear_module, "sequence_parallel_all_gather", all_gather)
+    layer = _column_layer()
+    layer.quant_method.apply.return_value = output_parallel
+
+    output = layer(local_input)
+
+    all_gather.assert_called_once_with(local_input)
+    layer.quant_method.apply.assert_called_once_with(layer, gathered_input, None)
+    torch.testing.assert_close(output, output_parallel)
+
+
+def test_row_parallel_linear_reduce_scatters_sequence_shards(monkeypatch):
+    input_parallel = torch.arange(4, dtype=torch.float32).view(4, 1)
+    output_parallel = torch.cat([input_parallel, input_parallel], dim=1)
+    local_output = output_parallel[:2]
+    reduce_scatter = Mock(return_value=local_output)
+    all_reduce = Mock(side_effect=AssertionError("unexpected all-reduce"))
+    monkeypatch.setattr(
+        linear_module,
+        "sequence_parallel_reduce_scatter",
+        reduce_scatter,
+    )
+    monkeypatch.setattr(
+        linear_module,
+        "tensor_model_parallel_all_reduce",
+        all_reduce,
+    )
+    layer = _row_layer()
+    layer.quant_method.apply.return_value = output_parallel
+
+    output = layer(input_parallel)
+
+    reduce_scatter.assert_called_once_with(output_parallel)
+    all_reduce.assert_not_called()
+    torch.testing.assert_close(output, local_output)
+
+
+def test_sequence_parallel_reduce_scatter_does_not_pad(monkeypatch):
+    output_parallel = torch.arange(6, dtype=torch.float32).view(3, 2)
+    local_output = output_parallel[:1]
+    custom_collective = Mock(return_value=None)
+    reduce_scatter = Mock(return_value=local_output)
+    monkeypatch.setattr(
+        communication_op,
+        "_custom_sequence_parallel_collective",
+        custom_collective,
+    )
+    monkeypatch.setattr(
+        communication_op,
+        "tensor_model_parallel_reduce_scatter",
+        reduce_scatter,
+    )
+
+    output = communication_op.sequence_parallel_reduce_scatter(output_parallel)
+
+    custom_collective.assert_called_once_with("custom_reduce_scatter", output_parallel)
+    reduce_scatter.assert_called_once_with(output_parallel, dim=0)
+    torch.testing.assert_close(output, local_output)
+
+
+def test_row_parallel_linear_keeps_all_reduce_by_default(monkeypatch):
+    output_parallel = torch.arange(8, dtype=torch.float32).view(4, 2)
+    reduced_output = output_parallel + 1
+    all_reduce = Mock(return_value=reduced_output)
+    reduce_scatter = Mock(side_effect=AssertionError("unexpected reduce-scatter"))
+    monkeypatch.setattr(
+        linear_module,
+        "tensor_model_parallel_all_reduce",
+        all_reduce,
+    )
+    monkeypatch.setattr(
+        linear_module,
+        "sequence_parallel_reduce_scatter",
+        reduce_scatter,
+    )
+    layer = _row_layer()
+    layer.sequence_parallel = False
+
+    output = layer.reduce_output(output_parallel)
+
+    all_reduce.assert_called_once_with(output_parallel)
+    reduce_scatter.assert_not_called()
+    torch.testing.assert_close(output, reduced_output)
+
+
+def test_column_parallel_lora_reuses_base_input_preparation():
+    local_input = torch.arange(4, dtype=torch.float32).view(2, 2)
+    gathered_input = torch.cat([local_input, local_input + 4])
+    output_parallel = gathered_input[:, :1]
+    base_layer = _column_layer()
+    base_layer.prepare_input = Mock(return_value=gathered_input)
+    lora_layer = object.__new__(ColumnParallelLinearWithLoRA)
+    nn.Module.__init__(lora_layer)
+    lora_layer.base_layer = base_layer
+    lora_layer.tp_size = 2
+    object.__setattr__(lora_layer, "apply", Mock(return_value=output_parallel))
+
+    output = lora_layer(local_input)
+
+    base_layer.prepare_input.assert_called_once_with(local_input)
+    lora_layer.apply.assert_called_once_with(gathered_input, None)
+    torch.testing.assert_close(output, output_parallel)
+
+
+def test_row_parallel_lora_reuses_base_output_reduction():
+    input_parallel = torch.arange(4, dtype=torch.float32).view(4, 1)
+    output_parallel = torch.cat([input_parallel, input_parallel], dim=1)
+    local_output = output_parallel[:2]
+    base_layer = _row_layer()
+    base_layer.reduce_output = Mock(return_value=local_output)
+    lora_layer = object.__new__(RowParallelLinearWithLoRA)
+    nn.Module.__init__(lora_layer)
+    lora_layer.base_layer = base_layer
+    lora_layer.tp_rank = 0
+    lora_layer.tp_size = 2
+    object.__setattr__(lora_layer, "apply", Mock(return_value=output_parallel))
+
+    output = lora_layer(input_parallel)
+
+    base_layer.reduce_output.assert_called_once_with(output_parallel)
+    torch.testing.assert_close(output, local_output)

--- a/tests/model_executor/layers/test_linear_sequence_parallel.py
+++ b/tests/model_executor/layers/test_linear_sequence_parallel.py
@@ -1,8 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from types import SimpleNamespace
 from unittest.mock import Mock
 
+import pytest
 import torch
 from torch import nn
 
@@ -14,6 +16,7 @@ from vllm.model_executor.layers.linear import (
     ColumnParallelLinear,
     RowParallelLinear,
 )
+from vllm.model_executor.models import utils as model_utils
 
 
 def _column_layer() -> ColumnParallelLinear:
@@ -35,7 +38,7 @@ def _row_layer() -> RowParallelLinear:
     layer.bias = None
     layer.input_is_parallel = True
     layer.quant_method = Mock()
-    layer.reduce_results = True
+    layer.reduce_results = False
     layer.return_bias = False
     layer.sequence_parallel = True
     layer.skip_bias_add = False
@@ -50,6 +53,12 @@ def test_column_parallel_linear_gathers_sequence_shards(monkeypatch):
     output_parallel = gathered_input[:, :1]
     all_gather = Mock(return_value=gathered_input)
     monkeypatch.setattr(linear_module, "sequence_parallel_all_gather", all_gather)
+    monkeypatch.setattr(linear_module, "is_forward_context_available", lambda: True)
+    monkeypatch.setattr(
+        linear_module,
+        "get_forward_context",
+        lambda: SimpleNamespace(batch_descriptor=SimpleNamespace(num_tokens=4)),
+    )
     layer = _column_layer()
     layer.quant_method.apply.return_value = output_parallel
 
@@ -57,6 +66,27 @@ def test_column_parallel_linear_gathers_sequence_shards(monkeypatch):
 
     all_gather.assert_called_once_with(local_input)
     layer.quant_method.apply.assert_called_once_with(layer, gathered_input, None)
+    torch.testing.assert_close(output, output_parallel)
+
+
+def test_column_parallel_linear_skips_gather_for_replicated_input(monkeypatch):
+    replicated_input = torch.arange(8, dtype=torch.float32).view(4, 2)
+    output_parallel = replicated_input[:, :1]
+    all_gather = Mock(side_effect=AssertionError("unexpected all-gather"))
+    monkeypatch.setattr(linear_module, "sequence_parallel_all_gather", all_gather)
+    monkeypatch.setattr(linear_module, "is_forward_context_available", lambda: True)
+    monkeypatch.setattr(
+        linear_module,
+        "get_forward_context",
+        lambda: SimpleNamespace(batch_descriptor=SimpleNamespace(num_tokens=4)),
+    )
+    layer = _column_layer()
+    layer.quant_method.apply.return_value = output_parallel
+
+    output = layer(replicated_input)
+
+    all_gather.assert_not_called()
+    layer.quant_method.apply.assert_called_once_with(layer, replicated_input, None)
     torch.testing.assert_close(output, output_parallel)
 
 
@@ -84,6 +114,30 @@ def test_row_parallel_linear_reduce_scatters_sequence_shards(monkeypatch):
     reduce_scatter.assert_called_once_with(output_parallel)
     all_reduce.assert_not_called()
     torch.testing.assert_close(output, local_output)
+
+
+def test_row_parallel_linear_requires_runner_padding(monkeypatch):
+    output_parallel = torch.arange(6, dtype=torch.float32).view(3, 2)
+    reduce_scatter = Mock()
+    monkeypatch.setattr(
+        linear_module,
+        "sequence_parallel_reduce_scatter",
+        reduce_scatter,
+    )
+    layer = _row_layer()
+
+    with pytest.raises(AssertionError, match="padded by the model runner"):
+        layer.reduce_output(output_parallel)
+
+    reduce_scatter.assert_not_called()
+
+
+def test_sequence_parallel_chunk_requires_runner_padding(monkeypatch):
+    monkeypatch.setattr(model_utils, "get_tensor_model_parallel_world_size", lambda: 2)
+    monkeypatch.setattr(model_utils, "get_tensor_model_parallel_rank", lambda: 0)
+
+    with pytest.raises(AssertionError, match="padded by the model runner"):
+        model_utils.sequence_parallel_chunk_impl(torch.zeros(3, 2))
 
 
 def test_sequence_parallel_reduce_scatter_does_not_pad(monkeypatch):
@@ -126,6 +180,7 @@ def test_row_parallel_linear_keeps_all_reduce_by_default(monkeypatch):
     )
     layer = _row_layer()
     layer.sequence_parallel = False
+    layer.reduce_results = True
 
     output = layer.reduce_output(output_parallel)
 

--- a/tests/models/kimi_k3/test_sequence_parallel.py
+++ b/tests/models/kimi_k3/test_sequence_parallel.py
@@ -10,6 +10,7 @@ import torch
 from torch import nn
 
 from vllm.config import ParallelConfig
+from vllm.distributed import communication_op as sp_comm
 from vllm.model_executor.layers.activation import SiluAndMul
 from vllm.models.common.ops import sequence_parallel as sp_ops
 from vllm.models.kimi_k3.nvidia import model as kimi_model
@@ -349,12 +350,15 @@ def test_sp_all_gather_uses_custom_kernel(monkeypatch):
         custom_all_gather=custom_all_gather,
     )
     monkeypatch.setattr(
-        sp_ops,
+        sp_comm,
         "get_tp_group",
-        lambda: SimpleNamespace(device_communicator=device_communicator),
+        lambda: SimpleNamespace(
+            device_communicator=device_communicator,
+            world_size=2,
+        ),
     )
     fallback = Mock(side_effect=AssertionError("unexpected fallback"))
-    monkeypatch.setattr(sp_ops, "tensor_model_parallel_all_gather", fallback)
+    monkeypatch.setattr(sp_comm, "tensor_model_parallel_all_gather", fallback)
 
     output = sp_ops.sp_all_gather(hidden_states)
 
@@ -371,17 +375,18 @@ def test_sp_reduce_scatter_uses_custom_kernel_after_padding(monkeypatch):
         custom_reduce_scatter=custom_reduce_scatter,
     )
     monkeypatch.setattr(
-        sp_ops,
+        sp_comm,
         "get_tp_group",
-        lambda: SimpleNamespace(device_communicator=device_communicator),
+        lambda: SimpleNamespace(
+            device_communicator=device_communicator,
+            world_size=2,
+        ),
     )
     monkeypatch.setattr(
-        sp_ops,
-        "get_tensor_model_parallel_world_size",
-        lambda: 2,
+        sp_comm,
+        "tensor_model_parallel_reduce_scatter",
+        Mock(side_effect=AssertionError("unexpected fallback")),
     )
-    fallback = Mock(side_effect=AssertionError("unexpected fallback"))
-    monkeypatch.setattr(sp_ops, "tensor_model_parallel_reduce_scatter", fallback)
 
     output = sp_ops.sp_reduce_scatter(hidden_states)
 
@@ -390,7 +395,7 @@ def test_sp_reduce_scatter_uses_custom_kernel_after_padding(monkeypatch):
     assert padded.shape == (4, 2)
     torch.testing.assert_close(padded[:3], hidden_states)
     torch.testing.assert_close(padded[3], torch.zeros(2))
-    fallback.assert_not_called()
+    sp_comm.tensor_model_parallel_reduce_scatter.assert_not_called()
 
 
 @pytest.mark.parametrize("shape", [(3,), (3, 2, 2)])
@@ -413,25 +418,20 @@ def test_sp_shard_pads_only_the_token_axis(monkeypatch, shape):
 def test_sp_collectives_fall_back_without_custom_kernel(monkeypatch):
     hidden_states = torch.arange(4, dtype=torch.float32).view(2, 2)
     monkeypatch.setattr(
-        sp_ops,
+        sp_comm,
         "get_tp_group",
-        lambda: SimpleNamespace(device_communicator=None),
-    )
-    monkeypatch.setattr(
-        sp_ops,
-        "get_tensor_model_parallel_world_size",
-        lambda: 2,
+        lambda: SimpleNamespace(device_communicator=None, world_size=2),
     )
     all_gather = Mock(return_value=hidden_states)
     reduce_scatter = Mock(return_value=hidden_states)
-    monkeypatch.setattr(sp_ops, "tensor_model_parallel_all_gather", all_gather)
+    monkeypatch.setattr(sp_comm, "tensor_model_parallel_all_gather", all_gather)
     monkeypatch.setattr(
-        sp_ops,
+        sp_comm,
         "tensor_model_parallel_reduce_scatter",
         reduce_scatter,
     )
 
     torch.testing.assert_close(sp_ops.sp_all_gather(hidden_states), hidden_states)
     torch.testing.assert_close(sp_ops.sp_reduce_scatter(hidden_states), hidden_states)
-    all_gather.assert_called_once_with(hidden_states, 0)
-    reduce_scatter.assert_called_once_with(hidden_states, 0)
+    all_gather.assert_called_once_with(hidden_states, dim=0)
+    reduce_scatter.assert_called_once_with(hidden_states, dim=0)

--- a/tests/models/test_qwen3_next_sequence_parallel.py
+++ b/tests/models/test_qwen3_next_sequence_parallel.py
@@ -1,0 +1,108 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from unittest.mock import Mock
+
+import pytest
+import torch
+from torch import nn
+
+from vllm.model_executor.models import qwen3_next
+
+
+class _IdentityNorm(nn.Module):
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        residual: torch.Tensor | None = None,
+    ):
+        if residual is None:
+            return hidden_states
+        return hidden_states, residual
+
+
+class _SequenceParallelAttention(nn.Module):
+    def __init__(self, layer_type: str) -> None:
+        super().__init__()
+        self.layer_type = layer_type
+        self.input_num_tokens: list[int] = []
+        self.num_tokens = 0
+        self.full_num_tokens = 4
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        positions: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        self.input_num_tokens.append(hidden_states.shape[0])
+        if hidden_states.shape[0] != self.full_num_tokens:
+            hidden_states = torch.cat([hidden_states, hidden_states], dim=0)
+        self.num_tokens = hidden_states.shape[0]
+        assert self.num_tokens % 2 == 0
+        return hidden_states.chunk(2, dim=0)[0]
+
+
+class _RecordingMoe(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.num_tokens = 0
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        already_sequence_parallel: bool = False,
+    ) -> torch.Tensor:
+        assert already_sequence_parallel
+        self.num_tokens = hidden_states.shape[0]
+        return hidden_states
+
+
+@pytest.mark.parametrize("layer_type", ["full_attention", "linear_attention"])
+def test_qwen_decoder_uses_linear_sequence_parallel_boundary(
+    monkeypatch,
+    layer_type: str,
+):
+    layer = object.__new__(qwen3_next.Qwen3NextDecoderLayer)
+    nn.Module.__init__(layer)
+    layer.layer_type = layer_type
+    layer.layer_scale = False
+    layer.use_attn_reduce_scatter_for_moe = True
+    layer.input_layernorm = _IdentityNorm()
+    layer.post_attention_layernorm = _IdentityNorm()
+    attention = _SequenceParallelAttention(layer_type)
+    if layer_type == "full_attention":
+        layer.self_attn = attention
+    else:
+        layer.linear_attn = attention
+    layer.mlp = _RecordingMoe()
+
+    shard = Mock(side_effect=lambda hidden_states: hidden_states[:2].clone())
+    monkeypatch.setattr(qwen3_next, "sequence_parallel_chunk", shard)
+
+    positions = torch.arange(4)
+    full_hidden_states = torch.arange(8, dtype=torch.float32).view(4, 2)
+    hidden_states, residual = layer(
+        positions=positions,
+        hidden_states=full_hidden_states,
+        residual=None,
+    )
+
+    assert hidden_states.shape == residual.shape == (2, 2)
+    assert attention.num_tokens == 4
+    assert attention.input_num_tokens == [4]
+    assert layer.mlp.num_tokens == 2
+    shard.assert_called_once_with(full_hidden_states)
+    sequence_shard = hidden_states
+
+    hidden_states, residual = layer(
+        positions=positions,
+        hidden_states=hidden_states,
+        residual=residual,
+    )
+
+    assert hidden_states.shape == residual.shape == (2, 2)
+    assert attention.num_tokens == 4
+    assert attention.input_num_tokens == [4, 2]
+    assert layer.mlp.num_tokens == 2
+    torch.testing.assert_close(sequence_shard, hidden_states)
+    shard.assert_called_once()

--- a/tests/v1/worker/test_gpu_model_runner.py
+++ b/tests/v1/worker/test_gpu_model_runner.py
@@ -287,6 +287,21 @@ def test_reasoning_config_without_custom_logitsprocs_does_not_need_output_token_
     assert runner.input_batch.logitsprocs_need_output_token_ids is False
 
 
+def test_model_runner_pads_moe_sequence_parallel_input():
+    runner = object.__new__(GPUModelRunner)
+    parallel_config = SimpleNamespace(
+        tensor_parallel_size=4,
+        use_sequence_parallel_moe=True,
+    )
+    runner.parallel_config = parallel_config
+    runner.vllm_config = SimpleNamespace(parallel_config=parallel_config)
+    runner.compilation_config = SimpleNamespace(
+        pass_config=SimpleNamespace(enable_sp=False)
+    )
+
+    assert runner._pad_for_sequence_parallelism(5) == 8
+
+
 @pytest.mark.skip_global_cleanup
 @pytest.mark.parametrize(
     ("world_size", "is_last_rank", "expected_calls"),

--- a/tests/v1/worker/test_gpu_model_runner_v2_eplb.py
+++ b/tests/v1/worker/test_gpu_model_runner_v2_eplb.py
@@ -12,6 +12,16 @@ from vllm.v1.worker.gpu import eplb_utils as eplb
 from vllm.v1.worker.gpu import model_runner as mrv2
 
 
+def test_v2_model_runner_pads_moe_sequence_parallel_input():
+    runner = object.__new__(mrv2.GPUModelRunner)
+    runner.parallel_config = SimpleNamespace(
+        tensor_parallel_size=4,
+        use_sequence_parallel_moe=True,
+    )
+
+    assert runner._pad_for_sequence_parallelism(5) == 8
+
+
 class FakeMemoryProfiler:
     def __enter__(self):
         self.consumed_memory = 0

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -1918,9 +1918,9 @@ class VllmConfig:
                 # de-duplicate and sort the sizes
                 cudagraph_capture_sizes = sorted(set(cudagraph_capture_sizes))
 
-            if (
-                self.parallel_config.tensor_parallel_size > 1
-                and self.compilation_config.pass_config.enable_sp
+            if self.parallel_config.tensor_parallel_size > 1 and (
+                self.compilation_config.pass_config.enable_sp
+                or self.parallel_config.use_sequence_parallel_moe
             ):
                 cudagraph_capture_sizes = self.update_sizes_for_sequence_parallelism(
                     cudagraph_capture_sizes

--- a/vllm/distributed/communication_op.py
+++ b/vllm/distributed/communication_op.py
@@ -28,6 +28,32 @@ def tensor_model_parallel_reduce_scatter(
     return get_tp_group().reduce_scatter(input_, dim)
 
 
+def _custom_sequence_parallel_collective(
+    name: str, input_: torch.Tensor
+) -> torch.Tensor | None:
+    device_communicator = get_tp_group().device_communicator
+    if device_communicator is None:
+        return None
+    collective = getattr(device_communicator, name, None)
+    return None if collective is None else collective(input_)
+
+
+def sequence_parallel_all_gather(input_: torch.Tensor) -> torch.Tensor:
+    """Gather token shards across the tensor-parallel group."""
+    output = _custom_sequence_parallel_collective("custom_all_gather", input_)
+    if output is None:
+        output = tensor_model_parallel_all_gather(input_, dim=0)
+    return output
+
+
+def sequence_parallel_reduce_scatter(input_: torch.Tensor) -> torch.Tensor:
+    """Sum partial results and scatter them along the token dimension."""
+    output = _custom_sequence_parallel_collective("custom_reduce_scatter", input_)
+    if output is not None:
+        return output
+    return tensor_model_parallel_reduce_scatter(input_, dim=0)
+
+
 def tensor_model_parallel_gather(
     input_: torch.Tensor, dst: int = 0, dim: int = -1
 ) -> torch.Tensor | None:

--- a/vllm/lora/layers/column_parallel_linear.py
+++ b/vllm/lora/layers/column_parallel_linear.py
@@ -130,7 +130,8 @@ class ColumnParallelLinearWithLoRA(BaseLinearLayerWithLoRA):
         return lora_b
 
     def forward(
-        self, input_: torch.Tensor
+        self,
+        input_: torch.Tensor,
     ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor | None]:
         """Forward of ColumnParallelLinear
 
@@ -141,7 +142,7 @@ class ColumnParallelLinearWithLoRA(BaseLinearLayerWithLoRA):
             - output
             - bias
         """
-        input_ = self.base_layer.prepare_input(input_)
+        input_ = self.prepare_input(input_)
         bias = self.base_layer.bias if not self.base_layer.skip_bias_add else None
 
         # Matrix multiply.
@@ -157,6 +158,12 @@ class ColumnParallelLinearWithLoRA(BaseLinearLayerWithLoRA):
 
         output_bias = self.base_layer.bias if self.base_layer.skip_bias_add else None
         return output, output_bias
+
+    def prepare_input(
+        self,
+        input_: torch.Tensor,
+    ) -> torch.Tensor:
+        return self.base_layer.prepare_input(input_)
 
     @classmethod
     @_not_fully_sharded_can_replace

--- a/vllm/lora/layers/column_parallel_linear.py
+++ b/vllm/lora/layers/column_parallel_linear.py
@@ -141,6 +141,7 @@ class ColumnParallelLinearWithLoRA(BaseLinearLayerWithLoRA):
             - output
             - bias
         """
+        input_ = self.base_layer.prepare_input(input_)
         bias = self.base_layer.bias if not self.base_layer.skip_bias_add else None
 
         # Matrix multiply.

--- a/vllm/lora/layers/row_parallel_linear.py
+++ b/vllm/lora/layers/row_parallel_linear.py
@@ -70,10 +70,7 @@ class RowParallelLinearWithLoRA(BaseLinearLayerWithLoRA):
             else self.base_layer.bias
         )
         output_parallel = self.apply(input_parallel, bias_)
-        if self.base_layer.reduce_results and self.tp_size > 1:
-            output = tensor_model_parallel_all_reduce(output_parallel)
-        else:
-            output = output_parallel
+        output = self.base_layer.reduce_output(output_parallel)
 
         output_bias = self.base_layer.bias if self.base_layer.skip_bias_add else None
         if not self.base_layer.return_bias:

--- a/vllm/model_executor/layers/linear.py
+++ b/vllm/model_executor/layers/linear.py
@@ -16,6 +16,8 @@ from vllm.distributed import (
     divide,
     get_tensor_model_parallel_rank,
     get_tensor_model_parallel_world_size,
+    sequence_parallel_all_gather,
+    sequence_parallel_reduce_scatter,
     split_tensor_along_last_dim,
     tensor_model_parallel_all_gather,
     tensor_model_parallel_all_reduce,
@@ -438,6 +440,8 @@ class ColumnParallelLinear(LinearBase):
                         (e.g. model.layers.0.qkv_proj)
         return_bias: If true, return bias together with outputs in forward pass.
         disable_tp: If true, weights matrix won't be sharded through tp rank.
+        sequence_parallel: If true, gather token shards before the matrix
+            multiplication.
         tp_rank: Override the tensor-parallel rank used for sharding. Defaults to
             the global TP rank. Used to shard at a coarser granularity than one
             shard per rank (see ``DCPGroupColumnParallelLinear``).
@@ -460,6 +464,7 @@ class ColumnParallelLinear(LinearBase):
         *,
         return_bias: bool = True,
         disable_tp: bool = False,
+        sequence_parallel: bool = False,
         tp_rank: int | None = None,
         tp_size: int | None = None,
     ):
@@ -500,6 +505,7 @@ class ColumnParallelLinear(LinearBase):
 
         self._maybe_allow_fp8_block_shape_mismatch()
         self.gather_output = gather_output
+        self.sequence_parallel = sequence_parallel
 
         self.quant_method.create_weights(
             layer=self,
@@ -592,6 +598,7 @@ class ColumnParallelLinear(LinearBase):
         self,
         input_,
     ) -> torch.Tensor | tuple[torch.Tensor, Parameter | None]:
+        input_ = self.prepare_input(input_)
         bias = self.bias if not self.skip_bias_add else None
 
         # Matrix multiply.
@@ -608,12 +615,18 @@ class ColumnParallelLinear(LinearBase):
         output_bias = self.bias if self.skip_bias_add else None
         return output, output_bias
 
+    def prepare_input(self, input_: torch.Tensor) -> torch.Tensor:
+        if self.sequence_parallel and self.tp_size > 1:
+            return sequence_parallel_all_gather(input_)
+        return input_
+
     def extra_repr(self) -> str:
         s = f"in_features={self.input_size}"
         s += f", output_features={self.output_size_per_partition}"
         s += f", bias={self.bias is not None}"
         s += f", tp_size={self.tp_size}"
         s += f", gather_output={self.gather_output}"
+        s += f", sequence_parallel={self.sequence_parallel}"
         return s
 
 
@@ -682,6 +695,8 @@ class MergedColumnParallelLinear(ColumnParallelLinear):
         return_bias: If true, return bias together with outputs in forward pass.
         disable_tp: If true, all weights matrix won't be sharded, this layer
                     will be treated as a "Replicated" MergedLinear.
+        sequence_parallel: If true, gather token shards before the matrix
+            multiplication.
     """
 
     def __init__(
@@ -697,6 +712,7 @@ class MergedColumnParallelLinear(ColumnParallelLinear):
         *,
         return_bias: bool = True,
         disable_tp: bool = False,
+        sequence_parallel: bool = False,
     ):
         self.output_sizes = output_sizes
         self.tp_size = get_tensor_model_parallel_world_size() if not disable_tp else 1
@@ -714,6 +730,7 @@ class MergedColumnParallelLinear(ColumnParallelLinear):
             prefix=prefix,
             return_bias=return_bias,
             disable_tp=disable_tp,
+            sequence_parallel=sequence_parallel,
         )
 
     def validate_shard_id(self, shard_id: Any) -> TypeIs[int | tuple[int, ...] | None]:
@@ -1045,6 +1062,8 @@ class QKVParallelLinear(ColumnParallelLinear):
                         (e.g. model.layers.0.qkv_proj)
         return_bias: If true, return bias together with outputs in forward pass.
         disable_tp: If true, weights matrix won't be sharded through tp rank.
+        sequence_parallel: If true, gather token shards before the matrix
+            multiplication.
     """
 
     def __init__(
@@ -1062,6 +1081,7 @@ class QKVParallelLinear(ColumnParallelLinear):
         return_bias: bool = True,
         disable_tp: bool = False,
         v_head_size: int | None = None,
+        sequence_parallel: bool = False,
     ):
         self.hidden_size = hidden_size
         self.head_size = head_size
@@ -1098,6 +1118,7 @@ class QKVParallelLinear(ColumnParallelLinear):
             prefix=prefix,
             return_bias=return_bias,
             disable_tp=disable_tp,
+            sequence_parallel=sequence_parallel,
         )
 
     def validate_shard_id(self, shard_id: Any) -> TypeIs[str | None]:
@@ -1641,6 +1662,8 @@ class RowParallelLinear(LinearBase):
                         (e.g. model.layers.0.down_proj)
         return_bias: If true, return bias together with outputs in forward pass.
         disable_tp: If true, weights matrix won't be sharded through tp rank.
+        sequence_parallel: If true, reduce-scatter partial outputs along the
+            token dimension instead of all-reducing them.
     """
 
     # --8<-- [end:row_parallel_linear]
@@ -1659,6 +1682,7 @@ class RowParallelLinear(LinearBase):
         *,
         return_bias: bool = True,
         disable_tp: bool = False,
+        sequence_parallel: bool = False,
     ):
         # Divide the weight matrix along the first dimension.
         self.tp_rank = get_tensor_model_parallel_rank() if not disable_tp else 0
@@ -1681,6 +1705,7 @@ class RowParallelLinear(LinearBase):
 
         self.input_is_parallel = input_is_parallel
         self.reduce_results = reduce_results
+        self.sequence_parallel = sequence_parallel
 
         self.quant_method.create_weights(
             layer=self,
@@ -1763,15 +1788,19 @@ class RowParallelLinear(LinearBase):
         bias_ = None if (self.tp_rank > 0 or self.skip_bias_add) else self.bias
         output_parallel = self.quant_method.apply(self, input_parallel, bias_)
 
-        if self.reduce_results and self.tp_size > 1:
-            output = tensor_model_parallel_all_reduce(output_parallel)
-        else:
-            output = output_parallel
+        output = self.reduce_output(output_parallel)
 
         if not self.return_bias:
             return output
         output_bias = self.bias if self.skip_bias_add else None
         return output, output_bias
+
+    def reduce_output(self, output_parallel: torch.Tensor) -> torch.Tensor:
+        if not self.reduce_results or self.tp_size == 1:
+            return output_parallel
+        if self.sequence_parallel:
+            return sequence_parallel_reduce_scatter(output_parallel)
+        return tensor_model_parallel_all_reduce(output_parallel)
 
     def extra_repr(self) -> str:
         s = f"in_features={self.input_size_per_partition}"
@@ -1779,4 +1808,5 @@ class RowParallelLinear(LinearBase):
         s += f", bias={self.bias is not None}"
         s += f", tp_size={self.tp_size}"
         s += f", reduce_results={self.reduce_results}"
+        s += f", sequence_parallel={self.sequence_parallel}"
         return s

--- a/vllm/model_executor/layers/linear.py
+++ b/vllm/model_executor/layers/linear.py
@@ -11,7 +11,7 @@ from torch.nn.parameter import Parameter
 from typing_extensions import TypeIs
 
 import vllm.envs as envs
-from vllm.config import get_current_vllm_config
+from vllm.config import get_current_vllm_config, get_current_vllm_config_or_none
 from vllm.distributed import (
     divide,
     get_tensor_model_parallel_rank,
@@ -21,6 +21,10 @@ from vllm.distributed import (
     split_tensor_along_last_dim,
     tensor_model_parallel_all_gather,
     tensor_model_parallel_all_reduce,
+)
+from vllm.forward_context import (
+    get_forward_context,
+    is_forward_context_available,
 )
 from vllm.logger import init_logger
 from vllm.model_executor.custom_op import PluggableLayer
@@ -47,6 +51,34 @@ from vllm.model_executor.utils import set_weight_attrs
 from vllm.platforms import current_platform
 
 logger = init_logger(__name__)
+
+
+# Models whose attention AG/RS communication is handled by ColumnParallelLinear
+# and RowParallelLinear instead of model-specific forward code.
+_LINEAR_SEQUENCE_PARALLEL_MODEL_TYPES = frozenset(
+    {
+        "qwen3_next",
+        "qwen3_5_moe_text",
+    }
+)
+
+
+def _use_linear_sequence_parallel() -> bool:
+    # Only these models have moved attention AG/RS into the parallel Linear
+    # layers. Other models still execute AG/RS in their model code, so enabling
+    # this path for them would perform the same collective twice.
+    vllm_config = get_current_vllm_config_or_none()
+    if vllm_config is None:
+        return False
+    model_type = getattr(
+        vllm_config.model_config.hf_text_config,
+        "model_type",
+        None,
+    )
+    return vllm_config.parallel_config.use_sequence_parallel_moe and (
+        model_type in _LINEAR_SEQUENCE_PARALLEL_MODEL_TYPES
+    )
+
 
 WEIGHT_LOADER_V2_SUPPORTED = [
     "UnquantizedLinearMethod",
@@ -440,8 +472,6 @@ class ColumnParallelLinear(LinearBase):
                         (e.g. model.layers.0.qkv_proj)
         return_bias: If true, return bias together with outputs in forward pass.
         disable_tp: If true, weights matrix won't be sharded through tp rank.
-        sequence_parallel: If true, gather token shards before the matrix
-            multiplication.
         tp_rank: Override the tensor-parallel rank used for sharding. Defaults to
             the global TP rank. Used to shard at a coarser granularity than one
             shard per rank (see ``DCPGroupColumnParallelLinear``).
@@ -464,7 +494,6 @@ class ColumnParallelLinear(LinearBase):
         *,
         return_bias: bool = True,
         disable_tp: bool = False,
-        sequence_parallel: bool = False,
         tp_rank: int | None = None,
         tp_size: int | None = None,
     ):
@@ -505,7 +534,7 @@ class ColumnParallelLinear(LinearBase):
 
         self._maybe_allow_fp8_block_shape_mismatch()
         self.gather_output = gather_output
-        self.sequence_parallel = sequence_parallel
+        self.sequence_parallel = _use_linear_sequence_parallel()
 
         self.quant_method.create_weights(
             layer=self,
@@ -615,10 +644,20 @@ class ColumnParallelLinear(LinearBase):
         output_bias = self.bias if self.skip_bias_add else None
         return output, output_bias
 
-    def prepare_input(self, input_: torch.Tensor) -> torch.Tensor:
-        if self.sequence_parallel and self.tp_size > 1:
-            return sequence_parallel_all_gather(input_)
-        return input_
+    def prepare_input(
+        self,
+        input_: torch.Tensor,
+    ) -> torch.Tensor:
+        if not self.sequence_parallel or self.tp_size == 1:
+            return input_
+        if is_forward_context_available():
+            batch_descriptor = get_forward_context().batch_descriptor
+            if (
+                batch_descriptor is not None
+                and input_.shape[0] == batch_descriptor.num_tokens
+            ):
+                return input_
+        return sequence_parallel_all_gather(input_)
 
     def extra_repr(self) -> str:
         s = f"in_features={self.input_size}"
@@ -695,8 +734,6 @@ class MergedColumnParallelLinear(ColumnParallelLinear):
         return_bias: If true, return bias together with outputs in forward pass.
         disable_tp: If true, all weights matrix won't be sharded, this layer
                     will be treated as a "Replicated" MergedLinear.
-        sequence_parallel: If true, gather token shards before the matrix
-            multiplication.
     """
 
     def __init__(
@@ -712,7 +749,6 @@ class MergedColumnParallelLinear(ColumnParallelLinear):
         *,
         return_bias: bool = True,
         disable_tp: bool = False,
-        sequence_parallel: bool = False,
     ):
         self.output_sizes = output_sizes
         self.tp_size = get_tensor_model_parallel_world_size() if not disable_tp else 1
@@ -730,7 +766,6 @@ class MergedColumnParallelLinear(ColumnParallelLinear):
             prefix=prefix,
             return_bias=return_bias,
             disable_tp=disable_tp,
-            sequence_parallel=sequence_parallel,
         )
 
     def validate_shard_id(self, shard_id: Any) -> TypeIs[int | tuple[int, ...] | None]:
@@ -1062,8 +1097,6 @@ class QKVParallelLinear(ColumnParallelLinear):
                         (e.g. model.layers.0.qkv_proj)
         return_bias: If true, return bias together with outputs in forward pass.
         disable_tp: If true, weights matrix won't be sharded through tp rank.
-        sequence_parallel: If true, gather token shards before the matrix
-            multiplication.
     """
 
     def __init__(
@@ -1081,7 +1114,6 @@ class QKVParallelLinear(ColumnParallelLinear):
         return_bias: bool = True,
         disable_tp: bool = False,
         v_head_size: int | None = None,
-        sequence_parallel: bool = False,
     ):
         self.hidden_size = hidden_size
         self.head_size = head_size
@@ -1118,7 +1150,6 @@ class QKVParallelLinear(ColumnParallelLinear):
             prefix=prefix,
             return_bias=return_bias,
             disable_tp=disable_tp,
-            sequence_parallel=sequence_parallel,
         )
 
     def validate_shard_id(self, shard_id: Any) -> TypeIs[str | None]:
@@ -1662,8 +1693,6 @@ class RowParallelLinear(LinearBase):
                         (e.g. model.layers.0.down_proj)
         return_bias: If true, return bias together with outputs in forward pass.
         disable_tp: If true, weights matrix won't be sharded through tp rank.
-        sequence_parallel: If true, reduce-scatter partial outputs along the
-            token dimension instead of all-reducing them.
     """
 
     # --8<-- [end:row_parallel_linear]
@@ -1682,7 +1711,6 @@ class RowParallelLinear(LinearBase):
         *,
         return_bias: bool = True,
         disable_tp: bool = False,
-        sequence_parallel: bool = False,
     ):
         # Divide the weight matrix along the first dimension.
         self.tp_rank = get_tensor_model_parallel_rank() if not disable_tp else 0
@@ -1705,7 +1733,7 @@ class RowParallelLinear(LinearBase):
 
         self.input_is_parallel = input_is_parallel
         self.reduce_results = reduce_results
-        self.sequence_parallel = sequence_parallel
+        self.sequence_parallel = _use_linear_sequence_parallel()
 
         self.quant_method.create_weights(
             layer=self,
@@ -1796,10 +1824,15 @@ class RowParallelLinear(LinearBase):
         return output, output_bias
 
     def reduce_output(self, output_parallel: torch.Tensor) -> torch.Tensor:
-        if not self.reduce_results or self.tp_size == 1:
+        if self.tp_size == 1:
             return output_parallel
-        if self.sequence_parallel:
+        if self.sequence_parallel and not self.reduce_results:
+            assert output_parallel.shape[0] % self.tp_size == 0, (
+                "Sequence-parallel input must be padded by the model runner"
+            )
             return sequence_parallel_reduce_scatter(output_parallel)
+        if not self.reduce_results:
+            return output_parallel
         return tensor_model_parallel_all_reduce(output_parallel)
 
     def extra_repr(self) -> str:

--- a/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
@@ -774,6 +774,12 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
     ) -> torch.Tensor:
         return self._forward_method(hidden_states)
 
+    def _prepare_sequence_parallel_input(
+        self,
+        hidden_states: torch.Tensor,
+    ) -> torch.Tensor:
+        return self.in_proj_qkvz.prepare_input(hidden_states)
+
     def _output_projection(
         self,
         core_attn_out: torch.Tensor,
@@ -799,6 +805,7 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
     ) -> torch.Tensor:
         """ROCm forward using AITER Triton fused projection+attention when
         available, otherwise falling back to the generic CUDA path."""
+        hidden_states = self._prepare_sequence_parallel_input(hidden_states)
         if GDN_AITER_TRITON_AVAILABLE:
             num_tokens = hidden_states.size(0)
             projected_states_qkvz, _ = self.in_proj_qkvz(hidden_states)
@@ -839,6 +846,7 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         2. Core attention (custom op)
         3. Output projection
         """
+        hidden_states = self._prepare_sequence_parallel_input(hidden_states)
         num_tokens = hidden_states.size(0)
         # ============================================================
         # Part 1: Input Projection
@@ -899,6 +907,7 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         2. Core attention (custom op)
         3. Output projection
         """
+        hidden_states = self._prepare_sequence_parallel_input(hidden_states)
         num_tokens = hidden_states.size(0)
 
         # ============================================================
@@ -943,6 +952,8 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         hidden_states: torch.Tensor,
     ) -> torch.Tensor:
         assert not hasattr(self, "in_proj_qkv"), "lora isn't supported on CPU."
+
+        hidden_states = self._prepare_sequence_parallel_input(hidden_states)
 
         mixed_qkvz, _ = self.in_proj_qkvz(hidden_states)
         ba, _ = self.in_proj_ba(hidden_states)

--- a/vllm/model_executor/models/qwen3_next.py
+++ b/vllm/model_executor/models/qwen3_next.py
@@ -16,7 +16,6 @@ from vllm.distributed import (
     get_pp_group,
     get_tensor_model_parallel_world_size,
     tensor_model_parallel_all_gather,
-    tensor_model_parallel_reduce_scatter,
 )
 from vllm.logger import init_logger
 from vllm.model_executor.layers.attention import Attention
@@ -495,10 +494,8 @@ class Qwen3NextDecoderLayer(nn.Module):
         **kwargs: object,
     ):
         full_num_tokens = positions.shape[-1]
-        input_is_sequence_parallel = (
-            self.use_attn_reduce_scatter_for_moe
-            and residual is not None
-            and hidden_states.shape[0] != full_num_tokens
+        shard_residual_after_attention = self.use_attn_reduce_scatter_for_moe and (
+            residual is None or hidden_states.shape[0] == full_num_tokens
         )
 
         if residual is None:
@@ -506,10 +503,6 @@ class Qwen3NextDecoderLayer(nn.Module):
             hidden_states = self.input_layernorm(hidden_states)
         else:
             hidden_states, residual = self.input_layernorm(hidden_states, residual)
-
-        if input_is_sequence_parallel:
-            hidden_states = tensor_model_parallel_all_gather(hidden_states, 0)
-            hidden_states = hidden_states[:full_num_tokens]
 
         if self.layer_type == "linear_attention":
             hidden_states = self.linear_attn(hidden_states=hidden_states)
@@ -531,15 +524,8 @@ class Qwen3NextDecoderLayer(nn.Module):
                     self.attn_layer_scale.to(hidden_states.dtype) + 1
                 )
 
-        if self.use_attn_reduce_scatter_for_moe:
-            tp_world_size = get_tensor_model_parallel_world_size()
-            # small trick using minus, eg. -17 % 8 = 7
-            sp_pad = (-hidden_states.shape[0]) % tp_world_size
-            # pad if not divisible by world size
-            hidden_states = torch.nn.functional.pad(hidden_states, (0, 0, 0, sp_pad))
-            hidden_states = tensor_model_parallel_reduce_scatter(hidden_states, 0)
-            if not input_is_sequence_parallel:
-                residual = sequence_parallel_chunk(residual)
+        if shard_residual_after_attention:
+            residual = sequence_parallel_chunk(residual)
 
         # Fully Connected
         hidden_states, residual = self.post_attention_layernorm(hidden_states, residual)

--- a/vllm/model_executor/models/utils.py
+++ b/vllm/model_executor/models/utils.py
@@ -25,7 +25,6 @@ from vllm.model_executor.model_loader.weight_utils import default_weight_loader
 from vllm.model_executor.models.interfaces import supports_any_eagle
 from vllm.multimodal import NestedTensors
 from vllm.sequence import IntermediateTensors
-from vllm.utils.math_utils import cdiv
 from vllm.utils.torch_utils import (
     direct_register_custom_op,
 )
@@ -968,9 +967,8 @@ def fast_topk(
 
 
 # Chunk x along the num_tokens axis for sequence parallelism
-# NOTE: This is wrapped in a torch custom op to work around the following issue:
-# The output tensor can have a sequence length 0 at small input sequence lengths
-# even though we explicitly pad to avoid this.
+# NOTE: This is wrapped in a torch custom op because a functional custom op must
+# not return a view of its input.
 def sequence_parallel_chunk(x: torch.Tensor) -> torch.Tensor:
     return torch.ops.vllm.sequence_parallel_chunk_impl(x)
 
@@ -979,26 +977,18 @@ def sequence_parallel_chunk_impl(x: torch.Tensor) -> torch.Tensor:
     tp_size = get_tensor_model_parallel_world_size()
     tp_rank = get_tensor_model_parallel_rank()
 
-    # all_gather needs the sequence length to be divisible by tp_size
     seq_len = x.size(0)
-    remainder = seq_len % tp_size
-    if remainder != 0:
-        pad_len = tp_size - remainder
-        y = nn.functional.pad(x, (0, 0, 0, pad_len))
-    else:
-        y = x
-
-    chunk = y.shape[0] // tp_size
+    assert seq_len % tp_size == 0, (
+        "Sequence-parallel input must be padded by the model runner"
+    )
+    chunk = seq_len // tp_size
     start = tp_rank * chunk
-    out = torch.narrow(y, 0, start, chunk)
-    # narrow() returns a view; clone when it aliases the input (no-pad case),
-    # since a functional custom op must not return a view of an input.
-    return out.clone() if y is x else out
+    return torch.narrow(x, 0, start, chunk).clone()
 
 
 def sequence_parallel_chunk_impl_fake(x: torch.Tensor) -> torch.Tensor:
     tp_size = get_tensor_model_parallel_world_size()
-    seq_len = cdiv(x.size(0), tp_size)
+    seq_len = x.size(0) // tp_size
     shape = list(x.shape)
     shape[0] = seq_len
     out = torch.empty(shape, dtype=x.dtype, device=x.device)

--- a/vllm/models/common/ops/sequence_parallel.py
+++ b/vllm/models/common/ops/sequence_parallel.py
@@ -6,25 +6,13 @@ import torch
 from vllm.distributed import (
     get_tensor_model_parallel_rank,
     get_tensor_model_parallel_world_size,
-    get_tp_group,
-    tensor_model_parallel_all_gather,
-    tensor_model_parallel_reduce_scatter,
+    sequence_parallel_all_gather,
+    sequence_parallel_reduce_scatter,
 )
 
 
-def _custom_collective(name: str, x: torch.Tensor) -> torch.Tensor | None:
-    device_communicator = get_tp_group().device_communicator
-    if device_communicator is None:
-        return None
-    collective = getattr(device_communicator, name, None)
-    return None if collective is None else collective(x)
-
-
 def sp_all_gather(x: torch.Tensor) -> torch.Tensor:
-    output = _custom_collective("custom_all_gather", x)
-    if output is not None:
-        return output
-    return tensor_model_parallel_all_gather(x, 0)
+    return sequence_parallel_all_gather(x)
 
 
 def sp_reduce_scatter(x: torch.Tensor) -> torch.Tensor:
@@ -33,10 +21,7 @@ def sp_reduce_scatter(x: torch.Tensor) -> torch.Tensor:
     sp_pad = (-x.shape[0]) % tp_size
     if sp_pad > 0:
         x = torch.nn.functional.pad(x, (0, 0, 0, sp_pad))
-    output = _custom_collective("custom_reduce_scatter", x)
-    if output is not None:
-        return output
-    return tensor_model_parallel_reduce_scatter(x, 0)
+    return sequence_parallel_reduce_scatter(x)
 
 
 def sp_shard(x: torch.Tensor) -> torch.Tensor:

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -58,7 +58,7 @@ from vllm.multimodal.encoder_budget import (
 )
 from vllm.sequence import IntermediateTensors
 from vllm.tasks import SupportedTask
-from vllm.utils.math_utils import cdiv
+from vllm.utils.math_utils import cdiv, round_up
 from vllm.utils.mem_utils import DeviceMemoryProfiler, format_gib
 from vllm.utils.torch_utils import STR_DTYPE_TO_TORCH_DTYPE
 from vllm.v1.core.sched.output import GrammarOutput, SchedulerOutput
@@ -167,7 +167,9 @@ class GPUModelRunner(LoRAModelRunnerMixin):
 
         self.vocab_size = self.model_config.get_vocab_size()
         self.max_model_len = self.model_config.max_model_len
-        self.max_num_tokens = self.scheduler_config.max_num_batched_tokens
+        self.max_num_tokens = self._pad_for_sequence_parallelism(
+            self.scheduler_config.max_num_batched_tokens
+        )
         self.max_num_reqs = self.scheduler_config.max_num_seqs
         self.is_encoder_decoder = self.model_config.is_encoder_decoder
 
@@ -298,6 +300,12 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         self.routed_experts_capturer: RoutedExpertsCapturer | None = None
 
         set_offloader(create_offloader(self.vllm_config.offload_config))
+
+    def _pad_for_sequence_parallelism(self, num_tokens: int) -> int:
+        tp_size = self.parallel_config.tensor_parallel_size
+        if self.parallel_config.use_sequence_parallel_moe and tp_size > 1:
+            return round_up(num_tokens, tp_size)
+        return num_tokens
 
     def update_max_model_len(self, max_model_len: int) -> None:
         self.max_model_len = max_model_len
@@ -974,6 +982,9 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         num_tokens = scheduler_output.total_num_scheduled_tokens
         num_tokens_after_padding = batch_desc.num_tokens
         assert num_tokens > 0
+        if num_tokens_after_padding > num_tokens:
+            self.input_buffers.input_ids[num_tokens:num_tokens_after_padding].zero_()
+            self.input_buffers.positions[num_tokens:num_tokens_after_padding].zero_()
         if envs.VLLM_MOE_SKIP_PADDING:
             # Mark trailing cudagraph-padding rows so kernels can skip work for
             # them when supported.
@@ -1289,7 +1300,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         batch_desc, num_tokens_across_dp = dispatch_cg_and_sync_dp(
             self.cudagraph_manager,
             num_reqs,
-            num_toks,
+            self._pad_for_sequence_parallelism(num_toks),
             uniform_tok_count,
             self.dp_size,
             self.dp_rank,
@@ -1403,10 +1414,31 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             if inputs_embeds is not None and not self.model.requires_raw_input_tokens:
                 input_ids = None
 
+        if (
+            inputs_embeds is not None
+            and input_batch.num_tokens_after_padding > input_batch.num_tokens
+        ):
+            inputs_embeds[
+                input_batch.num_tokens : input_batch.num_tokens_after_padding
+            ].zero_()
+
         if self.is_encoder_only:
             output = make_empty_encoder_model_runner_output(scheduler_output)
             output.ec_connector_output = ec_connector_output
             return output
+
+        model_state_inputs = self.model_state.prepare_inputs(
+            input_batch,
+            self.req_states,
+        )
+        model_state_positions = model_state_inputs.get("positions")
+        if (
+            model_state_positions is not None
+            and input_batch.num_tokens_after_padding > input_batch.num_tokens
+        ):
+            model_state_positions[
+                ..., input_batch.num_tokens : input_batch.num_tokens_after_padding
+            ].zero_()
 
         model_inputs = {
             "input_ids": input_ids,
@@ -1415,7 +1447,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             "intermediate_tensors": None,
             # NOTE: Values returned by `prepare_inputs` will override the default
             # values above.
-            **self.model_state.prepare_inputs(input_batch, self.req_states),
+            **model_state_inputs,
         }
         if not self.is_first_pp_rank:
             # Update for non-first PP ranks.

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -544,6 +544,10 @@ class GPUModelRunner(
         self.dcp_world_size = self.parallel_config.decode_context_parallel_size
         self.dcp_rank = 0 if self.dcp_world_size <= 1 else get_dcp_group().rank_in_group
         self.max_num_tokens = scheduler_config.max_num_batched_tokens
+        if parallel_config.use_sequence_parallel_moe:
+            self.max_num_tokens = round_up(
+                self.max_num_tokens, parallel_config.tensor_parallel_size
+            )
         self.max_num_reqs = scheduler_config.max_num_seqs
 
         # Broadcast PP output for external_launcher (torchrun)
@@ -3564,10 +3568,12 @@ class GPUModelRunner(
         )
 
     def _pad_for_sequence_parallelism(self, num_scheduled_tokens: int) -> int:
-        # Pad tokens to multiple of tensor_parallel_size when
-        # enabled collective fusion for SP
         tp_size = self.vllm_config.parallel_config.tensor_parallel_size
-        if self.compilation_config.pass_config.enable_sp and tp_size > 1:
+        sequence_parallel = (
+            self.compilation_config.pass_config.enable_sp
+            or self.parallel_config.use_sequence_parallel_moe
+        )
+        if sequence_parallel and tp_size > 1:
             return round_up(num_scheduled_tokens, tp_size)
         return num_scheduled_tokens
 
@@ -3694,14 +3700,20 @@ class GPUModelRunner(
             inputs_embeds = None
             model_kwargs = self._init_model_kwargs()
 
+        if num_input_tokens > num_scheduled_tokens:
+            if input_ids is not None:
+                input_ids[num_scheduled_tokens:].zero_()
+            if inputs_embeds is not None:
+                inputs_embeds[num_scheduled_tokens:].zero_()
+
         if self.uses_mrope:
             positions = self.mrope_positions.gpu[:, :num_input_tokens]
         elif self.uses_xdrope_dim > 0:
             positions = self.xdrope_positions.gpu[:, :num_input_tokens]
         else:
             positions = self.positions[:num_input_tokens]
-            if num_input_tokens > num_scheduled_tokens:
-                self.positions[num_scheduled_tokens:num_input_tokens].zero_()
+        if num_input_tokens > num_scheduled_tokens:
+            positions[..., num_scheduled_tokens:num_input_tokens].zero_()
 
         if is_first_rank:
             intermediate_tensors = None
@@ -4081,7 +4093,10 @@ class GPUModelRunner(
             num_tokens_padded, disable_full=use_cascade_attn or has_encoder_output
         )
         num_tokens_padded = batch_descriptor.num_tokens
-        if self.compilation_config.pass_config.enable_sp:
+        if (
+            self.compilation_config.pass_config.enable_sp
+            or self.parallel_config.use_sequence_parallel_moe
+        ):
             assert (
                 batch_descriptor.num_tokens
                 % self.vllm_config.parallel_config.tensor_parallel_size

--- a/vllm/v1/worker/gpu_ubatch_wrapper.py
+++ b/vllm/v1/worker/gpu_ubatch_wrapper.py
@@ -3,7 +3,7 @@
 
 import threading
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Any
 
 import torch
@@ -359,13 +359,18 @@ class UBatchWrapper:
         # slot_mapping can be None, an empty dict (from create_forward_context
         # converting None to {}), or a list of dicts (one per ubatch)
         has_slot_mapping = slot_mapping and isinstance(slot_mapping, list)
+        assert batch_descriptor is not None
         for i, ubatch_slice in enumerate(ubatch_slices):
+            ubatch_batch_descriptor = replace(
+                batch_descriptor,
+                num_tokens=ubatch_slice.num_tokens,
+            )
             forward_contexts.append(
                 create_forward_context(
                     attn_metadata[i] if attn_metadata is not None else None,
                     self.vllm_config,
                     dp_metadata=dp_metadata[i],
-                    batch_descriptor=batch_descriptor,
+                    batch_descriptor=ubatch_batch_descriptor,
                     cudagraph_runtime_mode=cudagraph_runtime_mode,
                     slot_mapping=slot_mapping[i] if has_slot_mapping else None,
                 )

--- a/vllm/v1/worker/gpu_ubatch_wrapper.py
+++ b/vllm/v1/worker/gpu_ubatch_wrapper.py
@@ -3,7 +3,7 @@
 
 import threading
 from collections.abc import Callable
-from dataclasses import dataclass, replace
+from dataclasses import dataclass
 from typing import Any
 
 import torch
@@ -359,18 +359,13 @@ class UBatchWrapper:
         # slot_mapping can be None, an empty dict (from create_forward_context
         # converting None to {}), or a list of dicts (one per ubatch)
         has_slot_mapping = slot_mapping and isinstance(slot_mapping, list)
-        assert batch_descriptor is not None
         for i, ubatch_slice in enumerate(ubatch_slices):
-            ubatch_batch_descriptor = replace(
-                batch_descriptor,
-                num_tokens=ubatch_slice.num_tokens,
-            )
             forward_contexts.append(
                 create_forward_context(
                     attn_metadata[i] if attn_metadata is not None else None,
                     self.vllm_config,
                     dp_metadata=dp_metadata[i],
-                    batch_descriptor=ubatch_batch_descriptor,
+                    batch_descriptor=batch_descriptor,
                     cudagraph_runtime_mode=cudagraph_runtime_mode,
                     slot_mapping=slot_mapping[i] if has_slot_mapping else None,
                 )


### PR DESCRIPTION
## Purpose

This is a draft PR for discussing a sequence-parallel (SP) refactor for Qwen3-Next and Qwen3.5-MoE.

Today, the all-gather before attention and the reduce-scatter after attention are owned by model-specific decoder code. This couples the SP boundary to each model implementation, duplicates collective-selection logic, and makes it easy for related paths—such as LoRA, linear attention, or another model runner—to drift from the main attention path.

This PR moves those communication boundaries to the tensor-parallel linear layers that naturally own them:

- `ColumnParallelLinear` gathers a sequence shard before an attention input projection.
- `RowParallelLinear` reduce-scatters the attention output when the caller requests unreduced row-parallel results.

The refactor preserves the existing Qwen SP behavior while making the communication contract reusable by attention implementations that use the same parallel linear layers.

## Implementation

- Add sequence-parallel collective wrappers in `communication_op.py`. They use custom device-communicator collectives when available and otherwise fall back to the TP all-gather / reduce-scatter implementations.
- Enable the linear-layer SP path only for Qwen3-Next and Qwen3.5-MoE when `use_sequence_parallel_moe` is enabled. Other models retain their current behavior.
- Remove the duplicated attention all-gather / reduce-scatter logic from the Qwen3-Next decoder layer. The decoder remains responsible for sharding the residual at the transition into the MoE path.
- Route the Qwen Gated DeltaNet linear-attention input through the same `ColumnParallelLinear` preparation path.
- Reuse the base linear-layer input preparation and output reduction from LoRA wrappers, so LoRA follows the same SP boundary.
- Make both V1 GPU model runners pad SP-MoE batches to the TP world size and align CUDA-graph capture sizes with this padded token count. Model-level SP helpers can therefore require, rather than independently introduce, padding.

## Scope

This does not add a new user-facing configuration option or change the SP algorithm. It refactors where the existing communication and padding behavior is implemented, with Qwen3-Next and Qwen3.5-MoE as the initial users.

## Discussion points

- Is `ColumnParallelLinear` / `RowParallelLinear` the preferred shared boundary for model SP communication, or should this be represented by a more explicit attention-level abstraction?
- Is restricting the initial rollout by model type acceptable, with follow-up migrations for other SP-capable models?
- Does the runner-owned padding contract provide the right separation between
  scheduling and model execution?

## Test Plan

The final PR will include targeted unit tests and TP>1 serving correctness results for Qwen3-Next and Qwen3.5-MoE with `use_sequence_parallel_moe=True`.
