### PR TITLE
[Bugfix] Remap ModelOpt q_scale to attn.q_scale

### DIFF
--- a/tests/model_executor/test_weight_utils.py
+++ b/tests/model_executor/test_weight_utils.py
@@ -85,6 +85,23 @@ class TestMaybeRemapKvScaleName:
         )
         assert result == "model.layers.0.self_attn.attn.v_scale"
 
+    def test_modelopt_q_proj_q_scale(self):
+        """ModelOpt format: q_proj.q_scale -> attn.q_scale.
+
+        Checkpoints that quantize the query as well as the KV cache (e.g. NVFP4
+        W4A4) ship a q_scale next to k_scale/v_scale."""
+        result = maybe_remap_kv_scale_name(
+            "model.layers.0.self_attn.q_proj.q_scale", self.PARAMS_DICT
+        )
+        assert result == "model.layers.0.self_attn.attn.q_scale"
+
+    def test_qkv_proj_q_scale(self):
+        """Fused qkv_proj format: qkv_proj.q_scale -> attn.q_scale"""
+        result = maybe_remap_kv_scale_name(
+            "model.layers.0.self_attn.qkv_proj.q_scale", self.PARAMS_DICT
+        )
+        assert result == "model.layers.0.self_attn.attn.q_scale"
+
     def test_deprecated_kv_scale(self):
         """Old format: kv_scale -> attn.k_scale (deprecated)"""
         result = maybe_remap_kv_scale_name(
@@ -190,6 +207,11 @@ class TestKvCacheScaleMapper:
                 "model.layers.0.self_attn.qkv_proj.v_scale",
                 "model.layers.0.self_attn.attn.v_scale",
             ),
