### PR TITLE
[Security] Include cache_salt in HF3FS external cache keys

### DIFF
--- a/tests/v1/kv_connector/unit/test_hf3fs_connector.py
+++ b/tests/v1/kv_connector/unit/test_hf3fs_connector.py
@@ -7,13 +7,21 @@ Tests for HF3FS KV Connector high-level components:
 """
 
 import os
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
 import torch
 
 from vllm.distributed.kv_transfer.kv_connector.v1.hf3fs.hf3fs_connector import (
+    HF3FSKVConnector,
     HF3FSKVConnectorStats,
+)
+from vllm.distributed.kv_transfer.kv_connector.v1.hf3fs.utils.common import (
+    HF3FSConnectorMetadata,
+    HF3FSRequestMetadata,
+    LoadBlockInfo,
+    RequestSchedulingState,
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.hf3fs.utils.hf3fs_mock_client import (
     Hf3fsClient as MockHf3fsClient,
@@ -28,6 +36,12 @@ from vllm.distributed.kv_transfer.kv_connector.v1.hf3fs.utils.hf3fs_mock_client 
 def hf3fs_stats():
     """Fresh HF3FSKVConnectorStats instance."""
     return HF3FSKVConnectorStats()
+
+
+def _make_hash_connector() -> HF3FSKVConnector:
+    connector = object.__new__(HF3FSKVConnector)
+    connector._block_size = 4
+    return connector
 
 
 def _make_cuda_event():
@@ -228,3 +242,104 @@ class TestHF3FSKVConnectorStats:
         clone = hf3fs_stats.clone_and_reset()
         assert clone.data["num_transfer_task"] == 2
         assert hf3fs_stats.is_empty()
+
+
+# ===========================================================================
+# TestHF3FSCacheSaltIsolation
+# ===========================================================================
+
+
+def _request_metadata(
+    cache_salt: str, load_op: LoadBlockInfo | None = None
+) -> HF3FSRequestMetadata:
+    state = RequestSchedulingState(
+        request_id=cache_salt,
+        token_ids=list(range(8)),
+        allocated_block_ids=[10, 11],
+        cache_salt=cache_salt,
+    )
+    request_metadata = HF3FSRequestMetadata.from_scheduling_state(
+        state, 4, load_op=load_op
+    )
+    assert request_metadata is not None
+    return request_metadata
+
+
+def _worker_hashes(
+    request_metadata: HF3FSRequestMetadata, *, load: bool = False
+) -> list[str]:
+    metadata = HF3FSConnectorMetadata()
+    metadata.add_request(request_metadata)
+
+    connector = _make_hash_connector()
+    connector._max_device_buffer_count = 8
+    connector._connector_metadata = metadata
+    connector._async_manager = MagicMock()
+
+    if load:
+        connector.start_load_kv(None)
+        submit = connector._async_manager.submit_load_operation
+    else:
+        connector.wait_for_save()
+        submit = connector._async_manager.submit_save_operation
+
+    submit.assert_called_once()
+    assert metadata.requests[0].cache_salt == request_metadata.cache_salt
+    return submit.call_args.args[2]
+
+
+class TestHF3FSCacheSaltIsolation:
+    """Verify cache_salt isolation through scheduler and worker paths."""
+
+    def test_scheduler_lookup_and_hash_chain_are_isolated_by_salt(self):
+        connector = _make_hash_connector()
+        prompt_token_ids = list(range(9))
+        tenant_a_keys = connector._generate_block_hashes(
+            prompt_token_ids[:8], 0, cache_salt="tenant-A"
+        )
+        tenant_b_keys = connector._generate_block_hashes(
+            prompt_token_ids[:8], 0, cache_salt="tenant-B"
+        )
+        assert connector._generate_block_hashes(list(range(4)), 0)[0] == (
+            "44aad182b5a8a40926162f81a84f091f"
+        )
+        assert all(a != b for a, b in zip(tenant_a_keys, tenant_b_keys))
+
+        stored_keys = set(tenant_a_keys)
+        connector._scheduling_states = {}
+        connector._metadata_client = MagicMock()
+        connector._metadata_client.batch_key_exists.side_effect = lambda hashes: [
+            block_hash in stored_keys for block_hash in hashes
+        ]
+
+        tenant_a = SimpleNamespace(
+            request_id="request-a",
+            prompt_token_ids=prompt_token_ids,
+            cache_salt="tenant-A",
+        )
+        tenant_b = SimpleNamespace(
+            request_id="request-b",
+            prompt_token_ids=prompt_token_ids,
+            cache_salt="tenant-B",
+        )
+
+        assert connector.get_num_new_matched_tokens(tenant_a, 0) == (8, True)
+        assert connector.get_num_new_matched_tokens(tenant_b, 0) == (0, False)
+
+    def test_salt_survives_worker_save_and_load_handoff(self):
+        tenant_a_save = _worker_hashes(_request_metadata("tenant-A"))
+        expected_hashes = _make_hash_connector()._generate_block_hashes(
+            list(range(8)), 0, cache_salt="tenant-A"
+        )
+        assert tenant_a_save == expected_hashes
+
+        load_op = LoadBlockInfo(
+            num_computed_blocks=1,
+            num_blocks_to_load=1,
+            need_fetch_block_ids=[11],
+        )
+        tenant_a_load = _worker_hashes(
+            _request_metadata("tenant-A", load_op), load=True
+        )
+
+        assert tenant_a_load == expected_hashes[1:]

--- a/vllm/distributed/kv_transfer/kv_connector/v1/hf3fs/hf3fs_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/hf3fs/hf3fs_connector.py
@@ -628,7 +628,11 @@ class HF3FSKVConnector(KVConnectorBase_V1):
                 continue
 
             skip_blocks = request.save_block_op.skip_leading_blocks
-            block_hashes = self._generate_block_hashes(request.token_ids, skip_blocks)
+            block_hashes = self._generate_block_hashes(
+                request.token_ids,
+                skip_blocks,
+                cache_salt=request.cache_salt,
+            )
             block_ids = request.block_ids[skip_blocks : skip_blocks + len(block_hashes)]
 
             for i in range(0, len(block_ids), self._max_device_buffer_count):
@@ -651,7 +655,10 @@ class HF3FSKVConnector(KVConnectorBase_V1):
             load_op = request.load_block_op
             block_ids = request.block_ids[: load_op.num_blocks_to_load]
             block_hashes = self._generate_block_hashes(
-                request.token_ids, load_op.num_computed_blocks, len(block_ids)
+                request.token_ids,
+                load_op.num_computed_blocks,
+                len(block_ids),
+                cache_salt=request.cache_salt,
             )
 
             for i in range(0, len(block_ids), self._max_device_buffer_count):
@@ -699,6 +706,7 @@ class HF3FSKVConnector(KVConnectorBase_V1):
         try:
             state = self._get_or_create_scheduling_state(request.request_id)
             state.request = request
+            state.cache_salt = request.cache_salt or ""
             assert request.prompt_token_ids is not None
 
             num_tokens_to_check = self._align_to_block_size(
@@ -714,7 +722,9 @@ class HF3FSKVConnector(KVConnectorBase_V1):
                 return 0, False
 
             token_ids_to_check = request.prompt_token_ids[:num_tokens_to_check]
-            block_hashes = self._generate_block_hashes(token_ids_to_check, 0)
+            block_hashes = self._generate_block_hashes(
+                token_ids_to_check, 0, cache_salt=state.cache_salt
+            )
 
             # Check existence
             exists_results = self._metadata_client.batch_key_exists(block_hashes)
@@ -761,6 +771,7 @@ class HF3FSKVConnector(KVConnectorBase_V1):
         """Update state after block allocation."""
         state = self._get_or_create_scheduling_state(request.request_id)
         state.request = request
+        state.cache_salt = request.cache_salt or ""
 
         if num_external_tokens <= 0 or not state.needs_loading():
             return
@@ -807,6 +818,8 @@ class HF3FSKVConnector(KVConnectorBase_V1):
             assert (
                 state.request is not None and state.request.prompt_token_ids is not None
             )
+            if not state.cache_salt and state.request.cache_salt:
+                state.cache_salt = state.request.cache_salt
             # Create load request metadata
             num_cached_blocks = (
                 state.load_op.num_computed_blocks + state.load_op.num_blocks_to_load
@@ -957,6 +970,8 @@ class HF3FSKVConnector(KVConnectorBase_V1):
         token_ids: list[int],
         start_block_id: int,
         max_blocks_count: int | None = None,
+        *,
+        cache_salt: str = "",
     ) -> list[str]:
         """Generate block hashes for token sequence."""
         block_hashes = []
@@ -967,8 +982,9 @@ class HF3FSKVConnector(KVConnectorBase_V1):
                 break
 
             end_idx = start_idx + self._block_size
+            salt = cache_salt if start_idx == 0 else ""
             block_hash = self._compute_prefix_hash(
-                token_ids[start_idx:end_idx], previous_hash
+                token_ids[start_idx:end_idx], previous_hash, cache_salt=salt
             )
 
             block_index = start_idx // self._block_size
@@ -1005,10 +1021,16 @@ class HF3FSKVConnector(KVConnectorBase_V1):
                 )
 
     def _compute_prefix_hash(
-        self, token_ids: list[int], previous_hash: str = ""
+        self,
+        token_ids: list[int],
+        previous_hash: str = "",
+        *,
+        cache_salt: str = "",
     ) -> str:
         """Compute prefix hash for token block."""
-        combined_string = f"{previous_hash}_{token_ids}"
+        # The salt component also versions unsalted keys out of the legacy
+        # token-only namespace so pre-fix entries cannot remain addressable.
+        combined_string = f"{cache_salt}_{previous_hash}_{token_ids}"
         return hashlib.md5(combined_string.encode()).hexdigest()
 
     def _align_to_block_size(self, num_tokens: int) -> int:

--- a/vllm/distributed/kv_transfer/kv_connector/v1/hf3fs/utils/common.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/hf3fs/utils/common.py
@@ -59,6 +59,9 @@ class RequestSchedulingState:
     # Scheduling phase
     phase: str = "NEW"  # NEW -> WAITING_TO_LOAD -> ACTIVE -> FINISHED
 
+    # Request-specific namespace for external cache keys.
+    cache_salt: str = ""
+
     def needs_loading(self) -> bool:
         """Check if request needs loading."""
         return self.load_op is not None and self.load_op.num_blocks_to_load > 0
@@ -96,6 +99,7 @@ class HF3FSRequestMetadata:
     block_ids: list[int]
     load_block_op: LoadBlockInfo | None = None
     save_block_op: SaveBlockInfo | None = None
+    cache_salt: str = ""
 
     @staticmethod
     def from_scheduling_state(
@@ -125,6 +129,7 @@ class HF3FSRequestMetadata:
             block_ids=state.allocated_block_ids,
             load_block_op=load_op,
             save_block_op=SaveBlockInfo(skip_leading_blocks=skip_blocks),
+            cache_salt=state.cache_salt,
         )
 
 


### PR DESCRIPTION
## Summary

HF3FS external cache keys were derived from token IDs alone and omitted the per-request `cache_salt`. Engines sharing an HF3FS metadata service could therefore alias the same exact prefix across different salts and expose cached-prefix membership through hit observability.

This change:

- carries `cache_salt` through scheduler state and HF3FS worker metadata;
- injects the salt into the first full-block hash so chained descendant hashes remain isolated;
- uses the salted keys consistently for metadata lookup, save, and load; and
- adds CPU-only production-path tests for A-hit/B-miss isolation and save/load key agreement.

