### PR TITLE
fix and test EPLB balancedness calculation

### DIFF
--- a/tests/distributed/test_eplb_algo.py
+++ b/tests/distributed/test_eplb_algo.py
@@ -5,8 +5,27 @@ import numpy as np
 import pytest
 import torch
 
-from vllm.distributed.eplb.eplb_state import compute_logical_maps
+from vllm.distributed.eplb.eplb_state import (
+    _compute_eplb_load_stats,  # pyright: ignore[reportPrivateUsage]
+    compute_logical_maps,
+)
 from vllm.distributed.eplb.policy.default import DefaultEplbPolicy
+
+
+def test_eplb_load_stats_reduce_across_ranks():
+    num_tokens_per_rank = torch.tensor(
+        [
+            [100, 0, 0, 0],
+            [100, 0, 0, 0],
+        ],
+        dtype=torch.float32,
+    )
+
+    avg_tokens, max_tokens = _compute_eplb_load_stats(num_tokens_per_rank)
+
+    assert avg_tokens.item() == 50
+    assert max_tokens.item() == 200
+    assert (avg_tokens / max_tokens).item() == 0.25
 
 
 def test_basic_rebalance():

--- a/vllm/distributed/eplb/eplb_state.py
+++ b/vllm/distributed/eplb/eplb_state.py
@@ -61,6 +61,14 @@ from .rebalance_execute import (
 logger = init_logger(__name__)
 
 
+def _compute_eplb_load_stats(
+    num_tokens_per_rank: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    avg_tokens = num_tokens_per_rank.mean(dim=1).sum()
+    max_tokens = num_tokens_per_rank.max(dim=1).values.sum()
+    return avg_tokens, max_tokens
+
+
 @dataclass
 class EplbStats:
     """
@@ -584,8 +592,9 @@ class EplbState:
                 # Compute balancedness ratio:
                 # for each layer:
                 #   (mean load across ranks) / (max load across ranks)
-                avg_tokens_tensor = num_tokens_per_rank.mean(dim=0).sum(dim=0)
-                max_tokens_tensor = num_tokens_per_rank.max(dim=0).values.sum(dim=0)
+                avg_tokens_tensor, max_tokens_tensor = _compute_eplb_load_stats(
+                    num_tokens_per_rank
+                )
 
                 # Just to make type checker happy
                 tokens_tensors: list[float] = torch.stack(


### PR DESCRIPTION


## Purpose

Fix EPLB balancedness logging to aggregate rank load within each MoE layer. The
current reduction uses the layer axis, so it can report perfect balance when one
EP rank receives all tokens in every layer.

## Test Plan

```bash
pytest -q tests/distributed/test_eplb_algo.py
```

## Test Result

The new regression case has equal token totals per layer with all tokens routed
to one rank. Before the fix, it produced `avg_tokens=100` and `max_tokens=100`;
after the fix, it produces the expected `avg_tokens=50` and `max_tokens=200`.

```text
15 passed, 1 skipped
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] Documentation updates are not required for this metrics-only fix.
</details>