### PR TITLE
[Bugfix] DeepSeek-V4: don't emit an empty `<think></think>` block for reasoningless turns

### DIFF
--- a/tests/tokenizers_/test_deepseek_v4.py
+++ b/tests/tokenizers_/test_deepseek_v4.py
@@ -315,3 +315,57 @@ def test_deepseek_v4_matches_reference_golden_fixtures(case_id, kwargs):
 
     expected = (FIXTURES_DIR / f"test_output_{case_id}.txt").read_text()
     assert prompt == expected
+
+
+def _thinking_prompt_with_reasoning(reasoning):
+    """Render a tool-calling conversation whose first assistant turn has `reasoning`."""
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+    ]
+    assistant = {"role": "assistant", "content": "On it."}
+    if reasoning is not None:
+        assistant["reasoning"] = reasoning
+
+    return _tokenizer().apply_chat_template(
+        [
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "Weather?"},
+            assistant,
+            {"role": "user", "content": "And tomorrow?"},
+        ],
+        tools=tools,
+        tokenize=False,
+        reasoning_effort="high",
+    )
+
+
+@pytest.mark.parametrize("reasoning", ["", None])
+def test_deepseek_v4_no_empty_thinking_block_for_reasoningless_turn(reasoning):
+    """An assistant turn without reasoning is encoded chat-style.
+
+    Declaring tools disables `drop_thinking`, so every prior assistant turn keeps its
+    thinking block. When the client did not send reasoning back for a turn there is
+    nothing to put in that block, and emitting `<think></think>` produces a sequence
+    that appears in none of the reference encoding's expected outputs.
+    """
+    prompt = _thinking_prompt_with_reasoning(reasoning)
+
+    assert "<think></think>" not in prompt
+    assert "<｜Assistant｜></think>On it." in prompt
+    # The generation prompt must still open a real thinking block.
+    assert prompt.endswith("<｜Assistant｜><think>")
+
+
+def test_deepseek_v4_keeps_thinking_block_when_reasoning_present():
+    """Turns that do carry reasoning are unchanged."""
+    prompt = _thinking_prompt_with_reasoning("Let me check the forecast.")
+
+    assert "<｜Assistant｜><think>Let me check the forecast.</think>On it." in prompt
+    assert "<think></think>" not in prompt
+    assert prompt.endswith("<｜Assistant｜><think>")

--- a/vllm/tokenizers/deepseek_v4_encoding.py
+++ b/vllm/tokenizers/deepseek_v4_encoding.py
@@ -199,6 +199,37 @@ def find_last_user_index(messages: List[Dict[str, Any]]) -> int:
 # Message Rendering
 # ============================================================
 
