### PR TITLE
  [Bugfix][Frontend] Import parser plugins under the vllm.* namespace so their logs survive

### DIFF
--- a/tests/tool_use/test_plugin_logging.py
+++ b/tests/tool_use/test_plugin_logging.py
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""A parser loaded from a plugin path must log like the rest of vLLM.
+
+Only the ``vllm`` logger is configured (``vllm/logger.py``), so a plugin
+imported under a module name taken from its file name gets a logger with no
+handler anywhere up its chain: ``logger.info`` and ``logger.debug`` are dropped
+and warnings escape outside vLLM's formatting and level settings. Importing the
+plugin under the ``vllm.*`` namespace is what keeps it configured, and plugin
+authors need to do nothing.
+"""
+
+import logging
+import sys
+
+import pytest
+
+from vllm.reasoning import ReasoningParserManager
+from vllm.tool_parsers import ToolParserManager
+
+
+def _write_plugin(tmp_path, name):
+    """A plugin that records the module name it was imported under."""
+    plugin = tmp_path / f"{name}.py"
+    plugin.write_text("IMPORTED_AS = __name__\n")
+    return plugin
+
+
+def _configured_ancestor(name):
+    """The logger that would actually handle a record from ``name``."""
+    logger = logging.getLogger(name)
+    while logger:
+        if logger.handlers:
+            return logger
+        if not logger.propagate:
+            return None
+        logger = logger.parent
+    return None
+
+
+@pytest.mark.parametrize(
+    "manager,importer,prefix",
+    [
+        (ToolParserManager, "import_tool_parser", "vllm.tool_parsers.plugins."),
+        (
+            ReasoningParserManager,
+            "import_reasoning_parser",
+            "vllm.reasoning.plugins.",
+        ),
+    ],
+)
+def test_plugin_is_imported_under_the_vllm_logging_namespace(
+    tmp_path, manager, importer, prefix
+):
+    name = "dummy_parser_plugin"
+    getattr(manager, importer)(str(_write_plugin(tmp_path, name)))
+
+    module = sys.modules[prefix + name]
+    assert module.IMPORTED_AS == prefix + name
+
+    handler_owner = _configured_ancestor(module.IMPORTED_AS)
+    assert handler_owner is not None, (
+        f"records from {module.IMPORTED_AS} reach no handler"
+    )
+    assert handler_owner.name == "vllm"

--- a/vllm/reasoning/abs_reasoning_parsers.py
+++ b/vllm/reasoning/abs_reasoning_parsers.py
@@ -363,7 +363,11 @@ class ReasoningParserManager:
         Import a user-defined reasoning parser by the path
         of the reasoning parser define file.
         """
-        module_name = os.path.splitext(os.path.basename(plugin_path))[0]
+        # See ToolParserManager.import_tool_parser: the vllm.* prefix keeps
+        # the plugin's own logger inside the configured logging namespace.
+        module_name = "vllm.reasoning.plugins." + os.path.splitext(
+            os.path.basename(plugin_path)
+        )[0]
 
         try:
             import_from_path(module_name, plugin_path)

--- a/vllm/tool_parsers/abstract_tool_parser.py
+++ b/vllm/tool_parsers/abstract_tool_parser.py
@@ -369,7 +369,13 @@ class ToolParserManager:
     def import_tool_parser(cls, plugin_path: str) -> None:
         """Import a user-defined parser file from arbitrary path."""
 
-        module_name = os.path.splitext(os.path.basename(plugin_path))[0]
+        # Imported under the vllm.* namespace so that a plugin doing the usual
+        # `logger = init_logger(__name__)` lands inside the logging config: only
+        # the "vllm" logger is configured, so a module-named logger has no
+        # handler at all and its INFO/DEBUG records are dropped.
+        module_name = "vllm.tool_parsers.plugins." + os.path.splitext(
+            os.path.basename(plugin_path)
+        )[0]
         try:
             import_from_path(module_name, plugin_path)
         except Exception:


### PR DESCRIPTION
Fixes #52027
## Purpose

  `ToolParserManager.import_tool_parser` and
  `ReasoningParserManager.import_reasoning_parser` import a plugin under a module
  name taken from its file name, so a plugin doing what every in-tree parser does
  - `logger = init_logger(__name__)` - ends up with a logger named after its file.
  Only the `vllm` logger is configured in `DEFAULT_LOGGING_CONFIG`, so that logger
  has no handler anywhere up its chain:

  * `logger.info` and `logger.debug` are dropped entirely - Python's
    `logging.lastResort` fallback is WARNING-level;
  * `logger.warning` and above leave *outside* vLLM's configuration: unformatted,
    and unaffected by `VLLM_LOGGING_LEVEL` or `VLLM_LOGGING_CONFIG_PATH`.

  Importing the plugin as `vllm.tool_parsers.plugins.<name>` (and
  `vllm.reasoning.plugins.<name>`) puts `__name__` inside the configured
  namespace, so plugin authors need to do nothing.

  Two notes on safety:

  * `import_from_path` uses `spec_from_file_location` and assigns `sys.modules`
    directly, so the dotted name needs no parent package.
  * Relative imports inside a plugin were already impossible under a bare module
    name, so nothing regresses there.

  ## Test Plan

  `tests/tool_use/test_plugin_logging.py`, parametrized over both managers: it
  writes a plugin that records `__name__`, imports it through the manager, and
  walks the logger chain from that name.

  ## Test Result

  The test asserts that a record from the plugin's own logger reaches a handler,
  and that the handler belongs to the `vllm` logger. Before this change the walk
  ends at the root with no handler; after it, it stops at `vllm`.

  Verified in isolation (stdlib only, vLLM's logging config shape):

  dummy_parser_plugin                            -> handler: None
  vllm.tool_parsers.plugins.dummy_parser_plugin  -> handler: vllm

  Found while running a tool parser as a plugin: three parser bugs stayed
  invisible for a day because every warning the parser emitted was dropped.
