### PR TITLE
[FS-Offloading] : Simplify fs manager

### DIFF
--- a/tests/v1/kv_offload/tiering/test_fs_tier.py
+++ b/tests/v1/kv_offload/tiering/test_fs_tier.py
@@ -447,7 +447,9 @@ def test_wait_idle_blocks_until_tasks_complete():
     """wait_idle must not return while a task is still in flight."""
     pool = DualQueueThreadPool(n_read_threads=1, n_write_threads=1)
     gate = threading.Event()
-    pool.enqueue_store(job_id=1, n_tasks=1, tasks=[lambda: gate.wait(timeout=5.0)])
+    pool.enqueue_store(
+        job_id=1, n_tasks=1, tasks=[(lambda: gate.wait(timeout=5.0), [None])]
+    )
 
     waiter = threading.Thread(target=pool.wait_idle)
     waiter.start()

--- a/tests/v1/kv_offload/tiering/test_fs_tier.py
+++ b/tests/v1/kv_offload/tiering/test_fs_tier.py
@@ -40,7 +40,7 @@ from vllm.v1.kv_offload.tiering.factory import SecondaryTierFactory
 from vllm.v1.kv_offload.tiering.fs.manager import (
     FileSystemTierManager,
 )
-from vllm.v1.kv_offload.tiering.fs.thread_pool import DualQueueThreadPool
+from vllm.v1.kv_offload.tiering.fs.thread_pool import DualQueueThreadPool, Task
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -447,8 +447,17 @@ def test_wait_idle_blocks_until_tasks_complete():
     """wait_idle must not return while a task is still in flight."""
     pool = DualQueueThreadPool(n_read_threads=1, n_write_threads=1)
     gate = threading.Event()
+
+    def blocking_batch_store_block(*args, **kwargs):
+        gate.wait(timeout=5.0)
+
+    # dummy task
+    task = Task(key=key(0), offset=0)
     pool.enqueue_store(
-        job_id=1, n_tasks=1, tasks=[(lambda: gate.wait(timeout=5.0), [None])]
+        job_id=1,
+        n_tasks=1,
+        tasks=[task],
+        make_io_fn=lambda batch: blocking_batch_store_block,
     )
 
     waiter = threading.Thread(target=pool.wait_idle)
@@ -463,6 +472,28 @@ def test_wait_idle_blocks_until_tasks_complete():
         gate.set()
         pool.shutdown(wait=True)
         waiter.join(timeout=5.0)
+
+
+@pytest.mark.parametrize(
+    ("n_tasks", "n_threads", "expected_sizes"),
+    [
+        (7, 1, [7]),
+        (6, 1, [6]),
+        (2, 1, [2]),
+        (0, 1, []),
+    ],
+)
+def test_batch_tasks_distribution(n_tasks, n_threads, expected_sizes):
+    """_batch_tasks splits tasks evenly across n_threads (largest remainder
+    first), preserving order and accounting for every task."""
+    pool = DualQueueThreadPool(n_read_threads=1, n_write_threads=1)
+    try:
+        tasks = [Task(key=key(i), offset=i) for i in range(n_tasks)]
+        batches = list(pool._batch_tasks(tasks, n_threads))
+        assert [len(b) for b in batches] == expected_sizes
+        assert [t for b in batches for t in b] == tasks
+    finally:
+        pool.shutdown(wait=True)
 
 
 def test_batch_lookup_c_extension(tmp_path):

--- a/tests/v1/kv_offload/tiering/test_fs_tier.py
+++ b/tests/v1/kv_offload/tiering/test_fs_tier.py
@@ -452,7 +452,7 @@ def test_wait_idle_blocks_until_tasks_complete():
         gate.wait(timeout=5.0)
 
     # dummy task
