### PR TITLE
[Observability] Add OpenTelemetry tracing to GPU-less render server endpoints

### DIFF
--- a/tests/entrypoints/scale_out/render/test_render_tracing.py
+++ b/tests/entrypoints/scale_out/render/test_render_tracing.py
@@ -1,0 +1,142 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tracing tests for the GPU-less render server (`vllm launch render`)."""
+
+import socket
+import time
+from collections.abc import Generator
+from concurrent import futures
+
+import grpc
+import httpx
+import pytest
+import pytest_asyncio
+from opentelemetry.proto.collector.trace.v1.trace_service_pb2_grpc import (
+    add_TraceServiceServicer_to_server,
+)
+
+from tests.tracing.conftest import (
+    FAKE_TRACE_SERVER_ADDRESS,
+    FakeTraceService,
+)
+from tests.utils import RemoteLaunchRenderServer
+
+MODEL_NAME = "hmellor/tiny-random-LlamaForCausalLM"
+
+# W3C traceparent header with a fixed trace id and parent span id.
+TRACEPARENT = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+
+
+@pytest.fixture(scope="module")
+def trace_service() -> Generator[FakeTraceService, None, None]:
+    """Module-scoped fake OTLP trace service for the render server process."""
+    server = grpc.server(futures.ThreadPoolExecutor(max_workers=2))
+    service = FakeTraceService()
+    add_TraceServiceServicer_to_server(service, server)
+    server.add_insecure_port(FAKE_TRACE_SERVER_ADDRESS)
+    server.start()
+
+    host, port = FAKE_TRACE_SERVER_ADDRESS.rsplit(":", 1)
+    deadline = time.monotonic() + 5.0
+    while time.monotonic() < deadline:
+        try:
+            with socket.create_connection((host, int(port)), timeout=0.5):
+                break
+        except OSError:
+            time.sleep(0.1)
+
+    yield service
+
+    server.stop(grace=None)
+
+
+@pytest.fixture(scope="module")
+def server(trace_service):
+    args = ["--otlp-traces-endpoint", FAKE_TRACE_SERVER_ADDRESS]
+    with RemoteLaunchRenderServer(MODEL_NAME, args, max_wait_seconds=120) as srv:
+        yield srv
+
+
+@pytest_asyncio.fixture
+async def client(server):
+    async with httpx.AsyncClient(
+        base_url=server.url_for(""), timeout=30.0
+    ) as http_client:
+        yield http_client
+
+
+def _wait_for_span(
+    trace_service: FakeTraceService,
+    span_name: str,
+    timeout: float = 30.0,
+) -> dict:
+    """Wait until a span with the given name has been exported."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        for span in trace_service.get_all_spans():
+            if span["name"] == span_name:
+                return span
+        time.sleep(0.25)
+    raise AssertionError(f"No span named '{span_name}' was exported within {timeout}s")
+
+
+def _assert_span_linked_to_trace(span: dict, traceparent: str) -> None:
+    """Assert the span belongs to the trace carried by `traceparent`."""
+    _, trace_id, parent_span_id, _ = traceparent.split("-")
+    assert span["trace_id"] == trace_id
+    assert span["parent_span_id"] == parent_span_id
+
+
+@pytest.mark.asyncio
+async def test_render_chat_completion_span(client, trace_service):
+    """A span is exported for the chat render endpoint, linked to the caller's
+    trace context."""
+    response = await client.post(
+        "/v1/chat/completions/render",
+        headers={"traceparent": TRACEPARENT},
+        json={
+            "model": MODEL_NAME,
+            "messages": [{"role": "user", "content": "Hello, how are you?"}],
+        },
+    )
+
+    assert response.status_code == 200
+
+    span = _wait_for_span(trace_service, "render_chat_completion")
+    _assert_span_linked_to_trace(span, TRACEPARENT)
+
+
+@pytest.mark.asyncio
+async def test_render_completion_span(client, trace_service):
+    """A span is exported for the completion render endpoint."""
+    response = await client.post(
+        "/v1/completions/render",
+        headers={"traceparent": TRACEPARENT},
+        json={
+            "model": MODEL_NAME,
+            "prompt": "Once upon a time",
+        },
+    )
+
+    assert response.status_code == 200
+
+    span = _wait_for_span(trace_service, "render_completion")
+    _assert_span_linked_to_trace(span, TRACEPARENT)
+
+
+@pytest.mark.asyncio
+async def test_tokenize_span(client, trace_service):
+    """A span is exported for the tokenize endpoint."""
+    response = await client.post(
+        "/tokenize",
+        headers={"traceparent": TRACEPARENT},
+        json={
+            "model": MODEL_NAME,
+            "prompt": "Hello world",
+        },
+    )
+
+    assert response.status_code == 200
+
+    span = _wait_for_span(trace_service, "tokenize")
+    _assert_span_linked_to_trace(span, TRACEPARENT)

