### PR TITLE
[MoE] Accept prequantized DeepGEMM inputs

### DIFF
--- a/tests/kernels/moe/test_deepgemm.py
+++ b/tests/kernels/moe/test_deepgemm.py
@@ -34,6 +34,7 @@ from vllm.model_executor.layers.fused_moe.experts.triton_deep_gemm_moe import (
 from vllm.model_executor.layers.fused_moe.fused_moe import fused_experts
 from vllm.model_executor.layers.quantization.utils.fp8_utils import (
     per_token_group_quant_fp8,
+    per_token_group_quant_fp8_packed_for_deepgemm,
 )
 from vllm.utils.deep_gemm import (
     calc_diff,
@@ -184,6 +185,26 @@ def run_single_case(m, n, k, topk, num_experts, block_size):
     )
     diff = calc_diff(out_deepgemm, out_triton)
     assert diff < 0.001, f"Diff exceeded 1%: {diff}"
+    if deep_gemm_experts.input_quant_key is not None:
+        prequantized, prequantized_scale = (
+            per_token_group_quant_fp8_packed_for_deepgemm(tokens_bf16, block_size[1])
+        )
+        out_prequantized = deep_gemm_experts.apply(
+            hidden_states=tokens_bf16,
+            w1=w1,
+            w2=w2,
+            topk_weights=topk_weights,
+            topk_ids=topk_ids,
+            global_num_experts=num_experts,
+            activation=MoEActivation.SILU,
+            apply_router_weight_on_input=False,
+            expert_map=None,
+            prequantized_data=prequantized,
+            prequantized_scale=prequantized_scale,
+        )
+        torch.testing.assert_close(out_prequantized, out_deepgemm, rtol=0, atol=0)
+        return 2
+    return 1
 
 
 # Note: N <= 512 will disable the deepgemm path due to performance issues.
@@ -222,7 +243,7 @@ def test_deepgemm_vs_triton(m, n, k, topk, num_experts, monkeypatch, workspace_i
         if topk > num_experts:
             pytest.skip(f"topk={topk} > num_experts={num_experts}")
 
-        run_single_case(
+        expected_calls = run_single_case(
             m=m,
             n=n,
             k=k,
@@ -232,7 +253,7 @@ def test_deepgemm_vs_triton(m, n, k, topk, num_experts, monkeypatch, workspace_i
         )
 
         # ensure that the DeepGEMM path was indeed taken.
-        assert call_counter["cnt"] == 1, (
+        assert call_counter["cnt"] == expected_calls, (
             f"DeepGEMM path was not executed during the test. "
             f"Call counter: {call_counter['cnt']}"
         )

--- a/tests/kernels/moe/test_silu_mul_fp8_quant_deep_gemm.py
+++ b/tests/kernels/moe/test_silu_mul_fp8_quant_deep_gemm.py
@@ -150,7 +150,7 @@ def pack_scales(x: torch.Tensor, tokens_per_expert: torch.Tensor) -> torch.Tenso
 
     # Add i32_padding here so we can view it as a i32 tensor later on.
     i32_padding = round_up(G, 4) - G
-    ref_s_i8 = torch.empty((E, T, G + i32_padding), dtype=torch.uint8, device=DEVICE)
+    ref_s_i8 = torch.zeros((E, T, G + i32_padding), dtype=torch.uint8, device=DEVICE)
     for e in range(E):
         nt = tokens_per_expert[e].item()
         ref_s_i8[e, :nt, :G] = x[e, :nt].view(torch.int32) >> 23
@@ -184,7 +184,7 @@ def ref_with_scale_fmt(
     ]
 
     ref_q = torch.empty((E, T, H), dtype=fp8_dtype, device=DEVICE)
-    ref_s_f32 = torch.empty(
+    ref_s_f32 = torch.zeros(
         (E, T, cdiv(H, group_size)), dtype=torch.float32, device=DEVICE
     )
 

--- a/vllm/model_executor/layers/fused_moe/deep_gemm_utils.py
+++ b/vllm/model_executor/layers/fused_moe/deep_gemm_utils.py
@@ -187,6 +187,7 @@ def _fwd_kernel_ep_scatter_2(
     SCALE_HIDDEN_SIZE: tl.constexpr,
     SCALE_HIDDEN_SIZE_PAD: tl.constexpr,
     PACK_UE8M0: tl.constexpr,
+    INPUT_PACKED_UE8M0: tl.constexpr,
     SCALE_PACKED_SIZE: tl.constexpr,
     SCALE_PACKED_SIZE_PAD: tl.constexpr,
 ):
@@ -210,28 +211,37 @@ def _fwd_kernel_ep_scatter_2(
         to_copy = tl.load(recv_x + token_id * recv_x_stride0 + offset_in, mask=mask)
 
         if PACK_UE8M0:
-            # Pack 4 UE8M0 bytes into one int32 (byte j = group 4*pk+j).
             base_s = recv_x_scale + token_id * recv_x_scale_stride0
-            g0, g1 = offs_pk * 4, offs_pk * 4 + 1
-            g2, g3 = offs_pk * 4 + 2, offs_pk * 4 + 3
-            b0 = tl.load(
-                base_s + g0 * recv_x_scale_stride1, mask=g0 < SCALE_HIDDEN_SIZE
-            )
-            b1 = tl.load(
-                base_s + g1 * recv_x_scale_stride1, mask=g1 < SCALE_HIDDEN_SIZE
-            )
-            b2 = tl.load(
-                base_s + g2 * recv_x_scale_stride1, mask=g2 < SCALE_HIDDEN_SIZE
-            )
-            b3 = tl.load(
-                base_s + g3 * recv_x_scale_stride1, mask=g3 < SCALE_HIDDEN_SIZE
-            )
-            packed_s = (
-                b0.to(tl.int32)
-                | (b1.to(tl.int32) << 8)
-                | (b2.to(tl.int32) << 16)
-                | (b3.to(tl.int32) << 24)
-            )
+            if INPUT_PACKED_UE8M0:
+                packed_s = tl.load(
+                    base_s + offs_pk * recv_x_scale_stride1, mask=mask_pk
+                )
+            else:
+                # Pack 4 UE8M0 bytes into one int32 (byte j = group 4*pk+j).
+                g0, g1 = offs_pk * 4, offs_pk * 4 + 1
+                g2, g3 = offs_pk * 4 + 2, offs_pk * 4 + 3
+                b0 = tl.load(
+                    base_s + g0 * recv_x_scale_stride1,
+                    mask=g0 < SCALE_HIDDEN_SIZE,
+                )
+                b1 = tl.load(
+                    base_s + g1 * recv_x_scale_stride1,
+                    mask=g1 < SCALE_HIDDEN_SIZE,
+                )
+                b2 = tl.load(
+                    base_s + g2 * recv_x_scale_stride1,
+                    mask=g2 < SCALE_HIDDEN_SIZE,
+                )
+                b3 = tl.load(
+                    base_s + g3 * recv_x_scale_stride1,
+                    mask=g3 < SCALE_HIDDEN_SIZE,
+                )
+                packed_s = (
+                    b0.to(tl.int32)
+                    | (b1.to(tl.int32) << 8)
+                    | (b2.to(tl.int32) << 16)
+                    | (b3.to(tl.int32) << 24)
+                )
         else:
             to_copy_s = tl.load(
                 recv_x_scale + token_id * recv_x_scale_stride0 + offset_in_s,
@@ -286,6 +296,7 @@ def ep_scatter(
     align_m: int = 128,
     block_size: int = 128,
     pack_ue8m0: bool = False,
+    input_packed_ue8m0: bool = False,
 ):
     # BLOCK_E is the m_indices fill-loop tile (masked), independent of align_m.
     BLOCK_E = 128
@@ -299,7 +310,9 @@ def ep_scatter(
     assert m_indices.shape[0] % align_m == 0
     assert expert_start_loc.shape[0] == num_experts
 
-    # pack_ue8m0: scatter packs 4 UE8M0 bytes per int32; else copies scales as-is.
+    assert not input_packed_ue8m0 or pack_ue8m0
+    # pack_ue8m0: scatter writes 4 UE8M0 bytes per int32; input may already
+    # have that representation or be packed by the scatter kernel.
     scale_hidden_size = hidden_size // BLOCK_D
     scale_packed_size = (scale_hidden_size + 3) // 4 if pack_ue8m0 else 1
 
@@ -346,6 +359,7 @@ def ep_scatter(
         SCALE_HIDDEN_SIZE=scale_hidden_size,
         SCALE_HIDDEN_SIZE_PAD=triton.next_power_of_2(scale_hidden_size),
         PACK_UE8M0=pack_ue8m0,
+        INPUT_PACKED_UE8M0=input_packed_ue8m0,
         SCALE_PACKED_SIZE=scale_packed_size,
         SCALE_PACKED_SIZE_PAD=triton.next_power_of_2(scale_packed_size),
     )
@@ -493,9 +507,10 @@ def deepgemm_moe_permute(
     if aq_out is None:
         aq_out = torch.empty((M_sum, H), device=device, dtype=aq.dtype)
 
-    # uint8 UE8M0 (MXFP8) -> scatter packs into DeepGEMM's int32 MN-major
-    # TMA-aligned layout; float32 (FP8/FP4) scattered row-major as-is.
-    pack_ue8m0 = aq_scale.dtype == torch.uint8
+    # uint8 UE8M0 (MXFP8) is packed by scatter; int32 UE8M0 is already packed;
+    # float32 FP8/FP4 scales are scattered row-major as-is.
+    input_packed_ue8m0 = aq_scale.dtype == torch.int32
+    pack_ue8m0 = aq_scale.dtype == torch.uint8 or input_packed_ue8m0
     sf_k = H // block_k
     if pack_ue8m0:
         packed_sf_k = (sf_k + 3) // 4
@@ -544,6 +559,7 @@ def deepgemm_moe_permute(
         align_m=align_used,
         block_size=block_k,
         pack_ue8m0=pack_ue8m0,
+        input_packed_ue8m0=input_packed_ue8m0,
     )
 
     return aq_out, aq_scale_out, expert_ids, inv_perm, align_used

--- a/vllm/model_executor/layers/fused_moe/experts/deep_gemm_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/deep_gemm_moe.py
@@ -148,6 +148,15 @@ class DeepGemmExperts(mk.FusedMoEExpertsModular):
             quant_config.gemm1_beta if quant_config.gemm1_beta is not None else 0.0
         )
 
+    @property
+    def input_quant_key(self) -> QuantKey | None:
+        if (
+            self.mxfp8
+            or DeepGemmQuantScaleFMT.from_oracle() != DeepGemmQuantScaleFMT.UE8M0
+        ):
+            return None
+        return kFp8Dynamic128Sym
+
     @staticmethod
     def activation_format() -> mk.FusedMoEActivationFormat:
         return mk.FusedMoEActivationFormat.Standard

--- a/vllm/model_executor/layers/fused_moe/experts/triton_deep_gemm_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/triton_deep_gemm_moe.py
@@ -16,6 +16,7 @@ from vllm.model_executor.layers.fused_moe.experts.deep_gemm_moe import (
 )
 from vllm.model_executor.layers.fused_moe.experts.fallback import FallbackExperts
 from vllm.model_executor.layers.fused_moe.experts.triton_moe import TritonExperts
+from vllm.model_executor.layers.quantization.utils.quant_utils import QuantKey
 from vllm.utils.deep_gemm import (
     is_deep_gemm_e8m0_used,
 )
@@ -29,6 +30,12 @@ class TritonOrDeepGemmExperts(FallbackExperts):
             experts=DeepGemmExperts(moe_config, quant_config),
             fallback_experts=TritonExperts(moe_config, quant_config),
         )
+
+    @property
+    def input_quant_key(self) -> QuantKey | None:
+        if is_deep_gemm_e8m0_used():
+            return self.experts.input_quant_key
+        return None
 
     @staticmethod
     def get_clses() -> tuple[

--- a/vllm/model_executor/layers/fused_moe/fused_moe_method_base.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe_method_base.py
@@ -16,6 +16,7 @@ from vllm.model_executor.layers.fused_moe.config import (
 from vllm.model_executor.layers.quantization.base_config import (
     QuantizeMethodBase,
 )
+from vllm.model_executor.layers.quantization.utils.quant_utils import QuantKey
 
 if TYPE_CHECKING:
     from vllm.model_executor.layers.fused_moe.routed_experts import RoutedExperts
@@ -36,6 +37,10 @@ class FusedMoEMethodBase(QuantizeMethodBase):
         # NOTE(rob): temporary attribute to indicate support for
         # completed migration to the new internal MK interface.
         return self.moe_kernel is not None
+
+    @property
+    def input_quant_key(self) -> QuantKey | None:
+        return None
 
     @property
     def mk_can_overlap_shared_experts(self) -> bool:

--- a/vllm/model_executor/layers/fused_moe/modular_kernel.py
+++ b/vllm/model_executor/layers/fused_moe/modular_kernel.py
@@ -261,6 +261,10 @@ class FusedMoEPrepareAndFinalizeModular(FusedMoEPrepareAndFinalize):
     described above for the Modular case.
     """
 
+    def supports_prequantized_input(self) -> bool:
+        """Whether prepare may be bypassed with matching quantized input."""
+        return False
+
     @abstractmethod
     def prepare(
         self,
@@ -527,6 +531,11 @@ class FusedMoEExperts(ABC):
         Sample subclasses that override are AITER and FlashInfer CUTLASS.
         """
         return False
+
+    @property
+    def input_quant_key(self) -> QuantKey | None:
+        """Quantization contract accepted from an upstream fused producer."""
+        return None
 
     @staticmethod
     @abstractmethod
@@ -1433,6 +1442,8 @@ class FusedMoEKernelModularImpl:
         apply_router_weight_on_input: bool = False,
         shared_experts: SharedExperts | None = None,
         shared_experts_input: torch.Tensor | None = None,
+        prequantized_data: torch.Tensor | None = None,
+        prequantized_scale: torch.Tensor | None = None,
     ) -> torch.Tensor:
         """
         This function computes a Mixture of Experts (MoE) layer using two sets
@@ -1468,14 +1479,24 @@ class FusedMoEKernelModularImpl:
         if global_num_experts == -1:
             global_num_experts = local_num_experts
 
-        a1q, a1q_scale, expert_tokens_meta, topk_ids, topk_weights = self._prepare(
-            hidden_states,
-            topk_weights,
-            topk_ids,
-            global_num_experts,
-            expert_map,
-            apply_router_weight_on_input,
-        )
+        if prequantized_data is None:
+            assert prequantized_scale is None
+            a1q, a1q_scale, expert_tokens_meta, topk_ids, topk_weights = self._prepare(
+                hidden_states,
+                topk_weights,
+                topk_ids,
+                global_num_experts,
+                expert_map,
+                apply_router_weight_on_input,
+            )
+        else:
+            assert prequantized_scale is not None
+            assert self.prepare_finalize.supports_prequantized_input()
+            assert not apply_router_weight_on_input
+            assert prequantized_data.shape == hidden_states.shape
+            a1q = prequantized_data
+            a1q_scale = prequantized_scale
+            expert_tokens_meta = None
 
         # Stash the original unquantized hidden states on the LoRA context
         # so apply_w13_lora sees correct-magnitude activations instead of
@@ -1633,6 +1654,15 @@ class FusedMoEKernel:
         return self.impl.fused_experts
 
     @property
+    def input_quant_key(self) -> QuantKey | None:
+        if (
+            isinstance(self.impl, FusedMoEKernelModularImpl)
+            and self.impl.prepare_finalize.supports_prequantized_input()
+        ):
+            return self.fused_experts.input_quant_key
+        return None
+
+    @property
     def moe_config(self) -> FusedMoEConfig:
         return self.fused_experts.moe_config
 
@@ -1702,6 +1732,8 @@ class FusedMoEKernel:
         apply_router_weight_on_input: bool,
         shared_experts: SharedExperts | None = None,
         shared_experts_input: torch.Tensor | None = None,
+        prequantized_data: torch.Tensor | None = None,
+        prequantized_scale: torch.Tensor | None = None,
     ) -> torch.Tensor:
         assert isinstance(self.impl, FusedMoEKernelModularImpl)
         return self.impl.apply(
@@ -1716,4 +1748,6 @@ class FusedMoEKernel:
             apply_router_weight_on_input=apply_router_weight_on_input,
             shared_experts=shared_experts,
             shared_experts_input=shared_experts_input,
+            prequantized_data=prequantized_data,
+            prequantized_scale=prequantized_scale,
         )

--- a/vllm/model_executor/layers/fused_moe/prepare_finalize/no_dp_ep.py
+++ b/vllm/model_executor/layers/fused_moe/prepare_finalize/no_dp_ep.py
@@ -38,6 +38,9 @@ def _quantize_input(
 
 
 class MoEPrepareAndFinalizeNoDPEPModular(mk.FusedMoEPrepareAndFinalizeModular):
+    def supports_prequantized_input(self) -> bool:
+        return True
+
     @property
     def activation_format(self) -> mk.FusedMoEActivationFormat:
         return mk.FusedMoEActivationFormat.Standard

--- a/vllm/model_executor/layers/fused_moe/routed_experts.py
+++ b/vllm/model_executor/layers/fused_moe/routed_experts.py
@@ -1230,6 +1230,30 @@ class RoutedExperts(PluggableLayer):
             shared_experts_input=shared_experts_input,
         )
 
+    def forward_modular_prequantized(
+        self,
+        x: torch.Tensor,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+        data: torch.Tensor,
+        scale: torch.Tensor,
+        shared_experts: "SharedExperts | None" = None,
+        shared_experts_input: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        assert not self.quant_method.is_monolithic
+        apply_prequantized = getattr(self.quant_method, "apply_prequantized", None)
+        assert apply_prequantized is not None
+        return apply_prequantized(
+            layer=self,
+            x=x,
+            topk_weights=topk_weights,
+            topk_ids=topk_ids,
+            shared_experts=shared_experts,
+            shared_experts_input=shared_experts_input,
+            data=data,
+            scale=scale,
+        )
+
     def forward_monolithic(
         self,
         x: torch.Tensor,

--- a/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
+++ b/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
@@ -44,6 +44,8 @@ from vllm.model_executor.layers.fused_moe.runner.shared_experts import (
     SharedExperts,
     SharedExpertsOrder,
 )
+from vllm.model_executor.layers.fusion.quant_activation import QuantizedActivation
+from vllm.model_executor.layers.quantization.utils.quant_utils import QuantKey
 from vllm.platforms import current_platform
 from vllm.utils.torch_utils import (
     _USE_LAYERNAME,
@@ -117,6 +119,8 @@ def _moe_forward(
     router_logits: torch.Tensor,
     shared_experts_input: torch.Tensor | None,
     input_ids: torch.Tensor | None,
+    prequantized_data: torch.Tensor | None,
+    prequantized_scale: torch.Tensor | None,
     layer_name: _layer_name_type,
     hidden_dim_unpadded: int,
 ) -> torch.Tensor:
@@ -126,6 +130,8 @@ def _moe_forward(
         router_logits,
         shared_experts_input,
         input_ids,
+        prequantized_data,
+        prequantized_scale,
     )
 
 
@@ -134,6 +140,8 @@ def _moe_forward_fake(
     router_logits: torch.Tensor,
     shared_experts_input: torch.Tensor | None,
     input_ids: torch.Tensor | None,
+    prequantized_data: torch.Tensor | None,
+    prequantized_scale: torch.Tensor | None,
     layer_name: _layer_name_type,
     hidden_dim_unpadded: int,
 ) -> torch.Tensor:
@@ -151,6 +159,8 @@ def _moe_forward_shared(
     router_logits: torch.Tensor,
     shared_experts_input: torch.Tensor | None,
     input_ids: torch.Tensor | None,
+    prequantized_data: torch.Tensor | None,
+    prequantized_scale: torch.Tensor | None,
     layer_name: _layer_name_type,
     hidden_dim_unpadded: int,
 ) -> tuple[torch.Tensor, torch.Tensor]:
@@ -160,6 +170,8 @@ def _moe_forward_shared(
         router_logits,
         shared_experts_input,
         input_ids,
+        prequantized_data,
+        prequantized_scale,
     )
 
 
@@ -168,6 +180,8 @@ def _moe_forward_shared_fake(
     router_logits: torch.Tensor,
     shared_experts_input: torch.Tensor | None,
     input_ids: torch.Tensor | None,
+    prequantized_data: torch.Tensor | None,
+    prequantized_scale: torch.Tensor | None,
     layer_name: _layer_name_type,
     hidden_dim_unpadded: int,
 ) -> tuple[torch.Tensor, torch.Tensor]:
@@ -310,6 +324,10 @@ class MoERunner(MoERunnerInterface):
     @property
     def shared_experts(self) -> SharedExperts | None:
         return self._shared_experts
+
+    @property
+    def input_quant_key(self) -> QuantKey | None:
+        return self._quant_method.input_quant_key
 
     # TODO(bnell): Temporary hack. Get rid of this.
     def _replace_quant_method(self, quant_method: FusedMoEMethodBase):
@@ -574,6 +592,8 @@ class MoERunner(MoERunnerInterface):
         shared_experts_input: torch.Tensor | None,
         input_ids: torch.Tensor | None = None,
         shared_experts_overlapping: bool = False,
+        prequantized_data: torch.Tensor | None = None,
+        prequantized_scale: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor | None, torch.Tensor]:
         """Run expert routing and the fused MoE kernel via the quant method.
 
@@ -605,13 +625,26 @@ class MoERunner(MoERunnerInterface):
                 input_ids=input_ids,
             )
 
-            fused_out = self.routed_experts.forward_modular(
-                x=hidden_states,
-                topk_weights=topk_weights,
-                topk_ids=topk_ids,
-                shared_experts=self._shared_experts,
-                shared_experts_input=shared_experts_input,
-            )
+            if prequantized_data is None:
+                assert prequantized_scale is None
+                fused_out = self.routed_experts.forward_modular(
+                    x=hidden_states,
+                    topk_weights=topk_weights,
+                    topk_ids=topk_ids,
+                    shared_experts=self._shared_experts,
+                    shared_experts_input=shared_experts_input,
+                )
+            else:
+                assert prequantized_scale is not None
+                fused_out = self.routed_experts.forward_modular_prequantized(
+                    x=hidden_states,
+                    topk_weights=topk_weights,
+                    topk_ids=topk_ids,
+                    data=prequantized_data,
+                    scale=prequantized_scale,
+                    shared_experts=self._shared_experts,
+                    shared_experts_input=shared_experts_input,
+                )
 
         if shared_experts_overlapping:
             assert self._shared_experts is not None
@@ -659,6 +692,7 @@ class MoERunner(MoERunnerInterface):
         router_logits: torch.Tensor,
         input_ids: torch.Tensor | None = None,
         shared_experts_input: torch.Tensor | None = None,
+        quantized_hidden_states: QuantizedActivation | None = None,
     ) -> torch.Tensor:
         """Invoke the fused moe layer.
 
@@ -703,11 +737,22 @@ class MoERunner(MoERunnerInterface):
             )
         )
 
+        if quantized_hidden_states is None:
+            prequantized_data = None
+            prequantized_scale = None
+        else:
+            assert quantized_hidden_states.quant_key == self.input_quant_key
+            assert quantized_hidden_states.orig_shape == hidden_states.shape
+            prequantized_data = quantized_hidden_states.data
+            prequantized_scale = quantized_hidden_states.scale
+
         result = self._forward_entry(
             hidden_states,
             router_logits,
             shared_experts_input,
             input_ids,
+            prequantized_data,
+            prequantized_scale,
             self._encode_layer_name(),
             self.moe_config.hidden_dim_unpadded
             if self._quant_method.has_unpadded_output
@@ -825,6 +870,8 @@ class MoERunner(MoERunnerInterface):
         router_logits: torch.Tensor,
         shared_experts_input: torch.Tensor | None,
         input_ids: torch.Tensor | None = None,
+        prequantized_data: torch.Tensor | None = None,
+        prequantized_scale: torch.Tensor | None = None,
     ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
         """Entry point called by the custom op to run the MoE computation.
 
@@ -868,12 +915,18 @@ class MoERunner(MoERunnerInterface):
                 router_logits,
             )
 
+            if prequantized_data is not None:
+                assert not self.do_naive_dispatch_combine
+                assert self.moe_config.pcp_size == 1
+
             shared_output, hidden_states = self._apply_quant_method(
                 hidden_states=hidden_states,
                 router_logits=router_logits,
                 shared_experts_input=shared_experts_input,
                 input_ids=input_ids,
                 shared_experts_overlapping=shared_experts_overlapping,
+                prequantized_data=prequantized_data,
+                prequantized_scale=prequantized_scale,
             )
 
             return self._maybe_combine(

--- a/vllm/model_executor/layers/fused_moe/runner/moe_runner_interface.py
+++ b/vllm/model_executor/layers/fused_moe/runner/moe_runner_interface.py
@@ -14,6 +14,7 @@ from vllm.model_executor.layers.fused_moe.fused_moe_method_base import (
 from vllm.model_executor.layers.fused_moe.runner.shared_experts import (
     SharedExperts,
 )
+from vllm.model_executor.layers.quantization.utils.quant_utils import QuantKey
 
 
 class MoERunnerInterface(PluggableLayer, ABC):
@@ -43,6 +44,11 @@ class MoERunnerInterface(PluggableLayer, ABC):
     @property
     @abstractmethod
     def shared_experts(self) -> SharedExperts | None:
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def input_quant_key(self) -> QuantKey | None:
         raise NotImplementedError
 
     @property

--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -58,6 +58,7 @@ from vllm.model_executor.layers.quantization.utils.marlin_utils import (
 )
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     GroupShape,
+    QuantKey,
     create_fp8_quant_key,
     is_layer_skipped,
     kFp8Dynamic128Sym,
@@ -772,6 +773,12 @@ class Fp8MoEMethod(FusedMoEMethodBase):
     def supports_eplb(self) -> bool:
         return True
 
+    @property
+    def input_quant_key(self) -> QuantKey | None:
+        if self.moe_kernel is None:
+            return None
+        return self.moe_kernel.input_quant_key
+
     def apply_monolithic(
         self,
         layer: RoutedExperts,
@@ -819,6 +826,36 @@ class Fp8MoEMethod(FusedMoEMethodBase):
             apply_router_weight_on_input=layer.apply_router_weight_on_input,
             shared_experts=shared_experts,
             shared_experts_input=shared_experts_input,
+        )
+
+    def apply_prequantized(
+        self,
+        layer: RoutedExperts,
+        x: torch.Tensor,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+        shared_experts: SharedExperts | None,
+        shared_experts_input: torch.Tensor | None,
+        data: torch.Tensor,
+        scale: torch.Tensor,
+    ) -> torch.Tensor:
+        assert not self.is_monolithic
+        assert self.moe_kernel is not None
+        assert self.input_quant_key == kFp8Dynamic128Sym
+        return self.moe_kernel.apply(
+            x,
+            layer.w13_weight,
+            layer.w2_weight,
+            topk_weights,
+            topk_ids,
+            activation=layer.activation,
+            global_num_experts=layer.global_num_experts,
+            expert_map=layer.expert_map,
+            apply_router_weight_on_input=layer.apply_router_weight_on_input,
+            shared_experts=shared_experts,
+            shared_experts_input=shared_experts_input,
+            prequantized_data=data,
+            prequantized_scale=scale,
         )
 
 

--- a/vllm/models/kimi_k3/amd/latent_moe_runner.py
+++ b/vllm/models/kimi_k3/amd/latent_moe_runner.py
@@ -8,6 +8,7 @@ from vllm.distributed import (
 )
 from vllm.logger import init_logger
 from vllm.model_executor.layers.fused_moe.runner.moe_runner import MoERunner, _unpack
+from vllm.model_executor.layers.fusion.quant_activation import QuantizedActivation
 
 logger = init_logger(__name__)
 
@@ -96,13 +97,22 @@ class ROCmLatentMoERunner(MoERunner):
         router_logits: torch.Tensor,
         input_ids: torch.Tensor | None = None,
         shared_experts_input: torch.Tensor | None = None,
+        quantized_hidden_states: QuantizedActivation | None = None,
     ) -> torch.Tensor:
-        if self._tail_shardable and not self._fused_output_is_reduced:
+        if (
+            quantized_hidden_states is None
+            and self._tail_shardable
+            and not self._fused_output_is_reduced
+        ):
             return self._fused_forward(
                 hidden_states, router_logits, input_ids, shared_experts_input
             )
         return super().forward(
-            hidden_states, router_logits, input_ids, shared_experts_input
+            hidden_states,
+            router_logits,
+            input_ids,
+            shared_experts_input,
+            quantized_hidden_states,
         )
 
     def _fused_forward(
@@ -133,6 +143,8 @@ class ROCmLatentMoERunner(MoERunner):
             router_logits,
             shared_experts_input,
             input_ids,
+            None,
+            None,
             self._encode_layer_name(),
             self.moe_config.hidden_dim_unpadded
             if self._quant_method.has_unpadded_output

--- a/vllm/models/kimi_k3/nvidia/latent_moe_runner.py
+++ b/vllm/models/kimi_k3/nvidia/latent_moe_runner.py
@@ -12,6 +12,7 @@ from vllm.distributed import (
 )
 from vllm.logger import init_logger
 from vllm.model_executor.layers.fused_moe.runner.moe_runner import MoERunner, _unpack
+from vllm.model_executor.layers.fusion.quant_activation import QuantizedActivation
 from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.platforms import current_platform
 from vllm.utils.multi_stream_utils import maybe_execute_in_parallel
@@ -273,13 +274,18 @@ class LatentMoERunner(MoERunner):
         router_logits: torch.Tensor,
         input_ids: torch.Tensor | None = None,
         shared_experts_input: torch.Tensor | None = None,
+        quantized_hidden_states: QuantizedActivation | None = None,
     ) -> torch.Tensor:
-        if self._use_fused_path():
+        if quantized_hidden_states is None and self._use_fused_path():
             return self._fused_forward(
                 hidden_states, router_logits, input_ids, shared_experts_input
             )
         return super().forward(
-            hidden_states, router_logits, input_ids, shared_experts_input
+            hidden_states,
+            router_logits,
+            input_ids,
+            shared_experts_input,
+            quantized_hidden_states,
         )
 
     def _fused_forward(
@@ -309,6 +315,8 @@ class LatentMoERunner(MoERunner):
             router_logits,
             shared_experts_input,
             input_ids,
+            None,
+            None,
             self._encode_layer_name(),
             self.moe_config.hidden_dim_unpadded
             if self._quant_method.has_unpadded_output

--- a/vllm/utils/deep_gemm.py
+++ b/vllm/utils/deep_gemm.py
@@ -91,6 +91,7 @@ class DeepGemmQuantScaleFMT(Enum):
 
 
 @functools.cache
+@torch.compiler.assume_constant_result
 def is_deep_gemm_supported() -> bool:
     """Return `True` if DeepGEMM is supported on the current platform.
     Currently, only Hopper and Blackwell GPUs are supported.
@@ -100,6 +101,7 @@ def is_deep_gemm_supported() -> bool:
 
 
 @functools.cache
+@torch.compiler.assume_constant_result
 def is_deep_gemm_e8m0_used() -> bool:
     """Return `True` if vLLM is configured to use DeepGEMM "
     "E8M0 scale on a Hopper or Blackwell-class GPU.


### PR DESCRIPTION
## Purpose

Allow modular FP8 MoE execution to consume a matching packed DeepGEMM
activation produced upstream, avoiding duplicate input quantization.

This PR adds an explicit prequantized-input capability to modular prepare/finalize
and expert interfaces, transports the data and scale through the opaque MoE op,
and teaches DeepGEMM's expert scatter to accept already-packed UE8M0 scales.
Unsupported dispatch modes retain the existing path.

This is independent of the block-linear consumer in #51939 and does not include
model-level all-reduce or MTP changes.

## Duplicate-work check

No issue number was provided. I searched open PRs for `MoE prequantized input`
and `DeepGEMM prequantized activation`; the only exact prior implementation was
the superseded draft #51936. #49636 concerns a FlashInfer MoE-EP backend and
does not add this modular DeepGEMM input contract.

## Tests

```bash
.venv/bin/python -m pytest \
  tests/kernels/moe/test_deepgemm.py \
  tests/kernels/moe/test_silu_mul_fp8_quant_deep_gemm.py -q
# 32 passed, 3 skipped

git diff --cached --name-only -z | xargs -0 pre-commit run --files
# all applicable hooks passed, including ruff and mypy
```

## AI assistance disclosure

This change was developed with OpenAI Codex assistance. This is a draft PR;
the human submitter must review every changed line and confirm they understand
and can defend the change before marking it ready.
