### PR TITLE
[LoRA][MoE] Fix PEFT 0.18+ target_parameters LoRA loading for 3D MoE experts

### DIFF
--- a/tests/lora/test_lora_manager.py
+++ b/tests/lora/test_lora_manager.py
@@ -74,6 +74,52 @@ def test_from_lora_tensors(qwen3_lora_files, device):
         assert lora.lora_a.shape[0] == 8
 
 
+def test_from_lora_tensors_propagates_target_parameters(qwen3_lora_files):
+    """A PEFT 0.18+ ``target_parameters`` list flows from PEFTHelper onto the
+    built LoRAModel, so 3D MoE LoRA loading can read it. Older adapters (no
+    target_parameters) yield None.
+    """
+    tensors = load_file(os.path.join(qwen3_lora_files, "adapter_model.safetensors"))
+    peft_helper = PEFTHelper.from_local_dir(
+        qwen3_lora_files, max_position_embeddings=4096
+    )
+
+    peft_helper.target_parameters = ["mlp.experts.gate_up_proj"]
+    lora_model = LoRAModel.from_lora_tensors(1, tensors, peft_helper=peft_helper)
+    assert lora_model.target_parameters == ["mlp.experts.gate_up_proj"]
+    # clone() must preserve it (fresh list, not a shared reference).
+    cloned = lora_model.clone(2)
+    assert cloned.target_parameters == ["mlp.experts.gate_up_proj"]
+    assert cloned.target_parameters is not lora_model.target_parameters
+
+    peft_helper.target_parameters = None
+    legacy = LoRAModel.from_lora_tensors(3, tensors, peft_helper=peft_helper)
+    assert legacy.target_parameters is None
+
+
+@pytest.mark.parametrize(
+    "target_parameters,expected",
+    [
+        (None, False),
+        ([], False),
+        (["q_proj", "v_proj"], False),
+        (["mlp.experts.gate_up_proj"], True),
+        (["model.layers.0.mlp.experts.down_proj"], True),
+        (["mlp.experts.w13_weight", "mlp.experts.w2_weight"], True),
+    ],
+)
+def test_target_parameters_indicates_3d_lora(target_parameters, expected):
+    """The 3D-layout discriminator fires only when target_parameters names a
+    fused MoE expert weight -- matched by suffix so both a bare name and a
+    fully-qualified path resolve. A plain LoRA (or none) must not trip it,
+    otherwise native/dummy MoE adapters would be wrongly transposed.
+    """
+    lora_model = LoRAModel(1, 8, {}, target_parameters=target_parameters)
+    assert (
+        LoRAModelManager._target_parameters_indicates_3d_lora(lora_model) is expected
+    )
+
+
 def create_lora(
     lora_id: int, model: nn.Module, sub_modules: list[str], device: torch.device
 ) -> LoRAModel:

--- a/tests/lora/test_peft_helper.py
+++ b/tests/lora/test_peft_helper.py
@@ -101,6 +101,33 @@ def test_peft_helper_error(
         ).validate_legal(lora_config)
 
 
+def test_peft_helper_target_parameters_direct():
+    """PEFT 0.18+ records ``target_parameters`` when LoRA is trained against a
+    fused nn.Parameter (e.g. a 3D MoE expert weight) instead of an nn.Module.
+    PEFTHelper must round-trip it so 3D MoE LoRA loading can detect the layout.
+
+    Network-free: constructs PEFTHelper.from_dict() rather than reading an
+    on-disk adapter_config.json.
+    """
+    config = {
+        "r": 8,
+        "lora_alpha": 16,
+        "target_modules": ["q_proj"],
+        "target_parameters": ["mlp.experts.gate_up_proj", "mlp.experts.down_proj"],
+    }
+    peft_helper = PEFTHelper.from_dict(config)
+    assert peft_helper.target_parameters == [
+        "mlp.experts.gate_up_proj",
+        "mlp.experts.down_proj",
+    ]
+
+    # Absent in older adapters -> defaults to None, not a crash.
+    legacy = PEFTHelper.from_dict(
+        {"r": 8, "lora_alpha": 16, "target_modules": ["q_proj"]}
+    )
+    assert legacy.target_parameters is None
+
+
 @pytest.mark.parametrize("bad_rank", [0, -1, -8])
 def test_peft_helper_invalid_rank_direct(bad_rank: int):
     """Regression test: constructing a PEFTHelper with a non-positive rank

--- a/vllm/lora/lora_model.py
+++ b/vllm/lora/lora_model.py
@@ -66,6 +66,7 @@ class LoRAModel:
         rank: int,
         loras: dict[str, LoRALayerWeights],
         is_3d_lora_weight: bool = False,
+        target_parameters: list[str] | None = None,
     ) -> None:
         """
         Args:
