### PR TITLE
[KV Offload] Carry request provenance through stored events

### DIFF
--- a/tests/v1/kv_connector/unit/offloading_connector/test_events.py
+++ b/tests/v1/kv_connector/unit/offloading_connector/test_events.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
@@ -22,7 +23,14 @@ from vllm.distributed.kv_transfer.kv_connector.v1.offloading.events import (
 from vllm.distributed.kv_transfer.kv_connector.v1.offloading.scheduler import (
     GroupOffloadConfig,
 )
-from vllm.v1.core.kv_cache_utils import BlockHash, maybe_convert_block_hash
+from vllm.utils.hashing import sha256
+from vllm.v1.core.kv_cache_utils import (
+    BlockHash,
+    generate_block_hash_extra_keys,
+    hash_block_tokens,
+    init_none_hash,
+    maybe_convert_block_hash,
+)
 from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
     KVCacheConfig,
@@ -35,6 +43,7 @@ from vllm.v1.kv_offload.base import (
     OffloadingEvent,
     OffloadingKVEventsConfig,
     OffloadKey,
+    ReqContext,
     make_offload_key,
 )
 from vllm.v1.kv_offload.tiering.spec import TieringOffloadingSpec
@@ -67,12 +76,37 @@ def _wire_hash(block_hash: BlockHash):
     return maybe_convert_block_hash(block_hash)
 
 
+def _rehash_request(req, block_size: int) -> None:
+    init_none_hash(sha256)
+    block_hashes: list[BlockHash] = []
+    parent: BlockHash | None = None
+    mm_idx = 0
+    for start in range(0, len(req.all_token_ids), block_size):
+        end = start + block_size
+        assert end <= len(req.all_token_ids)
+        extra_keys, mm_idx = generate_block_hash_extra_keys(req, start, end, mm_idx)
+        parent = hash_block_tokens(
+            sha256,
+            parent,
+            req.all_token_ids[start:end],
+            extra_keys,
+        )
+        block_hashes.append(parent)
+    req.block_hashes = block_hashes
+
+
 def _request(*, block_hashes: list[BlockHash], token_count: int, req_id: str = "req"):
     req = MagicMock()
     req.request_id = req_id
     req.block_hashes = block_hashes
     req.all_token_ids = list(range(1, token_count + 1))
     req.lora_request = None
+    req.mm_features = []
+    req.cache_salt = None
+    req.prompt_embeds = None
+    req._prompt_embeds_per_block_hashes = {}
+    req.req_context = ReqContext(req_id)
+    req.resumable = False
     return req
 
 
@@ -104,13 +138,13 @@ def _record_chunks(
     group_config: GroupOffloadConfig,
     num_chunks: int,
 ) -> list[OffloadKey]:
+    tracker.on_new_request(req.req_context, req, (group_config,))
     keys: list[OffloadKey] = []
     hbf = group_config.hashes_per_chunk
     for chunk_idx in range(num_chunks):
         tail_hash = req.block_hashes[(chunk_idx + 1) * hbf - 1]
         assert tail_hash is not None
         key = make_offload_key(tail_hash, group_config.group_idx)
-        tracker.record_store(req, group_config, chunk_idx, key)
         keys.append(key)
     return keys
 
@@ -121,32 +155,21 @@ def _record_lookup_chunks(
     group_config: GroupOffloadConfig,
     num_chunks: int,
 ) -> list[OffloadKey]:
-    keys: list[OffloadKey] = []
-    hbf = group_config.hashes_per_chunk
-    for chunk_idx in range(num_chunks):
-        tail_hash = req.block_hashes[(chunk_idx + 1) * hbf - 1]
-        assert tail_hash is not None
-        key = make_offload_key(tail_hash, group_config.group_idx)
-        tracker.record_lookup(
-            req,
-            group_config,
-            chunk_idx,
-            key,
-        )
-        keys.append(key)
-    return keys
+    return _record_chunks(tracker, req, group_config, num_chunks)
 
 
 def _stored_event(
     keys: list[OffloadKey],
     medium: Medium = _CPU_MEDIUM,
     locality: Locality | None = None,
+    req_context: ReqContext | None = None,
 ) -> OffloadingEvent:
     return OffloadingEvent(
         keys=keys,
         medium=medium,
         removed=False,
         locality=locality,
+        req_context=req_context,
     )
 
 
@@ -185,7 +208,14 @@ def test_take_events_forwards_locality_to_rich_store():
 
     events = list(
         tracker.take_events(
-            [_stored_event([key], locality=Locality.LOCAL, medium=Medium.STORAGE)]
+            [
+                _stored_event(
+                    [key],
+                    locality=Locality.LOCAL,
+                    medium=Medium.STORAGE,
+                    req_context=req.req_context,
+                )
+            ]
         )
     )
 
@@ -203,7 +233,14 @@ def test_take_events_forwards_locality_to_placeholder_store():
 
     events = list(
         tracker.take_events(
-            [_stored_event([key], locality=Locality.REMOTE, medium=Medium.STORAGE)]
+            [
+                _stored_event(
+                    [key],
+                    locality=Locality.REMOTE,
+                    medium=Medium.STORAGE,
+                    req_context=req.req_context,
+                )
+            ]
         )
     )
 
@@ -221,8 +258,13 @@ def test_partial_tail_event_describes_hash_aligned_physical_block_prefix():
     req = _request(block_hashes=[_hash(i) for i in range(8)], token_count=32)
     key = make_offload_key(req.block_hashes[6], group_config.group_idx)
 
-    tracker.record_partial_store(req, group_config, 28, key)
-    [event] = tracker.take_events([_stored_event([key])])
+    tracker.on_new_request(
+        req.req_context,
+        req,
+        (group_config,),
+        supports_partial_tail=True,
+    )
+    [event] = tracker.take_events([_stored_event([key], req_context=req.req_context)])
 
     assert isinstance(event, BlockStored)
     assert event.block_hashes == [_wire_hash(_hash(i)) for i in range(4, 7)]
@@ -231,7 +273,7 @@ def test_partial_tail_event_describes_hash_aligned_physical_block_prefix():
     assert event.block_size == 4
 
 
-def test_partial_tail_lookup_does_not_overwrite_store_metadata():
+def test_partial_tail_event_uses_its_exact_request_context():
     tracker = _tracker()
     group_config = _group_config()
     stored_req = _request(block_hashes=[_hash(0)], token_count=4)
@@ -239,25 +281,34 @@ def test_partial_tail_lookup_does_not_overwrite_store_metadata():
     lookup_req.all_token_ids = [9, 9, 9, 9]
     key = make_offload_key(stored_req.block_hashes[0], group_config.group_idx)
 
-    tracker.record_partial_store(stored_req, group_config, 4, key)
-    tracker.record_partial_lookup(lookup_req, group_config, 4, key)
-    [event] = tracker.take_events([_stored_event([key])])
+    tracker.on_new_request(
+        stored_req.req_context,
+        stored_req,
+        (group_config,),
+        supports_partial_tail=True,
+    )
+    tracker.on_new_request(
+        lookup_req.req_context,
+        lookup_req,
+        (group_config,),
+        supports_partial_tail=True,
+    )
+    [event] = tracker.take_events(
+        [_stored_event([key], req_context=stored_req.req_context)]
+    )
 
     assert isinstance(event, BlockStored)
     assert event.token_ids == [1, 2, 3, 4]
 
 
-@pytest.mark.parametrize(
-    "record_method", ["record_partial_store", "record_partial_lookup"]
-)
-def test_partial_tail_sliding_window_event_uses_placeholder(record_method):
+def test_partial_tail_sliding_window_event_uses_placeholder():
     tracker = _tracker()
     group_config = _group_config(sliding_window_size_in_chunks=1)
     req = _request(block_hashes=[_hash(0)], token_count=4)
     key = make_offload_key(req.block_hashes[0], group_config.group_idx)
 
-    getattr(tracker, record_method)(req, group_config, 4, key)
-    [event] = tracker.take_events([_stored_event([key])])
+    tracker.on_new_request(req.req_context, req, (group_config,))
+    [event] = tracker.take_events([_stored_event([key], req_context=req.req_context)])
 
     assert isinstance(event, BlockStored)
     assert event.block_hashes == [_wire_hash(_hash(0))]
@@ -291,7 +342,9 @@ def test_take_events_publishes_routable_block_stored():
     )
     keys = _record_chunks(tracker, req, group_config, num_chunks=6)
 
-    batch1 = list(tracker.take_events([_stored_event(keys[:3])]))
+    batch1 = list(
+        tracker.take_events([_stored_event(keys[:3], req_context=req.req_context)])
+    )
     assert len(batch1) == 3
 
     for i, event in enumerate(batch1):
@@ -308,22 +361,24 @@ def test_take_events_publishes_routable_block_stored():
             assert event.parent_block_hash == _wire_hash(_hash(i - 1))
         assert event.lora_id is None
         assert event.lora_name is None
-        assert event.extra_keys is None
+        assert event.extra_keys == [None]
         assert event.group_idx == 0
         assert event.kv_cache_spec_kind == KVCacheSpecKind.FULL_ATTENTION.value
         assert event.kv_cache_spec_sliding_window is None
 
-    batch2 = list(tracker.take_events([_stored_event(keys[3:])]))
+    batch2 = list(
+        tracker.take_events([_stored_event(keys[3:], req_context=req.req_context)])
+    )
     assert len(batch2) == 3
     assert batch2[0].parent_block_hash == batch1[-1].block_hashes[-1]
 
-    assert len(tracker._pending_event_metadata) == 6
+    assert len(tracker._removal_metadata) == 6
 
 
 def test_promotion_emits_full_cpu_stored_event():
-    tracker, _, _, key = _lookup_chunk()
+    tracker, req, _, key = _lookup_chunk()
 
-    [event] = tracker.take_events([_stored_event([key])])
+    [event] = tracker.take_events([_stored_event([key], req_context=req.req_context)])
 
     assert isinstance(event, BlockStored)
     assert event.medium == MEDIUM_CPU
@@ -333,10 +388,223 @@ def test_promotion_emits_full_cpu_stored_event():
     assert event.block_size == 4
     assert event.lora_id is None
     assert event.lora_name is None
-    assert event.extra_keys is None
+    assert event.extra_keys == [None]
     assert event.group_idx == 0
     assert event.kv_cache_spec_kind == KVCacheSpecKind.FULL_ATTENTION.value
     assert event.kv_cache_spec_sliding_window is None
+
+
+def test_request_event_context_builds_payload_lazily():
+    tracker = _tracker()
+    req = _request(block_hashes=[_hash(0)], token_count=4)
+    [key] = _record_chunks(tracker, req, _group_config(), num_chunks=1)
+    state = tracker._request_event_context(req.req_context)
+
+    assert state is not None
+    assert not state.locators
+
+    list(tracker.take_events([_stored_event([key], req_context=req.req_context)]))
+
+    assert state.locators[key] == 4
+
+
+def test_request_event_context_indexes_only_valid_group_chunk_tails():
+    tracker = _tracker()
+    group0 = _group_config(group_idx=0, block_size=4, blocks_per_chunk=2)
+    group1 = _group_config(
+        group_idx=1,
+        block_size=8,
+        blocks_per_chunk=2,
+        tokens_per_hash=4,
+    )
+    req = _request(block_hashes=[_hash(i) for i in range(4)], token_count=16)
+    tracker.on_new_request(req.req_context, req, (group0, group1))
+    state = tracker._request_event_context(req.req_context)
+    assert state is not None
+    assert not state.locators
+
+    key0 = make_offload_key(req.block_hashes[1], group0.group_idx)
+    key1 = make_offload_key(req.block_hashes[3], group1.group_idx)
+    events = list(
+        tracker.take_events([_stored_event([key0, key1], req_context=req.req_context)])
+    )
+
+    assert [(event.group_idx, len(event.token_ids)) for event in events] == [
+        (0, 8),
+        (1, 16),
+    ]
+    assert set(state.locators) == {
+        key0,
+        make_offload_key(req.block_hashes[3], group0.group_idx),
+        key1,
+    }
+
+
+def test_stored_event_uses_context_carried_by_raw_event():
+    tracker = _tracker()
+    group_config = _group_config()
+    first_req = _request(block_hashes=[_hash(0)], token_count=4)
+    second_req = _request(block_hashes=[_hash(1)], token_count=4)
+    second_req.all_token_ids = [9, 9, 9, 9]
+    [first_key] = _record_chunks(tracker, first_req, group_config, num_chunks=1)
+    [second_key] = _record_chunks(tracker, second_req, group_config, num_chunks=1)
+
+    [first_event] = tracker.take_events(
+        [_stored_event([first_key], req_context=first_req.req_context)]
+    )
+    [second_event] = tracker.take_events(
+        [_stored_event([second_key], req_context=second_req.req_context)]
+    )
+
+    assert first_req.request_id == second_req.request_id
+    assert first_req.req_context is not second_req.req_context
+    assert first_event.token_ids == [1, 2, 3, 4]
+    assert second_event.token_ids == [9, 9, 9, 9]
+
+
+@pytest.mark.parametrize(
+    "event_context",
+    [None, ReqContext("external")],
+    ids=["missing", "external"],
+)
+def test_stored_event_without_matching_context_uses_placeholder(event_context):
+    tracker = _tracker()
+    req = _request(block_hashes=[_hash(0)], token_count=4)
+    [key] = _record_chunks(tracker, req, _group_config(), num_chunks=1)
+
+    [event] = tracker.take_events([_stored_event([key], req_context=event_context)])
+
+    assert isinstance(event, BlockStored)
+    assert event.block_hashes == [_wire_hash(_hash(0))]
+    assert event.parent_block_hash is None
+    assert event.token_ids == []
+    assert event.block_size == 0
+
+
+@pytest.mark.parametrize("unsafe_path", ["resumable", "mamba_truncation"])
+def test_token_mutating_request_uses_placeholder(unsafe_path):
+    tracker = _tracker()
+    req = _request(block_hashes=[_hash(0)], token_count=4)
+    [key] = _record_chunks(tracker, req, _group_config(), num_chunks=1)
+    if unsafe_path == "resumable":
+        req.resumable = True
+    else:
+        req.kv_transfer_params = {"_p_side_truncated": True}
+
+    [event] = tracker.take_events([_stored_event([key], req_context=req.req_context)])
+
+    assert event.block_hashes == [_wire_hash(_hash(0))]
+    assert event.token_ids == []
+    assert event.block_size == 0
+
+
+def test_full_event_extra_keys_match_gpu_block_granularity():
+    tracker = _tracker()
+    req = _request(block_hashes=[_hash(0), _hash(1)], token_count=8)
+    req.cache_salt = "salt"
+    req.lora_request = SimpleNamespace(
+        adapter_id=7,
+        name="adapter",
+        lora_name="adapter",
+    )
+    [key] = _record_chunks(
+        tracker,
+        req,
+        _group_config(blocks_per_chunk=2),
+        num_chunks=1,
+    )
+
+    [event] = tracker.take_events([_stored_event([key], req_context=req.req_context)])
+
+    assert event.extra_keys == [("adapter", "salt"), ("adapter",)]
+    assert event.lora_id == 7
+    assert event.lora_name == "adapter"
+
+
+def test_full_event_extra_keys_include_prompt_embeddings():
+    tracker = _tracker()
+    group_config = _group_config(blocks_per_chunk=2)
+    req = _request(block_hashes=[_hash(0), _hash(1)], token_count=8)
+    req.prompt_embeds = torch.arange(24, dtype=torch.float32).reshape(8, 3)
+    _rehash_request(req, block_size=4)
+    [key] = _record_chunks(tracker, req, group_config, num_chunks=1)
+
+    [event] = tracker.take_events([_stored_event([key], req_context=req.req_context)])
+
+    expected = []
+    mm_idx = 0
+    for start in (0, 4):
+        extra_keys, mm_idx = generate_block_hash_extra_keys(
+            req, start, start + 4, mm_idx
+        )
+        expected.append(extra_keys)
+    assert event.block_hashes == [_wire_hash(value) for value in req.block_hashes]
+    assert event.token_ids == req.all_token_ids
+    assert event.extra_keys == expected
+
+
+def test_partial_event_extra_keys_include_cache_salt_and_lora():
+    tracker = _tracker()
+    group_config = _group_config(
+        block_size=16,
+        tokens_per_hash=4,
+    )
+    req = _request(block_hashes=[_hash(i) for i in range(4)], token_count=16)
+    req.cache_salt = "salt"
+    req.lora_request = SimpleNamespace(
+        adapter_id=7,
+        name="adapter",
+        lora_name="adapter",
+    )
+    key = make_offload_key(req.block_hashes[2], group_config.group_idx)
+
+    tracker.on_new_request(
+        req.req_context,
+        req,
+        (group_config,),
+        supports_partial_tail=True,
+    )
+    [event] = tracker.take_events([_stored_event([key], req_context=req.req_context)])
+
+    assert event.extra_keys == [
+        ("adapter", "salt"),
+        ("adapter",),
+        ("adapter",),
+    ]
+    assert event.lora_id == 7
+    assert event.lora_name == "adapter"
+
+
+def test_partial_event_extra_keys_replay_mm_features_from_request_start():
+    tracker = _tracker()
+    group_config = _group_config(
+        block_size=16,
+        tokens_per_hash=4,
+    )
+    req = _request(block_hashes=[_hash(i) for i in range(8)], token_count=32)
+    req.mm_features = [
+        SimpleNamespace(
+            identifier="A",
+            mm_position=SimpleNamespace(offset=18, length=4),
+        ),
+        SimpleNamespace(
+            identifier="B",
+            mm_position=SimpleNamespace(offset=40, length=4),
+        ),
+    ]
+    _rehash_request(req, block_size=4)
+    key = make_offload_key(req.block_hashes[6], group_config.group_idx)
+    tracker.on_new_request(
+        req.req_context,
+        req,
+        (group_config,),
+        supports_partial_tail=True,
+    )
+    [event] = tracker.take_events([_stored_event([key], req_context=req.req_context)])
+
+    assert event.block_hashes == [_wire_hash(value) for value in req.block_hashes[4:7]]
+    assert event.token_ids == req.all_token_ids[16:28]
+    assert event.extra_keys == [(("A", 2),), (("A", -2),), None]
 
 
 @pytest.mark.parametrize(
@@ -361,7 +629,7 @@ def test_event_hashes_use_group_block_size(
     )
     [key] = _record_chunks(tracker, req, group_config, num_chunks=1)
 
-    [event] = tracker.take_events([_stored_event([key])])
+    [event] = tracker.take_events([_stored_event([key], req_context=req.req_context)])
 
     assert isinstance(event, BlockStored)
     assert event.block_hashes == [_wire_hash(_hash(i)) for i in expected_hash_indices]
@@ -382,7 +650,9 @@ def test_lookup_promotion_factor_gt_1_store_and_remove():
     )
     keys = _record_lookup_chunks(tracker, req, group_config, num_chunks=2)
 
