### PR TITLE
[CI] Parallelize release image publishing

### DIFF
--- a/.buildkite/release-pipeline.yaml
+++ b/.buildkite/release-pipeline.yaml
@@ -959,14 +959,21 @@ steps:
       - step: build-cpu-release-image-arm64
         allow_failure: true
 
-  - label: "Publish release images to DockerHub"
+  - label: "Publish {{matrix}} release images to DockerHub"
     depends_on:
       - block-publish-release-images
     key: publish-release-images-dockerhub
     agents:
       queue: small_cpu_queue_release
     commands:
-      - "bash .buildkite/scripts/publish-release-images.sh"
+      - "bash .buildkite/scripts/publish-release-images.sh {{matrix}}"
+    matrix:
+      - "cuda-13-0"
+      - "cuda-12-9"
+      - "ubuntu-24-04"
+      - "rocm"
+      - "xpu"
+      - "cpu"
     plugins:
       - docker-login#v3.0.0:
           username: vllmbot

--- a/.buildkite/release-pipeline.yaml
+++ b/.buildkite/release-pipeline.yaml
@@ -970,7 +970,8 @@ steps:
     matrix:
       - "cuda-13-0"
       - "cuda-12-9"
-      - "ubuntu-24-04"
+      - "cuda-13-0-ubuntu-24-04"
+      - "cuda-12-9-ubuntu-24-04"
       - "rocm"
       - "xpu"
       - "cpu"

--- a/.buildkite/scripts/publish-release-images.sh
+++ b/.buildkite/scripts/publish-release-images.sh
@@ -10,9 +10,10 @@ set -euo pipefail
 
 TARGET="${1:-all}"
 case "${TARGET}" in
-  cuda-13-0 | cuda-12-9 | ubuntu-24-04 | rocm | xpu | cpu | all) ;;
+  cuda-13-0 | cuda-12-9 | cuda-13-0-ubuntu-24-04 | \
+    cuda-12-9-ubuntu-24-04 | rocm | xpu | cpu | all) ;;
   *)
-    echo "Usage: $0 {cuda-13-0|cuda-12-9|ubuntu-24-04|rocm|xpu|cpu|all}"
+    echo "Usage: $0 {cuda-13-0|cuda-12-9|cuda-13-0-ubuntu-24-04|cuda-12-9-ubuntu-24-04|rocm|xpu|cpu|all}"
     exit 2
     ;;
 esac
@@ -88,7 +89,7 @@ fi
 
 # ---- Ubuntu 24.04 (CUDA 13.0) ----
 
-if target_enabled ubuntu-24-04; then
+if target_enabled cuda-13-0-ubuntu-24-04; then
   docker pull public.ecr.aws/q9t5s3a7/vllm-release-repo:${COMMIT}-x86_64-ubuntu2404
   docker pull public.ecr.aws/q9t5s3a7/vllm-release-repo:${COMMIT}-aarch64-ubuntu2404
 
@@ -108,9 +109,11 @@ if target_enabled ubuntu-24-04; then
   docker manifest create vllm/vllm-openai:v${RELEASE_VERSION}-ubuntu2404 vllm/vllm-openai:v${RELEASE_VERSION}-x86_64-ubuntu2404 vllm/vllm-openai:v${RELEASE_VERSION}-aarch64-ubuntu2404
   docker manifest push vllm/vllm-openai:latest-ubuntu2404
   docker manifest push vllm/vllm-openai:v${RELEASE_VERSION}-ubuntu2404
+fi
 
-  # ---- Ubuntu 24.04 (CUDA 12.9) ----
+# ---- Ubuntu 24.04 (CUDA 12.9) ----
 
+if target_enabled cuda-12-9-ubuntu-24-04; then
   docker pull public.ecr.aws/q9t5s3a7/vllm-release-repo:${COMMIT}-x86_64-cu129-ubuntu2404
   docker pull public.ecr.aws/q9t5s3a7/vllm-release-repo:${COMMIT}-aarch64-cu129-ubuntu2404
 

--- a/.buildkite/scripts/publish-release-images.sh
+++ b/.buildkite/scripts/publish-release-images.sh
@@ -2,11 +2,24 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 #
-# Publish release Docker images from ECR to DockerHub.
+# Publish a release Docker image family from ECR to DockerHub.
 # Pulls per-arch images, tags with latest and versioned tags, pushes them,
 # then creates and pushes multi-arch manifests.
 
 set -euo pipefail
+
+TARGET="${1:-all}"
+case "${TARGET}" in
+  cuda-13-0 | cuda-12-9 | ubuntu-24-04 | rocm | xpu | cpu | all) ;;
+  *)
+    echo "Usage: $0 {cuda-13-0|cuda-12-9|ubuntu-24-04|rocm|xpu|cpu|all}"
+    exit 2
+    ;;
+esac
+
+target_enabled() {
+  [ "${TARGET}" = "all" ] || [ "${TARGET}" = "$1" ]
+}
 
 RELEASE_VERSION=$(buildkite-agent meta-data get release-version --default "" | sed 's/^v//')
 if [ -z "${RELEASE_VERSION}" ]; then
