### PR TITLE
[CI][ROCm][Disagg] Fix Kimi K2.5/K2.6 MXFP4 MLA backends on ROCm nightly for accuracy eval (disable aiter OPUS FMHA)

### DIFF
--- a/.buildkite/amd-disagg/models.yaml
+++ b/.buildkite/amd-disagg/models.yaml
@@ -86,13 +86,13 @@ models:
   - model: Kimi-K2.6-MXFP4
     env:
       VLLM_ROCM_USE_AITER: "1"
-      VLLM_ROCM_USE_AITER_MLA: "1"
       AMDGCN_USE_BUFFER_OPS: "1"
+      VLLM_ROCM_USE_AITER_MLA: "1"
       VLLM_ROCM_QUICK_REDUCE_QUANTIZATION: "INT4"
       VLLM_ROCM_USE_SKINNY_GEMM: "0"
       VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS: "1"
       AITER_DISABLE_FMHA_OPUS: "1"
-    base_flags: "--trust-remote-code --kv-cache-dtype fp8 --mm-encoder-tp-mode data --block-size 16"
+    base_flags: "--trust-remote-code --kv-cache-dtype fp8 --mm-encoder-tp-mode data --block-size 16 --attention-backend ROCM_AITER_MLA"
     prefill:
       tp: "--gpu-memory-utilization 0.9"
     decode:

--- a/.buildkite/amd-disagg/models.yaml
+++ b/.buildkite/amd-disagg/models.yaml
@@ -76,7 +76,8 @@ models:
       VLLM_ROCM_USE_AITER: "1"
       VLLM_ROCM_USE_AITER_MOE: "1"
       VLLM_ROCM_USE_AITER_RMSNORM: "1"
-    base_flags: "--trust-remote-code"
+      AITER_DISABLE_FMHA_OPUS: "1"
+    base_flags: "--trust-remote-code --attention-backend TRITON_MLA"
     prefill:
       tp: "--gpu-memory-utilization 0.85"
     decode:
@@ -86,11 +87,11 @@ models:
     env:
       VLLM_ROCM_USE_AITER: "1"
       AMDGCN_USE_BUFFER_OPS: "1"
-      VLLM_ROCM_USE_AITER_MLA: "1"
       VLLM_ROCM_QUICK_REDUCE_QUANTIZATION: "INT4"
       VLLM_ROCM_USE_SKINNY_GEMM: "0"
       VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS: "1"
-    base_flags: "--trust-remote-code --kv-cache-dtype fp8 --mm-encoder-tp-mode data --block-size 1 --attention-backend ROCM_AITER_MLA"
+      AITER_DISABLE_FMHA_OPUS: "1"
+    base_flags: "--trust-remote-code --kv-cache-dtype fp8 --mm-encoder-tp-mode data --block-size 16 --attention-backend TRITON_MLA"
     prefill:
       tp: "--gpu-memory-utilization 0.9"
     decode:

--- a/.buildkite/amd-disagg/models.yaml
+++ b/.buildkite/amd-disagg/models.yaml
@@ -92,7 +92,7 @@ models:
       VLLM_ROCM_USE_SKINNY_GEMM: "0"
       VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS: "1"
       AITER_DISABLE_FMHA_OPUS: "1"
-    base_flags: "--trust-remote-code --kv-cache-dtype fp8 --mm-encoder-tp-mode data --block-size 16 --attention-backend ROCM_AITER_MLA"
+    base_flags: "--trust-remote-code --kv-cache-dtype fp8 --mm-encoder-tp-mode data --block-size 16"
     prefill:
       tp: "--gpu-memory-utilization 0.9"
     decode:

--- a/.buildkite/amd-disagg/models.yaml
+++ b/.buildkite/amd-disagg/models.yaml
@@ -77,7 +77,7 @@ models:
       VLLM_ROCM_USE_AITER_MOE: "1"
       VLLM_ROCM_USE_AITER_RMSNORM: "1"
       AITER_DISABLE_FMHA_OPUS: "1"
-    base_flags: "--trust-remote-code --attention-backend TRITON_MLA"
+    base_flags: "--trust-remote-code"
     prefill:
       tp: "--gpu-memory-utilization 0.85"
     decode:
@@ -86,12 +86,13 @@ models:
   - model: Kimi-K2.6-MXFP4
     env:
       VLLM_ROCM_USE_AITER: "1"
+      VLLM_ROCM_USE_AITER_MLA: "1"
       AMDGCN_USE_BUFFER_OPS: "1"
       VLLM_ROCM_QUICK_REDUCE_QUANTIZATION: "INT4"
       VLLM_ROCM_USE_SKINNY_GEMM: "0"
       VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS: "1"
       AITER_DISABLE_FMHA_OPUS: "1"
-    base_flags: "--trust-remote-code --kv-cache-dtype fp8 --mm-encoder-tp-mode data --block-size 16 --attention-backend TRITON_MLA"
+    base_flags: "--trust-remote-code --kv-cache-dtype fp8 --mm-encoder-tp-mode data --block-size 16"
     prefill:
       tp: "--gpu-memory-utilization 0.9"
     decode:


### PR DESCRIPTION
## Purpose

