### PR TITLE
[Bugfix][CPU] Take an attention group's query head count from its layers

### DIFF
--- a/.buildkite/hardware_tests/cpu.yaml
+++ b/.buildkite/hardware_tests/cpu.yaml
@@ -11,6 +11,7 @@ steps:
   - CMakeLists.txt
   - vllm/_custom_ops.py
   - tests/kernels/attention/test_cpu_attn.py
+  - tests/v1/attention/test_group_head_counts.py
   - tests/kernels/moe/test_cpu_fused_moe.py
   - tests/kernels/moe/test_cpu_quant_fused_moe.py
   - tests/kernels/test_onednn.py
@@ -27,6 +28,7 @@ steps:
     - |
       bash .buildkite/scripts/hardware_ci/run-cpu-test.sh 30m "
       pytest -x -v -s tests/kernels/attention/test_cpu_attn.py
+      pytest -x -v -s tests/v1/attention/test_group_head_counts.py
       pytest -x -v -s tests/kernels/moe/test_cpu_fused_moe.py
       pytest -x -v -s tests/kernels/moe/test_cpu_quant_fused_moe.py
       pytest -x -v -s tests/kernels/mamba/test_cpu_short_conv.py

--- a/tests/v1/attention/test_group_head_counts.py
+++ b/tests/v1/attention/test_group_head_counts.py
@@ -1,17 +1,16 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""A KV cache group may hold layers with different query head counts — e.g.
-Laguna, which overrides the head count per layer. Scheduler metadata describes
-an attention scratchpad whose layout depends on that count, so layers differing
-from the model-wide default need metadata of their own. Sharing one blob makes
-the wider layers index past the end of the split-KV reduction scratchpad,
-corrupting memory.
+"""Scheduler metadata sizes a scratchpad from the query head count, so it must
+come from the builder's own group: the model-wide ``get_num_attention_heads()``
+is wrong for models that vary it per layer (e.g. Laguna), and too small a
+scratchpad is indexed past its end.
 """
 
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
+import torch
 
 from vllm.platforms import current_platform
 from vllm.v1.attention.backends.cpu_attn import (
@@ -23,38 +22,61 @@ pytestmark = pytest.mark.skipif(
     not current_platform.is_cpu(), reason="CPU attention backend"
 )
 
+# Laguna's shape: 48 query heads model-wide, 64 on its sliding layers, both
+# against 8 KV heads.
+MODEL_WIDE_NUM_HEADS = 48
+NUM_KV_HEADS = 8
+
 
 def _layers(layer_num_heads: list[int]):
-    """Stand-in attention layers, one per head count, as one KV cache group."""
+    """Stand-in attention layers, one per head count, as one attention group."""
     return {
         f"layer_{i}": SimpleNamespace(
-            impl=MagicMock(spec=CPUAttentionBackendImpl, num_heads=num_heads)
+            impl=MagicMock(
+                spec=CPUAttentionBackendImpl,
+                num_heads=num_heads,
+                sliding_window=None,
+            )
         )
         for i, num_heads in enumerate(layer_num_heads)
     }
 
 
-@pytest.mark.parametrize(
-    "layer_num_heads,default_num_heads,expected",
-    [
-        # Uniform: every layer matches the default, so no extra metadata.
-        ([8, 8], 8, set()),
-        # Laguna-style: the wider layers each need their own metadata.
-        ([8, 16, 8, 16], 8, {16}),
-        # The default need not be the most common count.
-        ([16, 32], 8, {16, 32}),
-    ],
-)
-def test_cpu_group_extra_num_heads(layer_num_heads, default_num_heads, expected):
+def _build(layer_num_heads: list[int]) -> CPUAttentionMetadataBuilder:
     layers = _layers(layer_num_heads)
-    builder = SimpleNamespace(
-        vllm_config=None,
-        layer_names=list(layers),
-        num_heads=default_num_heads,
-    )
-    with patch(
-        "vllm.v1.attention.backends.cpu_attn.get_layers_from_vllm_config",
-        return_value=layers,
+    vllm_config = MagicMock()
+    vllm_config.model_config.dtype = torch.bfloat16
+    vllm_config.model_config.get_num_attention_heads.return_value = MODEL_WIDE_NUM_HEADS
+    vllm_config.cache_config.block_size = 16
+    vllm_config.cache_config.cache_dtype = "auto"
+    kv_cache_spec = SimpleNamespace(num_kv_heads=NUM_KV_HEADS, head_size=64)
+
+    with (
+        patch(
+            "vllm.v1.attention.backends.utils.get_layers_from_vllm_config",
+            return_value=layers,
+        ),
+        patch(
+            "vllm.v1.attention.backends.cpu_attn.get_layers_from_vllm_config",
+            return_value=layers,
+        ),
     ):
-        extra = CPUAttentionMetadataBuilder._group_extra_num_heads(builder)
-    assert extra == expected
+        return CPUAttentionMetadataBuilder(
+            kv_cache_spec=kv_cache_spec,
+            layer_names=list(layers),
+            vllm_config=vllm_config,
+            device=torch.device("cpu"),
+        )
+
+
+@pytest.mark.parametrize("group_num_heads", [MODEL_WIDE_NUM_HEADS, 64, 16])
+def test_num_heads_comes_from_the_group(group_num_heads):
+    """The group's own count wins, even when it is not the model-wide one."""
+    builder = _build([group_num_heads, group_num_heads])
+    assert builder.num_heads == group_num_heads
+
+
+def test_mixed_head_counts_in_one_group_are_rejected():
+    """Grouping guarantees uniformity; a mixed group means that broke."""
+    with pytest.raises(AssertionError, match="share num_heads"):
+        _build([MODEL_WIDE_NUM_HEADS, 64])

--- a/tests/v1/attention/test_group_head_counts.py
+++ b/tests/v1/attention/test_group_head_counts.py
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""A KV cache group may hold layers with different query head counts — e.g.
+Laguna, which overrides the head count per layer. Scheduler metadata describes
+an attention scratchpad whose layout depends on that count, so layers differing
+from the model-wide default need metadata of their own. Sharing one blob makes
+the wider layers index past the end of the split-KV reduction scratchpad,
+corrupting memory.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from vllm.v1.attention.backends.cpu_attn import (
+    CPUAttentionBackendImpl,
+    CPUAttentionMetadataBuilder,
+)
+
+
+def _layers(layer_num_heads: list[int]):
+    """Stand-in attention layers, one per head count, as one KV cache group."""
+    return {
+        f"layer_{i}": SimpleNamespace(
+            impl=MagicMock(spec=CPUAttentionBackendImpl, num_heads=num_heads)
+        )
+        for i, num_heads in enumerate(layer_num_heads)
+    }
+
+
+@pytest.mark.parametrize(
+    "layer_num_heads,default_num_heads,expected",
+    [
+        # Uniform: every layer matches the default, so no extra metadata.
+        ([8, 8], 8, set()),
+        # Laguna-style: the wider layers each need their own metadata.
+        ([8, 16, 8, 16], 8, {16}),
+        # The default need not be the most common count.
+        ([16, 32], 8, {16, 32}),
+    ],
+)
+def test_cpu_group_extra_num_heads(layer_num_heads, default_num_heads, expected):
+    layers = _layers(layer_num_heads)
+    builder = SimpleNamespace(
+        vllm_config=None,
+        layer_names=list(layers),
+        num_heads=default_num_heads,
+    )
+    with patch(
+        "vllm.v1.attention.backends.cpu_attn.get_layers_from_vllm_config",
+        return_value=layers,
+    ):
+        extra = CPUAttentionMetadataBuilder._group_extra_num_heads(builder)
+    assert extra == expected

--- a/tests/v1/attention/test_group_head_counts.py
+++ b/tests/v1/attention/test_group_head_counts.py
@@ -13,9 +13,14 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from vllm.platforms import current_platform
 from vllm.v1.attention.backends.cpu_attn import (
     CPUAttentionBackendImpl,
     CPUAttentionMetadataBuilder,
+)
+
+pytestmark = pytest.mark.skipif(
+    not current_platform.is_cpu(), reason="CPU attention backend"
 )
 
 

--- a/vllm/v1/attention/backends/cpu_attn.py
+++ b/vllm/v1/attention/backends/cpu_attn.py
@@ -159,9 +159,8 @@ class CPUAttentionMetadataBuilder(AttentionMetadataBuilder[CPUAttentionMetadata]
         )
         self.head_dim = kv_cache_spec.head_size
         self.dtype = vllm_config.model_config.dtype
-        # Resolved from the layers on the first build(), once they exist.
-        self.window_size: int | None = None
-        self.extra_num_heads: set[int] | None = None
+        self.window_size = self._group_sliding_window()
+        self.extra_num_heads = self._group_extra_num_heads()
         self.block_size = vllm_config.cache_config.block_size
         self.kv_cache_dtype = vllm_config.cache_config.cache_dtype
         self.isa = _get_attn_isa(
@@ -222,11 +221,6 @@ class CPUAttentionMetadataBuilder(AttentionMetadataBuilder[CPUAttentionMetadata]
         common_attn_metadata: CommonAttentionMetadata,
         fast_build: bool = False,
     ) -> CPUAttentionMetadata:
-        if self.window_size is None:
-            self.window_size = self._group_sliding_window()
-        if self.extra_num_heads is None:
-            self.extra_num_heads = self._group_extra_num_heads()
-
         num_reqs = common_attn_metadata.num_reqs
         num_actual_tokens = common_attn_metadata.num_actual_tokens
         max_query_len = common_attn_metadata.max_query_len

--- a/vllm/v1/attention/backends/cpu_attn.py
+++ b/vllm/v1/attention/backends/cpu_attn.py
@@ -31,6 +31,7 @@ from vllm.v1.attention.backend import (
 )
 from vllm.v1.attention.backends.utils import (
     KVCacheLayoutType,
+    get_num_attention_heads_from_layers,
 )
 from vllm.v1.kv_cache_interface import (
     AttentionSpec,
@@ -126,9 +127,6 @@ class CPUAttentionMetadata:
     scheduler_metadata: torch.Tensor | None
     causal: bool = True
     dynamic_causal: torch.Tensor | None = None
-    # Set only when the group's layers do not all share one query head count,
-    # in which case each layer takes the metadata matching its own count.
-    scheduler_metadata_by_num_heads: dict[int, torch.Tensor] | None = None
 
     # can be removed after deprecate sdpa
     use_sdpa_prefill: bool = False
@@ -154,13 +152,15 @@ class CPUAttentionMetadataBuilder(AttentionMetadataBuilder[CPUAttentionMetadata]
 
         parallel_config = vllm_config.parallel_config
         self.num_kv_heads = kv_cache_spec.num_kv_heads
-        self.num_heads = vllm_config.model_config.get_num_attention_heads(
-            parallel_config
-        )
+        # The scheduler metadata built here sizes a scratchpad from the query
+        # head count, so it must come from this group's layers: the model-wide
+        # count is wrong for models that vary it per layer (e.g. Laguna).
+        self.num_heads = get_num_attention_heads_from_layers(
+            vllm_config, layer_names
+        ) or vllm_config.model_config.get_num_attention_heads(parallel_config)
         self.head_dim = kv_cache_spec.head_size
         self.dtype = vllm_config.model_config.dtype
         self.window_size = self._group_sliding_window()
-        self.extra_num_heads = self._group_extra_num_heads()
         self.block_size = vllm_config.cache_config.block_size
         self.kv_cache_dtype = vllm_config.cache_config.cache_dtype
         self.isa = _get_attn_isa(
@@ -194,26 +194,6 @@ class CPUAttentionMetadataBuilder(AttentionMetadataBuilder[CPUAttentionMetadata]
             return -1
         window = windows.pop()
         return -1 if window is None else window
-
-    def _group_extra_num_heads(self) -> set[int]:
-        """Query head counts in this group that differ from ``self.num_heads``.
-
-        Scheduler metadata describes an attention scratchpad whose layout
-        depends on the number of query heads, and it is built once for the
-        whole group. Some models (e.g. Laguna) give individual layers their own
-        head count, which the model-wide default used here does not reflect, so
-        those layers need metadata of their own. Sharing one blob would let the
-        wider layers index past the end of the split-KV reduction scratchpad.
-        """
-        layers = get_layers_from_vllm_config(
-            self.vllm_config, Attention, self.layer_names
-        )
-        return {
-            layer.impl.num_heads
-            for layer in layers.values()
-            if isinstance(layer.impl, CPUAttentionBackendImpl)
-            and layer.impl.num_heads != self.num_heads
-        }
 
     def build(
         self,
@@ -269,31 +249,21 @@ class CPUAttentionMetadataBuilder(AttentionMetadataBuilder[CPUAttentionMetadata]
             )
             block_table_tensor = encoder_block_table
 
-        def build_scheduler_metadata(num_heads: int) -> torch.Tensor:
-            return ops.cpu_attn_get_scheduler_metadata(
-                num_reqs=num_reqs,
-                num_heads=num_heads,
-                num_kv_heads=self.num_kv_heads,
-                head_dim=self.head_dim,
-                seq_lens=seq_lens,
-                dtype=self.dtype,
-                query_start_loc=query_start_loc,
-                causal=causal,
-                sliding_window_size=self.window_size,
-                isa=self.isa,
-                enable_kv_split=envs.VLLM_CPU_ATTN_SPLIT_KV,
-                dynamic_causal=dynamic_casual,
-                kv_cache_dtype=self.kv_cache_dtype,
-            )
-
-        scheduler_metadata = build_scheduler_metadata(self.num_heads)
-        scheduler_metadata_by_num_heads = None
-        if self.extra_num_heads:
-            scheduler_metadata_by_num_heads = {self.num_heads: scheduler_metadata}
-            for num_heads in self.extra_num_heads:
-                scheduler_metadata_by_num_heads[num_heads] = build_scheduler_metadata(
-                    num_heads
-                )
+        scheduler_metadata = ops.cpu_attn_get_scheduler_metadata(
+            num_reqs=num_reqs,
+            num_heads=self.num_heads,
+            num_kv_heads=self.num_kv_heads,
+            head_dim=self.head_dim,
+            seq_lens=seq_lens,
+            dtype=self.dtype,
+            query_start_loc=query_start_loc,
+            causal=causal,
+            sliding_window_size=self.window_size,
+            isa=self.isa,
+            enable_kv_split=envs.VLLM_CPU_ATTN_SPLIT_KV,
+            dynamic_causal=dynamic_casual,
+            kv_cache_dtype=self.kv_cache_dtype,
+        )
 
         attn_metadata = CPUAttentionMetadata(
             num_actual_tokens=num_actual_tokens,
@@ -307,7 +277,6 @@ class CPUAttentionMetadataBuilder(AttentionMetadataBuilder[CPUAttentionMetadata]
             causal=causal,
             encoder_cache=encoder_cache_tensor,
             dynamic_causal=dynamic_casual,
-            scheduler_metadata_by_num_heads=scheduler_metadata_by_num_heads,
         )
 
         return attn_metadata
@@ -437,12 +406,6 @@ class CPUAttentionBackendImpl(AttentionImpl):
                 kv_cache_dtype=self.kv_cache_dtype,
             )
 
-        scheduler_metadata = attn_metadata.scheduler_metadata
-        if attn_metadata.scheduler_metadata_by_num_heads is not None:
-            scheduler_metadata = attn_metadata.scheduler_metadata_by_num_heads[
-                self.num_heads
-            ]
-
         ops.cpu_attention_with_kv_cache(
             query=query[:num_actual_tokens],
             key_cache=key_cache,
@@ -456,7 +419,7 @@ class CPUAttentionBackendImpl(AttentionImpl):
             sliding_window=self.sliding_window,
             block_table=attn_metadata.block_table,
             softcap=self.logits_soft_cap,
-            scheduler_metadata=scheduler_metadata,
+            scheduler_metadata=attn_metadata.scheduler_metadata,
             s_aux=self.sinks,
             dynamic_causal=attn_metadata.dynamic_causal,
             k_scale=layer._k_scale_float,

--- a/vllm/v1/attention/backends/cpu_attn.py
+++ b/vllm/v1/attention/backends/cpu_attn.py
@@ -126,6 +126,9 @@ class CPUAttentionMetadata:
     scheduler_metadata: torch.Tensor | None
     causal: bool = True
     dynamic_causal: torch.Tensor | None = None
+    # Set only when the group's layers do not all share one query head count,
+    # in which case each layer takes the metadata matching its own count.
+    scheduler_metadata_by_num_heads: dict[int, torch.Tensor] | None = None
 
     # can be removed after deprecate sdpa
     use_sdpa_prefill: bool = False
@@ -158,6 +161,7 @@ class CPUAttentionMetadataBuilder(AttentionMetadataBuilder[CPUAttentionMetadata]
         self.dtype = vllm_config.model_config.dtype
         # Resolved from the layers on the first build(), once they exist.
         self.window_size: int | None = None
+        self.extra_num_heads: set[int] | None = None
         self.block_size = vllm_config.cache_config.block_size
         self.kv_cache_dtype = vllm_config.cache_config.cache_dtype
         self.isa = _get_attn_isa(
@@ -192,6 +196,26 @@ class CPUAttentionMetadataBuilder(AttentionMetadataBuilder[CPUAttentionMetadata]
         window = windows.pop()
         return -1 if window is None else window
 
+    def _group_extra_num_heads(self) -> set[int]:
+        """Query head counts in this group that differ from ``self.num_heads``.
+
+        Scheduler metadata describes an attention scratchpad whose layout
+        depends on the number of query heads, and it is built once for the
+        whole group. Some models (e.g. Laguna) give individual layers their own
+        head count, which the model-wide default used here does not reflect, so
+        those layers need metadata of their own. Sharing one blob would let the
+        wider layers index past the end of the split-KV reduction scratchpad.
+        """
+        layers = get_layers_from_vllm_config(
+            self.vllm_config, Attention, self.layer_names
+        )
+        return {
+            layer.impl.num_heads
+            for layer in layers.values()
+            if isinstance(layer.impl, CPUAttentionBackendImpl)
+            and layer.impl.num_heads != self.num_heads
+        }
+
     def build(
         self,
         common_prefix_len: int,
@@ -200,6 +224,8 @@ class CPUAttentionMetadataBuilder(AttentionMetadataBuilder[CPUAttentionMetadata]
     ) -> CPUAttentionMetadata:
         if self.window_size is None:
             self.window_size = self._group_sliding_window()
+        if self.extra_num_heads is None:
+            self.extra_num_heads = self._group_extra_num_heads()
 
         num_reqs = common_attn_metadata.num_reqs
         num_actual_tokens = common_attn_metadata.num_actual_tokens
@@ -249,21 +275,31 @@ class CPUAttentionMetadataBuilder(AttentionMetadataBuilder[CPUAttentionMetadata]
             )
             block_table_tensor = encoder_block_table
 
-        scheduler_metadata = ops.cpu_attn_get_scheduler_metadata(
-            num_reqs=num_reqs,
-            num_heads=self.num_heads,
-            num_kv_heads=self.num_kv_heads,
-            head_dim=self.head_dim,
-            seq_lens=seq_lens,
-            dtype=self.dtype,
-            query_start_loc=query_start_loc,
-            causal=causal,
-            sliding_window_size=self.window_size,
-            isa=self.isa,
-            enable_kv_split=envs.VLLM_CPU_ATTN_SPLIT_KV,
-            dynamic_causal=dynamic_casual,
-            kv_cache_dtype=self.kv_cache_dtype,
-        )
+        def build_scheduler_metadata(num_heads: int) -> torch.Tensor:
+            return ops.cpu_attn_get_scheduler_metadata(
+                num_reqs=num_reqs,
+                num_heads=num_heads,
+                num_kv_heads=self.num_kv_heads,
+                head_dim=self.head_dim,
+                seq_lens=seq_lens,
+                dtype=self.dtype,
+                query_start_loc=query_start_loc,
+                causal=causal,
+                sliding_window_size=self.window_size,
+                isa=self.isa,
+                enable_kv_split=envs.VLLM_CPU_ATTN_SPLIT_KV,
+                dynamic_causal=dynamic_casual,
+                kv_cache_dtype=self.kv_cache_dtype,
+            )
+
+        scheduler_metadata = build_scheduler_metadata(self.num_heads)
+        scheduler_metadata_by_num_heads = None
+        if self.extra_num_heads:
+            scheduler_metadata_by_num_heads = {self.num_heads: scheduler_metadata}
+            for num_heads in self.extra_num_heads:
+                scheduler_metadata_by_num_heads[num_heads] = build_scheduler_metadata(
+                    num_heads
+                )
 
         attn_metadata = CPUAttentionMetadata(
             num_actual_tokens=num_actual_tokens,
@@ -277,6 +313,7 @@ class CPUAttentionMetadataBuilder(AttentionMetadataBuilder[CPUAttentionMetadata]
             causal=causal,
             encoder_cache=encoder_cache_tensor,
             dynamic_causal=dynamic_casual,
+            scheduler_metadata_by_num_heads=scheduler_metadata_by_num_heads,
         )
 
         return attn_metadata
@@ -406,6 +443,12 @@ class CPUAttentionBackendImpl(AttentionImpl):
                 kv_cache_dtype=self.kv_cache_dtype,
             )
 
+        scheduler_metadata = attn_metadata.scheduler_metadata
+        if attn_metadata.scheduler_metadata_by_num_heads is not None:
+            scheduler_metadata = attn_metadata.scheduler_metadata_by_num_heads[
+                self.num_heads
+            ]
+
         ops.cpu_attention_with_kv_cache(
             query=query[:num_actual_tokens],
             key_cache=key_cache,
@@ -419,7 +462,7 @@ class CPUAttentionBackendImpl(AttentionImpl):
             sliding_window=self.sliding_window,
             block_table=attn_metadata.block_table,
             softcap=self.logits_soft_cap,
-            scheduler_metadata=attn_metadata.scheduler_metadata,
+            scheduler_metadata=scheduler_metadata,
             s_aux=self.sinks,
             dynamic_causal=attn_metadata.dynamic_causal,
             k_scale=layer._k_scale_float,


### PR DESCRIPTION

## Purpose
`CPUAttentionMetadataBuilder` sizes the split-KV scratchpad from the model-wide query head count, but the kernel runs with each layer's own count. so models that vary it per layer (e.g. Laguna) index past the end of the scratchpad and
the decode segfaults or hangs. Attention groups are keyed on `num_heads_q`, so take the count from the group's layers via `get_num_attention_heads_from_layers()`, as `triton_attn` and `flashinfer` already do. Models with a uniform count are unaffected.


Change-Id: I671eadc2b5601f1a3af12f39391657a11df1c9f7



## Test Plan

- `pytest tests/v1/attention/test_group_head_counts.py` — new unit test, mirroring `test_group_sliding_window.py`: uniform heads, Laguna-style alternating heads, and a default that is not the most common count.
- A tiny Laguna config with per-layer heads `[8, 16, 8, 16]` against 2 KV heads and random weights (`load_format=dummy`, so no checkpoint is needed), decoding 512 tokens so split-KV reduction engages. Run both on unpatched `main` and with this change.
- Laguna-XS-2.1-INT4 end to end on CPU with TP=2: a 300-token decode, plus GSM8K 5-shot over the full 1319 prompts via lm_eval.

<details>
<summary>Reproducer</summary>

```python
import json, os, tempfile
from vllm import LLM, SamplingParams

CONFIG = {
    "architectures": ["LagunaForCausalLM"], "model_type": "laguna",
    "hidden_size": 512, "intermediate_size": 1024, "num_hidden_layers": 4,
    "num_attention_heads": 8, "num_attention_heads_per_layer": [8, 16, 8, 16],
    "num_key_value_heads": 2, "head_dim": 64, "max_position_embeddings": 4096,
    "rms_norm_eps": 1e-6, "rope_theta": 500000.0, "tie_word_embeddings": False,
    "torch_dtype": "bfloat16", "mlp_only_layers": [0, 1, 2, 3],
    "num_experts": 4, "num_experts_per_tok": 2, "moe_intermediate_size": 128,
    "shared_expert_intermediate_size": 128,
}

model_dir = tempfile.mkdtemp()
with open(os.path.join(model_dir, "config.json"), "w") as f:
    json.dump(CONFIG, f)

llm = LLM(model=model_dir, tokenizer="<any tokenizer>", load_format="dummy",
          dtype="bfloat16", max_model_len=2048, enforce_eager=True)
out = llm.generate(["context " * 64],
                   SamplingParams(max_tokens=512, temperature=0.0, ignore_eos=True))
print("SURVIVED", len(out[0].outputs[0].token_ids))
```
</details>

## Test Result

- Unit tests: 6 passed (3 new, plus the 3 existing sliding-window cases).
- Reproducer: hangs on current `main` and is killed at the timeout; passes in 1.5s with this change.
- Laguna-XS 300-token decode: previously segfaulted or hung, now completes in 47s with coherent output.
- GSM8K 5-shot, full 1319 prompts. Before this change the same run died with an `execute_model` timeout.

  | Filter | exact_match | stderr |
  | --- | --- | --- |
  | flexible-extract | 0.9014 | ±0.0082 |
  | strict-match | 0.8908 | ±0.0086 |

Instrumenting the scratchpad bounds shows the overrun directly on unpatched `main`: the region holds 6336 bytes per KV head while the split-KV write path needs 8384, because sizing assumes 6 query heads per KV head (48 heads / 8 KV heads) and the 64-head layers address it with a stride of 8.

```
[SCRATCHPAD-SIZING]   split_num=2 max_tile=6 q_heads=24 kv_heads=4 q_per_kv=6 per_kv_head=6336
[SCRATCHPAD-OVERFLOW] per_head_need=8384 per_kv_head=6336 q_head_tile_size=8
```

Models whose layers share one head count keep the existing single-blob path, so there is no extra allocation or lookup for them.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

