### PR TITLE
[Perf] Skip the per-step q concat in TRITON_MLA decode by passing q_nope/q_pe through separate kernel pointers

### DIFF
--- a/tests/kernels/attention/test_triton_decode_attention.py
+++ b/tests/kernels/attention/test_triton_decode_attention.py
@@ -323,3 +323,78 @@ def test_decode_attention_cross_layer_view(H_Q, H_KV, D_QK, D_V, is_mla, PAGE_SI
     # Same data and same compute order; only addressing differs.
     assert torch.equal(o_ref, o_xl)
     assert torch.equal(lse_ref, lse_xl)
+
+
+@pytest.mark.parametrize("B", [3, 37])
+@pytest.mark.parametrize("L", [1027])
+@pytest.mark.parametrize("H_Q", [16, 128])
+@pytest.mark.parametrize("D_QK, D_V", [(576, 512), (288, 256)])
+@pytest.mark.parametrize("PAGE_SIZE", [16, 64])
+def test_decode_attention_mla_tuple_q(B, L, H_Q, D_QK, D_V, PAGE_SIZE):
+    """MLA decode accepts q as a (q_nope, q_pe) tuple and produces bitwise
+    identical results to the packed [*, nope | pe] layout, including when the
+    tuple components are non-contiguous views (the layouts the MLA decode
+    path actually produces: a transposed bmm output and a split of q)."""
+    torch.manual_seed(0)
+    CACHE_SIZE = 8192
+    dtype = torch.bfloat16
+    seq_len = L
+    sm_scale = 1.0 / (D_QK**0.5)
+    num_kv_splits = 8
+
+    num_pages_per_batch = cdiv(seq_len, PAGE_SIZE)
+    req_to_page = torch.randint(
+        0, CACHE_SIZE // PAGE_SIZE, (B, num_pages_per_batch), device=DEVICE_TYPE
+    )
+
+    q = torch.randn(B, H_Q, D_QK, dtype=dtype, device=DEVICE_TYPE)
+
+    kv_buffer = torch.randn(
+        CACHE_SIZE // PAGE_SIZE, PAGE_SIZE, 1, D_QK, dtype=dtype, device=DEVICE_TYPE
+    )
+    k_buffer = kv_buffer
+    v_buffer = kv_buffer[..., :D_V]
+
+    b_seq_len = torch.full((B,), seq_len, device=DEVICE_TYPE)
+
+    def run(q_arg):
+        o = torch.zeros(B, H_Q, D_V, dtype=dtype, device=DEVICE_TYPE)
+        lse = torch.zeros(B, H_Q, dtype=dtype, device=DEVICE_TYPE)
+        attn_logits = torch.empty(
+            (B, H_Q, num_kv_splits, D_V + 1), dtype=torch.float32, device=DEVICE_TYPE
+        )
+        decode_attention_fwd(
+            q_arg,
+            k_buffer,
+            v_buffer,
+            o,
+            lse,
+            req_to_page,
+            b_seq_len,
+            attn_logits,
+            num_kv_splits,
+            sm_scale,
+            PAGE_SIZE,
+            is_mla=True,
+        )
+        return o, lse
+
+    o_ref, lse_ref = run(q)
+
+    # Contiguous tuple components.
+    o_t, lse_t = run((q[..., :D_V].contiguous(), q[..., D_V:].contiguous()))
+    assert torch.equal(o_ref, o_t)
+    assert torch.equal(lse_ref, lse_t)
+
+    # Strided tuple components, mimicking the decode path: q_nope as a
+    # transposed (H, B, D_V) buffer (bmm absorb output) and q_pe as a
+    # last-dim split view of a packed tensor.
+    q_nope_hbd = q[..., :D_V].transpose(0, 1).contiguous()
+    q_nope_strided = q_nope_hbd.transpose(0, 1)
+    assert not q_nope_strided.is_contiguous()
+    q_pe_view = q[..., D_V:]
+    torch.testing.assert_close(q_nope_strided, q[..., :D_V], rtol=0, atol=0)
+
+    o_s, lse_s = run((q_nope_strided, q_pe_view))
+    assert torch.equal(o_ref, o_s)
+    assert torch.equal(lse_ref, lse_s)

--- a/vllm/v1/attention/backends/mla/triton_mla.py
+++ b/vllm/v1/attention/backends/mla/triton_mla.py
@@ -249,15 +249,20 @@ class TritonMLAImpl(MLACommonImpl[MLACommonMetadata]):
         assert attn_metadata.decode is not None
 
         if type(q) is tuple:
-            q = torch.cat(q, dim=-1)
-
-        assert isinstance(q, torch.Tensor)
-        B = q.shape[0]
-        q_num_heads = q.shape[1]
+            # Keep (ql_nope, q_pe) unmaterialized: decode_attention_fwd loads
+            # the two segments through separate pointers, so the per-layer
+            # head-dim concat (an extra kernel launch and a full copy of q on
+            # every decode step) is skipped.
+            q_ref = q[0]
+        else:
+            assert isinstance(q, torch.Tensor)
+            q_ref = q
+        B = q_ref.shape[0]
+        q_num_heads = q_ref.shape[1]
         o = torch.zeros(
-            B, q_num_heads, self.kv_lora_rank, dtype=q.dtype, device=q.device
+            B, q_num_heads, self.kv_lora_rank, dtype=q_ref.dtype, device=q_ref.device
         )
-        lse = torch.zeros(B, q_num_heads, dtype=q.dtype, device=q.device)
+        lse = torch.zeros(B, q_num_heads, dtype=q_ref.dtype, device=q_ref.device)
 
         # For batch invariance, use only 1 split to ensure deterministic reduction
         if envs.VLLM_BATCH_INVARIANT:
@@ -280,7 +285,7 @@ class TritonMLAImpl(MLACommonImpl[MLACommonMetadata]):
             )
         else:
             attn_logits = torch.empty(
-                logits_shape, dtype=torch.float32, device=q.device
+                logits_shape, dtype=torch.float32, device=q_ref.device
             )
 
         # Add a head dim of 1

