### PR TITLE
[Test] Add pause/resume E2E tests

### DIFF
--- a/tests/entrypoints/serve/dev/rlhf/conftest.py
+++ b/tests/entrypoints/serve/dev/rlhf/conftest.py
@@ -10,15 +10,18 @@ PR:  https://github.com/vllm-project/vllm/pull/45586
 """
 
 import contextlib
+import json
 import os
 import subprocess
 import sys
+import threading
 import time
+from collections.abc import Callable
 from contextlib import contextmanager
-from typing import Callable
+from dataclasses import dataclass, field
+from typing import Any
 
 import requests
-
 
 # ---------------------------------------------------------------------------
 # Model / server defaults
@@ -177,8 +180,9 @@ def gen(url, prompt="The capital of France is", max_tokens=8, timeout=30):
         return None
 
 
-def gen_with_logprobs(url, prompt="The capital of France is", max_tokens=8,
-                      logprobs=5, timeout=30):
+def gen_with_logprobs(
+    url, prompt="The capital of France is", max_tokens=8, logprobs=5, timeout=30
+):
     """Fire a /v1/completions request with logprobs; return JSON or None."""
     try:
         r = requests.post(
@@ -208,19 +212,72 @@ def ok(resp) -> bool:
 
 
 # ---------------------------------------------------------------------------
-# HTTP helpers — sleep / wake / pause / resume
+# HTTP helpers — stream generation
 # ---------------------------------------------------------------------------
 
 
-def sleep(url, level=1, mode="abort"):
-    return requests.post(
-        f"{url}/sleep", params={"level": level, "mode": mode}, timeout=15
-    ).status_code
+@dataclass
+class StreamResult:
+    started: threading.Event = field(default_factory=threading.Event)
+    done: threading.Event = field(default_factory=threading.Event)
+    chunks: list[dict[str, Any]] = field(default_factory=list)
+    finish_reason: str | None = None
+    error: Exception | None = None
 
 
-def wake(url, tags=None):
-    params = {"tags": tags} if tags else {}
-    return requests.post(f"{url}/wake_up", params=params, timeout=20).status_code
+def stream_completion(url: str, result: StreamResult, max_tokens: int) -> None:
+    try:
+        with requests.post(
+            f"{url}/v1/completions",
+            json={
+                "model": "m",
+                "prompt": "Count upward slowly: one, two, three,",
+                "max_tokens": max_tokens,
+                "temperature": 0,
+                "ignore_eos": True,
+                "stream": True,
+            },
+            stream=True,
+            timeout=(5, 60),
+        ) as response:
+            response.raise_for_status()
+            for line in response.iter_lines(decode_unicode=True):
+                if not line or line == "data: [DONE]":
+                    continue
+                assert line.startswith("data: ")
+                chunk = json.loads(line.removeprefix("data: "))
+                result.chunks.append(chunk)
+                choice = chunk["choices"][0]
+                if choice.get("text"):
+                    result.started.set()
+                if choice.get("finish_reason") is not None:
+                    result.finish_reason = choice["finish_reason"]
+    except Exception as error:
+        result.error = error
+    finally:
+        result.done.set()
+
+
+def start_stream(url: str, max_tokens: int) -> tuple[StreamResult, threading.Thread]:
+    result = StreamResult()
+    thread = threading.Thread(
+        target=stream_completion,
+        args=(url, result, max_tokens),
+    )
+    thread.start()
+    started = result.started.wait(timeout=10)
+    if not started or result.done.is_set():
+        pause(url, mode="abort")
+        resume(url)
+        thread.join(timeout=10)
+    assert started, "request did not start generating"
+    assert not result.done.is_set(), "request completed before it could be paused"
+    return result, thread
+
+
+# ---------------------------------------------------------------------------
+# HTTP helpers — pause / resume
+# ---------------------------------------------------------------------------
 
 
 def pause(url, mode="abort", clear_cache=True):
@@ -233,6 +290,54 @@ def pause(url, mode="abort", clear_cache=True):
 
 def resume(url):
     return requests.post(f"{url}/resume", timeout=10).status_code
+
+
+def completion_with_cache_details(url: str, prompt: str) -> dict[str, Any]:
+    response = requests.post(
+        f"{url}/v1/completions",
+        json={
+            "model": "m",
+            "prompt": prompt,
+            "max_tokens": 8,
+            "temperature": 0,
+            "logprobs": 1,
+        },
+        timeout=30,
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+def golden_output(response: dict[str, Any]) -> dict[str, Any]:
+    choice = response["choices"][0]
+    usage = response["usage"]
+    return {
+        "text": choice["text"],
+        "finish_reason": choice["finish_reason"],
+        "tokens": choice["logprobs"]["tokens"],
+        "prompt_tokens": usage["prompt_tokens"],
+        "completion_tokens": usage["completion_tokens"],
+    }
+
+
+def cached_tokens(response: dict[str, Any]) -> int:
+    return response["usage"]["prompt_tokens_details"]["cached_tokens"]
+
+
+# ---------------------------------------------------------------------------
+# HTTP helpers — sleep / wake
+# ---------------------------------------------------------------------------
+
+
+def sleep(url, level=1, mode="abort"):
+    return requests.post(
+        f"{url}/sleep", params={"level": level, "mode": mode}, timeout=15
+    ).status_code
+
+
+def wake(url, tags=None):
+    params = {"tags": tags} if tags else {}
+    return requests.post(f"{url}/wake_up", params=params, timeout=20).status_code
 
 
 def is_sleeping(url) -> bool:
@@ -286,7 +391,7 @@ def gpu_free_bytes(device: int = 0) -> int:
         [
             sys.executable,
             "-c",
-            f"import torch; f,_=torch.cuda.mem_get_info({device}); print(f)",
+            f"import torch; f,_=torch.accelerator.get_memory_info({device}); print(f)",
         ],
         timeout=10,
     )

--- a/tests/entrypoints/serve/dev/rlhf/conftest.py
+++ b/tests/entrypoints/serve/dev/rlhf/conftest.py
@@ -1,0 +1,309 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Shared fixtures and helpers for the RL lifecycle test suite.
+
+All test modules under this directory import from here to avoid duplication.
+
+RFC: https://github.com/vllm-project/vllm/issues/45585
+PR:  https://github.com/vllm-project/vllm/pull/45586
+"""
+
+import contextlib
+import os
+import subprocess
+import sys
+import time
+from contextlib import contextmanager
+from typing import Callable
+
+import requests
+
+
+# ---------------------------------------------------------------------------
+# Model / server defaults
+# ---------------------------------------------------------------------------
+
+
+MODEL_NAME = os.environ.get("VLLM_TEST_MODEL", "Qwen/Qwen3-0.6B")
+
+
+_BASE_ARGS = [
+    "--dtype",
+    "bfloat16",
+    "--max-model-len",
+    "2048",
+    "--max-num-seqs",
+    "32",
+    "--gpu-memory-utilization",
+    "0.75",
+    "--enable-sleep-mode",
+    "--enforce-eager",
+]
+
+
+# Lightweight args for state-machine / protocol tests that don't need real
+# weights (avoids spending time downloading a 1B checkpoint in T0 tests).
+_DUMMY_ARGS = [
+    "--dtype",
+    "bfloat16",
+    "--max-model-len",
+    "128",
+    "--max-num-seqs",
+    "8",
+    "--gpu-memory-utilization",
+    "0.5",
+    "--enable-sleep-mode",
+    "--enforce-eager",
+    "--load-format",
+    "dummy",
+]
+
+
+# ---------------------------------------------------------------------------
+# Server harness
+# ---------------------------------------------------------------------------
+
+
+@contextmanager
+def server(
+    extra_args=None,
+    port: int = 8770,
+    timeout: float = 180.0,
+    dummy_weights: bool = False,
+):
+    """Launch a vLLM server with the dev router; yield its base URL.
+
+    Args:
+        extra_args:      Additional CLI flags appended after the base args.
+        port:            HTTP port to bind (caller is responsible for uniqueness).
+        timeout:         Seconds to wait for /health before giving up.
+        dummy_weights:   If True, use --load-format dummy (fast, no real weights).
+    """
+    env = {**os.environ, "VLLM_SERVER_DEV_MODE": "1"}
+    base = _DUMMY_ARGS if dummy_weights else _BASE_ARGS
+    cmd = [
+        sys.executable,
+        "-m",
+        "vllm.entrypoints.openai.api_server",
+        "--model",
+        MODEL_NAME,
+        "--port",
+        str(port),
+        "--served-model-name",
+        "m",
+        *(base + (extra_args or [])),
+    ]
+    proc = subprocess.Popen(
+        cmd, env=env, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE
+    )
+    url = f"http://localhost:{port}"
+    try:
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            if proc.poll() is not None:
+                err = (
+                    proc.stderr.read(4000).decode(errors="replace")
+                    if proc.stderr
+                    else ""
+                )
+                raise RuntimeError(f"vllm server exited during startup:\n{err}")
+            with contextlib.suppress(Exception):
+                if requests.get(f"{url}/health", timeout=3).status_code == 200:
+                    break
+            time.sleep(1)
+        else:
+            proc.terminate()
+            raise RuntimeError("vllm server did not start in time")
+        yield url
+    finally:
+        proc.terminate()
+        with contextlib.suppress(subprocess.TimeoutExpired):
+            proc.wait(timeout=10)
+        if proc.poll() is None:
+            proc.kill()
+
+
+# ---------------------------------------------------------------------------
+# Polling helper (200-lie workaround)
+# ---------------------------------------------------------------------------
+
+
+def poll_until(
+    predicate: Callable[[], bool],
+    timeout: float = 10.0,
+    interval: float = 0.5,
+) -> bool:
+    """Poll predicate() until it returns True or timeout expires.
+
+    Workaround for the vLLM sleep/wake "200-lie" — the HTTP endpoints may
+    return 200 before the underlying operation is complete, so callers that
+    need to verify state *after* an operation can use this helper instead of
+    assuming the 200 means completion.
+
+    Returns True if predicate became true within timeout, False otherwise.
+    """
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            if predicate():
+                return True
+        except Exception:
+            pass
+        time.sleep(interval)
+    return False
+
+
+# ---------------------------------------------------------------------------
+# HTTP helpers — generation
+# ---------------------------------------------------------------------------
+
+
+def gen(url, prompt="The capital of France is", max_tokens=8, timeout=30):
+    """Fire a /v1/completions request; return JSON or None on any error."""
+    try:
+        r = requests.post(
+            f"{url}/v1/completions",
+            json={
+                "model": "m",
+                "prompt": prompt,
+                "max_tokens": max_tokens,
+                "temperature": 0,
+            },
+            timeout=timeout,
+        )
+        return r.json()
+    except Exception:
+        return None
+
+
+def gen_with_logprobs(url, prompt="The capital of France is", max_tokens=8,
+                      logprobs=5, timeout=30):
+    """Fire a /v1/completions request with logprobs; return JSON or None."""
+    try:
+        r = requests.post(
+            f"{url}/v1/completions",
+            json={
+                "model": "m",
+                "prompt": prompt,
+                "max_tokens": max_tokens,
+                "temperature": 0,
+                "logprobs": logprobs,
+            },
+            timeout=timeout,
+        )
+        return r.json()
+    except Exception:
+        return None
+
+
+def ok(resp) -> bool:
+    """True iff resp is a successful completion (has choices, no error key)."""
+    return (
+        resp is not None
+        and "choices" in resp
+        and bool(resp["choices"])
+        and "error" not in resp
+    )
+
+
+# ---------------------------------------------------------------------------
+# HTTP helpers — sleep / wake / pause / resume
+# ---------------------------------------------------------------------------
+
+
+def sleep(url, level=1, mode="abort"):
+    return requests.post(
+        f"{url}/sleep", params={"level": level, "mode": mode}, timeout=15
+    ).status_code
+
+
+def wake(url, tags=None):
+    params = {"tags": tags} if tags else {}
+    return requests.post(f"{url}/wake_up", params=params, timeout=20).status_code
+
+
+def pause(url, mode="abort", clear_cache=True):
+    return requests.post(
+        f"{url}/pause",
+        params={"mode": mode, "clear_cache": clear_cache},
+        timeout=15,
+    ).status_code
+
+
+def resume(url):
+    return requests.post(f"{url}/resume", timeout=10).status_code
+
+
+def is_sleeping(url) -> bool:
+    return requests.get(f"{url}/is_sleeping", timeout=5).json()["is_sleeping"]
+
+
+def is_paused(url) -> bool:
+    return requests.get(f"{url}/is_paused", timeout=5).json()["is_paused"]
+
+
+def health(url) -> int:
+    try:
+        return requests.get(f"{url}/health", timeout=5).status_code
+    except Exception:
+        return 0
+
+
+# ---------------------------------------------------------------------------
+# HTTP helpers — weight transfer
+# ---------------------------------------------------------------------------
+
+
+def start_weight_update(url, is_checkpoint_format=True):
+    return requests.post(
+        f"{url}/start_weight_update",
+        json={"is_checkpoint_format": is_checkpoint_format},
+        timeout=10,
+    )
+
+
+def finish_weight_update(url):
+    return requests.post(f"{url}/finish_weight_update", timeout=10)
+
+
+def get_world_size(url, include_dp=True):
+    return requests.get(
+        f"{url}/get_world_size",
+        params={"include_dp": include_dp},
+        timeout=5,
+    )
+
+
+# ---------------------------------------------------------------------------
+# GPU / metrics helpers
+# ---------------------------------------------------------------------------
+
+
+def gpu_free_bytes(device: int = 0) -> int:
+    """Read GPU free bytes via subprocess to avoid import-time torch init."""
+    out = subprocess.check_output(
+        [
+            sys.executable,
+            "-c",
+            f"import torch; f,_=torch.cuda.mem_get_info({device}); print(f)",
+        ],
+        timeout=10,
+    )
+    return int(out.strip())
+
+
+def sleep_metrics(url):
+    """Return (awake, weights_offloaded, discard_all) from /metrics."""
+    try:
+        from prometheus_client.parser import text_string_to_metric_families
+    except ImportError:
+        return None, None, None
+
+    r = requests.get(f"{url}/metrics", timeout=5)
+    vals: dict = {}
+    for family in text_string_to_metric_families(r.text):
+        if family.name == "vllm:engine_sleep_state":
+            for s in family.samples:
+                vals[s.labels.get("sleep_state", "")] = s.value
+    return vals.get("awake"), vals.get("weights_offloaded"), vals.get("discard_all")