@@ -15,12 +28,10 @@ if [ -z "${RELEASE_VERSION}" ]; then
 fi
 
 COMMIT="$BUILDKITE_COMMIT"
-ROCM_BASE_CACHE_KEY=$(.buildkite/scripts/cache-rocm-base-wheels.sh key)
 
 echo "========================================"
-echo "Publishing release images v${RELEASE_VERSION}"
+echo "Publishing ${TARGET} release images v${RELEASE_VERSION}"
 echo "  Commit: ${COMMIT}"
-echo "  ROCm base cache key: ${ROCM_BASE_CACHE_KEY}"
 echo "========================================"
 
 # Login to ECR to pull staging images
@@ -29,122 +40,135 @@ aws ecr-public get-login-password --region us-east-1 | \
 
 # ---- CUDA (default: 13.0) ----
 
-docker pull public.ecr.aws/q9t5s3a7/vllm-release-repo:${COMMIT}-x86_64
-docker pull public.ecr.aws/q9t5s3a7/vllm-release-repo:${COMMIT}-aarch64
+if target_enabled cuda-13-0; then
+  docker pull public.ecr.aws/q9t5s3a7/vllm-release-repo:${COMMIT}-x86_64
+  docker pull public.ecr.aws/q9t5s3a7/vllm-release-repo:${COMMIT}-aarch64
 
-docker tag public.ecr.aws/q9t5s3a7/vllm-release-repo:${COMMIT}-x86_64 vllm/vllm-openai:latest-x86_64
-docker tag public.ecr.aws/q9t5s3a7/vllm-release-repo:${COMMIT}-x86_64 vllm/vllm-openai:v${RELEASE_VERSION}-x86_64
-docker push vllm/vllm-openai:latest-x86_64
-docker push vllm/vllm-openai:v${RELEASE_VERSION}-x86_64
+  docker tag public.ecr.aws/q9t5s3a7/vllm-release-repo:${COMMIT}-x86_64 vllm/vllm-openai:latest-x86_64
+  docker tag public.ecr.aws/q9t5s3a7/vllm-release-repo:${COMMIT}-x86_64 vllm/vllm-openai:v${RELEASE_VERSION}-x86_64
+  docker push vllm/vllm-openai:latest-x86_64
+  docker push vllm/vllm-openai:v${RELEASE_VERSION}-x86_64
 
-docker tag public.ecr.aws/q9t5s3a7/vllm-release-repo:${COMMIT}-aarch64 vllm/vllm-openai:latest-aarch64
-docker tag public.ecr.aws/q9t5s3a7/vllm-release-repo:${COMMIT}-aarch64 vllm/vllm-openai:v${RELEASE_VERSION}-aarch64
-docker push vllm/vllm-openai:latest-aarch64
-docker push vllm/vllm-openai:v${RELEASE_VERSION}-aarch64
+  docker tag public.ecr.aws/q9t5s3a7/vllm-release-repo:${COMMIT}-aarch64 vllm/vllm-openai:latest-aarch64
+  docker tag public.ecr.aws/q9t5s3a7/vllm-release-repo:${COMMIT}-aarch64 vllm/vllm-openai:v${RELEASE_VERSION}-aarch64
+  docker push vllm/vllm-openai:latest-aarch64
+  docker push vllm/vllm-openai:v${RELEASE_VERSION}-aarch64
 
-docker manifest rm vllm/vllm-openai:latest || true
-docker manifest rm vllm/vllm-openai:v${RELEASE_VERSION} || true
-docker manifest create vllm/vllm-openai:latest vllm/vllm-openai:latest-x86_64 vllm/vllm-openai:latest-aarch64
-docker manifest create vllm/vllm-openai:v${RELEASE_VERSION} vllm/vllm-openai:v${RELEASE_VERSION}-x86_64 vllm/vllm-openai:v${RELEASE_VERSION}-aarch64
-docker manifest push vllm/vllm-openai:latest
-docker manifest push vllm/vllm-openai:v${RELEASE_VERSION}
+  docker manifest rm vllm/vllm-openai:latest || true
+  docker manifest rm vllm/vllm-openai:v${RELEASE_VERSION} || true
+  docker manifest create vllm/vllm-openai:latest vllm/vllm-openai:latest-x86_64 vllm/vllm-openai:latest-aarch64
+  docker manifest create vllm/vllm-openai:v${RELEASE_VERSION} vllm/vllm-openai:v${RELEASE_VERSION}-x86_64 vllm/vllm-openai:v${RELEASE_VERSION}-aarch64
+  docker manifest push vllm/vllm-openai:latest
+  docker manifest push vllm/vllm-openai:v${RELEASE_VERSION}
+fi
 
 # ---- CUDA 12.9 ----
 
