### PR TITLE
[Feature] Add layerwise KV cache transfer support with mooncake session API

### DIFF
--- a/tests/v1/kv_connector/unit/test_mooncake_store_layerwise.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_layerwise.py
@@ -723,6 +723,8 @@ class TestSendingThreadSessionApi:
         called_keys, called_sizes, _ = store.batch_put_session_start.call_args[0]
         assert called_keys == keys
         assert called_sizes == [object_size, object_size]
+        # Successfully-started keys seed the per-layer range-put filter.
+        assert thread._active_put_keys == {"key_a", "key_b"}
 
     def test_start_put_sessions_partial_failure_revokes(self):
         """Failed session starts are revoked."""
@@ -735,6 +737,8 @@ class TestSendingThreadSessionApi:
 
         # Failed key should be revoked
         store.batch_put_session_revoke.assert_called_once_with(["fail_key"])
+        # Only the successful key remains writable.
+        assert thread._active_put_keys == {"ok_key"}
 
     def test_handle_request_dispatches_session_path(self):
         """use_key_major_ranges=True dispatches to session handler."""

--- a/tests/v1/kv_connector/unit/test_mooncake_store_layerwise.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_layerwise.py
@@ -1,0 +1,1056 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for MooncakeStoreConnector layerwise KV cache support."""
+
+from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store import (
+    worker as mooncake_store_worker,
+)
+
+# ============================================================================
+# Mock helpers for _build_layer_tasks and sync tests
+# ============================================================================
+
+import threading
+from unittest.mock import MagicMock
+
+from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.data import (
+    ChunkedTokenDatabase,
+    KeyMetadata,
+    LayerTransferTask,
+    ReqMeta,
+    LoadSpec,
+)
+from vllm.v1.core.kv_cache_utils import BlockHash
+from vllm.v1.kv_cache_interface import (
+    FullAttentionSpec,
+    KVCacheGroupSpec,
+)
+
+
+def _make_layerwise_bare_worker(
+    *,
+    num_layers: int = 2,
+    num_groups: int = 1,
+    block_size: int = 16,
+    tp_rank: int = 0,
+    put_step: int = 1,
+) -> "mooncake_store_worker.MooncakeStoreWorker":  # noqa: F821
+    """Construct a minimal MooncakeStoreWorker with layerwise attributes."""
+    from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store import (
+        worker as mooncake_store_worker,
+    )
+
+    worker = object.__new__(mooncake_store_worker.MooncakeStoreWorker)
+    worker._layerwise_enabled = True
+    worker._num_layers = num_layers
+    worker.tp_rank = tp_rank
+    worker._group_tp_replication_factors = tuple([put_step] * num_groups)
+    worker.block_size = block_size
+    worker.num_blocks = 10
+    worker.kv_send_thread = None
+    worker.kv_recv_threads = []
+    worker.store = MagicMock()
+    worker._kv_connector_stats_lock = threading.Lock()
+    worker.kv_connector_stats = MagicMock()
+
+    # Layerwise task / event dictionaries
+    worker._layer_save_tasks = {l: [] for l in range(num_layers)}
+    worker._layer_load_tasks = {l: [] for l in range(num_layers)}
+    worker._layer_save_finished_events = {
+        l: threading.Event() for l in range(num_layers)
+    }
+    worker._layer_load_finished_events = {
+        l: threading.Event() for l in range(num_layers)
+    }
+    worker._current_save_layer = 0
+    worker._current_load_layer = 0
+    worker._next_load_layer_to_submit = 0
+    worker._num_prefetch_layers = 1
+
+    # Create token databases
+    worker.token_dbs = []
+    for g_idx in range(num_groups):
+        md = KeyMetadata("test-model", tp_rank, 0, 0, 0, group_id=g_idx)
+        db = ChunkedTokenDatabase(md, block_size=block_size, hash_block_size=block_size)
+        db.set_kv_caches_base_addr([0x1000 + g_idx * 0x1000])
+        db.set_block_len([256])
+        worker.token_dbs.append(db)
+
+    # Coordinator
+    specs = [
+        FullAttentionSpec(block_size=block_size, num_kv_heads=8, head_size=64, dtype=None)
+        for _ in range(num_groups)
+    ]
+    groups = [KVCacheGroupSpec([f"layer{g}"], spec) for g, spec in enumerate(specs)]
+    worker.coord = mooncake_store_worker.MooncakeStoreCoordinator(
+        groups,
+        scheduler_block_size=block_size,
+        hash_block_size=block_size,
+    )
+    return worker
+
+
+def _make_test_reqmeta(
+    req_id: str = "test_req",
+    token_len: int = 32,
+    block_ids: tuple[list[int], ...] | None = None,
+    can_save: bool = True,
+    can_load: bool = False,
+    block_hashes: list[BlockHash] | None = None,
+    num_prompt_tokens: int = 32,
+) -> ReqMeta:
+    """Create a ReqMeta for testing _build_layer_tasks_from_requests."""
+    if block_hashes is None:
+        block_hashes = [BlockHash(f"h{i:016d}".encode()) for i in range(32)]
+    if block_ids is None:
+        num_blocks = (token_len + 15) // 16
+        block_ids = (list(range(num_blocks)),)
+    load_spec = None
+    if can_load:
+        load_spec = LoadSpec(
+            vllm_cached_tokens=0,
+            kvpool_cached_tokens=token_len,
+            can_load=True,
+            token_len=token_len,
+        )
+    return ReqMeta(
+        req_id=req_id,
+        token_len_chunk=token_len,
+        block_ids=block_ids,
+        block_hashes=block_hashes,
+        can_save=can_save,
+        load_spec=load_spec,
+        num_prompt_tokens=num_prompt_tokens,
+    )
+
+class TestSubmitReadyLayerLoads:
+    """Test _submit_ready_layer_loads round-robin distribution."""
+
+    def test_round_robin_across_recv_threads(self):
+        """Tasks are distributed round-robin, not broadcast to all threads."""
+        worker = _make_layerwise_bare_worker(num_layers=2)
+
+        # Build some load tasks
+        for layer_id in range(2):
+            task = LayerTransferTask(
+                req_id=f"req_{layer_id}",
+                group_id=0,
+                layer_idx_in_group=layer_id,
+                physical_layer_id=layer_id,
+                key_list=[f"key_{layer_id}"],
+                addr_list=[[0x2000]],
+                size_list=[[256]],
+                block_ids=[layer_id],
+                is_save=False,
+            )
+            worker._layer_load_tasks[layer_id].append(task)
+
+        # Create mock recv threads
+        mock_threads = [MagicMock() for _ in range(3)]
+        worker.kv_recv_threads = mock_threads
+        worker._num_prefetch_layers = 2
+
+        worker._submit_ready_layer_loads()
+
+        # Each task should be sent to exactly one thread
+        for mt in mock_threads:
+            assert len(mt.add_request.call_args_list) <= 2, (
+                f"Thread received {len(mt.add_request.call_args_list)} tasks, "
+                f"expected ≤2 (round-robin)"
+            )
+
+        # Total calls across all threads = total tasks = 2
+        total_calls = sum(len(mt.add_request.call_args_list) for mt in mock_threads)
+        assert total_calls == 2, f"Expected 2 total calls, got {total_calls}"
+
+
+class TestLayerwiseStateReset:
+    """Test _reset_layer_state event and state management."""
+
+    def test_reset_creates_new_events(self):
+        """_reset_layer_state replaces Event objects."""
+        worker = _make_layerwise_bare_worker(num_layers=3)
+        old_save_events = {
+            l: worker._layer_save_finished_events[l] for l in range(3)
+        }
+        old_load_events = {
+            l: worker._layer_load_finished_events[l] for l in range(3)
+        }
+
+        worker._reset_layer_state()
+
+        for l in range(3):
+            assert worker._layer_save_finished_events[l] is not old_save_events[l]
+            assert worker._layer_load_finished_events[l] is not old_load_events[l]
+
+    def test_reset_syncs_events_to_threads(self):
+        """Layerwsie: new events are synced to transfer threads after reset."""
+        worker = _make_layerwise_bare_worker(num_layers=2)
+
+        # Create layerwise-enabled mock threads
+        worker.kv_send_thread = MagicMock()
+        worker.kv_send_thread._layerwise_enabled = True
+        worker.kv_recv_threads = [
+            MagicMock(_layerwise_enabled=True),
+            MagicMock(_layerwise_enabled=False),  # one non-layerwise
+        ]
+
+        worker._reset_layer_state()
+
+        # Sending thread: should receive 2 set_layer_finished_event calls (is_save=True)
+        assert worker.kv_send_thread.set_layer_finished_event.call_count == 2
+        for call_args in worker.kv_send_thread.set_layer_finished_event.call_args_list:
+            assert call_args.args[1] is True  # is_save=True
+
+        # Only the layerwise-enabled recv thread should receive calls
+        thread0 = worker.kv_recv_threads[0]
+        assert thread0.set_layer_finished_event.call_count == 2
+        for call_args in thread0.set_layer_finished_event.call_args_list:
+            assert call_args.args[1] is False  # is_save=False
+
+        # Non-layerwise thread should not receive calls
+        thread1 = worker.kv_recv_threads[1]
+        assert thread1.set_layer_finished_event.call_count == 0
+
+
+# ============================================================================
+# Layerwise Save/Load Flow Tests
+# Tests for save_kv_layer, wait_for_layer_load, and _handle_request
+# ============================================================================
+
+import time
+from unittest.mock import MagicMock
+
+
+def _make_layerwise_send_thread(
+    store: MagicMock,
+    *,
+    num_layers: int = 2,
+    block_size: int = 16,
+) -> "mooncake_store_worker.KVCacheStoreSendingThread":
+    """Create a KVCacheStoreSendingThread with layerwise enabled for testing."""
+    from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store import (
+        worker as mooncake_store_worker,
+    )
+    from vllm.v1.kv_cache_interface import FullAttentionSpec, KVCacheGroupSpec
+
+    db = ChunkedTokenDatabase(
+        KeyMetadata("test-model", 0, 0, 0, 0), block_size=block_size
+    )
+    db.set_kv_caches_base_addr([0x1000])
+    db.set_block_len([256])
+    spec = FullAttentionSpec(block_size=block_size, num_kv_heads=8, head_size=64, dtype=None)
+    coord = mooncake_store_worker.MooncakeStoreCoordinator(
+        [KVCacheGroupSpec(["layer0"], spec)],
+        scheduler_block_size=block_size,
+        hash_block_size=block_size,
+    )
+    thread = mooncake_store_worker.KVCacheStoreSendingThread(
+        store=store,
+        coord=coord,
+        token_databases=[db],
+        block_size=block_size,
+        tp_rank=0,
+        group_put_steps=[1],
+        kv_role="kv_producer",
+        ready_event=threading.Event(),
+    )
+    # Enable layerwise mode.
+    thread.enable_layerwise(num_layers)
+    # Replace task_done to prevent blocking.
+    thread.request_queue.task_done = MagicMock()
+    return thread
+
+
+def _make_layerwise_recv_thread(
+    store: MagicMock,
+    *,
+    num_layers: int = 2,
+    block_size: int = 16,
+    token_databases: list | None = None,
+) -> "mooncake_store_worker.KVCacheStoreRecvingThread":
+    """Create a KVCacheStoreRecvingThread with layerwise enabled for testing."""
+    from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store import (
+        worker as mooncake_store_worker,
+    )
+    from vllm.v1.kv_cache_interface import FullAttentionSpec, KVCacheGroupSpec
+
+    if token_databases is None:
+        db = ChunkedTokenDatabase(
+            KeyMetadata("test-model", 0, 0, 0, 0), block_size=block_size
+        )
+        db.set_kv_caches_base_addr([0x1000])
+        db.set_block_len([256])
+        token_databases = [db]
+
+    spec = FullAttentionSpec(block_size=block_size, num_kv_heads=8, head_size=64, dtype=None)
+    coord = mooncake_store_worker.MooncakeStoreCoordinator(
+        [KVCacheGroupSpec(["layer0"], spec)],
+        scheduler_block_size=block_size,
+        hash_block_size=block_size,
+    )
+    thread = mooncake_store_worker.KVCacheStoreRecvingThread(
+        store=store,
+        coord=coord,
+        token_databases=token_databases,
+        block_size=block_size,
+        tp_rank=0,
+        ready_event=threading.Event(),
+        disk_offload_buffer_budget_bytes=None,
+    )
+    # Enable layerwise mode.
+    thread.enable_layerwise(num_layers)
+    thread.request_queue.task_done = MagicMock()
+    return thread
+
+
+class TestSaveKvLayer:
+    """Test save_kv_layer submits tasks and handles last-layer completion."""
+
+    def test_save_kv_layer_submits_tasks_to_send_thread(self):
+        """save_kv_layer must send tasks for the matching layer to kv_send_thread."""
+        worker = _make_layerwise_bare_worker(num_layers=4)
+        worker.kv_send_thread = MagicMock()
+        worker.kv_send_thread._layerwise_enabled = True
+
+        # Pre-populate save tasks for each layer.
+        for layer_id in range(4):
+            task = LayerTransferTask(
+                req_id="test_req",
+                group_id=0,
+                layer_idx_in_group=layer_id,
+                physical_layer_id=layer_id,
+                key_list=[f"layer{layer_id}_key"],
+                addr_list=[[0x2000 + layer_id * 0x1000]],
+                size_list=[[256]],
+                block_ids=[layer_id],
+                is_save=True,
+            )
+            worker._layer_save_tasks[layer_id].append(task)
+
+        # Simulate the per-layer forward calls to save_kv_layer.
+        for layer_id in range(4):
+            worker.save_kv_layer(f"model.layers.{layer_id}.self_attn", None, None)
+
+        # Each layer should have called add_request (4 total).
+        assert worker.kv_send_thread.add_request.call_count == 4
+        # Verify the submitted task layer_ids.
+        for i, call_args in enumerate(worker.kv_send_thread.add_request.call_args_list):
+            task = call_args.args[0]
+            assert isinstance(task, LayerTransferTask)
+            assert task.physical_layer_id == i
+
+    def test_save_kv_layer_last_layer_triggers_reset(self):
+        """Last layer must call _wait_for_all_layer_saves and _reset_layer_state."""
+        worker = _make_layerwise_bare_worker(num_layers=2)
+        worker.kv_send_thread = MagicMock()
+        worker.kv_send_thread._layerwise_enabled = True
+
+        # Pre-populate save tasks.
+        for layer_id in range(2):
+            task = LayerTransferTask(
+                req_id="test_req1", group_id=0,
+                layer_idx_in_group=layer_id, physical_layer_id=layer_id,
+                key_list=["k"], addr_list=[[0x2000]], size_list=[[256]],
+                block_ids=[layer_id], is_save=True,
+            )
+            worker._layer_save_tasks[layer_id].append(task)
+            # Pre-set the save event (simulating transfer-thread completion).
+            worker._layer_save_finished_events[layer_id].set()
+
+        old_save_events = {l: worker._layer_save_finished_events[l] for l in range(2)}
+        old_load_events = {l: worker._layer_load_finished_events[l] for l in range(2)}
+
+        # Save the last layer.
+        worker.save_kv_layer("model.layers.1.self_attn", None, None)
+
+        # The last layer must trigger a reset: events are replaced ...
+        for l in range(2):
+            assert worker._layer_save_finished_events[l] is not old_save_events[l]
+            assert worker._layer_load_finished_events[l] is not old_load_events[l]
+        # ... and task lists are cleared.
+        for l in range(2):
+            assert worker._layer_save_tasks[l] == []
+            assert worker._layer_load_tasks[l] == []
+
+
+class TestWaitForLayerLoad:
+    """Test wait_for_layer_load submits prefetch and waits for completion."""
+
+    def test_wait_for_layer_load_submits_prefetch(self):
+        """wait_for_layer_load must trigger _submit_ready_layer_loads."""
+        worker = _make_layerwise_bare_worker(num_layers=4)
+        worker.kv_recv_threads = [MagicMock()]
+
+        # Pre-populate load tasks so _submit_ready_layer_loads has work.
+        for layer_id in range(4):
+            task = LayerTransferTask(
+                req_id="test_req", group_id=0,
+                layer_idx_in_group=layer_id, physical_layer_id=layer_id,
+                key_list=["k"], addr_list=[[0x2000]], size_list=[[256]],
+                block_ids=[layer_id], is_save=False,
+            )
+            worker._layer_load_tasks[layer_id].append(task)
+
+        # Ensure each layer's event starts unset.
+        for layer_id in range(4):
+            worker._layer_load_finished_events[layer_id].clear()
+
+        # Set the event from another thread (simulating async transfer completion).
+        def _set_events_after_delay():
+            time.sleep(0.05)
+            worker._layer_load_finished_events[0].set()
+
+        import threading as _thr
+        setter = _thr.Thread(target=_set_events_after_delay, daemon=True)
+        setter.start()
+
+        # wait_for_layer_load blocks until layer 0 is loaded.
+        worker.wait_for_layer_load("model.layers.0.self_attn")
+
+        assert worker._current_load_layer == 1
+
+    def test_wait_for_layer_load_prefetch_advances_counter(self):
+        """_submit_ready_layer_loads advances _next_load_layer_to_submit."""
+        worker = _make_layerwise_bare_worker(num_layers=4)
+        worker.kv_recv_threads = [MagicMock()]
+
+        # Pre-populate load tasks.
+        for layer_id in range(4):
+            task = LayerTransferTask(
+                req_id="test_req", group_id=0,
+                layer_idx_in_group=layer_id, physical_layer_id=layer_id,
+                key_list=["k"], addr_list=[[0x2000]], size_list=[[256]],
+                block_ids=[layer_id], is_save=False,
+            )
+            worker._layer_load_tasks[layer_id].append(task)
+
+        # Pre-set the events.
+        for i in range(4):
+            worker._layer_load_finished_events[i].set()
+
+        assert worker._next_load_layer_to_submit == 0
+
+        # First call submits prefetch_layers layers.
+        worker.wait_for_layer_load("model.layers.0.self_attn")
+        # prefetch_layers=1, so only layer 0 was submitted.
+        assert worker._next_load_layer_to_submit == 1
+        assert worker._current_load_layer == 1
+
+        # Second call submits layer 1.
+        worker.wait_for_layer_load("model.layers.1.self_attn")
+        assert worker._next_load_layer_to_submit == 2
+        assert worker._current_load_layer == 2
+
+
+class TestLayerwiseSendHandleLayerTask:
+    """Test KVCacheStoreSendingThread._handle_request layerwise path."""
+
+    def test_send_handle_request_puts_to_store(self):
+        """Layerwise save must call batch_put_from_multi_buffers for non-existent keys."""
+        store = MagicMock()
+        store.batch_is_exist.return_value = [False, False]  # both keys absent
+        store.batch_put_from_multi_buffers.return_value = True
+
+        thread = _make_layerwise_send_thread(store, num_layers=2)
+        layer_id = 1  # last layer — set_finished_request is only called on the final layer
+        event = thread._layer_save_finished_events[layer_id]
+
+        task = LayerTransferTask(
+            req_id="test_send",
+            group_id=0,
+            layer_idx_in_group=layer_id,
+            physical_layer_id=layer_id,
+            key_list=["save_key_1", "save_key_2"],
+            addr_list=[[0x3000], [0x4000]],
+            size_list=[[256], [256]],
+            block_ids=[1, 2],
+            is_save=True,
+        )
+
+        thread._handle_request(task)
+
+        # batch_is_exist dedup check should be called.
+        store.batch_is_exist.assert_called_once_with(["save_key_1", "save_key_2"])
+        # Only absent keys should be put.
+        store.batch_put_from_multi_buffers.assert_called_once_with(
+            ["save_key_1", "save_key_2"],
+            [[0x3000], [0x4000]],
+            [[256], [256]],
+        )
+        # Event should be set.
+        assert event.is_set()
+        # Request should be marked finished.
+        assert "test_send" in thread.finished_requests
+
+    def test_send_handle_request_skips_existing_keys(self):
+        """Keys that already exist in store should be skipped (dedup)."""
+        store = MagicMock()
+        # First key exists, second does not.
+        store.batch_is_exist.return_value = [True, False]
+        store.batch_put_from_multi_buffers.return_value = True
+
+        thread = _make_layerwise_send_thread(store, num_layers=1)
+        event = thread._layer_save_finished_events[0]
+
+        task = LayerTransferTask(
+            req_id="test_dedup",
+            group_id=0,
+            layer_idx_in_group=0,
+            physical_layer_id=0,
+            key_list=["existing_key", "new_key"],
+            addr_list=[[0x3000], [0x4000]],
+            size_list=[[256], [256]],
+            block_ids=[1, 2],
+            is_save=True,
+        )
+
+        thread._handle_request(task)
+
+        # Only the absent key should be put.
+        store.batch_put_from_multi_buffers.assert_called_once_with(
+            ["new_key"],  # only new_key
+            [[0x4000]],   # its address
+            [[256]],      # its size
+        )
+        assert event.is_set()
+
+
+class TestLayerwiseRecvHandleLayerTask:
+    """Test KVCacheStoreRecvingThread._handle_request layerwise path."""
+
+    def test_recv_handle_request_gets_from_store(self):
+        """Layerwise load must call batch_get_into_multi_buffers."""
+        store = MagicMock()
+        store.batch_get_into_multi_buffers.return_value = [256, 256]  # all succeed
+
+        thread = _make_layerwise_recv_thread(store, num_layers=2)
+        layer_id = 0
+        event = thread._layer_load_finished_events[layer_id]
+
+        task = LayerTransferTask(
+            req_id="test_recv",
+            group_id=0,
+            layer_idx_in_group=layer_id,
+            physical_layer_id=layer_id,
+            key_list=["load_key_1", "load_key_2"],
+            addr_list=[[0x3000], [0x4000]],
+            size_list=[[256], [256]],
+            block_ids=[1, 2],
+            is_save=False,
+        )
+
+        thread._handle_request(task)
+
+        store.batch_get_into_multi_buffers.assert_called_once_with(
+            ["load_key_1", "load_key_2"],
+            [[0x3000], [0x4000]],
+            [[256], [256]],
+        )
+        assert event.is_set()
+
+    def test_recv_handle_request_load_failure_tracks_block_ids(self):
+        """Failed blocks should be tracked via _add_load_error_block_ids."""
+        store = MagicMock()
+        # Second key fails to load (-5 indicates failure).
+        store.batch_get_into_multi_buffers.return_value = [256, -5]
+
+        thread = _make_layerwise_recv_thread(store, num_layers=2)
+        layer_id = 0
+        event = thread._layer_load_finished_events[layer_id]
+
+        task = LayerTransferTask(
+            req_id="test_fail_load",
+            group_id=0,
+            layer_idx_in_group=layer_id,
+            physical_layer_id=layer_id,
+            key_list=["ok_key", "fail_key"],
+            addr_list=[[0x3000], [0x4000]],
+            size_list=[[256], [256]],
+            block_ids=[10, 20],  # second chunk fails
+            is_save=False,
+        )
+
+        thread._handle_request(task)
+
+        # The failed block_id (20) should be recorded.
+        assert event.is_set()
+        failed_blocks = thread.get_and_clear_block_ids_with_load_errors()
+        assert 20 in failed_blocks
+
+
+class TestSaveKvLayerIntegration:
+    """Integration tests: worker.save_kv_layer -> send thread _handle_request."""
+
+    def test_save_flow_integration(self):
+        """Full integration: populated tasks -> save_kv_layer -> thread processes."""
+        store = MagicMock()
+        store.batch_is_exist.return_value = [False, False]
+        store.batch_put_from_multi_buffers.return_value = True
+
+        worker = _make_layerwise_bare_worker(num_layers=2)
+        # Attach the real send thread to the worker.
+        send_thread = _make_layerwise_send_thread(store, num_layers=2)
+        worker.kv_send_thread = send_thread
+
+        # Sync worker events to the send thread (as register_kv_caches() does).
+        for layer_id in range(2):
+            send_thread.set_layer_finished_event(
+                layer_id, True, worker._layer_save_finished_events[layer_id]
+            )
+
+        # Build tasks via _build_layer_tasks_from_requests.
+        req = _make_test_reqmeta(token_len=32)
+        worker._build_layer_tasks_from_requests([req])
+
+        # Verify tasks were built.
+        assert len(worker._layer_save_tasks[0]) == 1
+        assert len(worker._layer_save_tasks[1]) == 1
+
+        # Simulate the forward pass, saving layer by layer.
+        worker.save_kv_layer("model.layers.0.self_attn", None, None)
+        # Layer 0's tasks are queued but not yet processed.
+
+        # Manually drain the send thread's queue.
+        while not send_thread.request_queue.empty():
+            item = send_thread.request_queue.get_nowait()
+            send_thread._handle_request(item)
+            send_thread.request_queue.task_done()
+
+        # Layer 0's event should be set (the send thread uses the worker's event).
+        assert worker._layer_save_finished_events[0].is_set()
+        store.batch_put_from_multi_buffers.assert_called()
+
+        # Reset mocks, then handle layer 1.
+        store.reset_mock()
+        store.batch_is_exist.return_value = [False]
+        store.batch_put_from_multi_buffers.return_value = True
+
+        worker.save_kv_layer("model.layers.1.self_attn", None, None)
+
+        while not send_thread.request_queue.empty():
+            item = send_thread.request_queue.get_nowait()
+            send_thread._handle_request(item)
+            send_thread.request_queue.task_done()
+
+        # Layer 1's event should be set.
+        assert worker._layer_save_finished_events[1].is_set()
+
+
+class TestLoadFlowIntegration:
+    """Integration tests: worker.wait_for_layer_load -> recv thread _handle_request."""
+
+    def test_load_flow_integration(self):
+        """Full integration: populated tasks -> wait_for_layer_load -> thread processes."""
+        store = MagicMock()
+        store.batch_get_into_multi_buffers.return_value = [256, 256]
+
+        worker = _make_layerwise_bare_worker(num_layers=2)
+        recv_thread = _make_layerwise_recv_thread(store, num_layers=2)
+        worker.kv_recv_threads = [recv_thread]
+
+        # Build load tasks.
+        req = _make_test_reqmeta(can_save=False, can_load=True, token_len=32)
+        worker._build_layer_tasks_from_requests([req])
+
+        assert len(worker._layer_load_tasks[0]) == 1
+
+        # Start a background thread to drain the recv thread's queue.
+        def _consume_recv_queue():
+            while not recv_thread.request_queue.empty():
+                item = recv_thread.request_queue.get_nowait()
+                recv_thread._handle_request(item)
+                recv_thread.request_queue.task_done()
+
+        consumer = threading.Thread(target=_consume_recv_queue, daemon=True)
+        consumer.start()
+
+        # wait_for_layer_load blocks until the event is set, so the consumer
+        # must be running before we call it.
+        consumer.join()
+
+        # Manually set the event (simulating consumer completion).
+        worker._layer_load_finished_events[0].set()
+
+        old_count = worker._current_load_layer
+        worker.wait_for_layer_load("model.layers.0.self_attn")
+
+        assert worker._current_load_layer == old_count + 1
+
+    def test_load_failure_propagates_to_worker(self):
+        """Load failures in recv thread should propagate to worker."""
+        store = MagicMock()
+        # The key fails to load.
+        store.batch_get_into_multi_buffers.return_value = [-5]
+
+        worker = _make_layerwise_bare_worker(num_layers=1, num_groups=1)
+        recv_thread = _make_layerwise_recv_thread(store, num_layers=1)
+        worker.kv_recv_threads = [recv_thread]
+
+        task = LayerTransferTask(
+            req_id="test_fail_prop",
+            group_id=0,
+            layer_idx_in_group=0,
+            physical_layer_id=0,
+            key_list=["fail_key"],
+            addr_list=[[0x3000]],
+            size_list=[[256]],
+            block_ids=[42],
+            is_save=False,
+        )
+        recv_thread._handle_request(task)
+
+        # Verify the worker can observe the failure.
+        failed_blocks = worker.get_block_ids_with_load_errors()
+        assert 42 in failed_blocks
+
+
+class TestSendingThreadSessionApi:
+    """Test KVCacheStoreSendingThread session API methods."""
+
+    def test_start_put_sessions_calls_batch_put_session_start(self):
+        """start_put_sessions calls batch_put_session_start with correct args."""
+        store = MagicMock()
+        store.batch_put_session_start.return_value = [0, 0]  # both succeed
+        thread = _make_layerwise_send_thread(store, num_layers=2)
+        thread._use_session_api = True
+
+        keys = ["key_a", "key_b"]
+        object_size = 8192
+        thread.start_put_sessions(keys, object_size)
+
+        store.batch_put_session_start.assert_called_once()
+        called_keys, called_sizes, _ = store.batch_put_session_start.call_args[0]
+        assert called_keys == keys
+        assert called_sizes == [object_size, object_size]
+
+    def test_start_put_sessions_partial_failure_revokes(self):
+        """Failed session starts are revoked."""
+        store = MagicMock()
+        store.batch_put_session_start.return_value = [0, -1]  # second fails
+        thread = _make_layerwise_send_thread(store, num_layers=1)
+        thread._use_session_api = True
+
+        thread.start_put_sessions(["ok_key", "fail_key"], 4096)
+
+        # Failed key should be revoked
+        store.batch_put_session_revoke.assert_called_once_with(["fail_key"])
+
+    def test_handle_request_dispatches_session_path(self):
+        """use_key_major_ranges=True dispatches to session handler."""
+        store = MagicMock()
+        store.batch_put_from_multi_buffer_ranges.return_value = [256]
+        thread = _make_layerwise_send_thread(store, num_layers=2)
+        thread._use_session_api = True
+        thread._active_put_keys = {"block_key_0", "block_key_1"}
+
+        task = LayerTransferTask(
+            req_id="test_session",
+            group_id=0,
+            layer_idx_in_group=0,
+            physical_layer_id=0,
+            key_list=["block_key_0", "block_key_1"],
+            addr_list=[[0x3000], [0x4000]],
+            size_list=[[256], [256]],
+            dst_offset_list=[[0], [256]],
+            block_ids=[1, 2],
+            is_save=True,
+            use_key_major_ranges=True,
+        )
+
+        thread._handle_request(task)
+
+        store.batch_put_from_multi_buffer_ranges.assert_called_once()
+        assert thread._layer_save_finished_events[0].is_set()
+
+    def test_handle_request_session_revokes_failed_keys(self):
+        """Failed range-put keys are revoked and excluded from next layers."""
+        store = MagicMock()
+        # key_1 succeeds, key_2 fails
+        store.batch_put_from_multi_buffer_ranges.return_value = [256, -5]
+        thread = _make_layerwise_send_thread(store, num_layers=2)
+        thread._use_session_api = True
+        thread._active_put_keys = {"key_1", "key_2"}
+
+        task = LayerTransferTask(
+            req_id="test_revoke",
+            group_id=0,
+            layer_idx_in_group=0,
+            physical_layer_id=0,
+            key_list=["key_1", "key_2"],
+            addr_list=[[0x3000], [0x4000]],
+            size_list=[[256], [256]],
+            dst_offset_list=[[0], [256]],
+            block_ids=[1, 2],
+            is_save=True,
+            use_key_major_ranges=True,
+        )
+
+        thread._handle_request(task)
+
+        # key_2 should be revoked
+        store.batch_put_session_revoke.assert_called_once_with(["key_2"])
+        # key_2 removed from active set
+        assert "key_2" not in thread._active_put_keys
+        assert "key_1" in thread._active_put_keys
+
+    def test_handle_request_session_last_layer_commits(self):
+        """Last layer calls batch_put_session_end to commit."""
+        store = MagicMock()
+        store.batch_put_from_multi_buffer_ranges.return_value = [256]
+        store.batch_put_session_end.return_value = [0]
+        thread = _make_layerwise_send_thread(store, num_layers=2)
+        thread._use_session_api = True
+        thread._active_put_keys = {"k1"}
+
+        task = LayerTransferTask(
+            req_id="test_last",
+            group_id=0,
+            layer_idx_in_group=1,
+            physical_layer_id=1,  # last layer (0-indexed, num_layers=2)
+            key_list=["k1"],
+            addr_list=[[0x3000]],
+            size_list=[[256]],
+            dst_offset_list=[[512]],
+            block_ids=[10],
+            is_save=True,
+            use_key_major_ranges=True,
+        )
+
+        thread._handle_request(task)
+
+        store.batch_put_session_end.assert_called_once_with(["k1"])
+        assert thread._active_put_keys is None  # reset after last layer
+
+
+class TestRecvingThreadSessionApi:
+    """Test KVCacheStoreRecvingThread session API methods."""
+
+    def test_start_get_sessions_calls_batch_get_session_start(self):
+        """start_get_sessions calls batch_get_session_start."""
+        store = MagicMock()
+        store.batch_get_session_start.return_value = [0, 0]
+        thread = _make_layerwise_recv_thread(store, num_layers=2)
+        thread._use_session_api = True
+
+        keys = ["load_key_a", "load_key_b"]
+        thread.start_get_sessions(keys)
+
+        store.batch_get_session_start.assert_called_once_with(keys)
+
+    def test_end_get_sessions_calls_batch_get_session_end(self):
+        """end_get_sessions calls batch_get_session_end."""
+        store = MagicMock()
+        thread = _make_layerwise_recv_thread(store, num_layers=1)
+        thread._use_session_api = True
+
+        keys = ["load_key_a", "load_key_b"]
+        thread.end_get_sessions(keys)
+
+        store.batch_get_session_end.assert_called_once_with(keys)
+
+    def test_handle_request_dispatches_session_path(self):
+        """use_key_major_ranges=True dispatches to session handler."""
+        store = MagicMock()
+        store.batch_get_into_multi_buffer_ranges.return_value = [256, 256]
+        thread = _make_layerwise_recv_thread(store, num_layers=2)
+        thread._use_session_api = True
+        thread._active_load_indices = {0, 1}
+
+        task = LayerTransferTask(
+            req_id="test_load_session",
+            group_id=0,
+            layer_idx_in_group=0,
+            physical_layer_id=0,
+            key_list=["load_key_1", "load_key_2"],
+            addr_list=[[0x3000], [0x4000]],
+            size_list=[[256], [256]],
+            dst_offset_list=[[0], [512]],
+            block_ids=[10, 20],
+            is_save=False,
+            use_key_major_ranges=True,
+        )
+
+        thread._handle_request(task)
+
+        store.batch_get_into_multi_buffer_ranges.assert_called_once()
+        assert thread._layer_load_finished_events[0].is_set()
+
+    def test_handle_request_session_tracks_failures(self):
+        """Failed range-get keys are tracked and excluded from next layers."""
+        store = MagicMock()
+        store.batch_get_into_multi_buffer_ranges.return_value = [256, -5]
+        thread = _make_layerwise_recv_thread(store, num_layers=2)
+        thread._use_session_api = True
+        thread._active_load_indices = {0, 1}
+
+        task = LayerTransferTask(
+            req_id="test_load_fail",
+            group_id=0,
+            layer_idx_in_group=0,
+            physical_layer_id=0,
+            key_list=["ok_key", "fail_key"],
+            addr_list=[[0x3000], [0x4000]],
+            size_list=[[256], [256]],
+            dst_offset_list=[[0], [512]],
+            block_ids=[10, 20],
+            is_save=False,
+            use_key_major_ranges=True,
+        )
+
+        thread._handle_request(task)
+
+        # Failed blocks tracked
+        failed = thread.get_and_clear_block_ids_with_load_errors()
+        assert 20 in failed
+        # Failed index removed from active set
+        assert 1 not in thread._active_load_indices
+
+    def test_handle_request_session_last_layer_finalizes(self):
+        """Last layer finalizes request tracking."""
+        store = MagicMock()
+        store.batch_get_into_multi_buffer_ranges.return_value = [256]
+        thread = _make_layerwise_recv_thread(store, num_layers=2)
+        thread._use_session_api = True
+        thread._active_load_indices = {0}
+
+        task = LayerTransferTask(
+            req_id="test_last_load",
+            group_id=0,
+            layer_idx_in_group=1,
+            physical_layer_id=1,  # last layer
+            key_list=["load_key"],
+            addr_list=[[0x3000]],
+            size_list=[[256]],
+            dst_offset_list=[[0]],
+            block_ids=[30],
+            is_save=False,
+            use_key_major_ranges=True,
+        )
+
+        thread._handle_request(task)
+
+        assert "test_last_load" in thread.finished_requests
+        assert thread._active_load_indices is None
+
+
+class TestWorkerSessionApiIntegration:
+    """Integration tests for MooncakeStoreWorker session API."""
+
+    def test_start_layerwise_sessions_starts_put_and_get(self):
+        """_start_layerwise_sessions starts both put and get sessions."""
+        store = MagicMock()
+        store.batch_put_session_start.return_value = [0]
+        store.batch_get_session_start.return_value = [0]
+        worker = _make_layerwise_bare_worker(num_layers=2)
+        worker._use_session_api = True
+        worker._page_size_bytes = 256
+        worker._load_sessions_closed = True
+        worker._load_session_lock = threading.Lock()
+        worker._opened_load_keys = []
+
+        # Setup send thread
+        send_thread = _make_layerwise_send_thread(store, num_layers=2)
+        send_thread._use_session_api = True
+        worker.kv_send_thread = send_thread
+
+        # Setup recv thread
+        recv_thread = _make_layerwise_recv_thread(store, num_layers=2)
+        recv_thread._use_session_api = True
+        worker.kv_recv_threads = [recv_thread]
+
+        req = _make_test_reqmeta(can_save=True, can_load=True, token_len=32)
+        worker._start_layerwise_sessions([req])
+
+        store.batch_put_session_start.assert_called()
+        store.batch_get_session_start.assert_called()
+        assert not worker._load_sessions_closed
+
+    def test_close_load_sessions_once_idempotent(self):
+        """_close_load_sessions_once only releases sessions once."""
+        store = MagicMock()
+        worker = _make_layerwise_bare_worker(num_layers=1)
+        worker._use_session_api = True
+        worker._load_session_lock = threading.Lock()
+        worker._load_sessions_closed = False
+        worker._opened_load_keys = ["key_a"]
+
+        recv_thread = _make_layerwise_recv_thread(store, num_layers=1)
+        recv_thread._use_session_api = True
+        worker.kv_recv_threads = [recv_thread]
+
+        # First call
+        worker._close_load_sessions_once()
+        assert worker._load_sessions_closed is True
+        assert store.batch_get_session_end.call_count == 1
+
+        # Second call — should be a no-op
+        worker._close_load_sessions_once()
+        assert store.batch_get_session_end.call_count == 1  # unchanged
+
+
+class TestBuildLayerTasksSessionApi:
+    """Test _build_layer_tasks_from_requests with session API enabled."""
+
+    def test_session_api_save_task_uses_block_key(self):
+        """Session API save tasks use block keys (no @layer:N suffix)."""
+        store = MagicMock()
+        store.batch_put_session_start.return_value = [0, 0]
+        store.batch_get_session_start.return_value = [0]
+        worker = _make_layerwise_bare_worker(num_layers=2)
+        worker._use_session_api = True
+        worker._page_size_bytes = 256
+        worker._load_sessions_closed = False
+        worker._load_session_lock = threading.Lock()
+        worker._opened_load_keys = []
+
+        send_thread = _make_layerwise_send_thread(store, num_layers=2)
+        send_thread._use_session_api = True
+        worker.kv_send_thread = send_thread
+
+        recv_thread = _make_layerwise_recv_thread(store, num_layers=2)
+        recv_thread._use_session_api = True
+        worker.kv_recv_threads = [recv_thread]
+
+        req = _make_test_reqmeta()
+        worker._build_layer_tasks_from_requests([req])
+
+        # Verify save tasks use block-level keys
+        for layer_id in range(2):
+            tasks = worker._layer_save_tasks[layer_id]
+            assert len(tasks) > 0
+            for task in tasks:
+                assert task.use_key_major_ranges is True
+                for key in task.key_list:
+                    assert "@layer:" not in key
+                if task.dst_offset_list:
+                    assert len(task.dst_offset_list) == len(task.key_list)
+
+    def test_session_api_load_task_has_offsets(self):
+        """Session API load tasks include per-layer byte offsets."""
+        store = MagicMock()
+        store.batch_put_session_start.return_value = [0]
+        store.batch_get_session_start.return_value = [0]
+        worker = _make_layerwise_bare_worker(num_layers=1)
+        worker._use_session_api = True
+        worker._page_size_bytes = 256
+        worker._load_sessions_closed = False
+        worker._load_session_lock = threading.Lock()
+        worker._opened_load_keys = []
+
+        send_thread = _make_layerwise_send_thread(store, num_layers=1)
+        send_thread._use_session_api = True
+        worker.kv_send_thread = send_thread
+
+        recv_thread = _make_layerwise_recv_thread(store, num_layers=1)
+        recv_thread._use_session_api = True
+        worker.kv_recv_threads = [recv_thread]
+
+        req = _make_test_reqmeta(can_save=False, can_load=True, token_len=32)
+        worker._build_layer_tasks_from_requests([req])
+
+        for layer_id in range(1):
+            tasks = worker._layer_load_tasks[layer_id]
+            for task in tasks:
+                assert task.use_key_major_ranges is True
+                assert len(task.dst_offset_list) == len(task.key_list)

--- a/tests/v1/kv_connector/unit/test_mooncake_store_layerwise.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_layerwise.py
@@ -67,6 +67,15 @@ def _make_layerwise_bare_worker(
     worker._next_load_layer_to_submit = 0
     worker._num_prefetch_layers = 1
 
+    # Session API shared state (FUNC-FIX 2/3/4).
+    from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.mooncake_session_tracker import (  # noqa: E501
+        MooncakeSessionTracker,
+    )
+    worker._session_tracker = MooncakeSessionTracker()
+    worker._put_started_keys = set()
+    worker._put_started_keys_lock = threading.Lock()
+    worker._current_mooncake_last_chunk_req_ids = set()
+
     # Create token databases
     worker.token_dbs = []
     for g_idx in range(num_groups):
@@ -164,53 +173,29 @@ class TestSubmitReadyLayerLoads:
         assert total_calls == 2, f"Expected 2 total calls, got {total_calls}"
 
 
-class TestLayerwiseStateReset:
-    """Test _reset_layer_state event and state management."""
+class TestLayerwiseEventReuse:
+    """FUNC-FIX 5/6: events are cleared (not rebuilt) across chunks."""
 
-    def test_reset_creates_new_events(self):
-        """_reset_layer_state replaces Event objects."""
+    def test_events_reused_not_rebuilt(self):
+        """_init_layerwise_config builds events once; they survive a round."""
         worker = _make_layerwise_bare_worker(num_layers=3)
-        old_save_events = {
+        save_events = {
             l: worker._layer_save_finished_events[l] for l in range(3)
         }
-        old_load_events = {
+        load_events = {
             l: worker._layer_load_finished_events[l] for l in range(3)
         }
 
-        worker._reset_layer_state()
+        # Simulate a round: set + clear some events.
+        worker._layer_save_finished_events[0].set()
+        worker._layer_load_finished_events[1].set()
 
+        # The save_kv_layer / wait_for_layer_load close events they use, but
+        # the worker must keep the same event objects so transfer threads (which
+        # hold references) stay in sync.
         for l in range(3):
-            assert worker._layer_save_finished_events[l] is not old_save_events[l]
-            assert worker._layer_load_finished_events[l] is not old_load_events[l]
-
-    def test_reset_syncs_events_to_threads(self):
-        """Layerwsie: new events are synced to transfer threads after reset."""
-        worker = _make_layerwise_bare_worker(num_layers=2)
-
-        # Create layerwise-enabled mock threads
-        worker.kv_send_thread = MagicMock()
-        worker.kv_send_thread._layerwise_enabled = True
-        worker.kv_recv_threads = [
-            MagicMock(_layerwise_enabled=True),
-            MagicMock(_layerwise_enabled=False),  # one non-layerwise
-        ]
-
-        worker._reset_layer_state()
-
-        # Sending thread: should receive 2 set_layer_finished_event calls (is_save=True)
-        assert worker.kv_send_thread.set_layer_finished_event.call_count == 2
-        for call_args in worker.kv_send_thread.set_layer_finished_event.call_args_list:
-            assert call_args.args[1] is True  # is_save=True
-
-        # Only the layerwise-enabled recv thread should receive calls
-        thread0 = worker.kv_recv_threads[0]
-        assert thread0.set_layer_finished_event.call_count == 2
-        for call_args in thread0.set_layer_finished_event.call_args_list:
-            assert call_args.args[1] is False  # is_save=False
-
-        # Non-layerwise thread should not receive calls
-        thread1 = worker.kv_recv_threads[1]
-        assert thread1.set_layer_finished_event.call_count == 0
+            assert worker._layer_save_finished_events[l] is save_events[l]
+            assert worker._layer_load_finished_events[l] is load_events[l]
 
 
 # ============================================================================
@@ -340,8 +325,8 @@ class TestSaveKvLayer:
             assert isinstance(task, LayerTransferTask)
             assert task.physical_layer_id == i
 
-    def test_save_kv_layer_last_layer_triggers_reset(self):
-        """Last layer must call _wait_for_all_layer_saves and _reset_layer_state."""
+    def test_save_kv_layer_last_layer_clears_events(self):
+        """Last layer waits then clears (not rebuilds) the save events (FUNC-FIX 5)."""
         worker = _make_layerwise_bare_worker(num_layers=2)
         worker.kv_send_thread = MagicMock()
         worker.kv_send_thread._layerwise_enabled = True
@@ -359,19 +344,14 @@ class TestSaveKvLayer:
             worker._layer_save_finished_events[layer_id].set()
 
         old_save_events = {l: worker._layer_save_finished_events[l] for l in range(2)}
-        old_load_events = {l: worker._layer_load_finished_events[l] for l in range(2)}
 
         # Save the last layer.
         worker.save_kv_layer("model.layers.1.self_attn", None, None)
 
-        # The last layer must trigger a reset: events are replaced ...
+        # FUNC-FIX 5: events are reused (same object) and CLEARED, not rebuilt.
         for l in range(2):
-            assert worker._layer_save_finished_events[l] is not old_save_events[l]
-            assert worker._layer_load_finished_events[l] is not old_load_events[l]
-        # ... and task lists are cleared.
-        for l in range(2):
-            assert worker._layer_save_tasks[l] == []
-            assert worker._layer_load_tasks[l] == []
+            assert worker._layer_save_finished_events[l] is old_save_events[l]
+            assert not worker._layer_save_finished_events[l].is_set()
 
 
 class TestWaitForLayerLoad:
@@ -579,6 +559,96 @@ class TestLayerwiseRecvHandleLayerTask:
         assert 20 in failed_blocks
 
 
+class TestLayerwiseStoreJobLedger:
+    """Test layerwise save tasks participate in the store_job_id ledger."""
+
+    def test_store_job_id_passed_to_save_tasks(self):
+        """_build_layer_tasks_from_requests copies ReqMeta.store_job_id to tasks."""
+        worker = _make_layerwise_bare_worker(num_layers=2)
+        req = _make_test_reqmeta()
+        req.store_job_id = 42
+        worker._build_layer_tasks_from_requests([req])
+
+        for layer_id in range(2):
+            tasks = worker._layer_save_tasks[layer_id]
+            assert len(tasks) == 1
+            for task in tasks:
+                assert task.store_job_id == 42
+
+    def test_save_kv_layer_layer0_registers_store_job_id(self):
+        """save_kv_layer layer 0 enters the store_job_id into the ledger."""
+        worker = _make_layerwise_bare_worker(num_layers=2)
+        send_thread = _make_layerwise_send_thread(MagicMock(), num_layers=2)
+        worker.kv_send_thread = send_thread
+
+        req = _make_test_reqmeta()
+        req.store_job_id = 7
+        worker._build_layer_tasks_from_requests([req])
+
+        worker.save_kv_layer("model.layers.0.self_attn", None, None)
+
+        assert "test_req" in send_thread.stored_requests
+        assert 7 in send_thread.stored_requests["test_req"]
+
+    def test_handle_layer_task_finishes_job_on_last_layer(self):
+        """Sending thread finishes the store_job_id on the last layer."""
+        store = MagicMock()
+        store.batch_is_exist.return_value = [False]
+        store.batch_put_from_multi_buffers.return_value = True
+        thread = _make_layerwise_send_thread(store, num_layers=2)
+
+        task = LayerTransferTask(
+            req_id="test_finish",
+            group_id=0,
+            layer_idx_in_group=1,
+            physical_layer_id=1,  # last layer
+            key_list=["k"],
+            addr_list=[[0x3000]],
+            size_list=[[256]],
+            block_ids=[1],
+            is_save=True,
+            store_job_id=5,
+        )
+        thread.stored_requests["test_finish"] = {5}
+
+        thread._handle_layer_task(task)
+
+        assert thread._completed_saves.get(5) == 1
+        completed = thread.take_completed_saves()
+        assert completed[5] == 1
+
+    def test_handle_layer_range_task_finishes_job_on_last_layer(self):
+        """Session-API sending thread finishes the store_job_id on the last layer."""
+        store = MagicMock()
+        store.batch_put_from_multi_buffer_ranges.return_value = [0]
+        store.batch_put_session_end.return_value = [0]
+        thread = _make_layerwise_send_thread(store, num_layers=2)
+        thread._use_session_api = True
+        thread._active_put_keys = {"k1"}
+
+        task = LayerTransferTask(
+            req_id="test_range_finish",
+            group_id=0,
+            layer_idx_in_group=1,
+            physical_layer_id=1,  # last layer
+            key_list=["k1"],
+            addr_list=[[0x3000]],
+            size_list=[[256]],
+            dst_offset_list=[[512]],
+            block_ids=[10],
+            is_save=True,
+            use_key_major_ranges=True,
+            store_job_id=6,
+        )
+        thread.stored_requests["test_range_finish"] = {6}
+
+        thread._handle_layer_range_task(task)
+
+        assert thread._completed_saves.get(6) == 1
+        completed = thread.take_completed_saves()
+        assert completed[6] == 1
+
+
 class TestSaveKvLayerIntegration:
     """Integration tests: worker.save_kv_layer -> send thread _handle_request."""
 
@@ -726,8 +796,8 @@ class TestSendingThreadSessionApi:
         # Successfully-started keys seed the per-layer range-put filter.
         assert thread._active_put_keys == {"key_a", "key_b"}
 
-    def test_start_put_sessions_partial_failure_revokes(self):
-        """Failed session starts are revoked."""
+    def test_start_put_sessions_partial_failure_degrades(self):
+        """Failed session starts are degraded (not revoked - FUNC-FIX 2)."""
         store = MagicMock()
         store.batch_put_session_start.return_value = [0, -1]  # second fails
         thread = _make_layerwise_send_thread(store, num_layers=1)
@@ -735,10 +805,13 @@ class TestSendingThreadSessionApi:
 
         thread.start_put_sessions(["ok_key", "fail_key"], 4096)
 
-        # Failed key should be revoked
-        store.batch_put_session_revoke.assert_called_once_with(["fail_key"])
+        # Failed key is degraded, NOT revoked (revoking would delete committed KV)
+        store.batch_put_session_revoke.assert_not_called()
         # Only the successful key remains writable.
         assert thread._active_put_keys == {"ok_key"}
+        # The successful key enters the dedup set.
+        assert "ok_key" in thread._put_started_keys
+        assert "fail_key" not in thread._put_started_keys
 
     def test_handle_request_dispatches_session_path(self):
         """use_key_major_ranges=True dispatches to session handler."""
@@ -767,8 +840,8 @@ class TestSendingThreadSessionApi:
         store.batch_put_from_multi_buffer_ranges.assert_called_once()
         assert thread._layer_save_finished_events[0].is_set()
 
-    def test_handle_request_session_revokes_failed_keys(self):
-        """Failed range-put keys are revoked and excluded from next layers."""
+    def test_handle_request_session_drops_failed_keys(self):
+        """Failed range-put keys are dropped from the active set (not revoked - FUNC-FIX 2)."""
         store = MagicMock()
         # key_1 succeeds, key_2 fails
         store.batch_put_from_multi_buffer_ranges.return_value = [256, -5]
@@ -792,9 +865,9 @@ class TestSendingThreadSessionApi:
 
         thread._handle_request(task)
 
-        # key_2 should be revoked
-        store.batch_put_session_revoke.assert_called_once_with(["key_2"])
-        # key_2 removed from active set
+        # key_2 is NOT revoked (could delete committed KV from earlier layers)
+        store.batch_put_session_revoke.assert_not_called()
+        # key_2 removed from active set for this step
         assert "key_2" not in thread._active_put_keys
         assert "key_1" in thread._active_put_keys
 

--- a/tests/v1/kv_connector/unit/test_mooncake_store_scheduler.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_scheduler.py
@@ -49,6 +49,9 @@ def _make_bare_scheduler(
     scheduler._next_store_job_id = 0
     scheduler._pinned_saves = {}
     scheduler._boundary_state_group_ids = frozenset({1})
+    # __init__ (scheduler.py:68) sets this unconditionally; the bare stub
+    # bypasses __init__ but lookup()/alloc path read this layerwise guard.
+    scheduler._layerwise_enabled = False
     return scheduler
 
 

--- a/tests/v1/kv_connector/unit/test_mooncake_store_worker.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_worker.py
@@ -2756,6 +2756,11 @@ def _make_bare_worker(
     worker.tp_size = 1
     worker.num_kv_head = 1
     worker.pp_size = 1
+    # __init__ (worker.py:2204-2205) sets these unconditionally; replicate
+    # here since the bare worker bypasses __init__. register_kv_caches(),
+    # get_finished(), and lookup() all read these layerwise guards.
+    worker._layerwise_enabled = False
+    worker._use_session_api = False
     # Minimal single-full-attention-group config so the coordinator-based
     # lookup path works (the connector no longer carries a legacy single-group
     # path; everything flows through the coordinator).

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/connector.py
@@ -280,34 +280,15 @@ class MooncakeStoreConnector(KVConnectorBase_V1, SupportsHMA):
         self.connector_worker.register_kv_caches(kv_caches)
 
     def start_load_kv(self, forward_context: ForwardContext, **kwargs: Any) -> None:
-        if self._layerwise_enabled:
-            # Phase 1: build per-layer tasks before model forward so that
-            # wait_for_layer_load() / save_kv_layer() (called during the
-            # forward pass) have tasks to consume.
-            assert self.connector_worker is not None
-            metadata = self._get_connector_metadata()
-            assert isinstance(metadata, MooncakeStoreConnectorMetadata)
-            self.connector_worker.start_load_kv(metadata)
-        else:
-            # Non-layerwise path: simply forward to the worker.
-            assert self.connector_worker is not None
-            metadata = self._get_connector_metadata()
-            assert isinstance(metadata, MooncakeStoreConnectorMetadata)
-            self.connector_worker.start_load_kv(metadata)
+        assert self.connector_worker is not None
+        metadata = self._get_connector_metadata()
+        assert isinstance(metadata, MooncakeStoreConnectorMetadata)
+        self.connector_worker.start_load_kv(metadata)
 
     @property
     def _layerwise_enabled(self) -> bool:
         """Check if layerwise mode is enabled."""
         extra_config = self._kv_transfer_config.kv_connector_extra_config
-        return str(extra_config.get("use_layerwise", "False")).lower() == "true"
-
-    @classmethod
-    def requires_piecewise_for_cudagraph(cls, extra_config: dict) -> bool:
-        """Layerwise mode requires PIECEWISE cudagraph mode.
-
-        Because wait_for_layer_load() and save_kv_layer() contain blocking
-        Python synchronization that cannot be captured in CUDA graphs.
-        """
         return str(extra_config.get("use_layerwise", "False")).lower() == "true"
 
     def wait_for_layer_load(self, layer_name: str) -> None:

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/connector.py
@@ -280,14 +280,47 @@ class MooncakeStoreConnector(KVConnectorBase_V1, SupportsHMA):
         self.connector_worker.register_kv_caches(kv_caches)
 
     def start_load_kv(self, forward_context: ForwardContext, **kwargs: Any) -> None:
-        assert self.connector_worker is not None
-        metadata = self._get_connector_metadata()
-        assert isinstance(metadata, MooncakeStoreConnectorMetadata)
-        self.connector_worker.start_load_kv(metadata)
+        if self._layerwise_enabled:
+            # Phase 1: build per-layer tasks before model forward so that
+            # wait_for_layer_load() / save_kv_layer() (called during the
+            # forward pass) have tasks to consume.
+            assert self.connector_worker is not None
+            metadata = self._get_connector_metadata()
+            assert isinstance(metadata, MooncakeStoreConnectorMetadata)
+            self.connector_worker.start_load_kv(metadata)
+        else:
+            # Non-layerwise path: simply forward to the worker.
+            assert self.connector_worker is not None
+            metadata = self._get_connector_metadata()
+            assert isinstance(metadata, MooncakeStoreConnectorMetadata)
+            self.connector_worker.start_load_kv(metadata)
+
+    @property
+    def _layerwise_enabled(self) -> bool:
+        """Check if layerwise mode is enabled."""
+        extra_config = self._kv_transfer_config.kv_connector_extra_config
+        return str(extra_config.get("use_layerwise", "False")).lower() == "true"
+
+    @classmethod
+    def requires_piecewise_for_cudagraph(cls, extra_config: dict) -> bool:
+        """Layerwise mode requires PIECEWISE cudagraph mode.
+
+        Because wait_for_layer_load() and save_kv_layer() contain blocking
+        Python synchronization that cannot be captured in CUDA graphs.
+        """
+        return str(extra_config.get("use_layerwise", "False")).lower() == "true"
 
     def wait_for_layer_load(self, layer_name: str) -> None:
-        # No layerwise support - no-op
-        return
+        """Wait for a layer's KV cache to finish loading.
+
+        Called by the ``@maybe_transfer_kv_layer`` decorator before each
+        layer's attention computation in layerwise mode.
+        """
+        if not self._layerwise_enabled:
+            return
+
+        assert self.connector_worker is not None
+        self.connector_worker.wait_for_layer_load(layer_name)
 
     def save_kv_layer(
         self,
@@ -296,8 +329,16 @@ class MooncakeStoreConnector(KVConnectorBase_V1, SupportsHMA):
         attn_metadata: AttentionMetadata,
         **kwargs: Any,
     ) -> None:
-        # No layerwise support - no-op
-        return
+        """Save a layer's KV cache to the store.
+
+        Called by the ``@maybe_transfer_kv_layer`` decorator after each layer's
+        attention computation in layerwise mode.
+        """
+        if not self._layerwise_enabled:
+            return
+
+        assert self.connector_worker is not None
+        self.connector_worker.save_kv_layer(layer_name, kv_layer, attn_metadata)
 
     def wait_for_save(self):
         assert self.connector_worker is not None

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/data.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/data.py
@@ -659,6 +659,11 @@ class LayerTransferTask:
     # True → Mooncake session API path (batch_put/get_*_ranges);
     # False → legacy per-layer-key path (batch_put/get_from_multi_buffers).
     use_key_major_ranges: bool = False
+    # The store_job_id assigned by the scheduler for this save batch.
+    # Only meaningful when is_save=True. It lets the sending thread finish
+    # the store job on the last layer so the scheduler can release pinned
+    # GPU blocks via build_connector_worker_meta().
+    store_job_id: int | None = None
 
 
 class MooncakeStoreConnectorMetadata(KVConnectorMetadata):

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/data.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/data.py
@@ -185,6 +185,7 @@ class ChunkedTokenDatabase:
         self.kv_caches_base_addr: list[int] = []
         self.block_len: list[int] = []
         self._key_prefix = PoolKey.build_prefix(metadata)
+        self.num_layers: int = 0  # total layers, used to slice block_len per layer
 
     def key_for(self, chunk_hash: BlockHash) -> str:
         return PoolKey.build_key_string(self._key_prefix, chunk_hash.hex())
@@ -298,6 +299,148 @@ class ChunkedTokenDatabase:
             end_idx = min(start_idx + self.block_size, token_len)
             h = block_hashes[end_idx // self.hash_block_size - 1]
             yield start_idx, end_idx, h
+
+    # ======================================================================
+    # Layerwise Support
+    # ======================================================================
+
+    def key_for_layer(self, chunk_hash: BlockHash, layer_id: int) -> str:
+        """Return the store key for a chunk hash at a given layer.
+
+        Args:
+            chunk_hash: Hash of the chunk.
+            layer_id: Layer index.
+
+        Returns:
+            Key string with the ``@layer:N`` suffix.
+        """
+        base_key = self.key_for(chunk_hash)
+        return f"{base_key}@layer:{layer_id}"
+
+    def key_for_block(self, chunk_hash: BlockHash) -> str:
+        """Return the block-level key (no layer suffix).
+
+        In Session API mode all layers of a block share one key, addressed by a
+        byte offset. Alias of ``key_for()`` kept for clarity.
+        """
+        return self.key_for(chunk_hash)
+
+    def prepare_values_for_layer(
+        self,
+        chunks: Sequence[tuple[int, int]],
+        block_ids: list[int],
+        layer_id: int,
+    ) -> tuple[list[list[int]], list[list[int]], list[int]]:
+        """Compute memory addresses for a specific layer.
+
+        Slice ``kv_caches_base_addr`` / ``block_len`` by ``num_layers`` to
+        extract the target layer's segments (following vllm-ascend's
+        ``LayerBatchBuilder._build_transfer_arrays``).
+
+        Args:
+            chunks: [(start, end), ...] token ranges.
+            block_ids: Corresponding block-id list.
+            layer_id: Layer index (used for the address offset).
+
+        Returns:
+            (addr_lists, size_lists, chunk_block_ids)
+        """
+        if not chunks:
+            return [], [], []
+
+        if self.num_layers > 0 and self.block_len:
+            caches_per_layer = len(self.block_len) // max(1, self.num_layers)
+            if (caches_per_layer > 0
+                    and caches_per_layer * self.num_layers == len(self.block_len)
+                    and (layer_id + 1) * caches_per_layer <= len(self.block_len)):
+                base = np.asarray(self.kv_caches_base_addr, dtype=np.int64)
+                length = len(self.block_len)
+                blen = np.asarray(
+                    [self.block_len[i % length] for i in range(base.shape[0])],
+                    dtype=np.int64,
+                )
+                layer_start = layer_id * caches_per_layer
+                layer_end = layer_start + caches_per_layer
+                layer_base = base[layer_start:layer_end]
+                layer_blen = blen[layer_start:layer_end]
+
+                n = len(chunks)
+                starts = np.fromiter((c[0] for c in chunks), dtype=np.int64, count=n)
+                spans = np.fromiter((c[1] for c in chunks), dtype=np.int64, count=n) - starts
+                assert not (spans % self.block_size).any()
+                bids = np.fromiter(
+                    (block_ids[i] for i in (starts // self.block_size).tolist()),
+                    dtype=np.int64,
+                    count=n,
+                )
+                addrs = layer_base[None, :] + bids[:, None] * layer_blen[None, :]
+                sizes = layer_blen[None, :] * (spans // self.block_size)[:, None]
+                return addrs.tolist(), sizes.tolist(), bids.tolist()
+
+        return self.prepare_values(chunks, block_ids)
+
+    def prepare_values_for_layer_offset(
+        self,
+        chunks: Sequence[tuple[int, int]],
+        block_ids: list[int],
+        layer_id: int,
+    ) -> tuple[list[list[int]], list[list[int]], list[list[int]], list[int]]:
+        """Compute per-layer addresses, sizes, object-byte offsets, and block IDs.
+
+        Returns (addr_lists, size_lists, offset_lists, block_ids_out) where
+        offset_lists contains the destination byte offset for each (key,
+        segment) pair within the Mooncake session object.  The offset is::
+
+            layer_id * page_size_bytes + segment_relative_offset
+
+        where page_size_bytes = sum(block_len_per_layer).  The per-layer
+        addresses and sizes are identical to ``prepare_values_for_layer``.
+
+        Args:
+            chunks: [(start, end), ...] token ranges.
+            block_ids: corresponding block-id list.
+            layer_id: layer index (for address slicing and base-offset).
+
+        Returns:
+            (addr_lists, size_lists, offset_lists, block_ids_out)
+            — one sub-list per chunk.
+        """
+        addrs, sizes, block_ids_out = self.prepare_values_for_layer(
+            chunks, block_ids, layer_id
+        )
+        if not addrs:
+            return [], [], [], []
+
+        offset_lists: list[list[int]] = []
+        if self.num_layers > 0 and self.block_len:
+            caches_per_layer = len(self.block_len) // max(1, self.num_layers)
+            if not (caches_per_layer > 0
+                    and caches_per_layer * self.num_layers == len(self.block_len)
+                    and (layer_id + 1) * caches_per_layer <= len(self.block_len)):
+                caches_per_layer = len(self.block_len)
+        else:
+            caches_per_layer = len(self.block_len)
+
+        page_size_bytes = sum(self.block_len[:caches_per_layer]) if caches_per_layer > 0 else 0
+        layer_base_offset = layer_id * page_size_bytes
+
+        # Per-segment relative offsets (cumulative within one layer)
+        segment_offsets: list[int] = []
+        cumulative = 0
+        for blen in self.block_len[:caches_per_layer]:
+            segment_offsets.append(cumulative)
+            cumulative += blen
+
+        for chunk_sizes in sizes:
+            chunk_offsets: list[int] = []
+            for i in range(len(chunk_sizes)):
+                seg_idx = i % max(1, caches_per_layer)
+                chunk_offsets.append(
+                    layer_base_offset + segment_offsets[seg_idx]
+                )
+            offset_lists.append(chunk_offsets)
+
+        return addrs, sizes, offset_lists, block_ids_out
 
 
 @dataclass(frozen=True)
@@ -491,6 +634,31 @@ class MooncakeStoreWorkerMetadata(KVConnectorWorkerMetadata):
                 self.completed_saves.get(store_job_id, 0) + count
             )
         return self
+
+
+# ============================================================================
+# Layerwise KV Cache Data Structures (Phase 1)
+# ============================================================================
+
+@dataclass
+class LayerTransferTask:
+    """Per-layer transfer task for one request on one layer."""
+    req_id: str
+    group_id: int
+    layer_idx_in_group: int  # layer index within its group
+    physical_layer_id: int  # global layer index
+    key_list: list[str]
+    addr_list: list[list[int]]
+    size_list: list[list[int]]
+    block_ids: list[int]
+    is_save: bool = True
+    # Per-segment destination/src byte offsets within the Mooncake session object.
+    # Only used when use_key_major_ranges is True (Session API mode).
+    # Shape: [num_chunks][num_segments_per_chunk], parallel to addr_list / size_list.
+    dst_offset_list: list[list[int]] = field(default_factory=list)
+    # True → Mooncake session API path (batch_put/get_*_ranges);
+    # False → legacy per-layer-key path (batch_put/get_from_multi_buffers).
+    use_key_major_ranges: bool = False
 
 
 class MooncakeStoreConnectorMetadata(KVConnectorMetadata):

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/mooncake_session_tracker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/mooncake_session_tracker.py
@@ -1,0 +1,144 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+#
+
+from __future__ import annotations
+
+import threading
+from collections.abc import Iterable, Mapping
+
+
+class MooncakeSessionTracker:
+    """Track chunk-spanning Mooncake sessions owned by this Worker."""
+
+    def __init__(self) -> None:
+        self._lock = threading.RLock()
+        self._request_load_entries: dict[str, dict[str, int]] = {}
+        self._pending_put_owners: dict[str, dict[str, int]] = {}
+        self._load_key_owners: dict[str, set[str]] = {}
+
+    @staticmethod
+    def _replace_block_entry(entries: dict[str, int], key: str, block_index: int) -> None:
+        for previous_key, previous_index in list(entries.items()):
+            if previous_index == block_index and previous_key != key:
+                del entries[previous_key]
+        entries[key] = block_index
+
+    def register_put_keys(
+        self,
+        req_id: str,
+        entries: Iterable[tuple[str, int]],
+    ) -> None:
+        """Remember which requests should consume a key after PutEnd succeeds."""
+        with self._lock:
+            for key, block_index in entries:
+                self._pending_put_owners.setdefault(key, {})[req_id] = block_index
+
+    def commit_put_keys(self, keys: Iterable[str]) -> None:
+        """Promote successfully committed keys into each owner's future loads."""
+        with self._lock:
+            for key in keys:
+                request_entries = self._pending_put_owners.pop(key, {})
+                for req_id, block_index in request_entries.items():
+                    entries = self._request_load_entries.setdefault(req_id, {})
+                    self._replace_block_entry(entries, key, block_index)
+
+    def revoke_put_keys(self, keys: Iterable[str]) -> None:
+        with self._lock:
+            for key in keys:
+                self._pending_put_owners.pop(key, None)
+
+    def prepare_load_entries(
+        self,
+        req_id: str,
+        current_entries: Iterable[tuple[str, int]],
+    ) -> list[tuple[str, int]]:
+        """Merge current hits with keys completed by earlier chunks."""
+        with self._lock:
+            entries = self._request_load_entries.setdefault(req_id, {})
+            for key, block_index in current_entries:
+                self._replace_block_entry(entries, key, block_index)
+            return list(entries.items())
+
+    def record_get_result(
+        self,
+        key: str,
+        req_ids: Iterable[str],
+        *,
+        succeeded: bool,
+    ) -> None:
+        """Update active owners after a per-chunk BatchGetStart result."""
+        with self._lock:
+            if succeeded:
+                self._load_key_owners.setdefault(key, set()).update(req_ids)
+            else:
+                # RealClient erases its process-local session when renewal
+                # fails, so no previous owner still has an active session.
+                self._load_key_owners.pop(key, None)
+
+    def release_failed_get_attempts(
+        self,
+        request_ids_by_key: Mapping[str, Iterable[str]],
+    ) -> list[str]:
+        """Release only owners involved in a failed BatchGetStart attempt."""
+        with self._lock:
+            keys_to_end: list[str] = []
+            for key, req_ids in request_ids_by_key.items():
+                owners = self._load_key_owners.get(key)
+                if owners is None:
+                    # The failed call may have opened a Client session before
+                    # returning a malformed result. No request owns it.
+                    keys_to_end.append(key)
+                    continue
+                owners.difference_update(req_ids)
+                if not owners:
+                    keys_to_end.append(key)
+                    del self._load_key_owners[key]
+            return keys_to_end
+
+    def _release_active_owners_locked(
+        self,
+        req_ids: set[str],
+    ) -> list[str]:
+        keys_to_end: list[str] = []
+        for key, owners in list(self._load_key_owners.items()):
+            owners.difference_update(req_ids)
+            if not owners:
+                keys_to_end.append(key)
+                del self._load_key_owners[key]
+        return keys_to_end
+
+    def release_for_retry(self, req_ids: set[str]) -> list[str]:
+        """Release active owners while retaining state needed by a retry."""
+        if not req_ids:
+            return []
+        with self._lock:
+            return self._release_active_owners_locked(req_ids)
+
+    def release_terminal(self, req_ids: set[str]) -> list[str]:
+        """Release active owners and delete all terminal request state."""
+        if not req_ids:
+            return []
+        with self._lock:
+            keys_to_end = self._release_active_owners_locked(req_ids)
+            for req_id in req_ids:
+                self._request_load_entries.pop(req_id, None)
+            for key, owners in list(self._pending_put_owners.items()):
+                for req_id in req_ids:
+                    owners.pop(req_id, None)
+                if not owners:
+                    del self._pending_put_owners[key]
+            return keys_to_end

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/scheduler.py
@@ -61,6 +61,14 @@ class MooncakeStoreScheduler:
         self.kv_role = vllm_config.kv_transfer_config.kv_role
         kvc_extra_config = vllm_config.kv_transfer_config.kv_connector_extra_config
         self.load_async = kvc_extra_config.get("load_async", True)
