### PR TITLE
[Bugfix][Spec Decode] Preserve constant effective K schedule semantics

### DIFF
--- a/tests/v1/spec_decode/test_dynamic_sd.py
+++ b/tests/v1/spec_decode/test_dynamic_sd.py
@@ -7,7 +7,10 @@ import logging
 import pytest
 
 from tests.v1.core.utils import create_requests, create_scheduler
+from vllm.config import CUDAGraphMode
 from vllm.v1.core.sched.scheduler import Scheduler
+from vllm.v1.cudagraph_dispatcher import CudagraphDispatcher
+from vllm.v1.outputs import DraftTokenIds, ModelRunnerOutput
 from vllm.v1.spec_decode.dynamic.utils import build_dynamic_sd_schedule_lookup
 from vllm.v1.structured_output import StructuredOutputManager
 
@@ -93,6 +96,35 @@ def test_dynamic_sd_clamps_k_to_runtime_max():
 
     assert dynamic_sd_lookup[1] == 3
     assert dynamic_sd_lookup[256] == 3
+
+
+@pytest.mark.parametrize(
+    ("schedule", "runtime_max_k", "expected_constant_k", "expected_variable"),
+    [
+        (None, 3, None, False),
+        ([(1, 16, 3)], 3, 3, False),
+        ([(1, 16, 3), (32, 64, 3)], 3, 3, False),
+        ([(1, 16, 5), (32, 64, 4)], 3, 3, False),
+        ([(1, 16, 3), (32, 64, 1)], 3, None, True),
+        ([(1, 16, 0)], 3, None, True),
+        ([1], 3, None, True),
+    ],
+)
+def test_speculative_config_classifies_effective_schedule_shape(
+    schedule: object,
+    runtime_max_k,
+    expected_constant_k,
+    expected_variable,
+):
+    config = _make_scheduler_with_dynamic_sd(
+        [(1, 16, runtime_max_k)],
+        runtime_num_speculative_tokens=runtime_max_k,
+    ).vllm_config.speculative_config
+    assert config is not None
+    config.num_speculative_tokens_per_batch_size = schedule  # type: ignore[assignment]
+
+    assert config.constant_num_speculative_tokens() == expected_constant_k
+    assert config.uses_variable_speculative_decoding() is expected_variable
 
 
 def test_dynamic_sd_rejects_invalid_schedule_entry():
@@ -214,6 +246,93 @@ def test_dynamic_sd_is_disabled_with_data_parallel(caplog_vllm):
     output = _add_requests_and_schedule(scheduler, 256)
     assert len(output.num_scheduled_tokens) == 256
     assert output.num_spec_tokens_to_schedule == 3
