### PR TITLE
[Bugfix][KV Cache] Fix incremental multimodal block hashing

### DIFF
--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -759,6 +759,37 @@ def test_request_block_hasher(hash_fn):
 
 
 @pytest.mark.parametrize("hash_fn", [sha256, sha256_cbor])
+def test_request_block_hasher_incremental_append_with_multiple_mm_features(hash_fn):
+    mm_positions = [
+        PlaceholderRange(offset=4, length=2),
+        PlaceholderRange(offset=6, length=1),
+    ]
+    incremental = make_request(
+        request_id="incremental",
+        prompt_token_ids=list(range(7)),
+        block_size=4,
+        hash_fn=hash_fn,
+        mm_positions=mm_positions,
+        mm_hashes=["A", "B"],
+    )
+    incremental.append_output_token_ids(7)
+    fresh = make_request(
+        request_id="fresh",
+        prompt_token_ids=list(range(8)),
+        block_size=4,
+        hash_fn=hash_fn,
+        mm_positions=mm_positions,
+        mm_hashes=["A", "B"],
+    )
+
+    expected_second_hash = hash_fn(
+        (incremental.block_hashes[0], (4, 5, 6, 7), (("A", 0), ("B", 2)))
+    )
+    assert incremental.block_hashes[1] == expected_second_hash
+    assert incremental.block_hashes == fresh.block_hashes
+
+
+@pytest.mark.parametrize("hash_fn", [sha256, sha256_cbor])
 def test_hash_tokens_different_mm_input(hash_fn):
     request1 = make_request(
         request_id="0",

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -15,6 +15,7 @@ from typing import Any, NamedTuple, NewType, TypeAlias, cast, overload
 from vllm import envs
 from vllm.config import VllmConfig
 from vllm.logger import init_logger
+from vllm.multimodal.utils import get_mm_features_in_window
 from vllm.utils.hashing import xxhash, xxhash_cbor
 from vllm.utils.math_utils import cdiv, round_up
 from vllm.utils.mem_utils import format_gib
@@ -732,12 +733,15 @@ def get_request_block_hasher(
             return []
 
         curr_mm_idx = 0
-        if start_token_idx > 0:
-            # Set curr_mm_idx = -1 to indicate the last mm input.
-            # Note that since we reach to this branch only when the block is
-            # completed with generated tokens, we only need to consider the
-            # last mm input.
-            curr_mm_idx = -1
+        mm_features = request.mm_features
+        if start_token_idx > 0 and mm_features:
+            last_mm_pos = mm_features[-1].mm_position
+            if last_mm_pos.offset + last_mm_pos.length > start_token_idx:
+                curr_mm_idx, _ = get_mm_features_in_window(
+                    mm_features,
+                    start_token_idx,
+                    start_token_idx + hash_block_size,
+                )
 
         prev_block_hash_value = (
             request.block_hashes[-1] if request.block_hashes else None


### PR DESCRIPTION
## Purpose

`Request.append_output_token_ids()` computes block hashes incrementally when a
new full block is completed. If that block overlaps multiple multimodal
features, the existing incremental path starts from only the final feature and
can omit an earlier feature in the same block. The resulting hash then differs
from a freshly constructed request with identical tokens and multimodal input.

This change starts multimodal hashing from the first feature overlapping the
new block, using the existing `get_mm_features_in_window()` helper. It adds a
regression test for both supported hash functions and checks that incremental
and fresh construction produce identical block hashes.

Addresses the multimodal hashing subproblem identified in #49377 and #49448.
The prior investigation and patch direction in #49448 are credited to
@edwardlong-ctrl, who is also attributed in the commit trailer.

This does not duplicate an open PR:

- #49448 was closed unmerged by its author.
- #49619 rehashes after streaming-session token replacement; it does not change
  the ordinary `append_output_token_ids()` path fixed here.
- #50114 skips no-op hasher calls before a full-block boundary; it retains the
  last-feature assumption addressed here.
- Searches for `49377 in:body` and multimodal block-hash keywords found no open
  PR implementing this fix.

AI assistance was used in developing this PR.

## Test Plan

The repository uv environment is denoted by `<venv>` below.

```bash
<venv>/bin/python -m pytest -q tests/v1/core/test_kv_cache_utils.py \
  -k 'incremental_append_with_multiple_mm_features'
<venv>/bin/python -m pytest -q tests/v1/core/test_kv_cache_utils.py \
  -k 'request_block_hasher or hash_tokens_different_mm_input'
<venv>/bin/python -m pytest -q tests/v1/core/test_kv_cache_utils.py
ruff check vllm/v1/core/kv_cache_utils.py \
  tests/v1/core/test_kv_cache_utils.py
ruff format --check vllm/v1/core/kv_cache_utils.py \
  tests/v1/core/test_kv_cache_utils.py
git diff --check origin/main...HEAD
```

An additional seeded local differential test compares incremental hashing with
fresh hashing across randomized multimodal layouts and block boundaries.

## Test Result

- New regression: 2 passed, 77 deselected.
- Neighboring request block-hasher tests: 8 passed, 71 deselected.
- Randomized differential check: 500 layouts and 1,147 completed block
  boundaries; every incremental hash list matched fresh construction.
- Ruff checks, formatting checks, and `git diff --check`: passed.
- Complete test file: 61 passed, 18 failed. All 18 failures occur while
  `ModelConfig` attempts to access Hugging Face in the network-restricted test
  environment; they do not reach the modified block-hashing path.
- Model evaluation: not applicable; this changes cache-key construction and
  does not change model execution or generated outputs.
