### PR TITLE
[Frontend][Rust] Bound chat-template evaluation to prevent DoS (#52025)

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -62,7 +62,7 @@ itertools = "0.14.0"
 libc = "0.2.177"
 llm-multimodal = { git = "https://github.com/smg-project/llm-multimodal", rev = "15adba5e025d8636ba4a334fb379b1371f6196a1", default-features = false, features = ["native-tls"] }
 mimalloc = "0.1.52"
-minijinja = { version = "2.24", features = ["unstable_machinery", "json", "builtins", "loader", "loop_controls", "preserve_order"] }
+minijinja = { version = "2.24", features = ["unstable_machinery", "json", "builtins", "loader", "loop_controls", "preserve_order", "fuel"] }
 minijinja-contrib = { version = "2.24", features = ["pycompat"] }
 native-tls-vendored = { package = "native-tls", version = "0.2.18", features = ["vendored"] }
 ndarray = { version = "0.17", features = ["serde"] }

--- a/rust/src/chat/src/renderer/hf/template.rs
+++ b/rust/src/chat/src/renderer/hf/template.rs
@@ -25,12 +25,31 @@ use crate::renderer::hf::{TemplateMessage, TemplateTool};
 
 type Result<T> = std::result::Result<T, TemplateError>;
 
+/// Evaluation budget for rendering a chat template, in minijinja "fuel" units
+/// (roughly one unit per executed instruction).
+///
+/// Chat templates can be supplied by an (unauthenticated) request or by the
+/// model, and rendering cost is `O(N^depth)` in caller-controlled loop bounds.
+/// minijinja's per-`range()` limit is walked around by nesting, so without a
+/// total budget a tiny template can occupy a request-runtime worker thread for
+/// tens of seconds. A legitimate chat template only iterates over the messages,
+/// tools and documents in the request and needs a negligible fraction of this,
+/// so the budget bounds hostile templates while leaving real ones unaffected.
+/// For reference, minijinja already refuses a single `range()` above ~1M
+/// elements; this total budget is ~20x that, well above any real chat template.
+/// See <https://github.com/vllm-project/vllm/issues/52025>.
+const CHAT_TEMPLATE_FUEL: u64 = 20_000_000;
+
 /// Build a pre-configured environment with the given template string.
 fn build_environment(template: String) -> Result<Environment<'static>> {
     let mut env = Environment::new();
 
     env.set_trim_blocks(true);
     env.set_lstrip_blocks(true);
+
+    // Bound total evaluation work so a caller- or model-supplied template cannot
+    // exhaust a request-runtime worker thread (see `CHAT_TEMPLATE_FUEL`).
+    env.set_fuel(Some(CHAT_TEMPLATE_FUEL));
 
     env.add_template_owned("chat".to_owned(), template)?;
 
@@ -331,5 +350,51 @@ mod tests {
         let template = load_chat_template(&path).unwrap();
 
         assert_eq!(template.as_deref(), Some("{{ messages }}"));
+    }
+
+    /// A template whose evaluation cost is `O(N^depth)` in caller-controlled loop
+    /// bounds must be rejected by the fuel budget rather than running unbounded.
+    /// See <https://github.com/vllm-project/vllm/issues/52025>.
+    #[test]
+    fn test_chat_template_evaluation_is_bounded() {
+        // `range(999)^3` would run ~10^9 iterations (tens of CPU-seconds) without a
+        // budget; every individual `range()` here is small and individually legal.
+        let bomb = "{% for x0 in range(999) %}{% for x1 in range(999) %}\
+             {% for x2 in range(999) %}{% endfor %}{% endfor %}{% endfor %}ok";
+        let template =
+            CompiledChatTemplate::new(bomb.to_string(), ChatTemplateContentFormatOption::Auto)
+                .unwrap();
+
+        let start = std::time::Instant::now();
+        let result = template.apply(TemplateContext::default());
+        let elapsed = start.elapsed();
+
+        assert!(
+            result.is_err(),
+            "a template that exceeds the evaluation budget must be rejected"
+        );
+        // The budget must fire well before the unbounded ~55s cost. The bound is
+        // generous so the test stays robust on slow CI while still proving the cap.
+        assert!(
+            elapsed < std::time::Duration::from_secs(20),
+            "bounded rendering should fail fast, took {elapsed:?}"
+        );
+    }
+
+    /// A template performing a legitimate, non-trivial amount of work (the kind a
+    /// real chat template does while iterating messages/tools) must still render
+    /// well within the fuel budget.
+    #[test]
+    fn test_chat_template_within_budget_renders() {
+        let template = CompiledChatTemplate::new(
+            "{% for i in range(50000) %}{% endfor %}ok".to_string(),
+            ChatTemplateContentFormatOption::Auto,
+        )
+        .unwrap();
+
+        let result = template
+            .apply(TemplateContext::default())
+            .expect("a template within the evaluation budget must render");
+        assert_eq!(result, "ok");
     }
 }

