### PR TITLE
[Bugfix][Tool Parser] GigaChat3: stop special tokens split across deltas leaking into output

### DIFF
--- a/tests/tool_parsers/test_gigachat3_tool_parser.py
+++ b/tests/tool_parsers/test_gigachat3_tool_parser.py
@@ -350,3 +350,65 @@ def test_streaming_tool_call_with_large_steps(
     assert call.function.name == "manage_user_memory"
     args_dict = json.loads(call.function.arguments)
     assert args_dict == COMPLEX_ARGS_DICT
+
+
+@pytest.mark.parametrize(
+    "model_output, expected_content, expected_args",
+    [
+        pytest.param(
+            MIXED_OUTPUT_GIGACHAT3, CONTENT_TEXT, SIMPLE_ARGS_DICT, id="gigachat3"
+        ),
+        pytest.param(
+            MIXED_OUTPUT_GIGACHAT31, CONTENT_TEXT, SIMPLE_ARGS_DICT, id="gigachat31"
+        ),
+        pytest.param(
+            SIMPLE_FUNCTION_OUTPUT_GIGACHAT3,
+            None,
+            SIMPLE_ARGS_DICT,
+            id="gigachat3_no_content",
+        ),
+        pytest.param(
+            SIMPLE_FUNCTION_OUTPUT_GIGACHAT31,
+            None,
+            SIMPLE_ARGS_DICT,
+            id="gigachat31_no_content",
+        ),
+        pytest.param(
+            MIXED_OUTPUT_GIGACHAT31 + EOS_TOKEN,
+            CONTENT_TEXT,
+            SIMPLE_ARGS_DICT,
+            id="gigachat31_eos",
+        ),
+        pytest.param(
+            PARAMETERLESS_FUNCTION_OUTPUT_GIGACHAT31,
+            None,
+            {},
+            id="gigachat31_parameterless",
+        ),
+    ],
+)
+def test_streaming_split_special_tokens(
+    model_output: str,
+    expected_content: str | None,
+    expected_args: dict,
+    gigachat_tokenizer: TokenizerLike,
+):
+    """Special tokens split across deltas must not leak into content or
+    arguments. They are single tokens for the real tokenizer, but proxies
+    and re-chunking layers can split them; the parser previously matched
+    them against delta_text only, so split markers streamed out verbatim
+    and a trailing "}</s" fragment could end up in the arguments.
+    """
+    tool_parser: ToolParser = ToolParserManager.get_tool_parser("gigachat3")(
+        gigachat_tokenizer
+    )
+    deltas = [model_output[i : i + 3] for i in range(0, len(model_output), 3)]
+    reconstructor = run_tool_extraction_streaming(
+        tool_parser, deltas, assert_one_tool_per_delta=False
+    )
+    assert (reconstructor.other_content or None) == expected_content
+    assert len(reconstructor.tool_calls) == 1
+    call = reconstructor.tool_calls[0]
+    assert call.function.name == "manage_user_memory"
+    assert json.loads(call.function.arguments) == expected_args
+    assert tool_parser.get_remaining_unstreamed_args() == ""

--- a/vllm/tool_parsers/gigachat3_tool_parser.py
+++ b/vllm/tool_parsers/gigachat3_tool_parser.py
@@ -45,16 +45,23 @@ ARGS_REGEX = re.compile(
     re.DOTALL,
 )
 
+EOS_TOKEN = "</s>"
+CONTENT_STOP_TOKENS = ("<|message_sep|>", "<|function_call|>")
+CONTENT_HOLD_TOKENS = (*CONTENT_STOP_TOKENS, EOS_TOKEN)
+
 
 class GigaChat3ToolParser(ToolParser):
     def __init__(self, tokenizer: TokenizerLike, tools: list[Tool] | None = None):
         super().__init__(tokenizer, tools)
-        self.tool_started: bool = False
         self.tool_name_sent: bool = False
         self.tool_id: str | None = None
         self.prev_tool_call_arr: list[dict] = []
-        self.end_content: bool = False
         self.streamed_args_for_tool: list[str] = []
+        # Content scanner state: text before _content_consumed has been
+        # emitted (or dropped as special tokens); once _content_done is set,
+        # everything after belongs to the function call.
+        self._content_consumed: int = 0
+        self._content_done: bool = False
 
     def adjust_request(
         self, request: ChatCompletionRequest | ResponsesRequest
@@ -128,22 +135,15 @@ class GigaChat3ToolParser(ToolParser):
         delta_token_ids: Sequence[int],
         request: ChatCompletionRequest,
     ) -> DeltaMessage | None:
-        content = None
         func_name = None
         cur_args = None
-        m_func = REGEX_FUNCTION_CALL.search(current_text)
-        if not self.tool_started:
-            m_content = REGEX_CONTENT_PATTERN.search(delta_text)
-            if m_content:
-                content = m_content.group(1)
-                self.end_content = True
-            else:
-                if not self.end_content:
-                    content = delta_text
-            if m_func:
-                self.tool_started = True
+        if not self._content_done:
+            content = self._stream_content(current_text)
             if content:
                 return DeltaMessage(content=content)
+            if not self._content_done:
+                return None
+        m_func = REGEX_FUNCTION_CALL.search(current_text)
         if not m_func:
             return None
         json_tail = m_func.group(1).strip()
@@ -153,15 +153,21 @@ class GigaChat3ToolParser(ToolParser):
         args_match = ARGS_REGEX.search(json_tail)
         if args_match:
             cur_args = args_match.group(1).strip()
-            if cur_args.endswith("</s>"):
-                cur_args = cur_args[: -len("</s>")]
-            if cur_args.endswith("}"):  # last '}' end of json
-                try:
-                    candidate = cur_args[:-1].strip()
-                    json.loads(candidate, strict=False)
-                    cur_args = candidate
-                except json.JSONDecodeError:
-                    pass
+            # The regex captures to the end of the payload, so cur_args may
+            # end with text that is not part of the arguments yet: a partial
+            # or complete EOS token, and the enclosing object's closing
+            # brace. Hold those back until later text resolves them, so the
+            # streamed prefix never has to shrink.
+            if cur_args.endswith(EOS_TOKEN):
+                cur_args = cur_args[: -len(EOS_TOKEN)]
+            else:
+                for k in range(len(EOS_TOKEN) - 1, 0, -1):
+                    if cur_args.endswith(EOS_TOKEN[:k]):
+                        cur_args = cur_args[:-k]
+                        break
+            cur_args = cur_args.rstrip()
+            if cur_args.endswith("}"):
+                cur_args = cur_args[:-1]
         if not self.prev_tool_call_arr:
             self.prev_tool_call_arr.append({})
         if not self.tool_name_sent:
@@ -212,3 +218,35 @@ class GigaChat3ToolParser(ToolParser):
                 )
             ],
         )
