### PR TITLE
[Spec Decode] Preserve embedded MTP draft runtime settings

### DIFF
--- a/tests/config/test_speculative_draft_hf_overrides.py
+++ b/tests/config/test_speculative_draft_hf_overrides.py
@@ -40,6 +40,39 @@ def test_dict_overrides_are_not_forwarded_to_draft():
 
 
 @pytest.mark.cpu_test
+def test_dict_rope_overrides_are_forwarded_to_embedded_mtp_draft():
+    """Embedded MTP drafts must share target runtime positional overrides."""
+    composed = SpeculativeConfig.compose_draft_hf_overrides(
+        {
+            "max_position_embeddings": 262144,
+            "rope_parameters": {
+                "rope_type": "yarn",
+                "factor": 2.0,
+                "original_max_position_embeddings": 262144,
+            },
+        },
+        forward_mapping=True,
+    )
+    out = composed(
+        _make_hf_config(
+            architectures=["BailingMoeV3ForCausalLM"],
+            model_type="bailing_hybrid",
+            max_position_embeddings=131072,
+            rope_parameters=None,
+            num_nextn_predict_layers=1,
+        )
+    )
+
+    assert out.architectures == ["BailingMoeV3MTPModel"]
+    assert out.max_position_embeddings == 262144
+    assert out.rope_parameters == {
+        "rope_type": "yarn",
+        "factor": 2.0,
+        "original_max_position_embeddings": 262144,
+    }
+
+
+@pytest.mark.cpu_test
 def test_none_overrides_fall_back_to_arch_mapping():
     composed = SpeculativeConfig.compose_draft_hf_overrides(None)
     assert composed is SpeculativeConfig.hf_config_override

--- a/tests/model_executor/test_weight_utils.py
+++ b/tests/model_executor/test_weight_utils.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import tempfile
+from types import SimpleNamespace
 
 import huggingface_hub.constants
 import pytest
@@ -9,8 +10,28 @@ from huggingface_hub.utils import LocalEntryNotFoundError
 
 from vllm.model_executor.model_loader.weight_utils import (
     download_weights_from_hf,
+    get_quant_config,
     maybe_remap_kv_scale_name,
 )
+
+
+@pytest.mark.cpu_test
+def test_callable_hf_overrides_allow_default_quant_config():
+    """Config transforms must not block config-free quantization methods."""
+    model_config = SimpleNamespace(
+        quantization="fp8",
+        quantization_config=None,
+        hf_config=SimpleNamespace(
+            quantization_config=None,
+            compression_config=None,
+            text_config=None,
+        ),
+        hf_overrides=lambda config: config,
+    )
+
+    quant_config = get_quant_config(model_config, SimpleNamespace())
+
+    assert quant_config.get_name() == "fp8"
 
 
 def test_download_weights_from_hf():

--- a/tests/v1/spec_decode/test_llm_base_proposer_config.py
+++ b/tests/v1/spec_decode/test_llm_base_proposer_config.py
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from vllm.config import VllmConfig
+from vllm.v1.spec_decode.llm_base_proposer import SpecDecodeBaseProposer
+
+
+@pytest.mark.cpu_test
+def test_draft_vllm_config_uses_draft_model_load_and_quant_configs():
+    target_model = SimpleNamespace(name="target")
+    draft_model = SimpleNamespace(name="draft")
+    target_load = SimpleNamespace(name="target-load")
+    draft_load = SimpleNamespace(name="draft-load")
+    draft_quant = SimpleNamespace(name="draft-quant")
+
+    base = SimpleNamespace(
+        model_config=target_model,
+        load_config=target_load,
+        quant_config=SimpleNamespace(name="target-quant"),
+        kernel_config=SimpleNamespace(moe_backend=None),
+        attention_config=SimpleNamespace(backend=None),
+        cache_config=SimpleNamespace(cache_dtype="auto"),
+    )
+    speculative_config = SimpleNamespace(
+        draft_load_config=draft_load,
+        moe_backend=None,
+        attention_backend=None,
+        kv_cache_dtype=None,
+    )
+    proposer = object.__new__(SpecDecodeBaseProposer)
+    proposer.vllm_config = base
+    proposer.speculative_config = speculative_config
+    proposer.draft_model_config = draft_model
+
+    def fake_replace(instance, **updates):
+        values = vars(instance).copy()
+        values.update(updates)
+        return SimpleNamespace(**values)
+
+    with (
+        patch(
+            "vllm.v1.spec_decode.llm_base_proposer.replace",
+            side_effect=fake_replace,
+        ),
+        patch.object(
+            VllmConfig,
+            "get_quantization_config",
+            return_value=draft_quant,
+        ) as get_quant_config,
+    ):
+        result = proposer._create_draft_vllm_config()
+
+    get_quant_config.assert_called_once_with(draft_model, draft_load)
+    assert result.model_config is draft_model
+    assert result.load_config is draft_load
+    assert result.quant_config is draft_quant

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -3,7 +3,7 @@
 
 import copy
 import functools
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from typing import TYPE_CHECKING, Any, Literal, get_args
 
 from pydantic import Field, SkipValidation, field_validator, model_validator
