### PR TITLE
Move thinking-budget state without sharing it between requests

### DIFF
--- a/tests/v1/logits_processors/test_correctness.py
+++ b/tests/v1/logits_processors/test_correctness.py
@@ -1011,6 +1011,44 @@ def test_thinking_budget_holder_swap_exchanges_state():
     assert h._state[1]["thinking_token_budget"] == b0
 
 
+def test_thinking_budget_holder_mixed_swap_moves_single_state():
+    vc = VllmConfig()
+    vc.reasoning_config = MockReasoningConfig()
+    h = ThinkingBudgetStateHolder(
+        vc.reasoning_config,
+        vc.scheduler_config.max_num_seqs,
+        0,
+        torch.device("cpu"),
+        False,
+    )
+    h.sync_batch(
+        BatchUpdate(
+            batch_size=2,
+            removed=(),
+            added=[
+                (
+                    0,
+                    SamplingParams(thinking_token_budget=3),
+                    None,
+                    [],
+                ),
+            ],
+            moved=(),
+        )
+    )
+    original_state = h._state[0]
+    h.sync_batch(
+        BatchUpdate(
+            batch_size=2,
+            removed=(),
+            added=(),
+            moved=[(1, 0, MoveDirectionality.SWAP)],
+        )
+    )
+    assert 0 not in h._state
+    assert h._state[1] is original_state
+
+
 def test_thinking_budget_holder_unidirectional_move():
     vc = VllmConfig()
     vc.reasoning_config = MockReasoningConfig()

--- a/vllm/v1/sample/thinking_budget_state.py
+++ b/vllm/v1/sample/thinking_budget_state.py
@@ -99,17 +99,12 @@ class ThinkingBudgetStateHolder:
                 self._state.pop(index, None)
 
         for i1, i2, direction in batch_update.moved:
-            if direction == MoveDirectionality.SWAP:
-                state1 = self._state.get(i1)
-                state2 = self._state.get(i2)
-                if state1 is not None:
-                    self._state[i2] = state1
-                if state2 is not None:
-                    self._state[i1] = state2
-            else:
-                state = self._state.pop(i1, None)
-                if state is not None:
-                    self._state[i2] = state
+            state1 = self._state.pop(i1, None)
+            state2 = self._state.pop(i2, None)
+            if state1 is not None:
+                self._state[i2] = state1
+            if state2 is not None and direction == MoveDirectionality.SWAP:
+                self._state[i1] = state2
 
     def update_state(
         self,


### PR DESCRIPTION
# Move thinking-budget state without sharing it between requests

## What this fixes

vLLM stores thinking-budget state by the request's current batch row. When a mixed batch was
reordered, a two-row swap copied a state entry to its new row without removing it from the old
row. Two unrelated requests could then refer to the same state object.

For example, one client can submit a request containing `<think>` with
`thinking_token_budget=0` while another client's ordinary completion is running. If the scheduler
places those requests on opposite sides of a mixed prefill/decode swap, the old code leaves the
first request's "end reasoning now" state on both rows. Before this change, vLLM could then force
`</think>` into the unrelated completion. After this change, state is removed from both old rows
before either entry is assigned to its new row, so each state follows only its own request.

## Why it matters

An ordinary API client could alter another client's generated response on deployments that enable
reasoning, use the legacy model runner, and encounter the required batch reorder. The demonstrated
effect is insertion of the configured reasoning-end token, not arbitrary text or data disclosure.

## The change

`ThinkingBudgetStateHolder.sync_batch()` now removes both endpoint entries first and then assigns
the surviving entries according to the move. This handles swaps and one-way moves with the same
move-not-copy rule. The test checks both the destination row and the absence of stale state at the
source row.

## How it was tested

Without the fix, the focused mixed-swap test failed; with it, the test passed. In a live replay of
the affected scheduling pattern, the unpatched server corrupted 6 of 6 victim responses. The
patched control corrupted 0 of 4.

## Reference

Advisory: GHSA-fpch-3xrf-7q96

Track B: this is a public PR against `vllm-project/vllm@main`.

## Credit

- @KernelClint (Clinton Thomas) and @dhalf (Lucas Bourtoule)
- Patch the Planet (Trail of Bits + OpenAI collaboration); discovered using GPT-5.5-Cyber

All commits include DCO `Signed-off-by` trailers.
