### PR TITLE
[Refactor] Use common sp utils for Qwen3.5 MoE

### DIFF
--- a/vllm/distributed/device_communicators/custom_all_reduce.py
+++ b/vllm/distributed/device_communicators/custom_all_reduce.py
@@ -402,7 +402,7 @@ class CustomAllreduce:
             return False
         if self.world_size == 16 and not self.mnnvl_only:
             return False
-        inp_size = inp.nbytes
+        inp_size = inp.numel() * inp.element_size()
         if inp.dtype not in (
             torch.float32,
             torch.float16,
@@ -456,7 +456,7 @@ class CustomAllreduce:
             return False
         if self.world_size == 16 and not self.mnnvl_only:
             return False
-        inp_size = inp.nbytes
+        inp_size = inp.numel() * inp.element_size()
         if inp.dtype not in (torch.float32, torch.float16, torch.bfloat16):
             return False
         if inp.shape[0] % self.world_size != 0:

--- a/vllm/model_executor/models/qwen3_5.py
+++ b/vllm/model_executor/models/qwen3_5.py
@@ -134,19 +134,18 @@ class Qwen3_5DecoderLayer(Qwen3NextDecoderLayer):
         self.layer_type = layer_type
         self.layer_idx = extract_layer_index(prefix)
         is_moe_layer = config.model_type == "qwen3_5_moe_text"
-        self.use_attn_reduce_scatter_for_moe = (
+        self.use_sequence_parallel = (
             parallel_config.use_sequence_parallel_moe
             and parallel_config.pipeline_parallel_size == 1
             and is_moe_layer
         )
-
         if self.layer_type == "linear_attention":
             self.linear_attn = QwenGatedDeltaNetAttention(
                 config=config,
                 vllm_config=vllm_config,
                 prefix=f"{prefix}.linear_attn",
                 gqa_interleaved_layout=False,
-                reduce_results=not self.use_attn_reduce_scatter_for_moe,
+                reduce_results=not self.use_sequence_parallel,
             )
         elif self.layer_type == "full_attention":
             self.self_attn = Qwen3NextAttention(
@@ -155,7 +154,7 @@ class Qwen3_5DecoderLayer(Qwen3NextDecoderLayer):
                 cache_config=cache_config,
                 quant_config=quant_config,
                 prefix=f"{prefix}.self_attn",
-                reduce_results=not self.use_attn_reduce_scatter_for_moe,
+                reduce_results=not self.use_sequence_parallel,
             )
         else:
             raise ValueError(f"Invalid layer_type {self.layer_type}")

--- a/vllm/model_executor/models/qwen3_5.py
+++ b/vllm/model_executor/models/qwen3_5.py
@@ -133,11 +133,11 @@ class Qwen3_5DecoderLayer(Qwen3NextDecoderLayer):
 
         self.layer_type = layer_type
         self.layer_idx = extract_layer_index(prefix)
-        is_moe_layer = config.model_type == "qwen3_5_moe_text"
+        self.is_moe_layer = config.model_type == "qwen3_5_moe_text"
         self.use_sequence_parallel = (
             parallel_config.use_sequence_parallel_moe
             and parallel_config.pipeline_parallel_size == 1
-            and is_moe_layer
+            and self.is_moe_layer
         )
         if self.layer_type == "linear_attention":
             self.linear_attn = QwenGatedDeltaNetAttention(
@@ -172,6 +172,7 @@ class Qwen3_5DecoderLayer(Qwen3NextDecoderLayer):
                 intermediate_size=config.intermediate_size,
                 hidden_act=config.hidden_act,
                 quant_config=quant_config,
+                is_sequence_parallel=self.use_sequence_parallel,
                 prefix=f"{prefix}.mlp",
             )
         else:

--- a/vllm/model_executor/models/qwen3_5_mtp.py
+++ b/vllm/model_executor/models/qwen3_5_mtp.py
@@ -28,7 +28,7 @@ from vllm.model_executor.models.qwen3_next import (
     QwenNextMixtureOfExperts,
     _is_shared_expert_fse_compatible,
 )
-from vllm.models.common.ops.sequence_parallel import sp_all_gather
+from vllm.models.common.ops.sequence_parallel import sp_all_gather, sp_shard
 from vllm.sequence import IntermediateTensors
 from vllm.transformers_utils.configs.qwen3_5 import Qwen3_5TextConfig
 from vllm.transformers_utils.configs.qwen3_5_moe import Qwen3_5MoeTextConfig
@@ -161,6 +161,8 @@ class Qwen3_5MultiTokenPredictor(nn.Module):
 
         current_step_idx = spec_step_idx % self.num_mtp_layers
         mtp_layer = self.layers[current_step_idx]
+        if mtp_layer.use_sequence_parallel:
+            hidden_states = sp_shard(hidden_states)
         hidden_states, residual = mtp_layer(
             positions=positions,
             hidden_states=hidden_states,

--- a/vllm/model_executor/models/qwen3_5_mtp.py
+++ b/vllm/model_executor/models/qwen3_5_mtp.py
@@ -26,9 +26,9 @@ from vllm.model_executor.models.qwen3_5 import (
 )
 from vllm.model_executor.models.qwen3_next import (
     QwenNextMixtureOfExperts,
-    _all_gather_hidden_and_residual,
     _is_shared_expert_fse_compatible,
 )
+from vllm.models.common.ops.sequence_parallel import sp_all_gather
 from vllm.sequence import IntermediateTensors
 from vllm.transformers_utils.configs.qwen3_5 import Qwen3_5TextConfig
 from vllm.transformers_utils.configs.qwen3_5_moe import Qwen3_5MoeTextConfig
@@ -172,15 +172,9 @@ class Qwen3_5MultiTokenPredictor(nn.Module):
                 {"hidden_states": hidden_states, "residual": residual}
             )
 
-        if mtp_layer.use_attn_reduce_scatter_for_moe:
-            hidden_states, residual = _all_gather_hidden_and_residual(
-                hidden_states,
-                residual,
-                positions.shape[-1],
-                self.config.hidden_size,
-            )
-
         hidden_states, _ = self.norm(hidden_states, residual)
+        if mtp_layer.use_sequence_parallel:
+            hidden_states = sp_all_gather(hidden_states)[: positions.shape[-1]]
         return hidden_states
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:

--- a/vllm/model_executor/models/qwen3_next.py
+++ b/vllm/model_executor/models/qwen3_next.py
@@ -8,6 +8,7 @@ from itertools import islice
 import torch
 from torch import nn
 
+import vllm.envs as envs
 from vllm._aiter_ops import rocm_aiter_ops
 from vllm.compilation.decorators import support_torch_compile
 from vllm.config import CacheConfig, ModelConfig, VllmConfig
@@ -15,9 +16,8 @@ from vllm.distributed import (
     get_ep_group,
     get_pp_group,
     get_tensor_model_parallel_world_size,
-    tensor_model_parallel_all_gather,
-    tensor_model_parallel_reduce_scatter,
 )
+from vllm.forward_context import get_forward_context, is_forward_context_available
 from vllm.logger import init_logger
 from vllm.model_executor.layers.attention import Attention
 from vllm.model_executor.layers.fused_moe import FusedMoEFactory
@@ -47,7 +47,12 @@ from vllm.model_executor.layers.vocab_parallel_embedding import (
     VocabParallelEmbedding,
 )
 from vllm.model_executor.models.qwen2_moe import Qwen2MoeMLP as Qwen3NextMLP
-from vllm.model_executor.models.utils import sequence_parallel_chunk
+from vllm.models.common.ops.sequence_parallel import (
+    sp_all_gather,
+    sp_padding_mask,
+    sp_reduce_scatter,
+    sp_shard,
+)
 from vllm.platforms import current_platform
 from vllm.sequence import IntermediateTensors
 from vllm.transformers_utils.configs.qwen3_next import Qwen3NextConfig
@@ -203,7 +208,7 @@ class Qwen3NextSparseMoeBlock(nn.Module):
         hidden_states = hidden_states.view(-1, hidden_dim)
 
         if self.is_sequence_parallel and not already_sequence_parallel:
-            hidden_states = sequence_parallel_chunk(hidden_states)
+            hidden_states = sp_shard(hidden_states)
 
         if self.experts.is_internal_router:
             # In this case, the gate/router runs inside the MoERunner class
@@ -218,9 +223,7 @@ class Qwen3NextSparseMoeBlock(nn.Module):
             )
 
         if self.is_sequence_parallel and not already_sequence_parallel:
-            final_hidden_states = tensor_model_parallel_all_gather(
-                final_hidden_states, 0
-            )
+            final_hidden_states = sp_all_gather(final_hidden_states)
             final_hidden_states = final_hidden_states[:num_tokens]
 
         return final_hidden_states.view(orig_shape)
@@ -423,7 +426,7 @@ class Qwen3NextDecoderLayer(nn.Module):
             config.num_experts > 0
             and (self.layer_idx + 1) % config.decoder_sparse_step == 0
         )