@@ -693,17 +693,51 @@ class SpeculativeConfig:
         return target_hf_overrides(hf_config)
 
     @staticmethod
+    def _update_nested_hf_config(
+        target: PretrainedConfig | dict[str, Any],
+        updates: Mapping[str, Any],
+    ) -> None:
+        for key, value in updates.items():
+            nested_target = (
+                target.get(key)
+                if isinstance(target, dict)
+                else getattr(target, key, None)
+            )
+            if (
+                isinstance(value, Mapping)
+                and nested_target is not None
+                and (
+                    isinstance(nested_target, dict)
+                    or hasattr(nested_target, "__dict__")
+                )
+            ):
+                SpeculativeConfig._update_nested_hf_config(nested_target, value)
+            elif isinstance(target, dict):
+                target[key] = value
+            else:
+                setattr(target, key, value)
+
+    @staticmethod
+    def _apply_mapping_hf_override(
+        target_hf_overrides: Mapping[str, Any],
+        hf_config: PretrainedConfig,
+    ) -> PretrainedConfig:
+        """Apply target CLI overrides before deriving the embedded draft config."""
+        SpeculativeConfig._update_nested_hf_config(hf_config, target_hf_overrides)
+        return SpeculativeConfig.hf_config_override(hf_config)
+
+    @staticmethod
     def compose_draft_hf_overrides(
         target_hf_overrides: HfOverrides | None,
+        *,
+        forward_mapping: bool = False,
     ) -> Callable[[PretrainedConfig], PretrainedConfig]:
         """Build the ``hf_overrides`` for the draft ``ModelConfig``.
 
-        Callable overrides on the target are config-to-config transforms
-        (e.g. test harnesses shrinking ``num_hidden_layers``) and must also
-        reach the draft config — otherwise a draft belonging to a large
-        target is instantiated at full size even when the target is shrunk.
-        Dict overrides are target-specific key patches and are not applied
-        to the draft.
+        Callable overrides on the target are config-to-config transforms and
+        must also reach the draft config. Mapping overrides normally remain
+        target-only, but embedded MTP drafts opt in so runtime positional
+        changes remain identical between target and draft.
 
         The composed override must stay picklable: the draft ``ModelConfig``
         is sent to spawned engine-core processes, so a local closure would
@@ -711,6 +745,14 @@ class SpeculativeConfig:
         target via ``functools.partial`` over a module-referenceable static
         method instead.
         """
+        if forward_mapping and isinstance(target_hf_overrides, Mapping):
+            if not target_hf_overrides:
+                return SpeculativeConfig.hf_config_override
+            return functools.partial(
+                SpeculativeConfig._apply_mapping_hf_override,
+                copy.deepcopy(dict(target_hf_overrides)),
+            )
+
         if not callable(target_hf_overrides):
             return SpeculativeConfig.hf_config_override
 
@@ -891,9 +933,12 @@ class SpeculativeConfig:
                 else:
                     # Compose any callable hf_overrides set on the target so the
                     # draft config receives the same transform (e.g. the test
-                    # shrink). Dict overrides stay target-only.
+                    # shrink). Embedded MTP drafts also inherit mapping
+                    # overrides because they share the target's positional
+                    # configuration.
                     draft_hf_overrides = SpeculativeConfig.compose_draft_hf_overrides(
-                        self.target_model_config.hf_overrides
+                        self.target_model_config.hf_overrides,
+                        forward_mapping=self.method == "mtp",
                     )
                 self.draft_model_config = ModelConfig(
                     model=self.model,
@@ -920,6 +965,19 @@ class SpeculativeConfig:
                     hf_overrides=draft_hf_overrides,
                     config_format=self.target_model_config.config_format,
                 )
