### PR TITLE
[Kimi-K3][DCP] Publish prefill KV directly in MLA layout

### DIFF
--- a/.buildkite/test_areas/distributed.yaml
+++ b/.buildkite/test_areas/distributed.yaml
@@ -182,7 +182,7 @@ steps:
 
 - label: Distributed Tests (8xH100)
   key: distributed-tests-8xh100
-  timeout_in_minutes: 20
+  timeout_in_minutes: 30
   device: h100
   num_devices: 8
   working_dir: "/vllm-workspace/tests"
@@ -194,6 +194,11 @@ steps:
   - vllm/v1/engine/llm_engine.py
   - vllm/v1/executor/uniproc_executor.py
   - vllm/v1/worker/gpu_worker.py
+  - vllm/v1/attention/ops/dcp_utils.py
+  - vllm/model_executor/layers/attention/mla_attention.py
+  - vllm/model_executor/layers/attention/sparse_mla_attention.py
+  - csrc/libtorch_stable/attention/dcp_utils/
+  - tests/distributed/test_dcp_direct_a2a_lse_reduce.py
   - tests/distributed/test_mnnvl_alltoall.py
 
   commands:
@@ -201,6 +206,7 @@ steps:
   - export NCCL_CUMEM_HOST_ENABLE=0
   # test with torchrun tp=2 and dp=4 with ep
   - torchrun --nproc-per-node=8 ../examples/features/torchrun/torchrun_dp_example_offline.py --tp-size=2 --pp-size=1 --dp-size=4 --enable-ep
+  - pytest -v -s distributed/test_dcp_direct_a2a_lse_reduce.py
 
 - label: Distributed Tests (4xA100)
   key: distributed-tests-4xa100

--- a/csrc/libtorch_stable/attention/dcp_utils/dcp_direct_kv_gather.cu
+++ b/csrc/libtorch_stable/attention/dcp_utils/dcp_direct_kv_gather.cu
@@ -20,28 +20,53 @@ using vllm::direct_dcp::wait_for_epoch;
 constexpr int kThreads = 256;
 // KV chunks need many blocks in flight to saturate the fabric.
 constexpr int64_t kMaxMulticastBlocks = 128;
-constexpr int64_t kMaxCopyBlocks = 1024;
 
-// Multicast each rank's KV slice and completion epoch to every replica.
+// Multicast each rank's valid local rows directly into compact, request-major
+// kv_c and k_pe planes. dst_rows maps every padded local input row to its final
+// output row, or -1 for padding. Destination rows are disjoint across source
+// ranks, so all ranks can publish concurrently without atomics.
 __global__ void direct_dcp_kv_gather_multimem_kernel(
-    const uint4* local_kv, uint4* mc_kv, uint32_t* mc_signal,
-    const uint32_t* received_signal, const int64_t* epoch_ptr,
-    uint32_t* completion, int64_t world_size, int64_t rank, int64_t slice_bytes,
-    int64_t slot_stride_bytes) {
+    const uint4* local_kv, const int32_t* dst_rows, uint4* mc_kv,
+    uint32_t* mc_signal, const uint32_t* received_signal,
+    const int64_t* epoch_ptr, uint32_t* completion, int64_t world_size,
+    int64_t rank, int64_t num_tokens, int64_t items_per_row,
+    int64_t kv_c_items_per_row, int64_t output_tokens,
+    int64_t max_gathered_tokens, int64_t buffer_slot,
+    int64_t slot_stride_items) {
   uint32_t epoch = static_cast<uint32_t>(epoch_ptr[0]);
-  int64_t buffer_slot = static_cast<int64_t>(epoch & 1u);
-  int64_t item_count = slice_bytes / sizeof(uint4);
-  mc_kv += buffer_slot * slot_stride_bytes / sizeof(uint4);
-  mc_kv += rank * item_count;
+  mc_kv += buffer_slot * slot_stride_items;
 
+  int64_t item_count = num_tokens * items_per_row;
   int64_t item_stride = static_cast<int64_t>(gridDim.x) * blockDim.x;
   for (int64_t item =
            static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
        item < item_count; item += item_stride) {
-    multimem_store_16(mc_kv + item, local_kv[item]);
+    int64_t src_row = item / items_per_row;
+    int32_t dst_row = dst_rows[src_row];
+    if (dst_row < 0) {
+      continue;
+    }
+    if (dst_row >= output_tokens) {
+      printf(
+          "direct DCP final-layout kv-gather destination out of bounds "
+          "source=%lld dst=%d output_tokens=%lld\n",
+          static_cast<long long>(rank), dst_row,
+          static_cast<long long>(output_tokens));
+      asm volatile("trap;");
+    }
+    int64_t row_item = item - src_row * items_per_row;
+    int64_t dst_item;
+    if (row_item < kv_c_items_per_row) {
+      dst_item = static_cast<int64_t>(dst_row) * kv_c_items_per_row + row_item;
+    } else {
+      int64_t k_pe_items_per_row = items_per_row - kv_c_items_per_row;
+      dst_item = max_gathered_tokens * kv_c_items_per_row +
+                 static_cast<int64_t>(dst_row) * k_pe_items_per_row + row_item -
+                 kv_c_items_per_row;
+    }
+    multimem_store_16(mc_kv + dst_item, local_kv[item]);
   }
 
-  // Publish all multicast writes before incrementing completion.
   __threadfence_system();
   __syncthreads();
   if (threadIdx.x != 0) {
@@ -56,59 +81,57 @@ __global__ void direct_dcp_kv_gather_multimem_kernel(
 
   multimem_store_release_system(mc_signal + buffer_slot * world_size + rank,
                                 epoch);
-
   for (int64_t source_rank = 0; source_rank < world_size; ++source_rank) {
     int64_t signal_item = buffer_slot * world_size + source_rank;
     if (!wait_for_epoch(received_signal + signal_item, epoch)) {
-      printf("direct DCP kv-gather multimem timeout source=%lld epoch=%u\n",
+      printf("direct DCP final-layout kv-gather timeout source=%lld epoch=%u\n",
              static_cast<long long>(source_rank), epoch);
       asm volatile("trap;");
     }
   }
 }
 
-// Materialize the acquired slot into the caller's workspace.
-template <typename copy_t>
-__global__ void materialize_kv_gather_kernel(const copy_t* received_kv,
-                                             const int64_t* epoch_ptr,
-                                             copy_t* gathered_kv,
-                                             int64_t gathered_item_count,
-                                             int64_t slot_stride_items) {
-  uint32_t epoch = static_cast<uint32_t>(epoch_ptr[0]);
-  int64_t buffer_slot = static_cast<int64_t>(epoch & 1u);
-  received_kv += buffer_slot * slot_stride_items;
-  int64_t item = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
-  int64_t item_stride = static_cast<int64_t>(gridDim.x) * blockDim.x;
-  for (; item < gathered_item_count; item += item_stride) {
-    gathered_kv[item] = received_kv[item];
-  }
-}
-
-void direct_dcp_kv_gather(
-    const torch::stable::Tensor& local_kv, torch::stable::Tensor& received_kv,
-    torch::stable::Tensor& received_signal, torch::stable::Tensor& completion,
-    torch::stable::Tensor& epoch, torch::stable::Tensor& gathered_kv,
-    int64_t world_size, int64_t rank, int64_t max_gathered_tokens,
-    int64_t kv_mc_ptr, int64_t signal_mc_ptr) {
+void direct_dcp_kv_gather(const torch::stable::Tensor& local_kv,
+                          const torch::stable::Tensor& dst_rows,
+                          torch::stable::Tensor& received_kv,
+                          torch::stable::Tensor& received_signal,
+                          torch::stable::Tensor& completion,
+                          torch::stable::Tensor& epoch, int64_t output_tokens,
+                          int64_t plane_split_dim, int64_t buffer_slot,
+                          int64_t world_size, int64_t rank,
+                          int64_t max_gathered_tokens, int64_t kv_mc_ptr,
+                          int64_t signal_mc_ptr) {
   using torch::headeronly::ScalarType;
 
   STD_TORCH_CHECK(local_kv.is_cuda(), "local kv must be a CUDA tensor");
   ScalarType dtype = local_kv.scalar_type();
   STD_TORCH_CHECK(dtype == ScalarType::Half || dtype == ScalarType::BFloat16 ||
                       dtype == ScalarType::Float8_e4m3fn,
-                  "direct DCP kv-gather only supports FP16, BF16, and FP8");
+                  "direct DCP final-layout kv-gather only supports FP16, "
+                  "BF16, and FP8");
   STD_TORCH_CHECK(local_kv.dim() == 2 && local_kv.is_contiguous(),
                   "local kv must be a contiguous [T,D] tensor");
+  STD_TORCH_CHECK(dst_rows.is_cuda() && dst_rows.is_contiguous() &&
+                      dst_rows.scalar_type() == ScalarType::Int &&
+                      dst_rows.dim() == 1 &&
+                      dst_rows.numel() == local_kv.size(0),
+                  "final-layout destination rows must be CUDA int32 [T]");
   STD_TORCH_CHECK(world_size > 1, "world_size must be greater than 1");
   STD_TORCH_CHECK(rank >= 0 && rank < world_size, "invalid rank");
+  STD_TORCH_CHECK(buffer_slot == 0 || buffer_slot == 1,
+                  "final-layout buffer slot must be 0 or 1");
+  STD_TORCH_CHECK(output_tokens > 0 && output_tokens <= max_gathered_tokens,
+                  "final-layout output exceeds symmetric buffer capacity");
 
   int64_t num_tokens = local_kv.size(0);
   int64_t token_dim = local_kv.size(1);
   int64_t element_size = local_kv.element_size();
   STD_TORCH_CHECK(num_tokens > 0 && token_dim > 0,
                   "local kv dimensions must be positive");
+  STD_TORCH_CHECK(plane_split_dim > 0 && plane_split_dim < token_dim,
+                  "final-layout plane split must be within the token row");
   STD_TORCH_CHECK(num_tokens * world_size <= max_gathered_tokens,
-                  "gathered kv exceeds symmetric kv-gather buffer capacity");
+                  "padded gathered kv exceeds symmetric buffer capacity");
 
   STD_TORCH_CHECK(received_kv.is_cuda() && received_kv.scalar_type() == dtype &&
                       received_kv.is_contiguous() && received_kv.dim() == 3 &&
@@ -130,65 +153,57 @@ void direct_dcp_kv_gather(
                       epoch.scalar_type() == ScalarType::Long &&
                       epoch.numel() == 1,
                   "epoch must be a one-element CUDA int64 tensor");
-  STD_TORCH_CHECK(gathered_kv.is_cuda() && gathered_kv.scalar_type() == dtype &&
-                      gathered_kv.is_contiguous() && gathered_kv.dim() == 2 &&
-                      gathered_kv.size(0) == num_tokens * world_size &&
-                      gathered_kv.size(1) == token_dim,
-                  "gathered kv must be contiguous with shape [world_size*T,D]");
-  int64_t device_index = local_kv.get_device_index();
-  STD_TORCH_CHECK(
-      received_kv.get_device_index() == device_index &&
-          received_signal.get_device_index() == device_index &&
-          completion.get_device_index() == device_index &&
-          epoch.get_device_index() == device_index &&
-          gathered_kv.get_device_index() == device_index,
-      "direct DCP kv-gather tensors must be on the same CUDA device");
 
-  int64_t slice_bytes = num_tokens * token_dim * element_size;
-  int64_t slot_stride_bytes = max_gathered_tokens * token_dim * element_size;
+  int64_t device_index = local_kv.get_device_index();
+  STD_TORCH_CHECK(dst_rows.get_device_index() == device_index &&
+                      received_kv.get_device_index() == device_index &&
+                      received_signal.get_device_index() == device_index &&
+                      completion.get_device_index() == device_index &&
+                      epoch.get_device_index() == device_index,
+                  "direct DCP final-layout tensors must share a CUDA device");
+
+  int64_t row_bytes = token_dim * element_size;
+  int64_t kv_c_row_bytes = plane_split_dim * element_size;
+  int64_t k_pe_row_bytes = row_bytes - kv_c_row_bytes;
+  int64_t slot_stride_bytes = max_gathered_tokens * row_bytes;
   bool vectorized =
       reinterpret_cast<uintptr_t>(local_kv.data_ptr()) % alignof(uint4) == 0 &&
       reinterpret_cast<uintptr_t>(received_kv.data_ptr()) % alignof(uint4) ==
           0 &&
-      reinterpret_cast<uintptr_t>(gathered_kv.data_ptr()) % alignof(uint4) ==
-          0 &&
-      slice_bytes % sizeof(uint4) == 0 &&
+      row_bytes % sizeof(uint4) == 0 && kv_c_row_bytes % sizeof(uint4) == 0 &&
+      k_pe_row_bytes % sizeof(uint4) == 0 &&
       slot_stride_bytes % sizeof(uint4) == 0;
-  STD_TORCH_CHECK(
-      vectorized,
-      "direct DCP kv-gather requires 16-byte-aligned pointers and strides");
+  STD_TORCH_CHECK(vectorized,
+                  "direct DCP final-layout kv-gather requires 16-byte-aligned "
+                  "planes, rows, and pointers");
   STD_TORCH_CHECK(kv_mc_ptr != 0 && signal_mc_ptr != 0,
-                  "direct DCP kv-gather requires multicast pointers");
+                  "direct DCP final-layout kv-gather requires multicast "
+                  "pointers");
 
   const torch::stable::accelerator::DeviceGuard device_guard(device_index);
   cudaStream_t stream = get_current_cuda_stream();
   increment_epoch_kernel<<<1, 1, 0, stream>>>(
       epoch.mutable_data_ptr<int64_t>());
-  check_cuda_launch("direct DCP kv-gather");
+  check_cuda_launch("direct DCP final-layout kv-gather");
 
-  int64_t item_count = slice_bytes / sizeof(uint4);
+  int64_t items_per_row = row_bytes / sizeof(uint4);
+  int64_t kv_c_items_per_row = kv_c_row_bytes / sizeof(uint4);
+  int64_t item_count = num_tokens * items_per_row;
   int64_t blocks = (item_count + kThreads - 1) / kThreads;
   blocks = blocks < kMaxMulticastBlocks ? blocks : kMaxMulticastBlocks;
   direct_dcp_kv_gather_multimem_kernel<<<blocks, kThreads, 0, stream>>>(
       reinterpret_cast<const uint4*>(local_kv.data_ptr()),
+      dst_rows.const_data_ptr<int32_t>(),
       reinterpret_cast<uint4*>(static_cast<uintptr_t>(kv_mc_ptr)),
       reinterpret_cast<uint32_t*>(static_cast<uintptr_t>(signal_mc_ptr)),
       reinterpret_cast<const uint32_t*>(
           received_signal.const_data_ptr<int32_t>()),
       epoch.const_data_ptr<int64_t>(),
       reinterpret_cast<uint32_t*>(completion.mutable_data_ptr<int32_t>()),
-      world_size, rank, slice_bytes, slot_stride_bytes);
-  check_cuda_launch("direct DCP kv-gather");
-
-  int64_t gathered_item_count = world_size * item_count;
-  int64_t copy_blocks = (gathered_item_count + kThreads - 1) / kThreads;
-  copy_blocks = copy_blocks < kMaxCopyBlocks ? copy_blocks : kMaxCopyBlocks;
-  materialize_kv_gather_kernel<uint4><<<copy_blocks, kThreads, 0, stream>>>(
-      reinterpret_cast<const uint4*>(received_kv.data_ptr()),
-      epoch.const_data_ptr<int64_t>(),
-      reinterpret_cast<uint4*>(gathered_kv.mutable_data_ptr()),
-      gathered_item_count, slot_stride_bytes / sizeof(uint4));
-  check_cuda_launch("direct DCP kv-gather");
+      world_size, rank, num_tokens, items_per_row, kv_c_items_per_row,
+      output_tokens, max_gathered_tokens, buffer_slot,
+      slot_stride_bytes / sizeof(uint4));
+  check_cuda_launch("direct DCP final-layout kv-gather");
 }
 
 }  // namespace
