### PR TITLE
[Bugfix][Parser] Preserve engine content without tool calls

### DIFF
--- a/tests/parser/engine/test_inkling.py
+++ b/tests/parser/engine/test_inkling.py
@@ -166,6 +166,15 @@ def _delegating(mock_tokenizer, tools=None):
     return parser_cls(mock_tokenizer, tools or [])
 
 
+def _tool_only_delegating(mock_tokenizer, tools=None):
+    parser_cls = ParserManager.get_parser(
+        tool_parser_name="inkling",
+        reasoning_parser_name=None,
+        enable_auto_tools=True,
+    )
+    return parser_cls(mock_tokenizer, tools or [])
+
+
 def _stream_delegating(parser, request, text, chunk_size, prompt_token_ids):
     """Stream ``text`` through ``DelegatingParser.parse_delta``, ``chunk_size``
     tokens per delta; return ``(content, reasoning, ordered tool names,
@@ -595,6 +604,19 @@ class TestRegisteredAdapters:
         assert result.tools_called
         assert result.tool_calls[0].function.name == "f"
         assert json.loads(result.tool_calls[0].function.arguments) == {"a": 1}
+
+
+class TestDelegatingToolOnly:
+    def test_plain_text_non_streaming(self, mock_tokenizer, mock_request):
+        tools = [_function_tool()]
+        mock_request.tools = tools
+        _, content, calls = _tool_only_delegating(mock_tokenizer, tools).parse(
+            f"{TEXT_START}The answer is 42.{END_MESSAGE}",
+            mock_request,
+            enable_auto_tools=True,
+        )
+        assert content == "The answer is 42."
+        assert not calls
 
 
 class TestDelegatingTwoPass:

--- a/tests/parser/test_parse.py
+++ b/tests/parser/test_parse.py
@@ -11,6 +11,7 @@ from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
 from vllm.parser.abstract_parser import DelegatingParser
 from vllm.parser.utils import count_history_tool_calls
 from vllm.reasoning.basic_parsers import BaseThinkingReasoningParser
+from vllm.tool_parsers.abstract_tool_parser import ExtractedToolCallInformation
 from vllm.tool_parsers.hermes_tool_parser import Hermes2ProToolParser
 
 
@@ -140,6 +141,25 @@ def test_parse_plain_text_no_reasoning_parser(tokenizer, reasoning, tool):
     assert content == PLAIN_TEXT
     assert tool_calls is not None
     assert len(tool_calls) == 0
+
+
+def test_plain_tool_parser_no_call_keeps_original_content(tokenizer, monkeypatch):
+    parser = make_parser(tokenizer, tool=True)
+    request = make_request(tools=TOOLS, tool_choice="auto")
+    monkeypatch.setattr(
+        parser.tool_parser,
+        "extract_tool_calls",
+        lambda *_args, **_kwargs: ExtractedToolCallInformation(
+            tools_called=False,
+            tool_calls=[],
+            content="transformed content",
+        ),
+    )
+
+    _, content, tool_calls = parser.parse(PLAIN_TEXT, request, enable_auto_tools=True)
+
+    assert content == PLAIN_TEXT
+    assert tool_calls is None
 
 
 @pytest.mark.parametrize(

--- a/vllm/parser/abstract_parser.py
+++ b/vllm/parser/abstract_parser.py
@@ -504,7 +504,7 @@ class DelegatingParser(Parser):
                     or (isinstance(content, str) and not content.strip())
                 ):
                     return [], None
-                return None, content
+                return None, tool_call_info.content if self._engine_based else content
 
         return tool_calls, content
 


### PR DESCRIPTION
## Purpose

Fixes #52214.

When an engine-backed tool parser is used without a reasoning parser, the non-streaming no-tool-call path currently discards the parser engine's normalized content and returns the original model output. This can leak format markers such as Inkling content-block delimiters into the API response.

Return `tool_call_info.content` only for engine-based parser compositions when automatic parsing finds no tool call. Plain tool parsers keep the existing behavior of returning the untouched input.

The regression coverage verifies both sides of that boundary:

- an engine-backed, tool-only Inkling parser returns clean plain-text content when no tool is called;
- a non-engine tool parser still returns the original input even if its no-call result contains transformed content.

### Duplicate-work check

I searched open pull requests for #52214 and for DelegatingParser engine/no-tool-call content handling. No open PR addresses this issue. Nearby PRs concern token-ID preservation, streaming finalization, or `tool_choice="none"`, not this non-streaming no-call handoff. The issue reporter also confirmed that they are not preparing a patch and asked me to proceed.

## Test Plan

```bash
.venv/bin/python -m pytest tests/parser/engine/test_inkling.py -q
HF_HOME=/path/to/writable/cache .venv/bin/python -m pytest tests/parser/test_parse.py -q
.venv/bin/python -m pytest tests/parser/engine -q
PRE_COMMIT_HOME=/path/to/writable/cache .venv/bin/pre-commit run --files \\
  vllm/parser/abstract_parser.py \\
  tests/parser/engine/test_inkling.py \\
  tests/parser/test_parse.py
```

## Test Result

Before the production fix, the new Inkling regression fails with:

```text
Expected: The answer is 42.
Actual:   <|content_text|>The answer is 42.<|end_message|>
```

With the fix:

- focused parser tests: 106 passed;
- full parser-engine suite: 3,784 passed;
- all relevant pre-commit hooks passed;
- `git diff --check` passed.

### Model evaluation

Not run. This is a unit-level parser-composition fix that requires no model weights or GPU; the failure and corrected output are deterministically covered with the existing mock tokenizer and parser-engine tests.

### AI assistance disclosure

OpenAI Codex was used to investigate, implement, test, and draft this pull request. I reviewed the changed lines and test results.

---

<details>
<summary>Essential Elements of an Effective PR Description Checklist</summary>

- [x] The purpose and linked issue are described.
- [x] The test plan is provided.
- [x] The before/after test results are provided.
- [x] No documentation update is required because this corrects internal parser behavior without changing the public interface.

</details>
