### PR TITLE
fix(platform): resolve short-form GPU UUIDs in CUDA_VISIBLE_DEVICES

### DIFF
--- a/tests/cuda/test_cuda_context.py
+++ b/tests/cuda/test_cuda_context.py
@@ -192,5 +192,77 @@ def test_has_device_capability_comparisons(monkeypatch):
         NvmlCudaPlatform.get_device_capability.cache_clear()
 
 
+def _stub_nvml_uuids(monkeypatch, uuids: dict[int, str]):
+    """Stub NVML to report the given physical-index -> UUID map.
+
+    ``nvmlDeviceGetHandleByUUID`` only matches exact, full UUIDs (mirroring
+    NVML, which has no prefix-matching fallback), so short-form UUIDs must be
+    resolved via the prefix scan in
+    ``device_control_id_to_physical_device_id``.
+    """
+    from vllm.platforms.cuda import pynvml
+
+    def handle_by_index(index: int):
+        return f"handle-{index}"
+
+    def handle_by_uuid(uuid: str):
+        for index, full in uuids.items():
+            if full == uuid:
+                return f"handle-{index}"
+        raise pynvml.NVMLError_NotFound()
+
+    def index_of(handle: str):
+        return int(handle.split("-")[1])
+
+    monkeypatch.setattr(pynvml, "nvmlInit", lambda: None)
+    monkeypatch.setattr(pynvml, "nvmlShutdown", lambda: None)
+    monkeypatch.setattr(pynvml, "nvmlDeviceGetCount", lambda: len(uuids))
+    monkeypatch.setattr(pynvml, "nvmlDeviceGetHandleByIndex", handle_by_index)
+    monkeypatch.setattr(pynvml, "nvmlDeviceGetHandleByUUID", handle_by_uuid)
+    monkeypatch.setattr(pynvml, "nvmlDeviceGetIndex", index_of)
+    monkeypatch.setattr(pynvml, "nvmlDeviceGetUUID",
+                        lambda h: uuids[index_of(h)])
+
+
+def test_device_control_id_short_uuid_prefix(monkeypatch):
+    """CUDA_VISIBLE_DEVICES accepts the first few characters of a GPU UUID
+    (NVIDIA-documented short form); NVML only matches exact UUIDs, so the
+    platform must fall back to a prefix scan."""
+    from vllm.platforms.cuda import NvmlCudaPlatform
+
+    uuids = {
+        0: "GPU-af7b61d8-21af-baea-6a19-42a1f9f7c3cb",
+        1: "GPU-95a445f6-69ca-10b5-3201-e1cf693804b2",
+    }
+    _stub_nvml_uuids(monkeypatch, uuids)
+
+    # Short prefix resolves to the correct physical index.
+    assert NvmlCudaPlatform.device_control_id_to_physical_device_id(
+        "GPU-95a445f6") == 1
+    assert NvmlCudaPlatform.device_control_id_to_physical_device_id(
+        "GPU-af7b61d8") == 0
+    # Short prefix without the leading "GPU-".
+    assert NvmlCudaPlatform.device_control_id_to_physical_device_id(
+        "95a445f6") == 1
+    # Exact full UUID still works.
+    assert NvmlCudaPlatform.device_control_id_to_physical_device_id(
+        "GPU-af7b61d8-21af-baea-6a19-42a1f9f7c3cb") == 0
+    # Integer IDs still work.
+    assert NvmlCudaPlatform.device_control_id_to_physical_device_id("0") == 0
+    assert NvmlCudaPlatform.device_control_id_to_physical_device_id("1") == 1
+
+
+def test_device_control_id_short_uuid_no_match(monkeypatch):
+    """A prefix that matches no physical device must surface NVML's not-found
+    error rather than silently mapping to an unrelated device."""
+    from vllm.platforms.cuda import NvmlCudaPlatform, pynvml
+
+    _stub_nvml_uuids(monkeypatch, {
+        0: "GPU-af7b61d8-21af-baea-6a19-42a1f9f7c3cb",
+    })
+    with pytest.raises(pynvml.NVMLError_NotFound):
+        NvmlCudaPlatform.device_control_id_to_physical_device_id("GPU-zzzz")
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/cuda/test_cuda_context.py
+++ b/tests/cuda/test_cuda_context.py
@@ -192,9 +192,9 @@ def test_has_device_capability_comparisons(monkeypatch):
         NvmlCudaPlatform.get_device_capability.cache_clear()
 
 
