### PR TITLE
[Bugfix] Release worker RPC payload before next dequeue

### DIFF
--- a/tests/v1/executor/test_multiproc_executor.py
+++ b/tests/v1/executor/test_multiproc_executor.py
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import weakref
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from vllm.v1.executor.multiproc_executor import WorkerProc
+
+
+class _ExitWorkerLoop(RuntimeError):
+    pass
+
+
+class _RpcPayload:
+    pass
+
+
+class _PayloadLifetimeCheckingQueue:
+    def __init__(self) -> None:
+        self.payload_ref: weakref.ReferenceType[_RpcPayload] | None = None
+        self.dequeue_count = 0
+
+    def dequeue(self, *, indefinite: bool):
+        assert indefinite
+        self.dequeue_count += 1
+        if self.dequeue_count == 1:
+            payload = _RpcPayload()
+            self.payload_ref = weakref.ref(payload)
+            return "consume", (payload,), {}, None
+
+        assert self.payload_ref is not None
+        assert self.payload_ref() is None
+        raise _ExitWorkerLoop
+
+
+def test_worker_rpc_payload_released_before_next_dequeue():
+    queue = _PayloadLifetimeCheckingQueue()
+    worker_proc: Any = WorkerProc.__new__(WorkerProc)
+    worker_proc.rpc_broadcast_mq = queue
+    worker_proc.rank = 0
+    worker_proc.worker = SimpleNamespace(consume=lambda payload: payload)
+    worker_proc.handle_output = lambda output: None
+
+    with pytest.raises(_ExitWorkerLoop):
+        worker_proc.worker_busy_loop()
+
+    assert queue.dequeue_count == 2
+
+
+def test_execute_worker_rpc_returns_worker_exception():
+    def fail():
+        raise RuntimeError("test error")
+
+    worker_proc: Any = WorkerProc.__new__(WorkerProc)
+    worker_proc.rank = 0
+    worker_proc.worker = SimpleNamespace(fail=fail)
+    outputs: list[Any] = []
+    worker_proc.handle_output = outputs.append
+
+    worker_proc._execute_worker_rpc(("fail", (), {}, None))
+
+    assert len(outputs) == 1
+    assert isinstance(outputs[0], RuntimeError)
+    assert str(outputs[0]) == "test error"

--- a/vllm/v1/executor/multiproc_executor.py
+++ b/vllm/v1/executor/multiproc_executor.py
@@ -1013,28 +1013,33 @@ class WorkerProc:
         """Main busy loop for Multiprocessing Workers"""
         assert self.rpc_broadcast_mq is not None
         while True:
-            method, args, kwargs, output_rank = self.rpc_broadcast_mq.dequeue(
-                indefinite=True
-            )
-            try:
-                if isinstance(method, str):
-                    func = getattr(self.worker, method)
-                elif isinstance(method, bytes):
-                    func = partial(cloudpickle.loads(method), self.worker)
+            self._execute_worker_rpc(self.rpc_broadcast_mq.dequeue(indefinite=True))
 
-                output = func(*args, **kwargs)
+    def _execute_worker_rpc(
+        self,
+        rpc_request: tuple[str | bytes, tuple[Any, ...], dict[str, Any], int | None],
+    ) -> None:
+        """Execute one RPC in a separate frame from the dequeue loop."""
+        method, args, kwargs, output_rank = rpc_request
+        try:
+            if isinstance(method, str):
+                func = getattr(self.worker, method)
+            elif isinstance(method, bytes):
+                func = partial(cloudpickle.loads(method), self.worker)
 
