### PR TITLE
[UT][XPU] fix b12x UT

### DIFF
--- a/tests/model_executor/kernels/test_b12x_mxfp8_linear.py
+++ b/tests/model_executor/kernels/test_b12x_mxfp8_linear.py
@@ -768,6 +768,21 @@ def test_b12x_mxfp8_reload_reuses_packed_tensor_addresses(monkeypatch) -> None:
     assert layer.weight_scale.numel() == 0
 
 
+@pytest.fixture
+def _mock_b12x_cuda_fp8_platform(monkeypatch: pytest.MonkeyPatch) -> None:
+    import vllm.model_executor.layers.quantization.utils.fp8_utils as fp8_utils
+
+    monkeypatch.setattr(
+        fp8_utils,
+        "current_platform",
+        types.SimpleNamespace(
+            is_fp8_fnuz=lambda: False,
+            is_rocm=lambda: False,
+        ),
+    )
+
+
+@pytest.mark.usefixtures("_mock_b12x_cuda_fp8_platform")
 def test_b12x_block_fp8_process_weights_keeps_native_block_layout() -> None:
     layer = torch.nn.Module()
     layer.weight = torch.nn.Parameter(
@@ -797,6 +812,7 @@ def test_b12x_block_fp8_process_weights_keeps_native_block_layout() -> None:
 
 
 @pytest.mark.parametrize("scale_dtype", [torch.float8_e8m0fnu, torch.uint8])
+@pytest.mark.usefixtures("_mock_b12x_cuda_fp8_platform")
 def test_b12x_block_fp8_upcasts_e8m0_weight_scales(scale_dtype) -> None:
     layer = torch.nn.Module()
     layer.weight = torch.nn.Parameter(

--- a/tests/model_executor/kernels/test_b12x_mxfp8_linear.py
+++ b/tests/model_executor/kernels/test_b12x_mxfp8_linear.py
@@ -778,6 +778,9 @@ def _mock_b12x_cuda_fp8_platform(monkeypatch: pytest.MonkeyPatch) -> None:
         types.SimpleNamespace(
             is_fp8_fnuz=lambda: False,
             is_rocm=lambda: False,
+            fp8_dtype=lambda: torch.float8_e4m3fn,
+            is_xpu=lambda: False,
+            is_cuda_alike=lambda: True,
         ),
     )
 

--- a/tests/model_executor/kernels/test_b12x_mxfp8_linear.py
+++ b/tests/model_executor/kernels/test_b12x_mxfp8_linear.py
@@ -46,7 +46,7 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
     kFp8Static128BlockSym,
     kFp8StaticTensorSym,
 )
-from vllm.platforms import PlatformEnum
+from vllm.platforms import PlatformEnum, current_platform
 from vllm.utils.b12x import b12x_warmup_token_counts
 
 
@@ -100,6 +100,7 @@ def test_b12x_backend_does_not_intercept_unquantized_bf16(
     dist_init,
 ) -> None:
     default_vllm_config.kernel_config.linear_backend = "b12x"
+    device = current_platform.device_type
     layer = ReplicatedLinear(
         128,
         64,
@@ -107,9 +108,9 @@ def test_b12x_backend_does_not_intercept_unquantized_bf16(
         params_dtype=torch.bfloat16,
         quant_config=None,
         prefix="bf16_linear",
-    ).cuda()
+    ).to(device)
     layer.weight.data.normal_()
-    x = torch.randn(8, 128, device="cuda", dtype=torch.bfloat16)
+    x = torch.randn(8, 128, device=device, dtype=torch.bfloat16)
 
     output, output_bias = layer(x)
     expected = torch.nn.functional.linear(x, layer.weight)

--- a/vllm/utils/flashinfer.py
+++ b/vllm/utils/flashinfer.py
@@ -126,6 +126,7 @@ flashinfer_cutedsl_grouped_gemm_nt_masked = _lazy_import_wrapper(
     "flashinfer.cute_dsl.blockscaled_gemm", "grouped_gemm_nt_masked"
 )
 flashinfer_fp4_quantize = _lazy_import_wrapper("flashinfer", "fp4_quantize")
+flashinfer_mxfp4_quantize = _lazy_import_wrapper("flashinfer", "mxfp4_quantize")
 nvfp4_batched_quantize = _lazy_import_wrapper("flashinfer", "nvfp4_batched_quantize")
 silu_and_mul_scaled_nvfp4_experts_quantize = _lazy_import_wrapper(
     "flashinfer", "silu_and_mul_scaled_nvfp4_experts_quantize"


### PR DESCRIPTION
**Intel CI failure**: https://buildkite.com/vllm/intel-ci/builds/8908/canvas?sid=019ffe6c-17b4-443f-bc9f-8bf51457f9e2&tab=output
**Root cause**: b12x.py does from vllm.utils.flashinfer import flashinfer_mxfp4_quantize, but the function was never registered in that module. The test's monkeypatch.setattr then fails with AttributeError because there's nothing to patch.

**Fix**: Added flashinfer_mxfp4_quantize = _lazy_import_wrapper("flashinfer", "mxfp4_quantize") to flashinfer.py, following the exact same pattern used for flashinfer_fp4_quantize and the other lazy wrappers.