### PR TITLE
[Attention] Support speculative decode in Triton MLA

### DIFF
--- a/tests/v1/attention/test_triton_mla_causal_verify.py
+++ b/tests/v1/attention/test_triton_mla_causal_verify.py
@@ -1,0 +1,65 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from vllm.model_executor.layers.attention.mla_attention import QueryLenSupport
+from vllm.v1.attention.backends.mla import triton_mla
+
+
+@pytest.mark.cpu_test
+def test_causal_multi_token_decode_flattens_with_prefix_lengths(monkeypatch):
+    assert (
+        triton_mla.TritonMLAMetadataBuilder.query_len_support == QueryLenSupport.UNIFORM
+    )
+
+    captured = {}
+
+    def decode_spy(*args, **kwargs):
+        captured["block_table"] = args[5].clone()
+        captured["seq_lens"] = args[6].clone()
+
+    monkeypatch.setattr(triton_mla, "decode_attention_fwd", decode_spy)
+    monkeypatch.setattr(triton_mla, "_compute_num_kv_splits", lambda *_: 1)
+
+    impl = object.__new__(triton_mla.TritonMLAImpl)
+    impl.kv_lora_rank = 2
+    impl.scale = 1.0
+    impl._sm_count = 1
+
+    query_len = 3
+    num_decodes = 3
+    num_heads = 2
+    head_size = 3
+    block_table = torch.arange(12, dtype=torch.int32).view(num_decodes, 4)
+    seq_lens = torch.tensor([10, 2, 0], dtype=torch.int32)
+    metadata = SimpleNamespace(
+        causal=True,
+        num_decodes=num_decodes,
+        num_decode_tokens=num_decodes * query_len,
+        max_seq_len=10,
+        decode=SimpleNamespace(block_table=block_table, seq_lens=seq_lens),
+    )
+    q = torch.zeros(num_decodes * query_len, num_heads, head_size)
+    kv_cache = torch.zeros(8, 4, head_size)
+
+    output, lse = impl.forward_mqa(
+        q,
+        kv_cache,
+        metadata,
+        SimpleNamespace(_k_scale=1.0),
+    )
+
+    assert output.shape == (num_decodes * query_len, num_heads, 2)
+    assert lse is not None
+    assert lse.shape == (num_decodes * query_len, num_heads)
+    torch.testing.assert_close(
+        captured["block_table"], block_table.repeat_interleave(query_len, dim=0)
+    )
+    torch.testing.assert_close(
+        captured["seq_lens"],
+        torch.tensor([8, 9, 10, 0, 1, 2, 0, 0, 0], dtype=torch.int32),
+    )

--- a/vllm/v1/attention/backends/mla/triton_mla.py
+++ b/vllm/v1/attention/backends/mla/triton_mla.py
@@ -13,6 +13,7 @@ from vllm.model_executor.layers.attention.mla_attention import (
     MLACommonImpl,
     MLACommonMetadata,
     MLACommonMetadataBuilder,
+    QueryLenSupport,
 )
 from vllm.platforms import current_platform
 from vllm.platforms.interface import DeviceCapability
@@ -51,6 +52,7 @@ class TritonMLAMetadataBuilder(MLACommonMetadataBuilder[MLACommonMetadata]):
     _cudagraph_support: ClassVar[AttentionCGSupport] = (
         AttentionCGSupport.UNIFORM_SINGLE_TOKEN_DECODE
     )
+    query_len_support: ClassVar[QueryLenSupport] = QueryLenSupport.UNIFORM
     # Non-causal DSpark block is flattened to one decode row per query token in
     # forward_mqa, so no intra-block causal masking is required.
     supports_non_causal_multi_token_decode: ClassVar[bool] = True
