### PR TITLE
[Bugfix] Declare SupportsEagle3 on KimiLinearForCausalLM

### DIFF
--- a/tests/models/kimi_k3/test_eagle3.py
+++ b/tests/models/kimi_k3/test_eagle3.py
@@ -10,6 +10,7 @@ from vllm.model_executor.models.interfaces import supports_eagle3
 from vllm.models.kimi_k3.nvidia import model as kimi_model
 from vllm.models.kimi_k3.nvidia.model import (
     KimiK3ForConditionalGeneration,
+    KimiLinearForCausalLM,
     KimiLinearModel,
 )
 
@@ -23,6 +24,14 @@ def _make_kimi_linear_model() -> KimiLinearModel:
 
 def test_kimi_k3_advertises_eagle3_support():
     assert supports_eagle3(KimiK3ForConditionalGeneration)
+
+
+def test_kimi_linear_advertises_eagle3_support():
+    # The text-only architecture serves the same inner KimiLinearModel, which
+    # already carries the EagleModelMixin tap machinery - only the interface
+    # declaration was missing, so EAGLE3-family speculative decoding (dspark)
+    # was rejected at startup with "Model does not support EAGLE3 interface".
+    assert supports_eagle3(KimiLinearForCausalLM)
 
 
 def test_kimi_k3_uses_shared_eagle3_layer_configuration():

--- a/vllm/models/kimi_k3/nvidia/model.py
+++ b/vllm/models/kimi_k3/nvidia/model.py
@@ -1397,7 +1397,7 @@ class KimiLinearModel(nn.Module, EagleModelMixin, SupportsQuant):
 
 
 class KimiLinearForCausalLM(
-    nn.Module, HasInnerState, SupportsPP, MixtureOfExperts, IsHybrid
+    nn.Module, HasInnerState, SupportsPP, MixtureOfExperts, IsHybrid, SupportsEagle3
 ):
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
         super().__init__()


### PR DESCRIPTION
### Purpose

`KimiK3ForConditionalGeneration` (multimodal) declares `SupportsEagle3`; the text-only `KimiLinearForCausalLM` does not — even though both serve the same inner `KimiLinearModel`, which already inherits `EagleModelMixin` and implements the aux-hidden-state tap machinery. Serving a text-only Kimi-K3 checkpoint with EAGLE3-family speculative decoding (e.g. `dspark`) therefore dies at startup:

```
RuntimeError: Model does not support EAGLE3 interface
```

Adding the interface to the class bases is the whole fix: the protocol's default `set_aux_hidden_state_layers` / `get_eagle3_default_aux_hidden_state_layers` delegate to `self.model`, which satisfies their `EagleModelMixin` requirement.

### Test plan

- `tests/models/kimi_k3/test_eagle3.py` gains `test_kimi_linear_advertises_eagle3_support`, mirroring the existing multimodal assertion; it fails on `main` and passes with this change.
- Runtime-validated: a text-only Kimi-K3 checkpoint served with a `dspark` draft on 8× RTX 3090 using an equivalent patch (that is how we hit the error).

---
Assisted-By: Claude
