### PR TITLE
[Quant][MTP] Reuse packed FP8 logits inputs

### DIFF
--- a/tests/fusion/test_quant_activation_contract.py
+++ b/tests/fusion/test_quant_activation_contract.py
@@ -34,8 +34,11 @@ from vllm.model_executor.layers.fusion.quant_activation import (
     QuantizedActivation,
     as_quantized_activation,
     expose_input_quant_key,
+    index_quantized_activation,
 )
+from vllm.model_executor.layers.logits_processor import LogitsProcessor
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
+    kFp8Dynamic128Sym,
     kFp8StaticTensorSym,
     kNvfp4Dynamic,
 )
@@ -129,3 +132,50 @@ def test_as_quantized_activation_validates_key():
         as_quantized_activation(qa, None)
     assert as_quantized_activation(torch.zeros(2, 4), kFp8StaticTensorSym) is None
     assert as_quantized_activation(qa, kFp8StaticTensorSym) is qa
+
+
+def test_index_fp8_block_activation_repacks_scale_layout():
+    data = torch.arange(30).view(5, 6)
+    scale = torch.empty_strided((5, 2), (1, 8), dtype=torch.int32)
+    scale.copy_(torch.arange(10).view(5, 2))
+    activation = QuantizedActivation(
+        data=data,
+        scale=scale,
+        orig_dtype=torch.bfloat16,
+        orig_shape=data.shape,
+        quant_key=kFp8Dynamic128Sym,
+    )
+
+    indexed = index_quantized_activation(activation, torch.tensor([4, 1, 3]))
+
+    assert isinstance(indexed, QuantizedActivation)
+    torch.testing.assert_close(indexed.data, data[[4, 1, 3]])
+    torch.testing.assert_close(indexed.scale, scale[[4, 1, 3]])
+    assert indexed.scale.stride() == (1, 4)
+    assert indexed.orig_shape == (3, 6)
+
+
+def test_logits_processor_forwards_quantized_activation(default_vllm_config):
+    activation = QuantizedActivation(
+        data=torch.empty(2, 4),
+        scale=torch.empty(2, 1),
+        orig_dtype=torch.bfloat16,
+        orig_shape=torch.Size([2, 4]),
+        quant_key=kFp8Dynamic128Sym,
+    )
+
+    class RecordingQuantMethod:
+        received = None
+
+        def apply(self, layer, hidden_states, bias=None):
+            self.received = hidden_states
+            return torch.ones(2, 3)
+
+    head = torch.nn.Module()
+    head.quant_method = RecordingQuantMethod()
+    head.tp_size = 1
+
+    logits = LogitsProcessor(3)(head, activation)
+
+    assert head.quant_method.received is activation
+    torch.testing.assert_close(logits, torch.ones(2, 3))

--- a/tests/models/deepseek_v32/test_sequence_parallel.py
+++ b/tests/models/deepseek_v32/test_sequence_parallel.py
@@ -7,6 +7,10 @@ from unittest.mock import Mock
 import torch
 from torch import nn
 
+from vllm.model_executor.layers.fusion.quant_activation import QuantizedActivation
+from vllm.model_executor.layers.quantization.utils.quant_utils import (
+    kFp8Dynamic128Sym,
+)
 from vllm.models.deepseek_v32.nvidia import model as deepseek_v32_model
 from vllm.models.deepseek_v32.nvidia import mtp as deepseek_v32_mtp
 
@@ -146,3 +150,59 @@ def test_mtp_projects_sequence_shard_and_restores_full_output(monkeypatch):
     torch.testing.assert_close(hidden_states, expected)
     torch.testing.assert_close(recycled_hidden_states, expected)
     norm.assert_called_once()