@@ -76,6 +77,9 @@ class LoRAModel:
                 fused (gate_up_proj / down_proj) layout. Propagated from the
                 originating LoRARequest. Only consulted by the LoRA model
                 manager when enable_mixed_moe_lora_format is on.
+            target_parameters: the PEFT 0.18+ ``target_parameters`` list from
+                adapter_config.json, propagated for downstream consumers (e.g.
+                _stack_moe_lora_weights) to detect the loaded 3D MoE layout.
 
         """
         self.id = lora_model_id
@@ -86,6 +90,7 @@ class LoRAModel:
         self.rank = rank
         self.loras: dict[str, LoRALayerWeights] = loras
         self.is_3d_lora_weight = is_3d_lora_weight
+        self.target_parameters: list[str] | None = target_parameters
 
     def clone(self, lora_model_id: int) -> "LoRAModel":
         """Return a copy of the object with different ids.
@@ -96,6 +101,11 @@ class LoRAModel:
             rank=self.rank,
             loras=self.loras.copy(),
             is_3d_lora_weight=self.is_3d_lora_weight,
+            target_parameters=(
+                list(self.target_parameters)
+                if self.target_parameters is not None
+                else None
+            ),
         )
 
     def get_lora(self, module_name: str) -> LoRALayerWeights | None:
@@ -161,7 +171,12 @@ class LoRAModel:
                 if pin_memory:
                     loras[module_name].lora_b = loras[module_name].lora_b.pin_memory()
 
