### PR TITLE
[Perf][Qwen3.5] Avoid GDN decode gate copies

### DIFF
--- a/tests/kernels/test_fused_recurrent_packed_decode.py
+++ b/tests/kernels/test_fused_recurrent_packed_decode.py
@@ -13,8 +13,9 @@ from vllm.third_party.flash_linear_attention.ops import (
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="Need CUDA device")
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32])
 @pytest.mark.parametrize("strided_mixed_qkv", [False, True])
+@pytest.mark.parametrize("strided_gates", [False, True])
 def test_fused_recurrent_packed_decode_matches_reference(
-    dtype: torch.dtype, strided_mixed_qkv: bool
+    dtype: torch.dtype, strided_mixed_qkv: bool, strided_gates: bool
 ):
     torch.manual_seed(0)
 
@@ -36,8 +37,14 @@ def test_fused_recurrent_packed_decode_matches_reference(
     else:
         mixed_qkv = torch.randn((B, qkv_dim), device=device, dtype=dtype)
 
-    a = torch.randn((B, HV), device=device, dtype=dtype)
-    b = torch.randn((B, HV), device=device, dtype=dtype)
+    if strided_gates:
+        gates = torch.randn((B, 4 * HV), device=device, dtype=dtype)
+        b_global, a_global = gates.chunk(2, dim=-1)
+        b = b_global[:, :HV]
+        a = a_global[:, :HV]
+    else:
+        a = torch.randn((B, HV), device=device, dtype=dtype)
+        b = torch.randn((B, HV), device=device, dtype=dtype)
     A_log = torch.randn((HV,), device=device, dtype=dtype)
     dt_bias = torch.randn((HV,), device=device, dtype=dtype)
 

--- a/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
@@ -862,8 +862,6 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
             mixed_qkv, z = mixed_qkvz.split([qkv_size, z_size], dim=-1)
             z = z.reshape(z.size(0), -1, self.head_v_dim)
             b, a = self.split_ba(ba)
-            b = b.contiguous()
-            a = a.contiguous()
 
         # ============================================================
         # Part 2: Core Attention (Custom Op)
@@ -1219,6 +1217,11 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
                 core_attn_out=core_attn_out,
                 attn_metadata=attn_metadata,
             )
+
+        # Other recurrent paths require contiguous gates. Materialize them
+        # here so packed decode can consume Qwen3.5's projection views directly.
+        b = b.contiguous()
+        a = a.contiguous()
 
         has_initial_state = attn_metadata.has_initial_state
         spec_query_start_loc = attn_metadata.spec_query_start_loc


### PR DESCRIPTION
## Purpose

Qwen3.5 projects the GDN beta/alpha gates into one packed `[b, a]` buffer. Splitting that buffer produces valid row-strided views, but `forward_cuda` materializes both views with `.contiguous()` before entering the GDN custom op. This emits two copy kernels per GDN layer for multi-request standard decode.

This change keeps the gate projections as views through the existing packed non-spec decode path. The packed recurrent CUDA/Triton kernel already consumes tensor strides, so no new kernel is needed. Prefill, speculative decode, and fallback paths still materialize contiguous gates inside `_forward_core`, preserving their existing contracts.

The kernel test now covers independently strided QKV and gate inputs, including gate rows whose storage stride is larger than the logical packed `[b, a]` width (the replicated-BA/TP slicing shape).

### Why this is not duplicate work

I searched open vLLM PRs for `Qwen3.5 GDN decode projection`, `GDN gate contiguous decode`, `GDN strided gates`, and `GDN projection unpack Conv1D`.

- #42746 fuses the input projection GEMMs; this change removes downstream gate materialization and is composable with it.
- #51674 fuses the post-conv MTP/speculative decode path; this change targets ordinary packed non-spec decode before Conv1D.
- #50226 optimizes causal-conv prefill, not decode projection views.
- #45717 covers input-projection GEMM fusion and prefill scan-output copy elision, not these decode gate copies.

