### PR TITLE
[Profiler] Add VLLM_ENABLE_MULTINODE_PROFILING to sync profiler start across DP ranks

### DIFF
--- a/tests/v1/worker/test_gpu_profiler.py
+++ b/tests/v1/worker/test_gpu_profiler.py
@@ -380,6 +380,41 @@ class TestWorkerSyncedProfileStart:
         Worker._maybe_start_synced_profile(worker)
         profiler.start.assert_not_called()
 
+    def test_creates_profiler_on_remote_rank(self):
+        """A rank that reached consensus via the OR-reduce but never received
+        start_profile has no profiler wrapper yet; it must be created and
+        started here, not silently skipped. Regression: an early
+        ``self.profiler is None`` return dropped every rank that did not get the
+        HTTP call, so only the called node captured (single-node traces)."""
+        sync = DPProfilerSync()
+        sync.observe(consensus=True)  # remote request; this rank never asked
+        worker = self._worker(sync, profiler=None)
+        worker.profiler_config = MagicMock(profiler="torch")
+
+        created = MagicMock()
+
+        def _create(*args, **kwargs):
+            worker.profiler = created
+
+        worker._create_profiler.side_effect = _create
+
+        Worker._maybe_start_synced_profile(worker)
+
+        worker._create_profiler.assert_called_once()
+        created.start.assert_called_once()
+
+    def test_skips_when_profiling_not_configured(self):
+        """Consensus on a rank where profiling is not configured must no-op
+        (and not build a profiler), rather than crash."""
+        sync = DPProfilerSync()
+        sync.observe(consensus=True)
+        worker = self._worker(sync, profiler=None)
+        worker.profiler_config = None
+
+        Worker._maybe_start_synced_profile(worker)
+
+        worker._create_profiler.assert_not_called()
+
 
 def test_profiler_entered_during_capture():
     """Profiler is used as a context manager in _warmup_and_capture,

--- a/tests/v1/worker/test_gpu_profiler.py
+++ b/tests/v1/worker/test_gpu_profiler.py
@@ -416,6 +416,42 @@ class TestWorkerSyncedProfileStart:
         worker._create_profiler.assert_not_called()
 
 
+class TestWorkerExecuteDummyBatch:
+    """execute_dummy_batch must advance the profiler on idle steps so a DP rank
+    that started capture via the OR-reduced synced start but then only services
+    dummy batches still counts these iterations, reaches max_iterations, stops,
+    and dumps its trace. Regression: dummy batches started the profiler (via
+    _maybe_start_synced_profile) but never stepped it (step runs only in
+    execute_model's annotate_profile), so idle ranks never exported and
+    multi-node capture silently degraded to the busy ranks only."""
+
+    def _worker(self, profiler):
+        worker = MagicMock()
+        worker.profiler = profiler
+        worker.model_runner.uniform_decode_query_len = 1
+        return worker
+
+    def test_steps_profiler_on_dummy_batch(self):
+        profiler = MagicMock()
+        worker = self._worker(profiler)
+
+        Worker.execute_dummy_batch(worker)
+
+        profiler.step.assert_called_once()
+        worker.model_runner._dummy_run.assert_called_once()
+        worker._maybe_start_synced_profile.assert_called_once()
+
+    def test_no_step_when_profiler_absent(self):
+        worker = self._worker(profiler=None)
+
+        # Must not raise when there is no profiler yet, and must still run the
+        # dummy batch and check for a synced start.
+        Worker.execute_dummy_batch(worker)
+
+        worker.model_runner._dummy_run.assert_called_once()
+        worker._maybe_start_synced_profile.assert_called_once()
+
+
 def test_profiler_entered_during_capture():
     """Profiler is used as a context manager in _warmup_and_capture,
     confirming it is active during the actual graph capture run."""

--- a/tests/v1/worker/test_gpu_profiler.py
+++ b/tests/v1/worker/test_gpu_profiler.py
@@ -8,6 +8,7 @@ from vllm.config import CUDAGraphMode, ProfilerConfig
 from vllm.config.profiler import _is_uri_path
 from vllm.profiler.wrapper import WorkerProfiler
 from vllm.v1.core.sched.output import CachedRequestData
+from vllm.v1.worker.dp_utils import DPProfilerSync
 from vllm.v1.worker.gpu_model_runner import GPUModelRunner
 from vllm.v1.worker.gpu_worker import Worker
 
@@ -280,6 +281,104 @@ class TestAnnotateProfile:
         assert self._annotate(detailed=True) == (
             "execute_5_context_1(sq4sk4sqsq16sqsk16)_generation_1(sq1sk11sqsq1sqsk11)"
         )
+
+
+class TestDPProfilerSync:
+    """Unit tests for the OR-reduced, deferred profiler start used by
+    VLLM_ENABLE_MULTINODE_PROFILING (see DPProfilerSync). observe(consensus)
+    stands in for the value read back from the per-step DP all-reduce."""
+
+    def test_local_request_reaches_consensus(self):
+        sync = DPProfilerSync()
+        assert sync.consume_start() is False  # nothing requested yet
+
+        sync.request_start()
+        assert sync._pending is True
+        # Reduce carries this rank's request; every rank observes the OR.
+        sync.observe(consensus=True)
+
+        assert sync.consume_start() is True
+        # Consumed exactly once, and the request is cleared afterwards.
+        assert sync.consume_start() is False
+        assert sync._pending is False
+
+    def test_remote_request_starts_this_rank(self):
+        """A rank that never received start_profile still starts once the OR
+        across DP ranks is True (only one rank needs the HTTP call)."""
+        sync = DPProfilerSync()
+        assert sync._pending is False
+
+        sync.observe(consensus=True)
+
+        assert sync.consume_start() is True
+
+    def test_no_request_no_start(self):
+        sync = DPProfilerSync()
+        sync.observe(consensus=False)
+        assert sync.consume_start() is False
+
+    def test_latch_survives_later_false_observation(self):
+        """After consensus, a second reduce in the same step (PP+SP) reports
+        False once _pending is cleared; that must not drop the latch before the
+        worker consumes it."""
+        sync = DPProfilerSync()
+        sync.request_start()
+        sync.observe(consensus=True)
+        sync.observe(consensus=False)  # second reduce, pending already cleared
+        assert sync.consume_start() is True
+
+    def test_cancel_drops_pending_request(self):
+        """stop_profile before consensus cancels a pending start."""
+        sync = DPProfilerSync()
+        sync.request_start()
+        sync.cancel()
+        assert sync._pending is False
+        # A stale reduce value must not resurrect a cancelled request as a start
+        # this rank acts on; but if the OR is genuinely True from another rank it
+        # still starts. Here nothing else requested, so no start.
+        sync.observe(consensus=False)
+        assert sync.consume_start() is False
+
+
+class TestWorkerSyncedProfileStart:
+    """Worker._maybe_start_synced_profile drives the deferred start from the
+    per-step consensus latch."""
+
+    def _worker(self, dp_profiler_sync, profiler):
+        worker = MagicMock()
+        worker.model_runner.dp_profiler_sync = dp_profiler_sync
+        worker.profiler = profiler
+        return worker
+
+    def test_starts_on_consensus(self):
+        sync = DPProfilerSync()
+        sync.request_start()
+        sync.observe(consensus=True)
+        profiler = MagicMock()
+        worker = self._worker(sync, profiler)
+
+        Worker._maybe_start_synced_profile(worker)
+        profiler.start.assert_called_once()
+
+        # Latch consumed: a later step does not start again.
+        Worker._maybe_start_synced_profile(worker)
+        profiler.start.assert_called_once()
+
+    def test_no_start_without_consensus(self):
+        sync = DPProfilerSync()
+        sync.request_start()  # requested but reduce has not agreed yet
+        profiler = MagicMock()
+        worker = self._worker(sync, profiler)
+
+        Worker._maybe_start_synced_profile(worker)
+        profiler.start.assert_not_called()
+
+    def test_noop_when_sync_disabled(self):
+        profiler = MagicMock()
+        worker = self._worker(None, profiler)
+
+        Worker._maybe_start_synced_profile(worker)
+        profiler.start.assert_not_called()
 
 
 def test_profiler_entered_during_capture():

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -301,6 +301,15 @@ if TYPE_CHECKING:
     VLLM_ELASTIC_EP_SCALE_UP_LAUNCH: bool = False
     VLLM_ELASTIC_EP_DRAIN_REQUESTS: bool = False
     VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS: bool = True
+    VLLM_ENABLE_MULTINODE_PROFILING: bool = False
+    """If set, the torch profiler start is synchronized across all data-parallel
+    ranks so per-rank traces from different nodes cover the same iterations,
+    which is required to align multi-node profiles. The start request is
+    OR-reduced onto the existing per-step DP coordination all-reduce and capture
+    begins on the agreed step everywhere, so it needs no extra collective and,
+    unlike a barrier on the profiler control path, cannot deadlock when only a
+    subset of ranks receives start_profile. Only affects DP (data_parallel_size
+    > 1); off by default."""
     VLLM_NIXL_EP_MAX_NUM_RANKS: int = 32
     VLLM_XPU_ENABLE_XPU_GRAPH: bool = False
     VLLM_XPU_USE_SAMPLER_KERNEL: bool = True
@@ -2057,6 +2066,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # memory allocation. Enabled by default as of v0.21.0
     "VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS": lambda: bool(
         int(os.getenv("VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS", "1"))
+    ),
+    # If set to 1, synchronize the torch profiler start across all DP ranks (via
+    # the per-step DP coordination all-reduce) so multi-node per-rank traces
+    # cover the same iterations. Only affects data_parallel_size > 1.
+    "VLLM_ENABLE_MULTINODE_PROFILING": lambda: bool(
+        int(os.getenv("VLLM_ENABLE_MULTINODE_PROFILING", "0"))
     ),
     # NIXL EP environment variables
     "VLLM_NIXL_EP_MAX_NUM_RANKS": lambda: int(

--- a/vllm/v1/worker/dp_utils.py
+++ b/vllm/v1/worker/dp_utils.py
@@ -15,6 +15,54 @@ from vllm.v1.worker.ubatch_utils import (
 logger = init_logger(__name__)
 
 
+class DPProfilerSync:
+    """Starts the torch profiler on the same step across all DP ranks.
+
+    ``start_profile`` reaches each DP rank asynchronously, at a different point
+    in its own step loop, and every step all DP ranks must jointly execute the
+    EP all-to-all / DP coordination collective. A separate barrier on the
+    profiler control path therefore deadlocks: the first rank to reach it stops
+    stepping, so the others wedge on the next collective before they ever reach
+    their own barrier (see VLLM_ENABLE_MULTINODE_PROFILING).
+
+    Instead this rides the per-step DP coordination all-reduce that every rank
+    already executes in lockstep. ``request_start`` sets a pending flag; the
+    flag is OR-reduced across DP ranks inside ``_synchronize_dp_ranks``; once any
+    rank has requested it, ``start_now`` latches on every rank on the same step,
+    and the worker starts capture next step. No extra collective, no deadlock,
+    and it needs only one rank to receive start_profile (the OR propagates it).
+    """
+
+    def __init__(self) -> None:
+        # This rank has received start_profile but capture has not begun yet.
+        self._pending = False
+        # Consensus reached: every rank should start capture. Latched until the
+        # worker consumes it, so a second reduce in the same step (PP+SP) can't
+        # clear it before the worker reads it.
+        self.start_now = False
+
+    def request_start(self) -> None:
+        self._pending = True
+
+    def cancel(self) -> None:
+        """Drop a pending request (e.g. stop_profile before capture began)."""
+        self._pending = False
+        self.start_now = False
+
+    def observe(self, consensus: bool) -> None:
+        """Record the OR-reduced request flag from a DP coordination reduce."""
+        if consensus:
+            self.start_now = True
+
+    def consume_start(self) -> bool:
+        """Return True once, on the step every rank agreed to start capture."""
+        if self.start_now:
+            self.start_now = False
+            self._pending = False
+            return True
+        return False
+
+
 def _get_device_and_group(parallel_config: ParallelConfig):
     # Use the actual device assigned to the DP group, not just the device type
     device = get_dp_group().device
@@ -39,16 +87,20 @@ def _run_ar(
     padded_num_tokens_per_ubatch: int,
     cudagraph_mode: int,
     parallel_config: ParallelConfig,
+    profile_start_pending: bool = False,
 ) -> torch.Tensor:
     dp_size = parallel_config.data_parallel_size
     dp_rank = parallel_config.data_parallel_rank
     device, group = _get_device_and_group(parallel_config)
-    # Populate this rank's contribution on CPU to reduce GPU syncs.
-    tensor_cpu = torch.zeros(4, dp_size, dtype=torch.int32)
+    # Populate this rank's contribution on CPU to reduce GPU syncs. Row 4 carries
+    # the profiler start request so it is OR-reduced together with the batch
+    # coordination, avoiding a separate collective (see DPProfilerSync).
+    tensor_cpu = torch.zeros(5, dp_size, dtype=torch.int32)
     tensor_cpu[0][dp_rank] = orig_num_tokens_per_ubatch
     tensor_cpu[1][dp_rank] = padded_num_tokens_per_ubatch
     tensor_cpu[2][dp_rank] = 1 if should_ubatch else 0
     tensor_cpu[3][dp_rank] = cudagraph_mode
+    tensor_cpu[4][dp_rank] = 1 if profile_start_pending else 0
     tensor = tensor_cpu.to(device, non_blocking=True)
     dist.all_reduce(tensor, group=group)
     return tensor
@@ -104,6 +156,7 @@ def _synchronize_dp_ranks(
     should_attempt_ubatching: bool,
     cudagraph_mode: int,
     parallel_config: ParallelConfig,
+    profiler_sync: "DPProfilerSync | None" = None,
 ) -> tuple[bool, torch.Tensor | None, int]:
     """
     1. Decides if each DP rank is going to microbatch. Either all ranks
@@ -134,7 +187,13 @@ def _synchronize_dp_ranks(
         padded_num_tokens_per_ubatch=num_tokens_padded,
         cudagraph_mode=cudagraph_mode,
         parallel_config=parallel_config,
+        profile_start_pending=profiler_sync is not None and profiler_sync._pending,
     )
+
+    # OR-reduced profiler start request: latch it so the worker starts capture
+    # on the same step across all DP ranks.
+    if profiler_sync is not None:
+        profiler_sync.observe(bool(tensor[4].any().item()))
 
     # Synchronize cudagraph_mode across ranks first (take min).
     # This is needed before DP padding decision since we use the synced
@@ -168,6 +227,7 @@ def coordinate_batch_across_dp(
     num_tokens_padded: int | None = None,
     uniform_decode: bool | None = None,
     cudagraph_mode: int = 0,
+    profiler_sync: "DPProfilerSync | None" = None,
 ) -> tuple[bool, torch.Tensor | None, int]:
     """
     Coordinates amongst all DP ranks to determine if and how the full batch
@@ -183,6 +243,9 @@ def coordinate_batch_across_dp(
             only contains single token decodes
         cudagraph_mode: The cudagraph mode for this rank (0=NONE, 1=PIECEWISE, 2=FULL).
             DP padding is enabled when synced cudagraph mode across ranks is not NONE.
+        profiler_sync: Optional DPProfilerSync. When provided, its pending
+            profiler-start request is OR-reduced across DP ranks so capture
+            starts on the same step everywhere (see VLLM_ENABLE_MULTINODE_PROFILING).
 
     Returns: tuple[
         ubatch_slices: if this is set then all DP ranks have agreed to
@@ -219,6 +282,7 @@ def coordinate_batch_across_dp(
             should_attempt_ubatching,
             cudagraph_mode,
             parallel_config,
+            profiler_sync=profiler_sync,
         )
     )
 

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -217,7 +217,7 @@ from vllm.v1.worker.cp_utils import (
     get_dcp_dummy_context_len,
     prepare_dcp_dummy_context_metadata,
 )
-from vllm.v1.worker.dp_utils import coordinate_batch_across_dp
+from vllm.v1.worker.dp_utils import DPProfilerSync, coordinate_batch_across_dp
 from vllm.v1.worker.ec_connector_model_runner_mixin import ECConnectorModelRunnerMixin
 from vllm.v1.worker.gpu.attn_utils import _reshape_attention_kv_cache
 from vllm.v1.worker.gpu_input_batch import CachedRequestState, InputBatch
@@ -515,6 +515,19 @@ class GPUModelRunner(
         self.scheduler_config = vllm_config.scheduler_config
         self.speculative_config = vllm_config.speculative_config
         self.observability_config = vllm_config.observability_config
+
+        # Rides the per-step DP coordination all-reduce to start the torch
+        # profiler on the same step across all DP ranks. Only meaningful with DP
+        # (that reduce only runs when data_parallel_size > 1) and opt-in via
+        # VLLM_ENABLE_MULTINODE_PROFILING.
+        self.dp_profiler_sync: DPProfilerSync | None = (
+            DPProfilerSync()
+            if (
+                envs.VLLM_ENABLE_MULTINODE_PROFILING
+                and self.parallel_config.data_parallel_size > 1
+            )
+            else None
+        )
 
         model_config = self.model_config
         cache_config = self.cache_config
@@ -4107,6 +4120,7 @@ class GPUModelRunner(
                     num_tokens_padded=num_tokens_padded,
                     uniform_decode=uniform_decode,
                     cudagraph_mode=cudagraph_mode.value,
+                    profiler_sync=self.dp_profiler_sync,
                 )
             )
 

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -1127,41 +1127,12 @@ class Worker(WorkerBase):
             )
 
         if is_start:
-            # Generate the trace name by combining prefix with comprehensive rank suffix
-            from vllm.distributed.utils import get_worker_rank_suffix
+            # Create the profiler wrapper only on the first start call; later
+            # calls (including an OR-reduced synced start on a rank that never
+            # received start_profile locally) reuse the existing wrapper.
+            self._create_profiler(profile_prefix)
+            assert self.profiler is not None
 
-            rank_suffix = get_worker_rank_suffix(global_rank=self.rank)
-
-            # Build the full trace name
-            if profile_prefix:
-                trace_name = f"{profile_prefix}_{rank_suffix}"
-            else:
-                trace_name = rank_suffix
-
-            # Create the profiler wrapper only on the first start call
-            if self.profiler is None:
-                profiler_type = self.profiler_config.profiler
-                if profiler_type == "torch":
-                    self.profiler = TorchProfilerWrapper(
-                        self.profiler_config,
-                        worker_name=trace_name,
-                        local_rank=self.local_rank,
-                        activities=["CPU", "CUDA"],
-                    )
-                    logger.debug(
-                        "Starting torch profiler with trace name: %s", trace_name
-                    )
-                elif profiler_type == "cuda":
-                    self.profiler = CudaProfilerWrapper(self.profiler_config)
-                    logger.debug("Starting CUDA profiler")
-                else:
-                    # Config validation should prevent this code being reached
-                    raise ValueError(
-                        f"Invalid profiler value of {self.profiler_config.profiler}"
-                    )
-
-            # If profiler already initialized, restart profiling but keep
-            # the original trace name from the first initialization.
             dp_profiler_sync = getattr(self.model_runner, "dp_profiler_sync", None)
             if dp_profiler_sync is not None:
                 # Defer the actual start: request it here and let the per-step DP
@@ -1181,17 +1152,71 @@ class Worker(WorkerBase):
                 return
             self.profiler.stop()
 
+    def _create_profiler(self, profile_prefix: str | None = None) -> None:
+        """Build self.profiler (torch/cuda wrapper) if not already created.
+
+        Idempotent: the first call wins the trace name; later calls (e.g. an
+        OR-reduced synced start on a rank that never received start_profile
+        locally) reuse the existing wrapper.
+        """
+        if self.profiler is not None:
+            return
+
+        # Generate the trace name by combining prefix with comprehensive rank suffix
+        from vllm.distributed.utils import get_worker_rank_suffix
+
+        rank_suffix = get_worker_rank_suffix(global_rank=self.rank)
+        trace_name = (
+            f"{profile_prefix}_{rank_suffix}" if profile_prefix else rank_suffix
+        )
+
+        profiler_type = self.profiler_config.profiler
+        if profiler_type == "torch":
+            self.profiler = TorchProfilerWrapper(
+                self.profiler_config,
+                worker_name=trace_name,
+                local_rank=self.local_rank,
+                activities=["CPU", "CUDA"],
+            )
+            logger.debug("Starting torch profiler with trace name: %s", trace_name)
+        elif profiler_type == "cuda":
+            self.profiler = CudaProfilerWrapper(self.profiler_config)
+            logger.debug("Starting CUDA profiler")
+        else:
+            # Config validation should prevent this code being reached
+            raise ValueError(
+                f"Invalid profiler value of {self.profiler_config.profiler}"
+            )
+
     def _maybe_start_synced_profile(self) -> None:
         """Start capture once all DP ranks have agreed on the start step.
 
         Called every worker step (real and dummy) so idle DP ranks start in
         lockstep with busy ones. No-op unless VLLM_ENABLE_MULTINODE_PROFILING
         deferred a start via DPProfilerSync.
+
+        Only one rank needs to receive start_profile: the request is OR-reduced
+        across DP ranks, so a rank that never got the HTTP call still reaches
+        consensus here. Such a rank has no profiler wrapper yet (it is created in
+        profile()), so build it now -- otherwise the latch is consumed and the
+        rank silently never captures.
         """
         dp_profiler_sync = getattr(self.model_runner, "dp_profiler_sync", None)
-        if dp_profiler_sync is None or self.profiler is None:
+        if dp_profiler_sync is None:
             return
         if dp_profiler_sync.consume_start():
+            if self.profiler is None:
+                if (
+                    self.profiler_config is None
+                    or self.profiler_config.profiler is None
+                ):
+                    logger.warning(
+                        "Synced profile start requested but profiling is not "
+                        "configured on this rank; skipping."
+                    )
+                    return
+                self._create_profiler()
+            assert self.profiler is not None
             self.profiler.start()
 
     def execute_dummy_batch(self) -> None:

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -1221,6 +1221,15 @@ class Worker(WorkerBase):
 
     def execute_dummy_batch(self) -> None:
         num_tokens = getattr(self.model_runner, "uniform_decode_query_len", 1)
+        # Advance the profiler on idle (dummy) steps too. An idle DP rank still
+        # runs the DP coordination collective in lockstep with busy ranks, so a
+        # rank that started capture via the OR-reduced synced start but then only
+        # services dummy batches must still count these iterations -- otherwise
+        # its profiler never reaches max_iterations, never stops, and never dumps
+        # a trace, silently degrading multi-node capture to the busy ranks only
+        # (see DPProfilerSync / VLLM_ENABLE_MULTINODE_PROFILING).
+        if self.profiler is not None:
+            self.profiler.step()
         self.model_runner._dummy_run(num_tokens, uniform_decode=True)
         self._maybe_start_synced_profile()
 

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -1084,6 +1084,8 @@ class Worker(WorkerBase):
             output = self.model_runner.execute_model(
                 scheduler_output, intermediate_tensors
             )
+            # Start capture in lockstep once the DP ranks agreed this step.
+            self._maybe_start_synced_profile()
             if (
                 self.use_v2_model_runner
                 and self.model_runner.is_pooling_model
@@ -1160,16 +1162,42 @@ class Worker(WorkerBase):
 
             # If profiler already initialized, restart profiling but keep
             # the original trace name from the first initialization.
-            self.profiler.start()
+            dp_profiler_sync = getattr(self.model_runner, "dp_profiler_sync", None)
+            if dp_profiler_sync is not None:
+                # Defer the actual start: request it here and let the per-step DP
+                # coordination reduce agree on a common start step across ranks,
+                # so multi-node traces cover the same iterations without a
+                # deadlock-prone barrier (see DPProfilerSync).
+                dp_profiler_sync.request_start()
+            else:
+                self.profiler.start()
         else:
+            dp_profiler_sync = getattr(self.model_runner, "dp_profiler_sync", None)
+            if dp_profiler_sync is not None:
+                # Drop a request that never reached consensus yet.
+                dp_profiler_sync.cancel()
             if self.profiler is None:
                 logger.warning("Profiler was not started, nothing to stop.")
                 return
             self.profiler.stop()
 
+    def _maybe_start_synced_profile(self) -> None:
+        """Start capture once all DP ranks have agreed on the start step.
+
+        Called every worker step (real and dummy) so idle DP ranks start in
+        lockstep with busy ones. No-op unless VLLM_ENABLE_MULTINODE_PROFILING
+        deferred a start via DPProfilerSync.
+        """
+        dp_profiler_sync = getattr(self.model_runner, "dp_profiler_sync", None)
+        if dp_profiler_sync is None or self.profiler is None:
+            return
+        if dp_profiler_sync.consume_start():
+            self.profiler.start()
+
     def execute_dummy_batch(self) -> None:
         num_tokens = getattr(self.model_runner, "uniform_decode_query_len", 1)
         self.model_runner._dummy_run(num_tokens, uniform_decode=True)
+        self._maybe_start_synced_profile()
 
     def add_lora(self, lora_request: LoRARequest) -> bool:
         return self.model_runner.add_lora(lora_request)


### PR DESCRIPTION
## Purpose

When profiling a multi-node data-parallel deployment, per-rank Kineto traces cannot be aligned onto a common time axis:

- Kineto stamps each event on the local `CLOCK_MONOTONIC`, whose origin differs per host.
- `start_profile` reaches each DP rank asynchronously, at a different point in its own step loop.

So traces from different nodes cover different iterations, and there is no shared landmark to line them up.

## Why not a barrier

A `torch.distributed.barrier()` on the profiler control path does not work here and deadlocks:

- `start_profile` is not a world collective. Under external-LB DP it is dispatched per engine core, and even when every pod is hit (e.g. sending `/start_profile` to all pods), each arrives at a different, unsynchronized step.
- Every decode step, all DP ranks must jointly execute the EP all-to-all / DP coordination collective. The first rank to reach the barrier stops stepping, so the other ranks wedge on the next collective before they ever reach their own barrier. Neither side converges.

## What this does

Ride the per-step DP coordination all-reduce that every rank already executes in lockstep (`coordinate_batch_across_dp` -> `_synchronize_dp_ranks`), which is correctly ordered against the EP collective.

Add opt-in `VLLM_ENABLE_MULTINODE_PROFILING` (off by default, only affects `data_parallel_size > 1`). When set:

1. `start_profile` on a worker only records a pending request (`DPProfilerSync.request_start`) instead of starting capture.
2. The pending flag is OR-reduced onto the existing per-step all-reduce (one extra row in the coordination tensor).
3. Once any rank has requested it, every rank latches the decision on the same step and the worker starts capture on the next step.

Consequences:
- No extra collective and no new failure mode: it reuses a collective every rank already runs, so it cannot deadlock the way a control-path barrier does.
- Only one rank needs to receive `start_profile`; the OR propagates the request to all ranks.
- Capture begins on the same step on every rank, giving multi-node traces a shared start iteration to align on.

## Test Plan

- `tests/v1/worker/test_gpu_profiler.py`:
  - `TestDPProfilerSync`: local request reaches consensus; a remote-only request still starts this rank; no request -> no start; the latch survives a later `False` observation (PP+SP double reduce in one step); `cancel()` drops a pending request; start fires exactly once.
  - `TestWorkerSyncedProfileStart`: `Worker._maybe_start_synced_profile` starts on consensus exactly once, does nothing without consensus, and is a no-op when the sync is disabled.
- Default path unchanged: with the env var unset, `start_profile` starts capture immediately as before.