--- a/tests/entrypoints/serve/dev/rlhf/state_transitions/test_pause_resume.py
+++ b/tests/entrypoints/serve/dev/rlhf/state_transitions/test_pause_resume.py
@@ -158,10 +158,8 @@ class TestPauseResume:
                 params={"mode": "invalid"},
                 timeout=10,
             )
-            assert response.status_code == 422
-            assert any(
-                error["loc"][-1] == "mode" for error in response.json()["detail"]
-            )
+            assert response.status_code == 400
+            assert response.json()["error"]["param"] == "query.mode"
             assert is_paused(server_url) is paused
 
             assert resume(server_url) == 200
@@ -170,7 +168,7 @@ class TestPauseResume:
         ("mode", "max_tokens", "inflight_finish_reason"),
         [
             pytest.param("abort", 256, "abort", id="abort"),
-            pytest.param("wait", 64, "length", id="wait"),
+            pytest.param("wait", 256, "length", id="wait"),
             pytest.param("keep", 256, "length", id="keep"),
         ],
     )
@@ -195,10 +193,10 @@ class TestPauseResume:
             assert is_paused(server_url)
 
             if mode in ("abort", "wait"):
-                assert inflight.done.wait(timeout=5)
+                assert inflight.done.is_set()
             else:
                 chunks_after_pause = len(inflight.chunks)
