### PR TITLE
[Bugfix][Model] Fix DualChunkRotaryEmbedding hard-coded cuda device crash

### DIFF
--- a/tests/model_executor/layers/test_dual_chunk_rope.py
+++ b/tests/model_executor/layers/test_dual_chunk_rope.py
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for DualChunkRotaryEmbedding device handling."""
+
+import pytest
+import torch
+
+from vllm.model_executor.layers.rotary_embedding.dual_chunk_rope import (
+    DualChunkRotaryEmbedding,
+)
+from vllm.platforms import current_platform
+
+# Lightweight unit test (no distributed env / large GPU buffers): skip the
+# global post-test cleanup for speed, per the skip_global_cleanup convention.
+pytestmark = pytest.mark.skip_global_cleanup
+
+HEAD_SIZE = 32
+ROTARY_DIM = 32
+MAX_POS = 128
+BASE = 10000.0
+CHUNK_SIZE = 64
+LOCAL_SIZE = 8
+DTYPE = torch.float
+
+
+def _make_embedding() -> DualChunkRotaryEmbedding:
+    return DualChunkRotaryEmbedding(
+        head_size=HEAD_SIZE,
+        rotary_dim=ROTARY_DIM,
+        max_position_embeddings=MAX_POS,
+        base=BASE,
+        is_neox_style=True,
+        dtype=DTYPE,
+        chunk_size=CHUNK_SIZE,
+        local_size=LOCAL_SIZE,
+    )
+
+
+def test_device_follows_platform_type(monkeypatch, default_vllm_config):
+    """Regression guard for the "Torch not compiled with CUDA enabled" crash.
+
+    DualChunkRotaryEmbedding must place its cos/sin caches on the active
+    platform's device (current_platform.device_type), not a hard-coded "cuda".
+    The device index is pinned and the platform device type is forced to "cpu"
+    so the test runs on any runner - the real cos/sin build calls
+    `.to(device=self.device)`, which must target an available device. With the
+    old hard-coded "cuda" this would build `self.device = cuda:0` and the
+    assertions (`type == "cpu"`, `type != "cuda"`) would fail.
+    """
+    monkeypatch.setattr(torch.accelerator, "current_device_index", lambda: 0)
+    monkeypatch.setattr(current_platform, "device_type", "cpu")
+
+    emb = _make_embedding()
+
+    assert emb.device == torch.device("cpu", 0)
+    assert emb.device.type != "cuda"
+    # The cos/sin caches were built end-to-end on the platform device.
+    chunk_len = CHUNK_SIZE - LOCAL_SIZE
+    assert emb.cos_sin_q_cache.shape == (chunk_len, ROTARY_DIM)
+    assert emb.cos_sin_k_cache.shape == (MAX_POS, ROTARY_DIM)
+    assert emb.cos_sin_q_cache.device.type == "cpu"
+
+
+def test_device_matches_real_platform(monkeypatch, default_vllm_config):
+    """On the real platform (no device-type mock), the device type must equal
+    current_platform.device_type. Pins the portable contract on whatever
+    backend CI runs on; the device index still comes from
+    torch.accelerator.current_device_index()."""
+    monkeypatch.setattr(torch.accelerator, "current_device_index", lambda: 0)
+
+    emb = _make_embedding()
+
+    assert emb.device.type == current_platform.device_type
+    assert emb.device.index == 0
+    assert emb.cos_sin_q_cache.device.type == current_platform.device_type

--- a/vllm/model_executor/layers/rotary_embedding/dual_chunk_rope.py
+++ b/vllm/model_executor/layers/rotary_embedding/dual_chunk_rope.py
@@ -5,6 +5,7 @@
 import torch
 
 from vllm.model_executor.custom_op import CustomOp
+from vllm.platforms import current_platform
 
 from .common import rotate_gptj, rotate_neox
 
@@ -37,7 +38,7 @@ class DualChunkRotaryEmbedding(CustomOp):
         self.local_size = local_size
         self.dtype = dtype
         device_idx = torch.accelerator.current_device_index()
-        self.device = torch.device(f"cuda:{device_idx}")
+        self.device = torch.device(current_platform.device_type, device_idx)
         (q_cache, qc_cache, k_cache, qc_no_clamp_cache, q_inter_cache) = (
             self._compute_cos_sin_cache()
         )


### PR DESCRIPTION
## Purpose

`DualChunkRotaryEmbedding.__init__` hard-codes `self.device = torch.device(f"cuda:{device_idx}")` alongside the portable `torch.accelerator.current_device_index()`. On any non-CUDA backend the subsequent `.to(device=self.device)` inside `_compute_cos_sin_cache` triggers CUDA lazy-init and crashes model loading with "Torch not compiled with CUDA enabled" for every Dual Chunk Attention model (e.g. Qwen2.5-*-1M).

Reproduced on Ascend NPU when serving Qwen2.5-7B-Instruct-1M:

```
(EngineCore) Starting to load model .../Qwen2.5-7B-Instruct-1M...
(EngineCore) EngineCore failed to start.
Traceback (most recent call last):
  File ".../vllm/v1/engine/core.py", line 1200, in run_engine_core
    engine_core = EngineCoreProc(*args, engine_index=dp_rank, **kwargs)
  File ".../vllm/v1/engine/core.py", line 123, in __init__
    self.model_executor = executor_class(vllm_config)
  File ".../vllm/v1/executor/uniproc_executor.py", line 68, in _init_executor
    self.driver_worker.load_model()
  File ".../vllm/model_executor/model_loader/__init__.py", line 140, in get_model
    return loader.load_model(...)
  File ".../vllm/model_executor/model_loader/utils.py", line 63, in initialize_model
    model = model_class(vllm_config=vllm_config, prefix=prefix)
  File ".../vllm/model_executor/models/qwen2.py", line 458, in __init__
    self.model = Qwen2Model(...)
  File ".../vllm/model_executor/models/qwen2.py", line 375, in __init__
    self.start_layer, self.end_layer, self.layers = make_layers(...)
  File ".../vllm/model_executor/models/utils.py", line 711, in make_layers
    + get_offloader().wrap_modules(...)
  File ".../vllm/model_executor/offloader/base.py", line 104, in wrap_modules
    return list(modules_generator)
  File ".../vllm/model_executor/models/qwen2.py", line 263, in __init__
    self.self_attn = Qwen2Attention(...)
  File ".../vllm/model_executor/models/qwen2.py", line 178, in __init__
    self.rotary_emb = get_rope(...)
  File ".../vllm/model_executor/layers/rotary_embedding/__init__.py", line 92, in get_rope
    rotary_emb = DualChunkRotaryEmbedding(...)
  File ".../vllm/model_executor/layers/rotary_embedding/dual_chunk_rope.py", line 42, in __init__
    self._compute_cos_sin_cache()
  File ".../vllm/model_executor/layers/rotary_embedding/dual_chunk_rope.py", line 105, in _compute_cos_sin_cache
    q_cache = torch.cat((q_cos, q_sin), dim=-1).to(...)
  File ".../torch/cuda/__init__.py", line 417, in _lazy_init
    raise AssertionError("Torch not compiled with CUDA enabled")
AssertionError: Torch not compiled with CUDA enabled
```

Fix: use `current_platform.device_type` instead of the "cuda" literal - the same portable pattern already used across vllm (config, compilation passes, other layers). The device index still comes from `torch.accelerator.current_device_index()`. No cache values change; only the device the cos/sin caches are placed on.

## Test Plan

- New unit test `tests/model_executor/layers/test_dual_chunk_rope.py`:
  ```bash
  python -m pytest tests/model_executor/layers/test_dual_chunk_rope.py -v
  ```
- E2E: `vllm serve` a Dual Chunk Attention model (e.g. Qwen2.5-7B-Instruct-1M) on a non-CUDA backend (Ascend NPU).

## Test Result

**Before** (Ascend NPU): `vllm serve Qwen2.5-7B-Instruct-1M` crashes during model loading (traceback above), `AssertionError: Torch not compiled with CUDA enabled`.

**After**:
- UT:
  ```
  tests/model_executor/layers/test_dual_chunk_rope.py::test_device_follows_platform_type PASSED
  tests/model_executor/layers/test_dual_chunk_rope.py::test_device_matches_real_platform PASSED
  ```
- `vllm serve Qwen2.5-7B-Instruct-1M` on Ascend NPU starts and serves normally.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>