### PR TITLE
[Rust Frontend] Add Hunyuan A13B tool parser

### DIFF
--- a/rust/src/chat/src/lib.rs
+++ b/rust/src/chat/src/lib.rs
@@ -403,7 +403,7 @@ mod tests {
         )
         .unwrap_err();
 
-        expect_test::expect!["tool parser `definitely_missing_tool_parser` is not registered (choose from: deepseek_v3, deepseek_v31, deepseek_v32, deepseek_v4, gemma4, glm45, glm47, granite4, hermes, hy_v3, inkling, internlm, kimi_k2, kimi_k3, llama3_json, llama4_json, minimax_m2, minimax_m3, mistral, phi4_mini_json, qwen3_coder, qwen3_xml, seed_oss)"].assert_eq(&error.to_report_string());
+        expect_test::expect!["tool parser `definitely_missing_tool_parser` is not registered (choose from: deepseek_v3, deepseek_v31, deepseek_v32, deepseek_v4, gemma4, glm45, glm47, granite4, hermes, hunyuan_a13b, hy_v3, inkling, internlm, kimi_k2, kimi_k3, llama3_json, llama4_json, minimax_m2, minimax_m3, mistral, phi4_mini_json, qwen3_coder, qwen3_xml, seed_oss)"].assert_eq(&error.to_report_string());
     }
 
     #[test]

--- a/rust/src/chat/src/parser/tool/mod.rs
+++ b/rust/src/chat/src/parser/tool/mod.rs
@@ -7,10 +7,11 @@ use std::sync::{Arc, LazyLock};
 
 pub use vllm_parser::tool::{
     DeepSeekV3ToolParser, DeepSeekV4ToolParser, DeepSeekV31ToolParser, DeepSeekV32ToolParser,
-    Glm45MoeToolParser, Glm47MoeToolParser, Granite4ToolParser, HermesToolParser, HyV3ToolParser,
-    Internlm2ToolParser, KimiK2ToolParser, Llama3JsonToolParser, MinimaxM2ToolParser,
-    MinimaxM3ToolParser, MistralToolParser, Phi4MiniJsonToolParser, Qwen3CoderToolParser,
-    Qwen3XmlToolParser, SeedOssToolParser, ToolParser, ToolParserError,
+    Glm45MoeToolParser, Glm47MoeToolParser, Granite4ToolParser, HermesToolParser,
+    HunyuanA13BToolParser, HyV3ToolParser, Internlm2ToolParser, KimiK2ToolParser,
+    Llama3JsonToolParser, MinimaxM2ToolParser, MinimaxM3ToolParser, MistralToolParser,
+    Phi4MiniJsonToolParser, Qwen3CoderToolParser, Qwen3XmlToolParser, SeedOssToolParser,
+    ToolParser, ToolParserError,
 };
 
 use crate::parser::ParserFactory;
