### PR TITLE
[Model] Enable LoRA support for tower and connector in Cosmos3-Edge

### DIFF
--- a/docs/models/supported_models.md
+++ b/docs/models/supported_models.md
@@ -543,7 +543,7 @@ These models primarily accept the [`LLM.generate`](./generative_models.md#llmgen
 | `Blip2ForConditionalGeneration` | BLIP-2 | T + I<sup>E</sup> | `Salesforce/blip2-opt-2.7b`, `Salesforce/blip2-opt-6.7b`, etc. | ✅︎ | ✅︎ |
 | `Cohere2VisionForConditionalGeneration` | Command A Vision, Command-A+ | T + I<sup>+</sup> | `CohereLabs/command-a-vision-07-2025`, `CohereLabs/command-a-plus-05-2026`, etc. | | ✅︎ |
 | `Cosmos3ForConditionalGeneration` | Cosmos3 (understanding tower) | T + I<sup>E+</sup> + V<sup>E+</sup> | `nvidia/Cosmos3-Nano`, `nvidia/Cosmos3-Super` | | ✅︎ |
-| `Cosmos3EdgeForConditionalGeneration` | Cosmos3-Edge (understanding tower) | T + I<sup>E+</sup> + V<sup>E+</sup> | `nvidia/Cosmos3-Edge` | | ✅︎ |
+| `Cosmos3EdgeForConditionalGeneration` | Cosmos3-Edge (understanding tower) | T + I<sup>E+</sup> + V<sup>E+</sup> | `nvidia/Cosmos3-Edge` | ✅︎ | ✅︎ |
 | `DeepseekVLV2ForCausalLM` | DeepSeek-VL2 | T + I<sup>+</sup> | `deepseek-ai/deepseek-vl2-tiny`, `deepseek-ai/deepseek-vl2-small`, `deepseek-ai/deepseek-vl2`, etc. | | ✅︎ |
 | `DeepseekOCRForCausalLM` | DeepSeek-OCR | T + I<sup>+</sup> | `deepseek-ai/DeepSeek-OCR`, etc. | ✅︎ | ✅︎ |
 | `DeepseekOCR2ForCausalLM` | DeepSeek-OCR-2 | T + I<sup>+</sup> | `deepseek-ai/DeepSeek-OCR-2`, etc. | ✅︎ | ✅︎ |

--- a/vllm/model_executor/models/cosmos3_edge.py
+++ b/vllm/model_executor/models/cosmos3_edge.py
@@ -18,13 +18,14 @@ from vllm.model_executor.layers.rotary_embedding import get_rope
 from vllm.model_executor.layers.vocab_parallel_embedding import ParallelLMHead
 from vllm.model_executor.models.module_mapping import MultiModelKeys
 from vllm.multimodal import MULTIMODAL_REGISTRY
-from vllm.multimodal.inputs import MultiModalFeatureSpec
+from vllm.multimodal.inputs import MultiModalFeatureSpec, MultiModalKwargsItem
 from vllm.sequence import IntermediateTensors
 from vllm.transformers_utils.configs.nemotron_h import NemotronHConfig
 from vllm.utils.torch_utils import async_tensor_h2d
 
 from .interfaces import (
     MultiModalEmbeddings,
+    SupportsLoRA,
     SupportsMRoPE,
     SupportsMultiModal,
     SupportsPP,
@@ -487,6 +488,7 @@ def _cosmos3_edge_diffusers_prefix_map() -> dict[str, str]:
 class Cosmos3EdgeForConditionalGeneration(
     nn.Module,
     SupportsMultiModal,
+    SupportsLoRA,
     SupportsPP,
     SupportsMRoPE,
 ):
@@ -544,6 +546,7 @@ class Cosmos3EdgeForConditionalGeneration(
     allow_patterns_overrides = ["[tv]*er/*.safetensors"]
 
     supports_encoder_tp_data = True
+    supports_tower_connector_lora = True
 
     @classmethod
     def get_placeholder_str(cls, modality: str, i: int) -> str | None:
@@ -749,6 +752,17 @@ class Cosmos3EdgeForConditionalGeneration(
             connector="visual.projector",
             tower_model="visual.",
         )
+
+    def get_mm_lora_token_counts(
+        self,
+        *,
+        modality: str,
+        mm_kwargs: MultiModalKwargsItem | None,
+        num_mm_embeds: int,
+    ) -> tuple[int, int | None]:
+        del modality, mm_kwargs
+        merge_size = self.visual.spatial_merge_size
+        return num_mm_embeds * merge_size**2, num_mm_embeds
 
     def get_mrope_input_positions(
         self,


### PR DESCRIPTION
## Purpose

An operator serving `nvidia/Cosmos3-Edge` can attach a LoRA adapter to the language model but not
to the vision tower or the connector. Adapting the model to a new visual domain, such as a different
imaging modality or an unusual camera, therefore means full fine-tuning. With `--enable-lora` the
engine currently refuses to start: `lora_model_runner_mixin.py:54` raises
`ValueError: Cosmos3EdgeForConditionalGeneration does not support LoRA yet.`

A model opts in by declaring `SupportsLoRA`, setting `supports_tower_connector_lora`, and returning
its tower and connector row counts from `get_mm_lora_token_counts`. Cosmos3-Edge's `get_mm_mapping`
and `packed_modules_mapping` were already correct, so this PR adds those three things and fills in
the LoRA cell in `docs/models/supported_models.md`.

Wrong row counts don't raise. The LoRA metadata buffer keeps its values between forward passes, so a
row the count misses reads a stale adapter index and the request gets plausible output from the
wrong adapter. That is why the counts below are measured on real tensors rather than derived.

Part of #31479, which the maintainer closed on 2026-09-02 once most towers supported LoRA. No
closing keyword, like the merged siblings.

## Technical details

**The capability flag is required.** Since #53092, `vllm/lora/model_manager.py:204` enables
tower/connector LoRA only when the model sets `supports_tower_connector_lora`, which defaults to
`False` at `vllm/model_executor/models/interfaces.py:192`. Without it the engine starts, logs "LoRA
with tower connector is enabled, but the model ... does not support it. This will be ignored.", and
serves without the adapter. #53519 fixed exactly this for LFM2-VL.

**Only the unified hook is implemented.** #55071 deprecates the split `get_num_mm_encoder_tokens` /
`get_num_mm_connector_tokens` pair, so the model overrides `get_mm_lora_token_counts` directly, in
the shape #55071 gives Keye and Qwen3-VL. Each LLM token is `spatial_merge_size**2` rows entering the
tower and one row entering the connector, for images and video alike.

**The merge factor comes from `self.visual.spatial_merge_size`**, not `config.vision_config` as in
Qwen2.5-VL and Qwen3-VL. `Cosmos3EdgeConfig.__init__` copies it from the projector config at
`vllm/transformers_utils/configs/cosmos3_edge.py:126`:

```python
self.vision_config.spatial_merge_size = self.projector_config.spatial_merge_size
```

The checkpoint stores the value on the projector, and `Cosmos3EdgeVisionModel` builds the projector
from it at `cosmos3_edge.py:225` and `:237`. The same file already divides by
`self.visual.spatial_merge_size**2` when it splits vision embeddings per item, at `:598`.

There is no divisibility assertion. At engine init `model_manager.py:252` calls the hook once per
modality with the whole-batch encoder budget, which need not be a multiple of anything.

## Duplicate check

Per `AGENTS.md`, re-run immediately before opening:

```bash
gh issue view 31479 --repo vllm-project/vllm --comments
gh pr list --repo vllm-project/vllm --state open --search "31479 in:body"
gh pr list --repo vllm-project/vllm --state all  --search "Cosmos3-Edge LoRA"
gh pr list --repo vllm-project/vllm --state open --search "tower connector lora"
gh pr list --repo vllm-project/vllm --state open --search "Cosmos3EdgeForConditionalGeneration"
```

Re-run on 2026-09-12. No other PR adds tower/connector LoRA to Cosmos3-Edge, and the class-name
search returns only this PR. The nine other open PRs that reference #31479 target other models.
Related PRs a reviewer may find:

- #51221 adds EVS video pruning to this model. Open, idle since 2026-08-06. See *Known
  limitations*.
- #52229 adds encoder CUDA graphs to this model and edits the same class bases and import block.
  Whichever lands second has a one-line conflict.
- #42662, merged 2026-08-13, moved the call sites to `get_mm_lora_token_counts`.
- #55071 is the open refactor that deprecates the split helpers. This PR already uses its shape.
- #47400 fixes a different bug in the same mapping builder, where cache-served items are counted
  although the encoder skips them. Independent of this change.

## Test Plan

```bash
# Existing mapping test: mocked model, no GPU
.venv/bin/python -m pytest tests/v1/worker/test_gpu_model_runner.py -k mm_loras
.venv/bin/python -m pytest tests/models/test_registry.py
COSMOS3_EDGE_MODEL_PATH=<snapshot> .venv/bin/python -m pytest \
    tests/models/multimodal/processing/test_cosmos3_edge.py

pre-commit run --from-ref upstream/main --to-ref HEAD
pre-commit run mypy-3.12 --hook-stage manual \
    --files vllm/model_executor/models/cosmos3_edge.py

# Row counts, without and with a rank-8 adapter (script below)
.venv/bin/python probe_rows.py
.venv/bin/python probe_rows.py --adapter <adapter-dir>
```

No test is added, in line with review on #51780, #49788 and #48215. The evidence is the measured row
counts below.

Environment: RTX 3090 24 GB, driver 610.57.04, CUDA 13.2, torch 2.13.0, transformers 5.16.1, base
`9d3e991ece`.

## Test Result

Every command in the test plan passes: 1 passed for `-k mm_loras`, 392 passed and 12 skipped for the
registry, 3 passed for the processing test, and both pre-commit runs are clean.

With `enable_lora=True, enable_tower_connector_lora=True, max_lora_rank=8` the engine starts and logs

```
WARNING [model_manager.py:242] LoRA for the tower and connector of multimodal models is
experimental and may contain bugs. Please report any related issues on GitHub if you encounter them.
```

with no "This will be ignored" line. The LoRA manager reports `supports_tower_connector_lora=True`
and builds Punica wrappers for `language_model`, `visual.` and `visual.projector`.

**Hook output against real tensor rows.** Forward pre-hooks record the rows entering
`visual.encoder.encoder.layers.0.self_attn.qkv_proj` for the tower and `visual.projector.linear_fc1`
for the connector.

| input | LLM tokens | tower rows observed | hook | connector rows observed | hook |
|---|---|---|---|---|---|
| image | 1107 | 4428 | 4428 | 1107 | 1107 |
| video, 4 frames | 4180 | 16720 | 16720 | 4180 | 4180 |

The counts are identical with and without an adapter attached.

<details>
<summary>probe_rows.py, which produces the table above</summary>

```python
import argparse
import os

os.environ.setdefault("VLLM_ENABLE_V1_MULTIPROCESSING", "0")

from types import SimpleNamespace

from vllm import LLM, SamplingParams
from vllm.assets.image import ImageAsset
from vllm.assets.video import VideoAsset
from vllm.lora.request import LoRARequest
from vllm.model_executor.models.cosmos3_edge import (
    Cosmos3EdgeForConditionalGeneration as C3E,
)
from vllm.transformers_utils.config import get_config

parser = argparse.ArgumentParser()
parser.add_argument("--adapter", help="LoRA dir; enables tower/connector LoRA")
args = parser.parse_args()

MODEL = "nvidia/Cosmos3-Edge"
TOWER = "visual.encoder.encoder.layers.0.self_attn.qkv_proj"
CONNECTOR = "visual.projector.linear_fc1"

seen: dict[str, list[int]] = {"tower": [], "connector": []}


def install_hooks(model):
    def record(key):
        def hook(_module, args):
            seen[key].append(args[0].shape[-2])

        return hook

    for name, module in model.named_modules():
        if name == TOWER:
            module.register_forward_pre_hook(record("tower"))
        elif name == CONNECTOR:
            module.register_forward_pre_hook(record("connector"))


lora_kwargs = (
    dict(enable_lora=True, enable_tower_connector_lora=True, max_lora_rank=8)
    if args.adapter
    else {}
)
lora_request = LoRARequest("probe", 1, args.adapter) if args.adapter else None

llm = LLM(
    model=MODEL,
    max_model_len=16384,
    limit_mm_per_prompt={"image": 1, "video": 1},
    gpu_memory_utilization=0.85,
    enforce_eager=True,
    allowed_local_media_path="/",
    mm_processor_cache_gb=0,
    **lora_kwargs,
)
llm.apply_model(install_hooks)

config = get_config(MODEL, trust_remote_code=False)
tokenizer = llm.get_tokenizer()
start = tokenizer.decode([config.vision_start_token_id])
end = tokenizer.decode([config.vision_end_token_id])
image_pad = tokenizer.decode([config.image_token_id])
params = SamplingParams(temperature=0.0, max_tokens=1)


def check(label, output, token_id, modality):
    llm_tokens = output[0].prompt_token_ids.count(token_id)
    encoder_rows, connector_rows = seen["tower"][-1], seen["connector"][-1]
    stub = SimpleNamespace(
        visual=SimpleNamespace(
            spatial_merge_size=config.projector_config.spatial_merge_size
        )
    )
    predicted_encoder, predicted_connector = C3E.get_mm_lora_token_counts(
        stub, modality=modality, mm_kwargs=None, num_mm_embeds=llm_tokens
    )
    print(
        f"{label:<8} llm_tokens={llm_tokens}  "
        f"encoder observed={encoder_rows} helper={predicted_encoder} "
        f"{'OK' if encoder_rows == predicted_encoder else 'MISMATCH'}  "
        f"connector observed={connector_rows} helper={predicted_connector} "
        f"{'OK' if connector_rows == predicted_connector else 'MISMATCH'}"
    )


check(
    "image",
    llm.generate(
        {
            "prompt": f"<|im_start|>user\n{start}{image_pad}{end}Describe."
            f"<|im_end|>\n<|im_start|>assistant\n",
            "multi_modal_data": {"image": ImageAsset("stop_sign").pil_image},
        },
        params,
        lora_request=lora_request,
    ),
    config.image_token_id,
    "image",
)

video = VideoAsset(name="baby_reading", num_frames=4)
check(
    "video",
    llm.chat(
        [
            {
                "role": "user",
                "content": [
                    {
                        "type": "video_url",
                        "video_url": {"url": f"file://{video.video_path}"},
                    },
                    {"type": "text", "text": "Describe."},
                ],
            }
        ],
        params,
        lora_request=lora_request,
    ),
    config.video_token_id,
    "video",
)
```

The video prompt goes through the chat template. A hand-built video placeholder leaves out the
per-frame timestamp tokens, which misplaces the embeddings without an error and would invalidate the
comparison.

</details>

**The adapter reaches the tower and the connector.** I used a random rank-8 adapter (alpha 16,
nonzero B) targeting `visual.encoder.encoder.layers.0.self_attn.{q,k,v,out}_proj`,
`visual.encoder.encoder.layers.0.mlp.fc{1,2}` and `visual.projector.linear_fc{1,2}`. For both the
image and the video request:

- vLLM wraps 109 tower and 2 connector linear layers. Their Punica shrink and expand ops run as
  active with the adapter and are skipped without it.
- The input to `visual.encoder.encoder.layers.0.self_attn.qkv_proj` is identical with and without
  the adapter, and its output changes by 2.78% for the image and 2.70% for the video, measured as
  `||a - b|| / ||b||`.
- The output of `visual.projector.linear_fc2` changes by 16.5% and 18.6%. That includes the change
  already coming from the tower, so it shows the adapter reaches the connector, not the connector's
  own share.

This shows the adapter path is used. It is not a model-quality measurement.

## Known limitations

- Video pruning (EVS) isn't handled. This model doesn't implement `SupportsMultiModalPruning`, so the
  problem can't occur here yet. On models that do, `PlaceholderRange.get_num_embeds()` returns the
  post-prune count while the tower has already processed every frame, so the tower count comes out
  short by roughly `1/(1-q)` for pruning rate `q`, bounded by the frame count. The cause is in the
  shared call sites, `vllm/v1/worker/gpu/mm/lora.py:50` and `vllm/v1/worker/gpu_model_runner.py:3062`,
  and it already affects Qwen2.5-VL, Qwen3-VL and Qwen3-VL-MoE. Images are unaffected. #51221 would
  make it reachable on this model, so whichever of #51221 and this PR lands second should add a guard
  that rejects EVS pruning combined with tower LoRA.
  <!-- TODO(human): link upstream call-site issue -->

## Acceptance criteria

- [x] No new tests, in line with review on sibling PRs (see *Test Plan*)
- [x] Existing tests pass locally
- [x] pre-commit clean on the changed files, including mypy
- [x] No breaking changes; the change is additive
- [x] Documentation updated (`docs/models/supported_models.md`)
- [x] Duplicate-work checks re-run on 2026-09-12, per `AGENTS.md`
- [x] AI assistance disclosed

## AI assistance

AI assistance was used. I reviewed every changed line, and the results above come from real runs on
the stated hardware.

<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