+
+
+def test_constant_schedule_is_kept_with_data_parallel(caplog_vllm):
+    with caplog_vllm.at_level(logging.WARNING, logger="vllm"):
+        scheduler = create_scheduler(
+            max_num_seqs=16,
+            max_num_batched_tokens=160,
+            num_speculative_tokens=3,
+            num_speculative_tokens_per_batch_size=[
+                (1, 8, 2),
+                (9, 16, 2),
+            ],
+            data_parallel_size=2,
+        )
+
+    speculative_config = scheduler.vllm_config.speculative_config
+    assert speculative_config is not None
+    assert speculative_config.num_speculative_tokens_per_batch_size is not None
+    assert scheduler.dynamic_sd_lookup is not None
+    assert scheduler.num_spec_tokens == 2
+    assert scheduler.num_uniform_spec_tokens == 2
+    assert "Dynamic speculative decoding is not supported" not in caplog_vllm.text
+
+    output = _add_requests_and_schedule(scheduler, 16)
+    assert output.num_spec_tokens_to_schedule == 2
+
+
+def test_constant_schedule_pads_first_decode_step_with_effective_k(monkeypatch):
+    monkeypatch.setenv("VLLM_USE_V2_MODEL_RUNNER", "0")
+    scheduler = create_scheduler(
+        num_speculative_tokens=3,
+        num_speculative_tokens_per_batch_size=[(1, 16, 2)],
+        enable_prefix_caching=True,
+        block_size=16,
+    )
+    assert scheduler.vllm_config.compilation_config.cudagraph_mode.has_full_cudagraphs()
+    assert scheduler.vllm_config.num_speculative_tokens == 2
+    assert scheduler.num_spec_tokens == 2
+    assert scheduler.num_uniform_spec_tokens == 2
+    compilation_config = scheduler.vllm_config.compilation_config
+    compilation_config.cudagraph_capture_sizes = [3, 6]
+    compilation_config.max_cudagraph_capture_size = 6
+    dispatcher = CudagraphDispatcher(scheduler.vllm_config)
+    dispatcher.initialize_cudagraph_keys(
+        compilation_config.cudagraph_mode,
+        uniform_decode_query_len=3,
+    )
+    runtime_mode, batch_descriptor = dispatcher.dispatch(
+        num_tokens=3,
+        uniform_decode=True,
+    )
+    assert runtime_mode == CUDAGraphMode.FULL
+    assert batch_descriptor.uniform
+    running_request, cache_hit_request = create_requests(
+        num_requests=2,
+        num_tokens=33,
+        same_prompt=True,
+        max_tokens=16,
+    )
+
+    scheduler.add_request(running_request)
+    output = scheduler.schedule()
+    scheduler.update_from_output(
+        output,
+        ModelRunnerOutput(
+            req_ids=[running_request.request_id],
+            req_id_to_index={running_request.request_id: 0},
+            sampled_token_ids=[[100]],
+            logprobs=None,
+            prompt_logprobs_dict={},
+            pooler_output=[],
+        ),
+    )
+    scheduler.update_draft_token_ids(
+        DraftTokenIds([running_request.request_id], [[1, 2]])
+    )
+
+    scheduler.add_request(cache_hit_request)
+    output = scheduler.schedule()
+
+    assert output.num_spec_tokens_to_schedule == 2
+    assert output.scheduled_spec_decode_tokens[running_request.request_id] == [1, 2]
+    assert output.num_scheduled_tokens[cache_hit_request.request_id] == 3
+    assert output.scheduled_spec_decode_tokens[cache_hit_request.request_id] == [
+        -1,
+        -1,
+    ]
 
 
 def test_scheduler_uses_static_k_when_no_requests_are_scheduled():

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -1493,6 +1493,31 @@ class SpeculativeConfig:
     def uses_dynamic_speculative_decoding(self) -> bool:
         return self.num_speculative_tokens_per_batch_size is not None
 
+    def constant_num_speculative_tokens(self) -> int | None:
+        """Return a positive K when every schedule entry resolves to it."""
+        schedule = self.num_speculative_tokens_per_batch_size
+        if not schedule or any(
+            not isinstance(entry, list | tuple) or len(entry) != 3 for entry in schedule
+        ):
+            return None
+
+        max_k = self.num_speculative_tokens
+        try:
+            scheduled_k = {min(int(entry[2]), max_k) for entry in schedule}
+        except (TypeError, ValueError):
+            return None
+        if len(scheduled_k) != 1:
+            return None
+
+        constant_k = next(iter(scheduled_k))
+        return constant_k if constant_k > 0 else None
+
+    def uses_variable_speculative_decoding(self) -> bool:
+        """Whether the schedule can change the target verification width."""
+        return self.uses_dynamic_speculative_decoding() and (
+            self.constant_num_speculative_tokens() is None
+        )
+
     def uses_draft_model(self) -> bool:
         return self.method == "draft_model"
 

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -926,7 +926,7 @@ class VllmConfig:
         speculative_config = self.speculative_config
         if (
             speculative_config is None
-            or not speculative_config.uses_dynamic_speculative_decoding()
+            or not speculative_config.uses_variable_speculative_decoding()
             or not self.compilation_config.cudagraph_mode.has_full_cudagraphs()
             or self.use_v2_model_runner
         ):
@@ -941,11 +941,20 @@ class VllmConfig:
         )
         self.compilation_config.cudagraph_mode = CUDAGraphMode.PIECEWISE
 
+    def _normalize_constant_speculative_schedule(self) -> None:
+        speculative_config = self.speculative_config
+        if speculative_config is None:
+            return
+
+        constant_k = speculative_config.constant_num_speculative_tokens()
+        if constant_k is not None:
+            speculative_config.num_speculative_tokens = constant_k
+
     def _maybe_disable_dynamic_sd_for_data_parallel(self) -> None:
         speculative_config = self.speculative_config
         if (
             speculative_config is None
-            or not speculative_config.uses_dynamic_speculative_decoding()
+            or not speculative_config.uses_variable_speculative_decoding()
             or self.parallel_config.data_parallel_size <= 1
         ):
             return
