### PR TITLE
[Bugfix][Multimodal] Guard read_frames against empty frame indices

### DIFF
--- a/tests/multimodal/test_video.py
+++ b/tests/multimodal/test_video.py
@@ -6,7 +6,9 @@ import sys
 import threading
 from contextlib import ExitStack, contextmanager
 from pathlib import Path
+from typing import cast
 
+import cv2
 import numpy as np
 import numpy.typing as npt
 import pytest
@@ -672,6 +674,60 @@ def test_video_backend_handles_broken_frames(monkeypatch: pytest.MonkeyPatch):
             f"Expected fewer than {metadata['total_num_frames']} frames, "
             f"but loaded {frames.shape[0]} frames"
         )
+
+
+class _ZeroFrameVideoCapture:
+    """cv2.VideoCapture stand-in for a degenerate video with no frames."""
+
+    WIDTH = 320
+    HEIGHT = 240
+
+    def get(self, prop):
+        return {
+            cv2.CAP_PROP_FRAME_WIDTH: self.WIDTH,
+            cv2.CAP_PROP_FRAME_HEIGHT: self.HEIGHT,
+            cv2.CAP_PROP_FRAME_COUNT: 0,
+        }.get(prop, 0)
+
+    def grab(self):
+        return False
+
+    def retrieve(self):
+        return (False, None)
+
+
+@pytest.mark.parametrize("frame_recovery", [False, True])
+def test_read_frames_handles_empty_frame_indices(frame_recovery: bool):
+    """Empty frame list (e.g. a 0-frame video) must not crash read_frames.
+
+    Qwen3VLVideoBackend.compute_frames_index_to_sample() returns an empty list
+    for a 0-frame video (it lacks the base class's max(1, ...) floor), which
+    previously crashed read_frames (IndexError in the recovery path, ValueError
+    from max() otherwise).
+    """
+    cap = cast(cv2.VideoCapture, _ZeroFrameVideoCapture())
+    frames, valid_frame_indices = VideoBackend.read_frames(
+        cap, [], total_frames_num=0, frame_recovery=frame_recovery
+    )
+    assert frames.shape == (0, cap.HEIGHT, cap.WIDTH, 3)
+    assert valid_frame_indices == []
+
+
+def test_qwen3vl_zero_frame_video_does_not_crash():
+    """Qwen3VL zero-frame video flows through read_frames without error."""
+    source = VideoSourceMetadata(total_frames_num=0, original_fps=30, duration=1)
+    target = VideoTargetMetadata(num_frames=-1, fps=2, max_duration=10)
+    frame_idx = Qwen3VLVideoBackend.compute_frames_index_to_sample(source, target)
+    assert frame_idx == []  # current behavior for a zero-frame video
+
+    frames, valid_frame_indices = VideoBackend.read_frames(
+        cast(cv2.VideoCapture, _ZeroFrameVideoCapture()),
+        frame_idx,
+        total_frames_num=0,
+        frame_recovery=True,
+    )
+    assert frames.shape[0] == 0
+    assert valid_frame_indices == []
 
 
 # ============================================================================

--- a/vllm/multimodal/video.py
+++ b/vllm/multimodal/video.py
@@ -507,6 +507,13 @@ class OpenCVVideoBackendMixin:
         *,
         frame_recovery: bool = False,
     ) -> tuple[npt.NDArray, list[int]]:
+        if not frame_idx:
+            # Degenerate input (e.g. a video with zero frames): nothing to load.
+            # Match the shape produced by the internal readers for empty input.
+            width = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
+            height = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
+            return np.empty((0, height, width, 3), dtype=np.uint8), []
+
         if frame_recovery:
             num_frames_to_sample = len(frame_idx)
             frames, valid_frame_indices, recovered_map = cls._read_frames_with_recovery(


### PR DESCRIPTION
## Summary

`Qwen3VLVideoBackend.compute_frames_index_to_sample()` returns an empty list for a 0-frame video (it lacks the base class's `max(1, ...)` floor), which then crashed `VideoBackend.read_frames()`:

- **frame-recovery path** (`_read_frames_with_recovery`): `IndexError: list index out of range` at `next_target_map[frame_indices[-1]] = total_frames` — the same line's neighbor `max_frame_idx = frame_indices[-1] if frame_indices else 0` is guarded a few lines above, but this one is not.
- **no-recovery path**: `ValueError: max() iterable argument is empty`.

`read_frames` is the single entry point shared by **every** video backend (OpenCV / PyAV / TorchCodec / DeepStream), so the guard protects all of them.

This adds an early return for empty frame lists that matches the empty-shaped frames (`np.empty((0, h, w, 3))`) the recovery path already produces for empty input — the same state downstream code already receives today for 0-frame videos through the base-class path.

## Test

```bash
.venv/bin/python -m pytest \
  "tests/multimodal/test_video.py::test_read_frames_handles_empty_frame_indices" \
  "tests/multimodal/test_video.py::test_qwen3vl_zero_frame_video_does_not_crash" -v
# 3 passed
```

- `ruff check` / `ruff format` on both changed files: clean.
- Full `tests/multimodal/test_video.py` run: 40 passed, 5 skipped; the 25 failures are all `ModuleNotFoundError: No module named 'av'/'torchcodec'` (video decode deps absent in this CPU environment), unrelated to this change.

**Model evaluation:** not applicable — this is a crash-only fix for degenerate (0-frame) input; it does not change output, accuracy, or serving behavior for any valid input.

## Duplicate / overlap check

No open PR references an empty-frame crash in `read_frames` or the Qwen3VL `compute_frames_index_to_sample` path.

- #50990 *"Validate dynamic video sampling metadata"* is related in theme but does **not** overlap: it adds validation to `DynamicVideoBackend` only, and does not touch `read_frames`, the Qwen3VL backend, or any backend's `read_frames` boundary.
- `bad_words` / YAML-config / JSON-schema empty-input fixes are unrelated code paths.

## AI assistance

This change was developed with AI assistance (Claude Code): bug identification, fix, and tests were AI-drafted and reviewed by a human before submission.