### PR TITLE
[Bugfix] Support 0-dim tensors in packed weight transfer

### DIFF
--- a/tests/distributed/test_packed_tensor.py
+++ b/tests/distributed/test_packed_tensor.py
@@ -618,6 +618,7 @@ class TestPackedIpcRoundtrip:
         """Test basic IPC producer -> consumer roundtrip."""
         params = [
             ("w1", torch.randn(10, 20, dtype=torch.float32).cuda()),
+            ("scale", torch.tensor(1.5, dtype=torch.float32).cuda()),
             ("w2", torch.randn(5, dtype=torch.float16).cuda()),
         ]
         gpu_uuid = self._get_gpu_uuid()
@@ -634,7 +635,7 @@ class TestPackedIpcRoundtrip:
         )
 
         assert num_chunks == 1
-        assert len(result) == 2
+        assert len(result) == len(params)
         for (orig_name, orig_tensor), (res_name, res_tensor) in zip(params, result):
             assert orig_name == res_name
             assert res_tensor.shape == orig_tensor.shape
@@ -746,3 +747,56 @@ class TestPackedIpcRoundtrip:
                 tensor_sizes=c.tensor_sizes,
                 device_index=torch.cuda.current_device(),
             )
+
+
+# --- Unit Tests: scalar (0-dim) tensors ---
+
+
+@pytest.mark.parametrize(
+    "dtype",
+    [torch.float32, torch.float16, torch.bfloat16],
+)
+def test_pack_unpack_scalar(dtype):
+    """Test a 0-dim tensor round-trips alongside a regular one."""
+    params = [
+        ("weight", torch.randn(2, 3, dtype=dtype)),
+        ("scale", torch.tensor(1.5, dtype=dtype)),
+    ]
+
+    chunk = pack_tensors(
+        iter(params),
+        lambda item: item[1],
+        buffer_size_bytes=1024,
+    )
+    assert chunk is not None
+
+    result = unpack_tensor(
+        chunk.packed_tensor,
+        chunk.names,
+        chunk.shapes,
+        chunk.dtypes,
+        chunk.tensor_sizes,
+    )
+
+    for (expected_name, expected), (name, actual) in zip(params, result):
+        assert name == expected_name
+        assert actual.shape == expected.shape
+        torch.testing.assert_close(actual, expected)
+
+
+def test_unpack_scalar():
+    """Test unpack_tensor restores a 0-dim shape."""
+    packed = torch.tensor([1.5], dtype=torch.float32).view(torch.uint8)
+
+    result = unpack_tensor(
+        packed,
+        names=["scale"],
+        shapes=[[]],
+        dtypes=[torch.float32],
+        tensor_sizes=[packed.numel()],
+    )
+
+    name, tensor = result[0]
+    assert name == "scale"
+    assert tensor.shape == torch.Size([])
+    assert tensor.item() == 1.5

