### PR TITLE
[Bugfix] VLLM 0.27.0 has not been fixed MiniCPM-V-4.6 startup fails

### DIFF
--- a/vllm/model_executor/models/minicpmv4_6.py
+++ b/vllm/model_executor/models/minicpmv4_6.py
@@ -25,6 +25,7 @@ from vllm.model_executor.layers.mamba.mamba_utils import (
     MambaStateShapeCalculator,
 )
 from vllm.model_executor.layers.quantization import QuantizationConfig
+from vllm.model_executor.model_loader.weight_utils import default_weight_loader
 from vllm.multimodal import MULTIMODAL_REGISTRY
 from vllm.multimodal.inputs import (
     MultiModalFeatureSpec,
@@ -649,14 +650,6 @@ class MiniCPMV4_6ProcessingInfo(MiniCPMVProcessingInfo):
 
 
 class MiniCPMV4_6ViTWindowAttentionSelfAttn(nn.Module):
-    hf_to_vllm_mapper = WeightsMapper(
-        orig_to_new_stacked={
-            ".q_proj": (".qkv_proj", "q"),
-            ".k_proj": (".qkv_proj", "k"),
-            ".v_proj": (".qkv_proj", "v"),
-        }
-    )
-
     def __init__(
         self,
         config,
@@ -705,8 +698,28 @@ class MiniCPMV4_6ViTWindowAttentionSelfAttn(nn.Module):
         return out
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
-        loader = AutoWeightsLoader(self)
-        return loader.load_weights(weights, mapper=self.hf_to_vllm_mapper)
+        stacked_params_mapping = [
+            # (param_name, shard_name, shard_id)
+            ("qkv_proj", "q_proj", "q"),
+            ("qkv_proj", "k_proj", "k"),
+            ("qkv_proj", "v_proj", "v"),
+        ]
+        params_dict = dict(self.named_parameters())
+        loaded_params: set[str] = set()
+        for name, loaded_weight in weights:
+            for param_name, shard_name, shard_id in stacked_params_mapping:
+                if shard_name not in name:
+                    continue
+                name = name.replace(shard_name, param_name)
+                param = params_dict[name]
+                param.weight_loader(param, loaded_weight, shard_id)
+                break
+            else:
+                param = params_dict[name]
+                weight_loader = getattr(param, "weight_loader", default_weight_loader)
+                weight_loader(param, loaded_weight)
+            loaded_params.add(name)
+        return loaded_params
 
 
 class MiniCPMV4_6ViTWindowAttentionMerger(nn.Module):


### PR DESCRIPTION
## Purpose

Fixes #51842.

Serving `openbmb/MiniCPM-V-4_6` fails during weight loading, before the server
starts:

ValueError: There is no module or parameter named 'k_proj' in
MiniCPMV4_6ViTWindowAttentionSelfAttn. The available parameters ... are:
{'qkv_proj.weight', 'qkv_proj.bias', 'out_proj.weight', 'out_proj.bias'}

**Root cause.** The MiniCPM-V-4.6 ViT attention checkpoint stores separate
`q_proj`/`k_proj`/`v_proj`, while vLLM fuses them into a single
`QKVParallelLinear` (`qkv_proj`). `MiniCPMV4_6ViTWindowAttentionSelfAttn` tried
to fuse them with a class-level `WeightsMapper(orig_to_new_stacked=...)` applied
inside the submodule's own `load_weights`. Two problems make this a no-op:

1. `AutoWeightsLoader` strips the module prefix before dispatching to a
   submodule's `load_weights`, so the keys arriving here are bare
   (`k_proj.weight`), but the mapper substrings carry a leading dot
   (`.k_proj`) and never match. The unmapped `k_proj` then hits the "no
   parameter named 'k_proj'" error.
2. The leading dots cannot simply be dropped: `orig_to_new_stacked` applies
   every matching rule without breaking, and `qkv_proj` contains the substring
   `v_proj`, so a de-dotted mapper would re-map `k_proj → qkv_proj → qkqkv_proj`
   with the wrong shard id.

## Test Plan
- Repro on 2× T4 (Turing, so `--dtype float16`), `tensor_parallel_size=2`, which
  triggers the failing weight-load path before and after the fix:
  ```python
  from vllm import LLM, SamplingParams
  llm = LLM(model="openbmb/MiniCPM-V-4_6", trust_remote_code=True,
            dtype="float16", tensor_parallel_size=2, max_model_len=4096,
            enforce_eager=True)
  print(llm.generate(["Describe yourself in one sentence."],
                     SamplingParams(max_tokens=32))[0].outputs[0].text)
- Lint/compile on the change: ruff check and python -m py_compile.
## Test Result
- Before: startup aborts with
ValueError: There is no module or parameter named 'k_proj' in MiniCPMV4_6ViTWindowAttentionSelfAttn .
- After: model loads successfully
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

