### PR TITLE
[Quant][DeepSeek V3.2] Fuse attention FP8 quantization

### DIFF
--- a/tests/kernels/test_fused_deepseek_v32_norm_rope.py
+++ b/tests/kernels/test_fused_deepseek_v32_norm_rope.py
@@ -27,6 +27,9 @@ rtol/atol=1e-2 (the tolerance the sibling deepseek_v4 fused-kernel test uses).
 import pytest
 import torch
 
+from vllm.model_executor.layers.quantization.utils.fp8_utils import (
+    per_token_group_quant_fp8_packed_for_deepgemm,
+)
 from vllm.models.deepseek_v32.common import kernels as K
 from vllm.platforms import current_platform
 
@@ -290,6 +293,67 @@ def test_fused_norm_rope_no_indexer(num_tokens: int):
     )
     # Shared layers reuse the previous indexer's top-k: buffer must be untouched.
     assert (topk == 7).all(), "topk buffer should be untouched on shared layer"
+
+
+@pytest.mark.parametrize("num_tokens", [1, 17, 512])
+def test_fused_norm_rope_quantizes_q_lora_for_deepgemm(num_tokens: int):
+    torch.manual_seed(7)
+    dev = "cuda"
+    max_pos = 8192
+    pos = torch.arange(num_tokens, device=dev, dtype=torch.int64)
+    q_c = torch.randn(num_tokens, Q_LORA, device=dev, dtype=torch.bfloat16)
+    kv_c = torch.randn(num_tokens, KV_LORA, device=dev, dtype=torch.bfloat16)
+    k_pe = torch.randn(num_tokens, ROPE_DIM, device=dev, dtype=torch.bfloat16)
+    qw = torch.randn(Q_LORA, device=dev, dtype=torch.bfloat16)
+    kvw = torch.randn(KV_LORA, device=dev, dtype=torch.bfloat16)
+    mla_cos_sin = make_cos_sin(max_pos, ROPE_DIM, dev)
+    mla_cache = torch.zeros(
+        1,
+        max_pos,
+        KV_LORA + ROPE_DIM,
+        device=dev,
+        dtype=torch.bfloat16,
+    )
+    slot = torch.arange(num_tokens, device=dev, dtype=torch.int64)
+    topk = torch.full((num_tokens, 2048), 7, device=dev, dtype=torch.int32)
+    q_quant = torch.empty_like(q_c, dtype=FP8)
+    num_scale_packs = (Q_LORA // 128 + 3) // 4
+    aligned_tokens = ((num_tokens + 3) // 4) * 4
+    q_scale = torch.empty_strided(
+        (num_tokens, num_scale_packs),
+        (1, aligned_tokens),
+        device=dev,
+        dtype=torch.int32,
+    )
+
+    q_out = K.fused_norm_rope(
+        pos,
+        q_c,
+        qw,
+        EPS,
+        kv_c,
+        kvw,
+        EPS,
+        k_pe,
+        mla_cos_sin,
+        None,
+        None,
+        None,
+        EPS,
+        None,
+        topk,
+        slot_mapping=slot,
+        mla_kv_cache=mla_cache,
+        has_indexer=False,
+        q_c_quant_out=q_quant,
+        q_c_quant_scale=q_scale,
+    )
+    ref_quant, ref_scale = per_token_group_quant_fp8_packed_for_deepgemm(q_out, 128)
+
+    torch.testing.assert_close(
+        q_quant.view(torch.uint8), ref_quant.view(torch.uint8), rtol=0, atol=0
+    )
+    torch.testing.assert_close(q_scale, ref_scale, rtol=0, atol=0)
 
 
 @pytest.mark.parametrize("num_tokens", [1, 4, 17, 512])

--- a/vllm/models/deepseek_v32/attention.py
+++ b/vllm/models/deepseek_v32/attention.py
@@ -9,6 +9,10 @@ from vllm.config import CacheConfig, VllmConfig
 from vllm.distributed import get_tensor_model_parallel_world_size
 from vllm.forward_context import get_forward_context
 from vllm.model_executor.layers.attention import MLAAttention
+from vllm.model_executor.layers.fusion.fused_act_quant import (
+    maybe_allocate_fp8_block_quant,
+)
+from vllm.model_executor.layers.fusion.quant_activation import QuantizedActivation
 from vllm.model_executor.layers.layernorm import LayerNorm, RMSNorm
 from vllm.model_executor.layers.linear import (
     ColumnParallelLinear,
@@ -332,9 +336,12 @@ class DeepseekV32Attention(MLAAttention):
         self,
         positions: torch.Tensor,
         hidden_states: torch.Tensor,
+        qkv_input: torch.Tensor | QuantizedActivation | None = None,
     ) -> torch.Tensor:
         # Captured: A-projections (+ indexer A-GEMM on indexer layers).
-        qkv_lora = self.fused_qkv_a_proj(hidden_states)[0]
+        qkv_lora = self.fused_qkv_a_proj(
+            hidden_states if qkv_input is None else qkv_input
+        )[0]
         q_c, kv_c, k_pe = qkv_lora.split(
             [self.q_lora_rank, self.kv_lora_rank, self.qk_rope_head_dim], dim=-1
         )
@@ -394,6 +401,10 @@ class DeepseekV32Attention(MLAAttention):
             mla_kv_cache = self.kv_cache
             mla_k_scale = self._k_scale
 
+        q_consumers = [self.q_b_proj]
+        if self.indexer is not None and not self.skip_topk:
+            q_consumers.append(self.indexer.wq_b)
+        q_c_quant = maybe_allocate_fp8_block_quant(q_c, *q_consumers)
         q_c = fused_norm_rope(
             positions,
             q_c,
@@ -417,15 +428,20 @@ class DeepseekV32Attention(MLAAttention):
             mla_k_scale=mla_k_scale,
             has_indexer=has_indexer,
             index_rope_interleave=self._index_rope_interleave,
+            q_c_quant_out=q_c_quant.data if q_c_quant is not None else None,
+            q_c_quant_scale=q_c_quant.scale if q_c_quant is not None else None,
         )
 
-        q = self.q_b_proj(q_c)[0].view(-1, self.num_local_heads, self.qk_head_dim)
+        q_proj_input = q_c_quant if q_c_quant is not None else q_c
+        q = self.q_b_proj(q_proj_input)[0].view(
+            -1, self.num_local_heads, self.qk_head_dim
+        )
         q_nope, q_pe = q.split([self.qk_nope_head_dim, self.qk_rope_head_dim], dim=-1)
         q_nope = q_nope.transpose(0, 1)
         ql_nope = torch.bmm(q_nope, self.W_UK_T).transpose(0, 1)
 
         if self.indexer is not None and not self.skip_topk:
-            index_q = self.indexer.wq_b(q_c)[0]
+            index_q = self.indexer.wq_b(q_proj_input)[0]
             index_q = index_q.view(-1, self.indexer.n_head, self.indexer.head_dim)
         else:
             index_q = None

--- a/vllm/models/deepseek_v32/common/kernels.py
+++ b/vllm/models/deepseek_v32/common/kernels.py
@@ -96,8 +96,15 @@ def _fused_norm_rope_kernel(
     q_rms_eps,
     q_c_out_ptr,
     q_c_out_stride,
+    q_c_quant_out_ptr,
+    q_c_quant_scale_ptr,
+    q_c_quant_scale_stride,
     Q_DIM: tl.constexpr,
     Q_BLOCK_SIZE: tl.constexpr,
+    Q_FP8_QUANT: tl.constexpr,
+    Q_QUANT_GROUP_SIZE: tl.constexpr,
+    Q_NUM_GROUPS: tl.constexpr,
+    Q_NUM_SCALE_PACKS: tl.constexpr,
     # KV RMS norm
     kv_ptr,
     kv_stride,
@@ -188,7 +195,42 @@ def _fused_norm_rope_kernel(
         q_c = tl.load(q_c_ptr + tok_idx * q_c_stride + q_block, mask=q_mask, other=0.0)
         q_c_rms_w = tl.load(q_rms_norm_w_ptr + q_block, mask=q_mask)
         q_c = _rms_norm(q_c, q_c_rms_w, q_rms_eps, Q_DIM)
+        q_c = q_c.to(q_c_out_ptr.dtype.element_ty)
         tl.store(q_c_out_ptr + tok_idx * q_c_out_stride + q_block, q_c, mask=q_mask)
+        if Q_FP8_QUANT:
+            num_groups: tl.constexpr = Q_BLOCK_SIZE // Q_QUANT_GROUP_SIZE
+            q_groups = tl.reshape(q_c.to(tl.float32), (num_groups, Q_QUANT_GROUP_SIZE))
+            group_absmax = tl.max(tl.abs(q_groups), axis=1)
+            scale = tl.maximum(group_absmax * (1.0 / 448.0), 1e-10)
+            scale = tl.math.exp2(tl.math.ceil(tl.math.log2(scale)))
+            q_quant = tl.clamp(
+                q_groups / tl.reshape(scale, (num_groups, 1)), -448.0, 448.0
+            ).to(q_c_quant_out_ptr.dtype.element_ty)
+            tl.store(
+                q_c_quant_out_ptr + tok_idx * Q_DIM + q_block,
+                tl.reshape(q_quant, (Q_BLOCK_SIZE,)),
+                mask=q_mask,
+            )
+
+            scales_per_pack: tl.constexpr = 4
+            scale_packs = tl.reshape(
+                scale, (num_groups // scales_per_pack, scales_per_pack)
+            )
+            scale_bits = scale_packs.to(tl.int32, bitcast=True)
+            scale_bytes = (scale_bits >> 23) & 0xFF
+            byte_offsets = tl.arange(0, scales_per_pack)
+            group_offsets = (
+                tl.arange(0, num_groups // scales_per_pack)[:, None] * scales_per_pack
+                + byte_offsets[None, :]
+            )
+            scale_bytes = tl.where(group_offsets < Q_NUM_GROUPS, scale_bytes, 0)
+            packed_scale = tl.sum(scale_bytes << (byte_offsets[None, :] * 8), axis=1)
+            pack_offsets = tl.arange(0, num_groups // scales_per_pack)
+            tl.store(
+                q_c_quant_scale_ptr + tok_idx + pack_offsets * q_c_quant_scale_stride,
+                packed_scale,
+                mask=pack_offsets < Q_NUM_SCALE_PACKS,
+            )
     elif pid == 1:
         # KV RMS Norm + KV RoPE + MLA concat_and_cache.
         # Merged so the normed kv_c and RoPE'd k_pe can be written
@@ -395,6 +437,8 @@ def fused_norm_rope(
     has_indexer: bool = True,
     index_rope_interleave: bool = False,
     q_c_out: torch.Tensor | None = None,
+    q_c_quant_out: torch.Tensor | None = None,
+    q_c_quant_scale: torch.Tensor | None = None,
 ) -> torch.Tensor:
     assert positions.ndim == 1
     assert q_c.ndim == 2
@@ -478,6 +522,18 @@ def fused_norm_rope(
 
     if q_c_out is None:
         q_c_out = torch.empty_like(q_c)
+    q_fp8_quant = q_c_quant_out is not None
+    assert q_fp8_quant == (q_c_quant_scale is not None)
+    if q_fp8_quant:
+        assert q_dim % 128 == 0
+        assert q_c_quant_out is not None
+        assert q_c_quant_scale is not None
+        assert q_c_quant_out.shape == q_c.shape
+        assert q_c_quant_scale.shape == (num_tokens, (q_dim // 128 + 3) // 4)
+        assert q_c_quant_scale.stride(0) == 1
+    else:
+        q_c_quant_out = torch.empty(0, dtype=torch.float8_e4m3fn, device=device)
+        q_c_quant_scale = torch.empty(0, dtype=torch.int32, device=device)
     use_pdl = current_platform.is_arch_support_pdl()
     _fused_norm_rope_kernel[(4, num_tokens)](
         positions,
@@ -488,8 +544,15 @@ def fused_norm_rope(
         q_rms_eps,
         q_c_out,
         q_c_out.stride(0),
+        q_c_quant_out,
+        q_c_quant_scale,
+        q_c_quant_scale.stride(1) if q_fp8_quant else 0,
         q_dim,
         triton.next_power_of_2(q_dim),
+        q_fp8_quant,
+        128,
+        q_dim // 128 if q_fp8_quant else 0,
+        (q_dim // 128 + 3) // 4 if q_fp8_quant else 0,
         # KV RMS norm
         kv_c,
         kv_c.stride(0),

--- a/vllm/models/deepseek_v32/nvidia/ops/fused_q_cutedsl.py
+++ b/vllm/models/deepseek_v32/nvidia/ops/fused_q_cutedsl.py
@@ -10,6 +10,7 @@ from cutlass import BFloat16, Float8E4M3FN, Float32, Int64, Uint8, Uint16, Uint3
 
 from vllm.cute_utils import _TORCH_TO_CUTE_DTYPE, cvt
 from vllm.platforms import current_platform
+from vllm.utils.torch_utils import direct_register_custom_op
 
 
 def _make_fake_tensor(dtype, shape, divisibility):
@@ -25,6 +26,11 @@ def _make_fake_tensor(dtype, shape, divisibility):
     )
 
 
+@torch.compiler.assume_constant_result
+def _is_sm100_or_newer() -> bool:
+    return current_platform.has_device_capability(100)
+
+
 def is_fused_q_cutedsl_supported(
     q_pe: torch.Tensor,
     index_q: torch.Tensor | None,
@@ -34,7 +40,7 @@ def is_fused_q_cutedsl_supported(
     quantize_mqa: bool,
 ) -> bool:
     if not (
-        current_platform.has_device_capability(100)
+        _is_sm100_or_newer()
         and quantize_mqa
         and q_pe.dtype == ql_nope.dtype == torch.bfloat16
         and q_pe.shape[-1] == 64
@@ -52,7 +58,7 @@ def is_fused_q_cutedsl_supported(
     )
 
 
-def fused_q_cutedsl(
+def _fused_q_cutedsl_impl(
     positions: torch.Tensor,
     q_pe: torch.Tensor,
     rope_cache: torch.Tensor,
@@ -107,6 +113,70 @@ def fused_q_cutedsl(
         idx_q_fp8,
         idx_weights_out,
         float(idx_weights_softmax_scale * idx_weights_head_scale),
+    )
+
+
+def _fused_q_cutedsl_fake(
+    positions: torch.Tensor,
+    q_pe: torch.Tensor,
+    rope_cache: torch.Tensor,
+    ql_nope: torch.Tensor,
+    q_scale: torch.Tensor,
+    mqa_output: torch.Tensor,
+    idx_q: torch.Tensor,
+    idx_rope_cache: torch.Tensor,
+    idx_weights: torch.Tensor,
+    idx_weights_softmax_scale: float,
+    idx_weights_head_scale: float,
+    idx_q_fp8: torch.Tensor,
+    idx_weights_out: torch.Tensor,
+    has_indexer: bool = True,
+    index_rope_interleave: bool = True,
+) -> None:
+    return None
+
+
+direct_register_custom_op(
+    op_name="fused_q_cutedsl",
+    op_func=_fused_q_cutedsl_impl,
+    mutates_args=["mqa_output", "idx_q_fp8", "idx_weights_out"],
+    fake_impl=_fused_q_cutedsl_fake,
+)
+
+
+def fused_q_cutedsl(
+    positions: torch.Tensor,
+    q_pe: torch.Tensor,
+    rope_cache: torch.Tensor,
+    ql_nope: torch.Tensor,
+    q_scale: torch.Tensor,
+    mqa_output: torch.Tensor,
+    idx_q: torch.Tensor,
+    idx_rope_cache: torch.Tensor,
+    idx_weights: torch.Tensor,
+    idx_weights_softmax_scale: float,
+    idx_weights_head_scale: float,
+    idx_q_fp8: torch.Tensor,
+    idx_weights_out: torch.Tensor,
+    has_indexer: bool = True,
+    index_rope_interleave: bool = True,
+) -> None:
+    torch.ops.vllm.fused_q_cutedsl(
+        positions,
+        q_pe,
+        rope_cache,
+        ql_nope,
+        q_scale,
+        mqa_output,
+        idx_q,
+        idx_rope_cache,
+        idx_weights,
+        idx_weights_softmax_scale,
+        idx_weights_head_scale,
+        idx_q_fp8,
+        idx_weights_out,
+        has_indexer,
+        index_rope_interleave,
     )
 
 


### PR DESCRIPTION
## Purpose

Fuse DeepSeek V3.2's Q-LoRA RMSNorm with packed 1x128 FP8 quantization, so the
Q projection and sparse indexer can share one quantized activation. The CuTe DSL
Q kernel is also registered as an opaque custom op so this path remains usable
with piecewise CUDA graphs.

This focused model integration was extracted from #51936.

## Dependencies

- #51939: DeepGEMM block-linear prequantized-input contract
- #51942: packed DeepGEMM activation allocation utility

The branch intentionally contains only this four-file integration diff against
`main`; it will become testable in isolation once those prerequisites land.

## Duplicate-work check

No issue number was provided. I searched open PRs for `DeepSeek V3.2 fused norm
quant MTP` and `fused_q_cutedsl custom op`. The only exact implementation was
the superseded draft #51936. #45151 fuses a different attention epilogue.

## Validation

On the integrated branch, this test file passed as part of:

```bash
.venv/bin/python -m pytest \
  tests/kernels/moe/test_deepgemm.py \
  tests/kernels/moe/test_silu_mul_fp8_quant_deep_gemm.py \
  tests/kernels/test_fused_deepseek_v32_norm_rope.py -q
# 85 passed, 3 skipped
```

For this isolated diff:

```bash
git diff --cached --name-only -z | xargs -0 pre-commit run --files
# all applicable hooks passed, including ruff and mypy
```

## AI assistance disclosure

This change was developed with OpenAI Codex assistance. This is a draft PR;
the human submitter must review every changed line and confirm they understand
and can defend the change before marking it ready.
