### PR TITLE
[Core] Add configurable load-balancing strategy to EPLB

### DIFF
--- a/docs/serving/expert_parallel_deployment.md
+++ b/docs/serving/expert_parallel_deployment.md
@@ -155,6 +155,7 @@ Configure EPLB with the `--eplb-config` argument, which accepts a JSON string. T
 | `num_redundant_experts` | Additional global experts per EP rank beyond equal distribution | `0` |
 | `use_async` | Use non-blocking EPLB for reduced latency overhead | `true` |
 | `policy` | The policy type for expert parallel load balancing | `"default"` |
+| `load_balancing_strategy` | Expert placement strategy: `"auto"`, `"hierarchical"`, or `"global"` | `"auto"` |
 | `communicator` | Backend for expert weight transfers: `"torch_nccl"`, `"torch_gloo"`, `"pynccl"`, `"nixl"`,  or `null` (auto) | `null` |
 
 For example:
@@ -175,6 +176,23 @@ vllm serve Qwen/Qwen3-30B-A3B \
             --eplb-config.num_redundant_experts 2 \
             --eplb-config.log_balancedness true
     ```
+
+For disaggregated serving, use hierarchical load balancing on prefill
+instances to preserve expert-group locality across nodes, and global load
+balancing on decode instances to distribute experts across all ranks, as
+recommended by the [DeepSeek EPLB implementation](https://github.com/deepseek-ai/EPLB):
+
+```bash
+# Prefill instance
+--eplb-config '{"load_balancing_strategy":"hierarchical"}'
+
+# Decode instance
+--eplb-config '{"load_balancing_strategy":"global"}'
+```
+
+The default `"auto"` strategy preserves the previous topology-selection
+behavior. It uses the detected expert groups and node count, falling back to a
+single-node topology when the EP rank count is not divisible by the node count.
 
 ### Expert Distribution Formula
 

--- a/tests/distributed/test_eplb_algo.py
+++ b/tests/distributed/test_eplb_algo.py
@@ -5,8 +5,56 @@ import numpy as np
 import pytest
 import torch
 
-from vllm.distributed.eplb.eplb_state import compute_logical_maps
+from vllm.config import EPLBConfig
+from vllm.distributed.eplb.eplb_state import (
+    _resolve_eplb_rebalancing_topology,
+    compute_logical_maps,
+)
 from vllm.distributed.eplb.policy.default import DefaultEplbPolicy
+
+
+@pytest.mark.parametrize("strategy", ["auto", "hierarchical", "global"])
+def test_eplb_load_balancing_strategy_config(strategy):
+    config = EPLBConfig(load_balancing_strategy=strategy)
+    assert config.load_balancing_strategy == strategy
+
+
+def test_eplb_load_balancing_strategy_config_rejects_unknown_value():
+    with pytest.raises(ValueError, match="Input should be"):
+        EPLBConfig(**{"load_balancing_strategy": "local"})
+
+
+@pytest.mark.parametrize(
+    ("strategy", "expected"),
+    [
+        ("auto", (8, 2)),
+        ("hierarchical", (8, 2)),
+        ("global", (1, 1)),
+    ],
+)
+def test_resolve_eplb_rebalancing_topology(strategy, expected):
+    assert _resolve_eplb_rebalancing_topology(strategy, 8, 2, 8) == expected
+
+
+def test_auto_eplb_rebalancing_preserves_legacy_single_node_fallback():
+    assert _resolve_eplb_rebalancing_topology("auto", 8, 3, 8) == (8, 1)
+
+
+def test_auto_eplb_rebalancing_preserves_legacy_policy_fallback():
+    assert _resolve_eplb_rebalancing_topology("auto", 7, 2, 8) == (7, 2)
+
+
+@pytest.mark.parametrize(
+    ("num_groups", "num_nodes", "num_gpus"),
+    [(7, 2, 8), (8, 3, 8)],
+)
+def test_hierarchical_eplb_rebalancing_rejects_incompatible_topology(
+    num_groups, num_nodes, num_gpus
+):
+    with pytest.raises(ValueError, match="Hierarchical EPLB requires"):
+        _resolve_eplb_rebalancing_topology(
+            "hierarchical", num_groups, num_nodes, num_gpus
+        )
 
 
 def test_basic_rebalance():

--- a/vllm/config/parallel.py
+++ b/vllm/config/parallel.py
@@ -37,6 +37,7 @@ ExpertPlacementStrategy = Literal["linear", "round_robin"]
 DistributedExecutorBackend = Literal["ray", "mp", "uni", "external_launcher"]
 DataParallelBackend = Literal["ray", "mp"]
 EPLBPolicyOption = Literal["default"]
+EPLBLoadBalancingStrategy = Literal["auto", "hierarchical", "global"]
 DCPCommBackend = Literal["ag_rs", "a2a"]
 EPLBCommunicatorBackend = Literal["torch_nccl", "torch_gloo", "nixl", "pynccl"]
 All2AllBackend = Literal[
@@ -88,6 +89,15 @@ class EPLBConfig:
 
     policy: EPLBPolicyOption = "default"
     """The policy type for expert parallel load balancing (EPLB)."""
+
+    load_balancing_strategy: EPLBLoadBalancingStrategy = "auto"
+    """Expert placement strategy used by the EPLB policy.
+
+    ``"hierarchical"`` preserves expert-group locality across nodes and is
+    intended for prefill deployments. ``"global"`` balances experts across
+    all ranks and is intended for decode deployments. ``"auto"`` preserves
+    the existing topology-selection behavior.
+    """
 
     communicator: EPLBCommunicatorBackend | None = None
     """

--- a/vllm/distributed/eplb/eplb_state.py
+++ b/vllm/distributed/eplb/eplb_state.py
@@ -35,6 +35,7 @@ import torch
 from torch.distributed import ProcessGroup, all_reduce
 
 from vllm.config import ModelConfig, ParallelConfig
+from vllm.config.parallel import EPLBLoadBalancingStrategy
 from vllm.config.utils import compute_hash_cached
 from vllm.distributed.parallel_state import (
     get_ep_group,
@@ -59,6 +60,43 @@ from .rebalance_execute import (
 )
 
 logger = init_logger(__name__)
+
+
+def _resolve_eplb_rebalancing_topology(
+    strategy: EPLBLoadBalancingStrategy,
+    num_groups: int,
+    num_nodes: int,
+    num_gpus: int,
+) -> tuple[int, int]:
+    """Resolve the group and node counts used for EPLB rebalancing.
+
+    Args:
+        strategy: Requested load-balancing strategy.
+        num_groups: Number of expert groups.
+        num_nodes: Number of nodes in the EP group.
+        num_gpus: Number of ranks in the EP group.
+
+    Returns:
+        The expert-group and node counts passed to the EPLB policy.
+
+    Raises:
+        ValueError: If hierarchical balancing is explicitly requested for an
+            incompatible topology.
+    """
+    supports_hierarchical = num_groups % num_nodes == 0 and num_gpus % num_nodes == 0
+    if strategy == "hierarchical":
+        if not supports_hierarchical:
+            raise ValueError(
+                "Hierarchical EPLB requires num_groups and num_gpus to be "
+                f"divisible by num_nodes, but got {num_groups=}, {num_gpus=}, "
+                f"and {num_nodes=}."
+            )
+        return num_groups, num_nodes
+    if strategy == "global":
+        return 1, 1
+    if num_gpus % num_nodes != 0:
+        return num_groups, 1
+    return num_groups, num_nodes
 
 
 @dataclass
@@ -781,7 +819,6 @@ class EplbState:
         # Perform all-reduce to get the expert load across all ranks for each model
         global_expert_load_windows = self._allreduce_list(global_expert_load_windows)
 
-        # TODO(bowen): Treat differently for prefill and decode nodes
         eplb_model_state = next(iter(self.model_states.values()))
         model = eplb_model_state.model
         num_replicas = model.num_physical_experts
@@ -803,12 +840,25 @@ class EplbState:
             num_nodes = get_node_count()
             num_gpus = ep_group.size()
 
-        if num_gpus % num_nodes != 0:
-            num_nodes = 1
+        requested_num_groups = num_groups
+        requested_num_nodes = num_nodes
+        strategy = self.parallel_config.eplb_config.load_balancing_strategy
+        num_groups, num_nodes = _resolve_eplb_rebalancing_topology(
+            strategy,
+            num_groups,
+            num_nodes,
+            num_gpus,
+        )
+        if strategy == "auto" and (num_groups, num_nodes) != (
+            requested_num_groups,
+            requested_num_nodes,
+        ):
             logger.warning_once(
-                f"num_gpus % num_nodes != 0, "
-                "not using hierarchical rearrangement algorithm.\n"
-                f"{num_gpus=}, {num_nodes=}"
+                "Falling back to a single-node EPLB topology because "
+                "hierarchical balancing is unavailable for %s, %s, and %s.",
+                f"num_groups={requested_num_groups}",
+                f"num_gpus={num_gpus}",
+                f"num_nodes={requested_num_nodes}",
             )
 
         # Get new expert mappings


### PR DESCRIPTION
## Purpose

EPLB currently selects hierarchical or global rebalancing implicitly and
leaves a TODO in `EplbState.rearrange` to treat prefill and decode nodes
differently. The [DeepSeek EPLB
documentation](https://github.com/deepseek-ai/EPLB) recommends hierarchical
load balancing for prefill deployments with smaller expert-parallel groups and
global load balancing for decode deployments with larger expert-parallel
groups. This configuration flag was also discussed when EPLB was introduced in
[#18343](https://github.com/vllm-project/vllm/pull/18343#issuecomment-2918047879).

This PR adds `load_balancing_strategy` to `EPLBConfig`:

- `"auto"` is the default and preserves the existing topology-selection
  behavior;
- `"hierarchical"` preserves expert-group locality across detected nodes and
  rejects incompatible group/node or rank/node topologies;
- `"global"` passes a single global group and node to the existing EPLB
  policy.

The strategy is selected explicitly by each deployment. It is not inferred
from `KVTransferConfig.kv_role`, because disaggregated deployments may set
`kv_role="kv_both"` on both the prefill and decode instances. The existing
load window, policy implementation, expert transfer, and map commit paths are
unchanged.

Duplicate-work checks were run on 2026-08-12:

```bash
gh pr list --repo vllm-project/vllm --state open \
  --search 'EPLB load_balancing_strategy'
