### PR TITLE
[CI/Build][torch.compile] Add E2E correctness test for QK-norm+RoPE fusion

### DIFF
--- a/.buildkite/test_areas/compile.yaml
+++ b/.buildkite/test_areas/compile.yaml
@@ -36,7 +36,21 @@ steps:
   - tests/compile/correctness_e2e/test_qk_norm_rope.py
   commands:
   - export VLLM_TEST_CLEAN_GPU_MEMORY=1
-  - pytest -v -s tests/compile/correctness_e2e/test_qk_norm_rope.py
+  - pytest -v -s tests/compile/correctness_e2e/test_qk_norm_rope.py -k "not tp2"
+
+- label: ":nvidia: (H100) QK-Norm+RoPE Correctness TP2"
+  key: qk-norm-rope-correctness-tests-2xh100
+  timeout_in_minutes: 30
+  working_dir: "/vllm-workspace/"
+  device: h100
+  num_devices: 2
+  source_file_dependencies:
+  - csrc/libtorch_stable/fused_qknorm_rope_kernel.cu
+  - vllm/compilation/passes/fusion/qk_norm_rope_fusion.py
+  - tests/compile/correctness_e2e/test_qk_norm_rope.py
+  commands:
+  - export VLLM_TEST_CLEAN_GPU_MEMORY=1
+  - pytest -v -s tests/compile/correctness_e2e/test_qk_norm_rope.py -k "tp2"
 
 - label: ":nvidia: (H100) Distributed Compile"
   key: distributed-compile-unit-tests-2xh100

--- a/.buildkite/test_areas/compile.yaml
+++ b/.buildkite/test_areas/compile.yaml
@@ -24,6 +24,20 @@ steps:
   - export VLLM_TEST_CLEAN_GPU_MEMORY=1
   - pytest -v -s tests/compile/correctness_e2e/test_async_tp.py
 
+- label: ":nvidia: (H100) QK-Norm+RoPE Correctness"
+  key: qk-norm-rope-correctness-tests-h100
+  timeout_in_minutes: 30
+  working_dir: "/vllm-workspace/"
+  device: h100
+  num_devices: 1
+  source_file_dependencies:
+  - csrc/libtorch_stable/fused_qknorm_rope_kernel.cu
+  - vllm/compilation/passes/fusion/qk_norm_rope_fusion.py
+  - tests/compile/correctness_e2e/test_qk_norm_rope.py
+  commands:
+  - export VLLM_TEST_CLEAN_GPU_MEMORY=1
+  - pytest -v -s tests/compile/correctness_e2e/test_qk_norm_rope.py
+
 - label: ":nvidia: (H100) Distributed Compile"
   key: distributed-compile-unit-tests-2xh100
   timeout_in_minutes: 45

--- a/tests/compile/correctness_e2e/test_qk_norm_rope.py
+++ b/tests/compile/correctness_e2e/test_qk_norm_rope.py
@@ -12,7 +12,11 @@ asks for.
 import json
 
 from tests.models.registry import _HfExamplesInfo
-from tests.utils import compare_two_settings, create_new_process_for_each_test
+from tests.utils import (
+    compare_two_settings,
+    create_new_process_for_each_test,
+    multi_gpu_test,
+)
 from vllm.config import CompilationMode
 
 # Qwen3 RMSNorms Q/K before RoPE (`q_norm`/`k_norm`), which is the pattern the
@@ -65,3 +69,10 @@ def _compare_fusion_settings(tp_size: int) -> None:
 @create_new_process_for_each_test()
 def test_qk_norm_rope_fusion_correctness():
     _compare_fusion_settings(tp_size=1)
+
+
+# Sharding splits the heads the pass reasons about, so TP is worth covering
+# separately. multi_gpu_test already applies create_new_process_for_each_test.
+@multi_gpu_test(num_gpus=2)
+def test_qk_norm_rope_fusion_correctness_tp2():
+    _compare_fusion_settings(tp_size=2)

