### PR TITLE
[Bugfix][Structured Outputs] Reject empty JSON schemas

### DIFF
--- a/docs/features/structured_outputs.md
+++ b/docs/features/structured_outputs.md
@@ -85,6 +85,12 @@ For this we can use the `json` parameter in two different ways:
 - Using directly a [JSON Schema](https://json-schema.org/)
 - Defining a [Pydantic model](https://docs.pydantic.dev/latest/) and then extracting the JSON Schema from it (which is normally an easier option).
 
+vLLM requires a non-empty schema for the `json` parameter. Although the empty
+schema `{}` is valid JSON Schema and accepts any JSON value, vLLM rejects it
+because it leaves number generation unconstrained and may continue until
+`max_tokens`. Provide a concrete schema instead, or use `json_object=True` only
+when any JSON object matches the intended output.
+
 The next example shows how to use the `response_format` parameter with a Pydantic model:
 
 ??? code

--- a/rust/src/engine-core-client/src/protocol/structured_outputs.rs
+++ b/rust/src/engine-core-client/src/protocol/structured_outputs.rs
@@ -5,7 +5,7 @@ use enum_as_inner::EnumAsInner;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::Value;
 
-use crate::error::{Error, Result};
+use crate::error::{Error, Result, bail_invalid_structured_outputs_params};
 
 /// Structured-output backend selected for EngineCore grammar compilation.
 ///
@@ -75,6 +75,11 @@ impl StructuredOutputsParams {
         Self::from_constraint(StructuredOutputConstraint::Json(json))
     }
 
+    pub fn try_json(json: Value) -> Result<Self> {
+        validate_json_schema(&json)?;
+        Ok(Self::json(json))
+    }
+
     pub fn regex(regex: impl Into<String>) -> Self {
         Self::from_constraint(StructuredOutputConstraint::Regex(regex.into()))
     }
@@ -104,6 +109,23 @@ impl StructuredOutputsParams {
             backend: StructuredOutputBackend::default(),
         }
     }
+}
+
+fn validate_json_schema(json: &Value) -> Result<()> {
+    let is_empty_schema = match json {
+        Value::Object(schema) => schema.is_empty(),
+        Value::String(schema) => {
+            matches!(serde_json::from_str(schema), Ok(Value::Object(schema)) if schema.is_empty())
+        }
+        _ => false,
+    };
+    if is_empty_schema {
+        bail_invalid_structured_outputs_params!(
+            "structured_outputs.json cannot be an empty JSON schema; provide a non-empty \
+             schema, or use json_object=true when JSON object output is intended"
+        );
+    }
+    Ok(())
 }
 
 /// Wire-compatible structured-output payload used by Python engine-core.
