### PR TITLE
[Bugfix][Reasoning] Fix streaming reasoning content misrouted to content when stop parameter desyncs delta_text from delta_token_ids

### DIFF
--- a/tests/reasoning/test_base_thinking_reasoning_parser.py
+++ b/tests/reasoning/test_base_thinking_reasoning_parser.py
@@ -436,3 +436,61 @@ class TestBaseThinkingReasoningParserEdgeCases:
         # Should treat as regular content since tokens don't match exactly
         assert reasoning == ("<test:thinking>Not a real token</test:thinking>Content")
         assert content is None
+
+    def test_stop_buffer_desync_end_token_in_ids_but_not_text(self, test_tokenizer):
+        """Simulate stop-buffer desync where end_token_id is in delta_token_ids
+        but end_token text is held back from delta_text.
+
+        Round 1: delta_text trails delta_token_ids (end_token text buffered).
+        Round 2: released text contains end_token, no new tokens.
+        """
+        parser = TestThinkingReasoningParser(test_tokenizer)
+        end_token = parser.end_token
+        end_token_id = parser.end_token_id
+        start_token_id = parser.start_token_id
+
+        # ── Round 1: end_token_id in tokens but not in text ──
+        prev_text_r1 = "some reasoning "
+        prev_ids_r1 = [start_token_id, 100, 101]
+        delta_text_r1 = "tail "
+        delta_ids_r1 = [102, end_token_id, 200, 201]
+
+        msg1 = parser.extract_reasoning_streaming(
+            previous_text=prev_text_r1,
+            current_text=prev_text_r1 + delta_text_r1,
+            delta_text=delta_text_r1,
+            previous_token_ids=prev_ids_r1,
+            current_token_ids=prev_ids_r1 + delta_ids_r1,
+            delta_token_ids=delta_ids_r1,
+        )
+        # Must emit reasoning (not None) while the text catches up
+        assert msg1 is not None, "Round 1 should emit a delta message"
+        assert msg1.reasoning == "tail ", (
+            "Text trailing end_token should be emitted as reasoning"
+        )
+        assert msg1.content is None, (
+            "Content must remain None until the end_token text is visible"
+        )
+
+        # ── Round 2: end_token text now visible, no new tokens ──
+        prev_text_r2 = prev_text_r1 + delta_text_r1
+        prev_ids_r2 = prev_ids_r1 + delta_ids_r1
+        delta_text_r2 = end_token + " D E"
+        delta_ids_r2: list[int] = []
+
+        msg2 = parser.extract_reasoning_streaming(
+            previous_text=prev_text_r2,
+            current_text=prev_text_r2 + delta_text_r2,
+            delta_text=delta_text_r2,
+            previous_token_ids=prev_ids_r2,
+            current_token_ids=prev_ids_r2 + delta_ids_r2,
+            delta_token_ids=delta_ids_r2,
+        )
+        # Must split the released text on the end_token
+        assert msg2 is not None, "Round 2 should emit a delta message"
+        assert msg2.reasoning == "", (
+            "Empty reasoning section before end_token"
+        )
+        assert msg2.content == " D E", (
+            "Content after end_token should be routed as content"
+        )

--- a/vllm/parser/abstract_parser.py
+++ b/vllm/parser/abstract_parser.py
@@ -848,26 +848,37 @@ class DelegatingParser(Parser):
                     current_token_ids, delta_token_ids
                 )
             if should_transition:
-                state.reasoning_ended = True
-                reasoning_transitioned = True
-                current_token_ids = self.extract_content_ids(delta_token_ids)
-                # Flush whenever the reasoning parser is engine-based (not only
-                # when _engine_based is True): it buffers the post-marker text
-                # (e.g. the "<" of "<tool_call>"), surfaced via finish_streaming().
-                flush_delta = (
-                    reasoning_parser.finish_streaming()  # type: ignore[union-attr, attr-defined]
-                    if reasoning_parser is not None
-                    and reasoning_parser.engine_based_streaming
-                    else None
-                )
-                current_text = (
-                    (delta_message.content if delta_message else None) or ""
-                ) + ((flush_delta.content if flush_delta else None) or "")
-                if self._engine_based:
-                    if delta_message and self._tool_parser is not None:
-                        delta_message.content = None
-                else:
-                    delta_text = current_text
+                # Guard against premature state transition caused by
+                # stop-buffer desync: the detokenizer may hold back
+                # characters so delta_text trails delta_token_ids.
+                # Don't transition until the end marker text is visible.
+                if reasoning_parser is not None and not reasoning_parser.engine_based_streaming:
+                    reasoning_end_str = getattr(
+                        reasoning_parser, "reasoning_end_str", None
+                    )
+                    if reasoning_end_str and reasoning_end_str not in delta_text:
+                        should_transition = False
+                if should_transition:
+                    state.reasoning_ended = True
+                    reasoning_transitioned = True
+                    current_token_ids = self.extract_content_ids(delta_token_ids)
+                    # Flush whenever the reasoning parser is engine-based (not only
+                    # when _engine_based is True): it buffers the post-marker text
+                    # (e.g. the "<" of "<tool_call>"), surfaced via finish_streaming().
+                    flush_delta = (
+                        reasoning_parser.finish_streaming()  # type: ignore[union-attr, attr-defined]
+                        if reasoning_parser is not None
+                        and reasoning_parser.engine_based_streaming
+                        else None
+                    )
+                    current_text = (
+                        (delta_message.content if delta_message else None) or ""
+                    ) + ((flush_delta.content if flush_delta else None) or "")
+                    if self._engine_based:
+                        if delta_message and self._tool_parser is not None:
+                            delta_message.content = None
+                    else:
+                        delta_text = current_text
 
         # Tool call extraction
         if self._in_tool_call_phase(state):