@@ -28,6 +29,7 @@ pub mod names {
     pub const INKLING: &str = "inkling";
     pub const GRANITE4: &str = "granite4";
     pub const HERMES: &str = "hermes";
+    pub const HUNYUAN_A13B: &str = "hunyuan_a13b";
     pub const HY_V3: &str = "hy_v3";
     // Matches the Python CLI name `--tool-call-parser internlm`, which Python
     // also routes to `Internlm2ToolParser` despite the version-agnostic name.
@@ -76,6 +78,7 @@ impl ToolParserFactory {
             .register_unified_dummy(names::INKLING)
             .register_parser::<Granite4ToolParser>(names::GRANITE4)
             .register_parser::<HermesToolParser>(names::HERMES)
+            .register_parser::<HunyuanA13BToolParser>(names::HUNYUAN_A13B)
             .register_parser::<HyV3ToolParser>(names::HY_V3)
             .register_parser::<Internlm2ToolParser>(names::INTERNLM)
             .register_parser::<KimiK2ToolParser>(names::KIMI_K2)
@@ -98,6 +101,8 @@ impl ToolParserFactory {
             .register_pattern("qwen3.5", names::QWEN3_CODER)
             .register_pattern("qwen", names::QWEN3_XML)
             .register_pattern("hermes", names::HERMES)
+            .register_pattern("hunyuan-a13b", names::HUNYUAN_A13B)
+            .register_pattern("hunyuan_a13b", names::HUNYUAN_A13B)
             .register_pattern("hy3", names::HY_V3)
             .register_pattern("hy_v3", names::HY_V3)
             // Narrow to `internlm2` substring so it matches `internlm2-chat-7b`

--- a/rust/src/chat/src/parser/tool/tests.rs
+++ b/rust/src/chat/src/parser/tool/tests.rs
@@ -157,6 +157,14 @@ fn factory_new_resolves_default_patterns() {
         Some(names::HERMES)
     );
     assert_eq!(
+        factory.resolve_name_for_model("tencent/Hunyuan-A13B-Instruct"),
+        Some(names::HUNYUAN_A13B)
+    );
+    assert_eq!(
+        factory.resolve_name_for_model("tencent/Hunyuan_A13B-Instruct"),
+        Some(names::HUNYUAN_A13B)
+    );
+    assert_eq!(
         factory.resolve_name_for_model("tencent/Hy3-preview"),
         Some(names::HY_V3)
     );

--- a/rust/src/parser/src/tool/json/hunyuan_a13b.rs
+++ b/rust/src/parser/src/tool/json/hunyuan_a13b.rs
@@ -1,0 +1,362 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+use super::{JsonToolCallConfig, JsonToolCallParser, JsonToolCallWhitespace};
+use crate::tool::{Result, Tool, ToolParser, ToolParserEvent, ToolParserOutput};
+
+const ASSISTANT_PREFIX: &str = "助手：";
+
+const HUNYUAN_A13B_CONFIG: JsonToolCallConfig = JsonToolCallConfig {
+    parser_name: "Hunyuan A13B",
+    start_marker: "<tool_calls>",
+    end_marker: "</tool_calls>",
+    marker_whitespace: JsonToolCallWhitespace::Optional,
+    delimiter: Some(","),
+    name_key: "name",
+    arguments_key: &["arguments"],
+};
+
+/// Tool parser for Hunyuan A13B models.
+///
+/// Hunyuan A13B emits an array of OpenAI-style function calls wrapped in
+/// `<tool_calls>` tags:
+///
+/// ```text
+/// <tool_calls>[{"name":"get_weather","arguments":{"city":"Beijing"}}]</tool_calls>
+/// ```
+///
+/// The shared JSON parser streams argument text without re-serializing it and
+/// tracks JSON nesting structurally. This is important for Hunyuan outputs:
+/// nested objects and argument properties named `name` must not be mistaken
+/// for a second tool-call header.
+pub struct HunyuanA13BToolParser {
+    inner: JsonToolCallParser,
+    pending_prefix: String,
+    prefix_decided: bool,
+}
+
+impl HunyuanA13BToolParser {
+    /// Create a Hunyuan A13B tool parser.
+    fn new(_tools: &[Tool]) -> Self {
+        Self {
+            inner: JsonToolCallParser::new(HUNYUAN_A13B_CONFIG)
+                .with_container("[", "]")
+                .discard_after_end(),
+            pending_prefix: String::new(),
+            prefix_decided: false,
+        }
+    }
+
+    /// Strip the chat-template prefix from a natural-language response while
+    /// preserving ordinary leading text and arbitrary streaming boundaries.
+    fn append_output(&mut self, parsed: ToolParserOutput, output: &mut ToolParserOutput) {
+        for event in parsed.events {
+            match event {
+                ToolParserEvent::Text(text) if !self.prefix_decided => {
+                    self.pending_prefix.push_str(&text);
+                    if self.pending_prefix.starts_with(ASSISTANT_PREFIX) {
+                        self.pending_prefix.drain(..ASSISTANT_PREFIX.len());
+                        self.prefix_decided = true;
+                        output.push_text(std::mem::take(&mut self.pending_prefix));
+                    } else if !ASSISTANT_PREFIX.starts_with(&self.pending_prefix) {
+                        self.prefix_decided = true;
+                        output.push_text(std::mem::take(&mut self.pending_prefix));
+                    }
+                }
+                ToolParserEvent::Text(text) => output.push_text(text),
+                ToolParserEvent::ToolCall(call) => {
+                    if !self.pending_prefix.is_empty() {
+                        self.prefix_decided = true;
+                        output.push_text(std::mem::take(&mut self.pending_prefix));
+                    }
+                    output.push_call(call);
+                }
+            }
+        }
+    }
+}
+
+impl ToolParser for HunyuanA13BToolParser {
+    fn create(tools: &[Tool]) -> Result<Box<dyn ToolParser>>
+    where
+        Self: Sized + 'static,
+    {
+        Ok(Box::new(Self::new(tools)))
+    }
+
+    fn parse_into(&mut self, chunk: &str, output: &mut ToolParserOutput) -> Result<()> {
+        let mut parsed = ToolParserOutput::default();
+        let result = self.inner.parse_into(chunk, &mut parsed);
+        self.append_output(parsed, output);
+        result
+    }
+
+    fn finish(&mut self) -> Result<ToolParserOutput> {
+        let parsed = self.inner.finish()?;
+        let mut output = ToolParserOutput::default();
+        self.append_output(parsed, &mut output);
+        if !self.pending_prefix.is_empty() {
+            output.push_text(std::mem::take(&mut self.pending_prefix));
+        }
+        self.prefix_decided = false;
+        Ok(output)
+    }
+
+    fn reset(&mut self) -> String {
+        let mut pending = std::mem::take(&mut self.pending_prefix);
+        pending.push_str(&self.inner.reset());
+        self.prefix_decided = false;
+        pending
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use expect_test::expect;
+    use thiserror_ext::AsReport;
+
+    use super::HunyuanA13BToolParser;
+    use crate::tool::test_utils::{collect_stream, split_by_chars, test_tools};
+    use crate::tool::{ToolParser, ToolParserTestExt as _};
+
+    fn build_call(function_name: &str, arguments: &str) -> String {
+        format!(r#"{{"name":"{function_name}","arguments":{arguments}}}"#)
+    }
+
+    fn wrap(calls: &[String]) -> String {
+        format!("<tool_calls>[{}]</tool_calls>", calls.join(","))
+    }
+
+    #[test]
+    fn hunyuan_a13b_parse_complete_without_tool_call_keeps_text() {
+        let mut parser = HunyuanA13BToolParser::new(&test_tools());
+        let output = parser.parse_complete("How can I help you today?").unwrap();
+
+        assert_eq!(output.normal_text(), "How can I help you today?");
+        assert!(output.calls().is_empty());
+    }
+
+    #[test]
+    fn hunyuan_a13b_strips_assistant_prefix_from_natural_language() {
+        let mut parser = HunyuanA13BToolParser::new(&test_tools());
+        let chunks = ["助", "手", "：How can I help?"];
+
+        let output = collect_stream(&mut parser, &chunks);
+
+        assert_eq!(output.normal_text(), "How can I help?");
+        assert!(output.calls().is_empty());
+    }
+
+    #[test]
+    fn hunyuan_a13b_preserves_nonleading_assistant_prefix() {
+        let mut parser = HunyuanA13BToolParser::new(&test_tools());
+        let input = "Quoted template text: 助手：How can I help?";
+
+        let output = parser.parse_complete(input).unwrap();
+
+        assert_eq!(output.normal_text(), input);
+        assert!(output.calls().is_empty());
+    }
+
+    #[test]
+    fn hunyuan_a13b_extracts_parallel_calls_and_nested_arguments() {
+        let mut parser = HunyuanA13BToolParser::new(&test_tools());
+        let input = wrap(&[
+            build_call("get_weather", r#"{"city":"San Francisco","days":3}"#),
+            build_call(
+                "update_record",
+                r#"{"data":{"profile":{"name":"John"},"aliases":["John","Johnny"]}}"#,
+            ),
+        ]);
+
+        let output = parser.parse_complete(&input).unwrap();
+
+        expect![[r#"
+            ToolParserOutput {
+                events: [
+                    ToolCall(
+                        ToolCallDelta {
+                            tool_index: 0,
+                            name: Some(
+                                "get_weather",
+                            ),
+                            arguments: "{\"city\":\"San Francisco\",\"days\":3}",
+                        },
+                    ),
+                    ToolCall(
+                        ToolCallDelta {
+                            tool_index: 1,
+                            name: Some(
+                                "update_record",
+                            ),
+                            arguments: "{\"data\":{\"profile\":{\"name\":\"John\"},\"aliases\":[\"John\",\"Johnny\"]}}",
+                        },
+                    ),
+                ],
+            }
+        "#]]
+        .assert_debug_eq(&output);
+    }
+
+    #[test]
+    fn hunyuan_a13b_preserves_prefix_text_and_non_ascii_arguments() {
+        let mut parser = HunyuanA13BToolParser::new(&test_tools());
+        let input = format!(
+            "I will call the tool now. {}",
+            wrap(&[build_call("get_weather", r#"{"city":"北京"}"#)])
+        );
+
+        let output = parser.parse_complete(&input).unwrap();
+
+        assert_eq!(output.normal_text(), "I will call the tool now. ");
+        assert_eq!(output.calls().len(), 1);
+        assert_eq!(output.calls()[0].arguments, r#"{"city":"北京"}"#);
+    }
+
+    #[test]
+    fn hunyuan_a13b_allows_whitespace_before_json_array() {
+        let mut parser = HunyuanA13BToolParser::new(&test_tools());
+        let input = concat!(
+            "<tool_calls>\n  [\n",
+            "  {\"name\": \"get_weather\", \"arguments\": {\"city\": \"Tokyo\"}}\n",
+            "]\n</tool_calls>"
+        );
+
+        let chunks = split_by_chars(input, 4);
+        let output = collect_stream(&mut parser, &chunks);
+
+        assert!(output.normal_text().is_empty());
+        assert_eq!(output.calls().len(), 1);
+        assert_eq!(output.calls()[0].name.as_deref(), Some("get_weather"));
+        assert_eq!(output.calls()[0].arguments, r#"{"city": "Tokyo"}"#);
+    }
+
+    #[test]
+    fn hunyuan_a13b_accepts_empty_tool_call_array() {
+        let mut parser = HunyuanA13BToolParser::new(&test_tools());
+
+        let output = parser.parse_complete("<tool_calls>[]</tool_calls>").unwrap();
+
+        assert!(output.normal_text().is_empty());
+        assert!(output.calls().is_empty());
+    }
+
+    #[test]
+    fn hunyuan_a13b_streaming_accepts_empty_tool_call_array() {
+        let input = "<tool_calls>[]</tool_calls>";
+        let chunks = split_by_chars(input, 1);
+        let mut parser = HunyuanA13BToolParser::new(&test_tools());
+
+        let output = collect_stream(&mut parser, &chunks);
+
+        assert!(output.normal_text().is_empty());
+        assert!(output.calls().is_empty());
+    }
+
+    #[test]
+    fn hunyuan_a13b_empty_array_preserves_prefix_and_discards_streaming_suffix() {
+        let chunks = [
+            "Before <tool_calls>[",
+            "]</tool_calls>discarded",
+            " across chunks",
+        ];
+        let mut parser = HunyuanA13BToolParser::new(&test_tools());
+
+        let output = collect_stream(&mut parser, &chunks);
+
+        assert_eq!(output.normal_text(), "Before ");
+        assert!(output.calls().is_empty());
+    }
+
+    #[test]
+    fn hunyuan_a13b_rejects_trailing_comma() {
+        let mut parser = HunyuanA13BToolParser::new(&test_tools());
+        let input = format!(
+            "<tool_calls>[{},]</tool_calls>",
+            build_call("get_weather", r#"{"city":"Seattle"}"#)
+        );
+
+        assert!(parser.parse_complete(&input).is_err());
+    }
+
+    #[test]
+    fn hunyuan_a13b_discards_text_after_tool_calls() {
+        let mut parser = HunyuanA13BToolParser::new(&test_tools());
+        let input = format!(
+            "{}\nThank you!",
+            wrap(&[build_call("get_weather", r#"{"city":"Seattle"}"#)])
+        );
+
+        let output = parser.parse_complete(&input).unwrap();
+
+        assert!(output.normal_text().is_empty());
+        assert_eq!(output.calls().len(), 1);
+        assert_eq!(output.calls()[0].name.as_deref(), Some("get_weather"));
+    }
+
+    #[test]
+    fn hunyuan_a13b_streaming_discards_text_after_tool_calls() {
+        let tool_call = wrap(&[build_call("get_weather", r#"{"city":"Seattle"}"#)]);
+        let chunks = [tool_call.as_str(), "\nThank", " you!"];
+        let mut parser = HunyuanA13BToolParser::new(&test_tools());
+
+        let output = collect_stream(&mut parser, &chunks);
+
+        assert!(output.normal_text().is_empty());
+        assert_eq!(output.calls().len(), 1);
+        assert_eq!(output.calls()[0].name.as_deref(), Some("get_weather"));
+    }
+
+    #[test]
+    fn hunyuan_a13b_streaming_handles_arbitrary_chunk_boundaries() {
+        let input = wrap(&[build_call(
+            "get_weather",
+            r#"{"city":"Boston","metadata":{"name":"forecast"}}"#,
+        )]);
+        let chunks = split_by_chars(&input, 5);
+        let mut parser = HunyuanA13BToolParser::new(&test_tools());
+
+        let output = collect_stream(&mut parser, &chunks);
+
+        assert_eq!(output.calls().len(), 1);
+        assert_eq!(output.calls()[0].name.as_deref(), Some("get_weather"));
+        assert_eq!(
+            output.calls()[0].arguments,
+            r#"{"city":"Boston","metadata":{"name":"forecast"}}"#
+        );
+    }
+
+    #[test]
+    fn hunyuan_a13b_streaming_does_not_treat_argument_name_as_another_call() {
+        let mut parser = HunyuanA13BToolParser::new(&test_tools());
+        let chunks = [
+            r#"<tool_calls>[{"name":"update_record","arguments":{"name":"#,
+            r#""display name","nested":{"name":"inner"}}}"#,
+            "]</tool_calls>",
+        ];
+
+        let output = collect_stream(&mut parser, &chunks);
+
+        assert_eq!(output.calls().len(), 1);
+        assert_eq!(output.calls()[0].name.as_deref(), Some("update_record"));
+        assert_eq!(
+            output.calls()[0].arguments,
+            r#"{"name":"display name","nested":{"name":"inner"}}"#
+        );
+    }
+
+    #[test]
+    fn hunyuan_a13b_finish_errors_on_truncated_tool_call() {
+        let mut parser = HunyuanA13BToolParser::new(&test_tools());
+        parser
+            .parse_chunk(r#"<tool_calls>[{"name":"get_weather","arguments":{"city""#)
+            .unwrap();
+
+        let error = parser.finish().unwrap_err();
+
+        assert_eq!(
+            error.to_report_string(),
+            "tool parser parsing failed: incomplete Hunyuan A13B tool call"
+        );
+    }
+}

--- a/rust/src/parser/src/tool/json/mod.rs
+++ b/rust/src/parser/src/tool/json/mod.rs
@@ -5,6 +5,7 @@
 
 pub use granite4::Granite4ToolParser;
 pub use hermes::HermesToolParser;
+pub use hunyuan_a13b::HunyuanA13BToolParser;
 pub use internlm2::Internlm2ToolParser;
 pub use llama::Llama3JsonToolParser;
 pub use mistral::MistralToolParser;
@@ -13,6 +14,7 @@ pub use qwen::Qwen3XmlToolParser;
 
 mod granite4;
 mod hermes;
+mod hunyuan_a13b;
 mod internlm2;
 mod llama;
 mod mistral;
@@ -32,6 +34,12 @@ use super::utils::{
 use super::{Result, ToolCallDelta, ToolParserOutput};
 
 pub(crate) type JsonToolInput<'i> = Partial<&'i str>;
+
+#[derive(Debug, Clone, Copy)]
+struct JsonToolCallContainer {
+    start_marker: &'static str,
+    end_marker: &'static str,
+}
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct JsonToolCallConfig {
@@ -74,6 +82,9 @@ pub(crate) enum JsonToolCallEvent {
 #[derive(Debug)]
 struct JsonToolCallParser {
     config: JsonToolCallConfig,
+    container: Option<JsonToolCallContainer>,
+    discard_after_end: bool,
+    tool_block_finished: bool,
     buffer: String,
     mode: JsonToolCallMode,
     active_tool_index: Option<usize>,
@@ -85,6 +96,9 @@ impl JsonToolCallParser {
     fn new(config: JsonToolCallConfig) -> Self {
         Self {
             config,
+            container: None,
+            discard_after_end: false,
+            tool_block_finished: false,
             buffer: String::new(),
             mode: JsonToolCallMode::Text,
             active_tool_index: None,
@@ -92,15 +106,45 @@ impl JsonToolCallParser {
         }
     }
 
+    /// Configure delimiters around the sequence of JSON tool-call objects.
+    fn with_container(mut self, start_marker: &'static str, end_marker: &'static str) -> Self {
+        self.container = Some(JsonToolCallContainer {
+            start_marker,
+            end_marker,
+        });
+        self
+    }
+
+    /// Discard text after a complete marker-wrapped tool-call block.
+    fn discard_after_end(mut self) -> Self {
+        self.discard_after_end = true;
+        self
+    }
+
     fn parse_into(&mut self, chunk: &str, output: &mut ToolParserOutput) -> Result<()> {
+        if self.tool_block_finished {
+            return Ok(());
+        }
+
         self.buffer.push_str(chunk);
         let config = self.config;
+        let container = self.container;
 
         while let Some((event, consumed_len)) = parse_buffered_event(&self.buffer, |input| {
-            parse_next_json_tool_call_event(input, &mut self.mode, config)
+            parse_next_json_tool_call_event(
+                input,
+                &mut self.mode,
+                config,
+                container,
+                self.emitted_tool_count == 0,
+            )
         })? {
             self.apply_event(event, output)?;
             self.buffer.drain(..consumed_len);
+            if self.tool_block_finished {
+                self.buffer.clear();
+                break;
+            }
         }
 
         Ok(())
@@ -165,6 +209,7 @@ impl JsonToolCallParser {
             JsonToolCallEvent::ToolCallEnd => {
                 self.active_tool_index = None;
                 self.mode = JsonToolCallMode::Text;
+                self.tool_block_finished = self.discard_after_end;
             }
         }
         Ok(())
@@ -174,6 +219,7 @@ impl JsonToolCallParser {
         self.mode = JsonToolCallMode::Text;
         self.active_tool_index = None;
         self.emitted_tool_count = 0;
+        self.tool_block_finished = false;
         std::mem::take(&mut self.buffer)
     }
 }
@@ -183,13 +229,35 @@ fn parse_next_json_tool_call_event(
     input: &mut JsonToolInput<'_>,
     mode: &mut JsonToolCallMode,
     config: JsonToolCallConfig,
+    container: Option<JsonToolCallContainer>,
+    allow_empty_container: bool,
 ) -> ModalResult<JsonToolCallEvent> {
     match mode {
-        JsonToolCallMode::Text => parse_text_event(input, config),
-        JsonToolCallMode::Header => tool_call_header_event(input, config),
-        JsonToolCallMode::Arguments { json_scan } => {
-            parse_arguments_event(input, json_scan, config)
+        JsonToolCallMode::Text => parse_text_event(input, config, container),
+        JsonToolCallMode::Header => {
+            parse_header_event(input, config, container, allow_empty_container)
         }
+        JsonToolCallMode::Arguments { json_scan } => {
+            parse_arguments_event(input, json_scan, config, container)
+        }
+    }
+}
+
+/// Parse either the next JSON tool-call header or an empty container end.
+fn parse_header_event(
+    input: &mut JsonToolInput<'_>,
+    config: JsonToolCallConfig,
+    container: Option<JsonToolCallContainer>,
+    allow_empty_container: bool,
+) -> ModalResult<JsonToolCallEvent> {
+    if container.is_some() && allow_empty_container {
+        alt((
+            |input: &mut JsonToolInput<'_>| tool_call_end_event(input, config, container),
+            |input: &mut JsonToolInput<'_>| tool_call_header_event(input, config),
+        ))
+        .parse_next(input)
+    } else {
+        tool_call_header_event(input, config)
     }
 }
 
@@ -197,9 +265,10 @@ fn parse_next_json_tool_call_event(
 fn parse_text_event(
     input: &mut JsonToolInput<'_>,
     config: JsonToolCallConfig,
+    container: Option<JsonToolCallContainer>,
 ) -> ModalResult<JsonToolCallEvent> {
     alt((
-        |input: &mut JsonToolInput<'_>| tool_call_start_event(input, config),
+        |input: &mut JsonToolInput<'_>| tool_call_start_event(input, config, container),
         |input: &mut JsonToolInput<'_>| safe_text_event(input, config),
     ))
     .parse_next(input)
@@ -209,10 +278,12 @@ fn parse_text_event(
 fn tool_call_start_event(
     input: &mut JsonToolInput<'_>,
     config: JsonToolCallConfig,
+    container: Option<JsonToolCallContainer>,
 ) -> ModalResult<JsonToolCallEvent> {
     seq!(
         _: literal(config.start_marker),
         _: |input: &mut JsonToolInput<'_>| marker_whitespace(input, config),
+        _: |input: &mut JsonToolInput<'_>| container_start(input, container, config),
     )
     .value(JsonToolCallEvent::ToolCallStart)
     .parse_next(input)
@@ -296,9 +367,10 @@ fn parse_arguments_event(
     input: &mut JsonToolInput<'_>,
     json_scan: &mut JsonObjectScanState,
     config: JsonToolCallConfig,
+    container: Option<JsonToolCallContainer>,
 ) -> ModalResult<JsonToolCallEvent> {
     if json_scan.complete() {
-        tool_call_close_event(input, config)
+        tool_call_close_event(input, config, container)
     } else {
         argument_delta_event(input, json_scan)
     }
@@ -316,16 +388,17 @@ fn argument_delta_event(
 fn tool_call_close_event(
     input: &mut JsonToolInput<'_>,
     config: JsonToolCallConfig,
+    container: Option<JsonToolCallContainer>,
 ) -> ModalResult<JsonToolCallEvent> {
     seq!(_: ws0, _: literal("}")).parse_next(input)?;
 
     match config.delimiter {
         Some(delimiter) => alt((
-            |input: &mut JsonToolInput<'_>| tool_call_end_event(input, config),
+            |input: &mut JsonToolInput<'_>| tool_call_end_event(input, config, container),
             |input: &mut JsonToolInput<'_>| tool_call_delimiter_event(input, delimiter),
         ))
         .parse_next(input),
-        None => tool_call_end_event(input, config),
+        None => tool_call_end_event(input, config, container),
     }
 }
 
@@ -333,13 +406,49 @@ fn tool_call_close_event(
 fn tool_call_end_event(
     input: &mut JsonToolInput<'_>,
     config: JsonToolCallConfig,
+    container: Option<JsonToolCallContainer>,
 ) -> ModalResult<JsonToolCallEvent> {
     seq!(
         _: |input: &mut JsonToolInput<'_>| marker_whitespace(input, config),
+        _: |input: &mut JsonToolInput<'_>| container_end(input, container, config),
         _: literal(config.end_marker),
     )
     .value(JsonToolCallEvent::ToolCallEnd)
     .parse_next(input)
+}
+
+/// Parse the configured sequence opening delimiter, if any.
+fn container_start(
+    input: &mut JsonToolInput<'_>,
+    container: Option<JsonToolCallContainer>,
+    config: JsonToolCallConfig,
+) -> ModalResult<()> {
+    match container {
+        Some(container) => seq!(
+            _: literal(container.start_marker),
+            _: |input: &mut JsonToolInput<'_>| marker_whitespace(input, config),
+        )
+        .void()
+        .parse_next(input),
+        None => Ok(()),
+    }
+}
+
+/// Parse the configured sequence closing delimiter, if any.
+fn container_end(
+    input: &mut JsonToolInput<'_>,
+    container: Option<JsonToolCallContainer>,
+    config: JsonToolCallConfig,
+) -> ModalResult<()> {
+    match container {
+        Some(container) => seq!(
+            _: literal(container.end_marker),
+            _: |input: &mut JsonToolInput<'_>| marker_whitespace(input, config),
+        )
+        .void()
+        .parse_next(input),
+        None => Ok(()),
+    }
 }
 
 /// Parse a delimiter between JSON tool calls inside one marker block.

--- a/rust/src/parser/src/tool/mod.rs
+++ b/rust/src/parser/src/tool/mod.rs
@@ -26,8 +26,8 @@ pub use error::{Result, ToolParserError};
 pub use glm_xml::{Glm45MoeToolParser, Glm47MoeToolParser};
 pub use hy_v3::HyV3ToolParser;
 pub use json::{
-    Granite4ToolParser, HermesToolParser, Internlm2ToolParser, Llama3JsonToolParser,
-    MistralToolParser, Phi4MiniJsonToolParser, Qwen3XmlToolParser,
+    Granite4ToolParser, HermesToolParser, HunyuanA13BToolParser, Internlm2ToolParser,
+    Llama3JsonToolParser, MistralToolParser, Phi4MiniJsonToolParser, Qwen3XmlToolParser,
 };
 pub use kimi_k2::KimiK2ToolParser;
 pub use minimax_m2::MinimaxM2ToolParser;


### PR DESCRIPTION
## Purpose

The Rust frontend exposes parser selection and automatic model matching, but it did not provide the Python frontend's `hunyuan_a13b` tool parser. Serving `tencent/Hunyuan-A13B-Instruct` through the Rust frontend therefore could not parse the model's `<tool_calls>[...]</tool_calls>` JSON-array format into OpenAI tool-call deltas.

This PR adds a Hunyuan A13B parser using the existing shared incremental JSON tool-call core. It supports parallel calls, empty call arrays, nested argument objects, non-ASCII text, arbitrary streaming chunk boundaries, whitespace between `<tool_calls>` and the JSON array, and argument properties named `name` without treating them as new call headers. To match the Python parser, it also strips the leading chat-template `助手：` prefix from natural-language responses and discards text after a completed tool-call block, including an empty block. The parser is registered under the Python-compatible `hunyuan_a13b` name, with model-name matching for the hyphenated and underscored Hunyuan A13B forms.

This contributes to the Rust frontend parity roadmap in #44280.

Duplicate-work check: I reviewed #44280's claims and searched current open PRs for `hunyuan rust`, `hunyuan_a13b`, `Hunyuan A13B Rust Frontend`, `HunyuanA13BToolParser`, and `tool_calls JSON array Rust Frontend`. No open PR adds this parser. Related PRs cover HY-V3 reasoning (#48800), Python Hunyuan parser fixes (#49535 and #47954), and a Python Hermes parser-engine migration (#51937), so they do not overlap this Rust implementation.

AI assistance was used to research, implement, test, and review this change. The commit includes the required attribution trailer. This is intentionally a draft so the account owner can complete the final human review before marking it ready.

## Test Plan

```bash
cargo fmt --all --check
cargo nextest run -p vllm-parser
cargo nextest run -p vllm-chat factory_new_resolves_default_patterns
cargo nextest run -p vllm-chat validate_parser_overrides_rejects_unknown_tool_parser
cargo clippy -p vllm-parser -p vllm-chat --all-targets -- -D warnings
git diff --check origin/main...HEAD
```

The parser unit tests cover:

- ordinary text without a tool call;
- chat-template prefix removal across streaming chunk boundaries;
- preservation of a non-leading `助手：` occurrence in ordinary content;
- parallel calls and deeply nested arguments;
- prefix text and non-ASCII arguments;
- whitespace and newlines before the JSON array;
- empty arrays in complete and character-by-character streaming input;
- discarded suffix text after complete and empty tool-call blocks;
- rejection of an invalid trailing comma;
- arbitrary streaming chunk boundaries;
- nested argument keys named `name`;
- a truncated tool call failing closed.

## Test Result

- `cargo fmt --all --check`: passed
- Full `vllm-parser` nextest suite: 431 passed (including 15 Hunyuan tests)
- factory model-pattern test: 1 passed
- unknown-parser registry snapshot test: 1 passed
- Clippy with warnings denied for `vllm-parser` and `vllm-chat`: passed
- `git diff --check`: passed

Clippy emitted only a dependency-level future-incompatibility notice for `proc-macro-error2`; it emitted no lint failure for this change. An additional full `vllm-chat` run passed 268 tests before eight network-transport integration tests hit the local sandbox's `Operation not permitted` restriction and fail-fast cancelled the remainder; the two chat tests affected by this change passed independently. No model evaluation is required because this adds frontend parsing parity and does not change model inference or generated tokens.

---

<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] Purpose and related roadmap are documented.
- [x] Exact test commands are provided.
- [x] Test results are reported.
- [x] No model documentation update is required; this adds a frontend parser for an already supported model/parser format.
</details>
