### PR TITLE
[P/D][Perf] Cut decode-side TTFT for NIXL P/D: first-token seeding, fast KV side channels, concurrent dispatch

### DIFF
--- a/docs/features/nixl_connector_usage.md
+++ b/docs/features/nixl_connector_usage.md
@@ -410,6 +410,20 @@ Support use case: Prefill with `LBHNC` and decode with `LBNHC` with experimental
 --kv-transfer-config '{..., "enable_permute_local_kv":"True"}'
 ```
 
+## Performance Tuning
+
+### Block size and descriptor fragmentation
+
+NixlConnector builds one memory descriptor per KV block (per layer), so transfer latency is highly sensitive to `--block-size`. With the default block size of 16, a multi-thousand-token transfer decomposes into tens of thousands of small (~KB-scale, dtype/model dependent) descriptors and per-descriptor overhead dominates the transfer time, especially on hosts without GPU P2P or with TCP transports.
+
+Increasing `--block-size` on **both** the prefiller and the decoder reduces the descriptor count proportionally. As a reference point, on an 8×L20 host (Qwen3-32B-FP8, TP2, fp8 KV cache, ~5k-token prompts), moving from `--block-size 16` to `--block-size 64` cut the per-request KV pull from ~105ms to ~47ms.
+
+Notes:
+
+- Both sides must use the same block size (heterogeneous block sizes fall back to a slower post-processing path).
+- Attention backends cap the physical kernel page size (e.g. 64 for FlashInfer). Requesting a larger logical block size than the kernel supports gives no further benefit: NixlConnector logs `User-specified logical block size (...) does not match physical kernel block size (...)` and descriptors stay at the kernel granularity.
+- Watch the `Avg number of descriptors` field of the periodic `KV Transfer metrics` log line (see [Metrics Reference](#metrics-reference)) to verify the effect.
+
 ## Metrics Reference
 
 vLLM periodically logs a `KV Transfer metrics` line summarising NIXL transfer

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_worker.py
@@ -498,6 +498,27 @@ class NixlBaseConnectorWorker:
         # background handshake thread, matching the _ready_requests pattern.
         self._failed_recv_reqs: queue.Queue[ReqId] = queue.Queue()
 
+        # Fast KV side channels (pull mode only, opt-in; see nixl/fast_kv.py).
+        self.fast_dispatch_enabled = False
+        self.fast_notify_enabled = False
+        # Guards recv bookkeeping across the main thread and the
+        # fast-dispatch/fast-notify threads.
+        self._fast_lock = threading.RLock()
+        # Reqs whose pulls the fast-notify poller polls/reports.
+        self._fast_eligible: set[ReqId] = set()
+        # Fast-eligible reqs that saw a transfer failure (slow path reports).
+        self._fast_failed: set[ReqId] = set()
+        # Fast-notified reqs pending their idempotent slow-path re-report.
+        self._fast_done_recving: set[ReqId] = set()
+        # Reqs initiated by the fast-dispatch listener.
+        self._fast_dispatched: dict[ReqId, float] = {}
+        # All initiated recv reqs (either path); dedups double-initiation.
+        self._recv_initiated: dict[ReqId, float] = {}
+        self._fast_stop_event = threading.Event()
+        self._fast_zmq_ctx: zmq.Context | None = None
+        self._fast_poller_t: threading.Thread | None = None
+        self._fast_dispatch_t: threading.Thread | None = None
+
         # Handshake metadata of this worker for NIXL transfers.
         self.xfer_handshake_metadata: NixlHandshakePayload | None = None
         # Background thread for initializing new NIXL handshakes.
@@ -2030,20 +2051,30 @@ class NixlBaseConnectorWorker:
         to track which workers are done.
         """
         assert self.transfer_topo is not None
-        done_sending = self._get_new_notifs()
-        done_recving = self._pop_done_transfers(self._recving_transfers)
+        with self._fast_lock:
+            done_sending = self._get_new_notifs()
+            # Reqs owned by the fast-notify poller are reported below.
+            done_recving = self._pop_done_transfers(
+                self._recving_transfers, skip=self._fast_eligible
+            )
 
-        # Drain queue of requests where handshake or transfer setup failed.
-        failed_recv_reqs = set[ReqId]()
-        while not self._failed_recv_reqs.empty():
-            try:
-                failed_recv_reqs.add(self._failed_recv_reqs.get_nowait())
-            except queue.Empty:
-                break
+            # Drain queue of requests where handshake or transfer setup failed.
+            failed_recv_reqs = set[ReqId]()
+            while not self._failed_recv_reqs.empty():
+                try:
+                    failed_recv_reqs.add(self._failed_recv_reqs.get_nowait())
+                except queue.Empty:
+                    break
 
-        # Add failed requests to done_recving for scheduler tracking
-        # (blocks are already marked invalid, scheduler will handle recompute)
-        done_recving.update(failed_recv_reqs)
+            # Add failed requests to done_recving for scheduler tracking
+            # (blocks are already marked invalid, scheduler will handle recompute)
+            done_recving.update(failed_recv_reqs)
+
+            # Re-report fast-notified reqs through the regular path so
+            # KVOutputAggregator bookkeeping is unchanged; scheduler dedups.
+            fast_done_recving = self._fast_done_recving
+            self._fast_done_recving = set()
+            done_recving |= fast_done_recving
 
         if len(done_sending) > 0 or len(done_recving) > 0:
             logger.debug(
@@ -2058,6 +2089,10 @@ class NixlBaseConnectorWorker:
         block_ids_for_blocksize_post_process = defaultdict(list)
         block_ids_for_heterogeneous_attn_post_process = list[list[int]]()
         for req_id in done_recving:
+            if req_id in fast_done_recving:
+                # Fast-notify eligibility guarantees no post-processing.
+                self._recving_metadata.pop(req_id, None)
+                continue
             # clean up metadata for completed requests
             meta = self._recving_metadata.pop(req_id, None)
             assert meta is not None, f"{req_id} not found in recving_metadata list"
@@ -2189,16 +2224,23 @@ class NixlBaseConnectorWorker:
                     new_expiry,
                 )
 
-    def _pop_done_transfers(self, transfers: dict[str, list[int]]) -> set[str]:
+    def _pop_done_transfers(
+        self,
+        transfers: dict[str, list[int]],
+        skip: set[str] | None = None,
+    ) -> set[str]:
         """
         Pop completed xfers by checking for DONE state.
         Args:
             transfers: dict of req_id -> list[running_xfer]
+            skip: req_ids polled elsewhere (fast-notify poller); untouched.
         Returns:
             set of req_ids that have all done xfers
         """
         done_req_ids: set[str] = set()
         for req_id, handles in list(transfers.items()):
+            if skip and req_id in skip:
+                continue
             in_progress = []
             for handle in handles:
                 try:
@@ -2568,6 +2610,14 @@ class NixlBaseConnectorWorker:
         if not hasattr(self, "_handshake_initiation_executor"):
             # error happens during init, no need to shutdown
             return
+        self._fast_stop_event.set()
+        for t in (self._fast_poller_t, self._fast_dispatch_t):
+            if t is not None and t.is_alive():
+                t.join(timeout=1.0)
+        self._fast_poller_t = None
+        self._fast_dispatch_t = None
+        # The fast zmq context is deliberately not term()'d: term would
+        # block on sockets owned by already-killed daemon threads.
         self._handshake_initiation_executor.shutdown(wait=False)
         for handles in self._recving_transfers.values():
             for handle in handles:

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/fast_kv.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/fast_kv.py
@@ -1,0 +1,190 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Fast KV side channels for the NIXL pull connector.
+
+Optional ipc channels between the EngineCore and TP worker processes that
+bypass the per-step SchedulerOutput/ModelRunnerOutput round trip: fast
+dispatch (EngineCore PUB -> worker SUB) starts NIXL reads right after
+schedule(), and fast notify (worker PUSH -> EngineCore PULL) reports pull
+completion without waiting for the step boundary. Both are hints only; the
+regular get_finished() path still reports every request (scheduler dedups).
+Enable via kv_connector_extra_config: fast_kv_dispatch / fast_kv_notify.
+"""
+
+import contextlib
+import os
+import pickle
+import threading
+from typing import TYPE_CHECKING, Any
+
+import zmq
+
+import vllm.envs as envs
+from vllm.config import VllmConfig
+from vllm.logger import init_logger
+
+if TYPE_CHECKING:
+    from vllm.v1.core.sched.output import SchedulerOutput
+
+logger = init_logger(__name__)
+
+_PULL_CONNECTORS = ("NixlConnector", "NixlPullConnector")
+
+
+def fast_dispatch_enabled(vllm_config: VllmConfig) -> bool:
+    ktc = vllm_config.kv_transfer_config
+    return ktc is not None and bool(
+        ktc.get_from_extra_config("fast_kv_dispatch", False)
+    )
+
+
+def fast_notify_enabled(vllm_config: VllmConfig) -> bool:
+    ktc = vllm_config.kv_transfer_config
+    return ktc is not None and bool(ktc.get_from_extra_config("fast_kv_notify", False))
+
+
+def _fast_kv_base_port(vllm_config: VllmConfig) -> int:
+    # Unique per vLLM instance on this host, like the NIXL side channel port.
+    return (
+        envs.VLLM_NIXL_SIDE_CHANNEL_PORT
+        + vllm_config.parallel_config.data_parallel_index
+    )
+
+
+def fast_kv_dispatch_path(vllm_config: VllmConfig) -> str:
+    return f"ipc:///tmp/vllm_nixl_fkd_{_fast_kv_base_port(vllm_config)}.sock"
+
+
+def fast_kv_notify_path(vllm_config: VllmConfig) -> str:
+    return f"ipc:///tmp/vllm_nixl_fkn_{_fast_kv_base_port(vllm_config)}.sock"
+
+
+def _unlink_ipc_path(path: str) -> None:
+    if path.startswith("ipc://"):
+        with contextlib.suppress(OSError):
+            os.unlink(path[len("ipc://") :])
+
+
+class NixlFastKVEngineCoreBridge:
+    """EngineCore-process endpoints of the fast KV side channels (owns the
+    bound ends of both ipc sockets; workers connect)."""
+
+    def __init__(self, vllm_config: VllmConfig, scheduler: Any, output_queue: Any):
+        self.scheduler = scheduler
+        self.output_queue = output_queue
+        self.world_size = vllm_config.parallel_config.world_size
+        self.dispatch_enabled = fast_dispatch_enabled(vllm_config)
+        self.notify_enabled = fast_notify_enabled(vllm_config) and hasattr(
+            scheduler, "on_fast_kv_recv_finished"
+        )
+        self._ctx = zmq.Context()
+        self._stop_event = threading.Event()
+        self._dispatch_sock: zmq.Socket | None = None
+        self._notify_t: threading.Thread | None = None
+        if self.dispatch_enabled:
+            path = fast_kv_dispatch_path(vllm_config)
+            _unlink_ipc_path(path)
+            sock = self._ctx.socket(zmq.PUB)
+            sock.setsockopt(zmq.LINGER, 0)
+            sock.bind(path)
+            self._dispatch_sock = sock
+        if self.notify_enabled:
+            self._notify_path = fast_kv_notify_path(vllm_config)
+            _unlink_ipc_path(self._notify_path)
+            self._notify_t = threading.Thread(
+                target=self._notify_loop,
+                daemon=True,
+                name="nixl-fast-kv-notify",
+            )
+            self._notify_t.start()
+        logger.info(
+            "NIXL fast KV EngineCore bridge initialized "
+            "(dispatch=%s notify=%s world_size=%d)",
+            self.dispatch_enabled,
+            self.notify_enabled,
+            self.world_size,
+        )
+
+    def dispatch(self, scheduler_output: "SchedulerOutput") -> None:
+        """Publish new pull metadata to the workers right after schedule()."""
+        if self._dispatch_sock is None:
+            return
+        meta = scheduler_output.kv_connector_metadata
+        reqs_to_recv = getattr(meta, "reqs_to_recv", None)
+        if not reqs_to_recv:
+            return
+        try:
+            self._dispatch_sock.send(pickle.dumps(reqs_to_recv))
+        except Exception:
+            logger.exception(
+                "Fast KV dispatch failed; workers will pick the metadata up "
+                "with the next execute_model call."
+            )
+
+    def _notify_loop(self):
+        sock = self._ctx.socket(zmq.PULL)
+        sock.setsockopt(zmq.LINGER, 0)
+        sock.bind(self._notify_path)
+        poller = zmq.Poller()
+        poller.register(sock, zmq.POLLIN)
+        pending: dict[str, set[int]] = {}
+        try:
+            while not self._stop_event.is_set():
+                if not poller.poll(timeout=200):
+                    continue
+                req_id, rank = pickle.loads(sock.recv())
+                ranks = pending.setdefault(req_id, set())
+                ranks.add(rank)
+                if len(ranks) < self.world_size:
+                    continue
+                del pending[req_id]
+                try:
+                    result = self.scheduler.on_fast_kv_recv_finished(req_id)
+                except Exception:
+                    logger.exception(
+                        "on_fast_kv_recv_finished failed for %s; the regular "
+                        "get_finished path will resume the request.",
+                        req_id,
+                    )
+                    continue
+                if result is None:
+                    continue
+                client_index, engine_core_output = result
+                # Same cross-thread pattern as _send_finish_outputs_to_client.
+                from vllm.v1.engine import EngineCoreOutputs
+
+                self.output_queue.put_nowait(
+                    (client_index, EngineCoreOutputs(outputs=[engine_core_output]))
+                )
+        except Exception:
+            logger.exception(
+                "NIXL fast-notify bridge thread died; completions fall back "
+                "to the regular per-step path."
+            )
+        finally:
+            sock.close(linger=0)
+
+    def shutdown(self):
+        self._stop_event.set()
+        if self._dispatch_sock is not None:
+            with contextlib.suppress(Exception):
+                self._dispatch_sock.close(linger=0)
+            self._dispatch_sock = None
+        if self._notify_t is not None and self._notify_t.is_alive():
+            self._notify_t.join(timeout=1.0)
+        self._notify_t = None
+        # The zmq context is deliberately not term()'d: term would block on
+        # sockets owned by already-killed daemon threads.
+
+
+def maybe_create_fast_kv_bridge(
+    vllm_config: VllmConfig, scheduler: Any, output_queue: Any
+) -> NixlFastKVEngineCoreBridge | None:
+    """Create the bridge iff the NIXL pull connector is in use and at least
+    one fast path is enabled."""
+    ktc = vllm_config.kv_transfer_config
+    if ktc is None or ktc.kv_connector not in _PULL_CONNECTORS:
+        return None
+    if not (fast_dispatch_enabled(vllm_config) or fast_notify_enabled(vllm_config)):
+        return None
+    return NixlFastKVEngineCoreBridge(vllm_config, scheduler, output_queue)

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/fast_kv.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/fast_kv.py
@@ -77,9 +77,16 @@ class NixlFastKVEngineCoreBridge:
         self.notify_enabled = fast_notify_enabled(vllm_config) and hasattr(
             scheduler, "on_fast_kv_recv_finished"
         )
+        # Scheduler-side connector, for on_pd_kv_ready (early-arm).
+        self.connector_scheduler = getattr(
+            getattr(scheduler, "connector", None), "connector_scheduler", None
+        )
         self._ctx = zmq.Context()
         self._stop_event = threading.Event()
         self._dispatch_sock: zmq.Socket | None = None
+        # The dispatch socket is written from the busy loop and the notify
+        # thread; zmq sockets are not thread-safe.
+        self._dispatch_lock = threading.Lock()
         self._notify_t: threading.Thread | None = None
         if self.dispatch_enabled:
             path = fast_kv_dispatch_path(vllm_config)
@@ -114,7 +121,8 @@ class NixlFastKVEngineCoreBridge:
         if not reqs_to_recv:
             return
         try:
-            self._dispatch_sock.send(pickle.dumps(reqs_to_recv))
+            with self._dispatch_lock:
+                self._dispatch_sock.send(pickle.dumps(reqs_to_recv))
         except Exception:
             logger.exception(
                 "Fast KV dispatch failed; workers will pick the metadata up "
@@ -132,7 +140,11 @@ class NixlFastKVEngineCoreBridge:
             while not self._stop_event.is_set():
                 if not poller.poll(timeout=200):
                     continue
-                req_id, rank = pickle.loads(sock.recv())
+                msg = pickle.loads(sock.recv())
+                if len(msg) == 3 and msg[0] == "pd_ready":
+                    self._handle_pd_ready(msg[1], msg[2])
+                    continue
+                req_id, rank = msg
                 ranks = pending.setdefault(req_id, set())
                 ranks.add(rank)
                 if len(ranks) < self.world_size:
@@ -163,6 +175,35 @@ class NixlFastKVEngineCoreBridge:
             )
         finally:
             sock.close(linger=0)
+
+    def _handle_pd_ready(self, raw_request_id: str, kv_transfer_params: dict) -> None:
+        """Early-arm: merge the ready params into the armed request and
+        fast-publish its pull metadata. Runs on the notify thread."""
+        cs = self.connector_scheduler
+        if cs is None or not getattr(cs, "pd_early_arm_enabled", False):
+            return
+        try:
+            result = cs.on_pd_kv_ready(raw_request_id, kv_transfer_params)
+        except Exception:
+            logger.exception(
+                "on_pd_kv_ready failed for %s; the armed-timeout fallback "
+                "will recompute locally.",
+                raw_request_id,
+            )
+            return
+        if result is None or self._dispatch_sock is None:
+            # The next step's connector metadata delivers the pull.
+            return
+        req_id, req_meta = result
+        try:
+            with self._dispatch_lock:
+                self._dispatch_sock.send(pickle.dumps({req_id: req_meta}))
+        except Exception:
+            logger.exception(
+                "Fast publish of pd_ready pull metadata failed for %s; the "
+                "next step's connector metadata delivers it.",
+                req_id,
+            )
 
     def shutdown(self):
         self._stop_event.set()

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/pull_scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/pull_scheduler.py
@@ -6,14 +6,21 @@ import time
 from typing import TYPE_CHECKING, Any
 
 from vllm.distributed.kv_transfer.kv_connector.utils import BlockIds
+from vllm.distributed.kv_transfer.kv_connector.v1.base import KVConnectorMetadata
 from vllm.distributed.kv_transfer.kv_connector.v1.nixl.base_scheduler import (
     NixlBaseConnectorScheduler,
+)
+from vllm.distributed.kv_transfer.kv_connector.v1.nixl.metadata import (
+    NixlConnectorMetadata,
+    ReqId,
+    ReqMeta,
 )
 from vllm.logger import init_logger
 
 if TYPE_CHECKING:
     from vllm.config import VllmConfig
     from vllm.v1.core.kv_cache_manager import KVCacheBlocks
+    from vllm.v1.core.sched.output import SchedulerOutput
     from vllm.v1.kv_cache_interface import KVCacheConfig
     from vllm.v1.request import Request
 
@@ -37,9 +44,35 @@ class NixlPullConnectorScheduler(NixlBaseConnectorScheduler):
             )
         )
 
+        # Concurrent P/D dispatch: max time a decode "prepare" request may
+        # stay parked/armed waiting for the KV-ready notification; on expiry
+        # it falls back to a local prefill.
+        self.prepare_ready_timeout_s = float(
+            vllm_config.kv_transfer_config.get_from_extra_config(
+                "prepare_ready_timeout_s", 10.0
+            )
+        )
+        # Early-arm: allocate a prepare request's blocks on the first
+        # schedule pass and let the KV-ready notification start the pull
+        # directly from the bridge thread (blocks pinned during prefill).
+        self.pd_early_arm_enabled = bool(
+            vllm_config.kv_transfer_config.get_from_extra_config(
+                "pd_early_arm", False
+            )
+        )
+        # Early-arm state, shared between the engine thread and the bridge
+        # notify thread; dict/list ops are GIL-atomic and ownership is
+        # handed over via dict.pop.
+        # Armed prepare requests: blocks allocated, pull deferred.
+        self._pd_armed: dict[ReqId, tuple[Request, BlockIds]] = {}
+        # KV-ready params that arrived before their request was armed.
+        self._pd_pending_ready: dict[str, tuple[dict[str, Any], float]] = {}
+        # Armed pulls riding the next step's metadata as slow-path backup.
+        self._pd_ready_backup: list[tuple[ReqId, ReqMeta]] = []
+
     def get_num_new_matched_tokens(
         self, request: "Request", num_computed_tokens: int
-    ) -> tuple[int, bool]:
+    ) -> tuple[int | None, bool]:
         """
         For remote prefill, pull all prompt blocks from remote
         asynchronously relative to engine execution.
@@ -50,7 +83,8 @@ class NixlPullConnectorScheduler(NixlBaseConnectorScheduler):
                 computed tokens for this request
         Returns:
             * the number of tokens that can be loaded from the
-              external KV cache beyond what is already computed.
+              external KV cache beyond what is already computed
+              (None to have the scheduler query again later).
             * true if the external KV cache tokens will be loaded
               asynchronously (between scheduler steps).
         """
@@ -64,6 +98,35 @@ class NixlPullConnectorScheduler(NixlBaseConnectorScheduler):
         )
 
         if params is not None and params.get("do_remote_prefill"):
+            if not params.get("remote_block_ids") and (
+                params.get("remote_ready") is False
+            ):
+                # Concurrent P/D dispatch: prepare request, remote KV
+                # metadata not arrived yet.
+                pending = self._pd_take_pending_ready(request.request_id)
+                if pending is not None:
+                    # Ready notification raced ahead; merge and pull now.
+                    self._pd_merge_ready_params(params, pending)
+                elif self.pd_early_arm_enabled:
+                    # Early-arm: allocate blocks via the normal async-load
+                    # path; update_state_after_alloc arms the request.
+                    params.setdefault("_pd_parked_ts", time.monotonic())
+                else:
+                    # Late-alloc parking: None skips the request in
+                    # schedule() without allocating blocks.
+                    now = time.monotonic()
+                    parked_ts = params.setdefault("_pd_parked_ts", now)
+                    if now - parked_ts > self.prepare_ready_timeout_s:
+                        logger.warning(
+                            "PD prepare request %s waited %.1fs for the "
+                            "KV-ready notification; falling back to local "
+                            "prefill.",
+                            request.request_id,
+                            now - parked_ts,
+                        )
+                        params["do_remote_prefill"] = False
+                        return 0, False
+                    return None, False
             # Remote prefill: get all prompt blocks from remote.
             token_ids = request.prompt_token_ids or []
             actual = self._get_remote_prefill_token_count(len(token_ids))
@@ -175,11 +238,138 @@ class NixlPullConnectorScheduler(NixlBaseConnectorScheduler):
                         "request will not utilize KVTransfer",
                         params,
                     )
+            elif self.pd_early_arm_enabled and params.get("remote_ready") is False:
+                # Early-arm: stash the allocated blocks for on_pd_kv_ready.
+                unhashed_local_block_ids = (
+                    blocks.get_unhashed_block_ids_all_groups()
+                    if num_external_tokens > 0
+                    else ()
+                )
+                local_block_ids = self.get_exchange_clipped_blocks(
+                    unhashed_local_block_ids
+                )
+                pending = self._pd_take_pending_ready(request.request_id)
+                if pending is not None:
+                    # Ready already landed: pull with this very step.
+                    self._pd_merge_ready_params(params, pending)
+                    self._reqs_need_recv[request.request_id] = (
+                        request,
+                        local_block_ids,
+                    )
+                else:
+                    self._pd_armed[request.request_id] = (request, local_block_ids)
+                    params["_pd_armed_ts"] = time.monotonic()
             else:
                 assert num_external_tokens == 0
             # Only trigger 1 KV transfer per request.
             params["do_remote_prefill"] = False
             params["_remote_blocks_processed"] = True
+
+    @staticmethod
+    def _pd_merge_ready_params(
+        params: dict[str, Any], ready_params: dict[str, Any]
+    ) -> None:
+        """Merge the prefill-side kv_transfer_params and mark remote ready."""
+        params.update(ready_params)
+        params["remote_ready"] = True
+
+    def _pd_take_pending_ready(self, req_id: ReqId) -> dict[str, Any] | None:
+        """Pop a stashed KV-ready notification matching this internal
+        request id (internal ids embed the router-side raw id, hence the
+        substring match). Engine thread only."""
+        if not self._pd_pending_ready:
+            return None
+        for raw_id in list(self._pd_pending_ready):
+            if raw_id in req_id:
+                params, _ = self._pd_pending_ready.pop(raw_id)
+                return params
+        return None
+
+    def pd_cancel_armed(self, req_id: ReqId) -> bool:
+        """Atomically claim an armed entry (timeout/abort path); False if
+        on_pd_kv_ready already claimed it and the pull is going ahead."""
+        return self._pd_armed.pop(req_id, None) is not None
+
+    def on_pd_kv_ready(
+        self, raw_request_id: str, kv_transfer_params: dict[str, Any]
+    ) -> tuple[ReqId, ReqMeta] | None:
+        """Deliver the prefill's kv_transfer_params for an armed prepare
+        request and build its pull metadata immediately.
+
+        Called from the bridge notify thread (or the UTILITY RPC fallback).
+        The armed entry is claimed with an atomic dict.pop that arbitrates
+        against the armed-timeout fallback. Returns (req_id, ReqMeta) when
+        the pull was armed (caller may fast-publish it; the next step's
+        metadata re-delivers it as backup), else None (params stashed for
+        the engine thread).
+        """
+        if not self.pd_early_arm_enabled:
+            return None
+        armed_req_id = None
+        for req_id in list(self._pd_armed):
+            if raw_request_id in req_id:
+                armed_req_id = req_id
+                break
+        entry = (
+            self._pd_armed.pop(armed_req_id, None) if armed_req_id is not None else None
+        )
+        if entry is None:
+            # Not armed yet or claimed by the timeout path: stash and prune.
+            now = time.monotonic()
+            self._pd_pending_ready[raw_request_id] = (kv_transfer_params, now)
+            for raw_id, (_, ts) in list(self._pd_pending_ready.items()):
+                if now - ts > 60.0:
+                    self._pd_pending_ready.pop(raw_id, None)
+            return None
+        request, local_block_ids = entry
+        params = request.kv_transfer_params
+        assert params is not None
+        self._pd_merge_ready_params(params, kv_transfer_params)
+        # The pull is triggered right here; keep the flag False or
+        # request_finished would queue a spurious empty recv.
+        params["do_remote_prefill"] = False
+        params.pop("_pd_armed_ts", None)
+        if not all(
+            params.get(p) is not None
+            for p in (
+                "remote_block_ids",
+                "remote_engine_id",
+                "remote_request_id",
+                "remote_host",
+                "remote_port",
+            )
+        ):
+            logger.warning(
+                "Got invalid KV-ready params for %s: %s; re-arming for the "
+                "timeout fallback (local prefill).",
+                armed_req_id,
+                kv_transfer_params,
+            )
+            params["_pd_armed_ts"] = time.monotonic()
+            self._pd_armed[armed_req_id] = (request, local_block_ids)
+            return None
+        helper = NixlConnectorMetadata()
+        helper.add_new_req_to_recv(
+            request_id=armed_req_id,
+            local_block_ids=local_block_ids,
+            kv_transfer_params=params,
+        )
+        req_meta = helper.reqs_to_recv[armed_req_id]
+        self._pd_ready_backup.append((armed_req_id, req_meta))
+        return armed_req_id, req_meta
+
+    def build_connector_meta(
+        self,
+        scheduler_output: "SchedulerOutput",
+    ) -> KVConnectorMetadata:
+        meta = super().build_connector_meta(scheduler_output)
+        # Early-arm: slow-path backup of the bridge's fast publish.
+        if self._pd_ready_backup:
+            assert isinstance(meta, NixlConnectorMetadata)
+            while self._pd_ready_backup:
+                req_id, req_meta = self._pd_ready_backup.pop()
+                meta.reqs_to_recv.setdefault(req_id, req_meta)
+        return meta
 
     def request_finished(
         self,
@@ -202,6 +392,10 @@ class NixlPullConnectorScheduler(NixlBaseConnectorScheduler):
         )
         if not params:
             return False, None
+
+        # Early-arm: a late KV-ready notification must not start a pull
+        # into freed blocks.
+        self._pd_armed.pop(request.request_id, None)
 
         is_p_node = bool(params.get("do_remote_decode"))
         is_d_node = not is_p_node

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/pull_scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/pull_scheduler.py
@@ -30,6 +30,12 @@ class NixlPullConnectorScheduler(NixlBaseConnectorScheduler):
         kv_cache_config: "KVCacheConfig",
     ):
         super().__init__(vllm_config, engine_id, kv_cache_config)
+        assert vllm_config.kv_transfer_config is not None
+        self.seed_first_token = bool(
+            vllm_config.kv_transfer_config.get_from_extra_config(
+                "seed_first_token", False
+            )
+        )
 
     def get_num_new_matched_tokens(
         self, request: "Request", num_computed_tokens: int
@@ -263,7 +269,7 @@ class NixlPullConnectorScheduler(NixlBaseConnectorScheduler):
 
             remote_num_tokens = request.num_computed_tokens
 
-        return delay_free_blocks, dict(
+        params = dict(
             do_remote_prefill=is_p_node,
             do_remote_decode=is_d_node,
             remote_block_ids=block_ids,
@@ -276,3 +282,6 @@ class NixlPullConnectorScheduler(NixlBaseConnectorScheduler):
             remote_blocks_expiry_time=blocks_expiry_time,
             transfer_mode=self._TRANSFER_MODE,
         )
+        if self.seed_first_token and is_p_node and request.num_output_tokens > 0:
+            params["first_token_ids"] = list(request.output_token_ids)
+        return delay_free_blocks, params

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/pull_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/pull_worker.py
@@ -2,20 +2,33 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Pull-specific (READ) worker-side logic for the NIXL connector."""
 
+import pickle
+import threading
 import time
 from typing import TYPE_CHECKING
+
+import zmq
 
 from vllm.distributed.kv_transfer.kv_connector.v1.nixl.base_worker import (
     NixlBaseConnectorWorker,
 )
+from vllm.distributed.kv_transfer.kv_connector.v1.nixl.fast_kv import (
+    fast_dispatch_enabled,
+    fast_kv_dispatch_path,
+    fast_kv_notify_path,
+    fast_notify_enabled,
+)
 from vllm.distributed.kv_transfer.kv_connector.v1.nixl.metadata import (
     NixlConnectorMetadata,
+    ReqId,
     ReqMeta,
+    TransferHandle,
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.nixl.tp_mapping import (
     ReadSpec,
 )
 from vllm.logger import init_logger
+from vllm.platforms import current_platform
 
 if TYPE_CHECKING:
     from vllm.config import VllmConfig
@@ -38,6 +51,34 @@ class NixlPullConnectorWorker(NixlBaseConnectorWorker):
         kv_cache_config: "KVCacheConfig",
     ):
         super().__init__(vllm_config, engine_id, kv_cache_config)
+        # Fast KV side channels (opt-in, see nixl/fast_kv.py).
+        self.fast_dispatch_enabled = fast_dispatch_enabled(vllm_config)
+        self.fast_notify_enabled = fast_notify_enabled(vllm_config)
+        if self.fast_dispatch_enabled or self.fast_notify_enabled:
+            self._fast_zmq_ctx = zmq.Context()
+        if self.fast_notify_enabled:
+            self._fast_poller_t = threading.Thread(
+                target=self._fast_poller_loop,
+                daemon=True,
+                name="nixl-fast-kv-poller",
+            )
+            self._fast_poller_t.start()
+        if self.fast_dispatch_enabled:
+            self._fast_dispatch_t = threading.Thread(
+                target=self._fast_dispatch_loop,
+                daemon=True,
+                name="nixl-fast-kv-dispatch",
+            )
+            self._fast_dispatch_t.start()
+        if self.fast_dispatch_enabled or self.fast_notify_enabled:
+            logger.info(
+                "NIXL fast KV side channels enabled (dispatch=%s notify=%s) "
+                "dispatch_path=%s notify_path=%s",
+                self.fast_dispatch_enabled,
+                self.fast_notify_enabled,
+                fast_kv_dispatch_path(vllm_config),
+                fast_kv_notify_path(vllm_config),
+            )
 
     def start_load_kv(self, metadata: NixlConnectorMetadata):
         """
@@ -45,36 +86,16 @@ class NixlPullConnectorWorker(NixlBaseConnectorWorker):
         We check for these trnxs to complete in each step().
         """
         for req_id, meta in metadata.reqs_to_recv.items():
-            meta.local_physical_block_ids = self._logical_to_kernel_block_ids(
-                meta.local_block_ids, self._physical_blocks_per_logical_kv_block
-            )
-            assert meta.remote is not None
-            # Remote block IDs are kept logical here; expanded in
-            # _read_blocks_for_req using the remote engine's phys ratio.
-            remote_engine_id = meta.remote.engine_id
-            logger.debug(
-                "start_load_kv for request %s from remote engine %s. "
-                "Num local_block_ids: %s. Num remote_block_ids: %s. ",
-                req_id,
-                remote_engine_id,
-                len(meta.local_physical_block_ids),
-                len(meta.remote.block_ids),
-            )
-            # always store metadata for failure recovery
-            self._recving_metadata[req_id] = meta
-            if remote_engine_id not in self._remote_agents:
-                # Initiate handshake with remote engine to exchange metadata.
-                with self._handshake_lock:
-                    if remote_engine_id not in self._remote_agents:
-                        self._background_nixl_handshake(req_id, remote_engine_id, meta)
-                        continue
-
-            # Handshake already completed, start async read xfer.
-            self._read_blocks_for_req(req_id, meta)
+            with self._fast_lock:
+                if self._fast_dispatched.pop(req_id, None) is not None:
+                    # Already initiated by the fast-dispatch listener.
+                    continue
+                self._initiate_recv(req_id, meta)
 
         # Start transfers for requests whose handshakes have now finished.
-        while not self._ready_requests.empty():
-            self._read_blocks_for_req(*self._ready_requests.get_nowait())
+        with self._fast_lock:
+            while not self._ready_requests.empty():
+                self._read_blocks_and_mark(*self._ready_requests.get_nowait())
 
         if self.pcp_rank > 0:
             return
@@ -114,6 +135,213 @@ class NixlPullConnectorWorker(NixlBaseConnectorWorker):
         # Send heartbeats to P-side engines to keep KV blocks alive while
         # requests sit in the D scheduler WAITING queue.
         self._send_heartbeats(metadata)
+
+    def _initiate_recv(self, req_id: ReqId, meta: ReqMeta):
+        """Bookkeep and start (or defer to handshake) one recv request.
+        Callers must hold _fast_lock."""
+        meta.local_physical_block_ids = self._logical_to_kernel_block_ids(
+            meta.local_block_ids, self._physical_blocks_per_logical_kv_block
+        )
+        assert meta.remote is not None
+        # Remote block IDs are kept logical here; expanded in
+        # _read_blocks_for_req using the remote engine's phys ratio.
+        remote_engine_id = meta.remote.engine_id
+        logger.debug(
+            "start_load_kv for request %s from remote engine %s. "
+            "Num local_block_ids: %s. Num remote_block_ids: %s. ",
+            req_id,
+            remote_engine_id,
+            len(meta.local_physical_block_ids),
+            len(meta.remote.block_ids),
+        )
+        # always store metadata for failure recovery
+        self._recving_metadata[req_id] = meta
+        self._recv_initiated[req_id] = time.monotonic()
+        if remote_engine_id not in self._remote_agents:
+            # Initiate handshake with remote engine to exchange metadata.
+            with self._handshake_lock:
+                if remote_engine_id not in self._remote_agents:
+                    self._background_nixl_handshake(req_id, remote_engine_id, meta)
+                    return
+
+        # Handshake already completed, start async read xfer.
+        self._read_blocks_and_mark(req_id, meta)
+
+    def _read_blocks_and_mark(self, req_id: ReqId, meta: ReqMeta):
+        """_read_blocks_for_req + fast-notify eligibility marking.
+        Callers must hold _fast_lock."""
+        self._read_blocks_for_req(req_id, meta)
+        if not self.fast_notify_enabled:
+            return
+        assert meta.remote is not None and self.transfer_topo is not None
+        # Only fast-notify requests whose KV is usable the instant the
+        # transfer finishes (no host-buffer sync, no post-processing).
+        remote_info = self.transfer_topo.get_engine_info(meta.remote.engine_id)
+        block_size_ratio = self.transfer_topo.block_size_ratio(
+            remote_info.remote_block_size
+        )
+        hetero_ppl = (
+            remote_info.remote_physical_blocks_per_logical
+            != self._physical_blocks_per_logical_kv_block
+        )
+        if (
+            self.use_host_buffer
+            or self.enable_permute_local_kv
+            or self.enable_heterogeneous_attn_post_process
+            or block_size_ratio != 1
+            or hetero_ppl
+            or (current_platform.is_rocm() and self._has_mamba)
+        ):
+            return
+        self._fast_eligible.add(req_id)
+
+    def _fast_dispatch_loop(self):
+        """Listener thread: initiate NIXL pulls as soon as the EngineCore
+        publishes new recv metadata."""
+        assert self._fast_zmq_ctx is not None
+        sock = self._fast_zmq_ctx.socket(zmq.SUB)
+        sock.setsockopt(zmq.SUBSCRIBE, b"")
+        sock.setsockopt(zmq.LINGER, 0)
+        sock.connect(fast_kv_dispatch_path(self.vllm_config))
+        poller = zmq.Poller()
+        poller.register(sock, zmq.POLLIN)
+        last_prune = time.monotonic()
+        try:
+            while not self._fast_stop_event.is_set():
+                if not poller.poll(timeout=200):
+                    continue
+                reqs: dict[ReqId, ReqMeta] = pickle.loads(sock.recv())
+                with self._fast_lock:
+                    now = time.monotonic()
+                    if now - last_prune > 60:
+                        last_prune = now
+                        self._recv_initiated = {
+                            r: t
+                            for r, t in self._recv_initiated.items()
+                            if now - t < 600
+                        }
+                    for req_id, meta in reqs.items():
+                        if (
+                            req_id in self._fast_dispatched
+                            or req_id in self._recv_initiated
+                        ):
+                            continue
+                        self._fast_dispatched[req_id] = time.monotonic()
+                        try:
+                            self._initiate_recv(req_id, meta)
+                        except Exception:
+                            logger.exception(
+                                "Fast-dispatch initiation failed for %s; "
+                                "deferring to the regular path.",
+                                req_id,
+                            )
+                            self._fast_dispatched.pop(req_id, None)
+                            self._recv_initiated.pop(req_id, None)
+                            self._recving_metadata.pop(req_id, None)
+                            self._fast_eligible.discard(req_id)
+        except Exception:
+            logger.exception(
+                "NIXL fast-dispatch listener died; falling back to the "
+                "regular per-step dispatch path."
+            )
+        finally:
+            sock.close(linger=0)
+
+    def _fast_poller_loop(self):
+        """Poller thread: detect recv-transfer completion and push
+        (req_id, tp_rank) to the EngineCore bridge."""
+        assert self._fast_zmq_ctx is not None
+        sock = self._fast_zmq_ctx.socket(zmq.PUSH)
+        sock.setsockopt(zmq.LINGER, 0)
+        sock.setsockopt(zmq.SNDHWM, 1000)
+        sock.connect(fast_kv_notify_path(self.vllm_config))
+        last_prune = time.monotonic()
+        try:
+            while not self._fast_stop_event.is_set():
+                done_reqs: list[ReqId] = []
+                with self._fast_lock:
+                    # Start transfers whose handshakes have now finished.
+                    while not self._ready_requests.empty():
+                        self._read_blocks_and_mark(*self._ready_requests.get_nowait())
+                    for req_id in list(self._fast_eligible):
+                        if not self._fast_poll_req(req_id):
+                            continue
+                        self._fast_eligible.discard(req_id)
+                        if req_id in self._fast_failed:
+                            # Failures are reported via the slow path.
+                            self._fast_failed.discard(req_id)
+                            continue
+                        self._fast_done_recving.add(req_id)
+                        done_reqs.append(req_id)
+                    now = time.monotonic()
+                    if now - last_prune > 60:
+                        last_prune = now
+                        self._fast_dispatched = {
+                            r: t
+                            for r, t in self._fast_dispatched.items()
+                            if now - t < 600
+                        }
+                for req_id in done_reqs:
+                    try:
+                        sock.send(pickle.dumps((req_id, self.tp_rank)), zmq.NOBLOCK)
+                    except zmq.Again:
+                        logger.warning(
+                            "Fast KV notify queue full; dropping hint for %s",
+                            req_id,
+                        )
+                time.sleep(0.0005)
+        except Exception:
+            logger.exception(
+                "NIXL fast-notify poller died; completions fall back to the "
+                "regular get_finished path."
+            )
+            with self._fast_lock:
+                self._fast_eligible.clear()
+        finally:
+            sock.close(linger=0)
+
+    def _fast_poll_req(self, req_id: ReqId) -> bool:
+        """Poll one request's recv transfers (called with _fast_lock held);
+        returns True when no transfer is left in progress."""
+        handles = self._recving_transfers.get(req_id)
+        if not handles:
+            # E.g. full local prefix hit: no read was posted at all.
+            self._recving_transfers.pop(req_id, None)
+            return True
+        in_progress: list[TransferHandle] = []
+        for handle in handles:
+            try:
+                xfer_state = self.nixl_wrapper.check_xfer_state(handle)
+                if xfer_state == "DONE":
+                    res = self.nixl_wrapper.get_xfer_telemetry(handle)
+                    self.xfer_stats.record_transfer(res)
+                    self.nixl_wrapper.release_xfer_handle(handle)
+                elif xfer_state == "PROC":
+                    in_progress.append(handle)
+                    continue
+                else:
+                    self._log_failure(
+                        failure_type="transfer_failed",
+                        msg="Marking blocks as invalid",
+                        req_id=req_id,
+                        xfer_state=xfer_state,
+                    )
+                    self._handle_failed_transfer(req_id, handle)
+                    self._fast_failed.add(req_id)
+            except Exception as e:
+                self._log_failure(
+                    failure_type="transfer_exception",
+                    msg="Marking blocks as invalid",
+                    req_id=req_id,
+                    error=e,
+                )
+                self._handle_failed_transfer(req_id, handle)
+                self._fast_failed.add(req_id)
+        if in_progress:
+            self._recving_transfers[req_id] = in_progress
+            return False
+        del self._recving_transfers[req_id]
+        return True
 
     def _is_turn2_read_expired(self, meta: ReqMeta) -> bool:
         """Whether D's cached blocks for this turn-2 readback have (nearly) expired."""

--- a/vllm/entrypoints/serve/__init__.py
+++ b/vllm/entrypoints/serve/__init__.py
@@ -39,6 +39,12 @@ def register_vllm_serve_api_routers(app: FastAPI):
 
     attach_tokenize_router(app)
 
+    from vllm.entrypoints.serve.pd_disagg.api_router import (
+        attach_router as attach_pd_disagg_router,
+    )
+
+    attach_pd_disagg_router(app)
+
 
 def register_vllm_dev_api_routers(app: FastAPI):
     logger.warning(

--- a/vllm/entrypoints/serve/pd_disagg/__init__.py
+++ b/vllm/entrypoints/serve/pd_disagg/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project

--- a/vllm/entrypoints/serve/pd_disagg/api_router.py
+++ b/vllm/entrypoints/serve/pd_disagg/api_router.py
@@ -1,0 +1,100 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""P/D concurrent dispatch: KV-ready notification endpoint.
+
+The disaggregation router posts the prefill's kv_transfer_params to
+``POST /v1/pd_kv_ready`` as soon as the prefill responds, resuming the
+decode-side prepare request parked/armed in the scheduler.
+"""
+
+import pickle
+from http import HTTPStatus
+from typing import Any
+
+from fastapi import APIRouter, FastAPI, Request
+from fastapi.responses import JSONResponse
+
+from vllm.engine.protocol import EngineClient
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+router = APIRouter()
+
+
+def engine_client(request: Request) -> EngineClient:
+    return request.app.state.engine_client
+
+
+def _pd_ready_fast_push(
+    raw_request: Request, raw_request_id: str, kv_transfer_params: dict[str, Any]
+) -> bool:
+    """Early-arm fast path: push the KV-ready notification straight to the
+    EngineCore fast-KV bridge over the notify ipc socket. Fire-and-forget
+    (losses covered by the armed-timeout fallback); False if unavailable."""
+    vllm_config = getattr(raw_request.app.state, "vllm_config", None)
+    if vllm_config is None:
+        return False
+    try:
+        from vllm.distributed.kv_transfer.kv_connector.v1.nixl.fast_kv import (
+            fast_kv_notify_path,
+            fast_notify_enabled,
+        )
+
+        ktc = vllm_config.kv_transfer_config
+        if (
+            ktc is None
+            or ktc.kv_connector not in ("NixlConnector", "NixlPullConnector")
+            or not fast_notify_enabled(vllm_config)
+            or not ktc.get_from_extra_config("pd_early_arm", False)
+        ):
+            return False
+        app_state = raw_request.app.state
+        sock = getattr(app_state, "pd_kv_ready_sock", None)
+        if sock is None:
+            import zmq
+
+            sock = zmq.Context.instance().socket(zmq.PUSH)
+            sock.setsockopt(zmq.LINGER, 0)
+            sock.connect(fast_kv_notify_path(vllm_config))
+            app_state.pd_kv_ready_sock = sock
+        import zmq
+
+        sock.send(
+            pickle.dumps(("pd_ready", raw_request_id, kv_transfer_params)),
+            zmq.NOBLOCK,
+        )
+        return True
+    except Exception:
+        logger.exception("pd_kv_ready fast push failed")
+        return False
+
+
+@router.post("/v1/pd_kv_ready")
+async def pd_kv_ready(raw_request: Request):
+    """Body: {"request_id": <router request id>,
+    "kv_transfer_params": {...}}."""
+    body = await raw_request.json()
+    raw_request_id = body.get("request_id")
+    kv_transfer_params = body.get("kv_transfer_params")
+    if not raw_request_id or not isinstance(kv_transfer_params, dict):
+        return JSONResponse(
+            content={"error": "request_id and kv_transfer_params are required"},
+            status_code=HTTPStatus.BAD_REQUEST.value,
+        )
+    if _pd_ready_fast_push(raw_request, raw_request_id, kv_transfer_params):
+        return JSONResponse(content={"queued": True})
+    client = engine_client(raw_request)
+    engine_core = getattr(client, "engine_core", None)
+    call_utility = getattr(engine_core, "call_utility_async", None)
+    if call_utility is None:
+        return JSONResponse(
+            content={"error": "engine does not support pd_kv_ready"},
+            status_code=HTTPStatus.NOT_IMPLEMENTED.value,
+        )
+    matched = await call_utility("update_pd_kv_ready", raw_request_id, kv_transfer_params)
+    return JSONResponse(content={"matched": bool(matched)})
+
+
+def attach_router(app: FastAPI):
+    app.include_router(router)

--- a/vllm/v1/core/sched/output.py
+++ b/vllm/v1/core/sched/output.py
@@ -48,6 +48,9 @@ class NewRequestData:
     # Only used for v2 model runner.
     prefill_token_ids: list[int] | None = None
 
+    # Tokens already sampled elsewhere (P/D first-token seeding).
+    output_token_ids: list[int] | None = None
+
     @classmethod
     def from_request(
         cls,
@@ -74,6 +77,9 @@ class NewRequestData:
             prompt_embeds=request.prompt_embeds,
             prompt_is_token_ids=request.prompt_is_token_ids,
             prefill_token_ids=prefill_token_ids,
+            output_token_ids=(
+                list(request.output_token_ids) if request.output_token_ids else None
+            ),
         )
 
     @property

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -222,6 +222,17 @@ class Scheduler(SchedulerInterface):
             and kv_transfer_config.get_from_extra_config("seed_first_token", False)
         )
 
+        # P/D concurrent dispatch: KV-ready notifications that arrived
+        # before their prepare request reached the scheduler.
+        self._pd_pending_ready: dict[str, tuple[dict[str, Any], float]] = {}
+        # Max time an armed prepare request may wait for the KV-ready
+        # notification before falling back to a local prefill.
+        self._pd_prepare_ready_timeout_s = float(
+            kv_transfer_config.get_from_extra_config("prepare_ready_timeout_s", 10.0)
+            if kv_transfer_config is not None
+            else 10.0
+        )
+
         # Grammar compilation failures to finish as per-request errors in
         # update_from_output.
         self.grammar_compile_error_reqs: set[str] = set()
@@ -2369,6 +2380,14 @@ class Scheduler(SchedulerInterface):
         else:
             if request.resumable:
                 request.streaming_queue = deque()
+            # P/D: merge a KV-ready notification that raced ahead of this
+            # prepare request.
+            if self._pd_pending_ready and self._pd_request_awaiting_ready(request):
+                for raw_id in list(self._pd_pending_ready):
+                    if raw_id in request.request_id:
+                        params, _ = self._pd_pending_ready.pop(raw_id)
+                        self._pd_merge_kv_ready(request, params)
+                        break
             self._enqueue_waiting_request(request)
             self.requests[request.request_id] = request
             if self.spec_decode_metrics_level != "none":
@@ -2379,6 +2398,99 @@ class Scheduler(SchedulerInterface):
                 self.connector.on_new_request(request)
             if self.log_stats:
                 request.record_event(EngineCoreEventType.QUEUED)
+
+    @staticmethod
+    def _pd_request_awaiting_ready(request: Request) -> bool:
+        """True for a decode prepare request whose remote-KV metadata has
+        not been merged yet."""
+        params = request.kv_transfer_params
+        return bool(
+            params is not None
+            and params.get("do_remote_prefill")
+            and not params.get("remote_block_ids")
+            and params.get("remote_ready") is False
+        )
+
+    @staticmethod
+    def _pd_merge_kv_ready(
+        request: Request, kv_transfer_params: dict[str, Any]
+    ) -> None:
+        assert request.kv_transfer_params is not None
+        request.kv_transfer_params.update(kv_transfer_params)
+        request.kv_transfer_params["remote_ready"] = True
+        request.kv_transfer_params["do_remote_prefill"] = True
+
+    def update_pd_kv_ready(
+        self, raw_request_id: str, kv_transfer_params: dict[str, Any]
+    ) -> bool:
+        """P/D concurrent dispatch: deliver the prefill-side
+        kv_transfer_params to the parked decode prepare request.
+
+        Runs in the engine busy loop between steps (utility RPC), so no
+        locking against schedule() is needed. Internal request ids embed the
+        router-side raw id, hence the substring match. With early-arm the
+        connector owns the armed state, so delegate to it.
+        """
+        connector_scheduler = getattr(self.connector, "connector_scheduler", None)
+        if connector_scheduler is not None and getattr(
+            connector_scheduler, "pd_early_arm_enabled", False
+        ):
+            result = connector_scheduler.on_pd_kv_ready(
+                raw_request_id, kv_transfer_params
+            )
+            return result is not None
+        matched = False
+        for req_id, request in self.requests.items():
+            if raw_request_id not in req_id:
+                continue
+            if not self._pd_request_awaiting_ready(request):
+                logger.warning(
+                    "PD KV-ready notification for %s ignored: request is not "
+                    "awaiting remote KV metadata (params=%s).",
+                    req_id,
+                    request.kv_transfer_params,
+                )
+                continue
+            self._pd_merge_kv_ready(request, kv_transfer_params)
+            matched = True
+        if not matched:
+            # Prepare request not in the scheduler yet: stash and prune.
+            now = time.monotonic()
+            self._pd_pending_ready[raw_request_id] = (kv_transfer_params, now)
+            for raw_id, (_, ts) in list(self._pd_pending_ready.items()):
+                if now - ts > 60.0:
+                    del self._pd_pending_ready[raw_id]
+        return matched
+
+    def _pd_check_armed_timeout(self, request: Request) -> bool:
+        """P/D early-arm: on KV-ready timeout, inject a synthetic failed
+        recv so the standard failure path frees the blocks and recomputes
+        locally. Returns True when the timeout was injected."""
+        params = request.kv_transfer_params
+        armed_ts = params.get("_pd_armed_ts") if params else None
+        if armed_ts is None:
+            return False
+        elapsed = time.monotonic() - armed_ts
+        if elapsed <= self._pd_prepare_ready_timeout_s:
+            return False
+        connector_scheduler = getattr(self.connector, "connector_scheduler", None)
+        cancel = getattr(connector_scheduler, "pd_cancel_armed", None)
+        if cancel is None or not cancel(request.request_id):
+            # on_pd_kv_ready claimed the entry; the pull is going ahead.
+            return False
+        logger.warning(
+            "PD armed request %s waited %.1fs for the KV-ready notification; "
+            "falling back to local prefill.",
+            request.request_id,
+            elapsed,
+        )
+        assert params is not None
+        params.pop("_pd_armed_ts", None)
+        # No KV was received: nothing valid to cache, free and recompute.
+        request.num_computed_tokens = 0
+        self.failed_recving_kv_req_ids.add(request.request_id)
+        self.finished_recving_kv_req_ids.add(request.request_id)
+        return True
 
     def finish_requests(
         self, request_ids: str | Iterable[str] | None, finished_status: RequestStatus
@@ -2831,7 +2943,10 @@ class Scheduler(SchedulerInterface):
             # update_from_output(), based on worker-side connector signals
             # in KVConnectorOutput.finished_recving
             if request.request_id not in self.finished_recving_kv_req_ids:
-                return False
+                if not self._pd_check_armed_timeout(request):
+                    return False
+                # Armed timeout injected: fall through to free the blocks
+                # and recompute locally.
             self._update_waiting_for_remote_kv(request)
             if request.num_preemptions:
                 request.status = RequestStatus.PREEMPTED

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -216,6 +216,12 @@ class Scheduler(SchedulerInterface):
         self.finished_recving_kv_req_ids: set[str] = set()
         self.failed_recving_kv_req_ids: set[str] = set()
 
+        kv_transfer_config = vllm_config.kv_transfer_config
+        self.seed_first_token_enabled = bool(
+            kv_transfer_config is not None
+            and kv_transfer_config.get_from_extra_config("seed_first_token", False)
+        )
+
         # Grammar compilation failures to finish as per-request errors in
         # update_from_output.
         self.grammar_compile_error_reqs: set[str] = set()
@@ -2105,7 +2111,7 @@ class Scheduler(SchedulerInterface):
 
         # KV Connector: update state for finished KV Transfers.
         if kv_connector_output:
-            self._update_from_kv_xfer_finished(kv_connector_output)
+            self._update_from_kv_xfer_finished(kv_connector_output, outputs)
 
         # EC Connector: update state from worker-side EC connector output.
         if self.ec_connector is not None and ec_connector_output:
@@ -2852,7 +2858,11 @@ class Scheduler(SchedulerInterface):
             f"{request.status.name} for request {request.request_id}"
         )
 
-    def _update_from_kv_xfer_finished(self, kv_connector_output: KVConnectorOutput):
+    def _update_from_kv_xfer_finished(
+        self,
+        kv_connector_output: KVConnectorOutput,
+        outputs: dict[int, list[EngineCoreOutput]] | None = None,
+    ):
         """
         KV Connector: update the scheduler state based on the output.
 
@@ -2872,7 +2882,12 @@ class Scheduler(SchedulerInterface):
             assert req_id in self.requests
             req = self.requests[req_id]
             if req.status == RequestStatus.WAITING_FOR_REMOTE_KVS:
+                already_reported = req_id in self.finished_recving_kv_req_ids
                 self.finished_recving_kv_req_ids.add(req_id)
+                if outputs is not None and not already_reported:
+                    seeded_output = self._try_seed_first_token(req_id)
+                    if seeded_output is not None:
+                        outputs[req.client_index].append(seeded_output)
             else:
                 assert RequestStatus.is_finished(req.status)
                 self._free_blocks(self.requests[req_id])
@@ -2880,6 +2895,52 @@ class Scheduler(SchedulerInterface):
             logger.debug("Finished sending KV transfer for request %s", req_id)
             assert req_id in self.requests
             self._free_blocks(self.requests[req_id])
+
+    def _try_seed_first_token(self, req_id: str) -> EngineCoreOutput | None:
+        """Emit the first token sampled on the prefill instance
+        (kv_transfer_params["first_token_ids"]), or return None to fall
+        back to the recompute path."""
+        if not self.seed_first_token_enabled:
+            return None
+        request = self.requests.get(req_id)
+        if request is None or request.status != RequestStatus.WAITING_FOR_REMOTE_KVS:
+            return None
+        if req_id in self.failed_recving_kv_req_ids:
+            return None
+        params = request.kv_transfer_params
+        first_token_ids = params.get("first_token_ids") if params else None
+        if not first_token_ids or len(first_token_ids) != 1:
+            return None
+        sampling_params = request.sampling_params
+        if (
+            sampling_params is None
+            or request.pooling_params is not None
+            or sampling_params.logprobs is not None
+            or sampling_params.prompt_logprobs is not None
+            or request.use_structured_output
+            or self.num_spec_tokens > 0
+            or request.num_output_tokens > 0
+            or request.num_preemptions > 0
+        ):
+            return None
+        token_id = first_token_ids[0]
+        # A seeded token that would immediately finish the request must go
+        # through the normal stop machinery instead.
+        if request.max_tokens <= 1 or request.num_tokens + 1 >= self.max_model_len:
+            return None
+        if 1 >= sampling_params.min_tokens:
+            if token_id == sampling_params.eos_token_id:
+                return None
+            if token_id in (sampling_params.stop_token_ids or ()):
+                return None
+
+        request.append_output_token_ids(token_id)
+        return EngineCoreOutput(
+            request_id=req_id,
+            new_token_ids=[token_id],
+            events=request.take_events(),
+            trace_headers=request.trace_headers,
+        )
 
     def _update_requests_with_invalid_blocks(
         self,

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -2879,8 +2879,10 @@ class Scheduler(SchedulerInterface):
         # KV Connector:: update recv and send status from last step.
         for req_id in kv_connector_output.finished_recving or ():
             logger.debug("Finished recving KV transfer for request %s", req_id)
-            assert req_id in self.requests
-            req = self.requests[req_id]
+            req = self.requests.get(req_id)
+            if req is None:
+                # Late report (fast-notify already resumed and freed it).
+                continue
             if req.status == RequestStatus.WAITING_FOR_REMOTE_KVS:
                 already_reported = req_id in self.finished_recving_kv_req_ids
                 self.finished_recving_kv_req_ids.add(req_id)
@@ -2888,9 +2890,11 @@ class Scheduler(SchedulerInterface):
                     seeded_output = self._try_seed_first_token(req_id)
                     if seeded_output is not None:
                         outputs[req.client_index].append(seeded_output)
+            elif RequestStatus.is_finished(req.status):
+                self._free_blocks(req)
             else:
-                assert RequestStatus.is_finished(req.status)
-                self._free_blocks(self.requests[req_id])
+                # Duplicate of a fast-notify completion; already promoted.
+                continue
         for req_id in kv_connector_output.finished_sending or ():
             logger.debug("Finished sending KV transfer for request %s", req_id)
             assert req_id in self.requests
@@ -2941,6 +2945,26 @@ class Scheduler(SchedulerInterface):
             events=request.take_events(),
             trace_headers=request.trace_headers,
         )
+
+    def on_fast_kv_recv_finished(
+        self, req_id: str
+    ) -> tuple[int, EngineCoreOutput] | None:
+        """P/D fast KV notify (see nixl/fast_kv.py). Called from the
+        fast-notify bridge thread, so only GIL-atomic mutations are allowed;
+        the set add happens AFTER seeding so schedule() only consumes a
+        fully seeded request. Returns (client_index, EngineCoreOutput) when
+        token #1 was seeded and must be emitted by the caller, else None.
+        """
+        request = self.requests.get(req_id)
+        if request is None or request.status != RequestStatus.WAITING_FOR_REMOTE_KVS:
+            return None
+        if req_id in self.finished_recving_kv_req_ids:
+            return None
+        seeded_output = self._try_seed_first_token(req_id)
+        self.finished_recving_kv_req_ids.add(req_id)
+        if seeded_output is None:
+            return None
+        return request.client_index, seeded_output
 
     def _update_requests_with_invalid_blocks(
         self,

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -506,6 +506,15 @@ class EngineCore:
         # (i.e. client-aborted vs stop criteria met).
         self.scheduler.finish_requests(request_ids, RequestStatus.FINISHED_ABORTED)
 
+    def update_pd_kv_ready(
+        self, raw_request_id: str, kv_transfer_params: dict[str, Any]
+    ) -> bool:
+        """P/D concurrent dispatch: utility RPC behind /v1/pd_kv_ready."""
+        update = getattr(self.scheduler, "update_pd_kv_ready", None)
+        if update is None:
+            return False
+        return update(raw_request_id, kv_transfer_params)
+
     @contextmanager
     def log_error_detail(self, scheduler_output: SchedulerOutput):
         """Execute the model and log detailed info on failure."""

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -237,6 +237,9 @@ class EngineCore:
         )
         self.async_scheduling = vllm_config.scheduler_config.async_scheduling
 
+        # Fast KV side channels (see nixl/fast_kv.py); set by EngineCoreProc.
+        self.fast_kv_bridge = None
+
         self.aborts_queue = queue.Queue[list[str]]()
 
         self._idle_state_callbacks: list[Callable] = []
@@ -606,6 +609,8 @@ class EngineCore:
         if not self.scheduler.has_requests():
             return {}, False
         scheduler_output = self.scheduler.schedule(self._should_throttle_prefills())
+        if self.fast_kv_bridge is not None:
+            self.fast_kv_bridge.dispatch(scheduler_output)
         future = self.model_executor.execute_model(scheduler_output, non_block=True)
         grammar_output = self.scheduler.get_grammar_bitmask(scheduler_output)
         with (
@@ -664,6 +669,8 @@ class EngineCore:
         deferred_scheduler_output = None
         if self.scheduler.has_requests():
             scheduler_output = self.scheduler.schedule(self._should_throttle_prefills())
+            if self.fast_kv_bridge is not None:
+                self.fast_kv_bridge.dispatch(scheduler_output)
             with self.log_error_detail(scheduler_output):
                 exec_future = self.model_executor.execute_model(
                     scheduler_output, non_block=True
@@ -763,6 +770,9 @@ class EngineCore:
 
     def shutdown(self):
         logger.debug_once("[shutdown] EngineCore: tearing down local resources")
+        if self.fast_kv_bridge is not None:
+            self.fast_kv_bridge.shutdown()
+            self.fast_kv_bridge = None
         self.structured_output_manager.clear_backend()
         if self.model_executor:
             self.model_executor.shutdown()
@@ -1101,6 +1111,21 @@ class EngineCoreProc(EngineCore):
                     engine=self,
                     parallel_config=vllm_config.parallel_config,
                 )
+
+            try:
+                from vllm.distributed.kv_transfer.kv_connector.v1.nixl.fast_kv import (  # noqa: E501
+                    maybe_create_fast_kv_bridge,
+                )
+
+                self.fast_kv_bridge = maybe_create_fast_kv_bridge(
+                    vllm_config, self.scheduler, self.output_queue
+                )
+            except Exception:
+                logger.exception(
+                    "Failed to initialize the fast KV bridge; falling back "
+                    "to per-step KV transfer dispatch/notification."
+                )
+                self.fast_kv_bridge = None
 
             # Background Threads and Queues for IO. These enable us to
             # overlap ZMQ socket IO with GPU since they release the GIL,

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1354,7 +1354,7 @@ class GPUModelRunner(
                 generator=generator,
                 block_ids=new_req_data.block_ids,
                 num_computed_tokens=new_req_data.num_computed_tokens,
-                output_token_ids=[],
+                output_token_ids=list(new_req_data.output_token_ids or []),
                 lora_request=new_req_data.lora_request,
             )
             self.requests[req_id] = req_state


### PR DESCRIPTION
### Purpose

In P/D disaggregation with NixlConnector, the decode-side handover (prefill
emits token#1 → client receives token#1) costs ~197ms p50 on our 3P1D setup,
while the actual KV transfer is only ~29ms. The rest is orchestration:
recomputing a token the prefill already sampled, waiting for engine-step
boundaries, and serial router dispatch. This PR removes those overheads with
three independent, individually flag-gated features plus a docs addition
(one commit each) (RFC at https://github.com/vllm-project/vllm/issues/50913):

1. **First-token seeding** (`seed_first_token`): the prefill already samples
   token#1 (`max_tokens=1`); ship it in `kv_transfer_params["first_token_ids"]`
   and let the decode scheduler emit it the moment the KV load completes,
   instead of recomputing it with a full forward (~58ms p50 incl. step
   alignment). Falls back to the recompute path for logprobs, structured
   output, spec decode, preempted/resumed requests, KV-load failures, or a
   seeded token that would immediately finish the request.

2. **Fast KV side channels** (`fast_kv_dispatch` / `fast_kv_notify`): two
   optional ZMQ IPC channels between the decode EngineCore and its TP workers.
   Dispatch publishes new pull metadata right after `schedule()` so workers
   start the NIXL read immediately (instead of with the next `execute_model`,
   ~28ms away); notify reports pull completion within ~0.5ms (instead of at
   the end of the in-flight step, ~28ms). Both are hints only: the per-step
   `SchedulerOutput`/`ModelRunnerOutput` paths remain the source of truth and
   dedup against them, so a lost message degrades to today's latency.

3. **Concurrent P/D dispatch support** (`prepare_ready_timeout_s`,
   `pd_early_arm`): a cooperating router may send the decode request while the
   prefill is still running (`{"do_remote_prefill": true, "remote_ready":
   false}`); the scheduler parks it, and a new `POST /v1/pd_kv_ready` endpoint
   delivers the prefill's `kv_transfer_params` when it responds. This overlaps
   decode-side HTTP parsing/tokenization/scheduling (~32ms p50) with the
   prefill. Optional early-arm allocates blocks up front so the ready
   notification starts the pull directly from the fast-KV bridge thread
   (trade-off: blocks pinned during prefill). Lost notifications hit
   `prepare_ready_timeout_s` (default 10s) and fall back to a full local
   prefill.

4. **Docs**: a "Performance tuning" section in `nixl_connector_usage.md` on
   `--block-size` (default 16 fragments a ~5k-token pull into tens of
   thousands of ~8KB NIXL descriptors; 64 cut our handover from ~263ms to
   ~197ms with no code change).

All flags live in `kv_connector_extra_config` and default off; with them off
(and no cooperating router) no socket or thread is created and behavior is
unchanged. The companion router PR (vllm-project/router) implements the
concurrent-dispatch side; features 1–2 work without it.

### Feature switches (for testing)

| Feature | Switch | Where | Default |
|---|---|---|---|
| 1. First-token seeding | `seed_first_token` | P **and** D | `false` |
| 2. Fast dispatch | `fast_kv_dispatch` | D | `false` |
| 2. Fast notify | `fast_kv_notify` | D | `false` |
| 3. Concurrent dispatch | `VLLM_PD_CONCURRENT_DISPATCH=1` (router env, companion PR) | router | off |
| 3. Early-arm | `pd_early_arm` | D | `false` |
| 3. Park/arm timeout | `prepare_ready_timeout_s` | D | `10.0` |
| 4. Block size | `--block-size 64` | P and D | `16` |

All boolean switches go in `kv_connector_extra_config`. Everything-on decode
side example:

```bash
--block-size 64 \
--kv-transfer-config '{"kv_connector": "NixlConnector", "kv_role": "kv_both",
  "kv_connector_extra_config": {"seed_first_token": true,
    "fast_kv_dispatch": true, "fast_kv_notify": true,
    "pd_early_arm": true, "prepare_ready_timeout_s": 10.0}}'