@@ -1391,6 +1400,7 @@ class VllmConfig:
                 "optimization level defaults."
             )
 
+        self._normalize_constant_speculative_schedule()
         self._maybe_disable_dynamic_sd_for_data_parallel()
         self._maybe_override_dynamic_sd_cudagraph_mode()
 

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -245,9 +245,17 @@ class Scheduler(SchedulerInterface):
         speculative_config = vllm_config.speculative_config
         self.use_eagle = False
         self.num_spec_tokens = vllm_config.num_speculative_tokens
+        self.num_uniform_spec_tokens = self.num_spec_tokens
         self.num_lookahead_tokens = vllm_config.num_lookahead_tokens
         self.dynamic_sd_lookup: list[int] | None = None
+        self.variable_speculative_tokens = False
         if speculative_config is not None:
+            self.variable_speculative_tokens = (
+                speculative_config.uses_variable_speculative_decoding()
+            )
+            constant_k = speculative_config.constant_num_speculative_tokens()
+            if constant_k is not None:
+                self.num_uniform_spec_tokens = constant_k
             if speculative_config.num_speculative_tokens_per_batch_size:
                 self.dynamic_sd_lookup = build_dynamic_sd_schedule_lookup(
                     speculative_config.num_speculative_tokens_per_batch_size,
@@ -890,12 +898,15 @@ class Scheduler(SchedulerInterface):
                     # preserve full cudagraph for this step.
                     # Not for diffusion where draft tokens can't be padded.
                     if (
-                        (self.num_spec_tokens > 0 and self.dynamic_sd_lookup is None)
+                        (
+                            self.num_uniform_spec_tokens > 0
+                            and not self.variable_speculative_tokens
+                        )
                         and self.num_sampled_tokens_per_step > 0
                         and num_new_tokens == 1
                         and (scheduled_running_reqs and not prefill_scheduled)
                     ):
-                        num_new_tokens = 1 + self.num_spec_tokens
+                        num_new_tokens = 1 + self.num_uniform_spec_tokens
                         if (
                             num_new_tokens > request_token_budget
                             or num_computed_tokens + num_new_tokens > self.max_model_len
@@ -1085,7 +1096,7 @@ class Scheduler(SchedulerInterface):
                 if pad_spec_decode:
                     scheduled_spec_decode_tokens[request_id] = [
                         -1
-                    ] * self.num_spec_tokens
+                    ] * self.num_uniform_spec_tokens
                 # Only track requests that will still be prefilling after this chunk.
                 if num_computed_tokens + num_new_tokens < request.num_tokens:
                     self._inflight_prefills.add(request)


### PR DESCRIPTION
## Purpose

`num_speculative_tokens_per_batch_size` is currently treated as runtime-variable whenever the schedule is present. Some schedules are syntactically non-uniform but resolve to one positive effective K after the configured runtime maximum is applied:

```text
num_speculative_tokens = 3
schedule = [(1, 8, 5), (9, 16, 4)]
effective K values = {min(5, 3), min(4, 3)} = {3}
```

Such a schedule cannot change the target verification width. The current behavior has three effects:

1. V1 downgrades `FULL_AND_PIECEWISE` to `PIECEWISE`.
2. Data parallelism disables the schedule and falls back to the raw maximum K, which changes the configured effective K.
3. Prefix-cache-hit requests entering their first decode step are not padded to the effective verification width.

This PR:

- classifies a schedule as constant only when every entry resolves to the same positive K after runtime clamping;
- normalizes the runtime maximum to that effective K so the Scheduler, GPU Runner, metrics, and CUDA Graph descriptor use one width;
- applies the V1 graph downgrade and DP fallback only when the effective verification width can vary; and
- pads prefix-cache-hit requests with the constant effective K.

Malformed schedules, genuinely variable schedules, and K=0 stay on the conservative path. Existing schedule validation remains in place. No CUDA kernel, drafter, verifier, or rejection-sampling rule is changed.

## Why this is not duplicate work

Before implementation I checked the issue and searched open PRs by issue number and by the areas `constant effective K`, `speculative schedule`, `full cudagraph capture sizes`, `separate decode capture sizes`, and related terms.

- #48944 adds a context-length axis to K selection; this change only classifies schedules that collapse to one runtime width.
- #50488 ensures wide uniform-decode batches are represented in the capture grid; this change addresses an earlier configuration/shape classification boundary.
- #52000 dispatches more uniform-decode batches to padded FULL graphs; it does not preserve a constant schedule's effective K under data parallelism.
- #49652 handles fixed-width autoregressive draft-decode capture; it does not classify the target verification schedule.
- #52070 covers always-K=0 behavior. K=0 is deliberately excluded here.

## Test plan

### Focused behavior tests

```bash
HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1 \
  /vllm-workspace/.venv/bin/python -m pytest -q \
  tests/v1/spec_decode/test_dynamic_sd.py
```

```text
26 passed, 15 warnings in 7.59s
```

Coverage includes:

- no schedule, one entry, same-K entries, values clamped to one K, variable K, K=0, and malformed entries;
- preserving effective K=2 under DP when the raw maximum is K=3;
- prefix-cache-hit first-decode padding with the effective K; and
- direct Dispatcher assertions that the normalized runtime shape is uniform and resolves to `CUDAGraphMode.FULL`.

### Repository hooks

```bash
uv tool run pre-commit run --files \
  tests/v1/spec_decode/test_dynamic_sd.py \
  vllm/config/speculative.py \
  vllm/config/vllm.py \
  vllm/v1/core/sched/scheduler.py
```

All applicable hooks passed, including Ruff, mypy, typos, SPDX, forbidden-import, and configuration checks. `git diff --check` passed.

## GPU validation

Environment:

- NVIDIA RTX PRO 6000 Blackwell Server Edition;
- Qwen3-8B BF16, V1 model runner;
- N-gram speculation, raw maximum K=3, effective schedule K=2;
- random input/output length 128/128.

### Single-GPU paired matrix

Each concurrency level used five paired repetitions with alternating execution order.

| Concurrency | Base PIECEWISE | Patched FULL | Paired change | 95% CI |
|---:|---:|---:|---:|---:|
| 1 | 94.12 | 92.45 | -1.78% | [-1.98%, -1.57%] |
| 2 | 174.05 | 169.16 | -2.81% | [-2.91%, -2.71%] |
| 4 | 344.90 | 367.47 | +6.55% | [+6.20%, +6.90%] |
| 8 | 658.70 | 638.82 | -3.02% | [-3.31%, -2.73%] |

A five-run isolation control with the patched build forced to PIECEWISE was approximately neutral at concurrency 1 (94.05 vs 94.12 output tok/s). This indicates that effective-K normalization itself is not the main regression source; FULL-versus-PIECEWISE performance crosses over by workload shape on this setup.

These results do not support a universal performance claim. They show that shape safety and performance admission are separate decisions. A follow-up should select FULL only for empirically winning token/batch buckets, with PIECEWISE as the fail-closed default.

### Two-GPU data-parallel stress test

Two DP ranks were tested at temperature 0 for three repetitions at concurrency 7 and 16:

- 2304 total requests completed, 0 failed;
- base logs show the schedule disabled and a fallback to K=3;
- patched logs show both ranks initialized with effective K=2 and retained the schedule.

The throughput numbers are intentionally not presented as a same-K speedup because the base and patched runs execute different K. This test validates configuration semantics, rank consistency, and absence of a DP deadlock.

## Current assessment

The DP behavior is a concrete configuration-semantics fix: a schedule whose effective K is always 2 should not silently become K=3 merely because DP is enabled. The effective-width propagation and direct Dispatcher test also fix a gap where graphs could be captured without the runtime descriptor selecting the expected replay path.

The FULL graph policy needs further reviewer discussion or a separate performance-admission change because the measured crossover is non-monotonic. This PR remains a draft while that scope is resolved.

## AI assistance disclosure

OpenAI Codex assisted with prior-art checks, implementation and test drafting, GPU benchmark execution, and documentation. The human submitter must review every changed line, rerun the relevant tests, and be able to defend the change end-to-end before requesting merge.
