### PR TITLE
[Bugfix][V1] Fix silent -inf logprobs when logprob_token_ids shares a batch

### DIFF
--- a/tests/v1/sample/test_sampler.py
+++ b/tests/v1/sample/test_sampler.py
@@ -448,3 +448,49 @@ def test_sampler_bad_words(
                 assert logits_for_req[token_id] == -float("inf")
             else:
                 assert logits_for_req[token_id] != -float("inf")
+
+
+@pytest.mark.parametrize("device", DEVICES)
+def test_sampler_mixed_topk_and_logprob_token_ids(device: str):
+    """Mixed batch: request 0 asks for top-k logprobs, request 1 asks for
+    logprob_token_ids. Requests that are not in logprob_token_ids must still
+    receive their true top-k logprob rows; the specific-token gather must not
+    replace other requests' results.
+
+    Guards against the Sampler.forward batch-global preference for
+    logprob_token_ids_tensors, which silently turns rows of requests without
+    logprob_token_ids into zero-padded, -inf logprob garbage whenever any
+    co-batched request sets logprob_token_ids.
+    """
+    torch.manual_seed(0)
+    torch.set_default_device(device)
+    k = 5
+    custom_ids = [3, 7, 99]
+
+    fake_logits = torch.rand(2, VOCAB_SIZE)
+    sampling_metadata = _create_default_sampling_metadata(
+        NUM_OUTPUT_TOKENS, 2, VOCAB_SIZE, torch.device(device)
+    )
+    sampling_metadata.max_num_logprobs = k
+    sampling_metadata.logprob_token_ids = {1: custom_ids}
+
+    sampler = Sampler()
+    output = sampler.forward(fake_logits, sampling_metadata)
+    logprobs_tensors = output.logprobs_tensors
+    assert logprobs_tensors is not None
+
+    expected_logprobs = fake_logits.log_softmax(dim=-1, dtype=torch.float32)
+
+    # Request 0 (top-k): sampled token first, then its own true top-k tokens.
+    row0_ids = logprobs_tensors.logprob_token_ids[0].tolist()
+    row0_lps = logprobs_tensors.logprobs[0]
+    assert torch.isfinite(row0_lps).all(), (
+        f"top-k request got non-finite logprobs: {row0_lps.tolist()}"
+    )
+    assert row0_ids[0] == expected_logprobs[0].argmax().item()
+    assert set(row0_ids[1:]) == set(expected_logprobs[0].topk(k).indices.tolist())
+
+    # Request 1 (logprob_token_ids): sampled token plus the requested ids.
+    row1_ids = logprobs_tensors.logprob_token_ids[1].tolist()
+    assert row1_ids[0] == expected_logprobs[1].argmax().item()
+    assert set(custom_ids).issubset(row1_ids[1:])

--- a/vllm/v1/sample/sampler.py
+++ b/vllm/v1/sample/sampler.py
@@ -130,10 +130,21 @@ class Sampler(nn.Module):
                 raw_logprobs, num_logprobs, token_ids=sampled
             )
 
-        # If we have both num_logprobs and logprob_token_ids, prefer
-        # logprob_token_ids as it's more specific
-        if logprob_token_ids_tensors is not None and num_logprobs is not None:
-            logprobs_tensors = logprob_token_ids_tensors
+        # If we have both num_logprobs and logprob_token_ids in the batch,
+        # merge the specific-token rows into the top-k result per request,
+        # since requests without logprob_token_ids still expect their top-k
+        # logprobs. The num_logprobs == -1 case (spec-decode bonus tokens)
+        # requires the full-vocab tensor; never narrow it.
+        if logprob_token_ids_tensors is not None and (
+            num_logprobs is not None and num_logprobs > 0
+        ):
+            assert logprobs_tensors is not None
+            assert sampling_metadata.logprob_token_ids is not None
+            logprobs_tensors = self.merge_specific_token_logprobs(
+                logprobs_tensors,
+                logprob_token_ids_tensors,
+                sampling_metadata.logprob_token_ids,
+            )
 
         # Use int32 to reduce the tensor size.
         sampled = sampled.to(torch.int32)
@@ -223,6 +234,32 @@ class Sampler(nn.Module):
             logprobs=gathered_logprobs,
             selected_token_ranks=token_ranks,
         )
+
+    @staticmethod
+    def merge_specific_token_logprobs(
+        topk_tensors: LogprobsTensors,
+        specific_tensors: LogprobsTensors,
+        logprob_token_ids: dict[int, list[int]],
+    ) -> LogprobsTensors:
+        """Merge specific-token rows into the batch's top-k logprobs result.
+
+        Requests listed in ``logprob_token_ids`` get their requested-token
+        rows; all other requests keep their top-k rows. Columns past a
+        row's true content stay padding (token id 0, logprob -inf) and are
+        never read downstream.
+        """
+        batch_size, topk_cols = topk_tensors.logprobs.shape
+        spec_cols = specific_tensors.logprobs.shape[1]
+        num_cols = max(topk_cols, spec_cols)
+        out_ids = topk_tensors.logprob_token_ids.new_zeros((batch_size, num_cols))
+        out_lps = topk_tensors.logprobs.new_full((batch_size, num_cols), -float("inf"))
+        out_ids[:, :topk_cols] = topk_tensors.logprob_token_ids
+        out_lps[:, :topk_cols] = topk_tensors.logprobs
+        rows = sorted(logprob_token_ids)
+        out_ids[rows, :spec_cols] = specific_tensors.logprob_token_ids[rows]
+        out_lps[rows, :spec_cols] = specific_tensors.logprobs[rows]
+        # Both inputs contain the same sampled-token ranks.
+        return LogprobsTensors(out_ids, out_lps, topk_tensors.selected_token_ranks)
 
     @staticmethod
     def apply_temperature(


### PR DESCRIPTION
## Purpose

I ran into an odd interaction between generative-scoring traffic and top-k logprobs: whenever a request with `logprob_token_ids` shares a batch with a `logprobs=k` request, V1 `Sampler.forward` replaces the whole batch's top-k result with the specific-token gather, so the other requests get `-inf` rows (API: one collapsed `<pad>: -9999.0` entry instead of their top-k). Text is unaffected, so this fails silently; two concurrent requests are enough to trigger this behaviour. V1 sampler only, the V2 runner already merges per-request.

Fix: merge specific-token rows into the top-k result per request, gated on `num_logprobs > 0` so the spec-decode bonus path keeps its full-vocab tensor (which also removes the #42592 crash precondition). Complementary to #44727.

AI-assisted, every line reviewed and tested by the submitter.

## Test Plan

`pytest tests/v1/sample/test_sampler.py`

New regression test included. E2E A/B on two identical gemma-4-26B-A4B-it (V1) servers, greedy, 16 concurrent mixed pairs each.

## Test Result

Unit: fails on main (`[sampled, -inf, -inf, -inf]`), passes with patch; file 37/37. E2E: unpatched 16/16 corrupted, patched 16/16 correct.
