### PR TITLE
[Refactor][MRV2] Unify uniform decode token count helper

### DIFF
--- a/tests/v1/spec_decode/test_dynamic_sd_cug.py
+++ b/tests/v1/spec_decode/test_dynamic_sd_cug.py
@@ -124,10 +124,11 @@ def test_dynamic_sd_full_cudagraph_covers_all_uniform_decode_shapes(monkeypatch)
             # Uniform decode means every request contributes the same number of
             # tokens, so the total token count is exactly num_reqs * query_len.
             num_tokens = num_reqs * max_query_len
-            uniform_tok_count = gpu_cudagraph_utils.get_uniform_token_count(
+            uniform_tok_count = get_uniform_decode_token_count(
                 num_reqs,
                 num_tokens,
                 max_query_len,
+                has_prefill=False,
             )
 
             # The scheduler should mark every one of these shapes as a uniform
@@ -233,8 +234,8 @@ def test_prompt_chunks_shaped_like_spec_decode_miss_the_full_graph(monkeypatch):
 
     # The batch shape is indistinguishable from a full batch of spec decodes.
     assert (
-        gpu_cudagraph_utils.get_uniform_token_count(
-            num_reqs, num_tokens, decode_query_len
+        get_uniform_decode_token_count(
+            num_reqs, num_tokens, decode_query_len, has_prefill=False
         )
         == decode_query_len
     )
@@ -305,10 +306,11 @@ def test_basic_sd_does_not_capture_shorter_full_decode_shapes(monkeypatch):
             # These are still uniform decode batches, but basic SD should only
             # have FULL graphs for query_len == max_decode_query_len.
             num_tokens = num_reqs * max_query_len
-            uniform_tok_count = gpu_cudagraph_utils.get_uniform_token_count(
+            uniform_tok_count = get_uniform_decode_token_count(
                 num_reqs,
                 num_tokens,
                 max_query_len,
+                has_prefill=False,
             )
             assert uniform_tok_count == max_query_len
 
@@ -370,10 +372,11 @@ def test_dynamic_sd_only_captures_scheduled_query_lengths(monkeypatch):
     for num_reqs in range(1, max_num_seqs + 1):
         for max_query_len in range(1, max_decode_query_len + 1):
             num_tokens = num_reqs * max_query_len
-            uniform_tok_count = gpu_cudagraph_utils.get_uniform_token_count(
+            uniform_tok_count = get_uniform_decode_token_count(
                 num_reqs,
                 num_tokens,
                 max_query_len,
+                has_prefill=False,
             )
             assert uniform_tok_count == max_query_len
 

--- a/vllm/v1/worker/gpu/cudagraph_utils.py
+++ b/vllm/v1/worker/gpu/cudagraph_utils.py
@@ -35,7 +35,7 @@ from vllm.v1.worker.gpu.block_table import BlockTables
 from vllm.v1.worker.gpu.cp_utils import prepare_dcp_local_seq_lens
 from vllm.v1.worker.gpu.input_batch import InputBatch, InputBuffers
 from vllm.v1.worker.gpu.model_states.interface import ModelState
-from vllm.v1.worker.utils import AttentionGroup, is_uniform_query_len
+from vllm.v1.worker.utils import AttentionGroup
 
 logger = init_logger(__name__)
 
@@ -87,22 +87,6 @@ def _is_compatible(
         and desc.num_tokens >= num_tokens
         and desc.num_active_loras == num_active_loras
     )
-
-
-def get_uniform_token_count(
-    num_reqs: int, num_tokens: int, max_query_len: int
-) -> int | None:
-    """
-    Return the uniform token count if batch is uniform, else None.
-    A batch is uniform if all requests have the same number of tokens.
-
-    Shape test only, valid for batches known to be decoding by construction
-    (e.g. dummy runs). Scheduled batches must use
-    `get_uniform_decode_token_count`.
-    """
-    if is_uniform_query_len(num_reqs, num_tokens, max_query_len):
-        return max_query_len
-    return None
 
 
 class CudaGraphManager:

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -88,7 +88,6 @@ from vllm.v1.worker.gpu.cp_utils import prepare_dcp_local_seq_lens
 from vllm.v1.worker.gpu.cudagraph_utils import (
     BatchExecutionDescriptor,
     ModelCudaGraphManager,
-    get_uniform_token_count,
 )
 from vllm.v1.worker.gpu.dp_utils import dispatch_cg_and_sync_dp
 from vllm.v1.worker.gpu.ec_connector import get_ec_connector
@@ -991,7 +990,9 @@ class GPUModelRunner(LoRAModelRunnerMixin):
 
         if dummy_run:
             # Dummy batches are uniform by construction.
-            return None, get_uniform_token_count(num_reqs, num_toks, max_query_len)
+            return None, get_uniform_decode_token_count(
+                num_reqs, num_toks, max_query_len, has_prefill=False
+            )
 
         # batch_idx -> req_id
         req_ids = sort_batch_req_ids(num_tokens_per_req, self.decode_query_len)


### PR DESCRIPTION
## Purpose

Remove the redundant `get_uniform_token_count` wrapper and route its callers through `get_uniform_decode_token_count`. Dummy and capture-only paths pass `has_prefill=False`, preserving their existing shape-only behavior while exposing a single token-count API.

This addresses the follow-up review on #51865: https://github.com/vllm-project/vllm/pull/51865#discussion_r3763278414

This does not duplicate an existing PR. I searched open PRs for #51865, #49918, the branch name, and uniform-token-count keywords. #50532 contains the original bug fix; it does not perform this post-merge API consolidation.

## Test Plan

- `.venv/bin/python -m pytest tests/v1/worker/test_gpu_batch_ordering.py tests/v1/spec_decode/test_dynamic_sd_cug.py -v`
- `.venv/bin/pre-commit run --files tests/v1/spec_decode/test_dynamic_sd_cug.py vllm/v1/worker/gpu/cudagraph_utils.py vllm/v1/worker/gpu/model_runner.py`
- `git diff --check`

## Test Result

- Focused pytest suite: **14 passed**, 16 deprecation warnings.
- All targeted pre-commit hooks passed, including ruff, mypy, typos, SPDX, and repository policy checks.
- `git diff --check` passed.
- Model evaluation is not applicable because this is a behavior-preserving helper consolidation; the decode-aware predicate and call-site semantics are unchanged.

AI assistance from OpenAI Codex was used to implement and validate this change. I reviewed every changed line.

- [x] Purpose documented.
- [x] Test plan documented.
- [x] Test results documented.
- [x] No documentation update required.