### PR TITLE
[Spec Decode] Test extract_hidden_states on NemotronH hybrid models

### DIFF
--- a/tests/v1/kv_connector/extract_hidden_states_integration/test_extraction.py
+++ b/tests/v1/kv_connector/extract_hidden_states_integration/test_extraction.py
@@ -8,7 +8,7 @@ import pytest
 import torch
 
 from tests.utils import create_new_process_for_each_test, multi_gpu_test
-from vllm import LLM, ModelRegistry, SamplingParams
+from vllm import LLM, ModelRegistry, SamplingParams, TokensPrompt
 from vllm.distributed.kv_transfer.kv_connector.v1 import (
     example_hidden_states_connector,
 )
@@ -294,6 +294,135 @@ def test_extract_hidden_states_qwen35_hybrid_smoke(tmp_path):
             len(output.prompt_token_ids),
             len(layer_ids),
             hidden_size,
+        )
+
+
+@pytest.fixture
+def tiny_nemotron_h_config_path(tmp_path_factory):
+    """A tiny NemotronH config exercising all four layer types.
+
+    NemotronH builds its layer stack from ``hybrid_override_pattern`` rather
+    than from a uniform decoder block, so a layer index is not necessarily an
+    attention or Mamba layer. This pattern interleaves all four types --
+    ``M`` (Mamba2), ``*`` (full attention), ``-`` (MLP) and ``E`` (MoE) -- so
+    that the aux hidden state layer ids below land on different kinds of layer.
+    """
+    from transformers import AutoTokenizer
+
+    from vllm.transformers_utils.configs.nemotron_h import NemotronHConfig
+
+    config_dir = tmp_path_factory.mktemp("tiny_nemotron_h")
+
+    # M - M * M - M E * E - M E  (13 layers, all four types represented)
+    hybrid_override_pattern = "M-M*M-ME*E-ME"
+
+    config = NemotronHConfig(
+        vocab_size=1000,
+        hidden_size=256,
+        intermediate_size=512,
+        num_hidden_layers=len(hybrid_override_pattern),
+        hybrid_override_pattern=hybrid_override_pattern,
+        num_attention_heads=4,
+        head_dim=64,
+        num_key_value_heads=2,
+        max_position_embeddings=1024,
+        # Mamba2 state dims kept small but valid: mamba_num_heads *
+        # mamba_head_dim must be divisible by 8 * n_groups for the conv split.
+        ssm_state_size=16,
+        mamba_num_heads=8,
+        mamba_head_dim=32,
+        mamba_n_groups=2,
+        mamba_chunk_size=32,
+        # MoE layers ("E") -- small expert count keeps the dummy load cheap.
+        n_routed_experts=4,
+        n_shared_experts=1,
+        moe_intermediate_size=256,
+        moe_shared_expert_intermediate_size=256,
+        num_experts_per_tok=2,
+        architectures=["NemotronHForCausalLM"],
+    )
+    config.save_pretrained(config_dir)
+
+    tokenizer = AutoTokenizer.from_pretrained(
+        "TinyLlama/TinyLlama-1.1B-Chat-v1.0",
+        cache_dir=os.path.expanduser("~/.cache/huggingface"),
+    )
+    tokenizer.save_pretrained(config_dir)
+
+    return str(config_dir)
+
+
+@create_new_process_for_each_test()
+def test_extract_hidden_states_nemotron_h_hybrid_smoke(
+    tiny_nemotron_h_config_path, tmp_path
+):
+    """Hidden state extraction on NemotronH (Mamba2 + attention + MLP + MoE).
+
+    NemotronH is a three-way hybrid: unlike the Qwen3.5 case covered above, its
+    stack mixes Mamba2, full-attention, MLP and MoE layers, and its Mamba SSM
+    state cache is forced to float32 by ``NemotronHForCausalLMConfig``. That
+    makes the Mamba page size -- and therefore the page the hidden state cache
+    must align to -- differ from every model this path is currently tested on.
+
+    The aux layer ids capture the outputs of an attention layer, an MoE layer
+    and a Mamba2 layer respectively (aux id ``k`` is the output of layer
+    ``k-1``; see the fixture's pattern).
+
+    Note on what this can and cannot assert: with ``load_format="dummy"`` the
+    weights are drawn from U(-1e-3, 1e-3), and NemotronH's MLP activation is
+    relu^2, so every block contributes ~1e-10 of the residual and all three
+    captured layers read back as (a bfloat16 rounding of) the embeddings. Per
+    layer *values* are therefore not meaningful here -- that is what the
+    predictable-model test above exists to check -- so this test asserts the
+    plumbing: shapes, token alignment and non-zero states across a Mamba2 +
+    attention + MoE stack.
+    """
+    layer_ids = [4, 8, 12]
+    hidden_size = 256  # matches the tiny config above
+    vocab_size = 1000  # matches the tiny config above
+
+    llm = LLM(
+        model=tiny_nemotron_h_config_path,
+        speculative_config={
+            "method": "extract_hidden_states",
+            "num_speculative_tokens": 1,
+            "draft_model_config": {
+                "hf_config": {"eagle_aux_hidden_state_layer_ids": layer_ids}
+            },
+        },
+        kv_transfer_config={
+            "kv_connector": "ExampleHiddenStatesConnector",
+            "kv_role": "kv_producer",
+            "kv_connector_extra_config": {"shared_storage_path": str(tmp_path)},
+        },
+        max_model_len=256,
+        enforce_eager=True,
+        gpu_memory_utilization=0.4,
+        trust_remote_code=True,
+        load_format="dummy",
+    )
+
+    # Feed token ids directly rather than text: the tiny config declares
+    # vocab_size=1000 while the borrowed tokenizer emits ids far above that,
+    # which would index past the embedding table (a device-side assert).
+    token_prompts = [
+        TokensPrompt(prompt_token_ids=[10 + i for i in range(n)]) for n in (4, 9)
+    ]
+    assert all(max(p["prompt_token_ids"]) < vocab_size for p in token_prompts), (
+        "prompt token ids must stay inside the tiny config's vocabulary"
+    )
+
+    sampling_params = SamplingParams(max_tokens=1, temperature=0.0)
+    outputs = llm.generate(token_prompts, sampling_params)
+
+    assert len(outputs) == len(token_prompts)
+    for output in outputs:
+        # get_and_check_output also asserts the states are not all zeros, which
+        # is the failure mode hybrid verifiers regressed into previously: the
+        # shapes stay correct while every value silently reads back as zero.
+        get_and_check_output(
+            output,
+            (len(output.prompt_token_ids), len(layer_ids), hidden_size),
         )
 
 