+
+
+def test_mtp_fuses_final_reduce_norm_quant_for_logits(monkeypatch):
+    layer = object.__new__(deepseek_v32_mtp.DeepseekV32MultiTokenPredictorLayer)
+    nn.Module.__init__(layer)
+    layer.enorm = _IdentityNorm()
+    layer.hnorm = _IdentityNorm()
+    layer.eh_proj = _RecordingProjection()
+    layer._eh_plan = None
+    mtp_block = _SequenceParallelMTPBlock()
+    mtp_block.use_sequence_parallel = False
+    object.__setattr__(layer, "mtp_block", mtp_block)
+    norm = _IdentityNorm()
+    head = nn.Module()
+    object.__setattr__(layer, "shared_head", SimpleNamespace(norm=norm, head=head))
+
+    monkeypatch.setattr(
+        deepseek_v32_mtp,
+        "fused_eh_norm",
+        lambda positions, inputs_embeds, previous_hidden_states, *args: torch.cat(
+            [inputs_embeds, previous_hidden_states], dim=-1
+        ),
+    )
+    monkeypatch.setattr(deepseek_v32_mtp, "run_glm52_plan", lambda *args: None)
+
+    quantized = QuantizedActivation(
+        data=torch.empty(3, 2),
+        scale=torch.empty_strided((3, 1), (1, 4), dtype=torch.int32),
+        orig_dtype=torch.float32,
+        orig_shape=torch.Size([3, 2]),
+        quant_key=kFp8Dynamic128Sym,
+    )
+    fused = Mock(return_value=(torch.full((3, 2), 7.0), torch.empty(3, 2), quantized))
+    monkeypatch.setattr(deepseek_v32_mtp, "fused_allreduce_rms_norm_fp8_quant", fused)
+
+    inputs_embeds = torch.arange(6, dtype=torch.float32).view(3, 2)
+    logits_input, recycled_hidden_states = layer(
+        input_ids=torch.zeros(3, dtype=torch.long),
+        positions=torch.arange(3),
+        previous_hidden_states=torch.zeros_like(inputs_embeds),
+        inputs_embeds=inputs_embeds,
+    )
+
+    assert logits_input is quantized
+    torch.testing.assert_close(recycled_hidden_states, torch.full((3, 2), 7.0))
+    assert fused.call_args.args[2:] == (norm, head)
+
+    fused.return_value = (torch.full((3, 2), 9.0), torch.empty(3, 2), None)
+    logits_input, recycled_hidden_states = layer(
+        input_ids=torch.zeros(3, dtype=torch.long),
+        positions=torch.arange(3),
+        previous_hidden_states=torch.zeros_like(inputs_embeds),
+        inputs_embeds=inputs_embeds,
+    )
+    torch.testing.assert_close(logits_input, torch.full((3, 2), 9.0))
+    assert logits_input is recycled_hidden_states

--- a/vllm/model_executor/layers/fusion/quant_activation.py
+++ b/vllm/model_executor/layers/fusion/quant_activation.py
@@ -12,7 +12,10 @@ from dataclasses import dataclass
 
 import torch
 
-from vllm.model_executor.layers.quantization.utils.quant_utils import QuantKey
+from vllm.model_executor.layers.quantization.utils.quant_utils import (
+    QuantKey,
+    kFp8Dynamic128Sym,
+)
 
 
 @dataclass
@@ -33,6 +36,41 @@ class QuantizedActivation:
     orig_dtype: torch.dtype
     orig_shape: torch.Size
     quant_key: QuantKey