--- a/vllm/v1/attention/ops/triton_decode_attention.py
+++ b/vllm/v1/attention/ops/triton_decode_attention.py
@@ -278,6 +278,7 @@ def _decode_att_m_fwd(
 @triton.jit
 def _fwd_grouped_kernel_stage1(
     Q,
+    Q_PE,
     K_Buffer,
     V_Buffer,
     sm_scale,
@@ -287,6 +288,8 @@ def _fwd_grouped_kernel_stage1(
     stride_req_to_tokens_b,
     stride_qbs,
     stride_qh,
+    stride_qpe_bs,
+    stride_qpe_h,
     stride_buf_kpbs,
     stride_buf_kbs,
     stride_buf_kh,
@@ -338,13 +341,20 @@ def _fwd_grouped_kernel_stage1(
     )
 
     if BLOCK_DPE > 0:
+        # offs_dpe indexes the packed [nope | pe] layout (used for K below);
+        # Q_PE is its own pointer to the pe segment, so its last-dim offset
+        # is rebased to 0. When the caller passes a packed q, Q_PE is simply
+        # a view of q starting at BLOCK_DMODEL and the addresses are
+        # identical to indexing Q with offs_dpe.
         offs_dpe = BLOCK_DMODEL + tl.arange(0, BLOCK_DPE)
         mask_dpe = offs_dpe < Lk
         off_qpe = (
-            cur_batch * stride_qbs + cur_head[:, None] * stride_qh + offs_dpe[None, :]
+            cur_batch * stride_qpe_bs
+            + cur_head[:, None] * stride_qpe_h
+            + (offs_dpe - BLOCK_DMODEL)[None, :]
         )
         qpe = tl.load(
-            Q + off_qpe,
+            Q_PE + off_qpe,
             mask=(mask_h[:, None]) & (mask_dpe[None, :]),
             other=0.0,
             cache_modifier=".ca",
@@ -507,6 +517,20 @@ def _decode_grouped_att_m_fwd(
     if is_hip_:
         BLOCK = 16
 
+    # q may arrive as (q_nope, q_pe): feed the pe segment to the kernel
+    # through its own pointer instead of materializing the head-dim concat.
+    # The zero-copy path requires the nope width to coincide with the
+    # BLOCK_DMODEL boundary the kernel splits the packed layout at;
+    # otherwise fall back to the packed concat.
+    if isinstance(q, tuple):
+        if BLOCK_DPE > 0 and q[0].shape[-1] == BLOCK_DMODEL:
+            q, q_pe = q
+        else:
+            q = torch.cat(q, dim=-1)
+            q_pe = q[..., BLOCK_DMODEL:] if BLOCK_DPE > 0 else q
+    else:
+        q_pe = q[..., BLOCK_DMODEL:] if BLOCK_DPE > 0 else q
+
     batch, head_num = q.shape[0], q.shape[1]
     kv_group_num = q.shape[1] // k_buffer.shape[-2]
 
@@ -533,6 +557,7 @@ def _decode_grouped_att_m_fwd(
 
     _fwd_grouped_kernel_stage1[grid](
         q,
+        q_pe,
         k_buffer,
         v_buffer,
         sm_scale,
@@ -542,6 +567,8 @@ def _decode_grouped_att_m_fwd(
         Req_to_tokens.stride(0),
         q.stride(0),
         q.stride(1),
+        q_pe.stride(0),
+        q_pe.stride(1),
         _page_stride(k_buffer, page_size),
         k_buffer.stride(-3),  # Assume (..., PAGE_SIZE, NUM_HEADS, HEAD_DIM)
         k_buffer.stride(-2),  # Assume (..., PAGE_SIZE, NUM_HEADS, HEAD_DIM)
@@ -748,8 +775,9 @@ def decode_attention_fwd_grouped(
         v_scale,
         is_mla=is_mla,
     )
+    q_sample = q[0] if isinstance(q, tuple) else q
     _decode_softmax_reducev_fwd(
-        attn_logits, q, o, lse, v_buffer, b_seq_len, num_kv_splits
+        attn_logits, q_sample, o, lse, v_buffer, b_seq_len, num_kv_splits
     )
 
 
@@ -772,14 +800,20 @@ def decode_attention_fwd(
 ):
     assert num_kv_splits == attn_logits.shape[2]
 
-    if k_scale is None:
-        k_scale = torch.tensor(1.0, dtype=torch.float32, device=q.device)
-    if v_scale is None:
-        v_scale = torch.tensor(1.0, dtype=torch.float32, device=q.device)
+    # q may be a packed [*, nope | pe] tensor or a (q_nope, q_pe) tuple; the
+    # grouped path consumes the tuple zero-copy (see _decode_grouped_att_m_fwd).
+    q_sample = q[0] if isinstance(q, tuple) else q
 
-    kv_group_num = q.shape[1] // v_buffer.shape[-2]
+    if k_scale is None:
+        k_scale = torch.tensor(1.0, dtype=torch.float32, device=q_sample.device)
+    if v_scale is None:
+        v_scale = torch.tensor(1.0, dtype=torch.float32, device=q_sample.device)
+
+    kv_group_num = q_sample.shape[1] // v_buffer.shape[-2]
 
     if kv_group_num == 1:
+        if isinstance(q, tuple):
+            q = torch.cat(q, dim=-1)
         # MHA
         decode_attention_fwd_normal(
             q,


### PR DESCRIPTION
## Purpose

`TritonMLAImpl.forward_mqa` receives the decode query as a `(ql_nope, q_pe)` tuple and materializes `torch.cat(q, dim=-1)` before every kernel launch — one extra kernel launch plus a full copy of q, per layer, per decode step. The Triton stage-1 kernel never needs the packed buffer: it already loads the nope and pe segments with two separate `tl.load` calls.

This PR gives the stage-1 kernel a second pointer (`Q_PE`, with its own batch/head strides) and passes the tuple through as-is, so the concat disappears from the decode hot path. CUTLASS_MLA and FLASH_ATTN_MLA already consume the tuple without materializing it; this brings TRITON_MLA in line.

On an RTX PRO 6000 (SM120), where TRITON_MLA is the default MLA backend, profiling DeepSeek-V2-Lite decode (B=64, 128 steps) shows the concat (`CatArrayBatchedCopy`) costs 10.6 ms of GPU time per generate call — all of it recoverable.

**Design notes:**
- The zero-copy path engages when `q[0].shape[-1] == BLOCK_DMODEL` (the boundary the kernel splits the packed layout at; `kv_lora_rank` for the MLA shapes: 512 for DeepSeek V2/V3/R1, 256 with 288-dim variants). Any other tuple shape falls back to the packed concat, so behavior is unchanged for shapes the fast path cannot serve.
- Packed-tensor callers are untouched: for them `Q_PE` is a view of `q` at offset `BLOCK_DMODEL`, and the kernel computes byte-identical addresses to the old `Q + offs_dpe` indexing (the last-dim offset is rebased to 0 against the new pointer).
- On the non-MLA grouped path (GQA), `BLOCK_DPE == 0`, so the `Q_PE` load is compiled out; `q_pe` is passed as `q` purely to keep the launch signature uniform.
- The tuple components the decode path actually produces are non-contiguous (`ql_nope` is a transposed bmm output, `q_pe` a last-dim split view); the kernel handles them via the explicit strides, which the new test covers.

## Test Plan

Regression test (new, fails before this change because the tuple previously reached `q.shape` in the launcher):

```bash
pytest tests/kernels/attention/test_triton_decode_attention.py -k tuple_q
```

It checks the tuple path against the packed path for bitwise-equal `o` and `lse`, with both contiguous and strided (transposed-bmm + split-view) tuple components, over `{B=3,37} x {H=16,128} x {(576,512),(288,256)} x {page 16,64}`.

Full existing suites:

```bash
pytest tests/kernels/attention/test_triton_decode_attention.py
pytest tests/v1/attention/test_mla_backends.py -k "correctness and R1 and auto and 1.0 and not spec_decode"
```

Kernel benchmark (old cat+launch vs tuple, exact decode-path layouts, `triton.testing.do_bench`, DeepSeek-V2-Lite geometry H=16, Lk=576, Lv=512, page 64):
end-to-end decode benchmark with `LLM.generate` (DeepSeek-V2-Lite, 64 prompts x 128 tokens, greedy, 3 warmup + 12 timed reps, deterministic Triton MoE backend for token comparison).

## Test Result

All on RTX PRO 6000 Blackwell (SM120, 97 GB), torch 2.11.0+cu130, triton 3.6.0, CUDA driver 580.105.08.

**Correctness**
- New `tuple_q` test: 16 failed before the change (tuple hit `AttributeError` in the launcher) → **131 passed** for the whole file after.
- `test_mla_backends.py` R1 correctness subset: **80 passed** (TRITON_MLA vs SDPA reference; small/medium/large decode, prefill and mixed batches). The SM100-only backends (CUTLASS_MLA/FLASHINFER_MLA) fail on SM120 identically before and after this change (pre-existing; they are not in this PR's path).
- Bitwise: `torch.equal` on `o` and `lse` between tuple and packed paths in every benchmark config below.
- End-to-end: greedy token ids **identical** to baseline across 64 prompts x 128 tokens (with the deterministic Triton MoE backend; baseline self-reproducibility verified first).

**Kernel-level** (decode_attention_fwd incl. old concat, median µs, `do_bench`):

| B | S | before (cat) | after (tuple) | speedup |
|---|---|---|---|---|
| 8 | 512 | 120.6 | 112.7 | 1.070x |
| 8 | 3000 | 128.2 | 120.2 | 1.067x |
| 8 | 16000 | 242.8 | 235.1 | 1.033x |
| 32 | 512 | 131.4 | 124.2 | 1.058x |
| 32 | 3000 | 196.1 | 191.1 | 1.026x |
| 32 | 16000 | 586.4 | 579.5 | 1.012x |
| 128 | 512 | 156.3 | 145.6 | 1.074x |
| 128 | 3000 | 478.7 | 473.5 | 1.011x |
| 128 | 16000 | 1955.0 | 1947.1 | 1.004x |
| 256 | 512 | 254.9 | 238.5 | 1.069x |
| 256 | 3000 | 840.1 | 829.6 | 1.013x |
| 256 | 16000 | 3844.2 | 3838.7 | 1.001x |

12/12 configs faster; the win is the removed copy, so it is largest where attention itself is cheap (small S / small B, i.e. latency-sensitive decode) and dilutes at long context.

**GPU-time profile** (torch.profiler over one generate call, DeepSeek-V2-Lite, B=64, 128 steps):

| | before | after |
|---|---|---|
| `CatArrayBatchedCopy` (the concat) | 10.60 ms | **0** |
| `_fwd_grouped_kernel_stage1` | 55.36 ms | 55.00 ms |
| `_fwd_kernel_stage2` | 13.85 ms | 13.84 ms |
| total GPU | 943.8 ms | 932.0 ms |

Stage-1 does not regress from consuming the strided input — consistent with the strided q access being amortized against the KV-bound loop.

**End-to-end** (64 prompts x 128 tokens, median of 12): 2773.8 ms → 2761.1 ms (**1.0046x**). The e2e effect is small on this MoE model because MoE GEMMs dominate; the honest claim is the kernel-level and GPU-time numbers above.

**Not run / needs CI:** ROCm (the fallback path is exercised by the same unit test, but no AMD hardware here); Hopper validation may be added as a follow-up comment.

---

<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

AI-assisted; all numbers are from real runs on the hardware listed above.