-        self.use_attn_reduce_scatter_for_moe = (
+        self.use_sequence_parallel = (
             parallel_config.use_sequence_parallel_moe
             and parallel_config.pipeline_parallel_size == 1
             and is_moe_layer
@@ -435,7 +438,7 @@ class Qwen3NextDecoderLayer(nn.Module):
                 vllm_config=vllm_config,
                 prefix=f"{prefix}.linear_attn",
                 gqa_interleaved_layout=True,
-                reduce_results=not self.use_attn_reduce_scatter_for_moe,
+                reduce_results=not self.use_sequence_parallel,
             )
         elif self.layer_type == "full_attention":
             self.self_attn = Qwen3NextAttention(
@@ -443,7 +446,7 @@ class Qwen3NextDecoderLayer(nn.Module):
                 model_config=model_config,
                 cache_config=cache_config,
                 quant_config=quant_config,
-                reduce_results=not self.use_attn_reduce_scatter_for_moe,
+                reduce_results=not self.use_sequence_parallel,
                 prefix=f"{prefix}.self_attn",
             )
         else:
@@ -492,14 +495,14 @@ class Qwen3NextDecoderLayer(nn.Module):
         hidden_states: torch.Tensor,
         residual: torch.Tensor | None,
         positions: torch.Tensor = None,
+        input_is_sequence_parallel: bool | None = None,
         **kwargs: object,
     ):
         full_num_tokens = positions.shape[-1]
