### PR TITLE
[Kimi-K3] Support DCP partial prefix cache hit

### DIFF
--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -585,13 +585,20 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
                 )
         # Fine-grained hash hits require Mamba "align", no context
         # parallelism, and compatible cache managers in every group.
+        # TP needs hashing finer than the Mamba block. DCP accepts equality
+        # because it scales the effective full-attention block instead.
         has_partial_mamba_group = any(
             isinstance(g.kv_cache_spec, MambaSpec)
             and g.kv_cache_spec.mamba_cache_mode == "align"
-            and g.kv_cache_spec.block_size > hash_block_size
+            and (
+                (dcp_world_size == 1 and g.kv_cache_spec.block_size > hash_block_size)
+                or (
+                    dcp_world_size > 1 and g.kv_cache_spec.block_size >= hash_block_size
+                )
+            )
             for g in kv_cache_config.kv_cache_groups
         )
-        self.enable_partial_hash_hits = dcp_world_size == 1 and has_partial_mamba_group
+        self.enable_partial_hash_hits = has_partial_mamba_group
         if self.enable_partial_hash_hits:
             unsupported_partial_hit_managers = {
                 type(manager).__name__


### PR DESCRIPTION
Port of #50493 onto `agentx-k3`.