### PR TITLE
[Bugfix][Frontend] Fix prompt_logprobs=0 bypassing admission guards and chat echo

### DIFF
--- a/rust/src/server/src/routes/openai/chat_completions/convert.rs
+++ b/rust/src/server/src/routes/openai/chat_completions/convert.rs
@@ -119,12 +119,14 @@ pub(super) fn prepare_chat_request(
     let requested_logprobs = request.logprobs;
     let is_named_tool_choice = matches!(&request.tool_choice, Some(ToolChoice::Function { .. }));
 
-    // Auto-enable prompt logprobs for non-streaming echo, matching Python vLLM's
-    // behavior.
+    // Auto-enable prompt logprobs for non-streaming echo, but only when the
+    // caller actually requested output logprobs -- matching Python vLLM's
+    // behavior of inheriting `top_logprobs` for echo only when `logprobs` was
+    // explicitly requested, rather than unconditionally on every echo request.
     let top_logprobs = request.top_logprobs.unwrap_or(0);
     let prompt_logprobs = request
         .prompt_logprobs
-        .or((request.echo && !request.stream).then_some(top_logprobs));
+        .or((request.echo && !request.stream && request.logprobs).then_some(top_logprobs));
     let include_prompt_logprobs = prompt_logprobs.is_some();
 
     let structured_outputs = convert_from_response_format(
@@ -1390,6 +1392,53 @@ mod tests {
         .expect("request is valid");
 
         assert_eq!(prepared.chat_request.sampling_params.logprobs, Some(3));
+        assert_eq!(prepared.chat_request.sampling_params.prompt_logprobs, None);
+        assert!(!prepared.options.include_prompt_logprobs);
+    }
+
+    #[test]
+    fn prepare_chat_request_enables_prompt_logprobs_for_non_streaming_echo_with_logprobs() {
+        let request = ChatCompletionRequest {
+            stream: false,
+            logprobs: true,
+            top_logprobs: Some(3),
+            echo: true,
+            ..base_request()
+        };
+
+        let prepared = prepare_chat_request(
+            request,
+            &served(&["Qwen/Qwen1.5-0.5B-Chat"]),
+            ResolvedRequestContext::default(),
+        )
+        .expect("request is valid");
+
+        assert_eq!(
+            prepared.chat_request.sampling_params.prompt_logprobs,
+            Some(3)
+        );
+        assert!(prepared.options.include_prompt_logprobs);
+    }
+
+    #[test]
+    fn prepare_chat_request_does_not_enable_prompt_logprobs_for_echo_without_logprobs() {
+        // Echo alone must not implicitly turn on prompt logprobs -- only when
+        // the caller actually asked for output logprobs, matching Python
+        // vLLM's chat protocol behavior.
+        let request = ChatCompletionRequest {
+            stream: false,
+            logprobs: false,
+            echo: true,
+            ..base_request()
+        };
+
+        let prepared = prepare_chat_request(
+            request,
+            &served(&["Qwen/Qwen1.5-0.5B-Chat"]),
+            ResolvedRequestContext::default(),
+        )
+        .expect("request is valid");
+
         assert_eq!(prepared.chat_request.sampling_params.prompt_logprobs, None);
         assert!(!prepared.options.include_prompt_logprobs);
     }

--- a/rust/src/server/src/routes/openai/chat_completions/validate.rs
+++ b/rust/src/server/src/routes/openai/chat_completions/validate.rs
@@ -43,7 +43,7 @@ pub(super) fn validate_request_compat(
             );
         }
 
-        if request.stream && (prompt_logprobs > 0 || prompt_logprobs == -1) {
+        if request.stream {
             bail_invalid_request!(
                 param = "prompt_logprobs",
                 "prompt_logprobs are not available when stream=true."
@@ -299,6 +299,18 @@ mod tests {
 
         let request = ChatCompletionRequest {
             prompt_logprobs: Some(-1),
+            ..base_request()
+        };
+        assert!(validate_request_compat(&request, &served(&["Qwen/Qwen1.5-0.5B-Chat"])).is_err());
+    }
+
+    #[test]
+    fn validate_request_compat_rejects_streaming_prompt_logprobs_zero() {
+        // prompt_logprobs=0 is a meaningful, explicit request (not "unset"),
+        // so it must be rejected under stream=true just like any other
+        // prompt_logprobs value.
+        let request = ChatCompletionRequest {
+            prompt_logprobs: Some(0),
             ..base_request()
         };
         assert!(validate_request_compat(&request, &served(&["Qwen/Qwen1.5-0.5B-Chat"])).is_err());

--- a/rust/src/server/src/routes/openai/completions/validate.rs
+++ b/rust/src/server/src/routes/openai/completions/validate.rs
@@ -52,7 +52,7 @@ pub(super) fn validate_request_compat(
     }
 
     if let Some(prompt_logprobs) = request.prompt_logprobs {
-        if request.stream && (prompt_logprobs > 0 || prompt_logprobs == -1) {
+        if request.stream {
             bail_invalid_request!(
                 param = "prompt_logprobs",
                 "`prompt_logprobs` are not available when `stream=true`."
@@ -177,6 +177,20 @@ mod tests {
     fn validate_request_compat_rejects_streaming_prompt_logprobs() {
         let request = CompletionRequest {
             prompt_logprobs: Some(1),
+            ..base_request()
+        };
+        assert!(
+            validate_request_compat(&request, &served_names(&["Qwen/Qwen1.5-0.5B-Chat"])).is_err()
+        );
+    }
+
+    #[test]
+    fn validate_request_compat_rejects_streaming_prompt_logprobs_zero() {
+        // prompt_logprobs=0 is a meaningful, explicit request (not "unset"),
+        // so it must be rejected under stream=true just like any other
+        // prompt_logprobs value.
+        let request = CompletionRequest {
+            prompt_logprobs: Some(0),
             ..base_request()
         };
         assert!(

--- a/tests/entrypoints/openai/chat_completion/test_chat.py
+++ b/tests/entrypoints/openai/chat_completion/test_chat.py
@@ -1012,6 +1012,77 @@ def test_chat_completion_request_n_parameter_default():
     assert sampling_params.n == 1, f"Expected n=1 (default), got n={sampling_params.n}"
 
 
+# Unit tests for echo + prompt_logprobs interaction in
+# ChatCompletionRequest.to_sampling_params()
+def test_chat_completion_request_echo_without_logprobs_does_not_set_prompt_logprobs():
+    """echo=True alone must not implicitly enable prompt_logprobs.
+
+    ChatCompletionRequest.top_logprobs defaults to 0 (not None), so naively
+    inheriting it for echo would set prompt_logprobs=0 on every echo request,
+    even though 0 is itself a meaningful, "requested" value downstream.
+    """
+    request = ChatCompletionRequest(
+        model="test-model",
+        messages=[{"role": "user", "content": "Hello"}],
+        echo=True,
+    )
+
+    sampling_params = request.to_sampling_params(
+        max_tokens=10,
+        default_sampling_params={},
+    )
+
+    assert sampling_params.prompt_logprobs is None
+
+
+def test_chat_completion_request_echo_with_logprobs_inherits_top_logprobs():
+    """echo=True with logprobs actually requested still inherits top_logprobs."""
+    request = ChatCompletionRequest(
+        model="test-model",
+        messages=[{"role": "user", "content": "Hello"}],
+        echo=True,
+        logprobs=True,
+        top_logprobs=3,
+    )
+
+    sampling_params = request.to_sampling_params(
+        max_tokens=10,
+        default_sampling_params={},
+    )
+
+    assert sampling_params.prompt_logprobs == 3
+
+
+def test_chat_completion_request_explicit_prompt_logprobs_zero_is_preserved():
+    """An explicit prompt_logprobs=0 request must reach SamplingParams as 0,
+    not be dropped, so downstream admission guards can see it."""
+    request = ChatCompletionRequest(
+        model="test-model",
+        messages=[{"role": "user", "content": "Hello"}],
+        prompt_logprobs=0,
+    )
+
+    sampling_params = request.to_sampling_params(
+        max_tokens=10,
+        default_sampling_params={},
+    )
+
+    assert sampling_params.prompt_logprobs == 0
+
+
+def test_chat_completion_request_rejects_prompt_logprobs_zero_with_stream():
+    """prompt_logprobs=0 is a meaningful, explicit request (not "unset"), so
+    it must be rejected under stream=True just like any other prompt_logprobs
+    value, per the documented "not available when stream=True" rule."""
+    with pytest.raises(VLLMValidationError, match="not available when `stream=True`"):
+        ChatCompletionRequest(
+            model="test-model",
+            messages=[{"role": "user", "content": "Hello"}],
+            prompt_logprobs=0,
+            stream=True,
+        )
+
+
 def test_chat_completion_request_accepts_model_specific_reasoning_effort():
     request = ChatCompletionRequest(
         model="test-model",

--- a/tests/entrypoints/openai/chat_completion/test_chat.py
+++ b/tests/entrypoints/openai/chat_completion/test_chat.py
@@ -1083,6 +1083,23 @@ def test_chat_completion_request_rejects_prompt_logprobs_zero_with_stream():
         )
 
 
+def test_chat_completion_request_accepts_prompt_logprobs_zero_with_raw_false_stream():
+    """A raw, not-yet-coerced `stream="false"` must not be treated as truthy.
+
+    The cross-field check runs as an "after" validator against the typed,
+    coerced `self.stream` (a real bool), not the raw request dict, so a
+    string "false" that pydantic coerces to False must not wrongly reject a
+    valid `prompt_logprobs=0` request."""
+    request = ChatCompletionRequest(
+        model="test-model",
+        messages=[{"role": "user", "content": "Hello"}],
+        prompt_logprobs=0,
+        stream="false",
+    )
+    assert request.stream is False
+    assert request.prompt_logprobs == 0
+
+
 def test_chat_completion_request_accepts_model_specific_reasoning_effort():
     request = ChatCompletionRequest(
         model="test-model",

--- a/tests/entrypoints/openai/completion/test_completion.py
+++ b/tests/entrypoints/openai/completion/test_completion.py
@@ -852,3 +852,20 @@ def test_completion_request_rejects_prompt_logprobs_zero_with_stream():
             prompt_logprobs=0,
             stream=True,
         )
+
+
+def test_completion_request_accepts_prompt_logprobs_zero_with_raw_false_stream():
+    """A raw, not-yet-coerced `stream="false"` must not be treated as truthy.
+
+    The cross-field check runs as an "after" validator against the typed,
+    coerced `self.stream` (a real bool), not the raw request dict, so a
+    string "false" that pydantic coerces to False must not wrongly reject a
+    valid `prompt_logprobs=0` request."""
+    request = CompletionRequest(
+        model="test-model",
+        prompt="Hello",
+        prompt_logprobs=0,
+        stream="false",
+    )
+    assert request.stream is False
+    assert request.prompt_logprobs == 0

--- a/tests/entrypoints/openai/completion/test_completion.py
+++ b/tests/entrypoints/openai/completion/test_completion.py
@@ -10,6 +10,7 @@ from openai import BadRequestError
 
 from tests.utils import RemoteOpenAIServer
 from vllm.entrypoints.openai.completion.protocol import CompletionRequest
+from vllm.exceptions import VLLMValidationError
 from vllm.sampling_params import SamplingParams
 from vllm.tokenizers import get_tokenizer
 
@@ -838,3 +839,16 @@ def test_completion_request_forwards_routed_experts_prompt_start():
     )
 
     assert sampling_params.routed_experts_prompt_start == 3
+
+
+def test_completion_request_rejects_prompt_logprobs_zero_with_stream():
+    """prompt_logprobs=0 is a meaningful, explicit request (not "unset"), so
+    it must be rejected under stream=True just like any other prompt_logprobs
+    value, per the documented "not available when stream=True" rule."""
+    with pytest.raises(VLLMValidationError, match="not available when `stream=True`"):
+        CompletionRequest(
+            model="test-model",
+            prompt="Hello",
+            prompt_logprobs=0,
+            stream=True,
+        )

--- a/tests/v1/engine/test_async_llm.py
+++ b/tests/v1/engine/test_async_llm.py
@@ -497,6 +497,34 @@ async def test_dp_rank_argument():
 
 
 @pytest.mark.asyncio(scope="module")
+async def test_kv_sharing_fast_prefill_rejects_prompt_logprobs_zero():
+    """prompt_logprobs=0 is a meaningful, explicit request ("return the
+    prompt token's own logprob"), not "unset" -- it must be rejected by the
+    kv_sharing_fast_prefill admission-time guard just like any other
+    prompt_logprobs value, before any GPU work begins.
+    """
+    engine_args = AsyncEngineArgs(
+        model=TEXT_ENGINE_ARGS.model,
+        enforce_eager=True,
+        kv_sharing_fast_prefill=True,
+    )
+    with ExitStack() as after:
+        with set_default_torch_num_threads(1):
+            engine = AsyncLLM.from_engine_args(engine_args)
+        after.callback(engine.shutdown)
+
+        sampling_params = SamplingParams(prompt_logprobs=0, max_tokens=5)
+
+        with pytest.raises(VLLMValidationError, match="kv-sharing-fast-prefill"):
+            async for _ in engine.generate(
+                request_id="request-kv-sharing-prompt-logprobs-zero",
+                prompt=TEXT_PROMPT,
+                sampling_params=sampling_params,
+            ):
+                pass
+
+
+@pytest.mark.asyncio(scope="module")
 async def test_header_dp_rank_argument():
     with ExitStack() as after:
         with set_default_torch_num_threads(1):

--- a/tests/v1/engine/test_llm_engine.py
+++ b/tests/v1/engine/test_llm_engine.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 from vllm import LLM
+from vllm.exceptions import VLLMValidationError
 from vllm.sampling_params import SamplingParams, StructuredOutputsParams
 from vllm.v1.metrics.reader import Counter, Gauge, Histogram, Metric, Vector
 
@@ -252,7 +253,7 @@ def test_kv_sharing_fast_prefill_rejects_prompt_logprobs_zero():
         max_model_len=128,
         gpu_memory_utilization=0.5,
     )
-    with pytest.raises(ValueError, match="kv-sharing-fast-prefill"):
+    with pytest.raises(VLLMValidationError, match="kv-sharing-fast-prefill"):
         llm.generate(
             "Hello, my name is",
             SamplingParams(prompt_logprobs=0, max_tokens=5),

--- a/tests/v1/engine/test_llm_engine.py
+++ b/tests/v1/engine/test_llm_engine.py
@@ -236,3 +236,24 @@ def test_skip_tokenizer_initialization(model: str):
     assert len(completions) > 0
     assert completions[0].text == ""
     assert completions[0].token_ids
+
+
+def test_kv_sharing_fast_prefill_rejects_prompt_logprobs_zero():
+    """prompt_logprobs=0 is a meaningful, explicit request ("return the
+    prompt token's own logprob"), not "unset" -- it must be rejected by the
+    same admission-time check as any other prompt_logprobs value, before any
+    GPU work begins.
+    """
+    llm = LLM(
+        model=MODEL,
+        kv_sharing_fast_prefill=True,
+        enforce_eager=True,
+        dtype=DTYPE,
+        max_model_len=128,
+        gpu_memory_utilization=0.5,
+    )
+    with pytest.raises(ValueError, match="kv-sharing-fast-prefill"):
+        llm.generate(
+            "Hello, my name is",
+            SamplingParams(prompt_logprobs=0, max_tokens=5),
+        )

--- a/vllm/entrypoints/openai/chat_completion/protocol.py
+++ b/vllm/entrypoints/openai/chat_completion/protocol.py
@@ -824,19 +824,16 @@ class ChatCompletionRequest(OpenAIBaseModel):
                     parameter=field_name,
                     value=field_value,
                 )
-        if (prompt_logprobs := data.get("prompt_logprobs")) is not None:
-            if data.get("stream"):
-                raise VLLMValidationError(
-                    "`prompt_logprobs` are not available when `stream=True`.",
-                    parameter="prompt_logprobs",
-                )
-
-            if prompt_logprobs < 0 and prompt_logprobs != -1:
-                raise VLLMValidationError(
-                    "`prompt_logprobs` must be a positive value or -1.",
-                    parameter="prompt_logprobs",
-                    value=prompt_logprobs,
-                )
+        if (
+            (prompt_logprobs := data.get("prompt_logprobs")) is not None
+            and prompt_logprobs < 0
+            and prompt_logprobs != -1
+        ):
+            raise VLLMValidationError(
+                "`prompt_logprobs` must be a positive value or -1.",
+                parameter="prompt_logprobs",
+                value=prompt_logprobs,
+            )
         if (top_logprobs := data.get("top_logprobs")) is not None:
             if top_logprobs < 0 and top_logprobs != -1:
                 raise VLLMValidationError(
@@ -852,6 +849,23 @@ class ChatCompletionRequest(OpenAIBaseModel):
                 )
 
         return data
+
+    @model_validator(mode="after")
+    def _check_prompt_logprobs_stream(self) -> "ChatCompletionRequest":
+        """Reject `prompt_logprobs` under `stream=True`.
+
+        Runs "after" typed validation (not alongside the raw-dict checks in
+        check_logprobs) so `self.stream` is a real coerced bool. A raw,
+        not-yet-coerced value like `stream="false"` is truthy in a "before"
+        validator even though it resolves to False, which would wrongly
+        reject a valid `prompt_logprobs=0` request.
+        """
+        if self.prompt_logprobs is not None and self.stream:
+            raise VLLMValidationError(
+                "`prompt_logprobs` are not available when `stream=True`.",
+                parameter="prompt_logprobs",
+            )
+        return self
 
     @model_validator(mode="before")
     @classmethod

--- a/vllm/entrypoints/openai/chat_completion/protocol.py
+++ b/vllm/entrypoints/openai/chat_completion/protocol.py
@@ -699,7 +699,7 @@ class ChatCompletionRequest(OpenAIBaseModel):
                 )
 
         prompt_logprobs = self.prompt_logprobs
-        if prompt_logprobs is None and self.echo:
+        if prompt_logprobs is None and self.echo and self.logprobs:
             prompt_logprobs = self.top_logprobs
 
         extra_args: dict[str, Any] = self.vllm_xargs if self.vllm_xargs else {}
@@ -825,7 +825,7 @@ class ChatCompletionRequest(OpenAIBaseModel):
                     value=field_value,
                 )
         if (prompt_logprobs := data.get("prompt_logprobs")) is not None:
-            if data.get("stream") and (prompt_logprobs > 0 or prompt_logprobs == -1):
+            if data.get("stream"):
                 raise VLLMValidationError(
                     "`prompt_logprobs` are not available when `stream=True`.",
                     parameter="prompt_logprobs",

--- a/vllm/entrypoints/openai/completion/protocol.py
+++ b/vllm/entrypoints/openai/completion/protocol.py
@@ -513,19 +513,16 @@ class CompletionRequest(OpenAIBaseModel):
                     parameter=field_name,
                     value=field_value,
                 )
-        if (prompt_logprobs := data.get("prompt_logprobs")) is not None:
-            if data.get("stream"):
-                raise VLLMValidationError(
-                    "`prompt_logprobs` are not available when `stream=True`.",
-                    parameter="prompt_logprobs",
-                )
-
-            if prompt_logprobs < 0 and prompt_logprobs != -1:
-                raise VLLMValidationError(
-                    "`prompt_logprobs` must be a positive value or -1.",
-                    parameter="prompt_logprobs",
-                    value=prompt_logprobs,
-                )
+        if (
+            (prompt_logprobs := data.get("prompt_logprobs")) is not None
+            and prompt_logprobs < 0
+            and prompt_logprobs != -1
+        ):
+            raise VLLMValidationError(
+                "`prompt_logprobs` must be a positive value or -1.",
+                parameter="prompt_logprobs",
+                value=prompt_logprobs,
+            )
         if (
             (logprobs := data.get("logprobs")) is not None
             and logprobs < 0
@@ -538,6 +535,23 @@ class CompletionRequest(OpenAIBaseModel):
             )
 
         return data
+
+    @model_validator(mode="after")
+    def _check_prompt_logprobs_stream(self) -> "CompletionRequest":
+        """Reject `prompt_logprobs` under `stream=True`.
+
+        Runs "after" typed validation (not alongside the raw-dict checks in
+        check_logprobs) so `self.stream` is a real coerced bool. A raw,
+        not-yet-coerced value like `stream="false"` is truthy in a "before"
+        validator even though it resolves to False, which would wrongly
+        reject a valid `prompt_logprobs=0` request.
+        """
+        if self.prompt_logprobs is not None and self.stream:
+            raise VLLMValidationError(
+                "`prompt_logprobs` are not available when `stream=True`.",
+                parameter="prompt_logprobs",
+            )
+        return self
 
     @model_validator(mode="before")
     @classmethod

--- a/vllm/entrypoints/openai/completion/protocol.py
+++ b/vllm/entrypoints/openai/completion/protocol.py
@@ -514,7 +514,7 @@ class CompletionRequest(OpenAIBaseModel):
                     value=field_value,
                 )
         if (prompt_logprobs := data.get("prompt_logprobs")) is not None:
-            if data.get("stream") and (prompt_logprobs > 0 or prompt_logprobs == -1):
+            if data.get("stream"):
                 raise VLLMValidationError(
                     "`prompt_logprobs` are not available when `stream=True`.",
                     parameter="prompt_logprobs",

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -372,7 +372,7 @@ class AsyncLLM(EngineClient):
         if (
             self.vllm_config.cache_config.kv_sharing_fast_prefill
             and not is_pooling
-            and params.prompt_logprobs
+            and params.prompt_logprobs is not None
         ):
             raise VLLMValidationError(
                 "--kv-sharing-fast-prefill produces incorrect logprobs for "

--- a/vllm/v1/engine/llm_engine.py
+++ b/vllm/v1/engine/llm_engine.py
@@ -15,6 +15,7 @@ from vllm.config import ParallelConfig, VllmConfig
 from vllm.distributed import stateless_destroy_torch_distributed_process_group
 from vllm.distributed.parallel_state import get_dp_group
 from vllm.engine.arg_utils import EngineArgs
+from vllm.exceptions import VLLMValidationError
 from vllm.inputs import EngineInput, PromptType
 from vllm.logger import init_logger
 from vllm.lora.request import LoRARequest
@@ -274,6 +275,19 @@ class LLMEngine:
 
         # Use cloned params that may have been updated in process_inputs()
         params = request.params
+
+        # Validate incompatible feature combinations at request-admission time
+        # so the user gets a clear error before any GPU work begins.
+        if (
+            self.vllm_config.cache_config.kv_sharing_fast_prefill
+            and isinstance(params, SamplingParams)
+            and params.prompt_logprobs is not None
+        ):
+            raise VLLMValidationError(
+                "--kv-sharing-fast-prefill produces incorrect logprobs for "
+                "prompt tokens, please disable it when the requests need "
+                "prompt logprobs"
+            )
 
         n = params.n if isinstance(params, SamplingParams) else 1
 

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -4338,9 +4338,9 @@ class GPUModelRunner(
 
             if self.cache_config.kv_sharing_fast_prefill:
                 assert not self.num_prompt_logprobs, (
-                    "--kv-sharing-fast-prefill produces incorrect "
-                    "logprobs for prompt tokens, tokens, please disable "
-                    "it when the requests need prompt logprobs"
+                    "--kv-sharing-fast-prefill produces incorrect logprobs for "
+                    "prompt tokens, please disable it when the requests need "
+                    "prompt logprobs"
                 )
 
             num_reqs = self.input_batch.num_reqs


### PR DESCRIPTION
## Summary

`prompt_logprobs=0` is a valid, meaningful `SamplingParams` value ("return
the prompt token's own logprob, no alternatives"), but several checks along
the request path test it with plain truthiness instead of `is not None`, so
a value of `0` silently slips through:

- `ChatCompletionRequest.to_sampling_params` inherits `top_logprobs` (which
  defaults to `0`, not `None`) for *any* `echo=True` chat request, even when
  the client never asked for logprobs at all. Every echo request therefore
  does unrequested prompt-logprobs work (extra `compute_logits` pass,
  `gather_logprobs`, forced device sync per prefill step, and an unrequested
  `prompt_logprobs` array in the response). `cast_bool(null)`-style truthy
  checks miss `0` the same way `bool(0)` does anywhere else in Python.
- `AsyncLLM.add_request` and `check_logprobs` (both chat and completion
  protocol) use truthy checks, so `prompt_logprobs=0` bypasses the
  `--kv-sharing-fast-prefill` incompatibility guard and the documented
  `stream=True` rejection — while `GPUModelRunner` downstream checks
  `is not None` and hits a bare `assert`, which aborts the whole
  `execute_model` step and kills the engine-core process for **every**
  in-flight and future client, not just the offending request.
- `LLMEngine.add_request` (the sync path used by `LLM.generate()`) had no
  such guard at all, for any value — so the same crash is reachable there
  too, for any `prompt_logprobs`, not just `0`.

## Fix

- Only inherit `top_logprobs` for chat `echo` when `logprobs` was actually
  requested (`ChatCompletionRequest.logprobs`), mirroring
  `CompletionRequest`'s existing, already-correct idiom (its source field,
  `logprobs`, defaults to `None`, so its analogous branch is a no-op unless
  the client explicitly set it).
- Use `is not None` consistently for the `--kv-sharing-fast-prefill`
  admission guard in both `AsyncLLM.add_request` (async path) and
  `LLMEngine.add_request` (sync path, guard added — there was none).
- `check_logprobs` now rejects any non-`None` `prompt_logprobs` under
  `stream=True`, in both the chat and completion protocols, instead of only
  `> 0` / `== -1`.
- Fixed a stray "tokens, tokens," typo in the `GPUModelRunner` backstop
  assert message, touched while already on that exact line.

Diff is intentionally scoped to these checks — no changes to the grammar,
scheduler, or any GPU/kernel code.

## Not a duplicate of #49622

#49622 (open) adds the sync-path admission check to `LLMEngine.add_request`
and fixes the assert typo, but keeps the **truthy** check
(`params.prompt_logprobs`), so it does not close the `prompt_logprobs=0`
gap, and it doesn't touch the chat `echo` implicit-enablement bug or the
`stream=True` rejection gap. This PR's `LLMEngine.add_request` change and
typo fix overlap with #49622 at the file level; if #49622 merges first this
one becomes a small `is not None` correction on top of it (and drops the
typo hunk), rather than a conflicting approach — happy to rebase either way.

## Test Plan

Unit tests added:
- `tests/entrypoints/openai/chat_completion/test_chat.py` —
  `test_chat_completion_request_echo_without_logprobs_does_not_set_prompt_logprobs`,
  `test_chat_completion_request_echo_with_logprobs_inherits_top_logprobs`,
  `test_chat_completion_request_explicit_prompt_logprobs_zero_is_preserved`,
  `test_chat_completion_request_rejects_prompt_logprobs_zero_with_stream`
- `tests/entrypoints/openai/completion/test_completion.py` —
  `test_completion_request_rejects_prompt_logprobs_zero_with_stream`
- `tests/v1/engine/test_async_llm.py` —
  `test_kv_sharing_fast_prefill_rejects_prompt_logprobs_zero`
- `tests/v1/engine/test_llm_engine.py` —
  `test_kv_sharing_fast_prefill_rejects_prompt_logprobs_zero`

Commands run (Linux, real install, not a container/CI runner):

```bash
VLLM_USE_PRECOMPILED=1 uv pip install -e . --torch-backend=cpu
python -m pytest tests/entrypoints/openai/chat_completion/test_chat.py::test_chat_completion_request_echo_without_logprobs_does_not_set_prompt_logprobs \
  tests/entrypoints/openai/chat_completion/test_chat.py::test_chat_completion_request_echo_with_logprobs_inherits_top_logprobs \
  tests/entrypoints/openai/chat_completion/test_chat.py::test_chat_completion_request_explicit_prompt_logprobs_zero_is_preserved \
  tests/entrypoints/openai/chat_completion/test_chat.py::test_chat_completion_request_rejects_prompt_logprobs_zero_with_stream \
  tests/entrypoints/openai/completion/test_completion.py::test_completion_request_rejects_prompt_logprobs_zero_with_stream \
  -v
# 5 passed

# Red/green check: reverted only the 5 source files to their pre-fix state
# (git checkout HEAD~1 -- <files>) and reran the same 3 assertion-bearing
# tests -> all 3 FAILED (assert 0 is None / DID NOT RAISE VLLMValidationError),
# confirming they genuinely exercise the bug. Restored the fix -> green again.

ruff check <changed files>       # All checks passed!
ruff format --check <changed files>   # 9 files already formatted
```

`test_kv_sharing_fast_prefill_rejects_prompt_logprobs_zero` (both the async
and sync variants) require booting a real `LLM`/`AsyncLLM` instance. In my
local sandbox this hits `AttributeError: '_OpNamespace' '_C' object has no
attribute 'init_cpu_memory_env'` on **any** engine boot, including a
completely vanilla one with no `kv_sharing_fast_prefill` involved — a
precompiled-wheel/HEAD-source drift specific to my environment, not caused
by this change. They should run normally in CI, where the build matches the
commit under test.

## Model evaluation

Not applicable — this is a request-validation/control-flow fix. It does not
change model forward passes, sampling, or output tokens for any request that
was already passing validation correctly.

## AI assistance disclosure

This change was developed with AI assistance (Claude). I reviewed every
changed line, ran the tests and lint listed above myself, and can defend the
fix and its scope in review.