### PR TITLE
[Doc] Fix group numbering in Case 3 of hybrid_kv_cache_manager.md

### DIFF
--- a/docs/design/hybrid_kv_cache_manager.md
+++ b/docs/design/hybrid_kv_cache_manager.md
@@ -115,9 +115,10 @@ Unfortunately, not all models have such a beautiful ratio, and approach in Case 
 - Group 0: 10 full attention layers (full.0 - full.9)
 - Group 1: 10 sliding window attention layers (sw.0 - sw.9)
 - Group 2: 10 sliding window attention layers (sw.10 - sw.19)
-- ...
-- Group 6: 10 sliding window attention layers (sw.40 - sw.49)
-- Group 7: 2 sliding window attention layers (sw.50 - sw.51) and 8 padding layers
+- Group 3: 10 sliding window attention layers (sw.20 - sw.29)
+- Group 4: 10 sliding window attention layers (sw.30 - sw.39)
+- Group 5: 10 sliding window attention layers (sw.40 - sw.49)
+- Group 6: 2 sliding window attention layers (sw.50 - sw.51) and 8 padding layers
 
 We will update this algorithm if this heuristic leads to a bad result when a new model comes out (e.g., 20 full + 30 sw, the group size should be 10 instead of 20).
 


### PR DESCRIPTION
## Purpose

Fix a self-inconsistent group numbering in `docs/design/hybrid_kv_cache_manager.md` Case 3 (lines 111-124).

The doc says Gemma-3-27b has 52 sliding-window layers, but lists:

- Group 6: 10 sliding window attention layers (sw.40 - sw.49)
- Group 7: 2 sliding window attention layers (sw.50 - sw.51) and 8 padding layers

With group_size=10, 52 sw layers end at Group 6 (sw.50-51 + 8 padding); there is no Group 7. sw.40-49 belongs to Group 5.

Renumbered to: Group 5 = sw.40-49, Group 6 = sw.50-51 + 8 padding (7 groups total, Group 0-6).

## Why not duplicating an existing PR

Searched `gh issue list` / `gh pr list` for "hybrid_kv_cache_manager": no open issue or PR. Pure documentation fix.

## Test Plan

- pre-commit run markdownlint-cli2 --files docs/design/hybrid_kv_cache_manager.md

## Test Result

Local environment has no pre-commit/Python; relying on CI check.

---

## AI Assistance

This PR was drafted with AI assistance; the human submitter reviewed every changed line. Co-authored-by: deepseek-v4-flash