### PR TITLE
Copy CPU shared-memory tails at their exact length

### DIFF
--- a/.buildkite/scripts/hardware_ci/run-cpu-test-arm.sh
+++ b/.buildkite/scripts/hardware_ci/run-cpu-test-arm.sh
@@ -50,7 +50,8 @@ kernel_tests() {
     pytest -x -v -s tests/kernels/moe/test_cpu_int4_moe.py
     pytest -x -v -s tests/kernels/mamba/test_cpu_short_conv.py
     pytest -x -v -s tests/kernels/mamba/test_causal_conv1d.py
-    pytest -x -v -s tests/kernels/mamba/test_mamba_ssm.py"
+    pytest -x -v -s tests/kernels/mamba/test_mamba_ssm.py
+    pytest -x -v -s tests/distributed/test_shm_tail.py"
 }
 
 model_tests() {

--- a/csrc/cpu/shm.cpp
+++ b/csrc/cpu/shm.cpp
@@ -1,5 +1,6 @@
 #include "cpu/cpu_types.hpp"
 
+#include <cstring>
 #include <fcntl.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
@@ -456,10 +457,16 @@ void memcpy_from_shm(void* dst, void* src, const int64_t bytes) {
 }
 
 void memcpy_to_shm(void* dst, void* src, const int64_t bytes) {
+  const int64_t aligned_bytes = ((bytes >> 6) << 6);  // 64 bytes aligned
+  int64_t i = 0;
 #pragma GCC unroll 4
-  for (int64_t i = 0; i < bytes; i += 64) {
+  for (; i < aligned_bytes; i += 64) {
     vec_op::INT8Vec64 data((int8_t*)src + i);
     data.nt_save((int8_t*)dst + i);
+  }
+  if (aligned_bytes < bytes) {
+    std::memcpy((int8_t*)dst + aligned_bytes, (int8_t*)src + aligned_bytes,
+                static_cast<size_t>(bytes - aligned_bytes));
   }
 }
 

--- a/tests/distributed/shm_tail_guard_harness.cpp
+++ b/tests/distributed/shm_tail_guard_harness.cpp
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+#include <cstdint>
+#include <cstdlib>
+#include <iostream>
+#include <string_view>
+#include <vector>
+
+#include <sys/mman.h>
+#include <unistd.h>
+
+#ifndef MAP_ANON
+  #define MAP_ANON MAP_ANONYMOUS
+#endif
+
+#ifndef MAP_POPULATE
+  #define MAP_POPULATE 0
+#endif
+
+#include "csrc/cpu/shm.cpp"
+
+struct GuardedBuffer {
+  void* mapping = MAP_FAILED;
+  size_t page_size = 0;
+  int8_t* data = nullptr;
+
+  explicit GuardedBuffer(int64_t bytes) {
+    page_size = static_cast<size_t>(sysconf(_SC_PAGESIZE));
+    if (bytes <= 0 || static_cast<size_t>(bytes) > page_size) {
+      std::cerr << "bytes must fit in one page\n";
+      std::exit(2);
+    }
+    mapping = mmap(nullptr, page_size * 2, PROT_READ | PROT_WRITE,
+                   MAP_PRIVATE | MAP_ANON, -1, 0);
+    if (mapping == MAP_FAILED) {
+      perror("mmap");
+      std::exit(2);
+    }
+    if (mprotect(static_cast<int8_t*>(mapping) + page_size, page_size,
+                 PROT_NONE) != 0) {
+      perror("mprotect");
+      std::exit(2);
+    }
+    data = static_cast<int8_t*>(mapping) + page_size - bytes;
+  }
+
+  ~GuardedBuffer() {
+    if (mapping != MAP_FAILED) {
+      munmap(mapping, page_size * 2);
+    }
+  }
+};
+
+int run_copy(int8_t* dst, int8_t* src, int64_t bytes) {
+  for (int64_t i = 0; i < bytes; ++i) {
+    src[i] = static_cast<int8_t>(i % 127);
+    dst[i] = 0;
+  }
+
+  shm_cc_ops::memcpy_to_shm(dst, src, bytes);
+
+  for (int64_t i = 0; i < bytes; ++i) {
+    if (dst[i] != src[i]) {
+      std::cerr << "copy mismatch at index " << i << "\n";
+      return 1;
+    }
+  }
+  return 0;
+}
+
+int main(int argc, char** argv) {
+  const int64_t bytes = argc > 1 ? std::strtoll(argv[1], nullptr, 10) : 65;
+  const std::string_view mode = argc > 2 ? argv[2] : "guard-src";
+  std::cout << "bytes=" << bytes << " mode=" << mode << std::endl;
+
+  if (mode == "guard-src") {
+    GuardedBuffer src(bytes);
+    std::vector<int8_t> dst(static_cast<size_t>(bytes) + 64);
+    return run_copy(dst.data(), src.data, bytes);
+  }
+  if (mode == "guard-dst") {
+    std::vector<int8_t> src(static_cast<size_t>(bytes) + 64);
+    GuardedBuffer dst(bytes);
+    return run_copy(dst.data, src.data(), bytes);
+  }
+
+  std::cerr << "mode must be guard-src or guard-dst\n";
+  return 2;
+}

--- a/tests/distributed/test_shm_tail.py
+++ b/tests/distributed/test_shm_tail.py
@@ -1,0 +1,137 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Direct-source regression for the ARM SHM copy tail boundary.
+
+Apple Silicon does not build `csrc/cpu/shm.cpp` into the normal CPU extension,
+so this test compiles the exact source file under ASan instead of exercising an
+installed operator path. That preserves the vulnerable native boundary while
+keeping the regression runnable on the host that reproduced the bug.
+"""
+
+import os
+import platform
+import shlex
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import torch
+from torch.utils.cpp_extension import include_paths, library_paths
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_HARNESS = Path(__file__).with_name("shm_tail_guard_harness.cpp")
+_DARWIN_OPENMP_INSTALL_NAME = "/opt/llvm-openmp/lib/libomp.dylib"
+
+if not (_REPO_ROOT / "csrc/cpu/shm.cpp").exists():
+    pytest.skip("C/C++ source tree not available", allow_module_level=True)
+
+pytestmark = pytest.mark.skipif(
+    platform.machine() not in {"arm64", "aarch64"},
+    reason="The direct SHM tail harness currently targets the ARM vector backend.",
+)
+
+
+def _compiler_command() -> list[str]:
+    command = shlex.split(os.environ.get("CXX", "clang++"))
+    if not command or shutil.which(command[0]) is None:
+        pytest.skip("A C++ compiler is required for the SHM tail harness")
+    return command
+
+
+def _run_checked(command: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(command, cwd=cwd, capture_output=True, text=True)
+    assert result.returncode == 0, (
+        f"command failed: {' '.join(command)}\n"
+        f"stdout:\n{result.stdout}\n"
+        f"stderr:\n{result.stderr}"
+    )
+    return result
+
+
+def _rewrite_darwin_openmp_install_name(binary: Path) -> None:
+    if sys.platform != "darwin":
+        return
+    otool = shutil.which("otool")
+    install_name_tool = shutil.which("install_name_tool")
+    if otool is None or install_name_tool is None:
+        pytest.skip("otool and install_name_tool are required on Darwin")
+    assert otool is not None
+    assert install_name_tool is not None
+
+    linked_libraries = _run_checked([otool, "-L", str(binary)], _REPO_ROOT)
+    if _DARWIN_OPENMP_INSTALL_NAME not in linked_libraries.stdout:
+        return
+    _run_checked(
+        [
+            install_name_tool,
+            "-change",
+            _DARWIN_OPENMP_INSTALL_NAME,
+            "@rpath/libomp.dylib",
+            str(binary),
+        ],
+        _REPO_ROOT,
+    )
+
+
+@pytest.fixture(scope="module")
+def shm_tail_harness(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    binary = tmp_path_factory.mktemp("shm-tail") / "shm_tail_guard_harness"
+    command = [
+        *_compiler_command(),
+        "-std=c++17",
+        "-O0",
+        "-g",
+        "-fsanitize=address",
+        "-fno-omit-frame-pointer",
+        f"-D_GLIBCXX_USE_CXX11_ABI={int(torch.compiled_with_cxx11_abi())}",
+        "-Icsrc",
+        "-I.",
+        *[f"-I{path}" for path in include_paths(device_type="cpu")],
+        str(_HARNESS),
+        *[f"-L{path}" for path in library_paths(device_type="cpu")],
+        *[f"-Wl,-rpath,{path}" for path in library_paths(device_type="cpu")],
+        "-ltorch",
+        "-ltorch_cpu",
+        "-lc10",
+        "-o",
+        str(binary),
+    ]
+    if sys.platform == "darwin":
+        command.append("-lomp")
+    _run_checked(command, _REPO_ROOT)
+    _rewrite_darwin_openmp_install_name(binary)
+    return binary
+
+
+@pytest.mark.parametrize(
+    ("bytes_to_copy", "guard_mode"),
+    [
+        (1, "guard-src"),
+        (1, "guard-dst"),
+        (64, "guard-src"),
+        (65, "guard-src"),
+        (65, "guard-dst"),
+        (100, "guard-src"),
+        (100, "guard-dst"),
+    ],
+)
+def test_memcpy_to_shm_handles_tail_without_page_fault(
+    shm_tail_harness: Path, bytes_to_copy: int, guard_mode: str
+) -> None:
+    env = os.environ.copy()
+    env["ASAN_OPTIONS"] = "halt_on_error=1:detect_leaks=0"
+    result = subprocess.run(
+        [str(shm_tail_harness), str(bytes_to_copy), guard_mode],
+        cwd=_REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        f"SHM tail harness failed for {bytes_to_copy} bytes in {guard_mode}\n"
+        f"stdout:\n{result.stdout}\n"
+        f"stderr:\n{result.stderr}"
+    )


### PR DESCRIPTION
# Copy CPU shared-memory tails at their exact length

## What this fixes

The CPU shared-memory all-reduce helper copied data in 64-byte blocks. It still performed a full
64-byte load and store for the final partial block.

For example, a 65-byte copy completed the first 64-byte block and then read and wrote another 64
bytes for the one remaining byte. Before this change, that second operation touched 63 bytes past
both buffers. If the buffer ended at a protected page boundary, the native vLLM process faulted.
After this change, vLLM copies complete 64-byte blocks with the vectorized path and copies exactly
one byte for that final remainder.

## Why it matters

A non-aligned tensor chunk reaching CPU shared-memory all-reduce could read and overwrite memory
outside its buffers and crash the engine-adjacent process. The demonstrated impact is denial of
service. Code execution was not demonstrated.

## The change

`memcpy_to_shm()` now stops the 64-byte loop at the aligned prefix and uses `std::memcpy()` for the
exact remaining byte count. The branch also adds a guard-page harness for 1-, 64-, 65-, and
100-byte copies and places the test in the ARM CPU CI job.

## How it was tested

This failure only reproduces on the ARM vector backend, so it was proven on an Apple Silicon
(arm64) host by compiling `csrc/cpu/shm.cpp` directly under AddressSanitizer against a guard page
(the added `tests/distributed/test_shm_tail.py`).

- Without the fix, AddressSanitizer caught the out-of-bounds for a non-64-byte-aligned copy: a
  read past the end of the source buffer at `shm.cpp:461`, and a write past the end of the
  destination buffer at `:462`.
- With the fix, all 7 guard-page cases (1, 64, 65, and 100 bytes) passed.

The test is placed in the ARM CPU CI job so upstream ARM CI re-exercises it on every change.

## Reference

Advisory: GHSA-xf2m-jh9q-wwg5

Track B: this is a public PR against `vllm-project/vllm@main`.

## Credit

- @KernelClint (Clinton Thomas) and @dhalf (Lucas Bourtoule)
- Patch the Planet (Trail of Bits + OpenAI collaboration); discovered using GPT-5.5-Cyber

All commits include DCO `Signed-off-by` trailers.
