### PR TITLE
[XPU] [Bugfix] process ragged weights in xpu linear backend

### DIFF
--- a/vllm/model_executor/kernels/linear/scaled_mm/xpu.py
+++ b/vllm/model_executor/kernels/linear/scaled_mm/xpu.py
@@ -2,7 +2,6 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import math
-
 from collections.abc import Sequence
 
 import torch
@@ -206,16 +205,11 @@ class XPUFp8BlockScaledMMKernel(Fp8BlockScaledMMLinearKernel):
         )
         scale = getattr(layer, scale_attr)
 
-        # oneDNN derives the weight block-group width as N // n_blocks (n_blocks
-        # = scale columns) and requires it to evenly divide N. Checkpoints use a
-        # block_n-wide N group so n_blocks = ceil(N / block_n); when N is not a
-        # multiple of block_n the width is fractional and oneDNN cannot build
-        # the matmul primitive (e.g. DeepSeek/GLM MLA fused_qkv_a_proj N=2624,
-        # kv_a_proj_with_mqa N=576 with block_n=128). Instead of padding the
-        # weight on every forward, shrink the group width once here to
-        # gcd(N, block_n) and expand the scale along N so each finer block
-        # reuses the coarse block's scale. When N % block_n == 0 this is a
-        # no-op.
+        # Ragged N (N % block_n != 0): oneDNN needs n_blocks to divide N.
+        # Weight untouched; only repeat scale rows to a finer N-group so that
+        # n_blocks divides N (g = gcd(N, block_n)):
+        #   scale [ceil(N/block_n), K/block_k] --> [N/g, K/block_k]
+        # No-op when N % block_n == 0.
         block_n, block_k = self.weight_group_shape
         N, K = layer.weight.shape
         if N % block_n != 0:
@@ -224,12 +218,8 @@ class XPUFp8BlockScaledMMKernel(Fp8BlockScaledMMLinearKernel):
             src_idx = torch.div(col_start, block_n, rounding_mode="floor")
             scale = scale.index_select(0, src_idx).contiguous()
 
