### PR TITLE
[Bugfix][KVConnector][MoRIIO] Fix MoRIIO port collisions for deployments using both DP and TP

### DIFF
--- a/tests/v1/kv_connector/unit/test_moriio_tp_ack.py
+++ b/tests/v1/kv_connector/unit/test_moriio_tp_ack.py
@@ -2,20 +2,29 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import threading
+from types import SimpleNamespace
 
 import pytest
 
 from vllm.distributed.kv_transfer.kv_connector.v1.moriio.moriio_common import (
     MoRIIOMode,
     MoRIIOTransferAck,
+    RemoteAllocInfo,
+    WriteTask,
+    get_port_offset,
+    resolve_peer_tp_size,
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.moriio.moriio_connector import (
     MoRIIOConnector,
+    MoRIIOConnectorScheduler,
     MoRIIOConnectorWorker,
     get_moriio_expected_ack_count,
     get_moriio_remote_tp_rank,
     resolve_moriio_transfer_ack,
     validate_moriio_heterogeneous_tp_kv_heads,
+)
+from vllm.distributed.kv_transfer.kv_connector.v1.moriio.moriio_engine import (
+    MoRIIOWriter,
 )
 
 
@@ -25,6 +34,145 @@ def test_remote_tp_rank_same_tp_maps_to_self():
         1,
         2,
         3,
+    ]
+
+
+@pytest.mark.parametrize(("dp_size", "tp_size"), [(2, 2), (2, 4), (4, 2)])
+def test_dp_tp_port_offsets_are_injective(dp_size, tp_size):
+    offsets = {
+        get_port_offset(dp_rank, tp_rank, tp_size)
+        for dp_rank in range(dp_size)
+        for tp_rank in range(tp_size)
+    }
+
+    assert len(offsets) == dp_size * tp_size
+
+
+def test_port_offset_rejects_unknown_tp_size():
+    """0 is the "unknown peer TP" sentinel; it must not silently drop the DP term."""
+    with pytest.raises(ValueError, match="tp_size must be positive"):
+        get_port_offset(1, 0, 0)
+
+
+def test_resolve_peer_tp_size_falls_back_when_unadvertised():
+    assert resolve_peer_tp_size({}, 4) == 4
+    assert resolve_peer_tp_size({"tp_size": 0}, 4) == 4
+    assert resolve_peer_tp_size({"tp_size": 2}, 4) == 2
+    assert resolve_peer_tp_size({"remote_tp_size": 8, "tp_size": 2}, 4) == 8
+
+
+def test_early_write_release_uses_producer_tp_size():
+    scheduler = MoRIIOConnectorScheduler.__new__(MoRIIOConnectorScheduler)
+    scheduler.tp_size = 4
+    sent = []
+    scheduler._send_transfer_release = lambda *args: sent.append(args)
+
+    scheduler._release_write_prefill_blocks(
+        "req",
+        {
+            "transfer_id": "tx",
+            "remote_dp_rank": 1,
+            "remote_host": "producer",
+            "remote_notify_port": 7000,
+            "tp_size": 2,
+        },
+    )
+
+    assert sent == [
+        ("tx", "producer", 7000 + get_port_offset(1, 0, 2)),
+        ("tx", "producer", 7000 + get_port_offset(1, 1, 2)),
+    ]
+
+
+def _writer_with_stub_worker(tp_rank, world_size):
+    sent = []
+    wrapper = SimpleNamespace(
+        lock=threading.Lock(),
+        done_req_ids=[],
+        done_remote_allocate_req_dict={},
+        waiting_for_transfer_complete=lambda _: None,
+        send_notify=lambda _, host, port, **kwargs: sent.append((host, port)),
+        _mark_transfer_terminal_locked=lambda _: None,
+    )
+    worker = SimpleNamespace(
+        moriio_wrapper=wrapper,
+        tp_rank=tp_rank,
+        world_size=world_size,
+    )
+    writer = MoRIIOWriter.__new__(MoRIIOWriter)
+    writer._worker_ref = lambda: worker
+    writer._write_state_lock = threading.Lock()
+    writer._sealed_writes = {}
+    writer._clear_transfer_state = lambda _: None
+    return writer, worker, sent
+
+
+def _complete_write(
+    writer,
+    worker,
+    transfer_id,
+    decode_dp_rank,
+    notify_port,
+    decode_tp_size,
+    remote_ip="127.0.0.1",
+):
+    info = RemoteAllocInfo(block_ids=None)  # type: ignore[arg-type]
+    info.decode_dp_rank = decode_dp_rank
+    worker.moriio_wrapper.done_remote_allocate_req_dict[transfer_id] = info
+    writer._execute_write_task(
+        WriteTask(
+            request_id="req",
+            transfer_id=transfer_id,
+            dst_engine_id="decode",
+            local_block_ids=[0],
+            remote_block_ids_hint=None,
+            layer_name="layer",
+            event=None,  # type: ignore[arg-type]
+            remote_notify_port=notify_port,
+            remote_ip=remote_ip,
+            remote_tp_size=decode_tp_size,
+        )
+    )
+    info.block_ids = [0]
+    info.writes_expected = 1
+    info.writes_done = 1
+    writer._finalize_if_complete(transfer_id, info)
+
+
+@pytest.mark.parametrize("decode_dp_rank", [0, 1])
+def test_write_done_targets_the_exact_decode_rank_that_bound_the_port(decode_dp_rank):
+    base, producer_tp, decode_tp = 7000, 4, 2
+    bound = {
+        base + get_port_offset(dp, tp, decode_tp): (dp, tp)
+        for dp in range(2)
+        for tp in range(decode_tp)
+    }
+
+    for producer_rank in range(producer_tp):
+        writer, worker, sent = _writer_with_stub_worker(producer_rank, producer_tp)
+        _complete_write(
+            writer,
+            worker,
+            f"tx-{producer_rank}",
+            decode_dp_rank,
+            base,
+            decode_tp,
+        )
+        ((_, port),) = sent
+        expected_tp = get_moriio_remote_tp_rank(producer_rank, producer_tp, decode_tp)
+        assert bound[port] == (decode_dp_rank, expected_tp)
+
+
+def test_write_done_uses_per_request_decode_tp_size():
+    base = 7000
+    writer, worker, sent = _writer_with_stub_worker(tp_rank=0, world_size=8)
+
+    _complete_write(writer, worker, "tx-a", 1, base, 2, remote_ip="host-a")
+    _complete_write(writer, worker, "tx-b", 1, base, 4, remote_ip="host-b")
+
+    assert sent == [
+        ("host-a", base + get_port_offset(1, 0, 2)),
+        ("host-b", base + get_port_offset(1, 0, 4)),
     ]
 
 

