### PR TITLE
[Docs] extract_hidden_states supports chunked prefill

### DIFF
--- a/docs/features/speculative_decoding/extract_hidden_states.md
+++ b/docs/features/speculative_decoding/extract_hidden_states.md
@@ -123,4 +123,5 @@ Each request produces a `.safetensors` file containing:
 The file path is returned in `output.kv_transfer_params["hidden_states_path"]`. Use `load_hidden_states()` from the connector module to read the file with proper synchronization.
 
 !!! note
-    Chunked prefill is not compatible with this feature and must be disabled.
+    Chunked prefill is supported. Hidden states for a prompt split across
+    multiple scheduler iterations are reassembled before they are written.


### PR DESCRIPTION
## Summary

The `extract_hidden_states` docs state:

> Chunked prefill is not compatible with this feature and must be disabled.

That appears to be stale. The feature's own integration test exercises chunked prefill deliberately, in `tests/v1/kv_connector/extract_hidden_states_integration/test_extraction.py`:

```
2. **Chunked prefill**: max_num_batched_tokens=128 with ~500-token
   prompts so each is split across multiple scheduler iterations —
   verifies hidden states are reassembled correctly.
```

It runs with `max_num_batched_tokens=128` against ~500-token prompts, so each prompt is split across scheduler iterations, and the test asserts the states are reassembled correctly.

I found this while enabling the feature on a NemotronH hybrid model, where the engine also ran with chunked prefill enabled and returned correct per-layer hidden states.

## Test Plan

Docs-only change; no code paths touched. The behavioural claim is backed by the existing test above.

## Test Result

n/a — documentation only.