### PR TITLE
Enhance engine snapshot management and API lifecycle

### DIFF
--- a/docs/features/sleep_mode.md
+++ b/docs/features/sleep_mode.md
@@ -107,10 +107,39 @@ curl -X POST 'http://localhost:8000/collective_rpc' -H 'Content-Type: applicatio
 curl -X POST 'http://localhost:8000/wake_up?tags=kv_cache'
 ```
 
+#### Engine snapshots (level 3)
+
+Level 3 uses a launcher-managed EngineCore checkpoint so the server process can
+hibernate and wake without a cold engine restart. It is an experimental,
+development-only path and requires the Python frontend, one API server, a
+single-node `UniProcExecutor`, and all parallel sizes set to 1. Enabling the
+flag without `VLLM_SERVER_DEV_MODE=1` fails before engine startup. The
+`criu` and `cuda-checkpoint` executables must be available on `PATH` or in the
+SCR bundle paths used by the vLLM development image. CRIU also needs the host
+permissions required to checkpoint the EngineCore process.
+
+```bash
+VLLM_SERVER_DEV_MODE=1 vllm serve Qwen/Qwen3-0.6B \
+  --enable-engine-snapshot \
+  --enable-sleep-mode \
+  --engine-snapshot-provider=criu_cuda \
+  --engine-snapshot-resource-policy=l2_prepared \
+  --engine-snapshot-dir=/snapshots \
+  --port 8000
+```
+
+Use `POST /sleep?level=3&mode=wait` to capture the EngineCore and
+`POST /wake_up` to restore it. `GET /snapshot/status` reports the checkpoint
+state. The snapshot directory contains process-image and model/runtime state;
+keep it on a local, access-controlled filesystem and do not expose these
+development endpoints on a production network.
+
 #### HTTP endpoints
 
 - `POST /sleep?level=1` — Put the model to sleep (`level=1`).
+- `POST /sleep?level=3&mode=wait` — Capture an EngineCore snapshot (experimental).
 - `POST /wake_up` — Wake up the model. Supports optional `tags` query parameters for partial wake-up (e.g., `?tags=weights`).
+- `GET /snapshot/status` — Report the EngineCore snapshot state.
 - `POST /collective_rpc` — Perform a collective remote procedure call (RPC).
 - `GET /is_sleeping` — Check if the model is sleeping.
 

--- a/docs/features/sleep_mode.md
+++ b/docs/features/sleep_mode.md
@@ -123,10 +123,16 @@ VLLM_SERVER_DEV_MODE=1 vllm serve Qwen/Qwen3-0.6B \
   --enable-engine-snapshot \
   --enable-sleep-mode \
   --engine-snapshot-provider=criu_cuda \
-  --engine-snapshot-resource-policy=l2_prepared \
+  --engine-snapshot-resource-policy=minimized \
   --engine-snapshot-dir=/snapshots \
   --port 8000
 ```
+
+Engine snapshots expose two resource policies. The default `full` policy keeps
+weights, KV cache, and runtime state in the CUDA process image. The `minimized`
+policy removes weights and KV cache before capture, then reloads the weights
+from the configured model files and recreates the KV cache after restore.
+Intermediate resource combinations are not user-configurable.
 
 Use `POST /sleep?level=3&mode=wait` to capture the EngineCore and
 `POST /wake_up` to restore it. `GET /snapshot/status` reports the checkpoint

