### PR TITLE
[Bugfix] Quietly reject invalid post-reasoning speculative drafts

### DIFF
--- a/tests/v1/spec_decode/test_mtp_structured_output.py
+++ b/tests/v1/spec_decode/test_mtp_structured_output.py
@@ -189,7 +189,9 @@ def test_bitmask_constrained_when_reasoning_ends_midwindow(backend):
 
 
 @pytest.mark.parametrize("backend", ["xgrammar", "guidance"])
-def test_bitmask_post_reasoning_end_drafts_skip_grammar_advance(backend):
+def test_bitmask_post_reasoning_end_drafts_skip_grammar_advance(
+    backend, caplog, monkeypatch
+):
     """Post-marker drafts predate the bitmask and may be grammar-invalid;
     grammar_bitmask must skip the grammar advance instead of asserting.
     """
@@ -221,7 +223,24 @@ def test_bitmask_post_reasoning_end_drafts_skip_grammar_advance(backend):
     # A token that the JSON grammar would reject as the first post-marker
     # token; without the fix grammar.accept_tokens fires the assertion.
     invalid_post = tokenizer.encode("z")[0]
-    drafts = [pre, marker, invalid_post]
+    unreachable_post = tokenizer.encode('"')[0]
+    drafts = [pre, marker, invalid_post, unreachable_post]
+
+    validate_calls = []
+    accept_calls = []
+    original_validate = grammar.validate_tokens
+    original_accept = grammar.accept_tokens
+
+    def validate_spy(tokens):
+        validate_calls.append(list(tokens))
+        return original_validate(tokens)
+
+    def accept_spy(req_id, tokens):
+        accept_calls.append((req_id, list(tokens)))
+        return original_accept(req_id, tokens)
+
+    monkeypatch.setattr(grammar, "validate_tokens", validate_spy)
+    monkeypatch.setattr(grammar, "accept_tokens", accept_spy)
 
     bitmask = manager.grammar_bitmask(
         requests={request.request_id: request},
@@ -235,6 +254,94 @@ def test_bitmask_post_reasoning_end_drafts_skip_grammar_advance(backend):
     assert not (bitmask[2] == -1).all()
     # Grammar must not have advanced through the unvalidated draft.
     assert not grammar.is_terminated()
+    assert validate_calls == [[invalid_post]]
+    assert accept_calls == []
+    assert "Failed to advance FSM" not in caplog.text
+
+
+@pytest.mark.parametrize("backend", ["xgrammar", "guidance"])
+def test_bitmask_valid_post_reasoning_draft_advances_then_rolls_back(
+    backend, caplog, monkeypatch
+):
+    """A valid post-marker draft is persisted for the next bitmask row, then
+    rolled back so repeated scheduler probes remain idempotent.
+    """
+    tokenizer, manager, request, _ = _make_manager_and_request(backend, prompt_str="{")
+    grammar = request.structured_output_request.grammar
+    assert grammar.accept_tokens(request.request_id, tokenizer.encode("{"))
+    processed_before = getattr(grammar, "num_processed_tokens", None)
+
+    marker = tokenizer.encode("\n")[0]
+    manager.reasoner_cls = _MarkerReasoner
+    request.structured_output_request.reasoner = _MarkerReasoner(marker)
+    request.structured_output_request.reasoning_ended = False
+
+    valid_post = tokenizer.encode('"')[0]
+    drafts = [tokenizer.encode(" ")[0], marker, valid_post]
+    validate_calls = []
+    accept_calls = []
+    original_validate = grammar.validate_tokens
+    original_accept = grammar.accept_tokens
+
+    def validate_spy(tokens):
+        validate_calls.append(list(tokens))
+        return original_validate(tokens)
+
+    def accept_spy(req_id, tokens):
+        accept_calls.append((req_id, list(tokens)))
+        return original_accept(req_id, tokens)
+
+    monkeypatch.setattr(grammar, "validate_tokens", validate_spy)
+    monkeypatch.setattr(grammar, "accept_tokens", accept_spy)
+
+    first = manager.grammar_bitmask(
+        requests={request.request_id: request},
+        structured_output_request_ids=[request.request_id],
+        scheduled_spec_decode_tokens={request.request_id: drafts},
+    )
+    second = manager.grammar_bitmask(
+        requests={request.request_id: request},
+        structured_output_request_ids=[request.request_id],
+        scheduled_spec_decode_tokens={request.request_id: drafts},
+    )
+
+    assert first is not None and second is not None
+    assert (first == second).all()
+    assert validate_calls == [[valid_post], [valid_post]]
+    assert accept_calls == [
+        (request.request_id, [valid_post]),
+        (request.request_id, [valid_post]),
+    ]
+    if processed_before is not None:
+        assert grammar.num_processed_tokens == processed_before
+    assert not grammar.is_terminated()
+    assert "Failed to advance FSM" not in caplog.text
+
+
+def test_bitmask_post_reasoning_validation_accept_mismatch_fails_closed(monkeypatch):
+    """A backend state mismatch is not an expected speculative rejection."""
+    tokenizer, manager, request, _ = _make_manager_and_request(
+        "xgrammar", prompt_str="{"
+    )
+    grammar = request.structured_output_request.grammar
+    assert grammar.accept_tokens(request.request_id, tokenizer.encode("{"))
+
+    marker = tokenizer.encode("\n")[0]
+    manager.reasoner_cls = _MarkerReasoner
+    request.structured_output_request.reasoner = _MarkerReasoner(marker)
+    request.structured_output_request.reasoning_ended = False
+    post = tokenizer.encode('"')[0]
+    drafts = [tokenizer.encode(" ")[0], marker, post]
+
+    monkeypatch.setattr(grammar, "validate_tokens", lambda tokens: list(tokens))
+    monkeypatch.setattr(grammar, "accept_tokens", lambda req_id, tokens: False)
+
+    with pytest.raises(AssertionError):
+        manager.grammar_bitmask(
+            requests={request.request_id: request},
+            structured_output_request_ids=[request.request_id],
+            scheduled_spec_decode_tokens={request.request_id: drafts},
+        )
 
 
 @pytest.mark.parametrize("backend", ["xgrammar", "guidance"])

--- a/vllm/v1/structured_output/__init__.py
+++ b/vllm/v1/structured_output/__init__.py
@@ -300,6 +300,7 @@ class StructuredOutputManager:
 
                 state_advancements = 0
                 post_reasoning_end_in_window = False
+                post_reasoning_prefix_valid = True
                 req_tokens = scheduled_spec_decode_tokens.get(req_id, ())
                 for i, token in enumerate(req_tokens):
                     self._fill_bitmasks(((grammar, cumulative_index, apply_bitmask),))
@@ -329,7 +330,27 @@ class StructuredOutputManager:
                             advance_grammar = False
                             post_reasoning_end_in_window = True
                     if advance_grammar and not grammar.is_terminated():
-                        accepted = grammar.accept_tokens(req_id, [token])
+                        if post_reasoning_end_in_window:
+                            # These drafts were produced before the grammar
+                            # became active. Probe without logging an expected
+                            # rejection, then persist only valid transitions.
+                            # Once one draft is rejected, the speculative
+                            # suffix is unreachable and must not be probed
+                            # against a state that omitted that draft.
+                            accepted = post_reasoning_prefix_valid and (
+                                grammar.validate_tokens([token]) == [token]
+                            )
+                            if not accepted:
+                                post_reasoning_prefix_valid = False
+                            elif not grammar.accept_tokens(req_id, [token]):
+                                # Validation is non-advancing. If the same
+                                # transition cannot then be persisted, fail
+                                # closed rather than hiding inconsistent state.
+                                raise AssertionError(
+                                    (token, req_id, scheduled_spec_decode_tokens)
+                                )
+                        else:
+                            accepted = grammar.accept_tokens(req_id, [token])
                         if accepted:
                             state_advancements += 1
                         elif not post_reasoning_end_in_window:


### PR DESCRIPTION
## Purpose

When reasoning ends inside a speculative window, post-boundary drafts were
sampled before the structured-output grammar became active. Current main
intentionally tolerates a grammar rejection while simulating those drafts in
`StructuredOutputManager.grammar_bitmask`, but calls the logging
`accept_tokens()` path first. A successful request can therefore emit
`Failed to advance FSM` and a terminated-matcher warning even though the
invalid speculative draft is correctly rejected.

This change uses the non-advancing `validate_tokens()` operation for that
narrow post-reasoning probe. Valid drafts are still persisted temporarily and
rolled back as before. The first invalid draft makes its speculative suffix
unreachable. A validation/acceptance state mismatch still fails closed.

This does not duplicate #40962 or #43424. Those PRs validate or truncate
accepted output before commit and adjust scheduler accounting. This PR does
not change accepted output, request state, or scheduler accounting; it only
avoids invoking a noisy mutating operation for a rejection that the existing
bitmask simulation already treats as expected. #44392 filters reasoning
boundary tokens rather than grammar-invalid post-boundary drafts.

AI assistance disclosure: OpenAI Codex assisted with upstream research,
implementation, tests, and PR drafting. The human submitter is responsible
for the change and will complete line-by-line review before marking this draft
ready for review.

## Test Plan

- Exercise invalid and valid post-reasoning speculative drafts with Xgrammar
  and Guidance.
- Verify invalid drafts never reach `accept_tokens()` and emit no FSM error.
- Verify valid drafts advance, roll back, and remain idempotent.
- Verify a validate/accept mismatch still raises.
- Run focused lint, formatting, compilation, and live structured-output checks.

## Test Result

- `ruff check` on both changed files: passed.
- `ruff format --check` on both changed files: passed.
- Python compilation of both changed files: passed.
- Focused v0.24-derived MoET test file: `20 passed` with Xgrammar and Guidance.
- Bounded DeepSeek-V4-Flash live check with speculative decoding: HTTP 200,
  `finish_reason=stop`, correct schema-conforming JSON, and no
  `Failed to advance FSM` or terminated-matcher warning in the correlated log.
- Current-main pytest collection was not run on the serving host because that
  isolated checkout lacks the required compiled FlashAttention extension; no
  mainline vLLM build or installation was performed. Upstream CI should run
  the focused test file in its supported environment.

This patch changes Python scheduler-side grammar simulation only; it has no
compiled-component changes.
