### PR TITLE
Roll back mirrored multimodal cache entries after rejection

### DIFF
--- a/tests/test_mm_ipc_cache_desync.py
+++ b/tests/test_mm_ipc_cache_desync.py
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+
+from vllm.config import ModelConfig
+from vllm.multimodal.cache import (
+    MultiModalProcessorSenderCache,
+    MultiModalReceiverCache,
+)
+from vllm.multimodal.inputs import MultiModalKwargsItem
+
+pytestmark = [pytest.mark.cpu_test, pytest.mark.skip_global_cleanup]
+
+
+def test_rejected_request_cleanup_removes_sender_only_cache_entry():
+    model_config = ModelConfig(
+        model="llava-hf/llava-onevision-qwen2-0.5b-ov-hf",
+        mm_processor_cache_gb=1,
+    )
+    sender_cache = MultiModalProcessorSenderCache(model_config)
+    receiver_cache = MultiModalReceiverCache(model_config)
+
+    first_item = MultiModalKwargsItem.dummy()
+    sender_cache.get_and_update_item((first_item, []), "image_X")
+    assert sender_cache.is_cached_item("image_X")
+
+    sender_cache.discard_sender_cache_item("image_X")
+    assert not sender_cache.is_cached_item("image_X")
+
+    second_item = MultiModalKwargsItem.dummy()
+    forwarded_item, _ = sender_cache.get_and_update_item((second_item, []), "image_X")
+
+    assert forwarded_item is second_item
+    assert receiver_cache.get_and_update_item(forwarded_item, "image_X") is second_item

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -54,7 +54,7 @@ from vllm.entrypoints.serve.utils.request_logger import RequestLogger
 from vllm.entrypoints.serve.utils.tool_calls_utils import (
     maybe_filter_parallel_tool_calls,
 )
-from vllm.inputs import EngineInput, MultiModalPlaceholders
+from vllm.inputs import EngineInput, MultiModalHashes, MultiModalPlaceholders
 from vllm.logger import init_logger
 from vllm.logprobs import Logprob
 from vllm.outputs import RequestOutput
@@ -284,16 +284,24 @@ class OpenAIServingChat(GenerateBaseServing):
                 request_id if len(engine_inputs) == 1 else f"{request_id}_{i}"
             )
 
-            max_tokens = get_max_tokens(
-                max_model_len,
-                request.max_completion_tokens
-                if request.max_completion_tokens is not None
-                else request.max_tokens,
-                self._extract_prompt_len(engine_input),
-                self.default_sampling_params,
-                self.override_max_tokens,
-                truncate_prompt_tokens=request.truncate_prompt_tokens,
-            )
+            try:
+                max_tokens = get_max_tokens(
+                    max_model_len,
+                    request.max_completion_tokens
+                    if request.max_completion_tokens is not None
+                    else request.max_tokens,
+                    self._extract_prompt_len(engine_input),
+                    self.default_sampling_params,
+                    self.override_max_tokens,
+                    truncate_prompt_tokens=request.truncate_prompt_tokens,
+                )
+            except ValueError:
+                for rendered_input in engine_inputs:
+                    if mm_hashes := cast(
+                        MultiModalHashes | None, rendered_input.get("mm_hashes")
+                    ):
+                        self.renderer.discard_mm_cache_entries(mm_hashes)
+                raise
 
             sampling_params: SamplingParams | BeamSearchParams
             if request.use_beam_search:

--- a/vllm/multimodal/cache.py
+++ b/vllm/multimodal/cache.py
@@ -299,6 +299,10 @@ class BaseMultiModalProcessorCache(
         """Close the underlying cache, if needed."""
         pass
 
+    def discard_sender_cache_item(self, mm_hash: str) -> None:
+        """Discard a sender-side cache item after a rejected request."""
+        pass
+
     @abstractmethod
     def touch_sender_cache_item(self, mm_hash: str) -> None:
         """
@@ -368,6 +372,10 @@ class MultiModalProcessorOnlyCache(BaseMultiModalProcessorCache):
         self._cache.touch(mm_hash)
 
     @override
+    def discard_sender_cache_item(self, mm_hash: str) -> None:
+        self._cache.pop(mm_hash, None)
+
+    @override
     def clear_cache(self) -> None:
         self._cache.clear()
 
@@ -424,6 +432,10 @@ class MultiModalProcessorSenderCache(BaseMultiModalProcessorCache):
     @override
     def touch_sender_cache_item(self, mm_hash: str) -> None:
         self._cache.touch(mm_hash)
+
+    @override
+    def discard_sender_cache_item(self, mm_hash: str) -> None:
+        self._cache.pop(mm_hash, None)
 
     @override
     def clear_cache(self) -> None:

--- a/vllm/renderers/base.py
+++ b/vllm/renderers/base.py
@@ -175,6 +175,14 @@ class BaseRenderer(ABC, Generic[_T]):
 
         return self.mm_processor.cache
 
+    def discard_mm_cache_entries(self, mm_hashes: Mapping[str, list[str]]) -> None:
+        mm_processor_cache = self.mm_processor_cache
+        if mm_processor_cache is None:
+            return
+        for hashes in mm_hashes.values():
+            for mm_hash in hashes:
+                mm_processor_cache.discard_sender_cache_item(mm_hash)
+
     def stat_mm_cache(self) -> MultiModalCacheStats | None:
         mm_cache_stats = self._mm_cache_stats
         if mm_cache_stats is None:


### PR DESCRIPTION
# Roll back mirrored multimodal cache entries after rejection

## What this fixes

The multimodal IPC cache has a sender side in the renderer and a receiver side in the engine. The
renderer inserted image data into its cache before the final prompt-length check. If that check
rejected the request, the engine never saw the new entry, but the renderer kept it.

For example, request A can contain an image and a prompt that is one token too long. Before this
change, A was rejected after the renderer cached the image. Later, request B using the same image
was sent as a cache reference because the renderer believed the engine already had it. The engine
did not, so B failed on a missing cache entry and could make the shared engine unhealthy. After
this change, rejecting A also removes its newly inserted sender-side entries, and B sends the
image normally.

## Why it matters

An ordinary multimodal client could use a rejected request to put the two sides of the IPC cache
out of sync, causing a later request—possibly another tenant's—to fail. This affects deployments
using the mirrored multimodal IPC cache path.

## The change

When prompt-length admission rejects a rendered request, the renderer now walks the request's
multimodal hashes and discards those items from the sender cache. LRU and shared-memory cache
implementations expose the same discard operation, which is a no-op when an entry is already
absent.

## How it was tested

Without the fix, the focused reject-then-reuse test failed; with the fix, it passed. The test
confirms that a rejected request removes the sender entry and that the next request with the same
media does not emit a stale cache-only reference.

## Reference

Advisory: GHSA-ph3r-5jfg-f84f

Track B: this is a public PR against `vllm-project/vllm@main`.

## Credit

- @KernelClint (Clinton Thomas) and @dhalf (Lucas Bourtoule)
- Patch the Planet (Trail of Bits + OpenAI collaboration); discovered using GPT-5.5-Cyber

All commits include DCO `Signed-off-by` trailers.
