### PR TITLE
[Bugfix] Pin DeepEP by its full commit hash

### DIFF
--- a/tools/ep_kernels/install_python_libraries.sh
+++ b/tools/ep_kernels/install_python_libraries.sh
@@ -8,7 +8,9 @@ set -ex
 #   --nvshmem-ver <ver>  NVSHMEM version 
 
 CUDA_HOME=${CUDA_HOME:-/usr/local/cuda}
-DEEPEP_COMMIT_HASH=${DEEPEP_COMMIT_HASH:-"d4f41e4e93"}
+# Pinned in full: an abbreviated hash is not a ref, so a consumer that
+# fetches the pin directly ("git fetch origin <sha>") cannot resolve it.
+DEEPEP_COMMIT_HASH=${DEEPEP_COMMIT_HASH:-"d4f41e4e93602a15e95f55f6ee8df8f1aaa0e4bb"}
 
 NVSHMEM_VER=${NVSHMEM_VER:-"3.3.24"}  # Default supports both CUDA 12 and 13
 WORKSPACE=${WORKSPACE:-$(pwd)/ep_kernels_workspace}


### PR DESCRIPTION
## Purpose

`tools/ep_kernels/install_python_libraries.sh` pins DeepEP by a 10-character abbreviation:

```bash
DEEPEP_COMMIT_HASH=${DEEPEP_COMMIT_HASH:-"d4f41e4e93"}
```

An abbreviated object ID is not a ref, so it cannot be fetched directly. GitHub serves any *complete* commit via `allowAnySHA1InWant`, but an abbreviation is never a valid want:

```console
$ git fetch --depth 1 origin d4f41e4e93602a15e95f55f6ee8df8f1aaa0e4bb
 * branch  d4f41e4e93602a15e95f55f6ee8df8f1aaa0e4bb -> FETCH_HEAD

$ git fetch --depth 1 origin d4f41e4e93
fatal: couldn't find remote ref d4f41e4e93
```

Cloning the whole repository and checking out afterwards resolves the abbreviation locally, which is why this goes unnoticed in the common path. It breaks any consumer that fetches only the pinned commit — a reasonable thing to do for a large dependency — and the resulting error names a network-shaped problem rather than the pin.

This is the same hash, written in full. `--deepep-ref` and the `DEEPEP_COMMIT_HASH` environment override are unaffected.

## Test Plan

`bash -n tools/ep_kernels/install_python_libraries.sh`, plus the fetch comparison above run against `github.com/deepseek-ai/DeepEP`.

## Test Result

The full hash fetches successfully; the abbreviation fails. The commit resolved is unchanged: `d4f41e4e93602a15e95f55f6ee8df8f1aaa0e4bb` ("Add fence.proxy.async.shared::cta between mbarrier wait and TMA load. (#642)").