### PR TITLE
[Kernel] Add tuned fused_moe config for NVIDIA GB10 (Nemotron-3-Super shape, E=512 N=2688)

### DIFF
--- a/vllm/model_executor/layers/fused_moe/configs/E=512,N=2688,device_name=NVIDIA_GB10.json
+++ b/vllm/model_executor/layers/fused_moe/configs/E=512,N=2688,device_name=NVIDIA_GB10.json
@@ -1,0 +1,97 @@
+{
+    "1": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 5
+    },
+    "2": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 8,
+        "num_stages": 3
+    },
+    "4": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "8": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 5
+    },
+    "16": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "SPLIT_K": 1,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "32": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "SPLIT_K": 1,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "64": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "SPLIT_K": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "256": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "SPLIT_K": 1,
+        "num_warps": 8,
+        "num_stages": 3
+    },
+    "1024": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "SPLIT_K": 1,
+        "num_warps": 8,
+        "num_stages": 3
+    },
+    "2048": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "SPLIT_K": 1,
+        "num_warps": 8,
+        "num_stages": 3
+    },
+    "4096": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "SPLIT_K": 1,
+        "num_warps": 8,
+        "num_stages": 3
+    }
+}


### PR DESCRIPTION
**Problem.** No `E=512,N=2688,device_name=NVIDIA_GB10` config exists: every Nemotron-3-Super serve on a DGX Spark falls back to the default heuristic and logs "Using default MoE config. Performance might be sub-optimal!" Second config for this device, first for this shape (#45949 covers E=512,N=512 fp8).

**What's in the file.** Decode keys M=1,2,4,8 tuned on hardware; rows at M=16,32,64,256,1024,2048,4096 pinned to the default heuristic's own per-M choices. The pins are required: `try_get_optimal_moe_config` snaps to the nearest key with no fallback, and a tuned-keys-only ladder measured −2.35% on pp2048 (prefill-scale M landing on a small-M config); the pinned rows make large-M lookups exactly-stock. The ladder stops at M=8 because the stock tuner cannot complete this shape on unified memory (companion issue to follow — [#MEMORY-ISSUE]); extension is mechanical.

**Evidence.**
- Kernel-level A/B (CUDA-event, same boot): +2.3% to +5.2% per decode key, **+3.5% geomean** over the default heuristic.
- Serve-level paired A/B (12 boots): pp2048 −0.59% [−1.74, +0.55] (n=32/arm); serve decode a wash (+0.09% [−2.56, +2.75]). We claim the kernel-level win only, not an end-to-end speedup.
- The startup warning clears with the config present (verified in the leg-B serve log).
- Environment: vLLM 83ad767ee, driver 610.57.04, GB10 121 GB unified.