### PR TITLE
[V1][CUDA graph] Dispatch uniform-decode batches to a padded FULL graph instead of falling to eager PIECEWISE

### DIFF
--- a/tests/v1/cudagraph/test_cudagraph_manager.py
+++ b/tests/v1/cudagraph/test_cudagraph_manager.py
@@ -109,3 +109,135 @@ def test_full_capture_sets_graph_pool_id_before_cuda_graph(monkeypatch):
         manager.capture(create_forward_fn)
 
     mock_cuda_graph.assert_called_once()
+
+
+# Spec-decode query length used by the padding tests below. With qlen=3 the
+# uniform-decode graphs land on multiples of 3 (round_up(size, 3)), which leaves
+# gaps against the power-of-two capture ladder -- exactly the case the padding
+# dispatch has to cover.
+_DECODE_QUERY_LEN = 3
+
+
+def _create_spec_decode_vllm_config() -> MagicMock:
+    """Config whose capture ladder leaves a uniform-decode gap at 12 tokens.
+
+    capture_sizes [1, 2, 4, 8, 16, 24] with qlen=3 produce FULL decode graphs at
+    round_up(size, 3) = 3, 6, 9, 18, 24 tokens and PIECEWISE graphs at the raw
+    sizes. 12 tokens (4 requests x qlen 3) therefore has no exact FULL decode
+    graph; the only descriptor staged for it is the size-16 PIECEWISE one.
+    """
+    compilation_config = CompilationConfig(
+        cudagraph_mode="FULL_AND_PIECEWISE",
+        cudagraph_capture_sizes=[1, 2, 4, 8, 16, 24],
+    )
+    compilation_config.max_cudagraph_capture_size = 24
+    compilation_config.post_init_cudagraph_sizes()
+
+    vllm_config = MagicMock(spec=VllmConfig)
+    vllm_config.compilation_config = compilation_config
+    vllm_config.scheduler_config = SchedulerConfig.default_factory(max_num_seqs=8)
+    vllm_config.parallel_config = ParallelConfig()
+    vllm_config.speculative_config = None
+    vllm_config.num_speculative_tokens = 0
+    return vllm_config
+
+
+def _make_spec_decode_manager(monkeypatch) -> gpu_cudagraph_utils.CudaGraphManager:
+    monkeypatch.setattr(
+        gpu_cudagraph_utils,
+        "get_pp_group",
+        lambda: SimpleNamespace(is_first_rank=True, is_last_rank=True),
+    )
+    monkeypatch.setattr(
+        gpu_cudagraph_utils.current_platform,
+        "get_global_graph_pool",
+        lambda: object(),
+    )
+    manager = gpu_cudagraph_utils.CudaGraphManager(
+        vllm_config=_create_spec_decode_vllm_config(),
+        device=torch.device("cpu"),
+        cudagraph_mode=CUDAGraphMode.FULL_AND_PIECEWISE,
+        decode_query_len=_DECODE_QUERY_LEN,
+    )
+    # dispatch() only consults the candidate lists once capture has run; these
+    # tests exercise selection, not capture, so mark it done.
+    manager._graphs_captured = True
+    return manager
+
+
+def test_uniform_decode_pads_up_to_full_graph(monkeypatch):
+    """A uniform-decode batch with no exact FULL graph must pad, not go PIECEWISE.
+
+    Without pad-up dispatch, 12 tokens finds only the size-16 PIECEWISE
+    descriptor -- which _is_compatible accepts, because a PIECEWISE descriptor
+    has uniform_token_count=None and matches anything -- so attention runs eager
+    (metadata build plus kernels on the host critical path) every decode step.
+    The size-18 FULL decode graph can serve the batch by padding 4 requests up
+    to 6, and must win.
+    """
+    manager = _make_spec_decode_manager(monkeypatch)
+
+    desc = manager.dispatch(
+        num_reqs=4,
+        num_tokens=12,
+        uniform_token_count=_DECODE_QUERY_LEN,
+        num_active_loras=0,
+    )
+
+    assert desc.cg_mode == CUDAGraphMode.FULL
+    assert desc.uniform_token_count == _DECODE_QUERY_LEN
+    # Smallest FULL decode graph that fits, not merely any of them.
+    assert desc.num_tokens == 18
+    assert desc.num_reqs == 6
+
+
+def test_uniform_decode_exact_match_is_not_over_padded(monkeypatch):
+    """An exact FULL decode graph still wins over larger pad-up candidates."""
+    manager = _make_spec_decode_manager(monkeypatch)
+
+    desc = manager.dispatch(
+        num_reqs=3,
+        num_tokens=9,
+        uniform_token_count=_DECODE_QUERY_LEN,
+        num_active_loras=0,
+    )
+
+    assert desc.cg_mode == CUDAGraphMode.FULL
+    assert desc.num_tokens == 9
+    assert desc.num_reqs == 3
+
+
+def test_mixed_batch_never_selects_a_uniform_decode_graph(monkeypatch):
+    """The safety property: pad-up candidates must be inert for mixed batches.
+
+    Uniform-decode descriptors are offered ahead of the mixed fallback for every
+    token count, so this asserts _is_compatible really does reject them when the
+    batch is not uniform -- otherwise a prefill batch would replay a decode-only
+    graph and silently produce wrong results.
+    """
+    manager = _make_spec_decode_manager(monkeypatch)
+
+    desc = manager.dispatch(
+        num_reqs=2,
+        num_tokens=12,
+        uniform_token_count=None,
+        num_active_loras=0,
+    )
+
+    assert desc.cg_mode == CUDAGraphMode.PIECEWISE
+    assert desc.uniform_token_count is None
+    assert desc.num_tokens == 16
+
+
+def test_uniform_decode_beyond_capture_ladder_falls_back(monkeypatch):
+    """Past the largest captured graph there is nothing to pad up to."""
+    manager = _make_spec_decode_manager(monkeypatch)
+
+    desc = manager.dispatch(
+        num_reqs=9,
+        num_tokens=27,
+        uniform_token_count=_DECODE_QUERY_LEN,
+        num_active_loras=0,
+    )
+
+    assert desc.cg_mode == CUDAGraphMode.NONE