--- a/vllm/entrypoints/cli/launch.py
+++ b/vllm/entrypoints/cli/launch.py
@@ -138,6 +138,7 @@ async def run_launch_fastapi(args: argparse.Namespace) -> None:
     # 2. Build and serve the API server
     engine_args = AsyncEngineArgs.from_cli_args(args)
     model_config = engine_args.create_model_config()
+    observability_config = engine_args.create_observability_config()
 
     # Render servers preprocess data only — no inference, no quantized kernels.
     # Clear quantization so VllmConfig skips quant dtype/capability validation.
@@ -147,7 +148,9 @@ async def run_launch_fastapi(args: argparse.Namespace) -> None:
     # cache space warning from CpuPlatform.check_and_update_config.
     envs.VLLM_CPU_KVCACHE_SPACE = 0
 
-    vllm_config = VllmConfig(model_config=model_config)
+    vllm_config = VllmConfig(
+        model_config=model_config, observability_config=observability_config
+    )
     shutdown_task = await build_and_serve_renderer(
         vllm_config, listen_address, sock, args
     )

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -48,7 +48,7 @@ from vllm.renderers.online_derenderer import OnlineDerenderer
 from vllm.renderers.online_renderer import OnlineRenderer
 from vllm.tasks import POOLING_TASKS, SupportedTask
 from vllm.tool_parsers import ToolParserManager
-from vllm.tracing import instrument
+from vllm.tracing import init_tracer, instrument
 from vllm.usage.usage_lib import UsageContext
 from vllm.utils.argparse_utils import FlexibleArgumentParser
 from vllm.utils.network_utils import is_valid_ipv6_address
@@ -373,6 +373,10 @@ async def init_render_app_state(
             for name in served_model_names
         ],
     )
+
+    tracing_endpoint = vllm_config.observability_config.otlp_traces_endpoint
+    if tracing_endpoint is not None:
+        init_tracer("vllm.renderer", tracing_endpoint)
 
     if args.enable_log_requests:
         request_logger = RequestLogger(max_log_len=args.max_log_len)

--- a/vllm/entrypoints/scale_out/derender/api_router.py
+++ b/vllm/entrypoints/scale_out/derender/api_router.py
@@ -6,7 +6,10 @@ from fastapi import APIRouter, Depends, Request
 from fastapi.responses import JSONResponse
 
 from vllm.entrypoints.openai.engine.protocol import ErrorResponse
