### PR TITLE
[Misc] Add unit tests for GDN/FLA Triton kernels

### DIFF
--- a/tests/kernels/mamba/test_chunk_fwd_o.py
+++ b/tests/kernels/mamba/test_chunk_fwd_o.py
@@ -1,0 +1,260 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Precision tests for vllm's chunk_fwd_o Triton operator.
+
+Exercises chunk_fwd_kernel_o via its Python wrapper. For each chunk of BT=64
+timesteps and head, it computes:
+    o = (Q @ H^T + causal(Q @ K^T) @ V) * scale
+where H is a pre-computed recurrent hidden state, with optional gating via a
+cumulative log-decay g. Compared against a naive float32 PyTorch reference.
+"""
+
+import pytest
+import torch
+
+from vllm.platforms import current_platform
+from vllm.third_party.flash_linear_attention.ops.chunk_o import chunk_fwd_o
+from vllm.third_party.flash_linear_attention.ops.index import prepare_chunk_indices
+from vllm.third_party.flash_linear_attention.ops.utils import FLA_CHUNK_SIZE
+
+pytestmark = pytest.mark.skipif(
+    not (current_platform.is_cuda_alike() or current_platform.is_xpu()),
+    reason="chunk_fwd_o dispatches a Triton kernel that requires a "
+    "CUDA-alike or XPU device.",
+)
+
+DEVICE = current_platform.device_type
+
+TOL_FP32 = (1e-2, 1e-3)  # (rtol, atol) vs the float32 reference
+TOL_FP16 = (1e-2, 1e-3)
+TOL_BF16 = (2e-2, 5e-3)  # bf16 has 8 mantissa bits against fp16's 11
+
+
+def _chunk_fwd_o_ref(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    h: torch.Tensor,
+    g: torch.Tensor | None = None,
+    scale: float | None = None,
+    cu_seqlens: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Naive PyTorch reference for the chunked forward output kernel.
+
+    Both code paths share one loop: the kernel treats a fixed batch as a
+    degenerate varlen one, so a `None` cu_seqlens becomes [0, T, 2T, ...].
+
+    Args:
+        q: (B, T, Hg, K) — query tensor (Hg may be < H for GQA).
+        k: (B, T, Hg, K) — key tensor.
+        v: (B, T, H, V) — value tensor.
+        h: (NT_total, H, V, K) — hidden state per (sequence, local chunk).
+        g: (B, T, H) — optional cumulative log-decay (per head).
+        cu_seqlens: 1D tensor of N+1 offsets into a flattened B=1 batch;
+            None means B equal-length sequences of T timesteps.
+
+    Returns:
+        o: same shape as v.
+    """
+    B, T, Hg, K = q.shape
+    H, V = v.shape[2], v.shape[3]
+    BT = FLA_CHUNK_SIZE
+    T_flat = B * T
+    rep = H // Hg  # GQA replication factor (1 when Hg == H)
+    if scale is None:
+        scale = K**-0.5
+
+    if cu_seqlens is None:
+        bounds = [(b * T, b * T + T) for b in range(B)]
+    else:
+        offsets = cu_seqlens.tolist()
+        # The kernel leaves anything past cu_seqlens[-1] uninitialized.
+        assert B == 1 and offsets[-1] == T, (
+            f"varlen expects a flattened, unpadded batch: got B={B}, T={T}, "
+            f"cu_seqlens[-1]={offsets[-1]}"
+        )
+        bounds = list(zip(offsets[:-1], offsets[1:]))
+
+    # Fold the batch axis into time, as the kernel does via bos.
+    q, k, v = (x.reshape(1, T_flat, *x.shape[2:]) for x in (q, k, v))
+    if g is not None:
+        g = g.reshape(1, T_flat, H)
+
+    o = torch.zeros(1, T_flat, H, V, dtype=torch.float32, device=q.device)
+
+    i_tg = 0
+    for bos, eos in bounds:
+        for t0 in range(bos, eos, BT):
+            t1 = min(t0 + BT, eos)
+            bt = t1 - t0
+            mask = torch.tril(torch.ones(bt, bt, device=q.device))
+
+            for hh in range(H):
+                hg_idx = hh // rep
+
+                q_c = q[0, t0:t1, hg_idx].float()  # (bt, K)
+                k_c = k[0, t0:t1, hg_idx].float()  # (bt, K)
+                v_c = v[0, t0:t1, hh].float()  # (bt, V)
+                h_block = h[i_tg, hh].float()  # (V, K)
+
+                inter = q_c @ h_block.t()  # (bt, V)
+                attn = q_c @ k_c.t()  # (bt, bt)
+
+                if g is not None:
+                    g_c = g[0, t0:t1, hh].float()
+                    inter = inter * torch.exp(g_c).unsqueeze(-1)
+                    attn = attn * torch.exp(g_c[:, None] - g_c[None, :])
+
+                attn = attn * mask
+                intra = attn @ v_c
+
+                o[0, t0:t1, hh] = inter * scale + intra * scale
+            i_tg += 1
+
+    return o.view(B, T, H, V)
+
+
+def _make_inputs(
+    B: int,
+    T: int,
+    H: int,
+    Hg: int,
+    K: int,
+    V: int,
+    dtype: torch.dtype = torch.float32,
+    use_g: bool = True,
+    chunk_indices: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor | None]:
+    if chunk_indices is not None:
+        # One h row per (sequence, local chunk); B is not part of that count.
+        assert B == 1, "varlen inputs must be a flattened B=1 batch"
+        NT = len(chunk_indices)
+    else:
+        NT = B * ((T + FLA_CHUNK_SIZE - 1) // FLA_CHUNK_SIZE)
+    q = torch.randn(B, T, Hg, K, device=DEVICE, dtype=dtype) * 0.1
+    k = torch.randn(B, T, Hg, K, device=DEVICE, dtype=dtype) * 0.1
+    v = torch.randn(B, T, H, V, device=DEVICE, dtype=dtype) * 0.1
+    h = torch.randn(NT, H, V, K, device=DEVICE, dtype=dtype) * 0.1
+    # g stays fp32 as in the real pipeline; the kernel's exp() requires it.
+    g = (
+        torch.randn(B, T, H, device=DEVICE, dtype=torch.float32) * 0.1
+        if use_g
+        else None
+    )
+    return q, k, v, h, g
+
+
+# (B, T, H, Hg, K, V, use_g)
+CONFIGS = [
+    (1, 64, 2, 2, 64, 64, True),
+    (1, 64, 2, 2, 64, 64, False),  # no gating
+    (1, 128, 2, 2, 64, 64, True),  # two chunks
+    (2, 64, 2, 2, 64, 64, True),  # batch > 1
+    (1, 64, 4, 2, 64, 64, True),  # GQA (Hg < H)
+    (1, 64, 2, 2, 128, 64, True),  # K = 128 (two blocks)
+    (1, 64, 2, 2, 64, 128, True),  # V = 128 (two blocks)
+    (1, 100, 2, 2, 64, 64, True),  # partial final chunk (100 = 64 + 36)
+]
+
+
+@pytest.mark.parametrize(("B", "T", "H", "Hg", "K", "V", "use_g"), CONFIGS)
+@torch.inference_mode()
+def test_chunk_fwd_o(
+    B: int, T: int, H: int, Hg: int, K: int, V: int, use_g: bool
+) -> None:
+    """chunk_fwd_o must match the naive reference (fp32)."""
+    torch.manual_seed(0)
+    q, k, v, h, g = _make_inputs(B, T, H, Hg, K, V, use_g=use_g)
+
+    o = chunk_fwd_o(q, k, v, h, g=g)
+    o_ref = _chunk_fwd_o_ref(q, k, v, h, g=g)
+
+    assert o.shape == o_ref.shape
+    assert o.dtype == v.dtype
+    assert not torch.any(torch.isnan(o))
+    rtol, atol = TOL_FP32
+    torch.testing.assert_close(o.float(), o_ref, rtol=rtol, atol=atol)
+
+
+@pytest.mark.parametrize(
+    ("dtype", "tol"),
+    [(torch.bfloat16, TOL_BF16), (torch.float16, TOL_FP16)],
+)
+@torch.inference_mode()
+def test_chunk_fwd_o_low_precision(
+    dtype: torch.dtype, tol: tuple[float, float]
+) -> None:
+    """bf16/fp16 inputs must match the fp32 reference (the dtype used in prod)."""
+    torch.manual_seed(0)
+    q, k, v, h, g = _make_inputs(1, 64, 2, 2, 64, 64, dtype, use_g=True)
+
+    o = chunk_fwd_o(q, k, v, h, g=g)
+    o_ref = _chunk_fwd_o_ref(q, k, v, h, g=g)
+
+    assert o.dtype == dtype  # o.float() below would hide a wrong dtype
+    rtol, atol = tol
+    torch.testing.assert_close(o.float(), o_ref, rtol=rtol, atol=atol)
+
+
+@pytest.mark.parametrize("use_g", [True, False])
+@torch.inference_mode()
+def test_chunk_fwd_o_varlen(use_g: bool) -> None:
+    """cu_seqlens (IS_VARLEN branch) must match the naive varlen reference.
+
+    Real prefill batches always flatten multiple sequences and drive this
+    kernel through cu_seqlens/chunk_indices, exercising the bos/eos/i_tg
+    offset math instead of the fixed-batch path above. Parametrized over
+    gating so all four USE_G x IS_VARLEN kernel variants get covered.
+    """
+    torch.manual_seed(0)
+    cu_seqlens = torch.tensor([0, 40, 96, 250], device=DEVICE, dtype=torch.int32)
+    T = int(cu_seqlens[-1])
+    chunk_indices = prepare_chunk_indices(cu_seqlens, FLA_CHUNK_SIZE)
+    q, k, v, h, g = _make_inputs(
+        1, T, 2, 2, 64, 64, use_g=use_g, chunk_indices=chunk_indices
+    )
+
+    o = chunk_fwd_o(q, k, v, h, g=g, cu_seqlens=cu_seqlens, chunk_indices=chunk_indices)
+    o_ref = _chunk_fwd_o_ref(q, k, v, h, g=g, cu_seqlens=cu_seqlens)
+
+    assert o.shape == o_ref.shape
+    assert o.dtype == v.dtype
+    assert not torch.any(torch.isnan(o))
+    rtol, atol = TOL_FP32
+    torch.testing.assert_close(o.float(), o_ref, rtol=rtol, atol=atol)
+
+
+@torch.inference_mode()
+def test_chunk_fwd_o_core_attn_out_buffer_reuse() -> None:
+    """core_attn_out must be written in-place and match a fresh allocation.
+
+    Real GDN layers (Qwen/Kimi) pre-allocate a core_attn_out buffer and pass
+    it in to avoid an extra allocation per forward pass; this exercises that
+    reuse path in chunk_fwd_o instead of the default torch.empty_like(v).
+    """
+    torch.manual_seed(0)
+    q, k, v, h, g = _make_inputs(1, 64, 2, 2, 64, 64, use_g=True)
+
+    core_attn_out = torch.zeros_like(v)
+    o = chunk_fwd_o(q, k, v, h, g=g, core_attn_out=core_attn_out)
+    o_ref = _chunk_fwd_o_ref(q, k, v, h, g=g)
+
+    assert o.data_ptr() == core_attn_out.data_ptr()
+    assert not torch.any(torch.isnan(o))
+    rtol, atol = TOL_FP32
+    torch.testing.assert_close(o.float(), o_ref, rtol=rtol, atol=atol)
+
+
+@torch.inference_mode()
+def test_chunk_fwd_o_non_default_scale() -> None:
+    """A non-default scale must be honoured, not silently replaced by K**-0.5."""
+    torch.manual_seed(0)
+    q, k, v, h, g = _make_inputs(1, 64, 2, 2, 64, 64, use_g=True)
+
+    scale = 0.5  # K**-0.5 would be 0.125
+    o = chunk_fwd_o(q, k, v, h, g=g, scale=scale)
+    o_ref = _chunk_fwd_o_ref(q, k, v, h, g=g, scale=scale)
+
+    assert not torch.any(torch.isnan(o))
+    rtol, atol = TOL_FP32
+    torch.testing.assert_close(o.float(), o_ref, rtol=rtol, atol=atol)

--- a/tests/kernels/mamba/test_gdn_gating.py
+++ b/tests/kernels/mamba/test_gdn_gating.py
@@ -1,0 +1,103 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Accuracy tests for GDN gating Triton kernels."""
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from vllm.model_executor.layers.mamba.gdn.qwen_gdn_linear_attn import fused_gdn_gating
+from vllm.platforms import current_platform
+
+pytestmark = pytest.mark.skipif(
+    not (current_platform.is_cuda_alike() or current_platform.is_xpu()),
+    reason="fused_gdn_gating dispatches a Triton kernel that requires a "
+    "CUDA-alike or XPU device.",
+)
+
+DEVICE = current_platform.device_type
+
+
+def fused_gdn_gating_ref(A_log, a, b, dt_bias, beta=1.0, threshold=20.0):
+    x = a.float() + dt_bias.float()
+    softplus_x = F.softplus(x, beta=beta, threshold=threshold)
+    g = -torch.exp(A_log.float()) * softplus_x
+    g = g.unsqueeze(0)
+    beta_output = torch.sigmoid(b.float()).to(b.dtype)
+    beta_output = beta_output.unsqueeze(0)
+    return g, beta_output
+
+
+CONFIGS = [
+    pytest.param(1, 8, torch.float32, id="B1_H8_f32"),
+    pytest.param(1, 16, torch.float32, id="B1_H16_f32"),
+    pytest.param(2, 32, torch.float32, id="B2_H32_f32"),
+    pytest.param(4, 64, torch.float32, id="B4_H64_f32"),
+    pytest.param(8, 128, torch.float32, id="B8_H128_f32"),
+    pytest.param(16, 256, torch.float32, id="B16_H256_f32"),
+    pytest.param(1, 8, torch.bfloat16, id="B1_H8_bf16"),
+    pytest.param(2, 16, torch.bfloat16, id="B2_H16_bf16"),
+    pytest.param(4, 32, torch.bfloat16, id="B4_H32_bf16"),
+    pytest.param(8, 64, torch.bfloat16, id="B8_H64_bf16"),
+    pytest.param(16, 128, torch.bfloat16, id="B16_H128_bf16"),
+    pytest.param(1, 8, torch.float16, id="B1_H8_f16"),
+    pytest.param(2, 16, torch.float16, id="B2_H16_f16"),
+    pytest.param(4, 32, torch.float16, id="B4_H32_f16"),
+    pytest.param(8, 64, torch.float16, id="B8_H64_f16"),
+    pytest.param(16, 128, torch.float16, id="B16_H128_f16"),
+    # Edge cases: num_heads < BLK_HEADS=8, odd, non-power-of-two
+    pytest.param(1, 1, torch.float32, id="B1_H1_f32"),
+    pytest.param(1, 7, torch.float32, id="B1_H7_f32"),
+    pytest.param(32, 9, torch.float32, id="B32_H9_f32"),
+    # Large
+    pytest.param(32, 512, torch.bfloat16, id="B32_H512_bf16"),
+    pytest.param(64, 256, torch.float16, id="B64_H256_f16"),
+]
+
+
+@pytest.mark.parametrize("batch,num_heads,dtype", CONFIGS)
+@torch.inference_mode()
+def test_fused_gdn_gating(batch, num_heads, dtype):
+    A_log = torch.randn(num_heads, device=DEVICE, dtype=torch.float32)
+    a = torch.randn(batch, num_heads, device=DEVICE, dtype=dtype)
+    b = torch.randn(batch, num_heads, device=DEVICE, dtype=dtype)
+    dt_bias = torch.randn(num_heads, device=DEVICE, dtype=torch.float32)
+
+    g_out, beta_out = fused_gdn_gating(A_log, a, b, dt_bias)
+    g_ref, beta_ref = fused_gdn_gating_ref(A_log, a, b, dt_bias)
+
+    assert beta_out.dtype == b.dtype, (
+        f"beta_output dtype mismatch: expected {b.dtype}, got {beta_out.dtype}"
+    )
+    torch.testing.assert_close(g_out, g_ref, atol=1e-4, rtol=1e-4)
+    torch.testing.assert_close(beta_out.float(), beta_ref.float(), atol=1e-3, rtol=1e-3)
+
+
+@pytest.mark.parametrize(
+    "beta_val,threshold_val",
+    [
+        pytest.param(1.0, 20.0, id="default"),
+        pytest.param(0.5, 10.0, id="beta0.5_thr10"),
+        pytest.param(2.0, 40.0, id="beta2_thr40"),
+    ],
+)
+@torch.inference_mode()
+def test_fused_gdn_gating_params(beta_val, threshold_val):
+    batch, num_heads = 4, 32
+    A_log = torch.randn(num_heads, device=DEVICE, dtype=torch.float32)
+    a = torch.randn(batch, num_heads, device=DEVICE, dtype=torch.float32)
+    b = torch.randn(batch, num_heads, device=DEVICE, dtype=torch.float32)
+    dt_bias = torch.randn(num_heads, device=DEVICE, dtype=torch.float32)
+
+    g_out, beta_out = fused_gdn_gating(
+        A_log, a, b, dt_bias, beta=beta_val, threshold=threshold_val
+    )
+    g_ref, beta_ref = fused_gdn_gating_ref(
+        A_log, a, b, dt_bias, beta=beta_val, threshold=threshold_val
+    )
+
+    assert beta_out.dtype == b.dtype, (
+        f"beta_output dtype mismatch: expected {b.dtype}, got {beta_out.dtype}"
+    )
+    torch.testing.assert_close(g_out, g_ref, atol=1e-4, rtol=1e-4)
+    torch.testing.assert_close(beta_out.float(), beta_ref.float(), atol=1e-3, rtol=1e-3)

--- a/tests/kernels/test_fused_recurrent_gated_delta_rule.py
+++ b/tests/kernels/test_fused_recurrent_gated_delta_rule.py
@@ -1,0 +1,258 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Accuracy tests for the fused_recurrent_gated_delta_rule GDN/FLA Triton kernel."""
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from vllm.platforms import current_platform
+from vllm.third_party.flash_linear_attention.ops import fused_recurrent_gated_delta_rule
+from vllm.utils.torch_utils import set_random_seed
+from vllm.v1.attention.backends.utils import NULL_BLOCK_ID, PAD_SLOT_ID
+
+pytestmark = pytest.mark.skipif(
+    not (current_platform.is_cuda_alike() or current_platform.is_xpu()),
+    reason="fused_recurrent_gated_delta_rule dispatches a Triton kernel that "
+    "requires a CUDA-alike or XPU device.",
+)
+
+DEVICE = current_platform.device_type
+
+# HV > H is grouped value attention; V > 32 splits the grid over V.
+SHAPES = [(4, 4, 128, 128), (2, 8, 128, 128), (2, 8, 64, 32)]
+SERVING = (torch.bfloat16, True, False)
+SERVING_FP32 = (torch.float32, True, False)
+NO_L2NORM = (torch.float32, False, False)
+HEADWISE_BETA = (torch.float32, True, True)
+MODES = [SERVING, SERVING_FP32, NO_L2NORM, HEADWISE_BETA]
+TOL = {torch.bfloat16: 1e-2, torch.float32: 1e-4}
+
+
+@pytest.fixture(autouse=True)
+def setup_device():
+    with torch.device(DEVICE):
+        set_random_seed(0)
+        yield
+
+
+def ref_fused_recurrent_gated_delta_rule(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    initial_state: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+    ssm_state_indices: torch.Tensor,
+    num_accepted_tokens: torch.Tensor | None = None,
+    use_qk_l2norm_in_kernel: bool = False,
+    inplace_final_state: bool = True,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """float32 recurrence over the shared state pool, sequential only over time."""
+    q, k, v, g, beta = (x.float()[0] for x in (q, k, v, g, beta))
+    if beta.ndim == 2:  # scalar beta must broadcast over V
+        beta = beta[..., None]
+    if use_qk_l2norm_in_kernel:
+        q, k = (x * torch.rsqrt(x.pow(2).sum(-1, keepdim=True) + 1e-6) for x in (q, k))
+    rep = v.shape[1] // q.shape[1]
+    q = (q * k.shape[-1] ** -0.5).repeat_interleave(rep, dim=1)
+    k = k.repeat_interleave(rep, dim=1)
+
+    o = torch.zeros_like(v)
+    pool = initial_state.float().clone()
+    final_state = (
+        pool.clone()
+        if inplace_final_state
+        else torch.zeros(v.shape[0], *pool.shape[1:])
+    )
+    indices = ssm_state_indices.view(cu_seqlens.numel() - 1, -1).long()
+
+    for n in range(cu_seqlens.numel() - 1):
+        bos, eos = int(cu_seqlens[n]), int(cu_seqlens[n + 1])
+        first = 0 if num_accepted_tokens is None else int(num_accepted_tokens[n]) - 1
+        if indices[n, first] <= 0:
+            continue
+        h = pool[indices[n, first]]
+        for t in range(bos, eos):
+            k_t = k[t][:, None]
+            h = h * g[t][:, None, None].exp()
+            h = h + ((v[t] - (h * k_t).sum(-1)) * beta[t])[..., None] * k_t
+            o[t] = (h * q[t][:, None]).sum(-1)
+            final_state[indices[n, t - bos] if inplace_final_state else t] = h
+
+    return o.unsqueeze(0), final_state
+
+
+def make_gdn_inputs(
+    num_tokens: int,
+    H: int,
+    HV: int,
+    K: int,
+    V: int,
+    dtype: torch.dtype,
+    beta_headwise: bool = False,
+) -> tuple[torch.Tensor, ...]:
+    # Op docstring recipe: unit-norm k, g < 0 keep the recurrence stable.
+    q = torch.randn(1, num_tokens, H, K, dtype=dtype)
+    k = F.normalize(torch.randn(1, num_tokens, H, K, dtype=dtype), dim=-1)
+    v = torch.randn(1, num_tokens, HV, V, dtype=dtype)
+    g = F.logsigmoid(torch.rand(1, num_tokens, HV))
+    beta_shape = (1, num_tokens, HV, V) if beta_headwise else (1, num_tokens, HV)
+    beta = torch.rand(beta_shape, dtype=dtype).sigmoid()
+    return q, k, v, g, beta
+
+
+def make_batch(
+    num_seqs: int, seq_len: int, num_pad: int
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Uniform requests plus GDN's trailing zero-token NULL_BLOCK_ID padding."""
+    num_tokens = num_seqs * seq_len
+    cu_seqlens = torch.arange(0, num_tokens + 1, seq_len, dtype=torch.int32)
+    indices = (torch.randperm(num_tokens, dtype=torch.int32) + 1).view(
+        num_seqs, seq_len
+    )
+    pad = torch.full((num_pad, seq_len), NULL_BLOCK_ID, dtype=torch.int32)
+    return torch.cat([cu_seqlens, cu_seqlens[-1].repeat(num_pad)]), torch.cat(
+        [indices, pad]
+    )
+
+
+def run_pair(
+    inputs: tuple[torch.Tensor, ...],
+    state: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+    indices: torch.Tensor,
+    **kwargs,
+) -> tuple[tuple[torch.Tensor, torch.Tensor], tuple[torch.Tensor, torch.Tensor]]:
+    """Reference first: it mirrors the op's kwargs, and the op overwrites `state`."""
+    ref = ref_fused_recurrent_gated_delta_rule(
+        *inputs, state, cu_seqlens, indices, **kwargs
+    )
+    out = fused_recurrent_gated_delta_rule(
+        *inputs,
+        initial_state=state,
+        cu_seqlens=cu_seqlens,
+        ssm_state_indices=indices,
+        **kwargs,
+    )
+    return out, ref
+
+
+@pytest.mark.parametrize("num_decodes,num_pad", [(1, 0), (3, 2)])
+@pytest.mark.parametrize("H,HV,K,V", SHAPES)
+@pytest.mark.parametrize("dtype,use_qk_l2norm,beta_headwise", MODES)
+def test_fused_recurrent_gated_delta_rule_decode(
+    num_decodes: int,
+    num_pad: int,
+    H: int,
+    HV: int,
+    K: int,
+    V: int,
+    dtype: torch.dtype,
+    use_qk_l2norm: bool,
+    beta_headwise: bool,
+) -> None:
+    inputs = make_gdn_inputs(num_decodes, H, HV, K, V, dtype, beta_headwise)
+    state = torch.randn(num_decodes + 1, HV, V, K)
+    cu_seqlens, indices = make_batch(num_decodes, 1, num_pad)
+
+    (o, _), (o_ref, state_ref) = run_pair(
+        inputs,
+        state,
+        cu_seqlens,
+        indices[:, 0],
+        inplace_final_state=True,
+        use_qk_l2norm_in_kernel=use_qk_l2norm,
+    )
+
+    tol = TOL[dtype]
+    torch.testing.assert_close(o.float(), o_ref, atol=tol, rtol=tol)
+    torch.testing.assert_close(state, state_ref, atol=tol, rtol=tol)
+
+
+@pytest.mark.parametrize(
+    "num_spec_decodes,num_pad,num_spec_tokens", [(1, 0, 1), (2, 2, 3)]
+)
+@pytest.mark.parametrize("H,HV,K,V", SHAPES)
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
+def test_fused_recurrent_gated_delta_rule_spec_decode(
+    num_spec_decodes: int,
+    num_pad: int,
+    num_spec_tokens: int,
+    H: int,
+    HV: int,
+    K: int,
+    V: int,
+    dtype: torch.dtype,
+) -> None:
+    seq_len = num_spec_tokens + 1
+    num_tokens = num_spec_decodes * seq_len
+    inputs = make_gdn_inputs(num_tokens, H, HV, K, V, dtype)
+    state = torch.randn(num_tokens + 1, HV, V, K)
+    cu_seqlens, indices = make_batch(num_spec_decodes, seq_len, num_pad)
+    num_accepted_tokens = torch.randint(
+        1, seq_len + 1, (num_spec_decodes + num_pad,), dtype=torch.int32
+    )
+
+    (o, _), (o_ref, state_ref) = run_pair(
+        inputs,
+        state,
+        cu_seqlens,
+        indices,
+        inplace_final_state=True,
+        num_accepted_tokens=num_accepted_tokens,
+        use_qk_l2norm_in_kernel=True,
+    )
+
+    tol = TOL[dtype]
+    torch.testing.assert_close(o.float(), o_ref, atol=tol, rtol=tol)
+    torch.testing.assert_close(state, state_ref, atol=tol, rtol=tol)
+
+
+@pytest.mark.parametrize("H,HV,K,V", SHAPES)
+def test_fused_recurrent_gated_delta_rule_non_inplace_final_state(
+    H: int, HV: int, K: int, V: int
+) -> None:
+    num_seqs, seq_len = 2, 4
+    num_tokens = num_seqs * seq_len
+    inputs = make_gdn_inputs(num_tokens, H, HV, K, V, torch.float32)
+    state = torch.randn(num_tokens + 1, HV, V, K)
+    state_before = state.clone()
+    cu_seqlens, indices = make_batch(num_seqs, seq_len, 0)
+
+    (o, per_token), (o_ref, per_token_ref) = run_pair(
+        inputs,
+        state,
+        cu_seqlens,
+        indices,
+        inplace_final_state=False,
+        use_qk_l2norm_in_kernel=True,
+    )
+
+    tol = TOL[torch.float32]
+    torch.testing.assert_close(o.float(), o_ref, atol=tol, rtol=tol)
+    torch.testing.assert_close(per_token.float(), per_token_ref, atol=tol, rtol=tol)
+    torch.testing.assert_close(state, state_before, atol=0, rtol=0)
+
+
+@pytest.mark.parametrize("invalid_id", [NULL_BLOCK_ID, PAD_SLOT_ID])
+def test_fused_recurrent_gated_delta_rule_skips_invalid_state_index(
+    invalid_id: int,
+) -> None:
+    num_decodes, H, HV, K, V = 4, 4, 8, 128, 128
+    inputs = make_gdn_inputs(num_decodes, H, HV, K, V, torch.bfloat16)
+    state = torch.randn(num_decodes + 1, HV, V, K)
+    cu_seqlens, indices = make_batch(num_decodes, 1, 0)
+    indices = indices[:, 0]
+    indices[1] = invalid_id
+
+    (o, _), (o_ref, state_ref) = run_pair(
+        inputs, state, cu_seqlens, indices, inplace_final_state=True
+    )
+
+    # skipped requests never write o
+    valid = indices > 0
+    tol = TOL[torch.bfloat16]
+    torch.testing.assert_close(o[:, valid].float(), o_ref[:, valid], atol=tol, rtol=tol)
+    torch.testing.assert_close(state, state_ref, atol=tol, rtol=tol)

--- a/tests/kernels/test_l2norm.py
+++ b/tests/kernels/test_l2norm.py
@@ -1,0 +1,102 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Precision tests for vllm's l2norm_fwd Triton operator.
+
+The l2norm_fwd wrapper dispatches based on the USE_DEFAULT_FLA_NORM flag and the
+feature dim D. These tests cover two of the three Triton kernels:
+
+    USE_DEFAULT_FLA_NORM == 0            -> l2norm_fwd_kernel2  (any D)
+    USE_DEFAULT_FLA_NORM == 1, D >  512  -> l2norm_fwd_kernel1
+
+Both paths are exercised against a float32 PyTorch reference
+(y = x / sqrt(sum(x^2) + eps), per row).
+
+Source: vllm/third_party/flash_linear_attention/ops/l2norm.py
+"""
+
+from unittest.mock import patch
+
+import pytest
+import torch
+
+from vllm.platforms import current_platform
+from vllm.third_party.flash_linear_attention.ops import l2norm as l2norm_mod
+from vllm.third_party.flash_linear_attention.ops.l2norm import l2norm_fwd
+
+pytestmark = pytest.mark.skipif(
+    not (current_platform.is_cuda_alike() or current_platform.is_xpu()),
+    reason="l2norm_fwd dispatches a Triton kernel that requires a "
+    "CUDA-alike or XPU device.",
+)
+
+DEVICE = current_platform.device_type
+EPS = 1e-6
+
+
+def l2norm_ref(x, eps=EPS):
+    """Pure PyTorch L2 norm over the last dim: y = x / sqrt(sum(x^2) + eps)."""
+    return x / torch.sqrt((x * x).sum(dim=-1, keepdim=True) + eps)
+
+
+def _set_flag(monkeypatch, use_default):
+    # USE_DEFAULT_FLA_NORM is read from the env at import time; patch the module
+    # attribute directly so dispatch is deterministic regardless of import order.
+    monkeypatch.setattr(l2norm_mod, "USE_DEFAULT_FLA_NORM", use_default)
+
+
+# (use_default, D, kernel)
+ROUTING_CASES = [
+    (0, 64, "l2norm_fwd_kernel2"),
+    (0, 1024, "l2norm_fwd_kernel2"),
+    (1, 768, "l2norm_fwd_kernel1"),
+    (1, 2048, "l2norm_fwd_kernel1"),
+]
+
+
+@pytest.mark.parametrize("use_default,D,kernel", ROUTING_CASES)
+@torch.inference_mode()
+def test_l2norm_dispatch(monkeypatch, use_default, D, kernel):
+    """l2norm_fwd routes to the expected kernel for the given flag and D."""
+    _set_flag(monkeypatch, use_default)
+    x = torch.randn(8, D, device=DEVICE, dtype=torch.float32)
+
+    real = getattr(l2norm_mod, kernel)
+    with patch.object(l2norm_mod, kernel, wraps=real) as spy:
+        # triton launches as kernel[grid](...), so the launch is observed on
+        # __getitem__ rather than on the mock itself.
+        spy.__getitem__.side_effect = real.__getitem__
+        l2norm_fwd(x, eps=EPS)
+
+    assert spy.__getitem__.called, f"expected {kernel} to be launched"
+
+
+# (use_default, shape, dtype, tol) - flag=1 is paired only with D > 512 so the
+# matrix stays on l2norm_fwd_kernel1.
+NUMERIC_CASES = [
+    (0, (16, 64), torch.float32, 1e-4),
+    (0, (64, 256), torch.float32, 1e-4),
+    (0, (128, 512), torch.float32, 1e-4),
+    (0, (1024, 128), torch.float32, 1e-4),
+    (0, (4, 32, 1024), torch.float32, 1e-4),
+    (0, (64, 1024), torch.bfloat16, 5e-3),
+    (1, (16, 1024), torch.float32, 1e-4),
+    (1, (1, 2048), torch.float32, 1e-4),
+    (1, (64, 768), torch.float32, 1e-4),
+    (1, (4, 32, 1024), torch.float32, 1e-4),
+    (1, (64, 1024), torch.bfloat16, 5e-3),
+]
+
+
+@pytest.mark.parametrize("use_default,shape,dtype,tol", NUMERIC_CASES)
+@torch.inference_mode()
+def test_l2norm_matches_reference(monkeypatch, use_default, shape, dtype, tol):
+    """l2norm_fwd output matches the float32 reference (2D and 3D inputs)."""
+    _set_flag(monkeypatch, use_default)
+    torch.manual_seed(0)
+    x = torch.randn(*shape, device=DEVICE, dtype=dtype)
+
+    y = l2norm_fwd(x, eps=EPS)
+    y_ref = l2norm_ref(x.float(), eps=EPS)
+
+    assert y.shape == x.shape
+    torch.testing.assert_close(y.float(), y_ref, rtol=tol, atol=tol)


### PR DESCRIPTION
## Purpose

Adds unit tests for four GDN/FLA Triton kernels with no direct coverage today.
Bundles four already-open PRs into one review unit:

- #44315 - `fused_gdn_gating_kernel`
- #46059 - `l2norm_fwd_kernel1` / `l2norm_fwd_kernel2`
- #47976 - `fused_recurrent_gated_delta_rule`
- #48571 - `chunk_fwd_kernel_o`

## Test plan

```bash
pytest -v tests/kernels/mamba/test_gdn_gating.py \
          tests/kernels/mamba/test_chunk_fwd_o.py \
          tests/kernels/test_l2norm.py \
          tests/kernels/test_fused_recurrent_gated_delta_rule.py
```

### Results:

| Test file | Run | Passed | Failed | Skipped |
| --- | --- | --- | --- | --- |
| `test_gdn_gating.py` | 24 | 24 | 0 | 0 |
| `test_chunk_fwd_o.py` | 14 | 14 | 0 | 0 |
| `test_l2norm.py` | 15 | 15 | 0 | 0 |
| `test_fused_recurrent_gated_delta_rule.py` | 41 | 41 | 0 | 0 |
| **Total** | **94** | **94** | **0** | **0** |

Tested on Intel B70 and H200