### PR TITLE
[Bugfix][Spec Decode] Apply suppress_tokens on the Gemma 4 MTP sparse path

### DIFF
--- a/tests/model_executor/test_gemma4_mtp_sparse_suppress.py
+++ b/tests/model_executor/test_gemma4_mtp_sparse_suppress.py
@@ -1,0 +1,120 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+
+from vllm.model_executor.models.gemma4_mtp import Gemma4MTPMaskedEmbedder
+
+HIDDEN_SIZE = 2
+VOCAB_SIZE = 16
+NUM_CENTROIDS = 4
+TOP_K = 2
+
+# Token scores, chosen so the ranking among selected candidates is
+# unambiguous: 5 wins, then 2, then 6.
+TOKEN_SCORES = {5: 100.0, 2: 50.0, 6: 25.0}
+
+BEST_TOKEN = 5
+SECOND_TOKEN = 2
+THIRD_TOKEN = 6
+
+
+def make_embedder() -> Gemma4MTPMaskedEmbedder:
+    embedder = Gemma4MTPMaskedEmbedder(
+        hidden_size=HIDDEN_SIZE,
+        vocab_size=VOCAB_SIZE,
+        num_centroids=NUM_CENTROIDS,
+        centroid_intermediate_top_k=TOP_K,
+    )
+    # Identity ordering: centroid c owns tokens [4c, 4c+1, 4c+2, 4c+3].
+    embedder.token_ordering.copy_(torch.arange(VOCAB_SIZE))
+    # With hidden_states = [1, 0], centroid scores are the first weight
+    # column, so centroids 0 and 1 are always selected -> candidate tokens
+    # 0..7.
+    with torch.no_grad():
+        embedder.centroids.weight.zero_()
+        embedder.centroids.weight[:, 0] = torch.tensor([10.0, 9.0, 1.0, 0.0])
+    return embedder
+
+
+def make_lm_head_weight() -> torch.Tensor:
+    lm_head_weight = torch.zeros((VOCAB_SIZE, HIDDEN_SIZE))
+    for token_id, score in TOKEN_SCORES.items():
+        lm_head_weight[token_id, 0] = score
+    return lm_head_weight
+
+
+HIDDEN_STATES = torch.tensor([[1.0, 0.0]])
+
+
+@pytest.mark.cpu_test
+def test_sparse_argmax_without_suppression_returns_best_token():
+    embedder = make_embedder()
+
+    top = embedder.get_top_tokens(HIDDEN_STATES, make_lm_head_weight())
+
+    assert top.tolist() == [BEST_TOKEN]
+
+
+@pytest.mark.cpu_test
+def test_sparse_argmax_skips_suppressed_token():
+    """Regression test: the sparse path bypasses ``compute_logits``.
+
+    ``Gemma4Proposer._greedy_sample`` calls ``get_top_tokens`` directly, so
+    suppression applied in ``compute_logits`` never runs. Without masking
+    here the drafter can emit a suppressed token.
+    """
+    embedder = make_embedder()
+    embedder.set_suppressed_token_ids([BEST_TOKEN])
+
+    top = embedder.get_top_tokens(HIDDEN_STATES, make_lm_head_weight())
+
+    assert top.tolist() == [SECOND_TOKEN]
+
+
+@pytest.mark.cpu_test
+def test_sparse_argmax_skips_multiple_suppressed_tokens():
+    embedder = make_embedder()
+    embedder.set_suppressed_token_ids([BEST_TOKEN, SECOND_TOKEN])
+
+    top = embedder.get_top_tokens(HIDDEN_STATES, make_lm_head_weight())
+
+    assert top.tolist() == [THIRD_TOKEN]
+
+
+@pytest.mark.cpu_test
+@pytest.mark.parametrize("token_ids", [[], None])
+def test_empty_suppression_is_a_noop(token_ids):
+    embedder = make_embedder()
+    embedder.set_suppressed_token_ids(token_ids)
+
+    assert embedder.has_suppressed_tokens is False
+    assert not embedder.suppress_mask.any()
+    top = embedder.get_top_tokens(HIDDEN_STATES, make_lm_head_weight())
+    assert top.tolist() == [BEST_TOKEN]
+
+
+@pytest.mark.cpu_test
+def test_suppress_mask_is_not_persistent():
+    """The mask is config-derived, so it must stay out of ``state_dict``.
+
+    A persistent buffer would surface as an unexpected key during weight
+    loading.
+    """
+    embedder = make_embedder()
+    embedder.set_suppressed_token_ids([BEST_TOKEN])
+
+    assert "suppress_mask" not in embedder.state_dict()
+    assert "token_ordering" in embedder.state_dict()
+
+
+@pytest.mark.cpu_test
+def test_suppression_survives_batched_hidden_states():
+    embedder = make_embedder()
+    embedder.set_suppressed_token_ids([BEST_TOKEN])
+
+    hidden_states = HIDDEN_STATES.expand(4, HIDDEN_SIZE).contiguous()
+    top = embedder.get_top_tokens(hidden_states, make_lm_head_weight())
+
+    assert top.tolist() == [SECOND_TOKEN] * 4

