### PR TITLE
[ROCm][AITER] Fix fused QK-norm+RoPE+cache abort by allocating K/V as separate head groups

### DIFF
--- a/tests/compile/passes/test_rocm_aiter_qk_norm_rope_kvcache_fusion.py
+++ b/tests/compile/passes/test_rocm_aiter_qk_norm_rope_kvcache_fusion.py
@@ -420,9 +420,9 @@ _FUSION_CONFIGS = [
 @pytest.mark.parametrize("use_shuffle_kv_layout", ["1", "0"])
 @pytest.mark.parametrize(
     "kv_stride_order",
-    # FA/unified use the 4D packed cache (num_blocks, num_kv_heads, block_size,
-    # 2*head_size); no separate K/V dim to permute.
-    [pytest.param((0, 1, 2, 3), id="packed_4d")],
+    # Allocate in whatever order the backend's get_kv_cache_shape reports
+    # (separate K/V head-group planes under AITER, packed content otherwise).
+    [pytest.param((0, 1, 2, 3), id="natural_order")],
 )
 @pytest.mark.parametrize("enable_aiter_triton_rope", [True, False])
 @pytest.mark.parametrize("block_size", [16, 32, 64])

--- a/tests/v1/attention/test_rocm_aiter_kv_geometry.py
+++ b/tests/v1/attention/test_rocm_aiter_kv_geometry.py
@@ -1,0 +1,131 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""KV-cache geometry contract for the AITER attention backends.
+
+The AITER fused QK-norm+RoPE+cache kernel addresses each side as
+``block_id * stride(0) + token * (H*hs) + head * hs`` and hard-asserts that
+each side is contiguous from dim 1 (``k_cache/v_cache must be contiguous
+within a block``). Violating it aborts the process rather than raising, so
+this pins the allocated shape and the strides the split views hand to the
+kernel.
+"""
+
+import pytest
+import torch
+
+from vllm._aiter_ops import is_aiter_found_and_supported, rocm_aiter_ops
+from vllm.v1.attention.backends.rocm_aiter_fa import (
+    AiterFlashAttentionBackend,
+    AiterFlashAttentionImpl,
+)
+from vllm.v1.attention.backends.rocm_aiter_unified_attn import (
+    RocmAiterUnifiedAttentionBackend,
+    RocmAiterUnifiedAttentionImpl,
+)
+
+NUM_BLOCKS = 4
+BLOCK_SIZE = 16
+NUM_KV_HEADS = 2
+HEAD_SIZE = 128
+
+pytestmark = pytest.mark.skipif(
+    not is_aiter_found_and_supported(),
+    reason="Only test on ROCm with AITER installed and supported",
+)
+
+
+def is_contiguous_from_dim1(t: torch.Tensor) -> bool:
+    """Mirror of the AITER-side predicate guarding the fused kernel.
+
+    The block stride (dim 0) is free -- the kernel reads ``stride(0)`` per
+    side -- but everything inside a block must be densely packed.
+    """
+    expected = 1
+    for dim in range(t.dim() - 1, 0, -1):
+        if t.stride(dim) != expected:
+            return False
+        expected *= t.size(dim)
+    return True
+
+
+def _make_impl(impl_cls):
+    return impl_cls(
+        num_heads=NUM_KV_HEADS * 2,
+        head_size=HEAD_SIZE,
+        scale=1.0,
+        num_kv_heads=NUM_KV_HEADS,
+        alibi_slopes=None,
+        sliding_window=None,
+        kv_cache_dtype="auto",
+    )
+
+
+@pytest.fixture
+def aiter_env(monkeypatch: pytest.MonkeyPatch):
+    """Enable AITER with the shuffle layout off (separate K/V head groups)."""
+    with monkeypatch.context() as m:
+        m.setenv("VLLM_ROCM_USE_AITER", "1")
+        m.setenv("VLLM_ROCM_SHUFFLE_KV_CACHE_LAYOUT", "0")
+        rocm_aiter_ops.refresh_env_variables()
+        yield
+    rocm_aiter_ops.refresh_env_variables()
+
+
+@pytest.mark.parametrize(
+    "backend_cls, impl_cls",
+    [
+        (AiterFlashAttentionBackend, AiterFlashAttentionImpl),
+        (RocmAiterUnifiedAttentionBackend, RocmAiterUnifiedAttentionImpl),
+    ],
+)
+def test_split_sides_satisfy_fused_kernel_contract(aiter_env, backend_cls, impl_cls):
+    """Each split side must be block-contiguous with token/head strides."""
+    shape = backend_cls.get_kv_cache_shape(
+        NUM_BLOCKS, BLOCK_SIZE, NUM_KV_HEADS, HEAD_SIZE
+    )
+    assert shape == (NUM_BLOCKS, 2, BLOCK_SIZE, NUM_KV_HEADS * HEAD_SIZE)
+
+    kv_cache = torch.zeros(shape, dtype=torch.bfloat16, device="cpu")
+    key_cache, value_cache = _make_impl(impl_cls)._split_kv_cache(kv_cache)
+
+    for side in (key_cache, value_cache):
+        assert side.shape == (NUM_BLOCKS, BLOCK_SIZE, NUM_KV_HEADS, HEAD_SIZE)
+        assert is_contiguous_from_dim1(side)
+        # slot stride spans one token's head group, head stride one head.
+        assert side.stride(1) == NUM_KV_HEADS * HEAD_SIZE
+        assert side.stride(2) == HEAD_SIZE
+        # Each side's block stride spans both halves.
+        assert side.stride(0) == 2 * BLOCK_SIZE * NUM_KV_HEADS * HEAD_SIZE
+
+    # The two halves must not alias.
+    key_cache[0, 0, 0, 0] = 1.0
+    assert value_cache[0, 0, 0, 0] == 0.0
+
+
+def test_packed_layout_retained_under_shuffle(monkeypatch: pytest.MonkeyPatch):
+    """The shuffle path keeps its own x-packed interior, so it stays packed."""
+    with monkeypatch.context() as m:
+        m.setenv("VLLM_ROCM_USE_AITER", "1")
+        m.setenv("VLLM_ROCM_SHUFFLE_KV_CACHE_LAYOUT", "1")
+        rocm_aiter_ops.refresh_env_variables()
+        shape = AiterFlashAttentionBackend.get_kv_cache_shape(
+            NUM_BLOCKS, BLOCK_SIZE, NUM_KV_HEADS, HEAD_SIZE
+        )
+        assert shape == (NUM_BLOCKS, NUM_KV_HEADS, BLOCK_SIZE, 2 * HEAD_SIZE)
+        impl = _make_impl(AiterFlashAttentionImpl)
+        assert not impl.fused_qk_norm_rope_kvcache_supported()
+    rocm_aiter_ops.refresh_env_variables()
+
+
+def test_packed_split_would_violate_the_contract():
+    """Guards the premise: the packed layout cannot satisfy the kernel.
+
+    Splitting the packed content dim leaves the head dim strided by the whole
+    block, which is what made the fused path abort.
+    """
+    packed = torch.zeros(
+        NUM_BLOCKS, NUM_KV_HEADS, BLOCK_SIZE, 2 * HEAD_SIZE, dtype=torch.bfloat16
+    )
+    key_cache, value_cache = packed.transpose(1, 2).split(HEAD_SIZE, dim=-1)
+    assert not is_contiguous_from_dim1(key_cache)
+    assert not is_contiguous_from_dim1(value_cache)

--- a/tests/v1/kv_connector/unit/offloading_connector/test_canonical_mapping.py
+++ b/tests/v1/kv_connector/unit/offloading_connector/test_canonical_mapping.py
@@ -97,6 +97,28 @@ def _packed_hnd_cache(spec) -> torch.Tensor:
     )
 
 
+def _split_nhd_flat_cache(spec) -> torch.Tensor:
+    """K and V in separate page halves (num_blocks, 2, block_size, heads * hs)
+    — the ROCm AITER form; same bytes as split_nhd with the heads flattened."""
+    return torch.zeros(
+        NUM_BLOCKS,
+        2,
+        spec.block_size,
+        spec.num_kv_heads * spec.head_size,
+        dtype=torch.int8,
+    )
+
+
+@pytest.fixture
+def aiter_split_heads(monkeypatch: pytest.MonkeyPatch):
+    """Pretend ROCm AITER allocated the cache, without needing a ROCm host."""
+    monkeypatch.setattr(
+        "vllm.distributed.kv_transfer.kv_connector.v1."
+        "offloading.canonical_mapping._aiter_separate_kv_head_groups",
+        lambda: True,
+    )
+
+
 CACHE_BUILDERS = {
     "split_nhd": _split_nhd_cache,
     "split_hnd": _split_hnd_cache,
@@ -150,6 +172,29 @@ def test_split_nhd_placement_rank2_of_4():
     ]
     # Heads are sharded, not replicated: this rank writes every block
     assert mapping.num_writers == 1
+
+
+def test_split_nhd_flat_matches_split_nhd(aiter_split_heads):
+    """Flattening the head group must not change the byte mapping."""
+    spec = _full_spec(num_kv_heads=4)
+    ctx = _ctx(rank=2, tp=4, heads=4)
+    flat = _mapping(spec, _split_nhd_flat_cache(spec), ctx)
+    nhd = _mapping(spec, _split_nhd_cache(spec), ctx)
+    assert _triples(flat.runs) == _triples(nhd.runs)
+    assert flat.canonical_page_size_bytes == nhd.canonical_page_size_bytes
+    assert flat.parallelism_agnostic
+
+
+def test_split_nhd_flat_fails_closed_when_shape_is_ambiguous(aiter_split_heads):
+    """At heads == 2 the flat and packed forms are byte-identical; refuse to guess."""
+    spec = _full_spec(num_kv_heads=2)
+    flat = _split_nhd_flat_cache(spec)
+    packed = _packed_hnd_cache(spec)
+    assert tuple(flat.shape) == tuple(packed.shape)
+    assert flat.stride() == packed.stride()
+
+    # Uncertifiable, so the caller falls back to an opaque whole-page mapping.
+    assert _try_mapping(spec, flat, _ctx(rank=2, tp=4)) is None
 
 
 def test_packed_nhd_placement_rank2_of_4():

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/canonical_mapping.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/canonical_mapping.py
@@ -243,6 +243,19 @@ def _split_kv_regions(
     return None
 
 
+def _aiter_separate_kv_head_groups() -> bool:
+    """Whether ROCm AITER is allocating K and V in separate page halves."""
+    from vllm.platforms import current_platform
+
+    if not current_platform.is_rocm():
+        return False
+    from vllm._aiter_ops import rocm_aiter_ops
+
+    return (
+        rocm_aiter_ops.is_enabled() and not rocm_aiter_ops.is_shuffle_kv_cache_enabled()
+    )
+
+
 def _attention_byte_regions(
     kv_cache: torch.Tensor,
     spec: AttentionSpec,
@@ -254,6 +267,27 @@ def _attention_byte_regions(
     """Byte regions of an attention page, given this rank's head shard.
     None when the physical layout is not recognized (fail closed)."""
     bs, heads, head_size = spec.block_size, spec.num_kv_heads, spec.head_size
+    if _aiter_separate_kv_head_groups() and tuple(kv_cache.shape) == (
+        num_blocks,
+        2,
+        bs,
+        heads * head_size,
+    ):
+        # ROCm AITER split layout: the same bytes as the 5-D form above with the
+        # head group flattened into the content dim. At heads == 2 the shape
+        # *and* strides are identical to the packed form below, so the layout
+        # is unknowable from the tensor alone -- fail closed instead of
+        # guessing. TODO: slice_for_tp_transfer (see the KV-layout RFC) will
+        # carry layout identity so it no longer has to be inferred here.
+        if heads == 2 or kv_cache.stride(-1) != 1:
+            return None
+        return _split_kv_regions(
+            kv_cache.unflatten(-1, (heads, head_size)),
+            spec,
+            head_shard,
+            num_head_shards,
+            cp_size,
+        )
     if tuple(kv_cache.shape) == (num_blocks, heads, bs, 2 * head_size):
         return _packed_kv_regions(kv_cache, spec, head_shard, num_head_shards, cp_size)
     if tuple(kv_cache.shape) == (num_blocks, 2, bs, heads, head_size):

--- a/vllm/v1/attention/backends/rocm_aiter_fa.py
+++ b/vllm/v1/attention/backends/rocm_aiter_fa.py
@@ -710,6 +710,20 @@ class AiterFlashAttentionMetadataBuilder(
         return False
 
 
+def _use_separate_kv_head_groups() -> bool:
+    """K and V in separate page halves, each a token-major head group.
+
+    The AITER fused QK-norm+RoPE+cache kernel addresses each side as
+    block_id * stride(0) + token * (H*hs) + head * hs and asserts per-side
+    contiguity within a block, which the packed content layout cannot satisfy
+    (splitting it leaves the head dim strided). The shuffle-layout variant uses
+    its own x-packed interior and keeps the packed content dim.
+    """
+    return (
+        rocm_aiter_ops.is_enabled() and not rocm_aiter_ops.is_shuffle_kv_cache_enabled()
+    )
+
+
 class AiterFlashAttentionBackend(AttentionBackend):
     supported_dtypes: ClassVar[list[torch.dtype]] = [torch.float16, torch.bfloat16]
 
@@ -771,6 +785,9 @@ class AiterFlashAttentionBackend(AttentionBackend):
     ) -> tuple[int, ...]:
         if block_size % 16 != 0:
             raise ValueError("Block size must be a multiple of 16.")
+        if _use_separate_kv_head_groups():
+            # Two block-contiguous token-major sides: (B, 2, N, H*hs).
+            return (num_blocks, 2, block_size, num_kv_heads * head_size)
         # K and V are packed into the content dim: logical (B, H, N, 2*hs).
         return (num_blocks, num_kv_heads, block_size, 2 * head_size)
 
@@ -821,6 +838,7 @@ class AiterFlashAttentionImpl(AttentionImpl):
         self.logits_soft_cap = logits_soft_cap
         self.kv_sharing_target_layer_name = kv_sharing_target_layer_name
         self.sinks = sinks
+        self.separate_kv_head_groups = _use_separate_kv_head_groups()
 
         assert self.num_heads % self.num_kv_heads == 0
         self.num_queries_per_kv = self.num_heads // self.num_kv_heads
@@ -1036,8 +1054,10 @@ class AiterFlashAttentionImpl(AttentionImpl):
             query: shape = [num_tokens, num_heads, head_size]
             key: shape = [num_tokens, num_kv_heads, head_size]
             value: shape = [num_tokens, num_kv_heads, head_size]
-            kv_cache: shape =
-                [num_blocks, 2, block_size, num_kv_heads, head_size]
+            kv_cache: shape = see get_kv_cache_shape; either the separate
+                split layout [num_blocks, 2, block_size,
+                num_kv_heads * head_size] or the packed content layout
+                [num_blocks, num_kv_heads, block_size, 2 * head_size]
             attn_metadata: Metadata for attention.
         Returns:
             shape = [num_tokens, num_heads * head_size]
@@ -1387,6 +1407,12 @@ class AiterFlashAttentionImpl(AttentionImpl):
     def _split_kv_cache(
         self, kv_cache: torch.Tensor
     ) -> tuple[torch.Tensor, torch.Tensor]:
+        if self.separate_kv_head_groups:
+            # (B, 2, N, H*hs) -> ((B, N, H, hs), (B, N, H, hs)), each side
+            # contiguous within a block as the AITER fused kernel requires.
+            key_cache, value_cache = kv_cache.unbind(1)
+            shape = (*key_cache.shape[:-1], self.num_kv_heads, self.head_size)
+            return key_cache.view(shape), value_cache.view(shape)
         # (B, H, N, 2*hs) -> ((B, N, H, hs), (B, N, H, hs))
         return kv_cache.transpose(1, 2).split(self.head_size, dim=-1)
 
@@ -1453,12 +1479,9 @@ class AiterFlashAttentionImpl(AttentionImpl):
         )
 
     def fused_qk_norm_rope_kvcache_supported(self):
-        # Only fuse when shuffle layout is off; the shuffle write path uses a
-        # dedicated cache update, mirroring fused_rope_kvcache_supported.
-        return (
-            rocm_aiter_ops.is_enabled()
-            and not rocm_aiter_ops.is_shuffle_kv_cache_enabled()
-        )
+        # The fused kernel requires each side to be contiguous within a block,
+        # which only the split layout provides.
+        return self.separate_kv_head_groups
 
     def do_qk_norm_rope_kvcache_update(
         self,

--- a/vllm/v1/attention/backends/rocm_aiter_unified_attn.py
+++ b/vllm/v1/attention/backends/rocm_aiter_unified_attn.py
@@ -26,6 +26,16 @@ from vllm.v1.attention.backends.rocm_attn import (
 logger = init_logger(__name__)
 
 
+def _use_separate_kv_head_groups() -> bool:
+    """K and V in separate page halves, each a token-major head group.
+
+    The AITER fused QK-norm+RoPE+cache kernel asserts that each side is
+    contiguous within a block, which the packed content layout cannot satisfy.
+    This backend is NHD-only, so the shuffle layout does not apply here.
+    """
+    return rocm_aiter_ops.is_enabled()
+
+
 class RocmAiterUnifiedAttentionBackend(RocmAttentionBackend):
     supported_dtypes: ClassVar[list[torch.dtype]] = [torch.float16, torch.bfloat16]
     supported_kv_cache_dtypes: ClassVar[list[CacheDType]] = [
@@ -87,6 +97,9 @@ class RocmAiterUnifiedAttentionBackend(RocmAttentionBackend):
     ) -> tuple[int, ...]:
         if block_size % 16 != 0:
             raise ValueError("Block size must be a multiple of 16.")
+        if _use_separate_kv_head_groups():
+            # Two block-contiguous token-major sides: (B, 2, N, H*hs).
+            return (num_blocks, 2, block_size, num_kv_heads * head_size)
         # K and V are packed into the content dim: logical (B, H, N, 2*hs).
         return (num_blocks, num_kv_heads, block_size, 2 * head_size)
 
@@ -147,10 +160,17 @@ class RocmAiterUnifiedAttentionImpl(RocmAttentionImpl):
 
         self.unified_attention = unified_attention
         self.supports_quant_query_input = True
+        self.separate_kv_head_groups = _use_separate_kv_head_groups()
 
     def _split_kv_cache(
         self, kv_cache: torch.Tensor
     ) -> tuple[torch.Tensor, torch.Tensor]:
+        if self.separate_kv_head_groups:
+            # (B, 2, N, H*hs) -> ((B, N, H, hs), (B, N, H, hs)), each side
+            # contiguous within a block as the AITER fused kernel requires.
+            key_cache, value_cache = kv_cache.unbind(1)
+            shape = (*key_cache.shape[:-1], self.num_kv_heads, self.head_size)
+            return key_cache.view(shape), value_cache.view(shape)
         # (B, H, N, 2*hs) -> ((B, N, H, hs), (B, N, H, hs))
         return kv_cache.transpose(1, 2).split(self.head_size, dim=-1)
 
@@ -172,8 +192,10 @@ class RocmAiterUnifiedAttentionImpl(RocmAttentionImpl):
             query: shape = [num_tokens, num_heads, head_size]
             key: shape = [num_tokens, num_kv_heads, head_size]
             value: shape = [num_tokens, num_kv_heads, head_size]
-            kv_cache: shape =
-                [num_blocks, 2, block_size, num_kv_heads, head_size]
+            kv_cache: shape = see get_kv_cache_shape; either the separate
+                split layout [num_blocks, 2, block_size,
+                num_kv_heads * head_size] or the packed content layout
+                [num_blocks, num_kv_heads, block_size, 2 * head_size]
             attn_metadata: Metadata for attention.
         Returns:
             shape = [num_tokens, num_heads * head_size]
@@ -312,7 +334,9 @@ class RocmAiterUnifiedAttentionImpl(RocmAttentionImpl):
         return rocm_aiter_ops.is_enabled()
 
     def fused_qk_norm_rope_kvcache_supported(self):
-        return rocm_aiter_ops.is_enabled()
+        # The fused kernel requires each side to be contiguous within a block,
+        # which only the split layout provides.
+        return self.separate_kv_head_groups
 
     def do_qk_norm_rope_kvcache_update(
         self,


### PR DESCRIPTION
## Purpose

The AITER fused QK-norm+RoPE+cache kernel addresses each side as
`block_id * stride(0) + token * (H*hs) + head * hs` and hard-asserts that each side is
contiguous *within a block*. Both AITER attention backends allocate a **packed** content
dim, `(num_blocks, num_kv_heads, block_size, 2*head_size)`. Splitting that
(`transpose(1, 2).split(head_size, -1)`) leaves the head dim strided by the whole block, so
the assert fires and **aborts the process**:

```
[AITER] .../csrc/kernels/fused_qk_norm_rope_cache_quant.cu:2952
        k_cache/v_cache must be contiguous within a block (dims >= 1)
Fatal Python error: Aborted
```

Before this PR, *every* case in `test_rocm_aiter_qk_norm_rope_kvcache_fusion.py` dies this
way (SIGABRT, exit 134) — for both `ROCM_AITER_FA` and `ROCM_AITER_UNIFIED_ATTN`. Reduced
to the two layouts, with `num_kv_heads=2, head_size=128, block_size=16`:

| layout | k/v side stride | kernel |
|---|---|---|
| packed split | `(8192, 256, **4096**, 1)` — head stride ≠ `hs` | **abort** |
| separate head groups | `(8192, 256, **128**, 1)` | accepted |

## Fix

Allocate K and V as separate head groups — `(num_blocks, 2, block_size,
num_kv_heads*head_size)` — so each side is one contiguous token-major region per block,
exactly the kernel's contract.

- The **shuffle** layout keeps the packed content dim: it has its own x-packed interior and
  a dedicated write path, and already gates this fusion off.
- `fused_qk_norm_rope_kvcache_supported()` now returns the allocation flag rather than
  re-deriving the predicate, so the gate cannot drift from the layout it depends on.
- `RocmAttentionBackend`'s shape is untouched — `ROCM_AITER_UNIFIED_ATTN` overrides
  `get_kv_cache_shape` itself, so ROCM_ATTN's prefix-prefill layout is unaffected.

### KV-offloading connector

`canonical_mapping.py` identifies layouts by sniffing the cache shape. At
`num_kv_heads == 2` the new shape **and its strides** are byte-identical to the packed form,
so the layout is unknowable from the tensor alone. This fails closed there (opaque
whole-page fallback) instead of emitting a wrong mapping, and maps it properly when the
shape is unambiguous. `slice_for_tp_transfer` in the KV-layout RFC will carry layout
identity and remove the guess.

## Test Plan / Result

All on MI300X (gfx942), `amd-aiter` 0.1.16.post2.

| Suite | Before | After |
|---|---|---|
| `tests/compile/passes/test_rocm_aiter_qk_norm_rope_kvcache_fusion.py` | **SIGABRT on case 1** | **1440 passed**, 1440 skipped |
| `tests/v1/attention/test_rocm_aiter_kv_geometry.py` (new) | — | 4 passed |
| `tests/v1/kv_connector/unit/offloading_connector/` | 244 passed | 244 passed (+2 new) |
| `tests/v1/worker/test_kv_block_zeroer.py`, `test_kv_head_stride_canonicalization.py` | 15 passed | 15 passed |

The fusion test already asserts `fusion_pass.matched_count == 1` and compares fused vs
unfused q/k/v **and** the KV cache, so these 1440 cases verify the fused kernel both runs
and is numerically correct on the new layout.

E2e (Qwen3-0.6B, greedy + long multi-block prompts): `ROCM_AITER_FA`,
`ROCM_AITER_UNIFIED_ATTN`, `--kv-cache-dtype fp8`, and AITER-off all produce coherent
output. Since the fusion pattern does not match Qwen3, these exercise the **unfused**
`reshape_and_cache` write path against the new layout.

### Model evaluation — GSM8K, 5-shot, full 1319 questions

Both arms `VLLM_ROCM_USE_AITER=1`, `--attention-backend ROCM_AITER_FA`; baseline is a
detached worktree at `640a09086d`, so this isolates the layout.

| | flexible-extract | strict-match |
|---|---|---|
| packed (base) | 0.3844 ± 0.0134 | 0.3950 ± 0.0135 |
| separate head groups (this PR) | 0.3844 ± 0.0134 | 0.3950 ± 0.0135 |

Identical, as expected for a pure data-placement change under greedy decoding.

### Throughput

`bench throughput`, in256/out512, 64 prompts, 3 alternating reps on one GPU:
separate head groups **8553 ± 129** vs packed **8620 ± 37** output tok/s — a 0.8% mean gap,
smaller than the run-to-run spread. Neutral.

## Notes

- **Not a duplicate.** Searched open PRs for `aiter qk_norm rope kvcache fusion`,
  `get_kv_cache_shape aiter`, `rocm_aiter_fa`. The nearest are #41222 (enables shuffled
  rope + KV-cache fusion — the *shuffle* path, which this PR deliberately leaves packed),
  #45144 (MTP + fp8 + shuffle-KV config) and #46597 (backend *priority*). None touch the
  contiguity contract or the non-shuffle allocation.
- **Pre-existing bug found, not fixed here:** with
  `VLLM_ROCM_SHUFFLE_KV_CACHE_LAYOUT=1` the AITER FA path emits garbage tokens. Verified on
  `640a09086d` with these changes stashed, so it is independent of this PR and left alone.
- **AI assistance was used** for this change (investigation, implementation, and the test
  runs above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
