### PR TITLE
[Docs] Fix `WhisperEncoderLayer.forward` docstring in `dots3_note`

### DIFF
--- a/vllm/models/dots3_note/nvidia/audio_encoder.py
+++ b/vllm/models/dots3_note/nvidia/audio_encoder.py
@@ -345,17 +345,26 @@ class WhisperEncoderLayer(nn.Module):
         output_attentions: bool = False,
         rotary_cos: torch.Tensor | None = None,
         rotary_sin: torch.Tensor | None = None,
-    ) -> torch.Tensor:
+    ) -> tuple[Any, ...]:
         """
         Args:
-            hidden_states (`torch.FloatTensor`): input to the layer of shape `(seq_len, batch, embed_dim)`
-            attention_mask (`torch.FloatTensor`): attention mask of size
-                `(batch, 1, tgt_len, src_len)` where padding elements are indicated by very large negative values.
-            layer_head_mask (`torch.FloatTensor`): mask for attention heads in a given layer of size
-                `(encoder_attention_heads,)`.
-            output_attentions (`bool`, *optional*):
-                Whether or not to return the attentions tensors of all attention layers. See `attentions` under
-                returned tensors for more detail.
+            hidden_states: Input to the layer of shape `(batch, seq_len,
+                embed_dim)`, or `(total_tokens, embed_dim)` when `cu_seqlens_q`
+                is given.
+            cu_seqlens_q: Cumulative query sequence lengths for packed
+                variable-length input. If `None`, the input is treated as a
+                padded batch.
+            cu_seqlens_kv: Cumulative key/value sequence lengths for packed
+                variable-length input.
+            max_seqlen_q: Longest query sequence in the packed batch.
+            max_seqlen_kv: Longest key/value sequence in the packed batch.
+            output_attentions: Whether to also return the attention weights.
+            rotary_cos: Cosine component of the rotary position embedding.
+            rotary_sin: Sine component of the rotary position embedding.
+
+        Returns:
+            A tuple of the output hidden states, followed by the attention
+            weights if `output_attentions` is `True`.
         """
         residual = hidden_states
         hidden_states = self.self_attn_layer_norm(hidden_states)


### PR DESCRIPTION
## Purpose

The docs build emits griffe warnings for `vllm/models/dots3_note/nvidia/audio_encoder.py`:

```
WARNING - griffe: audio_encoder.py:351: Parameter 'attention_mask' does not appear in the function signature
WARNING - griffe: audio_encoder.py:353: Parameter 'layer_head_mask' does not appear in the function signature
```

The `WhisperEncoderLayer.forward` docstring was inherited from the upstream HF Whisper implementation and never updated for this layer's signature, which takes packed variable-length inputs (`cu_seqlens_*`, `max_seqlen_*`) and rotary embeddings instead of `attention_mask`/`layer_head_mask`.

This documents the parameters the method actually takes. It also corrects the return annotation, which claimed `torch.Tensor` while the method returns `tuple[Any, ...]` (hidden states, plus attention weights when `output_attentions=True`).

Docstring only, plus one annotation. No runtime behaviour change.

## Not a duplicate

- `gh pr list --state open --search "griffe docstring parameter"` returns only #51342, which fixes an unrelated annotation in `vllm/benchmarks/throughput.py`.
- `gh pr list --state open --search "dots3_note audio_encoder"` returns nothing.

## Test Plan

Run griffe's Google-style docstring parser over the module and check for warnings.

## Test Result

Before:

```
WARNING: module.py:351: Parameter 'attention_mask' does not appear in the function signature
WARNING: module.py:353: Parameter 'layer_head_mask' does not appear in the function signature
```

After: no warnings.

`pre-commit run --files vllm/models/dots3_note/nvidia/audio_encoder.py` passes, including `mypy` and `ruff`.

No model evaluation is included because the change touches no executed code.

## Note

AI assistance (Claude Code) was used for this change. I have reviewed every changed line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)