### PR TITLE
[Bug] Fix cudaErrorNoKernelImageForDevice in fused_add_rms_norm for T…

### DIFF
--- a/csrc/libtorch_stable/layernorm_kernels.cu
+++ b/csrc/libtorch_stable/layernorm_kernels.cu
@@ -104,14 +104,14 @@ __global__ void rms_norm_kernel(
    packed and vectorized operations, which help with the
    memory latency bottleneck. */
 template <typename scalar_t, int width, bool HasWeight>
-__global__ std::enable_if_t<(width > 0) && _typeConvert<scalar_t>::exists>
-fused_add_rms_norm_kernel(
+__global__ void fused_add_rms_norm_kernel(
     scalar_t* __restrict__ input,  // [..., hidden_size]
     const int64_t input_stride,
     scalar_t* __restrict__ residual,      // [..., hidden_size]
     const scalar_t* __restrict__ weight,  // [hidden_size], null if !HasWeight
     const float epsilon, const int num_tokens, const int hidden_size,
     const int64_t residual_stride) {
+  if constexpr (width > 0 && _typeConvert<scalar_t>::exists) {
   // Sanity checks on our vector struct and type-punned pointer arithmetic
   static_assert(std::is_pod_v<_f16Vec<scalar_t, width>>);
   static_assert(sizeof(_f16Vec<scalar_t, width>) == sizeof(scalar_t) * width);
@@ -171,20 +171,7 @@ fused_add_rms_norm_kernel(
     }
     input_v[strided_id] = out;
   }
-}
-
-/* Generic fused_add_rms_norm_kernel
-   The width field is not used here but necessary for other specializations.
- */
-template <typename scalar_t, int width, bool HasWeight>
-__global__ std::enable_if_t<(width == 0) || !_typeConvert<scalar_t>::exists>
-fused_add_rms_norm_kernel(
-    scalar_t* __restrict__ input,  // [..., hidden_size]
-    const int64_t input_stride,
-    scalar_t* __restrict__ residual,      // [..., hidden_size]
-    const scalar_t* __restrict__ weight,  // [hidden_size], null if !HasWeight
-    const float epsilon, const int num_tokens, const int hidden_size,
-    const int64_t residual_stride) {
+  } else {
   __shared__ float s_variance;
   float variance = 0.0f;
 
@@ -213,6 +200,7 @@ fused_add_rms_norm_kernel(
     } else {
       input[blockIdx.x * input_stride + idx] = (scalar_t)(x * s_variance);
     }
+  }
   }
 }
 

