### PR TITLE
[MoE][NVIDIA] Add shared expert fusion for TRTLLM FP8

### DIFF
--- a/tests/kernels/moe/test_moe_layer.py
+++ b/tests/kernels/moe/test_moe_layer.py
@@ -26,6 +26,7 @@ from tests.kernels.moe.modular_kernel_tools.parallel_utils import (
 from tests.kernels.moe.utils import TestMLP, make_test_weights, moe_quantize_weights
 from vllm.config import (
     CompilationConfig,
+    KernelConfig,
     ParallelConfig,
     SchedulerConfig,
     VllmConfig,
@@ -1013,6 +1014,8 @@ def make_fused_moe_layer(
     routed_output_transform: torch.nn.Module | None = None,
     pcp_size: int | None = 1,
     is_sequence_parallel: bool = False,
+    n_shared_experts: int | None = None,
+    fuse_shared_experts: bool | None = None,
 ) -> MoERunner:
     quant_config, qw = make_quant_config(quantization, w1, w2, global_num_experts)
 
@@ -1052,6 +1055,8 @@ def make_fused_moe_layer(
         num_redundant_experts=num_redundant_experts,
         has_bias=has_bias,
         is_sequence_parallel=is_sequence_parallel,
+        n_shared_experts=n_shared_experts,
+        fuse_shared_experts=fuse_shared_experts,
         **kwargs,
     )
 
@@ -1598,6 +1603,112 @@ def _run_one_config(
         torch.testing.assert_close(expected, actual, atol=atol, rtol=rtol)
     finally:
         torch.accelerator.synchronize()
+
+
+def test_fused_shared_experts_cuda() -> None:
+    """A shared expert can run as an always-on CUDA grouped-GEMM slot."""
+    if not current_platform.is_cuda():
+        pytest.skip("CUDA-only shared-expert fusion test")
+
+    set_random_seed(7)
+    device = torch.accelerator.current_accelerator()
+    num_tokens = 8
+    hidden_size = 256
+    intermediate_size = 128
+    num_routed_experts = 4
+    num_shared_experts = 1
+    top_k = 2
+    num_total_experts = num_routed_experts + num_shared_experts
+    dtype = torch.bfloat16
+    if not is_workspace_manager_initialized():
+        init_workspace_manager(device)
+
+    hidden_states = torch.randn(num_tokens, hidden_size, device=device, dtype=dtype)
+    router_logits = torch.randn(
+        num_tokens, num_routed_experts, device=device, dtype=dtype
+    )
+    w1 = (
+        torch.randn(
+            num_total_experts,
+            2 * intermediate_size,
+            hidden_size,
+            device=device,
+            dtype=dtype,
+        )
+        / 10
+    )
+    w2 = (
+        torch.randn(
+            num_total_experts,
+            hidden_size,
+            intermediate_size,
+            device=device,
+            dtype=dtype,
+        )
+        / 10
+    )
+
+    vllm_config = VllmConfig(
+        parallel_config=ParallelConfig(),
+        compilation_config=CompilationConfig(),
+        kernel_config=KernelConfig(moe_backend="triton"),
+        scheduler_config=SchedulerConfig.default_factory(max_num_batched_tokens=128),
+    )
+    _set_vllm_config(vllm_config, 1, rank=0, local_rank=0)
+
+    with set_current_vllm_config(vllm_config):
+        layer = make_fused_moe_layer(
+            quantization=None,
+            use_ep=False,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            in_dtype=dtype,
+            tp_size=1,
+            ep_size=1,
+            dp_size=1,
+            w1=w1,
+            w2=w2,
+            top_k=top_k,
+            global_num_experts=num_routed_experts,
+            renormalize=True,
+            n_shared_experts=num_shared_experts,
+            fuse_shared_experts=True,
+        )
+
+        with set_forward_context(
+            None,
+            vllm_config,
+            num_tokens=num_tokens,
+            num_tokens_across_dp=torch.tensor([num_tokens], device=device),
+        ):
+            actual = layer(hidden_states, router_logits)
+
+    routed_weights = torch.softmax(router_logits.float(), dim=-1)
+    routed_weights, routed_ids = torch.topk(routed_weights, top_k, dim=-1)
+    routed_weights /= routed_weights.sum(dim=-1, keepdim=True)
+    shared_ids = torch.full(
+        (num_tokens, 1), num_routed_experts, device=device, dtype=routed_ids.dtype
+    )
+    shared_weights = torch.ones(
+        (num_tokens, 1), device=device, dtype=routed_weights.dtype
+    )
+    expert_ids = torch.cat((routed_ids, shared_ids), dim=-1)
+    expert_weights = torch.cat((routed_weights, shared_weights), dim=-1)
+
+    expected = torch.zeros_like(hidden_states)
+    for token_id in range(num_tokens):
+        for slot in range(top_k + num_shared_experts):
+            expert_id = expert_ids[token_id, slot]
+            gate_up = torch.nn.functional.linear(hidden_states[token_id], w1[expert_id])
+            gate, up = gate_up.chunk(2, dim=-1)
+            expert_out = torch.nn.functional.linear(
+                torch.nn.functional.silu(gate) * up, w2[expert_id]
+            )
+            expected[token_id] += expert_out * expert_weights[token_id, slot]
+
+    assert not layer.is_monolithic
+    assert layer.routed_experts.w13_weight.shape[0] == num_total_experts
+    torch.testing.assert_close(actual, expected, atol=4e-2, rtol=4e-2)
 
 
 # Test for non-parallel cases (world_size == 1) - backend doesn't matter

--- a/tests/kernels/moe/test_routing.py
+++ b/tests/kernels/moe/test_routing.py
@@ -75,6 +75,95 @@ def test_degenerate_grouped_config_uses_standard_topk() -> None:
     )
 
 
+def test_standard_router_appends_fused_shared_experts() -> None:
+    num_experts = 8
+    num_shared = 2
+    top_k = 2
+    shared_weight = 0.75
+    router = create_fused_moe_router(
+        top_k=top_k,
+        global_num_experts=num_experts,
+        renormalize=True,
+        num_fused_shared_experts=num_shared,
+        shared_expert_weight=shared_weight,
+    )
+    hidden_states, router_logits = make_test_data(4, 16, num_experts)
+
+    weights, ids = router.select_experts(hidden_states, router_logits)
+    routed_weights, routed_ids = baseline_fused_topk(
+        router_logits, top_k=top_k, renormalize=True
+    )
+
+    assert_routing_results_close(
+        weights[:, :top_k],
+        ids[:, :top_k],
+        routed_weights,
+        routed_ids,
+    )
+    torch.testing.assert_close(
+        ids[:, top_k:],
+        torch.tensor(
+            [num_experts, num_experts + 1], device="cuda", dtype=ids.dtype
+        ).expand(4, 2),
+    )
+    torch.testing.assert_close(
+        weights[:, top_k:],
+        torch.full((4, num_shared), shared_weight, device="cuda"),
+    )
+
+
+def test_standard_router_can_defer_fused_shared_experts() -> None:
+    num_experts = 8
+    top_k = 2
+    router = create_fused_moe_router(
+        top_k=top_k,
+        global_num_experts=num_experts,
+        renormalize=True,
+        num_fused_shared_experts=1,
+    )
+    router.defer_fused_shared_experts = True
+    hidden_states, router_logits = make_test_data(4, 16, num_experts)
+
+    weights, ids = router.select_experts(hidden_states, router_logits)
+
+    assert weights.shape == (4, top_k)
+    assert ids.shape == (4, top_k)
+
+
+def test_standard_router_uses_fused_shared_expert_gate() -> None:
+    num_experts = 8
+    num_shared = 1
+    top_k = 2
+    router = create_fused_moe_router(
+        top_k=top_k,
+        global_num_experts=num_experts,
+        renormalize=True,
+        num_fused_shared_experts=num_shared,
+    )
+    router.defer_fused_shared_experts = True
+    hidden_states, routed_logits = make_test_data(4, 16, num_experts)
+    shared_logits = torch.tensor([[0.0], [1.0], [-1.0], [2.0]], device="cuda")
+
+    weights, ids = router.select_experts(
+        hidden_states, torch.cat((routed_logits, shared_logits), dim=-1)
+    )
+    routed_weights, routed_ids = baseline_fused_topk(
+        routed_logits, top_k=top_k, renormalize=True
+    )
+
+    assert_routing_results_close(
+        weights[:, :top_k],
+        ids[:, :top_k],
+        routed_weights,
+        routed_ids,
+    )
+    torch.testing.assert_close(
+        ids[:, top_k:],
+        torch.full((4, num_shared), num_experts, device="cuda", dtype=ids.dtype),
+    )
+    torch.testing.assert_close(weights[:, top_k:], torch.sigmoid(shared_logits))
+
+
 def test_multiple_expert_groups_use_grouped_topk() -> None:
     router = create_fused_moe_router(
         top_k=4,

--- a/tests/kernels/moe/test_unquantized_backend_selection.py
+++ b/tests/kernels/moe/test_unquantized_backend_selection.py
@@ -482,6 +482,17 @@ def test_select_lora_backend_prefers_triton():
     assert experts_cls is not None
 
 
+@pytest.mark.skipif(not current_platform.is_cuda(), reason="CUDA-specific test")
+def test_fused_shared_experts_select_modular_backend():
+    moe_config = make_dummy_moe_config()
+    moe_config.num_fused_shared_experts = 1
+
+    _, experts_cls = select_unquantized_moe_backend(moe_config=moe_config)
+
+    assert experts_cls is not None
+    assert not experts_cls.is_monolithic()
+
+
 @skipif_not_cuda_rocm
 def test_select_lora_explicit_non_triton_backend():
     """LoRA should override explicit non-Triton backend to Triton."""

--- a/tests/models/deepseek_v32/test_sequence_parallel.py
+++ b/tests/models/deepseek_v32/test_sequence_parallel.py
@@ -7,6 +7,7 @@ from unittest.mock import Mock
 import torch
 from torch import nn
 
+from vllm.model_executor.layers.quantization.fp8 import Fp8Config
 from vllm.models.deepseek_v32.nvidia import model as deepseek_v32_model
 from vllm.models.deepseek_v32.nvidia import mtp as deepseek_v32_mtp
 
@@ -60,6 +61,55 @@ class _SequenceParallelMTPBlock:
     ):
         assert residual is None
         return hidden_states * 2, hidden_states * 3
+
+
+def test_shared_expert_fusion_requires_matching_fp8_storage():
+    prefix = "model.layers.3.mlp"
+    matching_fp8 = Fp8Config(
+        is_checkpoint_fp8_serialized=True,
+        activation_scheme="dynamic",
+        weight_block_size=[128, 128],
+    )
+    mismatched_fp8 = Fp8Config(
+        is_checkpoint_fp8_serialized=True,
+        activation_scheme="dynamic",
+        ignored_layers=[f"{prefix}.shared_experts"],
+        weight_block_size=[128, 128],
+    )
+
+    assert deepseek_v32_model._can_fuse_shared_experts(None, prefix)
+    assert deepseek_v32_model._can_fuse_shared_experts(matching_fp8, prefix)
+    assert not deepseek_v32_model._can_fuse_shared_experts(mismatched_fp8, prefix)
+
+
+def test_shared_expert_fusion_loader_decision_is_per_layer(monkeypatch):
+    class FakeMoE(nn.Module):
+        def __init__(self, enabled: bool) -> None:
+            super().__init__()
+            self.is_fusion_moe_shared_experts_enabled = enabled
+
+    monkeypatch.setattr(deepseek_v32_model, "DeepseekV2MoE", FakeMoE)
+    fusion_by_layer = deepseek_v32_model._get_shared_expert_fusion_by_layer(
+        (("layers.2.mlp", FakeMoE(True)), ("layers.3.mlp", FakeMoE(False)))
+    )
+
+    assert fusion_by_layer == {2: True, 3: False}
+
+    weights = (
+        ("model.layers.2.mlp.shared_experts.gate_proj.weight", torch.ones(2, 1)),
+        ("model.layers.3.mlp.shared_experts.gate_proj.weight", torch.ones(2, 1)),
+    )
+    transformed = list(
+        deepseek_v32_model._fuse_shared_expert_weights_by_layer(
+            weights,
+            fusion_by_layer,
+            n_routed_experts=8,
+            n_shared_experts=1,
+        )
+    )
+
+    assert transformed[0][0] == "model.layers.2.mlp.experts.8.gate_proj.weight"
+    assert transformed[1][0] == weights[1][0]
 
 
 def _mock_sequence_parallel_collectives(monkeypatch, module):

--- a/tests/quantization/test_fp8.py
+++ b/tests/quantization/test_fp8.py
@@ -6,11 +6,14 @@ Run `pytest tests/quantization/test_fp8.py --forked`.
 """
 
 import logging
+from types import SimpleNamespace
+from unittest.mock import Mock
 
 import pytest
 import regex as re
 import torch
 
+import vllm.model_executor.layers.fused_moe.modular_kernel as mk
 from tests.quantization.utils import is_quant_method_supported
 from vllm import _custom_ops as ops
 from vllm.config.model import ModelConfig
@@ -21,6 +24,13 @@ from vllm.model_executor.layers.attention.attention import (
     set_default_quant_scales,
 )
 from vllm.model_executor.layers.fused_moe import FusedMoEFactory
+from vllm.model_executor.layers.fused_moe.experts.trtllm_fp8_moe import (
+    TrtLlmFp8ExpertsBase,
+    TrtLlmFp8ExpertsModular,
+)
+from vllm.model_executor.layers.fused_moe.utils import (
+    trtllm_moe_pack_topk_ids_weights,
+)
 from vllm.model_executor.layers.quantization.fp8 import (
     Fp8Config,
     Fp8KVCacheMethod,
@@ -30,6 +40,13 @@ from vllm.model_executor.layers.quantization.fp8 import (
 from vllm.model_executor.layers.quantization.kv_cache import BaseKVCacheMethod
 from vllm.model_executor.layers.quantization.online.fp8 import (
     Fp8PerTensorOnlineLinearMethod,
+)
+from vllm.model_executor.layers.quantization.utils.flashinfer_utils import (
+    prepare_fp8_moe_layer_for_fi,
+)
+from vllm.model_executor.layers.quantization.utils.quant_utils import (
+    kFp8Dynamic128Sym,
+    kFp8Static128BlockSym,
 )
 from vllm.model_executor.model_loader.weight_utils import default_weight_loader
 from vllm.platforms import current_platform
@@ -45,6 +62,252 @@ MODELS = [
         marks=pytest.mark.skip(reason="Checkpoint removed from HF."),
     ),
 ]
+
+
+def test_fp8_moe_modular_apply_includes_fused_shared_experts():
+    method = object.__new__(Fp8MoEMethod)
+    method.moe_kernel = Mock(is_monolithic=False)
+    layer = Mock(
+        kernel_global_num_experts=257,
+        global_num_experts=256,
+        activation=Mock(),
+        expert_map=None,
+        apply_router_weight_on_input=False,
+    )
+    layer.w13_weight = torch.empty(257, 1, 1)
+    layer.w2_weight = torch.empty(257, 1, 1)
+
+    method.apply(
+        layer=layer,
+        x=torch.empty(1, 1),
+        topk_weights=torch.empty(1, 9),
+        topk_ids=torch.empty(1, 9, dtype=torch.int32),
+        shared_experts=None,
+        shared_experts_input=None,
+    )
+
+    assert method.moe_kernel.apply.call_args.kwargs["global_num_experts"] == 257
+
+
+@pytest.mark.parametrize(
+    (
+        "num_experts",
+        "num_fused_shared_experts",
+        "is_monolithic",
+        "expected_reason",
+    ),
+    [
+        (256, 0, False, None),
+        (256, 1, False, None),
+        (2048, 1, False, "at most 2048"),
+    ],
+)
+def test_trtllm_fp8_moe_validates_kernel_expert_count(
+    monkeypatch,
+    num_experts,
+    num_fused_shared_experts,
+    is_monolithic,
+    expected_reason,
+):
+    monkeypatch.setattr(
+        mk.FusedMoEExperts,
+        "is_supported_config",
+        staticmethod(lambda *args: (True, None)),
+    )
+    moe_config = Mock(
+        num_experts=num_experts,
+        num_fused_shared_experts=num_fused_shared_experts,
+    )
+    experts_cls = Mock(
+        is_monolithic=Mock(return_value=is_monolithic),
+    )
+
+    supported, reason = TrtLlmFp8ExpertsBase.is_supported_config(
+        experts_cls,
+        moe_config,
+        kFp8Static128BlockSym,
+        kFp8Dynamic128Sym,
+        Mock(),
+    )
+
+    assert supported is (expected_reason is None)
+    if expected_reason is not None:
+        assert reason is not None
+        assert expected_reason in reason
+
+
+def test_flashinfer_trtllm_pads_fused_shared_expert_rows(monkeypatch):
+    monkeypatch.setattr(
+        "vllm.model_executor.layers.quantization.utils.flashinfer_utils."
+        "_shuffle_deepseek_fp8_moe_weights",
+        lambda w13, w2: (w13, w2),
+    )
+    layer = SimpleNamespace(
+        moe_config=SimpleNamespace(
+            is_act_and_mul=True,
+            num_fused_shared_experts=1,
+        ),
+        weight_block_size=[128, 128],
+        activation=SimpleNamespace(is_gated=True),
+        quant_method=SimpleNamespace(is_monolithic=False),
+    )
+    w13 = torch.full((257, 256, 128), 2, dtype=torch.float8_e4m3fn)
+    w2 = torch.full((257, 128, 128), 3, dtype=torch.float8_e4m3fn)
+    w13_scale = torch.full((257, 2, 1), 4.0)
+    w2_scale = torch.full((257, 1, 1), 5.0)
+
+    padded = prepare_fp8_moe_layer_for_fi(
+        layer,
+        w13,
+        w2,
+        w13_scale,
+        None,
+        w2_scale,
+        None,
+        is_trtllm=True,
+    )
+
+    padded_w13, padded_w2, padded_w13_scale, padded_w2_scale = padded
+    assert padded_w13.shape[0] == 260
+    assert padded_w2.shape[0] == 260
+    assert padded_w13_scale.shape[0] == 260
+    assert padded_w2_scale.shape[0] == 260
+    assert not padded_w13[257:].float().count_nonzero()
+    assert not padded_w2[257:].float().count_nonzero()
+    assert (padded_w13_scale[257:] == 1).all()
+    assert (padded_w2_scale[257:] == 1).all()
+
+
+def test_trtllm_fp8_modular_uses_padded_fused_expert_count(monkeypatch):
+    experts = object.__new__(TrtLlmFp8ExpertsModular)
+    experts.intermediate_size_per_partition = 128
+    experts.local_num_experts = 257
+    experts.ep_rank = 0
+    experts.topk = 8
+    experts.moe_config = Mock(
+        num_experts=256,
+        num_fused_shared_experts=1,
+        fused_shared_expert_weight=1.0,
+        max_num_tokens=1,
+        dp_size=1,
+    )
+    experts.quant_config = Mock(
+        block_shape=[128, 128],
+        w1_scale=torch.empty(1),
+        w2_scale=torch.empty(1),
+    )
+    experts.gemm1_alpha = None
+    experts.gemm1_beta = None
+    experts.gemm1_clamp_limit = None
+
+    pack = Mock(return_value=torch.empty(1, 9, dtype=torch.int32))
+    monkeypatch.setattr(
+        "vllm.model_executor.layers.fused_moe.experts.trtllm_fp8_moe."
+        "trtllm_moe_pack_topk_ids_weights",
+        pack,
+    )
+    import flashinfer
+
+    kernel = Mock()
+    monkeypatch.setattr(
+        flashinfer.fused_moe,
+        "trtllm_fp8_block_scale_routed_moe",
+        kernel,
+    )
+    experts.apply(
+        output=torch.empty(1, 128),
+        hidden_states=torch.empty(1, 128),
+        w1=torch.empty(260, 1, 1),
+        w2=torch.empty(260, 1, 1),
+        topk_weights=torch.empty(1, 8),
+        topk_ids=torch.empty(1, 8, dtype=torch.int32),
+        activation=mk.MoEActivation.SILU,
+        global_num_experts=257,
+        expert_map=None,
+        a1q_scale=torch.empty(1, 1),
+        a2_scale=None,
+        workspace13=torch.empty(0),
+        workspace2=torch.empty(0),
+        expert_tokens_meta=None,
+        apply_router_weight_on_input=False,
+    )
+
+    assert kernel.call_args.kwargs["num_experts"] == 260
+    assert kernel.call_args.kwargs["local_num_experts"] == 260
+    assert kernel.call_args.kwargs["top_k"] == 9
+    assert pack.call_args.kwargs == {
+        "num_fused_shared_experts": 1,
+        "first_shared_expert_id": 256,
+        "fused_shared_expert_weight": 1.0,
+    }
+
+
+@pytest.mark.skipif(not current_platform.is_cuda(), reason="Requires CUDA")
+def test_trtllm_pack_appends_fused_shared_experts() -> None:
+    routed_ids = torch.tensor([[3, 1], [0, 2]], dtype=torch.int32, device="cuda")
+    routed_weights = torch.tensor(
+        [[0.75, 0.25], [0.625, 0.375]], dtype=torch.float32, device="cuda"
+    )
+    shared_ids = torch.tensor([[4], [4]], dtype=torch.int32, device="cuda")
+    shared_weights = torch.full((2, 1), 0.5, dtype=torch.float32, device="cuda")
+
+    expected = trtllm_moe_pack_topk_ids_weights(
+        torch.cat((routed_ids, shared_ids), dim=1),
+        torch.cat((routed_weights, shared_weights), dim=1),
+    )
+    actual = trtllm_moe_pack_topk_ids_weights(
+        routed_ids,
+        routed_weights,
+        num_fused_shared_experts=1,
+        first_shared_expert_id=4,
+        fused_shared_expert_weight=0.5,
+    )
+
+    torch.testing.assert_close(actual, expected)
+
+
+@pytest.mark.parametrize(
+    ("native_fused_shared_experts", "expected"),
+    [(False, False), (True, True)],
+)
+def test_monolithic_kernel_must_handle_fused_shared_experts_natively(
+    native_fused_shared_experts,
+    expected,
+):
+    experts_cls = Mock(
+        _supports_current_device=Mock(return_value=True),
+        _supports_activation=Mock(return_value=True),
+        _supports_quant_scheme=Mock(return_value=True),
+        _supports_parallel_config=Mock(return_value=True),
+        _supports_routing_method=Mock(return_value=True),
+        _supports_router_logits_dtype=Mock(return_value=True),
+        _supports_shape=Mock(return_value=True),
+        activation_format=Mock(return_value=mk.FusedMoEActivationFormat.Standard),
+        is_monolithic=Mock(return_value=True),
+        supports_native_fused_shared_experts=Mock(
+            return_value=native_fused_shared_experts
+        ),
+    )
+    moe_config = Mock(
+        is_act_and_mul=True,
+        activation=Mock(),
+        moe_parallel_config=Mock(),
+        routing_method=Mock(),
+        router_logits_dtype=torch.float32,
+        hidden_dim=128,
+        is_lora_enabled=False,
+        num_fused_shared_experts=1,
+    )
+
+    supported, _ = mk.FusedMoEExperts.is_supported_config(
+        experts_cls,
+        moe_config,
+        None,
+        None,
+        mk.FusedMoEActivationFormat.Standard,
+    )
+
+    assert supported is expected
 
 
 @pytest.mark.skipif(

--- a/vllm/model_executor/layers/fused_moe/config.py
+++ b/vllm/model_executor/layers/fused_moe/config.py
@@ -1305,6 +1305,12 @@ class FusedMoEConfig:
     has_bias: bool = False
     is_lora_enabled: bool = False
 
+    # Shared experts represented as always-on expert slots. Modular kernels
+    # consume appended routing assignments; capable monolithic kernels handle
+    # the shared slots internally.
+    num_fused_shared_experts: int = 0
+    fused_shared_expert_weight: float = 1.0
+
     # When True, the MoE skips its final cross-rank all-reduce (and the separate
     # shared-expert reduce), returning the partial per-rank sum. The caller is
     # then responsible for the reduction (e.g. fusing it into the next RMSNorm).

--- a/vllm/model_executor/layers/fused_moe/expert_map_manager.py
+++ b/vllm/model_executor/layers/fused_moe/expert_map_manager.py
@@ -256,7 +256,7 @@ class ExpertMapManager:
             )
 
     def _init_aiter_shared_experts_topK_buffer(self):
-        if self.num_fused_shared_experts > 0:
+        if self.rocm_aiter_enabled and self.num_fused_shared_experts > 0:
             dp_size = self.moe_parallel_config.dp_size
             init_aiter_topK_meta_data(
                 n_routed_experts=self.global_num_experts,

--- a/vllm/model_executor/layers/fused_moe/experts/trtllm_fp8_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/trtllm_fp8_moe.py
@@ -57,12 +57,29 @@ class TrtLlmFp8ExpertsBase:
             activation_key,
             activation_format,
         )
-        if not supported or moe_config.num_experts <= 2048:
+        if not supported:
             return supported, reason
-        return False, (
-            "FlashInfer TRTLLM routing supports at most 2048 experts, "
-            f"but got {moe_config.num_experts}"
+        kernel_num_experts = moe_config.num_experts
+        can_pad_fused_shared_experts = (
+            moe_config.num_fused_shared_experts > 0
+            and not cls.is_monolithic()
+            and (weight_key, activation_key)
+            == (kFp8Static128BlockSym, kFp8Dynamic128Sym)
         )
+        if can_pad_fused_shared_experts:
+            kernel_num_experts += moe_config.num_fused_shared_experts
+            kernel_num_experts = (kernel_num_experts + 3) // 4 * 4
+        if kernel_num_experts > 2048:
+            return False, (
+                "FlashInfer TRTLLM routing supports at most 2048 experts, "
+                f"but got {kernel_num_experts}"
+            )
+        if kernel_num_experts % 4 != 0:
+            return False, (
+                "FlashInfer TRTLLM routing requires the expert count to be "
+                f"divisible by 4, but got {kernel_num_experts}"
+            )
+        return True, None
 
     def __init__(
         self,
@@ -176,6 +193,10 @@ class TrtLlmFp8ExpertsModular(TrtLlmFp8ExpertsBase, mk.FusedMoEExpertsModular):
         ]
         return (weight_key, activation_key) in SUPPORTED_W_A
 
+    @staticmethod
+    def supports_packed_fused_shared_experts() -> bool:
+        return True
+
     def moe_problem_size(
         self,
         a1: torch.Tensor,
@@ -236,8 +257,23 @@ class TrtLlmFp8ExpertsModular(TrtLlmFp8ExpertsBase, mk.FusedMoEExpertsModular):
         import flashinfer
         from flashinfer.fused_moe import Fp8QuantizationType, WeightLayout
 
-        # Pack topk ids and weights into format expected by the kernel.
-        packed_topk_ids = trtllm_moe_pack_topk_ids_weights(topk_ids, topk_weights)
+        num_packed_shared_experts = 0
+        if (
+            self.moe_config.num_fused_shared_experts > 0
+            and topk_ids.size(1) == self.topk
+        ):
+            num_packed_shared_experts = self.moe_config.num_fused_shared_experts
+
+        # Pack topk ids and weights into the format expected by the kernel.
+        # When routing deferred the always-on shared slots, synthesize them in
+        # this same kernel instead of materializing and concatenating tensors.
+        packed_topk_ids = trtllm_moe_pack_topk_ids_weights(
+            topk_ids,
+            topk_weights,
+            num_fused_shared_experts=num_packed_shared_experts,
+            first_shared_expert_id=self.moe_config.num_experts,
+            fused_shared_expert_weight=self.moe_config.fused_shared_expert_weight,
+        )
 
         assert a1q_scale is not None
 
@@ -253,6 +289,13 @@ class TrtLlmFp8ExpertsModular(TrtLlmFp8ExpertsBase, mk.FusedMoEExpertsModular):
             weight_layout = WeightLayout.BlockMajorK
             hidden_states_scale = a1q_scale.t().contiguous()
 
+        kernel_num_experts = global_num_experts
+        kernel_local_num_experts = self.local_num_experts
+        if self.moe_config.num_fused_shared_experts > 0:
+            assert self.ep_rank == 0
+            kernel_num_experts = w1.shape[0]
+            kernel_local_num_experts = w1.shape[0]
+
         flashinfer.fused_moe.trtllm_fp8_block_scale_routed_moe(
             topk_ids=packed_topk_ids,
             routing_bias=None,
@@ -265,13 +308,13 @@ class TrtLlmFp8ExpertsModular(TrtLlmFp8ExpertsBase, mk.FusedMoEExpertsModular):
             gemm1_clamp_limit=self.gemm1_clamp_limit,
             gemm2_weights=w2,
             gemm2_weights_scale=self.quant_config.w2_scale,
-            num_experts=global_num_experts,
-            top_k=topk_ids.size(1),
+            num_experts=kernel_num_experts,
+            top_k=packed_topk_ids.size(1),
             n_group=None,
             topk_group=None,
             intermediate_size=self.intermediate_size_per_partition,
             local_expert_offset=self.ep_rank * self.local_num_experts,
-            local_num_experts=self.local_num_experts,
+            local_num_experts=kernel_local_num_experts,
             routed_scaling_factor=None,
             routing_method_type=1,  # not used
             use_shuffled_weight=use_shuffled_weight,

--- a/vllm/model_executor/layers/fused_moe/fused_moe_method_base.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe_method_base.py
@@ -45,6 +45,14 @@ class FusedMoEMethodBase(QuantizeMethodBase):
             self.moe_kernel is not None and self.moe_kernel.can_overlap_shared_experts
         )
 
+    @property
+    def supports_packed_fused_shared_experts(self) -> bool:
+        return (
+            self.moe_kernel is not None
+            and not self.moe_kernel.is_monolithic
+            and self.moe_kernel.fused_experts.supports_packed_fused_shared_experts()
+        )
+
     @abstractmethod
     def create_weights(
         self,

--- a/vllm/model_executor/layers/fused_moe/fused_moe_modular_method.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe_modular_method.py
@@ -95,7 +95,7 @@ class FusedMoEModularMethod(FusedMoEMethodBase, CustomOp):
             topk_weights=topk_weights,
             topk_ids=topk_ids,
             activation=layer.activation,
-            global_num_experts=layer.global_num_experts,
+            global_num_experts=layer.kernel_global_num_experts,
             apply_router_weight_on_input=layer.apply_router_weight_on_input,
             expert_map=layer.expert_map,
             shared_experts=shared_experts,

--- a/vllm/model_executor/layers/fused_moe/layer.py
+++ b/vllm/model_executor/layers/fused_moe/layer.py
@@ -25,6 +25,7 @@ from vllm.model_executor.layers.fused_moe.expert_map_manager import (
     ExpertMapManager,
 )
 from vllm.model_executor.layers.fused_moe.routed_experts import RoutedExperts
+from vllm.model_executor.layers.fused_moe.router.base_router import BaseRouter
 from vllm.model_executor.layers.fused_moe.router.fused_moe_router import (
     FusedMoERouter,
 )
@@ -75,23 +76,23 @@ def determine_expert_counts(
     num_redundant_experts: int,
     n_shared_experts: int | None,
     is_act_and_mul: bool,
+    fuse_shared_experts: bool | None,
 ) -> tuple[int, int, int]:
     global_num_experts = num_experts + num_redundant_experts
     logical_num_experts = num_experts
-    # Shared-expert fusion: append the shared expert(s) as routed-expert slots
-    # so they run in the same grouped GEMM. Gated by
-    # VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS: either the native aiter fused-MoE
-    # path (env + master switch, via is_fusion_moe_shared_experts_enabled) or the
-    # backend-neutral router-append path (env alone, independent of the master
-    # switch; e.g. the MM3 triton/flydsl mxfp8 MoE). Gated activations only.
-    fuse_shared_enabled = (
-        rocm_aiter_ops.is_fusion_moe_shared_experts_enabled()
-        or envs.VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS
-    ) and is_act_and_mul
+    # Appended shared experts use the same packed weights and activation as the
+    # routed experts, so only gated expert MLPs support this representation.
+    if n_shared_experts is not None and n_shared_experts < 0:
+        raise ValueError("n_shared_experts must be non-negative")
+    if fuse_shared_experts is None:
+        fuse_shared_experts = (
+            rocm_aiter_ops.is_fusion_moe_shared_experts_enabled()
+            or envs.VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS
+        )
+    if n_shared_experts and fuse_shared_experts and not is_act_and_mul:
+        raise ValueError("Fused shared experts require a gated MoE activation")
 
-    num_fused_shared_experts = (
-        n_shared_experts if n_shared_experts is not None and fuse_shared_enabled else 0
-    )
+    num_fused_shared_experts = (n_shared_experts or 0) if fuse_shared_experts else 0
 
     return global_num_experts, logical_num_experts, num_fused_shared_experts
 
@@ -131,6 +132,7 @@ def FusedMoEFactory(
     reduce_results: bool = True,
     ckpt_names: tuple[str, str, str] = ("gate_proj", "down_proj", "up_proj"),
     n_shared_experts: int | None = None,
+    fuse_shared_experts: bool | None = None,
     router_logits_dtype: torch.dtype | None = None,
     gate: torch.nn.Module | None = None,
     shared_experts: torch.nn.Module | None = None,
@@ -194,7 +196,11 @@ def FusedMoEFactory(
         ckpt_names: Checkpoint parameter name tuple (gate_proj, down_proj,
             up_proj) used for weight loading
         n_shared_experts: Number of shared experts to fuse into the routed
-            grouped GEMM (ROCm; requires aiter FSE or the router-append path)
+            grouped GEMM. These experts must use the routed experts' weight
+            dtype, quantization format, activation, and intermediate size.
+        fuse_shared_experts: Explicitly enable or disable shared-expert fusion.
+            ``True`` enables the modular CUDA path. ``None`` preserves the
+            existing ROCm environment-controlled behavior.
         router_logits_dtype: Data type for router logits buffers
         gate: Pre-configured gate module
         shared_experts: Pre-configured shared experts module
@@ -242,8 +248,23 @@ def FusedMoEFactory(
             num_redundant_experts,
             n_shared_experts,
             is_act_and_mul,
+            fuse_shared_experts,
         )
     )
+
+    native_aiter_shared_experts = (
+        num_fused_shared_experts > 0
+        and rocm_aiter_ops.is_fusion_moe_shared_experts_enabled()
+    )
+    if (
+        num_fused_shared_experts > 0
+        and (moe_parallel_config.use_ep or enable_eplb)
+        and not native_aiter_shared_experts
+    ):
+        raise ValueError(
+            "Fused shared experts with expert parallelism or EPLB currently "
+            "require the ROCm AITER fused-shared-expert path."
+        )
 
     # Initialize EPLB manager (or None?)
     eplb_state: EplbLayerState | None = None
@@ -282,6 +303,16 @@ def FusedMoEFactory(
 
     # TODO(bnell): we should not have to create a router if the kernel is
     # monolithic.
+    shared_expert_weight = (
+        1.0 / routed_scaling_factor
+        if (
+            apply_routed_scale_to_output
+            and num_fused_shared_experts > 0
+            and routed_scaling_factor
+        )
+        else 1.0
+    )
+
     if router is None:
         router = create_fused_moe_router(
             top_k=top_k,
@@ -307,18 +338,21 @@ def FusedMoEFactory(
             # the runner scales the combined output by routed_scaling_factor, so
             # the shared slot weight must be 1/routed_scaling_factor for its net
             # contribution to be 1.0 (matching the un-scaled separate-MLP add).
-            shared_expert_weight=(
-                (1.0 / routed_scaling_factor)
-                if (
-                    apply_routed_scale_to_output
-                    and num_fused_shared_experts > 0
-                    and routed_scaling_factor
-                )
-                else 1.0
-            ),
+            shared_expert_weight=shared_expert_weight,
             zero_expert_type=zero_expert_type,
             num_logical_experts=logical_num_experts,
             hash_indices_table=hash_indices_table,
+        )
+
+    if num_fused_shared_experts > 0:
+        if not isinstance(router, BaseRouter):
+            raise ValueError(
+                "Fused shared experts require a BaseRouter-compatible router, got "
+                f"{type(router).__name__}."
+            )
+        router.configure_fused_shared_experts(
+            num_fused_shared_experts,
+            shared_expert_weight,
         )
 
     if params_dtype is None:
@@ -359,6 +393,8 @@ def FusedMoEFactory(
         activation_situ_linear_beta=activation_situ_linear_beta,
         max_capture_size=vllm_config.compilation_config.max_cudagraph_capture_size,
         skip_final_all_reduce=skip_final_all_reduce,
+        num_fused_shared_experts=num_fused_shared_experts,
+        fused_shared_expert_weight=shared_expert_weight,
     )
 
     logger.debug("FusedMoEConfig = %s", moe_config)

--- a/vllm/model_executor/layers/fused_moe/modular_kernel.py
+++ b/vllm/model_executor/layers/fused_moe/modular_kernel.py
@@ -582,6 +582,12 @@ class FusedMoEExperts(ABC):
             return False, _make_reason("batch invariance")
         elif moe_config.is_lora_enabled and not cls.supports_lora():
             return False, _make_reason("LoRA")
+        elif (
+            moe_config.num_fused_shared_experts > 0
+            and cls.is_monolithic()
+            and not cls.supports_native_fused_shared_experts()
+        ):
+            return False, _make_reason("externally routed fused shared experts")
         return True, None
 
     @staticmethod
@@ -753,6 +759,14 @@ class FusedMoEExperts(ABC):
         LoRA-aware experts should mix in LoRAExpertsMixin, which flips this
         to True and provides the per-forward LoRA state plumbing.
         """
+        return False
+
+    @staticmethod
+    def supports_native_fused_shared_experts() -> bool:
+        return False
+
+    @staticmethod
+    def supports_packed_fused_shared_experts() -> bool:
         return False
 
     def supports_packed_ue8m0_act_scales(self) -> bool:

--- a/vllm/model_executor/layers/fused_moe/routed_experts.py
+++ b/vllm/model_executor/layers/fused_moe/routed_experts.py
@@ -174,6 +174,13 @@ class RoutedExperts(PluggableLayer):
 
         self.lora_base_layer_prefix = ""
 
+    @property
+    def kernel_global_num_experts(self) -> int:
+        """Expert count visible to externally routed expert kernels."""
+        if self.moe_config.aiter_fmoe_shared_expert_enabled:
+            return self.global_num_experts
+        return self.global_num_experts + self.moe_config.num_fused_shared_experts
+
     # TODO(bnell): Temporary hack. Get rid of this.
     def _replace_quant_method(self, quant_method: FusedMoEMethodBase):
         self.quant_method = quant_method

--- a/vllm/model_executor/layers/fused_moe/router/aiter_shared_routed_fused_moe_router.py
+++ b/vllm/model_executor/layers/fused_moe/router/aiter_shared_routed_fused_moe_router.py
@@ -47,6 +47,10 @@ class AiterSharedRoutedFusedMoERouter(BaseRouter):
         self.num_fused_shared_experts = num_fused_shared_experts
 
     @property
+    def handles_fused_shared_experts(self) -> bool:
+        return True
+
+    @property
     def routing_method_type(self) -> RoutingMethodType:
         return get_routing_method_type(
             scoring_func=self.scoring_func,

--- a/vllm/model_executor/layers/fused_moe/router/base_router.py
+++ b/vllm/model_executor/layers/fused_moe/router/base_router.py
@@ -170,17 +170,81 @@ class BaseRouter(FusedMoERouter):
         top_k: int,
         global_num_experts: int,
         eplb_state: EplbLayerState | None = None,
+        num_fused_shared_experts: int = 0,
+        shared_expert_weight: float = 1.0,
     ):
         """
         Args:
             top_k: Number of experts to select per token
             global_num_experts: Total number of experts
             eplb_state: Optional EPLBLayerState for load balancing
+            num_fused_shared_experts: Number of always-on shared experts
+                appended after routed expert selection.
+            shared_expert_weight: Scale for each appended shared expert.
         """
         super().__init__(eplb_state=eplb_state)
         self.top_k = top_k
         self.global_num_experts = global_num_experts
+        self.num_fused_shared_experts = num_fused_shared_experts
+        self.shared_expert_weight = shared_expert_weight
+        self.defer_fused_shared_experts = False
         self.capture_fn: Callable[[torch.Tensor], None] | None = None
+
+    @property
+    def handles_fused_shared_experts(self) -> bool:
+        """Whether ``_compute_routing`` appends shared experts itself."""
+        return False
+
+    def configure_fused_shared_experts(
+        self,
+        num_fused_shared_experts: int,
+        shared_expert_weight: float = 1.0,
+    ) -> None:
+        if self.handles_fused_shared_experts:
+            return
+        self.num_fused_shared_experts = num_fused_shared_experts
+        self.shared_expert_weight = shared_expert_weight
+
+    def _append_fused_shared_experts(
+        self,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+        router_logits: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        num_shared = self.num_fused_shared_experts
+        can_defer = (
+            self.defer_fused_shared_experts
+            and router_logits.shape[-1] == self.global_num_experts
+        )
+        if num_shared == 0 or can_defer:
+            return topk_weights, topk_ids
+
+        num_tokens = topk_ids.shape[0]
+        shared_ids = torch.arange(
+            self.global_num_experts,
+            self.global_num_experts + num_shared,
+            dtype=topk_ids.dtype,
+            device=topk_ids.device,
+        ).expand(num_tokens, num_shared)
+
+        if router_logits.shape[-1] == self.global_num_experts + num_shared:
+            shared_weights = torch.sigmoid(
+                router_logits[:, self.global_num_experts :].float()
+            )
+            if self.shared_expert_weight != 1.0:
+                shared_weights *= self.shared_expert_weight
+        else:
+            shared_weights = torch.full(
+                (num_tokens, num_shared),
+                self.shared_expert_weight,
+                dtype=topk_weights.dtype,
+                device=topk_weights.device,
+            )
+
+        return (
+            torch.cat((topk_weights, shared_weights), dim=-1),
+            torch.cat((topk_ids, shared_ids), dim=-1),
+        )
 
     def set_capture_fn(self, capture_fn: Callable[[torch.Tensor], None] | None) -> None:
         """Set a capture callback for logical routed expert IDs."""
@@ -288,8 +352,21 @@ class BaseRouter(FusedMoERouter):
         self._validate_eplb_state()
 
         # Step 2: Compute routing (delegated to subclass)
+        routed_router_logits = router_logits
+        if (
+            self.num_fused_shared_experts > 0
+            and router_logits.shape[-1]
+            == self.global_num_experts + self.num_fused_shared_experts
+        ):
+            routed_router_logits = router_logits[
+                :, : self.global_num_experts
+            ].contiguous()
+
         topk_weights, topk_ids = self._compute_routing(
-            hidden_states, router_logits, topk_indices_dtype, input_ids=input_ids
+            hidden_states,
+            routed_router_logits,
+            topk_indices_dtype,
+            input_ids=input_ids,
         )
 
         # Capture logical ids before EPLB mapping.
@@ -298,6 +375,12 @@ class BaseRouter(FusedMoERouter):
 
         # Step 3: Apply EPLB mapping
         topk_ids = self._apply_eplb_mapping(topk_ids)
+
+        # Shared experts are not part of EPLB and are deliberately appended
+        # after capture and logical-to-physical mapping.
+        topk_weights, topk_ids = self._append_fused_shared_experts(
+            topk_weights, topk_ids, router_logits
+        )
 
         # Step 4: Convert indices dtype
         topk_ids = self._convert_indices_dtype(topk_ids, topk_indices_dtype)

--- a/vllm/model_executor/layers/fused_moe/router/custom_routing_router.py
+++ b/vllm/model_executor/layers/fused_moe/router/custom_routing_router.py
@@ -19,11 +19,15 @@ class CustomRoutingRouter(BaseRouter):
         custom_routing_function: Callable,
         eplb_state: EplbLayerState | None = None,
         renormalize: bool = True,
+        num_fused_shared_experts: int = 0,
+        shared_expert_weight: float = 1.0,
     ):
         super().__init__(
             top_k=top_k,
             global_num_experts=global_num_experts,
             eplb_state=eplb_state,
+            num_fused_shared_experts=num_fused_shared_experts,
+            shared_expert_weight=shared_expert_weight,
         )
         self.custom_routing_function = custom_routing_function
         self.renormalize = renormalize

--- a/vllm/model_executor/layers/fused_moe/router/fused_topk_bias_router.py
+++ b/vllm/model_executor/layers/fused_moe/router/fused_topk_bias_router.py
@@ -311,6 +311,8 @@ class FusedTopKBiasRouter(BaseRouter):
             top_k=top_k,
             global_num_experts=global_num_experts,
             eplb_state=eplb_state,
+            num_fused_shared_experts=num_fused_shared_experts,
+            shared_expert_weight=shared_expert_weight,
         )
         self.e_score_correction_bias = e_score_correction_bias
         self.renormalize = renormalize
@@ -318,11 +320,6 @@ class FusedTopKBiasRouter(BaseRouter):
         self.routed_scaling_factor = routed_scaling_factor
         self.scoring_func = scoring_func
         self._hash_indices_table = hash_indices_table
-        # Fused shared experts: append constant slots (ids immediately after
-        # the routed experts, [global, global+n)) routed to by every token at
-        # ``shared_expert_weight``, AFTER the routed top-k is renormalized.
-        self.num_fused_shared_experts = num_fused_shared_experts
-        self.shared_expert_weight = shared_expert_weight
 
     @property
     def routing_method_type(self) -> RoutingMethodType:
@@ -358,24 +355,5 @@ class FusedTopKBiasRouter(BaseRouter):
             hash_indices_table=self._hash_indices_table,
             routed_scaling_factor=self.routed_scaling_factor,
         )
