### PR TITLE
[ROCm][DSV4] Use the AITER tuned GEMM for full-graph decode attention

### DIFF
--- a/vllm/models/deepseek_v4/amd/rocm.py
+++ b/vllm/models/deepseek_v4/amd/rocm.py
@@ -6,11 +6,15 @@ from typing import cast
 
 import torch
 
+from vllm._aiter_ops import rocm_aiter_ops
+from vllm.compilation.breakable_cudagraph import eager_break_during_capture
+from vllm.config import CUDAGraphMode
 from vllm.distributed import (
     get_tensor_model_parallel_world_size,
     tensor_model_parallel_all_reduce,
 )
 from vllm.forward_context import get_forward_context
+from vllm.models.common.ops.fused_qk_rmsnorm import fused_q_kv_rmsnorm
 from vllm.models.deepseek_v4.attention import DeepseekV4Attention
 from vllm.models.deepseek_v4.common.ops import dequantize_and_gather_k_cache
 from vllm.models.deepseek_v4.sparse_mla import (
@@ -451,6 +455,125 @@ class DeepseekV4ROCMAiterMLAAttention(DeepseekV4Attention):
         # Block scale for the preshuffled weight; None = not preshuffled.
         self._wqa_wkv_scale: torch.Tensor | None = None
         self._wo_b_scale: torch.Tensor | None = None
+        # Weight dtypes and the AITER toggle cannot change after load, so the
+        # dtype-dependent half of the predicate is resolved once here.
+        self._tgemm_static_eligible = (
+            self.compressor is not None
+            and rocm_aiter_ops.is_tgemm_enabled()
+            and self.compressor.fused_wkv_wgate.weight.dtype == torch.bfloat16
+            and (
+                self.indexer is None
+                or self.indexer.compressor.fused_wkv_wgate.weight.dtype
+                == torch.bfloat16
+            )
+        )
+
+    def _use_aiter_tgemm(self, hidden_states: torch.Tensor) -> bool:
+        """Whether to run the tuned-GEMM attention path for this call.
+
+        The tuned GEMM is only profitable under a full-graph decode, so it is
+        restricted to stream capture for FULL/NONE and to the warmup run that
+        precedes a FULL capture. Warmup must agree with capture: if the two
+        disagree the captured graph would replay a kernel the warmup never
+        exercised.
+        """
+        forward_context = get_forward_context()
+
+        return (
+            self._tgemm_static_eligible
+            and hidden_states.dtype == torch.bfloat16
+            and (
+                forward_context.additional_kwargs.get("cudagraph_warmup_mode")
+                == CUDAGraphMode.FULL
+                or (
+                    torch.cuda.is_current_stream_capturing()
+                    and forward_context.cudagraph_runtime_mode
+                    in (
+                        CUDAGraphMode.FULL,
+                        CUDAGraphMode.NONE,
+                    )
+                )
+            )
+        )
+
+    def forward(
+        self,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        llama_4_scaling: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        if not self._use_aiter_tgemm(hidden_states):
+            return super().forward(positions, hidden_states, llama_4_scaling)
+
+        num_tokens = hidden_states.shape[0]
+        output = torch.empty(
+            (num_tokens, self.padded_heads, self.head_dim),
+            dtype=hidden_states.dtype,
+            device=hidden_states.device,
+        )
+        self._forward_aiter_tgemm(
+            hidden_states,
+            positions,
+            output,
+        )
+        return self._o_proj(output[:, : self.n_local_heads], positions)
+
+    @eager_break_during_capture
+    def _forward_aiter_tgemm(
+        self,
+        hidden_states: torch.Tensor,
+        positions: torch.Tensor,
+        output: torch.Tensor,
+    ) -> None:
+        from aiter.tuned_gemm import tgemm
+
+        assert self.compressor is not None
+
+        kv_score = tgemm.mm(
+            hidden_states,
+            self.compressor.fused_wkv_wgate.weight,
+            otype=torch.bfloat16,
+        )
+        indexer_kv_score = None
+        if self.indexer is not None:
+            indexer_compressor = self.indexer.compressor
+            indexer_kv_score = tgemm.mm(
+                hidden_states,
+                indexer_compressor.fused_wkv_wgate.weight,
+                otype=torch.bfloat16,
+            )
+
+        qr_kv = self._fused_wqa_wkv_gemm(hidden_states)
+        qr, kv = qr_kv.split([self.q_lora_rank, self.head_dim], dim=-1)
+        qr, kv = fused_q_kv_rmsnorm(
+            qr,
+            kv,
+            self.q_norm.weight.data,
+            self.kv_norm.weight.data,
+            self.eps,
+        )
+        q = self.wq_b(qr).view(-1, self.n_local_heads, self.head_dim)
+        q = self._fused_qnorm_rope_kv_insert(
+            q,
+            kv,
+            positions,
+            get_forward_context().attn_metadata,
+        )
+
+        self.compressor(kv_score, positions, self.rotary_emb)
+        if self.indexer is not None:
+            assert indexer_kv_score is not None
+            indexer_weights, _ = self.indexer.weights_proj(hidden_states)
+            self.indexer(
+                hidden_states,
+                qr,
+                indexer_kv_score,
+                indexer_weights,
+                positions,
+                self.indexer_rotary_emb,
+            )
+
+        self.forward_mqa(q, kv, positions, output)
 
     @classmethod
     def get_padded_num_q_heads(cls, num_heads: int) -> int:

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -17,7 +17,7 @@ from vllm.v1.attention.backends.registry import AttentionBackendEnum
 if TYPE_CHECKING:
     from torch.distributed import PrefixStore, ProcessGroup
 
-    from vllm.config import VllmConfig
+    from vllm.config import CUDAGraphMode, VllmConfig
     from vllm.config.kernel import IrOpPriorityConfig
     from vllm.inputs import EngineInput
     from vllm.pooling_params import PoolingParams
@@ -1267,6 +1267,19 @@ class Platform:
         Set some additional forward context for the current platform if needs.
         """
         return {}
+
+    @classmethod
+    def cudagraph_warmup_context(
+        cls, cudagraph_mode: "CUDAGraphMode"
+    ) -> contextlib.AbstractContextManager[None]:
+        """Return a context that is active while a cudagraph warmup runs.
+
+        Warmup runs execute eagerly, so a layer cannot tell from the runtime
+        mode alone which graph mode is about to be captured. Platforms that
+        must select the same kernel during warmup as during capture can
+        override this to publish the pending mode.
+        """
+        return contextlib.nullcontext()
 
     @classmethod
     def num_compute_units(cls, device_id: int = 0) -> int:

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -1,11 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import contextlib
 import os
 import platform
+from collections.abc import Iterator
+from contextvars import ContextVar
 from datetime import timedelta
 from functools import cache, lru_cache, wraps
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import regex as re
 import torch
@@ -19,11 +22,18 @@ from vllm.v1.attention.backends.registry import AttentionBackendEnum
 from .interface import DeviceCapability, Platform, PlatformEnum, in_wsl
 
 if TYPE_CHECKING:
-    from vllm.config import VllmConfig
+    from vllm.config import CUDAGraphMode, VllmConfig
     from vllm.config.kernel import IrOpPriorityConfig
     from vllm.v1.attention.selector import AttentionSelectorConfig
 
 logger = init_logger(__name__)
+
+# Set only while a cudagraph warmup run is in flight; carries the mode that is
+# about to be captured so layers can select the matching kernel. A ContextVar
+# keeps this correct when warmup runs on multiple threads.
+_cudagraph_warmup_mode: ContextVar[Any] = ContextVar(
+    "vllm_rocm_cudagraph_warmup_mode", default=None
+)
 
 try:
     from amdsmi import (
@@ -534,6 +544,25 @@ class RocmPlatform(Platform):
         "online",
         "gpt_oss_mxfp4",
     ]
+
+    @classmethod
+    def set_additional_forward_context(
+        cls, *args: Any, **kwargs: Any
+    ) -> dict[str, Any]:
+        additional_context = super().set_additional_forward_context(*args, **kwargs)
+        additional_context["cudagraph_warmup_mode"] = _cudagraph_warmup_mode.get()
+        return additional_context
+
+    @classmethod
+    @contextlib.contextmanager
+    def cudagraph_warmup_context(
+        cls, cudagraph_mode: "CUDAGraphMode"
+    ) -> Iterator[None]:
+        token = _cudagraph_warmup_mode.set(cudagraph_mode)
+        try:
+            yield
+        finally:
+            _cudagraph_warmup_mode.reset(token)
 
     @classmethod
     def import_kernels(cls) -> None:

--- a/vllm/v1/worker/gpu/cudagraph_utils.py
+++ b/vllm/v1/worker/gpu/cudagraph_utils.py
@@ -323,7 +323,8 @@ class CudaGraphManager:
                     forward_fn = create_forward_fn(desc, warmup=True)
 
                     # Warmup
-                    forward_fn(CUDAGraphMode.NONE)
+                    with current_platform.cudagraph_warmup_context(desc.cg_mode):
+                        forward_fn(CUDAGraphMode.NONE)
 
                     # Capture
                     logger.debug(

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -7006,18 +7006,19 @@ class GPUModelRunner(
         if num_warmups is None:
             num_warmups = self.compilation_config.cudagraph_num_of_warmups
         force_attention = cudagraph_runtime_mode == CUDAGraphMode.FULL
-        for _ in range(num_warmups):
-            self._dummy_run(
-                desc.num_tokens,
-                cudagraph_runtime_mode=CUDAGraphMode.NONE,
-                force_attention=force_attention,
-                uniform_decode=desc.uniform,
-                allow_microbatching=allow_microbatching,
-                skip_eplb=True,
-                remove_lora=False,
-                num_active_loras=desc.num_active_loras,
-                profile_seq_lens=profile_seq_lens,
-            )
+        with current_platform.cudagraph_warmup_context(cudagraph_runtime_mode):
+            for _ in range(num_warmups):
+                self._dummy_run(
+                    desc.num_tokens,
+                    cudagraph_runtime_mode=CUDAGraphMode.NONE,
+                    force_attention=force_attention,
+                    uniform_decode=desc.uniform,
+                    allow_microbatching=allow_microbatching,
+                    skip_eplb=True,
+                    remove_lora=False,
+                    num_active_loras=desc.num_active_loras,
+                    profile_seq_lens=profile_seq_lens,
+                )
         if num_warmups > 0:
             # Warmups may use auxiliary streams. Ensure all of their work has
             # completed before beginning CUDA graph capture.

--- a/vllm/v1/worker/gpu_ubatch_wrapper.py
+++ b/vllm/v1/worker/gpu_ubatch_wrapper.py
@@ -356,6 +356,10 @@ class UBatchWrapper:
     ) -> list[UbatchMetadata]:
         # Create one forward context per ubatch
         forward_contexts = []
+        # Platform state on the outer context (e.g. the pending cudagraph
+        # warmup mode) must reach each ubatch context too, so that layers see
+        # the same state whether or not microbatching is in play.
+        additional_kwargs = get_forward_context().additional_kwargs
         # slot_mapping can be None, an empty dict (from create_forward_context
         # converting None to {}), or a list of dicts (one per ubatch)
         has_slot_mapping = slot_mapping and isinstance(slot_mapping, list)
@@ -368,6 +372,7 @@ class UBatchWrapper:
                     batch_descriptor=batch_descriptor,
                     cudagraph_runtime_mode=cudagraph_runtime_mode,
                     slot_mapping=slot_mapping[i] if has_slot_mapping else None,
+                    additional_kwargs=additional_kwargs.copy(),
                 )
             )
 


### PR DESCRIPTION
## Purpose

Runs the DeepSeek-V4 attention projections through AITER's tuned GEMM (`aiter.tuned_gemm.tgemm`) under full-graph decode on ROCm.

Doing that needs one piece of generic plumbing. A cudagraph warmup run executes eagerly with `cudagraph_runtime_mode=NONE`, so a layer cannot tell from the runtime mode alone whether a `FULL` graph is about to be captured. That matters whenever kernel selection differs between warmup and capture: if the warmup picks a different kernel than the capture, the captured graph replays a kernel the warmup never exercised.

This PR adds `Platform.cudagraph_warmup_context(cudagraph_mode)` to publish the pending mode for the duration of a warmup run.

## Changes

**Generic (no behaviour change off ROCm)**
- `platforms/interface.py` — new `cudagraph_warmup_context()` classmethod, defaulting to `contextlib.nullcontext()`.
- `v1/worker/gpu_model_runner.py`, `v1/worker/gpu/cudagraph_utils.py` — wrap the two warmup loops in that context.
- `v1/worker/gpu_ubatch_wrapper.py` — forward the outer forward-context's `additional_kwargs` into each ubatch context, so microbatched runs observe the same platform state.

**ROCm**
- `platforms/rocm.py` — implement the hook with a `ContextVar`, surfaced via `set_additional_forward_context()`. A `ContextVar` (rather than a module global) keeps this correct if warmup ever runs on multiple threads.
- `models/deepseek_v4/amd/rocm.py` — `_use_aiter_tgemm()` gates the tuned-GEMM path on stream capture for `FULL`/`NONE`, or on the warmup that precedes a `FULL` capture. The dtype/toggle half of the predicate is resolved once in `__init__` (`_tgemm_static_eligible`) since weight dtypes cannot change after load.

Every other platform inherits the `nullcontext` default, so this is inert off ROCm.

## Test Plan

- `--compilation-config '{"cudagraph_mode":"FULL"}'` on DeepSeek-V4 / MI355X (gfx950), with and without `VLLM_ROCM_USE_AITER=1`, checking that warmup and capture agree and that graph capture succeeds.
- Non-ROCm smoke test to confirm the default `nullcontext` path is unchanged.

## Test Result

### Fixed-seq-len 8k/1k (complete)

DeepSeek-V4-Pro, MI355X TP=8, ISL 8192 / OSL 1024. Both arms are the same nightly
(`0.26.1rc1.dev542+gb22afe45a`) plus #51635; the only difference is this PR.
The TGEMM path was verified to actually execute (one-time probe log fired on all
8 workers in every run), so a flat result cannot be confused with "gate never opened".


| Concurrency | Output tok/s (base → +PR) | Δ | Median TPOT (base → +PR) | Δ |
|---|---|---|---|---|
| 8  | 284.79 → 291.33 | **+2.30%** | 24.67 → 24.16 ms | −2.04% |
| 16 | 483.69 → 488.59 | **+1.01%** | 29.32 → 29.02 ms | −1.03% |
| 32 | 708.51 → 712.89 | **+0.62%** | 40.78 → 40.52 ms | −0.65% |
| 64 | 955.23 → 958.04 | **+0.29%** | 62.55 → 62.36 ms | −0.30% |

Median TTFT is unchanged (321-395 ms both ways) and completion counts are identical
per arm (80/80, 160/160, 318/320, 639/640).

**Noise floor:** the baseline c8 config was re-run a second time to quantify
run-to-run variance: 284.79 vs 285.31 tok/s, i.e. **±0.18%**. The +2.30% at c8 is
~13x that spread; the +0.29% at c64 is only ~1.6x it and should be read as
"no regression" rather than a measured win. The monotonic decay with batch size
matches the mechanism: the tuned GEMM replaces untuned `torch.mm` on the attention
input projections, which is a larger share of step time at low concurrency.

**Scope note:** AITER's `tuned_gemm` treats its CSV tables as a soft dependency --
on a lookup miss it logs `not found tuned config ... will use default config` and
falls back to `torch native`. This PR is therefore correct and beneficial without
any tuning-table change; a shape with tuned rows resolves to a `flydsl`/`opus`
kernel, one without gets the same `torch` path as before.

### Agentic (AgentX) trace replay -- inconclusive

TP=8 / EP=1 / concurrency 32 / MTP on (`method='mtp'`, 3 spec tokens) / 1200 s,
Weka claude-code trace corpus. The +PR arm completed cleanly (1023 profiled
requests, 354 warmup-dropped, **0 errors**) and the TGEMM path was confirmed
active on all 8 workers:

| metric | +PR arm |
|---|---|
| output tok/s | 528.48 |
| total tok/s | 80427.08 |
| TTFT p50 / p90 | 0.73 s / 3.02 s |
| TPOT p50 / p90 | 42.3 ms / 60.3 ms |
| prefix-cache hit rate | 0.956 |

**No A/B delta is reported from this run.** The launcher derives its output
directory from `(topology, concurrency, router policy, kv-offloading)` with no
arm identifier, so the second arm overwrote the first. Only the +PR numbers
survived; the baseline arm has to be re-run into a distinct directory before a
comparison is meaningful. The single-arm numbers above are recorded only as
evidence the path runs clean under an agentic workload, not as a speedup claim.

### Pending

- Agentic A/B re-run with per-arm result directories.
- lm-eval accuracy comparison between the two arms.
