### PR TITLE
[Bugfix] Fix standalone torch.compile cache loading after relocation

### DIFF
--- a/tests/compile/test_compiler_interface.py
+++ b/tests/compile/test_compiler_interface.py
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from vllm.compilation.compiler_interface import InductorStandaloneAdaptor
+
+
+@pytest.mark.parametrize("save_format", ["binary", "unpacked"])
+def test_inductor_standalone_load_uses_current_cache_dir(
+    tmp_path: Path,
+    save_format: str,
+):
+    old_cache_dir = tmp_path / "old"
+    new_cache_dir = tmp_path / "new"
+    key = "artifact_shape_None_subgraph_0"
+
+    adaptor = InductorStandaloneAdaptor(save_format=save_format)
+    adaptor.initialize_cache(str(new_cache_dir))
+
+    # Simulate a handle persisted before the cache directory was relocated.
+    handle = (key, str(old_cache_dir / key))
+
+    with (
+        patch(
+            "torch._inductor.CompiledArtifact.load",
+            return_value=MagicMock(),
+        ) as load_mock,
+        patch(
+            "torch._inductor.compile_fx.graph_returns_tuple",
+            return_value=True,
+        ),
+    ):
+        adaptor.load(
+            handle=handle,
+            graph=MagicMock(),
+            example_inputs=[],
+            graph_index=0,
+            compile_range=MagicMock(),
+        )
+
+    load_mock.assert_called_once_with(
+        path=str(new_cache_dir / key),
+        format=save_format,
+    )

--- a/vllm/compilation/compiler_interface.py
+++ b/vllm/compilation/compiler_interface.py
@@ -424,7 +424,7 @@ class InductorStandaloneAdaptor(CompilerInterface):
         assert isinstance(handle, tuple)
         assert isinstance(handle[0], str)
         assert isinstance(handle[1], str)
-        path = handle[1]
+        path = os.path.join(self.cache_dir, handle[0])
         inductor_compiled_graph = torch._inductor.CompiledArtifact.load(
             path=path, format=self.save_format
         )


### PR DESCRIPTION
## Purpose

Fixes #52154.

The standalone Inductor compile cache persists artifact handles as `(key, absolute_path)`.

vLLM supports reusing its `torch.compile` cache after copying it to another machine or baking it into a container image. If the cache directory changes location in that process, the artifact exists under the new cache directory, but `InductorStandaloneAdaptor.load()` still uses the persisted absolute path. If the original location is unavailable, loading fails with `FileNotFoundError`.

This change reconstructs the artifact path from the adaptor's current `self.cache_dir` and the persisted artifact key (`handle[0]`) instead of loading from the stale path in `handle[1]`.

The persisted handle format remains unchanged, so this fix does not require changing existing cache metadata.

## Test Plan

Added a regression test covering both standalone artifact save formats:

- `binary`
- `unpacked`

The test initializes the adaptor with a relocated cache directory while using a handle that contains the old absolute path, and verifies that `CompiledArtifact.load()` resolves the artifact from the current cache directory.

```bash
python -m pytest -q \
  --confcutdir=tests/compile \
  tests/compile/test_compiler_interface.py
```

## Test Result

Before this change:

```text
2 failed

Expected: .../new/artifact_shape_None_subgraph_0
Actual:   .../old/artifact_shape_None_subgraph_0
```

With this change:

```text
2 passed
```

Also verified with `git diff --check` and pre-commit on the modified files.