### PR TITLE
[Build][AMD] Update triton_kernels pin for RDNA MXFP4 matmul_ogs config

### DIFF
--- a/cmake/external_projects/triton_kernels.cmake
+++ b/cmake/external_projects/triton_kernels.cmake
@@ -13,7 +13,7 @@ else()
   if (VLLM_TARGET_DEVICE STREQUAL "rocm")
     set(TRITON_GIT "https://github.com/ROCm/triton.git")
     # Pinned from release/internal/3.6.x
-    set(TRITON_KERNELS_TAG "0f380657dbf3ee86eb57558ff71df24f03b5d4e7")
+    set(TRITON_KERNELS_TAG "74e4569a70a34d7466d3707bf9d8a7762167068e")
   else()
     set(TRITON_GIT "https://github.com/triton-lang/triton.git")
     set(TRITON_KERNELS_TAG "v3.5.1")

--- a/docker/Dockerfile.rocm
+++ b/docker/Dockerfile.rocm
@@ -5,7 +5,7 @@ ARG VLLM_BRANCH="main"
 ARG COMMON_WORKDIR=/app
 ARG BASE_IMAGE=rocm/vllm-dev:base
 ARG CI_BASE_IMAGE=rocm/vllm-dev:ci_base
-ARG ROCM_TRITON_KERNELS_COMMIT=0f380657dbf3ee86eb57558ff71df24f03b5d4e7
+ARG ROCM_TRITON_KERNELS_COMMIT=74e4569a70a34d7466d3707bf9d8a7762167068e
 ARG INSTALL_LMCACHE=false
 # NIC backend for MoRI RDMA support.
 # By default (all), drivers and userspace libraries for all supported NIC types


### PR DESCRIPTION
Advances the ROCm triton_kernels pin to 74e4569a70, which backports upstream Triton PR #10810 ("[AMD][kernels] Improve MXFP4 matmul_ogs config on RDNA"). Avoids register spilling in the MXFP4 MoE GEMMs on RDNA.




## Purpose

Advances the ROCm `triton_kernels` pin in `cmake/external_projects/triton_kernels.cmake` from
`0f380657` to `74e4569a70`, picking up the RDNA MXFP4 `matmul_ogs` configuration change.

- Upstream Triton PR: https://github.com/triton-lang/triton/pull/10810
- ROCm backport (the commit this pin now points at): https://github.com/ROCm/triton/pull/951

**Why it matters.** On RDNA the current pin selects `block_m = 128` tiles for the MXFP4 MoE GEMMs. The
fp32 accumulator alone is `BLOCK_M × BLOCK_N` registers, which at that tile size consumes half of the
256-VGPR wave32 budget before any operand is loaded. Register demand exceeds the architectural cap, the
compiler spills to scratch memory, and the spills land inside the K-loop where the cost is paid on every
iteration. WMMA instruction counts are unchanged — the arithmetic is identical and the extra time is pure
spill overhead.

The backported configuration sets `block_m` explicitly for MXFP4 on RDNA, so the spilling tiles are never
built.

This is a pin bump only. The kernel selection logic is ROCm's backport of upstream work; no vLLM code is
changed beyond the pinned SHA.

## Test Plan

`gpt-oss-20b` (MXFP4 MoE) on RDNA, TP=1. 

```bash
vllm bench throughput \
  --model openai/gpt-oss-20b --max_model_len 4096 --trust-remote-code \
  --dataset-name sharegpt --dataset-path ShareGPT_V3_unfiltered_cleaned_split.json \
  --num_prompts 1000 --tensor_parallel_size 1 --gpu-memory-utilization 0.8
```

Register and spill counts read from `.vgpr_count` / `.vgpr_spill_count` in the compiled `.amdgcn`
products, selecting the autotune-chosen variant by `num_warps`.

## Test Result

Confirmed the performance gain on RDNA that the linked PRs describe. 
Throughput improved and no remaining kernel spills observed.