### PR TITLE
[Quantization] Clarify MXFP4 MoE W13 layout requirement from backends

### DIFF
--- a/tests/kernels/moe/test_ocp_mx_moe.py
+++ b/tests/kernels/moe/test_ocp_mx_moe.py
@@ -1495,7 +1495,6 @@ ROCM_BACKEND_CONFIGS = {
         "requires_gfx950": False,
         "backend_override": "EMULATION",
     },
->>>>>>> 2d7822bf3d (Aggressive refactor: fully deprecate gpt-oss methods)
 }
 
 

--- a/tests/kernels/moe/test_ocp_mx_moe.py
+++ b/tests/kernels/moe/test_ocp_mx_moe.py
@@ -238,13 +238,19 @@ def reference_moe(
     # Apply activation
     if activation in ("swiglu", "silu"):
         if use_interleaved_layout:
-            # SWIGLUOAI: interleaved gate/up layout
             t = swigluoai(t, alpha=alpha, limit=limit)
         else:
-            # Standard swiglu/silu: chunked layout
             t = swiglu(t, alpha=alpha, beta=beta, limit=limit)
+    elif activation == "gelu":
+        gate, up = torch.chunk(t, 2, dim=-1)
+        gate = torch.nn.functional.gelu(gate)
+        t = gate * up
+    elif activation == "situ":
+        gate, up = torch.chunk(t, 2, dim=-1)
+        situ_beta = alpha  # reuse alpha param for situ_beta
+        gate_out = situ_beta * torch.tanh(gate / situ_beta) / (1.0 + torch.exp(-gate))
+        t = gate_out * up
     elif activation == "relu2":
-        # RELU2_NO_MUL: relu(x)^2
         t = torch.relu(t)
         t = t * t
     else:
@@ -1391,13 +1397,64 @@ ROCM_BACKEND_CONFIGS = {
         "requires_aiter": False,
         "requires_gfx950": False,
     },
+    "TRITON_UNFUSED__SILU": {
+        "activation": "SILU",
+        "rtol": 0.3,
+        "percent": 0.95,
+        "requires_aiter": False,
+        "requires_gfx950": False,
+        "backend_override": "TRITON_UNFUSED",
+    },
+    "TRITON_UNFUSED__SWIGLUOAI_UNINTERLEAVE": {
+        "activation": "SWIGLUOAI_UNINTERLEAVE",
+        "rtol": 0.5,
+        "percent": 0.8,
+        "requires_aiter": False,
+        "requires_gfx950": False,
+        "backend_override": "TRITON_UNFUSED",
+    },
     "AITER_MXFP4_BF16": {
         "activation": "SWIGLUOAI",
+        "rtol": 0.1,
+        "percent": 0.6,
+        "requires_aiter": True,
+        "requires_gfx950": True,
+    },
+    "AITER_MXFP4_BF16__SILU": {
+        "activation": "SILU",
         "rtol": 0.1,
         "percent": 0.7,
         "requires_aiter": True,
         "requires_gfx950": True,
+        "backend_override": "AITER_MXFP4_BF16",
     },
+    "AITER_MXFP4_BF16__GELU": {
+        "activation": "GELU",
+        "rtol": 0.1,
+        "percent": 0.7,
+        "requires_aiter": True,
+        "requires_gfx950": True,
+        "backend_override": "AITER_MXFP4_BF16",
+    },
+    "AITER_MXFP4_BF16__SWIGLUOAI_UNINTERLEAVE": {
+        "activation": "SWIGLUOAI_UNINTERLEAVE",
+        "rtol": 0.1,
+        "percent": 0.6,
+        "requires_aiter": True,
+        "requires_gfx950": True,
+        "backend_override": "AITER_MXFP4_BF16",
+    },
+    # SITU: AITER doesn't register situ activation type yet
+    # (get_aiter_activation_type("situ") returns None on gfx950).
+    # Uncomment once AITER adds SITU support.
+    # "AITER_MXFP4_BF16__SITU": {
+    #     "activation": "SITU",
+    #     "rtol": 0.1,
+    #     "percent": 0.7,
+    #     "requires_aiter": True,
+    #     "requires_gfx950": True,
+    #     "backend_override": "AITER_MXFP4_BF16",
+    # },
     "AITER_MXFP4_FP8": {
         "activation": "SWIGLUOAI",
         "rtol": 0.5,
@@ -1406,17 +1463,44 @@ ROCM_BACKEND_CONFIGS = {
         "requires_gfx950": True,
     },
     "AITER_MXFP4_MXFP4": {
+        "activation": "SWIGLUOAI",
+        "rtol": 1.0,
+        "percent": 0.55,
+        "cosine_threshold": 0.6,
+        "requires_aiter": True,
+        "requires_gfx950": True,
+    },
+    "AITER_MXFP4_MXFP4__SILU": {
         "activation": "SILU",
         "act_type": "mxfp4",
         "rtol": 1.0,
         "percent": 0.8,
         "requires_aiter": True,
         "requires_gfx950": True,
+        "backend_override": "AITER_MXFP4_MXFP4",
     },
+    "EMULATION": {
+        "activation": "SWIGLUOAI",
+        "rtol": 0.5,
+        "percent": 0.6,
+        "requires_aiter": False,
+        "requires_gfx950": False,
+    },
+    "EMULATION__SILU": {
+        "activation": "SILU",
+        "rtol": 0.5,
+        "percent": 0.5,
+        "cosine_threshold": 0.85,
+        "requires_aiter": False,
+        "requires_gfx950": False,
+        "backend_override": "EMULATION",
+    },
+>>>>>>> 2d7822bf3d (Aggressive refactor: fully deprecate gpt-oss methods)
 }
 
 
 @pytest.mark.parametrize("backend_name", list(ROCM_BACKEND_CONFIGS.keys()))
+@pytest.mark.parametrize("input_layout", ["CONTIGUOUS_W1W3", "INTERLEAVED_W1W3"])
 @pytest.mark.parametrize("topk", [4])
 @pytest.mark.parametrize("num_experts", [8])
 @pytest.mark.parametrize("num_tokens,hidden_size,intermediate_size", [(16, 256, 256)])
@@ -1427,6 +1511,7 @@ ROCM_BACKEND_CONFIGS = {
 @torch.inference_mode()
 def test_rocm_mxfp4_moe_oracle(
     backend_name: str,
+    input_layout: str,
     topk: int,
     num_experts: int,
     num_tokens: int,
@@ -1438,8 +1523,8 @@ def test_rocm_mxfp4_moe_oracle(
     Test ROCm MXFP4 MoE using oracle functions.
 
     This test validates that the oracle functions work end-to-end:
-    - select_mxfp4_moe_backend() selects a valid backend
-    - convert_gpt_oss_weight_to_mxfp4_moe_kernel_format() converts weights without error
+    - convert_weight_to_mxfp4_moe_kernel_format() converts weights correctly
+      for both CONTIGUOUS_W1W3 and INTERLEAVED_W1W3 input layouts
     - make_mxfp4_moe_quant_config() builds a valid quant config
     - make_mxfp4_moe_kernel() creates a kernel that runs without error
     - The kernel output is within accuracy tolerance of reference
@@ -1457,10 +1542,12 @@ def test_rocm_mxfp4_moe_oracle(
     import vllm.distributed.parallel_state as ps
     from vllm.config import VllmConfig, set_current_vllm_config
     from vllm.model_executor.layers.fused_moe.activation import MoEActivation
+    from vllm.model_executor.layers.fused_moe.modular_kernel import W13Layout
     from vllm.model_executor.layers.fused_moe.oracle.mxfp4 import (
         Mxfp4MoeBackend,
+        _interleave_w13,
         backend_to_kernel_cls,
-        convert_gpt_oss_weight_to_mxfp4_moe_kernel_format,
+        convert_weight_to_mxfp4_moe_kernel_format,
         make_mxfp4_moe_kernel,
         make_mxfp4_moe_quant_config,
     )
@@ -1475,16 +1562,20 @@ def test_rocm_mxfp4_moe_oracle(
     # AITER must be enabled or aiter_mxfp4_w4a8_moe asserts before dispatch.
     monkeypatch.setattr(rocm_aiter_ops, "_AITER_ENABLED", True)
 
-    # Map string to enum
-    backend = Mxfp4MoeBackend[backend_name]
+    # Map string to enum (handle backend_override for activation variants)
+    actual_backend_name = config.get("backend_override", backend_name)
+    backend = Mxfp4MoeBackend[actual_backend_name]
 
     # Get experts class from oracle
     experts_cls_list = backend_to_kernel_cls(backend)
     if experts_cls_list is None or len(experts_cls_list) == 0:
-        pytest.skip(f"Backend {backend_name} not available")
+        pytest.skip(f"Backend {actual_backend_name} not available")
 
     # Use first experts class
     experts_cls = experts_cls_list[0]
+
+    # Resolve input layout enum
+    w13_layout = W13Layout[input_layout]
 
     torch.manual_seed(42)
     dtype = torch.bfloat16
@@ -1549,10 +1640,23 @@ def test_rocm_mxfp4_moe_oracle(
     # Create static input scales for W4A8 backend (AITER_MXFP4_FP8)
     w13_input_scale: torch.Tensor | None = None
     w2_input_scale: torch.Tensor | None = None
-    if backend_name == "AITER_MXFP4_FP8":
+    if actual_backend_name == "AITER_MXFP4_FP8":
         # Static FP8 scales: one scale per expert
         w13_input_scale = torch.ones(num_experts, dtype=torch.float32, device=device)
         w2_input_scale = torch.ones(num_experts, dtype=torch.float32, device=device)
+
+    # Select activation based on backend config
+    activation_name = str(config["activation"])
+    activation = MoEActivation[activation_name]
+
+    # Save contiguous bias refs before potential interleaving
+    w13_bias_ref = w13_bias.clone()
+    w2_bias_ref = w2_bias.clone()
+
+    # Prepare input layout: quantized weights start as CONTIGUOUS_W1W3,
+    # interleave if the test requests INTERLEAVED_W1W3 input.
+    if w13_layout == W13Layout.INTERLEAVED_W1W3:
+        w13_quant, w13_scale, w13_bias = _interleave_w13(w13_quant, w13_scale, w13_bias)
 
     # Create mock layer for oracle functions
     class MockLayer:
@@ -1562,6 +1666,7 @@ def test_rocm_mxfp4_moe_oracle(
         w2_weight_scale: torch.Tensor
         w13_input_scale: torch.Tensor | None
         w2_input_scale: torch.Tensor | None
+        activation: MoEActivation
 
     layer = MockLayer()
     layer.w13_weight = w13_quant
@@ -1570,10 +1675,11 @@ def test_rocm_mxfp4_moe_oracle(
     layer.w2_weight_scale = w2_scale
     layer.w13_input_scale = w13_input_scale
     layer.w2_input_scale = w2_input_scale
+    layer.activation = activation
 
     # Convert weights using oracle
     w13_conv, w2_conv, w13_scale_conv, w2_scale_conv, w13_bias_conv, w2_bias_conv = (
-        convert_gpt_oss_weight_to_mxfp4_moe_kernel_format(
+        convert_weight_to_mxfp4_moe_kernel_format(
             mxfp4_backend=backend,
             layer=layer,  # type: ignore[arg-type]
             w13_weight=w13_quant,
@@ -1582,10 +1688,15 @@ def test_rocm_mxfp4_moe_oracle(
             w2_weight_scale=w2_scale,
             w13_bias=w13_bias,
             w2_bias=w2_bias,
+            input_w13_layout=w13_layout,
         )
     )
 
     # Build quant config using oracle
+    is_swigluoai_family = activation in (
+        MoEActivation.SWIGLUOAI,
+        MoEActivation.SWIGLUOAI_UNINTERLEAVE,
+    )
     quant_config = make_mxfp4_moe_quant_config(
         mxfp4_backend=backend,
         w1_scale=w13_scale_conv,
@@ -1594,11 +1705,8 @@ def test_rocm_mxfp4_moe_oracle(
         w2_bias=w2_bias_conv,
         a1_scale=w13_input_scale,
         a2_scale=w2_input_scale,
+        swiglu_limit=7.0 if is_swigluoai_family else None,
     )
-
-    # Select activation based on backend
-    activation_name = str(config["activation"])
-    activation = MoEActivation[activation_name]
 
     # Build kernel using oracle
     assert quant_config is not None, "Failed to create quant config"
@@ -1662,14 +1770,20 @@ def test_rocm_mxfp4_moe_oracle(
         w2_quant_ref.view(torch.uint8), w2_scale_ref, torch.bfloat16, axis=-1
     )
 
-    # Determine activation type and layout
-    # SWIGLUOAI uses interleaved layout (gate/up alternating)
-    # SILU uses chunked layout (first half gate, second half up)
-    use_interleaved = activation == MoEActivation.SWIGLUOAI
-    if activation in [MoEActivation.SWIGLUOAI, MoEActivation.SILU]:
-        act_name = "swiglu"
-    else:
-        act_name = "relu2"
+    # # The reference always uses contiguous w13 (the saved ref weights are
+    # # contiguous). For SWIGLUOAI the reference uses interleaved layout in
+    # # the activation; for all others it uses chunked (contiguous) layout.
+    # use_interleaved = activation == MoEActivation.SWIGLUOAI
+
+    # Map MoEActivation to reference_moe activation name and parameters.
+    _ACT_TO_REF = {
+        MoEActivation.SWIGLUOAI: ("swiglu", 1.702, 1.0, 7.0),
+        MoEActivation.SWIGLUOAI_UNINTERLEAVE: ("swiglu", 1.702, 1.0, 7.0),
+        MoEActivation.SILU: ("swiglu", 1.0, 0.0, None),
+        MoEActivation.GELU: ("gelu", 1.0, 0.0, None),
+        MoEActivation.SITU: ("situ", 1.0, 0.0, None),
+    }
+    ref_act, ref_alpha, ref_beta, ref_limit = _ACT_TO_REF[activation]
 
     ref = reference_moe(
         router_logits,
@@ -1677,15 +1791,15 @@ def test_rocm_mxfp4_moe_oracle(
         num_experts,
         x.to(torch.float32),
         w13_dq.to(torch.float32),
-        w13_bias.to(torch.float32),
+        w13_bias_ref.to(torch.float32),
         w2_dq.to(torch.float32),
-        w2_bias.to(torch.float32),
-        alpha=1.702 if activation == MoEActivation.SWIGLUOAI else 1.0,
-        beta=1.0 if activation == MoEActivation.SWIGLUOAI else 0.0,
-        limit=7.0 if activation == MoEActivation.SWIGLUOAI else None,
+        w2_bias_ref.to(torch.float32),
+        alpha=ref_alpha,
+        beta=ref_beta,
+        limit=ref_limit,
         act_type=str(config.get("act_type", "bf16")),
-        activation=act_name,
-        use_interleaved_layout=use_interleaved,
+        activation=ref_act,
+        use_interleaved_layout=False,  # reference always use contiguous layout
     )
 
     # Compute and print accuracy statistics
@@ -1712,6 +1826,25 @@ def test_rocm_mxfp4_moe_oracle(
     for rtol in [0.1, 0.5, 1.0, 2.0]:
         within_tol = (diff <= rtol * out.float().abs()).float().mean()
         print(f"  Within rtol={rtol}: {within_tol * 100:.1f}%")
+
+    # Cosine similarity
+    ref_flat = ref.float().flatten()
+    out_flat = out.float().flatten()
+    cosine_sim = torch.nn.functional.cosine_similarity(
+        ref_flat.unsqueeze(0), out_flat.unsqueeze(0)
+    ).item()
+    norm_ratio = out_flat.norm() / (ref_flat.norm() + 1e-6)
+    print(f"  Cosine similarity: {cosine_sim:.6f}")
+    print(f"  Norm ratio (out/ref): {norm_ratio:.4f}")
+
+    cosine_threshold = config.get("cosine_threshold", 0.9)
+    assert cosine_sim > cosine_threshold, (
+        f"Cosine similarity {cosine_sim:.4f} < {cosine_threshold} — likely a "
+        f"layout or correctness bug, not just quantization noise"
+    )
+    assert 0.5 < norm_ratio < 2.0, (
+        f"Norm ratio {norm_ratio:.4f} outside [0.5, 2.0] — magnitude error"
+    )
 
     # Check accuracy using per-backend thresholds
     check_accuracy(ref, out, atol=0.1, rtol=config["rtol"], percent=config["percent"])

--- a/tests/kernels/moe/test_w13_layout.py
+++ b/tests/kernels/moe/test_w13_layout.py
@@ -1,0 +1,288 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for W13Layout enum, interleave/deinterleave helpers, and the
+merged oracle functions.
+
+Run: pytest tests/kernels/moe/test_w13_layout.py -v
+"""
+
+from unittest.mock import patch
+
+import pytest
+import torch
+
+from vllm.model_executor.layers.fused_moe.activation import MoEActivation
+from vllm.model_executor.layers.fused_moe.modular_kernel import W13Layout
+from vllm.model_executor.layers.fused_moe.oracle.mxfp4 import (
+    _deinterleave_w13,
+    _interleave_w13,
+    _swap_w13_halves,
+    convert_w13_layout,
+)
+
+pytestmark = pytest.mark.cpu_test
+
+
+class TestInterleaveDeinterleaveRoundTrip:
+    """_interleave_w13 and _deinterleave_w13 must be inverses."""
+
+    @staticmethod
+    def _make_w13(e: int = 2, n: int = 8, k: int = 4) -> torch.Tensor:
+        return torch.arange(e * n * k, dtype=torch.uint8).reshape(e, n, k)
+
+    @staticmethod
+    def _make_scale(e: int = 2, n: int = 8, k_scale: int = 2) -> torch.Tensor:
+        return torch.arange(e * n * k_scale, dtype=torch.float32).reshape(e, n, k_scale)
+
+    @staticmethod
+    def _make_bias(e: int = 2, n: int = 8) -> torch.Tensor:
+        return torch.arange(e * n, dtype=torch.float32).reshape(e, n)
+
+    def test_interleave_then_deinterleave_is_identity(self):
+        w = self._make_w13()
+        s = self._make_scale()
+        b = self._make_bias()
+
+        wi, si, bi = _interleave_w13(w.clone(), s.clone(), b.clone())
+        wd, sd, bd = _deinterleave_w13(wi, si, bi)
+
+        torch.testing.assert_close(wd.view(torch.uint8), w)
+        torch.testing.assert_close(sd, s)
+        torch.testing.assert_close(bd, b)
+
+    def test_deinterleave_then_interleave_is_identity(self):
+        w = self._make_w13()
+        s = self._make_scale()
+        b = self._make_bias()
+
+        wd, sd, bd = _deinterleave_w13(w.clone(), s.clone(), b.clone())
+        wi, si, bi = _interleave_w13(wd, sd, bd)
+
+        torch.testing.assert_close(wi.view(torch.uint8), w)
+        torch.testing.assert_close(si, s)
+        torch.testing.assert_close(bi, b)
+
+    def test_interleave_produces_correct_pattern(self):
+        w = torch.tensor([[[10, 11], [20, 21], [30, 31], [40, 41]]], dtype=torch.uint8)
+        s = torch.tensor([[[1.0, 2.0], [3.0, 4.0], [5.0, 6.0], [7.0, 8.0]]])
+        # Contiguous: [gate0, gate1, up0, up1]
+        # Interleaved: [gate0, up0, gate1, up1]
+        wi, si, _ = _interleave_w13(w, s, None)
+        expected_w = torch.tensor(
+            [[[10, 11], [30, 31], [20, 21], [40, 41]]], dtype=torch.uint8
+        )
+        expected_s = torch.tensor([[[1.0, 2.0], [5.0, 6.0], [3.0, 4.0], [7.0, 8.0]]])
+        torch.testing.assert_close(wi.view(torch.uint8), expected_w)
+        torch.testing.assert_close(si, expected_s)
+
+    def test_round_trip_without_bias(self):
+        w = self._make_w13()
+        s = self._make_scale()
+
+        wi, si, bi = _interleave_w13(w.clone(), s.clone(), None)
+        assert bi is None
+        wd, sd, bd = _deinterleave_w13(wi, si, None)
+        assert bd is None
+
+        torch.testing.assert_close(wd.view(torch.uint8), w)
+        torch.testing.assert_close(sd, s)
+
+
+class TestSwapW13Halves:
+    """_swap_w13_halves flips gate/up ordering."""
+
+    @staticmethod
+    def _make_w13(e: int = 1, n: int = 4, k: int = 2) -> torch.Tensor:
+        return torch.arange(e * n * k, dtype=torch.uint8).reshape(e, n, k)
+
+    @staticmethod
+    def _make_scale(e: int = 1, n: int = 4, k_scale: int = 1) -> torch.Tensor:
+        return torch.arange(e * n * k_scale, dtype=torch.float32).reshape(e, n, k_scale)
+
+    @staticmethod
+    def _make_bias(e: int = 1, n: int = 4) -> torch.Tensor:
+        return torch.arange(e * n, dtype=torch.float32).reshape(e, n)
+
+    def test_swap_flips_halves(self):
+        w = torch.tensor([[[10, 11], [20, 21], [30, 31], [40, 41]]], dtype=torch.uint8)
+        s = torch.tensor([[[1.0], [2.0], [3.0], [4.0]]])
+        b = torch.tensor([[100.0, 200.0, 300.0, 400.0]])
+
+        ws, ss, bs = _swap_w13_halves(w, s, b)
+
+        expected_w = torch.tensor(
+            [[[30, 31], [40, 41], [10, 11], [20, 21]]], dtype=torch.uint8
+        )
+        expected_s = torch.tensor([[[3.0], [4.0], [1.0], [2.0]]])
+        expected_b = torch.tensor([[300.0, 400.0, 100.0, 200.0]])
+        torch.testing.assert_close(ws, expected_w)
+        torch.testing.assert_close(ss, expected_s)
+        torch.testing.assert_close(bs, expected_b)
+
+    def test_double_swap_is_identity(self):
+        w = self._make_w13()
+        s = self._make_scale()
+        b = self._make_bias()
+
+        w1, s1, b1 = _swap_w13_halves(w.clone(), s.clone(), b.clone())
+        w2, s2, b2 = _swap_w13_halves(w1, s1, b1)
+
+        torch.testing.assert_close(w2, w)
+        torch.testing.assert_close(s2, s)
+        torch.testing.assert_close(b2, b)
+
+    def test_swap_without_bias(self):
+        w = self._make_w13()
+        s = self._make_scale()
+        _, _, b_out = _swap_w13_halves(w, s, None)
+        assert b_out is None
+
+
+class TestConvertW13Layout:
+    """convert_w13_layout handles all from/to combinations."""
+
+    @staticmethod
+    def _make_contiguous_w1w3():
+        """[gate0, gate1, up0, up1] — 1 expert, 4 rows, 2 cols."""
+        w = torch.tensor([[[10, 11], [20, 21], [30, 31], [40, 41]]], dtype=torch.uint8)
+        s = torch.tensor([[[1.0], [2.0], [3.0], [4.0]]])
+        b = torch.tensor([[100.0, 200.0, 300.0, 400.0]])
+        return w, s, b
+
+    def test_same_layout_is_noop(self):
+        w, s, b = self._make_contiguous_w1w3()
+        wo, so, bo = convert_w13_layout(
+            w, s, b, W13Layout.CONTIGUOUS_W1W3, W13Layout.CONTIGUOUS_W1W3
+        )
+        assert wo is w
+        assert so is s
+        assert bo is b
+
+    @pytest.mark.parametrize(
+        "from_layout, to_layout",
+        [
+            (W13Layout.CONTIGUOUS_W1W3, W13Layout.CONTIGUOUS_W3W1),
+            (W13Layout.CONTIGUOUS_W1W3, W13Layout.INTERLEAVED_W1W3),
+            (W13Layout.CONTIGUOUS_W1W3, W13Layout.INTERLEAVED_W3W1),
+            (W13Layout.CONTIGUOUS_W3W1, W13Layout.CONTIGUOUS_W1W3),
+            (W13Layout.CONTIGUOUS_W3W1, W13Layout.INTERLEAVED_W1W3),
+            (W13Layout.CONTIGUOUS_W3W1, W13Layout.INTERLEAVED_W3W1),
+            (W13Layout.INTERLEAVED_W1W3, W13Layout.CONTIGUOUS_W1W3),
+            (W13Layout.INTERLEAVED_W1W3, W13Layout.CONTIGUOUS_W3W1),
+            (W13Layout.INTERLEAVED_W1W3, W13Layout.INTERLEAVED_W3W1),
+            (W13Layout.INTERLEAVED_W3W1, W13Layout.CONTIGUOUS_W1W3),
+            (W13Layout.INTERLEAVED_W3W1, W13Layout.CONTIGUOUS_W3W1),
+            (W13Layout.INTERLEAVED_W3W1, W13Layout.INTERLEAVED_W1W3),
+        ],
+    )
+    def test_round_trip(self, from_layout, to_layout):
+        w, s, b = self._make_contiguous_w1w3()
+        w_orig, s_orig, b_orig = w.clone(), s.clone(), b.clone()
+
+        w1, s1, b1 = convert_w13_layout(
+            w_orig, s_orig, b_orig, W13Layout.CONTIGUOUS_W1W3, from_layout
+        )
+        w2, s2, b2 = convert_w13_layout(w1, s1, b1, from_layout, to_layout)
+        w3, s3, b3 = convert_w13_layout(
+            w2, s2, b2, to_layout, W13Layout.CONTIGUOUS_W1W3
+        )
+
+        torch.testing.assert_close(w3.view(torch.uint8), w)
+        torch.testing.assert_close(s3, s)
+        torch.testing.assert_close(b3, b)
+
+    def test_contiguous_to_interleaved_pattern(self):
+        w, s, b = self._make_contiguous_w1w3()
+        wi, si, _ = convert_w13_layout(
+            w, s, None, W13Layout.CONTIGUOUS_W1W3, W13Layout.INTERLEAVED_W1W3
+        )
+        expected_w = torch.tensor(
+            [[[10, 11], [30, 31], [20, 21], [40, 41]]], dtype=torch.uint8
+        )
+        expected_s = torch.tensor([[[1.0], [3.0], [2.0], [4.0]]])
+        torch.testing.assert_close(wi.view(torch.uint8), expected_w)
+        torch.testing.assert_close(si, expected_s)
+
+    def test_contiguous_w1w3_to_contiguous_w3w1(self):
+        w, s, b = self._make_contiguous_w1w3()
+        ws, ss, bs = convert_w13_layout(
+            w, s, b, W13Layout.CONTIGUOUS_W1W3, W13Layout.CONTIGUOUS_W3W1
+        )
+        expected_w = torch.tensor(
+            [[[30, 31], [40, 41], [10, 11], [20, 21]]], dtype=torch.uint8
+        )
+        torch.testing.assert_close(ws, expected_w)
+
+    def test_contiguous_w1w3_to_interleaved_w3w1(self):
+        w, s, b = self._make_contiguous_w1w3()
+        wo, so, bo = convert_w13_layout(
+            w, s, b, W13Layout.CONTIGUOUS_W1W3, W13Layout.INTERLEAVED_W3W1
+        )
+        expected_w = torch.tensor(
+            [[[30, 31], [10, 11], [40, 41], [20, 21]]], dtype=torch.uint8
+        )
+        torch.testing.assert_close(wo.view(torch.uint8), expected_w)
+
+
+class TestExpectedW13Layout:
+    """Each expert class must return the correct W13Layout."""
+
+    @pytest.mark.parametrize(
+        "activation, expected",
+        [
+            (MoEActivation.SILU, W13Layout.CONTIGUOUS_W1W3),
+            (MoEActivation.GELU, W13Layout.CONTIGUOUS_W1W3),
+            (MoEActivation.SWIGLUOAI, W13Layout.INTERLEAVED_W1W3),
+            (MoEActivation.SWIGLUOAI_UNINTERLEAVE, W13Layout.CONTIGUOUS_W1W3),
+            (MoEActivation.SITU, W13Layout.CONTIGUOUS_W1W3),
+            (MoEActivation.SWIGLUSTEP, W13Layout.CONTIGUOUS_W1W3),
+        ],
+    )
+    def test_base_class_default(self, activation, expected):
+        from vllm.model_executor.layers.fused_moe.modular_kernel import (
+            FusedMoEExperts,
+        )
+
+        assert FusedMoEExperts._expected_w13_layout(activation) == expected
+
+
+class TestDeprecatedWrappers:
+    """Deprecated functions must delegate to the merged versions."""
+
+    def test_select_gpt_oss_delegates(self):
+        from vllm.model_executor.layers.fused_moe.oracle import mxfp4 as mod
+
+        sentinel = (object(), object())
+        with patch.object(
+            mod,
+            "select_mxfp4_moe_backend",
+            return_value=sentinel,
+        ) as mocked:
+            config = object()
+            result = mod.select_gpt_oss_mxfp4_moe_backend(config)
+
+        mocked.assert_called_once_with(config, None, use_gpt_oss_priority=True)
+        assert result is sentinel
+
+    def test_convert_gpt_oss_delegates(self):
+        from vllm.model_executor.layers.fused_moe.oracle import mxfp4 as mod
+
+        sentinel = (None,) * 6
+        with patch.object(
+            mod,
+            "convert_weight_to_mxfp4_moe_kernel_format",
+            return_value=sentinel,
+        ) as mocked:
+            w = torch.zeros(1)
+            result = mod.convert_gpt_oss_weight_to_mxfp4_moe_kernel_format(
+                mxfp4_backend=mod.Mxfp4MoeBackend.MARLIN,
+                layer=None,
+                w13_weight=w,
+                w2_weight=w,
+                w13_weight_scale=w,
+                w2_weight_scale=w,
+            )
+
+        assert result is sentinel
+        _, kwargs = mocked.call_args
+        assert kwargs["input_w13_layout"] == W13Layout.INTERLEAVED_W1W3

--- a/vllm/model_executor/layers/fused_moe/experts/aiter_mxfp4_w4a8_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/aiter_mxfp4_w4a8_moe.py
@@ -13,6 +13,7 @@ from vllm.model_executor.layers.fused_moe.config import (
     FusedMoEQuantConfig,
     RoutingMethodType,
 )
+from vllm.model_executor.layers.fused_moe.modular_kernel import W13Layout
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     QuantKey,
     kFp8StaticTensorSym,
@@ -303,6 +304,14 @@ class AiterW4A8ExpertsMonolithic(mk.FusedMoEExpertsMonolithic):
     def _supports_activation(activation: MoEActivation) -> bool:
         # Only SILU activation (swiglu) is supported
         return activation == MoEActivation.SWIGLUOAI
+
+    @staticmethod
+    def _expected_w13_layout(
+        activation: MoEActivation,
+        weight_key: "QuantKey | None" = None,
+        activation_key: "QuantKey | None" = None,
+    ) -> W13Layout:
+        return W13Layout.INTERLEAVED_W1W3
 
     @staticmethod
     def _supports_parallel_config(
@@ -652,6 +661,14 @@ class AiterW4A16ExpertsMonolithic(mk.FusedMoEExpertsMonolithic):
     @staticmethod
     def _supports_activation(activation: MoEActivation) -> bool:
         return activation in (MoEActivation.SWIGLUOAI, MoEActivation.SILU)
+
+    @staticmethod
+    def _expected_w13_layout(
+        activation: MoEActivation,
+        weight_key: "QuantKey | None" = None,
+        activation_key: "QuantKey | None" = None,
+    ) -> W13Layout:
+        return W13Layout.INTERLEAVED_W1W3
 
     @staticmethod
     def _supports_parallel_config(

--- a/vllm/model_executor/layers/fused_moe/experts/cpu_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/cpu_moe.py
@@ -31,6 +31,7 @@ from vllm.model_executor.layers.fused_moe.config import (
     FusedMoEQuantConfig,
     RoutingMethodType,
 )
+from vllm.model_executor.layers.fused_moe.modular_kernel import W13Layout
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     QuantKey,
     kFp8Dynamic128Sym,
@@ -742,6 +743,14 @@ class CPUExpertsMxfp4(mk.FusedMoEExpertsMonolithic):
     @staticmethod
     def _supports_activation(activation: MoEActivation) -> bool:
         return activation in (MoEActivation.SILU, MoEActivation.SWIGLUOAI)
+
+    @staticmethod
+    def _expected_w13_layout(
+        activation: MoEActivation,
+        weight_key: "QuantKey | None" = None,
+        activation_key: "QuantKey | None" = None,
+    ) -> W13Layout:
+        return W13Layout.CONTIGUOUS_W1W3
 
     @staticmethod
     def _supports_parallel_config(

--- a/vllm/model_executor/layers/fused_moe/experts/deep_gemm_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/deep_gemm_moe.py
@@ -16,6 +16,7 @@ from vllm.model_executor.layers.fused_moe.deep_gemm_utils import (
     deepgemm_moe_permute,
     deepgemm_unpermute_and_reduce,
 )
+from vllm.model_executor.layers.fused_moe.modular_kernel import W13Layout
 from vllm.model_executor.layers.fused_moe.topk_weight_and_reduce import (
     TopKWeightAndReduceNoOP,
 )
@@ -452,6 +453,14 @@ class DeepGemmFP4Experts(mk.FusedMoEExpertsModular):
             MoEActivation.SWIGLUSTEP,
             MoEActivation.SITU,
         ]
+
+    @staticmethod
+    def _expected_w13_layout(
+        activation: MoEActivation,
+        weight_key: "QuantKey | None" = None,
+        activation_key: "QuantKey | None" = None,
+    ) -> W13Layout:
+        return W13Layout.CONTIGUOUS_W1W3
 
     @staticmethod
     def _supports_parallel_config(moe_parallel_config: FusedMoEParallelConfig) -> bool:

--- a/vllm/model_executor/layers/fused_moe/experts/flashinfer_cutlass_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/flashinfer_cutlass_moe.py
@@ -10,6 +10,7 @@ from vllm.model_executor.layers.fused_moe.config import (
     FusedMoEParallelConfig,
     FusedMoEQuantConfig,
 )
+from vllm.model_executor.layers.fused_moe.modular_kernel import W13Layout
 from vllm.model_executor.layers.fused_moe.topk_weight_and_reduce import (
     TopKWeightAndReduceNoOP,
 )
@@ -190,6 +191,14 @@ class FlashInferExperts(mk.FusedMoEExpertsModular):
             MoEActivation.SWIGLUOAI,
             MoEActivation.SWIGLUOAI_UNINTERLEAVE,
         ]
+
+    @staticmethod
+    def _expected_w13_layout(
+        activation: MoEActivation,
+        weight_key: "QuantKey | None" = None,
+        activation_key: "QuantKey | None" = None,
+    ) -> W13Layout:
+        return W13Layout.CONTIGUOUS_W3W1
 
     @staticmethod
     def _supports_parallel_config(moe_parallel_config: FusedMoEParallelConfig) -> bool:

--- a/vllm/model_executor/layers/fused_moe/experts/gpt_oss_triton_kernels_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/gpt_oss_triton_kernels_moe.py
@@ -16,6 +16,7 @@ from vllm.model_executor.layers.fused_moe.config import (
 from vllm.model_executor.layers.fused_moe.experts.lora_experts_mixin import (
     LoRAExpertsMixin,
 )
+from vllm.model_executor.layers.fused_moe.modular_kernel import W13Layout
 from vllm.model_executor.layers.fused_moe.topk_weight_and_reduce import (
     TopKWeightAndReduceNoOP,
 )
@@ -908,6 +909,14 @@ class BaseOAITritonExperts(mk.FusedMoEExpertsModular):
         raise NotImplementedError
 
     @staticmethod
+    def _expected_w13_layout(
+        activation: MoEActivation,
+        weight_key: "QuantKey | None" = None,
+        activation_key: "QuantKey | None" = None,
+    ) -> W13Layout:
+        return W13Layout.INTERLEAVED_W1W3
+
+    @staticmethod
     def _supports_parallel_config(moe_parallel_config: FusedMoEParallelConfig) -> bool:
         return True
 
@@ -1062,6 +1071,16 @@ class UnfusedOAITritonExperts(LoRAExpertsMixin, BaseOAITritonExperts):
             MoEActivation.SWIGLUSTEP,
             MoEActivation.SWIGLUOAI_UNINTERLEAVE,
         ]
+
+    @staticmethod
+    def _expected_w13_layout(
+        activation: MoEActivation,
+        weight_key: "QuantKey | None" = None,
+        activation_key: "QuantKey | None" = None,
+    ) -> W13Layout:
+        if activation == MoEActivation.SWIGLUOAI:
+            return W13Layout.INTERLEAVED_W1W3
+        return W13Layout.CONTIGUOUS_W1W3
 
     @staticmethod
     def activation_format() -> mk.FusedMoEActivationFormat:
@@ -1325,6 +1344,14 @@ class OAITritonMxfp4ExpertsMonolithic(mk.FusedMoEExpertsMonolithic):
     @staticmethod
     def _supports_activation(activation: MoEActivation) -> bool:
         return activation == MoEActivation.SWIGLUOAI
+
+    @staticmethod
+    def _expected_w13_layout(
+        activation: MoEActivation,
+        weight_key: "QuantKey | None" = None,
+        activation_key: "QuantKey | None" = None,
+    ) -> W13Layout:
+        return W13Layout.INTERLEAVED_W1W3
 
     @staticmethod
     def _supports_parallel_config(

--- a/vllm/model_executor/layers/fused_moe/experts/rocm_aiter_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/rocm_aiter_moe.py
@@ -14,6 +14,7 @@ from vllm.model_executor.layers.fused_moe.config import (
     FusedMoEParallelConfig,
     FusedMoEQuantConfig,
 )
+from vllm.model_executor.layers.fused_moe.modular_kernel import W13Layout
 from vllm.model_executor.layers.fused_moe.topk_weight_and_reduce import (
     TopKWeightAndReduceNoOP,
 )
@@ -27,6 +28,7 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
     kFp8StaticTensorSym,
     kMxfp4Dynamic,
     kMxfp4Static,
+    kMxfp8Dynamic,
 )
 
 
@@ -488,6 +490,23 @@ class AiterExperts(mk.FusedMoEExpertsModular):
             MoEActivation.SWIGLUOAI,
             MoEActivation.SWIGLUOAI_UNINTERLEAVE,
         ]
+
+    @staticmethod
+    def _expected_w13_layout(
+        activation: MoEActivation,
+        weight_key: "QuantKey | None" = None,
+        activation_key: "QuantKey | None" = None,
+    ) -> W13Layout:
+        if weight_key == kMxfp4Static and activation_key is None:
+            # W4A16: The kernel expects interleaved layout. However,
+            # shuffle_weight_a16w4 handles interleaving internally
+            # (is_guinterleave=True), so it expects contiguous input.
+            return W13Layout.CONTIGUOUS_W1W3
+        if weight_key == kMxfp4Static and activation_key == kMxfp4Dynamic:
+            return W13Layout.CONTIGUOUS_W1W3
+        if weight_key == kMxfp4Static and activation_key == kMxfp8Dynamic:
+            return W13Layout.INTERLEAVED_W1W3
+        return W13Layout.CONTIGUOUS_W1W3
 
     @staticmethod
     def _supports_parallel_config(moe_parallel_config: FusedMoEParallelConfig) -> bool:

--- a/vllm/model_executor/layers/fused_moe/experts/trtllm_mxfp4_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/trtllm_mxfp4_moe.py
@@ -11,6 +11,7 @@ from vllm.model_executor.layers.fused_moe.config import (
     FusedMoEQuantConfig,
     RoutingMethodType,
 )
+from vllm.model_executor.layers.fused_moe.modular_kernel import W13Layout
 from vllm.model_executor.layers.fused_moe.topk_weight_and_reduce import (
     TopKWeightAndReduceNoOP,
 )
@@ -144,6 +145,14 @@ class TrtLlmMxfp4ExpertsBase:
             MoEActivation.SWIGLUOAI,
             MoEActivation.SILU,
         )
+
+    @staticmethod
+    def _expected_w13_layout(
+        activation: MoEActivation,
+        weight_key: "QuantKey | None" = None,
+        activation_key: "QuantKey | None" = None,
+    ) -> W13Layout:
+        return W13Layout.INTERLEAVED_W3W1
 
     @staticmethod
     def _flashinfer_activation_type(activation: MoEActivation) -> int:

--- a/vllm/model_executor/layers/fused_moe/modular_kernel.py
+++ b/vllm/model_executor/layers/fused_moe/modular_kernel.py
@@ -81,6 +81,15 @@ logger = init_logger(__name__)
 #
 
 
+class W13Layout(Enum):
+    """Layout of the fused gate/up (w13) weight tensor."""
+
+    CONTIGUOUS_W1W3 = "contiguous_w1w3"
+    CONTIGUOUS_W3W1 = "contiguous_w3w1"
+    INTERLEAVED_W1W3 = "interleaved_w1w3"
+    INTERLEAVED_W3W1 = "interleaved_w3w1"
+
+
 class FusedMoEActivationFormat(Enum):
     """
     The standard activation format (num_tokens, hidden dim).
@@ -623,6 +632,22 @@ class FusedMoEExperts(ABC):
         Whether the kernel supports a particular act function.
         """
         raise NotImplementedError
+
+    @staticmethod
+    def _expected_w13_layout(
+        activation: MoEActivation,
+        weight_key: QuantKey | None = None,
+        activation_key: QuantKey | None = None,
+    ) -> W13Layout:
+        """W13 layout the kernel expects for a given activation.
+
+        Default: INTERLEAVED_W1W3 for SWIGLUOAI, CONTIGUOUS_W1W3 otherwise.
+        Backends with fused activations or quant-scheme-dependent layouts
+        should override this.
+        """
+        if activation == MoEActivation.SWIGLUOAI:
+            return W13Layout.INTERLEAVED_W1W3
+        return W13Layout.CONTIGUOUS_W1W3
 
     @staticmethod
     @abstractmethod

--- a/vllm/model_executor/layers/fused_moe/oracle/__init__.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/__init__.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from vllm.model_executor.layers.fused_moe.modular_kernel import W13Layout
 from vllm.model_executor.layers.fused_moe.oracle.base import MoEKernelOracle
 from vllm.model_executor.layers.fused_moe.oracle.unquantized import (
     UnquantizedMoEKernelOracle,
@@ -9,4 +10,5 @@ from vllm.model_executor.layers.fused_moe.oracle.unquantized import (
 __all__ = [
     "MoEKernelOracle",
     "UnquantizedMoEKernelOracle",
+    "W13Layout",
 ]

--- a/vllm/model_executor/layers/fused_moe/oracle/mxfp4.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/mxfp4.py
@@ -142,6 +142,58 @@ TRITON_BACKENDS = (
 )
 
 
+def _interleave_w13(
+    w13_weight: torch.Tensor,
+    w13_weight_scale: torch.Tensor,
+    w13_bias: torch.Tensor | None,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
+    """Convert contiguous w13 [gate; up] to interleaved [g0,u0,g1,u1,...]."""
+    e, n, k = w13_weight.shape
+    w13_weight = (
+        w13_weight.view(torch.uint8)
+        .view(e, 2, n // 2, k)
+        .permute(0, 2, 1, 3)
+        .contiguous()
+        .view(e, n, k)
+        .view(w13_weight.dtype)
+    )
+    w13_weight_scale = (
+        w13_weight_scale.view(e, 2, n // 2, -1)
+        .permute(0, 2, 1, 3)
+        .contiguous()
+        .view(e, n, -1)
+    )
+    if w13_bias is not None:
+        w13_bias = w13_bias.view(e, 2, n // 2).permute(0, 2, 1).contiguous().view(e, n)
+    return w13_weight, w13_weight_scale, w13_bias
+
+
+def _deinterleave_w13(
+    w13_weight: torch.Tensor,
+    w13_weight_scale: torch.Tensor,
+    w13_bias: torch.Tensor | None,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
+    """Convert interleaved w13 [g0,u0,g1,u1,...] to contiguous [gate; up]."""
+    e, n, k = w13_weight.shape
+    w13_weight = (
+        w13_weight.view(torch.uint8)
+        .view(e, n // 2, 2, k)
+        .permute(0, 2, 1, 3)
+        .contiguous()
+        .view(e, n, k)
+        .view(w13_weight.dtype)
+    )
+    w13_weight_scale = (
+        w13_weight_scale.view(e, n // 2, 2, -1)
+        .permute(0, 2, 1, 3)
+        .contiguous()
+        .view(e, n, -1)
+    )
+    if w13_bias is not None:
+        w13_bias = w13_bias.view(e, n // 2, 2).permute(0, 2, 1).contiguous().view(e, n)
+    return w13_weight, w13_weight_scale, w13_bias
+
+
 def backend_to_kernel_cls(
     backend: Mxfp4MoeBackend,
 ) -> list[type[mk.FusedMoEExperts]]:
@@ -335,6 +387,8 @@ def _get_priority_backends() -> list[Mxfp4MoeBackend]:
     if current_platform.is_rocm():
         return [
             Mxfp4MoeBackend.AITER_MXFP4_BF16,
+            Mxfp4MoeBackend.AITER_MXFP4_FP8,
+            Mxfp4MoeBackend.AITER_MXFP4_MXFP4,
             Mxfp4MoeBackend.EMULATION,
         ]
     if current_platform.is_xpu():
@@ -441,12 +495,18 @@ def _filter_by_activation(
     return bf16 if bf16 else backends
 
 
-def select_mxfp4_moe_backend(
+def select_gpt_oss_mxfp4_moe_backend(
     config: FusedMoEConfig,
     activation_key: QuantKey | None = None,
 ) -> tuple[Mxfp4MoeBackend, type[mk.FusedMoEExperts] | None]:
     """
-    Select the primary MXFP4 MoE backend.
+    Select the primary MXFP4 MoE backend for GPT-OSS (interleaved w13).
+
+    .. deprecated::
+        This function duplicates ``select_mxfp4_moe_backend`` with an
+        interleaved-specific priority list.
+        TODO: merge into ``select_mxfp4_moe_backend`` so that a single
+        entry-point handles both interleaved and non-interleaved checkpoints.
 
     Args:
         config: MoE configuration
@@ -560,13 +620,20 @@ def select_mxfp4_moe_backend(
     )
 
 
-def select_deepseek_v4_mxfp4_moe_backend(
+def select_mxfp4_moe_backend(
     config: FusedMoEConfig,
+    activation_key: QuantKey | None = None,
 ) -> tuple[Mxfp4MoeBackend, type[mk.FusedMoEExperts] | None]:
     """
-    Select the MXFP4 MoE backend with MXFP8 activation as top priority.
-    Falls back through BF16 and other backends.
+    Select the MXFP4 MoE backend.
+
+    Args:
+        config: MoE configuration
+        activation_key: Optional activation quantization key. If provided,
+            filters backends to those matching the requested activation.
     """
+    requested_activation_key = _resolve_activation_key(activation_key)
+
     activation_format = (
         mk.FusedMoEActivationFormat.BatchedExperts
         if config.moe_parallel_config.use_batched_activation_format
@@ -583,14 +650,26 @@ def select_deepseek_v4_mxfp4_moe_backend(
                 Mxfp4MoeBackend.BATCHED_MARLIN if b == Mxfp4MoeBackend.MARLIN else b
                 for b in requested_backends
             ]
+        candidates = _filter_by_activation(requested_backends, requested_activation_key)
+        if not candidates:
+            raise ValueError(
+                f"moe_backend={runner_backend!r} does not support "
+                f"activation={requested_activation_key}; supported "
+                f"variants: {[b.name for b in requested_backends]}"
+            )
         last_error: Exception | None = None
-        for requested_backend in requested_backends:
+        for requested_backend in candidates:
+            act_key = (
+                requested_activation_key
+                if requested_activation_key is not None
+                else _backend_activation_key(requested_backend)
+            )
             try:
                 return _return_or_raise(
                     requested_backend,
                     config,
                     kMxfp4Static,
-                    _backend_activation_key(requested_backend),
+                    act_key,
                     activation_format,
                 )
             except ValueError as e:
@@ -611,21 +690,41 @@ def select_deepseek_v4_mxfp4_moe_backend(
     else:
         priority_backends = _get_priority_backends()
 
-    # Iterate priority backends: TRTLLM MXFP8, then Triton.
+    if requested_activation_key is not None:
+        priority_backends = _filter_by_activation(
+            priority_backends, requested_activation_key
+        )
+
+    unsupported_reasons = []
     for backend in priority_backends:
-        activation_key = _backend_activation_key(backend)
+        act_key = (
+            requested_activation_key
+            if requested_activation_key is not None
+            else _backend_activation_key(backend)
+        )
         for k_cls in backend_to_kernel_cls(backend):
             supported, reason = k_cls.is_supported_config(
-                k_cls, config, kMxfp4Static, activation_key, activation_format
+                k_cls, config, kMxfp4Static, act_key, activation_format
             )
             if supported:
                 logger.info_once(_make_log_backend(backend), scope="local")
                 return backend, k_cls
             else:
                 logger.debug_once(_make_log_unsupported(backend, reason), scope="local")
+                unsupported_reasons.append((backend, reason))
 
+    unsupported_log = "; ".join(
+        [
+            f"backend: {backend.value}, reason: {reason}"
+            for backend, reason in unsupported_reasons
+        ]
+    )
     raise NotImplementedError(
-        "No MXFP4 MoE backend supports the deployment configuration."
+        "No MXFP4 MoE backend supports the deployment configuration. "
+        f"weight_key=kMxfp4Static, activation_key={activation_key}. "
+        f"Candidate backends were: "
+        f"{[backend.value for backend in priority_backends]}. "
+        f"Unsupported reasons: {unsupported_log}. "
     )
 
 
@@ -692,8 +791,6 @@ def convert_gpt_oss_weight_to_mxfp4_moe_kernel_format(
     w2_weight_scale: torch.Tensor,
     w13_bias: torch.Tensor | None = None,
     w2_bias: torch.Tensor | None = None,
-    w13_input_scale: torch.Tensor | None = None,
-    w2_input_scale: torch.Tensor | None = None,
     _cache_permute_indices: dict[torch.Size, torch.Tensor] | None = None,
 ) -> tuple[
     torch.Tensor,
@@ -703,23 +800,52 @@ def convert_gpt_oss_weight_to_mxfp4_moe_kernel_format(
     torch.Tensor | None,
     torch.Tensor | None,
 ]:
-    """Convert loaded weights into backend-specific kernel format."""
+    """Convert interleaved GPT-OSS weights into backend-specific format.
 
-    if mxfp4_backend == Mxfp4MoeBackend.DEEPGEMM_MXFP4:
-        w13_weight_scale, w2_weight_scale = _pack_deepgemm_mxfp4_scales(
-            w13_weight,
-            w2_weight,
-            w13_weight_scale,
-            w2_weight_scale,
+    .. deprecated::
+        Most backends now de-interleave w13 and delegate to
+        ``convert_weight_to_mxfp4_moe_kernel_format``.
+        TODO: merge into ``convert_weight_to_mxfp4_moe_kernel_format``
+        so that a single entry-point handles both layouts.
+    """
+
+    if mxfp4_backend in {
+        Mxfp4MoeBackend.EMULATION,
+        Mxfp4MoeBackend.AITER_MXFP4_MXFP4,
+        Mxfp4MoeBackend.AITER_MXFP4_FP8,
+    }:
+        w13_weight, w13_weight_scale, w13_bias = _deinterleave_w13(
+            w13_weight, w13_weight_scale, w13_bias
+        )
+        return convert_weight_to_mxfp4_moe_kernel_format(
+            mxfp4_backend=mxfp4_backend,
+            layer=layer,
+            w13_weight=w13_weight,
+            w2_weight=w2_weight,
+            w13_weight_scale=w13_weight_scale,
+            w2_weight_scale=w2_weight_scale,
+            w13_bias=w13_bias,
+            w2_bias=w2_bias,
+            _cache_permute_indices=_cache_permute_indices,
         )
 
-        return (
-            w13_weight.data,
-            w2_weight.data,
-            w13_weight_scale,
-            w2_weight_scale,
-            w13_bias,
-            w2_bias,
+    if mxfp4_backend in {
+        Mxfp4MoeBackend.DEEPGEMM_MXFP4,
+        Mxfp4MoeBackend.MARLIN,
+        Mxfp4MoeBackend.BATCHED_MARLIN,
+        Mxfp4MoeBackend.XPU,
+        Mxfp4MoeBackend.CPU,
+    }:
+        return convert_weight_to_mxfp4_moe_kernel_format(
+            mxfp4_backend=mxfp4_backend,
+            layer=layer,
+            w13_weight=w13_weight,
+            w2_weight=w2_weight,
+            w13_weight_scale=w13_weight_scale,
+            w2_weight_scale=w2_weight_scale,
+            w13_bias=w13_bias,
+            w2_bias=w2_bias,
+            _cache_permute_indices=_cache_permute_indices,
         )
 
     num_experts = w13_weight.shape[0]
@@ -744,24 +870,6 @@ def convert_gpt_oss_weight_to_mxfp4_moe_kernel_format(
             getattr(layer, "w13_bias", None),
             getattr(layer, "w2_bias", None),
         )
-    elif mxfp4_backend in (
-        Mxfp4MoeBackend.MARLIN,
-        Mxfp4MoeBackend.BATCHED_MARLIN,
-    ):
-        from vllm.model_executor.layers.quantization.utils.marlin_utils_fp4 import (
-            prepare_moe_mxfp4_layer_for_marlin,
-        )
-
-        return prepare_moe_mxfp4_layer_for_marlin(
-            layer,
-            w13_weight,
-            w2_weight,
-            w13_weight_scale,
-            w2_weight_scale,
-            w13_bias,
-            w2_bias,
-        )
-
     elif mxfp4_backend in TRTLLM_BACKENDS:
         assert _cache_permute_indices is not None
         from flashinfer.fp4_quantization import nvfp4_block_scale_interleave
@@ -980,49 +1088,6 @@ def convert_gpt_oss_weight_to_mxfp4_moe_kernel_format(
                 w2_bias,
             )
 
-    elif mxfp4_backend == Mxfp4MoeBackend.AITER_MXFP4_MXFP4:
-        from vllm._aiter_ops import rocm_aiter_ops
-
-        if w13_bias is not None:
-            w13_bias = w13_bias.data.to(torch.float32)
-        if w2_bias is not None:
-            w2_bias = w2_bias.data.to(torch.float32)
-
-        # e8m0_shuffle on weight scales (GFX950 swizzle layout)
-        from aiter.utility.fp4_utils import e8m0_shuffle
-
-        s0, s1, _ = w13_weight_scale.shape
-        w13_weight_scale.data = e8m0_shuffle(w13_weight_scale.view(s0 * s1, -1)).view(
-            s0, s1, -1
-        )
-
-        s0, s1, _ = w2_weight_scale.shape
-        w2_weight_scale.data = e8m0_shuffle(w2_weight_scale.view(s0 * s1, -1)).view(
-            s0, s1, -1
-        )
-
-        # View as native FP4 dtype
-        fp4_dtype = getattr(torch, "float4_e2m1fn_x2", None)
-        if fp4_dtype is not None:
-            w13_weight.data = w13_weight.data.view(fp4_dtype)
-            w2_weight.data = w2_weight.data.view(fp4_dtype)
-
-        # Shuffle weights for AITER CK kernel
-        shuffled_w13, shuffled_w2 = rocm_aiter_ops.shuffle_weights(
-            w13_weight, w2_weight
-        )
-        shuffled_w13.is_shuffled = True
-        shuffled_w2.is_shuffled = True
-
-        return (
-            shuffled_w13,
-            shuffled_w2,
-            w13_weight_scale,
-            w2_weight_scale,
-            w13_bias,
-            w2_bias,
-        )
-
     elif mxfp4_backend == Mxfp4MoeBackend.AITER_MXFP4_BF16:
         from vllm._aiter_ops import rocm_aiter_ops
 
@@ -1088,63 +1153,6 @@ def convert_gpt_oss_weight_to_mxfp4_moe_kernel_format(
             w2_bias,
         )
 
-    elif mxfp4_backend == Mxfp4MoeBackend.AITER_MXFP4_FP8:
-        # W4A8: MXFP4 weights + static FP8 activations (triton kernel)
-        from triton_kernels.matmul_ogs import FlexCtx, PrecisionConfig
-        from triton_kernels.numerics import InFlexData
-
-        if w13_bias is not None:
-            w13_bias = w13_bias.to(torch.float32)
-        if w2_bias is not None:
-            w2_bias = w2_bias.to(torch.float32)
-
-        # Process static FP8 input scales (reduce to scalar, warn if not uniform)
-        w13_input_scale = layer.w13_input_scale
-        w2_input_scale = layer.w2_input_scale
-        if w13_input_scale is None or w2_input_scale is None:
-            raise ValueError(
-                "W4A8 (AITER_MXFP4_FP8) requires static input scales, but found "
-                "w13_input_scale or w2_input_scale is None."
-            )
-        if not all_close_1d(w13_input_scale) or not all_close_1d(w2_input_scale):
-            logger.warning_once(
-                "Found input_scales that are not equal for "
-                "fp8 MoE layer. Using the maximum across experts "
-                "for each layer."
-            )
-        w13_input_scale = w13_input_scale.max().to(torch.float32)
-        w2_input_scale = w2_input_scale.max().to(torch.float32)
-
-        # Swizzle weights for GFX950
-        w13_weight, w13_flex, w13_scale = _swizzle_mxfp4(w13_weight, w13_weight_scale)
-        w2_weight, w2_flex, w2_scale = _swizzle_mxfp4(w2_weight, w2_weight_scale)
-
-        # Create InFlexData for activation scales
-        lhs_data13 = InFlexData(scale=w13_input_scale)
-        lhs_data2 = InFlexData(scale=w2_input_scale)
-
-        # Create PrecisionConfig with both weight and activation info
-        w13_precision_config = PrecisionConfig(
-            weight_scale=w13_scale,
-            flex_ctx=FlexCtx(rhs_data=w13_flex, lhs_data=lhs_data13),
-        )
-        w2_precision_config = PrecisionConfig(
-            weight_scale=w2_scale,
-            flex_ctx=FlexCtx(rhs_data=w2_flex, lhs_data=lhs_data2),
-        )
-
-        del layer.w13_weight
-        del layer.w2_weight
-
-        return (
-            w13_weight,
-            w2_weight,
-            w13_precision_config,
-            w2_precision_config,
-            w13_bias,
-            w2_bias,
-        )
-
     elif mxfp4_backend in TRITON_BACKENDS:
         from triton_kernels.matmul_ogs import FlexCtx, PrecisionConfig
 
@@ -1182,73 +1190,6 @@ def convert_gpt_oss_weight_to_mxfp4_moe_kernel_format(
             w2_weight,
             w13_precision_config,
             w2_precision_config,
-            w13_bias,
-            w2_bias,
-        )
-    elif mxfp4_backend == Mxfp4MoeBackend.XPU:
-        # No additional transformation needed for XPU backend
-        return (
-            w13_weight,
-            w2_weight,
-            w13_weight_scale,
-            w2_weight_scale,
-            w13_bias,
-            w2_bias,
-        )
-    elif mxfp4_backend == Mxfp4MoeBackend.CPU:
-        from vllm.model_executor.layers.fused_moe.experts.cpu_moe import (
-            prepare_mxfp4_moe_layer_for_cpu,
-        )
-
-        packed_w13, packed_w2, packed_w13_scale, packed_w2_scale = (
-            prepare_mxfp4_moe_layer_for_cpu(
-                w13_weight.data,
-                w2_weight.data,
-                w13_weight_scale.data,
-                w2_weight_scale.data,
-            )
-        )
-        if w13_bias is not None:
-            w13_bias = w13_bias.data.to(torch.float32)
-        if w2_bias is not None:
-            w2_bias = w2_bias.data.to(torch.float32)
-        return (
-            packed_w13,
-            packed_w2,
-            packed_w13_scale,
-            packed_w2_scale,
-            w13_bias,
-            w2_bias,
-        )
-    elif mxfp4_backend == Mxfp4MoeBackend.EMULATION:
-        w13_has_per_expert_scale = (
-            w13_input_scale is not None
-            and w13_input_scale.ndim == 1
-            and not all_close_1d(w13_input_scale)
-        )
-        w2_has_per_expert_scale = (
-            w2_input_scale is not None
-            and w2_input_scale.ndim == 1
-            and not all_close_1d(w2_input_scale)
-        )
-        if w13_has_per_expert_scale or w2_has_per_expert_scale:
-            logger.warning_once(
-                "Found input_scales that are not equal for OCP MX MoE "
-                "emulation. Using the maximum across experts for each layer."
-            )
-        if w13_input_scale is not None:
-            layer.w13_input_scale = torch.nn.Parameter(
-                w13_input_scale.max().to(torch.float32), requires_grad=False
-            )
-        if w2_input_scale is not None:
-            layer.w2_input_scale = torch.nn.Parameter(
-                w2_input_scale.max().to(torch.float32), requires_grad=False
-            )
-        return (
-            w13_weight,
-            w2_weight,
-            w13_weight_scale,
-            w2_weight_scale,
             w13_bias,
             w2_bias,
         )
@@ -1660,6 +1601,31 @@ def convert_weight_to_mxfp4_moe_kernel_format(
             w13_bias,
             w2_bias,
         )
+    elif mxfp4_backend == Mxfp4MoeBackend.CPU:
+        from vllm.model_executor.layers.fused_moe.experts.cpu_moe import (
+            prepare_mxfp4_moe_layer_for_cpu,
+        )
+
+        packed_w13, packed_w2, packed_w13_scale, packed_w2_scale = (
+            prepare_mxfp4_moe_layer_for_cpu(
+                w13_weight.data,
+                w2_weight.data,
+                w13_weight_scale.data,
+                w2_weight_scale.data,
+            )
+        )
+        if w13_bias is not None:
+            w13_bias = w13_bias.data.to(torch.float32)
+        if w2_bias is not None:
+            w2_bias = w2_bias.data.to(torch.float32)
+        return (
+            packed_w13,
+            packed_w2,
+            packed_w13_scale,
+            packed_w2_scale,
+            w13_bias,
+            w2_bias,
+        )
     elif mxfp4_backend in (
         Mxfp4MoeBackend.XPU,
         Mxfp4MoeBackend.EMULATION,
@@ -1674,21 +1640,102 @@ def convert_weight_to_mxfp4_moe_kernel_format(
             w13_bias,
             w2_bias,
         )
-    elif mxfp4_backend in (
-        Mxfp4MoeBackend.AITER_MXFP4_MXFP4,
-        Mxfp4MoeBackend.AITER_MXFP4_FP8,
-    ):
-        return convert_gpt_oss_weight_to_mxfp4_moe_kernel_format(
-            mxfp4_backend=mxfp4_backend,
-            layer=layer,
-            w13_weight=w13_weight,
-            w2_weight=w2_weight,
-            w13_weight_scale=w13_weight_scale,
-            w2_weight_scale=w2_weight_scale,
-            w13_bias=w13_bias,
-            w2_bias=w2_bias,
-            _cache_permute_indices=_cache_permute_indices,
+    elif mxfp4_backend == Mxfp4MoeBackend.AITER_MXFP4_MXFP4:
+        from vllm._aiter_ops import rocm_aiter_ops
+
+        if w13_bias is not None:
+            w13_bias = w13_bias.data.to(torch.float32)
+        if w2_bias is not None:
+            w2_bias = w2_bias.data.to(torch.float32)
+
+        from aiter.utility.fp4_utils import e8m0_shuffle
+
+        s0, s1, _ = w13_weight_scale.shape
+        w13_weight_scale.data = e8m0_shuffle(w13_weight_scale.view(s0 * s1, -1)).view(
+            s0, s1, -1
         )
+
+        s0, s1, _ = w2_weight_scale.shape
+        w2_weight_scale.data = e8m0_shuffle(w2_weight_scale.view(s0 * s1, -1)).view(
+            s0, s1, -1
+        )
+
+        fp4_dtype = getattr(torch, "float4_e2m1fn_x2", None)
+        if fp4_dtype is not None:
+            w13_weight.data = w13_weight.data.view(fp4_dtype)
+            w2_weight.data = w2_weight.data.view(fp4_dtype)
+
+        shuffled_w13, shuffled_w2 = rocm_aiter_ops.shuffle_weights(
+            w13_weight, w2_weight
+        )
+        shuffled_w13.is_shuffled = True
+        shuffled_w2.is_shuffled = True
+
+        return (
+            shuffled_w13,
+            shuffled_w2,
+            w13_weight_scale,
+            w2_weight_scale,
+            w13_bias,
+            w2_bias,
+        )
+
+    elif mxfp4_backend == Mxfp4MoeBackend.AITER_MXFP4_FP8:
+        from triton_kernels.matmul_ogs import FlexCtx, PrecisionConfig
+        from triton_kernels.numerics import InFlexData
+
+        if w13_bias is not None:
+            w13_bias = w13_bias.to(torch.float32)
+        if w2_bias is not None:
+            w2_bias = w2_bias.to(torch.float32)
+
+        w13_input_scale = layer.w13_input_scale
+        w2_input_scale = layer.w2_input_scale
+        if w13_input_scale is None or w2_input_scale is None:
+            raise ValueError(
+                "W4A8 (AITER_MXFP4_FP8) requires static input scales, "
+                "but found w13_input_scale or w2_input_scale is None."
+            )
+        if not all_close_1d(w13_input_scale) or not all_close_1d(w2_input_scale):
+            logger.warning_once(
+                "Found input_scales that are not equal for "
+                "fp8 MoE layer. Using the maximum across experts "
+                "for each layer."
+            )
+        w13_input_scale = w13_input_scale.max().to(torch.float32)
+        w2_input_scale = w2_input_scale.max().to(torch.float32)
+
+        w13_weight, w13_weight_scale, w13_bias = _interleave_w13(
+            w13_weight, w13_weight_scale, w13_bias
+        )
+
+        w13_weight, w13_flex, w13_scale = _swizzle_mxfp4(w13_weight, w13_weight_scale)
+        w2_weight, w2_flex, w2_scale = _swizzle_mxfp4(w2_weight, w2_weight_scale)
+
+        lhs_data13 = InFlexData(scale=w13_input_scale)
+        lhs_data2 = InFlexData(scale=w2_input_scale)
+
+        w13_precision_config = PrecisionConfig(
+            weight_scale=w13_scale,
+            flex_ctx=FlexCtx(rhs_data=w13_flex, lhs_data=lhs_data13),
+        )
+        w2_precision_config = PrecisionConfig(
+            weight_scale=w2_scale,
+            flex_ctx=FlexCtx(rhs_data=w2_flex, lhs_data=lhs_data2),
+        )
+
+        del layer.w13_weight
+        del layer.w2_weight
+
+        return (
+            w13_weight,
+            w2_weight,
+            w13_precision_config,
+            w2_precision_config,
+            w13_bias,
+            w2_bias,
+        )
+
     else:
         raise ValueError(
             f"Unsupported mxfp4_backend for Mxfp4MoEMethod: {mxfp4_backend}. "

--- a/vllm/model_executor/layers/fused_moe/oracle/mxfp4.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/mxfp4.py
@@ -1219,12 +1219,9 @@ def convert_weight_to_mxfp4_moe_kernel_format(  # noqa: C901
         Mxfp4MoeBackend.FLASHINFER_CUTLASS_MXFP4_BF16,
         Mxfp4MoeBackend.FLASHINFER_CUTLASS_MXFP4_MXFP8,
     ):
-        # FlashInfer CUTLASS consumes [w3; w1]: swap halves.
-        w13_weight = swap_w13_to_w31(w13_weight.data)
-        w13_weight_scale = swap_w13_to_w31(w13_weight_scale.data)
+        # FlashInfer CUTLASS consumes [w3; w1]
         if w13_bias is not None:
-            b1, b3 = torch.chunk(w13_bias.data, 2, dim=-1)
-            w13_bias = torch.cat([b3, b1], dim=-1).to(torch.bfloat16)
+            w13_bias = w13_bias.data.to(torch.bfloat16)
         if w2_bias is not None:
             w2_bias = w2_bias.data.to(torch.bfloat16)
 

--- a/vllm/model_executor/layers/fused_moe/oracle/mxfp4.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/mxfp4.py
@@ -27,6 +27,7 @@ from vllm.model_executor.layers.fused_moe.config import (
     mxfp4_w4a16_moe_quant_config,
     ocp_mx_moe_quant_config,
 )
+from vllm.model_executor.layers.fused_moe.modular_kernel import W13Layout
 from vllm.model_executor.layers.quantization.utils.flashinfer_utils import (
     swap_w13_to_w31,
 )
@@ -140,6 +141,78 @@ TRITON_BACKENDS = (
     Mxfp4MoeBackend.TRITON,
     Mxfp4MoeBackend.TRITON_UNFUSED,
 )
+
+
+def _swap_w13_halves(
+    w13_weight: torch.Tensor,
+    w13_weight_scale: torch.Tensor,
+    w13_bias: torch.Tensor | None,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
+    """Swap w1/w3 ordering: [w1;w3] <-> [w3;w1] or [g,u,...] <-> [u,g,...]."""
+    w13_weight = swap_w13_to_w31(w13_weight)
+    w13_weight_scale = swap_w13_to_w31(w13_weight_scale)
+    if w13_bias is not None:
+        b1, b3 = torch.chunk(w13_bias, 2, dim=-1)
+        w13_bias = torch.cat([b3, b1], dim=-1)
+    return w13_weight, w13_weight_scale, w13_bias
+
+
+def convert_w13_layout(
+    w13_weight: torch.Tensor,
+    w13_weight_scale: torch.Tensor,
+    w13_bias: torch.Tensor | None,
+    from_layout: W13Layout,
+    to_layout: W13Layout,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
+    """Convert w13 between any two W13Layout formats.
+
+    Decomposes into at most two primitives:
+    - swap halves (W1W3 <-> W3W1)
+    - interleave / deinterleave (contiguous <-> interleaved)
+    """
+    if from_layout == to_layout:
+        logger.info_once(
+            "convert_w13_layout: no-op (%s -> %s)", from_layout.value, to_layout.value
+        )
+        return w13_weight, w13_weight_scale, w13_bias
+
+    _CONTIGUOUS = {W13Layout.CONTIGUOUS_W1W3, W13Layout.CONTIGUOUS_W3W1}
+    _W1W3 = {W13Layout.CONTIGUOUS_W1W3, W13Layout.INTERLEAVED_W1W3}
+
+    from_is_contiguous = from_layout in _CONTIGUOUS
+    to_is_contiguous = to_layout in _CONTIGUOUS
+    from_is_w1w3 = from_layout in _W1W3
+    to_is_w1w3 = to_layout in _W1W3
+
+    need_swap = from_is_w1w3 != to_is_w1w3
+    need_repack = from_is_contiguous != to_is_contiguous
+
+    ops = []
+    if need_swap:
+        ops.append("swap")
+        w13_weight, w13_weight_scale, w13_bias = _swap_w13_halves(
+            w13_weight, w13_weight_scale, w13_bias
+        )
+
+    if need_repack:
+        if to_is_contiguous:
+            ops.append("deinterleave")
+            w13_weight, w13_weight_scale, w13_bias = _deinterleave_w13(
+                w13_weight, w13_weight_scale, w13_bias
+            )
+        else:
+            ops.append("interleave")
+            w13_weight, w13_weight_scale, w13_bias = _interleave_w13(
+                w13_weight, w13_weight_scale, w13_bias
+            )
+
+    logger.info_once(
+        "convert_w13_layout: %s -> %s (ops: %s)",
+        from_layout.value,
+        to_layout.value,
+        ", ".join(ops) if ops else "none",
+    )
+    return w13_weight, w13_weight_scale, w13_bias
 
 
 def _interleave_w13(
@@ -389,6 +462,10 @@ def _get_priority_backends() -> list[Mxfp4MoeBackend]:
             Mxfp4MoeBackend.AITER_MXFP4_BF16,
             Mxfp4MoeBackend.AITER_MXFP4_FP8,
             Mxfp4MoeBackend.AITER_MXFP4_MXFP4,
+            Mxfp4MoeBackend.TRITON,
+            # TRITON_UNFUSED has bug with MTP support
+            # TODO re-enable after kernel is fixed
+            # TRITON_UNFUSED
             Mxfp4MoeBackend.EMULATION,
         ]
     if current_platform.is_xpu():
@@ -499,130 +576,15 @@ def select_gpt_oss_mxfp4_moe_backend(
     config: FusedMoEConfig,
     activation_key: QuantKey | None = None,
 ) -> tuple[Mxfp4MoeBackend, type[mk.FusedMoEExperts] | None]:
-    """
-    Select the primary MXFP4 MoE backend for GPT-OSS (interleaved w13).
-
-    .. deprecated::
-        This function duplicates ``select_mxfp4_moe_backend`` with an
-        interleaved-specific priority list.
-        TODO: merge into ``select_mxfp4_moe_backend`` so that a single
-        entry-point handles both interleaved and non-interleaved checkpoints.
-
-    Args:
-        config: MoE configuration
-        activation_key: Optional activation quantization key. If provided,
-            overrides the default activation key for backend selection.
-            Use kFp8StaticTensorSym for W4A8 scheme.
-
-    Note: Shape-specific fallbacks may still occur at runtime.
-    """
-    requested_activation_key = _resolve_activation_key(activation_key)
-
-    activation_format = (
-        mk.FusedMoEActivationFormat.BatchedExperts
-        if config.moe_parallel_config.use_batched_activation_format
-        else mk.FusedMoEActivationFormat.Standard
-    )
-
-    runner_backend = config.moe_backend
-    if runner_backend != "auto":
-        requested_backends = map_mxfp4_backend(runner_backend)
-        if activation_format == mk.FusedMoEActivationFormat.BatchedExperts:
-            requested_backends = [
-                Mxfp4MoeBackend.BATCHED_MARLIN if b == Mxfp4MoeBackend.MARLIN else b
-                for b in requested_backends
-            ]
-        candidates = _filter_by_activation(requested_backends, requested_activation_key)
-        if not candidates:
-            raise ValueError(
-                f"moe_backend={runner_backend!r} does not support "
-                f"activation={requested_activation_key}; supported variants: "
-                f"{[b.name for b in requested_backends]}"
-            )
-        last_error: Exception | None = None
-        for requested_backend in candidates:
-            act_key = (
-                requested_activation_key
-                if requested_activation_key is not None
-                else _backend_activation_key(requested_backend)
-            )
-            try:
-                return _return_or_raise(
-                    requested_backend,
-                    config,
-                    kMxfp4Static,
-                    act_key,
-                    activation_format,
-                )
-            except ValueError as e:
-                last_error = e
-        assert last_error is not None
-        raise last_error
-
-    # Select kernels in order of backend.
-    AVAILABLE_BACKENDS = _filter_by_activation(
-        _get_priority_backends_for_gpt_oss(), requested_activation_key
-    )
-
-    unsupported_reasons = []
-    for backend in AVAILABLE_BACKENDS:
-        # Use requested_activation_key if provided, otherwise use backend default
-        act_key = (
-            requested_activation_key
-            if requested_activation_key is not None
-            else _backend_activation_key(backend)
-        )
-        for k_cls in backend_to_kernel_cls(backend):
-            supported, reason = k_cls.is_supported_config(
-                k_cls, config, kMxfp4Static, act_key, activation_format
-            )
-            if supported:
-                logger.info_once(_make_log_backend(backend))
-                return backend, k_cls
-            else:
-                logger.debug_once(_make_log_unsupported(backend, reason))
-                unsupported_reasons.append((backend, reason))
-
-    if current_platform.is_xpu():
-        backend = Mxfp4MoeBackend.XPU
-        logger.info_once(_make_log_backend(backend))
-        return _return_or_raise(
-            Mxfp4MoeBackend.XPU,
-            config,
-            kMxfp4Static,
-            None,
-            activation_format,
-        )
-
-    if current_platform.is_cpu():
-        backend = Mxfp4MoeBackend.CPU
-        logger.info_once(_make_log_backend(backend))
-        return _return_or_raise(
-            Mxfp4MoeBackend.CPU,
-            config,
-            kMxfp4Static,
-            None,
-            activation_format,
-        )
-
-    unsupported_log = "; ".join(
-        [
-            f"backend: {backend.value}, reason: {reason}"
-            for backend, reason in unsupported_reasons
-        ]
-    )
-    raise NotImplementedError(
-        "No MXFP4 MoE backend supports the deployment configuration. "
-        f"weight_key=kMxfp4Static, activation_key={activation_key}. "
-        f"Candidate backends were: "
-        f"{[backend.value for backend in AVAILABLE_BACKENDS]}. "
-        f"Unsupported reasons: {unsupported_log}. "
-    )
+    """Deprecated: use ``select_mxfp4_moe_backend(..., use_gpt_oss_priority=True)``."""
+    return select_mxfp4_moe_backend(config, activation_key, use_gpt_oss_priority=True)
 
 
 def select_mxfp4_moe_backend(
     config: FusedMoEConfig,
     activation_key: QuantKey | None = None,
+    *,
+    use_gpt_oss_priority: bool = False,
 ) -> tuple[Mxfp4MoeBackend, type[mk.FusedMoEExperts] | None]:
     """
     Select the MXFP4 MoE backend.
@@ -631,6 +593,10 @@ def select_mxfp4_moe_backend(
         config: MoE configuration
         activation_key: Optional activation quantization key. If provided,
             filters backends to those matching the requested activation.
+        use_gpt_oss_priority: When True, use the GPT-OSS priority list
+            (broader backend coverage including TRTLLM BF16, TRITON, etc.)
+            and fall back to XPU/CPU platforms. When False (default), use
+            the standard priority list.
     """
     requested_activation_key = _resolve_activation_key(activation_key)
 
@@ -677,9 +643,11 @@ def select_mxfp4_moe_backend(
         assert last_error is not None
         raise last_error
 
-    # DeepSeek-V4 on ROCm: prefer AITER FlyDSL MoE (better perf + accuracy
-    # after shuffle/TP-offset fixes), with Triton-unfused as fallback.
-    if (
+    if use_gpt_oss_priority:
+        priority_backends = _filter_by_activation(
+            _get_priority_backends_for_gpt_oss(), requested_activation_key
+        )
+    elif (
         current_platform.is_rocm()
         and config.routing_method == RoutingMethodType.DeepseekV4
     ):
@@ -687,13 +655,16 @@ def select_mxfp4_moe_backend(
             Mxfp4MoeBackend.AITER_MXFP4_BF16,
             Mxfp4MoeBackend.TRITON_UNFUSED,
         ]
+        if requested_activation_key is not None:
+            priority_backends = _filter_by_activation(
+                priority_backends, requested_activation_key
+            )
     else:
         priority_backends = _get_priority_backends()
-
-    if requested_activation_key is not None:
-        priority_backends = _filter_by_activation(
-            priority_backends, requested_activation_key
-        )
+        if requested_activation_key is not None:
+            priority_backends = _filter_by_activation(
+                priority_backends, requested_activation_key
+            )
 
     unsupported_reasons = []
     for backend in priority_backends:
@@ -707,11 +678,33 @@ def select_mxfp4_moe_backend(
                 k_cls, config, kMxfp4Static, act_key, activation_format
             )
             if supported:
-                logger.info_once(_make_log_backend(backend), scope="local")
+                logger.info_once(_make_log_backend(backend), scope="process")
                 return backend, k_cls
             else:
-                logger.debug_once(_make_log_unsupported(backend, reason), scope="local")
+                logger.debug_once(
+                    _make_log_unsupported(backend, reason), scope="process"
+                )
                 unsupported_reasons.append((backend, reason))
+
+    if current_platform.is_xpu():
+        return _return_or_raise(
+            Mxfp4MoeBackend.XPU,
+            config,
+            kMxfp4Static,
+            None,
+            activation_format,
+            scope="process",
+        )
+
+    if current_platform.is_cpu():
+        return _return_or_raise(
+            Mxfp4MoeBackend.CPU,
+            config,
+            kMxfp4Static,
+            None,
+            activation_format,
+            scope="process",
+        )
 
     unsupported_log = "; ".join(
         [
@@ -800,407 +793,33 @@ def convert_gpt_oss_weight_to_mxfp4_moe_kernel_format(
     torch.Tensor | None,
     torch.Tensor | None,
 ]:
-    """Convert interleaved GPT-OSS weights into backend-specific format.
-
-    .. deprecated::
-        Most backends now de-interleave w13 and delegate to
-        ``convert_weight_to_mxfp4_moe_kernel_format``.
-        TODO: merge into ``convert_weight_to_mxfp4_moe_kernel_format``
-        so that a single entry-point handles both layouts.
-    """
-
-    if mxfp4_backend in {
-        Mxfp4MoeBackend.EMULATION,
-        Mxfp4MoeBackend.AITER_MXFP4_MXFP4,
-        Mxfp4MoeBackend.AITER_MXFP4_FP8,
-    }:
-        w13_weight, w13_weight_scale, w13_bias = _deinterleave_w13(
-            w13_weight, w13_weight_scale, w13_bias
-        )
-        return convert_weight_to_mxfp4_moe_kernel_format(
-            mxfp4_backend=mxfp4_backend,
-            layer=layer,
-            w13_weight=w13_weight,
-            w2_weight=w2_weight,
-            w13_weight_scale=w13_weight_scale,
-            w2_weight_scale=w2_weight_scale,
-            w13_bias=w13_bias,
-            w2_bias=w2_bias,
-            _cache_permute_indices=_cache_permute_indices,
-        )
-
-    if mxfp4_backend in {
-        Mxfp4MoeBackend.DEEPGEMM_MXFP4,
-        Mxfp4MoeBackend.MARLIN,
-        Mxfp4MoeBackend.BATCHED_MARLIN,
-        Mxfp4MoeBackend.XPU,
-        Mxfp4MoeBackend.CPU,
-    }:
-        return convert_weight_to_mxfp4_moe_kernel_format(
-            mxfp4_backend=mxfp4_backend,
-            layer=layer,
-            w13_weight=w13_weight,
-            w2_weight=w2_weight,
-            w13_weight_scale=w13_weight_scale,
-            w2_weight_scale=w2_weight_scale,
-            w13_bias=w13_bias,
-            w2_bias=w2_bias,
-            _cache_permute_indices=_cache_permute_indices,
-        )
-
-    num_experts = w13_weight.shape[0]
-    intermediate_size = w13_weight.shape[1] // 2
-    hidden_size = w13_weight.shape[2] * 2
-
-    sf_block_size = 32  # mxfp4 block size
-
-    if mxfp4_backend == Mxfp4MoeBackend.HUMMING:
-        from vllm.model_executor.layers.quantization.utils.humming_utils import (
-            convert_to_humming_moe_kernel_format,
-        )
-
-        convert_to_humming_moe_kernel_format(
-            layer, quant_config={"quant_method": "gpt_oss_mxfp4"}
-        )
-        return (
-            layer.w13_weight,
-            layer.w2_weight,
-            layer.w13_weight_scale,
-            layer.w2_weight_scale,
-            getattr(layer, "w13_bias", None),
-            getattr(layer, "w2_bias", None),
-        )
-    elif mxfp4_backend in TRTLLM_BACKENDS:
-        assert _cache_permute_indices is not None
-        from flashinfer.fp4_quantization import nvfp4_block_scale_interleave
-        from flashinfer.fused_moe.core import get_w2_permute_indices_with_cache
-
-        # gemm1_alpha/beta/clamp_limit are created by the expert class
-        # (TrtLlmMxfp4ExpertsBase), not on the layer.
-
-        w13_weight = w13_weight.data
-        w2_weight = w2_weight.data
-        w13_weight_scale = w13_weight_scale.data
-        w2_weight_scale = w2_weight_scale.data
-        assert w13_bias is not None and w2_bias is not None
-        w13_bias = w13_bias.data.to(torch.float32)
-        w2_bias = w2_bias.data.to(torch.float32)
-
-        # Swap w1 and w3 as the definition of swiglu is different in trtllm-gen
-        def swap_every_two_rows(x, axis=-1):
-            shape = x.shape
-            if axis < 0:
-                axis = len(shape) + axis
-            new_shape = list(shape)
-            new_shape[axis] = shape[axis] // 2
-            new_shape.insert(axis + 1, 2)
-            x = x.reshape(*new_shape)
-            x = x.flip(axis + 1)
-            new_shape = list(shape)
-            return x.reshape(*new_shape)
-
-        w13_weight_scale = swap_every_two_rows(w13_weight_scale, -2)
-        w13_weight = swap_every_two_rows(w13_weight, -2)
-        w13_bias = swap_every_two_rows(w13_bias, -1)
-
-        # Shuffle weights and scaling factors for transposed mma output
-        gemm1_weights_shuffled = []
-        gemm1_scales_shuffled = []
-        gemm2_weights_shuffled = []
-        gemm2_scales_shuffled = []
-        gemm1_bias_shuffled = []
-        gemm2_bias_shuffled = []
-        epilogue_tile_m = 128
-        for i in range(num_experts):
-            # w13 weight
-            permute_indices = get_w2_permute_indices_with_cache(
-                _cache_permute_indices,
-                w13_weight[i].view(torch.uint8),
-                epilogue_tile_m,
-            )
-            gemm1_weights_shuffled.append(
-                w13_weight[i]
-                .view(torch.uint8)[permute_indices.to(w13_weight.device)]
-                .contiguous()
-            )
-            # w13 scale
-            permute_sf_indices = get_w2_permute_indices_with_cache(
-                _cache_permute_indices,
-                w13_weight_scale[i].view(torch.uint8),
-                epilogue_tile_m,
-                num_elts_per_sf=16,
-            )
-            gemm1_scales_shuffled.append(
-                nvfp4_block_scale_interleave(
-                    w13_weight_scale[i]
-                    .view(torch.uint8)[permute_sf_indices.to(w13_weight_scale.device)]
-                    .contiguous()
-                )
-            )
-            # w13 bias
-            permute_bias_indices = get_w2_permute_indices_with_cache(
-                _cache_permute_indices,
-                w13_bias[i].clone().reshape(-1, 1),
-                epilogue_tile_m,
-            )
-            gemm1_bias_shuffled.append(
-                w13_bias[i]
-                .clone()
-                .reshape(-1, 1)[permute_bias_indices.to(w13_bias.device)]
-                .contiguous()
-            )
-            # w2 weight
-            permute_indices = get_w2_permute_indices_with_cache(
-                _cache_permute_indices,
-                w2_weight[i].view(torch.uint8),
-                epilogue_tile_m,
-            )
-            gemm2_weights_shuffled.append(
-                w2_weight[i]
-                .view(torch.uint8)[permute_indices.to(w2_weight.device)]
-                .contiguous()
-            )
-            # w2 scale
-            permute_sf_indices = get_w2_permute_indices_with_cache(
-                _cache_permute_indices,
-                w2_weight_scale[i].view(torch.uint8),
-                epilogue_tile_m,
-                num_elts_per_sf=16,
-            )
-            gemm2_scales_shuffled.append(
-                nvfp4_block_scale_interleave(
-                    w2_weight_scale[i]
-                    .view(torch.uint8)[permute_sf_indices.to(w2_weight_scale.device)]
-                    .contiguous()
-                )
-            )
-            # w2 bias
-            permute_indices = get_w2_permute_indices_with_cache(
-                _cache_permute_indices,
-                w2_bias[i].clone().reshape(-1, 1),
-                epilogue_tile_m,
-            )
-            gemm2_bias_shuffled.append(
-                w2_bias[i]
-                .clone()
-                .reshape(-1, 1)[permute_indices.to(w2_bias.device)]
-                .contiguous()
-            )
-
-        w13_weight = torch.stack(gemm1_weights_shuffled)
-        w13_weight_scale = (
-            torch.stack(gemm1_scales_shuffled)
-            .reshape(num_experts, 2 * intermediate_size, hidden_size // sf_block_size)
-            .view(torch.float8_e4m3fn)
-        )
-        w2_weight = torch.stack(gemm2_weights_shuffled)
-        w2_weight_scale = (
-            torch.stack(gemm2_scales_shuffled)
-            .reshape(num_experts, hidden_size, intermediate_size // sf_block_size)
-            .view(torch.float8_e4m3fn)
-        )
-        w13_bias = torch.stack(gemm1_bias_shuffled).reshape(num_experts, -1)
-        w2_bias = torch.stack(gemm2_bias_shuffled).reshape(num_experts, -1)
-
-        return (
-            w13_weight,
-            w2_weight,
-            w13_weight_scale,
-            w2_weight_scale,
-            w13_bias,
-            w2_bias,
-        )
-
-    elif mxfp4_backend in (
-        Mxfp4MoeBackend.FLASHINFER_CUTLASS_MXFP4_BF16,
-        Mxfp4MoeBackend.FLASHINFER_CUTLASS_MXFP4_MXFP8,
-    ):
-        # De-interleave and swap for w13 weight, bias, and scales
-        w13_w = w13_weight.data
-        gate_w, up_w = w13_w[:, ::2, :], w13_w[:, 1::2, :]
-        deinterleaved_w13_w = torch.cat([gate_w, up_w], dim=1)
-        w1_w, w3_w = torch.chunk(deinterleaved_w13_w, 2, dim=1)
-        w13_weight_swapped = torch.cat([w3_w, w1_w], dim=1)
-
-        assert w13_bias is not None and w2_bias is not None
-        w13_b = w13_bias.data.to(torch.float32)
-        gate_b, up_b = w13_b[:, ::2], w13_b[:, 1::2]
-        deinterleaved_w13_b = torch.cat([gate_b, up_b], dim=1)
-        b1, b3 = torch.chunk(deinterleaved_w13_b, 2, dim=-1)
-        w13_bias_swapped = torch.cat([b3, b1], dim=-1).to(torch.bfloat16)
-
-        w13_s = w13_weight_scale.data
-        gate_s, up_s = w13_s[:, ::2, :], w13_s[:, 1::2, :]
-        deinterleaved_w13_s = torch.cat([gate_s, up_s], dim=1)
-        s1, s3 = torch.chunk(deinterleaved_w13_s, 2, dim=1)
-        w13_scale_swapped = torch.cat([s3, s1], dim=1)
-
-        if mxfp4_backend == Mxfp4MoeBackend.FLASHINFER_CUTLASS_MXFP4_MXFP8:
-            from flashinfer import block_scale_interleave
-
-            orig_shape = w13_scale_swapped.shape
-            w13_scale_interleaved = block_scale_interleave(
-                w13_scale_swapped.view(torch.uint8)
-            ).reshape(orig_shape)
-
-            w2_s = w2_weight_scale.data
-            orig_shape = w2_s.shape
-            w2_scale_interleaved = block_scale_interleave(
-                w2_s.view(torch.uint8)
-            ).reshape(orig_shape)
-
-            return (
-                w13_weight_swapped,
-                w2_weight,
-                w13_scale_interleaved,
-                w2_scale_interleaved,
-                w13_bias_swapped,
-                w2_bias,
-            )
-
-        else:
-            assert mxfp4_backend == Mxfp4MoeBackend.FLASHINFER_CUTLASS_MXFP4_BF16
-
-            from flashinfer.fused_moe import (
-                interleave_moe_scales_for_sm90_mixed_gemm,
-                interleave_moe_weights_for_sm90_mixed_gemm,
-            )
-
-            w13_weight_interleaved = interleave_moe_weights_for_sm90_mixed_gemm(
-                w13_weight_swapped.contiguous(), "fp4"
-            )
-            w2_weight_interleaved = interleave_moe_weights_for_sm90_mixed_gemm(
-                w2_weight.contiguous(), "fp4"
-            )
-            w31_scales_interleaved = interleave_moe_scales_for_sm90_mixed_gemm(
-                w13_scale_swapped.to(torch.uint8)
-            )
-            w2_scale_interleaved = interleave_moe_scales_for_sm90_mixed_gemm(
-                w2_weight_scale.data.to(torch.uint8)
-            )
-
-            return (
-                w13_weight_interleaved,
-                w2_weight_interleaved,
-                w31_scales_interleaved,
-                w2_scale_interleaved,
-                w13_bias_swapped,
-                w2_bias,
-            )
-
-    elif mxfp4_backend == Mxfp4MoeBackend.AITER_MXFP4_BF16:
-        from vllm._aiter_ops import rocm_aiter_ops
-
-        if w13_bias is not None:
-            w13_bias = w13_bias.data.to(torch.float32)
-        if w2_bias is not None:
-            w2_bias = w2_bias.data.to(torch.float32)
-
-        e, n, k = w13_weight.shape
-
-        # De-interleave w13 rows: gate/up pairs -> contiguous gate, up blocks
-        w13_weight.view(torch.uint8).copy_(
-            w13_weight.data.view(torch.uint8)
-            .view(e, n // 2, 2, k)
-            .permute(0, 2, 1, 3)
-            .contiguous()
-            .view(e, n, k)
-        )
-        w13_weight_scale.data = (
-            w13_weight_scale.data.view(e, n // 2, 2, -1)
-            .permute(0, 2, 1, 3)
-            .contiguous()
-            .view(e, n, -1)
-        )
-
-        # View as native FP4 dtype for AITER shuffle
-        w13_weight.data = w13_weight.data.view(torch.float4_e2m1fn_x2)
-        w2_weight.data = w2_weight.data.view(torch.float4_e2m1fn_x2)
-
-        # Shuffle weights and scales for AITER CK kernel layout
-        w13_weight.data = rocm_aiter_ops.shuffle_weight_a16w4(w13_weight, 16, True)
-        shuffled_w13_scale = rocm_aiter_ops.shuffle_scale_a16w4(
-            w13_weight_scale.view(-1, w13_weight_scale.shape[-1]),
-            num_experts,
-            True,
-        )
-
-        w2_weight.data = rocm_aiter_ops.shuffle_weight_a16w4(w2_weight, 16, False)
-        shuffled_w2_scale = rocm_aiter_ops.shuffle_scale_a16w4(
-            w2_weight_scale.view(-1, w2_weight_scale.shape[-1]),
-            num_experts,
-            False,
-        )
-
-        # Permute bias to match de-interleaved weight layout
-        if w13_bias is not None:
-            w13_bias = (
-                w13_bias.data.view(-1, n // 2, 2)
-                .permute(0, 2, 1)
-                .contiguous()
-                .view(-1, n)
-            )
-
-        w13_weight.is_shuffled = True
-        w2_weight.is_shuffled = True
-
-        return (
-            w13_weight,
-            w2_weight,
-            shuffled_w13_scale,
-            shuffled_w2_scale,
-            w13_bias,
-            w2_bias,
-        )
-
-    elif mxfp4_backend in TRITON_BACKENDS:
-        from triton_kernels.matmul_ogs import FlexCtx, PrecisionConfig
-
-        if w13_bias is not None:
-            w13_bias = w13_bias.to(torch.float32)
-        if w2_bias is not None:
-            w2_bias = w2_bias.to(torch.float32)
-
-        w13_weight, w13_flex, w13_scale = _swizzle_mxfp4(
-            w13_weight,
-            w13_weight_scale,
-        )
-        w2_weight, w2_flex, w2_scale = _swizzle_mxfp4(
-            w2_weight,
-            w2_weight_scale,
-        )
-
-        w13_precision_config = PrecisionConfig(
-            weight_scale=w13_scale, flex_ctx=FlexCtx(rhs_data=w13_flex)
-        )
-        w2_precision_config = PrecisionConfig(
-            weight_scale=w2_scale, flex_ctx=FlexCtx(rhs_data=w2_flex)
-        )
-
-        # The original mxfp4 block scales have been swizzled into the
-        # precision configs above and are no longer read by the kernel, so
-        # drop the now-dead weight/scale Parameters to free their memory.
-        del layer.w13_weight
-        del layer.w2_weight
-        del layer.w13_weight_scale
-        del layer.w2_weight_scale
-
-        return (
-            w13_weight,
-            w2_weight,
-            w13_precision_config,
-            w2_precision_config,
-            w13_bias,
-            w2_bias,
-        )
-    else:
-        raise ValueError(
-            f"Unsupported mxfp4_backend: {mxfp4_backend}: "
-            f"should be one of: {list(Mxfp4MoeBackend)}."
-        )
+    """Deprecated: use ``convert_weight_to_mxfp4_moe_kernel_format``
+    with ``input_w13_layout=W13Layout.INTERLEAVED_W1W3``."""
+    return convert_weight_to_mxfp4_moe_kernel_format(
+        mxfp4_backend=mxfp4_backend,
+        layer=layer,
+        w13_weight=w13_weight,
+        w2_weight=w2_weight,
+        w13_weight_scale=w13_weight_scale,
+        w2_weight_scale=w2_weight_scale,
+        w13_bias=w13_bias,
+        w2_bias=w2_bias,
+        _cache_permute_indices=_cache_permute_indices,
+        input_w13_layout=W13Layout.INTERLEAVED_W1W3,
+    )
 
 
-def convert_weight_to_mxfp4_moe_kernel_format(
+# Kept as a module-level helper for the TRITON contiguous→interleaved path.
+def _shuffle_weight_columns(w: torch.Tensor) -> torch.Tensor:
+    shape = w.shape
+    n = shape[-1]
+    first = w[..., : n // 2]
+    second = w[..., n // 2 :]
+    stacked = torch.stack((first, second), dim=-1)
+    return stacked.reshape(shape)
+
+
+def convert_weight_to_mxfp4_moe_kernel_format(  # noqa: C901
     mxfp4_backend: Mxfp4MoeBackend,
     layer: torch.nn.Module,
     w13_weight: torch.Tensor,
@@ -1211,6 +830,7 @@ def convert_weight_to_mxfp4_moe_kernel_format(
     w2_bias: torch.Tensor | None = None,
     _cache_permute_indices: dict[torch.Size, torch.Tensor] | None = None,
     activation: MoEActivation | None = None,
+    input_w13_layout: W13Layout = W13Layout.CONTIGUOUS_W1W3,
 ) -> tuple[
     torch.Tensor,
     torch.Tensor,
@@ -1221,13 +841,40 @@ def convert_weight_to_mxfp4_moe_kernel_format(
 ]:
     """Convert loaded weights into backend-specific kernel format.
 
-    Supports DeepGEMM, FlashInfer, TRTLLM MXFP8, Triton and Marlin backends.
+    Args:
+        input_w13_layout: Layout of the input w13 tensor.
+            CONTIGUOUS_W1W3 for standard checkpoints (default).
+            INTERLEAVED_W1W3 for GPT-OSS checkpoints.
     """
+    _SUPPORTED_INPUT_LAYOUTS = (
+        W13Layout.CONTIGUOUS_W1W3,
+        W13Layout.INTERLEAVED_W1W3,
+    )
+    if input_w13_layout not in _SUPPORTED_INPUT_LAYOUTS:
+        raise ValueError(
+            f"Unsupported input_w13_layout={input_w13_layout}. "
+            f"Expected one of {[ly.value for ly in _SUPPORTED_INPUT_LAYOUTS]}."
+        )
+
     is_gfx1250 = False
     if current_platform.is_rocm():
         from vllm.platforms.rocm import on_gfx1250
 
         is_gfx1250 = on_gfx1250()
+
+    experts_cls = backend_to_kernel_cls(mxfp4_backend)[0]
+    target_layout = experts_cls._expected_w13_layout(
+        layer.activation,
+        weight_key=kMxfp4Static,
+        activation_key=_backend_activation_key(mxfp4_backend),
+    )
+    w13_weight, w13_weight_scale, w13_bias = convert_w13_layout(
+        w13_weight,
+        w13_weight_scale,
+        w13_bias,
+        input_w13_layout,
+        target_layout,
+    )
 
     if mxfp4_backend == Mxfp4MoeBackend.DEEPGEMM_MXFP4:
         w13_weight_scale, w2_weight_scale = _pack_deepgemm_mxfp4_scales(
@@ -1251,8 +898,11 @@ def convert_weight_to_mxfp4_moe_kernel_format(
             convert_to_humming_moe_kernel_format,
         )
 
+        quant_method = (
+            "gpt_oss_mxfp4" if layer.activation == MoEActivation.SWIGLUOAI else "mxfp4"
+        )
         convert_to_humming_moe_kernel_format(
-            layer, quant_config={"quant_method": "mxfp4"}
+            layer, quant_config={"quant_method": quant_method}
         )
         return (
             layer.w13_weight,
@@ -1298,26 +948,7 @@ def convert_weight_to_mxfp4_moe_kernel_format(
         if w2_bias is not None:
             w2_bias = w2_bias.data.to(torch.float32)
 
-        # Swap w1/w3 and interleave to match TRTLLM SwiGLU convention.
-        # Standard loading gives contiguous [w1/gate, w3/up].
         # TRTLLM kernel expects interleaved [w3_0, w1_0, w3_1, w1_1, ...].
-        w1_weight = w13_weight[:, :intermediate_size, :]
-        w3_weight = w13_weight[:, intermediate_size:, :]
-        w13_weight = torch.stack([w3_weight, w1_weight], dim=2).reshape(
-            w13_weight.shape
-        )
-
-        w1_scale = w13_weight_scale[:, :intermediate_size, :]
-        w3_scale = w13_weight_scale[:, intermediate_size:, :]
-        w13_weight_scale = torch.stack([w3_scale, w1_scale], dim=2).reshape(
-            w13_weight_scale.shape
-        )
-
-        if w13_bias is not None:
-            b1 = w13_bias[:, :intermediate_size]
-            b3 = w13_bias[:, intermediate_size:]
-            w13_bias = torch.stack([b3, b1], dim=2).reshape(w13_bias.shape)
-
         # Shuffle weights and scaling factors for transposed mma output.
         # Permute indices depend only on shape (cached by torch.Size),
         # so compute once and apply to all experts via batched indexing.
@@ -1401,78 +1032,40 @@ def convert_weight_to_mxfp4_moe_kernel_format(
         )
 
     elif mxfp4_backend == Mxfp4MoeBackend.AITER_MXFP4_BF16 and not is_gfx1250:
-        # Initially introduced for DeepSeekV4
-
-        if w13_bias is not None:
-            w13_bias = w13_bias.data.to(torch.float32)
-        if w2_bias is not None:
-            w2_bias = w2_bias.data.to(torch.float32)
-
         import os
 
         # TODO: Remove this once AITER is fixed
         # Necessary for AITER side from crashing
         os.environ["AITER_BF16_FP8_MOE_BOUND"] = "0"
 
-        if activation == MoEActivation.SITU:
-            from aiter.utility.fp4_utils import e8m0_shuffle
+        if w13_bias is not None:
+            w13_bias = w13_bias.data.to(torch.float32)
+        if w2_bias is not None:
+            w2_bias = w2_bias.data.to(torch.float32)
 
-            from vllm._aiter_ops import rocm_aiter_ops
+        from vllm._aiter_ops import rocm_aiter_ops
 
-            fp4_dtype = torch.float4_e2m1fn_x2
-            e8m0_dtype = torch.float8_e8m0fnu
-            # a8w4 uses gate/up-interleaved flydsl kernels;
-            # default a16w4 keeps the separated layout.
-            guinterleave = rocm_aiter_ops.is_fused_moe_situv2_a8w4_enabled()
-            w13 = rocm_aiter_ops.shuffle_weight_a16w4(
-                w13_weight.data.view(fp4_dtype), 16, guinterleave
-            )
-            w2 = rocm_aiter_ops.shuffle_weight_a16w4(
-                w2_weight.data.view(fp4_dtype), 16, False
-            )
-            w13_scale_raw = w13_weight_scale.data.view(e8m0_dtype)
-            w2_scale_raw = w2_weight_scale.data.view(e8m0_dtype)
-            w13_scale = rocm_aiter_ops.shuffle_scale_a16w4(
-                w13_scale_raw.view(-1, w13_scale_raw.shape[-1]),
-                num_experts,
-                guinterleave,
-            )
-            w2_scale = e8m0_shuffle(w2_scale_raw.view(-1, w2_scale_raw.shape[-1]))
-            w13.is_shuffled = True
-            w2.is_shuffled = True
-            return (w13, w2, w13_scale, w2_scale, w13_bias, w2_bias)
+        # TODO: Create AITER_MXFP4_MXFP8 for a8w4 kernel.
+        # a8w4 uses gate/up-interleaved flydsl kernels;
+        # default a16w4 keeps the separated layout.
+        # The different layout conversion logic is declared
+        # in AiterExperts._expected_w13_layout and handled
+        # by convert_w13_layout.
 
-        from aiter.ops.shuffle import shuffle_scale as _shuf_s
-        from aiter.ops.shuffle import shuffle_weight as _shuf_w
+        w13_weight.data = w13_weight.data.view(torch.float4_e2m1fn_x2)
+        w2_weight.data = w2_weight.data.view(torch.float4_e2m1fn_x2)
 
-        w13_weight = torch.nn.Parameter(
-            _shuf_w(
-                w13_weight.data.view(torch.float4_e2m1fn_x2),
-                is_guinterleave=True,
-                gate_up=True,
-            ),
-            requires_grad=False,
-        )
-        shuffled_w13_scale = _shuf_s(
-            w13_weight_scale.reshape(-1, w13_weight_scale.shape[-1]),
+        w13_weight.data = rocm_aiter_ops.shuffle_weight_a16w4(w13_weight, 16, True)
+        shuffled_w13_scale = rocm_aiter_ops.shuffle_scale_a16w4(
+            w13_weight_scale.view(-1, w13_weight_scale.shape[-1]),
             num_experts,
             True,
-            True,
         )
 
-        w2_weight = torch.nn.Parameter(
-            _shuf_w(
-                w2_weight.data.view(torch.float4_e2m1fn_x2),
-                is_guinterleave=True,
-                gate_up=False,
-            ),
-            requires_grad=False,
-        )
-        # use_gu_interleave
-        shuffled_w2_scale = _shuf_s(
-            w2_weight_scale.reshape(-1, w2_weight_scale.shape[-1]),
+        w2_weight.data = rocm_aiter_ops.shuffle_weight_a16w4(w2_weight, 16, False)
+        shuffled_w2_scale = rocm_aiter_ops.shuffle_scale_a16w4(
+            w2_weight_scale.view(-1, w2_weight_scale.shape[-1]),
             num_experts,
-            True,
             False,
         )
 
@@ -1493,24 +1086,8 @@ def convert_weight_to_mxfp4_moe_kernel_format(
     ):
         from triton_kernels.matmul_ogs import FlexCtx, PrecisionConfig
 
-        if mxfp4_backend == Mxfp4MoeBackend.TRITON:
-
-            def shuffle_weight(w: torch.Tensor) -> torch.Tensor:
-                shape = w.shape
-                n = shape[-1]
-                first = w[..., : n // 2]
-                second = w[..., n // 2 :]
-                stacked = torch.stack((first, second), dim=-1)
-                return stacked.reshape(shape)
-
-            w13_weight = shuffle_weight(w13_weight)
-            w13_weight_scale = shuffle_weight(w13_weight_scale)
-
-            if w13_bias is not None:
-                w13_bias = shuffle_weight(w13_bias.to(torch.float32))
-        else:
-            if w13_bias is not None:
-                w13_bias = w13_bias.to(torch.float32)
+        if w13_bias is not None:
+            w13_bias = w13_bias.to(torch.float32)
 
         if w2_bias is not None:
             w2_bias = w2_bias.to(torch.float32)
@@ -1547,13 +1124,102 @@ def convert_weight_to_mxfp4_moe_kernel_format(
             w13_bias,
             w2_bias,
         )
+    elif mxfp4_backend == Mxfp4MoeBackend.AITER_MXFP4_MXFP4:
+        from vllm._aiter_ops import rocm_aiter_ops
+
+        if w13_bias is not None:
+            w13_bias = w13_bias.data.to(torch.float32)
+        if w2_bias is not None:
+            w2_bias = w2_bias.data.to(torch.float32)
+
+        from aiter.utility.fp4_utils import e8m0_shuffle
+
+        s0, s1, _ = w13_weight_scale.shape
+        w13_weight_scale.data = e8m0_shuffle(w13_weight_scale.view(s0 * s1, -1)).view(
+            s0, s1, -1
+        )
+
+        s0, s1, _ = w2_weight_scale.shape
+        w2_weight_scale.data = e8m0_shuffle(w2_weight_scale.view(s0 * s1, -1)).view(
+            s0, s1, -1
+        )
+
+        fp4_dtype = getattr(torch, "float4_e2m1fn_x2", None)
+        if fp4_dtype is not None:
+            w13_weight.data = w13_weight.data.view(fp4_dtype)
+            w2_weight.data = w2_weight.data.view(fp4_dtype)
+
+        shuffled_w13, shuffled_w2 = rocm_aiter_ops.shuffle_weights(
+            w13_weight, w2_weight
+        )
+        shuffled_w13.is_shuffled = True
+        shuffled_w2.is_shuffled = True
+
+        return (
+            shuffled_w13,
+            shuffled_w2,
+            w13_weight_scale,
+            w2_weight_scale,
+            w13_bias,
+            w2_bias,
+        )
+
+    elif mxfp4_backend == Mxfp4MoeBackend.AITER_MXFP4_FP8:
+        from triton_kernels.matmul_ogs import FlexCtx, PrecisionConfig
+        from triton_kernels.numerics import InFlexData
+
+        if w13_bias is not None:
+            w13_bias = w13_bias.to(torch.float32)
+        if w2_bias is not None:
+            w2_bias = w2_bias.to(torch.float32)
+
+        w13_input_scale = layer.w13_input_scale
+        w2_input_scale = layer.w2_input_scale
+        if w13_input_scale is None or w2_input_scale is None:
+            raise ValueError(
+                "W4A8 (AITER_MXFP4_FP8) requires static input scales, "
+                "but found w13_input_scale or w2_input_scale is None."
+            )
+        if not all_close_1d(w13_input_scale) or not all_close_1d(w2_input_scale):
+            logger.warning_once(
+                "Found input_scales that are not equal for "
+                "fp8 MoE layer. Using the maximum across experts "
+                "for each layer."
+            )
+        w13_input_scale = w13_input_scale.max().to(torch.float32)
+        w2_input_scale = w2_input_scale.max().to(torch.float32)
+
+        w13_weight, w13_flex, w13_scale = _swizzle_mxfp4(w13_weight, w13_weight_scale)
+        w2_weight, w2_flex, w2_scale = _swizzle_mxfp4(w2_weight, w2_weight_scale)
+
+        lhs_data13 = InFlexData(scale=w13_input_scale)
+        lhs_data2 = InFlexData(scale=w2_input_scale)
+
+        w13_precision_config = PrecisionConfig(
+            weight_scale=w13_scale,
+            flex_ctx=FlexCtx(rhs_data=w13_flex, lhs_data=lhs_data13),
+        )
+        w2_precision_config = PrecisionConfig(
+            weight_scale=w2_scale,
+            flex_ctx=FlexCtx(rhs_data=w2_flex, lhs_data=lhs_data2),
+        )
+
+        del layer.w13_weight
+        del layer.w2_weight
+
+        return (
+            w13_weight,
+            w2_weight,
+            w13_precision_config,
+            w2_precision_config,
+            w13_bias,
+            w2_bias,
+        )
     elif mxfp4_backend in (
         Mxfp4MoeBackend.FLASHINFER_CUTLASS_MXFP4_BF16,
         Mxfp4MoeBackend.FLASHINFER_CUTLASS_MXFP4_MXFP8,
     ):
-        # Standard checkpoints store fused gate/up tensors as [w1; w3], while
-        # FlashInfer CUTLASS consumes [w3; w1]. Keep weights, scales, and bias
-        # in the same order before applying the backend-specific interleave.
+        # FlashInfer CUTLASS consumes [w3; w1]: swap halves.
         w13_weight = swap_w13_to_w31(w13_weight.data)
         w13_weight_scale = swap_w13_to_w31(w13_weight_scale.data)
         if w13_bias is not None:
@@ -1630,108 +1296,11 @@ def convert_weight_to_mxfp4_moe_kernel_format(
         Mxfp4MoeBackend.XPU,
         Mxfp4MoeBackend.EMULATION,
     ):
-        # No additional transformation is needed: XPU consumes the checkpoint
-        # layout directly, while emulation dequantizes that layout at runtime.
         return (
             w13_weight,
             w2_weight,
             w13_weight_scale,
             w2_weight_scale,
-            w13_bias,
-            w2_bias,
-        )
-    elif mxfp4_backend == Mxfp4MoeBackend.AITER_MXFP4_MXFP4:
-        from vllm._aiter_ops import rocm_aiter_ops
-
-        if w13_bias is not None:
-            w13_bias = w13_bias.data.to(torch.float32)
-        if w2_bias is not None:
-            w2_bias = w2_bias.data.to(torch.float32)
-
-        from aiter.utility.fp4_utils import e8m0_shuffle
-
-        s0, s1, _ = w13_weight_scale.shape
-        w13_weight_scale.data = e8m0_shuffle(w13_weight_scale.view(s0 * s1, -1)).view(
-            s0, s1, -1
-        )
-
-        s0, s1, _ = w2_weight_scale.shape
-        w2_weight_scale.data = e8m0_shuffle(w2_weight_scale.view(s0 * s1, -1)).view(
-            s0, s1, -1
-        )
-
-        fp4_dtype = getattr(torch, "float4_e2m1fn_x2", None)
-        if fp4_dtype is not None:
-            w13_weight.data = w13_weight.data.view(fp4_dtype)
-            w2_weight.data = w2_weight.data.view(fp4_dtype)
-
-        shuffled_w13, shuffled_w2 = rocm_aiter_ops.shuffle_weights(
-            w13_weight, w2_weight
-        )
-        shuffled_w13.is_shuffled = True
-        shuffled_w2.is_shuffled = True
-
-        return (
-            shuffled_w13,
-            shuffled_w2,
-            w13_weight_scale,
-            w2_weight_scale,
-            w13_bias,
-            w2_bias,
-        )
-
-    elif mxfp4_backend == Mxfp4MoeBackend.AITER_MXFP4_FP8:
-        from triton_kernels.matmul_ogs import FlexCtx, PrecisionConfig
-        from triton_kernels.numerics import InFlexData
-
-        if w13_bias is not None:
-            w13_bias = w13_bias.to(torch.float32)
-        if w2_bias is not None:
-            w2_bias = w2_bias.to(torch.float32)
-
-        w13_input_scale = layer.w13_input_scale
-        w2_input_scale = layer.w2_input_scale
-        if w13_input_scale is None or w2_input_scale is None:
-            raise ValueError(
-                "W4A8 (AITER_MXFP4_FP8) requires static input scales, "
-                "but found w13_input_scale or w2_input_scale is None."
-            )
-        if not all_close_1d(w13_input_scale) or not all_close_1d(w2_input_scale):
-            logger.warning_once(
-                "Found input_scales that are not equal for "
-                "fp8 MoE layer. Using the maximum across experts "
-                "for each layer."
-            )
-        w13_input_scale = w13_input_scale.max().to(torch.float32)
-        w2_input_scale = w2_input_scale.max().to(torch.float32)
-
-        w13_weight, w13_weight_scale, w13_bias = _interleave_w13(
-            w13_weight, w13_weight_scale, w13_bias
-        )
-
-        w13_weight, w13_flex, w13_scale = _swizzle_mxfp4(w13_weight, w13_weight_scale)
-        w2_weight, w2_flex, w2_scale = _swizzle_mxfp4(w2_weight, w2_weight_scale)
-
-        lhs_data13 = InFlexData(scale=w13_input_scale)
-        lhs_data2 = InFlexData(scale=w2_input_scale)
-
-        w13_precision_config = PrecisionConfig(
-            weight_scale=w13_scale,
-            flex_ctx=FlexCtx(rhs_data=w13_flex, lhs_data=lhs_data13),
-        )
-        w2_precision_config = PrecisionConfig(
-            weight_scale=w2_scale,
-            flex_ctx=FlexCtx(rhs_data=w2_flex, lhs_data=lhs_data2),
-        )
-
-        del layer.w13_weight
-        del layer.w2_weight
-
-        return (
-            w13_weight,
-            w2_weight,
-            w13_precision_config,
-            w2_precision_config,
             w13_bias,
             w2_bias,
         )

--- a/vllm/model_executor/layers/quantization/mxfp4.py
+++ b/vllm/model_executor/layers/quantization/mxfp4.py
@@ -17,15 +17,14 @@ from vllm.model_executor.layers.fused_moe import modular_kernel as mk
 from vllm.model_executor.layers.fused_moe.config import (
     mxfp4_w4a16_moe_quant_config,
 )
+from vllm.model_executor.layers.fused_moe.modular_kernel import W13Layout
 from vllm.model_executor.layers.fused_moe.oracle.mxfp4 import (
     TRITON_BACKENDS,
     Mxfp4MoeBackend,
-    convert_gpt_oss_weight_to_mxfp4_moe_kernel_format,
     convert_weight_to_mxfp4_moe_kernel_format,
     make_mxfp4_moe_kernel,
     make_mxfp4_moe_quant_config,
     mxfp4_round_up_hidden_size_and_intermediate_size,
-    select_gpt_oss_mxfp4_moe_backend,
     select_mxfp4_moe_backend,
 )
 from vllm.model_executor.layers.linear import LinearBase, UnquantizedLinearMethod
@@ -144,7 +143,9 @@ class GptOssMxfp4MoEMethod(FusedMoEMethodBase):
     def __init__(self, moe: FusedMoEConfig):
         super().__init__(moe)
         self.weight_dtype = "gpt_oss_mxfp4"
-        self.mxfp4_backend, self.experts_cls = select_gpt_oss_mxfp4_moe_backend(moe)
+        self.mxfp4_backend, self.experts_cls = select_mxfp4_moe_backend(
+            moe, use_gpt_oss_priority=True
+        )
 
         self.max_capture_size = moe.max_capture_size
 
@@ -334,7 +335,7 @@ class GptOssMxfp4MoEMethod(FusedMoEMethodBase):
 
         # Convert weights to kernel format
         w13, w2, w13_scale, w2_scale, w13_bias, w2_bias = (
-            convert_gpt_oss_weight_to_mxfp4_moe_kernel_format(
+            convert_weight_to_mxfp4_moe_kernel_format(
                 mxfp4_backend=self.mxfp4_backend,
                 layer=layer,
                 w13_weight=w13,
@@ -344,6 +345,7 @@ class GptOssMxfp4MoEMethod(FusedMoEMethodBase):
                 w13_bias=w13_bias,
                 w2_bias=w2_bias,
                 _cache_permute_indices=self._cache_permute_indices,
+                input_w13_layout=W13Layout.INTERLEAVED_W1W3,
             )
         )
 

--- a/vllm/model_executor/layers/quantization/mxfp4.py
+++ b/vllm/model_executor/layers/quantization/mxfp4.py
@@ -25,7 +25,7 @@ from vllm.model_executor.layers.fused_moe.oracle.mxfp4 import (
     make_mxfp4_moe_kernel,
     make_mxfp4_moe_quant_config,
     mxfp4_round_up_hidden_size_and_intermediate_size,
-    select_deepseek_v4_mxfp4_moe_backend,
+    select_gpt_oss_mxfp4_moe_backend,
     select_mxfp4_moe_backend,
 )
 from vllm.model_executor.layers.linear import LinearBase, UnquantizedLinearMethod
@@ -144,7 +144,7 @@ class GptOssMxfp4MoEMethod(FusedMoEMethodBase):
     def __init__(self, moe: FusedMoEConfig):
         super().__init__(moe)
         self.weight_dtype = "gpt_oss_mxfp4"
-        self.mxfp4_backend, self.experts_cls = select_mxfp4_moe_backend(moe)
+        self.mxfp4_backend, self.experts_cls = select_gpt_oss_mxfp4_moe_backend(moe)
 
         self.max_capture_size = moe.max_capture_size
 
@@ -476,7 +476,7 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
         super().__init__(moe)
 
         self.weight_dtype = "mxfp4"
-        self.mxfp4_backend, self.experts_cls = select_deepseek_v4_mxfp4_moe_backend(moe)
+        self.mxfp4_backend, self.experts_cls = select_mxfp4_moe_backend(moe)
 
         self.max_capture_size = moe.max_capture_size
 

--- a/vllm/model_executor/layers/quantization/quark/quark_moe.py
+++ b/vllm/model_executor/layers/quantization/quark/quark_moe.py
@@ -44,9 +44,11 @@ from vllm.model_executor.layers.fused_moe.oracle.mxfp4 import (
     Mxfp4MoeBackend,
     backend_to_kernel_cls,
     convert_gpt_oss_weight_to_mxfp4_moe_kernel_format,
+    convert_weight_to_mxfp4_moe_kernel_format,
     make_mxfp4_moe_kernel,
     make_mxfp4_moe_quant_config,
     mxfp4_round_up_hidden_size_and_intermediate_size,
+    select_gpt_oss_mxfp4_moe_backend,
     select_mxfp4_moe_backend,
 )
 from vllm.model_executor.layers.fused_moe.oracle.nvfp4 import (
@@ -1091,18 +1093,28 @@ class QuarkOCP_MX_MoEMethod(QuarkMoEMethod):
         else:
             self.static_input_scales = False
 
+        self.model_type = getattr(
+            get_current_vllm_config().model_config.hf_config, "model_type", None
+        )
+
+        # TODO: Remove this after select_gpt_oss_mxfp4_moe_backend is deprecated
+        if self.model_type == "gpt_oss":
+            _select_mxfp4_moe_backend = select_gpt_oss_mxfp4_moe_backend
+        else:
+            _select_mxfp4_moe_backend = select_mxfp4_moe_backend
+
         # Select backend based on OCP MX scheme
         if self.ocp_mx_scheme == "w_mxfp4":
             # W4A16: weight-only MXFP4
-            self.mxfp4_backend, self.experts_cls = select_mxfp4_moe_backend(moe)
+            self.mxfp4_backend, self.experts_cls = _select_mxfp4_moe_backend(moe)
         elif self.ocp_mx_scheme == "w_mxfp4_a_fp8" and self.static_input_scales:
             # W4A8: MXFP4 weights + static FP8 activations
-            self.mxfp4_backend, self.experts_cls = select_mxfp4_moe_backend(
+            self.mxfp4_backend, self.experts_cls = _select_mxfp4_moe_backend(
                 moe, activation_key=kFp8StaticTensorSym
             )
         elif self.ocp_mx_scheme == "w_mxfp4_a_mxfp4":
             # W4A4: MXFP4 weights + MXFP4 activations
-            self.mxfp4_backend, self.experts_cls = select_mxfp4_moe_backend(
+            self.mxfp4_backend, self.experts_cls = _select_mxfp4_moe_backend(
                 moe, activation_key=kMxfp4Dynamic
             )
 
@@ -1123,10 +1135,6 @@ class QuarkOCP_MX_MoEMethod(QuarkMoEMethod):
                 f"not implemented for OCP MX scheme {self.ocp_mx_scheme}. "
                 "Please open an issue."
             )
-
-        self.model_type = getattr(
-            get_current_vllm_config().model_config.hf_config, "model_type", None
-        )
 
         # If no native backend available, use emulation.
         if self.mxfp4_backend is Mxfp4MoeBackend.NONE:
@@ -1281,13 +1289,24 @@ class QuarkOCP_MX_MoEMethod(QuarkMoEMethod):
         self._setup_kernel(layer)
 
     def _setup_kernel(self, layer: RoutedExperts):
-        """Setup kernel using oracle functions for MXFP4 schemes (W4A16, W4A8)."""
+        """Setup kernel using oracle functions for MXFP4 schemes (W4A16, W4A8, W4A4)."""
         w13_bias = getattr(layer, "w13_bias", None)
         w2_bias = getattr(layer, "w2_bias", None)
 
+        # TODO: Remove this after convert_gpt_oss_weight_to_mxfp4_moe_kernel_format
+        # is deprecated
+        if self.model_type == "gpt_oss":
+            _convert_weight_to_mxfp4_moe_kernel_format = (
+                convert_gpt_oss_weight_to_mxfp4_moe_kernel_format
+            )
+        else:
+            _convert_weight_to_mxfp4_moe_kernel_format = (
+                convert_weight_to_mxfp4_moe_kernel_format
+            )
+
         # Convert weights to kernel format (handles all backend-specific logic)
         w13, w2, w13_scale, w2_scale, w13_bias, w2_bias = (
-            convert_gpt_oss_weight_to_mxfp4_moe_kernel_format(
+            _convert_weight_to_mxfp4_moe_kernel_format(
                 mxfp4_backend=self.mxfp4_backend,
                 layer=layer,
                 w13_weight=layer.w13_weight,
@@ -1296,8 +1315,6 @@ class QuarkOCP_MX_MoEMethod(QuarkMoEMethod):
                 w2_weight_scale=layer.w2_weight_scale,
                 w13_bias=w13_bias,
                 w2_bias=w2_bias,
-                w13_input_scale=layer.w13_input_scale,
-                w2_input_scale=layer.w2_input_scale,
             )
         )
 

--- a/vllm/model_executor/layers/quantization/quark/quark_moe.py
+++ b/vllm/model_executor/layers/quantization/quark/quark_moe.py
@@ -26,6 +26,7 @@ from vllm.model_executor.layers.fused_moe.config import (
     mxfp4_w4a16_moe_quant_config,
     ocp_mx_moe_quant_config,
 )
+from vllm.model_executor.layers.fused_moe.modular_kernel import W13Layout
 from vllm.model_executor.layers.fused_moe.oracle.fp8 import (
     convert_to_fp8_moe_kernel_format,
     make_fp8_moe_kernel,
@@ -43,12 +44,10 @@ from vllm.model_executor.layers.fused_moe.oracle.mxfp4 import (
     TRITON_BACKENDS,
     Mxfp4MoeBackend,
     backend_to_kernel_cls,
-    convert_gpt_oss_weight_to_mxfp4_moe_kernel_format,
     convert_weight_to_mxfp4_moe_kernel_format,
     make_mxfp4_moe_kernel,
     make_mxfp4_moe_quant_config,
     mxfp4_round_up_hidden_size_and_intermediate_size,
-    select_gpt_oss_mxfp4_moe_backend,
     select_mxfp4_moe_backend,
 )
 from vllm.model_executor.layers.fused_moe.oracle.nvfp4 import (
@@ -1097,25 +1096,27 @@ class QuarkOCP_MX_MoEMethod(QuarkMoEMethod):
             get_current_vllm_config().model_config.hf_config, "model_type", None
         )
 
-        # TODO: Remove this after select_gpt_oss_mxfp4_moe_backend is deprecated
-        if self.model_type == "gpt_oss":
-            _select_mxfp4_moe_backend = select_gpt_oss_mxfp4_moe_backend
-        else:
-            _select_mxfp4_moe_backend = select_mxfp4_moe_backend
+        _use_gpt_oss = self.model_type == "gpt_oss"
 
         # Select backend based on OCP MX scheme
         if self.ocp_mx_scheme == "w_mxfp4":
             # W4A16: weight-only MXFP4
-            self.mxfp4_backend, self.experts_cls = _select_mxfp4_moe_backend(moe)
+            self.mxfp4_backend, self.experts_cls = select_mxfp4_moe_backend(
+                moe, use_gpt_oss_priority=_use_gpt_oss
+            )
         elif self.ocp_mx_scheme == "w_mxfp4_a_fp8" and self.static_input_scales:
             # W4A8: MXFP4 weights + static FP8 activations
-            self.mxfp4_backend, self.experts_cls = _select_mxfp4_moe_backend(
-                moe, activation_key=kFp8StaticTensorSym
+            self.mxfp4_backend, self.experts_cls = select_mxfp4_moe_backend(
+                moe,
+                activation_key=kFp8StaticTensorSym,
+                use_gpt_oss_priority=_use_gpt_oss,
             )
         elif self.ocp_mx_scheme == "w_mxfp4_a_mxfp4":
             # W4A4: MXFP4 weights + MXFP4 activations
-            self.mxfp4_backend, self.experts_cls = _select_mxfp4_moe_backend(
-                moe, activation_key=kMxfp4Dynamic
+            self.mxfp4_backend, self.experts_cls = select_mxfp4_moe_backend(
+                moe,
+                activation_key=kMxfp4Dynamic,
+                use_gpt_oss_priority=_use_gpt_oss,
             )
 
         # Validation for unsupported schemes
@@ -1293,20 +1294,15 @@ class QuarkOCP_MX_MoEMethod(QuarkMoEMethod):
         w13_bias = getattr(layer, "w13_bias", None)
         w2_bias = getattr(layer, "w2_bias", None)
 
-        # TODO: Remove this after convert_gpt_oss_weight_to_mxfp4_moe_kernel_format
-        # is deprecated
-        if self.model_type == "gpt_oss":
-            _convert_weight_to_mxfp4_moe_kernel_format = (
-                convert_gpt_oss_weight_to_mxfp4_moe_kernel_format
-            )
-        else:
-            _convert_weight_to_mxfp4_moe_kernel_format = (
-                convert_weight_to_mxfp4_moe_kernel_format
-            )
+        _input_layout = (
+            W13Layout.INTERLEAVED_W1W3
+            if self.model_type == "gpt_oss"
+            else W13Layout.CONTIGUOUS_W1W3
+        )
 
         # Convert weights to kernel format (handles all backend-specific logic)
         w13, w2, w13_scale, w2_scale, w13_bias, w2_bias = (
-            _convert_weight_to_mxfp4_moe_kernel_format(
+            convert_weight_to_mxfp4_moe_kernel_format(
                 mxfp4_backend=self.mxfp4_backend,
                 layer=layer,
                 w13_weight=layer.w13_weight,
@@ -1315,6 +1311,7 @@ class QuarkOCP_MX_MoEMethod(QuarkMoEMethod):
                 w2_weight_scale=layer.w2_weight_scale,
                 w13_bias=w13_bias,
                 w2_bias=w2_bias,
+                input_w13_layout=_input_layout,
             )
         )
 


### PR DESCRIPTION
## Background

GPT-OSS checkpoints store fused gate/up weights in interleaved row order [g0, u0, g1, u1, ...], while standard MoE checkpoints (DeepSeek, Kimi-K3, and most of the ckpts from different quantizers etc.) store them contiguously [gate; up].

In the beginning when mxfp4 oracle was initially created, this interleaved weight format is overlooked. Some backends accepts interleaved format while others accepts contiguous format. They are all mixed together in the same `convert_weight_*` and `select_mxfp4_moe_backend` call.

Later when DSV4 was added, two parallel functions (convert_gpt_oss_weight_* and convert_weight_*) were created. The original `convert_weight_*` was renamed `convert_gpt_oss_weight_*`, despite it handles more models than just gpt-oss. Now several backends shared identical code between them, meaning they silently accepted either layout without converting, which is incorrect for backends that assume a specific layout.

## Audit DeepDive

This PR starts a complete, deepdive audit to the existing state of all the backends. **NOTE:** The audit is produced by Claude Code, and verified carefully by the author. There could be mistakes.

### Terminology

- **Contiguous [w1;w3]** = `[gate_0..gate_N; up_0..up_N]` (standard vLLM checkpoint layout)
- **Contiguous [w3;w1]** = `[up_0..up_N; gate_0..gate_N]` (FlashInfer CUTLASS convention, halves swapped)
- **Interleaved [g,u]** = `[gate_0, up_0, gate_1, up_1, ...]` (GPT-OSS checkpoint layout)
- **Interleaved [u,g]** = `[up_0, gate_0, up_1, gate_1, ...]` (TRTLLM convention, w1/w3 swapped within pairs)

### w13 Layout Expected by Backend x Activation

| Backend | Activation | w13 Layout | Proof |
|---|---|---|---|
| **DEEPGEMM_MXFP4** | SILU | **Contiguous [w1;w3]** | [`fp8_utils.py:143`](https://github.com/vllm-project/vllm/blob/4be4e9a580/vllm/model_executor/layers/quantization/utils/fp8_utils.py#L143): `hidden_size: tl.constexpr = N // 2`; [`fp8_utils.py:165-178`](https://github.com/vllm-project/vllm/blob/4be4e9a580/vllm/model_executor/layers/quantization/utils/fp8_utils.py#L165): loads gate from `input_ptr + offset`, up from `input_ptr + hidden_size + offset` |
| | SWIGLUSTEP | **Contiguous [w1;w3]** | [`layers/activation.py:37-38`](https://github.com/vllm-project/vllm/blob/4be4e9a580/vllm/model_executor/layers/activation.py#L37): `gate = tl.load(x_row_ptr + offsets)`, `up = tl.load(x_row_ptr + offsets + d)` with `d = n // 2` at [line 55](https://github.com/vllm-project/vllm/blob/4be4e9a580/vllm/model_executor/layers/activation.py#L55) |
| | SITU | **Contiguous [w1;w3]** | [`activation_kernels.cu:483-484`](https://github.com/vllm-project/vllm/blob/4be4e9a580/csrc/libtorch_stable/activation_kernels.cu#L483): `gate_ptr = input + row * 2 * d`, `up_ptr = gate_ptr + d` |
| **TRTLLM** | SWIGLUOAI, SILU, SITU | **Interleaved [u,g]** | [`mxfp4.py:1310-1317`](https://github.com/vllm-project/vllm/blob/4be4e9a580/vllm/model_executor/layers/fused_moe/oracle/mxfp4.py#L1310): comment "TRTLLM kernel expects interleaved [w3_0, w1_0, ...]"; `torch.stack([w3_weight, w1_weight], dim=2).reshape()` produces `[up_0, gate_0, up_1, gate_1, ...]` |
| | | | [`trtllm_mxfp4_moe.py:139-146`](https://github.com/vllm-project/vllm/blob/4be4e9a580/vllm/model_executor/layers/fused_moe/experts/trtllm_mxfp4_moe.py#L139): SITU support gated behind `has_flashinfer_situ_activation()` |
| **FLASHINFER_CUTLASS** | SILU, GELU_TANH, SWIGLUOAI, SWIGLUOAI_UNINTERLEAVE, RELU2_NO_MUL | **Contiguous [w3;w1]** (swapped halves) | [`flashinfer_utils.py:53-56`](https://github.com/vllm-project/vllm/blob/4be4e9a580/vllm/model_executor/layers/quantization/utils/flashinfer_utils.py#L53): `swap_w13_to_w31` reshapes to `(-1, 2, half, cols)` and `.flip(dims=[1])`, swapping gate and up halves |
| | | | [`mxfp4.py:1535-1539`](https://github.com/vllm-project/vllm/blob/4be4e9a580/vllm/model_executor/layers/fused_moe/oracle/mxfp4.py#L1535): comment "Standard checkpoints store [w1; w3], FlashInfer CUTLASS consumes [w3; w1]" |
| | | | [`flashinfer_cutlass_moe.py:191-198`](https://github.com/vllm-project/vllm/blob/4be4e9a580/vllm/model_executor/layers/fused_moe/experts/flashinfer_cutlass_moe.py#L191): `_supports_activation` lists SILU, GELU_TANH, RELU2_NO_MUL, SWIGLUOAI, SWIGLUOAI_UNINTERLEAVE |
| **TRITON (fused)** | SWIGLUOAI | **Interleaved [g,u]** | [`_swiglu.py:52`](https://github.com/vllm-project/vllm/blob/4be4e9a580/vllm/third_party/triton_kernels/swiglu_details/_swiglu.py#L52): `gelu, linear = tl.split(tl.reshape(input, (input.shape[0], input.shape[1] // 2, 2)))` — reshapes to `(M, N//2, 2)` then splits, pairing consecutive elements |
| | | | [`gpt_oss_triton_kernels_moe.py:967-968`](https://github.com/vllm-project/vllm/blob/4be4e9a580/vllm/model_executor/layers/fused_moe/experts/gpt_oss_triton_kernels_moe.py#L967): `_supports_activation` returns `activation == MoEActivation.SWIGLUOAI` |
| | | | [`mxfp4.py:1477-1485`](https://github.com/vllm-project/vllm/blob/4be4e9a580/vllm/model_executor/layers/fused_moe/oracle/mxfp4.py#L1477): `shuffle_weight` converts contiguous `[w1;w3]` to interleaved via `torch.stack((first, second), dim=-1).reshape(shape)` |
| **TRITON_UNFUSED** | SWIGLUOAI | **Interleaved [g,u]** | [`activation_kernels.cu:410`](https://github.com/vllm-project/vllm/blob/4be4e9a580/csrc/libtorch_stable/activation_kernels.cu#L410): comment `// Interleaved gate/up: input has [gate0, up0, gate1, up1, ...]`; vectorized path at [line 448](https://github.com/vllm-project/vllm/blob/4be4e9a580/csrc/libtorch_stable/activation_kernels.cu#L448): `ACT_FN(vp[2*j], vp[2*j+1], ...)` |
| | SWIGLUOAI_UNINTERLEAVE | **Contiguous [w1;w3]** | [`fused_moe/activation.py:262-268`](https://github.com/vllm-project/vllm/blob/4be4e9a580/vllm/model_executor/layers/fused_moe/activation.py#L262): dispatches to `silu_and_mul_with_clamp` → [`activation_kernels.cu:102-108`](https://github.com/vllm-project/vllm/blob/4be4e9a580/csrc/libtorch_stable/activation_kernels.cu#L102): `x_ptr = input + token_idx * 2 * d`, `y_ptr = x_ptr + d` |
| | SILU, GELU, SWIGLUSTEP | **Contiguous [w1;w3]** | [`fused_moe/activation.py:230-236`](https://github.com/vllm-project/vllm/blob/4be4e9a580/vllm/model_executor/layers/fused_moe/activation.py#L230): dispatches to `silu_and_mul` etc. → `act_and_mul_kernel` at [`activation_kernels.cu:104`](https://github.com/vllm-project/vllm/blob/4be4e9a580/csrc/libtorch_stable/activation_kernels.cu#L104): `input // [..., 2, d]` midpoint split |
| | | | [`gpt_oss_triton_kernels_moe.py:1057-1064`](https://github.com/vllm-project/vllm/blob/4be4e9a580/vllm/model_executor/layers/fused_moe/experts/gpt_oss_triton_kernels_moe.py#L1057): `_supports_activation` lists SILU, GELU, SWIGLUOAI, SWIGLUSTEP, SWIGLUOAI_UNINTERLEAVE |
| **AITER W4A16** (CK) | SILU, GELU, SWIGLUOAI, SWIGLUOAI_UNINTERLEAVE | **Interleaved [g,u]** | [`rocm_aiter_moe.py:384-385`](https://github.com/vllm-project/vllm/blob/4be4e9a580/vllm/model_executor/layers/fused_moe/experts/rocm_aiter_moe.py#L384): `gate_mode = GateMode.INTERLEAVE.value` when `use_mxfp4_w4a16=True` |
| | | | [`mxfp4.py:1429-1434`](https://github.com/vllm-project/vllm/blob/4be4e9a580/vllm/model_executor/layers/fused_moe/oracle/mxfp4.py#L1429): weight shuffle with `is_guinterleave=True, gate_up=True` |
| | SITU | **Contiguous [w1;w3]** (separated) | [`rocm_aiter_moe.py:374-383`](https://github.com/vllm-project/vllm/blob/4be4e9a580/vllm/model_executor/layers/fused_moe/experts/rocm_aiter_moe.py#L374): SITU defaults to `GateMode.SEPARATED.value` (unless env-var `VLLM_ROCM_USE_AITER_MOE_SITUV2_A8W4=1` enables interleaved a8w4 path) |
| | | | Note: weight prep at [`mxfp4.py:1429-1434`](https://github.com/vllm-project/vllm/blob/4be4e9a580/vllm/model_executor/layers/fused_moe/oracle/mxfp4.py#L1429) always uses `is_guinterleave=True` regardless of activation — `is_guinterleave` controls CK tile layout, not logical gate/up ordering. Runtime `gate_mode` controls which kernel variant is dispatched. |
| **AITER W4A8** (triton) | SWIGLUOAI | **Interleaved [g,u]** | [`mxfp4.py:1689-1691`](https://github.com/vllm-project/vllm/blob/4be4e9a580/vllm/model_executor/layers/fused_moe/oracle/mxfp4.py#L1689): `_interleave_w13(w13_weight, w13_weight_scale, w13_bias)` converts contiguous → interleaved before `_swizzle_mxfp4` |
| | | | [`moe_op_gemm_a8w4.py:719-722`](https://github.com/ROCm/aiter/blob/e6e70704f5/aiter/ops/triton/moe/moe_op_gemm_a8w4.py#L719): `a_gelu = a[..., ::2]`, `a_linear = a[..., 1::2]` in `swiglu_torch` |
| | | | [`aiter_mxfp4_w4a8_moe.py:305`](https://github.com/vllm-project/vllm/blob/4be4e9a580/vllm/model_executor/layers/fused_moe/experts/aiter_mxfp4_w4a8_moe.py#L305): only supports `MoEActivation.SWIGLUOAI` |
| **AITER W4A4** (CK) | SILU, GELU, SWIGLUOAI, SWIGLUOAI_UNINTERLEAVE | **Contiguous [w1;w3]** | [`rocm_aiter_moe.py:374`](https://github.com/vllm-project/vllm/blob/4be4e9a580/vllm/model_executor/layers/fused_moe/experts/rocm_aiter_moe.py#L374): default `gate_mode = ""` (not set for W4A4 path); [`_aiter_ops.py:228`](https://github.com/vllm-project/vllm/blob/4be4e9a580/vllm/_aiter_ops.py#L228): `gate_mode: str = ""` means `gate_mode` not passed to kernel |
| | | | [`mxfp4.py:1624-1662`](https://github.com/vllm-project/vllm/blob/4be4e9a580/vllm/model_executor/layers/fused_moe/oracle/mxfp4.py#L1624): no `_interleave_w13` call; only `e8m0_shuffle` + `shuffle_weights` |
| **MARLIN/BATCHED_MARLIN** | SWIGLUOAI | **Interleaved [g,u]** | Pure GEMM → [`fused_moe/activation.py:260-261`](https://github.com/vllm-project/vllm/blob/4be4e9a580/vllm/model_executor/layers/fused_moe/activation.py#L260): `torch.ops._C.swigluoai_and_mul(output, input)` → [`activation_kernels.cu:410-466`](https://github.com/vllm-project/vllm/blob/4be4e9a580/csrc/libtorch_stable/activation_kernels.cu#L410): interleaved `gate = in_ptr[2*idx]`, `up = in_ptr[2*idx+1]` |
| | SILU, GELU, SITU, SWIGLUSTEP, SWIGLUOAI_UNINTERLEAVE | **Contiguous [w1;w3]** | Pure GEMM → [`fused_moe/activation.py:230-268`](https://github.com/vllm-project/vllm/blob/4be4e9a580/vllm/model_executor/layers/fused_moe/activation.py#L230): dispatches to `silu_and_mul` etc. → [`activation_kernels.cu:102-108`](https://github.com/vllm-project/vllm/blob/4be4e9a580/csrc/libtorch_stable/activation_kernels.cu#L102): `x_ptr = input + token_idx * 2 * d`, `y_ptr = x_ptr + d` |
| | | | [`marlin_moe.py:170-177`](https://github.com/vllm-project/vllm/blob/4be4e9a580/vllm/model_executor/layers/fused_moe/experts/marlin_moe.py#L170): calls `apply_moe_activation` after GEMM |
| **XPU** | SILU, GELU, GELU_TANH, SWIGLUOAI, RELU2_NO_MUL | **Unknown** | [`xpu_moe.py:170`](https://github.com/vllm-project/vllm/blob/4be4e9a580/vllm/model_executor/layers/fused_moe/experts/xpu_moe.py#L170): `activation=activation.value` passed to external `XpuFusedMoe` from `vllm_xpu_kernels`; cannot trace kernel source |
| **CPU** | SILU, SWIGLUOAI | **Contiguous [w1;w3]** | [`moe.cpp:454-455`](https://github.com/vllm-project/vllm/blob/4be4e9a580/csrc/cpu/sgl-kernels/moe.cpp#L454): `nb_upper = nb, nb_lower = nb + NB` — `NB` is block count in first half, `nb + NB` indexes second half (midpoint split) |
| | | | Both `silu_and_mul` and `swiglu` activation paths use identical `nb_upper/nb_lower` addressing. SWIGLUOAI differs only in activation math (clamped sigmoid), not in layout. |
| **EMULATION** | All (via `apply_moe_activation`) | Same activation dispatch as other external-activation backends | [`ocp_mx_emulation_moe.py:38`](https://github.com/vllm-project/vllm/blob/4be4e9a580/vllm/model_executor/layers/fused_moe/experts/ocp_mx_emulation_moe.py#L38): inherits `TritonExperts`; [`ocp_mx_emulation_moe.py:188`](https://github.com/vllm-project/vllm/blob/4be4e9a580/vllm/model_executor/layers/fused_moe/experts/ocp_mx_emulation_moe.py#L188): dequantizes then calls `super().apply()` → `apply_moe_activation` |
| **HUMMING** | All (via `apply_moe_activation`) | Same activation dispatch as other external-activation backends | [`fused_humming_moe.py:302-305`](https://github.com/vllm-project/vllm/blob/4be4e9a580/vllm/model_executor/layers/fused_moe/experts/fused_humming_moe.py#L302): `_supports_activation` delegates to `apply_moe_activation_supported(activation)`; [`fused_humming_moe.py:553-574`](https://github.com/vllm-project/vllm/blob/4be4e9a580/vllm/model_executor/layers/fused_moe/experts/fused_humming_moe.py#L553): `apply_activation()` calls `self.activation()` → `apply_moe_activation` |

The AITER backends are in a better shape after this change. Other backends are updated with best effort and would need careful community review.

## Next steps
- [x] Remove `convert_gpt_oss_weight_*` and `select_gpt_oss_mxfp4_moe_backend`. Extend `select_mxfp4_moe_backend` to differentiate source gate-up layout.
- [ ] Enable SITU aiter unittest.
- [x] Validate e2e model runs locally.

## Local tests

```yaml
model_name: "deepseek-ai/DeepSeek-V4-Flash-0731"
accuracy_threshold: 0.92
num_questions: 1319
num_fewshot: 8
startup_max_wait_seconds: 1800
server_args: >-
  --tensor-parallel-size 4
  --max-model-len 4096
  --trust-remote-code
  --kv-cache-dtype fp8
  --tokenizer-mode deepseek_v4
env:
  VLLM_ROCM_USE_AITER: "1"
  VLLM_ROCM_USE_AITER_MOE: "1"
```

```
GSM8K Results for deepseek-ai/DeepSeek-V4-Flash-0731:
  Measured metric: 0.9454
  Expected metric: 0.9200
  Tolerance: 0.0800
  Questions: 1319
  Invalid rate: 0.000
  Latency: 52.6s
  QPS: 25.1
```