### PR TITLE
[Misc] Enable test_fused_moe_wn16 on XPU

### DIFF
--- a/tests/kernels/moe/test_moe.py
+++ b/tests/kernels/moe/test_moe.py
@@ -575,6 +575,10 @@ def test_naive_block_assignment_moe(
 @pytest.mark.parametrize("group_size", [64, 128])
 @pytest.mark.parametrize("has_zp", [True, False])
 @pytest.mark.parametrize("weight_bits", [4, 8])
+@pytest.mark.skipif(
+    not (current_platform.is_cuda_alike() or current_platform.is_xpu()),
+    reason="MoE WNA16 Triton kernels require CUDA/ROCm or XPU.",
+)
 def test_fused_moe_wn16(
     m: int,
     n: int,
@@ -587,10 +591,10 @@ def test_fused_moe_wn16(
     has_zp: bool,
     weight_bits: int,
 ):
-    a = torch.randn((m, k), device="cuda", dtype=dtype) / 10
-    w1 = torch.randn((e, 2 * n, k), device="cuda", dtype=dtype) / 10
-    w2 = torch.randn((e, k, n), device="cuda", dtype=dtype) / 10
-    score = torch.randn((m, e), device="cuda", dtype=dtype)
+    a = torch.randn((m, k), device=DEVICE_TYPE, dtype=dtype) / 10
+    w1 = torch.randn((e, 2 * n, k), device=DEVICE_TYPE, dtype=dtype) / 10
+    w2 = torch.randn((e, k, n), device=DEVICE_TYPE, dtype=dtype) / 10
+    score = torch.randn((m, e), device=DEVICE_TYPE, dtype=dtype)
 
     if weight_bits == 4:
         pack_factor = 2
@@ -602,16 +606,22 @@ def test_fused_moe_wn16(
     w1_ref = w1.clone()
     w2_ref = w2.clone()
     w1_qweight = torch.empty(
-        (e, 2 * n, k // pack_factor), device="cuda", dtype=torch.uint8
+        (e, 2 * n, k // pack_factor), device=DEVICE_TYPE, dtype=torch.uint8
     )
-    w2_qweight = torch.empty((e, k, n // pack_factor), device="cuda", dtype=torch.uint8)
-    w1_scales = torch.empty((e, 2 * n, k // group_size), device="cuda", dtype=dtype)
-    w2_scales = torch.empty((e, k, n // group_size), device="cuda", dtype=dtype)
+    w2_qweight = torch.empty(
+        (e, k, n // pack_factor), device=DEVICE_TYPE, dtype=torch.uint8
+    )
+    w1_scales = torch.empty(
+        (e, 2 * n, k // group_size), device=DEVICE_TYPE, dtype=dtype
+    )
+    w2_scales = torch.empty((e, k, n // group_size), device=DEVICE_TYPE, dtype=dtype)
     w1_qzeros = torch.empty(
-        (e, 2 * n // pack_factor, k // group_size), device="cuda", dtype=torch.uint8
+        (e, 2 * n // pack_factor, k // group_size),
+        device=DEVICE_TYPE,
+        dtype=torch.uint8,
     )
     w2_qzeros = torch.empty(
-        (e, k // pack_factor, n // group_size), device="cuda", dtype=torch.uint8
+        (e, k // pack_factor, n // group_size), device=DEVICE_TYPE, dtype=torch.uint8
     )
 
     for i in range(e * 2):
@@ -653,9 +663,9 @@ def test_fused_moe_wn16(
 
     if ep_size > 1:
         local_e = e // ep_size
-        e_ids = torch.randint(0, e, (local_e,), device="cuda", dtype=torch.int32)
-        e_map = torch.full((e,), -1, device="cuda", dtype=torch.int32)
-        e_map[e_ids] = torch.arange(local_e, device="cuda", dtype=torch.int32)
+        e_ids = torch.randint(0, e, (local_e,), device=DEVICE_TYPE, dtype=torch.int32)
+        e_map = torch.full((e,), -1, device=DEVICE_TYPE, dtype=torch.int32)
+        e_map[e_ids] = torch.arange(local_e, device=DEVICE_TYPE, dtype=torch.int32)
         w1_ref = w1_ref[e_ids]
         w2_ref = w2_ref[e_ids]
         w1_qweight = w1_qweight[e_ids]


### PR DESCRIPTION
## Purpose

Enables XPU coverage for `test_fused_moe_wn16`, which exercises the
`fused_moe_kernel_gptq_awq` Triton kernel (fused MoE with GPTQ/AWQ INT4/INT8
weight-only quantization).

- Hardcoded `device="cuda"` replaced with the `DEVICE_TYPE` already defined in
  this module (`current_platform.device_type`).
- Added a `skipif` guard so platforms without the kernel skip instead of failing
  on a missing device.

Test-only device-selector adaptation; no kernel or production logic is modified.
`DEVICE_TYPE` is `"cuda"` on CUDA and ROCm, so CUDA behaviour is unchanged.

## Test Plan

```
pytest tests/kernels/moe/test_moe.py -k wn16 -v
```

## Test Result

All pass on Intel Arc Pro B70 (BMG, torch 2.12.0+xpu, Triton 3.8.0):

| Test | passed | failed | skipped |
| --- | --- | --- | --- |
| `test_fused_moe_wn16` | 384 | 0 | 0 |

384 passed in 176s.

Replaces #45809, which cannot run CI: the Buildkite branch-name validator
rejects the old head branch `pmanczak/UT-fused_moe_kernel_gptq_awq-(MoE)`
("Invalid branch name. Contains disallowed characters."). Same diff, branch
name without parentheses.

