### PR TITLE
[Bugfix] Fall back to native sampler when FlashInfer sampling kernel fails to build

### DIFF
--- a/tests/v1/sample/test_topk_topp_sampler.py
+++ b/tests/v1/sample/test_topk_topp_sampler.py
@@ -114,6 +114,63 @@ def test_rocm_aiter_sampler_defers_import_when_generators_force_native(
     assert logits_to_return is None
 
 
+def test_forward_cuda_falls_back_to_native_on_flashinfer_build_failure(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """FlashInfer sampling kernels are JIT-built on first use. If that build
+    fails at call time (e.g. no usable CUDA toolkit), forward_cuda should warn
+    once, permanently switch to the native sampler, and still return valid
+    token ids rather than crashing the engine. Regression for #49497.
+    """
+    from vllm.v1.sample.ops import topk_topp_sampler
+
+    def _raise_build_error(*args, **kwargs):
+        raise RuntimeError(
+            "Could not find nvcc and default cuda_home='/usr/local/cuda' doesn't exist"
+        )
+
+    monkeypatch.setattr(topk_topp_sampler, "flashinfer_sample", _raise_build_error)
+    # User did not explicitly force the sampler on -> degrade gracefully.
+    monkeypatch.setattr(topk_topp_sampler.envs, "is_set", lambda name: False)
+
+    sampler = topk_topp_sampler.TopKTopPSampler()
+
+    logits = torch.randn(4, 16)
+    k = torch.full((4,), 2, dtype=torch.int32)
+
+    token_ids, logits_to_return = sampler.forward_cuda(logits, {}, k, None)
+
+    assert token_ids.shape == (4,)
+    assert torch.all(token_ids >= 0) and torch.all(token_ids < 16)
+    assert logits_to_return is None
+    # Fast path is permanently disabled so later calls skip the failing build.
+    assert sampler.forward == sampler.forward_native
+
+
+def test_forward_cuda_raises_when_flashinfer_explicitly_forced(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """When the user sets VLLM_USE_FLASHINFER_SAMPLER=1 but the kernel fails to
+    build, forward_cuda should raise a clear RuntimeError naming the env var
+    instead of silently falling back or surfacing the raw build error (#49497).
+    """
+    from vllm.v1.sample.ops import topk_topp_sampler
+
+    def _raise_build_error(*args, **kwargs):
+        raise RuntimeError("Could not find nvcc")
+
+    monkeypatch.setattr(topk_topp_sampler, "flashinfer_sample", _raise_build_error)
+    monkeypatch.setattr(topk_topp_sampler.envs, "is_set", lambda name: True)
+
+    sampler = topk_topp_sampler.TopKTopPSampler()
+
+    logits = torch.randn(4, 16)
+    k = torch.full((4,), 2, dtype=torch.int32)
+
+    with pytest.raises(RuntimeError, match="VLLM_USE_FLASHINFER_SAMPLER=1"):
+        sampler.forward_cuda(logits, {}, k, None)
+
+
 def test_random_sample_uses_fp64_exponential_race_when_requested():
     torch.set_default_device(DEVICE_TYPE)
     probs = torch.tensor(

--- a/vllm/v1/sample/ops/topk_topp_sampler.py
+++ b/vllm/v1/sample/ops/topk_topp_sampler.py
@@ -179,7 +179,27 @@ class TopKTopPSampler(nn.Module):
         # flashinfer sampling functions expect contiguous logits.
         # In flex_attn/triton_attn fp32 inference, logits can be non-contiguous
         # because of slicing operation in logits_processor.
-        return flashinfer_sample(logits.contiguous(), k, p, generators), None
+        try:
+            return flashinfer_sample(logits.contiguous(), k, p, generators), None
+        except Exception as e:
+            # FlashInfer may JIT-compile its sampling kernels on first use.
+            # If that fails (e.g. no usable CUDA toolkit, or the ninja build
+            # errors out), degrade to the PyTorch-native sampler instead of
+            # taking down the engine. See #49497.
+            if envs.is_set("VLLM_USE_FLASHINFER_SAMPLER"):
+                raise RuntimeError(
+                    "FlashInfer top-p/top-k sampling was explicitly enabled "
+                    "via VLLM_USE_FLASHINFER_SAMPLER=1, but its sampling "
+                    f"kernel failed to build or load: {e}"
+                ) from e
+            logger.warning_once(
+                "FlashInfer top-p/top-k sampling kernel failed to build or "
+                "load (%s). Falling back to the PyTorch-native sampler. Set "
+                "VLLM_USE_FLASHINFER_SAMPLER=0 to silence this warning.",
+                e,
+            )
+            self.forward = self.forward_native
+            return self.forward_native(logits, generators, k, p)
 
     def forward_cpu(
         self,

--- a/vllm/v1/worker/gpu/sample/sampler.py
+++ b/vllm/v1/worker/gpu/sample/sampler.py
@@ -7,6 +7,7 @@ import torch
 import vllm.envs as envs
 from vllm.config.model import PROCESSED_LOGPROBS_MODES, LogprobsMode
 from vllm.config.reasoning import ReasoningConfig
+from vllm.logger import init_logger
 from vllm.sampling_params import SamplingParams
 from vllm.v1.sample.ops.topk_topp_sampler import (
     apply_top_k_top_p,
@@ -27,6 +28,8 @@ from vllm.v1.worker.gpu.sample.penalties import PenaltiesState
 from vllm.v1.worker.gpu.sample.states import NO_LOGPROBS, SamplingStates
 from vllm.v1.worker.gpu.sample.thinking_budget import ThinkingBudgetState
 from vllm.v1.worker.gpu.states import RequestState
+
+logger = init_logger(__name__)
 
 
 class Sampler:
@@ -271,16 +274,37 @@ class Sampler:
 
         # Sample the next token.
         if use_flashinfer:
-            sampled = flashinfer_sample(processed_logits, top_k, top_p).to(torch.int64)
-        else:
-            processed_logits = apply_top_k_top_p(processed_logits, top_k, top_p)
-            sampled = gumbel_sample(
-                processed_logits,
-                expanded_idx_mapping,
-                self.sampling_states.temperature.gpu,
-                self.sampling_states.seeds.gpu,
-                pos,
-                apply_temperature=False,
-                use_fp64=self.use_fp64_gumbel,
-            )
+            try:
+                sampled = flashinfer_sample(processed_logits, top_k, top_p).to(
+                    torch.int64
+                )
+                return sampled, processed_logits
+            except Exception as e:
+                # FlashInfer may JIT-compile its sampling kernels on first
+                # use. If that fails, permanently degrade to the native
+                # sampler instead of taking down the engine. See #49497.
+                if envs.is_set("VLLM_USE_FLASHINFER_SAMPLER"):
+                    raise RuntimeError(
+                        "FlashInfer top-p/top-k sampling was explicitly "
+                        "enabled via VLLM_USE_FLASHINFER_SAMPLER=1, but its "
+                        f"sampling kernel failed to build or load: {e}"
+                    ) from e
+                logger.warning_once(
+                    "FlashInfer top-p/top-k sampling kernel failed to build "
+                    "or load (%s). Falling back to the PyTorch-native "
+                    "sampler. Set VLLM_USE_FLASHINFER_SAMPLER=0 to silence "
+                    "this warning.",
+                    e,
+                )
+                self.use_flashinfer = False
+        processed_logits = apply_top_k_top_p(processed_logits, top_k, top_p)
+        sampled = gumbel_sample(
+            processed_logits,
+            expanded_idx_mapping,
+            self.sampling_states.temperature.gpu,
+            self.sampling_states.seeds.gpu,
+            pos,
+            apply_temperature=False,
+            use_fp64=self.use_fp64_gumbel,
+        )
         return sampled, processed_logits


### PR DESCRIPTION
> **AI assistance was used on this PR.** The fix and its design are mine; an AI assistant
> (Claude Opus 5) helped with the rebase onto current `main`, running and interpreting the
> test/control runs, and drafting this description. Attribution is in the commit trailer.
> I have reviewed every changed line and run the tests myself.

## Purpose

Fixes #49497.

FlashInfer JIT-compiles its top-k/top-p sampling kernels on first use. When that build fails at call time, the exception propagates out of the sampler and takes down engine startup, with no fallback to the PyTorch-native sampler.

This wraps the FlashInfer sampling call in both runner paths — `TopKTopPSampler.forward_cuda` (V1) and `vllm/v1/worker/gpu/sample/sampler.py` (V2 model runner) — so that a build failure warns once and permanently degrades to the native sampler. When the user has explicitly opted in with `VLLM_USE_FLASHINFER_SAMPLER=1`, it raises a clear `RuntimeError` naming that variable instead of silently falling back.

### Relationship to the neighbouring fixes

There are three distinct failure modes in this area, and this PR is deliberately scoped to the third:

| | Failure mode | Where it's caught |
|---|---|---|
| #49314 | FlashInfer not discoverable at all (no `nvcc`, no `flashinfer_cubin`) | backend gate, via `has_flashinfer()` |
| #48956 | FlashInfer present but cannot target the current GPU arch | eligibility check |
| **this PR** | FlashInfer selected, but the sampling kernel **fails to build at call time** | call site, try/except → native |

The first two decide *whether to select* FlashInfer. This one handles the build failing *after* it has been selected, which no gate can predict. It applies cleanly to `main` standalone and does not depend on either of the others landing first.

### Why this is not a duplicate

Per `AGENTS.md`, duplicate-work checks run before proposing:

```bash
gh issue view 49497 --repo vllm-project/vllm --comments
gh pr list --repo vllm-project/vllm --state open --search "49497 in:body"
gh pr list --repo vllm-project/vllm --state open --search "flashinfer sampler fallback"
```

No open PR addresses the JIT-build-failure case. The only neighbours the keyword search surfaces in this area are #48956 (FlashInfer cannot target the GPU arch) and #49314 (backend discovery gate via `has_flashinfer()`), both distinct per the table above. @Aliiiqbp noted in the issue that they were planning work here; as of opening, no PR exists, and I flagged my implementation in the thread so we don't write it twice.

### Model evaluation

Not applicable, and stating that rather than leaving it for review. On the success path the generated code is byte-identical — the `try` returns exactly what the previous call returned, so sampling output and accuracy are unchanged. The new path is reached only when the FlashInfer kernel fails to build, where the current behaviour is a crashed engine rather than different output. If a reviewer would still like numbers, `tests/evals/gsm8k` is the obvious target and I'll run it on request.

On sequencing: I said in the issue thread that I'd hold this until #49314 merged so the gate change went in first. Opening now instead because @Aliiiqbp mentioned planning work in the same area, and having the implementation visible seemed better than two people writing the same fix. Happy to rebase, re-scope, or close in favour of another approach if maintainers would rather sequence it differently.

## Test Plan

Two regression tests added to `tests/v1/sample/test_topk_topp_sampler.py`, both monkeypatching `flashinfer_sample` to raise a representative build error:

- `test_forward_cuda_falls_back_to_native_on_flashinfer_build_failure` — asserts valid token ids are still returned, and that `sampler.forward` is permanently rebound to `forward_native` so later calls skip the failing build.
- `test_forward_cuda_raises_when_flashinfer_explicitly_forced` — asserts a `RuntimeError` matching `VLLM_USE_FLASHINFER_SAMPLER=1` when the user opted in explicitly.

```
pytest tests/v1/sample/test_topk_topp_sampler.py
```

## Test Result

Both new tests pass:

```
tests/v1/sample/test_topk_topp_sampler.py::test_forward_cuda_falls_back_to_native_on_flashinfer_build_failure PASSED
tests/v1/sample/test_topk_topp_sampler.py::test_forward_cuda_raises_when_flashinfer_explicitly_forced PASSED
2 passed, 131 deselected
```

Full file, run with and without this commit on the same machine to separate pre-existing failures from anything introduced here:

| | failed | passed |
|---|---|---|
| without this commit (`239fc7355`) | 34 | 95 |
| with this commit | 34 | **97** |

The 34 failures are identical in both runs. They are the `TestFlashInferTopkToppRobustness` / `TestFlashInferDistributionMatch` cases, which require a working FlashInfer build and therefore cannot pass on a box without a discoverable CUDA toolkit — the exact environment this bug is about. This change introduces no new failures and adds the two passing tests above.

Environment: RTX 4060 Ti, WSL2 (kernel 6.18.33), driver 596.49, torch 2.11.0+cu130, no system CUDA toolkit (`nvcc` not on PATH, `flashinfer_cubin` not importable) — the same environment as the issue report.

Also verified end-to-end on that box before rebasing: both runner paths warn once and generate normally instead of crashing engine startup.

Rebased onto current `main`; the only conflict was an import union in `vllm/v1/worker/gpu/sample/sampler.py`. `pre-commit` passes clean (ruff check, ruff format, mypy, SPDX, forbidden-imports) with no files modified.

cc @hclsys @Aliiiqbp