--- a/rust/src/chat/src/renderer/hf/template.rs
+++ b/rust/src/chat/src/renderer/hf/template.rs
@@ -365,19 +365,14 @@ mod tests {
             CompiledChatTemplate::new(bomb.to_string(), ChatTemplateContentFormatOption::Auto)
                 .unwrap();
 
-        let start = std::time::Instant::now();
+        // Without the fuel budget this render would run for tens of seconds; with
+        // it, evaluation stops once the budget is exhausted and returns an error.
+        // We assert on that error rather than on wall-clock time, which would be
+        // nondeterministic on slow or contended CI workers.
         let result = template.apply(TemplateContext::default());
-        let elapsed = start.elapsed();
-
         assert!(
             result.is_err(),
             "a template that exceeds the evaluation budget must be rejected"
-        );
-        // The budget must fire well before the unbounded ~55s cost. The bound is
-        // generous so the test stays robust on slow CI while still proving the cap.
-        assert!(
-            elapsed < std::time::Duration::from_secs(20),
-            "bounded rendering should fail fast, took {elapsed:?}"
         );
     }
 


### PR DESCRIPTION
## Purpose

Fixes #52025.

The Rust frontend renders a caller-supplied (or model-supplied) Jinja `chat_template` from `POST /v1/chat/completions` with **no evaluation budget**. Rendering cost is `O(N^depth)` in caller-controlled loop bounds, and minijinja's per-`range()` element limit is trivially walked around by nesting three individually-legal `range()` calls. A **116-byte** request body can occupy a request-runtime worker thread for **tens of seconds**:

```jinja
{% for x0 in range(999) %}{% for x1 in range(999) %}{% for x2 in range(999) %}{% endfor %}{% endfor %}{% endfor %}ok
```

The request runtime is a bounded pool (`worker_threads = min(available_parallelism, 32)`), so a small number of such requests can stall the chat-completions plane while `/health` stays green. The request-supplied gate (`trust_request_chat_template`, default off in Python vLLM) is not yet implemented in the Rust frontend, and the **model-supplied** template path has no gate at all.

This wires up minijinja's existing `fuel` feature and sets a total evaluation budget in `build_environment` (`rust/src/chat/src/renderer/hf/template.rs`). The budget bounds total work regardless of who supplied the template, so a hostile template is rejected quickly while legitimate templates — which only iterate over the request's messages/tools/documents — are unaffected. For reference, minijinja itself already refuses a single `range()` above ~1M elements; the budget here (20M fuel units) is ~20× that, well above any real chat template.

This is the primary remediation (item 1) from the issue. Implementing `trust_request_chat_template` and `spawn_blocking`-ing the render (items 2 and 4) are follow-ups and out of scope here.

## Test Plan

`cargo test -p vllm-chat` — added two tests in `template.rs`:
- `test_chat_template_evaluation_is_bounded`: the nested-`range()` bomb from the issue is now rejected (and returns quickly instead of running for ~55s).
- `test_chat_template_within_budget_renders`: a legitimate template doing non-trivial work (`range(50000)`) still renders.

## Test Result

```
$ cargo test -p vllm-chat
test result: ok. 267 passed; 0 failed
test result: ok. 17 passed; 0 failed
test result: ok. 16 passed; 0 failed
```

All existing `vllm-chat` tests pass (the budget does not affect any real template); `cargo fmt --check` and `cargo clippy -p vllm-chat` are clean.
