### PR TITLE
[Quant] Fuse all-reduce RMSNorm with packed FP8

### DIFF
--- a/tests/kernels/core/test_fused_allreduce_gemma_rms_norm.py
+++ b/tests/kernels/core/test_fused_allreduce_gemma_rms_norm.py
@@ -18,8 +18,18 @@ from vllm.distributed.communication_op import tensor_model_parallel_all_reduce
 from vllm.model_executor.layers.fused_allreduce_gemma_rms_norm import (
     fused_allreduce_gemma_rms_norm,
 )
-from vllm.model_executor.layers.layernorm import GemmaRMSNorm
+from vllm.model_executor.layers.layernorm import GemmaRMSNorm, RMSNorm
+from vllm.model_executor.layers.quantization.utils.fp8_utils import (
+    per_token_group_quant_fp8_packed_for_deepgemm,
+)
+from vllm.model_executor.layers.quantization.utils.quant_utils import (
+    kFp8Dynamic128Sym,
+)
+from vllm.models.common.ops.fused_allreduce_rms_norm import (
+    fused_allreduce_rms_norm_fp8_quant,
+)
 from vllm.platforms import current_platform
+from vllm.utils.deep_gemm import DeepGemmQuantScaleFMT, is_deep_gemm_e8m0_used
 from vllm.utils.network_utils import get_open_port
 from vllm.utils.torch_utils import set_random_seed
 