-        return cls(lora_model_id, peft_helper.r, loras)
+        return cls(
+            lora_model_id,
+            peft_helper.r,
+            loras,
+            target_parameters=peft_helper.target_parameters,
+        )
 
     @classmethod
     def from_local_checkpoint(

--- a/vllm/lora/model_manager.py
+++ b/vllm/lora/model_manager.py
@@ -842,6 +842,25 @@ class LoRAModelManager:
                     lora.lora_a = lora.lora_a.pin_memory()
                     lora.lora_b = lora.lora_b.pin_memory()
 
+    @staticmethod
+    def _target_parameters_indicates_3d_lora(lora_model: LoRAModel) -> bool:
+        """Whether the adapter's PEFT 0.18+ ``target_parameters`` names a fused
+        MoE expert weight.
+
+        A match signals the on-disk tensors follow the PEFT 3D layout (lora_A
+        applied to PEFT's "in" = the layer's output axis) rather than
+        vLLM-native. Match by suffix so both ``mlp.experts.gate_up_proj`` and a
+        fully-qualified prefix resolve.
+        """
+        target_parameters = lora_model.target_parameters or []
+        keywords = (
+            "experts.gate_up_proj",
+            "experts.down_proj",
+            "experts.w13_weight",
+            "experts.w2_weight",
+        )
+        return any(any(kw in tp for kw in keywords) for tp in target_parameters)
+
     def _stack_moe_lora_weights(
         self, lora_model: LoRAModel, module: FusedMoE3DWithLoRA, module_name: str
     ):
@@ -872,30 +891,68 @@ class LoRAModelManager:
                 ep_rank = module.ep_rank
                 expert_start = ep_rank * local_num_experts
                 expert_end = expert_start + local_num_experts
+                hidden_size = module.hidden_size
 
-                # (num_experts,rank,input_size)
+                # PEFT 0.18+ target_parameters against a fused 3D expert tensor
+                # [E, dim1, dim2] saves lora_a[E*r, in=dim1] / lora_b[out=dim2,
+                # E*r], reading the parameter positionally as [E, in, out]. For
+                # Qwen3-MoE that flips the forward semantics: PEFT's "in" is the
+                # layer's output side and PEFT's "out" is the input side.
+                # vLLM's create_dummy_lora_weights uses the opposite (native)
+                # layout; the two share a flat shape but have opposite dim
+                # semantics, so we disambiguate. Primary signal: target_parameters
+                # names a fused expert weight. Fallback: native lora_a trailing
+                # dim == hidden_size.
+                if lora_model.target_parameters:
+                    is_peft_layout = self._target_parameters_indicates_3d_lora(
+                        lora_model
+                    )
+                else:
+                    is_peft_layout = gate_up_proj_lora.lora_a.shape[-1] != hidden_size
+
+                # Reshape + EP-slice to this rank's owned expert range (same for
+                # both layouts). For non-EP (local == global) the slice is a
+                # no-op. Result: lora_a [E_local, r, in], lora_b [E_local, out, r].
                 gate_up_proj_lora.lora_a = gate_up_proj_lora.lora_a.reshape(
                     global_num_experts, -1, gate_up_proj_lora.lora_a.shape[-1]
                 )[expert_start:expert_end].contiguous()
                 down_proj_lora.lora_a = down_proj_lora.lora_a.reshape(
                     global_num_experts, -1, down_proj_lora.lora_a.shape[-1]
                 )[expert_start:expert_end].contiguous()
+                gate_up_proj_lora.lora_b = (
+                    gate_up_proj_lora.lora_b.reshape(
+                        gate_up_proj_lora.lora_b.shape[0], -1, global_num_experts
+                    )[..., expert_start:expert_end]
+                    .permute(2, 0, 1)
+                    .contiguous()
+                )
+                down_proj_lora.lora_b = (
+                    down_proj_lora.lora_b.reshape(
+                        down_proj_lora.lora_b.shape[0], -1, global_num_experts
+                    )[..., expert_start:expert_end]
+                    .permute(2, 0, 1)
+                    .contiguous()
+                )
 
-                # (output_size,rank,num_experts)
-                gate_up_proj_lora.lora_b = gate_up_proj_lora.lora_b.reshape(
-                    gate_up_proj_lora.lora_b.shape[0], -1, global_num_experts
-                )[..., expert_start:expert_end]
-                down_proj_lora.lora_b = down_proj_lora.lora_b.reshape(
-                    down_proj_lora.lora_b.shape[0], -1, global_num_experts
-                )[..., expert_start:expert_end]
-
-                # (num_experts,output_size,rank)
-                gate_up_proj_lora.lora_b = gate_up_proj_lora.lora_b.permute(
-                    2, 0, 1
-                ).contiguous()
-                down_proj_lora.lora_b = down_proj_lora.lora_b.permute(
-                    2, 0, 1
-                ).contiguous()
+                if is_peft_layout:
+                    # PEFT A/B trade roles vs vLLM's add_lora_w13/w2 kernels, and
+                    # each expert's delta is transposed. Swap A<->B and transpose
+                    # the trailing two dims so the buffers match [E, r, in] and
+                    # [E, out, r]. Per expert: delta_vllm = delta_peft^T.
+                    peft_gu_a, peft_gu_b = (
+                        gate_up_proj_lora.lora_a,
+                        gate_up_proj_lora.lora_b,
+                    )
+                    peft_dn_a, peft_dn_b = (
+                        down_proj_lora.lora_a,
+                        down_proj_lora.lora_b,
+                    )
+                    # vLLM A = PEFT B^T (applied to the layer input)
+                    gate_up_proj_lora.lora_a = peft_gu_b.transpose(-2, -1).contiguous()
+                    down_proj_lora.lora_a = peft_dn_b.transpose(-2, -1).contiguous()
+                    # vLLM B = PEFT A^T (produces the layer output)
+                    gate_up_proj_lora.lora_b = peft_gu_a.transpose(-2, -1).contiguous()
+                    down_proj_lora.lora_b = peft_dn_a.transpose(-2, -1).contiguous()
 
                 module_lora.lora_a = [
                     gate_up_proj_lora.lora_a,

--- a/vllm/lora/peft_helper.py
+++ b/vllm/lora/peft_helper.py
@@ -31,6 +31,12 @@ class PEFTHelper:
 
     bias: Literal["none"] = field(default="none")
     modules_to_save: list[str] | None = field(default=None)
+    # PEFT 0.18+ `target_parameters`: parameter-path suffixes (e.g.
+    # "mlp.experts.gate_up_proj") for which LoRA was trained against an
+    # nn.Parameter instead of an nn.Module. Consumed by 3D MoE LoRA loading in
+    # model_manager._stack_moe_lora_weights to disambiguate the PEFT vs
+    # vLLM-native lora_A/B layout.
+    target_parameters: list[str] | None = field(default=None)
     # True to use Rank-Stabilized LoRA (rsLoRA, see: https://arxiv.org/abs/2312.03732)
     use_rslora: bool = field(default=False)
     # True to use Weight-Decomposed Low-Rank Adaptation (DoRA, see: https://arxiv.org/abs/2402.09353)


### PR DESCRIPTION
# [LoRA][MoE] Fix PEFT 0.18+ `target_parameters` LoRA loading for 3D MoE experts

## Summary

PEFT 0.18+ can train a LoRA against a **fused 3D MoE expert parameter** via
`target_parameters` (e.g. `mlp.experts.gate_up_proj` / `down_proj`) rather than
against an `nn.Module`. When it does, it reads the parameter `[E, dim1, dim2]`
positionally as `[E, in=dim1, out=dim2]`. vLLM's `add_lora_w13` / `add_lora_w2`
punica kernels use the opposite `nn.Linear` `[out, in]` convention, so per
expert the trained delta is the transpose of what vLLM expects:
`ΔW_vllm = ΔW_peft^T`.

On stock vLLM this is **not** a silent no-op — `_stack_moe_lora_weights`
reshapes the adapter with the wrong dimension semantics and `set_lora` raises a
shape mismatch that kills the engine. Serving a real Qwen3.5-35B-A3B
(`Qwen3_5MoeForConditionalGeneration`) expert LoRA fails in
`vllm/lora/layers/fused_moe.py`:

```
RuntimeError: The size of tensor a (512) must match the size of tensor b (2048)
              at non-singleton dimension 2
```

(512 = `moe_intermediate_size`, 2048 = `hidden_size`.)

## Fix

1. **`peft_helper.py`** — parse the `target_parameters` list from
   `adapter_config.json`.
2. **`lora_model.py`** — propagate `target_parameters` onto `LoRAModel`
   (constructor, `clone()`, and `from_lora_tensors`).
3. **`model_manager.py`** — in `_stack_moe_lora_weights`, detect the PEFT 3D
   layout and, when present, swap `lora_A`/`lora_B` and transpose the trailing
   two dims **after** the existing EP-aware expert slicing (so the fix composes
   with expert parallelism).

### Why the layout must be *detected*, not assumed

`create_dummy_lora_weights` builds dummy MoE LoRA buffers in the **native**
layout that shares the same flat shape as the PEFT layout, so an unconditional
transpose would corrupt native/dummy adapters. Detection uses:

- **Primary signal:** `target_parameters` names a fused expert weight
  (`experts.gate_up_proj` / `experts.down_proj` / `experts.w13_weight` /
  `experts.w2_weight`).
- **Fallback** (older adapters that don't record `target_parameters`): native
  `lora_a` trailing dim equals `hidden_size`; the PEFT layout does not.

## Testing

All results below were produced against this branch's **source** (editable
install, `VLLM_USE_PRECOMPILED=1 uv pip install -e .`) on an H200 — not a
monkeypatch over a released wheel.

### Unit tests (added in this change)

```
python -m pytest -v \
  tests/lora/test_peft_helper.py::test_peft_helper_target_parameters_direct \
  tests/lora/test_lora_manager.py::test_target_parameters_indicates_3d_lora \
  tests/lora/test_lora_manager.py::test_from_lora_tensors_propagates_target_parameters \
  tests/lora/test_peft_helper.py::test_peft_helper_pass \
  tests/lora/test_lora_manager.py::test_from_lora_tensors
```

→ **10 passed** (the discriminator test is parametrized over 6 cases). The last
two are pre-existing tests on adjacent code, included as a regression check.

### End-to-end numerical proof (Qwen3.5-35B-A3B expert LoRA)

Bug reproduced: serving the raw PEFT adapter on the **unpatched** loader crashes
in `set_lora` with the `512 vs 2048` error above.

With the fix, three arms are compared by **chosen-token logprobs** (see caveat):
base (no adapter), an independent offline-converted oracle (native layout,
self-checks `max|ΔW_vllm − ΔW_peft^T| = 0.000e+00` over 320 experts), and the
raw PEFT adapter loaded directly.

| prompt | [effect] oracle-vs-base max\|Δlogprob\| | [equiv] raw-vs-oracle max\|Δlogprob\| |
|---|---|---|
| chest pain dx | 0.2808 | 0.0000 |
| night blindness | 0.1846 | 0.0000 |
| neonatal meningitis | 0.1028 | 0.0000 |
| diabetic antihypertensive | 0.1601 | 0.0000 |
| PKU enzyme | 0.0758 | 0.0000 |

- **[effect]** the adapter demonstrably changes output (one prompt even flips
  the greedy answer ordering).
- **[equiv]** the directly-loaded raw adapter is **bit-identical** to the
  offline-converted oracle across all 32 tokens × 5 prompts, no greedy-path
  divergence → the in-loader transpose matches the independently-verified
  transform. **VERDICT: PASS.**

**Testing caveat (why logprobs, not decoded text):** for an experts-only
(8-of-256, rank-32) adapter, greedy decoded text is a false-negative trap — the
adapter shifts logits substantially yet often does not flip the greedy argmax on
short prompts, so text can look identical to base even when the adapter is
correctly applied. The verdict is therefore numerical.

## Model evaluation

This change is the difference between a hard crash and a correctly-applied
adapter for the affected adapter class; the numerical equivalence-vs-oracle
result above is the output-affecting evidence. Broader `tests/evals/` accuracy
runs can be added if reviewers want them.

## AI assistance disclosure

AI assistance (Claude) was used to author this change. A human submitter has
reviewed every changed line and run the tests above.
