### PR TITLE
[Core][Perf] Zero new KV blocks by cache group

### DIFF
--- a/tests/v1/kv_connector/unit/test_nixl_connector_hma.py
+++ b/tests/v1/kv_connector/unit/test_nixl_connector_hma.py
@@ -965,15 +965,15 @@ def test_scheduler_filters_connector_loaded_blocks_from_zeroing():
     from vllm.v1.core.sched.scheduler import Scheduler
 
     class FakeKVCacheManager:
-        def take_new_block_ids(self):
-            return [9, 10, 11, 12]
+        def take_new_block_ids_by_group(self):
+            return [[9, 10, 11, 12]]
 
     scheduler = object.__new__(Scheduler)
     scheduler.needs_kv_cache_zeroing = True
     scheduler.kv_cache_manager = FakeKVCacheManager()
     scheduler._skip_zero_block_ids = {10, 12}
 
-    assert scheduler._get_new_block_ids_to_zero() == [9, 11]
+    assert scheduler._get_new_block_ids_to_zero() == [[9, 11]]
     assert not scheduler._skip_zero_block_ids
 
 
@@ -1002,7 +1002,7 @@ def test_failed_load_rezeroes_unwritten_skipped_blocks():
     # Attention blocks covering tokens >= 48 are re-recorded for zeroing
     # and flow into the next step's zero list; Mamba blocks are not.
     scheduler._skip_zero_block_ids = set()
-    assert scheduler._get_new_block_ids_to_zero() == [13, 14, 15]
+    assert scheduler._get_new_block_ids_to_zero() == [[13, 14, 15], []]
 
 
 # ── Mamba N-1 prefill tests ──────────────────────────────────────────────

--- a/tests/v1/worker/test_kv_block_zeroer.py
+++ b/tests/v1/worker/test_kv_block_zeroer.py
@@ -71,6 +71,43 @@ def test_attention_blocks_are_zeroed(spec):
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_block_ids_are_zeroed_only_in_their_cache_group():
+    device = torch.device("cuda")
+    spec = SlidingWindowSpec(
+        block_size=2,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.uint8,
+        sliding_window=4,
+    )
+    group_0_storage = torch.ones((4, 1, 2, 2), dtype=torch.uint8, device=device)
+    group_1_storage = torch.ones((4, 1, 2, 2), dtype=torch.uint8, device=device)
+    zeroer = KVBlockZeroer(
+        device,
+        attn_groups_iter=[
+            AttentionGroup(_BlockFirstBackend, ["group_0"], spec, 0),  # type: ignore[arg-type]
+            AttentionGroup(_BlockFirstBackend, ["group_1"], spec, 1),  # type: ignore[arg-type]
+        ],
+        kernel_block_sizes=[2, 2],
+        cache_dtype="fp8",
+        static_forward_context={
+            "group_0": SimpleNamespace(kv_cache=group_0_storage),
+            "group_1": SimpleNamespace(kv_cache=group_1_storage),
+        },
+    )
+
+    zeroer.zero_block_ids_by_group([[1], [2]])
+    torch.accelerator.synchronize()
+
+    expected_group_0 = torch.ones_like(group_0_storage)
+    expected_group_0[1] = 0
+    expected_group_1 = torch.ones_like(group_1_storage)
+    expected_group_1[2] = 0
+    assert torch.equal(group_0_storage, expected_group_0)
+    assert torch.equal(group_1_storage, expected_group_1)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
 def test_block_ids_are_not_overwritten_while_copy_is_in_flight():
     device = torch.device("cuda")
     num_blocks = 4

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -800,12 +800,25 @@ class KVCacheManager:
             truncated.append(list(group_blocks[:num_blocks]))
         return self.create_kv_cache_blocks(tuple(truncated))
 