-docker pull public.ecr.aws/q9t5s3a7/vllm-release-repo:${COMMIT}-x86_64-cu129
-docker pull public.ecr.aws/q9t5s3a7/vllm-release-repo:${COMMIT}-aarch64-cu129
+if target_enabled cuda-12-9; then
+  docker pull public.ecr.aws/q9t5s3a7/vllm-release-repo:${COMMIT}-x86_64-cu129
+  docker pull public.ecr.aws/q9t5s3a7/vllm-release-repo:${COMMIT}-aarch64-cu129
 
-docker tag public.ecr.aws/q9t5s3a7/vllm-release-repo:${COMMIT}-x86_64-cu129 vllm/vllm-openai:latest-x86_64-cu129
-docker tag public.ecr.aws/q9t5s3a7/vllm-release-repo:${COMMIT}-x86_64-cu129 vllm/vllm-openai:v${RELEASE_VERSION}-x86_64-cu129
-docker push vllm/vllm-openai:latest-x86_64-cu129
-docker push vllm/vllm-openai:v${RELEASE_VERSION}-x86_64-cu129
+  docker tag public.ecr.aws/q9t5s3a7/vllm-release-repo:${COMMIT}-x86_64-cu129 vllm/vllm-openai:latest-x86_64-cu129
+  docker tag public.ecr.aws/q9t5s3a7/vllm-release-repo:${COMMIT}-x86_64-cu129 vllm/vllm-openai:v${RELEASE_VERSION}-x86_64-cu129
+  docker push vllm/vllm-openai:latest-x86_64-cu129
+  docker push vllm/vllm-openai:v${RELEASE_VERSION}-x86_64-cu129
 
-docker tag public.ecr.aws/q9t5s3a7/vllm-release-repo:${COMMIT}-aarch64-cu129 vllm/vllm-openai:latest-aarch64-cu129
-docker tag public.ecr.aws/q9t5s3a7/vllm-release-repo:${COMMIT}-aarch64-cu129 vllm/vllm-openai:v${RELEASE_VERSION}-aarch64-cu129
-docker push vllm/vllm-openai:latest-aarch64-cu129
-docker push vllm/vllm-openai:v${RELEASE_VERSION}-aarch64-cu129
+  docker tag public.ecr.aws/q9t5s3a7/vllm-release-repo:${COMMIT}-aarch64-cu129 vllm/vllm-openai:latest-aarch64-cu129
+  docker tag public.ecr.aws/q9t5s3a7/vllm-release-repo:${COMMIT}-aarch64-cu129 vllm/vllm-openai:v${RELEASE_VERSION}-aarch64-cu129
+  docker push vllm/vllm-openai:latest-aarch64-cu129
+  docker push vllm/vllm-openai:v${RELEASE_VERSION}-aarch64-cu129
 
-docker manifest rm vllm/vllm-openai:latest-cu129 || true
-docker manifest rm vllm/vllm-openai:v${RELEASE_VERSION}-cu129 || true
-docker manifest create vllm/vllm-openai:latest-cu129 vllm/vllm-openai:latest-x86_64-cu129 vllm/vllm-openai:latest-aarch64-cu129
-docker manifest create vllm/vllm-openai:v${RELEASE_VERSION}-cu129 vllm/vllm-openai:v${RELEASE_VERSION}-x86_64-cu129 vllm/vllm-openai:v${RELEASE_VERSION}-aarch64-cu129
-docker manifest push vllm/vllm-openai:latest-cu129
-docker manifest push vllm/vllm-openai:v${RELEASE_VERSION}-cu129
+  docker manifest rm vllm/vllm-openai:latest-cu129 || true
+  docker manifest rm vllm/vllm-openai:v${RELEASE_VERSION}-cu129 || true
+  docker manifest create vllm/vllm-openai:latest-cu129 vllm/vllm-openai:latest-x86_64-cu129 vllm/vllm-openai:latest-aarch64-cu129
+  docker manifest create vllm/vllm-openai:v${RELEASE_VERSION}-cu129 vllm/vllm-openai:v${RELEASE_VERSION}-x86_64-cu129 vllm/vllm-openai:v${RELEASE_VERSION}-aarch64-cu129
+  docker manifest push vllm/vllm-openai:latest-cu129
+  docker manifest push vllm/vllm-openai:v${RELEASE_VERSION}-cu129
+fi
 
 # ---- Ubuntu 24.04 (CUDA 13.0) ----
 
-docker pull public.ecr.aws/q9t5s3a7/vllm-release-repo:${COMMIT}-x86_64-ubuntu2404
-docker pull public.ecr.aws/q9t5s3a7/vllm-release-repo:${COMMIT}-aarch64-ubuntu2404
+if target_enabled ubuntu-24-04; then
+  docker pull public.ecr.aws/q9t5s3a7/vllm-release-repo:${COMMIT}-x86_64-ubuntu2404
+  docker pull public.ecr.aws/q9t5s3a7/vllm-release-repo:${COMMIT}-aarch64-ubuntu2404
 
