### PR TITLE
[Bugfix][Qwen3.5-MTP] Load a dedicated mtp.lm_head draft head

### DIFF
--- a/tests/model_executor/test_qwen3_5_mtp_weight_loading.py
+++ b/tests/model_executor/test_qwen3_5_mtp_weight_loading.py
@@ -1,0 +1,87 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""CPU-only tests for Qwen3.5 MTP checkpoint weight-name remapping.
+
+Checkpoints differ in how they ship the draft model's output head: some carry a
+dedicated ``mtp.lm_head.*``, others expect the draft to reuse the base model's
+top-level ``lm_head.*``. Both layouts must resolve onto ``Qwen3_5MTP.lm_head``.
+"""
+
+from unittest.mock import Mock, patch
+
+BASE_LM_HEAD = "lm_head.weight"
+DRAFT_LM_HEAD = "mtp.lm_head.weight"
+EMBED_TOKENS = "model.language_model.embed_tokens.weight"
+MTP_LAYER = "mtp.layers.0.input_layernorm.weight"
+BASE_MODEL_LAYER = "model.language_model.layers.0.input_layernorm.weight"
+
+
+def _remap(names: list[str]) -> list[tuple[str, str]]:
+    """Return the ``(remapped_name, source_name)`` stream ``load_weights`` builds.
+
+    ``load_weights`` only uses ``self`` to construct the loader, so a Mock stands
+    in for the module. Each weight carries its own checkpoint name as its value,
+    which lets a test assert *which* checkpoint tensor reached a parameter.
+    """
+    from vllm.model_executor.models.qwen3_5_mtp import Qwen3_5MTP
+
+    captured: list[tuple[str, str]] = []
+
+    class _CapturingLoader:
+        def __init__(self, module):
+            pass
+
+        def load_weights(self, weights, **kwargs):
+            captured.extend(weights)
+            return set()
+
+    with patch(
+        "vllm.model_executor.models.qwen3_5_mtp.AutoWeightsLoader", _CapturingLoader
+    ):
+        Qwen3_5MTP.load_weights(Mock(), [(name, name) for name in names])
+
+    return captured
+
+
+def _source_of(remapped: list[tuple[str, str]], name: str) -> list[str]:
+    return [source for target, source in remapped if target == name]
+
+
+def test_dedicated_draft_head_preferred():
+    """A checkpoint carrying both heads must load the draft head, once."""
+    remapped = _remap([BASE_LM_HEAD, MTP_LAYER, DRAFT_LM_HEAD])
+    assert _source_of(remapped, BASE_LM_HEAD) == [DRAFT_LM_HEAD]
+
+
+def test_dedicated_draft_head_preferred_before_base_head():
+    """The choice must not depend on the order weights arrive in."""
+    remapped = _remap([DRAFT_LM_HEAD, MTP_LAYER, BASE_LM_HEAD])
+    assert _source_of(remapped, BASE_LM_HEAD) == [DRAFT_LM_HEAD]
+
+
+def test_base_head_used_when_no_draft_head():
+    """Without a dedicated draft head, the draft reuses the base model's head."""
+    remapped = _remap([BASE_LM_HEAD, MTP_LAYER])
+    assert _source_of(remapped, BASE_LM_HEAD) == [BASE_LM_HEAD]
+
+
+def test_draft_head_scales_also_remapped():
+    """Quantization scales alongside the draft head follow the same path."""
+    remapped = _remap(["mtp.lm_head.weight_scale", "mtp.lm_head.input_scale"])
+    assert dict(remapped) == {
+        "lm_head.weight_scale": "mtp.lm_head.weight_scale",
+        "lm_head.input_scale": "mtp.lm_head.input_scale",
+    }
+
+
+def test_mtp_prefix_and_embed_tokens_remap_unchanged():
+    """Existing remaps must be preserved: mtp.* -> model.*, and the base
+    model's input embedding is shared with the draft."""
+    remapped = dict(_remap([MTP_LAYER, EMBED_TOKENS]))
+    assert remapped["model.layers.0.input_layernorm.weight"] == MTP_LAYER
+    assert remapped["model.embed_tokens.weight"] == EMBED_TOKENS
+
+
+def test_base_model_weights_dropped():
+    """Target-model weights are loaded by the target, not the draft."""
+    assert _remap([BASE_MODEL_LAYER]) == []

--- a/vllm/model_executor/models/qwen3_5_mtp.py
+++ b/vllm/model_executor/models/qwen3_5_mtp.py
@@ -301,15 +301,29 @@ class Qwen3_5MTP(LocalArgmaxMixin, nn.Module, SupportsMultiModal):
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
         def remap_weight_names(weights):
