### PR TITLE
[Bugfix] Fix Humming MXFP4 MoE W4A8 activation path and small-M TMA crash

### DIFF
--- a/vllm/model_executor/layers/fused_moe/experts/fused_humming_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/fused_humming_moe.py
@@ -92,6 +92,19 @@ def get_humming_moe_gemm_type() -> str:
     return gemm_type
 
 
+def _cap_tuning_config_k_block(tuning_config: list, max_k_block: int = 128) -> None:
+    """Cap each tile's K-block (block_shape[2]) at ``max_k_block`` in place.
+
+    A K-block of 256 produces a TMA descriptor the driver rejects at launch
+    (CUDA_ERROR_MISALIGNED_ADDRESS); 128 is what Humming uses for larger M.
+    """
+    for entry in tuning_config:
+        config = entry[2]
+        block_shape = config.get("block_shape")
+        if block_shape and len(block_shape) == 3 and block_shape[2] > max_k_block:
+            config["block_shape"] = [block_shape[0], block_shape[1], max_k_block]
+
+
 class HummingExpertsBase(mk.FusedMoEExpertsModular):
     def __init__(
         self,
@@ -143,6 +156,13 @@ class HummingExpertsBase(mk.FusedMoEExpertsModular):
             gemm_type=self.humming_gemm_type(),
         )
         self.compute_config_str = json.dumps(self.compute_config)
+        # Small-M tiles can select a K-block of 256, whose TMA descriptor the
+        # driver rejects at cuLaunchKernelEx (CUDA_ERROR_MISALIGNED_ADDRESS).
+        # Cap the K-block at 128 -- what Humming already uses for larger M and
+        # which launches cleanly (warp_shape K is 128 in every entry). This also
+        # fires in profile_run, so it is not avoidable with --enforce-eager.
+        _cap_tuning_config_k_block(self.w13_tuning_config)
+        _cap_tuning_config_k_block(self.w2_tuning_config)
         self.w13_tuning_config_str = json.dumps(self.w13_tuning_config)
         self.w2_tuning_config_str = json.dumps(self.w2_tuning_config)
 

--- a/vllm/model_executor/layers/fused_moe/oracle/mxfp4.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/mxfp4.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import inspect
 from enum import Enum
 from typing import TYPE_CHECKING, Literal, Union
 
@@ -1803,9 +1804,18 @@ def make_mxfp4_moe_kernel(
     experts_cls: type[mk.FusedMoEExperts],
     mxfp4_backend: Mxfp4MoeBackend,
     routing_tables: tuple[torch.Tensor, torch.Tensor, torch.Tensor] | None = None,
+    layer: torch.nn.Module | None = None,
 ) -> mk.FusedMoEKernel:
     """Create a FusedMoEKernel for the given MXFP4 backend."""
     is_monolithic = issubclass(experts_cls, mk.FusedMoEExpertsMonolithic)
