### PR TITLE
[Frontend] Honour --host for the run-batch Prometheus metrics server

### DIFF
--- a/tests/entrypoints/launchers/test_run_batch.py
+++ b/tests/entrypoints/launchers/test_run_batch.py
@@ -1110,3 +1110,44 @@ async def test_upload_data_error_includes_awaited_response_body():
     message = str(exc_info.value)
     assert "server-error-detail" in message
     assert "coroutine" not in message
+
+
+@pytest.mark.parametrize(
+    ("argv", "expected_addr"),
+    [
+        (["--host", "127.0.0.1"], "127.0.0.1"),
+        (["--url", "127.0.0.2"], "127.0.0.2"),
+        (["--host", "127.0.0.1", "--url", "127.0.0.2"], "127.0.0.1"),
+        ([], "0.0.0.0"),
+    ],
+)
+def test_metrics_server_binds_to_the_requested_host(argv, expected_addr):
+    """`--url` is deprecated in favour of `--host`, so `run-batch` must honour
+    `--host` and fall back to `--url` only when `--host` was not given. Binding
+    somewhere the caller did not ask for is the failure that matters here: the
+    default is every interface."""
+    from vllm.entrypoints.cli.run_batch import RunBatchSubcommand
+    from vllm.entrypoints.launchers.run_batch import make_arg_parser
+    from vllm.utils.argparse_utils import FlexibleArgumentParser
+
+    parser = make_arg_parser(FlexibleArgumentParser())
+    args = parser.parse_args(
+        [
+            "-i",
+            "in.jsonl",
+            "-o",
+            "out.jsonl",
+            "--model",
+            CHAT_MODEL_NAME,
+            "--enable-metrics",
+            *argv,
+        ]
+    )
+
+    with (
+        patch("prometheus_client.start_http_server") as mock_server,
+        patch("vllm.entrypoints.launchers.run_batch.main", new=AsyncMock()),
+    ):
+        RunBatchSubcommand.cmd(args)
+
+    assert mock_server.call_args.kwargs["addr"] == expected_addr

--- a/vllm/entrypoints/cli/run_batch.py
+++ b/vllm/entrypoints/cli/run_batch.py
@@ -39,7 +39,9 @@ class RunBatchSubcommand(CLISubcommand):
             from prometheus_client import start_http_server
 
             logger.info("Prometheus metrics enabled")
-            start_http_server(port=args.port, addr=args.url)
+            # --url is deprecated in favour of --host, so prefer --host and fall
+            # back to it only when --host was not given.
+            start_http_server(port=args.port, addr=args.host or args.url)
         else:
             logger.info("Prometheus metrics disabled")
 


### PR DESCRIPTION
## Problem

`BatchFrontendArgs` declares `--host` for the Prometheus metrics server and marks `--url` deprecated in favour of it:

```python
host: str | None = None
"""Host name for the Prometheus metrics server (only needed if enable-metrics is set)."""
url: str = "0.0.0.0"
"""[DEPRECATED] Host name for the Prometheus metrics server ... Use --host instead."""
...
frontend_kwargs["url"]["deprecated"] = True
```

The CLI path binds with the deprecated one:

```python
# vllm/entrypoints/cli/run_batch.py:42
start_http_server(port=args.port, addr=args.url)
```

So `vllm run-batch --enable-metrics --host 127.0.0.1 -i in.jsonl -o out.jsonl` starts the metrics server on `0.0.0.0`, every interface, when the caller explicitly asked for loopback. Nothing warns.

The two entry points disagree on the same flags. `python -m vllm.entrypoints.openai.run_batch` uses `addr=args.host` at `run_batch.py:873`; only the `vllm run-batch` subcommand uses `args.url`.

```
invocation                            binds now    binds after
--host 127.0.0.1                      0.0.0.0      127.0.0.1
--url 127.0.0.2 (deprecated)          127.0.0.2    127.0.0.2
--host 127.0.0.1 --url 127.0.0.2      127.0.0.2    127.0.0.1
neither (defaults)                    0.0.0.0      0.0.0.0
```

`addr` is what `prometheus_client.start_http_server` passes to the socket bind, so this is the difference between a metrics endpoint reachable only from the box and one reachable from anywhere that can route to it.

## Fix

Prefer `--host`, falling back to the deprecated `--url` only when `--host` was not given. The default and the deprecated flag keep working exactly as before, so nothing that relies on either changes.

## Not a duplicate

Checked per AGENTS.md:

```
gh pr list --repo vllm-project/vllm --state open --search "run-batch metrics host"
gh pr list --repo vllm-project/vllm --state open --search "run_batch start_http_server"
gh api -X GET search/issues -f q="repo:vllm-project/vllm run-batch host metrics"
gh api "repos/vllm-project/vllm/commits?path=vllm/entrypoints/cli/run_batch.py&per_page=10"
```

The second returns nothing; the first and third return unrelated perf and ROCm work that the fuzzy search matched on the word "metrics". No open PR touches `vllm/entrypoints/cli/run_batch.py`, and the ten most recent commits to that file are CLI help, formatting and import-style changes, none of them on this line.

## Tests run and results

A parametrised unit test added to `tests/entrypoints/openai/test_run_batch.py`, covering all four invocations above. It parses real args through `make_arg_parser`, patches `prometheus_client.start_http_server` and `run_batch.main`, and asserts the `addr` that was passed, so it needs no model and no GPU.

Being straight about what I could and could not run: I do not have a machine that can import vLLM, so I could not execute the new test here, and CI is the check. What I did verify locally, and what the table above comes from, is the argument resolution itself, evaluated over the four invocations against both the old and the new expression, plus that `prometheus_client.start_http_server`'s `addr` really is the bind address (`127.0.0.1` binds loopback, `0.0.0.0` binds every interface, and `None` binds `::`). The two source lines and the deprecation marking were read from `main` at 1ab2801.

Related, and deliberately left alone: the module entry point passes `addr=args.host`, which is `None` unless `--host` is given, and `start_http_server(addr=None)` binds `::` rather than the `0.0.0.0` its signature defaults to. Both are all-interfaces, so it is not the same bug, but if you would like the two paths to agree exactly I am happy to align that in this PR.

## Model evaluation

Not applicable: this changes which address a Prometheus metrics HTTP server binds to. It does not touch generation, sampling, scheduling or any serving path, and produces no change to model output or accuracy.

## AI assistance

AI assistance was used for this change.
