### PR TITLE
[ROCm][DSv4] Add FlyDSL fused mega-MoE backend for DeepSeek V4

### DIFF
--- a/vllm/config/kernel.py
+++ b/vllm/config/kernel.py
@@ -135,6 +135,7 @@ MoEBackend = Literal[
     "triton_unfused",
     "aiter",
     "flydsl",
+    "flydsl_mega_moe",
     "hpc",
     "emulation",
 ]
@@ -208,6 +209,9 @@ class KernelConfig:
     - "triton_unfused": Use Triton unfused MoE kernels
     - "aiter": Use AMD AITer kernels (ROCm only)
     - "flydsl": Use AMD FlyDSL kernels (ROCm only)
+    - "flydsl_mega_moe": Use AMD FlyDSL fused mega-MoE kernels, which fuse EP
+      dispatch, both expert GEMMs, and EP combine into one launch chain
+      (ROCm, DeepSeek V4, single node, requires expert parallel)
     - "hpc": Use HPC kernels (FP8 and Hopper only)
     - "emulation": use BF16/FP16 GEMM, dequantizing weights and
                    running QDQ on activations.

--- a/vllm/models/deepseek_v4/amd/dspark.py
+++ b/vllm/models/deepseek_v4/amd/dspark.py
@@ -11,8 +11,10 @@ ROCm port of ``nvidia/dspark.py``. Follows the same nvidia->amd recipe used for
     tilelang / triton / torch) instead of calling the tilelang kernels directly,
     and gate the trailing ``mhc_post`` on ``use_fused_mhc`` (False on the aiter
     path, where the decoder layer already applies hc_post in-layer);
-  * drop the mega-MoE weight path (``make_deepseek_v4_expert_params_mapping`` /
-    ``use_mega_moe`` / ``finalize_mega_moe_weights`` do not exist in amd/model.py).
+  * use the AMD mega-MoE weight path
+    (``make_deepseek_v4_mega_expert_params_mapping`` /
+    ``finalize_mega_moe_layers``) when the draft layers were built with
+    ``--moe-backend flydsl_mega_moe``.
 
 Everything else — the semi-autoregressive drafting hooks, the Markov head, the
 sliding-window context-KV insert, and the checkpoint ``mtp.*`` weight remap — is
@@ -48,6 +50,10 @@ from vllm.model_executor.models.qwen3_dspark import (
 )
 from vllm.model_executor.models.utils import maybe_prefix
 
+from .mega_moe_experts import (
+    finalize_mega_moe_layers,
+    make_deepseek_v4_mega_expert_params_mapping,
+)
 from .model import (
     DeepseekV4DecoderLayer,
 )
