### PR TITLE
# [kimik3][ROCm] Enable torch.compile for so post-grad fusion passes work (aiter::fused_qk_rmsnorm_kernel, aiter::allreduce_fusion_kernel_1stage)

### DIFF
--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -769,6 +769,7 @@ class CompilationConfig:
         "vllm::short_conv",
         "vllm::linear_attention",
         "vllm::qwen_gdn_attention_core",
+        "vllm::kimi_kda_attention_core",
         "vllm::gdn_attention_core_xpu",
         "vllm::olmo_hybrid_gdn_full_forward",
         "vllm::sparse_attn_indexer",

--- a/vllm/models/kimi_k3/amd/kda.py
+++ b/vllm/models/kimi_k3/amd/kda.py
@@ -38,6 +38,7 @@ from vllm.model_executor.layers.mamba.ops.gather_initial_states import (
 )
 from vllm.model_executor.model_loader.weight_utils import sharded_weight_loader
 from vllm.model_executor.utils import set_weight_attrs
+from vllm.utils.torch_utils import direct_register_custom_op
 from vllm.models.kimi_k3.amd.ops.third_party.kda import (
     chunk_kda_with_fused_gate,
     fused_recurrent_kda,
@@ -229,12 +230,13 @@ class KimiK3DeltaAttention(GatedDeltaNetAttention):
             device=hidden_states.device,
         )
 
