### PR TITLE
[Bugfix] DeepSeek-V4: render request-level tools after the system prompt

### DIFF
--- a/tests/tokenizers_/fixtures/deepseek_v4/test_output_1.txt
+++ b/tests/tokenizers_/fixtures/deepseek_v4/test_output_1.txt
@@ -1,4 +1,4 @@
-<｜begin▁of▁sentence｜>
+<｜begin▁of▁sentence｜>You are a helpful assistant.
 
 ## Tools
 
@@ -26,7 +26,7 @@ Otherwise, output directly after </think> with tool calls or final response.
 {"name": "search", "description": "Search the web for information", "parameters": {"type": "object", "properties": {"query": {"type": "string", "description": "Search query"}, "num_results": {"type": "integer", "description": "Number of results to return"}}, "required": ["query"]}}
 
 You MUST strictly follow the above defined tool name and parameter schemas to invoke tool calls.
-You are a helpful assistant.<｜User｜>What's the weather in Beijing?<｜Assistant｜><think>The user wants to know the weather in Beijing. I should use the get_weather tool.</think>
+<｜User｜>What's the weather in Beijing?<｜Assistant｜><think>The user wants to know the weather in Beijing. I should use the get_weather tool.</think>
 
 <｜DSML｜tool_calls>
 <｜DSML｜invoke name="get_weather">

--- a/tests/tokenizers_/test_deepseek_v4.py
+++ b/tests/tokenizers_/test_deepseek_v4.py
@@ -315,3 +315,93 @@ def test_deepseek_v4_matches_reference_golden_fixtures(case_id, kwargs):
 
     expected = (FIXTURES_DIR / f"test_output_{case_id}.txt").read_text()
     assert prompt == expected
+
+
+_ONE_TOOL = [
+    {
+        "type": "function",
+        "function": {
+            "name": "tool_beta",
+            "parameters": {"type": "object", "properties": {}},
+        },
+    }
+]
+
+
+def test_deepseek_v4_tools_render_after_the_system_prompt():
+    """Request-level tools attach to the existing system message, not a new one.
+
+    The reference layout is `{system_content}\n\n## Tools ...`; inserting a fresh
+    system message renders the whole tools block ahead of the system prompt.
+    """
+    prompt = _tokenizer().apply_chat_template(
+        [
+            {"role": "system", "content": "SYSTEM_MARKER"},
+            {"role": "user", "content": "Weather?"},
+        ],
+        tools=_ONE_TOOL,
+        tokenize=False,
+        thinking=True,
+    )
+
+    assert prompt.count("## Tools") == 1
+    assert prompt.index("SYSTEM_MARKER") < prompt.index("## Tools")
+    assert "SYSTEM_MARKER\n\n## Tools" in prompt
+
+
+def test_deepseek_v4_tools_render_after_a_developer_prompt():
+    """A leading developer message carries tools the same way a system message does."""
+    prompt = _tokenizer().apply_chat_template(
+        [
+            {"role": "developer", "content": "DEVELOPER_MARKER"},
+            {"role": "user", "content": "Weather?"},
+        ],
+        tools=_ONE_TOOL,
+        tokenize=False,
+        thinking=True,
+    )
+
+    assert prompt.count("## Tools") == 1
+    assert prompt.index("DEVELOPER_MARKER") < prompt.index("## Tools")
+
+
+def test_deepseek_v4_tools_still_rendered_without_a_leading_system_message():
+    """With no system/developer message to attach to, one is inserted."""
+    prompt = _tokenizer().apply_chat_template(
+        [{"role": "user", "content": "Weather?"}],
+        tools=_ONE_TOOL,
+        tokenize=False,
+        thinking=True,
+    )
+
+    assert prompt.count("## Tools") == 1
+    assert '"name": "tool_beta"' in prompt
+
+
+def test_deepseek_v4_request_tools_replace_message_tools():
+    """Request-level tools win; rendering both would emit the block twice."""
+    prompt = _tokenizer().apply_chat_template(
+        [
+            {
+                "role": "system",
+                "content": "SYSTEM_MARKER",
+                "tools": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "tool_alpha",
+                            "parameters": {"type": "object", "properties": {}},
+                        },
+                    }
+                ],
+            },
+            {"role": "user", "content": "Weather?"},
+        ],
+        tools=_ONE_TOOL,
+        tokenize=False,
+        thinking=True,
+    )
+
+    assert prompt.count("## Tools") == 1
+    assert "tool_beta" in prompt
+    assert "tool_alpha" not in prompt

--- a/vllm/tokenizers/deepseek_v4.py
+++ b/vllm/tokenizers/deepseek_v4.py
@@ -35,10 +35,25 @@ def get_deepseek_v4_tokenizer(tokenizer: HfTokenizer) -> HfTokenizer:
             thinking_mode = "thinking" if thinking_enabled else "chat"
 
             conversation = kwargs.get("conversation", messages)