@@ -366,15 +372,19 @@ class DSparkDeepseekV4ForCausalLM(nn.Module):
         Non-mtp weights (embed/head/main layers) belong to the target model and
         are skipped here. ``embed_tokens``/``lm_head`` are aliased from the target.
         """
-        # AMD DeepseekV4MoE has no mega-MoE path; always use the standard
-        # per-expert fused-MoE mapping (mirrors amd/mtp.py).
-        expert_mapping = fused_moe_make_expert_params_mapping(
-            self,
-            ckpt_gate_proj_name="w1",
-            ckpt_down_proj_name="w2",
-            ckpt_up_proj_name="w3",
-            num_experts=self.config.n_routed_experts,
-        )
+        first_layer = self.model.layers[0]
+        if getattr(first_layer.ffn, "use_mega_moe", False):
+            expert_mapping = make_deepseek_v4_mega_expert_params_mapping(
+                self.config.n_routed_experts
+            )
+        else:
+            expert_mapping = fused_moe_make_expert_params_mapping(
+                self,
+                ckpt_gate_proj_name="w1",
+                ckpt_down_proj_name="w2",
+                ckpt_up_proj_name="w3",
+                num_experts=self.config.n_routed_experts,
+            )
         expert_scale_suffix = (
             ".weight_scale"
             if getattr(self.config, "expert_dtype", "fp4") == "fp4"
@@ -469,6 +479,7 @@ class DSparkDeepseekV4ForCausalLM(nn.Module):
                 weight_loader(param, loaded_weight)
                 loaded_params.add(name)
 
+        finalize_mega_moe_layers(self.model.layers)
         logger.info_once("DSpark draft model loaded: %d params", len(loaded_params))
         return loaded_params
 

--- a/vllm/models/deepseek_v4/amd/mega_moe_experts.py
+++ b/vllm/models/deepseek_v4/amd/mega_moe_experts.py
@@ -1,0 +1,351 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""ROCm MegaMoE expert layer for DeepSeek V4.
+
+The AMD counterpart to ``nvidia/model.py``'s ``DeepseekV4MegaMoEExperts``. The
+kernel is aiter's ``MegaMoEV2`` (FlyDSL), which fuses EP dispatch, both expert
+GEMMs, and EP combine into a single launch chain. Unlike the CUDA path there is
+no separate input-staging kernel: ``MegaMoEV2.forward`` quantizes the bf16
+hidden states to fp8 with per-1x32 e8m0 scales itself.
+
+Weight layout matches the existing ROCm MXFP4 fused-MoE path -- the packed fp4
+weights and their e8m0 scales are run through aiter's ``shuffle_weight_a16w4``
+and ``shuffle_scale_a16w4``, exactly as ``fused_moe/oracle/mxfp4.py`` does for
+the CK kernels, so no new checkpoint handling is required.
+"""
+
+from __future__ import annotations
+
+import torch
+from torch import nn
+
+from vllm.config import VllmConfig
+from vllm.distributed.parallel_state import get_ep_group
+from vllm.logger import init_logger
+from vllm.model_executor.utils import set_weight_attrs
+from vllm.models.deepseek_v4.amd.mega_moe_runtime import (
+    MegaMoERuntime,
+    MegaMoEShape,
+    resolve_max_tok_per_rank,
+)
+
+logger = init_logger(__name__)
+
+
+def shuffle_mega_moe_weights(
+    w13: torch.Tensor,
+    w13_scale: torch.Tensor,
+    w2: torch.Tensor,
+    w2_scale: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Convert checkpoint-layout fp4 expert weights into aiter's kernel layout.
+
+    Split out of :meth:`DeepseekV4MegaMoEExperts.finalize_weights` so it can be
+    tested against the reference preparation in aiter's own
+    ``test_mega_moe_v2.py`` without standing up a distributed environment.
+
+    Inputs are in checkpoint layout -- ``w13`` is ``(E, 2*inter, hidden//2)``
+    packed two fp4 per byte with w1 occupying rows ``[0, inter)`` and w3 rows
+    ``[inter, 2*inter)``; scales are per-1x32 e8m0 bytes. ``shuffle_scale``
+    asserts a 2-D input and treats the leading axis as ``E * N``, so the scales
+    are flattened before the call.
+    """
+    from aiter.ops.shuffle import shuffle_scale_a16w4, shuffle_weight_a16w4
+
+    experts = w13.shape[0]
+
+    # The shuffles are layout transforms driven by shape; the fp4 pair packing
+    # only has to survive as opaque bytes.
+    w13_packed = w13.view(torch.float4_e2m1fn_x2)
+    w2_packed = w2.view(torch.float4_e2m1fn_x2)
+
+    return (
+        shuffle_weight_a16w4(w13_packed, 16, True).contiguous(),
+        shuffle_scale_a16w4(
+            w13_scale.reshape(-1, w13_scale.shape[-1]), experts, True
+        ).contiguous(),
+        shuffle_weight_a16w4(w2_packed, 16, False).contiguous(),
+        shuffle_scale_a16w4(
+            w2_scale.reshape(-1, w2_scale.shape[-1]), experts, False
+        ).contiguous(),
+    )
+
+
+def make_deepseek_v4_mega_expert_params_mapping(
+    num_experts: int,
+) -> list[tuple[str, str, int, str]]:
+    """Checkpoint -> parameter mapping for the mega-MoE expert layout.
+
+    ``fused_moe_make_expert_params_mapping`` targets FusedMoE's parameter
+    names, which the mega path does not have. This is the AMD copy of
+    ``nvidia/model.py``'s ``make_deepseek_v4_expert_params_mapping``: w1/w3 land
+    in the fused ``w13_`` parameters, w2 in ``w2_``, and the per-expert loader
+    on :class:`DeepseekV4MegaMoEExperts` does the sharding.
+    """
+    return [
+        (
+            "experts.w13_" if shard_id in ("w1", "w3") else "experts.w2_",
+            f"experts.{expert_id}.{weight_name}.",
+            expert_id,
+            shard_id,
+        )
+        for expert_id in range(num_experts)
+        for shard_id, weight_name in (("w1", "w1"), ("w2", "w2"), ("w3", "w3"))
+    ]
+
+
+def finalize_mega_moe_layers(layers) -> None:
+    """Run mega weight finalization over a layer container.
+
+    Tolerates the three shapes the DeepSeek V4 code uses -- a list of decoder
+    layers, a ``ModuleDict`` of MTP layers, and MTP layers that wrap the real
+    decoder layer in ``.mtp_block`` -- and is a no-op when the mega path is off.
+    """
+    if hasattr(layers, "values"):
+        layers = layers.values()
+    for layer in layers:
+        layer = getattr(layer, "mtp_block", layer)
+        ffn = getattr(layer, "ffn", None)
+        finalize = getattr(ffn, "finalize_mega_moe_weights", None)
+        if finalize is not None:
+            finalize()
+
+
+class DeepseekV4MegaMoEExperts(nn.Module):
+    """Routed experts backed by aiter's fused MegaMoEV2 kernel."""
+
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        *,
+        num_experts: int,
+        num_local_experts: int,
+        experts_start_idx: int,
+        top_k: int,
+        hidden_size: int,
+        intermediate_size: int,
+        swiglu_limit: float,
+        prefix: str = "",
+    ):
+        super().__init__()
+        self.prefix = prefix
+        self.num_experts = num_experts
+        self.num_local_experts = num_local_experts
+        self.experts_start_idx = experts_start_idx
+        self.experts_end_idx = experts_start_idx + num_local_experts
+        self.top_k = top_k
+        self.hidden_size = hidden_size
+        self.intermediate_size = intermediate_size
+        self.swiglu_limit = swiglu_limit
+
+        ep_group = get_ep_group()
+        self.ep_size = ep_group.world_size
+        self.ep_rank = ep_group.rank_in_group
+
+        # MegaMoEV2 rejects any forward pass carrying more tokens than
+        # max_tok_per_rank, so this must round the scheduler budget *up* to the
+        # next power of two. It is also what sizes the symmetric buffers.
+        self.max_num_tokens = vllm_config.scheduler_config.max_num_batched_tokens
+        self.max_tok_per_rank = resolve_max_tok_per_rank(self.max_num_tokens)
+
+        weight_attrs = {"weight_loader": self.weight_loader}
+
+        # Loader-side layout, matching the checkpoint: fp4 packed two-per-byte
+        # with per-1x32 e8m0 scales. finalize_weights() replaces these with the
+        # shuffled layout the kernel wants.
+        self.w13_weight = nn.Parameter(
+            torch.zeros(
+                num_local_experts,
+                2 * intermediate_size,
+                hidden_size // 2,
+                dtype=torch.uint8,
+            ),
+            requires_grad=False,
+        )
+        set_weight_attrs(self.w13_weight, weight_attrs)
+
+        self.w13_weight_scale = nn.Parameter(
+            torch.zeros(
+                num_local_experts,
+                2 * intermediate_size,
+                hidden_size // 32,
+                dtype=torch.uint8,
+            ),
+            requires_grad=False,
+        )
+        set_weight_attrs(self.w13_weight_scale, weight_attrs)
+        self.w13_weight_scale.quant_method = "block"
+
+        self.w2_weight = nn.Parameter(
+            torch.zeros(
+                num_local_experts,
+                hidden_size,
+                intermediate_size // 2,
+                dtype=torch.uint8,
+            ),
+            requires_grad=False,
+        )
+        set_weight_attrs(self.w2_weight, weight_attrs)
+
+        self.w2_weight_scale = nn.Parameter(
+            torch.zeros(
+                num_local_experts,
+                hidden_size,
+                intermediate_size // 32,
+                dtype=torch.uint8,
+            ),
+            requires_grad=False,
+        )
+        set_weight_attrs(self.w2_weight_scale, weight_attrs)
+        self.w2_weight_scale.quant_method = "block"
+
+        self._shuffled: tuple[torch.Tensor, ...] | None = None
+
+        compilation_config = vllm_config.compilation_config
+        if prefix in compilation_config.static_forward_context:
+            raise ValueError(f"Duplicate layer name: {prefix}")
+        compilation_config.static_forward_context[prefix] = self
+
+    # --- weight loading ---------------------------------------------------
+
+    def weight_loader(
+        self,
+        param: nn.Parameter,
+        loaded_weight: torch.Tensor,
+        weight_name: str,
+        shard_id: str,
+        expert_id: int,
+        return_success: bool = False,
+    ) -> bool | None:
+        if not (self.experts_start_idx <= expert_id < self.experts_end_idx):
+            return False if return_success else None
+        local_expert_id = expert_id - self.experts_start_idx
+
+        expert_data = param.data[local_expert_id]
+        if shard_id in ("w1", "w3"):
+            if "w13_" not in weight_name:
+                return False if return_success else None
+            shard_offset = 0 if shard_id == "w1" else self.intermediate_size
+            expert_data = expert_data.narrow(0, shard_offset, self.intermediate_size)
+        elif shard_id == "w2":
+            if "w2_" not in weight_name:
+                return False if return_success else None
+        else:
+            raise ValueError(f"Unsupported expert shard id: {shard_id}")
+
+        if expert_data.shape != loaded_weight.shape:
+            raise ValueError(
+                f"DeepSeek V4 MegaMoE expert weight shape mismatch for "
+                f"{weight_name}: parameter shard {tuple(expert_data.shape)} "
+                f"vs checkpoint {tuple(loaded_weight.shape)}"
+            )
+        expert_data.copy_(loaded_weight.view(expert_data.dtype))
+
+        return True if return_success else None
+
+    def finalize_weights(self) -> None:
+        """Shuffle the loaded weights into aiter's a16w4 kernel layout.
+
+        Idempotent: safe to call again after dummy-weight loading, mirroring
+        the CUDA path.
+        """
+        if self._shuffled is not None:
+            return
+
+        (
+            w13_shuffled,
+            w13_scale_shuffled,
+            w2_shuffled,
+            w2_scale_shuffled,
+        ) = shuffle_mega_moe_weights(
+            self.w13_weight.data,
+            self.w13_weight_scale.data,
+            self.w2_weight.data,
+            self.w2_weight_scale.data,
+        )
+
+        self._shuffled = (
+            w13_shuffled,
+            w13_scale_shuffled,
+            w2_shuffled,
+            w2_scale_shuffled,
+        )
+
+        # Build the shared instance here rather than lazily in forward().
+        # MegaMoEV2.__init__ allocates the symmetric buffers and ends in
+        # shmem_barrier_all(), so it is collective and host-blocking: every EP
+        # rank must reach it. Weight finalization runs on all ranks at model
+        # load, whereas a forward pass may legitimately skip this layer on a
+        # rank that has no tokens under DP attention -- which would deadlock.
+        self._runtime().build(
+            w1=w13_shuffled,
+            w1_scale=w13_scale_shuffled,
+            w2=w2_shuffled,
+            w2_scale=w2_scale_shuffled,
+        )
+
+        # Drop the loader-side parameters; the shuffle helpers return fresh
+        # tensors, so the original storage is no longer referenced.
+        self.w13_weight = None
+        self.w13_weight_scale = None
+        self.w2_weight = None
+        self.w2_weight_scale = None
+        torch.cuda.empty_cache()
+
+    # --- runtime ----------------------------------------------------------
+
+    def _runtime(self) -> MegaMoERuntime:
+        shape = MegaMoEShape(
+            world_size=self.ep_size,
+            model_dim=self.hidden_size,
+            inter_dim=self.intermediate_size,
+            experts=self.num_experts,
+            topk=self.top_k,
+            max_tok_per_rank=self.max_tok_per_rank,
+            swiglu_limit=self.swiglu_limit,
+        )
+        return MegaMoERuntime.get(shape, self.ep_rank)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+    ) -> torch.Tensor:
+        num_tokens = hidden_states.shape[0]
+        if num_tokens > self.max_tok_per_rank:
+            raise ValueError(
+                f"DeepSeek V4 MegaMoE got {num_tokens} tokens, but the "
+                f"symmetric buffers were sized for {self.max_tok_per_rank}."
+            )
+
+        # Covers the dummy-weight-loading path, as on CUDA.
+        self.finalize_weights()
+        assert self._shuffled is not None
+        w13, w13_scale, w2, w2_scale = self._shuffled
+
+        runtime = self._runtime()
+
+        # The kernel's contracts: contiguous bf16 activations, float32 routing
+        # weights, int32 expert ids.
+        x = (
+            hidden_states
+            if hidden_states.is_contiguous()
+            else hidden_states.contiguous()
+        )
+        if x.dtype != torch.bfloat16:
+            x = x.to(torch.bfloat16)
+        wts = topk_weights.to(torch.float32).contiguous()
+        ids = topk_ids.to(torch.int32).contiguous()
+
+        with runtime.bind_weights(
+            self, w1=w13, w1_scale=w13_scale, w2=w2, w2_scale=w2_scale
+        ) as moe:
+            out = moe.forward(x, wts, ids)
+
+        # The kernel returns a view into the shared symmetric combine buffer,
+        # which the next layer's call will overwrite. Copy out before returning.
+        return out.clone()
+
+
+DeepseekV4MegaMoEExperts.weight_loader.supports_moe_loading = True  # type: ignore[attr-defined]

