### PR TITLE
[Bugfix] Apply logits scaling in the Transformers backend

### DIFF
--- a/tests/models/transformers/test_backend.py
+++ b/tests/models/transformers/test_backend.py
@@ -4,6 +4,7 @@
 
 import contextlib
 import os
+import re
 import tempfile
 from typing import Any
 
@@ -15,6 +16,10 @@ from transformers import AutoConfig, AutoModel
 from vllm.config import ModelConfig, VllmConfig
 from vllm.model_executor.models.interfaces import SupportsMultiModal
 from vllm.model_executor.models.transformers.base import Base
+from vllm.model_executor.models.transformers.causal import (
+    get_logit_scale,
+    probe_logit_scale,
+)
 from vllm.model_executor.models.transformers.multimodal import MultiModalMixin
 from vllm.model_executor.models.utils import StageMissingLayer
 
@@ -136,6 +141,100 @@ def test_hybrid_attention(vllm_runner: type[VllmRunner]) -> None:
         model="hmellor/tiny-random-Gemma2ForCausalLM",
         kwargs_ref=kwargs_ref,
         kwargs_test=kwargs_test,
+    )
+
+
+@pytest.mark.parametrize(
+    "config_cls,kwargs,expected",
+    [
+        ("GraniteConfig", {"logits_scaling": 8.0}, 0.125),  # divides
+        ("HyperCLOVAXConfig", {"logits_scaling": 8.0}, 8.0),  # muP, multiplies
+        ("CohereConfig", {"logit_scale": 0.0625}, 0.0625),  # multiplies
+        ("MiniCPM3Config", {"dim_model_base": 1280}, 0.5),  # half of `hidden_size`
+        ("InklingTextConfig", {}, 1 / 24),  # `logits_mup_width_multiplier`
+        ("LlamaConfig", {}, 1.0),
+        ("Gemma2Config", {}, 1.0),  # softcapping is not a scale, must not be folded in
+    ],
+)
+def test_get_logit_scale(
+    config_cls: str, kwargs: dict[str, Any], expected: float
+) -> None:
+    """Transformers has no single convention for how it scales the logits."""
+    import transformers
+
+    config = getattr(transformers, config_cls)(**kwargs)
+    assert get_logit_scale(config) == pytest.approx(expected)
+
+
+def test_probe_logit_scale_runs_for_scaled_models() -> None:
+    """Canary: every model which may scale its logits must stay measurable.
+
+    The scale is measured by running the Transformers wrapper's own `forward`. If
+    an upgrade breaks that for a model which does scale its logits, we fall back
+    to no scaling and its logprobs are wrong, so fail here instead.
+    """
+    from transformers.models.auto.modeling_auto import MODEL_FOR_CAUSAL_LM_MAPPING
+
+    # muP multipliers Transformers applies inside the decoder, which this backend
+    # keeps, so they are correctly absent from the logit scale
+    ignore = {"embedding_multiplier", "residual_multiplier", "attention_multiplier"}
+    checked, failed = [], []
+    for config_cls, model_cls in MODEL_FOR_CAUSAL_LM_MAPPING.items():
+        try:
+            config = config_cls()
+        except Exception:
+            continue
+        fields = [
+            name
+            for name, value in vars(config).items()
+            if re.search(r"logit|mup|multiplier", name, re.I)
+            and name not in ignore
+            and type(value) is float
+        ]
+        if not fields:
+            continue
+        # Non-default values, to reach code guarded on the default being unset
+        for field in fields:
+            setattr(config, field, 8.0)
+        checked.append(model_cls.__name__)
+        try:
+            probe_logit_scale(config)
+        except Exception as e:
+            failed.append(f"{model_cls.__name__} ({', '.join(fields)}): {e!r}")
+
+    assert not failed, f"could not measure the logit scale of: {failed}"
+    assert len(checked) > 10, f"the sweep has stopped finding models: {checked}"
+
+
+def test_logits_scaling(vllm_runner: type[VllmRunner]) -> None:
+    """Granite-style configs divide the logits, which only logprobs reveal.
+
+    Dividing does not reorder the logits, so the generated tokens are identical
+    either way and `check_logprobs_close` cannot catch a missing division.
+    """
+    model = get_model("GraniteForCausalLM")
+    assert AutoConfig.from_pretrained(model).logits_scaling != 1.0
+    kwargs: dict[str, Any] = {"max_model_len": 1024, "enforce_eager": True}
+
+    logprobs = {}
+    for impl in ("auto", "transformers"):
+        with vllm_runner(model, model_impl=impl, **kwargs) as runner:
+            model_config = runner.llm.llm_engine.model_config
+            assert model_config.using_transformers_backend() == (impl == "transformers")
+            _, _, steps = runner.generate_greedy_logprobs(["Hello"], 8, 5)[0]
+            # Scaling the logits stretches the gaps between them, so compare the
+            # spread of each step's logprobs rather than their absolute values
+            logprobs[impl] = [
+                max(lp.logprob for lp in step.values())
+                - min(lp.logprob for lp in step.values())
+                for step in steps
+            ]
+
+    torch.testing.assert_close(
+        torch.tensor(logprobs["transformers"]),
+        torch.tensor(logprobs["auto"]),
+        atol=0.2,
+        rtol=0,
     )
 
 

