### PR TITLE
[Bugfix] DeepSeek-V4: pick e8m0 expert-scale representation per desti…

### DIFF
--- a/vllm/models/deepseek_v4/nvidia/dspark.py
+++ b/vllm/models/deepseek_v4/nvidia/dspark.py
@@ -53,6 +53,7 @@ from .model import (
     DeepseekV4Model,
     _use_sequence_parallel,
     make_deepseek_v4_expert_params_mapping,
+    ue8m0_uint8_to_float,
 )
 
 logger = init_logger(__name__)
@@ -435,21 +436,31 @@ class DSparkDeepseekV4ForCausalLM(nn.Module):
                     self.quant_config, name, loaded_weight
                 )
 
-            # E8M0 expert scales: keep raw exponent bytes.
+            # E8M0 expert scales: raw exponent bytes for a uint8 (FP4)
+            # parameter, decoded float32 for a block-fp8 one. Same reasoning
+            # as DeepseekV4Model.load_weights -- the representation depends on
+            # the destination, not on the checkpoint tensor.
             if ".experts." in name:
-                if (
+                is_e8m0_scale = (
                     "weight_scale" in name
                     and loaded_weight.dtype == torch.float8_e8m0fnu
-                ):
-                    loaded_weight = loaded_weight.view(torch.uint8)
+                )
                 for param_name, weight_name, expert_id, shard_id in expert_mapping:
                     if weight_name not in name:
                         continue
                     name_mapped = name.replace(weight_name, param_name)
                     param = params_dict[name_mapped]
