### PR TITLE
[Misc] Use VLLMValidationError in scoring input validation

### DIFF
--- a/tests/entrypoints/pooling/scoring/test_utils.py
+++ b/tests/entrypoints/pooling/scoring/test_utils.py
@@ -1,0 +1,65 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+
+from vllm.entrypoints.pooling.scoring.typing import ScoreInput
+from vllm.entrypoints.pooling.scoring.utils import validate_score_input
+from vllm.exceptions import VLLMValidationError
+
+
+@pytest.mark.parametrize(
+    ("data_1", "data_2", "is_multimodal_model", "architecture", "message"),
+    [
+        pytest.param(
+            {"content": []},
+            "document",
+            False,
+            "TestModel",
+            "MultiModalParam is not supported for TestModel",
+            id="unsupported-multimodal-input",
+        ),
+        pytest.param(
+            ["query 1", "query 2"],
+            ["document"],
+            False,
+            "TestModel",
+            "Input lengths must be either 1:1, 1:N or N:N",
+            id="incompatible-input-lengths",
+        ),
+        pytest.param(
+            [],
+            ["document"],
+            False,
+            "TestModel",
+            "At least one text element must be given",
+            id="empty-first-input",
+        ),
+        pytest.param(
+            ["query"],
+            [],
+            False,
+            "TestModel",
+            "At least one text_pair element must be given",
+            id="empty-second-input",
+        ),
+    ],
+)
+def test_validate_score_input_rejects_invalid_inputs(
+    data_1: ScoreInput | list[ScoreInput],
+    data_2: ScoreInput | list[ScoreInput],
+    is_multimodal_model: bool,
+    architecture: str,
+    message: str,
+):
+    with pytest.raises(VLLMValidationError) as exc_info:
+        validate_score_input(
+            data_1,
+            data_2,
+            is_multimodal_model=is_multimodal_model,
+            architecture=architecture,
+        )
+
+    assert str(exc_info.value) == message
+    assert exc_info.value.parameter is None
+    assert exc_info.value.value is None

--- a/vllm/entrypoints/pooling/scoring/utils.py
+++ b/vllm/entrypoints/pooling/scoring/utils.py
@@ -15,6 +15,7 @@ from vllm.entrypoints.chat_utils import (
     MultiModalItemTracker,
     _parse_chat_message_content_parts,
 )
+from vllm.exceptions import VLLMValidationError
 from vllm.inputs import MultiModalDataDict, MultiModalUUIDDict
 
 from .typing import (
@@ -85,7 +86,9 @@ def _validate_mm_score_input(
             out.append(d)
         else:
             if not is_multimodal_model:
-                raise ValueError(f"MultiModalParam is not supported for {architecture}")
+                raise VLLMValidationError(
+                    f"MultiModalParam is not supported for {architecture}"
+                )
             content = cast(list[ScoreContentPartParam], d.get("content", []))
             out.append(content)
     return out
@@ -99,11 +102,11 @@ def _validate_score_input_lens(
     len_2 = len(data_2)
 
     if len_1 > 1 and len_1 != len_2:
-        raise ValueError("Input lengths must be either 1:1, 1:N or N:N")
+        raise VLLMValidationError("Input lengths must be either 1:1, 1:N or N:N")
     if len_1 == 0:
-        raise ValueError("At least one text element must be given")
+        raise VLLMValidationError("At least one text element must be given")
     if len_2 == 0:
-        raise ValueError("At least one text_pair element must be given")
+        raise VLLMValidationError("At least one text_pair element must be given")
 
 
 def validate_score_input(


### PR DESCRIPTION
## Purpose

Part of #48227.

Migrate four client-caused validation errors in `vllm/entrypoints/pooling/scoring/utils.py` from raw `ValueError` to `VLLMValidationError`:

- unsupported multimodal input
- incompatible input lengths
- empty first input
- empty second input

This preserves the existing validation behavior and error messages. The `parameter` and `value` fields remain unset because this utility is shared by `/score`, `/rerank`, and offline `LLM.score()`, whose public parameter names differ.

Online serving continues to map these errors to HTTP 400. Offline callers now receive the typed `VLLMValidationError` instead of `ValueError`, as intended by the RFC migration.

## Duplicate-work check

I searched open PRs for #48227 and for scoring-related `VLLMValidationError` changes and inspected the current `main` implementation. I found no open PR migrating these four errors. I also discussed this narrow file-level scope in #48227 before implementation.

AI assistance disclosure: Codex assisted with implementation, test generation, and review. I reviewed and understand all changed lines and validated the behavior locally.

## Test Plan

```bash
pytest -q tests/entrypoints/pooling/scoring/test_utils.py
pre-commit run --from-ref origin/main --to-ref HEAD
```

## Test Result

```text
4 passed in 0.32s
All applicable pre-commit hooks passed.
```
