### PR TITLE
[Bugfix] Bound Anthropic stop sequences

### DIFF
--- a/vllm/entrypoints/anthropic/protocol.py
+++ b/vllm/entrypoints/anthropic/protocol.py
@@ -3,9 +3,11 @@
 """Pydantic models for Anthropic API protocol"""
 
 import time
-from typing import Any, Literal
+from typing import Annotated, Any, Literal
 
 from pydantic import BaseModel, Field, field_validator, model_validator
+
+import vllm.envs as envs
 
 
 class AnthropicError(BaseModel):
@@ -123,7 +125,9 @@ class AnthropicMessagesRequest(BaseModel):
     max_tokens: int
     metadata: dict[str, Any] | None = None
     output_config: AnthropicOutputConfig | None = None
-    stop_sequences: list[str] | None = None
+    stop_sequences: (
+        Annotated[list[str], Field(max_length=envs.VLLM_MAX_STOP_STRINGS)] | None
+    ) = None
     stream: bool | None = False
     system: str | list[AnthropicContentBlock] | None = None
     temperature: float | None = None


### PR DESCRIPTION
## Purpose

PR [#51447](https://github.com/vllm-project/vllm/pull/51447) bounded OpenAI stop parameters with `VLLM_MAX_STOP_STRINGS`. Anthropic requests remained unbounded, despite being converted internally into a bounded `ChatCompletionRequest`. Consequently, an Anthropic request with five stop sequences passed ingress validation but failed during conversion, returning HTTP 500. This change applies the same limit at the Anthropic API boundary. No duplicate open PR was found.

This PR applies `VLLM_MAX_STOP_STRINGS` to Anthropic `stop_sequences`. Without this, oversized requests pass Anthropic validation and fail during OpenAI request conversion with HTTP 500.

## Reproducer Example main vs PR branch

Submit an Anthropic request containing five `stop_sequences`.

Request:

```json
{
  "model": "test",
  "messages": [{"role": "user", "content": "hello"}],
  "max_tokens": 1,
  "stop_sequences": ["a", "b", "c", "d", "e"]
}
```

**On main**:

```text
500 Internal Server Error
ChatCompletionRequest.stop: List should have at most 4 items
```

**On this branch**:

```text
Request validation error
AnthropicMessagesRequest.stop_sequences: List should have at most 4 items
```

### AI Assistance
Codex (GPT-5) assisted with drafting the change. All changed lines were human-reviewed and tests were human-run.