### PR TITLE
Bound request-controlled audio preprocessing

### DIFF
--- a/docs/serving/online_serving/speech_to_text.md
+++ b/docs/serving/online_serving/speech_to_text.md
@@ -16,6 +16,8 @@ NOTE: beam search is currently supported in the transcriptions endpoint for enco
 
 Set the maximum audio file size (in MB) that VLLM will accept, via the
 `VLLM_MAX_AUDIO_CLIP_FILESIZE_MB` environment variable. Default is 25 MB.
+Set the maximum accepted audio channel count via the
+`VLLM_MAX_AUDIO_CHANNELS` environment variable. Default is 8 channels.
 
 ### Uploading Audio Files
 

--- a/docs/usage/security.md
+++ b/docs/usage/security.md
@@ -99,6 +99,7 @@ denial of service:
 | `VLLM_MAX_AUDIO_DECODE_DURATION_S` | `600` | Maximum decoded audio duration in seconds. Prevents compressed audio from expanding into gigabytes of float32 PCM. |
 | `VLLM_MAX_AUDIO_DECODE_BYTES` | `268435456` (256 MiB) | Maximum float32 PCM bytes that audio decoding may allocate. Guards against sample-rate forgery where an inflated header sample rate bypasses the duration guard while the actual frame count causes a multi-GiB allocation. |
 | `VLLM_MAX_EMBED_DECODE_BYTES` | `2147483648` (2 GiB) | Maximum bytes a client-supplied embedding payload (`prompt_embeds`, `image_embeds`, `audio_embeds`, `video_embeds`) may allocate once densified. A sparse tensor carries its own declared shape, so a payload of a few hundred bytes can expand into hundreds of GiB. Checked before `to_dense()`, so the memory is never allocated. Set to `0` to disable. |
+| `VLLM_MAX_AUDIO_CHANNELS` | `8` | Maximum number of channels accepted in compressed audio before decode. Prevents high-channel-count files from amplifying intermediate PCM allocations before mono reduction. |
 
 Setting any of these to `0` disables the corresponding limit. This is **not
 recommended** for deployments exposed to untrusted users, as it removes the

--- a/tests/multimodal/media/test_audio.py
+++ b/tests/multimodal/media/test_audio.py
@@ -2,7 +2,8 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 from io import BytesIO
 from pathlib import Path
-from unittest.mock import patch
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
 
 import numpy as np
 import pybase64 as base64
@@ -13,6 +14,7 @@ from vllm.multimodal.media import AudioMediaIO
 from vllm.multimodal.media import audio as audio_module
 from vllm.multimodal.media.audio import (
     load_audio,
+    load_audio_pyav,
     load_audio_soundfile,
     load_audio_torchcodec,
 )
@@ -98,6 +100,141 @@ def test_load_audio_max_duration_rejected(dummy_audio_bytes):
     """Audio exceeding the duration limit must be rejected during decode."""
     with pytest.raises(ValueError, match="exceeds maximum allowed duration"):
         load_audio(BytesIO(dummy_audio_bytes), sr=None, max_duration_s=0.0001)
