### PR TITLE
[Bugfix] Preserve Anthropic disable_parallel_tool_use

### DIFF
--- a/vllm/entrypoints/anthropic/protocol.py
+++ b/vllm/entrypoints/anthropic/protocol.py
@@ -95,6 +95,7 @@ class AnthropicToolChoice(BaseModel):
 
     type: Literal["auto", "any", "tool", "none"]
     name: str | None = None
+    disable_parallel_tool_use: bool | None = None
 
     @model_validator(mode="after")
     def validate_name_required_for_tool(self) -> "AnthropicToolChoice":

--- a/vllm/entrypoints/anthropic/serving.py
+++ b/vllm/entrypoints/anthropic/serving.py
@@ -539,6 +539,9 @@ class AnthropicServingMessages(OpenAIServingChat):
             req.tool_choice = None
             return
 
+        req.parallel_tool_calls = (
+            not anthropic_request.tool_choice.disable_parallel_tool_use
+        )
         tool_choice_type = anthropic_request.tool_choice.type
         if tool_choice_type == "auto":
             req.tool_choice = "auto"


### PR DESCRIPTION
## Purpose

Anthropic’s `disable_parallel_tool_use` was silently discarded, leaving the converted OpenAI request with `parallel_tool_calls=True`. This preserves the field and maps it to the existing inverse OpenAI setting. 

## Reproducer

```python
request = AnthropicMessagesRequest(
    model="test",
    messages=[{"role": "user", "content": "Use a tool"}],
    max_tokens=8,
    tool_choice={"type": "auto", "disable_parallel_tool_use": True},
)
converted = AnthropicServingMessages._convert_anthropic_to_openai_request(request)

print(request.tool_choice.model_dump(exclude_none=True))
print(converted.parallel_tool_calls)
```

**On Main**

```text
{'type': 'auto'}
True
```

**On this branch**

```text
{'type': 'auto', 'disable_parallel_tool_use': True}
False
```

## Test Plan and Results

```bash
.venv/bin/python -m pytest tests/entrypoints/anthropic/test_anthropic_messages_conversion.py -q
```

```text
# 51 passed
```
