### PR TITLE
[Bugfix] Add DeepseekV4ForCausalLM to benchmark_moe.py model param dispatch

### DIFF
--- a/benchmarks/kernels/benchmark_moe.py
+++ b/benchmarks/kernels/benchmark_moe.py
@@ -766,6 +766,7 @@ def get_model_params(config):
         "DeepseekV2ForCausalLM",
         "DeepseekV3ForCausalLM",
         "DeepseekV32ForCausalLM",
+        "DeepseekV4ForCausalLM",
         "GlmMoeDsaForCausalLM",
         "Glm4MoeForCausalLM",
         "Glm4MoeLiteForCausalLM",


### PR DESCRIPTION
## Purpose

Fixes #52042.

`benchmark_moe.py --tune` crashes for DeepSeek-V4 models
(e.g. `deepseek-ai/DeepSeek-V4-Flash-0731`):

```text
AttributeError: 'DeepseekV4Config' object has no attribute 'num_local_experts'
```

`get_model_params()` dispatches on the architecture string. The DeepSeek-family
branch reads `n_routed_experts` / `num_experts_per_tok` / `moe_intermediate_size`,
but `DeepseekV4ForCausalLM` is missing from its tuple, so V4 falls through to the
Mixtral default, which reads `num_local_experts` — not present on DeepSeek configs.

This adds `DeepseekV4ForCausalLM` (the registered arch name, see
`vllm/model_executor/models/registry.py`) to that tuple. vLLM's own V4 model reads
exactly those three fields when building the MoE gate and experts
(`vllm/models/deepseek_v4/nvidia/model.py`), so the branch returns the correct
shapes rather than plausible-but-wrong ones.

`DeepSeekV4MTPModel` / `DSparkDraftModel` are intentionally left out: the dispatch
carries no MTP/draft architecture for any family, and this benchmark tunes
main-model MoE shapes.

**Relation to existing PRs:** #49088 generalizes this dispatch to alias-based field
probing and would make this change redundant, but it has been inactive since
2026-07-19; this is a minimal targeted unblock for the filed issue, and I am happy
to close it if #49088 lands first. #40546 only improves the fallback error message.
#50082 adds Kimi K3 via the same one-architecture pattern.

## Test Plan

The change only affects config-field dispatch, so no GPU is required. Called
`get_model_params()` with a `DeepseekV4Config` carrying V4-Flash MoE fields
(`n_routed_experts=256`, `num_experts_per_tok=8`, `moe_intermediate_size=2048`,
`hidden_size=7168`), plus a `DeepseekV3ForCausalLM` control to confirm the existing
branch is unaffected.

## Test Result

- Before: `AttributeError: 'DeepseekV4Config' object has no attribute 'num_local_experts'` — the exact error from #52042
- After: returns `(256, 8, 2048, 7168)`
- V3 control unchanged: `(160, 6, 1536, 5120)`
- `ruff check` and `ruff format --check` clean on the file

Model evaluation: not applicable — this is a benchmarking-script fix with no effect
on model output, accuracy, or serving.

---

This change was developed with AI assistance; I reviewed and tested every line.