-        input_is_sequence_parallel = (
-            self.use_attn_reduce_scatter_for_moe
-            and residual is not None
-            and hidden_states.shape[0] != full_num_tokens
-        )
+        if input_is_sequence_parallel is None:
+            input_is_sequence_parallel = (
+                self.use_sequence_parallel and residual is not None
+            )
 
         if residual is None:
             residual = hidden_states
@@ -508,7 +511,7 @@ class Qwen3NextDecoderLayer(nn.Module):
             hidden_states, residual = self.input_layernorm(hidden_states, residual)
 
         if input_is_sequence_parallel:
-            hidden_states = tensor_model_parallel_all_gather(hidden_states, 0)
+            hidden_states = sp_all_gather(hidden_states)
             hidden_states = hidden_states[:full_num_tokens]
 
         if self.layer_type == "linear_attention":
@@ -531,19 +534,23 @@ class Qwen3NextDecoderLayer(nn.Module):
                     self.attn_layer_scale.to(hidden_states.dtype) + 1
                 )
 
-        if self.use_attn_reduce_scatter_for_moe:
-            tp_world_size = get_tensor_model_parallel_world_size()
-            # small trick using minus, eg. -17 % 8 = 7
-            sp_pad = (-hidden_states.shape[0]) % tp_world_size
-            # pad if not divisible by world size
-            hidden_states = torch.nn.functional.pad(hidden_states, (0, 0, 0, sp_pad))
-            hidden_states = tensor_model_parallel_reduce_scatter(hidden_states, 0)
+        if self.use_sequence_parallel:
+            if (
+                not input_is_sequence_parallel
+                and envs.VLLM_MOE_SKIP_PADDING
+                and is_forward_context_available()
+            ):
+                forward_context = get_forward_context()
+                forward_context.is_padding = sp_padding_mask(
+                    forward_context.is_padding, hidden_states
+                )
+            hidden_states = sp_reduce_scatter(hidden_states)
             if not input_is_sequence_parallel:
-                residual = sequence_parallel_chunk(residual)
+                residual = sp_shard(residual)
 
         # Fully Connected
         hidden_states, residual = self.post_attention_layernorm(hidden_states, residual)
