### PR TITLE
[Build] DeepGEMM pin has no SM120 kernels: family-12 Blackwell cannot run hyperconnections

### DIFF
--- a/cmake/external_projects/deepgemm.cmake
+++ b/cmake/external_projects/deepgemm.cmake
@@ -28,9 +28,13 @@ if(DEEPGEMM_SRC_DIR)
   message(STATUS "DeepGEMM using local DEEPGEMM_SRC_DIR: ${deepgemm_SOURCE_DIR}")
 else()
   # Keep in sync with tools/install_deepgemm.sh
-  set(_DEEPGEMM_UPSTREAM_REPO "https://github.com/vllm-project/DeepGEMM.git")
+  # DeepSeek upstream, which ships sm120_tf32_hc_prenorm_gemm. The
+  # vllm-project fork provides only the SM90 and SM100 implementations, so
+  # family-12 Blackwell (SM120/SM121) hits DG_HOST_UNREACHABLE in
+  # csrc/apis/hyperconnection.hpp whenever a model uses hyperconnections.
+  set(_DEEPGEMM_UPSTREAM_REPO "https://github.com/deepseek-ai/DeepGEMM.git")
   # TODO: switch to nv_dev branch after it support situ
-  set(_DEEPGEMM_UPSTREAM_TAG "e21c821f39a2056d68067a466c64ddc942200106")
+  set(_DEEPGEMM_UPSTREAM_TAG "a6b593d2826719dcf4892609af7b84ee23aaf32a")
 
   set(_deepgemm_fc_root "${FETCHCONTENT_BASE_DIR}")
   if(NOT _deepgemm_fc_root)

--- a/tools/install_deepgemm.sh
+++ b/tools/install_deepgemm.sh
@@ -6,9 +6,10 @@ set -e
 
 # Default values
 # Keep DEEPGEMM_GIT_REF in sync with cmake/external_projects/deepgemm.cmake
-DEEPGEMM_GIT_REPO="https://github.com/vllm-project/DeepGEMM.git"
-# NOTE: This is currently targeting nv-dev branch due to sm120 support
-DEEPGEMM_GIT_REF="e21c821f39a2056d68067a466c64ddc942200106"
+DEEPGEMM_GIT_REPO="https://github.com/deepseek-ai/DeepGEMM.git"
+# NOTE: DeepSeek upstream, which carries the SM120 kernels (including
+# sm120_tf32_hc_prenorm_gemm) that family-12 Blackwell needs.
+DEEPGEMM_GIT_REF="a6b593d2826719dcf4892609af7b84ee23aaf32a"
 WHEEL_DIR=""
 
 # Parse command line arguments


### PR DESCRIPTION
## The problem

DeepGEMM dispatches the TF32 hyperconnection pre-norm GEMM on the device arch major, in
`csrc/apis/hyperconnection.hpp`. At the revision this repository pins,
`vllm-project/DeepGEMM` `e21c821`, that dispatch handles `arch_major` 9 and 10 only:

```cpp
const auto arch_major = device_runtime->get_arch_major();
if (arch_major == 9) {
    sm90_tf32_hc_prenorm_gemm(...);
} else if (arch_major == 10) {
    sm100_tf32_hc_prenorm_gemm(...);
} else {
    DG_HOST_UNREACHABLE("Unsupported architecture");
}
```

That revision ships no `sm120_*` implementation at all. `csrc/jit_kernels/impls/`
contains `sm90_*` and `sm100_*` only. `tools/install_deepgemm.sh` currently comments
that the pin targets nv-dev "due to sm120 support", but the pinned tree does not carry
it.

So every SM120/SM121 device aborts as soon as a model exercises hyperconnections.
DeepSeek-V4 Flash is one: it is configured with `hc_mult=4`, so the path is hit on the
first forward pass.

## The change

Points both pins at `deepseek-ai/DeepGEMM` `a6b593d`, which carries `sm120_bf16_gemm`,
`sm120_bmk_bnk_mn`, `sm120_fp8_fp4_gemm_1d1d` and `sm120_tf32_hc_prenorm_gemm`, and
whose dispatch has the `arch_major == 12` branch.

`cmake/external_projects/deepgemm.cmake` and `tools/install_deepgemm.sh` both document
that they must stay in sync, so both are updated. To be explicit: only the cmake path
is exercised by my build; the `install_deepgemm.sh` edit is the same two values kept
in sync, but I have not run that script.

## Testing

With this change, DeepSeek-V4-Flash-0731 builds and serves on 2× NVIDIA GB10 (SM121,
aarch64, CUDA 13.2, torch 2.13.0+cu132) with `--tensor-parallel-size 2` across two
nodes. That is the configuration currently running here, and the fetched tree does
contain the four `sm120_*` kernels.

The failure itself does not really need a reproduction, since it is visible in the
pinned tree: `csrc/apis/hyperconnection.hpp` at `e21c821` has no `arch_major == 12`
branch, and `csrc/jit_kernels/impls/sm120_tf32_hc_prenorm_gemm.hpp` does not exist at
that revision. For the record, we did hit `DG_HOST_UNREACHABLE("Unsupported
architecture")` on the old pin before switching, but I no longer have that log and am
not claiming a fresh reproduction. Note it is a runtime abort rather than a build
error: DeepGEMM JIT-compiles its kernels, so the build succeeds and the process dies
on the first forward pass reaching the dispatch.

Recipe, scripts and raw measurements from that setup:
https://github.com/Mirrdhyn/dsv4-flash-dgx-spark

## Caveat, and a question for maintainers

This is the minimal change that demonstrably fixes SM12x, but it may not be the change
you want.

The two hyperconnection kernels shared by both trees are byte-identical
(`sm90_tf32_hc_prenorm_gemm.hpp` `c17d1b5`, `sm100_tf32_hc_prenorm_gemm.hpp`
`0071e2c`), so the hyperconnection path itself is unaffected on SM90 and SM100. Other
kernels have diverged, however: `sm90_bf16_gemm.hpp` differs between the two revisions,
which suggests the fork carries vLLM-specific work that repointing would drop. I have
no SM90 or SM100 hardware and have not tested those architectures.

If the fork does carry changes worth keeping, the better fix is to port the `sm120_*`
kernels into `vllm-project/DeepGEMM`, or to rebase the fork onto a newer upstream, and
leave the pin where it is. I am happy to redo the patch that way. Either path is fine
by me; the point of this PR is that SM12x is currently broken and the fix is small.
