### PR TITLE
[Model] Skip unused Jina V5 output layers

### DIFF
--- a/tests/models/language/pooling/test_jina_embeddings_v5.py
+++ b/tests/models/language/pooling/test_jina_embeddings_v5.py
@@ -14,7 +14,6 @@ from types import SimpleNamespace
 from typing import cast
 
 import pytest
-import torch
 from transformers import PretrainedConfig
 
 from vllm.config import ModelConfig
@@ -22,13 +21,6 @@ from vllm.model_executor.models.config import (
     MODELS_CONFIG_MAP,
     JinaEmbeddingsV5ModelConfig,
 )
-from vllm.model_executor.models.jina import (
-    JinaEmbeddingsV5DecoderModel,
-    JinaEmbeddingsV5EncoderModel,
-)
-from vllm.model_executor.models.llama import LlamaForCausalLM
-from vllm.model_executor.models.qwen3 import Qwen3ForCausalLM
-from vllm.model_executor.models.utils import StageMissingLayer
 
 
 def _model_config(hf_config: PretrainedConfig) -> ModelConfig:
@@ -73,40 +65,3 @@ def test_supported_decoder_backbone_is_accepted():
     JinaEmbeddingsV5ModelConfig.verify_and_update_model_config(
         _model_config(PretrainedConfig(is_decoder=True))
     )
-
-
-@pytest.mark.cpu_test
-@pytest.mark.parametrize(
-    ("model_cls", "base_cls"),
-    [
-        (JinaEmbeddingsV5DecoderModel, Qwen3ForCausalLM),
-        (JinaEmbeddingsV5EncoderModel, LlamaForCausalLM),
-    ],
-)
-def test_pooling_model_skips_output_layer(monkeypatch, model_cls, base_cls):
-    class FakeLMHead(torch.nn.Linear):
-        pass
-
-    class FakeLogitsProcessor(torch.nn.Module):
-        pass
-
-    def fake_base_init(self, *, vllm_config, prefix=""):
-        torch.nn.Module.__init__(self)
-        self.model = torch.nn.Linear(2, 2, bias=False)
-        self.lm_head = FakeLMHead(2, 1024, bias=False)
-        self.logits_processor = FakeLogitsProcessor()
-
-    import vllm.model_executor.models.jina as jina_module
-
-    monkeypatch.setattr(jina_module, "ParallelLMHead", FakeLMHead)
-    monkeypatch.setattr(jina_module, "LogitsProcessor", FakeLogitsProcessor)
-    monkeypatch.setattr(jina_module, "_setup_jina_v5_task_and_pooler", lambda *_: None)
-    monkeypatch.setattr(base_cls, "__init__", fake_base_init)
-
-    model = model_cls(vllm_config=object())
-
-    assert isinstance(model.lm_head, StageMissingLayer)
-    assert isinstance(model.logits_processor, StageMissingLayer)
-    params = dict(model.named_parameters())
-    assert list(params) == ["model.weight"]
-    assert params["model.weight"] is model.model.weight

--- a/tests/models/language/pooling/test_jina_embeddings_v5.py
+++ b/tests/models/language/pooling/test_jina_embeddings_v5.py
@@ -14,6 +14,7 @@ from types import SimpleNamespace
 from typing import cast
 
 import pytest
+import torch
 from transformers import PretrainedConfig
 
 from vllm.config import ModelConfig
@@ -21,6 +22,13 @@ from vllm.model_executor.models.config import (
     MODELS_CONFIG_MAP,
     JinaEmbeddingsV5ModelConfig,
 )
+from vllm.model_executor.models.jina import (
+    JinaEmbeddingsV5DecoderModel,
+    JinaEmbeddingsV5EncoderModel,
+)
+from vllm.model_executor.models.llama import LlamaForCausalLM
+from vllm.model_executor.models.qwen3 import Qwen3ForCausalLM
+from vllm.model_executor.models.utils import StageMissingLayer
 
 
 def _model_config(hf_config: PretrainedConfig) -> ModelConfig:
@@ -65,3 +73,40 @@ def test_supported_decoder_backbone_is_accepted():
     JinaEmbeddingsV5ModelConfig.verify_and_update_model_config(
         _model_config(PretrainedConfig(is_decoder=True))
     )
+
+
+@pytest.mark.cpu_test
+@pytest.mark.parametrize(
+    ("model_cls", "base_cls"),
+    [
+        (JinaEmbeddingsV5DecoderModel, Qwen3ForCausalLM),
+        (JinaEmbeddingsV5EncoderModel, LlamaForCausalLM),
+    ],
+)
+def test_pooling_model_skips_output_layer(monkeypatch, model_cls, base_cls):
+    class FakeLMHead(torch.nn.Linear):
+        pass
+
+    class FakeLogitsProcessor(torch.nn.Module):
+        pass
+
+    def fake_base_init(self, *, vllm_config, prefix=""):
+        torch.nn.Module.__init__(self)
+        self.model = torch.nn.Linear(2, 2, bias=False)
+        self.lm_head = FakeLMHead(2, 1024, bias=False)
+        self.logits_processor = FakeLogitsProcessor()
+
+    import vllm.model_executor.models.jina as jina_module
+
+    monkeypatch.setattr(jina_module, "ParallelLMHead", FakeLMHead)
+    monkeypatch.setattr(jina_module, "LogitsProcessor", FakeLogitsProcessor)
+    monkeypatch.setattr(jina_module, "_setup_jina_v5_task_and_pooler", lambda *_: None)
+    monkeypatch.setattr(base_cls, "__init__", fake_base_init)
+
+    model = model_cls(vllm_config=object())
+
+    assert isinstance(model.lm_head, StageMissingLayer)
+    assert isinstance(model.logits_processor, StageMissingLayer)
+    params = dict(model.named_parameters())
+    assert list(params) == ["model.weight"]
+    assert params["model.weight"] is model.model.weight

