### PR TITLE
[Misc] Warn when EAGLE/MTP speculation costs a large prefix-cache hit

### DIFF
--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -3,6 +3,7 @@
 import copy
 import hashlib
 import importlib
+import logging
 from collections.abc import Callable
 from types import SimpleNamespace
 from typing import Any
@@ -3034,3 +3035,128 @@ def test_resolve_block_hashes_rejects_mismatched_view():
     mismatched = BlockHashListWithBlockSize(raw, 2, 8)
     with pytest.raises(AssertionError):
         resolve_block_hashes(mismatched, 2, 4)
+
+
+def _eagle_drop_config(
+    method: str | None,
+    enable_prefix_caching: bool = True,
+    block_size: int = 16,
+    dcp: int = 1,
+):
+    """Minimal VllmConfig stand-in for the EAGLE/MTP prefix-cache drop helpers."""
+    eagle_methods = ("eagle", "eagle3", "mtp", "dflash", "dspark")
+    spec = (
+        None
+        if method is None
+        else SimpleNamespace(
+            method=method,
+            use_eagle=lambda: method in eagle_methods,
+        )
+    )
+    return SimpleNamespace(
+        cache_config=SimpleNamespace(
+            block_size=block_size,
+            enable_prefix_caching=enable_prefix_caching,
+            prefix_match_unit=None,
+        ),
+        parallel_config=SimpleNamespace(decode_context_parallel_size=dcp),
+        speculative_config=spec,
+    )
+
+
+def _hybrid_eagle_kv_cache_config(block_size: int = 1072):
+    """Full-attention + align-mode Mamba groups, as built for Qwen3.5-style models."""
+    full_spec = FullAttentionSpec(
+        block_size=block_size,
+        num_kv_heads=1,
+        head_size=128,
+        dtype=torch.bfloat16,
+    )
+    mamba_spec = MambaSpec(
+        block_size=block_size,
+        shapes=((4096,),),
+        dtypes=(torch.bfloat16,),
+        mamba_cache_mode="align",
+    )
+    return KVCacheConfig(
+        num_blocks=1,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(["model.full_attn"], full_spec),
+            KVCacheGroupSpec(["model.mamba"], mamba_spec),
+        ],
+    )
+
+
+def test_eagle_prefix_cache_drop_tokens_hybrid_reports_enlarged_block():
+    # The Mamba group never drops; the full-attention group drops its whole
+    # (enlarged) block because hash_block_size == the group block size here.
+    kv_cache_config = _hybrid_eagle_kv_cache_config(block_size=1072)
+    assert (
+        kv_cache_utils.eagle_prefix_cache_drop_tokens(
+            kv_cache_config, _eagle_drop_config("mtp"), hash_block_size=1072
+        )
+        == 1072
+    )
+
+
+def test_eagle_prefix_cache_drop_tokens_uses_hash_granularity_when_available():
+    # With fine-grained partial hash hits the drop shrinks to one hash block.
+    kv_cache_config = _hybrid_eagle_kv_cache_config(block_size=1072)
+    assert (
+        kv_cache_utils.eagle_prefix_cache_drop_tokens(
+            kv_cache_config, _eagle_drop_config("mtp"), hash_block_size=16
+        )
+        == 16
+    )
+
+
+@pytest.mark.parametrize(
+    "method,enable_prefix_caching",
+    [
+        (None, True),  # no speculative decoding at all
+        ("ngram", True),  # not an EAGLE-style method: no hidden-state reuse
+        ("mtp", False),  # prefix caching off: nothing to lose
+    ],
+)
+def test_eagle_prefix_cache_drop_tokens_zero_when_inapplicable(
+    method, enable_prefix_caching
+):
+    kv_cache_config = _hybrid_eagle_kv_cache_config(block_size=1072)
+    vllm_config = _eagle_drop_config(method, enable_prefix_caching)
+    assert (
+        kv_cache_utils.eagle_prefix_cache_drop_tokens(
+            kv_cache_config, vllm_config, hash_block_size=1072
+        )
+        == 0
+    )
+
+
+def test_maybe_warn_eagle_prefix_cache_loss_warns_on_hybrid(caplog):
+    kv_cache_config = _hybrid_eagle_kv_cache_config(block_size=1072)
+    with caplog.at_level(logging.WARNING, logger="vllm.v1.core.kv_cache_utils"):
+        kv_cache_utils.maybe_warn_eagle_prefix_cache_loss(
+            kv_cache_config, _eagle_drop_config("mtp"), hash_block_size=1072
+        )
+    assert "1072 tokens per request are dropped" in caplog.text
+
+
+def test_maybe_warn_eagle_prefix_cache_loss_quiet_on_plain_attention(caplog):
+    # A single full-attention group at the nominal block size loses one small
+    # block: not worth a startup warning.
+    full_spec = FullAttentionSpec(
+        block_size=16,
+        num_kv_heads=1,
+        head_size=128,
+        dtype=torch.bfloat16,
+    )
+    kv_cache_config = KVCacheConfig(
+        num_blocks=1,
+        kv_cache_tensors=[],
+        kv_cache_groups=[KVCacheGroupSpec(["model.full_attn"], full_spec)],
+    )
+    with caplog.at_level(logging.WARNING, logger="vllm.v1.core.kv_cache_utils"):
+        kv_cache_utils.maybe_warn_eagle_prefix_cache_loss(
+            kv_cache_config, _eagle_drop_config("eagle3"), hash_block_size=16
+        )
+    assert caplog.text == ""

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -95,6 +95,11 @@ logger = init_logger(__name__)
 NONE_HASH: BlockHash
 _CBOR_HASH_FUNCTIONS = frozenset({sha256_cbor, xxhash_cbor})
 
