### PR TITLE
[Bugfix][Profiler] Fix API server crash on double /stop_profile

### DIFF
--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -7,9 +7,7 @@ import time
 import warnings
 from collections.abc import AsyncGenerator, Iterable, Mapping
 from copy import copy
-from typing import Any
-
-import torch
+from typing import Any, Optional
 
 import vllm.envs as envs
 from vllm import TokensPrompt
@@ -34,6 +32,7 @@ from vllm.lora.request import LoRARequest
 from vllm.multimodal import MULTIMODAL_REGISTRY, MultiModalRegistry
 from vllm.outputs import STREAM_FINISHED, PoolingRequestOutput, RequestOutput
 from vllm.pooling_params import PoolingParams
+from vllm.profiler.wrapper import TorchProfilerWrapper
 from vllm.renderers import renderer_from_config
 from vllm.renderers.inputs.preprocess import extract_prompt_components
 from vllm.sampling_params import RequestOutputKind, SamplingParams
@@ -92,6 +91,7 @@ class AsyncLLM(EngineClient):
         client_addresses: dict[str, Any] | None = None,
         client_count: int = 1,
         client_index: int = 0,
+        profiler: Optional[TorchProfilerWrapper] = None,  # type: ignore # noqa
     ) -> None:
         """
         Create an AsyncLLM.
@@ -195,19 +195,12 @@ class AsyncLLM(EngineClient):
                 profiler_dir,
             )
             worker_name = f"{socket.gethostname()}_{os.getpid()}.async_llm"
-            self.profiler = torch.profiler.profile(
-                activities=[
-                    torch.profiler.ProfilerActivity.CPU,
-                ],
-                with_stack=vllm_config.profiler_config.torch_profiler_with_stack,
-                on_trace_ready=torch.profiler.tensorboard_trace_handler(
-                    profiler_dir,
-                    worker_name=worker_name,
-                    use_gzip=vllm_config.profiler_config.torch_profiler_use_gzip,
-                ),
+            self.profiler = TorchProfilerWrapper(
+                vllm_config.profiler_config,
+                worker_name=worker_name,
+                local_rank=0,
+                activities=["CPU"],
             )
-        else:
-            self.profiler = None
 
     @classmethod
     def from_vllm_config(


### PR DESCRIPTION
## Purpose
Fixes #51676 

## Test Plan
Start vLLM
```bash
vllm serve Qwen/Qwen3.5-0.8B --max-model-len 262144 --reasoning-parser qwen3 --profiler-config '{"profiler":"torch","torch_profiler_dir":"vllm-prof-test/"}' --gpu-memory-utilization 0.6 --max-model-len 32768 --max-num-seqs 128
```
enable profiler
```
curl -X POST http://localhost:8000/start_profile
```
generate some load
```
vllm bench serve --model Qwen/Qwen3.5-0.8B --host localhost --port 8000 --num-prompts 100 --max-concurrency 64 #generate some load
```
stop the profiler twice (you can even run the two calls concurrently, the second causes the segfault)
```
curl -X POST http://localhost:8000/stop_profile #ok, wait a little
curl -X POST http://localhost:8000/stop_profile # this triggers the segfault
```
## Test Result
*  before: 200 / 200 / 500 (or segfault with a large trace)
*  after:  200 / 200 / 200 (second stop is a no-op)
