### PR TITLE
[Bugfix] Bump minimum setuptools version

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -35,7 +35,7 @@ mistral_common[image] >= 1.9.1
 opencv-python-headless >= 4.13.0    # required for video IO
 pyyaml
 six>=1.16.0; python_version > '3.11' # transitive dependency of pandas that needs to be the latest version for python 3.12
-setuptools>=77.0.3,<81.0.0; python_version > '3.11' # Setuptools is used by triton, we need to ensure a modern version is installed for 3.12+ so that it does not try to import distutils, which was removed in 3.12
+setuptools>=83.0.0; python_version > '3.11' # Setuptools is used by triton, we need to ensure a modern version is installed for 3.12+ so that it does not try to import distutils, which was removed in 3.12
 einops # Required for Qwen2-VL.
 compressed-tensors == 0.13.0 # required for compressed-tensors
 depyf==0.20.0 # required for profiling and debugging with compilation config


### PR DESCRIPTION


## Purpose

Fixes #51993.

Raise the minimum `setuptools` version in the common requirements to 83.0.0 so installations do not resolve versions affected by the reported security advisories.

## Test Plan

- Parse the changed requirement and verify that 83.0.0 and 84.0.0 satisfy it, 82.0.1 does not, and the Python version marker is unchanged.
- Ask pip to resolve `setuptools>=83.0.0` in dry-run mode.
- Run all pre-commit hooks applicable to `requirements/common.txt`.

## Test Result

- Requirement assertions passed.
- Pip dry-run resolved `setuptools-84.0.0`.
- `.venv/bin/pre-commit run --files requirements/common.txt` passed.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. N/A: dependency-only change.
- [x] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0). N/A: no user-facing behavior change.
</details>

