### PR TITLE
[ROCm][DSV4] Opt-in AITER gluon kernel for sparse-MLA decode on gfx950

### DIFF
--- a/tests/kernels/attention/test_rocm_triton_attn_dsv4.py
+++ b/tests/kernels/attention/test_rocm_triton_attn_dsv4.py
@@ -198,6 +198,88 @@ def _ragged_from_rows(
     )
 
 
+@pytest.fixture
+def sparse_decode_mod():
+    from vllm.v1.attention.ops import rocm_aiter_mla_sparse as mod
+
+    mod._resolve_rocm_sparse_attn_decode.cache_clear()
+    yield mod
+    mod._resolve_rocm_sparse_attn_decode.cache_clear()
+
+
+def test_sparse_decode_resolver_defaults_to_triton(
+    monkeypatch, sparse_decode_mod
+) -> None:
+    mod = sparse_decode_mod
+    monkeypatch.setattr(
+        mod,
+        "envs",
+        SimpleNamespace(VLLM_ROCM_USE_AITER_SPARSE_MLA_GLUON=False),
+    )
+
+    assert (
+        mod._resolve_rocm_sparse_attn_decode()
+        is mod._rocm_sparse_attn_decode_ragged_triton
+    )
+
+
+def test_sparse_decode_resolver_rejects_unsupported_gpu(
+    monkeypatch, sparse_decode_mod
+) -> None:
+    mod = sparse_decode_mod
+    monkeypatch.setattr(
+        mod,
+        "envs",
+        SimpleNamespace(VLLM_ROCM_USE_AITER_SPARSE_MLA_GLUON=True),
+    )
+    monkeypatch.setattr(mod, "_ON_GFX950", False)
+
+    with pytest.raises(RuntimeError, match="requires an AMD gfx950 GPU"):
+        mod._resolve_rocm_sparse_attn_decode()
+
+
+def test_sparse_decode_resolver_rejects_missing_aiter_kernel(
+    monkeypatch, sparse_decode_mod
+) -> None:
+    mod = sparse_decode_mod
+    monkeypatch.setattr(
+        mod,
+        "envs",
+        SimpleNamespace(VLLM_ROCM_USE_AITER_SPARSE_MLA_GLUON=True),
+    )
+    monkeypatch.setattr(mod, "_ON_GFX950", True)
+
+    def raise_import_error():
+        raise ImportError("pa_decode_sparse is unavailable")
+
+    monkeypatch.setattr(mod, "_load_aiter_pa_decode_sparse", raise_import_error)
+
+    with pytest.raises(RuntimeError, match="requires an AITER build"):
+        mod._resolve_rocm_sparse_attn_decode()
+
+
+def test_sparse_decode_resolver_selects_gluon(
+    monkeypatch, sparse_decode_mod
+) -> None:
+    mod = sparse_decode_mod
+    fake_pa_decode_sparse = object()
+    monkeypatch.setattr(
+        mod,
+        "envs",
+        SimpleNamespace(VLLM_ROCM_USE_AITER_SPARSE_MLA_GLUON=True),
+    )
+    monkeypatch.setattr(mod, "_ON_GFX950", True)
+    monkeypatch.setattr(
+        mod, "_load_aiter_pa_decode_sparse", lambda: fake_pa_decode_sparse
+    )
+    monkeypatch.setattr(mod.logger, "info_once", lambda *args, **kwargs: None)
+
+    decode_impl = mod._resolve_rocm_sparse_attn_decode()
+
+    assert decode_impl.func is mod._rocm_sparse_attn_decode_gluon
+    assert decode_impl.args == (fake_pa_decode_sparse,)
+
+
 @torch.inference_mode()
 def test_paged_mqa_logits_do_not_contain_nan(monkeypatch) -> None:
     from vllm._aiter_ops import rocm_aiter_ops

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -49,6 +49,29 @@ def test_p2p_side_channel_defaults_and_override(monkeypatch: pytest.MonkeyPatch)
     assert envs.VLLM_P2P_SIDE_CHANNEL_PORT == 5799
 
 
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (None, False),
+        ("0", False),
+        ("false", False),
+        ("1", True),
+        ("true", True),
+    ],
+)
+def test_rocm_sparse_mla_gluon_env(
+    monkeypatch: pytest.MonkeyPatch,
+    value: str | None,
+    expected: bool,
+) -> None:
+    if value is None:
+        monkeypatch.delenv("VLLM_ROCM_USE_AITER_SPARSE_MLA_GLUON", raising=False)
+    else:
+        monkeypatch.setenv("VLLM_ROCM_USE_AITER_SPARSE_MLA_GLUON", value)
+
+    assert envs.VLLM_ROCM_USE_AITER_SPARSE_MLA_GLUON is expected
+
+
 def test_getattr_with_cache(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("VLLM_HOST_IP", "1.1.1.1")
     monkeypatch.setenv("VLLM_PORT", "1234")

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -139,6 +139,7 @@ if TYPE_CHECKING:
     VLLM_ROCM_USE_AITER_MOE_SITUV2_A8W4: bool = False
     VLLM_ROCM_USE_AITER_RMSNORM: bool = True
     VLLM_ROCM_USE_AITER_MLA: bool = True
+    VLLM_ROCM_USE_AITER_SPARSE_MLA_GLUON: bool = False
     VLLM_ROCM_AITER_MLA_ASM_PADDING: Literal["auto", "gluon", "asm"] = "auto"
     VLLM_ROCM_USE_AITER_MHA: bool = True
     VLLM_ROCM_USE_AITER_FP4_ASM_GEMM: bool = False
@@ -1278,6 +1279,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # By default is enabled.
     "VLLM_ROCM_USE_AITER_MLA": lambda: (
         os.getenv("VLLM_ROCM_USE_AITER_MLA", "True").lower() in ("true", "1")
+    ),
+    # Whether to use AITER's gluon kernel for sparse MLA decode.
+    # By default is disabled.
+    "VLLM_ROCM_USE_AITER_SPARSE_MLA_GLUON": lambda: (
+        os.getenv("VLLM_ROCM_USE_AITER_SPARSE_MLA_GLUON", "False").lower()
+        in ("true", "1")
     ),
     # Small-head (<16) AITER MLA decode kernel selection. Small head counts
     # (e.g. Kimi-K3: 12 heads/rank at TP8, 6 at TP16) can decode either through

--- a/vllm/models/deepseek_v4/amd/rocm.py
+++ b/vllm/models/deepseek_v4/amd/rocm.py
@@ -28,6 +28,7 @@ from vllm.v1.attention.backends.mla.sparse_swa import (
     DeepseekSparseSWAMetadataBuilder,
 )
 from vllm.v1.attention.ops.rocm_aiter_mla_sparse import (
+    _resolve_rocm_sparse_attn_decode,
     build_ragged_indices_from_dense,
     rocm_inv_rope_einsum,
     rocm_sparse_attn_decode,
@@ -452,6 +453,7 @@ class DeepseekV4ROCMAiterMLAAttention(DeepseekV4Attention):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        _resolve_rocm_sparse_attn_decode()
         # Block scale for the preshuffled weight; None = not preshuffled.
         self._wqa_wkv_scale: torch.Tensor | None = None
         self._wo_b_scale: torch.Tensor | None = None

--- a/vllm/v1/attention/ops/rocm_aiter_mla_sparse.py
+++ b/vllm/v1/attention/ops/rocm_aiter_mla_sparse.py
@@ -3,6 +3,7 @@
 import functools
 import importlib
 import math
+from collections.abc import Callable
 from importlib.util import find_spec
 
 import torch
@@ -11,6 +12,7 @@ import torch.nn.functional as F
 import vllm.envs as envs
 from vllm.compilation.breakable_cudagraph import eager_break_during_capture
 from vllm.forward_context import get_forward_context
+from vllm.logger import init_logger
 from vllm.platforms import current_platform
 from vllm.triton_utils import tl, triton
 from vllm.utils.torch_utils import LayerNameType
@@ -23,6 +25,8 @@ if current_platform.is_rocm():
 else:
     _ON_GFX942 = False
     _ON_GFX950 = False
+
+logger = init_logger(__name__)
 
 
 @triton.jit
@@ -2197,58 +2201,59 @@ def _rocm_sparse_attn_decode_ragged_triton(
     return out
 
 
-def _rocm_sparse_attn_decode_triton(
+def _load_aiter_pa_decode_sparse() -> Callable[..., torch.Tensor]:
+    from aiter.ops.triton.attention.pa_decode_sparse import pa_decode_sparse
+
+    return pa_decode_sparse
+
+
+def _rocm_sparse_attn_decode_gluon(
+    pa_decode_sparse: Callable[..., torch.Tensor],
     q: torch.Tensor,
     main_cache: torch.Tensor,
     main_indices: torch.Tensor,
+    main_indptr: torch.Tensor,
     scale: float,
     attn_sink: torch.Tensor | None,
     nope_head_dim: int,
     rope_head_dim: int,
-    extra_cache: torch.Tensor | None = None,
-    extra_indices: torch.Tensor | None = None,
-    main_lengths: torch.Tensor | None = None,
-    extra_lengths: torch.Tensor | None = None,
-    main_ragged_indices: torch.Tensor | None = None,
-    main_ragged_indptr: torch.Tensor | None = None,
-    extra_ragged_indices: torch.Tensor | None = None,
-    extra_ragged_indptr: torch.Tensor | None = None,
+    extra_cache: torch.Tensor | None,
+    extra_indices: torch.Tensor | None,
+    extra_indptr: torch.Tensor | None,
 ) -> torch.Tensor:
-    if main_ragged_indices is None or main_ragged_indptr is None:
-        main_ragged_indices, main_ragged_indptr = build_ragged_indices_from_dense(
-            main_indices,
-            main_lengths
-            if main_lengths is not None
-            else (main_indices >= 0).sum(dim=-1, dtype=torch.int32),
-            num_rows=main_cache.shape[0] * main_cache.shape[1],
-        )
-
-    if (
-        (extra_ragged_indices is None or extra_ragged_indptr is None)
-        and extra_cache is not None
-        and extra_indices is not None
-    ):
-        extra_ragged_indices, extra_ragged_indptr = build_ragged_indices_from_dense(
-            extra_indices,
-            extra_lengths
-            if extra_lengths is not None
-            else (extra_indices >= 0).sum(dim=-1, dtype=torch.int32),
-            num_rows=extra_cache.shape[0] * extra_cache.shape[1],
-        )
-
-    return _rocm_sparse_attn_decode_ragged_triton(
-        q=q,
-        main_cache=main_cache,
-        main_indices=main_ragged_indices,
-        main_indptr=main_ragged_indptr,
-        scale=scale,
-        attn_sink=attn_sink,
-        nope_head_dim=nope_head_dim,
-        rope_head_dim=rope_head_dim,
+    """Run the packed fp8_ds_mla decode on aiter's gfx950 gluon kernel."""
+    del nope_head_dim, rope_head_dim
+    return pa_decode_sparse(
+        q,
+        main_cache,
+        main_indices,
+        main_indptr,
+        attn_sink,
+        scale,
+        has_invalid=True,
         extra_cache=extra_cache,
-        extra_indices=extra_ragged_indices,
-        extra_indptr=extra_ragged_indptr,
+        extra_indices=extra_indices,
+        extra_indptr=extra_indptr,
     )
+
+
+@functools.cache
+def _resolve_rocm_sparse_attn_decode() -> Callable[..., torch.Tensor]:
+    if not envs.VLLM_ROCM_USE_AITER_SPARSE_MLA_GLUON:
+        return _rocm_sparse_attn_decode_ragged_triton
+    if not _ON_GFX950:
+        raise RuntimeError(
+            "VLLM_ROCM_USE_AITER_SPARSE_MLA_GLUON requires an AMD gfx950 GPU."
+        )
+    try:
+        pa_decode_sparse = _load_aiter_pa_decode_sparse()
+    except ImportError as exc:
+        raise RuntimeError(
+            "VLLM_ROCM_USE_AITER_SPARSE_MLA_GLUON requires an AITER build "
+            "providing aiter.ops.triton.attention.pa_decode_sparse."
+        ) from exc
+    logger.info_once("Using AITER gfx950 Gluon kernel for sparse MLA decode.")
+    return functools.partial(_rocm_sparse_attn_decode_gluon, pa_decode_sparse)
 
 
 def rocm_sparse_attn_prefill(
@@ -2348,21 +2353,44 @@ def rocm_sparse_attn_decode(
         if topk_indices is not None:
             extra_indices = topk_indices.reshape(topk_indices.shape[0], -1)
 
-    attn_out = _rocm_sparse_attn_decode_triton(
+    if swa_ragged_indices is None or swa_ragged_indptr is None:
+        swa_ragged_indices, swa_ragged_indptr = build_ragged_indices_from_dense(
+            main_indices,
+            swa_lens,
+            num_rows=swa_k_cache.shape[0] * swa_k_cache.shape[1],
+        )
+
+    if (
+        (topk_ragged_indices is None or topk_ragged_indptr is None)
+        and extra_cache is not None
+        and extra_indices is not None
+    ):
+        topk_ragged_indices, topk_ragged_indptr = build_ragged_indices_from_dense(
+            extra_indices,
+            topk_lens
+            if topk_lens is not None
+            else (extra_indices >= 0).sum(dim=-1, dtype=torch.int32),
+            num_rows=extra_cache.shape[0] * extra_cache.shape[1],
+        )
+
+    assert swa_ragged_indices is not None
+    assert swa_ragged_indptr is not None
+    if extra_cache is not None:
+        assert topk_ragged_indices is not None
+        assert topk_ragged_indptr is not None
+
+    decode_impl = _resolve_rocm_sparse_attn_decode()
+    attn_out = decode_impl(
         q=q,
         main_cache=swa_k_cache,
-        main_indices=main_indices,
+        main_indices=swa_ragged_indices,
+        main_indptr=swa_ragged_indptr,
         scale=scale,
         attn_sink=None if attn_sink is None else attn_sink[: q.shape[1]],
         nope_head_dim=nope_head_dim,
         rope_head_dim=rope_head_dim,
         extra_cache=extra_cache,
-        extra_indices=extra_indices,
-        main_lengths=swa_lens,
-        extra_lengths=topk_lens,
-        main_ragged_indices=swa_ragged_indices,
-        main_ragged_indptr=swa_ragged_indptr,
-        extra_ragged_indices=topk_ragged_indices,
-        extra_ragged_indptr=topk_ragged_indptr,
+        extra_indices=topk_ragged_indices,
+        extra_indptr=topk_ragged_indptr,
     )
     output.copy_(attn_out.to(output.dtype))


### PR DESCRIPTION
## Purpose

Adds an opt-in gfx950 Gluon replacement for the Triton sparse-MLA decode pair
(`_sparse_attn_decode_partial_kernel` and
`_sparse_attn_decode_reduce_kernel`), provided by AITER
([ROCm/aiter#4382](https://github.com/ROCm/aiter/pull/4382)).

## Duplicate-work check

Open-PR searches for `sparse MLA Gluon`,
`VLLM_ROCM_USE_AITER_SPARSE_MLA_GLUON`, and `AITER sparse MLA decode`
found no other PR implementing this AITER Gluon dispatch.

PR #52212 modifies the same module but is materially different: it optimizes
the existing/default Triton long-context decode path. This PR adds an opt-in
AITER implementation and leaves the Triton implementation as the default.

## Changes

- Register `VLLM_ROCM_USE_AITER_SPARSE_MLA_GLUON` in `vllm/envs.py`.
  It defaults to `False` and accepts the standard `true` and `1` forms.
- Resolve the decode implementation once with `functools.cache`.
  Model initialization warms the resolver, so an explicit Gluon opt-in fails
  before serving if the GPU is not gfx950 or AITER does not provide
  `pa_decode_sparse`.
- Build the shared ragged indices before dispatch and select the implementation
  from `rocm_sparse_attn_decode`.
- Let kernel launch failures propagate. There is no broad launch-time exception
  handler or process-wide fallback latch.
- Log the selected AITER Gluon implementation with `logger.info_once`.
- Pass `has_invalid=True` because `build_ragged_indices_from_dense` can retain
  `-1` sentinels inside the ragged range.
- Add focused coverage for environment parsing and resolver selection/failure.

## Dependency

vLLM currently pins AITER at `v0.1.19`, which does not contain the Gluon kernel
from ROCm/aiter#4382 or the large-pool offset fix from ROCm/aiter#4673. This PR
must remain on hold until the AITER version is bumped.

ROCm/aiter#4673 is needed for large strided KV pools. Without it, the Gluon
driver can select buffer loads using the tensor's element count rather than its
addressable strided span. Once the span exceeds a 32-bit offset, wrapped offsets
can return incorrect data.

## Validation

Checks run for the latest revision:

```text
.venv/bin/python -m py_compile \
  vllm/envs.py \
  vllm/models/deepseek_v4/amd/rocm.py \
  vllm/v1/attention/ops/rocm_aiter_mla_sparse.py \
  tests/test_envs.py \
  tests/kernels/attention/test_rocm_triton_attn_dsv4.py
Result: passed

git diff --check
Result: passed

Isolated execution of the env parser and cached resolver definitions
Result: passed for disabled selection, gfx950 validation, missing-symbol
failure, cached Gluon selection, and argument forwarding
```

The added pytest cases were not run locally because this host cannot install the
branch's test dependencies through its current CA configuration. They are:

```text
.venv/bin/python -m pytest \
  tests/test_envs.py::test_rocm_sparse_mla_gluon_env -v

.venv/bin/python -m pytest \
  tests/kernels/attention/test_rocm_triton_attn_dsv4.py \
  -k sparse_decode_resolver -v
```

## Hardware results

DeepSeek-V4 on MI355X (gfx950), comparing the Triton default with
`VLLM_ROCM_USE_AITER_SPARSE_MLA_GLUON=1`:

| Concurrency | Output tok/s (base -> Gluon) | Change | Median TPOT (base -> Gluon) | Change |
|---:|---:|---:|---:|---:|
| 8 | 284.79 -> 291.33 | +2.30% | 24.67 -> 24.16 ms | -2.04% |
| 16 | 483.69 -> 488.59 | +1.01% | 29.32 -> 29.02 ms | -1.03% |
| 32 | 708.51 -> 712.89 | +0.62% | 40.78 -> 40.52 ms | -0.65% |
| 64 | 955.23 -> 958.04 | +0.29% | 62.55 -> 62.36 ms | -0.30% |

### AgentX replay

Fast mode, TP=8, concurrency 32, MTP enabled:

| Metric | Triton | Gluon | Change |
|---|---:|---:|---:|
| Output tok/s | 430.76 | 453.23 | +5.22% |
| Output tok/s/GPU | 53.84 | 56.65 | +5.22% |
| Per-user tok/s | 32.72 | 39.96 | +22.12% |
| ITL average | 39.83 ms | 34.60 ms | -13.11% |
| ITL p50 | 35.87 ms | 26.44 ms | -26.30% |
| Time-to-second-token p50 | 38.19 ms | 21.79 ms | -42.95% |
| TTFT p50 | 656.7 ms | 700.6 ms | +6.68% |

### GSM8K accuracy

Full set of 1,319 questions with the Gluon path enabled and the AITER large-pool
fix applied:

| Parallelism | Flexible extract | Strict match | Gluon dispatches | Failures |
|---|---:|---:|---:|---:|
| TP=8 | 0.9666 +/- 0.0049 | 0.9666 +/- 0.0049 | 8 | 0 |
| DP-attention=8 + EP8 | 0.9613 +/- 0.0053 | 0.9613 +/- 0.0053 | 8 | 0 |

## AI assistance

Claude Opus 5 and OpenAI Codex assisted with investigation, implementation,
testing support, and drafting. The human submitter directed the work and is
responsible for reviewing and validating the change end to end.
