### PR TITLE
[Feature] Add opt-in dynamic NVFP4 MoE GEMM2 quantization

### DIFF
--- a/tests/kernels/moe/test_trtllm_nvfp4_moe.py
+++ b/tests/kernels/moe/test_trtllm_nvfp4_moe.py
@@ -17,13 +17,19 @@ from tests.kernels.moe.utils import make_test_quant_config
 from tests.kernels.quantization.nvfp4_utils import (
     FLOAT4_E2M1_MAX,
     FLOAT8_E4M3_MAX,
+    break_fp4_bytes,
+    convert_swizzled_to_linear,
     dequantize_nvfp4_to_dtype,
 )
 from tests.kernels.utils import torch_moe
 from vllm import _custom_ops as ops
 from vllm.config import ParallelConfig, VllmConfig, set_current_vllm_config
 from vllm.model_executor.custom_op import CustomOp, op_registry
-from vllm.model_executor.layers.activation import SiluAndMulWithClamp, SituAndMul
+from vllm.model_executor.layers.activation import (
+    SiluAndMul,
+    SiluAndMulWithClamp,
+    SituAndMul,
+)
 from vllm.model_executor.layers.fused_moe import fused_topk
 from vllm.model_executor.layers.fused_moe.activation import MoEActivation
 from vllm.model_executor.layers.fused_moe.all2all_utils import (
@@ -33,9 +39,15 @@ from vllm.model_executor.layers.fused_moe.config import (
     FusedMoEConfig,
     FusedMoEParallelConfig,
     RoutingMethodType,
+    nvfp4_moe_quant_config,
 )
 from vllm.model_executor.layers.fused_moe.experts.trtllm_nvfp4_moe import (
     TrtLlmNvFp4ExpertsModular,
+    TrtLlmNvFp4ExpertsMonolithic,
+)
+from vllm.model_executor.layers.quantization.utils.flashinfer_fp4_moe import (
+    prepare_static_weights_for_trtllm_fp4_moe,
+    reorder_w1w3_to_w3w1,
 )
 from vllm.platforms import current_platform
 from vllm.utils.flashinfer import has_flashinfer_trtllm_fused_moe
@@ -105,6 +117,77 @@ ACTIVATION_CASES = [
     ),
     pytest.param(MoEActivation.GELU, MoEActivation.GELU, None, id="gelu"),
 ]
+
+
+def _dequantize_linear_nvfp4(
+    tensor_fp4: torch.Tensor,
+    tensor_sf: torch.Tensor,
+    global_decode_scale: torch.Tensor,
+) -> torch.Tensor:
+    """Dequantize row-major K16 NVFP4 scales without layout conversion."""
+    m, packed_k = tensor_fp4.shape
+    values = break_fp4_bytes(tensor_fp4, torch.float32).reshape(m, -1, 16)
+    block_scales = tensor_sf.view(torch.float8_e4m3fn).float().reshape(m, -1)
+    return (
+        values * block_scales.unsqueeze(-1) * global_decode_scale.reshape(m, 1, 1)
+    ).reshape(m, packed_k * 2)
+
+
+def _dynamic_gemm2_reference(
+    hidden_states: torch.Tensor,
+    w1: torch.Tensor,
+    w2: torch.Tensor,
+    topk_weights: torch.Tensor,
+    topk_ids: torch.Tensor,
+    gemm1_encode_scale: torch.Tensor,
+) -> torch.Tensor:
+    """Reference static GEMM1 input and per-routed-row dynamic GEMM2 input."""
+    from flashinfer import SfLayout, nvfp4_quantize
+
+    hidden_fp4, hidden_sf = ops.scaled_fp4_quant(
+        hidden_states,
+        gemm1_encode_scale,
+        is_sf_swizzled_layout=False,
+    )
+    hidden_dequant = _dequantize_linear_nvfp4(
+        hidden_fp4,
+        hidden_sf,
+        (1.0 / gemm1_encode_scale).expand(hidden_states.shape[0]),
+    ).to(hidden_states.dtype)
+
+    m, topk = topk_ids.shape
+    expanded_hidden = (
+        hidden_dequant[:, None, :].expand(m, topk, -1).reshape(m * topk, -1)
+    )
+    flat_topk_ids = topk_ids.reshape(-1)
+    route_outputs = torch.zeros(
+        (m * topk, hidden_states.shape[1]),
+        dtype=hidden_states.dtype,
+        device=hidden_states.device,
+    )
+
+    for expert_idx in range(w1.shape[0]):
+        expert_mask = flat_topk_ids == expert_idx
+        if not expert_mask.any():
+            continue
+        gemm1_output = expanded_hidden[expert_mask] @ w1[expert_idx].T
+        gemm2_input = SiluAndMul()(gemm1_output)
+        gemm2_fp4, gemm2_sf, gemm2_decode_scale = nvfp4_quantize(
+            gemm2_input,
+            1.0 / (FLOAT8_E4M3_MAX * FLOAT4_E2M1_MAX),
+            sfLayout=SfLayout.layout_linear,
+            per_token_activation=True,
+        )
+        gemm2_input_dequant = _dequantize_linear_nvfp4(
+            gemm2_fp4, gemm2_sf, gemm2_decode_scale
+        ).to(hidden_states.dtype)
+        route_outputs[expert_mask] = gemm2_input_dequant @ w2[expert_idx].T
+
+    return (
+        (route_outputs.view(m, topk, -1).float() * topk_weights.unsqueeze(-1).float())
+        .sum(dim=1)
+        .to(hidden_states.dtype)
+    )
 
 
 @pytest.mark.parametrize("m,n,k", MNK_FACTORS)
