### PR TITLE
[Bugfix] Guard DeepSeek V4 MRV1 piecewise CUDA graphs

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -67,6 +67,43 @@ def test_v2_model_runner_env_tri_state(monkeypatch, env_value, expected):
 
 
 @pytest.mark.parametrize(
+    "cudagraph_mode",
+    [CUDAGraphMode.PIECEWISE, CUDAGraphMode.FULL_AND_PIECEWISE],
+)
+def test_deepseek_v4_rejects_mrv1_piecewise_cudagraph(cudagraph_mode):
+    config = SimpleNamespace(
+        use_v2_model_runner=False,
+        model_config=SimpleNamespace(architectures=["DeepseekV4ForCausalLM"]),
+        compilation_config=SimpleNamespace(cudagraph_mode=cudagraph_mode),
+    )
+
+    with pytest.raises(ValueError, match="DeepSeek V4 does not support PIECEWISE"):
+        VllmConfig._validate_mrv1_piecewise_cudagraph(config)
+
+
+@pytest.mark.parametrize(
+    ("use_v2_model_runner", "architecture", "cudagraph_mode"),
+    [
+        (True, "DeepseekV4ForCausalLM", CUDAGraphMode.PIECEWISE),
+        (False, "DeepseekV4ForCausalLM", CUDAGraphMode.NONE),
+        (False, "DeepseekV4ForCausalLM", CUDAGraphMode.FULL),
+        (False, "DeepseekV4ForCausalLM", CUDAGraphMode.FULL_DECODE_ONLY),
+        (False, "LlamaForCausalLM", CUDAGraphMode.PIECEWISE),
+    ],
+)
+def test_mrv1_piecewise_cudagraph_allowed(
+    use_v2_model_runner, architecture, cudagraph_mode
+):
+    config = SimpleNamespace(
+        use_v2_model_runner=use_v2_model_runner,
+        model_config=SimpleNamespace(architectures=[architecture]),
+        compilation_config=SimpleNamespace(cudagraph_mode=cudagraph_mode),
+    )
+
+    VllmConfig._validate_mrv1_piecewise_cudagraph(config)
+
+
+@pytest.mark.parametrize(
     ("use_v2_model_runner", "expected_capture_sizes"),
     [
         (False, [4, 8, 12, 16]),
@@ -176,6 +213,16 @@ def test_resolve_cudagraph_mode_adjusts_spec_decode_sizes_only_for_v1(
                 runner_type="generate",
                 is_moe=True,
                 is_quantized=False,
+            ),
+            True,
+        ),
+        (
+            SimpleNamespace(
+                model="deepseek-ai/DeepSeek-V4-Flash",
+                architectures=["DeepseekV4ForCausalLM"],
+                runner_type="generate",
+                is_moe=True,
+                is_quantized=True,
             ),
             True,
         ),

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -66,9 +66,14 @@ else:
 
 logger = init_logger(__name__)
 
+MRV1_UNSUPPORTED_PIECEWISE_CUDAGRAPH_ARCHITECTURES = frozenset(
+    {"DeepseekV4ForCausalLM"}
+)
+
 DEFAULT_V2_MODEL_RUNNER_ARCHITECTURES = frozenset(
     {
         "DeepseekV2ForCausalLM",
+        "DeepseekV4ForCausalLM",
         "GraniteMoeForCausalLM",
         "InklingForCausalLM",
         "InklingForConditionalGeneration",
@@ -701,6 +706,25 @@ class VllmConfig:
         if getattr(model_config, "is_attention_free", False):
             return False
         return is_default_v2_architecture or not model_config.is_moe
+
+    def _validate_mrv1_piecewise_cudagraph(self) -> None:
+        if self.use_v2_model_runner:
+            return
+        model_config = self.model_config
+        if model_config is None:
+            return
+        if not self.compilation_config.cudagraph_mode.has_piecewise_cudagraphs():
+            return
+        architectures = getattr(model_config, "architectures", [])
+        if any(
+            arch in MRV1_UNSUPPORTED_PIECEWISE_CUDAGRAPH_ARCHITECTURES
+            for arch in architectures
+        ):
+            raise ValueError(
+                "DeepSeek V4 does not support PIECEWISE CUDA graphs with "
+                "Model Runner V1. Use Model Runner V2 or disable PIECEWISE "
+                "CUDA graphs."
+            )
 
     @property
     def needs_dp_coordinator(self) -> bool:
@@ -1588,6 +1612,8 @@ class VllmConfig:
                         "this will likely lead to an error.",
                         "pipeline parallelism",
                     )
+
+        self._validate_mrv1_piecewise_cudagraph()
 
         # final check of cudagraph mode after all possible updates
         if current_platform.is_cuda_alike():


### PR DESCRIPTION
## Summary

Default `DeepseekV4ForCausalLM` to Model Runner V2 and reject only the known-broken configuration:

- DeepSeek V4
- Model Runner V1
- `PIECEWISE` or `FULL_AND_PIECEWISE` CUDA graphs

The validation runs after CUDA-graph mode resolution. MRV1 therefore remains available with eager/`NONE`, `FULL`, or `FULL_DECODE_ONLY`; other model architectures are unaffected.

## Why

#51430 exposed a correctness problem in the legacy V1 model runner's breakable PIECEWISE CUDA-graph path. The same attention implementation retains normal GSM8K accuracy and MTP acceptance with Model Runner V2.

Failing this specific combination avoids silent output corruption while preserving MRV1 for configurations that do not exercise the affected path.

The error directs users to either select MRV2 or disable PIECEWISE CUDA graphs.

## Relationship to #51750

This is an alternative to #51750, not a duplicate. #51750 exactly reverts #51430 and restores the wider MRV1 eager region. This PR leaves the attention implementation unchanged, defaults DeepSeek V4 to the already-correct MRV2 path, and fails closed if a user explicitly reaches the broken MRV1 PIECEWISE path.

The required duplicate searches found no other open PR adding this configuration guard.

## Model validation

GPU validation ran through Slurm on a GB200 node with TP=2, FP4 indexer cache, MTP with two speculative tokens, and CUDA graphs enabled.

| code | runner | questions | GSM8K | MTP draft acceptance |
| --- | --- | ---: | ---: | ---: |
| exact post-#51430 commit `635dd6aae` | MRV2 | 256 | 0.9570 | 80.7–81.4% |
| unmodified current main | MRV2 | 1,319 | 0.9500 | 81.1–82.1% |
| exact post-#51430 commit `635dd6aae` | MRV1 + PIECEWISE | 1,319 | 0.0311 | collapsed to 3.1–5.5% |

## Tests

```bash
env -u VLLM_USE_V2_MODEL_RUNNER \
  .venv/bin/python -m pytest tests/test_config.py \
  -k 'v2_model_runner or mrv1_piecewise' -q
# 29 passed

.venv/bin/pre-commit run ruff-check --files \
  vllm/config/vllm.py tests/test_config.py
.venv/bin/pre-commit run ruff-format --files \
  vllm/config/vllm.py tests/test_config.py
.venv/bin/pre-commit run mypy-3.12 --files \
  vllm/config/vllm.py tests/test_config.py --hook-stage manual
```

The tests cover both rejected PIECEWISE modes and the allowed MRV2, eager/NONE, FULL, FULL_DECODE_ONLY, and non-DeepSeek-V4 cases.

## AI assistance

AI assistance was used to investigate the runner-specific regression, implement this change, run validation, and prepare this PR.

Before marking ready for review, the human submitter must:

- [ ] review and understand every changed line
- [ ] independently confirm the relevant test results
