### PR TITLE
[Build] Update DeepGEMM pin to deepseek-ai nv_dev tip

### DIFF
--- a/cmake/external_projects/deepgemm.cmake
+++ b/cmake/external_projects/deepgemm.cmake
@@ -28,9 +28,9 @@ if(DEEPGEMM_SRC_DIR)
   message(STATUS "DeepGEMM using local DEEPGEMM_SRC_DIR: ${deepgemm_SOURCE_DIR}")
 else()
   # Keep in sync with tools/install_deepgemm.sh
-  set(_DEEPGEMM_UPSTREAM_REPO "https://github.com/vllm-project/DeepGEMM.git")
-  # TODO: switch to nv_dev branch after it support situ
-  set(_DEEPGEMM_UPSTREAM_TAG "e21c821f39a2056d68067a466c64ddc942200106")
+  set(_DEEPGEMM_UPSTREAM_REPO "https://github.com/deepseek-ai/DeepGEMM.git")
+  # Pinned to the tip of the nv_dev branch (SM120 support).
+  set(_DEEPGEMM_UPSTREAM_TAG "8b1392b978f5a03c828dd1711090d7fb50958b8a")
 
   set(_deepgemm_fc_root "${FETCHCONTENT_BASE_DIR}")
   if(NOT _deepgemm_fc_root)

--- a/tools/install_deepgemm.sh
+++ b/tools/install_deepgemm.sh
@@ -6,9 +6,9 @@ set -e
 
 # Default values
 # Keep DEEPGEMM_GIT_REF in sync with cmake/external_projects/deepgemm.cmake
-DEEPGEMM_GIT_REPO="https://github.com/vllm-project/DeepGEMM.git"
-# NOTE: This is currently targeting nv-dev branch due to sm120 support
-DEEPGEMM_GIT_REF="e21c821f39a2056d68067a466c64ddc942200106"
+DEEPGEMM_GIT_REPO="https://github.com/deepseek-ai/DeepGEMM.git"
+# NOTE: This is currently targeting the nv_dev branch tip due to sm120 support
+DEEPGEMM_GIT_REF="8b1392b978f5a03c828dd1711090d7fb50958b8a"
 WHEEL_DIR=""
 
 # Parse command line arguments


### PR DESCRIPTION
## Purpose

Update both DeepGEMM pins (`cmake/external_projects/deepgemm.cmake` and `tools/install_deepgemm.sh`, which are documented to stay in sync) from the `vllm-project/DeepGEMM` fork at `e21c821f` to upstream `deepseek-ai/DeepGEMM` at `8b1392b978f5a03c828dd1711090d7fb50958b8a`, the current tip of the `nv_dev` branch.

The fork pin was kept because the plain `nv_dev` branch previously lacked SiTU support (see the removed TODO comment in the cmake file). The `nv_dev` tip now carries SiTU for FP8xFP4 MegaMoE (`situ_beta` / `situ_linear_beta` in `csrc/apis/mega.hpp`, `deep_gemm/mega/__init__.py`, `csrc/jit_kernels/impls/sm100_fp8_fp4_mega_moe.hpp`, `deep_gemm/include/deep_gemm/impls/sm100_fp8_fp4_mega_moe.cuh`) alongside the SM120/SM121 kernels, so the fork indirection is no longer needed.

### Duplicate-work check

Required searches were run (`gh pr list --search deepgemm`, `--search "DeepGEMM pin"`). Related open PRs, and why this is not a duplicate:

- #51959 pins `deepseek-ai/DeepGEMM` at `a6b593d`, an older `nv_dev` commit. Verified that `a6b593d` has **no** SiTU support (no `situ` in `deep_gemm/mega/__init__.py` at that revision), so it would regress SiTU-dependent models. This PR pins the `nv_dev` tip which includes SiTU.
- #51382 and #50796 keep the `vllm-project` fork and pin handcrafted `nv_dev+situ` merge/cherry-pick revisions. This PR achieves the same SM120 + SiTU combination using upstream's own `nv_dev` branch, dropping the fork dependency entirely.

## Test plan and results

```bash
bash -n tools/install_deepgemm.sh                    # passed
pre-commit run --files cmake/external_projects/deepgemm.cmake tools/install_deepgemm.sh
                                                     # all applicable hooks passed; shellcheck hook
                                                     # could not run (shellcheck not installed locally)
git diff --check                                     # clean
```

Additionally verified against the pinned commit that the vendoring layout consumed by `cmake/external_projects/deepgemm.cmake` is unchanged: submodules `third-party/cutlass` + `third-party/fmt`, `csrc/python_api.cpp`, and `deep_gemm/{__init__.py,utils/,testing/,legacy/,mega/,include/}` all present at `8b1392b`.

A full CUDA build of the new pin and model evals were **not** run locally; requesting CI coverage.

## Disclosure

This change was prepared with AI assistance (Kimi Code); the diff was reviewed line-by-line by the submitter.