### PR TITLE
Cap the cumulative length of realtime sessions

### DIFF
--- a/rust/src/engine-core-client/src/tests/client.rs
+++ b/rust/src/engine-core-client/src/tests/client.rs
@@ -2737,7 +2737,11 @@ fn python_msgpack_fixtures_match_rust_encoding() {
                         finish_reason: Some(
                             Length,
                         ),
-                        stop_reason: None,
+                        stop_reason: Some(
+                            Text(
+                                "streaming-length-cap",
+                            ),
+                        ),
                         events: None,
                         kv_transfer_params: None,
                         ec_transfer_params: None,

--- a/rust/src/engine-core-client/src/tests/python_compat.py
+++ b/rust/src/engine-core-client/src/tests/python_compat.py
@@ -200,6 +200,7 @@ outputs = EngineCoreOutputs(
             request_id="req-1",
             new_token_ids=[7, 8],
             finish_reason=FinishReason.LENGTH,
+            stop_reason="streaming-length-cap",
         )
     ],
     finished_requests={"req-1"},

--- a/tests/v1/engine/test_output_processor.py
+++ b/tests/v1/engine/test_output_processor.py
@@ -5,6 +5,7 @@ import math
 import time
 from unittest.mock import MagicMock
 
+import msgspec
 import pytest
 
 from tests.v1.engine.utils import (
@@ -23,6 +24,7 @@ from vllm.tokenizers import TokenizerLike
 from vllm.v1.engine import (
     EngineCoreEvent,
     EngineCoreEventType,
+    EngineCoreOutput,
     EngineCoreOutputs,
     EngineCoreRequest,
     FinishReason,
@@ -681,6 +683,95 @@ def test_logprobs_processor(
 
     assert output_processor.get_num_unfinished_requests() == 0
     assert not output_processor.has_unfinished_requests()
+
+
+def test_terminal_streaming_output_finishes_request_without_applying_queued_update():
+    output_processor = OutputProcessor(None, log_stats=False)
+    request = EngineCoreRequest(
+        request_id="request-int",
+        external_req_id="request",
+        prompt_token_ids=[1, 2, 3],
+        mm_features=None,
+        arrival_time=0,
+        lora_request=None,
+        cache_salt=None,
+        data_parallel_rank=None,
+        sampling_params=SamplingParams(max_tokens=1, detokenize=False),
+        pooling_params=None,
+        resumable=True,
+    )
+    output_processor.add_request(request, None)
+    output_processor.add_request(
+        EngineCoreRequest(
+            request_id="request-int",
+            external_req_id="request",
+            prompt_token_ids=[4, 5],
+            mm_features=None,
+            arrival_time=1,
+            lora_request=None,
+            cache_salt=None,
+            data_parallel_rank=None,
+            sampling_params=SamplingParams(max_tokens=1, detokenize=False),
+            pooling_params=None,
+            resumable=True,
+        ),
+        None,
+    )
+
+    processed_outputs = output_processor.process_outputs(
+        [
+            EngineCoreOutput(
+                request_id="request-int",
+                new_token_ids=[],
+                finish_reason=FinishReason.LENGTH,
+            )
+        ],
+        finished_request_ids={"request-int"},
+    )
+
+    assert len(processed_outputs.request_outputs) == 1
+    request_output = processed_outputs.request_outputs[0]
+    assert request_output.finished
+    assert request_output.outputs[0].finish_reason == "length"
+    assert processed_outputs.reqs_to_abort == ["request-int"]
+    assert not output_processor.has_unfinished_requests()
+
+
+def test_engine_core_output_stop_reason_wire_position_remains_compatible():
+    # Mirror the preexisting Rust tuple order so inserting a field before
+    # stop_reason fails at the real wire boundary.
+    # mypy does not model msgspec's metaclass subclass options.
+    class LegacyEngineCoreOutput(  # type: ignore[call-arg]
+        msgspec.Struct,
+        array_like=True,
+        omit_defaults=True,
+    ):
+        request_id: str
+        new_token_ids: list[int]
+        new_logprobs: object | None = None
+        new_prompt_logprobs_tensors: object | None = None
+        pooling_output: object | None = None
+        finish_reason: FinishReason | None = None
+        stop_reason: int | str | None = None
+        events: object | None = None
+        kv_transfer_params: object | None = None
+        trace_headers: object | None = None
+        prefill_stats: object | None = None
+        routed_experts: object | None = None
+        num_nans_in_logits: int = 0
+
+    payload = msgspec.msgpack.encode(
+        EngineCoreOutput(
+            request_id="request-int",
+            new_token_ids=[],
+            finish_reason=FinishReason.LENGTH,
+            stop_reason="streaming-length-cap",
+        )
+    )
+
+    decoded = msgspec.msgpack.decode(payload, type=LegacyEngineCoreOutput)
+
+    assert decoded.stop_reason == "streaming-length-cap"
 
 
 @pytest.mark.parametrize(

--- a/tests/v1/streaming_input/test_async_llm_streaming.py
+++ b/tests/v1/streaming_input/test_async_llm_streaming.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import asyncio
+import contextlib
 from collections.abc import AsyncGenerator
 from unittest.mock import AsyncMock, MagicMock
 
@@ -10,8 +11,18 @@ import pytest
 from vllm.engine.protocol import StreamingInput
 from vllm.outputs import RequestOutput
 from vllm.sampling_params import RequestOutputKind, SamplingParams
+from vllm.v1.engine import (
+    EngineCoreOutput,
+    EngineCoreOutputs,
+    EngineCoreRequest,
+    FinishReason,
+)
 from vllm.v1.engine.async_llm import AsyncLLM
-from vllm.v1.engine.output_processor import RequestOutputCollector
+from vllm.v1.engine.core_client import DPLBAsyncMPClient
+from vllm.v1.engine.output_processor import (
+    OutputProcessorOutput,
+    RequestOutputCollector,
+)
 
 
 @pytest.fixture
@@ -104,6 +115,210 @@ def make_output(request_id: str, finished: bool) -> RequestOutput:
         outputs=[],
         finished=finished,
     )
+
+
+def test_dplb_resumable_updates_reuse_existing_route():
+    client = object.__new__(DPLBAsyncMPClient)
+    client.client_count = 1
+    client.reqs_in_flight = {}
+    client.streaming_req_ids = set()
+    client.pending_streaming_cleanup_req_ids = set()
+    client.core_engines = [b"\x00\x00", b"\x01\x00"]
+    client.lb_engines = [[0, 0], [0, 0]]
+    client.eng_start_index = 0
+
+    def make_request() -> EngineCoreRequest:
+        return EngineCoreRequest(
+            request_id="stream",
+            prompt_token_ids=[1],
+            mm_features=None,
+            sampling_params=SamplingParams(max_tokens=1),
+            pooling_params=None,
+            arrival_time=0.0,
+            lora_request=None,
+            cache_salt=None,
+            data_parallel_rank=None,
+            resumable=True,
+        )
+
+    first_engine = client.get_core_engine_for_request(make_request())
+    second_engine = client.get_core_engine_for_request(make_request())
+
+    assert second_engine == first_engine
+    assert client.reqs_in_flight == {"stream": first_engine}
+    assert client.lb_engines == [[1, 0], [0, 0]]
+
+
+def test_dplb_final_streaming_sentinel_reuses_existing_route():
+    client = object.__new__(DPLBAsyncMPClient)
+    client.client_count = 1
+    client.reqs_in_flight = {}
+    client.streaming_req_ids = set()
+    client.pending_streaming_cleanup_req_ids = set()
+    client.core_engines = [b"\x00\x00", b"\x01\x00"]
+    client.lb_engines = [[0, 0], [0, 0]]
+    client.eng_start_index = 0
+
+    resumable_request = EngineCoreRequest(
+        request_id="stream",
+        prompt_token_ids=[1],
+        mm_features=None,
+        sampling_params=SamplingParams(max_tokens=1),
+        pooling_params=None,
+        arrival_time=0.0,
+        lora_request=None,
+        cache_salt=None,
+        data_parallel_rank=None,
+        resumable=True,
+    )
+    final_sentinel = EngineCoreRequest(
+        request_id="stream",
+        prompt_token_ids=[0],
+        mm_features=None,
+        sampling_params=SamplingParams(max_tokens=1),
+        pooling_params=None,
+        arrival_time=0.0,
+        lora_request=None,
+        cache_salt=None,
+        data_parallel_rank=None,
+    )
+
+    first_engine = client.get_core_engine_for_request(resumable_request)
+    final_engine = client.get_core_engine_for_request(final_sentinel)
+
+    assert final_engine == first_engine
+    assert client.reqs_in_flight == {"stream": first_engine}
+    assert client.lb_engines == [[1, 0], [0, 0]]
+
+
+@pytest.mark.asyncio
+async def test_dplb_terminal_streaming_route_survives_until_abort_ack():
+    client = object.__new__(DPLBAsyncMPClient)
+    engine = b"\x01\x00"
+    client.reqs_in_flight = {
+        "terminal": engine,
+        "ordinary": engine,
+    }
+    client.streaming_req_ids = {"terminal"}
+    client.pending_streaming_cleanup_req_ids = set()
+    client.resources = MagicMock()
+    client.resources.engine_dead = False
+
+    terminal_outputs = EngineCoreOutputs(
+        outputs=[
+            EngineCoreOutput("terminal", [], finish_reason=FinishReason.LENGTH),
+        ],
+        finished_requests={"terminal"},
+    )
+    await DPLBAsyncMPClient.process_engine_outputs(client, terminal_outputs)
+    await DPLBAsyncMPClient.process_engine_outputs(
+        client,
+        EngineCoreOutputs(
+            outputs=[
+                EngineCoreOutput("ordinary", [1], finish_reason=FinishReason.LENGTH),
+            ],
+            finished_requests={"ordinary"},
+        ),
+    )
+
+    assert client.reqs_in_flight == {"terminal": engine}
+
+    abort_calls: list[tuple[list[str], bytes]] = []
+    abort_seen = asyncio.Event()
+
+    async def abort_requests(request_ids: list[str], target_engine: bytes):
+        abort_calls.append((request_ids, target_engine))
+        abort_seen.set()
+
+    client._abort_requests = abort_requests
+    outputs_delivered = False
+
+    async def get_output_async():
+        nonlocal outputs_delivered
+        if not outputs_delivered:
+            outputs_delivered = True
+            return terminal_outputs
+        await asyncio.Future()
+
+    client.get_output_async = get_output_async
+    output_processor = MagicMock()
+    output_processor.process_outputs.return_value = OutputProcessorOutput(
+        request_outputs=[],
+        reqs_to_abort=["terminal"],
+    )
+
+    llm = object.__new__(AsyncLLM)
+    llm.output_handler = None
+    llm.engine_core = client
+    llm.output_processor = output_processor
+    llm.log_stats = False
+    llm.logger_manager = None
+    llm.renderer = MagicMock()
+
+    AsyncLLM._run_output_handler(llm)
+    assert llm.output_handler is not None
+    try:
+        await asyncio.wait_for(abort_seen.wait(), timeout=1.0)
+        await asyncio.sleep(0)
+
+        assert abort_calls == [(["terminal"], engine)]
+        assert "terminal" not in client.reqs_in_flight
+        assert not client.streaming_req_ids
+    finally:
+        llm.output_handler.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await llm.output_handler
+        llm.engine_core = None
+
+
+@pytest.mark.asyncio
+async def test_dplb_finished_only_batch_waits_for_terminal_streaming_cleanup_ack():
+    client = object.__new__(DPLBAsyncMPClient)
+    engine = b"\x01\x00"
+    client.reqs_in_flight = {"terminal": engine}
+    client.streaming_req_ids = {"terminal"}
+    client.pending_streaming_cleanup_req_ids = set()
+
+    await DPLBAsyncMPClient.process_engine_outputs(
+        client,
+        EngineCoreOutputs(
+            outputs=[
+                EngineCoreOutput("terminal", [], finish_reason=FinishReason.LENGTH),
+            ],
+            finished_requests={"terminal"},
+        ),
+    )
+    await DPLBAsyncMPClient.process_engine_outputs(
+        client,
+        EngineCoreOutputs(finished_requests={"terminal"}),
+    )
+
+    assert client.reqs_in_flight == {"terminal": engine}
+    assert client.streaming_req_ids == {"terminal"}
+
+    await client.cleanup_finished_requests_async({"terminal"})
+
+    assert not client.reqs_in_flight
+    assert not client.streaming_req_ids
+    assert not client.pending_streaming_cleanup_req_ids
+
+
+@pytest.mark.asyncio
+async def test_dplb_finished_only_streaming_completion_cleans_without_terminal_output():
+    client = object.__new__(DPLBAsyncMPClient)
+    engine = b"\x01\x00"
+    client.reqs_in_flight = {"finished-only": engine}
+    client.streaming_req_ids = {"finished-only"}
+    client.pending_streaming_cleanup_req_ids = set()
+
+    await DPLBAsyncMPClient.process_engine_outputs(
+        client,
+        EngineCoreOutputs(finished_requests={"finished-only"}),
+    )
+
+    assert not client.reqs_in_flight
+    assert not client.streaming_req_ids
+    assert not client.pending_streaming_cleanup_req_ids
 
 
 @pytest.mark.asyncio

--- a/tests/v1/streaming_input/test_scheduler_streaming.py
+++ b/tests/v1/streaming_input/test_scheduler_streaming.py
@@ -1,11 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import queue
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import torch
 
+from vllm import PoolingParams
 from vllm.config import DeviceConfig, VllmConfig
 from vllm.multimodal.inputs import (
     MultiModalFeatureSpec,
@@ -14,7 +16,9 @@ from vllm.multimodal.inputs import (
 )
 from vllm.sampling_params import SamplingParams
 from vllm.v1.core.sched.scheduler import Scheduler
-from vllm.v1.engine import FinishReason
+from vllm.v1.engine import EngineCoreRequest, EngineCoreRequestType, FinishReason
+from vllm.v1.engine.core import EngineCore, EngineCoreProc
+from vllm.v1.engine.core_client import InprocClient
 from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
     KVCacheConfig,
@@ -48,14 +52,25 @@ class DummyRequest(Request):
         )
 
 
-def create_scheduler() -> Scheduler:
+class DummyPoolingRequest(Request):
+    def __init__(self, request_id: str, prompt_token_ids: list[int]):
+        super().__init__(
+            request_id=request_id,
+            prompt_token_ids=prompt_token_ids,
+            sampling_params=None,
+            pooling_params=PoolingParams(task="embed"),
+            resumable=False,
+        )
+
+
+def create_scheduler(max_model_len: int = 1024) -> Scheduler:
     vllm_config = VllmConfig(device_config=DeviceConfig("cpu"))
     vllm_config.model_config = MagicMock()
     vllm_config.model_config.skip_tokenizer_init = True
     vllm_config.model_config.is_multimodal_model = False
     vllm_config.model_config.is_encoder_decoder = False
     vllm_config.model_config.is_diffusion = False
-    vllm_config.model_config.max_model_len = 1024
+    vllm_config.model_config.max_model_len = max_model_len
     vllm_config.model_config.enable_return_routed_experts = False
     vllm_config.cache_config = MagicMock()
     vllm_config.cache_config.num_gpu_blocks = 1000
@@ -275,6 +290,465 @@ class TestStreamingScheduler(unittest.TestCase):
         _ = scheduler.schedule()
 
         assert session.status == RequestStatus.RUNNING
+
+    def test_resumed_session_over_max_model_len_is_length_capped(self):
+        scheduler = create_scheduler(max_model_len=8)
+        session = DummyRequest(
+            request_id="session",
+            prompt_token_ids=[0, 1, 2, 3],
+        )
+        scheduler.add_request(session)
+        session.append_output_token_ids([4, 5])
+        session.num_computed_tokens = 5
+        session.status = RequestStatus.WAITING_FOR_STREAMING_REQ
+        scheduler.num_waiting_for_streaming_input += 1
+        original_tokens = list(session.all_token_ids)
+        original_output_tokens = list(session.output_token_ids)
+
+        finished_reqs = scheduler.add_request(
+            DummyRequest(
+                request_id="session",
+                prompt_token_ids=[6, 7, 8, 9],
+            )
+        )
+
+        assert finished_reqs == [(session.request_id, session.client_index)]
+        assert session.status == RequestStatus.FINISHED_LENGTH_CAPPED
+        assert session.request_id not in scheduler.requests
+        assert list(session.all_token_ids) == original_tokens
+        assert list(session.output_token_ids) == original_output_tokens
+
+    def test_resumed_session_below_max_model_len_continues(self):
+        scheduler = create_scheduler(max_model_len=8)
+        session = DummyRequest(
+            request_id="session",
+            prompt_token_ids=[0, 1, 2, 3],
+        )
+        scheduler.add_request(session)
+        session.append_output_token_ids([4, 5])
+        session.num_computed_tokens = 5
+        session.status = RequestStatus.WAITING_FOR_STREAMING_REQ
+        scheduler.num_waiting_for_streaming_input += 1
+
+        scheduler.add_request(
+            DummyRequest(
+                request_id="session",
+                prompt_token_ids=[6, 7],
+            )
+        )
+
+        assert session.status == RequestStatus.WAITING
+        assert session.prompt_token_ids == [0, 1, 2, 3, 4, 6, 7]
+        output = scheduler.schedule()
+        assert output.num_scheduled_tokens[session.request_id] == 2
+
+    def test_direct_overcap_resume_returns_length_capped_request(self):
+        scheduler = create_scheduler(max_model_len=8)
+        session = DummyRequest(
+            request_id="session",
+            prompt_token_ids=[0, 1, 2, 3],
+        )
+        scheduler.add_request(session)
+        session.append_output_token_ids([4, 5])
+        session.num_computed_tokens = 5
+        session.status = RequestStatus.WAITING_FOR_STREAMING_REQ
+        scheduler.num_waiting_for_streaming_input += 1
+        engine_core = MagicMock(spec=EngineCore)
+        engine_core.scheduler = scheduler
+
+        finished_reqs = EngineCore.add_request(
+            engine_core,
+            DummyRequest(
+                request_id="session",
+                prompt_token_ids=[6, 7, 8, 9],
+            ),
+        )
+
+        assert finished_reqs == [(session.request_id, session.client_index)]
+
+    def test_direct_overcap_resume_emits_terminal_length_output(self):
+        scheduler = create_scheduler(max_model_len=8)
+        session = DummyRequest(
+            request_id="session",
+            prompt_token_ids=[0, 1, 2, 3],
+        )
+        scheduler.add_request(session)
+        session.append_output_token_ids([4, 5])
+        session.num_computed_tokens = 5
+        session.status = RequestStatus.WAITING_FOR_STREAMING_REQ
+        scheduler.num_waiting_for_streaming_input += 1
+        engine_core = MagicMock(spec=EngineCoreProc)
+        engine_core.scheduler = scheduler
+        engine_core.output_queue = queue.Queue()
+        engine_core._send_finished_outputs = (
+            EngineCoreProc._send_finished_outputs.__get__(engine_core, EngineCoreProc)
+        )
+        engine_core._send_finish_outputs_to_client = (
+            EngineCoreProc._send_finish_outputs_to_client.__get__(
+                engine_core, EngineCoreProc
+            )
+        )
+
+        EngineCoreProc.add_request(
+            engine_core,
+            DummyRequest(
+                request_id="session",
+                prompt_token_ids=[6, 7, 8, 9],
+            ),
+        )
+
+        client_index, engine_outputs = engine_core.output_queue.get_nowait()
+
+        assert client_index == session.client_index
+        assert engine_outputs.finished_requests == {session.request_id}
+        assert engine_outputs.outputs[0].finish_reason == FinishReason.LENGTH
+
+    def test_inproc_client_buffers_direct_overcap_terminal_output(self):
+        scheduler = create_scheduler(max_model_len=8)
+        session = DummyRequest(
+            request_id="session",
+            prompt_token_ids=[0, 1, 2, 3],
+        )
+        scheduler.add_request(session)
+        session.append_output_token_ids([4, 5])
+        session.num_computed_tokens = 5
+        session.status = RequestStatus.WAITING_FOR_STREAMING_REQ
+        scheduler.num_waiting_for_streaming_input += 1
+        resumed_request = DummyRequest(
+            request_id="session",
+            prompt_token_ids=[6, 7, 8, 9],
+        )
+        engine_core = MagicMock(spec=EngineCore)
+        engine_core.scheduler = scheduler
+        engine_core.preprocess_add_request.return_value = (resumed_request, 0)
+        engine_core.add_request = EngineCore.add_request.__get__(
+            engine_core, EngineCore
+        )
+        engine_core.step_fn = MagicMock(return_value=({}, False))
+
+        with patch("vllm.v1.engine.core_client.EngineCore", return_value=engine_core):
+            client = InprocClient()
+
+        client.add_request(
+            EngineCoreRequest(
+                request_id="session",
+                prompt_token_ids=[6, 7, 8, 9],
+                mm_features=None,
+                sampling_params=SamplingParams(max_tokens=16),
+                pooling_params=None,
+                arrival_time=0.0,
+                lora_request=None,
+                cache_salt=None,
+                data_parallel_rank=None,
+                resumable=True,
+            )
+        )
+        outputs = client.get_output()
+
+        assert outputs.finished_requests == {session.request_id}
+        assert outputs.outputs[0].finish_reason == FinishReason.LENGTH
+        engine_core.step_fn.assert_not_called()
+
+    def test_inproc_client_stays_live_for_buffered_overcap_cleanup(self):
+        scheduler = create_scheduler(max_model_len=8)
+        session = DummyRequest(
+            request_id="session",
+            prompt_token_ids=[0, 1, 2, 3],
+        )
+        scheduler.add_request(session)
+        session.append_output_token_ids([4, 5])
+        session.num_computed_tokens = 5
+        session.status = RequestStatus.WAITING_FOR_STREAMING_REQ
+        scheduler.num_waiting_for_streaming_input += 1
+        resumed_request = DummyRequest(
+            request_id="session",
+            prompt_token_ids=[6, 7, 8, 9],
+        )
+        engine_core = MagicMock(spec=EngineCore)
+        engine_core.scheduler = scheduler
+        engine_core.preprocess_add_request.return_value = (resumed_request, 0)
+        engine_core.add_request = EngineCore.add_request.__get__(
+            engine_core, EngineCore
+        )
+
+        def step_fn():
+            scheduler.schedule()
+            return {}, False
+
+        engine_core.step_fn = MagicMock(side_effect=step_fn)
+
+        with patch("vllm.v1.engine.core_client.EngineCore", return_value=engine_core):
+            client = InprocClient()
+
+        client.add_request(
+            EngineCoreRequest(
+                request_id="session",
+                prompt_token_ids=[6, 7, 8, 9],
+                mm_features=None,
+                sampling_params=SamplingParams(max_tokens=16),
+                pooling_params=None,
+                arrival_time=0.0,
+                lora_request=None,
+                cache_salt=None,
+                data_parallel_rank=None,
+                resumable=True,
+            )
+        )
+        client.get_output()
+
+        engine_core.step_fn.assert_not_called()
+        assert scheduler.has_finished_requests()
+        assert client.dp_engines_running()
+
+        client.get_output()
+
+        engine_core.step_fn.assert_called_once_with()
+        assert not scheduler.has_finished_requests()
+        assert not client.dp_engines_running()
+
+    def test_direct_overcap_resume_drops_already_queued_same_id_chunk(self):
+        scheduler = create_scheduler(max_model_len=8)
+        scheduler.kv_cache_manager.allocate_slots = MagicMock(
+            wraps=scheduler.kv_cache_manager.allocate_slots
+        )
+        session = DummyRequest(
+            request_id="session",
+            prompt_token_ids=[0, 1, 2, 3],
+        )
+        scheduler.add_request(session)
+        session.append_output_token_ids([4, 5])
+        session.num_computed_tokens = 5
+        session.status = RequestStatus.WAITING_FOR_STREAMING_REQ
+        scheduler.num_waiting_for_streaming_input += 1
+        engine_core = MagicMock(spec=EngineCoreProc)
+        engine_core.scheduler = scheduler
+        engine_core.input_queue = queue.Queue()
+        engine_core.output_queue = queue.Queue()
+        engine_core.has_work.return_value = True
+        engine_core._reject_add_in_shutdown.return_value = False
+        engine_core.add_request = EngineCoreProc.add_request.__get__(
+            engine_core, EngineCoreProc
+        )
+        engine_core._handle_client_request = (
+            EngineCoreProc._handle_client_request.__get__(engine_core, EngineCoreProc)
+        )
+        engine_core._send_finished_outputs = (
+            EngineCoreProc._send_finished_outputs.__get__(engine_core, EngineCoreProc)
+        )
+        engine_core._send_finish_outputs_to_client = (
+            EngineCoreProc._send_finish_outputs_to_client.__get__(
+                engine_core, EngineCoreProc
+            )
+        )
+
+        engine_core.input_queue.put_nowait(
+            (
+                EngineCoreRequestType.ADD,
+                (
+                    DummyRequest(
+                        request_id="session",
+                        prompt_token_ids=[6, 7, 8, 9],
+                    ),
+                    0,
+                ),
+            )
+        )
+        engine_core.input_queue.put_nowait(
+            (
+                EngineCoreRequestType.ADD,
+                (
+                    DummyRequest(
+                        request_id="session",
+                        prompt_token_ids=[10],
+                    ),
+                    0,
+                ),
+            )
+        )
+
+        EngineCoreProc._process_input_queue(engine_core)
+        scheduler_output = scheduler.schedule()
+
+        assert session.request_id not in scheduler.requests
+        assert session.request_id not in scheduler_output.num_scheduled_tokens
+        assert not scheduler_output.scheduled_new_reqs
+        scheduler.kv_cache_manager.allocate_slots.assert_not_called()
+
+    def test_abort_ack_allows_reuse_of_terminal_streaming_request_id(self):
+        scheduler = create_scheduler(max_model_len=8)
+        session = DummyRequest(
+            request_id="session",
+            prompt_token_ids=[0, 1, 2, 3],
+        )
+        scheduler.add_request(session)
+        session.append_output_token_ids([4, 5])
+        session.num_computed_tokens = 5
+        session.status = RequestStatus.WAITING_FOR_STREAMING_REQ
+        scheduler.num_waiting_for_streaming_input += 1
+        engine_core = MagicMock(spec=EngineCore)
+        engine_core.scheduler = scheduler
+
+        EngineCore.add_request(
+            engine_core,
+            DummyRequest(
+                request_id="session",
+                prompt_token_ids=[6, 7, 8, 9],
+            ),
+        )
+
+        assert session.request_id in scheduler.terminal_streaming_req_ids
+
+        EngineCore.abort_requests(engine_core, [session.request_id])
+
+        assert session.request_id not in scheduler.terminal_streaming_req_ids
+
+        replacement = DummyRequest(
+            request_id="session",
+            prompt_token_ids=[10],
+        )
+        EngineCore.add_request(engine_core, replacement)
+
+        assert scheduler.requests[session.request_id] is replacement
+        assert replacement.status == RequestStatus.WAITING
+
+    def test_schedule_time_overcap_session_emits_terminal_length_output(self):
+        scheduler = create_scheduler(max_model_len=8)
+        session = DummyRequest(
+            request_id="session",
+            prompt_token_ids=list(range(9)),
+        )
+        scheduler.add_request(session)
+
+        scheduler_output = scheduler.schedule()
+        engine_outputs = scheduler.update_from_output(
+            scheduler_output,
+            ModelRunnerOutput(req_ids=[], req_id_to_index={}),
+        )[session.client_index]
+
+        assert session.request_id in scheduler.terminal_streaming_req_ids
+        assert engine_outputs.finished_requests == {session.request_id}
+        assert engine_outputs.outputs[0].request_id == session.request_id
+        assert engine_outputs.outputs[0].finish_reason == FinishReason.LENGTH
+
+    def test_schedule_time_overcap_session_drops_same_id_until_abort_ack(self):
+        scheduler = create_scheduler(max_model_len=8)
+        session = DummyRequest(
+            request_id="session",
+            prompt_token_ids=list(range(9)),
+        )
+        scheduler.add_request(session)
+        scheduler.schedule()
+
+        scheduler.add_request(
+            DummyRequest(
+                request_id="session",
+                prompt_token_ids=[10],
+            )
+        )
+
+        assert session.request_id in scheduler.terminal_streaming_req_ids
+        assert session.request_id not in scheduler.requests
+
+        engine_core = MagicMock(spec=EngineCore)
+        engine_core.scheduler = scheduler
+        EngineCore.abort_requests(engine_core, [session.request_id])
+
+        replacement = DummyRequest(
+            request_id="session",
+            prompt_token_ids=[11],
+        )
+        EngineCore.add_request(engine_core, replacement)
+
+        assert session.request_id not in scheduler.terminal_streaming_req_ids
+        assert scheduler.requests[session.request_id] is replacement
+        assert replacement.status == RequestStatus.WAITING
+
+    def test_queued_overcap_session_reports_length_finish_reason(self):
+        scheduler = create_scheduler(max_model_len=8)
+        session = DummyRequest(
+            request_id="session",
+            prompt_token_ids=[0, 1, 2, 3],
+        )
+        scheduler.add_request(session)
+        scheduler_output = scheduler.schedule()
+        scheduler.add_request(
+            DummyRequest(
+                request_id="session",
+                prompt_token_ids=[6, 7, 8, 9],
+            )
+        )
+        model_output = ModelRunnerOutput(
+            req_ids=[session.request_id],
+            req_id_to_index={session.request_id: 0},
+            sampled_token_ids=[[STOP_TOKEN]],
+            logprobs=None,
+            prompt_logprobs_dict={session.request_id: None},
+            pooler_output=[],
+        )
+
+        engine_outputs = scheduler.update_from_output(scheduler_output, model_output)[
+            session.client_index
+        ]
+        engine_output = engine_outputs.outputs[0]
+
+        assert engine_output.finish_reason == FinishReason.LENGTH
+        assert engine_outputs.finished_requests == {session.request_id}
+        assert session.status == RequestStatus.FINISHED_LENGTH_CAPPED
+
+    def test_pooling_request_at_max_model_len_still_schedules(self):
+        scheduler = create_scheduler(max_model_len=8)
+        request = DummyPoolingRequest(
+            request_id="pooling",
+            prompt_token_ids=list(range(8)),
+        )
+        scheduler.add_request(request)
+
+        output = scheduler.schedule()
+
+        assert output.num_scheduled_tokens[request.request_id] == 8
+        assert request.status == RequestStatus.RUNNING
+
+    def test_overcap_waiting_session_does_not_allocate_slots(self):
+        scheduler = create_scheduler(max_model_len=8)
+        overcap = DummyRequest(
+            request_id="overcap",
+            prompt_token_ids=list(range(9)),
+        )
+        tail = DummyRequest(
+            request_id="tail",
+            prompt_token_ids=[10],
+        )
+        scheduler.add_request(overcap)
+        scheduler.add_request(tail)
+
+        output = scheduler.schedule()
+
+        assert output.finished_req_ids == {overcap.request_id}
+        assert overcap.status == RequestStatus.FINISHED_LENGTH_CAPPED
+        assert overcap.request_id not in output.num_scheduled_tokens
+        assert [request.req_id for request in output.scheduled_new_reqs] == [
+            tail.request_id
+        ]
+
+    def test_overcap_async_kv_waiting_session_does_not_allocate_slots(self):
+        scheduler = create_scheduler(max_model_len=8)
+        scheduler.connector = MagicMock()
+        scheduler.connector.get_num_new_matched_tokens.return_value = (1, True)
+        scheduler.connector.request_finished.return_value = (False, None)
+        scheduler.kv_cache_manager.allocate_slots = MagicMock(
+            wraps=scheduler.kv_cache_manager.allocate_slots
+        )
+        overcap = DummyRequest(
+            request_id="overcap",
+            prompt_token_ids=list(range(9)),
+        )
+        scheduler.add_request(overcap)
+
+        output = scheduler.schedule()
+
+        assert output.finished_req_ids == {overcap.request_id}
+        assert overcap.status == RequestStatus.FINISHED_LENGTH_CAPPED
+        scheduler.kv_cache_manager.allocate_slots.assert_not_called()
 
     def test_update_request_as_session_with_output_tokens(self):
         scheduler = create_scheduler()

--- a/vllm/v1/core/sched/interface.py
+++ b/vllm/v1/core/sched/interface.py
@@ -133,11 +133,15 @@ class SchedulerInterface(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def add_request(self, request: "Request") -> None:
+    def add_request(self, request: "Request") -> list[tuple[str, int]]:
         """Add a new request to the scheduler's internal queue.
 
         Args:
             request: The new request being added.
+
+        Returns:
+            Requests that were synchronously length-capped while applying a
+            resumed streaming-input update.
         """
         raise NotImplementedError
 

--- a/vllm/v1/core/sched/output.py
+++ b/vllm/v1/core/sched/output.py
@@ -303,6 +303,11 @@ class SchedulerOutput:
     # Number of spec tokens to schedule for the next step.
     num_spec_tokens_to_schedule: int = 0
 
+    # Resumable requests length-capped while selecting waiting work for this
+    # step. These need a frontend-visible terminal output after the worker
+    # consumes this SchedulerOutput.
+    terminal_streaming_reqs: list[tuple[str, int]] | None = None
+
     @classmethod
     def make_empty(cls) -> "SchedulerOutput":
         return cls(

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -53,7 +53,12 @@ from vllm.v1.core.sched.request_queue import (
     create_request_queue,
 )
 from vllm.v1.core.sched.utils import check_stop, remove_all
-from vllm.v1.engine import EngineCoreEventType, EngineCoreOutput, EngineCoreOutputs
+from vllm.v1.engine import (
+    EngineCoreEventType,
+    EngineCoreOutput,
+    EngineCoreOutputs,
+    FinishReason,
+)
 from vllm.v1.kv_cache_interface import (
     KVCacheConfig,
     MambaSpec,
@@ -210,6 +215,10 @@ class Scheduler(SchedulerInterface):
         # requests so that they can free the cached states for those requests.
         # This is flushed at the end of each scheduling step.
         self.finished_req_ids: set[str] = set()
+        # Resumable request IDs that finished in the engine but may still have
+        # same-ID input chunks queued until the frontend handles the terminal
+        # output and acknowledges cleanup through the abort path.
+        self.terminal_streaming_req_ids: set[str] = set()
 
         # IDs of requests preempted since the last call to schedule().
         self.reset_preempted_req_ids: set[str] = set()
@@ -577,6 +586,7 @@ class Scheduler(SchedulerInterface):
         scheduled_resumed_reqs: list[Request] = []
         scheduled_running_reqs: list[Request] = []
         preempted_reqs: list[Request] = []
+        terminal_streaming_reqs: list[tuple[str, int]] = []
 
         req_to_new_blocks: dict[str, KVCacheBlocks] = {}
         num_scheduled_tokens: dict[str, int] = {}
@@ -1015,6 +1025,22 @@ class Scheduler(SchedulerInterface):
                 external_load_encoder_input = []
                 new_encoder_compute_budget = encoder_compute_budget
                 pad_spec_decode = False
+                max_num_new_tokens = request.num_tokens - num_computed_tokens
+                if request.resumable:
+                    max_prompt_len = (
+                        self.max_model_len - self.num_sampled_tokens_per_step
+                    )
+                    if request.num_tokens > max_prompt_len:
+                        terminal_streaming_reqs.extend(
+                            self._finish_length_capped_streaming_request(request)
+                        )
+                        continue
+                    max_num_new_tokens = max_prompt_len - num_computed_tokens
+                    if max_num_new_tokens <= 0:
+                        terminal_streaming_reqs.extend(
+                            self._finish_length_capped_streaming_request(request)
+                        )
+                        continue
 
                 if load_kv_async:
                     # KVTransfer: loading remote KV, do not allocate for new work.
@@ -1030,7 +1056,10 @@ class Scheduler(SchedulerInterface):
                     # We use `request.num_tokens` instead of
                     # `request.num_prompt_tokens` to consider the resumed
                     # requests, which have output tokens.
-                    num_new_tokens = request.num_tokens - num_computed_tokens
+                    num_new_tokens = min(
+                        request.num_tokens - num_computed_tokens,
+                        max_num_new_tokens,
+                    )
 
                     # Pad new decode requests to uniform spec decoding size to
                     # preserve full cudagraph for this step.
@@ -1421,6 +1450,7 @@ class Scheduler(SchedulerInterface):
             kv_connector_block_state=kv_connector_block_state,
             num_spec_tokens_to_schedule=num_spec_tokens_to_schedule,
             ec_manager_metadata=self.encoder_cache_manager.get_manager_metadata(),
+            terminal_streaming_reqs=terminal_streaming_reqs or None,
         )
 
         # NOTE(Kuntai): this function is designed for multiple purposes:
@@ -1564,12 +1594,22 @@ class Scheduler(SchedulerInterface):
 
     def _update_request_as_session(
         self, session: Request, update: StreamingUpdate
-    ) -> None:
+    ) -> bool:
         """
         Updates the waiting session with the next streaming update.
 
         Discards the last sampled output token from the prior input chunk.
+
+        Returns:
+            True if the update was applied, or False if its cumulative prompt
+            would exceed the model length available before sampling.
         """
+        renewed_prompt_len = session.num_computed_tokens + len(
+            update.prompt_token_ids or ()
+        )
+        max_prompt_len = self.max_model_len - self.num_sampled_tokens_per_step
+        if renewed_prompt_len > max_prompt_len:
+            return False
 
         # Current streaming input behaviour: Keep only computed output tokens
         # (discard final sampled output token).
@@ -1604,6 +1644,8 @@ class Scheduler(SchedulerInterface):
 
         if self.log_stats:
             session.record_event(EngineCoreEventType.QUEUED)
+
+        return True
 
     def _make_cached_request_data(
         self,
@@ -1892,6 +1934,14 @@ class Scheduler(SchedulerInterface):
             perf_stats = self.perf_metrics.get_step_perf_stats_per_gpu(scheduler_output)
 
         outputs: dict[int, list[EngineCoreOutput]] = defaultdict(list)
+        # Terminal resumable requests need the batch-level finished signal even
+        # when the broader finished-set optimization is disabled.
+        terminal_streaming_req_ids_by_client: dict[int, set[str]] = defaultdict(set)
+        for req_id, client_index in scheduler_output.terminal_streaming_reqs or ():
+            outputs[client_index].append(
+                EngineCoreOutput(req_id, [], finish_reason=FinishReason.LENGTH)
+            )
+            terminal_streaming_req_ids_by_client[client_index].add(req_id)
         spec_decoding_stats: SpecDecodingStats | None = None
 
         failed_kv_load_req_ids = None
@@ -2009,6 +2059,7 @@ class Scheduler(SchedulerInterface):
                 self._free_encoder_inputs(request)
 
             stopped = False
+            finished = False
             new_logprobs = None
             new_sampling_mask = None
             new_token_ids = generated_token_ids
@@ -2125,7 +2176,15 @@ class Scheduler(SchedulerInterface):
                 finish_reason = request.get_finished_reason()
                 finished = self._handle_stopped_request(request)
                 if finished:
+                    updated_finish_reason = request.get_finished_reason()
+                    if updated_finish_reason is not None:
+                        finish_reason = updated_finish_reason
                     kv_transfer_params, ec_transfer_params = self._free_request(request)
+                    if request.resumable:
+                        self.terminal_streaming_req_ids.add(req_id)
+                        terminal_streaming_req_ids_by_client[request.client_index].add(
+                            req_id
+                        )
 
                 if status_before_stop == RequestStatus.RUNNING:
                     stopped_running_reqs.add(request)
@@ -2277,6 +2336,16 @@ class Scheduler(SchedulerInterface):
                     )
             finished_req_ids.clear()
 
+        for client_index, finished_set in terminal_streaming_req_ids_by_client.items():
+            if (eco := engine_core_outputs.get(client_index)) is not None:
+                if eco.finished_requests is None:
+                    eco.finished_requests = set()
+                eco.finished_requests.update(finished_set)
+            else:
+                engine_core_outputs[client_index] = EngineCoreOutputs(
+                    finished_requests=finished_set
+                )
+
         if (
             stats := self.make_stats(
                 spec_decoding_stats,
@@ -2340,7 +2409,9 @@ class Scheduler(SchedulerInterface):
             if update is None:
                 # Streaming request finished.
                 return True
-            self._update_request_as_session(request, update)
+            if not self._update_request_as_session(request, update):
+                request.status = RequestStatus.FINISHED_LENGTH_CAPPED
+                return True
         else:
             request.status = RequestStatus.WAITING_FOR_STREAMING_REQ
             self.num_waiting_for_streaming_input += 1
@@ -2472,7 +2543,24 @@ class Scheduler(SchedulerInterface):
         """Returns the fraction of the KV cache currently in use (0.0-1.0)."""
         return self.kv_cache_manager.usage
 
-    def add_request(self, request: Request) -> None:
+    def _finish_length_capped_streaming_request(
+        self, request: Request
+    ) -> list[tuple[str, int]]:
+        assert request.resumable
+        self.terminal_streaming_req_ids.add(request.request_id)
+        finished_requests = self.finish_requests(
+            request.request_id,
+            RequestStatus.FINISHED_LENGTH_CAPPED,
+        )
+        return [
+            (finished_request.request_id, finished_request.client_index)
+            for finished_request in finished_requests
+        ]
+
+    def add_request(self, request: Request) -> list[tuple[str, int]]:
+        if request.request_id in self.terminal_streaming_req_ids:
+            return []
+
         existing = self.requests.get(request.request_id)
         if existing is not None:
             update = StreamingUpdate.from_request(request)
@@ -2482,7 +2570,8 @@ class Scheduler(SchedulerInterface):
                 existing.streaming_queue.append(update)
             elif update is not None:
                 # Commence next input chunk.
-                self._update_request_as_session(existing, update)
+                if not self._update_request_as_session(existing, update):
+                    return self._finish_length_capped_streaming_request(existing)
             else:
                 # Streaming-input session finished.
                 self.finish_requests(request.request_id, RequestStatus.FINISHED_ABORTED)
@@ -2499,6 +2588,7 @@ class Scheduler(SchedulerInterface):
                 self.connector.on_new_request(request)
             if self.log_stats:
                 request.record_event(EngineCoreEventType.QUEUED)
+        return []
 
     def finish_requests(
         self, request_ids: str | Iterable[str] | None, finished_status: RequestStatus
@@ -2515,12 +2605,19 @@ class Scheduler(SchedulerInterface):
             already finished.
         """
         assert RequestStatus.is_finished(finished_status)
+        clear_all_terminal_streaming_req_ids = request_ids is None
         if isinstance(request_ids, str):
             request_ids = (request_ids,)
         elif request_ids is not None:
             request_ids = set(request_ids)
         else:
             request_ids = self.requests.keys()
+
+        if finished_status == RequestStatus.FINISHED_ABORTED:
+            if clear_all_terminal_streaming_req_ids:
+                self.terminal_streaming_req_ids.clear()
+            else:
+                self.terminal_streaming_req_ids.difference_update(request_ids)
 
         running_requests_to_remove = set()
         waiting_requests_to_remove = []

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -786,9 +786,21 @@ class AsyncLLM(EngineClient):
                     for start in range(0, num_outputs, chunk_size):
                         end = start + chunk_size
                         outputs_slice = engine_core_outputs[start:end]
+                        finished_output_ids = (
+                            {
+                                output.request_id
+                                for output in outputs_slice
+                                if output.request_id in outputs.finished_requests
+                            }
+                            if outputs.finished_requests
+                            else set()
+                        )
                         # 2) Process EngineCoreOutputs.
                         processed_outputs = output_processor.process_outputs(
-                            outputs_slice, outputs.timestamp, iteration_stats
+                            outputs_slice,
+                            outputs.timestamp,
+                            iteration_stats,
+                            outputs.finished_requests,
                         )
                         # NOTE: RequestOutputs are pushed to their queues.
                         assert not processed_outputs.request_outputs
@@ -811,6 +823,10 @@ class AsyncLLM(EngineClient):
                         if processed_outputs.reqs_to_abort:
                             await engine_core.abort_requests_async(
                                 processed_outputs.reqs_to_abort
+                            )
+                        if finished_output_ids:
+                            await engine_core.cleanup_finished_requests_async(
+                                finished_output_ids
                             )
 
                     output_processor.update_scheduler_stats(outputs.scheduler_stats)

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -441,7 +441,9 @@ class EngineCore:
             supported_pooling_tasks,
         )
 
-    def add_request(self, request: Request, request_wave: int = 0):
+    def add_request(
+        self, request: Request, request_wave: int = 0
+    ) -> list[tuple[str, int]]:
         """Add request to the scheduler.
 
         `request_wave`: indicate which wave of requests this is expected to
@@ -481,11 +483,12 @@ class EngineCore:
                 "Disabling ECTransfer for this request."
             )
 
-        self.scheduler.add_request(request)
+        length_capped_reqs = self.scheduler.add_request(request)
         if request.abort_immediately:
             # Immediately abort so the connector's request_finished hook runs
             # to free any pre-admission KV-transfer resources.
             self.abort_requests([request.request_id])
+        return length_capped_reqs
 
     def abort_requests(self, request_ids: list[str]):
         """Abort requests from the scheduler."""
@@ -1962,14 +1965,25 @@ class EngineCoreProc(EngineCore):
         """
         return not self.has_work()
 
+    def add_request(
+        self, request: Request, request_wave: int = 0
+    ) -> list[tuple[str, int]]:
+        length_capped_reqs = super().add_request(request, request_wave)
+        if length_capped_reqs:
+            self._send_finished_outputs(length_capped_reqs, FinishReason.LENGTH)
+        return length_capped_reqs
+
     def _send_finish_outputs_to_client(
-        self, req_ids: list[str], client_index: int, finish_reason: FinishReason
+        self,
+        req_ids: list[str],
+        client_index: int,
+        finish_reason: FinishReason,
     ) -> None:
         outputs = [
             EngineCoreOutput(req_id, [], finish_reason=finish_reason)
             for req_id in req_ids
         ]
-        eco = EngineCoreOutputs(finished_requests=req_ids, outputs=outputs)
+        eco = EngineCoreOutputs(finished_requests=set(req_ids), outputs=outputs)
         self.output_queue.put_nowait((client_index, eco))
 
     def _send_abort_outputs_to_client(
@@ -1981,6 +1995,24 @@ class EngineCoreProc(EngineCore):
         self, req_ids: list[str], client_index: int
     ) -> None:
         self._send_finish_outputs_to_client(req_ids, client_index, FinishReason.ERROR)
+
+    def _send_finished_outputs(
+        self,
+        finished_reqs: list[tuple[str, int]],
+        finish_reason: FinishReason,
+    ) -> None:
+        if not finished_reqs:
+            return
+
+        by_client = defaultdict[int, set[str]](set)
+        for req_id, client_index in finished_reqs:
+            by_client[client_index].add(req_id)
+        for client_index, req_ids in by_client.items():
+            self._send_finish_outputs_to_client(
+                list(req_ids),
+                client_index,
+                finish_reason,
+            )
 
     def _send_abort_outputs(self, aborted_reqs: list[Request]) -> None:
         # TODO(nick) this will be moved inside the scheduler
@@ -2084,8 +2116,10 @@ class DPEngineCoreProc(EngineCoreProc):
 
         return False
 
-    def add_request(self, request: Request, request_wave: int = 0):
-        super().add_request(request, request_wave)
+    def add_request(
+        self, request: Request, request_wave: int = 0
+    ) -> list[tuple[str, int]]:
+        length_capped_reqs = super().add_request(request, request_wave)
         if self.has_coordinator and request_wave != self.current_wave:
             if request_wave > self.current_wave:
                 self.current_wave = request_wave
@@ -2099,6 +2133,7 @@ class DPEngineCoreProc(EngineCoreProc):
                 self.output_queue.put_nowait(
                     (-1, EngineCoreOutputs(start_wave=self.current_wave))
                 )
+        return length_capped_reqs
 
     def resume_scheduler(self):
         if self.pending_pause or (self.engines_running and self.ignore_start_dp_wave):

--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -7,7 +7,7 @@ import sys
 import uuid
 import weakref
 from abc import ABC, abstractmethod
-from collections import Counter, defaultdict
+from collections import Counter, defaultdict, deque
 from collections.abc import Awaitable, Callable, Sequence
 from concurrent.futures import Future
 from dataclasses import dataclass
@@ -39,10 +39,12 @@ from vllm.v1.engine import (
     EEP_NOTIFICATION_CALL_ID,
     FT_STATUS_CALL_ID,
     EEPNotificationType,
+    EngineCoreOutput,
     EngineCoreOutputs,
     EngineCoreReadyResponse,
     EngineCoreRequest,
     EngineCoreRequestType,
+    FinishReason,
     PauseMode,
     ReconfigureDistributedRequest,
     ReconfigureRankType,
@@ -295,6 +297,9 @@ class EngineCoreClient(ABC):
     async def abort_requests_async(self, request_ids: list[str]) -> None:
         raise NotImplementedError
 
+    async def cleanup_finished_requests_async(self, request_ids: set[str]) -> None:
+        return None
+
     async def add_lora_async(self, lora_request: LoRARequest) -> bool:
         raise NotImplementedError
 
@@ -357,8 +362,12 @@ class InprocClient(EngineCoreClient):
             log_stats,
             executor_fail_callback=executor_fail_callback,
         )
+        self._pending_outputs: deque[EngineCoreOutputs] = deque()
 
     def get_output(self) -> EngineCoreOutputs:
+        if self._pending_outputs:
+            return self._pending_outputs.popleft()
+
         outputs, model_executed = self.engine_core.step_fn()
         self.engine_core.post_step(model_executed=model_executed)
         return outputs and outputs.get(0) or EngineCoreOutputs()
@@ -368,7 +377,18 @@ class InprocClient(EngineCoreClient):
 
     def add_request(self, request: EngineCoreRequest) -> None:
         req, request_wave = self.engine_core.preprocess_add_request(request)
-        self.engine_core.add_request(req, request_wave)
+        length_capped_reqs = self.engine_core.add_request(req, request_wave)
+        if length_capped_reqs:
+            req_ids = [req_id for req_id, _ in length_capped_reqs]
+            self._pending_outputs.append(
+                EngineCoreOutputs(
+                    outputs=[
+                        EngineCoreOutput(req_id, [], finish_reason=FinishReason.LENGTH)
+                        for req_id in req_ids
+                    ],
+                    finished_requests=set(req_ids),
+                )
+            )
 
     def abort_requests(self, request_ids: list[str]) -> None:
         if len(request_ids) > 0:
@@ -441,7 +461,7 @@ class InprocClient(EngineCoreClient):
         return self.engine_core.collective_rpc(method, timeout, args, kwargs)
 
     def dp_engines_running(self) -> bool:
-        return False
+        return self.engine_core.scheduler.has_finished_requests()
 
 
 @dataclass
@@ -1522,6 +1542,9 @@ class DPLBAsyncMPClient(DPAsyncMPClient):
 
         # To route aborts to the correct engine.
         self.reqs_in_flight: dict[str, EngineIdentity] = {}
+        self.streaming_req_ids: set[str] = set()
+        # Terminal streaming outputs remain routable until frontend cleanup.
+        self.pending_streaming_cleanup_req_ids: set[str] = set()
 
         # Exact per-engine count of this client's unfinished requests.
         self.engine_inflight: Counter[EngineIdentity] = Counter()
@@ -1544,6 +1567,12 @@ class DPLBAsyncMPClient(DPAsyncMPClient):
         ) // client_count
 
     def get_core_engine_for_request(self, request: EngineCoreRequest) -> EngineIdentity:
+        existing_engine = self.reqs_in_flight.get(request.request_id)
+        if existing_engine is not None and (
+            request.resumable or request.request_id in self.streaming_req_ids
+        ):
+            return existing_engine
+
         # Engines are in rank order.
         if (eng_index := request.data_parallel_rank) is None and (
             eng_index := get_late_interaction_engine_index(
@@ -1594,6 +1623,8 @@ class DPLBAsyncMPClient(DPAsyncMPClient):
         # Record which engine is chosen for this request, to handle aborts.
         self.reqs_in_flight[request.request_id] = chosen_engine
         self.engine_inflight[chosen_engine] += 1
+        if request.resumable:
+            self.streaming_req_ids.add(request.request_id)
         return chosen_engine
 
     async def call_utility_async(self, method: str, *args) -> Any:
@@ -1611,10 +1642,26 @@ class DPLBAsyncMPClient(DPAsyncMPClient):
     async def process_engine_outputs(
         self: "DPLBAsyncMPClient", outputs: EngineCoreOutputs
     ):
-        if outputs.finished_requests and self.reqs_in_flight:
-            for req_id in outputs.finished_requests:
-                if (engine := self.reqs_in_flight.pop(req_id, None)) is not None:
-                    self.engine_inflight[engine] -= 1
+        if not outputs.finished_requests:
+            return
+
+        output_req_ids = {output.request_id for output in outputs.outputs}
+        self.pending_streaming_cleanup_req_ids.update(
+            outputs.finished_requests & output_req_ids & self.streaming_req_ids
+        )
+        for req_id in (
+            outputs.finished_requests - self.pending_streaming_cleanup_req_ids
+        ):
+            if (engine := self.reqs_in_flight.pop(req_id, None)) is not None:
+                self.engine_inflight[engine] -= 1
+            self.streaming_req_ids.discard(req_id)
+
+    async def cleanup_finished_requests_async(self, request_ids: set[str]) -> None:
+        for req_id in request_ids:
+            if (engine := self.reqs_in_flight.pop(req_id, None)) is not None:
+                self.engine_inflight[engine] -= 1
+            self.streaming_req_ids.discard(req_id)
+            self.pending_streaming_cleanup_req_ids.discard(req_id)
 
     @staticmethod
     async def eep_process_engine_core_notification(

--- a/vllm/v1/engine/llm_engine.py
+++ b/vllm/v1/engine/llm_engine.py
@@ -320,6 +320,7 @@ class LLMEngine:
                 outputs.outputs,
                 engine_core_timestamp=outputs.timestamp,
                 iteration_stats=iteration_stats,
+                finished_request_ids=outputs.finished_requests,
             )
             self.output_processor.update_scheduler_stats(outputs.scheduler_stats)
 

--- a/vllm/v1/engine/output_processor.py
+++ b/vllm/v1/engine/output_processor.py
@@ -624,6 +624,7 @@ class OutputProcessor:
         engine_core_outputs: list[EngineCoreOutput],
         engine_core_timestamp: float | None = None,
         iteration_stats: IterationStats | None = None,
+        finished_request_ids: set[str] | None = None,
     ) -> OutputProcessorOutput:
         """
         Process the EngineCoreOutputs:
@@ -664,6 +665,12 @@ class OutputProcessor:
             new_token_ids = engine_core_output.new_token_ids
             pooling_output = engine_core_output.pooling_output
             finish_reason = engine_core_output.finish_reason
+            request_finished_in_engine = (
+                finished_request_ids is not None and req_id in finished_request_ids
+            )
+            is_streaming_input_request = (
+                req_state.streaming_input or req_state.input_chunk_queue is not None
+            )
             stop_reason = engine_core_output.stop_reason
             kv_transfer_params = engine_core_output.kv_transfer_params
             ec_transfer_params = engine_core_output.ec_transfer_params
@@ -725,15 +732,21 @@ class OutputProcessor:
 
             # Free completed requests.
             if finish_reason is not None:
-                if req_state.streaming_input:
+                if req_state.streaming_input and not request_finished_in_engine:
                     if req_state.input_chunk_queue:
                         update = req_state.input_chunk_queue.popleft()
                         req_state.apply_streaming_update(update)
                     else:
                         req_state.input_chunk_queue = None
                 else:
+                    if request_finished_in_engine and req_state.queue is not None:
+                        req_state.queue.close()
                     self._finish_request(req_state)
-                    if not engine_core_output.finished:
+                    if request_finished_in_engine and is_streaming_input_request:
+                        # Acknowledge engine-terminal streaming cleanup only
+                        # after the frontend has stopped accepting input chunks.
+                        reqs_to_abort.append(req_id)
+                    elif not engine_core_output.finished:
                         # If req not finished in EngineCore, but Detokenizer
                         # detected stop string, abort needed in EngineCore.
                         reqs_to_abort.append(req_id)


### PR DESCRIPTION
# Cap the cumulative length of realtime sessions

## What this fixes

The realtime API checked individual inputs but did not re-check the model-length limit when a
resumable session appended more tokens under the same request ID.

For example, on a server with `max_model_len=64`, a client can start a realtime audio session and
append enough audio to grow the cumulative prompt to 65 tokens. Before this change, the scheduler
accepted the update, entered an invalid state, and left `/health` returning 503. After this change,
the scheduler detects that the update would exceed the remaining budget, ends that session with a
normal length-limit result, and keeps the engine healthy.

## Why it matters

An ordinary authenticated `/v1/realtime` client could stop the shared engine for every concurrent
user by growing one resumable session beyond the configured context length. This is a service
availability issue; no code execution or data disclosure is involved.

## The change

Session updates now check cumulative computed tokens plus the appended tokens against
`max_model_len` before sampling. Over-limit sessions finish with `FinishReason.LENGTH` and the
`streaming-length-cap` stop reason. The change also keeps terminal request IDs and routing state
until cleanup is acknowledged, so late same-ID chunks cannot revive a finished session and all
workers complete cleanup.

## How it was tested

The focused suite changed from 18 failures, 3 passes, and 44 deselected tests without the fix to
21 passes and 44 deselected tests with it. It covers direct and schedule-time over-limit updates,
same-ID cleanup, route retention, and in-process cleanup. The live replay changed the 65-over-64
case from an unhealthy engine (`/health` 503) to a length-capped session with `/health` 200.

## Reference

Advisory: GHSA-v2m4-5w72-jf6h

Track B: this is a public PR against `vllm-project/vllm@main`.

## Credit

- @KernelClint (Clinton Thomas) and @dhalf (Lucas Bourtoule)
- Patch the Planet (Trail of Bits + OpenAI collaboration); discovered using GPT-5.5-Cyber

All commits include DCO `Signed-off-by` trailers.