+# Minimum EAGLE/MTP prefix-cache drop (in tokens) worth a startup warning.
+# Hybrid models routinely land in the thousands; plain attention models stay
+# at the nominal block size and should stay quiet.
+_EAGLE_PREFIX_CACHE_WARN_TOKENS = 512
+
 
 def init_none_hash(hash_fn: Callable[[Any], bytes]):
     global NONE_HASH
@@ -666,6 +671,96 @@ def resolve_kv_cache_block_sizes(
             f"Got group block sizes={group_block_sizes}."
         )
     return scheduler_block_size, hash_block_size
+
+
+def eagle_prefix_cache_drop_tokens(
+    kv_cache_config: KVCacheConfig,
+    vllm_config: VllmConfig,
+    hash_block_size: int,
+) -> int:
+    """Worst-case per-request prefix-cache loss from the EAGLE/MTP block drop.
+
+    EAGLE-style speculation (including MTP) cannot reuse the KV of the last
+    matched block, because the drafter runs one token ahead of the verified
+    prefix. ``KVCacheCoordinator`` therefore drops one drop-unit off every
+    affected group's prefix-cache hit. Returns the largest such drop unit in
+    tokens, or 0 when nothing is dropped.
+
+    Mirrors the drop accounting in ``KVCacheCoordinator`` at group-spec
+    granularity: the manager types that opt into fine-grained hash lookup
+    (full attention and ``align``-mode Mamba) are identified by their spec.
+    """
+    spec_config = vllm_config.speculative_config
+    if spec_config is None or not spec_config.use_eagle():
+        return 0
+    if not vllm_config.cache_config.enable_prefix_caching:
+        return 0
+
+    groups = kv_cache_config.kv_cache_groups
+    if not groups:
+        return 0
+
+    # Same fallback as KVCacheCoordinator: when no group is explicitly
+    # flagged, every group takes the drop.
+    affected = [g for g in groups if g.is_eagle_group] or groups
+
+    # Mirrors KVCacheCoordinator.enable_partial_hash_hits.
+    dcp = vllm_config.parallel_config.decode_context_parallel_size
+    partial_hash_hits = dcp == 1 and any(
+        isinstance(g.kv_cache_spec, MambaSpec)
+        and g.kv_cache_spec.mamba_cache_mode == "align"
+        and g.kv_cache_spec.block_size > hash_block_size
+        for g in groups
+    )
+
+    drops = []
+    for group in affected:
+        spec = group.kv_cache_spec
+        # Mamba's finder never drops; draft models have no mamba layers.
+        if isinstance(spec, MambaSpec):
+            continue
+        if partial_hash_hits and spec.block_size > hash_block_size:
+            drops.append(hash_block_size)
+        else:
+            drops.append(spec.block_size)
+    return max(drops, default=0)
+
+
+def maybe_warn_eagle_prefix_cache_loss(
+    kv_cache_config: KVCacheConfig,
+    vllm_config: VllmConfig,
+    hash_block_size: int,
+) -> None:
+    """Warn when the EAGLE/MTP block drop costs a large prefix-cache hit.
+
+    On hybrid (Mamba/GDN) models the KV cache manager enlarges the attention
+    block size to keep page sizes uniform, so the one-block drop can cost
+    thousands of tokens per request. This is expected behaviour rather than a
+    bug, but it is invisible in the logs today and is repeatedly reported as a
+    regression (see issue #38182).
+    """
+    drop_tokens = eagle_prefix_cache_drop_tokens(
+        kv_cache_config, vllm_config, hash_block_size
+    )
+    # Only speak up when the drop is much coarser than the requested block
+    # size; a 16- or 64-token drop is not worth a startup warning.
+    nominal = vllm_config.cache_config.block_size
+    if drop_tokens < max(_EAGLE_PREFIX_CACHE_WARN_TOKENS, nominal * 4):
+        return
+
+    logger.warning(
+        "Speculative decoding (method=%s) is enabled together with prefix "
+        "caching. EAGLE/MTP cannot reuse the KV of the last matched block, so "
+        "up to %d tokens per request are dropped from the prefix-cache hit "
+        "(the nominal block size is %d). Expect a lower "
+        "gpu_prefix_cache_hit_rate than a non-speculative baseline; the gap "
+        "widens with concurrency as eviction pressure rises. This is expected, "
+        "not a bug. If your workload relies on a high prefix-cache hit rate, "
+        "benchmark it against speculative decoding disabled.",
+        vllm_config.speculative_config.method,
+        drop_tokens,
+        nominal,
+    )
 
 
 def get_request_block_hasher(

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -49,6 +49,7 @@ from vllm.v1.core.kv_cache_utils import (
     get_kv_cache_configs,
     get_request_block_hasher,
     init_none_hash,
+    maybe_warn_eagle_prefix_cache_loss,
     resolve_kv_cache_block_sizes,
     update_kv_cache_capacity,
 )
@@ -155,6 +156,9 @@ class EngineCore:
 
         scheduler_block_size, hash_block_size = resolve_kv_cache_block_sizes(
             kv_cache_config, vllm_config
+        )
+        maybe_warn_eagle_prefix_cache_loss(
+            kv_cache_config, vllm_config, hash_block_size
         )
 
         self.scheduler: SchedulerInterface = Scheduler(


### PR DESCRIPTION
## Purpose

EAGLE-style speculation (including MTP) cannot reuse the KV of the last matched
block: the drafter runs one token ahead of the verified prefix, so
`KVCacheCoordinator` drops one drop-unit off every affected group's
prefix-cache hit. That is correct and intentional — see the discussion in #38182
and the design doc attached to #17137.

The problem is that nothing tells the operator. On hybrid Mamba/GDN models the
KV cache manager enlarges the attention block size to keep page sizes uniform,
so the one-block drop costs **thousands of tokens per request** instead of a
nominal 16. The result is a large, silent `gpu_prefix_cache_hit_rate` drop that
looks exactly like a regression, and gets reported as one repeatedly:

- #38182 — 92% → 71% on Qwen3.5-35B-A3B, 16 comments of rediscovery before a
  maintainer confirmed it is expected behaviour, not a bug
- #47194, #43559, #50188 — separate reports that start from the same surprise

This PR adds a startup warning when the computed drop is much coarser than the
configured block size, and stays quiet when fine-grained partial hash hits
already shrink it.

### Why a warning rather than a fix

The drop itself is required for correctness. #50438 proposes lookahead-aware
prefix-cache hashing as the real mitigation; until that lands, the behaviour is
here to stay and the only gap is that it is invisible. This is deliberately a
UX-only change: no scheduling, allocation, or cache behaviour is touched.

### Implementation notes

Two functions in `vllm/v1/core/kv_cache_utils.py`:

- `eagle_prefix_cache_drop_tokens()` computes the worst-case per-request loss,
  returning 0 when speculation is off, the method is not EAGLE-style, or prefix
  caching is disabled. Mamba groups are skipped because their finder never
  drops.
- `maybe_warn_eagle_prefix_cache_loss()` decides whether the loss is worth a
  warning. Threshold is `max(512, block_size * 4)` — a 16- or 64-token drop is
  not worth startup noise.

Called once from `EngineCore.__init__`, right after
`resolve_kv_cache_block_sizes()`. It has to be there rather than in config
validation because the group block sizes are only known after KV cache
initialisation.

Three things I would like reviewer input on:

1. **The threshold is a judgement call.** `max(512, block_size * 4)` separates
   "hybrid model losing thousands of tokens" from "plain attention losing one
   small block", but I have no principled basis for the exact numbers.
2. **`eagle_prefix_cache_drop_tokens` mirrors the drop accounting in
   `KVCacheCoordinator` rather than reusing it.** Reusing it would need the
   manager classes, and `single_type_kv_cache_manager` already imports
   `kv_cache_utils`, so that direction is a circular import. The duplication is
   flagged in the docstring, but if there is a better home for this function I
   am happy to move it.
3. **Wording.** The warning is long. Happy to trim if it reads as too much.

## Test Plan

```
pytest tests/v1/core/test_kv_cache_utils.py -k eagle_prefix_cache
pre-commit run --files vllm/v1/core/kv_cache_utils.py \
    vllm/v1/engine/core.py tests/v1/core/test_kv_cache_utils.py
```

Five new cases (7 after parametrisation) covering:

- hybrid full-attention + align-mode Mamba: reports the enlarged block size
- fine-grained partial hash hits available: drop shrinks to one hash block
- inapplicable configs return 0: no speculative config, non-EAGLE method
  (`ngram`), prefix caching disabled
- hybrid model: warning is emitted
- plain attention at the nominal block size: stays quiet

## Test Result

```
7 passed
```

`ruff format --diff`: 3 files already formatted
`ruff check`: All checks passed

### Field data motivating the change

Measured on 8×A100-SXM4-80GB (TP=8) with Qwen3.5-122B-A10B in BF16, vLLM 0.18.0,
`max_model_len=200000`, `qwen3_next_mtp` with `num_speculative_tokens=2`, prefix
caching enabled, 2877 real sessions per concurrency level. The KV cache was
5.17 GiB / 112,464 tokens on the baseline run:

| concurrency | prefix cache hit %, MTP on | prefix cache hit %, baseline | delta |
| ----------- | -------------------------: | ---------------------------: | ----: |
| 1           | 92.5                       | 94.8                         | -2.3pp |
| 8           | 88.0                       | 94.7                         | -6.7pp |
| 12          | 83.5                       | 93.3                         | -9.8pp |
| 15          | 82.2                       | 90.0                         | -7.8pp |

Draft acceptance stayed high and flat across concurrency (~78% at k=2, ~86% at
k=1), so the drafter was predicting well — the hit-rate loss was not an
acceptance problem. Without a log line pointing at the last-block drop, the
obvious reading of this table is "MTP broke prefix caching", which is what took
a full benchmark matrix to rule out.

On that version `enable_partial_hash_hits` does not exist yet, so the drop was
the full enlarged block on every request — the case this warning is meant to
catch.
