### PR TITLE
[CI/Build][CPU] Shrink triton-cpu-build layer by dropping build artifacts

### DIFF
--- a/docker/Dockerfile.cpu
+++ b/docker/Dockerfile.cpu
@@ -252,6 +252,7 @@ RUN mkdir dist
 RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=cache,target=/root/.cache/ccache \
     --mount=type=cache,target=/vllm-workspace/.deps,sharing=locked \
+    --mount=type=cache,target=/root/.triton \
     --mount=type=secret,id=aws-credentials,target=/root/.aws/credentials,required=false \
     if [ "$TARGETARCH" = "amd64" ] || [ "$VLLM_CPU_X86" != "0" ]; then \
         git clone --recurse-submodules "https://github.com/triton-lang/triton-cpu.git"; \
@@ -264,6 +265,8 @@ RUN --mount=type=cache,target=/root/.cache/uv \
         fi; \
         uv build --wheel --out-dir=../dist; \
         if [ "$USE_SCCACHE" = "1" ]; then sccache --show-stats; fi; \
+        cd ..; \
+        rm -rf triton-cpu; \
     fi
 
 ######################### TEST DEPS #########################


### PR DESCRIPTION
## Summary
- The `vllm-triton-cpu-build` stage in `docker/Dockerfile.cpu` clones and builds `triton-lang/triton-cpu`, but only the resulting wheel is needed by later stages/the final image.
- The cloned `triton-cpu` source/build tree and Triton's downloaded LLVM/MLIR toolchain (under `/root/.triton`) were being retained in the final layer, growing the stage to 3.46GB.
- This PR removes the `triton-cpu` source tree after the wheel is built, and moves `/root/.triton` into a cache mount so it never lands in the image layer (while still persisting across builds for faster rebuilds).
- As a side effect, this also addresses why this stage in CI (e.g. https://buildkite.com/vllm/ci/builds/83692) can look "not cached": BuildKit's remote cache import is lazy — a cached step's actual layer blobs are still pulled on demand by downstream stages that bind to it, so a large cached layer can still take a long time to materialize even though the step itself reports `CACHED`.

## Test plan
- [x] `docker build --target vllm-triton-cpu-build -f docker/Dockerfile.cpu .` on both base branch and this branch; compared final stage image sizes via `docker history`/`docker save`: **3.46GB → 1.44GB**.
- [x] `docker run --rm <image> ls -la /vllm-workspace/dist` on the new image: wheel is present and unchanged; `triton-cpu` source dir and `/root/.triton` are both absent from the layer.
- [x] Confirmed via `git diff` that no other stage is touched.