### PR TITLE
[Model Runner][Multimodal] Add exact-budget encoder CUDA graphs for Cosmos3-Edge

### DIFF
--- a/docs/design/cuda_graphs_multimodal.md
+++ b/docs/design/cuda_graphs_multimodal.md
@@ -21,6 +21,7 @@ For two-tower vision encoders (e.g., DeepSeek-OCR's SAM + CLIP with dynamic tili
 
 | Architecture | Models | CG for Image | CG for Video | Multi-Path Graph |
 | ------------ | ------ | ------------ | ------------ | --------------- |
+| `Cosmos3EdgeForConditionalGeneration` | `Cosmos3-Edge` | ✅︎ | ❌︎ | ❌︎ |
 | `DeepseekOCRForCausalLM` | `DeepSeek-OCR` | ✅︎ | ❌︎ | ✅︎ |
 | `Ernie4_5_VLMoeForConditionalGeneration` | `ERNIE-4.5-VL` | ✅︎ | ❌︎ | ❌︎ |
 | `Gemma3ForConditionalGeneration` | `Gemma3` | ✅︎ | ❌︎ | ❌︎ |
@@ -42,6 +43,7 @@ For two-tower vision encoders (e.g., DeepSeek-OCR's SAM + CLIP with dynamic tili
 
 | Architecture | NV Blackwell | NV Ampere | AMD MI300X | AMD MI350X / MI355X |
 | ------------ | ---------------- | ------------- | -------------- | --------------------- |
+| `Cosmos3EdgeForConditionalGeneration` | ✅︎ | ❔ | ❔ | ❔ |
 | `DeepseekOCRForCausalLM` | ✅︎ | ✅︎ | ❔ | ✅︎ |
 | `Ernie4_5_VLMoeForConditionalGeneration` | ✅︎ | ✅︎ | ❔ | ✅︎ |
 | `Gemma3ForConditionalGeneration` | ✅︎ | ✅︎ | ❔ | ✅︎ |
@@ -168,6 +170,15 @@ Models opt-in to encoder CUDA Graphs by implementing the [SupportsEncoderCudaGra
 
 !!! note
     The `SupportsEncoderCudaGraph` protocol is designed to be model-agnostic. New vision encoder models can opt-in by implementing the protocol methods without modifying the manager.
+
+    A path can set `require_exact_token_budget_match=True` when padding changes
+    its numerical behavior or erases the graph replay benefit. Inputs between
+    captured budgets then use the eager fallback. Cosmos3-Edge uses this policy
+    and defaults to one 64-token image per replay; fixed-resolution workloads
+    can add their exact merged-token counts through
+    `encoder_cudagraph_token_budgets`. Cosmos3-Edge supports at most one image
+    per replay, so leave `encoder_cudagraph_max_vision_items_per_batch` at its
+    auto-inferred value or set it to `1`.
 
 ## Configuration
 

--- a/tests/models/multimodal/generation/test_vit_cudagraph.py
+++ b/tests/models/multimodal/generation/test_vit_cudagraph.py
@@ -88,7 +88,54 @@ def minicpmv_chat_template(content: str) -> str:
     return f"<|im_start|>user\n{content}<|im_end|>\n<|im_start|>assistant\n"
 
 
+def cosmos3_edge_chat_template(content: str) -> str:
+    return f"<|im_start|>user\n{content}<|im_end|>\n<|im_start|>assistant\n<think>\n"
+
+
+def cosmos3_edge_dummy_hf_overrides(hf_config):
+    hf_config = dummy_hf_overrides(
+        hf_config,
+        model_arch="Cosmos3EdgeForConditionalGeneration",
+    )
+    if text_config := getattr(hf_config, "text_config", None):
+        text_config.update(
+            {
+                "num_hidden_layers": 2,
+                "hybrid_override_pattern": "*-",
+            }
+        )
+    return hf_config
+
+
 MODEL_CONFIGS: dict[str, VitCudagraphTestConfig] = {
+    "cosmos3_edge": VitCudagraphTestConfig(
+        model="nvidia/Cosmos3-Edge",
+        image_prompt=cosmos3_edge_chat_template(
+            "<|vision_start|><|image_pad|><|vision_end|>\nWhat is in this image?"
+        ),
+        video_prompt=cosmos3_edge_chat_template(
+            "<|vision_start|><|video_pad|><|vision_end|>\n"
+            "Describe this video in one sentence."
+        ),
+        needs_video_metadata=True,
+        compilation_config_overrides={
+            # The two fixtures produce 1,107 and 2,035 merged output tokens.
+            # Cosmos requires exact graph-budget matches and one item/replay.
+            "encoder_cudagraph_token_budgets": [1107, 2035],
+            "encoder_cudagraph_max_vision_items_per_batch": 1,
+        },
+        vllm_runner_kwargs={
+            "load_format": "dummy",
+            "hf_overrides": cosmos3_edge_dummy_hf_overrides,
+        },
+        marks=[
+            pytest.mark.core_model,
+            pytest.mark.skipif(
+                not current_platform.is_cuda(),
+                reason="Cosmos3-Edge encoder CUDA graphs are only validated on CUDA",
+            ),
+        ],
+    ),
     "gemma3": VitCudagraphTestConfig(
         model="google/gemma-3-4b-it",
         modalities=["image"],
@@ -442,6 +489,13 @@ def test_vit_cudagraph_image(model_id, vllm_runner, image_assets):
 
         # Ensure the output is a string
         assert isinstance(output_text, str)
+
+        if model_id == "cosmos3_edge":
+            runner = vllm_model.llm.llm_engine.model_executor.driver_worker.model_runner
+            manager = runner.encoder_cudagraph_manager
+            assert manager is not None
+            assert manager.graph_hits == 2
+            assert manager.graph_misses == 0
 
 
 @pytest.mark.parametrize("model_id", params_with_marks(MODEL_CONFIGS))

--- a/tests/models/multimodal/generation/test_vit_cudagraph.py
+++ b/tests/models/multimodal/generation/test_vit_cudagraph.py
@@ -107,6 +107,16 @@ def cosmos3_edge_dummy_hf_overrides(hf_config):
     return hf_config
 
 
+def _get_encoder_cudagraph_hit_miss_counts(worker):
+    model_runner = worker.model_runner
+    if hasattr(model_runner, "model_state"):
+        manager = model_runner.model_state.encoder_runner.cudagraph_manager
+    else:
+        manager = model_runner.encoder_cudagraph_manager
+    assert manager is not None
+    return manager.graph_hits, manager.graph_misses
+
+
 MODEL_CONFIGS: dict[str, VitCudagraphTestConfig] = {
     "cosmos3_edge": VitCudagraphTestConfig(
         model="nvidia/Cosmos3-Edge",
@@ -449,7 +459,7 @@ def get_compilation_config(config: VitCudagraphTestConfig):
 @pytest.mark.skipif(
     not current_platform.is_cuda_alike(), reason="Skip if not cuda or rocm"
 )
-def test_vit_cudagraph_image(model_id, vllm_runner, image_assets):
+def test_vit_cudagraph_image(model_id, vllm_runner, image_assets, monkeypatch):
     config = MODEL_CONFIGS[model_id]
 
     if config.skip:
@@ -465,6 +475,11 @@ def test_vit_cudagraph_image(model_id, vllm_runner, image_assets):
         }
     )
     images = [[asset.pil_image] for asset in image_assets]
+
+    if model_id == "cosmos3_edge":
+        # The callable used to read worker-local graph counters below must cross
+        # the EngineCore process boundary under default V1 multiprocessing.
+        monkeypatch.setenv("VLLM_ALLOW_INSECURE_SERIALIZATION", "1")
 
     with vllm_runner(
         config.model,
@@ -491,11 +506,10 @@ def test_vit_cudagraph_image(model_id, vllm_runner, image_assets):
         assert isinstance(output_text, str)
 
         if model_id == "cosmos3_edge":
-            runner = vllm_model.llm.llm_engine.model_executor.driver_worker.model_runner
-            manager = runner.encoder_cudagraph_manager
-            assert manager is not None
-            assert manager.graph_hits == 2
-            assert manager.graph_misses == 0
+            hit_miss_counts = vllm_model.collective_rpc(
+                _get_encoder_cudagraph_hit_miss_counts
+            )
+            assert hit_miss_counts == [(2, 0)]
 
 
 @pytest.mark.parametrize("model_id", params_with_marks(MODEL_CONFIGS))

--- a/tests/models/multimodal/test_cosmos3_edge.py
+++ b/tests/models/multimodal/test_cosmos3_edge.py
@@ -1,0 +1,76 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from vllm.model_executor.models.cosmos3_edge import (
+    Cosmos3EdgeForConditionalGeneration,
+    _build_merge_gather_idx,
+    patch_merging_by_param,
+)
+
+
+def test_cosmos3_edge_merge_gather_idx_matches_eager_layout():
+    grids = [[1, 4, 6], [1, 6, 4], [2, 4, 4]]
+    grid_thw = torch.tensor(grids, dtype=torch.int64)
+    hidden_size = 3
+    num_patches = sum(t * h * w for t, h, w in grids)
+    image_embeds = torch.arange(num_patches * hidden_size).view(
+        num_patches, hidden_size
+    )
+
+    expected = patch_merging_by_param(image_embeds, grid_thw, merge_size=2)
+    gather_idx = _build_merge_gather_idx(
+        grids, merge_size=2, device=torch.device("cpu")
+    )
+    actual = image_embeds.index_select(0, gather_idx).view(-1, 4 * hidden_size)
+
+    assert torch.equal(actual, expected)
+
+
+def _make_encoder_cudagraph_config_model(
+    max_items: int,
+    *,
+    enable_mm_embeds: bool = False,
+):
+    model = object.__new__(Cosmos3EdgeForConditionalGeneration)
+    model.multimodal_config = SimpleNamespace(
+        enable_mm_embeds=enable_mm_embeds,
+        get_limit_per_prompt=lambda modality: 1 if modality == "image" else 0,
+    )
+    model.vllm_config = SimpleNamespace(
+        compilation_config=SimpleNamespace(
+            encoder_cudagraph_max_vision_items_per_batch=max_items
+        )
+    )
+    model.visual = SimpleNamespace(out_hidden_size=2048)
+    return model
+
+
+def test_cosmos3_edge_encoder_cudagraph_uses_exact_single_image_budgets():
+    model = _make_encoder_cudagraph_config_model(max_items=0)
+
+    config = model.get_encoder_cudagraph_config()
+
+    assert model.get_encoder_cudagraph_budget_range(model.vllm_config) == (64, 64)
+    assert config.modalities == ["image"]
+    assert config.paths["default"].require_exact_token_budget_match
+
+
+def test_cosmos3_edge_encoder_cudagraph_rejects_multiple_images_per_replay():
+    model = _make_encoder_cudagraph_config_model(max_items=2)
+
+    with pytest.raises(ValueError, match="at most one image"):
+        model.get_encoder_cudagraph_config()
+
+
+def test_cosmos3_edge_encoder_cudagraph_disables_precomputed_embeddings():
+    model = _make_encoder_cudagraph_config_model(
+        max_items=0,
+        enable_mm_embeds=True,
+    )
+
+    assert model.get_encoder_cudagraph_config().modalities == []

--- a/tests/v1/cudagraph/test_encoder_cudagraph.py
+++ b/tests/v1/cudagraph/test_encoder_cudagraph.py
@@ -22,10 +22,12 @@ from vllm.model_executor.models.interfaces import SupportsEncoderCudaGraph
 from vllm.platforms import current_platform
 from vllm.v1.worker.encoder_cudagraph import (
     EncoderCudaGraphManager,
+    create_encoder_cudagraph_manager,
 )
 from vllm.v1.worker.encoder_cudagraph_defs import (
     EncoderCudaGraphCaptureInputs,
     EncoderCudaGraphConfig,
+    EncoderCudaGraphPathConfig,
     EncoderCudaGraphReplayBuffers,
     EncoderItemSpec,
 )
@@ -97,6 +99,27 @@ class _MockModel(SupportsEncoderCudaGraph):
 
     def get_encoder_cudagraph_budget_range(self, vllm_config):
         return (self._min_budget, self._max_budget)
+
+
+class _DisabledMockModel(_MockModel):
+    def get_encoder_cudagraph_config(self) -> EncoderCudaGraphConfig:
+        return EncoderCudaGraphConfig(
+            modalities=[],
+            buffer_keys=[],
+            out_hidden_size=32,
+        )
+
+
+def test_empty_modalities_disable_encoder_cudagraph_manager():
+    assert (
+        create_encoder_cudagraph_manager(
+            vllm_config=_MockVllmConfig(),
+            device=torch.device("cpu"),
+            dtype=torch.float32,
+            model=_DisabledMockModel(),
+        )
+        is None
+    )
 
 
 def _make_manager_with_budgets(budgets: list[int]) -> EncoderCudaGraphManager:
@@ -193,6 +216,25 @@ class TestFindBudgetGraph:
         assert mgr.token_budgets == [2048, 4096, 8192]
         # Budget selection still works correctly after sorting
         assert mgr._find_smallest_fitting_budget_given_tokens(3000) == 4096
+
+    @pytest.mark.parametrize(
+        "total_tokens,expected",
+        [
+            (2048, 2048),
+            (2049, None),
+            (4096, 4096),
+            (8191, None),
+            (8192, 8192),
+            (9000, None),
+        ],
+    )
+    def test_require_exact_match(self, total_tokens, expected):
+        mgr = _make_manager_with_budgets([2048, 4096, 8192])
+        result = mgr._find_smallest_fitting_budget_given_tokens(
+            total_tokens,
+            require_exact_match=True,
+        )
+        assert result == expected
 
     def test_num_graphs_to_capture_tracks_budgets(self):
         mgr = _make_manager_with_budgets([8192, 2048, 4096])
@@ -544,6 +586,20 @@ class TestEncoderCudaGraphCaptureReplay:
         assert len(result) == 1
         # Eager output: SimpleMockViTModel produces n_out = 81 tokens
         assert result[0].shape == (81, _HIDDEN)
+        assert self.mgr.graph_misses == 1
+
+    def test_eager_fallback_when_exact_budget_is_required(self):
+        self.mgr.config.paths["default"] = EncoderCudaGraphPathConfig(
+            require_exact_token_budget_match=True
+        )
+        # [1,6,6] produces 9 tokens, which fits the 16-token graph but does
+        # not exactly match a captured budget.
+        mm_kwargs = _make_mm_kwargs([[1, 6, 6]], self.device, self.dtype)
+        result = self.mgr.execute(mm_kwargs)
+
+        assert result is not None
+        assert result[0].shape == (9, _HIDDEN)
+        assert self.mgr.graph_hits == 0
         assert self.mgr.graph_misses == 1
 
     # --- counters ---

--- a/vllm/model_executor/models/cosmos3_edge.py
+++ b/vllm/model_executor/models/cosmos3_edge.py
@@ -1,13 +1,15 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-from collections.abc import Iterable
+from collections.abc import Hashable, Iterable
+from typing import Any
 
 import torch
 import torch.nn as nn
 from transformers import ProcessorMixin
 
 from vllm.config import VllmConfig
+from vllm.forward_context import set_forward_context
 from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.model_executor.layers.linear import (
     ColumnParallelLinear,
@@ -25,6 +27,7 @@ from vllm.utils.torch_utils import async_tensor_h2d
 
 from .interfaces import (
     MultiModalEmbeddings,
+    SupportsEncoderCudaGraph,
     SupportsMRoPE,
     SupportsMultiModal,
     SupportsPP,
@@ -58,6 +61,45 @@ from .vision import (
     is_vit_use_data_parallel,
     run_dp_sharded_mrope_vision_model,
 )
+
+
+def _pad_cumulative_seqlens_buffer(
+    dst: torch.Tensor,
+    src: torch.Tensor,
+) -> None:
+    n = src.shape[0]
+    dst.zero_()
+    dst[:n].copy_(src)
+    if n < dst.shape[0]:
+        dst[n:] = src[-1]
+
+
+def _build_merge_gather_idx(
+    grid_thw: list[list[int]],
+    merge_size: int,
+    device: torch.device,
+) -> torch.Tensor:
+    delta = torch.arange(merge_size, dtype=torch.int64)
+    dh, dw = torch.meshgrid(delta, delta, indexing="ij")
+    dh = dh.reshape(-1)
+    dw = dw.reshape(-1)
+
+    gather_idx_parts: list[torch.Tensor] = []
+    offset = 0
+    for t, h, w in grid_thw:
+        rows = torch.arange(h // merge_size, dtype=torch.int64)
+        cols = torch.arange(w // merge_size, dtype=torch.int64)
+        rr, cc = torch.meshgrid(rows, cols, indexing="ij")
+        frame_idx = (rr.reshape(-1, 1) * merge_size + dh) * w + (
+            cc.reshape(-1, 1) * merge_size + dw
+        )
+        for frame in range(t):
+            gather_idx_parts.append(frame_idx.reshape(-1) + offset + frame * h * w)
+        offset += t * h * w
+
+    if not gather_idx_parts:
+        return torch.empty(0, dtype=torch.int64, device=device)
+    return torch.cat(gather_idx_parts).to(device=device)
 
 
 class Cosmos3EdgeVisionEncoder(Siglip2VisionTransformer):
@@ -487,6 +529,7 @@ def _cosmos3_edge_diffusers_prefix_map() -> dict[str, str]:
 class Cosmos3EdgeForConditionalGeneration(
     nn.Module,
     SupportsMultiModal,
+    SupportsEncoderCudaGraph,
     SupportsPP,
     SupportsMRoPE,
 ):
@@ -556,6 +599,7 @@ class Cosmos3EdgeForConditionalGeneration(
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = "model"):
         super().__init__()
 
+        self.vllm_config = vllm_config
         config = vllm_config.model_config.hf_config
         quant_config = vllm_config.quant_config
         multimodal_config = vllm_config.model_config.multimodal_config
@@ -714,6 +758,291 @@ class Cosmos3EdgeForConditionalGeneration(
                 multimodal_embeddings += tuple(video_embeddings)
 
         return multimodal_embeddings
+
+    # -- SupportsEncoderCudaGraph protocol methods --
+
+    def get_encoder_cudagraph_config(self):
+        from vllm.v1.worker.encoder_cudagraph_defs import (
+            EncoderCudaGraphConfig,
+            EncoderCudaGraphPathConfig,
+        )
+
+        # EncoderCudaGraphManager currently dispatches by modality, not by the
+        # raw-pixels vs precomputed-embeddings representation. Keep the eager
+        # path when image_embeds may be supplied because the graph inputs below
+        # require pixel_values.
+        use_raw_images = (
+            not self.multimodal_config.enable_mm_embeds
+            and self.multimodal_config.get_limit_per_prompt("image") > 0
+        )
+        modalities = ["image"] if use_raw_images else []
+
+        max_items = (
+            self.vllm_config.compilation_config
+        ).encoder_cudagraph_max_vision_items_per_batch
+        if modalities and max_items > 1:
+            raise ValueError(
+                "Cosmos3-Edge encoder CUDA graphs support at most one image "
+                "per replay because its attention shape depends on each "
+                "image's grid. Set "
+                "encoder_cudagraph_max_vision_items_per_batch to 0 or 1."
+            )
+
+        return EncoderCudaGraphConfig(
+            modalities=modalities,
+            buffer_keys=[
+                "pixel_values",
+                "pos_embeds",
+                "cu_seqlens",
+                "max_seqlen",
+                "merge_gather_idx",
+            ],
+            out_hidden_size=self.visual.out_hidden_size,
+            padding_logics={"cu_seqlens": _pad_cumulative_seqlens_buffer},
+            paths={
+                "default": EncoderCudaGraphPathConfig(
+                    require_exact_token_budget_match=True
+                )
+            },
+        )
+
+    def get_max_frames_per_video(self) -> int:
+        return 0
+
+    def get_encoder_cudagraph_budget_range(
+        self,
+        vllm_config: VllmConfig,
+    ) -> tuple[int, int]:
+        # Cosmos has highly variable image shapes, and padding its 27-layer
+        # encoder to the next power-of-two can cost more than graph replay
+        # saves. Default to the minimum exact image size and one item per
+        # replay. Fixed-resolution workloads can provide additional exact
+        # budgets explicitly through CompilationConfig.
+        return 64, 64
+
+    @staticmethod
+    def _get_grid_thw_list(mm_kwargs: dict[str, Any]) -> list[list[int]]:
+        grid_thw = mm_kwargs["image_grid_thw"]
+        if isinstance(grid_thw, torch.Tensor):
+            return [[int(x) for x in row] for row in grid_thw.tolist()]
+        return [[int(x) for x in row] for row in grid_thw]
+
+    def get_encoder_cudagraph_item_specs(self, mm_kwargs: dict[str, Any]):
+        from vllm.v1.worker.encoder_cudagraph_defs import EncoderItemSpec
+
+        merge_size = self.visual.spatial_merge_size
+        specs = []
+        for t, h, w in self._get_grid_thw_list(mm_kwargs):
+            if h % merge_size != 0 or w % merge_size != 0:
+                raise ValueError(
+                    "Grid height and width must be divisible by merge_size: "
+                    f"got grid={(t, h, w)} and merge_size={merge_size}."
+                )
+            specs.append(
+                EncoderItemSpec(
+                    input_size=t * h * w,
+                    output_tokens=t * (h // merge_size) * (w // merge_size),
+                )
+            )
+        return specs
+
+    def select_encoder_cudagraph_items(
+        self,
+        mm_kwargs: dict[str, Any],
+        indices: list[int],
+    ) -> dict[str, Any]:
+        pixel_values = mm_kwargs["pixel_values"]
+        grid_thw = self._get_grid_thw_list(mm_kwargs)
+
+        if not indices:
+            return {
+                "pixel_values": pixel_values[:0],
+                "image_grid_thw": [],
+            }
+
+        patch_counts = [t * h * w for t, h, w in grid_thw]
+        offsets = [0]
+        for count in patch_counts:
+            offsets.append(offsets[-1] + count)
+
+        return {
+            "pixel_values": torch.cat(
+                [pixel_values[offsets[i] : offsets[i + 1]] for i in indices]
+            ),
+            "image_grid_thw": [grid_thw[i] for i in indices],
+        }
+
+    @staticmethod
+    def _get_frame_shapes(grid_thw: list[list[int]]) -> list[list[int]]:
+        return [[h, w] for t, h, w in grid_thw for _ in range(t)]
+
+    def _get_pos_embeds(
+        self,
+        frame_shapes: list[list[int]],
+    ) -> torch.Tensor:
+        embeddings = self.visual.encoder.embeddings
+        spatial_shapes = torch.tensor(frame_shapes, dtype=torch.int64)
+        lengths = [h * w for h, w in frame_shapes]
+        positional_embeddings = embeddings.position_embedding.weight.reshape(
+            embeddings.position_embedding_size,
+            embeddings.position_embedding_size,
+            -1,
+        )
+        return embeddings.resize_positional_embeddings_packed(
+            positional_embeddings,
+            spatial_shapes,
+            lengths_list=lengths,
+        )
+
+    @staticmethod
+    def _get_cu_seqlens(
+        frame_shapes: list[list[int]],
+        device: torch.device,
+    ) -> torch.Tensor:
+        lengths = torch.tensor(
+            [h * w for h, w in frame_shapes],
+            dtype=torch.int32,
+            device=device,
+        )
+        cu_seqlens = torch.zeros(
+            lengths.shape[0] + 1,
+            dtype=torch.int32,
+            device=device,
+        )
+        if lengths.numel() > 0:
+            cu_seqlens[1:] = lengths.cumsum(dim=0)
+        return cu_seqlens
+
+    @staticmethod
+    def _get_max_seqlen(frame_shapes: list[list[int]]) -> torch.Tensor:
+        max_seqlen = max((h * w for h, w in frame_shapes), default=0)
+        return torch.tensor(max_seqlen, dtype=torch.int32)
+
+    def _get_merge_gather_idx(
+        self,
+        grid_thw: list[list[int]],
+        device: torch.device,
+    ) -> torch.Tensor:
+        return _build_merge_gather_idx(
+            grid_thw,
+            self.visual.spatial_merge_size,
+            device,
+        )
+
+    def _prepare_encoder_cudagraph_values(
+        self,
+        pixel_values: torch.Tensor,
+        grid_thw: list[list[int]],
+    ) -> dict[str, torch.Tensor]:
+        expected_patches = sum(t * h * w for t, h, w in grid_thw)
+        actual_patches = pixel_values.shape[0]
+        if actual_patches < expected_patches:
+            raise ValueError(
+                "pixel_values contains fewer patches than image_grid_thw describes."
+            )
+        if actual_patches > expected_patches:
+            raise ValueError(
+                "pixel_values contains more patches than image_grid_thw describes: "
+                f"got {actual_patches}, expected {expected_patches}."
+            )
+        frame_shapes = self._get_frame_shapes(grid_thw)
+        return {
+            "pixel_values": pixel_values,
+            "pos_embeds": self._get_pos_embeds(frame_shapes),
+            "cu_seqlens": self._get_cu_seqlens(frame_shapes, pixel_values.device),
+            "max_seqlen": self._get_max_seqlen(frame_shapes),
+            "merge_gather_idx": self._get_merge_gather_idx(
+                grid_thw, pixel_values.device
+            ),
+        }
+
+    def prepare_encoder_cudagraph_capture_inputs(
+        self,
+        token_budget: int,
+        max_batch_size: int,
+        max_frames_per_batch: int,
+        device: torch.device,
+        dtype: torch.dtype,
+        path: str = "default",
+        axis_keys: tuple[Hashable, ...] | None = None,
+    ):
+        from vllm.v1.worker.encoder_cudagraph_defs import (
+            EncoderCudaGraphCaptureInputs,
+        )
+
+        merge_size = self.visual.spatial_merge_size
+        per_item_output = (token_budget + max_batch_size - 1) // max_batch_size
+        grid_thw = [
+            [1, merge_size, per_item_output * merge_size] for _ in range(max_batch_size)
+        ]
+        total_patches = sum(t * h * w for t, h, w in grid_thw)
+        patch_dim = self.visual.encoder.embeddings.patch_embedding.weight.shape[1]
+        pixel_values = torch.randn(
+            total_patches,
+            patch_dim,
+            device=device,
+            dtype=dtype,
+        )
+        values = self._prepare_encoder_cudagraph_values(pixel_values, grid_thw)
+        values["max_seqlen"] = torch.tensor(
+            token_budget * merge_size**2,
+            dtype=torch.int32,
+        )
+        return EncoderCudaGraphCaptureInputs(values=values)
+
+    def prepare_encoder_cudagraph_replay_buffers(
+        self,
+        mm_kwargs: dict[str, Any],
+        max_batch_size: int,
+        max_frames_per_batch: int,
+        path: str = "default",
+    ):
+        from vllm.v1.worker.encoder_cudagraph_defs import (
+            EncoderCudaGraphReplayBuffers,
+        )
+
+        values = self._prepare_encoder_cudagraph_values(
+            mm_kwargs["pixel_values"],
+            self._get_grid_thw_list(mm_kwargs),
+        )
+        return EncoderCudaGraphReplayBuffers(values=values)
+
+    def encoder_cudagraph_forward(
+        self,
+        values: dict[str, torch.Tensor],
+        path: str = "default",
+    ) -> torch.Tensor:
+        encoder = self.visual.encoder
+        pixel_values = values["pixel_values"].to(dtype=encoder.dtype)
+        patch_embeds = encoder.embeddings.patch_embedding(pixel_values)
+        hidden_states = (patch_embeds + values["pos_embeds"]).unsqueeze(0)
+
+        with set_forward_context(None, self.vllm_config):
+            image_embeds = encoder.encoder(
+                inputs_embeds=hidden_states,
+                cu_seqlens=values["cu_seqlens"],
+                max_seqlen=values["max_seqlen"],
+            )
+        if encoder.post_layernorm is not None:
+            image_embeds = encoder.post_layernorm(image_embeds)
+
+        gathered = image_embeds[0].index_select(0, values["merge_gather_idx"])
+        gathered = gathered.view(
+            -1,
+            self.visual.spatial_merge_size**2,
+            self.visual.projector.input_hidden_size,
+        )
+        return self.visual.projector(gathered)
+
+    def encoder_eager_forward(
+        self,
+        mm_kwargs: dict[str, Any],
+        path: str = "default",
+    ) -> torch.Tensor:
+        return self.visual(
+            mm_kwargs["pixel_values"],
+            self._get_grid_thw_list(mm_kwargs),
+        )
 
     def forward(
         self,

--- a/vllm/v1/worker/encoder_cudagraph.py
+++ b/vllm/v1/worker/encoder_cudagraph.py
@@ -19,6 +19,7 @@ from vllm.distributed import (
 from vllm.logger import init_logger
 from vllm.model_executor.models.interfaces import (
     SupportsEncoderCudaGraph,
+    supports_encoder_cudagraph,
 )
 from vllm.model_executor.models.utils import scatter_output_slices
 from vllm.model_executor.models.vision import get_load_balance_assignment
@@ -65,6 +66,29 @@ class BudgetGraphMetadata:
     axis_keys: CaptureAxisKeys = ()
 
 
+def create_encoder_cudagraph_manager(
+    vllm_config: VllmConfig,
+    device: torch.device,
+    dtype: torch.dtype,
+    model: object,
+) -> "EncoderCudaGraphManager | None":
+    """Create a manager when the model enables at least one graph modality."""
+    if not supports_encoder_cudagraph(model):
+        return None
+
+    config = model.get_encoder_cudagraph_config()
+    if not config.modalities:
+        return None
+
+    return EncoderCudaGraphManager(
+        vllm_config=vllm_config,
+        device=device,
+        dtype=dtype,
+        model=model,
+        config=config,
+    )
+
+
 class EncoderCudaGraphManager:
     """Budget-based CUDA graph capture/replay for vision encoders."""
 
@@ -74,6 +98,7 @@ class EncoderCudaGraphManager:
         device: torch.device,
         dtype: torch.dtype,
         model: SupportsEncoderCudaGraph,
+        config: EncoderCudaGraphConfig | None = None,
     ):
         """Initialize CUDA graph manager with provided token budgets
         and max batch size."""
@@ -81,7 +106,7 @@ class EncoderCudaGraphManager:
         self.device = device
         self.dtype = dtype
         self.model = model
-        self.config: EncoderCudaGraphConfig = model.get_encoder_cudagraph_config()
+        self.config = config or model.get_encoder_cudagraph_config()
 
         comp_config = vllm_config.compilation_config
         user_budgets = comp_config.encoder_cudagraph_token_budgets
@@ -345,7 +370,11 @@ class EncoderCudaGraphManager:
         )
 
     def _find_smallest_fitting_budget_given_tokens(
-        self, total_tokens: int, budgets: list[int] | None = None
+        self,
+        total_tokens: int,
+        budgets: list[int] | None = None,
+        *,
+        require_exact_match: bool = False,
     ) -> int | None:
         """Find smallest budget >= total_tokens.
 
@@ -355,6 +384,8 @@ class EncoderCudaGraphManager:
         budgets = budgets if budgets is not None else self.token_budgets
         for budget in budgets:
             if budget >= total_tokens:
+                if require_exact_match and budget != total_tokens:
+                    return None
                 return budget
         return None
 
@@ -479,7 +510,11 @@ class EncoderCudaGraphManager:
                     0
                     if current_tokens[path] == 0
                     else self._find_smallest_fitting_budget_given_tokens(
-                        current_tokens[path], self.path_token_budgets[path]
+                        current_tokens[path],
+                        self.path_token_budgets[path],
+                        require_exact_match=self.config.paths[
+                            path
+                        ].require_exact_token_budget_match,
                     )
                 )
                 for path in paths

--- a/vllm/v1/worker/encoder_cudagraph_defs.py
+++ b/vllm/v1/worker/encoder_cudagraph_defs.py
@@ -55,6 +55,14 @@ class EncoderCudaGraphPathConfig:
     allow_zero_tokens: bool = False
     """Whether a batch may omit this path entirely."""
 
+    require_exact_token_budget_match: bool = False
+    """Only replay a graph when its token budget exactly matches the input.
+
+    This avoids token-count padding for encoders whose compute cost depends
+    strongly on the captured sequence length. Inputs between captured budgets
+    fall back to eager execution.
+    """
+
 
 @dataclass
 class EncoderCudaGraphConfig:

--- a/vllm/v1/worker/gpu/model_states/interface.py
+++ b/vllm/v1/worker/gpu/model_states/interface.py
@@ -1,22 +1,18 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 from abc import ABC, abstractmethod
-from typing import Any, ClassVar, cast
+from typing import Any, ClassVar
 
 import torch
 import torch.nn as nn
 
 from vllm.config import VllmConfig
 from vllm.config.compilation import CUDAGraphMode
-from vllm.model_executor.models.interfaces import (
-    SupportsEncoderCudaGraph,
-    supports_encoder_cudagraph,
-)
 from vllm.tasks import GenerationTask
 from vllm.v1.attention.backend import AttentionCGSupport
 from vllm.v1.core.sched.output import NewRequestData
 from vllm.v1.kv_cache_interface import KVCacheConfig
-from vllm.v1.worker.encoder_cudagraph import EncoderCudaGraphManager
+from vllm.v1.worker.encoder_cudagraph import create_encoder_cudagraph_manager
 from vllm.v1.worker.gpu.input_batch import InputBatch
 from vllm.v1.worker.gpu.mm.encoder_cache import EncoderCache
 from vllm.v1.worker.gpu.mm.encoder_runner import EncoderRunner
@@ -70,14 +66,13 @@ class ModelState(ABC):
             enable_encoder_cuda_graph = (
                 not self.model_config.enforce_eager
                 and vllm_config.compilation_config.cudagraph_mm_encoder
-                and supports_encoder_cudagraph(model)
             )
             cudagraph_manager = (
-                EncoderCudaGraphManager(
+                create_encoder_cudagraph_manager(
                     vllm_config=vllm_config,
                     device=device,
                     dtype=self.dtype,
-                    model=cast(SupportsEncoderCudaGraph, model),
+                    model=model,
                 )
                 if enable_encoder_cuda_graph
                 else None

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -6632,23 +6632,16 @@ class GPUModelRunner(
         # Use get_model() to unwrap CUDAGraphWrapper/UBatchWrapper, because
         # @runtime_checkable Protocol isinstance() checks do not work through
         # __getattr__ forwarding.
-        from vllm.model_executor.models.interfaces import (
-            SupportsEncoderCudaGraph,
-            supports_encoder_cudagraph,
-        )
         from vllm.v1.worker.encoder_cudagraph import (
-            EncoderCudaGraphManager,
+            create_encoder_cudagraph_manager,
         )
 
         raw_model = self.get_model()
-        if not supports_encoder_cudagraph(raw_model):
-            return None
-
-        return EncoderCudaGraphManager(
+        return create_encoder_cudagraph_manager(
             vllm_config=self.vllm_config,
             device=self.device,
             dtype=self.dtype,
-            model=cast(SupportsEncoderCudaGraph, raw_model),
+            model=raw_model,
         )
 
     @torch.inference_mode()


### PR DESCRIPTION
## Purpose

This PR adds image-encoder CUDA Graph support for the recently added
`nvidia/Cosmos3-Edge` model.

Cosmos3-Edge has a 27-layer SigLIP2 vision encoder. A 64-token image launches
281 CUDA kernels in eager mode on the RTX PRO 6000 setup below, making the
encoder strongly launch-bound. The graph path precomputes dynamic metadata
outside capture and records only the tensor-only vision forward:

- patch projection and packed positional embeddings;
- packed `cu_seqlens` and `max_seqlen`;
- the 27-layer SigLIP2 encoder;
- the patch-merge gather and Cosmos projector.

Cosmos image shapes are highly dynamic. Padding an input into the next larger
graph can be slower than eager and, depending on the platform and capture
shape, can also change BF16 values. This PR therefore adds an opt-in per-path
`require_exact_token_budget_match` policy to the generic encoder CUDA Graph
manager. Cosmos enables it, defaults to one 64-token image per replay, and
sends inputs between captured budgets through the existing eager fallback.
Fixed-resolution deployments can add their exact merged-token counts with
`encoder_cudagraph_token_budgets`.

The graph path is intentionally limited to raw-pixel images and one image per
replay. Video and precomputed image embeddings continue to use eager execution.

## Cross-platform validation

The H20 validation supplements the RTX PRO 6000 results; it does not replace
them. All comparisons are within one GPU and use identical inputs. The main
performance and eager-regression benchmarks use balanced process order. The
two platforms use the same model revision, BF16, FlashAttention 2, TP=1,
`max_model_len=4096`, disabled prefix/MM processor caches, and
`FULL_DECODE_ONLY` decoder graphs.

| Setup | RTX PRO 6000 Blackwell Server Edition | NVIDIA H20 |
| --- | --- | --- |
| Compute capability / visible SMs | SM120 / 188 | SM90 / 78 |
| Driver / PyTorch | 580.159.03 / 2.11.0+cu130 | 535.161.08 / 2.11.0+cu130 |
| PR source | clean final-head `a2f44889f` worktree | the four `a0ef3899` production files over the official `2e2ffd104` nightly wheel |
| True pre-patch source | clean `2e2ffd104` worktree | untouched official `2e2ffd104` nightly wheel |
| Model | `nvidia/Cosmos3-Edge` revision `9eff1178c4e6dcbed1e27c8113109a6cd6d3706e` | same |

`a2f44889f` differs from `a0ef3899` only in the integration-test harness; the
four production files used by the H20 run are identical. The RTX PRO 6000 runs
used clean Python source trees with an identical runtime-only prebuilt-extension
overlay for both arms. The H20 wheel overlay ran successfully for these
experiments, but its PyTorch version differs from the wheel's declared
dependency, so it is recorded as an experimental setup, not a general
compatibility claim. FlashInfer autotuning was disabled on both platforms.

### Exact-64 performance

Each process used 5 warmups and 30 measured requests with unique 256x256
images, one output token, and the palindrome schedule
`pre-patch -> patched eager -> graph -> graph -> patched eager -> pre-patch`.
Values are the midpoint of the two slot medians. The primary fast-path
comparison is graph versus patched eager; graph versus true pre-patch is also
shown separately.

| GPU | Pre-patch encoder | Patched eager | Encoder graph | Graph vs pre-patch | Graph vs patched eager |
| --- | ---: | ---: | ---: | ---: | ---: |
| RTX PRO 6000 | 5.697 ms | 5.841 ms | **2.952 ms** | **-48.19%, 1.930x** | **-49.47%, 1.979x** |
| H20 | 8.760 ms | 8.970 ms | **3.548 ms** | **-59.50%, 2.469x** | **-60.45%, 2.528x** |

| GPU | Pre-patch wall | Patched eager | Graph wall | Graph vs pre-patch | Graph vs patched eager |
| --- | ---: | ---: | ---: | ---: | ---: |
| RTX PRO 6000 | 19.180 ms | 19.569 ms | **16.670 ms** | **-13.08%, 1.151x** | **-14.81%, 1.174x** |
| H20 | 21.822 ms | 22.664 ms | **17.255 ms** | **-20.93%, 1.265x** | **-23.87%, 1.313x** |

Both graph slots recorded 35 hits and 0 misses on each GPU. On the RTX PRO
6000, 60/60 paired encoder samples and 59/60 wall samples improved; one paired
wall sample did not improve. On H20, all 60 paired encoder and wall samples
improved. In the earlier memory-profile runs, reported CUDA Graph memory
increased by about 0.03 GiB on the RTX PRO 6000 and 0.02 GiB on H20.

The relative gain was larger in the measured H20 environment. I do not infer a
cause from SM count: GPU architecture, host, driver, and installation method
also differ.

### Correctness and dispatch

All comparisons in this table are within the same GPU and use identical input
images for the three source arms.

| Validation | RTX PRO 6000 | H20 |
| --- | --- | --- |
| Natural greedy generation | pre-patch = patched eager = graph for **960/960** token positions and all decoded text | same: **960/960** token positions and all text |
| Output diversity | 149 distinct token IDs / 25 distinct sequences | 76 distinct token IDs / 26 distinct sequences |
| Encoder tensors | **31/31 bitwise exact** across all three arms | **31/31 bitwise exact** across all three arms |
| Exact `[64, 256]` dispatch, 5 measured requests/shape | 64: 5 hits; 100: 5 eager fallbacks; 256: 5 hits | same |
| Forced-padding control for 64/100/256 | 15/15 one-token outputs and encoder tensors exact | same |
| Exact replay 256 -> 64 -> 256 | 3 measured hits, all tensors/tokens exact; repeated 256-token output bitwise exact | same |
| `max_vision_items=2` guard | expected actionable `ValueError` | same |
| `enable_mm_embeds=True` guard | manager disabled (`modalities=[]`), eager request still generated 8 tokens | same |

The MM-embeds guard check verifies that enabling that configuration disables
the graph manager and preserves eager execution; it is not a claim that the
test payload itself was a precomputed embedding tensor.

### Why exact budget matching is conservative

The following controls deliberately disabled the exact-match policy and forced
smaller inputs into larger captured graphs. `Exact policy` is graph-enabled but
records misses and executes eager fallback. Times are measured-request medians.

| GPU | Actual -> capture | Eager encoder | Exact policy (hit/miss) | Forced padding (hit/miss) | Forced/eager | Wall ratio | One-token outputs changed | Encoder tensor vs eager |
| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |
| RTX PRO 6000 | 176 -> 256 | 5.740 ms | 5.947 ms (0/30) | 6.397 ms (30/0) | **1.115x** | 1.040x | **1/30** | **0/30 exact**, max abs 1.061 |
| H20 | 176 -> 256 | 8.960 ms | 8.932 ms (0/30) | 9.409 ms (30/0) | **1.050x** | 1.031x | **0/30** | **30/30 exact** |
| RTX PRO 6000 | 64 -> 4096 | 5.919 ms | 5.781 ms (0/15) | 51.933 ms (15/0) | **8.775x** | 3.297x | **2/15** | **0/15 exact**, max abs 0.461 |
| H20 | 64 -> 4096 | 8.839 ms | 8.667 ms (0/15) | 112.319 ms (15/0) | **12.708x** | 5.826x | **0/15** | **15/15 exact** |

An earlier exploratory RTX PRO 6000 image set changed 6/30 one-token outputs
for 176 -> 256; the matched diverse-image rerun above changed 1/30. H20 stayed
bitwise exact even under the 4096-token control, while the RTX PRO 6000 did
not. Thus numerical sensitivity is platform- and shape-dependent: zero-length
`cu_seqlens` padding prevents padded tokens from participating in varlen
attention, but it does not guarantee bitwise equivalence for every differently
shaped GEMM/MLP capture.

The exact policy is therefore a conservative cross-platform performance and
numerical-consistency choice. Padding is not claimed to be slower in every small
case; for example, the five-sample 100 -> 256 control had opposite directions
on the two GPUs. The policy avoids relying on that variability.

### Eager-path regression audit

An independent `pre-patch -> patched eager -> patched eager -> pre-patch`
schedule used 60 measured requests per slot. These median deltas are much
smaller than the graph benefit; no material eager-path regression was observed,
and the deltas were within slot drift and run-to-run noise.

| GPU | Pre-patch encoder | Patched encoder | Delta | Pre-patch wall | Patched wall | Delta |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| RTX PRO 6000 | 5.7503 ms | 5.7418 ms | -0.147% | 19.3401 ms | 19.3697 ms | +0.153% |
| H20 | 8.812 ms | 8.697 ms | -1.31% | 21.974 ms | 21.785 ms | -0.86% |

## Correctness and testing

- `tests/v1/cudagraph/test_encoder_cudagraph.py`: **58 passed** on both
  platforms.
- `tests/models/multimodal/test_cosmos3_edge.py`: **4 passed** on both
  platforms.
- H20 in-process Cosmos image/video encoder-CG integration: **2 passed**.
- The H20 run exposed that the new graph-hit assertion accessed an in-process
  private object and failed under default V1 multiprocessing. The follow-up
  commit `a2f44889f` reads worker-local counters through `collective_rpc`.
  On the final RTX PRO 6000 head, the default-multiprocessing image/video run
  passed both cases.
- Final-head RTX PRO 6000 tests: 58 passed, 4 passed, and the default
  multiprocessing image/video integration 2 passed.
- All relevant pre-commit hooks passed locally, including ruff, mypy, typos,
  markdownlint, SPDX, forbidden imports, and configuration validation.

Final-head local commands from the source-overlay validation environment:

```bash
env PYTHONPATH=/root/r22/runtime_overlay:/root/r22/vllm-main \
  /root/vllm/.venv/bin/python -m pytest -q \
  tests/v1/cudagraph/test_encoder_cudagraph.py
env PYTHONPATH=/root/r22/runtime_overlay:/root/r22/vllm-main \
  /root/vllm/.venv/bin/python -m pytest -q \
  tests/models/multimodal/test_cosmos3_edge.py
env PYTHONPATH=/root/r22/runtime_overlay:/root/r22/vllm-main \
  /root/vllm/.venv/bin/python -m pytest -q \
  tests/models/multimodal/generation/test_vit_cudagraph.py -k cosmos3_edge
/root/vllm/.venv/bin/pre-commit run --files \
  $(git diff --name-only 2e2ffd104..HEAD)
```

## Duplicate-work check

I searched open and recently merged PRs for Cosmos3-Edge encoder CUDA Graphs,
exact encoder token budgets, and padding-sensitive graph fallback, and found no
duplicate implementation.

Related work is complementary:

- #42796 reduces excessive Qwen2.5-VL metadata padding;
- #43403 falls back when inputs exceed capture capacity;
- #42785 adds a secondary capture axis for inputs with the same token count but
  different shapes;
- #49852 adds MRV2 encoder CUDA Graph support;
- #51221 and #51949 touch Cosmos video pruning and LoRA, respectively.

The exact-token policy here handles inputs whose token count falls between
captured budgets and is orthogonal to #42785's secondary shape axis.

## AI assistance

OpenAI Codex assisted with code analysis, implementation, validation and
benchmark scripting, duplicate-work review, and drafting this PR description.