+    def take_new_block_ids_by_group(self) -> list[list[int]]:
+        """Drain new attention block IDs, preserving their cache group.
+
+        Block IDs are allocated from a shared pool, but each ID is used by
+        only one cache group at a time. Keeping the group association lets the
+        worker zero just that group's physical cache pages instead of applying
+        every new ID to every attention cache group.
+        """
+        return [
+            mgr.take_new_block_ids() for mgr in self.coordinator.single_type_managers
+        ]
+
     def take_new_block_ids(self) -> list[int]:
         """Drain and return new attention block IDs for zeroing."""
-        ids: list[int] = []
-        for mgr in self.coordinator.single_type_managers:
-            ids.extend(mgr.take_new_block_ids())
-        return ids
+        return [
+            block_id
+            for group_block_ids in self.take_new_block_ids_by_group()
+            for block_id in group_block_ids
+        ]
 
     def get_zeroing_block_ids_in_range(
         self, request_id: str, start_token: int, end_token: int

--- a/vllm/v1/core/sched/output.py
+++ b/vllm/v1/core/sched/output.py
@@ -250,10 +250,11 @@ class SchedulerOutput:
     ec_connector_metadata: ECConnectorMetadata | None = None
     # EC Cache Manager metadata
     ec_manager_metadata: EncoderCacheManagerMetadata | None = None
-    # Block IDs freshly allocated from the pool during this scheduling step.
-    # The worker zeros the corresponding GPU memory before the blocks are used,
-    # preventing stale NaN/data from corrupting attention or SSM computation.
-    new_block_ids_to_zero: list[int] | None = None
+    # Block IDs freshly allocated from the pool during this scheduling step,
+    # grouped by KV cache group. The worker zeros the corresponding group's GPU
+    # memory before the blocks are used, preventing stale NaN/data from
+    # corrupting attention computation without clearing unrelated cache groups.
+    new_block_ids_to_zero: list[list[int]] | None = None
 
     # CoW copies to apply after zeroing new blocks and before forward.
     kv_cache_block_copies: list[KVCacheBlockCopy] | None = None

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1269,19 +1269,22 @@ class Scheduler(SchedulerInterface):
     ) -> KVConnectorMetadata:
         return connector.build_connector_meta(scheduler_output)
 
-    def _get_new_block_ids_to_zero(self) -> list[int] | None:
+    def _get_new_block_ids_to_zero(self) -> list[list[int]] | None:
         # Drain new attention block ids every step so the manager-side list
         # does not grow unbounded; only kv-cache zeroing consumes them.
-        new_block_ids_to_zero = self.kv_cache_manager.take_new_block_ids()
+        new_block_ids_to_zero = self.kv_cache_manager.take_new_block_ids_by_group()
         if not self.needs_kv_cache_zeroing:
             return None
 
         if self._skip_zero_block_ids:
             skip = self._skip_zero_block_ids
-            new_block_ids_to_zero = [b for b in new_block_ids_to_zero if b not in skip]
+            new_block_ids_to_zero = [
+                [block_id for block_id in group_ids if block_id not in skip]
+                for group_ids in new_block_ids_to_zero
+            ]
             skip.clear()
 