-    task = Task(key=key(0), offset=0)
+    task = Task(key=key(0), path="dummy", offset=0)
     pool.enqueue_store(
         job_id=1,
         n_tasks=1,
@@ -488,7 +488,7 @@ def test_batch_tasks_distribution(n_tasks, n_threads, expected_sizes):
     first), preserving order and accounting for every task."""
     pool = DualQueueThreadPool(n_read_threads=1, n_write_threads=1)
     try:
-        tasks = [Task(key=key(i), offset=i) for i in range(n_tasks)]
+        tasks = [Task(key=key(i), path="dummy", offset=i) for i in range(n_tasks)]
         batches = list(pool._batch_tasks(tasks, n_threads))
         assert [len(b) for b in batches] == expected_sizes
         assert [t for b in batches for t in b] == tasks

--- a/vllm/v1/kv_offload/tiering/fs/manager.py
+++ b/vllm/v1/kv_offload/tiering/fs/manager.py
@@ -199,6 +199,7 @@ class FileSystemTierManager(SecondaryTierManager):
         for key, bid in zip(job_metadata.keys, job_metadata.block_ids):
             yield Task(
                 key=key,
+                path=self.file_mapper.get_file_name(key),
                 offset=int(bid) * self._block_size,
             )
 
@@ -222,7 +223,7 @@ class FileSystemTierManager(SecondaryTierManager):
         def make_io_fn(batch: list[Task]) -> Callable[[], None]:
             return functools.partial(
                 batch_store_block,
-                paths=[self.file_mapper.get_file_name(t.key) for t in batch],
+                paths=[t.path for t in batch],
                 offsets=[t.offset for t in batch],
                 view=self._primary_kv_view,
                 block_size=self._block_size,
@@ -247,7 +248,7 @@ class FileSystemTierManager(SecondaryTierManager):
         def make_io_fn(batch: list[Task]) -> Callable[[], None]:
             return functools.partial(
                 batch_load_block,
-                paths=[self.file_mapper.get_file_name(t.key) for t in batch],
+                paths=[t.path for t in batch],
                 offsets=[t.offset for t in batch],
                 view=self._primary_kv_view,
                 block_size=self._block_size,

--- a/vllm/v1/kv_offload/tiering/fs/manager.py
+++ b/vllm/v1/kv_offload/tiering/fs/manager.py
@@ -151,13 +151,6 @@ class FileSystemTierManager(SecondaryTierManager):
         # Keys of in-flight load (promotion) jobs, so a failed load can mark
         # its own cached lookup verdicts False (see get_finished_jobs).
         self._load_job_keys: dict[JobId, list[OffloadKey]] = {}
-        # Per load job: how many blocks loaded before a failure (partial keep).
-        # Written by the pool worker inside the load task before it raises (so
-        # before task_done publishes the job); read on the scheduler thread in
-        # get_finished_jobs only for job ids the finished queue returned. Under
-        # the GIL that read cannot observe the finished job without the prior
-        # write, so no extra lock is needed (get_finished is itself lock-free).
-        self._load_progress: dict[JobId, int] = {}
 
         # Extract block size from primary view
         assert primary_kv_view.strides is not None, (
@@ -226,7 +219,7 @@ class FileSystemTierManager(SecondaryTierManager):
             self._block_size,
             self._use_o_direct,
         )
-        self._pool.enqueue_store(job_metadata.job_id, 1, [task])
+        self._pool.enqueue_store(job_metadata.job_id, 1, [(task, keys)])
 
     @override
     def submit_load(self, job_metadata: TransferJob) -> None:
@@ -235,47 +228,26 @@ class FileSystemTierManager(SecondaryTierManager):
         # keys as a miss (see get_finished_jobs).
         keys = list(job_metadata.keys)
         self._load_job_keys[job_id] = keys
-        paths = [self.file_mapper.get_file_name(key) for key in keys]
-        offsets = [int(bid) * self._block_size for bid in job_metadata.block_ids]
-
-        def load_task() -> None:
-            try:
-                batch_load_block(
-                    paths,
-                    self._primary_kv_view,
-                    offsets,
-                    self._block_size,
-                    self._use_o_direct,
-                )
-            except OSError as exc:
-                # Runs on the pool worker thread. Record how many blocks loaded
-                # before the failure so get_finished_jobs can keep them; this
-                # write precedes task_done, so the scheduler reads it safely
-                # under the GIL once the finished queue hands back this job.
-                num_succeeded = getattr(exc, "num_succeeded", 0)
-                self._load_progress[job_id] = num_succeeded
-                # Surfaces errno (e.g. EMFILE "Too many open files") for both
-                # the C and Python load paths.
-                logger.debug(
-                    "Load of %d blocks for job %s failed at block %d: %s",
-                    len(paths),
-                    job_id,
-                    num_succeeded,
-                    exc,
-                )
-                raise
-
-        self._pool.enqueue_load(job_id, 1, [load_task])
+        task = functools.partial(
+            batch_load_block,
+            [self.file_mapper.get_file_name(key) for key in keys],
+            self._primary_kv_view,
+            [int(bid) * self._block_size for bid in job_metadata.block_ids],
+            self._block_size,
+            self._use_o_direct,
+        )
+        self._pool.enqueue_load(job_id, 1, [(task, keys)])
 
     @override
     def get_finished_jobs(self) -> Iterable[JobResult]:
         """Collect finished jobs; a failed promotion marks only its failed keys
         as a miss here (scheduler thread)."""
         results = []
-        for job_id, success, transfer_time in self._pool.get_finished():
+        for finished in self._pool.get_finished():
+            job_id = finished.job_id
             if self.events is not None:
                 keys = self._store_job_keys.pop(job_id, None)
-                if success and keys:
+                if finished.success and keys:
                     self.events.append(
                         OffloadingEvent(
                             keys=keys,
@@ -285,29 +257,25 @@ class FileSystemTierManager(SecondaryTierManager):
                         )
                     )
             load_keys = self._load_job_keys.pop(job_id, None)
-            num_succeeded = self._load_progress.pop(job_id, 0)
-            if load_keys is not None and not success:
-                # A batched load stops at the first bad block and reports how
-                # many loaded before it. Those earlier blocks are kept in the
-                # primary tier (reported via successful_keys); only this block
-                # and the ones after it are marked a miss and recomputed.
-                successful = load_keys[:num_succeeded]
-                failed = load_keys[num_succeeded:]
-                self._lookup_manager.mark_miss(failed)
+            if load_keys is not None and not finished.success:
+                # Keys the pool reported as failed are marked as a MISS in
+                # the lookup cache.
+                self._lookup_manager.mark_miss(finished.failed_keys)
+                successful = set(load_keys) - set(finished.failed_keys)
                 results.append(
                     JobResult(
                         job_id=job_id,
                         success=False,
                         successful_keys=tuple(successful) if successful else None,
-                        transfer_time=transfer_time,
+                        transfer_time=finished.transfer_time,
                     )
                 )
                 continue
             results.append(
                 JobResult(
                     job_id=job_id,
-                    success=success,
-                    transfer_time=transfer_time,
+                    success=finished.success,
+                    transfer_time=finished.transfer_time,
                 )
             )
         return results

--- a/vllm/v1/kv_offload/tiering/fs/manager.py
+++ b/vllm/v1/kv_offload/tiering/fs/manager.py
@@ -18,7 +18,7 @@ File naming:  <base_path>_r<rank>/<hhh>/<hh>_g<group_idx>/<hash_hex>.bin
 import functools
 import json
 import os
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from typing import TYPE_CHECKING, ClassVar
 
 try:
@@ -54,7 +54,7 @@ from vllm.v1.kv_offload.tiering.fs.io import (
     batch_store_block,
     probe_o_direct,
 )
-from vllm.v1.kv_offload.tiering.fs.thread_pool import DualQueueThreadPool
+from vllm.v1.kv_offload.tiering.fs.thread_pool import DualQueueThreadPool, Task
 
 if TYPE_CHECKING:
     from vllm.v1.kv_offload.base import OffloadingSpec
@@ -195,6 +195,13 @@ class FileSystemTierManager(SecondaryTierManager):
 
         self._lookup_manager = FsAsyncLookupManager(tier=self, tier_type=self.tier_type)
 
+    def _tasks_from_jobmetadata(self, job_metadata: TransferJob) -> Iterable[Task]:
+        for key, bid in zip(job_metadata.keys, job_metadata.block_ids):
+            yield Task(
+                key=key,
+                offset=int(bid) * self._block_size,
+            )
+
     @override
     def on_new_request(self, req_context: ReqContext) -> RequestOffloadingContext:
         return RequestOffloadingContext()
@@ -211,15 +218,23 @@ class FileSystemTierManager(SecondaryTierManager):
         keys = list(job_metadata.keys)
         if self.events is not None:
             self._store_job_keys[job_metadata.job_id] = keys
-        task = functools.partial(
-            batch_store_block,
-            [self.file_mapper.get_file_name(key) for key in keys],
-            self._primary_kv_view,
-            [int(bid) * self._block_size for bid in job_metadata.block_ids],
-            self._block_size,
-            self._use_o_direct,
+
+        def make_io_fn(batch: list[Task]) -> Callable[[], None]:
+            return functools.partial(
+                batch_store_block,
+                paths=[self.file_mapper.get_file_name(t.key) for t in batch],
+                offsets=[t.offset for t in batch],
+                view=self._primary_kv_view,
+                block_size=self._block_size,
+                use_o_direct=self._use_o_direct,
+            )
+
+        self._pool.enqueue_store(
+            job_metadata.job_id,
+            len(keys),
+            self._tasks_from_jobmetadata(job_metadata),
+            make_io_fn=make_io_fn,
         )
-        self._pool.enqueue_store(job_metadata.job_id, 1, [(task, keys)])
 
     @override
     def submit_load(self, job_metadata: TransferJob) -> None:
@@ -228,15 +243,23 @@ class FileSystemTierManager(SecondaryTierManager):
         # keys as a miss (see get_finished_jobs).
         keys = list(job_metadata.keys)
         self._load_job_keys[job_id] = keys
-        task = functools.partial(
-            batch_load_block,
-            [self.file_mapper.get_file_name(key) for key in keys],
-            self._primary_kv_view,
-            [int(bid) * self._block_size for bid in job_metadata.block_ids],
-            self._block_size,
-            self._use_o_direct,
+
+        def make_io_fn(batch: list[Task]) -> Callable[[], None]:
+            return functools.partial(
+                batch_load_block,
+                paths=[self.file_mapper.get_file_name(t.key) for t in batch],
+                offsets=[t.offset for t in batch],
+                view=self._primary_kv_view,
+                block_size=self._block_size,
+                use_o_direct=self._use_o_direct,
+            )
+
+        self._pool.enqueue_load(
+            job_metadata.job_id,
+            len(keys),
+            self._tasks_from_jobmetadata(job_metadata),
+            make_io_fn=make_io_fn,
         )
-        self._pool.enqueue_load(job_id, 1, [(task, keys)])
 
     @override
     def get_finished_jobs(self) -> Iterable[JobResult]:
@@ -260,10 +283,9 @@ class FileSystemTierManager(SecondaryTierManager):
             if load_keys is not None and not finished.success:
                 # Keys the pool reported as failed are marked as a MISS in
                 # the lookup cache.
-                self._lookup_manager.mark_miss(finished.failed_keys)
-                successful = tuple(
-                    k for k in load_keys if k not in finished.failed_keys
-                )
+                failed = set([t.key for t in finished.failed_tasks])
+                self._lookup_manager.mark_miss(failed)
+                successful = tuple(k for k in load_keys if k not in failed)
                 results.append(
                     JobResult(
                         job_id=job_id,

--- a/vllm/v1/kv_offload/tiering/fs/manager.py
+++ b/vllm/v1/kv_offload/tiering/fs/manager.py
@@ -261,7 +261,9 @@ class FileSystemTierManager(SecondaryTierManager):
                 # Keys the pool reported as failed are marked as a MISS in
                 # the lookup cache.
                 self._lookup_manager.mark_miss(finished.failed_keys)
-                successful = set(load_keys) - set(finished.failed_keys)
+                successful = tuple(
+                    k for k in load_keys if k not in finished.failed_keys
+                )
                 results.append(
                     JobResult(
                         job_id=job_id,

--- a/vllm/v1/kv_offload/tiering/fs/thread_pool.py
+++ b/vllm/v1/kv_offload/tiering/fs/thread_pool.py
@@ -12,18 +12,31 @@ import threading
 import time
 from collections import deque
 from collections.abc import Callable, Iterable
+from dataclasses import dataclass
 
 from vllm.logger import init_logger
+from vllm.v1.kv_offload.base import OffloadKey
 from vllm.v1.kv_offload.tiering.base import JobId
 
 logger = init_logger(__name__)
+
+
+@dataclass
+class PoolJobResult:
+    """Outcome of a job whose tasks have all completed."""
+
+    job_id: JobId
+    success: bool
+    transfer_time: float
+    failed_keys: list[OffloadKey]
 
 
 class JobState:
     """
     Thread-safe completion tracker for a set of per-block I/O tasks.
 
