### PR TITLE
Revert KV block zeroing generalization due to ROCm launch overflow

### DIFF
--- a/tests/v1/core/test_single_type_kv_cache_manager.py
+++ b/tests/v1/core/test_single_type_kv_cache_manager.py
@@ -26,12 +26,7 @@ from vllm.v1.kv_cache_interface import (
 pytestmark = pytest.mark.cpu_test
 
 
-def get_sliding_window_manager(
-    sliding_window_spec,
-    block_pool,
-    enable_caching=True,
-    needs_kv_cache_zeroing=False,
-):
+def get_sliding_window_manager(sliding_window_spec, block_pool, enable_caching=True):
     # Tests don't exercise admission gating; pass a large cap that is a no-op.
     return SlidingWindowManager(
         sliding_window_spec,
@@ -39,16 +34,12 @@ def get_sliding_window_manager(
         enable_caching=enable_caching,
         kv_cache_group_id=0,
         scheduler_block_size=sliding_window_spec.block_size,
-        needs_kv_cache_zeroing=needs_kv_cache_zeroing,
         max_admission_blocks_per_request=10**9,
     )
 
 
 def get_chunked_local_attention_manager(
-    chunked_local_attention_spec,
-    block_pool,
-    enable_caching=True,
-    needs_kv_cache_zeroing=False,
+    chunked_local_attention_spec, block_pool, enable_caching=True
 ):
     return ChunkedLocalAttentionManager(
         chunked_local_attention_spec,
@@ -56,65 +47,8 @@ def get_chunked_local_attention_manager(
         enable_caching=enable_caching,
         kv_cache_group_id=0,
         scheduler_block_size=chunked_local_attention_spec.block_size,
-        needs_kv_cache_zeroing=needs_kv_cache_zeroing,
         max_admission_blocks_per_request=10**9,
     )
-
-
-def test_sliding_window_records_new_blocks_for_zeroing():
-    block_size = 2
-    spec = SlidingWindowSpec(
-        block_size=block_size,
-        num_kv_heads=1,
-        head_size=1,
-        dtype=torch.float32,
-        sliding_window=4,
-    )
-    block_pool = BlockPool(
-        num_gpu_blocks=10, enable_caching=False, hash_block_size=block_size
-    )
-    manager = get_sliding_window_manager(
-        spec,
-        block_pool,
-        enable_caching=False,
-        needs_kv_cache_zeroing=True,
-    )
-
-    blocks = manager.allocate_new_blocks(
-        "request", num_tokens=4, num_tokens_main_model=4
-    )
-
-    assert manager.records_new_block_ids
-    assert manager.take_new_block_ids() == [block.block_id for block in blocks]
-    assert manager.take_new_block_ids() == []
-
-
-def test_chunked_local_attention_records_new_blocks_for_zeroing():
-    block_size = 2
-    spec = ChunkedLocalAttentionSpec(
-        block_size=block_size,
-        num_kv_heads=1,
-        head_size=1,
-        dtype=torch.float32,
-        attention_chunk_size=4,
-    )
-    block_pool = BlockPool(
-        num_gpu_blocks=10, enable_caching=False, hash_block_size=block_size
-    )
-    manager = get_chunked_local_attention_manager(
-        spec,
-        block_pool,
-        enable_caching=False,
-        needs_kv_cache_zeroing=True,
-    )
-
-    blocks = manager.allocate_new_blocks(
-        "request", num_tokens=4, num_tokens_main_model=4
-    )
-
-    assert manager.records_new_block_ids
-    assert manager.take_new_block_ids() == [block.block_id for block in blocks]
-    assert manager.take_new_block_ids() == []
 
 
 def test_chunked_local_attention_possible_cached_prefix():

--- a/tests/v1/worker/test_kv_block_zeroer.py
+++ b/tests/v1/worker/test_kv_block_zeroer.py
@@ -1,71 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-from types import SimpleNamespace
-
 import pytest
 import torch
 
-from vllm.v1.kv_cache_interface import (
-    ChunkedLocalAttentionSpec,
-    SlidingWindowSpec,
-)
-from vllm.v1.worker.utils import (
-    AttentionGroup,
-    KVBlockZeroer,
-    _zero_kv_blocks_kernel,
-)
-
-
-class _BlockFirstBackend:
-    @staticmethod
-    def get_kv_cache_block_dim(*args, **kwargs):
-        return 0
-
-
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
-@pytest.mark.parametrize(
-    "spec",
-    [
-        SlidingWindowSpec(
-            block_size=2,
-            num_kv_heads=1,
-            head_size=1,
-            dtype=torch.uint8,
-            sliding_window=4,
-        ),
-        ChunkedLocalAttentionSpec(
-            block_size=2,
-            num_kv_heads=1,
-            head_size=1,
-            dtype=torch.uint8,
-            attention_chunk_size=4,
-        ),
-    ],
-    ids=["sliding-window", "chunked-local"],
-)
-def test_attention_blocks_are_zeroed(spec):
-    device = torch.device("cuda")
-    storage = torch.ones((4, 1, 2, 2), dtype=torch.uint8, device=device)
-    layer_name = "draft.self_attn"
-    zeroer = KVBlockZeroer(
-        device,
-        attn_groups_iter=[
-            AttentionGroup(_BlockFirstBackend, [layer_name], spec, 0)  # type: ignore[arg-type]
-        ],
-        kernel_block_sizes=[2],
-        cache_dtype="fp8",
-        static_forward_context={
-            layer_name: SimpleNamespace(kv_cache=storage),
-        },
-    )
-
-    zeroer.zero_block_ids([1])
-    torch.accelerator.synchronize()
-
-    expected = torch.ones_like(storage)
-    expected[1] = 0
-    assert torch.equal(storage, expected)
+from vllm.v1.worker.utils import KVBlockZeroer, _zero_kv_blocks_kernel
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -16,7 +16,6 @@ from vllm.v1.core.kv_cache_utils import (
     resolve_block_hashes,
 )
 from vllm.v1.kv_cache_interface import (
-    AttentionSpec,
     ChunkedLocalAttentionSpec,
     CrossAttentionSpec,
     FullAttentionSpec,
@@ -84,8 +83,11 @@ class SingleTypeKVCacheManager(ABC):
         self._max_admission_blocks_per_request = max_admission_blocks_per_request
         # Record newly allocated block ids only when worker-side zeroing will
         # consume them and this manager holds a spec type that gets zeroed.
-        self._record_new_block_ids = needs_kv_cache_zeroing and isinstance(
-            kv_cache_spec, AttentionSpec
+        self._record_new_block_ids = needs_kv_cache_zeroing and type(kv_cache_spec) in (
+            FullAttentionSpec,
+            TQFullAttentionSpec,
+            MLAAttentionSpec,
+            HiddenStateCacheSpec,
         )
         self.new_block_ids: list[int] = []
 

--- a/vllm/v1/worker/utils.py
+++ b/vllm/v1/worker/utils.py
@@ -29,6 +29,7 @@ from vllm.v1.core.kv_cache_utils import KVCacheBlockCopy
 from vllm.v1.kv_cache_interface import (
     AttentionSpec,
     EncoderOnlyAttentionSpec,
+    FullAttentionSpec,
     KVCacheConfig,
     KVCacheGroupSpec,
     KVCacheSpec,
@@ -146,7 +147,7 @@ class KVBlockZeroer:
 
         for group in attn_groups_iter:
             spec = group.kv_cache_spec
-            if not isinstance(spec, AttentionSpec):
+            if not isinstance(spec, FullAttentionSpec):
                 continue
             if group.kv_cache_group_id >= len(kernel_block_sizes):
                 continue


### PR DESCRIPTION
## Summary

- Revert #51749, which generalized KV block zeroing from `FullAttentionSpec` to every `AttentionSpec`.
- On DeepSeek-V4-Pro with ROCm and 64 concurrent GSM8K requests, the broader zeroing path makes `_zero_kv_blocks_kernel` launch with a grid that exceeds the AMD Triton driver's signed integer limit.
- The resulting `OverflowError: signed integer is greater than maximum` kills the engine and causes all in-flight `/v1/chat/completions` requests to return HTTP 500.

## Duplicate check

I searched open PRs for `51749`, `KVBlockZeroer OverflowError ROCm`, and `Generalize KV block zeroing revert`; no existing PR addresses this failure.

## Test plan

- [x] `.venv/bin/python -m pytest tests/v1/core/test_single_type_kv_cache_manager.py tests/v1/worker/test_kv_block_zeroer.py -q` — 14 passed
- [x] Before revert: `dsv4_rocm_bench/run_gsm8k.sh` at concurrency 64 reproduced the worker failure in `KVBlockZeroer.zero_block_ids`, followed by `EngineDeadError` and HTTP 500 responses.
- [x] After revert: the full 1,319-sample GSM8K run completed at concurrency 64 in 192.2 seconds.
  - strict exact match: 0.96285
  - flexible exact match: 0.96209

This PR intentionally makes no claim about output quality from raw `/v1/completions` requests; DeepSeek-V4-Pro expects chat-template formatting, and the post-revert GSM8K evaluation used `/v1/chat/completions`.

AI assistance was used for log triage, identifying the failing code path, and drafting this PR. The human submitter reviewed the changes and ran the tests above.

Made with [Cursor](https://cursor.com)