### PR TITLE
[Attention] Allow 3D split-KV path for small-query spec-decode verify shapes

### DIFF
--- a/vllm/v1/attention/ops/triton_unified_attention.py
+++ b/vllm/v1/attention/ops/triton_unified_attention.py
@@ -1038,14 +1038,22 @@ def unified_attention(
     # 2. The batch includes at least one prefill request, or
     # 3. The number of sequences exceeds the configured threshold, or
     # 4. Batch invariance is enabled
+    # Allow the 3D (split-KV) launch for small-query speculative-decode verify
+    # shapes as well. With the previous `max_seqlen_q > 1` gate, an MTP/EAGLE
+    # verify step (q_len 2-8) over long KV fell back to the 2D grid — e.g.
+    # q_len=4 over ~7k KV launches ~8-10 workgroups on a 64-CU GPU, leaving it
+    # >84% idle (measured 1,279us/launch vs 33us at q_len=1 on gfx1201).
+    # The segment buffers and reduce_segments are already indexed per TOKEN,
+    # so the correct capacity guard is q.shape[0] (tokens), not num_seqs.
+    MAX_QLEN_3D = 8
     use_3d = not (
         seq_threshold_3D is None
         or num_par_softmax_segments is None
         or softmax_segm_output is None
         or softmax_segm_max is None
         or softmax_segm_expsum is None
-        or max_seqlen_q > 1
-        or num_seqs > seq_threshold_3D
+        or max_seqlen_q > MAX_QLEN_3D
+        or q.shape[0] > seq_threshold_3D
         or is_batch_invariant
     )
 


### PR DESCRIPTION
## Summary

The triton unified attention launcher gates its 3D (split-KV / flash-decoding) path on `max_seqlen_q > 1`, so any speculative-decode **verify** step (q_len = 2–8 for MTP/EAGLE-style methods) falls back to the 2D grid `(total_num_q_blocks, num_kv_heads)`. At long context with few sequences that grid cannot occupy the GPU: e.g. q_len=4 over ~7.4k KV launches ~8–10 workgroups on a 64-CU gfx1201, leaving >84% of the GPU idle while each workgroup serially walks the whole KV — measured **1,279 µs/launch vs 33 µs at q_len=1** on the same server (hybrid Qwen3.6-35B-A3B-family model, kv-cache block_size forced to 1072 by mamba page alignment, MTP k=3).

This PR relaxes the gate to `max_seqlen_q <= 8` and changes the segment-buffer capacity guard from sequences to **tokens** (`q.shape[0]`) — the segment buffers and `reduce_segments` are already indexed per token, so the existing allocation stays safe. ~10 lines, wrapper-only; kernel signatures unchanged.

## Measured impact (2× AMD Radeon AI PRO R9700, gfx1201, TP=2, ROCm 7.2, torch 2.11)

| shape (MTP k=3, 256-token answers) | before | after |
|---|---|---|
| warm ~7k-context decode | 58.9 tok/s | **111.3 tok/s (+89%)** |
| short-context decode | 111.1 | **123.2 (+11%)** |

- Greedy outputs byte-identical before/after; draft acceptance unchanged (2.9–3.3).
- The cliff is q_len 1→2 (leaving the split-KV path), not query-length scaling: with k=1 (verify q_len=2) per-step attention drops only ~25% vs q_len=4, while plain decode (q_len=1) at the same context/block size is fast.
- Quality A/B vs the previous engine on the same hardware, anchor conditions replicated (single-turn + agentic): IFEval 0.925→0.925 (exact), GPQA-D −1 item/60, GSM8K −1 item/50 (nothink) and +3/50 (thinking), AA-LCR +4/100 (same judge both sides), τ²-telecom 0.974→0.9825 (114/114 sims closed), AIME'25 score parity with better termination. All within or above single-run noise; no regressions.

## Related

Same gate targeted by #45450, #46724 and #44652 — this is the minimal version of that change with production numbers attached; happy to coordinate or rebase whichever route maintainers prefer.

## Contribution policy disclosures (per AGENTS.md)

- **AI assistance**: this PR was developed with AI assistance (Claude); the submitting human (Capicua25x) directed the investigation, operates the production deployment it was validated on, has reviewed every changed line, and will defend the change end-to-end.
- **Not a duplicate**: #45450, #46724 and #44652 target the same gate but are dormant (no activity since ~July) and each couples the gate change to additional scope (NVFP4 path, occupancy heuristics, non-causal support). This PR is the minimal gate relaxation alone, with production measurements; happy to fold it into any of those if their authors return.
- **Tests run**: `python -m py_compile vllm/v1/attention/ops/triton_unified_attention.py`; end-to-end serving A/B on 2×R9700 (TP2) — greedy outputs byte-identical pre/post at 6–7k context; spec-decode acceptance unchanged (2.9–3.3); 166-test domain regression suite with 0 fails; single-turn + agentic bench battery vs the prior engine within noise or above on all 7 anchored cells (table above). Long-context survival validated to 255k tokens.
- **Fail-closed self-evaluation**: the change recovers an 89% throughput regression for any speculative-decode verify shape (q_len 2–8) over long KV on the triton unified backend — not hardware-specific in mechanism; assessed as significant benefit rather than busywork.