-
-        if self.num_fused_shared_experts > 0:
-            m = topk_ids.shape[0]
-            n = self.num_fused_shared_experts
-            # global_num_experts counts only the routed experts; the fused
-            # shared experts occupy the slots immediately after them, i.e. ids
-            # [global_num_experts, global_num_experts + n).
-            base = self.global_num_experts
-            shared_ids = torch.arange(
-                base, base + n, dtype=topk_ids.dtype, device=topk_ids.device
-            ).expand(m, n)
-            shared_w = torch.full(
-                (m, n),
-                self.shared_expert_weight,
-                dtype=topk_weights.dtype,
-                device=topk_weights.device,
-            )
-            topk_ids = torch.cat([topk_ids, shared_ids], dim=-1)
-            topk_weights = torch.cat([topk_weights, shared_w], dim=-1)
 
         return topk_weights, topk_ids

--- a/vllm/model_executor/layers/fused_moe/router/fused_topk_router.py
+++ b/vllm/model_executor/layers/fused_moe/router/fused_topk_router.py
@@ -134,11 +134,15 @@ class FusedTopKRouter(BaseRouter):
         scoring_func: str = "softmax",
         renormalize: bool = True,
         eplb_state: EplbLayerState | None = None,
+        num_fused_shared_experts: int = 0,
+        shared_expert_weight: float = 1.0,
     ):
         super().__init__(
             top_k=top_k,
             global_num_experts=global_num_experts,
             eplb_state=eplb_state,
+            num_fused_shared_experts=num_fused_shared_experts,
+            shared_expert_weight=shared_expert_weight,
         )
         self.renormalize = renormalize
         self.scoring_func = scoring_func

