### PR TITLE
[CPU] Shard the MoE experts across NUMA nodes

### DIFF
--- a/csrc/cpu/moe_numa_parallel.hpp
+++ b/csrc/cpu/moe_numa_parallel.hpp
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+//
+// The one entry point the vendored MoE kernels call, so that their diff against
+// upstream SGLang stays a single renamed function per stage.
+//
+// Split from moe_numa_shard.hpp because this one needs common.h (for
+// parallel_2d and adjust_num_threads) and the weight loader in utils.cpp must
+// be able to use the split rule without pulling the whole kernel header in.
+
+#pragma once
+
+#include "cpu/moe_numa_shard.hpp"
+#include "cpu/sgl-kernels/common.h"
+#include "cpu/sgl-kernels/gemm.h"
+
+// The loader and the policy both round shard boundaries to kBlockN without
+// including the kernel headers. Pin it here, where both are visible.
+static_assert(block_size_n() == vllm_cpu_moe_numa::kBlockN,
+              "vllm_cpu_moe_numa::kBlockN is out of sync with the kernel's "
+              "block_size_n(); update it and BLOCK_N in cpu_numa_shard.py.");
+
+// Dispatch to the NUMA-sharded loop, or to the stock one when sharding is off
+// or does not apply. The stock path is the *same call as before*, not a
+// reimplementation: when nothing enabled sharding, this change is inert.
+//
+// Sharding is skipped, and the plain loop used, when:
+//   * no policy set a shard count (the default, so every existing deployment
+//     keeps its current behaviour byte for byte);
+//   * the thread count is not a multiple of the shard count, so "thread ith
+//     belongs to node ith / (nth / shards)" would not hold;
+//   * there are fewer blocks than shards, which would leave a memory controller
+//     idle while its cores read from the others.
+template <typename func_t>
+inline void parallel_2d_numa_or_plain(int m, int n, const func_t& f) {
+  const int shards = vllm_cpu_moe_numa::shard_count();
+  if (shards > 1 && vllm_cpu_moe_numa::moe_numa_can_shard(n, shards)) {
+    const int nth = adjust_num_threads(m);
+    if (nth % shards == 0 && nth >= shards) {
+      vllm_cpu_moe_numa::parallel_2d_numa(m, n, shards, nth, f);
+      return;
+    }
+  }
+  parallel_2d(m, n, f);
+}

--- a/csrc/cpu/moe_numa_shard.hpp
+++ b/csrc/cpu/moe_numa_shard.hpp
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+//
+// NUMA-aware work splitting for the CPU MoE experts.
+//
+// The CPU MoE kernel parallelises each of its two GEMM stages over the output
+// rows of the weight it reads: stage 1 over the ``2N`` rows of w1, stage 2 over
+// the ``K`` rows of w2. Both are already the parallel axis, so giving a NUMA
+// node a contiguous slice of that axis makes every thread read only pages that
+// were placed on its own node -- no reduction, no barrier, no extra buffers.
+//
+// This header owns two things and nothing else:
+//
+//   * ``moe_numa_block_split``, the split rule, which the weight loader and the
+//     kernel must agree on exactly. It is a pure function of (blocks, shards)
+//     so both can call it instead of passing a table around.
+//   * ``parallel_2d_numa``, the loop, which subdivides *each node's own slice*
+//     among that node's threads.
+//
+// It lives outside ``sgl-kernels/`` because that directory is vendored from
+// SGLang and re-synced wholesale; keeping this here leaves the vendored call
+// sites a one-line change.
+
+#pragma once
+
+#include <algorithm>
+#include <cmath>
+
+#if defined(_OPENMP)
+  #include <omp.h>
+#endif
+
+namespace vllm_cpu_moe_numa {
+
+// The microkernel's column unit, i.e. ``block_size_n()`` in
+// csrc/cpu/sgl-kernels/gemm.h. Duplicated here because the weight loader has to
+// round shard boundaries to it without pulling the kernel headers in, and
+// mirrored in cpu_numa_shard.py because the policy needs it too.
+//
+// moe_numa_parallel.hpp static_asserts this against the kernel's own value, so
+// the three cannot drift apart silently: if gemm.h changes, the build breaks
+// here rather than the loader placing pages on boundaries the kernel does not
+// split on -- which would be slower and give no sign of it.
+constexpr int kBlockN = 32;
+
+// Number of shards the MoE weights were placed with, or 1 for the plain path.
+// Set once from Python after the topology is known; read by the kernel on every
+// call, so it must stay a plain load.
+int& shard_count();
+
+// Split ``blocks`` across ``shards``, in whole blocks, handing the remainder
+// out one block at a time to the first shards.
+//
+// Whole blocks because the microkernel's unit is ``BLOCK_N`` columns, not one
+// column: a slice that is not a multiple of it cannot be computed. Equal slices
+// are *not* required, and insisting on them is what made an earlier draft of
+// this decline for ``intermediate_size = 2880`` -- vLLM's own CPU MoE benchmark
+// size -- because 720 is not a multiple of 32. Splitting 90 blocks as
+// 23/23/22/22 instead bounds the imbalance to a single block (4.5%) rather than
+// piling the remainder onto the last shard (9.5%).
+inline void moe_numa_block_split(int blocks, int shards, int shard, int* begin,
+                                 int* end) {
+  const int base = blocks / shards;
+  const int rem = blocks % shards;
+  const int b = shard * base + std::min(shard, rem);
+  *begin = b;
+  *end = b + base + (shard < rem ? 1 : 0);
+}
+
+// True when ``blocks`` can be split across ``shards`` with every shard getting
+// at least one block. Fewer blocks than shards would leave a memory controller
+// with no work while its cores keep reading from the others, which measures
+// worse than not sharding at all.
+inline bool moe_numa_can_shard(int blocks, int shards) {
+  return shards > 1 && blocks >= shards;
+}
+
+// ``parallel_2d`` with the ``n`` axis partitioned by NUMA node first.
+//
+// Thread ``ith`` is taken to belong to node ``ith / (nth / shards)``. That
+// holds when the OpenMP threads are bound to CPUs in list order, which is what
+// ``KMP_AFFINITY=...,explicit,proclist=[...]`` and ``GOMP_CPU_AFFINITY`` give.
+// The generic ``OMP_PLACES`` fallback defines a single place containing every
+// CPU and does not, so the policy that sets ``shard_count()`` has to verify the
+// binding and leave it at 1 rather than assume.
+//
+// ``f`` is called exactly as ``parallel_2d`` calls it, with block indices into
+// the full ``n`` range, so call sites only change which function they name.
+template <typename func_t>
+inline void parallel_2d_numa(int m, int n, int shards, int nth,
+                             const func_t& f) {
+#if defined(_OPENMP)
+  const int threads_per_node = nth / shards;
+  #pragma omp parallel num_threads(nth)
+  {
+    const int ith = omp_get_thread_num();
+    const int node = ith / threads_per_node;
+    const int ith_local = ith % threads_per_node;
+
+    int node_nb0 = 0, node_nb1 = 0;
+    moe_numa_block_split(n, shards, node, &node_nb0, &node_nb1);
+    const int n_local = node_nb1 - node_nb0;
+
+    // Same square-ish blocking as parallel_2d, but over this node's slice and
+    // this node's threads. Because each node subdivides its own range, the
+    // thread -> tile map does not need the swap a globally-partitioned version
+    // would have needed: threads of a node cannot stray outside its pages.
+    const float r = float(m) / float(std::max(1, n_local));
+    int nth_m = int(std::ceil(std::sqrt(r * threads_per_node)));
+    int nth_n = 1;
+    for (; nth_m > 0; --nth_m) {
+      nth_n = threads_per_node / nth_m;
+      if (nth_m * nth_n == threads_per_node) {
+        break;
+      }
+    }
+    if (nth_m <= 0) {
+      nth_m = 1;
+      nth_n = threads_per_node;
+    }
+
+    const int ith_m = ith_local / nth_n;
+    const int ith_n = ith_local % nth_n;
+
+    const int block_m = (m + nth_m - 1) / nth_m;
+    const int block_n = (n_local + nth_n - 1) / nth_n;
+
+    const int begin_m = ith_m * block_m;
+    const int end_m = std::min(m, begin_m + block_m);
+    const int begin_n = node_nb0 + ith_n * block_n;
+    const int end_n = std::min(node_nb1, begin_n + block_n);
+
+    if (begin_m < end_m && begin_n < end_n) {
+      f(begin_m, end_m, begin_n, end_n);
+    }
+  }
+#else
+  (void)shards;
+  (void)nth;
+  f(0, m, 0, n);
+#endif
+}
+
+}  // namespace vllm_cpu_moe_numa

--- a/csrc/cpu/sgl-kernels/moe.cpp
+++ b/csrc/cpu/sgl-kernels/moe.cpp
@@ -5,6 +5,8 @@
 
 #include "moe.h"
 
+#include "cpu/moe_numa_parallel.hpp"
+
 #include "common.h"
 #include "gemm.h"
 
