### PR TITLE
Validate scale-out multimodal data before engine handoff

### DIFF
--- a/tests/entrypoints/scale_out/token_in_token_out/test_protocol.py
+++ b/tests/entrypoints/scale_out/token_in_token_out/test_protocol.py
@@ -9,7 +9,13 @@ fail loudly if the validator semantics ever drift.
 
 import json
 
-from vllm.entrypoints.scale_out.token_in_token_out.protocol import GenerateRequest
+import pytest
+
+from vllm.entrypoints.scale_out.token_in_token_out.protocol import (
+    GenerateRequest,
+    MultiModalFeatures,
+    PlaceholderRangeInfo,
+)
 from vllm.sampling_params import SamplingParams
 
 
@@ -68,3 +74,39 @@ def test_internal_instance_construction_treats_all_as_provided():
     assert req.is_sampling_param_provided("temperature")
     # And keys we never touched should also count as provided in this path.
     assert req.is_sampling_param_provided("top_p")
+
+
+def test_multimodal_features_reject_mismatched_parallel_fields():
+    with pytest.raises(ValueError, match="same length"):
+        MultiModalFeatures(
+            mm_hashes={"image": ["a", "b"]},
+            mm_placeholders={"image": [PlaceholderRangeInfo(offset=0, length=1)]},
+            kwargs_data={"image": ["encoded"]},
+        )
+
+
+def test_multimodal_features_reject_overlapping_placeholders():
+    with pytest.raises(ValueError, match="non-overlapping"):
+        MultiModalFeatures(
+            mm_hashes={"image": ["a", "b"]},
+            mm_placeholders={
+                "image": [
+                    PlaceholderRangeInfo(offset=1, length=2),
+                    PlaceholderRangeInfo(offset=2, length=2),
+                ]
+            },
+            kwargs_data={"image": ["a", "b"]},
+        )
+
+
+def test_generate_request_rejects_placeholder_outside_prompt():
+    with pytest.raises(ValueError, match="within the token_ids sequence"):
+        GenerateRequest(
+            token_ids=[1, 2, 3],
+            sampling_params=SamplingParams(),
+            features=MultiModalFeatures(
+                mm_hashes={"image": ["a"]},
+                mm_placeholders={"image": [PlaceholderRangeInfo(offset=2, length=2)]},
+                kwargs_data={"image": ["encoded"]},
+            ),
+        )

--- a/vllm/entrypoints/scale_out/token_in_token_out/protocol.py
+++ b/vllm/entrypoints/scale_out/token_in_token_out/protocol.py
@@ -33,10 +33,10 @@ from vllm.utils import random_uuid
 class PlaceholderRangeInfo(BaseModel):
     """Serializable placeholder location for a single multi-modal item."""
 
-    offset: int
+    offset: int = Field(ge=0)
     """Start index of the placeholder tokens in the prompt."""
 
-    length: int
+    length: int = Field(gt=0)
     """Number of placeholder tokens."""
 
     # TODO: add ``is_embed: list[bool] | None`` once the /generate side