@@ -196,9 +211,9 @@ void direct_dcp_kv_gather(
 STABLE_TORCH_LIBRARY_FRAGMENT(_C, direct_dcp_kv_gather_ops) {
   direct_dcp_kv_gather_ops.def(
       "direct_dcp_kv_gather("
-      "Tensor local_kv, Tensor! received_kv, Tensor! received_signal, "
-      "Tensor! completion, "
-      "Tensor! epoch, Tensor! gathered_kv, "
+      "Tensor local_kv, Tensor dst_rows, Tensor! received_kv, "
+      "Tensor! received_signal, Tensor! completion, Tensor! epoch, "
+      "int output_tokens, int plane_split_dim, int buffer_slot, "
       "int world_size, int rank, int max_gathered_tokens, "
       "int kv_mc_ptr, int signal_mc_ptr) -> ()");
 }

--- a/tests/distributed/test_dcp_direct_a2a_lse_reduce.py
+++ b/tests/distributed/test_dcp_direct_a2a_lse_reduce.py
@@ -3,6 +3,7 @@
 """Tests for direct symmetric-memory DCP collectives."""
 
 import functools
+import time
 from unittest.mock import MagicMock
 
 import multiprocess as mp
@@ -15,6 +16,7 @@ from vllm.utils.network_utils import get_open_port
 from vllm.utils.system_utils import update_environment_variables
 
 mp.set_start_method("spawn", force=True)
+pytestmark = pytest.mark.skip_global_cleanup
 
 
 def _has_multicast_support() -> bool:
@@ -115,8 +117,9 @@ def _distributed_run(fn, world_size: int, extra_env: dict[str, str]) -> None:
         processes.append(process)
         process.start()
 
+    deadline = time.monotonic() + 120
     for process in processes:
-        process.join(timeout=120)
+        process.join(timeout=max(0, deadline - time.monotonic()))
 
     for process in processes:
         if process.is_alive():
@@ -222,7 +225,13 @@ class TestDirectDCPGating:
         monkeypatch.setenv("VLLM_USE_DIRECT_DCP_A2A", "1")
         dcp_utils.get_direct_dcp_kv_gather_workspace.cache_clear()
         workspace = dcp_utils.get_direct_dcp_kv_gather_workspace(
-            _FakeGroupCoordinator(), torch.device("cpu"), 64, 576, torch.bfloat16, 1
+            _FakeGroupCoordinator(),
+            torch.device("cpu"),
+            64,
+            576,
+            512,
+            torch.bfloat16,
+            1,
         )
         assert workspace is None
 
@@ -240,7 +249,13 @@ class TestDirectDCPGating:
         )
 
         result = dcp_utils.get_direct_dcp_kv_gather_workspace(
-            _FakeGroupCoordinator(), torch.device("cpu"), 64, 576, torch.bfloat16, 1
+            _FakeGroupCoordinator(),
+            torch.device("cpu"),
+            64,
+            576,
+            512,
+            torch.bfloat16,
+            1,
         )
 
         assert result is workspace