-    Each task calls task_done(success) when it finishes.
+    Each task calls task_done(keys, num_succeeded, success, transfer_time)
+    when it finishes.
     """
 
     __slots__ = (
@@ -32,6 +45,7 @@ class JobState:
         "_completed",
         "_success",
         "_transfer_time",
+        "_failed_keys",
         "_lock",
     )
 
@@ -41,6 +55,7 @@ class JobState:
         self._completed = 0
         self._success = True
         self._transfer_time = 0.0
+        self._failed_keys: list[OffloadKey] = []
         self._lock = threading.Lock()
 
     @property
@@ -48,15 +63,30 @@ class JobState:
         return self._job_id
 
     def task_done(
-        self, success: bool, transfer_time: float
-    ) -> tuple[bool, bool, float]:
-        """Returns if job completed and success flag"""
+        self,
+        keys: list[OffloadKey],
+        num_succeeded: int,
+        success: bool,
+        transfer_time: float,
+    ) -> PoolJobResult | None:
+        """
+        Records this task's outcome; returns the job's PoolJobResult once
+        every task has reported in, else None.
+        """
         with self._lock:
             self._completed += 1
             self._transfer_time += transfer_time
             if not success:
                 self._success = False
-            return self._completed == self._n_tasks, self._success, self._transfer_time
+                self._failed_keys.extend(keys[num_succeeded:])
+            if self._completed != self._n_tasks:
+                return None
+            return PoolJobResult(
+                job_id=self._job_id,
+                success=self._success,
+                transfer_time=self._transfer_time,
+                failed_keys=self._failed_keys,
+            )
 
 
 class DualQueueThreadPool:
@@ -79,7 +109,7 @@ class DualQueueThreadPool:
         self._condition = threading.Condition(threading.Lock())
         self._stop = False
         self._threads: list[threading.Thread] = []
-        self._finished_q: deque[tuple[JobId, bool, float]] = deque()
+        self._finished_q: deque[PoolJobResult] = deque()
         self._inflight_jobs = 0  # guarded by _condition
 
         for i in range(n_read_threads):
@@ -106,31 +136,38 @@ class DualQueueThreadPool:
         self,
         job_id: JobId,
         n_tasks: int,
-        tasks: Iterable[Callable],
+        tasks: Iterable[tuple[Callable[[], None], list[OffloadKey]]],
     ) -> None:
-        """Enqueue load tasks for a job (high-priority for load-priority threads)."""
+        """Enqueue load tasks for a job (high-priority for load-priority threads).
+
+        Each task is a (fn, keys) pair: `keys` are the keys `fn` loads, in the
+        same order `fn` processes them.
+        """
         state = JobState(job_id, n_tasks)
         with self._condition:
             self._inflight_jobs += 1
-            for fn in tasks:
-                self._load_q.append((fn, state))
+            for fn, keys in tasks:
+                self._load_q.append((fn, keys, state))
             self._condition.notify(n_tasks)
 
     def enqueue_store(
         self,
         job_id: JobId,
         n_tasks: int,
-        tasks: Iterable[Callable],
+        tasks: Iterable[tuple[Callable[[], None], list[OffloadKey]]],
     ) -> None:
-        """Enqueue store tasks for a job (high-priority for store-priority threads)."""
+        """Enqueue store tasks for a job (high-priority for store-priority threads).
+
+        See `enqueue_load` for the (fn, keys) task shape.
+        """
         state = JobState(job_id, n_tasks)
         with self._condition:
             self._inflight_jobs += 1
-            for fn in tasks:
-                self._store_q.append((fn, state))
+            for fn, keys in tasks:
+                self._store_q.append((fn, keys, state))
             self._condition.notify(n_tasks)
 
-    def get_finished(self) -> list[tuple[JobId, bool, float]]:
+    def get_finished(self) -> list[PoolJobResult]:
         # No lock needed: deque is thread-safe for concurrent append/popleft,
         # and the manager is the sole popper.
         jobs = []
@@ -173,12 +210,12 @@ class DualQueueThreadPool:
                     return
                 primary = self._load_q if load_priority else self._store_q
                 secondary = self._store_q if load_priority else self._load_q
-                task, state = primary.popleft() if primary else secondary.popleft()
+                fn, keys, state = primary.popleft() if primary else secondary.popleft()
             try:
                 start_time = time.monotonic()
-                task()
+                fn()
                 transfer_time = time.monotonic() - start_time
-                job_finished, success, total_time = state.task_done(True, transfer_time)
+                result = state.task_done(keys, len(keys), True, transfer_time)
             except Exception as exc:
                 transfer_time = time.monotonic() - start_time
                 logger.error(
@@ -186,12 +223,14 @@ class DualQueueThreadPool:
                     state.job_id,
                     exc,
                 )
-                job_finished, success, total_time = state.task_done(
-                    False, transfer_time
-                )
+                # num_succeeded is only set on a partial failure (see
+                # io.batch_load_block); other exceptions leave none of this
+                # task's keys credited as successful.
+                num_succeeded = getattr(exc, "num_succeeded", 0)
+                result = state.task_done(keys, num_succeeded, False, transfer_time)
 
-            if job_finished:
+            if result is not None:
                 with self._condition:
-                    self._finished_q.append((state.job_id, success, total_time))
+                    self._finished_q.append(result)
                     self._inflight_jobs -= 1
                     self._condition.notify_all()

--- a/vllm/v1/kv_offload/tiering/fs/thread_pool.py
+++ b/vllm/v1/kv_offload/tiering/fs/thread_pool.py
@@ -11,7 +11,7 @@ Thread pool:
 import threading
 import time
 from collections import deque
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Iterable, Iterator
 from dataclasses import dataclass
 
 from vllm.logger import init_logger
@@ -22,13 +22,19 @@ logger = init_logger(__name__)
 
 
 @dataclass
+class Task:
+    key: OffloadKey
+    offset: int
+
+
+@dataclass
 class PoolJobResult:
     """Outcome of a job whose tasks have all completed."""
 
     job_id: JobId
     success: bool
     transfer_time: float
-    failed_keys: list[OffloadKey]
+    failed_tasks: list[Task]
 
 
 class JobState:
@@ -45,7 +51,7 @@ class JobState:
         "_completed",
         "_success",
         "_transfer_time",
-        "_failed_keys",
+        "_failed_tasks",
         "_lock",
     )
 
@@ -55,7 +61,7 @@ class JobState:
         self._completed = 0
         self._success = True
         self._transfer_time = 0.0
-        self._failed_keys: list[OffloadKey] = []
+        self._failed_tasks: list[Task] = []
         self._lock = threading.Lock()
 
     @property
@@ -64,7 +70,7 @@ class JobState:
 
     def task_done(
         self,
-        keys: list[OffloadKey],
+        batch: list[Task],
         num_succeeded: int,
         success: bool,
         transfer_time: float,
@@ -74,18 +80,18 @@ class JobState:
         every task has reported in, else None.
         """
         with self._lock:
