### PR TITLE
[Bugfix][MM][CG] Skip encoder CUDA graphs on non-first PP ranks

### DIFF
--- a/.buildkite/test_areas/distributed.yaml
+++ b/.buildkite/test_areas/distributed.yaml
@@ -280,6 +280,7 @@ steps:
   - tests/distributed/
   commands:
   - pytest -v -s distributed/test_pp_cudagraph.py
+  - pytest -v -s distributed/test_pp_encoder_cudagraph.py
   - pytest -v -s distributed/test_pipeline_parallel.py
 
 - label: RayExecutorV2 (4 GPUs)

--- a/tests/distributed/test_pp_encoder_cudagraph.py
+++ b/tests/distributed/test_pp_encoder_cudagraph.py
@@ -1,0 +1,85 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import pytest
+from transformers import PretrainedConfig
+
+from vllm import LLM, SamplingParams
+from vllm.assets.image import ImageAsset
+
+from ..models.utils import dummy_hf_overrides
+from ..utils import multi_gpu_test
+
+MODEL = "Qwen/Qwen2-VL-2B-Instruct"
+
+PROMPT = (
+    "<|im_start|>user\n<|vision_start|><|image_pad|><|vision_end|>"
+    "What is in the image?<|im_end|>\n<|im_start|>assistant\n"
+)
+
+
+def pp_dummy_hf_overrides(hf_config: PretrainedConfig) -> PretrainedConfig:
+    """Shrink the model but keep one text layer per pipeline stage."""
+    hf_config = dummy_hf_overrides(
+        hf_config, model_arch="Qwen2VLForConditionalGeneration"
+    )
+    hf_config.get_text_config().update({"num_hidden_layers": 2})
+    return hf_config
+
+
+def probe_encoder_cudagraph(worker) -> dict[str, int | bool]:
+    from vllm.distributed.parallel_state import get_pp_group
+
+    manager = getattr(worker.model_runner, "encoder_cudagraph_manager", None)
+    stats = manager.get_cumulative_stats() if manager is not None else {}
+    return {
+        "pp_rank": get_pp_group().rank_in_group,
+        "present": manager is not None,
+        "graph_hits": stats.get("graph_hits", 0),
+        "graph_misses": stats.get("graph_misses", 0),
+    }
+
+
+@multi_gpu_test(num_gpus=2)
+def test_encoder_cudagraph_only_on_first_pp_stage(monkeypatch: pytest.MonkeyPatch):
+    # LLM.collective_rpc requires pickling a function.
+    monkeypatch.setenv("VLLM_ALLOW_INSECURE_SERIALIZATION", "1")
+    monkeypatch.setenv("VLLM_USE_V2_MODEL_RUNNER", "0")
+
+    llm = LLM(
+        model=MODEL,
+        load_format="dummy",
+        hf_overrides=pp_dummy_hf_overrides,
+        pipeline_parallel_size=2,
+        distributed_executor_backend="mp",
+        max_model_len=4096,
+        max_num_seqs=2,
+        limit_mm_per_prompt={"image": 1},
+        gpu_memory_utilization=0.6,
+        compilation_config={
+            "cudagraph_mm_encoder": True,
+            "cudagraph_capture_sizes": [1, 2],
+            "encoder_cudagraph_token_budgets": [4096],
+            "encoder_cudagraph_max_vision_items_per_batch": 1,
+        },
+    )
+
+    outputs = llm.generate(
+        [
+            {
+                "prompt": PROMPT,
+                "multi_modal_data": {"image": ImageAsset("stop_sign").pil_image},
+            }
+        ],
+        SamplingParams(temperature=0, max_tokens=8),
+    )
+    # Weights are dummy, so only the mechanics of generation are meaningful.
+    assert outputs and outputs[0].outputs[0].text is not None
+
+    probes = sorted(
+        llm.collective_rpc(probe_encoder_cudagraph),
+        key=lambda probe: probe["pp_rank"],
+    )
+
+    assert [probe["present"] for probe in probes] == [True, False]
+    assert probes[0]["graph_hits"] >= 1
+    assert probes[0]["graph_misses"] == 0