+
+    # Humming experts require the owning layer in their constructor; other
+    # experts classes don't accept it. Forward it only when the signature has it.
+    layer_kwargs = (
+        {"layer": layer}
+        if "layer" in inspect.signature(experts_cls.__init__).parameters
+        else {}
+    )
 
     prepare_finalize = maybe_make_prepare_finalize(
         moe=moe_config,
@@ -1824,6 +1834,7 @@ def make_mxfp4_moe_kernel(
         max_num_tokens = prepare_finalize.max_num_tokens_per_rank()
         assert max_num_tokens is not None
         experts = experts_cls(
+            **layer_kwargs,
             moe_config=moe_config,
             quant_config=moe_quant_config,
             max_num_tokens=max_num_tokens,
@@ -1831,6 +1842,7 @@ def make_mxfp4_moe_kernel(
         )
     else:
         experts = experts_cls(
+            **layer_kwargs,
             moe_config=moe_config,
             quant_config=moe_quant_config,
         )

--- a/vllm/model_executor/layers/quantization/mxfp4.py
+++ b/vllm/model_executor/layers/quantization/mxfp4.py
@@ -382,6 +382,7 @@ class GptOssMxfp4MoEMethod(FusedMoEMethodBase):
                 mxfp4_backend=self.mxfp4_backend,
                 experts_cls=self.experts_cls,
                 routing_tables=layer._expert_routing_tables(),
+                layer=layer,
             )
 
     def process_weights_after_loading(self, layer: RoutedExperts) -> None:
@@ -812,6 +813,7 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
                 mxfp4_backend=self.mxfp4_backend,
                 experts_cls=self.experts_cls,
                 routing_tables=layer._expert_routing_tables(),
+                layer=layer,
             )
 
     def _convert_k3_situ_weight_to_kernel_format(

--- a/vllm/model_executor/layers/quantization/utils/humming_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/humming_utils.py
@@ -1018,7 +1018,15 @@ def convert_to_humming_moe_kernel_format(
             weight_schema = BaseWeightSchema.from_config(quant_config)
 
         if input_schema is None:
-            input_quant_config = envs.VLLM_HUMMING_INPUT_QUANT_CONFIG or {}
+            # VLLM_HUMMING_INPUT_QUANT_CONFIG does not reach the EngineCore/worker
+            # subprocesses (present on the API-server process only), so it reads as
+            # empty here and the MoE silently falls back to unquantized bf16
+            # activations (W4A16). Default to block-FP8 group-128 to keep the
+            # intended W4A8 path when the env var is absent.
+            input_quant_config = envs.VLLM_HUMMING_INPUT_QUANT_CONFIG or {
+                "dtype": "float8e4m3",
+                "group_size": 128,
+            }
             if humming_is_layer_skipped(input_quant_config, layer.layer_name):
                 input_schema = HummingInputSchema()
             else:

--- a/vllm/utils/humming.py
+++ b/vllm/utils/humming.py
@@ -12,6 +12,8 @@ import importlib
 from typing import Any
 
 _EXPORTS: dict[str, str] = {
+    "HummingMethod": "humming.layer:HummingMethod",
+    "HummingLayerMeta": "humming.layer:HummingLayerMeta",
     "dtypes": "humming.dtypes",
     "DataType": "humming.dtypes:DataType",
     "GemmType": "humming.config:GemmType",


### PR DESCRIPTION
## Purpose

Fixes issues in the Humming MXFP4 MoE backend, hit while bringing up Kimi-K3 on H200.

Real bugs on current main:
- `VLLM_HUMMING_INPUT_QUANT_CONFIG` is not present in the EngineCore/worker subprocesses (only on the API-server process), so the MoE silently ran W4A16 (bf16 activations). Default to block-FP8 group-128 when the env var is absent to keep the intended W4A8 path.
- Small-M tiles could select a K-block of 256, whose TMA descriptor the driver rejects at `cuLaunchKernelEx` (`CUDA_ERROR_MISALIGNED_ADDRESS`). Cap the K-block at 128 (what Humming uses for larger M). This fires in `profile_run`, so it is not avoidable with `--enforce-eager`.

Also included (no-ops on current main, can be dropped): forwarding `layer` to experts constructors that accept it, and exporting `HummingMethod` / `HummingLayerMeta` from `vllm.utils.humming`. These were needed on an earlier Humming MoE state; main's `HummingExpertsBase` no longer takes `layer` and nothing imports those symbols.

## Test

Kimi-K3 (MXFP4 weight + block-FP8 g128 activation, `--moe-backend humming`) loads and serves on H200 with cudagraphs enabled (no `--enforce-eager`); GSM8K 5-shot = 43.6% flexible / 40.9% strict. `pre-commit run` passes on all changed files.

## Notes (draft)

- The input-quant default is a workaround for env-var propagation to workers; open to a cleaner fix (adding the var to the subprocess env allowlist).
- The K-block cap was verified on the deployed nightly; it needs re-confirmation against main's `get_heuristics_config` heuristics on H200.