### PR TITLE
[Bugfix] Fix DeepSeek V4/3.2 tokenizer vocab size overcount crashing guided decoding

### DIFF
--- a/tests/tokenizers_/test_deepseek_v4.py
+++ b/tests/tokenizers_/test_deepseek_v4.py
@@ -6,14 +6,10 @@ from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
-from tokenizers import AddedToken, Tokenizer
-from tokenizers.models import WordLevel
-from transformers import TokenizersBackend
 
 from vllm.entrypoints.chat_utils import parse_chat_messages
 from vllm.renderers.registry import RENDERER_REGISTRY
 from vllm.tokenizers.deepseek_v4 import get_deepseek_v4_tokenizer
-from vllm.tokenizers.deepseek_v32 import get_deepseek_v32_tokenizer
 from vllm.tokenizers.registry import TokenizerRegistry
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures" / "deepseek_v4"

--- a/tests/tokenizers_/test_deepseek_v4.py
+++ b/tests/tokenizers_/test_deepseek_v4.py
@@ -6,10 +6,14 @@ from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
+from tokenizers import AddedToken, Tokenizer
+from tokenizers.models import WordLevel
+from transformers import TokenizersBackend
 
 from vllm.entrypoints.chat_utils import parse_chat_messages
 from vllm.renderers.registry import RENDERER_REGISTRY
 from vllm.tokenizers.deepseek_v4 import get_deepseek_v4_tokenizer
+from vllm.tokenizers.deepseek_v32 import get_deepseek_v32_tokenizer
 from vllm.tokenizers.registry import TokenizerRegistry
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures" / "deepseek_v4"
@@ -74,6 +78,23 @@ def test_deepseek_v4_tokenizer_registered():
     assert RENDERER_REGISTRY.load_renderer_cls("deepseek_v4").__name__ == (
         "DeepseekV4Renderer"
     )
+
+
+@pytest.mark.parametrize(
+    "wrapper", [get_deepseek_v32_tokenizer, get_deepseek_v4_tokenizer]
+)
+def test_deepseek_tokenizer_preserves_vocab_size(wrapper):
+    backend = Tokenizer(
+        WordLevel({"<bos>": 0, "token": 1, "<unk>": 2}, unk_token="<unk>")
+    )
+    backend.add_special_tokens([AddedToken("<bos>", special=True)])
+    backend.add_tokens(["added"])
+    tokenizer = TokenizersBackend(tokenizer_object=backend)
+
+    wrapped = wrapper(tokenizer)
+
+    assert tokenizer.get_added_vocab() == {"<bos>": 0, "added": 3}
+    assert len(wrapped) == len(tokenizer) == 4
 
 
 def test_deepseek_v4_defaults_to_thinking_with_high_effort():

--- a/tests/tokenizers_/test_deepseek_v4.py
+++ b/tests/tokenizers_/test_deepseek_v4.py
@@ -80,23 +80,6 @@ def test_deepseek_v4_tokenizer_registered():
     )
 
 
-@pytest.mark.parametrize(
-    "wrapper", [get_deepseek_v32_tokenizer, get_deepseek_v4_tokenizer]
-)
-def test_deepseek_tokenizer_preserves_vocab_size(wrapper):
-    backend = Tokenizer(
-        WordLevel({"<bos>": 0, "token": 1, "<unk>": 2}, unk_token="<unk>")
-    )
-    backend.add_special_tokens([AddedToken("<bos>", special=True)])
-    backend.add_tokens(["added"])
-    tokenizer = TokenizersBackend(tokenizer_object=backend)
-
-    wrapped = wrapper(tokenizer)
-
-    assert tokenizer.get_added_vocab() == {"<bos>": 0, "added": 3}
-    assert len(wrapped) == len(tokenizer) == 4
-
-
 def test_deepseek_v4_defaults_to_thinking_with_high_effort():
     prompt = _tokenizer().apply_chat_template(
         [{"role": "user", "content": "Hello"}],

--- a/vllm/tokenizers/deepseek_v32.py
+++ b/vllm/tokenizers/deepseek_v32.py
@@ -19,8 +19,6 @@ def get_deepseek_v32_tokenizer(tokenizer: HfTokenizer) -> HfTokenizer:
     dsv32_tokenizer = copy.copy(tokenizer)
 
     added_vocab = tokenizer.get_added_vocab()
-    added_vocab_size = len(added_vocab)
-    tokenizer_vocab_size = tokenizer.vocab_size
 
     class _DeepseekV32Tokenizer(tokenizer.__class__):  # type: ignore
         def apply_chat_template(
@@ -65,10 +63,6 @@ def get_deepseek_v32_tokenizer(tokenizer: HfTokenizer) -> HfTokenizer:
 
         def num_special_tokens_to_add(self) -> int:
             return len(self.encode(""))
-
-        def __len__(self) -> int:
-            # </think> is an added token in DeepseekV32 tokenizer
-            return tokenizer_vocab_size + added_vocab_size
 
         def get_added_vocab(self) -> dict[str, int]:
             return added_vocab.copy()

--- a/vllm/tokenizers/deepseek_v4.py
+++ b/vllm/tokenizers/deepseek_v4.py
@@ -19,8 +19,6 @@ def get_deepseek_v4_tokenizer(tokenizer: HfTokenizer) -> HfTokenizer:
     dsv4_tokenizer = copy.copy(tokenizer)
 
     added_vocab = tokenizer.get_added_vocab()
-    added_vocab_size = len(added_vocab)
-    tokenizer_vocab_size = tokenizer.vocab_size
 
     class _DeepseekV4Tokenizer(tokenizer.__class__):  # type: ignore
         def apply_chat_template(
@@ -77,9 +75,6 @@ def get_deepseek_v4_tokenizer(tokenizer: HfTokenizer) -> HfTokenizer:
 
         def num_special_tokens_to_add(self) -> int:
             return len(self.encode(""))
-
-        def __len__(self) -> int:
-            return tokenizer_vocab_size + added_vocab_size
 
         def get_added_vocab(self) -> dict[str, int]:
             return added_vocab.copy()


### PR DESCRIPTION
## Purpose
Fixes #50924 #51467.

### Root cause
DeepseekV4Tokenizer.__len__ overcounts the vocabulary.
vllm/tokenizers/deepseek_v4.py:81-82 returns tokenizer.vocab_size + len(get_added_vocab()). For DeepSeek-V4-Flash-0731 that's 128000 + 1283 = 129283 — but 3 of those 1283 added tokens have ids below 128000 (they're already in the base vocab), so the true token count is 129280, exactly config.vocab_size. The override double-counts. (vllm/tokenizers/deepseek_v32.py:69 has the same stale pattern; it dates from when len() on an HF fast tokenizer didn't include added tokens — with transformers 5.x TokenizersBackend it does, so the override is now both redundant and wrong.)

## Test Plan
Repro steps from #50924:
```
vllm serve deepseek-ai/DeepSeek-V4-Flash-0731 \
  --tensor-parallel-size 4 \
  --gpu-memory-utilization 0.9 \
  --kv-cache-dtype fp8 \
  --max-num-seqs 64 \
  --reasoning-parser deepseek_v4 \
  --speculative-config.method dspark \
  --speculative-config.num_speculative_tokens 7 \
  --speculative-config.draft_sample_method greedy \
  --structured-outputs-config.backend guidance
```

