### PR TITLE
[Core] Fix MultiConnector returning duplicate finished_recving signals

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/multi_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/multi_connector.py
@@ -47,6 +47,7 @@ logger = init_logger(__name__)
 class MultiKVConnectorMetadata(KVConnectorMetadata):
     metadata: tuple[KVConnectorMetadata, ...]
     extra_async_saves: dict[str, int] | None = None
+    requests_to_connector: dict[str, int] | None = None
 
 
 @dataclass
@@ -202,6 +203,7 @@ class MultiConnector(KVConnectorBase_V1, SupportsHMA):
         # A mapping from request id to the index of the connector chosen to
         # load the request from (if any).
         self._requests_to_connector: dict[str, int] = {}
+        self._new_requests_to_connector: dict[str, int] = {}
 
         # Keeps track of *additional* remaining async saves (beyond 1) to be
         # finished per request. Not needed for async loads since we only allow
@@ -272,6 +274,8 @@ class MultiConnector(KVConnectorBase_V1, SupportsHMA):
         assert isinstance(connector_metadata, MultiKVConnectorMetadata)
         if connector_metadata.extra_async_saves:
             self._extra_async_saves.update(connector_metadata.extra_async_saves)
+        if connector_metadata.requests_to_connector:
+            self._requests_to_connector.update(connector_metadata.requests_to_connector)
         for c, cm in zip(self._connectors, connector_metadata.metadata):
             c.bind_connector_metadata(cm)
         super().bind_connector_metadata(connector_metadata)
@@ -340,9 +344,18 @@ class MultiConnector(KVConnectorBase_V1, SupportsHMA):
         self, finished_req_ids: set[str]
     ) -> KVConnectorTransferResults:
         results = KVConnectorTransferResults()
-        for connector in self._connectors:
+        for i, connector in enumerate(self._connectors):
             child_results = connector.get_transfer_results(finished_req_ids)
-            results.finished_recving.update(child_results.finished_recving)
+            
+            # Aggregate finished recving request ids.
+            # Only trust the finished_recving signal from the connector
+            # that was actually assigned to load this request's KV.
+            for req_id in child_results.finished_recving:
+                if self._requests_to_connector.get(req_id, -1) == i:
+                    results.finished_recving.add(req_id)
+                    # Pop it so we don't return it again and avoid memory leak
+                    self._requests_to_connector.pop(req_id, None)
+
             results.failed_recving.update(child_results.failed_recving)
             for req_id in child_results.finished_sending:
                 extra_pending = self._extra_async_saves.get(req_id)
@@ -426,6 +439,7 @@ class MultiConnector(KVConnectorBase_V1, SupportsHMA):
             # to this request.
             if to_return[0] == 0 and toks > 0:
                 self._requests_to_connector[request.request_id] = i
+                self._new_requests_to_connector[request.request_id] = i
                 to_return = (toks, load_async)
         return to_return
 
@@ -456,6 +470,9 @@ class MultiConnector(KVConnectorBase_V1, SupportsHMA):
         if self._extra_async_saves:
             metadata.extra_async_saves = self._extra_async_saves
             self._extra_async_saves = {}
+        if self._new_requests_to_connector:
+            metadata.requests_to_connector = self._new_requests_to_connector
+            self._new_requests_to_connector = {}
         return metadata
 
     def update_connector_output(self, connector_output: KVConnectorOutput):


### PR DESCRIPTION


## Purpose
Resolves #51846

Fixes a scheduler crash (`assert req.status == RequestStatus.WAITING_FOR_REMOTE_KVS`) that occurs in Disaggregated Prefill/Decode (PD) setups when multiple consumer KV connectors are configured (e.g., `NixlConnector` + `LMCacheMPConnector`).

### Root Cause
When multiple KV connectors are configured as consumers, `MultiConnector.get_finished()` blindly aggregated the `finished_recving` signal from *all* connectors. 

Even though `MultiConnector` only assigns the actual load operation to a single chosen connector, the unassigned connectors are given `0` tokens to load in `update_state_after_alloc`. As a result, they immediately consider their load operation "completed" and return the `req_id` as finished receiving. This results in the `MultiConnector` yielding the same `req_id` in two separate scheduler steps. The first signal correctly transitions the request out of `WAITING_FOR_REMOTE_KVS` to `RUNNING`, but the second signal crashes the scheduler since the request is no longer waiting for KV.

### The Fix
Updated `MultiConnector.get_finished()` to only trust the `finished_recving` signal if the connector reporting it was the one explicitly chosen to load the request's KV. 

## Test Plan

This is a pure logic fix to `MultiConnector` (fixing an oversight in the loop conditional).

**Local linting:**
- `pre-commit run ruff-check`
- `pre-commit run mypy-3.12 --all-files --hook-stage manual`

**Testing:**
Due to local environment dependency extraction errors blocking `pytest`, I am relying on the automated GitHub Actions CI pipeline to verify the existing `tests/v1/kv_connector/unit/test_multi_connector.py` suite. 

## Test Result

- `pre-commit` passed cleanly on the modified file.
- No model evaluation is included because this change is confined to the KV connector communication layer and cannot affect model output accuracy or logic.

> **Note:** AI assistance was used to root cause. I have reviewed every changed line and verified the logic fix myself.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>