-docker tag public.ecr.aws/q9t5s3a7/vllm-release-repo:${COMMIT}-x86_64-ubuntu2404 vllm/vllm-openai:latest-x86_64-ubuntu2404
-docker tag public.ecr.aws/q9t5s3a7/vllm-release-repo:${COMMIT}-x86_64-ubuntu2404 vllm/vllm-openai:v${RELEASE_VERSION}-x86_64-ubuntu2404
-docker push vllm/vllm-openai:latest-x86_64-ubuntu2404
-docker push vllm/vllm-openai:v${RELEASE_VERSION}-x86_64-ubuntu2404
+  docker tag public.ecr.aws/q9t5s3a7/vllm-release-repo:${COMMIT}-x86_64-ubuntu2404 vllm/vllm-openai:latest-x86_64-ubuntu2404
+  docker tag public.ecr.aws/q9t5s3a7/vllm-release-repo:${COMMIT}-x86_64-ubuntu2404 vllm/vllm-openai:v${RELEASE_VERSION}-x86_64-ubuntu2404
+  docker push vllm/vllm-openai:latest-x86_64-ubuntu2404
+  docker push vllm/vllm-openai:v${RELEASE_VERSION}-x86_64-ubuntu2404
 
-docker tag public.ecr.aws/q9t5s3a7/vllm-release-repo:${COMMIT}-aarch64-ubuntu2404 vllm/vllm-openai:latest-aarch64-ubuntu2404
-docker tag public.ecr.aws/q9t5s3a7/vllm-release-repo:${COMMIT}-aarch64-ubuntu2404 vllm/vllm-openai:v${RELEASE_VERSION}-aarch64-ubuntu2404
-docker push vllm/vllm-openai:latest-aarch64-ubuntu2404
-docker push vllm/vllm-openai:v${RELEASE_VERSION}-aarch64-ubuntu2404
+  docker tag public.ecr.aws/q9t5s3a7/vllm-release-repo:${COMMIT}-aarch64-ubuntu2404 vllm/vllm-openai:latest-aarch64-ubuntu2404
+  docker tag public.ecr.aws/q9t5s3a7/vllm-release-repo:${COMMIT}-aarch64-ubuntu2404 vllm/vllm-openai:v${RELEASE_VERSION}-aarch64-ubuntu2404
+  docker push vllm/vllm-openai:latest-aarch64-ubuntu2404
+  docker push vllm/vllm-openai:v${RELEASE_VERSION}-aarch64-ubuntu2404
 
-docker manifest rm vllm/vllm-openai:latest-ubuntu2404 || true
-docker manifest rm vllm/vllm-openai:v${RELEASE_VERSION}-ubuntu2404 || true
-docker manifest create vllm/vllm-openai:latest-ubuntu2404 vllm/vllm-openai:latest-x86_64-ubuntu2404 vllm/vllm-openai:latest-aarch64-ubuntu2404
-docker manifest create vllm/vllm-openai:v${RELEASE_VERSION}-ubuntu2404 vllm/vllm-openai:v${RELEASE_VERSION}-x86_64-ubuntu2404 vllm/vllm-openai:v${RELEASE_VERSION}-aarch64-ubuntu2404
-docker manifest push vllm/vllm-openai:latest-ubuntu2404
-docker manifest push vllm/vllm-openai:v${RELEASE_VERSION}-ubuntu2404
+  docker manifest rm vllm/vllm-openai:latest-ubuntu2404 || true
+  docker manifest rm vllm/vllm-openai:v${RELEASE_VERSION}-ubuntu2404 || true
+  docker manifest create vllm/vllm-openai:latest-ubuntu2404 vllm/vllm-openai:latest-x86_64-ubuntu2404 vllm/vllm-openai:latest-aarch64-ubuntu2404
+  docker manifest create vllm/vllm-openai:v${RELEASE_VERSION}-ubuntu2404 vllm/vllm-openai:v${RELEASE_VERSION}-x86_64-ubuntu2404 vllm/vllm-openai:v${RELEASE_VERSION}-aarch64-ubuntu2404
+  docker manifest push vllm/vllm-openai:latest-ubuntu2404
+  docker manifest push vllm/vllm-openai:v${RELEASE_VERSION}-ubuntu2404
 
-# ---- Ubuntu 24.04 (CUDA 12.9) ----
+  # ---- Ubuntu 24.04 (CUDA 12.9) ----
 
-docker pull public.ecr.aws/q9t5s3a7/vllm-release-repo:${COMMIT}-x86_64-cu129-ubuntu2404
-docker pull public.ecr.aws/q9t5s3a7/vllm-release-repo:${COMMIT}-aarch64-cu129-ubuntu2404
+  docker pull public.ecr.aws/q9t5s3a7/vllm-release-repo:${COMMIT}-x86_64-cu129-ubuntu2404
+  docker pull public.ecr.aws/q9t5s3a7/vllm-release-repo:${COMMIT}-aarch64-cu129-ubuntu2404
 