+
+
+def index_quantized_activation(
+    x: torch.Tensor | QuantizedActivation,
+    index: torch.Tensor | slice,
+) -> torch.Tensor | QuantizedActivation:
+    """Select rows while preserving the packed DeepGEMM scale layout."""
+    if not isinstance(x, QuantizedActivation):
+        return x[index]
+
+    assert x.quant_key == kFp8Dynamic128Sym
+    assert x.data.ndim == 2 and x.scale.ndim == 2
+    data = x.data[index]
+    if data.ndim == 1:
+        data = data.unsqueeze(0)
+
+    selected_scale = x.scale[index]
+    if selected_scale.ndim == 1:
+        selected_scale = selected_scale.unsqueeze(0)
+    num_rows = data.shape[0]
+    aligned_rows = ((num_rows + 3) // 4) * 4
+    scale = torch.empty_strided(
+        (num_rows, selected_scale.shape[1]),
+        (1, aligned_rows),
+        dtype=selected_scale.dtype,
+        device=selected_scale.device,
+    )
+    scale.copy_(selected_scale)
+    return QuantizedActivation(
+        data=data,
+        scale=scale,
+        orig_dtype=x.orig_dtype,
+        orig_shape=data.shape,
+        quant_key=x.quant_key,
+    )
 
 
 def expose_input_quant_key(layer: torch.nn.Module, kernel) -> None:

--- a/vllm/model_executor/layers/logits_processor.py
+++ b/vllm/model_executor/layers/logits_processor.py
@@ -11,6 +11,9 @@ from vllm.distributed import (
     tensor_model_parallel_gather,
 )
 from vllm.model_executor.custom_op import PluggableLayer
+from vllm.model_executor.layers.fusion.quant_activation import (
+    QuantizedActivation,
+)
 from vllm.model_executor.layers.vocab_parallel_embedding import (
     UnquantizedEmbeddingMethod,
     VocabParallelEmbedding,
@@ -63,10 +66,11 @@ class LogitsProcessor(PluggableLayer):
     def forward(
         self,
         lm_head: VocabParallelEmbedding,
-        hidden_states: torch.Tensor,
+        hidden_states: torch.Tensor | QuantizedActivation,
         embedding_bias: torch.Tensor | None = None,
     ) -> torch.Tensor | None:
         if self.logits_as_input:
+            assert isinstance(hidden_states, torch.Tensor)
             logits = hidden_states
         else:
             # Get the logits for the next tokens.
@@ -98,14 +102,21 @@ class LogitsProcessor(PluggableLayer):
     def _apply_head(
         self,
         lm_head: VocabParallelEmbedding,
-        hidden_states: torch.Tensor,
+        hidden_states: torch.Tensor | QuantizedActivation,
         embedding_bias: torch.Tensor | None,
     ) -> torch.Tensor:
         """Project hidden states through the lm_head, honoring head_dtype."""
-        if self.head_dtype is None or self.head_dtype == hidden_states.dtype:
+        input_dtype = (
+            hidden_states.orig_dtype
+            if isinstance(hidden_states, QuantizedActivation)
+            else hidden_states.dtype
+        )
+        if self.head_dtype is None or self.head_dtype == input_dtype:
             return lm_head.quant_method.apply(
                 lm_head, hidden_states, bias=embedding_bias
             )
+
+        assert isinstance(hidden_states, torch.Tensor)
 
         if not isinstance(lm_head.quant_method, UnquantizedEmbeddingMethod):
             raise ValueError(
@@ -136,7 +147,7 @@ class LogitsProcessor(PluggableLayer):
 
     def _get_logits(
         self,
-        hidden_states: torch.Tensor,
+        hidden_states: torch.Tensor | QuantizedActivation,
         lm_head: VocabParallelEmbedding,
         embedding_bias: torch.Tensor | None,
     ) -> torch.Tensor | None:

--- a/vllm/models/deepseek_v32/nvidia/mtp.py
+++ b/vllm/models/deepseek_v32/nvidia/mtp.py
@@ -9,10 +9,12 @@ import torch.nn as nn
 import vllm.envs as envs
 from vllm._aiter_ops import rocm_aiter_ops
 from vllm.config import VllmConfig
-from vllm.distributed import tensor_model_parallel_all_reduce
 from vllm.forward_context import get_forward_context, is_forward_context_available
 from vllm.model_executor.layers.fused_moe import (
     fused_moe_make_expert_params_mapping,
+)
+from vllm.model_executor.layers.fusion.quant_activation import (
+    QuantizedActivation,
 )
 from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
@@ -36,6 +38,9 @@ from vllm.model_executor.models.deepseek_v2 import (
 from vllm.model_executor.models.utils import (
     get_pp_missing_layer_names,
     maybe_prefix,
+)
+from vllm.models.common.ops.fused_allreduce_rms_norm import (
+    fused_allreduce_rms_norm_fp8_quant,
 )
 from vllm.models.common.ops.sequence_parallel import (
     sp_all_gather,
@@ -94,7 +99,7 @@ class DeepseekV32MultiTokenPredictorLayer(nn.Module):
         previous_hidden_states: torch.Tensor,
         inputs_embeds: torch.Tensor | None = None,
         spec_step_index: int = 0,
-    ) -> torch.Tensor:
+    ) -> tuple[torch.Tensor | QuantizedActivation, torch.Tensor]:
         assert inputs_embeds is not None
         # Fused: zero pos-0 embeds + enorm(embeds) + hnorm(prev) + cat -> [N, 2H].
         eh_input = fused_eh_norm(
@@ -119,23 +124,23 @@ class DeepseekV32MultiTokenPredictorLayer(nn.Module):
         hidden_states, residual = self.mtp_block(
             positions=positions, hidden_states=hidden_states, residual=None
         )
-        if not is_sequence_parallel:
-            # Without sequence parallelism, the MoE output is left un-reduced.
-            hidden_states = tensor_model_parallel_all_reduce(hidden_states)
-        # Recycle the POST-final-norm hidden into the next draft step. The
-        # residual-add is fused into the final RMSNorm so it is computed
-        # exactly once, and the result is returned for both tuple positions:
-        # the draft-logits hidden (compute_logits applies the LM head only) and
-        # the recycled previous_hidden_states. Recycling the pre-final-norm
-        # hidden mismatches the draft model's hnorm and lowers MTP acceptance;
-        # post-norm recycle matches deepseek_mtp.py (PR #45895). The tuple form
-        # is understood by both the V2 speculator (isinstance-tuple check) and
-        # the legacy proposer (model_returns_tuple is True for the
-        # DeepSeekMTPModel architecture).
-        hidden_states, _ = self.shared_head.norm(hidden_states, residual)
         if is_sequence_parallel:
+            hidden_states, _ = self.shared_head.norm(hidden_states, residual)
             hidden_states = sp_all_gather(hidden_states)[: positions.shape[0]]
-        return hidden_states, hidden_states
+            return hidden_states, hidden_states
+
+        hidden_states, _, logits_input = fused_allreduce_rms_norm_fp8_quant(
+            hidden_states,
+            residual,
+            self.shared_head.norm,
+            self.shared_head.head,
+        )
+        # Recycle the post-final-norm BF16 hidden while compute_logits consumes
+        # the packed FP8 activation when the shared LM head supports it.
+        return (
+            logits_input if logits_input is not None else hidden_states,
+            hidden_states,
+        )
 
 
 class DeepseekV32MultiTokenPredictor(nn.Module):
@@ -188,7 +193,7 @@ class DeepseekV32MultiTokenPredictor(nn.Module):
         previous_hidden_states: torch.Tensor,
         inputs_embeds: torch.Tensor | None = None,
         spec_step_idx: int = 0,
-    ) -> torch.Tensor:
+    ) -> tuple[torch.Tensor | QuantizedActivation, torch.Tensor]:
         if inputs_embeds is None:
             inputs_embeds = self.embed_tokens(input_ids)
         current_step_idx = spec_step_idx % self.num_mtp_layers
@@ -202,7 +207,7 @@ class DeepseekV32MultiTokenPredictor(nn.Module):
 
     def compute_logits(
         self,
-        hidden_states: torch.Tensor,
+        hidden_states: torch.Tensor | QuantizedActivation,
         spec_step_idx: int = 0,
     ) -> torch.Tensor:
         current_step_idx = spec_step_idx % self.num_mtp_layers
@@ -250,14 +255,14 @@ class DeepseekV32MTP(nn.Module, DeepseekV2MixtureOfExperts):
         intermediate_tensors: IntermediateTensors | None = None,
         inputs_embeds: torch.Tensor | None = None,
         spec_step_idx: int = 0,
-    ) -> torch.Tensor:
+    ) -> tuple[torch.Tensor | QuantizedActivation, torch.Tensor]:
         return self.model(
             input_ids, positions, hidden_states, inputs_embeds, spec_step_idx
         )
 
     def compute_logits(
         self,
-        hidden_states: torch.Tensor,
+        hidden_states: torch.Tensor | QuantizedActivation,
         spec_step_idx: int = 0,
     ) -> torch.Tensor | None:
         return self.model.compute_logits(hidden_states, spec_step_idx)