--- a/csrc/libtorch_stable/layernorm_kernels.cu
+++ b/csrc/libtorch_stable/layernorm_kernels.cu
@@ -112,95 +112,97 @@ __global__ void fused_add_rms_norm_kernel(
     const float epsilon, const int num_tokens, const int hidden_size,
     const int64_t residual_stride) {
   if constexpr (width > 0 && _typeConvert<scalar_t>::exists) {
-  // Sanity checks on our vector struct and type-punned pointer arithmetic
-  static_assert(std::is_pod_v<_f16Vec<scalar_t, width>>);
-  static_assert(sizeof(_f16Vec<scalar_t, width>) == sizeof(scalar_t) * width);
+    // Sanity checks on our vector struct and type-punned pointer arithmetic
+    static_assert(std::is_pod_v<_f16Vec<scalar_t, width>>);
+    static_assert(sizeof(_f16Vec<scalar_t, width>) == sizeof(scalar_t) * width);
 
-  const int vec_hidden_size = hidden_size / width;
-  const int64_t vec_input_stride = input_stride / width;
-  __shared__ float s_variance;
-  float variance = 0.0f;
-  /* These and the argument pointers are all declared `restrict` as they are
-     not aliased in practice. Argument pointers should not be dereferenced
-     in this kernel as that would be undefined behavior */
-  auto* __restrict__ input_v =
-      reinterpret_cast<_f16Vec<scalar_t, width>*>(input);
-  auto* __restrict__ residual_v =
-      reinterpret_cast<_f16Vec<scalar_t, width>*>(residual);
-  auto* __restrict__ weight_v =
-      reinterpret_cast<const _f16Vec<scalar_t, width>*>(weight);
+    const int vec_hidden_size = hidden_size / width;
+    const int64_t vec_input_stride = input_stride / width;
+    __shared__ float s_variance;
+    float variance = 0.0f;
+    /* These and the argument pointers are all declared `restrict` as they are
+       not aliased in practice. Argument pointers should not be dereferenced
+       in this kernel as that would be undefined behavior */
+    auto* __restrict__ input_v =
+        reinterpret_cast<_f16Vec<scalar_t, width>*>(input);
+    auto* __restrict__ residual_v =
+        reinterpret_cast<_f16Vec<scalar_t, width>*>(residual);
+    auto* __restrict__ weight_v =
+        reinterpret_cast<const _f16Vec<scalar_t, width>*>(weight);
 
-  for (int idx = threadIdx.x; idx < vec_hidden_size; idx += blockDim.x) {
-    int64_t id = blockIdx.x * residual_stride / width + idx;
-    int64_t strided_id = blockIdx.x * vec_input_stride + idx;
-    _f16Vec<scalar_t, width> temp = input_v[strided_id];
-    temp += residual_v[id];
-    variance += temp.sum_squares();
-    residual_v[id] = temp;
-  }
-
-  using BlockReduce = cub::BlockReduce<float, 1024>;
-  __shared__ typename BlockReduce::TempStorage reduceStore;
-  variance = BlockReduce(reduceStore).Reduce(variance, CubAddOp{}, blockDim.x);
-
-  if (threadIdx.x == 0) {
-    s_variance = rsqrtf(variance / hidden_size + epsilon);
-  }
-  __syncthreads();
-
-  for (int idx = threadIdx.x; idx < vec_hidden_size; idx += blockDim.x) {
-    int64_t id = blockIdx.x * residual_stride / width + idx;
-    int64_t strided_id = blockIdx.x * vec_input_stride + idx;
-    _f16Vec<scalar_t, width> res = residual_v[id];
-    _f16Vec<scalar_t, width> out;
-    using Converter = _typeConvert<scalar_t>;
-    if constexpr (HasWeight) {
-      _f16Vec<scalar_t, width> w = weight_v[idx];
-#pragma unroll
-      for (int j = 0; j < width; ++j) {
-        float x = Converter::convert(res.data[j]);
-        float wf = Converter::convert(w.data[j]);
-        out.data[j] = Converter::convert(x * s_variance * wf);
-      }
-    } else {
-#pragma unroll
-      for (int j = 0; j < width; ++j) {
-        float x = Converter::convert(res.data[j]);
-        out.data[j] = Converter::convert(x * s_variance);
-      }
+    for (int idx = threadIdx.x; idx < vec_hidden_size; idx += blockDim.x) {
+      int64_t id = blockIdx.x * residual_stride / width + idx;
+      int64_t strided_id = blockIdx.x * vec_input_stride + idx;
+      _f16Vec<scalar_t, width> temp = input_v[strided_id];
+      temp += residual_v[id];
+      variance += temp.sum_squares();
+      residual_v[id] = temp;
     }
-    input_v[strided_id] = out;
-  }
+
+    using BlockReduce = cub::BlockReduce<float, 1024>;
+    __shared__ typename BlockReduce::TempStorage reduceStore;
+    variance =
+        BlockReduce(reduceStore).Reduce(variance, CubAddOp{}, blockDim.x);
+
+    if (threadIdx.x == 0) {
+      s_variance = rsqrtf(variance / hidden_size + epsilon);
+    }
+    __syncthreads();
+
+    for (int idx = threadIdx.x; idx < vec_hidden_size; idx += blockDim.x) {
+      int64_t id = blockIdx.x * residual_stride / width + idx;
+      int64_t strided_id = blockIdx.x * vec_input_stride + idx;
+      _f16Vec<scalar_t, width> res = residual_v[id];
+      _f16Vec<scalar_t, width> out;
+      using Converter = _typeConvert<scalar_t>;
+      if constexpr (HasWeight) {
+        _f16Vec<scalar_t, width> w = weight_v[idx];
+#pragma unroll
+        for (int j = 0; j < width; ++j) {
+          float x = Converter::convert(res.data[j]);
+          float wf = Converter::convert(w.data[j]);
+          out.data[j] = Converter::convert(x * s_variance * wf);
+        }
+      } else {
+#pragma unroll
+        for (int j = 0; j < width; ++j) {
+          float x = Converter::convert(res.data[j]);
+          out.data[j] = Converter::convert(x * s_variance);
+        }
+      }
+      input_v[strided_id] = out;
+    }
   } else {
-  __shared__ float s_variance;
-  float variance = 0.0f;
+    __shared__ float s_variance;
+    float variance = 0.0f;
 
-  for (int idx = threadIdx.x; idx < hidden_size; idx += blockDim.x) {
-    scalar_t z = input[blockIdx.x * input_stride + idx];
-    z += residual[blockIdx.x * residual_stride + idx];
-    float x = (float)z;
-    variance += x * x;
-    residual[blockIdx.x * residual_stride + idx] = z;
-  }
-
-  using BlockReduce = cub::BlockReduce<float, 1024>;
-  __shared__ typename BlockReduce::TempStorage reduceStore;
-  variance = BlockReduce(reduceStore).Reduce(variance, CubAddOp{}, blockDim.x);
-
-  if (threadIdx.x == 0) {
-    s_variance = rsqrtf(variance / hidden_size + epsilon);
-  }
-  __syncthreads();
-
-  for (int idx = threadIdx.x; idx < hidden_size; idx += blockDim.x) {
-    float x = (float)residual[blockIdx.x * residual_stride + idx];
-    if constexpr (HasWeight) {
-      float w = (float)weight[idx];
-      input[blockIdx.x * input_stride + idx] = (scalar_t)(x * s_variance * w);
-    } else {
-      input[blockIdx.x * input_stride + idx] = (scalar_t)(x * s_variance);
+    for (int idx = threadIdx.x; idx < hidden_size; idx += blockDim.x) {
+      scalar_t z = input[blockIdx.x * input_stride + idx];
+      z += residual[blockIdx.x * residual_stride + idx];
+      float x = (float)z;
+      variance += x * x;
+      residual[blockIdx.x * residual_stride + idx] = z;
     }
-  }
+
+    using BlockReduce = cub::BlockReduce<float, 1024>;
+    __shared__ typename BlockReduce::TempStorage reduceStore;
+    variance =
+        BlockReduce(reduceStore).Reduce(variance, CubAddOp{}, blockDim.x);
+
+    if (threadIdx.x == 0) {
+      s_variance = rsqrtf(variance / hidden_size + epsilon);
+    }
+    __syncthreads();
+
+    for (int idx = threadIdx.x; idx < hidden_size; idx += blockDim.x) {
+      float x = (float)residual[blockIdx.x * residual_stride + idx];
+      if constexpr (HasWeight) {
+        float w = (float)weight[idx];
+        input[blockIdx.x * input_stride + idx] = (scalar_t)(x * s_variance * w);
+      } else {
+        input[blockIdx.x * input_stride + idx] = (scalar_t)(x * s_variance);
+      }
+    }
   }
 }
 

--- a/csrc/libtorch_stable/layernorm_kernels.cu
+++ b/csrc/libtorch_stable/layernorm_kernels.cu
@@ -112,97 +112,95 @@ __global__ void fused_add_rms_norm_kernel(
     const float epsilon, const int num_tokens, const int hidden_size,
     const int64_t residual_stride) {
   if constexpr (width > 0 && _typeConvert<scalar_t>::exists) {
-    // Sanity checks on our vector struct and type-punned pointer arithmetic
-    static_assert(std::is_pod_v<_f16Vec<scalar_t, width>>);
-    static_assert(sizeof(_f16Vec<scalar_t, width>) == sizeof(scalar_t) * width);
+  // Sanity checks on our vector struct and type-punned pointer arithmetic
+  static_assert(std::is_pod_v<_f16Vec<scalar_t, width>>);
+  static_assert(sizeof(_f16Vec<scalar_t, width>) == sizeof(scalar_t) * width);
 
-    const int vec_hidden_size = hidden_size / width;
-    const int64_t vec_input_stride = input_stride / width;
-    __shared__ float s_variance;
-    float variance = 0.0f;
-    /* These and the argument pointers are all declared `restrict` as they are
-       not aliased in practice. Argument pointers should not be dereferenced
-       in this kernel as that would be undefined behavior */
-    auto* __restrict__ input_v =
-        reinterpret_cast<_f16Vec<scalar_t, width>*>(input);
-    auto* __restrict__ residual_v =
-        reinterpret_cast<_f16Vec<scalar_t, width>*>(residual);
-    auto* __restrict__ weight_v =
-        reinterpret_cast<const _f16Vec<scalar_t, width>*>(weight);
+  const int vec_hidden_size = hidden_size / width;
+  const int64_t vec_input_stride = input_stride / width;
+  __shared__ float s_variance;
+  float variance = 0.0f;
+  /* These and the argument pointers are all declared `restrict` as they are
+     not aliased in practice. Argument pointers should not be dereferenced
+     in this kernel as that would be undefined behavior */
+  auto* __restrict__ input_v =
+      reinterpret_cast<_f16Vec<scalar_t, width>*>(input);
+  auto* __restrict__ residual_v =
+      reinterpret_cast<_f16Vec<scalar_t, width>*>(residual);
+  auto* __restrict__ weight_v =
+      reinterpret_cast<const _f16Vec<scalar_t, width>*>(weight);
 
-    for (int idx = threadIdx.x; idx < vec_hidden_size; idx += blockDim.x) {
-      int64_t id = blockIdx.x * residual_stride / width + idx;
-      int64_t strided_id = blockIdx.x * vec_input_stride + idx;
-      _f16Vec<scalar_t, width> temp = input_v[strided_id];
-      temp += residual_v[id];
-      variance += temp.sum_squares();
-      residual_v[id] = temp;
-    }
+  for (int idx = threadIdx.x; idx < vec_hidden_size; idx += blockDim.x) {
+    int64_t id = blockIdx.x * residual_stride / width + idx;
+    int64_t strided_id = blockIdx.x * vec_input_stride + idx;
+    _f16Vec<scalar_t, width> temp = input_v[strided_id];
+    temp += residual_v[id];
+    variance += temp.sum_squares();
+    residual_v[id] = temp;
+  }
 
-    using BlockReduce = cub::BlockReduce<float, 1024>;
-    __shared__ typename BlockReduce::TempStorage reduceStore;
-    variance =
-        BlockReduce(reduceStore).Reduce(variance, CubAddOp{}, blockDim.x);
+  using BlockReduce = cub::BlockReduce<float, 1024>;
+  __shared__ typename BlockReduce::TempStorage reduceStore;
+  variance = BlockReduce(reduceStore).Reduce(variance, CubAddOp{}, blockDim.x);
 
-    if (threadIdx.x == 0) {
-      s_variance = rsqrtf(variance / hidden_size + epsilon);
-    }
-    __syncthreads();
+  if (threadIdx.x == 0) {
+    s_variance = rsqrtf(variance / hidden_size + epsilon);
+  }
+  __syncthreads();
 
-    for (int idx = threadIdx.x; idx < vec_hidden_size; idx += blockDim.x) {
-      int64_t id = blockIdx.x * residual_stride / width + idx;
-      int64_t strided_id = blockIdx.x * vec_input_stride + idx;
-      _f16Vec<scalar_t, width> res = residual_v[id];
-      _f16Vec<scalar_t, width> out;
-      using Converter = _typeConvert<scalar_t>;
-      if constexpr (HasWeight) {
-        _f16Vec<scalar_t, width> w = weight_v[idx];
+  for (int idx = threadIdx.x; idx < vec_hidden_size; idx += blockDim.x) {
+    int64_t id = blockIdx.x * residual_stride / width + idx;
+    int64_t strided_id = blockIdx.x * vec_input_stride + idx;
+    _f16Vec<scalar_t, width> res = residual_v[id];
+    _f16Vec<scalar_t, width> out;
+    using Converter = _typeConvert<scalar_t>;
+    if constexpr (HasWeight) {
+      _f16Vec<scalar_t, width> w = weight_v[idx];
 #pragma unroll
-        for (int j = 0; j < width; ++j) {
-          float x = Converter::convert(res.data[j]);
-          float wf = Converter::convert(w.data[j]);
-          out.data[j] = Converter::convert(x * s_variance * wf);
-        }
-      } else {
-#pragma unroll
-        for (int j = 0; j < width; ++j) {
-          float x = Converter::convert(res.data[j]);
-          out.data[j] = Converter::convert(x * s_variance);
-        }
+      for (int j = 0; j < width; ++j) {
+        float x = Converter::convert(res.data[j]);
+        float wf = Converter::convert(w.data[j]);
+        out.data[j] = Converter::convert(x * s_variance * wf);
       }
-      input_v[strided_id] = out;
+    } else {
+#pragma unroll
+      for (int j = 0; j < width; ++j) {
+        float x = Converter::convert(res.data[j]);
+        out.data[j] = Converter::convert(x * s_variance);
+      }
     }
+    input_v[strided_id] = out;
+  }
   } else {
-    __shared__ float s_variance;
-    float variance = 0.0f;
+  __shared__ float s_variance;
+  float variance = 0.0f;
 
-    for (int idx = threadIdx.x; idx < hidden_size; idx += blockDim.x) {
-      scalar_t z = input[blockIdx.x * input_stride + idx];
-      z += residual[blockIdx.x * residual_stride + idx];
-      float x = (float)z;
-      variance += x * x;
-      residual[blockIdx.x * residual_stride + idx] = z;
+  for (int idx = threadIdx.x; idx < hidden_size; idx += blockDim.x) {
+    scalar_t z = input[blockIdx.x * input_stride + idx];
+    z += residual[blockIdx.x * residual_stride + idx];
+    float x = (float)z;
+    variance += x * x;
+    residual[blockIdx.x * residual_stride + idx] = z;
+  }
+
+  using BlockReduce = cub::BlockReduce<float, 1024>;
+  __shared__ typename BlockReduce::TempStorage reduceStore;
+  variance = BlockReduce(reduceStore).Reduce(variance, CubAddOp{}, blockDim.x);
+
+  if (threadIdx.x == 0) {
+    s_variance = rsqrtf(variance / hidden_size + epsilon);
+  }
+  __syncthreads();
+
+  for (int idx = threadIdx.x; idx < hidden_size; idx += blockDim.x) {
+    float x = (float)residual[blockIdx.x * residual_stride + idx];
+    if constexpr (HasWeight) {
+      float w = (float)weight[idx];
+      input[blockIdx.x * input_stride + idx] = (scalar_t)(x * s_variance * w);
+    } else {
+      input[blockIdx.x * input_stride + idx] = (scalar_t)(x * s_variance);
     }
-
-    using BlockReduce = cub::BlockReduce<float, 1024>;
-    __shared__ typename BlockReduce::TempStorage reduceStore;
-    variance =
-        BlockReduce(reduceStore).Reduce(variance, CubAddOp{}, blockDim.x);
-
-    if (threadIdx.x == 0) {
-      s_variance = rsqrtf(variance / hidden_size + epsilon);
-    }
-    __syncthreads();
-
-    for (int idx = threadIdx.x; idx < hidden_size; idx += blockDim.x) {
-      float x = (float)residual[blockIdx.x * residual_stride + idx];
-      if constexpr (HasWeight) {
-        float w = (float)weight[idx];
-        input[blockIdx.x * input_stride + idx] = (scalar_t)(x * s_variance * w);
-      } else {
-        input[blockIdx.x * input_stride + idx] = (scalar_t)(x * s_variance);
-      }
-    }
+  }
   }
 }
 

--- a/csrc/libtorch_stable/layernorm_quant_kernels.cu
+++ b/csrc/libtorch_stable/layernorm_quant_kernels.cu
@@ -85,8 +85,7 @@ __global__ void rms_norm_static_fp8_quant_kernel(
    packed and vectorized operations, which help with the
    memory latency bottleneck. */
 template <typename scalar_t, int width, typename fp8_type>
-__global__ std::enable_if_t<(width > 0) && _typeConvert<scalar_t>::exists>
-fused_add_rms_norm_static_fp8_quant_kernel(
+__global__ void fused_add_rms_norm_static_fp8_quant_kernel(
     fp8_type* __restrict__ out,    // [..., hidden_size]
     scalar_t* __restrict__ input,  // [..., hidden_size]
     const int input_stride,
@@ -94,6 +93,7 @@ fused_add_rms_norm_static_fp8_quant_kernel(
     const scalar_t* __restrict__ weight,  // [hidden_size]
     const float* __restrict__ scale,      // [1]
     const float epsilon, const int num_tokens, const int hidden_size) {
+  if constexpr (width > 0 && _typeConvert<scalar_t>::exists) {
   // Sanity checks on our vector struct and type-punned pointer arithmetic
   static_assert(std::is_pod_v<_f16Vec<scalar_t, width>>);
   static_assert(sizeof(_f16Vec<scalar_t, width>) == sizeof(scalar_t) * width);
@@ -152,21 +152,7 @@ fused_add_rms_norm_static_fp8_quant_kernel(
           Converter::convert(out_norm_h), scale_inv);
     }
   }
-}
-
-/* Generic fused_add_rms_norm_kernel
-   The width field is not used here but necessary for other specializations.
- */
-template <typename scalar_t, int width, typename fp8_type>
-__global__ std::enable_if_t<(width == 0) || !_typeConvert<scalar_t>::exists>
-fused_add_rms_norm_static_fp8_quant_kernel(
-    fp8_type* __restrict__ out,    // [..., hidden_size]
-    scalar_t* __restrict__ input,  // [..., hidden_size]
-    const int input_stride,
-    scalar_t* __restrict__ residual,      // [..., hidden_size]
-    const scalar_t* __restrict__ weight,  // [hidden_size]
-    const float* __restrict__ scale,      // [1]
-    const float epsilon, const int num_tokens, const int hidden_size) {
+  } else {
   __shared__ float s_variance;
   float variance = 0.0f;
 
@@ -198,6 +184,7 @@ fused_add_rms_norm_static_fp8_quant_kernel(
     scalar_t out_norm = static_cast<scalar_t>(x * s_variance * w);
     out[blockIdx.x * hidden_size + idx] = scaled_fp8_conversion<true, fp8_type>(
         static_cast<float>(out_norm), scale_inv);
+  }
   }
 }
 

--- a/csrc/libtorch_stable/layernorm_quant_kernels.cu
+++ b/csrc/libtorch_stable/layernorm_quant_kernels.cu
@@ -94,100 +94,97 @@ __global__ void fused_add_rms_norm_static_fp8_quant_kernel(
     const float* __restrict__ scale,      // [1]
     const float epsilon, const int num_tokens, const int hidden_size) {
   if constexpr (width > 0 && _typeConvert<scalar_t>::exists) {
-    // Sanity checks on our vector struct and type-punned pointer arithmetic
-    static_assert(std::is_pod_v<_f16Vec<scalar_t, width>>);
-    static_assert(sizeof(_f16Vec<scalar_t, width>) == sizeof(scalar_t) * width);
+  // Sanity checks on our vector struct and type-punned pointer arithmetic
+  static_assert(std::is_pod_v<_f16Vec<scalar_t, width>>);
+  static_assert(sizeof(_f16Vec<scalar_t, width>) == sizeof(scalar_t) * width);
 
-    const int vec_hidden_size = hidden_size / width;
-    const int vec_input_stride = input_stride / width;
-    __shared__ float s_variance;
-    float variance = 0.0f;
-    /* These and the argument pointers are all declared `restrict` as they are
-       not aliased in practice. Argument pointers should not be dereferenced
-       in this kernel as that would be undefined behavior */
-    auto* __restrict__ input_v =
-        reinterpret_cast<_f16Vec<scalar_t, width>*>(input);
-    auto* __restrict__ residual_v =
-        reinterpret_cast<_f16Vec<scalar_t, width>*>(residual);
-    auto* __restrict__ weight_v =
-        reinterpret_cast<const _f16Vec<scalar_t, width>*>(weight);
+  const int vec_hidden_size = hidden_size / width;
+  const int vec_input_stride = input_stride / width;
+  __shared__ float s_variance;
+  float variance = 0.0f;
+  /* These and the argument pointers are all declared `restrict` as they are
+     not aliased in practice. Argument pointers should not be dereferenced
+     in this kernel as that would be undefined behavior */
+  auto* __restrict__ input_v =
+      reinterpret_cast<_f16Vec<scalar_t, width>*>(input);
+  auto* __restrict__ residual_v =
+      reinterpret_cast<_f16Vec<scalar_t, width>*>(residual);
+  auto* __restrict__ weight_v =
+      reinterpret_cast<const _f16Vec<scalar_t, width>*>(weight);
 
-    for (int idx = threadIdx.x; idx < vec_hidden_size; idx += blockDim.x) {
-      int stride_id = blockIdx.x * vec_input_stride + idx;
-      int id = blockIdx.x * vec_hidden_size + idx;
-      _f16Vec<scalar_t, width> temp = input_v[stride_id];
-      temp += residual_v[id];
-      variance += temp.sum_squares();
-      residual_v[id] = temp;
-    }
+  for (int idx = threadIdx.x; idx < vec_hidden_size; idx += blockDim.x) {
+    int stride_id = blockIdx.x * vec_input_stride + idx;
+    int id = blockIdx.x * vec_hidden_size + idx;
+    _f16Vec<scalar_t, width> temp = input_v[stride_id];
+    temp += residual_v[id];
+    variance += temp.sum_squares();
+    residual_v[id] = temp;
+  }
 
-    using BlockReduce = cub::BlockReduce<float, 1024>;
-    __shared__ typename BlockReduce::TempStorage reduceStore;
-    variance =
-        BlockReduce(reduceStore).Reduce(variance, CubAddOp{}, blockDim.x);
+  using BlockReduce = cub::BlockReduce<float, 1024>;
+  __shared__ typename BlockReduce::TempStorage reduceStore;
+  variance = BlockReduce(reduceStore).Reduce(variance, CubAddOp{}, blockDim.x);
 
-    if (threadIdx.x == 0) {
-      s_variance = rsqrtf(variance / hidden_size + epsilon);
-    }
-    __syncthreads();
+  if (threadIdx.x == 0) {
+    s_variance = rsqrtf(variance / hidden_size + epsilon);
+  }
+  __syncthreads();
 
-    // invert scale to avoid division
-    float const scale_inv = 1.0f / *scale;
+  // invert scale to avoid division
+  float const scale_inv = 1.0f / *scale;
 
-    for (int idx = threadIdx.x; idx < vec_hidden_size; idx += blockDim.x) {
-      int id = blockIdx.x * vec_hidden_size + idx;
-      _f16Vec<scalar_t, width> res = residual_v[id];
-      _f16Vec<scalar_t, width> w = weight_v[idx];
-      using Converter = _typeConvert<scalar_t>;
-      using HipT = typename Converter::hip_type;
+  for (int idx = threadIdx.x; idx < vec_hidden_size; idx += blockDim.x) {
+    int id = blockIdx.x * vec_hidden_size + idx;
+    _f16Vec<scalar_t, width> res = residual_v[id];
+    _f16Vec<scalar_t, width> w = weight_v[idx];
+    using Converter = _typeConvert<scalar_t>;
+    using HipT = typename Converter::hip_type;
 #pragma unroll
-      for (int i = 0; i < width; ++i) {
-        float x = Converter::convert(res.data[i]);
-        float wf = Converter::convert(w.data[i]);
-        // See note in rms_norm_static_fp8_quant_kernel: round through scalar_t
-        // to match the unfused composite path at FP8 boundaries. We use the
-        // backend's hip_type for the intermediate since c10::Half/BFloat16 has
-        // ambiguous conversions on CUDA and no implicit conversion on ROCm.
-        HipT out_norm_h = Converter::convert(x * s_variance * wf);
-        out[id * width + i] = scaled_fp8_conversion<true, fp8_type>(
-            Converter::convert(out_norm_h), scale_inv);
-      }
-    }
-  } else {
-    __shared__ float s_variance;
-    float variance = 0.0f;
-
-    for (int idx = threadIdx.x; idx < hidden_size; idx += blockDim.x) {
-      scalar_t z = input[blockIdx.x * input_stride + idx];
-      z += residual[blockIdx.x * hidden_size + idx];
-      float x = (float)z;
-      variance += x * x;
-      residual[blockIdx.x * hidden_size + idx] = z;
-    }
-
-    using BlockReduce = cub::BlockReduce<float, 1024>;
-    __shared__ typename BlockReduce::TempStorage reduceStore;
-    variance =
-        BlockReduce(reduceStore).Reduce(variance, CubAddOp{}, blockDim.x);
-
-    if (threadIdx.x == 0) {
-      s_variance = rsqrtf(variance / hidden_size + epsilon);
-    }
-    __syncthreads();
-
-    // invert scale to avoid division
-    float const scale_inv = 1.0f / *scale;
-
-    for (int idx = threadIdx.x; idx < hidden_size; idx += blockDim.x) {
-      float x = (float)residual[blockIdx.x * hidden_size + idx];
-      float w = (float)weight[idx];
+    for (int i = 0; i < width; ++i) {
+      float x = Converter::convert(res.data[i]);
+      float wf = Converter::convert(w.data[i]);
       // See note in rms_norm_static_fp8_quant_kernel: round through scalar_t
-      // to match the unfused composite path at FP8 boundaries.
-      scalar_t out_norm = static_cast<scalar_t>(x * s_variance * w);
-      out[blockIdx.x * hidden_size + idx] =
-          scaled_fp8_conversion<true, fp8_type>(static_cast<float>(out_norm),
-                                                scale_inv);
+      // to match the unfused composite path at FP8 boundaries. We use the
+      // backend's hip_type for the intermediate since c10::Half/BFloat16 has
+      // ambiguous conversions on CUDA and no implicit conversion on ROCm.
+      HipT out_norm_h = Converter::convert(x * s_variance * wf);
+      out[id * width + i] = scaled_fp8_conversion<true, fp8_type>(
+          Converter::convert(out_norm_h), scale_inv);
     }
+  }
+  } else {
+  __shared__ float s_variance;
+  float variance = 0.0f;
+
+  for (int idx = threadIdx.x; idx < hidden_size; idx += blockDim.x) {
+    scalar_t z = input[blockIdx.x * input_stride + idx];
+    z += residual[blockIdx.x * hidden_size + idx];
+    float x = (float)z;
+    variance += x * x;
+    residual[blockIdx.x * hidden_size + idx] = z;
+  }
+
+  using BlockReduce = cub::BlockReduce<float, 1024>;
+  __shared__ typename BlockReduce::TempStorage reduceStore;
+  variance = BlockReduce(reduceStore).Reduce(variance, CubAddOp{}, blockDim.x);
+
+  if (threadIdx.x == 0) {
+    s_variance = rsqrtf(variance / hidden_size + epsilon);
+  }
+  __syncthreads();
+
+  // invert scale to avoid division
+  float const scale_inv = 1.0f / *scale;
+
+  for (int idx = threadIdx.x; idx < hidden_size; idx += blockDim.x) {
+    float x = (float)residual[blockIdx.x * hidden_size + idx];
+    float w = (float)weight[idx];
+    // See note in rms_norm_static_fp8_quant_kernel: round through scalar_t
+    // to match the unfused composite path at FP8 boundaries.
+    scalar_t out_norm = static_cast<scalar_t>(x * s_variance * w);
+    out[blockIdx.x * hidden_size + idx] = scaled_fp8_conversion<true, fp8_type>(
+        static_cast<float>(out_norm), scale_inv);
+  }
   }
 }
 

--- a/csrc/libtorch_stable/layernorm_quant_kernels.cu
+++ b/csrc/libtorch_stable/layernorm_quant_kernels.cu
@@ -94,97 +94,100 @@ __global__ void fused_add_rms_norm_static_fp8_quant_kernel(
     const float* __restrict__ scale,      // [1]
     const float epsilon, const int num_tokens, const int hidden_size) {
   if constexpr (width > 0 && _typeConvert<scalar_t>::exists) {
-  // Sanity checks on our vector struct and type-punned pointer arithmetic
-  static_assert(std::is_pod_v<_f16Vec<scalar_t, width>>);
-  static_assert(sizeof(_f16Vec<scalar_t, width>) == sizeof(scalar_t) * width);
+    // Sanity checks on our vector struct and type-punned pointer arithmetic
+    static_assert(std::is_pod_v<_f16Vec<scalar_t, width>>);
+    static_assert(sizeof(_f16Vec<scalar_t, width>) == sizeof(scalar_t) * width);
 
-  const int vec_hidden_size = hidden_size / width;
-  const int vec_input_stride = input_stride / width;
-  __shared__ float s_variance;
-  float variance = 0.0f;
-  /* These and the argument pointers are all declared `restrict` as they are
-     not aliased in practice. Argument pointers should not be dereferenced
-     in this kernel as that would be undefined behavior */
-  auto* __restrict__ input_v =
-      reinterpret_cast<_f16Vec<scalar_t, width>*>(input);
-  auto* __restrict__ residual_v =
-      reinterpret_cast<_f16Vec<scalar_t, width>*>(residual);
-  auto* __restrict__ weight_v =
-      reinterpret_cast<const _f16Vec<scalar_t, width>*>(weight);
+    const int vec_hidden_size = hidden_size / width;
+    const int vec_input_stride = input_stride / width;
+    __shared__ float s_variance;
+    float variance = 0.0f;
+    /* These and the argument pointers are all declared `restrict` as they are
+       not aliased in practice. Argument pointers should not be dereferenced
+       in this kernel as that would be undefined behavior */
+    auto* __restrict__ input_v =
+        reinterpret_cast<_f16Vec<scalar_t, width>*>(input);
+    auto* __restrict__ residual_v =
+        reinterpret_cast<_f16Vec<scalar_t, width>*>(residual);
+    auto* __restrict__ weight_v =
+        reinterpret_cast<const _f16Vec<scalar_t, width>*>(weight);
 
-  for (int idx = threadIdx.x; idx < vec_hidden_size; idx += blockDim.x) {
-    int stride_id = blockIdx.x * vec_input_stride + idx;
-    int id = blockIdx.x * vec_hidden_size + idx;
-    _f16Vec<scalar_t, width> temp = input_v[stride_id];
-    temp += residual_v[id];
-    variance += temp.sum_squares();
-    residual_v[id] = temp;
-  }
-
-  using BlockReduce = cub::BlockReduce<float, 1024>;
-  __shared__ typename BlockReduce::TempStorage reduceStore;
-  variance = BlockReduce(reduceStore).Reduce(variance, CubAddOp{}, blockDim.x);
-
-  if (threadIdx.x == 0) {
-    s_variance = rsqrtf(variance / hidden_size + epsilon);
-  }
-  __syncthreads();
-
-  // invert scale to avoid division
-  float const scale_inv = 1.0f / *scale;
-
-  for (int idx = threadIdx.x; idx < vec_hidden_size; idx += blockDim.x) {
-    int id = blockIdx.x * vec_hidden_size + idx;
-    _f16Vec<scalar_t, width> res = residual_v[id];
-    _f16Vec<scalar_t, width> w = weight_v[idx];
-    using Converter = _typeConvert<scalar_t>;
-    using HipT = typename Converter::hip_type;
-#pragma unroll
-    for (int i = 0; i < width; ++i) {
-      float x = Converter::convert(res.data[i]);
-      float wf = Converter::convert(w.data[i]);
-      // See note in rms_norm_static_fp8_quant_kernel: round through scalar_t
-      // to match the unfused composite path at FP8 boundaries. We use the
-      // backend's hip_type for the intermediate since c10::Half/BFloat16 has
-      // ambiguous conversions on CUDA and no implicit conversion on ROCm.
-      HipT out_norm_h = Converter::convert(x * s_variance * wf);
-      out[id * width + i] = scaled_fp8_conversion<true, fp8_type>(
-          Converter::convert(out_norm_h), scale_inv);
+    for (int idx = threadIdx.x; idx < vec_hidden_size; idx += blockDim.x) {
+      int stride_id = blockIdx.x * vec_input_stride + idx;
+      int id = blockIdx.x * vec_hidden_size + idx;
+      _f16Vec<scalar_t, width> temp = input_v[stride_id];
+      temp += residual_v[id];
+      variance += temp.sum_squares();
+      residual_v[id] = temp;
     }
-  }
+
+    using BlockReduce = cub::BlockReduce<float, 1024>;
+    __shared__ typename BlockReduce::TempStorage reduceStore;
+    variance =
+        BlockReduce(reduceStore).Reduce(variance, CubAddOp{}, blockDim.x);
+
+    if (threadIdx.x == 0) {
+      s_variance = rsqrtf(variance / hidden_size + epsilon);
+    }
+    __syncthreads();
+
+    // invert scale to avoid division
+    float const scale_inv = 1.0f / *scale;
+
+    for (int idx = threadIdx.x; idx < vec_hidden_size; idx += blockDim.x) {
+      int id = blockIdx.x * vec_hidden_size + idx;
+      _f16Vec<scalar_t, width> res = residual_v[id];
+      _f16Vec<scalar_t, width> w = weight_v[idx];
+      using Converter = _typeConvert<scalar_t>;
+      using HipT = typename Converter::hip_type;
+#pragma unroll
+      for (int i = 0; i < width; ++i) {
+        float x = Converter::convert(res.data[i]);
+        float wf = Converter::convert(w.data[i]);
+        // See note in rms_norm_static_fp8_quant_kernel: round through scalar_t
+        // to match the unfused composite path at FP8 boundaries. We use the
+        // backend's hip_type for the intermediate since c10::Half/BFloat16 has
+        // ambiguous conversions on CUDA and no implicit conversion on ROCm.
+        HipT out_norm_h = Converter::convert(x * s_variance * wf);
+        out[id * width + i] = scaled_fp8_conversion<true, fp8_type>(
+            Converter::convert(out_norm_h), scale_inv);
+      }
+    }
   } else {
-  __shared__ float s_variance;
-  float variance = 0.0f;
+    __shared__ float s_variance;
+    float variance = 0.0f;
 
-  for (int idx = threadIdx.x; idx < hidden_size; idx += blockDim.x) {
-    scalar_t z = input[blockIdx.x * input_stride + idx];
-    z += residual[blockIdx.x * hidden_size + idx];
-    float x = (float)z;
-    variance += x * x;
-    residual[blockIdx.x * hidden_size + idx] = z;
-  }
+    for (int idx = threadIdx.x; idx < hidden_size; idx += blockDim.x) {
+      scalar_t z = input[blockIdx.x * input_stride + idx];
+      z += residual[blockIdx.x * hidden_size + idx];
+      float x = (float)z;
+      variance += x * x;
+      residual[blockIdx.x * hidden_size + idx] = z;
+    }
 
-  using BlockReduce = cub::BlockReduce<float, 1024>;
-  __shared__ typename BlockReduce::TempStorage reduceStore;
-  variance = BlockReduce(reduceStore).Reduce(variance, CubAddOp{}, blockDim.x);
+    using BlockReduce = cub::BlockReduce<float, 1024>;
+    __shared__ typename BlockReduce::TempStorage reduceStore;
+    variance =
+        BlockReduce(reduceStore).Reduce(variance, CubAddOp{}, blockDim.x);
 
-  if (threadIdx.x == 0) {
-    s_variance = rsqrtf(variance / hidden_size + epsilon);
-  }
-  __syncthreads();
+    if (threadIdx.x == 0) {
+      s_variance = rsqrtf(variance / hidden_size + epsilon);
+    }
+    __syncthreads();
 
-  // invert scale to avoid division
-  float const scale_inv = 1.0f / *scale;
+    // invert scale to avoid division
+    float const scale_inv = 1.0f / *scale;
 
-  for (int idx = threadIdx.x; idx < hidden_size; idx += blockDim.x) {
-    float x = (float)residual[blockIdx.x * hidden_size + idx];
-    float w = (float)weight[idx];
-    // See note in rms_norm_static_fp8_quant_kernel: round through scalar_t
-    // to match the unfused composite path at FP8 boundaries.
-    scalar_t out_norm = static_cast<scalar_t>(x * s_variance * w);
-    out[blockIdx.x * hidden_size + idx] = scaled_fp8_conversion<true, fp8_type>(
-        static_cast<float>(out_norm), scale_inv);
-  }
+    for (int idx = threadIdx.x; idx < hidden_size; idx += blockDim.x) {
+      float x = (float)residual[blockIdx.x * hidden_size + idx];
+      float w = (float)weight[idx];
+      // See note in rms_norm_static_fp8_quant_kernel: round through scalar_t
+      // to match the unfused composite path at FP8 boundaries.
+      scalar_t out_norm = static_cast<scalar_t>(x * s_variance * w);
+      out[blockIdx.x * hidden_size + idx] =
+          scaled_fp8_conversion<true, fp8_type>(static_cast<float>(out_norm),
+                                                scale_inv);
+    }
   }
 }
 


### PR DESCRIPTION
## Purpose

This PR fixes a critical bug where `fused_add_rms_norm` and `fused_add_rms_norm_static_fp8_quant` kernels threw `cudaErrorSymbolNotFound` (CUDA Error 13) on older architectures like SM 7.5 (Turing) when using `bfloat16`. 

**Root Cause:**
The bug was caused by a compiler mismatch between the Host and Device compiler passes in `nvcc`. The previous kernel signatures used `std::enable_if_t` (SFINAE) predicated on `_typeConvert<scalar_t>::exists`. Because native `bfloat16` is only supported on SM 8.0+, the SFINAE condition evaluated differently on the host vs. the device for SM 7.5. This caused the compiler to generate different mangled symbol names for the host-side stub vs the device-side cubin. Furthermore, attempting to parse the discarded optimized execution branch on SM 7.5 caused a hard compilation error inside `_f16Vec`, which forced `nvcc` to silently drop the SM 7.5 kernel entirely.

**Fix:**
1. Unified the kernel template signatures by removing SFINAE and using `__global__ void` to guarantee identical symbol mangling across architectures.
2. Moved the conditional execution into the kernel body using `if constexpr`.
3. Added dummy types to the base `_typeConvert` template in `type_convert.cuh` to satisfy `nvcc`'s strict parsing of discarded `if constexpr` branches on SM 7.5, preventing the compiler from silently dropping the kernel.

**AI Assistance Attribution:**
Per the project's contributing guidelines in `AGENTS.md`, AI assistance was used during the debugging process to diagnose the NVCC SFINAE mangling bug and to structure the `if constexpr` fallback logic to prevent hard parsing errors on older SM architectures. The submitting human reviewed all changed lines and ran the relevant tests end-to-end to verify the fix.

Fixes #<YOUR_ISSUE_NUMBER_HERE> 

## Test Plan

Ran the complete IR layernorm test suite on a Tesla T4 (SM 7.5) to ensure all parameterizations (including `bfloat16` / `dtype1`) compile and execute successfully.

```bash
pytest tests/kernels/ir/test_layernorm.py
```

## Test Result

**Before:**
The `bfloat16` parameterized tests consistently threw fatal symbol lookup errors when attempting to launch the kernel on Turing hardware:
```text
RuntimeError: CUDA error: symbol not found
CUDA kernel errors might be asynchronously reported at some other API call...
```

**After:**
All tests pass cleanly with zero failures.
```text
========== 1442 passed, 184 skipped, 16 warnings in 848.15s (0:14:08) ==========
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>