-        if self.use_attn_reduce_scatter_for_moe:
+        if self.use_sequence_parallel:
             hidden_states = self.mlp(
                 hidden_states,
                 already_sequence_parallel=True,
@@ -575,15 +582,37 @@ def _all_gather_hidden_and_residual(
     hidden_size: int,
 ) -> tuple[torch.Tensor, torch.Tensor | None]:
     if residual is None:
-        hidden_states = tensor_model_parallel_all_gather(hidden_states, 0)
+        hidden_states = sp_all_gather(hidden_states)
         hidden_states = hidden_states[:full_num_tokens]
         return hidden_states, None
 
     combined_states = torch.cat([hidden_states, residual], dim=-1)
-    combined_states = tensor_model_parallel_all_gather(combined_states, 0)
+    combined_states = sp_all_gather(combined_states)
     combined_states = combined_states[:full_num_tokens]
     hidden_states, residual = combined_states.split([hidden_size, hidden_size], dim=-1)
     return hidden_states, residual
+
+
+def _restore_sequence_parallel_outputs(
+    tensors: list[torch.Tensor],
+    sequence_parallel: list[bool],
+    full_num_tokens: int,
+) -> list[torch.Tensor]:
+    assert len(tensors) == len(sequence_parallel)
+    sharded_indices = [
+        idx for idx, is_sharded in enumerate(sequence_parallel) if is_sharded
+    ]
+    if not sharded_indices:
+        return tensors
+
+    sharded_tensors = [tensors[idx] for idx in sharded_indices]
+    split_sizes = [tensor.shape[-1] for tensor in sharded_tensors]
+    packed = sp_all_gather(torch.cat(sharded_tensors, dim=-1))[:full_num_tokens]
+    for idx, tensor in zip(
+        sharded_indices, packed.split(split_sizes, dim=-1), strict=True
+    ):
+        tensors[idx] = tensor
+    return tensors
 
 
 @support_torch_compile
@@ -662,51 +691,46 @@ class Qwen3NextModel(nn.Module, EagleModelMixin):
             residual = intermediate_tensors["residual"]
 
         full_num_tokens = positions.shape[-1]
-        aux_hidden_states = self._maybe_add_hidden_state([], 0, hidden_states, residual)
+        states_are_sequence_parallel = False
+        aux_hidden_states: list[torch.Tensor] = []
+        aux_states_are_sequence_parallel: list[bool] = []
+        if 0 in self.aux_hidden_state_layers:
+            aux_hidden_states.append(hidden_states)
+            aux_states_are_sequence_parallel.append(False)
         for layer_idx, layer in enumerate(
             islice(self.layers, self.start_layer, self.end_layer),
             start=self.start_layer,
         ):
-            if (
-                hidden_states.shape[0] != full_num_tokens
-                and not layer.use_attn_reduce_scatter_for_moe
-            ):
+            if states_are_sequence_parallel and not layer.use_sequence_parallel:
                 hidden_states, residual = _all_gather_hidden_and_residual(
                     hidden_states,
                     residual,
                     full_num_tokens,
                     self.config.hidden_size,
                 )
+                states_are_sequence_parallel = False
             hidden_states, residual = layer(
                 positions=positions,
                 hidden_states=hidden_states,
                 residual=residual,
+                input_is_sequence_parallel=states_are_sequence_parallel,
             )
-            if (layer_idx + 1) in self.aux_hidden_state_layers and hidden_states.shape[
-                0
-            ] != full_num_tokens:
-                hidden_states, residual = _all_gather_hidden_and_residual(
-                    hidden_states,
-                    residual,
-                    full_num_tokens,
-                    self.config.hidden_size,
-                )
-            self._maybe_add_hidden_state(
-                aux_hidden_states, layer_idx + 1, hidden_states, residual
-            )
+            states_are_sequence_parallel = layer.use_sequence_parallel
+            if (layer_idx + 1) in self.aux_hidden_state_layers:
+                aux_hidden_states.append(hidden_states + residual)
+                aux_states_are_sequence_parallel.append(states_are_sequence_parallel)
 
         if not get_pp_group().is_last_rank:
             return IntermediateTensors(
                 {"hidden_states": hidden_states, "residual": residual}
             )
-        if hidden_states.shape[0] != full_num_tokens:
-            hidden_states, residual = _all_gather_hidden_and_residual(
-                hidden_states,
-                residual,
-                full_num_tokens,
-                self.config.hidden_size,
-            )
         hidden_states, _ = self.norm(hidden_states, residual)
+        outputs = _restore_sequence_parallel_outputs(
+            [hidden_states, *aux_hidden_states],
+            [states_are_sequence_parallel, *aux_states_are_sequence_parallel],
+            full_num_tokens,
+        )
+        hidden_states, *aux_hidden_states = outputs
         if aux_hidden_states:
             return hidden_states, aux_hidden_states
         return hidden_states

--- a/vllm/model_executor/models/qwen3_next.py
+++ b/vllm/model_executor/models/qwen3_next.py
@@ -51,6 +51,7 @@ from vllm.models.common.ops.sequence_parallel import (
     sp_all_gather,
     sp_padding_mask,
     sp_reduce_scatter,
+    sp_restore_outputs,
     sp_shard,
 )
 from vllm.platforms import current_platform
@@ -593,28 +594,6 @@ def _all_gather_hidden_and_residual(
     return hidden_states, residual
 
 
-def _restore_sequence_parallel_outputs(
-    tensors: list[torch.Tensor],
-    sequence_parallel: list[bool],
-    full_num_tokens: int,
-) -> list[torch.Tensor]:
-    assert len(tensors) == len(sequence_parallel)
-    sharded_indices = [
-        idx for idx, is_sharded in enumerate(sequence_parallel) if is_sharded
-    ]
-    if not sharded_indices:
-        return tensors
-
-    sharded_tensors = [tensors[idx] for idx in sharded_indices]
-    split_sizes = [tensor.shape[-1] for tensor in sharded_tensors]
-    packed = sp_all_gather(torch.cat(sharded_tensors, dim=-1))[:full_num_tokens]
-    for idx, tensor in zip(
-        sharded_indices, packed.split(split_sizes, dim=-1), strict=True
-    ):
-        tensors[idx] = tensor
-    return tensors
-
-
 @support_torch_compile
 class Qwen3NextModel(nn.Module, EagleModelMixin):
     hf_to_vllm_mapper = WeightsMapper(
@@ -725,7 +704,7 @@ class Qwen3NextModel(nn.Module, EagleModelMixin):
                 {"hidden_states": hidden_states, "residual": residual}
             )
         hidden_states, _ = self.norm(hidden_states, residual)
-        outputs = _restore_sequence_parallel_outputs(
+        outputs = sp_restore_outputs(
             [hidden_states, *aux_hidden_states],
             [states_are_sequence_parallel, *aux_states_are_sequence_parallel],
             full_num_tokens,

--- a/vllm/model_executor/models/qwen3_next.py
+++ b/vllm/model_executor/models/qwen3_next.py
@@ -420,17 +420,21 @@ class Qwen3NextDecoderLayer(nn.Module):
         self.layer_type = layer_type
         self.layer_idx = extract_layer_index(prefix)
 
-        mlp_only_layers = (
-            [] if not hasattr(config, "mlp_only_layers") else config.mlp_only_layers
-        )
-        is_moe_layer = (self.layer_idx not in mlp_only_layers) and (
+        mlp_only_layers = getattr(config, "mlp_only_layers", [])
+        self.is_moe_layer = (self.layer_idx not in mlp_only_layers) and (
             config.num_experts > 0
             and (self.layer_idx + 1) % config.decoder_sparse_step == 0
+        )
+        has_moe_layers = any(
+            layer_idx not in mlp_only_layers
+            and config.num_experts > 0
+            and (layer_idx + 1) % config.decoder_sparse_step == 0
+            for layer_idx in range(config.num_hidden_layers)
         )
         self.use_sequence_parallel = (
             parallel_config.use_sequence_parallel_moe
             and parallel_config.pipeline_parallel_size == 1
-            and is_moe_layer
+            and has_moe_layers
         )
 
         if self.layer_type == "linear_attention":
@@ -453,7 +457,7 @@ class Qwen3NextDecoderLayer(nn.Module):
         else:
             raise ValueError(f"Invalid layer_type {self.layer_type}")
 
-        if is_moe_layer:
+        if self.is_moe_layer:
             self.mlp = Qwen3NextSparseMoeBlock(
                 vllm_config=vllm_config,
                 prefix=f"{prefix}.mlp",
@@ -464,6 +468,7 @@ class Qwen3NextDecoderLayer(nn.Module):
                 intermediate_size=config.intermediate_size,
                 hidden_act=config.hidden_act,
                 quant_config=quant_config,
+                is_sequence_parallel=self.use_sequence_parallel,
                 prefix=f"{prefix}.mlp",
             )
 
@@ -496,14 +501,9 @@ class Qwen3NextDecoderLayer(nn.Module):
         hidden_states: torch.Tensor,
         residual: torch.Tensor | None,
         positions: torch.Tensor = None,
-        input_is_sequence_parallel: bool | None = None,
         **kwargs: object,
     ):
         full_num_tokens = positions.shape[-1]
-        if input_is_sequence_parallel is None:
-            input_is_sequence_parallel = (
-                self.use_sequence_parallel and residual is not None
-            )
 
         if residual is None:
             residual = hidden_states
@@ -511,7 +511,7 @@ class Qwen3NextDecoderLayer(nn.Module):
         else:
             hidden_states, residual = self.input_layernorm(hidden_states, residual)
 
-        if input_is_sequence_parallel:
+        if self.use_sequence_parallel:
             hidden_states = sp_all_gather(hidden_states)
             hidden_states = hidden_states[:full_num_tokens]
 
@@ -536,22 +536,11 @@ class Qwen3NextDecoderLayer(nn.Module):
                 )
 
         if self.use_sequence_parallel:
-            if (
-                not input_is_sequence_parallel
-                and envs.VLLM_MOE_SKIP_PADDING
-                and is_forward_context_available()
-            ):
-                forward_context = get_forward_context()
-                forward_context.is_padding = sp_padding_mask(
-                    forward_context.is_padding, hidden_states
-                )
             hidden_states = sp_reduce_scatter(hidden_states)
-            if not input_is_sequence_parallel:
-                residual = sp_shard(residual)
 
         # Fully Connected
         hidden_states, residual = self.post_attention_layernorm(hidden_states, residual)
-        if self.use_sequence_parallel:
+        if self.use_sequence_parallel and self.is_moe_layer:
             hidden_states = self.mlp(
                 hidden_states,
                 already_sequence_parallel=True,
@@ -574,24 +563,6 @@ class Qwen3NextDecoderLayer(nn.Module):
                 )
 
         return hidden_states, residual
-
-
-def _all_gather_hidden_and_residual(
-    hidden_states: torch.Tensor,
-    residual: torch.Tensor | None,
-    full_num_tokens: int,
-    hidden_size: int,
-) -> tuple[torch.Tensor, torch.Tensor | None]:
-    if residual is None:
-        hidden_states = sp_all_gather(hidden_states)
-        hidden_states = hidden_states[:full_num_tokens]
-        return hidden_states, None
-
-    combined_states = torch.cat([hidden_states, residual], dim=-1)
-    combined_states = sp_all_gather(combined_states)
-    combined_states = combined_states[:full_num_tokens]
-    hidden_states, residual = combined_states.split([hidden_size, hidden_size], dim=-1)
-    return hidden_states, residual
 
 
 @support_torch_compile
@@ -647,6 +618,9 @@ class Qwen3NextModel(nn.Module, EagleModelMixin):
             self.norm = PPMissingLayer()
 
         self.aux_hidden_state_layers: tuple[int, ...] = ()
+        self.use_sequence_parallel = any(
+            layer.use_sequence_parallel for layer in self.layers
+        )
 
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.embed_tokens(input_ids)
@@ -670,34 +644,29 @@ class Qwen3NextModel(nn.Module, EagleModelMixin):
             residual = intermediate_tensors["residual"]
 
         full_num_tokens = positions.shape[-1]
-        states_are_sequence_parallel = False
+        if self.use_sequence_parallel:
+            if envs.VLLM_MOE_SKIP_PADDING and is_forward_context_available():
+                forward_context = get_forward_context()
+                forward_context.is_padding = sp_padding_mask(
+                    forward_context.is_padding, hidden_states
+                )
+            hidden_states = sp_shard(hidden_states)
+            assert residual is None, "Sequence parallelism is not supported with PP"
+
         aux_hidden_states: list[torch.Tensor] = []
-        aux_states_are_sequence_parallel: list[bool] = []
         if 0 in self.aux_hidden_state_layers:
             aux_hidden_states.append(hidden_states)
-            aux_states_are_sequence_parallel.append(False)
         for layer_idx, layer in enumerate(
             islice(self.layers, self.start_layer, self.end_layer),
             start=self.start_layer,
         ):
-            if states_are_sequence_parallel and not layer.use_sequence_parallel:
-                hidden_states, residual = _all_gather_hidden_and_residual(
-                    hidden_states,
-                    residual,
-                    full_num_tokens,
-                    self.config.hidden_size,
-                )
-                states_are_sequence_parallel = False
             hidden_states, residual = layer(
                 positions=positions,
                 hidden_states=hidden_states,
                 residual=residual,
-                input_is_sequence_parallel=states_are_sequence_parallel,
             )
-            states_are_sequence_parallel = layer.use_sequence_parallel
             if (layer_idx + 1) in self.aux_hidden_state_layers:
                 aux_hidden_states.append(hidden_states + residual)
-                aux_states_are_sequence_parallel.append(states_are_sequence_parallel)
 
         if not get_pp_group().is_last_rank:
             return IntermediateTensors(
@@ -706,7 +675,7 @@ class Qwen3NextModel(nn.Module, EagleModelMixin):
         hidden_states, _ = self.norm(hidden_states, residual)
         outputs = sp_restore_outputs(
             [hidden_states, *aux_hidden_states],
-            [states_are_sequence_parallel, *aux_states_are_sequence_parallel],
+            [self.use_sequence_parallel] * (1 + len(aux_hidden_states)),
             full_num_tokens,
         )
         hidden_states, *aux_hidden_states = outputs

--- a/vllm/model_executor/models/qwen3_next_mtp.py
+++ b/vllm/model_executor/models/qwen3_next_mtp.py
@@ -22,8 +22,8 @@ from vllm.model_executor.models.qwen3_next import (
     Qwen3NextModel,
     Qwen3NextRMSNorm,
     QwenNextMixtureOfExperts,
-    _all_gather_hidden_and_residual,
 )
+from vllm.models.common.ops.sequence_parallel import sp_all_gather, sp_shard
 from vllm.sequence import IntermediateTensors
 from vllm.transformers_utils.configs.qwen3_next import Qwen3NextConfig
 
@@ -131,6 +131,8 @@ class Qwen3NextMultiTokenPredictor(nn.Module):
 
         current_step_idx = spec_step_idx % self.num_mtp_layers
         mtp_layer = self.layers[current_step_idx]
+        if mtp_layer.use_sequence_parallel:
+            hidden_states = sp_shard(hidden_states)
         hidden_states, residual = mtp_layer(
             positions=positions,
             hidden_states=hidden_states,
@@ -143,12 +145,9 @@ class Qwen3NextMultiTokenPredictor(nn.Module):
             )
 
         if mtp_layer.use_sequence_parallel:
-            hidden_states, residual = _all_gather_hidden_and_residual(
-                hidden_states,
-                residual,
-                positions.shape[-1],
-                self.config.hidden_size,
-            )
+            hidden_states = sp_all_gather(hidden_states + residual)
+            hidden_states = hidden_states[: positions.shape[-1]]
+            residual = None
         hidden_states, _ = self.norm(hidden_states, residual)
         return hidden_states
 

--- a/vllm/model_executor/models/qwen3_next_mtp.py
+++ b/vllm/model_executor/models/qwen3_next_mtp.py
@@ -142,7 +142,7 @@ class Qwen3NextMultiTokenPredictor(nn.Module):
                 {"hidden_states": hidden_states, "residual": residual}
             )
 
-        if mtp_layer.use_attn_reduce_scatter_for_moe:
+        if mtp_layer.use_sequence_parallel:
             hidden_states, residual = _all_gather_hidden_and_residual(
                 hidden_states,
                 residual,

--- a/vllm/models/common/ops/sequence_parallel.py
+++ b/vllm/models/common/ops/sequence_parallel.py
@@ -10,6 +10,39 @@ from vllm.distributed import (
     tensor_model_parallel_all_gather,
     tensor_model_parallel_reduce_scatter,
 )
+from vllm.utils.torch_utils import direct_register_custom_op
+
+
+def _sp_pad_compiled(x: torch.Tensor, tp_size: int, value: float) -> torch.Tensor:
+    sp_pad = (-x.shape[0]) % tp_size
+    pad = (0, 0) * (x.ndim - 1) + (0, sp_pad)
+    return torch.nn.functional.pad(x, pad, value=value)
+
+
+def _sp_pad_compiled_fake(x: torch.Tensor, tp_size: int, value: float) -> torch.Tensor:
+    new_shape = list(x.shape)
+    new_shape[0] += (-new_shape[0]) % tp_size
+    return torch.empty(new_shape, dtype=x.dtype, device=x.device)
+
+
+direct_register_custom_op(
+    op_name="sp_pad_compiled",
+    op_func=_sp_pad_compiled,
+    fake_impl=_sp_pad_compiled_fake,
+)
+
+
+def _sp_pad(x: torch.Tensor, tp_size: int, value: float = 0.0) -> torch.Tensor:
+    sp_pad = (-x.shape[0]) % tp_size
+    if torch.compiler.is_compiling():
+        # Keep dynamic padding opaque to Inductor. If aten.constant_pad_nd is
+        # compiled inline, its output can incorrectly reuse the unpadded input
+        # buffer when the tracing shape needs no padding.
+        return torch.ops.vllm.sp_pad_compiled(x, tp_size, value)
+    if sp_pad == 0:
+        return x
+    pad = (0, 0) * (x.ndim - 1) + (0, sp_pad)
+    return torch.nn.functional.pad(x, pad, value=value)
 
 
 def _custom_collective(name: str, x: torch.Tensor) -> torch.Tensor | None:
@@ -30,9 +63,7 @@ def sp_all_gather(x: torch.Tensor) -> torch.Tensor:
 def sp_reduce_scatter(x: torch.Tensor) -> torch.Tensor:
     assert x.ndim == 2
     tp_size = get_tensor_model_parallel_world_size()
-    sp_pad = (-x.shape[0]) % tp_size
-    if sp_pad > 0:
-        x = torch.nn.functional.pad(x, (0, 0, 0, sp_pad))
+    x = _sp_pad(x, tp_size)
     output = _custom_collective("custom_reduce_scatter", x)
     if output is not None:
         return output
@@ -42,10 +73,7 @@ def sp_reduce_scatter(x: torch.Tensor) -> torch.Tensor:
 def sp_shard(x: torch.Tensor) -> torch.Tensor:
     tp_size = get_tensor_model_parallel_world_size()
     tp_rank = get_tensor_model_parallel_rank()
-    sp_pad = (-x.shape[0]) % tp_size
-    if sp_pad > 0:
-        pad = (0, 0) * (x.ndim - 1) + (0, sp_pad)
-        x = torch.nn.functional.pad(x, pad)
+    x = _sp_pad(x, tp_size)
     chunk = x.shape[0] // tp_size
     return x[tp_rank * chunk : (tp_rank + 1) * chunk]
 
@@ -60,9 +88,7 @@ def sp_padding_mask(
     assert is_padding.shape[0] == num_tokens
 
     tp_size = get_tensor_model_parallel_world_size()
-    sp_pad = (-num_tokens) % tp_size
-    if sp_pad > 0:
-        is_padding = torch.nn.functional.pad(is_padding, (0, sp_pad), value=True)
+    is_padding = _sp_pad(is_padding, tp_size, value=1.0)
     chunk = is_padding.shape[0] // tp_size
     tp_rank = get_tensor_model_parallel_rank()
     return is_padding[tp_rank * chunk : (tp_rank + 1) * chunk]

--- a/vllm/models/common/ops/sequence_parallel.py
+++ b/vllm/models/common/ops/sequence_parallel.py
@@ -60,6 +60,29 @@ def sp_all_gather(x: torch.Tensor) -> torch.Tensor:
     return tensor_model_parallel_all_gather(x, 0)
 
 
+def sp_restore_outputs(
+    tensors: list[torch.Tensor],
+    sequence_parallel: list[bool],
+    full_num_tokens: int,
+) -> list[torch.Tensor]:
+    """Restore sequence-sharded outputs with a single packed all-gather."""
+    assert len(tensors) == len(sequence_parallel)
+    sharded_indices = [
+        idx for idx, is_sharded in enumerate(sequence_parallel) if is_sharded
+    ]
+    if not sharded_indices:
+        return tensors
+
+    sharded_tensors = [tensors[idx] for idx in sharded_indices]
+    split_sizes = [tensor.shape[-1] for tensor in sharded_tensors]
+    packed = sp_all_gather(torch.cat(sharded_tensors, dim=-1))[:full_num_tokens]
+    for idx, tensor in zip(
+        sharded_indices, packed.split(split_sizes, dim=-1), strict=True
+    ):
+        tensors[idx] = tensor
+    return tensors
+
+
 def sp_reduce_scatter(x: torch.Tensor) -> torch.Tensor:
     assert x.ndim == 2
     tp_size = get_tensor_model_parallel_world_size()


### PR DESCRIPTION
## Summary

This PR enables the common sequence-parallel path for Qwen3.5 MoE, keeps sequence-sharded tensors across attention/MoE boundaries, and restores full-token outputs only where required. It also preserves the Qwen3.5 MTP path by normalizing the local shard before gathering the final draft-model output.

## End-to-end flow

```text
Qwen3_5ForConditionalGeneration.forward
  -> Qwen3_5Model.forward
     -> Qwen3NextDecoderLayer.forward
        -> Qwen3NextAttention.forward
           -> sp_shard / sp_reduce_scatter
        -> Qwen3NextSparseMoeBlock.forward
           -> sp_all_gather (only when the MoE input must be restored)
     -> _restore_sequence_parallel_outputs
        -> one packed sp_all_gather for final and auxiliary states

MTP:
Qwen3_5MTP.forward
  -> decoder layer
  -> RMSNorm on the local sequence shard
  -> sp_all_gather
  -> trim sequence padding
```

## Results

Model: `Qwen/Qwen3.5-122B-A10B-FP8`, TP=2, DP=2, EP enabled.

### Non-MTP: main vs. this PR

The throughput numbers below use the steady-state runs (main's final run and the mean of this PR's final three runs).

| Branch | Output throughput | Total token throughput | Mean TTFT | Mean TPOT | GSM8K 5-shot flexible / strict |
|---|---:|---:|---:|---:|---:|
| main | 1,853.15 tok/s | 20,384.67 tok/s | 1,013.50 ms | 13.68 ms | Not separately rerun |
| this PR | 1,843.41 tok/s | 20,277.53 tok/s | 1,117.85 ms | 13.55 ms | 86.66% / 85.14% |

Output throughput differs by **-0.53%**, while mean TPOT improves by **0.94%**.

```bash
vllm bench serve \
  --model Qwen/Qwen3.5-122B-A10B-FP8 \
  --host localhost --port 8000 \
  --dataset-name random \
  --random-input-len 10240 \
  --random-output-len 1024 \
  --num-prompts 100 \
  --max-concurrency 32 \
  --temperature 0 --ignore-eos \
  --num-warmups 4

lm_eval \
  --model local-completions \
  --model_args model=Qwen/Qwen3.5-122B-A10B-FP8,base_url=http://127.0.0.1:8000/v1/completions,tokenizer=Qwen/Qwen3.5-122B-A10B-FP8,num_concurrent=32,max_retries=3,tokenized_requests=False,timeout=600 \
  --tasks gsm8k --num_fewshot 5 --batch_size 1 \
  --gen_kwargs temperature=0,max_gen_toks=256
```

### MTP: this PR

MTP was tested with two speculative tokens. A representative shape-stress run used 127 input tokens, 64 output tokens, 32 prompts, and concurrency 32.

| Branch | Output throughput | Mean TTFT | Mean TPOT | MTP acceptance | GSM8K 5-shot flexible / strict |
|---|---:|---:|---:|---:|---:|
| this PR + MTP | 1,421.63 tok/s | 500.94 ms | 9.20 ms | 78.66% | 86.05% / 84.38% |

All 32 requests completed successfully. Additional input lengths `1`, `3`, and `17` were also tested to cover small and non-divisible sequence shapes.

```bash
vllm serve Qwen/Qwen3.5-122B-A10B-FP8 \
  --tensor-parallel-size 2 \
  --data-parallel-size 2 \
  --enable-expert-parallel \
  --max-model-len 32768 \
  --speculative-config '{"method":"mtp","num_speculative_tokens":2,"max_model_len":32768}'

vllm bench serve \
  --model Qwen/Qwen3.5-122B-A10B-FP8 \
  --host localhost --port 8000 \
  --dataset-name random \
  --random-input-len 127 \
  --random-output-len 64 \
  --num-prompts 32 \
  --max-concurrency 32 \
  --temperature 0 --ignore-eos

lm_eval \
  --model local-completions \
  --model_args model=Qwen/Qwen3.5-122B-A10B-FP8,base_url=http://127.0.0.1:8000/v1/completions,tokenizer=Qwen/Qwen3.5-122B-A10B-FP8,num_concurrent=32,max_retries=3,tokenized_requests=False,timeout=600 \
  --tasks gsm8k --num_fewshot 5 --batch_size 1 \
  --gen_kwargs temperature=0,max_gen_toks=256
```


non-MTP:

(main)
```
local-completions ({'model': 'Qwen/Qwen3.5-122B-A10B-FP8', 'base_url': 'http://127.0.0.1:8000/v1/completions', 'tokenizer': 'Qwen/Qwen3.5-122B-A10B-FP8', 'num_concurrent': 32, 'max_retries': 3, 'tokenized_requests': False, 'timeout': 600}), gen_kwargs: ({'temperature': 0, 'max_gen_toks': 256}), limit: None, num_fewshot: 5, batch_size: 1
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.8650|±  |0.0094|
|     |       |strict-match    |     5|exact_match|↑  |0.8423|±  |0.0100|
```

(This PR)

```text
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.8666|±  |0.0094|
|     |       |strict-match    |     5|exact_match|↑  |0.8514|±  |0.0098|
```

MTP:

```text
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.8605|±  |0.0095|
|     |       |strict-match    |     5|exact_match|↑  |0.8438|±  |0.0100|
```