### PR TITLE
Preserve cache isolation across Harmony tool turns

### DIFF
--- a/tests/test_harmony_continuation_cache_salt.py
+++ b/tests/test_harmony_continuation_cache_salt.py
@@ -1,0 +1,65 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import pytest
+
+from vllm.entrypoints.openai.responses.context import HarmonyContext
+from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
+from vllm.entrypoints.openai.responses.serving import OpenAIServingResponses
+from vllm.inputs import tokens_input
+from vllm.sampling_params import SamplingParams
+
+pytestmark = [pytest.mark.cpu_test, pytest.mark.skip_global_cleanup]
+
+
+class _EngineClient:
+    def __init__(self):
+        self.inputs = []
+
+    def generate(self, engine_input, *_args, **_kwargs):
+        self.inputs.append(engine_input)
+
+        async def empty_generator():
+            if False:
+                yield None
+
+        return empty_generator()
+
+
+@pytest.mark.asyncio
+async def test_harmony_tool_continuation_preserves_cache_salt():
+    serving = OpenAIServingResponses.__new__(OpenAIServingResponses)
+    serving.model_config = SimpleNamespace(max_model_len=128)
+    serving.engine_client = _EngineClient()
+    serving._log_inputs = lambda *_args, **_kwargs: None
+
+    context = HarmonyContext.__new__(HarmonyContext)
+    context.request = ResponsesRequest(
+        model="m",
+        input="hello",
+        cache_salt="victim-salt",
+    )
+    context.append_output = lambda _output: None
+    context.append_tool_output = lambda _output: None
+    context.render_for_completion = lambda: [10, 11, 12]
+
+    needs_tool = iter([True, False])
+    context.need_builtin_tool_call = lambda: next(needs_tool)
+
+    async def call_tool():
+        return []
+
+    context.call_tool = call_tool
+
+    async for _ in serving._generate_with_builtin_tools(
+        request_id="resp-test",
+        engine_input=tokens_input([1, 2], cache_salt="victim-salt"),
+        sampling_params=SamplingParams(max_tokens=4),
+        context=context,
+    ):
+        pass
+
+    assert len(serving.engine_client.inputs) == 2
+    assert serving.engine_client.inputs[1]["cache_salt"] == "victim-salt"

--- a/vllm/entrypoints/openai/responses/context.py
+++ b/vllm/entrypoints/openai/responses/context.py
@@ -607,12 +607,14 @@ class HarmonyContext(ConversationContext):
         available_tools: list[str],
         function_tool_names: frozenset[str],
         response_parser: Parser | None = None,
+        request: ResponsesRequest | None = None,
     ):
         from vllm.parser.harmony import HarmonyParser, Segment
 
         assert isinstance(response_parser, HarmonyParser)
 
         self._messages = messages
+        self.request = request
         self.response_parser: HarmonyParser = response_parser
         self.finish_reason: str | None = None
         self.available_tools = available_tools

--- a/vllm/entrypoints/openai/responses/serving.py
+++ b/vllm/entrypoints/openai/responses/serving.py
@@ -466,6 +466,7 @@ class OpenAIServingResponses(GenerateBaseServing):
                     available_tools,
                     function_tool_names,
                     response_parser=response_parser,
+                    request=request,
                 )
             else:
                 if envs.VLLM_USE_EXPERIMENTAL_PARSER_CONTEXT:
@@ -720,7 +721,14 @@ class OpenAIServingResponses(GenerateBaseServing):
             # Render the next prompt token ids and update sampling_params.
             if isinstance(context, HarmonyContext):
                 token_ids = context.render_for_completion()
-                engine_input = tokens_input(token_ids)
+                engine_input = tokens_input(
+                    token_ids,
+                    cache_salt=(
+                        context.request.cache_salt
+                        if context.request is not None
+                        else None
+                    ),
+                )
 
                 sampling_params.max_tokens = max_model_len - len(token_ids)
             elif isinstance(context, ParsableContext):


### PR DESCRIPTION
# Preserve cache isolation across Harmony tool turns

## What this fixes

The Responses API accepts `cache_salt` so tenants can keep their prompt-cache entries separate.
On the GPT-OSS Harmony path, the first engine request carried that salt, but the engine request
created after a built-in or MCP tool call did not.

For example, a tenant could send a tool-using request with
`"cache_salt":"victim-secret"`. Before this change, vLLM rendered the next turn and submitted it
without the salt. That continuation entered the global unsalted cache. Another authenticated
tenant who guessed the post-tool conversation could submit the same text without a salt and see
the matching cached-token count in the Responses usage data.

After this change, every Harmony continuation carries the original `cache_salt`. A request using
a different salt, or no salt, cannot match that continuation's cache entry.

## Why it matters

On a multi-user deployment with Harmony tools enabled, one tenant could test whether a guessed
post-tool prompt had been processed for another tenant. This does not reveal arbitrary prompt
text by itself, but it breaks the prompt-cache separation that `cache_salt` is documented to
provide.

## The change

The continuation path now passes `context.request.cache_salt` when it rebuilds `tokens_input`,
matching the behavior of the first Harmony turn. The regression test records both engine inputs
and verifies that `"victim-salt"` is present on the continuation.

## How it was tested

Without the fix, the focused continuation test failed; with the fix, it passed. The earlier live
four-way replay also showed why the field matters: a matching unsalted probe reported 160 cached
tokens, a changed-history control reported 128, and a matching request under a different salt
reported 0. Preserving the salt removes the unintended unsalted match.

## Reference

Advisory: GHSA-935w-9g4m-p28p

Track B: this is a public PR against `vllm-project/vllm@main`.

## Credit

- @KernelClint (Clinton Thomas) and @dhalf (Lucas Bourtoule)
- Patch the Planet (Trail of Bits + OpenAI collaboration); discovered using GPT-5.5-Cyber

All commits include DCO `Signed-off-by` trailers.
