### PR TITLE
[ZenCPU][CI] Zen5 image build reuse cpu

### DIFF
--- a/.buildkite/image_build/image_build.yaml
+++ b/.buildkite/image_build/image_build.yaml
@@ -81,6 +81,29 @@ steps:
         - exit_status: -10  # Agent was lost
           limit: 2
 
+  - label: ":docker: Build Zen CPU image"
+    key: image-build-zen-cpu
+    # Minimal confirmation build: run the zen image build on the generic x86
+    # premerge queue to verify it succeeds. Reuses the shared `-cpu` image as its
+    # base, so it must run after the CPU image build.
+    #
+    # No source_file_dependencies: this step always runs for this validation PR
+    # so the build is exercised regardless of which files changed.
+    depends_on:
+      - image-build-cpu
+    agents:
+      queue: amd-cpu
+    commands:
+    - .buildkite/image_build/image_build_zen_cpu.sh $REGISTRY $REPO $BUILDKITE_COMMIT
+    env:
+      DOCKER_BUILDKIT: "1"
+    retry:
+      automatic:
+        - exit_status: -1  # Agent was lost
+          limit: 2
+        - exit_status: -10  # Agent was lost
+          limit: 2
+
   - label: ":docker: Build HPU image"
     soft_fail: true
     depends_on: []