-docker tag public.ecr.aws/q9t5s3a7/vllm-release-repo:${COMMIT}-x86_64-cu129-ubuntu2404 vllm/vllm-openai:latest-x86_64-cu129-ubuntu2404
-docker tag public.ecr.aws/q9t5s3a7/vllm-release-repo:${COMMIT}-x86_64-cu129-ubuntu2404 vllm/vllm-openai:v${RELEASE_VERSION}-x86_64-cu129-ubuntu2404
-docker push vllm/vllm-openai:latest-x86_64-cu129-ubuntu2404
-docker push vllm/vllm-openai:v${RELEASE_VERSION}-x86_64-cu129-ubuntu2404
+  docker tag public.ecr.aws/q9t5s3a7/vllm-release-repo:${COMMIT}-x86_64-cu129-ubuntu2404 vllm/vllm-openai:latest-x86_64-cu129-ubuntu2404
+  docker tag public.ecr.aws/q9t5s3a7/vllm-release-repo:${COMMIT}-x86_64-cu129-ubuntu2404 vllm/vllm-openai:v${RELEASE_VERSION}-x86_64-cu129-ubuntu2404
+  docker push vllm/vllm-openai:latest-x86_64-cu129-ubuntu2404
+  docker push vllm/vllm-openai:v${RELEASE_VERSION}-x86_64-cu129-ubuntu2404
 
-docker tag public.ecr.aws/q9t5s3a7/vllm-release-repo:${COMMIT}-aarch64-cu129-ubuntu2404 vllm/vllm-openai:latest-aarch64-cu129-ubuntu2404
-docker tag public.ecr.aws/q9t5s3a7/vllm-release-repo:${COMMIT}-aarch64-cu129-ubuntu2404 vllm/vllm-openai:v${RELEASE_VERSION}-aarch64-cu129-ubuntu2404
-docker push vllm/vllm-openai:latest-aarch64-cu129-ubuntu2404
-docker push vllm/vllm-openai:v${RELEASE_VERSION}-aarch64-cu129-ubuntu2404
+  docker tag public.ecr.aws/q9t5s3a7/vllm-release-repo:${COMMIT}-aarch64-cu129-ubuntu2404 vllm/vllm-openai:latest-aarch64-cu129-ubuntu2404
+  docker tag public.ecr.aws/q9t5s3a7/vllm-release-repo:${COMMIT}-aarch64-cu129-ubuntu2404 vllm/vllm-openai:v${RELEASE_VERSION}-aarch64-cu129-ubuntu2404
+  docker push vllm/vllm-openai:latest-aarch64-cu129-ubuntu2404
+  docker push vllm/vllm-openai:v${RELEASE_VERSION}-aarch64-cu129-ubuntu2404
 
-docker manifest rm vllm/vllm-openai:latest-cu129-ubuntu2404 || true
-docker manifest rm vllm/vllm-openai:v${RELEASE_VERSION}-cu129-ubuntu2404 || true
-docker manifest create vllm/vllm-openai:latest-cu129-ubuntu2404 vllm/vllm-openai:latest-x86_64-cu129-ubuntu2404 vllm/vllm-openai:latest-aarch64-cu129-ubuntu2404
-docker manifest create vllm/vllm-openai:v${RELEASE_VERSION}-cu129-ubuntu2404 vllm/vllm-openai:v${RELEASE_VERSION}-x86_64-cu129-ubuntu2404 vllm/vllm-openai:v${RELEASE_VERSION}-aarch64-cu129-ubuntu2404
-docker manifest push vllm/vllm-openai:latest-cu129-ubuntu2404
-docker manifest push vllm/vllm-openai:v${RELEASE_VERSION}-cu129-ubuntu2404
+  docker manifest rm vllm/vllm-openai:latest-cu129-ubuntu2404 || true
+  docker manifest rm vllm/vllm-openai:v${RELEASE_VERSION}-cu129-ubuntu2404 || true
+  docker manifest create vllm/vllm-openai:latest-cu129-ubuntu2404 vllm/vllm-openai:latest-x86_64-cu129-ubuntu2404 vllm/vllm-openai:latest-aarch64-cu129-ubuntu2404
+  docker manifest create vllm/vllm-openai:v${RELEASE_VERSION}-cu129-ubuntu2404 vllm/vllm-openai:v${RELEASE_VERSION}-x86_64-cu129-ubuntu2404 vllm/vllm-openai:v${RELEASE_VERSION}-aarch64-cu129-ubuntu2404
+  docker manifest push vllm/vllm-openai:latest-cu129-ubuntu2404
+  docker manifest push vllm/vllm-openai:v${RELEASE_VERSION}-cu129-ubuntu2404
+fi
 
 # ---- ROCm ----
 
