### PR TITLE
Fix Mooncake store request-ID ABA in async job accounting

### DIFF
--- a/tests/v1/kv_connector/unit/test_mooncake_store_hma_e2e.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_hma_e2e.py
@@ -37,6 +37,27 @@ from vllm.v1.kv_cache_interface import (
 )
 
 
+def _run_store_request(
+    thread: KVCacheStoreSendingThread, request: ReqMeta
+) -> mooncake_store_worker._StoreRequestJob:
+    thread.add_request(request)
+    job = thread.request_queue.get_nowait()
+    thread._handle_request(job)
+    return job
+
+
+def _offload_partial_tail(
+    thread: KVCacheStoreSendingThread, request: ReqMeta
+) -> bool:
+    thread.add_request(request)
+    job = thread.request_queue.get_nowait()
+    try:
+        return thread._maybe_offload_partial_tail(request, job.epoch)
+    finally:
+        thread.dec_stored_request(request.req_id, job.epoch)
+        thread.request_queue.task_done()
+
+
 class _DictStore:
     """In-memory MooncakeDistributedStore stand-in."""
 
@@ -229,11 +250,7 @@ def test_e2e_swa_plus_full_save_then_lookup_hits():
         block_hashes=hs,
         can_save=True,
     )
-    send_thread.add_stored_request("r0")
-    # Put the request in the queue so task_done() doesn't underflow.
-    send_thread.request_queue.put(save_req)
-    req = send_thread.request_queue.get()
-    send_thread._handle_request(req)
+    _run_store_request(send_thread, save_req)
 
     # Point worker.store at the dict store (the worker constructor captured
     # the MagicMock; replace with the real dict store for lookup).
@@ -430,7 +447,7 @@ def test_sub_block_partial_tail_offload_reads_cow_block():
         partial_tail_offloads=[(1, mamba_cow_block, 12)],
     )
 
-    send._maybe_offload_partial_tail(req)
+    _offload_partial_tail(send, req)
 
     # boundary = 12 // 4 * 4 = 12 -> keyed by hs[12 // 4 - 1] = hs[2].
     partial_hash = hs[2]
@@ -501,10 +518,8 @@ def test_offload_syncs_event_before_put():
         partial_tail_offloads=[(1, 7, 12)],
     )
     req.current_event = event
-    send.add_stored_request("r1")
 
-    send.request_queue.put(req)
-    send._handle_request(send.request_queue.get())
+    _run_store_request(send, req)
     assert send.request_queue.qsize() == 0
     assert store._data
     assert send.stored_requests["r1"] == 0
@@ -578,7 +593,7 @@ def test_sub_block_partial_tail_offload_covers_smaller_group_blocks():
         partial_tail_offloads=[(1, mamba_cow_block, 12)],
     )
 
-    send._maybe_offload_partial_tail(req)
+    _offload_partial_tail(send, req)
 
     # FA (block 4): full blocks ending at 4, 8 and 12, keyed by their normal
     # block-end hashes; mamba (block 16): the partial boundary block under

--- a/tests/v1/kv_connector/unit/test_mooncake_store_worker.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_worker.py
@@ -103,6 +103,35 @@ def _make_store_sending_thread(
     return thread
 
 
+def _queue_store_request(
+    thread: mooncake_store_worker.KVCacheStoreSendingThread,
+    request: ReqMeta,
+) -> mooncake_store_worker._StoreRequestJob:
+    thread.add_request(request)
+    return thread.request_queue.get_nowait()
+
+
+def _run_store_request(
+    thread: mooncake_store_worker.KVCacheStoreSendingThread,
+    request: ReqMeta,
+) -> mooncake_store_worker._StoreRequestJob:
+    job = _queue_store_request(thread, request)
+    thread._handle_request(job)
+    return job
+
+
+def _offload_partial_tail(
+    thread: mooncake_store_worker.KVCacheStoreSendingThread,
+    request: ReqMeta,
+) -> bool:
+    job = _queue_store_request(thread, request)
+    try:
+        return thread._maybe_offload_partial_tail(request, job.epoch)
+    finally:
+        thread.dec_stored_request(request.req_id, job.epoch)
+        thread.request_queue.task_done()
+
+
 def _make_store_recving_thread(
     store: MagicMock,
     *,
@@ -162,6 +191,16 @@ def _make_store_req(req_id: str, block_hashes: list[bytes]) -> ReqMeta:
         token_len_chunk=32,
         block_ids=([0, 1],),
         block_hashes=block_hashes,
+        can_save=True,
+    )
+
+
+def _make_empty_store_req(req_id: str) -> ReqMeta:
+    return ReqMeta(
+        req_id=req_id,
+        token_len_chunk=0,
+        block_ids=([],),
+        block_hashes=[],
         can_save=True,
     )
 
@@ -385,27 +424,25 @@ def test_store_sending_thread_skips_request_during_cpu_pressure():
     ]
     thread = _make_store_sending_thread(store)
 
-    thread.add_stored_request("req-a")
-    thread._handle_request(_make_store_req("req-a", [b"a0", b"a1"]))
+    req_a_job = _run_store_request(
+        thread, _make_store_req("req-a", [b"a0", b"a1"])
+    )
 
     assert thread._store_pressure_active is True
-    assert "req-a" in thread._skip_store_requests
+    assert ("req-a", req_a_job.epoch) in thread._skip_store_requests
     assert store.batch_put_from_multi_buffers.call_count == 1
 
-    thread.add_stored_request("req-a")
-    thread._handle_request(_make_store_req("req-a", [b"a2", b"a3"]))
+    _run_store_request(thread, _make_store_req("req-a", [b"a2", b"a3"]))
 
     assert store.batch_put_from_multi_buffers.call_count == 1
 
-    thread.add_stored_request("req-b")
-    thread._handle_request(_make_store_req("req-b", [b"b0", b"b1"]))
+    _run_store_request(thread, _make_store_req("req-b", [b"b0", b"b1"]))
 
     assert thread._store_pressure_active is False
-    assert "req-a" not in thread._skip_store_requests
+    assert ("req-a", req_a_job.epoch) not in thread._skip_store_requests
     assert store.batch_put_from_multi_buffers.call_count == 2
 
-    thread.add_stored_request("req-a")
-    thread._handle_request(_make_store_req("req-a", [b"a4", b"a5"]))
+    _run_store_request(thread, _make_store_req("req-a", [b"a4", b"a5"]))
 
     assert store.batch_put_from_multi_buffers.call_count == 3
 