gh pr list --repo vllm-project/vllm --state open \
  --search 'EPLB hierarchical global'
gh pr list --repo vllm-project/vllm --state open \
  --search 'prefill decode EPLB'
gh issue list --repo vllm-project/vllm --state open \
  --search 'prefill decode EPLB'
```

No open PR implements this configuration. #37656 adds FlashLB and
SwiftBalancer algorithms plus a policy factory; it does not expose the
prefill/decode topology choice addressed here. It touches two of the same files,
so a mechanical merge conflict may need to be resolved if it lands first.

AI assistance was used to inspect the codebase, implement the change, write
tests and documentation, and run the validation below. The human submitter will
review every changed line and is responsible for the contribution before this
draft is marked ready for review.

## Test Plan

```bash
.venv/bin/python -m pytest \
  tests/distributed/test_eplb_algo.py \
  tests/distributed/test_eplb_utils.py -v

.venv/bin/pre-commit run --files \
  vllm/config/parallel.py \
  vllm/distributed/eplb/eplb_state.py \
  tests/distributed/test_eplb_algo.py \
  docs/serving/expert_parallel_deployment.md
```

The serving regression used Qwen3-30B-A3B in BF16 with TP4, EP4, four
redundant experts, async EPLB, and `allgather_reducescatter` on one node with
four NVIDIA A100-SXM4 40 GB GPUs. The same workload was sent to the unmodified
v0.27.1 image and a validation image that overlaid a v0.27.1-compatible version
of the two changed runtime files:

```bash
python scripts/benchmark.py \
  --requests 32 --concurrency 8 --repeat 32 --max-tokens 128