--- a/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
@@ -9,6 +9,10 @@ from vllm.config import VllmConfig
 from vllm.config.compilation import CUDAGraphMode
 from vllm.forward_context import BatchDescriptor, set_forward_context
 from vllm.logger import init_logger
+from vllm.model_executor.layers.fusion.quant_activation import (
+    QuantizedActivation,
+    index_quantized_activation,
+)
 from vllm.triton_utils import tl, triton
 from vllm.v1.kv_cache_interface import KVCacheConfig
 from vllm.v1.worker.gpu.attn_utils import build_slot_mappings_by_layer
@@ -365,7 +369,7 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
         num_tokens_across_dp: torch.Tensor | None,
         cudagraph_runtime_mode: CUDAGraphMode = CUDAGraphMode.NONE,
         mm_inputs: tuple[list[torch.Tensor], torch.Tensor] | None = None,
-    ) -> tuple[torch.Tensor, torch.Tensor]:
+    ) -> tuple[torch.Tensor | QuantizedActivation, torch.Tensor]:
         batch_descriptor = BatchDescriptor(num_tokens=num_tokens)
         with set_forward_context(
             attn_metadata,
@@ -438,7 +442,9 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
             cudagraph_runtime_mode=cudagraph_runtime_mode,
             mm_inputs=mm_inputs,
         )
