### PR TITLE
[Security] Kill regex compilation subprocess on timeout

### DIFF
--- a/tests/v1/structured_output/test_regex_compilation_timeout.py
+++ b/tests/v1/structured_output/test_regex_compilation_timeout.py
@@ -4,11 +4,15 @@
 
 Verifies that adversarial regex patterns that would cause exponential
 DFA state-space explosion are rejected with a timeout rather than
-hanging indefinitely.
+hanging indefinitely, and that timed-out compilation work is killed
+(no lingering processes).
 
-Addresses advisory GHSA-rwxx-mrjm-wc2m.
+Addresses advisories GHSA-rwxx-mrjm-wc2m and GHSA-g773-5cq5-5j53.
 """
 
+import contextlib
+import os
+import subprocess
 import time
 from unittest.mock import patch
 
@@ -17,45 +21,156 @@ import pytest
 from vllm.v1.structured_output.utils import compile_regex_with_timeout
 
 
+def _slow_compile(pattern: str) -> str:
+    """Top-level picklable function that blocks indefinitely."""
+    time.sleep(120)
+    return "never"
+
+
+def _fast_compile(pattern: str) -> str:
+    """Top-level picklable function that returns immediately."""
+    return f"compiled:{pattern}"
+
+
+def _failing_compile(pattern: str) -> str:
+    """Top-level picklable function that raises."""
+    raise RuntimeError("compilation failed")
+
+
 class TestCompileRegexWithTimeout:
     """Unit tests for the compile_regex_with_timeout utility."""
 
     def test_normal_regex_compiles_successfully(self):
-        result = compile_regex_with_timeout(lambda pat: "compiled", r"[a-z]+")
-        assert result == "compiled"
+        result = compile_regex_with_timeout(_fast_compile, r"[a-z]+")
+        assert result == "compiled:[a-z]+"
 
     def test_timeout_raises_value_error(self):
-        def slow_compile(pattern: str):
-            time.sleep(10)
-            return "never"
-
         with (
-            patch("vllm.envs.VLLM_REGEX_COMPILATION_TIMEOUT_S", 1),
+            patch("vllm.envs.VLLM_REGEX_COMPILATION_TIMEOUT_S", 0.5),
             pytest.raises(ValueError, match="timed out"),
         ):
-            compile_regex_with_timeout(slow_compile, r"(a+)+b")
+            compile_regex_with_timeout(_slow_compile, r"(a+)+b")
 
     def test_timeout_disabled_when_zero(self):
-        result = None
         with patch("vllm.envs.VLLM_REGEX_COMPILATION_TIMEOUT_S", 0):
-            result = compile_regex_with_timeout(lambda pat: "no_timeout", r"(a+)+b")
-        assert result == "no_timeout"
+            result = compile_regex_with_timeout(_fast_compile, r"(a+)+b")
+        assert result == "compiled:(a+)+b"
 
     def test_compilation_error_propagates(self):
-        def failing_compile(pattern: str):
-            raise RuntimeError("compilation failed")
-
         with pytest.raises(RuntimeError, match="compilation failed"):
-            compile_regex_with_timeout(failing_compile, r"bad")
+            compile_regex_with_timeout(_failing_compile, r"bad")
 
     def test_pattern_included_in_error_message(self):
-        def slow_compile(pattern: str):
-            time.sleep(10)
-            return "never"
-
         pattern = r"(a+)+b"
         with (
-            patch("vllm.envs.VLLM_REGEX_COMPILATION_TIMEOUT_S", 1),
+            patch("vllm.envs.VLLM_REGEX_COMPILATION_TIMEOUT_S", 0.5),
             pytest.raises(ValueError, match=r"\(a\+\)\+b"),
         ):
-            compile_regex_with_timeout(slow_compile, pattern)
+            compile_regex_with_timeout(_slow_compile, pattern)
+
+
+class TestNoLingeringProcesses:
+    """Regression tests for GHSA-g773-5cq5-5j53.
+
+    Verifies that timed-out compilation subprocesses are killed before
+    the timeout error is returned, and that repeated timeouts do not
+    accumulate lingering workers.
+    """
+
+    def test_no_lingering_after_timeout(self):
+        """Child process must be dead when ValueError is raised."""
+        with (
+            patch("vllm.envs.VLLM_REGEX_COMPILATION_TIMEOUT_S", 0.5),
+            contextlib.suppress(ValueError),
+        ):
+            compile_regex_with_timeout(_slow_compile, "linger_test")
+
+        time.sleep(0.1)
+        result = subprocess.run(
+            ["pgrep", "-f", "_slow_compile"],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode != 0, (
+            f"Lingering process found after timeout: {result.stdout}"
+        )
+
+    def test_no_accumulation_after_sequential_timeouts(self):
+        """N sequential timeouts must leave 0 lingering processes."""
+        n = 4
+        with patch("vllm.envs.VLLM_REGEX_COMPILATION_TIMEOUT_S", 0.3):
+            for i in range(n):
+                with contextlib.suppress(ValueError):
+                    compile_regex_with_timeout(_slow_compile, f"accum_pattern_{i}")
+
+        time.sleep(0.1)
+        result = subprocess.run(
+            ["pgrep", "-f", "_slow_compile"],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode != 0, (
+            f"Lingering processes after {n} timeouts: {result.stdout}"
+        )
+
+    def test_fast_compilation_returns_normally(self):
+        """Fast compiles must still return correctly."""
+        with patch("vllm.envs.VLLM_REGEX_COMPILATION_TIMEOUT_S", 5):
+            results = []
+            for i in range(4):
+                results.append(compile_regex_with_timeout(_fast_compile, f"fast_{i}"))
+        assert results == [f"compiled:fast_{i}" for i in range(4)]
+
+    def test_semaphore_limits_concurrent_compiles(self):
+        """With MAX_CONCURRENT=1, only one compile can run at a time."""
+        with (
+            patch("vllm.envs.VLLM_REGEX_COMPILATION_TIMEOUT_S", 0.3),
+            patch("vllm.envs.VLLM_REGEX_COMPILATION_MAX_CONCURRENT", 1),
+        ):
+            import vllm.v1.structured_output.utils as utils_mod
+
+            old_sema = utils_mod._compile_semaphore
+            utils_mod._compile_semaphore = None
+            try:
+                t0 = time.perf_counter()
+                timeouts = 0
+                for i in range(3):
+                    with contextlib.suppress(ValueError):
+                        compile_regex_with_timeout(_slow_compile, f"sema_{i}")
+                    timeouts += 1
+                elapsed = time.perf_counter() - t0
+                assert timeouts == 3
+                assert elapsed >= 0.9, (
+                    f"Expected sequential execution (~0.9s), got {elapsed:.2f}s"
+                )
+            finally:
+                utils_mod._compile_semaphore = old_sema
+
+    def test_process_killed_on_sigkill(self):
+        """Verify the child PID no longer exists after timeout."""
+        child_pids = []
+        original_start = None
+
+        import multiprocessing.process as mp_proc
+
+        original_start = mp_proc.BaseProcess.start
+
+        def tracking_start(self):
+            original_start(self)
+            if self.pid:
+                child_pids.append(self.pid)
+
+        with (
+            patch("vllm.envs.VLLM_REGEX_COMPILATION_TIMEOUT_S", 0.5),
+            patch.object(mp_proc.BaseProcess, "start", tracking_start),
+            contextlib.suppress(ValueError),
+        ):
+            compile_regex_with_timeout(_slow_compile, "kill_test")
+
+        time.sleep(0.1)
+        for pid in child_pids:
+            try:
+                os.kill(pid, 0)
+                pytest.fail(f"Child process {pid} still alive after timeout")
+            except ProcessLookupError:
+                pass

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -213,6 +213,7 @@ if TYPE_CHECKING:
     VLLM_FLASHINFER_WORKSPACE_BUFFER_SIZE: int = 394 * 1024 * 1024
     VLLM_XGRAMMAR_CACHE_MB: int = 0
     VLLM_REGEX_COMPILATION_TIMEOUT_S: int = 5
+    VLLM_REGEX_COMPILATION_MAX_CONCURRENT: int = 1
     VLLM_MSGPACK_ZERO_COPY_THRESHOLD: int = 256
     VLLM_ALLOW_INSECURE_SERIALIZATION: bool = False
     VLLM_DISABLE_REQUEST_ID_RANDOMIZATION: bool = False
@@ -1608,6 +1609,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Set to 0 to disable the timeout (not recommended in production).
     "VLLM_REGEX_COMPILATION_TIMEOUT_S": lambda: int(
         os.getenv("VLLM_REGEX_COMPILATION_TIMEOUT_S", "5")
+    ),
+    # Maximum number of concurrent regex compilation subprocesses.
+    # Limits resource consumption from adversarial regex patterns that
+    # survive beyond the timeout deadline.
+    "VLLM_REGEX_COMPILATION_MAX_CONCURRENT": lambda: int(
+        os.getenv("VLLM_REGEX_COMPILATION_MAX_CONCURRENT", "1")
     ),
     # Control the threshold for msgspec to use 'zero copy' for
     # serialization/deserialization of tensors. Tensors below

--- a/vllm/v1/structured_output/backend_outlines.py
+++ b/vllm/v1/structured_output/backend_outlines.py
@@ -23,6 +23,7 @@ from vllm.v1.structured_output.backend_types import (
 )
 from vllm.v1.structured_output.utils import (
     OutlinesVocabulary,
+    _outlines_compile_index,
     compile_regex_with_timeout,
     get_outlines_cache,
     get_outlines_vocabulary,
@@ -63,8 +64,9 @@ class OutlinesBackend(StructuredOutputBackend):
             return self.cache[cache_key]
 
         index = compile_regex_with_timeout(
-            lambda pat: oc.Index(pat, vocabulary.inner),
+            _outlines_compile_index,
             regex_string,
+            vocabulary.inner,
         )
         self.cache[cache_key] = index
 

--- a/vllm/v1/structured_output/backend_xgrammar.py
+++ b/vllm/v1/structured_output/backend_xgrammar.py
@@ -18,6 +18,8 @@ from vllm.v1.structured_output.backend_types import (
     StructuredOutputOptions,
 )
 from vllm.v1.structured_output.utils import (
+    _xgr_compile_regex,
+    _xgr_grammar_from_regex,
     choice_as_grammar,
     compile_regex_with_timeout,
     convert_lark_to_ebnf,
@@ -68,6 +70,8 @@ class XgrammarBackend(StructuredOutputBackend):
             cache_enabled=True,
             cache_limit_bytes=vllm.envs.VLLM_XGRAMMAR_CACHE_MB * 1024 * 1024,
         )
+        self.tokenizer_info = tokenizer_info
+        self.tokenizer_info_json = tokenizer_info.serialize_json()
 
         self.num_speculative_tokens = 0
         if self.vllm_config.speculative_config is not None:
@@ -92,10 +96,12 @@ class XgrammarBackend(StructuredOutputBackend):
         elif request_type == StructuredOutputOptions.GRAMMAR:
             ctx = self.compiler.compile_grammar(grammar_spec)
         elif request_type == StructuredOutputOptions.REGEX:
-            ctx = compile_regex_with_timeout(
-                self.compiler.compile_regex,
+            serialized = compile_regex_with_timeout(
+                _xgr_compile_regex,
+                self.tokenizer_info_json,
                 grammar_spec,
             )
+            ctx = xgr.CompiledGrammar.deserialize_json(serialized, self.tokenizer_info)
         elif request_type == StructuredOutputOptions.STRUCTURAL_TAG:
             s_tag = json.loads(grammar_spec)
             if "structures" in s_tag:
@@ -286,7 +292,7 @@ def validate_xgrammar_grammar(sampling_params: SamplingParams) -> None:
     if so_params.regex:
         try:
             compile_regex_with_timeout(
-                xgr.Grammar.from_regex,
+                _xgr_grammar_from_regex,
                 so_params.regex,
             )
         except Exception as err:

--- a/vllm/v1/structured_output/utils.py
+++ b/vllm/v1/structured_output/utils.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 
 import hashlib
 import importlib.metadata
+import multiprocessing
 import os
+import signal
 import sqlite3
 import tempfile
+import threading
 from collections.abc import Callable
-from concurrent.futures import ThreadPoolExecutor, TimeoutError
-from typing import TYPE_CHECKING, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar
 
 import regex as re
 import torch
@@ -44,43 +46,144 @@ _T = TypeVar("_T")
 
 CACHE = None
 
+_compile_semaphore: threading.Semaphore | None = None
+_compile_semaphore_lock = threading.Lock()
+_mp_context = None
+_mp_context_lock = threading.Lock()
 
-def compile_regex_with_timeout(fn: Callable[[str], _T], pattern: str) -> _T:
-    """Run a regex compilation callable with a timeout.
+
+def _get_compile_semaphore() -> threading.Semaphore:
+    global _compile_semaphore
+    if _compile_semaphore is None:
+        with _compile_semaphore_lock:
+            if _compile_semaphore is None:
+                _compile_semaphore = threading.Semaphore(
+                    envs.VLLM_REGEX_COMPILATION_MAX_CONCURRENT
+                )
+    return _compile_semaphore
+
+
+def _get_mp_context():
+    global _mp_context
+    if _mp_context is None:
+        with _mp_context_lock:
+            if _mp_context is None:
+                _mp_context = multiprocessing.get_context("fork")
+    return _mp_context
+
+
+def _regex_compile_worker(
+    fn: Callable[..., Any],
+    args: tuple[Any, ...],
+    result_queue: multiprocessing.Queue,
+) -> None:
+    """Target for the forked subprocess that performs regex compilation."""
+    try:
+        result = fn(*args)
+        result_queue.put(("ok", result))
+    except Exception as exc:
+        result_queue.put(("err", exc))
+
+
+def compile_regex_with_timeout(fn: Callable[..., _T], *args: Any) -> _T:
+    """Run a regex compilation callable with a timeout in a killable process.
 
     Prevents ReDoS attacks where adversarial regex patterns (e.g. nested
     quantifiers like ``(a+)+b``) cause exponential DFA state-space explosion,
-    hanging the inference worker indefinitely.
+    hanging the inference worker indefinitely. Unlike the previous thread-based
+    approach, the compilation runs in a subprocess that is forcefully killed on
+    timeout, ensuring no CPU/memory-consuming work lingers.
 
     Args:
-        fn: Single-argument callable that takes the pattern and performs
-            the regex compilation.
-        pattern: The regex pattern string, passed to *fn* and included in
-            timeout error messages.
+        fn: Picklable callable that performs the regex compilation.
+        *args: Arguments passed to *fn*. Must be picklable.
 
     Raises:
-        ValueError: If compilation exceeds the configured timeout.
+        ValueError: If compilation exceeds the configured timeout or
+            the concurrency slot cannot be acquired.
     """
     timeout = envs.VLLM_REGEX_COMPILATION_TIMEOUT_S
     if timeout <= 0:
-        return fn(pattern)
+        return fn(*args)
 
-    executor = ThreadPoolExecutor(max_workers=1)
-    future = executor.submit(fn, pattern)
-    try:
-        result = future.result(timeout=timeout)
-    except TimeoutError:
-        future.cancel()
-        executor.shutdown(wait=False, cancel_futures=True)
+    semaphore = _get_compile_semaphore()
+    acquired = semaphore.acquire(timeout=timeout)
+    if not acquired:
+        pattern_str = str(args[0])[:200] if args else "<unknown>"
         raise ValueError(
-            f"Regex compilation timed out after {timeout}s. "
-            "The pattern may be too complex or contain constructs that "
-            "cause exponential state-space explosion (e.g. nested "
-            f"quantifiers). Pattern: {pattern[:200]}"
-        ) from None
-    else:
-        executor.shutdown(wait=False)
-        return result
+            f"Regex compilation could not acquire a compile slot within "
+            f"{timeout}s (max concurrent: "
+            f"{envs.VLLM_REGEX_COMPILATION_MAX_CONCURRENT}). "
+            f"Pattern: {pattern_str}"
+        )
+
+    try:
+        ctx = _get_mp_context()
+        result_queue: multiprocessing.Queue = ctx.Queue()
+        process = ctx.Process(
+            target=_regex_compile_worker,
+            args=(fn, args, result_queue),
+            daemon=True,
+        )
+        process.start()
+        process.join(timeout=timeout)
+
+        if process.is_alive():
+            pid = process.pid
+            if pid is not None:
+                os.kill(pid, signal.SIGKILL)
+            process.join(timeout=5)
+            pattern_str = str(args[0])[:200] if args else "<unknown>"
+            raise ValueError(
+                f"Regex compilation timed out after {timeout}s. "
+                "The pattern may be too complex or contain constructs that "
+                "cause exponential state-space explosion (e.g. nested "
+                f"quantifiers). Pattern: {pattern_str}"
+            ) from None
+
+        if process.exitcode != 0:
+            pattern_str = str(args[0])[:200] if args else "<unknown>"
+            raise ValueError(
+                f"Regex compilation process exited with code "
+                f"{process.exitcode}. Pattern: {pattern_str}"
+            ) from None
+
+        if result_queue.empty():
+            pattern_str = str(args[0])[:200] if args else "<unknown>"
+            raise ValueError(
+                f"Regex compilation process produced no result. Pattern: {pattern_str}"
+            ) from None
+
+        status, payload = result_queue.get_nowait()
+        if status == "ok":
+            return payload  # type: ignore[return-value]
+        else:
+            raise payload
+    finally:
+        semaphore.release()
+
+
+def _xgr_grammar_from_regex(pattern: str) -> str:
+    """Picklable worker: compile regex via xgrammar, return serialized JSON."""
+    import xgrammar as xgr
+
+    return xgr.Grammar.from_regex(pattern).serialize_json()
+
+
+def _xgr_compile_regex(tokenizer_info_json: str, pattern: str) -> str:
+    """Picklable worker: rebuild compiler in subprocess and compile regex."""
+    import xgrammar as xgr
+
+    info = xgr.TokenizerInfo.deserialize_json(tokenizer_info_json)
+    compiler = xgr.GrammarCompiler(info, max_threads=1)
+    return compiler.compile_regex(pattern).serialize_json()
+
+
+def _outlines_compile_index(pattern: str, vocabulary: Any) -> Any:
+    """Picklable worker: build outlines Index from pattern + vocabulary."""
+    import outlines_core as oc
+
+    return oc.Index(pattern, vocabulary)
 
 
 def apply_grammar_bitmask(


### PR DESCRIPTION
Replace the thread-based compile_regex_with_timeout() with a fork-based subprocess that is SIGKILL'd on deadline expiry. The previous ThreadPoolExecutor approach could not cancel already-running callables, allowing adversarial regex patterns to accumulate CPU/memory-consuming compiler workers after each timeout error.

- Use multiprocessing fork context for fast subprocess creation
- SIGKILL + join the child before returning ValueError on timeout
- Add global semaphore (VLLM_REGEX_COMPILATION_MAX_CONCURRENT, default 1) to bound concurrent compilation processes
- Adapt xgrammar/outlines/lm-format-enforcer call sites to use picklable top-level workers with serialize/deserialize round-trips
- Add regression tests asserting zero lingering processes after timeout