--- a/docs/usage/security.md
+++ b/docs/usage/security.md
@@ -230,6 +230,7 @@ These endpoints are **only available when the environment variable `VLLM_SERVER_
 - `/sleep` - Put engine to sleep (causes denial of service)
 - `/wake_up` - Wake engine from sleep
 - `/is_sleeping` - Check if engine is sleeping
+- `/snapshot/status` - Inspect EngineCore snapshot state
 - `/collective_rpc` - Execute arbitrary RPC methods on the engine (extremely dangerous)
 
 **Profiler endpoints (only when profiling is enabled via `--profiler-config`):**

--- a/tests/entrypoints/launchers/test_cli_args.py
+++ b/tests/entrypoints/launchers/test_cli_args.py
@@ -345,19 +345,15 @@ def test_engine_snapshot_resource_policy(serve_parser):
     assert args.engine_snapshot_resource_policy == "full"
 
     args = serve_parser.parse_args(
-        args=["--engine-snapshot-resource-policy", "discard_kv"]
+        args=["--engine-snapshot-resource-policy", "minimized"]
     )
-    assert args.engine_snapshot_resource_policy == "discard_kv"
+    assert args.engine_snapshot_resource_policy == "minimized"
 
-    args = serve_parser.parse_args(
-        args=["--engine-snapshot-resource-policy", "l2_prepared"]
-    )
-    assert args.engine_snapshot_resource_policy == "l2_prepared"
-
-    args = serve_parser.parse_args(
-        args=["--engine-snapshot-resource-policy", "l1_prepared"]
-    )
-    assert args.engine_snapshot_resource_policy == "l1_prepared"
+    for unsupported in ("discard_kv", "host_backup", "reload_weights"):
+        with pytest.raises(SystemExit):
+            serve_parser.parse_args(
+                args=["--engine-snapshot-resource-policy", unsupported]
+            )
 
     with pytest.raises(SystemExit):
         serve_parser.parse_args(

--- a/tests/entrypoints/launchers/test_cli_args.py
+++ b/tests/entrypoints/launchers/test_cli_args.py
@@ -201,6 +201,14 @@ def test_chat_template_validation_for_happy_paths(serve_parser):
     validate_parsed_serve_args(args)
 
 
+def test_engine_snapshot_requires_dev_mode(serve_parser, monkeypatch):
+    monkeypatch.setattr("vllm.envs.VLLM_SERVER_DEV_MODE", False)
+    args = serve_parser.parse_args(args=["--enable-engine-snapshot"])
+
+    with pytest.raises(ValueError, match="VLLM_SERVER_DEV_MODE=1"):
+        validate_parsed_serve_args(args)
+
+
 def test_chat_template_validation_for_sad_paths(serve_parser):
     """Ensure validation fails if the chat template doesn't exist"""
     args = serve_parser.parse_args(args=["--chat-template", "does/not/exist"])
@@ -329,6 +337,54 @@ def test_default_chat_template_kwargs_default_none(serve_parser):
     """Ensure default_chat_template_kwargs defaults to None"""
     args = serve_parser.parse_args(args=[])
     assert args.default_chat_template_kwargs is None
+
+
+def test_engine_snapshot_resource_policy(serve_parser):
+    args = serve_parser.parse_args(args=[])
+    assert args.engine_snapshot_provider == "criu_cuda"
+    assert args.engine_snapshot_resource_policy == "full"
+
+    args = serve_parser.parse_args(
+        args=["--engine-snapshot-resource-policy", "discard_kv"]
+    )
+    assert args.engine_snapshot_resource_policy == "discard_kv"
+
+    args = serve_parser.parse_args(
+        args=["--engine-snapshot-resource-policy", "l2_prepared"]
+    )
+    assert args.engine_snapshot_resource_policy == "l2_prepared"
+
+    args = serve_parser.parse_args(
+        args=["--engine-snapshot-resource-policy", "l1_prepared"]
+    )
+    assert args.engine_snapshot_resource_policy == "l1_prepared"
+
+    with pytest.raises(SystemExit):
+        serve_parser.parse_args(
+            args=["--engine-snapshot-resource-policy", "unsupported"]
+        )
+
+
+def test_engine_snapshot_persistence(serve_parser):
+    args = serve_parser.parse_args(args=[])
+    assert args.engine_snapshot_persistence == "durable"
+
+    args = serve_parser.parse_args(args=["--engine-snapshot-persistence", "page_cache"])
+    assert args.engine_snapshot_persistence == "page_cache"
+
+    with pytest.raises(SystemExit):
+        serve_parser.parse_args(args=["--engine-snapshot-persistence", "unsupported"])
+
+
+def test_engine_snapshot_integrity(serve_parser):
+    args = serve_parser.parse_args(args=[])
+    assert args.engine_snapshot_integrity == "optimistic"
+
+    args = serve_parser.parse_args(args=["--engine-snapshot-integrity", "strict"])
+    assert args.engine_snapshot_integrity == "strict"
+
+    with pytest.raises(SystemExit):
+        serve_parser.parse_args(args=["--engine-snapshot-integrity", "unsupported"])
 
 
 def test_default_chat_template_kwargs_invalid_json(serve_parser):

--- a/tests/snapshot/conftest.py
+++ b/tests/snapshot/conftest.py
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import signal
+import subprocess
+import sys
+from collections.abc import Iterator
+from contextlib import suppress
+
+import pytest
+
+
+@pytest.fixture
+def sleeping_child() -> Iterator[int]:
+    child = subprocess.Popen(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import signal; "
+                "signal.signal(signal.SIGUSR2, signal.SIG_IGN); "
+                "print('ready', flush=True); "
+                "signal.pause()"
+            ),
+        ],
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    assert child.stdout is not None
+    assert child.stdout.readline() == "ready\n"
+    child.stdout.close()
+    try:
+        yield child.pid
+    finally:
+        with suppress(ProcessLookupError):
+            child.send_signal(signal.SIGKILL)
+        child.wait(timeout=5)

--- a/tests/snapshot/test_allocator.py
+++ b/tests/snapshot/test_allocator.py
@@ -1,0 +1,208 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from typing import Any
+
+import pytest
+
+
+def test_pluggable_allocator_requires_loaded_library(monkeypatch):
+    import vllm.device_allocator.cumem as cumem
+
+    monkeypatch.setattr(cumem, "init_module", lambda *args: None)
+    monkeypatch.setattr(cumem, "lib_name", None)
+
+    with pytest.raises(RuntimeError, match="library is not loaded"):
+        cumem.get_pluggable_allocator(
+            lambda handle: None, lambda ptr: (0, 0, 0, 0)
+        )
+
+
+def test_selective_discard_preserves_other_allocations(monkeypatch):
+    import vllm.device_allocator.cumem as cumem
+    from vllm.device_allocator import AllocationData
+    from vllm.device_allocator.cumem import CuMemAllocator
+
+    allocator = CuMemAllocator()
+    weights = (0, 1024, 100, 1)
+    kv_cache = (0, 2048, 200, 2)
+    allocator.pointer_to_data = {
+        100: AllocationData(weights, "weights"),
+        200: AllocationData(kv_cache, "kv_cache"),
+    }
+    discarded: list[Any] = []
+    monkeypatch.setattr(cumem, "unmap_and_release", discarded.append)
+    monkeypatch.setattr(cumem.torch.accelerator, "synchronize", lambda *a: None)
+    monkeypatch.setattr(cumem.gc, "collect", lambda: None)
+    monkeypatch.setattr(cumem.torch.cuda, "empty_cache", lambda: None)
+
+    allocator.discard("kv_cache")
+
+    assert discarded == [kv_cache]
+    assert not allocator.pointer_to_data[100].is_asleep
+    assert allocator.pointer_to_data[200].is_asleep
+
+
+def test_selective_discard_skips_missing_and_asleep_tags(monkeypatch):
+    import vllm.device_allocator.cumem as cumem
+    from vllm.device_allocator import AllocationData
+    from vllm.device_allocator.cumem import CuMemAllocator
+
+    allocator = CuMemAllocator()
+    weights = AllocationData((0, 1024, 100, 1), "weights")
+    kv_cache = AllocationData((0, 2048, 200, 2), "kv_cache", is_asleep=True)
+    allocator.pointer_to_data = {100: weights, 200: kv_cache}
+    discarded: list[Any] = []
+    monkeypatch.setattr(cumem, "unmap_and_release", discarded.append)
+    monkeypatch.setattr(cumem.torch.accelerator, "synchronize", lambda *a: None)
+
+    allocator.discard(("weights", "kv_cache", "missing"))
+
+    assert discarded == [weights.handle]
+    assert allocator.pointer_to_data[100].is_asleep
+    assert allocator.pointer_to_data[200].is_asleep
+
+
+def test_selective_wake_maps_only_sleeping_allocations(monkeypatch):
+    import vllm.device_allocator.cumem as cumem
+    from vllm.device_allocator import AllocationData
+    from vllm.device_allocator.cumem import CuMemAllocator
+
+    allocator = CuMemAllocator()
+    weights = AllocationData((0, 1024, 100, 1), "weights")
+    kv_cache = AllocationData((0, 2048, 200, 2), "kv_cache", is_asleep=True)
+    allocator.pointer_to_data = {100: weights, 200: kv_cache}
+    mapped: list[Any] = []
+    monkeypatch.setattr(cumem, "create_and_map", mapped.append)
+    monkeypatch.setattr(cumem.gc, "collect", lambda: None)
+    monkeypatch.setattr(cumem.torch.accelerator, "empty_cache", lambda: None)
+
+    allocator.wake_up(["weights", "kv_cache"])
+
+    assert mapped == [kv_cache.handle]
+    assert not kv_cache.is_asleep
+
+
+def test_wake_retries_host_copy_without_remapping(monkeypatch):
+    import vllm.device_allocator.cumem as cumem
+    from vllm.device_allocator import AllocationData
+    from vllm.device_allocator.cumem import CuMemAllocator
+
+    class Backup:
+        def data_ptr(self):
+            return 300
+
+        def numel(self):
+            return 1024
+
+        def element_size(self):
+            return 1
+
+    allocator = CuMemAllocator()
+    backup = Backup()
+    weights = AllocationData(
+        (0, 1024, 100, 1),
+        "weights",
+        cpu_backup_tensor=backup,
+        is_asleep=True,
+    )
+    allocator.pointer_to_data = {100: weights}
+    mapped: list[Any] = []
+    copy_attempts = 0
+
+    def copy(*args):
+        nonlocal copy_attempts
+        copy_attempts += 1
+        if copy_attempts == 1:
+            raise RuntimeError("copy failed")
+
+    monkeypatch.setattr(cumem, "create_and_map", mapped.append)
+    monkeypatch.setattr(cumem.libcudart, "cudaMemcpy", copy)
+    monkeypatch.setattr(cumem.gc, "collect", lambda: None)
+    monkeypatch.setattr(cumem.torch.accelerator, "empty_cache", lambda: None)
+
+    with pytest.raises(RuntimeError, match="copy failed"):
+        allocator.wake_up(["weights"])
+
+    assert mapped == [weights.handle]
+    assert not weights.is_asleep
+    assert weights.cpu_backup_tensor is backup
+
+    allocator.wake_up(["weights"])
+
+    assert mapped == [weights.handle]
+    assert copy_attempts == 2
+    assert weights.cpu_backup_tensor is None
+
+
+def test_sleep_backs_up_only_selected_tags_and_wake_releases_backup(monkeypatch):
+    import vllm.device_allocator.cumem as cumem
+    from vllm.device_allocator import AllocationData
+    from vllm.device_allocator.cumem import CuMemAllocator
+
+    class Backup:
+        def __init__(self, size):
+            self.size = size
+
+        def data_ptr(self):
+            return 300
+
+        def numel(self):
+            return self.size
+
+        def element_size(self):
+            return 1
+
+    allocator = CuMemAllocator()
+    weights = AllocationData((0, 1024, 100, 1), "weights")
+    kv_cache = AllocationData((0, 2048, 200, 2), "kv_cache")
+    allocator.pointer_to_data = {100: weights, 200: kv_cache}
+    unmapped: list[Any] = []
+    mapped: list[Any] = []
+    copies: list[Any] = []
+    monkeypatch.setattr(cumem.torch, "empty", lambda size, **kwargs: Backup(size))
+    monkeypatch.setattr(
+        cumem.libcudart, "cudaMemcpy", lambda *args: copies.append(args)
+    )
+    monkeypatch.setattr(cumem, "unmap_and_release", unmapped.append)
+    monkeypatch.setattr(cumem, "create_and_map", mapped.append)
+    monkeypatch.setattr(cumem.gc, "collect", lambda: None)
+    monkeypatch.setattr(cumem.torch.cuda, "empty_cache", lambda: None)
+    monkeypatch.setattr(cumem.torch.accelerator, "empty_cache", lambda: None)
+
+    allocator.sleep(offload_tags=("weights",))
+
+    assert unmapped == [weights.handle, kv_cache.handle]
+    assert weights.is_asleep and kv_cache.is_asleep
+    assert weights.cpu_backup_tensor is not None
+    assert kv_cache.cpu_backup_tensor is None
+    diagnostics = allocator.allocation_diagnostics()["tags"]
+    assert diagnostics["weights"]["host_backup_bytes"] == 1024
+    assert diagnostics["kv_cache"]["host_backup_bytes"] == 0
+    assert copies == [(300, 100, 1024)]
+
+    allocator.wake_up()
+
+    assert mapped == [weights.handle, kv_cache.handle]
+    assert not weights.is_asleep and not kv_cache.is_asleep
+    assert weights.cpu_backup_tensor is None
+    assert copies == [(300, 100, 1024), (100, 300, 1024)]
+
+
+def test_allocator_diagnostics_distinguishes_va_and_mapping_state():
+    from vllm.device_allocator import AllocationData
+    from vllm.device_allocator.cumem import CuMemAllocator
+
+    allocator = CuMemAllocator()
+    allocator.pointer_to_data = {
+        100: AllocationData((0, 1024, 100, 1), "weights"),
+        200: AllocationData((0, 2048, 200, 2), "kv_cache", is_asleep=True),
+    }
+
+    diagnostics = allocator.allocation_diagnostics()["tags"]
+
+    assert diagnostics["weights"]["virtual_addresses"] == [100]
+    assert diagnostics["weights"]["mapped_virtual_addresses"] == [100]
+    assert diagnostics["kv_cache"]["logical_bytes"] == 2048
+    assert diagnostics["kv_cache"]["virtual_addresses"] == [200]
+    assert diagnostics["kv_cache"]["mapped_virtual_addresses"] == []

--- a/tests/snapshot/test_api_router.py
+++ b/tests/snapshot/test_api_router.py
@@ -1,0 +1,123 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import asyncio
+import json
+from types import SimpleNamespace
+from typing import cast
+
+import pytest
+from fastapi import HTTPException, Request
+
+from vllm.entrypoints.serve.dev.sleep.api_router import (
+    _run_exclusive_snapshot_operation,
+    _run_snapshot_lifecycle,
+    is_sleeping,
+)
+from vllm.entrypoints.serve.instrumentator.health import ready
+from vllm.snapshot.middleware import EngineSnapshotGate
+
+
+def test_snapshot_lifecycle_finishes_before_request_cancellation():
+    async def run():
+        started = asyncio.Event()
+        release = asyncio.Event()
+        completed = False
+
+        async def operation():
+            nonlocal completed
+            started.set()
+            await release.wait()
+            completed = True
+            return "done"
+
+        task = asyncio.create_task(_run_snapshot_lifecycle(operation()))
+        await started.wait()
+        task.cancel()
+        await asyncio.sleep(0)
+        assert not task.done()
+        release.set()
+
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert completed
+
+    asyncio.run(run())
+
+
+def test_snapshot_operations_reject_concurrent_sleep_or_wake():
+    async def run():
+        gate = EngineSnapshotGate()
+        started = asyncio.Event()
+        release = asyncio.Event()
+        request = cast(
+            Request,
+            SimpleNamespace(
+                app=SimpleNamespace(state=SimpleNamespace(engine_snapshot_gate=gate))
+            ),
+        )
+
+        async def operation():
+            started.set()
+            await release.wait()
+
+        first = asyncio.create_task(
+            _run_exclusive_snapshot_operation(request, operation)
+        )
+        await started.wait()
+
+        with pytest.raises(HTTPException) as exc_info:
+            await _run_exclusive_snapshot_operation(request, operation)
+        assert exc_info.value.status_code == 409
+
+        release.set()
+        await first
+
+    asyncio.run(run())
+
+
+def test_ready_is_healthy_for_render_only_server():
+    async def run():
+        request = cast(
+            Request,
+            SimpleNamespace(
+                app=SimpleNamespace(state=SimpleNamespace(engine_client=None))
+            ),
+        )
+        response = await ready(request)
+        assert response.status_code == 200
+
+    asyncio.run(run())
+
+
+def _snapshot_status_request(state: str) -> Request:
+    client = SimpleNamespace(request=lambda command, payload=None: {"state": state})
+    return cast(
+        Request,
+        SimpleNamespace(
+            app=SimpleNamespace(state=SimpleNamespace(engine_snapshot_client=client))
+        ),
+    )
+
+
+def test_is_sleeping_reports_failed_state_as_not_sleeping():
+    async def run():
+        response = await is_sleeping(_snapshot_status_request("FAILED"))
+        assert json.loads(response.body) == {
+            "is_sleeping": False,
+            "snapshot_state": "FAILED",
+        }
+
+    asyncio.run(run())
+
+
+def test_is_sleeping_reports_hibernated_state_as_level3_sleep():
+    async def run():
+        response = await is_sleeping(_snapshot_status_request("HIBERNATED"))
+        assert json.loads(response.body) == {
+            "is_sleeping": True,
+            "level": 3,
+            "snapshot_state": "HIBERNATED",
+        }
+
+    asyncio.run(run())

--- a/tests/snapshot/test_manager.py
+++ b/tests/snapshot/test_manager.py
@@ -1,0 +1,509 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import json
+import os
+import stat
+import time
+from typing import Any, cast
+
+import pytest
+
+from vllm.snapshot.manager import EngineSnapshotManager, SnapshotState
+from vllm.snapshot.protocol import SnapshotControlClient, SnapshotControlError
+from vllm.snapshot.providers import CriuCudaSnapshotProvider, FakeSnapshotProvider
+
+
+def _capture_snapshot(client: SnapshotControlClient) -> dict[str, Any]:
+    ticket = client.request("prepare_capture")["ticket"]
+    marker = {
+        "pid": ticket["root_pid"],
+        "nonce": ticket["nonce"],
+        "generation": ticket["generation"],
+        "snapshot_id": ticket["snapshot_id"],
+        "config_hash": ticket["config_hash"],
+        "state": "detached",
+    }
+    with open(ticket["marker_path"], "w") as marker_file:
+        json.dump(marker, marker_file)
+    return client.request("capture")
+
+
+def test_fake_provider_round_trip(tmp_path, sleeping_child):
+    manager = EngineSnapshotManager(
+        str(tmp_path / "control.sock"),
+        str(tmp_path / "snapshots"),
+        sleeping_child,
+        config_hash="test-config",
+    )
+    manager.start()
+    client = SnapshotControlClient(str(tmp_path / "control.sock"))
+    try:
+        initial = client.request("status")
+        assert initial["state"] == SnapshotState.READY
+        captured = _capture_snapshot(client)
+        assert captured["state"] == SnapshotState.HIBERNATED
+        manifest = captured["manifest"]
+        assert manifest["format_version"] == 2
+        assert manifest["resource_policy"] == {
+            "weights": "cuda_image",
+            "kv": "cuda_image",
+            "runtime": "cuda_image",
+        }
+        assert manifest["persistence"] == "durable"
+        assert manifest["integrity"] == "optimistic"
+        assert captured["manager_timings"]["total_seconds"] >= 0
+        assert captured["manager_timings"]["artifact_inventory_seconds"] >= 0
+        assert manifest["artifacts"]["files"]
+        assert "sha256" not in manifest["artifacts"]["files"][0]
+        snapshot_dir = tmp_path / "snapshots" / captured["snapshot_id"]
+        assert (snapshot_dir / "manifest.sha256").is_file()
+        assert os.waitpid(sleeping_child, os.WNOHANG | os.WUNTRACED)[1] != 0
+        restored = client.request("restore")
+        assert restored["state"] == SnapshotState.ATTACHING
+        assert restored["manager_timings"]["total_seconds"] >= 0
+        assert restored["manager_timings"]["artifact_validation_seconds"] >= 0
+        restored = client.request(
+            "confirm_attach",
+            {
+                field: restored["ticket"][field]
+                for field in (
+                    "nonce",
+                    "generation",
+                    "snapshot_id",
+                    "config_hash",
+                    "root_pid",
+                )
+            },
+        )
+        assert restored["state"] == SnapshotState.VERIFYING
+        restored = client.request("complete_restore")
+        assert restored["state"] == SnapshotState.READY
+        assert restored["generation"] == 1
+    finally:
+        manager.close()
+
+
+def test_page_cache_snapshot_skips_fsync(tmp_path, sleeping_child, monkeypatch):
+    manager = EngineSnapshotManager(
+        str(tmp_path / "control.sock"),
+        str(tmp_path / "snapshots"),
+        sleeping_child,
+        config_hash="test-config",
+        persistence="page_cache",
+    )
+    manager.start()
+    client = SnapshotControlClient(str(tmp_path / "control.sock"))
+    fsync_calls: list[int] = []
+    monkeypatch.setattr(os, "fsync", fsync_calls.append)
+    try:
+        captured = _capture_snapshot(client)
+
+        assert captured["persistence"] == "page_cache"
+        assert captured["manifest"]["persistence"] == "page_cache"
+        assert captured["manager_timings"]["fsync_seconds"] >= 0
+        assert fsync_calls == []
+        snapshot_dir = tmp_path / "snapshots" / captured["snapshot_id"]
+        assert (snapshot_dir / "manifest.sha256").is_file()
+
+        restored = client.request("restore")
+        assert restored["state"] == SnapshotState.ATTACHING
+        assert fsync_calls == []
+    finally:
+        manager.close()
+
+
+def test_durable_snapshot_syncs_nested_directories(
+    tmp_path, sleeping_child, monkeypatch
+):
+    manager = EngineSnapshotManager(
+        str(tmp_path / "control.sock"),
+        str(tmp_path / "snapshots"),
+        sleeping_child,
+        config_hash="test-config",
+    )
+    manager.start()
+    nested = tmp_path / "tree" / "images" / "nested"
+    nested.mkdir(parents=True)
+    (nested / "image").write_bytes(b"image")
+    synced_paths: list[Any] = []
+    original_sync_directory = manager._sync_directory
+
+    def record_sync(path):
+        synced_paths.append(path)
+        original_sync_directory(path)
+
+    monkeypatch.setattr(manager, "_sync_directory", record_sync)
+    try:
+        manager._sync_tree(tmp_path / "tree")
+    finally:
+        manager.close()
+
+    assert synced_paths == [nested, nested.parent, tmp_path / "tree"]
+
+
+def test_rejects_invalid_transition(tmp_path, sleeping_child):
+    manager = EngineSnapshotManager(
+        str(tmp_path / "control.sock"),
+        str(tmp_path / "snapshots"),
+        sleeping_child,
+    )
+    manager.start()
+    client = SnapshotControlClient(str(tmp_path / "control.sock"))
+    try:
+        with pytest.raises(SnapshotControlError, match="requires HIBERNATED"):
+            client.request("restore")
+    finally:
+        manager.close()
+
+
+def test_prepare_capture_keeps_ready_state_when_root_is_dead(tmp_path, monkeypatch):
+    manager = EngineSnapshotManager(
+        str(tmp_path / "control.sock"),
+        str(tmp_path / "snapshots"),
+        123,
+    )
+    monkeypatch.setattr(manager, "_pid_alive", lambda pid: False)
+
+    with pytest.raises(RuntimeError, match="EngineCore root is not alive"):
+        manager.prepare_capture()
+
+    assert manager.snapshot_status()["state"] == SnapshotState.READY
+    assert manager.snapshot_status()["operation_started_at"] is None
+
+
+@pytest.mark.parametrize(
+    "state", (SnapshotState.DRAINING, SnapshotState.ATTACHING, SnapshotState.VERIFYING)
+)
+def test_fail_capture_discards_engine_from_rollback_states(
+    tmp_path, sleeping_child, state
+):
+    manager = EngineSnapshotManager(
+        str(tmp_path / "control.sock"),
+        str(tmp_path / "snapshots"),
+        sleeping_child,
+    )
+    manager.start()
+    client = SnapshotControlClient(str(tmp_path / "control.sock"))
+    try:
+        client.request("prepare_capture")
+        manager.status.state = state
+
+        failed = client.request("fail_capture", {"error": "rollback failed"})
+
+        assert failed["state"] == SnapshotState.FAILED
+        assert failed["root_pid"] is None
+        assert failed["last_error"] == "rollback failed"
+        assert not manager._pid_alive(sleeping_child)
+    finally:
+        manager.close()
+
+
+def test_fail_capture_waits_for_provider_process_exit(tmp_path, monkeypatch):
+    manager = EngineSnapshotManager(
+        str(tmp_path / "control.sock"),
+        str(tmp_path / "snapshots"),
+        123,
+    )
+    manager.status.state = SnapshotState.DRAINING
+    alive = iter((True, True, False))
+    events: list[Any] = []
+    monkeypatch.setattr(manager, "_pid_alive", lambda pid: next(alive))
+    monkeypatch.setattr(
+        manager.provider,
+        "discard_restored",
+        lambda pid: events.append(("discard", pid)),
+    )
+    monkeypatch.setattr(
+        time, "sleep", lambda seconds: events.append(("sleep", seconds))
+    )
+
+    failed = manager.fail_capture("rollback failed")
+
+    assert failed["state"] == SnapshotState.FAILED
+    assert failed["root_pid"] is None
+    assert events == [("discard", 123), ("sleep", 0.05)]
+
+
+def test_fail_capture_records_provider_cleanup_failure(tmp_path, monkeypatch):
+    manager = EngineSnapshotManager(
+        str(tmp_path / "control.sock"),
+        str(tmp_path / "snapshots"),
+        123,
+    )
+    manager.status.state = SnapshotState.DRAINING
+    monkeypatch.setattr(manager, "_pid_alive", lambda pid: True)
+
+    def fail_cleanup(pid):
+        raise RuntimeError("cleanup failed")
+
+    monkeypatch.setattr(manager.provider, "discard_restored", fail_cleanup)
+
+    failed = manager.fail_capture("rollback failed")
+
+    assert failed["state"] == SnapshotState.FAILED
+    assert failed["root_pid"] == 123
+    assert failed["last_error"] == (
+        "rollback failed; Engine cleanup failed: cleanup failed"
+    )
+
+
+def test_start_rejects_nonempty_snapshot_directory(tmp_path, sleeping_child):
+    snapshot_root = tmp_path / "snapshots"
+    snapshot_root.mkdir()
+    (snapshot_root / "existing").write_text("preserve me")
+    manager = EngineSnapshotManager(
+        str(tmp_path / "control.sock"),
+        str(snapshot_root),
+        sleeping_child,
+    )
+
+    with pytest.raises(RuntimeError, match="not empty"):
+        manager.start()
+
+    assert (snapshot_root / "existing").read_text() == "preserve me"
+
+
+def test_start_restricts_snapshot_directory_permissions(tmp_path, sleeping_child):
+    snapshot_root = tmp_path / "snapshots"
+    snapshot_root.mkdir(mode=0o755)
+    manager = EngineSnapshotManager(
+        str(tmp_path / "control.sock"),
+        str(snapshot_root),
+        sleeping_child,
+    )
+
+    manager.start()
+    try:
+        assert stat.S_IMODE(snapshot_root.stat().st_mode) == 0o700
+    finally:
+        manager.close()
+
+
+def test_manager_reuses_resolved_provider(tmp_path, sleeping_child):
+    provider = FakeSnapshotProvider()
+
+    manager = EngineSnapshotManager(
+        str(tmp_path / "control.sock"),
+        str(tmp_path / "snapshots"),
+        sleeping_child,
+        provider=provider,
+    )
+
+    assert manager.provider is provider
+
+
+def test_resume_signal_reports_exited_process(tmp_path, sleeping_child, monkeypatch):
+    manager = EngineSnapshotManager(
+        str(tmp_path / "control.sock"),
+        str(tmp_path / "snapshots"),
+        sleeping_child,
+    )
+
+    def process_exited(pid, signum):
+        raise ProcessLookupError(pid)
+
+    monkeypatch.setattr(manager, "_pid_alive", lambda pid: True)
+    monkeypatch.setattr(os, "kill", process_exited)
+
+    assert not manager._signal_snapshot_resume(123)
+
+
+def test_snapshot_tree_cleanup_reports_residual_state(tmp_path, monkeypatch):
+    staging = tmp_path / "staging"
+    committed = tmp_path / "committed"
+    staging.mkdir()
+    committed.mkdir()
+
+    def fail_staging_cleanup(path):
+        if path == staging:
+            raise OSError("cleanup failed")
+        path.rmdir()
+
+    monkeypatch.setattr("vllm.snapshot.manager.shutil.rmtree", fail_staging_cleanup)
+
+    error = EngineSnapshotManager._remove_snapshot_trees(staging, committed)
+
+    assert error is not None
+    assert str(staging) in str(error)
+    assert staging.exists()
+    assert not committed.exists()
+
+
+def test_control_server_rejects_connection_at_capacity(tmp_path, sleeping_child):
+    manager = EngineSnapshotManager(
+        str(tmp_path / "control.sock"),
+        str(tmp_path / "snapshots"),
+        sleeping_child,
+    )
+
+    class Connection:
+        closed = False
+
+        def close(self):
+            self.closed = True
+
+    connection = Connection()
+
+    class Server:
+        def accept(self):
+            manager._stop.set()
+            return connection, None
+
+    while manager._request_slots.acquire(blocking=False):
+        pass
+    manager._server = cast(Any, Server())
+
+    manager._serve()
+
+    assert connection.closed
+
+
+def test_optimistic_restore_allows_same_size_artifact_change(tmp_path, sleeping_child):
+    manager = EngineSnapshotManager(
+        str(tmp_path / "control.sock"),
+        str(tmp_path / "snapshots"),
+        sleeping_child,
+        config_hash="test-config",
+    )
+    manager.start()
+    client = SnapshotControlClient(str(tmp_path / "control.sock"))
+    try:
+        captured = _capture_snapshot(client)
+        snapshot_dir = tmp_path / "snapshots" / captured["snapshot_id"]
+        artifact = snapshot_dir / "fake.img"
+        artifact.write_bytes(b"x" * artifact.stat().st_size)
+
+        restored = client.request("restore")
+
+        assert restored["state"] == SnapshotState.ATTACHING
+    finally:
+        manager.close()
+
+
+@pytest.mark.parametrize("change", ["add", "remove", "resize", "type"])
+def test_optimistic_restore_rejects_artifact_inventory_change(
+    tmp_path, sleeping_child, change
+):
+    manager = EngineSnapshotManager(
+        str(tmp_path / "control.sock"),
+        str(tmp_path / "snapshots"),
+        sleeping_child,
+        config_hash="test-config",
+    )
+    manager.start()
+    client = SnapshotControlClient(str(tmp_path / "control.sock"))
+    try:
+        captured = _capture_snapshot(client)
+        snapshot_dir = tmp_path / "snapshots" / captured["snapshot_id"]
+        artifact = snapshot_dir / "fake.img"
+        if change == "add":
+            (snapshot_dir / "added.img").write_bytes(b"added")
+        elif change == "remove":
+            artifact.unlink()
+        elif change == "resize":
+            artifact.write_bytes(artifact.read_bytes() + b"x")
+        else:
+            size = artifact.stat().st_size
+            artifact.unlink()
+            target = tmp_path / "same-size-target"
+            target.write_bytes(b"x" * size)
+            artifact.symlink_to(target)
+
+        with pytest.raises(SnapshotControlError, match="artifact inventory mismatch"):
+            client.request("restore")
+    finally:
+        manager.close()
+
+
+def test_strict_restore_rejects_same_size_artifact_change(tmp_path, sleeping_child):
+    manager = EngineSnapshotManager(
+        str(tmp_path / "control.sock"),
+        str(tmp_path / "snapshots"),
+        sleeping_child,
+        config_hash="test-config",
+        integrity="strict",
+    )
+    manager.start()
+    client = SnapshotControlClient(str(tmp_path / "control.sock"))
+    try:
+        captured = _capture_snapshot(client)
+        assert captured["integrity"] == "strict"
+        assert captured["manifest"]["integrity"] == "strict"
+        assert captured["manager_timings"]["artifact_sha256_seconds"] >= 0
+        snapshot_dir = tmp_path / "snapshots" / captured["snapshot_id"]
+        artifact = snapshot_dir / "fake.img"
+        artifact.write_bytes(b"x" * artifact.stat().st_size)
+
+        with pytest.raises(SnapshotControlError, match="artifact inventory mismatch"):
+            client.request("restore")
+    finally:
+        manager.close()
+
+
+def test_configured_artifact_identity_ignores_git_metadata(tmp_path):
+    model = tmp_path / "model"
+    model.mkdir()
+    (model / "config.json").write_text("{}")
+    (model / "model.safetensors").write_bytes(b"weights")
+    git_object = model / ".git" / "lfs" / "objects" / "duplicate"
+    git_object.parent.mkdir(parents=True)
+    git_object.write_bytes(b"weights")
+
+    identity = EngineSnapshotManager._path_identity(model, "optimistic")
+
+    assert [entry["path"] for entry in identity["files"]] == [
+        "config.json",
+        "model.safetensors",
+    ]
+    assert identity["total_bytes"] == 9
+    assert all("sha256" not in entry for entry in identity["files"])
+
+
+def test_optimistic_inventory_skips_file_digest(tmp_path, monkeypatch):
+    (tmp_path / "artifact").write_bytes(b"content")
+
+    def fail_digest(path):
+        raise AssertionError(f"unexpected content digest for {path}")
+
+    monkeypatch.setattr(
+        EngineSnapshotManager, "_file_digest", staticmethod(fail_digest)
+    )
+
+    inventory = EngineSnapshotManager._artifact_inventory(tmp_path, "optimistic")
+
+    assert inventory["total_bytes"] == 7
+    assert "sha256" not in inventory
+
+
+def test_nonretriable_restore_failure_enters_failed(tmp_path, sleeping_child):
+    class NonretriableProvider(CriuCudaSnapshotProvider):
+        def capture(self, root_pid, snapshot_dir):
+            return FakeSnapshotProvider().capture(root_pid, snapshot_dir)
+
+        def restore(self, snapshot_dir):
+            raise RuntimeError("restore failed")
+
+        def runtime_identity(self):
+            return {"provider": "test"}
+
+    manager = EngineSnapshotManager(
+        str(tmp_path / "control.sock"),
+        str(tmp_path / "snapshots"),
+        sleeping_child,
+    )
+    manager.provider = NonretriableProvider("criu", "cuda-checkpoint")
+    manager.compatibility = manager._runtime_compatibility()
+    manager.start()
+    client = SnapshotControlClient(str(tmp_path / "control.sock"))
+    try:
+        captured = _capture_snapshot(client)
+
+        with pytest.raises(SnapshotControlError, match="restore failed"):
+            client.request("restore")
+
+        assert client.request("status")["state"] == SnapshotState.FAILED
+        snapshot_dir = tmp_path / "snapshots" / captured["snapshot_id"]
+        assert (snapshot_dir / "restore-attempt.json").is_file()
+    finally:
+        manager.close()

--- a/tests/snapshot/test_middleware.py
+++ b/tests/snapshot/test_middleware.py
@@ -1,0 +1,115 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import asyncio
+import json
+from typing import cast
+
+from fastapi import Request
+
+from vllm.snapshot.middleware import (
+    EngineSnapshotGate,
+    EngineSnapshotMiddleware,
+    snapshot_control_error_handler,
+)
+from vllm.snapshot.protocol import SnapshotControlError
+
+
+def test_snapshot_control_errors_surface_code_and_conflict_status():
+    request = cast(Request, None)
+    conflict = snapshot_control_error_handler(
+        request, SnapshotControlError("engine is busy", code="busy")
+    )
+    assert conflict.status_code == 409
+    assert json.loads(conflict.body) == {"error": "engine is busy", "code": "busy"}
+
+    internal = snapshot_control_error_handler(
+        request, SnapshotControlError("capture failed")
+    )
+    assert internal.status_code == 500
+    assert json.loads(internal.body) == {
+        "error": "capture failed",
+        "code": "snapshot_error",
+    }
+
+
+def test_gate_closes_without_request_race():
+    async def run():
+        gate = EngineSnapshotGate()
+        assert await gate.enter()
+        assert await gate.close() == 1
+        assert not await gate.enter()
+        await gate.leave()
+        await gate.open()
+        assert await gate.enter()
+        await gate.leave()
+
+    asyncio.run(run())
+
+
+def test_gate_serializes_snapshot_operations():
+    async def run():
+        gate = EngineSnapshotGate()
+        assert await gate.begin_operation()
+        assert not await gate.begin_operation()
+        await gate.end_operation()
+        assert await gate.begin_operation()
+        await gate.end_operation()
+
+    asyncio.run(run())
+
+
+def test_gate_counts_realtime_websocket():
+    async def run():
+        entered = asyncio.Event()
+        release = asyncio.Event()
+
+        async def app(scope, receive, send):
+            entered.set()
+            await release.wait()
+
+        gate = EngineSnapshotGate()
+        middleware = EngineSnapshotMiddleware(app, gate)
+        task = asyncio.create_task(
+            middleware(
+                {"type": "websocket", "path": "/v1/realtime"},
+                None,
+                None,
+            )
+        )
+        await entered.wait()
+        assert await gate.close() == 1
+        release.set()
+        await task
+
+    asyncio.run(run())
+
+
+def test_gate_rejects_new_realtime_websocket_when_closed():
+    async def run():
+        sent = []
+
+        async def app(scope, receive, send):
+            raise AssertionError("closed gate must not call the app")
+
+        async def send(message):
+            sent.append(message)
+
+        gate = EngineSnapshotGate()
+        await gate.close()
+        middleware = EngineSnapshotMiddleware(app, gate)
+        await middleware(
+            {"type": "websocket", "path": "/v1/realtime"},
+            None,
+            send,
+        )
+
+        assert sent == [
+            {
+                "type": "websocket.close",
+                "code": 1013,
+                "reason": "engine unavailable",
+            }
+        ]
+
+    asyncio.run(run())

--- a/tests/snapshot/test_process.py
+++ b/tests/snapshot/test_process.py
@@ -1,0 +1,267 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import json
+import os
+import threading
+import time
+from typing import Any
+
+import pytest
+
+from vllm.v1.engine.utils import CoreEngineProcManager, _AdoptedProcess
+
+
+def test_snapshot_waits_for_liveness_monitor():
+    process = type(
+        "Process",
+        (),
+        {"pid": 123, "is_alive": lambda self: True},
+    )()
+    manager = object.__new__(CoreEngineProcManager)
+    manager.processes = [process]
+    manager._process_lock = threading.Lock()
+    manager._monitor_ready = threading.Event()
+    manager._replacement_event = threading.Event()
+    manager._snapshot_exit_event = threading.Event()
+    manager._expected_exit_pids = set()
+    manager._snapshot_pid = None
+    result: list[int] = []
+
+    thread = threading.Thread(target=lambda: result.append(manager.prepare_snapshot()))
+    thread.start()
+    time.sleep(0.05)
+    assert thread.is_alive()
+    manager._monitor_ready.set()
+    thread.join(timeout=1)
+
+    assert result == [123]
+
+
+def test_liveness_monitor_does_not_mask_unexpected_exit(monkeypatch):
+    import vllm.v1.engine.utils as engine_utils
+
+    joined: list[int] = []
+
+    class Process:
+        def __init__(self, pid, name, sentinel):
+            self.pid = pid
+            self.name = name
+            self.sentinel = sentinel
+            self.exitcode = -1
+
+        def is_alive(self):
+            return True
+
+        def join(self, timeout=None):
+            joined.append(self.pid)
+
+    expected = Process(123, "expected", 1)
+    unexpected = Process(456, "unexpected", 2)
+    manager = object.__new__(CoreEngineProcManager)
+    manager.processes = [expected, unexpected]
+    manager.manager_stopped = threading.Event()
+    manager.failed_proc_name = None
+    manager._process_lock = threading.Lock()
+    manager._replacement_event = threading.Event()
+    manager._monitor_ready = threading.Event()
+    manager._snapshot_exit_event = threading.Event()
+    manager._expected_exit_pids = {123}
+    manager._snapshot_pid = None
+    wait_calls = 0
+
+    def wait(sentinels, timeout):
+        nonlocal wait_calls
+        wait_calls += 1
+        if wait_calls == 1:
+            return [1, 2]
+        manager.manager_stopped.set()
+        return []
+
+    shutdown: list[bool] = []
+
+    def stop():
+        shutdown.append(True)
+        manager.manager_stopped.set()
+
+    monkeypatch.setattr(engine_utils.connection, "wait", wait)
+    monkeypatch.setattr(manager, "shutdown", stop)
+
+    manager.monitor_engine_liveness()
+
+    assert joined == [123]
+    assert manager.failed_proc_name == "unexpected"
+    assert shutdown == [True]
+
+
+def test_discard_restored_process_keeps_expected_exit_until_monitored(monkeypatch):
+    import vllm.v1.engine.utils as engine_utils
+
+    alive = iter((True, False))
+    process = type(
+        "Process",
+        (),
+        {
+            "pid": 123,
+            "is_alive": lambda self: next(alive),
+            "join": lambda self, timeout=None: None,
+        },
+    )()
+    manager = object.__new__(CoreEngineProcManager)
+    manager.processes = [process]
+    manager._process_lock = threading.Lock()
+    manager._replacement_event = threading.Event()
+    manager._expected_exit_pids = set()
+    manager._snapshot_pid = None
+    monkeypatch.setattr(engine_utils, "kill_process_tree", lambda pid: None)
+
+    manager.discard_restored_process()
+
+    assert manager._expected_exit_pids == {123}
+
+
+def test_discard_restored_process_unmarks_failed_exit(monkeypatch):
+    import vllm.v1.engine.utils as engine_utils
+
+    process = type(
+        "Process",
+        (),
+        {
+            "pid": 123,
+            "is_alive": lambda self: True,
+            "join": lambda self, timeout=None: None,
+        },
+    )()
+    manager = object.__new__(CoreEngineProcManager)
+    manager.processes = [process]
+    manager._process_lock = threading.Lock()
+    manager._replacement_event = threading.Event()
+    manager._expected_exit_pids = set()
+    manager._snapshot_pid = None
+    monkeypatch.setattr(engine_utils, "kill_process_tree", lambda pid: None)
+
+    with pytest.raises(RuntimeError, match="did not exit"):
+        manager.discard_restored_process()
+
+    assert manager._expected_exit_pids == set()
+
+
+def test_adopted_process_close_is_idempotent(monkeypatch):
+    process = object.__new__(_AdoptedProcess)
+    process._pidfd = 123
+    closed: list[int] = []
+    monkeypatch.setattr(os, "close", closed.append)
+
+    process.close()
+    process.close()
+
+    assert closed == [123]
+
+
+def test_snapshot_stdio_rebinds_to_source_process(monkeypatch):
+    import vllm.snapshot.process as snapshot_process
+
+    opened: list[tuple[str, int]] = []
+    duplicated: list[tuple[int, int, bool]] = []
+    closed: list[int] = []
+    source_fds = iter((101, 102))
+    monkeypatch.setattr(snapshot_process, "process_starttime", lambda pid: 456)
+
+    def open_fd(path, flags):
+        opened.append((path, flags))
+        return next(source_fds)
+
+    monkeypatch.setattr(os, "open", open_fd)
+    monkeypatch.setattr(
+        os,
+        "dup2",
+        lambda source, target, inheritable=True: duplicated.append(
+            (source, target, inheritable)
+        ),
+    )
+    monkeypatch.setattr(os, "close", closed.append)
+
+    snapshot_process.rebind_stdio(123, expected_starttime=456)
+
+    assert [path for path, _ in opened] == [
+        "/proc/123/fd/1",
+        "/proc/123/fd/2",
+    ]
+    assert duplicated == [(101, 1, True), (102, 2, True)]
+    assert closed == [101, 102]
+
+
+def test_snapshot_io_detach_requires_opt_in():
+    from vllm.v1.engine.core import EngineCoreProc
+
+    engine = object.__new__(EngineCoreProc)
+    engine._engine_snapshot_enabled = False
+
+    with pytest.raises(RuntimeError, match="snapshots are not enabled"):
+        engine.snapshot_detach_io("nonce", 1, "snapshot", "config", "marker", "durable")
+
+
+def test_snapshot_stdio_rejects_reused_source_pid(monkeypatch):
+    import vllm.snapshot.process as snapshot_process
+
+    monkeypatch.setattr(snapshot_process, "process_starttime", lambda pid: 789)
+
+    with pytest.raises(RuntimeError, match="source process identity changed"):
+        snapshot_process.rebind_stdio(123, expected_starttime=456)
+
+
+def test_snapshot_stdio_rejects_source_change_during_open(monkeypatch):
+    import vllm.snapshot.process as snapshot_process
+
+    starttimes = iter((456, 789))
+    duplicated: list[Any] = []
+    closed: list[int] = []
+    monkeypatch.setattr(
+        snapshot_process, "process_starttime", lambda pid: next(starttimes)
+    )
+    source_fds = iter((100, 101))
+    monkeypatch.setattr(os, "open", lambda path, flags: next(source_fds))
+    monkeypatch.setattr(os, "dup2", lambda *args, **kwargs: duplicated.append(args))
+    monkeypatch.setattr(os, "close", closed.append)
+
+    with pytest.raises(RuntimeError, match="source process identity changed"):
+        snapshot_process.rebind_stdio(123)
+
+    assert duplicated == []
+    assert closed == [100, 101]
+
+
+@pytest.mark.parametrize(
+    ("persistence", "expected_fsync_calls"),
+    (("durable", 1), ("page_cache", 0)),
+)
+def test_snapshot_detach_marker_honors_persistence(
+    tmp_path, monkeypatch, persistence, expected_fsync_calls
+):
+    from vllm.v1.engine.core import EngineCoreProc
+
+    engine = object.__new__(EngineCoreProc)
+    engine._engine_snapshot_enabled = True
+    engine._snapshot_input_stopped = threading.Event()
+    engine._snapshot_output_stopped = threading.Event()
+    engine._snapshot_input_stopped.set()
+    engine._snapshot_output_stopped.set()
+    engine._snapshot_io_lock = threading.Lock()
+    engine._snapshot_io_active = True
+    fsync_calls: list[int] = []
+    monkeypatch.setattr(os, "fsync", fsync_calls.append)
+
+    marker_path = tmp_path / "detached.json"
+    engine.snapshot_detach_io(
+        "nonce",
+        1,
+        "snapshot",
+        "config",
+        str(marker_path),
+        persistence,
+    )
+    engine._finish_snapshot_io_detach()
+
+    marker = json.loads(marker_path.read_text())
+    assert marker["state"] == "detached"
+    assert len(fsync_calls) == expected_fsync_calls

--- a/tests/snapshot/test_protocol.py
+++ b/tests/snapshot/test_protocol.py
@@ -1,0 +1,69 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from typing import Any, cast
+
+import pytest
+
+from vllm.snapshot.protocol import (
+    _MAX_MESSAGE_BYTES,
+    SnapshotControlClient,
+    SnapshotControlError,
+    _read_message,
+)
+
+
+class MessageSocket:
+    def __init__(self, *chunks: bytes):
+        self.chunks = list(chunks)
+
+    def recv(self, size: int) -> bytes:
+        return self.chunks.pop(0)
+
+
+def test_read_message_rejects_oversized_terminated_chunk():
+    chunks = [b"x" * 65536] * (_MAX_MESSAGE_BYTES // 65536)
+    sock = MessageSocket(*chunks, b"x\n")
+
+    with pytest.raises(SnapshotControlError, match="too large"):
+        _read_message(cast(Any, sock))
+
+
+def test_read_message_requires_newline_terminator():
+    sock = MessageSocket(b'{"ok": true}', b"")
+
+    with pytest.raises(SnapshotControlError, match="newline terminator"):
+        _read_message(cast(Any, sock))
+
+
+def test_read_message_normalizes_invalid_json():
+    sock = MessageSocket(b"not-json\n")
+
+    with pytest.raises(SnapshotControlError) as exc_info:
+        _read_message(cast(Any, sock))
+
+    assert exc_info.value.code == "invalid_message"
+
+
+def test_control_client_normalizes_connection_errors(monkeypatch):
+    class FailingSocket:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            pass
+
+        def settimeout(self, timeout):
+            pass
+
+        def connect(self, path):
+            raise ConnectionRefusedError(path)
+
+    monkeypatch.setattr(
+        "vllm.snapshot.protocol.socket.socket", lambda *args: FailingSocket()
+    )
+
+    with pytest.raises(SnapshotControlError) as exc_info:
+        SnapshotControlClient("control.sock").request("status")
+
+    assert exc_info.value.code == "connection_error"

--- a/tests/snapshot/test_providers.py
+++ b/tests/snapshot/test_providers.py
@@ -1,0 +1,163 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import os
+
+import pytest
+
+from vllm.snapshot.providers import (
+    CriuCudaSnapshotProvider,
+    make_snapshot_provider,
+)
+
+
+def criu_provider() -> CriuCudaSnapshotProvider:
+    return CriuCudaSnapshotProvider("criu", "cuda-checkpoint")
+
+
+def test_criu_provider_resolves_executable_paths(tmp_path, monkeypatch):
+    paths = {
+        "criu": tmp_path / "bin" / "criu",
+        "cuda-checkpoint": tmp_path / "bin" / "cuda-checkpoint",
+    }
+    monkeypatch.setattr(
+        "vllm.snapshot.providers.shutil.which", lambda name: str(paths[name])
+    )
+
+    provider = make_snapshot_provider("criu_cuda")
+
+    assert isinstance(provider, CriuCudaSnapshotProvider)
+    assert provider.criu_path == str(paths["criu"].resolve())
+    assert provider.cuda_checkpoint_path == str(paths["cuda-checkpoint"].resolve())
+
+
+@pytest.mark.parametrize("missing", ("criu", "cuda-checkpoint"))
+def test_criu_provider_requires_executables(monkeypatch, missing):
+    monkeypatch.setattr(
+        "vllm.snapshot.providers.shutil.which",
+        lambda name: None if name == missing else f"/usr/bin/{name}",
+    )
+
+    with pytest.raises(FileNotFoundError, match=missing):
+        make_snapshot_provider("criu_cuda")
+
+
+def test_criu_provider_removes_successful_restore_work(tmp_path, monkeypatch):
+    provider = criu_provider()
+    snapshot_dir = tmp_path / "snapshot"
+    (snapshot_dir / "images").mkdir(parents=True)
+
+    def run(command, **kwargs):
+        if "--pidfile" in command:
+            pidfile = command[command.index("--pidfile") + 1]
+            with open(pidfile, "w") as pidfile_handle:
+                pidfile_handle.write(f"{os.getpid()}\n")
+
+    monkeypatch.setattr(provider, "_run", run)
+    monkeypatch.setattr(provider, "_cuda_pids", lambda *args, **kwargs: [123])
+    monkeypatch.setattr(provider, "_run_cuda", lambda *args, **kwargs: None)
+
+    result = provider.restore(snapshot_dir)
+
+    assert result["root_pid"] == os.getpid()
+    assert not list(snapshot_dir.glob("restore-work-*"))
+
+
+def test_criu_provider_reports_restore_phase_timings(tmp_path, monkeypatch):
+    provider = criu_provider()
+    snapshot_dir = tmp_path / "snapshot"
+    (snapshot_dir / "images").mkdir(parents=True)
+    timestamps = iter(float(value) for value in range(6))
+
+    def run(command, **kwargs):
+        if "--pidfile" in command:
+            pidfile = command[command.index("--pidfile") + 1]
+            with open(pidfile, "w") as pidfile_handle:
+                pidfile_handle.write(f"{os.getpid()}\n")
+
+    monkeypatch.setattr(
+        "vllm.snapshot.providers.time.monotonic", lambda: next(timestamps)
+    )
+    monkeypatch.setattr(provider, "_run", run)
+    monkeypatch.setattr(provider, "_cuda_pids", lambda *args, **kwargs: [123])
+    monkeypatch.setattr(provider, "_run_cuda", lambda *args, **kwargs: None)
+
+    result = provider.restore(snapshot_dir)
+
+    assert result["criu_restore_seconds"] == 1.0
+    assert result["root_pid_read_seconds"] == 1.0
+    assert result["cuda_pid_discovery_seconds"] == 1.0
+    assert result["cuda_restore_action_seconds"] == 1.0
+    assert result["cuda_unlock_seconds"] == 1.0
+    assert result["cuda_restore_seconds"] == 4.0
+    assert result["restore_seconds"] == 5.0
+
+
+def test_criu_provider_removes_failed_restore_work(tmp_path, monkeypatch):
+    provider = criu_provider()
+    snapshot_dir = tmp_path / "snapshot"
+    (snapshot_dir / "images").mkdir(parents=True)
+    killed: list[int] = []
+
+    def run(command, **kwargs):
+        if "--pidfile" in command:
+            pidfile = command[command.index("--pidfile") + 1]
+            with open(pidfile, "w") as pidfile_handle:
+                pidfile_handle.write(f"{os.getpid()}\n")
+
+    def fail_cuda_restore(*args, **kwargs):
+        raise RuntimeError("restore failed")
+
+    monkeypatch.setattr(provider, "_run", run)
+    monkeypatch.setattr(provider, "_cuda_pids", lambda *args, **kwargs: [123])
+    monkeypatch.setattr(provider, "_run_cuda", fail_cuda_restore)
+    monkeypatch.setattr(provider, "_kill_tree", killed.append)
+
+    with pytest.raises(RuntimeError, match="restore failed"):
+        provider.restore(snapshot_dir)
+
+    assert killed == [os.getpid()]
+    assert not list(snapshot_dir.glob("restore-work-*"))
+
+
+@pytest.mark.parametrize("cuda_pids", ([], [123, 456]))
+def test_criu_provider_requires_one_cuda_process(monkeypatch, cuda_pids):
+    provider = criu_provider()
+    monkeypatch.setattr(provider, "_cuda_pids", lambda *args, **kwargs: cuda_pids)
+
+    with pytest.raises(RuntimeError, match=f"found {len(cuda_pids)}"):
+        provider._cuda_pid(999)
+
+
+def test_criu_capture_reports_cuda_rollback_failure(tmp_path, monkeypatch):
+    provider = criu_provider()
+    actions = []
+
+    def run_cuda(action, pid, *extra):
+        actions.append(action)
+        if action == "checkpoint":
+            raise RuntimeError("checkpoint failed")
+        if action == "restore":
+            raise RuntimeError("restore failed")
+
+    monkeypatch.setattr(provider, "_cuda_pid", lambda root_pid: root_pid)
+    monkeypatch.setattr(provider, "_run_cuda", run_cuda)
+
+    with pytest.raises(RuntimeError, match="rollback cleanup failed: restore"):
+        provider.capture(123, tmp_path / "snapshot")
+
+    assert actions == ["lock", "checkpoint", "restore", "unlock"]
+
+
+def test_criu_capture_skips_in_flight_connections(tmp_path, monkeypatch):
+    provider = criu_provider()
+    commands = []
+    monkeypatch.setattr(provider, "_cuda_pid", lambda root_pid: root_pid)
+    monkeypatch.setattr(provider, "_run_cuda", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        provider, "_run", lambda command, **kwargs: commands.append(command)
+    )
+
+    provider.capture(123, tmp_path / "snapshot")
+
+    assert "--skip-in-flight" in commands[0]

--- a/tests/snapshot/test_serve.py
+++ b/tests/snapshot/test_serve.py
@@ -1,0 +1,82 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from vllm.entrypoints.cli.serve import (
+    _validate_engine_snapshot_execution,
+    run_multi_api_server,
+)
+from vllm.v1.executor import Executor
+from vllm.v1.executor.multiproc_executor import MultiprocExecutor
+from vllm.v1.executor.uniproc_executor import UniProcExecutor
+
+
+def snapshot_config(**overrides) -> Any:
+    values = {
+        "data_parallel_size": 1,
+        "tensor_parallel_size": 1,
+        "pipeline_parallel_size": 1,
+        "prefill_context_parallel_size": 1,
+        "decode_context_parallel_size": 1,
+        "nnodes": 1,
+    }
+    values.update(overrides)
+    return SimpleNamespace(parallel_config=SimpleNamespace(**values))
+
+
+def test_engine_snapshot_accepts_uniproc_executor():
+    _validate_engine_snapshot_execution(snapshot_config(), UniProcExecutor)
+
+
+def test_engine_snapshot_resolves_provider_at_serve_entry(monkeypatch):
+    def fail_provider_check(name):
+        raise FileNotFoundError(f"missing {name}")
+
+    monkeypatch.setattr(
+        "vllm.snapshot.providers.make_snapshot_provider", fail_provider_check
+    )
+    args = SimpleNamespace(
+        api_server_count=1,
+        enable_engine_snapshot=True,
+        engine_snapshot_provider="criu_cuda",
+        headless=False,
+    )
+
+    with pytest.raises(FileNotFoundError, match="missing criu_cuda"):
+        run_multi_api_server(args)
+
+
+class DerivedUniProcExecutor(UniProcExecutor):
+    pass
+
+
+def test_engine_snapshot_accepts_uniproc_executor_subclass():
+    _validate_engine_snapshot_execution(snapshot_config(), DerivedUniProcExecutor)
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    (
+        ("data_parallel_size", 2),
+        ("tensor_parallel_size", 2),
+        ("pipeline_parallel_size", 2),
+        ("prefill_context_parallel_size", 2),
+        ("decode_context_parallel_size", 2),
+        ("nnodes", 2),
+    ),
+)
+def test_engine_snapshot_rejects_parallel_execution(field, value):
+    with pytest.raises(ValueError, match="all parallel sizes to be 1"):
+        _validate_engine_snapshot_execution(
+            snapshot_config(**{field: value}), UniProcExecutor
+        )
+
+
+@pytest.mark.parametrize("executor_class", (MultiprocExecutor, Executor))
+def test_engine_snapshot_rejects_non_uniproc_executor(executor_class):
+    with pytest.raises(ValueError, match="require UniProcExecutor"):
+        _validate_engine_snapshot_execution(snapshot_config(), executor_class)

--- a/tests/snapshot/test_worker.py
+++ b/tests/snapshot/test_worker.py
@@ -15,7 +15,7 @@ def _checkpoint_worker(worker_class, backend="uni"):
     return worker
 
 
-def test_l2_prepared_worker_lifecycle_order(monkeypatch):
+def test_reload_weights_worker_lifecycle_order(monkeypatch):
     import vllm.v1.worker.gpu_worker as gpu_worker
     from vllm.v1.worker.gpu_worker import Worker
 
@@ -139,7 +139,7 @@ def test_checkpoint_prepare_rejects_unknown_executor_before_side_effects(monkeyp
     assert worker._checkpoint_prepare_state is None
 
 
-def test_l2_prepared_worker_rolls_back_failed_discard(monkeypatch):
+def test_reload_weights_worker_rolls_back_failed_discard(monkeypatch):
     import vllm.v1.worker.gpu_worker as gpu_worker
     from vllm.v1.worker.gpu_worker import Worker
 
@@ -194,7 +194,7 @@ def test_l2_prepared_worker_rolls_back_failed_discard(monkeypatch):
     assert worker._checkpoint_prepare_state is not None
 
 
-def test_l2_prepared_worker_checks_discard_capability_before_side_effects(
+def test_reload_weights_worker_checks_discard_capability_before_side_effects(
     monkeypatch,
 ):
     import vllm.v1.worker.gpu_worker as gpu_worker
@@ -226,7 +226,7 @@ def test_l2_prepared_worker_checks_discard_capability_before_side_effects(
     assert worker._checkpoint_prepare_state is None
 
 
-def test_l2_prepared_worker_rejects_active_lora():
+def test_reload_weights_worker_rejects_active_lora():
     from vllm.v1.worker.gpu_worker import Worker
 
     worker = object.__new__(Worker)
@@ -238,7 +238,7 @@ def test_l2_prepared_worker_rejects_active_lora():
         Worker._validate_checkpoint_weight_reload(worker)
 
 
-def test_l2_prepared_worker_rejects_online_weight_updates():
+def test_reload_weights_worker_rejects_online_weight_updates():
     from vllm.v1.worker.gpu_worker import Worker
 
     worker = object.__new__(Worker)
@@ -250,7 +250,7 @@ def test_l2_prepared_worker_rejects_online_weight_updates():
         Worker._validate_checkpoint_weight_reload(worker)
 
 
-def test_l1_prepared_worker_lifecycle_order(monkeypatch):
+def test_host_backup_worker_lifecycle_order(monkeypatch):
     import vllm.v1.worker.gpu_worker as gpu_worker
     from vllm.v1.worker.gpu_worker import Worker
 
@@ -308,7 +308,7 @@ def test_l1_prepared_worker_lifecycle_order(monkeypatch):
     assert worker._checkpoint_prepare_state is None
 
 
-def test_l1_prepared_worker_rolls_back_failed_backup(monkeypatch):
+def test_host_backup_worker_rolls_back_failed_backup(monkeypatch):
     import vllm.v1.worker.gpu_worker as gpu_worker
     from vllm.v1.worker.gpu_worker import Worker
 

--- a/tests/snapshot/test_worker.py
+++ b/tests/snapshot/test_worker.py
@@ -1,0 +1,505 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+
+def _checkpoint_worker(worker_class, backend="uni"):
+    worker = object.__new__(worker_class)
+    worker._checkpoint_prepare_state = None
+    worker.parallel_config = SimpleNamespace(distributed_executor_backend=backend)
+    worker.vllm_config = SimpleNamespace(parallel_config=worker.parallel_config)
+    return worker
+
+
+def test_l2_prepared_worker_lifecycle_order(monkeypatch):
+    import vllm.v1.worker.gpu_worker as gpu_worker
+    from vllm.v1.worker.gpu_worker import Worker
+
+    events: list[Any] = []
+
+    class Allocator:
+        def discard(self, tags):
+            events.append(("discard", tags))
+
+        def wake_up(self, tags):
+            events.append(("wake_up", tags))
+
+    worker = _checkpoint_worker(Worker)
+    worker._validate_checkpoint_weight_reload = lambda: events.append("validate")
+    worker._save_sleep_buffers = lambda: events.append("save_buffers")
+    worker._restore_sleep_buffers = lambda: events.append("restore_buffers")
+    worker.reload_weights = lambda: events.append("reload_weights")
+    worker.model_runner = type(
+        "ModelRunner",
+        (),
+        {"post_kv_cache_wake_up": lambda self: events.append("kv_hook")},
+    )()
+    monkeypatch.setattr(gpu_worker, "get_discard_mem_allocator_instance", Allocator)
+    monkeypatch.setattr(gpu_worker, "get_mem_allocator_instance", Allocator)
+    monkeypatch.setattr(
+        gpu_worker,
+        "checkpoint_prepare_distributed_state",
+        lambda: events.append("communicator_prepare"),
+    )
+    monkeypatch.setattr(
+        gpu_worker,
+        "checkpoint_restore_distributed_state",
+        lambda: events.append("communicator_restore"),
+    )
+    policy = {"weights": "discard", "kv": "discard", "runtime": "cuda_image"}
+
+    prepare_timings = Worker.checkpoint_prepare(worker, policy)
+    restore_timings = Worker.checkpoint_restore(worker, policy)
+
+    assert events == [
+        "validate",
+        "save_buffers",
+        "communicator_prepare",
+        ("discard", ("weights", "kv_cache")),
+        ("wake_up", ["weights", "kv_cache"]),
+        "reload_weights",
+        "restore_buffers",
+        "kv_hook",
+        "communicator_restore",
+    ]
+    assert prepare_timings["total_seconds"] >= 0
+    assert restore_timings["total_seconds"] >= 0
+    assert worker._checkpoint_prepare_state is None
+
+
+def test_checkpoint_prepare_rejects_multiproc_before_side_effects(monkeypatch):
+    import vllm.v1.worker.gpu_worker as gpu_worker
+    from vllm.v1.worker.gpu_worker import Worker
+
+    events: list[Any] = []
+    worker = _checkpoint_worker(Worker, backend="mp")
+    monkeypatch.setattr(
+        gpu_worker,
+        "checkpoint_prepare_distributed_state",
+        lambda: events.append("communicator_prepare"),
+    )
+    policy = {"weights": "cuda_image", "kv": "cuda_image", "runtime": "cuda_image"}
+
+    with pytest.raises(RuntimeError, match="require UniProcExecutor"):
+        Worker.checkpoint_prepare(worker, policy)
+
+    assert events == []
+    assert worker._checkpoint_prepare_state is None
+
+
+def test_uniproc_worker_checkpoint_uses_communicator_hooks(monkeypatch):
+    import vllm.v1.worker.gpu_worker as gpu_worker
+    from vllm.v1.worker.gpu_worker import Worker
+
+    events: list[Any] = []
+    worker = _checkpoint_worker(Worker, backend="uni")
+    monkeypatch.setattr(
+        gpu_worker,
+        "checkpoint_prepare_distributed_state",
+        lambda: events.append("communicator_prepare"),
+    )
+    monkeypatch.setattr(
+        gpu_worker,
+        "checkpoint_restore_distributed_state",
+        lambda: events.append("communicator_restore"),
+    )
+    policy = {"weights": "cuda_image", "kv": "cuda_image", "runtime": "cuda_image"}
+
+    Worker.checkpoint_prepare(worker, policy)
+    Worker.checkpoint_restore(worker, policy)
+
+    assert events == ["communicator_prepare", "communicator_restore"]
+
+
+def test_checkpoint_prepare_rejects_unknown_executor_before_side_effects(monkeypatch):
+    import vllm.v1.worker.gpu_worker as gpu_worker
+    from vllm.v1.executor import Executor
+    from vllm.v1.worker.gpu_worker import Worker
+
+    class UnsupportedExecutor(Executor):
+        pass
+
+    events: list[Any] = []
+    worker = _checkpoint_worker(Worker, backend=UnsupportedExecutor)
+    monkeypatch.setattr(
+        gpu_worker,
+        "checkpoint_prepare_distributed_state",
+        lambda: events.append("communicator_prepare"),
+    )
+    policy = {"weights": "cuda_image", "kv": "cuda_image", "runtime": "cuda_image"}
+
+    with pytest.raises(RuntimeError, match="require UniProcExecutor"):
+        Worker.checkpoint_prepare(worker, policy)
+
+    assert events == []
+    assert worker._checkpoint_prepare_state is None
+
+
+def test_l2_prepared_worker_rolls_back_failed_discard(monkeypatch):
+    import vllm.v1.worker.gpu_worker as gpu_worker
+    from vllm.v1.worker.gpu_worker import Worker
+
+    events: list[Any] = []
+
+    class Allocator:
+        def discard(self, tags):
+            events.append(("discard", tags))
+            raise RuntimeError("discard failed")
+
+        def wake_up(self, tags):
+            events.append(("wake_up", tags))
+
+    worker = _checkpoint_worker(Worker)
+    worker._validate_checkpoint_weight_reload = lambda: events.append("validate")
+    worker._save_sleep_buffers = lambda: events.append("save_buffers")
+    worker._restore_sleep_buffers = lambda: events.append("restore_buffers")
+    worker.reload_weights = lambda: events.append("reload_weights")
+    worker.model_runner = type(
+        "ModelRunner",
+        (),
+        {"post_kv_cache_wake_up": lambda self: events.append("kv_hook")},
+    )()
+    monkeypatch.setattr(gpu_worker, "get_discard_mem_allocator_instance", Allocator)
+    monkeypatch.setattr(gpu_worker, "get_mem_allocator_instance", Allocator)
+    monkeypatch.setattr(
+        gpu_worker,
+        "checkpoint_prepare_distributed_state",
+        lambda: events.append("communicator_prepare"),
+    )
+    monkeypatch.setattr(
+        gpu_worker,
+        "checkpoint_restore_distributed_state",
+        lambda: events.append("communicator_restore"),
+    )
+    policy = {"weights": "discard", "kv": "discard", "runtime": "cuda_image"}
+
+    with pytest.raises(RuntimeError, match="discard failed"):
+        Worker.checkpoint_prepare(worker, policy)
+
+    assert events == [
+        "validate",
+        "save_buffers",
+        "communicator_prepare",
+        ("discard", ("weights", "kv_cache")),
+        ("wake_up", ["weights", "kv_cache"]),
+        "reload_weights",
+        "restore_buffers",
+        "kv_hook",
+        "communicator_restore",
+    ]
+    assert worker._checkpoint_prepare_state is not None
+
+
+def test_l2_prepared_worker_checks_discard_capability_before_side_effects(
+    monkeypatch,
+):
+    import vllm.v1.worker.gpu_worker as gpu_worker
+    from vllm.v1.worker.gpu_worker import Worker
+
+    events: list[Any] = []
+    worker = _checkpoint_worker(Worker)
+    worker._validate_checkpoint_weight_reload = lambda: events.append("validate")
+    worker._save_sleep_buffers = lambda: events.append("save_buffers")
+
+    def unsupported_allocator():
+        events.append("allocator")
+        raise NotImplementedError("selective discard is unsupported")
+
+    monkeypatch.setattr(
+        gpu_worker, "get_discard_mem_allocator_instance", unsupported_allocator
+    )
+    monkeypatch.setattr(
+        gpu_worker,
+        "checkpoint_prepare_distributed_state",
+        lambda: events.append("communicator_prepare"),
+    )
+    policy = {"weights": "discard", "kv": "discard", "runtime": "cuda_image"}
+
+    with pytest.raises(NotImplementedError, match="selective discard is unsupported"):
+        Worker.checkpoint_prepare(worker, policy)
+
+    assert events == ["validate", "allocator"]
+    assert worker._checkpoint_prepare_state is None
+
+
+def test_l2_prepared_worker_rejects_active_lora():
+    from vllm.v1.worker.gpu_worker import Worker
+
+    worker = object.__new__(Worker)
+    worker.get_draft_model = lambda: None
+    worker.vllm_config = type("Config", (), {"lora_config": object()})()
+    worker.list_loras = lambda: {1}
+
+    with pytest.raises(NotImplementedError, match="active LoRA adapters"):
+        Worker._validate_checkpoint_weight_reload(worker)
+
+
+def test_l2_prepared_worker_rejects_online_weight_updates():
+    from vllm.v1.worker.gpu_worker import Worker
+
+    worker = object.__new__(Worker)
+    worker.get_draft_model = lambda: None
+    worker.vllm_config = type("Config", (), {"lora_config": None})()
+    worker.weight_transfer_engine = object()
+
+    with pytest.raises(NotImplementedError, match="online weight updates"):
+        Worker._validate_checkpoint_weight_reload(worker)
+
+
+def test_l1_prepared_worker_lifecycle_order(monkeypatch):
+    import vllm.v1.worker.gpu_worker as gpu_worker
+    from vllm.v1.worker.gpu_worker import Worker
+
+    events: list[Any] = []
+
+    class Allocator:
+        def sleep(self, offload_tags=None):
+            events.append(("sleep", offload_tags))
+
+        def wake_up(self, tags=None):
+            events.append(("wake_up", tags))
+
+        def allocation_diagnostics(self):
+            return {"tags": {"weights": {"host_backup_bytes": 1024}}}
+
+    worker = _checkpoint_worker(Worker)
+    worker.model_runner = type(
+        "ModelRunner",
+        (),
+        {"post_kv_cache_wake_up": lambda self: events.append("kv_hook")},
+    )()
+    monkeypatch.setattr(gpu_worker, "get_mem_allocator_instance", Allocator)
+    monkeypatch.setattr(gpu_worker, "get_diagnostic_mem_allocator_instance", Allocator)
+    monkeypatch.setattr(
+        gpu_worker.torch._C,
+        "_host_emptyCache",
+        lambda: events.append("host_cache_clear"),
+    )
+    monkeypatch.setattr(
+        gpu_worker,
+        "checkpoint_prepare_distributed_state",
+        lambda: events.append("communicator_prepare"),
+    )
+    monkeypatch.setattr(
+        gpu_worker,
+        "checkpoint_restore_distributed_state",
+        lambda: events.append("communicator_restore"),
+    )
+    policy = {"weights": "host_backup", "kv": "discard", "runtime": "cuda_image"}
+
+    prepare_timings = Worker.checkpoint_prepare(worker, policy)
+    restore_timings = Worker.checkpoint_restore(worker, policy)
+
+    assert events == [
+        "communicator_prepare",
+        ("sleep", ("weights",)),
+        ("wake_up", None),
+        "host_cache_clear",
+        "kv_hook",
+        "communicator_restore",
+    ]
+    assert prepare_timings["host_backup_bytes"] == 1024
+    assert prepare_timings["total_seconds"] >= 0
+    assert restore_timings["host_restore_seconds"] >= 0
+    assert worker._checkpoint_prepare_state is None
+
+
+def test_l1_prepared_worker_rolls_back_failed_backup(monkeypatch):
+    import vllm.v1.worker.gpu_worker as gpu_worker
+    from vllm.v1.worker.gpu_worker import Worker
+
+    events: list[Any] = []
+
+    class Allocator:
+        def sleep(self, offload_tags=None):
+            events.append(("sleep", offload_tags))
+            raise RuntimeError("backup failed")
+
+        def wake_up(self, tags=None):
+            events.append(("wake_up", tags))
+
+    worker = _checkpoint_worker(Worker)
+    worker.model_runner = type(
+        "ModelRunner",
+        (),
+        {"post_kv_cache_wake_up": lambda self: events.append("kv_hook")},
+    )()
+    monkeypatch.setattr(gpu_worker, "get_mem_allocator_instance", Allocator)
+    monkeypatch.setattr(
+        gpu_worker.torch._C,
+        "_host_emptyCache",
+        lambda: events.append("host_cache_clear"),
+    )
+    monkeypatch.setattr(
+        gpu_worker,
+        "checkpoint_prepare_distributed_state",
+        lambda: events.append("communicator_prepare"),
+    )
+    monkeypatch.setattr(
+        gpu_worker,
+        "checkpoint_restore_distributed_state",
+        lambda: events.append("communicator_restore"),
+    )
+    policy = {"weights": "host_backup", "kv": "discard", "runtime": "cuda_image"}
+
+    with pytest.raises(RuntimeError, match="allocator prepare state is indeterminate"):
+        Worker.checkpoint_prepare(worker, policy)
+
+    assert events == [
+        "communicator_prepare",
+        ("sleep", ("weights",)),
+        ("wake_up", None),
+        "host_cache_clear",
+        "kv_hook",
+        "communicator_restore",
+    ]
+    assert worker._checkpoint_prepare_state is not None
+
+
+def test_checkpoint_restore_rejects_changed_policy(monkeypatch):
+    import vllm.v1.worker.gpu_worker as gpu_worker
+    from vllm.v1.worker.gpu_worker import Worker
+
+    class Allocator:
+        def sleep(self, offload_tags=None):
+            pass
+
+        def wake_up(self, tags=None):
+            pass
+
+        def allocation_diagnostics(self):
+            return {}
+
+    worker = _checkpoint_worker(Worker)
+    worker.model_runner = type(
+        "ModelRunner", (), {"post_kv_cache_wake_up": lambda self: None}
+    )()
+    monkeypatch.setattr(gpu_worker, "get_mem_allocator_instance", Allocator)
+    monkeypatch.setattr(gpu_worker, "get_diagnostic_mem_allocator_instance", Allocator)
+    monkeypatch.setattr(
+        gpu_worker, "checkpoint_prepare_distributed_state", lambda: None
+    )
+    monkeypatch.setattr(
+        gpu_worker, "checkpoint_restore_distributed_state", lambda: None
+    )
+    l1_policy = {"weights": "host_backup", "kv": "discard", "runtime": "cuda_image"}
+    l2_policy = {"weights": "discard", "kv": "discard", "runtime": "cuda_image"}
+
+    Worker.checkpoint_prepare(worker, l1_policy)
+
+    with pytest.raises(RuntimeError, match="policy changed"):
+        Worker.checkpoint_restore(worker, l2_policy)
+
+    assert worker._checkpoint_prepare_state is not None
+
+
+def test_checkpoint_rollback_continues_after_allocator_failure(monkeypatch):
+    import vllm.v1.worker.gpu_worker as gpu_worker
+    from vllm.v1.worker.gpu_worker import Worker
+
+    events: list[Any] = []
+
+    class Allocator:
+        def discard(self, tags):
+            events.append("discard")
+            raise RuntimeError("discard failed")
+
+        def wake_up(self, tags=None):
+            events.append("wake_up")
+            raise RuntimeError("wake failed")
+
+    worker = _checkpoint_worker(Worker)
+    worker._validate_checkpoint_weight_reload = lambda: events.append("validate")
+    worker._save_sleep_buffers = lambda: events.append("save_buffers")
+    worker._restore_sleep_buffers = lambda: events.append("restore_buffers")
+    worker.reload_weights = lambda: events.append("reload_weights")
+    worker.model_runner = type(
+        "ModelRunner", (), {"post_kv_cache_wake_up": lambda self: events.append("kv")}
+    )()
+    monkeypatch.setattr(gpu_worker, "get_discard_mem_allocator_instance", Allocator)
+    monkeypatch.setattr(gpu_worker, "get_mem_allocator_instance", Allocator)
+    monkeypatch.setattr(
+        gpu_worker,
+        "checkpoint_prepare_distributed_state",
+        lambda: events.append("communicator_prepare"),
+    )
+    monkeypatch.setattr(
+        gpu_worker,
+        "checkpoint_restore_distributed_state",
+        lambda: events.append("communicator_restore"),
+    )
+    policy = {"weights": "discard", "kv": "discard", "runtime": "cuda_image"}
+
+    with pytest.raises(RuntimeError, match="allocator restore: wake failed"):
+        Worker.checkpoint_prepare(worker, policy)
+
+    assert events == [
+        "validate",
+        "save_buffers",
+        "communicator_prepare",
+        "discard",
+        "wake_up",
+        "communicator_restore",
+    ]
+    assert worker._checkpoint_prepare_state is not None
+
+
+def test_checkpoint_abort_retries_weight_reload_before_buffers(monkeypatch):
+    import vllm.v1.worker.gpu_worker as gpu_worker
+    from vllm.v1.worker.gpu_worker import Worker
+
+    events: list[Any] = []
+    reload_attempts = 0
+
+    class Allocator:
+        def discard(self, tags):
+            events.append("discard")
+
+        def wake_up(self, tags=None):
+            events.append("wake_up")
+
+    def reload_weights():
+        nonlocal reload_attempts
+        reload_attempts += 1
+        events.append("reload_weights")
+        if reload_attempts == 1:
+            raise RuntimeError("reload failed")
+
+    worker = _checkpoint_worker(Worker)
+    worker._validate_checkpoint_weight_reload = lambda: None
+    worker._save_sleep_buffers = lambda: events.append("save_buffers")
+    worker._restore_sleep_buffers = lambda: events.append("restore_buffers")
+    worker.reload_weights = reload_weights
+    worker.model_runner = type(
+        "ModelRunner", (), {"post_kv_cache_wake_up": lambda self: events.append("kv")}
+    )()
+    monkeypatch.setattr(gpu_worker, "get_discard_mem_allocator_instance", Allocator)
+    monkeypatch.setattr(gpu_worker, "get_mem_allocator_instance", Allocator)
+    monkeypatch.setattr(
+        gpu_worker, "checkpoint_prepare_distributed_state", lambda: None
+    )
+    monkeypatch.setattr(
+        gpu_worker, "checkpoint_restore_distributed_state", lambda: None
+    )
+    policy = {"weights": "discard", "kv": "discard", "runtime": "cuda_image"}
+
+    Worker.checkpoint_prepare(worker, policy)
+    worker._checkpoint_prepare_state.allocator_prepare_failed = True
+
+    with pytest.raises(RuntimeError, match="weight reload: reload failed"):
+        Worker.checkpoint_abort(worker)
+
+    assert "restore_buffers" not in events
+    assert "kv" not in events
+
+    with pytest.raises(RuntimeError, match="allocator prepare state is indeterminate"):
+        Worker.checkpoint_abort(worker)
+
+    assert events.count("wake_up") == 1
+    assert events.count("reload_weights") == 2
+    assert events.count("restore_buffers") == 1
+    assert events.count("kv") == 1

--- a/vllm/device_allocator/__init__.py
+++ b/vllm/device_allocator/__init__.py
@@ -3,7 +3,7 @@
 
 import dataclasses
 from contextlib import AbstractContextManager
-from typing import Protocol, TypeAlias
+from typing import Protocol, TypeAlias, runtime_checkable
 
 import torch
 
@@ -34,6 +34,16 @@ class MemAllocator(Protocol):
     def get_current_usage(self) -> int: ...
 
 
+@runtime_checkable
+class DiscardMemAllocator(MemAllocator, Protocol):
+    def discard(self, tags: tuple[str, ...] | str) -> None: ...
+
+
+@runtime_checkable
+class DiagnosticMemAllocator(MemAllocator, Protocol):
+    def allocation_diagnostics(self) -> dict[str, object]: ...
+
+
 def get_mem_allocator_instance() -> MemAllocator:
     if current_platform.is_cuda_alike():
         from vllm.device_allocator.cumem import CuMemAllocator
@@ -50,3 +60,21 @@ def get_mem_allocator_instance() -> MemAllocator:
         f"{type(current_platform).__name__} "
         f"(device_type={current_platform.device_type})."
     )
+
+
+def get_discard_mem_allocator_instance() -> DiscardMemAllocator:
+    allocator = get_mem_allocator_instance()
+    if not isinstance(allocator, DiscardMemAllocator):
+        raise NotImplementedError(
+            f"{type(allocator).__name__} does not support selective discard"
+        )
+    return allocator
+
+
+def get_diagnostic_mem_allocator_instance() -> DiagnosticMemAllocator:
+    allocator = get_mem_allocator_instance()
+    if not isinstance(allocator, DiagnosticMemAllocator):
+        raise NotImplementedError(
+            f"{type(allocator).__name__} does not expose allocation diagnostics"
+        )
+    return allocator

--- a/vllm/device_allocator/cumem.py
+++ b/vllm/device_allocator/cumem.py
@@ -59,6 +59,8 @@ def get_pluggable_allocator(
     python_malloc_fn: Callable[[HandleType], None],
     python_free_func: Callable[[int], HandleType],
 ) -> torch.cuda.memory.CUDAPluggableAllocator:
+    if lib_name is None:
+        raise RuntimeError("cumem allocator library is not loaded")
     init_module(python_malloc_fn, python_free_func)
     new_alloc = torch.cuda.memory.CUDAPluggableAllocator(
         lib_name, "my_malloc", "my_free"
@@ -339,21 +341,19 @@ class CuMemAllocator:
         torch.accelerator.empty_cache()
 
         for ptr, data in self.pointer_to_data.items():
-            if not data.is_asleep:
-                continue
             if tags is None or data.tag in tags:
                 handle = data.handle
-                create_and_map(handle)
-                data.is_asleep = False
+                if data.is_asleep:
+                    create_and_map(handle)
+                    data.is_asleep = False
                 if data.cpu_backup_tensor is not None:
                     cpu_backup_tensor = data.cpu_backup_tensor
-                    if cpu_backup_tensor is not None:
-                        size_in_bytes = (
-                            cpu_backup_tensor.numel() * cpu_backup_tensor.element_size()
-                        )
-                        cpu_ptr = cpu_backup_tensor.data_ptr()
-                        libcudart.cudaMemcpy(ptr, cpu_ptr, size_in_bytes)
-                        data.cpu_backup_tensor = None
+                    size_in_bytes = (
+                        cpu_backup_tensor.numel() * cpu_backup_tensor.element_size()
+                    )
+                    cpu_ptr = cpu_backup_tensor.data_ptr()
+                    libcudart.cudaMemcpy(ptr, cpu_ptr, size_in_bytes)
+                    data.cpu_backup_tensor = None
 
     @contextmanager
     def use_memory_pool(self, tag: str | None = None):
@@ -424,3 +424,29 @@ class CuMemAllocator:
             handle = data.handle
             sum_bytes += handle[1]
         return sum_bytes
+
+    def allocation_diagnostics(self) -> dict[str, object]:
+        tags: dict[str, dict[str, Any]] = {}
+        for ptr, data in sorted(self.pointer_to_data.items()):
+            tag = tags.setdefault(
+                data.tag,
+                {
+                    "logical_bytes": 0,
+                    "allocation_count": 0,
+                    "virtual_addresses": [],
+                    "mapped_virtual_addresses": [],
+                    "host_backup_bytes": 0,
+                },
+            )
+            size = data.handle[1]
+            tag["logical_bytes"] += size
+            tag["allocation_count"] += 1
+            tag["virtual_addresses"].append(ptr)
+            if not data.is_asleep:
+                tag["mapped_virtual_addresses"].append(ptr)
+            if data.cpu_backup_tensor is not None:
+                tag["host_backup_bytes"] += (
+                    data.cpu_backup_tensor.numel()
+                    * data.cpu_backup_tensor.element_size()
+                )
+        return {"tags": tags}

--- a/vllm/engine/protocol.py
+++ b/vllm/engine/protocol.py
@@ -177,6 +177,49 @@ class EngineClient(ABC):
         """Check whether the engine is sleeping"""
         ...
 
+    async def is_idle(self) -> bool:
+        """Return whether frontend and EngineCore have no active requests."""
+        raise NotImplementedError
+
+    async def checkpoint_prepare(
+        self, resource_policy: dict[str, str]
+    ) -> list[dict[str, float]]:
+        """Prepare workers for a process checkpoint."""
+        raise NotImplementedError
+
+    async def checkpoint_restore(
+        self, resource_policy: dict[str, str]
+    ) -> list[dict[str, float]]:
+        """Restore workers after a process checkpoint."""
+        raise NotImplementedError
+
+    async def checkpoint_abort(self) -> list[dict[str, float]]:
+        """Undo worker checkpoint preparation."""
+        raise NotImplementedError
+
+    async def snapshot_detach_io(
+        self,
+        nonce: str,
+        generation: int,
+        snapshot_id: str,
+        config_hash: str,
+        marker_path: str,
+        persistence: str,
+    ) -> None:
+        """Detach EngineCore business sockets before checkpoint."""
+        raise NotImplementedError
+
+    async def snapshot_wait_for_attach(
+        self,
+        nonce: str,
+        generation: int,
+        snapshot_id: str,
+        config_hash: str,
+        root_pid: int,
+    ) -> None:
+        """Wait for and verify restored EngineCore socket attachment."""
+        raise NotImplementedError
+
     @abstractmethod
     async def add_lora(self, lora_request: LoRARequest) -> bool:
         """Load a new LoRA adapter into the engine for future requests."""

--- a/vllm/entrypoints/cli/serve.py
+++ b/vllm/entrypoints/cli/serve.py
@@ -9,6 +9,7 @@ import uvloop
 
 import vllm
 import vllm.envs as envs
+from vllm.config import VllmConfig
 from vllm.entrypoints.cli.types import CLISubcommand
 from vllm.entrypoints.launchers.api_server.entry import run_server, setup_server
 from vllm.entrypoints.launchers.cli_args import (
@@ -145,7 +146,11 @@ class ServeSubcommand(CLISubcommand):
             run_dp_supervisor(args)
         elif args.api_server_count < 1:
             run_headless(args)
-        elif args.api_server_count > 1 or rust_frontend_path:
+        elif (
+            args.api_server_count > 1
+            or rust_frontend_path
+            or args.enable_engine_snapshot
+        ):
             run_multi_api_server(args)
         else:
             # Single API server (this process).
@@ -259,6 +264,28 @@ def run_headless(args: argparse.Namespace):
         logger.info("Shutting down.")
 
 
+def _validate_engine_snapshot_execution(
+    vllm_config: VllmConfig, executor_class: type[Executor]
+) -> None:
+    parallel_config = vllm_config.parallel_config
+    if (
+        parallel_config.data_parallel_size != 1
+        or parallel_config.tensor_parallel_size != 1
+        or parallel_config.pipeline_parallel_size != 1
+        or parallel_config.prefill_context_parallel_size != 1
+        or parallel_config.decode_context_parallel_size != 1
+        or parallel_config.nnodes != 1
+    ):
+        raise ValueError(
+            "Engine snapshots currently require all parallel sizes to be 1"
+        )
+
+    from vllm.v1.executor.uniproc_executor import UniProcExecutor
+
+    if not issubclass(executor_class, UniProcExecutor):
+        raise ValueError("Engine snapshots currently require UniProcExecutor")
+
+
 def run_multi_api_server(args: argparse.Namespace):
     assert not args.headless
     rust_frontend_path = (
@@ -266,6 +293,16 @@ def run_multi_api_server(args: argparse.Namespace):
     )
     num_api_servers: int = args.api_server_count
     assert num_api_servers > 0
+    snapshot_provider = None
+
+    if args.enable_engine_snapshot:
+        if rust_frontend_path:
+            raise ValueError("Engine snapshots require the Python frontend")
+        if num_api_servers != 1:
+            raise ValueError("Engine snapshots currently require one API server")
+        from vllm.snapshot.providers import make_snapshot_provider
+
+        snapshot_provider = make_snapshot_provider(args.engine_snapshot_provider)
 
     if rust_frontend_path and num_api_servers > 1:
         raise ValueError(
@@ -297,12 +334,31 @@ def run_multi_api_server(args: argparse.Namespace):
     usage_context = UsageContext.OPENAI_API_SERVER
     vllm_config = engine_args.create_engine_config(usage_context=usage_context)
 
+    if args.enable_engine_snapshot:
+        from vllm.snapshot.resources import parse_snapshot_resource_policy
+
+        resource_policy = parse_snapshot_resource_policy(
+            args.engine_snapshot_resource_policy
+        )
+        if (
+            resource_policy.requires_allocator
+            and not vllm_config.model_config.enable_sleep_mode
+            and not vllm_config.model_config.enable_cumem_allocator
+        ):
+            raise ValueError(
+                "Engine snapshot resource policies that offload or discard "
+                "allocations require "
+                "--enable-sleep-mode or --enable-cumem-allocator"
+            )
+
     if num_api_servers > 1 and envs.VLLM_ALLOW_RUNTIME_LORA_UPDATING:
         raise ValueError(
             "VLLM_ALLOW_RUNTIME_LORA_UPDATING cannot be used with api_server_count > 1"
         )
 
     executor_class = Executor.get_class(vllm_config)
+    if args.enable_engine_snapshot:
+        _validate_engine_snapshot_execution(vllm_config, executor_class)
     log_stats = not engine_args.disable_log_stats
 
     parallel_config = vllm_config.parallel_config
@@ -312,6 +368,7 @@ def run_multi_api_server(args: argparse.Namespace):
     api_server_manager: APIServerProcessManager | RustFrontendProcessManager | None = (
         None
     )
+    snapshot_manager = None
 
     from vllm.v1.engine.utils import get_engine_zmq_addresses
 
@@ -328,7 +385,11 @@ def run_multi_api_server(args: argparse.Namespace):
     )
 
     with launch_core_engines(
-        vllm_config, executor_class, log_stats, addresses
+        vllm_config,
+        executor_class,
+        log_stats,
+        addresses,
+        enable_engine_snapshot=args.enable_engine_snapshot,
     ) as engine_launch:
         local_engine_manager = engine_launch.engine_manager
         coordinator = engine_launch.coordinator
@@ -367,6 +428,11 @@ def run_multi_api_server(args: argparse.Namespace):
                 output_addresses=addresses.outputs,
                 stats_update_address=stats_update_address,
                 tensor_queue=engine_launch.tensor_queue,
+                snapshot_control_path=(
+                    args.engine_snapshot_control_socket
+                    if args.enable_engine_snapshot
+                    else None
+                ),
             )
 
             if not is_ray_dp:
@@ -383,6 +449,66 @@ def run_multi_api_server(args: argparse.Namespace):
         # If any of these processes exit before the engines are up, the engine startup
         # will be aborted with an error.
         engine_launch.watched_frontend_processes = api_server_manager.processes
+
+    if args.enable_engine_snapshot:
+        try:
+            if not isinstance(local_engine_manager, CoreEngineProcManager):
+                raise RuntimeError(
+                    "Engine snapshots require CoreEngineProcManager"
+                )
+            if len(local_engine_manager.processes) != 1:
+                raise RuntimeError(
+                    "Engine snapshots require exactly one EngineCore process"
+                )
+            root_pid = local_engine_manager.processes[0].pid
+            if root_pid is None:
+                raise RuntimeError("EngineCore process PID is unavailable")
+            from vllm.snapshot.manager import EngineSnapshotManager, config_digest
+
+            if snapshot_provider is None:
+                raise RuntimeError("engine snapshot provider was not initialized")
+
+            snapshot_config = {
+                "model": args.model,
+                "tokenizer": args.tokenizer or args.model,
+                "revision": args.revision,
+                "tokenizer_revision": args.tokenizer_revision,
+                "dtype": args.dtype,
+                "max_model_len": args.max_model_len,
+                "served_model_name": args.served_model_name,
+                "load_format": args.load_format,
+                "tensor_parallel_size": args.tensor_parallel_size,
+                "pipeline_parallel_size": args.pipeline_parallel_size,
+                "data_parallel_size": args.data_parallel_size,
+                "enforce_eager": args.enforce_eager,
+                "integrity": args.engine_snapshot_integrity,
+                "vllm_config_hash": vllm_config.compute_hash(),
+            }
+
+            snapshot_manager = EngineSnapshotManager(
+                args.engine_snapshot_control_socket,
+                args.engine_snapshot_dir,
+                root_pid,
+                provider=snapshot_provider,
+                config_hash=config_digest(snapshot_config),
+                snapshot_config=snapshot_config,
+                resource_policy=args.engine_snapshot_resource_policy,
+                persistence=args.engine_snapshot_persistence,
+                integrity=args.engine_snapshot_integrity,
+                process_manager=local_engine_manager,
+            )
+            snapshot_manager.start()
+        except BaseException:
+            if snapshot_manager is not None:
+                snapshot_manager.close()
+            if api_server_manager is not None:
+                api_server_manager.shutdown()
+            if local_engine_manager:
+                local_engine_manager.shutdown()
+            if coordinator:
+                coordinator.shutdown()
+            sock.close()
+            raise
 
     # Wait for API servers.
     try:
@@ -404,6 +530,8 @@ def run_multi_api_server(args: argparse.Namespace):
             )
 
         api_server_manager.shutdown(timeout=timeout)
+        if snapshot_manager is not None:
+            snapshot_manager.close()
         if local_engine_manager:
             local_engine_manager.shutdown(timeout=to_timeout(shutdown_by))
         if coordinator:

--- a/vllm/entrypoints/launchers/api_server/entry.py
+++ b/vllm/entrypoints/launchers/api_server/entry.py
@@ -117,6 +117,7 @@ async def build_and_serve(
     listen_address: str,
     sock: socket.socket,
     args: Namespace,
+    snapshot_control_path: str | None = None,
     **uvicorn_kwargs,
 ) -> asyncio.Task:
     """Build FastAPI app, initialize state, and start serving.
@@ -133,7 +134,12 @@ async def build_and_serve(
     model_config = engine_client.model_config
 
     logger.info("Supported tasks: %s", supported_tasks)
-    app = build_app(args, supported_tasks, model_config)
+    app = build_app(
+        args,
+        supported_tasks,
+        model_config,
+        snapshot_control_path=snapshot_control_path,
+    )
     await init_app_state(engine_client, app.state, args, supported_tasks)
 
     logger.info("Starting vLLM server on %s", listen_address)
@@ -191,8 +197,16 @@ async def run_server_worker(
         args,
         client_config=client_config,
     ) as engine_client:
+        snapshot_control_path = (
+            client_config.get("snapshot_control_path") if client_config else None
+        )
         shutdown_task = await build_and_serve(
-            engine_client, listen_address, sock, args, **uvicorn_kwargs
+            engine_client,
+            listen_address,
+            sock,
+            args,
+            snapshot_control_path=snapshot_control_path,
+            **uvicorn_kwargs,
         )
     # NB: Await server shutdown only after the backend context is exited
     try:

--- a/vllm/entrypoints/launchers/app.py
+++ b/vllm/entrypoints/launchers/app.py
@@ -20,6 +20,7 @@ def build_app(
     args: Namespace,
     supported_tasks: tuple["SupportedTask", ...] | None = None,
     model_config: ModelConfig | None = None,
+    snapshot_control_path: str | None = None,
 ) -> FastAPI:
     if supported_tasks is None:
         warnings.warn(
@@ -41,6 +42,30 @@ def build_app(
         app = FastAPI(lifespan=lifespan)
     app.state.args = args
     app.root_path = args.root_path
+
+    if args.enable_engine_snapshot:
+        from vllm.snapshot.middleware import (
+            EngineSnapshotGate,
+            EngineSnapshotMiddleware,
+            snapshot_control_error_handler,
+        )
+        from vllm.snapshot.protocol import (
+            SnapshotControlClient,
+            SnapshotControlError,
+        )
+
+        control_path = (
+            snapshot_control_path
+            if snapshot_control_path is not None
+            else args.engine_snapshot_control_socket
+        )
+        app.state.engine_snapshot_client = SnapshotControlClient(control_path)
+        app.state.engine_snapshot_gate = EngineSnapshotGate()
+        app.add_middleware(
+            EngineSnapshotMiddleware,
+            gate=app.state.engine_snapshot_gate,
+        )
+        app.exception_handler(SnapshotControlError)(snapshot_control_error_handler)
 
     register_api_routers(args, app, supported_tasks, model_config)
 

--- a/vllm/entrypoints/launchers/cli_args.py
+++ b/vllm/entrypoints/launchers/cli_args.py
@@ -197,10 +197,8 @@ class BaseFrontendArgs:
     """Enable launcher-managed EngineCore snapshots for Sleep Mode level 3."""
     engine_snapshot_provider: Literal["fake", "criu_cuda"] = "criu_cuda"
     """Engine snapshot provider. The fake provider is for lifecycle testing."""
-    engine_snapshot_resource_policy: Literal[
-        "full", "discard_kv", "l1_prepared", "l2_prepared"
-    ] = "full"
-    """Internal Engine snapshot resource policy."""
+    engine_snapshot_resource_policy: Literal["full", "minimized"] = "full"
+    """Engine snapshot state captured in the process image."""
     engine_snapshot_persistence: Literal["durable", "page_cache"] = "durable"
     """Durability mode for Engine snapshot artifacts."""
     engine_snapshot_integrity: Literal["optimistic", "strict"] = "optimistic"

--- a/vllm/entrypoints/launchers/cli_args.py
+++ b/vllm/entrypoints/launchers/cli_args.py
@@ -193,6 +193,22 @@ class BaseFrontendArgs:
     """
     fingerprint_value: str | None = None
     """Literal fingerprint string used when ``--fingerprint-mode=custom``."""
+    enable_engine_snapshot: bool = False
+    """Enable launcher-managed EngineCore snapshots for Sleep Mode level 3."""
+    engine_snapshot_provider: Literal["fake", "criu_cuda"] = "criu_cuda"
+    """Engine snapshot provider. The fake provider is for lifecycle testing."""
+    engine_snapshot_resource_policy: Literal[
+        "full", "discard_kv", "l1_prepared", "l2_prepared"
+    ] = "full"
+    """Internal Engine snapshot resource policy."""
+    engine_snapshot_persistence: Literal["durable", "page_cache"] = "durable"
+    """Durability mode for Engine snapshot artifacts."""
+    engine_snapshot_integrity: Literal["optimistic", "strict"] = "optimistic"
+    """Integrity mode for Engine snapshot artifacts."""
+    engine_snapshot_dir: str = "/snapshots"
+    """Directory used for committed EngineCore snapshots."""
+    engine_snapshot_control_socket: str = "/snapshots/control.sock"
+    """Unix socket used by API processes to control the snapshot manager."""
 
     @classmethod
     def _customize_cli_kwargs(
@@ -423,6 +439,9 @@ def validate_parsed_serve_args(args: argparse.Namespace):
     # LaunchSubcommandBase.add_cli_args), so its args are serve args as well.
     if hasattr(args, "subparser") and args.subparser not in ("serve", "launch"):
         return
+
+    if getattr(args, "enable_engine_snapshot", False) and not envs.VLLM_SERVER_DEV_MODE:
+        raise ValueError("--enable-engine-snapshot requires VLLM_SERVER_DEV_MODE=1")
 
     # Ensure that the chat template is valid; raises if it likely isn't
     validate_chat_template(args.chat_template)

--- a/vllm/entrypoints/serve/dev/sleep/api_router.py
+++ b/vllm/entrypoints/serve/dev/sleep/api_router.py
@@ -1,48 +1,406 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import asyncio
+import time
+from collections.abc import Awaitable, Callable, Mapping
+from typing import Any, TypeVar, cast
 
-from fastapi import APIRouter, FastAPI, Request
+from fastapi import APIRouter, FastAPI, HTTPException, Request
 from fastapi.responses import JSONResponse, Response
 
 from vllm.engine.protocol import EngineClient
 from vllm.logger import init_logger
+from vllm.snapshot.protocol import SnapshotControlClient
+from vllm.v1.engine import PauseMode
 
 logger = init_logger(__name__)
+_T = TypeVar("_T")
 
 
 def engine_client(request: Request) -> EngineClient:
     return request.app.state.engine_client
 
 
+def snapshot_client(request: Request) -> SnapshotControlClient | None:
+    return getattr(request.app.state, "engine_snapshot_client", None)
+
+
 router = APIRouter()
 
 
+async def _attach_engine(
+    raw_request: Request,
+    client: SnapshotControlClient,
+    ticket: Mapping[str, Any],
+    resource_policy: dict[str, str],
+    *,
+    rollback: bool = False,
+) -> tuple[dict[str, float], list[dict[str, float]]]:
+    started = time.monotonic()
+    timings: dict[str, float] = {}
+    engine = engine_client(raw_request)
+    phase_started = time.monotonic()
+    await engine.snapshot_wait_for_attach(
+        ticket["nonce"],
+        ticket["generation"],
+        ticket["snapshot_id"],
+        ticket["config_hash"],
+        ticket["root_pid"],
+    )
+    timings["attach_wait_seconds"] = time.monotonic() - phase_started
+    phase_started = time.monotonic()
+    await asyncio.to_thread(
+        client.request,
+        "confirm_attach",
+        {
+            field: ticket[field]
+            for field in (
+                "nonce",
+                "generation",
+                "snapshot_id",
+                "config_hash",
+                "root_pid",
+            )
+        },
+    )
+    timings["manager_confirm_attach_seconds"] = time.monotonic() - phase_started
+    phase_started = time.monotonic()
+    worker_timings = await engine.checkpoint_restore(resource_policy)
+    timings["worker_restore_seconds"] = time.monotonic() - phase_started
+    phase_started = time.monotonic()
+    await engine.resume_generation()
+    timings["resume_generation_seconds"] = time.monotonic() - phase_started
+    phase_started = time.monotonic()
+    await engine.check_health()
+    timings["health_check_seconds"] = time.monotonic() - phase_started
+    command = "complete_capture_rollback" if rollback else "complete_restore"
+    phase_started = time.monotonic()
+    await asyncio.to_thread(client.request, command)
+    timings["manager_complete_seconds"] = time.monotonic() - phase_started
+    timings["total_seconds"] = time.monotonic() - started
+    return timings, worker_timings
+
+
+async def _fail_capture(client: SnapshotControlClient, error: BaseException) -> None:
+    status = await asyncio.to_thread(client.request, "status")
+    if status["state"] == "FAILED":
+        return
+    if status["state"] not in ("DRAINING", "ATTACHING", "VERIFYING"):
+        raise RuntimeError(f"cannot fail capture from state {status['state']}")
+    await asyncio.to_thread(client.request, "fail_capture", {"error": str(error)})
+
+
+async def _run_snapshot_lifecycle(operation: Awaitable[_T]) -> _T:
+    """Finish a snapshot lifecycle operation before honoring cancellation."""
+    task = asyncio.ensure_future(operation)
+    try:
+        return await asyncio.shield(task)
+    except asyncio.CancelledError:
+        while not task.done():
+            try:
+                await asyncio.shield(task)
+            except asyncio.CancelledError:
+                continue
+        try:
+            task.result()
+        except asyncio.CancelledError:
+            pass
+        except Exception:
+            logger.exception("Snapshot lifecycle failed after request cancellation")
+        raise
+
+
+async def _run_exclusive_snapshot_operation(
+    raw_request: Request,
+    operation: Callable[[], Awaitable[_T]],
+) -> _T:
+    gate = raw_request.app.state.engine_snapshot_gate
+    if not await gate.begin_operation():
+        raise HTTPException(409, "Another engine sleep or wake operation is running")
+    try:
+        return await operation()
+    finally:
+        await gate.end_operation()
+
+
 @router.post("/sleep")
-async def sleep(raw_request: Request):
-    # get POST params
+async def sleep(raw_request: Request) -> Response:
     level = raw_request.query_params.get("level", "1")
-    mode = raw_request.query_params.get("mode", "abort")
-    await engine_client(raw_request).sleep(int(level), mode)
+    mode_value = raw_request.query_params.get("mode", "abort")
+    if mode_value not in ("abort", "wait", "keep"):
+        raise HTTPException(400, "Sleep mode must be abort, wait, or keep")
+    mode = cast(PauseMode, mode_value)
+    try:
+        level_number = int(level)
+    except ValueError as exc:
+        raise HTTPException(400, "Sleep level must be an integer") from exc
+    if level_number not in (1, 2, 3):
+        raise HTTPException(400, "Sleep level must be 1, 2, or 3")
+    client = snapshot_client(raw_request)
+    if client is not None:
+        return await _run_snapshot_lifecycle(
+            _run_exclusive_snapshot_operation(
+                raw_request,
+                lambda: _sleep_with_snapshot(raw_request, client, level_number, mode),
+            )
+        )
+    if level_number == 3:
+        raise HTTPException(400, "Sleep Mode level 3 is not enabled")
+    await engine_client(raw_request).sleep(level_number, mode)
     return Response(status_code=200)
 
 
+async def _sleep_with_snapshot(
+    raw_request: Request,
+    client: SnapshotControlClient,
+    level: int,
+    mode: PauseMode,
+) -> Response:
+    if level == 3:
+        return await _sleep_level3(raw_request, mode)
+    status = await asyncio.to_thread(client.request, "status")
+    if status["state"] != "READY":
+        raise HTTPException(409, f"Engine snapshot state is {status['state']}")
+    await engine_client(raw_request).sleep(level, mode)
+    return Response(status_code=200)
+
+
+async def _sleep_level3(raw_request: Request, mode: PauseMode) -> JSONResponse:
+    started = time.monotonic()
+    timings: dict[str, float] = {}
+    client = snapshot_client(raw_request)
+    if client is None:
+        raise HTTPException(400, "Sleep Mode level 3 is not enabled")
+    status = await asyncio.to_thread(client.request, "status")
+    if status["state"] != "READY":
+        raise HTTPException(409, f"Engine snapshot state is {status['state']}")
+    engine = engine_client(raw_request)
+    resource_policy = status["resource_policy"]
+    gate = raw_request.app.state.engine_snapshot_gate
+    phase_started = time.monotonic()
+    active_requests = await gate.close()
+    timings["gate_close_seconds"] = time.monotonic() - phase_started
+    if active_requests:
+        await gate.open()
+        raise HTTPException(409, f"Engine has {active_requests} active API request(s)")
+    phase_started = time.monotonic()
+    initially_idle = await engine.is_idle()
+    timings["initial_idle_check_seconds"] = time.monotonic() - phase_started
+    if not initially_idle:
+        await gate.open()
+        raise HTTPException(409, "Engine has in-flight requests")
+    manager_prepared = False
+    checkpoint_prepare_started = False
+    paused = False
+    ticket: Mapping[str, Any] | None = None
+    detached = False
+    try:
+        phase_started = time.monotonic()
+        prepared_result = await asyncio.to_thread(client.request, "prepare_capture")
+        timings["manager_prepare_capture_seconds"] = time.monotonic() - phase_started
+        manager_prepared = True
+        ticket = prepared_result["ticket"]
+        phase_started = time.monotonic()
+        still_idle = await engine.is_idle()
+        timings["idle_recheck_seconds"] = time.monotonic() - phase_started
+        if not still_idle:
+            raise HTTPException(409, "Engine became busy during capture")
+        phase_started = time.monotonic()
+        await engine.pause_generation(
+            mode=mode, clear_cache=resource_policy["kv"] == "discard"
+        )
+        timings["pause_generation_seconds"] = time.monotonic() - phase_started
+        paused = True
+        phase_started = time.monotonic()
+        barrier_idle = await engine.is_idle()
+        timings["idle_barrier_seconds"] = time.monotonic() - phase_started
+        if not barrier_idle:
+            raise HTTPException(409, "Engine did not reach the idle barrier")
+        phase_started = time.monotonic()
+        checkpoint_prepare_started = True
+        worker_timings = await engine.checkpoint_prepare(resource_policy)
+        timings["worker_prepare_seconds"] = time.monotonic() - phase_started
+        phase_started = time.monotonic()
+        await engine.snapshot_detach_io(
+            ticket["nonce"],
+            ticket["generation"],
+            ticket["snapshot_id"],
+            ticket["config_hash"],
+            ticket["marker_path"],
+            prepared_result["persistence"],
+        )
+        timings["zmq_detach_seconds"] = time.monotonic() - phase_started
+        detached = True
+        phase_started = time.monotonic()
+        result = await asyncio.to_thread(client.request, "capture")
+        timings["manager_capture_seconds"] = time.monotonic() - phase_started
+        timings["total_seconds"] = time.monotonic() - started
+        return JSONResponse(
+            content=result | {"api_timings": timings, "worker_timings": worker_timings}
+        )
+    except (Exception, asyncio.CancelledError) as exc:
+        rollback_error = None
+        try:
+            status = await asyncio.to_thread(client.request, "status")
+            if detached and status["state"] == "ATTACHING":
+                assert ticket is not None
+                await _attach_engine(
+                    raw_request,
+                    client,
+                    {**ticket, "root_pid": status["root_pid"]},
+                    resource_policy,
+                    rollback=True,
+                )
+            elif detached and status["state"] == "DRAINING":
+                assert ticket is not None
+                rollback = await asyncio.to_thread(client.request, "rollback_capture")
+                await _attach_engine(
+                    raw_request,
+                    client,
+                    rollback["ticket"],
+                    resource_policy,
+                    rollback=True,
+                )
+            elif detached and status["state"] != "HIBERNATED":
+                raise RuntimeError(
+                    f"cannot roll back capture from state {status['state']}"
+                )
+            elif checkpoint_prepare_started:
+                await engine.checkpoint_abort()
+
+            if not detached and paused:
+                await engine.resume_generation()
+            if manager_prepared:
+                status = await asyncio.to_thread(client.request, "status")
+                if status["state"] == "DRAINING":
+                    await asyncio.to_thread(client.request, "abort_capture")
+                elif status["state"] not in ("READY", "HIBERNATED"):
+                    raise RuntimeError(
+                        "capture rollback did not return snapshot manager to READY"
+                    )
+        except (Exception, asyncio.CancelledError) as cleanup_exc:
+            rollback_error = cleanup_exc
+            try:
+                await _fail_capture(client, cleanup_exc)
+            except (Exception, asyncio.CancelledError):
+                logger.exception("Failed to mark snapshot operation as failed")
+
+        if rollback_error is None:
+            if not (detached and status["state"] == "HIBERNATED"):
+                await gate.open()
+            raise
+        raise RuntimeError(f"{exc}; capture rollback failed: {rollback_error}") from exc
+
+
+async def _wake_level3(
+    raw_request: Request,
+    client: SnapshotControlClient,
+    status: Mapping[str, Any],
+) -> JSONResponse:
+    started = time.monotonic()
+    timings: dict[str, float] = {}
+    phase_started = time.monotonic()
+    result = await asyncio.to_thread(client.request, "restore")
+    timings["manager_restore_seconds"] = time.monotonic() - phase_started
+    try:
+        provider_result = result["provider_result"]
+        manager_timings = result["manager_timings"]
+        attach_timings, worker_timings = await _attach_engine(
+            raw_request,
+            client,
+            result["ticket"],
+            status["resource_policy"],
+        )
+        result = await asyncio.to_thread(client.request, "status")
+        timings.update(
+            {
+                "attach_total_seconds" if name == "total_seconds" else name: seconds
+                for name, seconds in attach_timings.items()
+            }
+        )
+        phase_started = time.monotonic()
+        await raw_request.app.state.engine_snapshot_gate.open()
+        timings["gate_open_seconds"] = time.monotonic() - phase_started
+    except (Exception, asyncio.CancelledError) as exc:
+        await asyncio.to_thread(client.request, "fail_restore", {"error": str(exc)})
+        raise
+    timings["total_seconds"] = time.monotonic() - started
+    return JSONResponse(
+        content=result
+        | {
+            "provider_result": provider_result,
+            "manager_timings": manager_timings,
+            "api_timings": timings,
+            "worker_timings": worker_timings,
+        }
+    )
+
+
 @router.post("/wake_up")
-async def wake_up(raw_request: Request):
-    tags = raw_request.query_params.getlist("tags")
-    if tags == []:
-        # set to None to wake up all tags if no tags are provided
-        tags = None
+async def wake_up(raw_request: Request) -> Response:
+    tags: list[str] | None = raw_request.query_params.getlist("tags") or None
+    client = snapshot_client(raw_request)
+    if client is not None:
+        return await _run_snapshot_lifecycle(
+            _run_exclusive_snapshot_operation(
+                raw_request,
+                lambda: _wake_with_snapshot(raw_request, client, tags),
+            )
+        )
+    logger.info("wake up the engine with tags: %s", tags)
+    await engine_client(raw_request).wake_up(tags)
+    return Response(status_code=200)
+
+
+async def _wake_with_snapshot(
+    raw_request: Request,
+    client: SnapshotControlClient,
+    tags: list[str] | None,
+) -> Response:
+    status = await asyncio.to_thread(client.request, "status")
+    if status["state"] == "HIBERNATED":
+        if tags is not None:
+            raise HTTPException(400, "tags are not supported for level 3 wake")
+        return await _wake_level3(raw_request, client, status)
+    if status["state"] != "READY":
+        raise HTTPException(409, f"Engine snapshot state is {status['state']}")
     logger.info("wake up the engine with tags: %s", tags)
     await engine_client(raw_request).wake_up(tags)
     return Response(status_code=200)
 
 
 @router.get("/is_sleeping")
-async def is_sleeping(raw_request: Request):
+async def is_sleeping(raw_request: Request) -> JSONResponse:
+    client = snapshot_client(raw_request)
+    if client is not None:
+        status = await asyncio.to_thread(client.request, "status")
+        if status["state"] == "FAILED":
+            return JSONResponse(
+                content={
+                    "is_sleeping": False,
+                    "snapshot_state": status["state"],
+                }
+            )
+        if status["state"] != "READY":
+            return JSONResponse(
+                content={
+                    "is_sleeping": True,
+                    "level": 3,
+                    "snapshot_state": status["state"],
+                }
+            )
     is_sleeping = await engine_client(raw_request).is_sleeping()
     return JSONResponse(content={"is_sleeping": is_sleeping})
 
 
-def attach_router(app: FastAPI):
+@router.get("/snapshot/status")
+async def snapshot_status(raw_request: Request) -> JSONResponse:
+    client = snapshot_client(raw_request)
+    if client is None:
+        raise HTTPException(404, "Engine snapshots are not enabled")
+    return JSONResponse(content=await asyncio.to_thread(client.request, "status"))
+
+
+def attach_router(app: FastAPI) -> None:
     app.include_router(router)

--- a/vllm/entrypoints/serve/instrumentator/health.py
+++ b/vllm/entrypoints/serve/instrumentator/health.py
@@ -2,8 +2,10 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 
+import asyncio
+
 from fastapi import APIRouter, Request
-from fastapi.responses import Response
+from fastapi.responses import JSONResponse, Response
 
 from vllm.engine.protocol import EngineClient
 from vllm.logger import init_logger
@@ -15,7 +17,7 @@ logger = init_logger(__name__)
 router = APIRouter()
 
 
-def engine_client(request: Request) -> EngineClient:
+def engine_client(request: Request) -> EngineClient | None:
     return request.app.state.engine_client
 
 
@@ -23,8 +25,35 @@ def engine_client(request: Request) -> EngineClient:
 async def health(raw_request: Request) -> Response:
     """Health check."""
     client = engine_client(raw_request)
+    snapshot_client = getattr(raw_request.app.state, "engine_snapshot_client", None)
+    if snapshot_client is not None:
+        try:
+            await asyncio.to_thread(snapshot_client.request, "status")
+            return Response(status_code=200)
+        except Exception:
+            return Response(status_code=503)
     if client is None:
         # Render-only servers have no engine; they are always healthy.
+        return Response(status_code=200)
+    try:
+        await client.check_health()
+        return Response(status_code=200)
+    except EngineDeadError:
+        return Response(status_code=503)
+
+
+@router.get("/ready")
+async def ready(raw_request: Request) -> Response:
+    snapshot_client = getattr(raw_request.app.state, "engine_snapshot_client", None)
+    if snapshot_client is not None:
+        try:
+            status = await asyncio.to_thread(snapshot_client.request, "status")
+        except Exception:
+            return Response(status_code=503)
+        if status["state"] != "READY":
+            return JSONResponse(status_code=503, content=status)
+    client = engine_client(raw_request)
+    if client is None:
         return Response(status_code=200)
     try:
         await client.check_health()

--- a/vllm/snapshot/__init__.py
+++ b/vllm/snapshot/__init__.py
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from vllm.snapshot.manager import EngineSnapshotManager, SnapshotState
+
+__all__ = ["EngineSnapshotManager", "SnapshotState"]

--- a/vllm/snapshot/manager.py
+++ b/vllm/snapshot/manager.py
@@ -1,0 +1,1048 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import platform
+import shutil
+import signal
+import socket
+import sys
+import threading
+import time
+import uuid
+from dataclasses import asdict, dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any, Protocol
+
+from vllm.snapshot.protocol import SnapshotControlError, _read_message
+from vllm.snapshot.providers import (
+    CriuCudaSnapshotProvider,
+    SnapshotProvider,
+    make_snapshot_provider,
+)
+from vllm.snapshot.resources import parse_snapshot_resource_policy
+
+
+class SnapshotState(str, Enum):
+    READY = "READY"
+    DRAINING = "DRAINING"
+    PREPARING = "PREPARING"
+    SNAPSHOTTING = "SNAPSHOTTING"
+    HIBERNATED = "HIBERNATED"
+    RESTORING = "RESTORING"
+    ATTACHING = "ATTACHING"
+    VERIFYING = "VERIFYING"
+    FAILED = "FAILED"
+
+
+@dataclass
+class SnapshotStatus:
+    state: SnapshotState = SnapshotState.READY
+    generation: int = 0
+    snapshot_id: str | None = None
+    root_pid: int | None = None
+    last_error: str | None = None
+    operation_started_at: float | None = None
+    operation_finished_at: float | None = None
+
+
+@dataclass(frozen=True)
+class SnapshotTicket:
+    snapshot_id: str
+    nonce: str
+    generation: int
+    config_hash: str
+    root_pid: int
+    marker_path: str
+
+
+class SnapshotProcessManager(Protocol):
+    def prepare_snapshot(self) -> int: ...
+
+    def cancel_snapshot(self) -> None: ...
+
+    def wait_for_snapshot_exit(self, timeout: float = 30) -> None: ...
+
+    def adopt_restored_process(self, pid: int) -> None: ...
+
+    def discard_restored_process(self) -> None: ...
+
+
+_MAX_CONTROL_CONNECTIONS = 8
+_CONTROL_REQUEST_TIMEOUT_SECONDS = 5.0
+
+
+class EngineSnapshotManager:
+    def __init__(
+        self,
+        socket_path: str,
+        snapshot_root: str,
+        root_pid: int,
+        *,
+        provider: str | SnapshotProvider = "fake",
+        config_hash: str = "",
+        snapshot_config: dict[str, Any] | None = None,
+        resource_policy: str = "full",
+        persistence: str = "durable",
+        integrity: str = "optimistic",
+        process_manager: SnapshotProcessManager | None = None,
+    ) -> None:
+        self.socket_path = Path(socket_path)
+        self.snapshot_root = Path(snapshot_root)
+        self.status = SnapshotStatus(root_pid=root_pid)
+        self.config_hash = config_hash
+        self.provider = (
+            provider
+            if isinstance(provider, SnapshotProvider)
+            else make_snapshot_provider(provider)
+        )
+        self.snapshot_config = _json_value(snapshot_config or {})
+        self.resource_policy = parse_snapshot_resource_policy(resource_policy)
+        self.persistence = self._parse_persistence(persistence)
+        self.integrity = self._parse_integrity(integrity)
+        self.compatibility = self._runtime_compatibility()
+        self.configured_artifacts = self._configured_artifacts()
+        self.process_manager = process_manager
+        self._state_lock = threading.Lock()
+        self._operation_lock = threading.Lock()
+        self._stop = threading.Event()
+        self._request_slots = threading.BoundedSemaphore(_MAX_CONTROL_CONNECTIONS)
+        self._server: socket.socket | None = None
+        self._thread: threading.Thread | None = None
+        self._ticket: SnapshotTicket | None = None
+        self._previous_snapshot_id: str | None = None
+
+    def start(self) -> None:
+        self.snapshot_root.mkdir(parents=True, exist_ok=True, mode=0o700)
+        entries = list(self.snapshot_root.iterdir())
+        if entries:
+            names = ", ".join(sorted(entry.name for entry in entries))
+            raise RuntimeError(
+                "engine snapshot directory is not empty; inspect or explicitly "
+                f"remove its contents before cold start: {names}"
+            )
+        self.snapshot_root.chmod(0o700)
+        self.socket_path.parent.mkdir(parents=True, exist_ok=True)
+        self.socket_path.unlink(missing_ok=True)
+        self._server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        self._server.bind(str(self.socket_path))
+        os.chmod(self.socket_path, 0o600)
+        self._server.listen(_MAX_CONTROL_CONNECTIONS)
+        self._server.settimeout(0.2)
+        self._thread = threading.Thread(
+            target=self._serve, name="engine-snapshot-control", daemon=True
+        )
+        self._thread.start()
+
+    def close(self) -> None:
+        self._stop.set()
+        if self._server is not None:
+            self._server.close()
+        if self._thread is not None:
+            self._thread.join(timeout=2)
+        self.socket_path.unlink(missing_ok=True)
+
+    def snapshot_status(self) -> dict[str, Any]:
+        with self._state_lock:
+            return self._status_dict()
+
+    def prepare_capture(self) -> dict[str, Any]:
+        with self._state_lock:
+            if self.status.state is not SnapshotState.READY:
+                raise SnapshotControlError(
+                    f"capture requires READY, got {self.status.state}",
+                    code="invalid_state",
+                )
+            root_pid = self._require_live_root()
+            self.status.state = SnapshotState.DRAINING
+            self.status.operation_started_at = time.time()
+            self.status.operation_finished_at = None
+            self.status.last_error = None
+            snapshot_id = uuid.uuid4().hex
+            marker_path = self.snapshot_root / f".{snapshot_id}.detached.json"
+            marker_path.unlink(missing_ok=True)
+            self._ticket = SnapshotTicket(
+                snapshot_id=snapshot_id,
+                nonce=uuid.uuid4().hex,
+                generation=self.status.generation + 1,
+                config_hash=self.config_hash,
+                root_pid=root_pid,
+                marker_path=str(marker_path),
+            )
+            self._previous_snapshot_id = self.status.snapshot_id
+            return self._status_dict() | {"ticket": asdict(self._ticket)}
+
+    def abort_capture(self) -> dict[str, Any]:
+        with self._state_lock:
+            if self.status.state is not SnapshotState.DRAINING:
+                raise SnapshotControlError(
+                    f"abort requires DRAINING, got {self.status.state}",
+                    code="invalid_state",
+                )
+            self.status.state = SnapshotState.READY
+            self.status.operation_finished_at = time.time()
+            self._clear_ticket()
+            return self._status_dict()
+
+    def rollback_capture(self) -> dict[str, Any]:
+        with self._state_lock:
+            if self.status.state is not SnapshotState.DRAINING:
+                raise SnapshotControlError(
+                    f"rollback requires DRAINING, got {self.status.state}",
+                    code="invalid_state",
+                )
+            ticket = self._require_ticket()
+            self.status.state = SnapshotState.ATTACHING
+            self.status.last_error = "capture was canceled after EngineCore I/O detach"
+            self.status.operation_finished_at = time.time()
+            if not self._signal_snapshot_resume(ticket.root_pid):
+                self.status.state = SnapshotState.FAILED
+                self.status.root_pid = None
+                raise RuntimeError("EngineCore root exited before snapshot I/O resume")
+            return self._status_dict() | {
+                "ticket": asdict(ticket),
+            }
+
+    def capture(self) -> dict[str, Any]:
+        if not self._operation_lock.acquire(blocking=False):
+            raise SnapshotControlError(
+                "another snapshot operation is running", code="busy"
+            )
+        manager_started = time.monotonic()
+        manager_timings: dict[str, float] = {}
+        ticket: SnapshotTicket | None = None
+        root_pid: int | None = None
+        staging: Path | None = None
+        previous_snapshot_id: str | None = None
+        try:
+            with self._state_lock:
+                if self.status.state is not SnapshotState.DRAINING:
+                    raise SnapshotControlError(
+                        f"capture requires DRAINING, got {self.status.state}",
+                        code="invalid_state",
+                    )
+                ticket = self._require_ticket()
+                self.status.state = SnapshotState.PREPARING
+            phase_started = time.monotonic()
+            self._validate_detach_marker(ticket)
+            manager_timings["detach_marker_seconds"] = time.monotonic() - phase_started
+            phase_started = time.monotonic()
+            root_pid = (
+                self.process_manager.prepare_snapshot()
+                if self.process_manager is not None
+                else self._require_live_root()
+            )
+            manager_timings["process_prepare_seconds"] = (
+                time.monotonic() - phase_started
+            )
+            snapshot_id = ticket.snapshot_id
+            previous_snapshot_id = self._previous_snapshot_id
+            with self._state_lock:
+                self.status.snapshot_id = snapshot_id
+                self.status.state = SnapshotState.SNAPSHOTTING
+            staging = self.snapshot_root / f".{snapshot_id}.staging"
+            committed = self.snapshot_root / snapshot_id
+            result: dict[str, Any] | None = None
+            try:
+                phase_started = time.monotonic()
+                result = self.provider.capture(root_pid, staging)
+                manager_timings["provider_capture_seconds"] = (
+                    time.monotonic() - phase_started
+                )
+                phase_started = time.monotonic()
+                if (
+                    result.get("source_exited", False)
+                    and self.process_manager is not None
+                ):
+                    self.process_manager.wait_for_snapshot_exit()
+                manager_timings["source_exit_wait_seconds"] = (
+                    time.monotonic() - phase_started
+                )
+                (staging / "root.pid").write_text(f"{root_pid}\n")
+                phase_started = time.monotonic()
+                artifacts = self._artifact_inventory(staging, self.integrity)
+                inventory_seconds = time.monotonic() - phase_started
+                manager_timings["artifact_inventory_seconds"] = inventory_seconds
+                if self.integrity == "strict":
+                    manager_timings["artifact_sha256_seconds"] = inventory_seconds
+                phase_started = time.monotonic()
+                manifest = self._manifest(result, artifacts)
+                manifest_path = staging / "manifest.json"
+                manifest_bytes = (json.dumps(manifest, indent=2) + "\n").encode()
+                manifest_path.write_bytes(manifest_bytes)
+                (staging / "manifest.sha256").write_text(
+                    hashlib.sha256(manifest_bytes).hexdigest() + "\n"
+                )
+                manager_timings["manifest_write_seconds"] = (
+                    time.monotonic() - phase_started
+                )
+                phase_started = time.monotonic()
+                self._sync_tree(staging)
+                manager_timings["fsync_seconds"] = time.monotonic() - phase_started
+                phase_started = time.monotonic()
+                staging.rename(committed)
+                manager_timings["rename_seconds"] = time.monotonic() - phase_started
+                phase_started = time.monotonic()
+                self._sync_directory(self.snapshot_root)
+                manager_timings["parent_fsync_seconds"] = (
+                    time.monotonic() - phase_started
+                )
+                phase_started = time.monotonic()
+                if previous_snapshot_id is not None:
+                    shutil.rmtree(self.snapshot_root / previous_snapshot_id)
+                manager_timings["previous_snapshot_cleanup_seconds"] = (
+                    time.monotonic() - phase_started
+                )
+                with self._state_lock:
+                    self.status.state = SnapshotState.HIBERNATED
+                    if result.get("source_exited", False):
+                        self.status.root_pid = None
+                    self.status.operation_finished_at = time.time()
+                    self._remove_marker(ticket)
+                    manager_timings["total_seconds"] = (
+                        time.monotonic() - manager_started
+                    )
+                    return self._status_dict() | {
+                        "manifest": manifest,
+                        "manager_timings": manager_timings,
+                    }
+            except BaseException as exc:
+                rollback_result: dict[str, Any] | None = None
+                rollback_error: BaseException | None = None
+                if result is not None and result.get("source_exited", False):
+                    rollback_dir = committed if committed.exists() else staging
+                    try:
+                        rollback_result = self.provider.rollback_capture(rollback_dir)
+                        if rollback_result is None:
+                            raise RuntimeError(
+                                "snapshot provider cannot roll back an exited source"
+                            )
+                        if self.process_manager is not None:
+                            self.process_manager.adopt_restored_process(
+                                int(rollback_result["root_pid"])
+                            )
+                    except BaseException as rollback_exc:
+                        rollback_error = rollback_exc
+                elif self.process_manager is not None:
+                    self.process_manager.cancel_snapshot()
+                resume_succeeded = False
+                with self._state_lock:
+                    error = str(exc)
+                    if rollback_error is not None:
+                        error += f"; capture rollback failed: {rollback_error}"
+                    self.status.last_error = error
+                    self.status.snapshot_id = previous_snapshot_id
+                    self.status.operation_finished_at = time.time()
+                    self._remove_marker(ticket)
+                    if rollback_result is not None:
+                        resume_pid = int(rollback_result["root_pid"])
+                    else:
+                        resume_pid = root_pid
+                    if resume_pid is not None and self._signal_snapshot_resume(
+                        resume_pid
+                    ):
+                        resume_succeeded = True
+                        self.status.root_pid = resume_pid
+                        self.status.state = SnapshotState.ATTACHING
+                    else:
+                        self.status.root_pid = None
+                        self.status.state = SnapshotState.FAILED
+                cleanup_error = None
+                if rollback_result is not None or (
+                    result is None and resume_succeeded
+                ):
+                    cleanup_error = self._remove_snapshot_trees(staging, committed)
+                if cleanup_error is not None:
+                    with self._state_lock:
+                        self.status.last_error = (
+                            f"{self.status.last_error}; "
+                            f"snapshot cleanup failed: {cleanup_error}"
+                        )
+                    raise RuntimeError(
+                        f"{exc}; snapshot cleanup failed: {cleanup_error}"
+                    ) from exc
+                raise
+        except BaseException as exc:
+            if ticket is not None and root_pid is None:
+                with self._state_lock:
+                    self.status.last_error = str(exc)
+                    self.status.snapshot_id = self._previous_snapshot_id
+                    self.status.operation_finished_at = time.time()
+                    if self._signal_snapshot_resume(ticket.root_pid):
+                        self.status.state = SnapshotState.ATTACHING
+                    else:
+                        self.status.root_pid = None
+                        self.status.state = SnapshotState.FAILED
+            raise
+        finally:
+            self._operation_lock.release()
+
+    def restore(self) -> dict[str, Any]:
+        if not self._operation_lock.acquire(blocking=False):
+            raise SnapshotControlError(
+                "another snapshot operation is running", code="busy"
+            )
+        manager_started = time.monotonic()
+        manager_timings: dict[str, float] = {}
+        try:
+            with self._state_lock:
+                if self.status.state is not SnapshotState.HIBERNATED:
+                    raise SnapshotControlError(
+                        f"restore requires HIBERNATED, got {self.status.state}",
+                        code="invalid_state",
+                    )
+                self.status.state = SnapshotState.RESTORING
+                self.status.operation_started_at = time.time()
+                self.status.operation_finished_at = None
+                snapshot_dir = self._current_snapshot_dir()
+            result: dict[str, Any] | None = None
+            adopted = False
+            restore_attempted = False
+            try:
+                manager_timings.update(self._validate_manifest(snapshot_dir))
+                ticket = self._require_ticket()
+                phase_started = time.monotonic()
+                self._mark_restore_attempt(snapshot_dir)
+                manager_timings["restore_attempt_marker_seconds"] = (
+                    time.monotonic() - phase_started
+                )
+                restore_attempted = True
+                phase_started = time.monotonic()
+                result = self.provider.restore(snapshot_dir)
+                manager_timings["provider_restore_seconds"] = (
+                    time.monotonic() - phase_started
+                )
+                phase_started = time.monotonic()
+                if self.process_manager is not None:
+                    self.process_manager.adopt_restored_process(int(result["root_pid"]))
+                    adopted = True
+                manager_timings["pidfd_adopt_seconds"] = (
+                    time.monotonic() - phase_started
+                )
+                with self._state_lock:
+                    self.status.state = SnapshotState.ATTACHING
+                    self.status.root_pid = int(result["root_pid"])
+                    phase_started = time.monotonic()
+                    if not self._signal_snapshot_resume(self.status.root_pid):
+                        raise RuntimeError("restored EngineCore root is not alive")
+                    manager_timings["resume_signal_seconds"] = (
+                        time.monotonic() - phase_started
+                    )
+                    manager_timings["total_seconds"] = (
+                        time.monotonic() - manager_started
+                    )
+                    return self._status_dict() | {
+                        "provider_result": result,
+                        "ticket": asdict(ticket) | {"root_pid": self.status.root_pid},
+                        "manager_timings": manager_timings,
+                    }
+            except BaseException as exc:
+                cleanup_error = None
+                if result is not None:
+                    root_pid = int(result["root_pid"])
+                    try:
+                        if adopted and self.process_manager is not None:
+                            self.process_manager.discard_restored_process()
+                        elif self._pid_alive(root_pid):
+                            self._discard_provider_process(root_pid)
+                    except BaseException as cleanup_exc:
+                        cleanup_error = cleanup_exc
+                with self._state_lock:
+                    self.status.last_error = str(exc)
+                    if cleanup_error is not None:
+                        self.status.last_error += (
+                            f"; restored Engine cleanup failed: {cleanup_error}"
+                        )
+                    self.status.operation_finished_at = time.time()
+                    self.status.state = (
+                        SnapshotState.HIBERNATED
+                        if cleanup_error is None
+                        and (
+                            self.provider.restore_is_retriable or not restore_attempted
+                        )
+                        else SnapshotState.FAILED
+                    )
+                    self.status.root_pid = (
+                        int(result["root_pid"])
+                        if cleanup_error is not None
+                        and result is not None
+                        and self._pid_alive(int(result["root_pid"]))
+                        else None
+                    )
+                raise
+        finally:
+            self._operation_lock.release()
+
+    def complete_restore(self) -> dict[str, Any]:
+        with self._state_lock:
+            if self.status.state is not SnapshotState.VERIFYING:
+                raise SnapshotControlError(
+                    f"complete restore requires VERIFYING, got {self.status.state}",
+                    code="invalid_state",
+                )
+            self.status.state = SnapshotState.READY
+            self.status.generation = self._require_ticket().generation
+            self.status.operation_finished_at = time.time()
+            self._clear_ticket()
+            return self._status_dict()
+
+    def confirm_attach(self, payload: dict[str, Any]) -> dict[str, Any]:
+        with self._state_lock:
+            if self.status.state is not SnapshotState.ATTACHING:
+                raise SnapshotControlError(
+                    f"attach confirmation requires ATTACHING, got {self.status.state}",
+                    code="invalid_state",
+                )
+            ticket = self._require_ticket()
+            expected = asdict(ticket) | {"root_pid": self.status.root_pid}
+            for field in (
+                "snapshot_id",
+                "nonce",
+                "generation",
+                "config_hash",
+                "root_pid",
+            ):
+                if payload.get(field) != expected[field]:
+                    raise SnapshotControlError(
+                        f"attach confirmation {field} mismatch",
+                        code="identity_mismatch",
+                    )
+            self.status.state = SnapshotState.VERIFYING
+            return self._status_dict()
+
+    def complete_capture_rollback(self) -> dict[str, Any]:
+        with self._state_lock:
+            if (
+                self.status.state is not SnapshotState.VERIFYING
+                or self.status.snapshot_id != self._previous_snapshot_id
+            ):
+                raise SnapshotControlError(
+                    "capture rollback requires the previous snapshot in VERIFYING",
+                    code="invalid_state",
+                )
+            self.status.state = SnapshotState.READY
+            self.status.generation = self._require_ticket().generation
+            self.status.operation_finished_at = time.time()
+            self._clear_ticket()
+            return self._status_dict()
+
+    def fail_restore(self, error: str) -> dict[str, Any]:
+        with self._state_lock:
+            if self.status.state not in (
+                SnapshotState.ATTACHING,
+                SnapshotState.VERIFYING,
+            ):
+                raise SnapshotControlError(
+                    f"fail restore requires VERIFYING, got {self.status.state}",
+                    code="invalid_state",
+                )
+            cleanup_error = None
+            root_pid = self.status.root_pid
+            try:
+                if self.process_manager is not None:
+                    self.process_manager.discard_restored_process()
+                elif root_pid is not None and self._pid_alive(root_pid):
+                    self._discard_provider_process(root_pid)
+            except BaseException as exc:
+                cleanup_error = exc
+            self.status.state = (
+                SnapshotState.HIBERNATED
+                if self.provider.restore_is_retriable and cleanup_error is None
+                else SnapshotState.FAILED
+            )
+            self.status.root_pid = (
+                root_pid
+                if cleanup_error is not None
+                and root_pid is not None
+                and self._pid_alive(root_pid)
+                else None
+            )
+            self.status.last_error = error
+            if cleanup_error is not None:
+                self.status.last_error += (
+                    f"; restored Engine cleanup failed: {cleanup_error}"
+                )
+            self.status.operation_finished_at = time.time()
+            return self._status_dict()
+
+    def fail_capture(self, error: str) -> dict[str, Any]:
+        with self._state_lock:
+            if self.status.state not in (
+                SnapshotState.DRAINING,
+                SnapshotState.ATTACHING,
+                SnapshotState.VERIFYING,
+            ):
+                raise SnapshotControlError(
+                    "fail capture requires DRAINING, ATTACHING, or VERIFYING, "
+                    f"got {self.status.state}",
+                    code="invalid_state",
+                )
+            cleanup_error = None
+            root_pid = self.status.root_pid
+            try:
+                if self.process_manager is not None:
+                    self.process_manager.discard_restored_process()
+                elif root_pid is not None and self._pid_alive(root_pid):
+                    self._discard_provider_process(root_pid)
+            except BaseException as exc:
+                cleanup_error = exc
+            self.status.state = SnapshotState.FAILED
+            self.status.root_pid = (
+                root_pid
+                if cleanup_error is not None
+                and root_pid is not None
+                and self._pid_alive(root_pid)
+                else None
+            )
+            self.status.last_error = error
+            if cleanup_error is not None:
+                self.status.last_error += f"; Engine cleanup failed: {cleanup_error}"
+            self.status.operation_finished_at = time.time()
+            self._clear_ticket()
+            return self._status_dict()
+
+    def _serve(self) -> None:
+        assert self._server is not None
+        while not self._stop.is_set():
+            try:
+                conn, _ = self._server.accept()
+            except (TimeoutError, OSError):
+                continue
+            if not self._request_slots.acquire(blocking=False):
+                conn.close()
+                continue
+            threading.Thread(
+                target=self._handle_connection_with_slot,
+                args=(conn,),
+                daemon=True,
+                name="engine-snapshot-request",
+            ).start()
+
+    def _handle_connection_with_slot(self, conn: socket.socket) -> None:
+        try:
+            conn.settimeout(_CONTROL_REQUEST_TIMEOUT_SECONDS)
+            self._handle_connection(conn)
+        finally:
+            conn.close()
+            self._request_slots.release()
+
+    def _handle_connection(self, conn: socket.socket) -> None:
+        with conn:
+            try:
+                request = _read_message(conn)
+                command = request.get("command")
+                if command == "status":
+                    result = self.snapshot_status()
+                elif command == "prepare_capture":
+                    result = self.prepare_capture()
+                elif command == "abort_capture":
+                    result = self.abort_capture()
+                elif command == "rollback_capture":
+                    result = self.rollback_capture()
+                elif command == "capture":
+                    result = self.capture()
+                elif command == "restore":
+                    result = self.restore()
+                elif command == "complete_restore":
+                    result = self.complete_restore()
+                elif command == "confirm_attach":
+                    result = self.confirm_attach(dict(request.get("payload", {})))
+                elif command == "complete_capture_rollback":
+                    result = self.complete_capture_rollback()
+                elif command == "fail_restore":
+                    result = self.fail_restore(
+                        str(request.get("payload", {}).get("error", "verify failed"))
+                    )
+                elif command == "fail_capture":
+                    result = self.fail_capture(
+                        str(request.get("payload", {}).get("error", "prepare failed"))
+                    )
+                else:
+                    raise SnapshotControlError(
+                        f"unknown snapshot command: {command}",
+                        code="unknown_command",
+                    )
+                response = {"ok": True, "result": result}
+            except SnapshotControlError as exc:
+                response = {"ok": False, "code": exc.code, "error": str(exc)}
+            except Exception as exc:
+                response = {
+                    "ok": False,
+                    "code": "snapshot_error",
+                    "error": str(exc),
+                }
+            conn.sendall(json.dumps(response).encode() + b"\n")
+
+    def _status_dict(self) -> dict[str, Any]:
+        return asdict(self.status) | {
+            "state": self.status.state.value,
+            "resource_policy": self.resource_policy.to_wire(),
+            "persistence": self.persistence,
+            "integrity": self.integrity,
+        }
+
+    def _manifest(
+        self,
+        provider_result: dict[str, Any],
+        artifacts: dict[str, Any],
+    ) -> dict[str, Any]:
+        ticket = self._require_ticket()
+        return {
+            "format_version": 2,
+            "snapshot_id": self.status.snapshot_id,
+            "generation": ticket.generation,
+            "nonce": ticket.nonce,
+            "config_hash": self.config_hash,
+            "snapshot_config": self.snapshot_config,
+            "root_pid": self.status.root_pid,
+            "created_at": time.time(),
+            "resource_policy": self.resource_policy.to_wire(),
+            "persistence": self.persistence,
+            "integrity": self.integrity,
+            "compatibility": self.compatibility,
+            "configured_artifacts": self.configured_artifacts,
+            "provider": provider_result,
+            "artifacts": artifacts,
+        }
+
+    def _validate_manifest(self, snapshot_dir: Path) -> dict[str, float]:
+        timings = {}
+        phase_started = time.monotonic()
+        manifest_path = snapshot_dir / "manifest.json"
+        manifest_bytes = manifest_path.read_bytes()
+        manifest_digest = (snapshot_dir / "manifest.sha256").read_text().strip()
+        if hashlib.sha256(manifest_bytes).hexdigest() != manifest_digest:
+            raise RuntimeError("snapshot manifest digest mismatch")
+        manifest = json.loads(manifest_bytes)
+        timings["manifest_digest_seconds"] = time.monotonic() - phase_started
+        phase_started = time.monotonic()
+        ticket = self._require_ticket()
+        if manifest.get("format_version") != 2:
+            raise RuntimeError("unsupported snapshot format")
+        if manifest.get("snapshot_id") != self.status.snapshot_id:
+            raise RuntimeError("snapshot id mismatch")
+        if manifest.get("generation") != ticket.generation:
+            raise RuntimeError("snapshot generation mismatch")
+        if manifest.get("nonce") != ticket.nonce:
+            raise RuntimeError("snapshot nonce mismatch")
+        if manifest.get("root_pid") != ticket.root_pid:
+            raise RuntimeError("snapshot root PID mismatch")
+        if manifest.get("config_hash") != self.config_hash:
+            raise RuntimeError("snapshot config hash mismatch")
+        if manifest.get("snapshot_config") != self.snapshot_config:
+            raise RuntimeError("snapshot config mismatch")
+        if manifest.get("resource_policy") != self.resource_policy.to_wire():
+            raise RuntimeError("snapshot resource policy mismatch")
+        if manifest.get("persistence") != self.persistence:
+            raise RuntimeError("snapshot persistence mode mismatch")
+        if manifest.get("integrity") != self.integrity:
+            raise RuntimeError("snapshot integrity mode mismatch")
+        if manifest.get("compatibility") != self.compatibility:
+            raise RuntimeError("snapshot runtime compatibility mismatch")
+        if manifest.get("configured_artifacts") != self.configured_artifacts:
+            raise RuntimeError("snapshot model or tokenizer artifact mismatch")
+        timings["compatibility_validation_seconds"] = time.monotonic() - phase_started
+        phase_started = time.monotonic()
+        if manifest.get("artifacts") != self._artifact_inventory(
+            snapshot_dir, self.integrity
+        ):
+            raise RuntimeError("snapshot artifact inventory mismatch")
+        validation_seconds = time.monotonic() - phase_started
+        timings["artifact_validation_seconds"] = validation_seconds
+        if self.integrity == "strict":
+            timings["artifact_sha256_seconds"] = validation_seconds
+        return timings
+
+    def _mark_restore_attempt(self, snapshot_dir: Path) -> None:
+        if self.provider.restore_is_retriable:
+            return
+        marker_path = snapshot_dir / "restore-attempt.json"
+        marker = {
+            "attempted_at": time.time(),
+            "snapshot_id": self.status.snapshot_id,
+            "generation": self._require_ticket().generation,
+        }
+        try:
+            descriptor = os.open(
+                marker_path,
+                os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+                0o600,
+            )
+        except FileExistsError as exc:
+            raise RuntimeError(
+                "snapshot restore was already attempted and is not retriable"
+            ) from exc
+        with os.fdopen(descriptor, "w") as marker_file:
+            json.dump(marker, marker_file)
+            marker_file.write("\n")
+            marker_file.flush()
+            if self.persistence == "durable":
+                os.fsync(marker_file.fileno())
+        self._sync_directory(snapshot_dir)
+
+    @staticmethod
+    def _parse_persistence(name: str) -> str:
+        if name not in ("durable", "page_cache"):
+            raise ValueError(f"unknown snapshot persistence mode: {name}")
+        return name
+
+    @staticmethod
+    def _parse_integrity(name: str) -> str:
+        if name not in ("optimistic", "strict"):
+            raise ValueError(f"unknown snapshot integrity mode: {name}")
+        return name
+
+    def _runtime_compatibility(self) -> dict[str, Any]:
+        import torch
+
+        from vllm.platforms import current_platform
+        from vllm.version import __version__ as vllm_version
+
+        driver_path = Path("/proc/driver/nvidia/version")
+        capability = current_platform.get_device_capability()
+        gpu_uuid = (
+            current_platform.get_device_uuid()
+            if isinstance(self.provider, CriuCudaSnapshotProvider)
+            else None
+        )
+        compute_capability = (
+            {"major": capability.major, "minor": capability.minor}
+            if capability is not None
+            else None
+        )
+        return {
+            "python": sys.version,
+            "platform": {
+                "machine": platform.machine(),
+                "kernel": platform.release(),
+                "libc": list(platform.libc_ver()),
+            },
+            "vllm_version": vllm_version,
+            "torch_version": str(torch.__version__),
+            "torch_cuda": torch.version.cuda,
+            "gpu_uuid": gpu_uuid,
+            "compute_capability": compute_capability,
+            "nvidia_driver": (
+                driver_path.read_text(errors="replace").strip()
+                if driver_path.exists()
+                else None
+            ),
+            "provider": self.provider.runtime_identity(),
+        }
+
+    def _configured_artifacts(self) -> dict[str, Any]:
+        identities: dict[str, Any] = {}
+        path_identities: dict[str, dict[str, Any]] = {}
+        for name in ("model", "tokenizer"):
+            value = self.snapshot_config.get(name)
+            if value is None:
+                identities[name] = None
+                continue
+            path = Path(str(value))
+            if not path.exists():
+                identities[name] = {"locator": str(value)}
+                continue
+            resolved = str(path.resolve())
+            if resolved not in path_identities:
+                path_identities[resolved] = self._path_identity(path, self.integrity)
+            identities[name] = path_identities[resolved]
+        return identities
+
+    @classmethod
+    def _path_identity(cls, path: Path, integrity: str) -> dict[str, Any]:
+        if path.is_file():
+            files = [path]
+            root = path.parent
+        elif path.is_dir():
+            files = sorted(
+                entry
+                for entry in path.rglob("*")
+                if entry.is_file() and ".git" not in entry.relative_to(path).parts
+            )
+            root = path
+        else:
+            raise RuntimeError(
+                f"configured artifact is not a file or directory: {path}"
+            )
+        return {"root": str(path.resolve())} | cls._file_inventory(
+            root, files, integrity
+        )
+
+    @classmethod
+    def _artifact_inventory(cls, root: Path, integrity: str) -> dict[str, Any]:
+        excluded = {"manifest.json", "manifest.sha256", "restore-attempt.json"}
+        files = sorted(
+            path
+            for path in root.rglob("*")
+            if path.is_file()
+            and str(path.relative_to(root)) not in excluded
+            and "restore-work-" not in str(path.relative_to(root))
+        )
+        return cls._file_inventory(root, files, integrity)
+
+    @classmethod
+    def _file_inventory(
+        cls, root: Path, files: list[Path], integrity: str
+    ) -> dict[str, Any]:
+        strict = cls._parse_integrity(integrity) == "strict"
+        entries: list[dict[str, Any]] = []
+        for path in files:
+            entry = {
+                "path": str(path.relative_to(root)),
+                "type": "symlink" if path.is_symlink() else "file",
+                "size": path.stat().st_size,
+            }
+            if strict:
+                entry["sha256"] = cls._file_digest(path)
+            entries.append(entry)
+        inventory = {
+            "files": entries,
+            "total_bytes": sum(entry["size"] for entry in entries),
+        }
+        if strict:
+            inventory["sha256"] = config_digest(entries)
+        return inventory
+
+    @staticmethod
+    def _file_digest(path: Path) -> str:
+        digest = hashlib.sha256()
+        with path.open("rb") as input_file:
+            for chunk in iter(lambda: input_file.read(8 * 1024 * 1024), b""):
+                digest.update(chunk)
+        return digest.hexdigest()
+
+    def _current_snapshot_dir(self) -> Path:
+        if self.status.snapshot_id is None:
+            raise RuntimeError("snapshot id is missing")
+        return self.snapshot_root / self.status.snapshot_id
+
+    def _require_ticket(self) -> SnapshotTicket:
+        if self._ticket is None:
+            raise RuntimeError("snapshot ticket is missing")
+        return self._ticket
+
+    def _validate_detach_marker(self, ticket: SnapshotTicket) -> None:
+        deadline = time.monotonic() + 30
+        marker_path = Path(ticket.marker_path)
+        while True:
+            try:
+                marker = json.loads(marker_path.read_text())
+            except FileNotFoundError as exc:
+                if time.monotonic() >= deadline:
+                    raise TimeoutError(
+                        "timed out waiting for EngineCore I/O detach"
+                    ) from exc
+                time.sleep(0.05)
+                continue
+            expected = {
+                "pid": ticket.root_pid,
+                "nonce": ticket.nonce,
+                "generation": ticket.generation,
+                "snapshot_id": ticket.snapshot_id,
+                "config_hash": ticket.config_hash,
+                "state": "detached",
+            }
+            if marker != expected:
+                raise RuntimeError("EngineCore I/O detach marker mismatch")
+            return
+
+    @staticmethod
+    def _remove_marker(ticket: SnapshotTicket) -> None:
+        Path(ticket.marker_path).unlink(missing_ok=True)
+
+    def _clear_ticket(self) -> None:
+        if self._ticket is not None:
+            self._remove_marker(self._ticket)
+        self._ticket = None
+        self._previous_snapshot_id = None
+
+    def _require_live_root(self) -> int:
+        root_pid = self.status.root_pid
+        if root_pid is None or not self._pid_alive(root_pid):
+            raise RuntimeError("EngineCore root is not alive")
+        return root_pid
+
+    def _signal_snapshot_resume(self, root_pid: int) -> bool:
+        if not self._pid_alive(root_pid):
+            return False
+        try:
+            os.kill(root_pid, signal.SIGUSR2)
+        except ProcessLookupError:
+            return False
+        return True
+
+    @staticmethod
+    def _remove_snapshot_trees(*paths: Path) -> OSError | None:
+        cleanup_errors = []
+        for path in paths:
+            try:
+                shutil.rmtree(path)
+            except FileNotFoundError:
+                continue
+            except OSError as exc:
+                cleanup_errors.append(f"{path}: {exc}")
+        if cleanup_errors:
+            return OSError("; ".join(cleanup_errors))
+        return None
+
+    @staticmethod
+    def _pid_alive(pid: int) -> bool:
+        try:
+            os.kill(pid, 0)
+            stat = (Path("/proc") / str(pid) / "stat").read_text().split()
+        except ProcessLookupError:
+            return False
+        except FileNotFoundError:
+            return False
+        return len(stat) > 2 and stat[2] != "Z"
+
+    def _discard_provider_process(self, root_pid: int) -> None:
+        self.provider.discard_restored(root_pid)
+        deadline = time.monotonic() + 5
+        while self._pid_alive(root_pid):
+            if time.monotonic() >= deadline:
+                raise RuntimeError(
+                    f"EngineCore process tree rooted at PID {root_pid} did not exit"
+                )
+            time.sleep(0.05)
+
+    def _sync_tree(self, path: Path) -> None:
+        if self.persistence != "durable":
+            return
+        for root, _, files in os.walk(path):
+            root_path = Path(root)
+            for name in files:
+                entry = root_path / name
+                if entry.is_file():
+                    with entry.open("rb") as file:
+                        os.fsync(file.fileno())
+        for root, directories, _ in os.walk(path, topdown=False):
+            root_path = Path(root)
+            for name in directories:
+                directory = root_path / name
+                if not directory.is_symlink():
+                    self._sync_directory(directory)
+        self._sync_directory(path)
+
+    def _sync_directory(self, path: Path) -> None:
+        if self.persistence != "durable":
+            return
+        dir_fd = os.open(path, os.O_RDONLY)
+        try:
+            os.fsync(dir_fd)
+        finally:
+            os.close(dir_fd)
+
+
+def config_digest(value: Any) -> str:
+    encoded = json.dumps(value, sort_keys=True, default=str).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _json_value(value: Any) -> Any:
+    return json.loads(json.dumps(value, default=str))

--- a/vllm/snapshot/middleware.py
+++ b/vllm/snapshot/middleware.py
@@ -1,0 +1,116 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+import asyncio
+
+from fastapi import Request
+from fastapi.responses import JSONResponse
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+from vllm.snapshot.protocol import SnapshotControlError
+
+_CONFLICT_CODES = frozenset({"busy", "invalid_state", "identity_mismatch"})
+
+
+def snapshot_control_error_handler(
+    _: Request, exc: SnapshotControlError
+) -> JSONResponse:
+    status_code = 409 if exc.code in _CONFLICT_CODES else 500
+    return JSONResponse(
+        status_code=status_code,
+        content={"error": str(exc), "code": exc.code},
+    )
+
+
+class EngineSnapshotGate:
+    def __init__(self) -> None:
+        self._lock = asyncio.Lock()
+        self._accepting = True
+        self._active_requests = 0
+        self._operation_active = False
+
+    async def enter(self) -> bool:
+        async with self._lock:
+            if not self._accepting:
+                return False
+            self._active_requests += 1
+            return True
+
+    async def leave(self) -> None:
+        async with self._lock:
+            self._active_requests -= 1
+            if self._active_requests < 0:
+                raise RuntimeError("snapshot gate request count became negative")
+
+    async def close(self) -> int:
+        async with self._lock:
+            self._accepting = False
+            return self._active_requests
+
+    async def open(self) -> None:
+        async with self._lock:
+            self._accepting = True
+
+    async def begin_operation(self) -> bool:
+        async with self._lock:
+            if self._operation_active:
+                return False
+            self._operation_active = True
+            return True
+
+    async def end_operation(self) -> None:
+        async with self._lock:
+            if not self._operation_active:
+                raise RuntimeError("snapshot gate has no active operation")
+            self._operation_active = False
+
+
+class EngineSnapshotMiddleware:
+    _allowed_paths = {
+        "/health",
+        "/is_sleeping",
+        "/metrics",
+        "/ready",
+        "/sleep",
+        "/snapshot/status",
+        "/wake_up",
+    }
+
+    def __init__(self, app: ASGIApp, gate: EngineSnapshotGate) -> None:
+        self.app = app
+        self.gate = gate
+
+    async def __call__(
+        self,
+        scope: Scope,
+        receive: Receive,
+        send: Send,
+    ) -> None:
+        if (
+            scope["type"] not in ("http", "websocket")
+            or scope["path"] in self._allowed_paths
+        ):
+            await self.app(scope, receive, send)
+            return
+        if not await self.gate.enter():
+            if scope["type"] == "websocket":
+                await send(
+                    {
+                        "type": "websocket.close",
+                        "code": 1013,
+                        "reason": "engine unavailable",
+                    }
+                )
+                return
+            response = JSONResponse(
+                status_code=503,
+                content={"error": "engine unavailable"},
+            )
+            await response(scope, receive, send)
+            return
+        try:
+            await self.app(scope, receive, send)
+        finally:
+            await self.gate.leave()

--- a/vllm/snapshot/process.py
+++ b/vllm/snapshot/process.py
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def process_starttime(pid: int) -> int:
+    stat = (Path("/proc") / str(pid) / "stat").read_text()
+    fields = stat[stat.rfind(")") + 2 :].split()
+    if len(fields) <= 19:
+        raise RuntimeError(f"invalid process stat for PID {pid}")
+    return int(fields[19])
+
+
+def rebind_stdio(source_pid: int, expected_starttime: int | None = None) -> None:
+    source_starttime = process_starttime(source_pid)
+    if expected_starttime is not None and source_starttime != expected_starttime:
+        raise RuntimeError("stdio source process identity changed")
+    source_fds = []
+    try:
+        for target_fd in (1, 2):
+            source_fds.append(
+                os.open(
+                    f"/proc/{source_pid}/fd/{target_fd}",
+                    os.O_WRONLY | os.O_CLOEXEC,
+                )
+            )
+        if process_starttime(source_pid) != source_starttime:
+            raise RuntimeError("stdio source process identity changed")
+        for source_fd, target_fd in zip(source_fds, (1, 2)):
+            os.dup2(source_fd, target_fd, inheritable=True)
+    finally:
+        for source_fd in source_fds:
+            os.close(source_fd)

--- a/vllm/snapshot/protocol.py
+++ b/vllm/snapshot/protocol.py
@@ -1,0 +1,115 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+import json
+import socket
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+
+_MAX_MESSAGE_BYTES = 1024 * 1024
+_READ_CHUNK_BYTES = 65536
+
+
+class SnapshotControlError(RuntimeError):
+    def __init__(self, message: str, *, code: str = "snapshot_error") -> None:
+        super().__init__(message)
+        self.code = code
+
+
+@dataclass(frozen=True)
+class SnapshotControlClient:
+    path: str
+    timeout: float = 1800.0
+
+    def request(
+        self, command: str, payload: Mapping[str, Any] | None = None
+    ) -> dict[str, Any]:
+        request = {"command": command, "payload": dict(payload or {})}
+        try:
+            with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as sock:
+                sock.settimeout(self.timeout)
+                sock.connect(self.path)
+                sock.sendall(json.dumps(request).encode() + b"\n")
+                response = _read_message(sock)
+        except SnapshotControlError:
+            raise
+        except TimeoutError as exc:
+            raise SnapshotControlError(
+                f"snapshot control request timed out after {self.timeout} seconds",
+                code="timeout",
+            ) from exc
+        except OSError as exc:
+            raise SnapshotControlError(
+                f"snapshot control connection failed: {exc}",
+                code="connection_error",
+            ) from exc
+        if not response.get("ok", False):
+            raise SnapshotControlError(
+                response.get("error", "snapshot control request failed"),
+                code=response.get("code", "snapshot_error"),
+            )
+        result = response.get("result")
+        if not isinstance(result, dict):
+            raise SnapshotControlError(
+                "invalid snapshot control response",
+                code="invalid_message",
+            )
+        return result
+
+
+def _read_message(sock: socket.socket) -> dict[str, Any]:
+    chunks = bytearray()
+    while True:
+        try:
+            chunk = sock.recv(_READ_CHUNK_BYTES)
+        except TimeoutError as exc:
+            raise SnapshotControlError(
+                "snapshot control message timed out",
+                code="timeout",
+            ) from exc
+        except OSError as exc:
+            raise SnapshotControlError(
+                f"snapshot control connection failed: {exc}",
+                code="connection_error",
+            ) from exc
+        if not chunk:
+            if not chunks:
+                raise SnapshotControlError(
+                    "snapshot control connection closed",
+                    code="connection_error",
+                )
+            raise SnapshotControlError(
+                "snapshot control message is missing a newline terminator",
+                code="invalid_message",
+            )
+        chunks.extend(chunk)
+        newline = chunks.find(b"\n")
+        if newline >= 0:
+            if newline > _MAX_MESSAGE_BYTES:
+                raise SnapshotControlError(
+                    "snapshot control message is too large",
+                    code="invalid_message",
+                )
+            break
+        if len(chunks) > _MAX_MESSAGE_BYTES:
+            raise SnapshotControlError(
+                "snapshot control message is too large",
+                code="invalid_message",
+            )
+    try:
+        message = json.loads(bytes(chunks[:newline]))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise SnapshotControlError(
+            "invalid snapshot control JSON message",
+            code="invalid_message",
+        ) from exc
+    if not isinstance(message, dict):
+        raise SnapshotControlError(
+            "snapshot control message must be a JSON object",
+            code="invalid_message",
+        )
+    return message

--- a/vllm/snapshot/providers.py
+++ b/vllm/snapshot/providers.py
@@ -1,0 +1,402 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+import hashlib
+import os
+import shutil
+import signal
+import subprocess
+import time
+import uuid
+from abc import ABC, abstractmethod
+from contextlib import suppress
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import regex as re
+
+
+class SnapshotProvider(ABC):
+    @abstractmethod
+    def capture(self, root_pid: int, snapshot_dir: Path) -> dict[str, Any]: ...
+
+    @abstractmethod
+    def restore(self, snapshot_dir: Path) -> dict[str, Any]: ...
+
+    def discard_restored(self, root_pid: int) -> None:
+        self._kill_tree(root_pid)
+
+    def rollback_capture(self, snapshot_dir: Path) -> dict[str, Any] | None:
+        return None
+
+    @property
+    def restore_is_retriable(self) -> bool:
+        return True
+
+    def runtime_identity(self) -> dict[str, Any]:
+        return {"provider": type(self).__name__}
+
+    @staticmethod
+    def _process_tree(root_pid: int) -> list[int]:
+        children: dict[int, list[int]] = {}
+        for entry in Path("/proc").iterdir():
+            if not entry.name.isdigit():
+                continue
+            try:
+                stat = (entry / "stat").read_text()
+                fields = stat[stat.rfind(")") + 2 :].split()
+                children.setdefault(int(fields[1]), []).append(int(entry.name))
+            except (FileNotFoundError, IndexError, PermissionError, ValueError):
+                continue
+        tree = []
+        pending = [root_pid]
+        while pending:
+            pid = pending.pop()
+            tree.append(pid)
+            pending.extend(children.get(pid, ()))
+        return sorted(tree)
+
+    @classmethod
+    def _kill_tree(cls, root_pid: int) -> None:
+        for pid in reversed(cls._process_tree(root_pid)):
+            with suppress(ProcessLookupError):
+                os.kill(pid, signal.SIGKILL)
+
+
+@dataclass
+class FakeSnapshotProvider(SnapshotProvider):
+    delay: float = 0.0
+
+    def capture(self, root_pid: int, snapshot_dir: Path) -> dict[str, Any]:
+        started = time.monotonic()
+        if self.delay:
+            time.sleep(self.delay)
+        snapshot_dir.mkdir(parents=True, exist_ok=False)
+        (snapshot_dir / "fake.img").write_bytes(b"vllm-engine-snapshot\n")
+        os.kill(root_pid, signal.SIGSTOP)
+        return {
+            "root_pid": root_pid,
+            "source_exited": False,
+            "capture_seconds": time.monotonic() - started,
+            "provider": "fake",
+        }
+
+    def restore(self, snapshot_dir: Path) -> dict[str, Any]:
+        started = time.monotonic()
+        root_pid = int((snapshot_dir / "root.pid").read_text())
+        os.kill(root_pid, signal.SIGCONT)
+        return {
+            "root_pid": root_pid,
+            "source_exited": False,
+            "restore_seconds": time.monotonic() - started,
+            "provider": "fake",
+        }
+
+    def runtime_identity(self) -> dict[str, Any]:
+        return {"provider": "fake"}
+
+
+@dataclass
+class CriuCudaSnapshotProvider(SnapshotProvider):
+    criu_path: str
+    cuda_checkpoint_path: str
+    lock_timeout_ms: int = 30000
+    cuda_operation_timeout_seconds: float = 300
+    criu_operation_timeout_seconds: float = 1800
+
+    def capture(self, root_pid: int, snapshot_dir: Path) -> dict[str, Any]:
+        snapshot_dir.mkdir(parents=True, exist_ok=False)
+        images_dir = snapshot_dir / "images"
+        work_dir = snapshot_dir / "work"
+        images_dir.mkdir()
+        work_dir.mkdir()
+        cuda_pid = self._cuda_pid(root_pid)
+
+        started = time.monotonic()
+        locked = False
+        try:
+            self._run_cuda("lock", cuda_pid, "--timeout", str(self.lock_timeout_ms))
+            locked = True
+            self._run_cuda("checkpoint", cuda_pid)
+            cuda_end = time.monotonic()
+            self._run(
+                [
+                    self.criu_path,
+                    "dump",
+                    "--tree",
+                    str(root_pid),
+                    "--images-dir",
+                    str(images_dir),
+                    "--work-dir",
+                    str(work_dir),
+                    "--shell-job",
+                    "--file-locks",
+                    "--ext-unix-sk",
+                    "--link-remap",
+                    "--tcp-established",
+                    "--skip-in-flight",
+                    "--network-lock",
+                    "nftables",
+                    "-o",
+                    "dump.log",
+                    "-v4",
+                ],
+                env=self._criu_env(),
+                timeout=self.criu_operation_timeout_seconds,
+            )
+            criu_end = time.monotonic()
+        except Exception as exc:
+            cleanup_errors = []
+            if locked:
+                try:
+                    self._run_cuda("restore", cuda_pid)
+                except Exception as cleanup_error:
+                    cleanup_errors.append(f"restore: {cleanup_error}")
+                try:
+                    self._run_cuda("unlock", cuda_pid)
+                except Exception as cleanup_error:
+                    cleanup_errors.append(f"unlock: {cleanup_error}")
+            error = self._with_criu_log(exc, work_dir / "dump.log")
+            if cleanup_errors:
+                error = RuntimeError(
+                    f"{error}\nCUDA rollback cleanup failed: "
+                    + "; ".join(cleanup_errors)
+                )
+            raise error from exc
+        return {
+            "root_pid": root_pid,
+            "source_exited": True,
+            "cuda_pids": [cuda_pid],
+            "cuda_checkpoint_seconds": cuda_end - started,
+            "criu_dump_seconds": criu_end - cuda_end,
+            "capture_seconds": criu_end - started,
+            "provider": "criu_cuda",
+        }
+
+    def restore(self, snapshot_dir: Path) -> dict[str, Any]:
+        images_dir = snapshot_dir / "images"
+        work_dir = snapshot_dir / f"restore-work-{uuid.uuid4().hex}"
+        work_dir.mkdir(exist_ok=False)
+        pidfile = work_dir / "root.pid"
+        started = time.monotonic()
+        root_pid: int | None = None
+        try:
+            self._run(
+                [
+                    self.criu_path,
+                    "restore",
+                    "--images-dir",
+                    str(images_dir),
+                    "--work-dir",
+                    str(work_dir),
+                    "--shell-job",
+                    "--file-locks",
+                    "--ext-unix-sk",
+                    "--tcp-established",
+                    "--restore-detached",
+                    "--pidfile",
+                    str(pidfile),
+                    "-o",
+                    "restore.log",
+                    "-v4",
+                ],
+                env=self._criu_env(),
+                timeout=self.criu_operation_timeout_seconds,
+            )
+            criu_end = time.monotonic()
+            root_pid = int(pidfile.read_text())
+            pidfile_read_end = time.monotonic()
+            cuda_pid = self._cuda_pid(root_pid, restored=True)
+            cuda_pid_discovery_end = time.monotonic()
+            self._run_cuda("restore", cuda_pid)
+            cuda_restore_action_end = time.monotonic()
+            self._run_cuda("unlock", cuda_pid)
+            ended = time.monotonic()
+            shutil.rmtree(work_dir)
+        except Exception as exc:
+            if root_pid is not None:
+                self._kill_tree(root_pid)
+            error = self._with_criu_log(exc, work_dir / "restore.log")
+            try:
+                shutil.rmtree(work_dir)
+            except OSError as cleanup_error:
+                error = RuntimeError(
+                    f"{error}\nrestore work cleanup failed: {cleanup_error}"
+                )
+            raise error from exc
+        return {
+            "root_pid": root_pid,
+            "source_exited": False,
+            "cuda_pids": [cuda_pid],
+            "criu_restore_seconds": criu_end - started,
+            "root_pid_read_seconds": pidfile_read_end - criu_end,
+            "cuda_pid_discovery_seconds": (cuda_pid_discovery_end - pidfile_read_end),
+            "cuda_restore_action_seconds": (
+                cuda_restore_action_end - cuda_pid_discovery_end
+            ),
+            "cuda_unlock_seconds": ended - cuda_restore_action_end,
+            "cuda_restore_seconds": ended - criu_end,
+            "restore_seconds": ended - started,
+            "provider": "criu_cuda",
+        }
+
+    def rollback_capture(self, snapshot_dir: Path) -> dict[str, Any]:
+        return self.restore(snapshot_dir)
+
+    @property
+    def restore_is_retriable(self) -> bool:
+        return False
+
+    def runtime_identity(self) -> dict[str, Any]:
+        criu_version = self._run(
+            [self.criu_path, "--version"],
+            check=False,
+            env=self._criu_env(),
+        )
+        return {
+            "provider": "criu_cuda",
+            "criu": self._binary_identity(self.criu_path, criu_version.stdout.strip()),
+            "cuda_checkpoint": self._binary_identity(
+                self.cuda_checkpoint_path, self._cuda_checkpoint_version()
+            ),
+        }
+
+    def _cuda_checkpoint_version(self) -> str:
+        result = self._run([self.cuda_checkpoint_path, "--help"], check=False)
+        output = f"{result.stdout}\n{result.stderr}"
+        version = re.search(r"(?:version|Version)\s*:?\s*([^\s]+)", output)
+        return version.group(1) if version else "unknown"
+
+    @staticmethod
+    def _binary_identity(path: str, version: str) -> dict[str, Any]:
+        binary = Path(path)
+        digest = hashlib.sha256()
+        with binary.open("rb") as binary_file:
+            for chunk in iter(lambda: binary_file.read(1024 * 1024), b""):
+                digest.update(chunk)
+        return {
+            "path": str(binary.resolve()),
+            "size": binary.stat().st_size,
+            "sha256": digest.hexdigest(),
+            "version": version,
+        }
+
+    def _cuda_pids(self, root_pid: int, restored: bool = False) -> list[int]:
+        result = []
+        for pid in self._process_tree(root_pid):
+            command = [self.cuda_checkpoint_path]
+            command.append("--get-restore-tid" if restored else "--get-state")
+            command.extend(["--pid", str(pid)])
+            if subprocess.run(command, capture_output=True, timeout=10).returncode == 0:
+                result.append(pid)
+        return result
+
+    def _cuda_pid(self, root_pid: int, restored: bool = False) -> int:
+        cuda_pids = self._cuda_pids(root_pid, restored=restored)
+        if len(cuda_pids) != 1:
+            process_type = "restored CUDA process" if restored else "CUDA process"
+            raise RuntimeError(
+                f"expected exactly one {process_type} in EngineCore tree, "
+                f"found {len(cuda_pids)}"
+            )
+        return cuda_pids[0]
+
+    def _run_cuda(self, action: str, pid: int, *extra: str) -> None:
+        self._run(
+            self._cuda_command(action, pid, *extra),
+            timeout=self.cuda_operation_timeout_seconds,
+        )
+
+    def _cuda_command(self, action: str, pid: int, *extra: str) -> list[str]:
+        return [
+            self.cuda_checkpoint_path,
+            "--action",
+            action,
+            "--pid",
+            str(pid),
+            *extra,
+        ]
+
+    @staticmethod
+    def _criu_env() -> dict[str, str]:
+        env = os.environ.copy()
+        tunables = env.get("GLIBC_TUNABLES")
+        if tunables is None:
+            return env
+        filtered = ":".join(
+            value
+            for value in tunables.split(":")
+            if not value.startswith("glibc.pthread.rseq=")
+        )
+        if filtered:
+            env["GLIBC_TUNABLES"] = filtered
+        else:
+            env.pop("GLIBC_TUNABLES")
+        return env
+
+    @staticmethod
+    def _with_criu_log(exc: BaseException, path: Path) -> RuntimeError:
+        try:
+            log_tail = path.read_text(errors="replace")[-12000:].strip()
+        except FileNotFoundError:
+            log_tail = "CRIU log file is missing"
+        return RuntimeError(f"{exc}\nCRIU log tail:\n{log_tail}")
+
+    @staticmethod
+    def _run(
+        command: list[str],
+        check: bool = True,
+        env: dict[str, str] | None = None,
+        timeout: float | None = None,
+    ) -> subprocess.CompletedProcess:
+        result = subprocess.run(
+            command,
+            text=True,
+            capture_output=True,
+            env=env,
+            timeout=timeout,
+        )
+        if check and result.returncode != 0:
+            raise CriuCudaSnapshotProvider._command_error(
+                command,
+                result.returncode,
+                stdout=result.stdout,
+                stderr=result.stderr,
+            )
+        return result
+
+    @staticmethod
+    def _command_error(
+        command: list[str],
+        returncode: int,
+        *,
+        stdout: str | None,
+        stderr: str | None,
+    ) -> RuntimeError:
+        output = (stderr or stdout or "").strip()
+        return RuntimeError(
+            f"command failed ({returncode}): {' '.join(command)}: {output[-4000:]}"
+        )
+
+
+def resolve_snapshot_executable(name: str) -> str:
+    path = shutil.which(name)
+    if path is None:
+        raise FileNotFoundError(
+            f"engine snapshots require '{name}' to be available on PATH"
+        )
+    return str(Path(path).resolve())
+
+
+def make_snapshot_provider(name: str) -> SnapshotProvider:
+    if name == "fake":
+        return FakeSnapshotProvider()
+    if name == "criu_cuda":
+        return CriuCudaSnapshotProvider(
+            criu_path=resolve_snapshot_executable("criu"),
+            cuda_checkpoint_path=resolve_snapshot_executable("cuda-checkpoint"),
+        )
+    raise ValueError(f"unknown engine snapshot provider: {name}")

--- a/vllm/snapshot/resources.py
+++ b/vllm/snapshot/resources.py
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Literal, TypedDict, cast
+
+WeightResourcePolicy = Literal["cuda_image", "host_backup", "discard"]
+KVResourcePolicy = Literal["cuda_image", "discard"]
+RuntimeResourcePolicy = Literal["cuda_image"]
+
+
+class SnapshotResourcePolicyWire(TypedDict):
+    weights: WeightResourcePolicy
+    kv: KVResourcePolicy
+    runtime: RuntimeResourcePolicy
+
+
+@dataclass(frozen=True)
+class SnapshotResourcePolicy:
+    weights: WeightResourcePolicy
+    kv: KVResourcePolicy
+    runtime: RuntimeResourcePolicy
+
+    @property
+    def requires_allocator(self) -> bool:
+        return self.weights != "cuda_image" or self.kv == "discard"
+
+    def to_wire(self) -> SnapshotResourcePolicyWire:
+        return {
+            "weights": self.weights,
+            "kv": self.kv,
+            "runtime": self.runtime,
+        }
+
+
+_RESOURCE_POLICIES = {
+    "full": SnapshotResourcePolicy(
+        weights="cuda_image", kv="cuda_image", runtime="cuda_image"
+    ),
+    "discard_kv": SnapshotResourcePolicy(
+        weights="cuda_image", kv="discard", runtime="cuda_image"
+    ),
+    "l1_prepared": SnapshotResourcePolicy(
+        weights="host_backup", kv="discard", runtime="cuda_image"
+    ),
+    "l2_prepared": SnapshotResourcePolicy(
+        weights="discard", kv="discard", runtime="cuda_image"
+    ),
+}
+
+
+def parse_snapshot_resource_policy(name: str) -> SnapshotResourcePolicy:
+    try:
+        return _RESOURCE_POLICIES[name]
+    except KeyError as exc:
+        raise ValueError(f"unknown snapshot resource policy: {name}") from exc
+
+
+def decode_snapshot_resource_policy(
+    value: Mapping[str, object],
+) -> SnapshotResourcePolicy:
+    expected_fields = {"weights", "kv", "runtime"}
+    if set(value) != expected_fields or not all(
+        isinstance(value[field], str) for field in expected_fields
+    ):
+        raise ValueError("invalid snapshot resource policy")
+
+    policy = SnapshotResourcePolicy(
+        weights=cast(WeightResourcePolicy, value["weights"]),
+        kv=cast(KVResourcePolicy, value["kv"]),
+        runtime=cast(RuntimeResourcePolicy, value["runtime"]),
+    )
+    if policy not in _RESOURCE_POLICIES.values():
+        raise ValueError("unsupported snapshot resource policy")
+    return policy

--- a/vllm/snapshot/resources.py
+++ b/vllm/snapshot/resources.py
@@ -40,14 +40,18 @@ _RESOURCE_POLICIES = {
     "full": SnapshotResourcePolicy(
         weights="cuda_image", kv="cuda_image", runtime="cuda_image"
     ),
-    "discard_kv": SnapshotResourcePolicy(
+    "minimized": SnapshotResourcePolicy(
+        weights="discard", kv="discard", runtime="cuda_image"
+    ),
+}
+
+_SUPPORTED_RESOURCE_POLICIES = {
+    *_RESOURCE_POLICIES.values(),
+    SnapshotResourcePolicy(
         weights="cuda_image", kv="discard", runtime="cuda_image"
     ),
-    "l1_prepared": SnapshotResourcePolicy(
+    SnapshotResourcePolicy(
         weights="host_backup", kv="discard", runtime="cuda_image"
-    ),
-    "l2_prepared": SnapshotResourcePolicy(
-        weights="discard", kv="discard", runtime="cuda_image"
     ),
 }
 
@@ -73,6 +77,6 @@ def decode_snapshot_resource_policy(
         kv=cast(KVResourcePolicy, value["kv"]),
         runtime=cast(RuntimeResourcePolicy, value["runtime"]),
     )
-    if policy not in _RESOURCE_POLICIES.values():
+    if policy not in _SUPPORTED_RESOURCE_POLICIES:
         raise ValueError("unsupported snapshot resource policy")
     return policy

--- a/vllm/v1/engine/__init__.py
+++ b/vllm/v1/engine/__init__.py
@@ -102,6 +102,11 @@ class EngineCoreReadyResponse:
     weight_transfer_backend: str | None = None
     enable_sleep_mode: bool = False
     supports_draft_weight_updates: bool = False
+    snapshot_generation: int = 0
+    snapshot_nonce: str | None = None
+    snapshot_id: str | None = None
+    snapshot_config_hash: str | None = None
+    snapshot_root_pid: int | None = None
 
 
 class EngineCoreRequest(

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -983,14 +983,57 @@ class AsyncLLM(EngineClient):
         if self.logger_manager is not None:
             self.logger_manager.record_sleep_state(0, 0)
 
-    async def checkpoint_prepare(self) -> None:
-        await self.collective_rpc("checkpoint_prepare")
+    async def checkpoint_prepare(
+        self, resource_policy: dict[str, str]
+    ) -> list[dict[str, float]]:
+        return await self.collective_rpc("checkpoint_prepare", args=(resource_policy,))
 
-    async def checkpoint_restore(self) -> None:
-        await self.collective_rpc("checkpoint_restore")
+    async def checkpoint_restore(
+        self, resource_policy: dict[str, str]
+    ) -> list[dict[str, float]]:
+        return await self.collective_rpc("checkpoint_restore", args=(resource_policy,))
+
+    async def checkpoint_abort(self) -> list[dict[str, float]]:
+        return await self.collective_rpc("checkpoint_abort")
+
+    async def snapshot_detach_io(
+        self,
+        nonce: str,
+        generation: int,
+        snapshot_id: str,
+        config_hash: str,
+        marker_path: str,
+        persistence: str,
+    ) -> None:
+        await self.engine_core.snapshot_detach_io_async(
+            nonce,
+            generation,
+            snapshot_id,
+            config_hash,
+            marker_path,
+            persistence,
+        )
+
+    async def snapshot_wait_for_attach(
+        self,
+        nonce: str,
+        generation: int,
+        snapshot_id: str,
+        config_hash: str,
+        root_pid: int,
+    ) -> None:
+        await self.engine_core.snapshot_wait_for_attach_async(
+            nonce, generation, snapshot_id, config_hash, root_pid
+        )
 
     async def is_sleeping(self) -> bool:
         return await self.engine_core.is_sleeping_async()
+
+    async def is_idle(self) -> bool:
+        return (
+            not self.output_processor.has_unfinished_requests()
+            and not self.engine_core.dp_engines_running()
+        )
 
     async def add_lora(self, lora_request: LoRARequest) -> bool:
         """Load a new LoRA adapter into the engine for future requests."""

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import gc
+import json
 import os
 import queue
 import signal
@@ -33,6 +34,7 @@ from vllm.logging_utils.dump_input import dump_engine_exception
 from vllm.lora.request import LoRARequest
 from vllm.multimodal import MULTIMODAL_REGISTRY
 from vllm.multimodal.cache import MultiModalCacheMissError
+from vllm.snapshot.process import process_starttime, rebind_stdio
 from vllm.tasks import POOLING_TASKS, SupportedTask
 from vllm.tracing import instrument, maybe_init_worker_tracer
 from vllm.transformers_utils.config import maybe_register_config_serialize_by_value
@@ -1022,6 +1024,7 @@ class EngineCoreProc(EngineCore):
     """ZMQ-wrapper for running EngineCore in background process."""
 
     ENGINE_CORE_DEAD = b"ENGINE_CORE_DEAD"
+    ENGINE_CORE_IO_DETACH = b"ENGINE_CORE_IO_DETACH"
     addresses: EngineZmqAddresses
 
     @instrument(span_name="EngineCoreProc init")
@@ -1034,6 +1037,7 @@ class EngineCoreProc(EngineCore):
         log_stats: bool,
         client_handshake_address: str | None = None,
         tensor_queue: Queue | None = None,
+        enable_engine_snapshot: bool = False,
         *,
         engine_index: int = 0,
     ):
@@ -1047,6 +1051,21 @@ class EngineCoreProc(EngineCore):
         identity = self.engine_index.to_bytes(length=2, byteorder="little")
         self.engines_running = False
         self.shutdown_state = EngineShutdownState.RUNNING
+        self._engine_snapshot_enabled = enable_engine_snapshot
+        self._snapshot_identity = identity
+        self._snapshot_nonce: str | None = None
+        self._snapshot_generation = 0
+        self._snapshot_id: str | None = None
+        self._snapshot_config_hash: str | None = None
+        self._snapshot_marker_path: str | None = None
+        self._snapshot_persistence = "durable"
+        self._snapshot_io_stop = threading.Event()
+        self._snapshot_input_stopped = threading.Event()
+        self._snapshot_output_stopped = threading.Event()
+        self._snapshot_io_lock = threading.Lock()
+        self._snapshot_io_active = False
+        self._snapshot_parent_pid = os.getppid()
+        self._snapshot_parent_starttime = process_starttime(self._snapshot_parent_pid)
 
         # Receiver for tensor IPC
         self.tensor_ipc_receiver: TensorIpcReceiver | None = None
@@ -1107,37 +1126,14 @@ class EngineCoreProc(EngineCore):
             # and to overlap some serialization/deserialization with the
             # model forward pass.
             # Threads handle Socket <-> Queues and core_busy_loop uses Queue.
-            ready_event = threading.Event()
-            input_thread = threading.Thread(
-                target=self.process_input_sockets,
-                args=(
-                    addresses.inputs,
-                    addresses.coordinator_input,
-                    identity,
-                    ready_event,
-                ),
-                daemon=True,
-            )
-            input_thread.start()
-
-            self.output_thread = threading.Thread(
-                target=self.process_output_sockets,
-                args=(
-                    addresses.outputs,
-                    addresses.coordinator_output,
-                    self.engine_index,
-                ),
-                daemon=True,
-            )
-            self.output_thread.start()
-
-            # Don't complete handshake until DP coordinator ready message is
-            # received.
-            while not ready_event.wait(timeout=10):
-                if not input_thread.is_alive():
-                    raise RuntimeError("Input socket thread died during startup")
-                assert addresses.coordinator_input is not None
-                logger.info("Waiting for READY message from DP Coordinator...")
+            self._start_snapshot_io_threads()
+            if self._engine_snapshot_enabled:
+                self._snapshot_control_thread = threading.Thread(
+                    target=self._snapshot_io_control_loop,
+                    daemon=True,
+                    name="engine-snapshot-io-control",
+                )
+                self._snapshot_control_thread.start()
 
     @contextmanager
     def _perform_handshakes(
@@ -1284,6 +1280,9 @@ class EngineCoreProc(EngineCore):
     @staticmethod
     def run_engine_core(*args, dp_rank: int = 0, local_dp_rank: int = 0, **kwargs):
         """Launch EngineCore busy loop in background process."""
+
+        if kwargs.get("enable_engine_snapshot", False):
+            signal.pthread_sigmask(signal.SIG_BLOCK, {signal.SIGUSR2})
 
         # Ensure we can serialize transformer config after spawning
         maybe_register_config_serialize_by_value()
@@ -1593,15 +1592,18 @@ class EngineCoreProc(EngineCore):
         )
         return True
 
-    @staticmethod
     def _invoke_utility_method(
-        name: str, get_result: Callable, output: UtilityOutput, enqueue_output: Callable
+        self,
+        name: str,
+        get_result: Callable,
+        output: UtilityOutput,
+        enqueue_output: Callable,
     ):
         try:
             result = get_result()
             if isinstance(result, Future):
                 # Defer utility output handling until future completion.
-                callback = lambda future: EngineCoreProc._invoke_utility_method(
+                callback = lambda future: self._invoke_utility_method(
                     name, future.result, output, enqueue_output
                 )
                 result.add_done_callback(callback)
@@ -1611,6 +1613,8 @@ class EngineCoreProc(EngineCore):
             logger.exception("Invocation of %s method failed", name)
             output.failure_message = f"Call to {name} method failed: {str(e)}"
         enqueue_output(output)
+        if name == "snapshot_detach_io" and output.failure_message is None:
+            self._begin_snapshot_io_detach()
 
     @staticmethod
     def _convert_msgspec_args(method, args):
@@ -1683,7 +1687,132 @@ class EngineCoreProc(EngineCore):
             supports_draft_weight_updates=(
                 self.model_executor.supports_draft_weight_updates()
             ),
+            snapshot_generation=self._snapshot_generation,
+            snapshot_nonce=self._snapshot_nonce,
+            snapshot_id=self._snapshot_id,
+            snapshot_config_hash=self._snapshot_config_hash,
+            snapshot_root_pid=os.getpid(),
         )
+
+    def snapshot_detach_io(
+        self,
+        nonce: str,
+        generation: int,
+        snapshot_id: str,
+        config_hash: str,
+        marker_path: str,
+        persistence: str,
+    ) -> None:
+        if not self._engine_snapshot_enabled:
+            raise RuntimeError("EngineCore snapshots are not enabled")
+        if persistence not in ("durable", "page_cache"):
+            raise ValueError(f"unknown snapshot persistence mode: {persistence}")
+        with self._snapshot_io_lock:
+            if not self._snapshot_io_active:
+                raise RuntimeError("EngineCore business I/O is already detached")
+            self._snapshot_nonce = nonce
+            self._snapshot_generation = generation
+            self._snapshot_id = snapshot_id
+            self._snapshot_config_hash = config_hash
+            self._snapshot_marker_path = marker_path
+            self._snapshot_persistence = persistence
+
+    def _begin_snapshot_io_detach(self) -> None:
+        self._snapshot_io_stop.set()
+        self.output_queue.put_nowait(self.ENGINE_CORE_IO_DETACH)
+        threading.Thread(
+            target=self._finish_snapshot_io_detach,
+            daemon=True,
+            name="engine-snapshot-io-detach",
+        ).start()
+
+    def _finish_snapshot_io_detach(self) -> None:
+        if not self._snapshot_input_stopped.wait(timeout=30):
+            logger.error("Timed out stopping EngineCore input socket thread")
+            return
+        if not self._snapshot_output_stopped.wait(timeout=30):
+            logger.error("Timed out stopping EngineCore output socket thread")
+            return
+        with self._snapshot_io_lock:
+            self._snapshot_io_active = False
+        marker_path = self._snapshot_marker_path
+        if marker_path is None:
+            logger.error("EngineCore snapshot marker path is missing")
+            return
+        marker = {
+            "pid": os.getpid(),
+            "nonce": self._snapshot_nonce,
+            "generation": self._snapshot_generation,
+            "snapshot_id": self._snapshot_id,
+            "config_hash": self._snapshot_config_hash,
+            "state": "detached",
+        }
+        temporary = f"{marker_path}.tmp-{os.getpid()}"
+        with open(temporary, "w") as marker_file:
+            json.dump(marker, marker_file)
+            marker_file.write("\n")
+            marker_file.flush()
+            if self._snapshot_persistence == "durable":
+                os.fsync(marker_file.fileno())
+        os.replace(temporary, marker_path)
+
+    def _snapshot_io_control_loop(self) -> None:
+        while self.is_running():
+            signal.sigwait({signal.SIGUSR2})
+            if not self.is_running():
+                return
+            try:
+                self._restore_snapshot_stdio()
+                logger.info("Reattaching EngineCore business I/O")
+                self._start_snapshot_io_threads()
+                logger.info("EngineCore business I/O reattached")
+            except Exception:
+                logger.exception("Failed to reattach EngineCore business I/O")
+
+    def _restore_snapshot_stdio(self) -> None:
+        rebind_stdio(
+            self._snapshot_parent_pid,
+            expected_starttime=self._snapshot_parent_starttime,
+        )
+
+    def _start_snapshot_io_threads(self) -> None:
+        with self._snapshot_io_lock:
+            if self._snapshot_io_active:
+                raise RuntimeError("EngineCore business I/O is already attached")
+            self._snapshot_io_stop.clear()
+            self._snapshot_input_stopped.clear()
+            self._snapshot_output_stopped.clear()
+            ready_event = threading.Event()
+            self.input_thread = threading.Thread(
+                target=self.process_input_sockets,
+                args=(
+                    self.addresses.inputs,
+                    self.addresses.coordinator_input,
+                    self._snapshot_identity,
+                    ready_event,
+                ),
+                daemon=True,
+                name="engine-input",
+            )
+            self.output_thread = threading.Thread(
+                target=self.process_output_sockets,
+                args=(
+                    self.addresses.outputs,
+                    self.addresses.coordinator_output,
+                    self.engine_index,
+                ),
+                daemon=True,
+                name="engine-output",
+            )
+            self.input_thread.start()
+            self.output_thread.start()
+            self._snapshot_io_active = True
+        while not ready_event.wait(timeout=10):
+            if not self.input_thread.is_alive():
+                raise RuntimeError("Input socket thread died during attach")
+            if self.addresses.coordinator_input is None:
+                raise RuntimeError("Input socket thread did not become ready")
+            logger.info("Waiting for READY message from DP Coordinator...")
 
     def process_input_sockets(
         self,
@@ -1700,93 +1829,107 @@ class EngineCoreProc(EngineCore):
         )
         generic_decoder = MsgpackDecoder(oob_tensor_provider=self.tensor_ipc_receiver)
 
-        with ExitStack() as stack, zmq.Context() as ctx:
-            input_sockets = [
-                stack.enter_context(
-                    make_zmq_socket(
-                        ctx, input_address, zmq.DEALER, identity=identity, bind=False
+        try:
+            with ExitStack() as stack, zmq.Context() as ctx:
+                input_sockets = [
+                    stack.enter_context(
+                        make_zmq_socket(
+                            ctx,
+                            input_address,
+                            zmq.DEALER,
+                            identity=identity,
+                            bind=False,
+                        )
                     )
-                )
-                for input_address in input_addresses
-            ]
-            if coord_input_address is None:
-                coord_socket = None
-            else:
-                coord_socket = stack.enter_context(
-                    make_zmq_socket(
-                        ctx,
-                        coord_input_address,
-                        zmq.XSUB,
-                        identity=identity,
-                        bind=False,
+                    for input_address in input_addresses
+                ]
+                if coord_input_address is None:
+                    coord_socket = None
+                else:
+                    coord_socket = stack.enter_context(
+                        make_zmq_socket(
+                            ctx,
+                            coord_input_address,
+                            zmq.XSUB,
+                            identity=identity,
+                            bind=False,
+                        )
                     )
-                )
-                # Send subscription message to coordinator.
-                coord_socket.send(b"\x01")
+                    coord_socket.send(b"\x01")
 
-            # Register sockets with poller.
-            poller = zmq.Poller()
-            ready_response = self._make_ready_response()
-            ready_payload = msgspec.msgpack.encode(ready_response)
-            for input_socket in input_sockets:
-                # Send initial message to each input socket - this is required
-                # before the front-end ROUTER socket can send input messages
-                # back to us.
-                input_socket.send(ready_payload)
-                poller.register(input_socket, zmq.POLLIN)
+                poller = zmq.Poller()
+                ready_payload = msgspec.msgpack.encode(self._make_ready_response())
+                for input_socket in input_sockets:
+                    input_socket.send(ready_payload)
+                    poller.register(input_socket, zmq.POLLIN)
 
-            if coord_socket is not None:
-                # Wait for ready message from coordinator.
-                assert coord_socket.recv() == b"READY"
-                poller.register(coord_socket, zmq.POLLIN)
-
-            ready_event.set()
-            del ready_event
-            while True:
-                for input_socket, _ in poller.poll():
-                    # (RequestType, RequestData)
-                    type_frame, *data_frames = input_socket.recv_multipart(copy=False)
-                    # NOTE(yongji): ignore READY message sent by DP coordinator
-                    # that is used to notify newly started engines
-                    if type_frame.buffer == b"READY":
-                        assert input_socket == coord_socket
-                        continue
-                    request_type = EngineCoreRequestType(bytes(type_frame.buffer))
-
-                    # Deserialize the request data.
-                    request: Any
-                    if request_type == EngineCoreRequestType.ADD:
-                        req: EngineCoreRequest = add_request_decoder.decode(data_frames)
-                        try:
-                            request = self.preprocess_add_request(req)
-                        except MultiModalCacheMissError as e:
-                            # P0/P1 shadow drift -- return a retryable signal (P0
-                            # drops the stale entry, client resends with data).
-                            self._handle_mm_cache_miss(req, e)
-                            continue
-                        except Exception:
-                            self._handle_request_preproc_error(req)
-                            continue
-                    elif request_type == EngineCoreRequestType.UTILITY:
-                        request = generic_decoder.decode(data_frames)
-                        client_idx, call_id, method, args = request
-                        if method == FT_UTILITY_METHOD:
-                            self.ft_sentinel.handle_command(
-                                client_idx, call_id, args[0]
-                            )
-                            continue
+                if coord_socket is not None:
+                    if self._engine_snapshot_enabled:
+                        while not self._snapshot_io_stop.is_set():
+                            if (
+                                coord_socket.poll(timeout=100)
+                                and coord_socket.recv() == b"READY"
+                            ):
+                                break
+                        else:
+                            return
                     else:
-                        request = generic_decoder.decode(data_frames)
+                        assert coord_socket.recv() == b"READY"
+                    poller.register(coord_socket, zmq.POLLIN)
+
+                ready_event.set()
+                del ready_event
+                while not self._snapshot_io_stop.is_set():
+                    events = (
+                        poller.poll(timeout=100)
+                        if self._engine_snapshot_enabled
+                        else poller.poll()
+                    )
+                    for input_socket, _ in events:
+                        if self._snapshot_io_stop.is_set():
+                            break
+                        type_frame, *data_frames = input_socket.recv_multipart(
+                            copy=False
+                        )
+                        # NOTE(yongji): ignore READY message sent by DP coordinator
+                        # that is used to notify newly started engines
+                        if type_frame.buffer == b"READY":
+                            assert input_socket == coord_socket
+                            continue
+                        request_type = EngineCoreRequestType(bytes(type_frame.buffer))
+
+                        request: Any
+                        if request_type == EngineCoreRequestType.ADD:
+                            req: EngineCoreRequest = add_request_decoder.decode(
+                                data_frames
+                            )
+                            try:
+                                request = self.preprocess_add_request(req)
+                            except MultiModalCacheMissError as exc:
+                                self._handle_mm_cache_miss(req, exc)
+                                continue
+                            except Exception:
+                                self._handle_request_preproc_error(req)
+                                continue
+                        elif request_type == EngineCoreRequestType.UTILITY:
+                            request = generic_decoder.decode(data_frames)
+                            client_idx, call_id, method, args = request
+                            if method == FT_UTILITY_METHOD:
+                                self.ft_sentinel.handle_command(
+                                    client_idx, call_id, args[0]
+                                )
+                                continue
+                        else:
+                            request = generic_decoder.decode(data_frames)
 
                         if request_type == EngineCoreRequestType.ABORT:
-                            # Aborts are added to *both* queues, allows us to eagerly
-                            # process aborts while also ensuring ordering in the input
-                            # queue to avoid leaking requests. This is ok because
-                            # aborting in the scheduler is idempotent.
+                            # Aborts are added to both queues to process them eagerly
+                            # while preserving input queue ordering.
                             self.aborts_queue.put_nowait(request)
 
-                    # Push to input queue for core busy loop.
-                    self.input_queue.put_nowait((request_type, request))
+                        self.input_queue.put_nowait((request_type, request))
+        finally:
+            self._snapshot_input_stopped.set()
 
     def process_output_sockets(
         self, output_paths: list[str], coord_output_path: str | None, engine_index: int
@@ -1805,57 +1948,63 @@ class EngineCoreProc(EngineCore):
 
         # We must set linger to ensure the ENGINE_CORE_DEAD
         # message is sent prior to closing the socket.
-        with ExitStack() as stack, zmq.Context() as ctx:
-            sockets = [
-                stack.enter_context(
-                    make_zmq_socket(ctx, output_path, zmq.PUSH, linger=4000)
-                )
-                for output_path in output_paths
-            ]
-            coord_socket = (
-                stack.enter_context(
-                    make_zmq_socket(
-                        ctx, coord_output_path, zmq.PUSH, bind=False, linger=4000
+        try:
+            with ExitStack() as stack, zmq.Context() as ctx:
+                sockets = [
+                    stack.enter_context(
+                        make_zmq_socket(ctx, output_path, zmq.PUSH, linger=4000)
                     )
+                    for output_path in output_paths
+                ]
+                coord_socket = (
+                    stack.enter_context(
+                        make_zmq_socket(
+                            ctx,
+                            coord_output_path,
+                            zmq.PUSH,
+                            bind=False,
+                            linger=4000,
+                        )
+                    )
+                    if coord_output_path is not None
+                    else None
                 )
-                if coord_output_path is not None
-                else None
-            )
-            max_reuse_bufs = len(sockets) + 1
+                max_reuse_bufs = len(sockets) + 1
 
-            while True:
-                output = self.output_queue.get()
-                if output == EngineCoreProc.ENGINE_CORE_DEAD:
-                    for socket in sockets:
-                        socket.send(output)
-                    break
-                assert not isinstance(output, bytes)
-                client_index, outputs = output
-                outputs.engine_index = engine_index
+                while True:
+                    output = self.output_queue.get()
+                    if output == EngineCoreProc.ENGINE_CORE_DEAD:
+                        for socket in sockets:
+                            socket.send(output)
+                        break
+                    if output == EngineCoreProc.ENGINE_CORE_IO_DETACH:
+                        break
+                    assert not isinstance(output, bytes)
+                    client_index, outputs = output
+                    outputs.engine_index = engine_index
 
-                if client_index == -1:
-                    # Don't reuse buffer for coordinator message
-                    # which will be very small.
-                    assert coord_socket is not None
-                    coord_socket.send_multipart(encoder.encode(outputs))
-                    continue
+                    if client_index == -1:
+                        # Don't reuse buffers for small coordinator messages.
+                        assert coord_socket is not None
+                        coord_socket.send_multipart(encoder.encode(outputs))
+                        continue
 
-                # Reclaim buffers that zmq is finished with.
-                while pending and pending[-1][0].done:
-                    reclaimed = pending.pop()[1]
-                    if len(reuse_buffers) < max_reuse_bufs:
-                        reuse_buffers.append(reclaimed)
+                    while pending and pending[-1][0].done:
+                        reclaimed = pending.pop()[1]
+                        if len(reuse_buffers) < max_reuse_bufs:
+                            reuse_buffers.append(reclaimed)
 
-                buffer = reuse_buffers.pop() if reuse_buffers else bytearray()
-                buffers = encoder.encode_into(outputs, buffer)
-                tracker = self._send_msg_tracking_payload(
-                    sockets[client_index], buffers
-                )
-                if not tracker.done:
-                    pending.appendleft((tracker, buffer))
-                elif len(reuse_buffers) < max_reuse_bufs:
-                    # Limit the number of buffers to reuse.
-                    reuse_buffers.append(buffer)
+                    buffer = reuse_buffers.pop() if reuse_buffers else bytearray()
+                    buffers = encoder.encode_into(outputs, buffer)
+                    tracker = self._send_msg_tracking_payload(
+                        sockets[client_index], buffers
+                    )
+                    if not tracker.done:
+                        pending.appendleft((tracker, buffer))
+                    elif len(reuse_buffers) < max_reuse_bufs:
+                        reuse_buffers.append(buffer)
+        finally:
+            self._snapshot_output_stopped.set()
 
     def _handle_mm_cache_miss(
         self, request: EngineCoreRequest, err: MultiModalCacheMissError

--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -14,7 +14,7 @@ from dataclasses import dataclass
 from multiprocessing.connection import Connection
 from multiprocessing.queues import Queue
 from threading import Thread
-from typing import Any, TypeAlias, TypeVar
+from typing import Any, TypeAlias, TypeVar, cast
 
 import msgspec
 import msgspec.msgpack
@@ -540,7 +540,11 @@ class MPClient(EngineCoreClient):
             # Elastic EP can remove a rank and later add it back with the same
             # identity. The client input ROUTER needs handover to allow the new
             # engine to replace the dead connection.
-            enable_input_socket_handover = parallel_config.enable_elastic_ep
+            enable_input_socket_handover = (
+                parallel_config.enable_elastic_ep
+                or client_addresses is not None
+                and "snapshot_control_path" in client_addresses
+            )
 
             self.stats_update_address: str | None = None
             tensor_queue: Queue | None = None
@@ -1192,6 +1196,63 @@ class AsyncMPClient(MPClient):
 
     async def is_sleeping_async(self) -> bool:
         return await self.call_utility_async("is_sleeping")
+
+    async def snapshot_detach_io_async(
+        self,
+        nonce: str,
+        generation: int,
+        snapshot_id: str,
+        config_hash: str,
+        marker_path: str,
+        persistence: str,
+    ) -> None:
+        await self.call_utility_async(
+            "snapshot_detach_io",
+            nonce,
+            generation,
+            snapshot_id,
+            config_hash,
+            marker_path,
+            persistence,
+        )
+
+    async def snapshot_wait_for_attach_async(
+        self,
+        nonce: str,
+        generation: int,
+        snapshot_id: str,
+        config_hash: str,
+        root_pid: int,
+    ) -> None:
+        timeout = VLLM_ENGINE_READY_TIMEOUT_S
+        input_socket = cast(zmq.asyncio.Socket, self.input_socket)
+        try:
+            identity, payload = await asyncio.wait_for(
+                input_socket.recv_multipart(), timeout=timeout
+            )
+        except TimeoutError as exc:
+            raise TimeoutError(
+                f"Timed out after {timeout}s waiting for restored EngineCore attach"
+            ) from exc
+        if identity not in self.core_engines:
+            raise RuntimeError("Restored EngineCore used an unknown identity")
+        response = msgspec.msgpack.decode(payload, type=EngineCoreReadyResponse)
+        if response.snapshot_nonce != nonce:
+            raise RuntimeError("Restored EngineCore snapshot nonce mismatch")
+        if response.snapshot_generation != generation:
+            raise RuntimeError(
+                "Restored EngineCore generation mismatch: "
+                f"{response.snapshot_generation} != {generation}"
+            )
+        if response.snapshot_id != snapshot_id:
+            raise RuntimeError("Restored EngineCore snapshot id mismatch")
+        if response.snapshot_config_hash != config_hash:
+            raise RuntimeError("Restored EngineCore config hash mismatch")
+        if response.snapshot_root_pid != root_pid:
+            raise RuntimeError(
+                "Restored EngineCore root PID mismatch: "
+                f"{response.snapshot_root_pid} != {root_pid}"
+            )
 
     async def execute_dummy_batch_async(self) -> None:
         await self.call_utility_async("execute_dummy_batch")

--- a/vllm/v1/engine/utils.py
+++ b/vllm/v1/engine/utils.py
@@ -3,6 +3,8 @@
 
 import contextlib
 import os
+import select
+import signal
 import threading
 import weakref
 from collections.abc import Callable, Iterator, Sequence
@@ -28,7 +30,7 @@ from vllm.utils.network_utils import (
     get_tcp_uri,
     zmq_socket_ctx,
 )
-from vllm.utils.system_utils import get_mp_context
+from vllm.utils.system_utils import get_mp_context, kill_process_tree
 from vllm.v1.engine.coordinator import DPCoordinator
 from vllm.v1.executor import Executor
 from vllm.v1.executor.ray_utils import WORKER_SPECIFIC_ENV_VARS
@@ -159,6 +161,7 @@ class CoreEngineProcManager:
         log_stats: bool,
         client_handshake_address: str | None = None,
         tensor_queue: Queue | None = None,
+        enable_engine_snapshot: bool = False,
     ):
         self._request_shutdown_timeout = vllm_config.shutdown_timeout
         context = get_mp_context()
@@ -173,6 +176,8 @@ class CoreEngineProcManager:
 
         if client_handshake_address:
             common_kwargs["client_handshake_address"] = client_handshake_address
+        if enable_engine_snapshot:
+            common_kwargs["enable_engine_snapshot"] = True
 
         is_dp = vllm_config.parallel_config.data_parallel_size > 1
 
@@ -198,6 +203,12 @@ class CoreEngineProcManager:
         self._finalizer = weakref.finalize(self, shutdown, self.processes)
         self.manager_stopped = threading.Event()
         self.failed_proc_name: str | None = None
+        self._process_lock = threading.Lock()
+        self._replacement_event = threading.Event()
+        self._monitor_ready = threading.Event()
+        self._snapshot_exit_event = threading.Event()
+        self._expected_exit_pids: set[int] = set()
+        self._snapshot_pid: int | None = None
 
         # All ranks share this config object: capture the user-provided
         # --device-ids list before the per-rank shard overwrites it. Mutating
@@ -232,7 +243,16 @@ class CoreEngineProcManager:
                     dp_local_rank=local_dp_rank,
                     process_kind="EngineCore",
                 ):
-                    proc.start()
+                    if not enable_engine_snapshot:
+                        proc.start()
+                    else:
+                        previous_mask = signal.pthread_sigmask(
+                            signal.SIG_BLOCK, {signal.SIGUSR2}
+                        )
+                        try:
+                            proc.start()
+                        finally:
+                            signal.pthread_sigmask(signal.SIG_SETMASK, previous_mask)
         finally:
             # Kill other procs if not all are running.
             if self.finished_procs():
@@ -241,6 +261,7 @@ class CoreEngineProcManager:
     def shutdown(self, timeout: float | None = None) -> None:
         """Shutdown engine core processes with configurable timeout."""
         self.manager_stopped.set()
+        self._replacement_event.set()
         if self._finalizer.detach() is not None:
             process_timeout = get_engine_process_shutdown_timeout(
                 self._request_shutdown_timeout, timeout
@@ -255,33 +276,173 @@ class CoreEngineProcManager:
 
     def monitor_engine_liveness(self) -> None:
         """Monitor engine core process liveness."""
+        while not self.manager_stopped.is_set():
+            with self._process_lock:
+                sentinel_to_proc = {proc.sentinel: proc for proc in self.processes}
+                self._monitor_ready.set()
+            if not sentinel_to_proc:
+                break
+            died_sentinels = connection.wait(sentinel_to_proc, timeout=1)
+            if not died_sentinels:
+                continue
 
-        sentinel_to_proc = {proc.sentinel: proc for proc in self.processes}
-        sentinels = set(sentinel_to_proc.keys())
-
-        while sentinels and not self.manager_stopped.is_set():
-            died_sentinels = connection.wait(sentinels, timeout=1)
-
+            unexpected_exit = False
             for sentinel in died_sentinels:
-                proc = sentinel_to_proc.pop(cast(int, sentinel))
-                exitcode = proc.exitcode
-                if exitcode != 0 and not self.manager_stopped.is_set():
-                    self.failed_proc_name = proc.name
-            if died_sentinels:
+                proc = sentinel_to_proc[cast(int, sentinel)]
+                with self._process_lock:
+                    if proc.pid in self._expected_exit_pids:
+                        self._expected_exit_pids.remove(proc.pid)
+                        expected_exit = True
+                    elif proc not in self.processes:
+                        expected_exit = True
+                    else:
+                        expected_exit = False
+                        if proc.exitcode != 0 and not self.manager_stopped.is_set():
+                            self.failed_proc_name = proc.name
+                if expected_exit:
+                    proc.join(timeout=1)
+                    self._snapshot_exit_event.set()
+                else:
+                    unexpected_exit = True
+            if unexpected_exit:
                 break
 
-        self.shutdown()
+            while not self.manager_stopped.is_set():
+                with self._process_lock:
+                    replacement_ready = any(
+                        proc.sentinel not in sentinel_to_proc and proc.is_alive()
+                        for proc in self.processes
+                    )
+                    source_resumed = self._snapshot_pid is None and any(
+                        proc.is_alive() for proc in self.processes
+                    )
+                if replacement_ready or source_resumed:
+                    self._replacement_event.clear()
+                    break
+                self._replacement_event.wait(timeout=1)
+
+        if not self.manager_stopped.is_set():
+            self.shutdown()
+
+    def prepare_snapshot(self) -> int:
+        if not self._monitor_ready.wait(timeout=5):
+            raise TimeoutError("timed out waiting for EngineCore liveness monitor")
+        with self._process_lock:
+            if self._snapshot_pid is not None:
+                raise RuntimeError("an EngineCore snapshot is already active")
+            if len(self.processes) != 1:
+                raise RuntimeError("EngineCore snapshots require one root process")
+            proc = self.processes[0]
+            if not proc.is_alive() or proc.pid is None:
+                raise RuntimeError("EngineCore root is not alive")
+            self._snapshot_pid = proc.pid
+            self._expected_exit_pids.add(proc.pid)
+            self._replacement_event.clear()
+            self._snapshot_exit_event.clear()
+            return proc.pid
+
+    def cancel_snapshot(self) -> None:
+        with self._process_lock:
+            if self._snapshot_pid is not None:
+                self._expected_exit_pids.discard(self._snapshot_pid)
+            self._snapshot_pid = None
+            self._replacement_event.set()
+
+    def wait_for_snapshot_exit(self, timeout: float = 30) -> None:
+        if not self._snapshot_exit_event.wait(timeout):
+            raise TimeoutError("timed out waiting for EngineCore source exit")
+
+    def adopt_restored_process(self, pid: int) -> None:
+        with self._process_lock:
+            current = self.processes[0]
+            if self._snapshot_pid is None and current.is_alive():
+                raise RuntimeError("no EngineCore snapshot is active")
+            if current.pid == pid and current.is_alive():
+                self._expected_exit_pids.discard(pid)
+            else:
+                self._monitor_ready.clear()
+                if isinstance(current, _AdoptedProcess):
+                    current.close()
+                self.processes[:] = [
+                    cast(BaseProcess, _AdoptedProcess(pid, current.name))
+                ]
+            self._snapshot_pid = None
+            self._replacement_event.set()
+
+    def discard_restored_process(self) -> None:
+        with self._process_lock:
+            if self._snapshot_pid is not None:
+                raise RuntimeError("EngineCore source snapshot has not exited")
+            if len(self.processes) != 1:
+                raise RuntimeError("EngineCore snapshots require one root process")
+            proc = self.processes[0]
+            pid = proc.pid
+            if pid is not None and proc.is_alive():
+                self._expected_exit_pids.add(pid)
+                self._replacement_event.clear()
+                try:
+                    kill_process_tree(pid)
+                    proc.join(timeout=5)
+                    if proc.is_alive():
+                        raise RuntimeError(
+                            f"EngineCore process tree rooted at PID {pid} did not exit"
+                        )
+                except BaseException:
+                    self._expected_exit_pids.discard(pid)
+                    raise
 
     def sentinels(self) -> list:
-        return [proc.sentinel for proc in self.processes]
+        with self._process_lock:
+            return [proc.sentinel for proc in self.processes]
 
     def finished_procs(self) -> dict[str, int]:
         """Returns dict of proc name -> exit code for any finished procs."""
-        return {
-            proc.name: proc.exitcode
-            for proc in self.processes
-            if proc.exitcode is not None
-        }
+        with self._process_lock:
+            return {
+                proc.name: proc.exitcode
+                for proc in self.processes
+                if proc.exitcode is not None
+            }
+
+
+class _AdoptedProcess:
+    def __init__(self, pid: int, name: str):
+        self.pid = pid
+        self.name = name
+        self._pidfd: int | None = os.pidfd_open(pid)
+
+    @property
+    def sentinel(self) -> int:
+        if self._pidfd is None:
+            raise ValueError("process object is closed")
+        return self._pidfd
+
+    @property
+    def exitcode(self) -> int | None:
+        return None if self.is_alive() else -1
+
+    def is_alive(self) -> bool:
+        return (
+            self._pidfd is not None and not select.select([self._pidfd], [], [], 0)[0]
+        )
+
+    def terminate(self) -> None:
+        with contextlib.suppress(ProcessLookupError):
+            os.kill(self.pid, signal.SIGTERM)
+
+    def join(self, timeout: float | None = None) -> None:
+        if self._pidfd is not None:
+            select.select([self._pidfd], [], [], timeout)
+
+    def close(self) -> None:
+        pidfd = self._pidfd
+        self._pidfd = None
+        if pidfd is not None:
+            with contextlib.suppress(OSError):
+                os.close(pidfd)
+
+    def __del__(self):
+        self.close()
 
 
 class SignalCallback:
@@ -1106,6 +1267,7 @@ def launch_core_engines(
     executor_class: type[Executor],
     log_stats: bool,
     addresses: EngineZmqAddresses,
+    enable_engine_snapshot: bool = False,
 ) -> Iterator[CoreEngineLaunch]:
     """Launch engine and DP coordinator processes as needed."""
 
@@ -1229,6 +1391,7 @@ def launch_core_engines(
                 start_index=dp_rank,
                 local_start_index=local_start_index or 0,
                 tensor_queue=tensor_queue,
+                enable_engine_snapshot=enable_engine_snapshot,
             )
         else:
             local_engine_manager = None

--- a/vllm/v1/utils.py
+++ b/vllm/v1/utils.py
@@ -181,6 +181,7 @@ class APIServerProcessManager:
         target_server_fn: Callable | None = None,
         stats_update_address: str | None = None,
         tensor_queue: Queue | None = None,
+        snapshot_control_path: str | None = None,
     ):
         """Initialize and start API server worker processes.
 
@@ -200,6 +201,7 @@ class APIServerProcessManager:
             output_addresses: Output addresses for each API server
             stats_update_address: Optional stats update address
             tensor_queue: Optional tensor IPC queue for sharing MM tensors
+            snapshot_control_path: Optional Engine snapshot control socket path
         """
         self.listen_address = listen_address
         self.sock = sock
@@ -222,6 +224,8 @@ class APIServerProcessManager:
                 client_config["stats_update_address"] = stats_update_address
             if tensor_queue is not None:
                 client_config["tensor_queue"] = tensor_queue
+            if snapshot_control_path is not None:
+                client_config["snapshot_control_path"] = snapshot_control_path
 
             parent_recv, child_send = spawn_context.Pipe(duplex=False)
             self._address_pipes.append(parent_recv)

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -299,20 +299,20 @@ class Worker(WorkerBase):
 
         if self.get_draft_model() is not None:
             raise NotImplementedError(
-                "l2_prepared does not support speculative draft models"
+                "reload_weights does not support speculative draft models"
             )
         if self.vllm_config.lora_config is not None and self.list_loras():
             raise NotImplementedError(
-                "l2_prepared does not support active LoRA adapters"
+                "reload_weights does not support active LoRA adapters"
             )
         if self.weight_transfer_engine is not None:
             raise NotImplementedError(
-                "l2_prepared does not support online weight updates"
+                "reload_weights does not support online weight updates"
             )
         model_loader = get_model_loader(self.model_runner.load_config)
         if not hasattr(model_loader, "get_all_weights"):
             raise NotImplementedError(
-                "l2_prepared requires a model loader with get_all_weights"
+                "reload_weights requires a model loader with get_all_weights"
             )
 
     @staticmethod

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -5,8 +5,9 @@
 import gc
 import os
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from contextlib import AbstractContextManager, contextmanager, nullcontext
+from dataclasses import dataclass
 from datetime import timedelta
 from types import NoneType
 from typing import TYPE_CHECKING, Any
@@ -19,7 +20,11 @@ import torch.nn as nn
 import vllm.envs as envs
 from vllm.config import CUDAGraphMode, VllmConfig, set_current_vllm_config
 from vllm.config.compilation import CompilationMode
-from vllm.device_allocator import get_mem_allocator_instance
+from vllm.device_allocator import (
+    get_diagnostic_mem_allocator_instance,
+    get_discard_mem_allocator_instance,
+    get_mem_allocator_instance,
+)
 from vllm.distributed import (
     ensure_model_parallel_initialized,
     init_distributed_environment,
@@ -61,6 +66,10 @@ from vllm.profiler.wrapper import (
     TorchProfilerWrapper,
 )
 from vllm.sequence import IntermediateTensors
+from vllm.snapshot.resources import (
+    SnapshotResourcePolicy,
+    decode_snapshot_resource_policy,
+)
 from vllm.tasks import SupportedTask
 from vllm.tracing import instrument
 from vllm.utils.gc_utils import freeze_gc_heap, maybe_attach_gc_debug_callback
@@ -140,6 +149,21 @@ class AsyncIntermediateTensors(IntermediateTensors):
         return object.__getattribute__(self, name)
 
 
+@dataclass
+class _CheckpointPrepareState:
+    resource_policy: SnapshotResourcePolicy
+    buffers_saved: bool = False
+    communicator_prepare_started: bool = False
+    communicator_prepare_failed: bool = False
+    allocator_prepare_started: bool = False
+    allocator_prepare_failed: bool = False
+    allocator_restored: bool = False
+    weights_reloaded: bool = False
+    buffers_restored: bool = False
+    kv_cache_restored: bool = False
+    communicator_restored: bool = False
+
+
 class Worker(WorkerBase):
     def __init__(
         self,
@@ -170,6 +194,7 @@ class Worker(WorkerBase):
         # Buffers saved before sleep
         self._sleep_saved_buffers: dict[str, torch.Tensor] = {}
         self._sleep_saved_draft_buffers: dict[str, torch.Tensor] = {}
+        self._checkpoint_prepare_state: _CheckpointPrepareState | None = None
 
         # Weight transfer engine is created in `load_model` once the model
         # is available, since the engine needs a reference to the model.
@@ -207,15 +232,7 @@ class Worker(WorkerBase):
 
         # Save the buffers before level 2 sleep
         if level == 2:
-            model = self.model_runner.model
-            self._sleep_saved_buffers = {
-                name: buffer.cpu().clone() for name, buffer in model.named_buffers()
-            }
-            draft = self.get_draft_model()
-            if draft is not None:
-                self._sleep_saved_draft_buffers = {
-                    name: buffer.cpu().clone() for name, buffer in draft.named_buffers()
-                }
+            self._save_sleep_buffers()
 
         self._get_sleep_mode_backend().suspend(level)
 
@@ -241,14 +258,35 @@ class Worker(WorkerBase):
 
         # Restore the buffers after level 2 sleep
         wake_weights = tags is None or "weights" in tags
-        if wake_weights and len(self._sleep_saved_buffers):
+        if wake_weights:
+            self._restore_sleep_buffers()
+
+        if tags is None or "kv_cache" in tags:
+            self.model_runner.post_kv_cache_wake_up()
+
+    def _save_sleep_buffers(self) -> None:
+        model = self.model_runner.model
+        saved_buffers = {
+            name: buffer.cpu().clone() for name, buffer in model.named_buffers()
+        }
+        draft = self.get_draft_model()
+        saved_draft_buffers = {}
+        if draft is not None:
+            saved_draft_buffers = {
+                name: buffer.cpu().clone() for name, buffer in draft.named_buffers()
+            }
+        self._sleep_saved_buffers = saved_buffers
+        self._sleep_saved_draft_buffers = saved_draft_buffers
+
+    def _restore_sleep_buffers(self) -> None:
+        if self._sleep_saved_buffers:
             model = self.model_runner.model
             for name, buffer in model.named_buffers():
                 if name in self._sleep_saved_buffers:
                     buffer.data.copy_(self._sleep_saved_buffers[name].data)
             self._sleep_saved_buffers = {}
 
-        if wake_weights and len(self._sleep_saved_draft_buffers):
+        if self._sleep_saved_draft_buffers:
             draft = self.get_draft_model()
             if draft is not None:
                 for name, buffer in draft.named_buffers():
@@ -256,14 +294,263 @@ class Worker(WorkerBase):
                         buffer.data.copy_(self._sleep_saved_draft_buffers[name].data)
             self._sleep_saved_draft_buffers = {}
 
-        if tags is None or "kv_cache" in tags:
+    def _validate_checkpoint_weight_reload(self) -> None:
+        from vllm.model_executor.model_loader import get_model_loader
+
+        if self.get_draft_model() is not None:
+            raise NotImplementedError(
+                "l2_prepared does not support speculative draft models"
+            )
+        if self.vllm_config.lora_config is not None and self.list_loras():
+            raise NotImplementedError(
+                "l2_prepared does not support active LoRA adapters"
+            )
+        if self.weight_transfer_engine is not None:
+            raise NotImplementedError(
+                "l2_prepared does not support online weight updates"
+            )
+        model_loader = get_model_loader(self.model_runner.load_config)
+        if not hasattr(model_loader, "get_all_weights"):
+            raise NotImplementedError(
+                "l2_prepared requires a model loader with get_all_weights"
+            )
+
+    @staticmethod
+    def _empty_checkpoint_host_cache() -> None:
+        try:
+            torch._C._host_emptyCache()
+        except AttributeError:
+            logger.warning(
+                "torch._C._host_emptyCache() only available in PyTorch >=2.5"
+            )
+
+    @staticmethod
+    def _checkpoint_host_backup_bytes() -> int | None:
+        try:
+            diagnostics = (
+                get_diagnostic_mem_allocator_instance().allocation_diagnostics()
+            )
+            tags = diagnostics.get("tags")
+            weights = tags.get("weights") if isinstance(tags, dict) else None
+            host_backup_bytes = (
+                weights.get("host_backup_bytes") if isinstance(weights, dict) else None
+            )
+            return host_backup_bytes if isinstance(host_backup_bytes, int) else None
+        except Exception:
+            logger.warning(
+                "Failed to collect checkpoint allocator diagnostics", exc_info=True
+            )
+            return None
+
+    def checkpoint_prepare(
+        self, resource_policy: Mapping[str, object]
+    ) -> dict[str, float]:
+        if self._checkpoint_prepare_state is not None:
+            raise RuntimeError("checkpoint resources are already prepared")
+        policy = decode_snapshot_resource_policy(resource_policy)
+        from vllm.v1.executor import Executor
+        from vllm.v1.executor.uniproc_executor import UniProcExecutor
+
+        executor_class = Executor.get_class(self.vllm_config)
+        if not issubclass(executor_class, UniProcExecutor):
+            raise RuntimeError("checkpoint workers require UniProcExecutor")
+        if policy.weights == "discard":
+            self._validate_checkpoint_weight_reload()
+        allocator = None
+        discard_allocator = None
+        if policy.weights == "host_backup":
+            allocator = get_mem_allocator_instance()
+        elif policy.requires_allocator:
+            discard_allocator = get_discard_mem_allocator_instance()
+        state = _CheckpointPrepareState(policy)
+        self._checkpoint_prepare_state = state
+        started = time.monotonic()
+        timings: dict[str, float] = {}
+        discard_tags: list[str] = []
+        try:
+            if policy.weights == "discard":
+                phase_started = time.monotonic()
+                self._save_sleep_buffers()
+                state.buffers_saved = True
+                timings["buffer_save_seconds"] = time.monotonic() - phase_started
+                discard_tags.append("weights")
+            if policy.kv == "discard":
+                discard_tags.append("kv_cache")
+            phase_started = time.monotonic()
+            state.communicator_prepare_started = True
+            try:
+                checkpoint_prepare_distributed_state()
+            except BaseException:
+                state.communicator_prepare_failed = True
+                raise
+            timings["communicator_prepare_seconds"] = time.monotonic() - phase_started
+            if policy.weights == "host_backup":
+                phase_started = time.monotonic()
+                state.allocator_prepare_started = True
+                assert allocator is not None
+                try:
+                    allocator.sleep(offload_tags=("weights",))
+                except BaseException:
+                    state.allocator_prepare_failed = True
+                    raise
+                timings["host_backup_seconds"] = time.monotonic() - phase_started
+                host_backup_bytes = self._checkpoint_host_backup_bytes()
+                if host_backup_bytes is not None:
+                    timings["host_backup_bytes"] = float(host_backup_bytes)
+            elif discard_tags:
+                phase_started = time.monotonic()
+                state.allocator_prepare_started = True
+                assert discard_allocator is not None
+                try:
+                    discard_allocator.discard(tuple(discard_tags))
+                except BaseException:
+                    state.allocator_prepare_failed = True
+                    raise
+                timings["discard_seconds"] = time.monotonic() - phase_started
+        except BaseException as exc:
+            rollback_errors = self._rollback_checkpoint_prepare(state)
+            if rollback_errors:
+                raise RuntimeError(
+                    f"{exc}; checkpoint prepare rollback failed: "
+                    + "; ".join(rollback_errors)
+                ) from exc
+            raise
+        timings["total_seconds"] = time.monotonic() - started
+        return timings
+
+    def _rollback_checkpoint_prepare(self, state: _CheckpointPrepareState) -> list[str]:
+        errors: list[str] = []
+        policy = state.resource_policy
+        if not state.allocator_prepare_started:
+            state.allocator_restored = True
+        elif not state.allocator_restored:
+            try:
+                allocator = get_mem_allocator_instance()
+                if policy.weights == "host_backup":
+                    allocator.wake_up()
+                    self._empty_checkpoint_host_cache()
+                else:
+                    wake_tags = []
+                    if policy.weights == "discard":
+                        wake_tags.append("weights")
+                    if policy.kv == "discard":
+                        wake_tags.append("kv_cache")
+                    allocator.wake_up(wake_tags)
+                state.allocator_restored = True
+            except BaseException as exc:
+                errors.append(f"allocator restore: {exc}")
+
+        weights_ready = policy.weights != "discard"
+        if state.allocator_restored and state.allocator_prepare_started:
+            if policy.weights == "discard" and not state.weights_reloaded:
+                try:
+                    self.reload_weights()
+                    state.weights_reloaded = True
+                except BaseException as exc:
+                    errors.append(f"weight reload: {exc}")
+            weights_ready = policy.weights != "discard" or state.weights_reloaded
+            if state.buffers_saved and weights_ready and not state.buffers_restored:
+                try:
+                    self._restore_sleep_buffers()
+                    state.buffers_restored = True
+                except BaseException as exc:
+                    errors.append(f"buffer restore: {exc}")
+            buffers_ready = not state.buffers_saved or state.buffers_restored
+            if (
+                policy.kv == "discard"
+                and weights_ready
+                and buffers_ready
+                and not state.kv_cache_restored
+            ):
+                try:
+                    self.model_runner.post_kv_cache_wake_up()
+                    state.kv_cache_restored = True
+                except BaseException as exc:
+                    errors.append(f"KV cache restore hook: {exc}")
+        elif state.buffers_saved and not state.buffers_restored:
+            self._sleep_saved_buffers = {}
+            self._sleep_saved_draft_buffers = {}
+            state.buffers_restored = True
+
+        if state.communicator_prepare_started and not state.communicator_restored:
+            try:
+                checkpoint_restore_distributed_state()
+                state.communicator_restored = True
+            except BaseException as exc:
+                errors.append(f"communicator restore: {exc}")
+
+        if state.allocator_prepare_failed:
+            errors.append("allocator prepare state is indeterminate")
+        if state.communicator_prepare_failed:
+            errors.append("communicator prepare state is indeterminate")
+        if not errors:
+            self._checkpoint_prepare_state = None
+        return errors
+
+    def checkpoint_abort(self) -> dict[str, float]:
+        started = time.monotonic()
+        state = self._checkpoint_prepare_state
+        if state is None:
+            return {"total_seconds": time.monotonic() - started}
+        errors = self._rollback_checkpoint_prepare(state)
+        if errors:
+            raise RuntimeError("; ".join(errors))
+        return {"total_seconds": time.monotonic() - started}
+
+    def checkpoint_restore(
+        self, resource_policy: Mapping[str, object]
+    ) -> dict[str, float]:
+        state = self._checkpoint_prepare_state
+        if state is None:
+            raise RuntimeError("checkpoint resources were not prepared")
+        policy = decode_snapshot_resource_policy(resource_policy)
+        if policy != state.resource_policy:
+            raise RuntimeError("checkpoint resource policy changed after prepare")
+        started = time.monotonic()
+        timings: dict[str, float] = {}
+        if policy.weights == "host_backup":
+            phase_started = time.monotonic()
+            allocator = get_mem_allocator_instance()
+            allocator.wake_up()
+            self._empty_checkpoint_host_cache()
+            state.allocator_restored = True
+            timings["host_restore_seconds"] = time.monotonic() - phase_started
+        else:
+            wake_tags = []
+            if policy.weights == "discard":
+                wake_tags.append("weights")
+            if policy.kv == "discard":
+                wake_tags.append("kv_cache")
+            phase_started = time.monotonic()
+            if wake_tags:
+                get_mem_allocator_instance().wake_up(wake_tags)
+            state.allocator_restored = True
+            timings["va_remap_seconds"] = time.monotonic() - phase_started
+        phase_started = time.monotonic()
+        if policy.weights == "discard":
+            self.reload_weights()
+            state.weights_reloaded = True
+        timings["reload_weights_seconds"] = time.monotonic() - phase_started
+        phase_started = time.monotonic()
+        if policy.weights == "discard":
+            self._restore_sleep_buffers()
+            state.buffers_restored = True
+        timings["buffer_restore_seconds"] = time.monotonic() - phase_started
+        phase_started = time.monotonic()
+        if policy.kv == "discard":
             self.model_runner.post_kv_cache_wake_up()
-
-    def checkpoint_prepare(self) -> None:
-        checkpoint_prepare_distributed_state()
-
-    def checkpoint_restore(self) -> None:
+            state.kv_cache_restored = True
+        timings["kv_hook_seconds"] = time.monotonic() - phase_started
+        phase_started = time.monotonic()
         checkpoint_restore_distributed_state()
+        state.communicator_restored = True
+        timings["communicator_restore_seconds"] = time.monotonic() - phase_started
+        self._checkpoint_prepare_state = None
+        timings["total_seconds"] = time.monotonic() - started
+        return timings
+
+    def allocator_diagnostics(self) -> dict[str, object]:
+        return get_diagnostic_mem_allocator_instance().allocation_diagnostics()
 
     def _maybe_get_memory_pool_context(self, tag: str) -> AbstractContextManager:
         if (


### PR DESCRIPTION
## Purpose

Add an opt-in Engine Snapshot deep-sleep path that keeps the API frontend, HTTP listener, and launcher alive while snapshotting and exiting the `EngineCoreProc` subtree.

On wake, vLLM validates the snapshot and runtime environment, restores the EngineCore and CUDA state, adopts the restored process, reconnects the frontend, and reopens request admission only after health and semantic checks pass.

Design, roadmap, compatibility constraints, and complete experimental results are documented in [RFC #52125: vLLM Native Reusable Engine Snapshot Sleep (L3)](https://github.com/vllm-project/vllm/issues/52125).

This work overlaps with #51360 in its use of CRIU and CUDA Checkpoint/Restore for an initialized engine. The snapshot boundary and user-facing lifecycle differ:

- #51360 captures the complete initialized service process tree before the HTTP listener is bound and restores it during instance startup.
- This PR implements runtime deep sleep. The frontend and HTTP listener remain available for status and wake requests while only the EngineCore subtree is captured, terminated, restored, and reattached.

## Change Summary

- Add the Engine Snapshot lifecycle: `READY → DRAINING → PREPARING → SNAPSHOTTING → HIBERNATED` and `HIBERNATED → RESTORING → ATTACHING → VERIFYING → READY`.
- Add idle-only request admission control and readiness handling around snapshot transitions.
- Add EngineCore detach, expected-exit handling, restored-process adoption, and frontend reconnection.
- Add `fake` and `criu_cuda` snapshot providers.
- Add atomic snapshot artifact commit, manifest validation, diagnostics, rollback, and cleanup.
- Expose two L3 resource policies:
  - `full`: preserve weights, KV cache, and runtime state in the CUDA image.
  - `minimized`: discard weights and KV cache before capture, then reload weights from model files and rebuild KV cache after restore.
- Add development-mode CLI configuration and the Level 3 sleep, wake, and status endpoints.
- Add allocator, worker, process-lifecycle, provider, manager, API, middleware, CLI, and serving tests.
- Document prerequisites, supported scope, endpoints, snapshot contents, and deployment restrictions.

## Current Scope

The initial implementation supports:

- Same-machine restore.
- One host and one GPU.
- `TP=1`, `PP=1`, and `DP=1`.
- One Python API server using `UniProcExecutor`.
- Idle-only capture with no in-flight request preservation.
- `fake` and CRIU/CUDA providers.
- Development-mode enablement through `VLLM_SERVER_DEV_MODE=1`.

The feature is opt-in and does not change the default `vllm serve` process topology or request path.

Cross-machine restore, 1→N restore, multi-GPU snapshot groups, distributed topologies, and in-flight request preservation remain follow-up work described in the RFC.

## Test Plan

- Run Ruff on the changed Python files.
- Run Python 3.10 mypy on the changed typed modules.
- Run the snapshot unit-test suite: `pytest -q tests/snapshot`
- Run the Engine Snapshot CLI parser tests: `pytest -q tests/entrypoints/openai/test_cli_args.py -k engine_snapshot`
- Exercise the lifecycle and failure paths with the `fake` provider.
- Run repeated real CRIU/CUDA capture and restore cycles for the `full` and `minimized` policies.
- Verify restored inference output, process cleanup, physical HBM release, snapshot artifacts, and phase-level timing.

## Test Result

Test environment:

- single GPU.
- Qwen3-8B BF16.
- `TP=1`, `PP=1`, `DP=1`, one API server.
- Non-eager execution.
- Model, compilation cache, CRIU images, and snapshots stored on tmpfs.
- Six runs per group: one warmup followed by five measured runs.
- `minimized` was repeated across three groups for 15 measured runs.

Median results:

| L3 policy | Measured runs | Checkpoint time | Restore time | Artifact size |
| --- | ---: | ---: | ---: | ---: |
| `minimized` | 15 | 2.837 s | 5.948 s | 4.251 GiB |
| `full` | 5 | 27.242 s | 22.990 s | 49.659 GiB |

Restore time is measured from the `/wake_up` request to the first non-empty token from a fixed streaming request, with the final response content also checked.

Correctness and resource results:

- All reported `full` and `minimized` runs restored successfully and passed the fixed semantic checks.
- Every pre-restore model page-residency check reported 100%.
- Engine `read_bytes` delta was 0 in all reported runs.
- Every reported `HIBERNATED` check showed 0 MiB for both project-process HBM and full-GPU HBM.
- Ruff passed.
- Python 3.10 mypy passed.
- Snapshot tests: `75 passed`.
- CLI parser tests: `3 passed, 30 deselected`.

These validation results predate the final public-policy simplification commit and are not presented as a rerun of the current tree.

## AI Assistance

AI assistance was used for implementation, testing, analysis, and drafting. The submitter reviewed the changes and owns the final submission.