@@ -418,8 +455,7 @@ def test_store_sending_thread_records_mooncake_metrics():
     stats = MooncakeStoreConnectorStats()
     thread._record_operation_cb = stats.record_operation
 
-    thread.add_stored_request("req-a")
-    thread._handle_request(_make_store_req("req-a", [b"a0", b"a1"]))
+    _run_store_request(thread, _make_store_req("req-a", [b"a0", b"a1"]))
 
     assert len(stats.data["save_exists"]) == 1
     assert stats.data["save_exists"][0]["num_keys"] == 2
@@ -497,17 +533,16 @@ def test_store_sending_thread_delta_saves_only_new_full_attention_chunks():
     store.batch_put_from_multi_buffers.return_value = [256, 256]
     thread = _make_store_sending_thread(store)
 
-    thread.add_stored_request("req-a")
-    thread._saved_offset["req-a"] = 32
-    thread._handle_request(
-        ReqMeta(
+    request = ReqMeta(
             req_id="req-a",
             token_len_chunk=64,
             block_ids=([0, 1, 2, 3],),
             block_hashes=[b"a0", b"a1", b"a2", b"a3"],
             can_save=True,
         )
-    )
+    job = _queue_store_request(thread, request)
+    thread._saved_offset[(request.req_id, job.epoch)] = 32
+    thread._handle_request(job)
 
     keys = store.batch_is_exist.call_args.args[0]
     assert keys == [
@@ -523,17 +558,16 @@ def test_store_sending_thread_delta_strides_with_local_phase():
     store.batch_put_from_multi_buffers.return_value = [256]
     thread = _make_store_sending_thread(store, tp_rank=0, put_step=2)
 
-    thread.add_stored_request("req-a")
-    thread._saved_offset["req-a"] = 16
-    thread._handle_request(
-        ReqMeta(
+    request = ReqMeta(
             req_id="req-a",
             token_len_chunk=64,
             block_ids=([0, 1, 2, 3],),
             block_hashes=[b"a0", b"a1", b"a2", b"a3"],
             can_save=True,
         )
-    )
+    job = _queue_store_request(thread, request)
+    thread._saved_offset[(request.req_id, job.epoch)] = 16
+    thread._handle_request(job)
 
     keys = store.batch_is_exist.call_args.args[0]
     assert keys == [
@@ -550,8 +584,8 @@ def test_tp_sharded_group_saves_every_block_on_every_rank():
     thread = _make_store_sending_thread(store, tp_rank=0, put_step=2)
     thread.group_put_steps = [1]
 
-    thread.add_stored_request("req-a")
-    thread._handle_request(
+    _run_store_request(
+        thread,
         ReqMeta(
             req_id="req-a",
             token_len_chunk=64,
@@ -573,30 +607,28 @@ def test_store_sending_thread_retries_skipped_range_after_pressure():
 
     # Under pressure the request is skipped without persisting anything, so the
     # saved offset stays at 0.
-    thread._store_pressure_active = True
-    thread._skip_store_requests.add("req-a")
-
-    thread.add_stored_request("req-a")
-    thread._handle_request(
-        ReqMeta(
+    request = ReqMeta(
             req_id="req-a",
             token_len_chunk=16,
             block_ids=([0],),
             block_hashes=[b"a0"],
             can_save=True,
         )
-    )
+    job = _queue_store_request(thread, request)
+    thread._store_pressure_active = True
+    thread._skip_store_requests.add((request.req_id, job.epoch))
+    thread._handle_request(job)
 
     store.batch_is_exist.assert_not_called()
-    assert thread._saved_offset.get("req-a", 0) == 0
+    assert thread._saved_offset.get((request.req_id, job.epoch), 0) == 0
 
     thread._store_pressure_active = False
     thread._skip_store_requests.clear()
 
     # The next batch resumes from offset 0, re-covering the chunk skipped under
     # pressure (chunk 0) rather than losing it.
-    thread.add_stored_request("req-a")
-    thread._handle_request(
+    _run_store_request(
+        thread,
         ReqMeta(
             req_id="req-a",
             token_len_chunk=64,
@@ -660,7 +692,7 @@ def test_partial_tail_offload_skips_null_source_blocks():
     store.batch_put_from_multi_buffers.return_value = [256, 256]
     thread = _make_partial_tail_send_thread(store)
 
-    assert thread._maybe_offload_partial_tail(_make_partial_tail_req([0, 2, 3]))
+    assert _offload_partial_tail(thread, _make_partial_tail_req([0, 2, 3]))
 
     keys, addrs, _sizes, _replicate_config = (
         store.batch_put_from_multi_buffers.call_args.args
@@ -684,7 +716,7 @@ def test_partial_tail_offload_replaces_stale_group_ids_after_filtering():
         supports_group_ids=True,
     )
 
-    assert thread._maybe_offload_partial_tail(_make_partial_tail_req([1, 2, 3]))
+    assert _offload_partial_tail(thread, _make_partial_tail_req([1, 2, 3]))
 
     keys, _addrs, _sizes, config = store.batch_put_from_multi_buffers.call_args.args
     assert keys == [
@@ -701,11 +733,12 @@ def test_partial_tail_offload_replaces_stale_group_ids_after_filtering():
 def test_partial_tail_offload_honors_active_pressure_gate():
     store = MagicMock()
     thread = _make_partial_tail_send_thread(store)
+    request = _make_partial_tail_req([1, 2, 3])
+    job = _queue_store_request(thread, request)
     thread._store_pressure_active = True
-    thread._skip_store_requests.add("req-a")
-    thread.add_stored_request("req-a")
+    thread._skip_store_requests.add((request.req_id, job.epoch))
 
-    thread._handle_request(_make_partial_tail_req([1, 2, 3]))
+    thread._handle_request(job)
 
     store.batch_is_exist.assert_not_called()
     store.batch_put_from_multi_buffers.assert_not_called()
@@ -717,17 +750,15 @@ def test_partial_tail_put_failure_activates_pressure_gate():
     store.batch_is_exist.side_effect = lambda keys: [0] * len(keys)
     store.batch_put_from_multi_buffers.return_value = [256, -200, 256]
     thread = _make_partial_tail_send_thread(store)
-    thread.add_stored_request("req-a")
 
-    thread._handle_request(_make_partial_tail_req([1, 2, 3]))
+    job = _run_store_request(thread, _make_partial_tail_req([1, 2, 3]))
 
     assert thread._store_pressure_active is True
-    assert thread._skip_store_requests == {"req-a"}
-    assert thread._saved_offset.get("req-a", 0) == 0
+    assert thread._skip_store_requests == {("req-a", job.epoch)}
+    assert thread._saved_offset.get(("req-a", job.epoch), 0) == 0
     assert thread.stored_requests["req-a"] == 0
 
-    thread.add_stored_request("req-a")
-    thread._handle_request(_make_partial_tail_req([1, 2, 3]))
+    _run_store_request(thread, _make_partial_tail_req([1, 2, 3]))
     assert store.batch_put_from_multi_buffers.call_count == 1
 
 
@@ -737,17 +768,16 @@ def test_store_sending_thread_delta_start_rank_saves_second_local_chunk():
     store.batch_put_from_multi_buffers.return_value = [256, 256]
     thread = _make_store_sending_thread(store, tp_rank=1, put_step=2)
 
-    thread.add_stored_request("req-a")
-    thread._saved_offset["req-a"] = 16
-    thread._handle_request(
-        ReqMeta(
+    request = ReqMeta(
             req_id="req-a",
             token_len_chunk=64,
             block_ids=([0, 1, 2, 3],),
             block_hashes=[b"a0", b"a1", b"a2", b"a3"],
             can_save=True,
         )
-    )
+    job = _queue_store_request(thread, request)
+    thread._saved_offset[(request.req_id, job.epoch)] = 16
+    thread._handle_request(job)
 
     keys = store.batch_is_exist.call_args.args[0]
     assert keys == [
@@ -790,17 +820,16 @@ def test_store_sending_thread_delta_saves_only_new_masked_chunks():
         token_databases=[db_full, db_masked],
     )
 
-    thread.add_stored_request("req-a")
-    thread._saved_offset["req-a"] = 32
-    thread._handle_request(
-        ReqMeta(
+    request = ReqMeta(
             req_id="req-a",
             token_len_chunk=64,
             block_ids=([0, 1, 2, 3], [0, 1, 2, 3]),
             block_hashes=[b"a0", b"a1", b"a2", b"a3"],
             can_save=True,
         )
-    )
+    job = _queue_store_request(thread, request)
+    thread._saved_offset[(request.req_id, job.epoch)] = 32
+    thread._handle_request(job)
 
     keys = store.batch_is_exist.call_args.args[0]
     full_hashes = [k.rsplit("@", 1)[-1] for k in keys if "@group:0" in k]
@@ -845,8 +874,7 @@ def test_store_sending_thread_prepares_missing_chunks_once_per_group():
         coord=coord,
         token_databases=[db0, db1],
     )
-    thread.add_stored_request("req-a")
-    thread._handle_request(
+    _run_store_request(thread,
         ReqMeta(
             req_id="req-a",
             token_len_chunk=48,
@@ -881,15 +909,13 @@ def test_store_sending_thread_only_skips_on_no_available_handle():
     ]
     thread = _make_store_sending_thread(store)
 
-    thread.add_stored_request("req-a")
-    thread._handle_request(_make_store_req("req-a", [b"a0", b"a1"]))
+    _run_store_request(thread, _make_store_req("req-a", [b"a0", b"a1"]))
 
     assert thread._store_pressure_active is False
-    assert "req-a" not in thread._skip_store_requests
+    assert not thread._skip_store_requests
     assert store.batch_put_from_multi_buffers.call_count == 1
 
-    thread.add_stored_request("req-a")
-    thread._handle_request(_make_store_req("req-a", [b"a2", b"a3"]))
+    _run_store_request(thread, _make_store_req("req-a", [b"a2", b"a3"]))
 
     assert store.batch_put_from_multi_buffers.call_count == 2
 
@@ -901,9 +927,11 @@ def test_store_sending_thread_releases_pin_on_batch_is_exist_failure():
     store.batch_is_exist.side_effect = RuntimeError("mooncake down")
     thread = _make_store_sending_thread(store)
 
-    thread.add_stored_request("req-a")
+    job = _queue_store_request(
+        thread, _make_store_req("req-a", [b"a0", b"a1"])
+    )
     with pytest.raises(RuntimeError):
-        thread._handle_request(_make_store_req("req-a", [b"a0", b"a1"]))
+        thread._handle_request(job)
 
     assert thread.stored_requests["req-a"] == 0
     store.batch_put_from_multi_buffers.assert_not_called()
@@ -917,10 +945,159 @@ def test_store_sending_thread_releases_pin_on_batch_put_failure():
     store.batch_put_from_multi_buffers.side_effect = RuntimeError("rdma error")
     thread = _make_store_sending_thread(store)
 
-    thread.add_stored_request("req-a")
-    thread._handle_request(_make_store_req("req-a", [b"a0", b"a1"]))
+    _run_store_request(thread, _make_store_req("req-a", [b"a0", b"a1"]))
 
     assert thread.stored_requests["req-a"] == 0
+
+
+def test_store_request_normal_epoch_completes_and_cleans_up():
+    thread = _make_store_sending_thread(MagicMock())
+    request = _make_empty_store_req("normal")
+
+    thread.add_request(request)
+    assert thread.get_stored_request_state(request.req_id) == (1, 1)
+
+    job = thread.request_queue.get_nowait()
+    thread._handle_request(job)
+
+    assert job.epoch == 1
+    assert thread.get_stored_request_state(request.req_id) == (0, 1)
+    assert thread.delete_finished_stored_request(
+        request.req_id, expected_epoch=job.epoch
+    )
+    assert thread.get_stored_request_state(request.req_id) == (None, None)
+
+
+def test_queued_stale_store_job_does_not_decrement_reused_request_id():
+    thread = _make_store_sending_thread(MagicMock())
+    request = _make_empty_store_req("queued-aba")
+
+    thread.add_request(request)
+    assert thread.delete_finished_stored_request(request.req_id)
+    thread.add_request(request)
+    assert thread.get_stored_request_state(request.req_id) == (1, 2)
+
+    stale_job = thread.request_queue.get_nowait()
+    thread._handle_request(stale_job)
+    assert stale_job.epoch == 1
+    assert thread.get_stored_request_state(request.req_id) == (1, 2)
+
+    current_job = thread.request_queue.get_nowait()
+    thread._handle_request(current_job)
+    assert current_job.epoch == 2
+    assert thread.get_stored_request_state(request.req_id) == (0, 2)
+
+
+def test_active_stale_store_completion_does_not_decrement_new_epoch():
+    thread = _make_store_sending_thread(MagicMock())
+    request = _make_empty_store_req("active-aba")
+
+    old_job = _queue_store_request(thread, request)
+    assert thread.delete_finished_stored_request(request.req_id)
+    new_job = _queue_store_request(thread, request)
+    assert (old_job.epoch, new_job.epoch) == (1, 2)
+
+    assert not thread.dec_stored_request(request.req_id, old_job.epoch)
+    assert thread.get_stored_request_state(request.req_id) == (1, 2)
+
+    assert thread.dec_stored_request(request.req_id, new_job.epoch)
+    assert thread.get_stored_request_state(request.req_id) == (0, 2)
+
+
+def test_stale_store_job_cannot_mutate_new_epoch_auxiliary_state():
+    thread = _make_store_sending_thread(MagicMock())
+    request = _make_empty_store_req("state-aba")
+
+    old_job = _queue_store_request(thread, request)
+    thread._record_saved(request.req_id, old_job.epoch, 128)
+    assert thread._saved_offset[(request.req_id, old_job.epoch)] == 128
+
+    assert thread.delete_finished_stored_request(request.req_id)
+    new_job = _queue_store_request(thread, request)
+    assert new_job.epoch == 2
+
+    thread._record_saved(request.req_id, old_job.epoch, 256)
+    assert (request.req_id, old_job.epoch) not in thread._saved_offset
+    assert thread._mark_request_skipped_for_pressure(request.req_id, old_job.epoch)
+    assert (request.req_id, old_job.epoch) not in thread._skip_store_requests
+    assert not thread._clear_store_pressure(request.req_id, old_job.epoch)
+
+    stale_event = MagicMock()
+    assert not thread._update_kv_event_if_current(
+        request.req_id, old_job.epoch, [stale_event]
+    )
+    assert thread.get_kv_events() == []
+
+    current_event = MagicMock()
+    assert thread._update_kv_event_if_current(
+        request.req_id, new_job.epoch, [current_event]
+    )
+    assert thread.get_kv_events() == [current_event]
+
+    assert not thread.delete_finished_stored_request(
+        request.req_id, expected_epoch=old_job.epoch
+    )
+    assert thread.get_stored_request_state(request.req_id) == (1, new_job.epoch)
+
+
+def test_deferred_finished_sending_is_bound_to_store_epoch():
+    thread = _make_store_sending_thread(MagicMock())
+    store_worker = object.__new__(mooncake_store_worker.MooncakeStoreWorker)
+    store_worker.kv_send_thread = thread
+    store_worker.finished_store_req = {}
+    empty_meta = SimpleNamespace(preempted_req_ids=set())
+    request = _make_empty_store_req("deferred-aba")
+
+    thread.add_request(request)
+    assert (
+        store_worker._get_and_clear_finished_sending(
+            {request.req_id}, empty_meta
+        )
+        == set()
+    )
+    assert store_worker.finished_store_req == {request.req_id: 1}
+
+    first_job = thread.request_queue.get_nowait()
+    thread._handle_request(first_job)
+    assert store_worker._get_and_clear_finished_sending(set(), empty_meta) == {
+        request.req_id
+    }
+    assert store_worker.finished_store_req == {}
+    assert thread.get_stored_request_state(request.req_id) == (None, None)
+
+    thread.add_request(request)
+    assert (
+        store_worker._get_and_clear_finished_sending(
+            {request.req_id}, empty_meta
+        )
+        == set()
+    )
+    assert store_worker.finished_store_req == {request.req_id: 2}
+
+    preempt_meta = SimpleNamespace(preempted_req_ids={request.req_id})
+    assert (
+        store_worker._get_and_clear_finished_sending(set(), preempt_meta) == set()
+    )
+    assert store_worker.finished_store_req == {}
+
+    thread.add_request(request)
+    assert thread.get_stored_request_state(request.req_id) == (1, 3)
+
+    stale_job = thread.request_queue.get_nowait()
+    thread._handle_request(stale_job)
+    assert stale_job.epoch == 2
+    assert thread.get_stored_request_state(request.req_id) == (1, 3)
+
+    current_job = thread.request_queue.get_nowait()
+    thread._handle_request(current_job)
+    assert current_job.epoch == 3
+    assert thread.get_stored_request_state(request.req_id) == (0, 3)
+    assert (
+        store_worker._get_and_clear_finished_sending(
+            {request.req_id}, empty_meta
+        )
+        == {request.req_id}
+    )
 
 
 def test_store_recving_thread_reports_failed_block_ids():
@@ -991,8 +1168,7 @@ def test_store_sending_thread_passes_replicate_config_when_preferred_segment_set
     replicate_config = SimpleNamespace(preferred_segment="10.0.0.7:50053")
     thread = _make_store_sending_thread(store, replicate_config=replicate_config)
 
-    thread.add_stored_request("req-a")
-    thread._handle_request(_make_store_req("req-a", [b"a0", b"a1"]))
+    _run_store_request(thread, _make_store_req("req-a", [b"a0", b"a1"]))
 
     assert store.batch_put_from_multi_buffers.call_count == 1
     call_args = store.batch_put_from_multi_buffers.call_args.args
@@ -1010,8 +1186,7 @@ def test_store_sending_thread_passes_default_replicate_config_when_no_preferred_
     replicate_config = SimpleNamespace()
     thread = _make_store_sending_thread(store, replicate_config=replicate_config)
 
-    thread.add_stored_request("req-a")
-    thread._handle_request(_make_store_req("req-a", [b"a0", b"a1"]))
+    _run_store_request(thread, _make_store_req("req-a", [b"a0", b"a1"]))
 
     assert store.batch_put_from_multi_buffers.call_count == 1
     call_args = store.batch_put_from_multi_buffers.call_args.args
@@ -1067,8 +1242,7 @@ def test_store_sending_thread_sets_group_ids_when_enabled():
         supports_group_ids=True,
     )
 
-    thread.add_stored_request("req-a")
-    thread._handle_request(_make_store_req("req-a", [b"a0", b"a1"]))
+    _run_store_request(thread, _make_store_req("req-a", [b"a0", b"a1"]))
 
     assert store.batch_put_from_multi_buffers.call_count == 1
     keys, _addrs, _sizes, config = store.batch_put_from_multi_buffers.call_args.args
@@ -1092,8 +1266,7 @@ def test_store_sending_thread_leaves_group_ids_unchanged_when_flag_disabled():
         supports_group_ids=True,
     )
 
-    thread.add_stored_request("req-a")
-    thread._handle_request(_make_store_req("req-a", [b"a0", b"a1"]))
+    _run_store_request(thread, _make_store_req("req-a", [b"a0", b"a1"]))
 
     assert store.batch_put_from_multi_buffers.call_count == 1
     assert store.batch_put_from_multi_buffers.call_args.args[3] is replicate_config
@@ -1112,8 +1285,7 @@ def test_store_sending_thread_leaves_group_ids_unchanged_when_unsupported():
         supports_group_ids=False,
     )
 
-    thread.add_stored_request("req-a")
-    thread._handle_request(_make_store_req("req-a", [b"a0", b"a1"]))
+    _run_store_request(thread, _make_store_req("req-a", [b"a0", b"a1"]))
 
     assert store.batch_put_from_multi_buffers.call_count == 1
     assert store.batch_put_from_multi_buffers.call_args.args[3] is replicate_config
@@ -1180,8 +1352,7 @@ def test_store_sending_thread_group_id_excludes_physical_sharding():
         supports_group_ids=True,
     )
 
-    thread.add_stored_request("req-a")
-    thread._handle_request(_make_store_req("req-a", [b"a0", b"a1"]))
+    _run_store_request(thread, _make_store_req("req-a", [b"a0", b"a1"]))
 
     keys, _addrs, _sizes, config = store.batch_put_from_multi_buffers.call_args.args
     assert keys == [
@@ -1210,8 +1381,7 @@ def test_store_sending_thread_multiple_segments_share_logical_group_id():
         supports_group_ids=True,
     )
 
-    thread.add_stored_request("req-a")
-    thread._handle_request(_make_store_req("req-a", [b"a0", b"a1"]))
+    _run_store_request(thread, _make_store_req("req-a", [b"a0", b"a1"]))
 
     keys, addrs, sizes, config = store.batch_put_from_multi_buffers.call_args.args
     assert keys == [
@@ -1260,8 +1430,7 @@ def test_store_sending_thread_group_ids_share_across_kv_cache_groups():
         supports_group_ids=True,
     )
 
-    thread.add_stored_request("req-a")
-    thread._handle_request(_make_multi_group_store_req("req-a", [b"a0", b"a1"]))
+    _run_store_request(thread, _make_multi_group_store_req("req-a", [b"a0", b"a1"]))
 
     keys, addrs, sizes, config = store.batch_put_from_multi_buffers.call_args.args
     assert keys == [
@@ -1296,8 +1465,7 @@ def test_store_sending_thread_group_ids_follow_missing_key_filter():
         supports_group_ids=True,
     )
 
-    thread.add_stored_request("req-a")
-    thread._handle_request(_make_store_req("req-a", [b"a0", b"a1"]))
+    _run_store_request(thread, _make_store_req("req-a", [b"a0", b"a1"]))
 
     keys, _addrs, _sizes, config = store.batch_put_from_multi_buffers.call_args.args
     assert keys == ["test-model@tp_rank:0@pcp0@dcp0@pp_rank:0@group:0@6131"]
@@ -1866,8 +2034,7 @@ def test_store_sending_thread_clamps_token_len_to_lcm():
     # token_len_chunk=33 clamps to 32 → 2 chunks (not 3 with a partial 1-token chunk).
     thread = _make_store_sending_thread(store)
 
-    thread.add_stored_request("r0")
-    thread._handle_request(
+    _run_store_request(thread,
         ReqMeta(
             req_id="r0",
             token_len_chunk=33,
@@ -1905,8 +2072,7 @@ def test_store_sending_thread_skips_when_token_len_below_lcm():
         store, coord=coord, token_databases=[db], block_size=64
     )
 
-    thread.add_stored_request("r0")
-    thread._handle_request(
+    _run_store_request(thread,
         ReqMeta(
             req_id="r0",
             token_len_chunk=32,
@@ -1982,8 +2148,7 @@ def test_store_sending_thread_only_stores_swa_blocks_in_window():
     )
 
     hs = [bytes([i + 1]) * 4 for i in range(8)]
-    thread.add_stored_request("r0")
-    thread._handle_request(
+    _run_store_request(thread,
         ReqMeta(
             req_id="r0",
             token_len_chunk=64,
@@ -2057,17 +2222,16 @@ def test_store_sending_thread_delta_saves_only_new_swa_boundary_chunks():
     )
 
     hs = [bytes([i + 1]) * 4 for i in range(8)]
-    thread.add_stored_request("r0")
-    thread._saved_offset["r0"] = 32
-    thread._handle_request(
-        ReqMeta(
+    request = ReqMeta(
             req_id="r0",
             token_len_chunk=64,
             block_ids=([0, 1], list(range(8))),
             block_hashes=hs,
             can_save=True,
         )
-    )
+    job = _queue_store_request(thread, request)
+    thread._saved_offset[(request.req_id, job.epoch)] = 32
+    thread._handle_request(job)
 
     keys = store.batch_put_from_multi_buffers.call_args.args[0]
     full_hashes = [k.rsplit("@", 1)[-1] for k in keys if "@group:0" in k]
@@ -2128,8 +2292,7 @@ def test_store_sending_thread_kv_events_use_group_chunk_metadata():
     thread.enable_kv_event = True
 
     hs = [bytes([i + 1]) * 4 for i in range(4)]
-    thread.add_stored_request("r0")
-    thread._handle_request(
+    _run_store_request(thread,
         ReqMeta(
             req_id="r0",
             token_len_chunk=32,

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
@@ -474,6 +474,12 @@ class KVTransferThread(threading.Thread):
         return events
 
 
+@dataclass(frozen=True)
+class _StoreRequestJob:
+    request: ReqMeta
+    epoch: int
+
+
 class KVCacheStoreSendingThread(KVTransferThread):
     """Background thread for storing KV cache blocks to the store."""
 
@@ -516,54 +522,135 @@ class KVCacheStoreSendingThread(KVTransferThread):
 
         # Pause store requests when CPU/disk offloading is under pressure.
         self._store_pressure_active = False
-        self._skip_store_requests: set[str] = set()
+        self._skip_store_requests: set[tuple[str, int]] = set()
 
         # Per-request high-water mark of tokens actually persisted; the next
         # batch resumes here, so pressure-skipped or failed ranges are retried.
-        self._saved_offset: dict[str, int] = {}
+        self._saved_offset: dict[tuple[str, int], int] = {}
 
-    def add_stored_request(self, req_id: str):
+        # A request ID can be reused after preemption while an older store job
+        # is still in flight. Scope all async bookkeeping to its lifecycle.
+        self._next_store_epoch = 0
+        self._store_request_epochs: dict[str, int] = {}
+
+    def add_request(self, request: ReqMeta) -> None:
+        req_id = request.req_id
         with self.done_task_lock:
+            epoch = self._store_request_epochs.get(req_id)
+            if epoch is None:
+                self._next_store_epoch += 1
+                epoch = self._next_store_epoch
+                self._store_request_epochs[req_id] = epoch
             self.stored_requests[req_id] += 1
+            self.request_queue.put(_StoreRequestJob(request, epoch))
 
-    def dec_stored_request(self, req_id: str):
+    def get_stored_request_state(
+        self, req_id: str
+    ) -> tuple[int | None, int | None]:
         with self.done_task_lock:
-            if req_id in self.stored_requests:
-                self.stored_requests[req_id] -= 1
+            return (
+                self.stored_requests.get(req_id),
+                self._store_request_epochs.get(req_id),
+            )
 
-    def delete_finished_stored_request(self, req_id: str):
+    def is_current_store_job(self, req_id: str, job_epoch: int) -> bool:
         with self.done_task_lock:
-            if req_id in self.stored_requests:
-                del self.stored_requests[req_id]
-            self._skip_store_requests.discard(req_id)
-            self._saved_offset.pop(req_id, None)
+            return (
+                req_id in self.stored_requests
+                and self._store_request_epochs.get(req_id) == job_epoch
+            )
 
-    def _record_saved(self, req_id: str, token_len: int) -> None:
-        # Guard on liveness so a concurrent finish/preempt pop isn't recreated.
+    def dec_stored_request(self, req_id: str, job_epoch: int) -> bool:
         with self.done_task_lock:
-            if req_id in self.stored_requests:
-                self._saved_offset[req_id] = token_len
+            if self._store_request_epochs.get(req_id) != job_epoch:
+                self._skip_store_requests.discard((req_id, job_epoch))
+                self._saved_offset.pop((req_id, job_epoch), None)
+                return False
+            remaining = self.stored_requests.get(req_id)
+            if remaining is None or remaining <= 0:
+                logger.error(
+                    "Invalid Mooncake store job count for request %s "
+                    "(epoch=%d, count=%s)",
+                    req_id,
+                    job_epoch,
+                    remaining,
+                )
+                return False
+            self.stored_requests[req_id] = remaining - 1
+            return True
 
-    def _should_skip_request(self, req_id: str) -> bool:
+    def delete_finished_stored_request(
+        self, req_id: str, expected_epoch: int | None = None
+    ) -> bool:
         with self.done_task_lock:
-            return self._store_pressure_active and req_id in self._skip_store_requests
+            current_epoch = self._store_request_epochs.get(req_id)
+            if current_epoch is None or (
+                expected_epoch is not None and current_epoch != expected_epoch
+            ):
+                return False
+            self.stored_requests.pop(req_id, None)
+            self._store_request_epochs.pop(req_id, None)
+            self._skip_store_requests.discard((req_id, current_epoch))
+            self._saved_offset.pop((req_id, current_epoch), None)
+            return True
 
-    def _mark_request_skipped_for_pressure(self, req_id: str) -> bool:
+    def _get_saved_offset(self, req_id: str, job_epoch: int) -> int | None:
         with self.done_task_lock:
-            already_skipped = req_id in self._skip_store_requests
+            if self._store_request_epochs.get(req_id) != job_epoch:
+                return None
+            return self._saved_offset.get((req_id, job_epoch), 0)
+
+    def _record_saved(self, req_id: str, job_epoch: int, token_len: int) -> None:
+        with self.done_task_lock:
+            if self._store_request_epochs.get(req_id) == job_epoch:
+                self._saved_offset[(req_id, job_epoch)] = token_len
+
+    def _should_skip_request(self, req_id: str, job_epoch: int) -> bool:
+        with self.done_task_lock:
+            if self._store_request_epochs.get(req_id) != job_epoch:
+                return True
+            return self._store_pressure_active and (
+                req_id,
+                job_epoch,
+            ) in self._skip_store_requests
+
+    def _mark_request_skipped_for_pressure(
+        self, req_id: str, job_epoch: int
+    ) -> bool:
+        with self.done_task_lock:
+            if self._store_request_epochs.get(req_id) != job_epoch:
+                return True
+            request_key = (req_id, job_epoch)
+            already_skipped = request_key in self._skip_store_requests
             self._store_pressure_active = True
-            self._skip_store_requests.add(req_id)
+            self._skip_store_requests.add(request_key)
         return already_skipped
 
-    def _clear_store_pressure(self) -> bool:
+    def _clear_store_pressure(self, req_id: str, job_epoch: int) -> bool:
         with self.done_task_lock:
+            if self._store_request_epochs.get(req_id) != job_epoch:
+                return False
             if not self._store_pressure_active and not self._skip_store_requests:
                 return False
             self._store_pressure_active = False
             self._skip_store_requests.clear()
         return True
 
-    def _maybe_offload_partial_tail(self, req_meta: ReqMeta) -> bool:
+    def _update_kv_event_if_current(
+        self, req_id: str, job_epoch: int, events: list[BlockStored]
+    ) -> bool:
+        with self.done_task_lock:
+            if (
+                req_id not in self.stored_requests
+                or self._store_request_epochs.get(req_id) != job_epoch
+            ):
+                return False
+            self.update_kv_event(events)
+            return True
+
+    def _maybe_offload_partial_tail(
+        self, req_meta: ReqMeta, job_epoch: int
+    ) -> bool:
         """Offload the request's sub-block partial tail (its last prompt hash
         boundary) so a later request can hit the sub-block prefix.
 
@@ -604,7 +691,9 @@ class KVCacheStoreSendingThread(KVTransferThread):
         group_ids: list[str] | None = (
             [] if self.enable_group_semantics and self.supports_group_ids else None
         )
-        saved = self._saved_offset.get(req_meta.req_id, 0)
+        saved = self._get_saved_offset(req_meta.req_id, job_epoch)
+        if saved is None:
+            return False
         for g_idx, db in enumerate(self.token_databases):
             group_blocks = req_meta.block_ids[g_idx]
             # Distribute across ranks by the same rule as normal chunks.
@@ -683,6 +772,8 @@ class KVCacheStoreSendingThread(KVTransferThread):
         if req_meta.current_event is not None:
             # Fence the CoW block copy enqueued earlier this step.
             req_meta.current_event.synchronize()
+        if not self.is_current_store_job(req_meta.req_id, job_epoch):
+            return False
         if group_ids is not None:
             assert len(group_ids) == len(keys)
             self.replicate_config.group_ids = group_ids
@@ -727,17 +818,19 @@ class KVCacheStoreSendingThread(KVTransferThread):
                 failed_codes,
             )
             if MOONCAKE_NO_AVAILABLE_HANDLE in failed_codes:
-                self._mark_request_skipped_for_pressure(req_meta.req_id)
+                self._mark_request_skipped_for_pressure(req_meta.req_id, job_epoch)
             return False
 
-        if self._clear_store_pressure():
+        if self._clear_store_pressure(req_meta.req_id, job_epoch):
             logger.info(
                 "Mooncake CPU/disk offloading pressure cleared after a "
                 "successful partial-tail batch"
             )
         return True
 
-    def _handle_request(self, req_meta: ReqMeta):
+    def _handle_request(self, job: _StoreRequestJob):
+        req_meta = job.request
+        job_epoch = job.epoch
         # Cache hits are always a multiple of ``lcm_block_size`` tokens, which
         # is also ``store_mask``'s precondition.
         lcm_block_size = self.coord.lcm_block_size
@@ -746,7 +839,7 @@ class KVCacheStoreSendingThread(KVTransferThread):
         req_id = req_meta.req_id
         current_event = req_meta.current_event
 
-        if req_id not in self.stored_requests:
+        if not self.is_current_store_job(req_id, job_epoch):
             self.request_queue.task_done()
             return
 
@@ -754,7 +847,7 @@ class KVCacheStoreSendingThread(KVTransferThread):
         # so the scheduler can release the GPU blocks it pinned for this
         # request (via `delay_free_blocks`) even when the store path raises.
         try:
-            if self._should_skip_request(req_id):
+            if self._should_skip_request(req_id, job_epoch):
                 logger.debug(
                     "Skipping Mooncake store for request %s while CPU/disk "
                     "offloading is under pressure",
@@ -765,7 +858,7 @@ class KVCacheStoreSendingThread(KVTransferThread):
             # Offload the sub-block partial tail (independent of the normal
             # block-aligned save, which may be skipped this step).
             if req_meta.partial_tail_offloads is not None and not (
-                self._maybe_offload_partial_tail(req_meta)
+                self._maybe_offload_partial_tail(req_meta, job_epoch)
             ):
                 return
 
@@ -773,7 +866,9 @@ class KVCacheStoreSendingThread(KVTransferThread):
                 return
 
             # Resume from where this rank left off; only the new suffix is saved.
-            save_start = self._saved_offset.get(req_id, 0)
+            save_start = self._get_saved_offset(req_id, job_epoch)
+            if save_start is None:
+                return
 
             # Within each lcm region only per-spec relevant chunks are loaded
             # (e.g., SWA or linear attn), so mask out irrelevant chunks
@@ -808,7 +903,7 @@ class KVCacheStoreSendingThread(KVTransferThread):
                     group_indices.append(g_idx)
 
             if not keys:
-                self._record_saved(req_id, token_len)
+                self._record_saved(req_id, job_epoch, token_len)
                 return
 
             # Check which blocks already exist (dedup)
@@ -834,7 +929,7 @@ class KVCacheStoreSendingThread(KVTransferThread):
             ]
 
             if not missing_indices:
-                self._record_saved(req_id, token_len)
+                self._record_saved(req_id, job_epoch, token_len)
                 return
 
             if len(missing_indices) != len(keys):
@@ -916,6 +1011,8 @@ class KVCacheStoreSendingThread(KVTransferThread):
 
             if current_event is not None:
                 current_event.synchronize()
+            if not self.is_current_store_job(req_id, job_epoch):
+                return
 
             if group_ids is not None:
                 assert len(group_ids) == len(keys)
@@ -954,7 +1051,9 @@ class KVCacheStoreSendingThread(KVTransferThread):
                     )
                     if (
                         MOONCAKE_NO_AVAILABLE_HANDLE in failed_codes
-                        and not self._mark_request_skipped_for_pressure(req_id)
+                        and not self._mark_request_skipped_for_pressure(
+                            req_id, job_epoch
+                        )
                     ):
                         logger.warning(
                             "Detected Mooncake CPU/disk offloading pressure "
@@ -964,8 +1063,8 @@ class KVCacheStoreSendingThread(KVTransferThread):
                             req_id,
                         )
                 else:
-                    self._record_saved(req_id, token_len)
-                    if self._clear_store_pressure():
+                    self._record_saved(req_id, job_epoch, token_len)
+                    if self._clear_store_pressure(req_id, job_epoch):
                         logger.info(
                             "Mooncake CPU/disk offloading pressure cleared "
                             "after a successful store batch"
@@ -982,9 +1081,11 @@ class KVCacheStoreSendingThread(KVTransferThread):
                 logger.error("Failed to put key %s, error: %s", keys, e)
 
             if self.enable_kv_event and stored_events:
-                self.update_kv_event(stored_events)
+                self._update_kv_event_if_current(
+                    req_id, job_epoch, stored_events
+                )
         finally:
-            self.dec_stored_request(req_id)
+            self.dec_stored_request(req_id, job_epoch)
             self.request_queue.task_done()
 
 
@@ -1348,7 +1449,7 @@ class MooncakeStoreWorker:
         self.kv_recv_threads: list[KVCacheStoreRecvingThread] = []
         self.num_recv_threads = max(1, envs.VLLM_MOONCAKE_LOAD_RECV_THREADS)
         self.recv_request_queue: queue.Queue[ReqMeta] = queue.Queue()
-        self.finished_store_req: set[str] = set()
+        self.finished_store_req: dict[str, int] = {}
         self._kv_connector_stats_lock = threading.Lock()
         self.kv_connector_stats = MooncakeStoreConnectorStats()
 
@@ -1670,7 +1771,6 @@ class MooncakeStoreWorker:
                     continue
                 request.current_event = current_event
                 assert self.kv_send_thread is not None
-                self.kv_send_thread.add_stored_request(request.req_id)
                 self.kv_send_thread.add_request(request)
 
         # Check completion of previously queued transfers
@@ -1736,24 +1836,33 @@ class MooncakeStoreWorker:
         finished_sending: set[str] = set()
 
         for req_id in meta.preempted_req_ids:
+            self.finished_store_req.pop(req_id, None)
             self.kv_send_thread.delete_finished_stored_request(req_id)
 
-        for req_id in self.kv_send_thread.stored_requests.copy():
-            if (
-                self.kv_send_thread.stored_requests[req_id] == 0
-                and req_id in self.finished_store_req
-            ):
-                self.finished_store_req.remove(req_id)
-                finished_sending.add(req_id)
-                self.kv_send_thread.delete_finished_stored_request(req_id)
+        for req_id, finished_epoch in list(self.finished_store_req.items()):
+            req_remain_jobs, current_epoch = (
+                self.kv_send_thread.get_stored_request_state(req_id)
+            )
+            if current_epoch != finished_epoch:
+                self.finished_store_req.pop(req_id, None)
+            elif req_remain_jobs == 0:
+                self.finished_store_req.pop(req_id, None)
+                if self.kv_send_thread.delete_finished_stored_request(
+                    req_id, expected_epoch=finished_epoch
+                ):
+                    finished_sending.add(req_id)
 
         for req_id in finished_req_ids:
-            req_remain_jobs = self.kv_send_thread.stored_requests.get(req_id)
-            if req_remain_jobs == 0:
-                finished_sending.add(req_id)
-                self.kv_send_thread.delete_finished_stored_request(req_id)
-            elif req_remain_jobs is not None:
-                self.finished_store_req.add(req_id)
+            req_remain_jobs, current_epoch = (
+                self.kv_send_thread.get_stored_request_state(req_id)
+            )
+            if req_remain_jobs == 0 and current_epoch is not None:
+                if self.kv_send_thread.delete_finished_stored_request(
+                    req_id, expected_epoch=current_epoch
+                ):
+                    finished_sending.add(req_id)
+            elif req_remain_jobs is not None and current_epoch is not None:
+                self.finished_store_req[req_id] = current_epoch
 
         return finished_sending
 


### PR DESCRIPTION
Fixes #51637.

## Purpose

Fix a request-ID ABA race in `MooncakeStoreConnector` asynchronous store-job accounting.

`MooncakeStoreConnector` previously tracked asynchronous store jobs only by the reusable `req_id`. After preemption removed a request's tracking state, an older queued or active store job could complete after the same `req_id` had been reused by a newer lifecycle. The stale completion could then mutate the new lifecycle's bookkeeping, causing the in-flight counter to reach zero prematurely or become negative and corrupting completion accounting. In the observed failure, the counter became negative before the completion scan, so `finished_sending` was never emitted and KV blocks remained retained by finished requests.

This PR introduces a monotonically increasing epoch for each Mooncake store-request lifecycle and binds queued store jobs to `(req_id, epoch)`.

Specifically, it:

- atomically allocates an epoch, increments the in-flight count, and enqueues the epoch-tagged job;
- rejects stale queued or active jobs when their epoch no longer matches the current lifecycle;
- guards saved offsets, skip/pressure state, KV events, deferred completion, and lifecycle deletion to the matching epoch;
- prevents post-I/O accounting from an already-issued stale PUT from mutating a newer lifecycle; and
- adds deterministic CPU regression coverage for queued and active stale jobs, auxiliary state, and deferred completion across preemption.

A remote PUT that has already been issued remains non-cancellable; the fix ensures that its completion cannot mutate bookkeeping or local side effects belonging to a newer lifecycle.

### Why this is not a duplicate

Immediately before opening this PR, I searched open vLLM PRs for both `51637 in:body` and Mooncake preemption / `req_id` / ABA terms. Neither search returned a matching open PR.

Related changes that handle failed stores, scheduler-side request tracking, or stale completions of an absent request do not distinguish an old store job from a newer lifecycle that reuses the same `req_id`. Issue #51637 links to the closest related work and explains that distinction.

## Test Plan

Run formatting and static checks on the modified files, then run the directly affected suites and the complete Mooncake unit-test set.

```text
uv run --python .venv/bin/python pre-commit run --files \
  vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py \
  tests/v1/kv_connector/unit/test_mooncake_store_worker.py \
  tests/v1/kv_connector/unit/test_mooncake_store_hma_e2e.py

uv run --python .venv/bin/python pre-commit run mypy-3.12 \
  --hook-stage manual --files \
  vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py \
  tests/v1/kv_connector/unit/test_mooncake_store_worker.py \
  tests/v1/kv_connector/unit/test_mooncake_store_hma_e2e.py

uv run --python .venv/bin/python .venv/bin/python -m pytest \
  tests/v1/kv_connector/unit/test_mooncake_store_worker.py \
  tests/v1/kv_connector/unit/test_mooncake_store_hma_e2e.py -q

uv run --python .venv/bin/python .venv/bin/python -m pytest \
  tests/v1/kv_connector/unit/test_mooncake_connector_hybrid_mamba.py \
  tests/v1/kv_connector/unit/test_mooncake_store_prepare_values.py \
  tests/v1/kv_connector/unit/test_mooncake_connector_hma.py \
  tests/v1/kv_connector/unit/test_mooncake_connector.py \
  tests/v1/kv_connector/unit/test_mooncake_store_coordinator.py \
  tests/v1/kv_connector/unit/test_mooncake_store_scheduler.py \
  tests/v1/kv_connector/unit/test_mooncake_store_worker.py \
  tests/v1/kv_connector/unit/test_mooncake_stats.py \
  tests/v1/kv_connector/unit/test_mooncake_store_connector.py \
  tests/v1/kv_connector/unit/test_mooncake_store_hma_e2e.py -q
```

## Test Result

- `tests/v1/kv_connector/unit/test_mooncake_store_worker.py`: **114 passed**
- `tests/v1/kv_connector/unit/test_mooncake_store_hma_e2e.py`: **6 passed**
- Full Mooncake KV-connector unit-test set: **268 passed**
- `git diff --check`: clean
- pre-commit (`ruff`, format, typos): clean
- `mypy-3.12`: clean

### Deterministic lifecycle coverage

The worker suite adds five deterministic CPU lifecycle regressions covering:

1. normal epoch completion and cleanup;
2. a queued stale job after `req_id` reuse;
3. an active stale completion after `req_id` reuse;
4. stale-job rejection for saved offsets, skip/pressure transitions, KV events, and epoch-bound deletion; and
5. epoch-bound deferred `finished_sending`, including preemption and rebuilding with the same request ID.

### GPU / Mooncake validation

The corresponding epoch-aware worker design was also validated in the reproduction environment described in #51637:

| Configuration | Result |
|---|---|
| v0.26.0, up to 4 replicas × TP2 | 256/256 trajectories completed |
| v0.25.0 same-seed baseline | livelock reproduced |
| v0.25.0 same-seed patched | 128/128 trajectories completed |
| Patched runs | no counter underflow observed |
| Patched runs | no negative store counter observed |

These are historical GPU/Mooncake results for the corresponding epoch-aware patch, not a full GPU reproduction of this exact latest-`main` commit. Validation of the latest-`main` implementation is provided by the deterministic CPU regression coverage above.

## AI assistance

This PR was developed with AI assistance. The human submitter reviewed every changed line, validated the behavior, and ran the tests listed above.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>