### PR TITLE
[ROCm][Perf] Fold scalar KV scales in MiniMax-M3 sparse attention

### DIFF
--- a/vllm/models/minimax_m3/amd/ops/sparse_attn.py
+++ b/vllm/models/minimax_m3/amd/ops/sparse_attn.py
@@ -117,6 +117,11 @@ def _gqa_sparse_fwd_kernel(
     SUB_K: tl.constexpr,  # CDNA only: KV sub-tile width (see _IS_MI3XX)
 ):
     sm_scale_log2e = sm_scale * 1.4426950409
+    # Scalar KV scales are loop invariant. Fold them into the QK scale and
+    # normalized output instead of scaling every K/V element.
+    if KV_SCALE_MODE == 1:
+        sm_scale_log2e *= tl.load(k_scale_ptr)
+        value_scale = tl.load(v_scale_ptr)
     pid_q = tl.program_id(0)
     pid_kh = tl.program_id(1)
     pid_b = tl.program_id(2)
@@ -176,9 +181,7 @@ def _gqa_sparse_fwd_kernel(
                 )
                 if USE_FP8:
                     k_sub = k_sub.to(q.dtype)
-                    if KV_SCALE_MODE == 1:
-                        k_sub = (k_sub * tl.load(k_scale_ptr)).to(q.dtype)
-                    elif KV_SCALE_MODE == 2:
+                    if KV_SCALE_MODE == 2:
                         k_scale = tl.load(
                             k_scale_ptr
                             + pid_kh * stride_ks_h
@@ -212,9 +215,7 @@ def _gqa_sparse_fwd_kernel(
                 )
                 if USE_FP8:
                     v_sub = v_sub.to(q.dtype)
-                    if KV_SCALE_MODE == 1:
-                        v_sub = (v_sub * tl.load(v_scale_ptr)).to(q.dtype)
-                    elif KV_SCALE_MODE == 2:
+                    if KV_SCALE_MODE == 2:
                         v_scale = tl.load(
                             v_scale_ptr
                             + pid_kh * stride_vs_h
@@ -227,6 +228,8 @@ def _gqa_sparse_fwd_kernel(
                 m_i = m_ij
                 lse_i = m_ij + tl.log2(tl.exp2(lse_i - m_ij) + l_ij)
         acc_o = acc_o * tl.exp2(m_i - lse_i)[:, None]
+        if KV_SCALE_MODE == 1:
+            acc_o *= value_scale
         acc_o = tl.reshape(acc_o, BLOCK_SIZE_Q, BLOCK_SIZE_H, BLOCK_SIZE_D)
         o_ptrs = tl.make_block_ptr(
             base=o_ptr + q_start * stride_on + pid_h * stride_oh,

--- a/vllm/models/minimax_m3/common/ops/sparse_attn.py
+++ b/vllm/models/minimax_m3/common/ops/sparse_attn.py
@@ -94,6 +94,11 @@ def _gqa_sparse_fwd_kernel(
     KV_SCALE_MODE: tl.constexpr,  # 0: none, 1: scalar, 2: [kv_head, token]
 ):
     sm_scale_log2e = sm_scale * 1.4426950409
+    # Scalar KV scales are loop invariant. Fold them into the QK scale and
+    # normalized output instead of scaling every K/V element.
+    if KV_SCALE_MODE == 1:
+        sm_scale_log2e *= tl.load(k_scale_ptr)
+        value_scale = tl.load(v_scale_ptr)
     pid_q = tl.program_id(0)
     pid_kh = tl.program_id(1)
     pid_b = tl.program_id(2)
@@ -155,9 +160,7 @@ def _gqa_sparse_fwd_kernel(
             )
             if USE_FP8:
                 k = k.to(q.dtype)
-                if KV_SCALE_MODE == 1:
-                    k = (k * tl.load(k_scale_ptr)).to(q.dtype)
-                elif KV_SCALE_MODE == 2:
+                if KV_SCALE_MODE == 2:
                     k_scale = tl.load(
                         k_scale_ptr
                         + pid_kh * stride_ks_h
@@ -187,9 +190,7 @@ def _gqa_sparse_fwd_kernel(
             )
             if USE_FP8:
                 v = v.to(q.dtype)
-                if KV_SCALE_MODE == 1:
-                    v = (v * tl.load(v_scale_ptr)).to(q.dtype)
-                elif KV_SCALE_MODE == 2:
+                if KV_SCALE_MODE == 2:
                     v_scale = tl.load(
                         v_scale_ptr
                         + pid_kh * stride_vs_h
@@ -202,6 +203,8 @@ def _gqa_sparse_fwd_kernel(
             m_i = m_ij
             lse_i = m_ij + tl.log2(tl.exp2(lse_i - m_ij) + l_ij)
         acc_o = acc_o * tl.exp2(m_i - lse_i)[:, None]
+        if KV_SCALE_MODE == 1:
+            acc_o *= value_scale
         acc_o = tl.reshape(acc_o, BLOCK_SIZE_Q, BLOCK_SIZE_H, BLOCK_SIZE_D)
         o_ptrs = tl.make_block_ptr(
             base=o_ptr + q_start * stride_on + pid_h * stride_oh,
@@ -278,6 +281,11 @@ def _gqa_sparse_decode_kernel(
     USE_PDL: tl.constexpr,
 ):
     sm_scale_log2e = sm_scale * 1.4426950409
+    # Scalar KV scales are loop invariant. Fold them into the QK scale and
+    # normalized output instead of scaling every K/V element.
+    if KV_SCALE_MODE == 1:
+        sm_scale_log2e *= tl.load(k_scale_ptr)
+        value_scale = tl.load(v_scale_ptr)
     # split-K over the topk dimension: pid(0) folds (query-token, chunk).
     pid_bc, pid_kh = tl.program_id(0), tl.program_id(1)
     pid_b = pid_bc % total_q
@@ -341,9 +349,7 @@ def _gqa_sparse_decode_kernel(
         )
         if USE_FP8:
             k = k.to(q.dtype)
-            if KV_SCALE_MODE == 1:
-                k = (k * tl.load(k_scale_ptr)).to(q.dtype)
-            elif KV_SCALE_MODE == 2:
+            if KV_SCALE_MODE == 2:
                 k_scale = tl.load(
                     k_scale_ptr
                     + pid_kh * stride_ks_h
@@ -370,9 +376,7 @@ def _gqa_sparse_decode_kernel(
         )
         if USE_FP8:
             v = v.to(q.dtype)
-            if KV_SCALE_MODE == 1:
-                v = (v * tl.load(v_scale_ptr)).to(q.dtype)
-            elif KV_SCALE_MODE == 2:
+            if KV_SCALE_MODE == 2:
                 v_scale = tl.load(
                     v_scale_ptr
                     + pid_kh * stride_vs_h
@@ -392,6 +396,8 @@ def _gqa_sparse_decode_kernel(
     # can hit 0 * NaN. All-empty padded rows may still produce NaNs in merge.
     scale = tl.where(lse_i > float("-inf"), tl.exp2(m_i - lse_i), tl.zeros_like(lse_i))
     acc_o = acc_o * scale[:, None]
+    if KV_SCALE_MODE == 1:
+        acc_o *= value_scale
     o_ptrs = tl.make_block_ptr(
         base=o_ptr + pid_c * stride_o_c + pid_b * stride_o_b + pid_h * stride_o_h,
         shape=(gqa_group_size, head_dim),


### PR DESCRIPTION
> **Note:** Validation required cherry-picking two fixes on top of the nightly image:
> - [PR #51585](https://github.com/vllm-project/vllm/pull/51585) — Fix CUDA graph capture failure (zeroed CPU query offsets broke mixed-attention metadata builders)
> - [PR #51632](https://github.com/vllm-project/vllm/pull/51632) — Fix Triton fused shared expert alignment (incorrect expert count caused silent accuracy loss)
>
> Base image: `vllm/vllm-openai-rocm:nightly-3ee2df30337a301164c46ae444b76ee67e71c106`

## Purpose

MiniMax-M3 Triton sparse attention currently applies scalar FP8 KV scales to every K and V element loaded inside the attention loop. These scales are loop invariant, so the repeated conversions and multiplications add unnecessary work.

## Suggested Fix

For scalar scales (`KV_SCALE_MODE == 1`), fold the K scale into the attention score scale and apply the V scale once to the normalized FP32 accumulator.

The change covers AMD prefill, common prefill, and common decode. No-scale and per-token/head scale modes remain unchanged through the existing compile-time dispatch.

## Test Plan

```bash
pytest -q tests/kernels/test_minimax_m3_sparse_attn_fp8_scale.py
```

Compares scalar and per-token/head FP8 KV-cache outputs against a dequantized BF16 reference for both prefill and decode.

<details>
<summary>Serve command</summary>

```bash
export HIP_VISIBLE_DEVICES=0,1,2,3
export VLLM_ROCM_USE_AITER=1
export VLLM_USE_BREAKABLE_CUDAGRAPH=0
export VLLM_ROCM_USE_AITER_MOE=0
export VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS=1

vllm serve EmbeddedLLM/MiniMax-M3-FP8-dynamic \
  --served-model-name minimax-m3 \
  --tensor-parallel-size 4 \
  --block-size 128 \
  --max-model-len 262144 \
  --gpu-memory-utilization 0.92 \
  --enable-chunked-prefill \
  --max-num-batched-tokens 32768 \
  --max-num-seqs 32 \
  --no-enable-prefix-caching \
  --async-scheduling \
  --tool-call-parser minimax_m3 \
  --enable-auto-tool-choice \
  --reasoning-parser minimax_m3 \
  --kv-cache-dtype fp8 \
  --language-model-only \
  --port 8000 \
  --attention-backend ROCM_AITER_UNIFIED_ATTN
```

</details>

## Test Result

Kernel accuracy: 4/4 passed (scalar + per-token/head, prefill + decode).

End-to-end serving on 4x MI325X (gfx942), TP4, `EmbeddedLLM/MiniMax-M3-FP8-dynamic`, FP8 KV cache:

| ISL/OSL | Concurrency | Metric | Baseline | This PR | Change |
|---------|-------------|--------|----------|---------|--------|
| 8k/1k | 4 | Output tok/s | 309.18 | 315.52 | **+2.0%** |
| 8k/1k | 4 | TTFT median (ms) | 1683 | 1541 | **-8.5%** |
| 8k/1k | 8 | Output tok/s | 470.73 | 485.37 | **+3.1%** |
| 8k/1k | 8 | TTFT median (ms) | 2123 | 2041 | **-3.9%** |
| 128k/1k | 4 | Output tok/s | 93.48 | 99.85 | **+6.8%** |
| 128k/1k | 4 | TTFT median (ms) | 19229 | 17552 | **-8.7%** |
| 128k/1k | 8 | Output tok/s | 105.05 | 113.14 | **+7.7%** |
| 128k/1k | 8 | TTFT median (ms) | 34297 | 31230 | **-8.9%** |


| Task | Filter | n-shot | Baseline | This PR |
|------|--------|--------|----------|---------|
| GSM8K (full, 1319) | flexible-extract | 8 | 93.18% ± 0.69 | 92.95% ± 0.71 |
| GSM8K (full, 1319) | strict-match | 8 | 93.18% ± 0.69 | 92.87% ± 0.71 |
