### PR TITLE
[XPU] Fix UVA weight offloading (non-pinned-tensor views and static Triton launcher)

### DIFF
--- a/vllm/platforms/xpu.py
+++ b/vllm/platforms/xpu.py
@@ -326,6 +326,30 @@ class XPUPlatform(Platform):
                     )
                     setattr(pass_config, flag, False)
 
+        # UVA-offloaded weights are host USM allocations, which Inductor's
+        # static Triton launcher rejects ("Pointer argument doesn't reference
+        # XPU device memory"). Fall back to Triton's own launcher. Remove once
+        # the released torch contains pytorch/pytorch#188240, which relaxes
+        # that check to any memory type known by the driver.
+        offload_config = vllm_config.offload_config
+        uva_offloading = offload_config.offload_backend == "uva" or (
+            offload_config.offload_backend == "auto"
+            and offload_config.prefetch.offload_group_size == 0
+            and offload_config.uva.cpu_offload_gb > 0
+        )
+        if (
+            uva_offloading
+            and not envs.VLLM_WEIGHT_OFFLOADING_DISABLE_UVA
+            and compilation_config.mode != CompilationMode.NONE
+        ):
+            compilation_config.inductor_compile_config.setdefault(
+                "use_static_cuda_launcher", False
+            )
+            logger.info_once(
+                "Disabling Inductor's static Triton launcher because UVA "
+                "weight offloading is enabled."
+            )
+
         # check and update parallel config
         parallel_config = vllm_config.parallel_config
         # Only override worker_cls if it's still the default "auto"

--- a/vllm/utils/torch_utils.py
+++ b/vllm/utils/torch_utils.py
@@ -887,7 +887,15 @@ def get_accelerator_view_from_cpu_tensor(cpu_tensor: torch.Tensor) -> torch.Tens
     from vllm.platforms import current_platform
 
     if current_platform.is_xpu():
-        assert cpu_tensor.is_pinned(), "CPU tensor must be pinned"
+        # Remove once the vllm-xpu-kernels fix for empty and non-pinned inputs
+        # (vllm-project/vllm-xpu-kernels#513) is in a released package.
+        if cpu_tensor.numel() == 0:
+            return torch.empty(cpu_tensor.shape, dtype=cpu_tensor.dtype, device="xpu")
+        if not cpu_tensor.is_pinned():
+            contiguous_cpu = cpu_tensor.contiguous()
+            pinned = torch.empty_like(contiguous_cpu, pin_memory=True)
+            pinned.copy_(contiguous_cpu)
+            cpu_tensor = pinned
         return torch.ops._C.get_xpu_view_from_cpu_tensor(cpu_tensor)
     elif current_platform.is_cuda_alike():
         return torch.ops._C.get_cuda_view_from_cpu_tensor(cpu_tensor)


### PR DESCRIPTION
## Purpose
Fix two startup crashes when using weight offloading (--cpu-offload-gb) on XPU.

### Issue 1: Pinned-memory assertion failure

The assertion fails for zero‑element tensors (common in quantized checkpoints) or when pinning is disabled via VLLM_WEIGHT_OFFLOADING_DISABLE_PIN_MEMORY=1.

The underlying XPU kernel already handles both cases, but the Python wrapper enforces the assertion prematurely.
Fix: Drop the assertion and handle empty/pageable inputs the same way the CUDA view kernel does, keeping the pinned buffer alive via the view’s allocator.

This is a temporary workaround: it can be removed once a released vllm-xpu-kernels contains  [vllm-xpu-kernels#513](https://github.com/vllm-project/vllm-xpu-kernels/pull/513), which adds the same handling in the kernel.

### Issue 2: Triton launcher rejects host USM pointers
UVA-offloaded weights are exposed as XPU tensors backed by host USM memory.

Inductor’s static Triton launcher validates pointer arguments as device memory and rejects them.

**Fix**: Set inductor_compile_config["use_static_cuda_launcher"] = False in XPUPlatform.check_and_update_config() when UVA offloading is active.  User settings override via setdefault.

This is also a temporary workaround: it can be removed once a released torch contains [pytorch#188240](https://github.com/pytorch/pytorch/pull/188240), which relaxes the static launcher check to accept any memory type known by the driver.


## Test Plan
End‑to‑end test on Intel XPU with torch.compile enabled:

```
from vllm import LLM, SamplingParams

llm = LLM(model='JackFram/llama-160m', cpu_offload_gb=0.1, max_model_len=256, gpu_memory_utilization=0.5)

print(llm.generate(['The capital of France is'], SamplingParams(max_tokens=16, temperature=0))[0].outputs[0].text)
```
## Test Result
Before: AssertionError: CPU tensor must be pinned (or launcher error after fixing that).

After: command runs and produces correct output:
' Paris.\nThe city of Paris is the capital of France. It is the' 



