### PR TITLE
[Bugfix][Core] Restore incremental thinking-budget marker scans

### DIFF
--- a/tests/v1/logits_processors/test_correctness.py
+++ b/tests/v1/logits_processors/test_correctness.py
@@ -1269,6 +1269,41 @@ def test_thinking_budget_long_thinking_section_end_marker_found_at_correct_index
     )
 
 
+def test_thinking_budget_marker_search_is_incremental():
+    """Long thinking sections must not rescan the full output every step."""
+    h = ThinkingBudgetStateHolder(
+        MockReasoningConfig(), 8, 0, torch.device("cpu"), False
+    )
+    h.sync_batch(
+        BatchUpdate(
+            batch_size=1,
+            removed=(),
+            added=[(0, SamplingParams(thinking_token_budget=10_000), None, [])],
+            moved=(),
+        )
+    )
+    scanned_tokens = 0
+    original_find = h._find_last_sequence_index
+
+    def counted_find(target_list: list[int], token_ids: list[int]) -> int:
+        nonlocal scanned_tokens
+        scanned_tokens += len(target_list)
+        return original_find(target_list, token_ids)
+
+    h._find_last_sequence_index = counted_find  # type: ignore[method-assign]
+    out = list(MockReasoningConfig.reasoning_start_token_ids)
+    h.update_state([out], None, None)
+    for _ in range(500):
+        out.append(42)
+        h.update_state([out], None, None)
+
+    max_marker_len = max(
+        len(MockReasoningConfig.reasoning_start_token_ids),
+        len(MockReasoningConfig.reasoning_end_token_ids),
+    )
+    assert scanned_tokens <= 2 * len(out) * max_marker_len
+
+
 # --- Thinking budget re-entry tests (issue #43708) ---
 # Regression tests: after budget forces end-of-thinking token sequence,
 # the state machine must detect and enforce budget on subsequent blocks.

--- a/vllm/v1/sample/thinking_budget_state.py
+++ b/vllm/v1/sample/thinking_budget_state.py
@@ -236,9 +236,10 @@ class ThinkingBudgetStateHolder:
             state["force_index"] = []
             return
 
+        output = state.get("output_tok_ids", [])
+        scan_offset = state.get("scan_offset", 0)
+        output_slice = output[scan_offset:]
         if state["start_thinking"] == -1:
-            scan_offset = state.get("scan_offset", 0)
-            output_slice = state.get("output_tok_ids", [])[scan_offset:]
             start_thinking = self._find_last_sequence_index(
                 output_slice, self.think_start_token_ids
             )
@@ -246,14 +247,17 @@ class ThinkingBudgetStateHolder:
                 start_thinking += scan_offset
             state["start_thinking"] = start_thinking
         if state["end_thinking"] == -1:
-            scan_offset = state.get("scan_offset", 0)
-            output_slice = state.get("output_tok_ids", [])[scan_offset:]
             end_thinking = self._find_last_sequence_index(
                 output_slice, self.think_end_token_ids
             )
             if end_thinking >= 0:
                 end_thinking += scan_offset
             state["end_thinking"] = end_thinking
+
+        max_marker_len = max(
+            len(self.think_start_token_ids), len(self.think_end_token_ids)
+        )
+        state["scan_offset"] = max(scan_offset, len(output) - max_marker_len + 1)
 
         if (
             not state.get("in_end", False)


### PR DESCRIPTION
## Purpose

PR #46425 made thinking-budget marker searches incremental by advancing per-search cursors after unsuccessful scans. PR #45984 later removed those cursors while fixing natural `</think>` re-entry and replaced them with a shared `scan_offset` that only advances when a thinking section exits.

As a result, while a single long thinking section remains open and the end marker has not been generated, every decode step scans the complete growing output again. The cumulative marker-search work therefore regressed from linear to quadratic.

This PR advances `scan_offset` after every marker-search update while retaining `max_marker_len - 1` tokens of overlap. The overlap preserves detection of multi-token markers split across decode steps. Search results are still converted to absolute output indices, and the existing natural-end, forced-end, re-entry, and speculative-decoding state transitions are unchanged.

This restores the incremental marker-search behavior introduced by #46425 and regressed by #45984.

## Test Plan

- Add a deterministic complexity regression test that instruments `_find_last_sequence_index()` and counts the total number of tokens passed to marker searches.
- Assert a linear upper bound based on output length and maximum marker length instead of using a wall-clock threshold.
- Run all thinking-budget tests and the complete logits-processor correctness test file.
- Run Ruff checks on the modified files.

```text
.venv/bin/python -m pytest tests/v1/logits_processors/test_correctness.py -k thinking_budget -q
.venv/bin/python -m pytest tests/v1/logits_processors/test_correctness.py -q
uvx ruff check vllm/v1/sample/thinking_budget_state.py tests/v1/logits_processors/test_correctness.py
uvx ruff format --check vllm/v1/sample/thinking_budget_state.py tests/v1/logits_processors/test_correctness.py
```

## Test Result

### Complexity regression

The table below reports the cumulative number of tokens passed to marker searches while repeatedly appending one token to a long open thinking section.

| Revision | 500 steps | 1,000 steps | Growth ratio |
|---|---:|---:|---:|
| #46425 merge (`7f99e80c3`) | 1,504 | 3,004 | 2.00x |
| #45984 merge (`ed908cf0a`) | 126,254 | 502,504 | 3.98x |
| Upstream main before this patch | 126,254 | 502,504 | 3.98x |
| This patch | 1,504 | 3,004 | 2.00x |

The regressed implementation grows approximately fourfold when the sequence length doubles, while the patched implementation grows approximately twofold.

### CPU micro-benchmark

The CPU micro-benchmark follows the per-decode-step setup used by #46425: append one token to the full output list on every step and search for an end marker that is not present. Each result is the median of three runs.

| Steps | Upstream main | This patch | Speedup |
|---:|---:|---:|---:|
| 1,000 | 0.021085 s | 0.000700 s | 30.1x |
| 2,000 | 0.089897 s | 0.001439 s | 62.5x |
| 4,000 | 0.359857 s | 0.002841 s | 126.6x |
| 8,000 | 1.462388 s | 0.005671 s | 257.9x |

### Correctness and lint

```text
15 passed, 26 deselected
41 passed
All Ruff checks passed
2 files already formatted
```

## Duplicate-work Check

As of August 13, 2026, searches for open PRs containing `thinking_token_budget`, `scan_offset`, and thinking-budget performance did not find another PR addressing this regression.

## AI Assistance

AI assistance was used for source-history analysis, implementation, and test preparation. I reviewed the complete diff, verified the algorithmic reasoning, and ran the tests listed above.
