### PR TITLE
[Bugfix][DBO] Run the profile run without DBO when DBO is enabled.

### DIFF
--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -6566,7 +6566,9 @@ class GPUModelRunner(
 
         # Add `is_profile` here to pre-allocate communication buffers
         hidden_states, last_hidden_states = self._dummy_run(
-            self.max_num_tokens, is_profile=True
+            self.max_num_tokens,
+            is_profile=True,
+            allow_microbatching=False,
         )
         if get_pp_group().is_last_rank:
             if self.is_pooling_model:


### PR DESCRIPTION
## Purpose
Running the profile run with DBO effectively sets the max batch size to `max_num_tokens // 2`. If vllm bails out of DBO for any reason, it can end up in a situation where it's running with a batch size that is larger than `max_num_tokens // 2`. Deep EP v2 crashes in this case because an internal buffer wasn't sized correctly, but it's plausible that there is other undesirable behavior in the system when we encounter this scenario.

The fix is to run the profile run with DBO explicitly disabled.

## Test Result
```
vllm serve deepseek-ai/DeepSeek-V2-Lite \
--data-parallel-size 2 \
--enable-expert-parallel \
--all2all-backend deepep_highthroughput \
--enable-dbo \
--dbo-decode-token-threshold 32 \
--dbo-prefill-token-threshold 32
```
lm_eval result
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.3798|±  |0.0134|
|     |       |strict-match    |     5|exact_match|↑  |0.3783|±  |0.0134|
```