### PR TITLE
[Model] Enable tower and connector LoRA for Keye

### DIFF
--- a/vllm/model_executor/models/keye.py
+++ b/vllm/model_executor/models/keye.py
@@ -1466,6 +1466,14 @@ class BaseKeyeModule(nn.Module, SupportsMultiModal):
             tower_model="visual.",
         )
 
+    def get_num_mm_encoder_tokens(self, num_image_tokens: int) -> int:
+        merge_size = self.config.vision_config.spatial_merge_size
+        return num_image_tokens * merge_size**2
+
+    def get_num_mm_connector_tokens(self, num_vision_tokens: int) -> int:
+        merge_size = self.config.vision_config.spatial_merge_size
+        return num_vision_tokens // merge_size**2
+
 
 @MULTIMODAL_REGISTRY.register_processor(
     KeyeMultiModalProcessor,


### PR DESCRIPTION
## Summary

- Implement `get_num_mm_encoder_tokens()` and
  `get_num_mm_connector_tokens()` on `BaseKeyeModule`.
- Convert between the post-merge multimodal token count seen by the language
  model and the pre-merge activation length used by the vision tower and Keye
  projector.

Part of #31479.

## Implementation

Keye reports language-model image tokens after spatial merging:

```text
num_image_tokens = num_vision_tokens / spatial_merge_size**2
```

The vision tower operates on the unmerged patch sequence, while `mlp_AR`
groups each `spatial_merge_size x spatial_merge_size` block before its linear
layers. The LoRA activation mapping therefore needs the following conversions:

```text
encoder_tokens = image_tokens * spatial_merge_size**2
connector_tokens = vision_tokens // spatial_merge_size**2
```

The helpers live on `BaseKeyeModule`, so both
`KeyeForConditionalGeneration` and `KeyeVL1_5ForConditionalGeneration`
inherit them.

## Duplicate check

Before opening this PR, I searched open PRs referencing #31479, searched for
Keye LoRA contributions, and reviewed the issue discussion. I did not find an
existing Keye contribution or claim.

## Tests

Checks for the changed file:

```text
.venv/bin/pre-commit run --files \
  vllm/model_executor/models/keye.py \
  --show-diff-on-failure

All applicable hooks passed.
```

```text
git diff --check

Passed.
```

End-to-end GPU smoke test:

- Model: `Kwai-Keye/Keye-VL-8B-Preview`
- Hardware: one NVIDIA A800 80GB
- Dtype: bfloat16
- Configuration: `enable_lora=True`,
  `enable_tower_connector_lora=True`
- Cases: baseline, tower-only LoRA, connector-only LoRA, and combined LoRA
- Result: all four requests completed successfully with no token-count,
  activation-mapping, or tensor-shape errors
- Cumulative logprob deltas from baseline:
  - tower: `+0.2166887862`
  - connector: `+0.0464985056`
  - combined: `+0.1244461015`

The smoke test used deterministic synthetic rank-1 adapters. The non-zero
deltas verify that the tower and connector adapter paths affected computation;
they are not model-quality measurements.