-def _stub_nvml_uuids(monkeypatch,
-                     uuids: dict[int, str],
-                     mig_uuids: dict[int, list[str]] | None = None):
+def _stub_nvml_uuids(
+    monkeypatch, uuids: dict[int, str], mig_uuids: dict[int, list[str]] | None = None
+):
     """Stub NVML to report the given physical-index -> UUID map.
 
     ``nvmlDeviceGetHandleByUUID`` only matches exact, full UUIDs (mirroring
@@ -245,12 +245,17 @@ def _stub_nvml_uuids(monkeypatch,
     monkeypatch.setattr(pynvml, "nvmlDeviceGetHandleByUUID", handle_by_uuid)
     monkeypatch.setattr(pynvml, "nvmlDeviceGetIndex", index_of)
     monkeypatch.setattr(pynvml, "nvmlDeviceGetUUID", uuid_of)
-    monkeypatch.setattr(pynvml, "nvmlDeviceGetMaxMigDeviceCount",
-                        lambda h: len(mig_uuids.get(index_of(h), [])))
-    monkeypatch.setattr(pynvml, "nvmlDeviceGetMigDeviceHandleByIndex",
-                        mig_handle_by_index)
-    monkeypatch.setattr(pynvml, "nvmlDeviceGetDeviceHandleFromMigDeviceHandle",
-                        parent_handle_of)
+    monkeypatch.setattr(
+        pynvml,
+        "nvmlDeviceGetMaxMigDeviceCount",
+        lambda h: len(mig_uuids.get(index_of(h), [])),
+    )
+    monkeypatch.setattr(
+        pynvml, "nvmlDeviceGetMigDeviceHandleByIndex", mig_handle_by_index
+    )
+    monkeypatch.setattr(
+        pynvml, "nvmlDeviceGetDeviceHandleFromMigDeviceHandle", parent_handle_of
+    )
 
 
 def test_device_control_id_short_uuid_prefix(monkeypatch):
@@ -266,16 +271,17 @@ def test_device_control_id_short_uuid_prefix(monkeypatch):
     _stub_nvml_uuids(monkeypatch, uuids)
 
     # Short prefix resolves to the correct physical index.
-    assert NvmlCudaPlatform.device_control_id_to_physical_device_id(
-        "GPU-95a445f6") == 1
-    assert NvmlCudaPlatform.device_control_id_to_physical_device_id(
-        "GPU-af7b61d8") == 0
+    assert NvmlCudaPlatform.device_control_id_to_physical_device_id("GPU-95a445f6") == 1
+    assert NvmlCudaPlatform.device_control_id_to_physical_device_id("GPU-af7b61d8") == 0
     # Short prefix without the leading "GPU-".
-    assert NvmlCudaPlatform.device_control_id_to_physical_device_id(
-        "95a445f6") == 1
+    assert NvmlCudaPlatform.device_control_id_to_physical_device_id("95a445f6") == 1
     # Exact full UUID still works.
-    assert NvmlCudaPlatform.device_control_id_to_physical_device_id(
-        "GPU-af7b61d8-21af-baea-6a19-42a1f9f7c3cb") == 0
+    assert (
+        NvmlCudaPlatform.device_control_id_to_physical_device_id(
+            "GPU-af7b61d8-21af-baea-6a19-42a1f9f7c3cb"
+        )
+        == 0
+    )
     # Integer IDs still work.
     assert NvmlCudaPlatform.device_control_id_to_physical_device_id("0") == 0
     assert NvmlCudaPlatform.device_control_id_to_physical_device_id("1") == 1
@@ -294,23 +300,26 @@ def test_device_control_id_mig_uuid(monkeypatch):
             1: "GPU-95a445f6-69ca-10b5-3201-e1cf693804b2",
         },
         mig_uuids={
-            1: ["MIG-4c60d78c-506f-5593-938d-a136eaa1fa52",
-                "MIG-aa11bb22-cc33-4455-6677-8899aabbccdd"],
+            1: [
+                "MIG-4c60d78c-506f-5593-938d-a136eaa1fa52",
+                "MIG-aa11bb22-cc33-4455-6677-8899aabbccdd",
+            ],
         },
     )
 
     # Exact MIG UUID resolves to its parent GPU's physical index.
-    assert NvmlCudaPlatform.device_control_id_to_physical_device_id(
-        "MIG-4c60d78c-506f-5593-938d-a136eaa1fa52") == 1
+    assert (
+        NvmlCudaPlatform.device_control_id_to_physical_device_id(
+            "MIG-4c60d78c-506f-5593-938d-a136eaa1fa52"
+        )
+        == 1
+    )
     # Short MIG prefix.
-    assert NvmlCudaPlatform.device_control_id_to_physical_device_id(
-        "MIG-aa11bb22") == 1
+    assert NvmlCudaPlatform.device_control_id_to_physical_device_id("MIG-aa11bb22") == 1
     # Short MIG prefix without the leading "MIG-".
-    assert NvmlCudaPlatform.device_control_id_to_physical_device_id(
-        "4c60d78c") == 1
+    assert NvmlCudaPlatform.device_control_id_to_physical_device_id("4c60d78c") == 1
     # GPU UUIDs still resolve.
-    assert NvmlCudaPlatform.device_control_id_to_physical_device_id(
-        "GPU-95a445f6") == 1
+    assert NvmlCudaPlatform.device_control_id_to_physical_device_id("GPU-95a445f6") == 1
 
 
 def test_device_control_id_short_uuid_no_match(monkeypatch):
@@ -318,9 +327,12 @@ def test_device_control_id_short_uuid_no_match(monkeypatch):
     error rather than silently mapping to an unrelated device."""
     from vllm.platforms.cuda import NvmlCudaPlatform, pynvml
 