@@ -276,6 +359,191 @@ def test_trtllm_fp4_moe_no_graph(
         )
 
         torch.testing.assert_close(torch_output, trtllm_output, atol=2e-1, rtol=2e-1)
+
+
+@pytest.mark.parametrize("use_monolithic", [False, True], ids=["modular", "monolithic"])
+@torch.inference_mode()
+def test_trtllm_fp4_moe_dynamic_gemm2_matches_rowwise_reference(
+    use_monolithic: bool, workspace_init
+):
+    """Dynamic GEMM2 ignores its static scale and keeps GEMM1 static."""
+    m, n, k, e, topk = 17, 1024, 1024, 4, 2
+    dtype = torch.bfloat16
+
+    set_random_seed(11)
+    with set_current_vllm_config(
+        VllmConfig(parallel_config=ParallelConfig(pipeline_parallel_size=1))
+    ):
+        hidden_states = torch.randn((m, k), device="cuda", dtype=dtype) / 10
+        row_amplitudes = torch.logspace(
+            -1, 1, m, device="cuda", dtype=torch.float32
+        ).to(dtype)
+        hidden_states.mul_(row_amplitudes.unsqueeze(1))
+
+        w1_q, w2_q, reference_quant_config = make_test_quant_config(
+            e,
+            n,
+            k,
+            in_dtype=dtype,
+            quant_dtype="nvfp4",
+            per_act_token_quant=False,
+            make_gate=True,
+            is_scale_swizzled=False,
+        )
+        assert reference_quant_config.a1_gscale is not None
+        assert reference_quant_config.a2_gscale is not None
+        assert reference_quant_config.g1_alphas is not None
+        assert reference_quant_config.g2_alphas is not None
+        assert reference_quant_config.w1_scale is not None
+        assert reference_quant_config.w2_scale is not None
+        reference_quant_config.a1_gscale.fill_(8.0)
+        # Deliberately unusable for these activations. The dynamic path must
+        # neither fold nor consume this checkpoint-static GEMM2 input scale.
+        reference_quant_config.a2_gscale.fill_(1.0e-6)
+
+        w1_scale_linear = torch.stack(
+            [
+                convert_swizzled_to_linear(
+                    reference_quant_config.w1_scale[expert_idx], 2 * n, k, 16
+                )
+                for expert_idx in range(e)
+            ]
+        )
+        w2_scale_linear = torch.stack(
+            [
+                convert_swizzled_to_linear(
+                    reference_quant_config.w2_scale[expert_idx], k, n, 16
+                )
+                for expert_idx in range(e)
+            ]
+        )
+        w1_kernel, w1_scale_linear = reorder_w1w3_to_w3w1(
+            w1_q.clone(), w1_scale_linear, dim=1
+        )
+        (
+            w1_kernel,
+            w1_scale_kernel,
+            w2_kernel,
+            w2_scale_kernel,
+        ) = prepare_static_weights_for_trtllm_fp4_moe(
+            w1_kernel,
+            w2_q.clone(),
+            w1_scale_linear,
+            w2_scale_linear,
+            hidden_size=k,
+            intermediate_size=n,
+            num_experts=e,
+            is_gated_activation=True,
+        )
+        quant_config = nvfp4_moe_quant_config(
+            g1_alphas=reference_quant_config.g1_alphas,
+            g2_alphas=reference_quant_config.g2_alphas,
+            a1_gscale=reference_quant_config.a1_gscale,
+            a2_gscale=reference_quant_config.a2_gscale,
+            w1_scale=w1_scale_kernel,
+            w2_scale=w2_scale_kernel,
+            is_scale_swizzled=False,
+        )
+
+        score = torch.randn((m, e), device="cuda", dtype=dtype)
+        topk_weights, topk_ids, _ = fused_topk(
+            hidden_states, score, topk, renormalize=False
+        )
+        moe_config = FusedMoEConfig(
+            num_experts=e,
+            experts_per_token=topk,
+            hidden_dim=k,
+            intermediate_size=n,
+            num_local_experts=e,
+            num_logical_experts=e,
+            activation=MoEActivation.SILU,
+            device="cuda",
+            moe_parallel_config=FusedMoEParallelConfig.make_no_parallel(),
+            in_dtype=dtype,
+            routing_method=RoutingMethodType.TopK,
+            max_num_tokens=next_power_of_2(m),
+        )
+
+        experts_cls = (
+            TrtLlmNvFp4ExpertsMonolithic
+            if use_monolithic
+            else TrtLlmNvFp4ExpertsModular
+        )
+        trtllm_inner = experts_cls(
+            moe_config=moe_config,
+            quant_config=quant_config,
+            dynamic_gemm2=True,
+        )
+        fake_layer = torch.nn.Module()
+        fake_layer.w13_weight_scale_2 = quant_config.g1_alphas
+        fake_layer.w2_weight_scale_2 = quant_config.g2_alphas
+        fake_layer.w13_input_scale = 1.0 / quant_config.a1_gscale
+        fake_layer.w2_input_scale = 1.0 / quant_config.a2_gscale
+        trtllm_inner.process_weights_after_loading(fake_layer)
+
+        trtllm_experts = mk.FusedMoEKernel(
+            maybe_make_prepare_finalize(
+                moe=moe_config,
+                quant_config=quant_config,
+                allow_new_interface=True,
+                use_monolithic=use_monolithic,
+            ),
+            trtllm_inner,
+        )
+        if use_monolithic:
+            actual = trtllm_experts.apply_monolithic(
+                hidden_states=hidden_states,
+                w1=w1_kernel,
+                w2=w2_kernel,
+                router_logits=torch.softmax(score.float(), dim=-1),
+                activation=MoEActivation.SILU,
+                global_num_experts=e,
+                expert_map=None,
+                apply_router_weight_on_input=False,
+            )
+        else:
+            actual = trtllm_experts.apply(
+                hidden_states=hidden_states,
+                w1=w1_kernel,
+                w2=w2_kernel,
+                topk_weights=topk_weights,
+                topk_ids=topk_ids,
+                activation=MoEActivation.SILU,
+                global_num_experts=e,
+                expert_map=None,
+                apply_router_weight_on_input=False,
+            )
+
+        w1_dequant = torch.empty((e, 2 * n, k), device="cuda", dtype=dtype)
+        w2_dequant = torch.empty((e, k, n), device="cuda", dtype=dtype)
+        for expert_idx in range(e):
+            w1_dequant[expert_idx] = dequantize_nvfp4_to_dtype(
+                w1_q[expert_idx],
+                reference_quant_config.w1_scale[expert_idx],
+                1.0 / reference_quant_config.g1_alphas[expert_idx],
+                dtype=dtype,
+                device=w1_q.device,
+            )
+            w2_dequant[expert_idx] = dequantize_nvfp4_to_dtype(
+                w2_q[expert_idx],
+                reference_quant_config.w2_scale[expert_idx],
+                1.0 / reference_quant_config.g2_alphas[expert_idx],
+                dtype=dtype,
+                device=w2_q.device,
+            )
+
+        expected = _dynamic_gemm2_reference(
+            hidden_states,
+            w1_dequant,
+            w2_dequant,
+            topk_weights,
+            topk_ids,
+            reference_quant_config.a1_gscale[0],
+        )
+        relative_l2 = torch.linalg.vector_norm(actual.float() - expected.float())
+        relative_l2 /= torch.linalg.vector_norm(expected.float())
+        assert relative_l2 < 0.05
+        torch.testing.assert_close(actual, expected, atol=5e-1, rtol=2e-1)
 
 
 if __name__ == "__main__":

