### PR TITLE
[Bugfix] Run DP dummy forward on every zero-token rank

### DIFF
--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -4314,18 +4314,17 @@ class GPUModelRunner(
                     return make_empty_encoder_model_runner_output(scheduler_output)
 
             if not num_scheduled_tokens:
-                if (
-                    self.parallel_config.distributed_executor_backend
-                    == "external_launcher"
-                    and self.parallel_config.data_parallel_size > 1
-                ):
-                    # this is a corner case when both external launcher
-                    # and DP are enabled, num_scheduled_tokens could be
-                    # 0, and has_unfinished_requests in the outer loop
-                    # returns True. before returning early here we call
-                    # dummy run to ensure coordinate_batch_across_dp
-                    # is called into to avoid out of sync issues.
-                    self._dummy_run(1)
+                if self.parallel_config.data_parallel_size > 1:
+                    # Extend #44601 to all DP ranks (MoRI disagg is not
+                    # external_launcher; headless decode ranks still need B).
+                    coordinate_batch_across_dp(
+                        num_tokens_unpadded=0,
+                        parallel_config=self.parallel_config,
+                        allow_microbatching=True,
+                        num_tokens_padded=0,
+                        uniform_decode=False,
+                        cudagraph_mode=CUDAGraphMode.NONE.value,
+                    )
                 if not has_kv_transfer_group():
                     # Return empty ModelRunnerOutput if no work to do.
                     return EMPTY_MODEL_RUNNER_OUTPUT
@@ -5953,6 +5952,21 @@ class GPUModelRunner(
                 of max_query_len. Used to profile attention workspace that
                 scales with context length.
         """
+        if (
+            uniform_decode
+            and num_tokens == getattr(self, "uniform_decode_query_len", 1)
+            and self.parallel_config.data_parallel_size > 1
+        ):
+            coordinate_batch_across_dp(
+                num_tokens_unpadded=0,
+                parallel_config=self.parallel_config,
+                allow_microbatching=True,
+                num_tokens_padded=0,
+                uniform_decode=False,
+                cudagraph_mode=CUDAGraphMode.NONE.value,
+            )
+            return torch.tensor([]), torch.tensor([])
+
         mm_config = self.vllm_config.model_config.multimodal_config
         if mm_config and mm_config.mm_encoder_only:
             # The current dummy run only covers LM execution, so we can skip it.


### PR DESCRIPTION
## Purpose

With `data_parallel_size > 1` and expert parallel enabled, only one DP rank may hold tokens on a given step while others schedule zero tokens. Idle ranks currently return early from `execute_model` unless `distributed_executor_backend == "external_launcher"`. Multiproc and disaggregated WideEP deployments use a different backend, so idle ranks skip the dummy forward, miss per-layer EP collectives, and the busy rank deadlocks in all2all.

This change runs `_dummy_run(1)` on every zero-token step when `data_parallel_size > 1`, so all ranks stay in lockstep.

## Changes

`vllm/v1/worker/gpu_model_runner.py` (`execute_model`) only:

* Replace the `external_launcher` gate with `data_parallel_size > 1` before calling `_dummy_run(1)` on zero-token steps.
* Keep the existing early return after the dummy forward (empty output / KV connector no-forward paths unchanged).

No engine, connector, scheduler, or harness changes.

## Test Plan

MoRIIO **2P2D wide-EP** (DP16, WRITE) disaggregated serving, `ROUTER_TYPE=proxy`, `RUN_AFTER_HEALTH=accuracy`, image `vllm/vllm-openai-rocm:nightly`.

### MiniMax-M3-MXFP8 — 2P2D wide-EP DP16

```bash
export VLLM_ROCM_USE_AITER=1
export VLLM_ROCM_USE_AITER_MOE=1
export VLLM_ROCM_USE_AITER_RMSNORM=1
export VLLM_DP_DISABLE_BATCH_QUEUE=1
export ALL2ALL_BACKEND=allgather_reducescatter

# PREFILL — master (node0, DP ranks 0–7)
vllm serve /data/models2/MiniMax-M3-MXFP8 \
    --host $PREFILL_IP --port 20005 -tp 1 \
    --data-parallel-size 16 \
    --data-parallel-size-local 8 \
    --data-parallel-address $PREFILL_IP \
    --data-parallel-rpc-port 13345 \
    --enable-expert-parallel \
    --all2all-backend allgather_reducescatter \
    --trust-remote-code \
    --attention-backend TRITON_ATTN \
    --block-size 128 \
    --language-model-only \
    --kv-cache-dtype fp8 \
    --gpu-memory-utilization 0.85 \
    --enforce-eager \
    --no-async-scheduling \
    --no-disable-nccl-for-dp-synchronization \
    --kv-transfer-config '{"kv_connector":"MoRIIOConnector","kv_role":"kv_producer","kv_port":"9711",
      "kv_connector_extra_config":{"proxy_ip":"'$PREFILL_IP'","proxy_port":"10001",
      "proxy_ping_port":"36367","http_port":"20005","local_ping_port":"61555",
      "handshake_port":"6301","notify_port":"61005"}}'

# PREFILL — child (node1, headless, DP ranks 8–15)
vllm serve /data/models2/MiniMax-M3-MXFP8 \
    -tp 1 \
    --data-parallel-size 16 \
    --data-parallel-size-local 8 \
    --data-parallel-address $PREFILL_IP \
    --data-parallel-rpc-port 13345 \
    --data-parallel-start-rank 8 \
    --headless \
    --enable-expert-parallel \
    --all2all-backend allgather_reducescatter \
    --trust-remote-code \
    --attention-backend TRITON_ATTN \
    --block-size 128 \
    --language-model-only \
    --kv-cache-dtype fp8 \
    --gpu-memory-utilization 0.85 \
    --enforce-eager \
    --no-async-scheduling

# DECODE — master (node2, DP ranks 0–7)
vllm serve /data/models2/MiniMax-M3-MXFP8 \
    --host $DECODE_IP --port 20005 -tp 1 \
    --data-parallel-size 16 \
    --data-parallel-size-local 8 \
    --data-parallel-address $DECODE_IP \
    --data-parallel-rpc-port 13345 \
    --enable-expert-parallel \
    --all2all-backend allgather_reducescatter \
    --trust-remote-code \
    --attention-backend TRITON_ATTN \
    --block-size 128 \
    --language-model-only \
    --kv-cache-dtype fp8 \
    --gpu-memory-utilization 0.85 \
    --no-async-scheduling \
    --no-disable-nccl-for-dp-synchronization \
    --kv-transfer-config '{"kv_connector":"MoRIIOConnector","kv_role":"kv_consumer","kv_port":"9711",
      "kv_connector_extra_config":{"proxy_ip":"'$PREFILL_IP'","proxy_port":"10001",
      "proxy_ping_port":"36367","http_port":"20005","local_ping_port":"61555",
      "handshake_port":"6301","notify_port":"61005"}}'

# DECODE — child (node3, headless, DP ranks 8–15)
vllm serve /data/models2/MiniMax-M3-MXFP8 \
    -tp 1 \
    --data-parallel-size 16 \
    --data-parallel-size-local 8 \
    --data-parallel-address $DECODE_IP \
    --data-parallel-rpc-port 13345 \
    --data-parallel-start-rank 8 \
    --headless \
    --enable-expert-parallel \
    --all2all-backend allgather_reducescatter \
    --trust-remote-code \
    --attention-backend TRITON_ATTN \
    --block-size 128 \
    --language-model-only \
    --kv-cache-dtype fp8 \
    --gpu-memory-utilization 0.85 \
    --no-async-scheduling
```

### GSM8K evaluation

```bash
lm_eval --model local-completions \
    --tasks gsm8k \
    --model_args "model=/data/models2/MiniMax-M3-MXFP8,base_url=http://127.0.0.1:10001/v1/completions,num_concurrent=64,max_retries=3,tokenized_requests=False,trust_remote_code=True,timeout=7200" \
    --limit 250
```

## Test Result

MiniMax-M3-MXFP8, MoRIIO 2P2D wide-EP DP16 (proxy). GSM8K flexible-extract, threshold 0.80.

| Variant | Health | GSM8K exact_match |
| --- | --- | --- |
| No fix (idle ranks skip dummy forward on multiproc DP) | Fail (gloo / EP deadlock) | — |
| This fix | Pass | **0.8125** (PASS) |
