### PR TITLE
[Build] Gate cooperative top-k on CUDA 13

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -414,9 +414,12 @@ if(VLLM_GPU_LANG STREQUAL "CUDA" OR VLLM_GPU_LANG STREQUAL "HIP")
     "csrc/libtorch_stable/custom_all_reduce.cu"
     "csrc/libtorch_stable/fused_deepseek_v4_qnorm_rope_kv_insert_kernel.cu")
 
+  # cooperative_topk uses the CUDA 13 cluster PTX API signatures. CUDA 12.x's
+  # libcudacxx exposes different barrier and bulk-copy overloads, so retain the
+  # regular top-k fallback there instead of failing the extension build.
   if(VLLM_GPU_LANG STREQUAL "CUDA" AND
      DEFINED CMAKE_CUDA_COMPILER_VERSION AND
-     CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL 12.0)
+     CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL 13.0)
 
     if(${CMAKE_CUDA_COMPILER_VERSION} VERSION_GREATER_EQUAL 13.0)
       cuda_archs_loose_intersection(COOPERATIVE_TOPK_ARCHS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -414,9 +414,6 @@ if(VLLM_GPU_LANG STREQUAL "CUDA" OR VLLM_GPU_LANG STREQUAL "HIP")
     "csrc/libtorch_stable/custom_all_reduce.cu"
     "csrc/libtorch_stable/fused_deepseek_v4_qnorm_rope_kv_insert_kernel.cu")
 
-  # cooperative_topk uses the CUDA 13 cluster PTX API signatures. CUDA 12.x's
-  # libcudacxx exposes different barrier and bulk-copy overloads, so retain the
-  # regular top-k fallback there instead of failing the extension build.
   if(VLLM_GPU_LANG STREQUAL "CUDA" AND
      DEFINED CMAKE_CUDA_COMPILER_VERSION AND
      CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL 13.0)

--- a/setup.py
+++ b/setup.py
@@ -1135,6 +1135,7 @@ if _is_cuda() and os.getenv("VLLM_SKIP_FLASH_ATTN_BUILD") != "1":
     ):
         # FA3 requires CUDA 12.3 or later
         ext_modules.append(CMakeExtension(name="vllm.vllm_flash_attn._vllm_fa3_C"))
+
 if _is_cuda():
     # FA4 CuteDSL - Python-only component for FA4's cute DSL support
     # Optional since this doesn't produce a .so file, just copies Python files

--- a/setup.py
+++ b/setup.py
@@ -1128,13 +1128,14 @@ if sys.version_info >= (3, 11):
 if _is_hip():
     ext_modules.append(CMakeExtension(name="vllm._rocm_C"))
 
-if _is_cuda():
+if _is_cuda() and os.getenv("VLLM_SKIP_FLASH_ATTN_BUILD") != "1":
     ext_modules.append(CMakeExtension(name="vllm.vllm_flash_attn._vllm_fa2_C"))
     if USE_PRECOMPILED_EXTENSIONS or (
         CUDA_HOME and get_nvcc_cuda_version() >= Version("12.3")
     ):
         # FA3 requires CUDA 12.3 or later
         ext_modules.append(CMakeExtension(name="vllm.vllm_flash_attn._vllm_fa3_C"))
+if _is_cuda():
     # FA4 CuteDSL - Python-only component for FA4's cute DSL support
     # Optional since this doesn't produce a .so file, just copies Python files
     ext_modules.append(

--- a/vllm/vllm_flash_attn/__init__.py
+++ b/vllm/vllm_flash_attn/__init__.py
@@ -23,6 +23,7 @@ if os.path.islink(_cute_dir) and "flash_attn" not in sys.modules:
 from vllm.vllm_flash_attn.flash_attn_interface import (  # noqa: E402
     FA2_AVAILABLE,
     FA3_AVAILABLE,
+    FA4_AVAILABLE,
     compile_flash_attn_varlen_func_from_specs,
     fa_version_unsupported_reason,
     flash_attn_varlen_func,
@@ -30,10 +31,11 @@ from vllm.vllm_flash_attn.flash_attn_interface import (  # noqa: E402
     is_fa_version_supported,
 )
 
-if not (FA2_AVAILABLE or FA3_AVAILABLE):
+if not (FA2_AVAILABLE or FA3_AVAILABLE or FA4_AVAILABLE):
     raise ImportError(
         "vllm.vllm_flash_attn requires the CUDA flash attention extensions "
-        "(_vllm_fa2_C or _vllm_fa3_C). On ROCm, use upstream flash_attn."
+        "(_vllm_fa2_C or _vllm_fa3_C) or the FA4 CuTe DSL sources. "
+        "On ROCm, use upstream flash_attn."
     )
 
 __all__ = [


### PR DESCRIPTION
## Fixes

- Build cooperative top-k kernels only on CUDA 13 or newer.
- Let source builds skip bundled FA2/FA3 extensions while retaining Python-only FA4.
- Treat an FA4-only installation as a valid FlashAttention installation.

## Verification

- The patched source builds as vLLM 0.23.1rc1.dev1407+gdab991476 on CUDA 12.8.
- The baked SkyRL image imports FlashAttention successfully.