### PR TITLE
[Frontend] Add prediction token usage details

### DIFF
--- a/tests/entrypoints/openai/chat_completion/test_serving_chat.py
+++ b/tests/entrypoints/openai/chat_completion/test_serving_chat.py
@@ -1077,6 +1077,11 @@ def test_mm_prompt_tokens_details():
 
 def test_completion_tokens_details():
     assert _make_completion_tokens_details(7).reasoning_tokens == 7
+    details = _make_completion_tokens_details(7, 3, 2)
+    assert details is not None
+    assert details.reasoning_tokens == 7
+    assert details.accepted_prediction_tokens == 3
+    assert details.rejected_prediction_tokens == 2
 
 
 @pytest.mark.asyncio

--- a/tests/entrypoints/openai/chat_completion/test_serving_chat.py
+++ b/tests/entrypoints/openai/chat_completion/test_serving_chat.py
@@ -786,6 +786,69 @@ async def test_chat_completion_prediction_token_details():
 
 
 @pytest.mark.asyncio
+async def test_chat_completion_omits_prediction_details_without_spec_decode():
+    serving = _build_minimal_metrics_serving_chat(enable_per_request_metrics=False)
+    response = await serving.chat_completion_full_generator(
+        ChatCompletionRequest(
+            model="test-model",
+            messages=[{"role": "user", "content": "Test prompt"}],
+            max_tokens=10,
+            stream=False,
+        ),
+        _single_request_output(_make_metrics_request_output()),
+        "chatcmpl-test-id",
+        "test-model",
+        conversation=[{"role": "user", "content": "Test"}],
+        tokenizer=MagicMock(),
+        request_metadata=RequestResponseMetadata(request_id="chatcmpl-test-id"),
+    )
+
+    assert response.usage is not None
+    assert response.usage.completion_tokens_details is None
+
+
+@pytest.mark.asyncio
+async def test_chat_completion_sums_prediction_details_across_choices():
+    serving = _build_minimal_metrics_serving_chat(enable_per_request_metrics=False)
+    request_output = _make_metrics_request_output(
+        accepted_prediction_tokens=3,
+        rejected_prediction_tokens=2,
+    )
+    request_output.outputs.append(
+        CompletionOutput(
+            index=1,
+            text="World",
+            token_ids=[102],
+            cumulative_logprob=None,
+            logprobs=None,
+            finish_reason="stop",
+            num_accepted_spec_tokens=1,
+            num_rejected_spec_tokens=4,
+        )
+    )
+    response = await serving.chat_completion_full_generator(
+        ChatCompletionRequest(
+            model="test-model",
+            messages=[{"role": "user", "content": "Test prompt"}],
+            max_tokens=10,
+            stream=False,
+            n=2,
+        ),
+        _single_request_output(request_output),
+        "chatcmpl-test-id",
+        "test-model",
+        conversation=[{"role": "user", "content": "Test"}],
+        tokenizer=MagicMock(),
+        request_metadata=RequestResponseMetadata(request_id="chatcmpl-test-id"),
+    )
+
+    assert response.usage is not None
+    assert response.usage.completion_tokens_details is not None
+    assert response.usage.completion_tokens_details.accepted_prediction_tokens == 4
+    assert response.usage.completion_tokens_details.rejected_prediction_tokens == 6
+
+
+@pytest.mark.asyncio
 async def test_chat_streaming_prediction_token_details():
     serving = _build_minimal_metrics_serving_chat(enable_per_request_metrics=False)
     request = ChatCompletionRequest(
@@ -798,11 +861,44 @@ async def test_chat_streaming_prediction_token_details():
     chunks: list[dict[str, Any]] = []
     async for line in serving.chat_completion_stream_generator(
         request,
-        _single_request_output(
-            _make_metrics_request_output(
-                accepted_prediction_tokens=3,
-                rejected_prediction_tokens=2,
-            )
+        _stream_request_outputs(
+            RequestOutput(
+                request_id="test-id",
+                prompt="Test prompt",
+                prompt_token_ids=[1, 2, 3],
+                prompt_logprobs=None,
+                outputs=[
+                    CompletionOutput(
+                        index=0,
+                        text="Hel",
+                        token_ids=[100],
+                        cumulative_logprob=None,
+                        logprobs=None,
+                        num_accepted_spec_tokens=2,
+                        num_rejected_spec_tokens=1,
+                    )
+                ],
+                finished=False,
+            ),
+            RequestOutput(
+                request_id="test-id",
+                prompt="Test prompt",
+                prompt_token_ids=[1, 2, 3],
+                prompt_logprobs=None,
+                outputs=[
+                    CompletionOutput(
+                        index=0,
+                        text="lo",
+                        token_ids=[101],
+                        cumulative_logprob=None,
+                        logprobs=None,
+                        finish_reason="stop",
+                        num_accepted_spec_tokens=3,
+                        num_rejected_spec_tokens=2,
+                    )
+                ],
+                finished=True,
+            ),
         ),
         "chatcmpl-test-id",
         "test-model",

--- a/tests/entrypoints/openai/chat_completion/test_serving_chat.py
+++ b/tests/entrypoints/openai/chat_completion/test_serving_chat.py
@@ -642,6 +642,8 @@ def _build_minimal_metrics_serving_chat(
 def _make_metrics_request_output(
     metrics: RequestStateStats | None = _PER_REQUEST_STATS,
     token_ids: tuple[int, ...] = (100, 101),
+    accepted_prediction_tokens: int = 0,
+    rejected_prediction_tokens: int = 0,
 ) -> RequestOutput:
     return RequestOutput(
         request_id="test-id",
@@ -656,6 +658,8 @@ def _make_metrics_request_output(
                 cumulative_logprob=None,
                 logprobs=None,
                 finish_reason="stop",
+                num_accepted_spec_tokens=accepted_prediction_tokens,
+                num_rejected_spec_tokens=rejected_prediction_tokens,
             )
         ],
         finished=True,
@@ -750,6 +754,70 @@ async def test_chat_per_request_metrics_follow_server_flag():
     )
     assert enabled_response.metrics is not None
     assert enabled_response.metrics.time_to_first_token_ms == pytest.approx(500.0)
+
+
+@pytest.mark.asyncio
+async def test_chat_completion_prediction_token_details():
+    serving = _build_minimal_metrics_serving_chat(enable_per_request_metrics=False)
+    response = await serving.chat_completion_full_generator(
+        ChatCompletionRequest(
+            model="test-model",
+            messages=[{"role": "user", "content": "Test prompt"}],
+            max_tokens=10,
+            stream=False,
+        ),
+        _single_request_output(
+            _make_metrics_request_output(
+                accepted_prediction_tokens=3,
+                rejected_prediction_tokens=2,
+            )
+        ),
+        "chatcmpl-test-id",
+        "test-model",
+        conversation=[{"role": "user", "content": "Test"}],
+        tokenizer=MagicMock(),
+        request_metadata=RequestResponseMetadata(request_id="chatcmpl-test-id"),
+    )
+
+    assert response.usage is not None
+    assert response.usage.completion_tokens_details is not None
+    assert response.usage.completion_tokens_details.accepted_prediction_tokens == 3
+    assert response.usage.completion_tokens_details.rejected_prediction_tokens == 2
+
+
+@pytest.mark.asyncio
+async def test_chat_streaming_prediction_token_details():
+    serving = _build_minimal_metrics_serving_chat(enable_per_request_metrics=False)
+    request = ChatCompletionRequest(
+        model="test-model",
+        messages=[{"role": "user", "content": "Test prompt"}],
+        max_tokens=10,
+        stream=True,
+        stream_options={"include_usage": True},
+    )
+    chunks: list[dict[str, Any]] = []
+    async for line in serving.chat_completion_stream_generator(
+        request,
+        _single_request_output(
+            _make_metrics_request_output(
+                accepted_prediction_tokens=3,
+                rejected_prediction_tokens=2,
+            )
+        ),
+        "chatcmpl-test-id",
+        "test-model",
+        conversation=[{"role": "user", "content": "Test"}],
+        tokenizer=MagicMock(),
+        request_metadata=RequestResponseMetadata(request_id="chatcmpl-test-id"),
+    ):
+        if line.startswith("data: {"):
+            chunks.append(json.loads(line[len("data: ") :]))
+
+    usage = [chunk["usage"] for chunk in chunks if chunk.get("usage")][-1]
+    assert usage["completion_tokens_details"] == {
+        "accepted_prediction_tokens": 3,
+        "rejected_prediction_tokens": 2,
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/entrypoints/openai/completion/test_completion_error.py
+++ b/tests/entrypoints/openai/completion/test_completion_error.py
@@ -249,6 +249,7 @@ async def test_completion_streaming_prediction_token_details():
 
     usage = [chunk["usage"] for chunk in chunks if chunk.get("usage")][-1]
     assert usage["completion_tokens_details"] == {
+        "reasoning_tokens": 0,
         "accepted_prediction_tokens": 3,
         "rejected_prediction_tokens": 2,
     }

--- a/tests/entrypoints/openai/completion/test_completion_error.py
+++ b/tests/entrypoints/openai/completion/test_completion_error.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import json
+from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
@@ -109,6 +111,7 @@ def _build_minimal_metrics_serving_completion(
 ) -> OpenAIServingCompletion:
     serving = OpenAIServingCompletion.__new__(OpenAIServingCompletion)
     serving.enable_prompt_tokens_details = False
+    serving.enable_force_include_usage = False
     serving.system_fingerprint = None
     serving.enable_per_request_metrics = enable_per_request_metrics
     return serving
@@ -139,6 +142,12 @@ def _make_metrics_request_output(
         finished=True,
         metrics=metrics,
     )
+
+
+async def _single_indexed_request_output(
+    request_output: RequestOutput,
+) -> AsyncIterator[tuple[int, RequestOutput]]:
+    yield 0, request_output
 
 
 def _build_renderer(model_config: MockModelConfig):
@@ -204,6 +213,45 @@ def test_completion_prediction_token_details():
     assert response.usage.completion_tokens_details is not None
     assert response.usage.completion_tokens_details.accepted_prediction_tokens == 3
     assert response.usage.completion_tokens_details.rejected_prediction_tokens == 2
+
+
+@pytest.mark.asyncio
+async def test_completion_streaming_prediction_token_details():
+    serving = _build_minimal_metrics_serving_completion(
+        enable_per_request_metrics=False
+    )
+    request = CompletionRequest(
+        model=MODEL_NAME,
+        prompt="Test prompt",
+        max_tokens=10,
+        stream=True,
+        stream_options={"include_usage": True},
+    )
+    chunks: list[dict[str, Any]] = []
+    async for line in serving.completion_stream_generator(
+        request=request,
+        engine_inputs=[{"type": "tokens", "prompt_token_ids": [1, 2, 3]}],
+        result_generator=_single_indexed_request_output(
+            _make_metrics_request_output(
+                accepted_prediction_tokens=3,
+                rejected_prediction_tokens=2,
+            )
+        ),
+        request_id="cmpl-test-id",
+        created_time=0,
+        model_name=MODEL_NAME,
+        num_prompts=1,
+        tokenizer=None,
+        request_metadata=RequestResponseMetadata(request_id="cmpl-test-id"),
+    ):
+        if line.startswith("data: {"):
+            chunks.append(json.loads(line[len("data: ") :]))
+
+    usage = [chunk["usage"] for chunk in chunks if chunk.get("usage")][-1]
+    assert usage["completion_tokens_details"] == {
+        "accepted_prediction_tokens": 3,
+        "rejected_prediction_tokens": 2,
+    }
 
 
 def test_completion_per_request_metrics_suppressed_for_multiple_prompts():

--- a/tests/entrypoints/openai/completion/test_completion_error.py
+++ b/tests/entrypoints/openai/completion/test_completion_error.py
@@ -116,6 +116,8 @@ def _build_minimal_metrics_serving_completion(
 
 def _make_metrics_request_output(
     metrics: RequestStateStats | None = _PER_REQUEST_STATS,
+    accepted_prediction_tokens: int = 0,
+    rejected_prediction_tokens: int = 0,
 ) -> RequestOutput:
     return RequestOutput(
         request_id="test-id",
@@ -130,6 +132,8 @@ def _make_metrics_request_output(
                 cumulative_logprob=None,
                 logprobs=None,
                 finish_reason="stop",
+                num_accepted_spec_tokens=accepted_prediction_tokens,
+                num_rejected_spec_tokens=rejected_prediction_tokens,
             )
         ],
         finished=True,
@@ -176,6 +180,30 @@ def test_completion_per_request_metrics_follow_server_flag():
     )
     assert enabled_response.metrics is not None
     assert enabled_response.metrics.time_to_first_token_ms == pytest.approx(500.0)
+
+
+def test_completion_prediction_token_details():
+    serving = _build_minimal_metrics_serving_completion(
+        enable_per_request_metrics=False
+    )
+    response = serving.request_output_to_completion_response(
+        [
+            _make_metrics_request_output(
+                accepted_prediction_tokens=3,
+                rejected_prediction_tokens=2,
+            )
+        ],
+        CompletionRequest(model=MODEL_NAME, prompt="Test prompt", max_tokens=10),
+        "cmpl-test-id",
+        0,
+        MODEL_NAME,
+        None,
+        RequestResponseMetadata(request_id="cmpl-test-id"),
+    )
+
+    assert response.usage.completion_tokens_details is not None
+    assert response.usage.completion_tokens_details.accepted_prediction_tokens == 3
+    assert response.usage.completion_tokens_details.rejected_prediction_tokens == 2
 
 
 def test_completion_per_request_metrics_suppressed_for_multiple_prompts():

--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -728,12 +728,12 @@ def test_stop_via_update_from_output():
     scheduler_output = SchedulerOutput(
         scheduled_new_reqs=[],
         scheduled_cached_reqs=CachedRequestData.make_empty(),
-        num_scheduled_tokens={requests[0].request_id: 3, requests[1].request_id: 2},
-        total_num_scheduled_tokens=5,
+        num_scheduled_tokens={requests[0].request_id: 3, requests[1].request_id: 3},
+        total_num_scheduled_tokens=6,
         scheduled_encoder_inputs={},
         scheduled_spec_decode_tokens={
             requests[0].request_id: [10, 42],
-            requests[1].request_id: [13],
+            requests[1].request_id: [13, 99],
         },
         num_common_prefix_blocks=[],
         finished_req_ids=set(),
@@ -765,7 +765,7 @@ def test_stop_via_update_from_output():
     assert outputs_by_id[requests[0].request_id].num_accepted_spec_tokens == 2
     assert outputs_by_id[requests[0].request_id].num_rejected_spec_tokens == 0
     assert outputs_by_id[requests[1].request_id].num_accepted_spec_tokens == 1
-    assert outputs_by_id[requests[1].request_id].num_rejected_spec_tokens == 0
+    assert outputs_by_id[requests[1].request_id].num_rejected_spec_tokens == 1
 
     # Test case 3: Stop on max tokens
     scheduler = create_scheduler(num_speculative_tokens=2)

--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -760,7 +760,7 @@ def test_stop_via_update_from_output():
     assert list(requests[0].output_token_ids) == [10, 42]
     assert list(requests[1].output_token_ids) == [13, 14]
     outputs_by_id = {
-        output.request_id: output for output in engine_core_outputs.outputs
+        output.request_id: output for output in engine_core_outputs[0].outputs
     }
     assert outputs_by_id[requests[0].request_id].num_accepted_spec_tokens == 2
     assert outputs_by_id[requests[0].request_id].num_rejected_spec_tokens == 0

--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -749,7 +749,7 @@ def test_stop_via_update_from_output():
         pooler_output=[],
     )
 
-    scheduler.update_from_output(scheduler_output, model_output)
+    engine_core_outputs = scheduler.update_from_output(scheduler_output, model_output)
 
     # Verify first request stopped on custom token
     assert len(scheduler.running) == 1
@@ -759,6 +759,13 @@ def test_stop_via_update_from_output():
     assert requests[0].request_id in scheduler.finished_req_ids
     assert list(requests[0].output_token_ids) == [10, 42]
     assert list(requests[1].output_token_ids) == [13, 14]
+    outputs_by_id = {
+        output.request_id: output for output in engine_core_outputs.outputs
+    }
+    assert outputs_by_id[requests[0].request_id].num_accepted_spec_tokens == 2
+    assert outputs_by_id[requests[0].request_id].num_rejected_spec_tokens == 0
+    assert outputs_by_id[requests[1].request_id].num_accepted_spec_tokens == 1
+    assert outputs_by_id[requests[1].request_id].num_rejected_spec_tokens == 0
 
     # Test case 3: Stop on max tokens
     scheduler = create_scheduler(num_speculative_tokens=2)

--- a/tests/v1/engine/test_output_processor.py
+++ b/tests/v1/engine/test_output_processor.py
@@ -3,6 +3,7 @@
 
 import math
 import time
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -27,7 +28,11 @@ from vllm.v1.engine import (
     EngineCoreRequest,
     FinishReason,
 )
-from vllm.v1.engine.output_processor import OutputProcessor, RequestOutputCollector
+from vllm.v1.engine.output_processor import (
+    OutputProcessor,
+    RequestOutputCollector,
+    RequestState,
+)
 from vllm.v1.metrics.stats import IterationStats, SchedulerStats
 
 
@@ -218,33 +223,40 @@ def test_request_stream_interval_raises_but_not_below_engine_default(
     assert not output_processor.has_unfinished_requests()
 
 
-def test_speculative_token_counts_accumulate_per_request(dummy_test_vectors):
-    output_processor = OutputProcessor(
-        dummy_test_vectors.tokenizer, log_stats=False, stream_interval=1
-    )
-    request = EngineCoreRequest(
+def test_speculative_token_counts_accumulate_per_request():
+    output_processor = OutputProcessor(None, log_stats=False, stream_interval=1)
+    detokenizer = MagicMock()
+    detokenizer.update.return_value = None
+    detokenizer.get_next_output_text.return_value = ""
+    logprobs_processor = MagicMock()
+    logprobs_processor.logprobs = None
+    logprobs_processor.cumulative_logprob = None
+    logprobs_processor.pop_prompt_logprobs.return_value = None
+    output_processor.request_states["request-int"] = RequestState(
         request_id="request-int",
         external_req_id="request",
-        prompt_token_ids=dummy_test_vectors.prompt_tokens[0],
-        mm_features=None,
-        arrival_time=0,
+        parent_req=None,
+        request_index=0,
         lora_request=None,
-        cache_salt=None,
-        data_parallel_rank=None,
-        sampling_params=SamplingParams(
-            output_kind=RequestOutputKind.DELTA,
-            skip_special_tokens=False,
-            spaces_between_special_tokens=False,
-        ),
-        pooling_params=None,
+        output_kind=RequestOutputKind.DELTA,
+        prompt="",
+        prompt_token_ids=[1],
+        prompt_embeds=None,
+        logprobs_processor=logprobs_processor,
+        detokenizer=detokenizer,
+        max_tokens_param=2,
+        arrival_time=0,
+        queue=None,
+        log_stats=False,
+        stream_interval=1,
     )
-    output_processor.add_request(request, dummy_test_vectors.prompt_strings[0])
+    output_processor.external_req_ids["request"].append("request-int")
 
     first = output_processor.process_outputs(
         [
             EngineCoreOutput(
                 request_id="request-int",
-                new_token_ids=[dummy_test_vectors.generation_tokens[0][0]],
+                new_token_ids=[2],
                 num_accepted_spec_tokens=2,
                 num_rejected_spec_tokens=1,
             )
@@ -254,7 +266,7 @@ def test_speculative_token_counts_accumulate_per_request(dummy_test_vectors):
         [
             EngineCoreOutput(
                 request_id="request-int",
-                new_token_ids=[dummy_test_vectors.generation_tokens[0][1]],
+                new_token_ids=[3],
                 finish_reason=FinishReason.LENGTH,
                 num_accepted_spec_tokens=1,
                 num_rejected_spec_tokens=2,

--- a/tests/v1/engine/test_output_processor.py
+++ b/tests/v1/engine/test_output_processor.py
@@ -22,6 +22,7 @@ from vllm.tokenizers import TokenizerLike
 from vllm.v1.engine import (
     EngineCoreEvent,
     EngineCoreEventType,
+    EngineCoreOutput,
     EngineCoreOutputs,
     EngineCoreRequest,
     FinishReason,
@@ -215,6 +216,56 @@ def test_request_stream_interval_raises_but_not_below_engine_default(
         assert gen_tokens[request_id] == dummy_test_vectors.generation_tokens[idx]
 
     assert not output_processor.has_unfinished_requests()
+
+
+def test_speculative_token_counts_accumulate_per_request(dummy_test_vectors):
+    output_processor = OutputProcessor(
+        dummy_test_vectors.tokenizer, log_stats=False, stream_interval=1
+    )
+    request = EngineCoreRequest(
+        request_id="request-int",
+        external_req_id="request",
+        prompt_token_ids=dummy_test_vectors.prompt_tokens[0],
+        mm_features=None,
+        arrival_time=0,
+        lora_request=None,
+        cache_salt=None,
+        data_parallel_rank=None,
+        sampling_params=SamplingParams(
+            output_kind=RequestOutputKind.DELTA,
+            skip_special_tokens=False,
+            spaces_between_special_tokens=False,
+        ),
+        pooling_params=None,
+    )
+    output_processor.add_request(request, dummy_test_vectors.prompt_strings[0])
+
+    first = output_processor.process_outputs(
+        [
+            EngineCoreOutput(
+                request_id="request-int",
+                new_token_ids=[dummy_test_vectors.generation_tokens[0][0]],
+                num_accepted_spec_tokens=2,
+                num_rejected_spec_tokens=1,
+            )
+        ]
+    ).request_outputs[0]
+    second = output_processor.process_outputs(
+        [
+            EngineCoreOutput(
+                request_id="request-int",
+                new_token_ids=[dummy_test_vectors.generation_tokens[0][1]],
+                finish_reason=FinishReason.LENGTH,
+                num_accepted_spec_tokens=1,
+                num_rejected_spec_tokens=2,
+            )
+        ]
+    ).request_outputs[0]
+
+    assert first.outputs[0].num_accepted_spec_tokens == 2
+    assert first.outputs[0].num_rejected_spec_tokens == 1
+    assert second.outputs[0].num_accepted_spec_tokens == 3
+    assert second.outputs[0].num_rejected_spec_tokens == 3
 
 
 def _validate_logprobs(

--- a/vllm/entrypoints/generate/base/serving.py
+++ b/vllm/entrypoints/generate/base/serving.py
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import json
 import time
-from collections.abc import Awaitable, Mapping
+from collections.abc import Awaitable, Mapping, Sequence
 from dataclasses import dataclass, field
 from http import HTTPStatus
 from typing import TYPE_CHECKING, ClassVar, Generic, TypeVar
@@ -16,6 +16,7 @@ from vllm.entrypoints.generate.beam_search.online import BeamSearchOnlineMixin
 from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
 from vllm.entrypoints.openai.completion.protocol import CompletionRequest
 from vllm.entrypoints.openai.engine.protocol import (
+    CompletionTokenUsageInfo,
     ErrorResponse,
     GenerationError,
     PerRequestMetrics,
@@ -30,6 +31,7 @@ from vllm.inputs import EngineInput
 from vllm.logger import init_logger
 from vllm.logprobs import Logprob, PromptLogprobs
 from vllm.lora.request import LoRARequest
+from vllm.outputs import CompletionOutput
 from vllm.tokenizers import TokenizerLike
 from vllm.tracing import (
     contains_trace_headers,
@@ -47,6 +49,19 @@ RequestT = TypeVar("RequestT", bound=AnyRequest)
 _T = TypeVar("_T")
 SESSION_ID_HEADER = "X-Session-ID"
 PRIORITY_HEADER = "X-Vllm-Priority"
+
+
+def make_completion_tokens_details(
+    outputs: Sequence[CompletionOutput],
+) -> CompletionTokenUsageInfo | None:
+    accepted = sum(output.num_accepted_spec_tokens for output in outputs)
+    rejected = sum(output.num_rejected_spec_tokens for output in outputs)
+    if not accepted and not rejected:
+        return None
+    return CompletionTokenUsageInfo(
+        accepted_prediction_tokens=accepted,
+        rejected_prediction_tokens=rejected,
+    )
 
 
 def build_per_request_timing_metrics(

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -112,9 +112,7 @@ def _make_completion_tokens_details(
     accepted_prediction_tokens: int = 0,
     rejected_prediction_tokens: int = 0,
 ) -> CompletionTokenUsageInfo | None:
-    has_prediction_tokens = (
-        accepted_prediction_tokens or rejected_prediction_tokens
-    )
+    has_prediction_tokens = accepted_prediction_tokens or rejected_prediction_tokens
     if reasoning_tokens is None and not has_prediction_tokens:
         return None
     if reasoning_tokens is None:

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -108,9 +108,27 @@ def _make_prompt_tokens_details(
 
 
 def _make_completion_tokens_details(
-    reasoning_tokens: int,
-) -> CompletionTokenUsageInfo:
-    return CompletionTokenUsageInfo(reasoning_tokens=reasoning_tokens)
+    reasoning_tokens: int | None = None,
+    accepted_prediction_tokens: int = 0,
+    rejected_prediction_tokens: int = 0,
+) -> CompletionTokenUsageInfo | None:
+    has_prediction_tokens = (
+        accepted_prediction_tokens or rejected_prediction_tokens
+    )
+    if reasoning_tokens is None and not has_prediction_tokens:
+        return None
+    if reasoning_tokens is None:
+        return CompletionTokenUsageInfo(
+            accepted_prediction_tokens=accepted_prediction_tokens,
+            rejected_prediction_tokens=rejected_prediction_tokens,
+        )
+    if not has_prediction_tokens:
+        return CompletionTokenUsageInfo(reasoning_tokens=reasoning_tokens)
+    return CompletionTokenUsageInfo(
+        reasoning_tokens=reasoning_tokens,
+        accepted_prediction_tokens=accepted_prediction_tokens,
+        rejected_prediction_tokens=rejected_prediction_tokens,
+    )
 
 
 class OpenAIServingChat(GenerateBaseServing):
@@ -471,6 +489,8 @@ class OpenAIServingChat(GenerateBaseServing):
         # TODO: Remove once all reasoning parsers use the Parser Engine.
         generated_token_ids: list[list[int]] = [[] for _ in range(num_choices)]
         previous_reasoning_tokens = [0] * num_choices
+        accepted_prediction_tokens = [0] * num_choices
+        rejected_prediction_tokens = [0] * num_choices
         finish_reason_sent = [False] * num_choices
         num_prompt_tokens = 0
         num_cached_tokens = None
@@ -678,6 +698,8 @@ class OpenAIServingChat(GenerateBaseServing):
                         previous_reasoning_tokens[i] = parser.count_reasoning_tokens(
                             tuple(generated_token_ids[i])
                         )
+                    accepted_prediction_tokens[i] = output.num_accepted_spec_tokens
+                    rejected_prediction_tokens[i] = output.num_rejected_spec_tokens
 
                     # if the message delta is None (e.g. because it was a
                     # "control token" for tool calls or the parser otherwise
@@ -803,12 +825,12 @@ class OpenAIServingChat(GenerateBaseServing):
                             prompt_tokens=num_prompt_tokens,
                             completion_tokens=completion_tokens,
                             total_tokens=num_prompt_tokens + completion_tokens,
-                            completion_tokens_details=(
-                                _make_completion_tokens_details(
-                                    previous_reasoning_tokens[i]
-                                )
+                            completion_tokens_details=_make_completion_tokens_details(
+                                previous_reasoning_tokens[i]
                                 if self._include_reasoning_tokens_details
-                                else None
+                                else None,
+                                accepted_prediction_tokens[i],
+                                rejected_prediction_tokens[i],
                             ),
                         )
 
@@ -825,9 +847,11 @@ class OpenAIServingChat(GenerateBaseServing):
                     total_tokens=num_prompt_tokens + completion_tokens,
                     completion_tokens_details=_make_completion_tokens_details(
                         sum(previous_reasoning_tokens)
-                    )
-                    if self._include_reasoning_tokens_details
-                    else None,
+                        if self._include_reasoning_tokens_details
+                        else None,
+                        sum(accepted_prediction_tokens),
+                        sum(rejected_prediction_tokens),
+                    ),
                 )
                 final_usage.prompt_tokens_details = _make_prompt_tokens_details(
                     self.enable_prompt_tokens_details,
@@ -835,7 +859,6 @@ class OpenAIServingChat(GenerateBaseServing):
                     num_cache_creation_tokens,
                     mm_token_counts,
                 )
-
                 # In streaming, metrics ride on this final usage chunk, which is
                 # only emitted when usage reporting is enabled (i.e.
                 # ``stream_options.include_usage=true`` or
@@ -879,9 +902,11 @@ class OpenAIServingChat(GenerateBaseServing):
                 total_tokens=num_prompt_tokens + num_completion_tokens,
                 completion_tokens_details=_make_completion_tokens_details(
                     sum(previous_reasoning_tokens)
-                )
-                if self._include_reasoning_tokens_details
-                else None,
+                    if self._include_reasoning_tokens_details
+                    else None,
+                    sum(accepted_prediction_tokens),
+                    sum(rejected_prediction_tokens),
+                ),
             )
 
             # Log complete streaming response if output logging is enabled
@@ -1125,15 +1150,23 @@ class OpenAIServingChat(GenerateBaseServing):
         num_generated_tokens = sum(
             len(output.token_ids) for output in final_res.outputs
         )
+        accepted_prediction_tokens = sum(
+            output.num_accepted_spec_tokens for output in final_res.outputs
+        )
+        rejected_prediction_tokens = sum(
+            output.num_rejected_spec_tokens for output in final_res.outputs
+        )
         usage = UsageInfo(
             prompt_tokens=num_prompt_tokens,
             completion_tokens=num_generated_tokens,
             total_tokens=num_prompt_tokens + num_generated_tokens,
             completion_tokens_details=_make_completion_tokens_details(
                 total_reasoning_tokens
-            )
-            if self._include_reasoning_tokens_details
-            else None,
+                if self._include_reasoning_tokens_details
+                else None,
+                accepted_prediction_tokens,
+                rejected_prediction_tokens,
+            ),
         )
         usage.prompt_tokens_details = _make_prompt_tokens_details(
             self.enable_prompt_tokens_details,
@@ -1141,7 +1174,6 @@ class OpenAIServingChat(GenerateBaseServing):
             final_res.num_cache_creation_tokens,
             mm_token_counts,
         )
-
         request_metadata.final_usage_info = usage
 
         per_request_metrics: PerRequestMetrics | None = None

--- a/vllm/entrypoints/openai/completion/serving.py
+++ b/vllm/entrypoints/openai/completion/serving.py
@@ -17,6 +17,7 @@ from vllm.entrypoints.generate.base.serving import (
     build_spec_decoding_metrics,
     clamp_prompt_logprobs,
     format_token_id_placeholder,
+    make_completion_tokens_details,
 )
 from vllm.entrypoints.openai.completion.protocol import (
     CompletionLogProbs,
@@ -27,6 +28,7 @@ from vllm.entrypoints.openai.completion.protocol import (
     CompletionStreamResponse,
 )
 from vllm.entrypoints.openai.engine.protocol import (
+    CompletionTokenUsageInfo,
     ErrorResponse,
     PerRequestMetrics,
     PromptTokenUsageInfo,
@@ -296,6 +298,8 @@ class OpenAIServingCompletion(GenerateBaseServing):
         num_choices = 1 if request.n is None else request.n
         previous_text_lens = [0] * num_choices * num_prompts
         previous_num_tokens = [0] * num_choices * num_prompts
+        accepted_prediction_tokens = [0] * num_choices * num_prompts
+        rejected_prediction_tokens = [0] * num_choices * num_prompts
         has_echoed = [False] * num_choices * num_prompts
         num_prompt_tokens = [0] * num_prompts
         num_cached_tokens = None
@@ -397,6 +401,8 @@ class OpenAIServingCompletion(GenerateBaseServing):
 
                     previous_text_lens[i] += len(output.text)
                     previous_num_tokens[i] += len(output.token_ids)
+                    accepted_prediction_tokens[i] = output.num_accepted_spec_tokens
+                    rejected_prediction_tokens[i] = output.num_rejected_spec_tokens
                     finish_reason = output.finish_reason
                     stop_reason = output.stop_reason
 
@@ -439,6 +445,20 @@ class OpenAIServingCompletion(GenerateBaseServing):
                             completion_tokens=completion_tokens,
                             total_tokens=prompt_tokens + completion_tokens,
                         )
+                        if (
+                            accepted_prediction_tokens[i]
+                            or rejected_prediction_tokens[i]
+                        ):
+                            chunk.usage.completion_tokens_details = (
+                                CompletionTokenUsageInfo(
+                                    accepted_prediction_tokens=(
+                                        accepted_prediction_tokens[i]
+                                    ),
+                                    rejected_prediction_tokens=(
+                                        rejected_prediction_tokens[i]
+                                    ),
+                                )
+                            )
 
                     response_json = chunk.model_dump_json(exclude_unset=True)
                     yield f"data: {response_json}\n\n"
@@ -450,6 +470,11 @@ class OpenAIServingCompletion(GenerateBaseServing):
                 completion_tokens=total_completion_tokens,
                 total_tokens=total_prompt_tokens + total_completion_tokens,
             )
+            if any(accepted_prediction_tokens) or any(rejected_prediction_tokens):
+                final_usage_info.completion_tokens_details = CompletionTokenUsageInfo(
+                    accepted_prediction_tokens=sum(accepted_prediction_tokens),
+                    rejected_prediction_tokens=sum(rejected_prediction_tokens),
+                )
 
             if self.enable_prompt_tokens_details and num_cached_tokens is not None:
                 final_usage_info.prompt_tokens_details = PromptTokenUsageInfo(
@@ -604,6 +629,9 @@ class OpenAIServingCompletion(GenerateBaseServing):
             prompt_tokens=num_prompt_tokens,
             completion_tokens=num_generated_tokens,
             total_tokens=num_prompt_tokens + num_generated_tokens,
+        )
+        usage.completion_tokens_details = make_completion_tokens_details(
+            [output for res in final_res_batch for output in res.outputs]
         )
 
         if (

--- a/vllm/entrypoints/openai/engine/protocol.py
+++ b/vllm/entrypoints/openai/engine/protocol.py
@@ -119,6 +119,8 @@ class PromptTokenUsageInfo(OpenAIBaseModel):
 
 class CompletionTokenUsageInfo(OpenAIBaseModel):
     reasoning_tokens: int = 0
+    accepted_prediction_tokens: int | None = None
+    rejected_prediction_tokens: int | None = None
 
 
 class UsageInfo(OpenAIBaseModel):

--- a/vllm/outputs.py
+++ b/vllm/outputs.py
@@ -66,6 +66,8 @@ class CompletionOutput:
     lora_request: LoRARequest | None = None
     sampling_mask: SamplingMask | None = None
     spec_decode_metrics: RequestSpecDecodeMetrics | None = None
+    num_accepted_spec_tokens: int = 0
+    num_rejected_spec_tokens: int = 0
 
     def finished(self) -> bool:
         return self.finish_reason is not None
@@ -194,6 +196,12 @@ class RequestOutput:
                         )
                         completion.finish_reason = next_completion.finish_reason
                         completion.stop_reason = next_completion.stop_reason
+                        completion.num_accepted_spec_tokens = (
+                            next_completion.num_accepted_spec_tokens
+                        )
+                        completion.num_rejected_spec_tokens = (
+                            next_completion.num_rejected_spec_tokens
+                        )
                     else:
                         # Replace the output with the new one
                         self.outputs[i] = next_completion

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1859,13 +1859,23 @@ class Scheduler(SchedulerInterface):
             scheduled_spec_token_ids = (
                 scheduler_output.scheduled_spec_decode_tokens.get(req_id)
             )
+            num_accepted_spec_tokens = 0
+            num_rejected_spec_tokens = 0
             if scheduled_spec_token_ids and (
                 generated_token_ids or self.num_sampled_tokens_per_step == 0
             ):
                 num_draft_tokens = len(scheduled_spec_token_ids)
                 num_sampled = self.num_sampled_tokens_per_step
                 num_accepted = max(len(generated_token_ids) - num_sampled, 0)
+                num_invalid = (
+                    scheduler_output.num_invalid_spec_tokens.get(req_id, 0)
+                    if scheduler_output.num_invalid_spec_tokens
+                    else 0
+                )
                 num_rejected = num_draft_tokens - num_accepted
+                num_accepted_spec_tokens = num_accepted
+                num_rejected_spec_tokens = num_rejected - num_invalid
+                assert num_rejected_spec_tokens >= 0
                 # Rejections roll back num_computed_tokens (and, under async
                 # scheduling, num_output_placeholders, which covers the spec
                 # tokens). A stale rejection count predates the preemption
@@ -2068,6 +2078,8 @@ class Scheduler(SchedulerInterface):
                         ec_transfer_params=ec_transfer_params,
                         trace_headers=request.trace_headers,
                         routed_experts=routed_experts,
+                        num_accepted_spec_tokens=num_accepted_spec_tokens,
+                        num_rejected_spec_tokens=num_rejected_spec_tokens,
                         num_nans_in_logits=request.num_nans_in_logits,
                     )
                 )

--- a/vllm/v1/engine/__init__.py
+++ b/vllm/v1/engine/__init__.py
@@ -226,6 +226,8 @@ class EngineCoreOutput(
     # from its sender cache and the request is resent with the data. Appended last
     # so `array_like` positional serialization stays backward compatible.
     mm_cache_miss_hashes: list[str] | None = None
+    num_accepted_spec_tokens: int = 0
+    num_rejected_spec_tokens: int = 0
 
     new_sampling_mask: SamplingMaskLists | None = None
 

--- a/vllm/v1/engine/output_processor.py
+++ b/vllm/v1/engine/output_processor.py
@@ -179,6 +179,8 @@ class RequestState:
         # Per-sequence spec-decode accumulator; arrives once (on finish) via
         # EngineCoreOutput, then attached to this sequence's CompletionOutput.
         self.spec_decode_metrics: RequestSpecDecodeMetrics | None = None
+        self.num_accepted_spec_tokens = 0
+        self.num_rejected_spec_tokens = 0
 
         self.stats = RequestStateStats(arrival_time=arrival_time) if log_stats else None
 
@@ -431,6 +433,8 @@ class RequestState:
             sampling_mask=sampling_mask,
             logprobs=logprobs,
             cumulative_logprob=self.logprobs_processor.cumulative_logprob,
+            num_accepted_spec_tokens=self.num_accepted_spec_tokens,
+            num_rejected_spec_tokens=self.num_rejected_spec_tokens,
             finish_reason=str(finish_reason) if finished else None,
             stop_reason=stop_reason if finished else None,
             spec_decode_metrics=self.spec_decode_metrics if finished else None,
@@ -648,6 +652,12 @@ class OutputProcessor:
             stop_reason = engine_core_output.stop_reason
             kv_transfer_params = engine_core_output.kv_transfer_params
             ec_transfer_params = engine_core_output.ec_transfer_params
+            req_state.num_accepted_spec_tokens += (
+                engine_core_output.num_accepted_spec_tokens
+            )
+            req_state.num_rejected_spec_tokens += (
+                engine_core_output.num_rejected_spec_tokens
+            )
             if engine_core_output.routed_experts is not None:
                 req_state.routed_experts_chunks.append(
                     engine_core_output.routed_experts


### PR DESCRIPTION
## Summary

- expose per-request speculative decoding acceptance and rejection counts through engine outputs
- populate `completion_tokens_details.accepted_prediction_tokens` and `rejected_prediction_tokens` for streaming and non-streaming Chat Completions and Completions responses
- preserve per-choice accounting for parallel sampling and add focused scheduler, output processor, and serving tests
- preserve the upstream `reasoning_tokens` usage details when reasoning and prediction accounting are both present

Upstream added `reasoning_tokens` accounting after this PR was opened. The rebased implementation combines those details with prediction-token counts instead of overwriting either one.

## Why this is not a duplicate

I checked issue #50895 and searched open PRs by the issue number and by `accepted_prediction_tokens rejected_prediction_tokens`. No open PR implements these two fields. The existing related work focuses on `reasoning_tokens`, while this PR handles the speculative-decoding fields listed as untracked in #50895.

## Tests

Passed:

```text
.venv/bin/ruff check --ignore ISC004 <changed files>
.venv/bin/ruff format --check <changed files>
git diff --check
pre-commit hooks run by `git commit`
```

Focused pytest execution:

```text
.venv/bin/python -m pytest \
  tests/v1/engine/test_output_processor.py::test_speculative_token_counts_accumulate_per_request \
  tests/entrypoints/openai/chat_completion/test_serving_chat.py::test_chat_completion_prediction_token_details \
  tests/entrypoints/openai/chat_completion/test_serving_chat.py::test_chat_completion_omits_prediction_details_without_spec_decode \
  tests/entrypoints/openai/chat_completion/test_serving_chat.py::test_chat_completion_sums_prediction_details_across_choices \
  tests/entrypoints/openai/chat_completion/test_serving_chat.py::test_chat_streaming_prediction_token_details \
  tests/entrypoints/openai/chat_completion/test_serving_chat.py::test_streaming_reasoning_usage_counts_across_deltas \
  tests/entrypoints/openai/chat_completion/test_serving_chat.py::test_completion_tokens_details \
  tests/entrypoints/openai/completion/test_completion_error.py::test_completion_prediction_token_details \
  tests/entrypoints/openai/completion/test_completion_error.py::test_completion_streaming_prediction_token_details -q
```

Result: `9 passed, 14 warnings in 2.36s`.

```text
.venv/bin/python -m pytest \
  tests/v1/core/test_scheduler.py::test_stop_via_update_from_output -q
```

Result: `1 passed, 15 warnings in 1.26s`.

## Model evaluation

Not applicable. This change reports existing speculative-decoding accounting and does not affect model output, accuracy, or serving decisions.

## AI assistance

AI assistance was used to implement this change. I have reviewed every changed line and understand the implementation end to end.

Fixes #50895