--- a/tests/compile/correctness_e2e/test_qk_norm_rope.py
+++ b/tests/compile/correctness_e2e/test_qk_norm_rope.py
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""E2E correctness for ``QKNormRoPEFusionPass``.
+
+``tests/compile/fusions_e2e`` already asserts the pass fires the expected
+number of times, and ``tests/compile/passes/test_qk_norm_rope_fusion.py``
+checks a synthetic module numerically. Neither compares engine output on a
+real model, which is what https://github.com/vllm-project/vllm/issues/39428
+asks for.
+"""
+
+import json
+
+from tests.models.registry import _HfExamplesInfo
+from tests.utils import compare_two_settings, create_new_process_for_each_test
+from vllm.config import CompilationMode
+
+# Qwen3 RMSNorms Q/K before RoPE (`q_norm`/`k_norm`), which is the pattern the
+# pass matches, and its head_dim of 128 is in
+# SUPPORTED_FUSED_QK_NORM_ROPE_HEAD_DIMS. Llama-class models have no QK-norm
+# and cannot exercise the pass at all.
+MODEL_ID = "Qwen/Qwen3-0.6B"
+MODEL_INFO = _HfExamplesInfo(MODEL_ID)
+
+
+def _server_args(tp_size: int, enable_fusion: bool) -> list[str]:
+    compilation_config = {
+        "mode": CompilationMode.VLLM_COMPILE,
+        "splitting_ops": [],
+        "pass_config": {"enable_qk_norm_rope_fusion": enable_fusion},
+    }
+    return [
+        # The pass bails on dtypes other than bfloat16/float16.
+        "--dtype",
+        "bfloat16",
+        "--max-model-len",
+        "2048",
+        "--max-num-seqs",
+        "8",
+        "--tensor-parallel-size",
+        str(tp_size),
+        "--distributed-executor-backend",
+        "mp",
+        "--compilation_config",
+        json.dumps(compilation_config),
+    ]
+
+
+def _compare_fusion_settings(tp_size: int) -> None:
+    MODEL_INFO.check_transformers_version(on_fail="skip")
+    MODEL_INFO.check_available_online(on_fail="skip")
+
+    # Both settings pin the flag explicitly. PassConfig fields default to None
+    # and are resolved by optimization level, so leaving the baseline implicit
+    # risks enabling the pass on both sides and comparing identical configs.
+    compare_two_settings(
+        MODEL_ID,
+        _server_args(tp_size, enable_fusion=True),
+        _server_args(tp_size, enable_fusion=False),
+        method="generate",
+        force_v1_runner=True,
+    )
+
+
+@create_new_process_for_each_test()
+def test_qk_norm_rope_fusion_correctness():
+    _compare_fusion_settings(tp_size=1)


### PR DESCRIPTION
## Purpose

Partially addresses #39428, which notes that `tests/compile/fusions_e2e` prevents fusion regressions but gives us "no way of testing correctness for these fusion configurations."

Today the coverage looks like this:

| Layer | State |
|---|---|
| Unit correctness (synthetic module, `assert_close`) | exists for ~every pass, incl. `tests/compile/passes/test_qk_norm_rope_fusion.py` |
| E2E match-count (real model, counts patterns) | `tests/compile/fusions_e2e/` — runs norm_rope, asserts counts, never compares outputs |
| E2E correctness (real model, compares outputs) | `tests/compile/correctness_e2e/` — only `test_async_tp.py` and `test_sequence_parallel.py` |

This adds the third row for `QKNormRoPEFusionPass`. A unit test on a synthetic one-layer module cannot catch a pass that fuses the right number of sites but produces the wrong result once real multi-layer geometry, batching and the real traced graph are involved.

**This does not close #39428.** It covers the QK-norm+RoPE slice only. The quant slices (`rms_quant`, `act_quant`, `attn_quant`) need FP8, and `ar_rms_fusion` only activates on device capabilities `{90, 100, 103, 107}` per `FI_ALLREDUCE_FUSION_MAX_SIZE_MB`, so I could not exercise them on the hardware I have. `QKNormRoPEFusionPass` has no capability gate — only dtype and `head_size` checks — and its kernel guard is `__CUDA_ARCH__ >= 800`, so it is testable far more widely.

This also does not depend on #43610 or #39480. Those were blocked on a DeepSeek `--hf-overrides.num_hidden_layers` prerequisite; using a small dense Qwen3 model sidesteps it entirely.

Notes on the implementation:

- **Model choice.** Qwen3 RMSNorms Q/K before RoPE (`q_norm`/`k_norm`), which is the pattern the pass matches, and its `head_dim` of 128 is in `SUPPORTED_FUSED_QK_NORM_ROPE_HEAD_DIMS`. Llama-class models have no QK-norm and cannot exercise this pass at all.
- **Both settings pin the flag explicitly.** `PassConfig` fields default to `None` and are resolved by optimization level, so leaving the baseline implicit risks enabling the pass on both legs and silently comparing two identical configurations.
- **CI registration is required, not optional.** `tests/compile/correctness_e2e/` is not auto-discovered — the generic compile step globs with `find compile/ -maxdepth 1`, which excludes subdirectories. Without the Buildkite steps the test would never run.

## Test Plan

```bash
pytest -v -s tests/compile/correctness_e2e/test_qk_norm_rope.py -k "not tp2"   # TP=1
pytest -v -s tests/compile/correctness_e2e/test_qk_norm_rope.py -k "tp2"       # TP=2
pre-commit run --files tests/compile/correctness_e2e/test_qk_norm_rope.py \
                       .buildkite/test_areas/compile.yaml
```

Because a correctness test that never triggers the pass would pass vacuously, I also verified the pass actually fires, and that the comparison detects a real divergence.

## Test Result

Both legs were run on real hardware, on vllm `0.1.dev50+gb2506d62a`:

| Leg | Hardware | Result |
|---|---|---|
| TP=1 | NVIDIA A10G, capability **8.6** | `1 passed, 1 deselected in 199.94s` |
| TP=2 | 2x NVIDIA A100 80GB PCIe, capability **8.0** | `1 passed, 1 deselected in 276.20s` |

Capability 8.0 is the floor of the kernel's `__CUDA_ARCH__ >= 800` guard, so the two legs bracket the low end of the supported range rather than testing the same capability twice.

**The pass genuinely fires** (`VLLM_LOGGING_LEVEL=DEBUG`, Inductor caches disabled). Qwen3-0.6B has 28 layers, so 28 sites is one per layer, and TP=2 reports it once per rank:

```
TP=1  enable_qk_norm_rope_fusion=True   ->  Fused QK Norm+RoPE on 28 sites
TP=1  enable_qk_norm_rope_fusion=False  ->  (no fusion line; 0 occurrences)

TP=2  enable_qk_norm_rope_fusion=True   ->  Fused QK Norm+RoPE on 28 sites   (x2, one per rank)
TP=2  enable_qk_norm_rope_fusion=False  ->  (no fusion line; 0 occurrences)
```

Greedy output was identical in all four configurations:
`' Paris. The capital of France is also the capital of the Republic of France.'`

**The comparison is not vacuous.** With a throwaway probe that perturbs one leg (bfloat16 vs float16), `compare_two_settings` correctly fails:

```
E   AssertionError: Results for model='Qwen/Qwen3-0.6B' are not the same.
```

pre-commit clean, including mypy.

---

AI assistance was used for this change. I reviewed every changed line, ran the tests above myself, and can defend the change end to end.

Not a duplicate: the only open PRs referencing #39428 are #43610 and #39480, both merge-conflicted and untouched since 2026-06-30, and neither covers QK-norm+RoPE correctness. Open PRs matching "qk norm rope" (#49744, #50466, #50670, #50903, #51722) are all kernel-side work, not test coverage.
