### PR TITLE
[Bugfix][ROCm][CI] Give the AITER MLA decode metadata stub its MLA dims

### DIFF
--- a/tests/kernels/attention/test_rocm_aiter_mla_decode_metadata.py
+++ b/tests/kernels/attention/test_rocm_aiter_mla_decode_metadata.py
@@ -82,6 +82,7 @@ def _build_decode_metadata():
         create_vllm_config,
     )
     from vllm.config.vllm import set_current_vllm_config
+    from vllm.model_executor.layers.attention.mla_attention import get_mla_dims
     from vllm.v1.attention.backends.registry import AttentionBackendEnum
     from vllm.v1.kv_cache_interface import MLAAttentionSpec
     from vllm.v1.worker.workspace import init_workspace_manager
@@ -110,11 +111,20 @@ def _build_decode_metadata():
 
     builder_cls = AttentionBackendEnum.ROCM_AITER_MLA.get_class().get_builder_cls()
 
-    # The builder reads layer.prefill_backend from static_forward_context; a
-    # stub with the attribute is enough for metadata construction.
+    # The builder reads prefill_backend and the MLA latent dims off the layer,
+    # so the stub carries both; the dims come from the model config to stay in
+    # step with the checkpoint.
+    mla_dims = get_mla_dims(vllm_config.model_config)
     layer_name = "placeholder"
     vllm_config.compilation_config.static_forward_context[layer_name] = (
-        types.SimpleNamespace(prefill_backend=torch.empty((1,)))
+        types.SimpleNamespace(
+            prefill_backend=torch.empty((1,)),
+            q_lora_rank=mla_dims.q_lora_rank,
+            kv_lora_rank=mla_dims.kv_lora_rank,
+            qk_nope_head_dim=mla_dims.qk_nope_head_dim,
+            qk_rope_head_dim=mla_dims.qk_rope_head_dim,
+            v_head_dim=mla_dims.v_head_dim,
+        )
     )
 
     init_workspace_manager(device)


### PR DESCRIPTION
# Purpose

`tests/kernels/attention/test_rocm_aiter_mla_decode_metadata.py::test_persistent_decode_metadata_matches_fp8_golden`
fails on main with `AttributeError: 'types.SimpleNamespace' object has no
attribute 'q_lora_rank'`. Two jobs report it, the dedicated AITER MLA job and the sharded `kernels/attention` job, but it is the same test.

"[Model] Add native Dots3 NOTE multimodal support" (#51255), changed
`MLACommonMetadataBuilder.__init__` to read the MLA latent dimensions off the
layer in `static_forward_context` instead of calling
`get_mla_dims(self.model_config)`, so that hybrid MLA models can use different
dimensions per KV cache group. The builder now also sizes its chunked-prefill
workspace from `kv_lora_rank + qk_rope_head_dim` rather than from
`model_config.get_head_size()`.

This test stubs that layer with a `SimpleNamespace` holding only
`prefill_backend`, so the builder raises on the first dimension it asks for.
#51255 updated the same stub in the sibling test
`test_rocm_aiter_mla_causal_verify_mask.py` and in the MLA backend tests, but
missed this file, which uses the identical pattern.

# Test Plan

The change adds the five MLA dimensions to the stub. They are taken from
`get_mla_dims(vllm_config.model_config)`, which is what the builder itself used
before #51255, so the stub cannot drift from the `deepseek-ai/DeepSeek-R1`
configuration the rest of the test is built around. The sibling test hardcodes
the same values as module constants because it also builds tensors from them;
this one does not need them anywhere else.

On gfx950 (MI355X), with AITER:

```
pytest -v -s tests/kernels/attention/test_rocm_aiter_mla_decode_metadata.py \
             tests/kernels/attention/test_rocm_aiter_mla_causal_verify_mask.py
```

The repository was also searched for any other test stubbing a layer the same
way; these two are the only ones.

# Test Result

Before the change the decode metadata test fails with the `AttributeError`
above. After it, both tests pass. The assertion the test exists for, that the
builder's persistent decode metadata matches the golden recomputed with explicit
fp8 dtypes, is reached and holds; nothing about the coverage changes.


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