+
+    def _stream_content(self, current_text: str) -> str:
+        """Emit chat content up to the first special token.
+
+        Works on the accumulated text rather than a single delta, so special
+        tokens split across deltas are still recognized. A tail that could
+        still become a special token is held back until disambiguated.
+        """
+        out: list[str] = []
+        while not self._content_done and self._content_consumed < len(current_text):
+            seg = current_text[self._content_consumed :]
+            lt = seg.find("<")
+            if lt == -1:
+                out.append(seg)
+                self._content_consumed += len(seg)
+                break
+            if lt > 0:
+                out.append(seg[:lt])
+                self._content_consumed += lt
+                continue
+            if seg.startswith(CONTENT_STOP_TOKENS):
+                self._content_done = True
+                break
+            if seg.startswith(EOS_TOKEN):
+                # Dropped from content, as in non-streaming extraction.
+                self._content_consumed += len(EOS_TOKEN)
+                continue
+            if any(token.startswith(seg) for token in CONTENT_HOLD_TOKENS):
+                break
+            out.append("<")
+            self._content_consumed += 1
+        return "".join(out)


### PR DESCRIPTION
﻿FIX #51701

The gigachat3 streaming parser matches `<|message_sep|>` / `<|function_call|>` against `delta_text` only. The special tokens are single tokens for the real tokenizer, but anything that re-chunks the stream can split them, and then they leak into `delta.content`:

```
I'll check that for you.<|function_call|>
```

The arguments handling has a related problem: `ARGS_REGEX` captures to the end of the payload, so the wrapper object's closing brace and a partial `</s>` can end up in the streamed arguments before the end-trimming logic gets a chance to run, leaving clients with invalid JSON like `{"action": "create", "id": "preferences"}}</s`.

This changes the streaming path to scan the accumulated text for content, holding back any tail that could still become a special token, and to hold back the trailing brace/EOS tail from the arguments until later text resolves it. The streamed argument prefix never shrinks, so the existing prefix-diff logic keeps working. Non-streaming extraction is unchanged.

Not duplicating any open work: the only open PRs mentioning gigachat are #47501 (Rust port) and #47708 (GigaChat 3.5 support); no issue or PR covers the streaming parser (checked 2026-08-10).

Tests: `pytest tests/tool_parsers/test_gigachat3_tool_parser.py` — 30 passed (24 existing + 6 new cases feeding 3-char deltas that split the special tokens; they assert content/arguments match non-streaming and that `get_remaining_unstreamed_args()` is empty afterwards). Run on a CPU-only box with a `VLLM_TARGET_DEVICE=empty` install; the GPU-less env reports unrelated per-test teardown errors from conftest's accelerator cleanup. Also verified with a streaming-vs-nonstreaming differential harness over 7 output corpora x 6 chunk alignments: 16 divergence groups on main, 0 with this change. No model eval needed, frontend parsing only.