```

## Test Result

- EPLB unit and utility tests: `30 passed, 1 skipped` (the skipped case requires
  CUDA in the CPU development environment).
- All changed-file pre-commit hooks passed, including Ruff, formatting, typos,
  Markdown lint, mypy, SPDX, forbidden-import checks, and config-default
  validation.
- The unmodified v0.27.1 `auto` baseline and the patched `global` instance each
  served 32/32 requests.
- Baseline: TTFT p50/p95 42.70/77.62 ms; TPOT p50/p95 8.83/9.48 ms.
- Patched global: TTFT p50/p95 43.60/139.52 ms; TPOT p50/p95 8.60/8.75 ms.
- The patched instance completed profile rearrangement, triggered a real
  non-profile asynchronous rearrangement, remained healthy, and served a
  request afterward.

This is a single-node correctness and serving-regression test. Hierarchical and
global placement are effectively identical on one node, so the timing numbers
are not evidence of either a strategy speedup or a regression. A multi-node P/D
benchmark is required to evaluate the intended topology performance trade-off.
No output-accuracy change is expected because the policy implementation and
expert weights are unchanged.

---

<details>
<summary>Essential Elements of an Effective PR Description Checklist</summary>

- [x] The purpose and relevant prior discussion are included.
- [x] The test plan includes the commands used.
- [x] Test results, serving results, and the single-node limitation are included.
- [x] User-facing configuration documentation is updated.
- [x] Duplicate-work and AI-assistance disclosures are included.

</details>