+            # Qwen3-MoE / llm-compressor fused qkv_proj, quantized query
+            (
+                "model.layers.0.self_attn.qkv_proj.q_scale",
+                "model.layers.0.self_attn.attn.q_scale",
+            ),
             # ModelOpt / NVFP4 k_proj/v_proj
             (
                 "model.layers.0.self_attn.k_proj.k_scale",
@@ -198,6 +220,12 @@ class TestKvCacheScaleMapper:
             (
                 "model.layers.0.self_attn.v_proj.v_scale",
                 "model.layers.0.self_attn.attn.v_scale",
+            ),
+            # ModelOpt q_proj: checkpoints that also quantize the query (e.g.
+            # NVFP4 W4A4) ship a q_scale next to k_scale/v_scale.
+            (
+                "model.layers.0.self_attn.q_proj.q_scale",
+                "model.layers.0.self_attn.attn.q_scale",
             ),
             # deprecated fused kv_scale and bare scales
             (
@@ -242,7 +270,9 @@ class TestKvCacheScaleMapper:
         [
             "model.layers.0.self_attn.k_scale",
             "model.layers.0.self_attn.k_proj.k_scale",
+            "model.layers.0.self_attn.q_proj.q_scale",
             "model.layers.0.self_attn.qkv_proj.v_scale",
+            "model.layers.0.self_attn.qkv_proj.q_scale",
             "model.layers.0.mixer.k_proj.k_scale",
         ],
     )
@@ -274,6 +304,10 @@ class TestKvCacheScaleMapper:
         assert (
             combined._map_name("model.layers.0.self_attn.k_proj.k_scale")
             == "model.layers.0.self_attn.attn.k_scale"
+        )
+        assert (
+            combined._map_name("model.layers.0.self_attn.q_proj.q_scale")
+            == "model.layers.0.self_attn.attn.q_scale"
         )
         assert (
             combined._map_name("model.layers.0.self_attn.k_scale")

--- a/vllm/model_executor/layers/quantization/base_config.py
+++ b/vllm/model_executor/layers/quantization/base_config.py
@@ -204,12 +204,12 @@ class QuantizationConfig(ABC):
         orig_to_new_regex = {
             # Deprecated fused kv_scale -> attn.k_scale
             re.compile(r"\.kv_scale$"): r".attn.k_scale",
-            # ModelOpt: .self_attn.{k,v}_proj.{k,v}_scale -> .self_attn.attn.*
-            re.compile(r"\.self_attn\.[kv]_proj\.([kv])_scale$"): (
+            # ModelOpt: .self_attn.{q,k,v}_proj.{q,k,v}_scale -> .self_attn.attn.*
+            re.compile(r"\.self_attn\.[qkv]_proj\.([qkv])_scale$"): (
                 r".self_attn.attn.\1_scale"
             ),
-            # Fused QKV / qkqkv proj: .self_attn.qk(qk)v_proj.{k,v}_scale -> attn
-            re.compile(r"\.self_attn\.qk(?:qk)?v_proj\.([kv])_scale$"): (
+            # Fused QKV / qkqkv proj: .self_attn.qk(qk)v_proj.{q,k,v}_scale -> attn
+            re.compile(r"\.self_attn\.qk(?:qk)?v_proj\.([qkv])_scale$"): (
                 r".self_attn.attn.\1_scale"
             ),
             # NemotronH: .mixer.{k,v}_proj.{k,v}_scale -> .mixer.attn.*

--- a/vllm/model_executor/model_loader/weight_utils.py
+++ b/vllm/model_executor/model_loader/weight_utils.py
@@ -1413,18 +1413,18 @@ def maybe_remap_kv_scale_name(name: str, params_dict: dict) -> str | None:
         attn_str = "attn"
     # Define scale name mapping patterns in order of precedence
     scale_mapping_patterns = [
-        # ModelOpt format: .self_attn.{k,v}_proj.{k,v}_scale ->
-        # .self_attn.attn.{k,v}_scale
+        # ModelOpt format: .self_attn.{q,k,v}_proj.{q,k,v}_scale ->
+        # .self_attn.attn.{q,k,v}_scale
         (
-            r"\.self_attn\.([kv])_proj\.([kv])_scale$",
+            r"\.self_attn\.([qkv])_proj\.([qkv])_scale$",
             rf".self_attn.{attn_str}.\2_scale",
         ),
-        # QKV proj format: .self_attn.qkv_proj.{k,v}_scale ->
-        # .self_attn.attn.{k,v}_scale
-        (r"\.self_attn\.qkv_proj\.([kv])_scale$", r".self_attn.attn.\1_scale"),
-        # Qwen3 MoE format: .self_attn.qkqkv_proj.{k,v}_scale ->
-        # .self_attn.attn.{k,v}_scale
-        (r"\.self_attn\.qkqkv_proj\.([kv])_scale$", r".self_attn.attn.\1_scale"),
+        # QKV proj format: .self_attn.qkv_proj.{q,k,v}_scale ->
+        # .self_attn.attn.{q,k,v}_scale
+        (r"\.self_attn\.qkv_proj\.([qkv])_scale$", r".self_attn.attn.\1_scale"),
+        # Qwen3 MoE format: .self_attn.qkqkv_proj.{q,k,v}_scale ->
+        # .self_attn.attn.{q,k,v}_scale
+        (r"\.self_attn\.qkqkv_proj\.([qkv])_scale$", r".self_attn.attn.\1_scale"),
         # NemotronH format: .mixer.{k,v}_proj.{k,v}_scale ->
         # .mixer.attn.{k,v}_scale
         (r"\.mixer\.[kv]_proj\.([kv])_scale$", r".mixer.attn.\1_scale"),


### PR DESCRIPTION
## Purpose

vLLM's checkpoint scale-name remapping has dedicated rules for `k_scale`/`v_scale` in the ModelOpt per-projection and fused-QKV layouts, but no rule for `q_scale`. Checkpoints that quantize the query in addition to the KV cache — NVFP4 W4A4 exports ship `self_attn.q_proj.q_scale` right alongside `k_scale`/`v_scale` — therefore lose the query scale.

Two code paths are affected:

- **`QuantizationConfig.get_cache_scale_mapper()`** — `WeightsMapper._map_name_with_shard` applies *every* matching regex cumulatively rather than stopping at the first hit. With no ModelOpt rule for `q`, the name falls through to the generic `(?<!\.attn)\.([qkv])_scale$` catch-all and is rewritten to `...self_attn.q_proj.attn.q_scale` — a module path that does not exist. The scale is silently dropped.
- **`maybe_remap_kv_scale_name()`** — the `.q_scale` suffix passes the `endswith` guard, but the ModelOpt and `qkv_proj` patterns are `[kv]`-only, so the same catch-all produces a name that isn't in `params_dict`. That path warns and returns `None`, so the scale is not loaded.

The fix widens `[kv]` to `[qkv]` in the ModelOpt per-projection and fused-QKV patterns in both places, making `q` symmetric with `k` and `v`. In the mapper, the catch-all's `(?<!\.attn)` lookbehind then correctly declines to fire a second time, so the result stays idempotent.

No behavior change for existing checkpoints: before this patch the `q_scale` path produced a name that matches no module, so nothing can be depending on it.

Deliberately left out of scope: the NemotronH `.mixer.[kv]_proj.([kv])_scale` rule has the same shape and would need the same widening if a mixer-style checkpoint ever ships a `q_scale`. I have no such checkpoint to validate against, so I left it alone — happy to include it if you'd prefer the rules stay uniform.

## Test Plan

```bash
pytest -q tests/model_executor/test_weight_utils.py
```

Added coverage:

- `TestMaybeRemapKvScaleName::test_modelopt_q_proj_q_scale` and `::test_qkv_proj_q_scale`
- `TestKvCacheScaleMapper::test_remap` — `q_proj.q_scale` and `qkv_proj.q_scale` cases
- `TestKvCacheScaleMapper::test_idempotent` — both q forms
- `TestKvCacheScaleMapper::test_composes_with_qkv_mapper` — `q_scale` assertion, confirming the fix still composes with a model's own qkv fusion mapper

## Test Result

`self_attn.q_proj.q_scale` mapping, before and after:

| input | before | after |
| --- | --- | --- |
| `...self_attn.q_proj.q_scale` | `...self_attn.q_proj.attn.q_scale` (no such module) | `...self_attn.attn.q_scale` |
| `...self_attn.qkv_proj.q_scale` | `...self_attn.qkv_proj.attn.q_scale` (no such module) | `...self_attn.attn.q_scale` |
| `...self_attn.k_proj.k_scale` | `...self_attn.attn.k_scale` | unchanged |
| `...self_attn.v_proj.v_scale` | `...self_attn.attn.v_scale` | unchanged |

Validated end to end by serving an NVFP4 W4A4 checkpoint that carries per-projection `q_scale`/`k_scale`/`v_scale` (16 attention layers each): the model loads with zero missing or unexpected weights and scores as expected on a function-calling benchmark. Without this fix the query scale never reaches the attention layer.
