### PR TITLE
[BugFix]Reap orphaned CPU offload /dev/shm region files left by instances tha…

### DIFF
--- a/tests/v1/kv_offload/cpu/test_shared_offload_region.py
+++ b/tests/v1/kv_offload/cpu/test_shared_offload_region.py
@@ -563,6 +563,9 @@ def test_madvise_unexpected_oserror_propagates(iid, monkeypatch):
     with pytest.raises(OSError) as exc_info:
         _make_region(iid)
     assert exc_info.value.errno == errno.EIO
+    assert not os.path.exists(f"/dev/shm/vllm_offload_{iid}.mmap"), (
+        "a creator that fails partway through construction must not leak its file"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -790,6 +793,7 @@ def test_insufficient_space_raises_clear_error(monkeypatch):
     monkeypatch.setattr(region.os, "open", mock_open)
     monkeypatch.setattr(region.os, "unlink", mock_unlink)
     monkeypatch.setattr(region.os, "close", mock_close)
+    monkeypatch.setattr(region.fcntl, "flock", MagicMock())
     monkeypatch.setattr(
         region,
         "check_shm_free_space",
@@ -822,6 +826,7 @@ def test_ftruncate_failure_cleans_up_creator(monkeypatch):
     monkeypatch.setattr(region.os, "open", MagicMock(return_value=9999))
     monkeypatch.setattr(region.os, "unlink", mock_unlink)
     monkeypatch.setattr(region.os, "close", mock_close)
+    monkeypatch.setattr(region.fcntl, "flock", MagicMock())
     monkeypatch.setattr(region, "check_shm_free_space", MagicMock())
     monkeypatch.setattr(
         region.os,
@@ -840,3 +845,121 @@ def test_ftruncate_failure_cleans_up_creator(monkeypatch):
 
     mock_unlink.assert_called_once_with(mmap_path)
     mock_close.assert_called_once_with(9999)
+
+
+def _make_bare_orphan(age_s: float) -> str:
+    """Create a lone region file with no lock holder and a chosen mtime."""
+    path = f"/dev/shm/vllm_offload_{uuid.uuid4()}.mmap"
+    fd = os.open(path, os.O_CREAT | os.O_RDWR, 0o600)
+    os.close(fd)
+    stamp = time.time() - age_s
+    os.utime(path, (stamp, stamp))
+    return path
+
+
+def _child_create_and_exit_gracefully(engine_id: str) -> None:
+    """Create a creator region and return normally: atexit must remove the file."""
+    SharedOffloadRegion(
+        engine_id=engine_id,
+        num_blocks=2,
+        rank=0,
+        kv_bytes_per_block=PAGE_SIZE,
+        cpu_page_size=PAGE_SIZE,
+    )
+
+
+def _child_create_and_hold(engine_id: str, ready_queue) -> None:
+    """Create a creator region, signal readiness, then block holding its lock."""
+    SharedOffloadRegion(
+        engine_id=engine_id,
+        num_blocks=2,
+        rank=0,
+        kv_bytes_per_block=PAGE_SIZE,
+        cpu_page_size=PAGE_SIZE,
+    )
+    ready_queue.put(True)
+    time.sleep(60)
+
+
+def test_old_orphan_reaped_by_new_creator(iid):
+    """A stale region file with no live holder is reaped when a creator starts."""
+    orphan = _make_bare_orphan(age_s=10_000)
+    try:
+        with _region(iid):
+            assert not os.path.exists(orphan), "old unlocked orphan must be reaped"
+    finally:
+        _cleanup_file(orphan)
+
+
+def test_recent_orphan_within_grace_not_reaped(iid):
+    """A file too young to be sure it is stale must survive the sweep."""
+    orphan = _make_bare_orphan(age_s=0.0)
+    try:
+        with _region(iid):
+            assert os.path.exists(orphan), "young file must be left within grace"
+    finally:
+        _cleanup_file(orphan)
+
+
+def test_reaper_does_not_follow_symlink(iid, tmp_path):
+    """A symlink planted in world-writable /dev/shm must not be followed or reaped."""
+    target = tmp_path / "victim"
+    target.write_bytes(b"secret")
+    link = f"/dev/shm/vllm_offload_{uuid.uuid4()}.mmap"
+    os.symlink(target, link)
+    stamp = time.time() - 10_000
+    os.utime(link, (stamp, stamp), follow_symlinks=False)
+    try:
+        with _region(iid):
+            pass
+        assert os.path.islink(link), "symlink must not be reaped"
+        assert target.exists(), "symlink target must be untouched"
+    finally:
+        with contextlib.suppress(FileNotFoundError):
+            os.unlink(link)
+
+
+def test_live_region_not_reaped(iid):
+    """A live region holding a shared lock is never reaped, even if it looks old."""
+    with _region(iid) as live:
+        stamp = time.time() - 10_000
+        os.utime(live.mmap_path, (stamp, stamp))
+        with _region(str(uuid.uuid4())):
+            pass
+        assert os.path.exists(live.mmap_path), "locked live region must survive"
+
+
+def test_graceful_exit_removes_file_via_atexit(iid):
+    """A process that exits normally without cleanup() still removes its file."""
+    ctx = get_mp_context()
+    p = ctx.Process(target=_child_create_and_exit_gracefully, args=(iid,))
+    p.start()
+    p.join(timeout=30)
+    assert p.exitcode == 0
+    assert not os.path.exists(f"/dev/shm/vllm_offload_{iid}.mmap")
+
+
+def test_sigkilled_region_leaks_then_reaped(iid):
+    """SIGKILL cannot clean up, but the next creator reaps the leftover."""
+    path = f"/dev/shm/vllm_offload_{iid}.mmap"
+    ctx = get_mp_context()
+    ready = ctx.Queue()
+    p = ctx.Process(target=_child_create_and_hold, args=(iid, ready))
+    p.start()
+    try:
+        ready.get(timeout=30)
+        assert os.path.exists(path)
+        p.kill()
+        p.join(timeout=10)
+        assert os.path.exists(path), "SIGKILL is expected to leak the file"
+
+        stamp = time.time() - 10_000
+        os.utime(path, (stamp, stamp))
+        with _region(str(uuid.uuid4())):
+            pass
+        assert not os.path.exists(path), "leftover must be reaped by next creator"
+    finally:
+        if p.is_alive():
+            p.kill()
+            p.join(timeout=10)
+        _cleanup_file(path)

--- a/vllm/v1/kv_offload/cpu/shared_offload_region.py
+++ b/vllm/v1/kv_offload/cpu/shared_offload_region.py
@@ -1,6 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import atexit
+import contextlib
 import errno
+import fcntl
+import glob
 import mmap
 import os
 import time
@@ -19,6 +23,9 @@ logger = init_logger(__name__)
 
 # MADV_POPULATE_WRITE was added in Linux 5.14 (value 23).
 _MADV_POPULATE_WRITE = getattr(mmap, "MADV_POPULATE_WRITE", 23)
+
+_REGION_GLOB = "/dev/shm/vllm_offload_*.mmap"
+_ORPHAN_GRACE_S = 30.0
 
 
 def _wait_for_file_size(fd: int, expected_size: int, timeout: float = 30.0) -> None:
@@ -61,6 +68,31 @@ def _get_populate_write_fn(
         )
         return _fallback_populate_write
     return _madvise_populate_write
+
+
+def _reap_orphan_regions() -> None:
+    now = time.time()
+    for path in glob.glob(_REGION_GLOB):
+        try:
+            if now - os.lstat(path).st_mtime < _ORPHAN_GRACE_S:
+                continue
+            fd = os.open(path, os.O_RDWR | os.O_NOFOLLOW)
+        except OSError:
+            continue
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError:
+            os.close(fd)
+            continue
+        try:
+            os.unlink(path)
+            logger.warning(
+                "Reaped orphaned offload mmap file %s (no live holder)", path
+            )
+        except FileNotFoundError:
+            pass  # a concurrent creator already reclaimed it
+        finally:
+            os.close(fd)
 
 
 class SharedOffloadRegion:
@@ -107,6 +139,7 @@ class SharedOffloadRegion:
             # Joiner path — another worker won O_EXCL. Reopen and wait
             # for the file to reach expected size.
             self.fd = os.open(self.mmap_path, os.O_RDWR)
+            fcntl.flock(self.fd, fcntl.LOCK_SH)
             try:
                 _wait_for_file_size(self.fd, self.total_size_bytes)
             except (TimeoutError, OSError):
@@ -118,6 +151,7 @@ class SharedOffloadRegion:
             # failure here must clean up so concurrent joiners don't
             # land on a 0-byte stub and spin in _wait_for_file_size
             # for the full 30 s timeout.
+            fcntl.flock(self.fd, fcntl.LOCK_SH)
             try:
                 check_shm_free_space(self.total_size_bytes)
                 os.ftruncate(self.fd, self.total_size_bytes)
@@ -126,49 +160,76 @@ class SharedOffloadRegion:
                 os.close(self.fd)
                 raise
             self._creator = True
+            _reap_orphan_regions()
             logger.info(
                 "Created mmap file %s (%.2f GB)",
                 self.mmap_path,
                 self.total_size_bytes / 1e9,
             )
 
-        self.mmap_obj: mmap.mmap | None = mmap.mmap(
-            self.fd,
-            self.total_size_bytes,
-            flags=mmap.MAP_SHARED,
-            prot=mmap.PROT_READ | mmap.PROT_WRITE,
-        )
-
-        populate_write_fn = _get_populate_write_fn(self.mmap_obj)
-
-        if rank is not None:
-            # Populate only this worker's pages (one slot per block row).
-            worker_offset = rank * cpu_page_size
-            _t0 = time.perf_counter()
-            page_size = self.page_size
-            for block in range(num_blocks):
-                raw_offset = block * self._row_stride + worker_offset
-                aligned_offset = (raw_offset // page_size) * page_size
-                end = raw_offset + cpu_page_size
-                aligned_length = end - aligned_offset
-                populate_write_fn(self.mmap_obj, aligned_offset, aligned_length)
-            logger.debug(
-                "MADV_POPULATE_WRITE loop: %d blocks in %.3f s",
-                num_blocks,
-                time.perf_counter() - _t0,
-            )
-        else:
-            # No rank — populate the entire shared region in one call.
-            _t0 = time.perf_counter()
-            populate_write_fn(self.mmap_obj, 0, self.total_size_bytes)
-            logger.debug(
-                "MADV_POPULATE_WRITE entire region: %.3f s", time.perf_counter() - _t0
+        try:
+            self.mmap_obj: mmap.mmap | None = mmap.mmap(
+                self.fd,
+                self.total_size_bytes,
+                flags=mmap.MAP_SHARED,
+                prot=mmap.PROT_READ | mmap.PROT_WRITE,
             )
 
-        self._base = torch.frombuffer(memoryview(self.mmap_obj), dtype=torch.int8)
-        self._views: list[torch.Tensor] = []
-        self._canonical_offset = 0
-        self.is_pinned: bool = False
+            populate_write_fn = _get_populate_write_fn(self.mmap_obj)
+
+            if rank is not None:
+                # Populate only this worker's pages (one slot per block row).
+                worker_offset = rank * cpu_page_size
+                _t0 = time.perf_counter()
+                page_size = self.page_size
+                for block in range(num_blocks):
+                    raw_offset = block * self._row_stride + worker_offset
+                    aligned_offset = (raw_offset // page_size) * page_size
+                    end = raw_offset + cpu_page_size
+                    aligned_length = end - aligned_offset
+                    populate_write_fn(self.mmap_obj, aligned_offset, aligned_length)
+                logger.debug(
+                    "MADV_POPULATE_WRITE loop: %d blocks in %.3f s",
+                    num_blocks,
+                    time.perf_counter() - _t0,
+                )
+            else:
+                # No rank — populate the entire shared region in one call.
+                _t0 = time.perf_counter()
+                populate_write_fn(self.mmap_obj, 0, self.total_size_bytes)
+                logger.debug(
+                    "MADV_POPULATE_WRITE entire region: %.3f s",
+                    time.perf_counter() - _t0,
+                )
+
+            self._base = torch.frombuffer(memoryview(self.mmap_obj), dtype=torch.int8)
+            self._views: list[torch.Tensor] = []
+            self._canonical_offset = 0
+            self.is_pinned: bool = False
+        except BaseException:
+            self._abort_construction()
+            raise
+
+        if self._creator:
+            atexit.register(self.cleanup)
+
+    def _abort_construction(self) -> None:
+        if getattr(self, "_views", None):
+            self._views.clear()
+        self._base = None
+        obj = getattr(self, "mmap_obj", None)
+        if obj is not None:
+            with contextlib.suppress(Exception):
+                obj.close()
+            self.mmap_obj = None
+        if self.fd is not None:
+            with contextlib.suppress(Exception):
+                os.close(self.fd)
+            self.fd = None
+        if self._creator:
+            with contextlib.suppress(Exception):
+                os.unlink(self.mmap_path)
+            self._creator = False
 
     def create_next_worker_view(self, tensor_page_size: int) -> torch.Tensor:
         """Allocate a strided int8 view for this worker, one canonical tensor.
@@ -307,3 +368,4 @@ class SharedOffloadRegion:
                     "Failed to unlink path %s", self.mmap_path, exc_info=True
                 )
             self._creator = False
+        atexit.unregister(self.cleanup)


### PR DESCRIPTION



## Purpose
Fixes #51579: the CPU offload tier's `/dev/shm/vllm_offload_*.mmap` file was only removed via `AsyncLLM.__del__`, so any unclean exit (SIGKILL, crash) leaked it. Every worker now holds a shared `flock` for the region's lifetime, and a creator reaps any leftover file with no live lock holder on startup (plus `atexit` cleanup on graceful exit).
## Test Plan
Added unit tests in `tests/v1/kv_offload/cpu/test_shared_offload_region.py` covering orphan reaping, live regions being protected from reaping, atexit cleanup, and SIGKILL-then-reap. Run: `pytest tests/v1/kv_offload/cpu/test_shared_offload_region.py`.
## Test Result
All 40 tests pass, and `/dev/shm` is left with zero region files after the run. `ruff check` and `ruff format --check` both pass on the changed files.
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

