### PR TITLE
[Bugfix] Add forward_xpu to XDRotaryEmbedding for HunyuanOCR on XPU

### DIFF
--- a/vllm/model_executor/layers/rotary_embedding/xdrope.py
+++ b/vllm/model_executor/layers/rotary_embedding/xdrope.py
@@ -137,6 +137,18 @@ class XDRotaryEmbedding(DynamicNTKAlphaRotaryEmbedding):
         key = torch.cat((key_rot, key_pass), dim=-1).reshape(key_shape)
         return query, key
 
+    def forward_xpu(
+        self,
+        positions: torch.Tensor,
+        query: torch.Tensor,
+        key: torch.Tensor | None = None,
+        offsets: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        # No fused XPU kernel for XD-sectioned RoPE; the base
+        # RotaryEmbedding.forward_xpu calls the generic C++ kernel, which
+        # rejects the 2-D [4, num_tokens] xdrope positions. Use the native path.
+        return self.forward_native(positions, query, key, offsets)
+
     @staticmethod
     def get_next_input_positions(
         context_len: int,


### PR DESCRIPTION
## Purpose

`XDRotaryEmbedding` (rope_type `xdrope`, used by `tencent/HunyuanOCR`, arch `HunYuanVLForConditionalGeneration`) overrides `forward_native` and `forward_cuda` but not `forward_xpu`.

`CustomOp.dispatch_forward()` binds the method once at init based on `compilation_config.custom_ops`:
- Default (Inductor on): `custom_ops=[]` -> `'none'` -> custom op disabled -> `forward_native`. Handles the 2-D `[4, num_tokens]` xdrope positions correctly -> PASS.
- `--enforce-eager`: Inductor off -> `custom_ops=['all']` -> custom op enabled -> `forward_xpu`. `XDRotaryEmbedding` has none, so dispatch falls back to base `RotaryEmbedding.forward_xpu`, which calls the generic C++ kernel `torch.ops._C.rotary_embedding`. That kernel expects 1-D positions matching q/k `num_tokens`; given the 2-D `[4, num_tokens]` (P/W/H/T sections) positions it raises:

```
RuntimeError: query, key and positions must have the same batch_size and seq_len
```

crashing `EngineCore` during `profile_run`, so the model cannot serve at all under `--enforce-eager` on XPU.

Fix: add `forward_xpu` to `XDRotaryEmbedding` delegating to `forward_native` (no fused XPU xdrope kernel exists), mirroring how mrope handles XPU.

## Test Plan

```bash
vllm serve tencent/HunyuanOCR --dtype bfloat16 --tensor-parallel-size 1 \
  --max-model-len 8192 --gpu-memory-utilization 0.85 \
  -cc '{"inductor_compile_config":{"benchmark_combo_kernel":false}}' \
  --port 8005 --trust-remote-code --enforce-eager \
  --limit-mm-per-prompt '{"image": 1}'
```

## Test Result

Before fix - `EngineCore` crashes during `profile_run`:

```
  File ".../vllm/model_executor/models/hunyuan_v1.py", line 237, in forward
    q, k = self.rotary_emb(positions, q, k)
  File ".../vllm/model_executor/custom_op.py", line 136, in forward
    return self._forward_method(*args, **kwargs)
  File ".../vllm/model_executor/layers/rotary_embedding/base.py", line 288, in forward_xpu
    ops.rotary_embedding(...)
  File ".../vllm/_custom_ops.py", line 212, in rotary_embedding
    torch.ops._C.rotary_embedding(...)
RuntimeError: query, key and positions must have the same batch_size and seq_len
```

After fix:
- `Application startup complete`
- `/health` -> 200; `/v1/models` serves `tencent/HunyuanOCR`

Default (torch.compile) path already routed to `forward_native` and is unaffected.