--- a/vllm/distributed/weight_transfer/packed_tensor.py
+++ b/vllm/distributed/weight_transfer/packed_tensor.py
@@ -40,7 +40,7 @@ def unpack_tensor(
     unpacked_tensors = packed_tensor.split(tensor_sizes)
 
     return [
-        (name, tensor.contiguous().view(dtype).view(*shape))
+        (name, tensor.contiguous().view(dtype).view(shape))
         for name, shape, dtype, tensor in zip(names, shapes, dtypes, unpacked_tensors)
     ]
 
@@ -94,7 +94,7 @@ def pack_tensors(
 
         name, orig_tensor = item
         # Apply post processing and convert to linearized uint8 tensor
-        tensor = post_iter_func(item).contiguous().view(torch.uint8).view(-1)
+        tensor = post_iter_func(item).contiguous().view(-1).view(torch.uint8)
 
         if tensor.numel() > buffer_size_bytes:
             import warnings
@@ -338,7 +338,7 @@ def packed_ipc_producer(
 
     for name, orig_tensor in iterator:
         flat = (
-            post_iter_func((name, orig_tensor)).contiguous().view(torch.uint8).view(-1)
+            post_iter_func((name, orig_tensor)).contiguous().view(-1).view(torch.uint8)
         )
 
         if flat.numel() > buffer_size_bytes:


### PR DESCRIPTION
## Purpose

Packed weight transfer currently fails for 0-D (scalar) tensors.

On the producer side, `pack_tensors` and `packed_ipc_producer` reinterpret each tensor as `uint8` before flattening it. Reinterpreting to a dtype with a different element size requires `dim() > 0`, so a scalar raises:

```text
RuntimeError: self.dim() cannot be 0 to view Float as Byte (different element sizes)
```

On the consumer side, `unpack_tensor` restores the original shape with `.view(*shape)`. For a scalar, `shape == []`, so the call becomes `view()` and raises `TypeError`.

A single scalar fails the entire chunk it is packed into, not just that tensor.

The unpacked IPC path does not have either problem: it ships tensors through `reduce_tensor`/`rebuild_cuda_tensor` with no dtype reinterpretation, so it round-trips 0-D tensors already. Packed mode is documented as a bounded-memory alternative to the same transfer, so both should accept the same inputs. The receiving side is also prepared for shape-less weights: `weight_loader` in `vllm/model_executor/layers/linear.py` reshapes them on load, noting that scales "often do not have a shape (such as in the case of AutoFP8)". `unpack_tensor` raises before that handling runs.

## Changes

Both packed producer paths now flatten before reinterpreting the dtype, so the `uint8` view never sees a 0-dim tensor. `unpack_tensor` passes the shape sequence to `view()` rather than unpacking it, which is valid when the shape is empty.

`view(shape)` is used rather than `reshape(shape)` to preserve `unpack_tensor`'s existing view semantics. Both changes are byte-identical for every shape the existing tests cover, including the transposed, strided and permuted cases.

The flatten-before-reinterpret order matches what the rest of the codebase already does, including `shm_broadcast.py` in this same package:

* `vllm/distributed/device_communicators/shm_broadcast.py`: `.contiguous().reshape(-1).view(torch.uint8)`
* `vllm/distributed/ec_transfer/ec_connector/cpu/worker/__init__.py`: `.view(-1).view(torch.uint8)`
* `vllm/model_executor/layers/fused_moe/b12x.py`: `workspace.view(-1).view(torch.uint8)`
* `vllm/model_executor/kernels/linear/nvfp4/fbgemm.py`: `.view(-1).view(torch.uint8)` (two sites)

Test coverage:

* `test_pack_unpack_scalar`, a new CPU test covering a scalar packed alongside a 2-D tensor, over `float32`, `float16` and `bfloat16`
* `test_unpack_scalar`, covering `unpack_tensor` directly so the shape-restore path is pinned independently of the producer
* a scalar added to the existing `test_roundtrip_basic`, so the fix is exercised through `packed_ipc_producer` as well

## Test Plan

```bash
pytest -v -s tests/distributed/test_packed_tensor.py
```

`pack_tensors` and `unpack_tensor` are device-agnostic, so the new test needs no CUDA guard. The IPC round-trip test remains CUDA-only.

`pre-commit run --files` on both changed files passes locally: ruff check, ruff format, typos, mypy-3.10, SPDX headers and the forbidden-import checks.

## Test Result

Without the fix:

```text
>       tensor = post_iter_func(item).contiguous().view(torch.uint8).view(-1)
E       RuntimeError: self.dim() cannot be 0 to view Float as Byte (different element sizes)
vllm/distributed/weight_transfer/packed_tensor.py:97: RuntimeError
======================== 4 failed, 26 skipped in 2.22s =========================
```

With the fix:

```text
======================== 4 passed, 26 skipped in 2.21s =========================
```

The skipped tests require CUDA, including the IPC round-trip.