-                assert not inflight.done.wait(timeout=0.3)
+                assert not inflight.done.wait(timeout=5)
                 assert len(inflight.chunks) == chunks_after_pause, (
                     "in-flight request continued generating in keep mode"
                 )

--- a/tests/entrypoints/serve/dev/rlhf/state_transitions/test_pause_resume.py
+++ b/tests/entrypoints/serve/dev/rlhf/state_transitions/test_pause_resume.py
@@ -2,23 +2,25 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """End-to-end tests for the vLLM RL pause/resume lifecycle."""
 
-import json
 import os
-from unittest.mock import patch
 import threading
-from dataclasses import dataclass, field
 from typing import Any
+from unittest.mock import patch
 
 import pytest
 import requests
 
 from tests.entrypoints.serve.dev.rlhf.conftest import (
+    cached_tokens,
+    completion_with_cache_details,
     gen,
+    golden_output,
     is_paused,
     ok,
     pause,
     resume,
     server,
+    start_stream,
 )
 
 
@@ -33,14 +35,16 @@ def server_url(use_v2):
         "VLLM_USE_V2_MODEL_RUNNER": "1" if use_v2 else "0",
     }
 
-    with patch.dict(os.environ, env_vars):
-        with server(
+    with (
+        patch.dict(os.environ, env_vars),
+        server(
             extra_args=[
                 "--enable-prefix-caching",
                 "--enable-prompt-tokens-details",
             ]
-        ) as url:
-            yield url
+        ) as url,
+    ):
+        yield url
 
 
 @pytest.fixture(autouse=True)