The optimization goal was inspired by [SGLang #32919](https://github.com/sgl-project/sglang/pull/32919). I also prototyped its fused projection-unpack + Conv1D approach, but on current vLLM it duplicated work already handled efficiently by the existing Conv1D and packed recurrent kernels and was 6-8% slower. This PR therefore uses the smaller vLLM-native copy-elision approach.

## Test Plan

Run the packed recurrent decode correctness matrix on CUDA:

```bash
PYTHONPATH=/vllm-workspace/vllm-v0271-pr \
  /vllm-workspace/.venv/bin/python -m pytest \
  /vllm-workspace/vllm-v0271-pr/tests/kernels/test_fused_recurrent_packed_decode.py -q
```

Run the applicable changed-file checks:

```bash
.venv/bin/pre-commit run ruff-check --files \
  vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py \
  tests/kernels/test_fused_recurrent_packed_decode.py

.venv/bin/pre-commit run ruff-format --files \
  vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py \
  tests/kernels/test_fused_recurrent_packed_decode.py

.venv/bin/pre-commit run typos --files \
  vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py \
  tests/kernels/test_fused_recurrent_packed_decode.py

.venv/bin/pre-commit run mypy-3.12 --hook-stage manual --files \
  vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py \
  tests/kernels/test_fused_recurrent_packed_decode.py
```

## Test Result

### CUDA environment

- NVIDIA RTX PRO 6000 Blackwell Server Edition (SM120)
- PyTorch 2.13.0+cu130; CUDA 13.0
- Triton 3.7.1
- vLLM v0.27.1 container image
- BF16 benchmark shape matching Qwen3.5 TP=4 local dimensions: H=4, HV=8, K=V=128, QKV width=2048, Conv1D width=4

The PR targets `main`. For a fair validation against the requested environment, I applied only this PR's two-file diff to a `releases/v0.27.1` worktree and reused the v0.27.1 binary extensions from the container.

### Focused CUDA correctness

```text
12 passed, 14 warnings in 3.58s
```

The 12 cases cover FP16/BF16/FP32 and the cross product of contiguous/row-strided QKV and contiguous/arbitrary-row-strided gates. Outputs and recurrent-state updates are compared against the unpacked reference.

### Full-model v0.27.1 A/B

Validated `Qwen3.5-35B-A3B-FP8` with the stock v0.27.1 package versus the same v0.27.1 source plus this PR's exact diff. Both servers loaded successfully, completed `torch.compile` and CUDA graph capture, and served the same fixed request:

- tensor parallel size: 1 (the container's `/dev/shm` is 64 MiB, so TP=4 cannot initialize its NCCL shared-memory transport)
- prompts: `The capital of France is`, `2 + 2 equals`
- `max_tokens=32`, `temperature=0`, `seed=0`

The generated text was byte-for-byte identical for both prompts; all 64 completion tokens matched.

Warm request latency samples for the same two-prompt batch were:

| Variant | Samples (s) | Median (s) |
|---|---|---:|
| Stock v0.27.1 | 0.290951, 0.366429, 0.366041, 0.362382, 0.361293 | 0.362382 |
| v0.27.1 + this PR | 0.379611, 0.358161, 0.361898, 0.361542, 0.282469 | 0.361542 |

The approximately 0.2% median difference is within run-to-run noise; this A/B is a no-regression check, not an end-to-end speedup claim.

### Decode-chain microbenchmark

Using CUDA-event timing over 30 warmup and 200 measured iterations for the full Conv1D + packed recurrent boundary:

| Decode batch | Pre-change gate copies | PR gate views | Speedup |
|---:|---:|---:|---:|
| 1 | 0.0690 ms | 0.0667 ms | 1.04x |
| 2 | 0.0846 ms | 0.0674 ms | 1.26x |
| 8 | 0.0851 ms | 0.0671 ms | 1.27x |

The pre-change column materializes both gate views on every decode step; the PR column passes the row-strided views directly to the packed kernel.

### Static checks

```text
ruff check    Passed
ruff format   Passed
typos         Passed
mypy-3.12     Passed
git diff      --check Passed
```

The complete changed-file pre-commit invocation was also attempted, but its first-time Node environment bootstrap for markdownlint stalled. All applicable Python hooks are listed above and passed.

## AI assistance

OpenAI Codex was used for implementation support, duplicate-work research, test automation, and benchmark analysis. The human submitter must review every changed line, understand and defend the change end-to-end, and rerun the relevant checks before merge.