Kimi K2.5/K2.6 MXFP4 disaggregated GSM8K on `vllm/vllm-openai-rocm:nightly` failed at MLA **prefill** with HTTP 500 and `fmha_fwd_bf16_opus_fwd` TypeError. MLA prefill uses `ROCM_AITER_FA`, which on nightly (aiter 0.1.19) picks the broken **OPUS FMHA** kernel.

Setting `AITER_DISABLE_FMHA_OPUS=1` makes aiter fall back to `fmha_v3` / CK. Default AITER MLA is already on (`VLLM_ROCM_USE_AITER_MLA` defaults to true). K2.6 also needs `--block-size 16`; with `--block-size 1` health failed with `mla_gluon[bh16bn128] requires batch_size=1, got 512`.

## Changes

- **Kimi-K2.5-MXFP4** — add `AITER_DISABLE_FMHA_OPUS: "1"` to `env`.
- **Kimi-K2.6-MXFP4** — add `AITER_DISABLE_FMHA_OPUS: "1"`; use `--block-size 16`.

## Test Plan

MoRIIO **1P1D TP8** disaggregated serving, `ROUTER_TYPE=proxy`, `RUN_AFTER_HEALTH=accuracy`, image `vllm/vllm-openai-rocm:nightly`.

### Kimi-K2.5-MXFP4 — TP8 1P1D

```bash
# PREFILL — TP8
vllm serve /data/models2/Kimi-K2.5-MXFP4 \
    --host $PREFILL_IP --port 8100 --tensor-parallel-size 8 \
    --trust-remote-code \
    --attention-backend TRITON_MLA \
    --gpu-memory-utilization 0.85 \
    --kv-transfer-config '{"kv_connector":"MoRIIOConnector","kv_role":"kv_producer",
      "kv_connector_extra_config":{"proxy_ip":"$PREFILL_IP","proxy_ping_port":"36367",
      "http_port":"8100","handshake_port":"6301","notify_port":"61005"}}'

# DECODE — TP8
vllm serve /data/models2/Kimi-K2.5-MXFP4 \
    --host $DECODE_IP --port 8200 --tensor-parallel-size 8 \
    --trust-remote-code \
    --attention-backend TRITON_MLA \
    --gpu-memory-utilization 0.85 \
    --kv-transfer-config '{"kv_connector":"MoRIIOConnector","kv_role":"kv_consumer",
      "kv_connector_extra_config":{"proxy_ip":"$PREFILL_IP","proxy_ping_port":"36367",
      "http_port":"8200","handshake_port":"7301","notify_port":"62005"}}'
```

Set `AITER_DISABLE_FMHA_OPUS=1` in the prefill/decode environment before launch.

### Kimi-K2.6-MXFP4 — TP8 1P1D

```bash
# PREFILL — TP8
vllm serve /data/models2/Kimi-K2.6-MXFP4 \
    --host $PREFILL_IP --port 8100 --tensor-parallel-size 8 \
    --trust-remote-code --kv-cache-dtype fp8 --mm-encoder-tp-mode data --block-size 16 \
    --attention-backend TRITON_MLA \
    --gpu-memory-utilization 0.9 \
    --kv-transfer-config '{"kv_connector":"MoRIIOConnector","kv_role":"kv_producer",
      "kv_connector_extra_config":{"proxy_ip":"$PREFILL_IP","proxy_ping_port":"36367",
      "http_port":"8100","handshake_port":"6301","notify_port":"61005"}}'

# DECODE — TP8
vllm serve /data/models2/Kimi-K2.6-MXFP4 \
    --host $DECODE_IP --port 8200 --tensor-parallel-size 8 \
    --trust-remote-code --kv-cache-dtype fp8 --mm-encoder-tp-mode data --block-size 16 \
    --attention-backend TRITON_MLA \
    --gpu-memory-utilization 0.9 \
    --kv-transfer-config '{"kv_connector":"MoRIIOConnector","kv_role":"kv_consumer",
      "kv_connector_extra_config":{"proxy_ip":"$PREFILL_IP","proxy_ping_port":"36367",
      "http_port":"8200","handshake_port":"7301","notify_port":"62005"}}'
```

Set `AITER_DISABLE_FMHA_OPUS=1` in the prefill/decode environment before launch.

### GSM8K evaluation

```bash
lm_eval --model local-completions \
    --tasks gsm8k \
    --model_args "model=/data/models2/Kimi-K2.5-MXFP4,base_url=http://127.0.0.1:10001/v1/completions,num_concurrent=16,max_retries=3,tokenized_requests=False,trust_remote_code=True,timeout=7200" \
    --limit 250
```

Use the K2.6 model path the same way.

## Test Result

**Accuracy results (GSM8K, flexible-extract, limit 250)**

Verified on `vllm/vllm-openai-rocm:nightly` (`0.26.1rc1.dev602+g65b7662d3`, aiter 0.1.19, Aug 11 2026).

| Config | Without fix | With fix |
|--------|-------------|----------|
| K2.5 1P1D TP8 (proxy) | Fail: `ROCM_AITER_TRITON_MLA` (init) or `TRITON_MLA` only (aiter OPUS FMHA / eval) | **0.956** |
| K2.6 1P1D TP8 (proxy) | Fail: `ROCM_AITER_MLA` / `ROCM_AITER_TRITON_MLA` (init) or `TRITON_MLA` only (aiter OPUS FMHA / eval) | **0.936** |