### PR DESCRIPTION
## Purpose

`NemotronHForCausalLM` is the architecture vLLM's own contributor docs point to as the reference implementation for Mamba2 + attention hybrids, and it already implements the `EagleModelMixin` / `SupportsEagle3` hooks that `extract_hidden_states` consumes. It has no coverage in the `extract_hidden_states` integration tests.

The only hybrid verifier currently covered there is Qwen3.5 (`test_extract_hidden_states_qwen35_hybrid_smoke`), whose stack is Mamba2 + full attention. NemotronH differs in two ways that both land on the arithmetic this feature is sensitive to:

- It builds its layer stack from `hybrid_override_pattern`, interleaving **MLP and MoE** layers with Mamba2 and attention. A given aux layer id is therefore not necessarily an attention or Mamba layer, and the stack contains two block types the current tests never exercise.
- `NemotronHForCausalLMConfig.verify_and_update_config` forces `mamba_ssm_cache_dtype` to `float32`, so its Mamba page size is materially larger than a model whose SSM state stays in the model dtype.

Both feed the Mamba page size, and the hidden-state cache group's block size is derived from the common page it has to align to (`get_kv_cache_groups`, the `HiddenStateCacheSpec` branch). That is exactly the arithmetic that regressed silently for hybrid verifiers in #46301, where shapes stayed correct while every extracted value read back as zero — a failure mode that yielded a draft model with ~0% acceptance and "converged" cleanly in training before anyone noticed.

