### PR TITLE
[Bugfix][Model] Preserve Step3-VL zero-patch CUDA graph outputs

### DIFF
--- a/tests/models/multimodal/processing/test_step3_vl_image_embeds.py
+++ b/tests/models/multimodal/processing/test_step3_vl_image_embeds.py
@@ -12,6 +12,9 @@ from vllm.model_executor.models.step3_vl import (
 
 
 class _FakeStep3VL:
+    img_output_tokens = 2
+    patch_output_tokens = 1
+
     @staticmethod
     def _process_image_features(image_features: torch.Tensor) -> torch.Tensor:
         return image_features
@@ -56,3 +59,29 @@ def test_process_image_embeds_does_not_require_pixel_input_fields():
     assert len(outputs) == 2
     assert torch.equal(outputs[0], image_embeds[0])
     assert torch.equal(outputs[1], image_embeds[1])
+
+
+@pytest.mark.parametrize("clone", [True, False])
+def test_postprocess_encoder_output_respects_clone_for_zero_patch_output(clone):
+    """A replay must overwrite only output whose alias was requested."""
+    graph_output = torch.arange(4, dtype=torch.float16).reshape(2, 2)
+    dest: dict[int, torch.Tensor] = {}
+
+    Step3VLForConditionalGeneration.postprocess_encoder_output(
+        _FakeStep3VL(),
+        {"global": graph_output},
+        indices=[0],
+        per_item_out_tokens=[2],
+        dest=dest,
+        clone=clone,
+        batch_mm_kwargs={"num_patches": [0]},
+    )
+
+    postprocessed = dest[0]
+    snapshot = postprocessed.clone()
+    graph_output.fill_(-1)
+
+    if clone:
+        assert torch.equal(postprocessed, snapshot)
+    else:
+        assert torch.equal(postprocessed, graph_output)

--- a/vllm/model_executor/models/step3_vl.py
+++ b/vllm/model_executor/models/step3_vl.py
@@ -927,7 +927,10 @@ class Step3VLForConditionalGeneration(
                 parts.append(patch_part[cur_patch : cur_patch + np].reshape(-1, hidden))
                 cur_patch += np
             parts.append(global_part[i].reshape(-1, hidden))
-            merged[idx] = torch.cat(parts, dim=0) if len(parts) > 1 else parts[0]
+            if len(parts) > 1:
+                merged[idx] = torch.cat(parts, dim=0)
+            else:
+                merged[idx] = parts[0].clone() if clone else parts[0]
 
         out = [merged[i] for i in indices]
         for i, idx in enumerate(indices):


### PR DESCRIPTION
## Summary

- honor the encoder postprocessor's `clone` contract when a Step3-VL image has zero local patches
- keep the no-clone path as an alias while preserving cloned outputs across later CUDA graph replays
- add a focused regression test for both ownership modes

Without this, the single-part fast path returns the CUDA graph output buffer directly even when `clone=True`. A later replay can therefore overwrite a previously cached image embedding and make it represent another image.

## Validation

- Focused leased RTX 2080 Ti (SM75, FP16) model-level CUDA graph validation: **BASE RED / PATCH GREEN**
- Two distinct 512×512 images, `num_patches=[0, 0]`, real CUDA graph capture and production postprocessor
- Base: the first retained output changed after replaying the second image
- Patch: both replay-time outputs matched eager execution and the first retained output stayed unchanged
- `git diff --check`
- `python3 -m py_compile vllm/model_executor/models/step3_vl.py tests/models/multimodal/processing/test_step3_vl_image_embeds.py`

A local focused pytest was not run because this isolated worktree has no project virtual environment; the GPU model-level harness exercised the target production path directly.

## Duplicate check

I searched current open vLLM issues and PRs for Step3-VL, encoder CUDA graph, zero-patch, aliasing, and clone/output ownership. I found no open change addressing this ownership bug. The current `main` implementation still has the faulty single-part fast path.

## Model evaluation

This is an ownership/lifetime correction rather than a numerical model change. The leased GPU validation compared both images against eager output at replay time and confirmed exact preservation after the second replay.

## AI assistance

AI assistance was used for source investigation, implementation, and test-harness preparation. I reviewed every changed line and independently verified the diff, duplicate status, and GPU RED/GREEN evidence.
