### PR TITLE
[CI/Release][1/N][XPU] Publish XPU Triton shim index

### DIFF
--- a/.buildkite/release-pipeline.yaml
+++ b/.buildkite/release-pipeline.yaml
@@ -164,6 +164,14 @@ steps:
         env:
           DOCKER_BUILDKIT: "1"
 
+  - label: "Publish XPU Triton shim index"
+    key: publish-xpu-triton-shim
+    depends_on: ~
+    agents:
+      queue: cpu_queue_release
+    commands:
+      - "bash .buildkite/scripts/xpu/publish-triton-shim.sh"
+
   - label: "Generate and upload wheel indices"
     key: generate-wheel-indices
     depends_on: "build-wheels"

--- a/.buildkite/scripts/xpu/publish-triton-shim.sh
+++ b/.buildkite/scripts/xpu/publish-triton-shim.sh
@@ -47,7 +47,6 @@ if [[ "$DRY_RUN" == "1" ]]; then
     printf '{"Contents":[{"Key":"%s/%s"}]}' \
         "$PREFIX" "$WHEEL_FILENAME" > "$objects_path"
 else
-    aws sts get-caller-identity
     aws s3 cp "$wheel_path" "$S3_PREFIX"
     aws s3api list-objects-v2 \
         --bucket "$BUCKET" \

--- a/.buildkite/scripts/xpu/publish-triton-shim.sh
+++ b/.buildkite/scripts/xpu/publish-triton-shim.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+set -euo pipefail
+
+readonly BUCKET="vllm-wheels"
+readonly PREFIX="xpu"
+readonly WHEEL_URL="https://github.com/intel/intel-xpu-backend-for-triton/releases/download/v3.7.2/triton-3.7.2+xpu-py3-none-any.whl"
+readonly WHEEL_SHA256="3c822f73e9870512f59a6ecf5dc305a4bcab11fa623f9ce91011f604315227e9"
+readonly WHEEL_FILENAME="${WHEEL_URL##*/}"
+readonly ENCODED_WHEEL_FILENAME="${WHEEL_FILENAME/+/%2B}"
+readonly S3_PREFIX="s3://${BUCKET}/${PREFIX}/"
+readonly DRY_RUN="${DRY_RUN:-0}"
+
+if [[ "$DRY_RUN" != "0" && "$DRY_RUN" != "1" ]]; then
+    echo "DRY_RUN must be 0 or 1" >&2
+    exit 2
+fi
+
+cd "$(dirname "${BASH_SOURCE[0]}")/../../.."
+
+work_dir=$(mktemp -d)
+trap 'rm -rf "$work_dir"' EXIT
+
+wheel_path="$work_dir/$WHEEL_FILENAME"
+objects_path="$work_dir/objects.json"
+index_output_dir="$work_dir/$PREFIX"
+index_generator="$work_dir/generate-nightly-index.py"
+
+curl --fail --location --retry 3 --output "$wheel_path" "$WHEEL_URL"
+
+if command -v sha256sum >/dev/null 2>&1; then
+    actual_sha=$(sha256sum "$wheel_path")
+else
+    actual_sha=$(shasum -a 256 "$wheel_path")
+fi
+actual_sha=${actual_sha%% *}
+if [[ "$actual_sha" != "$WHEEL_SHA256" ]]; then
+    echo "SHA256 mismatch for $WHEEL_FILENAME" >&2
+    echo "Expected: $WHEEL_SHA256" >&2
+    echo "Actual:   $actual_sha" >&2
+    exit 1
+fi
+
+if [[ "$DRY_RUN" == "1" ]]; then
+    printf '{"Contents":[{"Key":"%s/%s"}]}' \
+        "$PREFIX" "$WHEEL_FILENAME" > "$objects_path"
+else
+    aws sts get-caller-identity
+    aws s3 cp "$wheel_path" "$S3_PREFIX"
+    aws s3api list-objects-v2 \
+        --bucket "$BUCKET" \
+        --prefix "$PREFIX/" \
+        --delimiter / \
+        --output json > "$objects_path"
+fi
+
+# Pick Python >= 3.12 locally or use the container fallback.
+# shellcheck source=../lib/select-python.sh
+source .buildkite/scripts/lib/select-python.sh
+select_python
+
+# The index generator only needs stdlib re here. Keep the tracked source intact.
+sed 's/import regex as re/import re/' \
+    .buildkite/scripts/generate-nightly-index.py > "$index_generator"
+
+# shellcheck disable=SC2086
+$PYTHON "$index_generator" \
+    --version "$PREFIX" \
+    --wheel-dir "$PREFIX" \
+    --current-objects "$objects_path" \
+    --output-dir "$index_output_dir" \
+    --comment "XPU Triton shim"
+
+grep -Fq 'href="triton/"' "$index_output_dir/index.html"
+grep -Fq "href=\"../$ENCODED_WHEEL_FILENAME\"" \
+    "$index_output_dir/triton/index.html"
+grep -Fq "\"filename\": \"$WHEEL_FILENAME\"" \
+    "$index_output_dir/triton/metadata.json"
+
+if [[ "$DRY_RUN" == "1" ]]; then
+    echo "Dry run succeeded; generated files:"
+    find "$index_output_dir" -type f -print | sort
+else
+    aws s3 cp --recursive "$index_output_dir/" "$S3_PREFIX"
+    echo "Published XPU Triton shim index to https://wheels.vllm.ai/$PREFIX/"
+fi


### PR DESCRIPTION
# Summary
This PR adds a release-pipeline job to publish the Intel XPU Triton compatibility shim to s3://vllm-wheels/xpu/.

- Downloads the pinned triton-3.7.2+xpu wheel from the Intel XPU Triton release.
- Verifies the wheel against its fixed SHA256 checksum before publishing.
- Generates and uploads PEP 503 indexes and metadata for:
  - https://wheels.vllm.ai/xpu/
  - https://wheels.vllm.ai/xpu/triton/
- Supports DRY_RUN=1 for local validation without writing to AWS.
- Validates %2B URL encoding and generated wheel metadata.

# Motivation
XPU installations require the triton compatibility package, which depends on triton-xpu==3.7.2. Publishing the pinned shim through the public vLLM wheel index removes the need to rely on a private package index.

# Duplicate-work check
This PR complements #50857 rather than duplicating it. #50857 builds and publishes the vLLM XPU wheel under commit-based indexes, while this PR publishes the separately maintained Triton compatibility shim under the stable top-level /xpu/ index.

Searches for triton shim and wheels.vllm.ai/xpu found no other open PR covering this behavior.

# Testing
- PYTHON_PROG="$PWD/.venv/bin/python" DRY_RUN=1 bash .buildkite/scripts/publish-xpu-triton-shim.sh
- shellcheck .buildkite/scripts/publish-xpu-triton-shim.sh
- .venv/bin/pre-commit run --files release-pipeline.yaml .buildkite/scripts/publish-xpu-triton-shim.sh
- Parsed the release pipeline with PyYAML.
- Ran git diff --check.

The dry run successfully downloaded and verified the pinned wheel and generated:

- xpu/index.html
- xpu/triton/index.html
- [xpu/triton/metadata.json]
It also verified that the wheel URL uses the required %2B encoding.

# AI Assistance
GitHub Copilot assisted with repository exploration, implementation, validation, and PR preparation. The changes were reviewed and tested locally.