### PR TITLE
[CI] Increase extended generation test timeout

### DIFF
--- a/.buildkite/test_areas/models_language.yaml
+++ b/.buildkite/test_areas/models_language.yaml
@@ -100,7 +100,7 @@ steps:
 - label: Language Models Test (Extended Generation) # 80min
   device: h200_35gb
   key: language-models-test-extended-generation
-  timeout_in_minutes: 65
+  timeout_in_minutes: 80
   optional: true
   source_file_dependencies:
   - vllm/


### PR DESCRIPTION
## Summary

Raise the **Language Models Test (Extended Generation)** timeout from 65 to 80 minutes. This keeps the existing test coverage and single-H200 resource shape unchanged.

## Why

PR #48186 reduced this timeout from 110 to 65 minutes based on one successful 48.9-minute nightly and a 15-minute buffer. Runtime variance has since consumed that buffer:

- [main #78476](https://buildkite.com/vllm/ci/builds/78476/canvas?jid=019f6cbb-c4f5-45f7-861d-bac2659246a8&tab=output) passed in 64m57s.
- Main timed out on July 17, July 20, July 22, and [August 13](https://buildkite.com/vllm/ci/builds/83797/canvas?jid=019ffced-fea8-4b35-8325-f34f24f8a27b&tab=output).
- The [August 13 retry](https://buildkite.com/vllm/ci/builds/83797/canvas?jid=019ffd60-4fb5-432d-8261-55c99025a4a1&tab=output) passed in about 52 minutes.

An 80-minute ceiling restores roughly 15 minutes of headroom above the observed near-65-minute runs. It avoids consuming a second H200 for sharding and does not remove or narrow any tests.

## Duplicate work

No open issue or pull request was found for this timeout adjustment. PR #48186 is related historical context, but it introduced the 65-minute value rather than fixing the resulting timeouts.

## Validation

- `yq eval '.' .buildkite/test_areas/models_language.yaml`
- `.venv/bin/pre-commit run --files .buildkite/test_areas/models_language.yaml`
- `git diff --check`

All applicable checks passed. An H200 test run was not performed locally because this is a Buildkite timeout-only change.

## Model evaluation

Not applicable. This changes only CI timeout metadata and does not affect model behavior, output, or accuracy.

## AI assistance

AI assistance was used to trace the main-branch timeout history, identify the regression in PR #48186, prepare the change, and draft this description. Reviewed by the submitter