### PR TITLE
[ROCm][Perf] Kimi-K3 DSpark draft MLA decode kernel for gfx950

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1184,6 +1184,18 @@ if(VLLM_GPU_LANG STREQUAL "CUDA" OR VLLM_GPU_LANG STREQUAL "HIP")
   target_compile_definitions(_C_stable_libtorch PRIVATE
     TORCH_TARGET_VERSION=0x020B000000000000ULL)
 
+  # The Kimi-K3 DSpark draft MLA kernel uses v_mfma_scale_f32_16x16x128_f8f6f4
+  # and ds_read_b64_tr_b8, both gfx950-only, and C++20 for std::bit_cast.
+  if(VLLM_GPU_LANG STREQUAL "HIP" AND "gfx950" IN_LIST VLLM_GPU_ARCHES)
+    set(KIMI_K3_H40_DRAFT_MLA_ARCHS "gfx950")
+    set(KIMI_K3_H40_DRAFT_MLA_SRC
+      "csrc/libtorch_stable/kimi_k3/h40_draft_mla_decode_rocm.hip")
+    set_source_files_properties(${KIMI_K3_H40_DRAFT_MLA_SRC} PROPERTIES
+      COMPILE_OPTIONS "-std=c++20")
+    list(APPEND VLLM_STABLE_EXT_SRC "${KIMI_K3_H40_DRAFT_MLA_SRC}")
+    message(STATUS "Building Kimi-K3 H40 draft MLA decode for gfx950")
+  endif()
+
   # Needed to use cuda/hip APIs from C-shim
   if(VLLM_GPU_LANG STREQUAL "CUDA")
     target_compile_definitions(_C_stable_libtorch PRIVATE USE_CUDA)
@@ -1204,6 +1216,10 @@ if(VLLM_GPU_LANG STREQUAL "CUDA" OR VLLM_GPU_LANG STREQUAL "HIP")
       CUTLASS_ENABLE_DIRECT_CUDA_DRIVER_CALL=1)
   elseif(VLLM_GPU_LANG STREQUAL "HIP")
     target_compile_definitions(_C_stable_libtorch PRIVATE USE_ROCM)
+    if(KIMI_K3_H40_DRAFT_MLA_ARCHS)
+      target_compile_definitions(_C_stable_libtorch PRIVATE
+        VLLM_ENABLE_KIMI_K3_H40_DRAFT_MLA=1)
+    endif()
   endif()
 
   # On ROCm, _C_stable_libtorch calls raw HIP APIs (e.g. hipGetDevice in

--- a/csrc/libtorch_stable/kimi_k3/h40_draft_mla_decode_rocm.hip
+++ b/csrc/libtorch_stable/kimi_k3/h40_draft_mla_decode_rocm.hip
@@ -1,0 +1,919 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+//
+// Kimi-K3 DSpark draft MLA decode for gfx950 (MI350/MI355).
+//
+// The DSpark draft group is a NON-CAUSAL multi-token block: all `qlen` query
+// positions of a request attend to the same committed KV prefix and never to a
+// sibling block token.  vLLM's Triton MLA path handles that by flattening the
+// block to one decode row per query token, so each of the `batch * qlen` rows
+// re-reads the whole KV span -- qlen times the traffic.  This kernel keeps the
+// block folded: all `qlen * num_heads` rows live in one 128-row workgroup tile
+// and the KV span is read exactly once.
+//
+// The MLA latent (512) plus RoPE (64) is consumed as fp8 e4m3 through
+// v_mfma_scale_f32_16x16x128_f8f6f4, which is why this is gfx950-only.
+//
+// Portions of this file and the bundled `opus/` headers are derived from AMD's
+// aiter (https://github.com/ROCm/aiter), MIT licensed, and are redistributed
+// here under those terms; see opus/opus.hpp for the original notice.
+
+#include <cstdint>
+#include <optional>
+
+#include <torch/csrc/inductor/aoti_torch/c/shim.h>
+#include <torch/csrc/stable/accelerator.h>
+#include <torch/csrc/stable/library.h>
+#include <torch/csrc/stable/ops.h>
+#include <torch/csrc/stable/tensor.h>
+#include <torch/headeronly/util/shim_utils.h>
+
+// Deliberately not ../torch_utils.h: it pulls <cuda_runtime.h>/<cublas_v2.h>,
+// which only resolve for sources that go through hipify.  This file is
+// HIP-native and is compiled as-is (hipify skips .hip), so it takes the two
+// stable-ABI pieces it needs directly.
+namespace {
+inline hipStream_t vllm_current_hip_stream(int32_t device_index) {
+  void* stream_ptr = nullptr;
+  TORCH_ERROR_CODE_CHECK(
+      aoti_torch_get_current_cuda_stream(device_index, &stream_ptr));
+  return reinterpret_cast<hipStream_t>(stream_ptr);
+}
+}  // namespace
+
+#include "opus/opus.hpp"
+#ifndef __HIP_DEVICE_COMPILE__
+#include "opus/hip_minimal.hpp"
+#endif
+
+#include <algorithm>
+#include <bit>
+#include <cstdint>
+
+#ifndef __launch_bounds__
+#define __launch_bounds__(threads, blocks) \
+    __attribute__((amdgpu_flat_work_group_size(1, threads), \
+                   amdgpu_waves_per_eu(blocks)))
+#endif
+
+namespace kimi_k3_h40_draft {
+
+#ifndef VLLM_K3_H40_PV_BATCH
+#define VLLM_K3_H40_PV_BATCH 4
+#endif
+#ifndef VLLM_K3_H40_EP_PITCH
+#define VLLM_K3_H40_EP_PITCH 520
+#endif
+#ifndef VLLM_K3_H40_Q_SUB
+#define VLLM_K3_H40_Q_SUB 2
+#endif
+// Ablation probes -- ALL give WRONG results.  They exist to price a component
+// by removing it and seeing how much time comes back.
+// Stage KV through registers instead of buffer_load...lds.  A microbenchmark
+// at the same 3.6 MB/WG footprint measures the direct-to-LDS DMA path at
+// 14.4 GB/s/CU against 23.3 GB/s/CU for plain register loads at 8 in flight --
+// the DMA path is latency-limited well below what the CU can do.  Since the
+// kernel time equals its DMA time exactly (MFMA is fully hidden inside it),
+// closing that gap should drop it onto the MFMA floor: 249.7 -> ~178 us.
+// STAGE_BATCH = halves issued before their ds_writes, i.e. loads in flight
+// = 5 * STAGE_BATCH, at 4 VGPRs each.
+// Query-position masking mode, baked in at compile time so neither build pays
+// for the other's branch.  1 = target verify: position p sees KV up to
+// full_len-(qlen-1)+p.  0 = the DSpark draft group, which vLLM documents as a
+// non-causal multi-token block -- every position sees the whole KV, so only
+// the out-of-range tail guard remains and `qpos` (an integer divide per row)
+// falls out as dead code.
+// The draft block is non-causal; only the tail guard remains.
+#define VLLM_K3_H40_CAUSAL 0
+// Read a vLLM paged block table directly instead of a pre-expanded per-token
+// index list.  Two reasons, both required for the in-engine draft path:
+//   * The DSpark draft step runs under a FULL CUDA graph.  Expanding a block
+//     table into token ids on the host side needs a data-dependent pack (the
+//     batch is ragged), which is not capturable; reading the table is.
+//   * A KV tile never straddles a page, because page_size is a multiple of
+//     KV_TILE.  So one scalar page lookup per tile replaces KV_TILE gathered
+//     index loads, and the 34 us/call expansion disappears entirely.
+// The static_assert lives in the launcher: page_size % KV_TILE == 0.
+// Always read vLLM's paged block table directly.
+#define VLLM_K3_H40_BLOCK_TABLE 1
+#ifndef VLLM_K3_H40_SCHED
+#define VLLM_K3_H40_SCHED 0
+#endif
+#ifndef VLLM_K3_H40_QK_PIPE
+#define VLLM_K3_H40_QK_PIPE 2
+#endif
+#ifndef VLLM_K3_H40_REDUCE_THREADS
+#define VLLM_K3_H40_REDUCE_THREADS 128
+#endif
+
+struct kargs
+{
+    const void* __restrict__ q_ptr;       // [T, qlen*nhead, 576] fp8
+    const void* __restrict__ kv_ptr;      // [rows, 576] fp8
+    const int* __restrict__ kv_indptr;    // [T+1]
+    const int* __restrict__ kv_indices;   // [sum(seq_len)]
+    // Block-table mode only; both null otherwise.
+    const int* __restrict__ kv_block_table; // [T, bt_stride]
+    const int* __restrict__ kv_seq_lens;    // [T]
+    int bt_stride;
+    int page_size;
+    float* __restrict__ part_m;           // [T, splits, rows_pad]
+    float* __restrict__ part_l;           // [T, splits, rows_pad]
+    float* __restrict__ part_acc;         // [T, splits, rows_pad, 512]
+    void* __restrict__ out_ptr;           // [T, qlen*nhead, 512] bf16
+    int T;
+    int qlen;
+    int nhead;
+    int valid_rows;
+    int rows_pad;
+    int h_offset;
+    int kv_rows;
+    int num_splits;
+    float qk_scale_log2;
+    float output_scale;
+};
+
+struct traits
+{
+    static constexpr int Q_TILE = 16;
+    static constexpr int Q_SUB = VLLM_K3_H40_Q_SUB;
+    static constexpr int NUM_WARPS = 4;
+    static constexpr int WARP_SIZE = 64;
+    static constexpr int BLOCK_SIZE = NUM_WARPS * WARP_SIZE;
+    static constexpr int HEADS_PER_BLOCK = NUM_WARPS * Q_SUB * Q_TILE;
+
+    static constexpr int KV_TILE = 128;
+    static constexpr int D_QK = 576;
+    static constexpr int D_V = 512;
+    static constexpr int D_SLICES = 5; // 4x128 + a zero-padded 64 tail
+    static constexpr int N_TILES = KV_TILE / 16;
+    static constexpr int O_TILES = D_V / 16;
+    static constexpr int K_BLOCKS = KV_TILE / 32;
+    static constexpr int S_LEN = N_TILES * 4;
+
+    // Same token permutation as pa_sparse_prefill_fp8_h40.  The first 32
+    // 16-byte cells are V and the final four cells are K-only RoPE.
+    static constexpr int ATOM = 128;
+    static constexpr int PAD = 64;
+    static constexpr int ROW = 36 * ATOM + PAD;
+    static constexpr int TILE_BYTES = 16 * ROW;
+    static constexpr int SLOTS_PER_WAVE = 16 / NUM_WARPS;
+    static constexpr int SMEM_BYTES = 2 * TILE_BYTES;
+
+    static constexpr int PV_BATCH = VLLM_K3_H40_PV_BATCH;
+    static constexpr int QK_PIPE = VLLM_K3_H40_QK_PIPE;
+    static_assert(QK_PIPE == 1 || QK_PIPE == 2);
+    static_assert(O_TILES % PV_BATCH == 0);
+    static constexpr int EP_PITCH =
+        VLLM_K3_H40_EP_PITCH; // fp32 elements per staged head row
+    static_assert(SMEM_BYTES <= 163840);
+    static_assert(
+        NUM_WARPS * Q_TILE * EP_PITCH * (int)sizeof(float)
+        <= SMEM_BYTES);
+};
+
+__host__ __device__ inline int ceil_div(int a, int b)
+{
+    return (a + b - 1) / b;
+}
+
+__global__ void partial_kernel(kargs args);
+__global__ void reduce_kernel(kargs args);
+
+#if defined(__HIP_DEVICE_COMPILE__) && defined(__gfx950__)
+
+namespace device {
+
+using namespace opus;
+using fp8_t = _BitInt(8);
+using u8_t = unsigned char;
+using i32x2 = int __attribute__((ext_vector_type(2)));
+using i32x4 = int __attribute__((ext_vector_type(4)));
+using i32x8 = int __attribute__((ext_vector_type(8)));
+using f32x4 = float __attribute__((ext_vector_type(4)));
+
+constexpr float LOWEST = -3.4028234663852886e38f;
+
+__device__ inline f32x4 mma_unit(const i32x8& a,
+                                const i32x8& b,
+                                const f32x4& c)
+{
+    return __builtin_amdgcn_mfma_scale_f32_16x16x128_f8f6f4(
+        a, b, c, 0, 0, 0, 127, 0, 127);
+}
+
+__device__ inline f32x4 mma_p(const i32x8& v,
+                             const i32x8& p,
+                             const f32x4& c,
+                             int p_scale)
+{
+    return __builtin_amdgcn_mfma_scale_f32_16x16x128_f8f6f4(
+        v, p, c, 0, 0, 0, 127, 0, p_scale);
+}
+
+__device__ inline i32x8 pack32(const i32x4& lo, const i32x4& hi)
+{
+    i32x8 out;
+#pragma unroll
+    for(int i = 0; i < 4; ++i)
+    {
+        out[i] = lo[i];
+        out[4 + i] = hi[i];
+    }
+    return out;
+}
+
+__device__ inline float reduce_max_groups(float v)
+{
+    vector_t<u32_t, 2> r32 = __builtin_amdgcn_permlane32_swap(
+        std::bit_cast<u32_t>(v), std::bit_cast<u32_t>(v), false, true);
+    v = max(std::bit_cast<float>(r32.x), std::bit_cast<float>(r32.y));
+    vector_t<u32_t, 2> r16 = __builtin_amdgcn_permlane16_swap(
+        std::bit_cast<u32_t>(v), std::bit_cast<u32_t>(v), false, true);
+    return max(std::bit_cast<float>(r16.x), std::bit_cast<float>(r16.y));
+}
+
+__device__ inline float reduce_sum_groups(float v)
+{
+    vector_t<u32_t, 2> r32 = __builtin_amdgcn_permlane32_swap(
+        std::bit_cast<u32_t>(v), std::bit_cast<u32_t>(v), false, true);
+    v = std::bit_cast<float>(r32.x) + std::bit_cast<float>(r32.y);
+    vector_t<u32_t, 2> r16 = __builtin_amdgcn_permlane16_swap(
+        std::bit_cast<u32_t>(v), std::bit_cast<u32_t>(v), false, true);
+    return std::bit_cast<float>(r16.x) + std::bit_cast<float>(r16.y);
+}
+
+__device__ inline void lds_barrier()
+{
+    s_waitcnt_lgkmcnt(0_I);
+    __builtin_amdgcn_s_barrier();
+}
+
+} // namespace device
+
+__global__ __launch_bounds__(traits::BLOCK_SIZE, 1)
+void partial_kernel(kargs args)
+{
+    using namespace opus;
+    using namespace device;
+    using T = traits;
+
+    const int req = (int)__builtin_amdgcn_workgroup_id_x();
+    const int h_block = (int)__builtin_amdgcn_workgroup_id_y();
+    const int split = (int)__builtin_amdgcn_workgroup_id_z();
+    const int tid = (int)__builtin_amdgcn_workitem_id_x();
+    int lane = tid & 63;
+    asm volatile("" : "+v"(lane));
+    const int warp = __builtin_amdgcn_readfirstlane(tid >> 6);
+    const int c = lane & 15;
+    const int g = lane >> 4;
+
+#if VLLM_K3_H40_BLOCK_TABLE
+    const int full_begin = 0;
+    const int full_len   = args.kv_seq_lens[req];
+#else
+    const int full_begin = args.kv_indptr[req];
+    const int full_len = args.kv_indptr[req + 1] - full_begin;
+#endif
+    const int full_tiles = ceil_div(full_len, T::KV_TILE);
+    const int tiles_per_split = ceil_div(full_tiles, args.num_splits);
+    const int first_tile = split * tiles_per_split;
+    const int last_tile = min(first_tile + tiles_per_split, full_tiles);
+    const int segment_begin = first_tile * T::KV_TILE;
+    const int segment_end = min(last_tile * T::KV_TILE, full_len);
+    const int segment_len = max(0, segment_end - segment_begin);
+    const int num_tiles = ceil_div(segment_len, T::KV_TILE);
+
+    const int h_base =
+        args.h_offset + h_block * T::HEADS_PER_BLOCK;
+    const int h_wave = warp * (T::Q_SUB * T::Q_TILE);
+
+    __shared__ char smem[T::SMEM_BYTES];
+
+    auto g_q = make_gmem(
+        reinterpret_cast<const fp8_t*>(args.q_ptr)
+            + ((size_t)req * args.valid_rows + h_base) * T::D_QK,
+        (unsigned)max(0, args.valid_rows - h_base) * T::D_QK);
+
+    i32x8 v_q[T::Q_SUB][T::D_SLICES];
+    const i32x4 zero4{0, 0, 0, 0};
+#pragma unroll
+    for(int qs = 0; qs < T::Q_SUB; ++qs)
+    {
+        const int q_row = (h_wave + qs * T::Q_TILE + c) * T::D_QK;
+        const int q_off = q_row + 16 * g;
+#pragma unroll
+        for(int ds = 0; ds < T::D_SLICES; ++ds)
+        {
+            const i32x4 lo = __builtin_bit_cast(
+                i32x4, load<16>(g_q, q_off + ds * 128));
+            const i32x4 hi = ds == T::D_SLICES - 1
+                ? zero4
+                : __builtin_bit_cast(
+                      i32x4, load<16>(g_q, q_off + ds * 128 + 64));
+            v_q[qs][ds] = pack32(lo, hi);
+        }
+    }
+
+    f32x4 v_o[T::Q_SUB][T::O_TILES];
+#pragma unroll
+    for(int qs = 0; qs < T::Q_SUB; ++qs)
+#pragma unroll
+        for(int ot = 0; ot < T::O_TILES; ++ot)
+            v_o[qs][ot] = f32x4{0.f, 0.f, 0.f, 0.f};
+
+    float m_row[T::Q_SUB];
+    float m_ref[T::Q_SUB];
+    float l_row[T::Q_SUB];
+#pragma unroll
+    for(int qs = 0; qs < T::Q_SUB; ++qs)
+    {
+        m_row[qs] = LOWEST;
+        m_ref[qs] = LOWEST;
+        l_row[qs] = 0.f;
+    }
+
+    if(num_tiles > 0)
+    {
+#if !VLLM_K3_H40_BLOCK_TABLE
+        // Flat-index mode addresses the whole cache from one descriptor, so it
+        // is limited to kv_rows * 576 < 2^32; the launcher rejects anything
+        // bigger rather than aliasing silently.
+        auto g_kv = make_gmem(
+            reinterpret_cast<const fp8_t*>(args.kv_ptr),
+            (unsigned)args.kv_rows * T::D_QK);
+        auto g_idx = make_gmem(
+            args.kv_indices + full_begin + segment_begin,
+            (unsigned)segment_len * sizeof(int));
+#endif
+
+        const int qk_base =
+            (c >> 2) * T::ROW + (c & 3) * 16 + g * T::ATOM;
+        const int pv_base = g * T::ROW + c * 8;
+        const int p_lane = 16 * ((lane & 7) >> 2) + (lane & 3);
+        const int d_lane = (lane >> 3) * 16;
+
+        auto load_rows = [&](int tile_idx,
+                             int (&rows)[T::SLOTS_PER_WAVE],
+                             int& page) {
+#if VLLM_K3_H40_BLOCK_TABLE
+            // segment_begin is a multiple of KV_TILE and page_size is a
+            // multiple of KV_TILE, so the whole tile lives in one page and the
+            // row ids are consecutive.  pg is clamped because the prologue
+            // prefetches one tile past the end; that tile's data is never
+            // consumed, but its address still has to be in range.
+            //
+            // rows[] are PAGE-LOCAL, and the page's byte offset is folded into
+            // a 64-bit base pointer by the caller.  A global row index would
+            // not fit: a production KV cache is 3846 pages x 3072 tokens, and
+            // 11.8e6 * 576 = 6.8e9 overflows the 32-bit buffer offset -- 37% of
+            // the cache aliases onto the wrong rows.  That is invisible at
+            // benchmark sizes (528 pages = 0.93 GB) and fatal in the engine.
+            const int tile_tok = segment_begin + tile_idx * T::KV_TILE;
+            int pg             = tile_tok / args.page_size;
+            pg                 = pg < args.bt_stride ? pg : args.bt_stride - 1;
+            page               = __builtin_amdgcn_readfirstlane(
+                args.kv_block_table[req * args.bt_stride + pg]);
+            const int base     = tile_tok - pg * args.page_size;
+#else
+            page = 0;
+#endif
+#pragma unroll
+            for(int half = 0; half < T::SLOTS_PER_WAVE; ++half)
+            {
+                const int s_hi = T::SLOTS_PER_WAVE * warp + half;
+                const int p =
+                    32 * (s_hi >> 2) + 4 * (s_hi & 3) + p_lane;
+#if VLLM_K3_H40_BLOCK_TABLE
+                rows[half] = base + p;
+#else
+                rows[half] =
+                    load(g_idx, tile_idx * T::KV_TILE + p)[0];
+#endif
+            }
+        };
+
+        auto issue_copy = [&](const int (&rows)[T::SLOTS_PER_WAVE],
+                              int page,
+                              int buf) {
+            char* const dst = smem + buf * T::TILE_BYTES;
+#if VLLM_K3_H40_BLOCK_TABLE
+            // One descriptor per tile, based at the page.  The 64-bit multiply
+            // happens here, in scalar registers, so every offset the loads see
+            // is page-local (< page_size * 576 = 1.77 MB) and cannot overflow.
+            auto g_kv = make_gmem(
+                reinterpret_cast<const fp8_t*>(args.kv_ptr)
+                    + (size_t)page * (size_t)args.page_size * T::D_QK,
+                (unsigned)args.page_size * T::D_QK);
+#endif
+#pragma unroll
+            for(int half = 0; half < T::SLOTS_PER_WAVE; ++half)
+            {
+                const int s_hi = T::SLOTS_PER_WAVE * warp + half;
+                const unsigned goff =
+                    (unsigned)rows[half] * T::D_QK
+                    + (unsigned)d_lane;
+#pragma unroll
+                for(int q = 0; q < 4; ++q)
+                    g_kv.template async_load<16>(
+                        dst + s_hi * T::ROW + q * 1024,
+                        goff + (unsigned)q * 128u);
+                if(d_lane < 64)
+                    g_kv.template async_load<16>(
+                        dst + s_hi * T::ROW + 4 * 1024,
+                        goff + 4u * 128u);
+            }
+        };
+
+        int rows0[T::SLOTS_PER_WAVE];
+        int rows1[T::SLOTS_PER_WAVE];
+        int page0 = 0, page1 = 0;
+        load_rows(0, rows0, page0);
+        issue_copy(rows0, page0, 0);
+        load_rows(1, rows0, page0);
+
+        int buf = 0;
+        for(int tile = 0; tile < num_tiles; ++tile)
+        {
+            s_waitcnt_vmcnt(0_I);
+            lds_barrier();
+
+            const bool has_next = tile + 1 < num_tiles;
+            if(has_next)
+            {
+                issue_copy(rows0, page0, buf ^ 1);
+                load_rows(tile + 2, rows1, page1);
+            }
+
+            auto s_kv = make_smem(
+                reinterpret_cast<fp8_t*>(
+                    smem + buf * T::TILE_BYTES));
+
+            float scores[T::Q_SUB][T::S_LEN];
+
+            auto load_k = [&](auto i_nt,
+                              i32x8 (&kk)[T::D_SLICES]) {
+                constexpr int nt = decltype(i_nt)::value;
+                constexpr int nt_off =
+                    (nt >> 1) * 4 * T::ROW + (nt & 1) * 64;
+                static_for<T::D_SLICES>([&](auto i_ds) {
+                    constexpr int ds = i_ds.value;
+                    constexpr int off0 = nt_off + ds * 1024;
+                    const i32x4 lo = __builtin_bit_cast(
+                        i32x4,
+                        s_kv.template _load<16>(qk_base + off0));
+                    const i32x4 hi =
+                        ds == T::D_SLICES - 1
+                        ? zero4
+                        : __builtin_bit_cast(
+                              i32x4,
+                              s_kv.template _load<16>(
+                                  qk_base + off0 + 4 * T::ATOM));
+                    kk[ds] = pack32(lo, hi);
+                });
+            };
+
+            i32x8 kbuf[T::QK_PIPE][T::D_SLICES];
+            if constexpr(T::QK_PIPE == 2)
+                load_k(number<0>{}, kbuf[0]);
+            static_for<T::N_TILES>([&](auto i_nt) {
+                constexpr int nt = i_nt.value;
+                if constexpr(T::QK_PIPE == 2)
+                {
+                    if constexpr(nt + 1 < T::N_TILES)
+                        load_k(number<nt + 1>{}, kbuf[(nt + 1) & 1]);
+                }
+                else
+                    load_k(number<nt>{}, kbuf[0]);
+
+                f32x4 acc[T::Q_SUB];
+#pragma unroll
+                for(int qs = 0; qs < T::Q_SUB; ++qs)
+                    acc[qs] = f32x4{0.f, 0.f, 0.f, 0.f};
+                static_for<T::D_SLICES>([&](auto i_ds) {
+                    constexpr int ds = i_ds.value;
+#pragma unroll
+                    for(int qs = 0; qs < T::Q_SUB; ++qs)
+                        acc[qs] = mma_unit(
+                            kbuf[T::QK_PIPE == 2 ? (nt & 1) : 0][ds],
+                            v_q[qs][ds],
+                            acc[qs]);
+                });
+#pragma unroll
+                for(int qs = 0; qs < T::Q_SUB; ++qs)
+#pragma unroll
+                    for(int i = 0; i < 4; ++i)
+                        scores[qs][nt * 4 + i] = acc[qs][i];
+#if VLLM_K3_H40_SCHED
+#pragma unroll
+                for(int rep = 0; rep < 3; ++rep)
+                {
+                    __builtin_amdgcn_sched_group_barrier(0x100, 3, 0);
+                    __builtin_amdgcn_sched_group_barrier(0x008, 4, 0);
+                }
+#endif
+            });
+
+            const int tile_global =
+                segment_begin + tile * T::KV_TILE;
+#if VLLM_K3_H40_CAUSAL
+            const bool maybe_mask =
+                tile_global + T::KV_TILE - 1 + args.qlen - 1
+                >= full_len;
+#else
+            // Non-causal needs no (qlen-1) slack: the predicate is exact and
+            // one fewer tile takes the masked path.
+            const bool maybe_mask =
+                tile_global + T::KV_TILE - 1 >= full_len;
+#endif
+
+            i32x8 v_p[T::Q_SUB];
+            float bias[T::Q_SUB];
+            int dexp[T::Q_SUB];
+#pragma unroll
+            for(int qs = 0; qs < T::Q_SUB; ++qs)
+            {
+                const int row =
+                    h_base + h_wave + qs * T::Q_TILE + c;
+#if VLLM_K3_H40_CAUSAL
+                const int qpos = row / args.nhead;
+                const int shift = args.qlen - 1 - qpos;
+#else
+                const int shift = 0;
+#endif
+
+                float local_max = LOWEST;
+                // Only the tail tile can be masked, but maybe_mask was a plain
+                // runtime scalar, so the per-element select was emitted on
+                // every tile: ATT charged 64 v_cndmask 2.2% of the kernel for
+                // work that matters on 1 tile in ~49.  Peel it onto a
+                // compile-time flag so the common path has no kv_pos, no
+                // compare, no select and no store-back.
+                auto scan = [&]<bool MASK>() {
+#pragma unroll
+                    for(int a = 0; a < T::N_TILES; ++a)
+#pragma unroll
+                        for(int b = 0; b < 4; ++b)
+                        {
+                            float s = scores[qs][a * 4 + b];
+                            if constexpr(MASK)
+                            {
+                                const int kv_pos =
+                                    tile_global + 16 * a + 4 * g + b;
+                                if(kv_pos + shift >= full_len)
+                                    s = LOWEST;
+                                scores[qs][a * 4 + b] = s;
+                            }
+                            local_max = max(local_max, s);
+                        }
+                };
+                if(maybe_mask)
+                    scan.template operator()<true>();
+                else
+                    scan.template operator()<false>();
+
+                const float row_max =
+                    reduce_max_groups(local_max)
+                    * args.qk_scale_log2;
+                const float new_m =
+                    __builtin_floorf(max(m_row[qs], row_max));
+                if(m_ref[qs] == LOWEST)
+                    m_ref[qs] = new_m;
+                m_row[qs] = new_m;
+                bias[qs] = -m_ref[qs];
+                dexp[qs] = (int)(new_m - m_ref[qs]);
+                // P is scaled by 2^(7-dexp) to land in e4m3's range.  Folding
+                // that into exp2's addend costs nothing -- it is already an fma
+                // operand -- and removes one v_ldexp_f32 per score element.
+                // dexp is exact (new_m and m_ref are both floored), so this is
+                // an identity, not an approximation.  local_sum then carries
+                // the factor and is unscaled once per row instead of 32 times.
+                const float pbias = bias[qs] + (float)(7 - dexp[qs]);
+
+                float local_sum = 0.f;
+                i32x8 packed;
+#pragma unroll
+                for(int a = 0; a < T::N_TILES; ++a)
+                {
+                    vector_t<float, 4> p4;
+#pragma unroll
+                    for(int b = 0; b < 4; ++b)
+                    {
+                        const float p = __builtin_amdgcn_exp2f(
+                            __builtin_fmaf(
+                                scores[qs][a * 4 + b],
+                                args.qk_scale_log2,
+                                pbias));
+                        local_sum += p;
+                        p4[b] = p;
+                    }
+                    packed[a] = __builtin_bit_cast(
+                        int, cast<fp8_t>(p4));
+                }
+                v_p[qs] = packed;
+                l_row[qs] += __builtin_ldexpf(
+                    reduce_sum_groups(local_sum), dexp[qs] - 7);
+            }
+
+            s_waitcnt_lgkmcnt(0_I);
+            auto load_v = [&](auto i_ot) {
+                constexpr int ot = decltype(i_ot)::value;
+                i32x8 v;
+                static_for<T::K_BLOCKS>([&](auto i_beta) {
+                    constexpr int beta = i_beta.value;
+                    const i32x2 r = __builtin_bit_cast(
+                        i32x2,
+                        s_kv.template _tr_load<
+                            8,
+                            ot * T::ATOM
+                                + beta * 4 * T::ROW>(pv_base));
+                    v[2 * beta] = r[0];
+                    v[2 * beta + 1] = r[1];
+                });
+                return v;
+            };
+
+            asm volatile("" ::: "memory");
+            s_waitcnt_lgkmcnt(0_I);
+            static_for<T::O_TILES / T::PV_BATCH>([&](auto i_batch) {
+                constexpr int first =
+                    i_batch.value * T::PV_BATCH;
+                i32x8 vv[T::PV_BATCH];
+                static_for<T::PV_BATCH>([&](auto i) {
+                    constexpr int j = i.value;
+                    vv[j] = load_v(number<first + j>{});
+                });
+                s_waitcnt_lgkmcnt(0_I);
+#pragma unroll
+                for(int j = 0; j < T::PV_BATCH; ++j)
+                    asm volatile("" : "+v"(vv[j]) ::);
+                static_for<T::PV_BATCH>([&](auto i) {
+                    constexpr int j = i.value;
+#pragma unroll
+                    for(int qs = 0; qs < T::Q_SUB; ++qs)
+                        v_o[qs][first + j] = mma_p(
+                            vv[j],
+                            v_p[qs],
+                            v_o[qs][first + j],
+                            127 + dexp[qs]);
+                });
+            });
+            if(has_next)
+            {
+#pragma unroll
+                for(int i = 0; i < T::SLOTS_PER_WAVE; ++i)
+                    rows0[i] = rows1[i];
+                page0 = page1;
+            }
+            buf ^= 1;
+        }
+    }
+
+    // The partial accumulator's native C layout scatters one wave over 16
+    // head rows.  Reuse the now-dead KV LDS as a transpose buffer so global
+    // stores are contiguous.  The barrier keeps an early wave from clobbering
+    // the final tile while another wave is still in PV.
+    lds_barrier();
+
+    const size_t ml_base =
+        ((size_t)req * args.num_splits + split)
+        * args.rows_pad;
+    if(g == 0)
+    {
+#pragma unroll
+        for(int qs = 0; qs < T::Q_SUB; ++qs)
+        {
+            const int row =
+                h_base + h_wave + qs * T::Q_TILE + c;
+            if(row < args.valid_rows)
+            {
+                args.part_m[ml_base + row] = m_ref[qs];
+                args.part_l[ml_base + row] = l_row[qs];
+            }
+        }
+    }
+
+    auto s_ep = make_smem(
+        reinterpret_cast<float*>(smem)
+        + warp * T::Q_TILE * T::EP_PITCH);
+    const size_t acc_base = ml_base * T::D_V;
+#pragma unroll
+    for(int qs = 0; qs < T::Q_SUB; ++qs)
+    {
+#pragma unroll
+        for(int ot = 0; ot < T::O_TILES; ++ot)
+        {
+            const f32x4 x = v_o[qs][ot] * 0.0078125f;
+            s_ep.template store<4>(
+                __builtin_bit_cast(vector_t<float, 4>, x),
+                c * T::EP_PITCH + ot * 16 + g * 4);
+        }
+        s_waitcnt_lgkmcnt(0_I);
+
+#pragma unroll
+        for(int hh = 0; hh < T::Q_TILE; ++hh)
+        {
+            const int row =
+                h_base + h_wave + qs * T::Q_TILE + hh;
+            if(row < args.valid_rows)
+            {
+#pragma unroll
+                for(int half = 0; half < 2; ++half)
+                {
+                    const auto x = s_ep.template load<4>(
+                        hh * T::EP_PITCH + half * 256 + lane * 4);
+                    float* dst =
+                        args.part_acc + acc_base
+                        + (size_t)row * T::D_V
+                        + half * 256 + lane * 4;
+                    *reinterpret_cast<vector_t<float, 4>*>(dst) = x;
+                }
+            }
+        }
+        s_waitcnt_lgkmcnt(0_I);
+    }
+}
+
+__global__ __launch_bounds__(VLLM_K3_H40_REDUCE_THREADS, 1)
+void reduce_kernel(kargs args)
+{
+    using device::f32x4;
+    const int linear_row = (int)__builtin_amdgcn_workgroup_id_x();
+    const int req = linear_row / args.valid_rows;
+    const int row = linear_row - req * args.valid_rows;
+    const int tid = (int)__builtin_amdgcn_workitem_id_x();
+
+    __shared__ float weights[VLLM_K3_H40_REDUCE_THREADS];
+    __shared__ float scratch[VLLM_K3_H40_REDUCE_THREADS];
+
+    const size_t req_base =
+        (size_t)req * args.num_splits * args.rows_pad;
+    float l = 0.f;
+    float m = device::LOWEST;
+    if(tid < args.num_splits)
+    {
+        const size_t off =
+            req_base + (size_t)tid * args.rows_pad + row;
+        l = args.part_l[off];
+        if(l > 0.f)
+            m = args.part_m[off];
+    }
+    scratch[tid] = m;
+    __builtin_amdgcn_s_barrier();
+    for(int stride = VLLM_K3_H40_REDUCE_THREADS / 2;
+        stride > 0;
+        stride >>= 1)
+    {
+        if(tid < stride)
+            scratch[tid] = max(scratch[tid], scratch[tid + stride]);
+        __builtin_amdgcn_s_barrier();
+    }
+    const float global_m = scratch[0];
+
+    float w = 0.f;
+    if(tid < args.num_splits && l > 0.f)
+        w = __builtin_amdgcn_exp2f(m - global_m);
+    weights[tid] = w;
+    scratch[tid] = w * l;
+    __builtin_amdgcn_s_barrier();
+    for(int stride = VLLM_K3_H40_REDUCE_THREADS / 2;
+        stride > 0;
+        stride >>= 1)
+    {
+        if(tid < stride)
+            scratch[tid] += scratch[tid + stride];
+        __builtin_amdgcn_s_barrier();
+    }
+    const float denom = scratch[0];
+
+    auto* out = reinterpret_cast<__bf16*>(args.out_ptr);
+    const size_t req_acc =
+        (size_t)req * args.num_splits
+        * args.rows_pad * traits::D_V;
+    for(int col = tid * 4;
+        col < traits::D_V;
+        col += VLLM_K3_H40_REDUCE_THREADS * 4)
+    {
+        f32x4 acc{0.f, 0.f, 0.f, 0.f};
+        for(int s = 0; s < args.num_splits; ++s)
+        {
+            const size_t off =
+                req_acc
+                + ((size_t)s * args.rows_pad + row) * traits::D_V
+                + col;
+            const f32x4 x =
+                *reinterpret_cast<const f32x4*>(args.part_acc + off);
+            acc += x * weights[s];
+        }
+        const float scale =
+            denom > 0.f ? args.output_scale / denom : 0.f;
+        const f32x4 y = acc * scale;
+        __bf16* dst =
+            out + ((size_t)req * args.valid_rows + row) * traits::D_V + col;
+#pragma unroll
+        for(int i = 0; i < 4; ++i)
+            dst[i] = (__bf16)y[i];
+    }
+}
+
+#else
+
+__global__ void partial_kernel(kargs) {}
+__global__ void reduce_kernel(kargs) {}
+
+#endif
+
+} // namespace kimi_k3_h40_draft
+
+#ifndef __HIP_DEVICE_COMPILE__
+
+namespace {
+// One workgroup per CU for exactly one round.  This depends only on shapes,
+// never on seq_lens, so it stays valid under CUDA graph capture -- the draft
+// step is captured as a FULL graph and a value-dependent launch would freeze.
+constexpr int kNumComputeUnits = 256;
+}  // namespace
+
+void kimi_k3_h40_draft_mla_decode(
+    torch::stable::Tensor const& q, torch::stable::Tensor const& kv_cache,
+    torch::stable::Tensor const& block_table,
+    torch::stable::Tensor const& seq_lens,
+    torch::stable::Tensor& partial_max, torch::stable::Tensor& partial_sum,
+    torch::stable::Tensor& partial_acc, torch::stable::Tensor& out,
+    int64_t query_len, int64_t num_splits, double qk_scale_log2,
+    double output_scale) {
+  using namespace kimi_k3_h40_draft;
+  using T = traits;
+
+  STD_TORCH_CHECK(q.is_cuda() && q.scalar_type() == torch::headeronly::ScalarType::Float8_e4m3fn,
+                  "q must be fp8_e4m3 on device");
+  STD_TORCH_CHECK(
+      kv_cache.is_cuda() && kv_cache.scalar_type() == torch::headeronly::ScalarType::Float8_e4m3fn,
+      "kv_cache must be fp8_e4m3 on device");
+  STD_TORCH_CHECK(out.scalar_type() == torch::headeronly::ScalarType::BFloat16,
+                  "out must be bfloat16");
+  STD_TORCH_CHECK(block_table.scalar_type() == torch::headeronly::ScalarType::Int &&
+                      seq_lens.scalar_type() == torch::headeronly::ScalarType::Int,
+                  "block_table and seq_lens must be int32");
+  STD_TORCH_CHECK(q.dim() == 3 && kv_cache.dim() == 3 && block_table.dim() == 2,
+                  "expected q[S,H,D], kv_cache[blocks,page,D], bt[T,pages]");
+
+  int64_t const total_rows = q.size(0);
+  int64_t const num_heads = q.size(1);
+  STD_TORCH_CHECK(q.size(2) == T::D_QK && out.size(2) == T::D_V,
+                  "MLA head dim must be 576 (512 latent + 64 rope)");
+
+  int64_t const num_reqs = seq_lens.size(0);
+  STD_TORCH_CHECK(query_len >= 1 && total_rows == num_reqs * query_len,
+                  "q rows must be num_reqs * query_len");
+
+  int64_t const page_size = kv_cache.size(1);
+  STD_TORCH_CHECK(page_size % T::KV_TILE == 0,
+                  "page_size must be a multiple of ", T::KV_TILE,
+                  " so a KV tile never straddles a page");
+  STD_TORCH_CHECK(block_table.stride(1) == 1, "block_table rows must be dense");
+
+  int64_t const rows = num_heads * query_len;
+  int64_t const workgroups = num_reqs * num_splits;
+  STD_TORCH_CHECK(partial_acc.numel() >= workgroups * rows * T::D_V &&
+                      partial_max.numel() >= workgroups * rows &&
+                      partial_sum.numel() >= workgroups * rows,
+                  "workspace too small for ", workgroups, " workgroups");
+
+  kargs args{};
+  args.q_ptr = q.data_ptr();
+  args.kv_ptr = kv_cache.data_ptr();
+  args.kv_block_table = static_cast<int const*>(block_table.data_ptr());
+  args.kv_seq_lens = static_cast<int const*>(seq_lens.data_ptr());
+  args.bt_stride = static_cast<int>(block_table.stride(0));
+  args.page_size = static_cast<int>(page_size);
+  args.part_m = static_cast<float*>(partial_max.data_ptr());
+  args.part_l = static_cast<float*>(partial_sum.data_ptr());
+  args.part_acc = static_cast<float*>(partial_acc.data_ptr());
+  args.out_ptr = out.data_ptr();
+  args.T = static_cast<int>(num_reqs);
+  args.qlen = static_cast<int>(query_len);
+  args.nhead = static_cast<int>(num_heads);
+  args.valid_rows = static_cast<int>(rows);
+  args.rows_pad = args.valid_rows;
+  // Page-local addressing keeps every buffer offset under 2^32; a global row
+  // index would not (a 6.8 GB cache overflows it and aliases 37% of its rows).
+  args.kv_rows = static_cast<int>(page_size);
+  args.num_splits = static_cast<int>(num_splits);
+  args.qk_scale_log2 = static_cast<float>(qk_scale_log2);
+  args.output_scale = static_cast<float>(output_scale);
+
+  torch::stable::accelerator::DeviceGuard const device_guard(
+      static_cast<torch::stable::accelerator::DeviceIndex>(q.get_device()));
+  hipStream_t const stream = vllm_current_hip_stream(q.get_device());
+
+  dim3 const grid(static_cast<unsigned>(num_reqs),
+                  static_cast<unsigned>(ceil_div(args.valid_rows,
+                                                 T::HEADS_PER_BLOCK)),
+                  static_cast<unsigned>(num_splits));
+  partial_kernel<<<grid, dim3(T::BLOCK_SIZE), 0, stream>>>(args);
+  reduce_kernel<<<dim3(static_cast<unsigned>(num_reqs * rows)),
+                  dim3(VLLM_K3_H40_REDUCE_THREADS), 0, stream>>>(args);
+}
+
+#endif  // __HIP_DEVICE_COMPILE__

--- a/csrc/libtorch_stable/kimi_k3/opus/hip_minimal.hpp
+++ b/csrc/libtorch_stable/kimi_k3/opus/hip_minimal.hpp
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+#ifndef HIP_MINIMAL_HPP
+#define HIP_MINIMAL_HPP
+
+/**
+ * @file opus/hip_minimal.hpp
+ * @brief Minimal HIP replacement for <hip/hip_runtime.h>.
+ *
+ * Replaces <hip/hip_runtime.h> (~100K+ preprocessed lines) on BOTH passes
+ * for opus-based kernels:
+ *   * host pass: dim3, hipError_t, hipMalloc, hipLaunchKernelGGL, etc.
+ *   * device pass: __launch_bounds__ / __global__ / __device__ /
+ *     __forceinline__ keyword fallbacks.
+ *
+ * For device intrinsics (threadIdx / blockIdx / __syncthreads etc.),
+ * include <opus/opus.hpp> and use opus::thread_id_x() / opus::block_id_x()
+ * / opus::sync_threads() etc.
+ *
+ * Usage:
+ *   #include <opus/hip_minimal.hpp>   // both passes — drop-in replacement
+ *
+ * Compile: hipcc kernel.cu -I<aiter_root>/csrc/include -D__HIPCC_RTC__ ...
+ */
+
+// ========== Attribute keyword fallbacks (both passes) ==========
+#ifndef __launch_bounds__
+#define __launch_bounds_impl0__(requiredMaxThreadsPerBlock) \
+    __attribute__((amdgpu_flat_work_group_size(1, requiredMaxThreadsPerBlock)))
+#define __launch_bounds_impl1__(requiredMaxThreadsPerBlock, minBlocksPerMultiprocessor) \
+    __attribute__((amdgpu_flat_work_group_size(1, requiredMaxThreadsPerBlock), \
+                   amdgpu_waves_per_eu(minBlocksPerMultiprocessor)))
+#define __launch_bounds_select__(_1, _2, impl_, ...) impl_
+#define __launch_bounds__(...) \
+    __launch_bounds_select__(__VA_ARGS__, __launch_bounds_impl1__, __launch_bounds_impl0__, )(__VA_ARGS__)
+#endif
+#ifndef __shared__
+#define __shared__      __attribute__((shared))
+#endif
+#ifndef __device__
+#define __device__      __attribute__((device))
+#endif
+#ifndef __global__
+#define __global__      __attribute__((global))
+#endif
+#ifndef __host__
+#define __host__        __attribute__((host))
+#endif
+#ifndef __forceinline__
+#define __forceinline__ inline __attribute__((always_inline))
+#endif
+#ifndef __noinline__
+#define __noinline__    __attribute__((noinline))
+#endif
+
+// ========== Host-side declarations (guarded to coexist with <hip/hip_runtime.h>) ==========
+#if !defined(HIP_INCLUDE_HIP_HIP_RUNTIME_API_H)
+
+#include <cstddef>   // size_t
+
+typedef int hipError_t;
+typedef void* hipStream_t;
+#define hipSuccess 0
+
+struct dim3 {
+    unsigned int x, y, z;
+    constexpr dim3(unsigned int _x = 1, unsigned int _y = 1, unsigned int _z = 1)
+        : x(_x), y(_y), z(_z) {}
+};
+
+// Error handling
+extern "C" hipError_t hipGetLastError();
+extern "C" hipError_t hipDeviceSynchronize();
+extern "C" const char* hipGetErrorString(hipError_t error);
+
+// Memory management
+extern "C" hipError_t hipMalloc(void** ptr, size_t size);
+extern "C" hipError_t hipFree(void* ptr);
+extern "C" hipError_t hipMemset(void* dst, int value, size_t sizeBytes);
+enum hipMemcpyKind { hipMemcpyHostToHost = 0, hipMemcpyHostToDevice = 1, hipMemcpyDeviceToHost = 2, hipMemcpyDeviceToDevice = 3, hipMemcpyDefault = 4 };
+extern "C" hipError_t hipMemcpy(void* dst, const void* src, size_t sizeBytes, hipMemcpyKind kind);
+template <typename T> inline hipError_t hipMalloc(T** ptr, size_t size) { return hipMalloc(reinterpret_cast<void**>(ptr), size); }
+
+// Events (timing)
+typedef void* hipEvent_t;
+extern "C" hipError_t hipEventCreate(hipEvent_t* event);
+extern "C" hipError_t hipEventDestroy(hipEvent_t event);
+extern "C" hipError_t hipEventRecord(hipEvent_t event, hipStream_t stream = nullptr);
+extern "C" hipError_t hipEventSynchronize(hipEvent_t event);
+extern "C" hipError_t hipEventElapsedTime(float* ms, hipEvent_t start, hipEvent_t stop);
+
+// Kernel launch (<<<>>> syntax)
+extern "C" hipError_t __hipPushCallConfiguration(dim3 gridDim, dim3 blockDim, size_t sharedMem = 0, hipStream_t stream = nullptr);
+extern "C" hipError_t __hipPopCallConfiguration(dim3* gridDim, dim3* blockDim, size_t* sharedMem, hipStream_t* stream);
+extern "C" hipError_t hipLaunchKernel(const void* function_address, dim3 numBlocks, dim3 dimBlocks, void** args, size_t sharedMemBytes, hipStream_t stream);
+#ifndef hipLaunchKernelGGL
+#define hipLaunchKernelGGL(kernel, numBlocks, dimBlocks, sharedMemBytes, stream, ...) \
+    kernel<<<numBlocks, dimBlocks, sharedMemBytes, stream>>>(__VA_ARGS__)
+#endif
+
+#endif // !HIP_INCLUDE_HIP_HIP_RUNTIME_API_H
+
+#endif // HIP_MINIMAL_HPP

--- a/csrc/libtorch_stable/kimi_k3/opus/opus.hpp
+++ b/csrc/libtorch_stable/kimi_k3/opus/opus.hpp
@@ -1,0 +1,3231 @@
+/***************************************************************************************************
+ * OPUS, AI (O)(P)erator Micro(U) (S)TD
+ *
+ * Crafting the micro standard templates for AI Operators on ROCm
+ *
+ * MIT License
+ * Copyright (C) 2025-2026 carlus.huang@amd.com
+ *
+ **************************************************************************************************/
+#pragma once
+
+// clang-format off
+#include <type_traits>
+#include <utility>
+
+#ifndef OPUS_ENABLE_RUNTIME_QUERY
+#define OPUS_ENABLE_RUNTIME_QUERY 0
+#endif
+
+#if OPUS_ENABLE_RUNTIME_QUERY && defined(__HIPCC__) && !defined(__HIP_DEVICE_COMPILE__)
+#include <hip/hip_runtime_api.h>
+#endif
+
+#ifdef __HIPCC__
+#define OPUS_H inline __host__
+#define OPUS_D inline __device__
+#define OPUS_H_D inline __host__ __device__
+#define OPUS_D_EXTERN __device__
+#define OPUS_H_D_EXTERN __host__ __device__
+#else
+#define OPUS_H inline
+#define OPUS_D
+#define OPUS_H_D inline
+#define OPUS_D_EXTERN
+#define OPUS_H_D_EXTERN
+#endif
+
+#ifndef OPUS_FP32_to_BF16_DEFAULT
+#define OPUS_FP32_to_BF16_DEFAULT 2 // truncate, valid on gfx94* and before
+#endif
+
+#ifndef OPUS_TILE_CONTAINER
+#define OPUS_TILE_CONTAINER 0 // 0:vector, 1:array of vector, 2:flattened array
+#endif
+
+namespace opus {
+/////////////////////////////////////////////////////////////////////////////////////////////////////////
+// type traits
+using std::remove_reference; using std::remove_reference_t; using std::remove_cv; using std::remove_cv_t; using std::is_same; using std::is_same_v;
+template<typename T> struct remove_cvref { using type = remove_cv_t<remove_reference_t<T>>; };
+template<typename T> using remove_cvref_t = remove_cv_t<remove_reference_t<T>>;
+/////////////////////////////////////////////////////////////////////////////////////////////////////////
+// constant
+using index_t = int;
+using long_index_t = long long;
+
+template<index_t I> struct number : public std::integral_constant<index_t, I> {};
+template<bool B>    struct bool_constant : public std::bool_constant<B> {};
+typedef bool_constant<true>  true_type;
+typedef bool_constant<false> false_type;
+
+template<typename>           struct is_constant : public false_type {};
+template<typename T, auto I> struct is_constant<std::integral_constant<T, I>> : true_type {};
+template<auto I>             struct is_constant<number<I>> : true_type {};
+template<auto I>             struct is_constant<bool_constant<I>> : true_type {};
+template <class T> static constexpr bool is_constant_v = is_constant<remove_cvref_t<T>>::value;    // prefer use this
+
+// using opus::operator""_I; // => add this in your code to utilize the literal cast, e.g. 2_I, 3_I
+template <char... Ds>
+OPUS_H_D constexpr decltype(auto) operator""_I() {
+    constexpr auto to_number_ = []() { index_t v = 0; ((v = v * 10 + (Ds - '0')), ...); return v; }; return number<to_number_()>{};
+}
+
+#define OPUS_LEFT_UNARY_OP(OP) template <auto x>         OPUS_H_D constexpr auto operator OP(number<x>)            { return number<(OP x)>{};   }
+#define OPUS_BINARY_OP(OP)     template <auto x, auto y> OPUS_H_D constexpr auto operator OP(number<x>, number<y>) { return number<(x OP y)>{}; }
+
+OPUS_LEFT_UNARY_OP(+) OPUS_LEFT_UNARY_OP(-) OPUS_LEFT_UNARY_OP(~) OPUS_LEFT_UNARY_OP(!)
+OPUS_BINARY_OP(+)   OPUS_BINARY_OP(-)   OPUS_BINARY_OP(*)   OPUS_BINARY_OP(/)
+OPUS_BINARY_OP(%)   OPUS_BINARY_OP(&)   OPUS_BINARY_OP(|)   OPUS_BINARY_OP(^)
+OPUS_BINARY_OP(<<)  OPUS_BINARY_OP(>>)  OPUS_BINARY_OP(&&)  OPUS_BINARY_OP(||)
+OPUS_BINARY_OP(==)  OPUS_BINARY_OP(!=)  OPUS_BINARY_OP(>)   OPUS_BINARY_OP(<)
+OPUS_BINARY_OP(>=)  OPUS_BINARY_OP(<=)
+
+#undef OPUS_LEFT_UNARY_OP
+#undef OPUS_BINARY_OP
+
+template<class T, class... R> constexpr bool is_any_of() noexcept { return (std::is_same_v<T, R> || ...); }
+template<class T, class... R> static constexpr bool is_any_of_v = is_any_of<T, R...>();
+/////////////////////////////////////////////////////////////////////////////////////////////////////////
+// underscore, useful struture to mock
+struct underscore { /*who am I*/ };
+static constexpr underscore _;
+template <typename T> struct is_underscore : false_type {};
+template <> struct is_underscore<underscore> : true_type {};
+template <typename T> static constexpr bool is_underscore_v = is_underscore<T>::value;
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////
+// constexpr functional math
+struct plus       { template<typename X, typename Y=X> OPUS_H_D constexpr decltype(auto) operator()(X a, Y b) const { return a + b; } };
+struct minus      { template<typename X, typename Y=X> OPUS_H_D constexpr decltype(auto) operator()(X a, Y b) const { return a - b; } };
+struct multiplies { template<typename X, typename Y=X> OPUS_H_D constexpr decltype(auto) operator()(X a, Y b) const { return a * b; } };
+struct divides    { template<typename X, typename Y=X> OPUS_H_D constexpr decltype(auto) operator()(X a, Y b) const { return a / b; } };
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////
+// seq
+template <index_t... Is>
+class seq {
+public:
+    using value_type = index_t;
+    OPUS_H_D static constexpr index_t size() { return sizeof...(Is);}
+    OPUS_H_D constexpr value_type operator[](index_t i) const { return data[i]; }
+    OPUS_H_D static constexpr value_type at(index_t i) { return data[i]; }
+    template <index_t I> OPUS_H_D static constexpr value_type at()          { return data[I]; }
+    template <index_t I> OPUS_H_D static constexpr value_type at(number<I>) { return data[I]; }
+private:
+    static constexpr value_type data[sizeof...(Is) + 1] = {Is..., value_type{}};
+};
+
+template <index_t I, index_t... Is> OPUS_H_D constexpr auto seq_pop_front(seq<I, Is...>) { return seq<Is...>{}; }
+
+template <index_t I, index_t... Is> OPUS_H_D constexpr decltype(auto) get(seq<Is...>const& ) { static_assert(I < sizeof...(Is)); return seq<Is...>::at(number<I>{}); }
+template <index_t I, index_t... Is> OPUS_H_D constexpr decltype(auto) get(seq<Is...>& )      { static_assert(I < sizeof...(Is)); return seq<Is...>::at(number<I>{}); }
+template <index_t I, index_t... Is> OPUS_H_D constexpr decltype(auto) get(seq<Is...>&& )     { static_assert(I < sizeof...(Is)); return seq<Is...>::at(number<I>{}); }
+
+namespace impl {
+template <typename T, T... Is> struct __integer_sequence;
+template <index_t... Is>       struct __integer_sequence<index_t, Is...> { using seq_type = seq<Is...>; };
+template<index_t, index_t, typename>                 struct __steped_integer_seq;
+template<index_t Start, index_t Step, index_t... Is> struct __steped_integer_seq<Start, Step, seq<Is...>> { using seq_type = seq<(Start + Is * Step) ... >; };
+
+template<typename>                   struct __make_index_seq;
+template <index_t N>                 struct __make_index_seq<seq<N>>          { using seq_type = typename __make_integer_seq<__integer_sequence, index_t, N>::seq_type; };
+template<index_t Start, index_t End> struct __make_index_seq<seq<Start, End>> { using seq_type = typename __steped_integer_seq<Start, 1, typename __make_index_seq< seq<(End-Start)/1> >::seq_type>::seq_type; };
+template<index_t Start, index_t End, index_t Step>  struct __make_index_seq<seq<Start, End, Step>> {
+    using seq_type = typename __steped_integer_seq<Start, Step, typename __make_index_seq< seq<(End-Start)/Step> >::seq_type>::seq_type;
+};
+} // namespace impl
+// make_index_seq<5> -> seq<0,1,2,3,4> | make_index_seq<4, 9> -> seq<4,5,6,7,8> | make_index_seq<4, 8, 2> -> seq<4, 6>
+template<index_t...Is> using make_index_seq = typename impl::__make_index_seq<seq<Is...>>::seq_type;
+
+namespace impl {
+template<index_t Value, index_t N>
+struct __make_repeated_seq {
+    template<index_t... I> static constexpr auto __make(seq<I...>) { return seq<(void(I), Value)...>{}; }
+    using seq_type = decltype(__make(make_index_seq<N>{}));
+};
+} // namespace impl
+template<index_t V, index_t N> using make_repeated_seq = typename impl::__make_repeated_seq<V, N>::seq_type;
+
+template<index_t...Xs, index_t...Ys> OPUS_H_D constexpr auto concat_seq(seq<Xs...>, seq<Ys...>) { return seq<Xs..., Ys...>{}; }
+
+namespace impl {
+template<typename, typename>                                 struct reduce_seq_impl;
+template <typename R, index_t I0, index_t I1, index_t... Is> struct reduce_seq_impl<R, seq<I0, I1, Is...>> { using type = typename reduce_seq_impl<R, seq<R{}(I0, I1), Is...>>::type; };
+template <typename R, index_t I>                             struct reduce_seq_impl<R, seq<I>> { using type = seq<I>; };
+template <typename R>                                        struct reduce_seq_impl<R, seq<>>  { using type = seq<>;  };
+}
+template<typename R, index_t...Xs> OPUS_H_D constexpr auto reduce_seq(seq<Xs...>) { return typename impl::reduce_seq_impl<R, seq<Xs...>>::type{}; }
+template<index_t...Xs> OPUS_H_D constexpr auto reduce_seq_sum(seq<Xs...>) { if constexpr (sizeof...(Xs) == 0) return seq<>{}; else return seq<(Xs + ...)>{}; }
+template<index_t...Xs> OPUS_H_D constexpr auto reduce_seq_mul(seq<Xs...>) { if constexpr (sizeof...(Xs) == 0) return seq<>{}; else return seq<(Xs * ...)>{}; }
+
+template<typename T> struct is_seq : false_type {};
+template<index_t... Is> struct is_seq<seq<Is...>> : true_type {};
+template<typename T> constexpr bool is_seq_v = is_seq<remove_cvref_t<T>>::value;
+
+template<typename T> OPUS_H_D constexpr std::enable_if_t<is_seq_v<T>, index_t> size(T&&) { return remove_cvref_t<T>::size(); /* tuple size */}
+template<typename T> OPUS_H_D constexpr std::enable_if_t<is_seq_v<T>, index_t> size()    { return remove_cvref_t<T>::size(); /* tuple size */}
+
+template <index_t I, typename T, std::enable_if_t<is_seq_v<T>, bool> = true> OPUS_H_D constexpr decltype(auto) get(T const& t) { static_assert(I < T::size()); return t[number<I>{}]; }
+template <index_t I, typename T, std::enable_if_t<is_seq_v<T>, bool> = true> OPUS_H_D constexpr decltype(auto) get(T&  t)      { static_assert(I < T::size()); return t[number<I>{}]; }
+template <index_t I, typename T, std::enable_if_t<is_seq_v<T>, bool> = true> OPUS_H_D constexpr decltype(auto) get(T&& t)      { static_assert(I < T::size()); return t[number<I>{}]; }
+/////////////////////////////////////////////////////////////////////////////////////////////////////////
+// functional
+namespace impl {
+template <class T>       struct static_for_impl;
+template <index_t... Is> struct static_for_impl<seq<Is...>> { template <class F> OPUS_H_D constexpr void operator()(F&& f) const { (f(number<Is>{}), ...); } };
+}   // namespace impl
+template<index_t N, typename F> OPUS_H_D constexpr void static_for(F f) { impl::static_for_impl<make_index_seq<N>>{}(f); }
+
+template<typename F, typename... R, std::enable_if_t<(is_constant_v<R> && ...), bool> = true>
+OPUS_H_D constexpr void static_for(F f, R...) { impl::static_for_impl<make_index_seq<R::value...>>{}(f); }
+
+namespace impl {
+// Flat static_ford: single-level static_for, non-recursive compile-time index decomposition via fold expressions
+template <index_t D, index_t... Is, index_t... Ns> constexpr index_t ford_stride(seq<Is...>, seq<Ns...>) { return ((Is > D ? Ns : index_t(1)) * ... * index_t(1)); }
+template <index_t D, index_t... Is, index_t... Ns> constexpr index_t ford_dim(seq<Is...>, seq<Ns...>) { return ((Is == D ? Ns : index_t(1)) * ...); }
+template <index_t I, index_t D, index_t... Ns> constexpr index_t ford_at() { return (I / ford_stride<D>(make_index_seq<sizeof...(Ns)>{}, seq<Ns...>{})) % ford_dim<D>(make_index_seq<sizeof...(Ns)>{}, seq<Ns...>{}); }
+template <typename Seq> struct static_ford_impl;
+template <index_t... Ns> struct static_ford_impl<seq<Ns...>> {
+    template <typename F, index_t I, index_t... Ds> OPUS_H_D static constexpr void call_one(F& f, number<I>, seq<Ds...>) { f(number<ford_at<I, Ds, Ns...>()>{}...); }
+    template <typename F> OPUS_H_D constexpr void operator()(F f) const { static_for<(Ns * ... * 1)>([&](auto I) { call_one(f, I, make_index_seq<sizeof...(Ns)>{}); }); }
+};
+template <> struct static_ford_impl<seq<>> { template <typename F> OPUS_H_D constexpr void operator()(F f) const { f(); } };
+}
+
+template<index_t... N, typename F> OPUS_H_D constexpr void static_ford(F f) { impl::static_ford_impl<seq<N...>>{}(f); }
+template<index_t... N, typename F> OPUS_H_D constexpr void static_ford(seq<N...>, F f) { impl::static_ford_impl<seq<N...>>{}(f); }
+template <class... T> struct tuple;
+template<index_t... N, typename F> OPUS_H_D constexpr void static_ford(tuple<number<N>...>, F f) { impl::static_ford_impl<seq<N...>>{}(f); }
+
+template<typename T, typename R = void> struct get_value_type { using type = remove_cvref_t<T>; };
+template<typename T, typename R = void> using get_value_t = typename get_value_type<T, R>::type;
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////
+// array, enhanced C like array style
+template <typename T, index_t N>
+struct array {
+    using value_type = remove_cvref_t<T>;
+    using type = array<value_type, N>;
+#if 0   // don't define following, just let me be trivially copyable class
+    OPUS_H_D constexpr array() = default;
+    OPUS_H_D constexpr array(const type& o) { static_for<N>([&](auto i){ content[i.value] = o[i.value]; }); }
+    OPUS_H_D constexpr type& operator=(const type o) { static_for<N>([&](auto i){ content[i.value] = o[i.value]; }); return *this; }
+    template<typename...Z, std::enable_if_t<(std::is_same_v<remove_cvref_t<Z>, value_type> && ...), bool> = true>
+    OPUS_H_D constexpr array(Z&&... zs) : content{zs...}  { /* used for make_array */ }
+#endif
+    OPUS_H_D constexpr value_type& operator[](index_t pos) { return content[pos]; }
+    OPUS_H_D constexpr const value_type& operator[](index_t pos) const { return content[pos]; }
+    template<index_t I> OPUS_H_D constexpr value_type& operator[](number<I>) { return content[I]; }
+    template<index_t I> OPUS_H_D constexpr const value_type& operator[](number<I>) const { return content[I]; }
+    OPUS_H_D constexpr void fill(const T& value) { static_for<N>([&](auto i){ content[i.value] = value; }); }
+    OPUS_H_D constexpr void clear() { fill(static_cast<T>(0)); }
+    OPUS_H_D static constexpr bool empty() { return size() == 0; }
+    OPUS_H_D static constexpr index_t size() { return N; }
+
+    // we need this "content" member to have a default value, so that the implicitly defined constructor could be constexpr
+    // see: https://en.cppreference.com/w/cpp/language/constexpr.html#constexpr_constructor
+    value_type content[N] {};
+};
+
+template <typename T, index_t N>
+OPUS_H_D constexpr bool operator==(const array<T,N>& x, const array<T,N>& y) { for (index_t i = 0; i < N; ++i) { if (x[i] != y[i]) { return false; } } return true; }
+
+template <typename T, index_t N> OPUS_H_D constexpr void clear(array<T,N>& a) { a.clear(); }
+template <typename T, index_t N> OPUS_H_D constexpr void fill(array<T,N>& a, T const& value) { a.fill(value); }
+
+template<typename T> struct is_array : false_type {};
+template<typename T, index_t N> struct is_array<array<T, N>> : true_type {};
+template<typename T> constexpr bool is_array_v = is_array<remove_cvref_t<T>>::value;
+template<typename T> struct get_value_type<T, std::enable_if_t<is_array_v<T>>> { using type = typename T::value_type; };
+
+namespace impl {
+template<typename> struct is_ref_wrapper : std::false_type{};
+template<typename T> struct is_ref_wrapper<std::reference_wrapper<T>> : std::true_type{};
+template<typename T> using not_ref_wrapper = std::negation<is_ref_wrapper<std::decay_t<T>>>;
+
+template<typename D, typename...> struct array_return_type_helper { using type = D; };
+template<typename... Types>
+struct array_return_type_helper<void, Types...> : std::common_type<Types...> {
+    static_assert(std::conjunction_v<not_ref_wrapper<Types>...>, "Types cannot contain reference_wrappers when D is void");
+};
+template<typename D, typename... Types> using array_return_type = opus::array<typename array_return_type_helper<D, Types...>::type, sizeof...(Types)>;
+}
+template<typename D = void, typename... Types> OPUS_H_D constexpr impl::array_return_type<D, Types...> make_array(Types&&... t) { return {std::forward<Types>(t)...}; }
+
+template <index_t I, typename T, std::enable_if_t<is_array_v<T>, bool> = true> OPUS_H_D constexpr decltype(auto) get(T const& t) { static_assert(I < T::size()); return t[number<I>{}]; }
+template <index_t I, typename T, std::enable_if_t<is_array_v<T>, bool> = true> OPUS_H_D constexpr decltype(auto) get(T&  t)      { static_assert(I < T::size()); return t[number<I>{}]; }
+template <index_t I, typename T, std::enable_if_t<is_array_v<T>, bool> = true> OPUS_H_D constexpr decltype(auto) get(T&& t)      { static_assert(I < T::size()); return t[number<I>{}]; }
+
+namespace impl {
+template <class T0, class T1, index_t... I0, index_t... I1>
+OPUS_H_D constexpr auto concat_array(T0 const& t0, T1 const& t1, seq<I0...>, seq<I1...>) { return opus::make_array(get<I0>(t0)..., get<I1>(t1)...); }
+template <class T0, class T1, class T2, index_t... I0, index_t... I1, index_t...I2>
+OPUS_H_D constexpr auto concat_array(T0 const& t0, T1 const& t1, T2 const& t2, seq<I0...>, seq<I1...>, seq<I2...>) { return opus::make_array(get<I0>(t0)..., get<I1>(t1)..., get<I2>(t2)...); }
+template <class T0, class T1, class T2, class T3, index_t... I0, index_t... I1, index_t...I2, index_t...I3>
+OPUS_H_D constexpr auto concat_array(T0 const& t0, T1 const& t1, T2 const& t2, T3 const& t3, seq<I0...>, seq<I1...>, seq<I2...>, seq<I3...>) { return opus::make_array(get<I0>(t0)..., get<I1>(t1)..., get<I2>(t2)..., get<I3>(t3)...); }
+}
+template <class T0> OPUS_H_D  constexpr auto concat_array(T0 const& t0) { return t0; }
+template <class T0, class T1>
+OPUS_H_D  constexpr auto concat_array(T0 const& t0, T1 const& t1) { return impl::concat_array(t0, t1, make_index_seq<T0::size()>{}, make_index_seq<T1::size()>{}); }
+template <class T0, class T1, class T2>
+OPUS_H_D  constexpr auto concat_array(T0 const& t0, T1 const& t1, T2 const& t2) { return impl::concat_array(t0, t1, t2, make_index_seq<T0::size()>{}, make_index_seq<T1::size()>{}, make_index_seq<T2::size()>{}); }
+template <class T0, class T1, class T2, class T3>
+OPUS_H_D  constexpr auto concat_array(T0 const& t0, T1 const& t1, T2 const& t2, T3 const& t3) {
+                                            return impl::concat_array(t0, t1, t2, t3, make_index_seq<T0::size()>{}, make_index_seq<T1::size()>{}, make_index_seq<T2::size()>{}, make_index_seq<T3::size()>{}); }
+template <class T0, class T1, class T2, class T3, class T4, class... Ts>
+OPUS_H_D  constexpr auto concat_array(T0 const& t0, T1 const& t1, T2 const& t2, T3 const& t3, T4 const& t4, Ts const&... ts) { return concat_array(concat_array(t0, t1, t2, t3), concat_array(t4, ts...)); }
+
+template<typename T> OPUS_H_D constexpr std::enable_if_t<is_array_v<T>, index_t> size(T&&) { return remove_cvref_t<T>::size(); /* tuple size */}
+template<typename T> OPUS_H_D constexpr std::enable_if_t<is_array_v<T>, index_t> size()    { return remove_cvref_t<T>::size(); /* tuple size */}
+/////////////////////////////////////////////////////////////////////////////////////////////////////////
+// tuple
+namespace impl {
+template <index_t idx, typename T, bool is_empty = (std::is_empty_v<T> || std::is_void_v<T>)> struct tuple_object {}; // the place where content is stored
+
+template <index_t idx, typename T>
+struct tuple_object<idx, T, true> {
+    OPUS_H_D constexpr tuple_object() {}
+    template <typename U, typename std::enable_if<!std::is_same<remove_cvref_t<U>, tuple_object>::value, bool>::type = false>
+    OPUS_H_D constexpr tuple_object(U&&) {}
+};
+template <index_t idx, typename T>
+struct tuple_object<idx, T, false> {
+    OPUS_H_D constexpr tuple_object() : element{} {}
+    template <typename U, typename std::enable_if<!std::is_same<remove_cvref_t<U>, tuple_object>::value, bool>::type = false>
+    OPUS_H_D constexpr tuple_object(U&& e) : element(std::forward<U>(e)) {}
+    T element;
+};
+
+// NOTE: we return a instance(not a reference) if content is empty
+template <index_t I, class T> OPUS_H_D constexpr T        getv(const tuple_object<I, T, true>&)    { return {}; }
+template <index_t I, class T> OPUS_H_D constexpr const T& getv(const tuple_object<I, T, false>& x) { return x.element; }
+template <index_t I, class T> OPUS_H_D constexpr T&       getv(tuple_object<I, T, false>& x)       { return x.element; }
+template <index_t I, class T> OPUS_H_D constexpr T&&      getv(tuple_object<I, T, false>&& x)      { return static_cast<T&&>(x.element); }
+
+template <typename index_seq, typename... T> struct tuple_base;
+
+template <index_t... I, typename... T>
+struct tuple_base<seq<I...>, T...> : tuple_object<I, T>... {
+    OPUS_H_D constexpr tuple_base() = default;
+
+    template <class U, typename std::enable_if<sizeof...(I) == 1 && sizeof...(T) == 1 && !std::is_same<remove_cvref_t<U>, tuple_base>::value, bool>::type = false>
+    OPUS_H_D constexpr tuple_base(U&& u) : tuple_object<I, T>(std::forward<U>(u))... {}
+
+    template <typename... U, typename std::enable_if<sizeof...(U) >= 2, bool>::type = false>
+    OPUS_H_D constexpr tuple_base(U&&... u) : tuple_object<I, T>(std::forward<U>(u))... { static_assert(sizeof...(I) == sizeof...(T) && sizeof...(I) == sizeof...(U), "wrong!"); }
+};
+} // namespace impl
+template <class... T>
+struct tuple : impl::tuple_base<make_index_seq<sizeof...(T)>, T...> {
+    OPUS_H_D static constexpr index_t size() { return sizeof...(T); }
+    using base = impl::tuple_base<make_index_seq<sizeof...(T)>, T...>;
+    OPUS_H_D constexpr tuple() = default;
+
+    template <typename U, typename std::enable_if<sizeof...(T) == 1 && !std::is_same<remove_cvref_t<U>, tuple>::value, bool>::type = false>
+    OPUS_H_D constexpr tuple(U&& u) : base(std::forward<U>(u)) {}
+
+    template <typename... U, typename std::enable_if<sizeof...(U) == sizeof...(T) && sizeof...(U) >= 2, bool>::type = false>
+    OPUS_H_D constexpr tuple(U&&... u) : base(std::forward<U>(u)...) {}
+};
+template<typename... T> __host__ __device__ tuple(T&&...) -> tuple<remove_cvref_t<T>...>;
+
+namespace impl {
+template<typename T, typename S> struct tuple_array_helper;
+template<typename T, index_t... Is> struct tuple_array_helper<T, seq<Is...>> { using type = tuple<decltype((Is, remove_cvref_t<T>{}))...>; };
+}
+template<typename T, index_t N> using tuple_array = typename impl::tuple_array_helper<T, make_index_seq<N>>::type;  // alias for tuple<T, T....>, Nx Ts
+
+// get the I-th type within the tuple, O(1) via compiler intrinsic
+template<index_t I, class T>     struct tuple_element;
+template<index_t I, class... Ts> struct tuple_element<I, opus::tuple<Ts...>> { using type = __type_pack_element<I, Ts...>; };
+template<index_t I, class T> using tuple_element_t = typename tuple_element<I, T>::type;
+
+template <index_t I, class... T> OPUS_H_D constexpr decltype(auto) get(tuple<T...> const& t) { static_assert(I < sizeof...(T)); return impl::getv<I>(t); }
+template <index_t I, class... T> OPUS_H_D constexpr decltype(auto) get(tuple<T...>& t)       { static_assert(I < sizeof...(T)); return impl::getv<I>(t); }
+template <index_t I, class... T> OPUS_H_D constexpr decltype(auto) get(tuple<T...>&& t)      { static_assert(I < sizeof...(T)); return impl::getv<I>(std::move(t)); }
+
+template <index_t I0, index_t I1, index_t... Is, class T>  /*recursive get*/
+OPUS_H_D constexpr decltype(auto) get(T&& t) { return get<I1, Is...>(get<I0>(std::move(t))); }
+
+template <typename... T> OPUS_H_D constexpr auto make_tuple(T&&... xs) { return tuple<remove_cvref_t<T>...>(std::forward<T>(xs)...); }
+
+template<typename F, typename... R, std::enable_if_t<(std::is_integral_v<R> && ...), bool> = true>  // const integer based static_for loop
+OPUS_H_D constexpr void static_for(F f, R... range) {
+    if      constexpr (sizeof...(range) == 1) { auto end = get<0>(make_tuple(range...));        for(index_t i = 0; i < end; i++) { f(i); } }
+    else if constexpr (sizeof...(range) == 2) { auto [start, end] = make_tuple(range...);       for(index_t i = start; i < end; i++) { f(i); } }
+    else if constexpr (sizeof...(range) == 3) { auto [start, end, step] = make_tuple(range...); for(index_t i = start; i < end; i += step) { f(i); } }
+}
+
+namespace impl {
+template <typename T, index_t... Is> OPUS_H_D constexpr auto make_repeated_tuple(T&& x, seq<Is...>) { return opus::make_tuple((void(Is), std::forward<T>(x))...); }
+} // namespace impl
+template <index_t N, typename T> OPUS_H_D constexpr auto make_repeated_tuple(T&& x) { return impl::make_repeated_tuple(std::forward<T>(x), make_index_seq<N>{}); }
+template <typename T, index_t N> OPUS_H_D constexpr auto make_repeated_tuple(T&& x, number<N>) { return impl::make_repeated_tuple(std::forward<T>(x), make_index_seq<N>{}); }
+
+namespace impl {
+template <class T0, class T1, index_t... I0, index_t... I1>
+OPUS_H_D constexpr auto concat_tuple(T0 const& t0, T1 const& t1, seq<I0...>, seq<I1...>) { return opus::make_tuple(get<I0>(t0)..., get<I1>(t1)...); }
+template <class T0, class T1, class T2, index_t... I0, index_t... I1, index_t...I2>
+OPUS_H_D constexpr auto concat_tuple(T0 const& t0, T1 const& t1, T2 const& t2, seq<I0...>, seq<I1...>, seq<I2...>) { return opus::make_tuple(get<I0>(t0)..., get<I1>(t1)..., get<I2>(t2)...); }
+template <class T0, class T1, class T2, class T3, index_t... I0, index_t... I1, index_t...I2, index_t...I3>
+OPUS_H_D constexpr auto concat_tuple(T0 const& t0, T1 const& t1, T2 const& t2, T3 const& t3, seq<I0...>, seq<I1...>, seq<I2...>, seq<I3...>) { return opus::make_tuple(get<I0>(t0)..., get<I1>(t1)..., get<I2>(t2)..., get<I3>(t3)...); }
+}
+template <class T0> OPUS_H_D  constexpr auto concat_tuple(T0 const& t0) { return t0; }
+template <class T0, class T1>
+OPUS_H_D  constexpr auto concat_tuple(T0 const& t0, T1 const& t1) { return impl::concat_tuple(t0, t1, make_index_seq<T0::size()>{}, make_index_seq<T1::size()>{}); }
+template <class T0, class T1, class T2>
+OPUS_H_D  constexpr auto concat_tuple(T0 const& t0, T1 const& t1, T2 const& t2) { return impl::concat_tuple(t0, t1, t2, make_index_seq<T0::size()>{}, make_index_seq<T1::size()>{}, make_index_seq<T2::size()>{}); }
+template <class T0, class T1, class T2, class T3>
+OPUS_H_D  constexpr auto concat_tuple(T0 const& t0, T1 const& t1, T2 const& t2, T3 const& t3) {
+                                            return impl::concat_tuple(t0, t1, t2, t3, make_index_seq<T0::size()>{}, make_index_seq<T1::size()>{}, make_index_seq<T2::size()>{}, make_index_seq<T3::size()>{}); }
+namespace impl { template <class T0, class T1, class T2, class T3, class T4, index_t... I0, index_t... I1, index_t... I2, index_t... I3, index_t... I4>
+OPUS_H_D constexpr auto concat_tuple(T0 const& t0, T1 const& t1, T2 const& t2, T3 const& t3, T4 const& t4, seq<I0...>, seq<I1...>, seq<I2...>, seq<I3...>, seq<I4...>) { return opus::make_tuple(get<I0>(t0)..., get<I1>(t1)..., get<I2>(t2)..., get<I3>(t3)..., get<I4>(t4)...); } }
+template <class T0, class T1, class T2, class T3, class T4>
+OPUS_H_D constexpr auto concat_tuple(T0 const& t0, T1 const& t1, T2 const& t2, T3 const& t3, T4 const& t4) { return impl::concat_tuple(t0, t1, t2, t3, t4, make_index_seq<T0::size()>{}, make_index_seq<T1::size()>{}, make_index_seq<T2::size()>{}, make_index_seq<T3::size()>{}, make_index_seq<T4::size()>{}); }
+template <class T0, class T1, class T2, class T3, class T4, class T5, class... Ts>
+OPUS_H_D constexpr auto concat_tuple(T0 const& t0, T1 const& t1, T2 const& t2, T3 const& t3, T4 const& t4, T5 const& t5, Ts const&... ts) { return concat_tuple(concat_tuple(t0, t1, t2, t3, t4), concat_tuple(t5, ts...)); }
+
+template <typename> struct is_tuple : false_type {};
+template <typename... T> struct is_tuple<opus::tuple<T...>> : true_type {};
+template <typename T> static constexpr bool is_tuple_v = is_tuple<remove_cvref_t<T>>::value;
+template <typename T> struct is_static_tuple : is_constant<remove_cvref_t<T>> {};
+template <> struct is_static_tuple<underscore> : true_type {};
+template <typename... T> struct is_static_tuple<opus::tuple<T...>> : bool_constant<(is_static_tuple<T>::value && ...)> {};
+template <typename T> static constexpr bool is_static_tuple_v = is_static_tuple<remove_cvref_t<T>>::value;
+template<typename T> struct get_value_type<T, std::enable_if_t<is_tuple_v<T>>> { using type = tuple_element_t<0, T>; };   // TODO: get the first element type
+
+template<typename T> OPUS_H_D constexpr std::enable_if_t<is_tuple_v<T>, index_t> size(T&&) { return remove_cvref_t<T>::size(); /* tuple size */}
+template<typename T> OPUS_H_D constexpr std::enable_if_t<is_tuple_v<T>, index_t> size()    { return remove_cvref_t<T>::size(); /* tuple size */}
+
+template <typename T, std::enable_if_t<!is_tuple_v<T>, bool> = true> OPUS_H_D constexpr auto explode_tuple(const T& t) { return opus::make_tuple(t); }
+template <typename T, index_t... Is> OPUS_H_D constexpr auto                                 explode_tuple(const T&, seq<Is...>);
+template <typename T, std::enable_if_t<is_tuple_v<T>, bool> = true> OPUS_H_D constexpr auto  explode_tuple(const T& t) { return explode_tuple(t, make_index_seq<size<T>()>{}); }
+template <typename T, index_t... Is> OPUS_H_D constexpr auto                                 explode_tuple(const T& t, seq<Is...>) { return concat_tuple(explode_tuple(get<Is>(t))...); }
+
+template <typename T, index_t... Is> OPUS_H_D constexpr auto flatten_tuple_general(const T& t, seq<Is...>) { return concat_tuple(explode_tuple(get<Is>(t))...); }
+template <typename T, std::enable_if_t<is_tuple_v<T> && !(is_tuple_v<tuple_element_t<0, remove_cvref_t<T>>>), bool> = true>
+OPUS_H_D constexpr auto flatten_tuple(const T& t) { return t; }  // already flat
+template <typename T, std::enable_if_t<!is_tuple_v<T>, bool> = true>
+OPUS_H_D constexpr auto flatten_tuple(const T& t) { return flatten_tuple_general(t, make_index_seq<size<T>()>{}); }  // non-tuple (e.g. seq)
+namespace impl { // direct flatten for 1-level nested tuples -- bypasses concat_tuple + explode_tuple
+template<typename T, index_t... Gs> constexpr auto group_sizes(seq<Gs...>) { return seq<size<tuple_element_t<Gs, T>>()...>{}; }
+template<typename T, index_t... Gs> constexpr index_t group_total(seq<Gs...>) { return (size<tuple_element_t<Gs, T>>() + ...); }
+template<index_t J, index_t... Gs, index_t... Ns> constexpr index_t flat_group(seq<Gs...>, seq<Ns...>) { index_t acc = 0, r = 0; ((void)(acc += Ns, (acc <= J ? (void)(r = Gs + 1) : (void)0)), ...); return r; }
+template<typename T, index_t G, index_t... Gs> constexpr index_t group_offset(seq<Gs...>) { return ((Gs < G ? size<tuple_element_t<Gs, T>>() : 0) + ...); }
+template<typename T, index_t J, typename GS> OPUS_H_D constexpr auto flatten_at(const T& t) {
+    constexpr auto gs = make_index_seq<size<T>()>{}; constexpr index_t G = flat_group<J>(gs, GS{}); return get<J - group_offset<T, G>(gs)>(get<G>(t)); }
+template<typename T, typename GS, index_t... Js> OPUS_H_D constexpr auto flatten_tuple_impl(const T& t, seq<Js...>) { return opus::make_tuple(flatten_at<T, Js, GS>(t)...); }
+}
+template <typename T, std::enable_if_t<is_tuple_v<T> && (is_tuple_v<tuple_element_t<0, remove_cvref_t<T>>>), bool> = true>
+OPUS_H_D constexpr auto flatten_tuple(const T& t) { using U = remove_cvref_t<T>; constexpr auto gs = make_index_seq<size<U>()>{}; return impl::flatten_tuple_impl<U, decltype(impl::group_sizes<U>(gs))>(t, make_index_seq<impl::group_total<U>(gs)>{}); }
+
+namespace impl {
+template<typename Outer, typename Inner, index_t...Is>
+OPUS_H_D constexpr auto embed_nested_tuple_impl(const Outer& ot, const Inner& it, seq<Is...>) { return opus::make_tuple(concat_tuple(get<Is>(ot), get<Is>(it))...); }
+
+template<typename TargetType, typename T, index_t...Is>
+OPUS_H_D constexpr auto tuple_count_impl(seq<Is...>) { return (number<std::is_same_v<remove_cvref_t<decltype(get<Is>(T{}))>, remove_cvref_t<TargetType>> ? 1 : 0>{} + ...); }
+}
+// Outer: tuple<tuple<X, X>, tuple<Y>>,  Inner: tuple<tuple<Z>, tuple<W>> => tuple<tuple<X, X, Z>, tuple<Y, W>>
+template<typename Outer, typename Inner>
+OPUS_H_D constexpr auto embed_nested_tuple(const Outer& ot, const Inner& it) {
+    static_assert(size<Outer>() == size<Inner>());
+    return impl::embed_nested_tuple_impl(ot, it, make_index_seq<size<Outer>()>{});
+}
+
+template< typename TargetType, typename T, std::enable_if_t<is_tuple_v<T>, bool> = true>
+OPUS_H_D constexpr index_t tuple_count(const T& /*t*/) { return impl::tuple_count_impl<TargetType, remove_cvref_t<T>>(make_index_seq<size<T>()>{}).value; }
+
+template< typename TargetType, typename T, std::enable_if_t<is_tuple_v<T>, bool> = true>
+OPUS_H_D constexpr index_t tuple_count() { return impl::tuple_count_impl<TargetType, remove_cvref_t<T>>(make_index_seq<size<T>()>{}).value; }
+
+template<index_t...Is> OPUS_H_D constexpr auto seq_to_tuple(seq<Is...>) { return opus::make_tuple(number<Is>{}...); }
+
+template<index_t...Is>                                             OPUS_H_D constexpr auto to_tuple(seq<Is...>) { return opus::make_tuple(number<Is>{}...); }
+template<typename T, std::enable_if_t<is_tuple_v<T>, bool> = true> OPUS_H_D constexpr auto to_tuple(const T& t) { return t; }
+
+namespace impl {
+template <typename R, typename T>            OPUS_H_D constexpr auto reduce_tuple_impl(const T& t, seq<>)  { return t; }
+template <typename R, typename T, index_t I> OPUS_H_D constexpr auto reduce_tuple_impl(const T& t, seq<I>) { return t; }
+
+template <typename R, typename T, index_t I0, index_t I1, index_t... Is>
+OPUS_H_D constexpr auto reduce_tuple_impl(const T& t, seq<I0, I1, Is...>) {
+    return reduce_tuple_impl<R>(opus::make_tuple(R{}(get<I0>(t), get<I1>(t)), get<Is>(t)...), make_index_seq<sizeof...(Is) + 1>{});
+}
+}
+template<typename R, typename T, std::enable_if_t<is_tuple_v<T>, bool> = true>
+OPUS_H_D constexpr auto reduce_tuple(const T & t) { return  impl::reduce_tuple_impl<R>(t, make_index_seq<size<T>()>{}); }
+template<typename T, std::enable_if_t<is_tuple_v<T>, bool> = true> OPUS_H_D constexpr auto reduce_tuple_sum(const T & t) { return reduce_tuple<opus::plus>(t); }
+template<typename T, std::enable_if_t<is_tuple_v<T>, bool> = true> OPUS_H_D constexpr auto reduce_tuple_mul(const T & t) { return reduce_tuple<opus::multiplies>(t); }
+// Fast path: fold expression for tuple of number<> types (avoids N-1 intermediate tuple types)
+template<typename... Ns, std::enable_if_t<sizeof...(Ns) != 0 && (is_constant_v<Ns> && ...), bool> = true>
+OPUS_H_D constexpr auto reduce_tuple_mul(const tuple<Ns...>&) { return opus::tuple<number<(Ns::value * ...)>>{}; }
+
+namespace impl {
+template<typename PT, index_t... Js>
+OPUS_H_D constexpr index_t underscore_count_in(seq<Js...>) { return ((is_underscore_v<remove_cvref_t<decltype(get<Js>(PT{}))>> ? 1 : 0) + ... + 0); }
+
+template<typename PT, typename MaxN, index_t I>
+OPUS_H_D constexpr index_t peephole_idx() { constexpr index_t c = underscore_count_in<PT>(make_index_seq<I>{}); return c < MaxN::value ? c : MaxN::value - 1; }
+
+template<typename PT, typename MaxN, index_t... Is>
+OPUS_H_D constexpr auto to_peepholed_seq_impl(seq<Is...>) { return seq<peephole_idx<PT, MaxN, Is>()...>{}; }
+
+template<typename PeepholedTuple, typename IncomTuple, index_t...Ps,  index_t...Is>
+OPUS_H_D constexpr decltype(auto) merge_peepholed_tuple_impl(PeepholedTuple&& pt, IncomTuple&& it, seq<Ps...>, seq<Is...>) {
+    return opus::make_tuple([&](){ if constexpr (is_underscore_v<remove_cvref_t<decltype(get<Ps>(pt))>>) return get<Is>(it);
+                                   else return get<Ps>(pt);}()... );
+}
+}
+// (Peepholed)tuple<*, *, _, *, _> + (Income)tuple<#, @> -> tuple<*, *, #, *, @>.  "_"(underscore) indicate a peephole for income tuple to chime in
+template<typename PeepholedTuple, typename IncomeTuple>
+OPUS_H_D constexpr decltype(auto) merge_peepholed_tuple(PeepholedTuple&& pt, IncomeTuple&& it) {
+    if constexpr (tuple_count<underscore, PeepholedTuple>() == 0) return pt;
+    else {
+        constexpr auto income_seq = impl::to_peepholed_seq_impl< remove_cvref_t<PeepholedTuple>,
+                                                                 number<opus::size<IncomeTuple>()> >(make_index_seq<opus::size<PeepholedTuple>()>{});
+        return impl::merge_peepholed_tuple_impl(std::forward<PeepholedTuple>(pt), std::forward<IncomeTuple>(it), make_index_seq<opus::size<PeepholedTuple>()>{}, income_seq);
+    }
+}
+} // namespace opus
+
+// implementing the "tuple-like binding protocol", don't use below directly
+namespace std {
+template <typename... Ts> struct tuple_size<opus::tuple<Ts...>>       : std::integral_constant<std::size_t, sizeof...(Ts)> {};
+template <typename... Ts> struct tuple_size<const opus::tuple<Ts...>> : std::integral_constant<std::size_t, sizeof...(Ts)> {};
+template <std::size_t I, typename... Ts> struct tuple_element<I, opus::tuple<Ts...>>       { using type = __type_pack_element<I, Ts...>; };
+template <std::size_t I, typename... Ts> struct tuple_element<I, const opus::tuple<Ts...>> { using type = const __type_pack_element<I, Ts...>; };
+} // namespace std
+
+namespace opus {
+// fwd-decl mma adaptors -- needed so make_tiled_mma() parses on archs (gfx12) where full defs are gated out.
+struct mfma_adaptor; struct mfma_adaptor_swap_ab; struct wmma_adaptor; struct wmma_adaptor_swap_ab;
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////
+// transforms
+template<typename X, typename Y, index_t... Is> constexpr auto embed(const X& x, const Y& y, seq<Is...>) { return ( ... + (get<Is>(x) * get<Is>(y))); }
+template<typename X, typename Y>                constexpr auto embed(const X& x, const Y& y) { return embed(x, y, make_index_seq<X::size()>{}); }
+
+namespace impl {
+template <typename F, typename X, index_t... Is> OPUS_H_D constexpr auto transform_tuple_impl(F f, const X& x, seq<Is...>) { return opus::make_tuple(f(get<Is>(x))...); }
+template <typename F, typename X, index_t... Is> OPUS_H_D constexpr auto transform_tuple_with_idx_impl(F f, const X& x, seq<Is...>) { return opus::make_tuple(f(get<Is>(x), number<Is>{})...); }
+} // namespace impl
+// f(auto item)
+template <typename F, typename X> OPUS_H_D constexpr auto transform_tuple(F f, const X& x) { return impl::transform_tuple_impl(f, x, make_index_seq<size<X>()>{}); }
+// f(auto item, auto index)
+template <typename F, typename X> OPUS_H_D constexpr auto transform_tuple_with_idx(F f, const X& x) { return impl::transform_tuple_with_idx_impl(f, x, make_index_seq<size<X>()>{}); }
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////
+// layout, simple linear nd layout with stride, static or dynamic supported
+namespace impl {
+template<typename Shape, index_t I, index_t... Js>
+OPUS_H_D constexpr auto packed_stride_at(seq<Js...>) { return (get<I + 1 + Js>(Shape{}) * ... * number<1>{}); }
+
+template<typename Shape, index_t... Is>
+OPUS_H_D constexpr auto packed_shape_to_stride_impl(seq<Is...>) { return opus::make_tuple(packed_stride_at<Shape, Is>(make_index_seq<Shape::size() - Is - 1>{})...); }
+}
+
+template<typename Shape>
+OPUS_H_D constexpr auto packed_shape_to_stride(const Shape&) { return impl::packed_shape_to_stride_impl<Shape>(make_index_seq<Shape::size()>{}); }
+
+template<typename Layout, typename Coord>
+OPUS_H_D constexpr decltype(auto) coord_to_linear(const Layout& layout, const Coord& coord) { static_assert(size<decltype(layout.stride())>() == size<Coord>()); return embed(layout.stride(), coord); }
+
+// Shape/Stride/Coord, they are all tuples. if Coord is not false_type, will use merge_peepholed_tuple() to construct real coord
+template<typename Shape_, typename Stride_, typename Coord_ = false_type>
+struct layout : public tuple<remove_cvref_t<Shape_>, remove_cvref_t<Stride_>, remove_cvref_t<Coord_>> {
+    using base   = tuple<remove_cvref_t<Shape_>, remove_cvref_t<Stride_>, remove_cvref_t<Coord_>>;
+    using Shape  = remove_cvref_t<Shape_>;
+    using Stride = remove_cvref_t<Stride_>;
+    using Coord  = remove_cvref_t<Coord_>;  // peepholed coord
+
+    static constexpr index_t rank = Shape::size();
+    static_assert(Shape::size() == Stride::size());
+    static_assert(std::is_same_v<Coord, false_type> || size<std::conditional_t<std::is_same_v<Coord, false_type>, Shape, Coord>>() == rank, "Coord should be either false_type or a tuple with same size as Shape");
+    static constexpr index_t coord_rank = [](){
+        if constexpr (std::is_same_v<Coord, false_type>) return rank;
+        else          return rank - tuple_count<underscore>(Coord{});
+    }();
+
+    OPUS_H_D constexpr layout(const Shape& shape, const Stride& stride, const Coord& coord = {}) : base(shape, stride, coord){}
+    OPUS_H_D constexpr layout(Shape&& shape, Stride&& stride, Coord&& coord = {}) : base(shape, stride, coord){}
+
+    // get ith element from shape/stride. if no I, then get the shape/stride as tuple
+    template <int... I> OPUS_H_D constexpr decltype(auto) shape()        { return get<0,I...>(static_cast<base&>(*this)); }
+    template <int... I> OPUS_H_D constexpr decltype(auto) shape()  const { return get<0,I...>(static_cast<const base&>(*this)); }
+    template <int... I> OPUS_H_D constexpr decltype(auto) stride()       { return get<1,I...>(static_cast<base&>(*this)); }
+    template <int... I> OPUS_H_D constexpr decltype(auto) stride() const { return get<1,I...>(static_cast<const base&>(*this)); }
+    template <int... I> OPUS_H_D constexpr decltype(auto) coord()        { return get<2,I...>(static_cast<base&>(*this)); }
+    template <int... I> OPUS_H_D constexpr decltype(auto) coord() const  { return get<2,I...>(static_cast<const base&>(*this)); }
+
+    template <typename... Cs, std::enable_if_t<(!is_tuple_v<Cs> && ...), bool> = true>
+    OPUS_H_D constexpr decltype(auto) operator()(Cs&&... cs) const { return this->operator()(opus::make_tuple(std::forward<Cs>(cs)...)); }
+
+    template <typename InCoord, std::enable_if_t<is_tuple_v<InCoord>, bool> = true>
+    OPUS_H_D constexpr decltype(auto) operator()(InCoord&& c) const {
+        if constexpr (std::is_same_v<Coord, false_type>) return coord_to_linear(*this, c);
+        else                                             return coord_to_linear(*this, merge_peepholed_tuple(coord(), c)); }
+};
+
+template <typename Layout> struct layout_linear;
+template<index_t cached_vec_, typename Layout> struct layout_cached;
+
+// use cached_vec to dispatch which layout implementation. cached_vec < 0 : "layout", cached_vec == 0 : "layout_linear", cached_vec > 0 : "layout_cached"
+template <index_t cached_vec = 0, typename Sx, typename Sy> OPUS_H_D constexpr auto make_layout(Sx&& s, Sy&& t) {
+    if      constexpr (cached_vec < 0)  return layout<Sx, Sy>(std::forward<Sx>(s), std::forward<Sy>(t));
+    else if constexpr (cached_vec == 0) return layout_linear<layout<Sx, Sy>>(std::forward<Sx>(s), std::forward<Sy>(t));
+    else                                return layout_cached<cached_vec, layout<Sx, Sy>>(std::forward<Sx>(s), std::forward<Sy>(t)); }
+template <index_t cached_vec = 0, typename Sx, typename Sy, typename Sz>
+OPUS_H_D constexpr auto                       make_layout(Sx&& s, Sy&& t, Sz&& c) {
+    if constexpr (cached_vec < 0)  return layout<Sx, Sy, Sz>(std::forward<Sx>(s), std::forward<Sy>(t), std::forward<Sz>(c));
+    if constexpr (cached_vec == 0) return layout_linear<layout<Sx, Sy, Sz>>(std::forward<Sx>(s), std::forward<Sy>(t), std::forward<Sz>(c));
+    else                           return layout_cached<cached_vec, layout<Sx, Sy, Sz>>(std::forward<Sx>(s), std::forward<Sy>(t), std::forward<Sz>(c)); }
+template <index_t cached_vec = 0, typename... Ts, std::enable_if_t<(!is_tuple_v<Ts> && ...), bool> = true>
+OPUS_H_D constexpr auto                       make_layout(Ts&&... ss) { return make_layout<cached_vec>(opus::make_tuple(ss...), packed_shape_to_stride(opus::make_tuple(ss...))); }
+template <index_t cached_vec = 0, typename S> OPUS_H_D constexpr auto make_layout(S&& s) { return make_layout<cached_vec>(std::forward<S>(s), packed_shape_to_stride(s)); }
+
+template <index_t cached_vec = 0, typename S> OPUS_H_D constexpr auto               make_layout_packed(S&& s) { return make_layout<cached_vec>(std::forward<S>(s), packed_shape_to_stride(s)); } // same as single arg make_layout
+template <index_t cached_vec = 0, typename Sx, typename Sz> OPUS_H_D constexpr auto make_layout_packed(Sx&& s, Sz&& c) { return make_layout<cached_vec>(std::forward<Sx>(s), packed_shape_to_stride(s), std::forward<Sz>(c)); }
+
+template <typename Layout>
+struct layout_linear : public remove_cvref_t<Layout>{
+    using base = remove_cvref_t<Layout>;
+
+    template<typename Shape, typename Stride, typename Coord = false_type>
+    OPUS_H_D constexpr layout_linear(const Shape& shape, const Stride& stride, const Coord& coord = {}) : base(shape, stride, coord), linear_offset(0){}
+
+    template<typename Shape, typename Stride, typename Coord = false_type>
+    OPUS_H_D constexpr layout_linear(Shape&& shape, Stride&& stride, Coord&& coord = {}) : base(shape, stride, coord), linear_offset(0){}
+
+    template <typename... Cs, std::enable_if_t<(!is_tuple_v<Cs> && ...), bool> = true>
+    OPUS_H_D constexpr decltype(auto) operator()(Cs&&... cs) const { return this->operator()(opus::make_tuple(std::forward<Cs>(cs)...)); }
+
+    template <typename InCoord, std::enable_if_t<is_tuple_v<InCoord>, bool> = true>
+    OPUS_H_D constexpr decltype(auto) operator()(InCoord&& c) const {
+        if constexpr (std::is_same_v<typename base::Coord, false_type>) return linear_offset + coord_to_linear(*this, c);
+        else                                             return linear_offset + coord_to_linear(*this, merge_peepholed_tuple(base::coord(), c)); }
+
+    OPUS_H_D constexpr void inc(index_t offset) { linear_offset += offset; }
+    OPUS_H_D constexpr layout_linear& operator+=(index_t offset) { inc(offset); return *this; }
+    OPUS_H_D constexpr layout_linear operator+(index_t offset) const { layout_linear result(*this); result += offset; return result; }
+
+    index_t linear_offset;
+};
+
+template <index_t vec, typename Layout> OPUS_H_D constexpr auto layout_to_vectorized_issue_space();
+template<index_t vec, typename Layout> OPUS_H_D constexpr auto layout_to_offsets(const Layout& u);
+
+template<index_t cached_vec_, typename Layout>
+struct layout_cached : public remove_cvref_t<Layout> {
+    using base = remove_cvref_t<Layout>;
+    static constexpr index_t cached_vec = cached_vec_;
+
+    static constexpr auto issue_space_vec = layout_to_vectorized_issue_space<cached_vec, base>();
+    static constexpr index_t num_issues = get<0>(reduce_tuple_mul(issue_space_vec)).value;
+
+    template<typename Shape, typename Stride, typename Coord = false_type>
+    OPUS_H_D constexpr layout_cached(const Shape& shape, const Stride& stride, const Coord& coord = {}) : base(shape, stride, coord), offsets{layout_to_offsets<cached_vec>(static_cast<base>(*this))}{}
+
+    template<typename Shape, typename Stride, typename Coord = false_type>
+    OPUS_H_D constexpr layout_cached(Shape&& shape, Stride&& stride, Coord&& coord = {}) : base(shape, stride, coord), offsets{layout_to_offsets<cached_vec>(static_cast<base>(*this))}{}
+
+    template <typename... Cs, std::enable_if_t<(!is_tuple_v<Cs> && ...), bool> = true>
+    OPUS_H_D constexpr decltype(auto) operator()(Cs&&... cs) const { return this->operator()(opus::make_tuple(std::forward<Cs>(cs)...)); }
+
+    template <typename InCoord, std::enable_if_t<is_tuple_v<InCoord>, bool> = true>
+    OPUS_H_D constexpr decltype(auto) operator()(InCoord&& c) const { constexpr auto u_linear = make_layout<-1>(issue_space_vec); return offsets[u_linear(c)]; }
+
+    OPUS_H_D constexpr void inc(index_t offset) { static_for<num_issues>([&](auto i){ offsets[i] += offset; }); }
+    OPUS_H_D constexpr layout_cached& operator+=(index_t offset) { inc(offset); return *this; }
+    OPUS_H_D constexpr layout_cached operator+(index_t offset) const { layout_cached result(*this); result += offset; return result; }
+
+    array<index_t, num_issues> offsets;
+};
+
+template<typename Layout, index_t N>
+struct layout_shifted : public remove_cvref_t<Layout> {
+    using base = remove_cvref_t<Layout>;
+    OPUS_H_D constexpr layout_shifted(const base& layout) : base(layout) {}
+    template<typename Shape, typename Stride, typename Coord = false_type>
+    OPUS_H_D constexpr layout_shifted(const Shape& shape, const Stride& stride, const Coord& coord = {}) : base(shape, stride, coord) {}
+    template <typename... Cs>
+    OPUS_H_D constexpr auto operator()(Cs&&... cs) const { return base::operator()(std::forward<Cs>(cs)...) + N; }
+};
+
+template<typename T> struct is_layout : false_type {};
+template<typename X, typename Y, typename Z> struct is_layout<layout<X, Y, Z>> : true_type {};
+template<index_t cached_vec, typename Layout> struct is_layout<layout_cached<cached_vec, Layout>> : true_type {};
+template<typename Layout> struct is_layout<layout_linear<Layout>> : true_type {};
+template<typename Layout, index_t N> struct is_layout<layout_shifted<Layout, N>> : true_type {};
+template<typename T> constexpr bool is_layout_v = is_layout<remove_cvref_t<T>>::value;
+
+template<typename Layout> struct layout_shift_traits { using base = Layout; static constexpr index_t value = 0; };
+template<typename Layout, index_t N> struct layout_shift_traits<layout_shifted<Layout, N>> { using base = remove_cvref_t<Layout>; static constexpr index_t value = N; };
+template<typename Layout, index_t N, std::enable_if_t<is_layout_v<remove_cvref_t<Layout>>, bool> = true>
+OPUS_H_D constexpr auto operator+(const Layout& layout, number<N>) {
+    using shift = layout_shift_traits<remove_cvref_t<Layout>>;
+    if constexpr (N == 0) return layout;
+    else                  return layout_shifted<typename shift::base, shift::value + N>(static_cast<const typename shift::base&>(layout));
+}
+
+template <typename Layout>
+OPUS_H_D constexpr auto layout_to_issue_space() {
+    using maybe_coord = std::conditional_t<std::is_same_v<typename Layout::Coord, false_type>, typename Layout::Shape, typename Layout::Coord>;
+    using issue_space_y = remove_cvref_t<decltype(pickup_shape(typename Layout::Shape{}, maybe_coord{}, underscore{}))>;
+    using single_issue_space = remove_cvref_t<decltype(make_repeated_tuple(number<1>{}, number<size<typename Layout::Shape>()>{}))>;
+    using fallback_issue_space_y = std::conditional_t<std::is_same_v<issue_space_y, opus::tuple<>>, single_issue_space, issue_space_y>;
+    using issue_space = std::conditional_t<std::is_same_v<typename Layout::Coord, false_type>, single_issue_space, fallback_issue_space_y>;
+    return issue_space{};
+}
+template<typename issue_space, int vec = 1>
+OPUS_H_D constexpr auto vectorize_issue_space(issue_space, number<vec> = {}) {
+    constexpr index_t vec_from_issue_space = get<size<issue_space>() - 1>(issue_space{}).value;     // here we get the original last dim length(which should be y dim)
+    static_assert(vec_from_issue_space % vec == 0, "please make sure requested vec size can be dividable of vec from issue space");
+
+    constexpr auto issue_space_vec = transform_tuple_with_idx([&](auto item, auto index){           // modify the last dim, divide it by vec. Result is still a tuple
+        if constexpr (index.value == size<issue_space>() - 1) return number<item.value / vec>{};
+        else                                                  return item;    }, issue_space{});
+    return issue_space_vec;
+}
+template <index_t vec, typename Layout>
+OPUS_H_D constexpr auto layout_to_vectorized_issue_space() {
+    constexpr auto issue_space = layout_to_issue_space<Layout>();
+    constexpr auto issue_space_vec = vectorize_issue_space(issue_space, number<vec>{});
+    return issue_space_vec;
+}
+
+// Cache issue-space computations for load/store (avoids redundant evaluation across methods)
+template<typename Layout, index_t vec = 1> struct layout_load_traits {
+    static constexpr auto issue_space = layout_to_issue_space<Layout>();
+    static constexpr auto issue_space_vec = vectorize_issue_space(issue_space, number<vec>{}); static constexpr auto r_elem = get<0>(reduce_tuple_mul(issue_space_vec));
+};
+// Runtime flat index -> multi-index tuple (all index_t) -- avoids per-iteration template instantiation
+template<index_t... Is, index_t... Ns> OPUS_H_D constexpr auto flat_to_coords(index_t flat, seq<Is...>, tuple<number<Ns>...>) {
+    constexpr index_t strides[] = {impl::ford_stride<Is>(make_index_seq<sizeof...(Ns)>{}, seq<Ns...>{})...}, dims[] = {Ns...};
+    return opus::make_tuple(static_cast<index_t>((flat / strides[Is]) % dims[Is])...); }
+// Pre-compute offsets via runtime loop -- 1 coord_to_linear instantiation per layout instead of N
+template<index_t vec, typename Layout> OPUS_H_D constexpr auto layout_to_offsets(const Layout& u) {
+    using LT = layout_load_traits<Layout, vec>; constexpr auto issue_space_vec = LT::issue_space_vec;
+    constexpr index_t num_issues = LT::r_elem.value, ndim = size<remove_cvref_t<decltype(issue_space_vec)>>();
+    array<index_t, num_issues> offsets;
+    for (index_t i = 0; i < num_issues; i++) offsets[i] = u(flat_to_coords(i, make_index_seq<ndim>{}, issue_space_vec));
+    return offsets; }
+// Compile-time per-issue offsets for layouts with static Shape/Stride
+template<typename Layout, index_t vec>
+inline constexpr auto layout_imm_offsets_v = layout_to_offsets<vec>(Layout{typename Layout::Shape{}, typename Layout::Stride{}, typename Layout::Coord{}});
+/////////////////////////////////////////////////////////////////////////////////////////////////////////
+// vector, a wrapper for __attribute__((ext_vector_type(*)))
+template <typename V_, index_t N_> // V_ must be literal type, otherwise clang ext_vector_type will not recognize
+struct vector {
+    static constexpr index_t N = N_;
+    using value_type           = remove_cvref_t<V_>;
+    using type = value_type __attribute__((ext_vector_type(N))); // this is danguous
+};
+template <typename T, index_t N> using vector_t = typename vector<T, N>::type;
+
+template <typename> struct is_vector : false_type {};
+template <typename T, index_t N> struct is_vector<T __attribute((ext_vector_type(N)))> : true_type {};
+template <typename T, index_t N> struct is_vector<T __attribute((ext_vector_type(N)))&> : true_type {};
+template <typename T, index_t N> struct is_vector<const T __attribute((ext_vector_type(N)))&> : true_type {};
+template <typename T, index_t N> struct is_vector<T __attribute((ext_vector_type(N)))&&> : true_type {};
+template <typename E> static constexpr bool is_vector_v = is_vector<E>::value;
+
+namespace impl {
+template <typename T>            struct vector_traits_impl { using dtype = remove_cvref_t<T>; static constexpr index_t size() { return 1; } };
+template <typename T, index_t N> struct vector_traits_impl<T __attribute__((ext_vector_type(N)))> { using dtype = T; static constexpr index_t size() { return N; } };
+template <typename T, index_t N> struct vector_traits_impl<array<T, N>> { using dtype = T; static constexpr index_t size() { return N; } };
+template <typename... T>         struct vector_traits_impl<tuple<T...>> { using dtype = __type_pack_element<0, T...> /*TODO: use first type*/; static constexpr index_t size() { return sizeof...(T); } };
+}
+template <typename T> struct vector_traits : public impl::vector_traits_impl<remove_cvref_t<T>> {};
+
+template<typename T> OPUS_H_D constexpr std::enable_if_t<is_vector_v<T>, index_t> size(T&&) {  return vector_traits<T>::size();   /* vector size */}
+template<typename T> OPUS_H_D constexpr std::enable_if_t<is_vector_v<T>, index_t> size()    {  return vector_traits<T>::size();   /* vector size */}
+
+template<typename T> struct get_value_type<T, std::enable_if_t<is_vector_v<T>>> { using type = typename vector_traits<T>::dtype; };
+
+namespace impl {
+template<typename D, typename...> struct vector_return_type_helper { using type = D; };
+template<typename... Types>
+struct vector_return_type_helper<void, Types...> : std::common_type<Types...> { static_assert(std::conjunction_v<not_ref_wrapper<Types>...>, "Types cannot contain reference_wrappers when D is void"); };
+template<typename D, typename... Types> using vector_return_type = opus::vector_t<typename vector_return_type_helper<D, Types...>::type, sizeof...(Types)>;
+}
+template<typename D = void, typename... Types> constexpr impl::vector_return_type<D, Types...> make_vector(Types&&... t) { return {std::forward<Types>(t)...}; }
+
+namespace impl {
+template <typename T, index_t... Is> OPUS_H_D constexpr auto make_repeated_vector(T&& x, seq<Is...>) { return opus::make_vector((void(Is), std::forward<T>(x))...); }
+} // namespace impl
+template <index_t N, typename T> OPUS_H_D constexpr auto make_repeated_vector(T&& x) { return impl::make_repeated_vector(std::forward<T>(x), make_index_seq<N>{}); }
+template <typename T, index_t N> OPUS_H_D constexpr auto make_repeated_vector(T&& x, number<N>) { return impl::make_repeated_vector(std::forward<T>(x), make_index_seq<N>{}); }
+
+// vector type can't return reference! error: non-const reference cannot bind to vector element
+template <index_t I, typename T, std::enable_if_t<is_vector_v<T>, bool> = true> OPUS_H_D constexpr typename vector_traits<T>::dtype get(T const& t) { static_assert(I < vector_traits<T>::size()); return t[I]; }
+template <index_t I, typename T, std::enable_if_t<is_vector_v<T>, bool> = true> OPUS_H_D constexpr typename vector_traits<T>::dtype get(T&& t)      { static_assert(I < vector_traits<T>::size()); return t[I]; }
+
+namespace impl {
+template <class T0, class T1, index_t... I0, index_t... I1>
+OPUS_H_D constexpr auto concat_vector(T0 const& t0, T1 const& t1, seq<I0...>, seq<I1...>) {
+    if constexpr (std::is_same_v<remove_cvref_t<T0>, remove_cvref_t<T1>> && sizeof...(I0) > 1) {
+        using R = vector_t<typename vector_traits<remove_cvref_t<T0>>::dtype, sizeof...(I0) + sizeof...(I1)>;
+        return __builtin_bit_cast(R, __builtin_shufflevector(t0, t1, I0..., (sizeof...(I0) + I1)...));
+    } else { return opus::make_vector(get<I0>(t0)..., get<I1>(t1)...); }
+}
+template <class T0, class T1, class T2, index_t... I0, index_t... I1, index_t...I2>
+OPUS_H_D constexpr auto concat_vector(T0 const& t0, T1 const& t1, T2 const& t2, seq<I0...>, seq<I1...>, seq<I2...>) { return opus::make_vector(get<I0>(t0)..., get<I1>(t1)..., get<I2>(t2)...); }
+template <class T0, class T1, class T2, class T3, index_t... I0, index_t... I1, index_t...I2, index_t...I3>
+OPUS_H_D constexpr auto concat_vector(T0 const& t0, T1 const& t1, T2 const& t2, T3 const& t3, seq<I0...>, seq<I1...>, seq<I2...>, seq<I3...>) { return opus::make_vector(get<I0>(t0)..., get<I1>(t1)..., get<I2>(t2)..., get<I3>(t3)...); }
+}
+template <class T0> OPUS_H_D  constexpr auto concat_vector(T0 const& t0) { return t0; }
+template <class T0, class T1>
+OPUS_H_D  constexpr auto concat_vector(T0 const& t0, T1 const& t1) { return impl::concat_vector(t0, t1, make_index_seq<size<T0>()>{}, make_index_seq<size<T1>()>{}); }
+template <class T0, class T1, class T2>
+OPUS_H_D  constexpr auto concat_vector(T0 const& t0, T1 const& t1, T2 const& t2) { return impl::concat_vector(t0, t1, t2, make_index_seq<T0::size()>{}, make_index_seq<T1::size()>{}, make_index_seq<T2::size()>{}); }
+template <class T0, class T1, class T2, class T3>
+OPUS_H_D  constexpr auto concat_vector(T0 const& t0, T1 const& t1, T2 const& t2, T3 const& t3) {
+                                            return impl::concat_vector(t0, t1, t2, t3, make_index_seq<T0::size()>{}, make_index_seq<T1::size()>{}, make_index_seq<T2::size()>{}, make_index_seq<T3::size()>{}); }
+template <class T0, class T1, class T2, class T3, class T4, class... Ts>
+OPUS_H_D  constexpr auto concat_vector(T0 const& t0, T1 const& t1, T2 const& t2, T3 const& t3, T4 const& t4, Ts const&... ts) { return concat_vector(concat_vector(t0, t1, t2, t3), concat_vector(t4, ts...)); }
+
+template <typename T, std::enable_if_t<is_vector_v<T>, bool> = true> OPUS_H_D constexpr void fill(T& a, typename vector_traits<T>::dtype const& value) {
+    if constexpr (size<T>() <= 4) { static_for<size<T>()>([&](auto i){ a[i.value] = value; }); }
+    else { for (index_t i = 0; i < size<T>(); ++i) a[i] = value; }  // runtime loop for large vectors
+}
+template <typename T, std::enable_if_t<is_vector_v<T>, bool> = true> OPUS_H_D constexpr void clear(T& a) { a = {}; }
+
+namespace impl {
+template<typename T, index_t... Is, std::enable_if_t<is_vector_v<T>, bool> = true>
+OPUS_H_D constexpr auto to_array_impl(const T& t, seq<Is...>) { return opus::make_array(t[Is]...); }
+
+template<typename T, index_t... Is, std::enable_if_t<is_array_v<T>, bool> = true>
+OPUS_H_D constexpr auto to_array_impl(const T& t, seq<Is...>) { return opus::concat_array(to_array_impl(get<Is>(t), make_index_seq< size(get<Is>(T{})) >{})...); }
+
+template<typename T, index_t... Is, std::enable_if_t<is_array_v<T> && !is_vector_v<typename T::value_type>, bool> = true>
+OPUS_H_D constexpr vector_t<typename T::value_type, T::size()> to_vector_impl(const T& t, seq<Is...>) { return {get<Is>(t)...}; }
+
+template<typename T, index_t... Is, std::enable_if_t<is_array_v<T> && is_vector_v<typename T::value_type>, bool> = true>
+OPUS_H_D constexpr vector_t<typename T::value_type, T::size()> to_vector_impl(const T& t, seq<Is...>) { return opus::concat_vector(to_vector_impl(get<Is>(t))...); }
+}
+
+template<typename T, std::enable_if_t<is_vector_v<T>, bool> = true> // vector type to array
+OPUS_H_D constexpr auto to_array(const T& t) { return impl::to_array_impl(t, make_index_seq<size<T>()>{}); }
+
+template<typename T, std::enable_if_t<is_array_v<T>, bool> = true>  // array of vector type to array
+OPUS_H_D constexpr auto to_array(const T& t) { return impl::to_array_impl(t, make_index_seq<size<T>()>{}); }
+
+template<typename T, std::enable_if_t<is_array_v<T>, bool> = true>
+OPUS_H_D constexpr auto to_vector(const T& t) { return impl::to_vector_impl(t, make_index_seq<size<T>()>{}); }
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////
+// slice
+namespace impl {
+template<typename C, index_t...Is, std::enable_if_t<is_vector_v<C>, bool> = true> OPUS_H_D constexpr auto slice_impl(C&& c, seq<Is...>) {
+    if constexpr (sizeof...(Is) == 1) return opus::make_vector(get<Is>(c)...);
+    else { using R = vector_t<typename vector_traits<remove_cvref_t<C>>::dtype, sizeof...(Is)>; return __builtin_bit_cast(R, __builtin_shufflevector(c, c, Is...)); }
+}
+template<typename C, index_t...Is, std::enable_if_t<is_array_v<C>, bool> = true>  OPUS_H_D constexpr auto slice_impl(C&& c, seq<Is...>) { return opus::make_array(get<Is>(c)...); }
+template<typename C, index_t...Is, std::enable_if_t<is_tuple_v<C>, bool> = true>  OPUS_H_D constexpr auto slice_impl(C&& c, seq<Is...>) { return opus::make_tuple(get<Is>(c)...); }
+
+template<index_t len, typename C, typename...Ts, std::enable_if_t<is_vector_v<C>, bool> = true>
+OPUS_H_D constexpr auto slice_impl_i(C&& c, Ts... ss) { vector_t<typename vector_traits<C>::dtype, len> r;  index_t d = 0;  static_for([&](auto i){r[d++] = c[i]; }, ss...);  return r; }
+
+template<index_t len, typename C, typename...Ts, std::enable_if_t<is_array_v<C>, bool> = true>
+OPUS_H_D constexpr auto slice_impl_i(C&& c, Ts... ss) { array<typename C::value_type, len> r;  index_t d = 0;  static_for([&](auto i){r[d++] = c[i]; }, ss...);  return r; }
+
+template<index_t... Is>
+OPUS_H_D constexpr bool is_contiguous_seq(seq<Is...>) {
+    if constexpr (sizeof...(Is) < 2) return true;
+    else { constexpr index_t idx[] = {Is...}; for (index_t i = 1; i < sizeof...(Is); ++i) { if (idx[i] != idx[i - 1] + 1) return false; } return true; }
+}
+
+template<typename C, typename V, index_t...Ds, index_t...Ss, std::enable_if_t<(is_vector_v<C> || is_array_v<C> || is_tuple_v<C>), bool> = true>
+OPUS_H_D constexpr auto set_slice_impl(C&& dst_c, V&& src_c, seq<Ds...>, seq<Ss...>) {
+    using dst_t = remove_cvref_t<C>; using src_t = remove_cvref_t<V>; using scalar = typename vector_traits<dst_t>::dtype;
+    constexpr index_t len = sizeof...(Ds);
+    // Copy at dword granularity for sub-dword scalar types with dword-aligned contiguous slices
+    if constexpr ((is_vector_v<dst_t> || is_array_v<dst_t>) && (is_vector_v<src_t> || is_array_v<src_t>) && is_contiguous_seq(seq<Ds...>{}) && is_contiguous_seq(seq<Ss...>{}) && sizeof(scalar) < 4 && len > 1) {
+        constexpr index_t epd = 4 / sizeof(scalar);
+        constexpr index_t d0 = seq<Ds...>::at(number<0>{}), s0 = seq<Ss...>::at(number<0>{}), dn = vector_traits<dst_t>::size(), sn = vector_traits<src_t>::size();
+        if constexpr (d0 % epd == 0 && s0 % epd == 0 && len % epd == 0 && dn % epd == 0 && sn % epd == 0) {
+            auto dst_i32 = __builtin_bit_cast(vector_t<int, dn / epd>, dst_c);
+            const auto src_i32 = __builtin_bit_cast(vector_t<int, sn / epd>, src_c);
+            static_for<len / epd>([&](auto i) { dst_i32[d0 / epd + i.value] = src_i32[s0 / epd + i.value]; });
+            dst_c = __builtin_bit_cast(dst_t, dst_i32); return;
+        }
+    }
+    if constexpr (is_contiguous_seq(seq<Ds...>{}) && is_contiguous_seq(seq<Ss...>{}) && (is_vector_v<dst_t> || is_array_v<dst_t>) && len > 2) {
+        constexpr index_t d0 = seq<Ds...>::at(number<0>{}), s0 = seq<Ss...>::at(number<0>{});
+        for (index_t i = 0; i < len; ++i) dst_c[d0 + i] = src_c[s0 + i];  // runtime loop avoids N-element fold instantiation
+    } else { ((dst_c[Ds] = src_c[Ss]), ...); }
+}
+}
+
+// static/dynamic slice. SS could be either number<x>, or const integer. Note tuple type does not support dynamic slice (ss is integral)
+// (1).[end] : 0.... end, (2).[start, end] : start...end, (3).[start, end, step], start...end but with step as interval (default is 1)
+template<typename C, typename... S, std::enable_if_t<is_vector_v<C> && (is_constant_v<S> && ...), bool> = true>
+OPUS_H_D constexpr auto slice(C&& c, S&&.../*ss*/) { return impl::slice_impl(std::forward<C>(c), make_index_seq<(S::value) ...>{}); }
+template<index_t len, typename C, typename... S, std::enable_if_t<is_vector_v<C> && (std::is_integral_v<S> && ...), bool> = true>
+OPUS_H_D constexpr auto slice(C&& c, S&&...ss) { return impl::slice_impl_i<len>(std::forward<C>(c), ss...); }
+template<typename C, typename... S, std::enable_if_t<is_array_v<C> && (is_constant_v<S> && ...), bool> = true>
+OPUS_H_D constexpr auto slice(C&& c, S&&.../*ss*/) { return impl::slice_impl(std::forward<C>(c), make_index_seq<(S::value) ...>{}); }
+template<index_t len, typename C, typename... S, std::enable_if_t<is_array_v<C> && (std::is_integral_v<S> && ...), bool> = true>
+OPUS_H_D constexpr auto slice(C&& c, S&&...ss) { return impl::slice_impl_i<len>(std::forward<C>(c), ss...); }
+template<typename C, typename... S, std::enable_if_t<is_tuple_v<C> && (is_constant_v<S> && ...), bool> = true>
+OPUS_H_D constexpr auto slice(C&& c, S&&.../*ss*/) { return impl::slice_impl(std::forward<C>(c), make_index_seq<(S::value) ...>{}); }
+
+template<typename C, typename V, typename... S, std::enable_if_t<(is_vector_v<C> || is_array_v<C> || is_tuple_v<C>) && (is_constant_v<S> && ...), bool> = true>
+OPUS_H_D constexpr auto set_slice(C&& dst_c, V&& src_c, S&&.../*ss*/) {
+    static_assert(std::is_same_v<typename vector_traits<C>::dtype, typename vector_traits<V>::dtype>);
+    using dst_seq = make_index_seq<(S::value) ...>;
+    return impl::set_slice_impl(std::forward<C>(dst_c), std::forward<V>(src_c), dst_seq{}, make_index_seq<size<dst_seq>()>{});
+}
+/////////////////////////////////////////////////////////////////////////////////////////////////////////
+// BELOW IS AMDGPU SPECIFIC TYPES/ARCH/INTRINSICS
+/////////////////////////////////////////////////////////////////////////////////////////////////////////
+// address space attribute
+#if defined(__HIP_DEVICE_COMPILE__)
+    #define OPUS_LDS_ADDR __attribute__((address_space(3)))
+#else
+    #define OPUS_LDS_ADDR
+#endif
+
+// dtype, suffix is "_t", and register corresponding ext_vector_type, and a specialization of is_dtype
+#define REGISTER_DTYPE(dtype_base_, dtype_impl_)        \
+    using dtype_base_ ## _t    = dtype_impl_;           \
+    using dtype_base_ ## x1_t  = dtype_base_ ## _t __attribute__((ext_vector_type(1 )));    \
+    using dtype_base_ ## x2_t  = dtype_base_ ## _t __attribute__((ext_vector_type(2 )));    \
+    using dtype_base_ ## x4_t  = dtype_base_ ## _t __attribute__((ext_vector_type(4 )));    \
+    using dtype_base_ ## x8_t  = dtype_base_ ## _t __attribute__((ext_vector_type(8 )));    \
+    using dtype_base_ ## x16_t = dtype_base_ ## _t __attribute__((ext_vector_type(16)));    \
+    using dtype_base_ ## x32_t = dtype_base_ ## _t __attribute__((ext_vector_type(32)));    \
+    using dtype_base_ ## x64_t = dtype_base_ ## _t __attribute__((ext_vector_type(64)));    \
+    template<> struct is_dtype<dtype_base_ ## _t> : true_type {};
+
+template<typename T> struct is_dtype : false_type {};
+template<typename T> constexpr bool is_dtype_v = is_dtype<remove_cvref_t<T>>::value;    // use this!
+
+REGISTER_DTYPE(fp32, float)
+#if __clang_major__ >= 20   // enable for rocm 7.0+
+REGISTER_DTYPE(bf16, __bf16)
+REGISTER_DTYPE(fp16, __fp16)
+#else
+REGISTER_DTYPE(bf16, unsigned short)
+REGISTER_DTYPE(fp16, _Float16)
+#endif
+REGISTER_DTYPE(fp8 , _BitInt(8))
+REGISTER_DTYPE(bf8 , unsigned _BitInt(8))
+REGISTER_DTYPE(i32 , int)
+REGISTER_DTYPE(u32 , unsigned int)
+REGISTER_DTYPE(i16 , short)
+#if __clang_major__ >= 20
+REGISTER_DTYPE(u16 , unsigned short)
+#endif
+REGISTER_DTYPE(i8  , signed char)
+REGISTER_DTYPE(u8  , unsigned char)
+
+///////////////////////////////////////////////////////////////////////////////////////////////////////////
+// numeric_limits -- returns min/max/lowest/quiet_nan/infinity in the *original* dtype
+// (see finfo below for float-valued properties like eps/max/min/tiny)
+template<typename T> struct numeric_limits;
+
+template<> struct numeric_limits<fp32_t> {
+    static constexpr unsigned int bin_min = 0x00800000, bin_max = 0x7F7FFFFF, bin_lowest = 0xFF7FFFFF, bin_qnan = 0x7FC00000, bin_inf = 0x7F800000;
+    OPUS_H_D static constexpr fp32_t min()       { return __builtin_bit_cast(fp32_t, bin_min); }
+    OPUS_H_D static constexpr fp32_t max()       { return __builtin_bit_cast(fp32_t, bin_max); }
+    OPUS_H_D static constexpr fp32_t lowest()    { return __builtin_bit_cast(fp32_t, bin_lowest); }
+    OPUS_H_D static constexpr fp32_t quiet_nan() { return __builtin_bit_cast(fp32_t, bin_qnan); }
+    OPUS_H_D static constexpr fp32_t infinity()  { return __builtin_bit_cast(fp32_t, bin_inf); }
+};
+template<> struct numeric_limits<fp16_t> {
+    static constexpr unsigned short bin_min = 0x0400, bin_max = 0x7BFF, bin_lowest = 0xFBFF, bin_qnan = 0x7E00, bin_inf = 0x7C00;
+    OPUS_H_D static constexpr fp16_t min()       { return __builtin_bit_cast(fp16_t, bin_min); }
+    OPUS_H_D static constexpr fp16_t max()       { return __builtin_bit_cast(fp16_t, bin_max); }
+    OPUS_H_D static constexpr fp16_t lowest()    { return __builtin_bit_cast(fp16_t, bin_lowest); }
+    OPUS_H_D static constexpr fp16_t quiet_nan() { return __builtin_bit_cast(fp16_t, bin_qnan); }
+    OPUS_H_D static constexpr fp16_t infinity()  { return __builtin_bit_cast(fp16_t, bin_inf); }
+};
+template<> struct numeric_limits<bf16_t> {
+    static constexpr unsigned short bin_min = 0x0080, bin_max = 0x7F7F, bin_lowest = 0xFF7F, bin_qnan = 0x7FC0, bin_inf = 0x7F80;
+    OPUS_H_D static constexpr bf16_t min()       { return __builtin_bit_cast(bf16_t, bin_min); }
+    OPUS_H_D static constexpr bf16_t max()       { return __builtin_bit_cast(bf16_t, bin_max); }
+    OPUS_H_D static constexpr bf16_t lowest()    { return __builtin_bit_cast(bf16_t, bin_lowest); }
+    OPUS_H_D static constexpr bf16_t quiet_nan() { return __builtin_bit_cast(bf16_t, bin_qnan); }
+    OPUS_H_D static constexpr bf16_t infinity()  { return __builtin_bit_cast(bf16_t, bin_inf); }
+};
+// fp8 E4M3: gfx950=OCP(ieee-like, NaN=0x7F), gfx942=fnuz(NaN=0x80). No infinity in either format.
+// NOTE: __builtin_bit_cast with _BitInt(8) is not yet constexpr in clang, so use static_cast via signed char.
+template<> struct numeric_limits<fp8_t> {
+#if defined(__gfx942__)
+    static constexpr unsigned char bin_min = 0x08, bin_max = 0x7F, bin_lowest = 0xFF, bin_qnan = 0x80, bin_inf = 0x00;
+#else
+    static constexpr unsigned char bin_min = 0x08, bin_max = 0x7E, bin_lowest = 0xFE, bin_qnan = 0x7F, bin_inf = 0x00;
+#endif
+    OPUS_H_D static constexpr fp8_t min()       { return static_cast<fp8_t>(static_cast<signed char>(bin_min)); }
+    OPUS_H_D static constexpr fp8_t max()       { return static_cast<fp8_t>(static_cast<signed char>(bin_max)); }
+    OPUS_H_D static constexpr fp8_t lowest()    { return static_cast<fp8_t>(static_cast<signed char>(bin_lowest)); }
+    OPUS_H_D static constexpr fp8_t quiet_nan() { return static_cast<fp8_t>(static_cast<signed char>(bin_qnan)); }
+    OPUS_H_D static constexpr fp8_t infinity()  { return static_cast<fp8_t>(static_cast<signed char>(bin_inf)); }
+};
+// bf8 E5M2: gfx950=OCP(ieee, has inf=0x7C, NaN=0x7E), gfx942=fnuz(no inf, NaN=0x80)
+template<> struct numeric_limits<bf8_t> {
+#if defined(__gfx942__)
+    static constexpr unsigned char bin_min = 0x04, bin_max = 0x7F, bin_lowest = 0xFF, bin_qnan = 0x80, bin_inf = 0x00;
+#else
+    static constexpr unsigned char bin_min = 0x04, bin_max = 0x7B, bin_lowest = 0xFB, bin_qnan = 0x7F, bin_inf = 0x7C;
+#endif
+    OPUS_H_D static constexpr bf8_t min()       { return static_cast<bf8_t>(bin_min); }
+    OPUS_H_D static constexpr bf8_t max()       { return static_cast<bf8_t>(bin_max); }
+    OPUS_H_D static constexpr bf8_t lowest()    { return static_cast<bf8_t>(bin_lowest); }
+    OPUS_H_D static constexpr bf8_t quiet_nan() { return static_cast<bf8_t>(bin_qnan); }
+    OPUS_H_D static constexpr bf8_t infinity()  { return static_cast<bf8_t>(bin_inf); }
+};
+template<> struct numeric_limits<i32_t> {
+    OPUS_H_D static constexpr i32_t min()       { return -2147483647 - 1; }
+    OPUS_H_D static constexpr i32_t max()       { return  2147483647; }
+    OPUS_H_D static constexpr i32_t lowest()    { return -2147483647 - 1; }
+    OPUS_H_D static constexpr i32_t quiet_nan() { return 0; }
+    OPUS_H_D static constexpr i32_t infinity()  { return 0; }
+};
+template<> struct numeric_limits<u32_t> {
+    OPUS_H_D static constexpr u32_t min()       { return 0; }
+    OPUS_H_D static constexpr u32_t max()       { return 4294967295U; }
+    OPUS_H_D static constexpr u32_t lowest()    { return 0; }
+    OPUS_H_D static constexpr u32_t quiet_nan() { return 0; }
+    OPUS_H_D static constexpr u32_t infinity()  { return 0; }
+};
+template<> struct numeric_limits<i16_t> {
+    OPUS_H_D static constexpr i16_t min()       { return -32768; }
+    OPUS_H_D static constexpr i16_t max()       { return  32767; }
+    OPUS_H_D static constexpr i16_t lowest()    { return -32768; }
+    OPUS_H_D static constexpr i16_t quiet_nan() { return 0; }
+    OPUS_H_D static constexpr i16_t infinity()  { return 0; }
+};
+#if __clang_major__ >= 20
+template<> struct numeric_limits<u16_t> {
+    OPUS_H_D static constexpr u16_t min()       { return 0; }
+    OPUS_H_D static constexpr u16_t max()       { return 65535; }
+    OPUS_H_D static constexpr u16_t lowest()    { return 0; }
+    OPUS_H_D static constexpr u16_t quiet_nan() { return 0; }
+    OPUS_H_D static constexpr u16_t infinity()  { return 0; }
+};
+#endif
+template<> struct numeric_limits<i8_t> {
+    OPUS_H_D static constexpr i8_t min()       { return -128; }
+    OPUS_H_D static constexpr i8_t max()       { return  127; }
+    OPUS_H_D static constexpr i8_t lowest()    { return -128; }
+    OPUS_H_D static constexpr i8_t quiet_nan() { return 0; }
+    OPUS_H_D static constexpr i8_t infinity()  { return 0; }
+};
+template<> struct numeric_limits<u8_t> {
+    OPUS_H_D static constexpr u8_t min()       { return 0; }
+    OPUS_H_D static constexpr u8_t max()       { return 255; }
+    OPUS_H_D static constexpr u8_t lowest()    { return 0; }
+    OPUS_H_D static constexpr u8_t quiet_nan() { return 0; }
+    OPUS_H_D static constexpr u8_t infinity()  { return 0; }
+};
+
+///////////////////////////////////////////////////////////////////////////////////////////////////////////
+// finfo -- like torch.finfo: eps/max/min/tiny as float, bits as int
+template<typename T> struct finfo;
+
+template<> struct finfo<fp32_t> {
+    static constexpr int bits = 32;
+    OPUS_H_D static constexpr float eps()  { return __builtin_bit_cast(float, 0x34000000u); }  // 2^-23
+    OPUS_H_D static constexpr float max()  { return __builtin_bit_cast(float, 0x7F7FFFFFu); }  // 3.4028235e+38
+    OPUS_H_D static constexpr float min()  { return __builtin_bit_cast(float, 0xFF7FFFFFu); }  // -3.4028235e+38
+    OPUS_H_D static constexpr float tiny() { return __builtin_bit_cast(float, 0x00800000u); }  // 2^-126
+};
+template<> struct finfo<fp16_t> {
+    static constexpr int bits = 16;
+    OPUS_H_D static constexpr float eps()  { return __builtin_bit_cast(float, 0x3A800000u); }  // 2^-10 = 9.765625e-4
+    OPUS_H_D static constexpr float max()  { return __builtin_bit_cast(float, 0x477FE000u); }  // 65504.0
+    OPUS_H_D static constexpr float min()  { return __builtin_bit_cast(float, 0xC77FE000u); }  // -65504.0
+    OPUS_H_D static constexpr float tiny() { return __builtin_bit_cast(float, 0x38800000u); }  // 2^-14
+};
+template<> struct finfo<bf16_t> {
+    static constexpr int bits = 16;
+    OPUS_H_D static constexpr float eps()  { return __builtin_bit_cast(float, 0x3C000000u); }  // 2^-7 = 0.0078125
+    OPUS_H_D static constexpr float max()  { return __builtin_bit_cast(float, 0x7F7F0000u); }  // 3.389531e+38
+    OPUS_H_D static constexpr float min()  { return __builtin_bit_cast(float, 0xFF7F0000u); }  // -3.389531e+38
+    OPUS_H_D static constexpr float tiny() { return __builtin_bit_cast(float, 0x00800000u); }  // 2^-126
+};
+// fp8 E4M3: gfx950=OCP(float8_e4m3fn, bias=7), gfx942=fnuz(float8_e4m3fnuz, bias=8)
+template<> struct finfo<fp8_t> {
+    static constexpr int bits = 8;
+    OPUS_H_D static constexpr float eps()  { return __builtin_bit_cast(float, 0x3E000000u); }  // 2^-3 = 0.125
+#if defined(__gfx942__)
+    OPUS_H_D static constexpr float max()  { return __builtin_bit_cast(float, 0x43700000u); }  // 240.0
+    OPUS_H_D static constexpr float min()  { return __builtin_bit_cast(float, 0xC3700000u); }  // -240.0
+    OPUS_H_D static constexpr float tiny() { return __builtin_bit_cast(float, 0x3C000000u); }  // 2^-7 = 0.0078125
+#else
+    OPUS_H_D static constexpr float max()  { return __builtin_bit_cast(float, 0x43E00000u); }  // 448.0
+    OPUS_H_D static constexpr float min()  { return __builtin_bit_cast(float, 0xC3E00000u); }  // -448.0
+    OPUS_H_D static constexpr float tiny() { return __builtin_bit_cast(float, 0x3C800000u); }  // 2^-6 = 0.015625
+#endif
+};
+// bf8 E5M2: gfx950=OCP(float8_e5m2, bias=15), gfx942=fnuz(float8_e5m2fnuz, bias=16)
+template<> struct finfo<bf8_t> {
+    static constexpr int bits = 8;
+#if defined(__gfx942__)
+    OPUS_H_D static constexpr float eps()  { return __builtin_bit_cast(float, 0x3E000000u); }  // 2^-3 = 0.125
+    OPUS_H_D static constexpr float max()  { return __builtin_bit_cast(float, 0x47600000u); }  // 57344.0
+    OPUS_H_D static constexpr float min()  { return __builtin_bit_cast(float, 0xC7600000u); }  // -57344.0
+    OPUS_H_D static constexpr float tiny() { return __builtin_bit_cast(float, 0x38000000u); }  // 2^-15
+#else
+    OPUS_H_D static constexpr float eps()  { return __builtin_bit_cast(float, 0x3E800000u); }  // 2^-2 = 0.25
+    OPUS_H_D static constexpr float max()  { return __builtin_bit_cast(float, 0x47600000u); }  // 57344.0
+    OPUS_H_D static constexpr float min()  { return __builtin_bit_cast(float, 0xC7600000u); }  // -57344.0
+    OPUS_H_D static constexpr float tiny() { return __builtin_bit_cast(float, 0x38800000u); }  // 2^-14
+#endif
+};
+template<> struct finfo<i8_t> {
+    static constexpr int bits = 8;
+    OPUS_H_D static constexpr float max()  { return 127.0f; }
+    OPUS_H_D static constexpr float min()  { return -128.0f; }
+};
+
+template<typename C, typename... S, std::enable_if_t<is_dtype_v<C> && (is_constant_v<S> && ...), bool> = true>
+OPUS_H_D constexpr auto slice(C&& container, S&&.../*ss*/) { return container; }    // TODO: fallback slice a normal value does nonthing
+/////////////////////////////////////////////////////////////////////////////////////////////////////////
+// type cast
+OPUS_D bf16_t fp32_to_bf16_rtn_asm(const float& x) {
+    union { float f; u32_t i; } u = {x}; constexpr u32_t f32_nan = 0x7fff0000; constexpr u32_t round_bias = 0x7fff; u32x2_t check_nan; u32_t tmp;
+    asm volatile("\nv_cmp_u_f32 %0, %2, %2 \nv_bfe_u32 %1, %2, 16, 1 \nv_add3_u32 %1, %2, %1, %3 \nv_cndmask_b32 %2, %1, %4, %0 \nv_lshrrev_b32 %2, 16, %2 \n"
+                 : "=s"(check_nan), "+v"(tmp), "+v"(u.f) : "v"(round_bias), "v"(f32_nan));
+    return bf16_t(u.i);
+}
+
+OPUS_D constexpr auto fp16_to_fp32(const fp16_t& x) { return static_cast<fp32_t>(x); }
+OPUS_D constexpr auto fp32_to_fp16(const fp32_t& x) { return static_cast<fp16_t>(x); }
+OPUS_D constexpr auto bf16_to_fp32(const bf16_t& x) { union { u32_t i; float f; } u = {static_cast<u32_t>(__builtin_bit_cast(unsigned short, x)) << 16}; return u.f;}
+OPUS_D constexpr unsigned short fp32_to_bf16_rtn_raw(float f)
+{
+    unsigned int bits = __builtin_bit_cast(unsigned int, f);
+    if(~bits & 0x7f800000) { bits += 0x7fff + ((bits >> 16) & 1); /* Round to nearest even */ }
+    else if(bits & 0xffff) { bits |= 0x10000; /* Preserve signaling NaN */ }
+    return static_cast<unsigned short>(bits >> 16);
+}
+#if (defined(__gfx950__) || defined(__gfx1250__) || defined(__gfx1201__) || defined(__gfx1200__)) && __clang_major__ >= 20
+template<index_t rm = OPUS_FP32_to_BF16_DEFAULT> // gfx950/gfx1250/gfx12 has instruction conversion, leave 'rm' here for compatiblity
+OPUS_D constexpr auto fp32_to_bf16(const fp32_t& x, number<rm> = {}) { return static_cast<bf16_t>(x); }
+#else
+template<index_t rm = OPUS_FP32_to_BF16_DEFAULT> // 0:standard, 1:truncate_with_nan, 2:truncate, 3:standard asm 4:rta_asm(round to nearest away)
+OPUS_D constexpr auto fp32_to_bf16(const fp32_t& x, number<rm> = {}) {
+    if      constexpr (rm == 0) {return __builtin_bit_cast(bf16_t, fp32_to_bf16_rtn_raw(x)); }
+    else if constexpr (rm == 1) {u32_t z = __builtin_bit_cast(u32_t, x); return __builtin_bit_cast(bf16_t, static_cast<unsigned short>(z | (!(~z & 0x7f800000) && (z & 0xffff) ? 0x10000 : 0) >> 16)); }
+    else if constexpr (rm == 2) {u32_t z = __builtin_bit_cast(u32_t, x); return __builtin_bit_cast(bf16_t, static_cast<unsigned short>(z >> 16)); }
+    else if constexpr (rm == 3) { return fp32_to_bf16_rtn_asm(x); }
+}
+#endif
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wuninitialized"
+#pragma clang diagnostic ignored "-Wc++20-extensions"
+// scalar fp8 <-> fp32 via packed intrinsics (lo slot only). NOT constexpr: clang eagerly rejects non-template
+// constexpr functions containing GPU builtins (__builtin_amdgcn_cvt_*) that can never be compile-time evaluated.
+// Template constexpr (packed variants, OPUS_CAST_DEFINE) survives because the check is deferred to instantiation.
+// TODO: we may remove constexpr from cast in the future
+OPUS_D auto fp32_to_fp8(const fp32_t& x) {
+#if defined(__HIP_DEVICE_COMPILE__) && !(defined(__gfx942__) || defined(__gfx950__) || defined(__gfx1200__) || defined(__gfx1201__) || defined(__gfx1250__))
+    // RDNA3/3.5 (gfx1100/gfx115x) lack fp8-conversion-insts; compile-only
+    // stub so headers build. BF16 code paths never invoke fp8 conversion.
+    (void)x; return __builtin_bit_cast(fp8_t, static_cast<signed char>(0));
+#else
+    int w; w = __builtin_amdgcn_cvt_pk_fp8_f32(x, 0.0f, w, /*sel=lo*/0);
+    return __builtin_bit_cast(fp8_t, static_cast<signed char>(w));
+#endif
+}
+OPUS_D auto fp8_to_fp32(const fp8_t& x) {
+#if defined(__HIP_DEVICE_COMPILE__) && !(defined(__gfx942__) || defined(__gfx950__) || defined(__gfx1200__) || defined(__gfx1201__) || defined(__gfx1250__))
+    (void)x; return fp32_t(0.0f);
+#else
+    int w = static_cast<int>(__builtin_bit_cast(unsigned char, x));
+    return __builtin_amdgcn_cvt_f32_fp8(w, /*byte=*/0);
+#endif
+}
+OPUS_D constexpr auto fp32_to_fp32(const fp32_t& x) { return x; }
+OPUS_D constexpr auto fp32_to_i8(const fp32_t& x) { return static_cast<i8_t>(x); }
+OPUS_D constexpr auto i8_to_fp32(const i8_t& x) { return static_cast<fp32_t>(x); }
+#pragma clang diagnostic pop
+
+#define OPUS_CAST_DEFINE(d_, s_) template<typename D, typename S, typename... Aux, std::enable_if_t<std::is_same_v<S, s_ ## _t> && std::is_same_v<D, d_ ## _t>, bool> = true> \
+                                    OPUS_D constexpr decltype(auto) cast(const S& s, Aux&&... aux) { return s_ ## _to_ ## d_(s, std::forward<Aux>(aux)...); }
+OPUS_CAST_DEFINE(fp16, fp32)
+OPUS_CAST_DEFINE(fp32, fp16)
+OPUS_CAST_DEFINE(bf16, fp32)
+OPUS_CAST_DEFINE(fp32, bf16)
+OPUS_CAST_DEFINE(fp8, fp32)
+OPUS_CAST_DEFINE(fp32, fp8)
+OPUS_CAST_DEFINE(fp32, fp32)
+OPUS_CAST_DEFINE(i8, fp32)
+OPUS_CAST_DEFINE(fp32, i8)
+
+namespace impl {
+// implement a "pack" of data, storage should pad to multiple of byte(8bit)
+template<typename storage_, unsigned int bits_, bool is_signed_ = true>
+struct dpacks {
+    using storage = remove_cvref_t<storage_>;
+    static constexpr unsigned int bits = bits_;
+    static constexpr unsigned int mask = (1 << bits) - 1;
+    static constexpr bool is_signed = is_signed_;
+    static constexpr unsigned int num_packs = sizeof(storage) * 8 / bits;   // we will not check if evenly divided or not here
+    OPUS_H_D                     constexpr storage operator[](index_t i) const { return (value >> (i * bits)) & mask; } // NOTE: not efficient, better use v_bfi/v_bfe/v_perm on device
+    template<index_t I> OPUS_H_D constexpr storage operator[](number<I>) const { return (value >> (I * bits)) & mask; } // NOTE: not efficient, better use v_bfi/v_bfe/v_perm on device
+    storage value;
+};
+
+template<typename storage_, unsigned int bits_, unsigned int exp_bits_, unsigned int mantissa_bits_, bool is_signed_ = true>
+struct fpacks : dpacks<storage_, bits_, is_signed_> {
+    static constexpr unsigned int exp_bits = exp_bits_;
+    static constexpr unsigned int mantissa_bits = mantissa_bits_;
+};
+} // namespace impl
+
+template <typename> struct is_packs : false_type {};
+template <typename S, unsigned int B, bool X> struct is_packs<impl::dpacks<S, B, X>> : true_type {};
+template <typename S, unsigned int B, unsigned int E, unsigned int M, bool X> struct is_packs<impl::fpacks<S, B, E, M, X>> : true_type {};
+template <typename T> static constexpr bool is_packs_v = is_packs<remove_cvref_t<T>>::value;
+
+// how many real data within one byte
+template <typename T, typename = void> struct num_packs { static constexpr int value = 1; };
+template <typename T> struct num_packs<T, std::enable_if_t<is_packs_v<T>>> { static constexpr int value = T::num_packs; };
+template <typename T> static constexpr int num_packs_v = num_packs<T>::value;
+
+template <typename T> struct sizeof_bits { static constexpr int value = int(sizeof(T) * 8); };
+template <> struct sizeof_bits<void> { static constexpr int value = 0; };
+template <typename S, unsigned int B, bool X> struct sizeof_bits<impl::dpacks<S, B, X>> { static constexpr int value = impl::dpacks<S, B, X>::bits; };
+template <typename S, unsigned int B, unsigned int E, unsigned int M, bool X> struct sizeof_bits<impl::fpacks<S, B, E, M, X>> { static constexpr int value = impl::fpacks<S, B, E, M, X>::bits; };
+template <class T> static constexpr auto sizeof_bits_v = sizeof_bits<T>::value;
+
+#define OPUS_DEFINE_DPACKS(name_, storage_, bits_, is_signed_) \
+    struct name_ : opus::impl::dpacks<storage_, bits_, is_signed_> { using base = opus::impl::dpacks<storage_, bits_, is_signed_>; };  \
+    template<> struct sizeof_bits<name_> { static constexpr int value = name_::bits; }; template<> struct is_packs<name_> : true_type {}; template<> struct is_dtype<name_> : true_type {};
+
+#define OPUS_DEFINE_FPACKS(name_, storage_, bits_, exp_bits_, mantissa_bits_, is_signed_) \
+    struct name_ : opus::impl::fpacks<storage_, bits_, exp_bits_, mantissa_bits_, is_signed_> {using base = opus::impl::fpacks<storage_, bits_, exp_bits_, mantissa_bits_, is_signed_>; };  \
+    template<> struct sizeof_bits<name_> { static constexpr int value = name_::bits; }; template<> struct is_packs<name_> : true_type {}; template<> struct is_dtype<name_> : true_type {};
+
+// NOTE: convention here. The subbyte type below is indeed "packed" data. e.g. fp4_t, underneath it is fp4x2 in one byte, but we don't name it this way
+// This is different from cutlass convention (e.g float4_e2m1_t, but storage is unsigned char, hence an array of float4_e2m1_t will be expanded), and different from ck convention(explicitly name it fp4x2_t)
+OPUS_DEFINE_DPACKS(int4_t , unsigned char, 4, true)           // int4x2
+OPUS_DEFINE_DPACKS(uint4_t, unsigned char, 4, false)          // uint4x2
+OPUS_DEFINE_FPACKS(fp4_t,   unsigned char, 4, 2, 1, true)     // fp4x2
+OPUS_DEFINE_FPACKS(e8m0_t,  unsigned char, 8, 8, 0, false)    // fp4x2
+
+// finfo specializations for subbyte/packed types (defined after OPUS_DEFINE_FPACKS)
+// fp4 E2M1: 1 sign, 2 exp, 1 mantissa, bias=1
+template<> struct finfo<fp4_t> {
+    static constexpr int bits = 4;
+    OPUS_H_D static constexpr float eps()  { return __builtin_bit_cast(float, 0x3F000000u); }  // 2^-1 = 0.5
+    OPUS_H_D static constexpr float max()  { return __builtin_bit_cast(float, 0x40C00000u); }  // 6.0
+    OPUS_H_D static constexpr float min()  { return __builtin_bit_cast(float, 0xC0C00000u); }  // -6.0
+    OPUS_H_D static constexpr float tiny() { return __builtin_bit_cast(float, 0x3F800000u); }  // 1.0
+};
+// e8m0: 8-bit exponent only, unsigned, bias=127
+template<> struct finfo<e8m0_t> {
+    static constexpr int bits = 8;
+    OPUS_H_D static constexpr float eps()  { return __builtin_bit_cast(float, 0x3F800000u); }  // 1.0
+    OPUS_H_D static constexpr float max()  { return __builtin_bit_cast(float, 0x7F000000u); }  // 2^127
+    OPUS_H_D static constexpr float min()  { return __builtin_bit_cast(float, 0x00400000u); }  // 2^-127 (unsigned, no negative)
+    OPUS_H_D static constexpr float tiny() { return __builtin_bit_cast(float, 0x00400000u); }  // 2^-127
+};
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wuninitialized"
+#pragma clang diagnostic ignored "-Wc++20-extensions"
+template<typename S, index_t sel = 0, std::enable_if_t<std::is_same_v<S, fp32x2_t>, bool> = true>
+OPUS_D constexpr decltype(auto) fp32_to_fp8_packed_x2(const S& s, number<sel> = {}) {
+    int w ; w = __builtin_amdgcn_cvt_pk_fp8_f32(s[0], s[1], w, sel);
+    return __builtin_bit_cast(fp8x2_t, static_cast<short>(w));
+}
+template<typename S, std::enable_if_t<std::is_same_v<S, fp32x4_t>, bool> = true>
+OPUS_D constexpr decltype(auto) fp32_to_fp8_packed_x4(const S& s) {
+    int w ; w = __builtin_amdgcn_cvt_pk_fp8_f32(s[0], s[1], w, 0); w = __builtin_amdgcn_cvt_pk_fp8_f32(s[2], s[3], w, 1);
+    return __builtin_bit_cast(fp8x4_t, w);
+}
+template<typename S, index_t sel = 0, std::enable_if_t<std::is_same_v<S, fp8x2_t>, bool> = true>
+OPUS_D constexpr decltype(auto) fp8_to_fp32_packed_x2(const S& s, number<sel> = {}) {
+    union { int bitwise; S f8_packs[2]; } value; value.f8_packs[0] = s;
+    return __builtin_amdgcn_cvt_pk_f32_fp8(value.bitwise, sel);
+}
+template<typename S, std::enable_if_t<std::is_same_v<S, fp8x4_t>, bool> = true>
+OPUS_D constexpr decltype(auto) fp8_to_fp32_packed_x4(const S& s) {
+    int bitwise = __builtin_bit_cast(int, s);
+    auto x = __builtin_amdgcn_cvt_pk_f32_fp8(bitwise, 0); auto y = __builtin_amdgcn_cvt_pk_f32_fp8(bitwise, 1);
+    return fp32x4_t{x[0], x[1], y[0], y[1]};
+}
+
+namespace impl {
+template<typename S, index_t... Xs>     OPUS_D constexpr decltype(auto) fold_as_tuple_of_vec(const S& s, seq<Xs...>) {
+    static_assert(size<S>() % sizeof...(Xs) == 0);
+    constexpr index_t Y_len = size<S>() / sizeof...(Xs);
+    auto gen_ = [&]<index_t X, index_t... Ys>(number<X>, seq<Ys...>){ return vector_t<get_value_t<S>, Y_len>{get<X * Y_len + Ys>(s)...}; };
+    return make_tuple(gen_(number<Xs>{}, make_index_seq<Y_len>{})...);
+}
+template<typename S, index_t... Xs>     OPUS_D constexpr decltype(auto) fold_as_tuple_of_arr(const S& s, seq<Xs...>) {
+    static_assert(size<S>() % sizeof...(Xs) == 0);
+    constexpr index_t Y_len = size<S>() / sizeof...(Xs);
+    auto gen_ = [&]<index_t X, index_t... Ys>(number<X>, seq<Ys...>){ return array<get_value_t<S>, Y_len>{get<X * Y_len + Ys>(s)...}; };
+    return make_tuple(gen_(number<Xs>{}, make_index_seq<Y_len>{})...);
+}
+template<typename S, index_t fold_size, std::enable_if_t<is_tuple_v<S> || is_vector_v<S> || is_array_v<S>, bool> = true>
+OPUS_D constexpr decltype(auto) fold_as_container_of_vec(const S& s, number<fold_size>) {
+    static_assert(size<S>() % fold_size == 0);
+    return fold_as_tuple_of_vec(s, make_index_seq<size<S>() / fold_size>{});
+}
+template<typename S, index_t fold_size, std::enable_if_t<is_tuple_v<S> || is_vector_v<S> || is_array_v<S>, bool> = true>
+OPUS_D constexpr decltype(auto) fold_as_container_of_arr(const S& s, number<fold_size>) {
+    static_assert(size<S>() % fold_size == 0);
+    return fold_as_tuple_of_arr(s, make_index_seq<size<S>() / fold_size>{});
+}
+
+// Unfold a tuple-of-sub-results (produced by auto-fold cast) back into a flat container. Used in pair with above
+// matching the original input container type OrigS.
+//   OrigS is vector  -> flat vector_t<elem, total>
+//   OrigS is array   -> flat array<elem, total>
+//   OrigS is tuple   -> flat tuple<elem, elem, ...>
+template<typename Tup, index_t inner_n, index_t... Flat>
+OPUS_D constexpr auto unfold_as_tuple(const Tup& tup, number<inner_n>, seq<Flat...>) { return make_tuple(get<Flat % inner_n>(getv<Flat / inner_n>(tup))...); }
+
+template<typename OrigS, typename Tup, std::enable_if_t<is_tuple_v<Tup>, bool> = true>
+OPUS_D constexpr auto unfold_from_container(const Tup& tup) {
+    using inner_t = remove_cvref_t<decltype(getv<0>(tup))>;
+    using elem_t = get_value_t<inner_t>;
+    constexpr index_t outer_n = opus::size<Tup>();
+    constexpr index_t inner_n = opus::size<inner_t>();
+    constexpr index_t total_n = outer_n * inner_n;
+    if constexpr (is_vector_v<OrigS>) { vector_t<elem_t, total_n> r; static_for<total_n>([&](auto f) { r[f.value] = get<f.value % inner_n>(getv<f.value / inner_n>(tup)); }); return r; }
+    else if constexpr (is_array_v<OrigS>) { array<elem_t, total_n> r; static_for<total_n>([&](auto f) { r[f.value] = get<f.value % inner_n>(getv<f.value / inner_n>(tup)); }); return r; }
+    else { /* tuple */  return unfold_as_tuple(tup, number<inner_n>{}, make_index_seq<total_n>{}); }
+}
+} // namespace impl
+#if defined(__gfx950__)
+template<typename S, index_t sel = 0, std::enable_if_t<std::is_same_v<S, fp32x2_t>, bool> = true>
+OPUS_D constexpr decltype(auto) fp32_to_fp4_packed_x2(const S& s, float scale = 1.0f, number<sel> = {}) {
+    u32_t w; w = __builtin_amdgcn_cvt_scalef32_pk_fp4_f32(w, s[0], s[1], scale, sel);
+    return __builtin_bit_cast(array<fp4_t, 1>, static_cast<u8_t>(w));
+}
+template<typename S, std::enable_if_t<std::is_same_v<S, fp32x4_t>, bool> = true>
+OPUS_D constexpr decltype(auto) fp32_to_fp4_packed_x4(const S& s, float scale = 1.0f) {
+    u32_t w; w = __builtin_amdgcn_cvt_scalef32_pk_fp4_f32(w, s[0], s[1], scale, 0); w = __builtin_amdgcn_cvt_scalef32_pk_fp4_f32(w, s[2], s[3], scale, 1);
+    return __builtin_bit_cast(array<fp4_t, 2>, static_cast<u16_t>(w));
+}
+template<typename S, std::enable_if_t<std::is_same_v<S, fp32x8_t>, bool> = true>
+OPUS_D constexpr decltype(auto) fp32_to_fp4_packed_x8(const S& s, float scale = 1.0f) {
+    u32_t w; w = __builtin_amdgcn_cvt_scalef32_pk_fp4_f32(w, s[0], s[1], scale, 0); w = __builtin_amdgcn_cvt_scalef32_pk_fp4_f32(w, s[2], s[3], scale, 1);
+    w = __builtin_amdgcn_cvt_scalef32_pk_fp4_f32(w, s[4], s[5], scale, 2); w = __builtin_amdgcn_cvt_scalef32_pk_fp4_f32(w, s[6], s[7], scale, 3);
+    return __builtin_bit_cast(array<fp4_t, 4>, w);
+}
+template<typename S, index_t sel = 0, std::enable_if_t<is_any_of_v<S, fp4_t, array<fp4_t, 1>>, bool> = true>
+OPUS_D constexpr decltype(auto) fp4_to_fp32_packed_x2(const S& s, float scale = 1.0f, number<sel> = {}) {
+    return __builtin_amdgcn_cvt_scalef32_pk_f32_fp4(static_cast<u32_t>(__builtin_bit_cast(u8_t, s)), scale, sel);
+}
+template<typename S, std::enable_if_t<std::is_same_v<S, array<fp4_t, 2>>, bool> = true>
+OPUS_D constexpr decltype(auto) fp4_to_fp32_packed_x4(const S& s, float scale = 1.0f) {
+    auto ss = static_cast<u32_t>(__builtin_bit_cast(u16_t, s));
+    auto x = __builtin_amdgcn_cvt_scalef32_pk_f32_fp4(ss, scale, 0); auto y = __builtin_amdgcn_cvt_scalef32_pk_f32_fp4(ss, scale, 1);
+    return fp32x4_t{x[0], x[1], y[0], y[1]};
+}
+template<typename S, std::enable_if_t<std::is_same_v<S, array<fp4_t, 4>>, bool> = true>
+OPUS_D constexpr decltype(auto) fp4_to_fp32_packed_x8(const S& s, float scale = 1.0f) {
+    auto ss = static_cast<u32_t>(__builtin_bit_cast(u32_t, s));
+    auto x = __builtin_amdgcn_cvt_scalef32_pk_f32_fp4(ss, scale, 0); auto y = __builtin_amdgcn_cvt_scalef32_pk_f32_fp4(ss, scale, 1);
+    auto z = __builtin_amdgcn_cvt_scalef32_pk_f32_fp4(ss, scale, 2); auto w = __builtin_amdgcn_cvt_scalef32_pk_f32_fp4(ss, scale, 3);
+    return fp32x8_t{x[0], x[1], y[0], y[1], z[0], z[1], w[0], w[1]};
+}
+
+template<typename S, index_t sel = 0, std::enable_if_t<std::is_same_v<S, bf16x2_t>, bool> = true>
+OPUS_D constexpr decltype(auto) bf16_to_fp4_packed_x2(const S& s, float scale = 1.0f, number<sel> = {}) {
+    union { unsigned int bitwise; fp4_t fp4_pack[4]; } value;
+    value.bitwise = __builtin_amdgcn_cvt_scalef32_pk_fp4_bf16(value.bitwise, s, scale, sel);
+    return value.fp4_pack[0];
+}
+template<typename S, index_t sel = 0, std::enable_if_t<std::is_same_v<S, fp4_t>, bool> = true>
+OPUS_D constexpr decltype(auto) fp4_to_bf16_packed_x2(const S& s, float scale = 1.0f, number<sel> = {}) { return __builtin_amdgcn_cvt_scalef32_pk_bf16_fp4(s, scale, sel); }
+#elif defined(__gfx1250__)
+// gfx1250: pk8 builtins convert 8 fp4 <-> 8 f32 at once
+// f32->fp4: __builtin_amdgcn_cvt_scalef32_pk8_fp4_f32(v8f32 src, float scale) -> i32
+// fp4->f32: __builtin_amdgcn_cvt_scale_pk8_f32_fp4(i32 src, i32 scale_sel, i32 imm) -> v8f32
+//   scale_sel = e8m0 scale byte (imm selects which byte), e8m0: val = 2^(byte-127), so 1.0 = 0x7F
+//   extract e8m0 from float: biased exponent = (float_bits >> 23) & 0xFF
+template<typename S, index_t sel = 0, std::enable_if_t<std::is_same_v<S, fp32x2_t>, bool> = true>
+OPUS_D constexpr decltype(auto) fp32_to_fp4_packed_x2(const S& s, float scale = 1.0f, number<sel> = {}) {
+    fp32x8_t v{s[0], s[1], 0, 0, 0, 0, 0, 0};
+    u32_t w = __builtin_amdgcn_cvt_scalef32_pk8_fp4_f32(v, scale);
+    return __builtin_bit_cast(array<fp4_t, 1>, static_cast<u8_t>(w));
+}
+template<typename S, std::enable_if_t<std::is_same_v<S, fp32x4_t>, bool> = true>
+OPUS_D constexpr decltype(auto) fp32_to_fp4_packed_x4(const S& s, float scale = 1.0f) {
+    fp32x8_t v{s[0], s[1], s[2], s[3], 0, 0, 0, 0};
+    u32_t w = __builtin_amdgcn_cvt_scalef32_pk8_fp4_f32(v, scale);
+    return __builtin_bit_cast(array<fp4_t, 2>, static_cast<u16_t>(w));
+}
+template<typename S, std::enable_if_t<std::is_same_v<S, fp32x8_t>, bool> = true>
+OPUS_D constexpr decltype(auto) fp32_to_fp4_packed_x8(const S& s, float scale = 1.0f) {
+    u32_t w = __builtin_amdgcn_cvt_scalef32_pk8_fp4_f32(s, scale);
+    return __builtin_bit_cast(array<fp4_t, 4>, w);
+}
+template<typename S, index_t sel = 0, std::enable_if_t<is_any_of_v<S, fp4_t, array<fp4_t, 1>>, bool> = true>
+OPUS_D constexpr decltype(auto) fp4_to_fp32_packed_x2(const S& s, float scale = 1.0f, number<sel> = {}) {
+    i32_t e = (__builtin_bit_cast(i32_t, scale) >> 23) & 0xFF;
+    i32_t scale_e8m0 = e * static_cast<i32_t>(0x01010101);
+    fp32x8_t r = __builtin_amdgcn_cvt_scale_pk8_f32_fp4(static_cast<i32_t>(__builtin_bit_cast(u8_t, s)), scale_e8m0, 0);
+    return fp32x2_t{r[0], r[1]};
+}
+template<typename S, std::enable_if_t<std::is_same_v<S, array<fp4_t, 2>>, bool> = true>
+OPUS_D constexpr decltype(auto) fp4_to_fp32_packed_x4(const S& s, float scale = 1.0f) {
+    i32_t e = (__builtin_bit_cast(i32_t, scale) >> 23) & 0xFF;
+    i32_t scale_e8m0 = e * static_cast<i32_t>(0x01010101);
+    fp32x8_t r = __builtin_amdgcn_cvt_scale_pk8_f32_fp4(static_cast<i32_t>(__builtin_bit_cast(u16_t, s)), scale_e8m0, 0);
+    return fp32x4_t{r[0], r[1], r[2], r[3]};
+}
+template<typename S, std::enable_if_t<std::is_same_v<S, array<fp4_t, 4>>, bool> = true>
+OPUS_D constexpr decltype(auto) fp4_to_fp32_packed_x8(const S& s, float scale = 1.0f) {
+    i32_t e = (__builtin_bit_cast(i32_t, scale) >> 23) & 0xFF;
+    i32_t scale_e8m0 = e * static_cast<i32_t>(0x01010101);
+    fp32x8_t r = __builtin_amdgcn_cvt_scale_pk8_f32_fp4(static_cast<i32_t>(__builtin_bit_cast(u32_t, s)), scale_e8m0, 0);
+    return fp32x8_t{r[0], r[1], r[2], r[3], r[4], r[5], r[6], r[7]};
+}
+// bf16<->fp4 stubs for gfx1250 (no pk bf16<->fp4 builtins available)
+template<typename S, index_t sel = 0, std::enable_if_t<std::is_same_v<S, bf16x2_t>, bool> = true>
+OPUS_D constexpr decltype(auto) bf16_to_fp4_packed_x2(const S& /*s*/, float /*scale*/ = 1.0f, number<sel> = {}) { return fp4_t{}; }
+template<typename S, index_t sel = 0, std::enable_if_t<std::is_same_v<S, fp4_t>, bool> = true>
+OPUS_D constexpr decltype(auto) fp4_to_bf16_packed_x2(const S& /*s*/, float /*scale*/ = 1.0f, number<sel> = {}) { return bf16x2_t{}; }
+#else
+template<typename S, std::enable_if_t<std::is_same_v<S, fp32x2_t>, bool> = true>  OPUS_D constexpr decltype(auto) fp32_to_fp4_packed_x2(const S& /*s*/, float /*scale*/ = 1.0f) { return array<fp4_t, 1>{}; }
+template<typename S, std::enable_if_t<std::is_same_v<S, fp32x4_t>, bool> = true>  OPUS_D constexpr decltype(auto) fp32_to_fp4_packed_x4(const S& /*s*/, float /*scale*/ = 1.0f) { return array<fp4_t, 2>{}; }
+template<typename S, std::enable_if_t<std::is_same_v<S, fp32x8_t>, bool> = true>  OPUS_D constexpr decltype(auto) fp32_to_fp4_packed_x8(const S& /*s*/, float /*scale*/ = 1.0f) { return array<fp4_t, 4>{}; }
+template<typename S, std::enable_if_t<is_any_of_v<S, fp4_t, array<fp4_t, 1>>, bool> = true>     OPUS_D constexpr decltype(auto) fp4_to_fp32_packed_x2(const S& /*s*/, float /*scale*/ = 1.0f) { return fp32x2_t{}; }
+template<typename S, std::enable_if_t<std::is_same_v<S, array<fp4_t, 2>>, bool> = true>     OPUS_D constexpr decltype(auto) fp4_to_fp32_packed_x4(const S& /*s*/, float /*scale*/ = 1.0f) { return fp32x4_t{}; }
+template<typename S, std::enable_if_t<std::is_same_v<S, array<fp4_t, 4>>, bool> = true>     OPUS_D constexpr decltype(auto) fp4_to_fp32_packed_x8(const S& /*s*/, float /*scale*/ = 1.0f) { return fp32x8_t{}; }
+template<typename S, std::enable_if_t<std::is_same_v<S, bf16x2_t>, bool> = true>  OPUS_D constexpr decltype(auto) bf16_to_fp4_packed_x2(const S& /*s*/, float /*scale*/ = 1.0f) { return fp4_t{}; }
+template<typename S, std::enable_if_t<std::is_same_v<S, fp4_t>, bool> = true>     OPUS_D constexpr decltype(auto) fp4_to_bf16_packed_x2(const S& /*s*/, float /*scale*/ = 1.0f) { return bf16x2_t{}; }
+#endif
+#pragma clang diagnostic pop
+
+template<typename D, typename S, typename... Aux, std::enable_if_t<std::is_same_v<S, fp32x2_t> && std::is_same_v<D, fp8_t>, bool> = true>
+OPUS_D constexpr decltype(auto) cast(const S& s, Aux&&... aux) { return fp32_to_fp8_packed_x2(s, std::forward<Aux>(aux)...); }
+template<typename D, typename S, typename... Aux, std::enable_if_t<std::is_same_v<S, fp32x4_t> && std::is_same_v<D, fp8_t>, bool> = true>
+OPUS_D constexpr decltype(auto) cast(const S& s, Aux&&... aux) { return fp32_to_fp8_packed_x4(s, std::forward<Aux>(aux)...); }
+template<typename D, typename S, typename... Aux, std::enable_if_t<std::is_same_v<S, fp8x2_t> && std::is_same_v<D, fp32_t>, bool> = true>
+OPUS_D constexpr decltype(auto) cast(const S& s, Aux&&... aux) { return fp8_to_fp32_packed_x2(s, std::forward<Aux>(aux)...); }
+template<typename D, typename S, typename... Aux, std::enable_if_t<std::is_same_v<S, fp8x4_t> && std::is_same_v<D, fp32_t>, bool> = true>
+OPUS_D constexpr decltype(auto) cast(const S& s, Aux&&... aux) { return fp8_to_fp32_packed_x4(s, std::forward<Aux>(aux)...); }
+
+template<typename D, typename S, typename... Aux, std::enable_if_t<std::is_same_v<S, fp32x2_t> && std::is_same_v<D, fp4_t>, bool> = true>
+OPUS_D constexpr decltype(auto) cast(const S& s, Aux&&... aux) { return fp32_to_fp4_packed_x2(s, std::forward<Aux>(aux)...); }
+template<typename D, typename S, typename... Aux, std::enable_if_t<std::is_same_v<S, fp32x4_t> && std::is_same_v<D, fp4_t>, bool> = true>
+OPUS_D constexpr decltype(auto) cast(const S& s, Aux&&... aux) { return fp32_to_fp4_packed_x4(s, std::forward<Aux>(aux)...); }
+template<typename D, typename S, typename... Aux, std::enable_if_t<std::is_same_v<S, fp32x8_t> && std::is_same_v<D, fp4_t>, bool> = true>
+OPUS_D constexpr decltype(auto) cast(const S& s, Aux&&... aux) { return fp32_to_fp4_packed_x8(s, std::forward<Aux>(aux)...); }
+template<typename D, typename S, typename... Aux, std::enable_if_t<is_any_of_v<S, fp4_t, array<fp4_t, 1>> && std::is_same_v<D, fp32_t>, bool> = true>
+OPUS_D constexpr decltype(auto) cast(const S& s, Aux&&... aux) { return fp4_to_fp32_packed_x2(s, std::forward<Aux>(aux)...); }
+template<typename D, typename S, typename... Aux, std::enable_if_t<std::is_same_v<S, array<fp4_t, 2>> && std::is_same_v<D, fp32_t>, bool> = true>
+OPUS_D constexpr decltype(auto) cast(const S& s, Aux&&... aux) { return fp4_to_fp32_packed_x4(s, std::forward<Aux>(aux)...); }
+template<typename D, typename S, typename... Aux, std::enable_if_t<std::is_same_v<S, array<fp4_t, 4>> && std::is_same_v<D, fp32_t>, bool> = true>
+OPUS_D constexpr decltype(auto) cast(const S& s, Aux&&... aux) { return fp4_to_fp32_packed_x8(s, std::forward<Aux>(aux)...); }
+
+namespace impl {
+// rocm-7.1.1, when there are multiple invokes of this kernel (across different __global__ in same compile target ?) will fail to inline below function
+template<typename D, typename S, index_t... Is, typename... Aux, std::enable_if_t<is_vector_v<S>, bool> = true>
+OPUS_D constexpr decltype(auto) cast_impl(const S& s, seq<Is...>, Aux&&... aux) {
+    return impl::vector_return_type<D, decltype(cast<D>(get<Is>(s), std::forward<Aux>(aux)...))...>{cast<D>(get<Is>(s), std::forward<Aux>(aux)...)...}; }
+    //return opus::make_vector(cast<D>(get<Is>(s), std::forward<Aux>(aux)...)...); }
+template<typename D, typename S, index_t... Is, typename... Aux, std::enable_if_t<is_tuple_v<S>, bool> = true>
+OPUS_D constexpr decltype(auto) cast_impl(const S& s, seq<Is...>, Aux&&... aux) {
+    return tuple<remove_cvref_t<decltype(cast<D>(get<Is>(s), std::forward<Aux>(aux)...))>...>(cast<D>(get<Is>(s), std::forward<Aux>(aux)...)...); }
+    // return opus::make_tuple(cast<D>(get<Is>(s), std::forward<Aux>(aux)...) ...   ); }
+template<typename D, typename S, index_t... Is, typename... Aux, std::enable_if_t<is_array_v<S>, bool> = true>
+OPUS_D constexpr decltype(auto) cast_impl(const S& s, seq<Is...>, Aux&&... aux) {
+    return impl::array_return_type<void, decltype(cast<D>(get<Is>(s), std::forward<Aux>(aux)...))...>{cast<D>(get<Is>(s), std::forward<Aux>(aux)...)...}; }
+    // return opus::make_array(cast<D>(get<Is>(s), std::forward<Aux>(aux)...)...); }
+}
+
+// entry point for vectorized cast(), non-dpacks
+template<typename D, typename S, typename... Aux, std::enable_if_t<((is_vector_v<S> || is_tuple_v<S> || is_array_v<S>) && !is_packs_v<D> && !is_packs_v<get_value_t<S>>)
+    && !(is_any_of_v<S, fp32x2_t, fp32x4_t>&& std::is_same_v<D, fp8_t >)
+    && !(is_any_of_v<S, fp8x2_t , fp8x4_t >&& std::is_same_v<D, fp32_t>)
+, bool> = true>
+OPUS_D constexpr decltype(auto) cast(const S& s, Aux&&... aux) {
+    if      constexpr (std::is_same_v<get_value_t<S>, fp32_t> && size<S>() % 4 == 0 && std::is_same_v<D, fp8_t>) { // fp32 -> fp8 , x4N
+                    return impl::unfold_from_container<S>(impl::cast_impl<D>(impl::fold_as_container_of_vec(s, number<4>{}), make_index_seq<size<S>() / 4>{}, std::forward<Aux>(aux)...)); }
+    else if constexpr (std::is_same_v<get_value_t<S>, fp32_t> && size<S>() % 2 == 0 && std::is_same_v<D, fp8_t>) { // fp32 -> fp8 , x2N
+                    return impl::unfold_from_container<S>(impl::cast_impl<D>(impl::fold_as_container_of_vec(s, number<2>{}), make_index_seq<size<S>() / 2>{}, std::forward<Aux>(aux)...)); }
+    else if constexpr (std::is_same_v<get_value_t<S>, fp8_t>  && size<S>() % 4 == 0 && std::is_same_v<D, fp32_t>) { // fp8 -> fp32, x4N
+                    return impl::unfold_from_container<S>(impl::cast_impl<D>(impl::fold_as_container_of_vec(s, number<4>{}), make_index_seq<size<S>() / 4>{}, std::forward<Aux>(aux)...)); }
+    else if constexpr (std::is_same_v<get_value_t<S>, fp8_t>  && size<S>() % 2 == 0 && std::is_same_v<D, fp32_t>) { // fp8 -> fp32, x2N
+                    return impl::unfold_from_container<S>(impl::cast_impl<D>(impl::fold_as_container_of_vec(s, number<2>{}), make_index_seq<size<S>() / 2>{}, std::forward<Aux>(aux)...)); }
+    else if constexpr (is_vector_v<S> && size<S>() > 16 && sizeof...(Aux) == 0) {
+        return __builtin_convertvector(s, vector_t<D, size<S>()>); }
+    else   return impl::cast_impl<D>(s, make_index_seq<size<S>()>{}, std::forward<Aux>(aux)...); }
+
+// entry point for vectorized cast(), for dpacks
+template<typename D, typename S, typename... Aux, std::enable_if_t<((is_vector_v<S> || is_tuple_v<S> || is_array_v<S>) && (is_packs_v<D> || is_packs_v<get_value_t<S>>))
+    && !(is_any_of_v<S, fp32x2_t, fp32x4_t, fp32x8_t> && std::is_same_v<D, fp4_t >)         // fp32
+    && !(is_any_of_v<S, fp4_t, array<fp4_t, 1>, array<fp4_t, 2>, array<fp4_t, 4>, tuple_array<fp4_t, 1>, tuple_array<fp4_t, 2>, tuple_array<fp4_t, 4>> && std::is_same_v<D, fp32_t>)
+, bool> = true>
+OPUS_D constexpr decltype(auto) cast(const S& s, Aux&&... aux) {
+    constexpr index_t num_packs_ = [&](){   // TODO: how to consider both D and S are packs?
+        if constexpr (is_packs_v<D>) { static_assert(size<S>() % D::num_packs == 0); return D::num_packs; } // TODO: do not support cast pack data one by one
+        else                         { return get_value_t<S>::num_packs; } }();
+    if      constexpr (std::is_same_v<get_value_t<S>, fp32_t> && size<S>() % 8 == 0 && std::is_same_v<D, fp4_t>) { // fp32 -> fp4 , x8N
+                    return impl::unfold_from_container<S>(impl::cast_impl<D>(impl::fold_as_container_of_vec(s, number<8>{}), make_index_seq<size<S>() / 8>{}, std::forward<Aux>(aux)...)); }
+    else if constexpr (std::is_same_v<get_value_t<S>, fp32_t> && size<S>() % 4 == 0 && std::is_same_v<D, fp4_t>) { // fp32 -> fp4 , x4N
+                    return impl::unfold_from_container<S>(impl::cast_impl<D>(impl::fold_as_container_of_vec(s, number<4>{}), make_index_seq<size<S>() / 4>{}, std::forward<Aux>(aux)...)); }
+    else if constexpr (std::is_same_v<get_value_t<S>, fp32_t> && size<S>() % 2 == 0 && std::is_same_v<D, fp4_t>) { // fp32 -> fp4 , x2N
+                    return impl::unfold_from_container<S>(impl::cast_impl<D>(impl::fold_as_container_of_vec(s, number<2>{}), make_index_seq<size<S>() / 2>{}, std::forward<Aux>(aux)...)); }
+    else if constexpr (std::is_same_v<get_value_t<S>, fp4_t> && size<S>() % 4 == 0) { // fp4 -> fp32 , x8N
+                    return impl::unfold_from_container<S>(impl::cast_impl<D>(impl::fold_as_container_of_arr(s, number<4>{}), make_index_seq<size<S>() / 4>{}, std::forward<Aux>(aux)...)); }
+    else if constexpr (std::is_same_v<get_value_t<S>, fp4_t> && size<S>() % 2 == 0) { // fp4 -> fp32 , x4N
+                    return impl::unfold_from_container<S>(impl::cast_impl<D>(impl::fold_as_container_of_arr(s, number<2>{}), make_index_seq<size<S>() / 2>{}, std::forward<Aux>(aux)...)); }
+    else            return impl::unfold_from_container<S>(impl::cast_impl<D>(impl::fold_as_container_of_vec(s, number<num_packs_>{}), make_index_seq<size<S>() / num_packs_>{}, std::forward<Aux>(aux)...));
+}
+
+#undef OPUS_DEFINE_DPACKS
+#undef OPUS_DEFINE_FPACKS
+#undef OPUS_CAST_DEFINE
+/////////////////////////////////////////////////////////////////////////////////////////////////////////
+// arch
+//
+// ---- HIPCC compilation model (clang-based)  ----
+//   hipcc compiles each translation unit in TWO passes: host pass, then device pass.
+//
+//   Host pass  : __device__ functions are fully parsed, name-resolved, template-instantiated, and constexpr/static_assert evaluated. Only machine code generation is skipped.
+//   Device pass: __host__ functions are truly skipped -- not parsed, not instantiated, not checked.
+//
+//   Key consequences:
+//     1. Architecture macros (__GFX9__, __gfx950__, etc.) are defined ONLY during the device pass. Any #if guard on them will take the #else branch during the host pass.
+//     2. __device__ constexpr variables and static_asserts inside __device__ templates are still evaluated during the host pass (since templates may be instantiated from __global__).
+//     3. If your device code relies on arch-specific preprocessor branches, consider guarding the entire implementation with #if defined(__HIP_DEVICE_COMPILE__) to skip the host pass.
+//
+// ---- get_warp_size() / get_smem_size() ----
+//   OPUS_H_D constexpr -- safe to use everywhere: template defaults, static_assert, constexpr variables, __shared__ array sizes, host launch-parameter calculations, etc.
+//   During the host pass (arch macros absent), they return safe defaults:
+//     get_warp_size() -> 64 (GFX9 default), 32 for gfx1250 (wave32)
+//     get_smem_size() -> 65536 (64 KB, non-gfx950 default)
+//   Note: __builtin_amdgcn_wavefrontsize() is NOT constexpr in clang, so it cannot be used in template arguments, static_assert, or if constexpr. Prefer get_warp_size() which uses
+//   preprocessor arch detection to provide a constexpr result.
+//
+// ---- query_warp_size() / query_smem_size() ----
+//   OPUS_H only -- runtime HIP API queries (hipGetDeviceProperties). Use when you need the true hardware value on the host (e.g. occupancy calculations).
+//   Guarded by OPUS_ENABLE_RUNTIME_QUERY (default 0). Define OPUS_ENABLE_RUNTIME_QUERY=1 before
+//   including opus.hpp (or via compiler flag) to enable these functions and the hip_runtime_api.h include.
+//
+// gfx12 wave32/64 detection: __AMDGCN_WAVEFRONT_SIZE__ removed in ROCm 7.2; _w32 builtins are gated by wavefrontsize32 target feature, so __has_builtin is a constexpr proxy.
+#if (defined(__gfx1201__) || defined(__gfx1200__)) && defined(__HIP_DEVICE_COMPILE__)
+#  if __has_builtin(__builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12)
+#    define OPUS_GFX120X_IS_WAVE32 1
+#  else
+#    define OPUS_GFX120X_IS_WAVE32 0
+#  endif
+#endif
+
+OPUS_H_D constexpr index_t get_warp_size()
+{
+#if defined(__gfx1250__)
+    return 32;
+#elif defined(__GFX9__) || !defined(__HIP_DEVICE_COMPILE__)
+    return 64;
+#elif defined(OPUS_GFX120X_IS_WAVE32) && !OPUS_GFX120X_IS_WAVE32
+    return 64;
+#else
+    return 32;
+#endif
+}
+OPUS_H_D constexpr index_t get_smem_size()
+{
+#if defined(__gfx950__)
+    return 163840;  // 160KB (CDNA4)
+#else
+    return 65536;   // 64KB
+#endif
+}
+
+// ---- Device intrinsic wrappers ----
+// Replace HIP runtime macros (threadIdx.x, __syncthreads, __all, etc.) so kernels compile
+// with just #include <opus/opus.hpp> -- no <hip/hip_runtime.h> needed.
+OPUS_D index_t thread_id_x() { return __builtin_amdgcn_workitem_id_x(); }
+OPUS_D index_t thread_id_y() { return __builtin_amdgcn_workitem_id_y(); }
+OPUS_D index_t thread_id_z() { return __builtin_amdgcn_workitem_id_z(); }
+OPUS_D index_t block_id_x()  { return __builtin_amdgcn_workgroup_id_x(); }
+OPUS_D index_t block_id_y()  { return __builtin_amdgcn_workgroup_id_y(); }
+OPUS_D index_t block_id_z()  { return __builtin_amdgcn_workgroup_id_z(); }
+OPUS_D index_t block_size_x() { return __builtin_amdgcn_workgroup_size_x(); }
+OPUS_D index_t block_size_y() { return __builtin_amdgcn_workgroup_size_y(); }
+OPUS_D index_t block_size_z() { return __builtin_amdgcn_workgroup_size_z(); }
+OPUS_D index_t grid_size_x()  { return __builtin_amdgcn_grid_size_x(); }
+OPUS_D index_t grid_size_y()  { return __builtin_amdgcn_grid_size_y(); }
+OPUS_D index_t grid_size_z()  { return __builtin_amdgcn_grid_size_z(); }
+OPUS_D void    sync_threads() { __builtin_amdgcn_s_barrier(); }
+#if !defined(HIP_INCLUDE_HIP_AMD_DETAIL_DEVICE_LIBRARY_DECLS_H)
+extern "C" __device__ int __ockl_wfall_i32(int);
+#endif
+#if !defined(HIP_INCLUDE_HIP_AMD_DETAIL_WARP_FUNCTIONS_H)
+OPUS_D int     warp_all(int predicate) { return __ockl_wfall_i32(predicate); }
+#endif
+
+#if OPUS_ENABLE_RUNTIME_QUERY
+OPUS_H index_t query_warp_size() { int d; (void)hipGetDevice(&d); hipDeviceProp_t p; (void)hipGetDeviceProperties(&p, d); return static_cast<index_t>(p.warpSize); }
+OPUS_H index_t query_smem_size() { int d; (void)hipGetDevice(&d); hipDeviceProp_t p; (void)hipGetDeviceProperties(&p, d); return static_cast<index_t>(p.sharedMemPerBlock); }
+OPUS_H index_t query_num_cu()    { int d; (void)hipGetDevice(&d); hipDeviceProp_t p; (void)hipGetDeviceProperties(&p, d); return static_cast<index_t>(p.multiProcessorCount); }
+#endif
+
+// Uses compiler builtins (__builtin_amdgcn_*) instead of HIP runtime APIs, so no <hip/hip_runtime.h> dependency.
+#ifdef __HIPCC__
+struct workgroup_barrier {
+    OPUS_D workgroup_barrier(unsigned int* ptr) : base_ptr(ptr) {}
+    OPUS_D unsigned int ld(unsigned int offset = 0) { return __atomic_load_n(base_ptr + offset, __ATOMIC_RELAXED); }
+    OPUS_D void wait_eq(unsigned int value, unsigned int offset = 0) { if (__builtin_amdgcn_workitem_id_x() == 0) while (ld(offset) != value) {} __builtin_amdgcn_s_barrier(); }
+    OPUS_D void wait_lt(unsigned int value, unsigned int offset = 0) { if (__builtin_amdgcn_workitem_id_x() == 0) while (ld(offset) < value) {} __builtin_amdgcn_s_barrier(); }
+    OPUS_D void inc(unsigned int offset = 0) { __builtin_amdgcn_s_barrier(); if (__builtin_amdgcn_workitem_id_x() == 0) __atomic_fetch_add(base_ptr + offset, 1u, __ATOMIC_RELAXED); }
+    unsigned int* base_ptr;
+};
+#endif
+
+// NOTE: all data in unsigned int. Prefer usage, construct a mdiv structure on host, pass the structure to kernel, and use div/divmod
+struct mdiv {
+    unsigned int divisor;   unsigned int multiplier;    unsigned int shift;
+    OPUS_H_D mdiv() : divisor(0), multiplier(0), shift(0) {}
+    OPUS_H_D mdiv(unsigned int divisor_) : divisor(divisor_) {
+        unsigned int shift_u32 = 0;
+        while ((1U << shift_u32) < divisor_) shift_u32++;
+        unsigned long long tmp_u64 = static_cast<unsigned long long>((1UL << shift_u32) - divisor_) << 32;
+        multiplier       = static_cast<unsigned int>(tmp_u64 / divisor_ + 1);
+        shift            = shift_u32;
+    }
+    // previously we use __umulhi(), which is defined in <hip/hip_runtime.hpp>, for __device__ compilation. Today compiler is smart enough to generate s_mul_hi_u32 / v_mul_hi_u32
+    OPUS_H_D unsigned int div(unsigned int dividend) const { unsigned int tmp = static_cast<unsigned int>((static_cast<unsigned long long>(dividend) * multiplier) >> 32); return (tmp + dividend) >> shift; }
+    OPUS_H_D void divmod(unsigned int dividend, unsigned int& quotient, unsigned int& remainder) const { quotient  = div(dividend);  remainder = dividend - (quotient * divisor); }
+    OPUS_H_D unsigned int get() const { return divisor; }
+};
+/////////////////////////////////////////////////////////////////////////////////////////////////////////
+// math
+template <typename T, int dpp_i, int row_mask = 0xf, int bank_mask = 0xf, bool bound_ctrl = true>
+OPUS_D T mov_dpp(T x, number<dpp_i>, number<row_mask> = {}, number<bank_mask> = {}, bool_constant<bound_ctrl> = {}) {
+    static_assert(sizeof(T) == 4); return __builtin_bit_cast(T, __builtin_amdgcn_mov_dpp(__builtin_bit_cast(int, x), dpp_i, row_mask, bank_mask, bound_ctrl));
+}
+
+template<typename O, typename T, int dpp_i, int row_mask = 0xf, int bank_mask = 0xf, bool bound_ctrl = true>
+OPUS_D T upd_dpp(const O& old, T x, number<dpp_i>, number<row_mask> = {}, number<bank_mask> = {}, bool_constant<bound_ctrl> = {}) {
+    static_assert(sizeof(T) == 4); return __builtin_bit_cast(T, __builtin_amdgcn_update_dpp(__builtin_bit_cast(int, old), __builtin_bit_cast(int, x), dpp_i, row_mask, bank_mask, bound_ctrl));
+}
+
+// lane index within wavefront (threadIdx.x % warp_size, e.g. wave64: tid=3->3, tid=70->6)
+OPUS_D unsigned int lane_id() {
+    if constexpr (get_warp_size() == 32) return __builtin_amdgcn_mbcnt_lo(-1, 0);
+    else return __builtin_amdgcn_mbcnt_hi(-1, __builtin_amdgcn_mbcnt_lo(-1, 0));
+}
+
+// cross-lane shuffle via ds_bpermute (no hip_runtime.h dependency)
+template<typename T>
+OPUS_D T shfl(T var, int src_lane, int width = get_warp_size()) {
+    static_assert(sizeof(T) == 4);  int self = lane_id();   int index = (src_lane & (width - 1)) + (self & ~(width - 1));
+    return __builtin_bit_cast(T, __builtin_amdgcn_ds_bpermute(index << 2, __builtin_bit_cast(int, var)));
+}
+
+template<typename T> OPUS_D T max(const T&a, const T&b)                { return a > b ? a : b; }
+template<> OPUS_D float       max<float>(const float&a, const float&b) { return __builtin_fmaxf(a, b); }
+template<typename T> OPUS_D T min(const T&a, const T&b)                { return a > b ? b : a; }
+template<> OPUS_D float       min<float>(const float&a, const float&b) { return __builtin_fminf(a, b); }
+
+template<typename T> OPUS_D T med3(const T&a, const T&b, const T&c) { auto max_0 = max(a, b); auto min_0 = min(a, b); return min(max_0, max(min_0, c)); }
+template<> OPUS_D float       med3<float>(const float&a, const float&b, const float&c) { return __builtin_amdgcn_fmed3f(a, b, c); }
+template<> OPUS_D fp16_t      med3<fp16_t>(const fp16_t&a, const fp16_t&b, const fp16_t&c) { return __builtin_amdgcn_fmed3h(a, b, c); }
+/////////////////////////////////////////////////////////////////////////////////////////////////////////
+// buffer load/store related
+OPUS_D constexpr auto buffer_default_config() {
+#if defined(__gfx803__) || defined(__gfx900__) || defined(__gfx906__) || defined(__gfx908__) || defined(__gfx90a__) || defined(__gfx942__) || defined(__gfx950__) || defined(__gfx9_4_generic__)
+    return 0x00020000;
+#elif defined(__gfx103__)
+    return 0x31014000;
+// gfx1200/gfx1201 (Navi 44/48) listed explicitly -- __gfx11__/__gfx12__ are typos (clang predefines only uppercase __GFX11__/__GFX12__), so without this gfx1200/gfx1201 fall into the 0xffffffff sentinel and make_gmem<> stores silently drop.
+#elif defined(__gfx11__) || defined(__gfx12__) || defined(__gfx1250__) || defined(__gfx1201__) || defined(__gfx1200__)
+    return 0x31004000;
+#else
+    return 0xffffffff;
+#endif
+}
+OPUS_D __amdgpu_buffer_rsrc_t make_buffer_rsrc(const void* ptr, unsigned int size = 0xffffffff, unsigned int config = buffer_default_config()) {
+    return __builtin_amdgcn_make_buffer_rsrc(const_cast<void*>(static_cast<const void*>(ptr)), 0, size, config); // void *p, short stride, int num, int flags
+}
+#if __clang_major__ < 20
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wundefined-inline"
+OPUS_D void llvm_amdgcn_raw_buffer_load_lds(i32x4_t r, OPUS_LDS_ADDR unsigned int* p, index_t size, index_t vos, index_t sos, index_t ios, index_t aux) __asm("llvm.amdgcn.raw.buffer.load.lds");
+#pragma clang diagnostic pop
+#endif
+template<typename T_>
+struct gmem {
+    using T = remove_cvref_t<T_>;
+    using scalar_type = typename vector_traits<T>::dtype;
+    static constexpr index_t vector_size = vector_traits<T>::size();
+    template<index_t vec = 1> using vector_type = vector_t<scalar_type, vec * vector_size>;
+
+    OPUS_D gmem(const void* ptr, unsigned int size = 0xffffffff, unsigned int config = buffer_default_config())
+        : cached_rsrc(make_buffer_rsrc(ptr, size, config))
+#if defined(__gfx1250__)
+        , raw_ptr(static_cast<const char*>(ptr))
+#endif
+    {}
+
+    template<index_t vec = 1, index_t aux = 0>   // os in unit of byte
+    OPUS_D auto _load(int v_os, int s_os = 0, number<aux> = {}) {
+        using type = vector_type<vec>;
+        if      constexpr (sizeof(type) == 1)  { return __builtin_bit_cast(type, __builtin_amdgcn_raw_buffer_load_b8  (cached_rsrc, v_os, s_os, aux)); }
+        else if constexpr (sizeof(type) == 2)  { return __builtin_bit_cast(type, __builtin_amdgcn_raw_buffer_load_b16 (cached_rsrc, v_os, s_os, aux)); }
+        else if constexpr (sizeof(type) == 4)  { return __builtin_bit_cast(type, __builtin_amdgcn_raw_buffer_load_b32 (cached_rsrc, v_os, s_os, aux)); }
+        else if constexpr (sizeof(type) == 8)  { return __builtin_bit_cast(type, __builtin_amdgcn_raw_buffer_load_b64 (cached_rsrc, v_os, s_os, aux)); }
+        else if constexpr (sizeof(type) == 16) { return __builtin_bit_cast(type, __builtin_amdgcn_raw_buffer_load_b128(cached_rsrc, v_os, s_os, aux)); }
+    }
+
+    // Async copy global -> LDS. Offsets are in bytes.
+    // IMPORTANT - i_os shifts BOTH ends of the copy, not just the source.
+    template<index_t vec = 1, index_t i_os = 0, index_t aux = 0>
+    OPUS_D void _async_load(OPUS_LDS_ADDR void* dst, int v_os, int s_os = 0, number<i_os> = {}, number<aux> = {}) {
+        using type = vector_type<vec>;
+#if defined(__gfx1250__)
+        static_assert(i_os >= 0 && i_os <= (1 << 23) - 1, "_async_load: i_os exceeds gfx1250 VGLOBAL IOFFSET range [0, 2^23 - 1]");
+        #define GPTR_(T, p) ((__attribute__((address_space(1))) T*)(p))
+        #define LPTR_(T, p) ((OPUS_LDS_ADDR T*)(p))
+        {
+            auto* src = raw_ptr + v_os + s_os;
+            if      constexpr (sizeof(type) == 1)  { __builtin_amdgcn_global_load_async_to_lds_b8  (GPTR_(char, src), LPTR_(char, dst), i_os, 0); }
+            else if constexpr (sizeof(type) == 2)  { __builtin_amdgcn_global_load_async_to_lds_b8  (GPTR_(char, src), LPTR_(char, dst), i_os, 0);
+                                                     __builtin_amdgcn_global_load_async_to_lds_b8  (GPTR_(char, src + 1), LPTR_(char, (char*)dst + 1), i_os, 0); }
+            else if constexpr (sizeof(type) == 4)  { __builtin_amdgcn_global_load_async_to_lds_b32 (GPTR_(int, src), LPTR_(int, dst), i_os, 0); }
+            else if constexpr (sizeof(type) == 8)  { __builtin_amdgcn_global_load_async_to_lds_b64 (GPTR_(i32x2_t, src), LPTR_(i32x2_t, dst), i_os, 0); }
+            else if constexpr (sizeof(type) == 16) { __builtin_amdgcn_global_load_async_to_lds_b128(GPTR_(i32x4_t, src), LPTR_(i32x4_t, dst), i_os, 0); }
+        }
+        #undef GPTR_
+        #undef LPTR_
+#elif defined(__gfx940__) || defined(__gfx941__) || defined(__gfx942__) || defined(__gfx950__)   // CDNA: buffer-load lands directly in LDS (vmem-to-lds-load-insts).
+        static_assert(i_os >= 0 && i_os <= (1 << 12) - 1, "_async_load: i_os exceeds CDNA MUBUF OFFSET range [0, 2^12 - 1]");
+#if __clang_major__ >= 20    // clang 20+ raw_ptr builtin (rocm 7.0+)
+        if      constexpr (sizeof(type) == 1)  { __builtin_amdgcn_raw_ptr_buffer_load_lds(cached_rsrc, dst,  1, v_os, s_os, i_os, aux); }
+        else if constexpr (sizeof(type) == 2)  { __builtin_amdgcn_raw_ptr_buffer_load_lds(cached_rsrc, dst,  2, v_os, s_os, i_os, aux); }
+        else if constexpr (sizeof(type) == 4)  { __builtin_amdgcn_raw_ptr_buffer_load_lds(cached_rsrc, dst,  4, v_os, s_os, i_os, aux); }
+#if  defined(__gfx950__)
+        else if constexpr (sizeof(type) == 12) { __builtin_amdgcn_raw_ptr_buffer_load_lds(cached_rsrc, dst, 12, v_os, s_os, i_os, aux); }
+        else if constexpr (sizeof(type) == 16) { __builtin_amdgcn_raw_ptr_buffer_load_lds(cached_rsrc, dst, 16, v_os, s_os, i_os, aux); }
+#endif
+#else
+        i32x4_t cached_rsrc_;
+        __builtin_memcpy(&cached_rsrc_, &cached_rsrc, sizeof(i32x4_t));   // builtin memcpy, __builtin_bit_cast() can not use here due to __amdgpu_buffer_rsrc_t is non copyable
+        if      constexpr (sizeof(type) == 1)  {llvm_amdgcn_raw_buffer_load_lds(cached_rsrc_, reinterpret_cast<OPUS_LDS_ADDR u32_t*>(dst),  1, v_os, s_os, i_os, aux); }
+        else if constexpr (sizeof(type) == 2)  {llvm_amdgcn_raw_buffer_load_lds(cached_rsrc_, reinterpret_cast<OPUS_LDS_ADDR u32_t*>(dst),  2, v_os, s_os, i_os, aux); }
+        else if constexpr (sizeof(type) == 4)  {llvm_amdgcn_raw_buffer_load_lds(cached_rsrc_, reinterpret_cast<OPUS_LDS_ADDR u32_t*>(dst),  4, v_os, s_os, i_os, aux); }
+#if  defined(__gfx950__)
+        else if constexpr (sizeof(type) == 12) {llvm_amdgcn_raw_buffer_load_lds(cached_rsrc_, reinterpret_cast<OPUS_LDS_ADDR u32_t*>(dst), 12, v_os, s_os, i_os, aux); }
+        else if constexpr (sizeof(type) == 16) {llvm_amdgcn_raw_buffer_load_lds(cached_rsrc_, reinterpret_cast<OPUS_LDS_ADDR u32_t*>(dst), 16, v_os, s_os, i_os, aux); }
+#endif
+#endif
+#else
+        auto val = _load<vec, aux>(v_os + i_os, s_os, number<aux>{});
+        dst = reinterpret_cast<OPUS_LDS_ADDR void*>(reinterpret_cast<__UINTPTR_TYPE__>(dst) + i_os);
+        *reinterpret_cast<OPUS_LDS_ADDR type*>(dst) = val;
+#endif
+    }
+
+    template<index_t vec = 1, typename V, index_t aux = 0>   // os in unit of byte
+    OPUS_D void _store(const V& x, int v_os, int s_os = 0, number<aux> = {}) {
+        static_assert((vec * vector_size) == vector_traits<V>::size(), "vector size need to be same, please check");
+        if      constexpr (sizeof(vector_type<vec>) == 1)  { __builtin_amdgcn_raw_buffer_store_b8  (__builtin_bit_cast(i8_t,    x), cached_rsrc, v_os, s_os, aux); }
+        else if constexpr (sizeof(vector_type<vec>) == 2)  { __builtin_amdgcn_raw_buffer_store_b16 (__builtin_bit_cast(i16_t,   x), cached_rsrc, v_os, s_os, aux); }
+        else if constexpr (sizeof(vector_type<vec>) == 4)  { __builtin_amdgcn_raw_buffer_store_b32 (__builtin_bit_cast(i32_t,   x), cached_rsrc, v_os, s_os, aux); }
+        else if constexpr (sizeof(vector_type<vec>) == 8)  { __builtin_amdgcn_raw_buffer_store_b64 (__builtin_bit_cast(i32x2_t, x), cached_rsrc, v_os, s_os, aux); }
+        else if constexpr (sizeof(vector_type<vec>) == 16) { __builtin_amdgcn_raw_buffer_store_b128(__builtin_bit_cast(i32x4_t, x), cached_rsrc, v_os, s_os, aux); }
+    }
+
+    template<index_t vec = 1, index_t aux = 0>   // os in unit of T and cast to vector with vec
+    OPUS_D auto load(int v_os, int s_os = 0, number<aux> = {}) { return _load<vec>(v_os * sizeof(T), s_os * sizeof(T), number<aux>{}); }
+
+    template<index_t vec = 1, index_t i_os = 0, index_t aux = 0>   // os in unit of T and cast to vector with vec; i_os = compile-time immediate byte offset (see _async_load notes; applies to both src and dst)
+    OPUS_D void async_load(void* dst, int v_os, int s_os = 0, number<i_os> = {}, number<aux> = {}) { _async_load<vec>(reinterpret_cast<OPUS_LDS_ADDR void*>(reinterpret_cast<__UINTPTR_TYPE__>(dst)), v_os * sizeof(T), s_os * sizeof(T), number<i_os>{}, number<aux>{}); }
+
+    template<index_t vec = 1, typename V, index_t aux = 0, std::enable_if_t<(is_vector_v<V> || is_dtype_v<V> || is_array_v<V>), bool> = true>   // os in unit of T and cast to vector with vec
+    OPUS_D void store(const V& x, int v_os, int s_os = 0, number<aux> = {}) {
+        static_assert(std::is_same_v<typename vector_traits<V>::dtype, scalar_type>, "scalar type must be same for the data to be stored" );
+        if constexpr (is_dtype_v<V> && (vec * vector_size) % vector_traits<V>::size() == 0) {
+            _store<vec>(make_repeated_vector(x, number<vec * vector_size / vector_traits<V>::size()>{}), v_os * sizeof(T), s_os * sizeof(T), number<aux>{});
+        } else {
+            static_assert((vec * vector_size) == vector_traits<V>::size(), "vector size need to be same, please check" );
+            _store<vec>(x, v_os * sizeof(T), s_os * sizeof(T), number<aux>{});
+        }
+    }
+
+    // bulk load API, give me a Shape of this tile, will issue multiple load instruction based on the y-shape space
+    template<index_t vec = 1, typename Layout, index_t aux = 0, std::enable_if_t<is_layout_v<Layout>, bool> = true>
+    OPUS_D auto load(const Layout& u, int s_os = 0/* do we really need this? */, number<aux> = {})
+    {
+        using LT = layout_load_traits<Layout, vec>;
+        constexpr auto r_elem = LT::r_elem;
+        auto offsets = layout_to_offsets<vec>(u);
+
+#if OPUS_TILE_CONTAINER == 0
+        vector_t<scalar_type, vec * vector_size * r_elem.value> r;
+        for (index_t i = 0; i < r_elem.value; i++) {
+            auto tmp = load<vec>(offsets[i], s_os, number<aux>{});
+            for (index_t j = 0; j < vec * vector_size; j++) r[i * vec * vector_size + j] = tmp[j];
+        }
+        return r;
+#elif OPUS_TILE_CONTAINER == 1
+        array<vector_type<vec>, r_elem.value> r;
+        for (index_t i = 0; i < r_elem.value; i++) r[i] = load<vec>(offsets[i], s_os, number<aux>{});
+        return r;
+#endif
+    }
+
+    template<index_t vec = 1, typename V, typename Layout, index_t aux = 0, std::enable_if_t<((is_array_v<V> || is_vector_v<V>) && is_layout_v<Layout>), bool> = true>
+    OPUS_D void store(const V& x, const Layout& u, int s_os = 0/* do we really need this? */, number<aux> = {})
+    {
+        using LT = layout_load_traits<Layout, vec>;
+        constexpr auto r_elem = LT::r_elem;
+        auto offsets = layout_to_offsets<vec>(u);
+
+#if OPUS_TILE_CONTAINER == 0
+        auto a_ = [&](){ if constexpr (is_array_v<V>) return to_vector(x);
+                         else if constexpr (is_dtype_v<V>) return make_repeated_vector(x, number<r_elem.value>{});
+                         else if constexpr (is_vector_v<V>) return x; }();
+#elif OPUS_TILE_CONTAINER == 1
+        auto a_ = to_array(x);
+#endif
+        for (index_t i = 0; i < r_elem.value; i++) {
+            vector_type<vec> v_;
+            for (index_t j = 0; j < vec * vector_size; j++) v_[j] = a_[i * vec * vector_size + j];
+            store<vec>(v_, offsets[i], s_os, number<aux>{});
+        }
+    }
+
+    template<index_t vec = 1, typename LayoutG, typename LayoutS, index_t i_os = 0, index_t aux = 0, std::enable_if_t<is_layout_v<LayoutG> && is_layout_v<LayoutS>, bool> = true>
+    OPUS_D void async_load(void* smem_base, const LayoutG& u_gmem, const LayoutS& u_smem, int s_os = 0, number<i_os> = {}, number<aux> = {}) {
+        using LT = layout_load_traits<LayoutG, vec>;
+        constexpr auto r_elem = LT::r_elem;
+        auto gmem_offsets = layout_to_offsets<vec>(u_gmem);
+        auto smem_offsets = layout_to_offsets<vec>(u_smem);
+        auto smem_ptr = reinterpret_cast<OPUS_LDS_ADDR scalar_type*>(reinterpret_cast<__UINTPTR_TYPE__>(smem_base));
+        for (index_t i = 0; i < r_elem.value; i++) {
+            async_load<vec>(reinterpret_cast<void*>(reinterpret_cast<__UINTPTR_TYPE__>(smem_ptr + smem_offsets[i])), gmem_offsets[i], s_os, number<i_os>{}, number<aux>{});
+        }
+    }
+
+    template<index_t vec = 1, typename Predicate, typename Layout, index_t aux = 0, std::enable_if_t<is_layout_v<Layout>, bool> = true>
+    OPUS_D auto load_if(const Predicate& pred, const Layout& u, int s_os = 0, number<aux> = {})
+    {
+        using LT = layout_load_traits<Layout, vec>;
+        constexpr auto issue_space = LT::issue_space;
+        constexpr auto issue_space_vec = LT::issue_space_vec;
+        constexpr auto r_elem = LT::r_elem;
+        auto offsets = layout_to_offsets<vec>(u);
+        constexpr auto u_r = make_layout<-1>(issue_space_vec);
+
+#if OPUS_TILE_CONTAINER == 0
+        vector_t<scalar_type, vec * vector_size * r_elem.value> r;
+        static_ford(issue_space_vec, [&](auto ... ids){
+            constexpr index_t idx = u_r(ids...);
+            auto tmp = pred(ids...) ? load<vec>(offsets[idx], s_os, number<aux>{}) : vector_type<vec>{0};
+            set_slice(r, tmp, number<idx * vec>{}, number<(idx + 1) * vec>{});
+        });
+        return r;
+#elif OPUS_TILE_CONTAINER == 1
+        array<vector_type<vec>, r_elem.value> r;
+        static_ford(issue_space_vec, [&](auto ... ids){ r[u_r(ids...)] = pred(ids...) ? load<vec>(offsets[u_r(ids...)], s_os, number<aux>{}) : vector_type<vec>{0}; });
+        return r;
+#endif
+    }
+
+    template<index_t vec = 1, typename Predicate, typename V, typename Layout, index_t aux = 0, std::enable_if_t<((is_array_v<V> || is_vector_v<V>) && is_layout_v<Layout>), bool> = true>
+    OPUS_D void store_if(const Predicate& pred, const V& x, const Layout& u, int s_os = 0, number<aux> = {})
+    {
+        using LT = layout_load_traits<Layout, vec>;
+        constexpr auto issue_space = LT::issue_space;
+        constexpr auto issue_space_vec = LT::issue_space_vec;
+        auto offsets = layout_to_offsets<vec>(u);
+        constexpr auto u_r = make_layout<-1>(issue_space);
+
+#if OPUS_TILE_CONTAINER == 0
+        auto a_ = [&](){ if constexpr (is_array_v<V>) return to_vector(x);
+                         else if constexpr (is_dtype_v<V>) return make_repeated_vector(x, number<get<0>(reduce_tuple_mul(issue_space)).value>{});
+                         else if constexpr (is_vector_v<V>) return x; }();
+#elif OPUS_TILE_CONTAINER == 1
+        auto a_ = to_array(x);
+#endif
+        static_ford(issue_space_vec, [&](auto ... ids){
+            if (pred(ids...)) {
+                constexpr index_t idx = u_r(ids...);
+                auto v_ = slice(a_, number<idx>{}, number<idx + vec>{});
+                store<vec>(v_, offsets[make_layout<-1>(issue_space_vec)(ids...)], s_os, number<aux>{});
+            }
+        });
+    }
+
+    template<index_t vec = 1, typename Predicate, typename LayoutG, typename LayoutS, index_t i_os = 0, index_t aux = 0, std::enable_if_t<is_layout_v<LayoutG> && is_layout_v<LayoutS>, bool> = true>
+    OPUS_D void async_load_if(const Predicate& pred, void* smem_base, const LayoutG& u_gmem, const LayoutS& u_smem, int s_os = 0, number<i_os> = {}, number<aux> = {}) {
+        using LT = layout_load_traits<LayoutG, vec>;
+        constexpr auto issue_space_vec = LT::issue_space_vec;
+        auto gmem_offsets = layout_to_offsets<vec>(u_gmem);
+        auto smem_offsets = layout_to_offsets<vec>(u_smem);
+        auto smem_ptr = reinterpret_cast<OPUS_LDS_ADDR scalar_type*>(reinterpret_cast<__UINTPTR_TYPE__>(smem_base));
+        constexpr auto u_r = make_layout<-1>(issue_space_vec);
+
+        static_ford(issue_space_vec, [&](auto... ids) {
+            constexpr index_t idx = u_r(ids...);
+            if (pred(ids...)) {
+                async_load<vec>(reinterpret_cast<void*>(reinterpret_cast<__UINTPTR_TYPE__>(smem_ptr + smem_offsets[idx])), gmem_offsets[idx], s_os, number<i_os>{}, number<aux>{});
+            } else {
+                using type = vector_type<vec>;
+                type z = {0};
+                *reinterpret_cast<OPUS_LDS_ADDR type*>(smem_ptr + smem_offsets[idx]) = z;
+            }
+        });
+    }
+
+    __amdgpu_buffer_rsrc_t cached_rsrc;
+#if defined(__gfx1250__)
+    const char* raw_ptr;  // flat pointer for global_load_async_to_lds (gfx1250 uses global addressing, not buffer rsrc)
+#endif
+};
+
+template<typename T_> OPUS_D decltype(auto) make_gmem(const T_* ptr, unsigned int size = 0xffffffff, unsigned int config = buffer_default_config()) { return gmem<T_>{ptr, size, config}; }
+/////////////////////////////////////////////////////////////////////////////////////////////////////////
+// smem load/store related
+template<typename T_>
+struct smem {
+    using T = remove_cvref_t<T_>;
+    using scalar_type = typename vector_traits<T>::dtype;
+    static constexpr index_t vector_size = vector_traits<T>::size();
+    template<index_t vec = 1> using vector_type = vector_t<scalar_type, vec * vector_size>;
+
+    OPUS_D smem(void* ptr_) : ptr(reinterpret_cast<OPUS_LDS_ADDR char*>(reinterpret_cast<__UINTPTR_TYPE__>(ptr_))) {}
+
+    template<index_t vec = 1> OPUS_D auto _load(int v_os/* in unit of byte*/) { using type = vector_type<vec>; return *reinterpret_cast<OPUS_LDS_ADDR type*>(ptr + v_os); }
+
+    template<index_t vec = 1, int imm_offset = 0> OPUS_D auto _tr_load(int v_os/* in unit of byte*/) {
+#if defined(__HIP_DEVICE_COMPILE__) && defined(__gfx950__)
+        using type = vector_type<vec>;
+        static_assert(sizeof(type) == 8, "DS_READ_B64_TR requires 8-byte (64-bit) load");
+        constexpr index_t elem_bits = sizeof_bits_v<scalar_type>;
+        i32x2_t raw;
+        const u32_t addr = static_cast<u32_t>(reinterpret_cast<__UINTPTR_TYPE__>(ptr + v_os));
+        if      constexpr (elem_bits == 16) { asm volatile("ds_read_b64_tr_b16 %0, %1 offset:%2\n" : "=v"(raw) : "v"(addr), "i"(imm_offset) : "memory"); }
+        else if constexpr (elem_bits == 8)  { asm volatile("ds_read_b64_tr_b8 %0, %1 offset:%2\n" : "=v"(raw) : "v"(addr), "i"(imm_offset) : "memory"); }
+        else if constexpr (elem_bits == 4)  { asm volatile("ds_read_b64_tr_b4 %0, %1 offset:%2\n" : "=v"(raw) : "v"(addr), "i"(imm_offset) : "memory"); }
+        else { static_assert(sizeof(T_) == 0, "smem::_tr_load: unsupported scalar type"); }
+        return __builtin_bit_cast(type, raw);
+#elif defined(__HIP_DEVICE_COMPILE__)
+        static_assert(sizeof(T_) == 0, "smem::_tr_load requires __gfx950__");
+        return _load<vec>(v_os + imm_offset);
+#else
+        return _load<vec>(v_os + imm_offset);
+#endif
+    }
+
+    template<index_t vec = 1, typename V>
+    OPUS_D void _store(const V& x, int v_os/* in unit of byte*/) {
+        static_assert((vec * vector_size) == vector_traits<V>::size(), "vector size need to be same, please check");
+        using type = vector_type<vec>;
+        *reinterpret_cast<OPUS_LDS_ADDR type*>(ptr + v_os) = __builtin_bit_cast(type, x);
+    }
+
+    template<index_t vec = 1> OPUS_D auto load(int v_os) { return _load<vec>(v_os * sizeof(T)); }
+
+    template<index_t vec = 1> OPUS_D auto tr_load(int v_os) { return _tr_load<vec>(v_os * sizeof(T)); }
+
+    template<index_t vec = 1, typename V, std::enable_if_t<(is_vector_v<V> || is_dtype_v<V> || is_array_v<V>), bool> = true>
+    OPUS_D void store(const V& x, int v_os) {
+        static_assert(std::is_same_v<typename vector_traits<V>::dtype, scalar_type>, "scalar type must be same for the data to be stored" );
+        if constexpr (is_dtype_v<V> && (vec * vector_size) % vector_traits<V>::size() == 0) {
+            _store<vec>(make_repeated_vector(x, number<vec * vector_size / vector_traits<V>::size()>{}), v_os * sizeof(T));
+        } else {
+            static_assert((vec * vector_size) == vector_traits<V>::size(), "vector size need to be same, please check" );
+            _store<vec>(x, v_os * sizeof(T));
+        }
+    }
+
+    // bulk load API, give me a Shape of this tile, will issue multiple load instruction based on the y-shape space
+    template<index_t vec = 1, typename Layout, std::enable_if_t<is_layout_v<Layout>, bool> = true>
+    OPUS_D auto load(const Layout& u)
+    {
+        using LT = layout_load_traits<Layout, vec>;
+        constexpr auto r_elem = LT::r_elem;
+        auto offsets = layout_to_offsets<vec>(u);
+
+#if OPUS_TILE_CONTAINER == 0
+        vector_t<scalar_type, vec * vector_size * r_elem.value> r;
+        for (index_t i = 0; i < r_elem.value; i++) {
+            auto tmp = load<vec>(offsets[i]);
+            for (index_t j = 0; j < vec * vector_size; j++) r[i * vec * vector_size + j] = tmp[j];
+        }
+        return r;
+#elif OPUS_TILE_CONTAINER == 1
+        array<vector_type<vec>, r_elem.value> r;
+        for (index_t i = 0; i < r_elem.value; i++) r[i] = load<vec>(offsets[i]);
+        return r;
+#endif
+    }
+
+    template<index_t vec = 1, typename Layout, std::enable_if_t<is_layout_v<Layout>, bool> = true>
+    OPUS_D auto tr_load(const Layout& u)
+    {
+        using LT = layout_load_traits<Layout, vec>;
+        constexpr auto r_elem = LT::r_elem;
+        constexpr bool is_static_layout = is_static_tuple_v<typename Layout::Shape> && is_static_tuple_v<typename Layout::Stride>;
+        [[maybe_unused]] auto offsets = layout_to_offsets<vec>(u);
+
+        auto issue = [&](auto i) {
+            if constexpr (is_static_layout) {
+                using shift = layout_shift_traits<remove_cvref_t<Layout>>;
+                constexpr int off = layout_imm_offsets_v<Layout, vec>[i.value] * sizeof(T);
+                if constexpr (off >= 0 && off <= 0xffff) {
+                    const auto& ub = static_cast<const typename shift::base&>(u);
+                    const int base = ub(make_repeated_tuple(number<0>{}, number<size<decltype(LT::issue_space_vec)>()>{})) * sizeof(T);
+                    return _tr_load<vec, off>(base);
+                }
+            }
+            return tr_load<vec>(offsets[i.value]);
+        };
+
+#if OPUS_TILE_CONTAINER == 0
+        vector_t<scalar_type, vec * vector_size * r_elem.value> r;
+        static_for<r_elem.value>([&](auto i){
+            set_slice(r, issue(i), number<i.value * vec>{}, number<(i.value + 1) * vec>{});
+        });
+        return r;
+#elif OPUS_TILE_CONTAINER == 1
+        array<vector_type<vec>, r_elem.value> r;
+        static_for<r_elem.value>([&](auto i){ r[i.value] = issue(i); });
+        return r;
+#endif
+    }
+
+    template<index_t vec = 1, typename V, typename Layout, std::enable_if_t<((is_array_v<V> || is_dtype_v<V> || is_vector_v<V>) && is_layout_v<Layout>), bool> = true>
+    OPUS_D void store(const V& x, const Layout& u)
+    {
+        using LT = layout_load_traits<Layout, vec>;
+        constexpr auto r_elem = LT::r_elem;
+        auto offsets = layout_to_offsets<vec>(u);
+
+#if OPUS_TILE_CONTAINER == 0
+        auto a_ = [&](){ if constexpr (is_array_v<V>) return to_vector(x);
+                         else if constexpr (is_dtype_v<V>) return make_repeated_vector(x, number<r_elem.value>{});
+                         else if constexpr (is_vector_v<V>) return x; }();
+#elif OPUS_TILE_CONTAINER == 1
+        auto a_ = to_array(x);
+#endif
+        for (index_t i = 0; i < r_elem.value; i++) {
+            vector_type<vec> v_;
+            for (index_t j = 0; j < vec * vector_size; j++) v_[j] = a_[i * vec * vector_size + j];
+            store<vec>(v_, offsets[i]);
+        }
+    }
+
+    template<index_t vec = 1, typename Predicate, typename Layout, std::enable_if_t<is_layout_v<Layout>, bool> = true>
+    OPUS_D auto load_if(const Predicate& pred, const Layout& u)
+    {
+        using LT = layout_load_traits<Layout, vec>;
+        constexpr auto issue_space_vec = LT::issue_space_vec;
+        constexpr auto r_elem = LT::r_elem;
+        auto offsets = layout_to_offsets<vec>(u);
+        constexpr auto u_r = make_layout<-1>(issue_space_vec);
+
+#if OPUS_TILE_CONTAINER == 0
+        vector_t<scalar_type, vec * vector_size * r_elem.value> r;
+        static_ford(issue_space_vec, [&](auto ... ids){
+            constexpr index_t idx = u_r(ids...);
+            auto tmp = pred(ids...) ? load<vec>(offsets[idx]) : vector_type<vec>{0};
+            set_slice(r, tmp, number<idx * vec>{}, number<(idx + 1) * vec>{});
+        });
+        return r;
+#elif OPUS_TILE_CONTAINER == 1
+        array<vector_type<vec>, r_elem.value> r;
+        static_ford(issue_space_vec, [&](auto ... ids){ r[u_r(ids...)] = pred(ids...) ? load<vec>(offsets[u_r(ids...)]) : vector_type<vec>{0}; });
+        return r;
+#endif
+    }
+
+    template<index_t vec = 1, typename Predicate, typename Layout, std::enable_if_t<is_layout_v<Layout>, bool> = true>
+    OPUS_D auto tr_load_if(const Predicate& pred, const Layout& u)
+    {
+        using LT = layout_load_traits<Layout, vec>;
+        constexpr auto issue_space_vec = LT::issue_space_vec;
+        constexpr auto r_elem = LT::r_elem;
+        constexpr bool is_static_layout = is_static_tuple_v<typename Layout::Shape> && is_static_tuple_v<typename Layout::Stride>;
+        [[maybe_unused]] auto offsets = layout_to_offsets<vec>(u);
+        constexpr auto u_r = make_layout<-1>(issue_space_vec);
+
+        auto issue = [&](auto i) {
+            if constexpr (is_static_layout) {
+                using shift = layout_shift_traits<remove_cvref_t<Layout>>;
+                constexpr int off = layout_imm_offsets_v<Layout, vec>[i.value] * sizeof(T);
+                if constexpr (off >= 0 && off <= 0xffff) {
+                    const auto& ub = static_cast<const typename shift::base&>(u);
+                    const int base = ub(make_repeated_tuple(number<0>{}, number<size<decltype(LT::issue_space_vec)>()>{})) * sizeof(T);
+                    return _tr_load<vec, off>(base);
+                }
+            }
+            return tr_load<vec>(offsets[i.value]);
+        };
+
+#if OPUS_TILE_CONTAINER == 0
+        vector_t<scalar_type, vec * vector_size * r_elem.value> r;
+        static_ford(issue_space_vec, [&](auto ... ids){
+            constexpr index_t idx = u_r(ids...);
+            auto tmp = pred(ids...) ? issue(number<idx>{}) : vector_type<vec>{0};
+            set_slice(r, tmp, number<idx * vec>{}, number<(idx + 1) * vec>{});
+        });
+        return r;
+#elif OPUS_TILE_CONTAINER == 1
+        array<vector_type<vec>, r_elem.value> r;
+        static_ford(issue_space_vec, [&](auto ... ids){ constexpr index_t idx = u_r(ids...); r[idx] = pred(ids...) ? issue(number<idx>{}) : vector_type<vec>{0}; });
+        return r;
+#endif
+    }
+
+    template<index_t vec = 1, typename Predicate, typename V, typename Layout, std::enable_if_t<((is_array_v<V> || is_dtype_v<V> || is_vector_v<V>) && is_layout_v<Layout>), bool> = true>
+    OPUS_D void store_if(const Predicate& pred, const V& x, const Layout& u)
+    {
+        using LT = layout_load_traits<Layout, vec>;
+        constexpr auto issue_space = LT::issue_space;
+        constexpr auto issue_space_vec = LT::issue_space_vec;
+        auto offsets = layout_to_offsets<vec>(u);
+        constexpr auto u_r = make_layout<-1>(issue_space);
+
+#if OPUS_TILE_CONTAINER == 0
+        auto a_ = [&](){ if constexpr (is_array_v<V>) return to_vector(x);
+                         else if constexpr (is_dtype_v<V>) return make_repeated_vector(x, number<get<0>(reduce_tuple_mul(issue_space)).value>{});
+                         else if constexpr (is_vector_v<V>) return x; }();
+#elif OPUS_TILE_CONTAINER == 1
+        auto a_ = to_array(x);
+#endif
+        static_ford(issue_space_vec, [&](auto ... ids){
+            if (pred(ids...)) {
+                constexpr index_t idx = u_r(ids...);
+                auto v_ = slice(a_, number<idx>{}, number<idx + vec>{});
+                store<vec>(v_, offsets[make_layout<-1>(issue_space_vec)(ids...)]);
+            }
+        });
+    }
+
+    OPUS_LDS_ADDR char* ptr; // in unit of byte
+};
+
+template<typename T_> OPUS_D decltype(auto) make_smem(T_* ptr) { return smem<T_>{ptr}; }
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////
+// mem type traits & free function wrappers (eliminate .template syntax in dependent context)
+template<typename>   struct is_gmem : false_type {};
+template<typename T> struct is_gmem<gmem<T>> : true_type {};
+template<typename T> constexpr bool is_gmem_v = is_gmem<remove_cvref_t<T>>::value;
+
+template<typename>   struct is_smem : false_type {};
+template<typename T> struct is_smem<smem<T>> : true_type {};
+template<typename T> constexpr bool is_smem_v = is_smem<remove_cvref_t<T>>::value;
+
+template<typename T> constexpr bool is_mem_v = is_gmem_v<T> || is_smem_v<T>;
+
+template<index_t vec = 1, typename Mem, typename... Args, std::enable_if_t<is_mem_v<Mem>, bool> = true>
+OPUS_D auto load(Mem& mem, Args&&... args) { return mem.template load<vec>(std::forward<Args>(args)...); }
+template<index_t vec = 1, typename Mem, typename... Args, std::enable_if_t<is_mem_v<Mem>, bool> = true>
+OPUS_D void store(Mem& mem, Args&&... args) { mem.template store<vec>(std::forward<Args>(args)...); }
+template<index_t vec = 1, typename Mem, typename... Args, std::enable_if_t<is_gmem_v<Mem>, bool> = true>
+OPUS_D void async_load(Mem& mem, Args&&... args) { mem.template async_load<vec>(std::forward<Args>(args)...); }
+
+template<index_t vec = 1, typename Mem, typename... Args, std::enable_if_t<is_mem_v<Mem>, bool> = true>
+OPUS_D auto load_if(Mem& mem, Args&&... args) { return mem.template load_if<vec>(std::forward<Args>(args)...); }
+template<index_t vec = 1, typename Mem, typename... Args, std::enable_if_t<is_smem_v<Mem>, bool> = true>
+OPUS_D auto tr_load(Mem& mem, Args&&... args) { return mem.template tr_load<vec>(std::forward<Args>(args)...); }
+template<index_t vec = 1, typename Mem, typename... Args, std::enable_if_t<is_smem_v<Mem>, bool> = true>
+OPUS_D auto tr_load_if(Mem& mem, Args&&... args) { return mem.template tr_load_if<vec>(std::forward<Args>(args)...); }
+template<index_t vec = 1, typename Mem, typename... Args, std::enable_if_t<is_mem_v<Mem>, bool> = true>
+OPUS_D void store_if(Mem& mem, Args&&... args) { mem.template store_if<vec>(std::forward<Args>(args)...); }
+template<index_t vec = 1, typename Mem, typename... Args, std::enable_if_t<is_gmem_v<Mem>, bool> = true>
+OPUS_D void async_load_if(Mem& mem, Args&&... args) { mem.template async_load_if<vec>(std::forward<Args>(args)...); }
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////
+// waitcnt
+#if defined(__gfx1250__)
+// gfx1250: split wait counters, exposed as native instruction wrappers via LLVM IR intrinsics.
+// s_wait_expcnt/s_wait_samplecnt/s_wait_bvhcnt do NOT exist on gfx1250.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wundefined-inline"
+OPUS_D void llvm_s_wait_loadcnt(short cnt)    __asm("llvm.amdgcn.s.wait.loadcnt");
+OPUS_D void llvm_s_wait_dscnt(short cnt)      __asm("llvm.amdgcn.s.wait.dscnt");
+OPUS_D void llvm_s_wait_storecnt(short cnt)   __asm("llvm.amdgcn.s.wait.storecnt");
+OPUS_D void llvm_s_wait_kmcnt(short cnt)      __asm("llvm.amdgcn.s.wait.kmcnt");
+OPUS_D void llvm_s_wait_asynccnt(short cnt)   __asm("llvm.amdgcn.s.wait.asynccnt");
+OPUS_D void llvm_s_wait_tensorcnt(short cnt)  __asm("llvm.amdgcn.s.wait.tensorcnt");
+#pragma clang diagnostic pop
+
+template <index_t cnt> OPUS_D void s_wait_loadcnt(number<cnt> = {})   { llvm_s_wait_loadcnt(cnt); }
+template <index_t cnt> OPUS_D void s_wait_dscnt(number<cnt> = {})     { llvm_s_wait_dscnt(cnt); }
+template <index_t cnt> OPUS_D void s_wait_storecnt(number<cnt> = {})  { llvm_s_wait_storecnt(cnt); }
+template <index_t cnt> OPUS_D void s_wait_kmcnt(number<cnt> = {})     { llvm_s_wait_kmcnt(cnt); }
+template <index_t cnt> OPUS_D void s_wait_asynccnt(number<cnt> = {})  { llvm_s_wait_asynccnt(cnt); }
+template <index_t cnt> OPUS_D void s_wait_tensorcnt(number<cnt> = {}) { llvm_s_wait_tensorcnt(cnt); }
+#else
+// gfx9: combined s_waitcnt instruction
+template <index_t vmcnt, index_t lgkmcnt, index_t expcnt = 7>
+OPUS_D void s_waitcnt(number<vmcnt>, number<lgkmcnt>, number<expcnt> = {})
+{   __builtin_amdgcn_s_waitcnt((((0b110000 & vmcnt) << (14 - 4)) | (0b1111 & vmcnt)) | ((0b111 & expcnt) << 4) | ((0b1111 & lgkmcnt) << 8)); }
+
+template <index_t vmcnt>   OPUS_D void s_waitcnt_vmcnt(number<vmcnt>) { s_waitcnt(number<vmcnt>{}, number<15>{}); }
+template <index_t lgkmcnt> OPUS_D void s_waitcnt_lgkmcnt(number<lgkmcnt>) { s_waitcnt(number<63>{}, number<lgkmcnt>{}); }
+#endif
+
+// Helper: resolve vtype for MFMA/WMMA registers. Packed types (fp4_t etc.) use underlying storage since ext_vector_type requires scalar types.
+namespace impl { template<typename T, index_t N, typename = void> struct mfma_vtype { using type = vector_t<T, N>; };
+template<typename T, index_t N> struct mfma_vtype<T, N, std::enable_if_t<is_packs_v<T>>> { using type = vector_t<typename T::storage, N>; }; }
+template<typename T, index_t N> using mfma_vtype_t = typename impl::mfma_vtype<T, N>::type;
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////
+// mfma (GFX9: gfx942, gfx950)
+#if defined(__GFX9__) || !defined(__HIP_DEVICE_COMPILE__)
+#define DISPATCH_MFMA_(ta_, tb_, tc_, wm_, wn_, wk_, inst_) \
+ (std::is_same_v<dtype_a, ta_> && std::is_same_v<dtype_b, tb_> && std::is_same_v<dtype_c, tc_> && wave_m == wm_ && wave_n == wn_ && wave_k == wk_) {  return inst_(a, b, c, cbsz, abid, blgp); }
+
+#define DISPATCH_MFMA_STEP_K_(ta_, tb_, tc_, wm_, wn_, wk_, inst_k_, inst_) \
+ (std::is_same_v<dtype_a, ta_> && std::is_same_v<dtype_b, tb_> && std::is_same_v<dtype_c, tc_> && wave_m == wm_ && wave_n == wn_ && wave_k == wk_) { \
+    constexpr index_t steps = wk_ / inst_k_;  constexpr index_t e_a = elem_a / steps; constexpr index_t e_b = elem_b / steps;   \
+    auto tmp = inst_(slice(a, number<0>{}, number<e_a>{}), slice(b, number<0>{}, number<e_b>{}), c, cbsz, abid, blgp);          \
+    static_for<steps - 1>([&](auto i){ tmp = inst_(slice(a, number<e_a * (i+1)>{}, number<e_a*(i+2)>{}), slice(b, number<e_b * (i+1)>{}, number<e_b * (i+2)>{}), tmp, cbsz, abid, blgp); });  \
+    return tmp; }
+
+// f32 MFMA: inputs are scalar floats (elem_a = elem_b = 1), extract via [0] from vector_t<fp32_t, 1>
+#define DISPATCH_MFMA_F32_(ta_, tb_, tc_, wm_, wn_, wk_, inst_) \
+ (std::is_same_v<dtype_a, ta_> && std::is_same_v<dtype_b, tb_> && std::is_same_v<dtype_c, tc_> && wave_m == wm_ && wave_n == wn_ && wave_k == wk_) { return inst_(a[0], b[0], c, cbsz, abid, blgp); }
+
+// gfx942 _1k bf16 intrinsics require short vectors; bitcast bf16 -> short before calling
+#define DISPATCH_MFMA_BF16_1K_(ta_, tb_, tc_, wm_, wn_, wk_, inst_) \
+ (std::is_same_v<dtype_a, ta_> && std::is_same_v<dtype_b, tb_> && std::is_same_v<dtype_c, tc_> && wave_m == wm_ && wave_n == wn_ && wave_k == wk_) { \
+    using _sa = short __attribute__((ext_vector_type(elem_a))); using _sb = short __attribute__((ext_vector_type(elem_b))); \
+    return inst_(__builtin_bit_cast(_sa, a), __builtin_bit_cast(_sb, b), c, cbsz, abid, blgp); }
+
+#define DISPATCH_MFMA_STEP_K_BF16_1K_(ta_, tb_, tc_, wm_, wn_, wk_, inst_k_, inst_) \
+ (std::is_same_v<dtype_a, ta_> && std::is_same_v<dtype_b, tb_> && std::is_same_v<dtype_c, tc_> && wave_m == wm_ && wave_n == wn_ && wave_k == wk_) { \
+    constexpr index_t steps = wk_ / inst_k_;  constexpr index_t e_a = elem_a / steps; constexpr index_t e_b = elem_b / steps;   \
+    using _sa = short __attribute__((ext_vector_type(e_a))); using _sb = short __attribute__((ext_vector_type(e_b))); \
+    auto tmp = inst_(__builtin_bit_cast(_sa, slice(a, number<0>{}, number<e_a>{})), __builtin_bit_cast(_sb, slice(b, number<0>{}, number<e_b>{})), c, cbsz, abid, blgp);          \
+    static_for<steps - 1>([&](auto i){ tmp = inst_(__builtin_bit_cast(_sa, slice(a, number<e_a * (i+1)>{}, number<e_a*(i+2)>{})), __builtin_bit_cast(_sb, slice(b, number<e_b * (i+1)>{}, number<e_b * (i+2)>{})), tmp, cbsz, abid, blgp); });  \
+    return tmp; }
+
+// fp8/bf8 intrinsics expect packed long (8 x 8-bit = 64-bit); bitcast ext_vector -> long
+#define DISPATCH_MFMA_8BIT_(ta_, tb_, tc_, wm_, wn_, wk_, inst_) \
+ (std::is_same_v<dtype_a, ta_> && std::is_same_v<dtype_b, tb_> && std::is_same_v<dtype_c, tc_> && wave_m == wm_ && wave_n == wn_ && wave_k == wk_) { \
+    return inst_(__builtin_bit_cast(long, a), __builtin_bit_cast(long, b), c, cbsz, abid, blgp); }
+
+// scaled MFMA (f8f6f4): input bitcast to i32x8_t (256 bits); uses format codes, runtime scale, and 2-bit byte-selectors (scale_op_sel_a/b) into the packed-int32 scale word.
+#define DISPATCH_MFMA_SCALE_(ta_, tb_, tc_, wm_, wn_, wk_, inst_) \
+ (std::is_same_v<dtype_a, ta_> && std::is_same_v<dtype_b, tb_> && std::is_same_v<dtype_c, tc_> && wave_m == wm_ && wave_n == wn_ && wave_k == wk_) { \
+    return inst_(__builtin_bit_cast(i32x8_t, a), __builtin_bit_cast(i32x8_t, b), c, fmt_a, fmt_b, scale_op_sel_a, scale_a, scale_op_sel_b, scale_b); }
+
+// prefer use make_mfma() to create instance, which will return impl::mfma_adaptor_xxx. In this way we can access layout info from the "mma"
+//
+// Scaled MFMA (gfx950: __builtin_amdgcn_mfma_scale_f32_{32x32x64,16x16x128}_f8f6f4)
+// is also dispatched from this struct via the operator()(a, b, c, int scale_a, int scale_b) overload.
+// Input registers are always 256 bits (i32x8_t) regardless of element type; bitcast is done internally.
+// Format codes (Atype / Btype): 0=fp8(E4M3), 1=bf8(E5M2), 2=fp6(E2M3), 3=bf6(E3M2), 4=fp4(E2M1)
+// scale_a, scale_b: E8M0 exponent values (int); actual_scale = 2^(value - 127). Use 127 for no scaling.
+template<typename dtype_a_, typename dtype_b_, typename dtype_c_, index_t wave_m_, index_t wave_n_, index_t wave_k_, index_t warp_size_ = get_warp_size()>
+struct mfma {
+    using dtype_a = remove_cvref_t<dtype_a_>;
+    using dtype_b = remove_cvref_t<dtype_b_>;
+    using dtype_c = remove_cvref_t<dtype_c_>;
+    static constexpr index_t wave_m = wave_m_;
+    static constexpr index_t wave_n = wave_n_;
+    static constexpr index_t wave_k = wave_k_;
+    static constexpr index_t warp_size = warp_size_;
+    static constexpr index_t elem_a = wave_m * wave_k / warp_size;
+    static constexpr index_t elem_b = wave_n * wave_k / warp_size;
+    static constexpr index_t elem_c = wave_m * wave_n / warp_size;
+
+    using vtype_a = mfma_vtype_t<dtype_a, elem_a>;
+    using vtype_b = mfma_vtype_t<dtype_b, elem_b>;
+    using vtype_c = vector_t<dtype_c, elem_c>;
+
+    // Format code for scaled MFMA (f8f6f4); -1 for types that don't support scaling
+    static constexpr int fmt_a = std::is_same_v<dtype_a, fp8_t> ? 0 : std::is_same_v<dtype_a, bf8_t> ? 1 : std::is_same_v<dtype_a, fp4_t> ? 4 : -1;
+    static constexpr int fmt_b = std::is_same_v<dtype_b, fp8_t> ? 0 : std::is_same_v<dtype_b, bf8_t> ? 1 : std::is_same_v<dtype_b, fp4_t> ? 4 : -1;
+
+    // Regular MFMA dispatch (cbsz/abid/blgp are compile-time parameters)
+    template<typename VA, typename VB, typename VC, index_t cbsz = 0, index_t abid = 0, index_t blgp = 0>
+    OPUS_D constexpr auto operator()(const VA& a, const VB& b, const VC& c, number<cbsz> = {}, number<abid> = {}, number<blgp> = {}) -> vtype_c {
+        (void)a; (void)b; (void)c; // used by DISPATCH_MFMA_ macros; suppress -Wunused-parameter on host
+        if      constexpr (false) {} // in case of macro not defined
+#if defined(__gfx942__) || defined(__gfx9_4_generic__) || defined(__gfx950__)
+        else if constexpr DISPATCH_MFMA_(fp16_t, fp16_t, fp32_t, 32, 32,  8, __builtin_amdgcn_mfma_f32_32x32x8f16)
+        else if constexpr DISPATCH_MFMA_(fp16_t, fp16_t, fp32_t, 16, 16, 16, __builtin_amdgcn_mfma_f32_16x16x16f16)
+        else if constexpr DISPATCH_MFMA_BF16_1K_(bf16_t, bf16_t, fp32_t, 32, 32,  8, __builtin_amdgcn_mfma_f32_32x32x8bf16_1k)
+        else if constexpr DISPATCH_MFMA_BF16_1K_(bf16_t, bf16_t, fp32_t, 16, 16, 16, __builtin_amdgcn_mfma_f32_16x16x16bf16_1k)
+        else if constexpr DISPATCH_MFMA_8BIT_(fp8_t , fp8_t , fp32_t, 32, 32, 16, __builtin_amdgcn_mfma_f32_32x32x16_fp8_fp8)
+        else if constexpr DISPATCH_MFMA_8BIT_(fp8_t , fp8_t , fp32_t, 16, 16, 32, __builtin_amdgcn_mfma_f32_16x16x32_fp8_fp8)
+        else if constexpr DISPATCH_MFMA_8BIT_(bf8_t , bf8_t , fp32_t, 32, 32, 16, __builtin_amdgcn_mfma_f32_32x32x16_bf8_bf8)
+        else if constexpr DISPATCH_MFMA_8BIT_(bf8_t , bf8_t , fp32_t, 16, 16, 32, __builtin_amdgcn_mfma_f32_16x16x32_bf8_bf8)
+        else if constexpr DISPATCH_MFMA_F32_(fp32_t, fp32_t, fp32_t, 32, 32,  2, __builtin_amdgcn_mfma_f32_32x32x2f32)
+        else if constexpr DISPATCH_MFMA_F32_(fp32_t, fp32_t, fp32_t, 16, 16,  4, __builtin_amdgcn_mfma_f32_16x16x4f32)
+#endif
+#if defined(__gfx942__) || defined(__gfx9_4_generic__)
+        else if constexpr DISPATCH_MFMA_STEP_K_(fp16_t, fp16_t, fp32_t, 32, 32, 16,  8, __builtin_amdgcn_mfma_f32_32x32x8f16)
+        else if constexpr DISPATCH_MFMA_STEP_K_(fp16_t, fp16_t, fp32_t, 16, 16, 32, 16, __builtin_amdgcn_mfma_f32_16x16x16f16)
+        else if constexpr DISPATCH_MFMA_STEP_K_BF16_1K_(bf16_t, bf16_t, fp32_t, 32, 32, 16,  8, __builtin_amdgcn_mfma_f32_32x32x8bf16_1k)
+        else if constexpr DISPATCH_MFMA_STEP_K_BF16_1K_(bf16_t, bf16_t, fp32_t, 16, 16, 32, 16, __builtin_amdgcn_mfma_f32_16x16x16bf16_1k)
+#endif
+#if defined(__gfx950__)
+        else if constexpr DISPATCH_MFMA_(fp16_t, fp16_t, fp32_t, 32, 32, 16, __builtin_amdgcn_mfma_f32_32x32x16_f16)
+        else if constexpr DISPATCH_MFMA_(fp16_t, fp16_t, fp32_t, 16, 16, 32, __builtin_amdgcn_mfma_f32_16x16x32_f16)
+        else if constexpr DISPATCH_MFMA_(bf16_t, bf16_t, fp32_t, 32, 32, 16, __builtin_amdgcn_mfma_f32_32x32x16_bf16)
+        else if constexpr DISPATCH_MFMA_(bf16_t, bf16_t, fp32_t, 16, 16, 32, __builtin_amdgcn_mfma_f32_16x16x32_bf16)
+#endif
+        __builtin_unreachable();    // supprize warning for return type deduction
+    }
+
+    template<typename VA, typename VB, index_t cbsz = 0, index_t abid = 0, index_t blgp = 0>
+    OPUS_D constexpr auto operator()(const VA& a, const VB& b, number<cbsz> = {}, number<abid> = {}, number<blgp> = {}) {
+        vtype_c c{0}; return operator()(a, b, c, number<cbsz>{}, number<abid>{}, number<blgp>{});
+    }
+
+    // Scaled MFMA dispatch (gfx950: f8f6f4 with E8M0 block exponent scaling)
+    // scale_a, scale_b are runtime E8M0 exponent values; 127 = no scaling (2^0 = 1.0).
+    // scale_op_sel_a/b: compile-time 2-bit byte-selectors picking which byte of the packed-int32 scale word feeds this MFMA; 0 = low byte = legacy scalar behavior.
+    template<typename VA, typename VB, typename VC, index_t scale_op_sel_a = 0, index_t scale_op_sel_b = 0>
+    OPUS_D constexpr auto operator()(const VA& a, const VB& b, const VC& c, int scale_a, int scale_b, number<scale_op_sel_a> = {}, number<scale_op_sel_b> = {}) -> vtype_c {
+        (void)a; (void)b; (void)c; (void)scale_a; (void)scale_b;  // used by DISPATCH_MFMA_SCALE_; suppress -Wunused-parameter on host
+        if      constexpr (false) {}
+#if defined(__gfx950__)
+        else if constexpr DISPATCH_MFMA_SCALE_(fp8_t, fp8_t, fp32_t, 32, 32,  64, __builtin_amdgcn_mfma_scale_f32_32x32x64_f8f6f4)
+        else if constexpr DISPATCH_MFMA_SCALE_(fp8_t, fp8_t, fp32_t, 16, 16, 128, __builtin_amdgcn_mfma_scale_f32_16x16x128_f8f6f4)
+        else if constexpr DISPATCH_MFMA_SCALE_(fp4_t, fp4_t, fp32_t, 32, 32,  64, __builtin_amdgcn_mfma_scale_f32_32x32x64_f8f6f4)
+        else if constexpr DISPATCH_MFMA_SCALE_(fp4_t, fp4_t, fp32_t, 16, 16, 128, __builtin_amdgcn_mfma_scale_f32_16x16x128_f8f6f4)
+#endif
+        __builtin_unreachable();
+    }
+
+    template<typename VA, typename VB, index_t scale_op_sel_a = 0, index_t scale_op_sel_b = 0>
+    OPUS_D constexpr auto operator()(const VA& a, const VB& b, int scale_a, int scale_b, number<scale_op_sel_a> = {}, number<scale_op_sel_b> = {}) {
+        vtype_c c{0}; return operator()(a, b, c, scale_a, scale_b, number<scale_op_sel_a>{}, number<scale_op_sel_b>{});
+    }
+};
+#undef DISPATCH_MFMA_
+#undef DISPATCH_MFMA_F32_
+#undef DISPATCH_MFMA_STEP_K_
+#undef DISPATCH_MFMA_BF16_1K_
+#undef DISPATCH_MFMA_STEP_K_BF16_1K_
+#undef DISPATCH_MFMA_8BIT_
+#undef DISPATCH_MFMA_SCALE_
+
+using mfma_f32_32x32x2_f32      = mfma<fp32_t, fp32_t, fp32_t, 32, 32,  2>;
+using mfma_f32_16x16x4_f32      = mfma<fp32_t, fp32_t, fp32_t, 16, 16,  4>;
+using mfma_f32_32x32x8_f16      = mfma<fp16_t, fp16_t, fp32_t, 32, 32,  8>;
+using mfma_f32_16x16x16_f16     = mfma<fp16_t, fp16_t, fp32_t, 16, 16, 16>;
+using mfma_f32_32x32x8_bf16     = mfma<bf16_t, bf16_t, fp32_t, 32, 32,  8>;
+using mfma_f32_16x16x16_bf16    = mfma<bf16_t, bf16_t, fp32_t, 16, 16, 16>;
+using mfma_f32_32x32x16_f16     = mfma<fp16_t, fp16_t, fp32_t, 32, 32, 16>;
+using mfma_f32_16x16x32_f16     = mfma<fp16_t, fp16_t, fp32_t, 16, 16, 32>;
+using mfma_f32_32x32x16_bf16    = mfma<bf16_t, bf16_t, fp32_t, 32, 32, 16>;
+using mfma_f32_16x16x32_bf16    = mfma<bf16_t, bf16_t, fp32_t, 16, 16, 32>;
+using mfma_f32_32x32x16_fp8_fp8 = mfma<fp8_t , fp8_t , fp32_t, 32, 32, 16>;
+using mfma_f32_16x16x32_fp8_fp8 = mfma<fp8_t , fp8_t , fp32_t, 16, 16, 32>;
+using mfma_f32_32x32x16_bf8_bf8 = mfma<bf8_t , bf8_t , fp32_t, 32, 32, 16>;
+using mfma_f32_16x16x32_bf8_bf8 = mfma<bf8_t , bf8_t , fp32_t, 16, 16, 32>;
+// Scaled MFMA type aliases (gfx950 only, unified into struct mfma)
+using mfma_f32_32x32x64_fp8_fp8   = mfma<fp8_t, fp8_t, fp32_t, 32, 32,  64>;
+using mfma_f32_16x16x128_fp8_fp8  = mfma<fp8_t, fp8_t, fp32_t, 16, 16, 128>;
+using mfma_f32_32x32x64_fp4_fp4   = mfma<fp4_t, fp4_t, fp32_t, 32, 32,  64>;
+using mfma_f32_16x16x128_fp4_fp4  = mfma<fp4_t, fp4_t, fp32_t, 16, 16, 128>;
+// Backward-compatible aliases (deprecated: prefer mfma_f32_* above)
+using mfma_scale_f32_32x32x64_fp8_fp8   = mfma_f32_32x32x64_fp8_fp8;
+using mfma_scale_f32_16x16x128_fp8_fp8  = mfma_f32_16x16x128_fp8_fp8;
+using mfma_scale_f32_32x32x64_fp4_fp4   = mfma_f32_32x32x64_fp4_fp4;
+using mfma_scale_f32_16x16x128_fp4_fp4  = mfma_f32_16x16x128_fp4_fp4;
+#endif // __GFX9__ (mfma)
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////
+// wmma (RDNA4 / wave32) -- gfx1250 uses wmma-256b builtins (16x16x{4,32,64,128}); gfx1200/gfx1201 (Navi 44/48) use wmma-128b _w32_gfx12 builtins (16x16x16). Dispatch macros for the two arg-list shapes differ -- gfx12 set is DISPATCH_WMMA_GFX12_*.
+#if defined(__gfx1250__) || defined(__gfx1201__) || defined(__gfx1200__) || !defined(__HIP_DEVICE_COMPILE__)
+// f16/bf16/f32 builtins: (neg_a, A, neg_b, B, matrix_fmts, C, clamp, neg_c)
+#define DISPATCH_WMMA_(ta_, tb_, tc_, wm_, wn_, wk_, inst_) \
+ (std::is_same_v<dtype_a, ta_> && std::is_same_v<dtype_b, tb_> && std::is_same_v<dtype_c, tc_> && \
+  wave_m == wm_ && wave_n == wn_ && wave_k == wk_) { \
+    return inst_(false, a, false, b, static_cast<short>(0), c, false, false); }
+// bf16f32 special: accumulator is f32 but output is bf16 => (neg_a, A, neg_b, B, fmts, C_f32, clamp, neg_c)
+// The builtin takes f32 accumulator and returns bf16 output; we store the f32 accum but return bf16.
+#define DISPATCH_WMMA_BF16F32_(ta_, tb_, tc_, wm_, wn_, wk_, inst_) \
+ (std::is_same_v<dtype_a, ta_> && std::is_same_v<dtype_b, tb_> && std::is_same_v<dtype_c, tc_> && \
+  wave_m == wm_ && wave_n == wn_ && wave_k == wk_) { \
+    return inst_(false, a, false, b, static_cast<short>(0), c, false, false); }
+// fp8/bf8 builtins: (A, B, matrix_fmts, C, clamp, neg_c)  -- no neg_a/neg_b
+// A/B are packed as _ExtVector<N, int>; bitcast from the fp8/bf8 vector
+#define DISPATCH_WMMA_8BIT_(ta_, tb_, tc_, wm_, wn_, wk_, inst_) \
+ (std::is_same_v<dtype_a, ta_> && std::is_same_v<dtype_b, tb_> && std::is_same_v<dtype_c, tc_> && \
+  wave_m == wm_ && wave_n == wn_ && wave_k == wk_) { \
+    constexpr index_t i32_a = elem_a * static_cast<index_t>(sizeof(dtype_a)) / static_cast<index_t>(sizeof(i32_t)); \
+    constexpr index_t i32_b = elem_b * static_cast<index_t>(sizeof(dtype_b)) / static_cast<index_t>(sizeof(i32_t)); \
+    return inst_(__builtin_bit_cast(vector_t<i32_t, i32_a>, a), \
+                 __builtin_bit_cast(vector_t<i32_t, i32_b>, b), \
+                 static_cast<short>(0), c, false, false); }
+
+// gfx12 builtins: 3-arg (A, B, C) -- no matrix_fmts/neg_c. ws_ selects _w32/_w64 (same {wm,wn,wk} triple).
+#define DISPATCH_WMMA_GFX12_MATCH_(ta_, tb_, tc_, wm_, wn_, wk_, ws_) \
+    (std::is_same_v<dtype_a, ta_> && std::is_same_v<dtype_b, tb_> && std::is_same_v<dtype_c, tc_> && wave_m == wm_ && wave_n == wn_ && wave_k == wk_ && warp_size == ws_)
+#define DISPATCH_WMMA_GFX12_F32_(ta_, tb_, tc_, wm_, wn_, wk_, ws_, inst_) \
+    DISPATCH_WMMA_GFX12_MATCH_(ta_, tb_, tc_, wm_, wn_, wk_, ws_) { return inst_(a, b, c); }
+#define DISPATCH_WMMA_GFX12_8BIT_(ta_, tb_, tc_, wm_, wn_, wk_, ws_, inst_) /* fp8/bf8: A/B bitcast to i32 */ \
+    DISPATCH_WMMA_GFX12_MATCH_(ta_, tb_, tc_, wm_, wn_, wk_, ws_) { \
+    constexpr index_t i32_a = elem_a * static_cast<index_t>(sizeof(dtype_a)) / static_cast<index_t>(sizeof(i32_t)); \
+    constexpr index_t i32_b = elem_b * static_cast<index_t>(sizeof(dtype_b)) / static_cast<index_t>(sizeof(i32_t)); \
+    return inst_(__builtin_bit_cast(vector_t<i32_t, i32_a>, a), __builtin_bit_cast(vector_t<i32_t, i32_b>, b), c); }
+#define DISPATCH_WMMA_GFX12_F32_STEP_K_(ta_, tb_, tc_, wm_, wn_, wk_, ws_, inst_k_, inst_) /* chain Nxinst for wider K */ \
+    DISPATCH_WMMA_GFX12_MATCH_(ta_, tb_, tc_, wm_, wn_, wk_, ws_) { \
+    constexpr index_t steps = wk_ / inst_k_, e_a = elem_a / steps, e_b = elem_b / steps; \
+    auto tmp = inst_(slice(a, number<0>{}, number<e_a>{}), slice(b, number<0>{}, number<e_b>{}), c); \
+    static_for<steps - 1>([&](auto i){ tmp = inst_(slice(a, number<e_a*(i+1)>{}, number<e_a*(i+2)>{}), slice(b, number<e_b*(i+1)>{}, number<e_b*(i+2)>{}), tmp); }); \
+    return tmp; }
+
+template<typename dtype_a_, typename dtype_b_, typename dtype_c_, index_t wave_m_, index_t wave_n_, index_t wave_k_, index_t warp_size_ = get_warp_size()>
+struct wmma {
+    using dtype_a = remove_cvref_t<dtype_a_>;
+    using dtype_b = remove_cvref_t<dtype_b_>;
+    using dtype_c = remove_cvref_t<dtype_c_>;
+    static constexpr index_t wave_m = wave_m_;
+    static constexpr index_t wave_n = wave_n_;
+    static constexpr index_t wave_k = wave_k_;
+    static constexpr index_t warp_size = warp_size_;  // 32 for gfx1250
+    static constexpr index_t elem_a = wave_m * wave_k / warp_size;
+    static constexpr index_t elem_b = wave_n * wave_k / warp_size;
+    static constexpr index_t elem_c = wave_m * wave_n / warp_size;
+
+    // For packed types (fp4), the hardware register packs multiple elements per byte.
+    // elem counts logical elements; the register holds elem * bits_per_element / 8 bytes.
+    // For non-packed types, sizeof(T) gives bytes per element directly.
+    static constexpr index_t reg_bytes_a = is_packs_v<dtype_a> ? (elem_a * sizeof_bits<dtype_a>::value / 8) : (elem_a * static_cast<index_t>(sizeof(dtype_a)));
+    static constexpr index_t reg_bytes_b = is_packs_v<dtype_b> ? (elem_b * sizeof_bits<dtype_b>::value / 8) : (elem_b * static_cast<index_t>(sizeof(dtype_b)));
+
+    // vtype: for packed types, use i32 dword vector matching the hardware register size.
+    // For non-packed types, use mfma_vtype_t (which gives ext_vector of the element type).
+    using vtype_a = std::conditional_t<is_packs_v<dtype_a>, vector_t<i32_t, reg_bytes_a / static_cast<index_t>(sizeof(i32_t))>, mfma_vtype_t<dtype_a, elem_a>>;
+    using vtype_b = std::conditional_t<is_packs_v<dtype_b>, vector_t<i32_t, reg_bytes_b / static_cast<index_t>(sizeof(i32_t))>, mfma_vtype_t<dtype_b, elem_b>>;
+    using vtype_c = vector_t<dtype_c, elem_c>;
+
+    // Format code for scaled WMMA (f8f6f4); -1 for types that don't support scaling
+    static constexpr int fmt_a = std::is_same_v<dtype_a, fp8_t> ? 0 : std::is_same_v<dtype_a, bf8_t> ? 1 : std::is_same_v<dtype_a, fp4_t> ? 4 : -1;
+    static constexpr int fmt_b = std::is_same_v<dtype_b, fp8_t> ? 0 : std::is_same_v<dtype_b, bf8_t> ? 1 : std::is_same_v<dtype_b, fp4_t> ? 4 : -1;
+
+    // Regular (non-scaled) dispatch
+    template<typename VA, typename VB, typename VC>
+    OPUS_D constexpr auto operator()(const VA& a, const VB& b, const VC& c) -> vtype_c {
+        (void)a; (void)b; (void)c;
+        if      constexpr (false) {}
+#if defined(__gfx1250__)
+        // f16/bf16 16x16x32
+        else if constexpr DISPATCH_WMMA_(fp16_t, fp16_t, fp32_t, 16, 16, 32, __builtin_amdgcn_wmma_f32_16x16x32_f16)
+        else if constexpr DISPATCH_WMMA_(fp16_t, fp16_t, fp16_t, 16, 16, 32, __builtin_amdgcn_wmma_f16_16x16x32_f16)
+        else if constexpr DISPATCH_WMMA_(bf16_t, bf16_t, fp32_t, 16, 16, 32, __builtin_amdgcn_wmma_f32_16x16x32_bf16)
+        else if constexpr DISPATCH_WMMA_(bf16_t, bf16_t, bf16_t, 16, 16, 32, __builtin_amdgcn_wmma_bf16_16x16x32_bf16)
+        // f32 16x16x4
+        else if constexpr DISPATCH_WMMA_(fp32_t, fp32_t, fp32_t, 16, 16,  4, __builtin_amdgcn_wmma_f32_16x16x4_f32)
+        // fp8/bf8 16x16x64 -> f32
+        else if constexpr DISPATCH_WMMA_8BIT_(fp8_t, fp8_t, fp32_t, 16, 16, 64, __builtin_amdgcn_wmma_f32_16x16x64_fp8_fp8)
+        else if constexpr DISPATCH_WMMA_8BIT_(fp8_t, bf8_t, fp32_t, 16, 16, 64, __builtin_amdgcn_wmma_f32_16x16x64_fp8_bf8)
+        else if constexpr DISPATCH_WMMA_8BIT_(bf8_t, fp8_t, fp32_t, 16, 16, 64, __builtin_amdgcn_wmma_f32_16x16x64_bf8_fp8)
+        else if constexpr DISPATCH_WMMA_8BIT_(bf8_t, bf8_t, fp32_t, 16, 16, 64, __builtin_amdgcn_wmma_f32_16x16x64_bf8_bf8)
+        // fp8/bf8 16x16x64 -> f16
+        else if constexpr DISPATCH_WMMA_8BIT_(fp8_t, fp8_t, fp16_t, 16, 16, 64, __builtin_amdgcn_wmma_f16_16x16x64_fp8_fp8)
+        else if constexpr DISPATCH_WMMA_8BIT_(fp8_t, bf8_t, fp16_t, 16, 16, 64, __builtin_amdgcn_wmma_f16_16x16x64_fp8_bf8)
+        else if constexpr DISPATCH_WMMA_8BIT_(bf8_t, fp8_t, fp16_t, 16, 16, 64, __builtin_amdgcn_wmma_f16_16x16x64_bf8_fp8)
+        else if constexpr DISPATCH_WMMA_8BIT_(bf8_t, bf8_t, fp16_t, 16, 16, 64, __builtin_amdgcn_wmma_f16_16x16x64_bf8_bf8)
+        // fp8/bf8 16x16x128 -> f32
+        else if constexpr DISPATCH_WMMA_8BIT_(fp8_t, fp8_t, fp32_t, 16, 16, 128, __builtin_amdgcn_wmma_f32_16x16x128_fp8_fp8)
+        else if constexpr DISPATCH_WMMA_8BIT_(fp8_t, bf8_t, fp32_t, 16, 16, 128, __builtin_amdgcn_wmma_f32_16x16x128_fp8_bf8)
+        else if constexpr DISPATCH_WMMA_8BIT_(bf8_t, fp8_t, fp32_t, 16, 16, 128, __builtin_amdgcn_wmma_f32_16x16x128_bf8_fp8)
+        else if constexpr DISPATCH_WMMA_8BIT_(bf8_t, bf8_t, fp32_t, 16, 16, 128, __builtin_amdgcn_wmma_f32_16x16x128_bf8_bf8)
+        // fp8/bf8 16x16x128 -> f16
+        else if constexpr DISPATCH_WMMA_8BIT_(fp8_t, fp8_t, fp16_t, 16, 16, 128, __builtin_amdgcn_wmma_f16_16x16x128_fp8_fp8)
+        else if constexpr DISPATCH_WMMA_8BIT_(fp8_t, bf8_t, fp16_t, 16, 16, 128, __builtin_amdgcn_wmma_f16_16x16x128_fp8_bf8)
+        else if constexpr DISPATCH_WMMA_8BIT_(bf8_t, fp8_t, fp16_t, 16, 16, 128, __builtin_amdgcn_wmma_f16_16x16x128_bf8_fp8)
+        else if constexpr DISPATCH_WMMA_8BIT_(bf8_t, bf8_t, fp16_t, 16, 16, 128, __builtin_amdgcn_wmma_f16_16x16x128_bf8_bf8)
+#endif
+#if defined(__gfx1201__) || defined(__gfx1200__)
+        // _w32/_w64 builtins gated by wavefrontsize target feature; OPUS_GFX120X_IS_WAVE32 selects the active wave mode.
+#  if OPUS_GFX120X_IS_WAVE32
+        // gfx12 wave32 16x16x16: f16/bf16/fp8/bf8 -> f32 + same-type acc. iu8/iu4 deferred.
+        else if constexpr DISPATCH_WMMA_GFX12_F32_ (fp16_t, fp16_t, fp32_t , 16, 16, 16, 32, __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12)
+        else if constexpr DISPATCH_WMMA_GFX12_F32_ (bf16_t, bf16_t, fp32_t , 16, 16, 16, 32, __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12)
+        else if constexpr DISPATCH_WMMA_GFX12_F32_ (fp16_t, fp16_t, fp16_t , 16, 16, 16, 32, __builtin_amdgcn_wmma_f16_16x16x16_f16_w32_gfx12)
+        else if constexpr DISPATCH_WMMA_GFX12_F32_ (bf16_t, bf16_t, bf16_t , 16, 16, 16, 32, __builtin_amdgcn_wmma_bf16_16x16x16_bf16_w32_gfx12)
+        else if constexpr DISPATCH_WMMA_GFX12_8BIT_(fp8_t , fp8_t , fp32_t , 16, 16, 16, 32, __builtin_amdgcn_wmma_f32_16x16x16_fp8_fp8_w32_gfx12)
+        else if constexpr DISPATCH_WMMA_GFX12_8BIT_(fp8_t , bf8_t , fp32_t , 16, 16, 16, 32, __builtin_amdgcn_wmma_f32_16x16x16_fp8_bf8_w32_gfx12)
+        else if constexpr DISPATCH_WMMA_GFX12_8BIT_(bf8_t , fp8_t , fp32_t , 16, 16, 16, 32, __builtin_amdgcn_wmma_f32_16x16x16_bf8_fp8_w32_gfx12)
+        else if constexpr DISPATCH_WMMA_GFX12_8BIT_(bf8_t , bf8_t , fp32_t , 16, 16, 16, 32, __builtin_amdgcn_wmma_f32_16x16x16_bf8_bf8_w32_gfx12)
+        // gfx12 wave32 16x16x32 synthetic: 2x stacked 16x16x16 along K.
+        else if constexpr DISPATCH_WMMA_GFX12_F32_STEP_K_(fp16_t, fp16_t, fp32_t , 16, 16, 32, 32, 16, __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12)
+        else if constexpr DISPATCH_WMMA_GFX12_F32_STEP_K_(bf16_t, bf16_t, fp32_t , 16, 16, 32, 32, 16, __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12)
+        else if constexpr DISPATCH_WMMA_GFX12_F32_STEP_K_(fp16_t, fp16_t, fp16_t , 16, 16, 32, 32, 16, __builtin_amdgcn_wmma_f16_16x16x16_f16_w32_gfx12)
+        else if constexpr DISPATCH_WMMA_GFX12_F32_STEP_K_(bf16_t, bf16_t, bf16_t , 16, 16, 32, 32, 16, __builtin_amdgcn_wmma_bf16_16x16x16_bf16_w32_gfx12)
+#  endif // wave32 builtin available
+#  if !OPUS_GFX120X_IS_WAVE32
+        // gfx12 wave64 16x16x16: native _w64_gfx12 builtins (4 elem/lane). Requires -mwavefrontsize64.
+        else if constexpr DISPATCH_WMMA_GFX12_F32_ (fp16_t, fp16_t, fp32_t , 16, 16, 16, 64, __builtin_amdgcn_wmma_f32_16x16x16_f16_w64_gfx12)
+        else if constexpr DISPATCH_WMMA_GFX12_F32_ (bf16_t, bf16_t, fp32_t , 16, 16, 16, 64, __builtin_amdgcn_wmma_f32_16x16x16_bf16_w64_gfx12)
+        else if constexpr DISPATCH_WMMA_GFX12_F32_ (fp16_t, fp16_t, fp16_t , 16, 16, 16, 64, __builtin_amdgcn_wmma_f16_16x16x16_f16_w64_gfx12)
+        else if constexpr DISPATCH_WMMA_GFX12_F32_ (bf16_t, bf16_t, bf16_t , 16, 16, 16, 64, __builtin_amdgcn_wmma_bf16_16x16x16_bf16_w64_gfx12)
+        // gfx12 wave64 16x16x32 synthetic: 2x stacked _w64 16x16x16 (8 elem/lane = 1 b128 load).
+        else if constexpr DISPATCH_WMMA_GFX12_F32_STEP_K_(fp16_t, fp16_t, fp32_t , 16, 16, 32, 64, 16, __builtin_amdgcn_wmma_f32_16x16x16_f16_w64_gfx12)
+        else if constexpr DISPATCH_WMMA_GFX12_F32_STEP_K_(bf16_t, bf16_t, fp32_t , 16, 16, 32, 64, 16, __builtin_amdgcn_wmma_f32_16x16x16_bf16_w64_gfx12)
+        else if constexpr DISPATCH_WMMA_GFX12_F32_STEP_K_(fp16_t, fp16_t, fp16_t , 16, 16, 32, 64, 16, __builtin_amdgcn_wmma_f16_16x16x16_f16_w64_gfx12)
+        else if constexpr DISPATCH_WMMA_GFX12_F32_STEP_K_(bf16_t, bf16_t, bf16_t , 16, 16, 32, 64, 16, __builtin_amdgcn_wmma_bf16_16x16x16_bf16_w64_gfx12)
+#  endif // wave64 builtin available
+#endif // __gfx1201__ / __gfx1200__
+        __builtin_unreachable();
+    }
+
+    template<typename VA, typename VB>
+    OPUS_D constexpr auto operator()(const VA& a, const VB& b) {
+        vtype_c c{0}; return operator()(a, b, c);
+    }
+
+    // Scaled WMMA dispatch (gfx1250: f8f6f4 / f4 with E8M0 block-scale)
+    // scale_a, scale_b are per-lane E8M0 exponent values; 127 = no scaling (2^0 = 1.0).
+    // BX32: int -- 4 packed E8M0 bytes (byte 0 used with scale_sel=0, scale_fmt=0).
+    // BX16: long -- 8 packed E8M0 bytes.
+    // matrix_a_scale_sel controls OPSEL: 0=scale from lanes 0-15, 1=scale from lanes 16-31.
+
+    // BX32 scaled dispatch
+    template<typename VA, typename VB, typename VC, index_t a_scale_sel = 0, index_t b_scale_sel = 0>
+    OPUS_D constexpr auto operator()(const VA& a, const VB& b, const VC& c,
+                                     int scale_a, int scale_b,
+                                     number<a_scale_sel> = {}, number<b_scale_sel> = {}) -> vtype_c {
+        (void)a; (void)b; (void)c; (void)scale_a; (void)scale_b;
+        if constexpr (false) {}
+#if defined(__gfx1250__)
+        // 16x16x128 f8f6f4 (fp8/fp4 via format code): builtin always takes i32x16
+        else if constexpr (fmt_a >= 0 && fmt_b >= 0 && std::is_same_v<dtype_c, fp32_t> && wave_m == 16 && wave_n == 16 && wave_k == 128) {
+            // For packed types (fp4), vtype may be smaller than i32x16; zero-pad via union.
+            auto pad_to_i32x16 = [](const auto& v) {
+                if constexpr (sizeof(v) == sizeof(i32x16_t)) return __builtin_bit_cast(i32x16_t, v);
+                else { union { i32x16_t w; char z[sizeof(i32x16_t)]; } u{}; __builtin_memcpy(&u, &v, sizeof(v)); return u.w; }
+            };
+            return __builtin_amdgcn_wmma_scale_f32_16x16x128_f8f6f4(
+                fmt_a, pad_to_i32x16(a),
+                fmt_b, pad_to_i32x16(b),
+                static_cast<short>(0), c,
+                a_scale_sel, 0, scale_a, b_scale_sel, 0, scale_b, false, false);
+        }
+        // 32x16x128 f4 (dedicated fp4 instruction): A=i32x16, B=i32x8
+        else if constexpr (std::is_same_v<dtype_a, fp4_t> && std::is_same_v<dtype_b, fp4_t> && std::is_same_v<dtype_c, fp32_t> && wave_m == 32 && wave_n == 16 && wave_k == 128) {
+            return __builtin_amdgcn_wmma_scale_f32_32x16x128_f4(
+                __builtin_bit_cast(i32x16_t, a),
+                __builtin_bit_cast(i32x8_t, b),
+                static_cast<short>(0), c,
+                a_scale_sel, 0, scale_a, b_scale_sel, 0, scale_b, false, false);
+        }
+#endif
+        __builtin_unreachable();
+    }
+
+    template<typename VA, typename VB, index_t a_scale_sel = 0, index_t b_scale_sel = 0>
+    OPUS_D constexpr auto operator()(const VA& a, const VB& b, int scale_a, int scale_b,
+                                     number<a_scale_sel> = {}, number<b_scale_sel> = {}) {
+        vtype_c c{0}; return operator()(a, b, c, scale_a, scale_b, number<a_scale_sel>{}, number<b_scale_sel>{});
+    }
+
+    // BX16 scaled dispatch (scale exponent is long = 64 bits = 8 packed E8M0 bytes)
+    template<typename VA, typename VB, typename VC, index_t a_scale_sel = 0, index_t b_scale_sel = 0>
+    OPUS_D constexpr auto operator()(const VA& a, const VB& b, const VC& c,
+                                     long scale_a, long scale_b,
+                                     number<a_scale_sel> = {}, number<b_scale_sel> = {}) -> vtype_c {
+        (void)a; (void)b; (void)c; (void)scale_a; (void)scale_b;
+        if constexpr (false) {}
+#if defined(__gfx1250__)
+        // 16x16x128 f8f6f4 BX16
+        else if constexpr (fmt_a >= 0 && fmt_b >= 0 && std::is_same_v<dtype_c, fp32_t> && wave_m == 16 && wave_n == 16 && wave_k == 128) {
+            auto pad_to_i32x16 = [](const auto& v) {
+                if constexpr (sizeof(v) == sizeof(i32x16_t)) return __builtin_bit_cast(i32x16_t, v);
+                else { union { i32x16_t w; char z[sizeof(i32x16_t)]; } u{}; __builtin_memcpy(&u, &v, sizeof(v)); return u.w; }
+            };
+            return __builtin_amdgcn_wmma_scale16_f32_16x16x128_f8f6f4(
+                fmt_a, pad_to_i32x16(a),
+                fmt_b, pad_to_i32x16(b),
+                static_cast<short>(0), c,
+                a_scale_sel, 0, scale_a, b_scale_sel, 0, scale_b, false, false);
+        }
+        // 32x16x128 f4 BX16
+        else if constexpr (std::is_same_v<dtype_a, fp4_t> && std::is_same_v<dtype_b, fp4_t> && std::is_same_v<dtype_c, fp32_t> && wave_m == 32 && wave_n == 16 && wave_k == 128) {
+            return __builtin_amdgcn_wmma_scale16_f32_32x16x128_f4(
+                __builtin_bit_cast(i32x16_t, a),
+                __builtin_bit_cast(i32x8_t, b),
+                static_cast<short>(0), c,
+                a_scale_sel, 0, scale_a, b_scale_sel, 0, scale_b, false, false);
+        }
+#endif
+        __builtin_unreachable();
+    }
+
+    template<typename VA, typename VB, index_t a_scale_sel = 0, index_t b_scale_sel = 0>
+    OPUS_D constexpr auto operator()(const VA& a, const VB& b, long scale_a, long scale_b,
+                                     number<a_scale_sel> = {}, number<b_scale_sel> = {}) {
+        vtype_c c{0}; return operator()(a, b, c, scale_a, scale_b, number<a_scale_sel>{}, number<b_scale_sel>{});
+    }
+};
+#undef DISPATCH_WMMA_
+#undef DISPATCH_WMMA_BF16F32_
+#undef DISPATCH_WMMA_8BIT_
+#undef DISPATCH_WMMA_GFX12_MATCH_
+#undef DISPATCH_WMMA_GFX12_F32_
+#undef DISPATCH_WMMA_GFX12_8BIT_
+#undef DISPATCH_WMMA_GFX12_F32_STEP_K_
+
+// gfx12 wave32 16x16x16 aliases (default warp_size). wave64 + synthetic 16x16x32 aliases below.
+using wmma_f32_16x16x16_f16     = wmma<fp16_t, fp16_t, fp32_t, 16, 16, 16>;
+using wmma_f16_16x16x16_f16     = wmma<fp16_t, fp16_t, fp16_t, 16, 16, 16>;
+using wmma_f32_16x16x16_bf16    = wmma<bf16_t, bf16_t, fp32_t, 16, 16, 16>;
+using wmma_bf16_16x16x16_bf16   = wmma<bf16_t, bf16_t, bf16_t, 16, 16, 16>;
+using wmma_f32_16x16x16_fp8_fp8 = wmma<fp8_t , fp8_t , fp32_t, 16, 16, 16>;
+using wmma_f32_16x16x16_fp8_bf8 = wmma<fp8_t , bf8_t , fp32_t, 16, 16, 16>;
+using wmma_f32_16x16x16_bf8_fp8 = wmma<bf8_t , fp8_t , fp32_t, 16, 16, 16>;
+using wmma_f32_16x16x16_bf8_bf8 = wmma<bf8_t , bf8_t , fp32_t, 16, 16, 16>;
+// gfx12 wave32 16x16x32 synthetic (2x 16x16x16).
+using wmma_f32_16x16x32_f16_w32   = wmma<fp16_t, fp16_t, fp32_t, 16, 16, 32, 32>;
+using wmma_f32_16x16x32_bf16_w32  = wmma<bf16_t, bf16_t, fp32_t, 16, 16, 32, 32>;
+using wmma_f16_16x16x32_f16_w32   = wmma<fp16_t, fp16_t, fp16_t, 16, 16, 32, 32>;
+using wmma_bf16_16x16x32_bf16_w32 = wmma<bf16_t, bf16_t, bf16_t, 16, 16, 32, 32>;
+// gfx12 wave64 16x16x16 (-mwavefrontsize64).
+using wmma_f32_16x16x16_f16_w64   = wmma<fp16_t, fp16_t, fp32_t, 16, 16, 16, 64>;
+using wmma_f32_16x16x16_bf16_w64  = wmma<bf16_t, bf16_t, fp32_t, 16, 16, 16, 64>;
+using wmma_f16_16x16x16_f16_w64   = wmma<fp16_t, fp16_t, fp16_t, 16, 16, 16, 64>;
+using wmma_bf16_16x16x16_bf16_w64 = wmma<bf16_t, bf16_t, bf16_t, 16, 16, 16, 64>;
+// gfx12 wave64 16x16x32 synthetic (2x 16x16x16_w64).
+using wmma_f32_16x16x32_f16_w64   = wmma<fp16_t, fp16_t, fp32_t, 16, 16, 32, 64>;
+using wmma_f32_16x16x32_bf16_w64  = wmma<bf16_t, bf16_t, fp32_t, 16, 16, 32, 64>;
+using wmma_f16_16x16x32_f16_w64   = wmma<fp16_t, fp16_t, fp16_t, 16, 16, 32, 64>;
+using wmma_bf16_16x16x32_bf16_w64 = wmma<bf16_t, bf16_t, bf16_t, 16, 16, 32, 64>;
+
+// f16/bf16 16x16x32
+using wmma_f32_16x16x32_f16   = wmma<fp16_t, fp16_t, fp32_t, 16, 16, 32>;
+using wmma_f16_16x16x32_f16   = wmma<fp16_t, fp16_t, fp16_t, 16, 16, 32>;
+using wmma_f32_16x16x32_bf16  = wmma<bf16_t, bf16_t, fp32_t, 16, 16, 32>;
+using wmma_bf16_16x16x32_bf16 = wmma<bf16_t, bf16_t, bf16_t, 16, 16, 32>;
+// f32 16x16x4
+using wmma_f32_16x16x4_f32    = wmma<fp32_t, fp32_t, fp32_t, 16, 16,  4>;
+// fp8/bf8 16x16x64
+using wmma_f32_16x16x64_fp8_fp8  = wmma<fp8_t, fp8_t, fp32_t, 16, 16, 64>;
+using wmma_f32_16x16x64_fp8_bf8  = wmma<fp8_t, bf8_t, fp32_t, 16, 16, 64>;
+using wmma_f32_16x16x64_bf8_fp8  = wmma<bf8_t, fp8_t, fp32_t, 16, 16, 64>;
+using wmma_f32_16x16x64_bf8_bf8  = wmma<bf8_t, bf8_t, fp32_t, 16, 16, 64>;
+using wmma_f16_16x16x64_fp8_fp8  = wmma<fp8_t, fp8_t, fp16_t, 16, 16, 64>;
+using wmma_f16_16x16x64_fp8_bf8  = wmma<fp8_t, bf8_t, fp16_t, 16, 16, 64>;
+using wmma_f16_16x16x64_bf8_fp8  = wmma<bf8_t, fp8_t, fp16_t, 16, 16, 64>;
+using wmma_f16_16x16x64_bf8_bf8  = wmma<bf8_t, bf8_t, fp16_t, 16, 16, 64>;
+// fp8/bf8 16x16x128
+using wmma_f32_16x16x128_fp8_fp8 = wmma<fp8_t, fp8_t, fp32_t, 16, 16, 128>;
+using wmma_f32_16x16x128_fp8_bf8 = wmma<fp8_t, bf8_t, fp32_t, 16, 16, 128>;
+using wmma_f32_16x16x128_bf8_fp8 = wmma<bf8_t, fp8_t, fp32_t, 16, 16, 128>;
+using wmma_f32_16x16x128_bf8_bf8 = wmma<bf8_t, bf8_t, fp32_t, 16, 16, 128>;
+using wmma_f16_16x16x128_fp8_fp8 = wmma<fp8_t, fp8_t, fp16_t, 16, 16, 128>;
+using wmma_f16_16x16x128_fp8_bf8 = wmma<fp8_t, bf8_t, fp16_t, 16, 16, 128>;
+using wmma_f16_16x16x128_bf8_fp8 = wmma<bf8_t, fp8_t, fp16_t, 16, 16, 128>;
+using wmma_f16_16x16x128_bf8_bf8 = wmma<bf8_t, bf8_t, fp16_t, 16, 16, 128>;
+// Scaled WMMA (f8f6f4 unified instruction, supports fp8/bf8/fp4 via format code)
+using wmma_scale_f32_16x16x128_fp8_fp8 = wmma<fp8_t, fp8_t, fp32_t, 16, 16, 128>;
+using wmma_scale_f32_16x16x128_fp4_fp4 = wmma<fp4_t, fp4_t, fp32_t, 16, 16, 128>;
+// Scaled WMMA (dedicated fp4 32x16x128 instruction)
+using wmma_scale_f32_32x16x128_fp4_fp4 = wmma<fp4_t, fp4_t, fp32_t, 32, 16, 128>;
+#endif // __gfx1250__ / __gfx1201__ / __gfx1200__ (wmma)
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////
+// adaptor
+struct p_dim {};
+struct y_dim {};
+
+namespace impl{ // utlity function to play with shape
+template<typename FDim, typename Target> static constexpr auto pickup_filter(seq<>) { return seq<>{}; }
+template<typename FDim, typename Target, index_t I0, index_t... Rest> static constexpr auto pickup_filter(seq<I0, Rest...>) {
+    if constexpr (std::is_same_v<remove_cvref_t<decltype(get<I0>(FDim{}))>, remove_cvref_t<Target>>) return concat_seq(seq<I0>{}, pickup_filter<FDim, Target>(seq<Rest...>{}));
+    else return pickup_filter<FDim, Target>(seq<Rest...>{}); }
+template<typename Shape, index_t... Fs> OPUS_D static constexpr auto pickup_shape_apply(seq<Fs...>) { return opus::make_tuple(get<Fs>(Shape{})...); }
+template<typename Shape, typename FDim, typename Target, index_t... Is>
+OPUS_D static constexpr auto pickup_shape_impl(const Shape&, const FDim&, Target, seq<Is...>) { static_assert(size<Shape>() == size<FDim>()); return pickup_shape_apply<Shape>(pickup_filter<FDim, Target>(seq<Is...>{})); }
+
+template<typename Dim, index_t... Js>
+OPUS_D constexpr index_t dim_group_size_sum(seq<Js...>) { return (static_cast<index_t>(get<Js>(Dim{}).size()) + ... + 0); }
+
+template<typename Shape, typename Dim, index_t DIdx, index_t... Ss>
+OPUS_D constexpr auto unflatten_shape_group(seq<Ss...>) {
+    constexpr index_t SStart = dim_group_size_sum<Dim>(make_index_seq<DIdx>{});
+    return opus::make_tuple(get<SStart + Ss>(Shape{})...);
+}
+
+template<typename Shape, typename Dim, index_t... DIs>
+OPUS_D constexpr auto unflatten_shape_impl(seq<DIs...>) { return opus::make_tuple(unflatten_shape_group<Shape, Dim, DIs>(make_index_seq<get<DIs>(Dim{}).size()>{})...); }
+
+template<typename Dim, index_t... Js>
+OPUS_D constexpr index_t p_count_in(seq<Js...>) { return ((std::is_same_v<remove_cvref_t<decltype(get<Js>(Dim{}))>, p_dim> ? 1 : 0) + ... + 0); }
+
+template<typename Dim, typename Coord, index_t... Is>
+OPUS_D constexpr auto unfold_p_coord_impl(const Coord& coord, seq<Is...>) {
+    return opus::make_tuple( [&]() -> decltype(auto) {
+            if constexpr (std::is_same_v<remove_cvref_t<decltype(get<Is>(Dim{}))>, p_dim>) return get< p_count_in<Dim>(make_index_seq<Is>{}) >(coord);
+            else                                                                           return underscore{};
+        }()...
+    );
+}
+
+template<typename Dim, index_t... Js>
+OPUS_D constexpr index_t dim_offset_sum(seq<Js...>) { return (static_cast<index_t>(size<decltype(get<Js>(Dim{}))>()) + ... + 0); }
+
+template<typename Dim, typename Shape, typename Stride, index_t I>
+OPUS_D constexpr auto unfold_x_stride_each(const Stride& stride) {
+    constexpr index_t C = dim_offset_sum<Dim>(make_index_seq<I>{});
+    constexpr index_t len = size<decltype(get<I>(Dim{}))>();
+    constexpr auto current_shape = slice(Shape{}, number<C>{}, number<C + len>{});
+    constexpr auto current_stride = packed_shape_to_stride(current_shape);
+    return transform_tuple([&](auto i_elem){ return i_elem * get<I>(stride); }, current_stride);
+}
+
+template<typename Dim, index_t J, index_t... Gs> constexpr index_t unfold_find_group(seq<Gs...>) {
+    index_t acc = 0, r = 0; ((void)(acc += size<decltype(get<Gs>(Dim{}))>(), (acc <= J ? (void)(r = Gs + 1) : (void)0)), ...); return r; }
+template<typename Dim, typename Shape, typename Stride, index_t J> OPUS_D constexpr auto unfold_x_stride_at(const Stride& stride) {
+    constexpr index_t G = unfold_find_group<Dim, J>(make_index_seq<size<Dim>()>{}); constexpr index_t group_end = dim_offset_sum<Dim>(make_index_seq<G + 1>{});
+    return packed_stride_at<Shape, J>(make_index_seq<group_end - J - 1>{}) * get<G>(stride); }
+template<typename Dim, typename Shape, typename Stride, index_t... Js> OPUS_D constexpr auto unfold_x_stride_flat(const Stride& stride, seq<Js...>) { return opus::make_tuple(unfold_x_stride_at<Dim, Shape, Stride, Js>(stride)...); }
+template<typename Dim, typename Shape, typename Stride, index_t... Is> OPUS_D constexpr auto unfold_x_stride_impl(const Stride& stride, seq<Is...>) { return unfold_x_stride_flat<Dim, Shape, Stride>(stride, make_index_seq<size<Shape>()>{}); }
+}
+
+template<typename Shape, typename Dim, typename Target>
+OPUS_D static constexpr auto pickup_shape(const Shape&, const Dim&, Target) { return pickup_shape_impl(Shape{}, flatten_tuple(Dim{}), Target{}, make_index_seq<size<Shape>()>{}); }
+
+// Shape : tuple<N0, N1, N2, N3, N4, N5>
+// Dim   : tuple<tuple<*, *>, tuple<*, *, *>, tuple<*>>
+// =>    : tuple<tuple<N0, N1>, tuple<N2, N3, N4>, tuple<N5>>
+template<typename Shape, typename Dim, index_t... Ds /* index for Dim not Shape */>
+OPUS_D constexpr auto unflatten_shape(const Shape&, const Dim&) {
+    return impl::unflatten_shape_impl<Shape, Dim>(make_index_seq<size<Dim>()>{});
+}
+
+// coord: tuple<a, b>, dim: tuple<tuple<p_dim, y_dim>, tuple<y_dim, p_dim, y_dim>> -> tuple <a, _, _, b, _>
+template<typename Dim, typename Coord>
+OPUS_D constexpr auto unfold_p_coord(const Dim&, const Coord& coord) {
+    constexpr auto flatten_dim = flatten_tuple(Dim{});
+    using FDim = remove_cvref_t<decltype(flatten_dim)>;
+    static_assert(tuple_count<opus::p_dim>(flatten_dim) == size<Coord>(), "input coord must be same size as p_dim inside Dim");
+    return impl::unfold_p_coord_impl<FDim, Coord>(coord, make_index_seq<size<FDim>()>{});
+}
+
+template<typename Dim, typename Shape, typename Stride>
+OPUS_D constexpr auto unfold_x_stride(const Dim&, const Shape&, const Stride& stride) {
+    constexpr auto flatten_dim = flatten_tuple(Dim{});
+    static_assert(size<Dim>() == size<Stride>(), "input stride must be same size as x_dim");
+    static_assert(size<Shape>() == size<remove_cvref_t<decltype(flatten_dim)>>(), "input shape must be same size as flattened dim");
+    return impl::unfold_x_stride_impl<Dim, Shape, Stride>(stride, make_index_seq<size<Dim>()>{});
+}
+
+#define OPUS_KP_(x_) static_assert(opus::tuple_count<opus::p_dim>(opus::flatten_tuple(x_ ())) == size<C>())
+// Per-axis layout API: generates y_shape_X, p_shape_X, layout_X (3 overloads), layout_X_packed, y_layout_X
+#define OPUS_ADAPTOR_LAYOUT_API_DEFINE_FOR(X)                                                                                                                       \
+    OPUS_D static constexpr auto y_shape_##X() { return y_shape(shape_##X(), dim_##X()); }                                                                          \
+    OPUS_D static constexpr auto p_shape_##X() { return p_shape(shape_##X(), dim_##X()); }                                                                          \
+    template<index_t cached_vec = 0> OPUS_D constexpr auto layout_##X() { return make_layout<cached_vec>(shape_##X());}                                             \
+    template<index_t cached_vec = 0, typename S> OPUS_D constexpr auto layout_##X(S&& stride) { return make_layout<cached_vec>(shape_##X(), unfold_x_stride(dim_##X(), shape_##X(), stride));} \
+    template<index_t cached_vec = 0, typename S, typename C> OPUS_D constexpr auto layout_##X(S&& stride, C&& z) { OPUS_KP_(dim_##X); return make_layout<cached_vec>(shape_##X(), unfold_x_stride(dim_##X(), shape_##X(), stride), opus::unfold_p_coord(dim_##X(), z));}  \
+    template<index_t cached_vec = 0, typename C> OPUS_D constexpr auto layout_##X##_packed(C&& z) { OPUS_KP_(dim_##X); return make_layout_packed<cached_vec>(shape_##X(), opus::unfold_p_coord(dim_##X(), z));}   \
+    template<index_t cached_vec = 0, typename... Ts, std::enable_if_t<(!is_tuple_v<Ts> && ...), bool> = true> OPUS_D constexpr auto layout_##X(Ts&&... strides) {return layout_##X<cached_vec>(opus::make_tuple(strides...)); }  \
+    template<index_t cached_vec = 0> OPUS_D constexpr auto y_layout_##X() { return make_layout<cached_vec>(y_shape_##X());}
+
+// any struct implement adaptor like feature must implement(or using from base) shape_a/b/c, dim_a/b/c
+#define OPUS_ADAPTOR_LAYOUT_API_DEFINE                                                                                                                              \
+    template<typename S, typename D> OPUS_D static constexpr auto y_shape(const S& /*shape*/, const D& /*dim*/) { return opus::pickup_shape(S{}, D{}, y_dim{}); }   \
+    template<typename S, typename D> OPUS_D static constexpr auto p_shape(const S& /*shape*/, const D& /*dim*/) { return opus::pickup_shape(S{}, D{}, p_dim{}); }   \
+    OPUS_ADAPTOR_LAYOUT_API_DEFINE_FOR(a)                                                                                                                           \
+    OPUS_ADAPTOR_LAYOUT_API_DEFINE_FOR(b)                                                                                                                           \
+    OPUS_ADAPTOR_LAYOUT_API_DEFINE_FOR(c)
+
+// Note: any class to support adaptor need include OPUS_ADAPTOR_LAYOUT_API_DEFINE and implement shape_a()/shape_b()/shape_c()
+// P indicates dim cross thread, Y indicates dim within thread, this is X layout (X=P+Y) view the tensor as a whole
+// A:[(grpm_a<p>), (rept_a<y>, grpk_a<p>, pack_a<y>)], MxK
+// B:[(grpn_b<p>), (rept_b<y>, grpk_b<p>, pack_b<y>)], NxK
+// C:[(rept_c<y>, grpm_c<p>, pack_c<y>), (grpn_c<p>)], MxN
+#if defined(__GFX9__) || !defined(__HIP_DEVICE_COMPILE__)
+namespace impl {
+template<typename MFMA>
+struct mfma_adaptor : public remove_cvref_t<MFMA> {
+    using mfma_type = remove_cvref_t<MFMA>;
+
+    static constexpr index_t grpm_a = mfma_type::wave_m;
+    static constexpr index_t grpn_b = mfma_type::wave_n;
+    static_assert(mfma_type::warp_size % grpm_a == 0 && mfma_type::warp_size % grpn_b == 0 && grpm_a == grpn_b);
+    static constexpr index_t grpk_a = mfma_type::warp_size / grpm_a;
+    static constexpr index_t grpk_b = grpk_a;
+    static constexpr index_t grpn_c = mfma_type::wave_n;
+    static constexpr index_t grpm_c = mfma_type::warp_size / grpn_c;
+
+    static constexpr index_t max_pack_a = 16 / sizeof(typename mfma_type::dtype_a); // max 4 dwords
+    static constexpr index_t max_pack_b = 16 / sizeof(typename mfma_type::dtype_b); // max 4 dwords
+    static constexpr index_t max_pack_c = 16 / sizeof(typename mfma_type::dtype_c); // max 4 dwords
+
+    // pack_* should be vector load from ds_read/global_read
+    static constexpr index_t pack_a = (max_pack_a < mfma_type::elem_a ? max_pack_a : mfma_type::elem_a);
+    static constexpr index_t pack_b = (max_pack_b < mfma_type::elem_b ? max_pack_b : mfma_type::elem_b);
+    static constexpr index_t pack_c = (max_pack_c < mfma_type::elem_c ? max_pack_c : mfma_type::elem_c);
+
+    static constexpr index_t rept_a = mfma_type::elem_a / pack_a;
+    static constexpr index_t rept_b = mfma_type::elem_b / pack_b;
+    static constexpr index_t rept_c = mfma_type::elem_c / pack_c;
+
+    // by default, this is X shape, P + Y
+    OPUS_D static constexpr auto shape_a() { return tuple<number<grpm_a>, number<rept_a>, number<grpk_a>, number<pack_a>>{}; }
+    OPUS_D static constexpr auto shape_b() { return tuple<number<grpn_b>, number<rept_b>, number<grpk_b>, number<pack_b>>{}; }
+    OPUS_D static constexpr auto shape_c() { return tuple<number<rept_c>, number<grpm_c>, number<pack_c>, number<grpn_c>>{}; }
+
+    // here we describe above shape by group them into a 2d shape style, and with p/y dim. we could put into same structure, but let's make things easier
+    OPUS_D static constexpr auto dim_a()   { return tuple< tuple<p_dim>,  tuple<y_dim, p_dim, y_dim> >{}; }    // dim encoding for A, MxK
+    OPUS_D static constexpr auto dim_b()   { return tuple< tuple<p_dim>,  tuple<y_dim, p_dim, y_dim> >{}; }    // dim encoding for B, NxK
+    OPUS_D static constexpr auto dim_c()   { return tuple< tuple<y_dim, p_dim, y_dim>,  tuple<p_dim> >{}; }    // dim encoding for C, MxN
+
+    OPUS_ADAPTOR_LAYOUT_API_DEFINE
+};
+
+// A:[(grpm_a<p>), (rept_a<y>, grpk_a<p>, pack_a<y>)], MxK
+// B:[(grpn_b<p>), (rept_b<y>, grpk_b<p>, pack_b<y>)], NxK
+// C:[(grpn_c<p>), (rept_c<y>, grpm_c<p>, pack_c<y>)], MxN transposed(!)
+template<typename MFMA>
+struct mfma_adaptor_swap_ab : mfma_adaptor<MFMA> {
+    using base = mfma_adaptor<MFMA>;
+    using base::shape_a; using base::shape_b; using base::dim_a; using base::dim_b; using base::y_shape; using base::p_shape;
+    using base::y_shape_a; using base::y_shape_b; using base::p_shape_a; using base::p_shape_b;
+    using base::layout_a; using base::layout_b; using base::layout_a_packed; using base::layout_b_packed; using base::y_layout_a; using base::y_layout_b;
+    OPUS_D static constexpr auto shape_c() { return tuple<number<base::grpn_c>, number<base::rept_c>, number<base::grpm_c>, number<base::pack_c>>{}; }
+    OPUS_D static constexpr auto dim_c()   { return tuple<tuple<p_dim>,  tuple<y_dim, p_dim, y_dim> >{}; }    // dim encoding for C, MxN
+    // Only generate _c layout methods (shape_c/dim_c changed)
+    OPUS_ADAPTOR_LAYOUT_API_DEFINE_FOR(c)
+
+    template<typename VA, typename VB, typename VC, index_t cbsz = 0, index_t abid = 0, index_t blgp = 0>
+    OPUS_D constexpr auto operator()(const VA& a, const VB& b, const VC& c, number<cbsz> = {}, number<abid> = {}, number<blgp> = {}) {
+        return base::operator()(b, a, c, number<cbsz>{}, number<abid>{}, number<blgp>{});
+    }
+
+    template<typename VA, typename VB, index_t cbsz = 0, index_t abid = 0, index_t blgp = 0>
+    OPUS_D constexpr auto operator()(const VA& a, const VB& b, number<cbsz> = {}, number<abid> = {}, number<blgp> = {}) {
+        typename MFMA::vtype_c c{0}; return operator()(a, b, c, number<cbsz>{}, number<abid>{}, number<blgp>{});
+    }
+
+    template<typename VA, typename VB, typename VC, index_t scale_op_sel_a = 0, index_t scale_op_sel_b = 0>
+    OPUS_D constexpr auto operator()(const VA& a, const VB& b, const VC& c, int scale_a, int scale_b, number<scale_op_sel_a> = {}, number<scale_op_sel_b> = {}) {
+        return base::operator()(b, a, c, scale_b, scale_a, number<scale_op_sel_b>{}, number<scale_op_sel_a>{});
+    }
+
+    template<typename VA, typename VB, index_t scale_op_sel_a = 0, index_t scale_op_sel_b = 0>
+    OPUS_D constexpr auto operator()(const VA& a, const VB& b, int scale_a, int scale_b, number<scale_op_sel_a> = {}, number<scale_op_sel_b> = {}) {
+        typename MFMA::vtype_c c{0}; return operator()(a, b, c, scale_a, scale_b, number<scale_op_sel_a>{}, number<scale_op_sel_b>{});
+    }
+};
+}
+// helper class to create adaptor instance for mfma, need be paired with make_mfma(). don't directly use it
+struct mfma_adaptor         { template<typename M> OPUS_D decltype(auto) operator()(M&&) { return impl::mfma_adaptor<remove_cvref_t<M>>{};} };
+struct mfma_adaptor_swap_ab { template<typename M> OPUS_D decltype(auto) operator()(M&&) { return impl::mfma_adaptor_swap_ab<remove_cvref_t<M>>{};} };
+
+template<typename d_a, typename d_b, typename d_c, index_t w_m, index_t w_n, index_t w_k, typename A = mfma_adaptor, index_t warp_size_ = get_warp_size()>
+OPUS_D decltype(auto) make_mfma(number<w_m>, number<w_n>, number<w_k>, A&& = {}, number<warp_size_> = {}) { return A{}(mfma<d_a, d_b, d_c, w_m, w_n, w_k, warp_size_>{}); }
+
+template<typename d_a, typename d_b, typename d_c, typename WaveMNK /*seq<m, n, k>*/, typename A = mfma_adaptor, index_t warp_size_ = get_warp_size()>
+OPUS_D decltype(auto) make_mfma(WaveMNK&&, A&& = {}, number<warp_size_> = {}) { return A{}(mfma<d_a, d_b, d_c, get<0>(WaveMNK{}), get<1>(WaveMNK{}), get<2>(WaveMNK{}), warp_size_>{}); }
+#endif // __GFX9__
+
+// wmma_adaptor: layout encoding for wave32 WMMA (gfx1250, gfx1200/gfx1201).
+// A:[(grpm_a<p>), (rept_a<y>, grpk_a<p>, pack_a<y>)], MxK
+// B:[(grpn_b<p>), (rept_b<y>, grpk_b<p>, pack_b<y>)], NxK
+// C:[(grpm_c<p>, rept_c<y>, pack_c<y>), (grpn_c<p>)], MxN
+#if defined(__gfx1250__) || defined(__gfx1201__) || defined(__gfx1200__) || !defined(__HIP_DEVICE_COMPILE__)
+namespace impl {
+template<typename WMMA>
+struct wmma_adaptor : public remove_cvref_t<WMMA> {
+    using wmma_type = remove_cvref_t<WMMA>;
+
+    static constexpr index_t grpm_a = wmma_type::wave_m;
+    static constexpr index_t grpn_b = wmma_type::wave_n;
+    static_assert(wmma_type::warp_size % grpm_a == 0 && wmma_type::warp_size % grpn_b == 0 && grpm_a == grpn_b);
+    static constexpr index_t grpk_a = wmma_type::warp_size / grpm_a;
+    static constexpr index_t grpk_b = grpk_a;
+    static constexpr index_t grpn_c = wmma_type::wave_n;
+    static constexpr index_t grpm_c = wmma_type::warp_size / grpn_c;
+
+    static constexpr index_t max_pack_a = 16 / sizeof(typename wmma_type::dtype_a);
+    static constexpr index_t max_pack_b = 16 / sizeof(typename wmma_type::dtype_b);
+    static constexpr index_t max_pack_c = 16 / sizeof(typename wmma_type::dtype_c);
+
+    static constexpr index_t pack_a = (max_pack_a < wmma_type::elem_a ? max_pack_a : wmma_type::elem_a);
+    static constexpr index_t pack_b = (max_pack_b < wmma_type::elem_b ? max_pack_b : wmma_type::elem_b);
+    static constexpr index_t pack_c = (max_pack_c < wmma_type::elem_c ? max_pack_c : wmma_type::elem_c);
+
+    static constexpr index_t rept_a = wmma_type::elem_a / pack_a;
+    static constexpr index_t rept_b = wmma_type::elem_b / pack_b;
+    static constexpr index_t rept_c = wmma_type::elem_c / pack_c;
+
+    OPUS_D static constexpr auto shape_a() { return tuple<number<grpm_a>, number<rept_a>, number<grpk_a>, number<pack_a>>{}; }
+    OPUS_D static constexpr auto shape_b() { return tuple<number<grpn_b>, number<rept_b>, number<grpk_a>, number<pack_b>>{}; }
+    OPUS_D static constexpr auto shape_c() { return tuple<number<grpm_c>, number<rept_c>, number<pack_c>, number<grpn_c>>{}; }
+
+    OPUS_D static constexpr auto dim_a()   { return tuple< tuple<p_dim>,  tuple<y_dim, p_dim, y_dim> >{}; }
+    OPUS_D static constexpr auto dim_b()   { return tuple< tuple<p_dim>,  tuple<y_dim, p_dim, y_dim> >{}; }
+    OPUS_D static constexpr auto dim_c()   { return tuple< tuple<p_dim, y_dim, y_dim>,  tuple<p_dim> >{}; }
+
+    OPUS_ADAPTOR_LAYOUT_API_DEFINE
+};
+
+template<typename WMMA>
+struct wmma_adaptor_swap_ab : wmma_adaptor<WMMA> {
+    using base = wmma_adaptor<WMMA>;
+    using base::shape_a; using base::shape_b; using base::dim_a; using base::dim_b; using base::y_shape; using base::p_shape;
+    using base::y_shape_a; using base::y_shape_b; using base::p_shape_a; using base::p_shape_b;
+    using base::layout_a; using base::layout_b; using base::layout_a_packed; using base::layout_b_packed; using base::y_layout_a; using base::y_layout_b;
+    OPUS_D static constexpr auto shape_c() { return tuple<number<base::grpn_c>, number<base::grpm_c>, number<base::rept_c>, number<base::pack_c>>{}; }
+    OPUS_D static constexpr auto dim_c()   { return tuple<tuple<p_dim>,  tuple<p_dim, y_dim, y_dim> >{}; }
+    // Only generate _c layout methods (shape_c/dim_c changed)
+    OPUS_ADAPTOR_LAYOUT_API_DEFINE_FOR(c)
+
+    template<typename VA, typename VB, typename VC>
+    OPUS_D constexpr auto operator()(const VA& a, const VB& b, const VC& c) {
+        return base::operator()(b, a, c);
+    }
+
+    template<typename VA, typename VB>
+    OPUS_D constexpr auto operator()(const VA& a, const VB& b) {
+        typename WMMA::vtype_c c{0}; return operator()(b, a, c);
+    }
+
+    // Scaled overloads (BX32 / BX16): swap a,b then forward to base
+    template<typename VA, typename VB, typename VC>
+    OPUS_D constexpr auto operator()(const VA& a, const VB& b, const VC& c, int scale_a, int scale_b) {
+        return base::operator()(b, a, c, scale_a, scale_b);
+    }
+
+    template<typename VA, typename VB, typename VC>
+    OPUS_D constexpr auto operator()(const VA& a, const VB& b, const VC& c, long scale_a, long scale_b) {
+        return base::operator()(b, a, c, scale_a, scale_b);
+    }
+};
+} // namespace impl (wmma_adaptor)
+
+struct wmma_adaptor         { template<typename M> OPUS_D decltype(auto) operator()(M&&) { return impl::wmma_adaptor<remove_cvref_t<M>>{};} };
+struct wmma_adaptor_swap_ab { template<typename M> OPUS_D decltype(auto) operator()(M&&) { return impl::wmma_adaptor_swap_ab<remove_cvref_t<M>>{};} };
+
+template<typename d_a, typename d_b, typename d_c, index_t w_m, index_t w_n, index_t w_k, typename A = wmma_adaptor, index_t warp_size_ = get_warp_size()>
+OPUS_D decltype(auto) make_wmma(number<w_m>, number<w_n>, number<w_k>, A&& = {}, number<warp_size_> = {}) { return A{}(wmma<d_a, d_b, d_c, w_m, w_n, w_k, warp_size_>{}); }
+
+template<typename d_a, typename d_b, typename d_c, typename WaveMNK, typename A = wmma_adaptor, index_t warp_size_ = get_warp_size()>
+OPUS_D decltype(auto) make_wmma(WaveMNK&&, A&& = {}, number<warp_size_> = {}) { return A{}(wmma<d_a, d_b, d_c, get<0>(WaveMNK{}), get<1>(WaveMNK{}), get<2>(WaveMNK{}), warp_size_>{}); }
+#endif // __gfx1250__ / __gfx1201__ / __gfx1200__ (wmma_adaptor)
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////
+namespace impl {
+// tiled mma, warp level mfma/wmma/... EXPAND_: each wave need repeat along m/n/k dim how many times. TILE_: number of waves in m/n/k dim
+// A:[(expd_m<y>, tile_m<p>), (expd_k<y>, tile_k<p>)]
+// B:[(expd_n<y>, tile_n<p>), (expd_k<y>, tile_k<p>)]
+// C:[(expd_m<y>, tile_m<p>), (expd_n<y>, tile_n<p>)]
+template <typename MMA_, index_t EXPAND_M, index_t EXPAND_N, index_t EXPAND_K, index_t TILE_M, index_t TILE_N, index_t TILE_K>
+struct tiled_mma_adaptor : public MMA_ {
+    using MMA = remove_cvref_t<MMA_>;
+    static constexpr index_t expd_m = EXPAND_M;
+    static constexpr index_t expd_n = EXPAND_N;
+    static constexpr index_t expd_k = EXPAND_K;
+    static constexpr index_t tile_m = TILE_M;
+    static constexpr index_t tile_n = TILE_N;
+    static constexpr index_t tile_k = TILE_K;
+#if OPUS_TILE_CONTAINER == 0
+    using vtype_a = vector_t<typename MMA::dtype_a, expd_m * expd_k * MMA::elem_a>;
+    using vtype_b = vector_t<typename MMA::dtype_b, expd_n * expd_k * MMA::elem_b>;
+    using vtype_c = vector_t<typename MMA::dtype_c, expd_m * expd_n * MMA::elem_c>;
+#elif OPUS_TILE_CONTAINER == 1
+    using vtype_a = array<typename MMA::vtype_a, expd_m * expd_k>;
+    using vtype_b = array<typename MMA::vtype_b, expd_n * expd_k>;
+    using vtype_c = array<typename MMA::vtype_c, expd_m * expd_n>;
+#endif
+    OPUS_D static constexpr auto tile_shape_a() { return tuple<number<expd_m>, number<tile_m>, number<expd_k>, number<tile_k>>{}; }
+    OPUS_D static constexpr auto tile_shape_b() { return tuple<number<expd_n>, number<tile_n>, number<expd_k>, number<tile_k>>{}; }
+    OPUS_D static constexpr auto tile_shape_c() { return tuple<number<expd_m>, number<tile_m>, number<expd_n>, number<tile_n>>{}; }
+
+    OPUS_D static constexpr auto tile_dim_a()   { return tuple< tuple<y_dim, p_dim>,  tuple<y_dim, p_dim> >{}; }    // dim encoding for A, MxK
+    OPUS_D static constexpr auto tile_dim_b()   { return tuple< tuple<y_dim, p_dim>,  tuple<y_dim, p_dim> >{}; }    // dim encoding for B, NxK
+    OPUS_D static constexpr auto tile_dim_c()   { return tuple< tuple<y_dim, p_dim>,  tuple<y_dim, p_dim> >{}; }    // dim encoding for C, MxN
+
+    OPUS_D static constexpr auto shape_a() { return flatten_tuple(embed_nested_tuple(unflatten_shape(tile_shape_a(), tile_dim_a()), unflatten_shape(MMA::shape_a(), MMA::dim_a()))); }
+    OPUS_D static constexpr auto shape_b() { return flatten_tuple(embed_nested_tuple(unflatten_shape(tile_shape_b(), tile_dim_b()), unflatten_shape(MMA::shape_b(), MMA::dim_b()))); }
+    OPUS_D static constexpr auto shape_c() { return flatten_tuple(embed_nested_tuple(unflatten_shape(tile_shape_c(), tile_dim_c()), unflatten_shape(MMA::shape_c(), MMA::dim_c()))); }
+
+    OPUS_D static constexpr auto dim_a()   { return embed_nested_tuple(tile_dim_a(), MMA::dim_a()); }    // dim encoding for A, MxK
+    OPUS_D static constexpr auto dim_b()   { return embed_nested_tuple(tile_dim_b(), MMA::dim_b()); }    // dim encoding for A, MxK
+    OPUS_D static constexpr auto dim_c()   { return embed_nested_tuple(tile_dim_c(), MMA::dim_c()); }    // dim encoding for A, MxK
+
+    // Cached tile sizes (avoids re-evaluating y_shape + reduce_tuple_mul in every operator/step_k)
+    static constexpr index_t mma_a_len = get<0>(reduce_tuple_mul(MMA::y_shape_a())).value;
+    static constexpr index_t mma_b_len = get<0>(reduce_tuple_mul(MMA::y_shape_b())).value;
+    static constexpr index_t mma_c_len = get<0>(reduce_tuple_mul(MMA::y_shape_c())).value;
+    static constexpr index_t tile_a_len = EXPAND_M * EXPAND_K * mma_a_len;
+    static constexpr index_t tile_b_len = EXPAND_N * EXPAND_K * mma_b_len;
+    static constexpr index_t tile_c_len = EXPAND_M * EXPAND_N * mma_c_len;
+
+    // input a/b/c is array of ext type e.g. "fp16x2_t a[2];", pass "a" to this function
+    // #pragma unroll required: constexpr trip counts but clang's heuristic gives up on large tiles -> runtime indices into vtype_a/b/c -> N-way s_cselect_b64 chain on GFX9 -> SGPR-spill-to-VGPR-lane blow-up.
+    template<typename VA, typename VB, typename VC, index_t cbsz = 0, index_t abid = 0, index_t blgp = 0,
+                    std::enable_if_t< (is_array_v< remove_cvref_t<VA> > && is_array_v< remove_cvref_t<VB> > && is_array_v< remove_cvref_t<VC> >), bool > = true>
+    OPUS_D constexpr auto operator()(const VA& a, const VB& b, const VC& c, number<cbsz> = {}, number<abid> = {}, number<blgp> = {}) {
+        VC c_ {c};
+        #pragma unroll
+        for (index_t I = 0; I < EXPAND_K * EXPAND_M * EXPAND_N; I++) {
+            index_t i_k = I / (EXPAND_M * EXPAND_N), i_m = (I / EXPAND_N) % EXPAND_M, i_n = I % EXPAND_N;
+            auto s_a = a[i_m * EXPAND_K + i_k]; auto s_b = b[i_n * EXPAND_K + i_k]; auto s_c = c_[i_m * EXPAND_N + i_n];
+            s_c = MMA{}(s_a, s_b, s_c); c_[i_m * EXPAND_N + i_n] = s_c;
+        }
+        return c_;
+    }
+    template<typename VA, typename VB, typename VC, index_t cbsz = 0, index_t abid = 0, index_t blgp = 0,
+                    std::enable_if_t< (is_vector_v< remove_cvref_t<VA> > && is_vector_v< remove_cvref_t<VB> > && is_vector_v< remove_cvref_t<VC> >), bool > = true>
+    OPUS_D constexpr auto operator()(const VA& a, const VB& b, const VC& c, number<cbsz> = {}, number<abid> = {}, number<blgp> = {}) {
+        static_assert(size<VA>() == tile_a_len);
+        static_assert(size<VB>() == tile_b_len);
+        static_assert(size<VC>() == tile_c_len);
+
+        constexpr index_t a_len = mma_a_len, b_len = mma_b_len, c_len = mma_c_len;
+
+        VC c_ {c};
+        #pragma unroll
+        for (index_t I = 0; I < EXPAND_K * EXPAND_M * EXPAND_N; I++) {
+            index_t i_k = I / (EXPAND_M * EXPAND_N), i_m = (I / EXPAND_N) % EXPAND_M, i_n = I % EXPAND_N;
+            index_t i_a = (i_m * EXPAND_K + i_k) * a_len, i_b = (i_n * EXPAND_K + i_k) * b_len, i_c = (i_m * EXPAND_N + i_n) * c_len;
+            typename MMA::vtype_a s_a;
+            #pragma unroll
+            for (index_t j = 0; j < a_len; j++) s_a[j] = a[i_a + j];
+            typename MMA::vtype_b s_b;
+            #pragma unroll
+            for (index_t j = 0; j < b_len; j++) s_b[j] = b[i_b + j];
+            typename MMA::vtype_c s_c;
+            #pragma unroll
+            for (index_t j = 0; j < c_len; j++) s_c[j] = c_[i_c + j];
+            s_c = MMA{}(s_a, s_b, s_c);
+            #pragma unroll
+            for (index_t j = 0; j < c_len; j++) c_[i_c + j] = s_c[j];
+        }
+        return c_;
+    }
+
+    template<typename VA, typename VB, index_t cbsz = 0, index_t abid = 0, index_t blgp = 0>
+    OPUS_D constexpr auto operator()(const VA& a, const VB& b, number<cbsz> = {}, number<abid> = {}, number<blgp> = {}) {
+        vtype_c c{0};
+        return operator()(a, b, c, number<cbsz>{}, number<abid>{}, number<blgp>{});
+    }
+
+    // Scaled MFMA (f8f6f4): forward scale_a, scale_b and per-call scale_op_sel to underlying MMA; all sub-MFMAs in this call share the same scale_op_sel (same K position in the packed-int32 scale word).
+    template<typename VA, typename VB, typename VC, index_t scale_op_sel_a = 0, index_t scale_op_sel_b = 0,
+             std::enable_if_t< (is_array_v< remove_cvref_t<VA> > && is_array_v< remove_cvref_t<VB> > && is_array_v< remove_cvref_t<VC> >), bool > = true>
+    OPUS_D constexpr auto operator()(const VA& a, const VB& b, const VC& c, int scale_a, int scale_b, number<scale_op_sel_a> = {}, number<scale_op_sel_b> = {}) {
+        VC c_ {c};
+        #pragma unroll
+        for (index_t I = 0; I < EXPAND_K * EXPAND_M * EXPAND_N; I++) {
+            index_t i_k = I / (EXPAND_M * EXPAND_N), i_m = (I / EXPAND_N) % EXPAND_M, i_n = I % EXPAND_N;
+            auto s_a = a[i_m * EXPAND_K + i_k]; auto s_b = b[i_n * EXPAND_K + i_k]; auto s_c = c_[i_m * EXPAND_N + i_n];
+            s_c = MMA{}(s_a, s_b, s_c, scale_a, scale_b, number<scale_op_sel_a>{}, number<scale_op_sel_b>{}); c_[i_m * EXPAND_N + i_n] = s_c;
+        }
+        return c_;
+    }
+
+    template<typename VA, typename VB, typename VC, index_t scale_op_sel_a = 0, index_t scale_op_sel_b = 0,
+             std::enable_if_t< (is_vector_v< remove_cvref_t<VA> > && is_vector_v< remove_cvref_t<VB> > && is_vector_v< remove_cvref_t<VC> >), bool > = true>
+    OPUS_D constexpr auto operator()(const VA& a, const VB& b, const VC& c, int scale_a, int scale_b, number<scale_op_sel_a> = {}, number<scale_op_sel_b> = {}) {
+        static_assert(size<VA>() == tile_a_len);
+        static_assert(size<VB>() == tile_b_len);
+        static_assert(size<VC>() == tile_c_len);
+
+        constexpr index_t a_len = mma_a_len, b_len = mma_b_len, c_len = mma_c_len;
+
+        VC c_ {c};
+        static_ford<EXPAND_K, EXPAND_M, EXPAND_N>([&](auto i_k, auto i_m, auto i_n){
+            constexpr index_t i_tile_a = i_m * EXPAND_K + i_k;
+            constexpr index_t i_tile_b = i_n * EXPAND_K + i_k;
+            constexpr index_t i_tile_c = i_m * EXPAND_N + i_n;
+            auto s_a = slice(a, number<i_tile_a * a_len>{}, number<i_tile_a * a_len + a_len>{});
+            auto s_b = slice(b, number<i_tile_b * b_len>{}, number<i_tile_b * b_len + b_len>{});
+            auto s_c = slice(c_, number<i_tile_c * c_len>{}, number<i_tile_c * c_len + c_len>{});
+            s_c = MMA{}(s_a, s_b, s_c, scale_a, scale_b, number<scale_op_sel_a>{}, number<scale_op_sel_b>{});
+            set_slice(c_, s_c, number<i_tile_c * c_len>{}, number<i_tile_c * c_len + c_len>{});
+        });
+        return c_;
+    }
+
+    template<typename VA, typename VB, index_t scale_op_sel_a = 0, index_t scale_op_sel_b = 0>
+    OPUS_D constexpr auto operator()(const VA& a, const VB& b, int scale_a, int scale_b, number<scale_op_sel_a> = {}, number<scale_op_sel_b> = {}) {
+        vtype_c c{0};
+        return operator()(a, b, c, scale_a, scale_b, number<scale_op_sel_a>{}, number<scale_op_sel_b>{});
+    }
+
+    template<index_t STEP_K, typename VA, typename VB, typename VC, index_t cbsz = 0, index_t abid = 0, index_t blgp = 0,
+                    std::enable_if_t< (is_array_v< remove_cvref_t<VA> > && is_array_v< remove_cvref_t<VB> > && is_array_v< remove_cvref_t<VC> >), bool > = true>
+    OPUS_D constexpr auto step_k(number<STEP_K>, const VA& a, const VB& b, const VC& c, number<cbsz> = {}, number<abid> = {}, number<blgp> = {}) {
+        static_assert(STEP_K < EXPAND_K);
+        VC c_ {c};
+        static_for<EXPAND_M * EXPAND_N>([&](auto I){
+            constexpr index_t i_m = I.value / EXPAND_N, i_n = I.value % EXPAND_N;
+            auto s_a = a[i_m * EXPAND_K + STEP_K]; auto s_b = b[i_n * EXPAND_K + STEP_K]; auto s_c = c_[i_m * EXPAND_N + i_n];
+            s_c = MMA{}(s_a, s_b, s_c); c_[i_m * EXPAND_N + i_n] = s_c;
+        });
+        return c_;
+    }
+
+    template<index_t STEP_K, typename VA, typename VB, typename VC, index_t cbsz = 0, index_t abid = 0, index_t blgp = 0,
+                    std::enable_if_t< (is_vector_v< remove_cvref_t<VA> > && is_vector_v< remove_cvref_t<VB> > && is_vector_v< remove_cvref_t<VC> >), bool > = true>
+    OPUS_D constexpr auto step_k(number<STEP_K>, const VA& a, const VB& b, const VC& c, number<cbsz> = {}, number<abid> = {}, number<blgp> = {}) {
+        static_assert(STEP_K < EXPAND_K);
+        static_assert(size<VA>() == tile_a_len);
+        static_assert(size<VB>() == tile_b_len);
+        static_assert(size<VC>() == tile_c_len);
+
+        constexpr index_t a_len = mma_a_len, b_len = mma_b_len, c_len = mma_c_len;
+
+        VC c_ {c};
+        #pragma unroll
+        for (index_t I = 0; I < EXPAND_M * EXPAND_N; I++) {
+            index_t i_m = I / EXPAND_N, i_n = I % EXPAND_N;
+            index_t i_a = (i_m * EXPAND_K + STEP_K) * a_len, i_b = (i_n * EXPAND_K + STEP_K) * b_len, i_c = (i_m * EXPAND_N + i_n) * c_len;
+            typename MMA::vtype_a s_a;
+            #pragma unroll
+            for (index_t j = 0; j < a_len; j++) s_a[j] = a[i_a + j];
+            typename MMA::vtype_b s_b;
+            #pragma unroll
+            for (index_t j = 0; j < b_len; j++) s_b[j] = b[i_b + j];
+            typename MMA::vtype_c s_c;
+            #pragma unroll
+            for (index_t j = 0; j < c_len; j++) s_c[j] = c_[i_c + j];
+            s_c = MMA{}(s_a, s_b, s_c);
+            #pragma unroll
+            for (index_t j = 0; j < c_len; j++) c_[i_c + j] = s_c[j];
+        }
+        return c_;
+    }
+
+    template<index_t STEP_K, typename VA, typename VB, index_t cbsz = 0, index_t abid = 0, index_t blgp = 0>
+    OPUS_D constexpr auto step_k(number<STEP_K> step, const VA& a, const VB& b, number<cbsz> = {}, number<abid> = {}, number<blgp> = {}) {
+        vtype_c c{0};
+        return step_k(step, a, b, c, number<cbsz>{}, number<abid>{}, number<blgp>{});
+    }
+
+    template<index_t STEP_K, typename VA, typename VB, typename VC, index_t scale_op_sel_a = 0, index_t scale_op_sel_b = 0,
+             std::enable_if_t< (is_array_v< remove_cvref_t<VA> > && is_array_v< remove_cvref_t<VB> > && is_array_v< remove_cvref_t<VC> >), bool > = true>
+    OPUS_D constexpr auto step_k(number<STEP_K>, const VA& a, const VB& b, const VC& c, int scale_a, int scale_b, number<scale_op_sel_a> = {}, number<scale_op_sel_b> = {}) {
+        static_assert(STEP_K < EXPAND_K);
+        VC c_ {c};
+        #pragma unroll
+        for (index_t I = 0; I < EXPAND_M * EXPAND_N; I++) {
+            index_t i_m = I / EXPAND_N, i_n = I % EXPAND_N;
+            auto s_a = a[i_m * EXPAND_K + STEP_K]; auto s_b = b[i_n * EXPAND_K + STEP_K]; auto s_c = c_[i_m * EXPAND_N + i_n];
+            s_c = MMA{}(s_a, s_b, s_c, scale_a, scale_b, number<scale_op_sel_a>{}, number<scale_op_sel_b>{}); c_[i_m * EXPAND_N + i_n] = s_c;
+        }
+        return c_;
+    }
+
+    template<index_t STEP_K, typename VA, typename VB, typename VC, index_t scale_op_sel_a = 0, index_t scale_op_sel_b = 0,
+             std::enable_if_t< (is_vector_v< remove_cvref_t<VA> > && is_vector_v< remove_cvref_t<VB> > && is_vector_v< remove_cvref_t<VC> >), bool > = true>
+    OPUS_D constexpr auto step_k(number<STEP_K>, const VA& a, const VB& b, const VC& c, int scale_a, int scale_b, number<scale_op_sel_a> = {}, number<scale_op_sel_b> = {}) {
+        static_assert(STEP_K < EXPAND_K);
+        static_assert(size<VA>() == tile_a_len);
+        static_assert(size<VB>() == tile_b_len);
+        static_assert(size<VC>() == tile_c_len);
+
+        constexpr index_t a_len = mma_a_len, b_len = mma_b_len, c_len = mma_c_len;
+
+        VC c_ {c};
+        #pragma unroll
+        for (index_t I = 0; I < EXPAND_M * EXPAND_N; I++) {
+            index_t i_m = I / EXPAND_N, i_n = I % EXPAND_N;
+            index_t i_a = (i_m * EXPAND_K + STEP_K) * a_len, i_b = (i_n * EXPAND_K + STEP_K) * b_len, i_c = (i_m * EXPAND_N + i_n) * c_len;
+            typename MMA::vtype_a s_a;
+            #pragma unroll
+            for (index_t j = 0; j < a_len; j++) s_a[j] = a[i_a + j];
+            typename MMA::vtype_b s_b;
+            #pragma unroll
+            for (index_t j = 0; j < b_len; j++) s_b[j] = b[i_b + j];
+            typename MMA::vtype_c s_c;
+            #pragma unroll
+            for (index_t j = 0; j < c_len; j++) s_c[j] = c_[i_c + j];
+            s_c = MMA{}(s_a, s_b, s_c, scale_a, scale_b, number<scale_op_sel_a>{}, number<scale_op_sel_b>{});
+            #pragma unroll
+            for (index_t j = 0; j < c_len; j++) c_[i_c + j] = s_c[j];
+        }
+        return c_;
+    }
+
+    template<index_t STEP_K, typename VA, typename VB, index_t scale_op_sel_a = 0, index_t scale_op_sel_b = 0>
+    OPUS_D constexpr auto step_k(number<STEP_K> step, const VA& a, const VB& b, int scale_a, int scale_b, number<scale_op_sel_a> = {}, number<scale_op_sel_b> = {}) {
+        vtype_c c{0};
+        return step_k(step, a, b, c, scale_a, scale_b, number<scale_op_sel_a>{}, number<scale_op_sel_b>{});
+    }
+
+    OPUS_ADAPTOR_LAYOUT_API_DEFINE
+};
+}
+struct tiled_mma_adaptor {
+    template<typename MMA, index_t... Ts> OPUS_D decltype(auto) operator()(MMA&&, number<Ts>...) { return impl::tiled_mma_adaptor<remove_cvref_t<MMA>, Ts...>{};}
+};
+
+template<typename MMA, index_t E_M, index_t E_N, index_t E_K, index_t T_M, index_t T_N, index_t T_K, typename A = tiled_mma_adaptor>
+OPUS_D decltype(auto) make_tiled_mma(MMA&& mma, number<E_M>, number<E_N>, number<E_K>, number<T_M>, number<T_N>, number<T_K>, A&& = {}) {
+    return A{}(std::forward<MMA>(mma), number<E_M>{}, number<E_N>{}, number<E_K>{}, number<T_M>{}, number<T_N>{}, number<T_K>{});
+}
+
+template<typename MMA, typename ES /* expand-m/n/k */, typename TS /* tile-m/n/k */, typename A = tiled_mma_adaptor>
+OPUS_D decltype(auto) make_tiled_mma(MMA&& mma, ES, TS, A&& = {}) {
+    return A{}(std::forward<MMA>(mma), number<get<0>(ES{})>{}, number<get<1>(ES{})>{}, number<get<2>(ES{})>{}, number<get<0>(TS{})>{}, number<get<1>(TS{})>{}, number<get<2>(TS{})>{});
+}
+
+template<typename d_a, typename d_b, typename d_c, typename ES /* expand-m/n/k */, typename TS /* tile-m/n/k */, typename WS /* wave-m/n/k*/,
+#if defined(__gfx1250__)
+         typename WA = wmma_adaptor,
+#else
+         typename WA = mfma_adaptor,
+#endif
+         typename TA = tiled_mma_adaptor, index_t warp_size = get_warp_size()>
+OPUS_D decltype(auto) make_tiled_mma(ES, TS, WS, WA&& = {}, TA&& = {}) {
+#if defined(__gfx1250__)
+    return TA{}(make_wmma<d_a, d_b, d_c>(WS{}, WA{}, number<warp_size>{}),
+#else
+    return TA{}(make_mfma<d_a, d_b, d_c>(WS{}, WA{}, number<warp_size>{}),
+#endif
+            number<get<0>(ES{})>{}, number<get<1>(ES{})>{}, number<get<2>(ES{})>{}, number<get<0>(TS{})>{}, number<get<1>(TS{})>{}, number<get<2>(TS{})>{});
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////
+template<index_t cached_vec = 0, typename L, typename D, typename S, typename C, std::enable_if_t<is_layout_v<L> && is_tuple_v<D> && is_tuple_v<S> && is_tuple_v<C>, bool> = true>
+OPUS_D constexpr auto partition_layout(L&& layout, D&& dims, S&& shapes, C&& p_coord) {
+    OPUS_KP_(dims);
+    return make_layout<cached_vec>(std::forward<S>(shapes), unfold_x_stride(std::forward<D>(dims), std::forward<S>(shapes), layout.stride()), unfold_p_coord(std::forward<D>(dims), p_coord));
+}
+// partition, use cached_vec to dispatch which layout implementation. cached_vec < 0 : "layout", cached_vec == 0 : "layout_linear", cached_vec > 0 : "layout_cached"
+template<index_t cached_vec = 0, typename M> OPUS_D constexpr auto partition_layout_a(M&& mma) { return mma.template layout_a<cached_vec>(); }
+template<index_t cached_vec = 0, typename M> OPUS_D constexpr auto partition_layout_b(M&& mma) { return mma.template layout_b<cached_vec>(); }
+template<index_t cached_vec = 0, typename M> OPUS_D constexpr auto partition_layout_c(M&& mma) { return mma.template layout_c<cached_vec>(); }
+
+template<index_t cached_vec = 0, typename M, typename S, std::enable_if_t<is_tuple_v<S>, bool> = true> OPUS_D constexpr auto partition_layout_a(M&& mma, S&& x_stride) { return mma.template layout_a<cached_vec>(std::forward<S>(x_stride)); }
+template<index_t cached_vec = 0, typename M, typename S, std::enable_if_t<is_tuple_v<S>, bool> = true> OPUS_D constexpr auto partition_layout_b(M&& mma, S&& x_stride) { return mma.template layout_b<cached_vec>(std::forward<S>(x_stride)); }
+template<index_t cached_vec = 0, typename M, typename S, std::enable_if_t<is_tuple_v<S>, bool> = true> OPUS_D constexpr auto partition_layout_c(M&& mma, S&& x_stride) { return mma.template layout_c<cached_vec>(std::forward<S>(x_stride)); }
+
+template<index_t cached_vec = 0, typename M, typename S, typename C, std::enable_if_t<is_tuple_v<S> && is_tuple_v<C>, bool> = true>
+OPUS_D constexpr auto partition_layout_a(M&& mma, S&& x_stride, C&& p_coord) { return mma.template layout_a<cached_vec>(std::forward<S>(x_stride), std::forward<C>(p_coord)); }
+template<index_t cached_vec = 0, typename M, typename S, typename C, std::enable_if_t<is_tuple_v<S> && is_tuple_v<C>, bool> = true>
+OPUS_D constexpr auto partition_layout_b(M&& mma, S&& x_stride, C&& p_coord) { return mma.template layout_b<cached_vec>(std::forward<S>(x_stride), std::forward<C>(p_coord)); }
+template<index_t cached_vec = 0, typename M, typename S, typename C, std::enable_if_t<is_tuple_v<S> && is_tuple_v<C>, bool> = true>
+OPUS_D constexpr auto partition_layout_c(M&& mma, S&& x_stride, C&& p_coord) { return mma.template layout_c<cached_vec>(std::forward<S>(x_stride), std::forward<C>(p_coord)); }
+
+template<index_t cached_vec = 0, typename M, typename C, std::enable_if_t<is_tuple_v<C>, bool> = true> OPUS_D constexpr auto partition_layout_a_packed(M&& mma, C&& p_coord) { return mma.template layout_a_packed<cached_vec>(std::forward<C>(p_coord)); }
+template<index_t cached_vec = 0, typename M, typename C, std::enable_if_t<is_tuple_v<C>, bool> = true> OPUS_D constexpr auto partition_layout_b_packed(M&& mma, C&& p_coord) { return mma.template layout_b_packed<cached_vec>(std::forward<C>(p_coord)); }
+template<index_t cached_vec = 0, typename M, typename C, std::enable_if_t<is_tuple_v<C>, bool> = true> OPUS_D constexpr auto partition_layout_c_packed(M&& mma, C&& p_coord) { return mma.template layout_c_packed<cached_vec>(std::forward<C>(p_coord)); }
+#undef OPUS_KP_
+
+} // namespace opus
+
+// call this macro within your kernel body to have fast access to opus types
+#define OPUS_USING_COMMON_TYPES  \
+    using opus::operator""_I;    \
+    using p_dim = opus::p_dim;   \
+    using y_dim = opus::y_dim;
+
+// call this macro in global scope (outside of your kernel function, or under structure)
+#define OPUS_USING_COMMON_TYPES_ALL     \
+    OPUS_USING_COMMON_TYPES             \
+    template<opus::index_t I>     using num = opus::number<I>;      \
+    template<typename... T>       using tup = opus::tuple<T...>;    \
+    template<opus::index_t... Is> using seq = opus::seq<Is...>;
+
+// clang-format on

--- a/csrc/libtorch_stable/ops.h
+++ b/csrc/libtorch_stable/ops.h
@@ -380,6 +380,15 @@ void fused_minimax_m3_qknorm_rope_kv_insert(
     std::optional<torch::stable::Tensor> q_fp8_out, double q_fp8_scale);
 
 #ifdef VLLM_ENABLE_FUSED_KDA_DECODE
+void kimi_k3_h40_draft_mla_decode(
+    torch::stable::Tensor const& q, torch::stable::Tensor const& kv_cache,
+    torch::stable::Tensor const& block_table,
+    torch::stable::Tensor const& seq_lens,
+    torch::stable::Tensor& partial_max, torch::stable::Tensor& partial_sum,
+    torch::stable::Tensor& partial_acc, torch::stable::Tensor& out,
+    int64_t query_len, int64_t num_splits, double qk_scale_log2,
+    double output_scale);
+
 void fused_kda_decode(
     torch::stable::Tensor const& x, torch::stable::Tensor const& weight,
     std::optional<torch::stable::Tensor> bias,

--- a/csrc/libtorch_stable/torch_bindings.cpp
+++ b/csrc/libtorch_stable/torch_bindings.cpp
@@ -527,6 +527,17 @@ STABLE_TORCH_LIBRARY_FRAGMENT(_C, ops) {
       "Tensor? norm_weight=None, float norm_eps=1e-5) -> ()");
 #endif
 
+#ifdef VLLM_ENABLE_KIMI_K3_H40_DRAFT_MLA
+  // Kimi-K3 DSpark draft MLA decode (gfx950).  The non-causal draft block stays
+  // folded, so the KV span is read once instead of once per query token.
+  ops.def(
+      "kimi_k3_h40_draft_mla_decode("
+      "Tensor q, Tensor kv_cache, Tensor block_table, Tensor seq_lens, "
+      "Tensor! partial_max, Tensor! partial_sum, Tensor! partial_acc, "
+      "Tensor! out, int query_len, int num_splits, float qk_scale_log2, "
+      "float output_scale) -> ()");
+#endif
+
 #ifdef VLLM_ENABLE_KIMI_K3_ATTN_RES
   ops.def(
       "kimi_k3_attn_res("
@@ -784,6 +795,11 @@ STABLE_TORCH_LIBRARY_IMPL(_C, CUDA, ops) {
            TORCH_BOX(&fused_minimax_m3_qknorm_rope_kv_insert));
 #ifdef VLLM_ENABLE_FUSED_KDA_DECODE
   ops.impl("fused_kda_decode", TORCH_BOX(&fused_kda_decode));
+#endif
+
+#ifdef VLLM_ENABLE_KIMI_K3_H40_DRAFT_MLA
+  ops.impl("kimi_k3_h40_draft_mla_decode",
+           TORCH_BOX(&kimi_k3_h40_draft_mla_decode));
 #endif
 
 #ifdef VLLM_ENABLE_KIMI_K3_ATTN_RES

--- a/tests/models/kimi_k3/test_amd_h40_draft_mla.py
+++ b/tests/models/kimi_k3/test_amd_h40_draft_mla.py
@@ -1,0 +1,101 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""gfx950 Kimi-K3 DSpark draft MLA decode kernel."""
+
+import math
+
+import pytest
+import torch
+
+from vllm.platforms import current_platform
+
+
+def _on_gfx950() -> bool:
+    if not current_platform.is_rocm():
+        return False
+    from vllm.platforms.rocm import on_gfx950
+
+    return on_gfx950()
+
+D_QK, D_V = 576, 512
+FP8 = torch.float8_e4m3fn
+
+pytestmark = pytest.mark.skipif(
+    not (current_platform.is_rocm() and _on_gfx950()),
+    reason="Kimi-K3 H40 draft MLA decode requires gfx950",
+)
+
+
+def _reference(q, kv, block_table, page, seq_len, q_scale, kv_scale, sm, req):
+    tok = torch.arange(seq_len, device=q.device)
+    rows = block_table[req, tok // page].long() * page + (tok % page)
+    kvr = kv.view(-1, D_QK)[rows].float() * kv_scale
+    qr = q[req].reshape(-1, D_QK).float() * q_scale
+    return torch.softmax((qr @ kvr.T) * sm, dim=-1) @ kvr[:, :D_V]
+
+
+@pytest.mark.parametrize("batch", [1, 4])
+@pytest.mark.parametrize("query_len", [7])
+@pytest.mark.parametrize("num_heads", [16])
+@pytest.mark.parametrize("seq_len", [4096, 8321])
+@pytest.mark.parametrize("page", [128, 3072])
+@pytest.mark.parametrize("shuffle_pages", [True])
+def test_h40_draft_mla_matches_reference(
+    batch, query_len, num_heads, seq_len, page, shuffle_pages
+):
+    from vllm.models.kimi_k3.amd.ops.h40_draft_mla import h40_draft_mla_decode
+
+    torch.manual_seed(0)
+    dev = torch.device("cuda")
+    fp8_max = torch.finfo(FP8).max
+    npage = (seq_len + page - 1) // page
+
+    q_real = torch.randn(batch, query_len, num_heads, D_QK, device=dev) * 0.5
+    kv_real = torch.randn(batch * npage, page, D_QK, device=dev) * 0.5
+    q_scale = float(q_real.abs().max()) / fp8_max
+    kv_scale = float(kv_real.abs().max()) / fp8_max
+    q = (q_real / q_scale).clamp(-fp8_max, fp8_max).to(FP8)
+    kv = (kv_real / kv_scale).clamp(-fp8_max, fp8_max).to(FP8)
+
+    pages = torch.arange(batch * npage, dtype=torch.int32, device=dev)
+    if shuffle_pages:
+        pages = pages[torch.randperm(batch * npage, device=dev)]
+    block_table = pages.view(batch, npage).contiguous()
+    seq_lens = torch.full((batch,), seq_len, dtype=torch.int32, device=dev)
+
+    out = torch.zeros(
+        batch * query_len, num_heads, D_V, dtype=torch.bfloat16, device=dev
+    )
+    sm = 1.0 / math.sqrt(192)
+
+    ran = h40_draft_mla_decode(
+        q.view(batch * query_len, num_heads, D_QK),
+        kv,
+        out,
+        block_table,
+        seq_lens,
+        query_len,
+        sm,
+        q_scale,
+        kv_scale,
+    )
+    assert ran, "kernel declined a shape it should support"
+    torch.cuda.synchronize()
+    assert torch.isfinite(out).all()
+
+    got = out.view(batch, query_len * num_heads, D_V)[0].float()
+    ref = _reference(q, kv, block_table, page, seq_len, q_scale, kv_scale, sm, 0)
+    # e4m3 P in the PV matmul is the error floor; it shrinks with context.
+    assert (got - ref).norm() / ref.norm() < 3e-2
+
+
+def test_h40_draft_mla_declines_unsupported_page_size():
+    from vllm.models.kimi_k3.amd.ops.h40_draft_mla import h40_draft_mla_decode
+
+    dev = torch.device("cuda")
+    q = torch.zeros(14, 16, D_QK, dtype=FP8, device=dev)
+    kv = torch.zeros(4, 100, D_QK, dtype=FP8, device=dev)  # 100 % 128 != 0
+    out = torch.zeros(14, 16, D_V, dtype=torch.bfloat16, device=dev)
+    bt = torch.zeros(2, 4, dtype=torch.int32, device=dev)
+    sl = torch.full((2,), 100, dtype=torch.int32, device=dev)
+    assert not h40_draft_mla_decode(q, kv, out, bt, sl, 7, 0.1, 1.0, 1.0)

--- a/vllm/models/kimi_k3/amd/ops/h40_draft_mla.py
+++ b/vllm/models/kimi_k3/amd/ops/h40_draft_mla.py
@@ -1,0 +1,97 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""gfx950 MLA decode for the Kimi-K3 DSpark draft group.
+
+The draft block is non-causal: every one of a request's ``query_len`` positions
+attends to the same committed KV prefix. The Triton path expresses that by
+flattening the block to one decode row per query token, which makes each row
+re-read the whole KV span -- ``query_len`` times the traffic. This kernel keeps
+the block folded into a single workgroup tile and reads the span once.
+"""
+
+import torch
+
+from vllm.platforms import current_platform
+from vllm.platforms.rocm import on_gfx950
+
+D_QK = 576  # 512 latent + 64 rope
+D_V = 512
+KV_TILE = 128
+LOG2E = 1.4426950408889634
+_NUM_CU = 256
+
+_WORKSPACE: dict[tuple, tuple[torch.Tensor, torch.Tensor, torch.Tensor]] = {}
+
+
+def _supported() -> bool:
+    # v_mfma_scale_f32_16x16x128_f8f6f4 and ds_read_b64_tr_b8 are gfx950-only.
+    return current_platform.is_rocm() and on_gfx950()
+
+
+def h40_draft_mla_decode(
+    q: torch.Tensor,
+    kv_cache: torch.Tensor,
+    out: torch.Tensor,
+    block_table: torch.Tensor,
+    seq_lens: torch.Tensor,
+    query_len: int,
+    sm_scale: float,
+    q_scale: float,
+    kv_scale: float,
+) -> bool:
+    """Fill ``out`` in place. Returns False if the shape is not supported."""
+    if not _supported():
+        return False
+    if q.dtype is not torch.float8_e4m3fn or kv_cache.dtype is not torch.float8_e4m3fn:
+        return False
+    if out.dtype is not torch.bfloat16:
+        return False
+    if q.dim() != 3 or q.size(2) != D_QK or out.size(-1) != D_V:
+        return False
+
+    num_reqs = seq_lens.numel()
+    if query_len < 2 or q.size(0) != num_reqs * query_len:
+        return False
+    if block_table.dim() != 2 or block_table.stride(1) != 1:
+        return False
+
+    page_size = kv_cache.size(1)
+    if page_size % KV_TILE:
+        # A KV tile would straddle a page; the kernel resolves one page per tile.
+        return False
+
+    num_heads = q.size(1)
+    rows = num_heads * query_len
+    blocks = -(-rows // KV_TILE)
+    # One workgroup per CU for exactly one round. Derived from shapes only, so
+    # it stays correct under CUDA graph capture.
+    num_splits = max(1, _NUM_CU // (num_reqs * blocks))
+
+    workgroups = num_reqs * num_splits
+    key = (rows, q.device.index)
+    ws = _WORKSPACE.get(key)
+    if ws is None or ws[0].size(0) < workgroups:
+        cap = max(workgroups, _NUM_CU)
+        opts = {"dtype": torch.float32, "device": q.device}
+        ws = (
+            torch.empty(cap, rows, **opts),
+            torch.empty(cap, rows, **opts),
+            torch.empty(cap, rows, D_V, **opts),
+        )
+        _WORKSPACE[key] = ws
+
+    torch.ops._C.kimi_k3_h40_draft_mla_decode(
+        q,
+        kv_cache,
+        block_table,
+        seq_lens,
+        ws[0][:workgroups].view(num_reqs, num_splits, rows),
+        ws[1][:workgroups].view(num_reqs, num_splits, rows),
+        ws[2][:workgroups].view(num_reqs, num_splits, rows, D_V),
+        out,
+        query_len,
+        num_splits,
+        sm_scale * q_scale * kv_scale * LOG2E,
+        kv_scale,
+    )
+    return True

--- a/vllm/v1/attention/backends/mla/triton_mla.py
+++ b/vllm/v1/attention/backends/mla/triton_mla.py
@@ -157,6 +157,30 @@ class TritonMLABackend(MLACommonBackend):
         return True
 
 
+
+_SCALE_CACHE: dict[int, tuple[torch.Tensor, float]] = {}
+
+
+def _scalar(t) -> float:
+    """float(t) without a per-call device->host sync.
+
+    The entry holds the tensor, not just the value: keying on the address alone
+    is a silent-wrong-answer bug, because freeing a scale tensor lets the
+    allocator hand its address to the next one, which would inherit the cached
+    value. Keeping a reference makes that impossible.
+    """
+    if t is None:
+        return 1.0
+    if not isinstance(t, torch.Tensor):
+        return float(t)
+    hit = _SCALE_CACHE.get(t.data_ptr())
+    if hit is not None and hit[0] is t:
+        return hit[1]
+    value = float(t.reshape(()).item())
+    _SCALE_CACHE[t.data_ptr()] = (t, value)
+    return value
+
+
 class TritonMLAImpl(MLACommonImpl[MLACommonMetadata]):
     can_return_lse_for_decode: bool = True
 
@@ -297,6 +321,28 @@ class TritonMLAImpl(MLACommonImpl[MLACommonMetadata]):
             # Mirrors FlashInferMLA's non-causal path.
             query_len = attn_metadata.num_decode_tokens // attn_metadata.num_decodes
             if query_len > 1:
+                # gfx950 can serve the block folded, reading the KV span once
+                # instead of once per query token. Falls through when the shape
+                # or dtype is not supported.
+                from vllm.models.kimi_k3.amd.ops.h40_draft_mla import (
+                    h40_draft_mla_decode,
+                )
+
+                if h40_draft_mla_decode(
+                    q,
+                    kv_c_and_k_pe_cache.squeeze(2),
+                    o,
+                    block_table,
+                    seq_lens,
+                    query_len,
+                    self.scale,
+                    _scalar(layer._q_scale),
+                    _scalar(layer._k_scale),
+                ):
+                    # The folded kernel does not produce an LSE; nothing on the
+                    # DSpark draft path consumes one.
+                    return o, None
+
                 block_table = block_table.repeat_interleave(query_len, dim=0)
                 seq_lens = seq_lens.repeat_interleave(query_len)
 


### PR DESCRIPTION
## Purpose

The Kimi-K3 DSpark draft group is a **non-causal multi-token block**: all
`query_len` positions of a request attend to the same committed KV prefix and
never to a sibling block token.

`TritonMLAImpl._forward_decode` expresses that by flattening the block to one
decode row per query token:

```python
block_table = block_table.repeat_interleave(query_len, dim=0)
seq_lens = seq_lens.repeat_interleave(query_len)
```

Correct, but every one of the `batch * query_len` rows then re-reads the whole
KV span, so the draft attention moves **`query_len` times** the KV it needs.

This PR adds a gfx950 kernel that keeps the block folded: all
`query_len * num_heads` rows share one 128-row workgroup tile, and the KV span
is read **once**. It is opt-in by shape — `h40_draft_mla_decode` returns False
and the existing Triton path runs unchanged for anything it does not support.

## Result

Production DSpark draft shape (batch 16, `query_len` 7, 16 heads/rank,
KV 100 000, page 3072, fp8 q + fp8 paged KV), MI355X, one process, same tensors,
`rocprofv3 --kernel-trace`:

| stage-1 kernel | KV read per step | time |
|---|---|---|
| Triton, flattened (what main does today) | 7x | 2764.0 us |
| **this kernel** | **1x** | **327.2 us** |

**8.45x** at the production shape. Two thirds of that is available without a new
kernel — folding query positions into head tiles instead of decode rows is worth
about 3.2x on its own (a folded Triton variant with `BLOCK_H=64` measures
855.7 us). The remaining **2.62x** is this kernel: fp8 `e4m3` operands through
`v_mfma_scale_f32_16x16x128_f8f6f4`, a single KV pass, and a fixed
accumulator frame that drops the online-softmax rescale.

Sweeping batch 1..32 x KV 8K/32K/100K, it is ahead at all 18 points
(1.83x-2.99x against the *folded* Triton variant, more against main's
flattened path); the margin grows with both batch and context.

## Accuracy

`rel_l2` against an fp32 reference at KV=100 000: **5.3e-3** (cosine 0.999986),
versus 1.7e-3 for the Triton path. The entire gap is the `e4m3` quantisation of
the softmax numerator `P` before the PV MFMA — simulating just that step in
torch reproduces the measured value at two context lengths (5.00e-3 at 100K,
1.49e-2 at 8K), while the accumulator framing itself contributes 6e-7. Error
shrinks with context. End-to-end on Kimi-K3 DP2xTP4 this leaves draft acceptance
unchanged within run-to-run variance (accept_len 3.19-3.40 vs 2.98-3.23).

## Scope and limits

- **gfx950 only.** `v_mfma_scale_f32_16x16x128_f8f6f4` and `ds_read_b64_tr_b8`
  do not exist on other targets; CMake builds the file only when `gfx950` is in
  `VLLM_GPU_ARCHES`, and the Python entry re-checks with `on_gfx950()`.
- **fp8 KV cache and fp8 query** only; bf16 falls through to Triton.
- **`page_size % 128 == 0`** — the kernel resolves one block-table page per KV
  tile, so a tile must not straddle a page. Other page sizes fall through.
- The folded kernel does not produce an LSE; the DSpark draft path does not
  consume one.
- Whole-cache addressing is page-local by construction: a production KV cache
  (3846 pages x 3072 tokens x 576 B = 6.8 GB) exceeds a 32-bit buffer offset, so
  the page base is folded into a 64-bit pointer per tile and every offset stays
  under `page_size * 576`.

## Provenance

`csrc/libtorch_stable/kimi_k3/opus/*.hpp` are vendored verbatim from AMD's
[aiter](https://github.com/ROCm/aiter) (MIT), and the kernel is derived from the
same codebase. Original notices are preserved. Happy to trim the vendored header
to the used subset, or to move the kernel behind an aiter dependency instead, if
maintainers prefer.

## Test plan

- `tests/models/kimi_k3/test_amd_h40_draft_mla.py` — matches a torch reference
  across batch 1/4, KV 4096/8321 (non-tile-aligned tail), page 128/3072, with
  shuffled page tables; plus a decline path for an unsupported page size.
- Validated out of tree against the Triton kernel on the production shape, with
  a shuffled paged block table, under CUDA graph capture and replay (including
  replay after changing `seq_lens` and after remapping the block table), and
  against a 6.34 GiB KV pool with the block table aimed past the 32-bit line.

## Not yet done — why this is a draft

The translation unit compiles standalone against the torch stable ABI on
ROCm 7, but I have **not** run a full in-tree `VLLM_TARGET_DEVICE=rocm` build, so
the CMake wiring is unverified. No benchmark script yet (happy to add one
mirroring `benchmarks/kernels/`). Marking draft until both are done.