@@ -79,12 +81,12 @@ class TritonMLAMetadataBuilder(MLACommonMetadataBuilder[MLACommonMetadata]):
         """
         if not is_workspace_manager_initialized():
             return
-        # Decode reorder threshold is 1, so decode tokens <= max_num_seqs.
-        B = self.vllm_config.scheduler_config.max_num_seqs
-        # Non-causal DSpark draft flattens each request's block to query_len
-        # decode rows; cover max_num_seqs * block_len rows.
-        if getattr(self, "non_causal_multi_token_decode", False):
-            B *= self.reorder_batch_threshold
+        # Uniform speculative verification blocks are flattened into decode
+        # rows, so reserve max_num_seqs * block_len rows.
+        B = (
+            self.vllm_config.scheduler_config.max_num_seqs
+            * self.reorder_batch_threshold
+        )
         # DCP all-gathers the query heads before forward_mqa.
         q_num_heads = self.num_heads * self.dcp_world_size
         max_splits = _compute_num_kv_splits(
@@ -290,15 +292,28 @@ class TritonMLAImpl(MLACommonImpl[MLACommonMetadata]):
 
         block_table = attn_metadata.decode.block_table
         seq_lens = attn_metadata.decode.seq_lens
+        query_len = attn_metadata.num_decode_tokens // attn_metadata.num_decodes
         if not attn_metadata.causal:
             # Non-causal DSpark block: flatten to one decode row per query token.
             # Each row attends to the same committed KV prefix (per-row seq_lens)
             # and never to sibling block tokens = non-causal block semantics.
             # Mirrors FlashInferMLA's non-causal path.
-            query_len = attn_metadata.num_decode_tokens // attn_metadata.num_decodes
             if query_len > 1:
                 block_table = block_table.repeat_interleave(query_len, dim=0)
                 seq_lens = seq_lens.repeat_interleave(query_len)
+        elif query_len > 1:
+            # The cache already contains the complete speculative verification
+            # block. Flatten it into decode rows and shorten each row's visible
+            # prefix so token i attends through itself, preserving causality.
+            block_table = block_table.repeat_interleave(query_len, dim=0)
+            seq_lens = seq_lens.repeat_interleave(query_len)
+            causal_offsets = torch.arange(
+                1 - query_len,
+                1,
+                dtype=seq_lens.dtype,
+                device=seq_lens.device,
+            ).repeat(attn_metadata.num_decodes)
+            seq_lens = torch.clamp(seq_lens + causal_offsets, min=0)
 
         # Run MQA — always pass layer scales. When KV cache is
         # BF16 the kernel's `if dtype.is_fp8()` check is a no-op.


### PR DESCRIPTION
## Purpose

Enable causal uniform multi-token decode in the Triton MLA backend so speculative verification blocks use the split-KV decode path instead of being classified as prefills.

Triton MLA previously left `query_len_support` at `SINGLE_ONLY`. With speculative decoding, a target verification block of `1 + num_speculative_tokens` was therefore routed through the MLA prefill backend. At long context this caused every generated step to scan the complete context as a prefill.

This change:

- declares uniform multi-token query support;
- flattens each verification block into decode rows;
- assigns causal KV prefix lengths to those rows so verification token `i` attends through itself but not later draft tokens;
- clamps graph-padding rows to zero length; and
- reserves split-KV workspace for the expanded row count.

## Test Plan

- Add a CPU regression test that intercepts the actual arguments passed to the Triton split-KV decode kernel.
- Cover multiple requests, a context shorter than the verification block, and a zero-length graph-padding request.
- Run Ruff lint and formatting checks.
- Validate with a real long-context MTP workload on SM120.

## Test Result

Focused regression:

```text
1 passed, 14 warnings in 0.38s
```

Ruff 0.14.0:

```text
All checks passed!
2 files already formatted
```

Real workload using Ling 3.0 Flash on one RTX PRO 6000 Blackwell, BF16 KV, Triton MLA, MTP2:

- 500,000 prompt tokens plus 1,024 generated tokens
- before: 5.93 generated tok/s because verification used full-context prefill
- after: 87.19 generated tok/s client-measured; 86.9 tok/s vLLM interval
- 3/3 long-context retrieval markers recovered
- coherent output and no runtime errors

The change does not alter single-token decode or the existing non-causal multi-token path.