-    _stub_nvml_uuids(monkeypatch, {
-        0: "GPU-af7b61d8-21af-baea-6a19-42a1f9f7c3cb",
-    })
+    _stub_nvml_uuids(
+        monkeypatch,
+        {
+            0: "GPU-af7b61d8-21af-baea-6a19-42a1f9f7c3cb",
+        },
+    )
     with pytest.raises(pynvml.NVMLError_NotFound):
         NvmlCudaPlatform.device_control_id_to_physical_device_id("GPU-zzzz")
 

--- a/tests/cuda/test_cuda_context.py
+++ b/tests/cuda/test_cuda_context.py
@@ -192,15 +192,22 @@ def test_has_device_capability_comparisons(monkeypatch):
         NvmlCudaPlatform.get_device_capability.cache_clear()
 
 
-def _stub_nvml_uuids(monkeypatch, uuids: dict[int, str]):
+def _stub_nvml_uuids(monkeypatch,
+                     uuids: dict[int, str],
+                     mig_uuids: dict[int, list[str]] | None = None):
     """Stub NVML to report the given physical-index -> UUID map.
 
     ``nvmlDeviceGetHandleByUUID`` only matches exact, full UUIDs (mirroring
     NVML, which has no prefix-matching fallback), so short-form UUIDs must be
     resolved via the prefix scan in
     ``device_control_id_to_physical_device_id``.
+
+    ``mig_uuids`` optionally maps a physical GPU index to the UUIDs of its MIG
+    instances; MIG devices resolve to their parent GPU's physical index.
     """
     from vllm.platforms.cuda import pynvml
+
+    mig_uuids = mig_uuids or {}
 
     def handle_by_index(index: int):
         return f"handle-{index}"
@@ -214,14 +221,36 @@ def _stub_nvml_uuids(monkeypatch, uuids: dict[int, str]):
     def index_of(handle: str):
         return int(handle.split("-")[1])
 
