### PR TITLE
[Frontend] Add explicit model info cache preparation

### DIFF
--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -9,7 +9,7 @@ vllm --help
 Available Commands:
 
 ```bash
-vllm {chat,complete,serve,launch,bench,collect-env,run-batch}
+vllm {chat,complete,serve,launch,bench,collect-env,prepare-model-info,run-batch}
 ```
 
 ## serve
@@ -187,6 +187,20 @@ Start collecting environment information.
 ```bash
 vllm collect-env
 ```
+
+## prepare-model-info
+
+Prepares the model-info cache for one built-in architecture in the installed
+runtime environment. Run this while building a deployment image, with the same
+`VLLM_CACHE_ROOT` that the server will use:
+
+```bash
+vllm prepare-model-info Qwen3ForCausalLM
+```
+
+The command does not download model weights. It uses vLLM's normal subprocess
+inspection so the calling process does not retain CUDA state. Missing or stale
+entries use the same subprocess inspection and cache replacement at runtime.
 
 ## run-batch
 

--- a/tests/entrypoints/unit_tests/test_launch_cli.py
+++ b/tests/entrypoints/unit_tests/test_launch_cli.py
@@ -1,12 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""Unit tests for the `vllm launch` CLI subcommand."""
+"""Unit tests for public vLLM CLI parser and dispatch paths."""
 
 import argparse
+import sys
 from unittest.mock import patch
 
 import pytest
 
+from vllm.entrypoints.cli import main as cli_main
 from vllm.entrypoints.cli.launch import (
     LaunchSubcommand,
     RenderSubcommand,
@@ -109,3 +111,17 @@ def test_launch_registered_in_main():
     assert hasattr(launch_module, "cmd_init")
     subcmds = launch_module.cmd_init()
     assert any(s.name == "launch" for s in subcmds)
+
+
+def test_prepare_model_info_registered_in_main(capsys):
+    with (
+        patch.object(sys, "argv", ["vllm", "prepare-model-info", "Qwen3ForCausalLM"]),
+        patch("vllm.entrypoints.cli.benchmark.main.maybe_exec_rust_bench"),
+        patch(
+            "vllm.model_executor.models.ModelRegistry.prepare_model_info"
+        ) as prepare_model_info,
+    ):
+        cli_main.main()
+
+    prepare_model_info.assert_called_once_with("Qwen3ForCausalLM")
+    assert capsys.readouterr().out == "prepared model info for Qwen3ForCausalLM\n"

--- a/tests/models/test_registry.py
+++ b/tests/models/test_registry.py
@@ -2,6 +2,8 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import warnings
+from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 import torch.cuda
@@ -11,6 +13,7 @@ from vllm.model_executor.models import (
     is_text_generation_model,
     supports_multimodal,
 )
+from vllm.model_executor.models import registry as model_registry_module
 from vllm.model_executor.models.adapters import (
     as_embedding_model,
     as_seq_cls_model,
@@ -21,6 +24,9 @@ from vllm.model_executor.models.registry import (
     _TEXT_GENERATION_MODELS,
     ModelRegistry,
     _LazyRegisteredModel,
+    _ModelInfo,
+    _ModelRegistry,
+    _RegisteredModel,
 )
 from vllm.platforms import current_platform
 
@@ -164,6 +170,86 @@ def test_lazy_modelinfo_package_hash_includes_submodules(tmp_path):
     second_hash = _LazyRegisteredModel._get_modelinfo_module_hash(init_file)
 
     assert first_hash != second_hash
+
+
+def test_prepare_model_info_inspects_builtin_lazy_registration():
+    registry = _ModelRegistry(
+        {"Qwen3ForCausalLM": ModelRegistry.models["Qwen3ForCausalLM"]}
+    )
+    with patch.object(_LazyRegisteredModel, "prepare_model_info") as prepare_model_info:
+        registry.prepare_model_info("Qwen3ForCausalLM")
+
+    prepare_model_info.assert_called_once_with()
+
+
+def test_lazy_prepare_model_info_requires_readable_cache(tmp_path, monkeypatch):
+    monkeypatch.setenv("VLLM_CACHE_ROOT", str(tmp_path))
+    registered_model = ModelRegistry.models["Qwen3ForCausalLM"]
+
+    with (
+        patch.object(_LazyRegisteredModel, "inspect_model_cls"),
+        pytest.raises(RuntimeError, match="was not persisted"),
+    ):
+        registered_model.prepare_model_info()
+
+
+def test_inspect_model_info_keeps_best_effort_cache_write(tmp_path, monkeypatch):
+    cache_root = tmp_path / "not-a-directory"
+    cache_root.write_text("occupied", encoding="utf-8")
+    monkeypatch.setenv("VLLM_CACHE_ROOT", str(cache_root))
+    registered_model = ModelRegistry.models["Qwen3ForCausalLM"]
+    model_info = _ModelInfo.from_model_cls(torch.nn.Module)
+
+    with patch(
+        "vllm.model_executor.models.registry._run_in_subprocess",
+        return_value=model_info,
+    ):
+        assert registered_model.inspect_model_cls() is model_info
+
+
+def test_lazy_prepare_model_info_accepts_readable_cache(tmp_path, monkeypatch):
+    monkeypatch.setenv("VLLM_CACHE_ROOT", str(tmp_path))
+    registered_model = ModelRegistry.models["Qwen3ForCausalLM"]
+    model_info = _ModelInfo.from_model_cls(torch.nn.Module)
+    model_path = Path(model_registry_module.__file__).parent / "qwen3.py"
+    module_hash = registered_model._get_modelinfo_module_hash(model_path)
+    registered_model._save_modelinfo_to_cache(model_info, module_hash)
+
+    with patch.object(
+        _LazyRegisteredModel, "inspect_model_cls", return_value=model_info
+    ):
+        registered_model.prepare_model_info()
+
+
+@pytest.mark.parametrize(
+    ("registration", "model_arch", "error"),
+    [
+        (None, "UnknownForCausalLM", "is not registered"),
+        (
+            _LazyRegisteredModel("plugin.models", "PluginModel"),
+            "PluginForCausalLM",
+            "is not a built-in model",
+        ),
+        (
+            _RegisteredModel(interfaces=None, model_cls=torch.nn.Module),
+            "Qwen3ForCausalLM",
+            "is not registered lazily",
+        ),
+        (
+            _LazyRegisteredModel("plugin.models", "PluginModel"),
+            "Qwen3ForCausalLM",
+            "does not use its built-in registration",
+        ),
+    ],
+)
+def test_prepare_model_info_rejects_unsupported_registration(
+    registration, model_arch, error
+):
+    models = {} if registration is None else {model_arch: registration}
+    registry = _ModelRegistry(models)
+
+    with pytest.raises(ValueError, match=error):
+        registry.prepare_model_info(model_arch)
 
 
 def test_hf_registry_coverage():

--- a/vllm/entrypoints/cli/main.py
+++ b/vllm/entrypoints/cli/main.py
@@ -19,6 +19,7 @@ def main():
     import vllm.entrypoints.cli.collect_env
     import vllm.entrypoints.cli.launch
     import vllm.entrypoints.cli.openai
+    import vllm.entrypoints.cli.prepare_model_info
     import vllm.entrypoints.cli.run_batch
     import vllm.entrypoints.cli.serve
     from vllm.entrypoints.serve.utils.api_utils import (
@@ -33,6 +34,7 @@ def main():
         vllm.entrypoints.cli.launch,
         vllm.entrypoints.cli.benchmark.main,
         vllm.entrypoints.cli.collect_env,
+        vllm.entrypoints.cli.prepare_model_info,
         vllm.entrypoints.cli.run_batch,
     ]
 

--- a/vllm/entrypoints/cli/prepare_model_info.py
+++ b/vllm/entrypoints/cli/prepare_model_info.py
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import argparse
+
+from vllm.entrypoints.cli.types import CLISubcommand
+from vllm.utils.argparse_utils import FlexibleArgumentParser
+
+
+class PrepareModelInfoSubcommand(CLISubcommand):
+    """The ``prepare-model-info`` subcommand for the vLLM CLI."""
+
+    name = "prepare-model-info"
+
+    @staticmethod
+    def cmd(args: argparse.Namespace) -> None:
+        from vllm.model_executor.models import ModelRegistry
+
+        ModelRegistry.prepare_model_info(args.architecture)
+        print(f"prepared model info for {args.architecture}")
+
+    def subparser_init(
+        self, subparsers: argparse._SubParsersAction
+    ) -> FlexibleArgumentParser:
+        parser = subparsers.add_parser(
+            self.name,
+            help="Prepare cached metadata for a built-in model architecture.",
+            description=(
+                "Inspect a built-in model architecture in a subprocess and cache "
+                "its metadata in VLLM_CACHE_ROOT for later vLLM starts."
+            ),
+            usage="vllm prepare-model-info ARCHITECTURE",
+        )
+        parser.add_argument(
+            "architecture",
+            help="A built-in architecture name, such as Qwen3ForCausalLM.",
+        )
+        return parser
+
+
+def cmd_init() -> list[CLISubcommand]:
+    return [PrepareModelInfoSubcommand()]

--- a/vllm/model_executor/models/registry.py
+++ b/vllm/model_executor/models/registry.py
@@ -909,6 +909,24 @@ class _LazyRegisteredModel(_BaseRegisteredModel):
         cls_name = f"{self.module_name}-{self.class_name}".replace(".", "-")
         return f"{cls_name}.json"
 
+    def _get_current_modelinfo_module_hash(self) -> str | None:
+        # Modules registered with a non-default location (e.g. the
+        # hardware-isolated ``vllm.models.<name>`` layout) live outside
+        # ``vllm/model_executor/models``. Resolve the module spec directly
+        # so the file-hash cache stays warm for them.
+        if self.module_name.startswith("vllm.model_executor.models."):
+            model_path = Path(__file__).parent / f"{self.module_name.split('.')[-1]}.py"
+        else:
+            try:
+                spec = importlib.util.find_spec(self.module_name)
+            except (ImportError, ValueError):
+                spec = None
+            model_path = Path(spec.origin) if spec is not None and spec.origin else None
+
+        if model_path is None or not model_path.exists():
+            return None
+        return self._get_modelinfo_module_hash(model_path)
+
     @staticmethod
     def _get_modelinfo_module_hash(model_path: Path) -> str:
         if model_path.name == "__init__.py":
@@ -979,23 +997,8 @@ class _LazyRegisteredModel(_BaseRegisteredModel):
 
     @logtime(logger=logger, msg="Registry inspect model class")
     def inspect_model_cls(self) -> _ModelInfo:
-        # Modules registered with a non-default location (e.g. the
-        # hardware-isolated ``vllm.models.<name>`` layout) live outside
-        # ``vllm/model_executor/models``. Resolve the module spec directly
-        # so the file-hash cache stays warm for them.
-        if self.module_name.startswith("vllm.model_executor.models."):
-            model_path = Path(__file__).parent / f"{self.module_name.split('.')[-1]}.py"
-        else:
-            try:
-                spec = importlib.util.find_spec(self.module_name)
-            except (ImportError, ValueError):
-                spec = None
-            model_path = Path(spec.origin) if spec is not None and spec.origin else None
-        module_hash = None
-
-        if model_path is not None and model_path.exists():
-            module_hash = self._get_modelinfo_module_hash(model_path)
-
+        module_hash = self._get_current_modelinfo_module_hash()
+        if module_hash is not None:
             mi = self._load_modelinfo_from_cache(module_hash)
             if mi is not None:
                 logger.debug(
@@ -1024,6 +1027,15 @@ class _LazyRegisteredModel(_BaseRegisteredModel):
             self._save_modelinfo_to_cache(mi, module_hash)
 
         return mi
+
+    def prepare_model_info(self) -> None:
+        self.inspect_model_cls()
+        module_hash = self._get_current_modelinfo_module_hash()
+        if module_hash is None or self._load_modelinfo_from_cache(module_hash) is None:
+            raise RuntimeError(
+                f"Model info cache for class {self.module_name}.{self.class_name} "
+                "was not persisted"
+            )
 
     def load_model_cls(self) -> type[nn.Module]:
         mod = importlib.import_module(self.module_name)
@@ -1064,6 +1076,34 @@ class _ModelRegistry:
 
     def get_supported_archs(self) -> Set[str]:
         return self.models.keys()
+
+    def prepare_model_info(self, model_arch: str) -> None:
+        """Populate the model-info cache for a built-in lazy registration."""
+        registered_model = self.models.get(model_arch)
+        if registered_model is None:
+            raise ValueError(f"Model architecture '{model_arch}' is not registered")
+
+        builtin_model = _VLLM_MODELS.get(model_arch)
+        if builtin_model is None:
+            raise ValueError(
+                f"Model architecture '{model_arch}' is not a built-in model"
+            )
+        if not isinstance(registered_model, _LazyRegisteredModel):
+            raise ValueError(
+                f"Model architecture '{model_arch}' is not registered lazily"
+            )
+
+        module_name, class_name = builtin_model
+        if (
+            registered_model.module_name != _resolve_module_name(module_name)
+            or registered_model.class_name != class_name
+        ):
+            raise ValueError(
+                f"Model architecture '{model_arch}' does not use its built-in "
+                "registration"
+            )
+
+        registered_model.prepare_model_info()
 
     def register_model(
         self,


### PR DESCRIPTION


## Purpose

PR #23558 by @manoelmarques added the source-hash-validated runtime ModelInfo cache and reported model-class inspection at 10.1034 seconds uncached versus 0.6127 seconds cached, n=1 per state. During review, @hmellor objected to mirroring common runtime requirements into the build. The merged design therefore populated the cache at runtime. Without a matching entry, first activation still pays the subprocess inspection.

This PR adds an explicit preparation command for the existing cache format:

```bash
vllm prepare-model-info Qwen3ForCausalLM
```

The command runs in the final installed environment and ensures a readable entry exists under `VLLM_CACHE_ROOT/modelinfos`. It does not download model weights. It accepts only an unchanged built-in lazy registration, then verifies that the entry can be read after it is written. Unknown, plugin, eager, and overridden registrations fail. Normal startup behavior is unchanged: missing or stale entries still use the existing subprocess inspection and safe replacement path, and ordinary cache writes remain best-effort.

This deliberately does not generate entries during a generic wheel or source build. Model inspection can depend on runtime packages, platform modules, and compiled extensions, so the entry must be prepared in the target runtime or final deployment image.

The tradeoff is time shifting, not free work. In the hardware gate, the preparation command took 9.7860 seconds, n=1, and produced an 870-byte entry. It is useful when that prepared cache is baked or distributed to matching fresh deployments with the same installed environment, or when readiness latency matters more than image preparation time. A writable deployment that starts once will populate the same cache on its own.

## Test Plan

Focused registry and public CLI coverage:

```bash
pytest -q \
  tests/entrypoints/unit_tests/test_launch_cli.py \
  tests/models/test_registry.py::test_prepare_model_info_inspects_builtin_lazy_registration \
  tests/models/test_registry.py::test_lazy_prepare_model_info_requires_readable_cache \
  tests/models/test_registry.py::test_inspect_model_info_keeps_best_effort_cache_write \
  tests/models/test_registry.py::test_lazy_prepare_model_info_accepts_readable_cache \
  tests/models/test_registry.py::test_prepare_model_info_rejects_unsupported_registration
```

All applicable changed-file pre-commit hooks were also run from exact base `b2506d62aec7e6bccc5959b829221a7ae217abf3` to exact head `13f5279875da8dd5e90c9a5a3f779fe839689e54`.

The end-to-end gate used Qwen3-0.6B FP16 TP1 on one RTX 4090 Laptop GPU, maximum model length 256, warm model pages, and identical non-ModelInfo generated state. The interleaved sequence was empty, valid, valid, empty, empty, valid.

## Test Result

Focused public CLI and registry coverage passed 20 tests. All applicable changed-file pre-commit hooks passed, including Ruff, formatting, markdownlint, Python 3.10 mypy, SPDX, lazy-import, forbidden-import, and configuration checks.

| Starting state | Process launch to HTTP ready | Process launch to first correct token |
| --- | ---: | ---: |
| Empty ModelInfo cache | 20.2773 s median | 20.4360 s median |
| Valid prepared entry | 16.0033 s median | 16.1558 s median |
| Reduction | 4.2739 s, 21.1% | 4.2802 s, 20.9% |

Each arm used n=3. All 18 exact-token requests passed, the deliberately wrong-token control failed, and all six cells passed GPU engagement, cleanup, source-origin, page-cache, and generated-state controls.

This hardware result used exact source `8a90f1ab7565b6b6ad824b5643c203bb40bddcac` on base `8bcc916a98a90822882455ab30aba02c409da2a6`. The same feature patch was then rebased without conflicts onto base `b2506d62aec7e6bccc5959b829221a7ae217abf3` at current head `13f5279875da8dd5e90c9a5a3f779fe839689e54`; its stable patch ID is unchanged, and the intervening upstream commits overlap none of the six feature files. It is a Qwen3-0.6B installed-runtime integration result, not an exact-current-head, dense-model, cross-platform, or wheel-build performance claim. The measured source used a recorded compatible precompiled runtime payload.

AI assistance was used. I reviewed the changes and can defend the implementation, constraints, and measurements.