-            self._completed += 1
+            self._completed += len(batch)
             self._transfer_time += transfer_time
             if not success:
                 self._success = False
-                self._failed_keys.extend(keys[num_succeeded:])
+                self._failed_tasks.extend(batch[num_succeeded:])
             if self._completed != self._n_tasks:
                 return None
             return PoolJobResult(
                 job_id=self._job_id,
                 success=self._success,
                 transfer_time=self._transfer_time,
-                failed_keys=self._failed_keys,
+                failed_tasks=self._failed_tasks,
             )
 
 
@@ -132,40 +138,85 @@ class DualQueueThreadPool:
             t.start()
             self._threads.append(t)
 
+    def _batch_tasks(
+        self,
+        tasks: list[Task],
+        n_threads: int,
+    ) -> Iterator[list[Task]]:
+        """
+        Batch tasks so that the request's tasks are split evenly across the
+        n_threads.
+        """
+        assert n_threads > 0
+
+        n_tasks = len(tasks)
+        q, r = divmod(n_tasks, n_threads)
+        batch_sizes = [q + 1 if i < r else q for i in range(n_threads)]
+        assert sum(batch_sizes) == n_tasks
+        start = 0
+        for bs in batch_sizes[: min(n_tasks, n_threads)]:
+            yield tasks[start : start + bs]
+            start += bs
+
+    def _enqueue(
+        self,
+        queue: deque,
+        make_io_fn: Callable[[list[Task]], Callable[[], None]],
+        job_id: JobId,
+        tasks: Iterable[Task],
+        n_tasks: int,
+        n_threads: int,
+    ) -> None:
+        """Batch `tasks` and append (fn, state, batch_size) entries to `queue`."""
+        if n_tasks == 0:
+            self._finished_q.append(PoolJobResult(job_id, True, 0.0, []))
+            return
+        state = JobState(job_id, n_tasks)
+        task_lst = list(tasks)  # Materialize tasks out of self._condition
+        assert len(task_lst) == n_tasks, "Unaccounted tasks"
+        n_batches = 0
+        with self._condition:
+            self._inflight_jobs += 1
+            for batch in self._batch_tasks(task_lst, n_threads):
+                queue.append((make_io_fn(batch), batch, state))
+                n_batches += 1
+            self._condition.notify(n_batches)
+
     def enqueue_load(
         self,
         job_id: JobId,
         n_tasks: int,
-        tasks: Iterable[tuple[Callable[[], None], list[OffloadKey]]],
+        tasks: Iterable[Task],
+        make_io_fn: Callable[[list[Task]], Callable[[], None]],
     ) -> None:
-        """Enqueue load tasks for a job (high-priority for load-priority threads).
+        """Enqueue load tasks for a job (high-priority for load-priority threads)."""
 
-        Each task is a (fn, keys) pair: `keys` are the keys `fn` loads, in the
-        same order `fn` processes them.
-        """
-        state = JobState(job_id, n_tasks)
-        with self._condition:
-            self._inflight_jobs += 1
-            for fn, keys in tasks:
-                self._load_q.append((fn, keys, state))
-            self._condition.notify(n_tasks)
+        self._enqueue(
+            self._load_q,
+            make_io_fn,
+            job_id,
+            tasks,
+            n_tasks=n_tasks,
+            n_threads=1,
+        )
 
     def enqueue_store(
         self,
         job_id: JobId,
         n_tasks: int,
-        tasks: Iterable[tuple[Callable[[], None], list[OffloadKey]]],
+        tasks: Iterable[Task],
+        make_io_fn: Callable[[list[Task]], Callable[[], None]],
     ) -> None:
-        """Enqueue store tasks for a job (high-priority for store-priority threads).
+        """Enqueue store tasks for a job (high-priority for store-priority threads)."""
 
-        See `enqueue_load` for the (fn, keys) task shape.
-        """
-        state = JobState(job_id, n_tasks)
-        with self._condition:
-            self._inflight_jobs += 1
-            for fn, keys in tasks:
-                self._store_q.append((fn, keys, state))
-            self._condition.notify(n_tasks)
+        self._enqueue(
+            self._store_q,
+            make_io_fn,
+            job_id,
+            tasks,
+            n_tasks=n_tasks,
+            n_threads=1,
+        )
 
     def get_finished(self) -> list[PoolJobResult]:
         # No lock needed: deque is thread-safe for concurrent append/popleft,
