### PR TITLE
[Core] Avoid importing optional modules in _has_module

### DIFF
--- a/tests/utils_/test_import_utils.py
+++ b/tests/utils_/test_import_utils.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-from unittest.mock import MagicMock, patch
+import sys
+from unittest.mock import patch
 
 import pytest
 
@@ -49,39 +50,34 @@ def test_placeholder_module_error_handling():
 
 
 class TestHasModule:
-    """Tests for _has_module with trial import verification."""
+    """Tests for _has_module availability checks."""
 
     def setup_method(self):
         # Clear the @cache between tests so each test gets a fresh call
         _has_module.cache_clear()
 
-    def test_returns_true_for_importable_stdlib_module(self):
+    def test_returns_true_for_available_stdlib_module(self):
         assert _has_module("json") is True
 
     def test_returns_false_for_nonexistent_module(self):
         assert _has_module("nonexistent_module_xyz_12345") is False
 
-    def test_returns_false_when_find_spec_succeeds_but_import_fails(self):
-        """Simulate a native extension whose shared library is missing.
+    def test_does_not_import_discoverable_module(self, tmp_path, monkeypatch):
+        """Discovery does not execute a module whose import would fail."""
+        module_name = "vllm_test_module_with_import_side_effect"
+        sentinel = tmp_path / "module_imported"
+        module_path = tmp_path / f"{module_name}.py"
+        module_path.write_text(
+            "from pathlib import Path\n"
+            f"Path({str(sentinel)!r}).touch()\n"
+            "raise ImportError('simulated missing runtime dependency')\n",
+            encoding="utf-8",
+        )
+        monkeypatch.syspath_prepend(str(tmp_path))
 
-        ``find_spec`` finds the package on disk, but the actual import
-        raises ``ImportError`` (e.g. missing ``libcudart.so``).
-        """
-        fake_spec = MagicMock()
-
-        with (
-            patch(
-                "vllm.utils.import_utils.importlib.util.find_spec",
-                return_value=fake_spec,
-            ),
-            patch(
-                "vllm.utils.import_utils.importlib.import_module",
-                side_effect=ImportError(
-                    "libcudart.so.12: cannot open shared object file"
-                ),
-            ),
-        ):
-            assert _has_module("fake_native_ext") is False
+        assert _has_module(module_name) is True
+        assert module_name not in sys.modules
+        assert not sentinel.exists()
 
     def test_returns_false_when_find_spec_raises(self):
         """``find_spec`` itself can raise for dotted names whose parent package
@@ -94,7 +90,7 @@ class TestHasModule:
             assert _has_module("fake_parent.child") is False
 
     def test_result_is_cached(self):
-        """Verify the @cache decorator prevents repeated imports."""
+        """Verify the @cache decorator prevents repeated lookups."""
         _has_module("json")  # prime the cache
 
         with patch("vllm.utils.import_utils.importlib.util.find_spec") as mock_spec:

--- a/vllm/utils/import_utils.py
+++ b/vllm/utils/import_utils.py
@@ -392,24 +392,22 @@ class LazyLoader(ModuleType):
 # Optional dependency detection utilities
 @cache
 def _has_module(module_name: str) -> bool:
-    """Return True if *module_name* can be imported in the current environment.
+    """Return True if *module_name* is discoverable in the current environment.
 
-    Uses ``importlib.util.find_spec`` as a fast pre-check, then performs a
-    trial import to verify that native dependencies (shared libraries, etc.)
-    are also satisfied. Any failure during the trial import is treated as the
-    module being unavailable. The result is cached so that subsequent queries
-    for the same module incur no additional overhead.
+    Checks for the target module without importing it. For dotted module
+    names, ``find_spec`` may still import the parent package. The result is
+    cached so that subsequent queries for the same module incur no additional
+    overhead. Runtime dependencies are not verified.
     """
     try:
-        if importlib.util.find_spec(module_name) is None:
-            return False
-        importlib.import_module(module_name)
+        return importlib.util.find_spec(module_name) is not None
     except Exception:
         logger.warning(
-            "Module %s was found but failed to import", module_name, exc_info=True
+            "Failed to determine whether module %s is available",
+            module_name,
+            exc_info=True,
         )
         return False
-    return True
 
 
 def has_deep_ep() -> bool:


### PR DESCRIPTION
## Purpose

Fixes #51162.

`_has_module` currently performs a trial import after `find_spec`, which can load optional native libraries and trigger import-time side effects during availability checks. This PR makes the check discovery-only and documents that runtime dependencies are not verified.

This intentionally changes the behavior introduced by #44035: a broken-but-discoverable package now returns `True`, and its real import error is surfaced at the next actual import site, which may occur while importing a dependent vLLM module, instead of silently disabling the backend. For dotted names, `find_spec` may still import the parent package.

No documentation changes are required.

## Duplicate-work check

I reviewed #51162 and all comments immediately before opening this PR.

- The open-PR search for `51162 in:body` finds #51159. That PR is a TileLang-specific lazy-import/JIT change and explicitly lists #51162 as separate follow-up work.
- The `_has_module` keyword search also finds #49035. That PR handles a missing dotted parent while retaining the trial import.
- No open PR implements this global discovery-only change.

## Test Plan

- Run the focused import utility tests in the Linux development environment.
- Run every pre-commit hook applicable to the two changed Python files.
- Check the patch for whitespace errors.

## Test Result

- `.venv/bin/python -m pytest tests/utils_/test_import_utils.py -v`: 6 passed, with 14 unrelated `torch.jit.script_method` deprecation warnings.
- `SKIP=check-json .venv/bin/pre-commit run --files vllm/utils/import_utils.py tests/utils_/test_import_utils.py`: all applicable hooks passed. `check-json` does not apply to these Python files.
- `git diff --check`: passed.

Model evaluation: N/A. This changes optional-dependency discovery and import timing, not model execution, output, or accuracy.

## AI assistance

OpenAI Codex was used for issue and duplicate-work research, implementation, Linux environment and test setup, and code review. The human submitter is responsible for understanding every changed line and defending the change.