### PR TITLE
[Bugfix][Model] Reuse CUDA segments when loading Inkling expert weights

### DIFF
--- a/tests/models/inkling/test_moe_weight_layout.py
+++ b/tests/models/inkling/test_moe_weight_layout.py
@@ -1,6 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import os
+import subprocess
+import sys
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -211,6 +215,67 @@ def test_moe_loads_channelwise_scale_for_tp(
         expected = expected[:, 4:].reshape(2, 2, 2, 1).transpose(1, 2).flatten(1, 2)
     torch.testing.assert_close(param, expected.float())
     assert loaded == [f"experts.routed_experts.{projection}_weight_scale"]
+
+
+def _assert_moe_w13_upload_reuses_cuda_allocator_segments() -> None:
+    torch.empty(1, device="cuda")
+
+    num_experts = 16
+    half = 256
+    hidden = 4096
+    param = torch.nn.Parameter(
+        torch.empty(
+            num_experts,
+            2 * half,
+            hidden,
+            dtype=torch.bfloat16,
+            device="cuda",
+        ),
+        requires_grad=False,
+    )
+    experts = SimpleNamespace(
+        w13_weight=param,
+        moe_config=SimpleNamespace(moe_parallel_config=SimpleNamespace(tp_rank=0)),
+    )
+    layer = SimpleNamespace(
+        experts=SimpleNamespace(routed_experts=experts),
+        _local_expert_slots=lambda: dict(enumerate(range(num_experts))),
+    )
+    checkpoint = (
+        torch.arange(
+            num_experts * 2 * half * hidden,
+            dtype=torch.int32,
+        )
+        .reshape(num_experts, 2 * half, hidden)
+        .to(torch.bfloat16)
+    )
+    reserved_before = torch.accelerator.memory_reserved()
+
+    moe.InklingMoE.load_expert_weight(
+        layer,
+        "experts.w13_weight",
+        checkpoint,
+    )
+    torch.accelerator.synchronize()
+
+    scratch_reserved = torch.accelerator.memory_reserved() - reserved_before
+    assert scratch_reserved <= 40 * 1024**2, (
+        f"expert uploads reserved {scratch_reserved} bytes of scratch CUDA memory"
+    )
+
+
+@pytest.mark.skipif(not current_platform.is_cuda(), reason="requires CUDA")
+def test_moe_w13_upload_reuses_cuda_allocator_segments() -> None:
+    env = os.environ.copy()
+    env["PYTORCH_CUDA_ALLOC_CONF"] = "max_split_size_mb:20"
+    repo_root = str(Path(__file__).parents[3])
+    env["PYTHONPATH"] = repo_root + os.pathsep + env.get("PYTHONPATH", "")
+    child_code = (
+        "from tests.models.inkling import test_moe_weight_layout as test_module\n"
+        "test_module._assert_moe_w13_upload_reuses_cuda_allocator_segments()\n"
+    )
+
+    subprocess.run([sys.executable, "-c", child_code], check=True, env=env)
 
 
 def test_sink_down_projection_is_packed_during_load(monkeypatch) -> None:

--- a/vllm/models/inkling/nvidia/moe.py
+++ b/vllm/models/inkling/nvidia/moe.py
@@ -605,8 +605,9 @@ class InklingMoE(nn.Module):
             # and OOMs the host) and de-interleave on device.
             half = param.shape[1] // 2
             for gid, lid in slots.items():
-                slab = weight[gid].narrow(0, tp_rank * 2 * half, 2 * half)
-                slab = slab.to(param.device)
+                slab = (
+                    weight[gid].narrow(0, tp_rank * 2 * half, 2 * half).to(param.device)
+                )
                 param.data[lid, :half].copy_(slab[0::2])
                 param.data[lid, half:].copy_(slab[1::2])
         else:


### PR DESCRIPTION
## Purpose

Fixes #51205.

The NVIDIA Inkling w13 loader dropped the previous CUDA scratch tensor before
allocating the next one. While `GPUWorker.load_model()` applies
`max_split_size_mb=20`, this leaves fully free 20 MiB allocator segments that
cannot satisfy the next smaller upload. CUDA reserved memory therefore grows
while allocated memory remains flat, which can exhaust lower-memory GPUs or
livelock the loader in allocator retries.

This change chains the CPU `narrow()` view and `.to(param.device)` operation so
the previous CUDA tensor remains alive until the next allocation completes.
The tensor layout and destination copies are unchanged.

Thanks to @brocktice for documenting the allocator interaction and suggested
fix in [this issue comment](https://github.com/vllm-project/vllm/issues/51205#issuecomment-5216204535).

Duplicate check: on 2026-08-12, no open PR referenced `#51205`, and no open PR
matched the Inkling loader / max-split allocator keywords.

AI assistance disclosure: OpenAI Codex assisted with root-cause validation,
test implementation, H200 A/B execution, and PR drafting. The human submitter
reviewed every changed line and the attached evidence before submission.

## Test Plan

```bash
CUDA_VISIBLE_DEVICES=7 .venv/bin/python -m pytest \
  tests/models/inkling/test_moe_weight_layout.py::test_moe_w13_upload_reuses_cuda_allocator_segments \
  -v -s

CUDA_VISIBLE_DEVICES=7 .venv/bin/python -m pytest \
  tests/models/inkling/test_moe_weight_layout.py -v

.venv/bin/pre-commit run --files \
  vllm/models/inkling/nvidia/moe.py \
  tests/models/inkling/test_moe_weight_layout.py
```

Full-model validation used `thinkingmachines/Inkling-Small-NVFP4` revision
`b6a99534467840620d411e4cd4ad5819b2610d9c` on 2x H200 with TP2, a 200k maximum
model length, chunked prefill, prefix caching, and the Inkling parsers. The
controlled allocator A/B removed the `expandable_segments` override so vLLM's
20 MiB load scope governed allocations, and used `--enforce-eager` to avoid an
independent upstream Inkling CUDA Graph assertion.

## Test Result

- Regression test on the upstream loader: expected failure with
  `335544320` bytes of scratch CUDA memory reserved; `1 failed` in 10.11s.
- Regression test with this patch: `1 passed, 14 warnings in 9.43s`.
- Nearby Inkling suite on the final rebased branch:
  `34 passed, 14 warnings in 17.04s`.
- All applicable pre-commit hooks passed.

At the final instrumented w13 upload on each TP rank:

| Measurement | Upstream loader | Patched loader |
| --- | ---: | ---: |
| Allocated memory | 78.3110 GiB | 78.3110 GiB |
| Reserved memory | 137.2695 GiB | 80.5078 GiB |
| Reserved minus allocated | 58.9586 GiB | 2.1968 GiB |
| Loaded checkpoint shards | 10/10 | 10/10 |
| API ready | Yes | Yes |
| Eager 8-token generation | Passed | Passed |

The patch reduced reserved-minus-allocated overhead by 56.7617 GiB per rank,
or 96.27%. This is a memory validation, not a load-time performance claim; the
sequential runs shared filesystem and kernel caches.

With the issue's original `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True`,
PyTorch 2.13.0+cu132 kept reserved memory flat and loaded all shards, so that
environment masks the allocator interaction on this machine. Its generation
request then hit a separate upstream CUDA Graph input-address assertion. The
controlled eager A/B above isolates the loader behavior.

The complete CUDA test requirements install was attempted, but the unrelated
optional `arctic-inference==0.1.1` C++ build failed because `<span>` was not
available. The directly required test dependency was installed, and the target
suite collected and passed as reported above.

---

- [x] The purpose and linked issue are documented.
- [x] Test commands are provided.
- [x] RED/GREEN and full-model results are provided.
- [x] No documentation update is needed for this loader bug fix.