-    stored = list(tracker.take_events([_stored_event(keys)]))
+    stored = list(
+        tracker.take_events([_stored_event(keys, req_context=req.req_context)])
+    )
     assert len(stored) == 2
 
     expected_hashes = []
@@ -404,7 +674,7 @@ def test_lookup_promotion_factor_gt_1_store_and_remove():
             assert event.parent_block_hash == _wire_hash(_hash(blocks_per_chunk - 1))
         expected_hashes.extend(expected_chunk_hashes)
 
-    assert len(tracker._pending_event_metadata) == 2
+    assert len(tracker._removal_metadata) == 2
 
     removed = list(tracker.take_events([_removed_event(keys)]))
     assert len(removed) == 1
@@ -412,7 +682,7 @@ def test_lookup_promotion_factor_gt_1_store_and_remove():
     assert removed[0].block_hashes == expected_hashes
     assert removed[0].medium == _CPU_MEDIUM.value
     assert removed[0].group_idx == 0
-    assert not tracker._pending_event_metadata
+    assert not tracker._removal_metadata
 
 
 def test_take_events_factor_gt_1_store_is_order_independent():
@@ -426,7 +696,16 @@ def test_take_events_factor_gt_1_store_is_order_independent():
     keys = _record_chunks(tracker, req, group_config, num_chunks=2)
     unknown_key = make_offload_key(_hash(12345), 0)
 
-    events = list(tracker.take_events([_stored_event([keys[1], unknown_key, keys[0]])]))
+    events = list(
+        tracker.take_events(
+            [
+                _stored_event(
+                    [keys[1], unknown_key, keys[0]],
+                    req_context=req.req_context,
+                )
+            ]
+        )
+    )
 
     assert len(events) == 3
     chunk1, placeholder, chunk0 = events
@@ -445,12 +724,12 @@ def test_take_events_opt_out_keeps_placeholders():
     _record_lookup_chunks(tracker, req, group_config, num_chunks=3)
 
     assert not tracker.self_describing_enabled
-    assert not tracker._pending_event_metadata
+    assert tracker._request_event_context(req.req_context) is None
 
     events = list(
         tracker.take_events(
             [
-                _stored_event(keys),
+                _stored_event(keys, req_context=req.req_context),
                 _removed_event(keys),
             ]
         )
@@ -481,9 +760,13 @@ def test_event_metadata_skips_non_full_attention_group(
     keys = _record_chunks(tracker, req, group_config, num_chunks=3)
     _record_lookup_chunks(tracker, req, group_config, num_chunks=3)
 
-    assert not tracker._pending_event_metadata
+    state = tracker._request_event_context(req.req_context)
+    assert state is not None
+    assert not state.locators
 
-    events = list(tracker.take_events([_stored_event(keys[:1])]))
+    events = list(
+        tracker.take_events([_stored_event(keys[:1], req_context=req.req_context)])
+    )
     assert len(events) == 1
     assert isinstance(events[0], BlockStored)
     assert events[0].block_size == 0
@@ -495,20 +778,12 @@ def test_pending_cpu_removal_consumes_hit_backfill_until_next_hit():
     req = _request(block_hashes=block_hashes, token_count=8)
     group_config = _group_config(blocks_per_chunk=2)
     key = _record_chunks(tracker, req, group_config, num_chunks=1)[0]
-    confirmed_meta = tracker._pending_event_metadata[key]
+    tracker.record_hit(req.req_context, key)
     lookup_req = _request(
         block_hashes=block_hashes,
         token_count=8,
         req_id="new-request",
     )
-
-    tracker.record_lookup(
-        lookup_req,
-        group_config,
-        0,
-        key,
-    )
-    assert tracker._pending_event_metadata[key] is confirmed_meta
 
     removed = list(tracker.take_events([_removed_event([key])]))
     assert len(removed) == 1
@@ -517,12 +792,8 @@ def test_pending_cpu_removal_consumes_hit_backfill_until_next_hit():
         _wire_hash(_hash(1)),
     ]
 
-    stored = list(tracker.take_events([_stored_event([key])]))
-    assert len(stored) == 1
-    assert stored[0].block_size == 0
-    assert stored[0].token_ids == []
-
-    tracker.record_lookup(lookup_req, group_config, 0, key)
+    tracker.on_new_request(lookup_req.req_context, lookup_req, (group_config,))
+    tracker.record_hit(lookup_req.req_context, key)
     removed = list(tracker.take_events([_removed_event([key])]))
     assert removed[0].block_hashes == [
         _wire_hash(_hash(0)),
@@ -530,13 +801,22 @@ def test_pending_cpu_removal_consumes_hit_backfill_until_next_hit():
     ]
 
 
-def test_secondary_stored_event_does_not_mutate_cpu_metadata():
-    tracker, _, _, key = _lookup_chunk()
-    expected_metadata = dict(tracker._pending_event_metadata)
+def test_storage_stored_event_does_not_create_legacy_removal_metadata():
+    tracker, req, _, key = _lookup_chunk()
 
-    stored = list(tracker.take_events([_stored_event([key], Medium.STORAGE)]))
+    stored = list(
+        tracker.take_events(
+            [
+                _stored_event(
+                    [key],
+                    Medium.STORAGE,
+                    req_context=req.req_context,
+                )
+            ]
+        )
+    )
     assert stored[0].token_ids == [1, 2, 3, 4]
-    assert tracker._pending_event_metadata == expected_metadata
+    assert not tracker._removal_metadata
 
 
 def test_take_events_groups_removed_hashes_by_kv_group():
@@ -547,6 +827,8 @@ def test_take_events_groups_removed_hashes_by_kv_group():
     req1 = _request(block_hashes=[_hash(10), _hash(11)], token_count=8)
     key0 = _record_chunks(tracker, req0, group0_config, num_chunks=1)[0]
     key1 = _record_chunks(tracker, req1, group1_config, num_chunks=1)[0]
+    list(tracker.take_events([_stored_event([key0], req_context=req0.req_context)]))
+    list(tracker.take_events([_stored_event([key1], req_context=req1.req_context)]))
 
     removed = list(tracker.take_events([_removed_event([key0, key1])]))
 
@@ -565,7 +847,9 @@ def test_take_events_supports_restore_after_eviction():
     req = _request(block_hashes=[_hash(0)], token_count=block_size)
     key = _record_chunks(tracker, req, group_config, num_chunks=1)[0]
 
-    first_store = list(tracker.take_events([_stored_event([key])]))
+    first_store = list(
+        tracker.take_events([_stored_event([key], req_context=req.req_context)])
+    )
     assert len(first_store) == 1
     assert isinstance(first_store[0], BlockStored)
     assert first_store[0].token_ids == [1, 2, 3, 4]
@@ -573,35 +857,54 @@ def test_take_events_supports_restore_after_eviction():
     removed = list(tracker.take_events([_removed_event([key])]))
     assert len(removed) == 1
     assert isinstance(removed[0], BlockRemoved)
-    assert not tracker._pending_event_metadata
+    assert not tracker._removal_metadata
 
-    req.all_token_ids = [5, 6, 7, 8]
-    tracker.record_store(req, group_config, chunk_idx=0, offload_key=key)
+    replacement_req = _request(
+        block_hashes=[_hash(0)],
+        token_count=block_size,
+        req_id=req.request_id,
+    )
+    tracker.on_new_request(
+        replacement_req.req_context, replacement_req, (group_config,)
+    )
 
-    second_store = list(tracker.take_events([_stored_event([key])]))
+    second_store = list(
+        tracker.take_events(
+            [_stored_event([key], req_context=replacement_req.req_context)]
+        )
+    )
     assert len(second_store) == 1
     assert isinstance(second_store[0], BlockStored)
-    assert second_store[0].token_ids == [5, 6, 7, 8]
+    assert second_store[0].token_ids == [1, 2, 3, 4]
 
 
-def test_reset_cache_clears_side_table():
+def test_reset_keeps_request_context_for_secondary_events():
     tracker = _tracker()
     group_config = _group_config()
     req = _request(block_hashes=[_hash(i) for i in range(3)], token_count=12)
     _record_lookup_chunks(tracker, req, group_config, num_chunks=3)
 
-    assert tracker._pending_event_metadata
+    key = make_offload_key(req.block_hashes[0], group_config.group_idx)
+    tracker.record_hit(req.req_context, key)
+    assert tracker._request_event_context(req.req_context) is not None
+    assert tracker._removal_metadata
 
     tracker.reset()
 
-    assert not tracker._pending_event_metadata
+    assert tracker._request_event_context(req.req_context) is not None
+    assert not tracker._removal_metadata
+
+    key = make_offload_key(req.block_hashes[0], group_config.group_idx)
+    [event] = tracker.take_events(
+        [_stored_event([key], medium=Medium.STORAGE, req_context=req.req_context)]
+    )
+    assert event.token_ids == [1, 2, 3, 4]
 
 
 def test_tiering_accepts_self_describing_kv_events():
     vllm_config = create_vllm_config(
         block_size=4,
         max_num_batched_tokens=16,
-        disable_hybrid_kv_cache_manager=False,
     )
     vllm_config.kv_transfer_config = KVTransferConfig(
         kv_connector="OffloadingConnector",

--- a/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
+++ b/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
@@ -83,6 +83,9 @@ def _make_partial_tail_request(
     request.block_hashes = [BlockHash(f"h{i}".encode()) for i in range(7)]
     request.all_token_ids = list(range(30))
     request.lora_request = None
+    request.mm_features = []
+    request.cache_salt = None
+    request.prompt_embeds = None
     request.is_finished.return_value = False
     scheduler.on_new_request(request)
     return request
@@ -134,6 +137,7 @@ def test_partial_tail_store_uses_attention_and_recurrent_cow_sources():
                     keys=list(scheduler._jobs[job_id].keys),
                     medium=Medium.CPU,
                     removed=False,
+                    req_context=req_status.req_context,
                 )
             ]
         )
@@ -379,7 +383,7 @@ def test_scheduler_reports_lookup_async_delay_on_resolve(request_runner):
     assert reduced[f"{_ConnectorMetricName.LOOKUP_ASYNC_DELAY}_sum"] > 0
 
 