@@ -66,6 +66,47 @@ class MultiModalFeatures(BaseModel):
     the item should be resolved from cache.  The entire field is
     ``None`` for metadata-only (cache-hit) responses.
     """
+
+    @model_validator(mode="after")
+    def _validate_parallel_fields(self) -> "MultiModalFeatures":
+        modalities = set(self.mm_hashes)
+        if set(self.mm_placeholders) != modalities:
+            raise ValueError(
+                "mm_hashes and mm_placeholders must use the same modalities"
+            )
+        if self.kwargs_data is not None and set(self.kwargs_data) != modalities:
+            raise ValueError("kwargs_data must use the same modalities as mm_hashes")
+
+        flattened_ranges: list[tuple[int, int]] = []
+        for modality in modalities:
+            num_hashes = len(self.mm_hashes[modality])
+            num_placeholders = len(self.mm_placeholders[modality])
+            if num_hashes != num_placeholders:
+                raise ValueError(
+                    f"{modality} mm_hashes and mm_placeholders must have "
+                    "the same length"
+                )
+            if (
+                self.kwargs_data is not None
+                and len(self.kwargs_data[modality]) != num_hashes
+            ):
+                raise ValueError(
+                    f"{modality} kwargs_data and mm_hashes must have the same length"
+                )
+            flattened_ranges.extend(
+                (placeholder.offset, placeholder.offset + placeholder.length)
+                for placeholder in self.mm_placeholders[modality]
+            )
+
+        flattened_ranges.sort()
+        for (offset, end), (next_offset, _) in zip(
+            flattened_ranges, flattened_ranges[1:]
+        ):
+            if next_offset < end:
+                raise ValueError(
+                    "mm_placeholders must be globally non-overlapping and sorted"
+                )
+        return self
 
 
 class GenerateRequest(BaseModel):
@@ -183,6 +224,20 @@ class GenerateRequest(BaseModel):
         if isinstance(data, dict):
             validate_cache_salt(data.get("cache_salt"))
         return data
+
+    @model_validator(mode="after")
+    def _validate_multimodal_feature_bounds(self) -> "GenerateRequest":
+        if self.features is None:
+            return self
+
+        prompt_len = len(self.token_ids)
+        for ranges in self.features.mm_placeholders.values():
+            for placeholder in ranges:
+                if placeholder.offset + placeholder.length > prompt_len:
+                    raise ValueError(
+                        "mm_placeholders must remain within the token_ids sequence"
+                    )
+        return self
 
     def is_sampling_param_provided(self, name: str) -> bool:
         """Whether the caller explicitly set ``sampling_params.<name>``.


### PR DESCRIPTION
# Validate scale-out multimodal data before engine handoff

## What this fixes

The scale-out API separates a trusted render request from a later generate request. The generate
route accepted the returned multimodal `features` object from the client and rebuilt internal
tensors, layout choices, placeholder ranges, and cache keys without checking that they still
matched the active model or the rendered data.

For example, a client can render a 32×32 Qwen image, change only its grid from `[1,4,4]` to
`[1,132,132]`, and replay it to `/inference/v1/generate`. Before this change, the engine trusted the
larger grid while the pixel tensor still held 4 rows. The request returned 500, the GPU reported an
illegal memory access, and `/health` returned 503. After this change, vLLM compares the grid with
the actual tensor before the vision encoder and rejects the mismatch as request data.

## Why it matters

On a deployment using scale-out multimodal serving, an authenticated client could stop the shared
engine with one altered render body. Other altered fields could make a request reuse another
request's cached encoder data or lose the model's sparse placeholder selection, producing wrong
cross-request results.

## The change

| Commit | Site | What now happens |
|---|---|---|
| `d05404f` | PTP-VLLM-025 — Qwen grid geometry | Grid dimensions must be positive, merge-compatible, and consistent with the pixel-tensor rows before encoding. |
| `b969204` | PTP-VLLM-026 — field layout tag | Decoded fields are rebound to the active model's declared layout; a caller-selected conflicting layout is rejected. |
| `803fa4d` | PTP-VLLM-027 — placeholder ranges | Offsets and lengths must be positive, non-overlapping, inside the prompt, and parallel to the feature lists. |
| `ab24a35` | PTP-VLLM-112 — sparse placeholder mask | Render and generate serialization preserve the per-token `is_embed` mask and verify its length. |
| `8501006` | PTP-VLLM-121 — multimodal cache key | Cache keys are derived from the serialized tensor payload, not a caller-supplied hash; cache-only reads are rejected. |

## How it was tested

| Site | Without the fix | With the fix |
|---|---:|---:|
| PTP-VLLM-025 | 22 failed, 4 passed | 26 passed |
| PTP-VLLM-026 | 6 failed, 5 passed | 11 passed |
| PTP-VLLM-027 | 3 failed, 5 passed | 8 passed |
| PTP-VLLM-112 | 2 failed | 2 passed |
| PTP-VLLM-121 | collection failed | 4 passed |

The tests mutate one field at a time and retain valid controls. The earlier live Qwen replay also
changed from HTTP 500 with an unhealthy engine to an early request rejection with the engine
remaining healthy.

## Reference

Advisory: GHSA-ph72-cqr5-qpp7

Track B: this is a public PR against `vllm-project/vllm@main`.

## Credit

- @KernelClint (Clinton Thomas) and @dhalf (Lucas Bourtoule)
- Patch the Planet (Trail of Bits + OpenAI collaboration); discovered using GPT-5.5-Cyber

All commits include DCO `Signed-off-by` trailers.
