### PR TITLE
[Bugfix] Use FlashInfer auto backend for MXFP4 Linear GEMM instead of hardcoded cute-dsl

### DIFF
--- a/vllm/model_executor/kernels/linear/mxfp4/flashinfer.py
+++ b/vllm/model_executor/kernels/linear/mxfp4/flashinfer.py
@@ -71,7 +71,7 @@ class FlashInferMxFp4LinearKernel(MxFp4LinearKernel):
             layer.weight_scale,
             alpha=None,
             out_dtype=x.dtype,
-            backend="cute-dsl",
+            backend="auto",
             block_size=_MXFP4_GROUP_SIZE,
             use_nvfp4=False,
         )


### PR DESCRIPTION

## Summary

FlashInferMxFp4LinearKernel hardcodes backend="cute-dsl" for the scaled FP4 GEMM. However, the CuTe DSL backend is only available on SM10x/11x GPUs. On SM12x GPUs, this causes the following failure:

```
flashinfer.utils.BackendSupportedError: mm_fp4 does not support backend
'cute-dsl' with capability 120
```

FlashInfer's mm_fp4 already supports backend="auto", which automatically dispatches to the best available backend for the current device (e.g., cute-dsl on SM10x, cudnn on SM12x, etc.). Since the library already knows which backend to select, there is no reason to hardcode a specific one.

This PR switches the GEMM backend from "cute-dsl" to "auto" and removes the manual backend selection logic.

## What changed

- `flashinfer_scaled_fp4_mm(backend="cute-dsl")` → `backend="auto"`

---

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

