### PR TITLE
[Perf] Move context_lens compute into prefill path for Minimax

### DIFF
--- a/vllm/models/minimax_m3/common/indexer.py
+++ b/vllm/models/minimax_m3/common/indexer.py
@@ -290,14 +290,13 @@ class MiniMaxM3IndexerTritonMetadataBuilder(MiniMaxM3IndexerMetadataBuilder):
         assert num_decodes + num_prefills == num_reqs
         assert num_decode_tokens + num_prefill_tokens == num_tokens
 
-        # Decode-first batch: context lengths into the stable cudagraph buffer.
-        context_lens = self.context_len_buffer[:num_reqs]
-        context_lens.copy_(
-            common_attn_metadata.compute_num_computed_tokens(), non_blocking=True
-        )
-
         prefill_metadata: MiniMaxM3IndexerPrefillMetadata | None = None
         if num_prefills > 0:
+            # Decode-first batch: context lengths into the stable cudagraph buffer.
+            context_lens = self.context_len_buffer[:num_reqs]
+            context_lens.copy_(
+                common_attn_metadata.compute_num_computed_tokens(), non_blocking=True
+            )
             prefill_metadata = MiniMaxM3IndexerPrefillMetadata(
                 cu_seqlens_q=(query_start_loc[num_decodes:] - num_decode_tokens).to(
                     torch.int32

--- a/vllm/models/minimax_m3/common/sparse_attention.py
+++ b/vllm/models/minimax_m3/common/sparse_attention.py
@@ -245,14 +245,13 @@ class MiniMaxM3SparseMetadataBuilder(AttentionMetadataBuilder[MiniMaxM3SparseMet
         assert num_decodes + num_prefills == num_reqs
         assert num_decode_tokens + num_prefill_tokens == num_tokens
 
-        # Decode-first batch: context lengths into the stable cudagraph buffer.
-        context_lens = self.context_len_buffer[:num_reqs]
-        context_lens.copy_(
-            common_attn_metadata.compute_num_computed_tokens(), non_blocking=True
-        )
-
         prefill_metadata: MiniMaxM3SparsePrefillMetadata | None = None
         if num_prefills > 0:
+            # Decode-first batch: context lengths into the stable cudagraph buffer.
+            context_lens = self.context_len_buffer[:num_reqs]
+            context_lens.copy_(
+                common_attn_metadata.compute_num_computed_tokens(), non_blocking=True
+            )
             seq_lens_cpu = common_attn_metadata.seq_lens_cpu_upper_bound
             assert seq_lens_cpu is not None
             prefill_seq_lens_cpu = seq_lens_cpu[num_decodes:]


### PR DESCRIPTION



## Purpose

Move `compute_num_computed_tokens()` from the top of the method into the `if num_prefills > 0` branch because it's only used in prefill. Since context_lens tensor is not used in decode path, this change avoids the tensor computed and discarded in decode path. Similar as #51913

## Profiling

Main:
<img width="1900" height="495" alt="Screenshot 2026-08-12 at 2 35 45 PM" src="https://github.com/user-attachments/assets/b96d9826-a679-4ce7-be55-9ca69556bfc3" />


PR:

<img width="1905" height="498" alt="Screenshot 2026-08-12 at 2 30 01 PM" src="https://github.com/user-attachments/assets/ed7b173c-02c0-4b48-b137-4d2820f9a00b" />


Main: `compute_num_computed_tokens` called in MiniMaxM3IndexerTritonMetadataBuilder.build() in decode path, takes extra 74µs.

PR: `compute_num_computed_tokens` not called.

## Benchmark

```
vllm serve MiniMaxAI/MiniMax-M3 \
  --tensor-parallel-size 8 \
  --max-num-seqs 16 \
  --block-size 128 \
  --no-enable-prefix-caching
```

```
vllm bench serve \
        --model MiniMaxAI/MiniMax-M3 \
        --dataset-name sharegpt \
        --dataset-path /tmp/ShareGPT_V3_unfiltered_cleaned_split.json \
        --sharegpt-output-len 300 \
        --num-prompts ${num_prompts} \
        --max-concurrency ${concurrency} \
        --num-warmups 200 \
        --ignore-eos
```

Main:

* concurrency 1

```
============ Serving Benchmark Result ============
Successful requests:                     60        
Failed requests:                         0         
Maximum request concurrency:             1         
Benchmark duration (s):                  119.30    
Total input tokens:                      15421     
Total generated tokens:                  18000     
Request throughput (req/s):              0.50      
Output token throughput (tok/s):         150.89    
Peak output token throughput (tok/s):    158.00    
Peak concurrent requests:                2.00      
Total token throughput (tok/s):          280.15    
---------------Time to First Token----------------
Mean TTFT (ms):                          85.10     
Median TTFT (ms):                        114.17    
P99 TTFT (ms):                           133.31    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          6.36      
Median TPOT (ms):                        6.36      
P99 TPOT (ms):                           6.38      
---------------Inter-token Latency----------------
Mean ITL (ms):                           6.36      
Median ITL (ms):                         6.36      
P99 ITL (ms):                            6.72      
==================================================
```

* concurrency 16
```
============ Serving Benchmark Result ============
Successful requests:                     960       
Failed requests:                         0         
Maximum request concurrency:             16        
Benchmark duration (s):                  300.81    
Total input tokens:                      216233    
Total generated tokens:                  288000    
Request throughput (req/s):              3.19      
Output token throughput (tok/s):         957.42    
Peak output token throughput (tok/s):    1072.00   
Peak concurrent requests:                32.00     
Total token throughput (tok/s):          1676.25   
---------------Time to First Token----------------
Mean TTFT (ms):                          303.93    
Median TTFT (ms):                        293.91    
P99 TTFT (ms):                           401.69    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          15.75     
Median TPOT (ms):                        15.72     
P99 TPOT (ms):                           16.54     
---------------Inter-token Latency----------------
Mean ITL (ms):                           15.75     
Median ITL (ms):                         15.39     
P99 ITL (ms):                            16.67     
==================================================
```

PR:

* concurrency 1

```
============ Serving Benchmark Result ============
Successful requests:                     60        
Failed requests:                         0         
Maximum request concurrency:             1         
Benchmark duration (s):                  119.22    
Total input tokens:                      15421     
Total generated tokens:                  18000     
Request throughput (req/s):              0.50      
Output token throughput (tok/s):         150.98    
Peak output token throughput (tok/s):    158.00    
Peak concurrent requests:                2.00      
Total token throughput (tok/s):          280.32    
---------------Time to First Token----------------
Mean TTFT (ms):                          84.08     
Median TTFT (ms):                        113.42    
P99 TTFT (ms):                           130.15    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          6.36      
Median TPOT (ms):                        6.36      
P99 TPOT (ms):                           6.38      
---------------Inter-token Latency----------------
Mean ITL (ms):                           6.36      
Median ITL (ms):                         6.36      
P99 ITL (ms):                            6.74      
==================================================
```

* concurrency 16

```
============ Serving Benchmark Result ============
Successful requests:                     960       
Failed requests:                         0         
Maximum request concurrency:             16        
Benchmark duration (s):                  296.84    
Total input tokens:                      216233    
Total generated tokens:                  288000    
Request throughput (req/s):              3.23      
Output token throughput (tok/s):         970.22    
Peak output token throughput (tok/s):    1057.00   
Peak concurrent requests:                32.00     
Total token throughput (tok/s):          1698.67   
---------------Time to First Token----------------
Mean TTFT (ms):                          247.74    
Median TTFT (ms):                        260.92    
P99 TTFT (ms):                           285.48    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          15.71     
Median TPOT (ms):                        15.72     
P99 TPOT (ms):                           16.26     
---------------Inter-token Latency----------------
Mean ITL (ms):                           15.71     
Median ITL (ms):                         15.43     
P99 ITL (ms):                            16.74     
==================================================
```

## Accuracy Testing

```
python3 -m lm_eval --model local-completions \
  --model_args model=MiniMaxAI/MiniMax-M3,base_url=http://127.0.0.1:8000/v1/completions,num_concurrent=16 \
  --tasks gsm8k
```

Main:

```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9121|±  |0.0078|
|     |       |strict-match    |     5|exact_match|↑  |0.9113|±  |0.0078|
```

PR:

```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9121|±  |0.0078|
|     |       |strict-match    |     5|exact_match|↑  |0.9121|±  |0.0078|
```


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

