### PR TITLE
[Bugfix][Spec Decode] Restore DeepSeek-V4 DSpark draft quantization

### DIFF
--- a/tests/config/test_speculative_dspark.py
+++ b/tests/config/test_speculative_dspark.py
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+
+from vllm.config import ModelConfig, ParallelConfig, SpeculativeConfig
+from vllm.model_executor.layers import quantization as me_quant
+from vllm.model_executor.layers.quantization.fp8 import Fp8Config
+from vllm.models.deepseek_v4.quant_config import DeepseekV4FP8Config
+from vllm.transformers_utils.configs.deepseek_v4 import DeepseekV4Config
+
+
+class _NoOverrideQuantizationConfig:
+    @classmethod
+    def override_quantization_method(cls, hf_quant_cfg, user_quant, hf_config=None):
+        return None
+
+
+@pytest.mark.cpu_test
+def test_deepseek_v4_dspark_preserves_specialized_fp8_quantization(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+):
+    quantization_configs = {
+        "fp8": Fp8Config,
+        "deepseek_v4_fp8": DeepseekV4FP8Config,
+    }
+    # Keep this config test independent of unrelated optional quant backends.
+    monkeypatch.setattr(me_quant, "QUANTIZATION_METHODS", list(quantization_configs))
+    monkeypatch.setattr(
+        me_quant,
+        "get_quantization_config",
+        lambda name: quantization_configs.get(name, _NoOverrideQuantizationConfig),
+    )
+
+    model_path = tmp_path / "deepseek-v4-dspark"
+    DeepseekV4Config(
+        architectures=["DeepseekV4ForCausalLM"],
+        hidden_size=16,
+        intermediate_size=32,
+        moe_intermediate_size=8,
+        num_hidden_layers=1,
+        num_attention_heads=1,
+        num_key_value_heads=1,
+        vocab_size=32,
+        torch_dtype="bfloat16",
+        quantization_config={
+            "activation_scheme": "dynamic",
+            "quant_method": "fp8",
+            "weight_block_size": [128, 128],
+        },
+    ).save_pretrained(model_path)
+    target_model_config = ModelConfig(
+        model=str(model_path), tokenizer_mode="skip", max_model_len=32
+    )
+
+    speculative_config = SpeculativeConfig(
+        model=str(model_path),
+        method="dspark",
+        num_speculative_tokens=5,
+        target_model_config=target_model_config,
+        target_parallel_config=ParallelConfig(),
+    )
+
+    draft_model_config = speculative_config.draft_model_config
+    assert draft_model_config.architectures == ["DSparkDraftModel"]
+    assert draft_model_config.quantization == "deepseek_v4_fp8"

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -999,6 +999,8 @@ class SpeculativeConfig:
                         "DSparkDraftModel"
                     ]
                     self.update_arch_()
+                    if self.draft_model_config.quantization == "fp8":
+                        self.draft_model_config.quantization = "deepseek_v4_fp8"
                 elif (
                     self.method == "dspark"
                     and "Gemma4DSparkModel" in self.draft_model_config.architectures


### PR DESCRIPTION
## Summary

- Restore the DeepSeek-V4 DSpark draft quantization to `deepseek_v4_fp8` after its model type is restored from `deepseek_mtp` to `deepseek_v4`.
- Prevent the draft from being constructed with plain `Fp8Config`, which leads to the reported `w13_weight_scale` loading failure.
- Add config-level regression coverage for the explicit DSpark model path.

## Root cause

`SpeculativeConfig.hf_config_override()` temporarily rewrites the DeepSeek-V4 draft model type to `deepseek_mtp` before `ModelConfig._verify_quantization()` runs.

Because `DeepseekV4FP8Config.override_quantization_method()` only recognizes `model_type == "deepseek_v4"` unless the quantization is explicitly specified, the draft quantization is frozen as plain `fp8`.

The DSpark branch later restores the model type and architecture, but did not restore the specialized quantization method. After #50330 made the loader derive the draft's own quantization config, the draft therefore receives `Fp8Config` instead of `DeepseekV4FP8Config`, matching the reported `w13_weight_scale` `KeyError`.

## Attribution and duplicate check

The config-side restoration was originally identified and proposed by @h-guo18 in #49133. That PR was later closed, while the loader-side draft-config isolation was merged through #50330. This PR adapts the remaining focused fix to current `main` and adds regression coverage for the user-visible failure reported in #51758.

I searched open PRs for `dspark quantization`, `w13_weight_scale`, and `deepseek_v4_fp8 speculative`. No focused open PR addresses this current-main regression. #41834 is a much broader SM12x enablement branch and does not contain this focused restoration on upstream `main`.

## Tests

Before the fix, the new regression test failed with:

```text
assert draft_model_config.quantization == "deepseek_v4_fp8"
E assert "fp8" == "deepseek_v4_fp8"
```

After the fix:

```text
9 passed, 16 warnings in 2.17s
```

Commands:

```bash
.venv/bin/python -m pytest \
  tests/config/test_speculative_dspark.py \
  tests/config/test_speculative_draft_hf_overrides.py \
  tests/model_executor/test_eagle_quantization.py::test_get_draft_quant_config_with_draft_model \
  tests/model_executor/test_eagle_quantization.py::test_get_draft_quant_config_without_draft_model \
  -q

ruff format --check \
  vllm/config/speculative.py \
  tests/config/test_speculative_dspark.py

ruff check \
  vllm/config/speculative.py \
  tests/config/test_speculative_dspark.py

git diff --check
```

## Model evaluation

Not run. This change only corrects quantization-config selection before weight loading and does not modify target-model inference math.

The regression was reproduced and fixed at the configuration level on a local 6×RTX 4090 system. Full-checkpoint DeepSeek-V4 DSpark loading still requires validation on supported hardware with the affected checkpoint.

## AI assistance disclosure

AI assistance was used for code inspection, test design, implementation support, and drafting this description. I reviewed every changed line and ran the tests listed above.
