### PR TITLE
[Attention] Move context_lens_tensor compute into GDN prefill path

### DIFF
--- a/vllm/v1/attention/backends/gdn_attn.py
+++ b/vllm/v1/attention/backends/gdn_attn.py
@@ -177,7 +177,6 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
 
         query_start_loc = m.query_start_loc
         query_start_loc_cpu = m.query_start_loc_cpu
-        context_lens_tensor = m.compute_num_computed_tokens()
         nums_dict, batch_ptr, token_chunk_offset_ptr = None, None, None
         block_table_tensor = mamba_get_block_table_tensor(
             m.block_table_tensor,
@@ -389,6 +388,7 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
                 )
 
         if num_prefills > 0:
+            context_lens_tensor = m.compute_num_computed_tokens()
             has_initial_state = context_lens_tensor > 0
             if spec_sequence_masks_cpu is not None:
                 has_initial_state = has_initial_state[~spec_sequence_masks_cpu]


### PR DESCRIPTION



## Purpose

Move `context_lens_tensor = m.compute_num_computed_tokens()` in GDNAttentionMetadataBuilder.build() from the top of the method into the `if num_prefills > 0` branch because it's only used in prefill. Since `context_lens_tensor` is not used in decode path, this change avoids the tensor computed and discarded in decode path.

e2e output throughput improves 7% at batch size 1 on H200.

## Profiling

Main:
<img width="1915" height="742" alt="Screenshot 2026-08-11 at 7 33 16 PM" src="https://github.com/user-attachments/assets/c55da8dd-3120-4d65-bba6-7e6f4b107dd2" />

PR:
<img width="1902" height="739" alt="Screenshot 2026-08-11 at 7 34 00 PM" src="https://github.com/user-attachments/assets/889ef25a-31ad-4316-a8c3-fa1e71c8fded" />

Main: `compute_num_computed_tokens` called in decode path GDNAttentionMetadataBuilder.build(), takes extra 54µs.

PR: `compute_num_computed_tokens` not called.

## Benchmark

```
vllm serve Qwen/Qwen3.6-35B-A3B \
  --tensor-parallel-size 1 \
  --max-num-seqs 16 \
  --speculative-config '{"model":"z-lab/Qwen3.6-35B-A3B-DFlash","method":"dflash","num_speculative_tokens":8}' \
  --no-enable-prefix-caching
```

```
vllm bench serve \
        --model Qwen/Qwen3.6-35B-A3B \
        --dataset-name sharegpt \
        --dataset-path /tmp/ShareGPT_V3_unfiltered_cleaned_split.json \
        --sharegpt-output-len 300 \
        --num-prompts ${num_prompts} \
        --max-concurrency ${concurrency} \
        --num-warmups 200 \
        --ignore-eos
```

Main:

* concurrency 1

```
============ Serving Benchmark Result ============
Successful requests:                     60        
Failed requests:                         0         
Maximum request concurrency:             1         
Benchmark duration (s):                  97.79     
Total input tokens:                      16410     
Total generated tokens:                  18000     
Request throughput (req/s):              0.61      
Output token throughput (tok/s):         184.07    
Peak output token throughput (tok/s):    60.00     
Peak concurrent requests:                3.00      
Total token throughput (tok/s):          351.88    
---------------Time to First Token----------------
Mean TTFT (ms):                          138.20    
Median TTFT (ms):                        132.91    
P99 TTFT (ms):                           723.12    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          4.99      
Median TPOT (ms):                        4.71      
P99 TPOT (ms):                           16.71     
---------------Inter-token Latency----------------
Mean ITL (ms):                           17.07     
Median ITL (ms):                         17.06     
P99 ITL (ms):                            17.78     
---------------Speculative Decoding---------------
Acceptance rate (%):                     30.62     
Acceptance length:                       3.45      
Drafts:                                  5243      
Draft tokens:                            41944     
Accepted tokens:                         12844     
Per-position acceptance (%):
  Position 0:                            66.83     
  Position 1:                            49.11     
  Position 2:                            36.62     
  Position 3:                            27.90     
  Position 4:                            22.09     
  Position 5:                            17.17     
  Position 6:                            13.98     
  Position 7:                            11.27     
==================================================
```

