### PR TITLE
[Kernel] Fix vllm_c fused_add_rms_norm to match native IR rounding semantics

### DIFF
--- a/csrc/libtorch_stable/layernorm_kernels.cu
+++ b/csrc/libtorch_stable/layernorm_kernels.cu
@@ -133,10 +133,9 @@ fused_add_rms_norm_kernel(
   for (int idx = threadIdx.x; idx < vec_hidden_size; idx += blockDim.x) {
     int64_t id = blockIdx.x * residual_stride / width + idx;
     int64_t strided_id = blockIdx.x * vec_input_stride + idx;
-    _f16Vec<scalar_t, width> temp = input_v[strided_id];
-    temp += residual_v[id];
-    variance += temp.sum_squares();
-    residual_v[id] = temp;
+    /* Match the native IR: compute the variance from the unrounded FP32
+       sum (x.float() + residual.float()) before the residual is rounded. */
+    variance += input_v[strided_id].sum_squares(residual_v[id]);
   }
 
   using BlockReduce = cub::BlockReduce<float, 1024>;
@@ -151,24 +150,25 @@ fused_add_rms_norm_kernel(
   for (int idx = threadIdx.x; idx < vec_hidden_size; idx += blockDim.x) {
     int64_t id = blockIdx.x * residual_stride / width + idx;
     int64_t strided_id = blockIdx.x * vec_input_stride + idx;
-    _f16Vec<scalar_t, width> res = residual_v[id];
-    _f16Vec<scalar_t, width> out;
     using Converter = _typeConvert<scalar_t>;
-    if constexpr (HasWeight) {
-      _f16Vec<scalar_t, width> w = weight_v[idx];
+    _f16Vec<scalar_t, width> sum;
+    _f16Vec<scalar_t, width> out;
 #pragma unroll
-      for (int j = 0; j < width; ++j) {
-        float x = Converter::convert(res.data[j]);
-        float wf = Converter::convert(w.data[j]);
-        out.data[j] = Converter::convert(x * s_variance * wf);
-      }
-    } else {
-#pragma unroll
-      for (int j = 0; j < width; ++j) {
-        float x = Converter::convert(res.data[j]);
-        out.data[j] = Converter::convert(x * s_variance);
+    for (int j = 0; j < width; ++j) {
+      float s = Converter::convert(input_v[strided_id].data[j]) +
+                Converter::convert(residual_v[id].data[j]);
+      sum.data[j] = Converter::convert(s);
+      float x_norm = s * s_variance;
+      if constexpr (HasWeight) {
+        /* Match the native IR, which rounds to the weight dtype before
+           multiplying: (x * rsqrt).to(weight.dtype) * weight. */
+        out.data[j] =
+            Converter::convert(x_norm) * weight_v[idx].data[j];
+      } else {
+        out.data[j] = Converter::convert(x_norm);
       }
     }
+    residual_v[id] = sum;
     input_v[strided_id] = out;
   }
 }
@@ -189,11 +189,11 @@ fused_add_rms_norm_kernel(
   float variance = 0.0f;
 
   for (int idx = threadIdx.x; idx < hidden_size; idx += blockDim.x) {
-    scalar_t z = input[blockIdx.x * input_stride + idx];
-    z += residual[blockIdx.x * residual_stride + idx];
-    float x = (float)z;
-    variance += x * x;
-    residual[blockIdx.x * residual_stride + idx] = z;
+    /* Match the native IR: compute the variance from the unrounded FP32
+       sum (x.float() + residual.float()) before the residual is rounded. */
+    float s = (float)input[blockIdx.x * input_stride + idx];
+    s += (float)residual[blockIdx.x * residual_stride + idx];
+    variance += s * s;
   }
 
   using BlockReduce = cub::BlockReduce<float, 1024>;
@@ -206,12 +206,17 @@ fused_add_rms_norm_kernel(
   __syncthreads();
 
   for (int idx = threadIdx.x; idx < hidden_size; idx += blockDim.x) {
-    float x = (float)residual[blockIdx.x * residual_stride + idx];
+    int64_t idx_input = blockIdx.x * input_stride + idx;
+    int64_t idx_residual = blockIdx.x * residual_stride + idx;
+    float s = (float)input[idx_input] + (float)residual[idx_residual];
+    residual[idx_residual] = (scalar_t)s;
+    float x_norm = s * s_variance;
     if constexpr (HasWeight) {
-      float w = (float)weight[idx];
-      input[blockIdx.x * input_stride + idx] = (scalar_t)(x * s_variance * w);
+      /* Match the native IR, which rounds to the weight dtype before
+         multiplying: (x * rsqrt).to(weight.dtype) * weight. */
+      input[idx_input] = (scalar_t)((scalar_t)x_norm * (scalar_t)weight[idx]);
     } else {
-      input[blockIdx.x * input_stride + idx] = (scalar_t)(x * s_variance);
+      input[idx_input] = (scalar_t)x_norm;
     }
   }
 }

--- a/csrc/libtorch_stable/type_convert.cuh
+++ b/csrc/libtorch_stable/type_convert.cuh
@@ -192,5 +192,29 @@ struct alignas(16) _f16Vec {
     }
     return result;
   }
+
+  /* Sum of squares of the elementwise FP32 sum (data[i] + other.data[i]).
+     The sum is kept in FP32, matching the native IR which computes
+     x.float() + residual.float() before squaring. */
+  __device__ float sum_squares(const _f16Vec<scalar_t, width>& other) const {
+    float result = 0.0f;
+    if constexpr (width % 2 == 0) {
+#pragma unroll
+      for (int i = 0; i < width; i += 2) {
+        float2 z = Converter::convert(T2{data[i], data[i + 1]});
+        float2 r = Converter::convert(T2{other.data[i], other.data[i + 1]});
+        float x = z.x + r.x;
+        float y = z.y + r.y;
+        result += x * x + y * y;
+      }
+    } else {
+#pragma unroll
+      for (int i = 0; i < width; ++i) {
+        float x = Converter::convert(data[i]) + Converter::convert(other.data[i]);
+        result += x * x;
+      }
+    }
+    return result;
+  }
 };
 }  // namespace vllm

--- a/tests/kernels/ir/test_layernorm.py
+++ b/tests/kernels/ir/test_layernorm.py
@@ -434,3 +434,63 @@ class TestFusedAddRMSNorm:
                 torch.library.opcheck(
                     torch.ops.vllm_ir.fused_add_rms_norm.maybe_inplace, args
                 )
+
+
+@pytest.mark.skipif(
+    not IS_GPGPU_DEVICE,
+    reason="Currently only kernels on CUDA, ROCm and XPU",
+)
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize("n_tokens", [8, 512])
+@pytest.mark.parametrize("hidden_size", [2048, 8192])
+def test_vllm_c_fused_add_rms_norm_rounding_order(
+    dtype: torch.dtype, n_tokens: int, hidden_size: int
+) -> None:
+    """vllm_c fused_add_rms_norm must match the native IR, which keeps
+    x.float() + residual.float() in FP32 through the variance and output
+    computation (see #52104).
+
+    Non-uniform inputs are required: when every element of a row is equal, the
+    rsqrt normalization exactly cancels a uniform per-element scale, so the
+    rounding order is unobservable. With random inputs, rounding the sum to
+    the input dtype before computing the variance (the old behavior) biases
+    each output by about half an ULP and is easy to detect.
+    """
+    impl = ir.ops.fused_add_rms_norm.impls["vllm_c"]
+    if not impl.supported:
+        pytest.skip("vllm_c impl not supported on this platform")
+
+    device = current_platform.device_type
+    g = torch.Generator(device=device).manual_seed(0)
+    x = torch.randn(n_tokens, hidden_size, dtype=dtype, device=device, generator=g)
+    x_residual = torch.randn(
+        n_tokens, hidden_size, dtype=dtype, device=device, generator=g
+    )
+    weight = torch.randn(hidden_size, dtype=dtype, device=device, generator=g)
+    epsilon = 1e-6
+
+    # Native IR semantics: keep x + residual in FP32 through the variance and
+    # output; round only on the residual write-back and the weight multiply.
+    summed_fp32 = x.float() + x_residual.float()
+    variance = summed_fp32.square().mean(dim=-1, keepdim=True)
+    native = summed_fp32 * torch.rsqrt(variance + epsilon)
+    native = (native.to(weight.dtype) * weight).to(dtype)
+    native_residual = summed_fp32.to(dtype)
+
+    output, residual_out = impl.impl_fn(x.clone(), x_residual.clone(), weight, epsilon)
+
+    # The residual write-back is a plain elementwise FP32 add followed by a
+    # single round, so it must match bit-exactly.
+    torch.testing.assert_close(residual_out, native_residual, rtol=0.0, atol=0.0)
+
+    # The variance differs from the reference only in the FP32 summation
+    # order, so the output may differ by rounding noise but not
+    # systematically. Rounding the sum before the variance (the bug) shifts
+    # roughly half of the outputs by one ULP.
+    mismatches = torch.count_nonzero(output != native).item()
+    numel = output.numel()
+    assert mismatches / numel < 0.01, (
+        "vllm_c fused_add_rms_norm diverges from native IR semantics "
+        f"({mismatches}/{numel} elements differ); the variance must be "
+        "computed from the unrounded FP32 sum"
+    )


### PR DESCRIPTION
# PR body — Fix vllm_c fused_add_rms_norm rounding order to match native IR

## Title
`[Kernel] Fix vllm_c fused_add_rms_norm to match native IR rounding semantics`

## Body

### Summary

Fixes #52104. The CUDA `vllm_c` implementation of `fused_add_rms_norm`
(vectorized and generic kernel specializations) computed the variance from the
**rounded** `input + residual` sum, while the native IR
(`vllm/ir/ops/layernorm.py`) keeps `x.float() + residual.float()` in FP32
through the variance and output computation and rounds only on the residual
write-back and the weight multiply.

Because CUDA dispatches `fused_add_rms_norm` to `["native"]` under Inductor but
`["vllm_c", "native"]` when compilation is disabled, selecting
`CompilationMode.NONE` could change numerical results and, accumulated over
many layers, greedy output tokens (observed with GLM-4.7-Flash in BF16).

This PR makes both `vllm_c` kernel paths follow the native arithmetic contract:

1. **First pass** accumulates the variance from the unrounded FP32 sum
   `float(input) + float(residual)` and no longer mutates `residual`.
2. **Second pass** recomputes the FP32 sum, writes `residual = dtype(sum)` with
   a single round, and normalizes from the FP32 sum.
3. The weighted output keeps the native IR rounding policy:
   `(x * rsqrt).to(weight.dtype) * weight` (round to the weight dtype before
   multiplying), matching `fused_add_rms_norm` in `vllm/ir/ops/layernorm.py`.

### Relationship to open PR #52151

PR #52151 fixes the same variance-rounding defect with the same
first-pass/second-pass structure. This PR is intentionally differentiated:

- #52151 normalizes the weighted output with a **single** rounding
  (`dtype(sum * scale * weight)`). The native IR rounds to the weight dtype
  **before** multiplying (`(x * rsqrt).to(weight.dtype) * weight`). On random
  BF16/FP16 inputs (512x8192) the two arithmetics differ in **~26%** of output
  elements by one ULP.
- This PR matches the native IR on the weighted path bit-for-bit: residual
  write-back is bit-exact, and the output differs from native only by FP32
  reduction-order noise (0.000% BF16 / 0.002% FP16 of elements).
- The regression test here is stricter than #52151's: the output must match the
  native reference within 1% (it fails against #52151's kernel) and the
  residual must match bit-exactly. #52151's tolerance-based mean-error test
  passes even when ~26% of elements differ by one ULP.

If the maintainers prefer, this can be folded into #52151 instead; the change
itself is small and self-contained.

### Test plan (run and results)

Environment: NVIDIA A10, CUDA 13.0, PyTorch 2.11.0+cu130, vLLM editable build
with `csrc` compilation (TORCH_CUDA_ARCH_LIST=8.6).

```bash
python -m pytest tests/kernels/ir/test_layernorm.py \
  -k test_vllm_c_fused_add_rms_norm_rounding_order -v
# 8 passed  (2 dtype x 2 n_tokens x 2 hidden_size)

python -m pytest tests/kernels/ir/test_layernorm.py
# 1450 passed, 184 skipped
```

New regression test `test_vllm_c_fused_add_rms_norm_rounding_order`:

- Uses random (non-uniform) inputs. Uniform inputs are avoided deliberately:
  for a row where every element is equal, the rsqrt normalization exactly
  cancels a uniform per-element scale, so the rounding order is unobservable.
- Asserts `residual_out == dtype(x.float() + residual.float())` bit-exactly.
- Asserts the output matches the native reference in >99% of elements.
  Measured divergence:
  - pre-fix kernel: ~34% of elements differ by one ULP
  - fixed kernel: 0.000% (BF16) / 0.002% (FP16) — FP32 reduction-order noise
  - PR #52151 arithmetic: ~26% (would fail this test)

### Model evaluation

Not run in this environment (no model weights available). The change alters
numerics by design; a reviewer should re-run the issue reporter's GLM-4.7-Flash
comparison (BF16, `CompilationMode.NONE` vs compiled) to confirm token-level
parity. This is called out explicitly rather than deferred.

### AI assistance disclosure

This change was prepared with AI assistance. The submitting human has reviewed
every changed line and the arithmetic, and ran the tests above on the hardware
listed in "Test plan".
