### PR TITLE
Support DSpark configs with `architectures=DSparkDraftModel` + `model_type=qwen3`

### DIFF
--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -950,6 +950,10 @@ class SpeculativeConfig:
                     "dspark" in self.draft_model_config.model.lower()
                     or "Qwen3DSparkModel" in self.draft_model_config.architectures
                     or "Gemma4DSparkModel" in self.draft_model_config.architectures
+                    or (
+                        "DSparkDraftModel" in self.draft_model_config.architectures
+                        and self.draft_model_config.hf_config.model_type == "qwen3"
+                    )
                 ):
                     self.method = "dspark"
                 elif self.draft_model_config.hf_config.model_type == "medusa":
@@ -1007,7 +1011,16 @@ class SpeculativeConfig:
                         self.draft_model_config.hf_config = eagle_config
                         self.update_arch_()
 
-                if self.method == "dspark" and (
+                if (
+                    self.method == "dspark"
+                    and "DSparkDraftModel" in self.draft_model_config.architectures
+                    and self.draft_model_config.hf_config.model_type == "qwen3"
+                ):
+                    self.draft_model_config.hf_config.architectures = [
+                        "Qwen3DSparkModel"
+                    ]
+                    self.update_arch_()
+                elif self.method == "dspark" and (
                     "Qwen3DSparkModel" not in self.draft_model_config.architectures
                     and "Gemma4DSparkModel" not in self.draft_model_config.architectures
                     and "K3DSparkModel" not in self.draft_model_config.architectures


### PR DESCRIPTION



## Purpose

Generic Qwen `DSparkDraftModel` is now normalized to `Qwen3DSparkModel` so models like https://huggingface.co/RadixArk/Qwen3.8-2.4T-A95B-DSpark can now run on vLLM

## Test Plan

## Test Result

Tested gsm8k with 
```
vllm serve mgoin/Qwen3.8-2.4T-A95B-NVFP4-pruned75 -tp=4 --spec-model RadixArk/Qwen3.8-2.4T-A95B-DSpark --spec-method dspark --spec-tokens 7
...
(APIServer pid=2078258) INFO 08-13 17:48:18 [metrics.py:120] SpecDecoding metrics: Mean acceptance length: 4.90, Accepted throughput: 1537.03 tokens/s, Drafted throughput: 2757.00 tokens/s, Accepted: 15372 tokens, Drafted: 27573 tokens, Per-position acceptance rate: 0.901, 0.795, 0.667, 0.550, 0.436, 0.327, 0.225, Avg Draft acceptance rate: 55.8%
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

