### PR TITLE
Fix fused add RMSNorm residual-sum variance

### DIFF
--- a/csrc/libtorch_stable/layernorm_kernels.cu
+++ b/csrc/libtorch_stable/layernorm_kernels.cu
@@ -133,10 +133,16 @@ fused_add_rms_norm_kernel(
   for (int idx = threadIdx.x; idx < vec_hidden_size; idx += blockDim.x) {
     int64_t id = blockIdx.x * residual_stride / width + idx;
     int64_t strided_id = blockIdx.x * vec_input_stride + idx;
-    _f16Vec<scalar_t, width> temp = input_v[strided_id];
-    temp += residual_v[id];
-    variance += temp.sum_squares();
-    residual_v[id] = temp;
+    _f16Vec<scalar_t, width> input_vec = input_v[strided_id];
+    _f16Vec<scalar_t, width> residual_vec = residual_v[id];
+    using Converter = _typeConvert<scalar_t>;
+#pragma unroll
+    for (int j = 0; j < width; ++j) {
+      float x = Converter::convert(input_vec.data[j]);
+      float r = Converter::convert(residual_vec.data[j]);
+      float sum = x + r;
+      variance += sum * sum;
+    }
   }
 
   using BlockReduce = cub::BlockReduce<float, 1024>;
@@ -151,24 +157,32 @@ fused_add_rms_norm_kernel(
   for (int idx = threadIdx.x; idx < vec_hidden_size; idx += blockDim.x) {
     int64_t id = blockIdx.x * residual_stride / width + idx;
     int64_t strided_id = blockIdx.x * vec_input_stride + idx;
-    _f16Vec<scalar_t, width> res = residual_v[id];
+    _f16Vec<scalar_t, width> input_vec = input_v[strided_id];
+    _f16Vec<scalar_t, width> residual_vec = residual_v[id];
     _f16Vec<scalar_t, width> out;
     using Converter = _typeConvert<scalar_t>;
     if constexpr (HasWeight) {
       _f16Vec<scalar_t, width> w = weight_v[idx];
 #pragma unroll
       for (int j = 0; j < width; ++j) {
-        float x = Converter::convert(res.data[j]);
+        float x = Converter::convert(input_vec.data[j]);
+        float r = Converter::convert(residual_vec.data[j]);
+        float sum = x + r;
         float wf = Converter::convert(w.data[j]);
-        out.data[j] = Converter::convert(x * s_variance * wf);
+        residual_vec.data[j] = Converter::convert(sum);
+        out.data[j] = Converter::convert(sum * s_variance * wf);
       }
     } else {
 #pragma unroll
       for (int j = 0; j < width; ++j) {
-        float x = Converter::convert(res.data[j]);
-        out.data[j] = Converter::convert(x * s_variance);
+        float x = Converter::convert(input_vec.data[j]);
+        float r = Converter::convert(residual_vec.data[j]);
+        float sum = x + r;
+        residual_vec.data[j] = Converter::convert(sum);
+        out.data[j] = Converter::convert(sum * s_variance);
       }
     }
+    residual_v[id] = residual_vec;
     input_v[strided_id] = out;
   }
 }
@@ -189,11 +203,10 @@ fused_add_rms_norm_kernel(
   float variance = 0.0f;
 
   for (int idx = threadIdx.x; idx < hidden_size; idx += blockDim.x) {
-    scalar_t z = input[blockIdx.x * input_stride + idx];
-    z += residual[blockIdx.x * residual_stride + idx];
-    float x = (float)z;
-    variance += x * x;
-    residual[blockIdx.x * residual_stride + idx] = z;
+    float x = (float)input[blockIdx.x * input_stride + idx];
+    float r = (float)residual[blockIdx.x * residual_stride + idx];
+    float z = x + r;
+    variance += z * z;
   }
 
   using BlockReduce = cub::BlockReduce<float, 1024>;
@@ -206,12 +219,15 @@ fused_add_rms_norm_kernel(
   __syncthreads();
 
   for (int idx = threadIdx.x; idx < hidden_size; idx += blockDim.x) {
-    float x = (float)residual[blockIdx.x * residual_stride + idx];
+    float x = (float)input[blockIdx.x * input_stride + idx];
+    float r = (float)residual[blockIdx.x * residual_stride + idx];
+    float z = x + r;
+    residual[blockIdx.x * residual_stride + idx] = (scalar_t)z;
     if constexpr (HasWeight) {
       float w = (float)weight[idx];
-      input[blockIdx.x * input_stride + idx] = (scalar_t)(x * s_variance * w);
+      input[blockIdx.x * input_stride + idx] = (scalar_t)(z * s_variance * w);
     } else {
-      input[blockIdx.x * input_stride + idx] = (scalar_t)(x * s_variance);
+      input[blockIdx.x * input_stride + idx] = (scalar_t)(z * s_variance);
     }
   }
 }

--- a/tests/kernels/ir/test_layernorm.py
+++ b/tests/kernels/ir/test_layernorm.py
@@ -256,6 +256,44 @@ def test_vllm_c_fused_add_rms_norm_accepts_nd_input():
     assert_close(ir.ops.fused_add_rms_norm, residual, ref_residual)
 
 
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.skipif(
+    not IS_GPGPU_DEVICE,
+    reason="Currently only kernels on CUDA, ROCm and XPU",
+)
+def test_vllm_c_fused_add_rms_norm_uses_fp32_sum_for_variance(dtype):
+    impl = ir.ops.fused_add_rms_norm.impls["vllm_c"]
+    if not impl.supported:
+        pytest.skip("vllm_c impl not supported on this platform")
+
+    torch.manual_seed(0)
+    device = current_platform.device_type
+    tokens = 4
+    hidden_size = 2048
+    epsilon = 1e-6
+    x = torch.randn(tokens, hidden_size, device=device, dtype=dtype)
+    x_residual = torch.randn_like(x)
+    weight = torch.randn(hidden_size, device=device, dtype=dtype)
+
+    summed_fp32 = x.float() + x_residual.float()
+    variance = summed_fp32.square().mean(dim=-1, keepdim=True)
+    expected_output = summed_fp32 * torch.rsqrt(variance + epsilon)
+    expected_output = (expected_output.to(weight.dtype) * weight).to(dtype)
+    expected_residual = summed_fp32.to(dtype)
+    rounded_sum = expected_residual.float()
+    rounded_variance = rounded_sum.square().mean(dim=-1, keepdim=True)
+    rounded_output = rounded_sum * torch.rsqrt(rounded_variance + epsilon)
+    rounded_output = (rounded_output.to(weight.dtype) * weight).to(dtype)
+
+    output, residual = impl.impl_fn(x.clone(), x_residual.clone(), weight, epsilon)
+
+    assert_close(ir.ops.fused_add_rms_norm, output, expected_output)
+    fp32_sum_error = (output.float() - expected_output.float()).abs().mean()
+    rounded_sum_error = (output.float() - rounded_output.float()).abs().mean()
+    assert fp32_sum_error < rounded_sum_error
+    torch.testing.assert_close(residual, expected_residual, rtol=0.0, atol=0.0)
+
+
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32])
 @pytest.mark.parametrize("n_tokens", NUM_TOKENS)
 @pytest.mark.parametrize("hidden_size", COMMON_HIDDEN_SIZES)


