### PR TITLE
[Bugfix] Disable sequence parallelism for Dots3 NOTE

### DIFF
--- a/vllm/models/dots3_note/nvidia/model.py
+++ b/vllm/models/dots3_note/nvidia/model.py
@@ -497,6 +497,7 @@ class Dots3NoteDecoderLayer(DeepseekV32DecoderLayer):
         layer_idx = int(prefix.split(sep=".")[-1])
         self.layer_idx = layer_idx
         self.use_mha = False
+        self.use_sequence_parallel = False
         attention_cls = (
             Dots3NoteSlidingAttention
             if config.layer_types[layer_idx] == "sliding_attention"
@@ -536,11 +537,7 @@ class Dots3NoteDecoderLayer(DeepseekV32DecoderLayer):
                 prefix=f"{prefix}.mlp",
                 reduce_results=False,
             )
-        self.use_sequence_parallel_moe = (
-            parallel_config.use_sequence_parallel_moe
-            and parallel_config.pipeline_parallel_size == 1
-            and isinstance(self.mlp, DeepseekV2MoE)
-        )
+        self.use_sequence_parallel_moe = False
         self.tp_size = parallel_config.tensor_parallel_size
         self.input_layernorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.post_attention_layernorm = RMSNorm(
@@ -559,6 +556,7 @@ class Dots3NoteModel(DeepseekV32Model):
         self.config = config
         self.device = current_platform.device_type
         self.vocab_size = config.vocab_size
+        self.use_sequence_parallel = False
         self.is_v32 = True
         self._weight_block_size = getattr(quant_config, "weight_block_size", None)
         topk_indices_buffer = torch.empty(


### PR DESCRIPTION
## Why

The DeepSeek V3.2 sequence-parallel refactor changed the inherited forward paths to use `use_sequence_parallel`.

Dots3 NOTE uses custom model and decoder initializers and has not adopted the new sequence-parallel execution path. This causes serving to fail during KV cache profiling with:

`AttributeError: 'Dots3NoteModel' object has no attribute 'use_sequence_parallel'`

## What changed

Explicitly disable sequence parallelism for Dots3 NOTE and keep its existing non-SP execution path.

## Validation

- BF16 DP8 + EP + MTP3: startup and inference passed.
- BF16 TP8 + EP + MTP3: startup and inference passed.
- Text and image requests completed successfully.
- No duplicate issue or PR was found.