### PR TITLE
fix(config): keep derived DP master IP with ray backend at dp=1

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -420,6 +420,42 @@ def test_reconfigure_for_independent_dp_rank_on_multinode_dense_model():
     assert parallel_config.world_size == 8
 
 
+def test_ray_dp_backend_keeps_derived_master_ip_at_dp1(monkeypatch):
+    """`--data-parallel-backend ray --data-parallel-size 1` must keep the
+    master IP derived by EngineArgs instead of falling back to
+    `VLLM_DP_MASTER_IP` (default "127.0.0.1"). Otherwise the DP placement
+    group lookup fails ("The DP master node (ip: 127.0.0.1) is missing or
+    dead"). See issue #51712."""
+    # Force the env fallback to a wrong value, so this test fails if the
+    # ray branch still reads it.
+    monkeypatch.setenv("VLLM_DP_MASTER_IP", "127.0.0.1")
+    monkeypatch.setenv("VLLM_DP_SIZE", "1")
+    monkeypatch.setenv("VLLM_DP_RANK", "0")
+    monkeypatch.setenv("VLLM_DP_RANK_LOCAL", "-1")
+    monkeypatch.setenv("VLLM_DP_MASTER_PORT", "29500")
+
+    parallel_config = ParallelConfig(
+        data_parallel_size=1,
+        data_parallel_size_local=1,
+        data_parallel_backend="ray",
+        data_parallel_master_ip="192.168.1.100",  # as derived by EngineArgs
+    )
+    assert parallel_config.data_parallel_master_ip == "192.168.1.100"
+
+
+def test_mp_dp_backend_falls_back_to_env_master_ip(monkeypatch):
+    """The non-ray (offline SPMD) path must keep reading VLLM_DP_MASTER_IP."""
+    monkeypatch.setenv("VLLM_DP_MASTER_IP", "10.0.0.5")
+
+    parallel_config = ParallelConfig(
+        data_parallel_size=1,
+        data_parallel_size_local=1,
+        data_parallel_backend="mp",
+        data_parallel_master_ip="192.168.1.100",
+    )
+    assert parallel_config.data_parallel_master_ip == "10.0.0.5"
+
+
 def test_draft_model_enables_async_scheduling_by_default():
     parallel_config = ParallelConfig(distributed_executor_backend="uni")
     model_config = ModelConfig("Qwen/Qwen3-0.6B", max_model_len=2048)

--- a/vllm/config/parallel.py
+++ b/vllm/config/parallel.py
@@ -888,8 +888,14 @@ class ParallelConfig:
                     f"data_parallel_rank ({self.data_parallel_rank})"
                     f" must be in the range [0, {self.data_parallel_size})"
                 )
-        else:
+        elif self.data_parallel_backend != "ray":
             # Otherwise fall back to env vars (e.g. for offline SPMD case).
+            # Skip this when the ray backend is selected: EngineArgs has
+            # already derived the DP master address from the Ray node (see
+            # `create_engine_config`), and the fallback below would discard it
+            # for the default `VLLM_DP_MASTER_IP` ("127.0.0.1"), breaking DP
+            # placement-group lookup with `--data-parallel-size 1
+            # --data-parallel-backend ray`.
             self.data_parallel_size = envs.VLLM_DP_SIZE
             self.data_parallel_rank = envs.VLLM_DP_RANK
             self.data_parallel_rank_local = envs.VLLM_DP_RANK_LOCAL

--- a/vllm/config/parallel.py
+++ b/vllm/config/parallel.py
@@ -890,12 +890,8 @@ class ParallelConfig:
                 )
         elif self.data_parallel_backend != "ray":
             # Otherwise fall back to env vars (e.g. for offline SPMD case).
-            # Skip this when the ray backend is selected: EngineArgs has
-            # already derived the DP master address from the Ray node (see
-            # `create_engine_config`), and the fallback below would discard it
-            # for the default `VLLM_DP_MASTER_IP` ("127.0.0.1"), breaking DP
-            # placement-group lookup with `--data-parallel-size 1
-            # --data-parallel-backend ray`.
+            # For ray, EngineArgs already derived the DP master address from
+            # the Ray node, so the env fallback must not override it.
             self.data_parallel_size = envs.VLLM_DP_SIZE
             self.data_parallel_rank = envs.VLLM_DP_RANK
             self.data_parallel_rank_local = envs.VLLM_DP_RANK_LOCAL


### PR DESCRIPTION
## Summary

Fixes #51712 — engine startup aborts with `--data-parallel-backend ray --data-parallel-size 1`:

```
AssertionError: The DP master node (ip: 127.0.0.1) is missing or dead
```

### Root cause

`EngineArgs.create_engine_config` correctly derives the DP master address from the Ray node (`get_ip()`) and logs *"Using host IP %s as ray-based data parallel address"*, then passes it to `ParallelConfig(data_parallel_master_ip=...)`.

`ParallelConfig.__post_init__` then discards it: with `data_parallel_size == 1` (and `data_parallel_size_local == 1`, not the `0` sentinel) the first branch does not hold, so the **env-var fallback** runs and overwrites `data_parallel_master_ip` with `VLLM_DP_MASTER_IP` (default `127.0.0.1`). `create_dp_placement_groups` then looks up the Ray resource `node:127.0.0.1`, which never exists because Ray registered the head under its real IP.

The bug does not reproduce at `--data-parallel-size 2` (the first branch holds there).

### Fix

Skip the env-var fallback when `data_parallel_backend == "ray"`: `create_engine_config` has already made a deliberate determination for that case (the derived Ray-node IP), and a downstream assertion depends on it. The `mp` (offline SPMD) path is unchanged.

```python
elif self.data_parallel_backend != "ray":
    # Otherwise fall back to env vars (e.g. for offline SPMD case).
    ...
```

### Validation

- Standalone branch-logic check: with `ray` + `dp=1`, the derived master IP is kept; with `mp` + `dp=1`, the env fallback still applies; `dp>1` and the `dp_local==0` sentinel are unchanged.
- New unit tests in `tests/test_config.py`:
  - `test_ray_dp_backend_keeps_derived_master_ip_at_dp1` — ray + dp=1 keeps the EngineArgs-derived IP even when `VLLM_DP_MASTER_IP` is set to a different value.
  - `test_mp_dp_backend_falls_back_to_env_master_ip` — the non-ray path still reads `VLLM_DP_MASTER_IP`.
