### PR TITLE
[Perf][Spec Decode] Disable EAGLE cache-hit block drop for always-K=0 dynamic DSD

### DIFF
--- a/tests/v1/core/test_eagle_cache_drop_k0.py
+++ b/tests/v1/core/test_eagle_cache_drop_k0.py
@@ -3,6 +3,7 @@
 """Opt-in disable of EAGLE last-block drop on prefix-cache hits for always-K=0 DSD."""
 
 import pytest
+import torch
 
 from tests.v1.core.test_prefix_caching import (
     make_kv_cache_config,
@@ -14,6 +15,12 @@ from tests.v1.core.utils import create_scheduler
 from vllm.utils.hashing import sha256
 from vllm.v1.core.kv_cache_utils import init_none_hash
 from vllm.v1.core.sched.scheduler import Scheduler, compute_drop_eagle_on_cache_hit
+from vllm.v1.kv_cache_interface import (
+    FullAttentionSpec,
+    KVCacheConfig,
+    KVCacheGroupSpec,
+    SlidingWindowSpec,
+)
 from vllm.v1.structured_output import StructuredOutputManager
 
 pytestmark = pytest.mark.cpu_test
@@ -89,6 +96,7 @@ def _make_eagle_dsd_scheduler(
     enable_prefix_caching: bool = True,
     use_kv_connector: bool = False,
     num_speculative_tokens: int | None = 3,
+    method: str = "mtp",
 ) -> Scheduler:
     """Build a scheduler with EAGLE/MTP `use_eagle()` and an optional DSD table.
 
@@ -108,7 +116,7 @@ def _make_eagle_dsd_scheduler(
     base = create_scheduler(**kwargs)
     spec = base.vllm_config.speculative_config
     if spec is not None:
-        spec.method = "mtp"
+        spec.method = method
     return Scheduler(
         vllm_config=base.vllm_config,
         kv_cache_config=base.kv_cache_config,
@@ -221,7 +229,15 @@ def test_unitary_cache_hit_keeps_last_block_when_drop_disabled():
 def test_hybrid_cache_hit_keeps_last_block_when_drop_disabled():
     block_size = 16
     kv_cache_config = make_kv_cache_config_hybrid_model(block_size, 31, 3)
-    manager = make_kv_cache_manager(
+    dropped = make_kv_cache_manager(
+        kv_cache_config,
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=block_size,
+        use_eagle=True,
+        drop_eagle_on_cache_hit=True,
+    )
+    kept = make_kv_cache_manager(
         kv_cache_config,
         max_model_len=8192,
         enable_caching=True,
@@ -232,13 +248,149 @@ def test_hybrid_cache_hit_keeps_last_block_when_drop_disabled():
 
     num_full_blocks = 6
     common_token_ids = [i for i in range(num_full_blocks) for _ in range(block_size)]
-    req0 = make_request("0", common_token_ids + [6] * 7, block_size, sha256)
-    computed_blocks, num_computed_tokens, _ = manager.get_computed_blocks(req0)
-    manager.allocate_slots(
-        req0, len(req0.all_token_ids), num_computed_tokens, computed_blocks
+
+    def _hit(manager):
+        req0 = make_request("0", common_token_ids + [6] * 7, block_size, sha256)
+        computed_blocks, num_computed_tokens, _ = manager.get_computed_blocks(req0)
+        manager.allocate_slots(
+            req0, len(req0.all_token_ids), num_computed_tokens, computed_blocks
+        )
+        req1 = make_request("1", common_token_ids + [6] * 5, block_size, sha256)
+        computed_blocks, num_computed_tokens, _ = manager.get_computed_blocks(req1)
+        return [len(g) for g in computed_blocks.blocks], num_computed_tokens
+
+    drop_lens, drop_tokens = _hit(dropped)
+    keep_lens, keep_tokens = _hit(kept)
+
+    assert keep_tokens == num_full_blocks * block_size
+    assert keep_lens == [num_full_blocks] * len(keep_lens)
+    assert drop_tokens < keep_tokens
+    assert all(d < k for d, k in zip(drop_lens, keep_lens, strict=True))
+
+
+def _swa_eagle_hybrid_config(block_size: int = 8) -> KVCacheConfig:
+    return KVCacheConfig(
+        num_blocks=100,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["full"],
+                FullAttentionSpec(
+                    block_size=4 * block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float16,
+                ),
+            ),
+            KVCacheGroupSpec(
+                ["swa_mtp"],
+                SlidingWindowSpec(
+                    block_size=block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                    sliding_window=block_size,
+                ),
+                is_eagle_group=True,
+            ),
+        ],
     )
 
-    req1 = make_request("1", common_token_ids + [6] * 5, block_size, sha256)
-    computed_blocks, num_computed_tokens, _ = manager.get_computed_blocks(req1)
-    assert num_computed_tokens == num_full_blocks * block_size
-    assert len(computed_blocks.blocks[0]) == num_full_blocks
+
+def test_hybrid_extra_block_not_published_when_drop_disabled():
+    """Stock EAGLE publishes the post-boundary lookahead block; opt-out must not.
+
+    Copied geometry from test_eagle_swa_boundary_caches_post_boundary_block:
+    40-token prefix, 8-token SWA blocks, 32-token alignment. hashes[4] is the
+    extra block. This fails if cache_blocks() still adds +block_size when
+    drop_eagle_on_cache_hit is False.
+    """
+    block_size = 8
+    kv_cache_config = _swa_eagle_hybrid_config(block_size)
+    stock = make_kv_cache_manager(
+        kv_cache_config=kv_cache_config,
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=block_size,
+        use_eagle=True,
+        drop_eagle_on_cache_hit=True,
+    )
+    no_drop = make_kv_cache_manager(
+        kv_cache_config=kv_cache_config,
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=block_size,
+        use_eagle=True,
+        drop_eagle_on_cache_hit=False,
+    )
+
+    token_ids = [i for i in range(5) for _ in range(block_size)]
+
+    def _prime(manager):
+        req = make_request("0", token_ids, block_size, sha256)
+        computed_blocks, _, _ = manager.get_computed_blocks(req)
+        blocks = manager.allocate_slots(
+            req,
+            len(token_ids),
+            len(computed_blocks.blocks[0]) * block_size,
+            computed_blocks,
+        )
+        assert blocks is not None
+        return req
+
+    stock_req = _prime(stock)
+    assert stock.block_pool.get_cached_block(
+        stock_req.block_hashes[3], kv_cache_group_ids=[1]
+    )
+    assert stock.block_pool.get_cached_block(
+        stock_req.block_hashes[4], kv_cache_group_ids=[1]
+    )
+    stock.free(stock_req)
+
+    no_drop_req = _prime(no_drop)
+    assert no_drop.block_pool.get_cached_block(
+        no_drop_req.block_hashes[3], kv_cache_group_ids=[1]
+    )
+    assert not no_drop.block_pool.get_cached_block(
+        no_drop_req.block_hashes[4], kv_cache_group_ids=[1]
+    )
+    no_drop.free(no_drop_req)
+
+    hit_req = make_request("1", token_ids + [999], block_size, sha256)
+    _, num_computed_tokens, _ = no_drop.get_computed_blocks(hit_req)
+    assert num_computed_tokens == 4 * block_size
+
+
+def test_scheduler_eagle3_opt_in_always_k0_disables_eagle_cache_drop():
+    scheduler = _make_eagle_dsd_scheduler(
+        ALWAYS_K0, disable_eagle_cache_drop_for_k0=True, method="eagle3"
+    )
+    assert scheduler.use_eagle is True
+    assert scheduler.drop_eagle_on_cache_hit is False
+
+
+def test_speculative_config_flag_keeps_last_block_on_lookup():
+    """Public SpeculativeConfig flag must reach an actual cache prime/lookup."""
+    scheduler = _make_eagle_dsd_scheduler(
+        ALWAYS_K0, disable_eagle_cache_drop_for_k0=True
+    )
+    block_size = scheduler.block_size
+    token_ids = [0] * (3 * block_size)
+    n_blocks, n_tokens = _prime_and_lookup(
+        scheduler.kv_cache_manager, token_ids, block_size
+    )
+    assert n_blocks == 2
+    assert n_tokens == 2 * block_size
+
+
+def test_mixed_schedule_flag_still_drops_last_block_on_lookup():
+    """Flag + mixed C3 must still drop the last block, not just the boolean."""
+    scheduler = _make_eagle_dsd_scheduler(MIXED_K, disable_eagle_cache_drop_for_k0=True)
+    assert scheduler.drop_eagle_on_cache_hit is True
+    block_size = scheduler.block_size
+    token_ids = [0] * (3 * block_size)
+    n_blocks, n_tokens = _prime_and_lookup(
+        scheduler.kv_cache_manager, token_ids, block_size
+    )
+    assert n_blocks == 1
+    assert n_tokens == 1 * block_size

--- a/tests/v1/core/test_eagle_cache_drop_k0.py
+++ b/tests/v1/core/test_eagle_cache_drop_k0.py
@@ -1,0 +1,244 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Opt-in disable of EAGLE last-block drop on prefix-cache hits for always-K=0 DSD."""
+
+import pytest
+
+from tests.v1.core.test_prefix_caching import (
+    make_kv_cache_config,
+    make_kv_cache_config_hybrid_model,
+    make_kv_cache_manager,
+    make_request,
+)
+from tests.v1.core.utils import create_scheduler
+from vllm.utils.hashing import sha256
+from vllm.v1.core.kv_cache_utils import init_none_hash
+from vllm.v1.core.sched.scheduler import Scheduler, compute_drop_eagle_on_cache_hit
+from vllm.v1.structured_output import StructuredOutputManager
+
+pytestmark = pytest.mark.cpu_test
+
+ALWAYS_K0 = [(1, 16, 0)]
+MIXED_K = [(1, 2, 2), (3, 16, 0)]
+
+
+@pytest.fixture(autouse=True)
+def _auto_init_hash_fn():
+    init_none_hash(sha256)
+
+
+def _k0_lookup() -> list[int]:
+    # Index 0 is unused; remaining entries are K for batch sizes 1..N.
+    return [0, 0, 0, 0]
+
+
+def _mixed_lookup() -> list[int]:
+    return [0, 2, 2, 0]
+
+
+@pytest.mark.parametrize(
+    (
+        "disable_flag",
+        "enable_prefix_caching",
+        "has_kv_connector",
+        "use_eagle",
+        "dynamic_sd_lookup",
+        "expected",
+    ),
+    [
+        pytest.param(False, True, False, True, _k0_lookup(), True, id="default-off"),
+        pytest.param(
+            True, True, False, True, _k0_lookup(), False, id="opt-in-always-k0"
+        ),
+        pytest.param(
+            True, True, False, True, _mixed_lookup(), True, id="mixed-schedule"
+        ),
+        pytest.param(True, True, False, True, None, True, id="no-lookup"),
+        pytest.param(True, True, False, True, [0], True, id="lookup-index0-only"),
+        pytest.param(True, True, False, False, _k0_lookup(), True, id="not-eagle"),
+        pytest.param(
+            True, False, False, True, _k0_lookup(), True, id="no-prefix-cache"
+        ),
+        pytest.param(True, True, True, True, _k0_lookup(), True, id="kv-connector"),
+    ],
+)
+def test_compute_drop_eagle_on_cache_hit(
+    disable_flag: bool,
+    enable_prefix_caching: bool,
+    has_kv_connector: bool,
+    use_eagle: bool,
+    dynamic_sd_lookup: list[int] | None,
+    expected: bool,
+):
+    assert (
+        compute_drop_eagle_on_cache_hit(
+            disable_eagle_cache_drop_for_k0=disable_flag,
+            enable_prefix_caching=enable_prefix_caching,
+            has_kv_connector=has_kv_connector,
+            use_eagle=use_eagle,
+            dynamic_sd_lookup=dynamic_sd_lookup,
+        )
+        is expected
+    )
+
+
+def _make_eagle_dsd_scheduler(
+    schedule: list[tuple[int, int, int]] | None,
+    *,
+    disable_eagle_cache_drop_for_k0: bool = False,
+    enable_prefix_caching: bool = True,
+    use_kv_connector: bool = False,
+    num_speculative_tokens: int | None = 3,
+) -> Scheduler:
+    """Build a scheduler with EAGLE/MTP `use_eagle()` and an optional DSD table.
+
+    `create_scheduler` defaults to ngram, which is not EAGLE. Reconstruct after
+    flipping `method` so the gate sees `use_eagle=True` without loading a draft
+    model.
+    """
+    kwargs: dict = dict(
+        enable_prefix_caching=enable_prefix_caching,
+        use_kv_connector=use_kv_connector,
+        disable_eagle_cache_drop_for_k0=disable_eagle_cache_drop_for_k0,
+    )
+    if num_speculative_tokens is not None:
+        kwargs["num_speculative_tokens"] = num_speculative_tokens
+        if schedule is not None:
+            kwargs["num_speculative_tokens_per_batch_size"] = schedule
+    base = create_scheduler(**kwargs)
+    spec = base.vllm_config.speculative_config
+    if spec is not None:
+        spec.method = "mtp"
+    return Scheduler(
+        vllm_config=base.vllm_config,
+        kv_cache_config=base.kv_cache_config,
+        block_size=base.block_size,
+        log_stats=True,
+        structured_output_manager=StructuredOutputManager(base.vllm_config),
+    )
+
+
+def test_scheduler_default_keeps_eagle_cache_drop():
+    scheduler = _make_eagle_dsd_scheduler(ALWAYS_K0)
+    assert scheduler.use_eagle is True
+    assert scheduler.drop_eagle_on_cache_hit is True
+    assert scheduler.kv_cache_manager.drop_eagle_on_cache_hit is True
+    assert scheduler.kv_cache_manager.coordinator.drop_eagle_on_cache_hit is True
+
+
+def test_scheduler_opt_in_always_k0_disables_eagle_cache_drop():
+    scheduler = _make_eagle_dsd_scheduler(
+        ALWAYS_K0, disable_eagle_cache_drop_for_k0=True
+    )
+    assert scheduler.use_eagle is True
+    assert scheduler.dynamic_sd_lookup is not None
+    assert max(scheduler.dynamic_sd_lookup[1:]) == 0
+    assert scheduler.drop_eagle_on_cache_hit is False
+    assert scheduler.kv_cache_manager.drop_eagle_on_cache_hit is False
+    assert scheduler.kv_cache_manager.coordinator.drop_eagle_on_cache_hit is False
+
+
+def test_scheduler_mixed_dsd_keeps_eagle_cache_drop():
+    scheduler = _make_eagle_dsd_scheduler(MIXED_K, disable_eagle_cache_drop_for_k0=True)
+    assert scheduler.use_eagle is True
+    assert scheduler.drop_eagle_on_cache_hit is True
+
+
+def test_scheduler_nospec_keeps_eagle_cache_drop():
+    scheduler = create_scheduler(enable_prefix_caching=True)
+    assert scheduler.use_eagle is False
+    assert scheduler.drop_eagle_on_cache_hit is True
+
+
+def test_scheduler_ngram_keeps_eagle_cache_drop():
+    scheduler = create_scheduler(
+        enable_prefix_caching=True,
+        num_speculative_tokens=3,
+        num_speculative_tokens_per_batch_size=ALWAYS_K0,
+        disable_eagle_cache_drop_for_k0=True,
+    )
+    assert scheduler.use_eagle is False
+    assert scheduler.drop_eagle_on_cache_hit is True
+
+
+def test_scheduler_kv_connector_keeps_eagle_cache_drop():
+    scheduler = _make_eagle_dsd_scheduler(
+        ALWAYS_K0,
+        disable_eagle_cache_drop_for_k0=True,
+        use_kv_connector=True,
+    )
+    assert scheduler.connector is not None
+    assert scheduler.use_eagle is True
+    assert scheduler.drop_eagle_on_cache_hit is True
+
+
+def _prime_and_lookup(
+    manager, token_ids: list[int], block_size: int
+) -> tuple[int, int]:
+    req = make_request("prime", token_ids, block_size, sha256)
+    computed_blocks, _, _ = manager.get_computed_blocks(req)
+    manager.allocate_slots(
+        req,
+        len(token_ids),
+        len(computed_blocks.blocks[0]) * block_size,
+        computed_blocks,
+    )
+    manager.free(req)
+
+    hit_req = make_request("hit", token_ids, block_size, sha256)
+    computed_blocks, num_tokens, _ = manager.get_computed_blocks(hit_req)
+    return len(computed_blocks.blocks[0]), num_tokens
+
+
+def test_unitary_cache_hit_keeps_last_block_when_drop_disabled():
+    block_size = 16
+    token_ids = [0] * (3 * block_size)
+    dropped = make_kv_cache_manager(
+        make_kv_cache_config(block_size, num_blocks=10),
+        max_model_len=8192,
+        enable_caching=True,
+        use_eagle=True,
+        hash_block_size=block_size,
+    )
+    kept = make_kv_cache_manager(
+        make_kv_cache_config(block_size, num_blocks=10),
+        max_model_len=8192,
+        enable_caching=True,
+        use_eagle=True,
+        drop_eagle_on_cache_hit=False,
+        hash_block_size=block_size,
+    )
+
+    n_blocks_drop, n_tokens_drop = _prime_and_lookup(dropped, token_ids, block_size)
+    n_blocks_keep, n_tokens_keep = _prime_and_lookup(kept, token_ids, block_size)
+
+    assert n_blocks_drop == 1
+    assert n_tokens_drop == 1 * block_size
+    assert n_blocks_keep == 2
+    assert n_tokens_keep == 2 * block_size
+
+
+def test_hybrid_cache_hit_keeps_last_block_when_drop_disabled():
+    block_size = 16
+    kv_cache_config = make_kv_cache_config_hybrid_model(block_size, 31, 3)
+    manager = make_kv_cache_manager(
+        kv_cache_config,
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=block_size,
+        use_eagle=True,
+        drop_eagle_on_cache_hit=False,
+    )
+
+    num_full_blocks = 6
+    common_token_ids = [i for i in range(num_full_blocks) for _ in range(block_size)]
+    req0 = make_request("0", common_token_ids + [6] * 7, block_size, sha256)
+    computed_blocks, num_computed_tokens, _ = manager.get_computed_blocks(req0)
+    manager.allocate_slots(
+        req0, len(req0.all_token_ids), num_computed_tokens, computed_blocks
+    )
+
+    req1 = make_request("1", common_token_ids + [6] * 5, block_size, sha256)
+    computed_blocks, num_computed_tokens, _ = manager.get_computed_blocks(req1)
+    assert num_computed_tokens == num_full_blocks * block_size
+    assert len(computed_blocks.blocks[0]) == num_full_blocks

--- a/tests/v1/core/test_mamba_align_chunk_split.py
+++ b/tests/v1/core/test_mamba_align_chunk_split.py
@@ -77,12 +77,14 @@ def _split(
     request: Request,
     num_new_tokens: int,
     use_eagle: bool = True,
+    drop_eagle_on_cache_hit: bool = True,
     partial_hit: bool = False,
 ) -> int:
     """Call the real `Scheduler._mamba_block_aligned_split` on a stub self."""
     stub = SimpleNamespace(
         cache_config=SimpleNamespace(block_size=MAMBA_BLOCK_SIZE),
         use_eagle=use_eagle,
+        drop_eagle_on_cache_hit=drop_eagle_on_cache_hit,
         max_num_scheduled_tokens=16384,
         scheduler_config=SimpleNamespace(long_prefill_token_threshold=0),
         # `prefix_match_unit` finer than the block size (#46384).
@@ -245,3 +247,15 @@ def test_unaligned_resume_never_runs_past_its_block(
             f"intermediate chunk end {end} is neither block-aligned nor the "
             f"partial-tail boundary"
         )
+
+
+def test_mamba_split_without_eagle_drop_matches_no_eagle() -> None:
+    """Disabling cache-hit drop must not apply the EAGLE last-block backoff."""
+    (request,) = create_requests(1, num_tokens=PROMPT_LEN, block_size=ATTN_BLOCK_SIZE)
+    no_eagle = _split(request, PROMPT_LEN, use_eagle=False)
+    no_drop = _split(request, PROMPT_LEN, use_eagle=True, drop_eagle_on_cache_hit=False)
+    with_drop = _split(
+        request, PROMPT_LEN, use_eagle=True, drop_eagle_on_cache_hit=True
+    )
+    assert no_drop == no_eagle == MAMBA_BLOCK_SIZE
+    assert with_drop == PROMPT_LEN

--- a/tests/v1/core/utils.py
+++ b/tests/v1/core/utils.py
@@ -67,6 +67,7 @@ def create_scheduler(
     pipeline_parallel_size: int = 1,
     data_parallel_size: int = 1,
     num_speculative_tokens_per_batch_size: list[tuple[int, int, int]] | None = None,
+    disable_eagle_cache_drop_for_k0: bool = False,
     use_ec_connector: bool = False,
     ec_role: str | None = None,
     use_v2_model_runner: bool | None = None,
@@ -147,6 +148,8 @@ def create_scheduler(
             spec_kwargs["num_speculative_tokens_per_batch_size"] = (
                 num_speculative_tokens_per_batch_size
             )
+        if disable_eagle_cache_drop_for_k0:
+            spec_kwargs["disable_eagle_cache_drop_for_k0"] = True
         if speculative_method is not None:
             spec_kwargs["method"] = speculative_method
             spec_kwargs["prompt_lookup_max"] = num_speculative_tokens

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -185,10 +185,11 @@ class SpeculativeConfig:
     inclusive batch-size range.
     """
     disable_eagle_cache_drop_for_k0: bool = False
-    """If True, skip EAGLE/MTP last-block drop on prefix-cache hits when the
-    dynamic SD lookup is always K=0. Default False preserves stock tokens.
-    Prefix caching must be on and no KV connector may be configured. Greedy
-    outputs can change when this is enabled."""
+    """If True, skip EAGLE-style last-block drop on prefix-cache hits when the
+    dynamic SD lookup is always K=0. Default False preserves stock cache-hit
+    behavior and observed greedy tokens. Prefix caching must be on and no KV
+    connector may be configured. Greedy outputs can change when this is
+    enabled. Applies to methods where ``use_eagle()`` is True."""
 
     # params generated in the post-init stage
     draft_model_config: SkipValidation[ModelConfig] = None  # type: ignore

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -184,6 +184,11 @@ class SpeculativeConfig:
     Each entry is ``(range_start, range_end, num_speculative_tokens)`` with an
     inclusive batch-size range.
     """
+    disable_eagle_cache_drop_for_k0: bool = False
+    """If True, skip EAGLE/MTP last-block drop on prefix-cache hits when the
+    dynamic SD lookup is always K=0. Default False preserves stock tokens.
+    Prefix caching must be on and no KV connector may be configured. Greedy
+    outputs can change when this is enabled."""
 
     # params generated in the post-init stage
     draft_model_config: SkipValidation[ModelConfig] = None  # type: ignore

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -80,10 +80,12 @@ class KVCacheCoordinator(ABC):
         scheduler_block_size: int,
         hash_block_size: int,
         metrics_collector: KVCacheMetricsCollector | None = None,
+        drop_eagle_on_cache_hit: bool = True,
     ):
         self.kv_cache_config = kv_cache_config
         self.max_model_len = max_model_len
         self.enable_caching = enable_caching
+        self.drop_eagle_on_cache_hit = drop_eagle_on_cache_hit
         # The scheduling granularity (LCM of all group block sizes), must be a multiple
         # of the hash_block_size and the block size of each group.
         assert scheduler_block_size % hash_block_size == 0 and all(
@@ -407,6 +409,7 @@ class KVCacheCoordinatorNoPrefixCache(KVCacheCoordinator):
         scheduler_block_size: int,
         hash_block_size: int,
         metrics_collector: KVCacheMetricsCollector | None = None,
+        drop_eagle_on_cache_hit: bool = True,
     ):
         super().__init__(
             kv_cache_config,
@@ -420,6 +423,7 @@ class KVCacheCoordinatorNoPrefixCache(KVCacheCoordinator):
             scheduler_block_size=scheduler_block_size,
             hash_block_size=hash_block_size,
             metrics_collector=metrics_collector,
+            drop_eagle_on_cache_hit=drop_eagle_on_cache_hit,
         )
         self.num_single_type_manager = len(self.single_type_managers)
 
@@ -457,6 +461,7 @@ class UnitaryKVCacheCoordinator(KVCacheCoordinator):
         scheduler_block_size: int,
         hash_block_size: int,
         metrics_collector: KVCacheMetricsCollector | None = None,
+        drop_eagle_on_cache_hit: bool = True,
     ):
         super().__init__(
             kv_cache_config,
@@ -470,6 +475,7 @@ class UnitaryKVCacheCoordinator(KVCacheCoordinator):
             scheduler_block_size=scheduler_block_size,
             hash_block_size=hash_block_size,
             metrics_collector=metrics_collector,
+            drop_eagle_on_cache_hit=drop_eagle_on_cache_hit,
         )
         self.kv_cache_spec = self.kv_cache_config.kv_cache_groups[0].kv_cache_spec
         self.block_size = self.kv_cache_spec.block_size
@@ -499,7 +505,8 @@ class UnitaryKVCacheCoordinator(KVCacheCoordinator):
             kv_cache_group_ids=[0],
             block_pool=self.block_pool,
             kv_cache_spec=self.kv_cache_spec,
-            drop_eagle_block=0 in self.eagle_group_ids,
+            drop_eagle_block=(0 in self.eagle_group_ids)
+            and self.drop_eagle_on_cache_hit,
             alignment_tokens=self.block_size,
             dcp_world_size=self.dcp_world_size,
             pcp_world_size=self.pcp_world_size,
@@ -542,6 +549,7 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
         scheduler_block_size: int,
         hash_block_size: int,
         metrics_collector: KVCacheMetricsCollector | None = None,
+        drop_eagle_on_cache_hit: bool = True,
     ):
         super().__init__(
             kv_cache_config,
@@ -555,6 +563,7 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
             scheduler_block_size=scheduler_block_size,
             hash_block_size=hash_block_size,
             metrics_collector=metrics_collector,
+            drop_eagle_on_cache_hit=drop_eagle_on_cache_hit,
         )
         # hash_block_size: the block size used to compute block hashes.
         # The actual block size usually equals hash_block_size, but in cases where
@@ -687,7 +696,11 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
             num_tokens_to_cache = aligned_num_computed_tokens
             # EAGLE groups match one block past each aligned boundary and drop
             # it, so make that lookahead block eligible to be cached.
-            if manager.use_eagle and aligned_num_computed_tokens > 0:
+            if (
+                manager.use_eagle
+                and self.drop_eagle_on_cache_hit
+                and aligned_num_computed_tokens > 0
+            ):
                 num_tokens_to_cache = min(
                     num_computed_tokens,
                     aligned_num_computed_tokens + manager.block_size,
@@ -764,7 +777,11 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
                     )
                     continue
 
-                drop_eagle_block = use_eagle and idx not in eagle_verified
+                drop_eagle_block = (
+                    self.drop_eagle_on_cache_hit
+                    and use_eagle
+                    and idx not in eagle_verified
+                )
 
                 _max_length = curr_hit_length
                 # Eagle matches one extra drop unit (one hash unit for
@@ -858,7 +875,7 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
                 kv_cache_group_ids=group_ids,
                 block_pool=self.block_pool,
                 kv_cache_spec=spec,
-                drop_eagle_block=use_eagle,
+                drop_eagle_block=use_eagle and self.drop_eagle_on_cache_hit,
                 alignment_tokens=self._cache_hit_alignment_tokens,
             )
             for gid, blks in zip(group_ids, blocks):