-                if output_rank is None or self.rank == output_rank:
-                    self.handle_output(output)
-            except Exception as e:
-                # Notes have been introduced in python 3.11
-                if hasattr(e, "add_note"):
-                    e.add_note(traceback.format_exc())
-                logger.exception("WorkerProc hit an exception.")
-                # exception might not be serializable, so we convert it to
-                # string, only for logging purpose.
-                if output_rank is None or self.rank == output_rank:
-                    self.handle_output(e)
+            output = func(*args, **kwargs)
+
+            if output_rank is None or self.rank == output_rank:
+                self.handle_output(output)
+        except Exception as e:
+            # Notes have been introduced in python 3.11
+            if hasattr(e, "add_note"):
+                e.add_note(traceback.format_exc())
+            logger.exception("WorkerProc hit an exception.")
+            # enqueue_output converts the exception to a FAILURE response
+            # containing its string representation before transport.
+            if output_rank is None or self.rank == output_rank:
+                self.handle_output(e)
 
     @staticmethod
     def setup_proc_title_and_log_prefix(enable_ep: bool) -> None:


### PR DESCRIPTION
## Summary

Fixes #43639 by executing each worker RPC in a separate stack frame. This
releases the deserialized request arguments and local output reference before
the next `MessageQueue.dequeue()` deserializes another request, without adding
a full `gc.collect()` to the RPC hot path.

The existing exception-to-worker-response behavior is preserved.

## Why this approach

The previous loop retains `method`, `args`, `kwargs`, and `output` while the
next request is being dequeued. For RPCs containing CPU tensors, that makes two
deserialized payloads overlap in lifetime and raises the transient CPU memory
high-water mark.

Moving one RPC iteration into `_execute_worker_rpc()` gives those references a
shorter, deterministic lifetime. A weak-reference regression test verifies
that the first payload has been released at the instant the second dequeue
begins.

This does not duplicate an open PR. I checked both `43639 in:body` and worker
RPC/deserialization memory-leak keywords. The earlier PR #45248 is closed and
used per-request `gc.collect()`, while this change avoids forcing global GC in
the hot path and uses deterministic lifetime coverage instead of an RSS
threshold.

## Tests

```text
pytest tests/v1/executor/test_multiproc_executor.py
2 passed

ruff check vllm/v1/executor/multiproc_executor.py \
  tests/v1/executor/test_multiproc_executor.py
All checks passed

ruff format --check vllm/v1/executor/multiproc_executor.py \
  tests/v1/executor/test_multiproc_executor.py
2 files already formatted

mypy --follow-imports=skip --ignore-missing-imports \
  vllm/v1/executor/multiproc_executor.py \
  tests/v1/executor/test_multiproc_executor.py
Success: no issues found in 2 source files
```

The lifetime comparison also reports:

```text
unpatched: payload alive when the next dequeue starts = true
patched:   payload alive when the next dequeue starts = false
```

## T4 performance A/B

I ran an alternating `baseline -> patched -> baseline -> patched` offline
throughput comparison on one NVIDIA Tesla T4. Both variants used the same
container, PyTorch/CUDA stack, FP16 Qwen3-MoE-derived 0.8B test model, random
seed, and benchmark arguments. The only changed mounted file was
`multiproc_executor.py`.

Configuration:

```text
vLLM 0.18.0 performance container
1x NVIDIA Tesla T4 (15 GiB)
64 requests per measured run
64 input tokens + 32 output tokens per request
FP16, TP=1, max_num_seqs=64
TRITON_ATTN, eager mode, seed=1234
```

| Run | Baseline total tok/s | Patched total tok/s | Paired delta |
| --- | ---: | ---: | ---: |
| 1 | 118.226 | 118.116 | -0.093% |
| 2 | 118.203 | 118.327 | +0.105% |
| Mean | 118.215 | 118.222 | +0.006% |

Mean inference time was 51.973 s for baseline and 51.970 s for patched over
6,144 tokens per run. No throughput regression was observed; the paired
variation is approximately +/-0.1%.

For transparency, this was a controlled performance-only A/B in an available
vLLM 0.18.0 CUDA image, with the same method-level change transplanted onto
that code path. The correctness and lifetime tests above were run against this
PR's latest-main checkout. No model evaluation is applicable because the
change does not affect model outputs or numerical execution.

## AI assistance

OpenAI Codex assisted with investigation, implementation, and test drafting.
I reviewed the resulting change and the validation described above.
