### PR TITLE
Avoid AITER FP8 BMM for MLA K projection

### DIFF
--- a/tests/v1/attention/test_mla_backends.py
+++ b/tests/v1/attention/test_mla_backends.py
@@ -155,6 +155,88 @@ def test_mla_post_load_preserves_runtime_weight_addresses(monkeypatch):
     torch.testing.assert_close(layer.W_UK_T, old_w_uk_t + 100)
 
 
+def test_mla_aiter_fp8_post_load_keeps_k_side_dense(monkeypatch):
+    layer = MLAAttention.__new__(MLAAttention)
+    torch.nn.Module.__init__(layer)
+    layer.kv_lora_rank = 2
+    layer.num_heads = 2
+    layer.qk_nope_head_dim = 3
+    layer.v_head_dim = 4
+    layer.kv_b_proj = torch.nn.Module()
+    layer.kv_b_proj.weight = torch.nn.Parameter(
+        torch.arange(28.0, dtype=torch.float16).reshape(14, 2)
+    )
+    layer.kv_b_proj.quant_method = None
+    layer.is_aiter_triton_fp4_bmm_enabled = False
+    layer.is_aiter_triton_fp8_bmm_enabled = True
+    layer.dcp_q_replicate = False
+    layer.quant_config = None
+    layer.layer_name = "test"
+
+    precompile_weights = []
+
+    def fake_dynamic_per_batched_tensor_quant(weight, dtype):
+        return weight.contiguous(), torch.ones((), device=weight.device)
+
+    def fake_triton_fp8_bmm(x, weight, scale, **kwargs):
+        precompile_weights.append(weight)
+        return torch.empty(
+            (x.shape[0], x.shape[1], weight.shape[1]),
+            dtype=x.dtype,
+            device=x.device,
+        )
+
+    monkeypatch.setattr(
+        mla_attention_module, "set_default_quant_scales", lambda *_, **__: None
+    )
+    monkeypatch.setattr(
+        mla_attention_module,
+        "dynamic_per_batched_tensor_quant",
+        fake_dynamic_per_batched_tensor_quant,
+    )
+    monkeypatch.setattr(mla_attention_module, "is_global_first_rank", lambda: False)
+    monkeypatch.setattr(
+        mla_attention_module.current_platform,
+        "fp8_dtype",
+        lambda: torch.float8_e4m3fn,
+    )
+    monkeypatch.setattr(
+        mla_attention_module.rocm_aiter_ops,
+        "triton_fp8_bmm",
+        fake_triton_fp8_bmm,
+        raising=False,
+    )
+
+    layer.process_weights_after_loading(torch.float32)
+
+    kv_b_proj_weight = layer.kv_b_proj.weight.T.float().view(
+        layer.kv_lora_rank,
+        layer.num_heads,
+        layer.qk_nope_head_dim + layer.v_head_dim,
+    )
+    expected_w_uk_t = kv_b_proj_weight[:, :, : layer.qk_nope_head_dim].permute(1, 2, 0)
+    expected_w_v = kv_b_proj_weight[:, :, layer.qk_nope_head_dim :].permute(1, 2, 0)
+
+    torch.testing.assert_close(layer.W_UK_T, expected_w_uk_t)
+    torch.testing.assert_close(layer.W_V, expected_w_v)
+
+    q_nope = torch.arange(
+        layer.num_heads * 5 * layer.qk_nope_head_dim, dtype=torch.float32
+    ).view(layer.num_heads, 5, layer.qk_nope_head_dim)
+    actual_k_proj = torch.bmm(q_nope, layer.W_UK_T)
+    expected_k_proj = torch.einsum(
+        "nbp,lnp->nbl",
+        q_nope,
+        kv_b_proj_weight[:, :, : layer.qk_nope_head_dim],
+    )
+    torch.testing.assert_close(actual_k_proj, expected_k_proj)
+
+    assert not hasattr(layer, "W_K")
+    assert not hasattr(layer, "W_K_scale")
+    assert precompile_weights
+    assert all(weight is layer.W_V for weight in precompile_weights)
+
+
 # Validate parameter combinations during collection, before GPU fixtures run.
 PREFILL_BACKENDS_TO_TEST = [
     MLAPrefillBackendEnum.ROCM_AITER_FA,

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -893,15 +893,6 @@ class MLAAttention(nn.Module, AttentionLayerBase):
                     prequant=True,
                     y_scale=self._q_scale if fp8_attention else None,
                 )
-            elif self.is_aiter_triton_fp8_bmm_enabled:
-                # Multiply+Transpose (N, B, P)x(N, P, L)->(N, B, L)->(B, N, L)
-                mqa_ql_nope = rocm_aiter_ops.triton_fp8_bmm(
-                    mqa_q_nope,
-                    self.W_K,
-                    self.W_K_scale,
-                    group_size=128,
-                    transpose_bm=True,
-                )
             else:
                 # Pads the head_dim if necessary (for the underlying kernel)
                 N, B, P = mqa_q_nope.shape
@@ -1020,9 +1011,9 @@ class MLAAttention(nn.Module, AttentionLayerBase):
         return output_padded
 
     def process_weights_after_loading(self, act_dtype: torch.dtype):
-        # we currently do not have quantized bmm's which are needed for
-        # `W_UV` and `W_UK_T`, we just store fp16/bf16 copies and perform
-        # the bmm's in 16-bit, the extra memory overhead of this is fairly low
+        # Decode uses transformed K/V projection weights. Backends that do not
+        # support quantized BMMs keep these weights dense; AITER paths quantize
+        # the pieces they can run through their BMM kernels below.
         kv_b_proj_weight = get_and_maybe_dequant_weights(
             self.kv_b_proj, out_dtype=act_dtype
         ).T