-        return new_block_ids_to_zero or None
+        return new_block_ids_to_zero if any(new_block_ids_to_zero) else None
 
     def _preempt_request(
         self, request: Request, timestamp: float, drop_stale_output: bool = False

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -1016,7 +1016,9 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         # stale NaN/data from corrupting attention or SSM computation.
         if scheduler_output.new_block_ids_to_zero:
             assert self.kv_block_zeroer is not None
-            self.kv_block_zeroer.zero_block_ids(scheduler_output.new_block_ids_to_zero)
+            self.kv_block_zeroer.zero_block_ids_by_group(
+                scheduler_output.new_block_ids_to_zero
+            )
 
         # Apply copy-on-write block copies for partial prefix-cache hits, after
         # zeroing new blocks and before the forward pass reads them.

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1196,10 +1196,10 @@ class GPUModelRunner(
             static_forward_context=self.compilation_config.static_forward_context,
         )
 
-    def _zero_block_ids(self, block_ids: list[int]) -> None:
-        """Zero the KV cache memory for the given block IDs."""
+    def _zero_block_ids(self, block_ids_by_group: list[list[int]]) -> None:
+        """Zero KV cache blocks in their owning cache groups."""
         if hasattr(self, "_kv_block_zeroer"):
-            self._kv_block_zeroer.zero_block_ids(block_ids)
+            self._kv_block_zeroer.zero_block_ids_by_group(block_ids_by_group)
 
     # Note: used for model runner override.
     def _init_device_properties(self) -> None:

--- a/vllm/v1/worker/utils.py
+++ b/vllm/v1/worker/utils.py
@@ -101,8 +101,8 @@ class KVBlockZeroer:
     """Manages efficient zeroing of KV cache blocks via a Triton kernel.
 
     Construct once after KV caches are allocated to precompute segment
-    addresses, then call :meth:`zero_block_ids` each step to zero
-    newly-allocated blocks.
+    addresses, then call :meth:`zero_block_ids_by_group` each step to zero
+    newly-allocated blocks in their owning cache groups.
     """
 
     def __init__(
@@ -130,13 +130,19 @@ class KVBlockZeroer:
         self._meta: (
             tuple[torch.Tensor, torch.Tensor, torch.Tensor, int, int, int] | None
         ) = None
+        self._meta_by_group: list[
+            tuple[torch.Tensor, torch.Tensor, torch.Tensor, int, int, int] | None
+        ] = [None] * len(kernel_block_sizes)
 
         if runner_only_attn_layers is None:
             runner_only_attn_layers = set()
-        seen_ptrs: set[int] = set()
+        seen_ptrs_by_group: list[set[int]] = [set() for _ in kernel_block_sizes]
         seg_addrs: list[int] = []
         seg_block_strides: list[int] = []
         seg_page_sizes: list[int] = []
+        group_seg_addrs: list[list[int]] = [[] for _ in kernel_block_sizes]
+        group_seg_block_strides: list[list[int]] = [[] for _ in kernel_block_sizes]
+        group_seg_page_sizes: list[list[int]] = [[] for _ in kernel_block_sizes]
 
         for group in attn_groups_iter:
             spec = group.kv_cache_spec
@@ -144,7 +150,8 @@ class KVBlockZeroer:
                 continue
             if group.kv_cache_group_id >= len(kernel_block_sizes):
                 continue
-            kernel_bs = kernel_block_sizes[group.kv_cache_group_id]
+            group_id = group.kv_cache_group_id
+            kernel_bs = kernel_block_sizes[group_id]
             assert spec.block_size % kernel_bs == 0
             ratio = spec.block_size // kernel_bs
             block_dim = group.backend.get_kv_cache_block_dim(
@@ -161,9 +168,9 @@ class KVBlockZeroer:
                 if not isinstance(kv, torch.Tensor):
                     continue
                 dp = kv.data_ptr()
-                if dp in seen_ptrs:
+                if dp in seen_ptrs_by_group[group_id]:
                     continue
-                seen_ptrs.add(dp)
+                seen_ptrs_by_group[group_id].add(dp)
 
                 el = kv.element_size()
                 block_stride_bytes = kv.stride(block_dim) * el
@@ -187,19 +194,39 @@ class KVBlockZeroer:
                     off_bytes = sum(i * s for i, s in zip(outer, outer_strides))
                     assert (dp + off_bytes) % 4 == 0
                     for virtual_index in range(ratio):
-                        seg_addrs.append(
-                            dp + off_bytes + virtual_index * block_stride_bytes
-                        )
-                        seg_block_strides.append(logical_block_stride_bytes // 4)
-                        seg_page_sizes.append(kernel_page_bytes // 4)
+                        seg_addr = dp + off_bytes + virtual_index * block_stride_bytes
+                        block_stride = logical_block_stride_bytes // 4
+                        page_size = kernel_page_bytes // 4
+                        seg_addrs.append(seg_addr)
+                        seg_block_strides.append(block_stride)
+                        seg_page_sizes.append(page_size)
+                        group_seg_addrs[group_id].append(seg_addr)
+                        group_seg_block_strides[group_id].append(block_stride)
+                        group_seg_page_sizes[group_id].append(page_size)
 
         if not seg_addrs:
-            self._meta = None
             return
 
+        self._meta = self._make_meta(seg_addrs, seg_block_strides, seg_page_sizes)
+        self._meta_by_group = [
+            self._make_meta(addrs, strides, page_sizes) if addrs else None
+            for addrs, strides, page_sizes in zip(
+                group_seg_addrs,
+                group_seg_block_strides,
+                group_seg_page_sizes,
+                strict=True,
+            )
+        ]
+
+    def _make_meta(
+        self,
+        seg_addrs: list[int],
+        seg_block_strides: list[int],
+        seg_page_sizes: list[int],
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, int, int, int]:
         max_page_size_el = max(seg_page_sizes)
         blk_size = min(1 << (max_page_size_el - 1).bit_length(), 1024)
-        self._meta = (
+        return (
             torch.tensor(seg_addrs, dtype=torch.uint64, device=self.device),
             torch.tensor(seg_block_strides, dtype=torch.int64, device=self.device),
             torch.tensor(seg_page_sizes, dtype=torch.int64, device=self.device),
@@ -209,8 +236,28 @@ class KVBlockZeroer:
         )
 
     def zero_block_ids(self, block_ids: list[int]) -> None:
-        """Zero the KV cache memory for the given block IDs."""
-        if not block_ids or self._meta is None:
+        """Zero the given block IDs in every attention cache group."""
+        self._zero_block_ids_with_meta(block_ids, self._meta)
+
+    def zero_block_ids_by_group(self, block_ids_by_group: list[list[int]]) -> None:
+        """Zero block IDs only in their owning KV cache groups."""
+        if len(block_ids_by_group) != len(self._meta_by_group):
+            raise ValueError(
+                "Expected block IDs for "
+                f"{len(self._meta_by_group)} KV cache groups, got "
+                f"{len(block_ids_by_group)}"
+            )
+        for block_ids, meta in zip(
+            block_ids_by_group, self._meta_by_group, strict=True
+        ):
+            self._zero_block_ids_with_meta(block_ids, meta)
+
+    def _zero_block_ids_with_meta(
+        self,
+        block_ids: list[int],
+        meta: tuple[torch.Tensor, torch.Tensor, torch.Tensor, int, int, int] | None,
+    ) -> None:
+        if not block_ids or meta is None:
             return
         (
             seg_addrs,
@@ -219,7 +266,7 @@ class KVBlockZeroer:
             max_chunks,
             blk_size,
             n_segs,
-        ) = self._meta
+        ) = meta
         n_blocks = len(block_ids)
         idx = async_tensor_h2d(block_ids, device=self.device, dtype=torch.int64)
         grid = (n_blocks, n_segs, max_chunks)
@@ -233,7 +280,15 @@ class KVBlockZeroer:
 
     def warmup(self, num_kv_blocks: int) -> None:
         """JIT-compile the zeroing kernel before the first real request."""
-        if num_kv_blocks > 0:
+        if num_kv_blocks <= 0:
+            return
+        if hasattr(self, "_meta_by_group"):
+            self.zero_block_ids_by_group(
+                [[0] if meta is not None else [] for meta in self._meta_by_group]
+            )
+        else:
+            # Compatibility for lightweight tests constructing the zeroer with
+            # ``__new__`` and a single aggregate metadata tuple.
             self.zero_block_ids([0])
 
 


### PR DESCRIPTION
## Purpose

#51749 correctly generalized recycled KV-page zeroing to every allocating
`AttentionSpec`, preventing stale FP8 sliding-window pages. However, the
scheduler currently flattens the newly allocated block IDs from every cache
manager, and `KVBlockZeroer` applies that union to every attention-cache
segment. On a hybrid or otherwise multi-group layout this creates unnecessary
`all new block IDs x all cache groups` work.

This PR preserves the cache-group association through `SchedulerOutput`, builds
zeroing metadata per group, and zeros each newly allocated block only in its
owning group's physical cache pages. It retains #51749's correctness coverage
and #52058's bounded 3-D launch geometry.

This is generic V1 KV-cache infrastructure, not an SM120-specific path. The
DeepSeek-V4 SM120 configuration below is the reproducer because it has five
active MLA/sliding-window managers.

### Relationship to adjacent work

- #51749 supplies the required all-`AttentionSpec` correctness coverage.
- #52058 fixed the major launch-geometry scaling problem and restored most of
  the prefill regression by using wide masked chunks on a 3-D grid.
- #50485 is alternative 3-D launch-geometry work.
- #52062 proposes reverting #51749; this PR instead preserves its stale-page
  fix while reducing the remaining redundant work.

Open PR and issue searches for `KVBlockZeroer group zeroing`,
`new_block_ids_to_zero`, `zeroing "cache group"`, and `"owning group" KV cache`
found no equivalent group-aware change.

## Test Plan

```bash
python -m pytest -q tests/v1/worker/test_kv_block_zeroer.py

python -m pytest -q \
  tests/v1/kv_connector/unit/test_nixl_connector_hma.py::test_scheduler_filters_connector_loaded_blocks_from_zeroing \
  tests/v1/kv_connector/unit/test_nixl_connector_hma.py::test_failed_load_rezeroes_unwritten_skipped_blocks \
  tests/v1/worker/test_kv_block_zeroer.py::test_large_dsv4_launch_geometry \
  tests/v1/core/test_single_type_kv_cache_manager.py::test_sliding_window_records_new_blocks_for_zeroing \
  tests/v1/core/test_single_type_kv_cache_manager.py::test_chunked_local_attention_records_new_blocks_for_zeroing

ruff format --check <changed files>
ruff check <changed files>
```

Live A/B: DeepSeek-V4-Flash-0731, 2x RTX PRO 6000 Blackwell, TP2 + EP, FP8 KV,
five cache managers, max model length 1M, FlashInfer 0.6.17. Both arms use the
same rebuilt tree and dependency set; the control is the parent commit and the
test arm adds only this commit. Each size has five sequential C=1 runs.

## Test Result

- KV block zeroer GPU suite: `9 passed`
- Focused scheduler/manager/geometry suite: `5 passed`
- MLA gather compatibility slice: `34 passed, 2437 deselected`
- Ruff format/check: passed
- Cold-load non-thinking HTTP smoke: `200`, exact `OK.`

Matched median prefill results after #52058:

| Prompt | Control TTFT | This PR TTFT | Control tok/s | This PR tok/s |
| ---: | ---: | ---: | ---: | ---: |
| 128 | 166 ms | 156 ms (-6.0%) | 919 | 966 (+5.1%) |
| 1K | 158 ms | 155 ms (-1.9%) | 6,641 | 6,753 (+1.7%) |
| 4K | 498 ms | 503 ms (+1.0%) | 8,268 | 8,189 (-1.0%) |
| 16K | 2.221 s | 2.224 s (+0.1%) | 7,382 | 7,376 (-0.1%) |

The benefit is concentrated in short-prefill latency; 4K and 16K are flat
within about 1%. Three live decode runs averaged 304.7 tok/s, unchanged from the
prior 304.0 tok/s five-run result.

AI assistance was used to bisect the original regression, implement the change,
and draft this description. I reviewed the diff and ran the validation above.