+def opens_thinking_block(
+    index: int,
+    messages: List[Dict[str, Any]],
+    thinking_mode: str,
+    drop_thinking: bool,
+    last_user_idx: int,
+) -> bool:
+    """
+    Whether the assistant turn at `index` opens a real `<think>` block.
+
+    False means the turn is encoded chat-style, with `</think>` placed directly after
+    `<｜Assistant｜>`. An assistant turn whose reasoning is not rendered has no thinking
+    block to open, so emitting `<think></think>` for it would put a token sequence in the
+    prompt that does not appear in any of the reference encoding's expected outputs.
+
+    `index` past the end of `messages` means there is no turn to render yet, i.e. this is
+    the generation prompt, which must open a real block so the model can reason.
+    """
+    if thinking_mode != "thinking":
+        return False
+    msg = messages[index] if 0 <= index < len(messages) else None
+    if msg is None or msg.get("role") != "assistant":
+        return True
+    # A task marker on the preceding message makes this a task output (no thinking).
+    if index - 1 >= 0 and messages[index - 1].get("task") is not None:
+        return False
+    if drop_thinking and index <= last_user_idx:
+        return False
+    return bool(msg.get("reasoning"))
+
+
 def render_message(
     index: int,
     messages: List[Dict[str, Any]],
@@ -334,9 +365,21 @@ def render_message(
         # Check if previous message has a task - if so, this is a task output (no thinking)
         prev_has_task = index - 1 >= 0 and messages[index - 1].get("task") is not None
 
+        # Transition tokens are emitted by the preceding user/developer message; only
+        # close the thinking block here if that message actually opened one.
+        opened_by_prev = (
+            index - 1 >= 0
+            and messages[index - 1].get("role") in ["user", "developer"]
+            and opens_thinking_block(
+                index, messages, thinking_mode, drop_thinking, last_user_idx
+            )
+        )
         if thinking_mode == "thinking" and not prev_has_task:
             if not drop_thinking or index > last_user_idx:
-                thinking_part = thinking_template.format(reasoning=reasoning) + thinking_end_token
+                if opened_by_prev or reasoning:
+                    thinking_part = thinking_template.format(reasoning=reasoning) + thinking_end_token
+                else:
+                    thinking_part = ""
             else:
                 thinking_part = ""
 
@@ -377,9 +420,9 @@ def render_message(
     elif messages[index].get("role") in ["user", "developer"]:
         # Normal generation: append Assistant + thinking token
         prompt += ASSISTANT_SP_TOKEN
-        if not drop_thinking and thinking_mode == "thinking":
-            prompt += thinking_start_token
-        elif drop_thinking and thinking_mode == "thinking" and index >= last_user_idx:
+        if opens_thinking_block(
+            index + 1, messages, thinking_mode, drop_thinking, last_user_idx
+        ):
             prompt += thinking_start_token
         else:
             prompt += thinking_end_token


### PR DESCRIPTION
## Purpose

Fixes #52253.

`vllm/tokenizers/deepseek_v4_encoding.py` rendered an assistant turn carrying no `reasoning` as a literal empty thinking block, `<｜Assistant｜><think></think>`.

Declaring tools force-disables `drop_thinking`:

```python
if any(m.get("tools") for m in full_messages):
    effective_drop_thinking = False
```

so every prior assistant turn keeps its thinking block — but when the client does not echo `reasoning` back for a turn, there is nothing to put in it.

`<think></think>` appears in **none** of the four expected outputs shipped with the checkpoint. Wherever those fixtures have an assistant turn whose reasoning is not rendered, the encoding is chat-style — `</think>` placed directly after `<｜Assistant｜>`:

- [`encoding/tests/test_output_2.txt`](https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-0731/blob/main/encoding/tests/test_output_2.txt) begins `<｜begin▁of▁sentence｜>You are a helpful assistant.<｜User｜>Hello<｜Assistant｜></think>Hi there! ...`, and [`test_encoding_dsv4.py`](https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-0731/blob/main/encoding/test_encoding_dsv4.py) asserts `encode_messages(messages, thinking_mode="thinking") == gold` for it.
- The reference encoder's own `drop_thinking` path emits the same form for turns before the last user message.
- [`encoding/README.md`](https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-0731/blob/main/encoding/README.md) documents `</think>` placed right after `<｜Assistant｜>` to close the block immediately.

So the reference encoding has two spellings for one situation — "thinking mode, assistant turn whose reasoning is not rendered". The `drop_thinking` spelling is attested and asserted; the tools spelling is neither, and no fixture covers `tools present + reasoning absent`.

## Changes

Introduce `opens_thinking_block()`, a single predicate shared by the transition branch and the assistant branch, so the two cannot disagree about whether a block was opened. A turn whose reasoning will not be rendered is encoded chat-style.

The assistant branch only closes a block the preceding user/developer message actually opened, so behaviour is unchanged when no transition ran.

Explicitly preserved:
- turns that carry reasoning are byte-identical to before
- the generation prompt still ends `<｜Assistant｜><think>` so the model can reason
- `chat` mode, `drop_thinking`, and the `task` marker paths are untouched

## Test Plan

New parametrized tests in `tests/tokenizers_/test_deepseek_v4.py` cover `reasoning=""` and a missing `reasoning` key, asserting no `<think></think>`, the chat-style form present, and the generation prompt intact — plus a test that a reasoning-carrying turn is unchanged.

## Test Result

Rendering all four reference fixtures with this change is **byte-identical to `main`**, and all four still match the expected outputs:

```
case 1 (thinking): PATCHED==gold True | patched==upstream True
case 2 (thinking): PATCHED==gold True | patched==upstream True
case 3 (thinking): PATCHED==gold True | patched==upstream True
case 4 (chat    ): PATCHED==gold True | patched==upstream True
```

The new tests fail on `main` and pass with this change:

```
upstream reasoning=""      | "<think></think>" present: True
upstream reasoning=missing | "<think></think>" present: True
patched  reasoning=""      | "<think></think>" present: False
patched  reasoning=missing | "<think></think>" present: False
```

Observed effect on a real deployment: in a ~336k-token tool-calling conversation containing 104 such blocks (the last 17 assistant turns consecutive), the model emitted `</think>` as its first generated token and produced no reasoning on every sample. Encoding only those turns chat-style restored reasoning. Downstream quality degradation had additional contributing factors and is not claimed here.
