### PR TITLE
[BugFix] Clamp Mooncake store token_len to hash coverage under MTP/async scheduling

### DIFF
--- a/tests/v1/kv_connector/unit/test_mooncake_store_worker.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_worker.py
@@ -491,6 +491,70 @@ def test_process_tokens_applies_stride_before_hash_access():
     assert results == [(96, 128, bytes([15]))]
 
 
+def test_process_tokens_clamps_when_token_len_exceeds_hash_coverage():
+    """Regression test for the MTP/async-scheduling assertion crash: the
+    scheduler-side tracker can report more tokens than have actually been
+    hashed yet (block_hashes only ever covers confirmed tokens, while async
+    scheduling + speculative decoding advance token bookkeeping optimistically).
+    process_tokens must clamp to the covered range instead of asserting.
+    """
+    db = ChunkedTokenDatabase(
+        KeyMetadata("test-model", 0, 0, 0, 0),
+        block_size=32,
+        hash_block_size=8,
+    )
+    # Only 2 hash-blocks (16 tokens) are hashed, but the caller optimistically
+    # claims 32 tokens are ready to save.
+    block_hashes = _RecordingBlockHashes([bytes([i]) for i in range(2)])
+
+    results = list(db.process_tokens(token_len=32, block_hashes=block_hashes))
+
+    assert results == [(0, 16, bytes([1]))]
+
+
+def test_process_tokens_clamp_can_yield_nothing_when_start_is_past_coverage():
+    """mask_num (the already-saved offset) can land past the clamped
+    coverage entirely -- must yield nothing, not raise or underflow."""
+    db = ChunkedTokenDatabase(
+        KeyMetadata("test-model", 0, 0, 0, 0),
+        block_size=32,
+        hash_block_size=8,
+    )
+    # 16 tokens hashed, but token_len and mask_num both optimistically assume
+    # more tokens exist than are actually covered.
+    block_hashes = _RecordingBlockHashes([bytes([i]) for i in range(2)])
+
+    results = list(
+        db.process_tokens(token_len=64, block_hashes=block_hashes, mask_num=32)
+    )
+
+    assert results == []
+
+
+def test_store_sending_thread_clamps_when_block_hashes_lag_token_len():
+    """End-to-end regression test for the incident: previously, a ReqMeta
+    whose token_len_chunk outran its block_hashes (as happens on decode with
+    MTP speculative acceptance under async scheduling) raised an
+    AssertionError inside process_tokens. KVCacheStoreSendingThread.run()
+    catches and logs that per request, but in the real cascade this fed the
+    prefill scheduler's invalid-block handling and triggered a fatal engine
+    crash. The sending thread must now save only the covered prefix instead
+    of raising.
+    """
+    store = MagicMock()
+    store.batch_is_exist.side_effect = lambda keys: [0] * len(keys)
+    store.batch_put_from_multi_buffers.return_value = [256]
+    thread = _make_store_sending_thread(store)
+
+    thread.add_stored_request("req-a")
+    # token_len_chunk=32 (2 scheduler blocks) but only 1 hash-block's worth
+    # of tokens has actually been hashed on the request.
+    thread._handle_request(_make_store_req("req-a", [b"a0"]))
+
+    assert store.batch_is_exist.call_count == 1
+    assert len(store.batch_is_exist.call_args.args[0]) == 1
+
+
 def test_store_sending_thread_delta_saves_only_new_full_attention_chunks():
     store = MagicMock()
     store.batch_is_exist.side_effect = lambda keys: [0] * len(keys)

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/data.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/data.py
@@ -268,8 +268,8 @@ class ChunkedTokenDatabase:
         rank regardless of where the processed suffix begins.
 
         Args:
-            token_len: Total number of tokens. Must be hash-block aligned and
-                covered by ``block_hashes`` when hashes are present.
+            token_len: Total number of tokens. Clamped internally to the
+                range covered by ``block_hashes``.
             block_hashes: Block hashes computed at ``hash_block_size`` granularity.
                 When ``block_size > hash_block_size`` each group's ``block_size`` chunk
                 is keyed by its last sub-hash via ``chunk_hashes_for_block_size``.
@@ -282,8 +282,29 @@ class ChunkedTokenDatabase:
         assert put_step > 0
         if not block_hashes:
             return
-        assert token_len % self.hash_block_size == 0
-        assert token_len // self.hash_block_size <= len(block_hashes)
+        # Clamp token_len to hash coverage.  With speculative decoding (MTP),
+        # the caller's token count can temporarily exceed the number of
+        # block hashes available.  Rather than crashing, save up to the
+        # covered range; the unsaved tail is picked up on the next step
+        # once hashes catch up.
+        max_covered = len(block_hashes) * self.hash_block_size
+        if token_len > max_covered:
+            logger.warning(
+                "Mooncake store: clamping save length from %d to %d tokens "
+                "(model=%s tp_rank=%d, hash_block_size=%d); block_hashes "
+                "have not caught up with the scheduler's token count yet. "
+                "Expected under MTP/async-scheduling races; the unsaved "
+                "tail is retried once hashes catch up.",
+                token_len,
+                max_covered,
+                self.metadata.model_name,
+                self.metadata.tp_rank,
+                self.hash_block_size,
+            )
+            token_len = max_covered
+        token_len = token_len // self.hash_block_size * self.hash_block_size
+        if token_len == 0:
+            return
         start_chunk = max(0, cdiv(mask_num, self.block_size))
         max_chunks = cdiv(token_len, self.block_size)
         if chunk_mask is not None:


### PR DESCRIPTION
## Purpose
- Under speculative decoding (MTP) combined with async scheduling, the scheduler can advance its token count optimistically before `block_hashes` are extended to match, tripping an assertion in `ChunkedTokenDatabase.process_tokens` and crashing the engine. 

- Clamp `token_len` to the range actually covered by `block_hashes` and save only that prefix instead of asserting; the remaining tail is picked up on a later step once the hashes catch up. Also log a warning when the clamp engages so the race stays observable.

## Note on scope
This clamp stops the crash but does not fully close a smaller side effect: `KVCacheStoreSendingThread._record_saved` records the pre-clamp (optimistic) token count rather than what was actually saved, so the worker's own resume offset can advance past the clamped range and the skipped tokens for that block are never retried, leaving a small gap in what's persisted to the external Mooncake store for that request (generation correctness is unaffected). 
A more complete fix would have `_record_saved` (and the scheduler's `RequestTracker` bookkeeping) advance only by the actually-covered amount so the gap is retried instead of permanently dropped. That's left out of this PR since it touches block-lifecycle bookkeeping (`request_finished`/`delay_free_blocks`) and carries more risk than warranted for a crash hotfix; happy to follow up separately if the cache-hit-rate impact turns out to matter in practice.

## Test plan

Fixes https://github.com/vllm-project/vllm/issues/51805


## Test Plan
Added unit tests for the clamp in `tests/v1/kv_connector/unit/test_mooncake_store_worker.py`, including an end-to-end regression test through `KVCacheStoreSendingThread`.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

