### PR TITLE
[Bugfix] Route Step3p5 forced tool choices through XML parser

### DIFF
--- a/tests/parser/test_parse.py
+++ b/tests/parser/test_parse.py
@@ -220,14 +220,18 @@ def test_parse_tool_only(tokenizer):
     ],
     ids=["required", "named"],
 )
-def test_parse_non_json_required_and_named_uses_tool_parser(tool_choice):
+def test_step_forced_tool_choice_uses_xml_generation_and_parser(tool_choice):
     class StepParser(DelegatingParser):
         tool_parser_cls = Step3p5ToolParser
 
     parser = StepParser(SimpleNamespace(), tools=TOOLS)
     request = make_request(tools=TOOLS, tool_choice=tool_choice)
+
+    adjusted_request = parser.adjust_request(request)
+    assert adjusted_request.structured_outputs is None
+
     reasoning, content, tool_calls = parser.parse(
-        STEP_TOOL_CALL, request, enable_auto_tools=True
+        STEP_TOOL_CALL, adjusted_request, enable_auto_tools=True
     )
 
     assert reasoning is None

--- a/tests/parser/test_parse.py
+++ b/tests/parser/test_parse.py
@@ -12,6 +12,7 @@ from vllm.parser.abstract_parser import DelegatingParser
 from vllm.parser.utils import count_history_tool_calls
 from vllm.reasoning.basic_parsers import BaseThinkingReasoningParser
 from vllm.tool_parsers.hermes_tool_parser import Hermes2ProToolParser
+from vllm.tool_parsers.step3p5_tool_parser import Step3p5ToolParser
 
 
 @pytest.fixture(autouse=True)
@@ -46,6 +47,12 @@ TOOL_CALL_ONLY = (
 )
 
 TOOL_ARGUMENTS = '{"city": "Dallas"}'
+
+STEP_TOOL_CALL = """<tool_call>
+<function=get_weather>
+<parameter=city>Dallas</parameter>
+</function>
+</tool_call>"""
 
 
 @pytest.fixture(scope="module")
@@ -196,6 +203,35 @@ def test_parse_tool_only(tokenizer):
     )
 
     assert reasoning is None
+    assert tool_calls is not None
+    assert len(tool_calls) == 1
+    assert tool_calls[0].name == "get_weather"
+    assert json.loads(tool_calls[0].arguments) == {"city": "Dallas"}
+
+
+@pytest.mark.parametrize(
+    "tool_choice",
+    [
+        "required",
+        {
+            "type": "function",
+            "function": {"name": "get_weather"},
+        },
+    ],
+    ids=["required", "named"],
+)
+def test_parse_non_json_required_and_named_uses_tool_parser(tool_choice):
+    class StepParser(DelegatingParser):
+        tool_parser_cls = Step3p5ToolParser
+
+    parser = StepParser(SimpleNamespace(), tools=TOOLS)
+    request = make_request(tools=TOOLS, tool_choice=tool_choice)
+    reasoning, content, tool_calls = parser.parse(
+        STEP_TOOL_CALL, request, enable_auto_tools=True
+    )
+
+    assert reasoning is None
+    assert not content or not content.strip()
     assert tool_calls is not None
     assert len(tool_calls) == 1
     assert tool_calls[0].name == "get_weather"

--- a/vllm/tool_parsers/step3p5_tool_parser.py
+++ b/vllm/tool_parsers/step3p5_tool_parser.py
@@ -6,9 +6,11 @@ from typing import Any
 from xml.parsers.expat import ParserCreate
 
 import regex as re
+from openai.types.responses import ToolChoiceFunction
 
 from vllm.entrypoints.chat_utils import make_tool_call_id
 from vllm.entrypoints.openai.chat_completion.protocol import (
+    ChatCompletionNamedToolChoiceParam,
     ChatCompletionRequest,
 )
 from vllm.entrypoints.openai.engine.protocol import (
@@ -19,6 +21,7 @@ from vllm.entrypoints.openai.engine.protocol import (
     FunctionCall,
     ToolCall,
 )
+from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
 from vllm.logger import init_logger
 from vllm.tokenizers import TokenizerLike
 from vllm.tool_parsers.abstract_tool_parser import Tool, ToolParser
@@ -1365,6 +1368,18 @@ class StreamingXMLToolCallParser:
 
 class Step3p5ToolParser(ToolParser):
     supports_required_and_named = False
+
+    def adjust_request(
+        self, request: ChatCompletionRequest | ResponsesRequest
+    ) -> ChatCompletionRequest | ResponsesRequest:
+        if request.tools:
+            tool_choice = request.tool_choice
+            if tool_choice == "required" or isinstance(
+                tool_choice,
+                (ChatCompletionNamedToolChoiceParam, ToolChoiceFunction),
+            ):
+                return request
+        return super().adjust_request(request)
 
     def __init__(self, tokenizer: TokenizerLike, tools: list[Tool] | None = None):
         super().__init__(tokenizer, tools)

--- a/vllm/tool_parsers/step3p5_tool_parser.py
+++ b/vllm/tool_parsers/step3p5_tool_parser.py
@@ -1364,6 +1364,8 @@ class StreamingXMLToolCallParser:
 
 
 class Step3p5ToolParser(ToolParser):
+    supports_required_and_named = False
+
     def __init__(self, tokenizer: TokenizerLike, tools: list[Tool] | None = None):
         super().__init__(tokenizer, tools)
         self.parser = StreamingXMLToolCallParser()


### PR DESCRIPTION
## Purpose

Fixes #51804.

Step3p5 emits XML tool calls, but named and required tool choices used the
generic JSON parsing path because `Step3p5ToolParser` inherited
`supports_required_and_named=True`. As a result, named choices returned the raw
XML as function arguments, while required choices failed to extract a call.

## Changes

- Set `Step3p5ToolParser.supports_required_and_named = False` so forced tool
  choices use the Step XML parser.
- Add generic parser regression coverage for both required and named tool
  choices using captured Step XML output.
