### PR TITLE
[Bugfix][KVConnector] Add opt-in gate for large Mooncake KV sends

### DIFF
--- a/tests/v1/kv_connector/unit/test_mooncake_connector.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_connector.py
@@ -3,6 +3,7 @@
 
 import asyncio
 import contextlib
+import os
 import time
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -1361,3 +1362,86 @@ async def test_kv_producer_heterogeneous_tp(monkeypatch, d_tp_size):
 
         prefill_worker.sender_loop = origin_sender_loop
         prefill_worker.shutdown()
+
+
+def test_large_request_gate_uses_largest_kv_group_block_count():
+    worker = MooncakeConnectorWorker.__new__(MooncakeConnectorWorker)
+    worker.shutdown = lambda: None
+    worker._large_request_semaphore = object()
+    worker.large_request_threshold_tokens = 32768
+    worker.block_size = 256
+
+    long_meta = SimpleNamespace(req_blocks={"request": ("transfer", [[0] * 256])})
+    short_meta = SimpleNamespace(req_blocks={"request": ("transfer", [[0] * 14])})
+    multi_group_meta = SimpleNamespace(
+        req_blocks={"request": ("transfer", [[0] * 100, [0] * 256])}
+    )
+
+    assert worker._is_large_request_meta(long_meta)
+    assert not worker._is_large_request_meta(short_meta)
+    assert worker._is_large_request_meta(multi_group_meta)
+
+
+def test_node_large_request_slots_are_mutually_exclusive(tmp_path):
+    async def run_test():
+        worker = MooncakeConnectorWorker.__new__(MooncakeConnectorWorker)
+        worker.shutdown = lambda: None
+        worker._node_large_request_slot_paths = (
+            MooncakeConnectorWorker._get_node_large_request_slot_paths(
+                str(tmp_path), "engine-a", 1
+            )
+        )
+        assert worker._node_large_request_slot_paths != (
+            MooncakeConnectorWorker._get_node_large_request_slot_paths(
+                str(tmp_path), "engine-b", 1
+            )
+        )
+
+        first_slot = await worker._acquire_node_large_request_slot()
+        assert first_slot is not None
+
+        waiting_for_slot = asyncio.create_task(
+            worker._acquire_node_large_request_slot()
+        )
+        await asyncio.sleep(0.01)
+        assert not waiting_for_slot.done()
+
+        worker._release_node_large_request_slot(first_slot)
+        second_slot = await asyncio.wait_for(waiting_for_slot, timeout=1)
+        assert second_slot is not None
+        worker._release_node_large_request_slot(second_slot)
+
+    asyncio.run(run_test())
+
+
+@pytest.mark.parametrize("num_slots", [0, -1])
+def test_node_large_request_slot_paths_empty_for_non_positive_slots(num_slots):
+    worker = MooncakeConnectorWorker.__new__(MooncakeConnectorWorker)
+    worker.shutdown = lambda: None
+    assert (
+        MooncakeConnectorWorker._get_node_large_request_slot_paths(
+            "/tmp", "engine-a", num_slots
+        )
+        == []
+    )
+
+
+@pytest.mark.skipif(not hasattr(os, "O_NOFOLLOW"), reason="O_NOFOLLOW unavailable")
+@pytest.mark.asyncio
+async def test_node_large_request_slots_skip_symlinks(tmp_path):
+    worker = MooncakeConnectorWorker.__new__(MooncakeConnectorWorker)
+    worker._node_large_request_slot_paths = (
+        MooncakeConnectorWorker._get_node_large_request_slot_paths(
+            str(tmp_path), "engine-a", 2
+        )
+    )
+    unsafe_target = tmp_path / "unsafe-target"
+    os.symlink(unsafe_target, worker._node_large_request_slot_paths[0])
+
+    slot = await asyncio.wait_for(worker._acquire_node_large_request_slot(), timeout=1)
+    assert slot is not None
+    assert not unsafe_target.exists()
+    assert os.path.samefile(
+        f"/proc/self/fd/{slot}", worker._node_large_request_slot_paths[1]
+    )
+    worker._release_node_large_request_slot(slot)

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py
@@ -1,7 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import asyncio
+import errno
+import fcntl
+import hashlib
 import logging
+import os
 import threading
 import time
 from collections import defaultdict
@@ -921,6 +925,72 @@ class MooncakeConnectorWorker:
         self.num_sender_workers = kv_transfer_config.kv_connector_extra_config.get(
             "num_workers", 10
         )
