### PR TITLE
[Bugfix][XPU] Run GDN attention as eager break under breakable cudagraph

### DIFF
--- a/vllm/_xpu_ops.py
+++ b/vllm/_xpu_ops.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 import torch
 from vllm_xpu_kernels.flash_attn_interface import flash_attn_varlen_func
 
+from vllm.compilation.breakable_cudagraph import eager_break_during_capture
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
 from vllm.triton_utils import tl, triton
@@ -1257,7 +1258,7 @@ class xpu_ops:
 
             direct_register_custom_op(
                 op_name="gdn_attention_core_xpu",
-                op_func=_gdn_attention_core_xpu_impl,
+                op_func=eager_break_during_capture(_gdn_attention_core_xpu_impl),
                 mutates_args=["core_attn_out", "z"],
                 fake_impl=_gdn_attention_core_xpu_fake,
             )


### PR DESCRIPTION
When breakable graph, Qwen3.5 on XPU produced garbage output. This PR is fix the GDN (Gated Delta Net) recurrent attention on XPU. 

The XPU GDN attention code reads and writes the conv and ssm state caches in place using data-dependent metadata. Under breakable-cudagraph capture the capture-time state addressing is frozen into the graph, so replay corrupts the recurrent state and hybrid models (e.g. Qwen3.5-9B) emit garbage output.

This PR wraps the gdn_attention_core_xpu custom op with eager_break_during_capture so it runs as an eager break during capture. 