--- a/vllm/model_executor/models/jina.py
+++ b/vllm/model_executor/models/jina.py
@@ -11,6 +11,8 @@ from safetensors.torch import load as safetensors_load
 from torch import nn
 
 from vllm.config import VllmConfig
+from vllm.model_executor.layers.logits_processor import LogitsProcessor
+from vllm.model_executor.layers.vocab_parallel_embedding import ParallelLMHead
 from vllm.sequence import IntermediateTensors
 from vllm.tasks import PoolingTask
 from vllm.transformers_utils.repo_utils import get_hf_file_bytes
@@ -26,7 +28,13 @@ from .interfaces import SupportsLateInteraction
 from .interfaces_base import VllmModelForPooling
 from .llama import LlamaForCausalLM
 from .qwen3 import Qwen3ForCausalLM, Qwen3Model
-from .utils import AutoWeightsLoader, WeightsMapper, maybe_prefix
+from .utils import (
+    AutoWeightsLoader,
+    StageMissingLayer,
+    WeightsMapper,
+    maybe_prefix,
+    no_init_weights,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -267,7 +275,12 @@ class JinaEmbeddingsV5DecoderModel(Qwen3ForCausalLM, VllmModelForPooling):
     )
 
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
-        super().__init__(vllm_config=vllm_config, prefix=prefix)
+        with no_init_weights(
+            self,
+            lambda mod: StageMissingLayer("output", mod),
+            targets=(LogitsProcessor, ParallelLMHead),
+        ):
+            super().__init__(vllm_config=vllm_config, prefix=prefix)
         _setup_jina_v5_task_and_pooler(self, vllm_config)
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
@@ -289,7 +302,12 @@ class JinaEmbeddingsV5EncoderModel(LlamaForCausalLM, VllmModelForPooling):
     )
 
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
-        super().__init__(vllm_config=vllm_config, prefix=prefix)
+        with no_init_weights(
+            self,
+            lambda mod: StageMissingLayer("output", mod),
+            targets=(LogitsProcessor, ParallelLMHead),
+        ):
+            super().__init__(vllm_config=vllm_config, prefix=prefix)
         _setup_jina_v5_task_and_pooler(self, vllm_config)
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:


### PR DESCRIPTION
## Purpose

Jina Embeddings V5 models are pooling-only, but their vLLM wrappers inherit
causal-LM classes. Because these wrappers already declare themselves as pooling
models, they bypass the generic pooling adapter that replaces generation-only
output layers. The encoder/nano variant therefore retained an unused
`ParallelLMHead` with shape `[128256, 768]`.

This change applies the existing pooling-model `no_init_weights` pattern to
both Jina V5 wrappers, replacing `ParallelLMHead` and `LogitsProcessor` with a
`StageMissingLayer`. The decoder/small checkpoint ties its output head to the
input embedding (`VocabParallelEmbedding`), so that shared embedding remains
intact.

On an NVIDIA RTX PRO 6000 Blackwell (TP=1), the nano checkpoint's loaded model
state changed as follows:

| Metric | Before | After |
|---|---:|---:|
| Registered parameter bytes | 620,533,248 | 423,532,032 |
| Unused `lm_head` bytes | 197,001,216 | 0 |
| CUDA memory delta after model load | 1,283,457,024 | 1,086,324,736 |

This removes 187.875 MiB of resident parameters (31.75%) and approximately
188 MiB of post-load CUDA memory. This is a resident-memory result; it is not a
claim that the transient module-construction peak is eliminated.

I searched open vLLM PRs and issues for Jina V5/Embeddings V5 combined with
`lm_head`, output-layer, and pooling terms and found no direct or semantic
duplicate. #32757 is the already-merged generic pooling mechanism used as the
implementation precedent, not another Jina-specific fix.

AI assistance (OpenAI Codex) was used to help investigate, implement, and test
this change. I reviewed the complete diff and the validation results.

## Test Plan

- Load and embed two natural prompts with both the base and patched
  `jinaai/jina-embeddings-v5-text-nano` checkpoints; compare parameter and
  post-load CUDA memory plus float32 embedding bytes.
- Repeat the embedding comparison with
  `jinaai/jina-embeddings-v5-text-small` to cover its tied embedding.
- Run the existing Jina pooling-model, adapter, and registry tests, then all
  pre-commit hooks applicable to the changed production file.

Commands:

```bash
.venv/bin/python -m pytest -q \
  tests/models/language/pooling/test_jina_embeddings_v5.py \
  tests/models/test_adapters.py \
  'tests/models/test_registry.py::test_registry_imports[JinaEmbeddingsV5Model]'

uvx pre-commit run --files \
  vllm/model_executor/models/jina.py

git diff --check
```

## Test Result

- Pytest: **12 passed**.
- Pre-commit: all applicable hooks passed, including Ruff, formatting, mypy,
  SPDX, forbidden-import, and configuration checks.
- Nano real-model A/B:
  - Both runs produced embedding SHA-256
    `f355f21e03004acfc86af056b3610282290563ab563dd5f9d04e5768bca06688`.
  - Both output vectors had shape `[768]` and L2 norm `1.0`.
  - Resident parameter and CUDA memory reductions are reported above.
- Small real-model A/B:
  - Both runs retained 1,192,099,840 parameter bytes and no independent
    `lm_head`, confirming the tied input embedding was not removed.
  - Both produced embedding SHA-256
    `c740490981d58e61cee407638b98c0ad724674e11341bc94086a7fa19a675942`.
  - Both output vectors had shape `[1024]` and L2 norm `1.0`.