--- a/vllm/models/deepseek_v4/amd/mega_moe_runtime.py
+++ b/vllm/models/deepseek_v4/amd/mega_moe_runtime.py
@@ -1,0 +1,283 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Process-wide MegaMoEV2 runtime for the ROCm DeepSeek V4 path.
+
+aiter's ``MegaMoEV2`` owns two very different kinds of state:
+
+* **Symmetric (mori shmem) buffers** -- the dispatch receive staging, the P2P
+  handshake flags, and the combine output. These are sized from
+  ``(world_size, max_tok_per_rank, hidden, experts_per_rank, topk)`` and are
+  completely independent of *which* expert weights are in play. At
+  ``max_tok_per_rank=16384`` they run to ~7.7 GiB per rank.
+* **Weight pointers** -- ``w1``/``w1_scale``/``w2``/``w2_scale``, four plain
+  attributes that the kernels read at launch time.
+
+DeepSeek V4 has 61 layers. Allocating the symmetric buffers per layer is not
+merely wasteful, it is impossible: 61 x 7.7 GiB does not fit on any GPU. But
+because the buffers do not depend on the weights, one instance can serve every
+layer as long as the weight attributes are swapped before each launch. That is
+what this module does -- a single cached ``MegaMoEV2`` keyed on the shapes that
+actually size the buffers, plus a ``bind_weights`` context manager that points
+it at one layer's weights for the duration of a call.
+
+This is safe because MoE layers execute sequentially within a forward pass and
+the kernels consume the weight pointers synchronously at launch. It would not
+be safe under concurrent execution of two MoE layers on the same stream, which
+vLLM does not do.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from dataclasses import dataclass
+
+import torch
+
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+# aiter's fixed-slot dispatch path is selected when max_tok_per_rank <= 255.
+# Above that the compact path is used, whose symmetric capacity grows as
+# world_size * mtpr * topk rather than experts_per_rank * ll_cap.
+_FIXED_SLOT_MAX_MTPR = 255
+
+# all2all backends whose manager brings up the mori symmetric heap itself.
+# "flydsl_intranode" is the overlay's backend, which also calls
+# shmem_torch_process_group_init.
+_MORI_ALL2ALL_BACKENDS = frozenset(
+    {"mori_high_throughput", "mori_low_latency", "flydsl_intranode"}
+)
+
+
+@dataclass(frozen=True)
+class MegaMoEShape:
+    """The parameters that size the symmetric buffers."""
+
+    world_size: int
+    model_dim: int
+    inter_dim: int
+    experts: int
+    topk: int
+    max_tok_per_rank: int
+    swiglu_limit: float
+
+
+def _next_power_of_two(value: int) -> int:
+    if value <= 1:
+        return 1
+    return 1 << (value - 1).bit_length()
+
+
+def resolve_max_tok_per_rank(max_num_tokens: int) -> int:
+    """Round a scheduler token budget up to a power of two.
+
+    ``MegaMoEV2`` requires a power-of-two ``max_tok_per_rank`` and rejects any
+    forward pass carrying more tokens than that, so this has to round up rather
+    than down.
+    """
+    if max_num_tokens <= 0:
+        raise ValueError(f"max_num_tokens must be positive, got {max_num_tokens}")
+    return _next_power_of_two(max_num_tokens)
+
+
+def estimate_symmetric_bytes(shape: MegaMoEShape) -> int:
+    """Approximate the per-rank mori shmem footprint for ``shape``.
+
+    Mirrors the capacity arithmetic in aiter's
+    ``FlyDSLDispatchCombineIntraNodeOp``. Used only for logging and for the
+    up-front sanity check -- the authoritative allocation happens inside aiter.
+    """
+    world = shape.world_size
+    mtpr = shape.max_tok_per_rank
+    epr = shape.experts // world
+    compact = mtpr > _FIXED_SLOT_MAX_MTPR
+    unit = 128 if compact else 32
+
+    if compact:
+        num_valid_max = world * mtpr * shape.topk + epr * unit
+    else:
+        ll_cap = ((world * mtpr + unit - 1) // unit) * unit
+        num_valid_max = epr * ll_cap + 256
+
+    # fp8 dispatch payload, e8m0 group scales (packed to int32), the int32/
+    # float32 side tables, and the stage-1 fp8 output staging buffer.
+    scale_i32_per_row = ((shape.model_dim // 32) + 3) // 4
+    per_row_bytes = (
+        shape.model_dim  # rx_em, one byte per fp8 element
+        + scale_i32_per_row * 4  # scale_em
+        + 3 * 4  # idx_em, wts_em, srcmap_em
+        + shape.inter_dim  # stage-1 fp8 output
+    )
+    return num_valid_max * per_row_bytes
+
+
+class MegaMoERuntime:
+    """Owns the one shared ``MegaMoEV2`` instance for this process."""
+
+    _instances: dict[MegaMoEShape, MegaMoERuntime] = {}
+
+    def __init__(self, shape: MegaMoEShape, rank: int):
+        self.shape = shape
+        self.rank = rank
+        self._moe = None
+        self._bound: object | None = None
+
+    @classmethod
+    def get(cls, shape: MegaMoEShape, rank: int) -> MegaMoERuntime:
+        runtime = cls._instances.get(shape)
+        if runtime is None:
+            runtime = cls(shape, rank)
+            cls._instances[shape] = runtime
+        elif runtime.rank != rank:
+            raise RuntimeError(
+                f"MegaMoERuntime cached for rank {runtime.rank} but requested "
+                f"for rank {rank}; the runtime is per-process."
+            )
+        return runtime
+
+    def _ensure_shmem_initialized(self) -> None:
+        """Bring up mori's symmetric heap if the all2all manager has not.
+
+        Two hazards, pulling in opposite directions:
+
+        * Initializing twice is not a no-op. ``shmem_torch_process_group_init``
+          does a ``dist.broadcast_object_list`` on the EP CPU group and builds
+          a socket bootstrap *before* the "already initialized" guard inside
+          ``libmori_shmem.so`` short-circuits, so a partial re-entry deadlocks;
+          and re-registering the process group silently rebinds the ``"mori"``
+          registry entry rather than raising.
+        * Probing whether it is already up is not possible from Python.
+          ``shmem_npes()`` **segfaults** when the heap has not been initialized
+          -- it dereferences the uninitialized global state singleton, which no
+          ``except`` can catch. Neither is there an ``is_initialized()``.
+
+        So decide from configuration instead of asking mori. Within a vLLM
+        process the heap has exactly one other possible owner:
+        ``MoriAll2AllManager``, constructed iff ``--all2all-backend`` is one of
+        the mori values. That is knowable up front, needs no probe, and is
+        evaluated identically on every rank -- which matters, because the
+        initialize branch is collective.
+        """
+        import mori  # type: ignore[import-not-found]
+
+        from vllm.config import get_current_vllm_config
+        from vllm.distributed.parallel_state import get_ep_group
+
+        if getattr(MegaMoERuntime, "_shmem_ready", False):
+            return
+
+        all2all_backend = get_current_vllm_config().parallel_config.all2all_backend
+        owned_by_all2all = all2all_backend in _MORI_ALL2ALL_BACKENDS
+
+        if owned_by_all2all:
+            logger.info_once(
+                "MegaMoEV2: reusing the mori symmetric heap brought up by "
+                "all2all backend %r",
+                all2all_backend,
+            )
+        else:
+            # Mirrors MoriAll2AllManager.__init__. Collective: every EP rank
+            # must arrive here, which holds because weight finalization runs on
+            # every rank at model load.
+            ep_group = get_ep_group()
+            torch._C._distributed_c10d._register_process_group(
+                "mori", ep_group.cpu_group
+            )
+            mori.shmem.shmem_torch_process_group_init("mori")
+            logger.info_once(
+                "MegaMoEV2: mori symmetric heap initialized (all2all backend "
+                "%r does not own it)",
+                all2all_backend,
+            )
+
+        MegaMoERuntime._shmem_ready = True
+
+    def build(
+        self,
+        *,
+        w1: torch.Tensor,
+        w1_scale: torch.Tensor,
+        w2: torch.Tensor,
+        w2_scale: torch.Tensor,
+    ) -> None:
+        """Construct the shared instance, using ``w1..w2_scale`` as the
+        initial binding. Subsequent layers rebind via :meth:`bind_weights`."""
+        if self._moe is not None:
+            return
+
+        from aiter.ops.flydsl.kernels.mega_moe import MegaMoEV2
+
+        self._ensure_shmem_initialized()
+
+        shape = self.shape
+        approx_gib = estimate_symmetric_bytes(shape) / 2**30
+        logger.info(
+            "MegaMoEV2: building shared instance world=%d model_dim=%d "
+            "inter_dim=%d experts=%d topk=%d max_tok_per_rank=%d "
+            "(~%.2f GiB symmetric per rank)",
+            shape.world_size,
+            shape.model_dim,
+            shape.inter_dim,
+            shape.experts,
+            shape.topk,
+            shape.max_tok_per_rank,
+            approx_gib,
+        )
+
+        self._moe = MegaMoEV2(
+            rank=self.rank,
+            world_size=shape.world_size,
+            model_dim=shape.model_dim,
+            inter_dim=shape.inter_dim,
+            experts=shape.experts,
+            topk=shape.topk,
+            quant="a8w4",
+            w1=w1,
+            w1_scale=w1_scale,
+            w2=w2,
+            w2_scale=w2_scale,
+            max_tok_per_rank=shape.max_tok_per_rank,
+            swiglu_limit=shape.swiglu_limit,
+        )
+        self._bound = None
+
+    @contextlib.contextmanager
+    def bind_weights(
+        self,
+        owner: object,
+        *,
+        w1: torch.Tensor,
+        w1_scale: torch.Tensor,
+        w2: torch.Tensor,
+        w2_scale: torch.Tensor,
+    ):
+        """Point the shared instance at one layer's weights for a call.
+
+        The kernels read ``w2``/``w2_scale`` by ``data_ptr()`` at launch and
+        take ``w1``/``w1_scale`` as tensor arguments, so rebinding is just four
+        attribute assignments. ``owner`` is recorded so a nested bind -- which
+        would silently corrupt the outer layer's launch -- is caught rather
+        than producing wrong numerics.
+        """
+        moe = self._moe
+        if moe is None:
+            raise RuntimeError("MegaMoERuntime.build() must be called first")
+        if self._bound is not None and self._bound is not owner:
+            raise RuntimeError(
+                "MegaMoEV2 weights are already bound to another layer; the "
+                "shared instance does not support nested or concurrent use."
+            )
+        previous = self._bound
+        self._bound = owner
+        # Match what MegaMoEV2.__init__ does to the initial binding: stage-1
+        # takes uint8 views of the packed fp4 weight and its e8m0 scales,
+        # stage-2 reads w2/w2_scale by data_ptr() and only needs contiguity.
+        moe._s1_w1 = w1.view(torch.uint8)
+        moe._s1_w1_scale = w1_scale.view(torch.uint8)
+        moe.w2 = w2
+        moe.w2_scale = w2_scale
+        try:
+            yield moe
+        finally:
+            self._bound = previous

--- a/vllm/models/deepseek_v4/amd/model.py
+++ b/vllm/models/deepseek_v4/amd/model.py
@@ -56,6 +56,11 @@ from vllm.model_executor.models.utils import (
     make_layers,
     maybe_prefix,
 )
+from vllm.models.deepseek_v4.amd.mega_moe_experts import (
+    DeepseekV4MegaMoEExperts,
+    finalize_mega_moe_layers,
+    make_deepseek_v4_mega_expert_params_mapping,
+)
 from vllm.models.deepseek_v4.amd.rocm import DeepseekV4ROCMAiterMLAAttention
 from vllm.platforms import current_platform
 from vllm.sequence import IntermediateTensors
@@ -211,6 +216,31 @@ class DeepseekV4MoE(nn.Module):
         config = vllm_config.model_config.hf_config
         quant_config = vllm_config.quant_config
         self.prefix = prefix
+        self.use_mega_moe = vllm_config.kernel_config.moe_backend == "flydsl_mega_moe"
+        if self.use_mega_moe:
+            if not vllm_config.parallel_config.enable_expert_parallel:
+                raise NotImplementedError(
+                    "DeepSeek V4 FlyDSL mega MoE requires expert parallel. "
+                    "Enable it with --enable-expert-parallel, or pick a "
+                    "different moe backend."
+                )
+            if getattr(config, "expert_dtype", "fp4") != "fp4":
+                raise NotImplementedError(
+                    "DeepSeek V4 FlyDSL mega MoE only supports fp4 experts; "
+                    f"got expert_dtype={config.expert_dtype!r}."
+                )
+            if self.tp_size != 1:
+                # The shared expert is built with reduce_results=False because
+                # FusedMoEFactory normally owns the all-reduce. On the mega path
+                # that layer is bypassed, so under TP>1 the shared expert's
+                # partial sums would never be reduced. DSv4 runs DP-attention +
+                # EP with TP=1, so reject rather than silently produce wrong
+                # numerics.
+                raise NotImplementedError(
+                    "DeepSeek V4 FlyDSL mega MoE requires tensor-parallel "
+                    f"size 1, got {self.tp_size}. Use data parallel with "
+                    "expert parallel instead."
+                )
 
         self.routed_scaling_factor = getattr(config, "routed_scaling_factor", 1.0)
         self.hidden_size = config.hidden_size
@@ -279,6 +309,10 @@ class DeepseekV4MoE(nn.Module):
         self.experts_start_idx = self.tp_rank * self.n_local_experts
         self.experts_end_idx = self.experts_start_idx + self.n_local_experts
 
+        if self.use_mega_moe:
+            self._init_mega_moe_experts(vllm_config, config, prefix)
+            return
+
         self.experts = FusedMoEFactory(
             shared_experts=self.shared_experts,
             n_shared_experts=(
@@ -300,11 +334,76 @@ class DeepseekV4MoE(nn.Module):
             router_logits_dtype=torch.float32,
         )
 
+    def _init_mega_moe_experts(self, vllm_config, config, prefix: str) -> None:
+        from vllm.distributed.parallel_state import get_ep_group
+
+        ep_group = get_ep_group()
+        self.ep_size = ep_group.world_size
+        self.ep_rank = ep_group.rank_in_group
+        assert config.n_routed_experts % self.ep_size == 0, (
+            f"n_routed_experts={config.n_routed_experts} must be divisible "
+            f"by ep_size={self.ep_size}"
+        )
+        self.n_local_experts = config.n_routed_experts // self.ep_size
+        self.experts_start_idx = self.ep_rank * self.n_local_experts
+        self.experts_end_idx = self.experts_start_idx + self.n_local_experts
+
+        self.experts = DeepseekV4MegaMoEExperts(
+            vllm_config,
+            num_experts=config.n_routed_experts,
+            num_local_experts=self.n_local_experts,
+            experts_start_idx=self.experts_start_idx,
+            top_k=config.num_experts_per_tok,
+            hidden_size=config.hidden_size,
+            intermediate_size=config.moe_intermediate_size,
+            swiglu_limit=self.swiglu_limit,
+            prefix=f"{prefix}.experts",
+        )
+
+    def _forward_mega_moe(
+        self, hidden_states: torch.Tensor, input_ids: torch.Tensor | None = None
+    ) -> torch.Tensor:
+        from vllm.model_executor.layers.fused_moe.router.fused_topk_bias_router import (
+            fused_topk_bias,
+        )
+
+        org_shape = hidden_states.shape
+        router_logits, _ = self.gate(hidden_states)
+        topk_weights, topk_ids = fused_topk_bias(
+            hidden_states=hidden_states,
+            gating_output=router_logits,
+            scoring_func=self.scoring_func,
+            e_score_correction_bias=(
+                self.gate.e_score_correction_bias.data
+                if self.gate.e_score_correction_bias is not None
+                else None
+            ),
+            topk=self.n_activated_experts,
+            renormalize=self.renormalize,
+            indices_type=self.hash_indices_dtype,
+            input_tokens=input_ids,
+            hash_indices_table=self.gate.tid2eid,
+            routed_scaling_factor=self.routed_scaling_factor,
+        )
+        final_hidden_states = self.experts(hidden_states, topk_weights, topk_ids)
+        if self.shared_experts is not None:
+            final_hidden_states = final_hidden_states + self.shared_experts(
+                hidden_states
+            )
+        return final_hidden_states.view(org_shape)
+
+    def finalize_mega_moe_weights(self) -> None:
+        if self.use_mega_moe:
+            self.experts.finalize_weights()
+
     def forward(
         self, hidden_states: torch.Tensor, input_ids: torch.Tensor | None = None
     ) -> torch.Tensor:
         if self.gate.tid2eid is not None and input_ids is None:
             raise ValueError("DeepSeek V4 hash MoE routing requires input_ids.")
+
+        if self.use_mega_moe:
+            return self._forward_mega_moe(hidden_states, input_ids)
 
         org_shape = hidden_states.shape
         final_hidden_states = self.experts(
@@ -867,6 +966,11 @@ class DeepseekV4Model(nn.Module, EagleModelMixin):
         return loaded_params
 
     def get_expert_mapping(self) -> list[tuple[str, str, int, str]]:
+        first_layer = next(iter(islice(self.layers, self.start_layer, self.end_layer)))
+        if getattr(first_layer.ffn, "use_mega_moe", False):
+            return make_deepseek_v4_mega_expert_params_mapping(
+                self.config.n_routed_experts
+            )
         # Params for weights, fp8 weight scales, fp8 activation scales
         # (param_name, weight_name, expert_id, shard_id)
         # When fusing shared experts, include the appended slots
@@ -1008,7 +1112,11 @@ class DeepseekV4ForCausalLM(nn.Module, SupportsPP, SupportsEagle3):
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
         loader = AutoWeightsLoader(self, skip_substrs=["mtp."])
-        return loader.load_weights(weights, mapper=self.hf_to_vllm_mapper)
+        loaded_params = loader.load_weights(weights, mapper=self.hf_to_vllm_mapper)
+        finalize_mega_moe_layers(
+            islice(self.model.layers, self.model.start_layer, self.model.end_layer)
+        )
+        return loaded_params
 
     def process_weights_after_loading(self) -> None:
         # After per-layer quant finalize, so we preshuffle the final fp8 weights.

--- a/vllm/models/deepseek_v4/amd/mtp.py
+++ b/vllm/models/deepseek_v4/amd/mtp.py
@@ -39,6 +39,10 @@ from vllm.model_executor.model_loader.weight_utils import default_weight_loader
 from vllm.model_executor.models.deepseek_mtp import SharedHead
 from vllm.model_executor.models.deepseek_v2 import get_spec_layer_idx_from_weight_name
 from vllm.model_executor.models.utils import maybe_prefix
+from vllm.models.deepseek_v4.amd.mega_moe_experts import (
+    finalize_mega_moe_layers,
+    make_deepseek_v4_mega_expert_params_mapping,
+)
 from vllm.models.deepseek_v4.common.ops import (
     fused_mtp_input_rmsnorm,
     mtp_shared_head_rmsnorm,
@@ -358,13 +362,19 @@ class DeepSeekV4MTP(nn.Module):
         head_rank_end = n_local_head * (tp_rank + 1)
 
         # Pre-compute expert mapping ONCE.
-        expert_mapping = fused_moe_make_expert_params_mapping(
-            self,
-            ckpt_gate_proj_name="w1",
-            ckpt_down_proj_name="w2",
-            ckpt_up_proj_name="w3",
-            num_experts=self.config.n_routed_experts,
-        )
+        first_layer = next(iter(self.model.layers.values()))
+        if getattr(first_layer.mtp_block.ffn, "use_mega_moe", False):
+            expert_mapping = make_deepseek_v4_mega_expert_params_mapping(
+                self.config.n_routed_experts
+            )
+        else:
+            expert_mapping = fused_moe_make_expert_params_mapping(
+                self,
+                ckpt_gate_proj_name="w1",
+                ckpt_down_proj_name="w2",
+                ckpt_up_proj_name="w3",
+                num_experts=self.config.n_routed_experts,
+            )
 
         # FP8 experts register ``..._weight_scale_inv`` (block_quant) while
         # FP4/MXFP4 experts register ``..._weight_scale``. Choose the suffix
@@ -489,6 +499,7 @@ class DeepSeekV4MTP(nn.Module):
                     f"Use a checkpoint that includes MTP layer weights, "
                     f"or disable speculative decoding."
                 )
+        finalize_mega_moe_layers(self.model.layers)
         logger.info_once("MTP draft model loaded: %d params", len(loaded_params))
         return loaded_params
 


### PR DESCRIPTION
## Purpose

Adds an opt-in FlyDSL fused mega-MoE backend for DeepSeek V4 on ROCm (gfx950 / MI355X).

On the current EP path, a DSv4 MoE layer issues a separate launch chain per stage: EP dispatch → expert GEMM1 → activation → expert GEMM2 → EP combine. This backend replaces that chain with a single fused `MegaMoEV2` call from aiter, which keeps the dispatched tokens resident and folds both expert GEMMs and the combine into one launch.

Enable with:

```
--moe-backend flydsl_mega_moe --enable-expert-parallel
```

## Design

- **Opt-in and off by default.** `KernelConfig.moe_backend` defaults to `"auto"`; this change only adds `"flydsl_mega_moe"` to the accepted values. When it is not selected, `DeepseekV4MoE` takes exactly the path it takes today.
- **Requirements are enforced, not assumed.** Selecting the backend without expert parallelism, without fp4 experts, or with TP > 1 raises `NotImplementedError`. The TP guard matters for correctness rather than performance: the shared expert is constructed with `reduce_results=False` because `FusedMoEFactory` normally owns the all-reduce, and the mega path bypasses that layer — under TP > 1 the shared expert's partial sums would never be reduced. Rejecting the config is preferable to silently producing wrong numerics.
- **Separate weight path.** Mega-MoE consumes a different expert weight layout, so it registers its own expert params mapping (`make_deepseek_v4_mega_expert_params_mapping`) and applies `shuffle_weight_a16w4` in a post-load finalize step. `finalize_mega_moe_layers()` is a documented no-op when the mega path is off, and tolerates the several shapes `model.layers` takes (list / `ModuleDict` / MTP-wrapped).
- **Shared with MTP and DSpark.** Both speculative-decode paths reuse the same layer construction, so the backend applies there too.
- **No import cost when unused.** Every `aiter` / `mori` import is function-local, so a non-ROCm build or a run that does not select the backend never imports them.

## Files

| File | |
|---|---|
| `vllm/config/kernel.py` | register `flydsl_mega_moe` as a `moe_backend` value |
| `vllm/models/deepseek_v4/amd/mega_moe_experts.py` | new — expert module, weight layout, params mapping, finalize |
| `vllm/models/deepseek_v4/amd/mega_moe_runtime.py` | new — `MegaMoEV2` runtime wrapper, EP handles, mori init |
| `vllm/models/deepseek_v4/amd/model.py` | dispatch, guards, expert-mapping and load-weights hooks |
| `vllm/models/deepseek_v4/amd/mtp.py`, `dspark.py` | share the mega path |

## Dependency

Requires the fused kernel from ROCm/aiter#4439, which is **merged** and present in aiter main.

## Test plan / status

Marked draft deliberately. The change was developed and measured as the vLLM-side delta of a working DSv4 FP4 image built on vLLM `02e63f2e4`, then rebased by hand onto current main across the `FusedMoE` → `FusedMoEFactory` rename and the surrounding dead-code removal. **Since that rebase only static checks have been run** (`ruff check`, `ruff format --check`, `py_compile`); it has not been re-validated end-to-end on 8×MI355X against this exact commit. I will re-run the DSv4 FP4 EP8 serving benchmark on top of this branch and post numbers before marking it ready for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
