### PR TITLE
[Bugfix][Kernel] Take a native fp8 KV cache in TRITON_MLA, and fold the non-causal decode

### DIFF
--- a/tests/kernels/attention/test_triton_decode_attention.py
+++ b/tests/kernels/attention/test_triton_decode_attention.py
@@ -6,7 +6,11 @@ import torch
 
 from vllm.platforms import current_platform
 from vllm.utils.math_utils import cdiv
-from vllm.v1.attention.ops.triton_decode_attention import decode_attention_fwd
+from vllm.v1.attention.ops.triton_decode_attention import (
+    decode_attention_fwd,
+    stage1_block_h,
+    stage1_head_tiles,
+)
 
 DEVICE_TYPE = current_platform.device_type
 
@@ -323,3 +327,117 @@ def test_decode_attention_cross_layer_view(H_Q, H_KV, D_QK, D_V, is_mla, PAGE_SI
     # Same data and same compute order; only addressing differs.
     assert torch.equal(o_ref, o_xl)
     assert torch.equal(lse_ref, lse_xl)
+
+
+def _reference_mla_decode(q, kv, req_to_page, seq_len, sm_scale, d_v, page_size):
+    """Plain-PyTorch MLA decode. v is the leading d_v dims of the same latent."""
+    B, H, _ = q.shape
+    d_qk = kv.shape[-1]
+    kv_flat = kv.reshape(-1, d_qk).float()
+    tok = req_to_page[:, :, 0:1] * page_size + torch.arange(
+        page_size, device=req_to_page.device
+    ).view(1, 1, -1)
+    tok = tok.reshape(B, -1)[:, :seq_len]
+    out = torch.empty(B, H, d_v, dtype=torch.float32, device=q.device)
+    for b in range(B):
+        k = kv_flat[tok[b]]
+        p = ((q[b].float() @ k.T) * sm_scale).softmax(-1)
+        out[b] = p @ k[:, :d_v]
+    return out
+
+
+# 112 = 16 query heads per rank x a 7-token DSpark block folded into the head
+# dim, i.e. the shape production actually launches; it is also not a multiple of
+# the 64-wide tile, so the final head tile is partial. 64 is the tile boundary.
+@pytest.mark.parametrize("H_Q", [64, 112])
+@pytest.mark.parametrize("quant", ["bf16", "fp8_kv", "fp8_kv_and_q"])
+def test_decode_attention_mla_wide_head_tile(H_Q, quant):
+    """MLA decode with enough query heads to select the wide head tile.
+
+    The other tests in this file compare one kernel launch against another, so a
+    tile-shape or masking fault that both launches share cancels out. This one
+    checks against PyTorch, and covers the >=64 kv_group_num branch that no
+    other case reaches.
+    """
+    B, seq_len, D_QK, D_V = 2, 517, 576, 512
+    PAGE_SIZE, CACHE_SIZE, num_kv_splits = 16, 4096, 8
+    dtype = torch.bfloat16
+    sm_scale = 1.0 / (D_QK**0.5)
+
+    req_to_page = torch.randint(
+        0,
+        CACHE_SIZE // PAGE_SIZE,
+        (B, cdiv(seq_len, PAGE_SIZE), 1),
+        device=DEVICE_TYPE,
+    )
+    q = torch.randn(B, H_Q, D_QK, dtype=dtype, device=DEVICE_TYPE) / 4
+    kv = torch.randn(CACHE_SIZE, 1, D_QK, dtype=dtype, device=DEVICE_TYPE) / 4
+
+    q_in, kv_in = q, kv
+    q_scale = k_scale = None
+    if quant != "bf16":
+        kv_fp8, k_scale = _quantize_to_fp8(kv)
+        kv_in = kv_fp8
+        # The reference has to see what the kernel sees.
+        kv = (kv_fp8.to(torch.float32) * k_scale).to(dtype)
+    if quant == "fp8_kv_and_q":
+        q_fp8, q_scale = _quantize_to_fp8(q)
+        q_in = q_fp8
+        q = (q_fp8.to(torch.float32) * q_scale).to(dtype)
+
+    ref = _reference_mla_decode(q, kv, req_to_page, seq_len, sm_scale, D_V, PAGE_SIZE)
+
+    kv_paged = kv_in.view(CACHE_SIZE // PAGE_SIZE, PAGE_SIZE, 1, D_QK)
+    o = torch.zeros(B, H_Q, D_V, dtype=dtype, device=DEVICE_TYPE)
+    lse = torch.zeros(B, H_Q, dtype=dtype, device=DEVICE_TYPE)
+    attn_logits = torch.empty(
+        (B, H_Q, num_kv_splits, D_V + 1), dtype=torch.float32, device=DEVICE_TYPE
+    )
+    decode_attention_fwd(
+        q_in,
+        kv_paged,
+        kv_paged[..., :D_V],
+        o,
+        lse,
+        req_to_page,
+        torch.full((B,), seq_len, device=DEVICE_TYPE),
+        attn_logits,
+        num_kv_splits,
+        sm_scale,
+        PAGE_SIZE,
+        k_scale=k_scale,
+        v_scale=k_scale,
+        q_scale=q_scale,
+        is_mla=True,
+    )
+
+    # Same tolerance as the fp8 case above; a tile or masking fault produces
+    # garbage rather than a small drift, so this is wide enough to catch it.
+    torch.testing.assert_close(ref.to(dtype), o, atol=5e-1, rtol=1e-2)
+
+
+@pytest.mark.parametrize(
+    "q_head_num,kv_group_num,is_mla,expected_block_h",
+    [
+        (112, 112, True, 64),  # folded DSpark block
+        (64, 64, True, 64),
+        (32, 32, True, 16),  # below the wide-tile threshold
+        (16, 16, True, 16),
+        (32, 4, False, 16),  # GQA never takes the wide tile
+    ],
+)
+def test_stage1_head_tiles_matches_launch_grid(
+    q_head_num, kv_group_num, is_mla, expected_block_h
+):
+    """The split heuristic sizes itself from this, so it must equal the grid.
+
+    _decode_grouped_att_m_fwd builds grid[1] as cdiv(q_head_num, min(BLOCK_H,
+    kv_group_num)). A caller that sizes num_kv_splits from a different number
+    over- or under-splits without failing, so pin the two together.
+    """
+    if not current_platform.is_rocm() and expected_block_h == 64:
+        pytest.skip("the wide tile is gated to HIP")
+    assert stage1_block_h(is_mla, kv_group_num) == expected_block_h
+    assert stage1_head_tiles(q_head_num, kv_group_num, is_mla) == cdiv(
+        q_head_num, min(expected_block_h, kv_group_num)
+    )

--- a/vllm/v1/attention/backends/mla/triton_mla.py
+++ b/vllm/v1/attention/backends/mla/triton_mla.py
@@ -7,6 +7,7 @@ import torch
 
 import vllm.envs as envs
 from vllm.config.cache import CacheDType
+from vllm.config import get_current_vllm_config
 from vllm.logger import init_logger
 from vllm.model_executor.layers.attention.mla_attention import (
     MLACommonBackend,
@@ -17,14 +18,18 @@ from vllm.model_executor.layers.attention.mla_attention import (
 from vllm.platforms import current_platform
 from vllm.platforms.interface import DeviceCapability
 from vllm.triton_utils import triton
-from vllm.utils.torch_utils import is_quantized_kv_cache
 from vllm.v1.attention.backend import (
     AttentionCGSupport,
     AttentionLayer,
     AttentionType,
     MultipleOf,
 )
-from vllm.v1.attention.ops.triton_decode_attention import decode_attention_fwd
+from vllm.v1.attention.ops.triton_decode_attention import (
+    decode_attention_fwd,
+    stage1_head_tiles,
+    stage1_workgroups_per_cu,
+)
+
 from vllm.v1.worker.workspace import (
     current_workspace_manager,
     is_workspace_manager_initialized,
@@ -32,27 +37,45 @@ from vllm.v1.worker.workspace import (
 
 logger = init_logger(__name__)
 
+_FP8_DTYPES = (
+    torch.float8_e4m3fn,
+    torch.float8_e4m3fnuz,
+    torch.float8_e5m2,
+)
+
 # num_kv_splits selection (shared by forward_mqa and the workspace reservation
 # so the two cannot drift). Both are hardware dependent.
 _MIN_WORK_PER_SPLIT = 512
-_SPLIT_OCCUPANCY_MULTIPLIER = 2
 
 
-def _compute_num_kv_splits(max_seq_len: int, sm_count: int) -> int:
-    # Power of 2 to avoid excessive kernel instantiations, capped by an SM-based
-    # maximum (occupancy multiplier allows multiple blocks per SM
-    # for latency hiding).
+def _compute_num_kv_splits(
+    max_seq_len: int,
+    sm_count: int,
+    grid_units: int = 1,
+    workgroups_per_cu: int = 2,
+) -> int:
+    # Power of 2 to avoid excessive kernel instantiations.
     ideal_splits = triton.next_power_of_2(max(1, max_seq_len // _MIN_WORK_PER_SPLIT))
-    max_splits = sm_count * _SPLIT_OCCUPANCY_MULTIPLIER
-    return min(ideal_splits, max_splits)
+    max_splits = sm_count * workgroups_per_cu
+    # Splitting past what it takes to fill the device buys no parallelism and
+    # costs a proportionally longer stage-2 reduction. grid_units must be the
+    # product of the stage-1 grid's non-split dimensions -- batch rows times
+    # head tiles -- which after the non-causal fold is neither the query-token
+    # count nor the row count alone. Load-bearing under full cudagraphs, where
+    # max_seq_len is the capture-time bound (max_model_len) rather than the
+    # live one.
+    occupancy_splits = triton.next_power_of_2(
+        triton.cdiv(max_splits, max(1, grid_units))
+    )
+    return min(ideal_splits, max_splits, occupancy_splits)
 
 
 class TritonMLAMetadataBuilder(MLACommonMetadataBuilder[MLACommonMetadata]):
     _cudagraph_support: ClassVar[AttentionCGSupport] = (
         AttentionCGSupport.UNIFORM_SINGLE_TOKEN_DECODE
     )
-    # Non-causal DSpark block is flattened to one decode row per query token in
-    # forward_mqa, so no intra-block causal masking is required.
+    # forward_mqa folds a non-causal DSpark block into the query-head dim, so
+    # no intra-block causal masking is required.
     supports_non_causal_multi_token_decode: ClassVar[bool] = True
 
     def __init__(self, kv_cache_spec, layer_names, vllm_config, device):
@@ -76,12 +99,15 @@ class TritonMLAMetadataBuilder(MLACommonMetadataBuilder[MLACommonMetadata]):
             return
         # Decode reorder threshold is 1, so decode tokens <= max_num_seqs.
         B = self.vllm_config.scheduler_config.max_num_seqs
-        # Non-causal DSpark draft flattens each request's block to query_len
-        # decode rows; cover max_num_seqs * block_len rows.
+        # o/lse/attn_logits are still allocated per query token even though the
+        # kernel sees them folded, so cover max_num_seqs * block_len rows.
         if getattr(self, "non_causal_multi_token_decode", False):
             B *= self.reorder_batch_threshold
         # DCP all-gathers the query heads before forward_mqa.
         q_num_heads = self.num_heads * self.dcp_world_size
+        # Defaults deliberately: grid_units=1 and two workgroups per CU give
+        # the largest split count any launch can ask for, so the reservation
+        # bounds every runtime shape.
         max_splits = _compute_num_kv_splits(
             self.model_config.max_model_len,
             current_platform.num_compute_units(),
@@ -146,7 +172,7 @@ class TritonMLABackend(MLACommonBackend):
 
     @classmethod
     def supports_non_causal(cls) -> bool:
-        # DSpark non-causal blocks are flattened to single-token decode rows in
+        # DSpark non-causal blocks are folded into the query-head dim in
         # TritonMLAImpl.forward_mqa (decode_attention_fwd has no causal flag /
         # no intra-block masking). Enables the non-causal AMD MLA path.
         return True
@@ -225,12 +251,7 @@ class TritonMLAImpl(MLACommonImpl[MLACommonMetadata]):
                     f"--kv-cache-dtype float16."
                 )
 
-        # For FP8 KV cache, we dequantize to BF16 on load inside the
-        # Triton kernel. Tell the common layer not to quantize queries
-        # to FP8 — we handle FP8 KV cache with BF16 queries (Mode 1).
-        if is_quantized_kv_cache(self.kv_cache_dtype):
-            self.supports_quant_query_input = False
-
+        self._out_dtype = get_current_vllm_config().model_config.dtype
         self._sm_count = current_platform.num_compute_units()
 
     def forward_mqa(
@@ -249,17 +270,45 @@ class TritonMLAImpl(MLACommonImpl[MLACommonMetadata]):
         assert isinstance(q, torch.Tensor)
         B = q.shape[0]
         q_num_heads = q.shape[1]
+        # The layer hands us a quantized query when the cache is quantized; its
+        # scale multiplies the scores alongside the key's, and the output stays
+        # in the model dtype.
+        is_fp8_q = q.dtype in _FP8_DTYPES
+        q_scale = layer._q_scale if is_fp8_q else None
+        out_dtype = self._out_dtype if is_fp8_q else q.dtype
         o = torch.zeros(
-            B, q_num_heads, self.kv_lora_rank, dtype=q.dtype, device=q.device
+            B, q_num_heads, self.kv_lora_rank, dtype=out_dtype, device=q.device
         )
-        lse = torch.zeros(B, q_num_heads, dtype=q.dtype, device=q.device)
+        lse = torch.zeros(B, q_num_heads, dtype=out_dtype, device=q.device)
+
+        # Non-causal DSpark block: every query token attends to the same
+        # committed KV prefix and never to a sibling block token. Hand the block
+        # to the kernel as extra query heads rather than as extra decode rows:
+        # the two are the same problem, but the kernel rereads the whole KV span
+        # once per head tile, so the row form multiplies KV traffic by the block
+        # length.
+        query_len = attn_metadata.max_query_len
+        folded_rows = 0
+        if not attn_metadata.causal and query_len > 1:
+            folded_rows = attn_metadata.num_decodes * query_len
 
         # For batch invariance, use only 1 split to ensure deterministic reduction
         if envs.VLLM_BATCH_INVARIANT:
             num_kv_splits = 1
         else:
+            # Size the splits against the stage-1 grid the launch will
+            # actually build: the fold trades decode rows for query heads, so
+            # rows alone understate the parallelism by the head-tile count.
+            if folded_rows:
+                rows, heads = folded_rows // query_len, q_num_heads * query_len
+            else:
+                rows, heads = B, q_num_heads
+            # MLA carries a single KV head, so kv_group_num == heads.
             num_kv_splits = _compute_num_kv_splits(
-                attn_metadata.max_seq_len, self._sm_count
+                attn_metadata.max_seq_len,
+                self._sm_count,
+                rows * stage1_head_tiles(heads, heads, is_mla=True),
+                stage1_workgroups_per_cu(True, heads),
             )
 
         # NOTE: the +1 stores the LogSumExp (LSE) that the stage2 kernel uses to
@@ -285,18 +334,32 @@ class TritonMLAImpl(MLACommonImpl[MLACommonMetadata]):
 
         block_table = attn_metadata.decode.block_table
         seq_lens = attn_metadata.decode.seq_lens
-        if not attn_metadata.causal:
-            # Non-causal DSpark block: flatten to one decode row per query token.
-            # Each row attends to the same committed KV prefix (per-row seq_lens)
-            # and never to sibling block tokens = non-causal block semantics.
-            # Mirrors FlashInferMLA's non-causal path.
-            query_len = attn_metadata.num_decode_tokens // attn_metadata.num_decodes
-            if query_len > 1:
-                block_table = block_table.repeat_interleave(query_len, dim=0)
-                seq_lens = seq_lens.repeat_interleave(query_len)
-
         # Run MQA — always pass layer scales. When KV cache is
         # BF16 the kernel's `if dtype.is_fp8()` check is a no-op.
+        if folded_rows:
+            # q rows are token-major within a request, so the fold is a view.
+            # Rows past the real queries are cudagraph padding: leave them zero.
+            n = folded_rows // query_len
+            h = q_num_heads * query_len
+            decode_attention_fwd(
+                q[:folded_rows].view(n, h, -1),
+                kv_c_and_k_pe_cache,
+                kv_c_cache,
+                o[:folded_rows].view(n, h, -1),
+                lse[:folded_rows].view(n, h),
+                block_table[:n],
+                seq_lens[:n],
+                attn_logits[:folded_rows].view(n, h, num_kv_splits, -1),
+                num_kv_splits,
+                self.scale,
+                PAGE_SIZE,
+                k_scale=layer._k_scale,
+                v_scale=layer._k_scale,
+                q_scale=q_scale,
+                is_mla=True,
+            )
+            return o, lse
+
         decode_attention_fwd(
             q,
             kv_c_and_k_pe_cache,
@@ -311,6 +374,7 @@ class TritonMLAImpl(MLACommonImpl[MLACommonMetadata]):
             PAGE_SIZE,
             k_scale=layer._k_scale,
             v_scale=layer._k_scale,
+            q_scale=q_scale,
             is_mla=True,
         )
 

--- a/vllm/v1/attention/ops/triton_decode_attention.py
+++ b/vllm/v1/attention/ops/triton_decode_attention.py
@@ -29,6 +29,7 @@ Memory-efficient attention for decoding.
 It supports page size >= 1.
 """
 
+import functools
 import logging
 
 import torch
@@ -39,7 +40,57 @@ from vllm.triton_utils import tl, triton
 
 is_hip_ = current_platform.is_rocm()
 
+_FP8_DTYPES = (torch.float8_e4m3fn, torch.float8_e4m3fnuz, torch.float8_e5m2)
+
 logger = logging.getLogger(__name__)
+
+# The stage-1 grid's head tiling. Exported because the caller sizes
+# num_kv_splits against this kernel's parallelism and the two must not drift.
+_WIDE_TILE_MIN_KV_GROUP = 64
+
+@functools.lru_cache(maxsize=None)
+def _unit_scale(device: torch.device) -> torch.Tensor:
+    """Stand-in for an absent quantization scale.
+
+    Cached because the decode path is cudagraph-captured: building the tensor
+    per call would allocate inside the capture region every step.
+    """
+    return torch.ones((), dtype=torch.float32, device=device)
+
+
+
+
+def stage1_block_h(is_mla: bool, kv_group_num: int) -> int:
+    """Query-head tile for `_fwd_grouped_kernel_stage1`.
+
+    A folded non-causal block arrives as many query heads on one row. Widening
+    the tile is what stops each tile rereading the whole KV span; 64 is the
+    widest that beat the alternatives on gfx950 (128 needs 8 warps to avoid
+    spilling and is still 2x slower).
+    """
+    # HIP only: the compensating BLOCK_N=64 below is gfx-specific, and at the
+    # NVIDIA BLOCK_N the wide tile needs 108544 B of shared memory, over the
+    # 101376 B that sm89 and sm120 allow -- and TRITON_MLA is sm120's default
+    # MLA backend, so it would abort on the first decode rather than fall back.
+    if is_hip_ and is_mla and kv_group_num >= _WIDE_TILE_MIN_KV_GROUP:
+        return 64
+    return 16
+
+
+def stage1_head_tiles(q_head_num: int, kv_group_num: int, is_mla: bool) -> int:
+    block_h = stage1_block_h(is_mla, kv_group_num)
+    return triton.cdiv(q_head_num, min(block_h, kv_group_num))
+
+
+def stage1_workgroups_per_cu(is_mla: bool, kv_group_num: int) -> int:
+    """How many stage-1 workgroups a CU can host at once.
+
+    The wide tile's fp32 [64, 512] accumulator saturates the 512-VGPR budget,
+    so only one workgroup is resident; assuming two over-splits the KV.
+    """
+    return 1 if stage1_block_h(is_mla, kv_group_num) > 16 else 2
+
+
 
 # Only print the following warnings when triton version < 3.2.0.
 # The issue won't affect performance or accuracy.
@@ -298,6 +349,7 @@ def _fwd_grouped_kernel_stage1(
     stride_mid_os,
     k_scale,
     v_scale,
+    q_scale,
     kv_group_num: tl.constexpr,
     q_head_num: tl.constexpr,
     BLOCK_DMODEL: tl.constexpr,
@@ -311,6 +363,7 @@ def _fwd_grouped_kernel_stage1(
     Lk: tl.constexpr,
     Lv: tl.constexpr,
     IS_MLA: tl.constexpr = False,
+    IS_FP8_KV: tl.constexpr = False,
 ):
     cur_batch = tl.program_id(0)
     cur_head_id = tl.program_id(1)
@@ -337,6 +390,11 @@ def _fwd_grouped_kernel_stage1(
         cache_modifier=".ca",
     )
 
+    # A quantized query is widened once here; e4m3 fits bf16 exactly, and
+    # its scale rides on the temperature with the key's.
+    if q.dtype.is_fp8():
+        q = q.to(tl.bfloat16)
+
     if BLOCK_DPE > 0:
         offs_dpe = BLOCK_DMODEL + tl.arange(0, BLOCK_DPE)
         mask_dpe = offs_dpe < Lk
@@ -349,6 +407,8 @@ def _fwd_grouped_kernel_stage1(
             other=0.0,
             cache_modifier=".ca",
         )
+        if qpe.dtype.is_fp8():
+            qpe = qpe.to(tl.bfloat16)
 
     kv_len_per_split = tl.cdiv(cur_batch_seq_len, NUM_KV_SPLITS)
     split_kv_start = kv_len_per_split * split_kv_id
@@ -366,6 +426,9 @@ def _fwd_grouped_kernel_stage1(
 
         ks = tl.load(k_scale)
         vs = tl.load(v_scale)
+        qs = tl.load(q_scale)
+        qk_scale = sm_scale * ks * qs if IS_FP8_KV else sm_scale
+        acc_scale = (ks if IS_MLA else vs) if IS_FP8_KV else 1.0
         for start_n in tl.range(split_kv_start, split_kv_end, BLOCK_N):
             offs_n = start_n + tl.arange(0, BLOCK_N)
             kv_page_number = tl.load(
@@ -388,10 +451,8 @@ def _fwd_grouped_kernel_stage1(
                 other=0.0,
                 cache_modifier=".cg",
             )
-
-            if k.dtype.is_fp8():
-                k = (k.to(tl.float32) * ks).to(q.dtype)
-            qk = tl.dot(q, k.to(q.dtype))
+            k = k.to(q.dtype)
+            qk = tl.dot(q, k)
             if BLOCK_DPE > 0:
                 offs_buf_kpe = kv_off_k[None, :] + base_offs_kpe
                 kpe = tl.load(
@@ -400,10 +461,8 @@ def _fwd_grouped_kernel_stage1(
                     other=0.0,
                     cache_modifier=".cg",
                 )
-                if kpe.dtype.is_fp8():
-                    kpe = (kpe.to(tl.float32) * ks).to(qpe.dtype)
                 qk += tl.dot(qpe, kpe.to(qpe.dtype))
-            qk *= sm_scale
+            qk *= qk_scale
 
             if logit_cap > 0:
                 qk = logit_cap * tanh(qk / logit_cap)
@@ -423,8 +482,7 @@ def _fwd_grouped_kernel_stage1(
                     mask=(offs_n[:, None] < split_kv_end) & (mask_dv[None, :]),
                     other=0.0,
                 )
-                if v.dtype.is_fp8():
-                    v = (v.to(tl.float32) * vs).to(q.dtype)
+                v = v.to(q.dtype)
             else:
                 # MLA uses a single c_kv.
                 # loading the same c_kv to interpret it as v is not necessary.
@@ -449,7 +507,7 @@ def _fwd_grouped_kernel_stage1(
 
         tl.store(
             Att_Out + offs_mid_o,
-            acc / e_sum[:, None],
+            acc * (acc_scale / e_sum)[:, None],
             mask=(mask_h[:, None]) & (mask_dv[None, :]),
         )
 
@@ -480,6 +538,7 @@ def _decode_grouped_att_m_fwd(
     logit_cap,
     k_scale,
     v_scale,
+    q_scale,
     is_mla=False,
 ):
     # with is_mla there is only a single c_kv in smem.
@@ -510,7 +569,9 @@ def _decode_grouped_att_m_fwd(
     batch, head_num = q.shape[0], q.shape[1]
     kv_group_num = q.shape[1] // k_buffer.shape[-2]
 
-    BLOCK_H = 16
+    BLOCK_H = stage1_block_h(is_mla, kv_group_num)
+    if BLOCK_H > 16 and is_hip_:
+        BLOCK = 64
     NUM_KV_SPLITS = num_kv_splits
     grid = (
         batch,
@@ -525,6 +586,11 @@ def _decode_grouped_att_m_fwd(
         # https://github.com/triton-lang/triton/blob/main/third_party/amd/backend/compiler.py
         extra_kargs = {"waves_per_eu": 1, "matrix_instr_nonkdim": 16, "kpack": 2}
         num_stages = 1
+        if is_mla:
+            # Measured on the folded DSpark shape: the extra stage spills
+            # (310 slots, 708 B/thread) yet still halves the kernel, so the
+            # pipelining is worth more than the scratch traffic.
+            num_stages = 2
     elif not is_hip_ and BLOCK_DMODEL >= 1024:
         # Avoid shared memory overflow on NVIDIA when BLOCK_DMODEL is large
         # like non-MLA D_QK=576, BLOCK_DMODEL=1024, BLOCK_H=16
@@ -553,6 +619,7 @@ def _decode_grouped_att_m_fwd(
         att_out.stride(2),
         k_scale,
         v_scale,
+        q_scale,
         kv_group_num=kv_group_num,
         q_head_num=head_num,
         BLOCK_DMODEL=BLOCK_DMODEL,
@@ -568,6 +635,7 @@ def _decode_grouped_att_m_fwd(
         Lk=Lk,
         Lv=Lv,
         IS_MLA=is_mla,
+        IS_FP8_KV=k_buffer.dtype in _FP8_DTYPES,
         **extra_kargs,
     )
 
@@ -731,6 +799,7 @@ def decode_attention_fwd_grouped(
     logit_cap=0.0,
     k_scale=None,
     v_scale=None,
+    q_scale=None,
     is_mla=False,
 ):
     _decode_grouped_att_m_fwd(
@@ -746,6 +815,7 @@ def decode_attention_fwd_grouped(
         logit_cap,
         k_scale,
         v_scale,
+        q_scale,
         is_mla=is_mla,
     )
     _decode_softmax_reducev_fwd(
@@ -768,14 +838,17 @@ def decode_attention_fwd(
     logit_cap=0.0,
     k_scale=None,
     v_scale=None,
+    q_scale=None,
     is_mla=False,
 ):
     assert num_kv_splits == attn_logits.shape[2]
 
+    if q_scale is None:
+        q_scale = _unit_scale(q.device)
     if k_scale is None:
-        k_scale = torch.tensor(1.0, dtype=torch.float32, device=q.device)
+        k_scale = _unit_scale(q.device)
     if v_scale is None:
-        v_scale = torch.tensor(1.0, dtype=torch.float32, device=q.device)
+        v_scale = _unit_scale(q.device)
 
     kv_group_num = q.shape[1] // v_buffer.shape[-2]
 
@@ -814,5 +887,6 @@ def decode_attention_fwd(
             logit_cap,
             k_scale,
             v_scale,
+            q_scale,
             is_mla=is_mla,
         )


### PR DESCRIPTION
## Purpose

Two things, both in the TRITON_MLA decode path.

### 1. Take a native fp8 KV cache

`TritonMLAImpl` clears `supports_quant_query_input`, so a model whose fp8 decode
requires a backend that accepts a quantized query cannot use TRITON_MLA — and on
ROCm TRITON_MLA is the only MLA backend declaring
`supports_non_causal_multi_token_decode`, so there is nothing to fall back to.

The refusal existed to protect an in-kernel dequant. This removes the dequant
instead, and then the refusal has nothing left to protect.

Scales are loop constants, so they do not belong in the loop. `k_scale` rides on
the softmax temperature and on the accumulator instead (`sm_scale * k_scale *
q_scale`, and `acc * acc_scale`), leaving the tile load as a plain fp8 → bf16
widening. That widening is **exact** for `e4m3fn`, `e4m3fnuz` and `e5m2`, so this
is strictly more accurate than the previous `(k.to(f32) * ks).to(bf16)`, which
rounded the product to bf16's mantissa once per element.

Because `q` may now be fp8, the output dtype comes from `model_config.dtype`
rather than from `q`.

### 2. Fold the non-causal multi-token decode into the head dim

Every query token in a non-causal decode block attends to the same committed KV
prefix and never to a sibling token, so the block was flattened to one decode row
per token. The kernel rereads the whole KV span once per head tile, so the row
form multiplied KV traffic by the block length. Handing the block over as extra
query **heads** is the same problem in one pass.

That makes the tile wide, so the head tile grows to 64 and HIP takes a second
pipeline stage. `num_kv_splits` is then sized from the stage-1 grid's real
parallelism — rows times head tiles — which after the fold is neither the
query-token count nor the row count alone. The tile rule is shared between the
sizing helper and the launcher so the two cannot drift.

## Performance

MI355X (gfx950), DP2xTP4 + EP, fp8 KV, 100K context, batch 16.
`_fwd_grouped_kernel_stage1` in a production trace:

| | per call |
|---|---|
| before | 3695.7 us |
| after | **628.2 us** |

Kernel sweeps at that shape (16 rows x 112 folded heads, 100K, fp8, page 64):

| BLOCK_H | 16 | 32 | 64 | 128 |
|---|---|---|---|---|
| time | 2855 us | 1367 us | **909 us** | 1001 us |

64 is the optimum of the reachable space — 56 and 112 are not powers of two and
do not compile, and 128 needs eight warps to avoid spilling. `num_stages=2` does
spill (310 slots, 708 B/thread, read out of the AMDGCN metadata) and is still
half the time of `num_stages=1` (905 vs 1775 us), so the pipelining is worth more
than the scratch traffic.

## Two smaller things this dragged in

- The absent-scale fallback built a device tensor per call on a
  cudagraph-captured path. It is a cached constant now.
- The wide head tile is gated to HIP. At the NVIDIA `BLOCK_N` it needs 108544 B
  of shared memory against the 101376 B that sm89 and sm120 allow, and TRITON_MLA
  is sm120's default MLA backend, so it would abort on the first decode rather
  than fall back.

## Test Plan

`tests/kernels/attention/test_triton_decode_attention.py` gains 11 cases:

- `test_decode_attention_mla_wide_head_tile` — checks the wide-tile path against a
  torch reference for `H_Q` in {64, 112} across bf16, fp8 KV, and fp8 KV + fp8
  query.
- `test_stage1_head_tiles_matches_launch_grid` — pins the shared tile rule to the
  grid the launcher actually builds, so the `num_kv_splits` sizing and the launch
  cannot drift apart.

Exercised end to end on 8x MI355X with an MLA model at fp8 KV, PP8/TP1 and
DP2xTP4 + EP; GSM8K (full 1319, 5-shot) stays at the level this stack holds
(~0.96).

Note the end-to-end numbers above were taken on a downstream branch carrying
additional model-specific work, not on this PR's exact tree. The kernel file
(`triton_decode_attention.py`) is byte-identical to the validated version; the
backend file differs from it only by a separate cudagraph change that is
deliberately not part of this PR.