-            messages = conversation.copy()
+            messages = list(conversation)
             if tools is not None and len(tools) > 0:
-                messages.insert(0, {"role": "system"})
-                messages[0]["tools"] = tools  # type: ignore[typeddict-unknown-key]
+                # Attach request-level tools to the leading system/developer message so the
+                # prompt reads `{content}\n\n## Tools ...`, which is what the reference
+                # encoding produces and what the golden outputs shipped with the checkpoint
+                # contain. Inserting a fresh message instead renders the entire tools block
+                # *ahead* of the system prompt.
+                #
+                # Request-level tools take precedence over tools already present on that
+                # message; rendering both would emit the tools block twice.
+                if messages and messages[0].get("role") in ("system", "developer"):
+                    head = dict(messages[0])
+                    head["tools"] = tools  # type: ignore[typeddict-unknown-key]
+                    messages[0] = head
+                else:
+                    messages.insert(
+                        0,
+                        {"role": "system", "tools": tools},  # type: ignore[typeddict-unknown-key]
+                    )
 
             reasoning_effort = kwargs.get("reasoning_effort")
             if not isinstance(reasoning_effort, str):


### PR DESCRIPTION
## Purpose

`vllm/tokenizers/deepseek_v4.py` inserted a **new** empty system message to carry request-level tools rather than attaching them to the existing one:

```python
if tools is not None and len(tools) > 0:
    messages.insert(0, {"role": "system"})
    messages[0]["tools"] = tools
```

The empty message renders as `""` + `"\n\n"` + the tools block, so the entire `## Tools` section lands **before** the system prompt. For a 53-tool schema that moves ~25k tokens, and the prompt diverges from the reference encoding at **token 6** — which is also the prefix-cache root.

### Why after the system prompt is correct

The reference implementation shipped with the checkpoint attaches tools to the existing message. [`encoding/test_encoding_dsv4.py`](https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-0731/blob/main/encoding/test_encoding_dsv4.py) does

```python
messages[0]["tools"] = td["tools"]
prompt = encode_messages(messages, thinking_mode="thinking")
assert prompt == gold
```

and [`encoding/tests/test_output_1.txt`](https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-0731/blob/main/encoding/tests/test_output_1.txt) begins:

```
<｜begin▁of▁sentence｜>You are a helpful assistant.

## Tools
```

Rendering case 1 both ways against that golden:

```
tools attached to the existing system message : == gold  True
tools in a newly inserted system message      : == gold  False
```

### Why CI did not catch it

`tests/tokenizers_/fixtures/deepseek_v4/test_output_1.txt` had been regenerated to match the inserted-message layout, so `test_deepseek_v4_matches_reference_golden_fixtures[1]` was asserting the wrong output:

| | md5 |
|---|---|
| checkpoint original | `c40a74c9492a3d0d1e8b2d50d140ac56` |
| vendored in-tree (before this PR) | `596044c041eda7f8fb55e2ee39cf725d` |

Cases 2, 3 and 4 were already byte-identical to the checkpoint and are untouched. Case 1 is the only tools case, which is exactly why it was the only one that drifted.

## Changes

- Attach request-level tools to the leading `system`/`developer` message; insert one only when there is nothing to attach to.
- Restore `test_output_1.txt` from the checkpoint, so the existing golden test enforces the reference layout.
- `developer` is included because the reference renders tools for that role too.
- Request-level tools now **replace** tools already present on that message. Previously both were rendered, emitting the `## Tools` block twice.

## Test Plan

The existing parametrized `test_deepseek_v4_matches_reference_golden_fixtures` becomes the regression test once the fixture is restored — it fails on `main` for case 1 and passes with this change.

Four new tests cover: tools after a system prompt, tools after a `developer` prompt, insertion when no system/developer message exists, and request-level tools replacing message-level ones.

## Test Result

All four restored goldens, rendered through the wrapper's marshalling:

```
case   upstream==gold   PATCHED==gold
   1            False            True
   2             True            True
   3             True            True
   4             True            True
```

Case 3 is unaffected because its tools arrive on a `developer` message rather than at request level, so the insert branch never fires there.

Edge cases, before → after:

```
developer-first, request-level tools : tools-first  -> developer-first,  1 tools block
no system/developer message          : 1 tools block -> 1 tools block  (unchanged)
message already carries tools        : 2 tools blocks -> 1 tools block (request-level wins)
```

## Note for reviewers

This changes the rendered prompt for every DeepSeek-V4 request that passes tools at request level, so it invalidates existing prefix caches and can shift eval numbers. The restored golden is the justification: the new layout is the checkpoint's own expected output, not a preference.

I could not determine why the in-tree fixture was changed. If that was deliberate rather than a red test being regenerated, I'd rather hear it before this lands.