-        # A ragged K would hit the same oneDNN limitation, but K is the
-        # reduction axis so it also needs the runtime activation-group scale
-        # expanded to match; that is not handled here. DeepSeek/GLM block-FP8
-        # checkpoints always keep K (hidden / LoRA / intermediate dims) aligned
-        # to block_k, so fail loudly instead of letting oneDNN crash with an
-        # opaque "could not create a primitive descriptor" error.
+        # Ragged K needs the runtime activation scale expanded too, which we
+        # don't handle; DeepSeek/GLM keep K block-aligned, so fail loudly.
         assert K % block_k == 0, (
             f"XPU block-scaled FP8 requires K ({K}) to be a multiple of the "
             f"weight block size ({block_k}); ragged-K weights are unsupported."

--- a/vllm/model_executor/kernels/linear/scaled_mm/xpu.py
+++ b/vllm/model_executor/kernels/linear/scaled_mm/xpu.py
@@ -206,15 +206,22 @@ class XPUFp8BlockScaledMMKernel(Fp8BlockScaledMMLinearKernel):
         scale = getattr(layer, scale_attr)
 
         # Ragged N (N % block_n != 0): oneDNN needs n_blocks to divide N.
-        # Weight untouched; only repeat scale rows to a finer N-group so that
-        # n_blocks divides N (g = gcd(N, block_n)):
-        #   scale [ceil(N/block_n), K/block_k] --> [N/g, K/block_k]
-        # No-op when N % block_n == 0.
+        # Weight untouched; only repeat scale rows to a finer N-group gn that
+        # divides both N and block_n (gn = gcd(N, block_n)):
+        #   scale [ceil(N/block_n), K/block_k] --> [N/gn, K/block_k]
+        # oneDNN only accepts gn that is a multiple of 16, and gcd(N, block_n)
+        # is a power of two (block_n=128), so gn must be >= 16. No-op when
+        # N % block_n == 0.
         block_n, block_k = self.weight_group_shape
         N, K = layer.weight.shape
         if N % block_n != 0:
-            g = math.gcd(N, block_n)
-            col_start = torch.arange(N // g, device=scale.device) * g
+            gn = math.gcd(N, block_n)
+            assert gn % 16 == 0, (
+                f"XPU block-scaled FP8: N ({N}) yields group width {gn}, but "
+                f"oneDNN only supports multiples of 16; this weight shape is "
+                f"unsupported."
+            )
+            col_start = torch.arange(N // gn, device=scale.device) * gn
             src_idx = torch.div(col_start, block_n, rounding_mode="floor")
             scale = scale.index_select(0, src_idx).contiguous()
 

--- a/vllm/model_executor/kernels/linear/scaled_mm/xpu.py
+++ b/vllm/model_executor/kernels/linear/scaled_mm/xpu.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import math
+
 from collections.abc import Sequence
 
 import torch
@@ -204,7 +206,36 @@ class XPUFp8BlockScaledMMKernel(Fp8BlockScaledMMLinearKernel):
         )
         scale = getattr(layer, scale_attr)
 
-        # Checkpoint scale is [n_blocks, k_blocks] (one value per 128x128 tile).
+        # oneDNN derives the weight block-group width as N // n_blocks (n_blocks
+        # = scale columns) and requires it to evenly divide N. Checkpoints use a
+        # block_n-wide N group so n_blocks = ceil(N / block_n); when N is not a
+        # multiple of block_n the width is fractional and oneDNN cannot build
+        # the matmul primitive (e.g. DeepSeek/GLM MLA fused_qkv_a_proj N=2624,
+        # kv_a_proj_with_mqa N=576 with block_n=128). Instead of padding the
+        # weight on every forward, shrink the group width once here to
+        # gcd(N, block_n) and expand the scale along N so each finer block
+        # reuses the coarse block's scale. When N % block_n == 0 this is a
+        # no-op.
+        block_n, block_k = self.weight_group_shape
+        N, K = layer.weight.shape
+        if N % block_n != 0:
+            g = math.gcd(N, block_n)
+            col_start = torch.arange(N // g, device=scale.device) * g
+            src_idx = torch.div(col_start, block_n, rounding_mode="floor")
+            scale = scale.index_select(0, src_idx).contiguous()
+
+        # A ragged K would hit the same oneDNN limitation, but K is the
+        # reduction axis so it also needs the runtime activation-group scale
+        # expanded to match; that is not handled here. DeepSeek/GLM block-FP8
+        # checkpoints always keep K (hidden / LoRA / intermediate dims) aligned
+        # to block_k, so fail loudly instead of letting oneDNN crash with an
+        # opaque "could not create a primitive descriptor" error.
+        assert K % block_k == 0, (
+            f"XPU block-scaled FP8 requires K ({K}) to be a multiple of the "
+            f"weight block size ({block_k}); ragged-K weights are unsupported."
+        )
+
+        # Checkpoint scale is [n_blocks, k_blocks] (one value per block tile).
         # oneDNN fp8_gemm requires contiguous [k_blocks, n_blocks] layout.
         # We store the transposed contiguous buffer as a .t() view so that:
         #   - MLA's scaled_dequantize still sees [n_blocks, k_blocks] shape


### PR DESCRIPTION
python examples/basic/offline_inference/generate.py     --model gaunernst/DeepSeek-V2-Lite-Chat-FP8     --enforce-eager --max-model-len 2048 --trust-remote-code

Before:
<img width="1688" height="171" alt="image" src="https://github.com/user-attachments/assets/82d1fcf4-19fd-48df-a105-ca1a77ca9db4" />

After:
<img width="865" height="227" alt="image" src="https://github.com/user-attachments/assets/62e97fea-e1b6-447a-b17a-1aeb9672f05c" />