--- a/vllm/model_executor/layers/fused_moe/router/grouped_topk_router.py
+++ b/vllm/model_executor/layers/fused_moe/router/grouped_topk_router.py
@@ -257,6 +257,7 @@ class GroupedTopKRouter(BaseRouter):
         routed_scaling_factor: float = 1.0,
         e_score_correction_bias: torch.Tensor | None = None,
         num_fused_shared_experts: int = 0,
+        shared_expert_weight: float = 1.0,
         eplb_state: EplbLayerState | None = None,
     ):
         super().__init__(
@@ -271,6 +272,17 @@ class GroupedTopKRouter(BaseRouter):
         self.routed_scaling_factor = routed_scaling_factor
         self.e_score_correction_bias = e_score_correction_bias
         self.num_fused_shared_experts = num_fused_shared_experts
+        if not self.handles_fused_shared_experts:
+            self.configure_fused_shared_experts(
+                num_fused_shared_experts, shared_expert_weight
+            )
+
+    @property
+    def handles_fused_shared_experts(self) -> bool:
+        return (
+            self.num_fused_shared_experts > 0
+            and rocm_aiter_ops.is_fusion_moe_shared_experts_enabled()
+        )
 
     @property
     def routing_method_type(self) -> RoutingMethodType:

--- a/vllm/model_executor/layers/fused_moe/router/router_factory.py
+++ b/vllm/model_executor/layers/fused_moe/router/router_factory.py
@@ -185,6 +185,7 @@ def create_fused_moe_router(
                 routed_scaling_factor=routed_scaling_factor,
                 e_score_correction_bias=e_score_correction_bias,
                 num_fused_shared_experts=num_fused_shared_experts,
+                shared_expert_weight=shared_expert_weight,
             )
         # Otherwise fall through to the non-grouped chain below.
 
@@ -195,6 +196,8 @@ def create_fused_moe_router(
             eplb_state=eplb_state,
             custom_routing_function=custom_routing_function,
             renormalize=renormalize,
+            num_fused_shared_experts=num_fused_shared_experts,
+            shared_expert_weight=shared_expert_weight,
         )
 
     assert scoring_func in ["sigmoid", "softmax", "sqrtsoftplus"]
@@ -233,4 +236,6 @@ def create_fused_moe_router(
         eplb_state=eplb_state,
         renormalize=renormalize,
         scoring_func=scoring_func,
+        num_fused_shared_experts=num_fused_shared_experts,
+        shared_expert_weight=shared_expert_weight,
     )

--- a/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
+++ b/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
@@ -31,6 +31,7 @@ from vllm.model_executor.layers.fused_moe.fused_moe_method_base import (
 from vllm.model_executor.layers.fused_moe.routed_experts import (
     RoutedExperts,
 )
+from vllm.model_executor.layers.fused_moe.router.base_router import BaseRouter
 from vllm.model_executor.layers.fused_moe.router.fused_moe_router import (
     FusedMoERouter,
 )
@@ -597,6 +598,10 @@ class MoERunner(MoERunnerInterface):
             )
         else:
             # Modular kernels: select experts first, then call routed_experts
+            if isinstance(self.router, BaseRouter):
+                self.router.defer_fused_shared_experts = (
+                    self._quant_method.supports_packed_fused_shared_experts
+                )
             topk_weights, topk_ids = self.router.select_experts(
                 hidden_states=hidden_states,
                 router_logits=router_logits,

--- a/vllm/model_executor/layers/fused_moe/unquantized_fused_moe_method.py
+++ b/vllm/model_executor/layers/fused_moe/unquantized_fused_moe_method.py
@@ -269,7 +269,7 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, CustomOp):
             topk_ids=topk_ids,
             activation=layer.activation,
             apply_router_weight_on_input=layer.apply_router_weight_on_input,
-            global_num_experts=layer.global_num_experts,
+            global_num_experts=layer.kernel_global_num_experts,
             expert_map=layer.expert_map,
             shared_experts=shared_experts,
             shared_experts_input=shared_experts_input,

--- a/vllm/model_executor/layers/fused_moe/utils.py
+++ b/vllm/model_executor/layers/fused_moe/utils.py
@@ -417,6 +417,53 @@ def _pack_topk_ids_weights_kernel(
     tl.store(output_ptr + offsets, packed, mask=mask)
 
 
+@triton.jit
+def _pack_topk_ids_weights_with_shared_kernel(
+    topk_ids_ptr,
+    topk_weights_ptr,
+    output_ptr,
+    n_elements,
+    first_shared_expert_id,
+    shared_expert_weight,
+    ROUTED_TOPK: tl.constexpr,
+    NUM_SHARED_EXPERTS: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+    USE_GDC: tl.constexpr,
+    launch_pdl: tl.constexpr,  # triton metadata
+):
+    pid = tl.program_id(axis=0)
+    offsets = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+    if USE_GDC:
+        tl.extra.cuda.gdc_launch_dependents()
+        tl.extra.cuda.gdc_wait()
+
+    output_topk: tl.constexpr = ROUTED_TOPK + NUM_SHARED_EXPERTS
+    token_idx = offsets // output_topk
+    slot_idx = offsets % output_topk
+    is_routed = slot_idx < ROUTED_TOPK
+    input_offsets = token_idx * ROUTED_TOPK + slot_idx
+
+    routed_expert_id = tl.load(
+        topk_ids_ptr + input_offsets,
+        mask=mask & is_routed,
+        other=0,
+    ).to(tl.int32)
+    shared_expert_id = first_shared_expert_id + slot_idx - ROUTED_TOPK
+    expert_id = tl.where(is_routed, routed_expert_id, shared_expert_id)
+
+    routed_weight = tl.load(
+        topk_weights_ptr + input_offsets,
+        mask=mask & is_routed,
+        other=0.0,
+    )
+    weight = tl.where(is_routed, routed_weight, shared_expert_weight)
+    weight_bf16 = weight.to(tl.bfloat16)
+    weight_int16 = weight_bf16.to(tl.int16, bitcast=True)
+    packed = (expert_id << 16) | (weight_int16.to(tl.int32) & 0xFFFF)
+    tl.store(output_ptr + offsets, packed, mask=mask)
+
+
 def fi_moe_largest_bucket(moe_config: "FusedMoEConfig") -> int:
     """Estimate FlashInfer's MoE autotuning maximum token count.
 
@@ -438,29 +485,50 @@ def trtllm_moe_pack_topk_ids_weights(
     topk_ids: torch.Tensor,
     topk_weights: torch.Tensor,
     block_size: int = 1024,
+    num_fused_shared_experts: int = 0,
+    first_shared_expert_id: int | None = None,
+    fused_shared_expert_weight: float = 1.0,
 ) -> torch.Tensor:
     assert topk_ids.shape == topk_weights.shape
     assert topk_ids.is_contiguous() and topk_weights.is_contiguous()
 
-    original_shape = topk_ids.shape
+    num_tokens, routed_topk = topk_ids.shape
+    output_topk = routed_topk + num_fused_shared_experts
+    output_shape = (num_tokens, output_topk)
     ids_flat = topk_ids.reshape(-1)
     weights_flat = topk_weights.reshape(-1)
 
-    n_elements = ids_flat.numel()
+    n_elements = num_tokens * output_topk
     output = torch.empty(n_elements, dtype=torch.int32, device=topk_ids.device)
 
     use_gdc = current_platform.is_cuda() and current_platform.has_device_capability(90)
     grid = (triton.cdiv(n_elements, block_size),)
-    _pack_topk_ids_weights_kernel[grid](
-        ids_flat,
-        weights_flat,
-        output,
-        n_elements,
-        BLOCK_SIZE=block_size,
-        USE_GDC=use_gdc,
-        launch_pdl=use_gdc,
-    )
-    return output.reshape(original_shape)
+    if num_fused_shared_experts > 0:
+        assert first_shared_expert_id is not None
+        _pack_topk_ids_weights_with_shared_kernel[grid](
+            ids_flat,
+            weights_flat,
+            output,
+            n_elements,
+            first_shared_expert_id,
+            fused_shared_expert_weight,
+            ROUTED_TOPK=routed_topk,
+            NUM_SHARED_EXPERTS=num_fused_shared_experts,
+            BLOCK_SIZE=block_size,
+            USE_GDC=use_gdc,
+            launch_pdl=use_gdc,
+        )
+    else:
+        _pack_topk_ids_weights_kernel[grid](
+            ids_flat,
+            weights_flat,
+            output,
+            n_elements,
+            BLOCK_SIZE=block_size,
+            USE_GDC=use_gdc,
+            launch_pdl=use_gdc,
+        )
+    return output.reshape(output_shape)
 
 
 @torch.compile(dynamic=True, backend=current_platform.simple_compile_backend)

--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -814,7 +814,7 @@ class Fp8MoEMethod(FusedMoEMethodBase):
             topk_weights,
             topk_ids,
             activation=layer.activation,
-            global_num_experts=layer.global_num_experts,
+            global_num_experts=layer.kernel_global_num_experts,
             expert_map=layer.expert_map,
             apply_router_weight_on_input=layer.apply_router_weight_on_input,
             shared_experts=shared_experts,

--- a/vllm/model_executor/layers/quantization/utils/flashinfer_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/flashinfer_utils.py
@@ -469,6 +469,29 @@ def prepare_fp8_moe_layer_for_fi(
     is_deepseek_fp8 = block_quant and not is_mxfp8
     is_gated = layer.activation.is_gated
 
+    if (
+        is_trtllm
+        and is_deepseek_fp8
+        and layer.moe_config.num_fused_shared_experts > 0
+        and w13.shape[0] % 4 != 0
+    ):
+        padded_num_experts = round_up(w13.shape[0], 4)
+
+        def pad_experts(x: torch.Tensor, value: float) -> torch.Tensor:
+            padded = x.new_full((padded_num_experts, *x.shape[1:]), value)
+            padded[: x.shape[0]].copy_(x)
+            return padded
+
+        logger.info_once(
+            "Padding FlashInfer TRTLLM fused expert count from %d to %d.",
+            w13.shape[0],
+            padded_num_experts,
+        )
+        w13 = pad_experts(w13, 0)
+        w2 = pad_experts(w2, 0)
+        w13_scale = pad_experts(w13_scale, 1)
+        w2_scale = pad_experts(w2_scale, 1)
+
     # MXFP8 TRT-LLM requires W31 swap + reorder + shuffle.
     if is_mxfp8 and is_trtllm:
         # FlashInfer TRT-LLM SwiGLU expects [up; gate] but vLLM stores

--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -285,6 +285,7 @@ class DeepseekV2MoE(nn.Module):
         reduce_results: bool = True,
         prefix: str = "",
         apply_routed_scale_to_output: bool = False,
+        fuse_shared_experts: bool | None = None,
     ):
         super().__init__()
         self.tp_size = get_tensor_model_parallel_world_size()
@@ -335,9 +336,14 @@ class DeepseekV2MoE(nn.Module):
         )
 
         self.is_rocm_aiter_moe_enabled = rocm_aiter_ops.is_fused_moe_enabled()
-        self.is_fusion_moe_shared_experts_enabled = (
-            rocm_aiter_ops.is_fusion_moe_shared_experts_enabled()
-        )
+        if fuse_shared_experts is None:
+            fuse_shared_experts = rocm_aiter_ops.is_fusion_moe_shared_experts_enabled()
+        self.is_fusion_moe_shared_experts_enabled = fuse_shared_experts
+        if fuse_shared_experts and config.n_shared_experts:
+            logger.info_once(
+                "Fusing %d shared expert(s) into the routed experts.",
+                config.n_shared_experts,
+            )
         if (
             self.is_rocm_aiter_moe_enabled
             and self.gate.e_score_correction_bias is not None
@@ -385,6 +391,7 @@ class DeepseekV2MoE(nn.Module):
             n_shared_experts=config.n_shared_experts
             if self.is_fusion_moe_shared_experts_enabled
             else None,
+            fuse_shared_experts=self.is_fusion_moe_shared_experts_enabled,
             router_logits_dtype=self.gate.out_dtype,
         )
 
@@ -1517,8 +1524,11 @@ class DeepseekV2Model(nn.Module):
         return hidden_states
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
-        rocm_aiter_moe_shared_expert_enabled = (
-            rocm_aiter_ops.is_fusion_moe_shared_experts_enabled()
+        fused_shared_experts_enabled = any(
+            isinstance(layer.mlp, DeepseekV2MoE)
+            and layer.mlp.is_fusion_moe_shared_experts_enabled
+            for layer in self.layers
+            if not isinstance(layer, PPMissingLayer)
         )
         stacked_params_mapping = [
             # (param_name, shard_name, shard_id)
@@ -1558,11 +1568,7 @@ class DeepseekV2Model(nn.Module):
             ckpt_down_proj_name="down_proj",
             ckpt_up_proj_name="up_proj",
             num_experts=self.config.n_routed_experts
-            + (
-                self.config.n_shared_experts
-                if rocm_aiter_moe_shared_expert_enabled
-                else 0
-            ),
+            + (self.config.n_shared_experts if fused_shared_experts_enabled else 0),
             num_redundant_experts=self.num_redundant_experts,
         )
 
@@ -1587,8 +1593,8 @@ class DeepseekV2Model(nn.Module):
             ):
                 continue  # this layer has no indexer; drop its checkpoint weights
 
-            is_fusion_moe_shared_experts_layer = (
-                rocm_aiter_moe_shared_expert_enabled and ("mlp.shared_experts" in name)
+            is_fusion_moe_shared_experts_layer = fused_shared_experts_enabled and (
+                "mlp.shared_experts" in name
             )
 
             if _try_load_fp8_indexer_wk(

--- a/vllm/model_executor/models/utils.py
+++ b/vllm/model_executor/models/utils.py
@@ -432,11 +432,12 @@ def maybe_fuse_shared_experts(
     ckpt_prefix: str = "mlp.shared_experts",
     enabled: bool | None = None,
 ) -> Iterable[tuple[str, torch.Tensor]]:
-    """Route AITER fused-shared-expert checkpoint weights into fused slots.
+    """Route fused-shared-expert checkpoint weights into routed slots.
 
-    When AITER fused-shared-experts is active, shared experts are packed into
-    the routed expert tensor. The checkpoint stores them under `ckpt_prefix`
-    as a single (possibly widened) tensor; this splits it into
+    When shared-expert fusion is active, shared experts are packed into the
+    routed expert tensor on either a modular CUDA backend or ROCm AITER. The
+    checkpoint stores them under `ckpt_prefix` as a single (possibly widened)
+    tensor; this splits it into
     `n_shared_experts` chunks named `mlp.experts.{n_routed_experts + j}` so
     the `RoutedExperts` loader treats them as extra experts. Yields the input
     unchanged when the fusion is inactive, so callers can wrap unconditionally.
@@ -446,11 +447,9 @@ def maybe_fuse_shared_experts(
         n_routed_experts: Number of routed experts; offsets the fused slots.
         n_shared_experts: Number of shared experts packed into the tensor.
         ckpt_prefix: Checkpoint module name of the shared experts.
-        enabled: Whether AITER fused-shared-experts is active. Defaults to
-            `rocm_aiter_ops.is_fusion_moe_shared_experts_enabled()`; pass an
-            explicit value only when the model gates on something more (e.g.
-            quant-spec compatibility) and it must match its construction-time
-            decision.
+        enabled: Whether fused shared experts are active. The default preserves
+            ROCm AITER behavior. CUDA integrations must pass their explicit
+            construction-time decision, including quant-spec compatibility.
 
     Yields:
         `(name, tensor)` pairs with shared experts routed to fused slots.

--- a/vllm/models/deepseek_v32/nvidia/model.py
+++ b/vllm/models/deepseek_v32/nvidia/model.py
@@ -14,6 +14,10 @@ from vllm.model_executor.layers.fused_moe import (
     fused_moe_make_expert_params_mapping,
 )
 from vllm.model_executor.layers.layernorm import RMSNorm
+from vllm.model_executor.layers.quantization import QuantizationConfig
+from vllm.model_executor.layers.quantization.utils.quant_utils import (
+    is_layer_skipped,
+)
 from vllm.model_executor.layers.vocab_parallel_embedding import (
     VocabParallelEmbedding,
 )
@@ -30,10 +34,12 @@ from vllm.model_executor.models.deepseek_v2 import (
 )
 from vllm.model_executor.models.utils import (
     PPMissingLayer,
+    extract_layer_index,
     get_pp_missing_layer_names,
     is_pp_missing_parameter,
     make_empty_intermediate_tensors_factory,
     make_layers,
+    maybe_fuse_shared_experts,
 )
 from vllm.models.common.ops.fused_allreduce_rms_norm import fused_allreduce_rms_norm
 from vllm.models.common.ops.sequence_parallel import (
@@ -46,6 +52,66 @@ from vllm.models.deepseek_v32.attention import DeepseekV32Attention
 from vllm.sequence import IntermediateTensors
 
 from .glm52_low_latency_gemm import enable_glm52_low_latency_gemm
+
+
+def _can_fuse_shared_experts(
+    quant_config: QuantizationConfig | None,
+    prefix: str,
+) -> bool:
+    if quant_config is None:
+        return True
+    if quant_config.get_name() != "fp8" or not getattr(
+        quant_config, "is_checkpoint_fp8_serialized", False
+    ):
+        return False
+
+    ignored_layers = getattr(quant_config, "ignored_layers", [])
+    fused_mapping = getattr(quant_config, "packed_modules_mapping", {})
+    match_mode = typing.cast(
+        typing.Literal["exact", "substring", "suffix"],
+        getattr(quant_config, "ignored_layers_match_mode", "exact"),
+    )
+    routed_experts_skipped = is_layer_skipped(
+        f"{prefix}.experts",
+        ignored_layers,
+        fused_mapping,
+        match_mode=match_mode,
+    )
+    shared_experts_skipped = is_layer_skipped(
+        f"{prefix}.shared_experts",
+        ignored_layers,
+        fused_mapping,
+        match_mode=match_mode,
+    )
+    return routed_experts_skipped == shared_experts_skipped
+
+
+def _get_shared_expert_fusion_by_layer(
+    named_modules: Iterable[tuple[str, torch.nn.Module]],
+) -> dict[int, bool]:
+    return {
+        extract_layer_index(module_name): module.is_fusion_moe_shared_experts_enabled
+        for module_name, module in named_modules
+        if isinstance(module, DeepseekV2MoE)
+    }
+
+
+def _fuse_shared_expert_weights_by_layer(
+    weights: Iterable[tuple[str, torch.Tensor]],
+    fusion_by_layer: dict[int, bool],
+    n_routed_experts: int,
+    n_shared_experts: int,
+) -> Iterable[tuple[str, torch.Tensor]]:
+    for name, weight in weights:
+        if "mlp.shared_experts." not in name:
+            yield name, weight
+            continue
+        yield from maybe_fuse_shared_experts(
+            ((name, weight),),
+            n_routed_experts=n_routed_experts,
+            n_shared_experts=n_shared_experts,
+            enabled=fusion_by_layer.get(extract_layer_index(name), False),
+        )
 
 
 class DeepseekV32DecoderLayer(torch.nn.Module):
@@ -94,6 +160,10 @@ class DeepseekV32DecoderLayer(torch.nn.Module):
                 reduce_results=False,
                 prefix=f"{prefix}.mlp",
                 apply_routed_scale_to_output=False,
+                fuse_shared_experts=(
+                    config.n_shared_experts is not None
+                    and _can_fuse_shared_experts(quant_config, f"{prefix}.mlp")
+                ),
             )
         else:
             self.mlp = DeepseekV2MLP(
@@ -286,8 +356,17 @@ class DeepseekV32Model(torch.nn.Module):
         return hidden_states
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
-        # DSA-only: MLA (fused_qkv_a_proj) + the fused indexer wk/weights_proj +
-        # routed experts. No MHA (qkv_proj) or ROCm shared-expert-fusion paths.
+        # DSA-only: MLA (fused_qkv_a_proj) + the fused indexer wk/weights_proj.
+        fuse_shared_experts_by_layer = _get_shared_expert_fusion_by_layer(
+            self.named_modules()
+        )
+        has_fused_shared_experts = any(fuse_shared_experts_by_layer.values())
+        weights = _fuse_shared_expert_weights_by_layer(
+            weights,
+            fuse_shared_experts_by_layer,
+            self.config.n_routed_experts,
+            self.config.n_shared_experts,
+        )
         stacked_params_mapping = [
             ("gate_up_proj", "gate_proj", 0),
             ("gate_up_proj", "up_proj", 1),
@@ -301,7 +380,8 @@ class DeepseekV32Model(torch.nn.Module):
             ckpt_gate_proj_name="gate_proj",
             ckpt_down_proj_name="down_proj",
             ckpt_up_proj_name="up_proj",
-            num_experts=self.config.n_routed_experts,
+            num_experts=self.config.n_routed_experts
+            + (self.config.n_shared_experts if has_fused_shared_experts else 0),
             num_redundant_experts=self.num_redundant_experts,
         )
 


### PR DESCRIPTION
## Summary

- Extend the FusedMoE abstraction so shared experts can be represented as always-on routed expert slots on NVIDIA GPUs.
- Enable the path for the NVIDIA DeepSeek-V3.2/GLM-5.2 model when routed and shared expert storage formats match.
- Run fused FP8 shared experts through the modular FlashInfer TRTLLM backend, including expert-row padding required by the kernel.
- Append and pack constant shared-expert routes in one Triton kernel, avoiding the extra top-k concatenation that regressed single-token decode.
- Preserve ROCm AITER's native fused-shared-expert routing behavior.

## Motivation

Shared-expert fusion was effectively limited to ROCm/AITER. NVIDIA models therefore launched the routed MoE and shared MLP separately even when both used compatible FP8 storage.

FlashInfer's native shared-expert entry point is not usable for this FP8 configuration, but its externally routed TRTLLM FP8 kernel handles the shared expert correctly when the shared rows and always-on route are included in the routed problem. This change adds that representation to FusedMoE and keeps the single-token path efficient by synthesizing the shared route while packing top-k IDs and weights.

## Duplicate-work check

I searched open PRs for `shared expert fusion`, `FusedMoE shared experts NVIDIA`, and `FlashInfer shared expert`, and inspected the related issue and PRs.

- #51695 standardizes model-level FSE enablement/quantization compatibility; it does not add NVIDIA routing, weight preparation, or FlashInfer execution. This PR may need a small rebase if that selection refactor lands first.
- #50963 tracks FlashInfer's native FP4 shared-expert API. This PR implements the externally routed TRTLLM **FP8** path and does not close that FP4 issue.
- #51632 fixes ROCm Triton expert-count alignment and does not implement the NVIDIA path.

No open PR found in those searches implements this change.

## Correctness

Real-weight model evaluation:

- Model: GLM-5.2-FP8 under `models/deepseek_v32/`
- Hardware: TP8 across two NVIDIA GB200 nodes
- Model override: `vllm.models.deepseek_v32.nvidia.model:DeepseekV32ForCausalLM`, forcing the NVIDIA implementation and avoiding the HF torch-compile path
- GSM8K exact match: **0.9325246**

Local tests on NVIDIA GB200:

```text
.venv/bin/python -m pytest tests/kernels/moe/test_routing.py -q
507 passed

.venv/bin/python -m pytest tests/models/deepseek_v32/test_sequence_parallel.py   tests/kernels/moe/test_routing.py tests/quantization/test_fp8.py   -k 'shared_expert_fusion or standard_router or trtllm_fp8_moe_validates_kernel_expert_count or flashinfer_trtllm_pads_fused_shared_expert_rows or trtllm_fp8_modular_uses_padded_fused_expert_count or trtllm_pack_appends_fused_shared_experts or monolithic_kernel_must_handle_fused_shared_experts_natively or fp8_moe_modular_apply_includes_fused_shared_experts' -q
14 passed, 524 deselected

.venv/bin/python -m pytest tests/kernels/moe/test_unquantized_backend_selection.py -q
26 passed, 1 skipped

.venv/bin/python -m pytest tests/kernels/moe/test_moe_layer.py   -k fused_shared_experts_cuda -q
1 passed, 510 deselected

.venv/bin/python -m pytest tests/models/deepseek_v32/test_sequence_parallel.py -q
4 passed

pre-commit run --files <all 28 changed files>
Passed, including ruff, mypy, typos, SPDX, and repository checks
```

## Performance

Dummy-weight GLM-5.2-FP8, TP8 across two 4xGB200 nodes, 16 input and 16 output tokens per request. The benchmark used the NVIDIA model override, `VLLM_USE_BREAKABLE_CUDAGRAPH=1`, `FULL_AND_PIECEWISE`, the default 83 regular capture sizes, prefix caching disabled, five warmup waves, and nine measured closed-loop burst waves per concurrency. Breakable graphs set compilation mode to `NONE`, so these results do not use torch/Inductor compilation.

| Concurrency | TTFT unfused | TTFT fused | Change | TPOT unfused | TPOT fused | Change |
|---:|---:|---:|---:|---:|---:|---:|
| 1 | 29.738 ms | 28.739 ms | -3.36% | 8.215 ms | 8.274 ms | +0.72% |
| 8 | 30.477 ms | 29.515 ms | -3.16% | 9.160 ms | 8.828 ms | -3.63% |
| 32 | 67.968 ms | 66.573 ms | -2.05% | 10.826 ms | 10.549 ms | -2.55% |
| 128 | 261.856 ms | 255.693 ms | -2.35% | 15.830 ms | 15.946 ms | +0.74% |
| 512 | 284.948 ms | 282.755 ms | -0.77% | 27.052 ms | 26.588 ms | -1.71% |

| Concurrency | Output throughput unfused | Output throughput fused | Change |
|---:|---:|---:|---:|
| 1 | 103.85 tok/s | 103.90 tok/s | +0.06% |
| 8 | 757.21 tok/s | 781.11 tok/s | +3.16% |
| 32 | 1,956.06 tok/s | 1,997.35 tok/s | +2.11% |
| 128 | 3,829.45 tok/s | 3,873.43 tok/s | +1.15% |
| 512 | 11,139.04 tok/s | 11,072.50 tok/s | -0.60% |

TTFT is queued-to-first-token time; median queue time remained below 0.6 ms. Fusion is neutral at concurrency 1 and improves median throughput by 1.1-3.2% at concurrency 8-128.

The fused concurrency-512 run was bimodal: five waves completed in 0.71-0.74 seconds and four in 0.90-0.92 seconds. Its p99 TTFT was 485.07 ms versus 306.78 ms unfused, and p99 TPOT was 39.48 ms versus 27.07 ms unfused. The median throughput result therefore does not show a benefit at concurrency 512, and the tail behavior needs further investigation.

### Kernel profile

I also captured matched PyTorch/CUPTI traces for fixed decode batches. These runs used the same dummy model, TP8 topology, `max_num_seqs=1024`, `max_num_batched_tokens=32768`, breakable `FULL_AND_PIECEWISE` CUDA graphs, and all 83 regular capture sizes as the end-to-end benchmark. The table reports the median steady-state GPU annotation on rank 0; profiler wall time is not used.

| Decode batch | Unfused main stream | Unfused shared stream | Fused main stream | Main-stream change |
|---:|---:|---:|---:|---:|
| 1 | 8.147 ms | 7.640 ms | 8.287 ms | +0.140 ms (+1.72%) |
| 8 | 9.145 ms | 8.622 ms | 8.811 ms | -0.334 ms (-3.65%) |
| 128 | 15.662 ms | 14.876 ms | 15.835 ms | +0.173 ms (+1.11%) |

The unfused shared-expert stream completes before the main stream at all three sizes, so its work is already hidden rather than added to the critical path. Fusion removes that competing stream and helps batch 8, but its modular routing overhead slightly exceeds the overlap benefit at batches 1 and 128. This matches the end-to-end TPOT trend.

The combined append-and-pack kernel costs 0.104-0.118 ms per decode step across 75 MoE layers (1.39-1.58 microseconds per layer). It has already removed the prior materialize-plus-concatenate path. Eliminating the remaining kernel would require a FlashInfer interface that can consume an implicit always-on shared route; no further safe vLLM-only optimization was identified from these traces.

### MoE operator microbenchmark

I separately measured one GLM-5.2-FP8 MoE layer from precomputed router
logits through routing, expert execution, runtime activation quantization, and
combine. The gate projection, TP communication/final all-reduce, attention,
scheduler, and frontend are excluded. Dummy BF16 weights were converted to
block FP8 before timing, so offline weight quantization is also excluded.

The benchmark uses the TP8 **per-rank** matrix shape on one GB200:
hidden size 6144, intermediate size 256 (= 2048 / TP8), 256 routed experts,
one shared expert, top-k 8, BF16 activations, block-FP8 [128, 128] weights,
and GLM-5.2 sigmoid/noaux routing with routed scale 2.5. It configures
`tp_size=1` with pre-sharded weights, so it is a kernel microbenchmark rather
than an actual distributed TP8 run.

Every token count has its own manually captured exact-shape
`torch.cuda.CUDAGraph`; vLLM model-runner CUDA graph dispatch is disabled.
The main baseline uses the monolithic FlashInfer TRTLLM routed MoE plus a
separate block-FP8 DeepGEMM shared MLP. To give the baseline its strongest
overlap behavior, `VLLM_SHARED_EXPERTS_STREAM_TOKEN_THRESHOLD=32768` forces
the shared MLP onto its auxiliary stream at every measured size; instrumentation
confirmed `MULTI_STREAM_OVERLAPPED` at both 1 and 8192 tokens. The fused path
uses the modular FlashInfer TRTLLM kernel with 257 logical experts padded to
260. Results are the median of three process-level medians on the same GB200.

| Tokens | Fused latency | Main always-overlap latency | Fused change | Fused throughput | Main throughput |
|---:|---:|---:|---:|---:|---:|
| 1 | 0.0369 ms | 0.0370 ms | -0.4% | 0.027M tok/s | 0.027M tok/s |
| 2 | 0.0419 ms | 0.0423 ms | -1.1% | 0.048M tok/s | 0.047M tok/s |
| 4 | 0.0531 ms | 0.0535 ms | -0.7% | 0.075M tok/s | 0.075M tok/s |
| 8 | 0.0757 ms | 0.0782 ms | -3.3% | 0.106M tok/s | 0.102M tok/s |
| 16 | 0.1024 ms | 0.1070 ms | -4.3% | 0.156M tok/s | 0.149M tok/s |
| 32 | 0.1481 ms | 0.1497 ms | -1.0% | 0.216M tok/s | 0.214M tok/s |
| 64 | 0.1979 ms | 0.1936 ms | +2.2% | 0.323M tok/s | 0.331M tok/s |
| 128 | 0.2227 ms | 0.2113 ms | +5.4% | 0.575M tok/s | 0.606M tok/s |
| 256 | 0.2512 ms | 0.2393 ms | +5.0% | 1.019M tok/s | 1.070M tok/s |
| 512 | 0.2712 ms | 0.3488 ms | -22.3% | 1.888M tok/s | 1.468M tok/s |
| 1024 | 0.3055 ms | 0.3863 ms | -20.9% | 3.351M tok/s | 2.651M tok/s |
| 2048 | 0.4039 ms | 0.4704 ms | -14.1% | 5.071M tok/s | 4.353M tok/s |
| 4096 | 0.6699 ms | 0.6859 ms | -2.3% | 6.114M tok/s | 5.972M tok/s |
| 8192 | 1.2046 ms | 1.2348 ms | -2.4% | 6.801M tok/s | 6.634M tok/s |

Fusion is neutral at the smallest shapes, loses 2-5% at 64-256 tokens where
the dense shared MLP overlaps effectively, wins 14-22% at 512-2048 tokens,
and remains 2-3% faster once both paths approach GEMM throughput limits.
Forcing overlap above the default 256-token threshold improves the main
baseline by only 0.8-4.0% at 512-8192 tokens because the FlashInfer routed MoE
and DeepGEMM shared MLP compete for the same GPU resources.

## AI assistance disclosure

AI assistance from OpenAI Codex was used to implement, debug, test, benchmark, profile, clean up, and prepare this draft PR. The human submitter is responsible for understanding and defending the change and must review every changed line and confirm the reported tests before marking the PR ready for review.

