### PR TITLE
[Docs] Note pooled aggregation semantics for mean_acceptance_length

### DIFF
--- a/vllm/v1/spec_decode/metrics.py
+++ b/vllm/v1/spec_decode/metrics.py
@@ -110,7 +110,11 @@ class SpecDecodingLogging:
             else float("nan")
         )
 
-        # Conventionally, mean acceptance length includes the bonus token
+        # Conventionally, mean acceptance length includes the bonus token.
+        # This is a *pooled* mean (weighted by drafts): it is equivalent to
+        # total_generated / total_verify_calls, not the unweighted mean of
+        # per-request means that some external benchmarks report (see #42508
+        # for a reproduction against SpecForge on variable-length workloads).
         mean_acceptance_length = 1 + (num_accepted_tokens / num_drafts)
 
         pos_matrix = np.array(self.accepted_tokens_per_pos_lists)
@@ -188,6 +192,13 @@ class SpecDecodingProm:
       1 + (
       rate(vllm:spec_decode_num_accepted_tokens_total[$interval]) /
       rate(vllm:spec_decode_num_drafts[$interval]))
+
+    Both the log line and this PromQL formula compute a *pooled* mean,
+    weighted by draft count. External benchmarks that instead report an
+    unweighted mean of per-request means (e.g., SpecForge's
+    ``average_acceptance_length``, which is ``statistics.fmean`` over
+    per-request lengths) are not directly comparable on variable-length
+    workloads. See #42508.
 
     A per-position acceptance rate vector can be computed using
 


### PR DESCRIPTION
## Purpose

`SpecDecodingLogging._log` and the PromQL recipe in `SpecDecodingProm.__doc__` compute the `mean_acceptance_length` as a **pooled mean** (weighted by draft count, equivalent to `total_generated / total_verify_calls`), not an unweighted mean of per-request means.

Some external benchmarks report the latter. SpecForge's `average_acceptance_length`, for example, is `statistics.fmean(acceptance_lengths)` over per-request lengths. On variable-length workloads the two aggregations can differ by several points in either direction, depending on the sign of the per-request-length ↔ acceptance-rate correlation. This has confused at least one report already (issue #42508: a 55.08%-vs-44% pooled-vs-mean-of-means gap for EAGLE3 on GSM8K, and 66.57%-vs-72% in the opposite direction for the standalone drafter, same numerator, different aggregation).

## Changes

Docstring/comment only. Adds a short aggregation note

- inline where `mean_acceptance_length` is computed, and
- inside `SpecDecodingProm.__doc__` below the existing PromQL recipe.

Both points cross-reference #42508 for the reproduction.

The metric definitions and the CLI/Prometheus output are byte-identical to before.

## Test Plan

None (comment/docstring only, no runtime behavior changed). `ruff format --check` clean; pre-commit hooks pass locally.

## Test Result

n/a

## Documentation Update

n/a (this PR *is* the documentation update).

## Essential Elements of an Effective PR Description Checklist

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [x] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1MBOTQeE4aOFIL8UkuGRyGXe6qYtsIt1FGWyxTvvIvtM/edit?tab=t.0).
