### PR TITLE
[BugFix] Fix custom all-reduce graph IPC under expandable_segments

### DIFF
--- a/tests/distributed/test_custom_all_reduce_expandable_segments.py
+++ b/tests/distributed/test_custom_all_reduce_expandable_segments.py
@@ -1,0 +1,91 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Regression: custom AR graph capture under expandable_segments.
+
+Reproduces the failure mode from https://github.com/vllm-project/vllm/issues/42609
+where pre-capture VMM activations are not legacy-IPC exportable.
+
+Requires 2 GPUs with P2P. Run with:
+  PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True \\
+    torchrun --nproc_per_node=2 \\
+    tests/distributed/test_custom_all_reduce_expandable_segments.py
+"""
+
+from __future__ import annotations
+
+import os
+
+import torch
+import torch.distributed as dist
+
+# Must be set before CUDA allocator first use in this process.
+os.environ.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
+os.environ.setdefault("VLLM_SKIP_P2P_CHECK", "1")
+
+from vllm.distributed.device_communicators.custom_all_reduce import (  # noqa: E402
+    CustomAllreduce,
+    _tensor_is_legacy_ipc_capable,
+)
+
+
+def main() -> None:
+    dist.init_process_group(backend="gloo")
+    rank = dist.get_rank()
+    world_size = dist.get_world_size()
+    assert world_size == 2, "this regression test expects nproc_per_node=2"
+
+    torch.cuda.set_device(rank)
+    device = torch.device(f"cuda:{rank}")
+
+    # Allocate under expandable_segments *before* capture (the residual hole).
+    n = 4096
+    x = torch.full((n,), float(rank + 1), device=device, dtype=torch.float32)
+    # Best-effort: on expandable_segments this is often not legacy-IPC-capable.
+    # The fix must still succeed either way.
+    print(
+        f"rank{rank}: pre-capture legacy_ipc={_tensor_is_legacy_ipc_capable(x)}",
+        flush=True,
+    )
+
+    ca = CustomAllreduce(group=dist.group.WORLD, device=device, max_size=1 << 20)
+    assert not ca.disabled, f"rank{rank}: custom AR disabled at init"
+
+    # Eager path first.
+    out_e = ca.custom_all_reduce(x)
+    assert out_e is not None
+    torch.cuda.synchronize()
+    expected = float(sum(range(1, world_size + 1)))
+    err_e = (out_e - expected).abs().max().item()
+    assert err_e < 1e-5, f"rank{rank}: eager err={err_e}"
+
+    # Graph capture with pre-allocated input (must not crash at IPC meta).
+    g = torch.cuda.CUDAGraph()
+    s = torch.cuda.Stream()
+    s.wait_stream(torch.cuda.current_stream())
+    static_in = x.clone()
+    static_out = torch.empty_like(static_in)
+    with torch.cuda.stream(s):
+        with ca.capture():
+            g.capture_begin()
+            y = ca.custom_all_reduce(static_in)
+            assert y is not None
+            static_out.copy_(y)
+            g.capture_end()
+    torch.cuda.current_stream().wait_stream(s)
+    assert not ca.disabled, f"rank{rank}: custom AR disabled after capture"
+    print(f"rank{rank}: graph capture+register OK", flush=True)
+
+    static_in.fill_(float(rank + 1))
+    g.replay()
+    torch.cuda.synchronize()
+    err_g = (static_out - expected).abs().max().item()
+    assert err_g < 1e-5, f"rank{rank}: graph replay err={err_g}"
+    print(f"rank{rank}: graph replay OK err={err_g}", flush=True)
+
+    ca.close()
+    dist.barrier()
+    dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/distributed/test_custom_all_reduce_expandable_segments.py
+++ b/tests/distributed/test_custom_all_reduce_expandable_segments.py
@@ -2,90 +2,231 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Regression: custom AR graph capture under expandable_segments.
 
-Reproduces the failure mode from https://github.com/vllm-project/vllm/issues/42609
-where pre-capture VMM activations are not legacy-IPC exportable.
+Covers https://github.com/vllm-project/vllm/issues/42609 — pre-capture VMM
+activations are not legacy-IPC exportable; capture must not crash and must
+still produce a correct all-reduce.
 
-Requires 2 GPUs with P2P. Run with:
-  PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True \\
-    torchrun --nproc_per_node=2 \\
-    tests/distributed/test_custom_all_reduce_expandable_segments.py
+Also unit-tests nesting-safe expandable_segments disable (no GPU required).
 """
 
 from __future__ import annotations
 
 import os
