### PR TITLE
[Tests] Centralize GSM8K eval definitions

### DIFF
--- a/.buildkite/scripts/scheduled_integration_test/deepseek_v2_lite_ep_eplb.sh
+++ b/.buildkite/scripts/scheduled_integration_test/deepseek_v2_lite_ep_eplb.sh
@@ -1,10 +1,8 @@
 #!/usr/bin/env bash
 set -euxo pipefail
 
-# args: [THRESHOLD] [NUM_QUESTIONS] [START_PORT]
-THRESHOLD=${1:-0.25}
-NUM_Q=${2:-1319}
-PORT=${3:-8010}
+# args: [START_PORT]
+PORT=${1:-8010}
 OUT_DIR=${OUT_DIR:-/tmp/vllm-scheduled}
 mkdir -p "${OUT_DIR}"
 
@@ -59,12 +57,7 @@ for BACK in "${BACKENDS[@]}"; do
 
   TAG=$(echo "$MODEL" | tr '/: \\n' '_____')
   OUT="${OUT_DIR}/${TAG}_${BACK}.json"
-  python3 tests/evals/gsm8k/gsm8k_eval.py --host http://127.0.0.1 --port "$PORT" --num-questions "${NUM_Q}" --save-results "${OUT}"
-  python3 - <<PY
-import json; acc=json.load(open('${OUT}'))['accuracy']
-print(f"${MODEL} ${BACK}: accuracy {acc:.3f}")
-assert acc >= ${THRESHOLD}, f"${MODEL} ${BACK} accuracy {acc}"
-PY
+  python3 tests/evals/gsm8k/gsm8k_eval.py --host http://127.0.0.1 --port "$PORT" --eval-spec scheduled_integration.deepseek-v2-lite-ep-eplb --save-results "${OUT}"
 
   cleanup
   SERVER_PID=

--- a/.buildkite/scripts/scheduled_integration_test/deepseek_v2_lite_prefetch_offload.sh
+++ b/.buildkite/scripts/scheduled_integration_test/deepseek_v2_lite_prefetch_offload.sh
@@ -4,14 +4,12 @@ set -euxo pipefail
 # Runs DeepSeek-V2-Lite with prefetch offloading of MoE expert weights
 # and validates GSM8K accuracy matches baseline (no offloading).
 #
-# args: [THRESHOLD] [NUM_QUESTIONS] [START_PORT]
+# args: [START_PORT]
 #
 # Environment variables:
 #   ATTENTION_BACKEND   - attention backend to use (e.g., FLASH_ATTN,
 #                         ROCM_ATTN, FLASHINFER). If unset, uses vllm default.
-THRESHOLD=${1:-0.25}
-NUM_Q=${2:-1319}
-PORT=${3:-8030}
+PORT=${1:-8030}
 OUT_DIR=${OUT_DIR:-/tmp/vllm-scheduled}
 mkdir -p "${OUT_DIR}"
 
@@ -67,12 +65,7 @@ wait_for_server "$PORT"
 
 TAG=$(echo "$MODEL" | tr '/: \\n' '_____')
 OUT="${OUT_DIR}/${TAG}_prefetch_offload.json"
-python3 tests/evals/gsm8k/gsm8k_eval.py --host http://127.0.0.1 --port "$PORT" --num-questions "${NUM_Q}" --save-results "${OUT}"
-python3 - <<PY
-import json; acc=json.load(open('${OUT}'))['accuracy']
-print(f"${MODEL} prefetch_offload: accuracy {acc:.3f}")
-assert acc >= ${THRESHOLD}, f"${MODEL} prefetch_offload accuracy {acc}"
-PY
+python3 tests/evals/gsm8k/gsm8k_eval.py --host http://127.0.0.1 --port "$PORT" --eval-spec scheduled_integration.deepseek-v2-lite-prefetch-offload --save-results "${OUT}"
 
 cleanup
 SERVER_PID=

--- a/.buildkite/scripts/scheduled_integration_test/qwen30b_a3b_fp8_block_ep_eplb.sh
+++ b/.buildkite/scripts/scheduled_integration_test/qwen30b_a3b_fp8_block_ep_eplb.sh
@@ -1,12 +1,10 @@
 #!/usr/bin/env bash
 set -euxo pipefail
 
-# args: [THRESHOLD] [NUM_QUESTIONS] [START_PORT] [DATA_PARALLEL_SIZE] [TENSOR_PARALLEL_SIZE]
-THRESHOLD=${1:-0.8}
-NUM_Q=${2:-1319}
-PORT=${3:-8020}
-DATA_PARALLEL_SIZE=${4:-2}
-TENSOR_PARALLEL_SIZE=${5:-2}
+# args: [START_PORT] [DATA_PARALLEL_SIZE] [TENSOR_PARALLEL_SIZE]
+PORT=${1:-8020}
+DATA_PARALLEL_SIZE=${2:-2}
+TENSOR_PARALLEL_SIZE=${3:-2}
 OUT_DIR=${OUT_DIR:-/tmp/vllm-scheduled}
 mkdir -p "${OUT_DIR}"
 
@@ -60,12 +58,7 @@ for BACK in "${BACKENDS[@]}"; do
 
   TAG=$(echo "$MODEL" | tr '/: \\n' '_____')
   OUT="${OUT_DIR}/${TAG}_${BACK}.json"
-  python3 tests/evals/gsm8k/gsm8k_eval.py --host http://127.0.0.1 --port "$PORT" --num-questions "${NUM_Q}" --save-results "${OUT}"
-  python3 - <<PY
-import json; acc=json.load(open('${OUT}'))['accuracy']
-print(f"${MODEL} ${BACK}: accuracy {acc:.3f}")
-assert acc >= ${THRESHOLD}, f"${MODEL} ${BACK} accuracy {acc}"
-PY
+  python3 tests/evals/gsm8k/gsm8k_eval.py --host http://127.0.0.1 --port "$PORT" --eval-spec scheduled_integration.qwen3-30b-fp8-block-ep-eplb --save-results "${OUT}"
 
   cleanup
   SERVER_PID=

--- a/.buildkite/scripts/scheduled_integration_test/qwen30b_a3b_fp8_dp4_async_eplb.sh
+++ b/.buildkite/scripts/scheduled_integration_test/qwen30b_a3b_fp8_dp4_async_eplb.sh
@@ -1,10 +1,8 @@
 #!/usr/bin/env bash
 set -euxo pipefail
 
-# args: [THRESHOLD] [NUM_QUESTIONS] [START_PORT]
-THRESHOLD=${1:-0.8}
-NUM_Q=${2:-1319}
-PORT=${3:-8050}
+# args: [START_PORT]
+PORT=${1:-8050}
 OUT_DIR=${OUT_DIR:-/tmp/vllm-scheduled}
 mkdir -p "${OUT_DIR}"
 
@@ -51,9 +49,4 @@ wait_for_server "$PORT"
 
 TAG=$(echo "$MODEL" | tr '/: \\n' '_____')
 OUT="${OUT_DIR}/${TAG}_${BACK}.json"
-python3 tests/evals/gsm8k/gsm8k_eval.py --host http://127.0.0.1 --port "$PORT" --num-questions "${NUM_Q}" --save-results "${OUT}"
-python3 - <<PY
-import json; acc=json.load(open('${OUT}'))['accuracy']
-print(f"${MODEL} ${BACK}: accuracy {acc:.3f}")
-assert acc >= ${THRESHOLD}, f"${MODEL} ${BACK} accuracy {acc}"
-PY
+python3 tests/evals/gsm8k/gsm8k_eval.py --host http://127.0.0.1 --port "$PORT" --eval-spec scheduled_integration.qwen3-30b-fp8-dp4-async-eplb --save-results "${OUT}"

--- a/.buildkite/scripts/scheduled_integration_test/qwen3_next_mtp_async_eplb.sh
+++ b/.buildkite/scripts/scheduled_integration_test/qwen3_next_mtp_async_eplb.sh
@@ -1,10 +1,8 @@
 #!/usr/bin/env bash
 set -euxo pipefail
 
-# args: [THRESHOLD] [NUM_QUESTIONS] [START_PORT]
-THRESHOLD=${1:-0.25}
-NUM_Q=${2:-1319}
-PORT=${3:-8040}
+# args: [START_PORT]
+PORT=${1:-8040}
 OUT_DIR=${OUT_DIR:-/tmp/vllm-scheduled}
 mkdir -p "${OUT_DIR}"
 
@@ -64,12 +62,7 @@ for BACK in "${BACKENDS[@]}"; do
 
   TAG=$(echo "$MODEL" | tr '/: \\n' '_____')
   OUT="${OUT_DIR}/${TAG}_${BACK}.json"
-  python3 tests/evals/gsm8k/gsm8k_eval.py --host http://127.0.0.1 --port "$PORT" --num-questions "${NUM_Q}" --save-results "${OUT}"
-  python3 - <<PY
-import json; acc=json.load(open('${OUT}'))['accuracy']
-print(f"${MODEL} ${BACK}: accuracy {acc:.3f}")
-assert acc >= ${THRESHOLD}, f"${MODEL} ${BACK} accuracy {acc}"
-PY
+  python3 tests/evals/gsm8k/gsm8k_eval.py --host http://127.0.0.1 --port "$PORT" --eval-spec scheduled_integration.qwen3-next-mtp-async-eplb --save-results "${OUT}"
 
   cleanup
   SERVER_PID=

--- a/.buildkite/test-amd.yaml
+++ b/.buildkite/test-amd.yaml
@@ -1183,7 +1183,7 @@ steps:
   - vllm/_aiter_ops.py
   - vllm/platforms/rocm.py
   commands:
-  - bash .buildkite/scripts/scheduled_integration_test/deepseek_v2_lite_prefetch_offload.sh 0.25 200 8030
+  - bash .buildkite/scripts/scheduled_integration_test/deepseek_v2_lite_prefetch_offload.sh 8030
 
 - label: LM Eval Small Models # TBD
   timeout_in_minutes: 180
@@ -1319,7 +1319,7 @@ steps:
   - vllm/_aiter_ops.py
   - vllm/platforms/rocm.py
   commands:
-  - bash .buildkite/scripts/scheduled_integration_test/deepseek_v2_lite_ep_eplb.sh 0.25 200 8010
+  - bash .buildkite/scripts/scheduled_integration_test/deepseek_v2_lite_ep_eplb.sh 8010
 
 - label: LM Eval Large Models (4xA100-4xMI300) # TBD
   timeout_in_minutes: 180
@@ -1362,7 +1362,7 @@ steps:
   - vllm/_aiter_ops.py
   - vllm/platforms/rocm.py
   commands:
-  - bash .buildkite/scripts/scheduled_integration_test/qwen30b_a3b_fp8_block_ep_eplb.sh 0.8 200 8020
+  - bash .buildkite/scripts/scheduled_integration_test/qwen30b_a3b_fp8_block_ep_eplb.sh 8020
 
 - label: Qwen3-30B-A3B-FP8 DP4 Async EPLB Accuracy (4xH100-4xMI300) # TBD
   timeout_in_minutes: 180
@@ -1384,7 +1384,7 @@ steps:
   - vllm/_aiter_ops.py
   - vllm/platforms/rocm.py
   commands:
-  - bash .buildkite/scripts/scheduled_integration_test/qwen30b_a3b_fp8_dp4_async_eplb.sh 0.8 200 8050
+  - bash .buildkite/scripts/scheduled_integration_test/qwen30b_a3b_fp8_dp4_async_eplb.sh 8050
 
 - label: Qwen3-Next-80B-A3B-Instruct MTP Async EPLB Accuracy # TBD
   timeout_in_minutes: 180
@@ -1407,7 +1407,7 @@ steps:
   - vllm/_aiter_ops.py
   - vllm/platforms/rocm.py
   commands:
-  - bash .buildkite/scripts/scheduled_integration_test/qwen3_next_mtp_async_eplb.sh 0.8 1319 8040
+  - bash .buildkite/scripts/scheduled_integration_test/qwen3_next_mtp_async_eplb.sh 8040
 
 - label: LM Eval Large Models (8xH200-8xMI300) # TBD
   timeout_in_minutes: 180
@@ -3319,7 +3319,7 @@ steps:
   - vllm/_aiter_ops.py
   - vllm/platforms/rocm.py
   commands:
-  - bash .buildkite/scripts/scheduled_integration_test/qwen30b_a3b_fp8_block_ep_eplb.sh 0.8 200 8020 2 1
+  - bash .buildkite/scripts/scheduled_integration_test/qwen30b_a3b_fp8_block_ep_eplb.sh 8020 2 1
 
 - label: LM Eval Large Models (4xH100-4xMI355) # TBD
   timeout_in_minutes: 180

--- a/.buildkite/test_areas/e2e_integration.yaml
+++ b/.buildkite/test_areas/e2e_integration.yaml
@@ -10,7 +10,7 @@ steps:
   num_devices: 4
   working_dir: "/vllm-workspace"
   commands:
-  - bash .buildkite/scripts/scheduled_integration_test/deepseek_v2_lite_ep_eplb.sh 0.25 200 8010
+  - bash .buildkite/scripts/scheduled_integration_test/deepseek_v2_lite_ep_eplb.sh 8010
 
 - label: Qwen3-30B-A3B-FP8-block Sync EPLB Accuracy (4xH100)
   key: qwen3-30b-a3b-fp8-block-sync-eplb-accuracy-4xh100
@@ -20,7 +20,7 @@ steps:
   num_devices: 4
   working_dir: "/vllm-workspace"
   commands:
-  - bash .buildkite/scripts/scheduled_integration_test/qwen30b_a3b_fp8_block_ep_eplb.sh 0.8 200 8020
+  - bash .buildkite/scripts/scheduled_integration_test/qwen30b_a3b_fp8_block_ep_eplb.sh 8020
 
 - label: Qwen3-30B-A3B-FP8-block Sync EPLB Accuracy (2xB200)
   key: qwen3-30b-a3b-fp8-block-sync-eplb-accuracy-2xb200
@@ -30,7 +30,7 @@ steps:
   num_devices: 2
   working_dir: "/vllm-workspace"
   commands:
-  - bash .buildkite/scripts/scheduled_integration_test/qwen30b_a3b_fp8_block_ep_eplb.sh 0.8 200 8020 2 1
+  - bash .buildkite/scripts/scheduled_integration_test/qwen30b_a3b_fp8_block_ep_eplb.sh 8020 2 1
 
 - label: Qwen3-30B-A3B-FP8 DP4 Async EPLB Accuracy
   key: qwen3-30b-a3b-fp8-dp4-async-eplb-accuracy
@@ -40,7 +40,7 @@ steps:
   num_devices: 4
   working_dir: "/vllm-workspace"
   commands:
-  - bash .buildkite/scripts/scheduled_integration_test/qwen30b_a3b_fp8_dp4_async_eplb.sh 0.8 200 8050
+  - bash .buildkite/scripts/scheduled_integration_test/qwen30b_a3b_fp8_dp4_async_eplb.sh 8050
 
 - label: DeepSeek V2-Lite Prefetch Offload Accuracy (H100)
   key: deepseek-v2-lite-prefetch-offload-accuracy-h100
@@ -50,4 +50,4 @@ steps:
   num_devices: 1
   working_dir: "/vllm-workspace"
   commands:
-  - bash .buildkite/scripts/scheduled_integration_test/deepseek_v2_lite_prefetch_offload.sh 0.25 200 8030
+  - bash .buildkite/scripts/scheduled_integration_test/deepseek_v2_lite_prefetch_offload.sh 8030

--- a/tests/distributed/test_context_parallel.py
+++ b/tests/distributed/test_context_parallel.py
@@ -13,10 +13,13 @@ import os
 from dataclasses import dataclass
 from typing import Literal, NamedTuple
 
-import lm_eval
 import pytest
 import torch
 
+from tests.evals.gsm8k.gsm8k_eval import (
+    assert_min_accuracy,
+    evaluate_gsm8k_lm_eval,
+)
 from tests.utils import RemoteOpenAIServer, create_new_process_for_each_test
 from vllm.config.model import RunnerOption
 from vllm.logger import init_logger