### PR DESCRIPTION

## Purpose

Fixes #52104.

The CUDA `vllm_c` fused-add RMSNorm kernel was computing variance from the low-precision rounded `input + residual` value. The native IR implementation keeps `input.float() + residual.float()` in FP32 through variance calculation, then rounds only the published residual output.

This PR aligns the vectorized and generic `fused_add_rms_norm` CUDA kernel paths with that native arithmetic contract:

- First pass computes variance from the FP32 residual sum without mutating `residual`.
- Second pass recomputes the FP32 sum, writes the rounded residual output, and normalizes from the FP32 sum.
- Adds a focused `vllm_c` regression test that checks the output is closer to the FP32-sum contract than to the old rounded-sum contract.

Duplicate-work checks run before opening this PR:

- `gh issue view 52104 --repo vllm-project/vllm --comments`: issue open; one comment suggesting regression coverage.
- `gh pr list --repo vllm-project/vllm --state open --search "52104 in:body"`: no open PRs.
- `gh pr list --repo vllm-project/vllm --state open --search "fused_add_rms_norm residual sum variance BF16 FP32 rounding"`: no open PRs.

AI assistance was used to investigate and prepare this change. The submitting human should review and be able to defend every changed line before merge.

## Test Plan

- Syntax check touched Python test file.
- Focused pytest selection for the new regression test.
- Ruff format/check on the touched Python test file.
- Clang-format on the touched CUDA file.
- Whitespace diff check.

No model evals were run; this is a kernel arithmetic consistency fix, not a model-output-quality change. Full CUDA validation should be run in CI because the local host has no GPGPU.

## Test Result

- `./.venv/bin/python -m py_compile tests/kernels/ir/test_layernorm.py`: passed.
- `./.venv/bin/python -m pytest tests/kernels/ir/test_layernorm.py -k fp32_sum_for_variance -v`: selected 2 tests; both skipped locally because this macOS host has no GPGPU.
- `./.venv/bin/pre-commit run ruff-format --files tests/kernels/ir/test_layernorm.py`: passed.
- `./.venv/bin/pre-commit run ruff-check --files tests/kernels/ir/test_layernorm.py`: passed.
- `./.venv/bin/pre-commit run clang-format --files csrc/libtorch_stable/layernorm_kernels.cu`: passed.
- `git diff --check`: passed.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