```

Prefill side only needs `--block-size 64` and `"seed_first_token": true`.

### Test Plan

- 3P1D single-node deployment (NixlConnector, TP2), features enabled
  incrementally and in flag-off A/B runs.
- Greedy correctness: temperature=0 responses byte-identical with seeding on
  vs. off; fallback coverage (logprobs, structured output, `max_tokens=1`).
- Load test: 1000 requests, ~4.9k-token prompts; TTFT/TPOT + handover trace.
- Fault injection: killed decode worker (fast-path dedup/fallback), dropped
  ready POST (park timeout → local prefill), aborts while parked/armed.

Hi maintainers @NickLucche @ApostaC @orozery @xuechendi @ivanium -- Could you shed some light on the relevant NIXL regression tests? I'll make sure to cover those items in the additional tests.

### Test Result

- Handover p50: 197ms → 63ms (seeding + side channels) → 52ms (concurrent
  dispatch, late-alloc) → 36ms (early-arm); remaining ~36ms is ~29ms NIXL
  transfer + ~5-7ms fixed hops.
- Vs. stock NIXL 3P1D at default settings: mean/median TTFT −23%, P99 TTFT
  −10%, request throughput +7%, TPOT unchanged (30.2ms).
- Greedy 1st token outputs identical with/without seeding.

Cc @WoosukKwon @robertgshaw2-redhat @njhill @ywang96 @alexm-redhat @heheda12345 @ApostaC @orozery @ivanium @DwyaneShi @Jeffwan 