--- a/tests/quantization/test_trtllm_nvfp4_dynamic_gemm2.py
+++ b/tests/quantization/test_trtllm_nvfp4_dynamic_gemm2.py
@@ -1,0 +1,232 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+import vllm.model_executor.layers.fused_moe.oracle.nvfp4 as nvfp4_oracle
+from vllm.model_executor.layers.fused_moe.activation import MoEActivation
+from vllm.model_executor.layers.fused_moe.config import (
+    FusedMoEConfig,
+    FusedMoEParallelConfig,
+    FusedMoEQuantConfig,
+    RoutingMethodType,
+    nvfp4_moe_quant_config,
+)
+from vllm.model_executor.layers.fused_moe.experts.trtllm_nvfp4_moe import (
+    TrtLlmNvFp4ExpertsModular,
+)
+from vllm.model_executor.layers.fused_moe.modular_kernel import (
+    FusedMoEActivationFormat,
+)
+from vllm.model_executor.layers.fused_moe.oracle.nvfp4 import (
+    NvFp4MoeBackend,
+    make_nvfp4_moe_kernel,
+)
+
+NUM_EXPERTS = 4
+
+
+def _make_moe_config() -> FusedMoEConfig:
+    return FusedMoEConfig(
+        num_experts=NUM_EXPERTS,
+        experts_per_token=2,
+        hidden_dim=16,
+        intermediate_size=32,
+        num_local_experts=NUM_EXPERTS,
+        num_logical_experts=NUM_EXPERTS,
+        activation=MoEActivation.SILU,
+        device="cpu",
+        moe_parallel_config=FusedMoEParallelConfig.make_no_parallel(),
+        in_dtype=torch.bfloat16,
+        routing_method=RoutingMethodType.TopK,
+    )
+
+
+def _make_layer_and_quant_config() -> tuple[torch.nn.Module, FusedMoEQuantConfig]:
+    layer = torch.nn.Module()
+    layer.register_parameter(
+        "w13_weight_scale_2",
+        torch.nn.Parameter(torch.arange(2, 6, dtype=torch.float32)),
+    )
+    layer.register_parameter(
+        "w2_weight_scale_2",
+        torch.nn.Parameter(torch.arange(6, 10, dtype=torch.float32)),
+    )
+    layer.w13_input_scale = torch.full((NUM_EXPERTS,), 2.0)
+    layer.w2_input_scale = torch.full((NUM_EXPERTS,), 4.0)
+    quant_config = nvfp4_moe_quant_config(
+        g1_alphas=layer.w13_weight_scale_2,
+        g2_alphas=layer.w2_weight_scale_2,
+        a1_gscale=torch.full((NUM_EXPERTS,), 0.5),
+        a2_gscale=torch.full((NUM_EXPERTS,), 0.25),
+        w1_scale=torch.ones((NUM_EXPERTS, 1, 1)),
+        w2_scale=torch.ones((NUM_EXPERTS, 1, 1)),
+    )
+    return layer, quant_config
+
+
+def _make_experts(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    dynamic_gemm2: bool,
+    per_token_activation: bool = False,
+) -> tuple[TrtLlmNvFp4ExpertsModular, torch.nn.Module]:
+    monkeypatch.setattr(torch.accelerator, "current_device_index", lambda: "cpu")
+    layer, quant_config = _make_layer_and_quant_config()
+    experts = TrtLlmNvFp4ExpertsModular(
+        moe_config=_make_moe_config(),
+        quant_config=quant_config,
+        dynamic_gemm2=dynamic_gemm2,
+        per_token_activation=per_token_activation,
+    )
+    experts.process_weights_after_loading(layer)
+    return experts, layer
+
+
+def test_dynamic_gemm2_preserves_static_gemm1_quantization(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    experts, layer = _make_experts(monkeypatch, dynamic_gemm2=True)
+
+    torch.testing.assert_close(
+        layer.w13_weight_scale_2, torch.arange(2, 6, dtype=torch.float32)
+    )
+    torch.testing.assert_close(
+        layer.w2_weight_scale_2, torch.arange(6, 10, dtype=torch.float32)
+    )
+    torch.testing.assert_close(experts.g1_scale_c, layer.w13_weight_scale_2)
+    assert experts.expects_unquantized_inputs is False
+
+    hidden_states = torch.zeros((3, 8), dtype=torch.uint8)
+    block_scale = torch.ones((3, 1), dtype=torch.uint8)
+    actual_hidden, actual_block, row_scale = experts._prepare_gemm1_input(
+        hidden_states, block_scale
+    )
+    assert actual_hidden is hidden_states
+    assert actual_block is block_scale
+    assert row_scale is not None and row_scale.is_contiguous()
+    torch.testing.assert_close(row_scale, torch.full((3,), 2.0))
+
+
+def test_static_path_keeps_scale_folding(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    experts, layer = _make_experts(monkeypatch, dynamic_gemm2=False)
+
+    torch.testing.assert_close(
+        layer.w13_weight_scale_2, 2 * torch.arange(2, 6, dtype=torch.float32)
+    )
+    torch.testing.assert_close(
+        layer.w2_weight_scale_2, 4 * torch.arange(6, 10, dtype=torch.float32)
+    )
+    torch.testing.assert_close(experts.g1_scale_c, 0.25 * layer.w13_weight_scale_2)
+
+
+def test_online_per_token_activation_still_selects_dynamic_gemm2(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    experts, layer = _make_experts(
+        monkeypatch, dynamic_gemm2=False, per_token_activation=True
+    )
+
+    assert experts.dynamic_gemm2 is True
+    assert experts.expects_unquantized_inputs is True
+    assert "gemm1_input_decode_scale" not in dict(layer.named_buffers())
+    torch.testing.assert_close(
+        layer.w13_weight_scale_2, torch.arange(2, 6, dtype=torch.float32)
+    )
+    torch.testing.assert_close(
+        layer.w2_weight_scale_2, torch.arange(6, 10, dtype=torch.float32)
+    )
+
+
+def test_dynamic_gemm2_state_is_eplb_safe(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    experts, layer = _make_experts(monkeypatch, dynamic_gemm2=True)
+
+    buffers = dict(layer.named_buffers())
+    assert buffers.keys() == {"gemm1_input_decode_scale"}
+    assert buffers["gemm1_input_decode_scale"].shape == torch.Size([])
+    assert "gemm1_input_decode_scale" not in layer.state_dict()
+
+    params = dict(layer.named_parameters())
+    assert all(param.shape[0] == NUM_EXPERTS for param in params.values())
+    permutation = torch.tensor([2, 0, 3, 1])
+    with torch.no_grad():
+        for param in params.values():
+            param.copy_(param[permutation])
+
+    assert experts.g1_scale_c.data_ptr() == params["g1_scale_c"].data_ptr()
+    torch.testing.assert_close(experts.gemm1_input_decode_scale, torch.tensor(2.0))
+
+
+def test_dynamic_gemm2_modular_workspace_uses_quantized_input(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    experts, _ = _make_experts(monkeypatch, dynamic_gemm2=True)
+    workspaces = experts.workspace_shapes(
+        M=3,
+        N=32,
+        K=8,
+        topk=2,
+        global_num_experts=NUM_EXPERTS,
+        local_num_experts=NUM_EXPERTS,
+        expert_tokens_meta=None,
+        activation=MoEActivation.SILU,
+    )
+    assert workspaces == ((0,), (0,), (3, 16))
+
+
+class _ExpertsSpy(TrtLlmNvFp4ExpertsModular):
+    def __init__(self, **kwargs) -> None:
+        self.kwargs = kwargs
+        self.moe_config = kwargs["moe_config"]
+
+
+@pytest.mark.parametrize("enabled", [False, True])
+def test_dynamic_gemm2_env_is_forwarded_to_trtllm_experts(
+    monkeypatch: pytest.MonkeyPatch, enabled: bool
+) -> None:
+    monkeypatch.setenv(
+        "VLLM_FLASHINFER_MOE_NVFP4_DYNAMIC_GEMM2", "1" if enabled else "0"
+    )
+    monkeypatch.setattr(
+        nvfp4_oracle,
+        "maybe_make_prepare_finalize",
+        lambda **_: SimpleNamespace(
+            activation_format=FusedMoEActivationFormat.Standard
+        ),
+    )
+    monkeypatch.setattr(
+        nvfp4_oracle.mk,
+        "FusedMoEKernel",
+        lambda _prepare_finalize, experts: SimpleNamespace(fused_experts=experts),
+    )
+    _, quant_config = _make_layer_and_quant_config()
+
+    kernel = make_nvfp4_moe_kernel(
+        moe_quant_config=quant_config,
+        moe_config=_make_moe_config(),
+        experts_cls=_ExpertsSpy,
+        backend=NvFp4MoeBackend.FLASHINFER_TRTLLM,
+    )
+    assert kernel.fused_experts.kwargs["dynamic_gemm2"] is enabled
+    assert kernel.fused_experts.kwargs["per_token_activation"] is False
+
+
+def test_dynamic_gemm2_rejects_other_backends(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("VLLM_FLASHINFER_MOE_NVFP4_DYNAMIC_GEMM2", "1")
+    _, quant_config = _make_layer_and_quant_config()
+    with pytest.raises(ValueError, match="requires the FlashInfer TRTLLM"):
+        make_nvfp4_moe_kernel(
+            moe_quant_config=quant_config,
+            moe_config=_make_moe_config(),
+            experts_cls=_ExpertsSpy,
+            backend=NvFp4MoeBackend.FLASHINFER_CUTLASS,
+        )

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -214,6 +214,7 @@ if TYPE_CHECKING:
     VLLM_KIMI_K3_GEMM_RS: bool = False
     VLLM_BLOCKSCALE_FP8_GEMM_FLASHINFER: bool = True
     VLLM_USE_FLASHINFER_MOE_INT4: bool = False
+    VLLM_FLASHINFER_MOE_NVFP4_DYNAMIC_GEMM2: bool = False
     VLLM_FLASHINFER_AUTOTUNE_CACHE_DIR: str | None = None
     VLLM_FLASHINFER_AUTOTUNE_SKIP_OPS: list[str] | None = None
     VLLM_FLASHINFER_ALLREDUCE_BACKEND: Literal["auto", "trtllm", "mnnvl"] = "auto"
@@ -1624,6 +1625,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Allow use of FlashInfer MxInt4 MoE kernels for fused moe ops.
     "VLLM_USE_FLASHINFER_MOE_INT4": lambda: bool(
         int(os.getenv("VLLM_USE_FLASHINFER_MOE_INT4", "0"))
+    ),
+    # Dynamically quantize the post-activation GEMM2 input per routed token.
+    # This is supported by the FlashInfer TRTLLM NVFP4 MoE backend only.
+    "VLLM_FLASHINFER_MOE_NVFP4_DYNAMIC_GEMM2": lambda: bool(
+        int(os.getenv("VLLM_FLASHINFER_MOE_NVFP4_DYNAMIC_GEMM2", "0"))
     ),
     # Control the cache sized used by the xgrammar compiler. The default
     # of 512 MB should be enough for roughly 1000 JSON schemas.

--- a/vllm/model_executor/layers/fused_moe/experts/trtllm_nvfp4_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/trtllm_nvfp4_moe.py
@@ -52,12 +52,16 @@ class TrtLlmNvFp4ExpertsBase:
         moe_config: FusedMoEConfig,
         quant_config: FusedMoEQuantConfig,
         per_token_activation: bool = False,
+        dynamic_gemm2: bool = False,
     ):
         self.moe_config = moe_config
         self.quant_config = quant_config
         # Quantize the input here (deferred from prepare) to capture a per-token
         # global scale, instead of a static one.
         self.per_token_activation = per_token_activation
+        # Supplying GEMM1 row scales selects FlashInfer's path that emits BF16
+        # post-activation rows and dynamically quantizes them for GEMM2.
+        self.dynamic_gemm2 = dynamic_gemm2 or per_token_activation
 
         self.routing_method_type = self.moe_config.routing_method
         self.topk = moe_config.experts_per_token
@@ -71,6 +75,13 @@ class TrtLlmNvFp4ExpertsBase:
         self.local_num_experts = moe_config.num_local_experts
         self.ep_rank = moe_config.moe_parallel_config.ep_rank
         self.is_situ = moe_config.activation == MoEActivation.SITU
+
+        if self.dynamic_gemm2:
+            assert self.quant_config.a1_gscale is not None
+            if not self.per_token_activation:
+                self.gemm1_input_decode_scale = (
+                    1.0 / self.quant_config.a1_gscale.reshape(-1)[0]
+                ).to(torch.float32)
 
         self.g1_scale_c = self._compute_g1_scale_c()
 
@@ -138,6 +149,10 @@ class TrtLlmNvFp4ExpertsBase:
     def _compute_g1_scale_c(self) -> torch.Tensor:
         assert self.quant_config.g1_alphas is not None
         assert self.quant_config.a2_gscale is not None
+        if self.dynamic_gemm2:
+            # The live GEMM2 row scale is supplied separately, so this value
+            # contains only the GEMM1 weight decode scale.
+            return self.quant_config.g1_alphas.clone()
         if not self.moe_config.is_act_and_mul:
             return self.quant_config.a2_gscale.clone()
         if self.is_situ:
@@ -151,8 +166,20 @@ class TrtLlmNvFp4ExpertsBase:
         return self.quant_config.g1_alphas * self.quant_config.a2_gscale
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
-        layer.w13_weight_scale_2.data.mul_(layer.w13_input_scale)
-        layer.w2_weight_scale_2.data.mul_(layer.w2_input_scale)
+        if self.dynamic_gemm2:
+            if not self.per_token_activation:
+                # GEMM1 stays checkpoint-quantized. FlashInfer requires its
+                # static outer decode scale as one FP32 value per input row
+                # when dynamic GEMM2 is selected.
+                layer.register_buffer(
+                    "gemm1_input_decode_scale",
+                    self.gemm1_input_decode_scale.clone(),
+                    persistent=False,
+                )
+                self.gemm1_input_decode_scale = layer.gemm1_input_decode_scale
+        else:
+            layer.w13_weight_scale_2.data.mul_(layer.w13_input_scale)
+            layer.w2_weight_scale_2.data.mul_(layer.w2_input_scale)
         # Recompute g1_scale_c since g1_alphas was just fused in-place.
         # Register as a layer parameter so EPLB rearranges it alongside
         # other expert weights.
@@ -276,6 +303,22 @@ class TrtLlmNvFp4ExpertsBase:
         )
         return hs_fp4, hs_block_scale, per_token_scale
 
+    def _prepare_gemm1_input(
+        self,
+        hidden_states: torch.Tensor,
+        a1q_scale: torch.Tensor | None,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
+        if self.per_token_activation:
+            return self._quantize_per_token_input(hidden_states)
+
+        assert a1q_scale is not None
+        per_token_scale = None
+        if self.dynamic_gemm2:
+            per_token_scale = self.gemm1_input_decode_scale.expand(
+                hidden_states.shape[0]
+            ).contiguous()
+        return hidden_states, a1q_scale, per_token_scale
+
     def _get_chunk_size(self) -> int:
         MAX_GRID_Y = 65535
         MAX_TILE_TOKENS_DIM = 128
@@ -360,14 +403,9 @@ class TrtLlmNvFp4ExpertsModular(TrtLlmNvFp4ExpertsBase, mk.FusedMoEExpertsModula
         assert self.quant_config.w1_scale is not None
         assert self.quant_config.w2_scale is not None
 
-        # Per-token: input is unquantized, quantize it here. Otherwise it was
-        # already quantized in prepare() with the static global scale.
-        if self.per_token_activation:
-            hidden_states, block_scale, per_token_scale = (
-                self._quantize_per_token_input(hidden_states)
-            )
-        else:
-            block_scale, per_token_scale = a1q_scale, None
+        hidden_states, block_scale, per_token_scale = self._prepare_gemm1_input(
+            hidden_states, a1q_scale
+        )
 
         # Pack topk ids and weights into format expected by the kernel.
         packed_tensor = trtllm_moe_pack_topk_ids_weights(topk_ids, topk_weights)
@@ -538,13 +576,9 @@ class TrtLlmNvFp4ExpertsMonolithic(
             and self.routing_method_type != RoutingMethodType.Llama4
         )
 
-        # Per-token: input is unquantized, quantize it here (see modular apply).
-        if self.per_token_activation:
-            hidden_states, block_scale, per_token_scale = (
-                self._quantize_per_token_input(hidden_states)
-            )
-        else:
-            block_scale, per_token_scale = a1q_scale, None
+        hidden_states, block_scale, per_token_scale = self._prepare_gemm1_input(
+            hidden_states, a1q_scale
+        )
 
         output1_scale_gate_scalar = self.quant_config.g1_alphas
 

--- a/vllm/model_executor/layers/fused_moe/oracle/nvfp4.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/nvfp4.py
@@ -4,6 +4,7 @@ from enum import Enum
 
 import torch
 
+import vllm.envs as envs
 import vllm.model_executor.layers.fused_moe.modular_kernel as mk
 from vllm.config.kernel import MoEBackend
 from vllm.logger import init_logger
@@ -544,6 +545,18 @@ def make_nvfp4_moe_kernel(
     routing_tables: tuple[torch.Tensor, torch.Tensor, torch.Tensor] | None = None,
     per_token_activation: bool = False,
 ) -> mk.FusedMoEKernel:
+    dynamic_gemm2 = envs.VLLM_FLASHINFER_MOE_NVFP4_DYNAMIC_GEMM2
+    if dynamic_gemm2 and backend != NvFp4MoeBackend.FLASHINFER_TRTLLM:
+        raise ValueError(
+            "VLLM_FLASHINFER_MOE_NVFP4_DYNAMIC_GEMM2 requires the "
+            "FlashInfer TRTLLM NVFP4 MoE backend."
+        )
+    if dynamic_gemm2:
+        logger.info_once(
+            "Using dynamic per-token GEMM2 input quantization for "
+            "FlashInfer TRTLLM NVFP4 MoE."
+        )
+
     # Create Prepare/Finalize.
     prepare_finalize = maybe_make_prepare_finalize(
         moe=moe_config,
@@ -557,8 +570,9 @@ def make_nvfp4_moe_kernel(
     logger.info_once("Using %s", prepare_finalize.__class__.__name__)
 
     extra_kwargs = {}
-    if backend == NvFp4MoeBackend.FLASHINFER_TRTLLM and per_token_activation:
-        extra_kwargs["per_token_activation"] = True
+    if backend == NvFp4MoeBackend.FLASHINFER_TRTLLM:
+        extra_kwargs["per_token_activation"] = per_token_activation
+        extra_kwargs["dynamic_gemm2"] = dynamic_gemm2
 
     # Create Experts.
     if prepare_finalize.activation_format == mk.FusedMoEActivationFormat.BatchedExperts:


### PR DESCRIPTION
### Summary

This adds a default-off runtime option for ordinary per-routed-token NVFP4 quantization of the post-activation GEMM2 input in the FlashInfer TRTLLM MoE backend:

```bash
VLLM_FLASHINFER_MOE_NVFP4_DYNAMIC_GEMM2=1 \
  vllm serve MODEL --moe-backend flashinfer_trtllm ...
```

The checkpoint's GEMM1 input remains quantized with its existing static outer scale and group-16 E4M3 block scales to allow working together with EP / EPLB. GEMM1 emits BF16 post-activation rows, FlashInfer computes one live FP32 outer scale per routed row, requantizes those rows to group-16 NVFP4, and runs GEMM2 with the existing W4A4 cubin. 

When the option is enabled, the checkpoint GEMM2 activation scale is ignored. The default path is unchanged. No FlashInfer or checkpoint change is required.

### Parallelism and state handling

- Monolithic and modular TRTLLM expert wrappers share the same scale handling.
- TP replicates the GEMM1 outer scale and constructs a rank-local row vector; no scale slicing or collective is needed.
- Modular EP keeps `expects_unquantized_inputs=False`, so the established static NVFP4 GEMM1 input and block scales are dispatched normally. The row vector is created from the post-dispatch token count on each rank.
- EPLB-visible values remain expert-major registered parameters. The shared GEMM1 outer decode scalar is a non-persistent buffer, so EPLB neither treats it as an expert tensor nor tries to permute it.
- Existing online `nvfp4_per_token` remains supported; it already supplies live GEMM1 row scales and automatically uses dynamic GEMM2. However, it does not support EP or EPLB.

### Performance and quality evidence

The exact production implementation was exercised on four B200 GPUs using the released Mistral Large 3 NVFP4, TP4, FlashInfer TRTLLM MoE, and concurrency one on an internal long context dataset. The results are as follows:

| Checkpoint  | Backend | Accuracy |
| ------------- | ------------- | ------------- |
| [Mistral Large 3 FP8](https://huggingface.co/mistralai/Mistral-Large-3-675B-Instruct-2512/commit/383ffea2c7d60dfd44ca960e8e691709d4fdb9cd)  | Flashinfer TRTLLM  | 88%  |
| [Mistral Large 3 NVFP4](https://huggingface.co/mistralai/Mistral-Large-3-675B-Instruct-2512-NVFP4/commit/c8fe8a02a4b2fb6af0cdeb4ee71fcf147742e59c)  | Flashinfer TRTLLM | 66%  |
| [Mistral Large 3 NVFP4](https://huggingface.co/mistralai/Mistral-Large-3-675B-Instruct-2512-NVFP4/commit/c8fe8a02a4b2fb6af0cdeb4ee71fcf147742e59c)  | Flashinfer TRTLLM (DYNAMIC_GEMM2=1)  | 87%  |

### Tests

Successfully ran the following tests:

```
tests/quantization/test_trtllm_nvfp4_dynamic_gemm2.py
tests/quantization/test_trtllm_nvfp4_hidden_dim_padding.py
tests/test_envs.py
tests/distributed/test_eplb_quant_scale_consistency.py
tests/kernels/moe/test_trtllm_nvfp4_moe.py
tests/quantization/test_trtllm_nvfp4_dynamic_gemm2.py
```

### Duplicate check

Merged PR #48538 is adjacent but different: it adds online weight quantization plus dynamic GEMM1/GEMM2 and restricts that mode to the monolithic path. This change targets already-quantized W4A4 checkpoints, keeps GEMM1 checkpoint-static, and supports the modular EP path.

### AI disclosure

AI assistance was used to investigate, implement, test, and draft this change. The human submitter must review every changed line and be prepared to explain and maintain it.

[Edited for conciseness]

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

