### PR TITLE
[Bugfix][MiniCPM-V] Fix AssertionError in get_dummy_mm_data when passing VideoDummyOptions to _get_dummy_images

### DIFF
--- a/vllm/model_executor/models/minicpmv.py
+++ b/vllm/model_executor/models/minicpmv.py
@@ -44,7 +44,11 @@ from transformers.dynamic_module_utils import (
 from typing_extensions import TypeVar
 
 from vllm.config import VllmConfig
-from vllm.config.multimodal import BaseDummyOptions
+from vllm.config.multimodal import (
+    BaseDummyOptions,
+    ImageDummyOptions,
+    VideoDummyOptions,
+)
 from vllm.inputs import ModalityData, MultiModalDataDict
 from vllm.model_executor.layers.quantization import QuantizationConfig
 from vllm.model_executor.layers.resampler import (
@@ -811,6 +815,18 @@ class MiniCPMVDummyInputsBuilder(BaseDummyInputsBuilder[_I]):
         image_overrides = mm_options.get("image")
         video_overrides = mm_options.get("video")
 
+        # Convert video overrides to image overrides for per-frame image generation,
+        # and apply num_frames override to num_video_frames.
+        video_frame_overrides: ImageDummyOptions | None = None
+        if isinstance(video_overrides, VideoDummyOptions):
+            if video_overrides.num_frames:
+                num_video_frames = min(num_video_frames, video_overrides.num_frames)
+            if video_overrides.width or video_overrides.height:
+                video_frame_overrides = ImageDummyOptions(
+                    width=video_overrides.width,
+                    height=video_overrides.height,
+                )
+
         return {
             "image": self._get_dummy_images(
                 width=image_width,
@@ -823,7 +839,7 @@ class MiniCPMVDummyInputsBuilder(BaseDummyInputsBuilder[_I]):
                     width=video_width,
                     height=video_height,
                     num_images=num_video_frames,
-                    overrides=video_overrides,
+                    overrides=video_frame_overrides,
                 )
             ]
             * num_videos,


### PR DESCRIPTION
**Issue**: pytest tests/lora/test_minicpmv_tp.py::test_minicpmv_lora raises AssertionError on non-CUDA platforms (e.g., XPU).
**Root Cause**:
Commit 9a276d6375 added a runtime assertion to _get_dummy_images in dummy_inputs.py:
assert overrides is None or isinstance(overrides, ImageDummyOptions)
However, MiniCPMVDummyInputsBuilder.get_dummy_mm_data in minicpmv.py had always been passing video_overrides (type VideoDummyOptions) directly to _get_dummy_images when constructing per-frame dummy images for video. This type mismatch was silently ignored before the assertion was introduced.
**Why upstream CI missed it**: test_minicpmv_lora is decorated with @pytest.mark.skipif(current_platform.is_cuda_alike(), ...), so it is skipped entirely on CUDA CI.
**Fix**: In minicpmv.py, convert VideoDummyOptions before passing to _get_dummy_images:
- Apply num_frames override to num_video_frames
- Convert width/height into an ImageDummyOptions instance