+        # Layerwise mode embeds KV load into the model forward pass
+        # (wait_for_layer_load is called during attention computation).
+        # The request MUST enter RUNNING state for the forward pass to
+        # start, so load_async (which puts requests into
+        # WAITING_FOR_REMOTE_KVS) is incompatible with layerwise mode.
+        self._layerwise_enabled = str(kvc_extra_config.get("use_layerwise", "False")).lower() == "true"
+        if self._layerwise_enabled:
+            self.load_async = False
         self.lookup_async = kvc_extra_config.get("lookup_async", False)
         # Skips lookup CPU cost on instances that never load KV from the store.
         self.enable_lookup = kvc_extra_config.get("enable_lookup", True)
@@ -161,7 +169,7 @@ class MooncakeStoreScheduler:
             tail_key_boundaries=lookup_result.tail_key_boundaries,
         )
 
-        return need_to_allocate, self.load_async
+        return need_to_allocate, self.load_async and not self._layerwise_enabled
 
     def update_state_after_alloc(
         self,

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
@@ -82,6 +82,7 @@ from vllm.v1.kv_cache_interface import (
 )
 
 from .metrics import MooncakeStoreConnectorStats
+from .mooncake_session_tracker import MooncakeSessionTracker
 
 logger = init_logger(__name__)
 
@@ -601,6 +602,10 @@ class KVCacheStoreSendingThread(KVTransferThread):
         # Keys whose put session opened this step (set by start_put_sessions,
         # consumed by the per-layer range-put handler). None/empty until then.
         self._active_put_keys: set[str] | None = None
+        # Process-wide dedup set + lock
+        self._put_started_keys: set[str] = set()
+        self._put_started_keys_lock = threading.Lock()
+        self._session_tracker: Any = None
 
     def add_request(self, request: ReqMeta | LayerTransferTask) -> None:
         # Layerwise per-layer tasks carry no store_job_id; enqueue them directly
@@ -654,6 +659,26 @@ class KVCacheStoreSendingThread(KVTransferThread):
             completed = self._completed_saves
             self._completed_saves = {}
         return completed
+
+    def _finish_layer_store_job(self, task: LayerTransferTask) -> None:
+        """Retire the store_job_id ledger entry for a layerwise save task.
+
+        Layerwise save tasks are dispatched per layer but share the same
+        store_job_id assigned by the scheduler to the whole batch. Finishing it
+        on the last layer lets build_connector_worker_meta() report completion
+        so the scheduler can release the GPU blocks it pinned.
+        """
+        store_job_id = task.store_job_id
+        if store_job_id is None or not task.is_save:
+            return
+        finish_meta = ReqMeta(
+            req_id=task.req_id,
+            token_len_chunk=0,
+            block_ids=(),
+            block_hashes=[],
+            store_job_id=store_job_id,
+        )
+        self.finish_store_job(finish_meta)
 
     def _record_saved(self, req_meta: ReqMeta, token_len: int) -> None:
         # Guard on job liveness so neither a concurrent finish/preempt pop nor a
@@ -967,14 +992,11 @@ class KVCacheStoreSendingThread(KVTransferThread):
     ) -> None:
         """Start put sessions for save keys (one Master RPC per batch).
 
-        Called by ``MooncakeStoreWorker._start_layerwise_sessions()`` before
-        per-layer tasks are constructed.  Once a session is open, subsequent
-        ``batch_put_from_multi_buffer_ranges()`` calls can write data at
-        layer offsets without additional Master communication.
+        Process-wide dedup (``_put_started_keys``, shared with the worker):
+        only ``new_keys`` (never PutStart'd before) are issued
+        ``batch_put_session_start``. Keys a prior chunk already started remain
+        writable this step so the per-layer range-put can continue writing them.
 
-        The set of keys whose session actually opened is recorded in
-        ``_active_put_keys`` so the per-layer range-put handler only writes
-        live sessions and skips any whose start failed.
         """
         if not self._use_session_api:
             return