+        extra_config = kv_transfer_config.kv_connector_extra_config
+        self.max_concurrent_large_requests = int(
+            extra_config.get("max_concurrent_large_requests", 0)
+        )
+        self.large_request_threshold_tokens = int(
+            extra_config.get("large_request_threshold_tokens", 0)
+        )
+        self.node_large_request_slots = int(
+            extra_config.get("node_large_request_slots", 0)
+        )
+        self.node_large_request_slot_dir = extra_config.get(
+            "node_large_request_slot_dir", "/dev/shm"
+        )
+        self.node_large_request_slot_namespace = extra_config.get(
+            "node_large_request_slot_namespace", engine_id
+        )
+        if self.max_concurrent_large_requests < 0:
+            raise ValueError(
+                "max_concurrent_large_requests must be non-negative, got "
+                f"{self.max_concurrent_large_requests}"
+            )
+        if self.large_request_threshold_tokens < 0:
+            raise ValueError(
+                "large_request_threshold_tokens must be non-negative, got "
+                f"{self.large_request_threshold_tokens}"
+            )
+        if self.node_large_request_slots < 0:
+            raise ValueError(
+                "node_large_request_slots must be non-negative, got "
+                f"{self.node_large_request_slots}"
+            )
+        if not isinstance(self.node_large_request_slot_namespace, str) or not (
+            self.node_large_request_slot_namespace
+        ):
+            raise ValueError(
+                "node_large_request_slot_namespace must be a non-empty string"
+            )
+        self._large_request_semaphore: asyncio.Semaphore | None = (
+            asyncio.Semaphore(self.max_concurrent_large_requests)
+            if self.max_concurrent_large_requests > 0
+            and self.large_request_threshold_tokens > 0
+            else None
+        )
+        if self._large_request_semaphore is not None:
+            logger.info(
+                "Mooncake limiting requests >= %d tokens to %d concurrent send(s)",
+                self.large_request_threshold_tokens,
+                self.max_concurrent_large_requests,
+            )
+        if self.node_large_request_slots and self._large_request_semaphore is None:
+            raise ValueError(
+                "node_large_request_slots requires positive "
+                "max_concurrent_large_requests and "
+                "large_request_threshold_tokens"
+            )
+        self._node_large_request_slot_paths = self._get_node_large_request_slot_paths(
+            self.node_large_request_slot_dir,
+            self.node_large_request_slot_namespace,
+            self.node_large_request_slots,
+        )
+        if self._node_large_request_slot_paths:
+            logger.info(
+                "Mooncake limiting long requests to %d shared node slot(s) under %s",
+                self.node_large_request_slots,
+                self.node_large_request_slot_dir,
+            )
         # Create more tasks than workers to keep the thread pool saturated.
         # Tasks can await async events, so a surplus (2x is a robust heuristic)
         # prevents workers from idling.
@@ -1174,7 +1244,16 @@ class MooncakeConnectorWorker:
                 identity, metadata_bytes = await self.sender_worker_queue.get()
                 try:
                     metadata = self._xfer_meta_decoder.decode(metadata_bytes)
