### PR TITLE
[Quantization] Remove dead `QuantizationConfig.is_mxfp4_quant`

### DIFF
--- a/vllm/model_executor/layers/quantization/base_config.py
+++ b/vllm/model_executor/layers/quantization/base_config.py
@@ -258,19 +258,3 @@ class QuantizationConfig(ABC):
         # TODO: revision is never passed currently in vllm.py,
         # but is used in subclasses, should we remove this parameter?
         pass
-
-    def is_mxfp4_quant(self, prefix: str, layer: torch.nn.Module) -> bool:
-        """
-        Determine if mxfp4 quantization will be used for this config.
-
-        This allows hidden_size rounding to happen before moe_config creation
-        without needing to instantiate quant_method first.
-
-        Args:
-            prefix: The layer prefix/name in the model
-            layer: The layer module
-
-        Returns:
-            True if this config uses MXFP4 quantization, False otherwise
-        """
-        return False

--- a/vllm/model_executor/layers/quantization/mxfp4.py
+++ b/vllm/model_executor/layers/quantization/mxfp4.py
@@ -104,10 +104,6 @@ class Mxfp4Config(QuantizationConfig):
             )
         return None
 
-    def is_mxfp4_quant(self, prefix: str, layer: torch.nn.Module) -> bool:
-        """MXFP4 config always uses MXFP4 quantization."""
-        return True
-
 
 class GptOssMxfp4Config(Mxfp4Config):
     """MXFP4 config for GPT-OSS checkpoints.

--- a/vllm/model_executor/layers/quantization/quark/quark.py
+++ b/vllm/model_executor/layers/quantization/quark/quark.py
@@ -576,22 +576,6 @@ class QuarkConfig(QuantizationConfig):
 
         return True
 
-    def is_mxfp4_quant(self, prefix: str, layer: torch.nn.Module) -> bool:
-        """
-        For Quark, determine if it's OCP MXFP4 by checking config directly.
-        This allows hidden_size rounding to happen before moe_config creation.
-        """
-        layer_quant_config = self._find_matched_config(prefix, layer)
-        weight_config = layer_quant_config.get("weight")
-        input_config = layer_quant_config.get("input_tensors")
-
-        return (
-            self._is_w_ocp_mx_a_x(weight_config, input_config)
-            and weight_config is not None
-            and weight_config.get("dtype") == "fp4"
-            and getattr(torch, "float4_e2m1fn_x2", None) is not None
-        )
-
     def _find_matched_config(
         self, layer_name: str, module: torch.nn.Module
     ) -> dict[str, Any]:

--- a/vllm/models/deepseek_v4/quant_config.py
+++ b/vllm/models/deepseek_v4/quant_config.py
@@ -192,8 +192,3 @@ class DeepseekV4FP8Config(Fp8Config):
             # expert_dtype == "fp8": fall through to Fp8Config which
             # returns Fp8MoEMethod with block-wise float32 scales.
         return super().get_quant_method(layer, prefix)
-
-    def is_mxfp4_quant(self, prefix, layer):
-        if not isinstance(layer, RoutedExperts) or self.expert_dtype != "fp4":
-            return False
-        return self.moe_quant_algo != "NVFP4"


### PR DESCRIPTION
## Purpose

This is dead code following https://github.com/vllm-project/vllm/pull/37128.

This was originally added in https://github.com/vllm-project/vllm/pull/29008 that supported padding for gpt-oss / certain MXFP4 backends, see: https://github.com/xuebwang-amd/vllm/blob/c62f664e97977ee54ab1d1c77604ebb45081bc06/vllm/model_executor/layers/fused_moe/layer.py#L259-L277

This is now handled in:

https://github.com/vllm-project/vllm/blob/490259c1f63faf025b8050504db63d81c817d781/vllm/model_executor/layers/fused_moe/oracle/mxfp4.py#L640

## Test Plan

N/A

## Test Result

N/A