### PR TITLE
[Bugfix][Core] Guard usage-telemetry CPU info collection against forked-worker failures

### DIFF
--- a/tests/usage/test_usage_lib.py
+++ b/tests/usage/test_usage_lib.py
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Regression tests for vLLM usage telemetry (vllm/usage/usage_lib.py).
+
+CPU info collection is best-effort; a failure inside a forked worker (e.g.
+py-cpuinfo re-executing itself) must degrade gracefully instead of killing
+engine startup (#51825).
+"""
+
+import json
+
+from vllm.usage import usage_lib
+from vllm.usage.usage_lib import UsageContext, UsageMessage
+
+
+def test_report_usage_survives_cpuinfo_failure(monkeypatch):
+    """The unguarded ``cpuinfo.get_cpu_info()`` raises inside forked workers;
+    telemetry must fall back to an empty ``info`` dict."""
+
+    def fail_cpu_info():
+        raise json.JSONDecodeError("invalid cpuinfo output", "not-json", 0)
+
+    monkeypatch.setattr(usage_lib.cpuinfo, "get_cpu_info", fail_cpu_info)
+    monkeypatch.setattr(UsageMessage, "_write_to_file", lambda *_: None)
+    monkeypatch.setattr(UsageMessage, "_send_to_server", lambda *_: None)
+
+    message = UsageMessage()
+    message._report_usage_once("TestModel", UsageContext.ENGINE_CONTEXT, {})
+
+    assert message.num_cpu is None
+    assert message.cpu_type == ""
+    assert message.cpu_family_model_stepping == ",,"
+    assert message.model_architecture == "TestModel"
+
+
+def test_report_usage_normal_path_unchanged(monkeypatch):
+    """The guard must not change the normal-path behavior."""
+    monkeypatch.setattr(
+        usage_lib.cpuinfo,
+        "get_cpu_info",
+        lambda: {
+            "count": 8,
+            "brand_raw": "Intel Core i7",
+            "family": 6,
+            "model": 158,
+            "stepping": 10,
+        },
+    )
+    monkeypatch.setattr(UsageMessage, "_write_to_file", lambda *_: None)
+    monkeypatch.setattr(UsageMessage, "_send_to_server", lambda *_: None)
+
+    message = UsageMessage()
+    message._report_usage_once("TestModel", UsageContext.ENGINE_CONTEXT, {})
+
+    assert message.num_cpu == 8
+    assert message.cpu_type == "Intel Core i7"
+    assert message.cpu_family_model_stepping == "6,158,10"

--- a/vllm/usage/usage_lib.py
+++ b/vllm/usage/usage_lib.py
@@ -219,10 +219,9 @@ class UsageMessage:
             # CPU info collection is best-effort and can fail inside
             # forked workers (py-cpuinfo re-executes itself); do not
             # take the whole engine down over optional telemetry.
-            logger.debug("Could not collect CPU info for usage stats",
-                         exc_info=True)
+            logger.debug("Could not collect CPU info for usage stats", exc_info=True)
             info = {}
-        self.num_cpu = info.get("count", None)
+        self.num_cpu = info.get("count")
         self.cpu_type = info.get("brand_raw", "")
         self.cpu_family_model_stepping = ",".join(
             [

--- a/vllm/usage/usage_lib.py
+++ b/vllm/usage/usage_lib.py
@@ -213,7 +213,15 @@ class UsageMessage:
         self.platform = platform.platform()
         self.total_memory = psutil.virtual_memory().total
 
-        info = cpuinfo.get_cpu_info()
+        try:
+            info = cpuinfo.get_cpu_info()
+        except Exception:
+            # CPU info collection is best-effort and can fail inside
+            # forked workers (py-cpuinfo re-executes itself); do not
+            # take the whole engine down over optional telemetry.
+            logger.debug("Could not collect CPU info for usage stats",
+                         exc_info=True)
+            info = {}
         self.num_cpu = info.get("count", None)
         self.cpu_type = info.get("brand_raw", "")
         self.cpu_family_model_stepping = ",".join(


### PR DESCRIPTION
## Purpose

Fixes #51825.

Optional usage telemetry could kill the engine at startup. `vllm/usage/usage_lib.py`
called `cpuinfo.get_cpu_info()` unguarded; `py-cpuinfo` re-executes itself in a
subprocess and parses the output as JSON, and inside a forked vLLM worker (e.g.
`--pipeline-parallel-size 2` with `distributed_executor_backend=mp`) that parse can
fail. Nothing caught the exception, so it propagated and took the whole engine down:

```
json.decoder.JSONDecodeError: Expecting value: line 1 column 2 (char 1)
```

## Change

- `vllm/usage/usage_lib.py`: wrap `cpuinfo.get_cpu_info()` in `try/except`, log at debug
  level, and fall back to an empty `info` dict. Telemetry is best-effort and must not
  affect engine startup.
- `tests/usage/test_usage_lib.py`: regression test that forces `get_cpu_info()` to raise
  and asserts graceful degradation, plus a check that the normal path is unchanged.

## Test Plan

```bash
pytest tests/usage/test_usage_lib.py -v
```

## Test Result

<!-- TODO: paste local pytest output -->

## Notes

- AI-assisted; reviewed by me. DCO `Signed-off-by:` present.