### PR TITLE
[Core] Expose MessageQueue busy-loop duration as VLLM_MQ_SPIN_SECONDS

### DIFF
--- a/vllm/distributed/device_communicators/shm_broadcast.py
+++ b/vllm/distributed/device_communicators/shm_broadcast.py
@@ -131,7 +131,7 @@ class SpinCondition:
         is_reader: bool,
         context: zmq.Context,
         notify_address: str,
-        busy_loop_s: float = 1,
+        busy_loop_s: float | None = None,
     ):
         self.is_reader = is_reader
 
@@ -140,6 +140,8 @@ class SpinCondition:
             self.last_read = time.monotonic()
 
             # Time to keep busy-looping on the shm buffer before going idle
+            if busy_loop_s is None:
+                busy_loop_s = envs.VLLM_MQ_SPIN_SECONDS
             self.busy_loop_s = busy_loop_s
 
             # Readers subscribe to write notifications

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
     VLLM_USE_MODELSCOPE: bool = False
     VLLM_USE_FASTOKENS: bool = False
     VLLM_RINGBUFFER_WARNING_INTERVAL: int = 60
+    VLLM_MQ_SPIN_SECONDS: float = 1.0
     VLLM_NCCL_SO_PATH: str | None = None
     LD_LIBRARY_PATH: str | None = None
     VLLM_ROCM_SLEEP_MEM_CHUNK_SIZE: int = 256
@@ -725,6 +726,13 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_RINGBUFFER_WARNING_INTERVAL": lambda: int(
         os.environ.get("VLLM_RINGBUFFER_WARNING_INTERVAL", "60")
     ),
+    # How long (seconds) MessageQueue readers keep busy-looping after the
+    # last message before falling back to blocking on the notify socket.
+    # The default keeps the historical always-spin behavior for latency.
+    # Lower values (e.g. 0.002) let reader processes sleep between decode
+    # steps, which greatly reduces CPU usage and heat on machines where
+    # CPU and GPU share a package/board (e.g. NVIDIA DGX Spark / GB10).
+    "VLLM_MQ_SPIN_SECONDS": lambda: float(os.getenv("VLLM_MQ_SPIN_SECONDS", "1")),
     # path to cudatoolkit home directory, under which should be bin, include,
     # and lib directories.
     "CUDA_HOME": lambda: os.environ.get("CUDA_HOME", None),
@@ -2189,6 +2197,7 @@ def compile_factors() -> dict[str, object]:
         "VLLM_RPC_BASE_PATH",
         "VLLM_USE_MODELSCOPE",
         "VLLM_RINGBUFFER_WARNING_INTERVAL",
+        "VLLM_MQ_SPIN_SECONDS",
         "VLLM_DEBUG_DUMP_PATH",
         "VLLM_PORT",
         "VLLM_CACHE_ROOT",


### PR DESCRIPTION
## Purpose

`SpinCondition` readers in `shm_broadcast.py` busy-loop (`sched_yield`) for `busy_loop_s` seconds after the last message before falling back to blocking on the zmq notify socket. The 1-second default is hardcoded at both call sites. During active decoding, messages arrive every few milliseconds, so readers never reach the idle path — the hybrid wait degenerates into a permanent spin.

On big servers this is a reasonable latency trade. But on machines where CPU and GPU share a package — e.g. NVIDIA DGX Spark (GB10) — it pins 3–4 performance cores at 100% doing no useful work, and becomes the dominant heat source. Measured on a 2-node GB10 cluster (TP=2, DeepSeek V4 Flash, mp executor), `py-spy` shows both `EngineCore` and `Worker` main threads spinning here:

```
Thread (active): "MainThread"
    sched_yield (vllm/distributed/utils.py:48)
    wait (vllm/distributed/device_communicators/shm_broadcast.py:196)
    acquire_read (vllm/distributed/device_communicators/shm_broadcast.py:698)
    dequeue (vllm/distributed/device_communicators/shm_broadcast.py:779)
    worker_busy_loop (vllm/v1/executor/multiproc_executor.py:987)
```

Under load the vLLM processes consumed **333% CPU** and drove the SoC hot-spot sensor to **96 °C** (thermal trip: 104.8 °C) while the GPU sensor stayed 20 °C cooler. Community reports place GB10 thermal shutdowns at ~87 °C, so this waiting heat alone pushes fanless nodes into the shutdown band.

## Change

Expose the spin window as `VLLM_MQ_SPIN_SECONDS`. **The default is unchanged** (1 s, historical always-spin behavior); the env var only gives deployments a knob to opt into blocking waits sooner.

## Test / Measurements

2× DGX Spark (GB10), TP=2 across nodes via `mp` executor + 200 GbE RoCE, DeepSeek V4 Flash 0731, continuous decode load (GPU util 95–96%):

| | default (1 s) | `VLLM_MQ_SPIN_SECONDS=0.002` |
|---|---|---|
| vLLM process CPU (sum) | 333% | **89%** |
| SoC hot-spot | 77 °C | **66 °C** |
| decode tok/s, c=1 | 52–63 (boot-to-boot range) | 58.0 |
| decode tok/s aggregate, c=8 | 154–173 | 157.8 |
| GPU util | 95% | 96% |

Throughput and TTFT stayed within the run-to-run noise band across repeated boots; only CPU time and heat changed. (Measurements taken on a 0.25.2-based build; the touched code is identical on `main`.)

`VLLM_MQ_SPIN_SECONDS` is added to `compile_factors()` ignored set since it is a runtime wait policy and cannot affect compiled artifacts.

Related: #21231 (100% CPU on several cores per node in distributed serving).
