### PR TITLE
[Bugfix][Spec Decode][Quantization] Handle quantized qkv_proj in DFlash fused-KV buffers

### DIFF
--- a/tests/v1/spec_decode/test_dflash_fusedkv_quantized.py
+++ b/tests/v1/spec_decode/test_dflash_fusedkv_quantized.py
@@ -1,0 +1,343 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tiered context-KV projection for quantized DFlash drafters (#51581).
+
+Pins down:
+- the strategy decision (fused / scaled_mm / dequant / per_layer),
+- the per-layer fallback's output layout,
+- the invariant that packed weights never reach a bare ``F.linear``,
+- the real-FP8 drafter precompute on GPU (per-layer / dequant / scaled_mm).
+"""
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.nn.functional as F
+from torch import nn
+
+from vllm.model_executor.layers.linear import LinearMethodBase, UnquantizedLinearMethod
+from vllm.model_executor.layers.quantization.fp8 import Fp8LinearMethod
+from vllm.model_executor.models.qwen3_dflash import (
+    ContextKVStrategy,
+    DFlashQwen3Model,
+    _decide_context_kv_strategy,
+)
+
+HIDDEN = 32
+HEAD_DIM = 8
+NUM_HEADS = 4
+NUM_KV_HEADS = 2
+NUM_LAYERS = 3
+NUM_CTX = 5
+Q_SIZE = NUM_HEADS * HEAD_DIM      # 32
+KV_SIZE = NUM_KV_HEADS * HEAD_DIM  # 16
+
+
+def _cpu_rms_norm(out, input, weight, eps):
+    """Reference RMSNorm writing into ``out`` (vLLM's fused kernel is CUDA-only).
+    Handles 1-D ([H]) and grouped [L, H] weights."""
+    var = input.float().pow(2).mean(-1, keepdim=True)
+    normed = (input * (var + eps).rsqrt()).to(input.dtype)
+    if weight.ndim == 2 and input.ndim >= 3:
+        weight = weight.reshape(weight.shape[0], *([1] * (input.ndim - 2)),
+                                weight.shape[1])
+    out.copy_(normed * weight)
+
+
+@pytest.fixture
+def cpu_rms_norm(monkeypatch):
+    from vllm.model_executor.models import qwen3_dflash as mod
+
+    monkeypatch.setattr(mod.ops, "rms_norm", _cpu_rms_norm)
+
+
+def _ints(*shape):
+    """Small-integer float32 data: additions are exact for bit-level compares."""
+    return torch.randint(-3, 4, shape).float()
+
+
+class _PackedLinearMethod(LinearMethodBase):
+    """Placeholder for an arbitrary weight-quantized method (layout-agnostic)."""
+
+    def create_weights(self, *args, **kwargs):
+        raise NotImplementedError
+
+    def apply(self, layer, x, bias=None):
+        out = torch.matmul(x, layer.unpacked_weight.t())
+        return out if bias is None else out + bias
+
+
+class _Projection(nn.Module):
+    """Stand-in for QKVParallelLinear. A quantized ``.weight`` access raises,
+    mirroring GPTQ/AWQ packed schemes where that attribute does not exist."""
+
+    def __init__(self, weight, bias, quant_method):
+        super().__init__()
+        self.unpacked_weight = weight
+        self.bias = bias
+        self.quant_method = quant_method
+        self.forward_calls = 0
+
+    @property
+    def weight(self):
+        if not isinstance(self.quant_method, UnquantizedLinearMethod):
+            raise AssertionError("fused precompute must not slice a quantized weight")
+        return self.unpacked_weight
+
+    def forward(self, x):
+        self.forward_calls += 1
+        return self.quant_method.apply(self, x, self.bias), None
+
+
+def _attn(proj):
+    return SimpleNamespace(
+        qkv_proj=proj,
+        q_size=Q_SIZE,
+        kv_size=KV_SIZE,
+        head_dim=HEAD_DIM,
+        num_kv_heads=NUM_KV_HEADS,
+        k_norm=SimpleNamespace(weight=torch.ones(HEAD_DIM)),
+    )
+
+
+def _build_model(quantized: bool, *, seed: int = 0):
+    torch.manual_seed(seed)
+    weights = [_ints(Q_SIZE + 2 * KV_SIZE, HIDDEN) for _ in range(NUM_LAYERS)]
+    method = _PackedLinearMethod() if quantized else UnquantizedLinearMethod()
+    projections = [_Projection(w, None, method) for w in weights]
+    layers_attn = [_attn(p) for p in projections]
+
+    model = object.__new__(DFlashQwen3Model)
+    nn.Module.__init__(model)
+    model.hidden_norm = SimpleNamespace(weight=torch.ones(HIDDEN))
+    model._rms_norm_eps = 1e-6
+    model.compute_dtype = torch.float32
+    model.layers = [
+        SimpleNamespace(input_layernorm=SimpleNamespace(weight=torch.ones(HIDDEN)))
+        for _ in layers_attn
+    ]
+    model._build_context_kv_buffers(layers_attn, has_bias=False)
+    return model, projections
+
+
+def _project(model):
+    return model._project_context_kv(
+        _ints(NUM_CTX, HIDDEN), NUM_CTX, NUM_LAYERS, NUM_KV_HEADS, HEAD_DIM
+    )
+
+
+def test_decide_strategy_unquantized():
+    p = _Projection(_ints(4, 4), None, UnquantizedLinearMethod())
+    assert _decide_context_kv_strategy([p, p]) is ContextKVStrategy.FUSED
+
+
+def test_decide_strategy_quantized_and_mixed():
+    p = _Projection(_ints(4, 4), None, _PackedLinearMethod())
+    u = _Projection(_ints(4, 4), None, UnquantizedLinearMethod())
+    assert _decide_context_kv_strategy([p, p]) is ContextKVStrategy.PER_LAYER
+    # Mixed (one quantized, one not) -> conservative per-layer.
+    assert _decide_context_kv_strategy([u, p]) is ContextKVStrategy.PER_LAYER
+
+
+def _simple_fp8(*, use_marlin=False, block_quant=False, use_deep_gemm=False):
+    """Real ``Fp8LinearMethod`` without running ``__init__`` (needs a config /
+    layer); only the attributes the strategy check reads are set."""
+    m = object.__new__(Fp8LinearMethod)
+    m.use_marlin = use_marlin
+    m.block_quant = block_quant
+    m.use_deep_gemm = use_deep_gemm
+    return m
+
+
+def test_decide_strategy_simple_fp8_gates_on_cutlass(monkeypatch):
+    """Simple FP8 (non-Marlin) -> SCALED_MM when cutlass-fp8 is available,
+    FUSED_DEQUANT otherwise."""
+    from vllm.model_executor.models import qwen3_dflash as mod
+
+    p = _Projection(_ints(4, 4), None, _simple_fp8())
+    monkeypatch.setattr(mod, "cutlass_fp8_supported", lambda: True)
+    assert _decide_context_kv_strategy([p, p]) is ContextKVStrategy.SCALED_MM
+    monkeypatch.setattr(mod, "cutlass_fp8_supported", lambda: False)
+    assert _decide_context_kv_strategy([p, p]) is ContextKVStrategy.FUSED_DEQUANT
+
+
+def test_decide_strategy_deep_gemm_goes_per_layer():
+    """FP8 on a DeepGEMM path transforms its scales -> PER_LAYER."""
+    p = _Projection(_ints(4, 4), None, _simple_fp8(use_deep_gemm=True))
+    assert _decide_context_kv_strategy([p, p]) is ContextKVStrategy.PER_LAYER
+
+
+def test_decide_strategy_marlin_goes_per_layer():
+    """Marlin (weight-only FP8) cannot be fused -> PER_LAYER."""
+    p = _Projection(_ints(4, 4), None, _simple_fp8(use_marlin=True))
+    assert _decide_context_kv_strategy([p, p]) is ContextKVStrategy.PER_LAYER
+
+
+def test_fused_matches_per_layer_unquantized(cpu_rms_norm):
+    """Unquantized: the FUSED fused path and the PER_LAYER path agree
+    bit-for-bit and produce the same [L, num_ctx, nkv, hd] layout."""
+    fused_model, _ = _build_model(False)
+    assert fused_model._kv_strategy is ContextKVStrategy.FUSED
+    per_model, projections = _build_model(True)
+    assert per_model._kv_strategy is ContextKVStrategy.PER_LAYER
+
+    torch.manual_seed(1234)
+    fk, fv = _project(fused_model)
+    torch.manual_seed(1234)
+    pk, pv = _project(per_model)
+
+    assert all(p.forward_calls == 1 for p in projections)
+    for fused, per in ((fk, pk), (fv, pv)):
+        assert fused.shape == per.shape == \
+            (NUM_LAYERS, NUM_CTX, NUM_KV_HEADS, HEAD_DIM)
+        assert torch.equal(fused, per)
+
+
+def test_quantized_projection_is_never_sliced(monkeypatch, cpu_rms_norm):
+    """Regression #51581: packed weights must never reach F.linear."""
+    model, _ = _build_model(True)
+    assert model._kv_strategy is ContextKVStrategy.PER_LAYER
+    assert not hasattr(model, "_fused_kv_weight")
+
+    monkeypatch.setattr(
+        F,
+        "linear",
+        lambda *a, **kw: pytest.fail("F.linear reached a packed weight"),
+    )
+    try:
+        all_k, all_v = _project(model)
+    finally:
+        monkeypatch.undo()
+    assert all_k.shape == (NUM_LAYERS, NUM_CTX, NUM_KV_HEADS, HEAD_DIM)
+    assert all_v.shape == all_k.shape
+
+
+# ---------------------------------------------------------------------------
+# GPU: real FP8 drafter (the issue's reproduction scenario)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_fp8_drafter_precompute(dist_init, default_vllm_config):
+    """Real FP8 QKV projections -> the strategy follows the platform:
+    - Marlin (A100/sm80): PER_LAYER
+    - cutlass-fp8 (sm89+): SCALED_MM
+    - non-Marlin, no cutlass-fp8: FUSED_DEQUANT
+
+    In every case the projected K/V must match the per-layer
+    ``quant_method.apply`` ground truth within quantization tolerance.
+    """
+    from vllm.model_executor.layers.linear import QKVParallelLinear
+    from vllm.model_executor.layers.quantization.fp8 import Fp8Config
+    from vllm.model_executor.layers.quantization.utils.w8a8_utils import (
+        cutlass_fp8_supported,
+    )
+
+    dtype, device = torch.bfloat16, "cuda"
+    quant_config = Fp8Config(
+        is_checkpoint_fp8_serialized=True, activation_scheme="dynamic"
+    )
+
+    def _make_proj():
+        proj = QKVParallelLinear(
+            hidden_size=HIDDEN,
+            head_size=HEAD_DIM,
+            total_num_heads=NUM_HEADS,
+            total_num_kv_heads=NUM_KV_HEADS,
+            bias=False,
+            params_dtype=dtype,
+            quant_config=quant_config,
+        ).to(device)
+        # Fill real fp8 weights + per-shard scales (offline-serialized format).
+        for name, p in proj.named_parameters():
+            if p.dtype == torch.float8_e4m3fn:
+                w = torch.randn(p.shape, dtype=torch.float32, device=device)
+                p.data.copy_(
+                    (w / w.abs().max() * 200).to(torch.float8_e4m3fn))
+        proj.weight_scale.data.copy_(
+            torch.tensor([1e-3, 1e-3, 1e-3], device=device))
+        proj.quant_method.process_weights_after_loading(proj)
+        return proj
+
+    projections = [_make_proj() for _ in range(NUM_LAYERS)]
+    layers_attn = [_attn(p) for p in projections]
+
+    model = object.__new__(DFlashQwen3Model)
+    nn.Module.__init__(model)
+    model.hidden_norm = SimpleNamespace(
+        weight=torch.ones(HIDDEN, device=device, dtype=dtype))
+    model._rms_norm_eps = 1e-6
+    model.compute_dtype = dtype
+    model.layers = [SimpleNamespace() for _ in layers_attn]
+    model._build_context_kv_buffers(layers_attn, has_bias=False)
+
+    use_marlin = any(
+        getattr(p.quant_method, "use_marlin", False) for p in projections
+    )
+    if use_marlin:
+        expected = ContextKVStrategy.PER_LAYER
+    elif cutlass_fp8_supported():
+        expected = ContextKVStrategy.SCALED_MM
+    else:
+        expected = ContextKVStrategy.FUSED_DEQUANT
+    assert model._kv_strategy is expected, model._kv_strategy
+
+    context_states = torch.randn(NUM_CTX, HIDDEN, device=device, dtype=dtype)
+    all_k, all_v = model._project_context_kv(
+        context_states, NUM_CTX, NUM_LAYERS, NUM_KV_HEADS, HEAD_DIM
+    )
+
+    # Per-layer ground truth (goes through quant_method.apply).
+    normed = torch.empty_like(context_states)
+    import vllm._custom_ops as ops
+
+    ops.rms_norm(normed, context_states, model.hidden_norm.weight, 1e-6)
+    per_k = []
+    per_v = []
+    for p in projections:
+        out = p.quant_method.apply(p, normed, bias=None)
+        per_k.append(out[..., Q_SIZE:Q_SIZE + KV_SIZE].view(
+            NUM_CTX, NUM_KV_HEADS, HEAD_DIM))
+        per_v.append(out[..., Q_SIZE + KV_SIZE:].view(
+            NUM_CTX, NUM_KV_HEADS, HEAD_DIM))
+    torch.testing.assert_close(all_k, torch.stack(per_k), rtol=0.02, atol=0.02)
+    torch.testing.assert_close(all_v, torch.stack(per_v), rtol=0.02, atol=0.02)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_fp16_compute_dtype_no_crash(dist_init, default_vllm_config):
+    """P1 regression guard: the fused buffer must use the model dtype
+    (an fp16 engine must not crash)."""
+    from vllm.model_executor.layers.linear import QKVParallelLinear
+
+    def _proj():
+        p = QKVParallelLinear(
+            hidden_size=HIDDEN,
+            head_size=HEAD_DIM,
+            total_num_heads=NUM_HEADS,
+            total_num_kv_heads=NUM_KV_HEADS,
+            bias=False,
+            params_dtype=torch.float16,
+        ).cuda()
+        p.weight.data.normal_(std=0.1)
+        return p
+
+    projections = [_proj() for _ in range(NUM_LAYERS)]
+    layers_attn = [_attn(p) for p in projections]
+    model = object.__new__(DFlashQwen3Model)
+    nn.Module.__init__(model)
+    model.hidden_norm = SimpleNamespace(
+        weight=torch.ones(HIDDEN, device="cuda", dtype=torch.float16))
+    model._rms_norm_eps = 1e-6
+    model.compute_dtype = torch.float16
+    model.layers = [SimpleNamespace() for _ in layers_attn]
+    model._build_context_kv_buffers(layers_attn, has_bias=False)
+
+    assert model._kv_strategy is ContextKVStrategy.FUSED
+    assert model._fused_kv_weight.dtype == torch.float16
+    context_states = torch.randn(
+        NUM_CTX, HIDDEN, device="cuda", dtype=torch.float16
+    )
+    all_k, all_v = model._project_context_kv(
+        context_states, NUM_CTX, NUM_LAYERS, NUM_KV_HEADS, HEAD_DIM
+    )
+    assert all_k.dtype == all_v.dtype == torch.float16

--- a/tests/v1/spec_decode/test_dflash_fusedkv_quantized.py
+++ b/tests/v1/spec_decode/test_dflash_fusedkv_quantized.py
@@ -8,6 +8,7 @@ Pins down:
 - the invariant that packed weights never reach a bare ``F.linear``,
 - the real-FP8 drafter precompute on GPU (per-layer / dequant / scaled_mm).
 """
+
 from types import SimpleNamespace
 
 import pytest
@@ -29,7 +30,7 @@ NUM_HEADS = 4
 NUM_KV_HEADS = 2
 NUM_LAYERS = 3
 NUM_CTX = 5
-Q_SIZE = NUM_HEADS * HEAD_DIM      # 32
+Q_SIZE = NUM_HEADS * HEAD_DIM  # 32
 KV_SIZE = NUM_KV_HEADS * HEAD_DIM  # 16
 
 
@@ -39,8 +40,9 @@ def _cpu_rms_norm(out, input, weight, eps):
     var = input.float().pow(2).mean(-1, keepdim=True)
     normed = (input * (var + eps).rsqrt()).to(input.dtype)
     if weight.ndim == 2 and input.ndim >= 3:
-        weight = weight.reshape(weight.shape[0], *([1] * (input.ndim - 2)),
-                                weight.shape[1])
+        weight = weight.reshape(
+            weight.shape[0], *([1] * (input.ndim - 2)), weight.shape[1]
+        )
     out.copy_(normed * weight)
 
 
@@ -188,8 +190,7 @@ def test_fused_matches_per_layer_unquantized(cpu_rms_norm):
 
     assert all(p.forward_calls == 1 for p in projections)
     for fused, per in ((fk, pk), (fv, pv)):
-        assert fused.shape == per.shape == \
-            (NUM_LAYERS, NUM_CTX, NUM_KV_HEADS, HEAD_DIM)
+        assert fused.shape == per.shape == (NUM_LAYERS, NUM_CTX, NUM_KV_HEADS, HEAD_DIM)
         assert torch.equal(fused, per)
 
 
@@ -215,6 +216,7 @@ def test_quantized_projection_is_never_sliced(monkeypatch, cpu_rms_norm):
 # ---------------------------------------------------------------------------
 # GPU: real FP8 drafter (the issue's reproduction scenario)
 # ---------------------------------------------------------------------------
+
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
 def test_fp8_drafter_precompute(dist_init, default_vllm_config):
@@ -251,10 +253,8 @@ def test_fp8_drafter_precompute(dist_init, default_vllm_config):
         for name, p in proj.named_parameters():
             if p.dtype == torch.float8_e4m3fn:
                 w = torch.randn(p.shape, dtype=torch.float32, device=device)
-                p.data.copy_(
-                    (w / w.abs().max() * 200).to(torch.float8_e4m3fn))
-        proj.weight_scale.data.copy_(
-            torch.tensor([1e-3, 1e-3, 1e-3], device=device))
+                p.data.copy_((w / w.abs().max() * 200).to(torch.float8_e4m3fn))
+        proj.weight_scale.data.copy_(torch.tensor([1e-3, 1e-3, 1e-3], device=device))
         proj.quant_method.process_weights_after_loading(proj)
         return proj
 
@@ -264,15 +264,14 @@ def test_fp8_drafter_precompute(dist_init, default_vllm_config):
     model = object.__new__(DFlashQwen3Model)
     nn.Module.__init__(model)
     model.hidden_norm = SimpleNamespace(
-        weight=torch.ones(HIDDEN, device=device, dtype=dtype))
+        weight=torch.ones(HIDDEN, device=device, dtype=dtype)
+    )
     model._rms_norm_eps = 1e-6
     model.compute_dtype = dtype
     model.layers = [SimpleNamespace() for _ in layers_attn]
     model._build_context_kv_buffers(layers_attn, has_bias=False)
 
-    use_marlin = any(
-        getattr(p.quant_method, "use_marlin", False) for p in projections
-    )
+    use_marlin = any(getattr(p.quant_method, "use_marlin", False) for p in projections)
     if use_marlin:
         expected = ContextKVStrategy.PER_LAYER
     elif cutlass_fp8_supported():
@@ -295,10 +294,10 @@ def test_fp8_drafter_precompute(dist_init, default_vllm_config):
     per_v = []
     for p in projections:
         out = p.quant_method.apply(p, normed, bias=None)
-        per_k.append(out[..., Q_SIZE:Q_SIZE + KV_SIZE].view(
-            NUM_CTX, NUM_KV_HEADS, HEAD_DIM))
-        per_v.append(out[..., Q_SIZE + KV_SIZE:].view(
-            NUM_CTX, NUM_KV_HEADS, HEAD_DIM))
+        per_k.append(
+            out[..., Q_SIZE : Q_SIZE + KV_SIZE].view(NUM_CTX, NUM_KV_HEADS, HEAD_DIM)
+        )
+        per_v.append(out[..., Q_SIZE + KV_SIZE :].view(NUM_CTX, NUM_KV_HEADS, HEAD_DIM))
     torch.testing.assert_close(all_k, torch.stack(per_k), rtol=0.02, atol=0.02)
     torch.testing.assert_close(all_v, torch.stack(per_v), rtol=0.02, atol=0.02)
 
@@ -326,7 +325,8 @@ def test_fp16_compute_dtype_no_crash(dist_init, default_vllm_config):
     model = object.__new__(DFlashQwen3Model)
     nn.Module.__init__(model)
     model.hidden_norm = SimpleNamespace(
-        weight=torch.ones(HIDDEN, device="cuda", dtype=torch.float16))
+        weight=torch.ones(HIDDEN, device="cuda", dtype=torch.float16)
+    )
     model._rms_norm_eps = 1e-6
     model.compute_dtype = torch.float16
     model.layers = [SimpleNamespace() for _ in layers_attn]
@@ -334,9 +334,7 @@ def test_fp16_compute_dtype_no_crash(dist_init, default_vllm_config):
 
     assert model._kv_strategy is ContextKVStrategy.FUSED
     assert model._fused_kv_weight.dtype == torch.float16
-    context_states = torch.randn(
-        NUM_CTX, HIDDEN, device="cuda", dtype=torch.float16
-    )
+    context_states = torch.randn(NUM_CTX, HIDDEN, device="cuda", dtype=torch.float16)
     all_k, all_v = model._project_context_kv(
         context_states, NUM_CTX, NUM_LAYERS, NUM_KV_HEADS, HEAD_DIM
     )

--- a/vllm/model_executor/models/gemma4_dspark.py
+++ b/vllm/model_executor/models/gemma4_dspark.py
@@ -336,7 +336,6 @@ class Gemma4DSparkForCausalLM(Qwen3DSparkForCausalLM):
                     p = params[name]
                     getattr(p, "weight_loader", default_weight_loader)(p, w)
                     loaded.add(name)
-        # The fused-KV buffers are built lazily on first use (after the loader
-        # has called ``process_weights_after_loading``), so quantized weights
+        # Fused-KV buffers are built lazily on first use so quantized weights
         # are in their final layout.
         return loaded

--- a/vllm/model_executor/models/gemma4_dspark.py
+++ b/vllm/model_executor/models/gemma4_dspark.py
@@ -23,7 +23,13 @@ from vllm.model_executor.model_loader.weight_utils import default_weight_loader
 from vllm.transformers_utils.configs.gemma4 import gemma4_layer_config
 
 from .gemma4_mtp import Gemma4MTPAttention, Gemma4MTPDecoderLayer
-from .qwen3_dflash import DFlashQwen3Model, _dflash_layer_causal
+from .qwen3_dflash import (
+    ContextKVStrategy,
+    DFlashQwen3Model,
+    _dflash_layer_causal,
+    _decide_context_kv_strategy,
+    _project_kv_per_layer,
+)
 from .qwen3_dspark import DSparkMarkovHead, Qwen3DSparkForCausalLM
 from .utils import extract_layer_index, maybe_prefix
 
@@ -212,10 +218,24 @@ class Gemma4DSparkModel(DFlashQwen3Model):
         self, layers_attn: list[nn.Module], has_bias: bool
     ) -> None:
         self._hidden_norm_weight = self.hidden_norm.weight.data
-        self._fused_k_weight = torch.cat([a.k_proj.weight for a in layers_attn], dim=0)
-        self._fused_k_bias: torch.Tensor | None = (
-            torch.cat([a.k_proj.bias for a in layers_attn], dim=0) if has_bias else None
+        # Two tiers: FUSED (all unquantized -> fused F.linear) or PER_LAYER
+        # (any quantized scheme -> per-layer quantized k_proj projection).
+        self._fuse_context_kv = (
+            _decide_context_kv_strategy((a.k_proj for a in layers_attn))
+            == ContextKVStrategy.FUSED
         )
+        if self._fuse_context_kv:
+            self._fused_k_weight = torch.cat(
+                [a.k_proj.weight for a in layers_attn], dim=0
+            )
+            self._fused_k_bias: torch.Tensor | None = (
+                torch.cat([a.k_proj.bias for a in layers_attn], dim=0)
+                if has_bias
+                else None
+            )
+        else:
+            self._k_projections = [a.k_proj for a in layers_attn]
+            self._fused_k_bias = None
         self._k_norm_weights = torch.stack(
             [a.k_norm.weight.data for a in layers_attn], dim=0
         ).contiguous()
@@ -241,7 +261,13 @@ class Gemma4DSparkModel(DFlashQwen3Model):
         ops.rms_norm(
             normed, context_states, self._hidden_norm_weight, self._rms_norm_eps
         )
-        all_k_flat = F.linear(normed, self._fused_k_weight, self._fused_k_bias)
+        if self._fuse_context_kv:
+            all_k_flat = F.linear(normed, self._fused_k_weight, self._fused_k_bias)
+        else:
+            # Per-layer quantized k_proj projection (k_eq_v: K == V source).
+            all_k_flat = _project_kv_per_layer(
+                normed, [(p, None) for p in self._k_projections]
+            )
         all_k = (
             all_k_flat.view(num_ctx, num_layers, num_kv_heads, head_dim)
             .permute(1, 0, 2, 3)
@@ -310,5 +336,7 @@ class Gemma4DSparkForCausalLM(Qwen3DSparkForCausalLM):
                     p = params[name]
                     getattr(p, "weight_loader", default_weight_loader)(p, w)
                     loaded.add(name)
-        self.model._build_fused_kv_buffers()
+        # The fused-KV buffers are built lazily on first use (after the loader
+        # has called ``process_weights_after_loading``), so quantized weights
+        # are in their final layout.
         return loaded

--- a/vllm/model_executor/models/gemma4_dspark.py
+++ b/vllm/model_executor/models/gemma4_dspark.py
@@ -26,8 +26,8 @@ from .gemma4_mtp import Gemma4MTPAttention, Gemma4MTPDecoderLayer
 from .qwen3_dflash import (
     ContextKVStrategy,
     DFlashQwen3Model,
-    _dflash_layer_causal,
     _decide_context_kv_strategy,
+    _dflash_layer_causal,
     _project_kv_per_layer,
 )
 from .qwen3_dspark import DSparkMarkovHead, Qwen3DSparkForCausalLM
@@ -221,7 +221,7 @@ class Gemma4DSparkModel(DFlashQwen3Model):
         # Two tiers: FUSED (all unquantized -> fused F.linear) or PER_LAYER
         # (any quantized scheme -> per-layer quantized k_proj projection).
         self._fuse_context_kv = (
-            _decide_context_kv_strategy((a.k_proj for a in layers_attn))
+            _decide_context_kv_strategy(a.k_proj for a in layers_attn)
             == ContextKVStrategy.FUSED
         )
         if self._fuse_context_kv:

--- a/vllm/model_executor/models/laguna_dflash.py
+++ b/vllm/model_executor/models/laguna_dflash.py
@@ -165,9 +165,7 @@ class DFlashLagunaModel(DFlashQwen3Model, EagleModelMixin):
         # Two tiers: FUSED (all unquantized -> stacked bmm) or PER_LAYER
         # (any quantized scheme -> per-layer quantized projection).
         self._fuse_context_kv = (
-            _decide_context_kv_strategy(
-                (a.qkv_proj for a in layers_attn)
-            )
+            _decide_context_kv_strategy(a.qkv_proj for a in layers_attn)
             == ContextKVStrategy.FUSED
         )
         if self._fuse_context_kv:

--- a/vllm/model_executor/models/laguna_dflash.py
+++ b/vllm/model_executor/models/laguna_dflash.py
@@ -346,7 +346,6 @@ class DFlashLagunaForCausalLM(nn.Module, SupportsEagle3):
         loaded_weight_names = loader.load_weights(model_weights.items())
         loaded_weight_names.add("lm_head.weight")
         loaded_weight_names.add("model.embed_tokens.weight")
-        # The fused-KV buffers are built lazily on first use (after the loader
-        # has called ``process_weights_after_loading``), so quantized weights
+        # Fused-KV buffers are built lazily on first use so quantized weights
         # are in their final layout.
         return loaded_weight_names

--- a/vllm/model_executor/models/laguna_dflash.py
+++ b/vllm/model_executor/models/laguna_dflash.py
@@ -31,7 +31,12 @@ from vllm.model_executor.models.interfaces import EagleModelMixin, SupportsEagle
 from vllm.multimodal.inputs import NestedTensors
 
 from .laguna import LagunaDecoderLayer
-from .qwen3_dflash import DFlashQwen3Model
+from .qwen3_dflash import (
+    ContextKVStrategy,
+    DFlashQwen3Model,
+    _decide_context_kv_strategy,
+    _project_kv_per_layer,
+)
 from .utils import (
     AutoWeightsLoader,
     get_draft_quant_config,
@@ -157,14 +162,26 @@ class DFlashLagunaModel(DFlashQwen3Model, EagleModelMixin):
         layers_attn: list[nn.Module],
         has_bias: bool,
     ) -> None:
-        self._kv_weights = torch.stack(
-            [a.qkv_proj.weight[a.q_size :] for a in layers_attn], dim=0
-        ).contiguous()
-        if has_bias:
-            self._kv_biases: torch.Tensor | None = torch.stack(
-                [a.qkv_proj.bias[a.q_size :] for a in layers_attn], dim=0
+        # Two tiers: FUSED (all unquantized -> stacked bmm) or PER_LAYER
+        # (any quantized scheme -> per-layer quantized projection).
+        self._fuse_context_kv = (
+            _decide_context_kv_strategy(
+                (a.qkv_proj for a in layers_attn)
+            )
+            == ContextKVStrategy.FUSED
+        )
+        if self._fuse_context_kv:
+            self._kv_weights = torch.stack(
+                [a.qkv_proj.weight[a.q_size :] for a in layers_attn], dim=0
             ).contiguous()
+            if has_bias:
+                self._kv_biases: torch.Tensor | None = torch.stack(
+                    [a.qkv_proj.bias[a.q_size :] for a in layers_attn], dim=0
+                ).contiguous()
+            else:
+                self._kv_biases = None
         else:
+            self._kv_projections = [(a.qkv_proj, a.q_size) for a in layers_attn]
             self._kv_biases = None
         self._input_layernorm_weights = torch.stack(
             [layer.input_layernorm.weight.data for layer in self.layers], dim=0
@@ -192,12 +209,21 @@ class DFlashLagunaModel(DFlashQwen3Model, EagleModelMixin):
             self._input_layernorm_weights,
             self._rms_norm_eps,
         )
-        all_kv_flat = torch.bmm(
-            normed_context_states,
-            self._kv_weights.transpose(1, 2),
-        )
-        if self._kv_biases is not None:
-            all_kv_flat += self._kv_biases[:, None, :]
+        if self._fuse_context_kv:
+            all_kv_flat = torch.bmm(
+                normed_context_states,
+                self._kv_weights.transpose(1, 2),
+            )
+            if self._kv_biases is not None:
+                all_kv_flat += self._kv_biases[:, None, :]
+        else:
+            # Per-layer quantized projection; each layer uses its own normed input.
+            all_kv_flat = _project_kv_per_layer(
+                normed_context_states,
+                self._kv_projections,
+                per_layer_input=True,
+                stack=True,
+            )
         all_kv = (
             all_kv_flat.view(num_layers, num_ctx, 2, num_kv_heads, head_dim)
             .permute(2, 0, 1, 3, 4)
@@ -206,16 +232,6 @@ class DFlashLagunaModel(DFlashQwen3Model, EagleModelMixin):
         all_k = all_kv[0]
         all_v = all_kv[1]
         return all_k, all_v
-
-    def _normalize_context_k(self, all_k: torch.Tensor) -> torch.Tensor:
-        all_k_normed = torch.empty_like(all_k)
-        ops.rms_norm(
-            all_k_normed,
-            all_k,
-            self._k_norm_weights,
-            self._rms_norm_eps,
-        )
-        return all_k_normed
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
         if self.quant_config is not None:
@@ -332,5 +348,7 @@ class DFlashLagunaForCausalLM(nn.Module, SupportsEagle3):
         loaded_weight_names = loader.load_weights(model_weights.items())
         loaded_weight_names.add("lm_head.weight")
         loaded_weight_names.add("model.embed_tokens.weight")
-        self.model._build_fused_kv_buffers()
+        # The fused-KV buffers are built lazily on first use (after the loader
+        # has called ``process_weights_after_loading``), so quantized weights
+        # are in their final layout.
         return loaded_weight_names

--- a/vllm/model_executor/models/qwen3_dflash.py
+++ b/vllm/model_executor/models/qwen3_dflash.py
@@ -612,9 +612,7 @@ class DFlashQwen3Model(nn.Module):
                     [a.qkv_proj.bias[a.q_size :] for a in layers_attn], dim=0
                 )
         elif self._kv_strategy == ContextKVStrategy.FUSED_DEQUANT:
-            # Dequant to the compute dtype, keep the fused F.linear. The buffers
-            # are built lazily on first use (after ``process_weights_after_loading``),
-            # so quantized weights are in their final layout.
+            # Dequant to the compute dtype, keep the fused F.linear.
             kv_weights = [
                 get_and_maybe_dequant_weights(p, out_dtype=self.compute_dtype)[
                     a.q_size :
@@ -797,9 +795,6 @@ class DFlashQwen3Model(nn.Module):
         the computation runs, and no K/V is written to cache.
         """
         if not hasattr(self, "_num_attn_layers"):
-            # Build the fused-KV buffers on first use.  This runs after the
-            # loader has called ``process_weights_after_loading``, so quantized
-            # weights are in their final layout.
             self._build_fused_kv_buffers()
 
         num_ctx = context_states.shape[0]

--- a/vllm/model_executor/models/qwen3_dflash.py
+++ b/vllm/model_executor/models/qwen3_dflash.py
@@ -518,9 +518,7 @@ class DFlashQwen3Model(nn.Module):
         self.vocab_size = self.config.vocab_size
         self.quant_config = get_draft_quant_config(vllm_config)
         # Compute dtype for the fused-KV path (dequant / scaled_mm).
-        self.compute_dtype = getattr(
-            vllm_config.model_config, "dtype", torch.bfloat16
-        )
+        self.compute_dtype = getattr(vllm_config.model_config, "dtype", torch.bfloat16)
 
         drafter_config = getattr(self.config, "eagle_config", {})
         drafter_config.update(getattr(self.config, "dflash_config", {}))

--- a/vllm/model_executor/models/qwen3_dflash.py
+++ b/vllm/model_executor/models/qwen3_dflash.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import enum
 import io
 from collections.abc import Iterable
 
@@ -23,9 +24,20 @@ from vllm.model_executor.layers.linear import (
     QKVParallelLinear,
     ReplicatedLinear,
     RowParallelLinear,
+    UnquantizedLinearMethod,
 )
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
 from vllm.model_executor.layers.quantization.base_config import QuantizationConfig
+from vllm.model_executor.layers.quantization.fp8 import Fp8LinearMethod
+from vllm.model_executor.layers.quantization.online.fp8 import (
+    Fp8PerTensorOnlineLinearMethod,
+)
+from vllm.model_executor.layers.quantization.utils.quant_utils import (
+    get_and_maybe_dequant_weights,
+)
+from vllm.model_executor.layers.quantization.utils.w8a8_utils import (
+    cutlass_fp8_supported,
+)
 from vllm.model_executor.layers.rotary_embedding import get_rope
 from vllm.model_executor.layers.vocab_parallel_embedding import (
     ParallelLMHead,
@@ -84,6 +96,123 @@ def _get_dflash_fc_input_size(vllm_config: VllmConfig) -> int:
         getattr(config, "target_hidden_size", None) or config.hidden_size
     )
     return target_hidden_size * num_features_to_use
+
+
+class ContextKVStrategy(str, enum.Enum):
+    """DFlash context-KV projection strategy (quantized-drafter support).
+
+    ``precompute_and_store_context_kv`` projects the target hidden states to
+    K/V with every drafter layer. For unquantized drafters this is a single
+    fused GEMM over the raw K/V rows. Quantized drafters cannot feed their
+    packed weights to a bare ``F.linear`` (see #51581); we pick a strategy
+    from the layers' ``quant_method`` metadata before ever touching ``.weight``
+    and build the fused buffers lazily after ``process_weights_after_loading``.
+
+    - FUSED:          all layers unquantized -> slice raw weights + one F.linear
+    - SCALED_MM:      simple FP8 (non-Marlin) on a cutlass-fp8 platform -> keep
+                      the quantized weights + per-column scales + one fused
+                      W8A8 GEMM (fusion and quantization both preserved)
+    - FUSED_DEQUANT:  simple FP8 but no quantized-GEMM primitive -> dequant to
+                      the compute dtype + one fused F.linear (fusion preserved)
+    - PER_LAYER:      grouped-int4/NVFP4/MXFP4/Marlin/unknown -> per-layer
+                      ``quant_method.apply`` (correct for every scheme, keeps
+                      the per-layer quantization)
+    """
+
+    FUSED = "fused"
+    SCALED_MM = "scaled_mm"
+    FUSED_DEQUANT = "dequant"
+    PER_LAYER = "per_layer"
+
+
+def _is_simple_fusable(proj: nn.Module) -> bool:
+    """Simple FP8 per-tensor/per-channel (non-Marlin, non-block, non-DeepGEMM).
+
+    Mirrors the schemes ``get_and_maybe_dequant_weights`` (quant_utils) can
+    dequantize into a plain ``[out, in]`` bf16 weight with a per-output-column
+    scale, so a fused buffer is only built when the dequant / W8A8 primitive
+    exists. Grouped(int4)/block(NVFP4/MXFP4)/Marlin scales cannot be folded and
+    must go through the per-layer path.
+    """
+    method = getattr(proj, "quant_method", None)
+    if method is None or isinstance(method, UnquantizedLinearMethod):
+        return True
+    if not isinstance(method, (Fp8LinearMethod, Fp8PerTensorOnlineLinearMethod)):
+        return False
+    return not (
+        getattr(method, "use_marlin", False)
+        or getattr(method, "block_quant", False)
+        or getattr(method, "use_deep_gemm", False)
+    )
+
+
+def _decide_context_kv_strategy(
+    projections: Iterable[nn.Module],
+) -> ContextKVStrategy:
+    """Pick the context-KV projection strategy.
+
+    Never touches ``.weight``, so packed/GPTQ/AWQ layers are safe to inspect.
+    """
+    projections = list(projections)
+    methods = [getattr(p, "quant_method", None) for p in projections]
+
+    # Unquantized: original fast path (zero change).
+    if all(m is None or isinstance(m, UnquantizedLinearMethod) for m in methods):
+        return ContextKVStrategy.FUSED
+
+    # Simple FP8: prefer a fused quantized GEMM; fall back to a fused dequant.
+    if all(_is_simple_fusable(p) for p in projections):
+        if cutlass_fp8_supported():
+            return ContextKVStrategy.SCALED_MM
+        return ContextKVStrategy.FUSED_DEQUANT
+
+    # Grouped/block/Marlin/mixed/unknown: per-layer quantized GEMMs.
+    return ContextKVStrategy.PER_LAYER
+
+
+def _kv_scale_vector(proj: nn.Module, q_size: int, kv_size: int) -> torch.Tensor:
+    """Per-output-row scale of the K/V rows of a quantized QKV projection
+    (``[2 * kv_size]``).
+
+    - per-tensor (1 or 3 scales): broadcast over the K/V rows
+    - per-channel: slice the K/V rows
+    """
+    s = getattr(proj, "weight_scale", None)
+    if s is None:
+        return torch.ones(2 * kv_size, device=proj.weight.device)
+    s = s.reshape(-1)
+    if s.numel() == 1:
+        return s[0].expand(2 * kv_size)
+    if s.numel() == 3:  # per-shard per-tensor scales: [q, k, v]
+        return torch.cat([s[1].expand(kv_size), s[2].expand(kv_size)])
+    return s[q_size:]  # per-channel: K/V rows
+
+
+def _project_kv_per_layer(
+    normed: torch.Tensor,
+    kv_projections: Iterable[tuple[nn.Module, int | None]],
+    *,
+    per_layer_input: bool = False,
+    stack: bool = False,
+) -> torch.Tensor:
+    """Per-layer quantized K/V projection (correct for every quant scheme).
+
+    ``kv_projections`` maps each layer to ``(projection, q_size)``; ``q_size``
+    is the number of Q rows/columns to drop, or ``None`` for K-only projections
+    that have no Q rows. ``per_layer_input=True`` feeds each layer its own slice
+    of a layer-major (grouped) input (laguna); otherwise all layers share
+    ``normed``. ``stack=True`` keeps the layer axis (laguna bmm path), otherwise
+    layers are concatenated along the feature axis (qwen3 / gemma4 layouts).
+    Each projection's bias is applied here (packed kernels return it separately).
+    """
+    outs = []
+    for i, (proj, q_size) in enumerate(kv_projections):
+        src = normed[i] if per_layer_input else normed
+        out, bias = proj(src)
+        if bias is not None:
+            out = out + bias
+        outs.append(out if q_size is None else out[..., q_size:])
+    return torch.stack(outs, dim=0) if stack else torch.cat(outs, dim=-1)
 
 
 def _resolve_layer_attention(
@@ -388,6 +517,10 @@ class DFlashQwen3Model(nn.Module):
         self.config = vllm_config.speculative_config.draft_model_config.hf_config
         self.vocab_size = self.config.vocab_size
         self.quant_config = get_draft_quant_config(vllm_config)
+        # Compute dtype for the fused-KV path (dequant / scaled_mm).
+        self.compute_dtype = getattr(
+            vllm_config.model_config, "dtype", torch.bfloat16
+        )
 
         drafter_config = getattr(self.config, "eagle_config", {})
         drafter_config.update(getattr(self.config, "dflash_config", {}))
@@ -468,14 +601,54 @@ class DFlashQwen3Model(nn.Module):
     ) -> None:
         self._hidden_norm_weight = self.hidden_norm.weight.data
 
-        # KV projection weights: [num_layers * 2 * kv_size, hidden_size]
-        kv_weights = [a.qkv_proj.weight[a.q_size :] for a in layers_attn]
-        self._fused_kv_weight = torch.cat(kv_weights, dim=0)
-        if has_bias:
-            kv_biases = [a.qkv_proj.bias[a.q_size :] for a in layers_attn]
-            self._fused_kv_bias: torch.Tensor | None = torch.cat(kv_biases, dim=0)
-        else:
-            self._fused_kv_bias = None
+        projections = [a.qkv_proj for a in layers_attn]
+        self._kv_strategy = _decide_context_kv_strategy(projections)
+        self._fused_kv_bias: torch.Tensor | None = None
+
+        if self._kv_strategy == ContextKVStrategy.FUSED:
+            # Unquantized: original fused fast path (zero change).
+            kv_weights = [a.qkv_proj.weight[a.q_size :] for a in layers_attn]
+            self._fused_kv_weight = torch.cat(kv_weights, dim=0)
+            if has_bias:
+                self._fused_kv_bias = torch.cat(
+                    [a.qkv_proj.bias[a.q_size :] for a in layers_attn], dim=0
+                )
+        elif self._kv_strategy == ContextKVStrategy.FUSED_DEQUANT:
+            # Dequant to the compute dtype, keep the fused F.linear. The buffers
+            # are built lazily on first use (after ``process_weights_after_loading``),
+            # so quantized weights are in their final layout.
+            kv_weights = [
+                get_and_maybe_dequant_weights(p, out_dtype=self.compute_dtype)[
+                    a.q_size :
+                ]
+                for p, a in zip(projections, layers_attn)
+            ]
+            self._fused_kv_weight = torch.cat(kv_weights, dim=0)
+            if has_bias:
+                self._fused_kv_bias = torch.cat(
+                    [a.qkv_proj.bias[a.q_size :] for a in layers_attn], dim=0
+                )
+        elif self._kv_strategy == ContextKVStrategy.SCALED_MM:
+            # Keep the quantized weights. After ``process_weights_after_loading``
+            # the cutlass-fp8 path stores the weight in [K, N] layout, so slice
+            # the K/V output COLUMNS and concatenate along N -> one fused W8A8 GEMM.
+            self._fused_kv_weight = torch.cat(
+                [p.weight[:, a.q_size :] for p, a in zip(projections, layers_attn)],
+                dim=1,
+            )
+            self._fused_kv_scale = torch.cat(
+                [
+                    _kv_scale_vector(p, a.q_size, a.kv_size)
+                    for p, a in zip(projections, layers_attn)
+                ],
+                dim=0,
+            ).unsqueeze(0)  # [1, L * 2 * kv_size] per-column
+            if has_bias:
+                self._fused_kv_bias = torch.cat(
+                    [a.qkv_proj.bias[a.q_size :] for a in layers_attn], dim=0
+                )
+        else:  # PER_LAYER
+            self._kv_projections = [(a.qkv_proj, a.q_size) for a in layers_attn]
 
         # K-norm weights stacked into one contiguous [num_layers, head_dim]
         # tensor so the per-layer K-norm runs as a single grouped kernel.
@@ -534,7 +707,7 @@ class DFlashQwen3Model(nn.Module):
         num_kv_heads: int,
         head_dim: int,
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        # --- Fused KV projection (one GEMM for all layers) ---
+        # --- KV projection (one fused GEMM for all layers when possible) ---
         normed_context_states = torch.empty_like(context_states)
         ops.rms_norm(
             normed_context_states,
@@ -542,9 +715,16 @@ class DFlashQwen3Model(nn.Module):
             self._hidden_norm_weight,
             self._rms_norm_eps,
         )
-        all_kv_flat = F.linear(
-            normed_context_states, self._fused_kv_weight, self._fused_kv_bias
-        )
+
+        if self._kv_strategy == ContextKVStrategy.SCALED_MM:
+            all_kv_flat = self._project_context_kv_scaled(normed_context_states)
+        elif self._kv_strategy == ContextKVStrategy.PER_LAYER:
+            all_kv_flat = self._project_context_kv_per_layer(normed_context_states)
+        else:  # FUSED / FUSED_DEQUANT
+            all_kv_flat = F.linear(
+                normed_context_states, self._fused_kv_weight, self._fused_kv_bias
+            )
+
         # Single contiguous copy that separates K/V and transposes to
         # layer-major layout.  Result: [2, L, num_ctx, nkv, hd] contiguous.
         # Indexing dim-0 gives contiguous [L, num_ctx, nkv, hd] for K and V.
@@ -556,6 +736,37 @@ class DFlashQwen3Model(nn.Module):
         all_k = all_kv[0]  # [L, num_ctx, nkv, hd], contiguous
         all_v = all_kv[1]  # [L, num_ctx, nkv, hd], contiguous
         return all_k, all_v
+
+    def _project_context_kv_scaled(self, normed: torch.Tensor) -> torch.Tensor:
+        """Fused W8A8 projection: dynamic FP8 activation + one cutlass_scaled_mm.
+
+        Weight is stored in [K, N] (cutlass layout); ``_fused_kv_scale`` is the
+        per-output-column (K/V row) scale vector."""
+        x_q, scale_a = ops.scaled_fp8_quant(
+            normed, scale=None, use_per_token_if_dynamic=True
+        )
+        out_dtype = (
+            normed.dtype
+            if normed.dtype in (torch.bfloat16, torch.float16)
+            else torch.bfloat16
+        )
+        return ops.cutlass_scaled_mm(
+            x_q,
+            self._fused_kv_weight,
+            scale_a,
+            self._fused_kv_scale,
+            out_dtype,
+            self._fused_kv_bias,
+        )
+
+    def _project_context_kv_per_layer(self, normed: torch.Tensor) -> torch.Tensor:
+        """Per-layer quantized projection; output layout matches the fused path
+        (``[num_ctx, L * 2 * kv_size]``).
+
+        Q rows are projected and discarded (packed kernels cannot compute only
+        the K/V rows); each layer's bias is applied in its module.
+        """
+        return _project_kv_per_layer(normed, self._kv_projections)
 
     def _normalize_context_k(self, all_k: torch.Tensor) -> torch.Tensor:
         # --- Grouped RMSNorm K across all layers ([L, num_ctx, nkv, hd]) ---
@@ -588,10 +799,9 @@ class DFlashQwen3Model(nn.Module):
         the computation runs, and no K/V is written to cache.
         """
         if not hasattr(self, "_num_attn_layers"):
-            logger.warning_once(
-                "DFlash buffer initialization was skipped. If dummy weights are not "
-                "in use, this may indicate an error in weight loading."
-            )
+            # Build the fused-KV buffers on first use.  This runs after the
+            # loader has called ``process_weights_after_loading``, so quantized
+            # weights are in their final layout.
             self._build_fused_kv_buffers()
 
         num_ctx = context_states.shape[0]
@@ -834,7 +1044,12 @@ class DFlashQwen3ForCausalLM(Qwen3ForCausalLM):
         mapper = WeightsMapper(orig_to_new_substr=orig_to_new_substr)
         loader = AutoWeightsLoader(self)
         loader.load_weights(model_weights.items(), mapper=mapper)
-        self.model._build_fused_kv_buffers()
+        # NOTE: fused-KV buffers are intentionally NOT built here. They are
+        # built lazily on first use in ``precompute_and_store_context_kv``,
+        # after the loader has run ``process_weights_after_loading`` on every
+        # layer, so that ``get_and_maybe_dequant_weights`` sees quantized
+        # weights in their final layout (required for the fused-KV path to
+        # support quantized drafters).
 
     def _read_mask_embedding(self) -> torch.Tensor | None:
         """Checks for an override mask embedding in `mask_embedding.pt` and returns it.

--- a/vllm/model_executor/models/qwen3_dspark.py
+++ b/vllm/model_executor/models/qwen3_dspark.py
@@ -364,4 +364,6 @@ class Qwen3DSparkForCausalLM(DFlashQwen3ForCausalLM):
         mapper = WeightsMapper(orig_to_new_substr=orig_to_new_substr)
         loader = AutoWeightsLoader(self)
         loader.load_weights(model_weights.items(), mapper=mapper)
-        self.model._build_fused_kv_buffers()
+        # The fused-KV buffers are built lazily on first use (after the loader
+        # has called ``process_weights_after_loading``), so quantized weights
+        # are in their final layout.

--- a/vllm/model_executor/models/qwen3_dspark.py
+++ b/vllm/model_executor/models/qwen3_dspark.py
@@ -364,6 +364,5 @@ class Qwen3DSparkForCausalLM(DFlashQwen3ForCausalLM):
         mapper = WeightsMapper(orig_to_new_substr=orig_to_new_substr)
         loader = AutoWeightsLoader(self)
         loader.load_weights(model_weights.items(), mapper=mapper)
-        # The fused-KV buffers are built lazily on first use (after the loader
-        # has called ``process_weights_after_loading``), so quantized weights
+        # Fused-KV buffers are built lazily on first use so quantized weights
         # are in their final layout.


### PR DESCRIPTION
## Purpose

Fixes #51581 (competing drafts #51620 / #53122 do not cover quantized drafters).

DFlash-family speculative decoding crashes at engine init when the drafter is quantized.
The DFlash fused-KV path sliced the raw `.weight` of the KV projections and fed it to a
single fused GEMM, bypassing the quant method. This PR reworks the fused context-KV
precompute into a tiered strategy:

| tier | when | behavior |
|---|---|---|
| `FUSED` | unquantized drafters | fuse qkv weights as before (fastest, unchanged) |
| `SCALED_MM` | per-tensor FP8 with cutlass fp8 | keep weights quantized, fuse per-output-row scales, run `cutlass_scaled_mm` |
| `FUSED_DEQUANT` | per-tensor FP8 without cutlass fp8 | dequant once into a fused bf16 weight at build time |
| `PER_LAYER` | anything else (marlin / block-quant / mixed) | project per layer and concat (always correct) |

The fused buffers are now built lazily at the first precompute (after
`process_weights_after_loading`), so quantized layers are handled after their scales
exist.

## Changes

- `vllm/model_executor/models/qwen3_dflash.py` (main rework, +225/-17)
- `vllm/model_executor/models/laguna_dflash.py`
- `vllm/model_executor/models/gemma4_dspark.py`
- `vllm/model_executor/models/qwen3_dspark.py`
- `tests/v1/spec_decode/test_dflash_fusedkv_quantized.py` (new, +341)

## Test Plan

```bash
pytest tests/v1/spec_decode/test_dflash_fusedkv_quantized.py -v
# plus an end-to-end serve with a quantized DFlash drafter:
vllm serve <model> --speculative-config '{"model": "<quantized-drafter>", ...}'
```

## Test Result

<!-- TODO: paste the new-test output and the e2e serve log (init succeeds, outputs match non-spec decode) -->

## Notes

- Rebased onto latest `main` (previously `needs-rebase`).
- Unquantized drafters keep the original fused path — no perf change there.
- AI-assisted; reviewed by me. DCO `Signed-off-by:` present.