### PR TITLE
[KV Connector][Offloading] Certify per-token-head KV quant in the canonical layout

### DIFF
--- a/tests/v1/kv_connector/unit/offloading_connector/test_canonical_mapping.py
+++ b/tests/v1/kv_connector/unit/offloading_connector/test_canonical_mapping.py
@@ -397,8 +397,7 @@ def test_fail_closed_cases():
 
 
 def _packed_nhd_quant_cache(spec) -> torch.Tensor:
-    """The per-token-head packed form: each (token, head) row is padded so
-    its fp32 scale sits inline after the quantized data."""
+    """Per-token-head packed form: fp32 scale inline after each row's data."""
     scale_pad = 4 // spec.dtype.itemsize
     inner = 2 * (spec.head_size + scale_pad)
     return torch.zeros(
@@ -407,9 +406,8 @@ def _packed_nhd_quant_cache(spec) -> torch.Tensor:
 
 
 def test_per_token_head_packed_rows_certify():
-    """Padded packed rows carry their scales inline, so head-shard fragments
-    stay self-contained and portable; the page must span the scale carve
-    (unpadded_page_size_bytes), matching the worker's offload refs."""
+    """Padded rows carry scales inline, so head shards stay portable; the
+    page spans the scale carve, matching the worker's offload refs."""
     spec = _full_spec(kv_quant_mode=KVQuantMode.FP8_PER_TOKEN_HEAD)
     cache = _packed_nhd_quant_cache(spec)
     per_rank = [_mapping(spec, cache, _ctx(rank=r, tp=2)) for r in range(2)]

--- a/tests/v1/kv_connector/unit/offloading_connector/test_canonical_mapping.py
+++ b/tests/v1/kv_connector/unit/offloading_connector/test_canonical_mapping.py
@@ -18,6 +18,7 @@ from vllm.v1.kv_cache_interface import (
     KVCacheSpec,
     KVQuantMode,
     MLAAttentionSpec,
+    SlidingWindowSpec,
 )
 from vllm.v1.kv_offload.base import CanonicalPageMapping, CopyRun
 
@@ -416,6 +417,31 @@ def test_per_token_head_packed_rows_certify():
     assert mapping.local_page_size_bytes == spec.unpadded_page_size_bytes
     assert mapping.canonical_page_size_bytes == 2 * spec.unpadded_page_size_bytes
     _verify_tiling("quant", per_rank)
+
+
+def test_streams_packed_into_head_size_certify():
+    """Short-conv state caches (Inkling) pack several streams into head_size
+    with head_size_v=0, head-major [num_blocks, H, N, D]: a head shard is one
+    contiguous run, so the canonical page is global head order."""
+    spec = SlidingWindowSpec(
+        block_size=4,
+        num_kv_heads=2,
+        head_size=256,
+        head_size_v=0,
+        dtype=torch.int8,
+        sliding_window=4,
+    )
+    cache = torch.zeros(
+        NUM_BLOCKS, spec.num_kv_heads, spec.block_size, spec.head_size, dtype=torch.int8
+    )
+    per_rank = [_mapping(spec, cache, _ctx(rank=r, tp=2, heads=2)) for r in range(2)]
+    _verify_tiling("sconv", per_rank)
+    page = spec.unpadded_page_size_bytes
+    assert [_triples(m.runs) for m in per_rank] == [
+        [(0, 0, page)],
+        [(0, page, page)],
+    ]
+    assert all(m.parallelism_agnostic for m in per_rank)
 
 
 def test_opaque_fallback_places_page_whole():

--- a/tests/v1/kv_connector/unit/offloading_connector/test_canonical_mapping.py
+++ b/tests/v1/kv_connector/unit/offloading_connector/test_canonical_mapping.py
@@ -396,6 +396,30 @@ def test_fail_closed_cases():
     assert _try_mapping(KVCacheSpec(block_size=4), None, _ctx(0, tp=4, total=8)) is None
 
 
+def _packed_nhd_quant_cache(spec) -> torch.Tensor:
+    """The per-token-head packed form: each (token, head) row is padded so
+    its fp32 scale sits inline after the quantized data."""
+    scale_pad = 4 // spec.dtype.itemsize
+    inner = 2 * (spec.head_size + scale_pad)
+    return torch.zeros(
+        NUM_BLOCKS, spec.block_size, spec.num_kv_heads, inner, dtype=torch.int8
+    ).permute(0, 2, 1, 3)
+
+
+def test_per_token_head_packed_rows_certify():
+    """Padded packed rows carry their scales inline, so head-shard fragments
+    stay self-contained and portable; the page must span the scale carve
+    (unpadded_page_size_bytes), matching the worker's offload refs."""
+    spec = _full_spec(kv_quant_mode=KVQuantMode.FP8_PER_TOKEN_HEAD)
+    cache = _packed_nhd_quant_cache(spec)
+    per_rank = [_mapping(spec, cache, _ctx(rank=r, tp=2)) for r in range(2)]
+    mapping = per_rank[0]
+    assert mapping.parallelism_agnostic
+    assert mapping.local_page_size_bytes == spec.unpadded_page_size_bytes
+    assert mapping.canonical_page_size_bytes == 2 * spec.unpadded_page_size_bytes
+    _verify_tiling("quant", per_rank)
+
+
 def test_opaque_fallback_places_page_whole():
     mapping = _opaque_fallback_mapping(1024, 4, 2)
     assert mapping.canonical_page_size_bytes == 4096

--- a/tests/v1/kv_connector/unit/offloading_connector/test_config.py
+++ b/tests/v1/kv_connector/unit/offloading_connector/test_config.py
@@ -619,6 +619,7 @@ def test_parallelism_agnostic_excluded(kv_cache_groups: list[KVCacheGroupSpec]):
     assert not _parallelism_agnostic(kv_cache_groups)
 
 
+_PTH = KVQuantMode.FP8_PER_TOKEN_HEAD
 _SWA_SPEC = SlidingWindowSpec(
     block_size=16,
     num_kv_heads=4,
@@ -635,6 +636,10 @@ _SWA_MLA_SPEC = SlidingWindowMLASpec(
 )
 
 
+def _groups(*specs: KVCacheSpec) -> list[KVCacheGroupSpec]:
+    return [KVCacheGroupSpec([f"l{i}"], spec) for i, spec in enumerate(specs)]
+
+
 def _uniform_group(*specs: KVCacheSpec) -> KVCacheGroupSpec:
     """GLM-5.2/DSv3.2-style wrapper: same-type specs, differing page sizes."""
     names = [f"l{i}" for i in range(len(specs))]
@@ -647,24 +652,11 @@ def _uniform_group(*specs: KVCacheSpec) -> KVCacheGroupSpec:
 @pytest.mark.parametrize(
     ("kv_cache_groups", "certified"),
     [
+        pytest.param(_groups(_mla_spec(head_size=576)), True, id="mla-latent"),
         pytest.param(
-            [KVCacheGroupSpec(["l0"], _mla_spec(head_size=576))],
-            True,
-            id="mla-latent",
+            _groups(_full_attention_spec(), _SWA_SPEC), True, id="attention-hybrid"
         ),
-        pytest.param(
-            [
-                KVCacheGroupSpec(["l0"], _full_attention_spec()),
-                KVCacheGroupSpec(["l1"], _SWA_SPEC),
-            ],
-            True,
-            id="attention-hybrid",
-        ),
-        pytest.param(
-            [KVCacheGroupSpec(["l0"], _SWA_MLA_SPEC)],
-            False,
-            id="swa-mla",
-        ),
+        pytest.param(_groups(_SWA_MLA_SPEC), False, id="swa-mla"),
         pytest.param(
             list(_make_mamba_hybrid_kv_cache_config().kv_cache_groups),
             False,
@@ -681,25 +673,12 @@ def _uniform_group(*specs: KVCacheSpec) -> KVCacheGroupSpec:
             id="uniform-uncertifiable-inner",
         ),
         pytest.param(
-            [
-                KVCacheGroupSpec(
-                    ["l0"],
-                    _full_attention_spec(kv_quant_mode=KVQuantMode.FP8_PER_TOKEN_HEAD),
-                )
-            ],
+            _groups(_full_attention_spec(kv_quant_mode=_PTH)),
             True,
             id="per-token-head-gqa",
         ),
         pytest.param(
-            [
-                KVCacheGroupSpec(
-                    ["l0"],
-                    _mla_spec(
-                        head_size=576,
-                        kv_quant_mode=KVQuantMode.FP8_PER_TOKEN_HEAD,
-                    ),
-                )
-            ],
+            _groups(_mla_spec(head_size=576, kv_quant_mode=_PTH)),
             False,
             id="per-token-head-mla",
         ),

--- a/tests/v1/kv_connector/unit/offloading_connector/test_config.py
+++ b/tests/v1/kv_connector/unit/offloading_connector/test_config.py
@@ -661,6 +661,42 @@ def test_canonical_layout_certifies_attention_hybrids():
     )
 
 
+def test_canonical_layout_certifies_uniform_type_wrapper():
+    """GLM-5.2/DSv3.2-style groups wrap same-type specs with different page
+    sizes (MLA plus its DSA indexer cache) in UniformTypeKVCacheSpecs; the
+    gate must look through the wrapper like the mapping derivation does."""
+
+    def uniform_groups(indexer_spec) -> list[KVCacheGroupSpec]:
+        return [
+            KVCacheGroupSpec(
+                ["mla_layer", "indexer_layer"],
+                UniformTypeKVCacheSpecs(
+                    block_size=16,
+                    kv_cache_specs={
+                        "mla_layer": _mla_spec(head_size=576),
+                        "indexer_layer": indexer_spec,
+                    },
+                ),
+            )
+        ]
+
+    mla_wrapped = uniform_groups(_mla_spec(head_size=128))
+    assert not _parallelism_agnostic(mla_wrapped)
+    assert _parallelism_agnostic(mla_wrapped, canonical=True)
+
+    # one uncertifiable inner spec poisons the wrapper
+    swa_mla_wrapped = uniform_groups(
+        SlidingWindowMLASpec(
+            block_size=16,
+            num_kv_heads=1,
+            head_size=576,
+            dtype=torch.float32,
+            sliding_window=128,
+        )
+    )
+    assert not _parallelism_agnostic(swa_mla_wrapped, canonical=True)
+
+
 def test_canonical_layout_certifies_v2_model_runner():
     """Canonical bytes are certified per layer against live tensor strides at
     registration, so the static gate must not depend on the model-runner

--- a/tests/v1/kv_connector/unit/offloading_connector/test_config.py
+++ b/tests/v1/kv_connector/unit/offloading_connector/test_config.py
@@ -206,8 +206,16 @@ def _make_mamba_hybrid_kv_cache_config() -> KVCacheConfig:
     )
 
 
-def _parallelism_agnostic(kv_cache_groups: list[KVCacheGroupSpec]) -> bool:
-    config = _make_vllm_config()
+def _parallelism_agnostic(
+    kv_cache_groups: list[KVCacheGroupSpec],
+    *,
+    canonical: bool = False,
+    v2: bool = False,
+) -> bool:
+    config = _make_vllm_config(
+        extra_config={"canonical_layout": True} if canonical else None
+    )
+    config.use_v2_model_runner = v2
     kv_cache_config = KVCacheConfig(
         num_blocks=0,
         kv_cache_tensors=[],
@@ -612,53 +620,74 @@ def test_canonical_layout_widens_parallelism_agnostic_to_mla():
     is requested."""
     mla_groups = [KVCacheGroupSpec(["l0"], _mla_spec(head_size=576))]
     assert not _parallelism_agnostic(mla_groups)
+    assert _parallelism_agnostic(mla_groups, canonical=True)
 
-    config = _make_vllm_config(extra_config={"canonical_layout": True})
-    kv_cache_config = KVCacheConfig(
-        num_blocks=0,
-        kv_cache_tensors=[],
-        kv_cache_groups=mla_groups,
-    )
-    offloading_config = build_offloading_config(config, kv_cache_config)
-    assert offloading_config.parallel.is_parallelism_agnostic
-    assert offloading_config.canonical_layout
+    # Mamba hybrids stay out: their state layers can only derive opaque
+    # (exact-topology) mappings
+    mamba_groups = list(_make_mamba_hybrid_kv_cache_config().kv_cache_groups)
+    assert not _parallelism_agnostic(mamba_groups, canonical=True)
 
-    # hybrid groupings stay out: their non-full-attention layers can only
-    # derive opaque (exact-topology) mappings
-    hybrid_config = KVCacheConfig(
-        num_blocks=0,
-        kv_cache_tensors=[],
-        kv_cache_groups=[
-            KVCacheGroupSpec(["l0"], _full_attention_spec()),
-            KVCacheGroupSpec(["l1"], _full_attention_spec()),
-        ],
+
+def test_canonical_layout_certifies_attention_hybrids():
+    """Hybrid attention models (full + sliding-window groups, e.g. gpt-oss)
+    certify group by group under the canonical layout; every layer's bytes
+    are head-shard fragments regardless of its window."""
+    hybrid_groups = [
+        KVCacheGroupSpec(["l0"], _full_attention_spec()),
+        KVCacheGroupSpec(
+            ["l1"],
+            SlidingWindowSpec(
+                block_size=16,
+                num_kv_heads=4,
+                head_size=128,
+                dtype=torch.float32,
+                sliding_window=128,
+            ),
+        ),
+    ]
+    assert not _parallelism_agnostic(hybrid_groups)
+    assert _parallelism_agnostic(hybrid_groups, canonical=True)
+
+    # DSv4-style sliding-window MLA is not a head-sharded layout; stays out
+    swa_mla = SlidingWindowMLASpec(
+        block_size=16,
+        num_kv_heads=1,
+        head_size=576,
+        dtype=torch.float32,
+        sliding_window=128,
     )
-    assert not build_offloading_config(
-        config, hybrid_config
-    ).parallel.is_parallelism_agnostic
+    assert not _parallelism_agnostic(
+        [KVCacheGroupSpec(["l0"], swa_mla)], canonical=True
+    )
 
 
 def test_canonical_layout_certifies_v2_model_runner():
     """Canonical bytes are certified per layer against live tensor strides at
     registration, so the static gate must not depend on the model-runner
     version — the v2 runner is the case the canonical layout exists for."""
+    groups = [KVCacheGroupSpec(["l0"], _full_attention_spec())]
+    assert not _parallelism_agnostic(groups, v2=True)
+    assert _parallelism_agnostic(groups, canonical=True, v2=True)
+
+
+def test_canonical_format_resolved_at_config_build():
+    """The canonical format id needs the vLLM config context to resolve the
+    KV cache layout; consumers like the scheduler-side FileMapper run outside
+    that context, so build_offloading_config must resolve it eagerly."""
     kv_cache_config = KVCacheConfig(
         num_blocks=0,
         kv_cache_tensors=[],
         kv_cache_groups=[KVCacheGroupSpec(["l0"], _full_attention_spec())],
     )
 
-    config = _make_vllm_config()
-    config.use_v2_model_runner = True
-    assert not build_offloading_config(
-        config, kv_cache_config
-    ).parallel.is_parallelism_agnostic
+    offloading_config = build_offloading_config(
+        _make_vllm_config(extra_config={"canonical_layout": True}), kv_cache_config
+    )
+    assert offloading_config.canonical_format is not None
+    assert offloading_config.canonical_format.startswith("v1-")
 
-    config = _make_vllm_config(extra_config={"canonical_layout": True})
-    config.use_v2_model_runner = True
-    assert build_offloading_config(
-        config, kv_cache_config
-    ).parallel.is_parallelism_agnostic
+    no_canonical = build_offloading_config(_make_vllm_config(), kv_cache_config)
+    assert no_canonical.canonical_format is None
 
 
 def test_parallelism_agnostic_disabled_on_v2_model_runner():

--- a/tests/v1/kv_connector/unit/offloading_connector/test_config.py
+++ b/tests/v1/kv_connector/unit/offloading_connector/test_config.py
@@ -24,6 +24,7 @@ from vllm.v1.kv_cache_interface import (
     KVCacheConfig,
     KVCacheGroupSpec,
     KVCacheTensor,
+    KVQuantMode,
     MambaSpec,
     MLAAttentionSpec,
     SlidingWindowMLASpec,
@@ -128,12 +129,13 @@ def _make_sizing_kv_cache_config(packed: bool) -> KVCacheConfig:
     )
 
 
-def _full_attention_spec(block_size: int = 16) -> FullAttentionSpec:
+def _full_attention_spec(block_size: int = 16, **kwargs: Any) -> FullAttentionSpec:
     return FullAttentionSpec(
         block_size=block_size,
         num_kv_heads=4,
         head_size=128,
         dtype=torch.float32,
+        **kwargs,
     )
 
 
@@ -141,12 +143,14 @@ def _mla_spec(
     block_size: int = 16,
     head_size: int = 512,
     dtype: torch.dtype = torch.float32,
+    **kwargs: Any,
 ) -> MLAAttentionSpec:
     return MLAAttentionSpec(
         block_size=block_size,
         num_kv_heads=1,
         head_size=head_size,
         dtype=dtype,
+        **kwargs,
     )
 
 
@@ -659,6 +663,21 @@ def test_canonical_layout_certifies_attention_hybrids():
     assert not _parallelism_agnostic(
         [KVCacheGroupSpec(["l0"], swa_mla)], canonical=True
     )
+
+
+def test_canonical_layout_certifies_per_token_head_quant():
+    """Per-token-head packed rows carry inline scales, so GQA groups certify
+    under the canonical layout; the direct layout and the MLA latent path
+    keep excluding it."""
+    pth = KVQuantMode.FP8_PER_TOKEN_HEAD
+    pth_groups = [KVCacheGroupSpec(["l0"], _full_attention_spec(kv_quant_mode=pth))]
+    assert not _parallelism_agnostic(pth_groups)
+    assert _parallelism_agnostic(pth_groups, canonical=True)
+
+    mla_pth_groups = [
+        KVCacheGroupSpec(["l0"], _mla_spec(head_size=576, kv_quant_mode=pth))
+    ]
+    assert not _parallelism_agnostic(mla_pth_groups, canonical=True)
 
 
 def test_canonical_layout_certifies_uniform_type_wrapper():

--- a/tests/v1/kv_connector/unit/offloading_connector/test_config.py
+++ b/tests/v1/kv_connector/unit/offloading_connector/test_config.py
@@ -23,6 +23,7 @@ from vllm.v1.kv_cache_interface import (
     HiddenStateCacheSpec,
     KVCacheConfig,
     KVCacheGroupSpec,
+    KVCacheSpec,
     KVCacheTensor,
     KVQuantMode,
     MambaSpec,
@@ -618,102 +619,97 @@ def test_parallelism_agnostic_excluded(kv_cache_groups: list[KVCacheGroupSpec]):
     assert not _parallelism_agnostic(kv_cache_groups)
 
 
-def test_canonical_layout_widens_parallelism_agnostic_to_mla():
-    """The canonical layout dedups the TP-replicated MLA latent into one
-    portable copy, so the gate admits MLA — but only when canonical_layout
-    is requested."""
-    mla_groups = [KVCacheGroupSpec(["l0"], _mla_spec(head_size=576))]
-    assert not _parallelism_agnostic(mla_groups)
-    assert _parallelism_agnostic(mla_groups, canonical=True)
+_SWA_SPEC = SlidingWindowSpec(
+    block_size=16,
+    num_kv_heads=4,
+    head_size=128,
+    dtype=torch.float32,
+    sliding_window=128,
+)
+_SWA_MLA_SPEC = SlidingWindowMLASpec(
+    block_size=16,
+    num_kv_heads=1,
+    head_size=576,
+    dtype=torch.float32,
+    sliding_window=128,
+)
 
-    # Mamba hybrids stay out: their state layers can only derive opaque
-    # (exact-topology) mappings
-    mamba_groups = list(_make_mamba_hybrid_kv_cache_config().kv_cache_groups)
-    assert not _parallelism_agnostic(mamba_groups, canonical=True)
+
+def _uniform_group(*specs: KVCacheSpec) -> KVCacheGroupSpec:
+    """GLM-5.2/DSv3.2-style wrapper: same-type specs, differing page sizes."""
+    names = [f"l{i}" for i in range(len(specs))]
+    return KVCacheGroupSpec(
+        names,
+        UniformTypeKVCacheSpecs(block_size=16, kv_cache_specs=dict(zip(names, specs))),
+    )
 
 
-def test_canonical_layout_certifies_attention_hybrids():
-    """Hybrid attention models (full + sliding-window groups, e.g. gpt-oss)
-    certify group by group under the canonical layout; every layer's bytes
-    are head-shard fragments regardless of its window."""
-    hybrid_groups = [
-        KVCacheGroupSpec(["l0"], _full_attention_spec()),
-        KVCacheGroupSpec(
-            ["l1"],
-            SlidingWindowSpec(
-                block_size=16,
-                num_kv_heads=4,
-                head_size=128,
-                dtype=torch.float32,
-                sliding_window=128,
-            ),
+@pytest.mark.parametrize(
+    ("kv_cache_groups", "certified"),
+    [
+        pytest.param(
+            [KVCacheGroupSpec(["l0"], _mla_spec(head_size=576))],
+            True,
+            id="mla-latent",
         ),
-    ]
-    assert not _parallelism_agnostic(hybrid_groups)
-    assert _parallelism_agnostic(hybrid_groups, canonical=True)
-
-    # DSv4-style sliding-window MLA is not a head-sharded layout; stays out
-    swa_mla = SlidingWindowMLASpec(
-        block_size=16,
-        num_kv_heads=1,
-        head_size=576,
-        dtype=torch.float32,
-        sliding_window=128,
-    )
-    assert not _parallelism_agnostic(
-        [KVCacheGroupSpec(["l0"], swa_mla)], canonical=True
-    )
-
-
-def test_canonical_layout_certifies_per_token_head_quant():
-    """Per-token-head packed rows carry inline scales, so GQA groups certify
-    under the canonical layout; the direct layout and the MLA latent path
-    keep excluding it."""
-    pth = KVQuantMode.FP8_PER_TOKEN_HEAD
-    pth_groups = [KVCacheGroupSpec(["l0"], _full_attention_spec(kv_quant_mode=pth))]
-    assert not _parallelism_agnostic(pth_groups)
-    assert _parallelism_agnostic(pth_groups, canonical=True)
-
-    mla_pth_groups = [
-        KVCacheGroupSpec(["l0"], _mla_spec(head_size=576, kv_quant_mode=pth))
-    ]
-    assert not _parallelism_agnostic(mla_pth_groups, canonical=True)
-
-
-def test_canonical_layout_certifies_uniform_type_wrapper():
-    """GLM-5.2/DSv3.2-style groups wrap same-type specs with different page
-    sizes (MLA plus its DSA indexer cache) in UniformTypeKVCacheSpecs; the
-    gate must look through the wrapper like the mapping derivation does."""
-
-    def uniform_groups(indexer_spec) -> list[KVCacheGroupSpec]:
-        return [
-            KVCacheGroupSpec(
-                ["mla_layer", "indexer_layer"],
-                UniformTypeKVCacheSpecs(
-                    block_size=16,
-                    kv_cache_specs={
-                        "mla_layer": _mla_spec(head_size=576),
-                        "indexer_layer": indexer_spec,
-                    },
-                ),
-            )
-        ]
-
-    mla_wrapped = uniform_groups(_mla_spec(head_size=128))
-    assert not _parallelism_agnostic(mla_wrapped)
-    assert _parallelism_agnostic(mla_wrapped, canonical=True)
-
-    # one uncertifiable inner spec poisons the wrapper
-    swa_mla_wrapped = uniform_groups(
-        SlidingWindowMLASpec(
-            block_size=16,
-            num_kv_heads=1,
-            head_size=576,
-            dtype=torch.float32,
-            sliding_window=128,
-        )
-    )
-    assert not _parallelism_agnostic(swa_mla_wrapped, canonical=True)
+        pytest.param(
+            [
+                KVCacheGroupSpec(["l0"], _full_attention_spec()),
+                KVCacheGroupSpec(["l1"], _SWA_SPEC),
+            ],
+            True,
+            id="attention-hybrid",
+        ),
+        pytest.param(
+            [KVCacheGroupSpec(["l0"], _SWA_MLA_SPEC)],
+            False,
+            id="swa-mla",
+        ),
+        pytest.param(
+            list(_make_mamba_hybrid_kv_cache_config().kv_cache_groups),
+            False,
+            id="mamba-hybrid",
+        ),
+        pytest.param(
+            [_uniform_group(_mla_spec(head_size=576), _mla_spec(head_size=128))],
+            True,
+            id="uniform-mla-wrapper",
+        ),
+        pytest.param(
+            [_uniform_group(_mla_spec(head_size=576), _SWA_MLA_SPEC)],
+            False,
+            id="uniform-uncertifiable-inner",
+        ),
+        pytest.param(
+            [
+                KVCacheGroupSpec(
+                    ["l0"],
+                    _full_attention_spec(kv_quant_mode=KVQuantMode.FP8_PER_TOKEN_HEAD),
+                )
+            ],
+            True,
+            id="per-token-head-gqa",
+        ),
+        pytest.param(
+            [
+                KVCacheGroupSpec(
+                    ["l0"],
+                    _mla_spec(
+                        head_size=576,
+                        kv_quant_mode=KVQuantMode.FP8_PER_TOKEN_HEAD,
+                    ),
+                )
+            ],
+            False,
+            id="per-token-head-mla",
+        ),
+    ],
+)
+def test_canonical_layout_gate(kv_cache_groups, certified):
+    """The canonical layout certifies portability group by group; none of
+    these shapes are portable in the direct layout."""
+    assert not _parallelism_agnostic(kv_cache_groups)
+    assert _parallelism_agnostic(kv_cache_groups, canonical=True) is certified
 
 
 def test_canonical_layout_certifies_v2_model_runner():

--- a/tests/v1/kv_offload/test_file_mapper.py
+++ b/tests/v1/kv_offload/test_file_mapper.py
@@ -53,6 +53,7 @@ def make_mapper_from_offloading_spec(**kwargs) -> FileMapper:
         ),
         replicated_layout=kwargs.get("replicated_layout", False),
         canonical_layout=kwargs.get("canonical_layout", False),
+        canonical_format=kwargs.get("canonical_format"),
     )
     spec = MagicMock(spec=OffloadingSpec)
     spec.config = config
@@ -211,15 +212,12 @@ def test_parallel_agnostic_separates_persistent_layouts():
 
 def test_canonical_layout_changes_storage_namespace():
     # Canonical bytes are not interchangeable with the direct layout, so the
-    # format id must fork the storage namespace.
-    from vllm.v1.attention.backends.utils import set_kv_cache_layout
-
-    set_kv_cache_layout("NHD")
-    try:
-        direct = make_mapper_from_offloading_spec()
-        canonical = make_mapper_from_offloading_spec(canonical_layout=True)
-    finally:
-        set_kv_cache_layout(None)
+    # format id must fork the storage namespace. The id is precomputed on
+    # OffloadingConfig, so the mapper needs no vLLM config context.
+    direct = make_mapper_from_offloading_spec()
+    canonical = make_mapper_from_offloading_spec(
+        canonical_layout=True, canonical_format="v1-nhd"
+    )
     assert "canonical_format" not in direct.fields
     assert canonical.fields["canonical_format"] == "v1-nhd"
     assert direct.base_path != canonical.base_path

--- a/tests/v1/kv_offload/test_file_mapper.py
+++ b/tests/v1/kv_offload/test_file_mapper.py
@@ -211,9 +211,7 @@ def test_parallel_agnostic_separates_persistent_layouts():
 
 
 def test_canonical_layout_changes_storage_namespace():
-    # Canonical bytes are not interchangeable with the direct layout, so the
-    # format id must fork the storage namespace. The id is precomputed on
-    # OffloadingConfig, so the mapper needs no vLLM config context.
+    # The canonical format id must fork the storage namespace
     direct = make_mapper_from_offloading_spec()
     canonical = make_mapper_from_offloading_spec(
         canonical_layout=True, canonical_format="v1-nhd"

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/canonical_mapping.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/canonical_mapping.py
@@ -157,10 +157,9 @@ def _packed_kv_regions(
 ) -> list[ByteRegion] | None:
     """K and V adjacent per (token, head), in NHD or HND stride order.
 
-    The inner dim is taken from the tensor: per-token-head quant pads it so
-    each (token, head) row carries its own inline scale, which makes the row
-    a self-contained, shard-portable unit. unpadded_page_size_bytes accounts
-    for the scale carve, so the size check below stays exact."""
+    Per-token-head quant pads each (token, head) row with its inline scale;
+    the inner dim comes from the tensor and unpadded_page_size_bytes covers
+    the carve."""
     bs, heads = spec.block_size, spec.num_kv_heads
     elem = kv_cache.element_size()
     head_elems = kv_cache.shape[3]
@@ -208,8 +207,7 @@ def _split_kv_regions(
     """K and V in separate page halves, in NHD or HND stride order."""
     bs, heads, head_size = spec.block_size, spec.num_kv_heads, spec.head_size
     elem = kv_cache.element_size()
-    # unpadded covers inline per-token-head scales, which split forms cannot
-    # carry per row; those fall through to the opaque fallback
+    # Per-token-head split forms mismatch here and fall to the opaque fallback
     if 2 * bs * heads * head_size * elem != spec.unpadded_page_size_bytes:
         return None
     _, half_stride, token_stride, head_stride, inner_stride = kv_cache.stride()
@@ -262,9 +260,7 @@ def _attention_byte_regions(
     None when the physical layout is not recognized (fail closed)."""
     bs, heads, head_size = spec.block_size, spec.num_kv_heads, spec.head_size
     if kv_cache.ndim == 4 and tuple(kv_cache.shape[:3]) == (num_blocks, heads, bs):
-        # The inner dim may differ from 2*head_size when per-(token, head)
-        # scales are padded inline (or int4 packs two values per byte);
-        # _packed_kv_regions validates it against the unpadded page size
+        # Inner dim may differ from 2*head_size (inline scales, int4 packing)
         return _packed_kv_regions(kv_cache, spec, head_shard, num_head_shards, cp_size)
     if tuple(kv_cache.shape) == (num_blocks, 2, bs, heads, head_size):
         return _split_kv_regions(kv_cache, spec, head_shard, num_head_shards, cp_size)
@@ -281,9 +277,7 @@ def _layer_mapping(
     if not isinstance(spec, AttentionSpec):
         return None
     bs = spec.block_size
-    # The offloaded span per block: equals real_page_size_bytes except for
-    # per-token-head quant, where it also covers the inline scale carve —
-    # matching CanonicalKVCacheRef.page_size_bytes on the worker side.
+    # Offloaded span per block; matches CanonicalKVCacheRef.page_size_bytes
     page = spec.unpadded_page_size_bytes
     if ctx.cp_size > 1 and (ctx.interleave > bs or bs % ctx.interleave):
         return None

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/canonical_mapping.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/canonical_mapping.py
@@ -155,11 +155,16 @@ def _packed_kv_regions(
     num_head_shards: int,
     cp_size: int,
 ) -> list[ByteRegion] | None:
-    """K and V adjacent per (token, head), in NHD or HND stride order."""
+    """K and V adjacent per (token, head), in NHD or HND stride order.
+
+    The inner dim is taken from the tensor: per-token-head quant pads it so
+    each (token, head) row carries its own inline scale, which makes the row
+    a self-contained, shard-portable unit. unpadded_page_size_bytes accounts
+    for the scale carve, so the size check below stays exact."""
     bs, heads = spec.block_size, spec.num_kv_heads
     elem = kv_cache.element_size()
-    head_elems = 2 * spec.head_size
-    if heads * bs * head_elems * elem != spec.real_page_size_bytes:
+    head_elems = kv_cache.shape[3]
+    if heads * bs * head_elems * elem != spec.unpadded_page_size_bytes:
         return None
     _, head_stride, token_stride, inner_stride = kv_cache.stride()
     if inner_stride != 1:
@@ -203,7 +208,9 @@ def _split_kv_regions(
     """K and V in separate page halves, in NHD or HND stride order."""
     bs, heads, head_size = spec.block_size, spec.num_kv_heads, spec.head_size
     elem = kv_cache.element_size()
-    if 2 * bs * heads * head_size * elem != spec.real_page_size_bytes:
+    # unpadded covers inline per-token-head scales, which split forms cannot
+    # carry per row; those fall through to the opaque fallback
+    if 2 * bs * heads * head_size * elem != spec.unpadded_page_size_bytes:
         return None
     _, half_stride, token_stride, head_stride, inner_stride = kv_cache.stride()
     if inner_stride != 1 or half_stride != bs * heads * head_size:
@@ -254,7 +261,10 @@ def _attention_byte_regions(
     """Byte regions of an attention page, given this rank's head shard.
     None when the physical layout is not recognized (fail closed)."""
     bs, heads, head_size = spec.block_size, spec.num_kv_heads, spec.head_size
-    if tuple(kv_cache.shape) == (num_blocks, heads, bs, 2 * head_size):
+    if kv_cache.ndim == 4 and tuple(kv_cache.shape[:3]) == (num_blocks, heads, bs):
+        # The inner dim may differ from 2*head_size when per-(token, head)
+        # scales are padded inline (or int4 packs two values per byte);
+        # _packed_kv_regions validates it against the unpadded page size
         return _packed_kv_regions(kv_cache, spec, head_shard, num_head_shards, cp_size)
     if tuple(kv_cache.shape) == (num_blocks, 2, bs, heads, head_size):
         return _split_kv_regions(kv_cache, spec, head_shard, num_head_shards, cp_size)
@@ -271,7 +281,10 @@ def _layer_mapping(
     if not isinstance(spec, AttentionSpec):
         return None
     bs = spec.block_size
-    page = spec.real_page_size_bytes
+    # The offloaded span per block: equals real_page_size_bytes except for
+    # per-token-head quant, where it also covers the inline scale carve —
+    # matching CanonicalKVCacheRef.page_size_bytes on the worker side.
+    page = spec.unpadded_page_size_bytes
     if ctx.cp_size > 1 and (ctx.interleave > bs or bs % ctx.interleave):
         return None
 
@@ -294,7 +307,7 @@ def _layer_mapping(
             parallelism_agnostic=ctx.cp_size == 1,
         )
 
-    if spec.kv_quant_mode.is_per_token_head or not isinstance(kv_cache, torch.Tensor):
+    if not isinstance(kv_cache, torch.Tensor):
         return None
     total, tp = ctx.total_kv_heads, ctx.tp_size
     if spec.num_kv_heads != max(1, total // tp):

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/config.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/config.py
@@ -8,7 +8,10 @@ from vllm.v1.core.kv_cache_utils import resolve_kv_cache_block_sizes
 from vllm.v1.kv_cache_interface import (
     AttentionSpec,
     FullAttentionSpec,
+    KVCacheSpec,
     MLAAttentionSpec,
+    SlidingWindowMLASpec,
+    SlidingWindowSpec,
 )
 from vllm.v1.kv_offload.config import (
     OffloadingCacheConfig,
@@ -136,6 +139,17 @@ def build_offloading_config(
     )
 
     canonical_layout = bool(extra_config.get("canonical_layout", False))
+    canonical_format = None
+    if canonical_layout:
+        from vllm.config import set_current_vllm_config
+
+        from .canonical_mapping import canonical_format_id
+
+        # canonical_format_id resolves the KV cache layout, which needs the
+        # current vLLM config; scheduler-side consumers run outside that
+        # context, so resolve the id here once.
+        with set_current_vllm_config(vllm_config):
+            canonical_format = canonical_format_id()
 
     # Only a single non-MLA full-attention group with genuinely head-sharded
     # pages is parallelism-invariant: replicated latent or GQA heads,
@@ -153,34 +167,43 @@ def build_offloading_config(
         and parallel_config.prefill_context_parallel_size == 1
     )
     # Canonical pages are topology-free by construction, so the canonical
-    # layout widens the gate to every config whose mappings derive portable:
-    # exactly-sharded or replicated GQA heads (writer rotation) and the
-    # TP-replicated MLA latent (one canonical copy for all replicas). The
-    # model-runner version is irrelevant here — certification happens per
-    # layer against live tensor strides at registration, and create_worker
-    # fails closed against this flag if any layer cannot be certified.
+    # layout widens the gate to every config whose mappings derive portable,
+    # group by group: sharded or replicated GQA heads, the TP-replicated MLA
+    # latent, and attention-only hybrids. Certification happens per layer
+    # against live tensor strides at registration, and create_worker fails
+    # closed against this flag if any layer cannot be certified.
     if canonical_layout and not is_parallelism_agnostic:
         tp_size = parallel_config.tensor_parallel_size
-        if isinstance(single_group_spec, FullAttentionSpec):
-            if type(single_group_spec) is MLAAttentionSpec:
-                spec_certifiable = (
-                    single_group_spec.compress_ratio == 1
-                    and single_group_spec.real_page_size_bytes
-                    % single_group_spec.block_size
-                    == 0
+        total_kv_heads = vllm_config.model_config.get_total_num_kv_heads()
+
+        def spec_certifiable(spec: KVCacheSpec) -> bool:
+            """Statically mirrors _layer_mapping's certifiable spec classes;
+            hybrid attention models certify group by group."""
+            if not isinstance(spec, AttentionSpec):
+                return False
+            if spec.kv_quant_mode.is_per_token_head:
+                return False
+            if type(spec) is MLAAttentionSpec:
+                return (
+                    spec.compress_ratio == 1
+                    and spec.real_page_size_bytes % spec.block_size == 0
                 )
-            else:
-                total_kv_heads = vllm_config.model_config.get_total_num_kv_heads()
-                spec_certifiable = (
-                    total_kv_heads % tp_size == 0 or tp_size % total_kv_heads == 0
-                )
-            is_parallelism_agnostic = (
-                spec_certifiable
-                and not single_group_spec.kv_quant_mode.is_per_token_head
-                and parallel_config.decode_context_parallel_size == 1
-                and parallel_config.prefill_context_parallel_size == 1
-                and parallel_config.world_size == tp_size
+            if isinstance(spec, (SlidingWindowMLASpec, MLAAttentionSpec)):
+                return False
+            if not isinstance(spec, (FullAttentionSpec, SlidingWindowSpec)):
+                return False
+            return total_kv_heads % tp_size == 0 or tp_size % total_kv_heads == 0
+
+        is_parallelism_agnostic = (
+            len(kv_cache_config.kv_cache_groups) > 0
+            and all(
+                spec_certifiable(group.kv_cache_spec)
+                for group in kv_cache_config.kv_cache_groups
             )
+            and parallel_config.decode_context_parallel_size == 1
+            and parallel_config.prefill_context_parallel_size == 1
+            and parallel_config.world_size == tp_size
+        )
 
     kv_events_config = vllm_config.kv_events_config
     cache_dtype = (
@@ -217,4 +240,5 @@ def build_offloading_config(
         ),
         replicated_layout=replicated_layout,
         canonical_layout=canonical_layout,
+        canonical_format=canonical_format,
     )

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/config.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/config.py
@@ -188,17 +188,18 @@ def build_offloading_config(
                 )
             if not isinstance(spec, AttentionSpec):
                 return False
-            if spec.kv_quant_mode.is_per_token_head:
-                return False
             if type(spec) is MLAAttentionSpec:
                 return (
-                    spec.compress_ratio == 1
+                    not spec.kv_quant_mode.is_per_token_head
+                    and spec.compress_ratio == 1
                     and spec.real_page_size_bytes % spec.block_size == 0
                 )
             if isinstance(spec, (SlidingWindowMLASpec, MLAAttentionSpec)):
                 return False
             if not isinstance(spec, (FullAttentionSpec, SlidingWindowSpec)):
                 return False
+            # Per-token-head quant is fine: its packed rows carry their
+            # scales inline, so head-shard fragments stay self-contained
             return total_kv_heads % tp_size == 0 or tp_size % total_kv_heads == 0
 
         is_parallelism_agnostic = (

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/config.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/config.py
@@ -146,9 +146,7 @@ def build_offloading_config(
 
         from .canonical_mapping import canonical_format_id
 
-        # canonical_format_id resolves the KV cache layout, which needs the
-        # current vLLM config; scheduler-side consumers run outside that
-        # context, so resolve the id here once.
+        # Resolved once here; consumers may run outside the vLLM config context
         with set_current_vllm_config(vllm_config):
             canonical_format = canonical_format_id()
 
@@ -167,22 +165,17 @@ def build_offloading_config(
         and parallel_config.decode_context_parallel_size == 1
         and parallel_config.prefill_context_parallel_size == 1
     )
-    # Canonical pages are topology-free by construction, so the canonical
-    # layout widens the gate to every config whose mappings derive portable,
-    # group by group: sharded or replicated GQA heads, the TP-replicated MLA
-    # latent, and attention-only hybrids. Certification happens per layer
-    # against live tensor strides at registration, and create_worker fails
-    # closed against this flag if any layer cannot be certified.
+    # Canonical pages are topology-free, so the gate widens to every config
+    # whose mappings derive portable, group by group; certification happens
+    # per layer at registration and create_worker fails closed on this flag.
     if canonical_layout and not is_parallelism_agnostic:
         tp_size = parallel_config.tensor_parallel_size
         total_kv_heads = vllm_config.model_config.get_total_num_kv_heads()
 
         def spec_certifiable(spec: KVCacheSpec) -> bool:
-            """Statically mirrors _layer_mapping's certifiable spec classes;
-            hybrid attention models certify group by group."""
+            """Statically mirrors _layer_mapping's certifiable spec classes."""
             if isinstance(spec, UniformTypeKVCacheSpecs):
-                # Same-type layers with differing page sizes (e.g. MLA plus
-                # its DSA indexer cache); mappings derive per inner spec
+                # Same-type layers with differing page sizes (MLA + DSA indexer)
                 return len(spec.kv_cache_specs) > 0 and all(
                     spec_certifiable(inner) for inner in spec.kv_cache_specs.values()
                 )
@@ -198,8 +191,7 @@ def build_offloading_config(
                 return False
             if not isinstance(spec, (FullAttentionSpec, SlidingWindowSpec)):
                 return False
-            # Per-token-head quant is fine: its packed rows carry their
-            # scales inline, so head-shard fragments stay self-contained
+            # Per-token-head packed rows carry scales inline; self-contained
             return total_kv_heads % tp_size == 0 or tp_size % total_kv_heads == 0
 
         is_parallelism_agnostic = (

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/config.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/config.py
@@ -12,6 +12,7 @@ from vllm.v1.kv_cache_interface import (
     MLAAttentionSpec,
     SlidingWindowMLASpec,
     SlidingWindowSpec,
+    UniformTypeKVCacheSpecs,
 )
 from vllm.v1.kv_offload.config import (
     OffloadingCacheConfig,
@@ -179,6 +180,12 @@ def build_offloading_config(
         def spec_certifiable(spec: KVCacheSpec) -> bool:
             """Statically mirrors _layer_mapping's certifiable spec classes;
             hybrid attention models certify group by group."""
+            if isinstance(spec, UniformTypeKVCacheSpecs):
+                # Same-type layers with differing page sizes (e.g. MLA plus
+                # its DSA indexer cache); mappings derive per inner spec
+                return len(spec.kv_cache_specs) > 0 and all(
+                    spec_certifiable(inner) for inner in spec.kv_cache_specs.values()
+                )
             if not isinstance(spec, AttentionSpec):
                 return False
             if spec.kv_quant_mode.is_per_token_head:

--- a/vllm/v1/kv_offload/config.py
+++ b/vllm/v1/kv_offload/config.py
@@ -80,3 +80,7 @@ class OffloadingConfig:
     # True when the canonical per-layer host byte layout was requested via
     # kv_connector_extra_config; certified per-layer at worker registration.
     canonical_layout: bool = False
+    # Identity of the canonical byte format when canonical_layout is set.
+    # Computed once at config build, where the vLLM config context exists —
+    # consumers (e.g. FileMapper) may run outside that context.
+    canonical_format: str | None = None

--- a/vllm/v1/kv_offload/config.py
+++ b/vllm/v1/kv_offload/config.py
@@ -80,7 +80,5 @@ class OffloadingConfig:
     # True when the canonical per-layer host byte layout was requested via
     # kv_connector_extra_config; certified per-layer at worker registration.
     canonical_layout: bool = False
-    # Identity of the canonical byte format when canonical_layout is set.
-    # Computed once at config build, where the vLLM config context exists —
-    # consumers (e.g. FileMapper) may run outside that context.
+    # Canonical format id, resolved at config build (needs the config context)
     canonical_format: str | None = None

--- a/vllm/v1/kv_offload/file_mapper.py
+++ b/vllm/v1/kv_offload/file_mapper.py
@@ -4,9 +4,6 @@
 import hashlib
 import json
 
-from vllm.distributed.kv_transfer.kv_connector.v1.offloading.canonical_mapping import (
-    canonical_format_id,
-)
 from vllm.v1.kv_offload.base import (
     OffloadingSpec,
     OffloadKey,
@@ -94,7 +91,6 @@ class FileMapper:
             for group in config.groups
         ]
         parallel = config.parallel
-        canonical_format = canonical_format_id() if config.canonical_layout else None
         return cls(
             root_dir=root_dir,
             model_name=config.model.name,
@@ -112,7 +108,7 @@ class FileMapper:
                 and (parallel.is_parallelism_agnostic or config.replicated_layout)
             ),
             replicated_layout=(parallel_agnostic and config.replicated_layout),
-            canonical_format=canonical_format,
+            canonical_format=config.canonical_format,
         )
 
     def get_file_name(self, key: OffloadKey) -> str:


### PR DESCRIPTION
Stacked on #51690. The packed per-token-head form pads each (token, head) row so its fp32 scale sits inline, making rows self-contained shard-portable units. Size regions against `unpadded_page_size_bytes`, which covers the scale carve and matches the worker's offload refs; split forms cannot carry scales per row and keep falling to the opaque fallback.

Unlocks TP-agnostic offload for per-token-head KV cache dtypes (`int8_per_token_head`, `fp8_per_token_head`, `int4_per_token_head`) on GQA models.

## Test plan

`pytest tests/v1/kv_connector/unit/offloading_connector/test_canonical_mapping.py tests/v1/kv_connector/unit/offloading_connector/test_config.py` (no GPU): padded-row certification, tiling across ranks, gate coverage.

E2E on 2x H200: Qwen3-4B-FP8 with `--kv-cache-dtype fp8_per_token_head` tp2 and canonical_layout: all layers certified portable, CPU load bytes equal store bytes.