@@ -48,97 +52,6 @@ def restore_unpaused_state(server_url):
     assert resume(server_url) == 200
     yield
     assert resume(server_url) == 200
-
-
-@dataclass
-class _StreamResult:
-    started: threading.Event = field(default_factory=threading.Event)
-    done: threading.Event = field(default_factory=threading.Event)
-    chunks: list[dict[str, Any]] = field(default_factory=list)
-    finish_reason: str | None = None
-    error: Exception | None = None
-
-
-def _stream_completion(url: str, result: _StreamResult, max_tokens: int) -> None:
-    try:
-        with requests.post(
-            f"{url}/v1/completions",
-            json={
-                "model": "m",
-                "prompt": "Count upward slowly: one, two, three,",
-                "max_tokens": max_tokens,
-                "temperature": 0,
-                "ignore_eos": True,
-                "stream": True,
-            },
-            stream=True,
-            timeout=(5, 60),
-        ) as response:
-            response.raise_for_status()
-            for line in response.iter_lines(decode_unicode=True):
-                if not line or line == "data: [DONE]":
-                    continue
-                assert line.startswith("data: ")
-                chunk = json.loads(line.removeprefix("data: "))
-                result.chunks.append(chunk)
-                choice = chunk["choices"][0]
-                if choice.get("text"):
-                    result.started.set()
-                if choice.get("finish_reason") is not None:
-                    result.finish_reason = choice["finish_reason"]
-    except Exception as error:
-        result.error = error
-    finally:
-        result.done.set()
-
-
-def _start_stream(url: str, max_tokens: int) -> tuple[_StreamResult, threading.Thread]:
-    result = _StreamResult()
-    thread = threading.Thread(
-        target=_stream_completion,
-        args=(url, result, max_tokens),
-    )
-    thread.start()
-    started = result.started.wait(timeout=10)
-    if not started or result.done.is_set():
-        pause(url, mode="abort")
-        resume(url)
-        thread.join(timeout=10)
-    assert started, "request did not start generating"
-    assert not result.done.is_set(), "request completed before it could be paused"
-    return result, thread
-
-
-def _completion_with_cache_details(url: str, prompt: str) -> dict[str, Any]:
-    response = requests.post(
-        f"{url}/v1/completions",
-        json={
-            "model": "m",
-            "prompt": prompt,
-            "max_tokens": 8,
-            "temperature": 0,
-            "logprobs": 1,
-        },
-        timeout=30,
-    )
-    response.raise_for_status()
-    return response.json()
-
-
-def _golden_output(response: dict[str, Any]) -> dict[str, Any]:
-    choice = response["choices"][0]
-    usage = response["usage"]
-    return {
-        "text": choice["text"],
-        "finish_reason": choice["finish_reason"],
-        "tokens": choice["logprobs"]["tokens"],
-        "prompt_tokens": usage["prompt_tokens"],
-        "completion_tokens": usage["completion_tokens"],
-    }
-
-
-def _cached_tokens(response: dict[str, Any]) -> int:
-    return response["usage"]["prompt_tokens_details"]["cached_tokens"]
 
 
 class TestPauseResume:
@@ -191,7 +104,7 @@ class TestPauseResume:
         max_tokens,
         inflight_finish_reason,
     ):
-        inflight, inflight_thread = _start_stream(server_url, max_tokens)
+        inflight, inflight_thread = start_stream(server_url, max_tokens)
         new_result: dict[str, Any] = {}
         new_done = threading.Event()
 
@@ -229,30 +142,27 @@ class TestPauseResume:
         assert not new_thread.is_alive()
         assert ok(new_result.get("response"))
 
-    def test_clear_cache_preserves_output_and_controls_prefix_cache(
-        self, server_url
-    ):
+    def test_clear_cache_preserves_output_and_controls_prefix_cache(self, server_url):
         prompt = (
-            "Paris is the capital of France. "
-            "Berlin is the capital of Germany. "
+            "Paris is the capital of France. Berlin is the capital of Germany. "
         ) * 20
 
         assert pause(server_url, clear_cache=True) == 200
         assert resume(server_url) == 200
-        baseline = _completion_with_cache_details(server_url, prompt)
-        warmed = _completion_with_cache_details(server_url, prompt)
+        baseline = completion_with_cache_details(server_url, prompt)
+        warmed = completion_with_cache_details(server_url, prompt)
 
-        assert _cached_tokens(baseline) == 0
-        assert _cached_tokens(warmed) > 0
+        assert cached_tokens(baseline) == 0
+        assert cached_tokens(warmed) > 0
 
         assert pause(server_url, clear_cache=False) == 200
         assert resume(server_url) == 200