@@ -982,35 +1004,64 @@ class KVCacheStoreSendingThread(KVTransferThread):
             self._active_put_keys = set()
             return
 
-        sizes = [object_size] * len(keys)
-        try:
-            results = self.store.batch_put_session_start(
-                keys, sizes, self.replicate_config
-            )
-        except Exception as exc:
-            logger.error("batch_put_session_start failed: %s", exc)
-            self._revoke_range_keys(keys)
-            self._active_put_keys = set()
+        with self._put_started_keys_lock:
+            previously_started = set(keys) & self._put_started_keys
+            new_keys = [k for k in keys if k not in self._put_started_keys]
+
+        started: set[str] = set(previously_started)
+
+        if new_keys:
+            sizes = [object_size] * len(new_keys)
+            session_start_time = time.perf_counter()
+            try:
+                results = self.store.batch_put_session_start(
+                    new_keys, sizes, self.replicate_config
+                )
+            except Exception as exc:
+                self._record_operation(
+                    "save_put_session_start",
+                    session_start_time,
+                    len(new_keys),
+                    status="error",
+                    num_failed_keys=len(new_keys),
+                )
+                logger.error("batch_put_session_start failed: %s", exc)
+            else:
+                self._record_operation(
+                    "save_put_session_start",
+                    session_start_time,
+                    len(new_keys),
+                )
+                newly_started = {k for k, r in zip(new_keys, results) if r == 0}
+                with self._put_started_keys_lock:
+                    self._put_started_keys.update(newly_started)
+                started |= newly_started
+
+        self._active_put_keys = started
+
+    def _remove_put_started_keys(self, keys: list[str]) -> None:
+        """Drop committed/revoked keys from the process-wide dedup set."""
+        if not keys:
             return