@@ -38,8 +41,6 @@ CP_TEST_MODELS = [
 
 # GSM8K eval configuration
 NUM_SHOTS = 5  # Few-shot examples
-TASK = "gsm8k"
-FILTER = "exact_match,strict-match"
 NUM_CONCURRENT = 128
 # tp accuracy with 2% buffer
 MIN_ACCURACY = {
@@ -256,19 +257,13 @@ def _test_cp_gsm8k(
             f"num_concurrent={NUM_CONCURRENT},tokenized_requests=False"
         )
 
-        results = lm_eval.simple_evaluate(
+        result = evaluate_gsm8k_lm_eval(
             model="local-completions",
             model_args=model_args,
-            tasks=TASK,
             num_fewshot=NUM_SHOTS,
         )
 
-        # Validate accuracy is reasonable
-        accuracy = results["results"][TASK][FILTER]
-        min_accuracy = MIN_ACCURACY[model_id]
-        assert accuracy >= min_accuracy, (
-            f"TP+DCP accuracy too low: {accuracy:.3f} < {min_accuracy:.3f}"
-        )
+        assert_min_accuracy(result, MIN_ACCURACY[model_id], context="TP+DCP")
 
 
 @pytest.mark.parametrize(

--- a/tests/distributed/test_context_parallel.py
+++ b/tests/distributed/test_context_parallel.py
@@ -17,8 +17,9 @@ import pytest
 import torch
 
 from tests.evals.gsm8k.gsm8k_eval import (
-    assert_min_accuracy,
+    assert_gsm8k_result,
     evaluate_gsm8k_lm_eval,
+    load_gsm8k_eval_specs,
 )
 from tests.utils import RemoteOpenAIServer, create_new_process_for_each_test
 from vllm.config.model import RunnerOption
@@ -31,25 +32,15 @@ logger = init_logger("test_context_parallel")
 
 VLLM_MULTI_NODE = os.getenv("VLLM_MULTI_NODE", "0") == "1"
 
-CP_TEST_MODELS = [
-    # TODO support other models
-    # [LANGUAGE GENERATION]
-    "deepseek-ai/DeepSeek-V2-Lite-Chat",
-    "Qwen/Qwen2.5-1.5B-Instruct",
-    "Qwen/Qwen3.5-0.8B",  # hybrid attention model
-]
+GSM8K_SPECS = {
+    spec.model: spec
+    for spec in load_gsm8k_eval_specs("context_parallel")
+    if spec.model is not None
+}
+CP_TEST_MODELS = list(GSM8K_SPECS)
 
 # GSM8K eval configuration
-NUM_SHOTS = 5  # Few-shot examples
 NUM_CONCURRENT = 128
-# tp accuracy with 2% buffer
-MIN_ACCURACY = {
-    # .buildkite/lm-eval-harness/configs/DeepSeek-V2-Lite-Chat.yaml
-    "deepseek-ai/DeepSeek-V2-Lite-Chat": 0.64,
-    # .buildkite/lm-eval-harness/configs/Qwen2.5-1.5B-Instruct.yaml
-    "Qwen/Qwen2.5-1.5B-Instruct": 0.52,
-    "Qwen/Qwen3.5-0.8B": 0.33,
-}
 
 
 class ParallelSetup(NamedTuple):
@@ -174,6 +165,7 @@ def _test_cp_gsm8k(
     method: Literal["generate"],
     is_multimodal: bool,
 ):
+    gsm8k_spec = GSM8K_SPECS[model_id]
     (
         tp_size,
         pp_size,
@@ -260,10 +252,10 @@ def _test_cp_gsm8k(
         result = evaluate_gsm8k_lm_eval(
             model="local-completions",
             model_args=model_args,
-            num_fewshot=NUM_SHOTS,
+            **gsm8k_spec.lm_eval_kwargs(),
         )
 
-        assert_min_accuracy(result, MIN_ACCURACY[model_id], context="TP+DCP")
+        assert_gsm8k_result(result, gsm8k_spec, context="TP+DCP")
 
 
 @pytest.mark.parametrize(

--- a/tests/distributed/test_elastic_ep.py
+++ b/tests/distributed/test_elastic_ep.py
@@ -10,7 +10,7 @@ from concurrent.futures import ThreadPoolExecutor
 import pytest
 import requests
 
-from ..evals.gsm8k.gsm8k_eval import evaluate_gsm8k
+from ..evals.gsm8k.gsm8k_eval import assert_min_accuracy, evaluate_gsm8k
 from ..utils import RemoteOpenAIServer, multi_gpu_test
 
 
@@ -149,15 +149,11 @@ def _run_gsm8k_eval(server: RemoteOpenAIServer, stage: str) -> float:
         host=f"http://{server.host}",
         port=server.port,
     )
-    accuracy = result["accuracy"]
+    accuracy = result.accuracy
     print(
-        f"[{stage}] GSM8K accuracy: {accuracy:.3f} "
-        f"({result['num_questions']} questions)"
+        f"[{stage}] GSM8K accuracy: {accuracy:.3f} ({result.num_questions} questions)"
     )
-    assert accuracy >= EXPECTED_ACCURACY, (
-        f"[{stage}] GSM8K accuracy {accuracy:.3f} is below "
-        f"expected threshold {EXPECTED_ACCURACY}"
-    )
+    assert_min_accuracy(result, EXPECTED_ACCURACY, context=stage)
     return accuracy
 
 

--- a/tests/distributed/test_elastic_ep.py
+++ b/tests/distributed/test_elastic_ep.py
@@ -10,7 +10,11 @@ from concurrent.futures import ThreadPoolExecutor
 import pytest
 import requests
 
-from ..evals.gsm8k.gsm8k_eval import assert_min_accuracy, evaluate_gsm8k
+from ..evals.gsm8k.gsm8k_eval import (
+    assert_gsm8k_result,
+    evaluate_gsm8k,
+    get_gsm8k_eval_spec,
+)
 from ..utils import RemoteOpenAIServer, multi_gpu_test
 
 
@@ -22,10 +26,9 @@ def cleanup_ray_between_tests():
     yield
 
 
-MODEL_NAME = "deepseek-ai/DeepSeek-V2-Lite-Chat"
-
-NUM_GSM8K_QUESTIONS = 256
-EXPECTED_ACCURACY = 0.58
+GSM8K_SPEC = get_gsm8k_eval_spec("elastic_ep", "deepseek-v2-lite-chat")
+assert GSM8K_SPEC.model is not None
+MODEL_NAME = GSM8K_SPEC.model
 ACCURACY_TOL = 0.08
 MAX_NUM_SEQS = 32
 
@@ -145,7 +148,7 @@ def _scale_with_traffic(
 def _run_gsm8k_eval(server: RemoteOpenAIServer, stage: str) -> float:
     assert server.port is not None
     result = evaluate_gsm8k(
-        num_questions=NUM_GSM8K_QUESTIONS,
+        **GSM8K_SPEC.isolated_kwargs(),
         host=f"http://{server.host}",
         port=server.port,
     )
@@ -153,7 +156,7 @@ def _run_gsm8k_eval(server: RemoteOpenAIServer, stage: str) -> float:
     print(
         f"[{stage}] GSM8K accuracy: {accuracy:.3f} ({result.num_questions} questions)"
     )
-    assert_min_accuracy(result, EXPECTED_ACCURACY, context=stage)
+    assert_gsm8k_result(result, GSM8K_SPEC, context=stage)
     return accuracy
 
 

--- a/tests/distributed/test_eplb_spec_decode.py
+++ b/tests/distributed/test_eplb_spec_decode.py
@@ -2,9 +2,12 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 from __future__ import annotations
 
-import lm_eval
 import pytest
 
+from tests.evals.gsm8k.gsm8k_eval import (
+    assert_min_accuracy,
+    evaluate_gsm8k_lm_eval,
+)
 from tests.utils import large_gpu_mark
 from vllm.platforms import current_platform
 
@@ -81,8 +84,6 @@ def test_eplb_spec_decode(
     """
     method, model_name, spec_model_name, tp_size, expected_gsm8k_value = model_setup
 
-    TASK = "gsm8k"
-    FILTER = "exact_match,strict-match"
     RTOL = 0.03
 
     model_args = get_model_args(
@@ -93,18 +94,13 @@ def test_eplb_spec_decode(
         model_max_len=4096,
     )
 
-    results = lm_eval.simple_evaluate(
+    result = evaluate_gsm8k_lm_eval(
         model="vllm",
         model_args=model_args,
-        tasks=TASK,
         batch_size=64,
         num_fewshot=8,
     )
-    measured_value = results["results"][TASK][FILTER]
-    assert (
-        measured_value - RTOL < expected_gsm8k_value
-        and measured_value + RTOL > expected_gsm8k_value
-    ), f"Expected: {expected_gsm8k_value} |  Measured: {measured_value}"
+    assert_min_accuracy(result, expected_gsm8k_value, tolerance=RTOL)
 
 
 @large_gpu_mark(min_gb=80)
@@ -113,8 +109,6 @@ def test_eplb_spec_decode_qwen3_next_mtp_async() -> None:
     Ensure async EPLB works with MTP speculative decoding for Qwen3-Next.
     """
 
-    TASK = "gsm8k"
-    FILTER = "exact_match,strict-match"
     RTOL = 0.03
     expected_gsm8k_value = 0.86
 
@@ -127,15 +121,10 @@ def test_eplb_spec_decode_qwen3_next_mtp_async() -> None:
         use_async=True,
     )
 
-    results = lm_eval.simple_evaluate(
+    result = evaluate_gsm8k_lm_eval(
         model="vllm",
         model_args=model_args,
-        tasks=TASK,
         batch_size=64,
         num_fewshot=8,
     )
-    measured_value = results["results"][TASK][FILTER]
-    assert (
-        measured_value - RTOL < expected_gsm8k_value
-        and measured_value + RTOL > expected_gsm8k_value
-    ), f"Expected: {expected_gsm8k_value} |  Measured: {measured_value}"
+    assert_min_accuracy(result, expected_gsm8k_value, tolerance=RTOL)

--- a/tests/distributed/test_eplb_spec_decode.py
+++ b/tests/distributed/test_eplb_spec_decode.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 import pytest
 
 from tests.evals.gsm8k.gsm8k_eval import (
-    assert_min_accuracy,
+    assert_gsm8k_result,
     evaluate_gsm8k_lm_eval,
+    get_gsm8k_eval_spec,
 )
 from tests.utils import large_gpu_mark
 from vllm.platforms import current_platform
@@ -58,16 +59,15 @@ pytestmark = pytest.mark.skipif(
     "model_setup",
     [
         pytest.param(
-            ("mtp", "Qwen/Qwen3-Next-80B-A3B-Instruct", None, 4, 0.86),
+            ("mtp", "qwen3-next-mtp", None, 4),
             marks=large_gpu_mark(min_gb=80),
         ),
         pytest.param(
             (
                 "eagle",
-                "meta-llama/Llama-4-Scout-17B-16E-Instruct",
+                "llama4-scout-eagle",
                 "morgendave/EAGLE-Llama-4-Scout-17B-16E-Instruct",
                 4,
-                0.92,
             ),
             marks=pytest.mark.skip(reason="Skipping due to CI OOM issues"),
         ),
@@ -76,18 +76,18 @@ pytestmark = pytest.mark.skipif(
 )
 def test_eplb_spec_decode(
     monkeypatch: pytest.MonkeyPatch,
-    model_setup: tuple[str, str, str, int, float],
+    model_setup: tuple[str, str, str | None, int],
 ):
     """
     Test the correctness of EPLB speculative decoding with GSM8K dataset.
     Applicable to MoE models with mtp or eagle spec decode.
     """
-    method, model_name, spec_model_name, tp_size, expected_gsm8k_value = model_setup
-
-    RTOL = 0.03
+    method, eval_id, spec_model_name, tp_size = model_setup
+    gsm8k_spec = get_gsm8k_eval_spec("eplb_spec_decode", eval_id)
+    assert gsm8k_spec.model is not None
 
     model_args = get_model_args(
-        model_name=model_name,
+        model_name=gsm8k_spec.model,
         spec_model_name=spec_model_name,
         spec_method=method,
         tp_size=tp_size,
@@ -98,9 +98,9 @@ def test_eplb_spec_decode(
         model="vllm",
         model_args=model_args,
         batch_size=64,
-        num_fewshot=8,
+        **gsm8k_spec.lm_eval_kwargs(),
     )
-    assert_min_accuracy(result, expected_gsm8k_value, tolerance=RTOL)
+    assert_gsm8k_result(result, gsm8k_spec)
 
 
 @large_gpu_mark(min_gb=80)
@@ -109,11 +109,11 @@ def test_eplb_spec_decode_qwen3_next_mtp_async() -> None:
     Ensure async EPLB works with MTP speculative decoding for Qwen3-Next.
     """
 
-    RTOL = 0.03
-    expected_gsm8k_value = 0.86
+    gsm8k_spec = get_gsm8k_eval_spec("eplb_spec_decode", "qwen3-next-mtp-async")
+    assert gsm8k_spec.model is not None
 
     model_args = get_model_args(
-        model_name="Qwen/Qwen3-Next-80B-A3B-Instruct",
+        model_name=gsm8k_spec.model,
         spec_model_name=None,
         spec_method="mtp",
         tp_size=4,
@@ -125,6 +125,6 @@ def test_eplb_spec_decode_qwen3_next_mtp_async() -> None:
         model="vllm",
         model_args=model_args,
         batch_size=64,
-        num_fewshot=8,
+        **gsm8k_spec.lm_eval_kwargs(),
     )
-    assert_min_accuracy(result, expected_gsm8k_value, tolerance=RTOL)
+    assert_gsm8k_result(result, gsm8k_spec)

--- a/tests/entrypoints/llm/test_accuracy.py
+++ b/tests/entrypoints/llm/test_accuracy.py
@@ -9,9 +9,12 @@ sure that the zmq frontend mp RPC message passing and
 AsyncLLMEngine are working correctly.
 """
 
-import lm_eval
 import pytest
 
+from tests.evals.gsm8k.gsm8k_eval import (
+    assert_min_accuracy,
+    evaluate_gsm8k_lm_eval,
+)
 from vllm.platforms import current_platform
 
 MODEL_NAMES = [
@@ -22,8 +25,6 @@ FP8_KV_MODEL_NAMES = [
     "Qwen/Qwen3-1.7B",
 ]
 NUM_CONCURRENT = 500
-TASK = "gsm8k"
-FILTER = "exact_match,strict-match"
 RTOL = 0.03
 EXPECTED_VALUES = {
     "Qwen/Qwen3-1.7B": 0.68,
@@ -39,22 +40,21 @@ def run_test(model_name, more_args=None):
     if more_args is not None:
         model_args = "{},{}".format(model_args, more_args)
 
-    results = lm_eval.simple_evaluate(
+    result = evaluate_gsm8k_lm_eval(
         model="vllm",
         model_args=model_args,
-        tasks="gsm8k",
         batch_size="auto",
     )
 
-    measured_value = results["results"][TASK][FILTER]
     assert model_name in EXPECTED_VALUES, (
         f"Cannot find the expected value for the model {model_name=}"
     )
-    expected_value = EXPECTED_VALUES[model_name]
-    assert (
-        measured_value - RTOL < expected_value
-        and measured_value + RTOL > expected_value
-    ), f"Expected: {expected_value} |  Measured: {measured_value}"
+    assert_min_accuracy(
+        result,
+        EXPECTED_VALUES[model_name],
+        tolerance=RTOL,
+        context=model_name,
+    )
 
 
 # TODO: [AlexM] Fix it with new CI/CD tests

--- a/tests/entrypoints/llm/test_accuracy.py
+++ b/tests/entrypoints/llm/test_accuracy.py
@@ -12,28 +12,22 @@ AsyncLLMEngine are working correctly.
 import pytest
 
 from tests.evals.gsm8k.gsm8k_eval import (
-    assert_min_accuracy,
+    GSM8KEvalSpec,
+    assert_gsm8k_result,
     evaluate_gsm8k_lm_eval,
+    load_gsm8k_eval_specs,
 )
 from vllm.platforms import current_platform
 
-MODEL_NAMES = [
-    "Qwen/Qwen3-1.7B",
-    "google/gemma-3-1b-it",
-]
-FP8_KV_MODEL_NAMES = [
-    "Qwen/Qwen3-1.7B",
-]
-NUM_CONCURRENT = 500
-RTOL = 0.03
-EXPECTED_VALUES = {
-    "Qwen/Qwen3-1.7B": 0.68,
-    "google/gemma-3-1b-it": 0.25,
-}
+GSM8K_SPECS = {spec.id: spec for spec in load_gsm8k_eval_specs("llm_entrypoint")}
+MODEL_SPECS = [GSM8K_SPECS["qwen3-1.7b"], GSM8K_SPECS["gemma3-1b-it"]]
+FP8_KV_MODEL_SPECS = [GSM8K_SPECS["qwen3-1.7b-fp8-kv"]]
 
 
-def run_test(model_name, more_args=None):
+def run_test(gsm8k_spec: GSM8KEvalSpec, more_args=None):
     """Run the end to end accuracy test."""
+    assert gsm8k_spec.model is not None
+    model_name = gsm8k_spec.model
 
     model_args = f"pretrained={model_name},max_model_len=4096"
 
@@ -44,25 +38,18 @@ def run_test(model_name, more_args=None):
         model="vllm",
         model_args=model_args,
         batch_size="auto",
+        **gsm8k_spec.lm_eval_kwargs(),
     )
 
-    assert model_name in EXPECTED_VALUES, (
-        f"Cannot find the expected value for the model {model_name=}"
-    )
-    assert_min_accuracy(
-        result,
-        EXPECTED_VALUES[model_name],
-        tolerance=RTOL,
-        context=model_name,
-    )
+    assert_gsm8k_result(result, gsm8k_spec, context=model_name)
 
 
 # TODO: [AlexM] Fix it with new CI/CD tests
 TPU_TP_TEST_STR = ""  # "tensor_parallel_size=4"
 
 
-@pytest.mark.parametrize("model", MODEL_NAMES)
-def test_lm_eval_accuracy_v1_engine(model):
+@pytest.mark.parametrize("gsm8k_spec", MODEL_SPECS, ids=lambda spec: spec.id)
+def test_lm_eval_accuracy_v1_engine(gsm8k_spec: GSM8KEvalSpec):
     """Run with the V1 Engine."""
 
     more_args = None
@@ -75,11 +62,11 @@ def test_lm_eval_accuracy_v1_engine(model):
         if TPU_TP_TEST_STR:
             more_args += ",{}".format(TPU_TP_TEST_STR)
 
-    run_test(model, more_args)
+    run_test(gsm8k_spec, more_args)
 
 
-@pytest.mark.parametrize("model", FP8_KV_MODEL_NAMES)
-def test_lm_eval_accuracy_v1_engine_fp8_kv_cache(model):
+@pytest.mark.parametrize("gsm8k_spec", FP8_KV_MODEL_SPECS, ids=lambda spec: spec.id)
+def test_lm_eval_accuracy_v1_engine_fp8_kv_cache(gsm8k_spec: GSM8KEvalSpec):
     """Run with the V1 Engine."""
 
     more_args = None
@@ -91,4 +78,4 @@ def test_lm_eval_accuracy_v1_engine_fp8_kv_cache(model):
         if TPU_TP_TEST_STR:
             more_args += ",{}".format(TPU_TP_TEST_STR)
 
-    run_test(model, more_args)
+    run_test(gsm8k_spec, more_args)

--- a/tests/entrypoints/openai/correctness/test_lmeval.py
+++ b/tests/entrypoints/openai/correctness/test_lmeval.py
@@ -9,16 +9,16 @@ sure that the zmq frontend mp RPC message passing and
 AsyncLLMEngine are working correctly.
 """
 
-import lm_eval
-
+from tests.evals.gsm8k.gsm8k_eval import (
+    assert_min_accuracy,
+    evaluate_gsm8k_lm_eval,
+)
 from vllm.platforms import current_platform
 
 from ....utils import RemoteOpenAIServer
 
 MODEL_NAME = "Qwen/Qwen2-1.5B-Instruct"
 NUM_CONCURRENT = 500
-TASK = "gsm8k"
-FILTER = "exact_match,strict-match"
 RTOL = 0.03
 EXPECTED_VALUE = 0.54
 DEFAULT_ARGS = ["--max-model-len", "4096"]
@@ -53,17 +53,12 @@ def run_test(more_args):
             f"num_concurrent={NUM_CONCURRENT},tokenized_requests=False"
         )
 
-        results = lm_eval.simple_evaluate(
+        result = evaluate_gsm8k_lm_eval(
             model="local-completions",
             model_args=model_args,
-            tasks=TASK,
         )
 
-        measured_value = results["results"][TASK][FILTER]
-        assert (
-            measured_value - RTOL < EXPECTED_VALUE
-            and measured_value + RTOL > EXPECTED_VALUE
-        ), f"Expected: {EXPECTED_VALUE} |  Measured: {measured_value}"
+        assert_min_accuracy(result, EXPECTED_VALUE, tolerance=RTOL)
 
 
 def test_lm_eval_accuracy_v1_engine():

--- a/tests/entrypoints/openai/correctness/test_lmeval.py
+++ b/tests/entrypoints/openai/correctness/test_lmeval.py
@@ -10,17 +10,18 @@ AsyncLLMEngine are working correctly.
 """
 
 from tests.evals.gsm8k.gsm8k_eval import (
-    assert_min_accuracy,
+    assert_gsm8k_result,
     evaluate_gsm8k_lm_eval,
+    get_gsm8k_eval_spec,
 )
 from vllm.platforms import current_platform
 
 from ....utils import RemoteOpenAIServer
 
-MODEL_NAME = "Qwen/Qwen2-1.5B-Instruct"
+GSM8K_SPEC = get_gsm8k_eval_spec("openai_entrypoint", "qwen2-1.5b-instruct")
+assert GSM8K_SPEC.model is not None
+MODEL_NAME = GSM8K_SPEC.model
 NUM_CONCURRENT = 500
-RTOL = 0.03
-EXPECTED_VALUE = 0.54
 DEFAULT_ARGS = ["--max-model-len", "4096"]
 MORE_ARGS_LIST = [
     [],  # Default
@@ -56,9 +57,10 @@ def run_test(more_args):
         result = evaluate_gsm8k_lm_eval(
             model="local-completions",
             model_args=model_args,
+            **GSM8K_SPEC.lm_eval_kwargs(),
         )
 
-        assert_min_accuracy(result, EXPECTED_VALUE, tolerance=RTOL)
+        assert_gsm8k_result(result, GSM8K_SPEC)
 
 
 def test_lm_eval_accuracy_v1_engine():

--- a/tests/evals/gsm8k/README.md
+++ b/tests/evals/gsm8k/README.md
@@ -1,6 +1,17 @@
 # GSM8K Accuracy Evaluation
 
-This directory contains a replacement for the lm-eval-harness GSM8K evaluation, using an isolated GSM8K script and vLLM server for better performance and control.
+This directory owns the shared result and assertion contract for GSM8K tests.
+It supports two explicit benchmark profiles:
+
+- `isolated-v1` uses the in-repo prompt builder and last-number scorer. It can
+  run against a vLLM server or an offline `LLM` and remains the fast path for
+  most model and feature correctness tests.
+- `lm-eval-v3` delegates prompting and scoring to lm-eval's version 3 `gsm8k`
+  task. It supports offline vLLM and OpenAI-compatible server adapters.
+
+The profiles are not score-equivalent. Tests must keep their existing profile
+and baseline unless they are deliberately rebaselined with model evaluation
+results.
 
 ## Usage
 
@@ -38,3 +49,26 @@ env:                      # Environment variables (optional)
 The `server_args` field accepts any arguments that can be passed to `vllm serve`.
 
 The `env` field accepts a dictionary of environment variables to set for the server process.
+
+## Shared test API
+
+Both profiles return `GSM8KResult`. Accuracy gates should use
+`assert_min_accuracy`, which reports the profile and metric and treats accuracy
+improvements as passing:
+
+```python
+from tests.evals.gsm8k.gsm8k_eval import (
+    assert_min_accuracy,
+    evaluate_gsm8k_lm_eval,
+)
+
+result = evaluate_gsm8k_lm_eval(
+    model="vllm",
+    model_args="pretrained=Qwen/Qwen3-1.7B,max_model_len=4096",
+)
+assert_min_accuracy(result, expected=0.68, tolerance=0.03)
+```
+
+`gsm8k_platinum`, the generic multi-task `.buildkite/lm-eval-harness` jobs, and
+uses of GSM8K questions as benchmark traffic are separate contracts and
+intentionally do not use this API.

--- a/tests/evals/gsm8k/README.md
+++ b/tests/evals/gsm8k/README.md
@@ -13,6 +13,24 @@ The profiles are not score-equivalent. Tests must keep their existing profile
 and baseline unless they are deliberately rebaselined with model evaluation
 results.
 
+## Evaluation inventory
+
+GSM8K benchmark definitions live in this directory even when the test launcher
+belongs to a topology-specific suite:
+
+- `configs/evals.yaml` is the searchable inventory for distributed,
+  entrypoint, connector, quantization, offloading, and speculative-decoding
+  tests. Each case records its source test, model, profile, metric, sample
+  count, few-shot count, token cap, accuracy floor, and tolerance.
+- The other `configs/*.yaml` files describe models run by
+  `test_gsm8k_correctness.py`; the adjacent `models-*.txt` files select which
+  configs each CI job runs.
+
+Topology-specific process setup stays with its owning test so hardware marks,
+fixtures, and feature assertions remain discoverable in that area. Those tests
+load their GSM8K settings through `get_gsm8k_eval_spec` instead of defining
+benchmark constants inline.
+
 ## Usage
 
 ### Run tests with pytest (like buildkite)
@@ -53,22 +71,25 @@ The `env` field accepts a dictionary of environment variables to set for the ser
 ## Shared test API
 
 Both profiles return `GSM8KResult`. Accuracy gates should use
-`assert_min_accuracy`, which reports the profile and metric and treats accuracy
-improvements as passing:
+`assert_gsm8k_result`, which verifies the YAML-selected profile and metric and
+treats accuracy improvements as passing:
 
 ```python
 from tests.evals.gsm8k.gsm8k_eval import (
-    assert_min_accuracy,
+    assert_gsm8k_result,
     evaluate_gsm8k_lm_eval,
+    get_gsm8k_eval_spec,
 )
 
+spec = get_gsm8k_eval_spec("llm_entrypoint", "qwen3-1.7b")
 result = evaluate_gsm8k_lm_eval(
     model="vllm",
     model_args="pretrained=Qwen/Qwen3-1.7B,max_model_len=4096",
+    **spec.lm_eval_kwargs(),
 )
-assert_min_accuracy(result, expected=0.68, tolerance=0.03)
+assert_gsm8k_result(result, spec)
 ```
 
-`gsm8k_platinum`, the generic multi-task `.buildkite/lm-eval-harness` jobs, and
-uses of GSM8K questions as benchmark traffic are separate contracts and
-intentionally do not use this API.
+`gsm8k_platinum`, generic multi-task `.buildkite/lm-eval-harness` jobs, and uses
+of GSM8K questions as benchmark traffic are separate contracts. They are not
+dedicated GSM8K correctness evals and intentionally do not use this API.

--- a/tests/evals/gsm8k/configs/evals.yaml
+++ b/tests/evals/gsm8k/configs/evals.yaml
@@ -1,0 +1,350 @@
+version: 1
+
+# This is the inventory for GSM8K evaluations whose launchers live outside
+# tests/evals/gsm8k. Topology-specific settings stay with their owning tests;
+# benchmark profile, sample size, few-shot count, and accuracy floor live here.
+profiles:
+  isolated-v1:
+    metric: last-number-exact-match
+    num_questions: 1319
+    num_fewshot: 5
+    max_tokens: 512
+    tolerance: 0.0
+  lm-eval-v3:
+    metric: exact_match,strict-match
+    num_questions: 1319
+    num_fewshot: 5
+    max_tokens: 0
+    tolerance: 0.0
+
+suites:
+  context_parallel:
+    source: tests/distributed/test_context_parallel.py
+    profile: lm-eval-v3
+    cases:
+      deepseek-v2-lite-chat:
+        model: deepseek-ai/DeepSeek-V2-Lite-Chat
+        accuracy_threshold: 0.64
+      qwen2.5-1.5b-instruct:
+        model: Qwen/Qwen2.5-1.5B-Instruct
+        accuracy_threshold: 0.52
+      qwen3.5-0.8b:
+        model: Qwen/Qwen3.5-0.8B
+        accuracy_threshold: 0.33
+
+  elastic_ep:
+    source: tests/distributed/test_elastic_ep.py
+    profile: isolated-v1
+    defaults:
+      num_questions: 256
+    cases:
+      deepseek-v2-lite-chat:
+        model: deepseek-ai/DeepSeek-V2-Lite-Chat
+        accuracy_threshold: 0.58
+
+  eplb_spec_decode:
+    source: tests/distributed/test_eplb_spec_decode.py
+    profile: lm-eval-v3
+    defaults:
+      num_fewshot: 8
+      tolerance: 0.03
+    cases:
+      qwen3-next-mtp:
+        model: Qwen/Qwen3-Next-80B-A3B-Instruct
+        accuracy_threshold: 0.86
+      llama4-scout-eagle:
+        model: meta-llama/Llama-4-Scout-17B-16E-Instruct
+        accuracy_threshold: 0.92
+      qwen3-next-mtp-async:
+        model: Qwen/Qwen3-Next-80B-A3B-Instruct
+        accuracy_threshold: 0.86
+
+  llm_entrypoint:
+    source: tests/entrypoints/llm/test_accuracy.py
+    profile: lm-eval-v3
+    defaults:
+      tolerance: 0.03
+    cases:
+      qwen3-1.7b:
+        model: Qwen/Qwen3-1.7B
+        accuracy_threshold: 0.68
+      gemma3-1b-it:
+        model: google/gemma-3-1b-it
+        accuracy_threshold: 0.25
+      qwen3-1.7b-fp8-kv:
+        model: Qwen/Qwen3-1.7B
+        accuracy_threshold: 0.68
+
+  openai_entrypoint:
+    source: tests/entrypoints/openai/correctness/test_lmeval.py
+    profile: lm-eval-v3
+    defaults:
+      tolerance: 0.03
+    cases:
+      qwen2-1.5b-instruct:
+        model: Qwen/Qwen2-1.5B-Instruct
+        accuracy_threshold: 0.54
+
+  kv_offloading:
+    source: tests/evals/gsm8k/test_gsm8k_offloading.py
+    profile: isolated-v1
+    defaults:
+      num_questions: 200
+      tolerance: 0.05
+    cases:
+      offloading-nemotron-h-8b:
+        model: nvidia/Nemotron-H-8B-Base-8K
+        accuracy_threshold: 0.39
+      offloading-gemma-4-e4b-it:
+        model: google/gemma-4-E4B-it
+        accuracy_threshold: 0.55
+      offloading-qwen3.5-35b:
+        model: Qwen/Qwen3.5-35B-A3B
+        accuracy_threshold: 0.75
+      offloading-deepseek-v4-flash:
+        model: deepseek-ai/DeepSeek-V4-Flash
+        accuracy_threshold: 0.90
+      offloading-deepseek-v2-lite-tiering-tp2:
+        model: deepseek-ai/DeepSeek-V2-Lite
+        accuracy_threshold: 0.35
+      simple-nemotron-h-8b:
+        model: nvidia/Nemotron-H-8B-Base-8K
+        accuracy_threshold: 0.45
+      simple-gemma-4-e4b-it:
+        model: google/gemma-4-E4B-it
+        accuracy_threshold: 0.55
+      simple-qwen3.5-35b:
+        model: Qwen/Qwen3.5-35B-A3B
+        accuracy_threshold: 0.75
+      simple-deepseek-v4-flash:
+        model: deepseek-ai/DeepSeek-V4-Flash
+        accuracy_threshold: 0.90
+
+  quark:
+    source: tests/quantization/test_quark.py
+    profile: lm-eval-v3
+    defaults:
+      num_fewshot: 8
+      tolerance: 0.03
+    cases:
+      deepseek-r1-mxfp4:
+        model: amd/DeepSeek-R1-WMXFP4-AMXFP4-Scale-UINT8-MoE-Quant
+        accuracy_threshold: 0.96
+
+  dbo:
+    source: tests/v1/distributed/test_dbo.py
+    profile: isolated-v1
+    defaults:
+      num_questions: 256
+    cases:
+      deepseek-v2-lite-chat:
+        model: deepseek-ai/DeepSeek-V2-Lite-Chat
+        accuracy_threshold: 0.62
+
+  dflash:
+    source: tests/v1/e2e/spec_decode/acceptance_rates/dflash/test_dflash.py
+    profile: isolated-v1
+    cases:
+      qwen3-mrv1:
+        model: Qwen/Qwen3-8B
+        accuracy_threshold: 0.80
+      qwen3-mrv2:
+        model: Qwen/Qwen3-8B
+        accuracy_threshold: 0.80
+      laguna-nvfp4-mrv2:
+        model: poolside/Laguna-XS-2.1-NVFP4
+        accuracy_threshold: 0.70
+        num_questions: 200
+
+  dspark:
+    source: tests/v1/e2e/spec_decode/acceptance_rates/dspark/test_dspark.py
+    profile: isolated-v1
+    defaults:
+      max_tokens: 256
+    cases:
+      qwen3-deepspec:
+        model: Qwen/Qwen3-4B-FP8
+        accuracy_threshold: 0.76095
+      gemma4-deepspec:
+        model: RedHatAI/gemma-4-12B-it-NVFP4
+        accuracy_threshold: 0.874
+        num_questions: 200
+      qwen3.6-speculators:
+        model: RedHatAI/Qwen3.6-35B-A3B-NVFP4
+        accuracy_threshold: 0.8075
+        num_questions: 200
+
+  spec_decode:
+    source: tests/v1/e2e/spec_decode/utils.py
+    profile: isolated-v1
+    cases:
+      default-sanity:
+        accuracy_threshold: 0.70
+
+  spec_decode_speculators:
+    source: tests/v1/e2e/spec_decode/speculators/test_speculators.py
+    profile: isolated-v1
+    cases:
+      llama3-eagle3:
+        model: RedHatAI/Llama-3.1-8B-Instruct-speculator.eagle3
+        accuracy_threshold: 0.72
+      qwen3-eagle3:
+        model: RedHatAI/Qwen3-8B-speculator.eagle3
+        accuracy_threshold: 0.84
+
+  ngram_suffix:
+    source: tests/v1/e2e/spec_decode/ngram_suffix/test_ngram_suffix.py
+    profile: isolated-v1
+    cases:
+      ngram:
+        accuracy_threshold: 0.70
+      suffix:
+        accuracy_threshold: 0.70
+      qwen3-ngram-gpu-async:
+        model: Qwen/Qwen3-8B
+        accuracy_threshold: 0.80
+
+  mtp:
+    source: tests/v1/e2e/spec_decode/mtp/test_mtp.py
+    profile: isolated-v1
+    cases:
+      mimo:
+        model: XiaomiMiMo/MiMo-7B-Base
+        accuracy_threshold: 0.50
+      deepseek-dummy:
+        model: ZixiQi/DeepSeek-V3-4layers-MTP-FP8
+        accuracy_threshold: 0.0
+      qwen3.5-hybrid:
+        model: Qwen/Qwen3.5-0.8B-Base
+        accuracy_threshold: 0.20
+      gemma4-e4b:
+        model: google/gemma-4-E4B-it
+        accuracy_threshold: 0.50
+
+  eagle:
+    source: tests/v1/e2e/spec_decode/eagle/test_eagle_correctness.py
+    profile: isolated-v1
+    cases:
+      deepseek-eagle-dummy:
+        model: eagle618/deepseek-v3-random
+        accuracy_threshold: 0.0
+      qwen3-eagle3:
+        model: Qwen/Qwen3-8B
+        accuracy_threshold: 0.80
+      qwen3-eagle3-transformers:
+        model: Qwen/Qwen3-8B
+        accuracy_threshold: 0.80
+      qwen3-vl-eagle3:
+        model: Qwen/Qwen3-VL-8B-Instruct
+        accuracy_threshold: 0.80
+      qwen2.5-vl-eagle3:
+        model: Qwen/Qwen2.5-VL-7B-Instruct
+        accuracy_threshold: 0.70
+      llama3-eagle3:
+        model: meta-llama/Llama-3.1-8B-Instruct
+        accuracy_threshold: 0.70
+
+  draft_model:
+    source: tests/v1/e2e/spec_decode/draft_model/test_draft_model.py
+    profile: isolated-v1
+    cases:
+      qwen3-0.6b-self-draft:
+        model: Qwen/Qwen3-0.6B
+        accuracy_threshold: 0.25
+      qwen3-1.7b-draft-0.6b:
+        model: Qwen/Qwen3-1.7B
+        accuracy_threshold: 0.50
+      qwen3-1.7b-tp2:
+        model: Qwen/Qwen3-1.7B
+        accuracy_threshold: 0.50
+
+  nixl:
+    source: tests/v1/kv_connector/nixl_integration/test_accuracy.py
+    profile: lm-eval-v3
+    defaults:
+      tolerance: 0.05
+    cases:
+      qwen3-0.6b:
+        model: Qwen/Qwen3-0.6B
+        accuracy_threshold: 0.41
+      deepseek-vl2-small:
+        model: deepseek-ai/deepseek-vl2-small
+        accuracy_threshold: 0.59
+      deepseek-vl2-tiny:
+        model: deepseek-ai/deepseek-vl2-tiny
+        accuracy_threshold: 0.19
+      deepseek-v2-lite-chat:
+        model: deepseek-ai/DeepSeek-V2-Lite-Chat
+        accuracy_threshold: 0.65
+      gemma3-4b-it:
+        model: google/gemma-3-4b-it
+        accuracy_threshold: 0.74
+      nemotron3-nano-fp8:
+        model: nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-FP8
+        accuracy_threshold: 0.84
+      granite4-h-tiny:
+        model: ibm-granite/granite-4.0-h-tiny
+        accuracy_threshold: 0.77
+      qwen3.5-0.8b:
+        model: Qwen/Qwen3.5-0.8B
+        accuracy_threshold: 0.33
+      gemma4-e2b-it:
+        model: google/gemma-4-E2B-it
+        accuracy_threshold: 0.485
+      jamba2-3b:
+        model: ai21labs/AI21-Jamba2-3B
+        accuracy_threshold: 0.74
+      deepseek-v4-flash:
+        model: deepseek-ai/DeepSeek-V4-Flash
+        accuracy_threshold: 0.95
+
+  mooncake:
+    source: tests/v1/kv_connector/mooncake_integration/test_accuracy.py
+    profile: lm-eval-v3
+    defaults:
+      tolerance: 0.05
+    cases:
+      qwen3-0.6b:
+        model: Qwen/Qwen3-0.6B
+        accuracy_threshold: 0.41
+
+  speculators:
+    source: tests/v1/spec_decode/test_speculators_correctness.py
+    profile: isolated-v1
+    cases:
+      dflash:
+        model: nm-testing/dflash-qwen3-8b-speculators
+        accuracy_threshold: 0.85845
+      peagle:
+        model: nm-testing/qwen3-8b-peagle-speculators
+        accuracy_threshold: 0.836
+      qwen3arch-eagle3:
+        model: inference-optimization/Qwen3-8B-from-Qwen3-8B_regen-speculators.eagle3-qwen3arch-ckpt1
+        accuracy_threshold: 0.836
+      qwen3arch-peagle:
+        model: inference-optimization/Qwen3-8B-speculators.peagle-qwen3arch-ckpt4
+        accuracy_threshold: 0.836
+
+  scheduled_integration:
+    source: .buildkite/scripts/scheduled_integration_test
+    profile: isolated-v1
+    defaults:
+      num_questions: 200
+      max_tokens: 256
+    cases:
+      qwen3-next-mtp-async-eplb:
+        model: Qwen/Qwen3-Next-80B-A3B-Instruct
+        accuracy_threshold: 0.80
+        num_questions: 1319
+      qwen3-30b-fp8-dp4-async-eplb:
+        model: Qwen/Qwen3-30B-A3B-FP8
+        accuracy_threshold: 0.80
+      qwen3-30b-fp8-block-ep-eplb:
+        model: QWen/Qwen3-30B-A3B-FP8
+        accuracy_threshold: 0.80
+      deepseek-v2-lite-prefetch-offload:
+        model: deepseek-ai/DeepSeek-V2-Lite
+        accuracy_threshold: 0.25
+      deepseek-v2-lite-ep-eplb:
+        model: deepseek-ai/DeepSeek-V2-lite
+        accuracy_threshold: 0.25

--- a/tests/evals/gsm8k/gsm8k_eval.py
+++ b/tests/evals/gsm8k/gsm8k_eval.py
@@ -1,18 +1,19 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""
-Isolated GSM8K evaluation script for vLLM serve endpoint.
-"""
+"""Shared GSM8K evaluation helpers and vLLM server CLI."""
 
 import argparse
 import ast
 import asyncio
 import json
+import math
 import os
 import tempfile
 import time
 from collections.abc import Generator
+from dataclasses import asdict, dataclass
+from typing import Any, Literal
 
 import aiohttp
 import numpy as np
@@ -23,6 +24,86 @@ from tqdm.asyncio import tqdm
 from vllm.assets.base import VLLM_S3_BUCKET_URL
 
 INVALID = -9999999
+GSM8K_TASK = "gsm8k"
+STRICT_MATCH = "exact_match,strict-match"
+FLEXIBLE_EXTRACT = "exact_match,flexible-extract"
+
+
+@dataclass(frozen=True)
+class GSM8KResult:
+    """Normalized result returned by every GSM8K evaluation path."""
+
+    accuracy: float
+    profile: Literal["isolated-v1", "lm-eval-v3"]
+    metric: str
+    num_questions: int = 0
+    num_shots: int = 0
+    max_tokens: int = 0
+    invalid_rate: float = 0.0
+    latency: float = 0.0
+    questions_per_second: float = 0.0
+    total_output_tokens: int = 0
+    tokens_per_second: float = 0.0
+    timestamp: float = 0.0
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable representation."""
+        return asdict(self)
+
+
+def assert_min_accuracy(
+    result: GSM8KResult,
+    expected: float,
+    *,
+    tolerance: float = 0.0,
+    context: str = "GSM8K",
+) -> None:
+    """Assert a one-sided accuracy floor with an optional absolute tolerance."""
+    minimum = expected - tolerance
+    if result.accuracy < minimum and not math.isclose(
+        result.accuracy, minimum, abs_tol=1e-12
+    ):
+        raise AssertionError(
+            f"{context}: {result.profile}/{result.metric} accuracy "
+            f"{result.accuracy:.4f} < {minimum:.4f} "
+            f"(expected {expected:.4f}, tolerance {tolerance:.4f})"
+        )
+
+
+def result_from_lm_eval(
+    results: dict[str, Any], metric: str = STRICT_MATCH
+) -> GSM8KResult:
+    """Normalize the output of lm-eval's version 3 GSM8K task."""
+    try:
+        accuracy = float(results["results"][GSM8K_TASK][metric])
+    except (KeyError, TypeError, ValueError) as exc:
+        raise ValueError(f"lm-eval did not return GSM8K metric {metric!r}") from exc
+    return GSM8KResult(
+        accuracy=accuracy,
+        profile="lm-eval-v3",
+        metric=metric,
+    )
+
+
+def evaluate_gsm8k_lm_eval(
+    *,
+    model: str,
+    model_args: str | dict[str, Any],
+    metric: str = STRICT_MATCH,
+    **kwargs: Any,
+) -> GSM8KResult:
+    """Run the canonical lm-eval GSM8K task and normalize its result."""
+    import lm_eval
+
+    results = lm_eval.simple_evaluate(
+        model=model,
+        model_args=model_args,
+        tasks=GSM8K_TASK,
+        **kwargs,
+    )
+    if results is None:
+        raise RuntimeError("lm-eval returned no GSM8K results")
+    return result_from_lm_eval(results, metric)
 
 
 def download_and_cache_file(url: str, filename: str | None = None) -> str:
@@ -101,16 +182,12 @@ async def call_vllm_api(
     if seed is not None:
         data["seed"] = seed
 
-    try:
-        async with session.post(f"{url}/v1/completions", json=data) as response:
-            response.raise_for_status()
-            result = await response.json()
-            text = result["choices"][0]["text"]
-            completion_tokens = result.get("usage", {}).get("completion_tokens", 0)
-            return text, completion_tokens
-    except Exception as e:
-        print(f"Error calling vLLM API ({type(e).__name__}): {e}")
-        return "", 0
+    async with session.post(f"{url}/v1/completions", json=data) as response:
+        response.raise_for_status()
+        result = await response.json()
+        text = result["choices"][0]["text"]
+        completion_tokens = result.get("usage", {}).get("completion_tokens", 0)
+        return text, completion_tokens
 
 
 async def call_vllm_chat_api(
@@ -134,16 +211,12 @@ async def call_vllm_chat_api(
     if seed is not None:
         data["seed"] = seed
 
-    try:
-        async with session.post(f"{url}/v1/chat/completions", json=data) as response:
-            response.raise_for_status()
-            result = await response.json()
-            text = result["choices"][0]["message"]["content"] or ""
-            completion_tokens = result.get("usage", {}).get("completion_tokens", 0)
-            return text, completion_tokens
-    except Exception as e:
-        print(f"Error calling vLLM chat API ({type(e).__name__}): {e}")
-        return "", 0
+    async with session.post(f"{url}/v1/chat/completions", json=data) as response:
+        response.raise_for_status()
+        result = await response.json()
+        text = result["choices"][0]["message"]["content"] or ""
+        completion_tokens = result.get("usage", {}).get("completion_tokens", 0)
+        return text, completion_tokens
 
 
 def _build_gsm8k_prompts(
@@ -184,8 +257,8 @@ def _score_gsm8k(
     num_shots: int,
     max_tokens: int,
     latency: float,
-) -> dict[str, float | int]:
-    """Score GSM8K responses and return a results dict."""
+) -> GSM8KResult:
+    """Score GSM8K responses using the isolated-v1 profile."""
     num_questions = len(labels)
     preds = [get_answer_value(state) for state in states]
     accuracy = np.mean(np.array(preds) == np.array(labels))
@@ -193,18 +266,20 @@ def _score_gsm8k(
     total_output_tokens = sum(output_tokens)
     tokens_per_second = total_output_tokens / latency if latency > 0 else 0.0
 
-    return {
-        "accuracy": accuracy,
-        "invalid_rate": invalid_rate,
-        "latency": latency,
-        "questions_per_second": num_questions / latency if latency > 0 else 0.0,
-        "total_output_tokens": total_output_tokens,
-        "tokens_per_second": tokens_per_second,
-        "num_questions": num_questions,
-        "num_shots": num_shots,
-        "max_tokens": max_tokens,
-        "timestamp": time.time(),
-    }
+    return GSM8KResult(
+        accuracy=float(accuracy),
+        profile="isolated-v1",
+        metric="last-number-exact-match",
+        invalid_rate=float(invalid_rate),
+        latency=latency,
+        questions_per_second=(num_questions / latency if latency > 0 else 0.0),
+        total_output_tokens=total_output_tokens,
+        tokens_per_second=tokens_per_second,
+        num_questions=num_questions,
+        num_shots=num_shots,
+        max_tokens=max_tokens,
+        timestamp=time.time(),
+    )
 
 
 def evaluate_gsm8k(
@@ -220,7 +295,7 @@ def evaluate_gsm8k(
     request_timeout_seconds: float = 600,
     gen_prefix: str = "",
     max_concurrency: int | None = None,
-) -> dict[str, float | int]:
+) -> GSM8KResult:
     """
     Evaluate GSM8K accuracy using vLLM serve endpoint.
 
@@ -295,7 +370,7 @@ def evaluate_gsm8k_offline(
     gen_prefix: str = "",
     use_chat_completions: bool = False,
     chat_template_kwargs: dict[str, object] | None = None,
-) -> dict[str, float | int]:
+) -> GSM8KResult:
     """Evaluate GSM8K accuracy using an offline vllm.LLM object.
 
     Same prompts and scoring as evaluate_gsm8k(), but runs generation
@@ -381,17 +456,17 @@ def main() -> None:
 
     # Print results to terminal
     print("\nResults:")
-    print(f"Accuracy: {result['accuracy']:.3f}")
-    print(f"Invalid responses: {result['invalid_rate']:.3f}")
-    print(f"Total latency: {result['latency']:.3f} s")
-    print(f"Questions per second: {result['questions_per_second']:.3f}")
-    print(f"Total output tokens: {result['total_output_tokens']}")
-    print(f"Output tokens per second: {result['tokens_per_second']:.3f}")
+    print(f"Accuracy: {result.accuracy:.3f}")
+    print(f"Invalid responses: {result.invalid_rate:.3f}")
+    print(f"Total latency: {result.latency:.3f} s")
+    print(f"Questions per second: {result.questions_per_second:.3f}")
+    print(f"Total output tokens: {result.total_output_tokens}")
+    print(f"Output tokens per second: {result.tokens_per_second:.3f}")
 
     # Optional file saving
     if args.save_results:
         with open(args.save_results, "w") as f:
-            json.dump(result, f, indent=2)
+            json.dump(result.to_dict(), f, indent=2)
         print(f"Results saved to {args.save_results}")
 
 

--- a/tests/evals/gsm8k/gsm8k_eval.py
+++ b/tests/evals/gsm8k/gsm8k_eval.py
@@ -13,12 +13,15 @@ import tempfile
 import time
 from collections.abc import Generator
 from dataclasses import asdict, dataclass
-from typing import Any, Literal
+from functools import cache
+from pathlib import Path
+from typing import Any, Literal, TypedDict, cast
 
 import aiohttp
 import numpy as np
 import regex as re
 import requests
+import yaml
 from tqdm.asyncio import tqdm
 
 from vllm.assets.base import VLLM_S3_BUCKET_URL
@@ -27,6 +30,99 @@ INVALID = -9999999
 GSM8K_TASK = "gsm8k"
 STRICT_MATCH = "exact_match,strict-match"
 FLEXIBLE_EXTRACT = "exact_match,flexible-extract"
+GSM8K_EVALS_PATH = Path(__file__).with_name("configs") / "evals.yaml"
+
+
+class IsolatedEvalKwargs(TypedDict):
+    num_questions: int
+    num_shots: int
+    max_tokens: int
+
+
+@dataclass(frozen=True)
+class GSM8KEvalSpec:
+    """YAML-owned definition of a GSM8K evaluation."""
+
+    suite: str
+    id: str
+    source: str
+    profile: Literal["isolated-v1", "lm-eval-v3"]
+    metric: str
+    accuracy_threshold: float
+    tolerance: float
+    num_questions: int
+    num_fewshot: int
+    max_tokens: int
+    model: str | None = None
+
+    @property
+    def name(self) -> str:
+        return f"{self.suite}.{self.id}"
+
+    def isolated_kwargs(self) -> IsolatedEvalKwargs:
+        return {
+            "num_questions": self.num_questions,
+            "num_shots": self.num_fewshot,
+            "max_tokens": self.max_tokens,
+        }
+
+    def lm_eval_kwargs(self) -> dict[str, int]:
+        return {"num_fewshot": self.num_fewshot}
+
+
+@cache
+def load_gsm8k_eval_specs(suite: str) -> tuple[GSM8KEvalSpec, ...]:
+    """Load one suite's evaluation definitions from the common manifest."""
+    with open(GSM8K_EVALS_PATH) as config_file:
+        manifest = yaml.safe_load(config_file)
+
+    try:
+        suite_data = manifest["suites"][suite]
+    except (KeyError, TypeError) as exc:
+        raise KeyError(f"Unknown GSM8K eval suite {suite!r}") from exc
+
+    profile_name = suite_data["profile"]
+    try:
+        profile_defaults = manifest["profiles"][profile_name]
+    except (KeyError, TypeError) as exc:
+        raise ValueError(
+            f"GSM8K eval suite {suite!r} has unknown profile {profile_name!r}"
+        ) from exc
+
+    specs = []
+    for case_id, case_data in suite_data["cases"].items():
+        values = profile_defaults | suite_data.get("defaults", {}) | case_data
+        tolerance = float(values["tolerance"])
+        accuracy_threshold = float(values["accuracy_threshold"])
+        if tolerance < 0:
+            raise ValueError(f"{suite}.{case_id} has a negative tolerance")
+        if not 0 <= accuracy_threshold <= 1:
+            raise ValueError(f"{suite}.{case_id} has an invalid accuracy threshold")
+
+        specs.append(
+            GSM8KEvalSpec(
+                suite=suite,
+                id=case_id,
+                source=suite_data["source"],
+                profile=cast(Literal["isolated-v1", "lm-eval-v3"], profile_name),
+                metric=values["metric"],
+                accuracy_threshold=accuracy_threshold,
+                tolerance=tolerance,
+                num_questions=int(values["num_questions"]),
+                num_fewshot=int(values["num_fewshot"]),
+                max_tokens=int(values["max_tokens"]),
+                model=values.get("model"),
+            )
+        )
+    return tuple(specs)
+
+
+def get_gsm8k_eval_spec(suite: str, case_id: str) -> GSM8KEvalSpec:
+    """Return one named evaluation from the common manifest."""
+    try:
+        return next(spec for spec in load_gsm8k_eval_specs(suite) if spec.id == case_id)
+    except StopIteration as exc:
+        raise KeyError(f"Unknown GSM8K eval {suite}.{case_id}") from exc
 
 
 @dataclass(frozen=True)
@@ -68,6 +164,26 @@ def assert_min_accuracy(
             f"{result.accuracy:.4f} < {minimum:.4f} "
             f"(expected {expected:.4f}, tolerance {tolerance:.4f})"
         )
+
+
+def assert_gsm8k_result(
+    result: GSM8KResult,
+    spec: GSM8KEvalSpec,
+    *,
+    context: str | None = None,
+) -> None:
+    """Validate a result against its YAML-owned profile and accuracy floor."""
+    if (result.profile, result.metric) != (spec.profile, spec.metric):
+        raise AssertionError(
+            f"{spec.name}: expected {spec.profile}/{spec.metric}, got "
+            f"{result.profile}/{result.metric}"
+        )
+    assert_min_accuracy(
+        result,
+        spec.accuracy_threshold,
+        tolerance=spec.tolerance,
+        context=context or spec.name,
+    )
 
 
 def result_from_lm_eval(
@@ -439,14 +555,30 @@ def main() -> None:
         type=int,
         help="Maximum number of concurrent requests",
     )
+    parser.add_argument(
+        "--eval-spec",
+        help="Evaluation ID from configs/evals.yaml, formatted as suite.case",
+    )
     parser.add_argument("--save-results", type=str, help="Save results to JSON file")
 
     args = parser.parse_args()
+    gsm8k_spec = None
+    eval_kwargs: IsolatedEvalKwargs = {
+        "num_questions": args.num_questions,
+        "num_shots": args.num_shots,
+        "max_tokens": args.max_tokens,
+    }
+    if args.eval_spec:
+        suite, separator, case_id = args.eval_spec.partition(".")
+        if not separator:
+            parser.error("--eval-spec must be formatted as suite.case")
+        gsm8k_spec = get_gsm8k_eval_spec(suite, case_id)
+        if gsm8k_spec.profile != "isolated-v1":
+            parser.error("the server CLI only supports isolated-v1 eval specs")
+        eval_kwargs = gsm8k_spec.isolated_kwargs()
 
     result = evaluate_gsm8k(
-        num_questions=args.num_questions,
-        num_shots=args.num_shots,
-        max_tokens=args.max_tokens,
+        **eval_kwargs,
         host=args.host,
         port=args.port,
         temperature=args.temperature,
@@ -468,6 +600,9 @@ def main() -> None:
         with open(args.save_results, "w") as f:
             json.dump(result.to_dict(), f, indent=2)
         print(f"Results saved to {args.save_results}")
+
+    if gsm8k_spec is not None:
+        assert_gsm8k_result(result, gsm8k_spec)
 
 
 if __name__ == "__main__":

--- a/tests/evals/gsm8k/test_gsm8k_correctness.py
+++ b/tests/evals/gsm8k/test_gsm8k_correctness.py
@@ -18,12 +18,12 @@ import yaml
 from tests.utils import RemoteOpenAIServer
 from vllm.platforms import current_platform
 
-from .gsm8k_eval import evaluate_gsm8k
+from .gsm8k_eval import GSM8KResult, assert_min_accuracy, evaluate_gsm8k
 
 DEFAULT_STARTUP_MAX_WAIT_SECONDS = 1200
 
 
-def run_gsm8k_eval(eval_config: dict, server_url: str) -> dict:
+def run_gsm8k_eval(eval_config: dict, server_url: str) -> GSM8KResult:
     """Run GSM8K evaluation using our isolated script."""
     # Extract host and port from server URL
     if "://" in server_url:
@@ -173,7 +173,7 @@ def test_gsm8k_correctness(config_filename):
 
         results = run_gsm8k_eval(eval_config, server_url)
 
-        measured_metric = results["accuracy"]
+        measured_metric = results.accuracy
         expected_metric = eval_config["accuracy_threshold"]
         tol = eval_config.get("tolerance", 0.08)
 
@@ -181,14 +181,17 @@ def test_gsm8k_correctness(config_filename):
         print(f"  Measured metric: {measured_metric:.4f}")
         print(f"  Expected metric: {expected_metric:.4f}")
         print(f"  Tolerance: {tol:.4f}")
-        print(f"  Questions: {results['num_questions']}")
-        print(f"  Invalid rate: {results['invalid_rate']:.3f}")
-        print(f"  Latency: {results['latency']:.1f}s")
-        print(f"  QPS: {results['questions_per_second']:.1f}")
+        print(f"  Profile: {results.profile}/{results.metric}")
+        print(f"  Questions: {results.num_questions}")
+        print(f"  Invalid rate: {results.invalid_rate:.3f}")
+        print(f"  Latency: {results.latency:.1f}s")
+        print(f"  QPS: {results.questions_per_second:.1f}")
 
-        assert measured_metric >= expected_metric - tol, (
-            f"GSM8K metric too low: {measured_metric:.4f} < "
-            f"{expected_metric:.4f} - {tol:.4f} = {expected_metric - tol:.4f}"
+        assert_min_accuracy(
+            results,
+            expected_metric,
+            tolerance=tol,
+            context=eval_config["model_name"],
         )
 
         # Speculative configs additionally assert that drafts are actually

--- a/tests/evals/gsm8k/test_gsm8k_eval.py
+++ b/tests/evals/gsm8k/test_gsm8k_eval.py
@@ -1,0 +1,116 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import asyncio
+
+import lm_eval
+import pytest
+
+from .gsm8k_eval import (
+    STRICT_MATCH,
+    GSM8KResult,
+    _score_gsm8k,
+    assert_min_accuracy,
+    call_vllm_api,
+    evaluate_gsm8k_lm_eval,
+    result_from_lm_eval,
+)
+
+
+def test_score_gsm8k_returns_normalized_isolated_result():
+    result = _score_gsm8k(
+        states=["The answer is 12", "no numeric answer"],
+        output_tokens=[5, 3],
+        labels=[12, 9],
+        num_shots=5,
+        max_tokens=256,
+        latency=2.0,
+    )
+
+    assert result == GSM8KResult(
+        accuracy=0.5,
+        profile="isolated-v1",
+        metric="last-number-exact-match",
+        num_questions=2,
+        num_shots=5,
+        max_tokens=256,
+        invalid_rate=0.5,
+        latency=2.0,
+        questions_per_second=1.0,
+        total_output_tokens=8,
+        tokens_per_second=4.0,
+        timestamp=result.timestamp,
+    )
+    assert result.to_dict()["accuracy"] == 0.5
+
+
+def test_result_from_lm_eval_identifies_profile_and_metric():
+    result = result_from_lm_eval({"results": {"gsm8k": {STRICT_MATCH: 0.75}}})
+
+    assert result.accuracy == 0.75
+    assert result.profile == "lm-eval-v3"
+    assert result.metric == STRICT_MATCH
+
+
+def test_result_from_lm_eval_rejects_missing_metric():
+    with pytest.raises(ValueError, match="did not return GSM8K metric"):
+        result_from_lm_eval({"results": {"gsm8k": {}}})
+
+
+def test_lm_eval_adapter_selects_gsm8k(monkeypatch: pytest.MonkeyPatch):
+    received = {}
+
+    def fake_evaluate(**kwargs):
+        received.update(kwargs)
+        return {"results": {"gsm8k": {STRICT_MATCH: 0.8}}}
+
+    monkeypatch.setattr(lm_eval, "simple_evaluate", fake_evaluate)
+
+    result = evaluate_gsm8k_lm_eval(
+        model="vllm",
+        model_args="pretrained=test",
+        num_fewshot=5,
+    )
+
+    assert result.accuracy == 0.8
+    assert received == {
+        "model": "vllm",
+        "model_args": "pretrained=test",
+        "tasks": "gsm8k",
+        "num_fewshot": 5,
+    }
+
+
+def test_min_accuracy_is_one_sided():
+    improved = GSM8KResult(accuracy=0.9, profile="lm-eval-v3", metric=STRICT_MATCH)
+    at_floor = GSM8KResult(accuracy=0.72, profile="lm-eval-v3", metric=STRICT_MATCH)
+    regressed = GSM8KResult(accuracy=0.71, profile="lm-eval-v3", metric=STRICT_MATCH)
+
+    assert_min_accuracy(improved, 0.8, tolerance=0.08)
+    assert_min_accuracy(at_floor, 0.8, tolerance=0.08)
+    with pytest.raises(AssertionError, match="lm-eval-v3/exact_match,strict-match"):
+        assert_min_accuracy(regressed, 0.8, tolerance=0.08)
+
+
+def test_http_errors_fail_evaluation():
+    class FailingRequest:
+        async def __aenter__(self):
+            raise RuntimeError("server unavailable")
+
+        async def __aexit__(self, *args):
+            return None
+
+    class FailingSession:
+        def post(self, *args, **kwargs):
+            return FailingRequest()
+
+    with pytest.raises(RuntimeError, match="server unavailable"):
+        asyncio.run(
+            call_vllm_api(
+                FailingSession(),
+                prompt="Question: 1 + 1?\nAnswer:",
+                temperature=0.0,
+                max_tokens=16,
+                url="http://localhost:8000",
+            )
+        )

--- a/tests/evals/gsm8k/test_gsm8k_eval.py
+++ b/tests/evals/gsm8k/test_gsm8k_eval.py
@@ -2,17 +2,22 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import asyncio
+from pathlib import Path
 
 import lm_eval
 import pytest
 
 from .gsm8k_eval import (
+    GSM8K_EVALS_PATH,
     STRICT_MATCH,
     GSM8KResult,
     _score_gsm8k,
+    assert_gsm8k_result,
     assert_min_accuracy,
     call_vllm_api,
     evaluate_gsm8k_lm_eval,
+    get_gsm8k_eval_spec,
+    load_gsm8k_eval_specs,
     result_from_lm_eval,
 )
 
@@ -90,6 +95,55 @@ def test_min_accuracy_is_one_sided():
     assert_min_accuracy(at_floor, 0.8, tolerance=0.08)
     with pytest.raises(AssertionError, match="lm-eval-v3/exact_match,strict-match"):
         assert_min_accuracy(regressed, 0.8, tolerance=0.08)
+
+
+def test_common_manifest_loads_all_scattered_suites():
+    expected_suites = {
+        "context_parallel",
+        "elastic_ep",
+        "eplb_spec_decode",
+        "llm_entrypoint",
+        "openai_entrypoint",
+        "kv_offloading",
+        "quark",
+        "dbo",
+        "dflash",
+        "dspark",
+        "spec_decode",
+        "spec_decode_speculators",
+        "ngram_suffix",
+        "mtp",
+        "eagle",
+        "draft_model",
+        "nixl",
+        "mooncake",
+        "speculators",
+        "scheduled_integration",
+    }
+    specs = [spec for suite in expected_suites for spec in load_gsm8k_eval_specs(suite)]
+    repo_root = Path(__file__).parents[3]
+
+    assert len(specs) == 68
+    assert all((repo_root / spec.source).exists() for spec in specs)
+    assert GSM8K_EVALS_PATH.is_file()
+
+
+def test_yaml_spec_validates_profile_metric_and_floor():
+    spec = get_gsm8k_eval_spec("llm_entrypoint", "qwen3-1.7b")
+    passing = GSM8KResult(
+        accuracy=spec.accuracy_threshold,
+        profile=spec.profile,
+        metric=spec.metric,
+    )
+    wrong_profile = GSM8KResult(
+        accuracy=1.0,
+        profile="isolated-v1",
+        metric="last-number-exact-match",
+    )
+
+    assert_gsm8k_result(passing, spec)
+    with pytest.raises(AssertionError, match="expected lm-eval-v3"):
+        assert_gsm8k_result(wrong_profile, spec)
 
 
 def test_http_errors_fail_evaluation():

--- a/tests/evals/gsm8k/test_gsm8k_offloading.py
+++ b/tests/evals/gsm8k/test_gsm8k_offloading.py
@@ -38,7 +38,7 @@ import requests
 from tests.utils import RemoteOpenAIServer
 from vllm.platforms import current_platform
 
-from .gsm8k_eval import evaluate_gsm8k
+from .gsm8k_eval import assert_min_accuracy, evaluate_gsm8k
 
 if not current_platform.is_cuda_alike():
     pytest.skip("Requires CUDA or ROCm", allow_module_level=True)
@@ -274,15 +274,16 @@ def test_gsm8k_offloading_correctness(cfg: OffloadingModelConfig):
 
             print(
                 f"GSM8K run {run_idx}/2 + {cfg.connector} ({cfg.id}): "
-                f"accuracy={results['accuracy']:.4f}, "
-                f"invalid_rate={results['invalid_rate']:.3f}, "
-                f"latency={results['latency']:.1f}s"
+                f"accuracy={results.accuracy:.4f}, "
+                f"invalid_rate={results.invalid_rate:.3f}, "
+                f"latency={results.latency:.1f}s"
             )
 
-            assert results["accuracy"] >= (cfg.accuracy_threshold - cfg.tolerance), (
-                f"GSM8K run {run_idx}/2 accuracy "
-                f"{results['accuracy']:.4f} below "
-                f"{cfg.accuracy_threshold - cfg.tolerance:.4f}"
+            assert_min_accuracy(
+                results,
+                cfg.accuracy_threshold,
+                tolerance=cfg.tolerance,
+                context=f"GSM8K run {run_idx}/2 {cfg.id}",
             )
 
             if run_idx == 1:

--- a/tests/evals/gsm8k/test_gsm8k_offloading.py
+++ b/tests/evals/gsm8k/test_gsm8k_offloading.py
@@ -38,13 +38,17 @@ import requests
 from tests.utils import RemoteOpenAIServer
 from vllm.platforms import current_platform
 
-from .gsm8k_eval import assert_min_accuracy, evaluate_gsm8k
+from .gsm8k_eval import (
+    GSM8KEvalSpec,
+    assert_gsm8k_result,
+    evaluate_gsm8k,
+    load_gsm8k_eval_specs,
+)
 
 if not current_platform.is_cuda_alike():
     pytest.skip("Requires CUDA or ROCm", allow_module_level=True)
 
-NUM_QUESTIONS = 200
-NUM_FEWSHOT = 5
+GSM8K_SPECS = {spec.id: spec for spec in load_gsm8k_eval_specs("kv_offloading")}
 
 _OFFLOAD_SYNC_TIMEOUT = 60
 
@@ -113,39 +117,37 @@ def _reset_gpu_prefix_cache(base_url: str) -> None:
 
 @dataclass
 class OffloadingModelConfig:
-    id: str
-    model: str
+    gsm8k_spec: GSM8KEvalSpec
     connector: str
-    accuracy_threshold: float
-    tolerance: float = 0.05
     extra_server_args: list[str] = field(default_factory=list)
     env_dict: dict[str, str] = field(default_factory=dict)
     cpu_offload_gib: int = 4
     startup_timeout: int = 600
     spec_name: str = "CPUOffloadingSpec"
 
+    @property
+    def id(self) -> str:
+        return self.gsm8k_spec.id
+
+    @property
+    def model(self) -> str:
+        assert self.gsm8k_spec.model is not None
+        return self.gsm8k_spec.model
+
 
 MODELS = [
     # ── OffloadingConnector ──────────────────────────────────────────
     OffloadingModelConfig(
-        id="offloading-nemotron-h-8b",
-        model="nvidia/Nemotron-H-8B-Base-8K",
+        gsm8k_spec=GSM8K_SPECS["offloading-nemotron-h-8b"],
         connector="OffloadingConnector",
-        # Baseline ~0.49 on 200 questions (measured on GB200).
-        accuracy_threshold=0.39,
     ),
     OffloadingModelConfig(
-        id="offloading-gemma-4-e4b-it",
-        model="google/gemma-4-E4B-it",
+        gsm8k_spec=GSM8K_SPECS["offloading-gemma-4-e4b-it"],
         connector="OffloadingConnector",
-        # Baseline ~0.64 on 200 questions (measured on GB200).
-        accuracy_threshold=0.55,
     ),
     OffloadingModelConfig(
-        id="offloading-qwen3.5-35b",
-        model="Qwen/Qwen3.5-35B-A3B",
+        gsm8k_spec=GSM8K_SPECS["offloading-qwen3.5-35b"],
         connector="OffloadingConnector",
-        accuracy_threshold=0.75,
         extra_server_args=[
             "--tensor-parallel-size",
             "2",
@@ -154,11 +156,8 @@ MODELS = [
         startup_timeout=1200,
     ),
     OffloadingModelConfig(
-        id="offloading-deepseek-v4-flash",
-        model="deepseek-ai/DeepSeek-V4-Flash",
+        gsm8k_spec=GSM8K_SPECS["offloading-deepseek-v4-flash"],
         connector="OffloadingConnector",
-        # Baseline ~0.97 on 200 questions (measured on GB200).
-        accuracy_threshold=0.90,
         extra_server_args=[
             "--tensor-parallel-size",
             "4",
@@ -172,11 +171,8 @@ MODELS = [
         startup_timeout=1200,
     ),
     OffloadingModelConfig(
-        id="offloading-deepseek-v2-lite-tiering-tp2",
-        model="deepseek-ai/DeepSeek-V2-Lite",
+        gsm8k_spec=GSM8K_SPECS["offloading-deepseek-v2-lite-tiering-tp2"],
         connector="OffloadingConnector",
-        # Baseline 0.360/0.345 over two runs (measured on 2xA100).
-        accuracy_threshold=0.35,
         extra_server_args=[
             "--tensor-parallel-size",
             "2",
@@ -187,22 +183,16 @@ MODELS = [
     ),
     # ── SimpleCPUOffloadConnector ────────────────────────────────────
     OffloadingModelConfig(
-        id="simple-nemotron-h-8b",
-        model="nvidia/Nemotron-H-8B-Base-8K",
+        gsm8k_spec=GSM8K_SPECS["simple-nemotron-h-8b"],
         connector="SimpleCPUOffloadConnector",
-        accuracy_threshold=0.45,
     ),
     OffloadingModelConfig(
-        id="simple-gemma-4-e4b-it",
-        model="google/gemma-4-E4B-it",
+        gsm8k_spec=GSM8K_SPECS["simple-gemma-4-e4b-it"],
         connector="SimpleCPUOffloadConnector",
-        accuracy_threshold=0.55,
     ),
     OffloadingModelConfig(
-        id="simple-qwen3.5-35b",
-        model="Qwen/Qwen3.5-35B-A3B",
+        gsm8k_spec=GSM8K_SPECS["simple-qwen3.5-35b"],
         connector="SimpleCPUOffloadConnector",
-        accuracy_threshold=0.75,
         extra_server_args=[
             "--tensor-parallel-size",
             "2",
@@ -211,10 +201,8 @@ MODELS = [
         startup_timeout=1200,
     ),
     OffloadingModelConfig(
-        id="simple-deepseek-v4-flash",
-        model="deepseek-ai/DeepSeek-V4-Flash",
+        gsm8k_spec=GSM8K_SPECS["simple-deepseek-v4-flash"],
         connector="SimpleCPUOffloadConnector",
-        accuracy_threshold=0.90,
         extra_server_args=[
             "--tensor-parallel-size",
             "4",
@@ -266,8 +254,7 @@ def test_gsm8k_offloading_correctness(cfg: OffloadingModelConfig):
 
         for run_idx in range(1, 3):
             results = evaluate_gsm8k(
-                num_questions=NUM_QUESTIONS,
-                num_shots=NUM_FEWSHOT,
+                **cfg.gsm8k_spec.isolated_kwargs(),
                 host=f"http://{server.host}",
                 port=server.port,
             )
@@ -279,10 +266,9 @@ def test_gsm8k_offloading_correctness(cfg: OffloadingModelConfig):
                 f"latency={results.latency:.1f}s"
             )
 
-            assert_min_accuracy(
+            assert_gsm8k_result(
                 results,
-                cfg.accuracy_threshold,
-                tolerance=cfg.tolerance,
+                cfg.gsm8k_spec,
                 context=f"GSM8K run {run_idx}/2 {cfg.id}",
             )
 

--- a/tests/quantization/test_quark.py
+++ b/tests/quantization/test_quark.py
@@ -17,6 +17,10 @@ import pytest
 import torch
 from packaging import version
 
+from tests.evals.gsm8k.gsm8k_eval import (
+    assert_min_accuracy,
+    evaluate_gsm8k_lm_eval,
+)
 from vllm._aiter_ops import is_aiter_found_and_supported
 from vllm.model_executor.layers.quantization.quark.quark import (  # noqa: E501
     QuarkConfig,
@@ -485,23 +489,21 @@ def test_mxfp4_gsm8k_correctness(config: AccuracyTestConfig):
     if device_count < 8:
         pytest.skip(f"This test requires >=8 gpus, got only {device_count}")
 
-    task = "gsm8k"
     rtol = 0.03
 
-    results = lm_eval.simple_evaluate(
+    result = evaluate_gsm8k_lm_eval(
         model="vllm",
         model_args=config.get_model_args(tp_size=8, model_max_len=38768),
-        tasks=task,
         batch_size=64,
         num_fewshot=8,
     )
 
-    EXPECTED_VALUE = config.excepted_value
-    measured_value = results["results"][task]["exact_match,strict-match"]
-    assert (
-        measured_value - rtol < EXPECTED_VALUE
-        and measured_value + rtol > EXPECTED_VALUE
-    ), f"Expected: {EXPECTED_VALUE} |  Measured: {measured_value}"
+    assert_min_accuracy(
+        result,
+        config.excepted_value,
+        tolerance=rtol,
+        context=config.model_name,
+    )
 
 
 @pytest.mark.skipif(

--- a/tests/quantization/test_quark.py
+++ b/tests/quantization/test_quark.py
@@ -18,8 +18,10 @@ import torch
 from packaging import version
 
 from tests.evals.gsm8k.gsm8k_eval import (
-    assert_min_accuracy,
+    GSM8KEvalSpec,
+    assert_gsm8k_result,
     evaluate_gsm8k_lm_eval,
+    load_gsm8k_eval_specs,
 )
 from vllm._aiter_ops import is_aiter_found_and_supported
 from vllm.model_executor.layers.quantization.quark.quark import (  # noqa: E501
@@ -368,13 +370,7 @@ class AccuracyTestConfig:
         return model_args
 
 
-GSM8K_ACCURACY_CONFIGS = [
-    # Private model.
-    AccuracyTestConfig(
-        model_name="amd/DeepSeek-R1-WMXFP4-AMXFP4-Scale-UINT8-MoE-Quant",
-        excepted_value=0.96,
-    ),
-]
+GSM8K_ACCURACY_CONFIGS = load_gsm8k_eval_specs("quark")
 
 WIKITEXT_ACCURACY_CONFIGS = [
     AccuracyTestConfig(
@@ -484,26 +480,25 @@ def test_nvfp4_wikitext_correctness(tp_size: int):
     not HF_HUB_AMD_ORG_ACCESS,
     reason="Read access to huggingface.co/amd is required for this test.",
 )
-def test_mxfp4_gsm8k_correctness(config: AccuracyTestConfig):
+def test_mxfp4_gsm8k_correctness(config: GSM8KEvalSpec):
     device_count = torch.accelerator.device_count()
     if device_count < 8:
         pytest.skip(f"This test requires >=8 gpus, got only {device_count}")
 
-    rtol = 0.03
+    assert config.model is not None
+    model_config = AccuracyTestConfig(
+        model_name=config.model,
+        excepted_value=config.accuracy_threshold,
+    )
 
     result = evaluate_gsm8k_lm_eval(
         model="vllm",
-        model_args=config.get_model_args(tp_size=8, model_max_len=38768),
+        model_args=model_config.get_model_args(tp_size=8, model_max_len=38768),
         batch_size=64,
-        num_fewshot=8,
+        **config.lm_eval_kwargs(),
     )
 
-    assert_min_accuracy(
-        result,
-        config.excepted_value,
-        tolerance=rtol,
-        context=config.model_name,
-    )
+    assert_gsm8k_result(result, config, context=config.model)
 
 
 @pytest.mark.skipif(

--- a/tests/v1/distributed/test_dbo.py
+++ b/tests/v1/distributed/test_dbo.py
@@ -11,7 +11,7 @@ correctly with the DeepSeek-V2-Lite model using GSM8K evaluation.
 import pytest
 import torch
 
-from tests.evals.gsm8k.gsm8k_eval import evaluate_gsm8k
+from tests.evals.gsm8k.gsm8k_eval import assert_min_accuracy, evaluate_gsm8k
 from tests.utils import RemoteOpenAIServer
 from vllm.utils.import_utils import has_deep_ep
 
@@ -102,8 +102,8 @@ def test_dbo_dp_ep_gsm8k(all2all_backend: str, num_gpus_available):
         )
 
         # Validate accuracy is reasonable
-        accuracy = results["accuracy"]
-        assert accuracy >= MIN_ACCURACY, (
-            f"DBO+DP+EP accuracy too low ({all2all_backend}): "
-            f"{accuracy:.3f} < {MIN_ACCURACY:.3f} "
+        assert_min_accuracy(
+            results,
+            MIN_ACCURACY,
+            context=f"DBO+DP+EP ({all2all_backend})",
         )

--- a/tests/v1/distributed/test_dbo.py
+++ b/tests/v1/distributed/test_dbo.py
@@ -11,7 +11,11 @@ correctly with the DeepSeek-V2-Lite model using GSM8K evaluation.
 import pytest
 import torch
 
-from tests.evals.gsm8k.gsm8k_eval import assert_min_accuracy, evaluate_gsm8k
+from tests.evals.gsm8k.gsm8k_eval import (
+    assert_gsm8k_result,
+    evaluate_gsm8k,
+    get_gsm8k_eval_spec,
+)
 from tests.utils import RemoteOpenAIServer
 from vllm.utils.import_utils import has_deep_ep
 
@@ -26,13 +30,10 @@ except Exception:
     # Be conservative: if we can't detect, don't xfail by default
     IS_BLACKWELL = False
 
-MODEL_NAME = "deepseek-ai/DeepSeek-V2-Lite-Chat"
+GSM8K_SPEC = get_gsm8k_eval_spec("dbo", "deepseek-v2-lite-chat")
+assert GSM8K_SPEC.model is not None
+MODEL_NAME = GSM8K_SPEC.model
 DP_SIZE = 2
-
-# GSM8K eval configuration
-NUM_QUESTIONS = 256  # Fast eval for CI; but must be large enough to hit dbo thresholds
-NUM_SHOTS = 5  # Few-shot examples
-MIN_ACCURACY = 0.62  # Expected 0.64 with 2% buffer (based on vLLM test data)
 
 # Increase max_num_seqs to trigger DBO for decode batches
 # With 64 seqs, decode batches should exceed the 32 token threshold
@@ -51,7 +52,7 @@ DEEPEP_BACKENDS = [
     IS_BLACKWELL,
     reason=(
         "Temporary: DBO accuracy unstable on Blackwell "
-        "(doesn't meet expectation of MIN_ACCURACY = 0.62)"
+        f"(doesn't meet expectation of {GSM8K_SPEC.accuracy_threshold})"
     ),
 )
 def test_dbo_dp_ep_gsm8k(all2all_backend: str, num_gpus_available):
@@ -95,15 +96,14 @@ def test_dbo_dp_ep_gsm8k(all2all_backend: str, num_gpus_available):
 
         # Run GSM8K evaluation
         results = evaluate_gsm8k(
-            num_questions=NUM_QUESTIONS,
-            num_shots=NUM_SHOTS,
+            **GSM8K_SPEC.isolated_kwargs(),
             host=host,
             port=port,
         )
 
         # Validate accuracy is reasonable
-        assert_min_accuracy(
+        assert_gsm8k_result(
             results,
-            MIN_ACCURACY,
+            GSM8K_SPEC,
             context=f"DBO+DP+EP ({all2all_backend})",
         )

--- a/tests/v1/e2e/spec_decode/acceptance_rates/dflash/test_dflash.py
+++ b/tests/v1/e2e/spec_decode/acceptance_rates/dflash/test_dflash.py
@@ -5,7 +5,10 @@ from dataclasses import dataclass
 
 import pytest
 
-from tests.evals.gsm8k.gsm8k_eval import evaluate_gsm8k_offline
+from tests.evals.gsm8k.gsm8k_eval import (
+    assert_min_accuracy,
+    evaluate_gsm8k_offline,
+)
 from tests.utils import single_gpu_only
 from vllm.config import CompilationConfig
 
@@ -141,7 +144,7 @@ def test_dflash_correctness(
             num_questions=config.num_questions,
             use_chat_completions=config.use_chat_completions,
         )
-        accuracy = results["accuracy"]
+        accuracy = results.accuracy
         acceptance_len = compute_acceptance_len(spec_llm.get_metrics())
         context = (
             f"DFlash target={config.model}, draft={config.draft_model}, MRV2={use_mrv2}"
@@ -151,10 +154,7 @@ def test_dflash_correctness(
             f"acceptance_len={acceptance_len:.2f}"
         )
 
-        assert accuracy >= config.expected_accuracy, (
-            f"{context}: GSM8K accuracy {accuracy:.3f} is below "
-            f"{config.expected_accuracy:.3f}; acceptance_len={acceptance_len:.3f}"
-        )
+        assert_min_accuracy(results, config.expected_accuracy, context=context)
         assert acceptance_len >= config.expected_acceptance_len, (
             f"{context}: acceptance_len {acceptance_len:.3f} is below "
             f"{config.expected_acceptance_len:.3f}; accuracy={accuracy:.3f}"

--- a/tests/v1/e2e/spec_decode/acceptance_rates/dflash/test_dflash.py
+++ b/tests/v1/e2e/spec_decode/acceptance_rates/dflash/test_dflash.py
@@ -6,8 +6,10 @@ from dataclasses import dataclass
 import pytest
 
 from tests.evals.gsm8k.gsm8k_eval import (
-    assert_min_accuracy,
+    GSM8KEvalSpec,
+    assert_gsm8k_result,
     evaluate_gsm8k_offline,
+    get_gsm8k_eval_spec,
 )
 from tests.utils import single_gpu_only
 from vllm.config import CompilationConfig
@@ -20,12 +22,10 @@ from ..utils import run_acceptance_length_eval
 class DFlashCorrectnessConfig:
     model: str
     draft_model: str
-    expected_accuracy: float
     expected_acceptance_len: float
     num_speculative_tokens: int = 16
     max_model_len: int = 4096
     max_num_seqs: int = 128
-    num_questions: int = 1319
     use_chat_completions: bool = False
     enforce_eager: bool = False
     disable_flashinfer_sampler: bool = False
@@ -34,19 +34,16 @@ class DFlashCorrectnessConfig:
 QWEN3_DFLASH = DFlashCorrectnessConfig(
     model="Qwen/Qwen3-8B",
     draft_model="z-lab/Qwen3-8B-DFlash-b16",
-    expected_accuracy=0.8,
     expected_acceptance_len=3.5,
 )
 
 LAGUNA_DFLASH_NVFP4 = DFlashCorrectnessConfig(
     model="poolside/Laguna-XS-2.1-NVFP4",
     draft_model="poolside/Laguna-XS-2.1-DFlash-NVFP4",
-    expected_accuracy=0.7,  # Standard GSM8K sanity floor.
     expected_acceptance_len=3.55 * 0.9,
     num_speculative_tokens=15,
     max_model_len=8192,
     max_num_seqs=32,
-    num_questions=200,
     use_chat_completions=True,
     enforce_eager=True,
     disable_flashinfer_sampler=True,
@@ -90,20 +87,23 @@ def test_dflash_reference_acceptance_lengths(
 
 @single_gpu_only
 @pytest.mark.parametrize(
-    ("config", "use_mrv2"),
+    ("config", "gsm8k_spec", "use_mrv2"),
     [
         pytest.param(
             QWEN3_DFLASH,
+            get_gsm8k_eval_spec("dflash", "qwen3-mrv1"),
             False,
             id="qwen3-mrv1",
         ),
         pytest.param(
             QWEN3_DFLASH,
+            get_gsm8k_eval_spec("dflash", "qwen3-mrv2"),
             True,
             id="qwen3-mrv2",
         ),
         pytest.param(
             LAGUNA_DFLASH_NVFP4,
+            get_gsm8k_eval_spec("dflash", "laguna-nvfp4-mrv2"),
             True,
             id="laguna-nvfp4-mrv2",
         ),
@@ -112,10 +112,12 @@ def test_dflash_reference_acceptance_lengths(
 def test_dflash_correctness(
     monkeypatch: pytest.MonkeyPatch,
     config: DFlashCorrectnessConfig,
+    gsm8k_spec: GSM8KEvalSpec,
     use_mrv2: bool,
     vllm_runner,
 ):
     """Guard GSM8K accuracy and batched acceptance length for DFlash models."""
+    assert gsm8k_spec.model == config.model
     monkeypatch.setenv("VLLM_USE_V2_MODEL_RUNNER", "1" if use_mrv2 else "0")
     if config.disable_flashinfer_sampler:
         monkeypatch.setenv("VLLM_USE_FLASHINFER_SAMPLER", "0")
@@ -141,8 +143,8 @@ def test_dflash_correctness(
         spec_llm = spec_runner.llm
         results = evaluate_gsm8k_offline(
             spec_llm,
-            num_questions=config.num_questions,
             use_chat_completions=config.use_chat_completions,
+            **gsm8k_spec.isolated_kwargs(),
         )
         accuracy = results.accuracy
         acceptance_len = compute_acceptance_len(spec_llm.get_metrics())
@@ -154,7 +156,7 @@ def test_dflash_correctness(
             f"acceptance_len={acceptance_len:.2f}"
         )
 
-        assert_min_accuracy(results, config.expected_accuracy, context=context)
+        assert_gsm8k_result(results, gsm8k_spec, context=context)
         assert acceptance_len >= config.expected_acceptance_len, (
             f"{context}: acceptance_len {acceptance_len:.3f} is below "
             f"{config.expected_acceptance_len:.3f}; accuracy={accuracy:.3f}"

--- a/tests/v1/e2e/spec_decode/acceptance_rates/dspark/test_dspark.py
+++ b/tests/v1/e2e/spec_decode/acceptance_rates/dspark/test_dspark.py
@@ -5,7 +5,10 @@ from dataclasses import dataclass
 
 import pytest
 
-from tests.evals.gsm8k.gsm8k_eval import evaluate_gsm8k_offline
+from tests.evals.gsm8k.gsm8k_eval import (
+    assert_min_accuracy,
+    evaluate_gsm8k_offline,
+)
 from vllm.config import CompilationConfig
 from vllm.platforms import current_platform
 
@@ -133,7 +136,7 @@ def test_dspark_correctness_and_acceptance_rate(
             use_chat_completions=config.use_chat_completions,
             chat_template_kwargs=config.chat_template_kwargs,
         )
-        accuracy = results["accuracy"]
+        accuracy = results.accuracy
         metrics = spec_llm.get_metrics()
         acceptance_rate = compute_acceptance_rate(metrics)
         acceptance_len = compute_acceptance_len(metrics)
@@ -145,8 +148,10 @@ def test_dspark_correctness_and_acceptance_rate(
         )
         print(f"{context}: {metrics_summary}")
 
-        assert accuracy >= config.reference_accuracy * REGRESSION_TOLERANCE, (
-            f"{context}: {metrics_summary}"
+        assert_min_accuracy(
+            results,
+            config.reference_accuracy * REGRESSION_TOLERANCE,
+            context=context,
         )
         assert (
             acceptance_rate >= config.reference_acceptance_rate * REGRESSION_TOLERANCE

--- a/tests/v1/e2e/spec_decode/acceptance_rates/dspark/test_dspark.py
+++ b/tests/v1/e2e/spec_decode/acceptance_rates/dspark/test_dspark.py
@@ -6,8 +6,10 @@ from dataclasses import dataclass
 import pytest
 
 from tests.evals.gsm8k.gsm8k_eval import (
-    assert_min_accuracy,
+    GSM8KEvalSpec,
+    assert_gsm8k_result,
     evaluate_gsm8k_offline,
+    get_gsm8k_eval_spec,
 )
 from vllm.config import CompilationConfig
 from vllm.platforms import current_platform
@@ -21,14 +23,11 @@ REGRESSION_TOLERANCE = 0.95
 class DSparkCorrectnessConfig:
     model: str
     draft_model: str
-    reference_accuracy: float
     reference_acceptance_rate: float
     reference_acceptance_len: float
     num_speculative_tokens: int = 7
     max_model_len: int = 4096
     max_num_seqs: int | None = None
-    num_questions: int = 1319
-    max_tokens: int = 256
     use_chat_completions: bool = False
     chat_template_kwargs: dict[str, object] | None = None
     attention_backend: str | None = None
@@ -43,7 +42,6 @@ class DSparkCorrectnessConfig:
 QWEN3_DSPARK_DEEPSPEC = DSparkCorrectnessConfig(
     model="Qwen/Qwen3-4B-FP8",
     draft_model="deepseek-ai/dspark_qwen3_4b_block7",
-    reference_accuracy=0.801,
     reference_acceptance_rate=0.428,
     reference_acceptance_len=3.994,
     attention_backend="FLASH_ATTN",
@@ -54,11 +52,9 @@ QWEN3_DSPARK_DEEPSPEC = DSparkCorrectnessConfig(
 GEMMA4_DSPARK_DEEPSPEC = DSparkCorrectnessConfig(
     model="RedHatAI/gemma-4-12B-it-NVFP4",
     draft_model="deepseek-ai/dspark_gemma4_12b_block7",
-    reference_accuracy=0.92,
     reference_acceptance_rate=0.58,
     reference_acceptance_len=5.0,
     max_num_seqs=32,
-    num_questions=200,
     use_chat_completions=True,
     gpu_memory_utilization=0.85,
     enforce_eager=True,
@@ -70,12 +66,10 @@ GEMMA4_DSPARK_DEEPSPEC = DSparkCorrectnessConfig(
 QWEN3_6_DSPARK_SPECULATORS = DSparkCorrectnessConfig(
     model="RedHatAI/Qwen3.6-35B-A3B-NVFP4",
     draft_model="RedHatAI/Qwen3.6-35B-A3B-speculator.dspark",
-    reference_accuracy=0.85,
     reference_acceptance_rate=0.41,
     reference_acceptance_len=4.25,
     num_speculative_tokens=8,
     max_num_seqs=32,
-    num_questions=200,
     use_chat_completions=True,
     chat_template_kwargs={"enable_thinking": False},
     gpu_memory_utilization=0.85,
@@ -84,19 +78,33 @@ QWEN3_6_DSPARK_SPECULATORS = DSparkCorrectnessConfig(
 
 
 @pytest.mark.parametrize(
-    "config",
+    ("config", "gsm8k_spec"),
     [
-        pytest.param(QWEN3_DSPARK_DEEPSPEC, id="qwen3-deepspec"),
-        pytest.param(GEMMA4_DSPARK_DEEPSPEC, id="gemma4-deepspec"),
-        pytest.param(QWEN3_6_DSPARK_SPECULATORS, id="qwen3.6-speculators"),
+        pytest.param(
+            QWEN3_DSPARK_DEEPSPEC,
+            get_gsm8k_eval_spec("dspark", "qwen3-deepspec"),
+            id="qwen3-deepspec",
+        ),
+        pytest.param(
+            GEMMA4_DSPARK_DEEPSPEC,
+            get_gsm8k_eval_spec("dspark", "gemma4-deepspec"),
+            id="gemma4-deepspec",
+        ),
+        pytest.param(
+            QWEN3_6_DSPARK_SPECULATORS,
+            get_gsm8k_eval_spec("dspark", "qwen3.6-speculators"),
+            id="qwen3.6-speculators",
+        ),
     ],
 )
 def test_dspark_correctness_and_acceptance_rate(
     monkeypatch: pytest.MonkeyPatch,
     config: DSparkCorrectnessConfig,
+    gsm8k_spec: GSM8KEvalSpec,
     vllm_runner,
 ):
     """Guard GSM8K accuracy and acceptance metrics for DSpark models."""
+    assert gsm8k_spec.model == config.model
     if config.disable_flashinfer_sampler:
         monkeypatch.setenv("VLLM_USE_FLASHINFER_SAMPLER", "0")
 
@@ -130,11 +138,10 @@ def test_dspark_correctness_and_acceptance_rate(
         spec_llm = spec_runner.llm
         results = evaluate_gsm8k_offline(
             spec_llm,
-            num_questions=config.num_questions,
-            max_tokens=config.max_tokens,
             temperature=1.0,
             use_chat_completions=config.use_chat_completions,
             chat_template_kwargs=config.chat_template_kwargs,
+            **gsm8k_spec.isolated_kwargs(),
         )
         accuracy = results.accuracy
         metrics = spec_llm.get_metrics()
@@ -148,11 +155,7 @@ def test_dspark_correctness_and_acceptance_rate(
         )
         print(f"{context}: {metrics_summary}")
 
-        assert_min_accuracy(
-            results,
-            config.reference_accuracy * REGRESSION_TOLERANCE,
-            context=context,
-        )
+        assert_gsm8k_result(results, gsm8k_spec, context=context)
         assert (
             acceptance_rate >= config.reference_acceptance_rate * REGRESSION_TOLERANCE
         ), f"{context}: {metrics_summary}"

--- a/tests/v1/e2e/spec_decode/draft_model/test_draft_model.py
+++ b/tests/v1/e2e/spec_decode/draft_model/test_draft_model.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 
 import pytest
 
+from tests.evals.gsm8k.gsm8k_eval import GSM8KEvalSpec, get_gsm8k_eval_spec
 from tests.utils import multi_gpu_only, single_gpu_only
 from vllm import SamplingParams
 from vllm.config import CompilationConfig, VllmConfig, replace
@@ -32,7 +33,7 @@ class ArgsTest:
     num_speculative_tokens: int
     expected_acceptance_rate: float
     expected_acceptance_len: float
-    expected_gsm8k_accuracy: float = 0.0  # skip by default
+    gsm8k_spec: GSM8KEvalSpec | None = None
     # Defaults
     enforce_eager: bool = True
     parallel_drafting: bool = False
@@ -71,7 +72,7 @@ cases = [
         num_speculative_tokens=3,  # K
         expected_acceptance_len=0.98 * (3 + 1),  # epsilon discount of K + 1
         expected_acceptance_rate=0.98,  # slight epsilon
-        expected_gsm8k_accuracy=0.25,  # ref: 35-40%
+        gsm8k_spec=get_gsm8k_eval_spec("draft_model", "qwen3-0.6b-self-draft"),
     ),
     # Smaller draft model, stochastic sampling.
     ArgsTest(
@@ -81,7 +82,7 @@ cases = [
         num_speculative_tokens=3,
         expected_acceptance_len=3.4,  # ref: 3.7
         expected_acceptance_rate=0.80,  # ref: 0.90
-        expected_gsm8k_accuracy=0.5,  # ref: 60%. Note gsm8k always runs greedy sampling
+        gsm8k_spec=get_gsm8k_eval_spec("draft_model", "qwen3-1.7b-draft-0.6b"),
     ),
 ]
 
@@ -159,7 +160,7 @@ def test_draft_model_tensor_parallelism(vllm_runner):
         draft_tensor_parallel_size=2,
         **some_high_acceptance_metrics(),
         enforce_eager=False,
-        expected_gsm8k_accuracy=0.5,
+        gsm8k_spec=get_gsm8k_eval_spec("draft_model", "qwen3-1.7b-tp2"),
     )
     assert_draft_model_correctness(sd_case, vllm_runner)
 
@@ -346,9 +347,9 @@ def assert_draft_model_correctness(args: ArgsTest, vllm_runner):
         acceptance_len: float = compute_acceptance_len(metrics)
 
         # Need to evaluate after getting metrics to avoid polluting the AR
-        evaluate_llm_for_gsm8k(
-            spec_llm, expected_accuracy_threshold=args.expected_gsm8k_accuracy
-        )
+        if args.gsm8k_spec is not None:
+            assert args.gsm8k_spec.model == args.target_model
+            evaluate_llm_for_gsm8k(spec_llm, args.gsm8k_spec)
 
         print(
             f"spec-decode: target={args.target_model}, draft={args.draft_model}, "

--- a/tests/v1/e2e/spec_decode/eagle/test_eagle_correctness.py
+++ b/tests/v1/e2e/spec_decode/eagle/test_eagle_correctness.py
@@ -3,6 +3,7 @@
 
 import pytest
 
+from tests.evals.gsm8k.gsm8k_eval import GSM8KEvalSpec, get_gsm8k_eval_spec
 from tests.utils import (
     get_attn_backend_list_based_on_platform,
     single_gpu_only,
@@ -24,7 +25,7 @@ from .utils import _run_eagle_correctness
         "mm_enabled",
         "enable_chunked_prefill",
         "model_impl",
-        "expected_accuracy_threshold",
+        "gsm8k_spec",
     ],
     [
         (
@@ -37,7 +38,7 @@ from .utils import _run_eagle_correctness
             False,
             False,
             "auto",
-            0.0,
+            get_gsm8k_eval_spec("eagle", "deepseek-eagle-dummy"),
         ),
     ],
     ids=["deepseek_eagle"],
@@ -48,7 +49,7 @@ def test_eagle_correctness_light(
     sampling_config: SamplingParams,
     model_setup: tuple[str, str, str, int],
     mm_enabled: bool,
-    expected_accuracy_threshold: float,
+    gsm8k_spec: GSM8KEvalSpec,
     enable_chunked_prefill: bool,
     model_impl: str,
     attn_backend: str,
@@ -59,7 +60,7 @@ def test_eagle_correctness_light(
         sampling_config,
         model_setup,
         mm_enabled,
-        expected_accuracy_threshold,
+        gsm8k_spec,
         enable_chunked_prefill,
         model_impl,
         attn_backend,
@@ -74,7 +75,7 @@ def test_eagle_correctness_light(
         "mm_enabled",
         "enable_chunked_prefill",
         "model_impl",
-        "expected_accuracy_threshold",
+        "gsm8k_spec",
     ],
     [
         (
@@ -82,14 +83,14 @@ def test_eagle_correctness_light(
             False,
             False,
             "auto",
-            0.8,
+            get_gsm8k_eval_spec("eagle", "qwen3-eagle3"),
         ),
         pytest.param(
             ("eagle3", "Qwen/Qwen3-8B", "AngelSlim/Qwen3-8B_eagle3", 1),
             False,
             False,
             "transformers",
-            0.8,
+            get_gsm8k_eval_spec("eagle", "qwen3-eagle3-transformers"),
             # TODO(hmellor): figure out why memory usage is so high
             marks=pytest.mark.skipif(
                 not current_platform.is_rocm(),
@@ -106,7 +107,7 @@ def test_eagle_correctness_light(
             False,
             False,
             "auto",
-            0.8,
+            get_gsm8k_eval_spec("eagle", "qwen3-vl-eagle3"),
         ),
         pytest.param(
             (
@@ -118,7 +119,7 @@ def test_eagle_correctness_light(
             False,
             False,
             "auto",
-            0.7,
+            get_gsm8k_eval_spec("eagle", "qwen2.5-vl-eagle3"),
             # TODO: Re-measure the reference threshold when re-enabling this case.
             # Text-only mode starts but loses target correctness with ROCm/TRITON;
             # full multimodal profiling currently fails during engine startup.
@@ -136,7 +137,7 @@ def test_eagle_correctness_light(
             False,
             False,
             "auto",
-            0.7,
+            get_gsm8k_eval_spec("eagle", "llama3-eagle3"),
         ),
     ],
     ids=[
@@ -153,7 +154,7 @@ def test_eagle_correctness_medium(
     sampling_config: SamplingParams,
     model_setup: tuple[str, str, str, int],
     mm_enabled: bool,
-    expected_accuracy_threshold: float,
+    gsm8k_spec: GSM8KEvalSpec,
     enable_chunked_prefill: bool,
     model_impl: str,
     attn_backend: str,
@@ -164,7 +165,7 @@ def test_eagle_correctness_medium(
         sampling_config,
         model_setup,
         mm_enabled,
-        expected_accuracy_threshold,
+        gsm8k_spec,
         enable_chunked_prefill,
         model_impl,
         attn_backend,

--- a/tests/v1/e2e/spec_decode/eagle/utils.py
+++ b/tests/v1/e2e/spec_decode/eagle/utils.py
@@ -5,6 +5,7 @@ from typing import Any
 
 import pytest
 
+from tests.evals.gsm8k.gsm8k_eval import GSM8KEvalSpec
 from vllm import SamplingParams
 from vllm.config import CompilationConfig
 from vllm.platforms import current_platform
@@ -22,7 +23,7 @@ def _run_eagle_correctness(
     sampling_config: SamplingParams,
     model_setup: tuple[str, str, str, int],
     mm_enabled: bool,
-    expected_accuracy_threshold: float,
+    gsm8k_spec: GSM8KEvalSpec,
     enable_chunked_prefill: bool,
     model_impl: str,
     attn_backend: str,
@@ -33,6 +34,7 @@ def _run_eagle_correctness(
     which should be the same when using eagle speculative decoding.
     """
     method, model_name, spec_model_name, tp_size = model_setup
+    assert gsm8k_spec.model == model_name
     _skip_if_insufficient_gpus_for_tp(tp_size)
 
     test_prompts = get_test_prompts(mm_enabled)
@@ -86,10 +88,7 @@ def _run_eagle_correctness(
             compilation_config=CompilationConfig(),
             **extra_kwargs,
         ) as ref_runner:
-            evaluate_llm_for_gsm8k(
-                ref_runner.llm,
-                expected_accuracy_threshold=expected_accuracy_threshold,
-            )
+            evaluate_llm_for_gsm8k(ref_runner.llm, gsm8k_spec)
             ref_outputs = ref_runner.llm.chat(test_prompts, sampling_config)
 
         with vllm_runner(
@@ -119,10 +118,7 @@ def _run_eagle_correctness(
                 f"Expected async scheduling for {method}: target={model_name}, "
                 f"draft={spec_model_name}, backend={attn_backend}; got {has_async}"
             )
-            evaluate_llm_for_gsm8k(
-                spec_runner.llm,
-                expected_accuracy_threshold=expected_accuracy_threshold,
-            )
+            evaluate_llm_for_gsm8k(spec_runner.llm, gsm8k_spec)
             spec_outputs = spec_runner.llm.chat(test_prompts, sampling_config)
 
         assert_request_outputs_match(

--- a/tests/v1/e2e/spec_decode/mtp/test_mtp.py
+++ b/tests/v1/e2e/spec_decode/mtp/test_mtp.py
@@ -5,6 +5,7 @@ from typing import Any
 
 import pytest
 
+from tests.evals.gsm8k.gsm8k_eval import GSM8KEvalSpec, get_gsm8k_eval_spec
 from tests.utils import single_gpu_only
 from vllm import SamplingParams
 from vllm.config import CompilationConfig
@@ -19,14 +20,18 @@ from ..utils import (
 
 
 @pytest.mark.parametrize(
-    ["model_setup", "mm_enabled", "expected_accuracy_threshold"],
+    ["model_setup", "mm_enabled", "gsm8k_spec"],
     [
         # Reference accuracy: 65%-70%.
-        (("mtp", "XiaomiMiMo/MiMo-7B-Base", 1, None), False, 0.5),
+        (
+            ("mtp", "XiaomiMiMo/MiMo-7B-Base", 1, None),
+            False,
+            get_gsm8k_eval_spec("mtp", "mimo"),
+        ),
         pytest.param(
             ("mtp", "ZixiQi/DeepSeek-V3-4layers-MTP-FP8", 1, None),
             False,
-            0.0,
+            get_gsm8k_eval_spec("mtp", "deepseek-dummy"),
             marks=pytest.mark.skipif(
                 current_platform.is_device_capability_family(100),
                 reason="DeepSeek MTP: TRTLLM MoE top_k check fails on Blackwell",
@@ -35,12 +40,12 @@ from ..utils import (
         (
             ("mtp", "Qwen/Qwen3.5-0.8B-Base", 1, None),
             False,
-            0.20,
+            get_gsm8k_eval_spec("mtp", "qwen3.5-hybrid"),
         ),  # hybrid + MTP, ref: ~34%-35%
         (
             ("mtp", "google/gemma-4-E4B-it", 1, "google/gemma-4-E4B-it-assistant"),
             False,
-            0.50,
+            get_gsm8k_eval_spec("mtp", "gemma4-e4b"),
         ),  # gemma4 MTP with assistant model, ref: ~62%
     ],
     ids=["mimo", "deepseek", "qwen3_5-hybrid", "gemma4-e4b"],
@@ -51,7 +56,7 @@ def test_mtp_correctness(
     sampling_config: SamplingParams,
     model_setup: tuple[str, str, int, str | None],
     mm_enabled: bool,
-    expected_accuracy_threshold: float,
+    gsm8k_spec: GSM8KEvalSpec,
     vllm_runner,
 ):
     """
@@ -62,6 +67,7 @@ def test_mtp_correctness(
     reference threshold for each model.
     """
     method, model_name, tp_size, draft_model = model_setup
+    assert gsm8k_spec.model == model_name
     _skip_if_insufficient_gpus_for_tp(tp_size)
 
     # Generate test prompts inside the function instead of using fixture
@@ -100,10 +106,7 @@ def test_mtp_correctness(
             **extra_kwargs,
         ) as ref_runner:
             ref_outputs = ref_runner.llm.chat(test_prompts, sampling_config)
-            evaluate_llm_for_gsm8k(
-                ref_runner.llm,
-                expected_accuracy_threshold=expected_accuracy_threshold,
-            )
+            evaluate_llm_for_gsm8k(ref_runner.llm, gsm8k_spec)
 
         speculative_config: dict[str, Any] = {
             "method": method,
@@ -134,10 +137,7 @@ def test_mtp_correctness(
                 f"Expected async scheduling for {method}: target={model_name}, "
                 f"draft={draft_model}; got {has_async}"
             )
-            evaluate_llm_for_gsm8k(
-                spec_runner.llm,
-                expected_accuracy_threshold=expected_accuracy_threshold,
-            )
+            evaluate_llm_for_gsm8k(spec_runner.llm, gsm8k_spec)
             spec_outputs = spec_runner.llm.chat(test_prompts, sampling_config)
 
         # Heuristic: expect at least 80% of the prompts to match exactly

--- a/tests/v1/e2e/spec_decode/ngram_suffix/test_ngram_suffix.py
+++ b/tests/v1/e2e/spec_decode/ngram_suffix/test_ngram_suffix.py
@@ -3,6 +3,7 @@
 
 import pytest
 
+from tests.evals.gsm8k.gsm8k_eval import GSM8KEvalSpec, get_gsm8k_eval_spec
 from tests.utils import single_gpu_only
 from vllm import SamplingParams
 from vllm.config import CompilationConfig
@@ -22,24 +23,31 @@ def disable_vllm_compile_cache_on_rocm(request: pytest.FixtureRequest) -> None:
 
 
 @pytest.mark.parametrize(
-    "speculative_config",
+    ("speculative_config", "gsm8k_spec"),
     [
-        {
-            "method": "ngram",
-            "prompt_lookup_max": 5,
-            "prompt_lookup_min": 3,
-            "num_speculative_tokens": 3,
-        },
-        {
-            "method": "suffix",
-            "suffix_decoding_max_spec_factor": 2.0,
-        },
+        (
+            {
+                "method": "ngram",
+                "prompt_lookup_max": 5,
+                "prompt_lookup_min": 3,
+                "num_speculative_tokens": 3,
+            },
+            get_gsm8k_eval_spec("ngram_suffix", "ngram"),
+        ),
+        (
+            {
+                "method": "suffix",
+                "suffix_decoding_max_spec_factor": 2.0,
+            },
+            get_gsm8k_eval_spec("ngram_suffix", "suffix"),
+        ),
     ],
 )
 @pytest.mark.usefixtures("disable_vllm_compile_cache_on_rocm")
 @single_gpu_only
 def test_ngram_and_suffix_correctness(
     speculative_config: dict,
+    gsm8k_spec: GSM8KEvalSpec,
     model_name: str,
     vllm_runner,
 ):
@@ -55,7 +63,7 @@ def test_ngram_and_suffix_correctness(
         # this, VllmRunner injects its reduced test-only capture sizes.
         compilation_config=CompilationConfig(),
     ) as runner:
-        evaluate_llm_for_gsm8k(runner.llm)
+        evaluate_llm_for_gsm8k(runner.llm, gsm8k_spec)
 
 
 @pytest.mark.parametrize("async_scheduling", [True], ids=["async"])
@@ -90,7 +98,10 @@ def test_ngram_gpu_default_with_async_scheduling(
             spec_runner.llm.llm_engine.vllm_config.scheduler_config.async_scheduling
             == async_scheduling
         )
-        evaluate_llm_for_gsm8k(spec_runner.llm, expected_accuracy_threshold=0.8)
+        evaluate_llm_for_gsm8k(
+            spec_runner.llm,
+            get_gsm8k_eval_spec("ngram_suffix", "qwen3-ngram-gpu-async"),
+        )
 
 
 @single_gpu_only

--- a/tests/v1/e2e/spec_decode/speculators/test_speculators.py
+++ b/tests/v1/e2e/spec_decode/speculators/test_speculators.py
@@ -3,6 +3,7 @@
 
 import pytest
 
+from tests.evals.gsm8k.gsm8k_eval import GSM8KEvalSpec, get_gsm8k_eval_spec
 from tests.utils import single_gpu_only
 from vllm import SamplingParams
 from vllm.config import CompilationConfig
@@ -15,12 +16,12 @@ from ..utils import (
 
 
 @pytest.mark.parametrize(
-    ["model_path", "expected_accuracy_threshold"],
+    "gsm8k_spec",
     [
         # Measured reference: 75%-80%.
-        ("RedHatAI/Llama-3.1-8B-Instruct-speculator.eagle3", 0.72),
+        get_gsm8k_eval_spec("spec_decode_speculators", "llama3-eagle3"),
         # Measured reference: 87%-92%.
-        ("RedHatAI/Qwen3-8B-speculator.eagle3", 0.84),
+        get_gsm8k_eval_spec("spec_decode_speculators", "qwen3-eagle3"),
     ],
     ids=["llama3_eagle3_speculator", "qwen3_eagle3_speculator"],
 )
@@ -28,8 +29,7 @@ from ..utils import (
 def test_speculators_model_integration(
     monkeypatch: pytest.MonkeyPatch,
     sampling_config: SamplingParams,
-    model_path: str,
-    expected_accuracy_threshold: float,
+    gsm8k_spec: GSM8KEvalSpec,
     vllm_runner,
 ):
     """
@@ -48,6 +48,8 @@ def test_speculators_model_integration(
     6. Output matches reference (non-speculative) generation
     """
     monkeypatch.setenv("VLLM_ALLOW_INSECURE_SERIALIZATION", "1")
+    assert gsm8k_spec.model is not None
+    model_path = gsm8k_spec.model
 
     # Generate test prompts
     test_prompts = get_test_prompts(mm_enabled=False)
@@ -62,9 +64,7 @@ def test_speculators_model_integration(
         max_model_len=4096,
         gpu_memory_utilization=0.92,
     ) as spec_runner:
-        evaluate_llm_for_gsm8k(
-            spec_runner.llm, expected_accuracy_threshold=expected_accuracy_threshold
-        )
+        evaluate_llm_for_gsm8k(spec_runner.llm, gsm8k_spec)
         spec_outputs = spec_runner.llm.chat(test_prompts, sampling_config)
 
         # Verify speculative config was auto-detected

--- a/tests/v1/e2e/spec_decode/utils.py
+++ b/tests/v1/e2e/spec_decode/utils.py
@@ -8,7 +8,11 @@ from typing import Any
 import pytest
 import torch
 
-from tests.evals.gsm8k.gsm8k_eval import _build_gsm8k_prompts, evaluate_gsm8k_offline
+from tests.evals.gsm8k.gsm8k_eval import (
+    _build_gsm8k_prompts,
+    assert_min_accuracy,
+    evaluate_gsm8k_offline,
+)
 from vllm import LLM, SamplingParams
 from vllm.assets.base import VLLM_S3_BUCKET_URL
 from vllm.assets.image import VLM_IMAGES_DIR
@@ -115,11 +119,9 @@ def evaluate_llm_for_gsm8k(llm: LLM, expected_accuracy_threshold: float = 0.70) 
         print("Skipping GSM8K evaluation")
         return
     results = evaluate_gsm8k_offline(llm)
-    accuracy = results["accuracy"]
+    accuracy = results.accuracy
     print(f"GSM8K accuracy: {accuracy:.3f}")
-    assert accuracy >= expected_accuracy_threshold, (
-        f"Expected GSM8K accuracy >= {expected_accuracy_threshold}, got {accuracy:.3f}"
-    )
+    assert_min_accuracy(results, expected_accuracy_threshold)
 
 
 def assert_request_outputs_match(

--- a/tests/v1/e2e/spec_decode/utils.py
+++ b/tests/v1/e2e/spec_decode/utils.py
@@ -9,9 +9,11 @@ import pytest
 import torch
 
 from tests.evals.gsm8k.gsm8k_eval import (
+    GSM8KEvalSpec,
     _build_gsm8k_prompts,
-    assert_min_accuracy,
+    assert_gsm8k_result,
     evaluate_gsm8k_offline,
+    get_gsm8k_eval_spec,
 )
 from vllm import LLM, SamplingParams
 from vllm.assets.base import VLLM_S3_BUCKET_URL
@@ -19,6 +21,8 @@ from vllm.assets.image import VLM_IMAGES_DIR
 from vllm.outputs import RequestOutput
 from vllm.utils.torch_utils import set_random_seed
 from vllm.v1.metrics.reader import Metric
+
+DEFAULT_GSM8K_SPEC = get_gsm8k_eval_spec("spec_decode", "default-sanity")
 
 
 def _skip_if_insufficient_gpus_for_tp(tp_size: int):
@@ -107,7 +111,10 @@ def stochastic_sampling() -> SamplingParams:
     return SamplingParams(temperature=1.0, max_tokens=10, ignore_eos=False)
 
 
-def evaluate_llm_for_gsm8k(llm: LLM, expected_accuracy_threshold: float = 0.70) -> None:
+def evaluate_llm_for_gsm8k(
+    llm: LLM,
+    gsm8k_spec: GSM8KEvalSpec = DEFAULT_GSM8K_SPEC,
+) -> None:
     """Evaluate the LLM on GSM8K and check that accuracy is above a sanity threshold.
 
     The default threshold assumes the LLM uses the same target model as the "model_name"
@@ -115,13 +122,13 @@ def evaluate_llm_for_gsm8k(llm: LLM, expected_accuracy_threshold: float = 0.70) 
     on GSM8K with greedy decoding, so we check that it's above a sanity threshold of 70%
     to verify that the model is correct.
     """
-    if expected_accuracy_threshold <= 0.0:
+    if gsm8k_spec.accuracy_threshold <= 0.0:
         print("Skipping GSM8K evaluation")
         return
-    results = evaluate_gsm8k_offline(llm)
+    results = evaluate_gsm8k_offline(llm, **gsm8k_spec.isolated_kwargs())
     accuracy = results.accuracy
     print(f"GSM8K accuracy: {accuracy:.3f}")
-    assert_min_accuracy(results, expected_accuracy_threshold)
+    assert_gsm8k_result(results, gsm8k_spec)
 
 
 def assert_request_outputs_match(

--- a/tests/v1/kv_connector/mooncake_integration/test_accuracy.py
+++ b/tests/v1/kv_connector/mooncake_integration/test_accuracy.py
@@ -2,13 +2,15 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import os
 
-import lm_eval
 import openai
+
+from tests.evals.gsm8k.gsm8k_eval import (
+    assert_min_accuracy,
+    evaluate_gsm8k_lm_eval,
+)
 
 BASE_URL = "http://localhost:8192/v1"
 NUM_CONCURRENT = 100
-TASK = "gsm8k"
-FILTER = "exact_match,strict-match"
 RTOL = 0.05
 
 # Model-specific expected values
@@ -17,8 +19,10 @@ EXPECTED_VALUES = {
 }
 
 SIMPLE_PROMPT = (
-    "The best part about working on vLLM is that I got to meet so many people across "
-    "various different organizations like UCB, Google, and Meta which means",
+    (
+        "The best part about working on vLLM is that I got to meet so many people "
+        "across various different organizations like UCB, Google, and Meta which means"
+    ),
 )
 
 # Get model name from environment variable
@@ -44,13 +48,12 @@ def test_accuracy():
         f"base_url={BASE_URL}/completions,"
         f"num_concurrent={NUM_CONCURRENT},tokenized_requests=False"
     )
-    results = lm_eval.simple_evaluate(
+    result = evaluate_gsm8k_lm_eval(
         model="local-completions",
         model_args=model_args,
-        tasks=TASK,
     )
 
-    measured_value = results["results"][TASK][FILTER]
+    measured_value = result.accuracy
     expected_value = EXPECTED_VALUES.get(MODEL_NAME)
 
     print(f"Measured accuracy value: {measured_value}\n")
@@ -61,7 +64,4 @@ def test_accuracy():
         )
         return
 
-    assert (
-        measured_value - RTOL < expected_value
-        and measured_value + RTOL > expected_value
-    ), f"Expected: {expected_value} | Measured: {measured_value}"
+    assert_min_accuracy(result, expected_value, tolerance=RTOL, context=MODEL_NAME)

--- a/tests/v1/kv_connector/mooncake_integration/test_accuracy.py
+++ b/tests/v1/kv_connector/mooncake_integration/test_accuracy.py
@@ -5,17 +5,17 @@ import os
 import openai
 
 from tests.evals.gsm8k.gsm8k_eval import (
-    assert_min_accuracy,
+    assert_gsm8k_result,
     evaluate_gsm8k_lm_eval,
+    load_gsm8k_eval_specs,
 )
 
 BASE_URL = "http://localhost:8192/v1"
 NUM_CONCURRENT = 100
-RTOL = 0.05
-
-# Model-specific expected values
-EXPECTED_VALUES = {
-    "Qwen/Qwen3-0.6B": 0.41,
+GSM8K_SPECS = {
+    spec.model: spec
+    for spec in load_gsm8k_eval_specs("mooncake")
+    if spec.model is not None
 }
 
 SIMPLE_PROMPT = (
@@ -42,6 +42,8 @@ def run_simple_prompt():
 def test_accuracy():
     """Run the end to end accuracy test."""
     run_simple_prompt()
+    gsm8k_spec = GSM8K_SPECS.get(MODEL_NAME)
+    eval_kwargs = gsm8k_spec.lm_eval_kwargs() if gsm8k_spec else {}
 
     model_args = (
         f"model={MODEL_NAME},"
@@ -51,17 +53,17 @@ def test_accuracy():
     result = evaluate_gsm8k_lm_eval(
         model="local-completions",
         model_args=model_args,
+        **eval_kwargs,
     )
 
     measured_value = result.accuracy
-    expected_value = EXPECTED_VALUES.get(MODEL_NAME)
 
     print(f"Measured accuracy value: {measured_value}\n")
-    if expected_value is None:
+    if gsm8k_spec is None:
         print(
             f"Warning: No expected value found for {MODEL_NAME}. "
             "Skipping accuracy check."
         )
         return
 
-    assert_min_accuracy(result, expected_value, tolerance=RTOL, context=MODEL_NAME)
+    assert_gsm8k_result(result, gsm8k_spec, context=MODEL_NAME)

--- a/tests/v1/kv_connector/nixl_integration/test_accuracy.py
+++ b/tests/v1/kv_connector/nixl_integration/test_accuracy.py
@@ -2,13 +2,15 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import os
 
-import lm_eval
 import openai
+
+from tests.evals.gsm8k.gsm8k_eval import (
+    assert_min_accuracy,
+    evaluate_gsm8k_lm_eval,
+)
 
 BASE_URL = "http://localhost:8192/v1"
 NUM_CONCURRENT = int(os.getenv("NUM_CONCURRENT", "100"))
-TASK = "gsm8k"
-FILTER = "exact_match,strict-match"
 # TODO(#43186): Widened from 0.03 to absorb chunk_scan/SSU numeric jitter
 # on granite-4.0-h-tiny under NIXL PD; tighten when the kernel divergence
 # is fixed.
@@ -30,25 +32,14 @@ EXPECTED_VALUES = {
 }
 
 SIMPLE_PROMPT = (
-    "The best part about working on vLLM is that I got to meet so many people across "
-    "various different organizations like UCB, Google, and Meta which means",
+    (
+        "The best part about working on vLLM is that I got to meet so many people "
+        "across various different organizations like UCB, Google, and Meta which means"
+    ),
 )
 
 # Get model name from environment variable
 MODEL_NAME = os.environ.get("TEST_MODEL", "Qwen/Qwen3-0.6B")
-
-
-def _meets_accuracy_threshold(measured_value: float, expected_value: float) -> bool:
-    return measured_value >= expected_value - RTOL
-
-
-def test_accuracy_threshold_is_one_sided():
-    expected_value = 0.77
-    minimum_value = expected_value - RTOL
-
-    assert _meets_accuracy_threshold(minimum_value, expected_value)
-    assert _meets_accuracy_threshold(expected_value + RTOL + 0.01, expected_value)
-    assert not _meets_accuracy_threshold(minimum_value - 0.01, expected_value)
 
 
 def run_simple_prompt():
@@ -75,10 +66,9 @@ def test_accuracy():
             "tokenizer_backend=huggingface,"
             "trust_remote_code=True"
         )
-        results = lm_eval.simple_evaluate(
+        result = evaluate_gsm8k_lm_eval(
             model="local-chat-completions",
             model_args=model_args,
-            tasks=TASK,
             num_fewshot=5,
             apply_chat_template=True,
         )
@@ -89,13 +79,12 @@ def test_accuracy():
             f"num_concurrent={NUM_CONCURRENT},tokenized_requests=False,"
             "trust_remote_code=True"
         )
-        results = lm_eval.simple_evaluate(
+        result = evaluate_gsm8k_lm_eval(
             model="local-completions",
             model_args=model_args,
-            tasks=TASK,
         )
 
-    measured_value = results["results"][TASK][FILTER]
+    measured_value = result.accuracy
     expected_value = EXPECTED_VALUES.get(MODEL_NAME)
 
     print(f"Measured accuracy value: {measured_value}\n")
@@ -106,7 +95,4 @@ def test_accuracy():
         )
         return
 
-    minimum_value = expected_value - RTOL
-    assert _meets_accuracy_threshold(measured_value, expected_value), (
-        f"Expected at least: {minimum_value} | Measured: {measured_value}"
-    )
+    assert_min_accuracy(result, expected_value, tolerance=RTOL, context=MODEL_NAME)

--- a/tests/v1/kv_connector/nixl_integration/test_accuracy.py
+++ b/tests/v1/kv_connector/nixl_integration/test_accuracy.py
@@ -5,30 +5,15 @@ import os
 import openai
 
 from tests.evals.gsm8k.gsm8k_eval import (
-    assert_min_accuracy,
+    assert_gsm8k_result,
     evaluate_gsm8k_lm_eval,
+    load_gsm8k_eval_specs,
 )
 
 BASE_URL = "http://localhost:8192/v1"
 NUM_CONCURRENT = int(os.getenv("NUM_CONCURRENT", "100"))
-# TODO(#43186): Widened from 0.03 to absorb chunk_scan/SSU numeric jitter
-# on granite-4.0-h-tiny under NIXL PD; tighten when the kernel divergence
-# is fixed.
-RTOL = 0.05
-
-# Model-specific expected values
-EXPECTED_VALUES = {
-    "Qwen/Qwen3-0.6B": 0.41,
-    "deepseek-ai/deepseek-vl2-small": 0.59,
-    "deepseek-ai/deepseek-vl2-tiny": 0.19,
-    "deepseek-ai/DeepSeek-V2-Lite-Chat": 0.65,
-    "google/gemma-3-4b-it": 0.74,
-    "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-FP8": 0.84,
-    "ibm-granite/granite-4.0-h-tiny": 0.77,
-    "Qwen/Qwen3.5-0.8B": 0.33,
-    "google/gemma-4-E2B-it": 0.485,
-    "ai21labs/AI21-Jamba2-3B": 0.74,
-    "deepseek-ai/DeepSeek-V4-Flash": 0.95,
+GSM8K_SPECS = {
+    spec.model: spec for spec in load_gsm8k_eval_specs("nixl") if spec.model is not None
 }
 
 SIMPLE_PROMPT = (
@@ -55,6 +40,8 @@ def run_simple_prompt():
 def test_accuracy():
     """Run the end to end accuracy test."""
     run_simple_prompt()
+    gsm8k_spec = GSM8K_SPECS.get(MODEL_NAME)
+    eval_kwargs = gsm8k_spec.lm_eval_kwargs() if gsm8k_spec else {}
 
     if "gemma-4" in MODEL_NAME:
         # Gemma4 is quite sensible to having a chat template applied, so we evaluate
@@ -69,8 +56,8 @@ def test_accuracy():
         result = evaluate_gsm8k_lm_eval(
             model="local-chat-completions",
             model_args=model_args,
-            num_fewshot=5,
             apply_chat_template=True,
+            **eval_kwargs,
         )
     else:
         model_args = (
@@ -82,17 +69,17 @@ def test_accuracy():
         result = evaluate_gsm8k_lm_eval(
             model="local-completions",
             model_args=model_args,
+            **eval_kwargs,
         )
 
     measured_value = result.accuracy
-    expected_value = EXPECTED_VALUES.get(MODEL_NAME)
 
     print(f"Measured accuracy value: {measured_value}\n")
-    if expected_value is None:
+    if gsm8k_spec is None:
         print(
             f"Warning: No expected value found for {MODEL_NAME}. "
             "Skipping accuracy check."
         )
         return
 
-    assert_min_accuracy(result, expected_value, tolerance=RTOL, context=MODEL_NAME)
+    assert_gsm8k_result(result, gsm8k_spec, context=MODEL_NAME)

--- a/tests/v1/spec_decode/test_speculators_correctness.py
+++ b/tests/v1/spec_decode/test_speculators_correctness.py
@@ -5,7 +5,10 @@ import dataclasses
 import pytest
 import torch
 
-from tests.evals.gsm8k.gsm8k_eval import evaluate_gsm8k_offline
+from tests.evals.gsm8k.gsm8k_eval import (
+    assert_min_accuracy,
+    evaluate_gsm8k_offline,
+)
 from tests.utils import large_gpu_mark
 from vllm import LLM
 from vllm.config import SpeculativeConfig
@@ -205,11 +208,13 @@ def test_speculators_correctness(monkeypatch, config):
     )
 
     results = evaluate_gsm8k_offline(spec_llm)
-    accuracy = results["accuracy"]
+    accuracy = results.accuracy
     print(f"GSM8K Accuracy: {accuracy:.4f}")
     accuracy_threshold = config.expected_gsm8k_accuracy * (1 - config.accuracy_rtol)
-    assert accuracy >= accuracy_threshold, (
-        f"Expected GSM8K accuracy >= {accuracy_threshold:.3f}, got {accuracy:.3f}"
+    assert_min_accuracy(
+        results,
+        accuracy_threshold,
+        context=config.display_name,
     )
 
     current_metrics = spec_llm.get_metrics()

--- a/tests/v1/spec_decode/test_speculators_correctness.py
+++ b/tests/v1/spec_decode/test_speculators_correctness.py
@@ -6,8 +6,10 @@ import pytest
 import torch
 
 from tests.evals.gsm8k.gsm8k_eval import (
-    assert_min_accuracy,
+    GSM8KEvalSpec,
+    assert_gsm8k_result,
     evaluate_gsm8k_offline,
+    get_gsm8k_eval_spec,
 )
 from tests.utils import large_gpu_mark
 from vllm import LLM
@@ -17,11 +19,9 @@ from vllm.distributed import cleanup_dist_env_and_memory
 
 @dataclasses.dataclass
 class SpeculatorTestConfig:
-    model_path: str
+    gsm8k_spec: GSM8KEvalSpec
     method: str
     display_name: str
-    expected_gsm8k_accuracy: float
-    accuracy_rtol: float
     expected_acceptance_len: float
     acceptance_len_rtol: float
     expected_per_pos_acceptance_rates: tuple[float, ...]
@@ -29,13 +29,16 @@ class SpeculatorTestConfig:
     quantization: str | None = None
     parallel_drafting: bool | None = None
 
+    @property
+    def model_path(self) -> str:
+        assert self.gsm8k_spec.model is not None
+        return self.gsm8k_spec.model
+
 
 DFLASH_CONFIG = SpeculatorTestConfig(
-    model_path="nm-testing/dflash-qwen3-8b-speculators",
+    gsm8k_spec=get_gsm8k_eval_spec("speculators", "dflash"),
     method="dflash",
     display_name="DFlash",
-    expected_gsm8k_accuracy=0.885,
-    accuracy_rtol=0.03,
     expected_acceptance_len=3.45,
     acceptance_len_rtol=0.15,
     expected_per_pos_acceptance_rates=(0.795, 0.611, 0.429, 0.282),
@@ -44,11 +47,9 @@ DFLASH_CONFIG = SpeculatorTestConfig(
 )
 
 PEAGLE_CONFIG = SpeculatorTestConfig(
-    model_path="nm-testing/qwen3-8b-peagle-speculators",
+    gsm8k_spec=get_gsm8k_eval_spec("speculators", "peagle"),
     method="eagle3",
     display_name="PEagle",
-    expected_gsm8k_accuracy=0.88,
-    accuracy_rtol=0.05,
     expected_acceptance_len=2.27,
     acceptance_len_rtol=0.20,
     expected_per_pos_acceptance_rates=(0.66, 0.36, 0.18, 0.09),
@@ -57,14 +58,9 @@ PEAGLE_CONFIG = SpeculatorTestConfig(
 )
 
 QWEN3_EAGLE3_CONFIG = SpeculatorTestConfig(
-    model_path=(
-        "inference-optimization/"
-        "Qwen3-8B-from-Qwen3-8B_regen-speculators.eagle3-qwen3arch-ckpt1"
-    ),
+    gsm8k_spec=get_gsm8k_eval_spec("speculators", "qwen3arch-eagle3"),
     method="eagle3",
     display_name="Qwen3 Eagle3",
-    expected_gsm8k_accuracy=0.88,
-    accuracy_rtol=0.05,
     expected_acceptance_len=2.67,
     acceptance_len_rtol=0.10,
     expected_per_pos_acceptance_rates=(0.76, 0.55, 0.36),
@@ -72,11 +68,9 @@ QWEN3_EAGLE3_CONFIG = SpeculatorTestConfig(
 )
 
 QWEN3_PEAGLE_CONFIG = SpeculatorTestConfig(
-    model_path="inference-optimization/Qwen3-8B-speculators.peagle-qwen3arch-ckpt4",
+    gsm8k_spec=get_gsm8k_eval_spec("speculators", "qwen3arch-peagle"),
     method="eagle3",
     display_name="Qwen3 PEagle",
-    expected_gsm8k_accuracy=0.88,
-    accuracy_rtol=0.05,
     expected_acceptance_len=3.42,
     acceptance_len_rtol=0.15,
     expected_per_pos_acceptance_rates=(0.78, 0.59, 0.43, 0.29, 0.18, 0.10, 0.05),
@@ -207,13 +201,12 @@ def test_speculators_correctness(monkeypatch, config):
         disable_log_stats=False,
     )
 
-    results = evaluate_gsm8k_offline(spec_llm)
+    results = evaluate_gsm8k_offline(spec_llm, **config.gsm8k_spec.isolated_kwargs())
     accuracy = results.accuracy
     print(f"GSM8K Accuracy: {accuracy:.4f}")
-    accuracy_threshold = config.expected_gsm8k_accuracy * (1 - config.accuracy_rtol)
-    assert_min_accuracy(
+    assert_gsm8k_result(
         results,
-        accuracy_threshold,
+        config.gsm8k_spec,
         context=config.display_name,
     )
 


### PR DESCRIPTION
## Purpose

GSM8K correctness evals were spread across domain test files, scheduled shell
jobs, and the existing model YAML runner. That made it difficult to see which
profiles, sample sizes, and accuracy floors CI actually uses.

This draft makes `tests/evals/gsm8k/` the common ownership area:

- `configs/evals.yaml` inventories 68 concrete eval cases across 20 scattered
  suites. Each entry records its source launcher, model, benchmark profile,
  metric, question/few-shot/token counts, accuracy floor, and tolerance.
- Distributed, entrypoint, connector, quantization, offloading, and
  speculative-decoding tests now load named YAML specs instead of defining
  GSM8K baselines inline.
- Five scheduled integration scripts use `--eval-spec` so their question
  counts and thresholds also come from the common manifest.
- Existing `configs/*.yaml` files remain the model definitions for the generic
  GSM8K server runner.
- A typed result and assertion contract verifies that each result matches the
  YAML-selected profile and metric before applying its one-sided accuracy
  floor.

Topology-specific launch code remains with its owning suite so GPU markers,
fixtures, process setup, and non-GSM8K feature assertions stay discoverable.

This does not duplicate #48253. That PR adds an opt-in chat evaluation mode and
a gpt-oss model config; this PR centralizes the existing cross-suite eval
inventory and result contract. The overlapping harness file will need
coordination if both changes proceed.

## Test Plan

```bash
../vllm/.venv/bin/python -m pytest tests/evals/gsm8k/test_gsm8k_eval.py -q
../vllm/.venv/bin/pre-commit run mypy-3.12 --hook-stage manual --files <changed Python files>
uvx ruff check <changed Python files>
uvx ruff format --check <changed Python files>
../vllm/.venv/bin/python -m py_compile <changed Python files>
bash -n <five changed scheduled scripts>
shellcheck <five changed scheduled scripts>
../vllm/.venv/bin/python tests/evals/gsm8k/gsm8k_eval.py --help
git diff --check
```

The normal commit hook suite was also run for both commits. The repository-wide
shell hook was skipped for the second commit because it reports unrelated
pre-existing findings across other scripts; direct ShellCheck on all five
changed scripts passed.

## Test Result

- Focused manifest/result tests: `8 passed`.
- Commit hooks: passed, including Ruff, formatting, Markdown lint, SPDX,
  forbidden-import checks, mypy for Python 3.10, and sign-off validation.
- Manual mypy 3.12 hook: passed.
- Changed-script Bash syntax and direct ShellCheck: passed.
- YAML parsing, Python compilation, CLI option smoke test, and
  `git diff --check`: passed.
- A broad `pytest --collect-only` check was attempted for migrated GPU suites.
  Eight unaffected items collected; GPU-heavy modules cannot import in this
  local environment because `_vllm_fa2_C`/`_vllm_fa3_C` are unavailable.

Model evaluation was not run locally. The change preserves prompts, scorers,
generation settings, and effective accuracy floors, but representative GPU
jobs should be run before the draft is marked ready.

AI assistance was used to audit, implement, and test this change. The human
submitter must review every changed line and verify the relevant GPU tests
before marking the PR ready for review.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose and ownership model are described above.
- [x] The test plan includes the commands run.
- [x] The available results and local GPU limitation are recorded.
- [x] The common eval inventory and API are documented.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://docs.vllm.ai/en/latest/contributing>**