--- a/tests/v1/cudagraph/test_cudagraph_manager.py
+++ b/tests/v1/cudagraph/test_cudagraph_manager.py
@@ -118,19 +118,20 @@ def test_full_capture_sets_graph_pool_id_before_cuda_graph(monkeypatch):
 _DECODE_QUERY_LEN = 3
 
 
-def _create_spec_decode_vllm_config() -> MagicMock:
-    """Config whose capture ladder leaves a uniform-decode gap at 12 tokens.
+def _create_decode_vllm_config(capture_sizes: list[int]) -> MagicMock:
+    """Config for the padding tests below.
 
-    capture_sizes [1, 2, 4, 8, 16, 24] with qlen=3 produce FULL decode graphs at
-    round_up(size, 3) = 3, 6, 9, 18, 24 tokens and PIECEWISE graphs at the raw
-    sizes. 12 tokens (4 requests x qlen 3) therefore has no exact FULL decode
-    graph; the only descriptor staged for it is the size-16 PIECEWISE one.
+    With capture_sizes [1, 2, 4, 8, 16, 24] and qlen=3, the FULL decode graphs
+    land on round_up(size, 3) = 3, 6, 9, 18, 24 tokens while the PIECEWISE
+    graphs stay on the raw sizes. 12 tokens (4 requests x qlen 3) therefore has
+    no exact FULL decode graph; the only descriptor staged for it is the size-16
+    PIECEWISE one.
     """
     compilation_config = CompilationConfig(
         cudagraph_mode="FULL_AND_PIECEWISE",
-        cudagraph_capture_sizes=[1, 2, 4, 8, 16, 24],
+        cudagraph_capture_sizes=capture_sizes,
     )
-    compilation_config.max_cudagraph_capture_size = 24
+    compilation_config.max_cudagraph_capture_size = capture_sizes[-1]
     compilation_config.post_init_cudagraph_sizes()
 
     vllm_config = MagicMock(spec=VllmConfig)
@@ -142,7 +143,11 @@ def _create_spec_decode_vllm_config() -> MagicMock:
     return vllm_config
 
 
-def _make_spec_decode_manager(monkeypatch) -> gpu_cudagraph_utils.CudaGraphManager:
+def _make_spec_decode_manager(
+    monkeypatch,
+    decode_query_len: int = _DECODE_QUERY_LEN,
+    capture_sizes: list[int] | None = None,
+) -> gpu_cudagraph_utils.CudaGraphManager:
     monkeypatch.setattr(
         gpu_cudagraph_utils,
         "get_pp_group",
@@ -154,10 +159,12 @@ def _make_spec_decode_manager(monkeypatch) -> gpu_cudagraph_utils.CudaGraphManag
         lambda: object(),
     )
     manager = gpu_cudagraph_utils.CudaGraphManager(
-        vllm_config=_create_spec_decode_vllm_config(),
+        vllm_config=_create_decode_vllm_config(
+            capture_sizes or [1, 2, 4, 8, 16, 24],
+        ),
         device=torch.device("cpu"),
         cudagraph_mode=CUDAGraphMode.FULL_AND_PIECEWISE,
-        decode_query_len=_DECODE_QUERY_LEN,
+        decode_query_len=decode_query_len,
     )
     # dispatch() only consults the candidate lists once capture has run; these
     # tests exercise selection, not capture, so mark it done.
@@ -241,3 +248,40 @@ def test_uniform_decode_beyond_capture_ladder_falls_back(monkeypatch):
     )
 
     assert desc.cg_mode == CUDAGraphMode.NONE
+
+
+@pytest.mark.parametrize(
+    "decode_query_len,capture_sizes",
+    [(1, [1, 2, 4, 8]), (2, [2, 4, 8, 16]), (8, [8, 16, 32, 64])],
+)
+def test_divisor_query_len_dispatch_is_unchanged(
+    monkeypatch, decode_query_len, capture_sizes
+):
+    """Pad-up dispatch is inert when the query length divides the ladder.
+
+    round_up(size, qlen) == size for every captured size, so a FULL decode
+    graph already exists at each one and there is no gap to pad across. The
+    smallest pad-up candidate that fits is then exactly the descriptor the
+    pre-change code took from the staged list. This covers decode_query_len=1
+    -- every deployment not running speculative decoding -- as well as
+    speculative query lengths that happen to divide the ladder.
+    """
+    manager = _make_spec_decode_manager(
+        monkeypatch,
+        decode_query_len=decode_query_len,
+        capture_sizes=capture_sizes,
+    )
+
+    max_reqs = capture_sizes[-1] // decode_query_len
+    for num_reqs in range(1, max_reqs + 1):
+        num_tokens = num_reqs * decode_query_len
+        desc = manager.dispatch(
+            num_reqs=num_reqs,
+            num_tokens=num_tokens,
+            uniform_token_count=decode_query_len,
+            num_active_loras=0,
+        )
+        expected = min(s for s in capture_sizes if s >= num_tokens)
+        assert desc.cg_mode == CUDAGraphMode.FULL, num_tokens
+        assert desc.num_tokens == expected, num_tokens
+        assert desc.num_reqs == expected // decode_query_len, num_tokens

--- a/vllm/v1/worker/gpu/cudagraph_utils.py
+++ b/vllm/v1/worker/gpu/cudagraph_utils.py
@@ -284,16 +284,50 @@ class CudaGraphManager:
         if not descs_by_token_lora:
             return
 
+        # FULL decode graphs, ascending by token count, can serve any smaller
+        # uniform-decode batch via request/token padding. They are inert for
+        # non-uniform batches (rejected by _is_compatible on uniform_token_count),
+        # so it is safe to offer them ahead of the mixed/PIECEWISE fallback for
+        # every token count. Without this, a uniform-decode batch whose exact
+        # token count has no FULL decode graph (a gap in round_up(size, qlen))
+        # silently drops to an eager PIECEWISE graph -- e.g. with a spec-decode
+        # query length of 3 and the default capture ladder, 12 tokens (4 reqs)
+        # finds only the size-16 PIECEWISE desc and never the size-18 FULL decode
+        # desc that could pad 4->6 reqs, so attention runs eager (metadata build
+        # + kernels on the host critical path) every decode step.
+        decode_full_descs = (
+            sorted(
+                (
+                    d
+                    for d in descs_by_mode.get(decode_mode, [])
+                    if d.uniform_token_count is not None
+                ),
+                key=lambda d: d.num_tokens,
+            )
+            if separate_decode_routine and decode_mode == CUDAGraphMode.FULL
+            else []
+        )
+
         all_token_counts = sorted({k[0] for k in descs_by_token_lora})
         current_range_start = 0
         for token_cg_size in all_token_counts:
             for i in range(current_range_start, token_cg_size + 1):
                 for num_active_loras in self.lora_capture_cases:
                     staging_key = (token_cg_size, num_active_loras)
-                    if staging_key in descs_by_token_lora:
-                        self._candidates[(i, num_active_loras)] = descs_by_token_lora[
-                            staging_key
-                        ]
+                    if staging_key not in descs_by_token_lora:
+                        continue
+                    fallback = descs_by_token_lora[staging_key]
+                    # Prefer the smallest FULL decode graph that can pad up to
+                    # this token count over the mixed/PIECEWISE fallback.
+                    pad_up = [
+                        d
+                        for d in decode_full_descs
+                        if d.num_tokens >= i
+                        and d.num_active_loras == num_active_loras
+                    ]
+                    self._candidates[(i, num_active_loras)] = pad_up + [
+                        d for d in fallback if d not in pad_up
+                    ]
             current_range_start = token_cg_size + 1
 
         for mode, descs in descs_by_mode.items():

--- a/vllm/v1/worker/gpu/cudagraph_utils.py
+++ b/vllm/v1/worker/gpu/cudagraph_utils.py
@@ -322,8 +322,7 @@ class CudaGraphManager:
                     pad_up = [
                         d
                         for d in decode_full_descs
-                        if d.num_tokens >= i
-                        and d.num_active_loras == num_active_loras
+                        if d.num_tokens >= i and d.num_active_loras == num_active_loras
                     ]
                     self._candidates[(i, num_active_loras)] = pad_up + [
                         d for d in fallback if d not in pad_up


### PR DESCRIPTION
**TL;DR:** with speculative decode, some concurrencies silently fall back to running
attention *eagerly* every step instead of from a captured CUDA graph, adding a fixed
per-step latency bubble. This makes them dispatch to a captured graph instead.

**What happens.** When `dispatch()` picks a CUDA graph for a batch, it looks up the
smallest captured graph big enough to hold it. With speculative decode there are two
kinds of graphs captured at *different* sizes:

- **FULL decode** graphs (fast: whole decode step, incl. attention, is captured)
- **PIECEWISE** graphs (attention runs eagerly, not captured)

Their sizes interleave, so for some batch sizes the smallest graph that fits happens
to be a PIECEWISE one — even though a slightly larger FULL decode graph exists and
could serve the batch by padding it with a few dummy rows. PIECEWISE always matches,
so the batch takes it and pays the eager-attention cost every decode step.

**Example** (`decode_query_len = 3`, default capture ladder):

| batch (conc) | tokens | smallest graph that fits | result |
|---|---|---|---|
| conc-4 | 12 | size-16 **PIECEWISE** | eager attention ❌ |
| conc-4 (this PR) | 12 | size-18 **FULL decode** (pad 4→6 reqs) | captured ✅ |

Symptom on a long-context agentic run: conc-4 / conc-12 show decode ITL p50 ~75 ms —
*slower* than conc-24 doing 6× the work — with the GPU stuck at launch-bound power
while reading "100% busy".

**Fix.** Offer the FULL decode graphs, ascending by token count, ahead of the mixed fallback
for every token count. `dispatch()` then picks the smallest FULL decode graph that fits and
only falls back to PIECEWISE when none does.

- No change to `dispatch()` or `_is_compatible()` — this only reorders the candidate lists
  built in `_init_candidates`.
- **Zero extra captured graphs**, so no additional capture time or memory.
- FULL decode graphs stay inert for non-uniform batches: a mixed batch passes
  `uniform_token_count=None`, and `_is_compatible` rejects any descriptor that has one.
- Varlen decode graphs are excluded. They are captured at every raw size, so they have no
  gaps to pad across, and the change is a no-op when `varlen_decode=True`.

**On request padding.** This does not introduce a new requirement on attention backends.
`_init_candidates` already maps a range of token counts onto each staged descriptor, so
uniform-decode batches are already padded onto larger FULL decode graphs today. With
`decode_query_len=3` and capture sizes `[1, 2, 4, 8, 16, 24]`, current `main` dispatches a
21-token / 7-request batch to the 24-token FULL decode graph, padding 7 requests up to 8.
The gaps at 12 and 15 tokens are the anomaly, not the padding. This PR makes the existing
mechanism cover them.

## Test Plan

Two things need to hold: the fix works, and it changes nothing for everyone else.

**1. Unit tests** — five new tests in `tests/v1/cudagraph/test_cudagraph_manager.py`:

- If a decode batch has no graph captured at its exact size, it now runs on the next size
  up instead of falling back to eager attention. This is the regression test for the fix:
  undo the dispatch change and it fails.
- If a graph was captured at exactly the right size, that one is still chosen. The fix must
  not push batches onto needlessly large graphs.
- A batch that mixes prefill and decode never lands on a decode-only graph. This is the
  correctness guard: replaying the wrong graph here would silently produce wrong output.
- A batch too big for any captured graph still falls back to eager, same as before.
- When every captured size is already a multiple of the query length — which covers every
  deployment not using speculative decoding — dispatch makes exactly the same choices it
  made before the fix.

**2. Exhaustive dispatch differential** — to substantiate "no effect without speculative
decoding" as a measurement rather than an argument, `dispatch()` was replayed over every
reachable `(num_tokens, num_reqs, uniform_token_count)` triple for seven combinations of
capture ladder, `max_num_seqs` and `decode_query_len` (query lengths 1, 2, 3 and 8), against
both this change and its parent commit, and the two decision sets diffed. Reachability
accounts for the data-parallel path, where `sync_cudagraph_and_dp_padding` passes the synced
(max-across-ranks) `num_tokens` with the *local* `num_reqs`, so `num_tokens > num_reqs *
query_len` is possible.

**3. End-to-end** — Kimi-K3 TP8 on MI355X, speculative decoding (`num_spec=2`,
`decode_query_len=3`), `FULL_AND_PIECEWISE`, long-context agentic sweep.

## Test Result

**1. Unit tests.** All five pass on this branch. On the parent commit, the regression test
fails as intended:

```
E   assert <CUDAGraphMode.PIECEWISE: 1> == <CUDAGraphMode.FULL: 2>
FAILED test_cudagraph_manager.py::test_uniform_decode_pads_up_to_full_graph
1 failed, 7 passed
```

The full `tests/v1/cudagraph/` suite passes on this branch: **94 passed, 5 skipped**.

**2. Dispatch differential.** Of **4440** reachable batches, **52** dispatch differently.
All 52 are `PIECEWISE -> FULL`, and all 52 are at `decode_query_len=3` — the only tested
query length that does not divide the capture ladder:

| capture sizes | max_num_seqs | decode_query_len | changed |
|---|---|---|---|
| `[1,2,4,8]` | 8 | 1 | none |
| `[1,2,4,8,16]` | 16 | 1 | none |
| `[1,2,4,8,16,32]` | 32 | 1 | none |
| `[1,2,4,8,16,24]` | 8 | 2 | none |
| `[1,2,4,8,16,24]` | 8 | 3 | 9 of 280 |
| `[1,2,4,8,16,32,48]` | 16 | 3 | 43 of 944 |
| `[1,2,4,8,16,32,64]` | 8 | 8 | none |

Query lengths 1, 2 and 8 are unchanged because each divides its ladder, so `round_up` leaves
no gaps. `decode_query_len=1` is every deployment not running speculative decoding, so those
configurations are provably unaffected.

Query lengths 1, 2 and 8 are unchanged because each divides its ladder, so `round_up` leaves
no gaps. `decode_query_len=1` is every deployment not running speculative decoding, so those
configurations are provably unaffected.

Three safety properties were also checked to hold across all 4440 reachable batches with the
fix applied: no mixed batch is ever given a uniform-decode graph, no batch is given a graph
smaller than its token count, and no batch is given a graph smaller than its request count.

- `py_compile` — clean.
- Kimi-K3 MI355X: conc-4 / conc-12 previously dropped to eager PIECEWISE (ITL p50
  ~75 ms, GPU launch-bound ~370 W); with this change they dispatch to the size-18 /
  size-42 FULL decode graphs, removing the bubble.
