### PR TITLE
[Bugfix][Core] Preserve Mamba running CoW after external hits

### DIFF
--- a/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
+++ b/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
@@ -333,6 +333,78 @@ def test_hybrid_mamba_partial_tail_owner_uses_cow_on_continue():
     assert moved[0].block_hash_num_tokens == 6
 
 
+def test_external_mamba_hit_same_block_uses_running_cow_on_continue():
+    """An external mid-block hit must become a running request even when its
+    first continuation does not need another Mamba block."""
+    hash_block_size = 2
+    mamba_block_size = 4 * hash_block_size
+    kv_cache_config = KVCacheConfig(
+        num_blocks=32,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["full"],
+                FullAttentionSpec(
+                    block_size=hash_block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                ),
+            ),
+            KVCacheGroupSpec(
+                ["mamba"],
+                MambaSpec(
+                    block_size=mamba_block_size,
+                    shapes=(1, 1),
+                    dtypes=(torch.float32,),
+                    mamba_cache_mode="align",
+                ),
+            ),
+        ],
+    )
+    manager = make_kv_cache_manager(
+        kv_cache_config=kv_cache_config,
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=hash_block_size,
+    )
+
+    request = make_request("0", [0] * 15, hash_block_size, sha256)
+    loaded_blocks = manager.allocate_slots(
+        request,
+        num_new_tokens=0,
+        num_external_computed_tokens=10,
+        delay_cache_blocks=True,
+    )
+    assert loaded_blocks is not None
+
+    request.num_computed_tokens = 10
+    first_step_blocks = manager.allocate_slots(request, num_new_tokens=4)
+    assert first_step_blocks is not None
+
+    source_block_id = manager.get_blocks("0").get_block_ids()[1][1]
+    partial_hash = request.block_hashes[14 // hash_block_size - 1]
+    partial_block = manager.block_pool.get_cached_block(
+        partial_hash, kv_cache_group_ids=[1]
+    )
+    assert partial_block is not None
+    assert partial_block[0].block_id == source_block_id
+
+    request.num_computed_tokens = 14
+    continuation_blocks = manager.allocate_slots(request, num_new_tokens=1)
+    assert continuation_blocks is not None
+
+    assert continuation_blocks.get_block_ids()[1] == []
+    assert manager.get_blocks("0").get_block_ids()[1][1] == source_block_id
+    copies, _ = manager.take_kv_cache_block_copies()
+    cow_copy = next(c for c in copies if c.src_block_id == source_block_id)
+    assert cow_copy.dst_block_id != source_block_id
+
+    moved = manager.block_pool.get_cached_block(partial_hash, kv_cache_group_ids=[1])
+    assert moved is not None
+    assert moved[0].block_id == cow_copy.dst_block_id
+
+
 def test_take_partial_tail_offloads_returns_cow_target():
     """The connector offload hand-off exposes the mamba CoW *target* block Y
     (the durable boundary state), not the overwritten source X, and only at

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -1559,6 +1559,7 @@ class MambaManager(SingleTypeKVCacheManager):
             # `num_required_blocks` might be less than `len(req_blocks)` if blocks are
             # over-allocated at last round.
             if num_required_blocks <= len(req_blocks) and not has_partial_hit:
+                self._allocated_block_reqs.add(request_id)
                 return []
             else:
                 prev_block_len = len(req_blocks)


### PR DESCRIPTION
## Summary

Preserve running-request copy-on-write semantics for Mamba `align` requests whose externally loaded prefix already provides every block needed by their first continuation.

The observed Kimi-K3 geometry is:

```text
external state@24,960
→ prefill to partial tail@25,472 (no Mamba block growth)
→ continue to prompt end@25,525
```

## Root cause

`allocate_external_computed_blocks()` can populate the request's Mamba block table, but when the first continuation stays in the same Mamba block, `allocate_new_blocks()` returns early without adding the request to `_allocated_block_reqs`.

If that continuation registers a partial-tail cache entry, the following CoW is then misclassified as a first-prefill CoW. Core replaces the live block in its table and returns the replacement block, while the worker treats the request as already running and appends returned block IDs. Core and worker consequently disagree about the live Mamba state column.

## Fix

Mark the request allocated on the no-new-block early-return path. A later partial-tail CoW then uses the running-request branch: the live block remains in the request table, the cached snapshot moves to the CoW target, and no replacement block is appended by the worker.

The regression models the async external-load sequence with smaller equivalent geometry:

```text
external state@10
→ prefill to partial tail@14
→ continue to prompt end@15
```

It asserts that the live Mamba block remains at its original table position and that the partial-tail hash moves to the queued CoW copy target.

## Scope and duplicate-work check

This is materially different from #51763. That PR suppresses the partial-tail stop after a mid-block resume, which avoids this transition but also gives up the valid partial-tail cache entry. This change preserves fine-grained partial-tail caching and fixes the scheduler/worker ownership bookkeeping that makes its continuation unsafe.

#51358 addresses exact Mamba boundary-state persistence and connector handoff lifetime; it does not mark an externally populated request allocated on this early-return path.

## Validation

The new regression was run without the source change and failed as expected because the continuation returned a replacement Mamba block:

```text
assert [10] == []
```

With the fix:

```bash
.venv/bin/python -m pytest tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py -q
# 23 passed
```

The macOS run disabled vLLM's autouse global accelerator cleanup for this CPU-only suite because PyTorch's MPS teardown raises an unrelated `CachingDeviceAllocator` assertion. The override was local and is not included in this PR.

```bash
pre-commit run --files \
  vllm/v1/core/single_type_kv_cache_manager.py \
  tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
# passed
```

Model evaluation has not been rerun because this branch is not deployed. The production pre-fix replay observed 3/12 verbatim repeats at the affected `24,960 → 25,472 → 25,525` geometry. A post-fix replay is required before this draft is marked ready.

## AI assistance

OpenAI Codex was used to investigate, implement, and test this change. The human submitter must review every changed line, understand the scheduler/worker block-table transition, and run the post-deployment model evaluation before marking the PR ready.