**This is coverage for a supported-but-untested combination, not a bug fix.** Before writing the test I verified on an A100-80GB against `nvidia/Nemotron-H-8B-Base-8K` that extraction works today and is numerically correct, and that the resolved geometry genuinely differs from the covered case:

| | attention block size | mamba page padding |
|---|---|---|
| Qwen3.5-0.8B (covered today) | 544 | 1.49% |
| Nemotron-H-8B | **1056** | **1.15%** |

With real weights and aux ids `[10, 26, 40]` over a 13-token prompt, the extracted states are distinct and deepen as expected — i.e. correct, not a repeated buffer:

| pair | cosine | max abs diff |
|---|---|---|
| L10 vs L26 | 0.974 | 33.1 |
| L10 vs L40 | 0.318 | 1866.2 |
| L26 vs L40 | 0.334 | 1882.5 |

`abs_mean` per layer: 0.084 → 0.377 → 2.268.

Follows the precedent of #39949 (hybrid support) and #46301 (hybrid block-size fix).

## Test Plan

Adds `test_extract_hidden_states_nemotron_h_hybrid_smoke`, built on a tiny synthetic `NemotronHConfig` rather than a real checkpoint, so it fits the 18 GB device the `Extract Hidden States Integration` CI job runs on. The pattern `"M-M*M-ME*E-ME"` covers all four layer types, and the aux layer ids `[4, 8, 12]` capture the outputs of an attention layer, an MoE layer and a Mamba2 layer respectively (aux id `k` is the residual stream after layer `k-1`).

Assertions come from the existing `get_and_check_output` helper: shape, token-id alignment, and states-not-all-zero.

```bash
export VLLM_WORKER_MULTIPROC_METHOD=spawn
pytest -v -s v1/kv_connector/extract_hidden_states_integration/test_extraction.py \
  -k "nemotron_h or qwen35"
```

## Test Result

Both the new test and the existing Qwen3.5 hybrid test pass, on one A100-80GB, against this branch:

```
tests/.../test_extraction.py::test_extract_hidden_states_qwen35_hybrid_smoke PASSED
tests/.../test_extraction.py::test_extract_hidden_states_nemotron_h_hybrid_smoke PASSED

=========== 2 passed, 2 deselected, 18 warnings in 622.10s (0:10:22) ===========
```

The Qwen3.5 case is included as a no-regression control. Lint on the changed file:

```
ruff check  -> All checks passed!
ruff format -> 1 file already formatted
```

Worth noting that the tiny config lands in its own alignment regime rather than
mirroring a real checkpoint's, which is useful coverage in itself:

```
Using auxiliary layers from speculative config: (4, 8, 12)
Setting attention block size to 48 tokens to ensure that attention page size is >= mamba page size.
Padding mamba page size by 29.73% to ensure that mamba page size and attention page size are exactly equal.
```

(against 1056 / 1.15% for the real Nemotron-H-8B, and 544 / 1.49% for Qwen3.5.)

## Note on what this test does and does not assert

Worth stating explicitly, because it bounds what the test can catch. Under `load_format="dummy"` the weights are drawn from `U(-1e-3, 1e-3)`, and NemotronH's MLP activation is relu², so each block contributes on the order of `1e-10` of the residual and all captured layers read back as a bfloat16 rounding of the embeddings. (Measured: `abs_mean` identical to the last digit across all three aux slots under dummy weights, matching a standalone simulation of the embedding magnitude to three significant figures; the real-weights numbers above are the contrast. Qwen3.5 does not show this because SwiGLU stays linear near zero.)

So this test asserts the plumbing — shapes, token alignment, non-zero states through a Mamba2 + attention + MoE stack — and deliberately does not assert per-layer values, which `test_extract_hidden_states_with_predictable_dummy_model` already covers with a model that emits known per-layer outputs. The docstring says the same, so a passing run isn't later read as a stronger guarantee than it gives.

Prompts are passed as explicit `TokensPrompt` ids rather than text: the tiny config declares `vocab_size=1000` while the borrowed TinyLlama tokenizer emits ids up to ~18.9k, which indexes past the embedding table and trips a device-side assert.

🤖 Generated with [Weave Router](https://router.workweave.ai)
