### PR TITLE
fix(docs): correct "Mixture-of-Expert" to "Mixture-of-Experts" in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ vLLM is flexible and easy to use with:
 vLLM seamlessly supports 200+ model architectures on Hugging Face, including:
 
 - Decoder-only LLMs (e.g., Llama, Qwen, Gemma)
-- Mixture-of-Expert LLMs (e.g., Mixtral, DeepSeek-V3, Qwen-MoE, GPT-OSS)
+- Mixture-of-Experts LLMs (e.g., Mixtral, DeepSeek-V3, Qwen-MoE, GPT-OSS)
 - Hybrid attention and state-space models (e.g., Mamba, Qwen3.5)
 - Multi-modal models (e.g., LLaVA, Qwen-VL, Pixtral)
 - Embedding and retrieval models (e.g., E5-Mistral, GTE, ColBERT)


### PR DESCRIPTION
## What does this PR do?

Fixes a typo in `README.md`: `Mixture-of-Expert` → `Mixture-of-Experts`.

The standard term is "Mixture of Experts" (MoE), plural. The singular form `Mixture-of-Expert` is a typo in the model architecture list.

## Changes

- `README.md` line 56: `Mixture-of-Expert LLMs` → `Mixture-of-Experts LLMs`

## Checklist

- [x] No code changes, documentation only
- [x] Verified the diff is minimal and correct

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)