--- a/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_common.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_common.py
@@ -4,7 +4,7 @@ import contextlib
 import os
 import threading
 import time
-from collections.abc import Iterator
+from collections.abc import Iterator, Mapping
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, NamedTuple
 
@@ -59,6 +59,8 @@ class WriteTask:
     event: torch.cuda.Event
     remote_notify_port: int
     remote_ip: str
+    # Decode TP degree for completion-port addressing; 0 means homogeneous.
+    remote_tp_size: int = 0
     enqueue_time: float = field(default_factory=time.perf_counter)
     retried: int = 0
 
@@ -88,6 +90,7 @@ class RemoteAllocInfo:
     completion_request_id: str | None = None
     completion_remote_notify_port: int | None = None
     completion_remote_ip: str | None = None
+    completion_decode_tp_size: int = 0
     completion_notified: bool = False
     transfer_statuses: list[Any] = field(default_factory=list)
     transfer_offsets: dict[
@@ -187,8 +190,56 @@ def get_moriio_mode(kv_transfer_config: KVTransferConfig) -> MoRIIOMode:
         return MoRIIOMode.WRITE
 
 
-def get_port_offset(dp_rank: int, tp_rank: int, tp_size: int = 1) -> int:
+def get_port_offset(dp_rank: int, tp_rank: int, tp_size: int) -> int:
+    # tp_size is the OWNER's TP degree: a rank binds at
+    # base + own_dp_local * own_tp_size + own_tp_rank.
+    if tp_size <= 0:
+        raise ValueError(f"tp_size must be positive for port offsets, got {tp_size}")
     return (dp_rank) * tp_size + tp_rank
+
+
+def get_moriio_remote_tp_rank(
+    local_tp_rank: int, local_tp_size: int, remote_tp_size: int
+) -> int:
+    if local_tp_size <= 0 or remote_tp_size <= 0:
+        raise ValueError("TP sizes must be positive")
+    if local_tp_rank < 0 or local_tp_rank >= local_tp_size:
+        raise ValueError(
+            f"local_tp_rank {local_tp_rank} must be in [0, {local_tp_size})"
+        )
+    if remote_tp_size == local_tp_size:
+        return local_tp_rank
+    if remote_tp_size > local_tp_size:
+        if remote_tp_size % local_tp_size != 0:
+            raise ValueError(
+                f"remote tp_size {remote_tp_size} must be a multiple of local "
+                f"tp_size {local_tp_size} for heterogeneous-TP P/D"
+            )
+        return local_tp_rank * (remote_tp_size // local_tp_size)
+    if local_tp_size % remote_tp_size != 0:
+        raise ValueError(
+            f"local tp_size {local_tp_size} must be a multiple of remote "
+            f"tp_size {remote_tp_size} for heterogeneous-TP P/D"
+        )
+    return local_tp_rank // (local_tp_size // remote_tp_size)
+
+
+def resolve_peer_tp_size(params: Mapping[str, Any], fallback: int) -> int:
+    """Peer TP degree advertised in ``kv_transfer_params``.
+
+    Args:
+        params: Peer-provided transfer params.
+        fallback: TP degree to assume when the peer advertises none.
+
+    Returns:
+        The peer's TP degree, or ``fallback`` when it is missing or invalid
+        (0 is the "unknown" sentinel and means homogeneous TP).
+    """
+    try:
+        peer_tp_size = int(params.get("remote_tp_size") or params.get("tp_size") or 0)
+    except (TypeError, ValueError):
+        peer_tp_size = 0
+    return peer_tp_size if peer_tp_size > 0 else fallback
 
 
 def fold_local_rank(global_dp_rank: int, dp_size_local: int) -> int:
@@ -305,7 +356,7 @@ class MoRIIOConfig:
         dp_rank = fold_local_rank(pc.data_parallel_rank, pc.data_parallel_size_local)
         base_notify_port = int(extra_config["notify_port"])
         tp_size = get_tensor_model_parallel_world_size()
-        port_offset = get_port_offset(dp_rank, tp_rank)
+        port_offset = get_port_offset(dp_rank, tp_rank, tp_size)
         backend = str(extra_config.get("backend", "rdma")).lower()
         if backend not in ("rdma", "xgmi"):
             raise ValueError(

--- a/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_connector.py
@@ -39,12 +39,14 @@ from vllm.distributed.kv_transfer.kv_connector.v1.moriio.moriio_common import (
     WriteTask,
     fold_local_rank,
     get_moriio_mode,
+    get_moriio_remote_tp_rank,
     get_peer_zmq_from_request_id,
     get_port_offset,
     get_role,
     parse_moriio_zmq_address,
     pod_index,
     resolve_host_ip,
+    resolve_peer_tp_size,
     set_role,
     zmq_ctx,
 )
@@ -101,32 +103,6 @@ except ImportError:
 
 def is_moriio_available() -> bool:
     return MoRIIO_enabled
-
-
-def get_moriio_remote_tp_rank(
-    local_tp_rank: int, local_tp_size: int, remote_tp_size: int
-) -> int:
-    if local_tp_size <= 0 or remote_tp_size <= 0:
-        raise ValueError("TP sizes must be positive")
-    if local_tp_rank < 0 or local_tp_rank >= local_tp_size:
-        raise ValueError(
-            f"local_tp_rank {local_tp_rank} must be in [0, {local_tp_size})"
-        )
-    if remote_tp_size == local_tp_size:
-        return local_tp_rank
-    if remote_tp_size > local_tp_size:
-        if remote_tp_size % local_tp_size != 0:
-            raise ValueError(
-                f"remote tp_size {remote_tp_size} must be a multiple of local "
-                f"tp_size {local_tp_size} for heterogeneous-TP P/D"
-            )
-        return local_tp_rank * (remote_tp_size // local_tp_size)
-    if local_tp_size % remote_tp_size != 0:
-        raise ValueError(
-            f"local tp_size {local_tp_size} must be a multiple of remote "
-            f"tp_size {remote_tp_size} for heterogeneous-TP P/D"
-        )
-    return local_tp_rank // (local_tp_size // remote_tp_size)
 
 
 def validate_moriio_heterogeneous_tp_kv_heads(
@@ -589,8 +565,12 @@ class MoRIIOConnectorScheduler:
                 return
 
         remote_notify_port = int(remote_notify_port)
-        for tp_index in range(self.tp_size):
-            target_port = remote_notify_port + get_port_offset(remote_dp_rank, tp_index)
+        # Address the producer's TP port layout, not the decoder's.
+        producer_tp_size = resolve_peer_tp_size(params, self.tp_size)
+        for tp_index in range(producer_tp_size):
+            target_port = remote_notify_port + get_port_offset(
+                int(remote_dp_rank), tp_index, producer_tp_size
+            )
             self._send_transfer_release(transfer_id, remote_host, target_port)
 
     def update_state_after_alloc(
@@ -785,9 +765,12 @@ class MoRIIOConnectorScheduler:
                         _pod_idx = pod_index(remote_dp_rank, _dp_local)
                         if 0 <= _pod_idx < len(_remote_hosts):
                             _notify_host = _remote_hosts[_pod_idx]
-                    for tp_index in range(self.tp_size):
+                    # Producer's TP degree, not ours: its ranks bind at
+                    # base + dp_local * producer_tp + tp.
+                    _producer_tp_size = resolve_peer_tp_size(_kvp, self.tp_size)
+                    for tp_index in range(_producer_tp_size):
                         target_port = remote_notify_port + get_port_offset(
-                            _remote_dp_rank_for_port, tp_index
+                            _remote_dp_rank_for_port, tp_index, _producer_tp_size
                         )
 
                         self.send_notify_block(
@@ -1217,7 +1200,7 @@ class MoRIIOConnectorWorker:
 
         self.side_channel_port: int = (
             self.moriio_config.handshake_port
-            + get_port_offset(self.dp_rank, self.tp_rank)
+            + get_port_offset(self.dp_rank, self.tp_rank, self.moriio_config.tp_size)
         )
         self.engine_id: EngineId = engine_id
 
@@ -1307,6 +1290,7 @@ class MoRIIOConnectorWorker:
         kv_layer: torch.Tensor,
         remote_notify_port: int,
         remote_ip: str,
+        remote_tp_size: int = 0,
     ) -> None:
         """Schedule a block write operation.
 
@@ -1320,6 +1304,7 @@ class MoRIIOConnectorWorker:
             kv_layer: KV cache tensor
             remote_notify_port: Port for completion notification
             remote_ip: IP address of remote node
+            remote_tp_size: Decode TP degree; 0 means assume homogeneous
         """
 
         # synchronization to prevent dirty reads between
@@ -1341,6 +1326,7 @@ class MoRIIOConnectorWorker:
             event=event,
             remote_notify_port=remote_notify_port,
             remote_ip=remote_ip,
+            remote_tp_size=remote_tp_size,
         )
         self._writer.schedule_write(task)
 
@@ -1529,12 +1515,15 @@ class MoRIIOConnectorWorker:
         # a hack to keep us moving. We will switch when moving to etcd
         # or where we have a single ZMQ socket in the scheduler.
 
+        # 0/unknown remote TP == homogeneous (as _remote_tp_rank does);
+        # forwarding the raw sentinel would drop the DP term from the offset.
+        peer_tp_size = int(remote_tp_size) or self.world_size
         dial_tp_rank = (
-            self._remote_tp_rank(remote_tp_size)
+            self._remote_tp_rank(peer_tp_size)
             if remote_tp_rank is None
             else int(remote_tp_rank)
         )
-        port_offset = get_port_offset(remote_dp_rank, dial_tp_rank, remote_tp_size)
+        port_offset = get_port_offset(remote_dp_rank, dial_tp_rank, peer_tp_size)
         path = make_zmq_path("tcp", host, port + port_offset)
         logger.debug("handshake Querying metadata on path: %s", path)
 
@@ -2407,6 +2396,7 @@ class MoRIIOConnectorWorker:
             kv_layer=kv_layer,
             remote_notify_port=meta.remote_notify_port,
             remote_ip=meta.remote_host,
+            remote_tp_size=int(meta.tp_size),
         )
 
     def merge_contiguous_blocks(
@@ -2565,6 +2555,9 @@ class MoRIIOConnectorWorker:
         # per (dp, tp); other configs use the fixed local-rank mapping (eff_tp ==
         # _remote_tp_rank), byte-identical to before. This key MUST match the one
         # the eager handshake stored the session under.
+        # 0/unknown remote TP == homogeneous (see _remote_tp_rank); resolve it
+        # before any rank or port arithmetic.
+        remote_tp_size = int(remote_tp_size) or self.world_size
         eff_tp = (
             int(chosen_tp)
             if chosen_tp is not None

--- a/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_engine.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_engine.py
@@ -32,6 +32,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.moriio.moriio_common import (
     TransferError,
     TransferId,
     WriteTask,
+    get_moriio_remote_tp_rank,
     get_port_offset,
     get_role,
     zmq_ctx,
@@ -311,6 +312,7 @@ class MoRIIOWriter:
         with self._write_state_lock:
             request_info.completion_request_id = task.request_id
             request_info.completion_remote_notify_port = task.remote_notify_port
+            request_info.completion_decode_tp_size = task.remote_tp_size
             # Wide-EP multi-pod: task.remote_ip addresses only the first pod,
             # so resolve the per-rank host from multi_pod_hosts (falls back to
             # task.remote_ip for single-pod or on any indexing miss).
@@ -455,6 +457,9 @@ class MoRIIOWriter:
             request_id = request_info.completion_request_id
             remote_notify_port = request_info.completion_remote_notify_port
             remote_ip = request_info.completion_remote_ip
+            decode_tp_size = (
+                request_info.completion_decode_tp_size or self.worker.world_size
+            )
             if request_id is None or remote_notify_port is None or remote_ip is None:
                 return
             transfer_statuses = list(request_info.transfer_statuses)
@@ -471,8 +476,15 @@ class MoRIIOWriter:
         _decode_dp_rank_for_port = int(request_info.decode_dp_rank)
         if _dp_local > 0:
             _decode_dp_rank_for_port = _decode_dp_rank_for_port % _dp_local
+        # Address the DECODE's port layout: its TP degree and the decode TP
+        # rank this producer rank maps to.
+        _decode_tp_rank = get_moriio_remote_tp_rank(
+            self.worker.tp_rank, self.worker.world_size, decode_tp_size
+        )
         remote_port = remote_notify_port + get_port_offset(
-            _decode_dp_rank_for_port, self.worker.tp_rank
+            _decode_dp_rank_for_port,
+            _decode_tp_rank,
+            decode_tp_size,
         )
         # Consider using RDMA immediate data in decode side
         # to eliminate the need for this notification.


### PR DESCRIPTION


## Purpose

Fix MoRIIO port collisions for deployments using both DP and TP.

Port offsets now use `dp_rank * tp_size + tp_rank`, where `tp_size` belongs to the listening peer. This also handles heterogeneous TP, asynchronous WRITE completion, and the unknown-TP sentinel correctly.

## Test Plan

Run the focused MoRIIO unit tests

## Test Result

Unit tests passed

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

