### PR TITLE
[Bugfix] Fix PP speculative decode cadence with sync scheduling

### DIFF
--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -1304,6 +1304,53 @@ def test_draft_slots_budgeted_per_scheduled_request(tmp_path, monkeypatch):
     assert scheduler.schedule().num_scheduled_tokens == {"0": 10, "1": 4}
 
 
+def test_v2_pp_spec_decode_waits_for_sampled_token_relay():
+    pp_size = 2
+    scheduler = create_scheduler(
+        async_scheduling=False,
+        num_speculative_tokens=3,
+        use_v2_model_runner=True,
+    )
+    # Emulate PP at the scheduler level without requiring multiple GPUs.
+    scheduler.use_pp = True
+    scheduler.parallel_config.pipeline_parallel_size = pp_size
+
+    (request,) = create_requests(num_requests=1, num_tokens=1)
+    scheduler.add_request(request)
+
+    prefill_output = scheduler.schedule()
+    prefill_step = scheduler.current_step
+    assert not request.is_prefill_chunk
+    assert request.next_decode_eligible_step == prefill_step + pp_size
+
+    # The drafter output can reach the base scheduler before the sampled anchor
+    # from this final prefill step has traversed the PP sampled-token FIFO.
+    scheduler.update_draft_token_ids(
+        DraftTokenIds([request.request_id], [[1, 2, 3]])
+    )
+
+    next_output = scheduler.schedule()
+    assert scheduler.current_step == prefill_step + 1
+    assert request.request_id not in next_output.num_scheduled_tokens
+
+    scheduler.update_from_output(
+        prefill_output,
+        ModelRunnerOutput(
+            req_ids=[request.request_id],
+            req_id_to_index={request.request_id: 0},
+            sampled_token_ids=[[42]],
+            logprobs=None,
+            prompt_logprobs_dict={},
+            pooler_output=[],
+        ),
+    )
+
+    eligible_output = scheduler.schedule()
+    assert scheduler.current_step == prefill_step + pp_size
+    assert request.request_id in eligible_output.num_scheduled_tokens
+    assert eligible_output.num_scheduled_tokens[request.request_id] == 4
+
+
 # Note - these test cases mirror some of those in test_rejection_sampler.py
 @pytest.mark.parametrize(
     "spec_tokens,output_tokens,expected",

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1346,6 +1346,16 @@ class Scheduler(SchedulerInterface):
             request.is_prefill_chunk = request.num_computed_tokens < (
                 request.num_tokens + request.num_output_placeholders
             )
+            if (
+                self.use_v2_model_runner
+                and self.use_pp
+                and self.vllm_config.speculative_config is not None
+                and not request.is_prefill_chunk
+            ):
+                request.next_decode_eligible_step = (
+                    self.current_step
+                    + self.parallel_config.pipeline_parallel_size
+                )
             scheduler_output.has_structured_output_requests |= (
                 request.use_structured_output and not request.is_prefill_chunk
             )


### PR DESCRIPTION
## Purpose

Fixes #52071.

When using the V2 model runner with pipeline parallelism and speculative decoding, the base `Scheduler` can schedule a request again before the sampled token from the previous PP step has been relayed back.

The scheduler already checks `request.next_decode_eligible_step`, but this value was only being updated in `AsyncScheduler`. With async scheduling disabled, speculative draft tokens can increase `num_tokens_with_spec` and make the request runnable again while the sampled-token state is still stale.

This PR updates `next_decode_eligible_step` in the base scheduler when:

- the V2 model runner is enabled;
- pipeline parallelism is enabled;
- speculative decoding is enabled;
- the request is no longer in a prefill chunk.

The next eligible step is set to:

```text
current_step + pipeline_parallel_size
```

This keeps non-final chunked prefill scheduling unchanged, while decode waits for the PP sampled-token relay before the request can be scheduled again.

The existing `AsyncScheduler` handling is unchanged.

Thanks @nickus for the detailed investigation in #52071. The reproduction, measurements, and analysis around the PP sampled-token relay and stale sampled tokens were especially helpful in narrowing this down to the scheduler cadence.

## Regression test

Added:

```text
tests/v1/core/test_scheduler.py::test_v2_pp_spec_decode_waits_for_sampled_token_relay
```

The test uses the base scheduler with:

- V2 model runner
- PP=2
- speculative decoding enabled
- async scheduling disabled

It simulates the final prefill step, injects speculative draft tokens, and checks that the request is not scheduled on the next step while the sampled token is still being relayed.

After the sampled token is settled, the request becomes eligible at the expected PP step and schedules the sampled-token anchor together with the draft tokens.

## Test results

Targeted regression:

```text
tests/v1/core/test_scheduler.py::test_v2_pp_spec_decode_waits_for_sampled_token_relay
1 passed
```

Related scheduler tests:

```text
tests/v1/core/test_async_scheduler.py
16 passed

tests/v1/core/test_scheduler.py -k "spec"
17 passed
```

`git diff --check` also passes.

## GPU E2E

I also ran a before/after GPU repro on 2x RTX 4090.

To keep the repro small while still exercising the real PP + MTP path, I used the GLM-4.7-Flash architecture with `load_format="dummy"` and reduced the model through `hf_overrides`.

The test configuration was:

```text
V2 model runner
async_scheduling=False
MTP speculative decoding
num_speculative_tokens=1
4 transformer layers
2 routed experts
greedy decoding
16 output tokens
```

The same setup was tested with PP=1 and PP=2.

### Before the fix

| Configuration | Result |
| --- | --- |
| PP=1 + V2 + MTP + async=False | PASS |
| PP=2 + V2 + MTP + async=False | FAIL — CUDA illegal memory access |

The PP=1 run completed normally and produced 15 speculative draft steps.

The PP=2 run did not produce an output and failed in the worker with:

```text
torch.AcceleratorError:
CUDA error: an illegal memory access was encountered
```

### After the fix

| Configuration | Result |
| --- | --- |
| PP=1 + V2 + MTP + async=False | PASS |
| PP=2 + V2 + MTP + async=False | PASS |

Both runs generated all 16 requested tokens and speculative decoding remained active:

```text
PP=1:
output_length = 16
num_drafts = 15

PP=2:
output_length = 16
num_drafts = 15
```

The PP=1 and PP=2 runs also produced identical token IDs:

```text
[55582, 18495, 55582, 18495, 55582, 18495, 55582, 18495,
 55582, 18495, 55582, 18495, 55582, 18495, 55582, 18495]
```

So with the same model setup and scheduler configuration:

| | Before fix | After fix |
| --- | --- | --- |
| PP=1 | PASS | PASS |
| PP=2 | CUDA illegal memory access | PASS |