* concurrency 16
```
============ Serving Benchmark Result ============
Successful requests:                     960       
Failed requests:                         0         
Maximum request concurrency:             16        
Benchmark duration (s):                  208.46    
Total input tokens:                      227546    
Total generated tokens:                  288000    
Request throughput (req/s):              4.61      
Output token throughput (tok/s):         1381.58   
Peak output token throughput (tok/s):    636.00    
Peak concurrent requests:                24.00     
Total token throughput (tok/s):          2473.16   
---------------Time to First Token----------------
Mean TTFT (ms):                          205.39    
Median TTFT (ms):                        192.83    
P99 TTFT (ms):                           367.00    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          10.87     
Median TPOT (ms):                        10.59     
P99 TPOT (ms):                           36.67     
---------------Inter-token Latency----------------
Mean ITL (ms):                           37.74     
Median ITL (ms):                         22.07     
P99 ITL (ms):                            155.20    
---------------Speculative Decoding---------------
Acceptance rate (%):                     31.23     
Acceptance length:                       3.50      
Drafts:                                  82664     
Draft tokens:                            661312    
Accepted tokens:                         206538    
Per-position acceptance (%):
  Position 0:                            70.86     
  Position 1:                            49.80     
  Position 2:                            36.20     
  Position 3:                            27.68     
  Position 4:                            21.82     
  Position 5:                            17.57     
  Position 6:                            14.30     
  Position 7:                            11.62     
==================================================
```

PR:

* concurrency 1

```
============ Serving Benchmark Result ============
Successful requests:                     60        
Failed requests:                         0         
Maximum request concurrency:             1         
Benchmark duration (s):                  91.14     
Total input tokens:                      16410     
Total generated tokens:                  18000     
Request throughput (req/s):              0.66      
Output token throughput (tok/s):         197.50    
Peak output token throughput (tok/s):    64.00     
Peak concurrent requests:                2.00      
Total token throughput (tok/s):          377.56    
---------------Time to First Token----------------
Mean TTFT (ms):                          137.76    
Median TTFT (ms):                        134.03    
P99 TTFT (ms):                           739.05    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          4.62      
Median TPOT (ms):                        4.36      
P99 TPOT (ms):                           15.52     
---------------Inter-token Latency----------------
Mean ITL (ms):                           15.80     
Median ITL (ms):                         15.82     
P99 ITL (ms):                            16.41     
---------------Speculative Decoding---------------
Acceptance rate (%):                     30.62     
Acceptance length:                       3.45      
Drafts:                                  5243      
Draft tokens:                            41944     
Accepted tokens:                         12844     
Per-position acceptance (%):
  Position 0:                            66.83     
  Position 1:                            49.11     
  Position 2:                            36.62     
  Position 3:                            27.90     
  Position 4:                            22.09     
  Position 5:                            17.17     
  Position 6:                            13.98     
  Position 7:                            11.27     
==================================================
```

* concurrency 16

```
============ Serving Benchmark Result ============
Successful requests:                     960       
Failed requests:                         0         
Maximum request concurrency:             16        
Benchmark duration (s):                  207.73    
Total input tokens:                      227546    
Total generated tokens:                  288000    
Request throughput (req/s):              4.62      
Output token throughput (tok/s):         1386.45   
Peak output token throughput (tok/s):    622.00    
Peak concurrent requests:                25.00     
Total token throughput (tok/s):          2481.87   
---------------Time to First Token----------------
Mean TTFT (ms):                          204.09    
Median TTFT (ms):                        194.36    
P99 TTFT (ms):                           376.01    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          10.84     
Median TPOT (ms):                        10.47     
P99 TPOT (ms):                           36.97     
---------------Inter-token Latency----------------
Mean ITL (ms):                           37.40     
Median ITL (ms):                         22.06     
P99 ITL (ms):                            157.55    
---------------Speculative Decoding---------------
Acceptance rate (%):                     30.97     
Acceptance length:                       3.48      
Drafts:                                  83199     
Draft tokens:                            665592    
Accepted tokens:                         206111    
Per-position acceptance (%):
  Position 0:                            70.68     
  Position 1:                            49.55     
  Position 2:                            35.93     
  Position 3:                            27.37     
  Position 4:                            21.52     
  Position 5:                            17.26     
  Position 6:                            14.01     
  Position 7:                            11.41     
==================================================
```

## Accuracy Testing

```
python3 -m lm_eval --model local-completions \
  --model_args model=Qwen/Qwen3.6-35B-A3B,base_url=http://127.0.0.1:8000/v1/completions,num_concurrent=16 \
  --tasks gsm8k
```

Main:

```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.3472|±  |0.0131|
|     |       |strict-match    |     5|exact_match|↑  |0.3268|±  |0.0129|
```

PR:

```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.3533|±  |0.0132|
|     |       |strict-match    |     5|exact_match|↑  |0.3306|±  |0.0130|
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

