### PR TITLE
docs: add Sealos deployment option for CPU install

### DIFF
--- a/docs/getting_started/installation/cpu.md
+++ b/docs/getting_started/installation/cpu.md
@@ -107,6 +107,12 @@ VLLM_USE_PRECOMPILED=1 VLLM_PRECOMPILED_WHEEL_VARIANT=cpu VLLM_TARGET_DEVICE=cpu
 
 ## Set up using Docker
 
+### Deploy on Sealos
+
+[![Deploy on Sealos](https://sealos.io/Deploy-on-Sealos.svg)](https://sealos.io/products/app-store/vllm)
+
+The template pins the CPU image and persists the Hugging Face cache so downloaded weights survive restarts.
+
 ### Pre-built images
 
 === "Intel/AMD x86"


### PR DESCRIPTION
## Summary

This PR adds a Sealos deployment option for the vLLM CPU installation guide.

It adds:
- a Deploy on Sealos button in `docs/getting_started/installation/cpu.md`
- a short note that the template pins the CPU image and persists the Hugging Face cache

## Why

This gives vLLM CPU users a one-click Kubernetes deployment path without changing the default install flow.

## Validation

- Sealos template: https://sealos.io/products/app-store/vllm
- Template repo: https://github.com/labring-actions/templates
- Validation record: PR #737, validated on 2026-08-10
- Persistence covered: yes
- Required env vars documented: yes

## Maintenance

I can help maintain the Sealos deployment path and follow up if the template or docs need updates.
Prepared with AI assistance and reviewed end to end.