### PR TITLE
[Bugfix][GDN] Make non-spec state_indices contiguous for the recurrent decode kernel

### DIFF
--- a/vllm/v1/attention/backends/gdn_attn.py
+++ b/vllm/v1/attention/backends/gdn_attn.py
@@ -258,6 +258,16 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
             non_spec_token_indx = None
             spec_state_indices_tensor = None
             non_spec_state_indices_tensor = block_table_tensor[:, 0]
+            # The recurrent decode kernel requires a 1-D, stride-1 tensor, but
+            # ``block_table_tensor[:, 0]`` is a strided column view (stride equals
+            # the block-table width). For a single-decode batch this is shape (1,)
+            # with stride (block_width,), and ``.contiguous()`` is a no-op on
+            # <=1-element tensors, so force a contiguous clone here at
+            # metadata-build time (outside any captured graph -> cudagraph-safe).
+            if non_spec_state_indices_tensor.stride(0) != 1:
+                non_spec_state_indices_tensor = non_spec_state_indices_tensor.clone(
+                    memory_format=torch.contiguous_format
+                )
             spec_query_start_loc = None
             non_spec_query_start_loc = query_start_loc
             non_spec_query_start_loc_cpu = query_start_loc_cpu


### PR DESCRIPTION
## Purpose

In `GDNAttentionMetadataBuilder`, the non-spec decode branch sets:

```python
non_spec_state_indices_tensor = block_table_tensor[:, 0]
```

This is a strided column view: `stride(0)` equals the block-table width, not 1. The recurrent decode kernel requires a **1-D, stride-1** `state_indices`, and this view is passed to the kernel directly in every path **except** the FULL-cudagraph decode fast-path (which copies it into a preallocated contiguous buffer).

For a single-decode batch the view is shape `(1,)` with stride `(block_width,)`, and `.contiguous()` is a **no-op** on `<=1`-element tensors (they report contiguous), so the kernel raises:

```
`state_indices` must be contiguous and one-dimensional.
```

## Fix

Force a contiguous clone at metadata-build time — outside any captured graph, so it is cudagraph-safe (a `.copy_()`/alloc inside the forward would corrupt captured graphs). `clone(memory_format=torch.contiguous_format)` guarantees `stride(0)==1` even for the single-element case, unlike `.contiguous()`. The guard `stride(0) != 1` makes it a no-op when the view is already contiguous, and the clone is a tiny `(num_decodes,)` tensor.

## Test

- Runs on a hybrid linear-attention (GDN) decode / spec-decode path.
- Before: `state_indices must be contiguous and one-dimensional` at warmup/decode.
- After: no `state_indices` error; decode and spec-decode run correctly.
- Regression: unchanged when the view is already stride-1 (guarded).