-                    await self.send_kv_to_decode(identity, sock, metadata)
+                    if self._is_large_request_meta(metadata):
+                        assert self._large_request_semaphore is not None
+                        async with self._large_request_semaphore:
+                            slot_fd = await self._acquire_node_large_request_slot()
+                            try:
+                                await self.send_kv_to_decode(identity, sock, metadata)
+                            finally:
+                                self._release_node_large_request_slot(slot_fd)
+                    else:
+                        await self.send_kv_to_decode(identity, sock, metadata)
                 except Exception as e:
                     logger.error("Error processing Mooncake xfer request: %s", e)
                     error_response = MooncakeXferResponse(
@@ -1189,6 +1268,72 @@ class MooncakeConnectorWorker:
                 break
             except Exception as e:
                 logger.error("Error in _sender_worker: %s", e)
+
+    def _is_large_request_meta(self, meta: MooncakeXferMetadata) -> bool:
+        """Return whether a pull covers a long-context request.
+
+        KV cache groups represent parallel cache layouts, so the largest group
+        block count is a better proxy for prompt length than the sum across all
+        groups.
+        """
+        if self._large_request_semaphore is None:
+            return False
+        max_blocks = max(
+            (
+                len(block_ids)
+                for _, request_groups in meta.req_blocks.values()
+                for block_ids in request_groups
+            ),
+            default=0,
+        )
+        return max_blocks * self.block_size >= self.large_request_threshold_tokens
+
+    @staticmethod
+    def _get_node_large_request_slot_paths(
+        slot_dir: str, namespace: str, num_slots: int
+    ) -> list[str]:
+        namespace_hash = hashlib.sha256(namespace.encode()).hexdigest()[:16]
+        return [
+            os.path.join(
+                slot_dir,
+                f"vllm-mooncake-large-request-{namespace_hash}-slot-{slot}",
+            )
+            for slot in range(num_slots)
+        ]
+
+    async def _acquire_node_large_request_slot(self) -> int | None:
+        """Acquire one advisory node-wide slot without blocking the event loop."""
+        if not self._node_large_request_slot_paths:
+            return None
+        flags = os.O_CREAT | os.O_RDWR | getattr(os, "O_NOFOLLOW", 0)
+        while True:
+            for slot_path in self._node_large_request_slot_paths:
+                try:
+                    fd = os.open(slot_path, flags, 0o600)
+                except OSError as exc:
+                    if exc.errno == errno.ELOOP:
+                        logger.warning(
+                            "Mooncake large-request slot path is a symlink; "
+                            "skipping unsafe path %s",
+                            slot_path,
+                        )
+                        continue
+                    raise
+                try:
+                    fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                    return fd
+                except BlockingIOError:
+                    os.close(fd)
+            await asyncio.sleep(0.001)
+
+    @staticmethod
+    def _release_node_large_request_slot(slot_fd: int | None) -> None:
+        if slot_fd is None:
+            return
+        try:
+            fcntl.flock(slot_fd, fcntl.LOCK_UN)
+        finally:
+            os.close(slot_fd)
 
     async def send_kv_to_decode(
         self, identity: bytes, sock: zmq.asyncio.Socket, meta: MooncakeXferMetadata


### PR DESCRIPTION
## Purpose

  Add an opt-in gate for large Mooncake KV sends on producer workers.

  This introduces three optional `kv_connector_extra_config` fields:

  - `max_concurrent_large_requests`: maximum concurrent large sends per producer worker
  - `large_request_threshold_tokens`: request-size threshold for applying the gate
  - `node_large_request_slots`: optional node-wide advisory slots shared by workers on the same node

  The feature is disabled by default, so existing Mooncake behavior is unchanged unless these fields are configured.

  For long-context P/D serving, multiple large Mooncake producer sends can compete for RDMA / transfer-engine resources at the
  same time. This can increase tail latency and, in some deployments, destabilize long-context requests.

  This PR adds a small opt-in gate so deployments can bound large KV sends without affecting short-context traffic.

  ## Implementation

  - Classify a request as "large" using the largest KV-cache group block count.
    KV cache groups represent parallel cache layouts, so summing across groups would overestimate prompt length.
  - Use an async semaphore to limit concurrent large sends inside each producer worker.
  - Optionally use advisory file locks under `node_large_request_slot_dir` to share slots across producer workers on the same
  node.
  - Namespace node-wide slot files by engine ID by default, so unrelated vLLM services do not contend.

  ## Test Plan

  Added unit coverage for:

  - large-request classification using the largest KV group
  - node-wide advisory slot mutual exclusion
  - namespace isolation for node-wide slot paths

 
  ## Test Result

  Local checks passed:

  ```text
  uvx ruff check vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py tests/v1/kv_connector/unit/
  test_mooncake_connector.py
  uvx ruff format --check vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py tests/v1/kv_connector/
  unit/test_mooncake_connector.py
  python3 -m py_compile vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py tests/v1/kv_connector/
  unit/test_mooncake_connector.py
  git diff --check

  Server-side pytest in the vLLM runtime container passed:

  python3 -m pytest -q /tmp/test_mooncake_large_request_gate.py
  ..                                                                       [100%]
  2 passed, 14 warnings in 7.51s
 ```

  I also validated the intended effect in a DeepSeek-V4-Pro H20 P/D deployment with 64K input / 1500 output, C=1:
```text

   Config              Samples    TTFT mean (ms)    TTFT p99 (ms)        TPOT p99      Total throughput    Notes
                                                                             (ms)               (tok/s)
  ━━━━━━━━━━━━━━━━━━  ━━━━━━━━━  ━━━━━━━━━━━━━━━━  ━━━━━━━━━━━━━━━  ━━━━━━━━━━━━━━  ━━━━━━━━━━━━━━━━━━━━  ━━━━━━━━━━━━━━━━━━━━
   No large-send             3           8846.50          9498.73           11.82               2548.34    baseline Mooncake
   gate                                                                                                    send path
   (65536x1500_c1_s
   trict_postro_r2_
   warm2)
  ──────────────────  ─────────  ────────────────  ───────────────  ──────────────  ────────────────────  ────────────────────
   Producer                  3           8503.67          9021.32           11.73               2609.43    coarse global
   num_workers=1                                                                                           throttling
   (65536x1500_send
   er1_warm2)
  ──────────────────  ─────────  ────────────────  ───────────────  ──────────────  ────────────────────  ────────────────────
   This PR gate              5           7963.10          8027.68           11.77               2653.75    large KV sends
   (65536x1500_node                                                                                        only
   slot6_warm2)
 ```
  

Compared with the baseline Mooncake send path, the opt-in gate reduced TTFT p99 from 9498.73 ms to 8027.68 ms (~15.5%) and improved total throughput from 2548.34 tok/s to 2653.75 tok/s (~4.1%) in this deployment validation.Compared with the coarse num_workers=1 workaround, this PR reduced TTFT p99 by ~11.0% while only gating large KV sends instead of globally reducing all sender parallelism.

This is a small deployment validation rather than a full benchmark suite, but it shows the intended effect: reducing long-context tail latency by bounding concurrent large KV sends.