### PR TITLE
[ROCm] Use silu_and_mul_with_clamp's torch._C op

### DIFF
--- a/tests/kernels/core/test_activation.py
+++ b/tests/kernels/core/test_activation.py
@@ -236,6 +236,10 @@ def test_swiglu_limit_func_without_routing_uses_output_buffer() -> None:
     torch.testing.assert_close(output, expected, atol=2e-2, rtol=2e-2)
 
 
+@pytest.mark.parametrize(
+    ("alpha", "beta"),
+    [(1.0, 0.0), (1.702, 0.0), (1.0, 1.0)],
+)
 @pytest.mark.parametrize("swiglu_limit", SWIGLU_LIMITS)
 @pytest.mark.parametrize("num_tokens", NUM_TOKENS)
 @pytest.mark.parametrize("d", D)
@@ -245,6 +249,8 @@ def test_swiglu_limit_func_without_routing_uses_output_buffer() -> None:
 @torch.inference_mode()
 def test_silu_and_mul_with_clamp(
     default_vllm_config,
+    alpha: float,
+    beta: float,
     swiglu_limit: float,
     num_tokens: int,
     d: int,
@@ -258,7 +264,24 @@ def test_silu_and_mul_with_clamp(
     # Use large values to ensure clamping is exercised.
     x = torch.randn(num_tokens, 2 * d, dtype=dtype) * swiglu_limit * 2
 
-    layer = SiluAndMulWithClamp(swiglu_limit, compile_native=False)
+    default_vllm_config.compilation_config.custom_ops = [
+        "none",
+        "+silu_and_mul_with_clamp",
+    ]
+    layer = SiluAndMulWithClamp(
+        swiglu_limit,
+        alpha=alpha,
+        beta=beta,
+        compile_native=False,
+    )
+    if current_platform.is_rocm():
+        expected_method = (
+            layer.forward_hip if alpha == 1.0 and beta == 0.0 else layer.forward_native
+        )
+        assert layer._forward_method == expected_method
+    else:
+        assert layer._forward_method == layer.forward_cuda
+
     out = layer(x)
     ref_out = layer.forward_native(x)
 
@@ -273,10 +296,11 @@ def test_silu_and_mul_with_clamp(
 
     # Verify clamping is actually being applied: the clamped output should
     # differ from the unclamped SiluAndMul output when inputs are large.
-    unclamped_out = SiluAndMul.forward_native(x)
-    assert not torch.equal(ref_out.float(), unclamped_out.float()), (
-        "Input was not large enough to exercise the clamp; increase scale"
-    )
+    if alpha == 1.0 and beta == 0.0:
+        unclamped_out = SiluAndMul.forward_native(x)
+        assert not torch.equal(ref_out.float(), unclamped_out.float()), (
+            "Input was not large enough to exercise the clamp; increase scale"
+        )
 
     # Verify gate clamping semantics with a controlled scalar case.
     # gate=large_val is clamped to limit first, then silu(limit) * 1.0.
@@ -309,7 +333,10 @@ def test_silu_and_mul_with_clamp(
 
     # opcheck
     out_buf = torch.empty(x.shape[:-1] + (d,), dtype=dtype, device=device)
-    opcheck(torch.ops._C.silu_and_mul_with_clamp, (out_buf, x, swiglu_limit))
+    opcheck(
+        torch.ops._C.silu_and_mul_with_clamp,
+        (out_buf, x, swiglu_limit, layer.alpha, layer.beta),
+    )
 
 
 @pytest.mark.parametrize("linear_beta", [-1.0, 2.0])

--- a/vllm/model_executor/layers/activation.py
+++ b/vllm/model_executor/layers/activation.py
@@ -229,10 +229,15 @@ class SiluAndMulWithClamp(CustomOp):
         self.swiglu_limit = float(swiglu_limit)
         self.alpha = float(alpha)
         self.beta = float(beta)
-        if current_platform.is_rocm() or current_platform.is_xpu():
+        if current_platform.is_xpu():
             self._forward_method = self.forward_native
         elif current_platform.is_cuda_alike():
-            self.op = torch.ops._C.silu_and_mul_with_clamp
+            # Limit the ROCm _C path to the default case to avoid the
+            # precision loss MiniMax saw without fp32 intermediates.
+            if current_platform.is_rocm() and (self.alpha != 1.0 or self.beta != 0.0):
+                self._forward_method = self.forward_native
+            else:
+                self.op = torch.ops._C.silu_and_mul_with_clamp
         elif current_platform.is_cpu():
             self._forward_method = self.forward_native
 


### PR DESCRIPTION
This is limited to alpha=1.0 and beta=0.0 as a safety consideration due to MiniMax previously avoiding this kernel in other cases.

During DeepSeekV4, day 0 support, forward_cuda was disabled in favor of forward_native for silu_and_mul_with_clamp. This can be reverted for similar accuracy and around a 6% speedup in cases without speculative decode.

Example Command:
VLLM_ROCM_USE_AITER=1 vllm serve deepseek-ai/DeepSeek-V4-Flash-0731 \
    --attention_backend ROCM_AITER_UNIFIED_ATTN \
    --compilation_config '{"mode":3,"cudagraph_mode":"FULL_DECODE_ONLY"}' \
    --gpu_memory_utilization 0.9 \
    --host 0.0.0.0 \
    --max_model_len 4096 \
    --max_num_seqs 512 \
    --no_enable_prefix_caching \
    --port 39817 \
    --tensor_parallel_size 4 \
    --no-enable-log-requests \
    --dtype auto \
    --kv-cache-dtype fp8 \
    --max-num-batched-tokens 8192 \
    --distributed-executor-backend mp \
    --trust-remote-code \
    --tokenizer-mode deepseek_v4 \
    --reasoning-parser deepseek_v4 \
    --tool-call-parser deepseek_v4 \
    --enable-auto-tool-choice

Accuracy for gsm8k with num_fewshot=8 remained in the 0.94 range.

Performance (tok/s before->after) for ISL=512, OSL=1024, temperature=0: concurrency=16: 1762.42->1883.16 (6.85%)
concurrency=128: 9152.36-> 9602.00 (5%)