+
+
+def _fake_pyav_container(num_channels: int) -> tuple[Mock, SimpleNamespace]:
+    frame = SimpleNamespace(
+        layout=SimpleNamespace(channels=[object()] * num_channels),
+        to_ndarray=Mock(return_value=np.zeros((num_channels, 1), dtype=np.float32)),
+    )
+    stream = SimpleNamespace(
+        codec_context=SimpleNamespace(channels=num_channels),
+        duration=0,
+        layout=SimpleNamespace(channels=[object()] * num_channels),
+        rate=16000,
+        thread_type=None,
+        time_base=None,
+    )
+    container = Mock()
+    container.__enter__ = Mock(return_value=container)
+    container.__exit__ = Mock(return_value=False)
+    container.decode.return_value = [frame]
+    container.duration = 0
+    container.streams = SimpleNamespace(audio=[stream])
+    return container, stream
+
+
+def _fake_soundfile(num_channels: int) -> Mock:
+    audio_file = Mock()
+    audio_file.__enter__ = Mock(return_value=audio_file)
+    audio_file.__exit__ = Mock(return_value=False)
+    audio_file.channels = num_channels
+    audio_file.frames = 1
+    audio_file.read.return_value = np.zeros((1, num_channels), dtype=np.float32)
+    audio_file.samplerate = 16000
+    return audio_file
+
+
+def test_load_audio_pyav_rejects_excessive_channels_before_decode(monkeypatch):
+    import vllm.envs as envs
+
+    monkeypatch.setattr(envs, "VLLM_MAX_AUDIO_CHANNELS", 8, raising=False)
+    container, stream = _fake_pyav_container(num_channels=64)
+
+    with (
+        patch("vllm.multimodal.media.audio.av.open", return_value=container),
+        pytest.raises(ValueError, match="channel count"),
+    ):
+        load_audio_pyav(BytesIO(b"fake"), sr=None)
+
+    container.decode.assert_not_called()
+    assert stream.thread_type == "AUTO"
+
+
+def test_load_audio_pyav_rejects_excessive_layout_channels_before_decode(monkeypatch):
+    import vllm.envs as envs
+
+    monkeypatch.setattr(envs, "VLLM_MAX_AUDIO_CHANNELS", 8, raising=False)
+    container, stream = _fake_pyav_container(num_channels=64)
+    stream.codec_context.channels = 0
+
+    with (
+        patch("vllm.multimodal.media.audio.av.open", return_value=container),
+        pytest.raises(ValueError, match="channel count"),
+    ):
+        load_audio_pyav(BytesIO(b"fake"), sr=None)
+
+    container.decode.assert_not_called()
+
+
+def test_load_audio_pyav_rejects_excessive_frame_channels_before_array(monkeypatch):
+    import vllm.envs as envs
+
+    monkeypatch.setattr(envs, "VLLM_MAX_AUDIO_CHANNELS", 8, raising=False)
+    container, stream = _fake_pyav_container(num_channels=64)
+    stream.codec_context.channels = 1
+    stream.layout.channels = [object()]
+    frame = container.decode.return_value[0]
+
+    with (
+        patch("vllm.multimodal.media.audio.av.open", return_value=container),
+        pytest.raises(ValueError, match="channel count"),
+    ):
+        load_audio_pyav(BytesIO(b"fake"), sr=None)
+
+    frame.to_ndarray.assert_not_called()
+
+
+def test_load_audio_soundfile_rejects_excessive_channels_before_read(monkeypatch):
+    import vllm.envs as envs
+
+    monkeypatch.setattr(envs, "VLLM_MAX_AUDIO_CHANNELS", 8, raising=False)
+    audio_file = _fake_soundfile(num_channels=64)
+
+    with (
+        patch(
+            "vllm.multimodal.media.audio.soundfile.SoundFile",
+            return_value=audio_file,
+        ),
+        pytest.raises(ValueError, match="channel count"),
+    ):
+        load_audio_soundfile(BytesIO(b"fake"), sr=None)
+
+    audio_file.read.assert_not_called()
+
+
+def test_load_audio_soundfile_allows_common_surround_channels(monkeypatch):
+    import vllm.envs as envs
+
+    monkeypatch.setattr(envs, "VLLM_MAX_AUDIO_CHANNELS", 8, raising=False)
+    audio_file = _fake_soundfile(num_channels=6)
+
+    with patch(
+        "vllm.multimodal.media.audio.soundfile.SoundFile",
+        return_value=audio_file,
+    ):
+        audio, sr = load_audio_soundfile(BytesIO(b"fake"), sr=None)
+
+    audio_file.read.assert_called_once_with(dtype="float32", always_2d=False)
+    assert sr == 16000
+    np.testing.assert_array_equal(audio, np.zeros(1, dtype=np.float32))
+
+
+def test_load_audio_soundfile_channel_limit_disabled(monkeypatch):
+    import vllm.envs as envs
+
+    monkeypatch.setattr(envs, "VLLM_MAX_AUDIO_CHANNELS", 0, raising=False)
+    audio_file = _fake_soundfile(num_channels=64)
+
+    with patch(
+        "vllm.multimodal.media.audio.soundfile.SoundFile",
+        return_value=audio_file,
+    ):
+        audio, sr = load_audio_soundfile(BytesIO(b"fake"), sr=None)
+
+    audio_file.read.assert_called_once_with(dtype="float32", always_2d=False)
+    assert sr == 16000
+    np.testing.assert_array_equal(audio, np.zeros(1, dtype=np.float32))
 
 
 def test_audio_media_io_from_video(video_assets):

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -81,6 +81,7 @@ if TYPE_CHECKING:
     VLLM_MAX_AUDIO_CLIP_FILESIZE_MB: int = 25
     VLLM_MAX_AUDIO_DECODE_DURATION_S: int = 600
     VLLM_MAX_AUDIO_DECODE_BYTES: int = 268_435_456
+    VLLM_MAX_AUDIO_CHANNELS: int = 8
     VLLM_MAX_AUDIO_PREPROCESS_WORKERS: int = max(1, min(os.cpu_count() or 1, 2))
     VLLM_MAX_EMBED_DECODE_BYTES: int = 2_147_483_648
     VLLM_MAX_IMAGE_PIXELS: int = 178_956_970
@@ -1032,6 +1033,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_MAX_EMBED_DECODE_BYTES": lambda: int(
         os.getenv("VLLM_MAX_EMBED_DECODE_BYTES", "2147483648")
     ),
+    # Maximum number of channels accepted in compressed audio before decode.
+    # Common surround layouts fit within 8 channels; larger layouts can
+    # amplify intermediate PCM allocations before mono reduction.
+    # Default is 8 channels.
+    "VLLM_MAX_AUDIO_CHANNELS": lambda: int(os.getenv("VLLM_MAX_AUDIO_CHANNELS", "8")),
     # Maximum number of worker threads used for STT preprocessing. The default
     # intentionally caps at 2 because that performed best in profiling.
     # https://github.com/vllm-project/vllm/pull/44612#issuecomment-4662757781
