### PR TITLE
[Bugfix][Benchmark] Check readiness before tokenizer init in rust vllm-bench

### DIFF
--- a/rust/src/bench/src/benchmark.rs
+++ b/rust/src/bench/src/benchmark.rs
@@ -18,7 +18,7 @@ use crate::metrics::steady_state;
 use crate::output::console::print_results;
 use crate::output::json::{append_result, build_result_json, compute_result_filename, save_result};
 use crate::rate_control::compute_schedule;
-use crate::ready_checker::wait_for_endpoint;
+use crate::ready_checker::run_initial_ready_check;
 
 /// Pre-resolve the hostname in `base_url` and pin all resolved IPs on the
 /// client builder via [`reqwest::ClientBuilder::resolve_to_addrs`].  This
@@ -358,6 +358,8 @@ pub async fn run_benchmark(config: &BenchConfig) -> Result<serde_json::Value> {
         (id, Some(name))
     };
 
+    run_initial_ready_check(config, &client, &model_id, &model_name).await?;
+
     // Load tokenizer (if needed)
     let tokenizer = if config.skip_tokenizer_init {
         None
@@ -680,26 +682,6 @@ pub async fn run_benchmark(config: &BenchConfig) -> Result<serde_json::Value> {
         chat_messages_json: first.chat_messages_json.clone(),
         prompt_list: first.prompt_list.clone(),
     };
-
-    // Ready check
-    if config.ready_check_timeout_sec > 0 {
-        tracing::info!("starting initial single-prompt test run");
-        let test_output = wait_for_endpoint(
-            config.backend,
-            &client,
-            &test_input,
-            config.ready_check_timeout_sec,
-            5,
-        )
-        .await?;
-        if !test_output.success {
-            return Err(BenchError::Backend(format!(
-                "Initial test run failed: {}",
-                test_output.error
-            )));
-        }
-        tracing::info!("initial single-prompt test run completed");
-    }
 
     // Verify and fix prompt token lengths against the server's /tokenize endpoint.
     // Runs after the ready check so a still-starting server isn't mistaken for a

--- a/rust/src/bench/src/benchmark.rs
+++ b/rust/src/bench/src/benchmark.rs
@@ -18,7 +18,7 @@ use crate::metrics::steady_state;
 use crate::output::console::print_results;
 use crate::output::json::{append_result, build_result_json, compute_result_filename, save_result};
 use crate::rate_control::compute_schedule;
-use crate::ready_checker::run_initial_ready_check;
+use crate::ready_checker::{get_first_model, wait_for_endpoint};
 
 /// Pre-resolve the hostname in `base_url` and pin all resolved IPs on the
 /// client builder via [`reqwest::ClientBuilder::resolve_to_addrs`].  This
@@ -281,40 +281,6 @@ pub(crate) fn assign_lora_modules(
     Some(out)
 }
 
-/// Fetch the first model from the server's /v1/models endpoint.
-async fn get_first_model_from_server(
-    base_url: &str,
-    client: &reqwest::Client,
-    extra_headers: &Option<std::collections::HashMap<String, String>>,
-) -> Result<(String, String)> {
-    let url = format!("{base_url}/v1/models");
-    let mut request = client.get(&url);
-    if let Some(headers) = extra_headers {
-        for (k, v) in headers {
-            request = request.header(k, v);
-        }
-    }
-    // Add API key from environment
-    if let Ok(api_key) = std::env::var("OPENAI_API_KEY") {
-        request = request.header("Authorization", format!("Bearer {api_key}"));
-    }
-
-    let response = request.send().await?;
-    let data: serde_json::Value = response.json().await?;
-
-    if let Some(models) = data.get("data").and_then(|d| d.as_array())
-        && let Some(first) = models.first()
-    {
-        let id = first.get("id").and_then(|v| v.as_str()).unwrap_or_default().to_string();
-        let root = first.get("root").and_then(|v| v.as_str()).unwrap_or(&id).to_string();
-        return Ok((id, root));
-    }
-
-    Err(BenchError::Config(format!(
-        "No models found on the server at {base_url}"
-    )))
-}
-
 /// Run the complete benchmark.
 ///
 /// This is the core orchestrator matching Python's benchmark() + main_async().
@@ -348,8 +314,13 @@ pub async fn run_benchmark(config: &BenchConfig) -> Result<serde_json::Value> {
         (m.clone(), config.model_name.clone())
     } else {
         tracing::info!(base_url = %config.base_url, "fetching first model from server");
-        let (name, id) =
-            get_first_model_from_server(&config.base_url, &client, &config.extra_headers).await?;
+        let (name, id) = get_first_model(
+            &config.base_url,
+            &client,
+            &config.extra_headers,
+            config.ready_check_timeout_sec,
+        )
+        .await?;
         tracing::info!(
             model_name = name,
             model_id = id,
@@ -358,15 +329,17 @@ pub async fn run_benchmark(config: &BenchConfig) -> Result<serde_json::Value> {
         (id, Some(name))
     };
 
-    run_initial_ready_check(config, &client, &model_id, &model_name).await?;
-
     // Load tokenizer (if needed)
     let tokenizer = if config.skip_tokenizer_init {
         None
     } else {
         let tid = config.tokenizer_id.as_deref().unwrap_or(&model_id);
         tracing::info!(tokenizer = tid, "loading tokenizer");
-        let server_info = Some((config.base_url.as_str(), model_id.as_str()));
+        let server_info = Some((
+            config.base_url.as_str(),
+            model_id.as_str(),
+            config.ready_check_timeout_sec,
+        ));
         let t =
             crate::tokenizer::load_tokenizer(tid, config.trust_remote_code, server_info).await?;
         Some(t)
@@ -682,6 +655,26 @@ pub async fn run_benchmark(config: &BenchConfig) -> Result<serde_json::Value> {
         chat_messages_json: first.chat_messages_json.clone(),
         prompt_list: first.prompt_list.clone(),
     };
+
+    // Ready check
+    if config.ready_check_timeout_sec > 0 {
+        tracing::info!("starting initial single-prompt test run");
+        let test_output = wait_for_endpoint(
+            config.backend,
+            &client,
+            &test_input,
+            config.ready_check_timeout_sec,
+            5,
+        )
+        .await?;
+        if !test_output.success {
+            return Err(BenchError::Backend(format!(
+                "Initial test run failed: {}",
+                test_output.error
+            )));
+        }
+        tracing::info!("initial single-prompt test run completed");
+    }
 
     // Verify and fix prompt token lengths against the server's /tokenize endpoint.
     // Runs after the ready check so a still-starting server isn't mistaken for a

--- a/rust/src/bench/src/multi_turn.rs
+++ b/rust/src/bench/src/multi_turn.rs
@@ -23,6 +23,7 @@ use crate::output::console::print_multi_turn_results;
 use crate::output::json::{
     append_result, build_multi_turn_result_json, compute_result_filename, save_result,
 };
+use crate::ready_checker::{get_first_model, wait_for_endpoint};
 
 /// Output from a single turn within a conversation.
 #[derive(Debug, Clone)]
@@ -74,7 +75,13 @@ pub async fn run_multi_turn_benchmark(config: &BenchConfig) -> Result<serde_json
         (m.clone(), config.model_name.clone())
     } else {
         tracing::info!(base_url = %config.base_url, "fetching first model from server");
-        let (name, id) = get_first_model(&config.base_url, &client, &config.extra_headers).await?;
+        let (name, id) = get_first_model(
+            &config.base_url,
+            &client,
+            &config.extra_headers,
+            config.ready_check_timeout_sec,
+        )
+        .await?;
         tracing::info!(
             model_name = name,
             model_id = id,
@@ -83,15 +90,17 @@ pub async fn run_multi_turn_benchmark(config: &BenchConfig) -> Result<serde_json
         (id, Some(name))
     };
 
-    crate::ready_checker::run_initial_ready_check(config, &client, &model_id, &model_name).await?;
-
     // Load tokenizer
     let tokenizer = if config.skip_tokenizer_init {
         None
     } else {
         let tid = config.tokenizer_id.as_deref().unwrap_or(&model_id);
         tracing::info!(tokenizer = tid, "loading tokenizer");
-        let server_info = Some((config.base_url.as_str(), model_id.as_str()));
+        let server_info = Some((
+            config.base_url.as_str(),
+            model_id.as_str(),
+            config.ready_check_timeout_sec,
+        ));
         let t =
             crate::tokenizer::load_tokenizer(tid, config.trust_remote_code, server_info).await?;
         Some(t)
@@ -244,6 +253,42 @@ pub async fn run_multi_turn_benchmark(config: &BenchConfig) -> Result<serde_json
         println!("  Total turns: {total_turns}");
         println!("  Total user message tokens: {total_user_tokens}");
         return Ok(serde_json::json!({"dry_run": true, "mode": "multi_turn"}));
+    }
+
+    // Ready check with a simple single request
+    if config.ready_check_timeout_sec > 0 {
+        let first_turn = &conversations[0].turns[0];
+        let test_input = RequestFuncInput {
+            prompt: first_turn.user_message.clone(),
+            api_url: config.api_url.clone(),
+            prompt_len: first_turn.user_message_len,
+            output_len: first_turn.expected_output_len,
+            model: model_id.clone(),
+            model_name: model_name.clone(),
+            logprobs: config.logprobs,
+            extra_headers: config.extra_headers.clone(),
+            extra_body: config.extra_body.clone(),
+            ignore_eos: config.ignore_eos,
+            request_id: None,
+            ..Default::default()
+        };
+
+        tracing::info!("starting initial single-prompt test run");
+        let test_output = wait_for_endpoint(
+            config.backend,
+            &client,
+            &test_input,
+            config.ready_check_timeout_sec,
+            5,
+        )
+        .await?;
+        if !test_output.success {
+            return Err(BenchError::Backend(format!(
+                "Initial test run failed: {}",
+                test_output.error
+            )));
+        }
+        tracing::info!("initial single-prompt test run completed");
     }
 
     // For random datasets in multi-turn mode, auto-set min_tokens to enforce
@@ -712,39 +757,6 @@ async fn run_conversation(
         total_duration_ms,
         all_success,
     }
-}
-
-/// Fetch the first model from the server's /v1/models endpoint.
-async fn get_first_model(
-    base_url: &str,
-    client: &reqwest::Client,
-    extra_headers: &Option<HashMap<String, String>>,
-) -> Result<(String, String)> {
-    let url = format!("{base_url}/v1/models");
-    let mut request = client.get(&url);
-    if let Some(headers) = extra_headers {
-        for (k, v) in headers {
-            request = request.header(k, v);
-        }
-    }
-    if let Ok(api_key) = std::env::var("OPENAI_API_KEY") {
-        request = request.header("Authorization", format!("Bearer {api_key}"));
-    }
-
-    let response = request.send().await?;
-    let data: serde_json::Value = response.json().await?;
-
-    if let Some(models) = data.get("data").and_then(|d| d.as_array())
-        && let Some(first) = models.first()
-    {
-        let id = first.get("id").and_then(|v| v.as_str()).unwrap_or_default().to_string();
-        let root = first.get("root").and_then(|v| v.as_str()).unwrap_or(&id).to_string();
-        return Ok((id, root));
-    }
-
-    Err(BenchError::Config(format!(
-        "No models found on the server at {base_url}"
-    )))
 }
 
 #[cfg(test)]

--- a/rust/src/bench/src/multi_turn.rs
+++ b/rust/src/bench/src/multi_turn.rs
@@ -83,6 +83,8 @@ pub async fn run_multi_turn_benchmark(config: &BenchConfig) -> Result<serde_json
         (id, Some(name))
     };
 
+    crate::ready_checker::run_initial_ready_check(config, &client, &model_id, &model_name).await?;
+
     // Load tokenizer
     let tokenizer = if config.skip_tokenizer_init {
         None
@@ -242,42 +244,6 @@ pub async fn run_multi_turn_benchmark(config: &BenchConfig) -> Result<serde_json
         println!("  Total turns: {total_turns}");
         println!("  Total user message tokens: {total_user_tokens}");
         return Ok(serde_json::json!({"dry_run": true, "mode": "multi_turn"}));
-    }
-
-    // Ready check with a simple single request
-    if config.ready_check_timeout_sec > 0 {
-        let first_turn = &conversations[0].turns[0];
-        let test_input = RequestFuncInput {
-            prompt: first_turn.user_message.clone(),
-            api_url: config.api_url.clone(),
-            prompt_len: first_turn.user_message_len,
-            output_len: first_turn.expected_output_len,
-            model: model_id.clone(),
-            model_name: model_name.clone(),
-            logprobs: config.logprobs,
-            extra_headers: config.extra_headers.clone(),
-            extra_body: config.extra_body.clone(),
-            ignore_eos: config.ignore_eos,
-            request_id: None,
-            ..Default::default()
-        };
-
-        tracing::info!("starting initial single-prompt test run");
-        let test_output = crate::ready_checker::wait_for_endpoint(
-            config.backend,
-            &client,
-            &test_input,
-            config.ready_check_timeout_sec,
-            5,
-        )
-        .await?;
-        if !test_output.success {
-            return Err(BenchError::Backend(format!(
-                "Initial test run failed: {}",
-                test_output.error
-            )));
-        }
-        tracing::info!("initial single-prompt test run completed");
     }
 
     // For random datasets in multi-turn mode, auto-set min_tokens to enforce

--- a/rust/src/bench/src/ready_checker.rs
+++ b/rust/src/bench/src/ready_checker.rs
@@ -1,13 +1,60 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+use std::sync::Arc;
 use std::time::Instant;
 
 use indicatif::{ProgressBar, ProgressStyle};
 
 use crate::backends::{RequestFuncInput, RequestFuncOutput, get_backend};
 use crate::cli::BackendKind;
+use crate::config::BenchConfig;
 use crate::error::{BenchError, Result};
+
+/// Wait for the configured backend before tokenizer and dataset initialization.
+pub async fn run_initial_ready_check(
+    config: &BenchConfig,
+    client: &reqwest::Client,
+    model_id: &str,
+    model_name: &Option<String>,
+) -> Result<()> {
+    if config.dry_run || config.ready_check_timeout_sec == 0 {
+        return Ok(());
+    }
+
+    let prompt_list = (config.backend == BackendKind::VllmRerank).then(|| {
+        Arc::from([
+            Arc::<str>::from("test query"),
+            Arc::<str>::from("test document"),
+        ])
+    });
+    let test_input = RequestFuncInput {
+        prompt: Arc::from("test"),
+        api_url: config.api_url.clone(),
+        prompt_len: 1,
+        output_len: 1,
+        model: model_id.to_string(),
+        model_name: model_name.clone(),
+        logprobs: config.logprobs,
+        extra_headers: config.extra_headers.clone(),
+        extra_body: config.extra_body.clone(),
+        ignore_eos: config.ignore_eos,
+        prompt_list,
+        ..Default::default()
+    };
+
+    tracing::info!("starting initial single-prompt test run");
+    wait_for_endpoint(
+        config.backend,
+        client,
+        &test_input,
+        config.ready_check_timeout_sec,
+        5,
+    )
+    .await?;
+    tracing::info!("initial single-prompt test run completed");
+    Ok(())
+}
 
 /// Wait for the serving endpoint to become available.
 ///

--- a/rust/src/bench/src/ready_checker.rs
+++ b/rust/src/bench/src/ready_checker.rs
@@ -1,59 +1,94 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-use std::sync::Arc;
+use std::future::Future;
 use std::time::Instant;
 
 use indicatif::{ProgressBar, ProgressStyle};
+use thiserror_ext::AsReport as _;
 
 use crate::backends::{RequestFuncInput, RequestFuncOutput, get_backend};
 use crate::cli::BackendKind;
-use crate::config::BenchConfig;
 use crate::error::{BenchError, Result};
 
-/// Wait for the configured backend before tokenizer and dataset initialization.
-pub async fn run_initial_ready_check(
-    config: &BenchConfig,
-    client: &reqwest::Client,
-    model_id: &str,
-    model_name: &Option<String>,
-) -> Result<()> {
-    if config.dry_run || config.ready_check_timeout_sec == 0 {
-        return Ok(());
+/// Retry an operation until it succeeds or the readiness timeout expires.
+pub(crate) async fn retry_with_timeout<T, F, Fut>(
+    timeout_seconds: u64,
+    retry_interval: u64,
+    mut operation: F,
+) -> Result<T>
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = Result<T>>,
+{
+    if timeout_seconds == 0 {
+        return operation().await;
     }
 
-    let prompt_list = (config.backend == BackendKind::VllmRerank).then(|| {
-        Arc::from([
-            Arc::<str>::from("test query"),
-            Arc::<str>::from("test document"),
-        ])
-    });
-    let test_input = RequestFuncInput {
-        prompt: Arc::from("test"),
-        api_url: config.api_url.clone(),
-        prompt_len: 1,
-        output_len: 1,
-        model: model_id.to_string(),
-        model_name: model_name.clone(),
-        logprobs: config.logprobs,
-        extra_headers: config.extra_headers.clone(),
-        extra_body: config.extra_body.clone(),
-        ignore_eos: config.ignore_eos,
-        prompt_list,
-        ..Default::default()
-    };
+    let deadline = Instant::now() + std::time::Duration::from_secs(timeout_seconds);
 
-    tracing::info!("starting initial single-prompt test run");
-    wait_for_endpoint(
-        config.backend,
-        client,
-        &test_input,
-        config.ready_check_timeout_sec,
-        5,
-    )
-    .await?;
-    tracing::info!("initial single-prompt test run completed");
-    Ok(())
+    loop {
+        let error = match operation().await {
+            Ok(value) => return Ok(value),
+            Err(error) => error,
+        };
+        tracing::warn!(error = %error.as_report(), "endpoint is not ready");
+
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            return Err(BenchError::EndpointTimeout(
+                timeout_seconds,
+                format!("{}", error.as_report()),
+            ));
+        }
+
+        let sleep_duration =
+            std::cmp::min(std::time::Duration::from_secs(retry_interval), remaining);
+        if !sleep_duration.is_zero() {
+            tokio::time::sleep(sleep_duration).await;
+        }
+    }
+}
+
+/// Fetch the first model from the server, retrying while it starts.
+pub(crate) async fn get_first_model(
+    base_url: &str,
+    client: &reqwest::Client,
+    extra_headers: &Option<std::collections::HashMap<String, String>>,
+    timeout_seconds: u64,
+) -> Result<(String, String)> {
+    let url = format!("{base_url}/v1/models");
+    retry_with_timeout(timeout_seconds, 5, || async {
+        let mut request = client.get(&url);
+        if let Some(headers) = extra_headers {
+            for (key, value) in headers {
+                request = request.header(key, value);
+            }
+        }
+        // Add API key from environment
+        if let Ok(api_key) = std::env::var("OPENAI_API_KEY") {
+            request = request.header("Authorization", format!("Bearer {api_key}"));
+        }
+
+        let response = request.send().await?.error_for_status()?;
+        let data: serde_json::Value = response.json().await?;
+        if let Some(model) = data
+            .get("data")
+            .and_then(|value| value.as_array())
+            .and_then(|models| models.first())
+        {
+            let id =
+                model.get("id").and_then(|value| value.as_str()).unwrap_or_default().to_string();
+            let root =
+                model.get("root").and_then(|value| value.as_str()).unwrap_or(&id).to_string();
+            return Ok((id, root));
+        }
+
+        Err(BenchError::Config(format!(
+            "No models found on the server at {base_url}"
+        )))
+    })
+    .await
 }
 
 /// Wait for the serving endpoint to become available.
@@ -110,7 +145,7 @@ pub async fn wait_for_endpoint(
                 last_error = err;
             }
             Err(e) => {
-                last_error = e.to_string();
+                last_error = format!("{}", e.as_report());
             }
         }
 
@@ -122,4 +157,44 @@ pub async fn wait_for_endpoint(
     }
 
     Err(BenchError::EndpointTimeout(timeout_seconds, last_error))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn retry_succeeds_after_transient_failures() {
+        let attempts = AtomicUsize::new(0);
+
+        let value = retry_with_timeout(1, 0, || async {
+            if attempts.fetch_add(1, Ordering::Relaxed) < 2 {
+                Err(BenchError::Backend("not ready".into()))
+            } else {
+                Ok(42)
+            }
+        })
+        .await
+        .unwrap();
+
+        assert_eq!(value, 42);
+        assert_eq!(attempts.load(Ordering::Relaxed), 3);
+    }
+
+    #[tokio::test]
+    async fn zero_timeout_does_not_retry() {
+        let attempts = AtomicUsize::new(0);
+
+        let error = retry_with_timeout(0, 0, || async {
+            attempts.fetch_add(1, Ordering::Relaxed);
+            Err::<(), _>(BenchError::Backend("not ready".into()))
+        })
+        .await
+        .unwrap_err();
+
+        assert!(matches!(error, BenchError::Backend(_)));
+        assert_eq!(attempts.load(Ordering::Relaxed), 1);
+    }
 }

--- a/rust/src/bench/src/tokenizer.rs
+++ b/rust/src/bench/src/tokenizer.rs
@@ -30,7 +30,7 @@ pub struct ServerTokenizer {
 
 impl ServerTokenizer {
     /// Create a new server tokenizer and verify connectivity.
-    pub async fn new(base_url: &str, model: &str) -> Result<Self> {
+    pub async fn new(base_url: &str, model: &str, timeout_seconds: u64) -> Result<Self> {
         let client = reqwest::Client::builder()
             .timeout(std::time::Duration::from_secs(30))
             .build()
@@ -49,7 +49,10 @@ impl ServerTokenizer {
         };
 
         // Probe the endpoint to verify it works and discover vocab size
-        let test_tokens = st.encode_async("test").await?;
+        let test_tokens = crate::ready_checker::retry_with_timeout(timeout_seconds, 5, || {
+            st.encode_async("test")
+        })
+        .await?;
         let max_id = test_tokens.iter().copied().max().unwrap_or(0);
         let estimated_vocab = (max_id * 2).max(131072);
 
@@ -225,11 +228,11 @@ impl TokenizerKind {
 /// 2. Tiktoken model file (for Kimi, Qwen, etc.)
 /// 3. Server-side /tokenize + /detokenize endpoints
 ///
-/// `server_info` is `Some((base_url, model))` to enable server-side fallback.
+/// `server_info` is `Some((base_url, model, timeout_seconds))` to enable server-side fallback.
 pub async fn load_tokenizer(
     model_id: &str,
     _trust_remote_code: bool,
-    server_info: Option<(&str, &str)>,
+    server_info: Option<(&str, &str, u64)>,
 ) -> Result<TokenizerKind> {
     // 0. Check for built-in tiktoken encoding names (no HF download needed). These are useful for
     //    consistent cross-model token counting (e.g. Artificial Analysis).
@@ -275,13 +278,13 @@ pub async fn load_tokenizer(
                 }
                 Err(tiktoken_err) => {
                     // 3. Try server-side fallback
-                    if let Some((base_url, model)) = server_info {
+                    if let Some((base_url, model, timeout_seconds)) = server_info {
                         tracing::info!(
                             model = model_id,
                             error = %tiktoken_err.as_report(),
                             "tiktoken unavailable; trying server-side tokenization"
                         );
-                        match ServerTokenizer::new(base_url, model).await {
+                        match ServerTokenizer::new(base_url, model, timeout_seconds).await {
                             Ok(srv) => {
                                 tracing::info!(
                                     model = model_id,


### PR DESCRIPTION
## Summary

Apply `--ready-check-timeout-sec` to the startup-dependent requests that can run before the benchmark readiness probe:

- retry `/v1/models` discovery when `--model` is omitted
- retry the `/tokenize` probe when tokenizer loading falls back to the server
- retain the dataset-derived readiness request immediately before tokenizer verification and the timed run

This keeps the readiness request representative of the benchmark payload, including token IDs, multimodal content, and pooling inputs. Local tokenizer loading and dataset generation can still overlap server startup.

## Duplicate work

Searched open PRs for `ready-check-timeout`, tokenizer readiness, and server-side tokenization readiness. No duplicate fix was found.

## Testing

- `cargo test -p vllm-bench` — 150 passed, 10 ignored
- `cargo clippy -p vllm-bench --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `pre-commit run`

## AI assistance

AI assistance was used to implement and test this change. I reviewed every changed line and can explain and maintain the implementation.