@@ -1077,11 +1068,10 @@ class MLAAttention(nn.Module, AttentionLayerBase):
                 W_UV.permute(1, 2, 0)
             )
         elif self.is_aiter_triton_fp8_bmm_enabled:
-            W_K = W_UK.transpose(0, 1)  # 16 512 128
             W_V = W_UV.permute(1, 2, 0)  # 16 128 512
-            self.W_K, self.W_K_scale = dynamic_per_batched_tensor_quant(
-                W_K, dtype=current_platform.fp8_dtype()
-            )
+            # Keep the transformed K-side weight dense after dequant+transpose;
+            # the V-side up-projection still uses the AITER FP8 BMM.
+            replace_parameter(self, "W_UK_T", W_UK.permute(1, 2, 0), prefer_copy=True)
             self.W_V, self.W_V_scale = dynamic_per_batched_tensor_quant(
                 W_V, dtype=current_platform.fp8_dtype()
             )
@@ -1100,15 +1090,6 @@ class MLAAttention(nn.Module, AttentionLayerBase):
                 )
 
             for m in pre_compilation_list:
-                x = torch.empty(
-                    (self.W_K.shape[0], m, self.W_K.shape[2]),
-                    dtype=torch.bfloat16,
-                    device=self.W_K.device,
-                )
-                rocm_aiter_ops.triton_fp8_bmm(
-                    x, self.W_K, self.W_K_scale, group_size=128, transpose_bm=True
-                )
-
                 x = torch.empty(
                     (self.W_V.shape[0], m, self.W_V.shape[2]),
                     dtype=torch.bfloat16,


### PR DESCRIPTION
## Purpose

This changes the ROCm AITER FP8 MLA decode path so the K-side up-projection stays dense after the post-load transform, while the V-side up-projection continues to use the AITER FP8 BMM.

The K-side MLA projection is a skinny batched matmul. Requantizing the transformed K weight and routing it through AITER FP8 BMM adds overhead for this shape and adds another quantization step. Keeping K dense reuses the existing `torch.bmm` path, keeps the K-side math tied directly to the dequantized model weight, and leaves the V-side AITER path unchanged.

What changed:

- remove the AITER FP8 runtime branch for the K-side MLA projection
- keep `W_UK_T` dense in `process_weights_after_loading` for the AITER FP8 path
- keep quantizing/precompiling `W_V` for the V-side AITER FP8 BMM
- add a unit test that checks both the post-load storage contract and the K-side projection math

This PR was developed with AI assistance. I reviewed the changed code paths and ran the checks below.

## Duplicate-work check

No linked issue exists for this change. I checked for open duplicate work with:

- `gh pr list --repo vllm-project/vllm --state open --search "AITER MLA FP8 BMM warmup"`
- `gh pr list --repo vllm-project/vllm --state open --search "rocm aiter mla fp8 bmm"`
- `gh pr list --repo vllm-project/vllm --state open --search "triton_fp8_bmm mla warmup"`
- `gh issue list --repo vllm-project/vllm --state open --search "AITER MLA FP8 BMM warmup"`

The closest related open PR is #52096, which is also mine. It is related but not a duplicate: #52096 changes startup precompile bounds for the AITER FP8 BMM path, while this PR changes the runtime K-side MLA projection path. If one lands first, the other may need a small rebase in the same `process_weights_after_loading` area.

## Test Plan

Local focused correctness:

```bash
PYTHONPATH=. uv run --no-sync --python 3.12 \
  --with-requirements requirements/common.txt \
  --with pytest --with torch --with tblib \
  pytest -q --confcutdir=tests/v1/attention \
  tests/v1/attention/test_mla_backends.py::test_mla_kv_cache_spec_uses_layer_cache_dtype \
  tests/v1/attention/test_mla_backends.py::test_mla_post_load_preserves_runtime_weight_addresses \
  tests/v1/attention/test_mla_backends.py::test_mla_aiter_fp8_post_load_keeps_k_side_dense
```

Local lint:

```bash
pre-commit run --files \
  vllm/model_executor/layers/attention/mla_attention.py \
  tests/v1/attention/test_mla_backends.py
```

MI300X focused correctness and microbench remain from the earlier draft run. I have not rerun full serve/generation on this branch after rebasing to current `origin/main`.

## Test Result

Local focused correctness: `4 passed, 14 warnings`.

Local lint: `pre-commit run --files ...` passed.

Earlier MI300X focused correctness: `4 passed, 14 warnings`.

Earlier MI300X isolated K-side projection results:

| tokens | old AITER FP8 K BMM median us | dense K `torch.bmm` median us | median speedup |
|---:|---:|---:|---:|
| 1 | 35.205 | 14.536 | +142.2% |
| 2 | 34.709 | 14.630 | +137.2% |
| 4 | 34.777 | 14.795 | +135.1% |
| 8 | 34.813 | 14.665 | +137.4% |
| 16 | 34.778 | 14.692 | +136.7% |
| 32 | 34.852 | 14.800 | +135.5% |
| 64 | 34.728 | 13.852 | +150.7% |
| 128 | 34.272 | 13.934 | +146.0% |
| 256 | 34.517 | 13.887 | +148.6% |

Caveat: I could not complete a full editable vLLM ROCm build on the current RunPod image because it ships PyTorch `2.10.0+rocm7.1.1`, while current vLLM's ROCm `_C_stable_libtorch` extension expects a newer PyTorch stable C++ API. The build failed before this patch was involved, at `_C_stable_libtorch` with missing `torch::stable::Tensor::layout`. A full serve/generation check should be run in the official vLLM ROCm dev image or another environment with the current supported ROCm/PyTorch stack.
