### PR TITLE
Avoid long-blocking H2D copies in ViT

### DIFF
--- a/vllm/model_executor/models/qwen3_vl.py
+++ b/vllm/model_executor/models/qwen3_vl.py
@@ -705,14 +705,14 @@ class Qwen3_VisionTransformer(nn.Module):
             else self.rot_pos_ids(h, w, self.spatial_merge_size).repeat(t, 1)
             for t, h, w in grid_thw
         ]
-        num_pos = sum(p.shape[0] for p in pos_ids)                                                                                                                                             
-        pinned = torch.empty(                                                                                                                                                                  
-            (num_pos, pos_ids[0].shape[1]),                                                                                                                                                    
-            dtype=pos_ids[0].dtype,                                                                                                                                                            
-            pin_memory=True,                                                                                                                                                                   
+        num_pos = sum(p.shape[0] for p in pos_ids)
+        pinned = torch.empty(
+            (num_pos, pos_ids[0].shape[1]),
+            dtype=pos_ids[0].dtype,
+            pin_memory=True,
         )
-        pos_ids = (
-            torch.cat(pos_ids, dim=0, out=pinned).to(self.device, non_blocking=True)
+        pos_ids = torch.cat(pos_ids, dim=0, out=pinned).to(
+            self.device, non_blocking=True
         )
 
         # Use pre-computed cos_sin_cache from RotaryEmbedding

--- a/vllm/model_executor/models/qwen3_vl.py
+++ b/vllm/model_executor/models/qwen3_vl.py
@@ -705,7 +705,9 @@ class Qwen3_VisionTransformer(nn.Module):
             else self.rot_pos_ids(h, w, self.spatial_merge_size).repeat(t, 1)
             for t, h, w in grid_thw
         ]
-        pos_ids = torch.cat(pos_ids, dim=0).to(self.device, non_blocking=True)
+        pos_ids = (
+            torch.cat(pos_ids, dim=0).pin_memory().to(self.device, non_blocking=True)
+        )
 
         # Use pre-computed cos_sin_cache from RotaryEmbedding
         cos, sin = self.rotary_pos_emb.get_cos_sin(max_grid_size)

--- a/vllm/model_executor/models/qwen3_vl.py
+++ b/vllm/model_executor/models/qwen3_vl.py
@@ -705,8 +705,14 @@ class Qwen3_VisionTransformer(nn.Module):
             else self.rot_pos_ids(h, w, self.spatial_merge_size).repeat(t, 1)
             for t, h, w in grid_thw
         ]
