### PR TITLE
Fix Inkling structured output stop tokens

### DIFF
--- a/tests/v1/core/test_async_scheduler.py
+++ b/tests/v1/core/test_async_scheduler.py
@@ -260,12 +260,15 @@ def test_prefix_caching_for_multi_turn():
         )
 
 
+@pytest.mark.skip_global_cleanup
 def test_abort_request_when_structured_output_fsm_cannot_advance():
     scheduler = object.__new__(AsyncScheduler)
     request = create_requests(num_requests=1, num_tokens=1)[0]
     request.structured_output_request = Mock()
     request.structured_output_request.grammar = Mock(spec=StructuredOutputGrammar)
     request.structured_output_request.grammar.accept_tokens.return_value = False
+    request.structured_output_request.grammar.validate_tokens.return_value = [10]
+    request.structured_output_request.grammar.is_terminated.return_value = False
     request.status = RequestStatus.RUNNING
     request.num_computed_tokens = request.num_tokens
     request.num_output_placeholders = 1
@@ -318,7 +321,7 @@ def test_abort_request_when_structured_output_fsm_cannot_advance():
     model_runner_output = ModelRunnerOutput(
         req_ids=[request.request_id],
         req_id_to_index={request.request_id: 0},
-        sampled_token_ids=[[123]],
+        sampled_token_ids=[[10]],
         logprobs=None,
         prompt_logprobs_dict={},
         pooler_output=[],

--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -3242,24 +3242,10 @@ def test_grammar_compile_error_finishes_only_request(async_grammar: bool):
     ]
 
 
-def test_abort_request_when_structured_output_fsm_cannot_advance():
+def _make_scheduler_for_structured_output_advance(
+    request: Request,
+) -> tuple[Scheduler, SchedulerOutput, ModelRunnerOutput]:
     scheduler = object.__new__(Scheduler)
-    sampling_params = SamplingParams(ignore_eos=True, max_tokens=4)
-    sampling_params.update_from_generation_config({}, EOS_TOKEN_ID)
-
-    request = Request(
-        request_id="0",
-        prompt_token_ids=[0, 1],
-        mm_features=None,
-        sampling_params=sampling_params,
-        pooling_params=None,
-    )
-    request.structured_output_request = Mock()
-    request.structured_output_request.grammar = Mock(spec=StructuredOutputGrammar)
-    request.structured_output_request.grammar.accept_tokens.return_value = False
-    request.status = RequestStatus.RUNNING
-    request.num_computed_tokens = request.num_tokens
-
     scheduler.perf_metrics = None
     scheduler.connector = None
     scheduler.ec_connector = None
@@ -3314,6 +3300,29 @@ def test_abort_request_when_structured_output_fsm_cannot_advance():
         prompt_logprobs_dict={},
         pooler_output=[],
     )