-docker pull public.ecr.aws/q9t5s3a7/vllm-release-repo:${COMMIT}-rocm
-docker pull public.ecr.aws/q9t5s3a7/vllm-release-repo:${ROCM_BASE_CACHE_KEY}-rocm-base
+if target_enabled rocm; then
+  ROCM_BASE_CACHE_KEY=$(.buildkite/scripts/cache-rocm-base-wheels.sh key)
+  echo "ROCm base cache key: ${ROCM_BASE_CACHE_KEY}"
 
-docker tag public.ecr.aws/q9t5s3a7/vllm-release-repo:${COMMIT}-rocm vllm/vllm-openai-rocm:latest
-docker tag public.ecr.aws/q9t5s3a7/vllm-release-repo:${COMMIT}-rocm vllm/vllm-openai-rocm:v${RELEASE_VERSION}
-docker push vllm/vllm-openai-rocm:latest
-docker push vllm/vllm-openai-rocm:v${RELEASE_VERSION}
+  docker pull public.ecr.aws/q9t5s3a7/vllm-release-repo:${COMMIT}-rocm
+  docker pull public.ecr.aws/q9t5s3a7/vllm-release-repo:${ROCM_BASE_CACHE_KEY}-rocm-base
 
-docker tag public.ecr.aws/q9t5s3a7/vllm-release-repo:${ROCM_BASE_CACHE_KEY}-rocm-base vllm/vllm-openai-rocm:latest-base
-docker tag public.ecr.aws/q9t5s3a7/vllm-release-repo:${ROCM_BASE_CACHE_KEY}-rocm-base vllm/vllm-openai-rocm:v${RELEASE_VERSION}-base
-docker push vllm/vllm-openai-rocm:latest-base
-docker push vllm/vllm-openai-rocm:v${RELEASE_VERSION}-base
+  docker tag public.ecr.aws/q9t5s3a7/vllm-release-repo:${COMMIT}-rocm vllm/vllm-openai-rocm:latest
+  docker tag public.ecr.aws/q9t5s3a7/vllm-release-repo:${COMMIT}-rocm vllm/vllm-openai-rocm:v${RELEASE_VERSION}
+  docker push vllm/vllm-openai-rocm:latest
+  docker push vllm/vllm-openai-rocm:v${RELEASE_VERSION}
+
+  docker tag public.ecr.aws/q9t5s3a7/vllm-release-repo:${ROCM_BASE_CACHE_KEY}-rocm-base vllm/vllm-openai-rocm:latest-base
+  docker tag public.ecr.aws/q9t5s3a7/vllm-release-repo:${ROCM_BASE_CACHE_KEY}-rocm-base vllm/vllm-openai-rocm:v${RELEASE_VERSION}-base
+  docker push vllm/vllm-openai-rocm:latest-base
+  docker push vllm/vllm-openai-rocm:v${RELEASE_VERSION}-base
+fi
 
 # ---- XPU ----
 
-docker pull public.ecr.aws/q9t5s3a7/vllm-release-repo:${COMMIT}-x86_64-xpu
+if target_enabled xpu; then
+  docker pull public.ecr.aws/q9t5s3a7/vllm-release-repo:${COMMIT}-x86_64-xpu
 
-docker tag public.ecr.aws/q9t5s3a7/vllm-release-repo:${COMMIT}-x86_64-xpu vllm/vllm-openai-xpu:latest-x86_64
-docker tag public.ecr.aws/q9t5s3a7/vllm-release-repo:${COMMIT}-x86_64-xpu vllm/vllm-openai-xpu:v${RELEASE_VERSION}-x86_64
-docker push vllm/vllm-openai-xpu:latest-x86_64
-docker push vllm/vllm-openai-xpu:v${RELEASE_VERSION}-x86_64
+  docker tag public.ecr.aws/q9t5s3a7/vllm-release-repo:${COMMIT}-x86_64-xpu vllm/vllm-openai-xpu:latest-x86_64
+  docker tag public.ecr.aws/q9t5s3a7/vllm-release-repo:${COMMIT}-x86_64-xpu vllm/vllm-openai-xpu:v${RELEASE_VERSION}-x86_64
+  docker push vllm/vllm-openai-xpu:latest-x86_64
+  docker push vllm/vllm-openai-xpu:v${RELEASE_VERSION}-x86_64
 
-docker manifest rm vllm/vllm-openai-xpu:latest || true
-docker manifest rm vllm/vllm-openai-xpu:v${RELEASE_VERSION} || true
-docker manifest create vllm/vllm-openai-xpu:latest vllm/vllm-openai-xpu:latest-x86_64 --amend
-docker manifest create vllm/vllm-openai-xpu:v${RELEASE_VERSION} vllm/vllm-openai-xpu:v${RELEASE_VERSION}-x86_64 --amend
-docker manifest push vllm/vllm-openai-xpu:latest
-docker manifest push vllm/vllm-openai-xpu:v${RELEASE_VERSION}
+  docker manifest rm vllm/vllm-openai-xpu:latest || true
+  docker manifest rm vllm/vllm-openai-xpu:v${RELEASE_VERSION} || true
+  docker manifest create vllm/vllm-openai-xpu:latest vllm/vllm-openai-xpu:latest-x86_64 --amend
+  docker manifest create vllm/vllm-openai-xpu:v${RELEASE_VERSION} vllm/vllm-openai-xpu:v${RELEASE_VERSION}-x86_64 --amend
+  docker manifest push vllm/vllm-openai-xpu:latest
+  docker manifest push vllm/vllm-openai-xpu:v${RELEASE_VERSION}
+fi
 
 # ---- CPU ----
 # CPU images are behind separate block steps and may not have been built.