+                    expert_weight = loaded_weight
+                    if is_e8m0_scale:
+                        raw_bytes = loaded_weight.view(torch.uint8)
+                        expert_weight = (
+                            raw_bytes
+                            if param.dtype == torch.uint8
+                            else ue8m0_uint8_to_float(raw_bytes)
+                        )
                     success = param.weight_loader(
                         param,
-                        loaded_weight,
+                        expert_weight,
                         name_mapped,
                         shard_id=shard_id,
                         expert_id=expert_id,

--- a/vllm/models/deepseek_v4/nvidia/model.py
+++ b/vllm/models/deepseek_v4/nvidia/model.py
@@ -165,6 +165,16 @@ def make_deepseek_v4_expert_params_mapping(
     ]
 
 
+def ue8m0_uint8_to_float(sf: torch.Tensor) -> torch.Tensor:
+    """Decode raw ue8m0 exponent bytes into the float32 scales they denote.
+
+    A ue8m0 byte ``v`` denotes ``2 ** (v - 127)``. Placing ``v`` in the
+    IEEE-754 exponent field (bits 23..30) reproduces that exactly, with no
+    rounding.
+    """
+    return (sf.to(torch.int32) << 23).view(torch.float32)
+
+
 class DeepseekV4MegaMoEExperts(nn.Module):
     _symm_buffer_cache: dict[tuple[int, int, int, int, int, int, int], object] = {}
 
@@ -309,7 +319,7 @@ class DeepseekV4MegaMoEExperts(nn.Module):
 
     @staticmethod
     def _ue8m0_uint8_to_float(sf: torch.Tensor) -> torch.Tensor:
-        return (sf.to(torch.int32) << 23).view(torch.float32)
+        return ue8m0_uint8_to_float(sf)
 
     def _check_runtime_supported(self) -> None:
         device = self.w13_weight.device
@@ -1259,15 +1269,26 @@ class DeepseekV4Model(nn.Module, EagleModelMixin):
                 break
             else:
                 if ".experts." in name:
-                    # E8M0 scales are stored as float8_e8m0fnu in
-                    # checkpoints but the MoE param is uint8. copy_()
-                    # would do a numeric conversion (e.g. 2^-7 → 0),
-                    # destroying the raw exponent bytes.
-                    if (
+                    # E8M0 scales are stored as float8_e8m0fnu in the
+                    # checkpoint, and how they must reach the weight loader
+                    # depends on the DESTINATION parameter:
+                    #
+                    #   * FP4 experts (Mxfp4MoEMethod / ModelOptNvFp4FusedMoE)
+                    #     keep the raw exponent bytes in a uint8 parameter, so
+                    #     a numeric copy_() would destroy them (2^-7 -> 0).
+                    #   * FP8 experts (expert_dtype="fp8" falls through to
+                    #     Fp8MoEMethod, which uses block-wise float32 scales)
+                    #     need the decoded value. Viewing as uint8 there makes
+                    #     copy_() write the exponent BYTE as a float
+                    #     (2^-7 -> 120.0), scaling every expert block by ~1e40
+                    #     and silently producing garbage output.
+                    #
+                    # Neither representation is right for both, so choose per
+                    # parameter below rather than once per checkpoint tensor.
+                    is_e8m0_scale = (
                         "weight_scale" in name
                         and loaded_weight.dtype == torch.float8_e8m0fnu
-                    ):
-                        loaded_weight = loaded_weight.view(torch.uint8)
+                    )
                     for mapping in expert_mapping:
                         param_name, weight_name, expert_id, expert_shard_id = mapping
                         if weight_name not in name:
@@ -1276,6 +1297,14 @@ class DeepseekV4Model(nn.Module, EagleModelMixin):
                         if is_pp_missing_parameter(name_mapped, self):
                             continue
                         param = params_dict[name_mapped]
+                        expert_weight = loaded_weight
+                        if is_e8m0_scale:
+                            raw_bytes = loaded_weight.view(torch.uint8)
+                            expert_weight = (
+                                raw_bytes
+                                if param.dtype == torch.uint8
+                                else ue8m0_uint8_to_float(raw_bytes)
+                            )
                         # We should ask the weight loader to return success or not
                         # here since otherwise we may skip experts with other
                         # available replicas.
@@ -1284,7 +1313,7 @@ class DeepseekV4Model(nn.Module, EagleModelMixin):
                         )
                         success = weight_loader(
                             param,
-                            loaded_weight,
+                            expert_weight,
                             name_mapped,
                             shard_id=expert_shard_id,
                             expert_id=expert_id,


### PR DESCRIPTION
# [Bugfix] DeepSeek-V4: pick the e8m0 expert-scale representation per destination parameter

Fixes [#43416](https://github.com/vllm-project/vllm/issues/43416) — *DeepSeek V4 Flash Model Output is Garbled*.

## Purpose

`DeepseekV4Model.load_weights` reinterprets every `float8_e8m0fnu` expert scale in the checkpoint as raw `uint8` bytes. That is correct when the destination parameter is `uint8` (the FP4 expert path), but for `expert_dtype == "fp8"` the destination is a **float32** block scale, so `copy_()` stores the exponent *byte* as a floating-point value — exponent `120`, which denotes `2**-7`, becomes `120.0`. Every expert block is then scaled by a factor of roughly `1e40`.

There is no exception and no warning: the model loads, serves, and emits fluent-looking multilingual token salad. This patch makes the choice per destination parameter instead of once per checkpoint tensor, which resolves the garbled output reported in [#43416](https://github.com/vllm-project/vllm/issues/43416).

## Root cause

The two halves of the pipeline disagree, and both state their assumption in a comment.

The loader assumes the destination is `uint8` (`vllm/models/deepseek_v4/nvidia/model.py`):

```python
if ".experts." in name:
    # E8M0 scales are stored as float8_e8m0fnu in
    # checkpoints but the MoE param is uint8. copy_()
    # would do a numeric conversion (e.g. 2^-7 → 0),
    # destroying the raw exponent bytes.
    if "weight_scale" in name and loaded_weight.dtype == torch.float8_e8m0fnu:
        loaded_weight = loaded_weight.view(torch.uint8)
```

The quantization config says the destination is `float32` whenever the experts are FP8 (`vllm/models/deepseek_v4/quant_config.py`, in `get_quant_method`):

```python
# expert_dtype == "fp8": fall through to Fp8Config which
# returns Fp8MoEMethod with block-wise float32 scales.
```

`DeepSeek-V4-Flash-FP8` is exactly that case. Its `config.json` declares

```json
"expert_dtype": "fp8",
"quantization_config": {"quant_method": "fp8", "fmt": "e4m3",
                        "scale_fmt": "ue8m0", "weight_block_size": [128, 128]}
```

and it stores its block scales as `F8_E8M0` tensors (776 of them in a single shard) alongside `F8_E4M3` weights. So the byte-view is taken, the parameter is float32, and `copy_()` performs a numeric conversion of the *byte value*:

| stored exponent byte | intended scale | value written into the float32 parameter |
|---|---|---|
| `120` | `2**-7 ≈ 7.8e-3` | `120.0` |
| `127` | `2**0 = 1.0` | `127.0` |

The correct decoder already exists in this file as `DeepseekV4MegaMoEExperts._ue8m0_uint8_to_float`:

```python
(sf.to(torch.int32) << 23).view(torch.float32)      # byte v -> 2**(v - 127), exactly
```

but it is only reachable from `DeepseekV4MegaMoEExperts.finalize_weights()`, which begins with

```python
if torch.cuda.get_device_capability(device)[0] != 10:
    raise NotImplementedError("DeepGEMM MegaMoE requires SM100 GPUs.")
```

so on SM90 nothing ever converts, and the corrupted scales reach the Triton `fp8_w8a8` MoE path unchanged.

## What this patch changes

1. **`vllm/models/deepseek_v4/nvidia/model.py`**
- hoist the decode to a module-level `ue8m0_uint8_to_float()`; the existing `DeepseekV4MegaMoEExperts._ue8m0_uint8_to_float` staticmethod now delegates to it, so the expression is not duplicated and the MegaMoE path is unchanged;
- in `DeepseekV4Model.load_weights`, move the byte-view-versus-decode decision **inside** the `expert_mapping` loop, where the destination `param` is resolved, and select on `param.dtype`: `uint8` → keep the raw exponent bytes; anything else → decode to float32.

2. **`vllm/models/deepseek_v4/nvidia/dspark.py`** — the DSpark draft-model loader carries an identical unconditional byte-view; it gets the same treatment, importing the helper from `.model`.

Two files, +50 −14. No kernel, config, or API change.

## Backward compatibility

FP4 checkpoints are unaffected. Their expert scale parameters are `uint8` (`Mxfp4MoEMethod` / `ModelOptNvFp4FusedMoE`), so they take the `param.dtype == torch.uint8` branch, which is byte-for-byte the previous behaviour. Only the block-FP8 destination — the case that is broken today — takes the new path.

## Test Plan

Model `DeepSeek-V4-Flash-FP8`, 8× H20-3e (SM90), `--tensor-parallel-size 8`, `--kv-cache-dtype fp8` (required: with the default `auto` the DSV4 path asserts `DeepseekV4 fp8_ds_mla layout only supports fp8 kv-cache, got auto`), greedy sampling, `enforce_eager=True`, no speculative decoding, no tool or reasoning parsers.

```python
from vllm import LLM, SamplingParams
llm = LLM(model=CKPT, tensor_parallel_size=8, kv_cache_dtype="fp8",
          max_model_len=8192, enforce_eager=True, trust_remote_code=True)
for o in llm.generate(["The capital of France is",
                       "Q: What is 17 + 25? A:",
                       "Q: Name the largest planet in our Solar System. A:"],
                      SamplingParams(temperature=0.0, max_tokens=48)):
    print(repr(o.outputs[0].text))
```

## Test Result

| prompt | before | after |
|---|---|---|
| `The capital of France is` | `' petabitsتماع的一张Conn的场景flix proiektuak...'` | `' Paris.'` |
| `Q: What is 17 + 25? A:` | `'[]( kinain� hilab忐 deb _"_odeline dével...'` | `' 42'` |
| `Name the largest planet ... A:` | `' bomb Gregg handicap彪 tug Flu类比带回...'` | `' Jupiter is the largest planet in our Solar System, with a diameter of about 86,881 miles (139,822 kilometers)...'` |

Beyond fluency, a 25-item short-answer probe with checkable answers (capitals, arithmetic, basic science, history, one non-English item), greedy, graded by substring match: **25/25 with the patch**. Before the patch the same prompt style is incoherent on every item, so the pre-patch score is 0 by inspection rather than by grading.

Verified on vLLM 0.27.1, which carries the identical code for the touched block; the patch itself is against `main`.

## Alternatives ruled out

Each of these was tested, and none of them is the cause:

* **Not the tokenizer, not the KV-cache layout.** Output is byte-identical between `--kv-cache-dtype fp8` and `fp8_ds_mla`, and between `tokenizer_mode` `auto` and `deepseek_v4`.
* **Not the environment.** Qwen3-30B-A3B on the same install, box, script and TP size produces correct text. (That checkpoint declares `scale_fmt: None`, so it never reaches this branch.)
* **Not CUDA graphs, not speculative decoding.** `enforce_eager=True` throughout; DSpark never enabled.
* **Not the stale `deep_gemm` reported in [#43416](https://github.com/vllm-project/vllm/issues/43416).** 0.27.1 vendors DeepGEMM 2.6.1 at `vllm/third_party/deep_gemm`, `has_deep_gemm()` returns True, and 79 `kernel.sm90_fp8_gemm_1d2d.*` kernels are compiled into `~/.cache/vllm/deep_gemm` during the failing run — so that upgrade cannot explain this instance.
* **`VLLM_USE_DEEP_GEMM=0` is not a workaround.** `fp8_einsum` still enters DeepGEMM and raises `Assertion error (.../utils/layout.hpp:39): t.dim() == N`; the DSV4 path has no non-DeepGEMM fallback.

## One related issue, deliberately not in this patch

`DeepseekV4FP8Config.is_scale_e8m0` infers the FP8 **linear** scale format from `expert_dtype`:

```python
# FP4 checkpoints store FP8 linear scales as e8m0fnu; FP8 expert
# checkpoints (Flash-Base) store them as float32.
return self.expert_dtype == "fp4"
```

For `DeepSeek-V4-Flash-FP8` that premise does not hold — `quantization_config.scale_fmt` is `"ue8m0"` and the linear scales are `F8_E8M0` — so it reports `False`. It appears harmless in practice: with `False` the linear scale parameter is float32 and `copy_()` from `float8_e8m0fnu` performs a correct numeric decode. (Forcing it `True` changes the output but does not fix it, so it is not the defect this PR addresses.) Reading `quantization_config.scale_fmt` there would be more robust, but it is an independent change and is left out to keep this patch to a single defect. It can be addressed separately.