+
+                # An embedded MTP head can be stored unquantized inside a
+                # quantized target checkpoint. When users explicitly select a
+                # different draft quantization method, checkpoint-level target
+                # metadata must not override it: only MTP weights are loaded by
+                # the draft model loader.
+                if (
+                    self.method == "mtp"
+                    and self.quantization is not None
+                    and self.quantization != self.target_model_config.quantization
+                ):
+                    self.draft_model_config.quantization = self.quantization
+                    self.draft_model_config.hf_config.quantization_config = None
 
                 # Old-format Medusa checkpoints (e.g. FasterDecoding/medusa-*)
                 # omit vocab_size in config.json, so MedusaConfig falls back to

--- a/vllm/model_executor/model_loader/weight_utils.py
+++ b/vllm/model_executor/model_loader/weight_utils.py
@@ -290,6 +290,14 @@ def get_quant_config(
     # hf_overrides
     hf_overrides = model_config.hf_overrides
     if not isinstance(hf_overrides, dict):
+        # Online quantizers with no config files construct a valid default
+        # config. Callable HF overrides have already been applied while loading
+        # the model config and must not prevent that default path.
+        if (
+            model_config.quantization_config is None
+            and not quant_cls.get_config_filenames()
+        ):
+            return quant_cls()
         raise ValueError(
             "hf_overrides must be a dict for get_quant_config "
             "to get the quantization config from it."

--- a/vllm/v1/spec_decode/llm_base_proposer.py
+++ b/vllm/v1/spec_decode/llm_base_proposer.py
@@ -1288,6 +1288,20 @@ class SpecDecodeBaseProposer:
         spec_cfg = self.speculative_config
         base = self.vllm_config
 
+        # Draft ModelConfig carries independent model, load, and quantization
+        # settings, while new-style model constructors read them from
+        # VllmConfig. Keep the two in sync so draft-specific options are not
+        # silently replaced by the target model's settings.
+        draft_load_config = spec_cfg.draft_load_config or base.load_config
+        base = replace(
+            base,
+            model_config=self.draft_model_config,
+            load_config=draft_load_config,
+            quant_config=VllmConfig.get_quantization_config(
+                self.draft_model_config, draft_load_config
+            ),
+        )
+
         if spec_cfg.moe_backend is not None:
             base = replace(
                 base,


### PR DESCRIPTION
## Purpose

Embedded MTP drafts are built from the target checkpoint, but their runtime
configuration could diverge from the target in two important ways:

- mapping-style `hf_overrides` were not forwarded, so long-context positional
  overrides applied to the target could leave the MTP draft at the checkpoint's
  original context configuration;
- new-style draft model constructors received the target `ModelConfig`,
  `LoadConfig`, and quantization config through `VllmConfig`, which silently
  discarded explicit draft settings such as `quantization="fp8"`.

This keeps embedded MTP drafts aligned with target runtime overrides while
preserving their explicitly selected model/load/quantization settings.

## Changes

- Forward mapping-style HF overrides to embedded MTP drafts only, while
  preserving existing standalone-draft behavior.
- Preserve an explicit MTP draft quantization method when target checkpoint
  metadata describes a different quantization scheme.
- Build the proposer `VllmConfig` with the draft model, load, and quantization
  configs.
- Permit config-free quantization methods to construct their default config
  when HF overrides are callable transforms.
- Add CPU regression coverage for positional override forwarding, default FP8
  config construction, and proposer config selection.

## Test plan and results

- `pytest -q tests/config/test_speculative_draft_hf_overrides.py tests/model_executor/test_weight_utils.py -k 'not download_weights_from_hf'`
  - 38 passed, 1 deselected
- `pytest -q tests/v1/spec_decode/test_llm_base_proposer_config.py`
  - 1 passed
- `ruff check` and `ruff format --check` on all changed files
  - passed
- Reconstructed a local Ling 3 MTP configuration from a ModelOpt NVFP4
  checkpoint with a 524,288-token target and factor-2 YaRN runtime override:
  - target and draft both resolved to `max_model_len=524288`;
  - target and draft both received the same YaRN parameters;
  - draft resolved to `BailingMoeV3MTPModel`;
  - target remained `modelopt_mixed`, while the draft resolved to `Fp8Config`.
- End-to-end hardware validation on SM120 with this change and the separate
  Triton MLA multi-token decode fix completed a roughly 500K-token prompt plus
  1,024-token decode coherently, including successful needle retrieval.