+        num_pos = sum(p.shape[0] for p in pos_ids)                                                                                                                                             
+        pinned = torch.empty(                                                                                                                                                                  
+            (num_pos, pos_ids[0].shape[1]),                                                                                                                                                    
+            dtype=pos_ids[0].dtype,                                                                                                                                                            
+            pin_memory=True,                                                                                                                                                                   
+        )
         pos_ids = (
-            torch.cat(pos_ids, dim=0).pin_memory().to(self.device, non_blocking=True)
+            torch.cat(pos_ids, dim=0, out=pinned).to(self.device, non_blocking=True)
         )
 
         # Use pre-computed cos_sin_cache from RotaryEmbedding

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -2251,10 +2251,20 @@ class GPUModelRunner(
 
         if self.uses_mrope:
             # Only relevant for models using M-RoPE (e.g, Qwen2-VL)
-            self.mrope_positions.gpu[:, :total_num_scheduled_tokens].copy_(
-                self.mrope_positions.cpu[:, :total_num_scheduled_tokens],
-                non_blocking=True,
-            )
+            # Copy one row at a time. mrope_positions is allocated as
+            # [3, max_num_tokens + 1] with a dummy trailing column to keep it
+            # non-contiguous for torch.compile, so cpu[:, :N] is a strided view.
+            # copy_() cannot express a strided source as a single
+            # cudaMemcpyAsync, so it first gathers into a contiguous *pageable*
+            # temporary, and a pageable H2D ignores non_blocking=True and
+            # synchronizes the stream before the transfer starts. Each row is
+            # contiguous within the pinned allocation, so per-row copies stay on
+            # the pinned path and are genuinely asynchronous.
+            for row in range(self.mrope_positions.gpu.shape[0]):
+                self.mrope_positions.gpu[row, :total_num_scheduled_tokens].copy_(
+                    self.mrope_positions.cpu[row, :total_num_scheduled_tokens],
+                    non_blocking=True,
+                )
         elif self.uses_xdrope_dim > 0:
             # Only relevant for models using XD-RoPE (e.g, HunYuan-VL)
             self.xdrope_positions.gpu[:, :total_num_scheduled_tokens].copy_(


### PR DESCRIPTION
## Purpose

Two host-to-device copies on the per-iteration critical path can take a very
long time to return. Despite `non_blocking=True`, the `cudaMemcpyAsync` call
blocks the calling thread, and the time it takes tracks the amount of GPU work
that has already been queued. That undoes the host run-ahead that asynchronous
scheduling and CUDA graphs exist to build up.

<img width="1576" height="352" alt="image" src="https://github.com/user-attachments/assets/4db27ffd-8dd4-40db-8e33-e42fddc2b324" />

Neither call site looks suspicious at a glance, which is why this is easy to
miss:

**M-RoPE positions (`vllm/v1/worker/gpu_model_runner.py`).** The staging buffer
is pinned. However `mrope_positions` is allocated as `[3, max_num_tokens + 1]`,
where the dummy trailing column is deliberately there to keep the tensor
non-contiguous for `torch.compile`. That makes `cpu[:, :N]` a strided view of a
pinned buffer. Using `CudaMemcpyAsync` with non-contiguous buffer leads to a silent synchronization.
Copying the three rows individually — each row being contiguous
within that same pinned allocation — makes the synchronization go away.

Before M-RoPE fix:
<img width="2447" height="457" alt="Screenshot 2026-08-11 at 11 48 09 AM" src="https://github.com/user-attachments/assets/26d9ec3b-43c9-4acc-be7f-8915524532c6" />

After M-RoPE fix:
<img width="2138" height="392" alt="Screenshot 2026-08-11 at 11 46 33 AM" src="https://github.com/user-attachments/assets/cdb1167c-c95f-4d1a-ab95-58f4861c5a67" />


As shown above, the new three HtoDs became truly pinned and the synchronization goes away. There is still a very long `cudamemcpyasync` because we haven't fixed the following vision position ids copies yet.

**Vision position ids (`vllm/model_executor/models/qwen3_vl.py`).**
`rot_pos_ids()` builds its per-image tensors from numpy, so the concatenated
`pos_ids` is not pinned. Calling `.pin_memory()` before
`.to(device, non_blocking=True)` makes the long copies go away. `pin_memory()`
is a host-side copy only and does not change what is transferred.

Before vision position ids fix:
<img width="2366" height="442" alt="Screenshot 2026-08-11 at 11 55 30 AM" src="https://github.com/user-attachments/assets/d7fbcd9e-d538-4ed1-8ea1-540b07d66d72" />

After vision position ids fix:
<img width="2277" height="465" alt="Screenshot 2026-08-11 at 11 58 53 AM" src="https://github.com/user-attachments/assets/b7f2f7b8-5ec5-4037-ae41-34a53187b6c0" />

After these two fixes, `cudaMemcpyAsync` synchronizations are totally eliminated.

## Scope

The M-RoPE change affects models using M-RoPE (Qwen2-VL, Qwen2.5-VL, Qwen3-VL)
on the V1 model runner. Model Runner V2 stages positions through UVA buffers and
does not perform this copy, so it is unaffected.

The vision position id change is specific to Qwen3-VL and is independent of the
model runner.

## Test Plan

Existing Qwen-VL correctness tests. The changes affect only how the transfer is
issued, not what is transferred.

## Test Result

Output is unchanged. Profiling shows the long-blocking copies are no longer
present at either call site.

## What is measured, and what is not

A microbenchmark that issues a single copy behind a fixed, deep queue of GPU
work, sweeping only the copy size, shows a payload threshold. Below it the
`cudaMemcpyAsync` call returns in microseconds. Above it the call takes roughly
as long as the GPU work already queued, and stays at that cost as the payload
grows further.

Being explicit about the limits of that result:

- The **root cause is not established.** We can show the threshold exists and is
  reproducible; we cannot yet say why.
- The observation is that above the threshold **the call becomes very long**. We
  have not demonstrated that it is specifically a stream synchronization.
- The threshold was found in a **microbenchmark**. It has not yet been confirmed
  end to end on a production model configuration.
- We have not established what PyTorch does internally for a strided host
  source, so no claim is made about that path here.

What is directly observable is the part this PR relies on: at both sites, issuing
the transfer from pinned, contiguous memory removes the long-blocking copies.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