@@ -153,44 +177,46 @@ docker manifest push vllm/vllm-openai-xpu:v${RELEASE_VERSION}
 # arch would leave `:latest-x86_64` pointing at the new release while the
 # `:latest` multi-arch manifest still resolves to the previous release.
 
-CPU_X86_TAG=public.ecr.aws/q9t5s3a7/vllm-cpu-release-repo:v${RELEASE_VERSION}
-CPU_ARM_TAG=public.ecr.aws/q9t5s3a7/vllm-arm64-cpu-release-repo:v${RELEASE_VERSION}
+if target_enabled cpu; then
+  CPU_X86_TAG=public.ecr.aws/q9t5s3a7/vllm-cpu-release-repo:v${RELEASE_VERSION}
+  CPU_ARM_TAG=public.ecr.aws/q9t5s3a7/vllm-arm64-cpu-release-repo:v${RELEASE_VERSION}
 
-CPU_X86_AVAILABLE=false
-CPU_ARM_AVAILABLE=false
-docker manifest inspect "${CPU_X86_TAG}" >/dev/null 2>&1 && CPU_X86_AVAILABLE=true
-docker manifest inspect "${CPU_ARM_TAG}" >/dev/null 2>&1 && CPU_ARM_AVAILABLE=true
+  CPU_X86_AVAILABLE=false
+  CPU_ARM_AVAILABLE=false
+  docker manifest inspect "${CPU_X86_TAG}" >/dev/null 2>&1 && CPU_X86_AVAILABLE=true
+  docker manifest inspect "${CPU_ARM_TAG}" >/dev/null 2>&1 && CPU_ARM_AVAILABLE=true
 
-if [ "$CPU_X86_AVAILABLE" = "true" ] && [ "$CPU_ARM_AVAILABLE" = "true" ]; then
-  docker pull "${CPU_X86_TAG}"
-  docker tag "${CPU_X86_TAG}" vllm/vllm-openai-cpu:latest-x86_64
-  docker tag "${CPU_X86_TAG}" vllm/vllm-openai-cpu:v${RELEASE_VERSION}-x86_64
-  docker push vllm/vllm-openai-cpu:latest-x86_64
-  docker push vllm/vllm-openai-cpu:v${RELEASE_VERSION}-x86_64
+  if [ "$CPU_X86_AVAILABLE" = "true" ] && [ "$CPU_ARM_AVAILABLE" = "true" ]; then
+    docker pull "${CPU_X86_TAG}"
+    docker tag "${CPU_X86_TAG}" vllm/vllm-openai-cpu:latest-x86_64
+    docker tag "${CPU_X86_TAG}" vllm/vllm-openai-cpu:v${RELEASE_VERSION}-x86_64
+    docker push vllm/vllm-openai-cpu:latest-x86_64
+    docker push vllm/vllm-openai-cpu:v${RELEASE_VERSION}-x86_64
 
-  docker pull "${CPU_ARM_TAG}"
-  docker tag "${CPU_ARM_TAG}" vllm/vllm-openai-cpu:latest-arm64
-  docker tag "${CPU_ARM_TAG}" vllm/vllm-openai-cpu:v${RELEASE_VERSION}-arm64
-  docker push vllm/vllm-openai-cpu:latest-arm64
-  docker push vllm/vllm-openai-cpu:v${RELEASE_VERSION}-arm64
+    docker pull "${CPU_ARM_TAG}"
+    docker tag "${CPU_ARM_TAG}" vllm/vllm-openai-cpu:latest-arm64
+    docker tag "${CPU_ARM_TAG}" vllm/vllm-openai-cpu:v${RELEASE_VERSION}-arm64
+    docker push vllm/vllm-openai-cpu:latest-arm64
+    docker push vllm/vllm-openai-cpu:v${RELEASE_VERSION}-arm64
 
