### PR TITLE
[Bugfix][V1] Restore hybrid GDN prefix-cache hits under MTP spec decoding

### DIFF
--- a/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
+++ b/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
@@ -1425,3 +1425,65 @@ def test_hybrid_sliding_window_group_disables_partial_hash_hits():
 
     assert num_computed == mamba_block_size
     assert len(computed_blocks.blocks[0]) * hash_block_size == num_computed
+
+
+def test_mamba_eagle_drops_state_at_block_aligned_prompt_end():
+    """A prompt ending on a mamba page keeps its state only at the boundary an
+    eagle replay lands on. The state at the prompt's own end is not cached: no
+    lookup can reach it, because a consumer's deepest key is that end and the
+    drafter rewinds one hash unit below it."""
+    hash_block_size = 2
+    mamba_block_size = 4 * hash_block_size
+    prompt_len = 2 * mamba_block_size
+    # Where a replay lands: the lookup caps at prompt_len - 1, then drops a unit.
+    rewound = (prompt_len - 1 - hash_block_size) // hash_block_size * hash_block_size
+
+    kv_cache_config = KVCacheConfig(
+        num_blocks=20,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["full"],
+                FullAttentionSpec(
+                    block_size=hash_block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                ),
+            ),
+            KVCacheGroupSpec(
+                ["mamba"],
+                MambaSpec(
+                    block_size=mamba_block_size,
+                    shapes=(1, 1),
+                    dtypes=(torch.float32,),
+                    mamba_cache_mode="align",
+                ),
+            ),
+        ],
+    )
+    manager = make_kv_cache_manager(
+        kv_cache_config=kv_cache_config,
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=hash_block_size,
+        use_eagle=True,
+    )
+
+    def mamba_state(num_tokens):
+        return manager.block_pool.get_cached_block(
+            req.block_hashes[num_tokens // hash_block_size - 1], kv_cache_group_ids=[1]
+        )
+
+    req = make_request("0", list(range(prompt_len)), hash_block_size, sha256)
+    _, num_computed, _ = manager.get_computed_blocks(req)
+    assert num_computed == 0
+    # The prefill stops at the replay boundary, so that state is materialized.
+    assert manager.allocate_slots(req, rewound, num_computed) is not None
+    req.num_computed_tokens = rewound
+    assert manager.allocate_slots(req, prompt_len - rewound) is not None
+    manager.free(req)
+    manager.new_step_starts()
+
+    assert mamba_state(rewound) is not None
+    assert mamba_state(prompt_len) is None

--- a/tests/v1/core/test_mamba_align_chunk_split.py
+++ b/tests/v1/core/test_mamba_align_chunk_split.py
@@ -15,6 +15,7 @@ import torch
 
 from vllm.utils.math_utils import cdiv
 from vllm.v1.core.kv_cache_manager import KVCacheManager
+from vllm.v1.core.kv_cache_utils import mamba_state_cache_position
 from vllm.v1.core.sched.scheduler import Scheduler
 from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
@@ -223,6 +224,10 @@ def test_unaligned_resume_never_runs_past_its_block(
     prompt_len = 3602
     (request,) = create_requests(1, num_tokens=prompt_len, block_size=ATTN_BLOCK_SIZE)
     tail_boundary = prompt_len // ATTN_BLOCK_SIZE * ATTN_BLOCK_SIZE
+    # `_split` runs with use_eagle, which adds the replay landing stop.
+    state_position = mamba_state_cache_position(
+        prompt_len, MAMBA_BLOCK_SIZE, ATTN_BLOCK_SIZE
+    )
 
     pos, ends = resume_at, []
     while pos < prompt_len:
@@ -241,7 +246,9 @@ def test_unaligned_resume_never_runs_past_its_block(
 
     for end in ends[:-1]:
         aligned = end % MAMBA_BLOCK_SIZE == 0
-        assert aligned or (partial_hit and end == tail_boundary), (
-            f"intermediate chunk end {end} is neither block-aligned nor the "
+        assert aligned or (
+            partial_hit and end in (tail_boundary, state_position)
+        ), (
+            f"intermediate chunk end {end} is neither block-aligned nor a "
             f"partial-tail boundary"
         )

--- a/tests/v1/core/test_mamba_align_chunk_split.py
+++ b/tests/v1/core/test_mamba_align_chunk_split.py
@@ -247,6 +247,7 @@ def test_unaligned_resume_never_runs_past_its_block(
     for end in ends[:-1]:
         aligned = end % MAMBA_BLOCK_SIZE == 0
         assert aligned or (partial_hit and end in (tail_boundary, state_position)), (
-            f"intermediate chunk end {end} is neither block-aligned nor a "
-            f"partial-tail boundary"
+            f"intermediate chunk end {end} is neither block-aligned nor the "
+            f"partial-tail boundary {tail_boundary} nor the replay landing "
+            f"position {state_position}"
         )

--- a/tests/v1/core/test_mamba_align_chunk_split.py
+++ b/tests/v1/core/test_mamba_align_chunk_split.py
@@ -246,9 +246,7 @@ def test_unaligned_resume_never_runs_past_its_block(
 
     for end in ends[:-1]:
         aligned = end % MAMBA_BLOCK_SIZE == 0
-        assert aligned or (
-            partial_hit and end in (tail_boundary, state_position)
-        ), (
+        assert aligned or (partial_hit and end in (tail_boundary, state_position)), (
             f"intermediate chunk end {end} is neither block-aligned nor a "
             f"partial-tail boundary"
         )

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -123,6 +123,8 @@ class KVCacheCoordinator(ABC):
             )
             for i, kv_cache_group in enumerate(self.kv_cache_config.kv_cache_groups)
         )
+        for manager in self.single_type_managers:
+            manager.engine_uses_eagle = use_eagle
 
         # A positive retention interval must be a multiple of the base hit granularity
         # (``scheduler_block_size``) to land on real cache-hit boundaries.

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -673,9 +673,10 @@ def mamba_state_cache_position(
 ) -> int:
     """Position at which a producer must snapshot Mamba state under spec decode.
 
-    A replay of this prefix caps its lookup at ``num_tokens - 1`` and then drops
-    one unit for EAGLE (see `FullAttentionManager.find_longest_cache_hit`), so it
-    lands one unit below the deepest boundary under that cap.
+    A replay of this prefix caps its lookup at ``num_tokens - 1`` (see
+    `KVCacheManager.get_computed_blocks`) and then drops one unit for EAGLE (see
+    `FullAttentionManager.find_longest_cache_hit`), so it lands one unit below
+    the deepest boundary under that cap. Clamped at 0 for short prefixes.
     """
     unit = min(hash_block_size, block_size)
     return max((num_tokens - 1 - unit) // unit * unit, 0)

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -668,6 +668,19 @@ def resolve_kv_cache_block_sizes(
     return scheduler_block_size, hash_block_size
 
 
+def mamba_state_cache_position(
+    num_tokens: int, block_size: int, hash_block_size: int
+) -> int:
+    """Position at which a producer must snapshot Mamba state under spec decode.
+
+    A replay of this prefix caps its lookup at ``num_tokens - 1`` and then drops
+    one unit for EAGLE (see `FullAttentionManager.find_longest_cache_hit`), so it
+    lands one unit below the deepest boundary under that cap.
+    """
+    unit = min(hash_block_size, block_size)
+    return max((num_tokens - 1 - unit) // unit * unit, 0)
+
+
 def get_request_block_hasher(
     hash_block_size: int,
     caching_hash_fn: Callable[[Any], bytes],

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -37,7 +37,7 @@ from vllm.v1.core.encoder_cache_manager import (
 )
 from vllm.v1.core.kv_cache_manager import KVCacheBlocks, KVCacheManager
 from vllm.v1.core.kv_cache_metrics import KVCacheMetricsCollector
-from vllm.v1.core.kv_cache_utils import KVCacheBlock
+from vllm.v1.core.kv_cache_utils import KVCacheBlock, mamba_state_cache_position
 from vllm.v1.core.sched.interface import PauseState, SchedulerInterface
 from vllm.v1.core.sched.output import (
     CachedRequestData,
@@ -404,6 +404,15 @@ class Scheduler(SchedulerInterface):
             if self.mamba_partial_cache_hit
             else 0
         )
+        # Where a replay of this prompt needs the state; a chunk must end there
+        # or it is never written (see ``mamba_state_cache_position``).
+        state_position = (
+            mamba_state_cache_position(
+                request.num_prompt_tokens, block_size, self.hash_block_size
+            )
+            if self.mamba_partial_cache_hit and self.use_eagle
+            else 0
+        )
         stops = (
             # Same invariant: a chunk starting mid-block stops at the boundary
             # rather than running past it.
@@ -415,6 +424,8 @@ class Scheduler(SchedulerInterface):
             tail_boundary
             if last_cache_position < tail_boundary < request.num_prompt_tokens
             else 0,
+            # Replay landing position (see ``state_position`` above).
+            state_position,
             # Marconi shared-prefix junction, block-floored (a sub-block
             # junction's state is not separately cacheable): cache its state
             # so sibling requests sharing the prefix can reuse it.

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -110,6 +110,11 @@ class SingleTypeKVCacheManager(ABC):
         # determining the attention groups.
         self.use_eagle = False
 
+        # Whether the engine runs an EAGLE/MTP drafter at all. Unlike
+        # ``use_eagle`` this is not per-group: the drop is applied to the draft
+        # attention group, but Mamba must still publish where it lands.
+        self.engine_uses_eagle = False
+
         # Partial-hit copy-on-write bookkeeping. Populated only by fine-grained
         # managers (full attention, mamba "align"); harmlessly empty elsewhere.
         self._partial_hit_reqs: dict[str, tuple[int, KVCacheBlock]] = {}
@@ -462,6 +467,7 @@ class SingleTypeKVCacheManager(ABC):
             use_eagle=self.use_eagle,
             retention_interval=retention_interval,
             reachable_boundaries=reachable_boundaries,
+            unreachable_boundaries=self._unreachable_boundaries(request),
         )
         self.block_pool.cache_full_blocks(
             request=request,
@@ -485,6 +491,7 @@ class SingleTypeKVCacheManager(ABC):
         use_eagle: bool,
         retention_interval: int | None = None,
         reachable_boundaries: Sequence[int] = (),
+        unreachable_boundaries: Sequence[int] = (),
     ) -> list[bool] | None:
         """Per-block mask for ``cache_full_blocks``. ``None`` means cache
         every (non-null) block — the default for full attention.
@@ -492,9 +499,14 @@ class SingleTypeKVCacheManager(ABC):
         Subclasses with sparse hit semantics (SWA / Mamba) override this to skip
         blocks that can never serve a hit at any alignment-aligned prefix length.
         ``reachable_boundaries`` are token positions whose reachable tail must be
-        retained; the base (dense) policy ignores them.
+        retained and ``unreachable_boundaries`` positions proven dead; the base
+        (dense) policy ignores both.
         """
         return None
+
+    def _unreachable_boundaries(self, request: Request) -> Sequence[int]:
+        """Token boundaries no lookup can land on, so not worth caching."""
+        return ()
 
     def pop_blocks_for_free(self, request_id: str) -> list[KVCacheBlock]:
         """
@@ -1012,6 +1024,7 @@ class SlidingWindowManager(SingleTypeKVCacheManager):
         use_eagle: bool,
         retention_interval: int | None = None,
         reachable_boundaries: Sequence[int] = (),
+        unreachable_boundaries: Sequence[int] = (),
     ) -> list[bool] | None:
         assert isinstance(kv_cache_spec, SlidingWindowSpec)
         if alignment_tokens is None:
@@ -1375,6 +1388,7 @@ class MambaManager(SingleTypeKVCacheManager):
         use_eagle: bool,
         retention_interval: int | None = None,
         reachable_boundaries: Sequence[int] = (),
+        unreachable_boundaries: Sequence[int] = (),
     ) -> list[bool] | None:
         """Sparse Mamba state-snapshot retention.
 
@@ -1387,12 +1401,26 @@ class MambaManager(SingleTypeKVCacheManager):
         ``reachable_boundaries`` are proven reuse points (the replay boundary and
         any cross-request shared-prefix junction, Marconi-style APC); their
         boundary state is always kept so sparse retention does not defeat reuse.
+        ``unreachable_boundaries`` are the converse and are dropped from every
+        retention mode, dense included.
         """
-        if retention_interval is None or alignment_tokens is None:
-            # Dense caching (default) or no alignment constraint imposed.
-            return None
         assert isinstance(kv_cache_spec, MambaSpec)
         block_size = kv_cache_spec.block_size
+
+        def drop_unreachable(mask: list[bool] | None) -> list[bool] | None:
+            if not unreachable_boundaries:
+                return mask
+            if mask is None:
+                mask = [True] * (end_block - start_block)
+            for boundary_tokens in unreachable_boundaries:
+                block = boundary_tokens // block_size - 1
+                if start_block <= block < end_block:
+                    mask[block - start_block] = False
+            return mask
+
+        if retention_interval is None or alignment_tokens is None:
+            # Dense caching (default) or no alignment constraint imposed.
+            return drop_unreachable(None)
         mask = [False] * (end_block - start_block)
 
         # (1) Segment-boundary states. A Mamba hit needs exactly the single
@@ -1404,7 +1432,7 @@ class MambaManager(SingleTypeKVCacheManager):
             per_segment = segment_tokens // block_size
             if per_segment <= 1:
                 # Interval at/below the block size: every block is a boundary.
-                return None
+                return drop_unreachable(None)
             first_boundary = (
                 start_block + per_segment
             ) // per_segment * per_segment - 1
@@ -1421,7 +1449,7 @@ class MambaManager(SingleTypeKVCacheManager):
             if start_block <= boundary_block < end_block:
                 mask[boundary_block - start_block] = True
 
-        return mask
+        return drop_unreachable(mask)
 
     def remove_skipped_blocks(
         self,
@@ -1708,6 +1736,47 @@ class MambaManager(SingleTypeKVCacheManager):
                     continue
                 self.cached_blocks_this_step.add(block.block_hash)
 
+    def _state_boundary(self, request: Request) -> int:
+        """Sub-block position whose state this prompt publishes, and where a
+        replay of it looks."""
+        hash_block_size = self.block_pool.hash_block_size
+        if self.engine_uses_eagle:
+            # A replay is rewound one hash unit, so the snapshot belongs there
+            # rather than at the prompt's tail.
+            return mamba_state_cache_position(
+                request.num_prompt_tokens, self.block_size, hash_block_size
+            )
+        return request.num_prompt_tokens // hash_block_size * hash_block_size
+
+    def _unreachable_boundaries(self, request: Request) -> Sequence[int]:
+        """A block-aligned prompt end, once the state below it is published.
+
+        No lookup can land at or past this prompt's own end: its deepest key is
+        that end, and the drafter rewinds one hash unit off whatever the EAGLE
+        group matched. The state there is therefore dead, while the rewound one
+        below it is where consumers land. Guarded on the latter being cached so
+        a prompt is never left without a state.
+        """
+        num_prompt_tokens = request.num_prompt_tokens
+        if (
+            self.mamba_cache_mode != "align"
+            or not self.engine_uses_eagle
+            or num_prompt_tokens % self.block_size != 0
+        ):
+            return ()
+        boundary = self._state_boundary(request)
+        idx = boundary // self.block_pool.hash_block_size - 1
+        if not 0 <= idx < len(request.block_hashes):
+            return ()
+        if (
+            self.block_pool.get_cached_block(
+                request.block_hashes[idx], [self.kv_cache_group_id]
+            )
+            is None
+        ):
+            return ()
+        return (num_prompt_tokens,)
+
     def new_step_starts(self) -> None:
         self.cached_blocks_this_step.clear()
 
@@ -1723,17 +1792,7 @@ class MambaManager(SingleTypeKVCacheManager):
             return None
         if num_tokens % hash_block_size != 0:
             return None
-        if self.use_eagle:
-            # Spec decode replays from one unit below the consumer's match, so
-            # the snapshot belongs there rather than at the prompt's tail.
-            boundary = mamba_state_cache_position(
-                request.num_prompt_tokens, self.block_size, hash_block_size
-            )
-        else:
-            boundary = (
-                request.num_prompt_tokens // hash_block_size
-            ) * hash_block_size
-        if num_tokens != boundary:
+        if num_tokens != self._state_boundary(request):
             return None
 
         block_idx = num_tokens // self.block_size

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -13,6 +13,7 @@ from vllm.v1.core.kv_cache_utils import (
     BlockHashListWithBlockSize,
     BlockHashWithGroupId,
     KVCacheBlock,
+    mamba_state_cache_position,
     resolve_block_hashes,
 )
 from vllm.v1.kv_cache_interface import (
@@ -793,28 +794,39 @@ class FullAttentionManager(SingleTypeKVCacheManager):
     ) -> None:
         """Cache the prompt tail when it ends inside a cache block.
 
-        Only the final prompt hash boundary is registered as a partial
-        prefix-cache entry; intermediate hash boundaries inside the same cache
-        block are intentionally skipped.
+        Only the final prompt hash boundary (plus, under EAGLE, the boundary a
+        replay can reach) is registered; intermediate hash boundaries inside the
+        same cache block are intentionally skipped.
         """
         hash_block_size = self.block_pool.hash_block_size
-        boundary_tokens = request.num_prompt_tokens // hash_block_size * hash_block_size
-        if boundary_tokens == 0 or boundary_tokens > num_tokens:
-            return
-        if boundary_tokens % self.block_size == 0:
-            return
+        prompt_tokens = request.num_prompt_tokens
+        boundaries = (prompt_tokens // hash_block_size * hash_block_size,)
+        if self.use_eagle:
+            # A replay caps its lookup at ``prompt_tokens - 1``, so a prompt
+            # ending on a boundary can only match one unit lower; the unshifted
+            # tail still serves requests extending this prompt. Deepest first:
+            # a deeper entry evicts shallower hashes on the same block, not the
+            # other way round.
+            replay_tail = (prompt_tokens - 1) // hash_block_size * hash_block_size
+            if replay_tail != boundaries[0]:
+                boundaries += (replay_tail,)
 
         blocks = self.req_to_blocks[request.request_id]
-        block_idx = boundary_tokens // self.block_size
-        if block_idx >= len(blocks):
-            return
-        self.block_pool.cache_partial_block(
-            request=request,
-            block=blocks[block_idx],
-            num_tokens=boundary_tokens,
-            kv_cache_group_id=self.kv_cache_group_id,
-            block_size=self.block_size,
-        )
+        for boundary_tokens in boundaries:
+            if boundary_tokens == 0 or boundary_tokens > num_tokens:
+                continue
+            if boundary_tokens % self.block_size == 0:
+                continue
+            block_idx = boundary_tokens // self.block_size
+            if block_idx >= len(blocks):
+                continue
+            self.block_pool.cache_partial_block(
+                request=request,
+                block=blocks[block_idx],
+                num_tokens=boundary_tokens,
+                kv_cache_group_id=self.kv_cache_group_id,
+                block_size=self.block_size,
+            )
 
     def get_num_common_prefix_blocks(self, running_request_id: str) -> int:
         blocks = self.req_to_blocks[running_request_id]
@@ -1711,10 +1723,17 @@ class MambaManager(SingleTypeKVCacheManager):
             return None
         if num_tokens % hash_block_size != 0:
             return None
-        latest_prompt_hash_boundary = (
-            request.num_prompt_tokens // hash_block_size
-        ) * hash_block_size
-        if num_tokens != latest_prompt_hash_boundary:
+        if self.use_eagle:
+            # Spec decode replays from one unit below the consumer's match, so
+            # the snapshot belongs there rather than at the prompt's tail.
+            boundary = mamba_state_cache_position(
+                request.num_prompt_tokens, self.block_size, hash_block_size
+            )
+        else:
+            boundary = (
+                request.num_prompt_tokens // hash_block_size
+            ) * hash_block_size
+        if num_tokens != boundary:
             return None
 
         block_idx = num_tokens // self.block_size

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -110,9 +110,6 @@ class SingleTypeKVCacheManager(ABC):
         # determining the attention groups.
         self.use_eagle = False
 
-        # Whether the engine runs an EAGLE/MTP drafter at all. Unlike
-        # ``use_eagle`` this is not per-group: the drop is applied to the draft
-        # attention group, but Mamba must still publish where it lands.
         self.engine_uses_eagle = False
 
         # Partial-hit copy-on-write bookkeeping. Populated only by fine-grained
@@ -505,7 +502,6 @@ class SingleTypeKVCacheManager(ABC):
         return None
 
     def _unreachable_boundaries(self, request: Request) -> Sequence[int]:
-        """Token boundaries no lookup can land on, so not worth caching."""
         return ()
 
     def pop_blocks_for_free(self, request_id: str) -> list[KVCacheBlock]:

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -817,8 +817,8 @@ class FullAttentionManager(SingleTypeKVCacheManager):
             # A replay caps its lookup at ``prompt_tokens - 1``, so a prompt
             # ending on a boundary can only match one unit lower; the unshifted
             # tail still serves requests extending this prompt. Deepest first:
-            # a deeper entry evicts shallower hashes on the same block, not the
-            # other way round.
+            # a deeper entry overwrites shallower hashes on the same block, not
+            # the other way round.
             replay_tail = (prompt_tokens - 1) // hash_block_size * hash_block_size
             if replay_tail != boundaries[0]:
                 boundaries += (replay_tail,)
@@ -1737,8 +1737,11 @@ class MambaManager(SingleTypeKVCacheManager):
                 self.cached_blocks_this_step.add(block.block_hash)
 
     def _state_boundary(self, request: Request) -> int:
-        """Sub-block position whose state this prompt publishes, and where a
-        replay of it looks."""
+        """Sub-block position whose state this prompt publishes.
+
+        Under a drafter that is where a replay of the prompt lands; otherwise it
+        is the prompt's own hash boundary.
+        """
         hash_block_size = self.block_pool.hash_block_size
         if self.engine_uses_eagle:
             # A replay is rewound one hash unit, so the snapshot belongs there
@@ -1751,11 +1754,11 @@ class MambaManager(SingleTypeKVCacheManager):
     def _unreachable_boundaries(self, request: Request) -> Sequence[int]:
         """A block-aligned prompt end, once the state below it is published.
 
-        No lookup can land at or past this prompt's own end: its deepest key is
-        that end, and the drafter rewinds one hash unit off whatever the EAGLE
-        group matched. The state there is therefore dead, while the rewound one
-        below it is where consumers land. Guarded on the latter being cached so
-        a prompt is never left without a state.
+        No replay of this prompt can land at or past its own end: the deepest
+        key it offers is that end, and the drafter rewinds one hash unit off
+        whatever the EAGLE group matched. The state there is therefore dead for
+        replays, while the rewound one below it is where they land. Guarded on
+        the latter being cached so a prompt is never left without a state.
         """
         num_prompt_tokens = request.num_prompt_tokens
         if (


### PR DESCRIPTION


## Purpose

On **Qwen3.5-122B-A10B** with MTP speculative decoding, a replay of a cached prompt never reaches the depth the prefix cache could give it, and prompts whose length is a multiple of the hash unit get **no hit at all**. Measured live before this change, with a 1072-token GDN page and `--prefix-match-unit 67`:

| prompt | cached tokens on replay | ceiling |
|---|---|---|
| 1072 | **0** | 938 |
| 2000 | **0** | 1876 |
| 2144 | **0** | 2010 |
| 3000 | 1072 | 2881 |
| 3500 | 2144 | 3417 |

### Root cause

Three rules compose badly. A lookup caps at `prompt_len - 1`, because the last token must be recomputed for logits. The MTP/EAGLE drafter then rewinds the hit one hash unit (67) further. But the producer publishes the GDN state at the prompt's own tail boundary, `prompt_len // 67 * 67`, which is at or above the cap — so the recurrent group cannot resume where the rewind lands, and the coordinator intersects the two groups down to the previous full page (or to zero).

The same cap breaks the full-attention side whenever `prompt_len` is a multiple of 67 — and every page multiple is, since `1072 = 16 × 67`. Its partial-tail entry is registered at `prompt_len // 67 * 67 == prompt_len`, which the `- 1` cap excludes, so full attention itself matches nothing below the page boundary and the hybrid hit collapses to 0. That is the `1072 → 0`, `2144 → 0` row above.

### Fix

Write-side only, all of it gated on MTP/EAGLE plus fine-grained hashing being active:

- `mamba_state_cache_position(num_tokens, block_size, hash_block_size)` in `kv_cache_utils.py`: `unit = min(hash_block_size, block_size)`, returns `(num_tokens - 1 - unit) // unit * unit` — the position a replay actually lands on.
- `Scheduler._mamba_block_aligned_split` stops a prefill chunk there, so that state exists to be published. It is an **extra** stop; the existing block-aligned stops stay. Replacing them lets intermediate chunks end off-grid and re-triggers the state poisoning of #43559 (14 tests in `test_mamba_align_chunk_split.py` fail that way).
- `MambaManager._cache_partial_tail_block` publishes the GDN state there instead of at the prompt tail.
- `FullAttentionManager._cache_partial_tail_block` additionally publishes `(prompt_len - 1) // 67 * 67`, the deepest tail a replay can reach. The unshifted tail is kept, because requests that *extend* this prompt have a higher cap and can still match it.
- `MambaManager` reports a block-aligned prompt end as unreachable through a new `reachable_block_mask()` argument, so that state is not cached in any retention mode: no lookup can land at or past a prompt's own end, and the rewound state below it is where consumers land. Guarded on the latter being cached. The rewound position is read from one `MambaManager` helper rather than recomputed per caller, and keys off whether the engine runs a drafter rather than the per-group `use_eagle` bit, which is only set on groups that take the drop.

Without the last item the page multiples stay at 0 no matter where the GDN state sits: the producer had the state at 938 / 2010 / 3082, but full attention offered nothing below 1072 / 2144 / 3216 for the intersection to meet.

## Test Plan

```bash
# unit
pytest tests/v1/core -q

# e2e: Qwen3.5-122B-A10B, 4x B200, MTP 3 tokens, sub-page hashing
vllm serve $QWEN35_122B --tensor-parallel-size 4 --enable-chunked-prefill \
    --spec-method mtp --spec-tokens 3 --prefix-match-unit 67 --port 8110
```

Hit depth is read from the `vllm:prefix_cache_hits_total` delta of a replay: a token-id prompt of an exact length is sent three times and the second and third deltas are the cached length. 132 lengths from 1 to 15k were swept — every page multiple with its `+1`, `+unit-1`, `+unit`, `+unit+1` neighbours, plus scattered lengths. Two further passes cover the configurations where the patch must do nothing, and quality was checked on top of real hits.

## Test Result

(1) Hit Length Boundary

All 132 lengths land exactly on the replay ceiling `(P - 1 - 67) // 67 * 67`. Page-boundary neighbourhoods, where the old code either missed entirely or fell back a full page:

| prompt | position | before | after | replay ceiling |
|---|---|---|---|---|
| 1072 | k*1072 | 0 | 938 | 938 |
| 1073 | k*1072 + 1 | 0 | 1005 | 1005 |
| 1138 | k*1072 + unit - 1 | 0 | 1005 | 1005 |
| 1139 | k*1072 + unit | 0 | 1005 | 1005 |
| 1140 | k*1072 + unit + 1 | 0 | 1072 | 1072 |
| 2144 | k*1072 | 0 | 2010 | 2010 |
| 2145 | k*1072 + 1 | 1072 | 2077 | 2077 |
| 2210 | k*1072 + unit - 1 | 1072 | 2077 | 2077 |
| 2211 | k*1072 + unit | 1072 | 2077 | 2077 |
| 2212 | k*1072 + unit + 1 | 1072 | 2144 | 2144 |
| 3216 | k*1072 | 0 | 3082 | 3082 |
| 3217 | k*1072 + 1 | 2144 | 3149 | 3149 |
| 3282 | k*1072 + unit - 1 | 2144 | 3149 | 3149 |
| 3283 | k*1072 + unit | 2144 | 3149 | 3149 |
| 3284 | k*1072 + unit + 1 | 2144 | 3216 | 3216 |
| 5360 | k*1072 | 0 | 5226 | 5226 |
| 5361 | k*1072 + 1 | 4288 | 5293 | 5293 |
| 5426 | k*1072 + unit - 1 | 4288 | 5293 | 5293 |
| 5427 | k*1072 + unit | 4288 | 5293 | 5293 |
| 5428 | k*1072 + unit + 1 | 4288 | 5360 | 5360 |
| 10720 | k*1072 | 7504 | 10586 | 10586 |
| 10721 | k*1072 + 1 | 9648 | 10653 | 10653 |
| 10786 | k*1072 + unit - 1 | 9648 | 10653 | 10653 |
| 10787 | k*1072 + unit | 9648 | 10653 | 10653 |
| 10788 | k*1072 + unit + 1 | 9648 | 10720 | 10720 |

Other lengths:

| prompt | before | after | ceiling |
|---|---|---|---|
| 500 | 0 | 402 | 402 |
| 999 | 0 | 871 | 871 |
| 2000 | 0 | 1876 | 1876 |
| 3000 | 1072 | 2881 | 2881 |
| 3500 | 2144 | 3417 | 3417 |
| 5000 | 3216 | 4891 | 4891 |
| 7777 | 6432 | 7705 | 7705 |
| 12345 | 10720 | 12261 | 12261 |
| 14999 | 12864 | 14874 | 14874 |

`before` comes from a CPU replica driving the real splitter and the real managers on the base commit; on the patched build that replica reproduces the end-to-end numbers length by length, so the two columns are comparable.

Configurations where the patch must be inert: re-running the same 132 lengths without `--prefix-match-unit` (both groups sit at 1072, so `hash_block_size == block_size` and sub-page hashing is off) gives `((P - 1) // 1072) * 1072 - 1072` on every length, and the CPU replica shows this build and the base commit agreeing on all 132. `mamba_cache_mode=all` cannot be exercised on this model — it is not in `SupportsMambaPrefixCaching`, so vLLM falls back to `align`.

Unit tests: `tests/v1/core` 492 passed. The one failure and two errors are GPU-exclusive e2e cases (`Free memory on device cuda:0 ... less than desired`) blocked by the serving process on the same box, and reproduce without this change. `tests/v1/core/test_mamba_align_chunk_split.py` is updated so the replay landing position counts as a legal intermediate chunk end alongside the partial-tail boundary.

(2) Model Quality Test

GPQA Diamond Score for Qwen/Qwen3.5-122B-A10B : 85.9% (match official score 86.6%)

GSM8K 5-shot, 300 questions: 0.890 / 0.853 with 0.0% / 1.3% invalid on this build, against 0.847 / 0.830 with 1.7% / 2.7% invalid on the base commit. Run-to-run spread is larger than the gap, so this is "no regression", not an accuracy claim.

Output quality on top of a real hit: an English passage of 700 / 1500 / 2400 / 3500 words, sent cold and then replayed (hits of 670 / 1608 / 2613 / 3819 tokens), returns byte-identical text at `temperature=0` in all four, twice over — no truncation, no repetition, no garbling.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

## Reproduce Low KVCache Hit Length with Qwen3.5

(1) Launch

```bash
CUDA_VISIBLE_DEVICES=0,1,2,3 \
PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True \
vllm serve Qwen/Qwen3.5-122B-A10B \
    --served-model-name Qwen3.5-122B-A10B \
    --trust-remote-code \
    --tensor-parallel-size 4 \
    --gpu-memory-utilization 0.90 \
    --max-model-len 262144 \
    --max-num-batched-tokens 8192 \
    --max-num-seqs 64 \
    --enable-chunked-prefill \
    --spec-method mtp \
    --spec-tokens 3 \
    --prefix-match-unit 67 \
    --host 0.0.0.0 --port 8110
```

(2) Send the same prompt twice

```bash
python3 - <<'EOF'
import json, random, re, urllib.request

N = 2144
BASE = "http://localhost:8110"

def hits_total():
    metrics = urllib.request.urlopen(f"{BASE}/metrics").read().decode()
    return float(
        re.search(r"^vllm:prefix_cache_hits_total\{[^}]*\} (\S+)", metrics, re.M).group(1)
    )

random.seed(N)
body = json.dumps({
    "model": "Qwen3.5-122B-A10B",
    "prompt": [random.randint(1000, 100000) for _ in range(N)],
    "max_tokens": 1,
    "temperature": 0,
}).encode()

for attempt in (1, 2):
    before = hits_total()
    urllib.request.urlopen(urllib.request.Request(
        f"{BASE}/v1/completions", body, {"Content-Type": "application/json"}))
    print(attempt, int(hits_total() - before))
EOF
```

(3) Check the second request's cache length

Before the fix it is 0, after the fix it is 2010.