--- a/.buildkite/image_build/image_build_zen_cpu.sh
+++ b/.buildkite/image_build/image_build_zen_cpu.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+#
+# Build the AMD Zen CPU image (vLLM + zentorch) as a two-step layered build:
+#   1. a CPU base image (vLLM installed) built from docker/Dockerfile.cpu
+#   2. docker/Dockerfile.zen --target vllm-zen-test -> zen image on top
+#
+# The image is (re)built from source every time, mirroring
+# .buildkite/scripts/hardware_ci/run-cpu-test.sh. It is not pushed to a registry.
+#
+# See docker/Dockerfile.zen for the build workflow this mirrors.
+set -e
+
+if [[ $# -lt 3 ]]; then
+  echo "Usage: $0 <registry> <repo> <commit>"
+  exit 1
+fi
+
+REGISTRY=$1
+REPO=$2
+BUILDKITE_COMMIT=$3
+
+# Local image tags (not pushed).
+BASE_IMAGE="$REGISTRY/$REPO:$BUILDKITE_COMMIT-cpu-base-for-zen"
+IMAGE="$REGISTRY/$REPO:$BUILDKITE_COMMIT-zen-cpu"
+
+# ZENTORCH_VERSION is optional; when unset the Dockerfile falls back to
+# installing zentorch via `vllm[zen]`.
+ZENTORCH_VERSION=${ZENTORCH_VERSION:-}
+
+# Step 1: build the CPU base image that Dockerfile.zen layers on.
+echo "--- :docker: Building CPU base image"
+docker build --file docker/Dockerfile.cpu \
+  --platform linux/amd64 \
+  --build-arg max_jobs=16 \
+  --build-arg buildkite_commit="$BUILDKITE_COMMIT" \
+  --build-arg VLLM_CPU_X86=true \
+  --tag "$BASE_IMAGE" \
+  --target vllm-openai \
+  --progress plain .
+
+# Step 2: build the zen test image on top of the CPU base.
+echo "--- :docker: Building Zen test image"
+docker build --file docker/Dockerfile.zen \
+  --platform linux/amd64 \
+  --build-arg BASE_IMAGE="$BASE_IMAGE" \
+  ${ZENTORCH_VERSION:+--build-arg ZENTORCH_VERSION="$ZENTORCH_VERSION"} \
+  --tag "$IMAGE" \
+  --target vllm-zen-test \
+  --progress plain .

--- a/.buildkite/image_build/image_build_zen_cpu.sh
+++ b/.buildkite/image_build/image_build_zen_cpu.sh
@@ -2,12 +2,16 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 #
-# Build the AMD Zen CPU image (vLLM + zentorch) as a two-step layered build:
-#   1. a CPU base image (vLLM installed) built from docker/Dockerfile.cpu
-#   2. docker/Dockerfile.zen --target vllm-zen-test -> zen image on top
+# Build the AMD Zen CPU image (vLLM + zentorch) by layering docker/Dockerfile.zen
+# on top of a CPU base image that already has vLLM installed.
 #
-# The image is (re)built from source every time, mirroring
-# .buildkite/scripts/hardware_ci/run-cpu-test.sh. It is not pushed to a registry.
+# To avoid recompiling vLLM from source, prefer reusing the shared CPU image that
+# the image-build-cpu step already builds and publishes for this commit
+# (`<repo>:<commit>-cpu`). It lives in public ECR, which allows anonymous pulls,
+# so no registry credentials are required. If the pull fails (e.g. the image
+# isn't published yet), fall back to building the base from docker/Dockerfile.cpu.
+#
+# The zen image is not pushed to a registry.
 #
 # See docker/Dockerfile.zen for the build workflow this mirrors.
 set -e
@@ -21,24 +25,33 @@ REGISTRY=$1
 REPO=$2
 BUILDKITE_COMMIT=$3
 
-# Local image tags (not pushed).
-BASE_IMAGE="$REGISTRY/$REPO:$BUILDKITE_COMMIT-cpu-base-for-zen"
+# The shared CPU image published by image-build-cpu (public ECR, anonymous pull).
+SHARED_CPU_IMAGE="$REGISTRY/$REPO:$BUILDKITE_COMMIT-cpu"
+# Local tags (not pushed).
+FALLBACK_BASE_IMAGE="zen-cpu-base:$BUILDKITE_COMMIT"
 IMAGE="$REGISTRY/$REPO:$BUILDKITE_COMMIT-zen-cpu"
 
 # ZENTORCH_VERSION is optional; when unset the Dockerfile falls back to
 # installing zentorch via `vllm[zen]`.
 ZENTORCH_VERSION=${ZENTORCH_VERSION:-}
 
-# Step 1: build the CPU base image that Dockerfile.zen layers on.
-echo "--- :docker: Building CPU base image"
-docker build --file docker/Dockerfile.cpu \
-  --platform linux/amd64 \
-  --build-arg max_jobs=16 \
-  --build-arg buildkite_commit="$BUILDKITE_COMMIT" \
-  --build-arg VLLM_CPU_X86=true \
-  --tag "$BASE_IMAGE" \
-  --target vllm-openai \
-  --progress plain .
+# Step 1: obtain the CPU base image that Dockerfile.zen layers on. Prefer pulling
+# the published `-cpu` image; fall back to building it from source if unavailable.
+if docker pull "$SHARED_CPU_IMAGE"; then
+  echo "--- :docker: Using published CPU image as base: $SHARED_CPU_IMAGE"
+  BASE_IMAGE="$SHARED_CPU_IMAGE"
+else
+  echo "--- :docker: Published CPU image unavailable; building base from source"
+  docker build --file docker/Dockerfile.cpu \
+    --platform linux/amd64 \
+    --build-arg max_jobs=16 \
+    --build-arg buildkite_commit="$BUILDKITE_COMMIT" \
+    --build-arg VLLM_CPU_X86=true \
+    --tag "$FALLBACK_BASE_IMAGE" \
+    --target vllm-openai \
+    --progress plain .
+  BASE_IMAGE="$FALLBACK_BASE_IMAGE"
+fi
 
 # Step 2: build the zen test image on top of the CPU base.
 echo "--- :docker: Building Zen test image"


### PR DESCRIPTION

## Purpose
Given that the zen CPU docker image build (`docker/Dockerfile.zen` + `.buildkite/image_build/image_build_zen_cpu.sh`) are already added, this PR adds `image-build-zen-cpu` step pinned to the `amd-cpu` queue, with **no** `source_file_dependencies` so it always runs, to confirm the zen image builds are successful. The step depends on `image-build-cpu` and reuses the published `<repo>:<commit>-cpu` image as its base (anonymous public-ECR pull), falling back to building the base from `docker/Dockerfile.cpu` if that image isn't available yet. Also drop the stale `vllm-openai-zen` target from `docker/Dockerfile.cpu`.
Image-build only: the zen5 hardware test and its runner are intentionally excluded from this confirmation PR and will land in follow-up PRs.

The ECR pull / source-fallback selection in image_build_zen_cpu.sh is exercised only in CI.

## Test Plan
This is a build-enablement PR, so the test is the image build itself succeeding in CI:
- The new `image-build-zen-cpu` Buildkite step has no `source_file_dependencies`, so it runs on every commit of this PR and exercises the full build path (pull shared `-cpu` base → layer `Dockerfile.zen` `vllm-zen-test` target).
- Local reproduction (x86 host with Docker + BuildKit), mirroring the CI entrypoint:
```bash
DOCKER_BUILDKIT=1 .buildkite/image_build/image_build_zen_cpu.sh <registry> <repo> <commit>
```
Both base-image paths are covered: the normal reuse path (published -cpu image present) and the source fallback (docker/Dockerfile.cpu, target vllm-openai) when the pull fails.

Out of scope (follow-up PRs): running the zen5 hardware tests and any runtime/accuracy validation of the resulting image.

## Test Result
Built locally on an x86 host (Docker + BuildKit), reproducing CI's layer-on-cached-base path:
- vllm-cpu-base:local from Dockerfile.cpu --target vllm-openai
- vllm-zen-cpu:local from Dockerfile.zen --target vllm-zen-test with --build-arg BASE_IMAGE=vllm-cpu-base:local; image exported successfully.
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [X] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [X] The test plan, such as providing test command.
- [X] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