--- a/vllm/model_executor/models/transformers/causal.py
+++ b/vllm/model_executor/models/transformers/causal.py
@@ -17,8 +17,14 @@
 """Transformers modeling backend mixin for causal language models."""
 
 from collections.abc import Iterable
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
+import torch
+import torch.nn as nn
+from transformers import AutoModelForCausalLM
+from transformers.models.auto.modeling_auto import MODEL_FOR_CAUSAL_LM_MAPPING
+
+from vllm.logger import init_logger
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
 from vllm.model_executor.layers.vocab_parallel_embedding import (
     ParallelLMHead,
@@ -28,9 +34,123 @@ from vllm.model_executor.models.interfaces_base import VllmModelForTextGeneratio
 from vllm.model_executor.models.utils import PPMissingLayer, maybe_prefix
 
 if TYPE_CHECKING:
-    import torch
+    from transformers import PretrainedConfig
 
     from vllm.config import VllmConfig
+
+logger = init_logger(__name__)
+
+PROBE_HIDDEN_STATES = torch.tensor([[[1.0, 2.0, 4.0, 8.0]]])
+"""Distinct values, so that a transform which is not a plain scale is detectable."""
+
+
+class ProbeOutput(dict):
+    """Decoder output holding known hidden states, with every other field unset."""
+
+    last_hidden_state = PROBE_HIDDEN_STATES
+
+    def __getattr__(self, name: str) -> None:
+        return None
+
+    def __getitem__(self, index: Any) -> torch.Tensor:
+        return PROBE_HIDDEN_STATES
+
+    def to_tuple(self) -> tuple[torch.Tensor]:
+        return (PROBE_HIDDEN_STATES,)
+
+
+class ProbeDecoder(nn.Module):
+    """Decoder returning known hidden states, however the wrapper reaches it."""
+
+    def forward(self, *args, **kwargs) -> ProbeOutput:
+        return ProbeOutput()
+
+    def __getattr__(self, name: str) -> nn.Module:
+        try:
+            return super().__getattr__(name)
+        except AttributeError:
+            return self
+
+
+class ProbeHead(nn.Identity):
+    """Head passing the hidden states through, with the `weight` wrappers read."""
+
+    weight = PROBE_HIDDEN_STATES
+
+
+def get_logit_scale(
+    text_config: "PretrainedConfig", trust_remote_code: bool = False
+) -> float:
+    """The scale Transformers applies to the logits after the decoder.
+
+    This backend replaces the `ForCausalLM` wrapper, which is where Transformers
+    scales the logits, so the scale has to be folded into our logits processor.
+    There is no config field or API to read it from, and the conventions differ
+    per model (`logit_scale` multiplies, `logits_scaling` divides except under
+    muP, `logits_mup_width_multiplier` divides the hidden states, ...), so run
+    the wrapper's own `forward` over known hidden states and measure it.
+    """
+    try:
+        scale = probe_logit_scale(text_config, trust_remote_code)
+    except Exception:
+        logger.warning_once(
+            "Could not determine whether %s scales the logits, assuming it does "
+            "not. Logprobs may be wrong if it does.",
+            text_config.model_type,
+        )
+        return 1.0
+
+    if scale is None:
+        logger.warning_once(
+            "%s does not scale the logits linearly, which this backend cannot "
+            "reproduce (e.g. final logit softcapping). Logprobs may be wrong.",
+            text_config.model_type,
+        )
+        return 1.0
+    return scale
+
+
+def probe_logit_scale(
+    text_config: "PretrainedConfig", trust_remote_code: bool = False
+) -> float | None:
+    """The measured logit scale, or `None` if the transform is not a plain scale.
+
+    Raises whatever running the wrapper's `forward` raises, so that callers can
+    tell "measured no scaling" from "could not measure".
+    """
+    model = build_logit_scale_probe(text_config, trust_remote_code)
+    logits = type(model).forward(model, inputs_embeds=PROBE_HIDDEN_STATES).logits
+    scale = (logits / PROBE_HIDDEN_STATES).flatten()
+    if not torch.allclose(scale, scale[0].expand_as(scale)):
+        return None
+    return scale[0].item()
+
+
+def build_logit_scale_probe(
+    text_config: "PretrainedConfig", trust_remote_code: bool
+) -> nn.Module:
+    """A `ForCausalLM` whose decoder and head are stubs, so only scaling is left."""
+    model_cls = MODEL_FOR_CAUSAL_LM_MAPPING.get(type(text_config), None)
+    if model_cls is not None:
+        # Skip `__init__` so that no weights are allocated
+        model = model_cls.__new__(model_cls)
+        nn.Module.__init__(model)
+        model.config = text_config
+    else:
+        with torch.device("meta"):
+            model = AutoModelForCausalLM.from_config(
+                text_config, trust_remote_code=trust_remote_code
+            )
+    decoder = ProbeDecoder()
+    # `__init__` caches config fields that `forward` reads off the model itself,
+    # or off the decoder, depending on the model
+    for name, value in vars(text_config).items():
+        if not name.startswith("_") and isinstance(value, (int, float)):
+            setattr(model, name, value)
+            setattr(decoder, name, value)
+    setattr(model, type(model).base_model_prefix, decoder)
+    model.lm_head = ProbeHead()
+    return model
 
 
 class CausalMixin(VllmModelForTextGeneration):
@@ -59,7 +179,9 @@ class CausalMixin(VllmModelForTextGeneration):
                         self.lm_head = self.lm_head.tie_weights(module)
                         break
 
-            logit_scale = getattr(self.text_config, "logit_scale", 1.0)
+            logit_scale = get_logit_scale(
+                self.text_config, self.model_config.trust_remote_code
+            )
             self.logits_processor = LogitsProcessor(
                 self.text_config.vocab_size, scale=logit_scale
             )


### PR DESCRIPTION
## Purpose

Transformers scales the logits in the `ForCausalLM` wrapper. This backend only loads the decoder and provides its own head and logits processor, so whatever the wrapper does after the decoder has to be reproduced here. Only `logit_scale` was, which means:

- Granite-family and MiniCPM3 models returned logprobs `logits_scaling`x too confident: 9x for `ibm/PowerLM-3b`, 10x for `ibm-granite/granite-swash-2b`.
- HyperCLOVAX silently dropped its muP multiplier.

Scaling does not reorder the logits, so the generated tokens are unaffected. That is why this went unnoticed, and it means the impact is on consumers of logprob values: sampling with a temperature or penalties, logprob-based evals, speculative decoding acceptance, and anything ranking sequences by score.

There is no config field or API to read the scale from, and no single convention for it either — `logit_scale` multiplies (Cohere), `logits_scaling` divides (Granite) except under muP where it multiplies (HyperCLOVAX), `logits_mup_width_multiplier` divides the hidden states (Inkling), `dim_model_base` implies a divisor (MiniCPM3), `lm_head_multiplier` multiplies (FalconH1). Rather than enumerate that, this PR measures it: at model init, build the model's own `ForCausalLM` class with its decoder and head replaced by stubs (no weights, no checkpoint), run its `forward` over known hidden states, and take the ratio. Whatever the wrapper does to the logits is then the only thing left in the output, and the value is inherited from Transformers instead of transcribed from it.

If the ratio is not constant across the hidden states, the transform is not a scale (final logit softcapping) and cannot be folded into a logits processor, so we warn and leave the logits alone — as today. Same if the probe cannot be run at all. Neither is a regression, but both are now visible in the log rather than silent.

Found while fixing attention sinks on the same backend (#52156), but independent of it.

## Test plan

Three new tests in `tests/models/transformers/test_backend.py`:

- `test_get_logit_scale` pins the measured scale for one config per convention (Granite, HyperCLOVAX, Cohere, MiniCPM3, Inkling), plus Llama for no scaling and Gemma2 to assert softcapping is *not* folded in as a scale. Pure CPU, no weights, runs in seconds.
- `test_probe_logit_scale_runs_for_scaled_models` is the canary for the approach: it sweeps `MODEL_FOR_CAUSAL_LM_MAPPING`, sets every float config field that looks like a logit multiplier to a non-default value, and asserts the probe can still be run for each. If a Transformers refactor breaks the probe for a model that does scale its logits, we would silently fall back to 1.0; this fails CI instead.
- `test_logits_scaling` compares the spread of the top-5 logprobs between the native and Transformers implementations of `ibm/PowerLM-3b`. Logprob *values* have to be compared because `check_logprobs_close` only compares token ids, which a missing division cannot change.

Commands and results (1x GB200, transformers 5.15.0):

```
pytest tests/models/transformers/test_backend.py -k "logit_scale"      # 8 passed
pytest tests/models/transformers/test_backend.py -k "logits_scaling"   # 1 passed
```

Mutation checks that the new tests bite:

- Reverting the fix entirely: `test_logits_scaling` fails on 8/8 positions, max difference 48.06 against a 0.2 tolerance.
- Dropping the config scalars from the decoder stub: the sweep fails on FalconH1, which reads its multiplier off the decoder.
- Dropping `weight` from the head stub: the sweep fails on xLSTM, which reads the head dtype off it.

What the probe finds across the 173 entries of `MODEL_FOR_CAUSAL_LM_MAPPING`, with default configs: 135 apply no scaling, 5 scale (Cohere/Cohere2/Cohere2Moe 0.0625, Inkling 1/24, MiniCPM3 0.1), 7 are nonlinear (Gemma2, Gemma3n, VaultGemma, RecurrentGemma, NanoChat, xLSTM — all final logit softcapping), 2 cannot have a default config built (Musicgen), and 24 wrappers cannot be run by the probe. Those 24 are encoder, seq2seq and legacy families (BERT variants, Whisper, TrOCR, XLNet, ...) whose head is not `lm_head`, plus Llama4/Mllama; none of them declares a logit scale, and they behave exactly as they do today.

## Model evaluation

Prompt logprobs for a 55-token paragraph, `ibm-granite/granite-swash-2b`, bf16, against HF eager as the reference (mean logprob -1.5943). Measured on top of #52156, since that model also needs the sink fix to produce sane output at all:

| build | mean logprob | mean abs delta | max abs delta |
| --- | --- | --- | --- |
| #52156 alone | -7.8748 | 6.8942 | 81.0792 |
| #52156 + this PR | **-1.5990** | **0.0165** | **0.0863** |

The remaining 0.0165 is bf16/kernel-level noise.

## Notes

- Not a duplicate: no open PR touches logits scaling in the Transformers backend.
- Final logit softcapping is still dropped by this backend, as it was before. It is not a scale, so it does not belong in the logits processor; `Attention(..., soft_cap=)` handles the attention-logit variant but the final one needs handling in `compute_logits`. Left for a separate PR, and the probe now warns when it is hit.
- HyperCLOVAX's muP direction is covered by the unit test only. The smallest registered checkpoint is `naver-hyperclovax/HyperCLOVAX-SEED-Think-14B`, too big for an e2e test here.
- AI assistance was used for this change (Claude Code).