-
-        failed = [k for k, r in zip(keys, results) if r != 0]
-        if failed:
-            logger.warning(
-                "batch_put_session_start failed for keys: %s", failed
-            )
-            self._revoke_range_keys(failed)
-
-        # Only keys whose session opened are writable this batch.
-        self._active_put_keys = {k for k, r in zip(keys, results) if r == 0}
+        with self._put_started_keys_lock:
+            for k in keys:
+                self._put_started_keys.discard(k)
 
     def _revoke_range_keys(self, keys: list[str]) -> None:
-        """Cancel unfinished put sessions (cleanup on failure)."""
+        """Cancel unfinished put sessions (cleanup on failure).
+
+        Only call for keys PutStart'd this step that have NOT been committed —
+        never for keys committed by an earlier chunk. ``finally``
+        removes them from the dedup set so a later chunk can retry.
+        """
         if not keys:
             return
         try:
             self.store.batch_put_session_revoke(keys)
         except Exception as exc:
             logger.error("batch_put_session_revoke failed: %s", exc)
+        finally:
+            self._remove_put_started_keys(keys)
 
     def _handle_layer_task(self, task: LayerTransferTask) -> None:
         """Legacy per-layer-key save path (Phase 1)."""
@@ -1077,6 +1128,8 @@ class KVCacheStoreSendingThread(KVTransferThread):
                 e,
             )
         finally:
+            if task.physical_layer_id == self._num_layers - 1:
+                self._finish_layer_store_job(task)
             self.request_queue.task_done()
 
     def _handle_layer_range_task(self, task: LayerTransferTask) -> None:
@@ -1132,12 +1185,13 @@ class KVCacheStoreSendingThread(KVTransferThread):
                     status="ok",
                 )
 
-                # Revoke failed keys — they are dropped from subsequent layers
+                # Failed range-put keys — only drop from this step's writable set.
+                # Do NOT revoke: a key opened by Start may already hold prior
+                # layers' data; revoking would delete it.
                 failed_keys = [
                     k for k, r in zip(active_keys, results) if r < 0
                 ]
                 if failed_keys:
-                    self._revoke_range_keys(failed_keys)
                     self._active_put_keys.difference_update(failed_keys)
                     logger.warning(
                         "Layer %d save: %d/%d range-put keys failed, req=%s",
@@ -1153,10 +1207,16 @@ class KVCacheStoreSendingThread(KVTransferThread):
                     k for k in keys if k in self._active_put_keys
                 ]
                 if commit_keys:
+                    commit_start = time.perf_counter()
                     try:
                         commit_results = self.store.batch_put_session_end(
                             commit_keys
                         )
+                        committed_keys = [
+                            k
+                            for k, r in zip(commit_keys, commit_results)
+                            if r == 0
+                        ]
                         failed_commit = [
                             k
                             for k, r in zip(commit_keys, commit_results)
@@ -1164,7 +1224,22 @@ class KVCacheStoreSendingThread(KVTransferThread):
                         ]
                         if failed_commit:
                             self._revoke_range_keys(failed_commit)
+                        if self._session_tracker is not None and committed_keys:
+                            self._session_tracker.commit_put_keys(committed_keys)
+                        self._remove_put_started_keys(committed_keys)
+                        self._record_operation(
+                            "save_put_session_end",
+                            commit_start,
+                            len(commit_keys),
+                        )
                     except Exception as exc:
+                        self._record_operation(
+                            "save_put_session_end",
+                            commit_start,
+                            len(commit_keys),
+                            status="error",
+                            num_failed_keys=len(commit_keys),
+                        )
                         logger.error(
                             "batch_put_session_end failed: %s", exc
                         )
@@ -1193,10 +1268,13 @@ class KVCacheStoreSendingThread(KVTransferThread):
                 req_id,
                 e,
             )
-            # On catastrophic failure, revoke all keys for this batch
-            self._revoke_range_keys(keys)
+            # Do NOT revoke the full key set: it may include keys
+            # whose KV was committed by an earlier chunk.
+            # Just abandon this step's active set.
             self._active_put_keys = None
         finally:
+            if layer_id == self._num_layers - 1:
+                self._finish_layer_store_job(task)
             self.request_queue.task_done()
 
     def _handle_request(self, req_meta: ReqMeta | LayerTransferTask):
@@ -1592,7 +1670,7 @@ class KVCacheStoreRecvingThread(KVTransferThread):
     def end_get_sessions(self, keys: list[str]) -> None:
         """Release get sessions (one shot per step).
 
-        Called by ``MooncakeStoreWorker._close_load_sessions_once()``.
+        Called by ``MooncakeStoreWorker.wait_for_layer_load()`` (release_terminal, last chunk only).
         """
         if not self._use_session_api or not keys:
             return
@@ -2197,7 +2275,6 @@ class MooncakeStoreWorker:
         self._current_load_layer: int = 0
         self._next_load_layer_to_submit: int = 0
         self._num_prefetch_layers: int = 1
-        self._save_finalized: bool = False
 
         # Read layerwise parameters from the extra config.
         kvc_extra = vllm_config.kv_transfer_config.kv_connector_extra_config
@@ -2265,10 +2342,12 @@ class MooncakeStoreWorker:
             self._load_sessions_closed = False
             self._load_session_lock = threading.Lock()
             self._opened_load_keys: list[str] = []
