### PR TITLE
[Model][Quantization] Add Ling 3.0 Flash FP4 support

### DIFF
--- a/vllm/model_executor/models/bailing_moe_v3.py
+++ b/vllm/model_executor/models/bailing_moe_v3.py
@@ -219,6 +219,19 @@ def _configure_ling_fp8_quant_config(
         quant_config.ignored_layers_match_mode = "suffix"
 
 
+def _normalize_mxfp4_expert_param_name(
+    quant_config: QuantizationConfig | None,
+    name: str,
+) -> str:
+    if (
+        isinstance(quant_config, Fp8Config)
+        and quant_config.store_dtype == "mxfp4"
+        and name.endswith("_weight_scale_inv")
+    ):
+        return name.removesuffix("_inv")
+    return name
+
+
 def _is_fp8_module_excluded(
     quant_config: QuantizationConfig | None,
     prefix: str,
@@ -1487,6 +1500,9 @@ class BailingMoeV3ForCausalLM(nn.Module, HasInnerState, IsHybrid, SupportsPP):
                 for param_name, weight_name, expert_id, shard_id in expert_mappings:
                     if weight_name in name:
                         mapped = name.replace(weight_name, param_name)
+                        mapped = _normalize_mxfp4_expert_param_name(
+                            self.quant_config, mapped
+                        )
                         load_param(mapped, weight, (expert_id, shard_id))
                         break
                 continue

--- a/vllm/model_executor/models/bailing_moe_v3_mtp.py
+++ b/vllm/model_executor/models/bailing_moe_v3_mtp.py
@@ -31,6 +31,7 @@ from vllm.model_executor.models.bailing_moe_v3 import (
     BailingMoeV3MoE,
     _configure_ling_fp8_quant_config,
     _maybe_pad_block_fp8_shared_expert_checkpoint_tensor,
+    _normalize_mxfp4_expert_param_name,
 )
 from vllm.model_executor.models.interfaces import SupportsPP
 from vllm.model_executor.models.utils import (
@@ -391,6 +392,9 @@ class BailingMoeV3MTPModel(nn.Module, SupportsPP):
                     if weight_name not in name:
                         continue
                     mapped_name = name.replace(weight_name, param_name)
+                    mapped_name = _normalize_mxfp4_expert_param_name(
+                        self.quant_config, mapped_name
+                    )
                     if load_param(mapped_name, loaded_weight, (expert_id, shard_id)):
                         loaded = True
                         break

--- a/vllm/model_executor/models/config.py
+++ b/vllm/model_executor/models/config.py
@@ -371,6 +371,26 @@ class KimiK3ForConditionalGenerationConfig(VerifyAndUpdateConfig):
                 quant_config["quant_method"] = "mxfp4"
 
 
+class BailingMoeV3ForCausalLMConfig(VerifyAndUpdateConfig):
+    """Map Ling3's mixed FP8/MXFP4 metadata to the existing FP8 config."""
+
+    @staticmethod
+    def verify_and_update_model_config(model_config: "ModelConfig") -> None:
+        for cfg in (
+            model_config.hf_config,
+            model_config.hf_text_config,
+            model_config.model_arch_config,
+        ):
+            quant_config = getattr(cfg, "quantization_config", None)
+            if not (
+                isinstance(quant_config, dict)
+                and quant_config.get("quant_method") == "fp8"
+                and quant_config.get("routed_experts_quant_method") == "mxfp4"
+            ):
+                continue
+            quant_config["store_dtype"] = "mxfp4"
+
+
 class GptOssForCausalLMConfig(VerifyAndUpdateConfig):
     @staticmethod
     def verify_and_update_model_config(model_config: "ModelConfig") -> None:
@@ -893,6 +913,8 @@ class LongcatFlashNgramForCausalLMConfig(VerifyAndUpdateConfig):
 
 
 MODELS_CONFIG_MAP: dict[str, type[VerifyAndUpdateConfig]] = {
+    "BailingMoeV3ForCausalLM": BailingMoeV3ForCausalLMConfig,
+    "BailingMoeV3MTPModel": BailingMoeV3ForCausalLMConfig,
     "ColBERTJinaRobertaModel": JinaRobertaModelConfig,
     "ColQwen3_5": ColQwen3_5Config,
     "DeepseekV4ForCausalLM": DeepseekV4ForCausalLMConfig,


### PR DESCRIPTION
## Purpose

Add loading and serving support for
[inclusionAI/Ling-3.0-flash-fp4](https://huggingface.co/inclusionAI/Ling-3.0-flash-fp4).

Ling FP4 uses mixed FP8/MXFP4 quantization metadata:

```json
{
  "quant_method": "fp8",
  "routed_experts_quant_method": "mxfp4"
}
```

This PR:

- adds a model-specific configuration hook that keeps `Fp8Config` while selecting MXFP4 storage for routed experts;
- maps routed-expert `*_weight_scale_inv` checkpoint names to the internal MXFP4 `*_weight_scale` parameters;
- applies the loading behavior to both the main and MTP models.

The change is gated on Ling's FP4 metadata, leaving BF16, FP8, and INT4 checkpoints unchanged.

No open PR currently adds Ling FP4 checkpoint loading.

## Test Plan

Run the full in-tree GSM8K evaluation in no-thinking mode. The evaluator uses the raw completions endpoint without applying Ling's chat template or enabling native thinking:

```bash
TMPDIR=/path/to/gsm8k PYTHONPATH=. .venv/bin/python -c '
from tests.evals.gsm8k.gsm8k_eval import evaluate_gsm8k

print(evaluate_gsm8k(
    port=8001,
    num_questions=1319,
    num_shots=5,
    max_tokens=256,
    temperature=0,
    seed=42,
    use_chat_completions=False,
    max_concurrency=16,
    request_timeout_seconds=3600,
))
'
```

## Test Result

NVIDIA GB10, CUDA 13.0, PyTorch 2.13.0+cu130:

| Checkpoint | Mode | Accuracy | Invalid responses | Output tokens/s |
| --- | --- | ---: | ---: | ---: |
| Ling 3.0 Flash FP4 | No thinking | 84.08% | 0.00% | 102.75 |
| Ling 3.0 Flash INT4 | No thinking | 86.28% | 0.00% | 109.67 |

Both runs used the same vLLM revision, 1,319 questions, 5-shot prompts, temperature 0, `max_tokens=256`, concurrency 16, and the raw completions endpoint. Ling's native thinking mode was not enabled.

## AI assistance disclosure

OpenAI Codex assisted with investigation, implementation, deployment, testing, evaluation analysis, and drafting this description. The human submitter reviewed the changes and understands the implementation.
