### PR TITLE
[Misc] Point the unquantized-MoE backend error at the speculative-config fix

### DIFF
--- a/vllm/model_executor/layers/fused_moe/oracle/unquantized.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/unquantized.py
@@ -174,7 +174,10 @@ def map_unquantized_backend(runner_backend: MoEBackend) -> UnquantizedMoeBackend
         return backend
     raise ValueError(
         f"moe_backend='{runner_backend}' is not supported for unquantized MoE. "
-        f"Expected one of {list(mapping.keys())}."
+        f"Expected one of {list(mapping.keys())}. "
+        f"If '{runner_backend}' is meant for a quantized model and this is an "
+        f"unquantized draft model, set `moe_backend` inside "
+        f"`--speculative-config` instead, which applies to the drafter only."
     )
 
 


### PR DESCRIPTION
## Problem

Serving a quantized MoE target with a speculative draft model whose MoE layers are unquantized applies the target's `--moe-backend` to the drafter too, which fails:

```
ValueError: moe_backend='flashinfer_b12x' is not supported for unquantized MoE.
            Expected one of ['triton', 'flashinfer_trtllm', 'flashinfer_cutlass', 'aiter'].
```

The message is accurate but incomplete: it reads as *this combination is unsupported*, when in fact vLLM already supports it — `SpeculativeConfig.moe_backend` (`vllm/config/speculative.py`) sets the drafter's backend independently, and its own docstring names this exact case ("quantized generator with unquantized drafter").

I spent a while concluding the configuration was impossible before finding that field. One sentence in the error would have prevented it.

## Change

```
moe_backend='flashinfer_b12x' is not supported for unquantized MoE.
Expected one of ['triton', 'flashinfer_trtllm', 'flashinfer_cutlass', 'aiter'].
If 'flashinfer_b12x' is meant for a quantized model and this is an unquantized
draft model, set `moe_backend` inside `--speculative-config` instead, which
applies to the drafter only.
```

Message-only; no behaviour change.

Encountered on vLLM 0.25.1, NVIDIA GB10 (SM121), verified the code path and the `SpeculativeConfig.moe_backend` field are unchanged on current main.

---

*Disclosure: prepared with assistance from Claude (Anthropic).*