@@ -256,7 +271,7 @@ class TestDirectDCPGating:
             (
                 "VLLM_USE_DIRECT_DCP_KV_GATHER",
                 "get_direct_dcp_kv_gather_workspace",
-                (64, 576, torch.bfloat16, 1),
+                (64, 576, 512, torch.bfloat16, 1),
             ),
         ],
     )
@@ -284,16 +299,37 @@ class TestDirectDCPGating:
     def test_kv_gather_rejects_invalid_workspace_geometry(self):
         with pytest.raises(ValueError, match="ubatch"):
             dcp_utils.DirectDCPKVGatherWorkspace(
-                None, torch.device("cpu"), 64, 576, num_ubatches=0
+                None, torch.device("cpu"), 64, 576, 512, num_ubatches=0
             )
         with pytest.raises(ValueError, match="divide evenly"):
             dcp_utils.DirectDCPKVGatherWorkspace(
-                _FakeProcessGroup(), torch.device("cpu"), 63, 576
+                _FakeProcessGroup(), torch.device("cpu"), 63, 576, 512
             )
         with pytest.raises(ValueError, match="16-byte"):
             dcp_utils.DirectDCPKVGatherWorkspace(
-                _FakeProcessGroup(), torch.device("cpu"), 64, 3
+                _FakeProcessGroup(), torch.device("cpu"), 64, 16, 4
             )
+
+    @pytest.mark.parametrize(
+        ("token_dim", "plane_split_dim", "dtype", "supported"),
+        [
+            (576, 512, torch.bfloat16, True),
+            (576, 512, torch.float16, True),
+            (576, 512, torch.float8_e4m3fn, True),
+            (16, 8, torch.bfloat16, True),
+            (16, 4, torch.bfloat16, False),
+            (24, 16, torch.float8_e4m3fn, False),
+            (16, 0, torch.bfloat16, False),
+            (16, 16, torch.bfloat16, False),
+        ],
+    )
+    def test_kv_gather_requires_each_plane_aligned(
+        self, token_dim, plane_split_dim, dtype, supported
+    ):
+        assert (
+            dcp_utils._kv_gather_layout_supported(token_dim, plane_split_dim, dtype)
+            is supported
+        )
 
     def test_q_gather_rejects_invalid_workspace_geometry(self):
         with pytest.raises(ValueError, match="ubatch"):
@@ -365,13 +401,29 @@ def test_mla_dcp_manager_selects_direct_backends(monkeypatch):
         is_lse_base_on_e=False,
         use_pcp=False,
     )
-    workspace = torch.empty(96, 8)
-
     assert manager.query_gather == direct_query.gather
-    manager.init_kv_gather(workspace, 64)
-    gathered_kv, local_kv = torch.empty(4, 8), torch.empty(2, 8)
-    manager.kv_gather(gathered_kv, local_kv)
-    direct_kv.gather.assert_called_once_with(gathered_kv, local_kv)
+    assert manager.init_kv_gather(64, 16, 8, torch.bfloat16)
+    dcp_manager.get_direct_dcp_kv_gather_workspace.assert_called_once_with(
+        group,
+        torch.device("cpu"),
+        64,
+        16,
+        8,
+        torch.bfloat16,
+        1,
+    )
+    local_kv = torch.empty(2, 8)
+    dst_rows = torch.tensor([0, 1], dtype=torch.int32)
+    compact_kv = (torch.empty(2, 1, 6), torch.empty(2, 1, 2))
+    direct_kv.gather.return_value = compact_kv
+    assert manager.use_direct_kv_gather
+    assert manager.direct_kv_gather(local_kv, dst_rows, 2, 1) is compact_kv
+    direct_kv.gather.assert_called_once_with(
+        local_kv,
+        dst_rows,
+        2,
+        1,
+    )
     output, lse = torch.empty(1), torch.empty(1)
     seq_lens = torch.ones(1, dtype=torch.int32)
     query_start_loc = torch.tensor([0, 1], dtype=torch.int32)
@@ -424,8 +476,7 @@ def test_mla_dcp_manager_selects_fallback_backends(monkeypatch):
 
     all_gather = MagicMock()
     monkeypatch.setattr(torch.distributed, "all_gather_into_tensor", all_gather)
-    workspace = torch.empty(96, 8)
-    manager.init_kv_gather(workspace, 64)
+    assert not manager.init_kv_gather(64, 16, 8, torch.bfloat16)
     output, local = torch.empty(4, 8), torch.empty(2, 8)
     manager.kv_gather(output, local)
     all_gather.assert_called_once_with(output, local, group=group.device_group)
@@ -502,7 +553,8 @@ def test_dcp_chunk_workspace_alignment_covers_interleave():
     assert align_mla_chunked_context_workspace_size(config, 8) == 64
 
 
-def test_sparse_mla_builder_initializes_dcp_manager(monkeypatch):
+@pytest.mark.parametrize("use_direct", [False, True])
+def test_sparse_mla_builder_initializes_dcp_manager(monkeypatch, use_direct):
     import vllm.model_executor.layers.attention.sparse_mla_attention as sparse_mla
 
     monkeypatch.setattr(
@@ -522,7 +574,7 @@ def test_sparse_mla_builder_initializes_dcp_manager(monkeypatch):
     )
 
     manager = object.__new__(dcp_utils.MLADCPManager)
-    manager.init_kv_gather = MagicMock()
+    manager.init_kv_gather = MagicMock(return_value=use_direct)
     layer = MagicMock(dcp_manager=manager)
     config = MagicMock()
     config.model_config.dtype = torch.bfloat16
@@ -545,9 +597,18 @@ def test_sparse_mla_builder_initializes_dcp_manager(monkeypatch):
 
     assert builder.dcp_manager is manager
     manager.init_kv_gather.assert_called_once_with(
-        builder.chunked_prefill_workspace,
         builder.chunked_prefill_workspace_size,
+        12,
+        8,
+        torch.bfloat16,
     )
+    local_rows = builder.chunked_prefill_workspace_size // 2
+    expected_rows = (
+        local_rows
+        if use_direct
+        else builder.chunked_prefill_workspace_size + local_rows
+    )
+    assert builder.chunked_prefill_workspace.shape == (expected_rows, 12)
 
 
 def test_sparse_mla_workspace_preserves_non_dcp_size():
@@ -744,49 +805,306 @@ def _distributed_direct_kv_gather_worker(env: dict[str, str]) -> None:
     try:
         rank = dist.get_rank()
         world_size = dist.get_world_size()
-        token_dim = 576
-        max_gathered_tokens = 128 * world_size
+        token_dim, plane_split_dim = 576, 512
+        max_gathered_tokens = 64
         active_ubatch = [0]
         dcp_utils.dbo_current_ubatch_id = lambda: active_ubatch[0]
 