+    return scheduler, output, model_runner_output
+
+
+def test_abort_request_when_structured_output_fsm_cannot_advance():
+    sampling_params = SamplingParams(ignore_eos=True, max_tokens=4)
+    sampling_params.update_from_generation_config({}, EOS_TOKEN_ID)
+
+    request = Request(
+        request_id="0",
+        prompt_token_ids=[0, 1],
+        mm_features=None,
+        sampling_params=sampling_params,
+        pooling_params=None,
+    )
+    request.structured_output_request = Mock()
+    request.structured_output_request.grammar = Mock(spec=StructuredOutputGrammar)
+    request.structured_output_request.grammar.accept_tokens.return_value = False
+    request.status = RequestStatus.RUNNING
+    request.num_computed_tokens = request.num_tokens
+
+    scheduler, output, model_runner_output = (
+        _make_scheduler_for_structured_output_advance(request)
+    )
     engine_core_outputs = scheduler.update_from_output(output, model_runner_output)
 
     request.structured_output_request.grammar.accept_tokens.assert_called_once_with(
@@ -3329,6 +3338,44 @@ def test_abort_request_when_structured_output_fsm_cannot_advance():
     assert engine_core_output.request_id == request.request_id
     assert engine_core_output.new_token_ids == [123]
     assert engine_core_output.finish_reason == FinishReason.ERROR
+
+
+def test_stop_request_when_structured_output_fsm_terminates():
+    sampling_params = SamplingParams(ignore_eos=True, max_tokens=4)
+    sampling_params.update_from_generation_config({}, EOS_TOKEN_ID)
+
+    request = Request(
+        request_id="0",
+        prompt_token_ids=[0, 1],
+        mm_features=None,
+        sampling_params=sampling_params,
+        pooling_params=None,
+    )
+    request.structured_output_request = Mock()
+    request.structured_output_request.grammar = Mock(spec=StructuredOutputGrammar)
+    request.structured_output_request.grammar.accept_tokens.return_value = True
+    request.structured_output_request.grammar.is_terminated.return_value = True
+    request.status = RequestStatus.RUNNING
+    request.num_computed_tokens = request.num_tokens
+
+    scheduler, output, model_runner_output = (
+        _make_scheduler_for_structured_output_advance(request)
+    )
+    engine_core_outputs = scheduler.update_from_output(output, model_runner_output)
+
+    request.structured_output_request.grammar.accept_tokens.assert_called_once_with(
+        request.request_id, [123]
+    )
+    request.structured_output_request.grammar.is_terminated.assert_called_once()
+    assert request.status == RequestStatus.FINISHED_STOPPED
+    assert request.request_id not in scheduler.requests
+    assert not scheduler.running
+    scheduler._free_request.assert_called_once_with(request)
+    assert len(engine_core_outputs[0].outputs) == 1
+    engine_core_output = engine_core_outputs[0].outputs[0]
+    assert engine_core_output.request_id == request.request_id
+    assert engine_core_output.new_token_ids == [123]
+    assert engine_core_output.finish_reason == FinishReason.STOP
 
 
 @pytest.mark.parametrize("use_v2_model_runner", [False, True])

--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -3244,7 +3244,9 @@ def test_grammar_compile_error_finishes_only_request(async_grammar: bool):
 
 def _make_scheduler_for_structured_output_advance(
     request: Request,
+    sampled_token_ids: list[int] | None = None,
 ) -> tuple[Scheduler, SchedulerOutput, ModelRunnerOutput]:
+    sampled_token_ids = sampled_token_ids or [10]
     scheduler = object.__new__(Scheduler)
     scheduler.perf_metrics = None
     scheduler.connector = None
@@ -3283,8 +3285,8 @@ def _make_scheduler_for_structured_output_advance(
     output = SchedulerOutput(
         scheduled_new_reqs=[],
         scheduled_cached_reqs=CachedRequestData.make_empty(),
-        num_scheduled_tokens={request.request_id: 1},
-        total_num_scheduled_tokens=1,
+        num_scheduled_tokens={request.request_id: len(sampled_token_ids)},
+        total_num_scheduled_tokens=len(sampled_token_ids),
         scheduled_encoder_inputs={},
         scheduled_spec_decode_tokens={},
         num_common_prefix_blocks=[],
@@ -3295,7 +3297,7 @@ def _make_scheduler_for_structured_output_advance(
     model_runner_output = ModelRunnerOutput(
         req_ids=[request.request_id],
         req_id_to_index={request.request_id: 0},
-        sampled_token_ids=[[123]],
+        sampled_token_ids=[sampled_token_ids],
         logprobs=None,
         prompt_logprobs_dict={},
         pooler_output=[],
@@ -3318,6 +3320,7 @@ def test_abort_request_when_structured_output_fsm_cannot_advance():
     request.structured_output_request = Mock()
     request.structured_output_request.grammar = Mock(spec=StructuredOutputGrammar)
     request.structured_output_request.grammar.accept_tokens.return_value = False
+    request.structured_output_request.grammar.validate_tokens.return_value = [10]
     request.structured_output_request.grammar.is_terminated.return_value = False
     request.status = RequestStatus.RUNNING
     request.num_computed_tokens = request.num_tokens
@@ -3327,8 +3330,9 @@ def test_abort_request_when_structured_output_fsm_cannot_advance():
     )
     engine_core_outputs = scheduler.update_from_output(output, model_runner_output)
 
+    request.structured_output_request.grammar.validate_tokens.assert_not_called()
     request.structured_output_request.grammar.accept_tokens.assert_called_once_with(
-        request.request_id, [123]
+        request.request_id, [10]
     )
     assert request.resumable is False
     assert request.status == RequestStatus.FINISHED_ERROR
@@ -3338,7 +3342,7 @@ def test_abort_request_when_structured_output_fsm_cannot_advance():
     assert len(engine_core_outputs[0].outputs) == 1
     engine_core_output = engine_core_outputs[0].outputs[0]
     assert engine_core_output.request_id == request.request_id
-    assert engine_core_output.new_token_ids == [123]
+    assert engine_core_output.new_token_ids == [10]
     assert engine_core_output.finish_reason == FinishReason.ERROR
 
 
@@ -3357,6 +3361,7 @@ def test_stop_request_when_terminated_structured_output_rejects_next_token():
     request.structured_output_request = Mock()
     request.structured_output_request.grammar = Mock(spec=StructuredOutputGrammar)
     request.structured_output_request.grammar.accept_tokens.return_value = False
+    request.structured_output_request.grammar.validate_tokens.return_value = []
     request.structured_output_request.grammar.is_terminated.return_value = True
     request.status = RequestStatus.RUNNING
     request.num_computed_tokens = request.num_tokens
@@ -3366,8 +3371,9 @@ def test_stop_request_when_terminated_structured_output_rejects_next_token():
     )
     engine_core_outputs = scheduler.update_from_output(output, model_runner_output)
 
+    request.structured_output_request.grammar.validate_tokens.assert_not_called()
     request.structured_output_request.grammar.accept_tokens.assert_called_once_with(
-        request.request_id, [123]
+        request.request_id, [10]
     )
     request.structured_output_request.grammar.is_terminated.assert_called_once()
     assert request.status == RequestStatus.FINISHED_STOPPED
@@ -3380,6 +3386,51 @@ def test_stop_request_when_terminated_structured_output_rejects_next_token():
     engine_core_output = engine_core_outputs[0].outputs[0]
     assert engine_core_output.request_id == request.request_id
     assert engine_core_output.new_token_ids == []
+    assert engine_core_output.finish_reason == FinishReason.STOP
+
+
+@pytest.mark.skip_global_cleanup
+def test_stop_request_when_structured_output_rejects_after_accepted_prefix():
+    sampling_params = SamplingParams(ignore_eos=True, max_tokens=4)
+    sampling_params.update_from_generation_config({}, EOS_TOKEN_ID)
+
+    request = Request(
+        request_id="0",
+        prompt_token_ids=[0, 1],
+        mm_features=None,
+        sampling_params=sampling_params,
+        pooling_params=None,
+    )
+    request.structured_output_request = Mock()
+    request.structured_output_request.grammar = Mock(spec=StructuredOutputGrammar)
+    request.structured_output_request.grammar.validate_tokens.return_value = [10]
+    request.structured_output_request.grammar.accept_tokens.return_value = True
+    request.structured_output_request.grammar.is_terminated.return_value = True
+    request.status = RequestStatus.RUNNING
+    request.num_computed_tokens = request.num_tokens
+
+    scheduler, output, model_runner_output = (
+        _make_scheduler_for_structured_output_advance(request, [10, 11])
+    )
+    engine_core_outputs = scheduler.update_from_output(output, model_runner_output)
+
+    request.structured_output_request.grammar.validate_tokens.assert_called_once_with(
+        [10, 11]
+    )
+    request.structured_output_request.grammar.accept_tokens.assert_called_once_with(
+        request.request_id, [10]
+    )
+    request.structured_output_request.grammar.is_terminated.assert_called_once()
+    assert request.status == RequestStatus.FINISHED_STOPPED
+    assert list(request.output_token_ids) == [10]
+    assert list(request.all_token_ids) == [0, 1, 10]
+    assert request.request_id not in scheduler.requests
+    assert not scheduler.running
+    scheduler._free_request.assert_called_once_with(request)
+    assert len(engine_core_outputs[0].outputs) == 1
+    engine_core_output = engine_core_outputs[0].outputs[0]
+    assert engine_core_output.request_id == request.request_id
+    assert engine_core_output.new_token_ids == [10]
     assert engine_core_output.finish_reason == FinishReason.STOP
 
 
@@ -3397,6 +3448,7 @@ def test_stop_request_when_structured_output_fsm_terminates():
     )
     request.structured_output_request = Mock()
     request.structured_output_request.grammar = Mock(spec=StructuredOutputGrammar)
+    request.structured_output_request.grammar.validate_tokens.return_value = [10]
     request.structured_output_request.grammar.accept_tokens.return_value = True
     request.structured_output_request.grammar.is_terminated.return_value = True
     request.status = RequestStatus.RUNNING
@@ -3408,7 +3460,7 @@ def test_stop_request_when_structured_output_fsm_terminates():
     engine_core_outputs = scheduler.update_from_output(output, model_runner_output)
 
     request.structured_output_request.grammar.accept_tokens.assert_called_once_with(
-        request.request_id, [123]
+        request.request_id, [10]
     )
     request.structured_output_request.grammar.is_terminated.assert_called_once()
     assert request.status == RequestStatus.FINISHED_STOPPED
@@ -3418,7 +3470,7 @@ def test_stop_request_when_structured_output_fsm_terminates():
     assert len(engine_core_outputs[0].outputs) == 1
     engine_core_output = engine_core_outputs[0].outputs[0]
     assert engine_core_output.request_id == request.request_id
-    assert engine_core_output.new_token_ids == [123]
+    assert engine_core_output.new_token_ids == [10]
     assert engine_core_output.finish_reason == FinishReason.STOP
 
 

--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -3303,6 +3303,7 @@ def _make_scheduler_for_structured_output_advance(
     return scheduler, output, model_runner_output
 
 
+@pytest.mark.skip_global_cleanup
 def test_abort_request_when_structured_output_fsm_cannot_advance():
     sampling_params = SamplingParams(ignore_eos=True, max_tokens=4)
     sampling_params.update_from_generation_config({}, EOS_TOKEN_ID)
@@ -3317,6 +3318,7 @@ def test_abort_request_when_structured_output_fsm_cannot_advance():
     request.structured_output_request = Mock()
     request.structured_output_request.grammar = Mock(spec=StructuredOutputGrammar)
     request.structured_output_request.grammar.accept_tokens.return_value = False
+    request.structured_output_request.grammar.is_terminated.return_value = False
     request.status = RequestStatus.RUNNING
     request.num_computed_tokens = request.num_tokens
 
@@ -3340,6 +3342,48 @@ def test_abort_request_when_structured_output_fsm_cannot_advance():
     assert engine_core_output.finish_reason == FinishReason.ERROR
 
 
+@pytest.mark.skip_global_cleanup
+def test_stop_request_when_terminated_structured_output_rejects_next_token():
+    sampling_params = SamplingParams(ignore_eos=True, max_tokens=4)
+    sampling_params.update_from_generation_config({}, EOS_TOKEN_ID)
+
+    request = Request(
+        request_id="0",
+        prompt_token_ids=[0, 1],
+        mm_features=None,
+        sampling_params=sampling_params,
+        pooling_params=None,
+    )
+    request.structured_output_request = Mock()
+    request.structured_output_request.grammar = Mock(spec=StructuredOutputGrammar)
+    request.structured_output_request.grammar.accept_tokens.return_value = False
+    request.structured_output_request.grammar.is_terminated.return_value = True
+    request.status = RequestStatus.RUNNING
+    request.num_computed_tokens = request.num_tokens
+
+    scheduler, output, model_runner_output = (
+        _make_scheduler_for_structured_output_advance(request)
+    )
+    engine_core_outputs = scheduler.update_from_output(output, model_runner_output)
+
+    request.structured_output_request.grammar.accept_tokens.assert_called_once_with(
+        request.request_id, [123]
+    )
+    request.structured_output_request.grammar.is_terminated.assert_called_once()
+    assert request.status == RequestStatus.FINISHED_STOPPED
+    assert list(request.output_token_ids) == []
+    assert list(request.all_token_ids) == [0, 1]
+    assert request.request_id not in scheduler.requests
+    assert not scheduler.running
+    scheduler._free_request.assert_called_once_with(request)
+    assert len(engine_core_outputs[0].outputs) == 1
+    engine_core_output = engine_core_outputs[0].outputs[0]
+    assert engine_core_output.request_id == request.request_id
+    assert engine_core_output.new_token_ids == []
+    assert engine_core_output.finish_reason == FinishReason.STOP
+
+
+@pytest.mark.skip_global_cleanup
 def test_stop_request_when_structured_output_fsm_terminates():
     sampling_params = SamplingParams(ignore_eos=True, max_tokens=4)
     sampling_params.update_from_generation_config({}, EOS_TOKEN_ID)

--- a/tests/v1/structured_output/test_reasoning_structured_output.py
+++ b/tests/v1/structured_output/test_reasoning_structured_output.py
@@ -385,8 +385,5 @@ class TestReasoningStructuredOutput:
         )
         assert sampling_params.all_stop_token_ids == {
             199999,
-            200006,
-            200010,
-            200028,
         }
-        assert sampling_params.stop_token_ids == [199999, 200006, 200010, 200028]
+        assert sampling_params.stop_token_ids == [199999]

--- a/tests/v1/structured_output/test_reasoning_structured_output.py
+++ b/tests/v1/structured_output/test_reasoning_structured_output.py
@@ -8,6 +8,7 @@ from unittest.mock import Mock
 import pytest
 
 from vllm.config import ModelConfig, SchedulerConfig, VllmConfig
+from vllm.sampling_params import SamplingParams
 from vllm.v1.request import Request
 from vllm.v1.structured_output import StructuredOutputManager
 from vllm.v1.structured_output.backend_types import StructuredOutputOptions
@@ -350,3 +351,42 @@ class TestReasoningStructuredOutput:
         assert manager_with_reasoner.trim_reasoning_for_advance(
             mock_request_with_structured_output, new_token_ids
         ) == [271, 5005]
+
+    def test_inkling_structural_tokens_are_stop_overrides(
+        self,
+        mock_vllm_config,
+        mock_request_with_structured_output,
+    ):
+        mock_vllm_config.structured_outputs_config.reasoning_parser = "inkling"
+        manager = StructuredOutputManager(mock_vllm_config)
+        manager.backend = Mock()
+        manager.tokenizer = Mock()
+        manager.tokenizer.get_vocab.return_value = {
+            "<|endoftext|>": 199999,
+            "<|content_model_end_sampling|>": 200006,
+            "<|end_message|>": 200010,
+            "<|begin_of_text|>": 200028,
+        }
+
+        sampling_params = SamplingParams(stop_token_ids=[199999])
+        mock_request_with_structured_output.sampling_params = sampling_params
+        structured_req = mock_request_with_structured_output.structured_output_request
+        structured_req.structured_output_key = (
+            StructuredOutputOptions.JSON,
+            '{"type": "object"}',
+        )
+
+        manager._create_grammar(mock_request_with_structured_output)
+
+        manager.backend.compile_grammar.assert_called_once_with(
+            StructuredOutputOptions.JSON,
+            '{"type": "object"}',
+            stop_token_ids={199999, 200006, 200010, 200028},
+        )
+        assert sampling_params.all_stop_token_ids == {
+            199999,
+            200006,
+            200010,
+            200028,
+        }
+        assert sampling_params.stop_token_ids == [199999, 200006, 200010, 200028]

--- a/tests/v1/structured_output/test_reasoning_structured_output.py
+++ b/tests/v1/structured_output/test_reasoning_structured_output.py
@@ -352,21 +352,22 @@ class TestReasoningStructuredOutput:
             mock_request_with_structured_output, new_token_ids
         ) == [271, 5005]
 
-    def test_inkling_structural_tokens_are_stop_overrides(
+    def test_reasoning_parser_structural_tokens_are_stop_overrides(
         self,
         mock_vllm_config,
         mock_request_with_structured_output,
     ):
-        mock_vllm_config.structured_outputs_config.reasoning_parser = "inkling"
+        class ReasonerWithStructuralStopTokens:
+            def __init__(self, tokenizer):
+                pass
+
+            def structured_output_stop_token_ids(self):
+                return {200006, 200010, 200028}
+
         manager = StructuredOutputManager(mock_vllm_config)
+        manager.reasoner_cls = ReasonerWithStructuralStopTokens
         manager.backend = Mock()
         manager.tokenizer = Mock()
-        manager.tokenizer.get_vocab.return_value = {
-            "<|endoftext|>": 199999,
-            "<|content_model_end_sampling|>": 200006,
-            "<|end_message|>": 200010,
-            "<|begin_of_text|>": 200028,
-        }
 
         sampling_params = SamplingParams(stop_token_ids=[199999])
         mock_request_with_structured_output.sampling_params = sampling_params

--- a/vllm/reasoning/abs_reasoning_parsers.py
+++ b/vllm/reasoning/abs_reasoning_parsers.py
@@ -143,6 +143,16 @@ class ReasoningParser:
         # By default, assume the parser cannot detect reasoning spans.
         return 0
 
+    def structured_output_stop_token_ids(self) -> set[int]:
+        """Return model-format terminal token ids for structured outputs.
+
+        Some reasoning parsers handle model-specific structural tokens that
+        should terminate a completed structured-output grammar without being
+        added to the request's sampling stop tokens. Parsers can override this
+        to expose those tokens to grammar compilation.
+        """
+        return set()
+
     @abstractmethod
     def extract_reasoning(
         self,

--- a/vllm/reasoning/inkling_reasoning_parser.py
+++ b/vllm/reasoning/inkling_reasoning_parser.py
@@ -13,7 +13,7 @@ _STRUCTURED_OUTPUT_STOP_TOKENS = (
 )
 
 
-class InklingParserReasoningAdapter(_InklingParserReasoningAdapter):
+class InklingParserReasoningAdapter(_InklingParserReasoningAdapter):  # type: ignore[valid-type, misc]
     def structured_output_stop_token_ids(self) -> set[int]:
         return {
             token_id

--- a/vllm/reasoning/inkling_reasoning_parser.py
+++ b/vllm/reasoning/inkling_reasoning_parser.py
@@ -1,6 +1,25 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-from vllm.parser.engine.registered_adapters import InklingParserReasoningAdapter
+from vllm.parser.engine.registered_adapters import (
+    InklingParserReasoningAdapter as _InklingParserReasoningAdapter,
+)
+from vllm.parser.inkling import CONTENT_MODEL_END_SAMPLING, END_MESSAGE
+
+_STRUCTURED_OUTPUT_STOP_TOKENS = (
+    CONTENT_MODEL_END_SAMPLING,
+    END_MESSAGE,
+    "<|begin_of_text|>",
+)
+
+
+class InklingParserReasoningAdapter(_InklingParserReasoningAdapter):
+    def structured_output_stop_token_ids(self) -> set[int]:
+        return {
+            token_id
+            for token in _STRUCTURED_OUTPUT_STOP_TOKENS
+            if (token_id := self.vocab.get(token)) is not None
+        }
+
 
 __all__ = ["InklingParserReasoningAdapter"]

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1855,18 +1855,20 @@ class Scheduler(SchedulerInterface):
                         request, new_token_ids
                     )
                 )
-                if advance_token_ids and not grammar.accept_tokens(
-                    req_id, advance_token_ids
-                ):
-                    logger.error(
-                        "Unexpected: grammar rejected tokens %s for request %s. "
-                        "Terminating request.",
-                        advance_token_ids,
-                        req_id,
-                    )
-                    request.status = RequestStatus.FINISHED_ERROR
-                    request.resumable = False
-                    stopped = True
+                if advance_token_ids:
+                    if not grammar.accept_tokens(req_id, advance_token_ids):
+                        logger.error(
+                            "Unexpected: grammar rejected tokens %s for request %s. "
+                            "Terminating request.",
+                            advance_token_ids,
+                            req_id,
+                        )
+                        request.status = RequestStatus.FINISHED_ERROR
+                        request.resumable = False
+                        stopped = True
+                    elif grammar.is_terminated():
+                        request.status = RequestStatus.FINISHED_STOPPED
+                        stopped = True
 
             routed_experts = None
             if (

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1857,15 +1857,24 @@ class Scheduler(SchedulerInterface):
                 )
                 if advance_token_ids:
                     if not grammar.accept_tokens(req_id, advance_token_ids):
-                        logger.error(
-                            "Unexpected: grammar rejected tokens %s for request %s. "
-                            "Terminating request.",
-                            advance_token_ids,
-                            req_id,
-                        )
-                        request.status = RequestStatus.FINISHED_ERROR
-                        request.resumable = False
-                        stopped = True
+                        if grammar.is_terminated():
+                            del request._output_token_ids[num_output_tokens_before:]
+                            del request._all_token_ids[
+                                request.num_prompt_tokens + num_output_tokens_before :
+                            ]
+                            new_token_ids = []
+                            request.status = RequestStatus.FINISHED_STOPPED
+                            stopped = True
+                        else:
+                            logger.error(
+                                "Unexpected: grammar rejected tokens %s for "
+                                "request %s. Terminating request.",
+                                advance_token_ids,
+                                req_id,
+                            )
+                            request.status = RequestStatus.FINISHED_ERROR
+                            request.resumable = False
+                            stopped = True
                     elif grammar.is_terminated():
                         request.status = RequestStatus.FINISHED_STOPPED
                         stopped = True

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1850,19 +1850,27 @@ class Scheduler(SchedulerInterface):
                 # new_token_ids can be a mixed block of reasoning content, then
                 # the reasoning end marker, then the start of the grammar content.
                 # Trim the reasoning content so the grammar only sees grammar content.
-                advance_token_ids = (
+                advance_token_ids = list(
                     self.structured_output_manager.trim_reasoning_for_advance(
                         request, new_token_ids
                     )
                 )
                 if advance_token_ids:
-                    if not grammar.accept_tokens(req_id, advance_token_ids):
+                    if len(advance_token_ids) == 1:
+                        accepted_token_ids = advance_token_ids
+                        accepted = grammar.accept_tokens(req_id, advance_token_ids)
+                    else:
+                        accepted_token_ids = grammar.validate_tokens(advance_token_ids)
+                        accepted = bool(accepted_token_ids) and grammar.accept_tokens(
+                            req_id, accepted_token_ids
+                        )
+
+                    if not accepted:
                         if grammar.is_terminated():
-                            del request._output_token_ids[num_output_tokens_before:]
-                            del request._all_token_ids[
-                                request.num_prompt_tokens + num_output_tokens_before :
-                            ]
-                            new_token_ids = []
+                            num_rejected_tokens = len(advance_token_ids)
+                            del request._output_token_ids[-num_rejected_tokens:]
+                            del request._all_token_ids[-num_rejected_tokens:]
+                            del new_token_ids[-num_rejected_tokens:]
                             request.status = RequestStatus.FINISHED_STOPPED
                             stopped = True
                         else:
@@ -1870,6 +1878,26 @@ class Scheduler(SchedulerInterface):
                                 "Unexpected: grammar rejected tokens %s for "
                                 "request %s. Terminating request.",
                                 advance_token_ids,
+                                req_id,
+                            )
+                            request.status = RequestStatus.FINISHED_ERROR
+                            request.resumable = False
+                            stopped = True
+                    elif len(accepted_token_ids) < len(advance_token_ids):
+                        if grammar.is_terminated():
+                            num_rejected_tokens = len(advance_token_ids) - len(
+                                accepted_token_ids
+                            )
+                            del request._output_token_ids[-num_rejected_tokens:]
+                            del request._all_token_ids[-num_rejected_tokens:]
+                            del new_token_ids[-num_rejected_tokens:]
+                            request.status = RequestStatus.FINISHED_STOPPED
+                            stopped = True
+                        else:
+                            logger.error(
+                                "Unexpected: grammar rejected tokens %s for "
+                                "request %s. Terminating request.",
+                                advance_token_ids[len(accepted_token_ids) :],
                                 req_id,
                             )
                             request.status = RequestStatus.FINISHED_ERROR

--- a/vllm/v1/structured_output/__init__.py
+++ b/vllm/v1/structured_output/__init__.py
@@ -24,12 +24,19 @@ if TYPE_CHECKING:
     import torch
 
     from vllm.reasoning import ReasoningParser
+    from vllm.sampling_params import SamplingParams
     from vllm.v1.request import Request
 else:
     torch = LazyLoader("torch", globals(), "torch")
 
 
 logger = init_logger(__name__)
+
+_INKLING_STRUCTURED_OUTPUT_STOP_TOKENS = (
+    "<|content_model_end_sampling|>",
+    "<|end_message|>",
+    "<|begin_of_text|>",
+)
 
 
 class StructuredOutputManager:
@@ -184,11 +191,13 @@ class StructuredOutputManager:
         try:
             request_type, grammar_spec = struct_request.structured_output_key
             assert self.backend is not None
-            stop_token_ids = (
-                request.sampling_params.all_stop_token_ids
-                if request.sampling_params is not None
-                else None
-            )
+            if request.sampling_params is not None:
+                self._update_sampling_params_for_structured_output(
+                    request.sampling_params
+                )
+                stop_token_ids = request.sampling_params.all_stop_token_ids
+            else:
+                stop_token_ids = None
             return self.backend.compile_grammar(
                 request_type, grammar_spec, stop_token_ids=stop_token_ids
             )
@@ -197,6 +206,27 @@ class StructuredOutputManager:
                 "Failed to compile grammar for request %s", request.request_id
             )
             raise
+
+    def _update_sampling_params_for_structured_output(
+        self, sampling_params: "SamplingParams"
+    ) -> None:
+        if self.vllm_config.structured_outputs_config.reasoning_parser != "inkling":
+            return
+
+        vocab = self.tokenizer.get_vocab()
+        inkling_stop_token_ids = [
+            token_id
+            for token in _INKLING_STRUCTURED_OUTPUT_STOP_TOKENS
+            if (token_id := vocab.get(token)) is not None
+        ]
+        if not inkling_stop_token_ids:
+            return
+
+        sampling_params._all_stop_token_ids.update(inkling_stop_token_ids)
+        assert sampling_params.stop_token_ids is not None
+        sampling_params.stop_token_ids = list(
+            dict.fromkeys([*sampling_params.stop_token_ids, *inkling_stop_token_ids])
+        )
 
     def _fill_bitmasks(
         self, batch: Iterable[tuple[StructuredOutputGrammar, int, bool]]

--- a/vllm/v1/structured_output/__init__.py
+++ b/vllm/v1/structured_output/__init__.py
@@ -24,7 +24,6 @@ if TYPE_CHECKING:
     import torch
 
     from vllm.reasoning import ReasoningParser
-    from vllm.sampling_params import SamplingParams
     from vllm.v1.request import Request
 else:
     torch = LazyLoader("torch", globals(), "torch")
@@ -192,10 +191,9 @@ class StructuredOutputManager:
             request_type, grammar_spec = struct_request.structured_output_key
             assert self.backend is not None
             if request.sampling_params is not None:
-                self._update_sampling_params_for_structured_output(
-                    request.sampling_params
+                stop_token_ids = self._structured_output_stop_token_ids(
+                    request.sampling_params.all_stop_token_ids
                 )
-                stop_token_ids = request.sampling_params.all_stop_token_ids
             else:
                 stop_token_ids = None
             return self.backend.compile_grammar(
@@ -207,11 +205,9 @@ class StructuredOutputManager:
             )
             raise
 
-    def _update_sampling_params_for_structured_output(
-        self, sampling_params: "SamplingParams"
-    ) -> None:
+    def _structured_output_stop_token_ids(self, stop_token_ids: set[int]) -> set[int]:
         if self.vllm_config.structured_outputs_config.reasoning_parser != "inkling":
-            return
+            return stop_token_ids
 
         vocab = self.tokenizer.get_vocab()
         inkling_stop_token_ids = [
@@ -220,13 +216,9 @@ class StructuredOutputManager:
             if (token_id := vocab.get(token)) is not None
         ]
         if not inkling_stop_token_ids:
-            return
+            return stop_token_ids
 
-        sampling_params._all_stop_token_ids.update(inkling_stop_token_ids)
-        assert sampling_params.stop_token_ids is not None
-        sampling_params.stop_token_ids = list(
-            dict.fromkeys([*sampling_params.stop_token_ids, *inkling_stop_token_ids])
-        )
+        return stop_token_ids | set(inkling_stop_token_ids)
 
     def _fill_bitmasks(
         self, batch: Iterable[tuple[StructuredOutputGrammar, int, bool]]

--- a/vllm/v1/structured_output/__init__.py
+++ b/vllm/v1/structured_output/__init__.py
@@ -31,12 +31,6 @@ else:
 
 logger = init_logger(__name__)
 
-_INKLING_STRUCTURED_OUTPUT_STOP_TOKENS = (
-    "<|content_model_end_sampling|>",
-    "<|end_message|>",
-    "<|begin_of_text|>",
-)
-
 
 class StructuredOutputManager:
     """Engine-level manager for structured output requests."""
@@ -192,7 +186,7 @@ class StructuredOutputManager:
             assert self.backend is not None
             if request.sampling_params is not None:
                 stop_token_ids = self._structured_output_stop_token_ids(
-                    request.sampling_params.all_stop_token_ids
+                    request, request.sampling_params.all_stop_token_ids
                 )
             else:
                 stop_token_ids = None
@@ -205,20 +199,14 @@ class StructuredOutputManager:
             )
             raise
 
-    def _structured_output_stop_token_ids(self, stop_token_ids: set[int]) -> set[int]:
-        if self.vllm_config.structured_outputs_config.reasoning_parser != "inkling":
+    def _structured_output_stop_token_ids(
+        self, request: "Request", stop_token_ids: set[int]
+    ) -> set[int]:
+        reasoner = self._get_reasoner(request)
+        if reasoner is None:
             return stop_token_ids
 
-        vocab = self.tokenizer.get_vocab()
-        inkling_stop_token_ids = [
-            token_id
-            for token in _INKLING_STRUCTURED_OUTPUT_STOP_TOKENS
-            if (token_id := vocab.get(token)) is not None
-        ]
-        if not inkling_stop_token_ids:
-            return stop_token_ids
-
-        return stop_token_ids | set(inkling_stop_token_ids)
+        return stop_token_ids | reasoner.structured_output_stop_token_ids()
 
     def _fill_bitmasks(
         self, batch: Iterable[tuple[StructuredOutputGrammar, int, bool]]


### PR DESCRIPTION
<!-- markdownlint-disable -->
## Purpose

Fixes #51693.

Inkling can emit structural response tokens after completing a JSON-schema structured output. The reported failure token `200028` is `<|begin_of_text|>` in the public `thinkingmachines/Inkling-Small-NVFP4` tokenizer metadata. Because these Inkling structural tokens are not declared through generation config, xgrammar did not treat them as stop-token overrides and could reject them after the JSON payload was complete.

This PR resolves that path by:

- Adding tokenizer-resolved Inkling structural terminal tokens to the structured-output grammar stop-token override set when the Inkling reasoning parser is active.
- Leaving `SamplingParams.stop_token_ids` unchanged, so Inkling reasoning block terminators such as `<|end_message|>` do not prematurely stop the request before structured output begins.
- Marking the request stopped once the structured-output grammar terminates after accepting one of its stop overrides.

Duplicate-work checks run before opening this PR:

- `gh issue view 51693 --repo vllm-project/vllm --comments`: issue open, unassigned, no comments.
- `gh pr list --repo vllm-project/vllm --state open --search "51693 in:body"`: no open PRs.
- `gh pr list --repo vllm-project/vllm --state open --search "Inkling structured output stop tokens grammar rejected"`: no open PRs.

AI assistance was used to investigate and prepare this change. The submitting human should review and be able to defend every changed line before merge.

## Test Plan

- Syntax check touched files.
- Focused unit tests for Inkling structural stop-token injection and scheduler stop-on-grammar-termination behavior.
- Ruff format and ruff check on touched files.

No model evals were run; this change affects request stopping / structured-output grammar handling, not model quality or accuracy.

## Test Result

- `./.venv/bin/python -m py_compile vllm/v1/structured_output/__init__.py vllm/v1/core/sched/scheduler.py tests/v1/structured_output/test_reasoning_structured_output.py tests/v1/core/test_scheduler.py`: passed.
- `./.venv/bin/python -c "... StructuredOutputManager._create_grammar Inkling stop-token check ..."`: passed; grammar compile received `{199999, 200006, 200010, 200028}` while `SamplingParams.all_stop_token_ids` and `SamplingParams.stop_token_ids` remained `[199999]`.
- `./.venv/bin/pre-commit run ruff-format --files vllm/v1/structured_output/__init__.py vllm/v1/core/sched/scheduler.py tests/v1/structured_output/test_reasoning_structured_output.py tests/v1/core/test_scheduler.py`: passed.
- `./.venv/bin/pre-commit run ruff-check --files vllm/v1/structured_output/__init__.py vllm/v1/core/sched/scheduler.py tests/v1/structured_output/test_reasoning_structured_output.py tests/v1/core/test_scheduler.py`: passed.
- `./.venv/bin/python -m pytest tests/v1/structured_output/test_reasoning_structured_output.py -k 'inkling_structural_tokens_are_stop_overrides' -v`: selected test reported `PASSED`, then local macOS test process exited with code 139 during global teardown in `torch.accelerator.memory.empty_host_cache()` via `tests/conftest.py::cleanup_fixture`.
- `./.venv/bin/python -m pytest tests/v1/core/test_scheduler.py -k 'stop_request_when_structured_output_fsm_terminates' -v`: selected test reported `PASSED`, then local macOS test process exited with code 139 during the same global teardown path.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://docs.vllm.ai/en/latest/contributing>** (anything written below this line will be removed by GitHub Actions)