-def test_max_offload_tokens_zero_does_not_record_pending_lookups(request_runner):
+def test_max_offload_tokens_zero_does_not_create_removal_metadata(request_runner):
     runner = request_runner(
         block_size=4,
         num_gpu_blocks=10,
@@ -399,13 +403,13 @@ def test_max_offload_tokens_zero_does_not_record_pending_lookups(request_runner)
 
     tracker = runner.connector_scheduler._events_tracker
     assert runner.manager.lookup.call_count == 3
-    assert not tracker._pending_event_metadata
+    assert not tracker._removal_metadata
     assert list(runner.connector_scheduler.take_events()) == []
 
     runner.manager.lookup.return_value = LookupResult.MISS
     runner.run(decoded_tokens=[EOS_TOKEN_ID])
 
-    assert not tracker._pending_event_metadata
+    assert not tracker._removal_metadata
     assert list(runner.connector_scheduler.take_events()) == []
 
 
@@ -434,14 +438,14 @@ def test_abort_before_hit_uses_placeholder_then_later_hit_heals_removal(
     runner.run(decoded_tokens=[])
 
     tracker = runner.connector_scheduler._events_tracker
-    assert not tracker._pending_event_metadata
+    assert not tracker._removal_metadata
     key = runner.manager.lookup.call_args.args[0]
     req_id = str(runner.req_id)
     req_status = runner.connector_scheduler._req_status[req_id]
 
     runner.scheduler.finish_requests((req_id,), RequestStatus.FINISHED_ABORTED)
 
-    assert not tracker._pending_event_metadata
+    assert not tracker._removal_metadata
 
     raw_events.append(OffloadingEvent(keys=[key], medium=Medium.CPU, removed=False))
     events = list(runner.connector_scheduler.take_events())
@@ -462,14 +466,53 @@ def test_abort_before_hit_uses_placeholder_then_later_hit_heals_removal(
         )
         == 1
     )
-    assert key in tracker._pending_event_metadata
+    assert (Medium.CPU, key) in tracker._removal_metadata
 
     raw_events.append(OffloadingEvent(keys=[key], medium=Medium.CPU, removed=True))
     [event] = runner.connector_scheduler.take_events()
     assert isinstance(event, BlockRemoved)
     assert event.medium == MEDIUM_CPU
     assert len(event.block_hashes) == 2
-    assert key not in tracker._pending_event_metadata
+    assert (Medium.CPU, key) not in tracker._removal_metadata
+
+
+def test_reset_buffers_queued_removal_before_clearing_metadata(request_runner):
+    runner = request_runner(
+        block_size=4,
+        num_gpu_blocks=10,
+        async_scheduling=False,
+        blocks_per_chunk=2,
+    )
+    raw_events: list[OffloadingEvent] = []
+
+    def take_raw_events():
+        yield from raw_events
+        raw_events.clear()
+
+    runner.manager.lookup.return_value = LookupResult.RETRY
+    runner.manager.take_events.side_effect = take_raw_events
+    runner.manager.prepare_store.side_effect = lambda keys, req_context: (
+        generate_store_output([])
+    )
+
+    runner.new_request(token_ids=[1] * 8)
+    runner.run(decoded_tokens=[])
+
+    scheduler = runner.connector_scheduler
+    tracker = scheduler._events_tracker
+    req_status = scheduler._req_status[str(runner.req_id)]
+    key = runner.manager.lookup.call_args.args[0]
+    tracker.record_hit(req_status.req_context, key)
+    assert (Medium.CPU, key) in tracker._removal_metadata
+
+    raw_events.append(OffloadingEvent(keys=[key], medium=Medium.CPU, removed=True))
+    scheduler.reset_cache()
+
+    assert not tracker._removal_metadata
+    [event] = scheduler.take_events()
+    assert isinstance(event, BlockRemoved)
+    assert len(event.block_hashes) == 2
+    assert not scheduler._pending_events
 
 
 @pytest.mark.parametrize("blocks_per_chunk", [1, 2])
@@ -499,7 +542,14 @@ def test_promotion_hit_precedes_stored_event_translation(
     raw_events: list[OffloadingEvent] = []
 
     def lookup(key, req_context):
-        raw_events.append(OffloadingEvent(keys=[key], medium=Medium.CPU, removed=False))
+        raw_events.append(
+            OffloadingEvent(
+                keys=[key],
+                medium=Medium.CPU,
+                removed=False,
+                req_context=req_context,
+            )
+        )
         return LookupResult.HIT
 
     def take_raw_events():
@@ -1238,33 +1288,19 @@ def _maximal_lookup(sched, keys, start_chunk_idx: int = 0):
 
 class TestMaximalPrefixLookup:
     def test_all_hit(self):
-        sched = _make_scheduler_with_lookup({1: LookupResult.HIT, 2: LookupResult.HIT})
-        assert _maximal_lookup(sched, to_keys([1, 2])) == 2
-
-    def test_records_absolute_chunk_indices(self):
         keys = to_keys([1, 2])
         sched = _make_scheduler_with_lookup({1: LookupResult.HIT, 2: LookupResult.HIT})
 
-        assert _maximal_lookup(sched, keys, start_chunk_idx=3) == 2
-        assert sched._events_tracker.record_lookup.call_args_list == [
-            call(
-                _LOOKUP_REQ,
-                _LOOKUP_GROUP_CONFIG,
-                3,
-                keys[0],
-            ),
-            call(
-                _LOOKUP_REQ,
-                _LOOKUP_GROUP_CONFIG,
-                4,
-                keys[1],
-            ),
+        assert _maximal_lookup(sched, keys) == 2
+        assert sched._events_tracker.record_hit.call_args_list == [
+            call(_EMPTY_REQ_CTX, keys[0]),
+            call(_EMPTY_REQ_CTX, keys[1]),
         ]
 
     def test_all_miss(self):
         sched = _make_scheduler_with_lookup({})
         assert _maximal_lookup(sched, to_keys([1, 2])) == 0
-        sched._events_tracker.record_lookup.assert_not_called()
+        sched._events_tracker.record_hit.assert_not_called()
 
     def test_partial_prefix(self):
         sched = _make_scheduler_with_lookup({1: LookupResult.HIT, 2: LookupResult.HIT})
@@ -1286,27 +1322,22 @@ class TestMaximalPrefixLookup:
         "pending_result",
         [LookupResult.RETRY, LookupResult.HIT_PENDING],
     )
-    def test_pending_result_is_not_recorded(
-        self,
-        pending_result: LookupResult,
-    ):
+    def test_pending_result_defers(self, pending_result: LookupResult):
         sched = _make_scheduler_with_lookup({1: pending_result})
 
         assert _maximal_lookup(sched, to_keys([1])) is None
-        sched._events_tracker.record_lookup.assert_not_called()
+        sched._events_tracker.record_hit.assert_not_called()
 
     def test_retry_defers(self):
         keys = to_keys([1, 2])
         sched = _make_scheduler_with_lookup(
             {1: LookupResult.RETRY, 2: LookupResult.HIT}
         )
+
         assert _maximal_lookup(sched, keys) is None
         assert sched.manager.lookup.call_count == 2
-        sched._events_tracker.record_lookup.assert_called_once_with(
-            _LOOKUP_REQ,
-            _LOOKUP_GROUP_CONFIG,
-            1,
-            keys[1],
+        sched._events_tracker.record_hit.assert_called_once_with(
+            _EMPTY_REQ_CTX, keys[1]
         )
 
     def test_retry_after_hit_defers(self):
@@ -1314,12 +1345,10 @@ class TestMaximalPrefixLookup:
         sched = _make_scheduler_with_lookup(
             {1: LookupResult.HIT, 2: LookupResult.RETRY}
         )
+
         assert _maximal_lookup(sched, keys) is None
-        sched._events_tracker.record_lookup.assert_called_once_with(
-            _LOOKUP_REQ,
-            _LOOKUP_GROUP_CONFIG,
-            0,
-            keys[0],
+        sched._events_tracker.record_hit.assert_called_once_with(
+            _EMPTY_REQ_CTX, keys[0]
         )
 
     def test_hit_pending_defers(self):
@@ -1327,33 +1356,31 @@ class TestMaximalPrefixLookup:
         sched = _make_scheduler_with_lookup(
             {1: LookupResult.HIT_PENDING, 2: LookupResult.HIT}
         )
+
         assert _maximal_lookup(sched, keys) is None
         assert sched.manager.lookup.call_count == 2
-        sched._events_tracker.record_lookup.assert_called_once_with(
-            _LOOKUP_REQ,
-            _LOOKUP_GROUP_CONFIG,
-            1,
-            keys[1],
+        sched._events_tracker.record_hit.assert_called_once_with(
+            _EMPTY_REQ_CTX, keys[1]
         )
 
     def test_hit_pending_does_not_stop_scan(self):
-        """HIT_PENDING defers but does not break — scan continues until miss."""
+        """HIT_PENDING defers but does not break until a miss."""
         sched = _make_scheduler_with_lookup(
             {1: LookupResult.HIT_PENDING, 2: LookupResult.MISS, 3: LookupResult.HIT}
         )
+
         assert _maximal_lookup(sched, to_keys([1, 2, 3])) is None
         assert sched.manager.lookup.call_count == 2
-        sched._events_tracker.record_lookup.assert_not_called()
+        sched._events_tracker.record_hit.assert_not_called()
 
     def test_retry_stops_at_miss(self):
-        """RETRY is treated as hit for iteration, but miss stops the scan."""
         sched = _make_scheduler_with_lookup(
             {1: LookupResult.RETRY, 2: LookupResult.MISS, 3: LookupResult.HIT}
         )
+
         assert _maximal_lookup(sched, to_keys([1, 2, 3])) is None
-        # lookup should have been called for blocks 1 and 2 (stops at miss)
         assert sched.manager.lookup.call_count == 2
-        sched._events_tracker.record_lookup.assert_not_called()
+        sched._events_tracker.record_hit.assert_not_called()
 
 
 class TestSlidingWindowLookup:
@@ -1728,6 +1755,73 @@ def test_complete_store_waits_for_all_worker_acks(
     )
     assert runner.manager.complete_store.call_count == 1
     assert job_id not in runner.connector_scheduler._jobs
+
+
+def test_worker_completion_uses_exact_request_state_after_req_id_reuse(
+    request_runner,
+):
+    runner = request_runner(
+        block_size=4,
+        num_gpu_blocks=20,
+        async_scheduling=False,
+    )
+    runner.new_request(token_ids=[0] * 4)
+    runner.manager.prepare_store.side_effect = lambda keys, req_context: (
+        generate_store_output(keys)
+    )
+    runner.run(decoded_tokens=[0], complete_transfers=False)
+
+    [job_id] = runner.connector_scheduler._jobs
+    old_status = runner.connector_scheduler._jobs[job_id].req_status
+    replacement = MagicMock()
+    replacement.req_context = ReqContext(old_status.req.request_id)
+    runner.connector_scheduler._req_status[old_status.req.request_id] = replacement
+
+    runner.connector_scheduler.update_connector_output(
+        KVConnectorOutput(
+            kv_connector_worker_meta=OffloadingWorkerMetadata(
+                completed_jobs={job_id: runner.connector_scheduler.config.num_workers}
+            )
+        )
+    )
+
+    assert runner.manager.complete_store.call_args.args[1] is old_status.req_context
+    assert (
+        runner.connector_scheduler._req_status[old_status.req.request_id] is replacement
+    )
+
+
+def test_worker_completion_cleans_state_when_manager_completion_raises(
+    request_runner,
+):
+    runner = request_runner(
+        block_size=4,
+        num_gpu_blocks=20,
+        async_scheduling=False,
+    )
+    runner.new_request(token_ids=[0] * 4)
+    runner.manager.prepare_store.side_effect = lambda keys, req_context: (
+        generate_store_output(keys)
+    )
+    runner.run(decoded_tokens=[0], complete_transfers=False)
+
+    [job_id] = runner.connector_scheduler._jobs
+    req_status = runner.connector_scheduler._jobs[job_id].req_status
+    runner.manager.complete_store.side_effect = RuntimeError("submit failed")
+
+    with pytest.raises(RuntimeError, match="submit failed"):
+        runner.connector_scheduler.update_connector_output(
+            KVConnectorOutput(
+                kv_connector_worker_meta=OffloadingWorkerMetadata(
+                    completed_jobs={
+                        job_id: runner.connector_scheduler.config.num_workers
+                    }
+                )
+            )
+        )
+
+    assert job_id not in runner.connector_scheduler._jobs
+    assert job_id not in req_status.transfer_jobs
 
 
 @pytest.mark.parametrize("async_scheduling", [True, False])
@@ -2383,6 +2477,9 @@ class TestEagle:
         req.block_hashes = [BlockHash(str(i).encode()) for i in range(num_hash_blocks)]
         req.all_token_ids = list(range(num_tokens))
         req.lora_request = None
+        req.mm_features = []
+        req.cache_salt = None
+        req.prompt_embeds = None
 
         state = RequestOffloadState(
             config=scheduler.config,

--- a/tests/v1/kv_offload/cpu/test_manager.py
+++ b/tests/v1/kv_offload/cpu/test_manager.py
@@ -40,6 +40,7 @@ def make_cpu_manager(
     cache_policy: str = "lru",
     cache_policy_module_path: str | None = None,
     enable_events: bool = False,
+    enable_event_provenance: bool = False,
     store_threshold: int = 0,
     max_tracker_size: int = 64_000,
 ) -> CPUOffloadingManager:
@@ -48,6 +49,7 @@ def make_cpu_manager(
         cache_policy=cache_policy,
         cache_policy_module_path=cache_policy_module_path,
         enable_events=enable_events,
+        enable_event_provenance=enable_event_provenance,
         store_threshold=store_threshold,
         max_tracker_size=max_tracker_size,
     )
@@ -146,7 +148,11 @@ def verify_events(
 
 def test_cpu_eviction_removed_precedes_stored():
     """An eviction is announced before the store that reuses its capacity."""
-    manager = make_cpu_manager(num_blocks=2, enable_events=True)
+    manager = make_cpu_manager(
+        num_blocks=2,
+        enable_events=True,
+        enable_event_provenance=True,
+    )
 
     manager.prepare_store(to_keys([1, 2]), _EMPTY_REQ_CTX)
     manager.complete_store(to_keys([1, 2]), _EMPTY_REQ_CTX)
@@ -161,6 +167,61 @@ def test_cpu_eviction_removed_precedes_stored():
     assert removed_idx and stored_idx, events
     assert max(removed_idx) < min(stored_idx)
     assert all(event.medium == manager.medium for event in events)
+    assert all(events[i].req_context is None for i in removed_idx)
+    assert all(events[i].req_context is _EMPTY_REQ_CTX for i in stored_idx)
+
+
+def test_cpu_reset_discards_stores_but_keeps_removals():
+    manager = make_cpu_manager(
+        num_blocks=1,
+        enable_events=True,
+        enable_event_provenance=True,
+    )
+    key1 = to_keys([1])
+    manager.prepare_store(key1, _EMPTY_REQ_CTX)
+    manager.complete_store(key1, _EMPTY_REQ_CTX)
+    list(manager.take_events())
+
+    key2 = to_keys([2])
+    manager.prepare_store(key2, _EMPTY_REQ_CTX)
+    manager.complete_store(key2, _EMPTY_REQ_CTX)
+
+    manager.reset_cache()
+
+    [event] = manager.take_events()
+    assert event.removed
+    assert event.keys == key1
+    assert event.req_context is None
+
+
+def test_cpu_take_events_detaches_queue_before_yielding():
+    manager = make_cpu_manager(
+        num_blocks=2,
+        enable_events=True,
+        enable_event_provenance=True,
+    )
+    keys = to_keys([1])
+    manager.prepare_store(keys, _EMPTY_REQ_CTX)
+    manager.complete_store(keys, _EMPTY_REQ_CTX)
+
+    event_iter = iter(manager.take_events())
+    event = next(event_iter)
+
+    assert event.req_context is _EMPTY_REQ_CTX
+    assert manager.events == []
+    event_iter.close()
+    assert list(manager.take_events()) == []
+
+
+def test_cpu_events_do_not_retain_context_when_provenance_is_disabled():
+    manager = make_cpu_manager(num_blocks=2, enable_events=True)
+    keys = to_keys([1])
+    manager.prepare_store(keys, _EMPTY_REQ_CTX)
+    manager.complete_store(keys, _EMPTY_REQ_CTX)
+
+    [event] = manager.take_events()
+
+    assert event.req_context is None
 
 
 @pytest.mark.parametrize("eviction_policy", ["lru", "arc"])
@@ -356,13 +417,14 @@ def test_cpu_manager_reports_cache_write_and_read_usage_gauges():
 
 
 def test_cpu_manager_clears_write_usage_after_failed_store():
-    manager = make_cpu_manager(num_blocks=4)
+    manager = make_cpu_manager(num_blocks=4, enable_events=True)
 
     manager.prepare_store(to_keys([1, 2]), _EMPTY_REQ_CTX)
     check_split_usage_stats(manager, write=0.5, read=0.0, total=0.5)
 
     manager.complete_store(to_keys([1, 2]), _EMPTY_REQ_CTX, success=False)
     check_split_usage_stats(manager, write=0.0, read=0.0, total=0.0)
+    assert list(manager.take_events()) == []
 
 
 def test_cpu_manager():

--- a/tests/v1/kv_offload/tiering/test_async_lookup.py
+++ b/tests/v1/kv_offload/tiering/test_async_lookup.py
@@ -82,7 +82,7 @@ class TestAsyncLookupManager:
         mgr._results_ready.wait()
         mgr._results_ready.clear()
         assert mgr.lookup(_key(1), ctx) is True
-        mgr.cleanup("req_a")
+        mgr.cleanup(ctx)
         assert _key(1) not in mgr._lookup_state
         mgr.shutdown()
 
@@ -97,10 +97,10 @@ class TestAsyncLookupManager:
         mgr._results_ready.clear()
         # Drain so result is applied
         mgr.lookup(_key(1), ctx_a)
-        mgr.cleanup("req_a")
+        mgr.cleanup(ctx_a)
         # Key still present because req_b still references it
         assert _key(1) in mgr._lookup_state
-        mgr.cleanup("req_b")
+        mgr.cleanup(ctx_b)
         assert _key(1) not in mgr._lookup_state
         mgr.shutdown()
 
@@ -118,7 +118,7 @@ class TestAsyncLookupManager:
         assert len(mgr._lookup_batch) == 1
         mgr.shutdown()
 
-    def test_cleanup_unknown_req_id_is_noop(self):
+    def test_cleanup_unknown_context_is_noop(self):
         mgr = InMemoryLookupManager(existing_keys={_key(1)})
         ctx = _ctx("req_a")
         mgr.lookup(_key(1), ctx)
@@ -126,8 +126,46 @@ class TestAsyncLookupManager:
         mgr._results_ready.wait()
         mgr._results_ready.clear()
         mgr.lookup(_key(1), ctx)
-        mgr.cleanup("nonexistent")
+        mgr.cleanup(_ctx("nonexistent"))
         assert _key(1) in mgr._lookup_state
+        mgr.shutdown()
+
+    def test_cleanup_distinguishes_reused_request_id(self):
+        mgr = InMemoryLookupManager(existing_keys={_key(1)})
+        old_ctx = _ctx("reused")
+        new_ctx = _ctx("reused")
+
+        mgr.lookup(_key(1), old_ctx)
+        mgr.lookup(_key(1), new_ctx)
+        mgr.cleanup(old_ctx)
+
+        state = mgr._lookup_state[_key(1)]
+        assert state.request_context_ids == {id(new_ctx)}
+
+        mgr.cleanup(new_ctx)
+        assert _key(1) not in mgr._lookup_state
+        mgr.shutdown()
+
+    def test_stale_result_does_not_resolve_recreated_key(self):
+        mgr = InMemoryLookupManager(existing_keys={_key(1)})
+        old_ctx = _ctx("old")
+        new_ctx = _ctx("new")
+
+        assert mgr.lookup(_key(1), old_ctx) is None
+        [(_, _, old_generation)] = mgr._lookup_batch
+        mgr.cleanup(old_ctx)
+
+        assert mgr.lookup(_key(1), new_ctx) is None
+        new_generation = mgr._lookup_state[_key(1)].generation
+        assert new_generation != old_generation
+
+        mgr._pending_results.put([(_key(1), old_generation, True)])
+        mgr.drain_results()
+        assert mgr._lookup_state[_key(1)].result is None
+
+        mgr._pending_results.put([(_key(1), new_generation, True)])
+        mgr.drain_results()
+        assert mgr._lookup_state[_key(1)].result is True
         mgr.shutdown()
 
     def test_multiple_flushes_across_steps(self):
@@ -193,11 +231,11 @@ class TestAsyncLookupManager:
         # (which direct-indexes _lookup_state per reverse-index key) tears down
         # both structures without raising.
         assert mgr._lookup_state[_key(1)].result is False
-        assert _key(1) in mgr._req_keys["reqA"]
-        mgr.cleanup("reqA")
+        assert _key(1) in mgr._req_keys[id(ctx)]
+        mgr.cleanup(ctx)
         assert _key(1) not in mgr._lookup_state
         assert _key(2) not in mgr._lookup_state
-        assert "reqA" not in mgr._req_keys
+        assert id(ctx) not in mgr._req_keys
         mgr.shutdown()
 
     def test_enqueue_once_invariant_enforced(self):
@@ -220,7 +258,8 @@ class TestAsyncLookupManager:
 
         # (b) A stray/duplicate result for the now-decided key violates the
         # enqueue-once invariant and must trip the assert.
-        mgr._pending_results.put([(_key(1), True)])
+        generation = mgr._lookup_state[_key(1)].generation
+        mgr._pending_results.put([(_key(1), generation, True)])
         with pytest.raises(AssertionError):
             mgr.drain_results()
         mgr.shutdown()

--- a/tests/v1/kv_offload/tiering/test_fs_tier.py
+++ b/tests/v1/kv_offload/tiering/test_fs_tier.py
@@ -55,6 +55,7 @@ _CTX = ReqContext(req_id="test")
 def _make_offloading_spec(
     enable_kv_cache_events: bool = False,
     *,
+    self_describing_kv_events: bool = False,
     tp_size: int = 1,
     rank: int = 0,
     world_size: int | None = None,
@@ -90,7 +91,7 @@ def _make_offloading_spec(
     spec.blocks_per_chunk = 1
     spec.kv_events_config = OffloadingKVEventsConfig(
         enable_kv_cache_events=enable_kv_cache_events,
-        self_describing_kv_events=False,
+        self_describing_kv_events=self_describing_kv_events,
     )
     return spec
 
@@ -195,7 +196,10 @@ def fs_tier_with_events(tmp_path):
     tensor = _page_aligned_zero_tensor(_NUM_BLOCKS, _BLOCK_ELEMENTS)
     mock_view = memoryview(tensor.numpy())
     tier = FileSystemTierManager(
-        offloading_spec=_make_offloading_spec(enable_kv_cache_events=True),
+        offloading_spec=_make_offloading_spec(
+            enable_kv_cache_events=True,
+            self_describing_kv_events=True,
+        ),
         primary_kv_view=mock_view,
         tier_type="fs",
         root_dir=str(tmp_path),
@@ -745,12 +749,16 @@ def test_successful_store_emits_stored_event(fs_tier_with_events):
     tier.submit_store(make_job(1, keys, [0, 1]))
     assert all(r.success for r in drain(tier))
 
-    events = list(tier.take_events())
-    assert len(events) == 1
-    assert events[0].keys == keys
-    assert events[0].medium == Medium.STORAGE
-    assert events[0].locality is Locality.LOCAL
-    assert not events[0].removed
+    event_iter = iter(tier.take_events())
+    event = next(event_iter)
+    assert tier.events == []
+    assert event.keys == keys
+    assert event.medium == Medium.STORAGE
+    assert event.locality is Locality.LOCAL
+    assert not event.removed
+    assert event.req_context is _CTX
+    assert tier._store_job_contexts == {}
+    event_iter.close()
     # take_events drains the buffer.
     assert list(tier.take_events()) == []
 
@@ -777,6 +785,7 @@ def test_store_event_uses_configured_locality(tmp_path, locality, expected):
         events = list(tier.take_events())
         assert len(events) == 1
         assert events[0].locality is expected
+        assert events[0].req_context is None
     finally:
         tier.shutdown()
 
@@ -848,6 +857,22 @@ def test_partially_failed_store_emits_no_event(fs_tier_with_events, monkeypatch)
     assert not results[0].success
     assert list(tier.take_events()) == []
     assert tier._store_job_keys == {}
+    assert tier._store_job_contexts == {}
+
+
+def test_submit_load_exception_clears_job_keys(fs_tier, monkeypatch):
+    tier, _ = fs_tier
+    monkeypatch.setattr(
+        tier._pool,
+        "enqueue_load",
+        MagicMock(side_effect=RuntimeError("submit failed")),
+    )
+
+    with pytest.raises(RuntimeError, match="submit failed"):
+        tier.submit_load(make_job(1, [key(1)], [0], is_promotion=True))
+
+    assert tier._load_job_keys == {}
+    assert tier._load_progress == {}
 
 
 def test_events_disabled_by_default(fs_tier):

--- a/tests/v1/kv_offload/tiering/test_obj_tier.py
+++ b/tests/v1/kv_offload/tiering/test_obj_tier.py
@@ -215,13 +215,17 @@ class MockNixlAgent:
 # ---------------------------------------------------------------------------
 
 
-def _make_events_spec(enable_kv_cache_events: bool) -> SimpleNamespace:
+def _make_events_spec(
+    enable_kv_cache_events: bool,
+    *,
+    self_describing_kv_events: bool = False,
+) -> SimpleNamespace:
     """Offloading spec stub with an explicit global KV events flag."""
     return SimpleNamespace(
         config=_make_offloading_config(enable_kv_cache_events),
         kv_events_config=OffloadingKVEventsConfig(
             enable_kv_cache_events=enable_kv_cache_events,
-            self_describing_kv_events=False,
+            self_describing_kv_events=self_describing_kv_events,
         ),
     )
 
@@ -457,6 +461,15 @@ class TestMockObjTierFailures:
         assert results[0].job_id == 2
         assert not results[0].success
 
+    def test_submit_load_exception_clears_job_keys(self):
+        tier, _ = _make_tier(num_blocks=4)
+        tier._submit_transfer = MagicMock(side_effect=RuntimeError("submit failed"))
+
+        with pytest.raises(RuntimeError, match="submit failed"):
+            tier.submit_load(make_job(2, [key(1)], [0]))
+
+        assert tier._load_job_keys == {}
+
     def test_submit_store_make_prepped_xfer_failure_reported_in_get_finished(self):
         tier, agent = _make_tier(num_blocks=4)
         agent.make_prepped_xfer = lambda *a, **k: None
@@ -607,7 +620,10 @@ class TestMockObjTierShutdown:
 class TestObjTierKVEvents:
     def setup_method(self):
         self.tier, self.agent = _make_tier(
-            offloading_spec=_make_events_spec(enable_kv_cache_events=True),
+            offloading_spec=_make_events_spec(
+                enable_kv_cache_events=True,
+                self_describing_kv_events=True,
+            ),
             enable_kv_events=True,
             locality="REMOTE",
         )
@@ -618,12 +634,16 @@ class TestObjTierKVEvents:
         self.tier.submit_store(make_job(1, keys, [0, 1]))
         assert all(r.success for r in drain(self.tier))
 
-        events = list(self.tier.take_events())
-        assert len(events) == 1
-        assert events[0].keys == keys
-        assert events[0].medium == Medium.STORAGE
-        assert events[0].locality is Locality.REMOTE
-        assert not events[0].removed
+        event_iter = iter(self.tier.take_events())
+        event = next(event_iter)
+        assert self.tier.events == []
+        assert event.keys == keys
+        assert event.medium == Medium.STORAGE
+        assert event.locality is Locality.REMOTE
+        assert not event.removed
+        assert event.req_context is _CTX
+        assert self.tier._store_job_contexts == {}
+        event_iter.close()
         # take_events drains the buffer.
         assert list(self.tier.take_events()) == []
 
@@ -645,6 +665,7 @@ class TestObjTierKVEvents:
             events = list(tier.take_events())
             assert len(events) == 1
             assert events[0].locality is expected
+            assert events[0].req_context is None
         finally:
             tier.shutdown()
 
@@ -686,6 +707,7 @@ class TestObjTierKVEvents:
         assert not results[0].success
         assert list(self.tier.take_events()) == []
         assert self.tier._store_job_keys == {}
+        assert self.tier._store_job_contexts == {}
 
     def test_submission_failure_emits_no_event(self):
         self.agent.make_prepped_xfer = lambda *a, **k: None
@@ -694,6 +716,7 @@ class TestObjTierKVEvents:
         assert not results[0].success
         assert list(self.tier.take_events()) == []
         assert self.tier._store_job_keys == {}
+        assert self.tier._store_job_contexts == {}
 
     def test_events_disabled_by_default(self):
         tier, _ = _make_tier()

--- a/tests/v1/kv_offload/tiering/test_tiering_offloading.py
+++ b/tests/v1/kv_offload/tiering/test_tiering_offloading.py
@@ -343,6 +343,43 @@ class TestTieringOffloadingManager:
             self.manager._process_finished_jobs()
         completed.assert_called_once_with(to_keys([1]), _CTX, True)
 
+    def test_promotion_stored_event_keeps_request_context(self):
+        mock_region = _mock_mmap_region(2)
+        primary = CPUPrimaryTierOffloadingManager(
+            num_blocks=2,
+            mmap_region=mock_region,
+            enable_events=True,
+            enable_event_provenance=True,
+        )
+        secondary = MetricsSecondaryTierManager(
+            offloading_spec=_MOCK_OFFLOADING_SPEC,
+            primary_kv_view=mock_region.create_kv_memoryview(),
+            tier_type="test_metrics",
+        )
+        secondary.lookup_result = LookupResult.HIT
+        manager = TieringOffloadingManager(
+            primary_tier=primary,
+            secondary_tiers=[secondary],
+        )
+        req_context = ReqContext(req_id="promotion")
+        [key] = to_keys([1])
+        manager.on_new_request(req_context)
+
+        assert manager.lookup(key, req_context) is LookupResult.HIT_PENDING
+        manager.on_schedule_end(
+            ScheduleEndContext(new_req_ids=(), preempted_req_ids=())
+        )
+        [job] = secondary.submitted_loads
+        secondary.finished_jobs = [JobResult(job_id=job.job_id, success=True)]
+
+        manager._process_finished_jobs()
+
+        [event] = manager.take_events()
+        assert event.keys == [key]
+        assert event.medium is Medium.CPU
+        assert not event.removed
+        assert event.req_context is req_context
+
     def test_take_events_aggregates_tier_owned_events(self, manager_setup):
         primary_event = OffloadingEvent(to_keys([1]), Medium.CPU, removed=False)
         secondary_event1 = OffloadingEvent(to_keys([2]), Medium.STORAGE, removed=False)
@@ -792,6 +829,31 @@ class TestTieringOffloadingManager:
         assert set(jm_b.keys) == {blocks[2], blocks[3]}
         assert jm_b.req_context is ctx_b
 
+    def test_promotion_submit_exception_unwinds_registered_job(self, manager_setup):
+        blocks = to_keys([42, 43])
+        contexts = [
+            ReqContext(req_id="promotion-submit-error-a"),
+            ReqContext(req_id="promotion-submit-error-b"),
+        ]
+        for block in blocks:
+            self.secondary_tier1.blocks[block] = True
+        self.secondary_tier1.submit_load = MagicMock(
+            side_effect=RuntimeError("submit failed")
+        )
+
+        for block, ctx in zip(blocks, contexts):
+            assert self.manager.lookup(block, ctx) is LookupResult.HIT_PENDING
+        with pytest.raises(RuntimeError, match="submit failed"):
+            self.manager.on_schedule_end(
+                ScheduleEndContext(new_req_ids=(), preempted_req_ids=())
+            )
+
+        assert self.manager._jobs == {}
+        assert self.manager._pending_load_submissions == {}
+        assert self.manager._metrics._tier_states[0].active_promotion_count == 0
+        for block, ctx in zip(blocks, contexts):
+            assert self.primary_tier.lookup(block, ctx) is LookupResult.MISS
+
     def test_lookup_shared_block_no_duplicate_promotion(self, manager_setup):
         """A block looked up by two requests in the same step is promoted once.
 
@@ -842,6 +904,24 @@ class TestTieringOffloadingManager:
         assert self.secondary_tier1.submit_store.call_count == 1
         job_metadata = self.secondary_tier1.submit_store.call_args.args[0]
         assert job_metadata.req_context is ctx
+
+    def test_cascade_submit_exception_unwinds_registered_job(self, manager_setup):
+        blocks = to_keys(range(2))
+        ctx = ReqContext(req_id="cascade-submit-error")
+        self._start_request(ctx)
+        result = self.manager.prepare_store(blocks, ctx)
+        assert result is not None
+        self.secondary_tier1.submit_store = MagicMock(
+            side_effect=RuntimeError("submit failed")
+        )
+
+        with pytest.raises(RuntimeError, match="submit failed"):
+            self.manager.complete_store(blocks, ctx, success=True)
+
+        assert self.manager._jobs == {}
+        assert self.manager._metrics._tier_states[0].active_cascade_count == 0
+        assert all(self.primary_tier._policy.get(key).ref_cnt == 0 for key in blocks)
+        assert self.manager._get_request_state(ctx).pending_primary_stores == 0
 
     def test_on_request_finished_delays_secondary_until_store_submitted(
         self, manager_setup
@@ -898,6 +978,39 @@ class TestTieringOffloadingManager:
             ("secondary_finish_1", ctx.req_id),
             ("secondary_finish_2", ctx.req_id),
         ]
+        assert not ctx._state
+
+    def test_complete_store_uses_exact_state_after_req_id_reuse(self, manager_setup):
+        blocks = to_keys(range(2))
+        old_ctx = ReqContext(req_id="reused")
+        new_ctx = ReqContext(req_id="reused")
+        self.manager.on_new_request(old_ctx)
+        result = self.manager.prepare_store(blocks, old_ctx)
+        assert result is not None
+
+        self.manager.on_new_request(new_ctx)
+        new_state = self.manager._req_state[new_ctx.req_id]
+        self.manager.complete_store(blocks, old_ctx, success=False)
+
+        assert new_state.pending_primary_stores == 0
+        assert self.manager._req_state[new_ctx.req_id] is new_state
+
+    def test_reset_finalizes_old_finished_state_after_req_id_reuse(self, manager_setup):
+        old_ctx = ReqContext(req_id="reused-reset")
+        new_ctx = ReqContext(req_id="reused-reset")
+        self.manager.on_new_request(old_ctx)
+        old_state = self.manager._req_state[old_ctx.req_id]
+        old_state.is_finished = True
+        old_state.pending_primary_stores = 1
+        self.manager.on_new_request(new_ctx)
+        new_state = self.manager._req_state[new_ctx.req_id]
+
+        self.manager.reset_cache()
+
+        assert id(old_ctx) not in self.manager._live_req_states
+        assert id(new_ctx) in self.manager._live_req_states
+        assert self.manager._req_state[new_ctx.req_id] is new_state
+        assert not old_ctx._state
 
     def test_failed_store_finalizes_finished_request(self, manager_setup):
         """Failed primary stores still unblock secondary finalization."""

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/events.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/events.py
@@ -4,19 +4,21 @@
 
 The OffloadingManager identifies an offloaded chunk only by its OffloadKey,
 so its raw events carry no token ids, parent hash, or block size.
-:class:`OffloadingEventsTracker` snapshots each chunk's full ``BlockStored``
-payload while the ``Request`` is alive and publishes stores as block-granular
-payloads: a chunk event may carry multiple constituent per-block hashes, and
-evictions fan out to the same hashes. Chunks overlapping a non-chunk-aligned
-shared prefix re-announce the shared hashes once per chunk; consumers are
-expected to deduplicate (reference-count) repeated store/remove announcements
-of the same hash. Opt-in via
-``kv_connector_extra_config["self_describing_kv_events"]``; inert unless
-KV cache events are enabled. See the PR description for the full design.
+:class:`OffloadingEventsTracker` keeps a request-scoped key locator on
+``ReqContext`` and builds the ``BlockStored`` payload only when a store event
+arrives. Store jobs keep that context through completion; only a minimal
+detached hash record survives for the legacy removal contract. A chunk event
+may carry multiple constituent per-block hashes, and evictions fan out to the
+same hashes. Chunks overlapping a non-chunk-aligned shared prefix re-announce
+the shared hashes once per chunk; consumers are expected to deduplicate
+(reference-count) repeated store/remove announcements of the same hash.
+Opt-in via ``kv_connector_extra_config["self_describing_kv_events"]``;
+inert unless KV cache events are enabled. See the PR description for the
+full design.
 """
 
 from collections.abc import Iterable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, NamedTuple
 
 from vllm.distributed.kv_events import (
@@ -29,6 +31,7 @@ from vllm.distributed.kv_events import (
 from vllm.logger import init_logger
 from vllm.v1.core.kv_cache_utils import (
     BlockHash,
+    generate_block_hash_extra_keys,
     maybe_convert_block_hash,
     resolve_block_hashes,
 )
@@ -42,8 +45,10 @@ from vllm.v1.kv_offload.base import (
     OffloadingEvent,
     OffloadingKVEventsConfig,
     OffloadKey,
+    ReqContext,
     get_offload_block_hash,
     get_offload_group_idx,
+    make_offload_key,
 )
 from vllm.v1.request import Request
 
@@ -75,11 +80,9 @@ def get_offloading_event_group_spec(
     )
 
 
-@dataclass(slots=True)
+@dataclass(frozen=True, slots=True)
 class _OffloadEventMetadata:
-    """BlockStored payload snapshot for one OffloadKey, captured while the
-    Request is available and kept until the matching eviction event. ``medium``
-    is forwarded from the OffloadingEvent."""
+    """Immutable ``BlockStored`` payload snapshot for one offload key."""
 
     # The chunk's constituent block hashes; the last one is the OffloadKey.
     block_hashes: tuple[BlockHash, ...]
@@ -88,21 +91,32 @@ class _OffloadEventMetadata:
     block_size: int
     lora_id: int | None
     lora_name: str | None
-    # Deferred: needs the same incremental curr_mm_idx handling as GPU events.
     extra_keys: tuple[tuple[Any, ...] | None, ...] | None
     group_idx: int
     kv_cache_spec: OffloadingEventGroupSpec
 
 
-class OffloadingEventsTracker:
-    """Tracks offloaded chunks' KV event payloads from store to eviction.
+@dataclass(slots=True)
+class _RequestEventContext:
+    """Lazy event locators owned by one request."""
 
-    The scheduler calls :meth:`record_store` from ``_build_store_jobs`` and
-    :meth:`record_lookup` for ready primary-tier hits while the ``Request`` is
-    available. Deferred and missing lookups add no state. Under the connector's
-    supported success-only transfer model, entries follow primary allocations
-    until CPU removal translation or :meth:`reset`.
-    """
+    request: Request
+    group_configs: dict[int, "GroupOffloadConfig"]
+    supports_partial_tail: bool
+    indexed_hash_count: int = 0
+    locators: dict[OffloadKey, int] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class _RemovalMetadata:
+    """Minimal detached record retained for the legacy removal contract."""
+
+    block_hashes: tuple[BlockHash, ...]
+    group_idx: int
+
+
+class OffloadingEventsTracker:
+    """Translates offload events using request-scoped key locators."""
 
     def __init__(self, config: OffloadingKVEventsConfig):
         self.config = config
@@ -110,89 +124,173 @@ class OffloadingEventsTracker:
             config.enable_kv_cache_events and config.self_describing_kv_events
         )
 
-        # OffloadKey -> payload snapshot, kept until CPU removal or reset.
-        self._pending_event_metadata: dict[OffloadKey, _OffloadEventMetadata] = {}
+        # PR 1 preserves the existing self-describing removal behavior. Keep
+        # only the hashes needed for that compatibility path, detached from
+        # the request-scoped stored-event payload.
+        self._removal_metadata: dict[tuple[Medium, OffloadKey], _RemovalMetadata] = {}
 
-    def record_store(
+    def on_new_request(
         self,
-        req: Request,
-        group_config: "GroupOffloadConfig",
-        chunk_idx: int,
-        offload_key: OffloadKey,
+        req_context: ReqContext,
+        request: Request,
+        group_configs: tuple["GroupOffloadConfig", ...],
+        supports_partial_tail: bool = False,
     ) -> None:
-        """Snapshot the KV cache event payload for one offloaded chunk.
-
-        No-op when self-describing event capture is disabled or for
-        sliding-window / SSM groups, which keep the legacy placeholder payload.
-        """
+        """Attach a lazy event context to one request."""
         if not self.self_describing_enabled:
             return
-        if group_config.sliding_window_size_in_chunks is not None:
-            return
-        meta = self._build_event_metadata(req, group_config, chunk_idx)
-        self._pending_event_metadata[offload_key] = meta
-
-    def record_lookup(
-        self,
-        req: Request,
-        group_config: "GroupOffloadConfig",
-        chunk_idx: int,
-        offload_key: OffloadKey,
-    ) -> None:
-        """Snapshot metadata for a ready primary-tier lookup hit."""
-        if not self.self_describing_enabled:
-            return
-        if group_config.sliding_window_size_in_chunks is not None:
-            return
-        if offload_key not in self._pending_event_metadata:
-            self._pending_event_metadata[offload_key] = self._build_event_metadata(
-                req, group_config, chunk_idx
+        req_context.set_state(
+            _RequestEventContext(
+                request=request,
+                group_configs={config.group_idx: config for config in group_configs},
+                supports_partial_tail=supports_partial_tail,
             )
+        )
 
-    def record_partial_store(
+    @staticmethod
+    def _request_event_context(
+        req_context: ReqContext | None,
+    ) -> _RequestEventContext | None:
+        if req_context is None:
+            return None
+        return req_context.get_state(_RequestEventContext)
+
+    @staticmethod
+    def _extend_locators(state: _RequestEventContext) -> None:
+        request = state.request
+        if len(request.block_hashes) < state.indexed_hash_count:
+            state.indexed_hash_count = 0
+            state.locators.clear()
+        for hash_idx in range(state.indexed_hash_count, len(request.block_hashes)):
+            block_hash = request.block_hashes[hash_idx]
+            for group_config in state.group_configs.values():
+                if group_config.sliding_window_size_in_chunks is not None:
+                    continue
+                hash_boundary = hash_idx + 1
+                if (
+                    hash_boundary % group_config.hashes_per_chunk != 0
+                    and not state.supports_partial_tail
+                ):
+                    continue
+                tokens_per_hash = group_config.tokens_per_chunk // (
+                    group_config.hashes_per_chunk
+                )
+                key = make_offload_key(block_hash, group_config.group_idx)
+                state.locators.setdefault(key, hash_boundary * tokens_per_hash)
+        state.indexed_hash_count = len(request.block_hashes)
+
+    def _locator_for(
         self,
-        req: Request,
-        group_config: "GroupOffloadConfig",
-        boundary_tokens: int,
+        state: _RequestEventContext,
         offload_key: OffloadKey,
-    ) -> None:
-        """Snapshot metadata for a newly stored partial recurrent tail."""
-        if group_config.sliding_window_size_in_chunks is not None:
+    ) -> tuple["GroupOffloadConfig", int] | None:
+        self._extend_locators(state)
+        boundary_tokens = state.locators.get(offload_key)
+        group_config = state.group_configs.get(get_offload_group_idx(offload_key))
+        if boundary_tokens is None or group_config is None:
+            return None
+        return group_config, boundary_tokens
+
+    def _metadata_for(
+        self,
+        state: _RequestEventContext,
+        offload_key: OffloadKey,
+    ) -> _OffloadEventMetadata | None:
+        if not self._request_is_event_safe(state.request):
+            return None
+        locator = self._locator_for(state, offload_key)
+        if locator is None:
+            return None
+        group_config, boundary_tokens = locator
+
+        if boundary_tokens % group_config.tokens_per_chunk == 0:
+            chunk_idx = boundary_tokens // group_config.tokens_per_chunk - 1
+            return self._build_event_metadata(state.request, group_config, chunk_idx)
+        return self._build_partial_event_metadata(
+            state.request, group_config, boundary_tokens
+        )
+
+    @staticmethod
+    def _request_is_event_safe(request: Request) -> bool:
+        # Resumable sessions can replace a sampled token after its block hash
+        # was appended. NIXL/Mooncake Mamba prefill can similarly truncate a
+        # request when combined with this connector. Until those paths roll
+        # back the hashes and offload keys, do not pair stale hashes with the
+        # mutated token list in a self-describing event.
+        if getattr(request, "resumable", False) is True:
+            return False
+        params = request.kv_transfer_params
+        return not (isinstance(params, dict) and params.get("_p_side_truncated"))
+
+    def record_hit(self, req_context: ReqContext, offload_key: OffloadKey) -> None:
+        """Backfill the detached removal record for a primary-tier hit."""
+        if not self.self_describing_enabled:
             return
-        self._record_partial_tail(req, group_config, boundary_tokens, offload_key)
-
-    def record_partial_lookup(
-        self,
-        req: Request,
-        group_config: "GroupOffloadConfig",
-        boundary_tokens: int,
-        offload_key: OffloadKey,
-    ) -> None:
-        """Backfill metadata for a partial recurrent tail lookup hit."""
-        if group_config.sliding_window_size_in_chunks is not None:
+        removal_key = (Medium.CPU, offload_key)
+        if removal_key in self._removal_metadata:
             return
-        if offload_key not in self._pending_event_metadata:
-            self._record_partial_tail(req, group_config, boundary_tokens, offload_key)
+        state = self._request_event_context(req_context)
+        if state is not None and not self._request_is_event_safe(state.request):
+            return
+        locator = self._locator_for(state, offload_key) if state is not None else None
+        if state is None or locator is None:
+            return
+        group_config, boundary_tokens = locator
+        block_hashes = self._block_hashes_for(
+            state.request,
+            group_config,
+            boundary_tokens,
+        )
+        self._removal_metadata[removal_key] = _RemovalMetadata(
+            block_hashes=block_hashes,
+            group_idx=group_config.group_idx,
+        )
 
-    def _record_partial_tail(
+    @staticmethod
+    def _block_hashes_for(
+        req: Request,
+        group_config: "GroupOffloadConfig",
+        boundary_tokens: int,
+    ) -> tuple[BlockHash, ...]:
+        tokens_per_hash = group_config.tokens_per_chunk // (
+            group_config.hashes_per_chunk
+        )
+        last_hash_idx = boundary_tokens // tokens_per_hash
+        if boundary_tokens % group_config.tokens_per_chunk == 0:
+            first_hash_idx = last_hash_idx - group_config.hashes_per_chunk
+            block_hashes = resolve_block_hashes(
+                req.block_hashes[first_hash_idx:last_hash_idx],
+                tokens_per_hash,
+                group_config.tokens_per_block,
+            )
+        else:
+            chunk_start = (
+                (boundary_tokens - 1) // group_config.tokens_per_chunk
+            ) * group_config.tokens_per_chunk
+            first_hash_idx = chunk_start // tokens_per_hash
+            block_hashes = req.block_hashes[first_hash_idx:last_hash_idx]
+        assert first_hash_idx >= 0
+        assert last_hash_idx <= len(req.block_hashes)
+        resolved_hashes = tuple(
+            block_hash for block_hash in block_hashes if block_hash is not None
+        )
+        assert resolved_hashes and len(resolved_hashes) == len(block_hashes)
+        return resolved_hashes
+
+    def _build_partial_event_metadata(
         self,
         req: Request,
         group_config: "GroupOffloadConfig",
         boundary_tokens: int,
-        offload_key: OffloadKey,
-    ) -> None:
+    ) -> _OffloadEventMetadata:
         """Build metadata for the valid prefix of one physical cache block.
 
         A partial recurrent tail ends on a hash boundary but before its
         physical cache block is full. The event describes only the valid
         hashes and tokens, not the unused remainder of that physical block.
         """
-        if not self.self_describing_enabled:
-            return
-
         tokens_per_hash = group_config.tokens_per_chunk // group_config.hashes_per_chunk
         # Subtract one so the boundary token itself cannot select the next
-        # physical block when the boundary lies exactly on a block edge.
         chunk_start = (
             (boundary_tokens - 1) // group_config.tokens_per_chunk
         ) * group_config.tokens_per_chunk
@@ -216,14 +314,20 @@ class OffloadingEventsTracker:
 
         lora_id = req.lora_request.adapter_id if req.lora_request is not None else None
         lora_name = req.lora_request.name if req.lora_request is not None else None
-        self._pending_event_metadata[offload_key] = _OffloadEventMetadata(
+        extra_keys = self._build_extra_keys(
+            req,
+            chunk_start,
+            boundary_tokens,
+            tokens_per_hash,
+        )
+        return _OffloadEventMetadata(
             block_hashes=block_hashes,
             parent_block_hash=parent_block_hash,
             token_ids=tuple(req.all_token_ids[chunk_start:boundary_tokens]),
             block_size=tokens_per_hash,
             lora_id=lora_id,
             lora_name=lora_name,
-            extra_keys=None,
+            extra_keys=extra_keys,
             group_idx=group_config.group_idx,
             kv_cache_spec=group_config.kv_event_group_spec,
         )
@@ -246,9 +350,30 @@ class OffloadingEventsTracker:
                 yield from self._take_stored_event(event)
 
     def reset(self) -> None:
-        """Drop all tracked state; pending payloads are stale after a
-        manager cache reset."""
-        self._pending_event_metadata.clear()
+        """Drop detached CPU removal records after a cache reset."""
+        self._removal_metadata.clear()
+
+    @staticmethod
+    def _build_extra_keys(
+        req: Request,
+        start_token_idx: int,
+        end_token_idx: int,
+        block_size: int,
+    ) -> tuple[tuple[Any, ...] | None, ...]:
+        """Match GPU event extra-key generation at event block granularity."""
+        assert start_token_idx % block_size == 0
+        assert end_token_idx % block_size == 0
+        curr_mm_idx = 0
+        extra_keys: list[tuple[Any, ...] | None] = []
+        for block_start in range(start_token_idx, end_token_idx, block_size):
+            block_extra_keys, curr_mm_idx = generate_block_hash_extra_keys(
+                req,
+                block_start,
+                block_start + block_size,
+                curr_mm_idx,
+            )
+            extra_keys.append(block_extra_keys)
+        return tuple(extra_keys)
 
     def _build_event_metadata(
         self,
@@ -263,7 +388,8 @@ class OffloadingEventsTracker:
         assert hashes_per_chunk > 0
         assert chunk_idx >= 0
         tokens_per_hash = group_config.tokens_per_chunk // hashes_per_chunk
-        # Each chunk's final raw hash is its OffloadKey.
+        # Each chunk's final raw hash is its OffloadKey. Resolve the raw hash
+        # chain to the owning KV group's block granularity, matching GPU events.
         first_hash_idx = chunk_idx * hashes_per_chunk
         last_hash_idx = first_hash_idx + hashes_per_chunk
         assert first_hash_idx >= 0
@@ -295,6 +421,12 @@ class OffloadingEventsTracker:
         tok_end = tok_start + group_config.tokens_per_chunk
         assert tok_end <= len(req.all_token_ids)
         token_ids = tuple(req.all_token_ids[tok_start:tok_end])
+        extra_keys = self._build_extra_keys(
+            req,
+            tok_start,
+            tok_end,
+            group_config.tokens_per_block,
+        )
 
         lora_id: int | None = None
         lora_name: str | None = None
@@ -309,7 +441,7 @@ class OffloadingEventsTracker:
             block_size=group_config.tokens_per_block,
             lora_id=lora_id,
             lora_name=lora_name,
-            extra_keys=None,
+            extra_keys=extra_keys,
             group_idx=group_config.group_idx,
             kv_cache_spec=group_config.kv_event_group_spec,
         )
@@ -335,24 +467,27 @@ class OffloadingEventsTracker:
         )
 
     def _take_stored_event(self, event: OffloadingEvent) -> Iterable[KVCacheEvent]:
-        # Metadata is read, NOT popped: the entry must survive until the
-        # eviction event so BlockRemoved can fan out to the same hashes.
-        # Events are self-contained (own parent), so key order is free.
         locality = event.locality.value if event.locality is not None else None
+        state = (
+            self._request_event_context(event.req_context)
+            if self.self_describing_enabled
+            else None
+        )
         for key in event.keys:
-            meta = self._pending_event_metadata.get(key)
+            meta = self._metadata_for(state, key) if state is not None else None
             if meta is None:
                 if self.self_describing_enabled:
-                    # Expected for unsupported shapes; warn once only.
                     logger.warning_once(
                         "OffloadingEventsTracker: no event metadata for "
                         "offload key during BlockStored emission; emitting a "
-                        "placeholder payload. Expected for non-full-attention "
-                        "groups and promotions not observed as a primary-tier "
-                        "hit before translation."
+                        "placeholder payload. Expected for external jobs and "
+                        "unsupported cache shapes."
                     )
                 yield self._placeholder_stored(key, event.medium, locality)
                 continue
+
+            if event.medium is Medium.CPU:
+                self._record_removal_metadata(event.medium, key, meta)
 
             yield BlockStored(
                 block_hashes=list(
@@ -384,7 +519,7 @@ class OffloadingEventsTracker:
         locality = event.locality.value if event.locality is not None else None
         by_group: dict[int, list] = {}
         for key in event.keys:
-            meta = self._pending_event_metadata.pop(key, None)
+            meta = self._removal_metadata.pop((event.medium, key), None)
             if meta is not None:
                 group_idx = meta.group_idx
                 by_group.setdefault(group_idx, []).extend(
@@ -411,3 +546,17 @@ class OffloadingEventsTracker:
                 group_idx=group_idx,
                 locality=locality,
             )
+
+    def _record_removal_metadata(
+        self,
+        medium: Medium,
+        key: OffloadKey,
+        metadata: _OffloadEventMetadata,
+    ) -> None:
+        self._removal_metadata.setdefault(
+            (medium, key),
+            _RemovalMetadata(
+                block_hashes=metadata.block_hashes,
+                group_idx=metadata.group_idx,
+            ),
+        )

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
@@ -69,6 +69,7 @@ class TransferJobStatus:
     """Tracks scheduler-side state for a single transfer job."""
 
     req_id: ReqId
+    req_status: "RequestOffloadState"
     # Number of workers still pending. Starts at num_workers,
     # decremented as each worker reports completion. Job is done at 0.
     pending_count: int
@@ -560,6 +561,7 @@ class OffloadingConnectorScheduler:
         self._block_id_to_pending_jobs: dict[int, set[int]] = {}
 
         self._events_tracker = OffloadingEventsTracker(spec.kv_events_config)
+        self._pending_events: list[KVCacheEvent] = []
 
     def _maybe_observe_lookup_async_delay(
         self, req_status: RequestOffloadState
@@ -612,12 +614,7 @@ class OffloadingConnectorScheduler:
             result = self.manager.lookup(key, req_context)
             match result:
                 case LookupResult.HIT:
-                    self._events_tracker.record_lookup(
-                        req,
-                        group_config,
-                        start_chunk_idx + local_idx,
-                        key,
-                    )
+                    self._events_tracker.record_hit(req_context, key)
                     hit_count += 1
                 case LookupResult.HIT_PENDING:
                     defer_lookup = True
@@ -908,12 +905,8 @@ class OffloadingConnectorScheduler:
 
             pending |= boundary_pending
             if not boundary_missed and not boundary_pending:
-                for group_config, key in zip(
-                    self.config.kv_group_configs, boundary_keys
-                ):
-                    self._events_tracker.record_partial_lookup(
-                        req_status.req, group_config, boundary, key
-                    )
+                for key in boundary_keys:
+                    self._events_tracker.record_hit(req_status.req_context, key)
                 req_status.partial_tail_boundary = boundary
                 return boundary - local_tokens
 
@@ -932,6 +925,12 @@ class OffloadingConnectorScheduler:
             offloading_context=offloading_context,
         )
         self._req_status[request.request_id] = req_status
+        self._events_tracker.on_new_request(
+            req_context,
+            request,
+            self.config.kv_group_configs,
+            self.config.supports_partial_tail,
+        )
 
     def get_num_new_matched_tokens(
         self, request: Request, num_computed_tokens: int
@@ -1091,6 +1090,7 @@ class OffloadingConnectorScheduler:
         req_status.transfer_jobs.add(load_job_id)
         self._jobs[load_job_id] = TransferJobStatus(
             req_id=request.request_id,
+            req_status=req_status,
             pending_count=self.config.num_workers,
             keys=set(keys_to_load),
             is_store=False,
@@ -1207,12 +1207,6 @@ class OffloadingConnectorScheduler:
             if not store_output.keys_to_store:
                 continue
 
-            for group_config, key in zip(self.config.kv_group_configs, keys):
-                if key in store_output.keys_to_store:
-                    self._events_tracker.record_partial_store(
-                        req, group_config, boundary, key
-                    )
-
             group_by_key = {key: idx for idx, key in enumerate(keys)}
             accepted_groups = [group_by_key[key] for key in store_output.keys_to_store]
             group_sizes = [0] * len(self.config.kv_group_configs)
@@ -1228,6 +1222,7 @@ class OffloadingConnectorScheduler:
                 self._block_id_to_pending_jobs.setdefault(block_id, set()).add(job_id)
             self._jobs[job_id] = TransferJobStatus(
                 req_id=req_id,
+                req_status=req_status,
                 pending_count=self.config.num_workers,
                 keys=set(store_output.keys_to_store),
                 is_store=True,
@@ -1366,11 +1361,6 @@ class OffloadingConnectorScheduler:
                         continue
 
                     chunk_idx = start_chunk_idx + idx
-
-                    self._events_tracker.record_store(
-                        req, group_config, chunk_idx, offload_key
-                    )
-
                     gpu_block_idx = chunk_idx * blocks_per_chunk
                     for i in range(blocks_per_chunk):
                         block_id = block_ids[gpu_block_idx + i]
@@ -1412,6 +1402,7 @@ class OffloadingConnectorScheduler:
             # when the request finishes
             self._jobs[job_id] = TransferJobStatus(
                 req_id=req_id,
+                req_status=req_status,
                 pending_count=self.config.num_workers,
                 keys=set(keys_to_store),
                 is_store=True,
@@ -1561,28 +1552,32 @@ class OffloadingConnectorScheduler:
                 continue
             assert job_status.pending_count == 0
 
-            req_status = self._req_status[job_status.req_id]
-            if job_status.is_store:
-                self.manager.complete_store(job_status.keys, req_status.req_context)
-            else:
-                self.manager.complete_load(job_status.keys, req_status.req_context)
-                if self._chunks_being_loaded:
+            req_status = job_status.req_status
+            try:
+                if job_status.is_store:
+                    self.manager.complete_store(job_status.keys, req_status.req_context)
+                else:
+                    self.manager.complete_load(job_status.keys, req_status.req_context)
+            finally:
+                if not job_status.is_store and self._chunks_being_loaded:
                     self._chunks_being_loaded.difference_update(job_status.keys)
-            if self._block_id_to_pending_jobs:
-                # Sliding window blocks are tracked from store creation
-                # and must be cleaned up unconditionally.
-                self._remove_pending_job(job_id, job_status.fenced_block_ids)
-                # Non-sliding-window blocks are only tracked after
-                # request_finished, so only clean up for finished requests.
-                if req_status.req.is_finished():
-                    self._remove_pending_job(
-                        job_id, job_status.deferred_fence_block_ids
-                    )
+                if self._block_id_to_pending_jobs:
+                    # Sliding window blocks are tracked from store creation
+                    # and must be cleaned up unconditionally.
+                    self._remove_pending_job(job_id, job_status.fenced_block_ids)
+                    # Non-sliding-window blocks are only tracked after
+                    # request_finished, so only clean up for finished requests.
+                    if req_status.req.is_finished():
+                        self._remove_pending_job(
+                            job_id, job_status.deferred_fence_block_ids
+                        )
 
-            del self._jobs[job_id]
-            req_status.transfer_jobs.remove(job_id)
-            if req_status.finished_signaled and not req_status.transfer_jobs:
-                del self._req_status[job_status.req_id]
+                del self._jobs[job_id]
+                req_status.transfer_jobs.remove(job_id)
+                if req_status.finished_signaled and not req_status.transfer_jobs:
+                    current_status = self._req_status.get(job_status.req_id)
+                    if current_status is req_status:
+                        del self._req_status[job_status.req_id]
 
     def get_stats(self) -> OffloadingConnectorStats | None:
         stats: OffloadingConnectorStats | None = None
@@ -1651,6 +1646,9 @@ class OffloadingConnectorScheduler:
             ``BlockStored`` or ``BlockRemoved`` events corresponding to
             the underlying :class:`OffloadingEvent` stream.
         """
+        pending_events = self._pending_events
+        self._pending_events = []
+        yield from pending_events
         yield from self._events_tracker.take_events(self.manager.take_events())
 
     def reset_cache(self) -> None:
@@ -1670,8 +1668,13 @@ class OffloadingConnectorScheduler:
                     self.manager.on_request_finished(status.req_context)
                 del self._req_status[req_id]
 
-        # Reset offloading manager cache
+        # Reset offloading manager cache. Raw removals already queued by an
+        # eviction remain valid and still need the detached expansion records.
         self.manager.reset_cache()
+        self._pending_events.extend(
+            self._events_tracker.take_events(self.manager.take_events())
+        )
+        self._events_tracker.reset()
 
         # Reset store progress so active requests re-offload from chunk 0.
         for status in self._req_status.values():
@@ -1685,10 +1688,6 @@ class OffloadingConnectorScheduler:
         self._jobs.clear()
         self._block_id_to_pending_jobs.clear()
 
-        # The manager pool is empty; pending event payloads and announced
-        # reference counts are stale.
-        self._events_tracker.reset()
-
         # Note: _current_batch_jobs_to_flush is intentionally NOT cleared.
         # The load flush IDs collected above must be delivered to workers.
         if self._chunks_being_loaded is not None:
@@ -1696,3 +1695,8 @@ class OffloadingConnectorScheduler:
 
     def shutdown(self) -> None:
         self.manager.shutdown()
+        self._events_tracker.reset()
+        self._pending_events.clear()
+        self._jobs.clear()
+        self._req_status.clear()
+        self._block_id_to_pending_jobs.clear()

--- a/vllm/v1/kv_offload/base.py
+++ b/vllm/v1/kv_offload/base.py
@@ -103,6 +103,9 @@ class ReqContext:
     def get_state(self, cls: type[_T]) -> _T | None:
         return self._state.get(cls)
 
+    def pop_state(self, cls: type[_T]) -> _T | None:
+        return self._state.pop(cls, None)
+
 
 class LookupResult(Enum):
     """Result of OffloadingManager.lookup()."""
@@ -157,6 +160,9 @@ class OffloadingEvent:
     # True if blocks are removed, False if stored
     removed: bool
     locality: Locality | None = None
+    # The request that produced a stored event, when known locally. Removal
+    # events are storage-owned and do not carry request context.
+    req_context: ReqContext | None = field(default=None, repr=False, compare=False)
 
 
 """

--- a/vllm/v1/kv_offload/cpu/manager.py
+++ b/vllm/v1/kv_offload/cpu/manager.py
@@ -45,6 +45,7 @@ class CPUOffloadingManager(OffloadingManager):
         cache_policy: str = "lru",
         cache_policy_module_path: str | None = None,
         enable_events: bool = False,
+        enable_event_provenance: bool = False,
         store_threshold: int = 1,
         max_tracker_size: int = 64_000,
     ):
@@ -53,6 +54,7 @@ class CPUOffloadingManager(OffloadingManager):
         self._num_allocated_blocks: int = 0
         self._free_list: list[int] = []
         self.events: list[OffloadingEvent] | None = [] if enable_events else None
+        self._enable_event_provenance = enable_event_provenance
         policy_cls = CachePolicyFactory.get_cache_policy_cls(
             cache_policy, cache_policy_module_path
         )
@@ -267,6 +269,9 @@ class CPUOffloadingManager(OffloadingManager):
                     keys=stored_keys,
                     medium=self.medium,
                     removed=False,
+                    req_context=(
+                        req_context if self._enable_event_provenance else None
+                    ),
                 )
             )
 
@@ -283,11 +288,21 @@ class CPUOffloadingManager(OffloadingManager):
 
         self._free_list.clear()
         self._num_allocated_blocks = 0
+        if self.events is not None:
+            # Stores queued before the reset no longer describe residency.
+            # Keep removals so consumers can invalidate prior announcements.
+            self.events = [event for event in self.events if event.removed]
 
     @override
     def take_events(self) -> Iterable[OffloadingEvent]:
         if self.events is not None:
-            yield from self.events
+            events = self.events
+            self.events = []
+            yield from events
+
+    @override
+    def shutdown(self) -> None:
+        if self.events is not None:
             self.events.clear()
 
     def get_stats(self) -> OffloadingConnectorStats | None:

--- a/vllm/v1/kv_offload/cpu/spec.py
+++ b/vllm/v1/kv_offload/cpu/spec.py
@@ -136,6 +136,9 @@ class CPUOffloadingSpec(OffloadingSpec):
                 cache_policy=self.eviction_policy,
                 cache_policy_module_path=self.cache_policy_module_path,
                 enable_events=self.kv_events_config.enable_kv_cache_events,
+                enable_event_provenance=(
+                    self.kv_events_config.self_describing_kv_events
+                ),
                 store_threshold=store_threshold,
                 max_tracker_size=max_tracker_size,
             )

--- a/vllm/v1/kv_offload/tiering/async_lookup.py
+++ b/vllm/v1/kv_offload/tiering/async_lookup.py
@@ -45,8 +45,9 @@ logger = init_logger(__name__)
 
 @dataclass(slots=True)
 class LookupState:
+    generation: int
     result: bool | None = None  # True (found), False (not found), None
-    request_ids: set[str] = field(default_factory=set)  # requests asking for the lookup
+    request_context_ids: set[int] = field(default_factory=set)
 
 
 class AsyncLookupManager(ABC):
@@ -76,23 +77,25 @@ class AsyncLookupManager(ABC):
 
         # key → LookupState; scheduler-owned, no lock needed.
         self._lookup_state: dict[OffloadKey, LookupState] = {}
-        # req_id → keys looked up by that request (reverse index for cleanup).
-        self._req_keys: dict[str, set[OffloadKey]] = {}
+        # ReqContext identity → keys looked up by that request incarnation.
+        self._req_keys: dict[int, set[OffloadKey]] = {}
 
-        # Accumulates (key, req_context) pairs during lookup() calls.
+        self._next_generation = 0
+
+        # Accumulates (key, req_context, generation) tuples during lookup().
         # Flushed as one queue item per step by flush().
-        self._lookup_batch: list[tuple[OffloadKey, ReqContext]] = []
+        self._lookup_batch: list[tuple[OffloadKey, ReqContext, int]] = []
 
         # Scheduler → worker: one full step's batch per item.
         # None is used as a shutdown sentinel.
         self._lookup_queue: queue.SimpleQueue[
-            list[tuple[OffloadKey, ReqContext]] | None
+            list[tuple[OffloadKey, ReqContext, int]] | None
         ] = queue.SimpleQueue()
 
         # Worker → scheduler: completed result batches.
         # Each item is a list of (key, found) pairs.
         # SimpleQueue is explicitly thread-safe for one writer / one reader.
-        self._pending_results: queue.SimpleQueue[list[tuple[OffloadKey, bool]]] = (
+        self._pending_results: queue.SimpleQueue[list[tuple[OffloadKey, int, bool]]] = (
             queue.SimpleQueue()
         )
         self._need_to_drain: bool = False
@@ -134,14 +137,16 @@ class AsyncLookupManager(ABC):
         if self._need_to_drain:
             self.drain_results()
             self._need_to_drain = False
-        req_id = req_context.req_id
+        context_id = id(req_context)
         state = self._lookup_state.get(key)
         if state is None:
-            state = LookupState()
+            generation = self._next_generation
+            self._next_generation += 1
+            state = LookupState(generation=generation)
             self._lookup_state[key] = state
-            self._lookup_batch.append((key, req_context))
-        state.request_ids.add(req_id)
-        self._req_keys.setdefault(req_id, set()).add(key)
+            self._lookup_batch.append((key, req_context, generation))
+        state.request_context_ids.add(context_id)
+        self._req_keys.setdefault(context_id, set()).add(key)
         return state.result
 
     def flush(self) -> None:
@@ -167,9 +172,9 @@ class AsyncLookupManager(ABC):
                 batch = self._pending_results.get_nowait()
             except queue.Empty:
                 break
-            for key, result in batch:
+            for key, generation, result in batch:
                 state = self._lookup_state.get(key)
-                if state is not None:
+                if state is not None and state.generation == generation:
                     # A key is enqueued for probing exactly once, so a decided
                     # verdict must never receive a second result. Enforcing it
                     # keeps a late/duplicate result from resurrecting a stale
@@ -190,16 +195,17 @@ class AsyncLookupManager(ABC):
             if state is not None:
                 state.result = False
 
-    def cleanup(self, req_id: str) -> None:
+    def cleanup(self, req_context: ReqContext) -> None:
         """Remove entries no longer needed by any active request.
 
         Called from the tier's on_request_finished(). Uses the reverse
         index to visit only keys associated with this request.
         """
-        for key in self._req_keys.pop(req_id, ()):
+        context_id = id(req_context)
+        for key in self._req_keys.pop(context_id, ()):
             state = self._lookup_state[key]
-            state.request_ids.discard(req_id)
-            if not state.request_ids:
+            state.request_context_ids.discard(context_id)
+            if not state.request_context_ids:
                 del self._lookup_state[key]
 
     def shutdown(self) -> None:
@@ -217,19 +223,20 @@ class AsyncLookupManager(ABC):
             if pending is None:
                 break
 
-            # Group by req_id.
-            batches: dict[str, tuple[ReqContext, list[OffloadKey]]] = {}
-            for key, req_context in pending:
-                req_id = req_context.req_id
-                if req_id not in batches:
-                    batches[req_id] = (req_context, [])
-                batches[req_id][1].append(key)
+            # Group by request incarnation, not the reusable request ID.
+            batches: dict[int, tuple[ReqContext, list[OffloadKey], list[int]]] = {}
+            for key, req_context, generation in pending:
+                context_id = id(req_context)
+                if context_id not in batches:
+                    batches[context_id] = (req_context, [], [])
+                batches[context_id][1].append(key)
+                batches[context_id][2].append(generation)
 
             if not batches:
                 continue
 
-            results: list[tuple[OffloadKey, bool]] = []
-            for req_context, keys in batches.values():
+            results: list[tuple[OffloadKey, int, bool]] = []
+            for req_context, keys, generations in batches.values():
                 try:
                     hits = self.batch_lookup(keys, req_context)
                 except Exception as exc:
@@ -241,8 +248,8 @@ class AsyncLookupManager(ABC):
                     )
                     hits = (False for _ in keys)
 
-                for key, hit in zip(keys, hits):
-                    results.append((key, hit))
+                for key, generation, hit in zip(keys, generations, hits):
+                    results.append((key, generation, hit))
 
             # Post the entire batch as one item — no lock needed.
             if results:

--- a/vllm/v1/kv_offload/tiering/fs/manager.py
+++ b/vllm/v1/kv_offload/tiering/fs/manager.py
@@ -146,8 +146,13 @@ class FileSystemTierManager(SecondaryTierManager):
                     "emit events.",
                     tier_type,
                 )
+        self._enable_event_provenance = bool(
+            self.events is not None
+            and offloading_spec.kv_events_config.self_describing_kv_events
+        )
         # Keys of in-flight store jobs, tracked only when events are enabled.
         self._store_job_keys: dict[JobId, list[OffloadKey]] = {}
+        self._store_job_contexts: dict[JobId, ReqContext] = {}
         # Keys of in-flight load (promotion) jobs, so a failed load can mark
         # its own cached lookup verdicts False (see get_finished_jobs).
         self._load_job_keys: dict[JobId, list[OffloadKey]] = {}
@@ -218,6 +223,8 @@ class FileSystemTierManager(SecondaryTierManager):
         keys = list(job_metadata.keys)
         if self.events is not None:
             self._store_job_keys[job_metadata.job_id] = keys
+            if self._enable_event_provenance:
+                self._store_job_contexts[job_metadata.job_id] = job_metadata.req_context
         task = functools.partial(
             batch_store_block,
             [self.file_mapper.get_file_name(key) for key in keys],
@@ -226,7 +233,12 @@ class FileSystemTierManager(SecondaryTierManager):
             self._block_size,
             self._use_o_direct,
         )
-        self._pool.enqueue_store(job_metadata.job_id, 1, [task])
+        try:
+            self._pool.enqueue_store(job_metadata.job_id, 1, [task])
+        except Exception:
+            self._store_job_keys.pop(job_metadata.job_id, None)
+            self._store_job_contexts.pop(job_metadata.job_id, None)
+            raise
 
     @override
     def submit_load(self, job_metadata: TransferJob) -> None:
@@ -265,7 +277,12 @@ class FileSystemTierManager(SecondaryTierManager):
                 )
                 raise
 
-        self._pool.enqueue_load(job_id, 1, [load_task])
+        try:
+            self._pool.enqueue_load(job_id, 1, [load_task])
+        except Exception:
+            self._load_job_keys.pop(job_id, None)
+            self._load_progress.pop(job_id, None)
+            raise
 
     @override
     def get_finished_jobs(self) -> Iterable[JobResult]:
@@ -275,6 +292,7 @@ class FileSystemTierManager(SecondaryTierManager):
         for job_id, success, transfer_time in self._pool.get_finished():
             if self.events is not None:
                 keys = self._store_job_keys.pop(job_id, None)
+                req_context = self._store_job_contexts.pop(job_id, None)
                 if success and keys:
                     self.events.append(
                         OffloadingEvent(
@@ -282,6 +300,7 @@ class FileSystemTierManager(SecondaryTierManager):
                             medium=self.medium,
                             removed=False,
                             locality=self.locality,
+                            req_context=req_context,
                         )
                     )
             load_keys = self._load_job_keys.pop(job_id, None)
@@ -315,8 +334,9 @@ class FileSystemTierManager(SecondaryTierManager):
     @override
     def take_events(self) -> Iterable[OffloadingEvent]:
         if self.events is not None:
-            yield from self.events
-            self.events.clear()
+            events = self.events
+            self.events = []
+            yield from events
 
     @override
     def drain_jobs(self) -> None:
@@ -324,7 +344,7 @@ class FileSystemTierManager(SecondaryTierManager):
         self._pool.wait_idle()
 
     def on_request_finished(self, req_context: ReqContext) -> None:
-        self._lookup_manager.cleanup(req_context.req_id)
+        self._lookup_manager.cleanup(req_context)
 
     @override
     def on_schedule_end(self, context: ScheduleEndContext) -> None:
@@ -340,3 +360,7 @@ class FileSystemTierManager(SecondaryTierManager):
         """
         self._lookup_manager.shutdown()
         self._pool.shutdown(wait=True)
+        self._store_job_keys.clear()
+        self._store_job_contexts.clear()
+        if self.events is not None:
+            self.events.clear()

--- a/vllm/v1/kv_offload/tiering/manager.py
+++ b/vllm/v1/kv_offload/tiering/manager.py
@@ -76,6 +76,11 @@ class RequestState:
     request_level_tiers: set[int] | None = None
 
 
+@dataclass(slots=True)
+class _RequestStateRef:
+    state: RequestState
+
+
 class JobMetadata(NamedTuple):
     transfer_job: TransferJob
     tier_idx: int
@@ -98,12 +103,14 @@ class CPUPrimaryTierOffloadingManager(CPUOffloadingManager):
         cache_policy: str = "lru",
         cache_policy_module_path: str | None = None,
         enable_events: bool = False,
+        enable_event_provenance: bool = False,
     ):
         super().__init__(
             num_blocks=num_blocks,
             cache_policy=cache_policy,
             cache_policy_module_path=cache_policy_module_path,
             enable_events=enable_events,
+            enable_event_provenance=enable_event_provenance,
         )
         self._mmap_region = mmap_region
         # read/write is for CPU<->secondary transfers,
@@ -211,9 +218,8 @@ class TieringOffloadingManager(OffloadingManager):
 
         # Pending promotion requests accumulated during lookup() calls; flushed
         # as one batched submit_load() per (tier, request) in on_schedule_end().
-        # Outer key: tier index. Inner key: req_context.req_id — the same ReqContext
-        # object is reused for all block lookups of a given request per engine step.
-        self._pending_load_submissions: dict[int, dict[str, PendingPromotion]] = {}
+        # Outer key: tier index. Inner key: ReqContext identity.
+        self._pending_load_submissions: dict[int, dict[int, PendingPromotion]] = {}
 
         # Gate for once-per-step execution of _maybe_process_finished_jobs().
         # Reset at the end of each step in on_schedule_end().
@@ -223,6 +229,7 @@ class TieringOffloadingManager(OffloadingManager):
         # Secondary tiers are finalized only after pending primary stores reach
         # complete_store(), since complete_store() can still submit cascades.
         self._req_state: dict[str, RequestState] = {}
+        self._live_req_states: dict[int, RequestState] = {}
 
         # Cached ParentManager wrappers for each secondary tier.
         self._tier_parents: dict[SecondaryTierManager, _SecondaryTierFacingParent] = {
@@ -247,6 +254,14 @@ class TieringOffloadingManager(OffloadingManager):
 
     def _pop_job(self, job_id: JobId) -> JobMetadata | None:
         return self._jobs.pop(job_id, None)
+
+    def _cancel_registered_job(self, job_id: JobId) -> JobMetadata:
+        job_metadata = self._jobs.pop(job_id)
+        self._metrics.on_job_finished(
+            job_metadata,
+            JobResult(job_id=job_id, success=False),
+        )
+        return job_metadata
 
     def _maybe_process_finished_jobs(self):
         """
@@ -456,7 +471,7 @@ class TieringOffloadingManager(OffloadingManager):
         # Defer submit_load to on_schedule_end(). Group by (tier, request) so
         # each request's blocks are submitted as one batched job per tier.
         tier_pending = self._pending_load_submissions.setdefault(tier_idx, {})
-        ctx_id = req_context.req_id
+        ctx_id = id(req_context)
         if ctx_id not in tier_pending:
             tier_pending[ctx_id] = PendingPromotion(
                 keys=[], block_ids=[], req_context=req_context
@@ -475,9 +490,17 @@ class TieringOffloadingManager(OffloadingManager):
         if not self._pending_load_submissions:
             return
 
-        for tier_idx, pending_by_ctx in self._pending_load_submissions.items():
+        pending_submissions = self._pending_load_submissions
+        self._pending_load_submissions = {}
+        entries = [
+            (tier_idx, entry)
+            for tier_idx, pending_by_ctx in pending_submissions.items()
+            for entry in pending_by_ctx.values()
+        ]
+        for entry_idx, (tier_idx, entry) in enumerate(entries):
             tier = self.secondary_tiers[tier_idx]
-            for entry in pending_by_ctx.values():
+            job_id: JobId | None = None
+            try:
                 job_id = self._next_job_id()
                 job_metadata = TransferJob(
                     job_id=job_id,
@@ -488,8 +511,17 @@ class TieringOffloadingManager(OffloadingManager):
                 )
                 self._register_job(job_metadata, tier_idx)
                 tier.submit_load(job_metadata)
-
-        self._pending_load_submissions.clear()
+            except Exception:
+                if job_id is not None and job_id in self._jobs:
+                    self._cancel_registered_job(job_id)
+                self.primary_tier.complete_write(entry.keys, entry.req_context, False)
+                for _, remaining in entries[entry_idx + 1 :]:
+                    self.primary_tier.complete_write(
+                        remaining.keys,
+                        remaining.req_context,
+                        False,
+                    )
+                raise
 
     @override
     def prepare_load(
@@ -584,20 +616,32 @@ class TieringOffloadingManager(OffloadingManager):
             return None
 
         if primary_result.keys_to_store:
-            state = self._req_state[req_context.req_id]
+            state = self._get_request_state(req_context)
             state.pending_primary_stores += 1
 
         # Step 3: For request-level tiers, cascade blocks already in primary
-        request_level_tiers = self._req_state[req_context.req_id].request_level_tiers
+        request_level_tiers = self._get_request_state(req_context).request_level_tiers
         if request_level_tiers:
             keys_to_store_set = set(primary_result.keys_to_store)
             keys_already_in_primary = tuple(
                 k for k in keys if k not in keys_to_store_set
             )
             if keys_already_in_primary:
-                self._cascade_existing_blocks_to_request_level_tiers(
-                    keys_already_in_primary, req_context, request_level_tiers
-                )
+                try:
+                    self._cascade_existing_blocks_to_request_level_tiers(
+                        keys_already_in_primary, req_context, request_level_tiers
+                    )
+                except Exception:
+                    if primary_result.keys_to_store:
+                        self.primary_tier.complete_store(
+                            primary_result.keys_to_store,
+                            req_context,
+                            False,
+                        )
+                        state = self._get_request_state(req_context)
+                        state.pending_primary_stores -= 1
+                        self._maybe_finalize_request(state)
+                    raise
 
         return primary_result
 
@@ -623,7 +667,12 @@ class TieringOffloadingManager(OffloadingManager):
         for tier_idx in request_level_tiers:
             job_metadata = self.create_store_job(ready_keys, req_context, tier_idx)
             tier = self.secondary_tiers[tier_idx]
-            tier.submit_store(job_metadata)
+            try:
+                tier.submit_store(job_metadata)
+            except Exception:
+                self._cancel_registered_job(job_metadata.job_id)
+                self.primary_tier.complete_read(ready_keys, req_context)
+                raise
 
     @override
     def complete_store(
@@ -653,23 +702,31 @@ class TieringOffloadingManager(OffloadingManager):
         # Step 1: Complete store in primary tier (makes blocks loadable)
         self.primary_tier.complete_store(keys, req_context, success)
 
-        if success:
-            # Step 2: Cascade to ALL secondary tiers
-            # For each secondary tier, call primary.prepare_read() to get the
-            # LoadStoreSpec AND to increment ref_cnt (protecting blocks from
-            # eviction during the async transfer). One prepare_read() call per
-            # secondary tier.
-            for tier_idx, tier in enumerate(self.secondary_tiers):
-                job_metadata = self.create_store_job(keys, req_context, tier_idx)
-                tier.submit_store(job_metadata)
+        state = self._get_request_state(req_context)
+        try:
+            if success:
+                # Step 2: Cascade to ALL secondary tiers
+                # For each secondary tier, call primary.prepare_read() to get the
+                # LoadStoreSpec AND to increment ref_cnt (protecting blocks from
+                # eviction during the async transfer). One prepare_read() call per
+                # secondary tier.
+                for tier_idx, tier in enumerate(self.secondary_tiers):
+                    job_metadata = self.create_store_job(keys, req_context, tier_idx)
+                    try:
+                        tier.submit_store(job_metadata)
+                    except Exception:
+                        self._cancel_registered_job(job_metadata.job_id)
+                        self.primary_tier.complete_read(keys, req_context)
+                        raise
+        finally:
+            # The GPU->primary completion has been consumed even if a secondary
+            # submission fails synchronously.
+            assert state.pending_primary_stores > 0
+            state.pending_primary_stores -= 1
+            self._maybe_finalize_request(state)
 
         # Note: The async transfers are now in flight. Their completion is
         # tracked via get_finished_jobs() / _maybe_process_finished_jobs().
-        req_id = req_context.req_id
-        state = self._req_state[req_id]
-        assert state.pending_primary_stores > 0
-        state.pending_primary_stores -= 1
-        self._maybe_finalize_request(req_id)
 
     def create_store_job(
         self,
@@ -713,6 +770,8 @@ class TieringOffloadingManager(OffloadingManager):
         Only stores REQUEST_LEVEL tier decisions for use in prepare_store.
         """
         state = RequestState(req_context=req_context)
+        req_context.set_state(_RequestStateRef(state))
+        self._live_req_states[id(req_context)] = state
         self._metrics.on_new_request(req_context)
         for tier_idx, tier in enumerate(self.secondary_tiers):
             if tier_idx == exclude_tier_idx:
@@ -731,6 +790,11 @@ class TieringOffloadingManager(OffloadingManager):
         )
         return RequestOffloadingContext(policy=policy)
 
+    def _get_request_state(self, req_context: ReqContext) -> RequestState:
+        state_ref = req_context.get_state(_RequestStateRef)
+        assert state_ref is not None
+        return state_ref.state
+
     @override
     def on_request_finished(
         self,
@@ -739,13 +803,13 @@ class TieringOffloadingManager(OffloadingManager):
         exclude_tier_idx: int | None = None,
     ) -> None:
         self.primary_tier.on_request_finished(req_context)
-        state = self._req_state[req_context.req_id]
+        state = self._get_request_state(req_context)
         state.is_finished = True
-        self._maybe_finalize_request(req_context.req_id, exclude_tier_idx)
+        self._maybe_finalize_request(state, exclude_tier_idx)
 
     def _maybe_finalize_request(
         self,
-        req_id: str,
+        state: RequestState,
         exclude_tier_idx: int | None = None,
     ) -> None:
         """Finalize secondary tiers once no more store cascades can be submitted.
@@ -754,7 +818,6 @@ class TieringOffloadingManager(OffloadingManager):
         It is delayed until pending GPU->primary stores finish, since their
         complete_store() callbacks may still submit primary->secondary stores.
         """
-        state = self._req_state[req_id]
         if not state.is_finished:
             return
         if state.pending_primary_stores != 0:
@@ -765,7 +828,11 @@ class TieringOffloadingManager(OffloadingManager):
                 continue
             tier.on_request_finished(state.req_context)
         self._metrics.on_request_finished(state.req_context)
-        del self._req_state[req_id]
+        current_state = self._req_state.get(state.req_context.req_id)
+        if current_state is state:
+            del self._req_state[state.req_context.req_id]
+        self._live_req_states.pop(id(state.req_context), None)
+        state.req_context.pop_state(_RequestStateRef)
 
     @override
     def on_schedule_end(self, context: ScheduleEndContext) -> None:
@@ -845,20 +912,24 @@ class TieringOffloadingManager(OffloadingManager):
         self._pending_load_submissions.clear()
         self._metrics.assert_idle()
 
-        finished_req_ids = []
-        for req_id, state in self._req_state.items():
+        finished_states = []
+        for state in self._live_req_states.values():
             state.pending_primary_stores = 0
             if not state.is_finished:
                 continue
             for tier in self.secondary_tiers:
                 tier.on_request_finished(state.req_context)
             self._metrics.on_request_finished(state.req_context)
-            finished_req_ids.append(req_id)
+            finished_states.append(state)
 
         self.primary_tier.reset_cache()
 
-        for req_id in finished_req_ids:
-            del self._req_state[req_id]
+        for state in finished_states:
+            current_state = self._req_state.get(state.req_context.req_id)
+            if current_state is state:
+                del self._req_state[state.req_context.req_id]
+            self._live_req_states.pop(id(state.req_context), None)
+            state.req_context.pop_state(_RequestStateRef)
         self._processed_jobs_this_step = False
 
     @override
@@ -892,3 +963,9 @@ class TieringOffloadingManager(OffloadingManager):
         for tier in self.secondary_tiers:
             tier.shutdown()
         self.primary_tier.shutdown()
+        for state in self._live_req_states.values():
+            state.req_context.pop_state(_RequestStateRef)
+        self._jobs.clear()
+        self._pending_load_submissions.clear()
+        self._req_state.clear()
+        self._live_req_states.clear()

--- a/vllm/v1/kv_offload/tiering/metrics.py
+++ b/vllm/v1/kv_offload/tiering/metrics.py
@@ -53,7 +53,7 @@ class TieringMetricsTracker:
         self._tier_types = tier_types
         self._num_primary_blocks = num_primary_blocks
         self._primary_block_size = primary_block_size
-        self._request_states: dict[str, _RequestMetricsState] = {}
+        self._request_states: dict[int, _RequestMetricsState] = {}
         self._tier_states = [_TierState() for _ in tier_types]
         self._stats = OffloadingConnectorStats()
 
@@ -66,16 +66,16 @@ class TieringMetricsTracker:
         return PRIMARY_TIER_LABEL
 
     def on_new_request(self, req_context: ReqContext) -> None:
-        self._request_states[req_context.req_id] = _RequestMetricsState()
+        self._request_states[id(req_context)] = _RequestMetricsState()
 
     def on_request_allocated(self, req_context: ReqContext) -> None:
-        state = self._request_states.get(req_context.req_id)
+        state = self._request_states.get(id(req_context))
         if state is None:
             return
         state.observed_lookups = None
 
     def on_request_finished(self, req_context: ReqContext) -> None:
-        self._request_states.pop(req_context.req_id, None)
+        self._request_states.pop(id(req_context), None)
 
     def on_lookup(
         self,
@@ -85,10 +85,11 @@ class TieringMetricsTracker:
         result: LookupResult,
         lookup_duration: float,
     ) -> None:
-        state = self._request_states.get(req_context.req_id)
+        context_id = id(req_context)
+        state = self._request_states.get(context_id)
         if state is None:
             state = _RequestMetricsState()
-            self._request_states[req_context.req_id] = state
+            self._request_states[context_id] = state
 
         if state.observed_lookups is not None and result in (
             LookupResult.HIT,

--- a/vllm/v1/kv_offload/tiering/obj/manager.py
+++ b/vllm/v1/kv_offload/tiering/obj/manager.py
@@ -139,8 +139,13 @@ class ObjectStoreSecondaryTierManager(SecondaryTierManager):
                     "emit events.",
                     tier_type,
                 )
+        self._enable_event_provenance = bool(
+            self.events is not None
+            and offloading_spec.kv_events_config.self_describing_kv_events
+        )
         # Keys of in-flight store jobs, tracked only when events are enabled.
         self._store_job_keys: dict[JobId, list[OffloadKey]] = {}
+        self._store_job_contexts: dict[JobId, ReqContext] = {}
         # Keys of in-flight load (promotion) jobs, so a failed download can
         # mark its own cached lookup verdicts False (see get_finished_jobs).
         self._load_job_keys: dict[JobId, list[OffloadKey]] = {}
@@ -282,20 +287,30 @@ class ObjectStoreSecondaryTierManager(SecondaryTierManager):
     def submit_store(self, job_metadata: TransferJob) -> None:
         if self.events is not None:
             self._store_job_keys[job_metadata.job_id] = list(job_metadata.keys)
+            if self._enable_event_provenance:
+                self._store_job_contexts[job_metadata.job_id] = job_metadata.req_context
         obj_keys = (self._file_mapper.get_file_name(k) for k in job_metadata.keys)
-        self._submit_transfer(
-            job_metadata.job_id, job_metadata.block_ids, obj_keys, NIXL_WRITE
-        )
+        try:
+            self._submit_transfer(
+                job_metadata.job_id, job_metadata.block_ids, obj_keys, NIXL_WRITE
+            )
+        except Exception:
+            self._store_job_keys.pop(job_metadata.job_id, None)
+            self._store_job_contexts.pop(job_metadata.job_id, None)
+            raise
 
     def submit_load(self, job_metadata: TransferJob) -> None:
-        self._load_job_keys[job_metadata.job_id] = list(job_metadata.keys)
+        job_id = job_metadata.job_id
+        self._load_job_keys[job_id] = list(job_metadata.keys)
         obj_keys = (self._file_mapper.get_file_name(k) for k in job_metadata.keys)
-        self._submit_transfer(
-            job_metadata.job_id, job_metadata.block_ids, obj_keys, NIXL_READ
-        )
+        try:
+            self._submit_transfer(job_id, job_metadata.block_ids, obj_keys, NIXL_READ)
+        except Exception:
+            self._load_job_keys.pop(job_id, None)
+            raise
 
     def on_request_finished(self, req_context: ReqContext) -> None:
-        self._lookup_manager.cleanup(req_context.req_id)
+        self._lookup_manager.cleanup(req_context)
 
     def on_schedule_end(self, context: ScheduleEndContext) -> None:
         self._lookup_manager.flush()
@@ -367,6 +382,7 @@ class ObjectStoreSecondaryTierManager(SecondaryTierManager):
         for result in results:
             if self.events is not None:
                 keys = self._store_job_keys.pop(result.job_id, None)
+                req_context = self._store_job_contexts.pop(result.job_id, None)
                 if result.success and keys:
                     self.events.append(
                         OffloadingEvent(
@@ -374,6 +390,7 @@ class ObjectStoreSecondaryTierManager(SecondaryTierManager):
                             medium=self.medium,
                             removed=False,
                             locality=self.locality,
+                            req_context=req_context,
                         )
                     )
             # Mark only the keys that did not load as a miss; the request
@@ -391,8 +408,9 @@ class ObjectStoreSecondaryTierManager(SecondaryTierManager):
 
     def take_events(self) -> Iterable[OffloadingEvent]:
         if self.events is not None:
-            yield from self.events
-            self.events.clear()
+            events = self.events
+            self.events = []
+            yield from events
 
     def drain_jobs(self) -> None:
         """Block until every submitted transfer has completed or failed.
@@ -436,6 +454,10 @@ class ObjectStoreSecondaryTierManager(SecondaryTierManager):
             except Exception as exc:
                 logger.warning("deregister_memory failed for job %d: %s", job_id, exc)
         self._transfers.clear()
+        self._store_job_keys.clear()
+        self._store_job_contexts.clear()
+        if self.events is not None:
+            self.events.clear()
         if self._dram_prepped_handle is not None:
             try:
                 self._agent.release_dlist_handle(self._dram_prepped_handle)

--- a/vllm/v1/kv_offload/tiering/spec.py
+++ b/vllm/v1/kv_offload/tiering/spec.py
@@ -313,6 +313,9 @@ class TieringOffloadingSpec(CPUOffloadingSpec):
                     cache_policy=self.eviction_policy,
                     cache_policy_module_path=self.cache_policy_module_path,
                     enable_events=self.kv_events_config.enable_kv_cache_events,
+                    enable_event_provenance=(
+                        self.kv_events_config.self_describing_kv_events
+                    ),
                     mmap_region=scheduler_mmap,
                 )
 


### PR DESCRIPTION
## Purpose

Carry request provenance through asynchronous KV-offload completions so locally initiated stores and promotions can emit full `BlockStored` events.

The current tracker snapshots full payloads at scheduler lookup/store time and keeps them in a global map. This PR instead keeps a lazy event locator with the request and builds the payload when the raw stored event arrives.

```text
Request + KV-group geometry
            |
     ReqContext event state
            |
   existing async job paths
            |
CPU / FS / OBJ completion
            |
OffloadingEvent(key, ReqContext)
            |
      full BlockStored
```

## Changes

- Attach request-scoped event state to `ReqContext`.
- Lazily resolve a stored key to its full-chunk or partial-tail boundary.
- Carry the exact `ReqContext` through CPU, FS, OBJ, cascade, and promotion completion.
- Use context identity, not request ID, when an old completion is finalized.
- Generate GPU-equivalent per-block `extra_keys`, including multimodal and prompt-embedding inputs.
- Keep placeholders for external work, unsupported cache shapes, and unsafe token-mutating requests.
- Keep only detached chunk hashes for the existing CPU removal contract; #49413 PR 2 removes that table.
- Preserve queued CPU removals and their detached expansion metadata across reset.
- Move context ownership from active work to the raw stored event, then release it after translation; failed submissions and shutdown unwind their owners.

## Scope

This PR does not change:

- `OffloadKey = (block_hash, group_idx)`;
- `prepare_store` admission or batching;
- worker transfer metadata;
- the legacy expanded-removal contract; or
- the public KV-event schema.

Single-key admission, k-way ordering, and #44865 remain separate work.

This PR is based on the KV-group block-granularity fix merged in #51614. Token-mutating paths affected by #49377 keep placeholder payloads until their hash and offload state are safe.

## Duplicate-work check

- #49506 is superseded by this narrower request-scoped design.
- #51614 is merged and provides the block-granularity base.
- #50087 changes request-level store policy/admission.
- #52022 fixes store-threshold accounting.
- #51646 only updates event-medium documentation.

No open PR above carries request provenance through async stored-event completion.

## Tests

All validation ran on the workstation against `3d204dfdaa`:

```text
.venv/bin/python -m pytest \
  tests/v1/kv_connector/unit/offloading_connector/test_events.py -q
32 passed

.venv/bin/python -m pytest \
  tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py -q
122 passed

.venv/bin/python -m pytest \
  tests/v1/kv_offload/cpu/test_manager.py \
  tests/v1/kv_offload/tiering/test_async_lookup.py \
  tests/v1/kv_offload/tiering/test_fs_tier.py \
  tests/v1/kv_offload/tiering/test_obj_tier.py \
  tests/v1/kv_offload/tiering/test_tiering_offloading.py -q
182 passed

pre-commit run ruff-format --files \
  $(git diff --name-only origin/main...HEAD -- '*.py')
Passed

pre-commit run ruff-check --files \
  $(git diff --name-only origin/main...HEAD -- '*.py')
Passed

pre-commit run mypy-3.12 --hook-stage manual \
  --files $(git diff --name-only origin/main...HEAD -- vllm)
Passed
```

Model evaluation: not applicable. This changes event metadata and lifecycle only, not model execution or output.

## AI assistance

AI assistance was used to trace the event lifecycle, implement the change, and draft tests. The human submitter must review every changed line and these test results before submission.
