### PR TITLE
[Docs] Warn that --api-key does not gate all endpoints

### DIFF
--- a/docs/serving/online_serving/openai_compatible_server.md
+++ b/docs/serving/online_serving/openai_compatible_server.md
@@ -2,6 +2,17 @@
 
 vLLM provides an HTTP server that implements OpenAI's [Completions API](https://platform.openai.com/docs/api-reference/completions), [Chat API](https://platform.openai.com/docs/api-reference/chat), and more! This functionality lets you serve models and interact with them using an HTTP client.
 
+!!! warning "API key authentication does not protect every endpoint"
+    The `--api-key` option (or `VLLM_API_KEY` environment variable) only
+    authenticates requests to endpoints under the `/v1`, `/v2`, and
+    `/inference` path prefixes. Other endpoints on the same HTTP server are
+    **not** authenticated — most notably `/invocations`, which exposes the same
+    inference capabilities as the `/v1` endpoints. Do not rely on `--api-key`
+    alone to secure vLLM. See
+    [API Key Authentication Limitations](../../usage/security.md#api-key-authentication-limitations)
+    for the full list of protected and unprotected endpoints and recommended
+    hardening, such as deploying behind a reverse proxy.
+
 ## Supported APIs
 
 We currently support the following OpenAI APIs:

--- a/vllm/entrypoints/openai/cli_args.py
+++ b/vllm/entrypoints/openai/cli_args.py
@@ -282,7 +282,15 @@ class FrontendArgs(BaseFrontendArgs):
     """Allowed headers."""
     api_key: list[str] | None = None
     """If provided, the server will require one of these keys to be presented in
-    the header."""
+    the header.
+
+    Warning: this only authenticates endpoints under the `/v1`, `/v2`, and
+    `/inference` path prefixes. Other endpoints on the same server, including
+    `/invocations` (which exposes the same inference capabilities as `/v1`),
+    remain unauthenticated. Do not rely on `--api-key` alone to secure vLLM;
+    see
+    https://docs.vllm.ai/en/latest/usage/security.html#api-key-authentication-limitations
+    for what it does and does not protect."""
     ssl_keyfile: str | None = None
     """The file path to the SSL key file."""
     ssl_certfile: str | None = None


### PR DESCRIPTION
## Summary

The `--api-key` boundary is currently only documented in `docs/usage/security.md`: it authenticates the `/v1`, `/v2`, and `/inference` path prefixes, but other endpoints on the same HTTP server — notably `/invocations`, which exposes the same inference capabilities as `/v1` — remain unauthenticated. Users (and LLM assistants, which frequently hit rate limits fetching the security docs) can easily miss this and expose an attacker-reachable inference surface.

This PR surfaces the same warning at the junctions where people actually look:

- **`vllm/entrypoints/openai/cli_args.py`** — expands the `--api-key` help text (rendered in `vllm serve --help` and the serve-args reference) to state the boundary and link to the security docs.
- **`docs/serving/online_serving/openai_compatible_server.md`** — adds a warning admonition separating `/v1` protections from unauthenticated endpoints like `/invocations`.

Both point to the [API Key Authentication Limitations](https://docs.vllm.ai/en/latest/usage/security.html#api-key-authentication-limitations) section for the full list of protected/unprotected endpoints and recommended hardening.

This originated from a security researcher's suggestion that the warnings present in the security docs also appear in `--api-key`/`--help` text and in the main OpenAI-Compatible Server docs, so users have fewer opportunities to miss them.

## Not a duplicate

No open PR addresses documenting the `--api-key` authentication boundary in the CLI help text or the OpenAI-compatible server docs (checked `gh pr list --search "api-key invocations security docs"` and related keyword searches).

## Testing

Docs/help-text only; no runtime behavior changes.

- `pre-commit run --all-files` on the changed files (ruff, ruff-format, markdownlint, mypy, typos, etc.) — all passed.
- No model/accuracy/serving behavior is affected, so model evals are not applicable.

## AI assistance

AI assistance (Claude Code) was used to draft these documentation changes. The human submitter reviewed every changed line.