@@ -2352,6 +2358,7 @@ def compile_factors() -> dict[str, object]:
         "VLLM_MAX_AUDIO_CLIP_FILESIZE_MB",
         "VLLM_MAX_AUDIO_DECODE_DURATION_S",
         "VLLM_MAX_AUDIO_DECODE_BYTES",
+        "VLLM_MAX_AUDIO_CHANNELS",
         "VLLM_MAX_AUDIO_PREPROCESS_WORKERS",
         "VLLM_MAX_EMBED_DECODE_BYTES",
         "VLLM_MAX_IMAGE_PIXELS",

--- a/vllm/multimodal/media/audio.py
+++ b/vllm/multimodal/media/audio.py
@@ -75,6 +75,34 @@ _TORCHCODEC_UNAVAILABLE_MSG = (
 _DURATION_GUARD_MARGIN_S = 1.0
 
 
+def _check_audio_channel_limit(num_channels: int | None) -> None:
+    max_channels = envs.VLLM_MAX_AUDIO_CHANNELS
+    if (
+        num_channels is not None
+        and num_channels > 0
+        and max_channels > 0
+        and num_channels > max_channels
+    ):
+        raise ValueError(
+            f"Audio channel count {num_channels} exceeds the maximum of "
+            f"{max_channels}. Set VLLM_MAX_AUDIO_CHANNELS to increase "
+            "this limit."
+        )
+
+
+def _get_pyav_channel_count(audio_obj) -> int | None:
+    codec_context = getattr(audio_obj, "codec_context", None)
+    codec_channels = getattr(codec_context, "channels", None)
+    if codec_channels:
+        return int(codec_channels)
+
+    layout = getattr(audio_obj, "layout", None)
+    layout_channels = getattr(layout, "channels", None)
+    if layout_channels is not None:
+        return len(layout_channels)
+    return None
+
+
 def load_audio_pyav(
     path: BytesIO | Path | str,
     *,
@@ -114,6 +142,7 @@ def load_audio_pyav(
             raise ValueError("No audio stream found.")
         stream = container.streams.audio[0]
         stream.thread_type = "AUTO"
+        _check_audio_channel_limit(_get_pyav_channel_count(stream))
         native_sr = stream.rate
         sr = sr or native_sr
 
@@ -152,9 +181,11 @@ def load_audio_pyav(
         )
         try:
             for frame in container.decode(stream):
+                _check_audio_channel_limit(_get_pyav_channel_count(frame))
                 if needs_resampling:
                     assert resampler is not None
                     for out_frame in resampler.resample(frame):
+                        _check_audio_channel_limit(_get_pyav_channel_count(out_frame))
                         arr = out_frame.to_ndarray()
                         total_samples += arr.shape[-1]
                         total_decode_bytes += arr.nbytes
@@ -211,6 +242,7 @@ def load_audio_soundfile(
 ) -> tuple[np.ndarray, int]:
     """Load audio via soundfile"""
     with soundfile.SoundFile(path) as f:
+        _check_audio_channel_limit(f.channels)
         native_sr = f.samplerate
         if max_duration_s is not None:
             file_duration_s = f.frames / native_sr


### PR DESCRIPTION
# Bound request-controlled audio channel count

## What this fixes

Compressed audio can declare a high channel count that amplifies intermediate PCM allocations
before mono reduction, so a small file could force a large allocation during decode.

This rejects audio whose channel count exceeds `VLLM_MAX_AUDIO_CHANNELS` (default 8) before
decode, across the PyAV stream/frame paths and the soundfile path.

## Why it matters

An authenticated client submitting audio could amplify decode-time memory out of proportion to the
request size. The impact is reduced service availability, not code execution or data access.

## Scope

This PR has been narrowed to the decoded channel-count guard (PTP-VLLM-058). The per-model
preprocessing-kwargs guards that were previously bundled here are deferred to separate follow-up so
this change can land on its own.

## The change

| Site | What now happens |
|---|---|
| PTP-VLLM-058 — decoded channel count | Audio with more than `VLLM_MAX_AUDIO_CHANNELS` channels is rejected before mono conversion, on both the PyAV and soundfile paths. |

## How it was tested

`pytest tests/multimodal/media/test_audio.py` — channel-count guard cases: audio above the limit is
rejected; values at or below the limit pass.

## Reference

Advisory: GHSA-j3vf-r27h-6x6j

Track B: this is a public PR against `vllm-project/vllm@main`.

## Credit

- @KernelClint (Clinton Thomas) and @dhalf (Lucas Bourtoule)
- Patch the Planet (Trail of Bits + OpenAI collaboration)
- AI assistance was used in preparing this change (model: GPT-5.5-Cyber); every changed line has been reviewed and is defended by the human submitter.

All commits include DCO `Signed-off-by` trailers.