-        self._forward(
-            mixed_qkv=mixed_qkv,
-            g1=g1,
-            g2=g2,
-            beta=beta,
-            core_attn_out=core_attn_out,
+        torch.ops.vllm.kimi_kda_attention_core(
+            mixed_qkv,
+            g1,
+            g2,
+            beta,
+            core_attn_out,
+            self.prefix,
         )
         core_attn_out = rearrange(core_attn_out, "1 n h d -> n (h d)")
         output[:] = self.o_proj(core_attn_out)[0]
@@ -528,3 +530,48 @@ class KimiK3DeltaAttention(GatedDeltaNetAttention):
         else:
             assert core_attn_out_spec is not None
         core_attn_out.copy_(self.o_norm(core_attn_out, g2))
+
+
+def kimi_kda_attention_core(
+    mixed_qkv: torch.Tensor,
+    g1: torch.Tensor,
+    g2: torch.Tensor,
+    beta: torch.Tensor,
+    core_attn_out: torch.Tensor,
+    layer_name: str,
+) -> None:
+    """Custom-op wrapper around the KDA conv1d + recurrent/chunk core.
+
+    ``core_attn_out`` is mutated in place. Registering this as a custom op
+    (and listing it in ``splitting_ops``) keeps the KDA branch visible to
+    torch.compile: without it the call has no compiler-visible effect and
+    the whole linear-attention path is eliminated from the graph.
+    """
+    forward_context = get_forward_context()
+    self = forward_context.no_compile_layers[layer_name]
+    self._forward(
+        mixed_qkv=mixed_qkv,
+        g1=g1,
+        g2=g2,
+        beta=beta,
+        core_attn_out=core_attn_out,
+    )
+
+
+def kimi_kda_attention_core_fake(
+    mixed_qkv: torch.Tensor,
+    g1: torch.Tensor,
+    g2: torch.Tensor,
+    beta: torch.Tensor,
+    core_attn_out: torch.Tensor,
+    layer_name: str,
+) -> None:
+    return
+
+
+direct_register_custom_op(
+    op_name="kimi_kda_attention_core",
+    op_func=kimi_kda_attention_core,
+    mutates_args=["core_attn_out"],
+    fake_impl=kimi_kda_attention_core_fake,
+)

--- a/vllm/models/kimi_k3/amd/latent_moe_runner.py
+++ b/vllm/models/kimi_k3/amd/latent_moe_runner.py
@@ -45,13 +45,17 @@ class ROCmLatentMoERunner(MoERunner):
         if self._tail_shardable:
             assert up_proj is not None
             self._up_proj_shard_size = up_proj.weight.shape[0] // tp_size
+            logger.info_once(
+                "Kimi-K3 latent-MoE tail: up-projecting only this rank's "
+                "hidden shard into the shared output.",
+                scope="global",
+            )
         else:
             logger.warning_once(
                 "K3 latent-MoE tail is not shardable under this config, "
                 "falling back to the replicated up-projection.",
                 scope="global",
             )
-        self._logged_sharded_tail = False
 
     def _shard_up_proj_tail(
         self,
@@ -62,14 +66,6 @@ class ROCmLatentMoERunner(MoERunner):
         """
         Tier 2: column-parallel up-projection folded into the final reduce.
         """
-        if not self._logged_sharded_tail:
-            self._logged_sharded_tail = True
-            logger.info_once(
-                "Kimi-K3 latent-MoE tail: up-projecting only this rank's "
-                "hidden shard into the shared output.",
-                scope="global",
-            )
-
         transform = self.routed_output_transform
         assert transform is not None
 

--- a/vllm/models/kimi_k3/amd/linear.py
+++ b/vllm/models/kimi_k3/amd/linear.py
@@ -7,6 +7,7 @@ from typing import Any
 import torch
 from torch import nn
 
+from vllm.compilation.decorators import support_torch_compile
 from vllm.config import CacheConfig, VllmConfig
 from vllm.distributed import (
     get_pp_group,
@@ -662,6 +663,7 @@ class KimiDecoderLayer(nn.Module):
         return prefix_sum, block_residual
 
 
+@support_torch_compile
 class KimiLinearModel(nn.Module, EagleModelMixin):
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
         super().__init__()

--- a/vllm/models/kimi_k3/amd/ops/attn_res.py
+++ b/vllm/models/kimi_k3/amd/ops/attn_res.py
@@ -11,6 +11,7 @@
 import torch
 
 from vllm.triton_utils import tl, triton
+from vllm.utils.torch_utils import direct_register_custom_op
 
 
 @triton.jit
@@ -136,7 +137,7 @@ def _attn_res_kernel(
     )
 
 
-def attn_res(
+def _attn_res_impl(
     prefix: torch.Tensor,
     delta: torch.Tensor | None,
     blocks: torch.Tensor,
@@ -191,3 +192,82 @@ def attn_res(
         num_stages=2,
     )
     return output
+
+
+def _kimi_attn_res(
+    prefix: torch.Tensor,
+    delta: torch.Tensor | None,
+    blocks: torch.Tensor,
+    norm_weight: torch.Tensor,
+    qk_weight: torch.Tensor,
+    output_norm_weight: torch.Tensor | None,
+    num_blocks: int,
+    block_write_idx: int,
+    eps: float,
+    output_norm_eps: float,
+) -> torch.Tensor:
+    return _attn_res_impl(
+        prefix, delta, blocks, norm_weight, qk_weight, output_norm_weight,
+        num_blocks, block_write_idx, eps, output_norm_eps,
+    )
+
+
+def _kimi_attn_res_fake(
+    prefix: torch.Tensor,
+    delta: torch.Tensor | None,
+    blocks: torch.Tensor,
+    norm_weight: torch.Tensor,
+    qk_weight: torch.Tensor,
+    output_norm_weight: torch.Tensor | None,
+    num_blocks: int,
+    block_write_idx: int,
+    eps: float,
+    output_norm_eps: float,
+) -> torch.Tensor:
+    return prefix.new_empty(prefix.shape)
+
+
+direct_register_custom_op(
+    op_name="kimi_attn_res",
+    op_func=_kimi_attn_res,
+    # WRITE_BLOCK=block_write_idx >= 0 makes the kernel store this layer's
+    # prefix sum into blocks[:, block_write_idx, :].
+    mutates_args=["blocks"],
+    fake_impl=_kimi_attn_res_fake,
+)
+
+
+def attn_res(
+    prefix: torch.Tensor,
+    delta: torch.Tensor | None,
+    blocks: torch.Tensor,
+    norm_weight: torch.Tensor,
+    qk_weight: torch.Tensor,
+    output_norm_weight: torch.Tensor | None,
+    num_blocks: int,
+    block_write_idx: int,
+    eps: float,
+    output_norm_eps: float,
+) -> torch.Tensor:
+    """Custom-op entry point for the attn-res kernel.
+
+    Two reasons this must not be traced by Dynamo:
+
+    * The launcher picks its tile/warp config from the token count
+      (``num_tokens == 0``, ``num_tokens >= 256``) and uses a ``(num_tokens,)``
+      grid. Traced directly, Dynamo evaluates those against the profile-run
+      batch and emits a dynamic-shape guard (``s >= 256``). vLLM drops such
+      guards, so the artifact specialised for the large-batch branch is then
+      reused for small decode batches.
+    * With ``block_write_idx >= 0`` the kernel writes into ``blocks`` in place.
+      Traced, that functionalises into ``select_scatter`` + ``copy_`` on a
+      graph input, forcing the attn-res block bank -- a buffer created inside
+      the traced region -- to be lifted to a mutated graph input.
+
+    Both showed up as failing ``assert_size_stride`` and CUDA illegal memory
+    accesses once CUDA graphs were enabled.
+    """
+    return torch.ops.vllm.kimi_attn_res(
+        prefix, delta, blocks, norm_weight, qk_weight, output_norm_weight,
+        num_blocks, block_write_idx, eps, output_norm_eps,
+    )


### PR DESCRIPTION
# [kimik3][ROCm] Enable torch.compile for so post-grad fusion passes work (aiter::fused_qk_rmsnorm_kernel, aiter::allreduce_fusion_kernel_1stage)

## Purpose

Kimi-K3's model classes carry no `@support_torch_compile` and vLLM logs:

```
`torch.compile` is turned on, but the model /path/to/Kimi-K3 does not support it.
Please open an issue on GitHub if you want it to be supported.
```

Because there is no inductor post-grad graph, **none of the fusion passes ever run
for K3** — even though they are enabled in the config and reported as active at
startup:

```
INFO [config/compilation.py] Enabled custom fusions: norm_quant, act_quant, allreduce_rms, mla_dual_rms_norm
... 'pass_config': {..., 'fuse_mla_dual_rms_norm': True, 'fuse_allreduce_rms': True, ...}
```

In particular `MLADualRMSNormFusionPass` already knows how to fuse the paired MLA
`q_a_layernorm` + `kv_a_layernorm` into AITER's `fused_qk_rmsnorm` kernel, but it
never sees a graph. Confirmed by instrumenting `VllmFusionPatternMatcherPass.__call__`:
zero pass invocations and zero pattern dumps on an otherwise fully-configured run.

This PR enables compilation so the existing passes can do their job. Two of the
three changes are **correctness fixes** that compilation exposes rather than
optimizations.

## Changes

1. **`vllm/models/kimi_k3/amd/linear.py`** — add `@support_torch_compile` to
   `KimiLinearModel`. Its `__init__(self, *, vllm_config, prefix)` and `forward`
   signatures already match the shape the decorator expects (same as
   `DeepseekV2Model`).

2. **`vllm/models/kimi_k3/amd/kda.py` + `vllm/config/compilation.py`** — wrap the
   KDA conv1d + recurrent/chunk core in a `kimi_kda_attention_core` custom op
   declaring `mutates_args=["core_attn_out"]`, and add
   `vllm::kimi_kda_attention_core` to the default `splitting_ops`.

   **This is required for correctness, not perf.** `KimiGatedDeltaNetAttention._forward`
   writes its result in place into a caller-allocated `core_attn_out` and returns
   `None`, and was not a registered custom op. Under fullgraph capture the call
   therefore has no compiler-visible effect and the entire linear-attention path is
   eliminated: with only the decorator applied, **all KDA kernels for all 69 KDA
   layers stop executing** (K3 is 24 MLA + 69 KDA), while the surrounding `o_proj`
   and MoE keep running on the uninitialized `torch.empty` buffer. It fails
   silently — no exception, no graph-break warning, just degenerate output. Follows
   the existing `vllm::qwen_gdn_attention_core` pattern.

3. **`vllm/models/kimi_k3/amd/ops/attn_res.py`** — register the attention-residual
   Triton launcher as `vllm::kimi_attn_res` with `mutates_args=["blocks"]`.

   Two problems, one op. First, the launcher picks its tile shape with a host-side
   branch on the token count:

   ```python
   if num_tokens >= 256 or num_blocks <= 1:
       block_l, num_warps = 1, 4
   else:
       block_l, num_warps = 4, 8
   ```

   Dynamo traced this, evaluated it on the large profile-run batch and emitted the
   dynamic-shape guard `s72 >= 256`. vLLM's wrapper drops guards, so the artifact
   specialized for the `>= 256` branch was silently reused for small decode
   batches. Second, with `block_write_idx >= 0` the kernel stores its prefix sum
   into `blocks` in place (`WRITE_BLOCK`), which is invisible to the compiler
   unless declared. Both are fixed by making this a custom op with the mutation
   declared; found via `TORCH_TRACE` + `tlparse`, reading the `user_stack` field of
   the raw `guard_added_fast` records.

4. **`vllm/models/kimi_k3/amd/latent_moe_runner.py`** — fullgraph capture cannot
   trace `logging.Logger` methods
   ([gb0291](https://meta-pytorch.github.io/compile-graph-break-site/gb/gb0291.html)):

   ```
   torch._dynamo.exc.Unsupported: logging.Logger method not supported for non-export cases
     Developer debug context: method: <Logger vllm.models.kimi_k3.amd.latent_moe_runner>.info_once
     from user code: latent_moe_runner.py:67 in _shard_up_proj_tail
   ```

   The one-shot diagnostic in `_shard_up_proj_tail` is hoisted into `__init__` under
   the same `self._tail_shardable` condition that gates its only call site, so the
   message is preserved and both the logger call and the `_logged_sharded_tail`
   state mutation leave the traced hot path.

**No changes to any fusion pass or pattern.** The existing DeepSeek-shaped MLA
dual-RMSNorm pattern matches K3 unmodified.

## Test Plan

Kimi-K3, MI355X, TP8, MXFP4 weights, AITER enabled. Two stacks:

- **A — upstream nightly, no spec decoding**, `--kv-cache-dtype fp8_e4m3`.
  Decode-only torch-profiler capture, three arms on identical settings
  (ISL 2048 / OSL 96 / concurrency 16, `wait_iterations=40`, `active_iterations=2`).
  All windows verified pure decode — `execute_context_0(0)_generation_16(16)`,
  zero prefill-attention kernels.
- **B — AMD downstream K3 stack with DSpark MTP + CUDA graphs**
  (`FULL_AND_PIECEWISE`, `--kv-cache-dtype fp8`, `num_speculative_tokens=2`),
  i.e. the configuration this model is actually served in. Added because
  compilation interacts with cudagraph capture and speculative decoding, and
  stack A exercises neither. Using agentX coni
- **Accuracy** — gsm8k via lm-eval against `/v1/completions`.

## Test Result

### Fusion passes now run (stack A)

Cumulative match table for one full model forward, per rank:

```
mla_dual_rms_norm_fusion_pass                  : 24   <- 1 per MLA layer (K3 has 24)
rocm_aiter_allreduce_fusion_pass               : 92   <- ~1 per layer (K3 has 93)
activation_quant_fusion_pass                   :  0
rocm_aiter_silu_mul_fp8_group_quant_fusion_pass:  0
RocmAiterRMSNormQuantFusionPass                :  0
```

`24` is exactly the MLA layer count, i.e. single coverage with no double counting.
Cross-check against the per-graph-piece `Replaced N patterns` lines: 16x1 + 8x2 +
176x4 = 736 across 8 ranks = 92/rank. Identical with and without the KDA custom
op, i.e. the new splitting op does not disturb the fusions.

### Kernel counts, pure-decode window (stack A, 2 steps, rank 0)

| kernel group | eager | decorator only | **this PR** |
|---|---|---|---|
| MLA attention (24 x 2) | 48 | 48 | **48** |
| MoE `mfma_moe1` (92 x 2) | 184 | 184 | **184** |
| KDA `causal_conv1d` + `fused_recurrent_kda` | 276 | **0** ❌ | **276** ✅ |
| `aiter::fused_qk_rmsnorm_kernel` (24 x 2) | 0 | 48 | **48** |
| `add_rmsnorm_quant` (all) | 282 | 2 | **2** |
| `aiter::allreduce_fusion_kernel_1stage` | 0 | 184 | **184** |

The middle column is the decorator applied *without* change (2) — included to show
the silent KDA loss that change (2) fixes. Corroborated independently of the
profiler by the server log: stock and this PR both log
`Triton kernel JIT compilation during inference:` for `chunk_kda_fwd_kernel_intra_sub_chunk`,
`fused_recurrent_kda_fwd_kernel`, `_causal_conv1d_fwd_kernel` and seven more
(223 / 224 lines); the decorator-only build logs **none** of them.

### Norm kernels in detail (stack A)

| Norm kernel | eager | this PR |
|---|---|---|
| `add_rmsnorm_quant` — `q_a_layernorm` | 48 x 230.392 us | — |
| `add_rmsnorm_quant` — `kv_a_layernorm` | 48 x 218.353 us | — |
| **`aiter::fused_qk_rmsnorm_kernel<bf16,256,8,true,1>`** | — | **48 x 231.194 us** |
| `add_rmsnorm_quant` — per-layer input/post-attn | 184 x 912.578 us | — (folded into allreduce fusion) |
| `add_rmsnorm_quant` — final norm | 2 x 10.718 us | 2 x 11.078 us |

96 launches / 448.745 us collapse into 48 launches / 231.194 us of
`aiter::fused_qk_rmsnorm_kernel<std::bfloat16_t, 256, 8, true, 1>`, and the 184
standalone per-layer norms are absorbed by the 92 allreduce+RMSNorm fusions.
Decode is where this matters: AITER's `_fused_qk_rmsnorm` wrapper deliberately
falls back to two separate `rmsnorm` calls at `m >= 16384` tokens, so the fused
kernel is the decode / small-batch path.

### Works under CUDA graphs + speculative decoding (stack B)

Pure-decode capture, DSpark MTP, concurrency 2 (verify batch
`2*CONC*(1+num_spec)` = 12), `FULL_AND_PIECEWISE`, 6 engine steps, rank 0.
Window verified pure decode: `execute_context_0(0)_generation_2(6)` x12, no
prefill kernels.

| kernel group | launches | per step | expected |
|---|---|---|---|
| `aiter::fused_qk_rmsnorm` | 144 | 24 | 24 MLA layers ✅ |
| `allreduce_fusion_kernel_1stage` | 558 | 93 | 93 layers ✅ |
| `fused_recurrent_kda` + `causal_conv1d_update` | 828 | 69 + 69 | 69 KDA layers ✅ |
| MLA `mla_a8w8_qh16_qseqlen4_gqaratio16_v3_ps` | 144 | 24 | 24 ✅ |

The KDA path stays fully alive at 69 layers/step with compilation, cudagraph
capture and MTP all active simultaneously, and the QK fusion covers exactly all
24 MLA layers.

Trace showing Cuda graph + MTP + compiler pass fusions active
<img width="2890" height="687" alt="image" src="https://github.com/user-attachments/assets/0c93dcd2-6533-4c7b-b48c-17aacd781306" />

### Accuracy — no regression

| stack | harness | baseline | this PR |
|---|---|---|---|
| A (no spec decode) | gsm8k, full 1319, 5-shot, greedy | 0.9098 ± 0.0079 | **0.9257 ± 0.0072** |
| B (DSpark MTP + cudagraph) | gsm8k, 250-sample, 5-shot | 0.988 | **0.984** |

Stack A's delta is within ~1.5 combined standard errors. Stack B was run with
`rejection_sample_method=block`; the `synthetic` variant is a throughput
approximation and is not a valid accuracy configuration.

## Known limitation: CUDA graph capture ladder (stack B)

On the AMD downstream MTP stack, enabling compilation narrows the range of CUDA
graph capture sizes that can be captured. Outside that range the **per-size warmup
forward** — before any capture begins, descending from the largest size — dies with
`Memory access fault by GPU node-N`.

**Root cause is not yet understood.** It is reported here rather than left for a
reviewer to hit. Note this is observed only on the downstream stack — the DSpark
MTP method and that cudagraph path are not upstream — so it may not be reachable
from an upstream configuration. It does not affect stack A, which captures the
default ladder without incident.


