### PR TITLE
[Perf][GLM-5.2] Optimize quantized MTP serving

### DIFF
--- a/tests/config/test_speculative_draft_hf_overrides.py
+++ b/tests/config/test_speculative_draft_hf_overrides.py
@@ -86,6 +86,21 @@ def test_arch_mapping_applies_before_callable_override():
 
 
 @pytest.mark.cpu_test
+def test_glm_dsa_uses_sparse_mtp_model():
+    config = _make_hf_config(
+        architectures=["GlmMoeDsaForCausalLM"],
+        model_type="glm_moe_dsa",
+        num_nextn_predict_layers=1,
+    )
+
+    out = SpeculativeConfig.hf_config_override(config)
+
+    assert out.model_type == "deepseek_mtp"
+    assert out.architectures == ["DeepseekV32MTPModel"]
+    assert out.n_predict == 1
+
+
+@pytest.mark.cpu_test
 def test_inkling_override_exposes_only_first_mtp_depth():
     text_config = _make_hf_config(
         architectures=["InklingForCausalLM"],

--- a/tests/fusion/test_quant_activation_contract.py
+++ b/tests/fusion/test_quant_activation_contract.py
@@ -5,6 +5,7 @@
 import pytest
 import torch
 
+import vllm.model_executor.kernels.linear.scaled_mm.deep_gemm as deep_gemm
 from vllm.model_executor.kernels.linear import (
     _POSSIBLE_FP8_BLOCK_KERNELS,
     _POSSIBLE_FP8_KERNELS,
@@ -19,8 +20,14 @@ from vllm.model_executor.kernels.linear.nvfp4.flashinfer import (
     FlashInferCutlassNvFp4LinearKernel,
     FlashInferTrtllmNvFp4LinearKernel,
 )
+from vllm.model_executor.kernels.linear.scaled_mm.BlockScaledMMLinearKernel import (
+    Fp8BlockScaledMMLinearKernel,
+)
 from vllm.model_executor.kernels.linear.scaled_mm.cutlass import (
     CutlassFP8ScaledMMLinearKernel,
+)
+from vllm.model_executor.kernels.linear.scaled_mm.deep_gemm import (
+    DeepGemmFp8BlockScaledMMKernel,
 )
 from vllm.model_executor.kernels.linear.scaled_mm.flashinfer import (
     FlashInferFP8ScaledMMLinearKernel,
@@ -30,20 +37,29 @@ from vllm.model_executor.kernels.linear.scaled_mm.ScaledMMLinearKernel import (
     Int8ScaledMMLinearKernel,
     Int8ScaledMMLinearLayerConfig,
 )
+from vllm.model_executor.layers.fusion.fused_act_quant import (
+    maybe_allocate_fp8_block_quant,
+)
 from vllm.model_executor.layers.fusion.quant_activation import (
     QuantizedActivation,
     as_quantized_activation,
     expose_input_quant_key,
+    index_quantized_activation,
 )
+from vllm.model_executor.layers.logits_processor import LogitsProcessor
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
+    kFp8Dynamic128Sym,
+    kFp8Static128BlockSym,
     kFp8StaticTensorSym,
     kNvfp4Dynamic,
 )
 from vllm.platforms import current_platform
+from vllm.utils.deep_gemm import DeepGemmQuantScaleFMT
 
 # The only backends that consume a pre-quantized activation.
 SUPPORTING = {
     CutlassFP8ScaledMMLinearKernel,
+    DeepGemmFp8BlockScaledMMKernel,
     FlashInferFP8ScaledMMLinearKernel,
     FlashInferCutlassNvFp4LinearKernel,
 }
@@ -73,6 +89,14 @@ def _probe(cls: type):
         obj.config = Int8ScaledMMLinearLayerConfig(
             is_static_input_scheme=True, is_channelwise=False, input_symmetric=True
         )
+    elif issubclass(cls, Fp8BlockScaledMMLinearKernel):
+        obj.config = FP8ScaledMMLinearLayerConfig(
+            weight_quant_key=kFp8Static128BlockSym,
+            activation_quant_key=kFp8Dynamic128Sym,
+            weight_shape=(128, 128),
+            input_dtype=torch.bfloat16,
+            out_dtype=torch.bfloat16,
+        )
     else:
         obj.config = FP8ScaledMMLinearLayerConfig(
             weight_quant_key=kFp8StaticTensorSym,
@@ -94,6 +118,33 @@ def _resolved_apply_weights(cls: type):
 def test_only_known_backends_support_prequantized_input():
     declarers = {c for c in _all_kernel_classes() if _probe(c).input_quant_key()}
     assert declarers == SUPPORTING
+
+
+def test_deepgemm_custom_op_hides_compiler_scale_storage_padding(monkeypatch):
+    q_input = torch.empty(3, 128)
+    input_scale = torch.empty_strided((4, 1), (1, 4), dtype=torch.int32)
+    weight = torch.empty(128, 128)
+    weight_scale = torch.empty(1, 1)
+    output = torch.empty(3, 128)
+    received_scale = None
+
+    def fake_fp8_gemm_nt(a, b, out, *, is_deep_gemm_e8m0_used):
+        nonlocal received_scale
+        received_scale = a[1]
+
+    monkeypatch.setattr(deep_gemm, "fp8_gemm_nt", fake_fp8_gemm_nt)
+    deep_gemm._fp8_gemm_nt_op(
+        q_input,
+        input_scale,
+        weight,
+        weight_scale,
+        output,
+        True,
+    )
+
+    assert received_scale is not None
+    assert received_scale.shape == (3, 1)
+    assert received_scale.stride() == input_scale.stride()
 
 
 def test_supporting_backend_declares_consume_via_helper():
@@ -129,3 +180,75 @@ def test_as_quantized_activation_validates_key():
         as_quantized_activation(qa, None)
     assert as_quantized_activation(torch.zeros(2, 4), kFp8StaticTensorSym) is None
     assert as_quantized_activation(qa, kFp8StaticTensorSym) is qa
+
+
+def test_shared_fp8_block_quant_allocation_requires_matching_consumers(monkeypatch):
+    monkeypatch.setattr(
+        DeepGemmQuantScaleFMT,
+        "from_oracle",
+        lambda: DeepGemmQuantScaleFMT.UE8M0,
+    )
+    x = torch.randn(5, 256, dtype=torch.bfloat16)
+    first = torch.nn.Module()
+    first.input_quant_key = kFp8Dynamic128Sym
+    second = torch.nn.Module()
+    second.input_quant_key = kFp8Dynamic128Sym
+
+    qa = maybe_allocate_fp8_block_quant(x, first, second)
+
+    assert qa is not None
+    assert qa.data.shape == x.shape
+    assert qa.scale.shape == (5, 1)
+    assert qa.scale.stride() == (1, 8)
+    assert qa.orig_shape == x.shape
+    assert qa.quant_key == kFp8Dynamic128Sym
+
+    second.input_quant_key = kFp8StaticTensorSym
+    assert maybe_allocate_fp8_block_quant(x, first, second) is None
+
+
+def test_index_fp8_block_activation_repacks_scale_layout():
+    data = torch.arange(30).view(5, 6)
+    scale = torch.empty_strided((5, 2), (1, 8), dtype=torch.int32)
+    scale.copy_(torch.arange(10).view(5, 2))
+    activation = QuantizedActivation(
+        data=data,
+        scale=scale,
+        orig_dtype=torch.bfloat16,
+        orig_shape=data.shape,
+        quant_key=kFp8Dynamic128Sym,
+    )
+
+    indexed = index_quantized_activation(activation, torch.tensor([4, 1, 3]))
+
+    assert isinstance(indexed, QuantizedActivation)
+    torch.testing.assert_close(indexed.data, data[[4, 1, 3]])
+    torch.testing.assert_close(indexed.scale, scale[[4, 1, 3]])
+    assert indexed.scale.stride() == (1, 4)
+    assert indexed.orig_shape == (3, 6)
+
+
+def test_logits_processor_forwards_quantized_activation(default_vllm_config):
+    activation = QuantizedActivation(
+        data=torch.empty(2, 4),
+        scale=torch.empty(2, 1),
+        orig_dtype=torch.bfloat16,
+        orig_shape=torch.Size([2, 4]),
+        quant_key=kFp8Dynamic128Sym,
+    )
+
+    class RecordingQuantMethod:
+        received = None
+
+        def apply(self, layer, hidden_states, bias=None):
+            self.received = hidden_states
+            return torch.ones(2, 3)
+
+    head = torch.nn.Module()
+    head.quant_method = RecordingQuantMethod()
+    head.tp_size = 1
+
+    logits = LogitsProcessor(3)(head, activation)
+
+    assert head.quant_method.received is activation
+    torch.testing.assert_close(logits, torch.ones(2, 3))

--- a/tests/kernels/core/test_fused_allreduce_gemma_rms_norm.py
+++ b/tests/kernels/core/test_fused_allreduce_gemma_rms_norm.py
@@ -18,8 +18,18 @@ from vllm.distributed.communication_op import tensor_model_parallel_all_reduce
 from vllm.model_executor.layers.fused_allreduce_gemma_rms_norm import (
     fused_allreduce_gemma_rms_norm,
 )
-from vllm.model_executor.layers.layernorm import GemmaRMSNorm
+from vllm.model_executor.layers.layernorm import GemmaRMSNorm, RMSNorm
+from vllm.model_executor.layers.quantization.utils.fp8_utils import (
+    per_token_group_quant_fp8_packed_for_deepgemm,
+)
+from vllm.model_executor.layers.quantization.utils.quant_utils import (
+    kFp8Dynamic128Sym,
+)
+from vllm.models.common.ops.fused_allreduce_rms_norm import (
+    fused_allreduce_rms_norm_fp8_quant,
+)
 from vllm.platforms import current_platform
+from vllm.utils.deep_gemm import DeepGemmQuantScaleFMT, is_deep_gemm_e8m0_used
 from vllm.utils.network_utils import get_open_port
 from vllm.utils.torch_utils import set_random_seed
 
@@ -103,6 +113,85 @@ def test_fused_allreduce_gemma_rms_norm(
             dtype,
             seed,
             eps,
+        ),
+        nprocs=world_size,
+        join=True,
+    )
+
+
+@ensure_current_vllm_config()
+def _worker_fused_ar_norm_group_fp8(
+    local_rank,
+    world_size,
+    port,
+    num_tokens,
+    hidden_size,
+    dtype,
+    seed,
+    eps,
+):
+    device = torch.device(f"cuda:{local_rank}")
+    torch.accelerator.set_device_index(device)
+    init_test_distributed_environment(
+        world_size, 1, local_rank, port, local_rank=local_rank
+    )
+    assert is_deep_gemm_e8m0_used()
+    DeepGemmQuantScaleFMT.init_oracle_cache()
+    assert DeepGemmQuantScaleFMT.from_oracle() == DeepGemmQuantScaleFMT.UE8M0
+
+    set_random_seed(seed)
+    norm = RMSNorm(hidden_size, eps=eps).cuda().to(dtype)
+    with torch.no_grad():
+        norm.weight.normal_(mean=1.0, std=0.1)
+
+    torch.manual_seed(seed + 7)
+    residual = torch.randn(num_tokens, hidden_size, dtype=dtype, device=device)
+    torch.manual_seed(seed + 1000 + local_rank)
+    partial = torch.randn(num_tokens, hidden_size, dtype=dtype, device=device)
+
+    reduced = tensor_model_parallel_all_reduce(partial.clone())
+    ref_out, ref_res = norm(reduced, residual.clone())
+
+    linear = torch.nn.Module()
+    linear.input_quant_key = kFp8Dynamic128Sym
+    out, res, quant = fused_allreduce_rms_norm_fp8_quant(
+        partial.clone(), residual.clone(), norm, linear
+    )
+    torch.accelerator.synchronize()
+
+    assert quant is not None
+    ref_quant, ref_scale = per_token_group_quant_fp8_packed_for_deepgemm(out, 128)
+    torch.testing.assert_close(out, ref_out, atol=2e-2, rtol=2e-2)
+    torch.testing.assert_close(res, ref_res, atol=2e-2, rtol=2e-2)
+    assert torch.equal(quant.data, ref_quant)
+    assert torch.equal(quant.scale, ref_scale)
+
+    cleanup_dist_env_and_memory()
+
+
+@pytest.mark.skipif(
+    not current_platform.is_device_capability_family(100),
+    reason="DeepGEMM packed UE8M0 scales require Blackwell",
+)
+@pytest.mark.parametrize("world_size", [2, 4])
+@pytest.mark.parametrize("num_tokens", [1, 17])
+def test_fused_allreduce_rms_norm_group_fp8(
+    world_size: int,
+    num_tokens: int,
+):
+    num_gpus = current_platform.device_count()
+    if num_gpus < world_size:
+        pytest.skip(f"Need >= {world_size} GPUs, have {num_gpus}")
+    spawn(
+        _worker_fused_ar_norm_group_fp8,
+        args=(
+            world_size,
+            str(get_open_port()),
+            num_tokens,
+            6144,
+            torch.bfloat16,
+            42,
+            1e-6,
         ),
         nprocs=world_size,
         join=True,

--- a/tests/kernels/moe/test_deepgemm.py
+++ b/tests/kernels/moe/test_deepgemm.py
@@ -34,6 +34,7 @@ from vllm.model_executor.layers.fused_moe.experts.triton_deep_gemm_moe import (
 from vllm.model_executor.layers.fused_moe.fused_moe import fused_experts
 from vllm.model_executor.layers.quantization.utils.fp8_utils import (
     per_token_group_quant_fp8,
+    per_token_group_quant_fp8_packed_for_deepgemm,
 )
 from vllm.utils.deep_gemm import (
     calc_diff,
@@ -184,6 +185,26 @@ def run_single_case(m, n, k, topk, num_experts, block_size):
     )
     diff = calc_diff(out_deepgemm, out_triton)
     assert diff < 0.001, f"Diff exceeded 1%: {diff}"
+    if deep_gemm_experts.input_quant_key is not None:
+        prequantized, prequantized_scale = (
+            per_token_group_quant_fp8_packed_for_deepgemm(tokens_bf16, block_size[1])
+        )
+        out_prequantized = deep_gemm_experts.apply(
+            hidden_states=tokens_bf16,
+            w1=w1,
+            w2=w2,
+            topk_weights=topk_weights,
+            topk_ids=topk_ids,
+            global_num_experts=num_experts,
+            activation=MoEActivation.SILU,
+            apply_router_weight_on_input=False,
+            expert_map=None,
+            prequantized_data=prequantized,
+            prequantized_scale=prequantized_scale,
+        )
+        torch.testing.assert_close(out_prequantized, out_deepgemm, rtol=0, atol=0)
+        return 2
+    return 1
 
 
 # Note: N <= 512 will disable the deepgemm path due to performance issues.
@@ -222,7 +243,7 @@ def test_deepgemm_vs_triton(m, n, k, topk, num_experts, monkeypatch, workspace_i
         if topk > num_experts:
             pytest.skip(f"topk={topk} > num_experts={num_experts}")
 
-        run_single_case(
+        expected_calls = run_single_case(
             m=m,
             n=n,
             k=k,
@@ -232,7 +253,7 @@ def test_deepgemm_vs_triton(m, n, k, topk, num_experts, monkeypatch, workspace_i
         )
 
         # ensure that the DeepGEMM path was indeed taken.
-        assert call_counter["cnt"] == 1, (
+        assert call_counter["cnt"] == expected_calls, (
             f"DeepGEMM path was not executed during the test. "
             f"Call counter: {call_counter['cnt']}"
         )

--- a/tests/kernels/moe/test_silu_mul_fp8_quant_deep_gemm.py
+++ b/tests/kernels/moe/test_silu_mul_fp8_quant_deep_gemm.py
@@ -150,7 +150,7 @@ def pack_scales(x: torch.Tensor, tokens_per_expert: torch.Tensor) -> torch.Tenso
 
     # Add i32_padding here so we can view it as a i32 tensor later on.
     i32_padding = round_up(G, 4) - G
-    ref_s_i8 = torch.empty((E, T, G + i32_padding), dtype=torch.uint8, device=DEVICE)
+    ref_s_i8 = torch.zeros((E, T, G + i32_padding), dtype=torch.uint8, device=DEVICE)
     for e in range(E):
         nt = tokens_per_expert[e].item()
         ref_s_i8[e, :nt, :G] = x[e, :nt].view(torch.int32) >> 23
@@ -184,7 +184,7 @@ def ref_with_scale_fmt(
     ]
 
     ref_q = torch.empty((E, T, H), dtype=fp8_dtype, device=DEVICE)
-    ref_s_f32 = torch.empty(
+    ref_s_f32 = torch.zeros(
         (E, T, cdiv(H, group_size)), dtype=torch.float32, device=DEVICE
     )
 

--- a/tests/kernels/test_fused_deepseek_v32_norm_rope.py
+++ b/tests/kernels/test_fused_deepseek_v32_norm_rope.py
@@ -27,6 +27,9 @@ rtol/atol=1e-2 (the tolerance the sibling deepseek_v4 fused-kernel test uses).
 import pytest
 import torch
 
+from vllm.model_executor.layers.quantization.utils.fp8_utils import (
+    per_token_group_quant_fp8_packed_for_deepgemm,
+)
 from vllm.models.deepseek_v32.common import kernels as K
 from vllm.platforms import current_platform
 
@@ -290,6 +293,67 @@ def test_fused_norm_rope_no_indexer(num_tokens: int):
     )
     # Shared layers reuse the previous indexer's top-k: buffer must be untouched.
     assert (topk == 7).all(), "topk buffer should be untouched on shared layer"
+
+
+@pytest.mark.parametrize("num_tokens", [1, 17, 512])
+def test_fused_norm_rope_quantizes_q_lora_for_deepgemm(num_tokens: int):
+    torch.manual_seed(7)
+    dev = "cuda"
+    max_pos = 8192
+    pos = torch.arange(num_tokens, device=dev, dtype=torch.int64)
+    q_c = torch.randn(num_tokens, Q_LORA, device=dev, dtype=torch.bfloat16)
+    kv_c = torch.randn(num_tokens, KV_LORA, device=dev, dtype=torch.bfloat16)
+    k_pe = torch.randn(num_tokens, ROPE_DIM, device=dev, dtype=torch.bfloat16)
+    qw = torch.randn(Q_LORA, device=dev, dtype=torch.bfloat16)
+    kvw = torch.randn(KV_LORA, device=dev, dtype=torch.bfloat16)
+    mla_cos_sin = make_cos_sin(max_pos, ROPE_DIM, dev)
+    mla_cache = torch.zeros(
+        1,
+        max_pos,
+        KV_LORA + ROPE_DIM,
+        device=dev,
+        dtype=torch.bfloat16,
+    )
+    slot = torch.arange(num_tokens, device=dev, dtype=torch.int64)
+    topk = torch.full((num_tokens, 2048), 7, device=dev, dtype=torch.int32)
+    q_quant = torch.empty_like(q_c, dtype=FP8)
+    num_scale_packs = (Q_LORA // 128 + 3) // 4
+    aligned_tokens = ((num_tokens + 3) // 4) * 4
+    q_scale = torch.empty_strided(
+        (num_tokens, num_scale_packs),
+        (1, aligned_tokens),
+        device=dev,
+        dtype=torch.int32,
+    )
+
+    q_out = K.fused_norm_rope(
+        pos,
+        q_c,
+        qw,
+        EPS,
+        kv_c,
+        kvw,
+        EPS,
+        k_pe,
+        mla_cos_sin,
+        None,
+        None,
+        None,
+        EPS,
+        None,
+        topk,
+        slot_mapping=slot,
+        mla_kv_cache=mla_cache,
+        has_indexer=False,
+        q_c_quant_out=q_quant,
+        q_c_quant_scale=q_scale,
+    )
+    ref_quant, ref_scale = per_token_group_quant_fp8_packed_for_deepgemm(q_out, 128)
+
+    torch.testing.assert_close(
+        q_quant.view(torch.uint8), ref_quant.view(torch.uint8), rtol=0, atol=0
+    )
+    torch.testing.assert_close(q_scale, ref_scale, rtol=0, atol=0)
 
 
 @pytest.mark.parametrize("num_tokens", [1, 4, 17, 512])

--- a/tests/models/deepseek_v32/test_sequence_parallel.py
+++ b/tests/models/deepseek_v32/test_sequence_parallel.py
@@ -7,8 +7,20 @@ from unittest.mock import Mock
 import torch
 from torch import nn
 
+from vllm.compilation.wrapper import TorchCompileWithNoGuardsWrapper
+from vllm.model_executor.layers.fusion.quant_activation import QuantizedActivation
+from vllm.model_executor.layers.quantization.utils.quant_utils import (
+    kFp8Dynamic128Sym,
+)
+from vllm.model_executor.models.deepseek_v2 import DeepseekV2MoE
 from vllm.models.deepseek_v32.nvidia import model as deepseek_v32_model
 from vllm.models.deepseek_v32.nvidia import mtp as deepseek_v32_mtp
+
+
+def test_nvidia_model_backbone_is_compile_free():
+    assert not issubclass(
+        deepseek_v32_model.DeepseekV32Model, TorchCompileWithNoGuardsWrapper
+    )
 
 
 class _IdentityNorm(nn.Module):
@@ -46,6 +58,22 @@ class _RecordingProjection(nn.Module):
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
         self.num_tokens = hidden_states.shape[0]
         return hidden_states[:, :2]
+
+
+class _RecordingMoE(DeepseekV2MoE):
+    def __init__(self) -> None:
+        nn.Module.__init__(self)
+        self.experts = nn.Module()
+        self.quantized_hidden_states = None
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        already_sequence_parallel: bool = False,
+        quantized_hidden_states: QuantizedActivation | None = None,
+    ) -> torch.Tensor:
+        self.quantized_hidden_states = quantized_hidden_states
+        return hidden_states
 
 
 class _SequenceParallelMTPBlock:
@@ -109,6 +137,34 @@ def test_decoder_layer_keeps_dense_states_sequence_sharded(monkeypatch):
     assert layer.mlp.num_tokens == 2
 
 
+def test_decoder_layer_passes_fused_quantization_to_moe(monkeypatch):
+    layer = object.__new__(deepseek_v32_model.DeepseekV32DecoderLayer)
+    nn.Module.__init__(layer)
+    layer.use_sequence_parallel = False
+    layer.input_layernorm = _IdentityNorm()
+    layer.post_attention_layernorm = _IdentityNorm()
+    layer.self_attn = _RecordingModule()
+    layer.mlp = _RecordingMoE()
+
+    hidden_states = torch.arange(6, dtype=torch.float32).view(3, 2)
+    quantized = QuantizedActivation(
+        data=torch.empty_like(hidden_states),
+        scale=torch.empty_strided((3, 1), (1, 4), dtype=torch.int32),
+        orig_dtype=hidden_states.dtype,
+        orig_shape=hidden_states.shape,
+        quant_key=kFp8Dynamic128Sym,
+    )
+    fused = Mock(return_value=(hidden_states + 1, hidden_states + 2, quantized))
+    monkeypatch.setattr(deepseek_v32_model, "fused_allreduce_rms_norm_fp8_quant", fused)
+
+    output, residual = layer(torch.arange(3), hidden_states, residual=None)
+
+    assert layer.mlp.quantized_hidden_states is quantized
+    assert fused.call_args.args[3] is layer.mlp.experts
+    torch.testing.assert_close(output, hidden_states + 1)
+    torch.testing.assert_close(residual, hidden_states + 2)
+
+
 def test_mtp_projects_sequence_shard_and_restores_full_output(monkeypatch):
     layer = object.__new__(deepseek_v32_mtp.DeepseekV32MultiTokenPredictorLayer)
     nn.Module.__init__(layer)
@@ -146,3 +202,59 @@ def test_mtp_projects_sequence_shard_and_restores_full_output(monkeypatch):
     torch.testing.assert_close(hidden_states, expected)
     torch.testing.assert_close(recycled_hidden_states, expected)
     norm.assert_called_once()
+
+
+def test_mtp_fuses_final_reduce_norm_quant_for_logits(monkeypatch):
+    layer = object.__new__(deepseek_v32_mtp.DeepseekV32MultiTokenPredictorLayer)
+    nn.Module.__init__(layer)
+    layer.enorm = _IdentityNorm()
+    layer.hnorm = _IdentityNorm()
+    layer.eh_proj = _RecordingProjection()
+    layer._eh_plan = None
+    mtp_block = _SequenceParallelMTPBlock()
+    mtp_block.use_sequence_parallel = False
+    object.__setattr__(layer, "mtp_block", mtp_block)
+    norm = _IdentityNorm()
+    head = nn.Module()
+    object.__setattr__(layer, "shared_head", SimpleNamespace(norm=norm, head=head))
+
+    monkeypatch.setattr(
+        deepseek_v32_mtp,
+        "fused_eh_norm",
+        lambda positions, inputs_embeds, previous_hidden_states, *args: torch.cat(
+            [inputs_embeds, previous_hidden_states], dim=-1
+        ),
+    )
+    monkeypatch.setattr(deepseek_v32_mtp, "run_glm52_plan", lambda *args: None)
+
+    quantized = QuantizedActivation(
+        data=torch.empty(3, 2),
+        scale=torch.empty_strided((3, 1), (1, 4), dtype=torch.int32),
+        orig_dtype=torch.float32,
+        orig_shape=torch.Size([3, 2]),
+        quant_key=kFp8Dynamic128Sym,
+    )
+    fused = Mock(return_value=(torch.full((3, 2), 7.0), torch.empty(3, 2), quantized))
+    monkeypatch.setattr(deepseek_v32_mtp, "fused_allreduce_rms_norm_fp8_quant", fused)
+
+    inputs_embeds = torch.arange(6, dtype=torch.float32).view(3, 2)
+    logits_input, recycled_hidden_states = layer(
+        input_ids=torch.zeros(3, dtype=torch.long),
+        positions=torch.arange(3),
+        previous_hidden_states=torch.zeros_like(inputs_embeds),
+        inputs_embeds=inputs_embeds,
+    )
+
+    assert logits_input is quantized
+    torch.testing.assert_close(recycled_hidden_states, torch.full((3, 2), 7.0))
+    assert fused.call_args.args[2:] == (norm, head)
+
+    fused.return_value = (torch.full((3, 2), 9.0), torch.empty(3, 2), None)
+    logits_input, recycled_hidden_states = layer(
+        input_ids=torch.zeros(3, dtype=torch.long),
+        positions=torch.arange(3),
+        previous_hidden_states=torch.zeros_like(inputs_embeds),
+        inputs_embeds=inputs_embeds,
+    )
+    torch.testing.assert_close(logits_input, torch.full((3, 2), 9.0))
+    assert logits_input is recycled_hidden_states

--- a/tests/models/registry.py
+++ b/tests/models/registry.py
@@ -1644,6 +1644,10 @@ _SPECULATIVE_DECODING_EXAMPLE_MODELS = {
         speculative_model="luccafong/deepseek_mtp_draft_random",
         trust_remote_code=True,
     ),
+    "DeepseekV32MTPModel": _HfExamplesInfo(
+        "deepseek-ai/DeepSeek-V3.2-Exp",
+        speculative_model="deepseek-ai/DeepSeek-V3.2-Exp",
+    ),
     "DeepSeekV4MTPModel": _HfExamplesInfo(
         "deepseek-ai/DeepSeek-V4-Flash",
         speculative_model="deepseek-ai/DeepSeek-V4-Flash",

--- a/tests/v1/spec_decode/test_llm_base_proposer_sampling.py
+++ b/tests/v1/spec_decode/test_llm_base_proposer_sampling.py
@@ -78,6 +78,7 @@ def test_compute_probs_and_sample_next_token_uses_fp64_exponential_race():
     ("architecture", "expected"),
     [
         ("DeepSeekMTPModel", True),
+        ("DeepseekV32MTPModel", True),
         ("KimiK3MTPModel", True),
         ("MiniMaxM3ForCausalLM", False),
     ],

--- a/vllm/compilation/passes/fusion/allreduce_rms_fusion.py
+++ b/vllm/compilation/passes/fusion/allreduce_rms_fusion.py
@@ -179,6 +179,7 @@ def _select_flashinfer_allreduce_use_oneshot(
 if flashinfer_comm is not None:
     from vllm.distributed.device_communicators.flashinfer_all_reduce import (
         destroy_fi_ar_workspace,
+        get_fi_ar_packed_quant_workspace,
         get_fi_ar_quant_workspace,
         get_fi_ar_workspace,
     )
@@ -200,6 +201,7 @@ if flashinfer_comm is not None:
         scale_out: torch.Tensor | None = None,
         scale_factor: torch.Tensor | None = None,
         weight_bias: float = 0.0,
+        block_quant_group_size: int = 0,
     ) -> None:
         # handle transformers backend passing outer batch dim.
         if allreduce_in.dim() != 2:
@@ -222,13 +224,32 @@ if flashinfer_comm is not None:
 
         # Select workspace based on pattern: quant patterns use the quant
         # workspace, non-quant patterns use the primary workspace.
-        is_quant_pattern = pattern_code in (
+        packed_quant_patterns = [
+            pattern
+            for name in (
+                "kARResidualRMSNormPerTokenGroupFP8PackedQuant",
+                "kARResidualRMSNormOutPerTokenGroupFP8PackedQuant",
+            )
+            if (pattern := getattr(ar_fusion_patterns, name, None)) is not None
+        ]
+        quant_patterns = [
             ar_fusion_patterns.kARResidualRMSNormFP8Quant,
             ar_fusion_patterns.kARResidualRMSNormFP4Quant,
+        ]
+        quant_patterns.extend(
+            pattern
+            for name in (
+                "kARResidualRMSNormDynamicFP8Quant",
+                "kARResidualRMSNormOutDynamicFP8Quant",
+            )
+            if (pattern := getattr(ar_fusion_patterns, name, None)) is not None
         )
-        get_workspace_fn = (
-            get_fi_ar_quant_workspace if is_quant_pattern else get_fi_ar_workspace
-        )
+        if pattern_code in packed_quant_patterns:
+            get_workspace_fn = get_fi_ar_packed_quant_workspace
+        elif pattern_code in quant_patterns:
+            get_workspace_fn = get_fi_ar_quant_workspace
+        else:
+            get_workspace_fn = get_fi_ar_workspace
         workspace = get_workspace_fn(
             world_size=world_size,
             rank=get_tensor_model_parallel_rank(),
@@ -262,6 +283,11 @@ if flashinfer_comm is not None:
         if workspace.backend in ("trtllm", "mnnvl"):
             layout_code = flashinfer_comm.QuantizationSFLayout.SWIZZLED_128x4
 
+        block_quant_kwargs = (
+            {"block_quant_group_size": block_quant_group_size}
+            if block_quant_group_size
+            else {}
+        )
         flashinfer_comm.allreduce_fusion(
             input=allreduce_in,
             workspace=workspace,
@@ -280,6 +306,7 @@ if flashinfer_comm is not None:
             use_oneshot=use_oneshot,
             fp32_acc=fp32_acc,
             weight_bias=weight_bias,
+            **block_quant_kwargs,
             # The one-shot Lamport all-reduce signals PDL completion before its
             # output buffer is committed when trigger_completion_at_end is
             # False, so the next PDL-launched kernel can read the uninitialized
@@ -308,6 +335,7 @@ if flashinfer_comm is not None:
         scale_out: torch.Tensor | None = None,
         scale_factor: torch.Tensor | None = None,
         weight_bias: float = 0.0,
+        block_quant_group_size: int = 0,
     ) -> None:
         pass
 

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -336,6 +336,7 @@ class SpeculativeConfig:
     @staticmethod
     def hf_config_override(hf_config: PretrainedConfig) -> PretrainedConfig:
         initial_architecture = hf_config.architectures[0]
+        use_sparse_mtp = hf_config.model_type == "glm_moe_dsa"
         if hf_config.model_type in (
             "deepseek_v3",
             "deepseek_v32",
@@ -345,7 +346,12 @@ class SpeculativeConfig:
         if hf_config.model_type == "deepseek_mtp":
             n_predict = getattr(hf_config, "num_nextn_predict_layers", None)
             hf_config.update(
-                {"n_predict": n_predict, "architectures": ["DeepSeekMTPModel"]}
+                {
+                    "n_predict": n_predict,
+                    "architectures": [
+                        "DeepseekV32MTPModel" if use_sparse_mtp else "DeepSeekMTPModel"
+                    ],
+                }
             )
         if hf_config.model_type == "deepseek_v4":
             hf_config.model_type = "deepseek_mtp"

--- a/vllm/distributed/device_communicators/flashinfer_all_reduce.py
+++ b/vllm/distributed/device_communicators/flashinfer_all_reduce.py
@@ -40,6 +40,9 @@ _fi_ar_workspace = None
 # allreduce backend or a fallback backend when the primary workspace is not
 # available on the current topology.
 _fi_ar_quant_workspace = None
+# TensorRT-LLM-only workspace for packed per-token-group FP8 patterns. MNNVL
+# does not currently implement the DeepGEMM UE8M0 scale layout.
+_fi_ar_packed_quant_workspace = None
 _fi_ar_workspace_groups: dict[int, ProcessGroup] = {}
 
 
@@ -270,27 +273,75 @@ def get_fi_ar_quant_workspace(
     return _fi_ar_quant_workspace
 
 
+def get_fi_ar_packed_quant_workspace(
+    world_size: int,
+    rank: int,
+    max_token_num: int,
+    hidden_dim: int,
+    dtype: torch.dtype,
+    group: ProcessGroup,
+):
+    """Return a TensorRT-LLM workspace for packed group-FP8 fusion."""
+    global _fi_ar_packed_quant_workspace
+    if _fi_ar_packed_quant_workspace is not None:
+        return _fi_ar_packed_quant_workspace
+
+    if get_node_count() > 1:
+        logger.warning_once(
+            "FlashInfer packed group-FP8 allreduce fusion is unavailable for "
+            "multi-node tensor parallelism; using the non-quantized fusion."
+        )
+        return None
+
+    for workspace in (_fi_ar_workspace, _fi_ar_quant_workspace):
+        if workspace is not None and workspace.backend == "trtllm":
+            _fi_ar_packed_quant_workspace = workspace
+            return workspace
+
+    _fi_ar_packed_quant_workspace = _create_workspace(
+        "trtllm", world_size, rank, max_token_num, hidden_dim, dtype, group
+    )
+    if _fi_ar_packed_quant_workspace is not None:
+        logger.info_once(
+            "Initialized FlashInfer packed group-FP8 allreduce fusion workspace"
+        )
+    return _fi_ar_packed_quant_workspace
+
+
 _fi_ar_workspace_lock = threading.Lock()
 
 
 def destroy_fi_ar_workspace():
-    global _fi_ar_workspace, _fi_ar_quant_workspace
+    global _fi_ar_workspace, _fi_ar_packed_quant_workspace, _fi_ar_quant_workspace
     with _fi_ar_workspace_lock:
-        is_alias = _fi_ar_workspace is _fi_ar_quant_workspace
+        workspaces = {
+            id(workspace): workspace
+            for workspace in (
+                _fi_ar_workspace,
+                _fi_ar_quant_workspace,
+                _fi_ar_packed_quant_workspace,
+            )
+            if workspace is not None
+        }
+        for workspace in workspaces.values():
+            workspace.destroy()
 
-        if _fi_ar_workspace is not None:
-            _fi_ar_workspace.destroy()
-        if _fi_ar_quant_workspace is not None and not is_alias:
-            _fi_ar_quant_workspace.destroy()
-
-        _fi_ar_workspace = _fi_ar_quant_workspace = None
+        _fi_ar_workspace = None
+        _fi_ar_quant_workspace = None
+        _fi_ar_packed_quant_workspace = None
         _fi_ar_workspace_groups.clear()
 
 
 def _fi_ar_workspaces_for_group(group: ProcessGroup) -> list[Any]:
-    workspaces = [_fi_ar_workspace]
-    if _fi_ar_quant_workspace is not _fi_ar_workspace:
-        workspaces.append(_fi_ar_quant_workspace)
+    workspaces = {
+        id(workspace): workspace
+        for workspace in (
+            _fi_ar_workspace,
+            _fi_ar_quant_workspace,
+            _fi_ar_packed_quant_workspace,
+        )
+        if workspace is not None
+    }.values()
 
     group_workspaces = []
     for workspace in workspaces:

--- a/vllm/model_executor/kernels/linear/scaled_mm/BlockScaledMMLinearKernel.py
+++ b/vllm/model_executor/kernels/linear/scaled_mm/BlockScaledMMLinearKernel.py
@@ -8,6 +8,10 @@ from typing import ClassVar
 import torch
 from typing_extensions import Self
 
+from vllm.model_executor.layers.fusion.quant_activation import (
+    QuantizedActivation,
+    as_quantized_activation,
+)
 from vllm.model_executor.layers.quantization.input_quant_fp8 import QuantFP8
 from vllm.model_executor.layers.quantization.utils.fp8_utils import (
     process_fp8_weight_block_strategy,
@@ -97,7 +101,7 @@ class Fp8BlockScaledMMLinearKernel(
     def apply_weights(
         self,
         layer: torch.nn.Module,
-        x: torch.Tensor,
+        x: torch.Tensor | QuantizedActivation,
         bias: torch.Tensor | None = None,
         **kwargs,
     ) -> torch.Tensor:
@@ -112,15 +116,20 @@ class Fp8BlockScaledMMLinearKernel(
         input_scale = params.input_scale
         scale_up = params.input_scale_ub
 
-        # View input as 2D matrix for fp8 methods
-        input_2d = x.view(-1, x.shape[-1])
-        output_shape = [*x.shape[:-1], weight.shape[0]]
+        qa = as_quantized_activation(x, self.input_quant_key())
+        if qa is not None:
+            q_input, input_scale = qa.data, qa.scale
+            output_shape = [*qa.orig_shape[:-1], weight.shape[0]]
+        else:
+            assert isinstance(x, torch.Tensor)
+            input_2d = x.view(-1, x.shape[-1])
+            output_shape = [*x.shape[:-1], weight.shape[0]]
 
-        if self.apply_input_quant:
+        if qa is None and self.apply_input_quant:
             q_input, input_scale = self.quant_fp8(
                 input_2d, input_scale, scale_up, use_triton=self.use_triton
             )
-        else:
+        elif qa is None:
             q_input = input_2d
             # Provide a concrete placeholder so apply_block_scaled_mm args are
             # always Tensors. Subclasses with apply_input_quant=False must not

--- a/vllm/model_executor/kernels/linear/scaled_mm/deep_gemm.py
+++ b/vllm/model_executor/kernels/linear/scaled_mm/deep_gemm.py
@@ -11,6 +11,8 @@ from vllm.model_executor.layers.quantization.utils.fp8_utils import (
 )
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     GroupShape,
+    QuantKey,
+    kFp8Dynamic128Sym,
 )
 from vllm.model_executor.utils import replace_parameter
 from vllm.platforms import current_platform
@@ -42,6 +44,11 @@ class DeepGemmFp8BlockScaledMMKernel(Fp8BlockScaledMMLinearKernel):
             tma_aligned_scales=envs.VLLM_USE_DEEP_GEMM_TMA_ALIGNED_SCALES,
             column_major_scales=True,
         )
+
+    def input_quant_key(self) -> QuantKey | None:
+        if self.config.activation_quant_key == kFp8Dynamic128Sym:
+            return kFp8Dynamic128Sym
+        return None
 
     @classmethod
     def is_supported(cls, compute_capability=None):
@@ -131,6 +138,11 @@ def _fp8_gemm_nt_op(
     output: torch.Tensor,
     use_deep_gemm_e8m0: bool,
 ) -> None:
+    if use_deep_gemm_e8m0 and input_scale.dtype == torch.int32:
+        logical_rows = q_input.shape[0]
+        aligned_rows = (logical_rows + 3) // 4 * 4
+        if input_scale.shape[0] == aligned_rows and aligned_rows != logical_rows:
+            input_scale = input_scale[:logical_rows]
     fp8_gemm_nt(
         (q_input, input_scale),
         (weight, weight_scale),

--- a/vllm/model_executor/layers/fused_allreduce_gemma_rms_norm.py
+++ b/vllm/model_executor/layers/fused_allreduce_gemma_rms_norm.py
@@ -52,6 +52,7 @@ except (ImportError, AttributeError):
 _FI_SUPPORTED_DTYPES = (torch.bfloat16, torch.float16)
 
 
+@torch.compiler.assume_constant_result
 def _max_token_num(tp_size: int, hidden_size: int, dtype: torch.dtype) -> int | None:
     """Workspace token budget for flashinfer fused all-reduce, or None if the
     current world size / device is unsupported. Mirrors ``FlashInferAllReduce``."""
@@ -62,6 +63,26 @@ def _max_token_num(tp_size: int, hidden_size: int, dtype: torch.dtype) -> int | 
         return None
     element_size = torch.tensor([], dtype=dtype).element_size()
     return int(max_size_mb * MiB) // (hidden_size * element_size)
+
+
+@torch.compiler.assume_constant_result
+def _has_flashinfer_workspace(
+    tp_size: int,
+    max_token_num: int,
+    hidden_size: int,
+    dtype: torch.dtype,
+) -> bool:
+    return (
+        get_fi_ar_workspace(
+            world_size=tp_size,
+            rank=get_tensor_model_parallel_rank(),
+            max_token_num=max_token_num,
+            hidden_dim=hidden_size,
+            dtype=dtype,
+            group=get_tp_group().cpu_group,
+        )
+        is not None
+    )
 
 
 def _can_use_flashinfer(hidden_states: torch.Tensor, tp_size: int) -> tuple[bool, int]:
@@ -87,15 +108,9 @@ def _can_use_flashinfer(hidden_states: torch.Tensor, tp_size: int) -> tuple[bool
 
     # Lazily create / fetch the (globally cached) workspace; returns None on
     # GPUs without NVSwitch, in which case we fall back gracefully.
-    workspace = get_fi_ar_workspace(
-        world_size=tp_size,
-        rank=get_tensor_model_parallel_rank(),
-        max_token_num=max_token_num,
-        hidden_dim=hidden_size,
-        dtype=hidden_states.dtype,
-        group=get_tp_group().cpu_group,
-    )
-    if workspace is None:
+    if not _has_flashinfer_workspace(
+        tp_size, max_token_num, hidden_size, hidden_states.dtype
+    ):
         return False, 0
     return True, max_token_num
 

--- a/vllm/model_executor/layers/fused_moe/deep_gemm_utils.py
+++ b/vllm/model_executor/layers/fused_moe/deep_gemm_utils.py
@@ -187,6 +187,7 @@ def _fwd_kernel_ep_scatter_2(
     SCALE_HIDDEN_SIZE: tl.constexpr,
     SCALE_HIDDEN_SIZE_PAD: tl.constexpr,
     PACK_UE8M0: tl.constexpr,
+    INPUT_PACKED_UE8M0: tl.constexpr,
     SCALE_PACKED_SIZE: tl.constexpr,
     SCALE_PACKED_SIZE_PAD: tl.constexpr,
 ):
@@ -210,28 +211,37 @@ def _fwd_kernel_ep_scatter_2(
         to_copy = tl.load(recv_x + token_id * recv_x_stride0 + offset_in, mask=mask)
 
         if PACK_UE8M0:
-            # Pack 4 UE8M0 bytes into one int32 (byte j = group 4*pk+j).
             base_s = recv_x_scale + token_id * recv_x_scale_stride0
-            g0, g1 = offs_pk * 4, offs_pk * 4 + 1
-            g2, g3 = offs_pk * 4 + 2, offs_pk * 4 + 3
-            b0 = tl.load(
-                base_s + g0 * recv_x_scale_stride1, mask=g0 < SCALE_HIDDEN_SIZE
-            )
-            b1 = tl.load(
-                base_s + g1 * recv_x_scale_stride1, mask=g1 < SCALE_HIDDEN_SIZE
-            )
-            b2 = tl.load(
-                base_s + g2 * recv_x_scale_stride1, mask=g2 < SCALE_HIDDEN_SIZE
-            )
-            b3 = tl.load(
-                base_s + g3 * recv_x_scale_stride1, mask=g3 < SCALE_HIDDEN_SIZE
-            )
-            packed_s = (
-                b0.to(tl.int32)
-                | (b1.to(tl.int32) << 8)
-                | (b2.to(tl.int32) << 16)
-                | (b3.to(tl.int32) << 24)
-            )
+            if INPUT_PACKED_UE8M0:
+                packed_s = tl.load(
+                    base_s + offs_pk * recv_x_scale_stride1, mask=mask_pk
+                )
+            else:
+                # Pack 4 UE8M0 bytes into one int32 (byte j = group 4*pk+j).
+                g0, g1 = offs_pk * 4, offs_pk * 4 + 1
+                g2, g3 = offs_pk * 4 + 2, offs_pk * 4 + 3
+                b0 = tl.load(
+                    base_s + g0 * recv_x_scale_stride1,
+                    mask=g0 < SCALE_HIDDEN_SIZE,
+                )
+                b1 = tl.load(
+                    base_s + g1 * recv_x_scale_stride1,
+                    mask=g1 < SCALE_HIDDEN_SIZE,
+                )
+                b2 = tl.load(
+                    base_s + g2 * recv_x_scale_stride1,
+                    mask=g2 < SCALE_HIDDEN_SIZE,
+                )
+                b3 = tl.load(
+                    base_s + g3 * recv_x_scale_stride1,
+                    mask=g3 < SCALE_HIDDEN_SIZE,
+                )
+                packed_s = (
+                    b0.to(tl.int32)
+                    | (b1.to(tl.int32) << 8)
+                    | (b2.to(tl.int32) << 16)
+                    | (b3.to(tl.int32) << 24)
+                )
         else:
             to_copy_s = tl.load(
                 recv_x_scale + token_id * recv_x_scale_stride0 + offset_in_s,
@@ -286,6 +296,7 @@ def ep_scatter(
     align_m: int = 128,
     block_size: int = 128,
     pack_ue8m0: bool = False,
+    input_packed_ue8m0: bool = False,
 ):
     # BLOCK_E is the m_indices fill-loop tile (masked), independent of align_m.
     BLOCK_E = 128
@@ -299,7 +310,9 @@ def ep_scatter(
     assert m_indices.shape[0] % align_m == 0
     assert expert_start_loc.shape[0] == num_experts
 
-    # pack_ue8m0: scatter packs 4 UE8M0 bytes per int32; else copies scales as-is.
+    assert not input_packed_ue8m0 or pack_ue8m0
+    # pack_ue8m0: scatter writes 4 UE8M0 bytes per int32; input may already
+    # have that representation or be packed by the scatter kernel.
     scale_hidden_size = hidden_size // BLOCK_D
     scale_packed_size = (scale_hidden_size + 3) // 4 if pack_ue8m0 else 1
 
@@ -346,6 +359,7 @@ def ep_scatter(
         SCALE_HIDDEN_SIZE=scale_hidden_size,
         SCALE_HIDDEN_SIZE_PAD=triton.next_power_of_2(scale_hidden_size),
         PACK_UE8M0=pack_ue8m0,
+        INPUT_PACKED_UE8M0=input_packed_ue8m0,
         SCALE_PACKED_SIZE=scale_packed_size,
         SCALE_PACKED_SIZE_PAD=triton.next_power_of_2(scale_packed_size),
     )
@@ -493,9 +507,10 @@ def deepgemm_moe_permute(
     if aq_out is None:
         aq_out = torch.empty((M_sum, H), device=device, dtype=aq.dtype)
 
-    # uint8 UE8M0 (MXFP8) -> scatter packs into DeepGEMM's int32 MN-major
-    # TMA-aligned layout; float32 (FP8/FP4) scattered row-major as-is.
-    pack_ue8m0 = aq_scale.dtype == torch.uint8
+    # uint8 UE8M0 (MXFP8) is packed by scatter; int32 UE8M0 is already packed;
+    # float32 FP8/FP4 scales are scattered row-major as-is.
+    input_packed_ue8m0 = aq_scale.dtype == torch.int32
+    pack_ue8m0 = aq_scale.dtype == torch.uint8 or input_packed_ue8m0
     sf_k = H // block_k
     if pack_ue8m0:
         packed_sf_k = (sf_k + 3) // 4
@@ -544,6 +559,7 @@ def deepgemm_moe_permute(
         align_m=align_used,
         block_size=block_k,
         pack_ue8m0=pack_ue8m0,
+        input_packed_ue8m0=input_packed_ue8m0,
     )
 
     return aq_out, aq_scale_out, expert_ids, inv_perm, align_used

--- a/vllm/model_executor/layers/fused_moe/experts/deep_gemm_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/deep_gemm_moe.py
@@ -148,6 +148,15 @@ class DeepGemmExperts(mk.FusedMoEExpertsModular):
             quant_config.gemm1_beta if quant_config.gemm1_beta is not None else 0.0
         )
 
+    @property
+    def input_quant_key(self) -> QuantKey | None:
+        if (
+            self.mxfp8
+            or DeepGemmQuantScaleFMT.from_oracle() != DeepGemmQuantScaleFMT.UE8M0
+        ):
+            return None
+        return kFp8Dynamic128Sym
+
     @staticmethod
     def activation_format() -> mk.FusedMoEActivationFormat:
         return mk.FusedMoEActivationFormat.Standard

--- a/vllm/model_executor/layers/fused_moe/experts/triton_deep_gemm_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/triton_deep_gemm_moe.py
@@ -16,6 +16,7 @@ from vllm.model_executor.layers.fused_moe.experts.deep_gemm_moe import (
 )
 from vllm.model_executor.layers.fused_moe.experts.fallback import FallbackExperts
 from vllm.model_executor.layers.fused_moe.experts.triton_moe import TritonExperts
+from vllm.model_executor.layers.quantization.utils.quant_utils import QuantKey
 from vllm.utils.deep_gemm import (
     is_deep_gemm_e8m0_used,
 )
@@ -29,6 +30,12 @@ class TritonOrDeepGemmExperts(FallbackExperts):
             experts=DeepGemmExperts(moe_config, quant_config),
             fallback_experts=TritonExperts(moe_config, quant_config),
         )
+
+    @property
+    def input_quant_key(self) -> QuantKey | None:
+        if is_deep_gemm_e8m0_used():
+            return self.experts.input_quant_key
+        return None
 
     @staticmethod
     def get_clses() -> tuple[

--- a/vllm/model_executor/layers/fused_moe/fused_moe_method_base.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe_method_base.py
@@ -16,6 +16,7 @@ from vllm.model_executor.layers.fused_moe.config import (
 from vllm.model_executor.layers.quantization.base_config import (
     QuantizeMethodBase,
 )
+from vllm.model_executor.layers.quantization.utils.quant_utils import QuantKey
 
 if TYPE_CHECKING:
     from vllm.model_executor.layers.fused_moe.routed_experts import RoutedExperts
@@ -36,6 +37,10 @@ class FusedMoEMethodBase(QuantizeMethodBase):
         # NOTE(rob): temporary attribute to indicate support for
         # completed migration to the new internal MK interface.
         return self.moe_kernel is not None
+
+    @property
+    def input_quant_key(self) -> QuantKey | None:
+        return None
 
     @property
     def mk_can_overlap_shared_experts(self) -> bool:

--- a/vllm/model_executor/layers/fused_moe/modular_kernel.py
+++ b/vllm/model_executor/layers/fused_moe/modular_kernel.py
@@ -261,6 +261,10 @@ class FusedMoEPrepareAndFinalizeModular(FusedMoEPrepareAndFinalize):
     described above for the Modular case.
     """
 
+    def supports_prequantized_input(self) -> bool:
+        """Whether prepare may be bypassed with matching quantized input."""
+        return False
+
     @abstractmethod
     def prepare(
         self,
@@ -527,6 +531,11 @@ class FusedMoEExperts(ABC):
         Sample subclasses that override are AITER and FlashInfer CUTLASS.
         """
         return False
+
+    @property
+    def input_quant_key(self) -> QuantKey | None:
+        """Quantization contract accepted from an upstream fused producer."""
+        return None
 
     @staticmethod
     @abstractmethod
@@ -1433,6 +1442,8 @@ class FusedMoEKernelModularImpl:
         apply_router_weight_on_input: bool = False,
         shared_experts: SharedExperts | None = None,
         shared_experts_input: torch.Tensor | None = None,
+        prequantized_data: torch.Tensor | None = None,
+        prequantized_scale: torch.Tensor | None = None,
     ) -> torch.Tensor:
         """
         This function computes a Mixture of Experts (MoE) layer using two sets
@@ -1468,14 +1479,24 @@ class FusedMoEKernelModularImpl:
         if global_num_experts == -1:
             global_num_experts = local_num_experts
 
-        a1q, a1q_scale, expert_tokens_meta, topk_ids, topk_weights = self._prepare(
-            hidden_states,
-            topk_weights,
-            topk_ids,
-            global_num_experts,
-            expert_map,
-            apply_router_weight_on_input,
-        )
+        if prequantized_data is None:
+            assert prequantized_scale is None
+            a1q, a1q_scale, expert_tokens_meta, topk_ids, topk_weights = self._prepare(
+                hidden_states,
+                topk_weights,
+                topk_ids,
+                global_num_experts,
+                expert_map,
+                apply_router_weight_on_input,
+            )
+        else:
+            assert prequantized_scale is not None
+            assert self.prepare_finalize.supports_prequantized_input()
+            assert not apply_router_weight_on_input
+            assert prequantized_data.shape == hidden_states.shape
+            a1q = prequantized_data
+            a1q_scale = prequantized_scale
+            expert_tokens_meta = None
 
         # Stash the original unquantized hidden states on the LoRA context
         # so apply_w13_lora sees correct-magnitude activations instead of
@@ -1633,6 +1654,15 @@ class FusedMoEKernel:
         return self.impl.fused_experts
 
     @property
+    def input_quant_key(self) -> QuantKey | None:
+        if (
+            isinstance(self.impl, FusedMoEKernelModularImpl)
+            and self.impl.prepare_finalize.supports_prequantized_input()
+        ):
+            return self.fused_experts.input_quant_key
+        return None
+
+    @property
     def moe_config(self) -> FusedMoEConfig:
         return self.fused_experts.moe_config
 
@@ -1702,6 +1732,8 @@ class FusedMoEKernel:
         apply_router_weight_on_input: bool,
         shared_experts: SharedExperts | None = None,
         shared_experts_input: torch.Tensor | None = None,
+        prequantized_data: torch.Tensor | None = None,
+        prequantized_scale: torch.Tensor | None = None,
     ) -> torch.Tensor:
         assert isinstance(self.impl, FusedMoEKernelModularImpl)
         return self.impl.apply(
@@ -1716,4 +1748,6 @@ class FusedMoEKernel:
             apply_router_weight_on_input=apply_router_weight_on_input,
             shared_experts=shared_experts,
             shared_experts_input=shared_experts_input,
+            prequantized_data=prequantized_data,
+            prequantized_scale=prequantized_scale,
         )

--- a/vllm/model_executor/layers/fused_moe/prepare_finalize/no_dp_ep.py
+++ b/vllm/model_executor/layers/fused_moe/prepare_finalize/no_dp_ep.py
@@ -38,6 +38,9 @@ def _quantize_input(
 
 
 class MoEPrepareAndFinalizeNoDPEPModular(mk.FusedMoEPrepareAndFinalizeModular):
+    def supports_prequantized_input(self) -> bool:
+        return True
+
     @property
     def activation_format(self) -> mk.FusedMoEActivationFormat:
         return mk.FusedMoEActivationFormat.Standard

--- a/vllm/model_executor/layers/fused_moe/routed_experts.py
+++ b/vllm/model_executor/layers/fused_moe/routed_experts.py
@@ -1230,6 +1230,30 @@ class RoutedExperts(PluggableLayer):
             shared_experts_input=shared_experts_input,
         )
 
+    def forward_modular_prequantized(
+        self,
+        x: torch.Tensor,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+        data: torch.Tensor,
+        scale: torch.Tensor,
+        shared_experts: "SharedExperts | None" = None,
+        shared_experts_input: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        assert not self.quant_method.is_monolithic
+        apply_prequantized = getattr(self.quant_method, "apply_prequantized", None)
+        assert apply_prequantized is not None
+        return apply_prequantized(
+            layer=self,
+            x=x,
+            topk_weights=topk_weights,
+            topk_ids=topk_ids,
+            shared_experts=shared_experts,
+            shared_experts_input=shared_experts_input,
+            data=data,
+            scale=scale,
+        )
+
     def forward_monolithic(
         self,
         x: torch.Tensor,

--- a/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
+++ b/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
@@ -44,6 +44,8 @@ from vllm.model_executor.layers.fused_moe.runner.shared_experts import (
     SharedExperts,
     SharedExpertsOrder,
 )
+from vllm.model_executor.layers.fusion.quant_activation import QuantizedActivation
+from vllm.model_executor.layers.quantization.utils.quant_utils import QuantKey
 from vllm.platforms import current_platform
 from vllm.utils.torch_utils import (
     _USE_LAYERNAME,
@@ -117,6 +119,8 @@ def _moe_forward(
     router_logits: torch.Tensor,
     shared_experts_input: torch.Tensor | None,
     input_ids: torch.Tensor | None,
+    prequantized_data: torch.Tensor | None,
+    prequantized_scale: torch.Tensor | None,
     layer_name: _layer_name_type,
     hidden_dim_unpadded: int,
 ) -> torch.Tensor:
@@ -126,6 +130,8 @@ def _moe_forward(
         router_logits,
         shared_experts_input,
         input_ids,
+        prequantized_data,
+        prequantized_scale,
     )
 
 
@@ -134,6 +140,8 @@ def _moe_forward_fake(
     router_logits: torch.Tensor,
     shared_experts_input: torch.Tensor | None,
     input_ids: torch.Tensor | None,
+    prequantized_data: torch.Tensor | None,
+    prequantized_scale: torch.Tensor | None,
     layer_name: _layer_name_type,
     hidden_dim_unpadded: int,
 ) -> torch.Tensor:
@@ -151,6 +159,8 @@ def _moe_forward_shared(
     router_logits: torch.Tensor,
     shared_experts_input: torch.Tensor | None,
     input_ids: torch.Tensor | None,
+    prequantized_data: torch.Tensor | None,
+    prequantized_scale: torch.Tensor | None,
     layer_name: _layer_name_type,
     hidden_dim_unpadded: int,
 ) -> tuple[torch.Tensor, torch.Tensor]:
@@ -160,6 +170,8 @@ def _moe_forward_shared(
         router_logits,
         shared_experts_input,
         input_ids,
+        prequantized_data,
+        prequantized_scale,
     )
 
 
@@ -168,6 +180,8 @@ def _moe_forward_shared_fake(
     router_logits: torch.Tensor,
     shared_experts_input: torch.Tensor | None,
     input_ids: torch.Tensor | None,
+    prequantized_data: torch.Tensor | None,
+    prequantized_scale: torch.Tensor | None,
     layer_name: _layer_name_type,
     hidden_dim_unpadded: int,
 ) -> tuple[torch.Tensor, torch.Tensor]:
@@ -310,6 +324,14 @@ class MoERunner(MoERunnerInterface):
     @property
     def shared_experts(self) -> SharedExperts | None:
         return self._shared_experts
+
+    @property
+    def is_internal_router(self) -> bool:
+        return self.gate is not None
+
+    @property
+    def input_quant_key(self) -> QuantKey | None:
+        return self._quant_method.input_quant_key
 
     # TODO(bnell): Temporary hack. Get rid of this.
     def _replace_quant_method(self, quant_method: FusedMoEMethodBase):
@@ -574,6 +596,8 @@ class MoERunner(MoERunnerInterface):
         shared_experts_input: torch.Tensor | None,
         input_ids: torch.Tensor | None = None,
         shared_experts_overlapping: bool = False,
+        prequantized_data: torch.Tensor | None = None,
+        prequantized_scale: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor | None, torch.Tensor]:
         """Run expert routing and the fused MoE kernel via the quant method.
 
@@ -605,13 +629,26 @@ class MoERunner(MoERunnerInterface):
                 input_ids=input_ids,
             )
 
-            fused_out = self.routed_experts.forward_modular(
-                x=hidden_states,
-                topk_weights=topk_weights,
-                topk_ids=topk_ids,
-                shared_experts=self._shared_experts,
-                shared_experts_input=shared_experts_input,
-            )
+            if prequantized_data is None:
+                assert prequantized_scale is None
+                fused_out = self.routed_experts.forward_modular(
+                    x=hidden_states,
+                    topk_weights=topk_weights,
+                    topk_ids=topk_ids,
+                    shared_experts=self._shared_experts,
+                    shared_experts_input=shared_experts_input,
+                )
+            else:
+                assert prequantized_scale is not None
+                fused_out = self.routed_experts.forward_modular_prequantized(
+                    x=hidden_states,
+                    topk_weights=topk_weights,
+                    topk_ids=topk_ids,
+                    data=prequantized_data,
+                    scale=prequantized_scale,
+                    shared_experts=self._shared_experts,
+                    shared_experts_input=shared_experts_input,
+                )
 
         if shared_experts_overlapping:
             assert self._shared_experts is not None
@@ -659,6 +696,7 @@ class MoERunner(MoERunnerInterface):
         router_logits: torch.Tensor,
         input_ids: torch.Tensor | None = None,
         shared_experts_input: torch.Tensor | None = None,
+        quantized_hidden_states: QuantizedActivation | None = None,
     ) -> torch.Tensor:
         """Invoke the fused moe layer.
 
@@ -703,11 +741,22 @@ class MoERunner(MoERunnerInterface):
             )
         )
 
+        if quantized_hidden_states is None:
+            prequantized_data = None
+            prequantized_scale = None
+        else:
+            assert quantized_hidden_states.quant_key == self.input_quant_key
+            assert quantized_hidden_states.orig_shape == hidden_states.shape
+            prequantized_data = quantized_hidden_states.data
+            prequantized_scale = quantized_hidden_states.scale
+
         result = self._forward_entry(
             hidden_states,
             router_logits,
             shared_experts_input,
             input_ids,
+            prequantized_data,
+            prequantized_scale,
             self._encode_layer_name(),
             self.moe_config.hidden_dim_unpadded
             if self._quant_method.has_unpadded_output
@@ -825,6 +874,8 @@ class MoERunner(MoERunnerInterface):
         router_logits: torch.Tensor,
         shared_experts_input: torch.Tensor | None,
         input_ids: torch.Tensor | None = None,
+        prequantized_data: torch.Tensor | None = None,
+        prequantized_scale: torch.Tensor | None = None,
     ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
         """Entry point called by the custom op to run the MoE computation.
 
@@ -868,12 +919,18 @@ class MoERunner(MoERunnerInterface):
                 router_logits,
             )
 
+            if prequantized_data is not None:
+                assert not self.do_naive_dispatch_combine
+                assert self.moe_config.pcp_size == 1
+
             shared_output, hidden_states = self._apply_quant_method(
                 hidden_states=hidden_states,
                 router_logits=router_logits,
                 shared_experts_input=shared_experts_input,
                 input_ids=input_ids,
                 shared_experts_overlapping=shared_experts_overlapping,
+                prequantized_data=prequantized_data,
+                prequantized_scale=prequantized_scale,
             )
 
             return self._maybe_combine(

--- a/vllm/model_executor/layers/fused_moe/runner/moe_runner_interface.py
+++ b/vllm/model_executor/layers/fused_moe/runner/moe_runner_interface.py
@@ -14,6 +14,7 @@ from vllm.model_executor.layers.fused_moe.fused_moe_method_base import (
 from vllm.model_executor.layers.fused_moe.runner.shared_experts import (
     SharedExperts,
 )
+from vllm.model_executor.layers.quantization.utils.quant_utils import QuantKey
 
 
 class MoERunnerInterface(PluggableLayer, ABC):
@@ -43,6 +44,16 @@ class MoERunnerInterface(PluggableLayer, ABC):
     @property
     @abstractmethod
     def shared_experts(self) -> SharedExperts | None:
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def is_internal_router(self) -> bool:
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def input_quant_key(self) -> QuantKey | None:
         raise NotImplementedError
 
     @property

--- a/vllm/model_executor/layers/fusion/fused_act_quant.py
+++ b/vllm/model_executor/layers/fusion/fused_act_quant.py
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import torch
+
+from vllm.model_executor.layers.quantization.utils.quant_utils import (
+    kFp8Dynamic128Sym,
+)
+from vllm.platforms import current_platform
+from vllm.utils.deep_gemm import DeepGemmQuantScaleFMT
+
+from .quant_activation import QuantizedActivation
+
+
+def maybe_allocate_fp8_block_quant(
+    x: torch.Tensor,
+    *linears: torch.nn.Module,
+) -> QuantizedActivation | None:
+    """Allocate a shared DeepGEMM FP8 activation for compatible consumers."""
+    if (
+        not linears
+        or DeepGemmQuantScaleFMT.from_oracle() != DeepGemmQuantScaleFMT.UE8M0
+    ):
+        return None
+
+    quant_key = getattr(linears[0], "input_quant_key", None)
+    if quant_key != kFp8Dynamic128Sym or any(
+        getattr(linear, "input_quant_key", None) != quant_key for linear in linears[1:]
+    ):
+        return None
+
+    group_size = quant_key.scale.group_shape.col
+    if x.shape[-1] % group_size != 0:
+        return None
+
+    num_rows = x.numel() // x.shape[-1]
+    num_groups = x.shape[-1] // group_size
+    num_scale_packs = (num_groups + 3) // 4
+    aligned_rows = ((num_rows + 3) // 4) * 4
+    data = torch.empty_like(x, dtype=current_platform.fp8_dtype())
+    scale = torch.empty_strided(
+        (num_rows, num_scale_packs),
+        (1, aligned_rows),
+        dtype=torch.int32,
+        device=x.device,
+    )
+    return QuantizedActivation(
+        data=data,
+        scale=scale,
+        orig_dtype=x.dtype,
+        orig_shape=x.shape,
+        quant_key=quant_key,
+    )

--- a/vllm/model_executor/layers/fusion/quant_activation.py
+++ b/vllm/model_executor/layers/fusion/quant_activation.py
@@ -12,7 +12,10 @@ from dataclasses import dataclass
 
 import torch
 
-from vllm.model_executor.layers.quantization.utils.quant_utils import QuantKey
+from vllm.model_executor.layers.quantization.utils.quant_utils import (
+    QuantKey,
+    kFp8Dynamic128Sym,
+)
 
 
 @dataclass
@@ -33,6 +36,41 @@ class QuantizedActivation:
     orig_dtype: torch.dtype
     orig_shape: torch.Size
     quant_key: QuantKey
+
+
+def index_quantized_activation(
+    x: torch.Tensor | QuantizedActivation,
+    index: torch.Tensor | slice,
+) -> torch.Tensor | QuantizedActivation:
+    """Select rows while preserving the packed DeepGEMM scale layout."""
+    if not isinstance(x, QuantizedActivation):
+        return x[index]
+
+    assert x.quant_key == kFp8Dynamic128Sym
+    assert x.data.ndim == 2 and x.scale.ndim == 2
+    data = x.data[index]
+    if data.ndim == 1:
+        data = data.unsqueeze(0)
+
+    selected_scale = x.scale[index]
+    if selected_scale.ndim == 1:
+        selected_scale = selected_scale.unsqueeze(0)
+    num_rows = data.shape[0]
+    aligned_rows = ((num_rows + 3) // 4) * 4
+    scale = torch.empty_strided(
+        (num_rows, selected_scale.shape[1]),
+        (1, aligned_rows),
+        dtype=selected_scale.dtype,
+        device=selected_scale.device,
+    )
+    scale.copy_(selected_scale)
+    return QuantizedActivation(
+        data=data,
+        scale=scale,
+        orig_dtype=x.orig_dtype,
+        orig_shape=data.shape,
+        quant_key=x.quant_key,
+    )
 
 
 def expose_input_quant_key(layer: torch.nn.Module, kernel) -> None:

--- a/vllm/model_executor/layers/logits_processor.py
+++ b/vllm/model_executor/layers/logits_processor.py
@@ -11,6 +11,9 @@ from vllm.distributed import (
     tensor_model_parallel_gather,
 )
 from vllm.model_executor.custom_op import PluggableLayer
+from vllm.model_executor.layers.fusion.quant_activation import (
+    QuantizedActivation,
+)
 from vllm.model_executor.layers.vocab_parallel_embedding import (
     UnquantizedEmbeddingMethod,
     VocabParallelEmbedding,
@@ -63,10 +66,11 @@ class LogitsProcessor(PluggableLayer):
     def forward(
         self,
         lm_head: VocabParallelEmbedding,
-        hidden_states: torch.Tensor,
+        hidden_states: torch.Tensor | QuantizedActivation,
         embedding_bias: torch.Tensor | None = None,
     ) -> torch.Tensor | None:
         if self.logits_as_input:
+            assert isinstance(hidden_states, torch.Tensor)
             logits = hidden_states
         else:
             # Get the logits for the next tokens.
@@ -98,14 +102,21 @@ class LogitsProcessor(PluggableLayer):
     def _apply_head(
         self,
         lm_head: VocabParallelEmbedding,
-        hidden_states: torch.Tensor,
+        hidden_states: torch.Tensor | QuantizedActivation,
         embedding_bias: torch.Tensor | None,
     ) -> torch.Tensor:
         """Project hidden states through the lm_head, honoring head_dtype."""
-        if self.head_dtype is None or self.head_dtype == hidden_states.dtype:
+        input_dtype = (
+            hidden_states.orig_dtype
+            if isinstance(hidden_states, QuantizedActivation)
+            else hidden_states.dtype
+        )
+        if self.head_dtype is None or self.head_dtype == input_dtype:
             return lm_head.quant_method.apply(
                 lm_head, hidden_states, bias=embedding_bias
             )
+
+        assert isinstance(hidden_states, torch.Tensor)
 
         if not isinstance(lm_head.quant_method, UnquantizedEmbeddingMethod):
             raise ValueError(
@@ -136,7 +147,7 @@ class LogitsProcessor(PluggableLayer):
 
     def _get_logits(
         self,
-        hidden_states: torch.Tensor,
+        hidden_states: torch.Tensor | QuantizedActivation,
         lm_head: VocabParallelEmbedding,
         embedding_bias: torch.Tensor | None,
     ) -> torch.Tensor | None:

--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -33,6 +33,10 @@ from vllm.model_executor.layers.fused_moe.oracle.fp8 import (
     make_fp8_moe_quant_config,
     select_fp8_moe_backend,
 )
+from vllm.model_executor.layers.fusion.quant_activation import (
+    QuantizedActivation,
+    expose_input_quant_key,
+)
 from vllm.model_executor.layers.linear import (
     LinearBase,
     LinearMethodBase,
@@ -58,6 +62,7 @@ from vllm.model_executor.layers.quantization.utils.marlin_utils import (
 )
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     GroupShape,
+    QuantKey,
     create_fp8_quant_key,
     is_layer_skipped,
     kFp8Dynamic128Sym,
@@ -364,6 +369,7 @@ class Fp8LinearMethod(LinearMethodBase):
             out_dtype=self.out_dtype,
             module_name=self.__class__.__name__,
         )
+        expose_input_quant_key(layer, self.fp8_linear)
 
         self.use_marlin = isinstance(self.fp8_linear, MarlinFP8ScaledMMLinearKernel)
 
@@ -418,7 +424,7 @@ class Fp8LinearMethod(LinearMethodBase):
     def apply(
         self,
         layer: torch.nn.Module,
-        x: torch.Tensor,
+        x: torch.Tensor | QuantizedActivation,
         bias: torch.Tensor | None = None,
     ) -> torch.Tensor:
         # if batch invariant mode is enabled, prefer direct FP8 path
@@ -772,6 +778,12 @@ class Fp8MoEMethod(FusedMoEMethodBase):
     def supports_eplb(self) -> bool:
         return True
 
+    @property
+    def input_quant_key(self) -> QuantKey | None:
+        if self.moe_kernel is None:
+            return None
+        return self.moe_kernel.input_quant_key
+
     def apply_monolithic(
         self,
         layer: RoutedExperts,
@@ -819,6 +831,36 @@ class Fp8MoEMethod(FusedMoEMethodBase):
             apply_router_weight_on_input=layer.apply_router_weight_on_input,
             shared_experts=shared_experts,
             shared_experts_input=shared_experts_input,
+        )
+
+    def apply_prequantized(
+        self,
+        layer: RoutedExperts,
+        x: torch.Tensor,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+        shared_experts: SharedExperts | None,
+        shared_experts_input: torch.Tensor | None,
+        data: torch.Tensor,
+        scale: torch.Tensor,
+    ) -> torch.Tensor:
+        assert not self.is_monolithic
+        assert self.moe_kernel is not None
+        assert self.input_quant_key == kFp8Dynamic128Sym
+        return self.moe_kernel.apply(
+            x,
+            layer.w13_weight,
+            layer.w2_weight,
+            topk_weights,
+            topk_ids,
+            activation=layer.activation,
+            global_num_experts=layer.global_num_experts,
+            expert_map=layer.expert_map,
+            apply_router_weight_on_input=layer.apply_router_weight_on_input,
+            shared_experts=shared_experts,
+            shared_experts_input=shared_experts_input,
+            prequantized_data=data,
+            prequantized_scale=scale,
         )
 
 

--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -54,6 +54,7 @@ from vllm.model_executor.layers.fused_moe import (
     GateLinear,
     fused_moe_make_expert_params_mapping,
 )
+from vllm.model_executor.layers.fusion.quant_activation import QuantizedActivation
 from vllm.model_executor.layers.layernorm import LayerNorm, RMSNorm
 from vllm.model_executor.layers.linear import (
     ColumnParallelLinear,
@@ -394,6 +395,7 @@ class DeepseekV2MoE(nn.Module):
         self,
         hidden_states: torch.Tensor,
         already_sequence_parallel: bool = False,
+        quantized_hidden_states: QuantizedActivation | None = None,
     ) -> torch.Tensor:
         num_tokens, hidden_dim = hidden_states.shape
         hidden_states = hidden_states.view(-1, hidden_dim)
@@ -403,9 +405,19 @@ class DeepseekV2MoE(nn.Module):
         if self.is_sequence_parallel and not already_sequence_parallel:
             hidden_states = sequence_parallel_chunk(hidden_states)
 
-        final_hidden_states = self.experts(
-            hidden_states=hidden_states, router_logits=hidden_states
-        )
+        if self.experts.is_internal_router:
+            final_hidden_states = self.experts(
+                hidden_states=hidden_states,
+                router_logits=hidden_states,
+                quantized_hidden_states=quantized_hidden_states,
+            )
+        else:
+            router_logits, _ = self.gate(hidden_states)
+            final_hidden_states = self.experts(
+                hidden_states=hidden_states,
+                router_logits=router_logits,
+                quantized_hidden_states=quantized_hidden_states,
+            )
 
         if self.is_sequence_parallel and not already_sequence_parallel:
             final_hidden_states = tensor_model_parallel_all_gather(

--- a/vllm/model_executor/models/registry.py
+++ b/vllm/model_executor/models/registry.py
@@ -645,6 +645,7 @@ _SPECULATIVE_DECODING_MODELS = {
     "Eagle3DeepseekV3ForCausalLM": ("deepseek_eagle3", "Eagle3DeepseekV2ForCausalLM"),
     "EagleDeepSeekMTPModel": ("deepseek_eagle", "EagleDeepseekV3ForCausalLM"),
     "DeepSeekMTPModel": ("deepseek_mtp", "DeepSeekMTP"),
+    "DeepseekV32MTPModel": ("vllm.models.deepseek_v32", "DeepseekV32MTP"),
     "DeepSeekV4MTPModel": ("vllm.models.deepseek_v4", "DeepSeekV4MTP"),
     "BailingMoeV3MTPModel": ("bailing_moe_v3_mtp", "BailingMoeV3MTPModel"),
     "MiniMaxM3MTP": ("vllm.models.minimax_m3", "MiniMaxM3MTP"),

--- a/vllm/models/common/ops/fused_allreduce_rms_norm.py
+++ b/vllm/models/common/ops/fused_allreduce_rms_norm.py
@@ -9,7 +9,9 @@ that doesn't fire for models running eager (or under a breakable CUDA graph).
 import torch
 
 from vllm.distributed import (
+    get_tensor_model_parallel_rank,
     get_tensor_model_parallel_world_size,
+    get_tp_group,
     tensor_model_parallel_all_reduce,
 )
 from vllm.model_executor.layers.fused_allreduce_gemma_rms_norm import (
@@ -17,7 +19,48 @@ from vllm.model_executor.layers.fused_allreduce_gemma_rms_norm import (
     _can_use_flashinfer,
     flashinfer_trtllm_fused_allreduce_norm,
 )
+from vllm.model_executor.layers.fusion.fused_act_quant import (
+    maybe_allocate_fp8_block_quant,
+)
+from vllm.model_executor.layers.fusion.quant_activation import (
+    QuantizedActivation,
+)
 from vllm.model_executor.layers.layernorm import RMSNorm
+
+try:
+    from vllm.distributed.device_communicators.flashinfer_all_reduce import (
+        flashinfer_comm,
+        get_fi_ar_packed_quant_workspace,
+    )
+
+    _AR_RESIDUAL_RMS_NORM_OUT_FP8_BLOCK_QUANT = getattr(
+        flashinfer_comm.AllReduceFusionPattern,
+        "kARResidualRMSNormOutPerTokenGroupFP8PackedQuant",
+        None,
+    )
+except (ImportError, AttributeError):
+    get_fi_ar_packed_quant_workspace = None  # type: ignore[assignment]
+    _AR_RESIDUAL_RMS_NORM_OUT_FP8_BLOCK_QUANT = None
+
+
+@torch.compiler.assume_constant_result
+def _has_packed_quant_workspace(
+    tp_size: int,
+    max_token_num: int,
+    hidden_size: int,
+    dtype: torch.dtype,
+) -> bool:
+    return (
+        get_fi_ar_packed_quant_workspace(
+            world_size=tp_size,
+            rank=get_tensor_model_parallel_rank(),
+            max_token_num=max_token_num,
+            hidden_dim=hidden_size,
+            dtype=dtype,
+            group=get_tp_group().cpu_group,
+        )
+        is not None
+    )
 
 
 def fused_allreduce_rms_norm(
@@ -61,3 +104,63 @@ def fused_allreduce_rms_norm(
 
     reduced = tensor_model_parallel_all_reduce(hidden_states)
     return norm(reduced, residual)
+
+
+def fused_allreduce_rms_norm_fp8_quant(
+    hidden_states: torch.Tensor,
+    residual: torch.Tensor,
+    norm: RMSNorm,
+    consumer: torch.nn.Module,
+) -> tuple[torch.Tensor, torch.Tensor, QuantizedActivation | None]:
+    """Fuse all-reduce, residual RMSNorm, and DeepGEMM FP8 quantization.
+
+    The normalized BF16 output remains available to unquantized consumers while
+    the returned activation lets ``consumer`` skip its input quantization. The
+    regular eager path is used when the required FlashInfer collective or
+    activation contract is unavailable.
+    """
+    tp_size = get_tensor_model_parallel_world_size()
+    if (
+        tp_size == 1
+        or flashinfer_trtllm_fused_allreduce_norm is None
+        or get_fi_ar_packed_quant_workspace is None
+        or _AR_RESIDUAL_RMS_NORM_OUT_FP8_BLOCK_QUANT is None
+    ):
+        norm_out, residual_out = fused_allreduce_rms_norm(hidden_states, residual, norm)
+        return norm_out, residual_out, None
+
+    ok, max_token_num = _can_use_flashinfer(hidden_states, tp_size)
+    if ok:
+        ok = _has_packed_quant_workspace(
+            tp_size,
+            max_token_num,
+            hidden_states.shape[-1],
+            hidden_states.dtype,
+        )
+    if not ok:
+        norm_out, residual_out = fused_allreduce_rms_norm(hidden_states, residual, norm)
+        return norm_out, residual_out, None
+
+    quant = maybe_allocate_fp8_block_quant(hidden_states, consumer)
+    if quant is None:
+        norm_out, residual_out = fused_allreduce_rms_norm(hidden_states, residual, norm)
+        return norm_out, residual_out, None
+
+    norm_out = torch.empty_like(hidden_states)
+    flashinfer_trtllm_fused_allreduce_norm(
+        allreduce_in=hidden_states,
+        residual=residual,
+        rms_gamma=norm.weight,
+        rms_eps=norm.variance_epsilon,
+        world_size=tp_size,
+        weight_bias=0.0,
+        launch_with_pdl=True,
+        fp32_acc=True,
+        max_token_num=max_token_num,
+        pattern_code=_AR_RESIDUAL_RMS_NORM_OUT_FP8_BLOCK_QUANT,
+        norm_out=norm_out,
+        quant_out=quant.data,
+        scale_out=quant.scale,
+        block_quant_group_size=128,
+    )
+    return norm_out, hidden_states, quant

--- a/vllm/models/deepseek_v32/attention.py
+++ b/vllm/models/deepseek_v32/attention.py
@@ -9,6 +9,10 @@ from vllm.config import CacheConfig, VllmConfig
 from vllm.distributed import get_tensor_model_parallel_world_size
 from vllm.forward_context import get_forward_context
 from vllm.model_executor.layers.attention import MLAAttention
+from vllm.model_executor.layers.fusion.fused_act_quant import (
+    maybe_allocate_fp8_block_quant,
+)
+from vllm.model_executor.layers.fusion.quant_activation import QuantizedActivation
 from vllm.model_executor.layers.layernorm import LayerNorm, RMSNorm
 from vllm.model_executor.layers.linear import (
     ColumnParallelLinear,
@@ -332,9 +336,12 @@ class DeepseekV32Attention(MLAAttention):
         self,
         positions: torch.Tensor,
         hidden_states: torch.Tensor,
+        qkv_input: torch.Tensor | QuantizedActivation | None = None,
     ) -> torch.Tensor:
         # Captured: A-projections (+ indexer A-GEMM on indexer layers).
-        qkv_lora = self.fused_qkv_a_proj(hidden_states)[0]
+        qkv_lora = self.fused_qkv_a_proj(
+            hidden_states if qkv_input is None else qkv_input
+        )[0]
         q_c, kv_c, k_pe = qkv_lora.split(
             [self.q_lora_rank, self.kv_lora_rank, self.qk_rope_head_dim], dim=-1
         )
@@ -394,6 +401,10 @@ class DeepseekV32Attention(MLAAttention):
             mla_kv_cache = self.kv_cache
             mla_k_scale = self._k_scale
 
+        q_consumers = [self.q_b_proj]
+        if self.indexer is not None and not self.skip_topk:
+            q_consumers.append(self.indexer.wq_b)
+        q_c_quant = maybe_allocate_fp8_block_quant(q_c, *q_consumers)
         q_c = fused_norm_rope(
             positions,
             q_c,
@@ -417,15 +428,20 @@ class DeepseekV32Attention(MLAAttention):
             mla_k_scale=mla_k_scale,
             has_indexer=has_indexer,
             index_rope_interleave=self._index_rope_interleave,
+            q_c_quant_out=q_c_quant.data if q_c_quant is not None else None,
+            q_c_quant_scale=q_c_quant.scale if q_c_quant is not None else None,
         )
 
-        q = self.q_b_proj(q_c)[0].view(-1, self.num_local_heads, self.qk_head_dim)
+        q_proj_input = q_c_quant if q_c_quant is not None else q_c
+        q = self.q_b_proj(q_proj_input)[0].view(
+            -1, self.num_local_heads, self.qk_head_dim
+        )
         q_nope, q_pe = q.split([self.qk_nope_head_dim, self.qk_rope_head_dim], dim=-1)
         q_nope = q_nope.transpose(0, 1)
         ql_nope = torch.bmm(q_nope, self.W_UK_T).transpose(0, 1)
 
         if self.indexer is not None and not self.skip_topk:
-            index_q = self.indexer.wq_b(q_c)[0]
+            index_q = self.indexer.wq_b(q_proj_input)[0]
             index_q = index_q.view(-1, self.indexer.n_head, self.indexer.head_dim)
         else:
             index_q = None

--- a/vllm/models/deepseek_v32/common/kernels.py
+++ b/vllm/models/deepseek_v32/common/kernels.py
@@ -96,8 +96,15 @@ def _fused_norm_rope_kernel(
     q_rms_eps,
     q_c_out_ptr,
     q_c_out_stride,
+    q_c_quant_out_ptr,
+    q_c_quant_scale_ptr,
+    q_c_quant_scale_stride,
     Q_DIM: tl.constexpr,
     Q_BLOCK_SIZE: tl.constexpr,
+    Q_FP8_QUANT: tl.constexpr,
+    Q_QUANT_GROUP_SIZE: tl.constexpr,
+    Q_NUM_GROUPS: tl.constexpr,
+    Q_NUM_SCALE_PACKS: tl.constexpr,
     # KV RMS norm
     kv_ptr,
     kv_stride,
@@ -188,7 +195,42 @@ def _fused_norm_rope_kernel(
         q_c = tl.load(q_c_ptr + tok_idx * q_c_stride + q_block, mask=q_mask, other=0.0)
         q_c_rms_w = tl.load(q_rms_norm_w_ptr + q_block, mask=q_mask)
         q_c = _rms_norm(q_c, q_c_rms_w, q_rms_eps, Q_DIM)
+        q_c = q_c.to(q_c_out_ptr.dtype.element_ty)
         tl.store(q_c_out_ptr + tok_idx * q_c_out_stride + q_block, q_c, mask=q_mask)
+        if Q_FP8_QUANT:
+            num_groups: tl.constexpr = Q_BLOCK_SIZE // Q_QUANT_GROUP_SIZE
+            q_groups = tl.reshape(q_c.to(tl.float32), (num_groups, Q_QUANT_GROUP_SIZE))
+            group_absmax = tl.max(tl.abs(q_groups), axis=1)
+            scale = tl.maximum(group_absmax * (1.0 / 448.0), 1e-10)
+            scale = tl.math.exp2(tl.math.ceil(tl.math.log2(scale)))
+            q_quant = tl.clamp(
+                q_groups / tl.reshape(scale, (num_groups, 1)), -448.0, 448.0
+            ).to(q_c_quant_out_ptr.dtype.element_ty)
+            tl.store(
+                q_c_quant_out_ptr + tok_idx * Q_DIM + q_block,
+                tl.reshape(q_quant, (Q_BLOCK_SIZE,)),
+                mask=q_mask,
+            )
+
+            scales_per_pack: tl.constexpr = 4
+            scale_packs = tl.reshape(
+                scale, (num_groups // scales_per_pack, scales_per_pack)
+            )
+            scale_bits = scale_packs.to(tl.int32, bitcast=True)
+            scale_bytes = (scale_bits >> 23) & 0xFF
+            byte_offsets = tl.arange(0, scales_per_pack)
+            group_offsets = (
+                tl.arange(0, num_groups // scales_per_pack)[:, None] * scales_per_pack
+                + byte_offsets[None, :]
+            )
+            scale_bytes = tl.where(group_offsets < Q_NUM_GROUPS, scale_bytes, 0)
+            packed_scale = tl.sum(scale_bytes << (byte_offsets[None, :] * 8), axis=1)
+            pack_offsets = tl.arange(0, num_groups // scales_per_pack)
+            tl.store(
+                q_c_quant_scale_ptr + tok_idx + pack_offsets * q_c_quant_scale_stride,
+                packed_scale,
+                mask=pack_offsets < Q_NUM_SCALE_PACKS,
+            )
     elif pid == 1:
         # KV RMS Norm + KV RoPE + MLA concat_and_cache.
         # Merged so the normed kv_c and RoPE'd k_pe can be written
@@ -395,6 +437,8 @@ def fused_norm_rope(
     has_indexer: bool = True,
     index_rope_interleave: bool = False,
     q_c_out: torch.Tensor | None = None,
+    q_c_quant_out: torch.Tensor | None = None,
+    q_c_quant_scale: torch.Tensor | None = None,
 ) -> torch.Tensor:
     assert positions.ndim == 1
     assert q_c.ndim == 2
@@ -478,6 +522,18 @@ def fused_norm_rope(
 
     if q_c_out is None:
         q_c_out = torch.empty_like(q_c)
+    q_fp8_quant = q_c_quant_out is not None
+    assert q_fp8_quant == (q_c_quant_scale is not None)
+    if q_fp8_quant:
+        assert q_dim % 128 == 0
+        assert q_c_quant_out is not None
+        assert q_c_quant_scale is not None
+        assert q_c_quant_out.shape == q_c.shape
+        assert q_c_quant_scale.shape == (num_tokens, (q_dim // 128 + 3) // 4)
+        assert q_c_quant_scale.stride(0) == 1
+    else:
+        q_c_quant_out = torch.empty(0, dtype=torch.float8_e4m3fn, device=device)
+        q_c_quant_scale = torch.empty(0, dtype=torch.int32, device=device)
     use_pdl = current_platform.is_arch_support_pdl()
     _fused_norm_rope_kernel[(4, num_tokens)](
         positions,
@@ -488,8 +544,15 @@ def fused_norm_rope(
         q_rms_eps,
         q_c_out,
         q_c_out.stride(0),
+        q_c_quant_out,
+        q_c_quant_scale,
+        q_c_quant_scale.stride(1) if q_fp8_quant else 0,
         q_dim,
         triton.next_power_of_2(q_dim),
+        q_fp8_quant,
+        128,
+        q_dim // 128 if q_fp8_quant else 0,
+        (q_dim // 128 + 3) // 4 if q_fp8_quant else 0,
         # KV RMS norm
         kv_c,
         kv_c.stride(0),

--- a/vllm/models/deepseek_v32/nvidia/model.py
+++ b/vllm/models/deepseek_v32/nvidia/model.py
@@ -35,7 +35,10 @@ from vllm.model_executor.models.utils import (
     make_empty_intermediate_tensors_factory,
     make_layers,
 )
-from vllm.models.common.ops.fused_allreduce_rms_norm import fused_allreduce_rms_norm
+from vllm.models.common.ops.fused_allreduce_rms_norm import (
+    fused_allreduce_rms_norm,
+    fused_allreduce_rms_norm_fp8_quant,
+)
 from vllm.models.common.ops.sequence_parallel import (
     sp_all_gather,
     sp_padding_mask,
@@ -118,6 +121,7 @@ class DeepseekV32DecoderLayer(torch.nn.Module):
         residual: torch.Tensor | None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         full_num_tokens = positions.shape[0]
+        qkv_input = None
 
         if residual is None:
             residual = hidden_states
@@ -127,26 +131,44 @@ class DeepseekV32DecoderLayer(torch.nn.Module):
         else:
             # The previous layer's MLP/MoE output is left un-reduced; fuse its
             # all-reduce into this input_layernorm.
-            hidden_states, residual = fused_allreduce_rms_norm(
-                hidden_states, residual, self.input_layernorm
+            hidden_states, residual, qkv_input = fused_allreduce_rms_norm_fp8_quant(
+                hidden_states,
+                residual,
+                self.input_layernorm,
+                self.self_attn.fused_qkv_a_proj,
             )
         if self.use_sequence_parallel:
             hidden_states = sp_all_gather(hidden_states)[:full_num_tokens]
 
         # self_attn's o_proj runs reduce_results=False; reduce before RMSNorm.
-        hidden_states = self.self_attn(positions=positions, hidden_states=hidden_states)
+        hidden_states = self.self_attn(
+            positions=positions,
+            hidden_states=hidden_states,
+            qkv_input=qkv_input,
+        )
+        moe_input = None
         if self.use_sequence_parallel:
             hidden_states = sp_reduce_scatter(hidden_states)
             hidden_states, residual = self.post_attention_layernorm(
                 hidden_states, residual
             )
         else:
-            hidden_states, residual = fused_allreduce_rms_norm(
-                hidden_states, residual, self.post_attention_layernorm
-            )
+            if isinstance(self.mlp, DeepseekV2MoE):
+                hidden_states, residual, moe_input = fused_allreduce_rms_norm_fp8_quant(
+                    hidden_states,
+                    residual,
+                    self.post_attention_layernorm,
+                    self.mlp.experts,
+                )
+            else:
+                hidden_states, residual = fused_allreduce_rms_norm(
+                    hidden_states, residual, self.post_attention_layernorm
+                )
 
         if self.use_sequence_parallel and isinstance(self.mlp, DeepseekV2MoE):
             hidden_states = self.mlp(hidden_states, already_sequence_parallel=True)
+        elif isinstance(self.mlp, DeepseekV2MoE):
+            hidden_states = self.mlp(hidden_states, quantized_hidden_states=moe_input)
         else:
             hidden_states = self.mlp(hidden_states)
         return hidden_states, residual

--- a/vllm/models/deepseek_v32/nvidia/mtp.py
+++ b/vllm/models/deepseek_v32/nvidia/mtp.py
@@ -9,10 +9,12 @@ import torch.nn as nn
 import vllm.envs as envs
 from vllm._aiter_ops import rocm_aiter_ops
 from vllm.config import VllmConfig
-from vllm.distributed import tensor_model_parallel_all_reduce
 from vllm.forward_context import get_forward_context, is_forward_context_available
 from vllm.model_executor.layers.fused_moe import (
     fused_moe_make_expert_params_mapping,
+)
+from vllm.model_executor.layers.fusion.quant_activation import (
+    QuantizedActivation,
 )
 from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
@@ -36,6 +38,9 @@ from vllm.model_executor.models.deepseek_v2 import (
 from vllm.model_executor.models.utils import (
     get_pp_missing_layer_names,
     maybe_prefix,
+)
+from vllm.models.common.ops.fused_allreduce_rms_norm import (
+    fused_allreduce_rms_norm_fp8_quant,
 )
 from vllm.models.common.ops.sequence_parallel import (
     sp_all_gather,
@@ -94,7 +99,7 @@ class DeepseekV32MultiTokenPredictorLayer(nn.Module):
         previous_hidden_states: torch.Tensor,
         inputs_embeds: torch.Tensor | None = None,
         spec_step_index: int = 0,
-    ) -> torch.Tensor:
+    ) -> tuple[torch.Tensor | QuantizedActivation, torch.Tensor]:
         assert inputs_embeds is not None
         # Fused: zero pos-0 embeds + enorm(embeds) + hnorm(prev) + cat -> [N, 2H].
         eh_input = fused_eh_norm(
@@ -119,23 +124,23 @@ class DeepseekV32MultiTokenPredictorLayer(nn.Module):
         hidden_states, residual = self.mtp_block(
             positions=positions, hidden_states=hidden_states, residual=None
         )
-        if not is_sequence_parallel:
-            # Without sequence parallelism, the MoE output is left un-reduced.
-            hidden_states = tensor_model_parallel_all_reduce(hidden_states)
-        # Recycle the POST-final-norm hidden into the next draft step. The
-        # residual-add is fused into the final RMSNorm so it is computed
-        # exactly once, and the result is returned for both tuple positions:
-        # the draft-logits hidden (compute_logits applies the LM head only) and
-        # the recycled previous_hidden_states. Recycling the pre-final-norm
-        # hidden mismatches the draft model's hnorm and lowers MTP acceptance;
-        # post-norm recycle matches deepseek_mtp.py (PR #45895). The tuple form
-        # is understood by both the V2 speculator (isinstance-tuple check) and
-        # the legacy proposer (model_returns_tuple is True for the
-        # DeepSeekMTPModel architecture).
-        hidden_states, _ = self.shared_head.norm(hidden_states, residual)
         if is_sequence_parallel:
+            hidden_states, _ = self.shared_head.norm(hidden_states, residual)
             hidden_states = sp_all_gather(hidden_states)[: positions.shape[0]]
-        return hidden_states, hidden_states
+            return hidden_states, hidden_states
+
+        hidden_states, _, logits_input = fused_allreduce_rms_norm_fp8_quant(
+            hidden_states,
+            residual,
+            self.shared_head.norm,
+            self.shared_head.head,
+        )
+        # Recycle the post-final-norm BF16 hidden while compute_logits consumes
+        # the packed FP8 activation when the shared LM head supports it.
+        return (
+            logits_input if logits_input is not None else hidden_states,
+            hidden_states,
+        )
 
 
 class DeepseekV32MultiTokenPredictor(nn.Module):
@@ -188,7 +193,7 @@ class DeepseekV32MultiTokenPredictor(nn.Module):
         previous_hidden_states: torch.Tensor,
         inputs_embeds: torch.Tensor | None = None,
         spec_step_idx: int = 0,
-    ) -> torch.Tensor:
+    ) -> tuple[torch.Tensor | QuantizedActivation, torch.Tensor]:
         if inputs_embeds is None:
             inputs_embeds = self.embed_tokens(input_ids)
         current_step_idx = spec_step_idx % self.num_mtp_layers
@@ -202,7 +207,7 @@ class DeepseekV32MultiTokenPredictor(nn.Module):
 
     def compute_logits(
         self,
-        hidden_states: torch.Tensor,
+        hidden_states: torch.Tensor | QuantizedActivation,
         spec_step_idx: int = 0,
     ) -> torch.Tensor:
         current_step_idx = spec_step_idx % self.num_mtp_layers
@@ -250,14 +255,14 @@ class DeepseekV32MTP(nn.Module, DeepseekV2MixtureOfExperts):
         intermediate_tensors: IntermediateTensors | None = None,
         inputs_embeds: torch.Tensor | None = None,
         spec_step_idx: int = 0,
-    ) -> torch.Tensor:
+    ) -> tuple[torch.Tensor | QuantizedActivation, torch.Tensor]:
         return self.model(
             input_ids, positions, hidden_states, inputs_embeds, spec_step_idx
         )
 
     def compute_logits(
         self,
-        hidden_states: torch.Tensor,
+        hidden_states: torch.Tensor | QuantizedActivation,
         spec_step_idx: int = 0,
     ) -> torch.Tensor | None:
         return self.model.compute_logits(hidden_states, spec_step_idx)

--- a/vllm/models/deepseek_v32/nvidia/ops/fused_q_cutedsl.py
+++ b/vllm/models/deepseek_v32/nvidia/ops/fused_q_cutedsl.py
@@ -10,6 +10,7 @@ from cutlass import BFloat16, Float8E4M3FN, Float32, Int64, Uint8, Uint16, Uint3
 
 from vllm.cute_utils import _TORCH_TO_CUTE_DTYPE, cvt
 from vllm.platforms import current_platform
+from vllm.utils.torch_utils import direct_register_custom_op
 
 
 def _make_fake_tensor(dtype, shape, divisibility):
@@ -25,6 +26,11 @@ def _make_fake_tensor(dtype, shape, divisibility):
     )
 
 
+@torch.compiler.assume_constant_result
+def _is_sm100_or_newer() -> bool:
+    return current_platform.has_device_capability(100)
+
+
 def is_fused_q_cutedsl_supported(
     q_pe: torch.Tensor,
     index_q: torch.Tensor | None,
@@ -34,7 +40,7 @@ def is_fused_q_cutedsl_supported(
     quantize_mqa: bool,
 ) -> bool:
     if not (
-        current_platform.has_device_capability(100)
+        _is_sm100_or_newer()
         and quantize_mqa
         and q_pe.dtype == ql_nope.dtype == torch.bfloat16
         and q_pe.shape[-1] == 64
@@ -52,7 +58,7 @@ def is_fused_q_cutedsl_supported(
     )
 
 
-def fused_q_cutedsl(
+def _fused_q_cutedsl_impl(
     positions: torch.Tensor,
     q_pe: torch.Tensor,
     rope_cache: torch.Tensor,
@@ -107,6 +113,70 @@ def fused_q_cutedsl(
         idx_q_fp8,
         idx_weights_out,
         float(idx_weights_softmax_scale * idx_weights_head_scale),
+    )
+
+
+def _fused_q_cutedsl_fake(
+    positions: torch.Tensor,
+    q_pe: torch.Tensor,
+    rope_cache: torch.Tensor,
+    ql_nope: torch.Tensor,
+    q_scale: torch.Tensor,
+    mqa_output: torch.Tensor,
+    idx_q: torch.Tensor,
+    idx_rope_cache: torch.Tensor,
+    idx_weights: torch.Tensor,
+    idx_weights_softmax_scale: float,
+    idx_weights_head_scale: float,
+    idx_q_fp8: torch.Tensor,
+    idx_weights_out: torch.Tensor,
+    has_indexer: bool = True,
+    index_rope_interleave: bool = True,
+) -> None:
+    return None
+
+
+direct_register_custom_op(
+    op_name="fused_q_cutedsl",
+    op_func=_fused_q_cutedsl_impl,
+    mutates_args=["mqa_output", "idx_q_fp8", "idx_weights_out"],
+    fake_impl=_fused_q_cutedsl_fake,
+)
+
+
+def fused_q_cutedsl(
+    positions: torch.Tensor,
+    q_pe: torch.Tensor,
+    rope_cache: torch.Tensor,
+    ql_nope: torch.Tensor,
+    q_scale: torch.Tensor,
+    mqa_output: torch.Tensor,
+    idx_q: torch.Tensor,
+    idx_rope_cache: torch.Tensor,
+    idx_weights: torch.Tensor,
+    idx_weights_softmax_scale: float,
+    idx_weights_head_scale: float,
+    idx_q_fp8: torch.Tensor,
+    idx_weights_out: torch.Tensor,
+    has_indexer: bool = True,
+    index_rope_interleave: bool = True,
+) -> None:
+    torch.ops.vllm.fused_q_cutedsl(
+        positions,
+        q_pe,
+        rope_cache,
+        ql_nope,
+        q_scale,
+        mqa_output,
+        idx_q,
+        idx_rope_cache,
+        idx_weights,
+        idx_weights_softmax_scale,
+        idx_weights_head_scale,
+        idx_q_fp8,
+        idx_weights_out,
+        has_indexer,
+        index_rope_interleave,
     )
 
 

--- a/vllm/models/kimi_k3/amd/latent_moe_runner.py
+++ b/vllm/models/kimi_k3/amd/latent_moe_runner.py
@@ -8,6 +8,7 @@ from vllm.distributed import (
 )
 from vllm.logger import init_logger
 from vllm.model_executor.layers.fused_moe.runner.moe_runner import MoERunner, _unpack
+from vllm.model_executor.layers.fusion.quant_activation import QuantizedActivation
 
 logger = init_logger(__name__)
 
@@ -96,13 +97,22 @@ class ROCmLatentMoERunner(MoERunner):
         router_logits: torch.Tensor,
         input_ids: torch.Tensor | None = None,
         shared_experts_input: torch.Tensor | None = None,
+        quantized_hidden_states: QuantizedActivation | None = None,
     ) -> torch.Tensor:
-        if self._tail_shardable and not self._fused_output_is_reduced:
+        if (
+            quantized_hidden_states is None
+            and self._tail_shardable
+            and not self._fused_output_is_reduced
+        ):
             return self._fused_forward(
                 hidden_states, router_logits, input_ids, shared_experts_input
             )
         return super().forward(
-            hidden_states, router_logits, input_ids, shared_experts_input
+            hidden_states,
+            router_logits,
+            input_ids,
+            shared_experts_input,
+            quantized_hidden_states,
         )
 
     def _fused_forward(
@@ -133,6 +143,8 @@ class ROCmLatentMoERunner(MoERunner):
             router_logits,
             shared_experts_input,
             input_ids,
+            None,
+            None,
             self._encode_layer_name(),
             self.moe_config.hidden_dim_unpadded
             if self._quant_method.has_unpadded_output

--- a/vllm/models/kimi_k3/nvidia/latent_moe_runner.py
+++ b/vllm/models/kimi_k3/nvidia/latent_moe_runner.py
@@ -12,6 +12,7 @@ from vllm.distributed import (
 )
 from vllm.logger import init_logger
 from vllm.model_executor.layers.fused_moe.runner.moe_runner import MoERunner, _unpack
+from vllm.model_executor.layers.fusion.quant_activation import QuantizedActivation
 from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.platforms import current_platform
 from vllm.utils.multi_stream_utils import maybe_execute_in_parallel
@@ -273,13 +274,18 @@ class LatentMoERunner(MoERunner):
         router_logits: torch.Tensor,
         input_ids: torch.Tensor | None = None,
         shared_experts_input: torch.Tensor | None = None,
+        quantized_hidden_states: QuantizedActivation | None = None,
     ) -> torch.Tensor:
-        if self._use_fused_path():
+        if quantized_hidden_states is None and self._use_fused_path():
             return self._fused_forward(
                 hidden_states, router_logits, input_ids, shared_experts_input
             )
         return super().forward(
-            hidden_states, router_logits, input_ids, shared_experts_input
+            hidden_states,
+            router_logits,
+            input_ids,
+            shared_experts_input,
+            quantized_hidden_states,
         )
 
     def _fused_forward(
@@ -309,6 +315,8 @@ class LatentMoERunner(MoERunner):
             router_logits,
             shared_experts_input,
             input_ids,
+            None,
+            None,
             self._encode_layer_name(),
             self.moe_config.hidden_dim_unpadded
             if self._quant_method.has_unpadded_output

--- a/vllm/utils/deep_gemm.py
+++ b/vllm/utils/deep_gemm.py
@@ -91,6 +91,7 @@ class DeepGemmQuantScaleFMT(Enum):
 
 
 @functools.cache
+@torch.compiler.assume_constant_result
 def is_deep_gemm_supported() -> bool:
     """Return `True` if DeepGEMM is supported on the current platform.
     Currently, only Hopper and Blackwell GPUs are supported.
@@ -100,6 +101,7 @@ def is_deep_gemm_supported() -> bool:
 
 
 @functools.cache
+@torch.compiler.assume_constant_result
 def is_deep_gemm_e8m0_used() -> bool:
     """Return `True` if vLLM is configured to use DeepGEMM "
     "E8M0 scale on a Hopper or Blackwell-class GPU.

--- a/vllm/v1/spec_decode/llm_base_proposer.py
+++ b/vllm/v1/spec_decode/llm_base_proposer.py
@@ -1018,7 +1018,11 @@ class SpecDecodeBaseProposer:
             # feedback into the next draft step.
             architectures = self.draft_model_config.hf_config.architectures or []
             return bool(
-                {"DeepSeekMTPModel", "KimiK3MTPModel"}.intersection(architectures)
+                {
+                    "DeepSeekMTPModel",
+                    "DeepseekV32MTPModel",
+                    "KimiK3MTPModel",
+                }.intersection(architectures)
             )
         return self.method not in ("mtp", "draft_model", "dflash")
 

--- a/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
@@ -9,6 +9,10 @@ from vllm.config import VllmConfig
 from vllm.config.compilation import CUDAGraphMode
 from vllm.forward_context import BatchDescriptor, set_forward_context
 from vllm.logger import init_logger
+from vllm.model_executor.layers.fusion.quant_activation import (
+    QuantizedActivation,
+    index_quantized_activation,
+)
 from vllm.triton_utils import tl, triton
 from vllm.v1.kv_cache_interface import KVCacheConfig
 from vllm.v1.worker.gpu.attn_utils import build_slot_mappings_by_layer
@@ -365,7 +369,7 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
         num_tokens_across_dp: torch.Tensor | None,
         cudagraph_runtime_mode: CUDAGraphMode = CUDAGraphMode.NONE,
         mm_inputs: tuple[list[torch.Tensor], torch.Tensor] | None = None,
-    ) -> tuple[torch.Tensor, torch.Tensor]:
+    ) -> tuple[torch.Tensor | QuantizedActivation, torch.Tensor]:
         batch_descriptor = BatchDescriptor(num_tokens=num_tokens)
         with set_forward_context(
             attn_metadata,
@@ -438,7 +442,9 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
             cudagraph_runtime_mode=cudagraph_runtime_mode,
             mm_inputs=mm_inputs,
         )
-        sample_hidden_states = last_hidden_states[last_token_indices]
+        sample_hidden_states = index_quantized_activation(
+            last_hidden_states, last_token_indices
+        )
 
         self.draft_tokens[:num_reqs, 0] = self.sample_draft(
             sample_hidden_states,
@@ -615,7 +621,9 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
             num_tokens_across_dp,
             cudagraph_runtime_mode,
         )
-        last_hidden_states = last_hidden_states[:num_reqs]
+        last_hidden_states = index_quantized_activation(
+            last_hidden_states, slice(None, num_reqs)
+        )
 
         sample_positions = positions
         if not self.advance_draft_positions:

--- a/vllm/v1/worker/gpu/spec_decode/multi_module_mtp/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/multi_module_mtp/speculator.py
@@ -9,6 +9,10 @@ from vllm.config import VllmConfig
 from vllm.config.compilation import CUDAGraphMode
 from vllm.forward_context import BatchDescriptor, set_forward_context
 from vllm.logger import init_logger
+from vllm.model_executor.layers.fusion.quant_activation import (
+    QuantizedActivation,
+    index_quantized_activation,
+)
 from vllm.triton_utils import tl, triton
 from vllm.v1.attention.backends.utils import PAD_SLOT_ID
 from vllm.v1.worker.gpu.attn_utils import build_slot_mappings_by_layer
@@ -258,7 +262,7 @@ class MultiModuleMTPSpeculator(DraftModelSpeculator):
         num_tokens_across_dp: torch.Tensor | None,
         spec_module_idx: int,
         cudagraph_runtime_mode: CUDAGraphMode = CUDAGraphMode.NONE,
-    ) -> tuple[torch.Tensor, torch.Tensor]:
+    ) -> tuple[torch.Tensor | QuantizedActivation, torch.Tensor]:
         batch_descriptor = BatchDescriptor(num_tokens=num_tokens)
         with set_forward_context(
             attn_metadata,
@@ -410,7 +414,9 @@ class MultiModuleMTPSpeculator(DraftModelSpeculator):
             )
 
             # Sample draft tokens for the current step.
-            sample_hidden_states = last_hidden_states[last_token_indices]
+            sample_hidden_states = index_quantized_activation(
+                last_hidden_states, last_token_indices
+            )
             draft_tokens = self.sample_draft(
                 sample_hidden_states,
                 sample_positions,


### PR DESCRIPTION
## Purpose

Optimize quantized GLM-5.2 serving on NVIDIA GPUs while preserving model
behavior and the existing dense MLP path.

This change:

- fuses activation and dynamic FP8 quantization, including the DeepGEMM
  SiLU-multiply path;
- fuses FlashInfer all-reduce + residual + RMSNorm + packed group-FP8
  quantization and forwards the prequantized activation into attention or MoE;
- lets supported modular MoE backends consume prequantized activations without
  repeating input quantization;
- keeps DeepSeek V3.2 / GLM-5.2 MTP on the compile-free NVIDIA implementation,
  preserves separate logits and feedback hidden-state contracts, and propagates
  quantized activations through speculative decoding;
- retains main's MRV2 fused multi-step decode and shared MTP top-k index buffer;
  and
- leaves dense MLP execution unchanged.

## Duplicate-work check

No issue number was provided, so an issue-specific PR search was not applicable.
I searched open PRs for `GLM-5.2 quant fusion MTP`,
`allreduce RMSNorm FP8 quant`, `DeepSeek V3.2 MTP optimization`, and
`dynamic FP8 fusion`.

The closest open work is adjacent rather than duplicative:

- #42230 adds a standalone SymmetricMemory Triton collective; this PR integrates
  FlashInfer's collective epilogue with GLM-5.2, DeepGEMM, MoE, and MTP.
- #45364 manually fuses Llama RMSNorm-to-quant without an all-reduce or
  DeepGEMM/MoE data flow.
- #45770 fixes mixed RMSNorm input/weight dtypes in existing kernels.
- #49828 adds a standalone CUDA SiLU-and-multiply dynamic per-token quant kernel;
  this PR's activation contract and DeepGEMM packed group-FP8 path are different.
- #45151 fuses an attention epilogue, and #46935 is an AsyncTP scaffold; neither
  implements this end-to-end model path.

## Performance and model evaluation

Hardware: two GB200 nodes, TP=8, concurrency=1, random 8,192-token input and
1,024-token output, two warmups, ten measured prompts, temperature 0, MTP=3,
piecewise CUDA graphs.

| zai-org/GLM-5.2-FP8 | Main | Optimized | Change |
|---|---:|---:|---:|
| Mean TTFT | 587.68 ms | 544.75 ms | -7.3% |
| Mean TPOT | 76.80 ms | 74.35 ms | -3.2% |
| MTP acceptance | 83.70% | 87.07% | +3.37 pp |

This A/B was collected before the final rebase onto current main; the resolved
rebase retained main's newer MRV2 lifecycle.

The final compile-free acceptance validation used the same 8K/1K, C1, MTP=3,
TP=8 setup and completed all ten prompts without failures:

| Model | Overall | Position 0 | Position 1 | Position 2 |
|---|---:|---:|---:|---:|
| zai-org/GLM-5.2-FP8 | 83.47% | 90.83% | 83.00% | 76.57% |
| nvidia/GLM-5.2-NVFP4 | 89.82% | 93.79% | 90.15% | 85.53% |

Full GSM8K evaluation for `zai-org/GLM-5.2-FP8`: 1,242 / 1,319 strict exact
matches, **94.16%**. The same score was reproduced after the miscellaneous quant
fusions and after the autoregressive/MTP changes.

## Test plan and results

```bash
.venv/bin/python -m pytest \
  tests/config/test_speculative_draft_hf_overrides.py \
  tests/fusion/test_quant_activation_contract.py \
  tests/models/deepseek_v32/test_sequence_parallel.py \
  tests/v1/spec_decode/test_llm_base_proposer_sampling.py -q
# 25 passed

.venv/bin/python -m pytest \
  tests/v1/worker/test_gpu_autoregressive_speculator.py -q
# 17 passed

.venv/bin/python -m pytest \
  tests/kernels/core/test_fused_allreduce_gemma_rms_norm.py::test_fused_allreduce_rms_norm_group_fp8 -q
# 4 passed

.venv/bin/python -m pytest \
  tests/kernels/moe/test_deepgemm.py \
  tests/kernels/moe/test_silu_mul_fp8_quant_deep_gemm.py \
  tests/kernels/test_fused_deepseek_v32_norm_rope.py -q
# 85 passed, 3 skipped

git diff --name-only -z origin/main...HEAD | xargs -0 pre-commit run --files
# all applicable hooks passed, including ruff and mypy
```

A broader run of `test_fused_allreduce_gemma_rms_norm.py` passed 18 existing
distributed cases, then hit one unchanged BF16 Gemma comparison at TP=4:
15 / 1,363,968 residual elements differed, with max absolute difference 0.03125
against the existing 0.02 tolerance. The newly added packed FP8 cases were then
run independently and all four passed. No tolerance was changed in this PR.

## AI assistance disclosure

This change was developed with OpenAI Codex assistance. This is intentionally a
draft PR. Before marking it ready for review, the human submitter must review
every changed line, understand and be able to defend the implementation and
results end-to-end, and update this section to confirm that review.
