### PR TITLE
[Bugfix] Fix collect_env.py crash when pip list command fails

### DIFF
--- a/tests/test_collect_env.py
+++ b/tests/test_collect_env.py
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from vllm.collect_env import get_pip_packages
+
+
+def test_get_pip_packages_handles_failed_command():
+    """`get_pip_packages` must not crash when the list command fails.
+
+    In a uv venv without `uv` on PATH, the command returns a nonzero code
+    and `run_and_read_all` returns None. Guard against calling
+    `.splitlines()` on None.
+    """
+
+    def failing_run_lambda(command):
+        return 1, "", "command not found"
+
+    _, out = get_pip_packages(failing_run_lambda)
+    assert out is None

--- a/vllm/collect_env.py
+++ b/vllm/collect_env.py
@@ -660,7 +660,6 @@ def get_pip_packages(run_lambda, patterns=None):
         if pip_available:
             cmd = [sys.executable, "-mpip", "list", "--format=freeze"]
         elif is_uv_venv():
-            print("uv is set")
             cmd = ["uv", "pip", "list", "--format=freeze"]
         else:
             raise RuntimeError(
@@ -668,6 +667,8 @@ def get_pip_packages(run_lambda, patterns=None):
             )
 
         out = run_and_read_all(run_lambda, cmd)
+        if out is None:
+            return None
         return "\n".join(
             line for line in out.splitlines() if any(name in line for name in patterns)
         )


### PR DESCRIPTION
## Purpose

Fixes the `collect_env.py` crash noted in #52027: in a uv venv with `uv` not on `PATH`, the pip-list command fails, `run_and_read_all` returns `None`, and `run_with_pip()` calls `None.splitlines()` → `AttributeError`.

Separate from #52026 (the logging fix for the same issue), which doesn't touch this file.

## Changes

- Return `None` when the list command fails, instead of calling `.splitlines()` on it (matches `get_conda_packages`; callers already handle `None`).
- Remove a leftover `print("uv is set")` debug line.

## Test

`tests/test_collect_env.py`: calls `get_pip_packages` with a failing command and checks it returns `None` instead of crashing.

```bash
.venv/bin/python -m pytest tests/test_collect_env.py -v
```
Passing; ruff clean.

## Related
- Refs [#52027](https://github.com/vllm-project/vllm/issues/52027) (fixes the collect_env.py part)
- Separate from #52026 (the logging fix for the same issue); doesn't touch this file

Notes
AI assistance was used; I reviewed every line and ran the test.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>