-        for dtype_idx, dtype_name in enumerate(("bfloat16", "float16")):
+        full_layout = (
+            [4, 4, 6],
+            [4, 0, 0],
+            [[8, 8, 7, 6], [4, 2, 2, 2], [6, 6, 5, 4]],
+        )
+        alternate_layout = (
+            [4, 4, 6],
+            [4, 0, 0],
+            [[8, 8, 8, 6], [3, 2, 2, 2], [6, 6, 5, 4]],
+        )
+        small_layout = ([4], [4], [[8, 8, 7, 6]])
+
+        def layout_maps(layout) -> tuple[list[list[int]], int]:
+            padded_lens, local_starts, context_lens = layout
+            maps: list[list[int]] = [[] for _ in range(world_size)]
+            output_start = 0
+            for padded_len, local_start, request_lens in zip(
+                padded_lens, local_starts, context_lens, strict=True
+            ):
+                valid_lens = [
+                    min(max(0, length - local_start), padded_len)
+                    for length in request_lens
+                ]
+                for source_rank, valid_len in enumerate(valid_lens):
+                    rank_start = output_start + sum(valid_lens[:source_rank])
+                    maps[source_rank].extend(range(rank_start, rank_start + valid_len))
+                    maps[source_rank].extend([-1] * (padded_len - valid_len))
+                output_start += sum(valid_lens)
+            valid_rows = sorted(row for rows in maps for row in rows if row >= 0)
+            assert valid_rows == list(range(output_start))
+            return maps, output_start
+
+        def make_local(
+            source_rank: int,
+            iteration: int,
+            num_rows: int,
+            dtype: torch.dtype,
+        ) -> torch.Tensor:
+            values = torch.arange(
+                num_rows * token_dim,
+                dtype=torch.int32,
+                device=device,
+            )
+            values = (values + source_rank * 7 + iteration * 13).remainder(29) - 14
+            return values.view(num_rows, token_dim).to(dtype)
+
+        def expected_planes(layout, iteration: int, dtype: torch.dtype):
+            maps, output_tokens = layout_maps(layout)
+            output = torch.empty(output_tokens, token_dim, dtype=dtype, device=device)
+            covered = torch.zeros(output_tokens, dtype=torch.bool, device=device)
+            for source_rank, rows in enumerate(maps):
+                source = make_local(source_rank, iteration, len(rows), dtype)
+                dst_rows = torch.tensor(rows, dtype=torch.int32, device=device)
+                valid = dst_rows >= 0
+                assert not torch.any(covered[dst_rows[valid]])
+                output[dst_rows[valid]] = source[valid]
+                covered[dst_rows[valid]] = True
+            assert torch.all(covered)
+            return (
+                output[:, :plane_split_dim].unsqueeze(1),
+                output[:, plane_split_dim:].unsqueeze(1),
+            )
+
+        def publish(workspace, dtype, iteration: int, buffer_slot: int, layout):
+            maps, output_tokens = layout_maps(layout)
+            actual = workspace.gather(
+                make_local(rank, iteration, len(maps[rank]), dtype),
+                torch.tensor(maps[rank], dtype=torch.int32, device=device),
+                output_tokens,
+                buffer_slot,
+            )
+            return actual, expected_planes(layout, iteration, dtype)
+
+        def assert_planes(actual, expected) -> None:
+            for actual_plane, expected_plane in zip(actual, expected, strict=True):
+                assert torch.equal(
+                    actual_plane.view(torch.uint8), expected_plane.view(torch.uint8)
+                )
+
+        def check_case(
+            workspace: dcp_utils.DirectDCPKVGatherWorkspace,
+            dtype: torch.dtype,
+            iteration: int,
+            ubatch: int,
+            buffer_slot: int,
+            layout,
+        ) -> None:
+            maps, output_tokens = layout_maps(layout)
+            local_kv = make_local(rank, iteration, len(maps[rank]), dtype)
+            dst_rows = torch.tensor(maps[rank], dtype=torch.int32, device=device)
+            active_ubatch[0] = ubatch
+
+            other_ubatch = 1 - ubatch
+            torch.accelerator.synchronize()
+            other_ubatch_before = workspace.received_kv[other_ubatch].clone()
+            inactive_slot_before = workspace.received_kv[
+                ubatch, 1 - buffer_slot
+            ].clone()
+            slot = workspace.received_kv[ubatch, buffer_slot].view(-1)
+            kv_c_capacity = max_gathered_tokens * plane_split_dim
+            kv_c_storage = slot[:kv_c_capacity].view(
+                max_gathered_tokens, plane_split_dim
+            )
+            k_pe_storage = slot[kv_c_capacity:].view(
+                max_gathered_tokens, token_dim - plane_split_dim
+            )
+            kv_c_tail_before = kv_c_storage[output_tokens:].clone()
+            k_pe_tail_before = k_pe_storage[output_tokens:].clone()
+            epochs_before = workspace.epoch.clone()
+            torch.accelerator.synchronize()
+
+            kv_c, k_pe = workspace.gather(
+                local_kv,
+                dst_rows,
+                output_tokens,
+                buffer_slot,
+            )
+            torch.accelerator.synchronize()
+
+            expected_kv_c, expected_k_pe = expected_planes(layout, iteration, dtype)
+            assert kv_c.shape == expected_kv_c.shape
+            assert k_pe.shape == expected_k_pe.shape
+            assert kv_c.dtype == k_pe.dtype == dtype
+            assert kv_c.is_contiguous() and k_pe.is_contiguous()
+            assert torch.equal(kv_c.view(torch.uint8), expected_kv_c.view(torch.uint8))
+            assert torch.equal(k_pe.view(torch.uint8), expected_k_pe.view(torch.uint8))
+            assert (
+                kv_c.data_ptr() == workspace.received_kv[ubatch, buffer_slot].data_ptr()
+            )
+            assert k_pe.data_ptr() == (
+                kv_c.data_ptr() + kv_c_capacity * workspace.received_kv.element_size()
+            )
+            assert int(workspace.epoch[ubatch].item()) == (
+                int(epochs_before[ubatch].item()) + 1
+            )
+            assert int(workspace.epoch[other_ubatch].item()) == int(
+                epochs_before[other_ubatch].item()
+            )
+            assert not torch.count_nonzero(workspace.completion)
+            assert torch.equal(
+                workspace.received_kv[other_ubatch].view(torch.uint8),
+                other_ubatch_before.view(torch.uint8),
+            )
+            assert torch.equal(
+                workspace.received_kv[ubatch, 1 - buffer_slot].view(torch.uint8),
+                inactive_slot_before.view(torch.uint8),
+            )
+            assert torch.equal(
+                kv_c_storage[output_tokens:].view(torch.uint8),
+                kv_c_tail_before.view(torch.uint8),
+            )
+            assert torch.equal(
+                k_pe_storage[output_tokens:].view(torch.uint8),
+                k_pe_tail_before.view(torch.uint8),
+            )
+            # The gather itself synchronizes publication, but a faster rank
+            # may otherwise start the next test case and multicast into what
+            # a slower rank is still validating as this case's inactive slot.
+            # Production keeps this ordering through same-stream attention
+            # consumption followed by K3's TP-wide rendezvous; the test needs
+            # an explicit rank barrier around its host-side assertions.
+            dist.barrier()
+
+        # Exercise the ownership contract once in depth for BF16, then retain
+        # one byte-exact kernel smoke for each additional supported dtype.
+        eager_cases = {
+            "bfloat16": (
+                (0, 0, 0, full_layout),
+                (1, 0, 1, alternate_layout),
+                (2, 0, 0, small_layout),
+            ),
+            "float16": ((3, 0, 0, full_layout),),
+            "float8_e4m3fn": ((4, 0, 0, full_layout),),
+        }
+        for dtype_name, cases in eager_cases.items():
             dtype = _dtype_from_name(dtype_name)
             workspace = dcp_utils.DirectDCPKVGatherWorkspace(
                 dist.group.WORLD,
                 device,
                 max_gathered_tokens,
                 token_dim,
+                plane_split_dim,
                 dtype,
                 num_ubatches=2,
             )
+            for args in cases:
+                check_case(workspace, dtype, *args)
 
-            # Use disjoint slices of one persistent chunked-context workspace.
-            storage = torch.zeros(
-                (world_size + 1) * 128, token_dim, device=device, dtype=dtype
-            )
-            for iteration, num_tokens in enumerate((1, 128, 17)):
-                generator = torch.Generator(device=device)
-                generator.manual_seed(7000 + rank * 101 + dtype_idx * 977 + iteration)
-                local_kv = storage[:num_tokens]
-                local_kv.copy_(
-                    torch.randn(
-                        num_tokens,
-                        token_dim,
-                        device=device,
-                        dtype=torch.float32,
-                        generator=generator,
-                    ).to(dtype)
-                )
-                gathered = storage[128 : 128 + num_tokens * world_size]
-                active_ubatch[0] = iteration % 2
-                workspace.gather(gathered, local_kv)
+            if dtype == torch.bfloat16:
+                active_ubatch[0] = 0
+
+                # A gather on the other slot is the all-rank rendezvous that
+                # makes the first slot reusable. Rank 0 deliberately consumes
+                # slot 0 late; no explicit barrier protects the critical
+                # slot-0 -> slot-1 -> slot-0 sequence.
+                first, expected = publish(workspace, dtype, 30, 0, full_layout)
                 torch.accelerator.synchronize()
+                if rank == 0:
+                    time.sleep(0.25)
+                assert_planes(first, expected)
+                publish(workspace, dtype, 31, 1, alternate_layout)
+                torch.accelerator.synchronize()
+                reused, expected = publish(workspace, dtype, 32, 0, small_layout)
+                torch.accelerator.synchronize()
+                assert_planes(reused, expected)
+                dist.barrier()  # Isolate the next ownership scenario.
 