+    def mig_handle_by_index(parent_handle: str, mig_idx: int):
+        parent = index_of(parent_handle)
+        migs = mig_uuids.get(parent, [])
+        if mig_idx >= len(migs):
+            raise pynvml.NVMLError_NotFound()
+        return f"mig-{parent}-{mig_idx}"
+
+    def parent_handle_of(mig_handle: str):
+        parent = int(mig_handle.split("-")[1])
+        return f"handle-{parent}"
+
+    def uuid_of(handle: str):
+        if handle.startswith("mig-"):
+            parent, mig_idx = int(handle.split("-")[1]), int(handle.split("-")[2])
+            return mig_uuids[parent][mig_idx]
+        return uuids[index_of(handle)]
+
     monkeypatch.setattr(pynvml, "nvmlInit", lambda: None)
     monkeypatch.setattr(pynvml, "nvmlShutdown", lambda: None)
     monkeypatch.setattr(pynvml, "nvmlDeviceGetCount", lambda: len(uuids))
     monkeypatch.setattr(pynvml, "nvmlDeviceGetHandleByIndex", handle_by_index)
     monkeypatch.setattr(pynvml, "nvmlDeviceGetHandleByUUID", handle_by_uuid)
     monkeypatch.setattr(pynvml, "nvmlDeviceGetIndex", index_of)
-    monkeypatch.setattr(pynvml, "nvmlDeviceGetUUID",
-                        lambda h: uuids[index_of(h)])
+    monkeypatch.setattr(pynvml, "nvmlDeviceGetUUID", uuid_of)
+    monkeypatch.setattr(pynvml, "nvmlDeviceGetMaxMigDeviceCount",
+                        lambda h: len(mig_uuids.get(index_of(h), [])))
+    monkeypatch.setattr(pynvml, "nvmlDeviceGetMigDeviceHandleByIndex",
+                        mig_handle_by_index)
+    monkeypatch.setattr(pynvml, "nvmlDeviceGetDeviceHandleFromMigDeviceHandle",
+                        parent_handle_of)
 
 
 def test_device_control_id_short_uuid_prefix(monkeypatch):
@@ -250,6 +279,38 @@ def test_device_control_id_short_uuid_prefix(monkeypatch):
     # Integer IDs still work.
     assert NvmlCudaPlatform.device_control_id_to_physical_device_id("0") == 0
     assert NvmlCudaPlatform.device_control_id_to_physical_device_id("1") == 1
+
+
+def test_device_control_id_mig_uuid(monkeypatch):
+    """MIG instance UUIDs (``MIG-...``) in CUDA_VISIBLE_DEVICES must resolve
+    to their parent GPU's physical index (issue #46132's scenario, fixed with
+    a prefix scan instead of silently returning the logical id)."""
+    from vllm.platforms.cuda import NvmlCudaPlatform
+
+    _stub_nvml_uuids(
+        monkeypatch,
+        uuids={
+            0: "GPU-af7b61d8-21af-baea-6a19-42a1f9f7c3cb",
+            1: "GPU-95a445f6-69ca-10b5-3201-e1cf693804b2",
+        },
+        mig_uuids={
+            1: ["MIG-4c60d78c-506f-5593-938d-a136eaa1fa52",
+                "MIG-aa11bb22-cc33-4455-6677-8899aabbccdd"],
+        },
+    )
+
+    # Exact MIG UUID resolves to its parent GPU's physical index.
+    assert NvmlCudaPlatform.device_control_id_to_physical_device_id(
+        "MIG-4c60d78c-506f-5593-938d-a136eaa1fa52") == 1
+    # Short MIG prefix.
+    assert NvmlCudaPlatform.device_control_id_to_physical_device_id(
+        "MIG-aa11bb22") == 1
+    # Short MIG prefix without the leading "MIG-".
+    assert NvmlCudaPlatform.device_control_id_to_physical_device_id(
+        "4c60d78c") == 1
+    # GPU UUIDs still resolve.
+    assert NvmlCudaPlatform.device_control_id_to_physical_device_id(
+        "GPU-95a445f6") == 1
 
 
 def test_device_control_id_short_uuid_no_match(monkeypatch):

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -729,12 +729,8 @@ class NvmlCudaPlatform(CudaPlatformBase):
                 handle = pynvml.nvmlDeviceGetHandleByUUID(device_id)
                 return pynvml.nvmlDeviceGetIndex(handle)
             except pynvml.NVMLError_NotFound:
-                # NVIDIA documents that CUDA_VISIBLE_DEVICES accepts the
-                # first few characters of a GPU UUID (including "GPU-") rather
-                # than the full 36-char UUID.  NVML's
-                # nvmlDeviceGetHandleByUUID() requires an exact, full match,
-                # so fall back to a prefix scan over the physical devices
-                # (and their MIG instances).
+                # CUDA_VISIBLE_DEVICES accepts a UUID prefix, but NVML needs
+                # an exact match, so fall back to a prefix scan.
                 prefix = device_id.removeprefix("GPU-").removeprefix("MIG-")
                 for index in range(pynvml.nvmlDeviceGetCount()):
                     handle = pynvml.nvmlDeviceGetHandleByIndex(index)

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -725,8 +725,22 @@ class NvmlCudaPlatform(CudaPlatformBase):
         try:
             return int(device_id)
         except ValueError:
-            handle = pynvml.nvmlDeviceGetHandleByUUID(device_id)
-            return pynvml.nvmlDeviceGetIndex(handle)
+            try:
+                handle = pynvml.nvmlDeviceGetHandleByUUID(device_id)
+                return pynvml.nvmlDeviceGetIndex(handle)
+            except pynvml.NVMLError_NotFound:
+                # NVIDIA documents that CUDA_VISIBLE_DEVICES accepts the
+                # first few characters of a GPU UUID (including "GPU-") rather
+                # than the full 36-char UUID.  NVML's
+                # nvmlDeviceGetHandleByUUID() requires an exact, full match,
+                # so fall back to a prefix scan over the physical devices.
+                prefix = device_id.removeprefix("GPU-")
+                for index in range(pynvml.nvmlDeviceGetCount()):
+                    handle = pynvml.nvmlDeviceGetHandleByIndex(index)
+                    uuid = pynvml.nvmlDeviceGetUUID(handle)
+                    if uuid.removeprefix("GPU-").startswith(prefix):
+                        return index
+                raise
 
     @classmethod
     @cache

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -733,13 +733,31 @@ class NvmlCudaPlatform(CudaPlatformBase):
                 # first few characters of a GPU UUID (including "GPU-") rather
                 # than the full 36-char UUID.  NVML's
                 # nvmlDeviceGetHandleByUUID() requires an exact, full match,
-                # so fall back to a prefix scan over the physical devices.
-                prefix = device_id.removeprefix("GPU-")
+                # so fall back to a prefix scan over the physical devices
+                # (and their MIG instances).
+                prefix = device_id.removeprefix("GPU-").removeprefix("MIG-")
                 for index in range(pynvml.nvmlDeviceGetCount()):
                     handle = pynvml.nvmlDeviceGetHandleByIndex(index)
                     uuid = pynvml.nvmlDeviceGetUUID(handle)
                     if uuid.removeprefix("GPU-").startswith(prefix):
                         return index
+                    # MIG instances share the parent GPU's physical index.
+                    try:
+                        for mig_idx in range(
+                                pynvml.nvmlDeviceGetMaxMigDeviceCount(handle)):
+                            mig_handle = (
+                                pynvml.nvmlDeviceGetMigDeviceHandleByIndex(
+                                    handle, mig_idx))
+                            mig_uuid = pynvml.nvmlDeviceGetUUID(mig_handle)
+                            if mig_uuid.removeprefix("MIG-").startswith(prefix):
+                                parent = (
+                                    pynvml
+                                    .nvmlDeviceGetDeviceHandleFromMigDeviceHandle(
+                                        mig_handle))
+                                return pynvml.nvmlDeviceGetIndex(parent)
+                    except pynvml.NVMLError:
+                        # No MIG instances on this device (or MIG disabled).
+                        pass
                 raise
 
     @classmethod

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -744,16 +744,18 @@ class NvmlCudaPlatform(CudaPlatformBase):
                     # MIG instances share the parent GPU's physical index.
                     try:
                         for mig_idx in range(
-                                pynvml.nvmlDeviceGetMaxMigDeviceCount(handle)):
-                            mig_handle = (
-                                pynvml.nvmlDeviceGetMigDeviceHandleByIndex(
-                                    handle, mig_idx))
+                            pynvml.nvmlDeviceGetMaxMigDeviceCount(handle)
+                        ):
+                            mig_handle = pynvml.nvmlDeviceGetMigDeviceHandleByIndex(
+                                handle, mig_idx
+                            )
                             mig_uuid = pynvml.nvmlDeviceGetUUID(mig_handle)
                             if mig_uuid.removeprefix("MIG-").startswith(prefix):
                                 parent = (
-                                    pynvml
-                                    .nvmlDeviceGetDeviceHandleFromMigDeviceHandle(
-                                        mig_handle))
+                                    pynvml.nvmlDeviceGetDeviceHandleFromMigDeviceHandle(
+                                        mig_handle
+                                    )
+                                )
                                 return pynvml.nvmlDeviceGetIndex(parent)
                     except pynvml.NVMLError:
                         # No MIG instances on this device (or MIG disabled).