+            # The draft's output head is `self.lm_head`, outside `self.model`.
+            # A checkpoint either ships a dedicated draft head (`mtp.lm_head.*`)
+            # or expects the draft to reuse the base model's top-level
+            # `lm_head.*`. Prefer the dedicated head; defer the base head so the
+            # choice does not depend on the order weights arrive in.
+            deferred_base_lm_head: list[tuple[str, torch.Tensor]] = []
+            seen_mtp_lm_head = False
             for name, weight in weights:
-                if name.startswith("mtp."):
+                if name.startswith("mtp.lm_head"):
+                    seen_mtp_lm_head = True
+                    name = name.replace("mtp.lm_head", "lm_head")
+                elif name.startswith("mtp."):
                     name = name.replace("mtp.", "model.")
-                elif any(key in name for key in ["embed_tokens", "lm_head"]):
-                    if "embed_tokens" in name:
-                        name = name.replace("language_model.", "")
+                elif "embed_tokens" in name:
+                    name = name.replace("language_model.", "")
+                elif "lm_head" in name:
+                    deferred_base_lm_head.append((name, weight))
+                    continue
                 else:
                     continue
                 yield name, weight
+            if not seen_mtp_lm_head:
+                yield from deferred_base_lm_head
 
         loader = AutoWeightsLoader(self)
         return loader.load_weights(remap_weight_names(weights))


### PR DESCRIPTION
## Purpose

`Qwen3_5MTP` keeps the draft model's output head at `self.lm_head`, outside `self.model`. Checkpoints ship this head in one of two ways:

1. a dedicated draft head at `mtp.lm_head.*`, or
2. no draft head at all, with the draft expected to reuse the base model's top-level `lm_head.*`.

`remap_weight_names` only handles the second layout. In the first, `mtp.lm_head.weight` matches the generic `mtp.` → `model.` rule and becomes `model.lm_head.weight`. `self.model` (`Qwen3_5MultiTokenPredictor`) has no `lm_head`, so the dedicated draft head is never loaded — it surfaces as an unexpected weight, and the draft silently falls back to whatever landed on `self.lm_head`.

This patch matches `mtp.lm_head` ahead of the generic `mtp.` rule and maps it onto the outer `lm_head`. Base `lm_head.*` tensors are deferred and emitted only if no dedicated draft head appeared in the stream, so which head wins does not depend on the order weights arrive in.

One note for review: the deferral holds references to the base-head tensors until the weight stream is exhausted. These are the CPU tensors the loader yields — mmap-backed for safetensors — so the cost is a retained mapping rather than an extra device allocation. If you'd rather not hold them at all, the alternative is to resolve which head the checkpoint contains before iterating; happy to restructure that way.

## Test Plan

```bash
pytest -q tests/model_executor/test_qwen3_5_mtp_weight_loading.py
```

New CPU-only test file. `load_weights` only touches `self` to construct the loader, so the tests call it with a `Mock` and a patched `AutoWeightsLoader` that captures the remapped stream. Each weight carries its own checkpoint name as its value, which lets a test assert *which* checkpoint tensor reached a given parameter.

Cases:

- dedicated draft head wins when both heads are present, in either stream order
- base head is used when no draft head exists (the pre-existing layout)
- draft-head quantization scales (`weight_scale`, `input_scale`) follow the same path
- existing remaps preserved: `mtp.*` → `model.*`, and `model.language_model.embed_tokens.*` → `model.embed_tokens.*`
- target-model weights are still dropped (they're loaded by the target, not the draft)

## Test Result

Which checkpoint tensor lands on `lm_head.weight`:

| checkpoint contents | before | after |
| --- | --- | --- |
| `lm_head.*` + `mtp.lm_head.*` | `lm_head.weight`, plus `model.lm_head.weight` emitted for a module that doesn't exist | `mtp.lm_head.weight` |
| `lm_head.*` + `mtp.lm_head.*` (draft first in stream) | same as above | `mtp.lm_head.weight` |
| `lm_head.*` only | `lm_head.weight` | `lm_head.weight` (unchanged) |

Validated end to end on an NVFP4 MTP checkpoint that ships both a dedicated `mtp.lm_head.*` (4 tensors) and a top-level `lm_head.*` (4 tensors): the model loads with zero missing or unexpected weights, and MTP speculative decoding reaches ~96.8% draft acceptance. Without this fix the dedicated draft head is reported unexpected and never loaded.