--- a/vllm/model_executor/models/gemma4_mtp.py
+++ b/vllm/model_executor/models/gemma4_mtp.py
@@ -69,6 +69,7 @@ class Gemma4MTPMaskedEmbedder(nn.Module):
     """
 
     token_ordering: torch.Tensor
+    suppress_mask: torch.Tensor
 
     def __init__(
         self,
@@ -90,6 +91,21 @@ class Gemma4MTPMaskedEmbedder(nn.Module):
             "token_ordering",
             torch.empty(vocab_size, dtype=torch.long),
         )
+        # Derived from the generation config rather than the checkpoint, so it
+        # is non-persistent and stays out of ``state_dict``.
+        self.has_suppressed_tokens = False
+        self.register_buffer(
+            "suppress_mask",
+            torch.zeros(vocab_size, dtype=torch.bool),
+            persistent=False,
+        )
+
+    def set_suppressed_token_ids(self, token_ids: list[int]) -> None:
+        """Mark tokens that the sparse argmax must never return."""
+        if not token_ids:
+            return
+        self.suppress_mask[torch.tensor(token_ids, dtype=torch.long)] = True
+        self.has_suppressed_tokens = True
 
     def _select_and_score(
         self,
@@ -143,6 +159,11 @@ class Gemma4MTPMaskedEmbedder(nn.Module):
     ) -> torch.Tensor:
         """Sparse argmax — returns vocab token IDs without full-vocab tensor."""
         logits, indices = self._select_and_score(hidden_states, lm_head_weight)
+        if self.has_suppressed_tokens:
+            # `compute_logits` masks suppressed tokens on the dense path, but
+            # this sparse argmax bypasses it entirely. Mask the candidates
+            # before the argmax so the drafter cannot emit a suppressed token.
+            logits = logits.masked_fill(self.suppress_mask[indices], float("-inf"))
         return indices.gather(-1, logits.argmax(-1, keepdim=True)).squeeze(-1)
 
 
@@ -519,6 +540,8 @@ class Gemma4MTP(nn.Module):
         draft_cfg = vllm_config.speculative_config.draft_model_config
         gen_cfg = draft_cfg.try_get_generation_config()
         self._suppress_token_ids = gen_cfg.get("suppress_tokens") if gen_cfg else None
+        if self.masked_embedding is not None and self._suppress_token_ids:
+            self.masked_embedding.set_suppressed_token_ids(self._suppress_token_ids)
 
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.model.embed_input_ids(input_ids)


### PR DESCRIPTION
## Purpose

When `use_ordered_embeddings` is set on a Gemma 4 MTP drafter, `Gemma4Proposer._greedy_sample` samples through `get_top_tokens` rather than `compute_logits`:

```python
# vllm/v1/spec_decode/gemma4.py:113
return self.model.get_top_tokens(hidden_states)
```

That reaches `Gemma4MTPMaskedEmbedder.get_top_tokens`, which takes a sparse argmax directly over the centroid-selected candidates:

```python
logits, indices = self._select_and_score(hidden_states, lm_head_weight)
return indices.gather(-1, logits.argmax(-1, keepdim=True)).squeeze(-1)
```

`compute_logits` — the only place `suppress_tokens` is applied — is never called on this path, so **the drafter can propose tokens the generation config marks as suppressed**. The same applies to the CUDA-graph-captured variant, since `_setup_centroids_cuda_graphs` captures `masked_emb.get_top_tokens` directly.

This is a correctness gap rather than a crash, so it is silent: the suppressed token is proposed by the drafter and then either accepted or rejected by the verifier depending on the target model's own distribution.

## Approach

Give `Gemma4MTPMaskedEmbedder` a boolean mask over the vocabulary, populated from the draft model's generation config in `Gemma4MTP.__init__`, and apply it to the candidate logits before the argmax.

The mask lives on the embedder rather than on `Gemma4MTP` because there are two call sites — `Gemma4MTP.get_top_tokens` and the proposer's direct `masked_emb.get_top_tokens` during graph capture — and only module-level state covers both.

It is registered with `persistent=False`: it is derived from the generation config, not a checkpoint weight, and a persistent buffer would surface as an unexpected key during weight loading.

The dense path is untouched — `forward` still returns unsuppressed full-vocab logits and `compute_logits` masks them, which the test asserts explicitly.

## Test plan

Adds `tests/model_executor/test_gemma4_mtp_sparse_suppress.py` (CPU-only, `@pytest.mark.cpu_test`). `Gemma4MTPMaskedEmbedder` has no `VllmConfig` dependency, so these construct it for real with a deterministic centroid layout: an identity `token_ordering`, fixed centroid weights so the selected candidate set is always tokens 0–7, and an `lm_head_weight` giving an unambiguous ranking (token 5 > 2 > 6).

- suppressing the best candidate returns the second-best, and suppressing both returns the third;
- `[]` and `None` are no-ops;
- `suppress_mask` stays out of `state_dict` while `token_ordering` remains in it;
- suppression holds across a batched `hidden_states`;
- `forward()` output is byte-identical with and without suppression configured.

## Known degenerate case, deliberately not matched

If *every* centroid-selected candidate is suppressed, the sparse argmax returns an arbitrary suppressed candidate, whereas the dense path returns the lowest-id non-selected token — non-selected positions are filled with `finfo.min`, which compares above `-inf`. Reaching this requires `suppress_tokens` to cover every token in the selected clusters. I left the behavior rather than encoding a somewhat arbitrary dense-path artifact as a contract, but happy to match it if reviewers prefer.

## Relationship to existing work

#48693 by @dumko2001 also touches sparse-path parity as part of a broader Gemma 4 refactor; it has been in draft with merge conflicts since July. None of its code is used here. This is deliberately scoped to the sparse suppression gap alone so it can be reviewed independently.

Depends on nothing, but is adjacent to the separate CUDA-graph fix for `compute_logits` on the dense path (#48503).

## Validation caveat

No GPU access here, so this has not been exercised on a real Gemma 4 MTP run, and the test file has not been executed against a real vLLM install. What was verified: the assertions above all pass against the actual patched `Gemma4MTPMaskedEmbedder` class source executed standalone against real torch, and `ruff check` / `ruff format` (pinned v0.14.0) are clean. Hardware confirmation would be welcome.

## AI assistance disclosure

Parts of this change and its test were drafted with AI assistance (Claude). I have reviewed every changed line and validated the behavior described above.
