### PR TITLE
[Bugfix][MoE] Support GELU tanh in FlashInfer B12x MoE

### DIFF
--- a/vllm/model_executor/layers/fused_moe/experts/flashinfer_b12x_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/flashinfer_b12x_moe.py
@@ -45,6 +45,7 @@ class FlashInferB12xExperts(mk.FusedMoEExpertsModular):
 
     _ACTIVATION_MAP: dict[MoEActivation, str] = {
         MoEActivation.SILU: "silu",
+        MoEActivation.GELU_TANH: "gelu_tanh",
         MoEActivation.RELU2_NO_MUL: "relu2",
     }
 
@@ -188,7 +189,11 @@ class FlashInferB12xExperts(mk.FusedMoEExpertsModular):
 
     @staticmethod
     def _supports_activation(activation: MoEActivation) -> bool:
-        return activation in (MoEActivation.SILU, MoEActivation.RELU2_NO_MUL)
+        return activation in (
+            MoEActivation.SILU,
+            MoEActivation.GELU_TANH,
+            MoEActivation.RELU2_NO_MUL,
+        )
 
     @staticmethod
     def _supports_parallel_config(moe_parallel_config: FusedMoEParallelConfig) -> bool:


### PR DESCRIPTION
## Summary

Adds `MoEActivation.GELU_TANH` support to the FlashInfer B12x MoE backend so Gemma 4 NVFP4 can use `--moe-backend flashinfer_b12x`.

## Validation

Validated with `nvidia/Gemma-4-26B-A4B-NVFP4` on DGX Spark using FlashInfer 0.6.16.post3
