### PR TITLE
[Bugfix][Ray] Cap placement-group wait backoff at the deadline

### DIFF
--- a/tests/v1/executor/test_ray_utils.py
+++ b/tests/v1/executor/test_ray_utils.py
@@ -2,7 +2,9 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import numpy as np
+import pytest
 
+from vllm.v1.executor import ray_utils
 from vllm.v1.executor.ray_utils import detach_zero_copy_from_model_runner_output
 from vllm.v1.outputs import (
     LogprobsLists,
@@ -82,3 +84,80 @@ def test_detach_zero_copy_routed_experts_without_logprobs():
     assert detached.slot_mapping.flags.writeable
     np.testing.assert_array_equal(detached.routing_data, original.routing_data)
     np.testing.assert_array_equal(detached.slot_mapping, original.slot_mapping)
+
+
+class _FakeClock:
+    """Deterministic stand-in for ``time.monotonic``."""
+
+    def __init__(self) -> None:
+        self.now = 1000.0
+
+    def monotonic(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+class _FakePlacementGroup:
+    bundle_specs = [{"GPU": 1}]
+
+    def ready(self):
+        return "pg-ready-ref"
+
+
+def test_wait_until_pg_ready_does_not_wait_past_the_deadline(monkeypatch):
+    """Before the cap, the final wait started at 1270s and blocked another
+    1280s, so the loop returned at ~2550s for a nominal 1800s timeout."""
+    clock = _FakeClock()
+    waits: list[float] = []
+
+    def fake_wait(refs, timeout):
+        # The placement group never becomes ready.
+        waits.append(timeout)
+        clock.advance(timeout)
+        return [], refs
+
+    def fake_get(ref, timeout):
+        raise ray_utils.ray.exceptions.GetTimeoutError()
+
+    monkeypatch.setattr(ray_utils.time, "monotonic", clock.monotonic)
+    monkeypatch.setattr(ray_utils.ray, "wait", fake_wait)
+    monkeypatch.setattr(ray_utils.ray, "get", fake_get)
+
+    start = clock.now
+    with pytest.raises(ValueError) as exc_info:
+        ray_utils._wait_until_pg_ready(_FakePlacementGroup())
+
+    elapsed = clock.now - start
+    assert elapsed == ray_utils.PG_WAIT_TIMEOUT
+    assert all(w > 0 for w in waits)
+    # The final wait is the one that used to overshoot.
+    assert waits[-1] == ray_utils.PG_WAIT_TIMEOUT - sum(waits[:-1])
+    # The error reports what was actually waited, not the nominal constant.
+    assert f"within {int(elapsed)} seconds" in str(exc_info.value)
+
+
+def test_wait_until_pg_removed_does_not_sleep_past_the_deadline(monkeypatch):
+    """The removal loop must also stop at the deadline instead of overshooting."""
+    clock = _FakeClock()
+    sleeps: list[float] = []
+
+    def fake_sleep(seconds):
+        sleeps.append(seconds)
+        clock.advance(seconds)
+
+    monkeypatch.setattr(ray_utils.time, "monotonic", clock.monotonic)
+    monkeypatch.setattr(ray_utils.time, "sleep", fake_sleep)
+    monkeypatch.setattr(ray_utils.ray.util, "remove_placement_group", lambda pg: None)
+    # The placement group is never actually removed.
+    monkeypatch.setattr(
+        ray_utils.ray.util, "get_current_placement_group", lambda: object()
+    )
+
+    start = clock.now
+    ray_utils._wait_until_pg_removed(_FakePlacementGroup())
+
+    elapsed = clock.now - start
+    assert elapsed == ray_utils.PG_WAIT_TIMEOUT
+    assert all(s >= 0 for s in sleeps)

--- a/vllm/v1/executor/ray_utils.py
+++ b/vllm/v1/executor/ray_utils.py
@@ -464,11 +464,16 @@ def _wait_until_pg_ready(current_placement_group: "PlacementGroup"):
     # if they cannot be provisioned.
     placement_group_specs = current_placement_group.bundle_specs
 
-    s = time.time()
+    s = time.monotonic()
     pg_ready_ref = current_placement_group.ready()
     wait_interval = 10
-    while time.time() - s < PG_WAIT_TIMEOUT:
-        ready, _ = ray.wait([pg_ready_ref], timeout=wait_interval)
+    while True:
+        # Cap the wait so the doubling backoff cannot block past the deadline.
+        remaining = PG_WAIT_TIMEOUT - (time.monotonic() - s)
+        if remaining <= 0:
+            break
+
+        ready, _ = ray.wait([pg_ready_ref], timeout=min(wait_interval, remaining))
         if len(ready) > 0:
             break
 
@@ -481,13 +486,14 @@ def _wait_until_pg_ready(current_placement_group: "PlacementGroup"):
             " and make sure the IP addresses used by ray cluster"
             " are the same as VLLM_HOST_IP environment variable"
             " specified in each node if you are running on a multi-node.",
-            int(time.time() - s),
+            int(time.monotonic() - s),
             placement_group_specs,
         )
 
     try:
         ray.get(pg_ready_ref, timeout=0)
     except ray.exceptions.GetTimeoutError:
+        waited = int(time.monotonic() - s)
         # Provide more helpful error message when GPU count is exceeded
         total_gpu_required = sum(spec.get("GPU", 0) for spec in placement_group_specs)
         # If more than one GPU is required for the placement group, provide a
@@ -500,7 +506,7 @@ def _wait_until_pg_ready(current_placement_group: "PlacementGroup"):
                 f"Cannot provide a placement group requiring "
                 f"{total_gpu_required} GPUs "
                 f"(placement_group_specs={placement_group_specs}) within "
-                f"{PG_WAIT_TIMEOUT} seconds.\n"
+                f"{waited} seconds.\n"
                 f"Tensor parallel size may exceed available GPUs in your "
                 f"cluster. Check resources with `ray status` and "
                 f"`ray list nodes`.\n"
@@ -511,7 +517,7 @@ def _wait_until_pg_ready(current_placement_group: "PlacementGroup"):
             raise ValueError(
                 "Cannot provide a placement group of "
                 f"{placement_group_specs=} within "
-                f"{PG_WAIT_TIMEOUT} seconds. See "
+                f"{waited} seconds. See "
                 "`ray status` and `ray list nodes` to make sure the cluster "
                 "has enough resources."
             ) from None
@@ -519,9 +525,9 @@ def _wait_until_pg_ready(current_placement_group: "PlacementGroup"):
 
 def _wait_until_pg_removed(current_placement_group: "PlacementGroup"):
     ray.util.remove_placement_group(current_placement_group)
-    s = time.time()
+    s = time.monotonic()
     wait_interval = 10
-    while time.time() - s < PG_WAIT_TIMEOUT:
+    while time.monotonic() - s < PG_WAIT_TIMEOUT:
         pg = ray.util.get_current_placement_group()
         if pg is None:
             break
@@ -530,9 +536,11 @@ def _wait_until_pg_removed(current_placement_group: "PlacementGroup"):
         wait_interval *= 2
         logger.info(
             "Waiting for removing a placement group of specs for %d seconds.",
-            int(time.time() - s),
+            int(time.monotonic() - s),
         )
-        time.sleep(wait_interval)
+        # Recompute after the poll so the sleep cannot overrun the deadline.
+        remaining = PG_WAIT_TIMEOUT - (time.monotonic() - s)
+        time.sleep(max(min(wait_interval, remaining), 0))
 
 
 def initialize_ray_cluster(


### PR DESCRIPTION
## Purpose

`_wait_until_pg_ready` does not honor `PG_WAIT_TIMEOUT`. The loop condition checks
elapsed time, but `ray.wait()` is called with `wait_interval`, which doubles every
iteration and is never capped against the time remaining. The final iteration
passes the `elapsed < 1800` check at 1270s and then blocks a further 1280s, so the
loop returns at ~2550s. The `ValueError` raised immediately afterwards
interpolates `PG_WAIT_TIMEOUT` rather than the time actually spent, so a 42-minute
wait is reported as 30. `_wait_until_pg_removed` has the same uncapped backoff
(~2540s).

- Cap each `ray.wait()` and `time.sleep()` at the remaining time.
- Use `time.monotonic()` for the deadline instead of `time.time()`.
- Report the measured elapsed time in the raised error instead of the constant.

Behavior change: the effective timeout drops from ~2550s to the nominal 1800s, so
provisioning that currently succeeds between those bounds will now fail at the
documented deadline. If that's a problem in practice, the natural pairing is
making the timeout configurable (#49530, #11135) — happy to add it here.

## Test Plan

Two regression tests using a fake clock advanced by the stubbed `ray.wait` /
`time.sleep`, so the 1800s scenario runs in milliseconds.

```bash
pytest tests/v1/executor/test_ray_utils.py tests/utils_/test_ray_utils.py -q
```

## Test Result

Both new tests fail on `main`:

```
FAILED tests/v1/executor/test_ray_utils.py::test_wait_until_pg_ready_does_not_wait_past_the_deadline
FAILED tests/v1/executor/test_ray_utils.py::test_wait_until_pg_removed_does_not_sleep_past_the_deadline
2 failed, 2 passed in 0.37s
```

With this change:

```
10 passed in 0.76s
```

`pre-commit run --files vllm/v1/executor/ray_utils.py tests/v1/executor/test_ray_utils.py`
passes. Not validated against a live multi-node Ray cluster.
