### PR TITLE
[XPU] Enable Kimi K3 KDA kernel tests on XPU

### DIFF
--- a/tests/models/kimi_k3/test_kda.py
+++ b/tests/models/kimi_k3/test_kda.py
@@ -30,9 +30,15 @@ from vllm.models.kimi_k3.nvidia.ops.third_party.kda import (
     fused_recurrent_kda_fwd,
     fused_recurrent_kda_packed_decode,
 )
+from vllm.platforms import current_platform
 from vllm.third_party.flash_linear_attention.ops.l2norm import l2norm_fwd
 
-DEVICE = "cuda"
+DEVICE = current_platform.device_type
+
+pytestmark = pytest.mark.skipif(
+    not (current_platform.is_cuda_alike() or current_platform.is_xpu()),
+    reason="The KDA kernels require a CUDA-alike or XPU device.",
+)
 
 # The AMD and NVIDIA copies of the KDA kernels are vendored separately and are
 # free to diverge, so the shared-semantics tests below run against both.

--- a/vllm/model_executor/layers/mamba/ops/gather_initial_states.py
+++ b/vllm/model_executor/layers/mamba/ops/gather_initial_states.py
@@ -49,7 +49,7 @@ def gather_initial_states(
 ) -> torch.Tensor:
     """Gather dense state rows, replacing uninitialized rows with zeros."""
     assert state.ndim >= 2
-    assert state.is_cuda
+    assert state.is_cuda or state.is_xpu
     assert indices.ndim == 1 and has_initial_state.ndim == 1
     assert indices.shape == has_initial_state.shape
     assert indices.device == state.device


### PR DESCRIPTION
## Purpose

`gather_initial_states()` asserted `state.is_cuda`, which is False for XPU tensors, so it blew
up before reaching the Triton kernel; widened to `state.is_cuda or state.is_xpu`. `test_kda.py`
hardcoded `DEVICE = "cuda"`, now taken from `current_platform.device_type` - the CUDA-only
cases already self-gate.

This gives XPU coverage of the KDA Triton kernels: chunked prefill (`chunk_kda`, plus the fused
gate/cumsum variant) and the fused-recurrent packed-decode and spec-decode paths.
## Test Plan

```bash
python -m pytest tests/models/kimi_k3/test_kda.py -v
```

## Test Result

45 passed, 6 skipped on Intel Arc Pro B70. Tested also on H200 - 51 passed