### PR TITLE
[BugFix] Clamp indexer scheduler-metadata seq_lens to avoid OOB read in DeepGEMM paged-MQA metadata kernel

### DIFF
--- a/vllm/v1/attention/backends/mla/indexer.py
+++ b/vllm/v1/attention/backends/mla/indexer.py
@@ -948,8 +948,18 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
 
             # DeepGEMM is required for the paged MQA logits on CUDA devices
             if current_platform.is_cuda() and has_deep_gemm():
+                # DeepGEMM sm90_paged_mqa_logits_metadata reads one element
+                # past its shared-memory prefix-sum buffer when every context
+                # length is zero and batch_size is a multiple of 32 (the
+                # per-SM binary search runs to q_idx == batch_size). All-zero
+                # lens occur whenever compress_ratio > 1 divides a dummy or
+                # padded decode batch seq_len of 1 down to 0 — e.g. every
+                # FULL-cudagraph capture warmup. Clamping only the scheduler
+                # input is safe: the schedule is a work-distribution hint and
+                # the logits kernel re-derives per-token work from the true
+                # context_lens.
                 self.scheduler_metadata_buffer[:] = get_paged_mqa_logits_metadata(
-                    seq_lens,
+                    torch.clamp(seq_lens, min=1),
                     self.kv_cache_spec.storage_block_size,
                     self.num_sms,
                 )


### PR DESCRIPTION
## Purpose

FIX #51970

DeepSeek-V4-Flash crashes at engine start with a CUDA illegal memory access during FULL cudagraph capture. The indexer metadata builder divides dummy-batch sequence lengths (1) by `compress_ratio` (4 for V4-Flash), producing all-zero lengths, and DeepGEMM's SM90 paged-MQA metadata scheduler reads one element past its shared-memory prefix-sum buffer when every length is zero and `batch_size` is a multiple of 32 — which capture sizes always are. Models with `compress_ratio = 1` never produce all-zero lengths, so only V4-Flash is affected.

This PR clamps only the scheduler-metadata input to a minimum of 1. The schedule is a work-distribution hint; the logits kernel re-derives per-token work from the true `context_lens`, so the clamp is semantics-preserving. A kernel-side bounds guard in DeepGEMM is the more fundamental fix, but the clamp also protects every released wheel, since wheels vendor DeepGEMM's JIT sources at build time.

## Test Plan

- Standalone kernel boundary probe (script in the linked issue): call `get_paged_mqa_logits_metadata` with zero-filled and nonzero-filled length tensors across batch sizes 8/32/33/64/250/256 on SM90.
- End-to-end: serve `deepseek-ai/DeepSeek-V4-Flash` on 4x GH200 (`--data-parallel-size 4 --enable-expert-parallel --kv-cache-dtype fp8 --max-model-len 128000`, default compilation config), then `vllm bench serve` (random, ISL 1024 / OSL 1, concurrency 16, 64 prompts) followed by a 10-minute idle health watch — the OSL=1 + idle sequence is the historical trigger for the dummy-batch path.

## Test Result

- Kernel probe before the fix: zero-filled lengths fault (illegal memory access) at batch sizes 32, 64, and 256; pass at 8, 33, and 250; nonzero fills pass at every batch size. This matches the shared-memory boundary (`align(batch_size, 32)` ints).
- Before: serving DeepSeek-V4-Flash with the default compilation config dies at "Capturing CUDA graphs (decode, FULL): 0/83", 2/2 attempts (failing worker varies).
- After: all 83 FULL decode graphs capture, startup completes, the OSL=1 benchmark finishes 64/64, and the 10-minute idle watch shows /health 200 throughout with zero engine errors.
