### PR TITLE
[Bugfix] Warn when DeepSeek-V4 silently defaults reasoning_effort to "high"

### DIFF
--- a/rust/src/chat/src/renderer/deepseek_v4/encoding.rs
+++ b/rust/src/chat/src/renderer/deepseek_v4/encoding.rs
@@ -153,10 +153,10 @@ fn resolve_thinking_options(request: &ChatRequest) -> Result<(ThinkingMode, &'st
             reasoning_effort_prompt = "";
         }
         None => {
-            if enable_thinking.is_none() {
+            if thinking_mode == ThinkingMode::Thinking {
                 DEFAULT_REASONING_EFFORT_WARNING.call_once(|| {
                     warn!(
-                        "DeepSeek-V4 request omitted both thinking/enable_thinking and \
+                        "DeepSeek-V4 request enables thinking mode without setting \
                          reasoning_effort; this now defaults to thinking mode with \
                          reasoning_effort=\"high\", which renders a reasoning-effort prompt \
                          prefix that was previously omitted by default. Pass \

--- a/rust/src/chat/src/renderer/deepseek_v4/encoding.rs
+++ b/rust/src/chat/src/renderer/deepseek_v4/encoding.rs
@@ -8,14 +8,18 @@
 
 use std::collections::HashMap;
 use std::fmt::Write as _;
+use std::sync::Once;
 
 use serde::Serialize;
 use serde_json::Value;
 use serde_json_fmt::JsonFormat;
+use tracing::warn;
 
 use crate::error::{Error, Result};
 use crate::request::{ChatContent, ChatMessage, ChatRequest, ChatTool, ReasoningEffort};
 use crate::{AssistantContentBlock, AssistantMessageExt, AssistantToolCall};
+
+static DEFAULT_REASONING_EFFORT_WARNING: Once = Once::new();
 
 const BOS_TOKEN: &str = "<｜begin▁of▁sentence｜>";
 const EOS_TOKEN: &str = "<｜end▁of▁sentence｜>";
@@ -130,7 +134,8 @@ pub(super) fn render_request(request: &ChatRequest) -> Result<String> {
 /// `reasoning_effort`; the generic template-kwargs map is left for HF
 /// templates.
 fn resolve_thinking_options(request: &ChatRequest) -> Result<(ThinkingMode, &'static str)> {
-    let mut thinking_mode = match request.enable_thinking()?.unwrap_or(true) {
+    let enable_thinking = request.enable_thinking()?;
+    let mut thinking_mode = match enable_thinking.unwrap_or(true) {
         true => ThinkingMode::Thinking,
         false => ThinkingMode::Chat,
     };
@@ -147,7 +152,20 @@ fn resolve_thinking_options(request: &ChatRequest) -> Result<(ThinkingMode, &'st
         Some(ReasoningEffort::Minimal | ReasoningEffort::Medium | ReasoningEffort::Low) => {
             reasoning_effort_prompt = "";
         }
-        None => {}
+        None => {
+            if enable_thinking.is_none() {
+                DEFAULT_REASONING_EFFORT_WARNING.call_once(|| {
+                    warn!(
+                        "DeepSeek-V4 request omitted both thinking/enable_thinking and \
+                         reasoning_effort; this now defaults to thinking mode with \
+                         reasoning_effort=\"high\", which renders a reasoning-effort prompt \
+                         prefix that was previously omitted by default. Pass \
+                         reasoning_effort=\"low\" explicitly to restore the prior default. \
+                         See https://github.com/vllm-project/vllm/issues/52083."
+                    );
+                });
+            }
+        }
     }
 
     Ok((thinking_mode, reasoning_effort_prompt))

--- a/tests/tokenizers_/test_deepseek_v4.py
+++ b/tests/tokenizers_/test_deepseek_v4.py
@@ -101,12 +101,30 @@ def test_deepseek_v4_warns_when_defaulting_reasoning_effort(caplog, disable_log_
     )
 
 
+@pytest.mark.parametrize("kwargs", [{"thinking": True}, {"enable_thinking": True}])
+def test_deepseek_v4_warns_when_thinking_explicit_without_reasoning_effort(
+    kwargs, caplog, disable_log_dedup
+):
+    with caplog.at_level("WARNING"):
+        _tokenizer().apply_chat_template(
+            [{"role": "user", "content": "Hello"}],
+            tokenize=False,
+            **kwargs,
+        )
+
+    assert any(
+        "defaults to thinking mode with reasoning_effort" in record.message
+        for record in caplog.records
+    )
+
+
 @pytest.mark.parametrize(
     "kwargs",
     [
-        {"thinking": True},
-        {"enable_thinking": True},
         {"reasoning_effort": "high"},
+        {"thinking": True, "reasoning_effort": "low"},
+        {"thinking": False},
+        {"enable_thinking": False},
     ],
 )
 def test_deepseek_v4_does_not_warn_when_explicit(kwargs, caplog, disable_log_dedup):

--- a/tests/tokenizers_/test_deepseek_v4.py
+++ b/tests/tokenizers_/test_deepseek_v4.py
@@ -88,6 +88,41 @@ def test_deepseek_v4_defaults_to_thinking_with_high_effort():
     assert prompt.endswith("<｜Assistant｜><think>")
 
 
+def test_deepseek_v4_warns_when_defaulting_reasoning_effort(caplog, disable_log_dedup):
+    with caplog.at_level("WARNING"):
+        _tokenizer().apply_chat_template(
+            [{"role": "user", "content": "Hello"}],
+            tokenize=False,
+        )
+
+    assert any(
+        "defaults to thinking mode with reasoning_effort" in record.message
+        for record in caplog.records
+    )
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"thinking": True},
+        {"enable_thinking": True},
+        {"reasoning_effort": "high"},
+    ],
+)
+def test_deepseek_v4_does_not_warn_when_explicit(kwargs, caplog, disable_log_dedup):
+    with caplog.at_level("WARNING"):
+        _tokenizer().apply_chat_template(
+            [{"role": "user", "content": "Hello"}],
+            tokenize=False,
+            **kwargs,
+        )
+
+    assert not any(
+        "defaults to thinking mode with reasoning_effort" in record.message
+        for record in caplog.records
+    )
+
+
 @pytest.mark.parametrize("kwargs", [{"thinking": True}, {"enable_thinking": True}])
 def test_deepseek_v4_enables_thinking_with_compatible_kwargs(kwargs):
     prompt = _tokenizer().apply_chat_template(

--- a/vllm/tokenizers/deepseek_v4.py
+++ b/vllm/tokenizers/deepseek_v4.py
@@ -6,10 +6,13 @@ from typing import Any
 from transformers import TokenizersBackend
 
 from vllm.entrypoints.chat_utils import ChatCompletionMessageParam
+from vllm.logger import init_logger
 
 from .deepseek_v4_encoding import encode_messages
 from .hf import HfTokenizer, get_cached_tokenizer
 from .protocol import TokenizerLike
+
+logger = init_logger(__name__)
 
 
 def get_deepseek_v4_tokenizer(tokenizer: HfTokenizer) -> HfTokenizer:
@@ -30,9 +33,23 @@ def get_deepseek_v4_tokenizer(tokenizer: HfTokenizer) -> HfTokenizer:
             thinking = kwargs.get("thinking")
             enable_thinking = kwargs.get("enable_thinking")
             thinking_enabled = bool(thinking) or bool(enable_thinking)
-            if "thinking" not in kwargs and "enable_thinking" not in kwargs:
+            thinking_unset = (
+                "thinking" not in kwargs and "enable_thinking" not in kwargs
+            )
+            if thinking_unset:
                 thinking_enabled = True
             thinking_mode = "thinking" if thinking_enabled else "chat"
+
+            if thinking_unset and not isinstance(kwargs.get("reasoning_effort"), str):
+                logger.warning_once(
+                    "DeepSeek-V4 request omitted both `thinking`/`enable_thinking` "
+                    "and `reasoning_effort`; this now defaults to thinking mode "
+                    'with reasoning_effort="high", which renders a '
+                    "reasoning-effort prompt prefix that was previously omitted "
+                    'by default. Pass reasoning_effort="low" explicitly to '
+                    "restore the prior default. See "
+                    "https://github.com/vllm-project/vllm/issues/52083."
+                )
 
             conversation = kwargs.get("conversation", messages)
             messages = conversation.copy()

--- a/vllm/tokenizers/deepseek_v4.py
+++ b/vllm/tokenizers/deepseek_v4.py
@@ -40,10 +40,10 @@ def get_deepseek_v4_tokenizer(tokenizer: HfTokenizer) -> HfTokenizer:
                 thinking_enabled = True
             thinking_mode = "thinking" if thinking_enabled else "chat"
 
-            if thinking_unset and not isinstance(kwargs.get("reasoning_effort"), str):
+            if thinking_enabled and not isinstance(kwargs.get("reasoning_effort"), str):
                 logger.warning_once(
-                    "DeepSeek-V4 request omitted both `thinking`/`enable_thinking` "
-                    "and `reasoning_effort`; this now defaults to thinking mode "
+                    "DeepSeek-V4 request enables thinking mode without setting "
+                    "`reasoning_effort`; this now defaults to thinking mode "
                     'with reasoning_effort="high", which renders a '
                     "reasoning-effort prompt prefix that was previously omitted "
                     'by default. Pass reasoning_effort="low" explicitly to '


### PR DESCRIPTION
## Purpose

Fixes #52083.

#50580 changed the DeepSeek-V4 chat encoding (both the Python tokenizer
wrapper `vllm/tokenizers/deepseek_v4.py` and the Rust renderer
`rust/src/chat/src/renderer/deepseek_v4/encoding.rs`) so that any
request which ends up with thinking mode enabled but no explicit
`reasoning_effort` now defaults to `reasoning_effort="high"`. That
happens both when a request omits `thinking`/`enable_thinking` **and**
`reasoning_effort` entirely (the implicit default), and when a caller
explicitly passes `thinking=True`/`enable_thinking=True` without also
setting `reasoning_effort` (thinking was requested, but the effort
default still silently changed). Either way it silently inserts a
reasoning-effort prompt prefix that was previously omitted by default.

This is a shared code path used by every DeepSeek-V4 checkpoint (Pro
and Flash-0731 alike) — there's no per-checkpoint differentiation in
the encoder/renderer. The change was an intentional, tested alignment
with the DeepSeek-V4-Flash-0731 hosted API contract, but it silently
changed the default request behavior for other DeepSeek-V4 deployments
(e.g. DSV4-Pro) that relied on the old "no reasoning-effort blurb
unless requested" default, causing a spike in truncations/reasoning
length as reported in the issue.

Given the encoder has no way to know which DeepSeek-V4 checkpoint
variant is being served, reverting or branching the default behavior
isn't a safe minimal fix — it could just as easily reintroduce the
original 0731 bug #50580 fixed for other deployments. Per the issue's
own suggestion ("At the very least, we should issue a warning that the
default behaviour has been changed"), this PR adds a one-time warning
in both encoders when this implicit default kicks in, telling users
how to restore the previous behavior explicitly with
`reasoning_effort="low"`.

The warning is keyed off the same `thinking_enabled`/resolved
`ThinkingMode::Thinking` condition that actually selects
`reasoning_effort="high"`, not off "thinking/enable_thinking were both
omitted" — an earlier version of this PR used the narrower condition
and missed the explicit-`thinking=True`-without-`reasoning_effort`
path, which hits the exact same silent default.

## Test Plan

- Added `test_deepseek_v4_warns_when_defaulting_reasoning_effort` and
  `test_deepseek_v4_warns_when_thinking_explicit_without_reasoning_effort`
  (parametrized over `thinking=True` and `enable_thinking=True`) to
  assert the warning fires for both trigger paths, and
  `test_deepseek_v4_does_not_warn_when_explicit` (parametrized over
  `reasoning_effort="high"`, `thinking=True` with an explicit
  `reasoning_effort="low"`, and `thinking=False`/`enable_thinking=False`)
  to assert it stays silent when `reasoning_effort` is set or thinking
  is off. All use the existing `disable_log_dedup` fixture to observe
  `logger.warning_once`.
- Verified the new
  `test_deepseek_v4_warns_when_thinking_explicit_without_reasoning_effort`
  test fails without the source fix: `git checkout HEAD --
  vllm/tokenizers/deepseek_v4.py` (reverting to the narrower
  `thinking_unset`-gated condition), ran the test (failed as expected
  with `assert False` for both parametrizations), then restored the
  `thinking_enabled`-gated fix.
- The Rust renderer change mirrors the same fix by checking the
  resolved `thinking_mode == ThinkingMode::Thinking` instead of
  `enable_thinking.is_none()`, gated by the same `std::sync::Once`; the
  existing 14 tests in `rust/src/chat/src/renderer/deepseek_v4/tests.rs`
  (including `omitted_thinking_and_effort_default_to_high`) continue to
  pass unchanged, confirming rendered output is untouched. No dedicated
  Rust test was added for the warning itself since this crate has no
  existing pattern for capturing `tracing` output in tests, and adding
  that infra seemed out of proportion for a log-only change.

### Commands run

```
.venv/bin/python -m pytest tests/tokenizers_/test_deepseek_v4.py -v
# 33 passed

cargo test -p vllm-chat renderer::deepseek_v4
# 14 passed

pre-commit run --files vllm/tokenizers/deepseek_v4.py tests/tokenizers_/test_deepseek_v4.py rust/src/chat/src/renderer/deepseek_v4/encoding.rs
# ruff-check, ruff-format, mypy, rust-cargo-fmt, etc. all passed
```

## Duplicate Check

Searched for open PRs referencing #52083 or similar titles — none
found. #50684 ("Fix DeepSeek-V4 reasoning_effort \"high\" tier and
message-level tools preservation") addresses a related but distinct
bug (the "high" tier text was mislabeled/missing, and message-level
`tools` were dropped for `role == "system"`) in the Python encoder
only; it does not touch the default-value regression described in
#52083, and doesn't touch the Rust renderer.

## AI Assistance

AI assistance (Claude) was used to bisect the regression to #50580,
compare the Python tokenizer wrapper and Rust renderer default-value
logic, implement the warning in both, and write/run the tests above.
All changes were reviewed and the listed commands were run and their
output verified by the submitting human.