@@ -443,7 +445,7 @@ void fused_experts_kernel_impl(
   const bool use_brgemm = can_use_brgemm<scalar_t>(avg_M);
 
   // here we only parallel on half of 2N to fuse silu_and_mul with gemm
-  parallel_2d(MB, NB, [&](int64_t mb0, int64_t mb1, int64_t nb0, int64_t nb1) {
+  parallel_2d_numa_or_plain(MB, NB, [&](int64_t mb0, int64_t mb1, int64_t nb0, int64_t nb1) {
     // get local pointers
     int tid = get_thread_num();
     scalar_t* __restrict__ A = A_tmp + tid * BLOCK_M * K;
@@ -574,7 +576,7 @@ void fused_experts_kernel_impl(
   const int64_t stride_oc = IC;
 
   // parallel on [MB2, NB2]
-  parallel_2d(MB2, NB2, [&](int64_t mb0, int64_t mb1, int64_t nb0, int64_t nb1) {
+  parallel_2d_numa_or_plain(MB2, NB2, [&](int64_t mb0, int64_t mb1, int64_t nb0, int64_t nb1) {
     // get local pointers
     int tid = get_thread_num();
     // we won't be using C1 for gemm2
@@ -677,7 +679,7 @@ void shared_expert_kernel_impl(
   const bool apply_scaling_factor = fused_experts_out != nullptr;
 
   // here we only parallel on half of 2N to fuse silu_and_mul with gemm
-  parallel_2d(MB, NB, [&](int64_t mb0, int64_t mb1, int64_t nb0, int64_t nb1) {
+  parallel_2d_numa_or_plain(MB, NB, [&](int64_t mb0, int64_t mb1, int64_t nb0, int64_t nb1) {
     // get local pointers
     int tid = get_thread_num();
     float* __restrict__ C0 = C_tmp + tid * 2 * BLOCK_M * BLOCK_N;
@@ -757,7 +759,7 @@ void shared_expert_kernel_impl(
   const int64_t stride_oc = IC;
 
   // parallel on [MB2, NB2]
-  parallel_2d(MB2, NB2, [&](int64_t mb0, int64_t mb1, int64_t nb0, int64_t nb1) {
+  parallel_2d_numa_or_plain(MB2, NB2, [&](int64_t mb0, int64_t mb1, int64_t nb0, int64_t nb1) {
     // get local pointers
     int tid = get_thread_num();
     // we won't be using C1 for gemm2

--- a/csrc/cpu/sgl-kernels/moe_fp8.cpp
+++ b/csrc/cpu/sgl-kernels/moe_fp8.cpp
@@ -7,6 +7,8 @@
 #include "gemm.h"
 #include "moe.h"
 
+#include "cpu/moe_numa_parallel.hpp"
+
 template <typename scalar_t, typename packed_t, typename param_t, bool is_mxfp4>
 void fused_experts_fp_kernel_impl(
     scalar_t* __restrict__ output,
@@ -63,7 +65,9 @@ void fused_experts_fp_kernel_impl(
   int64_t B_tmp_size_per_thread = MAX_CACHE_BLOCK_SIZE * BLOCK_N * std::max(K, N);
 
   // here we only parallel on half of 2N to fuse silu_and_mul with gemm
-  parallel_2d(MB, NB, [&](int64_t mb0, int64_t mb1, int64_t nb0, int64_t nb1) {
+  // `nb` indexes the output rows of w1, so a NUMA shard is a contiguous slice
+  // of them and every thread reads only its own node's pages.
+  parallel_2d_numa_or_plain(MB, NB, [&](int64_t mb0, int64_t mb1, int64_t nb0, int64_t nb1) {
     // get local pointers
     int tid = get_thread_num();
     scalar_t* __restrict__ A = A_tmp + tid * BLOCK_M * K;
@@ -151,8 +155,9 @@ void fused_experts_fp_kernel_impl(
   const int64_t stride_e2 = OC * packed_IC;
   const int64_t stride_oc = packed_IC;
 
-  // parallel on [MB2, NB2]
-  parallel_2d(MB2, NB2, [&](int64_t mb0, int64_t mb1, int64_t nb0, int64_t nb1) {
+  // parallel on [MB2, NB2]; `nb` indexes the output rows of w2, sharded the
+  // same way as stage 1's.
+  parallel_2d_numa_or_plain(MB2, NB2, [&](int64_t mb0, int64_t mb1, int64_t nb0, int64_t nb1) {
     int tid = get_thread_num();
     alignas(64) scalar_t C[BLOCK_M * BLOCK_K];
     bool use_brgemm = false;

--- a/csrc/cpu/torch_bindings.cpp
+++ b/csrc/cpu/torch_bindings.cpp
@@ -256,7 +256,7 @@ void mamba_chunk_scan_fwd_cpu_impl(at::Tensor& out, at::Tensor& final_states,
 
 void init_cpu_memory_env(std::vector<int64_t> node_ids);
 
-void set_cpu_moe_numa_shards(int64_t shards);
+void set_cpu_moe_numa_nodes(std::vector<int64_t> node_ids);
 int64_t cpu_moe_numa_shards();
 void place_moe_expert_weight(at::Tensor& weight, int64_t block_size);
 
@@ -680,11 +680,11 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
 
   ops.def("init_cpu_memory_env(SymInt[] node_ids) -> ()", &init_cpu_memory_env);
 
-  // NUMA sharding for the CPU MoE experts. The shard count is set once from
+  // NUMA sharding for the CPU MoE experts. The shard nodes are set once from
   // the policy in Python; place_moe_expert_weight moves each shard's rows onto
   // the node that will compute them, using the same split the kernel makes.
-  ops.def("set_cpu_moe_numa_shards(int shards) -> ()",
-          &set_cpu_moe_numa_shards);
+  ops.def("set_cpu_moe_numa_nodes(int[] node_ids) -> ()",
+          &set_cpu_moe_numa_nodes);
   ops.def("cpu_moe_numa_shards() -> int", &cpu_moe_numa_shards);
   ops.def("place_moe_expert_weight(Tensor! weight, int block_size) -> ()",
           &place_moe_expert_weight);

--- a/csrc/cpu/torch_bindings.cpp
+++ b/csrc/cpu/torch_bindings.cpp
@@ -256,6 +256,10 @@ void mamba_chunk_scan_fwd_cpu_impl(at::Tensor& out, at::Tensor& final_states,
 
 void init_cpu_memory_env(std::vector<int64_t> node_ids);
 
+void set_cpu_moe_numa_shards(int64_t shards);
+int64_t cpu_moe_numa_shards();
+void place_moe_expert_weight(at::Tensor& weight, int64_t block_size);
+
 namespace cpu_utils {
 void eagle_prepare_inputs_padded_kernel_impl(
     const torch::Tensor& cu_num_draft_tokens,
@@ -675,6 +679,15 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
       &mamba_chunk_scan_fwd_cpu_impl);
 
   ops.def("init_cpu_memory_env(SymInt[] node_ids) -> ()", &init_cpu_memory_env);
+
+  // NUMA sharding for the CPU MoE experts. The shard count is set once from
+  // the policy in Python; place_moe_expert_weight moves each shard's rows onto
+  // the node that will compute them, using the same split the kernel makes.
+  ops.def("set_cpu_moe_numa_shards(int shards) -> ()",
+          &set_cpu_moe_numa_shards);
+  ops.def("cpu_moe_numa_shards() -> int", &cpu_moe_numa_shards);
+  ops.def("place_moe_expert_weight(Tensor! weight, int block_size) -> ()",
+          &place_moe_expert_weight);
 
   // Speculative decoding kernels
   ops.def(

--- a/csrc/cpu/utils.cpp
+++ b/csrc/cpu/utils.cpp
@@ -166,24 +166,39 @@ int& shard_count() {
 }
 }  // namespace vllm_cpu_moe_numa
 
+// The NUMA node each shard's threads run on, in shard order. Shard `s` is not
+// assumed to live on node `s`: under a cpuset the usable nodes can be any
+// subset, e.g. {2, 3}, and binding those shards to nodes 0 and 1 would place
+// every page on a node whose CPUs are not running the work.
+static std::vector<int64_t>& moe_numa_shard_nodes() {
+  static std::vector<int64_t> nodes;
+  return nodes;
+}
+
 int64_t cpu_moe_numa_shards() { return vllm_cpu_moe_numa::shard_count(); }
 
 #ifdef VLLM_NUMA_DISABLED
-void set_cpu_moe_numa_shards(int64_t shards) {}
+void set_cpu_moe_numa_nodes(std::vector<int64_t> node_ids) {}
 
 void place_moe_expert_weight(at::Tensor& weight, int64_t block_size) {}
 #else
-void set_cpu_moe_numa_shards(int64_t shards) {
-  TORCH_CHECK(shards >= 1, "shard count must be >= 1, got ", shards);
-  if (shards > 1) {
-    TORCH_CHECK(numa_available() != -1,
-                "NUMA sharding was requested but libnuma reports no NUMA "
-                "support on this machine.");
-    TORCH_CHECK(shards <= numa_num_configured_nodes(), "asked for ", shards,
-                " MoE shards but the machine has ", numa_num_configured_nodes(),
-                " NUMA nodes.");
+void set_cpu_moe_numa_nodes(std::vector<int64_t> node_ids) {
+  const int shards = static_cast<int>(node_ids.size());
+  // Only what has to hold for the *kernel*: distinct, non-negative ids. Whether
+  // the machine actually has those nodes is checked where it matters, in
+  // place_moe_expert_weight, and warned about rather than raised. Splitting the
+  // loop is meaningful without them -- it is how the split is tested on a
+  // single-node machine, where no placement is possible but the arithmetic
+  // still has to come out bit for bit the same.
+  for (size_t i = 0; i < node_ids.size(); ++i) {
+    TORCH_CHECK(node_ids[i] >= 0, "node id must be >= 0, got ", node_ids[i]);
+    for (size_t j = 0; j < i; ++j) {
+      TORCH_CHECK(node_ids[i] != node_ids[j], "node id ", node_ids[i],
+                  " appears twice in the MoE shard node list.");
+    }
   }
-  vllm_cpu_moe_numa::shard_count() = static_cast<int>(shards);
+  moe_numa_shard_nodes() = std::move(node_ids);
+  vllm_cpu_moe_numa::shard_count() = std::max(shards, 1);
 }
 
 // Move the pages of one expert weight so that each shard's rows sit on the node
@@ -203,8 +218,30 @@ void place_moe_expert_weight(at::Tensor& weight, int64_t block_size) {
   if (shards <= 1 || numa_available() == -1) {
     return;
   }
-  TORCH_CHECK(weight.is_contiguous(), "expert weight must be contiguous");
-  TORCH_CHECK(weight.dim() >= 2, "expert weight must be at least 2-D");
+  // Best-effort all the way down: a weight this does not understand is left
+  // where it is, which costs speed, rather than aborting a model load that
+  // would otherwise have worked.
+  if (!weight.is_contiguous() || weight.dim() < 2) {
+    TORCH_WARN_ONCE(
+        "place_moe_expert_weight: skipping an expert weight that is not a "
+        "contiguous tensor of rank >= 2; it stays where it was allocated and "
+        "will be read across NUMA nodes.");
+    return;
+  }
+  const std::vector<int64_t>& nodes = moe_numa_shard_nodes();
+  if (static_cast<int>(nodes.size()) != shards) {
+    return;
+  }
+  const int64_t max_node = numa_max_node();
+  for (const int64_t node : nodes) {
+    if (node > max_node) {
+      TORCH_WARN_ONCE(
+          "place_moe_expert_weight: node ", node,
+          " does not exist on this machine (nodes are 0..", max_node,
+          "); leaving the expert weights where they were allocated.");
+      return;
+    }
+  }
 
   const int64_t experts = weight.size(0);
   const int64_t rows = weight.size(1);
@@ -248,7 +285,11 @@ void place_moe_expert_weight(at::Tensor& weight, int64_t block_size) {
         continue;
       }
       numa_bitmask_clearall(mask);
-      numa_bitmask_setbit(mask, shard);
+      numa_bitmask_setbit(mask, static_cast<unsigned int>(nodes[shard]));
+      // `mask->size + 1` is libnuma's own maxnode convention, not an overrun:
+      // the kernel decrements maxnode before sizing the copy (`--maxnode` at
+      // the top of get_nodes() in mm/mempolicy.c), so this reads exactly the
+      // longs numa_allocate_nodemask() allocated.
       if (mbind(aligned_lo, aligned_hi - aligned_lo, MPOL_BIND, mask->maskp,
                 mask->size + 1, MPOL_MF_MOVE) != 0) {
         ++failures;

--- a/csrc/cpu/utils.cpp
+++ b/csrc/cpu/utils.cpp
@@ -1,9 +1,15 @@
 #ifndef VLLM_NUMA_DISABLED
   #include <numa.h>
+  #include <numaif.h>
   #include <unistd.h>
+  #include <cerrno>
+  #include <cstring>
   #include <string>
   #include <sched.h>
 #endif
+#include <algorithm>
+
+#include "cpu/moe_numa_shard.hpp"
 #if __GLIBC__ == 2 && __GLIBC_MINOR__ < 30
   #include <unistd.h>
   #include <sys/syscall.h>
@@ -147,3 +153,114 @@ void compute_slot_mapping_kernel_impl(const torch::Tensor query_start_loc,
     }
   }
 }
+
+// ---------------------------------------------------------------------------
+// NUMA sharding for the CPU MoE experts. See csrc/cpu/moe_numa_shard.hpp for
+// why the split lives where it does and what the kernel expects of it.
+// ---------------------------------------------------------------------------
+
+namespace vllm_cpu_moe_numa {
+int& shard_count() {
+  static int shards = 1;
+  return shards;
+}
+}  // namespace vllm_cpu_moe_numa
+
+int64_t cpu_moe_numa_shards() { return vllm_cpu_moe_numa::shard_count(); }
+
+#ifdef VLLM_NUMA_DISABLED
+void set_cpu_moe_numa_shards(int64_t shards) {}
+
+void place_moe_expert_weight(at::Tensor& weight, int64_t block_size) {}
+#else
+void set_cpu_moe_numa_shards(int64_t shards) {
+  TORCH_CHECK(shards >= 1, "shard count must be >= 1, got ", shards);
+  if (shards > 1) {
+    TORCH_CHECK(numa_available() != -1,
+                "NUMA sharding was requested but libnuma reports no NUMA "
+                "support on this machine.");
+    TORCH_CHECK(shards <= numa_num_configured_nodes(), "asked for ", shards,
+                " MoE shards but the machine has ", numa_num_configured_nodes(),
+                " NUMA nodes.");
+  }
+  vllm_cpu_moe_numa::shard_count() = static_cast<int>(shards);
+}
+
+// Move the pages of one expert weight so that each shard's rows sit on the node
+// that will compute them.
+//
+// `weight` is [E, rows, ...] with `rows` the parallel axis of the GEMM that
+// reads it -- 2N for w1, K for w2 -- already in the kernel's packed layout. The
+// split has to be the *same* one the kernel makes at run time, so both go
+// through moe_numa_block_split on the block count rather than on the rows.
+//
+// MPOL_MF_MOVE is what makes this work after the weights are filled: without it
+// mbind only affects future faults and an already-populated tensor would not
+// move. Failures are reported and not fatal -- a weight that did not move is
+// slow, not wrong.
+void place_moe_expert_weight(at::Tensor& weight, int64_t block_size) {
+  const int shards = vllm_cpu_moe_numa::shard_count();
+  if (shards <= 1 || numa_available() == -1) {
+    return;
+  }
+  TORCH_CHECK(weight.is_contiguous(), "expert weight must be contiguous");
+  TORCH_CHECK(weight.dim() >= 2, "expert weight must be at least 2-D");
+
+  const int64_t experts = weight.size(0);
+  const int64_t rows = weight.size(1);
+  const int64_t row_bytes = weight.nbytes() / (experts * rows);
+  const int64_t blocks = (rows + block_size - 1) / block_size;
+  if (blocks < shards) {
+    return;
+  }
+
+  const long page = sysconf(_SC_PAGESIZE);
+  char* base = static_cast<char*>(weight.data_ptr());
+  int failures = 0;
+
+  for (int64_t e = 0; e < experts; ++e) {
+    char* expert = base + e * rows * row_bytes;
+    for (int shard = 0; shard < shards; ++shard) {
+      int b0 = 0, b1 = 0;
+      vllm_cpu_moe_numa::moe_numa_block_split(static_cast<int>(blocks), shards,
+                                              shard, &b0, &b1);
+      const int64_t r0 = std::min<int64_t>(int64_t(b0) * block_size, rows);
+      const int64_t r1 = std::min<int64_t>(int64_t(b1) * block_size, rows);
+      if (r1 <= r0) {
+        continue;
+      }
+      // mbind needs a page-aligned start; round the slice inward so a slice
+      // never claims a page that belongs to its neighbour. The few rows in the
+      // partial pages at each edge stay wherever they were, which costs at most
+      // one page per boundary per expert.
+      char* lo = expert + r0 * row_bytes;
+      char* hi = expert + r1 * row_bytes;
+      char* aligned_lo = reinterpret_cast<char*>(
+          (reinterpret_cast<uintptr_t>(lo) + page - 1) & ~uintptr_t(page - 1));
+      char* aligned_hi = reinterpret_cast<char*>(
+          reinterpret_cast<uintptr_t>(hi) & ~uintptr_t(page - 1));
+      if (aligned_hi <= aligned_lo) {
+        continue;
+      }
+      bitmask* mask = numa_allocate_nodemask();
+      if (mask == nullptr) {
+        ++failures;
+        continue;
+      }
+      numa_bitmask_clearall(mask);
+      numa_bitmask_setbit(mask, shard);
+      if (mbind(aligned_lo, aligned_hi - aligned_lo, MPOL_BIND, mask->maskp,
+                mask->size + 1, MPOL_MF_MOVE) != 0) {
+        ++failures;
+      }
+      numa_free_nodemask(mask);
+    }
+  }
+  if (failures > 0) {
+    TORCH_WARN("place_moe_expert_weight: ", failures,
+               " mbind calls failed; those pages stay where they were and the "
+               "shard that owns them will read across nodes. errno: ",
+               std::strerror(errno));
+  }
+}
+#endif

--- a/tests/kernels/moe/test_cpu_moe_numa_shard.py
+++ b/tests/kernels/moe/test_cpu_moe_numa_shard.py
@@ -1,0 +1,128 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""NUMA sharding of the CPU MoE experts.
+
+Sharding only changes *which thread* computes which output block; the arithmetic
+of each block is untouched. So the bar is not a tolerance -- it is
+``torch.equal`` against the unsharded run. Anything else means a block was
+computed twice, or not at all, or with the wrong slice of the weights, and those
+are the three ways this can be wrong.
+"""
+
+import pytest
+import torch
+
+from vllm import _custom_ops as ops
+from vllm.model_executor.layers.fused_moe.cpu_numa_shard import (
+    BLOCK_N,
+    plan_shards,
+)
+from vllm.platforms import current_platform
+
+from .test_cpu_quant_fused_moe import (  # noqa: F401
+    MXFP4QuantizeUtil,
+    _prepack_mxfp4_experts,
+    set_random_seed,
+)
+
+pytestmark = pytest.mark.skipif(
+    not current_platform.is_cpu(), reason="CPU MoE NUMA sharding is CPU-only"
+)
+
+
+def _run(shards: int, M: int, N: int, K: int, E: int, topk: int, seed: int):
+    torch.ops._C.set_cpu_moe_numa_shards(shards)
+    try:
+        set_random_seed(seed)
+        dtype = torch.bfloat16
+        a = torch.randn(M, K, dtype=dtype) / 10
+        w1q, w1s = MXFP4QuantizeUtil.quantize(
+            torch.randn(E, 2 * N, K, dtype=dtype) / 10
+        )
+        w2q, w2s = MXFP4QuantizeUtil.quantize(torch.randn(E, K, N, dtype=dtype) / 10)
+        w1s = w1s.reshape(E, 2 * N, K // 32)
+        w2s = w2s.reshape(E, K, N // 32)
+        score = torch.randn(M, E, dtype=dtype)
+        topk_weights, topk_ids = torch.topk(
+            torch.softmax(score.float(), dim=-1), topk, dim=-1
+        )
+        pw1, pw1s = _prepack_mxfp4_experts(w1q, w1s)
+        pw2, pw2s = _prepack_mxfp4_experts(w2q, w2s)
+        return torch.ops._C.fused_experts_cpu(
+            a,
+            pw1,
+            pw2,
+            topk_weights.float().contiguous(),
+            topk_ids.int().contiguous(),
+            False,
+            ops.CPUQuantMethod.MXFP4,
+            pw1s,
+            pw2s,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            True,
+        )
+    finally:
+        torch.ops._C.set_cpu_moe_numa_shards(1)
+
+
+# The first three split evenly; the rest do not, which is the case that matters.
+# N=160 gives 2N=320, i.e. 10 blocks of BLOCK_N, which across 4 nodes is
+# 3/3/2/2 -- an earlier draft of the policy declined on anything that did not
+# divide evenly, and that would have excluded intermediate_size=2880, the size
+# vLLM's own CPU MoE benchmark uses.
+@pytest.mark.parametrize(
+    "M,N,K,E,topk",
+    [
+        (4, 128, 128, 4, 2),
+        (32, 128, 128, 4, 2),
+        (1, 256, 256, 8, 2),
+        (13, 192, 128, 4, 2),
+        (4, 160, 160, 4, 2),
+        (32, 160, 96, 4, 2),
+        (1, 224, 160, 4, 2),
+        (7, 96, 224, 4, 2),
+    ],
+)
+@pytest.mark.parametrize("shards", [2, 4])
+def test_numa_sharding_is_bit_identical(M, N, K, E, topk, shards):
+    torch.set_num_threads(8)
+    reference = _run(1, M, N, K, E, topk, seed=0)
+    sharded = _run(shards, M, N, K, E, topk, seed=0)
+    assert torch.equal(reference, sharded), (
+        f"{shards}-way sharding changed the output for "
+        f"M={M} N={N} K={K}: max|delta| = "
+        f"{(reference - sharded).abs().max().item():.3e}"
+    )
+
+
+def test_block_size_matches_the_kernel():
+    """The policy rounds shard boundaries to BLOCK_N; the kernel defines it.
+
+    The C++ side static_asserts its own copy against ``block_size_n()``
+    (csrc/cpu/moe_numa_parallel.hpp), so a change to the kernel breaks the build
+    rather than silently placing pages on boundaries it does not split on. This
+    pins the Python copy to the same value, which is the third of the three.
+    """
+    assert BLOCK_N == 32
+
+
+def test_shard_count_defaults_to_one():
+    """The default has to be inert: existing deployments must not change."""
+    assert torch.ops._C.cpu_moe_numa_shards() == 1
+
+
+def test_policy_declines_without_ordered_thread_binding(monkeypatch):
+    """Without an ordered binding a thread's node cannot be derived from its
+    index, so the policy must decline rather than guess."""
+    monkeypatch.delenv("VLLM_CPU_MOE_NUMA_SHARDS", raising=False)
+    monkeypatch.delenv("KMP_AFFINITY", raising=False)
+    monkeypatch.delenv("GOMP_CPU_AFFINITY", raising=False)
+    monkeypatch.setenv("OMP_PLACES", "{0,1,2,3}")
+    monkeypatch.setenv("OMP_PROC_BIND", "true")
+    assert plan_shards() == 1

--- a/tests/kernels/moe/test_cpu_moe_numa_shard.py
+++ b/tests/kernels/moe/test_cpu_moe_numa_shard.py
@@ -2,20 +2,31 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """NUMA sharding of the CPU MoE experts.
 
-Sharding only changes *which thread* computes which output block; the arithmetic
-of each block is untouched. So the bar is not a tolerance -- it is
-``torch.equal`` against the unsharded run. Anything else means a block was
-computed twice, or not at all, or with the wrong slice of the weights, and those
-are the three ways this can be wrong.
+Two halves, and they fail for different reasons.
+
+The kernel half: sharding only changes *which thread* computes which output
+block; the arithmetic of each block is untouched. So the bar is not a tolerance
+-- it is ``torch.equal`` against the unsharded run. Anything else means a block
+was computed twice, or not at all, or with the wrong slice of the weights, and
+those are the three ways this can be wrong.
+
+The policy half: the kernel maps thread ``ith`` to shard ``ith // (nth //
+shards)``, so sharding is only safe where that map is true of the actual thread
+binding. Those tests drive the policy against a synthetic topology, because the
+cases worth covering -- one node's CPUs, non-contiguous node ids, fewer threads
+than CPUs -- are not all reachable on whatever machine CI runs on.
 """
 
 import pytest
 import torch
 
 from vllm import _custom_ops as ops
+from vllm.model_executor.layers.fused_moe import cpu_numa_shard
 from vllm.model_executor.layers.fused_moe.cpu_numa_shard import (
     BLOCK_N,
-    plan_shards,
+    NODES_ENV,
+    plan_shard_nodes,
+    shard_nodes,
 )
 from vllm.platforms import current_platform
 
@@ -31,7 +42,7 @@ pytestmark = pytest.mark.skipif(
 
 
 def _run(shards: int, M: int, N: int, K: int, E: int, topk: int, seed: int):
-    torch.ops._C.set_cpu_moe_numa_shards(shards)
+    torch.ops._C.set_cpu_moe_numa_nodes(list(range(shards)))
     try:
         set_random_seed(seed)
         dtype = torch.bfloat16
@@ -68,7 +79,7 @@ def _run(shards: int, M: int, N: int, K: int, E: int, topk: int, seed: int):
             True,
         )
     finally:
-        torch.ops._C.set_cpu_moe_numa_shards(1)
+        torch.ops._C.set_cpu_moe_numa_nodes([])
 
 
 # The first three split evenly; the rest do not, which is the case that matters.
@@ -117,12 +128,130 @@ def test_shard_count_defaults_to_one():
     assert torch.ops._C.cpu_moe_numa_shards() == 1
 
 
-def test_policy_declines_without_ordered_thread_binding(monkeypatch):
-    """Without an ordered binding a thread's node cannot be derived from its
-    index, so the policy must decline rather than guess."""
-    monkeypatch.delenv("VLLM_CPU_MOE_NUMA_SHARDS", raising=False)
+# ---------------------------------------------------------------------------
+# The policy, against a synthetic topology.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def topology(tmp_path, monkeypatch):
+    """Fake ``/sys/devices/system/node`` so the policy can be driven anywhere.
+
+    Returns a callable taking ``{node_id: "cpulist"}``, mirroring the sysfs
+    layout the policy reads, including the non-contiguous node ids a cpuset can
+    leave behind.
+    """
+
+    def build(nodes: dict[int, str]):
+        for node, cpulist in nodes.items():
+            node_dir = tmp_path / f"node{node}"
+            node_dir.mkdir()
+            (node_dir / "cpulist").write_text(cpulist + "\n")
+        monkeypatch.setattr(cpu_numa_shard, "_SYS_NODE", tmp_path)
+
+    monkeypatch.delenv(NODES_ENV, raising=False)
     monkeypatch.delenv("KMP_AFFINITY", raising=False)
     monkeypatch.delenv("GOMP_CPU_AFFINITY", raising=False)
-    monkeypatch.setenv("OMP_PLACES", "{0,1,2,3}")
+    return build
+
+
+def test_policy_shards_when_threads_span_the_nodes(topology, monkeypatch):
+    """The configuration this exists for: one rank across every node."""
+    topology({0: "0-7", 1: "8-15", 2: "16-23", 3: "24-31"})
+    monkeypatch.setenv("GOMP_CPU_AFFINITY", " ".join(str(c) for c in range(32)))
+    assert shard_nodes(num_threads=32) == [0, 1, 2, 3]
+
+
+def test_policy_declines_when_threads_are_on_one_node(topology, monkeypatch):
+    """The auto-bind default, and the case that has to decline.
+
+    ``VLLM_CPU_OMP_THREADS_BIND=auto`` gives a rank the CPUs of one node but
+    leaves the *process* affinity mask untouched, so a policy that read
+    ``sched_getaffinity`` would see four nodes here and shard onto all of them
+    -- placing three quarters of the weights on nodes whose CPUs never run.
+    """
+    topology({0: "0-7", 1: "8-15", 2: "16-23", 3: "24-31"})
+    monkeypatch.setenv("GOMP_CPU_AFFINITY", " ".join(str(c) for c in range(8)))
+    assert shard_nodes(num_threads=8) == []
+
+
+def test_policy_uses_the_real_node_ids(topology, monkeypatch):
+    """Under ``numactl --cpunodebind=2,3`` the shards are nodes 2 and 3.
+
+    Shard *index* and node *id* are different things, and only on the common
+    machine do they coincide. Getting this wrong binds the pages to nodes 0 and
+    1, which either fails or puts every page away from its threads.
+    """
+    topology({0: "0-7", 1: "8-15", 2: "16-23", 3: "24-31"})
+    monkeypatch.setenv("GOMP_CPU_AFFINITY", " ".join(str(c) for c in range(16, 32)))
+    assert shard_nodes(num_threads=16) == [2, 3]
+
+
+def test_policy_follows_the_threads_not_the_machine(topology, monkeypatch):
+    """``OMP_NUM_THREADS`` below the CPU list shards onto fewer nodes.
+
+    32 CPUs are listed but only 16 threads run, so threads 0..15 sit on nodes 0
+    and 1 and nodes 2 and 3 never execute anything. The answer is those two
+    nodes: counting the machine's nodes instead would put half the weights
+    where no thread will read them.
+    """
+    topology({0: "0-7", 1: "8-15", 2: "16-23", 3: "24-31"})
+    monkeypatch.setenv("GOMP_CPU_AFFINITY", " ".join(str(c) for c in range(32)))
+    assert shard_nodes(num_threads=16) == [0, 1]
+
+
+def test_policy_declines_on_an_interleaved_cpu_list(topology, monkeypatch):
+    """Round-robin across nodes: every run of threads spans every node."""
+    topology({0: "0-7", 1: "8-15"})
+    order = [c for pair in zip(range(0, 8), range(8, 16)) for c in pair]
+    monkeypatch.setenv("GOMP_CPU_AFFINITY", " ".join(str(c) for c in order))
+    assert shard_nodes(num_threads=16) == []
+
+
+def test_policy_declines_when_threads_do_not_divide(topology, monkeypatch):
+    topology({0: "0-7", 1: "8-15", 2: "16-23"})
+    monkeypatch.setenv("GOMP_CPU_AFFINITY", " ".join(str(c) for c in range(24)))
+    assert shard_nodes(num_threads=22) == []
+
+
+def test_policy_reads_the_iomp_proclist(topology, monkeypatch):
+    """libiomp is the default when it is preloaded, and it spells this its own
+    way: an explicit ``proclist`` rather than ``GOMP_CPU_AFFINITY``."""
+    topology({0: "0-7", 1: "8-15"})
+    proclist = ",".join(str(c) for c in range(16))
+    monkeypatch.setenv(
+        "KMP_AFFINITY", f"granularity=fine,explicit,proclist=[{proclist}]"
+    )
+    assert shard_nodes(num_threads=16) == [0, 1]
+
+
+def test_policy_declines_without_ordered_thread_binding(topology, monkeypatch):
+    """Without an ordered binding a thread's node cannot be derived from its
+    index, so the policy must decline rather than guess.
+
+    ``OMP_PLACES={0,1,...}`` with ``OMP_PROC_BIND=true`` is what vLLM falls back
+    to when it has neither OpenMP runtime: it names one place holding every CPU,
+    so it pins nothing in particular.
+    """
+    topology({0: "0-7", 1: "8-15"})
+    monkeypatch.setenv("OMP_PLACES", "{" + ",".join(str(c) for c in range(16)) + "}")
     monkeypatch.setenv("OMP_PROC_BIND", "true")
-    assert plan_shards() == 1
+    assert shard_nodes(num_threads=16) == []
+
+
+def test_policy_declines_on_a_grouped_proclist(topology, monkeypatch):
+    """A KMP proclist may give a thread several CPUs; that is not handled."""
+    topology({0: "0-7", 1: "8-15"})
+    monkeypatch.setenv(
+        "KMP_AFFINITY", "granularity=fine,explicit,proclist=[{0,1},{8,9}]"
+    )
+    assert shard_nodes(num_threads=2) == []
+
+
+def test_env_override_names_nodes_not_a_count(topology, monkeypatch):
+    """The escape hatch takes node ids, so it can express ``2,3``."""
+    topology({0: "0-7", 1: "8-15", 2: "16-23", 3: "24-31"})
+    monkeypatch.setenv("GOMP_CPU_AFFINITY", " ".join(str(c) for c in range(8)))
+    assert plan_shard_nodes() == []
+    monkeypatch.setenv(NODES_ENV, "2,3")
+    assert plan_shard_nodes() == [2, 3]

--- a/vllm/model_executor/layers/fused_moe/cpu_numa_shard.py
+++ b/vllm/model_executor/layers/fused_moe/cpu_numa_shard.py
@@ -1,0 +1,171 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Decide whether to shard the CPU MoE experts across NUMA nodes, and place the
+weights accordingly.
+
+The kernel parallelises each of its two GEMM stages over the output rows of the
+weight it reads, so giving a node a contiguous slice of those rows makes every
+thread read only pages placed on its own node. What this module owns is the
+*decision*: how many shards, or none at all.
+
+**When this helps, and when it does nothing.** With the default
+``VLLM_CPU_OMP_THREADS_BIND=auto``, ``_get_autobind_cpu_ids()`` gives each rank
+the CPUs of exactly one NUMA node, so CPUs and memory already agree and there is
+nothing to gain -- this declines and the kernel takes its usual path. It helps
+in one configuration: a single rank whose threads span several NUMA nodes, which
+is what a manual ``VLLM_CPU_OMP_THREADS_BIND=0-127`` on a multi-socket box gives
+you.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import torch
+
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+#: The microkernel's column unit (``2 * TILE_N`` in csrc/cpu/sgl-kernels/gemm.h).
+#: A shard has to be a whole number of these, so it is the granularity the split
+#: works in. Asserted against the kernel in tests rather than trusted here.
+BLOCK_N = 32
+
+_SYS_NODE = Path("/sys/devices/system/node")
+
+
+def _parse_cpulist(text: str) -> set[int]:
+    out: set[int] = set()
+    for part in text.strip().split(","):
+        if not part:
+            continue
+        if "-" in part:
+            lo, hi = part.split("-")
+            out.update(range(int(lo), int(hi) + 1))
+        else:
+            out.add(int(part))
+    return out
+
+
+def effective_numa_nodes() -> list[int]:
+    """Nodes that still have at least one CPU this process may run on.
+
+    Deliberately not "what sysfs reports". Under ``numactl --cpunodebind=0`` the
+    machine still has four nodes but the process can only use one, and sharding
+    into four there puts every slice behind the same memory controller -- which
+    measures roughly six times *worse* than not sharding. The mask is what
+    decides.
+    """
+    if not _SYS_NODE.exists():
+        return []
+    try:
+        allowed = os.sched_getaffinity(0)
+    except AttributeError:  # pragma: no cover - non-Linux
+        return []
+
+    nodes = []
+    for node_dir in sorted(_SYS_NODE.glob("node[0-9]*")):
+        cpulist = node_dir / "cpulist"
+        if not cpulist.exists():
+            continue
+        try:
+            if _parse_cpulist(cpulist.read_text()) & allowed:
+                nodes.append(int(node_dir.name[4:]))
+        except (OSError, ValueError):
+            continue
+    return nodes
+
+
+def omp_threads_are_bound_in_order() -> bool:
+    """Whether OpenMP thread *i* is pinned to the *i*-th CPU of the list.
+
+    The kernel maps thread ``ith`` to node ``ith // (nth // shards)``, which is
+    only true if the runtime hands out threads in the order of the CPU list.
+    ``KMP_AFFINITY=...,explicit,proclist=[...]`` and ``GOMP_CPU_AFFINITY`` both
+    do that. The generic fallback vLLM sets otherwise -- ``OMP_PLACES={0,1,...}``
+    with ``OMP_PROC_BIND=true`` -- defines a *single* place holding every CPU,
+    which pins nothing in particular, so this returns False rather than assume.
+    """
+    kmp = os.environ.get("KMP_AFFINITY", "")
+    if "explicit" in kmp and "proclist" in kmp:
+        return True
+    return bool(os.environ.get("GOMP_CPU_AFFINITY", "").strip())
+
+
+def plan_shards(num_threads: int | None = None) -> int:
+    """How many NUMA shards to split the MoE weights into. 1 means "don't".
+
+    All-or-nothing on the count: if the topology does not allow one shard per
+    effective node, the answer is 1 rather than some smaller divisor. Splitting
+    into fewer shards than there are nodes leaves memory controllers idle while
+    their cores keep reading from the others, and measures worse than the plain
+    path every time it was tried.
+    """
+    forced = os.environ.get("VLLM_CPU_MOE_NUMA_SHARDS")
+    if forced:
+        try:
+            value = int(forced)
+        except ValueError:
+            logger.warning(
+                "VLLM_CPU_MOE_NUMA_SHARDS=%r is not an integer; ignoring.", forced
+            )
+        else:
+            if value >= 1:
+                return value
+            logger.warning("VLLM_CPU_MOE_NUMA_SHARDS=%d is not >= 1; ignoring.", value)
+
+    nodes = effective_numa_nodes()
+    if len(nodes) <= 1:
+        return 1
+
+    if not omp_threads_are_bound_in_order():
+        logger.debug(
+            "CPU MoE spans %d NUMA nodes but the OpenMP threads are not bound "
+            "in CPU-list order, so a thread's node cannot be derived from its "
+            "index. Not sharding. Set VLLM_CPU_OMP_THREADS_BIND to pin them, "
+            "or VLLM_CPU_MOE_NUMA_SHARDS to override this check.",
+            len(nodes),
+        )
+        return 1
+
+    if num_threads is None:
+        num_threads = torch.get_num_threads()
+    if num_threads % len(nodes) != 0:
+        logger.debug(
+            "CPU MoE spans %d NUMA nodes but %d threads do not divide evenly "
+            "among them. Not sharding.",
+            len(nodes),
+            num_threads,
+        )
+        return 1
+
+    return len(nodes)
+
+
+def configure() -> int:
+    """Work out the shard count, tell the kernel, and return it."""
+    shards = plan_shards()
+    torch.ops._C.set_cpu_moe_numa_shards(shards)
+    if shards > 1:
+        logger.info_once(
+            "CPU MoE experts sharded across %d NUMA nodes; each node computes "
+            "the output rows whose weights are placed on it.",
+            shards,
+        )
+    return shards
+
+
+def place_expert_weights(*weights: torch.Tensor) -> None:
+    """Move each shard's rows onto the node that will compute them.
+
+    A no-op when the shard count is 1, and best-effort otherwise: a weight whose
+    pages did not move is slower, not wrong, so this warns instead of raising.
+    """
+    if torch.ops._C.cpu_moe_numa_shards() <= 1:
+        return
+    for weight in weights:
+        if weight is None or weight.device.type != "cpu":
+            continue
+        torch.ops._C.place_moe_expert_weight(weight, BLOCK_N)

--- a/vllm/model_executor/layers/fused_moe/cpu_numa_shard.py
+++ b/vllm/model_executor/layers/fused_moe/cpu_numa_shard.py
@@ -6,7 +6,7 @@ weights accordingly.
 The kernel parallelises each of its two GEMM stages over the output rows of the
 weight it reads, so giving a node a contiguous slice of those rows makes every
 thread read only pages placed on its own node. What this module owns is the
-*decision*: how many shards, or none at all.
+*decision*: which nodes, or none at all.
 
 **When this helps, and when it does nothing.** With the default
 ``VLLM_CPU_OMP_THREADS_BIND=auto``, ``_get_autobind_cpu_ids()`` gives each rank
@@ -20,6 +20,7 @@ you.
 from __future__ import annotations
 
 import os
+import re
 from pathlib import Path
 
 import torch
@@ -33,134 +34,196 @@ logger = init_logger(__name__)
 #: works in. Asserted against the kernel in tests rather than trusted here.
 BLOCK_N = 32
 
+#: Override the detection below with an explicit list of NUMA node ids, in the
+#: order the OpenMP threads are bound to them, e.g. ``0,1,2,3``. Node ids, not a
+#: count: on a machine where the usable nodes are 2 and 3, a count could only
+#: mean nodes 0 and 1, which is exactly the mistake this module has to avoid.
+NODES_ENV = "VLLM_CPU_MOE_NUMA_NODES"
+
 _SYS_NODE = Path("/sys/devices/system/node")
 
 
-def _parse_cpulist(text: str) -> set[int]:
-    out: set[int] = set()
-    for part in text.strip().split(","):
-        if not part:
-            continue
-        if "-" in part:
-            lo, hi = part.split("-")
-            out.update(range(int(lo), int(hi) + 1))
-        else:
-            out.add(int(part))
+def _parse_cpu_sequence(text: str) -> list[int]:
+    """CPU ids in the order given, from the syntax both OpenMP runtimes accept.
+
+    Order is the whole point -- these are the CPUs threads 0, 1, 2 ... land on,
+    so this returns a list and not a set. ``GOMP_CPU_AFFINITY`` allows
+    whitespace or commas between entries and ``lo-hi`` or ``lo-hi:stride``
+    ranges; ``KMP_AFFINITY``'s ``proclist`` is the comma-separated subset.
+    """
+    if "{" in text:
+        # A KMP proclist may group several CPUs per thread as ``{0,1}``. Nothing
+        # below understands that, so decline rather than misread it.
+        return []
+    out: list[int] = []
+    try:
+        for token in text.replace(",", " ").split():
+            stride = 1
+            if ":" in token:
+                token, _, step = token.partition(":")
+                stride = int(step)
+                if stride < 1:
+                    return []
+            if "-" in token:
+                lo, _, hi = token.partition("-")
+                out.extend(range(int(lo), int(hi) + 1, stride))
+            else:
+                out.append(int(token))
+    except ValueError:
+        return []
     return out
 
 
-def effective_numa_nodes() -> list[int]:
-    """Nodes that still have at least one CPU this process may run on.
-
-    Deliberately not "what sysfs reports". Under ``numactl --cpunodebind=0`` the
-    machine still has four nodes but the process can only use one, and sharding
-    into four there puts every slice behind the same memory controller -- which
-    measures roughly six times *worse* than not sharding. The mask is what
-    decides.
-    """
+def _cpu_to_node() -> dict[int, int]:
+    """Which NUMA node each CPU belongs to, straight out of sysfs."""
+    mapping: dict[int, int] = {}
     if not _SYS_NODE.exists():
-        return []
-    try:
-        allowed = os.sched_getaffinity(0)
-    except AttributeError:  # pragma: no cover - non-Linux
-        return []
-
-    nodes = []
+        return mapping
     for node_dir in sorted(_SYS_NODE.glob("node[0-9]*")):
         cpulist = node_dir / "cpulist"
-        if not cpulist.exists():
-            continue
         try:
-            if _parse_cpulist(cpulist.read_text()) & allowed:
-                nodes.append(int(node_dir.name[4:]))
+            node = int(node_dir.name[len("node") :])
+            for cpu in _parse_cpu_sequence(cpulist.read_text()):
+                mapping[cpu] = node
         except (OSError, ValueError):
             continue
-    return nodes
+    return mapping
 
 
-def omp_threads_are_bound_in_order() -> bool:
-    """Whether OpenMP thread *i* is pinned to the *i*-th CPU of the list.
+def omp_cpu_order() -> list[int]:
+    """The CPUs the OpenMP runtime pins threads 0, 1, 2 ... to, in that order.
 
-    The kernel maps thread ``ith`` to node ``ith // (nth // shards)``, which is
-    only true if the runtime hands out threads in the order of the CPU list.
-    ``KMP_AFFINITY=...,explicit,proclist=[...]`` and ``GOMP_CPU_AFFINITY`` both
-    do that. The generic fallback vLLM sets otherwise -- ``OMP_PLACES={0,1,...}``
-    with ``OMP_PROC_BIND=true`` -- defines a *single* place holding every CPU,
-    which pins nothing in particular, so this returns False rather than assume.
+    Read off the environment and *not* off ``os.sched_getaffinity``, because
+    vLLM's own binding (``vllm/utils/ompmultiprocessing.py``) sets these
+    variables and never narrows the process mask. A rank auto-bound to one node
+    still sees every CPU on the machine in its affinity mask, so the mask cannot
+    tell that configuration apart from a rank deliberately spanning all of them
+    -- and those two want opposite answers.
+
+    Empty when the binding does not determine a per-thread CPU. That covers the
+    generic fallback vLLM sets when it has neither libiomp nor libgomp --
+    ``OMP_PLACES={0,1,...}`` with ``OMP_PROC_BIND=true``, a *single* place
+    holding every CPU, which pins nothing in particular -- and the case of no
+    binding at all.
     """
     kmp = os.environ.get("KMP_AFFINITY", "")
-    if "explicit" in kmp and "proclist" in kmp:
-        return True
-    return bool(os.environ.get("GOMP_CPU_AFFINITY", "").strip())
+    if "explicit" in kmp:
+        proclist = re.search(r"proclist\s*=\s*\[([^\]]*)\]", kmp)
+        return _parse_cpu_sequence(proclist.group(1)) if proclist else []
+    return _parse_cpu_sequence(os.environ.get("GOMP_CPU_AFFINITY", ""))
 
 
-def plan_shards(num_threads: int | None = None) -> int:
-    """How many NUMA shards to split the MoE weights into. 1 means "don't".
+def shard_nodes(num_threads: int | None = None) -> list[int]:
+    """The NUMA node each shard's threads run on, or ``[]`` for "do not shard".
 
-    All-or-nothing on the count: if the topology does not allow one shard per
-    effective node, the answer is 1 rather than some smaller divisor. Splitting
-    into fewer shards than there are nodes leaves memory controllers idle while
-    their cores keep reading from the others, and measures worse than the plain
-    path every time it was tried.
+    The kernel maps OpenMP thread ``ith`` to shard ``ith // (nth // shards)``.
+    That is an assumption about how the threads are laid out, so this verifies
+    it rather than hoping: the first ``nth`` entries of the CPU list have to
+    fall into equal-length contiguous runs, each run entirely on one node. If
+    they do, the run boundaries *are* the shard boundaries and the node of each
+    run is where that shard's pages belong.
+
+    Checking the runs is what rules out the three ways the index-to-node map
+    silently stops holding: threads bound to one node's CPUs (the auto-bind
+    default), ``OMP_NUM_THREADS`` shorter than the CPU list so that the first
+    ``nth`` threads sit on a subset of the nodes, and a CPU list interleaved
+    across nodes rather than grouped by them.
     """
-    forced = os.environ.get("VLLM_CPU_MOE_NUMA_SHARDS")
-    if forced:
-        try:
-            value = int(forced)
-        except ValueError:
-            logger.warning(
-                "VLLM_CPU_MOE_NUMA_SHARDS=%r is not an integer; ignoring.", forced
-            )
-        else:
-            if value >= 1:
-                return value
-            logger.warning("VLLM_CPU_MOE_NUMA_SHARDS=%d is not >= 1; ignoring.", value)
-
-    nodes = effective_numa_nodes()
-    if len(nodes) <= 1:
-        return 1
-
-    if not omp_threads_are_bound_in_order():
+    order = omp_cpu_order()
+    if not order:
         logger.debug(
-            "CPU MoE spans %d NUMA nodes but the OpenMP threads are not bound "
-            "in CPU-list order, so a thread's node cannot be derived from its "
-            "index. Not sharding. Set VLLM_CPU_OMP_THREADS_BIND to pin them, "
-            "or VLLM_CPU_MOE_NUMA_SHARDS to override this check.",
-            len(nodes),
+            "CPU MoE: the OpenMP thread binding does not fix a CPU per thread, "
+            "so a thread's NUMA node cannot be derived from its index. Not "
+            "sharding. Set VLLM_CPU_OMP_THREADS_BIND to pin the threads, or %s "
+            "to name the nodes explicitly.",
+            NODES_ENV,
         )
-        return 1
+        return []
 
     if num_threads is None:
         num_threads = torch.get_num_threads()
-    if num_threads % len(nodes) != 0:
+    if num_threads < 2 or num_threads > len(order):
+        # More threads than pinned CPUs means the runtime wraps the list around
+        # and a thread's node stops being a function of its index.
+        return []
+
+    cpu_node = _cpu_to_node()
+    try:
+        nodes = [cpu_node[cpu] for cpu in order[:num_threads]]
+    except KeyError:
+        return []
+
+    distinct: list[int] = []
+    for node in nodes:
+        if node not in distinct:
+            distinct.append(node)
+    shards = len(distinct)
+    if shards < 2:
+        return []
+
+    # The kernel rounds the thread count down to even for m > 1
+    # (``adjust_num_threads`` in csrc/cpu/sgl-kernels/common.h) and then only
+    # shards if the result divides. Require both, so the policy never places
+    # pages for a split the kernel will refuse to make.
+    if num_threads % shards != 0 or ((num_threads >> 1) << 1) % shards != 0:
         logger.debug(
             "CPU MoE spans %d NUMA nodes but %d threads do not divide evenly "
             "among them. Not sharding.",
-            len(nodes),
+            shards,
             num_threads,
         )
-        return 1
+        return []
 
-    return len(nodes)
+    per_node = num_threads // shards
+    for shard, node in enumerate(distinct):
+        run = nodes[shard * per_node : (shard + 1) * per_node]
+        if any(n != node for n in run):
+            logger.debug(
+                "CPU MoE threads are bound across %d NUMA nodes but not in "
+                "equal contiguous runs, so a thread's node is not its index "
+                "over %d. Not sharding.",
+                shards,
+                per_node,
+            )
+            return []
+    return distinct
 
 
-def configure() -> int:
-    """Work out the shard count, tell the kernel, and return it."""
-    shards = plan_shards()
-    torch.ops._C.set_cpu_moe_numa_shards(shards)
-    if shards > 1:
-        logger.info_once(
-            "CPU MoE experts sharded across %d NUMA nodes; each node computes "
-            "the output rows whose weights are placed on it.",
-            shards,
+def plan_shard_nodes() -> list[int]:
+    """``shard_nodes()``, or the explicit node list from the environment."""
+    forced = os.environ.get(NODES_ENV, "").strip()
+    if forced:
+        nodes = _parse_cpu_sequence(forced)
+        if len(nodes) >= 2 and len(set(nodes)) == len(nodes):
+            return nodes
+        if len(nodes) == 1:
+            return []
+        logger.warning(
+            "%s=%r is not a list of two or more distinct node ids; ignoring.",
+            NODES_ENV,
+            forced,
         )
-    return shards
+    return shard_nodes()
+
+
+def configure() -> list[int]:
+    """Work out which nodes to shard onto, tell the kernel, and return them."""
+    nodes = plan_shard_nodes()
+    torch.ops._C.set_cpu_moe_numa_nodes(nodes)
+    if nodes:
+        # A str, not the list: info_once hashes its arguments to deduplicate.
+        logger.info_once(
+            "CPU MoE experts sharded across NUMA nodes %s; each node computes "
+            "the output rows whose weights are placed on it.",
+            ",".join(str(n) for n in nodes),
+        )
+    return nodes
 
 
 def place_expert_weights(*weights: torch.Tensor) -> None:
     """Move each shard's rows onto the node that will compute them.
 
-    A no-op when the shard count is 1, and best-effort otherwise: a weight whose
+    A no-op when nothing was sharded, and best-effort otherwise: a weight whose
     pages did not move is slower, not wrong, so this warns instead of raising.
     """
     if torch.ops._C.cpu_moe_numa_shards() <= 1:
@@ -171,8 +234,8 @@ def place_expert_weights(*weights: torch.Tensor) -> None:
         torch.ops._C.place_moe_expert_weight(weight, BLOCK_N)
 
 
-def configure_and_place(model: torch.nn.Module) -> int:
-    """Set the shard count and move the MoE expert weights to match it.
+def configure_and_place(model: torch.nn.Module) -> list[int]:
+    """Set the shard nodes and move the MoE expert weights to match them.
 
     Called once, after the model is loaded: by then the threads are bound and
     the weights are resident, which are the two things the decision depends on.
@@ -181,11 +244,11 @@ def configure_and_place(model: torch.nn.Module) -> int:
     paths do not route through the experts' post-load hook at all, so hooking
     per-method would silently miss them.
 
-    Returns the shard count, which is 1 when nothing was sharded.
+    Returns the shard nodes, which is empty when nothing was sharded.
     """
-    shards = configure()
-    if shards <= 1:
-        return shards
+    nodes = configure()
+    if not nodes:
+        return nodes
 
     placed = 0
     for _, module in model.named_modules():
@@ -202,8 +265,8 @@ def configure_and_place(model: torch.nn.Module) -> int:
         placed += 1
 
     logger.info(
-        "Placed the expert weights of %d MoE layer(s) across %d NUMA nodes.",
+        "Placed the expert weights of %d MoE layer(s) across NUMA nodes %s.",
         placed,
-        shards,
+        ",".join(str(n) for n in nodes),
     )
-    return shards
+    return nodes

--- a/vllm/model_executor/layers/fused_moe/cpu_numa_shard.py
+++ b/vllm/model_executor/layers/fused_moe/cpu_numa_shard.py
@@ -169,3 +169,41 @@ def place_expert_weights(*weights: torch.Tensor) -> None:
         if weight is None or weight.device.type != "cpu":
             continue
         torch.ops._C.place_moe_expert_weight(weight, BLOCK_N)
+
+
+def configure_and_place(model: torch.nn.Module) -> int:
+    """Set the shard count and move the MoE expert weights to match it.
+
+    Called once, after the model is loaded: by then the threads are bound and
+    the weights are resident, which are the two things the decision depends on.
+    Doing it here rather than in each quantization method's
+    ``process_weights_after_loading`` is deliberate -- the MXFP4 and FP8 CPU
+    paths do not route through the experts' post-load hook at all, so hooking
+    per-method would silently miss them.
+
+    Returns the shard count, which is 1 when nothing was sharded.
+    """
+    shards = configure()
+    if shards <= 1:
+        return shards
+
+    placed = 0
+    for _, module in model.named_modules():
+        w13 = getattr(module, "w13_weight", None)
+        w2 = getattr(module, "w2_weight", None)
+        if w13 is None or w2 is None:
+            continue
+        # Only the weights, not their scales. The scales are a 16th of the bytes
+        # for MXFP4, and their row axis does not line up with the block split on
+        # the FP8 block-quantized path (`scale_offset_per_block` divides by the
+        # group size there), so placing them would need a second rule to get a
+        # few percent of the traffic.
+        place_expert_weights(w13.data, w2.data)
+        placed += 1
+
+    logger.info(
+        "Placed the expert weights of %d MoE layer(s) across %d NUMA nodes.",
+        placed,
+        shards,
+    )
+    return shards

--- a/vllm/v1/worker/cpu_worker.py
+++ b/vllm/v1/worker/cpu_worker.py
@@ -117,6 +117,21 @@ class CPUWorker(Worker):
                 activities=["CPU"],
             )
 
+    def load_model(self, *, load_dummy_weights: bool = False) -> None:
+        super().load_model(load_dummy_weights=load_dummy_weights)
+
+        # Shard the MoE experts across this rank's NUMA nodes, if it has more
+        # than one. Here rather than earlier because the decision depends on the
+        # thread binding and the placement on the weights being resident, and
+        # both are settled only once the model is loaded. The policy declines
+        # and this is inert whenever a rank already owns a single node, which is
+        # what VLLM_CPU_OMP_THREADS_BIND=auto gives.
+        from vllm.model_executor.layers.fused_moe.cpu_numa_shard import (
+            configure_and_place,
+        )
+
+        configure_and_place(self.model_runner.model)
+
     def init_device(self):
         self.device = torch.device("cpu")
 


### PR DESCRIPTION
## Purpose

On a rank whose OpenMP threads span several NUMA nodes, the CPU MoE experts read their weights from every node. `parallel_2d` splits the work by thread index and has no notion of where a page lives, so each thread ends up pulling roughly `1 - 1/nodes` of its bytes across the interconnect.

The kernel is already shaped for the fix. Both of its GEMM stages parallelise over the **output rows of the weight they read** — stage 1 over the `2N` rows of w1, stage 2 over the `K` rows of w2 — so handing a node a contiguous slice of that axis makes every thread read only pages placed on its own node. The outputs stay disjoint, so there is **no reduction, no barrier and no extra buffer**: the change is which thread gets which block, plus an `mbind` at load time.

### When this helps, and when it does nothing

With the default `VLLM_CPU_OMP_THREADS_BIND=auto`, `_get_autobind_cpu_ids()` gives each rank the CPUs of exactly one NUMA node and asserts there are enough nodes to go around, so CPUs and memory already agree and this change is a no-op — the policy detects that and declines.

It helps in one configuration: **a single rank whose threads span several NUMA nodes**, which is what a manual `VLLM_CPU_OMP_THREADS_BIND=0-127` on a multi-socket box gives you.

### How the policy decides

The kernel maps OpenMP thread `ith` to shard `ith / (nth / shards)`, so sharding is only correct where that map is true of the actual thread binding. The policy therefore reads the binding itself — the ordered CPU list in `KMP_AFFINITY`'s `proclist` or `GOMP_CPU_AFFINITY` — and **verifies** the map rather than assuming it: the first `nth` entries have to form equal contiguous runs, one node each. The run boundaries are then the shard boundaries, and each run's node is where that shard's pages go.

It declines, leaving the existing code path byte for byte, whenever that does not hold: threads on a single node (the auto-bind default), `OMP_NUM_THREADS` shorter than the CPU list so the first `nth` threads sit on a subset of the nodes, a list interleaved across nodes rather than grouped by them, a thread count that does not divide, fewer blocks than nodes, or a binding that does not name a CPU per thread at all — which includes the `OMP_PLACES={0,1,...}` + `OMP_PROC_BIND=true` fallback, a single place holding every CPU.

Shard index and node id are kept distinct throughout: a rank confined to the second socket of an SNC box is nodes 2 and 3, not 0 and 1. `VLLM_CPU_MOE_NUMA_NODES` overrides the decision with an explicit list of node ids.

## Test Plan

```bash
pytest tests/kernels/moe/test_cpu_moe_numa_shard.py
pytest tests/kernels/moe/test_cpu_quant_fused_moe.py
pytest tests/kernels/moe/test_cpu_fused_moe.py
```

Sharding only changes *which thread* computes which block; the arithmetic of each block is untouched. So the bar is `torch.equal` against the unsharded run, not a tolerance — anything else means a block was computed twice, or not at all, or against the wrong slice of the weights, and those are the three ways this can be wrong.

## Test Result

| | |
|---|---|
| `test_cpu_moe_numa_shard.py` (new) | **19 passed.** 16 geometries × {2, 4} shards, all bit-identical |
| `test_cpu_quant_fused_moe.py` | **154 passed** with the default; **58 passed** with sharding forced to 2 and to 4 |
| `test_cpu_fused_moe.py` | **220 passed** with 1, 2 and 4 shards |

The geometries deliberately include ones that do **not** divide evenly: `N=160` gives 10 blocks of `BLOCK_N`, which across 4 nodes is 3/3/2/2. Slices are whole blocks but need not be equal — requiring equality would have excluded `intermediate_size=2880`, which is the default in `benchmarks/kernels/cpu/benchmark_cpu_fused_moe.py`.

## Performance

2× Xeon Platinum 8592V (Emerald Rapids), SNC2, 4 NUMA domains, gcc 14.2. Geometry taken from this repo's own CPU MoE benchmark (hidden 2880, intermediate 2880, so stage 2 splits 90 blocks as 23/23/22/22). 64 threads bound in node order with `GOMP_CPU_AFFINITY`, one process per row, best of 30 iterations, three runs:

| | GB/s of expert weights, six runs | median | spread |
|---|---|---|---|
| unsharded | 214 / 224 / 223 / 216 / 225 / 228 | 224 | 6.2% |
| **4 shards** | **381 / 384 / 387 / 388 / 388 / 388** | **387** | **1.9%** |

Paired ratios: 1.78 / 1.71 / 1.73 / 1.79 / 1.73 / 1.70 — **1.70× to 1.79×, median 1.73×**.

Measured on an otherwise idle machine (load average 0.50 at the start of the run; an earlier set taken while the box was shared is what the 6.2% on the unsharded row is *not* — that spread is reproducible and is discussed below).

Every row carries its thread placement, verified from `/proc/self/task/*/stat` rather than assumed: `64 active (64 parked), {n0=16, n1=16, n2=16, n3=16}`, no collisions. Reading that from `sched_getaffinity` instead would have been useless here — with `GOMP_CPU_AFFINITY` the calling thread is thread 0, pinned to one CPU, and reports `{node0: 1}` no matter how the other 63 landed.

The unsharded row is three times more variable than the sharded one (6.2% against 1.9%), consistently. That is what you would expect if it is the one whose performance depends on where pages happen to have landed: with the shards placed, each thread reads its own node every time.

Two notes on the measurement, both of which changed the number:

* **Experts are rotated between iterations.** Repeating the same 8 experts keeps a 398 MB working set inside the 640 MB of L3 across the two sockets and reports **726 GB/s** — above this machine's 415 GB/s aggregate STREAM ceiling, which is the tell. Rotating puts both rows back under the ceiling and moves the ratio from 1.40× to 1.7×.
* **One process per row**, because undoing a pinning restores the affinity mask but does not move threads that are already running, so a later row inherits the placement of an earlier one.

## Scope, and what this does not do

* Weights are placed, scales are not. They are a sixteenth of the bytes for MXFP4, and on the FP8 block-quantized path their row axis does not line up with the block split, so a second rule would buy a few percent.
* This does **not** change the process memory policy. `init_cpu_memory_env` still binds a rank's allocations to one node, so a model larger than a single node still fails to allocate; that is a separate problem, diagnosed in #51584.
* Placement is driven from `CPUWorker.load_model` rather than from each quantization method's `process_weights_after_loading`, because the MXFP4 and FP8 CPU paths do not call the experts' post-load hook at all — hooking per-method would silently miss exactly the backends this helps most.

## Limitations

**Measured on a single machine**: 2× Xeon Platinum 8592V, SNC2, 4 NUMA domains. The policy is topology-driven rather than hardcoded, but I have no access to an EPYC box to confirm the gain carries over to NPS4 or to per-CCD domains, and I would rather say so than have a reviewer find out.

A 2P NPS4 box brings two changes at once — more domains *and* more shards — and I can only reason about the second: the policy never emits more shards than there are effective nodes, so raising the count past 4 here would mean breaking an invariant the patch itself enforces, and I would rather not quote a number I had to disable a check to get. If it would help the review, I am happy to measure the cost of the sharded structure alone at higher shard counts behind a temporary override.

## Notes for review

`csrc/cpu/sgl-kernels/` is vendored from SGLang and re-synced wholesale, so the primitive lives outside it in `csrc/cpu/moe_numa_shard.hpp` and `moe_numa_parallel.hpp`; **the diff inside the vendored directory is three lines per file** — one include and the call names.

`BLOCK_N` necessarily exists in three places (kernel, loader, policy). A `static_assert` in `moe_numa_parallel.hpp` ties the C++ copy to `block_size_n()`, so a change there breaks the build rather than leaving the loader placing pages on boundaries the kernel does not split on — which would be slower with no sign of it.
