### PR TITLE
[BugFix][EPLB] Log correct avg/max token counts and balancedness

### DIFF
--- a/.buildkite/test-amd.yaml
+++ b/.buildkite/test-amd.yaml
@@ -760,10 +760,12 @@ steps:
   - vllm/distributed/eplb
   - tests/distributed/test_eplb_algo.py
   - tests/distributed/test_eplb_utils.py
+  - tests/distributed/test_eplb_state.py
   - vllm/platforms/rocm.py
   commands:
   - pytest -v -s distributed/test_eplb_algo.py
   - pytest -v -s distributed/test_eplb_utils.py
+  - pytest -v -s distributed/test_eplb_state.py
 
 - label: EPLB Execution # TBD
   timeout_in_minutes: 180

--- a/.buildkite/test_areas/expert_parallelism.yaml
+++ b/.buildkite/test_areas/expert_parallelism.yaml
@@ -11,9 +11,11 @@ steps:
   - vllm/distributed/eplb
   - tests/distributed/test_eplb_algo.py
   - tests/distributed/test_eplb_utils.py
+  - tests/distributed/test_eplb_state.py
   commands:
   - pytest -v -s distributed/test_eplb_algo.py
   - pytest -v -s distributed/test_eplb_utils.py
+  - pytest -v -s distributed/test_eplb_state.py
   mirror:
     amd:
       dind: false
@@ -25,6 +27,7 @@ steps:
       - vllm/distributed/eplb
       - tests/distributed/test_eplb_algo.py
       - tests/distributed/test_eplb_utils.py
+      - tests/distributed/test_eplb_state.py
       - vllm/platforms/rocm.py
 
 - label: EPLB Execution # 17min

--- a/tests/distributed/test_eplb_state.py
+++ b/tests/distributed/test_eplb_state.py
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for :class:`EplbState`."""
+
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+
+from vllm.config.parallel import ParallelConfig
+from vllm.distributed.eplb import eplb_state as eplb_state_module
+from vllm.distributed.eplb.eplb_state import EplbState
+
+
+def test_step_logged_metrics_reduce_over_rank_axis(monkeypatch):
+    """step()'s logged avg/max tokens must reduce across ranks, then sum
+    across layers (per its docstring) - not reduce across layers instead."""
+    # CpuGpuEvent wraps torch.cuda.Event, unavailable without CUDA.
+    monkeypatch.setattr(eplb_state_module, "CpuGpuEvent", MagicMock())
+    state = EplbState(ParallelConfig(), torch.device("cpu"))
+    state.expert_rearrangement_step_interval = 1_000
+    state.expert_load_window_size = 1
+
+    # Fake 2 EP ranks; skip the all-reduce by preloading cluster-wide load.
+    ep = MagicMock()
+    ep.device_group.size.return_value = 2
+    ep.device_group.rank.return_value = 0
+    monkeypatch.setattr(eplb_state_module, "get_ep_group", lambda: ep)
+    monkeypatch.setattr(state, "_allreduce_list", lambda t: t)
+    logger = MagicMock()
+    monkeypatch.setattr(eplb_state_module, "logger", logger)
+
+    # 3 layers x 4 experts; per-layer per-rank loads: 30/70, 3/7, 100/100.
+    load = torch.tensor(
+        [[10, 20, 30, 40], [1, 2, 3, 4], [50, 50, 50, 50]], dtype=torch.int32
+    )
+    state.model_states["m"] = MagicMock(
+        model_name="m",
+        expert_load_pass=load,
+        expert_load_window=torch.zeros((1, *load.shape), dtype=torch.int32),
+    )
+
+    state.step(log_stats=True)
+
+    avg, max_, balancedness = logger.info.call_args.args[3:6]
+    assert avg == pytest.approx(155.0)  # 310 total tokens / 2 ranks
+    assert max_ == pytest.approx(177.0)  # 70 + 7 + 100 per-layer rank maxima
+    assert balancedness == pytest.approx(155.0 / 177.0)

--- a/vllm/distributed/eplb/eplb_state.py
+++ b/vllm/distributed/eplb/eplb_state.py
@@ -584,8 +584,8 @@ class EplbState:
                 # Compute balancedness ratio:
                 # for each layer:
                 #   (mean load across ranks) / (max load across ranks)
-                avg_tokens_tensor = num_tokens_per_rank.mean(dim=0).sum(dim=0)
-                max_tokens_tensor = num_tokens_per_rank.max(dim=0).values.sum(dim=0)
+                avg_tokens_tensor = num_tokens_per_rank.mean(dim=-1).sum(dim=0)
+                max_tokens_tensor = num_tokens_per_rank.amax(dim=-1).sum(dim=0)
 
                 # Just to make type checker happy
                 tokens_tensors: list[float] = torch.stack(


### PR DESCRIPTION
## Purpose

Here is a fix for a small but confusing logging bug that I ran into: the EPLB balancedness log line reduced `avg_tokens`/`max_tokens` over the layer axis instead of the rank axis, so logged values were wrong whenever `num_moe_layers != num_ranks` leading to wrong conclusions about expert balance. Now both reduce the trailing rank axis. Log-only, actual rebalancing unaffected.

AI-assisted, every line reviewed and tested by the submitter.

## Test Plan

`pytest tests/distributed/test_eplb_state.py -v` (new CPU regression test, registered in the EPLB CI lane incl. AMD mirror).

I added the test to pin down the problem. Happy to remove it if you don't see any value in it.

## Test Result

Fails on `main` (`balancedness=0.517` vs correct `0.876`), passes with fix. No model evals: log-only change.