-  docker manifest rm vllm/vllm-openai-cpu:latest || true
-  docker manifest rm vllm/vllm-openai-cpu:v${RELEASE_VERSION} || true
-  docker manifest create vllm/vllm-openai-cpu:latest vllm/vllm-openai-cpu:latest-x86_64 vllm/vllm-openai-cpu:latest-arm64
-  docker manifest create vllm/vllm-openai-cpu:v${RELEASE_VERSION} vllm/vllm-openai-cpu:v${RELEASE_VERSION}-x86_64 vllm/vllm-openai-cpu:v${RELEASE_VERSION}-arm64
-  docker manifest push vllm/vllm-openai-cpu:latest
-  docker manifest push vllm/vllm-openai-cpu:v${RELEASE_VERSION}
-elif [ "$CPU_X86_AVAILABLE" = "false" ] && [ "$CPU_ARM_AVAILABLE" = "false" ]; then
-  echo "WARNING: Neither CPU image found in ECR, skipping CPU publish (ensure block-cpu-release-image-build and block-arm64-cpu-release-image-build were unblocked and the builds finished pushing)"
-else
-  # Partial state: one arch built, the other did not. Fail loudly rather than
-  # ship a Docker Hub state where `:latest-${arch}` and `:latest` (multi-arch)
-  # disagree on which release they point at.
-  echo "ERROR: Partial CPU build detected (x86_64=${CPU_X86_AVAILABLE}, arm64=${CPU_ARM_AVAILABLE})."
-  echo "       Refusing to publish to avoid split-tag drift between per-arch and multi-arch tags."
-  echo "       Re-run the missing CPU build and retry, or manually publish if a single-arch release is intended."
-  exit 1
+    docker manifest rm vllm/vllm-openai-cpu:latest || true
+    docker manifest rm vllm/vllm-openai-cpu:v${RELEASE_VERSION} || true
+    docker manifest create vllm/vllm-openai-cpu:latest vllm/vllm-openai-cpu:latest-x86_64 vllm/vllm-openai-cpu:latest-arm64
+    docker manifest create vllm/vllm-openai-cpu:v${RELEASE_VERSION} vllm/vllm-openai-cpu:v${RELEASE_VERSION}-x86_64 vllm/vllm-openai-cpu:v${RELEASE_VERSION}-arm64
+    docker manifest push vllm/vllm-openai-cpu:latest
+    docker manifest push vllm/vllm-openai-cpu:v${RELEASE_VERSION}
+  elif [ "$CPU_X86_AVAILABLE" = "false" ] && [ "$CPU_ARM_AVAILABLE" = "false" ]; then
+    echo "WARNING: Neither CPU image found in ECR, skipping CPU publish (ensure block-cpu-release-image-build and block-arm64-cpu-release-image-build were unblocked and the builds finished pushing)"
+  else
+    # Partial state: one arch built, the other did not. Fail loudly rather than
+    # ship a Docker Hub state where `:latest-${arch}` and `:latest` (multi-arch)
+    # disagree on which release they point at.
+    echo "ERROR: Partial CPU build detected (x86_64=${CPU_X86_AVAILABLE}, arm64=${CPU_ARM_AVAILABLE})."
+    echo "       Refusing to publish to avoid split-tag drift between per-arch and multi-arch tags."
+    echo "       Re-run the missing CPU build and retry, or manually publish if a single-arch release is intended."
+    exit 1
+  fi
 fi
 
 echo ""
-echo "Successfully published release images for v${RELEASE_VERSION}"
+echo "Successfully published ${TARGET} release images for v${RELEASE_VERSION}"


### PR DESCRIPTION
## Summary

- replace the single serial DockerHub publish job with a seven-way Buildkite matrix
- publish CUDA 13.0, CUDA 12.9, both Ubuntu 24.04 CUDA variants, ROCm, XPU, and CPU image families independently
- keep the existing approval block and preserve `all` as the script's backward-compatible default

## Why

Release v0.27.0 [build 4962](https://buildkite.com/vllm/release-v2/builds/4962#019fecea-e39a-47bf-a36f-b636de9f8c20) spent more than two hours in the DockerHub publish step. The script serially pulls, retags, and pushes every image family on one agent.

The measured family timings were:

- CUDA 13.0: 32m 34s
- CUDA 12.9: 40m 20s
- CUDA 13.0 on Ubuntu 24.04: 32m 39s
- CUDA 12.9 on Ubuntu 24.04: 39m 37s

Keeping both Ubuntu variants together would leave a roughly 72-minute critical path. Splitting them makes the publish critical path the slowest individual image family rather than the sum of all families, subject to release-queue capacity.

## Duplicate work

I searched open PRs for both parallel release-image publishing and references to `publish-release-images.sh`; no matching implementation was open when this PR was created.

## Validation

- `bk pipeline validate --file .buildkite/release-pipeline.yaml` — passed against the full online Buildkite schema
- `.venv/bin/pre-commit run shellcheck --files .buildkite/scripts/publish-release-images.sh` — passed
- `bash -n .buildkite/scripts/publish-release-images.sh` — passed
- exercised all seven targets plus the legacy `all` target with mocked registry commands
- verified the normalized Docker command list is unchanged from `origin/main`
- commit-time pre-commit hooks — passed

Model evaluations are not applicable because this change does not affect model output, accuracy, or serving behavior.

## AI assistance

AI assistance was used to investigate the live Buildkite job, implement the change, and run validation. This draft requires human review of every changed line before it is marked ready.