### PR TITLE
[BugFix][Spec Decode] Fix dynamic-SD draft decode capture

### DIFF
--- a/tests/v1/spec_decode/test_dynamic_sd_cug.py
+++ b/tests/v1/spec_decode/test_dynamic_sd_cug.py
@@ -16,6 +16,7 @@ from vllm.config import (
     VllmConfig,
 )
 from vllm.v1.worker.gpu import cudagraph_utils as gpu_cudagraph_utils
+from vllm.v1.worker.gpu.spec_decode.mtp.speculator import MTPSpeculator
 from vllm.v1.worker.utils import get_uniform_decode_token_count
 
 pytestmark = pytest.mark.cpu_test
@@ -148,6 +149,56 @@ def test_dynamic_sd_full_cudagraph_covers_all_uniform_decode_shapes(monkeypatch)
             assert desc.num_tokens == num_tokens
             assert desc.num_reqs == num_reqs
             assert desc.num_active_loras == 0
+
+
+def test_dynamic_sd_autoregressive_draft_decode_uses_fixed_query_len(monkeypatch):
+    max_num_seqs = 8
+    # The runtime schedule need not contain the configured upper-bound K;
+    # draft decode capture must still use fixed query length 1.
+    max_spec_tokens = 4
+
+    monkeypatch.setattr(
+        gpu_cudagraph_utils,
+        "get_pp_group",
+        lambda: SimpleNamespace(is_first_rank=True, is_last_rank=True),
+    )
+    vllm_config = _create_vllm_config_for_dsd(
+        max_num_seqs=max_num_seqs,
+        max_spec_tokens=max_spec_tokens,
+        num_spec_per_batch_size=[(1, 2, 3), (3, 4, 1), (5, 8, 0)],
+    )
+
+    speculator = object.__new__(MTPSpeculator)
+    speculator.vllm_config = vllm_config
+    speculator.device = torch.device("cpu")
+    speculator.num_speculative_steps = max_spec_tokens
+    speculator.init_cudagraph_manager(CUDAGraphMode.FULL_AND_PIECEWISE)
+
+    prefill_manager = speculator.prefill_cudagraph_manager
+    assert prefill_manager is not None
+    prefill_descs = prefill_manager._capture_descs[CUDAGraphMode.FULL]
+    assert {desc.uniform_token_count for desc in prefill_descs} == {1, 2, 4}
+
+    decode_manager = speculator.decode_cudagraph_manager
+    assert decode_manager is not None
+    decode_descs = decode_manager._capture_descs[CUDAGraphMode.FULL]
+    assert {desc.uniform_token_count for desc in decode_descs} == {1}
+
+    decode_manager._graphs_captured = True
+    for num_reqs in range(1, max_num_seqs + 1):
+        desc = decode_manager.dispatch(
+            num_reqs=num_reqs,
+            num_tokens=num_reqs,
+            uniform_token_count=1,
+            num_active_loras=0,
+        )
+        assert desc == gpu_cudagraph_utils.BatchExecutionDescriptor(
+            cg_mode=CUDAGraphMode.FULL,
+            num_tokens=num_reqs,
+            num_reqs=num_reqs,
+            uniform_token_count=1,
+            num_active_loras=0,
+        )
 
 
 def test_dynamic_sd_non_uniform_batch_falls_back_to_piecewise(monkeypatch):

--- a/vllm/v1/worker/gpu/cudagraph_utils.py
+++ b/vllm/v1/worker/gpu/cudagraph_utils.py
@@ -113,6 +113,7 @@ class CudaGraphManager:
         cudagraph_mode: CUDAGraphMode,
         decode_query_len: int,
         lora_capture_cases: list[int] | None = None,
+        use_dynamic_decode_query_len: bool = True,
     ):
         self.vllm_config = vllm_config
         self.device = device
@@ -121,6 +122,9 @@ class CudaGraphManager:
         assert self.compilation_config is not None
         self.cudagraph_mode = cudagraph_mode
         self.decode_query_len = decode_query_len