-        preserved = _completion_with_cache_details(server_url, prompt)
-        assert _golden_output(preserved) == _golden_output(baseline)
-        assert _cached_tokens(preserved) > 0
+        preserved = completion_with_cache_details(server_url, prompt)
+        assert golden_output(preserved) == golden_output(baseline)
+        assert cached_tokens(preserved) > 0
 
         assert pause(server_url, clear_cache=True) == 200
         assert resume(server_url) == 200
-        cleared = _completion_with_cache_details(server_url, prompt)
-        assert _golden_output(cleared) == _golden_output(baseline)
-        assert _cached_tokens(cleared) == 0
+        cleared = completion_with_cache_details(server_url, prompt)
+        assert golden_output(cleared) == golden_output(baseline)
+        assert cached_tokens(cleared) == 0

--- a/tests/entrypoints/serve/dev/rlhf/state_transitions/test_pause_resume.py
+++ b/tests/entrypoints/serve/dev/rlhf/state_transitions/test_pause_resume.py
@@ -1,0 +1,88 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+End-to-end tests for the vLLM RL pause/resume lifecycle.
+
+Endpoint surface under test
+---------------------------
+rlhf/api_router   : POST /pause  POST /resume   GET /is_paused
+
+Test classes
+------------------------------------------------
+TestPauseResume             /pause /resume /is_paused independent of sleep
+
+RFC: https://github.com/vllm-project/vllm/issues/45585
+Fixes regression introduced by: https://github.com/vllm-project/vllm/pull/44483
+"""
+
+import threading
+import time
+
+from tests.entrypoints.serve.dev.rlhf.conftest import (
+    gen,
+    ok,
+    pause,
+    resume,
+    server,
+)
+
+
+# ---------------------------------------------------------------------------
+# TestPauseResume
+# ---------------------------------------------------------------------------
+
+
+class TestPauseResume:
+    """POST /pause  POST /resume  GET /is_paused are independent of sleep.
+
+    /pause blocks scheduling without releasing GPU memory (level=0 equivalent
+    from the GPU side, but a distinct code path and distinct state flag).
+    """
+
+    def test_pause_mode_wait_drains_inflight_request(self):
+        """mode='wait' lets an in-flight request complete, then blocks new ones."""
+        with server() as url:
+            result: dict = {}
+
+            def _bg():
+                result["r"] = gen(url, max_tokens=32, timeout=60)
+
+            t = threading.Thread(target=_bg)
+            t.start()
+            time.sleep(0.5)
+
+            assert pause(url, mode="wait") == 200
+            t.join(timeout=30)
+            assert result.get("r") is not None, (
+                "in-flight request not completed after pause(mode=wait)"
+            )
+
+            resp = gen(url, timeout=5)
+            assert not ok(resp)
+            assert resume(url) == 200
+
+    def test_pause_mode_keep_resumes_frozen_request(self):
+        """mode='keep' freezes the request; it must complete after /resume."""
+        with server() as url:
+            result: dict = {}
+
+            def _bg():
+                result["r"] = gen(url, max_tokens=16, timeout=60)
+
+            t = threading.Thread(target=_bg)
+            t.start()
+            time.sleep(0.3)
+
+            assert pause(url, mode="keep") == 200
+            time.sleep(1)
+
+            # request must NOT have completed yet
+            assert not ok(result.get("r")), (
+                "request completed before resume in mode=keep"
+            )
+
+            assert resume(url) == 200
+            t.join(timeout=30)
+            assert ok(result.get("r")), (
+                "request not completed after resume in mode=keep"
+            )

--- a/tests/entrypoints/serve/dev/rlhf/state_transitions/test_pause_resume.py
+++ b/tests/entrypoints/serve/dev/rlhf/state_transitions/test_pause_resume.py
@@ -1,25 +1,18 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""
-End-to-end tests for the vLLM RL pause/resume lifecycle.
+"""End-to-end tests for the vLLM RL pause/resume lifecycle."""
 
-Endpoint surface under test
----------------------------
-rlhf/api_router   : POST /pause  POST /resume   GET /is_paused
-
-Test classes
-------------------------------------------------
-TestPauseResume             /pause /resume /is_paused independent of sleep
-
-RFC: https://github.com/vllm-project/vllm/issues/45585
-Fixes regression introduced by: https://github.com/vllm-project/vllm/pull/44483
-"""
-
+import json
 import threading
