### PR TITLE
[Security] Fix ReDoS in validation error path sanitizer

### DIFF
--- a/tests/entrypoints/serve/utils/test_api_utils.py
+++ b/tests/entrypoints/serve/utils/test_api_utils.py
@@ -164,3 +164,57 @@ class TestSanitizeMessageFilePaths:
         result = sanitize_message(msg)
         assert "0x" not in result
         assert "/usr/local/" not in result
+
+
+class TestSanitizeMessageReDoSResistance:
+    """Regression tests for GHSA-f2g9-pmwr-xwc7.
+
+    Verifies that sanitize_message performs bounded near-linear work
+    on adversarial slash-delimited input with no filename extension.
+    """
+
+    def test_slash_segments_no_extension_completes_quickly(self):
+        """50k slash-segments without dot-extension must complete in < 0.1s."""
+        import time
+
+        message = "/a" * 50000
+        t0 = time.perf_counter()
+        result = sanitize_message(message)
+        elapsed = time.perf_counter() - t0
+        assert elapsed < 0.1, f"Took {elapsed:.2f}s (expected < 0.1s)"
+        assert result == message
+
+    def test_alphanumeric_control_completes(self):
+        """100k alphanumeric chars must complete near-instantly."""
+        import time
+
+        message = "a" * 100000
+        t0 = time.perf_counter()
+        result = sanitize_message(message)
+        elapsed = time.perf_counter() - t0
+        assert elapsed < 0.1, f"Took {elapsed:.2f}s"
+        assert result == message
+
+    def test_linear_scaling(self):
+        """Verify near-linear scaling across input sizes."""
+        import time
+
+        times = []
+        for n in [1000, 10000, 50000]:
+            message = "/a" * n
+            t0 = time.perf_counter()
+            sanitize_message(message)
+            times.append(time.perf_counter() - t0)
+
+        ratio = times[-1] / max(times[0], 1e-9)
+        assert ratio < 100, (
+            f"50k/1k time ratio is {ratio:.0f}x (expected < 100x for linear)"
+        )
+
+    def test_path_redaction_still_works(self):
+        """Legitimate paths are still redacted after the fix."""
+        assert "<path>" in sanitize_message("Error in /app/server.py")
+        assert "<path>" in sanitize_message("at /workspace/vllm/engine.py")
+        assert "<path>" in sanitize_message(
+            "error at /usr/lib/python3.12/dist-packages/vllm/core.py"
+        )

--- a/vllm/entrypoints/serve/utils/api_utils.py
+++ b/vllm/entrypoints/serve/utils/api_utils.py
@@ -316,7 +316,8 @@ def sanitize_message(message: str) -> str:
     message = re.sub(
         r"/(?:home|usr|opt|var|tmp|root|lib|mnt|srv)(?:/[\w.\-]+)+", "<path>", message
     )
-    message = re.sub(r"(?:/[\w\-]+)+/[\w\-]+\.\w+", "<path>", message)
+    if "." in message:
+        message = re.sub(r"(?>/[\w\-]+)+/[\w\-]+\.\w+", "<path>", message)
     return message.strip()
 
 


### PR DESCRIPTION
## Summary

- Fix CWE-1333 regex denial-of-service in `sanitize_message()` where a 100KB slash-delimited input (`"/a" * 50000`) could keep an API worker busy for 3+ seconds per rejected request.
- Add a dot-character pre-check to skip the generic path regex entirely when no filename extension is possible, and use an atomic group `(?>...)` to prevent backtracking within repeated slash-segments for messages that do contain dots.
- Addresses GHSA-f2g9-pmwr-xwc7.

## Test plan

- [x] `pytest tests/entrypoints/serve/utils/test_api_utils.py -v` — 22 tests pass (4 new ReDoS regression tests)
- [x] `pytest tests/entrypoints/serve/utils/test_error_sanitization.py -v` — 9 tests pass
- [x] `pre-commit run --files <changed files>` — all hooks pass
- [x] Reproduced advisory PoC shape (`"/a" * 50000`): completes in <0.1ms after fix (was 3+ second hang)
- [x] Verified legitimate path redaction still works (`/app/server.py`, `/usr/lib/...` etc.)


Made with [Cursor](https://cursor.com)