-        sample_hidden_states = last_hidden_states[last_token_indices]
+        sample_hidden_states = index_quantized_activation(
+            last_hidden_states, last_token_indices
+        )
 
         self.draft_tokens[:num_reqs, 0] = self.sample_draft(
             sample_hidden_states,
@@ -615,7 +621,9 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
             num_tokens_across_dp,
             cudagraph_runtime_mode,
         )
-        last_hidden_states = last_hidden_states[:num_reqs]
+        last_hidden_states = index_quantized_activation(
+            last_hidden_states, slice(None, num_reqs)
+        )
 
         sample_positions = positions
         if not self.advance_draft_positions:

--- a/vllm/v1/worker/gpu/spec_decode/multi_module_mtp/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/multi_module_mtp/speculator.py
@@ -9,6 +9,10 @@ from vllm.config import VllmConfig
 from vllm.config.compilation import CUDAGraphMode
 from vllm.forward_context import BatchDescriptor, set_forward_context
 from vllm.logger import init_logger
+from vllm.model_executor.layers.fusion.quant_activation import (
+    QuantizedActivation,
+    index_quantized_activation,
+)
 from vllm.triton_utils import tl, triton
 from vllm.v1.attention.backends.utils import PAD_SLOT_ID
 from vllm.v1.worker.gpu.attn_utils import build_slot_mappings_by_layer
@@ -258,7 +262,7 @@ class MultiModuleMTPSpeculator(DraftModelSpeculator):
         num_tokens_across_dp: torch.Tensor | None,
         spec_module_idx: int,
         cudagraph_runtime_mode: CUDAGraphMode = CUDAGraphMode.NONE,
-    ) -> tuple[torch.Tensor, torch.Tensor]:
+    ) -> tuple[torch.Tensor | QuantizedActivation, torch.Tensor]:
         batch_descriptor = BatchDescriptor(num_tokens=num_tokens)
         with set_forward_context(
             attn_metadata,
@@ -410,7 +414,9 @@ class MultiModuleMTPSpeculator(DraftModelSpeculator):
             )
 
             # Sample draft tokens for the current step.
-            sample_hidden_states = last_hidden_states[last_token_indices]
+            sample_hidden_states = index_quantized_activation(
+                last_hidden_states, last_token_indices
+            )
             draft_tokens = self.sample_draft(
                 sample_hidden_states,
                 sample_positions,


### PR DESCRIPTION
## Purpose

Fuse the sparse DeepSeek V3.2 / GLM-5.2 MTP layer's final all-reduce and RMSNorm
with packed FP8 quantization for its shared LM head.

The draft layer returns two deliberately different values:

- a packed `QuantizedActivation` for logits projection; and
- the post-final-norm BF16 hidden state recycled into the next MTP position.

The logits processor and both autoregressive speculators preserve and index this
contract without unpacking and requantizing it.

## Dependencies

- #51938: select/register the sparse MTP architecture
- #51939: DeepGEMM block-linear prequantized-input contract
- #51942: all-reduce/RMSNorm/packed-FP8 producer

The branch contains only the seven-file MTP integration diff against `main`.
Until #51942 lands, isolated mypy reports the expected missing collective helper.

## Duplicate-work check

No issue number was provided. I searched open PRs for `DeepSeek V3.2 fused norm
quant MTP`. The only exact prior implementation was the superseded draft
#51936.

## Tests

The portions independent of the missing prerequisite symbol pass directly:

```bash
.venv/bin/python -m pytest \
  tests/fusion/test_quant_activation_contract.py \
  tests/v1/worker/test_gpu_autoregressive_speculator.py -q
# 23 passed
```

On the integrated branch:

```bash
.venv/bin/python -m pytest tests/models/deepseek_v32/test_sequence_parallel.py -q
# 5 passed
```

All hooks other than the expected prerequisite-related mypy error pass.

## Model evaluation

Two-node GB200, TP=8, C1, random 8K input / 1K output, MTP=3, ten measured
prompts, temperature 0:

| Model | Overall | Position 0 | Position 1 | Position 2 |
|---|---:|---:|---:|---:|
| zai-org/GLM-5.2-FP8 | 83.47% | 90.83% | 83.00% | 76.57% |
| nvidia/GLM-5.2-NVFP4 | 89.82% | 93.79% | 90.15% | 85.53% |

Both runs completed all ten prompts without failures.

## AI assistance disclosure

This change was developed with OpenAI Codex assistance. This is a blocked draft
PR; the human submitter must review every changed line and confirm they
understand and can defend the change before marking it ready.
