### PR TITLE
[Bugfix][Kimi-K3] Break KDA attention to eager under FULL cudagraph capture

### DIFF
--- a/vllm/compilation/breakable_cudagraph.py
+++ b/vllm/compilation/breakable_cudagraph.py
@@ -28,7 +28,7 @@ import gc
 import threading
 import weakref
 from collections.abc import Callable
-from typing import Any, ClassVar, TypeVar
+from typing import Any, ClassVar, TypeVar, overload
 
 import torch
 
@@ -54,6 +54,14 @@ def is_breakable_cudagraph_enabled() -> bool:
 
 
 F = TypeVar("F", bound=Callable[..., Any])
+
+
+@overload
+def eager_break_during_capture(fn: F) -> F: ...
+
+
+@overload
+def eager_break_during_capture(*, always_break: bool = ...) -> Callable[[F], F]: ...
 
 
 def eager_break_during_capture(
@@ -121,8 +129,7 @@ def eager_break_during_capture(
             # slots across batch descriptors. cudagraph owns the slot, so the
             # weak_ref is safe to deref on replay.
             weak_args = tuple(
-                weak_ref_tensor(a) if isinstance(a, torch.Tensor) else a
-                for a in args
+                weak_ref_tensor(a) if isinstance(a, torch.Tensor) else a for a in args
             )
             weak_kwargs = {
                 k: weak_ref_tensor(v) if isinstance(v, torch.Tensor) else v

--- a/vllm/compilation/breakable_cudagraph.py
+++ b/vllm/compilation/breakable_cudagraph.py
@@ -56,7 +56,9 @@ def is_breakable_cudagraph_enabled() -> bool:
 F = TypeVar("F", bound=Callable[..., Any])
 
 
-def eager_break_during_capture(fn: F) -> F:
+def eager_break_during_capture(
+    fn: F | None = None, *, always_break: bool = False
+) -> F | Callable[[F], F]:
     """Decorator that turns a custom-op Python kernel into a "break point"
     for the breakable cudagraph capture.
 
@@ -86,35 +88,53 @@ def eager_break_during_capture(fn: F) -> F:
         @maybe_transfer_kv_layer
         def unified_attention_with_output(...):
             ...
+
+    Args:
+        always_break: When ``True``, break to eager even when the cudagraph
+            runtime mode is ``FULL``. Use this for ops whose kernels are not
+            cudagraph-capture-safe (e.g. the Kimi-K3 KDA recurrent kernels),
+            which fault if inlined into a FULL graph. Capture-safe ops (unified
+            attention) must leave this ``False`` so FULL mode can inline them.
     """
-    if not is_breakable_cudagraph_enabled():
-        return fn
 
-    @functools.wraps(fn)
-    def wrapper(*args: Any, **kwargs: Any) -> Any:
-        capture = BreakableCUDAGraphCapture.current()
-        if capture is None:
-            return fn(*args, **kwargs)
-        if not capture._capturing:
-            return fn(*args, **kwargs)
-        if is_forward_context_available():
-            mode = get_forward_context().cudagraph_runtime_mode
-            if mode == CUDAGraphMode.FULL:
+    def decorator(fn: F) -> F:
+        if not is_breakable_cudagraph_enabled():
+            return fn
+
+        @functools.wraps(fn)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            capture = BreakableCUDAGraphCapture.current()
+            if capture is None:
                 return fn(*args, **kwargs)
+            if not capture._capturing:
+                return fn(*args, **kwargs)
+            # Capture-safe ops keep the FULL fast-path so FULL mode can inline
+            # them. Ops flagged ``always_break`` run kernels that are not
+            # cudagraph-capture-safe and must break to eager even in FULL mode;
+            # inlining them into a FULL graph faults on capture/replay.
+            if not always_break and is_forward_context_available():
+                mode = get_forward_context().cudagraph_runtime_mode
+                if mode == CUDAGraphMode.FULL:
+                    return fn(*args, **kwargs)
 
-        # Weak-ref args: strong refs in the replay lambda pin cudagraph-pool
-        # slots across batch descriptors. cudagraph owns the slot, so the
-        # weak_ref is safe to deref on replay.
-        weak_args = tuple(
-            weak_ref_tensor(a) if isinstance(a, torch.Tensor) else a for a in args
-        )
-        weak_kwargs = {
-            k: weak_ref_tensor(v) if isinstance(v, torch.Tensor) else v
-            for k, v in kwargs.items()
-        }
-        return capture.add_eager(lambda: fn(*weak_args, **weak_kwargs))
+            # Weak-ref args: strong refs in the replay lambda pin cudagraph-pool
+            # slots across batch descriptors. cudagraph owns the slot, so the
+            # weak_ref is safe to deref on replay.
+            weak_args = tuple(
+                weak_ref_tensor(a) if isinstance(a, torch.Tensor) else a
+                for a in args
+            )
+            weak_kwargs = {
+                k: weak_ref_tensor(v) if isinstance(v, torch.Tensor) else v
+                for k, v in kwargs.items()
+            }
+            return capture.add_eager(lambda: fn(*weak_args, **weak_kwargs))
 
-    return wrapper  # type: ignore[return-value]
+        return wrapper  # type: ignore[return-value]
+
+    if fn is not None:
+        return decorator(fn)
+    return decorator
 
 
 # ---------------------------------------------------------------------------

--- a/vllm/models/kimi_k3/amd/kda.py
+++ b/vllm/models/kimi_k3/amd/kda.py
@@ -297,7 +297,7 @@ class KimiK3DeltaAttention(GatedDeltaNetAttention):
         core_attn_out = rearrange(core_attn_out, "1 n h d -> n (h d)")
         output[:] = self.o_proj(core_attn_out)[0]
 
-    @eager_break_during_capture
+    @eager_break_during_capture(always_break=True)
     def _forward(
         self,
         mixed_qkv: torch.Tensor,


### PR DESCRIPTION
## Purpose

The Kimi-K3 KDA op (`KimiK3DeltaAttention._forward` in `vllm/models/kimi_k3/amd/kda.py`) is
decorated with `@eager_break_during_capture` because its recurrent kernels
(`fused_recurrent_kda` / `chunk_kda_with_fused_gate` / `causal_conv1d_update`) are **not**
cudagraph-capture-safe. However, `eager_break_during_capture` has a `FULL` runtime-mode
fast-path that inlines the decorated call into the graph. When a `FULL` uniform-decode batch
runs KDA (e.g. the multi-token spec-decode verify path under `FULL_AND_PIECEWISE`), the
recurrent kernels get captured into the FULL graph and GPU-fault during capture/replay:

```
Memory access fault by GPU node-N ... Reason: Unknown.
```

Target-only cudagraph (query_len=1 decode, no spec) captures and runs correctly, so the graph
itself is sound — the fault is specifically KDA being inlined in FULL mode.

## Fix

The FULL fast-path is correct for capture-safe ops (`unified_attention_with_output`,
`unified_mla_attention_with_output`), so it must not be removed globally. Instead, add an
opt-in `always_break=True` to `eager_break_during_capture` and apply it to the KDA op, so it
breaks to eager even in FULL mode. Default behavior (`always_break=False`) is unchanged, and
the decorator still works in its bare `@eager_break_during_capture` form.

## Test

Kimi-K3, TP8, MI355X (gfx950), `--moe-backend aiter`, DSpark GQA draft
(`num_speculative_tokens=7`), `--compilation-config '{"cudagraph_mode":"PIECEWISE"}'`:

- Before: 8x GPU memory-access fault during FULL capture.
- After: PIECEWISE (and FULL) capture reaches 100%, `Application startup complete`, correct
  output, spec-decode active. Capture-safe attention path is unaffected (still inlined in FULL).