+        # Some graph managers have a fixed query shape even when DSD changes
+        # the target verification length.
+        self.use_dynamic_decode_query_len = use_dynamic_decode_query_len
 
         self.dp_size = vllm_config.parallel_config.data_parallel_size
         self.tp_size = vllm_config.parallel_config.tensor_parallel_size
@@ -199,7 +203,8 @@ class CudaGraphManager:
         # to capture graphs for all possible values during decode.
         speculative_config = self.vllm_config.speculative_config
         if (
-            speculative_config
+            self.use_dynamic_decode_query_len
+            and speculative_config
             and speculative_config.uses_dynamic_speculative_decoding()
         ):
             num_spec_per_batch_size = (

--- a/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
@@ -142,6 +142,10 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
             self.device,
             cudagraph_mode,
             decode_query_len=1,
+            # Each autoregressive draft step processes exactly one token per
+            # request, regardless of the speculative token count selected by
+            # dynamic speculative decoding.
+            use_dynamic_decode_query_len=False,
         )
 
     def capture(self) -> None:


### PR DESCRIPTION
## Purpose

Fixes crash when FULL CUDA graphs are enabled under **dynamic speculative decoding (DSD)** with autoregressive MTP/EAGLE draft models.

Related: #48494, #49652 (same fix, rebased), #48329. Prerequisite for #50885 (FlashInfer FULL under spec-decode).

### Root cause

DSD expands CUDA-graph capture shapes using:

```text
num_new_sampled = manager.decode_query_len - max_speculative_tokens
runtime_query_len = scheduled_K + num_new_sampled
```

That is correct for **target verify** and **draft prefill** (`decode_query_len = K+1`), but **not** for autoregressive **draft decode**, which always processes exactly one token per request (`decode_query_len=1`).

With schedule e.g. `[[1,2,2],[3,16,0]]` and `K=2`:

```text
num_new = 1 - 2 = -1
query_lens = [1, -1]   # invalid
```

Capture then fails:

```text
InputBatch.make_dummy
assert 0 < num_reqs <= num_tokens
AssertionError
```

Stock FlashInfer never hits this because it forces `PIECEWISE` under spec-decode and draft-decode graphs are set to `CUDAGraphMode.NONE`. Enabling FULL (e.g. #50885) unmasks the bug.

## Test Plan

- [x] Unit: `tests/v1/spec_decode/test_dynamic_sd_cug.py::test_dynamic_sd_autoregressive_draft_decode_uses_fixed_query_len`
- [x] Production dual-RTX-5090 TP=2, MTP + DSD `[[1,2,2],[3,16,0]]`:
  - Without fix + FULL: crash-loop at draft decode capture
  - With fix + FULL: boots; target FULL 7/7, prefill FULL 7/7, **decode FULL 4/4**

## Changes

1. `CudaGraphManager(..., use_dynamic_decode_query_len=True)` — opt out of DSD query-len expansion when the manager has a fixed per-req query shape.
2. AR draft decode manager: `use_dynamic_decode_query_len=False`.
3. CPU unit test covering fixed `uniform_token_count == 1` for draft decode.

## Credit

Logic from #49652 (`fd355781f7`, @CZT0). Rebased onto current `main` (test import conflict resolved) after validating on SM120.

## Notes for #50885

This PR is the **boot-path** fix. Measuring FULL vs PIECEWISE after applying this + #50885 on ThinkingCap C3:

| Cell | PIECEWISE | FULL | Δ% |
|------|----------:|-----:|---:|
| short/s1 | 111.3 | 130.3 | **+17%** |
| short/s8 | 458.1 | 471.2 | **+3%** |
| long32k/s8 | ~157 | OOM (FLA prefill) | n/a |

Long concurrent load may still need memory work; this PR only fixes the capture assert.

Signed-off-by: Greg Weyer \<gweyer@live.com\>