@@ -210,12 +261,12 @@ class DualQueueThreadPool:
                     return
                 primary = self._load_q if load_priority else self._store_q
                 secondary = self._store_q if load_priority else self._load_q
-                fn, keys, state = primary.popleft() if primary else secondary.popleft()
+                fn, batch, state = primary.popleft() if primary else secondary.popleft()
             try:
                 start_time = time.monotonic()
                 fn()
                 transfer_time = time.monotonic() - start_time
-                result = state.task_done(keys, len(keys), True, transfer_time)
+                result = state.task_done(batch, len(batch), True, transfer_time)
             except Exception as exc:
                 transfer_time = time.monotonic() - start_time
                 logger.error(
@@ -227,7 +278,7 @@ class DualQueueThreadPool:
                 # io.batch_load_block); other exceptions leave none of this
                 # task's keys credited as successful.
                 num_succeeded = getattr(exc, "num_succeeded", 0)
-                result = state.task_done(keys, num_succeeded, False, transfer_time)
+                result = state.task_done(batch, num_succeeded, False, transfer_time)
 
             if result is not None:
                 with self._condition:

--- a/vllm/v1/kv_offload/tiering/fs/thread_pool.py
+++ b/vllm/v1/kv_offload/tiering/fs/thread_pool.py
@@ -24,6 +24,7 @@ logger = init_logger(__name__)
 @dataclass
 class Task:
     key: OffloadKey
+    path: str
     offset: int
 
 


### PR DESCRIPTION
## Purpose
The tracking of failed keys on `main` is handled in the fs/manager. This makes the manager more complicated than necessary. 

This PR makes failed_keys a first class citizen in the DualQueueThreadPool. The DualQueueThreadPool already maintains a JobState to track a Job's progress and reasons about failure/success based on results directly from the threadpool. With this change, the manager simply relies on the finished job results from the DualQueueThreadPool. 

This PR also adds batching infrasturcture to DualQueueThreadPool, but exercises it naively (same policy as main), i.e. all keys from a single request are processed by a single thread.

## Test Plan
`pytest -s tests/v1/kv_offload/tiering/test_fs_tier.py`

vllm serve command: 
```
++ vllm serve openai/gpt-oss-120b --tensor-parallel-size=2 --kv-transfer-config '{                                                               
  "kv_connector": "OffloadingConnector",                                                                                                         
  "kv_role": "kv_both",                                                                                                                          
  "kv_connector_extra_config": {                                                                                                                 
    "blocks_per_chunk" : 1,                                                                                                                      
    "spec_name": "TieringOffloadingSpec",                                                                                                        
    "cpu_bytes_to_use": 150323855360,                                                                                                            
    "eviction_policy": "lru",                                                                                                                    
    "secondary_tiers": [{                                                                                                                        
       "type": "fs",                                                                                                                             
       "root_dir": "/mnt/nvme-storage/",                                                                                                         
       "n_read_threads": 16,                                                                                                                     
       "n_write_threads": 16                                                                                                                     
    }]                                                                                                                                           
    ,"enable_cross_layers_blocks" : "True"                                                                                                       
  }                                                                                                                                              
}' --enable-prefix-caching --no-disable-hybrid-kv-cache-manager --port 8000    
```

lm eval command:
```
TARGET_URL="http://127.0.0.1:8000"
MODEL="openai/gpt-oss-120b"
LM_EVAL_NUM_CONCURRENT=1000
LM_EVAL_TASKS="gsm8k"


lm_eval \
  --model local-completions \
  --model_args "base_url=${TARGET_URL}/v1/completions,model=${MODEL},tokenized_requests=False,num_concurrent=${LM_EVAL_NUM_CONCURRENT},trust_remote_code=True" \
  --tasks ${LM_EVAL_TASKS} \
  --seed 42 \
  --num_fewshot 25 \
  --gen_kwargs temperature=0.0
```

## Test Result
Unit tests pass 

lm eval outputs : 
`Run 1 : cold cache`
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|                                                                        
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|                                                                        
|gsm8k|      3|flexible-extract|    25|exact_match|↑  |0.6247|±  |0.0133|                                                                        
|     |       |strict-match    |    25|exact_match|↑  |0.4223|±  |0.0136| 
```
`Run 2 : warm cache`
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|    25|exact_match|↑  |0.6270|±  |0.0133|
|     |       |strict-match    |    25|exact_match|↑  |0.4223|±  |0.0136|
```
`Run 3 : warm cache`
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|    25|exact_match|↑  |0.6156|±  |0.0134|
|     |       |strict-match    |    25|exact_match|↑  |0.4155|±  |0.0136|
```


## Performance
`guidellm command`
```
BENCH_RATE="64"
BENCH_RATE_TYPE="concurrent"
BENCH_MAX_SECONDS="700"
BENCH_RANDOM_SEED="889"
BENCH_TURNS=5
BENCH_PROMPT_TOKENS="4096"
BENCH_OUTPUT_TOKENS="512"
BENCH_PREFIX_TOKENS="10000"
PREFIX_COUNT=$((4 * BENCH_RATE))
#PREFIX_COUNT=$BENCH_RATE

DATA="{\"kind\":\"synthetic_text\",\"prompt_tokens\":${BENCH_PROMPT_TOKENS},\"output_tokens\":${BENCH_OUTPUT_TOKENS},\"turns\":${BENCH_TURNS},\"prefix_buckets\": [{\"bucket_weight\": 100, \"prefix_count\": ${PREFIX_COUNT}, \"prefix_tokens\": ${BENCH_PREFIX_TOKENS}}]}"

guidellm run \
          --backend "kind=openai_http,target=http://127.0.0.1:8000,request_format=/v1/completions" \
          --profile "kind=concurrent,streams=${BENCH_RATE}" \
          --constraint "kind=max_duration,seconds=${BENCH_MAX_SECONDS}" \
          --seed "kind=static,value=${BENCH_RANDOM_SEED}" \
          --data "$DATA"
```

`main commit 419b51b38517bd446c6e`
```
ℹ Server Throughput Statistics (All Requests)
|============|=======|======|=========|==============|===============|==============|
| Benchmark  | Requests             ||| Input Tokens | Output Tokens | Total Tokens |
| Strategy   | Concurrency || Per Sec | Per Sec      | Per Sec       | Per Sec      |
|            | Mdn   | Mean | Mean                                               ||||
|------------|-------|------|---------|--------------|---------------|--------------|
| concurrent | 64.0  | 63.7 | 3.2     | 75537.7      | 1661.7        | 77083.7      |
|============|=======|======|=========|==============|===============|==============|
```

`PR`
```
ℹ Server Throughput Statistics (All Requests)
|============|=======|======|=========|==============|===============|==============|
| Benchmark  | Requests             ||| Input Tokens | Output Tokens | Total Tokens |
| Strategy   | Concurrency || Per Sec | Per Sec      | Per Sec       | Per Sec      |
|            | Mdn   | Mean | Mean                                               ||||
|------------|-------|------|---------|--------------|---------------|--------------|
| concurrent | 64.0  | 63.7 | 3.2     | 75408.5      | 1647.8        | 77056.2      |
|============|=======|======|=========|==============|===============|==============|
```

No regression with PR. 