### PR TITLE
Revert "[Config] Update default `_max_num_batched_tokens` from 8192 to 16384" (#51726)

### DIFF
--- a/tests/v1/engine/test_engine_args.py
+++ b/tests/v1/engine/test_engine_args.py
@@ -5,6 +5,7 @@ from argparse import ArgumentError
 
 import pytest
 
+from vllm.config import VllmConfig
 from vllm.engine.arg_utils import EngineArgs
 from vllm.usage.usage_lib import UsageContext
 from vllm.utils.argparse_utils import FlexibleArgumentParser
@@ -61,6 +62,34 @@ def test_prefix_caching_xxhash_from_cli():
     args = parser.parse_args(["--prefix-caching-hash-algo", "xxhash_cbor"])
     vllm_config = EngineArgs.from_cli_args(args=args).create_engine_config()
     assert vllm_config.cache_config.prefix_caching_hash_algo == "xxhash_cbor"
+
+
+def test_defaults_with_usage_context():
+    engine_args = EngineArgs(model="facebook/opt-125m")
+    vllm_config: VllmConfig = engine_args.create_engine_config(UsageContext.LLM_CLASS)
+
+    from vllm.platforms import current_platform
+    from vllm.utils.mem_constants import GiB_bytes
+
+    device_memory = current_platform.get_device_total_memory()
+    device_name = current_platform.get_device_name().lower()
+    if device_memory >= 70 * GiB_bytes and "a100" not in device_name:
+        # For GPUs like H100, H200, and MI300x with >= 70GB memory
+        default_llm_tokens = 16384
+        default_server_tokens = 8192
+        default_max_num_seqs = 1024
+    else:
+        default_llm_tokens = 8192
+        default_server_tokens = 2048
+        default_max_num_seqs = 256
+
+    assert vllm_config.scheduler_config.max_num_seqs == default_max_num_seqs
+    assert vllm_config.scheduler_config.max_num_batched_tokens == default_llm_tokens  # noqa: E501
+
+    engine_args = EngineArgs(model="facebook/opt-125m")
+    vllm_config = engine_args.create_engine_config(UsageContext.OPENAI_API_SERVER)
+    assert vllm_config.scheduler_config.max_num_seqs == default_max_num_seqs
+    assert vllm_config.scheduler_config.max_num_batched_tokens == default_server_tokens  # noqa: E501
 
 
 def test_mm_prefix_lm_raises_batched_tokens_floor():

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -2566,18 +2566,8 @@ class EngineArgs:
         # NOTE(Kuntai): Setting large `max_num_batched_tokens` for A100 reduces
         # throughput, see PR #17885 for more details.
         # So here we do an extra device name check to prevent such regression.
-        if device_memory >= 160 * GiB_bytes:
-            # for GPUs like B200/B300 with >= 160GB memory, use the largest defaults
-            default_max_num_batched_tokens = {
-                UsageContext.LLM_CLASS: 16384,
-                UsageContext.OPENAI_API_SERVER: 16384,
-            }
-            default_max_num_seqs = {
-                UsageContext.LLM_CLASS: 1024,
-                UsageContext.OPENAI_API_SERVER: 1024,
-            }
-        elif device_memory >= 70 * GiB_bytes and "a100" not in device_name:
-            # For GPUs like H100 and H200, use larger offline defaults.
+        if device_memory >= 70 * GiB_bytes and "a100" not in device_name:
+            # For GPUs like H100 and MI300x, use larger default values.
             default_max_num_batched_tokens = {
                 UsageContext.LLM_CLASS: 16384,
                 UsageContext.OPENAI_API_SERVER: 8192,


### PR DESCRIPTION
Auto-generated by CI failure analyzer from nightly build [#83443](https://buildkite.com/vllm/ci/builds/83443) (commit `3e372c5`).

Reverts #51726 — "[Config] Update default `_max_num_batched_tokens` from 8192 to 16384".

## Why

This default flip is linked to **2 new nightly failures** on B200 hardware, both of which passed on the previous analyzed nightly (#83298). The PR is not itself incorrect — it makes two pre-existing, memory/bucket-sensitive defects reachable by doubling the server-context default on `device_memory >= 160 GiB` devices.

**1. `LM Eval Qwen3.5 Models (2xB200)`** — 2 configs fail at startup:

```
ValueError: max_num_seqs (384) exceeds available Mamba cache blocks (336).
Each decode sequence requires one Mamba cache block, so CUDA graph capture cannot proceed.
```

The eval configs set `max_num_seqs` but not `max_num_batched_tokens`, so they inherit the new default. Memory budget is unchanged (164.08 GiB, `gpu_memory_utilization=0.92`) and weights are identical, so the whole delta is peak activation: `8.18 -> 11.87 GiB` (DEP2) and `9.18 -> 13.04 GiB` (DEP2-MTP), shrinking KV cache `25.67 -> 21.80 GiB` and Mamba blocks below `max_num_seqs`. Related: #49064 proposes auto-clamping `max_num_seqs` instead of hard-failing.

**2. `MoE Refactor Integration Test (B200 DP - TEMPORARY)`** — `test_gsm8k_correctness[Qwen3-30B-A3B-BF16-triton]`:

```
CUDBG_EXCEPTION_WARP_ILLEGAL_ADDRESS (14)
  during [AutoTuner]: Tuning flashinfer::trtllm_bf16_moe: 0/23
```

`fi_moe_largest_bucket() = max(max_num_tokens * dp_size, 8192)` takes the bucket from 16384 to **32768** for this dp_size=2 config — the only config in either MoE Refactor job combining the BF16 trtllm kernel with DP=2. This is the known FlashInfer autotune fault in #45285 / #46083 / #46861.

## Please read before merging

A **narrower fix may be preferable** to this revert, and this PR is opened as a draft for that discussion:

- Pin `--max-num-batched-tokens 8192` (or raise `gpu_memory_utilization`) for the two `Qwen3.5-397B-A17B-NVFP4-DEP2*` eval configs.
- Add `--no-enable-flashinfer-autotune` to `Qwen3-30B-A3B-BF16-triton.yaml`, following the precedent set by #45002 for `Qwen3.5-35B-A3B-DEP2.yaml`.

The revert is offered as a low-risk stopgap to get the nightly green: it touches only `vllm/engine/arg_utils.py` and its test, and gives up a perf default rather than any correctness property.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