@@ -140,6 +162,10 @@ impl TryFrom<WireStructuredOutputsParams> for StructuredOutputsParams {
 
     fn try_from(raw: WireStructuredOutputsParams) -> Result<Self> {
         use StructuredOutputConstraint::*;
+
+        if let Some(json) = &raw.json {
+            validate_json_schema(json)?;
+        }
 
         let mut constraint = None;
 
@@ -239,6 +265,8 @@ impl<'de> Deserialize<'de> for StructuredOutputsParams {
 
 #[cfg(test)]
 mod tests {
+    use thiserror_ext::AsReport as _;
+
     use super::*;
 
     #[test]
@@ -287,6 +315,32 @@ mod tests {
         .unwrap_err();
 
         assert!(error.to_string().contains("json_object must be true"));
+    }
+
+    #[test]
+    fn structured_outputs_rejects_empty_json_schema() {
+        for schema in [
+            serde_json::json!({}),
+            serde_json::json!("{}"),
+            serde_json::json!(" \n {} \t"),
+        ] {
+            let error = serde_json::from_value::<StructuredOutputsParams>(
+                serde_json::json!({"json": schema}),
+            )
+            .unwrap_err();
+
+            assert!(error.to_report_string().contains("cannot be an empty JSON schema"));
+        }
+    }
+
+    #[test]
+    fn structured_outputs_accepts_nonempty_json_schema() {
+        for schema in [
+            serde_json::json!({"type": "object"}),
+            serde_json::json!(r#"{"type":"object"}"#),
+        ] {
+            StructuredOutputsParams::try_json(schema).unwrap();
+        }
     }
 
     #[test]

--- a/rust/src/server/src/grpc/convert.rs
+++ b/rust/src/server/src/grpc/convert.rs
@@ -4,6 +4,7 @@
 //! Conversion between gRPC protobuf types and internal `vllm-text`
 //! request/response types.
 
+use thiserror_ext::AsReport as _;
 use tonic::Status;
 use url::Url;
 use uuid::Uuid;
@@ -318,7 +319,8 @@ fn convert_structured_output(
         StructuredOutput::Json(schema) => {
             let json: serde_json::Value = serde_json::from_str(schema)
                 .map_err(|e| Status::invalid_argument(format!("invalid json schema: {e}")))?;
-            StructuredOutputsParams::json(json)
+            StructuredOutputsParams::try_json(json)
+                .map_err(|error| Status::invalid_argument(error.to_report_string()))?
         }
         StructuredOutput::Regex(regex) => StructuredOutputsParams::regex(regex.clone()),
         StructuredOutput::Choice(choices) => {
@@ -577,11 +579,15 @@ impl ResponseOpts {
 
 #[cfg(test)]
 mod tests {
+    use expect_test::expect;
     use vllm_engine_core_client::protocol::output::StopReason;
     use vllm_text::{FinishReason, Finished, Prompt};
 
     use super::pb::finish_info::{FinishReason as PbFinishReason, StopReason as PbStopReason};
-    use super::{ResponseOpts, pb, to_finish_info, to_sequence_output, to_text_request};
+    use super::{
+        ResponseOpts, convert_structured_output, pb, to_finish_info, to_sequence_output,
+        to_text_request,
+    };
 
     fn base_request() -> pb::GenerateRequest {
         pb::GenerateRequest {
@@ -662,6 +668,27 @@ mod tests {
         assert_eq!(text.sampling_params.skip_reading_prefix_cache, None);
         // Prompt conversion still succeeds and reaches the expected variant.
         assert!(matches!(text.prompt, Prompt::Text(s) if s == "hi"));
+    }
+
+    #[test]
+    fn grpc_rejects_empty_json_schema() {
+        let decoding = pb::DecodingParameters {
+            structured_output: Some(pb::decoding_parameters::StructuredOutput::Json(
+                "{}".to_string(),
+            )),
+            ..Default::default()
+        };
+
+        let error = convert_structured_output(&decoding).unwrap_err();
+
+        expect![[r#"
+            Status {
+                code: InvalidArgument,
+                message: "invalid structured outputs params: structured_outputs.json cannot be an empty JSON schema; provide a non-empty schema, or use json_object=true when JSON object output is intended",
+                source: None,
+            }
+        "#]]
+        .assert_debug_eq(&error);
     }
 
     fn finished(reason: FinishReason) -> Finished {

--- a/rust/src/server/src/routes/openai/utils/structured_outputs.rs
+++ b/rust/src/server/src/routes/openai/utils/structured_outputs.rs
@@ -3,6 +3,7 @@
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use thiserror_ext::AsReport as _;
 use vllm_engine_core_client::protocol::structured_outputs::StructuredOutputsParams;
 
 use crate::error::ApiError;
@@ -83,9 +84,13 @@ pub fn convert_from_response_format(
     match fmt {
         ResponseFormat::Text => Ok(None),
         ResponseFormat::JsonObject => Ok(Some(StructuredOutputsParams::json_object())),
-        ResponseFormat::JsonSchema { json_schema } => Ok(Some(StructuredOutputsParams::json(
-            json_schema.schema.clone(),
-        ))),
+        ResponseFormat::JsonSchema { json_schema } => {
+            StructuredOutputsParams::try_json(json_schema.schema.clone()).map(Some).map_err(
+                |error| {
+                    ApiError::invalid_request(error.to_report_string(), Some("response_format"))
+                },
+            )
+        }
         ResponseFormat::StructuralTag { .. } => {
             // The Python frontend dumps the entire response_format object (including the
             // `type` field) as a JSON string for the engine-core backend.
@@ -125,4 +130,35 @@ pub fn convert_from_response_format_value(
         )
     })?;
     convert_from_response_format(Some(&fmt), &None)
+}
+
+#[cfg(test)]
+mod tests {
+    use expect_test::expect;
+
+    use super::*;
+
+    #[test]
+    fn response_format_rejects_empty_json_schema() {
+        let response_format = ResponseFormat::JsonSchema {
+            json_schema: JsonSchemaFormat {
+                name: "response".to_string(),
+                description: None,
+                schema: serde_json::json!({}),
+                strict: None,
+            },
+        };
+
+        let error = convert_from_response_format(Some(&response_format), &None).unwrap_err();
+
+        expect![[r#"
+            InvalidRequest {
+                message: "invalid structured outputs params: structured_outputs.json cannot be an empty JSON schema; provide a non-empty schema, or use json_object=true when JSON object output is intended",
+                param: Some(
+                    "response_format",
+                ),
+            }
+        "#]]
+        .assert_debug_eq(&error);
+    }
 }

--- a/tests/entrypoints/openai/chat_completion/test_chat_completion.py
+++ b/tests/entrypoints/openai/chat_completion/test_chat_completion.py
@@ -77,6 +77,31 @@ async def test_invalid_json_schema(client: openai.AsyncOpenAI, model_name: str) 
 
 
 @pytest.mark.asyncio
+async def test_empty_json_schema_returns_bad_request(
+    client: openai.AsyncOpenAI,
+) -> None:
+    messages = [{"role": "user", "content": "Say hello"}]
+    empty_schemas: list[dict[str, object] | str] = [{}, "{}"]
+
+    for empty_schema in empty_schemas:
+        with pytest.raises(openai.BadRequestError) as exc_info:
+            await client.chat.completions.create(
+                model=MODEL_NAME,
+                messages=messages,
+                extra_body={"structured_outputs": {"json": empty_schema}},
+            )
+        assert exc_info.value.status_code == 400
+        assert "cannot be an empty JSON schema" in str(exc_info.value)
+
+    response = await client.chat.completions.create(
+        model=MODEL_NAME,
+        messages=messages,
+        max_completion_tokens=1,
+    )
+    assert response.choices
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "model_name",
     [MODEL_NAME],

--- a/tests/v1/structured_output/test_validation.py
+++ b/tests/v1/structured_output/test_validation.py
@@ -160,3 +160,30 @@ def test_auto_backend_falls_back_on_unsupported_schema(schema, expected_backend)
         tokenizer=object(),
     )
     assert params.structured_outputs._backend == expected_backend
+
+
+@pytest.mark.parametrize("json_schema", [{}, "{}", " \n {} \t"])
+def test_empty_json_schema_rejected(json_schema):
+    """The universal empty schema is rejected before unconstrained decoding."""
+    params = SamplingParams(
+        structured_outputs=StructuredOutputsParams(json=json_schema)
+    )
+    with pytest.raises(VLLMValidationError, match="cannot be an empty JSON schema"):
+        params._validate_structured_outputs(
+            _StubModelConfig(is_diffusion=False),
+            StructuredOutputsConfig(),
+            tokenizer=object(),
+        )
+
+
+@pytest.mark.parametrize("json_schema", [JSON_SCHEMA, '{"type": "object"}'])
+def test_nonempty_json_schema_allowed(json_schema):
+    """Non-empty schemas continue to pass request validation."""
+    params = SamplingParams(
+        structured_outputs=StructuredOutputsParams(json=json_schema)
+    )
+    params._validate_structured_outputs(
+        _StubModelConfig(is_diffusion=False),
+        StructuredOutputsConfig(),
+        tokenizer=object(),
+    )

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -5,6 +5,7 @@
 import copy
 import json as json_mod
 import math
+from contextlib import suppress
 from dataclasses import field
 from enum import Enum, IntEnum
 from functools import cached_property
@@ -1022,6 +1023,16 @@ class SamplingParams(
         ):
             raise VLLMValidationError(
                 "structured_outputs.json cannot be an empty string"
+            )
+        json_schema = self.structured_outputs.json
+        if isinstance(json_schema, str):
+            with suppress(json_mod.JSONDecodeError):
+                json_schema = json_mod.loads(json_schema)
+        if json_schema == {}:
+            raise VLLMValidationError(
+                "structured_outputs.json cannot be an empty JSON schema; "
+                "provide a non-empty schema, or use json_object=True when "
+                "JSON object output is intended"
             )
         # Reject json_object=False early to avoid engine-side crashes
         if self.structured_outputs.json_object is False:


### PR DESCRIPTION
## Purpose

Fix #52011 by rejecting an empty JSON Schema before structured-output backend selection. The empty schema `{}` is a valid universal JSON Schema, but it leaves number generation unconstrained. If decoding enters the number branch, it may continue producing digits until `max_tokens` and return an unusable response with `finish_reason="length"`.

This intentionally changes empty schemas from an unconstrained request to an HTTP 400 validation error. It covers dictionary input (`json={}`), serialized input (`json="{}"`), and serialized input with surrounding whitespace. Callers should provide a concrete non-empty schema, or use `json_object=True` only when any JSON object matches the intended output.

The Python and Rust frontends now apply the same check before backend compilation or model execution. The Rust request boundary covers raw `structured_outputs`, OpenAI `response_format`, and the gRPC structured-output path. Non-empty schemas continue to pass request validation, and a failed request does not prevent subsequent requests from completing.

This does not duplicate #40099, #51450, #45346, or #47176: those changes respectively address general repetition detection, whitespace-only Rust frontend strings, `json=""`/`json_object=False`, and other Rust validation parity gaps such as null schemas and mutually exclusive constraints. Open PR #51450 touches the same Rust protocol file, but its check only uses `value.trim().is_empty()`; it neither rejects an object `{}` nor parses serialized `"{}"`. A duplicate check on 2026-08-13 found no assignee, claim comment, linked pull request, or open pull request implementing empty-schema rejection.

AI assistance from OpenAI Codex was used to investigate the issue, implement the validation, add tests and documentation, and prepare this description. I reviewed every changed line, validated the behavior end to end, and ran the tests listed below.

## Test Plan

- `.venv/bin/python -m pytest tests/v1/structured_output/test_validation.py -v`
- `.venv/bin/python -m pytest tests/v1/structured_output -m cpu_test -q`
- `.venv/bin/python -m pytest tests/entrypoints/openai/chat_completion/test_chat_completion.py::test_empty_json_schema_returns_bad_request -v -s`
- `cd rust && cargo fmt --all --check`
- `cd rust && cargo test -p vllm-engine-core-client`
- `cd rust && cargo test -p vllm-server`
- `cd rust && cargo clippy -p vllm-engine-core-client -p vllm-server --tests -- -D warnings`
- `git diff --name-only -z origin/main...HEAD | xargs -0 .venv/bin/pre-commit run --files`
- Manual OpenAI API smoke tests against both the Python and Rust frontends with Qwen2.5-1.5B-Instruct, covering dictionary and serialized empty schemas followed by a normal request.
- `git diff --check origin/main...HEAD`

## Test Result

- On unmodified `main`, a direct validation probe accepted `{}`, `"{}"`, and a whitespace-padded `"{}"`.
- Focused validation tests: `9 passed, 14 warnings in 3.91s`.
- Structured-output CPU tests: `25 passed, 23 deselected, 14 warnings in 9.38s`.
- OpenAI API regression test: passed.
- Rust engine-core-client tests: `99 passed`; Rust server tests: `342 passed`; Clippy with warnings denied and `cargo fmt --check` both passed.
- Manual OpenAI API smoke tests with Qwen2.5-1.5B-Instruct produced the same result on both frontends: dictionary `{}` returned HTTP 400, serialized `"{}"` returned HTTP 400, and the immediately following normal request returned HTTP 200.
- All applicable pre-commit hooks passed, including Ruff, markdownlint, typos, mypy for Python 3.10, SPDX, forbidden-import checks, and configuration validation, including Rust formatting.
- `git diff --check origin/main...HEAD` passed.

Model evaluation is not applicable because the affected requests fail during validation before model execution. Successful request generation is not modified. User-facing behavior and the compatibility tradeoff are documented in `docs/features/structured_outputs.md`.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR and the issue it resolves are described above.
- [x] Reproducible unit, integration, lint, and manual test steps are listed.
- [x] Before-and-after validation and HTTP results are listed.
- [x] The necessary structured-output documentation is updated.
</details>

