### PR TITLE
[Quant][DeepSeek V3.2] Reuse fused quantized inputs

### DIFF
--- a/tests/models/deepseek_v32/test_sequence_parallel.py
+++ b/tests/models/deepseek_v32/test_sequence_parallel.py
@@ -7,6 +7,11 @@ from unittest.mock import Mock
 import torch
 from torch import nn
 
+from vllm.model_executor.layers.fusion.quant_activation import QuantizedActivation
+from vllm.model_executor.layers.quantization.utils.quant_utils import (
+    kFp8Dynamic128Sym,
+)
+from vllm.model_executor.models.deepseek_v2 import DeepseekV2MoE
 from vllm.models.deepseek_v32.nvidia import model as deepseek_v32_model
 from vllm.models.deepseek_v32.nvidia import mtp as deepseek_v32_mtp
 
@@ -46,6 +51,22 @@ class _RecordingProjection(nn.Module):
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
         self.num_tokens = hidden_states.shape[0]
         return hidden_states[:, :2]
+
+
+class _RecordingMoE(DeepseekV2MoE):
+    def __init__(self) -> None:
+        nn.Module.__init__(self)
+        self.experts = nn.Module()
+        self.quantized_hidden_states = None
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        already_sequence_parallel: bool = False,
+        quantized_hidden_states: QuantizedActivation | None = None,
+    ) -> torch.Tensor:
+        self.quantized_hidden_states = quantized_hidden_states
+        return hidden_states
 
 
 class _SequenceParallelMTPBlock:
@@ -107,6 +128,34 @@ def test_decoder_layer_keeps_dense_states_sequence_sharded(monkeypatch):
     assert hidden_states.shape == residual.shape == (2, 2)
     assert layer.self_attn.num_tokens == 3
     assert layer.mlp.num_tokens == 2
+
+
+def test_decoder_layer_passes_fused_quantization_to_moe(monkeypatch):
+    layer = object.__new__(deepseek_v32_model.DeepseekV32DecoderLayer)
+    nn.Module.__init__(layer)
+    layer.use_sequence_parallel = False
+    layer.input_layernorm = _IdentityNorm()
+    layer.post_attention_layernorm = _IdentityNorm()
+    layer.self_attn = _RecordingModule()
+    layer.mlp = _RecordingMoE()
+
+    hidden_states = torch.arange(6, dtype=torch.float32).view(3, 2)
+    quantized = QuantizedActivation(
+        data=torch.empty_like(hidden_states),
+        scale=torch.empty_strided((3, 1), (1, 4), dtype=torch.int32),
+        orig_dtype=hidden_states.dtype,
+        orig_shape=hidden_states.shape,
+        quant_key=kFp8Dynamic128Sym,
+    )
+    fused = Mock(return_value=(hidden_states + 1, hidden_states + 2, quantized))
+    monkeypatch.setattr(deepseek_v32_model, "fused_allreduce_rms_norm_fp8_quant", fused)
+
+    output, residual = layer(torch.arange(3), hidden_states, residual=None)
+
+    assert layer.mlp.quantized_hidden_states is quantized
+    assert fused.call_args.args[3] is layer.mlp.experts
+    torch.testing.assert_close(output, hidden_states + 1)
+    torch.testing.assert_close(residual, hidden_states + 2)
 
 
 def test_mtp_projects_sequence_shard_and_restores_full_output(monkeypatch):

--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -54,6 +54,7 @@ from vllm.model_executor.layers.fused_moe import (
     GateLinear,
     fused_moe_make_expert_params_mapping,
 )
+from vllm.model_executor.layers.fusion.quant_activation import QuantizedActivation
 from vllm.model_executor.layers.layernorm import LayerNorm, RMSNorm
 from vllm.model_executor.layers.linear import (
     ColumnParallelLinear,
@@ -394,6 +395,7 @@ class DeepseekV2MoE(nn.Module):
         self,
         hidden_states: torch.Tensor,
         already_sequence_parallel: bool = False,
+        quantized_hidden_states: QuantizedActivation | None = None,
     ) -> torch.Tensor:
         num_tokens, hidden_dim = hidden_states.shape
         hidden_states = hidden_states.view(-1, hidden_dim)
@@ -404,7 +406,9 @@ class DeepseekV2MoE(nn.Module):
             hidden_states = sequence_parallel_chunk(hidden_states)
 
         final_hidden_states = self.experts(
-            hidden_states=hidden_states, router_logits=hidden_states
+            hidden_states=hidden_states,
+            router_logits=hidden_states,
+            quantized_hidden_states=quantized_hidden_states,
         )
 
         if self.is_sequence_parallel and not already_sequence_parallel:

--- a/vllm/models/deepseek_v32/nvidia/model.py
+++ b/vllm/models/deepseek_v32/nvidia/model.py
@@ -35,7 +35,10 @@ from vllm.model_executor.models.utils import (
     make_empty_intermediate_tensors_factory,
     make_layers,
 )
