### PR TITLE
[Bugfix][MRV2] Fix DiffusionGemma runtime OOM via tiled logits projection

### DIFF
--- a/tests/v1/worker/test_gpu_diffusion_sampler.py
+++ b/tests/v1/worker/test_gpu_diffusion_sampler.py
@@ -1,0 +1,143 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""DiffusionSampler projects logits tile-by-tile (#50699): sampling outputs
+must not depend on the tile size, and peak memory must scale with the tile,
+not the batch."""
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import torch
+
+from vllm.model_executor.models import diffusion_gemma as dg
+from vllm.platforms import current_platform
+from vllm.sampling_params import SamplingParams
+from vllm.v1.worker.gpu.sample.states import SamplingStates
+
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+
+DEVICE = "cuda"
+
+
+def _make_sampler(num_reqs, canvas_len, vocab, hidden, weight, top_k=0):
+    states = dg.DiffusionGemmaRequestStates(
+        max_num_reqs=num_reqs,
+        canvas_length=canvas_len,
+        vocab_size=vocab,
+        max_denoising_steps=8,
+        device=torch.device(DEVICE),
+        hidden_size=hidden,
+        stability_threshold=2,
+    )
+    base = SimpleNamespace(
+        sampling_states=SamplingStates(num_reqs, vocab),
+        req_states=SimpleNamespace(
+            draft_tokens=torch.zeros(
+                num_reqs, canvas_len, dtype=torch.int64, device=DEVICE
+            )
+        ),
+        logprobs_mode="raw_logprobs",
+    )
+    sampler = dg.DiffusionSampler(
+        sampler=base,
+        diffusion_config=SimpleNamespace(canvas_length=canvas_len),
+        vocab_size=vocab,
+        diffusion_states=states,
+        compute_logits=lambda h: h @ weight.t(),
+        confidence_threshold=0.5,
+        t_min=0.0,
+        t_max=0.0,
+        entropy_bound=0.1,
+        embed_weight=weight,
+        normalizer=torch.tensor(1.0, device=DEVICE),
+    )
+    for i in range(num_reqs):
+        sampler.add_request(i, 4, SamplingParams(top_k=top_k))
+        states.is_encoder_phase[i] = False
+    sampler.apply_staged_writes()
+    return sampler, states
+
+
+def _make_batch(num_reqs, valid_lens):
+    cu = np.zeros(num_reqs + 1, dtype=np.int64)
+    cu[1:] = np.cumsum(valid_lens)
+    qsl_np = cu.astype(np.int32)
+    return SimpleNamespace(
+        num_reqs=num_reqs,
+        num_draft_tokens=int(max(valid_lens)),
+        idx_mapping_np=np.arange(num_reqs, dtype=np.intp),
+        idx_mapping=torch.arange(num_reqs, dtype=torch.int64, device=DEVICE),
+        cu_num_logits_np=cu,
+        query_start_loc_np=qsl_np,
+        query_start_loc=torch.from_numpy(qsl_np).to(DEVICE),
+    )
+
+
+@pytest.mark.parametrize("top_k", [0, 4])
+def test_tiled_projection_matches_full(monkeypatch, top_k):
+    """Deterministic outputs (t_min=t_max=0) are identical for group=1 tiling
+    and a single full-batch pass, including a truncated (padded) canvas."""
+    num_reqs, canvas_len, vocab, hidden = 4, 16, 1024, 32
+    torch.manual_seed(0)
+    weight = torch.randn(vocab, hidden, device=DEVICE)
+    valid_lens = [canvas_len, canvas_len, canvas_len, canvas_len - 3]
+    hs = torch.randn(sum(valid_lens), hidden, device=DEVICE)
+
+    results = []
+    for free in (2**60, 0):
+        torch.manual_seed(0)
+        sampler, states = _make_sampler(
+            num_reqs, canvas_len, vocab, hidden, weight, top_k
+        )
+        monkeypatch.setattr(
+            current_platform, "mem_get_info", lambda free=free: (free, 2**60)
+        )
+        out = sampler(hs.clone(), _make_batch(num_reqs, valid_lens))
+        results.append((out, states))
+
+    (out_full, st_full), (out_tiled, st_tiled) = results
+    torch.testing.assert_close(st_full.argmax_canvas, st_tiled.argmax_canvas)
+    torch.testing.assert_close(st_full.is_encoder_phase, st_tiled.is_encoder_phase)
+    torch.testing.assert_close(st_full.confident, st_tiled.confident)
+    torch.testing.assert_close(st_full.step, st_tiled.step)
+    torch.testing.assert_close(out_full.sampled_token_ids, out_tiled.sampled_token_ids)
+    torch.testing.assert_close(out_full.num_sampled, out_tiled.num_sampled)
+
+
+def test_tiling_bounds_peak_memory(monkeypatch):
+    """Forced group=1 tiling must not materialize full-batch logits."""
+    num_reqs, canvas_len, vocab, hidden = 8, 64, 32768, 64
+    torch.manual_seed(0)
+    weight = torch.randn(vocab, hidden, device=DEVICE)
+    valid_lens = [canvas_len] * num_reqs
+    hs = torch.randn(num_reqs * canvas_len, hidden, device=DEVICE)
+
+    peaks = {}
+    for name, free in (("full", 2**60), ("tiled", 0)):
+        torch.manual_seed(0)
+        sampler, _ = _make_sampler(num_reqs, canvas_len, vocab, hidden, weight)
+        monkeypatch.setattr(
+            current_platform, "mem_get_info", lambda free=free: (free, 2**60)
+        )
+        sampler(hs.clone(), _make_batch(num_reqs, valid_lens))
+        torch.accelerator.synchronize()
+        torch.accelerator.reset_peak_memory_stats()
+        base = torch.accelerator.memory_allocated()
+        sampler(hs.clone(), _make_batch(num_reqs, valid_lens))
+        torch.accelerator.synchronize()
+        peaks[name] = torch.accelerator.max_memory_allocated() - base
+
+    assert peaks["tiled"] < peaks["full"] / 2
+
+
+def test_profile_run_resets_state():
+    """profile_run exercises the decode pipeline for KV sizing, then leaves
+    slot 0 freshly initialized."""
+    num_reqs, canvas_len, vocab, hidden = 2, 16, 1024, 32
+    torch.manual_seed(0)
+    weight = torch.randn(vocab, hidden, device=DEVICE)
+    sampler, states = _make_sampler(num_reqs, canvas_len, vocab, hidden, weight)
+    sampler.profile_run(torch.zeros(num_reqs, hidden, device=DEVICE))
+    assert bool(states.is_encoder_phase[0])
+    assert int(states.step[0]) == 0

--- a/vllm/model_executor/models/diffusion_gemma.py
+++ b/vllm/model_executor/models/diffusion_gemma.py
@@ -16,7 +16,7 @@ via Gemma4MultimodalEmbedder.
 
 from __future__ import annotations
 
-from collections.abc import Iterable, Mapping
+from collections.abc import Callable, Iterable, Mapping
 from types import SimpleNamespace
 from typing import Any
 
@@ -825,6 +825,13 @@ class DiffusionGemmaModelState(ModelState):
     def get_supported_generation_tasks(self):
         return ("generate",)
 
+    def compute_sample_logits(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        return hidden_states
+
+    def dummy_sampler_run(self, sampler: Any, hidden_states: torch.Tensor) -> bool:
+        sampler.profile_run(hidden_states)
+        return True
+
     def custom_sampler(self, sampler: Any) -> tuple[Any, Any] | None:
         diffusion_config = self.vllm_config.diffusion_config
         gen = self.gen_config
@@ -847,6 +854,7 @@ class DiffusionGemmaModelState(ModelState):
             diffusion_config=diffusion_config,
             vocab_size=self.model_config.get_vocab_size(),
             diffusion_states=self.diffusion_states,
+            compute_logits=self.model.compute_logits,
             t_min=gen["t_min"],
             t_max=gen["t_max"],
             entropy_bound=entropy_bound,
@@ -1053,6 +1061,7 @@ class DiffusionSampler:
         vocab_size: int,
         diffusion_states: DiffusionGemmaRequestStates,
         *,
+        compute_logits: Callable[[torch.Tensor], torch.Tensor],
         confidence_threshold: float,
         t_min: float,
         t_max: float,
@@ -1064,6 +1073,7 @@ class DiffusionSampler:
         tp_size: int = 1,
         tp_group_name: str = "",
     ):
+        self.compute_logits = compute_logits
         self.sampling_states = sampler.sampling_states
         self.req_states = sampler.req_states
         self.logits_mode = sampler.logprobs_mode in ("raw_logits", "processed_logits")
@@ -1131,6 +1141,53 @@ class DiffusionSampler:
         # penalties_state.output_bin_counts, so expose a stub holding None;
         # post_update treats None bin counts as "no penalty bookkeeping".
         return _NO_PENALTIES_STATE
+
+    @torch.inference_mode()
+    def profile_run(self, hidden_states: torch.Tensor) -> None:
+        # The profiling dummy batch is prefill-shaped, so run one group=1
+        # decode tile here so KV-cache sizing reserves the sampler transient
+        # and _compiled_sample_step compiles before serving.
+        states = self.diffusion_states
+        CL = self.canvas_length
+        device = hidden_states.device
+        hidden = hidden_states.new_zeros((CL, hidden_states.shape[-1]))
+        slot = torch.zeros(1, dtype=torch.int64, device=device)
+        valid_len = torch.full((1,), CL, dtype=torch.int64, device=device)
+        states.add_request(0)
+        logits = self.compute_logits(hidden)
+        _compiled_sample_step(
+            logits,
+            slot,
+            slot,
+            slot,
+            valid_len,
+            states.canvas,
+            states.argmax_canvas,
+            states.step,
+            states.is_encoder_phase,
+            states.confident,
+            states.self_conditioning_embeds,
+            self.embed_weight,
+            self.normalizer,
+            states.accepted_canvas_history,
+            states.accepted_canvas_history_len,
+            self._sampled[:1],
+            self._num_sampled[:1],
+            self.req_states.draft_tokens,
+            max_denoising_steps=float(states.max_denoising_steps),
+            t_min=self.t_min,
+            t_max=self.t_max,
+            confidence_threshold=self.confidence_threshold,
+            vocab_size=self.vocab_size,
+            CL=CL,
+            ST=states.stability_threshold,
+            entropy_bound=self.entropy_bound,
+            sc_vocab_start=self.sc_vocab_start,
+            sc_vocab_end=self.sc_vocab_end,
+            tp_size=self.tp_size,
+            tp_group_name=self.tp_group_name,
+        )
+        states.add_request(0)
 
     # ------------------------------------------------------------------
     # Prefill
@@ -1228,12 +1285,12 @@ class DiffusionSampler:
 
     def __call__(
         self,
-        logits: torch.Tensor,
+        hidden_states: torch.Tensor,
         input_batch: Any,
         draft_logits: torch.Tensor | None = None,
     ) -> SamplerOutput:
         num_reqs = input_batch.num_reqs
-        device = logits.device
+        device = hidden_states.device
 
         if input_batch.num_draft_tokens == 0:
             return self._handle_prefill(input_batch, device)
@@ -1268,34 +1325,35 @@ class DiffusionSampler:
             valid_canvas_len_np.astype(np.int64), device=device
         )
 
-        # Per-request top_k/top_p, mirroring the AR sampler. Masked tokens
-        # become -inf and survive the temperature scaling in the compiled
-        # step, so Gumbel sampling, probs, and entropy all see the filtered
-        # distribution. The committed argmax (always the top-1 token) is
-        # unaffected; only the canvas exploration is constrained. Applied
-        # before canvas padding so phantom positions stay uniform.
-        if num_decode > 0:
-            top_k, top_p = self.sampling_states.get_top_k_top_p(
-                decode_slots.repeat_interleave(
-                    valid_canvas_len, output_size=int(valid_canvas_len_np.sum())
-                ),
-                decode_slots_np,
-            )
-            if top_k is not None or top_p is not None:
-                logits = apply_top_k_top_p(logits.float(), top_k, top_p)
-
         # Pad any truncated canvas back to CL so the uniform-CL sampler math
-        # holds. Phantom (padded) positions are zeroed → uniform logits → high
-        # entropy (no premature convergence) and argmax 0 (stable); they are
-        # never committed (num_sampled == real length). masked_fill (not
-        # multiply) so -inf entries from top_k/top_p filtering above don't
-        # turn phantom rows into NaN.
+        # holds. Zeroed hidden rows project to all-zero logits (the LM head
+        # has no bias) → uniform → high entropy (no premature convergence)
+        # and argmax 0 (stable); they are never committed.
+        valid_rows = None
         if num_decode > 0 and valid_canvas_len_np.min() < CL:
             ar = torch.arange(CL, device=device)
             starts = valid_canvas_len.cumsum(0) - valid_canvas_len  # row offset per req
             valid = ar.unsqueeze(0) < valid_canvas_len.unsqueeze(1)  # [num_decode, CL]
-            src = (starts.unsqueeze(1) + ar.unsqueeze(0)).clamp_max(logits.shape[0] - 1)
-            logits = logits[src.reshape(-1)].masked_fill_(~valid.reshape(-1, 1), 0)
+            src = (starts.unsqueeze(1) + ar.unsqueeze(0)).clamp_max(
+                hidden_states.shape[0] - 1
+            )
+            valid_rows = valid.reshape(-1)
+            hidden_states = hidden_states[src.reshape(-1)].masked_fill_(
+                ~valid_rows.unsqueeze(1), 0
+            )
+
+        # Per-request top_k/top_p, mirroring the AR sampler. Masked tokens
+        # become -inf and survive the temperature scaling in the compiled
+        # step, so Gumbel sampling, probs, and entropy all see the filtered
+        # distribution. The committed argmax (always the top-1 token) is
+        # unaffected. Applied per tile below; phantom rows are re-zeroed
+        # (masked_fill, not multiply, to avoid -inf * 0 NaN) to stay uniform.
+        top_k = top_p = None
+        if num_decode > 0:
+            top_k, top_p = self.sampling_states.get_top_k_top_p(
+                decode_slots.repeat_interleave(CL, output_size=num_decode * CL),
+                decode_slots_np,
+            )
 
         # Clear once: the tiled loop below only scatters its own decode slots,
         # so it must not re-clear earlier tiles' writes.
@@ -1314,26 +1372,37 @@ class DiffusionSampler:
         is_decode_np = per_req_nlogits_np > 0
         max_num_logprobs = self.sampling_states.max_num_logprobs(slots_np)
 
-        # Sample over the [num_decode * CL, vocab] logits. The fp32 pipeline in
-        # _compiled_sample_step keeps several live [group * CL, vocab] copies, so
-        # size each tile to a fraction of free memory to bound the transient at
-        # high concurrency. Tiling is bit-identical to a single pass.
+        # Project and sample per tile of requests: the vocab projection plus
+        # the fp32 pipeline in _compiled_sample_step keep several live
+        # [group * CL, vocab] copies, so size each tile to a fraction of free
+        # memory. Full-batch logits are never materialized.
         group = max(num_decode, 1)
         if num_decode > 0:
             free, _ = current_platform.mem_get_info()
-            # ~10 transient fp32 copies of [group * CL, vocab] inside the step
-            # (eager peaks at ~8; pad for allocator overhead and small tensors).
-            bytes_per_req = CL * self.vocab_size * 4 * 10
+            # ~12 fp32-equivalent copies of [group * CL, vocab] per tile:
+            # projected logits + softcap upcast + ~8 step transients, padded.
+            bytes_per_req = CL * self.vocab_size * 4 * 12
             budget = int(free * 0.5) // max(bytes_per_req, 1)
             group = max(1, min(num_decode, budget))
 
         for start_req in range(0, num_decode, group):
             end_req = min(start_req + group, num_decode)
             tile = slice(start_req, end_req)
+            tile_rows = slice(start_req * CL, end_req * CL)
             tile_slots = decode_slots[tile]
 
+            logits = self.compute_logits(hidden_states[tile_rows])
+            if top_k is not None or top_p is not None:
+                logits = apply_top_k_top_p(
+                    logits.float(),
+                    top_k[tile_rows] if top_k is not None else None,
+                    top_p[tile_rows] if top_p is not None else None,
+                )
+                if valid_rows is not None:
+                    logits.masked_fill_(~valid_rows[tile_rows].unsqueeze(1), 0)
+
             scaled = _compiled_sample_step(
-                logits[start_req * CL : end_req * CL],
+                logits,
                 tile_slots,
                 decode_idx[tile],
                 all_slots,

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -797,6 +797,9 @@ class GPUModelRunner(LoRAModelRunnerMixin):
 
     @torch.inference_mode()
     def _dummy_sampler_run(self, hidden_states: torch.Tensor) -> None:
+        assert self.sampler is not None
+        if self.model_state.dummy_sampler_run(self.sampler, hidden_states):
+            return
         num_reqs = hidden_states.shape[0]
         logits = self.model.compute_logits(hidden_states)
         dummy_input_batch = InputBatch.make_dummy(
@@ -806,7 +809,6 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         # NOTE(woosuk): During the initial memory profiling, the sampler may skip
         # top_k, top_p, and logprobs, using less GPU memory than what is possible
         # during actual execution.
-        assert self.sampler is not None
         self.sampler(logits, dummy_input_batch)
 
     @torch.inference_mode()
@@ -1376,7 +1378,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             logits = logits[:, : self.vocab_size]
         else:
             sample_hidden_states = hidden_states[input_batch.logits_indices]
-            logits = self.model.compute_logits(sample_hidden_states)
+            logits = self.model_state.compute_sample_logits(sample_hidden_states)
 
         if grammar_output is not None:
             # Apply grammar bitmask to the logits in-place.

--- a/vllm/v1/worker/gpu/model_states/interface.py
+++ b/vllm/v1/worker/gpu/model_states/interface.py
@@ -233,6 +233,17 @@ class ModelState(ABC):
         """
         return None
 
+    def compute_sample_logits(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        """Project the sampled hidden states to the logits fed to the sampler."""
+        return cast(Any, self.model).compute_logits(hidden_states)
+
+    def dummy_sampler_run(self, sampler: Any, hidden_states: torch.Tensor) -> bool:
+        """Run a model-specific sampler profiling pass.
+
+        Return ``True`` to skip the default dummy sampler run.
+        """
+        return False
+
     num_new_sampled_tokens_per_step: int = 1
     """New tokens sampled on each decode step 
     (excluding accepted draft tokens, a.k.a num bonus tokens)."""


### PR DESCRIPTION
## Purpose

- Fixes #50699: full-batch logits grow with concurrency and OOM the first decode batch
- Project logits per tile in the sampler; reserve the transient during profiling via a `profile_run` hook
- Not a duplicate: #46155 is an opt-in env-var sampler; this fixes the default path

## Test Plan

- `pytest tests/v1/worker/test_gpu_diffusion_sampler.py -v` (RTX 5090)
- `gpu-memory-utilization` A/B sweep, RTX 5090 32GB, NVFP4 26B, 8 concurrent requests x 512 tokens
- GSM8K 200 questions 5-shot, before vs after

## Test Result

- 4 passed, 0 failed

| util | before | after |
|---|---|---|
| 0.70-0.80 | serves | serves |
| 0.85 | engine dies on first batch (`Tried to allocate 2.00 GiB`, the #50699 failure) | serves |
| 0.90 | startup OOM | serves |
| 0.92 | startup OOM | startup OOM (prompt-logprobs path, follow-up) |

- Max stable KV cache: 508k -> 689k tokens (+36%); reserve costs ~55k tokens at low utils
- GSM8K: 92.0% -> 92.5% (noise), 5.67 -> 5.58 q/s; tiling no longer bit-identical, hence the eval

---

AI assistance was used for this change (Claude); every line was reviewed by the submitter.