### PR DESCRIPTION
## Summary

Fixes #51677 — engine init crashes when `CUDA_VISIBLE_DEVICES` uses NVIDIA's documented **short-form GPU UUID** (e.g. `GPU-af7b61d8` instead of the full `GPU-af7b61d8-21af-baea-6a19-42a1f9f7c3cb`).

NVIDIA documents the short form as valid for `CUDA_VISIBLE_DEVICES`:

> "It will also work when you specify the first few characters of the UUID (including 'GPU-') rather than the full UUID."

CUDA, PyTorch and nvidia-smi all resolve the short form correctly; vLLM does not.

### Root cause

`NvmlCudaPlatform.device_control_id_to_physical_device_id` resolves non-integer device ids via `pynvml.nvmlDeviceGetHandleByUUID(device_id)`, which requires an **exact, full UUID** match and has no prefix fallback — it raises `NVMLError_NotFound` for any abbreviated UUID. Since this resolution is also invoked from the short-lived subprocess vLLM spawns to probe model architectures, the crash happens before the model finishes loading.

### Fix

When the exact UUID lookup fails, fall back to a **prefix scan** over the physical devices (and their MIG instances), matching the requested prefix (with or without the leading `GPU-` / `MIG-`):

```python
except pynvml.NVMLError_NotFound:
    prefix = device_id.removeprefix("GPU-").removeprefix("MIG-")
    for index in range(pynvml.nvmlDeviceGetCount()):
        handle = pynvml.nvmlDeviceGetHandleByIndex(index)
        uuid = pynvml.nvmlDeviceGetUUID(handle)
        if uuid.removeprefix("GPU-").startswith(prefix):
            return index
        # MIG instances share the parent GPU's physical index.
        for mig_idx in range(pynvml.nvmlDeviceGetMaxMigDeviceCount(handle)):
            mig_handle = pynvml.nvmlDeviceGetMigDeviceHandleByIndex(handle, mig_idx)
            if pynvml.nvmlDeviceGetUUID(mig_handle).removeprefix("MIG-").startswith(prefix):
                parent = pynvml.nvmlDeviceGetDeviceHandleFromMigDeviceHandle(mig_handle)
                return pynvml.nvmlDeviceGetIndex(parent)
    raise
```

This also resolves MIG instance UUIDs (`MIG-...`), the same class of crash reported in #46132, but returns the **physical** GPU index (via the MIG device's parent handle) rather than #46132's approach of returning the logical device id — the logical id is wrong when the visible device set is non-contiguous, and would mis-direct subsequent NVML queries.

### Validation

- Reproduced on a real device: short-form UUID raised `NVMLError_NotFound` before the fix.
- After the fix, short-form/full GPU UUIDs, MIG UUIDs (exact + short prefix), and integer device ids all resolve correctly on a real GPU (MIG path no-ops cleanly when MIG is disabled).
- New unit tests (mock NVML, no GPU required):
  - `test_device_control_id_short_uuid_prefix` — GPU short prefix maps to the correct physical index, with/without the `GPU-` prefix; full UUID and integer ids still work.
  - `test_device_control_id_mig_uuid` — MIG UUIDs (exact + short prefix, with/without `MIG-`) map to their parent GPU's physical index.
  - `test_device_control_id_short_uuid_no_match` — an unmatched prefix surfaces `NVMLError_NotFound` rather than silently mapping to an unrelated device.
