### PR TITLE
[bot] Fix Gemma4-E2B heterogeneous per-layer config support

### DIFF
--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -699,6 +699,30 @@ def get_config(
         **kwargs,
     )
 
+    # For transformers 5.x heterogeneous per-layer configs (e.g. gemma4),
+    # allow global attribute access so vLLM can read head_dim etc. uniformly.
+    if hasattr(config, "allow_global_per_layer_attribute_access"):
+        config.allow_global_per_layer_attribute_access = True
+    # Also apply to text_config if present
+    text_config = getattr(config, "text_config", None)
+    if text_config is not None and hasattr(
+        text_config, "allow_global_per_layer_attribute_access"
+    ):
+        text_config.allow_global_per_layer_attribute_access = True
+        # For gemma4-style heterogeneous configs, synthesize global_head_dim
+        # from per-layer configs so vLLM model code can find it.
+        per_layer = getattr(text_config, "per_layer_config", None)
+        if per_layer and not hasattr(text_config, "global_head_dim"):
+            layer_types = getattr(text_config, "layer_types", [])
+            for i, lt in enumerate(layer_types):
+                if lt == "full_attention" and i < len(per_layer):
+                    full_head_dim = getattr(per_layer[i], "head_dim", None)
+                    if full_head_dim and full_head_dim != getattr(
+                        text_config, "head_dim", None
+                    ):
+                        text_config.global_head_dim = full_head_dim
+                    break
+
     # Patching defaults for GGUF models
     if _is_gguf:
         # Some models have different default values between GGUF and HF.

--- a/vllm/transformers_utils/model_arch_config_convertor.py
+++ b/vllm/transformers_utils/model_arch_config_convertor.py
@@ -453,8 +453,22 @@ class Gemma4ModelArchConfigConvertor(ModelArchConfigConvertorBase):
         # Gemma4 uses dual head dimensions: head_dim (sliding attention)
         # and global_head_dim (full attention).  Return the largest so
         # that attention backends allocate buffers large enough for both.
-        head_dim = getattr(self.hf_text_config, "head_dim", 0)
-        global_head_dim = getattr(self.hf_text_config, "global_head_dim", 0)
+        try:
+            head_dim = getattr(self.hf_text_config, "head_dim", 0)
+        except Exception:
+            head_dim = 0
+        try:
+            global_head_dim = getattr(self.hf_text_config, "global_head_dim", 0)
+        except Exception:
+            global_head_dim = 0
+        # If per-layer config, try accessing from layer configs directly
+        if head_dim == 0 and hasattr(self.hf_text_config, "per_layer_config"):
+            per_layer = self.hf_text_config.per_layer_config
+            if per_layer:
+                head_dim = getattr(per_layer[0], "head_dim", 0)
+                global_head_dim = max(
+                    getattr(lc, "head_dim", 0) for lc in per_layer
+                )
         return max(head_dim, global_head_dim) or super().get_head_size()
 
 


### PR DESCRIPTION
## Motivation

Gemma4-E2B (`google/gemma-4-E2B-it`) uses transformers 5.x heterogeneous per-layer configs, where `head_dim` is stored per-layer rather than as a flat global attribute. This breaks vLLM's uniform config attribute access, causing failures on model load.

## Technical Details

1. **`config.py`**: Enable `allow_global_per_layer_attribute_access` on both top-level and `text_config` so vLLM can read attributes globally. Synthesize `global_head_dim` from the first `full_attention` layer's per-layer config when it differs from the sliding attention `head_dim`.

2. **`model_arch_config_convertor.py`**: Make `Gemma4ModelArchConfigConvertor.get_head_size()` resilient to per-layer config format by:
   - Wrapping `getattr` in try/except (some config objects raise on missing attrs)
   - Falling back to reading `head_dim` directly from `per_layer_config` entries
   - Taking the max across all layer configs for `global_head_dim`

## Performance Impact

No performance impact — config-loading-only change. Enables Gemma4-E2B to load and run on Intel XPU (tested on Arc Pro B60 and Max 1550).

## Hardware

- Intel Arc Pro B60 (24 GB)
- Intel Data Center GPU Max 1550 (68.7 GB)