### PR TITLE
[ROCm][Kimi-K3] Coerce non-contiguous state_indices in KDA packed decode

### DIFF
--- a/vllm/models/kimi_k3/amd/ops/third_party/kda/fused_recurrent.py
+++ b/vllm/models/kimi_k3/amd/ops/third_party/kda/fused_recurrent.py
@@ -561,7 +561,13 @@ def fused_recurrent_kda_packed_decode(
     if initial_state.stride()[1:] != (V * K, K, 1):
         raise ValueError("`initial_state` must be contiguous within each cache slot.")
     if state_indices.ndim != 1 or state_indices.stride(0) != 1:
-        raise ValueError("`state_indices` must be contiguous and one-dimensional.")
+        # A piecewise CUDA graph can hand this kernel a non-contiguous / [B, 1]
+        # ``state_indices`` (full-graph capture modes prepare a 1-D contiguous
+        # one). The packed decode kernel only indexes ``state_indices[i_n]`` once
+        # per sequence, so flattening to a contiguous 1-D tensor is equivalent to
+        # the full-graph input and lets piecewise capture / eager warmup proceed
+        # instead of raising.
+        state_indices = state_indices.reshape(-1).contiguous()
     if A_log.ndim != 1 or not A_log.is_contiguous():
         raise ValueError("`A_log` must be contiguous and one-dimensional.")
     if not dt_bias.is_contiguous():


### PR DESCRIPTION
This PR in intended to be compatible with "cudagraph_mode":"FULL_AND_PIECEWISE". 

==

## Purpose

The KDA (Kimi Delta Attention) packed-decode kernel `fused_recurrent_kda_packed_decode` rejects a `state_indices` tensor that is not 1-D and contiguous:

```python
if state_indices.ndim != 1 or state_indices.stride(0) != 1:
    raise ValueError("`state_indices` must be contiguous and one-dimensional.")
```

Under **piecewise CUDA graph capture** (and eager warmup) the runtime can hand this kernel a non-contiguous / `[B, 1]` `state_indices`, whereas **full-graph** capture modes prepare a 1-D contiguous one. The consequence is that the same Kimi-K3 model boots under full-graph cudagraph modes but aborts during engine warmup under piecewise capture / eager mode with the `ValueError` above.

## Change

The packed-decode kernel only indexes `state_indices[i_n]` once per sequence, so flattening to a contiguous 1-D tensor is exactly equivalent to the full-graph input. Coerce with `reshape(-1).contiguous()` instead of raising, so piecewise capture / eager warmup can proceed.

## Test

Verified on gfx950 (MI355X) serving Kimi-K3 (fp8 KV, DSpark MTP): with this change the engine completes profiling/warmup and CUDA-graph capture and serves normally under piecewise-inclusive cudagraph modes; without it, warmup aborts at the KDA packed decode.