### PR TITLE
[Docs] Fix stale claim that Ray is the default multi-node runtime

### DIFF
--- a/docs/serving/parallelism_scaling.md
+++ b/docs/serving/parallelism_scaling.md
@@ -30,7 +30,7 @@ It's often advantageous to exploit the inherent parallelism of experts by using 
 
 vLLM supports distributed tensor-parallel and pipeline-parallel inference and serving. The implementation includes [Megatron-LM's tensor parallel algorithm](https://arxiv.org/pdf/1909.08053.pdf).
 
-The default distributed runtimes are [Ray](https://github.com/ray-project/ray) for multi-node inference and native Python `multiprocessing` for single-node inference. You can override the defaults by setting `distributed_executor_backend` in the `LLM` class or `--distributed-executor-backend` in the API server. Use `mp` for `multiprocessing` or `ray` for Ray.
+For multi-GPU inference, the default distributed runtime is native Python `multiprocessing`. [Ray](https://github.com/ray-project/ray) is not selected automatically for CUDA multi-node inference: to use it, set `distributed_executor_backend="ray"` in the `LLM` class or `--distributed-executor-backend ray` in the API server. vLLM selects Ray on its own only when it already runs inside a Ray placement group, for example under Ray Serve LLM, or when `--data-parallel-backend ray` is set. For multi-node `multiprocessing`, also set `--nnodes`, `--node-rank`, and `--master-addr`, as shown in [Running vLLM with MultiProcessing](#running-vllm-with-multiprocessing). If the world size exceeds the number of GPUs on the current node and neither a backend nor `--nnodes` is given, vLLM raises an error asking you to choose one.
 
 For multi-GPU inference, set `tensor_parallel_size` in the `LLM` class to the desired GPU count. For example, to run inference on 4 GPUs:
 


### PR DESCRIPTION
## Purpose
`ParallelConfig.__post_init__` defaults CUDA multi-node inference to `mp`, not Ray: with `nnodes > 1` it picks `mp`, and when the world size exceeds the GPUs on the current node with no backend and no `--nnodes` it raises an error telling the user to choose one. Ray is only selected on its own when vLLM already runs inside a Ray placement group or when `--data-parallel-backend ray` is set. The `distributed_executor_backend` field docstring already states that Ray must be set manually, so only the docs were stale.
## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

## AI Assistance

This PR was prepared with AI assistance (Claude). The claim was verified against `vllm/config/parallel.py` in the current `main`, the reworded paragraph was reviewed line by line by the submitter, and `pre-commit run --files docs/serving/parallelism_scaling.md` was run locally. Commit attribution is included via a `Co-authored-by:` trailer.