-                expected = torch.empty_like(gathered)
-                dist.all_gather_into_tensor(expected, local_kv.contiguous())
-                assert torch.equal(
-                    gathered.view(torch.uint8), expected.view(torch.uint8)
+                # Model execution may reset to slot 0 at a layer boundary.
+                # Simulate attention consumption followed by its downstream
+                # TP collective, then reuse the same slot immediately.
+                first, expected = publish(workspace, dtype, 33, 0, full_layout)
+                consumed = sum(plane.float().sum() for plane in first)
+                expected_consumed = sum(plane.float().sum() for plane in expected)
+                dist.all_reduce(consumed)
+                reused, expected = publish(workspace, dtype, 34, 0, small_layout)
+                torch.accelerator.synchronize()
+                torch.testing.assert_close(consumed, expected_consumed * world_size)
+                assert_planes(reused, expected)
+                dist.barrier()
+
+            if env.get("TEST_CUDA_GRAPH") != "1" or dtype != torch.bfloat16:
+                continue
+
+            graph_workspace = dcp_utils.DirectDCPKVGatherWorkspace(
+                dist.group.WORLD,
+                device,
+                max_gathered_tokens,
+                token_dim,
+                plane_split_dim,
+                dtype,
+                num_ubatches=2,
+            )
+            capture_maps, capture_output_tokens = layout_maps(full_layout)
+            captured_input = make_local(rank, 20, len(capture_maps[rank]), dtype)
+            captured_dst_rows = torch.tensor(
+                capture_maps[rank], dtype=torch.int32, device=device
+            )
+            active_ubatch[0] = 1
+            torch.accelerator.synchronize()
+            dist.barrier()
+            graph = torch.cuda.CUDAGraph()
+            with torch.cuda.graph(graph):
+                captured_kv_c, captured_k_pe = graph_workspace.gather(
+                    captured_input,
+                    captured_dst_rows,
+                    capture_output_tokens,
+                    buffer_slot=1,
                 )
+            dist.barrier()
+            graph.replay()
+            torch.accelerator.synchronize()
+            dist.barrier()
+            expected_kv_c, expected_k_pe = expected_planes(full_layout, 20, dtype)
+            assert torch.equal(
+                captured_kv_c.view(torch.uint8), expected_kv_c.view(torch.uint8)
+            )
+            assert torch.equal(
+                captured_k_pe.view(torch.uint8), expected_k_pe.view(torch.uint8)
+            )
+            dist.barrier()
+
+            # DBO owns a separate pair of buffers per ubatch. An eager call in
+            # ubatch 0 must not disturb the captured ubatch-1 slot.
+            check_case(
+                graph_workspace,
+                dtype,
+                iteration=21,
+                ubatch=0,
+                buffer_slot=0,
+                layout=small_layout,
+            )
+            maps, output_tokens = layout_maps(alternate_layout)
+            assert output_tokens == capture_output_tokens
+            captured_input.copy_(make_local(rank, 22, len(maps[rank]), dtype))
+            captured_dst_rows.copy_(
+                torch.tensor(maps[rank], dtype=torch.int32, device=device)
+            )
+            epochs_before = graph_workspace.epoch.clone()
+            torch.accelerator.synchronize()
+            active_ubatch[0] = 0  # Replay retains the ubatch captured above.
+            graph.replay()
+            torch.accelerator.synchronize()
+            expected_kv_c, expected_k_pe = expected_planes(alternate_layout, 22, dtype)
+            assert torch.equal(
+                captured_kv_c.view(torch.uint8), expected_kv_c.view(torch.uint8)
+            )
+            assert torch.equal(
+                captured_k_pe.view(torch.uint8), expected_k_pe.view(torch.uint8)
+            )
+            assert int(graph_workspace.epoch[1].item()) == (
+                int(epochs_before[1].item()) + 1
+            )
+            assert int(graph_workspace.epoch[0].item()) == int(epochs_before[0].item())
+            assert not torch.count_nonzero(graph_workspace.completion)
+            dist.barrier()
     finally:
         dist.destroy_process_group()
 
@@ -807,7 +1125,7 @@ def test_distributed_direct_kv_gather_matches_reference(world_size: int):
     _distributed_run(
         _distributed_direct_kv_gather_worker,
         world_size=world_size,
-        extra_env={},
+        extra_env={"TEST_CUDA_GRAPH": "1"},
     )
 
 

--- a/tests/v1/attention/test_mla_context_chunks.py
+++ b/tests/v1/attention/test_mla_context_chunks.py
@@ -8,10 +8,14 @@ chunk never covers a prefill without context (which is why the partial no
 longer needs an empty-span masking pass).
 """
 
+from types import SimpleNamespace
+
 import pytest
 import torch
 
+import vllm.model_executor.layers.attention.mla_attention as mla_attention
 from vllm.model_executor.layers.attention.mla_attention import (
+    build_dcp_kv_final_layout_dst_rows,
     build_mla_chunked_context_metadata,
     init_mla_context_partial,
     reorg_kvcache,
@@ -27,10 +31,16 @@ def build_chunked_context(
     block_size: int = BLOCK_SIZE,
     dcp_world_size: int = 1,
     dcp_local_block_size: int = 1,
+    dcp_manager=None,
 ):
     query_start_loc = torch.zeros(len(query_lens) + 1, dtype=torch.int32)
     query_start_loc[1:] = torch.tensor(query_lens, dtype=torch.int32).cumsum(0)
-    workspace_rows = workspace_size + workspace_size // dcp_world_size
+    if dcp_world_size == 1:
+        workspace_rows = workspace_size
+    elif dcp_manager is not None and dcp_manager.use_direct_kv_gather:
+        workspace_rows = workspace_size // dcp_world_size
+    else:
+        workspace_rows = workspace_size + workspace_size // dcp_world_size
     return build_mla_chunked_context_metadata(
         context_lens_cpu=torch.tensor(context_lens, dtype=torch.int32),
         prefill_query_start_loc_cpu=query_start_loc,
@@ -42,6 +52,7 @@ def build_chunked_context(
         dcp_world_size=dcp_world_size,
         dcp_local_block_size=dcp_local_block_size,
         dcp_virtual_block_size=dcp_local_block_size * dcp_world_size,
+        dcp_manager=dcp_manager,
     )
 
 
@@ -253,7 +264,7 @@ def test_dcp_reorg_uses_each_chunks_local_starts():
 
         toks = chunk.num_local_context_tokens
         rank_buffers = [torch.full((toks, 1, 1), -1) for _ in range(dcp_world_size)]
-        expected = []
+        expected: list[torch.Tensor] = []
         src_token_idx = 0
         for request, (padded_len, local_lens, local_start) in enumerate(
             zip(
@@ -286,3 +297,141 @@ def test_dcp_reorg_uses_each_chunks_local_starts():
         )
 
         torch.testing.assert_close(reorganized, torch.cat(expected))
+
+
+@pytest.mark.skip_global_cleanup
+def test_dcp_final_layout_dst_rows_maps_padding_and_continuations():
+    """The publish map is compact, disjoint, and skips padded local rows."""
+    padded_local_seq_lens = [4, 3]
+    local_context_lens_allranks = [[4, 3], [7, 5]]
+    local_starts = [0, 4]
+
+    rank_0 = build_dcp_kv_final_layout_dst_rows(
+        padded_local_seq_lens,
+        local_context_lens_allranks,
+        local_starts,
+        [7, 4],
+        dcp_rank=0,
+    )
+    rank_1 = build_dcp_kv_final_layout_dst_rows(
+        padded_local_seq_lens,
+        local_context_lens_allranks,
+        local_starts,
+        [7, 4],
+        dcp_rank=1,
+    )
+
+    assert rank_0.tolist() == [0, 1, 2, 3, 7, 8, 9]
+    assert rank_1.tolist() == [4, 5, 6, -1, 10, -1, -1]
+    valid_rows = sorted(row for row in [*rank_0.tolist(), *rank_1.tolist()] if row >= 0)
+    assert valid_rows == list(range(11))
+
+    zero_valid_maps = [
+        build_dcp_kv_final_layout_dst_rows(
+            padded_local_seq_lens=[2],
+            local_context_lens_allranks=[[4, 4, 3, 2]],
+            local_starts=[2],
+            output_seq_lens=[5],
+            dcp_rank=rank,
+        ).tolist()
+        for rank in range(4)
+    ]
+    assert zero_valid_maps == [[0, 1], [2, 3], [4, -1], [-1, -1]]
+
+
+@pytest.mark.skip_global_cleanup
+def test_dcp_final_layout_validates_each_request_exact_coverage():
+    """Equal batch totals cannot hide a gap in one request and overlap in another."""
+    with pytest.raises(ValueError, match="exactly cover request 0"):
+        build_dcp_kv_final_layout_dst_rows(
+            padded_local_seq_lens=[2, 2],
+            local_context_lens_allranks=[[1, 1], [2, 2]],
+            local_starts=[0, 0],
+            output_seq_lens=[3, 3],
+            dcp_rank=0,
+        )
+
+    mismatched_manager = SimpleNamespace(
+        use_direct_kv_gather=True,
+        group=SimpleNamespace(rank_in_group=0, world_size=4),
+    )
+    with pytest.raises(ValueError, match="world sizes differ"):
+        build_chunked_context(
+            [128],
+            [4],
+            1024,
+            dcp_world_size=2,
+            dcp_local_block_size=64,
+            dcp_manager=mismatched_manager,
+        )
+
+
+@pytest.mark.skip_global_cleanup
+def test_dcp_final_layout_publish_matches_reorg(monkeypatch):
+    """All source-rank maps jointly produce the existing compact layout."""
+    dcp_world_size, interleave, workspace_size = 2, 64, 1024
+    monkeypatch.setattr(mla_attention, "np_to_pinned_tensor", torch.from_numpy)
+    metadata_by_rank = []
+    for rank in range(dcp_world_size):
+        dcp_manager = SimpleNamespace(
+            use_direct_kv_gather=True,
+            group=SimpleNamespace(rank_in_group=rank, world_size=dcp_world_size),
+        )
+        metadata = build_chunked_context(
+            [3000, 200, 200],
+            [4, 4, 4],
+            workspace_size,
+            block_size=128,
+            dcp_world_size=dcp_world_size,
+            dcp_local_block_size=interleave,
+            dcp_manager=dcp_manager,
+        )
+        assert metadata is not None
+        assert metadata.workspace.shape[0] == workspace_size // dcp_world_size
+        assert all(
+            chunk.num_local_context_tokens <= workspace_size // dcp_world_size
+            for chunk in metadata.chunks
+        )
+        metadata_by_rank.append(metadata)
+
+    for chunk_index, chunk in enumerate(metadata_by_rank[0].chunks):
+        assert chunk.padded_local_seq_lens is not None
+        assert chunk.local_context_lens_allranks is not None
+        assert chunk.local_starts is not None
+
+        toks = chunk.num_local_context_tokens
+        compact = torch.full((chunk.num_context_tokens,), -1, dtype=torch.int64)
+        expected: list[list[torch.Tensor]] = []
+        for rank in range(dcp_world_size):
+            local = torch.full((toks,), -2, dtype=torch.int64)
+            src_token_idx = 0
+            for request, (padded_len, local_lens, local_start) in enumerate(
+                zip(
+                    chunk.padded_local_seq_lens,
+                    chunk.local_context_lens_allranks,
+                    chunk.local_starts,
+                )
+            ):
+                actual_len = min(max(0, local_lens[rank] - local_start), padded_len)
+                values = (
+                    request * 100_000
+                    + rank * 10_000
+                    + torch.arange(local_start, local_start + actual_len)
+                )
+                local[src_token_idx : src_token_idx + actual_len] = values
+                if rank == 0:
+                    expected.append([])
+                expected[request].append(values)
+                src_token_idx += padded_len
+
+            dst_rows = metadata_by_rank[rank].chunks[chunk_index].final_layout_dst_rows
+            assert dst_rows is not None
+            valid = dst_rows >= 0
+            assert torch.all(compact[dst_rows[valid]] == -1)
+            compact[dst_rows[valid]] = local[valid]
+
+        assert not torch.any(compact == -1)
+        torch.testing.assert_close(
+            compact,
+            torch.cat([torch.cat(request) for request in expected]),
+        )

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -1437,6 +1437,7 @@ class MLACommonPrefillMetadata:
         padded_local_token_to_seq: torch.Tensor | None = None
         num_local_context_tokens: int = 0
         local_starts: list[int] | None = None
+        final_layout_dst_rows: torch.Tensor | None = None
 
         @property
         def num_requests(self) -> int:
@@ -1707,6 +1708,69 @@ def _flat_int32(values: list[int] | np.ndarray) -> torch.Tensor:
     return np_to_pinned_tensor(np.asarray(values, dtype=np.int32))
 
 
+def build_dcp_kv_final_layout_dst_rows(
+    padded_local_seq_lens: list[int],
+    local_context_lens_allranks: list[list[int]],
+    local_starts: list[int],
+    output_seq_lens: list[int],
+    dcp_rank: int,
+) -> np.ndarray:
+    """Map padded local DCP rows to compact request-major output rows.
+
+    Local cache gathering packs every request into an equally padded segment on
+    every DCP rank.  The MLA consumer instead needs requests outermost and only
+    real rows from rank 0..N within each request.  Negative entries identify
+    local padding that the multicast publisher must skip.
+    """
+    if not (
+        len(padded_local_seq_lens)
+        == len(local_context_lens_allranks)
+        == len(local_starts)
+        == len(output_seq_lens)
+    ):
+        raise ValueError("DCP final-layout metadata must have equal request counts")
+    if not local_context_lens_allranks:
+        return np.empty(0, dtype=np.int32)
+    world_size = len(local_context_lens_allranks[0])
+    if world_size <= 1:
+        raise ValueError(
+            f"DCP final-layout metadata requires at least two ranks: {world_size}"
+        )
+    if not 0 <= dcp_rank < world_size:
+        raise ValueError(f"invalid DCP rank {dcp_rank} for world size {world_size}")
+
+    dst_rows: list[int] = []
+    request_output_start = 0
+    for request, (padded_len, context_lens, local_start, output_len) in enumerate(
+        zip(
+            padded_local_seq_lens,
+            local_context_lens_allranks,
+            local_starts,
+            output_seq_lens,
+            strict=True,
+        )
+    ):
+        if len(context_lens) != world_size:
+            raise ValueError("DCP final-layout metadata has inconsistent world sizes")
+        valid_lens = [
+            min(max(0, context_len - local_start), padded_len)
+            for context_len in context_lens
+        ]
+        covered = sum(valid_lens)
+        if covered != output_len:
+            raise ValueError(
+                "DCP final-layout rows do not exactly cover request "
+                f"{request}: rank lengths {valid_lens} cover {covered}, "
+                f"expected {output_len}"
+            )
+        local_valid = valid_lens[dcp_rank]
+        rank_output_start = request_output_start + sum(valid_lens[:dcp_rank])
+        dst_rows.extend(range(rank_output_start, rank_output_start + local_valid))
+        dst_rows.extend([-1] * (padded_len - local_valid))
+        request_output_start += output_len
+    return np.asarray(dst_rows, dtype=np.int32)
+
+
 def align_mla_chunked_context_workspace_size(
     vllm_config: VllmConfig,
     workspace_size: int,
@@ -1823,6 +1887,7 @@ def build_mla_chunked_context_metadata(
     token_to_seq_parts: list[np.ndarray] = []
     padded_local_cu_seq_lens_flat: list[int] = []
     padded_local_token_to_seq_parts: list[np.ndarray] = []
+    final_layout_dst_rows_parts: list[np.ndarray] = []
     local_starts_per_chunk: list[list[int]] = []
     local_seq_lens_per_chunk: list[list[int]] = []
     layouts: list[tuple[slice, slice, slice, slice]] = []
@@ -1864,6 +1929,24 @@ def build_mla_chunked_context_metadata(
                 np.repeat(np.arange(num_requests, dtype=np.int32), local_seq_lens)
             )
             num_local_tokens = sum(local_seq_lens)
+            if dcp_manager is not None and dcp_manager.use_direct_kv_gather:
+                assert local_context_lens_allranks is not None
+                if dcp_manager.group.world_size != dcp_world_size:
+                    raise ValueError(
+                        "DCP group and chunk metadata world sizes differ: "
+                        f"{dcp_manager.group.world_size} != {dcp_world_size}"
+                    )
+                request_context_lens = local_context_lens_allranks[
+                    plan.request_start : plan.request_end
+                ]
+                final_layout_dst_rows = build_dcp_kv_final_layout_dst_rows(
+                    local_seq_lens,
+                    request_context_lens,
+                    local_starts,
+                    plan.seq_lens,
+                    dcp_manager.group.rank_in_group,
+                )
+                final_layout_dst_rows_parts.append(final_layout_dst_rows)
             # The gather takes per-rank local offsets under DCP.
             starts_flat.extend(local_starts)
         else:
@@ -1897,6 +1980,13 @@ def build_mla_chunked_context_metadata(
         padded_local_token_to_seq = _flat_int32(
             np.concatenate(padded_local_token_to_seq_parts)
         ).to(device, non_blocking=True)
+        final_layout_dst_rows = (
+            _flat_int32(np.concatenate(final_layout_dst_rows_parts)).to(
+                device, non_blocking=True
+            )
+            if final_layout_dst_rows_parts
+            else None
+        )
 
     chunks: list[MLACommonPrefillMetadata.ContextChunk] = []
     for index, (plan, layout) in enumerate(zip(plans, layouts)):
@@ -1934,6 +2024,8 @@ def build_mla_chunked_context_metadata(
                 local_token_slice
             ]
             chunk.local_starts = local_starts_per_chunk[index]
+            if final_layout_dst_rows is not None:
+                chunk.final_layout_dst_rows = final_layout_dst_rows[local_token_slice]
         chunks.append(chunk)
 
     return MLACommonPrefillMetadata.ChunkedContextMetadata(
@@ -2105,27 +2197,33 @@ class MLACommonMetadataBuilder(AttentionMetadataBuilder[M]):
         use_packed_fp8_cache = vllm_config.cache_config.cache_dtype == "fp8_ds_mla"
         self.dcp_manager: MLADCPManager | None = None
         if self.dcp_world_size > 1:
-            # Note(hc): The local kvcache is incomplete when DCP is triggered,
-            # an additional kvcache allgather across the DCP group is therefore
-            # required, so the workspace has to be enlarged by 1/DCP relative
-            # to the original TP allocation.
             assert self.chunked_prefill_workspace_size % self.dcp_world_size == 0
-            self.chunked_prefill_workspace = torch.empty(
-                (
-                    self.chunked_prefill_workspace_size
-                    + self.chunked_prefill_workspace_size // self.dcp_world_size,
-                    self.mla_dims.kv_lora_rank + self.mla_dims.qk_rope_head_dim,
-                ),
-                dtype=torch.bfloat16
-                if use_packed_fp8_cache
-                else self.model_config.dtype,
-                device=device,
+            workspace_dtype = (
+                torch.bfloat16 if use_packed_fp8_cache else self.model_config.dtype
+            )
+            workspace_head_size = (
+                self.mla_dims.kv_lora_rank + self.mla_dims.qk_rope_head_dim
             )
             self.dcp_manager = getattr(attention_layer, "dcp_manager", None)
             assert isinstance(self.dcp_manager, MLADCPManager)
-            self.dcp_manager.init_kv_gather(
-                self.chunked_prefill_workspace,
+            use_direct_kv_gather = self.dcp_manager.init_kv_gather(
                 self.chunked_prefill_workspace_size,
+                workspace_head_size,
+                self.mla_dims.kv_lora_rank,
+                workspace_dtype,
+            )
+            # The direct path only materializes this rank's padded rows.  NCCL
+            # additionally needs a rank-major destination for every rank.
+            local_rows = self.chunked_prefill_workspace_size // self.dcp_world_size
+            workspace_rows = (
+                local_rows
+                if use_direct_kv_gather
+                else self.chunked_prefill_workspace_size + local_rows
+            )
+            self.chunked_prefill_workspace = torch.empty(
+                (workspace_rows, workspace_head_size),
+                dtype=workspace_dtype,
+                device=device,
             )
         else:
             self.chunked_prefill_workspace = torch.empty(
@@ -2733,38 +2831,55 @@ class MLACommonBaseImpl(MLAAttentionImpl[A], Generic[A]):
                     batch_size=chunk.num_requests,
                     seq_starts=chunk.starts,
                 )
-            # workspace
-            # |------- N tokens --------|--------- N*dcp_size tokens ----------|
-            # |<- use for local_gather ->|<--------- use for allgather -------->|
-            allgather_offset = workspace.shape[0] // (dcp_world_size + 1)
-            assert allgather_offset * (dcp_world_size + 1) == workspace.shape[0]
-            assert toks <= allgather_offset
-            local_gathered_kvcache = workspace[:toks]
-            cur_allgather_workspace = workspace[
-                allgather_offset : allgather_offset * (1 + dcp_world_size)
-            ]
-            assert toks * dcp_world_size <= cur_allgather_workspace.shape[0]
-            cur_allgather_kvcache = cur_allgather_workspace[: toks * dcp_world_size]
             dcp_manager = cast(MLADCPManager, chunked_context.dcp_manager)
-            dcp_manager.kv_gather(cur_allgather_kvcache, local_gathered_kvcache)
-            assert (
-                cur_allgather_kvcache.shape[-1]
-                == self.kv_lora_rank + self.qk_rope_head_dim
-            )
-            allgatered_kv_c_normed, allgatered_k_pe = cur_allgather_kvcache.unsqueeze(
-                1
-            ).split([self.kv_lora_rank, self.qk_rope_head_dim], dim=-1)
-
-            kv_c_normed, k_pe = reorg_kvcache(
-                allgatered_kv_c_normed,
-                allgatered_k_pe,
-                padded_local_chunk_seq_lens_lst=chunk.padded_local_seq_lens,
-                local_context_lens_allranks=chunk.local_context_lens_allranks,
-                local_starts=chunk.local_starts,
-                sum_seq_len=chunk.num_context_tokens,
-                max_seq_len=chunk.max_seq_len,
-                toks=toks,
-            )
+            if dcp_manager.use_direct_kv_gather:
+                assert toks <= workspace.shape[0]
+                local_gathered_kvcache = workspace[:toks]
+                assert chunk.final_layout_dst_rows is not None
+                kv_c_normed, k_pe = dcp_manager.direct_kv_gather(
+                    local_gathered_kvcache,
+                    chunk.final_layout_dst_rows,
+                    chunk.num_context_tokens,
+                    # The next gather synchronizes alternating chunks. The TP
+                    # output collective synchronizes the final chunk before
+                    # the next layer/forward resets the slot to zero.
+                    chunk.index & 1,
+                )
+                assert kv_c_normed.is_contiguous()
+                assert k_pe.is_contiguous()
+            else:
+                # workspace
+                # |------- N tokens --------|------ N*dcp_size tokens -------|
+                # |<- use for local gather ->|<------ use for allgather ----->|
+                allgather_offset = workspace.shape[0] // (dcp_world_size + 1)
+                assert allgather_offset * (dcp_world_size + 1) == workspace.shape[0]
+                assert toks <= allgather_offset
+                local_gathered_kvcache = workspace[:toks]
+                cur_allgather_workspace = workspace[
+                    allgather_offset : allgather_offset * (1 + dcp_world_size)
+                ]
+                assert toks * dcp_world_size <= cur_allgather_workspace.shape[0]
+                cur_allgather_kvcache = cur_allgather_workspace[: toks * dcp_world_size]
+                dcp_manager.kv_gather(cur_allgather_kvcache, local_gathered_kvcache)
+                assert (
+                    cur_allgather_kvcache.shape[-1]
+                    == self.kv_lora_rank + self.qk_rope_head_dim
+                )
+                allgatered_kv_c_normed, allgatered_k_pe = (
+                    cur_allgather_kvcache.unsqueeze(1).split(
+                        [self.kv_lora_rank, self.qk_rope_head_dim], dim=-1
+                    )
+                )
+                kv_c_normed, k_pe = reorg_kvcache(
+                    allgatered_kv_c_normed,
+                    allgatered_k_pe,
+                    padded_local_chunk_seq_lens_lst=chunk.padded_local_seq_lens,
+                    local_context_lens_allranks=chunk.local_context_lens_allranks,
+                    local_starts=chunk.local_starts,
+                    sum_seq_len=chunk.num_context_tokens,
+                    max_seq_len=chunk.max_seq_len,
+                    toks=toks,
+                )
             if kv_b_proj_input_dtype is not None:
                 kv_c_normed = kv_c_normed.to(kv_b_proj_input_dtype)
 

--- a/vllm/model_executor/layers/attention/sparse_mla_attention.py
+++ b/vllm/model_executor/layers/attention/sparse_mla_attention.py
@@ -140,16 +140,6 @@ class SparseMLACommonMetadataBuilder(AttentionMetadataBuilder[T]):
             self.mla_dims.kv_lora_rank + self.mla_dims.qk_rope_head_dim
         )
         workspace_rows = self.chunked_prefill_workspace_size
-        if self.dcp_world_size > 1:
-            # DCP gathers each rank's local KV shard into the workspace, so it
-            # needs an extra 1/DCP rows beyond the TP allocation.
-            assert self.chunked_prefill_workspace_size % self.dcp_world_size == 0
-            workspace_rows += self.chunked_prefill_workspace_size // self.dcp_world_size
-        self.chunked_prefill_workspace = torch.empty(
-            (workspace_rows, workspace_head_size),
-            dtype=self.model_config.dtype,
-            device=device,
-        )
         self.topk_mask_workspace: torch.Tensor | None = None
         if _is_masked_mha_available(
             self.model_config.model_arch_config.total_num_attention_heads,
@@ -170,13 +160,31 @@ class SparseMLACommonMetadataBuilder(AttentionMetadataBuilder[T]):
         layer_prefill_backend = attention_layer.prefill_backend
         self.dcp_manager: MLADCPManager | None = None
         if self.dcp_world_size > 1:
+            assert self.chunked_prefill_workspace_size % self.dcp_world_size == 0
             self.dcp_manager = getattr(attention_layer, "dcp_manager", None)
             assert isinstance(self.dcp_manager, MLADCPManager)
             if layer_prefill_backend is not None:
-                self.dcp_manager.init_kv_gather(
-                    self.chunked_prefill_workspace,
+                use_direct_kv_gather = self.dcp_manager.init_kv_gather(
                     self.chunked_prefill_workspace_size,
+                    workspace_head_size,
+                    self.mla_dims.kv_lora_rank,
+                    self.model_config.dtype,
                 )
+                local_rows = self.chunked_prefill_workspace_size // self.dcp_world_size
+                workspace_rows = (
+                    local_rows
+                    if use_direct_kv_gather
+                    else self.chunked_prefill_workspace_size + local_rows
+                )
+            else:
+                workspace_rows += (
+                    self.chunked_prefill_workspace_size // self.dcp_world_size
+                )
+        self.chunked_prefill_workspace = torch.empty(
+            (workspace_rows, workspace_head_size),
+            dtype=self.model_config.dtype,
+            device=device,
+        )
         self._prefill_backend = (
             layer_prefill_backend.clone() if layer_prefill_backend is not None else None
         )

--- a/vllm/models/kimi_k3/nvidia/mla.py
+++ b/vllm/models/kimi_k3/nvidia/mla.py
@@ -749,8 +749,9 @@ class MultiHeadLatentAttention(nn.Module, AttentionLayerBase):
         copied per chunk.
 
         Decode context parallelism keeps using
-        ``impl._context_parallel_compute_prefill_context``; its extra allgather
-        and reorg are not fused here.
+        ``impl._context_parallel_compute_prefill_context``. Its NCCL fallback
+        retains the extra all-gather and reorganization; the direct symmetric
+        path publishes into the compact MLA layout instead.
         """
         prefill = attn_metadata.prefill
         assert prefill is not None

--- a/vllm/v1/attention/ops/dcp_utils.py
+++ b/vllm/v1/attention/ops/dcp_utils.py
@@ -472,12 +472,31 @@ _KV_GATHER_SUPPORTED_DTYPES = (
 )
 
 
-def _kv_gather_layout_supported(token_dim: int, dtype: torch.dtype) -> bool:
-    return token_dim * torch.empty((), dtype=dtype).element_size() % 16 == 0
+def _kv_gather_layout_supported(
+    token_dim: int,
+    plane_split_dim: int,
+    dtype: torch.dtype,
+) -> bool:
+    """Whether both packed output planes support 16-byte multicast stores."""
+    if not 0 < plane_split_dim < token_dim:
+        return False
+    element_size = torch.empty((), dtype=dtype).element_size()
+    return (
+        plane_split_dim * element_size % 16 == 0
+        and (token_dim - plane_split_dim) * element_size % 16 == 0
+    )
 
 
 class DirectDCPKVGatherWorkspace(_DirectDCPWorkspace):
-    """Persistent symmetric buffers for direct DCP KV gather."""
+    """Persistent symmetric buffers for direct DCP KV gather.
+
+    Storage is owned by ``(DBO ubatch, buffer slot)``. Different ubatches have
+    disjoint buffers and may run independently. Within one ubatch, publishing
+    and consumption must remain stream ordered. Before reusing the same slot,
+    every rank must have consumed it and reached either a gather on the other
+    slot or another all-rank rendezvous. Concurrent same-ubatch use from
+    multiple streams is not supported.
+    """
 
     def __init__(
         self,
@@ -485,6 +504,7 @@ class DirectDCPKVGatherWorkspace(_DirectDCPWorkspace):
         device: torch.device,
         max_gathered_tokens: int,
         token_dim: int,
+        plane_split_dim: int,
         dtype: torch.dtype = torch.bfloat16,
         num_ubatches: int = 1,
     ) -> None:
@@ -500,8 +520,10 @@ class DirectDCPKVGatherWorkspace(_DirectDCPWorkspace):
                 "Direct DCP kv-gather dimensions must be positive, got "
                 f"T={max_gathered_tokens}, D={token_dim}"
             )
