### PR TITLE
[Core] Add shared-disk weight transfer backend

### DIFF
--- a/docs/training/weight_transfer/README.md
+++ b/docs/training/weight_transfer/README.md
@@ -34,6 +34,10 @@ engine drives on your behalf:
 | [NCCL](nccl.md) | NCCL broadcast | Separate GPUs for training and inference |
 | [IPC](ipc.md) | CUDA IPC handles | Colocated training and inference on same GPU |
 | [sparse_nccl](nccl.md#sparse-nccl) | NCCL broadcast | Sparse flat-index weight patches (TP=1/PP=1) |
+| [disk](disk.md) | Shared filesystem | Complete safetensors checkpoints written by the trainer |
+
+The `disk` backend is inference-side only and is driven directly through the
+weight-transfer client; it does not register a trainer-side data-plane engine.
 
 ## Quickstart
 
@@ -48,7 +52,7 @@ from vllm.config import WeightTransferConfig
 
 llm = LLM(
     model="my-model",
-    weight_transfer_config=WeightTransferConfig(backend="nccl"),  # or "ipc", "sparse_nccl"
+    weight_transfer_config=WeightTransferConfig(backend="nccl"),
 )
 ```
 

--- a/docs/training/weight_transfer/base.md
+++ b/docs/training/weight_transfer/base.md
@@ -497,7 +497,10 @@ Once registered, users select your backend via `WeightTransferConfig(backend="my
 
 ### WeightTransferEngineFactory
 
-The factory uses a registry pattern with lazy loading. Built-in engines (`nccl`, `ipc`, and `sparse_nccl`) are registered at import time but their modules are only loaded when the backend is actually requested. This avoids importing heavy dependencies (like NCCL communicators) when they aren't needed.
+The factory uses a registry pattern with lazy loading. Built-in engines (`nccl`,
+`ipc`, `sparse_nccl`, and `disk`) are registered at import time but their modules
+are only loaded when the backend is actually requested. This avoids importing
+heavy dependencies (like NCCL communicators) when they aren't needed.
 
 ```python
 from vllm.distributed.weight_transfer import WeightTransferEngineFactory

--- a/docs/training/weight_transfer/disk.md
+++ b/docs/training/weight_transfer/disk.md
@@ -1,0 +1,40 @@
+# Shared-disk weight updates
+
+The `disk` backend reloads a safetensors checkpoint from a local directory that
+is visible at the same path on every inference worker. It is useful when a
+trainer writes checkpoints to a shared filesystem and the orchestration layer
+wants to update a running vLLM engine without sending the tensors over NCCL or
+CUDA IPC.
+
+Configure the inference engine with the backend:
+
+```bash
+VLLM_SERVER_DEV_MODE=1 vllm serve my-model \
+    --weight-transfer-config '{"backend": "disk"}'
+```
+
+Then drive one update through the weight-transfer control plane:
+
+```python
+from vllm.distributed.weight_transfer import HTTPVLLMWeightSyncClient
+
+client = HTTPVLLMWeightSyncClient("http://localhost:8000")
+client.init_weight_transfer_engine({})
+client.start_weight_update()
+client.update_weights({"path": "/shared/checkpoints/step-100"})
+client.finish_weight_update("step-100")
+```
+
+The path must be an absolute local directory containing safetensors files, and
+every worker must see the same completed checkpoint at that path before the
+update starts. The backend accepts one complete checkpoint per
+start/update/finish session. It loads only safetensors from that directory; it
+does not reuse secondary weight sources retained from initial model loading. It
+uses the standard loader pipeline, including model-specific weight mapping,
+expert-parallel filtering, and missing-weight checks when the model reports
+loaded-weight metadata.
+
+This backend does not download Hugging Face Hub model IDs and does not use
+`fastsafetensors` or GPU Direct Storage. A failed reload is surfaced to the
+caller and the update session is cleaned up, but updates are not transactional:
+weights loaded before an error may already have been applied.

--- a/tests/distributed/test_weight_transfer.py
+++ b/tests/distributed/test_weight_transfer.py
@@ -6,9 +6,11 @@ Unit tests for engine classes (parsing, validation, registry).
 Integration tests for NCCL and IPC weight transfer between processes using Ray.
 """
 
+import json
 import pickle
 import threading
 import time
+from dataclasses import asdict
 from unittest.mock import MagicMock
 
 import pybase64 as base64
@@ -17,6 +19,7 @@ import ray
 import torch
 from torch.multiprocessing.reductions import reduce_tensor
 
+from vllm.config.load import LoadConfig
 from vllm.config.parallel import ParallelConfig
 from vllm.config.weight_transfer import WeightTransferConfig
 from vllm.distributed.weight_transfer import (
@@ -34,6 +37,12 @@ from vllm.distributed.weight_transfer.base import (
     TrainerInitInfo,
     WeightTransferInitRequest,
     WeightTransferUpdateRequest,
+)
+from vllm.distributed.weight_transfer.disk_engine import (
+    DiskWeightTransferEngine,
+    DiskWeightTransferInitInfo,
+    DiskWeightTransferUpdateInfo,
+    _PrimaryOnlyModelLoader,
 )
 from vllm.distributed.weight_transfer.ipc_engine import (
     IPCTrainerInitInfo,
@@ -294,6 +303,21 @@ class TestEngineRegistry:
         )
         assert isinstance(engine, SparseNCCLWeightTransferEngine)
 
+    @pytest.mark.skip_global_cleanup
+    def test_create_engine_disk(self):
+        config = WeightTransferConfig(backend="disk")
+        engine = WeightTransferEngineFactory.create_engine(
+            config,
+            create_mock_vllm_config(),
+            torch.device("cpu"),
+            MagicMock(spec=torch.nn.Module),
+        )
+        assert isinstance(engine, DiskWeightTransferEngine)
+
+    @pytest.mark.skip_global_cleanup
+    def test_disk_backend_config_serializes(self):
+        assert asdict(WeightTransferConfig(backend="disk")) == {"backend": "disk"}
+
     def test_create_engine_invalid_backend(self):
         config = WeightTransferConfig(backend="invalid")
         with pytest.raises(ValueError, match="Invalid weight transfer backend"):
@@ -309,6 +333,228 @@ class TestEngineRegistry:
             WeightTransferEngineFactory.register_engine(
                 "nccl", NCCLWeightTransferEngine
             )
+
+
+@pytest.mark.skip_global_cleanup
+class TestDiskWeightTransferEngine:
+    """CPU-only tests for shared-checkpoint weight update orchestration."""
+
+    def _checkpoint(self, tmp_path):
+        checkpoint = tmp_path / "checkpoint"
+        checkpoint.mkdir()
+        (checkpoint / "model.safetensors").touch()
+        return checkpoint
+
+    def _make_engine(self):
+        model_config = MagicMock()
+        model_config.model = "original-model"
+        model_config.revision = "original-revision"
+        vllm_config = create_mock_vllm_config()
+        vllm_config.model_config = model_config
+        model = MagicMock(spec=torch.nn.Module)
+        return DiskWeightTransferEngine(
+            WeightTransferConfig(backend="disk"),
+            vllm_config,
+            torch.device("cpu"),
+            model,
+        )
+
+    def test_update_info_requires_local_safetensors_directory(self, tmp_path):
+        with pytest.raises(ValueError, match="local directory"):
+            DiskWeightTransferUpdateInfo(path="org/model")
+
+        empty = tmp_path / "empty"
+        empty.mkdir()
+        with pytest.raises(ValueError, match="contains no safetensors"):
+            DiskWeightTransferUpdateInfo(path=str(empty))
+
+        checkpoint = self._checkpoint(tmp_path)
+        with pytest.raises(ValueError, match="absolute local directory"):
+            DiskWeightTransferUpdateInfo(path=checkpoint.name)
+
+    def test_primary_loader_reads_only_requested_safetensors(
+        self, tmp_path, monkeypatch
+    ):
+        checkpoint = self._checkpoint(tmp_path)
+        loader = _PrimaryOnlyModelLoader(LoadConfig(load_format="safetensors"))
+        seen_sources = []
+
+        def record_source(source):
+            seen_sources.append(source)
+            yield "weight", torch.ones(1)
+
+        monkeypatch.setattr(loader, "_get_weights_iterator", record_source)
+        model = MagicMock(spec=torch.nn.Module)
+        model.secondary_weights = [MagicMock()]
+        model_config = MagicMock()
+        model_config.model = str(checkpoint)
+        model_config.revision = None
+
+        assert [name for name, _ in loader.get_all_weights(model_config, model)] == [
+            "weight"
+        ]
+        assert len(seen_sources) == 1
+        assert seen_sources[0].model_or_path == str(checkpoint)
+        assert seen_sources[0].revision is None
+        assert seen_sources[0].fall_back_to_pt is False
+        assert seen_sources[0].allow_patterns_overrides == ["*.safetensors"]
+
+    def test_primary_loader_keeps_ep_mapping_and_strict_tracking(self, monkeypatch):
+        loader = _PrimaryOnlyModelLoader(
+            LoadConfig(
+                load_format="safetensors",
+                model_loader_extra_config={"enable_weights_track": True},
+            )
+        )
+        ep_filter = MagicMock()
+        monkeypatch.setattr(loader, "_init_ep_weight_filter", ep_filter)
+        monkeypatch.setattr(
+            loader,
+            "get_all_weights",
+            lambda model_config, model: iter([("checkpoint.weight", torch.ones(1))]),
+        )
+        model_config = MagicMock()
+        model_config.quantization = None
+
+        class MappingModel(torch.nn.Module):
+            def __init__(self, loaded_names):
+                super().__init__()
+                self.weight = torch.nn.Parameter(torch.zeros(1))
+                self.loaded_names = loaded_names
+                self.seen_weights = []
+
+            def load_weights(self, weights):
+                self.seen_weights = list(weights)
+                return self.loaded_names
+
+        model = MappingModel({"weight"})
+        loader.load_weights(model, model_config)
+        ep_filter.assert_called_once_with(model_config)
+        assert model.seen_weights[0][0] == "checkpoint.weight"
+
+        with pytest.raises(ValueError, match="Following weights were not initialized"):
+            loader.load_weights(MappingModel(set()), model_config)
+
+    def test_primary_loader_rejects_incomplete_safetensors_index(self, tmp_path):
+        checkpoint = self._checkpoint(tmp_path)
+        index = checkpoint / "model.safetensors.index.json"
+        index.write_text(json.dumps({"weight_map": {"weight": "missing.safetensors"}}))
+        loader = _PrimaryOnlyModelLoader(LoadConfig(load_format="safetensors"))
+
+        with pytest.raises(FileNotFoundError, match="missing.safetensors"):
+            loader._prepare_weights(
+                str(checkpoint),
+                subfolder=None,
+                revision=None,
+                fall_back_to_pt=False,
+                allow_patterns_overrides=["*.safetensors"],
+            )
+
+    def test_parse_init_info(self):
+        engine = self._make_engine()
+        assert isinstance(engine.parse_init_info({}), DiskWeightTransferInitInfo)
+
+    def test_loads_checkpoint_without_mutating_target_config(
+        self, tmp_path, monkeypatch
+    ):
+        import vllm.distributed.weight_transfer.disk_engine as disk_mod
+
+        checkpoint = self._checkpoint(tmp_path)
+        engine = self._make_engine()
+        initialized = MagicMock()
+        finalized = MagicMock()
+        monkeypatch.setattr(disk_mod, "initialize_layerwise_reload", initialized)
+        monkeypatch.setattr(disk_mod, "finalize_layerwise_reload", finalized)
+
+        loaders = []
+
+        class RecordingLoader:
+            def __init__(self, load_config):
+                self.load_config = load_config
+                self.loaded = []
+                loaders.append(self)
+
+            def load_weights(self, model, model_config):
+                self.loaded.append((model, model_config))
+
+        monkeypatch.setattr(disk_mod, "_PrimaryOnlyModelLoader", RecordingLoader)
+
+        engine.start_weight_update()
+        monkeypatch.setattr(torch.accelerator, "synchronize", MagicMock())
+        engine.update_weights({"path": str(checkpoint)})
+        engine.finish_weight_update()
+
+        initialized.assert_called_once_with(engine.model)
+        finalized.assert_called_once_with(engine.model, engine.model_config)
+        assert len(loaders) == 1
+        assert loaders[0].load_config.load_format == "safetensors"
+        assert loaders[0].load_config.model_loader_extra_config == {
+            "enable_weights_track": True
+        }
+        loaded_model, loaded_config = loaders[0].loaded[0]
+        assert loaded_model is engine.model
+        assert loaded_config is not engine.model_config
+        assert loaded_config.model == str(checkpoint)
+        assert loaded_config.revision is None
+        assert engine.model_config.model == "original-model"
+        assert engine.model_config.revision == "original-revision"
+
+    def test_rejects_second_checkpoint_in_session(self, tmp_path, monkeypatch):
+        import vllm.distributed.weight_transfer.disk_engine as disk_mod
+
+        checkpoint = self._checkpoint(tmp_path)
+        engine = self._make_engine()
+        monkeypatch.setattr(disk_mod, "initialize_layerwise_reload", MagicMock())
+        monkeypatch.setattr(disk_mod, "finalize_layerwise_reload", MagicMock())
+        monkeypatch.setattr(
+            disk_mod._PrimaryOnlyModelLoader, "load_weights", MagicMock()
+        )
+
+        engine.start_weight_update()
+        update = DiskWeightTransferUpdateInfo(path=str(checkpoint))
+        engine.receive_weights(update)
+        with pytest.raises(RuntimeError, match="exactly one checkpoint"):
+            engine.receive_weights(update)
+
+    def test_load_error_cleans_session_and_propagates(self, tmp_path, monkeypatch):
+        import vllm.distributed.weight_transfer.disk_engine as disk_mod
+
+        checkpoint = self._checkpoint(tmp_path)
+        engine = self._make_engine()
+        initialized = MagicMock()
+        finalized = MagicMock()
+        monkeypatch.setattr(disk_mod, "initialize_layerwise_reload", initialized)
+        monkeypatch.setattr(disk_mod, "finalize_layerwise_reload", finalized)
+        monkeypatch.setattr(
+            disk_mod._PrimaryOnlyModelLoader,
+            "load_weights",
+            MagicMock(side_effect=ValueError("checkpoint shape mismatch")),
+        )
+
+        engine.start_weight_update()
+        with pytest.raises(ValueError, match="checkpoint shape mismatch"):
+            engine.receive_weights(DiskWeightTransferUpdateInfo(path=str(checkpoint)))
+
+        finalized.assert_called_once_with(engine.model, engine.model_config)
+        engine.start_weight_update()
+        assert initialized.call_count == 2
+
+    def test_direct_lifecycle_guards(self, monkeypatch):
+        import vllm.distributed.weight_transfer.disk_engine as disk_mod
+
+        engine = self._make_engine()
+        monkeypatch.setattr(disk_mod, "initialize_layerwise_reload", MagicMock())
+        monkeypatch.setattr(disk_mod, "finalize_layerwise_reload", MagicMock())
+
+        with pytest.raises(RuntimeError, match="No shared-disk"):
+            engine.finish_weight_update()
+        engine.start_weight_update()
+        with pytest.raises(RuntimeError, match="already active"):
+            engine.start_weight_update()
+        with pytest.raises(RuntimeError, match="No checkpoint was loaded"):
+            engine.finish_weight_update()
+        engine.start_weight_update()
+        engine.shutdown()
 
 
 # --- Unit Tests: Sparse patch application (CPU) ---

--- a/tests/v1/worker/test_gpu_worker_weight_transfer.py
+++ b/tests/v1/worker/test_gpu_worker_weight_transfer.py
@@ -11,7 +11,7 @@ import pytest
 import torch
 import torch.nn as nn
 
-from vllm.config import VllmConfig, get_current_vllm_config
+from vllm.config import DeviceConfig, VllmConfig, get_current_vllm_config
 from vllm.lora.layers import BaseLayerWithLoRA
 from vllm.v1.worker.gpu_model_runner import _get_parameter_for_reload
 from vllm.v1.worker.gpu_worker import Worker
@@ -20,8 +20,13 @@ from vllm.v1.worker.gpu_worker import Worker
 class _RecordingEngine:
     """Minimal stand-in for a weight transfer engine."""
 
-    def __init__(self, raise_on_update: bool = False):
+    def __init__(
+        self,
+        raise_on_update: bool = False,
+        raise_on_finish: bool = False,
+    ):
         self.raise_on_update = raise_on_update
+        self.raise_on_finish = raise_on_finish
         self.started = False
         self.finished = False
         self.reset_count = 0
@@ -45,6 +50,8 @@ class _RecordingEngine:
     def finish_weight_update(self) -> None:
         self._record_config()
         self.finished = True
+        if self.raise_on_finish:
+            raise ValueError("finish boom")
 
     def reset_weight_update_target(self) -> None:
         self.reset_count += 1
@@ -64,7 +71,7 @@ class _RecordingModelRunner:
 
 def _make_worker(engine: _RecordingEngine | None) -> Worker:
     worker = object.__new__(Worker)
-    worker.vllm_config = VllmConfig()
+    worker.vllm_config = VllmConfig(device_config=DeviceConfig(device="cpu"))
     worker.weight_transfer_engine = engine
     worker._weight_update_active = False
     worker._weight_update_is_draft = False
@@ -116,6 +123,7 @@ def test_start_update_finish_delegates_to_engine():
     assert worker._weight_update_active is False
     assert engine.seen_configs == [worker.vllm_config] * 3
     assert worker.model_runner.reset_lora_calls == 1
+    assert worker._weight_update_is_draft is False
 
 
 def test_finish_draft_session_keeps_lora_state():
@@ -128,6 +136,7 @@ def test_finish_draft_session_keeps_lora_state():
     Worker.finish_weight_update(worker)
 
     assert worker.model_runner.reset_lora_calls == 0
+    assert worker._weight_update_is_draft is False
 
 
 def test_double_start_raises():
@@ -160,6 +169,32 @@ def test_update_resets_active_on_error():
     # A failed update ends the session so the next start is clean.
     assert engine.reset_count == 1
     assert worker._weight_update_active is False
+
+
+@pytest.mark.skip_global_cleanup
+@pytest.mark.parametrize("is_draft", [False, True])
+def test_finish_error_resets_target_and_allows_next_session(is_draft):
+    engine = _RecordingEngine(raise_on_finish=True)
+    engine.supports_draft_weight_update = True
+    worker = _make_worker(engine)
+    worker._set_draft_weight_update_target = lambda: None
+
+    if is_draft:
+        Worker.start_draft_weight_update(worker)
+    else:
+        Worker.start_weight_update(worker)
+    with pytest.raises(ValueError, match="finish boom"):
+        Worker.finish_weight_update(worker)
+
+    assert engine.reset_count == 1
+    assert worker._weight_update_active is False
+    assert worker._weight_update_is_draft is False
+    assert worker.model_runner.reset_lora_calls == 0
+
+    engine.raise_on_finish = False
+    Worker.start_weight_update(worker)
+    Worker.finish_weight_update(worker)
+    assert worker.model_runner.reset_lora_calls == 1
 
 
 def test_missing_engine_raises():

--- a/vllm/config/weight_transfer.py
+++ b/vllm/config/weight_transfer.py
@@ -9,7 +9,7 @@ from vllm.config.utils import config
 class WeightTransferConfig:
     """Configuration for weight transfer during RL training."""
 
-    backend: Literal["nccl", "ipc", "sparse_nccl"] | str = "nccl"
+    backend: Literal["nccl", "ipc", "sparse_nccl", "disk"] | str = "nccl"
     """The backend to use for weight transfer. Validated against the
     `WeightTransferEngineFactory` registry at engine creation time.
     """

--- a/vllm/distributed/weight_transfer/disk_engine.py
+++ b/vllm/distributed/weight_transfer/disk_engine.py
@@ -1,0 +1,186 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Shared-disk weight transfer backend."""
+
+import copy
+import os
+from collections.abc import Generator
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+import torch
+
+from vllm.config.load import LoadConfig
+from vllm.config.weight_transfer import WeightTransferConfig
+from vllm.distributed.weight_transfer.base import (
+    WeightTransferEngine,
+    WeightTransferInitInfo,
+    WeightTransferUpdateInfo,
+)
+from vllm.logger import init_logger
+from vllm.model_executor.model_loader.default_loader import DefaultModelLoader
+from vllm.model_executor.model_loader.reload import (
+    finalize_layerwise_reload,
+    initialize_layerwise_reload,
+)
+
+if TYPE_CHECKING:
+    from torch import nn
+
+    from vllm.config import ModelConfig, VllmConfig
+
+logger = init_logger(__name__)
+
+
+class _PrimaryOnlyModelLoader(DefaultModelLoader):
+    """Load only the checkpoint selected for the active update."""
+
+    def get_all_weights(
+        self,
+        model_config: "ModelConfig",
+        model: "nn.Module",
+    ) -> Generator[tuple[str, torch.Tensor], None, None]:
+        del model
+        source = self.Source(
+            model_or_path=model_config.model,
+            revision=model_config.revision,
+            fall_back_to_pt=False,
+            allow_patterns_overrides=["*.safetensors"],
+        )
+        yield from self._get_weights_iterator(source)
+
+
+@dataclass
+class DiskWeightTransferInitInfo(WeightTransferInitInfo):
+    """Worker-side initialization info for shared-disk weight updates."""
+
+
+@dataclass
+class DiskWeightTransferUpdateInfo(WeightTransferUpdateInfo):
+    """A local safetensors checkpoint visible to every inference worker."""
+
+    path: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.path, str) or not self.path:
+            raise ValueError("`path` must be a non-empty absolute local directory")
+        if not os.path.isabs(self.path):
+            raise ValueError("`path` must be an absolute local directory")
+
+        self.path = os.path.abspath(self.path)
+        if not os.path.isdir(self.path):
+            raise ValueError(
+                f"Shared-disk checkpoint path must be a local directory: {self.path}"
+            )
+        with os.scandir(self.path) as entries:
+            has_safetensors = any(
+                entry.name.endswith(".safetensors")
+                for entry in entries
+                if entry.is_file()
+            )
+        if not has_safetensors:
+            raise ValueError(
+                "Shared-disk checkpoint directory contains no safetensors files: "
+                f"{self.path}"
+            )
+
+
+class DiskWeightTransferEngine(
+    WeightTransferEngine[DiskWeightTransferInitInfo, DiskWeightTransferUpdateInfo]
+):
+    """Reload checkpoint-format weights from a worker-local shared directory."""
+
+    init_info_cls = DiskWeightTransferInitInfo
+    update_info_cls = DiskWeightTransferUpdateInfo
+
+    def __init__(
+        self,
+        config: WeightTransferConfig,
+        vllm_config: "VllmConfig",
+        device: torch.device,
+        model: torch.nn.Module,
+    ) -> None:
+        super().__init__(config, vllm_config, device, model)
+        self._session_active = False
+        self._checkpoint_loaded = False
+
+    def init_transfer_engine(self, init_info: DiskWeightTransferInitInfo) -> None:
+        """Initialize the backend. Shared-disk loading needs no rendezvous."""
+
+    def start_weight_update(self) -> None:
+        """Prepare the active model for one checkpoint reload."""
+        if self._session_active:
+            raise RuntimeError("A shared-disk weight update is already active")
+        self._session_active = True
+        self._checkpoint_loaded = False
+        try:
+            initialize_layerwise_reload(self.model)
+        except Exception:
+            self._abort_session()
+            raise
+
+    def finish_weight_update(self) -> None:
+        """Finalize processing for the reloaded checkpoint."""
+        if not self._session_active:
+            raise RuntimeError("No shared-disk weight update is active")
+        if not self._checkpoint_loaded:
+            self._abort_session()
+            raise RuntimeError(
+                "No checkpoint was loaded during the shared-disk update session"
+            )
+        try:
+            finalize_layerwise_reload(self.model, self.model_config)
+        finally:
+            self._session_active = False
+            self._checkpoint_loaded = False
+
+    def update_weights(self, update_info: dict[str, Any]) -> None:
+        """Validate and load a checkpoint, cleaning up failed sessions."""
+        try:
+            super().update_weights(update_info)
+        except Exception:
+            self._abort_session()
+            raise
+
+    def receive_weights(self, update_info: DiskWeightTransferUpdateInfo) -> None:
+        """Load one complete safetensors checkpoint from shared local storage."""
+        if not self._session_active:
+            raise RuntimeError(
+                "start_weight_update must be called before loading a checkpoint"
+            )
+        if self._checkpoint_loaded:
+            raise RuntimeError(
+                "The disk backend accepts exactly one checkpoint per update session"
+            )
+
+        model_config = copy.copy(self.model_config)
+        model_config.model = update_info.path
+        model_config.revision = None
+        load_config = LoadConfig(
+            load_format="safetensors",
+            model_loader_extra_config={"enable_weights_track": True},
+        )
+        loader = _PrimaryOnlyModelLoader(load_config)
+
+        try:
+            loader.load_weights(self.model, model_config)
+        except Exception:
+            self._abort_session()
+            raise
+
+        self._checkpoint_loaded = True
+
+    def shutdown(self) -> None:
+        """Release layerwise wrappers if shutdown interrupts an update."""
+        self._abort_session()
+
+    def _abort_session(self) -> None:
+        if not self._session_active:
+            return
+        try:
+            finalize_layerwise_reload(self.model, self.model_config)
+        except Exception:
+            logger.exception("Failed to clean up shared-disk weight update")
+        finally:
+            self._session_active = False
+            self._checkpoint_loaded = False

--- a/vllm/distributed/weight_transfer/factory.py
+++ b/vllm/distributed/weight_transfer/factory.py
@@ -234,6 +234,12 @@ WeightTransferEngineFactory.register_engine(
     "SparseNCCLWeightTransferEngine",
 )
 
+WeightTransferEngineFactory.register_engine(
+    "disk",
+    "vllm.distributed.weight_transfer.disk_engine",
+    "DiskWeightTransferEngine",
+)
+
 
 # Trainer-side engines, parallel to the worker registry above.
 WeightTransferTrainerFactory.register_engine(

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -1326,13 +1326,19 @@ class Worker(WorkerBase):
                 "finish_weight_update called without a matching start_weight_update."
             )
 
+        is_draft = self._weight_update_is_draft
         with set_current_vllm_config(self.vllm_config):
-            self.weight_transfer_engine.finish_weight_update()
-            self.weight_transfer_engine.reset_weight_update_target()
-            self._weight_update_active = False
+            try:
+                self.weight_transfer_engine.finish_weight_update()
+            finally:
+                try:
+                    self.weight_transfer_engine.reset_weight_update_target()
+                finally:
+                    self._weight_update_active = False
+                    self._weight_update_is_draft = False
 
         # Weight transfer bypasses GPUModelRunner.reload_weights().
-        if not self._weight_update_is_draft:
+        if not is_draft:
             self.model_runner.reset_lora_state()
 
     def shutdown(self) -> None:


### PR DESCRIPTION
## Purpose

Add an inference-side `disk` weight-transfer backend for deployments where a trainer writes a complete safetensors checkpoint to shared storage and an orchestrator reloads it into a running vLLM engine through the existing start/update/finish control plane.

The backend:

- accepts one absolute local checkpoint directory per update session, visible at the same path on every inference worker;
- loads only the requested primary safetensors checkpoint (not retained secondary weight sources);
- preserves the standard model loader's weight mapping, expert-parallel filtering, shard-index validation, and strict missing-weight tracking;
- registers lazily in the existing weight-transfer factory and documents the HTTP client flow;
- always clears worker/session state when finishing raises, while preserving the original exception.

Related use-case context: #48644. This PR does not close that broader request: it is inference-side only and intentionally does not add a trainer data plane, Hub downloads, fastsafetensors/GDS, or transactional rollback.

> AI assistance disclosure: this change was researched and implemented with OpenAI Codex assistance. It is opened as a Draft and must receive final human-owner review before being marked ready.

## Test Plan

```bash
uv run --no-project --active python -m pytest \
  tests/distributed/test_weight_transfer.py -k disk -q

uv run --no-project --active python -m pytest \
  tests/v1/worker/test_gpu_worker_weight_transfer.py \
  -k finish_error_resets_target_and_allows_next_session -q

uv run --no-project --active pre-commit run \
  --from-ref origin/main --to-ref HEAD
```

## Test Result

- Shared-disk backend tests: **11 passed**
- Worker finish-error cleanup (normal and draft sessions): **2 passed**
- All applicable pre-commit hooks passed, including Ruff, formatting, typos, Markdown, mypy, SPDX, lazy-import, and configuration validation.
- Re-run after rebasing onto the then-current upstream `main`.

---
<details>
<summary>Essential Elements of an Effective PR Description Checklist</summary>

- [x] Purpose and related context are documented.
- [x] Reproducible test commands are included.
- [x] Test results are included.
- [x] Backend documentation and an end-to-end client example are included.
</details>