-from vllm.entrypoints.serve.utils.api_utils import validate_json_request
+from vllm.entrypoints.serve.utils.api_utils import (
+    request_span,
+    validate_json_request,
+)
 from vllm.logger import init_logger
 
 from ..token_in_token_out.protocol import (
@@ -62,7 +65,8 @@ async def derender_chat_completion(
         )
 
     if isinstance(request, DerenderChatStreamRequest):
-        stream_result = await handler.derender_chat_stream_response(request)
+        async with request_span(raw_request, "derender_chat_completion"):
+            stream_result = await handler.derender_chat_stream_response(request)
         if isinstance(stream_result, ErrorResponse):
             return JSONResponse(
                 content=stream_result.model_dump(),
@@ -72,7 +76,8 @@ async def derender_chat_completion(
         response = DerenderChatStreamResponse(chunk=chunk, stream_state=stream_state)
         return JSONResponse(content=response.model_dump())
 
-    result = await handler.derender_chat_response(request)
+    async with request_span(raw_request, "derender_chat_completion"):
+        result = await handler.derender_chat_response(request)
     if isinstance(result, ErrorResponse):
         return JSONResponse(content=result.model_dump(), status_code=result.error.code)
     return JSONResponse(content=result.model_dump())
@@ -108,7 +113,8 @@ async def derender_completion(
         raise NotImplementedError("The model does not support Completions Derender API")
 
     if isinstance(request, DerenderCompletionStreamRequest):
-        stream_result = await handler.derender_completion_stream_response(request)
+        async with request_span(raw_request, "derender_completion"):
+            stream_result = await handler.derender_completion_stream_response(request)
         if isinstance(stream_result, ErrorResponse):
             return JSONResponse(
                 content=stream_result.model_dump(),
@@ -120,7 +126,8 @@ async def derender_completion(
         )
         return JSONResponse(content=response.model_dump())
 
-    result = await handler.derender_completion_response(request)
+    async with request_span(raw_request, "derender_completion"):
+        result = await handler.derender_completion_response(request)
     if isinstance(result, ErrorResponse):
         return JSONResponse(content=result.model_dump(), status_code=result.error.code)
     return JSONResponse(content=result.model_dump())

--- a/vllm/entrypoints/scale_out/render/api_router.py
+++ b/vllm/entrypoints/scale_out/render/api_router.py
@@ -8,7 +8,10 @@ from fastapi.responses import JSONResponse
 from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
 from vllm.entrypoints.openai.completion.protocol import CompletionRequest
 from vllm.entrypoints.openai.engine.protocol import ErrorResponse
-from vllm.entrypoints.serve.utils.api_utils import validate_json_request
+from vllm.entrypoints.serve.utils.api_utils import (
+    request_span,
+    validate_json_request,
+)
 from vllm.logger import init_logger
 
 from ..token_in_token_out.protocol import GenerateRequest
@@ -41,7 +44,8 @@ async def render_chat_completion(request: ChatCompletionRequest, raw_request: Re
             "The model does not support Chat Completions Render API"
         )
 
-    result = await handler.render_chat_request(request)
+    async with request_span(raw_request, "render_chat_completion"):
+        result = await handler.render_chat_request(request)
 
     if isinstance(result, ErrorResponse):
         return JSONResponse(content=result.model_dump(), status_code=result.error.code)
@@ -64,7 +68,8 @@ async def render_completion(request: CompletionRequest, raw_request: Request):
     if handler is None:
         raise NotImplementedError("The model does not support Completions Render API")
 
-    result = await handler.render_completion_request(request)
+    async with request_span(raw_request, "render_completion"):
+        result = await handler.render_completion_request(request)
 
     if isinstance(result, ErrorResponse):
         return JSONResponse(content=result.model_dump(), status_code=result.error.code)

--- a/vllm/entrypoints/serve/tokenize/api_router.py
+++ b/vllm/entrypoints/serve/tokenize/api_router.py
@@ -17,6 +17,7 @@ from vllm.entrypoints.serve.tokenize.protocol import (
 )
 from vllm.entrypoints.serve.tokenize.serving import ServingTokenization
 from vllm.entrypoints.serve.utils.api_utils import (
+    request_span,
     validate_json_request,
     with_cancellation,
 )
@@ -46,7 +47,8 @@ router = APIRouter()
 async def tokenize(request: TokenizeRequest, raw_request: Request):
     handler = tokenization(raw_request)
 
-    generator = await handler.create_tokenize(request, raw_request)
+    async with request_span(raw_request, "tokenize"):
+        generator = await handler.create_tokenize(request, raw_request)
 
     if isinstance(generator, ErrorResponse):
         return JSONResponse(
@@ -71,7 +73,8 @@ async def tokenize(request: TokenizeRequest, raw_request: Request):
 async def detokenize(request: DetokenizeRequest, raw_request: Request):
     handler = tokenization(raw_request)
 
-    generator = await handler.create_detokenize(request, raw_request)
+    async with request_span(raw_request, "detokenize"):
+        generator = await handler.create_detokenize(request, raw_request)
 
     if isinstance(generator, ErrorResponse):
         return JSONResponse(

--- a/vllm/entrypoints/serve/utils/api_utils.py
+++ b/vllm/entrypoints/serve/utils/api_utils.py
@@ -5,7 +5,9 @@ import asyncio
 import dataclasses
 import functools
 import os
+import time
 from argparse import Namespace
+from contextlib import asynccontextmanager
 from logging import Logger
 from string import Template
 from typing import Any
@@ -21,6 +23,7 @@ from vllm.entrypoints.openai.engine.protocol import StreamOptions
 from vllm.entrypoints.openai.models.protocol import LoRAModulePath
 from vllm.logger import current_formatter_type, init_logger
 from vllm.platforms import current_platform
+from vllm.tracing import SpanKind, extract_trace_context, instrument_manual
 from vllm.utils.argparse_utils import FlexibleArgumentParser
 
 logger = init_logger(__name__)
@@ -91,6 +94,26 @@ def with_cancellation(handler_func):
         return None
 
     return wrapper
+
+
+@asynccontextmanager
+async def request_span(raw_request: Request, span_name: str):
+    """Create an OpenTelemetry span covering an HTTP request handler.
+
+    The span is linked to the trace context carried by the request headers
+    (if any) and recorded with ``SpanKind.SERVER``.
+    """
+    start_time_ns = time.time_ns()
+    trace_context = extract_trace_context(raw_request.headers)
+    try:
+        yield
+    finally:
+        instrument_manual(
+            span_name=span_name,
+            start_time=start_time_ns,
+            context=trace_context,
+            kind=SpanKind.SERVER,
+        )
 
 
 def decrement_server_load(request: Request):


### PR DESCRIPTION
## Summary

Add OpenTelemetry tracing to the GPU-less render server (`vllm launch render`): every endpoint the command opens now emits a `SpanKind.SERVER` span linked to the caller's W3C trace context.

- **`vllm/entrypoints/cli/launch.py`** — `run_launch_fastapi` built `VllmConfig(model_config=...)` directly, silently dropping the observability CLI args. It now passes `observability_config` via `AsyncEngineArgs.create_observability_config()`, so `--otlp-traces-endpoint` takes effect (this is the same path `vllm serve` uses through `create_engine_config`).
- **`vllm/entrypoints/openai/api_server.py`** — `init_render_app_state` calls `init_tracer("vllm.renderer", otlp_traces_endpoint)` when configured, mirroring `AsyncLLM` in the engine.
- **`vllm/entrypoints/serve/utils/api_utils.py`** — new `request_span` async context manager that emits a `SpanKind.SERVER` span with `extract_trace_context(raw_request.headers)` as the parent, so spans join the caller's trace when `traceparent`/`tracestate` headers are present.
- **Routers** — render (`/v1/chat/completions/render`, `/v1/completions/render`), derender (`/v1/chat/completions/derender`, `/v1/completions/derender`, incl. streaming variants), tokenize (`/tokenize`, `/detokenize`) now wrap their serving calls in `request_span`.
- **`tests/entrypoints/scale_out/render/test_render_tracing.py`** — e2e test launching the render server against a fake OTLP collector; asserts exported spans carry the trace/span IDs from the request's `traceparent` header.

## Why this is not duplicating an existing PR

Open PR #39438 ("Extend OpenTelemetry instrumentation to remaining HTTP route handlers") covers the same area. It differs materially and is quite old (>2 months old). 

## AI assistance

This PR was created with AI assistance (opencode). A human reviewed every changed line and ran the tests above.