-        if not _kv_gather_layout_supported(token_dim, dtype):
-            raise ValueError("Direct DCP kv-gather requires 16-byte-aligned KV rows.")
+        if not _kv_gather_layout_supported(token_dim, plane_split_dim, dtype):
+            raise ValueError(
+                "Direct DCP kv-gather requires two nonempty 16-byte-aligned KV planes."
+            )
         super().__init__(group, device, num_ubatches)
         if self.world_size <= 1:
             raise ValueError("Direct DCP kv-gather requires at least two ranks")
@@ -511,6 +533,8 @@ class DirectDCPKVGatherWorkspace(_DirectDCPWorkspace):
                 f"ranks: {max_gathered_tokens} % {self.world_size} != 0"
             )
         self.max_gathered_tokens = max_gathered_tokens
+        self.token_dim = token_dim
+        self.plane_split_dim = plane_split_dim
 
         kv_shape = (num_ubatches, 2, max_gathered_tokens, token_dim)
         signal_shape = (num_ubatches, 2, self.world_size)
@@ -528,26 +552,48 @@ class DirectDCPKVGatherWorkspace(_DirectDCPWorkspace):
         self.completion = self.received_signal.new_zeros((num_ubatches, 2))
         torch.accelerator.synchronize()
 
-    def gather(self, gathered_kv: torch.Tensor, local_kv: torch.Tensor) -> None:
+    def gather(
+        self,
+        local_kv: torch.Tensor,
+        dst_rows: torch.Tensor,
+        output_tokens: int,
+        buffer_slot: int,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Publish valid rows into compact request-major KV planes."""
         ubatch = dbo_current_ubatch_id()
         if not 0 <= ubatch < self.num_ubatches:
             raise ValueError(
                 f"DCP kv-gather ubatch {ubatch} exceeds {self.num_ubatches} slots"
             )
+        # The custom op validates the dynamic tensor geometry, dtype, device,
+        # capacity, and slot before launching. Avoid duplicating those checks on
+        # this latency-sensitive host path.
+        token_dim = self.token_dim
+        plane_split_dim = self.plane_split_dim
         kv_multicast_ptr, signal_multicast_ptr = self.multicast_ptrs[ubatch]
         torch.ops._C.direct_dcp_kv_gather(
             local_kv,
+            dst_rows,
             self.received_kv[ubatch],
             self.received_signal[ubatch],
             self.completion[ubatch],
             self.epoch[ubatch : ubatch + 1],
-            gathered_kv,
+            output_tokens,
+            plane_split_dim,
+            buffer_slot,
             self.world_size,
             self.rank,
             self.max_gathered_tokens,
             kv_multicast_ptr,
             signal_multicast_ptr,
         )
+        slot = self.received_kv[ubatch, buffer_slot].view(-1)
+        kv_c_capacity = self.max_gathered_tokens * plane_split_dim
+        kv_c = slot[:kv_c_capacity].view(self.max_gathered_tokens, 1, plane_split_dim)
+        k_pe = slot[kv_c_capacity:].view(
+            self.max_gathered_tokens, 1, token_dim - plane_split_dim
+        )
+        return kv_c[:output_tokens], k_pe[:output_tokens]
 
 
 @functools.cache
@@ -556,6 +602,7 @@ def get_direct_dcp_kv_gather_workspace(
     device: torch.device,
     max_gathered_tokens: int,
     token_dim: int,
+    plane_split_dim: int,
     dtype: torch.dtype,
     num_ubatches: int,
 ) -> DirectDCPKVGatherWorkspace | None:
@@ -566,13 +613,14 @@ def get_direct_dcp_kv_gather_workspace(
         _KV_GATHER_SUPPORTED_DTYPES,
     ):
         return None
-    if not _kv_gather_layout_supported(token_dim, dtype):
+    if not _kv_gather_layout_supported(token_dim, plane_split_dim, dtype):
         return None
     return DirectDCPKVGatherWorkspace(
         group.device_group,
         device,
         max_gathered_tokens,
         token_dim,
+        plane_split_dim,
         dtype,
         num_ubatches,
     )
@@ -592,7 +640,7 @@ class DCPCombine(Protocol):
 class MLADCPManager:
     """Select and own layer-level collective implementations for MLA DCP."""
 
-    _kv_gather: Callable[[torch.Tensor, torch.Tensor], object]
+    _kv_gather: Callable[[torch.Tensor, torch.Tensor], object] | None
 
     def __init__(
         self,
@@ -614,6 +662,8 @@ class MLADCPManager:
         self.max_num_tokens = get_dcp_workspace_max_num_tokens(vllm_config)
         self.use_a2a = parallel_config.dcp_comm_backend == "a2a"
         self.padded_num_heads = padded_num_heads
+        self._direct_kv_gather_workspace: DirectDCPKVGatherWorkspace | None = None
+        self._kv_gather = None
 
         self.combine = self._init_combine(
             num_heads,
@@ -700,41 +750,77 @@ class MLADCPManager:
 
     def init_kv_gather(
         self,
-        workspace: torch.Tensor,
         max_gathered_tokens: int,
-    ) -> None:
+        token_dim: int,
+        plane_split_dim: int,
+        dtype: torch.dtype,
+    ) -> bool:
+        """Select the KV collective before allocating its local scratch.
+
+        Returns whether the direct final-layout publisher was selected.  That
+        path only needs one rank's local rows; the fallback additionally needs
+        a rank-major all-gather destination.
+        """
         world_size = self.group.world_size
-        assert max_gathered_tokens > 0
-        assert max_gathered_tokens % world_size == 0
-        assert workspace.ndim == 2
-        assert workspace.is_contiguous()
-        assert workspace.shape[0] == (
-            max_gathered_tokens + max_gathered_tokens // world_size
-        )
-        assert workspace.shape[1] > 0
+        if max_gathered_tokens <= 0 or max_gathered_tokens % world_size != 0:
+            raise ValueError(
+                "DCP KV gather capacity must be positive and divide evenly "
+                f"across {world_size} ranks, got {max_gathered_tokens}"
+            )
+        if token_dim <= 0:
+            raise ValueError(
+                f"DCP KV gather token dimension must be positive: {token_dim}"
+            )
 
         direct_workspace = get_direct_dcp_kv_gather_workspace(
             self.group,
-            workspace.device,
+            self.device,
             max_gathered_tokens,
-            workspace.shape[1],
-            workspace.dtype,
+            token_dim,
+            plane_split_dim,
+            dtype,
             self.num_ubatches,
         )
+        self._direct_kv_gather_workspace = direct_workspace
         if direct_workspace is not None:
             logger.info_once(
-                "Using direct symmetric-memory DCP chunked-context KV gather for MLA."
+                "Using direct symmetric-memory DCP final-layout KV multicast for MLA."
             )
-            self._kv_gather = direct_workspace.gather
+            self._kv_gather = None
         else:
             self._kv_gather = functools.partial(
                 torch.distributed.all_gather_into_tensor,
                 group=self.group.device_group,
             )
+        return direct_workspace is not None
+
+    @property
+    def use_direct_kv_gather(self) -> bool:
+        return self._direct_kv_gather_workspace is not None
 
     def kv_gather(
         self,
         gathered_kv: torch.Tensor,
         local_kv: torch.Tensor,
     ) -> object:
-        return self._kv_gather(gathered_kv, local_kv)
+        kv_gather = self._kv_gather
+        if kv_gather is None:
+            raise RuntimeError("NCCL DCP KV gather is not selected")
+        return kv_gather(gathered_kv, local_kv)
+
+    def direct_kv_gather(
+        self,
+        local_kv: torch.Tensor,
+        dst_rows: torch.Tensor,
+        output_tokens: int,
+        buffer_slot: int,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        workspace = self._direct_kv_gather_workspace
+        if not self.use_direct_kv_gather or workspace is None:
+            raise RuntimeError("direct DCP KV gather is not enabled")
+        return workspace.gather(
+            local_kv,
+            dst_rows,
+            output_tokens,
+            buffer_slot,
+        )


### PR DESCRIPTION
## Summary

Replace the direct DCP prefill KV path's rank-major gather, local materialization, and Python reorganization with a multicast publisher that writes valid rows directly into the compact request-major MLA layout.

- Publish separate contiguous `kv_c` and `k_pe` planes using per-chunk destination-row metadata.
- Skip DCP padding rather than copying and removing it afterward.
- Keep two ping-pong slots per DBO ubatch; different ubatches never alias.
- Reduce direct-path local scratch from rank-major gathered storage to this rank's padded rows.
- Preserve the NCCL all-gather/reorganization fallback when multicast, dtype, or plane alignment is unsupported.

## Buffer lifetime

The returned tensors alias symmetric memory. Within an ubatch, consumption stays on the same stream. A gather on the alternate slot is the all-rank rendezvous that makes the previous slot reusable; after the final context chunk, the tensor-parallel output collective is the post-consumption rendezvous before the next layer/forward resets to slot 0. DBO ubatches own disjoint slot pairs.

The distributed test covers both transitions without an explicit barrier in the critical sequence, including asymmetric delayed consumption.

## Validation

- Pre-commit suite: Ruff lint/format, mypy, clang-format 21.1.2, typos, SPDX, config validation, and repository checks.
- Unit coverage for exact destination maps, continuation/padding handling, per-request coverage, DCP-group geometry, direct/fallback scratch sizing, and sparse-MLA compatibility.
- Distributed coverage for BF16/FP16/FP8 byte-exact publication, zero-copy plane aliases, stale tails, completion/epoch state, DBO isolation, ping-pong lifetime, downstream-collective lifetime, and CUDA graph replay.
- Clean Linux/GB300 source build at `888f83d3`; 14/14 context-map tests and the focused four-rank direct-KV publication/lifetime test passed. The PR remains a draft for maintainer review.

## Paired benchmark evidence

On the pinned Kimi-K3 prototype tree (`0a131869`, tree `47c98e9`), using identical 8-GPU TP8+EP8+model-SP engines with replicated shared experts and the same controlled 60K–180K prefill workload:

| topology | fixed cohort 14 (5 requests) P50 TTFT | max passing offered QPS | first 15s/25s SLA miss |
|---|---:|---:|---:|
| pure TP8 | 3.130 s | 1.15 | 1.175 |
| direct DCP8, final-layout KV | 3.149 s | 1.15 | 1.175 |

At the 1.15-QPS boundary, DCP8 was 127 ms behind TP8 at P50 while exposing about 7.5x the KV-token capacity. This PR deliberately excludes the benchmark harness, scheduler observability, connector changes, MRV2 block-table fix, and DeepGEMM compatibility fix from that tested tree.

## Scope

This builds on the merged DCP implementation from #50484 and preserves the current fused Kimi-K3 chunked-context K/V packing path. No scheduler, model-weight, or benchmark-only changes are included.
