### PR TITLE
Revert "Avoid long-blocking H2D copies in ViT" (#51841)

### DIFF
--- a/vllm/model_executor/models/qwen3_vl.py
+++ b/vllm/model_executor/models/qwen3_vl.py
@@ -705,15 +705,7 @@ class Qwen3_VisionTransformer(nn.Module):
             else self.rot_pos_ids(h, w, self.spatial_merge_size).repeat(t, 1)
             for t, h, w in grid_thw
         ]
-        num_pos = sum(p.shape[0] for p in pos_ids)
-        pinned = torch.empty(
-            (num_pos, pos_ids[0].shape[1]),
-            dtype=pos_ids[0].dtype,
-            pin_memory=True,
-        )
-        pos_ids = torch.cat(pos_ids, dim=0, out=pinned).to(
-            self.device, non_blocking=True
-        )
+        pos_ids = torch.cat(pos_ids, dim=0).to(self.device, non_blocking=True)
 
         # Use pre-computed cos_sin_cache from RotaryEmbedding
         cos, sin = self.rotary_pos_emb.get_cos_sin(max_grid_size)

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -2256,20 +2256,10 @@ class GPUModelRunner(
 
         if self.uses_mrope:
             # Only relevant for models using M-RoPE (e.g, Qwen2-VL)
-            # Copy one row at a time. mrope_positions is allocated as
-            # [3, max_num_tokens + 1] with a dummy trailing column to keep it
-            # non-contiguous for torch.compile, so cpu[:, :N] is a strided view.
-            # copy_() cannot express a strided source as a single
-            # cudaMemcpyAsync, so it first gathers into a contiguous *pageable*
-            # temporary, and a pageable H2D ignores non_blocking=True and
-            # synchronizes the stream before the transfer starts. Each row is
-            # contiguous within the pinned allocation, so per-row copies stay on
-            # the pinned path and are genuinely asynchronous.
-            for row in range(self.mrope_positions.gpu.shape[0]):
-                self.mrope_positions.gpu[row, :total_num_scheduled_tokens].copy_(
-                    self.mrope_positions.cpu[row, :total_num_scheduled_tokens],
-                    non_blocking=True,
-                )
+            self.mrope_positions.gpu[:, :total_num_scheduled_tokens].copy_(
+                self.mrope_positions.cpu[:, :total_num_scheduled_tokens],
+                non_blocking=True,
+            )
         elif self.uses_xdrope_dim > 0:
             # Only relevant for models using XD-RoPE (e.g, HunYuan-VL)
             self.xdrope_positions.gpu[:, :total_num_scheduled_tokens].copy_(


### PR DESCRIPTION
Reverts the changes from #51841 ("Avoid long-blocking H2D copies in ViT").

## Why

`Arm CPU Test` has failed on every build since #51841 merged (nightly [#83608](https://buildkite.com/vllm/ci/builds/83608), plus per-commit postmerge builds 83603 and 83607 on the same commit). It passed on build 83539, the last run before the merge.

The failure is at engine startup, during `profile_run`:

```
File "vllm/model_executor/models/qwen3_vl.py", line 709, in rot_pos_emb
    pinned = torch.empty(
RuntimeError: pin_memory=True requires a CUDA or other accelerator backend;
no pinned memory allocator is available on this system.
```

`Qwen3_VisionTransformer.rot_pos_emb` now allocates a staging buffer with `pin_memory=True` unconditionally. On CPU-only platforms there is no pinned-memory allocator, so `torch.empty(..., pin_memory=True)` raises and `EngineCore` init dies:

```
RuntimeError: Worker failed with error 'pin_memory=True requires a CUDA or other
accelerator backend; no pinned memory allocator is available on this system.'
```

## Alternative to reverting

The H2D optimization is worth keeping. A narrower fix would be to gate the pinned allocation on accelerator availability and fall back to the plain `torch.cat` path otherwise, e.g. `pin_memory=current_platform.is_pin_memory_available()`. The same guard should be considered for the per-row `mrope_positions` copy in `gpu_model_runner.py`, which relies on the source being pinned to be genuinely async.

Reverting here because it restores CPU platforms immediately with no correctness or accuracy loss; a re-land with the platform guard is preferable if the author can turn it around quickly.

Auto-generated by CI failure analyzer.
