### PR TITLE
[KV Connector][Offloading] Keep per-layer KV registration when canonical_layout is requested

### DIFF
--- a/tests/v1/kv_connector/unit/offloading_connector/test_config.py
+++ b/tests/v1/kv_connector/unit/offloading_connector/test_config.py
@@ -662,10 +662,8 @@ def test_canonical_layout_certifies_v2_model_runner():
 
 
 def test_prefer_cross_layer_blocks_yields_to_canonical_layout():
-    """Canonical mappings are certified per layer, so the connector must not
-    steer the runner into cross-layer allocation when canonical_layout is
-    requested — otherwise uniform-attention models on the v1 runner refuse
-    to start."""
+    """The connector must not request cross-layer blocks under
+    canonical_layout: cross-layer slabs have no per-layer refs to certify."""
     from vllm.distributed.kv_transfer.kv_connector.v1.base import KVConnectorRole
     from vllm.distributed.kv_transfer.kv_connector.v1.offloading_connector import (
         OffloadingConnector,

--- a/tests/v1/kv_connector/unit/offloading_connector/test_config.py
+++ b/tests/v1/kv_connector/unit/offloading_connector/test_config.py
@@ -661,6 +661,36 @@ def test_canonical_layout_certifies_v2_model_runner():
     ).parallel.is_parallelism_agnostic
 
 
+def test_prefer_cross_layer_blocks_yields_to_canonical_layout():
+    """Canonical mappings are certified per layer, so the connector must not
+    steer the runner into cross-layer allocation when canonical_layout is
+    requested — otherwise uniform-attention models on the v1 runner refuse
+    to start."""
+    from vllm.distributed.kv_transfer.kv_connector.v1.base import KVConnectorRole
+    from vllm.distributed.kv_transfer.kv_connector.v1.offloading_connector import (
+        OffloadingConnector,
+    )
+
+    kv_cache_config = _make_kv_cache_config()
+    connector_module = "vllm.distributed.kv_transfer.kv_connector.v1"
+
+    def make_connector(extra_config: dict[str, Any] | None) -> OffloadingConnector:
+        with (
+            patch(f"{connector_module}.offloading_connector.OffloadingSpecFactory"),
+            patch(
+                f"{connector_module}.offloading_connector.OffloadingConnectorScheduler"
+            ),
+        ):
+            return OffloadingConnector(
+                _make_vllm_config(extra_config=extra_config),
+                KVConnectorRole.SCHEDULER,
+                kv_cache_config,
+            )
+
+    assert make_connector(None).prefer_cross_layer_blocks
+    assert not make_connector({"canonical_layout": True}).prefer_cross_layer_blocks
+
+
 def test_parallelism_agnostic_disabled_on_v2_model_runner():
     config = _make_vllm_config()
     config.use_v2_model_runner = True

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading_connector.py
@@ -49,9 +49,7 @@ from vllm.v1.request import Request
 class OffloadingConnector(KVConnectorBase_V1, SupportsHMA):
     @property
     def prefer_cross_layer_blocks(self) -> bool:
-        # Canonical mappings are certified per layer against registered
-        # tensors; a cross-layer slab has no per-layer refs to certify, so
-        # keep per-layer registration when the canonical layout is requested.
+        # Cross-layer slabs have no per-layer refs to certify canonical mappings
         return not self._canonical_layout
 
     @property

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading_connector.py
@@ -49,7 +49,10 @@ from vllm.v1.request import Request
 class OffloadingConnector(KVConnectorBase_V1, SupportsHMA):
     @property
     def prefer_cross_layer_blocks(self) -> bool:
-        return True
+        # Canonical mappings are certified per layer against registered
+        # tensors; a cross-layer slab has no per-layer refs to certify, so
+        # keep per-layer registration when the canonical layout is requested.
+        return not self._canonical_layout
 
     @property
     def requires_kv_delivery(self) -> bool:
@@ -66,6 +69,7 @@ class OffloadingConnector(KVConnectorBase_V1, SupportsHMA):
         super().__init__(vllm_config, role, kv_cache_config)
 
         offloading_config = build_offloading_config(vllm_config, kv_cache_config)
+        self._canonical_layout = offloading_config.canonical_layout
         spec = OffloadingSpecFactory.create_spec(offloading_config)
 
         self.connector_scheduler: OffloadingConnectorScheduler | None = None


### PR DESCRIPTION
The connector prefers cross-layer blocks, but a cross-layer slab has no per-layer refs to certify, so uniform-attention models on the V1 model runner refused `canonical_layout` at startup (e.g. Qwen3-30B-A3B at tp2). Keep per-layer registration when the canonical layout is requested; the preference is unchanged otherwise.

Unlocks canonical offload for uniform-attention MoE models on the V1 runner: Qwen3-MoE (30B-A3B / 235B-A22B), Mixtral-class, GLM-4.5-Air / GLM-4.6.

## Test plan

`pytest tests/v1/kv_connector/unit/offloading_connector/test_config.py` (no GPU).

E2E on 2x H200: Qwen3-30B-A3B tp2 with canonical_layout previously failed at startup; now starts with all layers certified portable and CPU loads verified. With canonical off, cross-layer allocation is unchanged.