### PR TITLE
[Testing] Fix test_sharded_state_loader

### DIFF
--- a/tests/model_executor/model_loader/test_sharded_state_loader.py
+++ b/tests/model_executor/model_loader/test_sharded_state_loader.py
@@ -12,7 +12,6 @@ import torch
 
 from vllm import LLM, SamplingParams
 from vllm.model_executor.model_loader import ShardedStateLoader
-from vllm.platforms import current_platform
 from vllm.transformers_utils.repo_utils import hf_api
 
 prompts = [
@@ -96,9 +95,10 @@ def test_sharded_state_loader(
     input_dir = llama_3p2_1b_files
     ctx = mp.get_context("spawn")
 
-    platform_args = {}
-    if current_platform.is_rocm() or current_platform.is_xpu():
-        platform_args["max_num_seqs"] = 1
+    # Keep batching deterministic: this test compares exact greedy outputs
+    # across separate engine processes, whose schedulers may otherwise form
+    # different batches depending on prompt-processing timing.
+    platform_args = {"max_num_seqs": 1}
 
     # Run in separate processes for memory & CUDA isolation
     with TemporaryDirectory() as output_dir:


### PR DESCRIPTION
## Purpose

This test compares the following:
1. load checkpoint -> generate outputs from prompts
2. load checkpoint -> reshard checkpoint -> reload checkpoint -> generate output from prompts

Generating the output from prompts assumes batch invariance; if the vLLM scheduler schedules a different amount of batches across 1 and 2 then we can get different results.

This PR forces the generation to do one sequence at a time to fix the batch size. This is what the rocm path did as well.

## Test Plan

Run test with PyTorch 2.14, where the divergence showed up

## Test Result

Test passed
