### PR TITLE
[ROCm] Reduce AITER MLA FP8 BMM warmup sizes

### DIFF
--- a/tests/kernels/attention/test_rocm_aiter_mla_fp8_bmm_precompile.py
+++ b/tests/kernels/attention/test_rocm_aiter_mla_fp8_bmm_precompile.py
@@ -1,0 +1,113 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+from vllm.model_executor.layers.attention.mla_attention import (
+    _get_aiter_fp8_bmm_precompile_batch_sizes,
+)
+
+
+def _vllm_config(
+    max_num_seqs: int,
+    max_num_batched_tokens: int = 2048,
+    max_num_scheduled_tokens: int | None = None,
+    num_speculative_tokens: int = 0,
+    max_cudagraph_capture_size: int | None = 512,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        scheduler_config=SimpleNamespace(
+            max_num_seqs=max_num_seqs,
+            max_num_batched_tokens=max_num_batched_tokens,
+            max_num_scheduled_tokens=max_num_scheduled_tokens,
+        ),
+        compilation_config=SimpleNamespace(
+            max_cudagraph_capture_size=max_cudagraph_capture_size,
+        ),
+        num_speculative_tokens=num_speculative_tokens,
+    )
+
+
+def test_aiter_fp8_bmm_precompile_uses_graph_limit() -> None:
+    vllm_config = _vllm_config(
+        max_num_seqs=1024,
+        max_cudagraph_capture_size=512,
+    )
+
+    assert _get_aiter_fp8_bmm_precompile_batch_sizes(vllm_config) == list(range(1, 513))
+
+
+def test_aiter_fp8_bmm_precompile_uses_scheduler_batch_size_below_graph_limit() -> None:
+    vllm_config = _vllm_config(max_num_seqs=128)
+
+    assert _get_aiter_fp8_bmm_precompile_batch_sizes(vllm_config) == list(range(1, 129))
+
+
+def test_aiter_fp8_bmm_precompile_uses_scheduled_token_limit() -> None:
+    vllm_config = _vllm_config(
+        max_num_seqs=128,
+        max_num_scheduled_tokens=64,
+    )
+
+    assert _get_aiter_fp8_bmm_precompile_batch_sizes(vllm_config) == list(range(1, 65))
+
+
+def test_aiter_fp8_bmm_precompile_uses_batched_token_limit() -> None:
+    vllm_config = _vllm_config(
+        max_num_seqs=128,
+        max_num_batched_tokens=32,
+    )
+
+    assert _get_aiter_fp8_bmm_precompile_batch_sizes(vllm_config) == list(range(1, 33))
+
+
+def test_aiter_fp8_bmm_precompile_accounts_for_spec_decode_tokens() -> None:
+    vllm_config = _vllm_config(
+        max_num_seqs=16,
+        num_speculative_tokens=3,
+    )
+
+    assert _get_aiter_fp8_bmm_precompile_batch_sizes(vllm_config) == list(range(1, 65))
+
+
+def test_aiter_fp8_bmm_precompile_caps_spec_decode_at_graph_limit() -> None:
+    vllm_config = _vllm_config(
+        max_num_seqs=256,
+        max_num_batched_tokens=2048,
+        max_cudagraph_capture_size=512,
+        num_speculative_tokens=3,
+    )
+
+    assert _get_aiter_fp8_bmm_precompile_batch_sizes(vllm_config) == list(range(1, 513))
+
+
+def test_aiter_fp8_bmm_precompile_caps_spec_decode_at_token_limit() -> None:
+    vllm_config = _vllm_config(
+        max_num_seqs=128,
+        max_num_batched_tokens=256,
+        num_speculative_tokens=3,
+    )
+
+    assert _get_aiter_fp8_bmm_precompile_batch_sizes(vllm_config) == list(range(1, 257))
+
+
+def test_aiter_fp8_bmm_precompile_caps_at_old_limit() -> None:
+    vllm_config = _vllm_config(
+        max_num_seqs=2048,
+        max_cudagraph_capture_size=None,
+    )
+
+    assert _get_aiter_fp8_bmm_precompile_batch_sizes(vllm_config) == list(
+        range(1, 1025)
+    )
+
+
+def test_aiter_fp8_bmm_precompile_defaults_to_old_limit() -> None:
+    vllm_config = _vllm_config(
+        max_num_seqs=0,
+        max_cudagraph_capture_size=None,
+    )
+
+    assert _get_aiter_fp8_bmm_precompile_batch_sizes(vllm_config) == list(
+        range(1, 1025)
+    )

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -306,6 +306,43 @@ from vllm.v1.kv_cache_interface import (
 logger = init_logger(__name__)
 
 _FP8_DTYPE = current_platform.fp8_dtype()
+_AITER_FP8_BMM_PRECOMPILE_MAX_BATCH_SIZE = 1024
+
+
+def _get_aiter_fp8_bmm_precompile_batch_sizes(
+    vllm_config: VllmConfig,
+) -> list[int]:
+    # Keep the old upper bound as a safety cap. The AITER Triton BMM kernels
+    # can still JIT-compile an unseen size later; this only controls startup
+    # warming for the decode-token counts vLLM can actually schedule.
+    scheduler_config = vllm_config.scheduler_config
+    max_num_seqs = scheduler_config.max_num_seqs or 0
+    decode_query_len = 1 + max(getattr(vllm_config, "num_speculative_tokens", 0), 0)
+    max_decode_tokens = max_num_seqs * decode_query_len
+
+    token_limit = (
+        scheduler_config.max_num_scheduled_tokens
+        or scheduler_config.max_num_batched_tokens
+        or 0
+    )
+    if token_limit > 0 and max_decode_tokens > 0:
+        max_decode_tokens = min(max_decode_tokens, token_limit)
+
+    # MLAAttention.forward_impl strips CUDA-graph padding before calling this
+    # BMM path, so warm a contiguous range of real sizes. Limit that range to
+    # graph-covered decode sizes when CUDA graphs are enabled; larger batches
+    # can still JIT later, but they already leave the captured fast path.
+    graph_limit = (
+        getattr(vllm_config.compilation_config, "max_cudagraph_capture_size", None) or 0
+    )
+    if graph_limit > 0 and max_decode_tokens > 0:
+        max_decode_tokens = min(max_decode_tokens, graph_limit)
+
+    max_size = min(
+        _AITER_FP8_BMM_PRECOMPILE_MAX_BATCH_SIZE,
+        max_decode_tokens or _AITER_FP8_BMM_PRECOMPILE_MAX_BATCH_SIZE,
+    )
+    return list(range(1, max_size + 1))
 
 
 def _detect_output_quant_key(
@@ -1086,17 +1123,18 @@ class MLAAttention(nn.Module, AttentionLayerBase):
                 W_V, dtype=current_platform.fp8_dtype()
             )
 
-            # The kernel operates on non-padded inputs. Hence, pre-compiling
-            # triton kernel to avoid runtime compilation for unseen batch sizes
-            # Pre-compile for batch sizes 1 to 1024 to cover most use-cases.
-            # On DS-R1, this step adds roughly 50s to the model loading time.
-            max_batch_size = 1024  # [ToDo] Find the optimal upper limit
-            pre_compilation_list = list(range(1, max_batch_size + 1))
+            # The kernel operates on non-padded decode tokens. Pre-compile the
+            # real decode-token counts the scheduler can emit; unseen sizes can
+            # still be JIT-compiled later, but skipping unreachable warmup
+            # shapes reduces model loading time.
+            pre_compilation_list = _get_aiter_fp8_bmm_precompile_batch_sizes(
+                self._vllm_config
+            )
             if is_global_first_rank():
                 pre_compilation_list = tqdm(
                     pre_compilation_list,
                     desc="[Aiter Triton] Pre-compiling fp8 BMM kernel",
-                    total=max_batch_size,
+                    total=len(pre_compilation_list),
                 )
 
             for m in pre_compilation_list:


### PR DESCRIPTION
## Purpose

Reduce ROCm AITER MLA FP8 BMM startup work by precompiling only the real decode sizes that are covered by the configured CUDA graph limit.

The previous path precompiled every FP8 BMM size from `1..1024` for every MLA layer. This patch keeps a contiguous warmup range, because `MLAAttention.forward_impl` strips CUDA-graph padding before this BMM path, but caps that range at the graph-covered decode size when CUDA graphs are enabled. Larger batches can still JIT later, but they are already outside the captured fast path.

The AITER Triton FP8 BMM kernel specializes on the query-row count. Warming sizes that vLLM will not use for captured decode increases model loading time before the server can handle requests.

For the tested DeepSeek-V2-Lite ROCm config, `max_cudagraph_capture_size` is `512`, so this changes each MLA layer's FP8 BMM warmup from `1..1024` to `1..512`. Small odd actual decode sizes, such as batch 7, remain covered because the warmup range is still contiguous.

This PR was developed with AI assistance. I reviewed the changed code paths, ran the checks below, and verified the ROCm smoke tests on MI300X.

## Duplicate-work check

No linked issue exists for this change. I checked for open duplicate work with:

- `gh pr list --repo vllm-project/vllm --state open --search "AITER MLA FP8 BMM warmup"`
- `gh pr list --repo vllm-project/vllm --state open --search "rocm aiter mla fp8 bmm"`
- `gh pr list --repo vllm-project/vllm --state open --search "triton_fp8_bmm mla warmup"`
- `gh issue list --repo vllm-project/vllm --state open --search "AITER MLA FP8 BMM warmup"`

The only close related open PR I found is #52063, which is also mine. It is related but not a duplicate: #52063 changes the runtime K-side MLA projection path, while this PR changes startup precompile bounds for the AITER FP8 BMM path that remains. If #52063 lands first, this PR may need a small rebase in the same `process_weights_after_loading` area.

## Test Plan

Local checks:

- `pre-commit run --files vllm/model_executor/layers/attention/mla_attention.py tests/kernels/attention/test_rocm_aiter_mla_fp8_bmm_precompile.py`
- `ruff check vllm/model_executor/layers/attention/mla_attention.py tests/kernels/attention/test_rocm_aiter_mla_fp8_bmm_precompile.py`
- `python -m py_compile vllm/model_executor/layers/attention/mla_attention.py tests/kernels/attention/test_rocm_aiter_mla_fp8_bmm_precompile.py`
- `git diff --check`
- `pytest -q tests/kernels/attention/test_rocm_aiter_mla_fp8_bmm_precompile.py`

RunPod MI300X smoke tests with `deepseek-ai/DeepSeek-V2-Lite`, ROCm AITER MLA, `max_model_len=1024`, `input_len=128`, `output_len=1`:

- batch 1 latency smoke
- batch 7 latency smoke, to verify an odd real decode size under the graph limit remains covered

## Test Result

Local checks:

- `pre-commit run --files ...`: passed
- `ruff check ...`: passed
- `python -m py_compile ...`: passed
- `git diff --check`: passed
- `PYTHONPATH=. uv run --no-sync --python 3.12 --with-requirements requirements/common.txt --with pytest --with tblib pytest -q tests/kernels/attention/test_rocm_aiter_mla_fp8_bmm_precompile.py`: passed (`9 passed, 14 warnings`)

RunPod MI300X smoke results:

- batch 1: FP8 BMM precompile changed to `0/512`; model load `58.38s`; generation completed; avg latency `13.84 ms`
- batch 7: FP8 BMM precompile changed to `0/512`; model load `57.30s`; generation completed; avg latency `63.4 ms`

No JIT-monitor warnings appeared after inference monitor activation in either smoke test.