--- a/tests/v1/worker/test_gpu_model_runner.py
+++ b/tests/v1/worker/test_gpu_model_runner.py
@@ -370,6 +370,59 @@ def test_sample_tokens_skips_pp_group_lookup_without_async_scheduling(
     assert output in (EMPTY_MODEL_RUNNER_OUTPUT, None)
 
 
+@pytest.mark.skip_global_cleanup
+def test_encoder_cudagraph_manager_skipped_on_non_first_pp_rank(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    runner = GPUModelRunner.__new__(GPUModelRunner)
+    runner.compilation_config = SimpleNamespace(cudagraph_mm_encoder=True)
+    runner.supports_mm_inputs = True
+    runner.model_config = SimpleNamespace(is_encoder_decoder=False)
+    runner.vllm_config = SimpleNamespace(is_ec_producer_only=False)
+    runner.get_model = Mock()
+
+    monkeypatch.setattr(
+        gpu_model_runner_module,
+        "get_pp_group",
+        lambda: SimpleNamespace(is_first_rank=False),
+    )
+
+    assert runner._create_encoder_cudagraph_manager() is None
+    runner.get_model.assert_not_called()
+
+
+@pytest.mark.skip_global_cleanup
+@pytest.mark.parametrize(
+    ("is_encoder_decoder", "is_ec_producer_only"),
+    [(True, False), (False, True)],
+    ids=["encoder-decoder", "ec-producer"],
+)
+def test_encoder_cudagraph_support_checked_on_non_first_pp_rank(
+    monkeypatch: pytest.MonkeyPatch,
+    is_encoder_decoder: bool,
+    is_ec_producer_only: bool,
+):
+    runner = GPUModelRunner.__new__(GPUModelRunner)
+    runner.compilation_config = SimpleNamespace(cudagraph_mm_encoder=True)
+    runner.supports_mm_inputs = True
+    runner.model_config = SimpleNamespace(
+        is_encoder_decoder=is_encoder_decoder,
+    )
+    runner.vllm_config = SimpleNamespace(
+        is_ec_producer_only=is_ec_producer_only,
+    )
+    runner.get_model = Mock(return_value=object())
+
+    monkeypatch.setattr(
+        gpu_model_runner_module,
+        "get_pp_group",
+        lambda: SimpleNamespace(is_first_rank=False),
+    )
+
+    assert runner._create_encoder_cudagraph_manager() is None
+    runner.get_model.assert_called_once()
+
+
 def test_select_common_block_size_no_valid_option():
     backend_a = _make_mock_backend_for_kernel_block_size([64])
     backend_b = _make_mock_backend_for_kernel_block_size([MultipleOf(16)])

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -6731,6 +6731,15 @@ class GPUModelRunner(
         ):
             return None
 
+        # Decoder-only multimodal models run the encoder only on the first PP
+        # rank. Encoder-decoder models and encode-only EC producers run it on
+        # every rank.
+        encoder_runs_on_all_pp_ranks = self.model_config.is_encoder_decoder or (
+            self.vllm_config.is_ec_producer_only
+        )
+        if not encoder_runs_on_all_pp_ranks and not get_pp_group().is_first_rank:
+            return None
+
         # Use get_model() to unwrap CUDAGraphWrapper/UBatchWrapper, because
         # @runtime_checkable Protocol isinstance() checks do not work through
         # __getattr__ forwarding.


### PR DESCRIPTION
## Purpose

Decoder-only multimodal models execute their encoder only on the first
pipeline-parallel rank. When multimodal encoder CUDA graphs were enabled,
Model Runner V1 nevertheless created, profiled, and captured an
`EncoderCudaGraphManager` on every rank. Later ranks never replayed those
graphs, wasting startup work and GPU memory.

Skip encoder CUDA-graph manager creation on non-first PP ranks for
decoder-only multimodal models. Preserve the existing all-rank behavior for
encoder-decoder models and encode-only EC producers.

Add focused unit coverage for the guard and its two exceptions, plus a PP=2
Qwen2-VL integration test that verifies only rank 0 owns and replays an
encoder graph. Wire the integration test into the existing Buildkite
Pipeline + Context Parallelism job.

## Test Plan

```bash
pytest tests/v1/worker/test_gpu_model_runner.py -q -k encoder_cudagraph
pytest -v -s tests/distributed/test_pp_encoder_cudagraph.py
VLLM_USE_V2_MODEL_RUNNER=0 pytest -v -s tests/distributed/test_pp_cudagraph.py
```

## Test Result

- Focused unit tests: `3 passed, 44 deselected`.
- PP=2 integration on an H100: `1 passed in 70.54s`; manager presence was
  `[True, False]`, rank 0 recorded at least one graph hit and zero misses,
  and generation completed. This run preceded reducing the committed test
  to one capture budget for CI; the PP behavior and assertions are unchanged.
- Existing legacy-runner PP CUDA-graph test on an H100:
  `1 passed in 163.2s`.
- Pre-commit checks passed.

No documentation update is needed because this changes internal graph
initialization only.

---
<details>
<summary>Essential Elements of an Effective PR Description Checklist</summary>

- [x] The purpose of the PR is described.
- [x] The test plan is provided.
- [x] The test results are provided.
- [x] No documentation update is required.

</details>

AI assistance was used in developing this change. I reviewed and understand
every submitted line.