-from vllm.models.common.ops.fused_allreduce_rms_norm import fused_allreduce_rms_norm
+from vllm.models.common.ops.fused_allreduce_rms_norm import (
+    fused_allreduce_rms_norm,
+    fused_allreduce_rms_norm_fp8_quant,
+)
 from vllm.models.common.ops.sequence_parallel import (
     sp_all_gather,
     sp_padding_mask,
@@ -118,6 +121,7 @@ class DeepseekV32DecoderLayer(torch.nn.Module):
         residual: torch.Tensor | None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         full_num_tokens = positions.shape[0]
+        qkv_input = None
 
         if residual is None:
             residual = hidden_states
@@ -127,26 +131,44 @@ class DeepseekV32DecoderLayer(torch.nn.Module):
         else:
             # The previous layer's MLP/MoE output is left un-reduced; fuse its
             # all-reduce into this input_layernorm.
-            hidden_states, residual = fused_allreduce_rms_norm(
-                hidden_states, residual, self.input_layernorm
+            hidden_states, residual, qkv_input = fused_allreduce_rms_norm_fp8_quant(
+                hidden_states,
+                residual,
+                self.input_layernorm,
+                self.self_attn.fused_qkv_a_proj,
             )
         if self.use_sequence_parallel:
             hidden_states = sp_all_gather(hidden_states)[:full_num_tokens]
 
         # self_attn's o_proj runs reduce_results=False; reduce before RMSNorm.
-        hidden_states = self.self_attn(positions=positions, hidden_states=hidden_states)
+        hidden_states = self.self_attn(
+            positions=positions,
+            hidden_states=hidden_states,
+            qkv_input=qkv_input,
+        )
+        moe_input = None
         if self.use_sequence_parallel:
             hidden_states = sp_reduce_scatter(hidden_states)
             hidden_states, residual = self.post_attention_layernorm(
                 hidden_states, residual
             )
         else:
-            hidden_states, residual = fused_allreduce_rms_norm(
-                hidden_states, residual, self.post_attention_layernorm
-            )
+            if isinstance(self.mlp, DeepseekV2MoE):
+                hidden_states, residual, moe_input = fused_allreduce_rms_norm_fp8_quant(
+                    hidden_states,
+                    residual,
+                    self.post_attention_layernorm,
+                    self.mlp.experts,
+                )
+            else:
+                hidden_states, residual = fused_allreduce_rms_norm(
+                    hidden_states, residual, self.post_attention_layernorm
+                )
 
         if self.use_sequence_parallel and isinstance(self.mlp, DeepseekV2MoE):
             hidden_states = self.mlp(hidden_states, already_sequence_parallel=True)
+        elif isinstance(self.mlp, DeepseekV2MoE):
+            hidden_states = self.mlp(hidden_states, quantized_hidden_states=moe_input)
         else:
             hidden_states = self.mlp(hidden_states)
         return hidden_states, residual


### PR DESCRIPTION
## Purpose

Wire the reusable packed-FP8 primitives into the DeepSeek V3.2 / GLM-5.2
decoder:

- feed all-reduce/RMSNorm's quantized output into the fused QKV projection;
- feed the post-attention quantized output into modular MoE; and
- preserve the existing dense MLP path unchanged.

This is the three-file autoregressive model integration extracted from #51936.

## Dependencies

- #51939: DeepGEMM block-linear prequantized-input contract
- #51941: modular MoE prequantized-input contract
- #51942: all-reduce/RMSNorm/packed-FP8 producer
- #51943: DeepSeek V3.2 attention input and fused norm-quant integration

The branch intentionally contains only this integration diff against `main`.
Until #51942 lands, isolated mypy reports the expected missing
`fused_allreduce_rms_norm_fp8_quant` symbol. Ruff and all non-mypy hooks pass.

## Duplicate-work check

No issue number was provided. I searched open PRs for `DeepSeek V3.2 fused norm
quant MTP`. The only exact prior implementation was the superseded draft
#51936; adjacent norm-quant PRs do not wire both attention and MoE consumers.

## Validation

On the integrated branch:

```bash
.venv/bin/python -m pytest tests/models/deepseek_v32/test_sequence_parallel.py -q
# 5 passed

.venv/bin/python -m pytest \
  tests/kernels/moe/test_deepgemm.py \
  tests/kernels/moe/test_silu_mul_fp8_quant_deep_gemm.py \
  tests/kernels/test_fused_deepseek_v32_norm_rope.py -q
# 85 passed, 3 skipped
```

For this isolated diff, Ruff check and format pass. Full type checking is
blocked only by the explicit prerequisite symbol above.

## Model evaluation

Full GSM8K evaluation for `zai-org/GLM-5.2-FP8`: 1,242 / 1,319 strict exact
matches (**94.16%**), reproduced after the quant fusions.

## AI assistance disclosure

This change was developed with OpenAI Codex assistance. This is a blocked draft
PR; the human submitter must review every changed line and confirm they
understand and can defend the change before marking it ready.