+import queue
+from unittest.mock import patch
 
+import pytest
 import torch
 import torch.distributed as dist
+import torch.multiprocessing as mp
 
-# Must be set before CUDA allocator first use in this process.
-os.environ.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
-os.environ.setdefault("VLLM_SKIP_P2P_CHECK", "1")
-
-from vllm.distributed.device_communicators.custom_all_reduce import (  # noqa: E402
+from vllm.distributed.device_communicators import custom_all_reduce as car
+from vllm.distributed.device_communicators.custom_all_reduce import (
     CustomAllreduce,
+    _disable_expandable_segments_for_cuda_ipc,
+    _should_use_registered_buffer_for_capture,
     _tensor_is_legacy_ipc_capable,
 )
+from vllm.platforms import current_platform
 
 
-def main() -> None:
-    dist.init_process_group(backend="gloo")
-    rank = dist.get_rank()
-    world_size = dist.get_world_size()
-    assert world_size == 2, "this regression test expects nproc_per_node=2"
+# ---------------------------------------------------------------------------
+# Unit tests (CPU / no multi-GPU required)
+# ---------------------------------------------------------------------------
 
-    torch.cuda.set_device(rank)
-    device = torch.device(f"cuda:{rank}")
 
-    # Allocate under expandable_segments *before* capture (the residual hole).
-    n = 4096
-    x = torch.full((n,), float(rank + 1), device=device, dtype=torch.float32)
-    # Best-effort: on expandable_segments this is often not legacy-IPC-capable.
-    # The fix must still succeed either way.
-    print(
-        f"rank{rank}: pre-capture legacy_ipc={_tensor_is_legacy_ipc_capable(x)}",
-        flush=True,
+def test_should_use_registered_buffer_rocm_preserves_zero_copy(monkeypatch):
+    """Non-CUDA platforms must keep historical registered=True capture path."""
+    monkeypatch.setattr(current_platform, "is_cuda", lambda: False)
+    # Fake tensor; should never call the CUDA probe.
+    t = torch.zeros(8)
+    with patch.object(car, "_tensor_is_legacy_ipc_capable") as probe:
+        assert _should_use_registered_buffer_for_capture(t) is True
+        probe.assert_not_called()
+
+
+def test_should_use_registered_buffer_cuda_uses_probe(monkeypatch):
+    monkeypatch.setattr(current_platform, "is_cuda", lambda: True)
+    t = torch.zeros(8)
+    with patch.object(car, "_tensor_is_legacy_ipc_capable", return_value=False) as probe:
+        assert _should_use_registered_buffer_for_capture(t) is False
+        probe.assert_called_once()
+    with patch.object(car, "_tensor_is_legacy_ipc_capable", return_value=True) as probe:
+        assert _should_use_registered_buffer_for_capture(t) is True
+        probe.assert_called_once()
+
+
+def test_expandable_segments_disable_is_nested_safe(monkeypatch):
+    """Nested disable must only set False once and restore True once."""
+    calls: list[bool] = []
+
+    def fake_set(enabled: bool) -> None:
+        calls.append(enabled)
+
+    monkeypatch.setattr(car, "_set_expandable_segments", fake_set)
+    monkeypatch.setattr(car, "_env_expandable_segments_enabled", lambda: True)
+    monkeypatch.setattr(current_platform, "is_cuda", lambda: True)
+    # Reset depth in case a previous test left it non-zero.
+    car._expandable_segments_disable_depth = 0
+
+    with _disable_expandable_segments_for_cuda_ipc(True):
+        with _disable_expandable_segments_for_cuda_ipc(True):
+            assert car._expandable_segments_disable_depth == 2
+        assert car._expandable_segments_disable_depth == 1
+    assert car._expandable_segments_disable_depth == 0
+    assert calls == [False, True]
+
+
+def test_expandable_segments_disable_noop_when_inactive(monkeypatch):
+    calls: list[bool] = []
+    monkeypatch.setattr(
+        car, "_set_expandable_segments", lambda enabled: calls.append(enabled)
     )
+    monkeypatch.setattr(car, "_env_expandable_segments_enabled", lambda: True)
+    monkeypatch.setattr(current_platform, "is_cuda", lambda: True)
+    car._expandable_segments_disable_depth = 0
 
-    ca = CustomAllreduce(group=dist.group.WORLD, device=device, max_size=1 << 20)
-    assert not ca.disabled, f"rank{rank}: custom AR disabled at init"
-
-    # Eager path first.
-    out_e = ca.custom_all_reduce(x)
-    assert out_e is not None
-    torch.cuda.synchronize()
-    expected = float(sum(range(1, world_size + 1)))
-    err_e = (out_e - expected).abs().max().item()
-    assert err_e < 1e-5, f"rank{rank}: eager err={err_e}"
-
-    # Graph capture with pre-allocated input (must not crash at IPC meta).
-    g = torch.cuda.CUDAGraph()
-    s = torch.cuda.Stream()
-    s.wait_stream(torch.cuda.current_stream())
-    static_in = x.clone()
-    static_out = torch.empty_like(static_in)
-    with torch.cuda.stream(s):
-        with ca.capture():
-            g.capture_begin()
-            y = ca.custom_all_reduce(static_in)
-            assert y is not None
-            static_out.copy_(y)
-            g.capture_end()
-    torch.cuda.current_stream().wait_stream(s)
-    assert not ca.disabled, f"rank{rank}: custom AR disabled after capture"
-    print(f"rank{rank}: graph capture+register OK", flush=True)
-
-    static_in.fill_(float(rank + 1))
-    g.replay()
-    torch.cuda.synchronize()
-    err_g = (static_out - expected).abs().max().item()
-    assert err_g < 1e-5, f"rank{rank}: graph replay err={err_g}"
-    print(f"rank{rank}: graph replay OK err={err_g}", flush=True)
-
-    ca.close()
-    dist.barrier()
-    dist.destroy_process_group()
+    with _disable_expandable_segments_for_cuda_ipc(False):
+        pass
+    assert calls == []
+    assert car._expandable_segments_disable_depth == 0
 
 
-if __name__ == "__main__":
-    main()
+# ---------------------------------------------------------------------------
+# Multi-GPU integration (pytest + mp.spawn)
+# ---------------------------------------------------------------------------
+
+
+def _expandable_segments_graph_worker(
+    local_rank: int, world_size: int, result_q: mp.Queue
+) -> None:
+    # Must run before first CUDA alloc in this process.
+    os.environ["PYTORCH_CUDA_ALLOC_CONF"] = "expandable_segments:True"
+    os.environ.setdefault("VLLM_SKIP_P2P_CHECK", "1")
+    os.environ["RANK"] = str(local_rank)
+    os.environ["LOCAL_RANK"] = str(local_rank)
+    os.environ["WORLD_SIZE"] = str(world_size)
+    os.environ.setdefault("MASTER_ADDR", "127.0.0.1")
+    os.environ.setdefault("MASTER_PORT", "29527")
+
+    try:
+        torch.cuda.set_device(local_rank)
+        dist.init_process_group(backend="gloo")
+        rank = dist.get_rank()
+        device = torch.device(f"cuda:{rank}")
+
+        n = 4096
+        # Pre-capture allocation under expandable_segments (the residual hole).
+        x = torch.full((n,), float(rank + 1), device=device, dtype=torch.float32)
+        legacy = _tensor_is_legacy_ipc_capable(x)
+        # On expandable_segments we expect VMM → not legacy-IPC-capable.
+        # If the platform still reports capable, the fix is a no-op path but
+        # correctness must still hold — fail the test so CI notices.
+        if current_platform.is_cuda() and legacy:
+            result_q.put(
+                (
+                    rank,
+                    "SKIP_UNEXPECTED_LEGACY_IPC",
+                    "pre-capture tensor reported legacy_ipc=True under "
+                    "expandable_segments:True; cannot prove fallback path",
+                )
+            )
+            dist.destroy_process_group()
+            return
+
+        assert not _should_use_registered_buffer_for_capture(x), (
+            "CUDA capture should choose registered=False for non-legacy-IPC "
+            f"tensor (rank={rank})"
+        )
+
+        ca = CustomAllreduce(group=dist.group.WORLD, device=device, max_size=1 << 20)
+        if ca.disabled:
+            result_q.put((rank, "SKIP_CUSTOM_AR_DISABLED", None))
+            dist.destroy_process_group()
+            return
+
+        expected = float(sum(range(1, world_size + 1)))
+        out_e = ca.custom_all_reduce(x)
+        assert out_e is not None
+        torch.cuda.synchronize()
+        assert (out_e - expected).abs().max().item() < 1e-5
+
+        g = torch.cuda.CUDAGraph()
+        s = torch.cuda.Stream()
+        s.wait_stream(torch.cuda.current_stream())
+        static_in = x.clone()
+        # Clone under expandable_segments should also be non-legacy-IPC.
+        assert not _tensor_is_legacy_ipc_capable(static_in)
+        static_out = torch.empty_like(static_in)
+        with torch.cuda.stream(s):
+            with ca.capture():
+                g.capture_begin()
+                y = ca.custom_all_reduce(static_in)
+                assert y is not None
+                static_out.copy_(y)
+                g.capture_end()
+        torch.cuda.current_stream().wait_stream(s)
+
+        static_in.fill_(float(rank + 1))
+        g.replay()
+        torch.cuda.synchronize()
+        err_g = (static_out - expected).abs().max().item()
+        assert err_g < 1e-5, f"graph replay err={err_g}"
+
+        ca.close()
+        dist.barrier()
+        dist.destroy_process_group()
+        result_q.put((rank, "OK", err_g))
+    except Exception as e:
+        result_q.put((local_rank, "FAIL", repr(e)))
+
+
+@pytest.mark.skipif(
+    not current_platform.is_cuda(),
+    reason="expandable_segments legacy-IPC regression is CUDA-specific",
+)
+@pytest.mark.skipif(
+    torch.cuda.device_count() < 2,
+    reason="Needs 2 GPUs with P2P for custom AR graph IPC",
+)
+def test_custom_all_reduce_graph_pre_capture_vmm_expandable_segments():
+    """TP=2: pre-capture VMM input + expandable_segments must not crash."""
+    world_size = 2
+    ctx = mp.get_context("spawn")
+    result_q: mp.Queue = ctx.Queue()
+    procs = [
+        ctx.Process(
+            target=_expandable_segments_graph_worker,
+            args=(rank, world_size, result_q),
+        )
+        for rank in range(world_size)
+    ]
+    for p in procs:
+        p.start()
+    results = []
+    try:
+        for _ in range(world_size):
+            results.append(result_q.get(timeout=180))
+    except queue.Empty as e:
+        for p in procs:
+            p.kill()
+        raise TimeoutError("workers did not report results") from e
+    finally:
+        for p in procs:
+            p.join(timeout=30)
+            if p.is_alive():
+                p.kill()
+                p.join(5)
+
+    statuses = {r[1] for r in results}
+    if "FAIL" in statuses:
+        pytest.fail(f"worker failure: {results}")
+    if statuses == {"SKIP_CUSTOM_AR_DISABLED"}:
+        pytest.skip("Custom all-reduce disabled on this platform/config")
+    if "SKIP_UNEXPECTED_LEGACY_IPC" in statuses:
+        pytest.skip(
+            "Allocator did not produce non-legacy-IPC tensors under "
+            "expandable_segments:True; cannot prove fallback path"
+        )
+    assert statuses == {"OK"}, results
+    assert len(results) == world_size

--- a/vllm/distributed/device_communicators/custom_all_reduce.py
+++ b/vllm/distributed/device_communicators/custom_all_reduce.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import os
+import threading
 from contextlib import contextmanager
 from typing import cast
 
@@ -33,6 +34,17 @@ except ImportError:
 
 logger = init_logger(__name__)
 
+# Nesting-safe disable of expandable_segments for custom-AR capture.
+# Depth is process-global (allocator settings are process-global). Only the
+# outermost disable applies/restores the setting so nested capture() calls
+# cannot re-enable expandable_segments while an outer capture still needs it
+# off.
+_expandable_segments_disable_lock = threading.Lock()
+_expandable_segments_disable_depth = 0
+
+# Cached CUDA driver entry point for legacy-IPC probes (CUDA only).
+_cu_pointer_get_attribute = None
+
 
 def _set_expandable_segments(enabled: bool) -> None:
     """Best-effort toggle of PyTorch expandable_segments allocator setting."""
@@ -44,55 +56,94 @@ def _set_expandable_segments(enabled: bool) -> None:
         torch.cuda.memory._set_allocator_settings(conf)
 
 
+def _env_expandable_segments_enabled() -> bool:
+    conf = os.environ.get("PYTORCH_CUDA_ALLOC_CONF", "")
+    return "expandable_segments:True" in conf
+
+
 @contextmanager
 def _disable_expandable_segments_for_cuda_ipc(active: bool):
     """Temporarily disable expandable_segments during custom-AR graph capture.
 
     ``cudaIpcGetMemHandle`` only accepts ``cudaMalloc`` allocations. With
     ``PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True``, *new* device tensors
-    come from CUDA VMM segments and cannot be legacy-IPC exported (see
-    https://github.com/vllm-project/vllm/issues/42609).
+    come from CUDA VMM segments and cannot be legacy-IPC exported (see issue
+    #42609).
 
     Pre-existing VMM tensors are unchanged by this toggle; the capture path
-    must fall back to the pre-registered scratch buffer when
-    ``_tensor_is_legacy_ipc_capable`` is false.
+    must fall back to the pre-registered scratch buffer when the input is not
+    legacy-IPC-capable.
 
-    No-op when custom AR is disabled, platform is non-CUDA, or expandable
-    segments are not enabled.
+    Nested uses are refcounted so only the outermost disable/restores the
+    process-global allocator setting. No-op when custom AR is disabled,
+    platform is non-CUDA, or expandable segments are not enabled in the env.
     """
-    conf = os.environ.get("PYTORCH_CUDA_ALLOC_CONF", "")
+    global _expandable_segments_disable_depth
+
     should_disable = (
-        active and current_platform.is_cuda() and "expandable_segments:True" in conf
+        active and current_platform.is_cuda() and _env_expandable_segments_enabled()
     )
     if not should_disable:
         yield
         return
 
-    logger.info_once(
-        "Temporarily disabling expandable_segments during custom allreduce "
-        "CUDA graph capture for CUDA IPC compatibility."
-    )
-    try:
-        _set_expandable_segments(False)
-    except Exception as e:
-        logger.warning_once(
-            "Could not disable expandable_segments for custom AR capture: %s",
-            e,
-        )
+    entered = False
+    with _expandable_segments_disable_lock:
+        if _expandable_segments_disable_depth == 0:
+            logger.info_once(
+                "Temporarily disabling expandable_segments during custom "
+                "allreduce CUDA graph capture for CUDA IPC compatibility."
+            )
+            try:
+                _set_expandable_segments(False)
+            except Exception as e:
+                logger.warning_once(
+                    "Could not disable expandable_segments for custom AR "
+                    "capture: %s",
+                    e,
+                )
+                # Leave depth at 0; do not restore what we never changed.
+                should_disable = False
+        if should_disable:
+            _expandable_segments_disable_depth += 1
+            entered = True
+
+    if not entered:
         yield
         return
 
     try:
         yield
     finally:
-        try:
-            _set_expandable_segments(True)
-        except Exception as e:
-            logger.warning(
-                "Failed to restore expandable_segments:True after custom AR "
-                "capture: %s",
-                e,
-            )
+        with _expandable_segments_disable_lock:
+            _expandable_segments_disable_depth -= 1
+            if _expandable_segments_disable_depth == 0:
+                try:
+                    # Env still has expandable_segments:True; restore runtime.
+                    _set_expandable_segments(True)
+                except Exception as e:
+                    logger.warning(
+                        "Failed to restore expandable_segments:True after "
+                        "custom AR capture: %s",
+                        e,
+                    )
+
+
+def _get_cu_pointer_get_attribute():
+    """Lazily load and cache ``cuPointerGetAttribute`` from libcuda."""
+    global _cu_pointer_get_attribute
+    if _cu_pointer_get_attribute is not None:
+        return _cu_pointer_get_attribute
+
+    import ctypes
+
+    # CU_POINTER_ATTRIBUTE_IS_LEGACY_IPC_CAPABLE = 10 (cuda.h).
+    libcuda = ctypes.CDLL("libcuda.so.1")
+    fn = libcuda.cuPointerGetAttribute
+    fn.argtypes = [ctypes.c_void_p, ctypes.c_int, ctypes.c_void_p]
+    fn.restype = ctypes.c_int
+    _cu_pointer_get_attribute = fn
+    return fn
 
 
 def _tensor_is_legacy_ipc_capable(t: torch.Tensor) -> bool:
@@ -110,12 +161,8 @@ def _tensor_is_legacy_ipc_capable(t: torch.Tensor) -> bool:
     try:
         import ctypes
 
-        # CU_POINTER_ATTRIBUTE_IS_LEGACY_IPC_CAPABLE = 10 (cuda.h).
-        # A compiled helper is preferable long-term; ctypes is sufficient for
-        # the capture-time fail-closed probe.
-        libcuda = ctypes.CDLL("libcuda.so.1")
         val = ctypes.c_int(0)
-        rc = libcuda.cuPointerGetAttribute(
+        rc = _get_cu_pointer_get_attribute()(
             ctypes.byref(val),
             ctypes.c_int(10),
             ctypes.c_void_p(ptr),
@@ -125,6 +172,18 @@ def _tensor_is_legacy_ipc_capable(t: torch.Tensor) -> bool:
         return bool(val.value)
     except Exception:
         return False
+
+
+def _should_use_registered_buffer_for_capture(inp: torch.Tensor) -> bool:
+    """Whether graph capture should zero-copy IPC-export ``inp``.
+
+    - CUDA: only when the allocation is legacy-IPC-capable.
+    - Non-CUDA (e.g. ROCm): preserve historical zero-copy ``registered=True``
+      behavior; do not apply the NVIDIA VMM probe.
+    """
+    if not current_platform.is_cuda():
+        return True
+    return _tensor_is_legacy_ipc_capable(inp)
 
 
 def _can_p2p(rank: int, world_size: int) -> bool:
@@ -483,12 +542,11 @@ class CustomAllreduce:
             return None
         if self._IS_CAPTURING:
             if torch.cuda.is_current_stream_capturing():
-                # Zero-copy only when the activation is legacy-IPC-capable.
-                # Pre-capture VMM tensors (expandable_segments) must use the
-                # pre-registered cudaMalloc scratch buffer (registered=False),
-                # same D2D path as eager — otherwise cudaIpcGetMemHandle fails
-                # during get_graph_buffer_ipc_meta (issue #42609).
-                use_zero_copy = _tensor_is_legacy_ipc_capable(input)
+                # CUDA + VMM: zero-copy only if legacy IPC can export the
+                # activation. Otherwise use the pre-registered cudaMalloc
+                # scratch buffer (registered=False), same as eager.
+                # ROCm/non-CUDA: keep historical registered=True.
+                use_zero_copy = _should_use_registered_buffer_for_capture(input)
                 if not use_zero_copy:
                     logger.debug_once(
                         "Custom allreduce graph capture: activation is not "

--- a/vllm/distributed/device_communicators/custom_all_reduce.py
+++ b/vllm/distributed/device_communicators/custom_all_reduce.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import os
 from contextlib import contextmanager
 from typing import cast
 
@@ -31,6 +32,99 @@ except ImportError:
     torch_symm_mem = None
 
 logger = init_logger(__name__)
+
+
+def _set_expandable_segments(enabled: bool) -> None:
+    """Best-effort toggle of PyTorch expandable_segments allocator setting."""
+    conf = f"expandable_segments:{'True' if enabled else 'False'}"
+    set_settings = getattr(torch._C, "_accelerator_setAllocatorSettings", None)
+    if set_settings is not None:
+        set_settings(conf)
+    else:
+        torch.cuda.memory._set_allocator_settings(conf)
+
+
+@contextmanager
+def _disable_expandable_segments_for_cuda_ipc(active: bool):
+    """Temporarily disable expandable_segments during custom-AR graph capture.
+
+    ``cudaIpcGetMemHandle`` only accepts ``cudaMalloc`` allocations. With
+    ``PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True``, *new* device tensors
+    come from CUDA VMM segments and cannot be legacy-IPC exported (see
+    https://github.com/vllm-project/vllm/issues/42609).
+
+    Pre-existing VMM tensors are unchanged by this toggle; the capture path
+    must fall back to the pre-registered scratch buffer when
+    ``_tensor_is_legacy_ipc_capable`` is false.
+
+    No-op when custom AR is disabled, platform is non-CUDA, or expandable
+    segments are not enabled.
+    """
+    conf = os.environ.get("PYTORCH_CUDA_ALLOC_CONF", "")
+    should_disable = (
+        active and current_platform.is_cuda() and "expandable_segments:True" in conf
+    )
+    if not should_disable:
+        yield
+        return
+
+    logger.info_once(
+        "Temporarily disabling expandable_segments during custom allreduce "
+        "CUDA graph capture for CUDA IPC compatibility."
+    )
+    try:
+        _set_expandable_segments(False)
+    except Exception as e:
+        logger.warning_once(
+            "Could not disable expandable_segments for custom AR capture: %s",
+            e,
+        )
+        yield
+        return
+
+    try:
+        yield
+    finally:
+        try:
+            _set_expandable_segments(True)
+        except Exception as e:
+            logger.warning(
+                "Failed to restore expandable_segments:True after custom AR "
+                "capture: %s",
+                e,
+            )
+
+
+def _tensor_is_legacy_ipc_capable(t: torch.Tensor) -> bool:
+    """True if legacy ``cudaIpcGetMemHandle`` can export this tensor's storage.
+
+    CUDA-only. VMM-backed memory (expandable_segments / CuMem) reports
+    ``CU_POINTER_ATTRIBUTE_IS_LEGACY_IPC_CAPABLE == 0``. Fail closed on probe
+    errors so callers use the pre-registered cudaMalloc scratch buffer.
+    """
+    if not current_platform.is_cuda() or not t.is_cuda:
+        return False
+    ptr = t.data_ptr()
+    if ptr == 0:
+        return False
+    try:
+        import ctypes
+
+        # CU_POINTER_ATTRIBUTE_IS_LEGACY_IPC_CAPABLE = 10 (cuda.h).
+        # A compiled helper is preferable long-term; ctypes is sufficient for
+        # the capture-time fail-closed probe.
+        libcuda = ctypes.CDLL("libcuda.so.1")
+        val = ctypes.c_int(0)
+        rc = libcuda.cuPointerGetAttribute(
+            ctypes.byref(val),
+            ctypes.c_int(10),
+            ctypes.c_void_p(ptr),
+        )
+        if rc != 0:
+            return False
+        return bool(val.value)
+    except Exception:
+        return False
 
 
 def _can_p2p(rank: int, world_size: int) -> bool:
@@ -318,13 +412,16 @@ class CustomAllreduce:
         `register_graph_buffers` call at the end of the context.
         It records all the buffer addresses used in the CUDA graph.
         """
-        try:
-            self._IS_CAPTURING = True
-            yield
-        finally:
-            self._IS_CAPTURING = False
-            if not self.disabled:
-                self.register_graph_buffers()
+        # Keep capture-time allocations on cudaMalloc when the user enabled
+        # expandable_segments (legacy IPC requirement for graph buffer export).
+        with _disable_expandable_segments_for_cuda_ipc(not self.disabled):
+            try:
+                self._IS_CAPTURING = True
+                yield
+            finally:
+                self._IS_CAPTURING = False
+                if not self.disabled:
+                    self.register_graph_buffers()
 
     def register_graph_buffers(self):
         handle, offset = ops.get_graph_buffer_ipc_meta(self._ptr)
@@ -386,7 +483,19 @@ class CustomAllreduce:
             return None
         if self._IS_CAPTURING:
             if torch.cuda.is_current_stream_capturing():
-                return self.all_reduce(input, registered=True)
+                # Zero-copy only when the activation is legacy-IPC-capable.
+                # Pre-capture VMM tensors (expandable_segments) must use the
+                # pre-registered cudaMalloc scratch buffer (registered=False),
+                # same D2D path as eager — otherwise cudaIpcGetMemHandle fails
+                # during get_graph_buffer_ipc_meta (issue #42609).
+                use_zero_copy = _tensor_is_legacy_ipc_capable(input)
+                if not use_zero_copy:
+                    logger.debug_once(
+                        "Custom allreduce graph capture: activation is not "
+                        "legacy-IPC-capable; using pre-registered buffer "
+                        "(D2D copy) instead of zero-copy IPC export."
+                    )
+                return self.all_reduce(input, registered=use_zero_copy)
             else:
                 # If warm up, mimic the allocation pattern since custom
                 # allreduce is out-of-place.


### PR DESCRIPTION
## Purpose

Fix graph-capture / startup crashes when custom all-reduce is enabled with
`PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True`.

Legacy `cudaIpcGetMemHandle` cannot export VMM-backed tensors. Graph buffer
registration (`get_graph_buffer_ipc_meta`) then fails with:

```text
Failed: Cuda error .../custom_all_reduce.cuh:... 'invalid argument'
```

and the worker exits.

Fixes https://github.com/vllm-project/vllm/issues/42609

### Relation to #43923 (not a duplicate)

https://github.com/vllm-project/vllm/pull/43923 correctly temporarily disables
`expandable_segments` during `CustomAllreduce.capture()` so *new* capture
allocations are `cudaMalloc`-backed (same idea as CuMemAllocator sleep-mode
handling). That is necessary but not always sufficient: activations allocated
*before* capture can still be VMM / non-legacy-IPC-capable, so zero-copy
`registered=True` still crashes.

This PR is self-contained and includes:

1. The capture-time expandable_segments toggle (same idea as #43923).
2. A CUDA-only legacy-IPC probe: use zero-copy only when
   `CU_POINTER_ATTRIBUTE_IS_LEGACY_IPC_CAPABLE`; otherwise fall back to the
   existing pre-registered `cudaMalloc` scratch buffer (`registered=False`,
   same as eager).
3. Nesting-safe refcount for the expandable_segments disable/restore.
4. ROCm / non-CUDA: preserve historical `registered=True` (do not apply the
   NVIDIA VMM probe).
5. Pytest unit tests + multiproc GPU regression.

#43923 remains valid prior art for the toggle-only case; this PR is not meant
to block that work if maintainers prefer a smaller first step.

## Test Plan

Unit tests (no multi-GPU):

```bash
pytest -q tests/distributed/test_custom_all_reduce_expandable_segments.py \
  -k "not pre_capture_vmm"
```

Multiproc GPU regression (2 GPUs with P2P):

```bash
pytest -q tests/distributed/test_custom_all_reduce_expandable_segments.py::test_custom_all_reduce_graph_pre_capture_vmm_expandable_segments
```

Equivalent manual form:

```bash
PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True \
  torchrun --nproc_per_node=2 \
  tests/distributed/test_custom_all_reduce_expandable_segments.py
```

(Prefer the pytest entrypoint; it asserts pre-capture `legacy_ipc=False` so the
fallback path is actually exercised.)

## Test Result

**Before** (expandable_segments:True, custom AR on, graph capture with
pre-capture VMM inputs):

```text
Failed: Cuda error .../custom_all_reduce.cuh:... 'invalid argument'
Worker proc died / EngineCore failed to start
```

**After** (this PR, same conditions):

| Check | Result |
|---|---|
| Unit tests (ROCm routing, CUDA probe routing, nested disable, noop) | 4 passed |
| Multiproc GPU: pre-capture `legacy_ipc=False`, capture/register/replay | 1 passed |
| Graph replay numerical error | 0.0 |
| pytest collection | 5 tests collected |

Local hardware used for the multiproc test: dual-GPU CUDA host with P2P.
Does not change model accuracy; crash-fix / transport path only.

## AI assistance

AI-assisted drafting and code review (Grok Build / Codex CLI). A human author
reviewed every changed line, ran the tests above, and owns the change end-to-end.

## Notes

- Does not change C++ `CUDACHECK` → `exit()` behavior (possible separate follow-up).
- Optional later: shared expandable_segments helper with `CuMemAllocator`;
  compiled pointer-attribute helper instead of ctypes.