-import time
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+import requests
 
 from tests.entrypoints.serve.dev.rlhf.conftest import (
     gen,
+    is_paused,
     ok,
     pause,
     resume,
@@ -27,62 +20,229 @@ from tests.entrypoints.serve.dev.rlhf.conftest import (
 )
 
 
-# ---------------------------------------------------------------------------
-# TestPauseResume
-# ---------------------------------------------------------------------------
+@pytest.fixture(scope="module")
+def server_url():
+    with server(
+        extra_args=[
+            "--enable-prefix-caching",
+            "--enable-prompt-tokens-details",
+        ]
+    ) as url:
+        yield url
+
+
+@pytest.fixture(autouse=True)
+def restore_unpaused_state(server_url):
+    assert resume(server_url) == 200
+    yield
+    assert resume(server_url) == 200
+
+
+@dataclass
+class _StreamResult:
+    started: threading.Event = field(default_factory=threading.Event)
+    done: threading.Event = field(default_factory=threading.Event)
+    chunks: list[dict[str, Any]] = field(default_factory=list)
+    finish_reason: str | None = None
+    error: Exception | None = None
+
+
+def _stream_completion(url: str, result: _StreamResult, max_tokens: int) -> None:
+    try:
+        with requests.post(
+            f"{url}/v1/completions",
+            json={
+                "model": "m",
+                "prompt": "Count upward slowly: one, two, three,",
+                "max_tokens": max_tokens,
+                "temperature": 0,
+                "ignore_eos": True,
+                "stream": True,
+            },
+            stream=True,
+            timeout=(5, 60),
+        ) as response:
+            response.raise_for_status()
+            for line in response.iter_lines(decode_unicode=True):
+                if not line or line == "data: [DONE]":
+                    continue
+                assert line.startswith("data: ")
+                chunk = json.loads(line.removeprefix("data: "))
+                result.chunks.append(chunk)
+                choice = chunk["choices"][0]
+                if choice.get("text"):
+                    result.started.set()
+                if choice.get("finish_reason") is not None:
+                    result.finish_reason = choice["finish_reason"]
+    except Exception as error:
+        result.error = error
+    finally:
+        result.done.set()
+
+
+def _start_stream(url: str, max_tokens: int) -> tuple[_StreamResult, threading.Thread]:
+    result = _StreamResult()
+    thread = threading.Thread(
+        target=_stream_completion,
+        args=(url, result, max_tokens),
+    )
+    thread.start()
+    started = result.started.wait(timeout=10)
+    if not started or result.done.is_set():
+        pause(url, mode="abort")
+        resume(url)
+        thread.join(timeout=10)
+    assert started, "request did not start generating"
+    assert not result.done.is_set(), "request completed before it could be paused"
+    return result, thread
+
+
+def _completion_with_cache_details(url: str, prompt: str) -> dict[str, Any]:
+    response = requests.post(
+        f"{url}/v1/completions",
+        json={
+            "model": "m",
+            "prompt": prompt,
+            "max_tokens": 8,
+            "temperature": 0,
+            "logprobs": 1,
+        },
+        timeout=30,
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+def _golden_output(response: dict[str, Any]) -> dict[str, Any]:
+    choice = response["choices"][0]
+    usage = response["usage"]
+    return {
+        "text": choice["text"],
+        "finish_reason": choice["finish_reason"],
+        "tokens": choice["logprobs"]["tokens"],
+        "prompt_tokens": usage["prompt_tokens"],
+        "completion_tokens": usage["completion_tokens"],
+    }
+
+
+def _cached_tokens(response: dict[str, Any]) -> int:
+    return response["usage"]["prompt_tokens_details"]["cached_tokens"]
 
 
 class TestPauseResume:
-    """POST /pause  POST /resume  GET /is_paused are independent of sleep.
+    def test_state_and_idempotency_across_cycles(self, server_url):
+        assert not is_paused(server_url)
 
-    /pause blocks scheduling without releasing GPU memory (level=0 equivalent
-    from the GPU side, but a distinct code path and distinct state flag).
-    """
+        assert resume(server_url) == 200
+        assert resume(server_url) == 200
+        assert not is_paused(server_url)
 
-    def test_pause_mode_wait_drains_inflight_request(self):
-        """mode='wait' lets an in-flight request complete, then blocks new ones."""
-        with server() as url:
-            result: dict = {}
+        for _ in range(2):
+            for mode in ("abort", "wait", "keep"):
+                assert pause(server_url, mode=mode) == 200
+                assert pause(server_url, mode=mode) == 200
+                assert is_paused(server_url)
 
-            def _bg():
-                result["r"] = gen(url, max_tokens=32, timeout=60)
+                assert resume(server_url) == 200
+                assert resume(server_url) == 200
+                assert not is_paused(server_url)
 
-            t = threading.Thread(target=_bg)
-            t.start()
-            time.sleep(0.5)
+    def test_invalid_mode_preserves_state(self, server_url):
+        for paused in (False, True):
+            if paused:
+                assert pause(server_url) == 200
+            assert is_paused(server_url) is paused
 
-            assert pause(url, mode="wait") == 200
-            t.join(timeout=30)
-            assert result.get("r") is not None, (
-                "in-flight request not completed after pause(mode=wait)"
+            response = requests.post(
+                f"{server_url}/pause",
+                params={"mode": "invalid"},
+                timeout=10,
             )
-
-            resp = gen(url, timeout=5)
-            assert not ok(resp)
-            assert resume(url) == 200
-
-    def test_pause_mode_keep_resumes_frozen_request(self):
-        """mode='keep' freezes the request; it must complete after /resume."""
-        with server() as url:
-            result: dict = {}
-
-            def _bg():
-                result["r"] = gen(url, max_tokens=16, timeout=60)
-
-            t = threading.Thread(target=_bg)
-            t.start()
-            time.sleep(0.3)
-
-            assert pause(url, mode="keep") == 200
-            time.sleep(1)
-
-            # request must NOT have completed yet
-            assert not ok(result.get("r")), (
-                "request completed before resume in mode=keep"
+            assert response.status_code == 422
+            assert any(
+                error["loc"][-1] == "mode" for error in response.json()["detail"]
             )
+            assert is_paused(server_url) is paused
 
-            assert resume(url) == 200
-            t.join(timeout=30)
-            assert ok(result.get("r")), (
-                "request not completed after resume in mode=keep"
+            assert resume(server_url) == 200
+
+    @pytest.mark.parametrize(
+        ("mode", "max_tokens", "inflight_finish_reason"),
+        [
+            pytest.param("abort", 256, "abort", id="abort"),
+            pytest.param("wait", 64, "length", id="wait"),
+            pytest.param("keep", 256, "length", id="keep"),
+        ],
+    )
+    def test_mode_request_lifecycle(
+        self,
+        server_url,
+        mode,
+        max_tokens,
+        inflight_finish_reason,
+    ):
+        inflight, inflight_thread = _start_stream(server_url, max_tokens)
+        new_result: dict[str, Any] = {}
+        new_done = threading.Event()
+
+        def _new_request():
+            new_result["response"] = gen(server_url, max_tokens=4, timeout=60)
+            new_done.set()
+
+        new_thread = threading.Thread(target=_new_request)
+        try:
+            assert pause(server_url, mode=mode) == 200
+            assert is_paused(server_url)
+
+            if mode in ("abort", "wait"):
+                assert inflight.done.wait(timeout=5)
+            else:
+                chunks_after_pause = len(inflight.chunks)
+                assert not inflight.done.wait(timeout=0.3)
+                assert len(inflight.chunks) == chunks_after_pause, (
+                    "in-flight request continued generating in keep mode"
+                )
+
+            new_thread.start()
+            assert not new_done.wait(timeout=0.3), (
+                "new request completed while generation was paused"
             )
+        finally:
+            assert resume(server_url) == 200
+            inflight_thread.join(timeout=30)
+            if new_thread.ident is not None:
+                new_thread.join(timeout=30)
+
+        assert not inflight_thread.is_alive()
+        assert inflight.error is None
+        assert inflight.finish_reason == inflight_finish_reason
+        assert not new_thread.is_alive()
+        assert ok(new_result.get("response"))
+
+    def test_clear_cache_preserves_output_and_controls_prefix_cache(
+        self, server_url
+    ):
+        prompt = (
+            "Paris is the capital of France. "
+            "Berlin is the capital of Germany. "
+        ) * 20
+
+        assert pause(server_url, clear_cache=True) == 200
+        assert resume(server_url) == 200
+        baseline = _completion_with_cache_details(server_url, prompt)
+        warmed = _completion_with_cache_details(server_url, prompt)
+
+        assert _cached_tokens(baseline) == 0
+        assert _cached_tokens(warmed) > 0
+
+        assert pause(server_url, clear_cache=False) == 200
+        assert resume(server_url) == 200
+        preserved = _completion_with_cache_details(server_url, prompt)
+        assert _golden_output(preserved) == _golden_output(baseline)
+        assert _cached_tokens(preserved) > 0
+
+        assert pause(server_url, clear_cache=True) == 200
+        assert resume(server_url) == 200
+        cleared = _completion_with_cache_details(server_url, prompt)
+        assert _golden_output(cleared) == _golden_output(baseline)
+        assert _cached_tokens(cleared) == 0

--- a/tests/entrypoints/serve/dev/rlhf/state_transitions/test_pause_resume.py
+++ b/tests/entrypoints/serve/dev/rlhf/state_transitions/test_pause_resume.py
@@ -3,6 +3,8 @@
 """End-to-end tests for the vLLM RL pause/resume lifecycle."""
 
 import json
+import os
+from unittest.mock import patch
 import threading
 from dataclasses import dataclass, field
 from typing import Any
@@ -20,15 +22,25 @@ from tests.entrypoints.serve.dev.rlhf.conftest import (
 )
 
 
+@pytest.fixture(scope="module", params=[False, True], ids=["MRV1", "MRV2"])
+def use_v2(request):
+    return request.param
+
+
 @pytest.fixture(scope="module")
-def server_url():
-    with server(
-        extra_args=[
-            "--enable-prefix-caching",
-            "--enable-prompt-tokens-details",
-        ]
-    ) as url:
-        yield url
+def server_url(use_v2):
+    env_vars = {
+        "VLLM_USE_V2_MODEL_RUNNER": "1" if use_v2 else "0",
+    }
+
+    with patch.dict(os.environ, env_vars):
+        with server(
+            extra_args=[
+                "--enable-prefix-caching",
+                "--enable-prompt-tokens-details",
+            ]
+        ) as url:
+            yield url
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION

## Purpose

One part of the RL CI Matrix for vLLM proposed by #45585. This PR adds end-to-end tests for the pause/resume API used in RL rollout, covering:
1. is_paused state & idempotency: repeated pause/resume, multiple cycles
2. Invalid mode behavior — return 400; state unchanged
3. Behavior of keep/wait/abort on in-flight and new requests, and behavior after resume
4. clear_cache=true/false behavior — golden output comparison

## Test Plan

### Test Matrix

Priority | Test Case | Main Coverage
-- | -- | --
P0 | test_pause_resume_state_is_idempotent_across_cycles | is_paused, repeated calls, multiple cycles
P0 | test_invalid_pause_mode_preserves_state | Status code and unchanged state for illegal mode
P0 | test_pause_mode_request_lifecycle[mode] | abort/wait/keep for in-flight, new requests, and resume
P1 | test_clear_cache_preserves_output_and_controls_prefix_cache | Golden output and cache retention/clearing

### Request Lifecycle Across the Three Modes

Expected behavior matrix:

| mode  | in-flight request at pause return                            | new request submitted after pause | after resume                                                |
| ----- | ------------------------------------------------------------ | --------------------------------- | ----------------------------------------------------------- |
| abort | already finished, `finish_reason == "abort"`                 | accepted but stays pending        | new request completes normally; old request does not resume |
| wait  | already finished normally, typically `finish_reason == "length"` | stays pending                     | new request completes normally                              |
| keep  | not yet finished, generation progress frozen                 | stays pending                     | both old and new requests complete normally                 |

### Speed & Stability

Use a class/module-scoped `server_url` fixture to start the server once and reuse it across all tests, calling `resume()` before and after each test to restore state. The cache test should perform its own `clear_cache=True` at the start to avoid cache pollution from shared server state.

abort/wait/keep and multi-request behavior already have fairly comprehensive coverage in lower-level tests. The HTTP E2E layer just needs to preserve the key mappings above.

## Test Result

```sh
=== Round 1: use_v2=False (MRV1) ===
server_url fixture setup   →  patch.dict(env, VLLM_USE_V2_MODEL_RUNNER=0)
                            →  server(...) starts one vLLM server process
  [Every test method in this module runs once against this server_url]
server_url fixture teardown →  server(...) shuts this process down

=== Round 2: use_v2=True (MRV2) ===
server_url fixture setup   →  patch.dict(env, VLLM_USE_V2_MODEL_RUNNER=1)
                            →  server(...) starts a fresh vLLM server process
  [Every test method in this module runs again against this new server_url]
server_url fixture teardown →  server(...) shuts this process down
```

H100 single card:

```sh
pytest --durations=0 -sv test_pause_resume.py
========================================================================= test session starts ==========================================================================
platform linux -- Python 3.11.15, pytest-9.1.1, pluggy-1.6.0 -- /opt/miniconda/envs/y00806874/bin/python3.11
cachedir: .pytest_cache
rootdir: /home/tests
plugins: typeguard-4.5.2, anyio-4.14.1
collected 12 items

test_pause_resume.py::TestPauseResume::test_state_and_idempotency_across_cycles[MRV1] PASSED
test_pause_resume.py::TestPauseResume::test_invalid_mode_preserves_state[MRV1] PASSED
test_pause_resume.py::TestPauseResume::test_mode_request_lifecycle[MRV1-abort] PASSED
test_pause_resume.py::TestPauseResume::test_mode_request_lifecycle[MRV1-wait] PASSED
test_pause_resume.py::TestPauseResume::test_mode_request_lifecycle[MRV1-keep] PASSED
test_pause_resume.py::TestPauseResume::test_clear_cache_preserves_output_and_controls_prefix_cache[MRV1] PASSED
test_pause_resume.py::TestPauseResume::test_state_and_idempotency_across_cycles[MRV2] PASSED
test_pause_resume.py::TestPauseResume::test_invalid_mode_preserves_state[MRV2] PASSED
test_pause_resume.py::TestPauseResume::test_mode_request_lifecycle[MRV2-abort] PASSED
test_pause_resume.py::TestPauseResume::test_mode_request_lifecycle[MRV2-wait] PASSED
test_pause_resume.py::TestPauseResume::test_mode_request_lifecycle[MRV2-keep] PASSED
test_pause_resume.py::TestPauseResume::test_clear_cache_preserves_output_and_controls_prefix_cache[MRV2] PASSED

========================================================================== slowest durations ===========================================================================
38.89s setup    test_pause_resume.py::TestPauseResume::test_state_and_idempotency_across_cycles[MRV2]
37.12s setup    test_pause_resume.py::TestPauseResume::test_state_and_idempotency_across_cycles[MRV1]
9.80s call     test_pause_resume.py::TestPauseResume::test_mode_request_lifecycle[MRV1-keep]
9.75s call     test_pause_resume.py::TestPauseResume::test_mode_request_lifecycle[MRV2-keep]
4.72s call     test_pause_resume.py::TestPauseResume::test_mode_request_lifecycle[MRV2-wait]
4.02s call     test_pause_resume.py::TestPauseResume::test_mode_request_lifecycle[MRV1-wait]
1.45s call     test_pause_resume.py::TestPauseResume::test_clear_cache_preserves_output_and_controls_prefix_cache[MRV1]
0.86s call     test_pause_resume.py::TestPauseResume::test_clear_cache_preserves_output_and_controls_prefix_cache[MRV2]
0.67s teardown test_pause_resume.py::TestPauseResume::test_clear_cache_preserves_output_and_controls_prefix_cache[MRV2]
0.63s call     test_pause_resume.py::TestPauseResume::test_mode_request_lifecycle[MRV2-abort]
0.60s call     test_pause_resume.py::TestPauseResume::test_mode_request_lifecycle[MRV1-abort]
0.46s call     test_pause_resume.py::TestPauseResume::test_state_and_idempotency_across_cycles[MRV1]
0.44s call     test_pause_resume.py::TestPauseResume::test_state_and_idempotency_across_cycles[MRV2]
0.08s call     test_pause_resume.py::TestPauseResume::test_invalid_mode_preserves_state[MRV1]
0.07s call     test_pause_resume.py::TestPauseResume::test_invalid_mode_preserves_state[MRV2]
0.01s teardown test_pause_resume.py::TestPauseResume::test_mode_request_lifecycle[MRV1-wait]
0.01s setup    test_pause_resume.py::TestPauseResume::test_mode_request_lifecycle[MRV1-wait]
0.01s teardown test_pause_resume.py::TestPauseResume::test_clear_cache_preserves_output_and_controls_prefix_cache[MRV1]
0.01s setup    test_pause_resume.py::TestPauseResume::test_mode_request_lifecycle[MRV1-keep]
0.01s teardown test_pause_resume.py::TestPauseResume::test_mode_request_lifecycle[MRV1-abort]
0.01s setup    test_pause_resume.py::TestPauseResume::test_mode_request_lifecycle[MRV1-abort]
0.01s setup    test_pause_resume.py::TestPauseResume::test_invalid_mode_preserves_state[MRV1]
0.01s teardown test_pause_resume.py::TestPauseResume::test_mode_request_lifecycle[MRV1-keep]

(13 durations < 0.005s hidden.  Use -vv to show these durations.)
==================================================================== 12 passed in 109.71s (0:01:49) ====================================================================
```

<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

