### PR TITLE
[Model] Register sparse DeepSeek V3.2 MTP

### DIFF
--- a/tests/config/test_speculative_draft_hf_overrides.py
+++ b/tests/config/test_speculative_draft_hf_overrides.py
@@ -86,6 +86,21 @@ def test_arch_mapping_applies_before_callable_override():
 
 
 @pytest.mark.cpu_test
+def test_glm_dsa_uses_sparse_mtp_model():
+    config = _make_hf_config(
+        architectures=["GlmMoeDsaForCausalLM"],
+        model_type="glm_moe_dsa",
+        num_nextn_predict_layers=1,
+    )
+
+    out = SpeculativeConfig.hf_config_override(config)
+
+    assert out.model_type == "deepseek_mtp"
+    assert out.architectures == ["DeepseekV32MTPModel"]
+    assert out.n_predict == 1
+
+
+@pytest.mark.cpu_test
 def test_inkling_override_exposes_only_first_mtp_depth():
     text_config = _make_hf_config(
         architectures=["InklingForCausalLM"],

--- a/tests/models/registry.py
+++ b/tests/models/registry.py
@@ -1644,6 +1644,10 @@ _SPECULATIVE_DECODING_EXAMPLE_MODELS = {
         speculative_model="luccafong/deepseek_mtp_draft_random",
         trust_remote_code=True,
     ),
+    "DeepseekV32MTPModel": _HfExamplesInfo(
+        "deepseek-ai/DeepSeek-V3.2-Exp",
+        speculative_model="deepseek-ai/DeepSeek-V3.2-Exp",
+    ),
     "DeepSeekV4MTPModel": _HfExamplesInfo(
         "deepseek-ai/DeepSeek-V4-Flash",
         speculative_model="deepseek-ai/DeepSeek-V4-Flash",

--- a/tests/v1/spec_decode/test_llm_base_proposer_sampling.py
+++ b/tests/v1/spec_decode/test_llm_base_proposer_sampling.py
@@ -78,6 +78,7 @@ def test_compute_probs_and_sample_next_token_uses_fp64_exponential_race():
     ("architecture", "expected"),
     [
         ("DeepSeekMTPModel", True),
+        ("DeepseekV32MTPModel", True),
         ("KimiK3MTPModel", True),
         ("MiniMaxM3ForCausalLM", False),
     ],

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -336,6 +336,7 @@ class SpeculativeConfig:
     @staticmethod
     def hf_config_override(hf_config: PretrainedConfig) -> PretrainedConfig:
         initial_architecture = hf_config.architectures[0]
+        use_sparse_mtp = hf_config.model_type == "glm_moe_dsa"
         if hf_config.model_type in (
             "deepseek_v3",
             "deepseek_v32",
@@ -345,7 +346,12 @@ class SpeculativeConfig:
         if hf_config.model_type == "deepseek_mtp":
             n_predict = getattr(hf_config, "num_nextn_predict_layers", None)
             hf_config.update(
-                {"n_predict": n_predict, "architectures": ["DeepSeekMTPModel"]}
+                {
+                    "n_predict": n_predict,
+                    "architectures": [
+                        "DeepseekV32MTPModel" if use_sparse_mtp else "DeepSeekMTPModel"
+                    ],
+                }
             )
         if hf_config.model_type == "deepseek_v4":
             hf_config.model_type = "deepseek_mtp"

--- a/vllm/model_executor/models/registry.py
+++ b/vllm/model_executor/models/registry.py
@@ -645,6 +645,7 @@ _SPECULATIVE_DECODING_MODELS = {
     "Eagle3DeepseekV3ForCausalLM": ("deepseek_eagle3", "Eagle3DeepseekV2ForCausalLM"),
     "EagleDeepSeekMTPModel": ("deepseek_eagle", "EagleDeepseekV3ForCausalLM"),
     "DeepSeekMTPModel": ("deepseek_mtp", "DeepSeekMTP"),
+    "DeepseekV32MTPModel": ("vllm.models.deepseek_v32", "DeepseekV32MTP"),
     "DeepSeekV4MTPModel": ("vllm.models.deepseek_v4", "DeepSeekV4MTP"),
     "BailingMoeV3MTPModel": ("bailing_moe_v3_mtp", "BailingMoeV3MTPModel"),
     "MiniMaxM3MTP": ("vllm.models.minimax_m3", "MiniMaxM3MTP"),

--- a/vllm/v1/spec_decode/llm_base_proposer.py
+++ b/vllm/v1/spec_decode/llm_base_proposer.py
@@ -1018,7 +1018,11 @@ class SpecDecodeBaseProposer:
             # feedback into the next draft step.
             architectures = self.draft_model_config.hf_config.architectures or []
             return bool(
-                {"DeepSeekMTPModel", "KimiK3MTPModel"}.intersection(architectures)
+                {
+                    "DeepSeekMTPModel",
+                    "DeepseekV32MTPModel",
+                    "KimiK3MTPModel",
+                }.intersection(architectures)
             )
         return self.method not in ("mtp", "draft_model", "dflash")
 


### PR DESCRIPTION
## Purpose

Register the sparse DeepSeek V3.2 MTP implementation and select it for
`glm_moe_dsa` speculative decoding configs.

GLM MoE DSA previously inherited the generic `DeepSeekMTPModel` override even
though its draft model needs the sparse DeepSeek V3.2 implementation. This PR:

- maps the config to `DeepseekV32MTPModel`;
- registers that architecture with the model registry; and
- preserves its `(logits_hidden, feedback_hidden)` return contract in the
  legacy proposer.

This PR is independent of the quantization optimization PRs split from #51936.

## Duplicate-work check

No issue number was provided. I searched open PRs for
`DeepseekV32MTPModel registry`; the only matching PR was the superseded draft
#51936 from which this focused change was extracted.

## Tests

```bash
.venv/bin/python -m pytest \
  tests/config/test_speculative_draft_hf_overrides.py \
  tests/v1/spec_decode/test_llm_base_proposer_sampling.py -q
# 12 passed

pre-commit run --files \
  tests/config/test_speculative_draft_hf_overrides.py \
  tests/models/registry.py \
  tests/v1/spec_decode/test_llm_base_proposer_sampling.py \
  vllm/config/speculative.py \
  vllm/model_executor/models/registry.py \
  vllm/v1/spec_decode/llm_base_proposer.py
# all applicable hooks passed
```

## AI assistance disclosure

This change was developed with OpenAI Codex assistance. This is a draft PR;
the human submitter must review every changed line and confirm they understand
and can defend the change before marking it ready.