--- a/vllm/reasoning/basic_parsers.py
+++ b/vllm/reasoning/basic_parsers.py
@@ -115,21 +115,39 @@ class BaseThinkingReasoningParser(ReasoningParser):
         ):
             return None
 
+        # Check if the end token text is visible in delta_text.
+        # delta_text may trail delta_token_ids when the stop buffer in the
+        # detokenizer holds back characters to avoid emitting a stop string.
+        end_token_in_text = self.end_token in delta_text
+
         # Check if start token is present in previous or delta.
         # Keep compatibility with models that don't generate start tokens.
         if self.start_token_id in previous_token_ids:
             if self.end_token_id in delta_token_ids:
-                # start token in previous, end token in delta,
-                # extract reasoning content
-                end_index = delta_text.find(self.end_token)
-                reasoning = delta_text[:end_index]
-                content = delta_text[end_index + len(self.end_token) :]
-                return DeltaMessage(
-                    reasoning=reasoning, content=content if content else None
-                )
+                # start token in previous, end token in delta
+                if end_token_in_text:
+                    end_index = delta_text.find(self.end_token)
+                    reasoning = delta_text[:end_index]
+                    content = delta_text[end_index + len(self.end_token) :]
+                    return DeltaMessage(
+                        reasoning=reasoning, content=content if content else None
+                    )
+                # end token ID detected but text not yet visible
+                # (delayed by stop buffer). Keep emitting reasoning
+                # until the text catches up.
+                return DeltaMessage(reasoning=delta_text)
             elif self.end_token_id in previous_token_ids:
-                # start token in previous, end token in previous,
-                # reasoning content continues
+                # start token in previous, end token in previous
+                if end_token_in_text:
+                    # End token text was held back by the stop buffer and
+                    # is now visible. Split on it so the marker doesn't
+                    # leak into content.
+                    end_index = delta_text.find(self.end_token)
+                    reasoning = delta_text[:end_index]
+                    content = delta_text[end_index + len(self.end_token) :]
+                    return DeltaMessage(
+                        reasoning=reasoning, content=content if content else None
+                    )
                 return DeltaMessage(content=delta_text)
             else:
                 # start token in previous, no end token in previous or delta,
@@ -137,15 +155,17 @@ class BaseThinkingReasoningParser(ReasoningParser):
                 return DeltaMessage(reasoning=delta_text)
         elif self.start_token_id in delta_token_ids:
             if self.end_token_id in delta_token_ids:
-                # start token in delta, end token in delta,
-                # extract reasoning content
-                start_index = delta_text.find(self.start_token)
-                end_index = delta_text.find(self.end_token)
-                reasoning = delta_text[start_index + len(self.start_token) : end_index]
-                content = delta_text[end_index + len(self.end_token) :]
-                return DeltaMessage(
-                    reasoning=reasoning, content=content if content else None
-                )
+                # start token in delta, end token in delta
+                if end_token_in_text:
+                    start_index = delta_text.find(self.start_token)
+                    end_index = delta_text.find(self.end_token)
+                    reasoning = delta_text[start_index + len(self.start_token) : end_index]
+                    content = delta_text[end_index + len(self.end_token) :]
+                    return DeltaMessage(
+                        reasoning=reasoning, content=content if content else None
+                    )
+                # end token ID detected but text not yet visible
+                return DeltaMessage(reasoning=delta_text)
             else:
                 # start token in delta, no end token in delta,
                 # reasoning content continues


### PR DESCRIPTION
## Summary

Fixes #51641 — a desynchronization between `delta_text` and `delta_token_ids` when the `stop` parameter is set with `include_stop_str_in_output=false`. The detokenizer's stop buffer holds back characters from `delta_text` but `delta_token_ids` reflects all tokens, causing the reasoning parser to misroute the reasoning tail and `end_token` marker into `content`.

### Root cause

When a streaming request carries a non-empty `stop` list:
1. **Detokenizer** holds back up to `max(len(stop)) - 1` chars from `delta_text` (stop buffer)
2. **Token IDs** (`delta_token_ids`) are NOT buffered — they reflect all tokens
3. **Parser** (`extract_reasoning_streaming`) detects `end_token_id` in `delta_token_ids` but `end_token` text isn't in `delta_text`, falls through to `None` (losing reasoning tail)
4. **Next round**: `end_token_id` in `previous_token_ids` triggers `content` routing — everything including the end_token marker leaks into content

### What changed

**`vllm/reasoning/basic_parsers.py`** — `BaseThinkingReasoningParser.extract_reasoning_streaming`:
- When `end_token_id` is in `delta_token_ids` but `end_token` text isn't visible in `delta_text`: keep emitting `reasoning` (don't fall through to `None`)
- When `end_token_id` is in `previous_token_ids` and `end_token` text IS visible (released from stop buffer): split on the text marker properly

**`vllm/parser/abstract_parser.py`** — `DelegatingParser.parse_delta`:
- Added a guard to prevent premature state transition when `is_reasoning_end_streaming` fires based on token IDs but the end marker text isn't visible in `delta_text`

### Tests

Added `test_stop_buffer_desync_end_token_in_ids_but_not_text` to `tests/reasoning/test_base_thinking_reasoning_parser.py` — a two-round streaming test that simulates:
1. Round 1: `delta_text` trails `delta_token_ids` (end_token text buffered)
2. Round 2: buffered text released, no new tokens — verifies correct split

### Not duplicating existing work

Checked `gh pr list --repo vllm-project/vllm --state open --search "51641 in:body"` — no existing PRs.

### AI assistance

This PR was developed with AI assistance (Claude Code). Every changed line has been reviewed.

Co-authored-by: Anthropic Claude