@@ -880,6 +897,7 @@ def get_kv_cache_coordinator(
     scheduler_block_size: int,
     hash_block_size: int,
     metrics_collector: KVCacheMetricsCollector | None = None,
+    drop_eagle_on_cache_hit: bool = True,
 ) -> KVCacheCoordinator:
     if not enable_caching:
         return KVCacheCoordinatorNoPrefixCache(
@@ -893,6 +911,7 @@ def get_kv_cache_coordinator(
             scheduler_block_size=scheduler_block_size,
             hash_block_size=hash_block_size,
             metrics_collector=metrics_collector,
+            drop_eagle_on_cache_hit=drop_eagle_on_cache_hit,
         )
     if len(kv_cache_config.kv_cache_groups) == 1:
         return UnitaryKVCacheCoordinator(
@@ -907,6 +926,7 @@ def get_kv_cache_coordinator(
             scheduler_block_size=scheduler_block_size,
             hash_block_size=hash_block_size,
             metrics_collector=metrics_collector,
+            drop_eagle_on_cache_hit=drop_eagle_on_cache_hit,
         )
     return HybridKVCacheCoordinator(
         kv_cache_config,
@@ -920,4 +940,5 @@ def get_kv_cache_coordinator(
         scheduler_block_size=scheduler_block_size,
         hash_block_size=hash_block_size,
         metrics_collector=metrics_collector,
+        drop_eagle_on_cache_hit=drop_eagle_on_cache_hit,
     )

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -125,6 +125,7 @@ class KVCacheManager:
         max_in_flight_tokens: int | None = None,
         enable_caching: bool = True,
         use_eagle: bool = False,
+        drop_eagle_on_cache_hit: bool = True,
         log_stats: bool = False,
         enable_kv_cache_events: bool = False,
         dcp_world_size: int = 1,
@@ -142,6 +143,7 @@ class KVCacheManager:
         self.enable_caching = enable_caching
         self.enable_kv_cache_events = enable_kv_cache_events
         self.use_eagle = use_eagle
+        self.drop_eagle_on_cache_hit = drop_eagle_on_cache_hit
         self.log_stats = log_stats
         self.metrics_collector = metrics_collector
         # FIXME: make prefix cache stats conditional on log_stats. We still need
@@ -154,6 +156,7 @@ class KVCacheManager:
             max_model_len=self.max_model_len,
             max_in_flight_tokens=max_in_flight_tokens,
             use_eagle=self.use_eagle,
+            drop_eagle_on_cache_hit=self.drop_eagle_on_cache_hit,
             enable_caching=self.enable_caching,
             enable_kv_cache_events=enable_kv_cache_events,
             dcp_world_size=dcp_world_size,

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -66,6 +66,32 @@ from vllm.v1.utils import record_function_or_nullcontext
 logger = init_logger(__name__)
 
 
+def compute_drop_eagle_on_cache_hit(
+    *,
+    disable_eagle_cache_drop_for_k0: bool,
+    enable_prefix_caching: bool,
+    has_kv_connector: bool,
+    use_eagle: bool,
+    dynamic_sd_lookup: list[int] | None,
+) -> bool:
+    """Whether EAGLE last-block drop should run on prefix-cache hits.
+
+    Default True preserves stock behavior. The opt-in disable applies only
+    when the dynamic SD lookup is always K=0 (index 0 is unused), prefix
+    caching is on, and no KV connector is configured.
+    """
+    disable = (
+        disable_eagle_cache_drop_for_k0
+        and enable_prefix_caching
+        and not has_kv_connector
+        and use_eagle
+        and dynamic_sd_lookup is not None
+        and len(dynamic_sd_lookup) > 1
+        and max(dynamic_sd_lookup[1:]) == 0
+    )
+    return not disable
+
+
 class Scheduler(SchedulerInterface):
     def __init__(
         self,
@@ -256,6 +282,18 @@ class Scheduler(SchedulerInterface):
                 )
             self.use_eagle = speculative_config.use_eagle()
 
+        disable_k0_drop = bool(
+            speculative_config is not None
+            and speculative_config.disable_eagle_cache_drop_for_k0
+        )
+        self.drop_eagle_on_cache_hit = compute_drop_eagle_on_cache_hit(
+            disable_eagle_cache_drop_for_k0=disable_k0_drop,
+            enable_prefix_caching=self.cache_config.enable_prefix_caching,
+            has_kv_connector=self.connector is not None,
+            use_eagle=self.use_eagle,
+            dynamic_sd_lookup=self.dynamic_sd_lookup,
+        )
+
         # Create the KV cache manager.
         if hash_block_size is None:
             hash_block_size = block_size
@@ -266,6 +304,7 @@ class Scheduler(SchedulerInterface):
             max_in_flight_tokens=vllm_config.max_in_flight_tokens,
             enable_caching=self.cache_config.enable_prefix_caching,
             use_eagle=self.use_eagle,
+            drop_eagle_on_cache_hit=self.drop_eagle_on_cache_hit,
             log_stats=self.log_stats,
             enable_kv_cache_events=self.enable_kv_cache_events,
             dcp_world_size=self.dcp_world_size,
@@ -378,7 +417,7 @@ class Scheduler(SchedulerInterface):
         # Eagle, FullAttn prunes the last matching block, so back off one
         # block to avoid a Mamba cache miss.
         last_cache_position = request.num_tokens - request.num_tokens % block_size
-        if self.use_eagle:
+        if self.use_eagle and self.drop_eagle_on_cache_hit:
             last_cache_position = max(last_cache_position - block_size, 0)
 
         end = start + num_new_tokens


### PR DESCRIPTION
> **Closed.** Author withdrawal: always-K=0 last-block skip is a workaround that changes greedy tokens. The correctness path is #50897. See the closing comment.


## Purpose

Opt-in skip of EAGLE-style last-block drop on prefix-cache hits when dynamic speculative decoding is **always K=0**. Default is off, so stock cache-hit behavior and observed greedy tokens are unchanged.

Always-K=0 DSD (`num_speculative_tokens_per_batch_size=[[1,16,0]]`) produces no draft tokens, but `use_eagle=True` still drops the last matched KV block on a prefix-cache hit. That inflates scheduled-token volume on a long-context warm workload (stock: 4 steps / ~24k tokens per burst vs nospec ~1 step). This PR keeps `use_eagle=True` and only disables that drop when the operator sets `disable_eagle_cache_drop_for_k0=True` **and** all of: prefix caching on, no KV connector, `use_eagle()` (EAGLE / EAGLE3 / MTP / DFlash / DSpark), dense lookup `max(lookup[1:])==0`.

Related: #49548 (always-K=0 slice only; not a universal fix).

This is a **performance tradeoff**, not a correctness fix. Greedy outputs can change when the flag is on (measured divergence at generated pos 22 multi-request / pos 67 single-request vs stock K=0).

## Test Plan

```bash
.venv/bin/python -m pytest \
  tests/v1/core/test_eagle_cache_drop_k0.py \
  tests/v1/core/test_mamba_align_chunk_split.py \
  tests/v1/core/test_prefix_caching.py::test_eagle_enabled_removes_last_block \
  tests/v1/core/test_prefix_caching.py::test_prefill_hybrid_model_eagle \
  tests/v1/core/test_prefix_caching.py::test_eagle_with_partial_blocks \
  tests/v1/core/test_prefix_caching.py::test_eagle_with_sliding_window \
  tests/v1/core/test_prefix_caching.py::test_prefill_hybrid_model_combinations_eagle \
  tests/v1/core/test_prefix_caching.py::test_eagle_swa_alignment_caches_extra_block \
  tests/v1/spec_decode/test_dynamic_sd.py -q
```

Enable (example):

```python
speculative_config={
    "method": "mtp",
    "num_speculative_tokens": 3,
    "num_speculative_tokens_per_batch_size": [[1, 16, 0]],
    "disable_eagle_cache_drop_for_k0": True,
}
# plus enable_prefix_caching=True; no KV connector
```

## Test Result

CPU unit tests above: **64 passed** (2026-08-12, local).

ThinkingCap-Qwen3.6-27B-FP8, dual RTX 5090 TP=2, always-K=0 `[[1,16,0]]`, ~49k prompt with prefix-cache hit, 8 sessions × 2 rounds × 128 tokens, inproc.

GPU validation used commit `da159d447d` overlaid into the production venv. The only extra local change was an uncommitted scheduler JSONL helper for the burst census; it does not change scheduling decisions.

**Primary comparison (this flag, one outing):** C0 **82.6 t/s** (n=1) vs B2 **136.7 t/s** (n=3, stdev 0.3), about **1.65×**. Mixed C3 `[[1,2,2],[3,16,0]]` does not enable the flag.

**Burst census (same outing):**

| Config | Warm steps/burst | Warm Σ tok/burst |
|---|---:|---:|
| Stock always-K=0 (C0) | 4 | 24,238 |
| This change (B2, flag on) | 2 | 11,429 |
| Coarse `use_eagle=False` (B1, earlier run) | 2 | 11,429 |

B2 matches B1’s 4→2 / 24k→11k shape. `use_eagle` stays True.

**Earlier local prototype (not this flag; do not mix with the numbers above):** same workload family, util 0.90, one-rep: C0 89.4 t/s, local B2 (`VLLM_SCHED_WARM_BATCH`) 147.0 t/s, B1 147.7 t/s. Nearby nospec ~178 t/s. Residual vs nospec is not attributed.

Greedy identity vs stock K=0 with the flag on: **FAIL** at pos 22 (multi) / pos 67 (single), 1 rep each.

**Small accuracy probe** (not GSM8K): 8 grade-school integer problems, greedy, ~2k-token shared stem cached first so the last-block drop actually runs. C0 **7/8**, B2 **8/8**. The seven unambiguous items matched. The eighth is an ambiguous wording trap (capacity 80 vs 80−15=65); C0 answered 65, B2 answered 80. Do **not** read 8/8 vs 7/8 as a quality win. Cliff check only: the flag did not break the clear math items. No named model eval (GSM8K / `tests/evals/`) was run.

## Why this is not a duplicate

No open PR implements an always-K=0 opt-in skip of `drop_eagle_on_cache_hit`.

**#50897** is the general correctness approach (successor-aware hashes so the last block can be kept without changing greedy tokens). It is **not** a substitute we can cite for this workload today:

- 43 files; **merge-conflicting** as of 2026-08-11. Collaborator review asked to **split** it (too pervasive; still keeps the old drop path, so core complexity goes up). A rebase alone does not address that. No LGTM.
- We have **not** measured #50897 on the always-K=0 ~49k warm-burst bench. Same speed as this flag is a hypothesis.

This PR is a small, default-off option for that measured always-K=0 volume defect. If successor-aware hashing lands and removes the defect, **deprecate and remove this flag**. The two do not conflict today (off by default; no hash-format change). Not discussed on #50897.

| Related | Difference |
|---|---|
| #50897 | Correctness-preserving hash redesign (see above). Not merge-ready as-is; unmeasured here. |
| #51769 | Warns when EAGLE-style methods cost a large prefix-cache hit. Diagnostic only. |
| #51295 | Hybrid attention miss/corruption from eagle drop. Different bug. |
| #48375 / #45614 | Mamba eagle-drop plumbing / hit accuracy. Not DSD K=0 scheduling volume. |
| #51466 / #51575 | Separate DSD work; #51466 was withdrawn after a negative policy experiment. Neither is bundled. |

KV-connector / Mooncake Store eagle-drop paths are **out of scope** (gate requires `connector is None`).

## AI disclosure

AI assistance was used to draft the implementation and tests. A human (Greg) is accountable for the PR and will review every changed line before merge.

---

<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>