-            # Placeholder: block_len is empty at __init__ time (it is filled
-            # later in register_kv_caches), so _compute_page_size_bytes() would
-            # return 0 here. The real value is (re)computed in register_kv_caches
-            # once the kv-cache layout is known.
+            # Process-wide dedup of keys whose PutStart already succeeded
+            # (across chunks/requests).
+            self._put_started_keys: set[str] = set()
+            self._put_started_keys_lock = threading.Lock()
+            self._session_tracker = MooncakeSessionTracker()
+            self._current_mooncake_last_chunk_req_ids: set[str] = set()
             self._page_size_bytes = 0
 
         logger.info(
@@ -2296,55 +2375,63 @@ class MooncakeStoreWorker:
         return sum(db.block_len[:caches_per_layer])
 
     def _start_layerwise_sessions(self, requests: list[ReqMeta]) -> None:
-        """Start put/get sessions before per-layer tasks are built.
-
-        Called from ``start_load_kv()`` *before* ``_build_layer_tasks_from_requests()``
-        so that subsequent per-layer ``batch_put_from_multi_buffer_ranges`` /
-        ``batch_get_into_multi_buffer_ranges`` calls operate on open sessions (zero
-        additional Master RPCs).
-
-        Put session:
-          Reserve object space on the store side via ``batch_put_session_start``.
-          The object size is ``page_size_bytes × num_layers`` — one linear region
-          with layer i at byte offset ``i × page_size_bytes``.
-
-        Get session:
-          Query replica location + acquire lease via ``batch_get_session_start``.
-        """
+        """Start put/get sessions before per-layer tasks are built."""
         if not self._use_session_api:
             return
 
         object_size = self._page_size_bytes * self._num_layers
 
-        # ---- Collect save keys (deduplicated across requests) ----
+        # Requests whose current chunk is the last prefill chunk. get sessions
+        # are only closed (release_terminal) for these — intermediate chunks
+        # keep their sessions open for cross-chunk continuity.
+        last_chunk_req_ids: set[str] = set()
+        for r in requests:
+            npt = r.num_prompt_tokens
+            if npt is None:
+                continue
+            block_aligned_prefill_end = npt // self.block_size * self.block_size
+            if r.token_len_chunk >= block_aligned_prefill_end:
+                last_chunk_req_ids.add(r.req_id)
+        self._current_mooncake_last_chunk_req_ids = last_chunk_req_ids
+
+        # ---- Collect save keys (incremental, this chunk only) ----
         save_keys: list[str] = []
         save_keys_set: set[str] = set()
+        save_entries_by_req: dict[str, list[tuple[str, int]]] = {}
         for req_meta in requests:
             if not req_meta.can_save:
                 continue
+            entries: list[tuple[str, int]] = []
             for group_id in range(len(req_meta.block_ids)):
                 db = self.token_dbs[group_id]
                 put_step = self._group_tp_replication_factors[group_id]
                 put_step_rank = (self.tp_rank + group_id) % put_step
-                for _, _, block_hash in db.process_tokens(
-                    req_meta.token_len_chunk,
+                save_start = req_meta.token_ids_start
+                save_end = req_meta.token_len_chunk
+                for start_idx, _, block_hash in db.process_tokens(
+                    save_end,
                     req_meta.block_hashes,
+                    mask_num=save_start,
                     put_step=put_step,
                     put_step_rank=put_step_rank,
                 ):
                     key = db.key_for(block_hash)
+                    entries.append((key, start_idx // self.block_size))
                     if key not in save_keys_set:
                         save_keys.append(key)
                         save_keys_set.add(key)
-
+            if entries:
+                save_entries_by_req[req_meta.req_id] = entries
         if save_keys and self.kv_send_thread is not None:
             self.kv_send_thread.start_put_sessions(save_keys, object_size)
         elif self.kv_send_thread is not None:
-            # No session phase this step — clear any stale active-key set so
-            # the range-put handler cannot reuse keys from a previous step.
             self.kv_send_thread._active_put_keys = set()
 
-        # ---- Collect load keys (deduplicated across requests) ----
+        if self._session_tracker is not None:
+            for req_id, entries in save_entries_by_req.items():
+                self._session_tracker.register_put_keys(req_id, entries)
+
+        # ---- Collect load keys (merge with prior-chunk committed keys) ----
         load_keys: list[str] = []
         load_keys_set: set[str] = set()
         for req_meta in requests:
@@ -2355,32 +2442,49 @@ class MooncakeStoreWorker:
                 load_spec.vllm_cached_tokens
                 // self.block_size * self.block_size
             )
+            current_entries: list[tuple[str, int]] = []
             for group_id in range(len(req_meta.block_ids)):
                 db = self.token_dbs[group_id]
-                for _, _, block_hash in db.process_tokens(
+                for start_idx, _, block_hash in db.process_tokens(
                     load_spec.token_len,
                     req_meta.block_hashes,
                     mask_num,
                 ):
                     key = db.key_for(block_hash)
-                    if key not in load_keys_set:
-                        load_keys.append(key)
-                        load_keys_set.add(key)
+                    current_entries.append((key, start_idx // self.block_size))
+            if self._session_tracker is not None and current_entries:
+                current_entries = self._session_tracker.prepare_load_entries(
+                    req_meta.req_id, current_entries
+                )
+            for key, _ in current_entries:
+                if key not in load_keys_set:
+                    load_keys.append(key)
+                    load_keys_set.add(key)
 
         if load_keys:
-            for recv_thread in self.kv_recv_threads:
-                recv_thread.start_get_sessions(load_keys)
+            opened = []
+            if self.kv_recv_threads:
+                opened = self.kv_recv_threads[0].start_get_sessions(load_keys)
+                for recv_thread in self.kv_recv_threads[1:]:
+                    recv_thread.start_get_sessions(load_keys)
+            if self._session_tracker is not None and opened:
+                owning_req_ids = {
+                    r.req_id
+                    for r in requests
+                    if r.load_spec is not None and r.load_spec.can_load
+                }
+                for key in opened:
+                    self._session_tracker.record_get_result(
+                        key, owning_req_ids, succeeded=True
+                    )
             with self._load_session_lock:
                 self._opened_load_keys = load_keys
                 self._load_sessions_closed = False
 
     def _close_load_sessions_once(self) -> None:
-        """Release all get sessions (one-shot per step).
+        """Release all get sessions (legacy one-shot, kept for reference).
 
-        Called at the end of the final layer's ``save_kv_layer``, after
-        ``_wait_for_all_layer_saves()`` and before ``_reset_layer_state()``.
-        At this point every layer has been loaded and saved, so the lease
-        can be released safely.
+        Replaced by release_terminal() in wait_for_layer_load().
         """
         if not self._use_session_api:
             return
@@ -2562,6 +2666,10 @@ class MooncakeStoreWorker:
                 self.kv_send_thread._use_session_api = getattr(
                     self, '_use_session_api', False
                 )
+                if self._use_session_api:
+                    self.kv_send_thread._put_started_keys = self._put_started_keys
+                    self.kv_send_thread._put_started_keys_lock = self._put_started_keys_lock
+                    self.kv_send_thread._session_tracker = self._session_tracker
                 for layer_id in range(self._num_layers):
                     self.kv_send_thread.set_layer_finished_event(
                         layer_id, True, self._layer_save_finished_events[layer_id]
@@ -2612,11 +2720,6 @@ class MooncakeStoreWorker:
             return
 
         if self._layerwise_enabled:
-            # Backfill load_spec.token_len before starting sessions. It defaults
-            # to 0 and _start_layerwise_sessions() reads it to decide which
-            # blocks to lease via batch_get_session_start(); leaving it empty
-            # means no get session is opened and the later
-            # batch_get_into_multi_buffer_ranges returns rc=-600 for every key.
             for req_meta in metadata.requests:
                 load_spec = req_meta.load_spec
                 if (
@@ -2638,8 +2741,9 @@ class MooncakeStoreWorker:
             assert self.load_async, "load_async must be True for better performance."
 
     def wait_for_save(self, metadata: MooncakeStoreConnectorMetadata):
-        """Issue async stores (non-layerwise) or no-op (layerwise).
+        """Issue async stores with CUDA event synchronization (non-layerwise) or no-op (layerwise).
 
+        Runs after the forward launch for compute-I/O overlap.
         Layerwise stores are issued per-layer from save_kv_layer().
         """
         if self._capacity_only or not self.can_put:
@@ -2784,6 +2888,7 @@ class MooncakeStoreWorker:
                             block_ids=list(block_ids_out),
                             is_save=True,
                             use_key_major_ranges=self._use_session_api,
+                            store_job_id=req_meta.store_job_id,
                         )
                         self._layer_save_tasks[physical_layer_id].append(task)
 
@@ -2861,6 +2966,7 @@ class MooncakeStoreWorker:
                             block_ids=block_ids,
                             is_save=False,
                             use_key_major_ranges=self._use_session_api,
+                            store_job_id=req_meta.store_job_id,
                         )
                         self._layer_load_tasks[physical_layer_id].append(task)
 
@@ -2924,6 +3030,20 @@ class MooncakeStoreWorker:
         # Submit this layer's save tasks to the send thread.
         tasks = self._layer_save_tasks.get(layer_id, [])
         if tasks and self.kv_send_thread:
+            if layer_id == 0:
+                seen_req_ids: set[str] = set()
+                with self.kv_send_thread.done_task_lock:
+                    for task in tasks:
+                        req_id = task.req_id
+                        if (
+                            req_id not in seen_req_ids
+                            and task.is_save
+                            and task.store_job_id is not None
+                        ):
+                            seen_req_ids.add(req_id)
+                            self.kv_send_thread.stored_requests.setdefault(
+                                req_id, set()
+                            ).add(task.store_job_id)
             for task in tasks:
                 self.kv_send_thread.add_request(task)
         elif not tasks:
@@ -2932,29 +3052,20 @@ class MooncakeStoreWorker:
             if event is not None:
                 event.set()
 
-        # Last layer: wait for all saves to complete.
-        # Guard: finalize only once per step. If save_kv_layer fires twice for
-        # the last layer (e.g. both the @maybe_transfer_kv_layer decorator and
-        # an explicit hook), the second call would otherwise hit the
-        # _reset_layer_state()-replaced events and hang in _wait_for_all_layer_saves.
-        if layer_id == self._num_layers - 1 and not self._save_finalized:
-            self._save_finalized = True
+        # Last layer: wait for all saves to complete, then clear (not rebuild)
+        # the save events so the next chunk reuses the SAME Event objects.
+        if layer_id == self._num_layers - 1:
             self._wait_for_all_layer_saves()
-            # Session API: release get-session leases now that all layers are done.
-            self._close_load_sessions_once()
-            # Reset state for the next round of requests.
-            self._reset_layer_state()
+            for lid in range(self._num_layers):
+                ev = self._layer_save_finished_events.get(lid)
+                if ev is not None:
+                    ev.clear()
 
     def wait_for_layer_load(self, layer_name: str) -> None:
-        """Wait for one layer's KV cache to finish loading from the store.
-
-        Called by ``@maybe_transfer_kv_layer`` before that layer's attention
-        forward runs.
-        """
+        """Wait for one layer's KV cache to finish loading from the store."""
         if not self._layerwise_enabled:
             return
 
-        # Extract the layer index from layer_name.
         from vllm.model_executor.models.utils import extract_layer_index
         try:
             layer_id = extract_layer_index(layer_name)
@@ -2965,24 +3076,49 @@ class MooncakeStoreWorker:
                 logger.warning("Cannot extract layer_id from %s", layer_name)
                 return
 
-        # Submit prefetch tasks for the following layers.
         self._submit_ready_layer_loads()
 
-        # No load tasks (cold start or full hit): mark complete directly.
         tasks = self._layer_load_tasks.get(layer_id, [])
         if not tasks:
+            # No load task — clear (not set) so stale set from a prior
+            # chunk cannot be mistaken for this layer's completion.
             event = self._layer_load_finished_events.get(layer_id)
             if event is not None:
-                event.set()
+                event.clear()
         else:
-            # Wait for this layer's load to complete.
             event = self._layer_load_finished_events.get(layer_id)
             if event is not None and not event.is_set():
                 if not event.wait(timeout=10.0):
                     logger.warning("Timeout waiting for layer %d to load", layer_id)
-                # Not cleared here; _reset_layer_state() rebuilds all events.
+            if event is not None:
+                event.clear()
 
         self._current_load_layer += 1
+
+        # Last layer of the last prefill chunk: close get sessions (reference-
+        # counted via tracker). Intermediate chunks keep get sessions open.
+        if (
+            layer_id == self._num_layers - 1
+            and self._use_session_api
+            and self._session_tracker is not None
+            and self._current_mooncake_last_chunk_req_ids
+        ):
+            keys_to_end = self._session_tracker.release_terminal(
+                self._current_mooncake_last_chunk_req_ids
+            )
+            if keys_to_end:
+                for recv_thread in self.kv_recv_threads:
+                    recv_thread.end_get_sessions(keys_to_end)
+            self._current_mooncake_last_chunk_req_ids = set()
+            with self._load_session_lock:
+                self._load_sessions_closed = True
+                self._opened_load_keys = []
+
+        # Reset counters at the last layer — events stay alive.
+        if layer_id == self._num_layers - 1:
+            self._current_save_layer = 0
+            self._current_load_layer = 0
+            self._next_load_layer_to_submit = 0
 
     def _wait_for_all_layer_saves(self) -> None:
         """Wait for all layers' saves to complete."""
@@ -2992,66 +3128,6 @@ class MooncakeStoreWorker:
                 if not event.wait(timeout=10.0):
                     logger.warning("Timeout waiting for layer %d to save", layer_id)
                 # Not cleared here; _reset_layer_state() rebuilds all events.
-
-    def _reset_layer_state(self) -> None:
-        """Reset layerwise state for the next round of requests.
-
-        Re-create all event objects (instead of clear()) so a stale set()
-        from the previous round's transfer threads cannot be mistaken for the
-        current round's completion signal.
-        """
-        self._current_save_layer = 0
-        self._current_load_layer = 0
-        self._next_load_layer_to_submit = 0
-        self._save_finalized = False
-
-        for layer_id in range(self._num_layers):
-            self._layer_save_tasks[layer_id] = []
-            self._layer_load_tasks[layer_id] = []
-
-        for layer_id in range(self._num_layers):
-            self._layer_save_finished_events[layer_id] = threading.Event()
-            self._layer_load_finished_events[layer_id] = threading.Event()
-
-        # Re-sync the events to the transfer threads.
-        if self.kv_send_thread is not None and self.kv_send_thread._layerwise_enabled:
-            for layer_id in range(self._num_layers):
-                self.kv_send_thread.set_layer_finished_event(
-                    layer_id, True, self._layer_save_finished_events[layer_id]
-                )
-        for recv_thread in self.kv_recv_threads:
-            if recv_thread._layerwise_enabled:
-                for layer_id in range(self._num_layers):
-                    recv_thread.set_layer_finished_event(
-                        layer_id, False, self._layer_load_finished_events[layer_id]
-                    )
-
-        # Session API: reset one-shot guard so the next step can release
-        # its load sessions.
-        if self._use_session_api:
-            self._load_sessions_closed = False
-            self._opened_load_keys = []
-
-
-        if self.can_put:
-            self._close_ended_store_requests(finished_req_ids, meta)
-
-        # Blocks read by a store job are released by the scheduler when the job
-        # reports back (see build_connector_worker_meta), so no request ever waits
-        # on a `finished_sending` signal to get its blocks back.
-        done_sending: set[str] = set()
-        done_recving: set[str] = set()
-        if self.load_async:
-            for recv_thread in self.kv_recv_threads:
-                done_recving |= recv_thread.get_and_clear_finished_requests()
-
-        logger.debug(
-            "Completed send: %d, recv: %d, tp_rank: %d",
-            len(done_sending),
-            len(done_recving),
-            self.tp_rank,
-        )
-        return done_sending, done_recving
 
     def get_block_ids_with_load_errors(self) -> set[int]:
         block_ids: set[int] = set()

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
@@ -106,12 +106,7 @@ _MOONCAKE_SESSION_METHODS = (
 
 
 def _mooncake_supports_session_api(store: Any) -> bool:
-    """Return True if the Mooncake store exposes all Session API methods.
-
-    Uses ``hasattr`` (which maps to ``__getattr__`` + catch), not ``getattr``,
-    because the real Mooncake client will raise AttributeError for unknown
-    methods rather than silently returning None.
-    """
+    # Return True if the Mooncake store exposes all Session API methods.
     for method in _MOONCAKE_SESSION_METHODS:
         try:
             attr = getattr(store, method)
@@ -2271,7 +2266,6 @@ class MooncakeStoreWorker:
         self._layer_load_tasks: dict[int, list[LayerTransferTask]] = {}
         self._layer_save_finished_events: dict[int, threading.Event] = {}
         self._layer_load_finished_events: dict[int, threading.Event] = {}
-        self._current_save_layer: int = 0
         self._current_load_layer: int = 0
         self._next_load_layer_to_submit: int = 0
         self._num_prefetch_layers: int = 1
@@ -3116,7 +3110,6 @@ class MooncakeStoreWorker:
 
         # Reset counters at the last layer — events stay alive.
         if layer_id == self._num_layers - 1:
-            self._current_save_layer = 0
             self._current_load_layer = 0
             self._next_load_layer_to_submit = 0
 

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
@@ -452,6 +452,7 @@ class KVTransferThread(threading.Thread):
         self._layerwise_enabled = False
         self._layer_save_finished_events: dict[int, threading.Event] = {}
         self._layer_load_finished_events: dict[int, threading.Event] = {}
+        self._layer_sync_save_events: dict[int, torch.cuda.Event] = {}
 
     def enable_layerwise(self, num_layers: int) -> None:
         """Enable layerwise mode with specified number of layers."""
@@ -1069,6 +1070,7 @@ class KVCacheStoreSendingThread(KVTransferThread):
             return
 
         req_id = task.req_id
+        layer_id = task.physical_layer_id
         start_time = time.perf_counter()
 
         try:
@@ -1079,6 +1081,10 @@ class KVCacheStoreSendingThread(KVTransferThread):
             actual_sizes = [s for s, e in zip(sizes, exist_mask) if not e]
 
             if actual_keys:
+                sync_event = self._layer_sync_save_events.get(layer_id)
+                if sync_event is not None:
+                    sync_event.synchronize()
+
                 batch_put_start = time.perf_counter()
                 res = self.store.batch_put_from_multi_buffers(
                     actual_keys, actual_addrs, actual_sizes
@@ -1100,7 +1106,6 @@ class KVCacheStoreSendingThread(KVTransferThread):
                     )
 
             if self._layerwise_enabled:
-                layer_id = task.physical_layer_id
                 event = self._layer_save_finished_events.get(layer_id)
                 if event:
                     event.set()
@@ -1163,6 +1168,10 @@ class KVCacheStoreSendingThread(KVTransferThread):
             active_keys = [keys[i] for i in active_indices]
 
             if active_keys:
+                sync_event = self._layer_sync_save_events.get(layer_id)
+                if sync_event is not None:
+                    sync_event.synchronize()
+
                 results = self.store.batch_put_from_multi_buffer_ranges(
                     active_keys,
                     [task.addr_list[i] for i in active_indices],
@@ -2323,12 +2332,14 @@ class MooncakeStoreWorker:
 
         self._layer_save_finished_events = {}
         self._layer_load_finished_events = {}
+        self._layer_sync_save_events: dict[int, torch.cuda.Event] = {}
         self._layer_save_tasks = {}
         self._layer_load_tasks = {}
 
         for layer_id in range(self._num_layers):
             self._layer_save_finished_events[layer_id] = threading.Event()
             self._layer_load_finished_events[layer_id] = threading.Event()
+            self._layer_sync_save_events[layer_id] = torch.cuda.Event()
             self._layer_save_tasks[layer_id] = []
             self._layer_load_tasks[layer_id] = []
 
@@ -2664,6 +2675,7 @@ class MooncakeStoreWorker:
                     self.kv_send_thread._put_started_keys = self._put_started_keys
                     self.kv_send_thread._put_started_keys_lock = self._put_started_keys_lock
                     self.kv_send_thread._session_tracker = self._session_tracker
+                self.kv_send_thread._layer_sync_save_events = self._layer_sync_save_events
                 for layer_id in range(self._num_layers):
                     self.kv_send_thread.set_layer_finished_event(
                         layer_id, True, self._layer_save_finished_events[layer_id]
@@ -3023,6 +3035,11 @@ class MooncakeStoreWorker:
 
         # Submit this layer's save tasks to the send thread.
         tasks = self._layer_save_tasks.get(layer_id, [])
+
+        sync_event = self._layer_sync_save_events.get(layer_id)
+        if sync_event is not None:
+            sync_event.record()
+
         if tasks and self.kv_send_thread:
             if layer_id == 0:
                 seen_req_ids: set[str] = set()

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
@@ -602,7 +602,12 @@ class KVCacheStoreSendingThread(KVTransferThread):
         # consumed by the per-layer range-put handler). None/empty until then.
         self._active_put_keys: set[str] | None = None
 
-    def add_request(self, request: ReqMeta) -> None:
+    def add_request(self, request: ReqMeta | LayerTransferTask) -> None:
+        # Layerwise per-layer tasks carry no store_job_id; enqueue them directly
+        # (the ledger only tracks bulk, non-layerwise store jobs).
+        if isinstance(request, LayerTransferTask):
+            super().add_request(request)
+            return
         # Register before enqueueing so a job is never picked up unledgered.
         assert request.store_job_id is not None
         with self.done_task_lock:

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
@@ -598,6 +598,8 @@ class KVCacheStoreSendingThread(KVTransferThread):
         self._retry_token_ids: dict[str, tuple[int, list[int]]] = {}
 
         # Session API state
+        # Keys whose put session opened this step (set by start_put_sessions,
+        # consumed by the per-layer range-put handler). None/empty until then.
         self._active_put_keys: set[str] | None = None
 
     def add_request(self, request: ReqMeta) -> None:
@@ -964,10 +966,15 @@ class KVCacheStoreSendingThread(KVTransferThread):
         per-layer tasks are constructed.  Once a session is open, subsequent
         ``batch_put_from_multi_buffer_ranges()`` calls can write data at
         layer offsets without additional Master communication.
+
+        The set of keys whose session actually opened is recorded in
+        ``_active_put_keys`` so the per-layer range-put handler only writes
+        live sessions and skips any whose start failed.
         """
         if not self._use_session_api:
             return
         if not keys:
+            self._active_put_keys = set()
             return
 
         sizes = [object_size] * len(keys)
@@ -978,6 +985,7 @@ class KVCacheStoreSendingThread(KVTransferThread):
         except Exception as exc:
             logger.error("batch_put_session_start failed: %s", exc)
             self._revoke_range_keys(keys)
+            self._active_put_keys = set()
             return
 
         failed = [k for k, r in zip(keys, results) if r != 0]
@@ -986,6 +994,9 @@ class KVCacheStoreSendingThread(KVTransferThread):
                 "batch_put_session_start failed for keys: %s", failed
             )
             self._revoke_range_keys(failed)
+
+        # Only keys whose session opened are writable this batch.
+        self._active_put_keys = {k for k, r in zip(keys, results) if r == 0}
 
     def _revoke_range_keys(self, keys: list[str]) -> None:
         """Cancel unfinished put sessions (cleanup on failure)."""
@@ -1084,8 +1095,11 @@ class KVCacheStoreSendingThread(KVTransferThread):
         start_time = time.perf_counter()
 
         try:
-            # Init the active-key set on the first layer
-            if self._active_put_keys is None or layer_id == 0:
+            # _active_put_keys is seeded by start_put_sessions() before the
+            # forward with the keys whose session actually opened. If a step
+            # reached the range-put handler without that (e.g. session start
+            # was skipped), fall back to treating all keys as active.
+            if self._active_put_keys is None:
                 self._active_put_keys = set(keys)
 
             # Only write keys whose session is still alive
@@ -1533,15 +1547,19 @@ class KVCacheStoreRecvingThread(KVTransferThread):
         # Session API state
         self._active_load_indices: set[int] | None = None
 
-    def start_get_sessions(self, keys: list[str]) -> None:
+    def start_get_sessions(self, keys: list[str]) -> list[str]:
         """Start get sessions for load keys (one Master RPC).
 
         Called by ``MooncakeStoreWorker._start_layerwise_sessions()``.
+
+        Returns the keys whose session actually opened. Fails gracefully on
+        partial failure: errored sessions are revoked and excluded from later
+        layers so the surviving sessions remain usable.
         """
         if not self._use_session_api:
-            return
+            return []
         if not keys:
-            return
+            return []
         try:
             results = self.store.batch_get_session_start(keys)
         except Exception as exc:
@@ -1550,12 +1568,21 @@ class KVCacheStoreRecvingThread(KVTransferThread):
                 self.store.batch_get_session_end(keys)
             except Exception:
                 pass
-            return
+            return []
         failed = [k for k, r in zip(keys, results) if r != 0]
+        opened = [k for k, r in zip(keys, results) if r == 0]
         if failed:
             logger.warning(
                 "batch_get_session_start missed/errored keys: %s", failed
             )
+            # Revoke sessions that failed to open so a fresh start_get_sessions
+            # on the next step cannot collide with a stale partial lease.
+            try:
+                self.store.batch_get_session_end(failed)
+            except Exception:
+                pass
+
+        return opened
 
     def end_get_sessions(self, keys: list[str]) -> None:
         """Release get sessions (one shot per step).
@@ -2165,12 +2192,13 @@ class MooncakeStoreWorker:
         self._current_load_layer: int = 0
         self._next_load_layer_to_submit: int = 0
         self._num_prefetch_layers: int = 1
+        self._save_finalized: bool = False
 
         # Read layerwise parameters from the extra config.
         kvc_extra = vllm_config.kv_transfer_config.kv_connector_extra_config
         if kvc_extra:
             self._layerwise_enabled = str(kvc_extra.get("use_layerwise", "False")).lower() == "true"
-            self._num_prefetch_layers = int(kvc_extra.get("layerwise_prefetch_layers", 1))
+            self._num_prefetch_layers = int(kvc_extra.get("layerwise_prefetch_layers", 2))
 
         # Layerwise mode embeds KV load into the model forward pass.
         # load_async (which reports finished_recving to the scheduler,
@@ -2232,7 +2260,11 @@ class MooncakeStoreWorker:
             self._load_sessions_closed = False
             self._load_session_lock = threading.Lock()
             self._opened_load_keys: list[str] = []
-            self._page_size_bytes = self._compute_page_size_bytes()
+            # Placeholder: block_len is empty at __init__ time (it is filled
+            # later in register_kv_caches), so _compute_page_size_bytes() would
+            # return 0 here. The real value is (re)computed in register_kv_caches
+            # once the kv-cache layout is known.
+            self._page_size_bytes = 0
 
         logger.info(
             "Layerwise mode enabled: num_layers=%d, prefetch_layers=%d%s",
@@ -2287,10 +2319,12 @@ class MooncakeStoreWorker:
                 continue
             for group_id in range(len(req_meta.block_ids)):
                 db = self.token_dbs[group_id]
-                put_step_rank = (self.tp_rank + group_id) % self._group_tp_replication_factors[group_id]
+                put_step = self._group_tp_replication_factors[group_id]
+                put_step_rank = (self.tp_rank + group_id) % put_step
                 for _, _, block_hash in db.process_tokens(
                     req_meta.token_len_chunk,
                     req_meta.block_hashes,
+                    put_step=put_step,
                     put_step_rank=put_step_rank,
                 ):
                     key = db.key_for(block_hash)
@@ -2300,6 +2334,10 @@ class MooncakeStoreWorker:
 
         if save_keys and self.kv_send_thread is not None:
             self.kv_send_thread.start_put_sessions(save_keys, object_size)
+        elif self.kv_send_thread is not None:
+            # No session phase this step — clear any stale active-key set so
+            # the range-put handler cannot reuse keys from a previous step.
+            self.kv_send_thread._active_put_keys = set()
 
         # ---- Collect load keys (deduplicated across requests) ----
         load_keys: list[str] = []
@@ -2488,6 +2526,12 @@ class MooncakeStoreWorker:
                 self.num_layers,
                 len(addrs),
             )
+            # block_len is only populated here, so the Session-API page size
+            # cannot be computed in __init__. Recompute it now that the kv-cache
+            # layout is known; otherwise object_size stays 0 and every
+            # batch_put_session_start fails (rc=-600).
+            if self._use_session_api:
+                self._page_size_bytes = self._compute_page_size_bytes()
 
         # Start transfer threads
         if self.can_put:
@@ -2563,6 +2607,20 @@ class MooncakeStoreWorker:
             return
 
         if self._layerwise_enabled:
+            # Backfill load_spec.token_len before starting sessions. It defaults
+            # to 0 and _start_layerwise_sessions() reads it to decide which
+            # blocks to lease via batch_get_session_start(); leaving it empty
+            # means no get session is opened and the later
+            # batch_get_into_multi_buffer_ranges returns rc=-600 for every key.
+            for req_meta in metadata.requests:
+                load_spec = req_meta.load_spec
+                if (
+                    load_spec is not None
+                    and load_spec.can_load
+                    and not load_spec.token_len
+                ):
+                    load_spec.token_len = load_spec.kvpool_cached_tokens
+
             self._start_layerwise_sessions(metadata.requests)
             self._build_layer_tasks_from_requests(metadata.requests)
         else:
@@ -2813,7 +2871,7 @@ class MooncakeStoreWorker:
             return
 
         # Submit up to prefetch_layers layers per call.
-        submit_count = self._num_prefetch_layers
+        submit_count = self._num_prefetch_layers if self._next_load_layer_to_submit == 0 else 1
         submitted = 0
 
         while (submitted < submit_count
@@ -2870,7 +2928,12 @@ class MooncakeStoreWorker:
                 event.set()
 
         # Last layer: wait for all saves to complete.
-        if layer_id == self._num_layers - 1:
+        # Guard: finalize only once per step. If save_kv_layer fires twice for
+        # the last layer (e.g. both the @maybe_transfer_kv_layer decorator and
+        # an explicit hook), the second call would otherwise hit the
+        # _reset_layer_state()-replaced events and hang in _wait_for_all_layer_saves.
+        if layer_id == self._num_layers - 1 and not self._save_finalized:
+            self._save_finalized = True
             self._wait_for_all_layer_saves()
             # Session API: release get-session leases now that all layers are done.
             self._close_load_sessions_once()
@@ -2935,6 +2998,7 @@ class MooncakeStoreWorker:
         self._current_save_layer = 0
         self._current_load_layer = 0
         self._next_load_layer_to_submit = 0
+        self._save_finalized = False
 
         for layer_id in range(self._num_layers):
             self._layer_save_tasks[layer_id] = []

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
@@ -44,6 +44,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.data import (  
     BlobBlockHashes,
     ChunkedTokenDatabase,
     KeyMetadata,
+    LayerTransferTask,
     MooncakeLookupResult,
     MooncakeStoreConnectorMetadata,
     MooncakeStoreWorkerMetadata,
@@ -90,6 +91,34 @@ DEFAULT_TENANT_ID = "default"
 
 MOONCAKE_NO_AVAILABLE_HANDLE = -200
 _T = TypeVar("_T")
+
+# Mooncake Session API methods (PR#2881) — used for capability detection.
+_MOONCAKE_SESSION_METHODS = (
+    "batch_put_session_start",
+    "batch_put_from_multi_buffer_ranges",
+    "batch_put_session_end",
+    "batch_put_session_revoke",
+    "batch_get_session_start",
+    "batch_get_into_multi_buffer_ranges",
+    "batch_get_session_end",
+)
+
+
+def _mooncake_supports_session_api(store: Any) -> bool:
+    """Return True if the Mooncake store exposes all Session API methods.
+
+    Uses ``hasattr`` (which maps to ``__getattr__`` + catch), not ``getattr``,
+    because the real Mooncake client will raise AttributeError for unknown
+    methods rather than silently returning None.
+    """
+    for method in _MOONCAKE_SESSION_METHODS:
+        try:
+            attr = getattr(store, method)
+        except Exception:
+            return False
+        if not callable(attr):
+            return False
+    return True
 
 
 def _rotate_list(values: list[_T], offset: int) -> list[_T]:
@@ -391,7 +420,13 @@ def _log_mooncake_load_tier_summary(
 
 
 class KVTransferThread(threading.Thread):
-    """Base class for async KV cache transfer threads."""
+    """Base class for async KV cache transfer threads.
+
+    Extended with layerwise support for per-layer KV cache transfer.
+    """
+
+    _num_layers: int = 0
+    _use_session_api: bool = False
 
     def __init__(
         self,
@@ -417,7 +452,29 @@ class KVTransferThread(threading.Thread):
         self.kv_event_lock = threading.Lock()
         self.kv_events: list[BlockStored] = []
 
-    def add_request(self, request: ReqMeta) -> None:
+        # Layerwise support
+        self._layerwise_enabled = False
+        self._layer_save_finished_events: dict[int, threading.Event] = {}
+        self._layer_load_finished_events: dict[int, threading.Event] = {}
+
+    def enable_layerwise(self, num_layers: int) -> None:
+        """Enable layerwise mode with specified number of layers."""
+        self._layerwise_enabled = True
+        self._num_layers = num_layers
+        for layer_id in range(num_layers):
+            self._layer_save_finished_events[layer_id] = threading.Event()
+            self._layer_load_finished_events[layer_id] = threading.Event()
+
+    def set_layer_finished_event(
+        self, layer_id: int, is_save: bool, event: threading.Event
+    ) -> None:
+        """Set the finished event for a specific layer."""
+        if is_save:
+            self._layer_save_finished_events[layer_id] = event
+        else:
+            self._layer_load_finished_events[layer_id] = event
+
+    def add_request(self, request: ReqMeta | LayerTransferTask) -> None:
         self.request_queue.put(request)
 
     def get_and_clear_finished_requests(self) -> set[str]:
@@ -539,6 +596,9 @@ class KVCacheStoreSendingThread(KVTransferThread):
         # Retained only after a failed store so retry events can recover the
         # token suffix without full snapshots on the normal path.
         self._retry_token_ids: dict[str, tuple[int, list[int]]] = {}
+
+        # Session API state
+        self._active_put_keys: set[str] | None = None
 
     def add_request(self, request: ReqMeta) -> None:
         # Register before enqueueing so a job is never picked up unledgered.
@@ -893,7 +953,244 @@ class KVCacheStoreSendingThread(KVTransferThread):
             )
         return True
 
-    def _handle_request(self, req_meta: ReqMeta):
+    def start_put_sessions(
+        self,
+        keys: list[str],
+        object_size: int,
+    ) -> None:
+        """Start put sessions for save keys (one Master RPC per batch).
+
+        Called by ``MooncakeStoreWorker._start_layerwise_sessions()`` before
+        per-layer tasks are constructed.  Once a session is open, subsequent
+        ``batch_put_from_multi_buffer_ranges()`` calls can write data at
+        layer offsets without additional Master communication.
+        """
+        if not self._use_session_api:
+            return
+        if not keys:
+            return
+
+        sizes = [object_size] * len(keys)
+        try:
+            results = self.store.batch_put_session_start(
+                keys, sizes, self.replicate_config
+            )
+        except Exception as exc:
+            logger.error("batch_put_session_start failed: %s", exc)
+            self._revoke_range_keys(keys)
+            return
+
+        failed = [k for k, r in zip(keys, results) if r != 0]
+        if failed:
+            logger.warning(
+                "batch_put_session_start failed for keys: %s", failed
+            )
+            self._revoke_range_keys(failed)
+
+    def _revoke_range_keys(self, keys: list[str]) -> None:
+        """Cancel unfinished put sessions (cleanup on failure)."""
+        if not keys:
+            return
+        try:
+            self.store.batch_put_session_revoke(keys)
+        except Exception as exc:
+            logger.error("batch_put_session_revoke failed: %s", exc)
+
+    def _handle_layer_task(self, task: LayerTransferTask) -> None:
+        """Legacy per-layer-key save path (Phase 1)."""
+        keys = task.key_list
+        addrs = task.addr_list
+        sizes = task.size_list
+
+        if not keys:
+            self.request_queue.task_done()
+            return
+
+        req_id = task.req_id
+        start_time = time.perf_counter()
+
+        try:
+            exist_mask = self.store.batch_is_exist(keys)
+
+            actual_keys = [k for k, e in zip(keys, exist_mask) if not e]
+            actual_addrs = [a for a, e in zip(addrs, exist_mask) if not e]
+            actual_sizes = [s for s, e in zip(sizes, exist_mask) if not e]
+
+            if actual_keys:
+                batch_put_start = time.perf_counter()
+                res = self.store.batch_put_from_multi_buffers(
+                    actual_keys, actual_addrs, actual_sizes
+                )
+
+                self._record_operation(
+                    "save_put_layer",
+                    batch_put_start,
+                    len(actual_keys),
+                    num_bytes=sum(sum(s) for s in actual_sizes),
+                    status="ok" if res else "error",
+                )
+
+                if not res:
+                    logger.error(
+                        "Layerwise save failed for layer %d, req %s",
+                        task.physical_layer_id,
+                        req_id,
+                    )
+
+            if self._layerwise_enabled:
+                layer_id = task.physical_layer_id
+                event = self._layer_save_finished_events.get(layer_id)
+                if event:
+                    event.set()
+
+            if task.physical_layer_id == self._num_layers - 1:
+                self.set_finished_request(req_id)
+
+        except Exception as e:
+            self._record_operation(
+                "save_put_layer",
+                start_time,
+                len(keys),
+                status="error",
+                num_failed_keys=len(keys),
+            )
+            logger.error(
+                "Layerwise save error for layer %d, req %s: %s",
+                task.physical_layer_id,
+                req_id,
+                e,
+            )
+        finally:
+            self.request_queue.task_done()
+
+    def _handle_layer_range_task(self, task: LayerTransferTask) -> None:
+        """Save a single layer via the Mooncake Session API.
+
+        Session lifecycle:
+        1. Layer 0: no extra work (session already open).
+        2. Layer 1..N-2: ``batch_put_from_multi_buffer_ranges`` (zero Master RPC).
+        3. Layer N-1 (last): ranges + ``batch_put_session_end`` to commit.
+        On per-key failure the failed keys are revoked and excluded from
+        subsequent layers.
+        """
+        keys = task.key_list
+        layer_id = task.physical_layer_id
+
+        if not keys:
+            self.request_queue.task_done()
+            return
+
+        req_id = task.req_id
+        start_time = time.perf_counter()
+
+        try:
+            # Init the active-key set on the first layer
+            if self._active_put_keys is None or layer_id == 0:
+                self._active_put_keys = set(keys)
+
+            # Only write keys whose session is still alive
+            active_indices = [
+                i for i, k in enumerate(keys)
+                if k in self._active_put_keys
+            ]
+            active_keys = [keys[i] for i in active_indices]
+
+            if active_keys:
+                results = self.store.batch_put_from_multi_buffer_ranges(
+                    active_keys,
+                    [task.addr_list[i] for i in active_indices],
+                    [task.size_list[i] for i in active_indices],
+                    [task.dst_offset_list[i] for i in active_indices],
+                )
+
+                self._record_operation(
+                    "save_put_ranges",
+                    start_time,
+                    len(active_keys),
+                    num_bytes=sum(
+                        sum(task.size_list[i]) for i in active_indices
+                    ),
+                    status="ok",
+                )
+
+                # Revoke failed keys — they are dropped from subsequent layers
+                failed_keys = [
+                    k for k, r in zip(active_keys, results) if r < 0
+                ]
+                if failed_keys:
+                    self._revoke_range_keys(failed_keys)
+                    self._active_put_keys.difference_update(failed_keys)
+                    logger.warning(
+                        "Layer %d save: %d/%d range-put keys failed, req=%s",
+                        layer_id,
+                        len(failed_keys),
+                        len(active_keys),
+                        req_id,
+                    )
+
+            # Last layer: commit all surviving sessions
+            if layer_id == self._num_layers - 1:
+                commit_keys = [
+                    k for k in keys if k in self._active_put_keys
+                ]
+                if commit_keys:
+                    try:
+                        commit_results = self.store.batch_put_session_end(
+                            commit_keys
+                        )
+                        failed_commit = [
+                            k
+                            for k, r in zip(commit_keys, commit_results)
+                            if r != 0
+                        ]
+                        if failed_commit:
+                            self._revoke_range_keys(failed_commit)
+                    except Exception as exc:
+                        logger.error(
+                            "batch_put_session_end failed: %s", exc
+                        )
+                        self._revoke_range_keys(commit_keys)
+
+                self._active_put_keys = None
+                self.set_finished_request(req_id)
+
+            # Signal layer completion
+            if self._layerwise_enabled:
+                event = self._layer_save_finished_events.get(layer_id)
+                if event:
+                    event.set()
+
+        except Exception as e:
+            self._record_operation(
+                "save_put_ranges",
+                start_time,
+                len(keys),
+                status="error",
+                num_failed_keys=len(keys),
+            )
+            logger.error(
+                "Session save error for layer %d, req %s: %s",
+                layer_id,
+                req_id,
+                e,
+            )
+            # On catastrophic failure, revoke all keys for this batch
+            self._revoke_range_keys(keys)
+            self._active_put_keys = None
+        finally:
+            self.request_queue.task_done()
+
+    def _handle_request(self, req_meta: ReqMeta | LayerTransferTask):
+        # ============================================================
+        # Layerwise support: dispatch to layer-specific handler
+        # ============================================================
+        if isinstance(req_meta, LayerTransferTask):
+            if req_meta.use_key_major_ranges and self._use_session_api:
+                self._handle_layer_range_task(req_meta)
+            else:
+                self._handle_layer_task(req_meta)
+            return
+
         # The single `finally` is the only way out, so the scheduler releases
         # this job's GPU block references however the job ends.
         save_completed = False
@@ -1233,6 +1530,45 @@ class KVCacheStoreRecvingThread(KVTransferThread):
         )
         self.coord = coord
 
+        # Session API state
+        self._active_load_indices: set[int] | None = None
+
+    def start_get_sessions(self, keys: list[str]) -> None:
+        """Start get sessions for load keys (one Master RPC).
+
+        Called by ``MooncakeStoreWorker._start_layerwise_sessions()``.
+        """
+        if not self._use_session_api:
+            return
+        if not keys:
+            return
+        try:
+            results = self.store.batch_get_session_start(keys)
+        except Exception as exc:
+            logger.error("batch_get_session_start failed: %s", exc)
+            try:
+                self.store.batch_get_session_end(keys)
+            except Exception:
+                pass
+            return
+        failed = [k for k, r in zip(keys, results) if r != 0]
+        if failed:
+            logger.warning(
+                "batch_get_session_start missed/errored keys: %s", failed
+            )
+
+    def end_get_sessions(self, keys: list[str]) -> None:
+        """Release get sessions (one shot per step).
+
+        Called by ``MooncakeStoreWorker._close_load_sessions_once()``.
+        """
+        if not self._use_session_api or not keys:
+            return
+        try:
+            self.store.batch_get_session_end(keys)
+        except Exception as exc:
+            logger.error("batch_get_session_end failed: %s", exc)
+
     def _add_load_error_block_ids(self, block_ids: list[int]) -> None:
         with self._invalid_block_ids_lock:
             self._invalid_block_ids.update(block_ids)
@@ -1243,7 +1579,181 @@ class KVCacheStoreRecvingThread(KVTransferThread):
             self._invalid_block_ids.clear()
         return invalid_block_ids
 
-    def _handle_request(self, req_meta: ReqMeta):
+    def _handle_layer_task(self, task: LayerTransferTask) -> None:
+        """Legacy per-layer-key load path (Phase 1)."""
+        keys = task.key_list
+        addrs = task.addr_list
+        sizes = task.size_list
+        block_ids = task.block_ids
+
+        if not keys:
+            self.request_queue.task_done()
+            return
+
+        req_id = task.req_id
+        layer_id = task.physical_layer_id
+
+        try:
+            load_start = time.perf_counter()
+            results = self.store.batch_get_into_multi_buffers(keys, addrs, sizes)
+
+            # Detect blocks that failed to load.
+            failed = [
+                (key, value, block_id)
+                for key, value, block_id in zip(keys, results, block_ids, strict=True)
+                if value < 0
+            ]
+
+            self._record_operation(
+                "load_get_layer",
+                load_start,
+                len(keys),
+                status="partial_failure" if failed else "ok",
+                num_failed_keys=len(failed),
+            )
+
+            if failed:
+                self._add_load_error_block_ids([block_id for _, _, block_id in failed])
+                logger.warning(
+                    "Layerwise load failed for layer %d, req %s: %d keys failed",
+                    layer_id,
+                    req_id,
+                    len(failed),
+                )
+
+            if self._layerwise_enabled:
+                event = self._layer_load_finished_events.get(layer_id)
+                if event:
+                    event.set()
+
+            if layer_id == self._num_layers - 1:
+                self.set_finished_request(req_id)
+
+        except Exception as e:
+            self._record_operation(
+                "load_get_layer",
+                time.perf_counter(),
+                len(keys),
+                status="error",
+                num_failed_keys=len(keys),
+            )
+            logger.error(
+                "Layerwise load error for layer %d, req %s: %s",
+                layer_id,
+                req_id,
+                e,
+            )
+        finally:
+            self.request_queue.task_done()
+
+    def _handle_layer_range_task(self, task: LayerTransferTask) -> None:
+        """Load a single layer via the Mooncake Session API.
+
+        Session lifecycle:
+        1. Layer 0: init active-index set (all keys start active).
+        2. Layer 1..N-2: ``batch_get_into_multi_buffer_ranges`` (zero Master RPC).
+        3. Layer N-1 (last): ranges + finalize request tracking.
+        On per-key failure the failed indices are marked as invalid and
+        excluded from subsequent layers.
+        """
+        keys = task.key_list
+        layer_id = task.physical_layer_id
+
+        if not keys:
+            self.request_queue.task_done()
+            return
+
+        req_id = task.req_id
+
+        try:
+            # Init active-index set on the first layer
+            if self._active_load_indices is None or layer_id == 0:
+                self._active_load_indices = set(range(len(keys)))
+
+            # Filter: only load indices whose get session is still alive
+            active_indices = [
+                i
+                for i in range(len(keys))
+                if i in self._active_load_indices
+            ]
+            active_keys = [keys[i] for i in active_indices]
+
+            if active_keys:
+                load_start = time.perf_counter()
+                results = self.store.batch_get_into_multi_buffer_ranges(
+                    active_keys,
+                    [task.addr_list[i] for i in active_indices],
+                    [task.size_list[i] for i in active_indices],
+                    [task.dst_offset_list[i] for i in active_indices],
+                )
+
+                self._record_operation(
+                    "load_get_ranges",
+                    load_start,
+                    len(active_keys),
+                    status="ok",
+                )
+
+                # Mark failed indices and drop them from subsequent layers
+                failed_indices = [
+                    i
+                    for i, r in zip(active_indices, results)
+                    if r < 0
+                ]
+                if failed_indices:
+                    self._add_load_error_block_ids(
+                        [task.block_ids[i] for i in failed_indices]
+                    )
+                    self._active_load_indices.difference_update(failed_indices)
+                    logger.warning(
+                        "Layer %d load: %d/%d range-get keys failed, req=%s",
+                        layer_id,
+                        len(failed_indices),
+                        len(active_keys),
+                        req_id,
+                    )
+
+            # Last layer: finalize the request
+            if layer_id == self._num_layers - 1:
+                self.set_finished_request(req_id)
+                self._active_load_indices = None
+
+            # Signal layer completion
+            if self._layerwise_enabled:
+                event = self._layer_load_finished_events.get(layer_id)
+                if event:
+                    event.set()
+
+        except Exception as e:
+            self._record_operation(
+                "load_get_ranges",
+                time.perf_counter(),
+                len(keys),
+                status="error",
+                num_failed_keys=len(keys),
+            )
+            logger.error(
+                "Session load error for layer %d, req %s: %s",
+                layer_id,
+                req_id,
+                e,
+            )
+            self._active_load_indices = None
+        finally:
+            self.request_queue.task_done()
+
+    def _handle_request(self, req_meta: ReqMeta | LayerTransferTask):
+        # ============================================================
+        # Layerwise support: dispatch to layer-specific handler
+        # ============================================================
+        if isinstance(req_meta, LayerTransferTask):
+            if req_meta.use_key_major_ranges:
+                self._handle_layer_range_task(req_meta)
+            else:
+                self._handle_layer_task(req_meta)
+            return
+
+        # Original non-layerwise handling (ReqMeta)
         token_len = req_meta.load_spec.token_len  # type: ignore[union-attr]
         req_id = req_meta.req_id
         mask_num = (
@@ -1417,6 +1927,8 @@ class KVCacheStoreRecvingThread(KVTransferThread):
 
 
 class MooncakeStoreWorker:
+
+    _use_session_api: bool = False
     """Worker-side component for MooncakeStoreConnector."""
 
     def __init__(
@@ -1640,6 +2152,44 @@ class MooncakeStoreWorker:
         ]
         self._init_lookup_key_prefixes()
 
+        # ============================================================
+        # Layerwise support
+        # ============================================================
+        self._layerwise_enabled = False
+        self._use_session_api = _mooncake_supports_session_api(self.store)
+        self._layer_save_tasks: dict[int, list[LayerTransferTask]] = {}
+        self._layer_load_tasks: dict[int, list[LayerTransferTask]] = {}
+        self._layer_save_finished_events: dict[int, threading.Event] = {}
+        self._layer_load_finished_events: dict[int, threading.Event] = {}
+        self._current_save_layer: int = 0
+        self._current_load_layer: int = 0
+        self._next_load_layer_to_submit: int = 0
+        self._num_prefetch_layers: int = 1
+
+        # Read layerwise parameters from the extra config.
+        kvc_extra = vllm_config.kv_transfer_config.kv_connector_extra_config
+        if kvc_extra:
+            self._layerwise_enabled = str(kvc_extra.get("use_layerwise", "False")).lower() == "true"
+            self._num_prefetch_layers = int(kvc_extra.get("layerwise_prefetch_layers", 1))
+
+        # Layerwise mode embeds KV load into the model forward pass.
+        # load_async (which reports finished_recving to the scheduler,
+        # expecting requests in WAITING_FOR_REMOTE_KVS) is incompatible
+        # with layerwise mode where requests enter RUNNING directly.
+        if self._layerwise_enabled:
+            self.load_async = False
+            if self._use_session_api:
+                logger.info(
+                    "Mooncake session API available, using ranged "
+                    "multi-buffer transfer for layerwise mode"
+                )
+            else:
+                logger.warning(
+                    "Mooncake session API not available, falling back "
+                    "to per-layer-key transfer for layerwise mode"
+                )
+            self._init_layerwise_config()
+
     def _spec_tp_replication_factor(self, spec: KVCacheSpec) -> int:
         if self.dcp_size > 1:
             return 1
@@ -1658,6 +2208,148 @@ class MooncakeStoreWorker:
         ):
             return self.tp_size
         return max(1, self.tp_size // self.num_kv_head)
+
+    def _init_layerwise_config(self) -> None:
+        """Initialize per-layer state (events, task lists, session API)."""
+        if not self._kv_cache_groups:
+            logger.warning("No KV cache groups configured for layerwise mode")
+            return
+
+        self._num_layers = self.num_layers  # Already set from model_config
+
+        self._layer_save_finished_events = {}
+        self._layer_load_finished_events = {}
+        self._layer_save_tasks = {}
+        self._layer_load_tasks = {}
+
+        for layer_id in range(self._num_layers):
+            self._layer_save_finished_events[layer_id] = threading.Event()
+            self._layer_load_finished_events[layer_id] = threading.Event()
+            self._layer_save_tasks[layer_id] = []
+            self._layer_load_tasks[layer_id] = []
+
+        if self._use_session_api:
+            self._load_sessions_closed = False
+            self._load_session_lock = threading.Lock()
+            self._opened_load_keys: list[str] = []
+            self._page_size_bytes = self._compute_page_size_bytes()
+
+        logger.info(
+            "Layerwise mode enabled: num_layers=%d, prefetch_layers=%d%s",
+            self._num_layers,
+            self._num_prefetch_layers,
+            ", session_api=True" if self._use_session_api else "",
+        )
+
+    def _compute_page_size_bytes(self) -> int:
+        """Compute the per-layer page size in bytes for Session API offset.
+
+        Uses the first group's ChunkedTokenDatabase.  When num_layers is set,
+        block_len is sliced by ``caches_per_layer = len(block_len) // num_layers``.
+        """
+        if not self.token_dbs:
+            return 0
+        db = self.token_dbs[0]
+        caches_per_layer = (
+            len(db.block_len) // max(1, db.num_layers) if db.num_layers > 0
+            else len(db.block_len)
+        )
+        if caches_per_layer == 0:
+            caches_per_layer = len(db.block_len)
+        return sum(db.block_len[:caches_per_layer])
+
+    def _start_layerwise_sessions(self, requests: list[ReqMeta]) -> None:
+        """Start put/get sessions before per-layer tasks are built.
+
+        Called from ``start_load_kv()`` *before* ``_build_layer_tasks_from_requests()``
+        so that subsequent per-layer ``batch_put_from_multi_buffer_ranges`` /
+        ``batch_get_into_multi_buffer_ranges`` calls operate on open sessions (zero
+        additional Master RPCs).
+
+        Put session:
+          Reserve object space on the store side via ``batch_put_session_start``.
+          The object size is ``page_size_bytes × num_layers`` — one linear region
+          with layer i at byte offset ``i × page_size_bytes``.
+
+        Get session:
+          Query replica location + acquire lease via ``batch_get_session_start``.
+        """
+        if not self._use_session_api:
+            return
+
+        object_size = self._page_size_bytes * self._num_layers
+
+        # ---- Collect save keys (deduplicated across requests) ----
+        save_keys: list[str] = []
+        save_keys_set: set[str] = set()
+        for req_meta in requests:
+            if not req_meta.can_save:
+                continue
+            for group_id in range(len(req_meta.block_ids)):
+                db = self.token_dbs[group_id]
+                put_step_rank = (self.tp_rank + group_id) % self._group_tp_replication_factors[group_id]
+                for _, _, block_hash in db.process_tokens(
+                    req_meta.token_len_chunk,
+                    req_meta.block_hashes,
+                    put_step_rank=put_step_rank,
+                ):
+                    key = db.key_for(block_hash)
+                    if key not in save_keys_set:
+                        save_keys.append(key)
+                        save_keys_set.add(key)
+
+        if save_keys and self.kv_send_thread is not None:
+            self.kv_send_thread.start_put_sessions(save_keys, object_size)
+
+        # ---- Collect load keys (deduplicated across requests) ----
+        load_keys: list[str] = []
+        load_keys_set: set[str] = set()
+        for req_meta in requests:
+            load_spec = req_meta.load_spec
+            if load_spec is None or not load_spec.can_load:
+                continue
+            mask_num = (
+                load_spec.vllm_cached_tokens
+                // self.block_size * self.block_size
+            )
+            for group_id in range(len(req_meta.block_ids)):
+                db = self.token_dbs[group_id]
+                for _, _, block_hash in db.process_tokens(
+                    load_spec.token_len,
+                    req_meta.block_hashes,
+                    mask_num,
+                ):
+                    key = db.key_for(block_hash)
+                    if key not in load_keys_set:
+                        load_keys.append(key)
+                        load_keys_set.add(key)
+
+        if load_keys:
+            for recv_thread in self.kv_recv_threads:
+                recv_thread.start_get_sessions(load_keys)
+            with self._load_session_lock:
+                self._opened_load_keys = load_keys
+                self._load_sessions_closed = False
+
+    def _close_load_sessions_once(self) -> None:
+        """Release all get sessions (one-shot per step).
+
+        Called at the end of the final layer's ``save_kv_layer``, after
+        ``_wait_for_all_layer_saves()`` and before ``_reset_layer_state()``.
+        At this point every layer has been loaded and saved, so the lease
+        can be released safely.
+        """
+        if not self._use_session_api:
+            return
+        with self._load_session_lock:
+            if self._load_sessions_closed:
+                return
+            self._load_sessions_closed = True
+            keys = list(self._opened_load_keys)
+
+        if keys:
+            for recv_thread in self.kv_recv_threads:
+                recv_thread.end_get_sessions(keys)
 
     def _compute_group_tp_replication_factors(self) -> tuple[int, ...]:
         """Return the number of byte-identical TP replicas per cache group.
@@ -1782,6 +2474,21 @@ class MooncakeStoreWorker:
             db.set_kv_caches_base_addr(addrs)
             db.set_block_len(block_lens)
 
+        # ============================================================
+        # Layerwise: set num_layers on each ChunkedTokenDatabase so
+        # prepare_values_for_layer() can extract the target layer's
+        # segment via block_len slicing.
+        # ============================================================
+        if self._layerwise_enabled and addrs and block_lens:
+            for db in self.token_dbs:
+                db.num_layers = self.num_layers
+            logger.info(
+                "Layerwise mode enabled with %d layers, %d segments, "
+                "using per-layer slicing for address calculation",
+                self.num_layers,
+                len(addrs),
+            )
+
         # Start transfer threads
         if self.can_put:
             ready_event_sending = threading.Event()
@@ -1800,6 +2507,16 @@ class MooncakeStoreWorker:
                 supports_group_ids=self._supports_group_ids,
                 record_operation=self._record_kv_connector_operation,
             )
+            # Enable layerwise mode in sending thread
+            if self._layerwise_enabled:
+                self.kv_send_thread.enable_layerwise(self._num_layers)
+                self.kv_send_thread._use_session_api = getattr(
+                    self, '_use_session_api', False
+                )
+                for layer_id in range(self._num_layers):
+                    self.kv_send_thread.set_layer_finished_event(
+                        layer_id, True, self._layer_save_finished_events[layer_id]
+                    )
             self.kv_send_thread.start()
 
         self.kv_recv_threads = []
@@ -1817,6 +2534,14 @@ class MooncakeStoreWorker:
                 record_operation=self._record_kv_connector_operation,
                 request_queue=self.recv_request_queue,
             )
+            # Enable layerwise mode in receiving thread
+            if self._layerwise_enabled:
+                recv_thread.enable_layerwise(self._num_layers)
+                recv_thread._use_session_api = self._use_session_api
+                for layer_id in range(self._num_layers):
+                    recv_thread.set_layer_finished_event(
+                        layer_id, False, self._layer_load_finished_events[layer_id]
+                    )
             recv_thread.name = f"KVCacheStoreRecvingThread-{i}"
             recv_thread.start()
             self.kv_recv_threads.append(recv_thread)
@@ -1828,31 +2553,36 @@ class MooncakeStoreWorker:
         )
 
     def start_load_kv(self, metadata: MooncakeStoreConnectorMetadata):
-        """Issue async loads.
+        """Start KV loads and, in layerwise mode, build per-layer tasks.
 
-        Runs after the forward launch on steps without sync loads
-        (SchedulerOutput.has_sync_kv_loads), keeping load submission off
-        the critical path while preserving compute-I/O overlap.
+        Non-layerwise path issues async loads. Layerwise path builds per-layer
+        save/load tasks here (before the model forward pass) so wait_for_layer_load()
+        and save_kv_layer() have tasks to consume during the forward pass.
         """
         if self._capacity_only:
             return
 
-        for request in metadata.requests:
-            load_spec = request.load_spec
-            if load_spec is None or not load_spec.can_load:
-                continue
-
-            load_spec.token_len = load_spec.kvpool_cached_tokens
-            self.recv_request_queue.put(request)
-
-        assert self.load_async, "load_async must be True for better performance."
+        if self._layerwise_enabled:
+            self._start_layerwise_sessions(metadata.requests)
+            self._build_layer_tasks_from_requests(metadata.requests)
+        else:
+            for request in metadata.requests:
+                load_spec = request.load_spec
+                if load_spec is None or not load_spec.can_load:
+                    continue
+                load_spec.token_len = load_spec.kvpool_cached_tokens
+                self.recv_request_queue.put(request)
+            assert self.load_async, "load_async must be True for better performance."
 
     def wait_for_save(self, metadata: MooncakeStoreConnectorMetadata):
-        """Issue async stores with CUDA event synchronization.
+        """Issue async stores (non-layerwise) or no-op (layerwise).
 
-        Runs after the forward launch for compute-I/O overlap.
+        Layerwise stores are issued per-layer from save_kv_layer().
         """
         if self._capacity_only or not self.can_put:
+            return
+
+        if self._layerwise_enabled:
             return
 
         current_event = None
@@ -1870,14 +2600,369 @@ class MooncakeStoreWorker:
             self.kv_send_thread.add_request(request)
 
     def get_finished(
-        self, finished_req_ids: set[str], meta: MooncakeStoreConnectorMetadata
+        self,
+        finished_req_ids: set[str],
+        meta: MooncakeStoreConnectorMetadata,
     ) -> tuple[set[str], set[str]]:
-        """Get completed send/recv request IDs.
+        """Collect completed send/recv request IDs.
 
-        Loads are issued in start_load_kv() and stores in wait_for_save().
+        Loads are issued in start_load_kv(); stores in wait_for_save() or, for
+        layerwise mode, in save_kv_layer(). Here we only collect completion.
         """
         if self._capacity_only:
             return set(), set()
+
+        if self.can_put:
+            self._close_ended_store_requests(finished_req_ids, meta)
+
+        # Blocks read by a store job are released by the scheduler when the job
+        # reports back (see build_connector_worker_meta), so no request ever waits
+        # on a `finished_sending` signal to get its blocks back.
+        done_sending: set[str] = set()
+        done_recving: set[str] = set()
+        if self.load_async:
+            for recv_thread in self.kv_recv_threads:
+                done_recving |= recv_thread.get_and_clear_finished_requests()
+
+        logger.debug(
+            "Completed send: %d, recv: %d, tp_rank: %d",
+            len(done_sending),
+            len(done_recving),
+            self.tp_rank,
+        )
+        return done_sending, done_recving
+
+    # ============================================================
+    # Layerwise KV Cache Methods (Phase 1)
+    # ============================================================
+
+    def _build_layer_tasks_from_requests(
+        self, requests: list[ReqMeta]
+    ) -> None:
+        """Build per-layer transfer tasks for each request.
+
+        Called from ``start_load_kv()`` before the model forward pass so that
+        ``wait_for_layer_load()`` and ``save_kv_layer()`` have tasks to consume.
+        """
+        if not self._layerwise_enabled:
+            return
+
+        # Clear tasks built for the previous step.
+        for layer_id in range(self._num_layers):
+            self._layer_save_tasks[layer_id] = []
+            self._layer_load_tasks[layer_id] = []
+
+        for req_meta in requests:
+            # Save path.
+            if req_meta.can_save:
+                # Skip tokens already saved (mirrors the legacy save path).
+                if hasattr(self.kv_send_thread, "_saved_offset"):
+                    save_start = self.kv_send_thread._saved_offset.get(
+                        req_meta.req_id, 0
+                    )
+                else:
+                    save_start = 0
+                lcm_block_size = self.coord.lcm_block_size
+                aligned_token_len = (
+                    req_meta.token_len_chunk // lcm_block_size * lcm_block_size
+                )
+                store_masks = self.coord.store_mask(
+                    aligned_token_len,
+                    save_start,
+                    num_prompt_tokens=req_meta.num_prompt_tokens,
+                )
+
+                for group_id, block_ids in enumerate(req_meta.block_ids):
+                    db = self.token_dbs[group_id]
+                    # Offset each group's chunk start so TP ranks spread evenly.
+                    put_step = self._group_tp_replication_factors[group_id]
+                    put_step_rank = (self.tp_rank + group_id) % put_step
+                    chunks_raw = list(db.process_tokens(
+                        req_meta.token_len_chunk,
+                        req_meta.block_hashes,
+                        mask_num=save_start,
+                        chunk_mask=store_masks[group_id],
+                        put_step=put_step,
+                        put_step_rank=put_step_rank,
+                    ))
+                    chunks: list[tuple[int, int]] = [(s, e) for s, e, _ in chunks_raw]
+                    chunk_hashes: list[BlockHash] = [bh for _, _, bh in chunks_raw]
+
+                    if not chunks:
+                        continue
+
+                    # Create one task per physical layer.
+                    for physical_layer_id in range(self._num_layers):
+                        if self._use_session_api:
+                            # Session API: block-level keys + per-layer offsets
+                            keys = [db.key_for_block(bh) for bh in chunk_hashes]
+                            addrs, sizes, offsets, block_ids_out = (
+                                db.prepare_values_for_layer_offset(
+                                    chunks, block_ids, physical_layer_id
+                                )
+                            )
+                        else:
+                            # Legacy: per-layer @layer:N keys
+                            keys = [db.key_for_layer(bh, physical_layer_id) for bh in chunk_hashes]
+                            addrs, sizes, block_ids_out = db.prepare_values_for_layer(
+                                chunks, block_ids, physical_layer_id
+                            )
+                            offsets = []
+
+                        task = LayerTransferTask(
+                            req_id=req_meta.req_id,
+                            group_id=group_id,
+                            layer_idx_in_group=physical_layer_id,
+                            physical_layer_id=physical_layer_id,
+                            key_list=keys,
+                            addr_list=addrs,
+                            size_list=sizes,
+                            dst_offset_list=offsets,
+                            block_ids=list(block_ids_out),
+                            is_save=True,
+                            use_key_major_ranges=self._use_session_api,
+                        )
+                        self._layer_save_tasks[physical_layer_id].append(task)
+
+            # Load path.
+            if req_meta.load_spec and req_meta.load_spec.can_load:
+                # Backfill token_len, mirroring the non-layerwise path in
+                # get_finished(). LoadSpec is created without token_len; in the
+                # non-layerwise path get_finished() fills it from
+                # kvpool_cached_tokens, but layerwise builds tasks here, before
+                # get_finished() runs.
+                if not req_meta.load_spec.token_len:
+                    req_meta.load_spec.token_len = req_meta.load_spec.kvpool_cached_tokens
+                mask_num = (
+                    req_meta.load_spec.vllm_cached_tokens
+                    // self.block_size
+                    * self.block_size
+                )
+                load_mask_per_group = self.coord.load_mask(
+                    req_meta.block_hashes, req_meta.load_spec.token_len
+                )
+
+                for group_id, block_ids in enumerate(req_meta.block_ids):
+                    db = self.token_dbs[group_id]
+                    mask = load_mask_per_group[group_id]
+                    chunks: list[tuple[int, int]] = []
+                    chunk_hashes: list[BlockHash] = []
+                    # actual_block_ids: per-chunk block ID for address calculation
+                    actual_block_ids: list[int] = []
+                    for start, end, block_hash in db.process_tokens(
+                        req_meta.load_spec.token_len,
+                        req_meta.block_hashes,
+                        mask_num,
+                    ):
+                        chunk_idx = start // db.block_size
+                        if chunk_idx >= len(mask) or not mask[chunk_idx]:
+                            continue
+                        chunks.append((start, end))
+                        chunk_hashes.append(block_hash)
+                        actual_block_ids.append(
+                            block_ids[chunk_idx] if chunk_idx < len(block_ids) else -1
+                        )
+
+                    if not chunks:
+                        continue
+
+                    for physical_layer_id in range(self._num_layers):
+                        if self._use_session_api:
+                            # Session API: block-level keys + per-layer offsets
+                            keys = [db.key_for_block(bh) for bh in chunk_hashes]
+                            addrs, sizes, offsets, block_ids_out = (
+                                db.prepare_values_for_layer_offset(
+                                    chunks, actual_block_ids, physical_layer_id
+                                )
+                            )
+                        else:
+                            # Legacy: per-layer @layer:N keys
+                            keys = [db.key_for_layer(bh, physical_layer_id) for bh in chunk_hashes]
+                            addrs, sizes, block_ids_out = db.prepare_values_for_layer(
+                                chunks, actual_block_ids, physical_layer_id
+                            )
+                            offsets = []
+
+                        # block_ids: the actual block ID for each chunk.
+                        block_ids: list[int] = list(block_ids_out)
+
+                        task = LayerTransferTask(
+                            req_id=req_meta.req_id,
+                            group_id=group_id,
+                            layer_idx_in_group=physical_layer_id,
+                            physical_layer_id=physical_layer_id,
+                            key_list=keys,
+                            addr_list=addrs,
+                            size_list=sizes,
+                            dst_offset_list=offsets,
+                            block_ids=block_ids,
+                            is_save=False,
+                            use_key_major_ranges=self._use_session_api,
+                        )
+                        self._layer_load_tasks[physical_layer_id].append(task)
+
+    def _submit_ready_layer_loads(self) -> None:
+        """Submit the next ready layers for loading (prefetch control).
+
+        While attention computes layer L, submit load tasks for the following
+        ``prefetch_layers`` layers. Tasks of the same layer are distributed
+        round-robin across recv threads so they never write the same GPU buffer
+        concurrently.
+        """
+        if not self._layerwise_enabled or not self.kv_recv_threads:
+            return
+
+        # Submit up to prefetch_layers layers per call.
+        submit_count = self._num_prefetch_layers
+        submitted = 0
+
+        while (submitted < submit_count
+               and self._next_load_layer_to_submit < self._num_layers):
+            layer_id = self._next_load_layer_to_submit
+            tasks = self._layer_load_tasks.get(layer_id, [])
+
+            if tasks:
+                for i, task in enumerate(tasks):
+                    # Round-robin: hand each task to a single recv thread.
+                    recv_thread = self.kv_recv_threads[
+                        i % len(self.kv_recv_threads)
+                    ]
+                    recv_thread.add_request(task)
+                submitted += 1
+
+            self._next_load_layer_to_submit += 1
+
+    def save_kv_layer(
+        self,
+        layer_name: str,
+        kv_layer: torch.Tensor,
+        attn_metadata: Any,
+    ) -> None:
+        """Save one layer's KV cache to the store.
+
+        Called by ``@maybe_transfer_kv_layer`` after that layer's attention
+        forward completes.
+        """
+        if not self._layerwise_enabled:
+            return
+
+        # Extract the layer index from layer_name.
+        from vllm.model_executor.models.utils import extract_layer_index
+        try:
+            layer_id = extract_layer_index(layer_name)
+        except Exception:
+            # Fallback: parse from layer_name string
+            if "model.layers" in layer_name:
+                layer_id = int(layer_name.split(".layers.")[1].split(".")[0])
+            else:
+                logger.warning("Cannot extract layer_id from %s", layer_name)
+                return
+
+        # Submit this layer's save tasks to the send thread.
+        tasks = self._layer_save_tasks.get(layer_id, [])
+        if tasks and self.kv_send_thread:
+            for task in tasks:
+                self.kv_send_thread.add_request(task)
+        elif not tasks:
+            # No save tasks (non-producer rank or cold start): mark complete.
+            event = self._layer_save_finished_events.get(layer_id)
+            if event is not None:
+                event.set()
+
+        # Last layer: wait for all saves to complete.
+        if layer_id == self._num_layers - 1:
+            self._wait_for_all_layer_saves()
+            # Session API: release get-session leases now that all layers are done.
+            self._close_load_sessions_once()
+            # Reset state for the next round of requests.
+            self._reset_layer_state()
+
+    def wait_for_layer_load(self, layer_name: str) -> None:
+        """Wait for one layer's KV cache to finish loading from the store.
+
+        Called by ``@maybe_transfer_kv_layer`` before that layer's attention
+        forward runs.
+        """
+        if not self._layerwise_enabled:
+            return
+
+        # Extract the layer index from layer_name.
+        from vllm.model_executor.models.utils import extract_layer_index
+        try:
+            layer_id = extract_layer_index(layer_name)
+        except Exception:
+            if "model.layers" in layer_name:
+                layer_id = int(layer_name.split(".layers.")[1].split(".")[0])
+            else:
+                logger.warning("Cannot extract layer_id from %s", layer_name)
+                return
+
+        # Submit prefetch tasks for the following layers.
+        self._submit_ready_layer_loads()
+
+        # No load tasks (cold start or full hit): mark complete directly.
+        tasks = self._layer_load_tasks.get(layer_id, [])
+        if not tasks:
+            event = self._layer_load_finished_events.get(layer_id)
+            if event is not None:
+                event.set()
+        else:
+            # Wait for this layer's load to complete.
+            event = self._layer_load_finished_events.get(layer_id)
+            if event is not None and not event.is_set():
+                if not event.wait(timeout=10.0):
+                    logger.warning("Timeout waiting for layer %d to load", layer_id)
+                # Not cleared here; _reset_layer_state() rebuilds all events.
+
+        self._current_load_layer += 1
+
+    def _wait_for_all_layer_saves(self) -> None:
+        """Wait for all layers' saves to complete."""
+        for layer_id in range(self._num_layers):
+            event = self._layer_save_finished_events.get(layer_id)
+            if event is not None:
+                if not event.wait(timeout=10.0):
+                    logger.warning("Timeout waiting for layer %d to save", layer_id)
+                # Not cleared here; _reset_layer_state() rebuilds all events.
+
+    def _reset_layer_state(self) -> None:
+        """Reset layerwise state for the next round of requests.
+
+        Re-create all event objects (instead of clear()) so a stale set()
+        from the previous round's transfer threads cannot be mistaken for the
+        current round's completion signal.
+        """
+        self._current_save_layer = 0
+        self._current_load_layer = 0
+        self._next_load_layer_to_submit = 0
+
+        for layer_id in range(self._num_layers):
+            self._layer_save_tasks[layer_id] = []
+            self._layer_load_tasks[layer_id] = []
+
+        for layer_id in range(self._num_layers):
+            self._layer_save_finished_events[layer_id] = threading.Event()
+            self._layer_load_finished_events[layer_id] = threading.Event()
+
+        # Re-sync the events to the transfer threads.
+        if self.kv_send_thread is not None and self.kv_send_thread._layerwise_enabled:
+            for layer_id in range(self._num_layers):
+                self.kv_send_thread.set_layer_finished_event(
+                    layer_id, True, self._layer_save_finished_events[layer_id]
+                )
+        for recv_thread in self.kv_recv_threads:
+            if recv_thread._layerwise_enabled:
+                for layer_id in range(self._num_layers):
+                    recv_thread.set_layer_finished_event(
+                        layer_id, False, self._layer_load_finished_events[layer_id]
+                    )
+
+        # Session API: reset one-shot guard so the next step can release
+        # its load sessions.
+        if self._use_session_api:
+            self._load_sessions_closed = False
+            self._opened_load_keys = []
+
 
         if self.can_put:
             self._close_ended_store_requests(finished_req_ids, meta)
@@ -1973,6 +3058,10 @@ class MooncakeStoreWorker:
         Checks across all rank-specific key namespaces that may be loaded. A
         hit covering all ``num_tokens`` is re-derived below the request end so
         the last token is recomputed for sampling.
+
+        In layerwise mode, every layer is stored independently under a
+        @layer:N key suffix.  A (group, hash) is "present" only when
+        ALL layers exist across ALL rank namespaces.
         """
         if self._capacity_only:
             return MooncakeLookupResult(0)
@@ -1981,7 +3070,8 @@ class MooncakeStoreWorker:
         if not block_hashes or token_len <= 0:
             return MooncakeLookupResult(0)
 
-        # Build per-(group, hash) candidate keys expanded across rank namespaces.
+        # Build per-(group, hash) candidate keys expanded across rank namespaces
+        # (and layers when layerwise).
         # candidate_meta stores the (group, hash_bytes) for key slice.
         candidate_keys: list[str] = []
         candidate_meta: list[tuple[int, bytes]] = []
@@ -2014,9 +3104,22 @@ class MooncakeStoreWorker:
                 h = group_hashes[chunk_id]
                 hash_hex = h.hex()
                 for key_prefix in key_prefixes:
-                    candidate_keys.append(
-                        PoolKey.build_key_string(key_prefix, hash_hex)
-                    )
+                    base_key = PoolKey.build_key_string(key_prefix, hash_hex)
+                    if self._layerwise_enabled:
+                        if self._use_session_api:
+                            # Session API: block-level key covers all layers.
+                            # A chunk is present when the block key exists
+                            # across ALL rank namespaces (no layer expansion).
+                            candidate_keys.append(base_key)
+                        else:
+                            # Query every layer: a chunk is present only when
+                            # ALL layers exist across ALL rank namespaces.
+                            for layer_id in range(self._num_layers):
+                                candidate_keys.append(
+                                    f"{base_key}@layer:{layer_id}"
+                                )
+                    else:
+                        candidate_keys.append(base_key)
                 candidate_meta.append((g_idx, bytes(h)))
 
         if not candidate_keys:
@@ -2044,10 +3147,14 @@ class MooncakeStoreWorker:
         # A (group, hash) is "present" only when every namespace that will be
         # loaded has it (per-group count: sharded groups need every rank's
         # shard, replicated groups one namespace per unique KV head).
+        # Layerwise non-session mode expands each key across layers, so the
+        # count is scaled by num_layers.
         exists_set = set()
         pos = 0
         for g_idx, hash_bytes in candidate_meta:
             count = len(self._lookup_key_prefixes[g_idx])
+            if self._layerwise_enabled and not self._use_session_api:
+                count *= self._num_layers
             if all(res[pos + j] == 1 for j in range(count)):
                 exists_set.add((g_idx, hash_bytes))
             pos += count

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
@@ -3083,7 +3083,9 @@ class MooncakeStoreWorker:
             event = self._layer_load_finished_events.get(layer_id)
             if event is not None and not event.is_set():
                 if not event.wait(timeout=10.0):
-                    logger.warning("Timeout waiting for layer %d to load", layer_id)
+                    raise RuntimeError(
+                        f"Timeout waiting for layer {layer_id} KV cache load"
+                    )
             if event is not None:
                 event.clear()
 


### PR DESCRIPTION

## Purpose
### What this PR does
This PR implements [RFC #51930](https://github.com/vllm-project/vllm/issues/51930) — layerwise (per-layer) KV cache transfer for the Mooncake store connector, reusing vLLM's existing layerwise infrastructure (`@maybe_transfer_kv_layer` decorator) to pipeline KV load/save with per-layer attention computation, and integrating the **Mooncake Session API** (https://github.com/kvcache-ai/Mooncake/pull/2881) to eliminate the key-explosion problem.
Specifically:

1. **Per-layer task construction & dispatch** — At each scheduler step, per-layer `LayerTransferTask` objects are pre-built for every active request. During the forward pass, the `@maybe_transfer_kv_layer` decorator drives the pipeline: `wait_for_layer_load(layer.i)` → attention forward → `save_kv_layer(layer.i)`, per layer, with per-layer `threading.Event` synchronization. The last layer's `save_kv_layer()` waits for all layer saves to complete.

2. **Session API integration (key explosion fix)** — Instead of encoding the layer index into the key, each KV block keeps a **single content-hash key**, and its data is stored as one contiguous page covering all layers. Per-layer read/write is addressed by a byte offset `layer_id × page_size_bytes + segment_offset` via the Session API's range-based operations. This restores the O(M) key space, dramatically reducing lookup and master overhead.

### Key design points

- **No scheduler / engine / model-execution changes** — the PR implements the layerwise hooks entirely inside the Mooncake store connector, reusing `@maybe_transfer_kv_layer`. (The one exception is `MooncakeStoreScheduler` forcing `load_async = False`, see below.)
- **Requires PIECEWISE cudagraph** — layerwise hooks contain blocking Python synchronization that cannot be captured in monolithic CUDA graphs, so `requires_piecewise_for_cudagraph()` signals the framework to use PIECEWISE capture when layerwise mode is on.
- **`load_async` disabled** — layerwise mode embeds KV load into the forward pass (requests enter RUNNING directly); the async-load path (which moves requests to `WAITING_FOR_REMOTE_KVS`) is incompatible and is disabled.

## Changed Files
#### `mooncake/store/worker.py`
The bulk of the implementation. Adds:

- **`KVCacheStoreSendingThread` (save path)**:
  - `start_put_sessions(keys, object_size)` — `batch_put_session_start` to reserve object space before the forward.
  - `_revoke_range_keys(keys)` — `batch_put_session_revoke` for failed/partial puts.
  - `_handle_layer_range_task()` — Session-API save: layers `0..N-2` do `batch_put_from_multi_buffer_ranges` at layer offsets; layer `N-1` additionally calls `batch_put_session_end` to commit.
  - `_handle_layer_task()` — legacy per-layer-key save path: save kv cache via `batch_put_from_multi_buffers` without mooncake session API; on the last layer marks the request finished.
- **`KVCacheStoreRecvingThread` (load path)**:
  - `start_get_sessions(keys)` / `end_get_sessions(keys)` — open/close get sessions.
  - `_handle_layer_range_task()` — Session-API load via `batch_get_into_multi_buffer_ranges`;
  - `_handle_layer_task()` — legacy per-layer-key load path: `batch_get_into_multi_buffers` pulls the layer's KV; signals the per-layer load-finished event and finalizes the request on the last layer.
- **`MooncakeStoreWorker`**:
  - `_init_layerwise_config()` — per-layer task/event initialization, page-size computation, Session API state.
  - `_start_layerwise_sessions()` — collect deduplicated save/load keys, open put/get sessions before task construction.
  - `_build_layer_tasks_from_requests()` — build per-layer `LayerTransferTask`s for save and load.
  - `save_kv_layer()` / `wait_for_layer_load()` — per-layer dispatch driven by `@maybe_transfer_kv_layer`; last-layer barrier waits for all saves, closes get sessions, resets state.
  - `_wait_for_all_layer_saves()` / `_reset_layer_state()` / `_close_load_sessions_once()` — synchronization and cleanup.

#### `mooncake/store/data.py` 

- **`key_for_layer(hash, layer_id)`** — legacy per-layer key (`...@layer:N`).
- **`key_for_block(hash)`** — Session-API block-level key (no layer suffix).
- **`prepare_values_for_layer(chunks, block_ids, layer_id)`** — compute per-layer memory addresses via `block_len` slicing.
- **`prepare_values_for_layer_offset(chunks, block_ids, layer_id)`** — compute per-layer addresses, sizes, **byte offsets** (`layer_id × page_size_bytes + segment_offset`), and block IDs (Session API path).
- **`LayerTransferTask`** — per-layer transfer task data structure.

#### `mooncake/store/connector.py`

- **`start_load_kv()`** — builds per-layer tasks before the model forward when layerwise mode is on (was a no-op).
- **`wait_for_layer_load()` / `save_kv_layer()`** — forward per-layer hooks to the worker.
- **`_layerwise_enabled`** property and **`requires_piecewise_for_cudagraph()`** — signals PIECEWISE cudagraph requirement.

#### `mooncake/store/scheduler.py` 

- **Disable `load_async` in layerwise mode** — layerwise embeds KV load into forward pass; requests must enter RUNNING directly, so the async-load path (`WAITING_FOR_REMOTE_KVS`) is skipped.


## Test Plan

```
.venv/bin/python -m pytest tests/v1/kv_connector/unit/test_mooncake_store_layerwise.py -v
```

## Test Result

```
collecting ... collected 28 items

tests/v1/kv_connector/unit/test_mooncake_store_layerwise.py::TestSubmitReadyLayerLoads::test_round_robin_across_recv_threads PASSED [  3%]
tests/v1/kv_connector/unit/test_mooncake_store_layerwise.py::TestLayerwiseStateReset::test_reset_creates_new_events PASSED [  7%]
tests/v1/kv_connector/unit/test_mooncake_store_layerwise.py::TestLayerwiseStateReset::test_reset_syncs_events_to_threads PASSED [ 10%]
tests/v1/kv_connector/unit/test_mooncake_store_layerwise.py::TestSaveKvLayer::test_save_kv_layer_submits_tasks_to_send_thread PASSED [ 14%]
tests/v1/kv_connector/unit/test_mooncake_store_layerwise.py::TestSaveKvLayer::test_save_kv_layer_last_layer_triggers_reset PASSED [ 17%]
tests/v1/kv_connector/unit/test_mooncake_store_layerwise.py::TestWaitForLayerLoad::test_wait_for_layer_load_submits_prefetch PASSED [ 21%]
tests/v1/kv_connector/unit/test_mooncake_store_layerwise.py::TestWaitForLayerLoad::test_wait_for_layer_load_prefetch_advances_counter PASSED [ 25%]
tests/v1/kv_connector/unit/test_mooncake_store_layerwise.py::TestLayerwiseSendHandleLayerTask::test_send_handle_request_puts_to_store PASSED [ 28%]
tests/v1/kv_connector/unit/test_mooncake_store_layerwise.py::TestLayerwiseSendHandleLayerTask::test_send_handle_request_skips_existing_keys PASSED [ 32%]
tests/v1/kv_connector/unit/test_mooncake_store_layerwise.py::TestLayerwiseRecvHandleLayerTask::test_recv_handle_request_gets_from_store PASSED [ 35%]
tests/v1/kv_connector/unit/test_mooncake_store_layerwise.py::TestLayerwiseRecvHandleLayerTask::test_recv_handle_request_load_failure_tracks_block_ids PASSED [ 39%]
tests/v1/kv_connector/unit/test_mooncake_store_layerwise.py::TestSaveKvLayerIntegration::test_save_flow_integration PASSED [ 42%]
tests/v1/kv_connector/unit/test_mooncake_store_layerwise.py::TestLoadFlowIntegration::test_load_flow_integration PASSED [ 46%]
tests/v1/kv_connector/unit/test_mooncake_store_layerwise.py::TestLoadFlowIntegration::test_load_failure_propagates_to_worker PASSED [ 50%]
tests/v1/kv_connector/unit/test_mooncake_store_layerwise.py::TestSendingThreadSessionApi::test_start_put_sessions_calls_batch_put_session_start PASSED [ 53%]
tests/v1/kv_connector/unit/test_mooncake_store_layerwise.py::TestSendingThreadSessionApi::test_start_put_sessions_partial_failure_revokes PASSED [ 57%]
tests/v1/kv_connector/unit/test_mooncake_store_layerwise.py::TestSendingThreadSessionApi::test_handle_request_dispatches_session_path PASSED [ 60%]
tests/v1/kv_connector/unit/test_mooncake_store_layerwise.py::TestSendingThreadSessionApi::test_handle_request_session_revokes_failed_keys PASSED [ 64%]
tests/v1/kv_connector/unit/test_mooncake_store_layerwise.py::TestSendingThreadSessionApi::test_handle_request_session_last_layer_commits PASSED [ 67%]
tests/v1/kv_connector/unit/test_mooncake_store_layerwise.py::TestRecvingThreadSessionApi::test_start_get_sessions_calls_batch_get_session_start PASSED [ 71%]
tests/v1/kv_connector/unit/test_mooncake_store_layerwise.py::TestRecvingThreadSessionApi::test_end_get_sessions_calls_batch_get_session_end PASSED [ 75%]
tests/v1/kv_connector/unit/test_mooncake_store_layerwise.py::TestRecvingThreadSessionApi::test_handle_request_dispatches_session_path PASSED [ 78%]
tests/v1/kv_connector/unit/test_mooncake_store_layerwise.py::TestRecvingThreadSessionApi::test_handle_request_session_tracks_failures PASSED [ 82%]
tests/v1/kv_connector/unit/test_mooncake_store_layerwise.py::TestRecvingThreadSessionApi::test_handle_request_session_last_layer_finalizes PASSED [ 85%]
tests/v1/kv_connector/unit/test_mooncake_store_layerwise.py::TestWorkerSessionApiIntegration::test_start_layerwise_sessions_starts_put_and_get PASSED [ 89%]
tests/v1/kv_connector/unit/test_mooncake_store_layerwise.py::TestWorkerSessionApiIntegration::test_close_load_sessions_once_idempotent PASSED [ 92%]
tests/v1/kv_connector/unit/test_mooncake_store_layerwise.py::TestBuildLayerTasksSessionApi::test_session_api_save_task_uses_block_key PASSED [ 96%]
tests/v1/kv_connector/unit/test_mooncake_store_layerwise.py::TestBuildLayerTasksSessionApi::test_session_api_load_task_has_offsets PASSED [100%]

======================= 28 passed, 16 warnings in 52.80s =======================
```

The 16 warnings are pre-existing `DeprecationWarning`s (torch.jit / SwigPy) from the
test environment, unrelated to this change.

## Co-author
@LCAIZJ 