### PR TITLE
[Bugfix][KV Offload] Rewind store cursor at both block_ids.clear() sites

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
@@ -958,6 +958,11 @@ class OffloadingConnectorScheduler:
         req_status = self._req_status[request.request_id]
         for group_state in req_status.group_states:
             group_state.block_ids.clear()
+            # block_ids is rebuilt from scratch below, so the store cursor must
+            # rewind with it. The BLOCK_LEVEL branch further down overwrites this
+            # with num_chunks; REQUEST_LEVEL relies on it being 0, which is only
+            # true on a request's first pass unless it is reset here.
+            group_state.next_stored_chunk_idx = 0
 
         if req_status.transfer_jobs:
             logger.debug(
@@ -1117,6 +1122,12 @@ class OffloadingConnectorScheduler:
             if preempted:
                 for group_state in req_status.group_states:
                     group_state.block_ids.clear()
+                    # Resumed requests arrive on the cached path, which supplies
+                    # only newly-allocated block ids, so block_ids is rebuilt from
+                    # index 0 while offload_keys/num_chunks still describe the whole
+                    # sequence. Without rewinding, the strided slice in
+                    # _build_store_jobs comes up short of offload_keys.
+                    group_state.next_stored_chunk_idx = 0
 
             if new_block_id_groups:
                 if self._sliding_window_groups:


### PR DESCRIPTION
## Summary

`OffloadingConnector` kills the engine with `AssertionError` in `_build_store_jobs`. Likely the
underlying cause of #52170. Updated to cover **both** sites where the invariant breaks.

## The invariant

`_build_store_jobs` compares a plain slice against a **strided** one:

```python
offload_keys      = group_state.offload_keys[start_chunk_idx:num_chunks]
offload_block_ids = group_state.block_ids[
    start_chunk_idx * bpc + bpc - 1 : num_chunks * bpc : bpc]
assert len(offload_keys) == len(offload_block_ids)
```

The strided slice needs `len(block_ids) >= num_chunks * blocks_per_chunk`. `num_chunks` comes from
token counts; `block_ids` comes from what the scheduler has supplied. Anything that empties
`block_ids` without rewinding `next_stored_chunk_idx` breaks it.

`block_ids` is cleared in **two** places. `next_stored_chunk_idx` is rewound in **neither** — the only
reset today is in `reset_cache()`.

### Site 1 — `_update_req_states`, resumed after preemption

```python
if preempted:
    for group_state in req_status.group_states:
        group_state.block_ids.clear()      # cursor left stale
```

The list cannot be reconstituted, because of what `yield_req_data` supplies:

```python
for req_data in scheduler_output.scheduled_new_reqs:
    yield req_data.req_id, req_data.block_ids, False    # FULL list
yield from zip(cached_reqs.req_ids,
               cached_reqs.new_block_ids,               # DELTA only
               (r in cached_reqs.resumed_req_ids for r in cached_reqs.req_ids))
```

`preempted` is `req_id in resumed_req_ids`, and resumed requests arrive on the **cached** path, which
carries only that step's newly-allocated blocks.

### Site 2 — `get_num_new_matched_tokens`, lookup path

```python
for group_state in req_status.group_states:
    group_state.block_ids.clear()          # cursor left stale
```

then, further down, the only post-lookup cursor write:

```python
# Skip prefix-hit chunks for block-level policy; for
# request-level, next_stored_chunk_idx stays at 0 so all
# chunks (including hits) are offloaded.
if req_status.offloading_context.policy == OffloadPolicy.BLOCK_LEVEL:
    group_state.next_stored_chunk_idx = num_chunks
```

`BLOCK_LEVEL` is fine — it overwrites the cursor. **`REQUEST_LEVEL` relies on "stays at 0", which the
code never enforces**; it is only true on a request's first pass. This function re-enters — the
in-flight-transfer branch returns `None` and asks the scheduler to query again — so a second call
clears `block_ids` with a cursor that has already advanced.

## Fix

Rewind `next_stored_chunk_idx` to 0 alongside each clear, matching what `reset_cache()` already does
(*"Reset store progress so active requests re-offload from chunk 0"*). At site 2 this makes the
existing comment true rather than aspirational; `BLOCK_LEVEL` still overwrites it immediately after.

Cost is re-storing chunks that may already be in the host cache — stores are keyed by block hash, so
redundant work rather than incorrect state. Clamping `num_chunks` to what `block_ids` supports would
also silence the assert, but leaves the cursor and the list describing different things, which is
what the assert exists to catch.

## Why it needs load to reproduce

Site 1 requires preemption — enough concurrent long requests that the scheduler evicts a running one.
Startup, smoke tests and idle soaks never preempt. That matches #52170 (30 concurrent multi-turn
conversations, 160K first prompts, prefix caching on).

## Status

Draft, and I want to be straight about the evidence: this is traced from source and explains the
stack trace, the timing and the load-dependence, but **I have not reproduced the assert against a
patched build**. My own repro attempts did not even reach preemption — the scheduler reported
`preempted_requests=0` throughout, because the load used short outputs, so requests never grew into
a full pool. Reproducing site 1 needs sustained concurrency with *long generations*, not just long
prompts.

Opening as a draft so the analysis is on #52170, which has no diagnosis yet.

Related: #49118 (closed) fixed a different trigger for the same assert — aborting a queued,
never-scheduled request.