@@ -103,6 +113,85 @@ def test_fused_allreduce_gemma_rms_norm(
             dtype,
             seed,
             eps,
+        ),
+        nprocs=world_size,
+        join=True,
+    )
+
+
+@ensure_current_vllm_config()
+def _worker_fused_ar_norm_group_fp8(
+    local_rank,
+    world_size,
+    port,
+    num_tokens,
+    hidden_size,
+    dtype,
+    seed,
+    eps,
+):
+    device = torch.device(f"cuda:{local_rank}")
+    torch.accelerator.set_device_index(device)
+    init_test_distributed_environment(
+        world_size, 1, local_rank, port, local_rank=local_rank
+    )
+    assert is_deep_gemm_e8m0_used()
+    DeepGemmQuantScaleFMT.init_oracle_cache()
+    assert DeepGemmQuantScaleFMT.from_oracle() == DeepGemmQuantScaleFMT.UE8M0
+
+    set_random_seed(seed)
+    norm = RMSNorm(hidden_size, eps=eps).cuda().to(dtype)
+    with torch.no_grad():
+        norm.weight.normal_(mean=1.0, std=0.1)
+
+    torch.manual_seed(seed + 7)
+    residual = torch.randn(num_tokens, hidden_size, dtype=dtype, device=device)
+    torch.manual_seed(seed + 1000 + local_rank)
+    partial = torch.randn(num_tokens, hidden_size, dtype=dtype, device=device)
+
+    reduced = tensor_model_parallel_all_reduce(partial.clone())
+    ref_out, ref_res = norm(reduced, residual.clone())
+
+    linear = torch.nn.Module()
+    linear.input_quant_key = kFp8Dynamic128Sym
+    out, res, quant = fused_allreduce_rms_norm_fp8_quant(
+        partial.clone(), residual.clone(), norm, linear
+    )
+    torch.accelerator.synchronize()
+
+    assert quant is not None
+    ref_quant, ref_scale = per_token_group_quant_fp8_packed_for_deepgemm(out, 128)
+    torch.testing.assert_close(out, ref_out, atol=2e-2, rtol=2e-2)
+    torch.testing.assert_close(res, ref_res, atol=2e-2, rtol=2e-2)
+    assert torch.equal(quant.data, ref_quant)
+    assert torch.equal(quant.scale, ref_scale)
+
+    cleanup_dist_env_and_memory()
+
+
+@pytest.mark.skipif(
+    not current_platform.is_device_capability_family(100),
+    reason="DeepGEMM packed UE8M0 scales require Blackwell",
+)
+@pytest.mark.parametrize("world_size", [2, 4])
+@pytest.mark.parametrize("num_tokens", [1, 17])
+def test_fused_allreduce_rms_norm_group_fp8(
+    world_size: int,
+    num_tokens: int,
+):
+    num_gpus = current_platform.device_count()
+    if num_gpus < world_size:
+        pytest.skip(f"Need >= {world_size} GPUs, have {num_gpus}")
+    spawn(
+        _worker_fused_ar_norm_group_fp8,
+        args=(
+            world_size,
+            str(get_open_port()),
+            num_tokens,
+            6144,
+            torch.bfloat16,
+            42,
+            1e-6,
         ),
         nprocs=world_size,
         join=True,

--- a/vllm/compilation/passes/fusion/allreduce_rms_fusion.py
+++ b/vllm/compilation/passes/fusion/allreduce_rms_fusion.py
@@ -179,6 +179,7 @@ def _select_flashinfer_allreduce_use_oneshot(
 if flashinfer_comm is not None:
     from vllm.distributed.device_communicators.flashinfer_all_reduce import (
         destroy_fi_ar_workspace,
+        get_fi_ar_packed_quant_workspace,
         get_fi_ar_quant_workspace,
         get_fi_ar_workspace,
     )
@@ -200,6 +201,7 @@ if flashinfer_comm is not None:
         scale_out: torch.Tensor | None = None,
         scale_factor: torch.Tensor | None = None,
         weight_bias: float = 0.0,
+        block_quant_group_size: int = 0,
     ) -> None:
         # handle transformers backend passing outer batch dim.
         if allreduce_in.dim() != 2:
@@ -222,13 +224,32 @@ if flashinfer_comm is not None:
 
         # Select workspace based on pattern: quant patterns use the quant
         # workspace, non-quant patterns use the primary workspace.
-        is_quant_pattern = pattern_code in (
+        packed_quant_patterns = [
+            pattern
+            for name in (
+                "kARResidualRMSNormPerTokenGroupFP8PackedQuant",
+                "kARResidualRMSNormOutPerTokenGroupFP8PackedQuant",
+            )
+            if (pattern := getattr(ar_fusion_patterns, name, None)) is not None
+        ]
+        quant_patterns = [
             ar_fusion_patterns.kARResidualRMSNormFP8Quant,
             ar_fusion_patterns.kARResidualRMSNormFP4Quant,
+        ]
+        quant_patterns.extend(
+            pattern
+            for name in (
+                "kARResidualRMSNormDynamicFP8Quant",
+                "kARResidualRMSNormOutDynamicFP8Quant",
+            )
+            if (pattern := getattr(ar_fusion_patterns, name, None)) is not None
         )
-        get_workspace_fn = (
-            get_fi_ar_quant_workspace if is_quant_pattern else get_fi_ar_workspace
-        )
+        if pattern_code in packed_quant_patterns:
+            get_workspace_fn = get_fi_ar_packed_quant_workspace
+        elif pattern_code in quant_patterns:
+            get_workspace_fn = get_fi_ar_quant_workspace
+        else:
+            get_workspace_fn = get_fi_ar_workspace
         workspace = get_workspace_fn(
             world_size=world_size,
             rank=get_tensor_model_parallel_rank(),
@@ -262,6 +283,11 @@ if flashinfer_comm is not None:
         if workspace.backend in ("trtllm", "mnnvl"):
             layout_code = flashinfer_comm.QuantizationSFLayout.SWIZZLED_128x4
 
+        block_quant_kwargs = (
+            {"block_quant_group_size": block_quant_group_size}
+            if block_quant_group_size
+            else {}
+        )
         flashinfer_comm.allreduce_fusion(
             input=allreduce_in,
             workspace=workspace,
@@ -280,6 +306,7 @@ if flashinfer_comm is not None:
             use_oneshot=use_oneshot,
             fp32_acc=fp32_acc,
             weight_bias=weight_bias,
+            **block_quant_kwargs,
             # The one-shot Lamport all-reduce signals PDL completion before its
             # output buffer is committed when trigger_completion_at_end is
             # False, so the next PDL-launched kernel can read the uninitialized
@@ -308,6 +335,7 @@ if flashinfer_comm is not None:
         scale_out: torch.Tensor | None = None,
         scale_factor: torch.Tensor | None = None,
         weight_bias: float = 0.0,
+        block_quant_group_size: int = 0,
     ) -> None:
         pass
 

--- a/vllm/distributed/device_communicators/flashinfer_all_reduce.py
+++ b/vllm/distributed/device_communicators/flashinfer_all_reduce.py
@@ -40,6 +40,9 @@ _fi_ar_workspace = None
 # allreduce backend or a fallback backend when the primary workspace is not
 # available on the current topology.
 _fi_ar_quant_workspace = None
+# TensorRT-LLM-only workspace for packed per-token-group FP8 patterns. MNNVL
+# does not currently implement the DeepGEMM UE8M0 scale layout.
+_fi_ar_packed_quant_workspace = None
 _fi_ar_workspace_groups: dict[int, ProcessGroup] = {}
 
 
@@ -270,27 +273,75 @@ def get_fi_ar_quant_workspace(
     return _fi_ar_quant_workspace
 
 
+def get_fi_ar_packed_quant_workspace(
+    world_size: int,
+    rank: int,
+    max_token_num: int,
+    hidden_dim: int,
+    dtype: torch.dtype,
+    group: ProcessGroup,
+):
+    """Return a TensorRT-LLM workspace for packed group-FP8 fusion."""
+    global _fi_ar_packed_quant_workspace
+    if _fi_ar_packed_quant_workspace is not None:
+        return _fi_ar_packed_quant_workspace
+
+    if get_node_count() > 1:
+        logger.warning_once(
+            "FlashInfer packed group-FP8 allreduce fusion is unavailable for "
+            "multi-node tensor parallelism; using the non-quantized fusion."
+        )
+        return None
+
+    for workspace in (_fi_ar_workspace, _fi_ar_quant_workspace):
+        if workspace is not None and workspace.backend == "trtllm":
+            _fi_ar_packed_quant_workspace = workspace
+            return workspace
+
+    _fi_ar_packed_quant_workspace = _create_workspace(
+        "trtllm", world_size, rank, max_token_num, hidden_dim, dtype, group
+    )
+    if _fi_ar_packed_quant_workspace is not None:
+        logger.info_once(
+            "Initialized FlashInfer packed group-FP8 allreduce fusion workspace"
+        )
+    return _fi_ar_packed_quant_workspace
+
+
 _fi_ar_workspace_lock = threading.Lock()
 
 
 def destroy_fi_ar_workspace():
-    global _fi_ar_workspace, _fi_ar_quant_workspace
+    global _fi_ar_workspace, _fi_ar_packed_quant_workspace, _fi_ar_quant_workspace
     with _fi_ar_workspace_lock:
-        is_alias = _fi_ar_workspace is _fi_ar_quant_workspace
+        workspaces = {
+            id(workspace): workspace
+            for workspace in (
+                _fi_ar_workspace,
+                _fi_ar_quant_workspace,
+                _fi_ar_packed_quant_workspace,
+            )
+            if workspace is not None
+        }
+        for workspace in workspaces.values():
+            workspace.destroy()
 
-        if _fi_ar_workspace is not None:
-            _fi_ar_workspace.destroy()
-        if _fi_ar_quant_workspace is not None and not is_alias:
-            _fi_ar_quant_workspace.destroy()
-
-        _fi_ar_workspace = _fi_ar_quant_workspace = None
+        _fi_ar_workspace = None
+        _fi_ar_quant_workspace = None
+        _fi_ar_packed_quant_workspace = None
         _fi_ar_workspace_groups.clear()
 
 
 def _fi_ar_workspaces_for_group(group: ProcessGroup) -> list[Any]:
-    workspaces = [_fi_ar_workspace]
-    if _fi_ar_quant_workspace is not _fi_ar_workspace:
-        workspaces.append(_fi_ar_quant_workspace)
+    workspaces = {
+        id(workspace): workspace
+        for workspace in (
+            _fi_ar_workspace,
+            _fi_ar_quant_workspace,
+            _fi_ar_packed_quant_workspace,
+        )
+        if workspace is not None
+    }.values()
 
     group_workspaces = []
     for workspace in workspaces:

--- a/vllm/model_executor/layers/fused_allreduce_gemma_rms_norm.py
+++ b/vllm/model_executor/layers/fused_allreduce_gemma_rms_norm.py
@@ -52,6 +52,7 @@ except (ImportError, AttributeError):
 _FI_SUPPORTED_DTYPES = (torch.bfloat16, torch.float16)
 
 
+@torch.compiler.assume_constant_result
 def _max_token_num(tp_size: int, hidden_size: int, dtype: torch.dtype) -> int | None:
     """Workspace token budget for flashinfer fused all-reduce, or None if the
     current world size / device is unsupported. Mirrors ``FlashInferAllReduce``."""
@@ -62,6 +63,26 @@ def _max_token_num(tp_size: int, hidden_size: int, dtype: torch.dtype) -> int | 
         return None
     element_size = torch.tensor([], dtype=dtype).element_size()
     return int(max_size_mb * MiB) // (hidden_size * element_size)
+
+
+@torch.compiler.assume_constant_result
+def _has_flashinfer_workspace(
+    tp_size: int,
+    max_token_num: int,
+    hidden_size: int,
+    dtype: torch.dtype,
+) -> bool:
+    return (
+        get_fi_ar_workspace(
+            world_size=tp_size,
+            rank=get_tensor_model_parallel_rank(),
+            max_token_num=max_token_num,
+            hidden_dim=hidden_size,
+            dtype=dtype,
+            group=get_tp_group().cpu_group,
+        )
+        is not None
+    )
 
 
 def _can_use_flashinfer(hidden_states: torch.Tensor, tp_size: int) -> tuple[bool, int]:
@@ -87,15 +108,9 @@ def _can_use_flashinfer(hidden_states: torch.Tensor, tp_size: int) -> tuple[bool
 
     # Lazily create / fetch the (globally cached) workspace; returns None on
     # GPUs without NVSwitch, in which case we fall back gracefully.
-    workspace = get_fi_ar_workspace(
-        world_size=tp_size,
-        rank=get_tensor_model_parallel_rank(),
-        max_token_num=max_token_num,
-        hidden_dim=hidden_size,
-        dtype=hidden_states.dtype,
-        group=get_tp_group().cpu_group,
-    )
-    if workspace is None:
+    if not _has_flashinfer_workspace(
+        tp_size, max_token_num, hidden_size, hidden_states.dtype
+    ):
         return False, 0
     return True, max_token_num
 

--- a/vllm/model_executor/layers/fusion/fused_act_quant.py
+++ b/vllm/model_executor/layers/fusion/fused_act_quant.py
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import torch
+
+from vllm.model_executor.layers.quantization.utils.quant_utils import (
+    kFp8Dynamic128Sym,
+)
+from vllm.platforms import current_platform
+from vllm.utils.deep_gemm import DeepGemmQuantScaleFMT
+
+from .quant_activation import QuantizedActivation
+
+
+def maybe_allocate_fp8_block_quant(
+    x: torch.Tensor,
+    *linears: torch.nn.Module,
+) -> QuantizedActivation | None:
+    """Allocate a shared DeepGEMM FP8 activation for compatible consumers."""
+    if (
+        not linears
+        or DeepGemmQuantScaleFMT.from_oracle() != DeepGemmQuantScaleFMT.UE8M0
+    ):
+        return None
+
+    quant_key = getattr(linears[0], "input_quant_key", None)
+    if quant_key != kFp8Dynamic128Sym or any(
+        getattr(linear, "input_quant_key", None) != quant_key for linear in linears[1:]
+    ):
+        return None
+
+    group_size = quant_key.scale.group_shape.col
+    if x.shape[-1] % group_size != 0:
+        return None
+
+    num_rows = x.numel() // x.shape[-1]
+    num_groups = x.shape[-1] // group_size
+    num_scale_packs = (num_groups + 3) // 4
+    aligned_rows = ((num_rows + 3) // 4) * 4
+    data = torch.empty_like(x, dtype=current_platform.fp8_dtype())
+    scale = torch.empty_strided(
+        (num_rows, num_scale_packs),
+        (1, aligned_rows),
+        dtype=torch.int32,
+        device=x.device,
+    )
+    return QuantizedActivation(
+        data=data,
+        scale=scale,
+        orig_dtype=x.dtype,
+        orig_shape=x.shape,
+        quant_key=quant_key,
+    )

--- a/vllm/models/common/ops/fused_allreduce_rms_norm.py
+++ b/vllm/models/common/ops/fused_allreduce_rms_norm.py
@@ -9,7 +9,9 @@ that doesn't fire for models running eager (or under a breakable CUDA graph).
 import torch
 
 from vllm.distributed import (
+    get_tensor_model_parallel_rank,
     get_tensor_model_parallel_world_size,
+    get_tp_group,
     tensor_model_parallel_all_reduce,
 )
 from vllm.model_executor.layers.fused_allreduce_gemma_rms_norm import (
@@ -17,7 +19,48 @@ from vllm.model_executor.layers.fused_allreduce_gemma_rms_norm import (
     _can_use_flashinfer,
     flashinfer_trtllm_fused_allreduce_norm,
 )
+from vllm.model_executor.layers.fusion.fused_act_quant import (
+    maybe_allocate_fp8_block_quant,
+)
+from vllm.model_executor.layers.fusion.quant_activation import (
+    QuantizedActivation,
+)
 from vllm.model_executor.layers.layernorm import RMSNorm
+
+try:
+    from vllm.distributed.device_communicators.flashinfer_all_reduce import (
+        flashinfer_comm,
+        get_fi_ar_packed_quant_workspace,
+    )
+
+    _AR_RESIDUAL_RMS_NORM_OUT_FP8_BLOCK_QUANT = getattr(
+        flashinfer_comm.AllReduceFusionPattern,
+        "kARResidualRMSNormOutPerTokenGroupFP8PackedQuant",
+        None,
+    )
+except (ImportError, AttributeError):
+    get_fi_ar_packed_quant_workspace = None  # type: ignore[assignment]
+    _AR_RESIDUAL_RMS_NORM_OUT_FP8_BLOCK_QUANT = None
+
+
+@torch.compiler.assume_constant_result
+def _has_packed_quant_workspace(
+    tp_size: int,
+    max_token_num: int,
+    hidden_size: int,
+    dtype: torch.dtype,
+) -> bool:
+    return (
+        get_fi_ar_packed_quant_workspace(
+            world_size=tp_size,
+            rank=get_tensor_model_parallel_rank(),
+            max_token_num=max_token_num,
+            hidden_dim=hidden_size,
+            dtype=dtype,
+            group=get_tp_group().cpu_group,
+        )
+        is not None
+    )
 
 
 def fused_allreduce_rms_norm(
@@ -61,3 +104,63 @@ def fused_allreduce_rms_norm(
 
     reduced = tensor_model_parallel_all_reduce(hidden_states)
     return norm(reduced, residual)
+
+
+def fused_allreduce_rms_norm_fp8_quant(
+    hidden_states: torch.Tensor,
+    residual: torch.Tensor,
+    norm: RMSNorm,
+    consumer: torch.nn.Module,
+) -> tuple[torch.Tensor, torch.Tensor, QuantizedActivation | None]:
+    """Fuse all-reduce, residual RMSNorm, and DeepGEMM FP8 quantization.
+
+    The normalized BF16 output remains available to unquantized consumers while
+    the returned activation lets ``consumer`` skip its input quantization. The
+    regular eager path is used when the required FlashInfer collective or
+    activation contract is unavailable.
+    """
+    tp_size = get_tensor_model_parallel_world_size()
+    if (
+        tp_size == 1
+        or flashinfer_trtllm_fused_allreduce_norm is None
+        or get_fi_ar_packed_quant_workspace is None
+        or _AR_RESIDUAL_RMS_NORM_OUT_FP8_BLOCK_QUANT is None
+    ):
+        norm_out, residual_out = fused_allreduce_rms_norm(hidden_states, residual, norm)
+        return norm_out, residual_out, None
+
+    ok, max_token_num = _can_use_flashinfer(hidden_states, tp_size)
+    if ok:
+        ok = _has_packed_quant_workspace(
+            tp_size,
+            max_token_num,
+            hidden_states.shape[-1],
+            hidden_states.dtype,
+        )
+    if not ok:
+        norm_out, residual_out = fused_allreduce_rms_norm(hidden_states, residual, norm)
+        return norm_out, residual_out, None
+
+    quant = maybe_allocate_fp8_block_quant(hidden_states, consumer)
+    if quant is None:
+        norm_out, residual_out = fused_allreduce_rms_norm(hidden_states, residual, norm)
+        return norm_out, residual_out, None
+
+    norm_out = torch.empty_like(hidden_states)
+    flashinfer_trtllm_fused_allreduce_norm(
+        allreduce_in=hidden_states,
+        residual=residual,
+        rms_gamma=norm.weight,
+        rms_eps=norm.variance_epsilon,
+        world_size=tp_size,
+        weight_bias=0.0,
+        launch_with_pdl=True,
+        fp32_acc=True,
+        max_token_num=max_token_num,
+        pattern_code=_AR_RESIDUAL_RMS_NORM_OUT_FP8_BLOCK_QUANT,
+        norm_out=norm_out,
+        quant_out=quant.data,
+        scale_out=quant.scale,
+        block_quant_group_size=128,
+    )
+    return norm_out, hidden_states, quant


### PR DESCRIPTION
## Purpose

Expose FlashInfer's all-reduce + residual + RMSNorm + packed per-group FP8
epilogue to eager model paths.

The helper returns both the normalized BF16 tensor and a compatible
`QuantizedActivation`, allowing an upstream model integration to skip a
separate DeepGEMM quantization kernel. It falls back to the existing
all-reduce/RMSNorm path when the pattern, topology, scale format, or consumer
contract is unsupported.

This is an independent primitive extracted from #51936. It does not change a
specific model and does not depend on #51939 or #51941; the test uses the public
consumer contract directly.

## Duplicate-work check

No issue number was provided. I searched open PRs for `FlashInfer allreduce
RMSNorm packed FP8` and `allreduce RMSNorm FP8 quant`. #42230 implements a
separate SymmetricMemory Triton collective, #45364 covers Llama RMSNorm-to-quant
without all-reduce, and #45770 fixes mixed norm-weight dtypes. None expose this
FlashInfer packed UE8M0 epilogue.

## Tests

```bash
.venv/bin/python -m pytest \
  tests/kernels/core/test_fused_allreduce_gemma_rms_norm.py::test_fused_allreduce_rms_norm_group_fp8 -q
# 4 passed

git diff --cached --name-only -z | xargs -0 pre-commit run --files
# all applicable hooks passed, including ruff and mypy
```

## AI assistance disclosure

This change was developed with OpenAI Codex assistance. This is a draft PR;
the human submitter must review every changed line and confirm they understand
and can defend the change before marking it ready.
