### PR TITLE
Fix stop buffer desync

### DIFF
--- a/tests/reasoning/test_stop_buffer_desync.py
+++ b/tests/reasoning/test_stop_buffer_desync.py
@@ -1,0 +1,67 @@
+from typing import Sequence
+import pytest
+
+from vllm.reasoning.basic_parsers import BaseThinkingReasoningParser
+from vllm.transformers_utils.tokenizer_group import BaseTokenizerGroup
+
+# Mock the parser so we don't need a real model or tokenizer
+class MockParser(BaseThinkingReasoningParser):
+    def __init__(self):
+        self.start_token_id = 1
+        self.end_token_id = 2
+        self.start_token = "<think>"
+        self.end_token = "</think>"
+
+@pytest.mark.skip_global_cleanup
+def test_stop_buffer_desync():
+    """
+    Tests that the streaming reasoning parser does not leak reasoning tags
+    into the content stream when a stop buffer holds back text.
+    Reproduces bug #51641.
+    """
+    parser = MockParser()
+
+    # Round 1: Model generates "</think> Hello" but stop buffer holds back text
+    previous_text = "<think>I have a plan"
+    delta_text = "</"
+    current_text = previous_text + delta_text
+    previous_token_ids = [1, 10, 11] # <think>, I, have a plan
+    delta_token_ids = [12, 2, 13] # </, </think>, Hello
+    current_token_ids = previous_token_ids + delta_token_ids
+
+    res1 = parser.extract_reasoning_streaming(
+        previous_text=previous_text,
+        current_text=current_text,
+        delta_text=delta_text,
+        previous_token_ids=previous_token_ids,
+        current_token_ids=current_token_ids,
+        delta_token_ids=delta_token_ids
+    )
+
+    # In Round 1, text hasn't caught up to token IDs, so it should still be in reasoning.
+    assert res1 is not None
+    assert res1.reasoning == "</"
+    assert res1.content is None
+
+    # Round 2: Stop buffer releases the rest of the text
+    previous_text = current_text
+    delta_text = "think> Hello"
+    current_text = previous_text + delta_text
+    previous_token_ids = current_token_ids
+    delta_token_ids = []
+    current_token_ids = previous_token_ids + delta_token_ids
+
+    res2 = parser.extract_reasoning_streaming(
+        previous_text=previous_text,
+        current_text=current_text,
+        delta_text=delta_text,
+        previous_token_ids=previous_token_ids,
+        current_token_ids=current_token_ids,
+        delta_token_ids=delta_token_ids
+    )
+
+    # In Round 2, the end token string is finally complete!
+    assert res2 is not None
+    assert res2.reasoning is None, f"Expected None reasoning, got {res2.reasoning}"
+    # If the bug was present, this would be 'think> Hello' and fail the assertion
+    assert res2.content == " Hello", f"Expected ' Hello', got {res2.content}"

--- a/vllm/reasoning/basic_parsers.py
+++ b/vllm/reasoning/basic_parsers.py
@@ -182,6 +182,7 @@ class BaseThinkingReasoningParser(ReasoningParser):
                     start_of_start = current_text.find(self.start_token)
                     start_in_delta = max(0, start_of_start + len(self.start_token) - len(previous_text)) if start_of_start != -1 else 0
                     return DeltaMessage(reasoning=delta_text[start_in_delta:])
+        else:
             # not find thinking start token
             return DeltaMessage(content=delta_text)
 

--- a/vllm/reasoning/basic_parsers.py
+++ b/vllm/reasoning/basic_parsers.py
@@ -118,39 +118,70 @@ class BaseThinkingReasoningParser(ReasoningParser):
         # Check if start token is present in previous or delta.
         # Keep compatibility with models that don't generate start tokens.
         if self.start_token_id in previous_token_ids:
-            if self.end_token_id in delta_token_ids:
-                # start token in previous, end token in delta,
-                # extract reasoning content
-                end_index = delta_text.find(self.end_token)
-                reasoning = delta_text[:end_index]
-                content = delta_text[end_index + len(self.end_token) :]
-                return DeltaMessage(
-                    reasoning=reasoning, content=content if content else None
-                )
-            elif self.end_token_id in previous_token_ids:
-                # start token in previous, end token in previous,
-                # reasoning content continues
-                return DeltaMessage(content=delta_text)
+            if self.end_token_id in current_token_ids:
+                if self.end_token in previous_text:
+                    # start token in previous, end token in previous text,
+                    # reasoning content continues as content
+                    return DeltaMessage(content=delta_text)
+                elif self.end_token in current_text:
+                    # end token just appeared in visible text
+                    end_index = delta_text.find(self.end_token)
+                    if end_index != -1:
+                        reasoning = delta_text[:end_index]
+                        content = delta_text[end_index + len(self.end_token) :]
+                    else:
+                        start_of_end = current_text.find(self.end_token)
+                        reasoning_tail_len = start_of_end - len(previous_text)
+                        reasoning = delta_text[:reasoning_tail_len] if reasoning_tail_len > 0 else ""
+                        content = delta_text[reasoning_tail_len + len(self.end_token) :]
+                    return DeltaMessage(
+                        reasoning=reasoning if reasoning else None,
+                        content=content if content else None
+                    )
+                else:
+                    # end token in IDs, but text is held back by stop buffer
+                    return DeltaMessage(reasoning=delta_text)
             else:
-                # start token in previous, no end token in previous or delta,
+                # start token in previous, no end token in current,
                 # reasoning content continues
                 return DeltaMessage(reasoning=delta_text)
         elif self.start_token_id in delta_token_ids:
             if self.end_token_id in delta_token_ids:
-                # start token in delta, end token in delta,
-                # extract reasoning content
-                start_index = delta_text.find(self.start_token)
-                end_index = delta_text.find(self.end_token)
-                reasoning = delta_text[start_index + len(self.start_token) : end_index]
-                content = delta_text[end_index + len(self.end_token) :]
-                return DeltaMessage(
-                    reasoning=reasoning, content=content if content else None
-                )
+                if self.end_token in current_text:
+                    start_index = delta_text.find(self.start_token)
+                    end_index = delta_text.find(self.end_token)
+                    if start_index != -1 and end_index != -1:
+                        reasoning = delta_text[start_index + len(self.start_token) : end_index]
+                        content = delta_text[end_index + len(self.end_token) :]
+                    else:
+                        start_of_start = current_text.find(self.start_token)
+                        start_of_end = current_text.find(self.end_token)
+                        reasoning_start = max(0, start_of_start + len(self.start_token) - len(previous_text)) if start_of_start != -1 else 0
+                        reasoning_end = max(0, start_of_end - len(previous_text)) if start_of_end != -1 else len(delta_text)
+                        reasoning = delta_text[reasoning_start:reasoning_end]
+                        content = delta_text[reasoning_end + len(self.end_token) :] if start_of_end != -1 else ""
+                    return DeltaMessage(
+                        reasoning=reasoning if reasoning else None,
+                        content=content if content else None
+                    )
+                else:
+                    # end token not visible yet
+                    start_index = delta_text.find(self.start_token)
+                    if start_index != -1:
+                        return DeltaMessage(reasoning=delta_text[start_index + len(self.start_token) :])
+                    else:
+                        start_of_start = current_text.find(self.start_token)
+                        start_in_delta = max(0, start_of_start + len(self.start_token) - len(previous_text)) if start_of_start != -1 else 0
+                        return DeltaMessage(reasoning=delta_text[start_in_delta:])
             else:
-                # start token in delta, no end token in delta,
-                # reasoning content continues
-                return DeltaMessage(reasoning=delta_text)
-        else:
+                # start token in delta, no end token
+                start_index = delta_text.find(self.start_token)
+                if start_index != -1:
+                    return DeltaMessage(reasoning=delta_text[start_index + len(self.start_token) :])
+                else:
+                    start_of_start = current_text.find(self.start_token)
+                    start_in_delta = max(0, start_of_start + len(self.start_token) - len(previous_text)) if start_of_start != -1 else 0
+                    return DeltaMessage(reasoning=delta_text[start_in_delta:])
             # not find thinking start token
             return DeltaMessage(content=delta_text)
 


### PR DESCRIPTION

## Purpose
When the stop buffer holds back text, `delta_text` temporarily falls behind `delta_token_ids`. The `extract_reasoning_streaming` parser previously used token IDs to drive state transitions. This caused
  the parser to incorrectly switch to the "content" state before the physical text actually caught up, resulting in `</think>` tags and reasoning tails permanently leaking into the visible `content` stream.
    
This PR implements **visible-text-first parsing**. The parser now drives state transitions purely based on whether the end token string (`</think>`) has physically appeared in `current_text`. 
    - Ignores the `end_token_id` state change if the text is still held in the stop buffer.
    - Robustly handles cases where the text chunks are split awkwardly across the reasoning/content boundary.
## Test Plan
Added an automated unit test `test_stop_buffer_desync` to `tests/reasoning/test_stop_buffer_desync.py` to mathematically verify the streaming separation. 

    Test command:
    `pytest tests/reasoning/test_stop_buffer_desync.py`
## Test Result
**Before Fix (Buggy output):**

    Round 1 (Token ID present, Text buffered):
    Reasoning: '<'
    Content: None
  
    Round 2 (Text released):
    Reasoning: None
    Content: 'think> Hello'  <-- Tag leaked into content


**After Fix (Correct output):**

    Round 1 (Token ID present, Text buffered):
    Reasoning: '</'
    Content: None
  
    Round 2 (Text released):
    Reasoning: None
    Content: ' Hello'      <-- Tag successfully filtered
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>
