### PR TITLE
[CI] Harden RemoteVLLMServer GPU cleanup checks

### DIFF
--- a/tests/entrypoints/launchers/test_shutdown.py
+++ b/tests/entrypoints/launchers/test_shutdown.py
@@ -272,7 +272,9 @@ async def test_wait_timeout_completes_requests():
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("wait_for_engine_idle", [0.0, 2.0])
-async def test_abort_timeout_exits_quickly(wait_for_engine_idle: float):
+async def test_abort_timeout_exits_within_cleanup_grace(
+    wait_for_engine_idle: float,
+):
     server_args = [
         "--dtype",
         "bfloat16",
@@ -303,19 +305,21 @@ async def test_abort_timeout_exits_quickly(wait_for_engine_idle: float):
             # Wait for engine to become idle
             await asyncio.sleep(wait_for_engine_idle)
 
-        start_time = time.time()
         proc.send_signal(signal.SIGTERM)
 
-        # abort timeout (0) should stop the server promptly.
+        # A zero request timeout aborts requests immediately, but process
+        # teardown may still use the platform-specific resource cleanup grace.
+        termination_timeout = remote_server._get_process_termination_timeout()
         try:
-            proc.wait(timeout=4.0)
+            proc.wait(timeout=termination_timeout)
         except subprocess.TimeoutExpired:
             proc.kill()
             proc.wait(timeout=5)
-            pytest.fail("Process did not exit after SIGTERM with abort timeout")
+            pytest.fail(
+                "Process did not exit within the resource cleanup grace "
+                f"({termination_timeout}s)"
+            )
 
-        exit_time = time.time() - start_time
-        assert exit_time < 4.1, f"Default shutdown took too long: {exit_time:.1f}s"
         assert proc.returncode in (0, -15, None), f"Unexpected: {proc.returncode}"
 
         await _assert_children_cleaned_up(child_pids)

--- a/tests/entrypoints/unit_tests/test_remote_vllm_server.py
+++ b/tests/entrypoints/unit_tests/test_remote_vllm_server.py
@@ -1,0 +1,306 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from collections.abc import Iterator
+from types import SimpleNamespace
+
+import pytest
+
+import tests.utils as test_utils
+from tests.utils import (
+    RemoteLaunchRenderServer,
+    RemoteOpenAIServer,
+    RemoteVLLMServer,
+)
+
+GIB = 1024**3
+GPU_SCOPE = ("cuda", ("0",))
+
+
+@pytest.fixture(autouse=True)
+def reset_remote_server_cleanup_state() -> Iterator[None]:
+    with RemoteVLLMServer._active_servers_lock:
+        saved_failures = RemoteVLLMServer._failed_gpu_cleanup.copy()
+        saved_active_servers = RemoteVLLMServer._active_servers.copy()
+        RemoteVLLMServer._failed_gpu_cleanup.clear()
+        RemoteVLLMServer._active_servers.clear()
+    try:
+        yield
+    finally:
+        with RemoteVLLMServer._active_servers_lock:
+            RemoteVLLMServer._failed_gpu_cleanup.clear()
+            RemoteVLLMServer._failed_gpu_cleanup.update(saved_failures)
+            RemoteVLLMServer._active_servers.clear()
+            RemoteVLLMServer._active_servers.update(saved_active_servers)
+
+
+def make_server(memory_used: float | None) -> RemoteVLLMServer:
+    server = object.__new__(RemoteVLLMServer)
+    server._gpu_device_scope = GPU_SCOPE
+    server._pre_server_gpu_memory = 1 * GIB
+    server._pre_server_gpu_memory_by_device = {"0": 1 * GIB}
+    server._get_gpu_memory_used = (  # type: ignore[method-assign]
+        lambda device_ids=None: memory_used
+    )
+    return server
+
+
+def test_gpu_device_ids_use_canonical_child_visibility(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    server = object.__new__(RemoteVLLMServer)
+    monkeypatch.setattr(
+        test_utils,
+        "current_platform",
+        SimpleNamespace(
+            is_rocm=lambda: True,
+            is_cuda=lambda: False,
+            is_xpu=lambda: False,
+            device_control_env_var="TEST_VISIBLE_DEVICES",
+            device_type="cuda",
+        ),
+    )
+
+    assert server._get_gpu_device_ids({"TEST_VISIBLE_DEVICES": "3,1,3"}) == ("1", "3")
+
+
+def test_xpu_device_ids_use_parent_logical_ordinals(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    server = object.__new__(RemoteVLLMServer)
+    monkeypatch.setattr(
+        test_utils,
+        "current_platform",
+        SimpleNamespace(
+            is_rocm=lambda: False,
+            is_cuda=lambda: False,
+            is_xpu=lambda: True,
+            device_count=lambda: 2,
+            device_control_env_var="ZE_AFFINITY_MASK",
+            device_type="xpu",
+        ),
+    )
+
+    assert server._get_gpu_device_ids({"ZE_AFFINITY_MASK": "2.0,3.0"}) == (
+        "0",
+        "1",
+    )
+
+
+def test_gpu_release_timeout_records_failed_cleanup():
+    server = make_server(5 * GIB)
+
+    with pytest.raises(RuntimeError, match="GPU memory did not release"):
+        server._wait_for_gpu_memory_release(timeout=0)
+
+    assert RemoteVLLMServer._failed_gpu_cleanup[GPU_SCOPE] == (
+        1 * GIB,
+        3 * GIB,
+        5 * GIB,
+    )
+
+
+def test_gpu_release_timeout_with_unavailable_telemetry_fails_closed():
+    server = make_server(None)
+
+    with pytest.raises(RuntimeError, match="Current: unavailable"):
+        server._wait_for_gpu_memory_release(timeout=0)
+
+    assert RemoteVLLMServer._failed_gpu_cleanup[GPU_SCOPE] == (
+        1 * GIB,
+        3 * GIB,
+        None,
+    )
+
+
+@pytest.mark.parametrize("memory_used", [5 * GIB, None])
+def test_failed_cleanup_blocks_next_server(memory_used: float | None):
+    RemoteVLLMServer._failed_gpu_cleanup[GPU_SCOPE] = (
+        1 * GIB,
+        3 * GIB,
+        5 * GIB,
+    )
+    server = make_server(memory_used)
+
+    with pytest.raises(RuntimeError, match="Refusing to start"):
+        server._ensure_failed_gpu_cleanup_recovered()
+
+    assert GPU_SCOPE in RemoteVLLMServer._failed_gpu_cleanup
+
+
+def test_recovered_gpu_memory_clears_failed_cleanup():
+    RemoteVLLMServer._failed_gpu_cleanup[GPU_SCOPE] = (
+        1 * GIB,
+        3 * GIB,
+        5 * GIB,
+    )
+    server = make_server(3 * GIB)
+
+    server._ensure_failed_gpu_cleanup_recovered()
+
+    assert GPU_SCOPE not in RemoteVLLMServer._failed_gpu_cleanup
+
+
+def test_active_server_defers_failed_cleanup_check():
+    active_server = make_server(5 * GIB)
+    with RemoteVLLMServer._active_servers_lock:
+        RemoteVLLMServer._active_servers.add(active_server)
+        RemoteVLLMServer._failed_gpu_cleanup[GPU_SCOPE] = (
+            1 * GIB,
+            3 * GIB,
+            5 * GIB,
+        )
+    server = make_server(5 * GIB)
+
+    server._ensure_failed_gpu_cleanup_recovered()
+
+    assert GPU_SCOPE in RemoteVLLMServer._failed_gpu_cleanup
+
+
+def test_partially_covered_failed_scope_blocks_new_server():
+    failed_scope = ("cuda", ("0", "1"))
+    active_server = make_server(5 * GIB)
+    active_server._gpu_device_scope = ("cuda", ("1",))
+    with RemoteVLLMServer._active_servers_lock:
+        RemoteVLLMServer._active_servers.add(active_server)
+        RemoteVLLMServer._failed_gpu_cleanup[failed_scope] = (
+            2 * GIB,
+            4 * GIB,
+            6 * GIB,
+        )
+    server = make_server(5 * GIB)
+
+    with pytest.raises(RuntimeError, match="cover only part"):
+        server._ensure_failed_gpu_cleanup_recovered()
+
+    assert failed_scope in RemoteVLLMServer._failed_gpu_cleanup
+
+
+def test_overlapping_scope_cannot_bypass_failed_cleanup():
+    RemoteVLLMServer._failed_gpu_cleanup[GPU_SCOPE] = (
+        1 * GIB,
+        3 * GIB,
+        5 * GIB,
+    )
+    server = make_server(5 * GIB)
+    server._gpu_device_scope = ("cuda", ("0", "1"))
+    measured_device_ids = []
+    server._get_gpu_memory_used = (  # type: ignore[method-assign]
+        lambda device_ids=None: measured_device_ids.append(device_ids) or 5 * GIB
+    )
+
+    with pytest.raises(RuntimeError, match="Refusing to start"):
+        server._ensure_failed_gpu_cleanup_recovered()
+
+    assert GPU_SCOPE in RemoteVLLMServer._failed_gpu_cleanup
+    assert measured_device_ids == [("0",)]
+
+
+def test_render_server_has_no_gpu_cleanup_scope():
+    server = object.__new__(RemoteLaunchRenderServer)
+
+    assert server._get_gpu_device_ids(None) is None
+
+
+def test_failed_cleanup_keeps_lowest_recovery_target():
+    server = make_server(5 * GIB)
+    server._record_failed_gpu_cleanup(2 * GIB, 4 * GIB, 6 * GIB)
+    server._record_failed_gpu_cleanup(1 * GIB, 3 * GIB, 5 * GIB)
+
+    assert RemoteVLLMServer._failed_gpu_cleanup[GPU_SCOPE] == (
+        1 * GIB,
+        3 * GIB,
+        5 * GIB,
+    )
+
+
+def test_shutdown_many_waits_once_per_device_scope():
+    terminated = []
+    waited = []
+
+    def make_shutdown_server(
+        name: str,
+        scope: tuple[str, tuple[str, ...]],
+        baseline: float,
+        baselines_by_device: dict[str, float] | None = None,
+    ) -> RemoteVLLMServer:
+        server = make_server(0)
+        server._gpu_device_scope = scope
+        server._pre_server_gpu_memory = baseline
+        server._pre_server_gpu_memory_by_device = baselines_by_device or {
+            scope[1][0]: baseline
+        }
+        server.proc = SimpleNamespace(pid=name)  # type: ignore[assignment]
+        server._terminate_process_tree = (  # type: ignore[method-assign]
+            lambda: terminated.append(name)
+        )
+        server._wait_for_gpu_memory_release = (  # type: ignore[method-assign]
+            lambda **kwargs: waited.append((name, kwargs))
+        )
+        return server
+
+    first = make_shutdown_server("first", ("cuda", ("0",)), 1 * GIB)
+    later = make_shutdown_server("later", ("cuda", ("0",)), 2 * GIB)
+    other = make_shutdown_server("other", ("cuda", ("1",)), 1 * GIB)
+
+    RemoteVLLMServer.shutdown_many([later, other, first])
+
+    assert sorted(terminated) == ["first", "later", "other"]
+    assert sorted(name for name, _ in waited) == ["first", "other"]
+
+
+def test_shutdown_many_uses_per_device_baseline_for_overlapping_scopes():
+    waited = []
+
+    def make_shutdown_server(
+        name: str,
+        scope: tuple[str, tuple[str, ...]],
+        baselines: dict[str, float],
+    ) -> RemoteVLLMServer:
+        server = make_server(0)
+        server._gpu_device_scope = scope
+        server._pre_server_gpu_memory_by_device = baselines
+        server._pre_server_gpu_memory = sum(baselines.values())
+        server.proc = SimpleNamespace(pid=name)  # type: ignore[assignment]
+        server._terminate_process_tree = lambda: None  # type: ignore[method-assign]
+        server._wait_for_gpu_memory_release = (  # type: ignore[method-assign]
+            lambda **kwargs: waited.append(kwargs)
+        )
+        return server
+
+    first = make_shutdown_server("first", ("cuda", ("0",)), {"0": 1 * GIB})
+    broader = make_shutdown_server(
+        "broader",
+        ("cuda", ("0", "1")),
+        {"0": 10 * GIB, "1": 1 * GIB},
+    )
+
+    RemoteVLLMServer.shutdown_many([broader, first])
+
+    assert waited == [
+        {
+            "device_ids": ("0", "1"),
+            "baseline": 2 * GIB,
+            "cleanup_scope": ("cuda", ("0", "1")),
+        }
+    ]
+
+
+@pytest.mark.parametrize(
+    ("request_timeout", "process_timeout", "expected_timeout"),
+    [(0, 60.0, 75.0), (0, 0, 15.0), (30, 30, 45.0)],
+)
+def test_openai_server_wait_covers_engine_cleanup(
+    monkeypatch: pytest.MonkeyPatch,
+    request_timeout: float,
+    process_timeout: float,
+    expected_timeout: float,
+):
+    server = object.__new__(RemoteOpenAIServer)
+    server._request_shutdown_timeout = request_timeout
+    monkeypatch.setattr(
+        "tests.utils.get_engine_process_shutdown_timeout",
+        lambda request_timeout, manager_timeout: process_timeout,
+    )
+
+    assert server._get_process_termination_timeout() == expected_timeout

--- a/tests/entrypoints/unit_tests/test_remote_vllm_server.py
+++ b/tests/entrypoints/unit_tests/test_remote_vllm_server.py
@@ -1,311 +1,33 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-from collections.abc import Iterator
-from types import SimpleNamespace
+from unittest.mock import Mock
 
 import pytest
 
 import tests.utils as test_utils
-from tests.utils import (
-    RemoteLaunchRenderServer,
-    RemoteOpenAIServer,
-    RemoteVLLMServer,
-)
-
-GIB = 1024**3
-GPU_SCOPE = ("cuda", ("0",))
+from tests.utils import RemoteOpenAIServer
 
 
-@pytest.fixture(autouse=True)
-def reset_remote_server_cleanup_state() -> Iterator[None]:
-    with RemoteVLLMServer._active_servers_lock:
-        saved_failures = RemoteVLLMServer._failed_gpu_cleanup.copy()
-        saved_active_servers = RemoteVLLMServer._active_servers.copy()
-        RemoteVLLMServer._failed_gpu_cleanup.clear()
-        RemoteVLLMServer._active_servers.clear()
-    try:
-        yield
-    finally:
-        with RemoteVLLMServer._active_servers_lock:
-            RemoteVLLMServer._failed_gpu_cleanup.clear()
-            RemoteVLLMServer._failed_gpu_cleanup.update(saved_failures)
-            RemoteVLLMServer._active_servers.clear()
-            RemoteVLLMServer._active_servers.update(saved_active_servers)
-
-
-def make_server(memory_used: float | None) -> RemoteVLLMServer:
-    server = object.__new__(RemoteVLLMServer)
-    server._gpu_device_scope = GPU_SCOPE
-    server._pre_server_gpu_memory = 1 * GIB
-    server._pre_server_gpu_memory_by_device = {"0": 1 * GIB}
-    server._get_gpu_memory_used = (  # type: ignore[method-assign]
-        lambda device_ids=None: memory_used
-    )
-    return server
-
-
-def test_gpu_device_ids_use_canonical_child_visibility(
+def test_openai_server_shutdown_wait_covers_engine_cleanup(
     monkeypatch: pytest.MonkeyPatch,
-):
-    server = object.__new__(RemoteVLLMServer)
-    monkeypatch.setattr(
-        test_utils,
-        "current_platform",
-        SimpleNamespace(
-            is_rocm=lambda: True,
-            is_cuda=lambda: False,
-            is_xpu=lambda: False,
-            device_control_env_var="TEST_VISIBLE_DEVICES",
-            device_type="cuda",
-        ),
-    )
-
-    assert server._get_gpu_device_ids({"TEST_VISIBLE_DEVICES": "3,1,3"}) == ("1", "3")
-
-
-def test_xpu_device_ids_use_parent_logical_ordinals(
-    monkeypatch: pytest.MonkeyPatch,
-):
-    server = object.__new__(RemoteVLLMServer)
-    monkeypatch.setattr(
-        test_utils,
-        "current_platform",
-        SimpleNamespace(
-            is_rocm=lambda: False,
-            is_cuda=lambda: False,
-            is_xpu=lambda: True,
-            device_count=lambda: 2,
-            device_control_env_var="ZE_AFFINITY_MASK",
-            device_type="xpu",
-        ),
-    )
-
-    assert server._get_gpu_device_ids({"ZE_AFFINITY_MASK": "2.0,3.0"}) == (
-        "0",
-        "1",
-    )
-
-
-def test_gpu_release_timeout_records_failed_cleanup():
-    server = make_server(5 * GIB)
-
-    with pytest.raises(RuntimeError, match="GPU memory did not release"):
-        server._wait_for_gpu_memory_release(timeout=0)
-
-    assert RemoteVLLMServer._failed_gpu_cleanup[GPU_SCOPE] == (
-        1 * GIB,
-        3 * GIB,
-        5 * GIB,
-    )
-
-
-def test_gpu_release_timeout_with_unavailable_telemetry_fails_closed():
-    server = make_server(None)
-
-    with pytest.raises(RuntimeError, match="Current: unavailable"):
-        server._wait_for_gpu_memory_release(timeout=0)
-
-    assert RemoteVLLMServer._failed_gpu_cleanup[GPU_SCOPE] == (
-        1 * GIB,
-        3 * GIB,
-        None,
-    )
-
-
-@pytest.mark.parametrize("memory_used", [5 * GIB, None])
-def test_failed_cleanup_blocks_next_server(memory_used: float | None):
-    RemoteVLLMServer._failed_gpu_cleanup[GPU_SCOPE] = (
-        1 * GIB,
-        3 * GIB,
-        5 * GIB,
-    )
-    server = make_server(memory_used)
-
-    with pytest.raises(RuntimeError, match="Refusing to start"):
-        server._ensure_failed_gpu_cleanup_recovered()
-
-    assert GPU_SCOPE in RemoteVLLMServer._failed_gpu_cleanup
-
-
-def test_recovered_gpu_memory_clears_failed_cleanup():
-    RemoteVLLMServer._failed_gpu_cleanup[GPU_SCOPE] = (
-        1 * GIB,
-        3 * GIB,
-        5 * GIB,
-    )
-    server = make_server(3 * GIB)
-
-    server._ensure_failed_gpu_cleanup_recovered()
-
-    assert GPU_SCOPE not in RemoteVLLMServer._failed_gpu_cleanup
-
-
-def test_active_server_defers_failed_cleanup_check():
-    active_server = make_server(5 * GIB)
-    with RemoteVLLMServer._active_servers_lock:
-        RemoteVLLMServer._active_servers.add(active_server)
-        RemoteVLLMServer._failed_gpu_cleanup[GPU_SCOPE] = (
-            1 * GIB,
-            3 * GIB,
-            5 * GIB,
-        )
-    server = make_server(5 * GIB)
-
-    server._ensure_failed_gpu_cleanup_recovered()
-
-    assert GPU_SCOPE in RemoteVLLMServer._failed_gpu_cleanup
-
-
-def test_partially_covered_failed_scope_blocks_new_server():
-    failed_scope = ("cuda", ("0", "1"))
-    active_server = make_server(5 * GIB)
-    active_server._gpu_device_scope = ("cuda", ("1",))
-    with RemoteVLLMServer._active_servers_lock:
-        RemoteVLLMServer._active_servers.add(active_server)
-        RemoteVLLMServer._failed_gpu_cleanup[failed_scope] = (
-            2 * GIB,
-            4 * GIB,
-            6 * GIB,
-        )
-    server = make_server(5 * GIB)
-
-    with pytest.raises(RuntimeError, match="cover only part"):
-        server._ensure_failed_gpu_cleanup_recovered()
-
-    assert failed_scope in RemoteVLLMServer._failed_gpu_cleanup
-
-
-def test_overlapping_scope_cannot_bypass_failed_cleanup():
-    RemoteVLLMServer._failed_gpu_cleanup[GPU_SCOPE] = (
-        1 * GIB,
-        3 * GIB,
-        5 * GIB,
-    )
-    server = make_server(5 * GIB)
-    server._gpu_device_scope = ("cuda", ("0", "1"))
-    measured_device_ids: list[tuple[str, ...] | None] = []
-
-    def get_gpu_memory_used(
-        device_ids: tuple[str, ...] | None = None,
-    ) -> float:
-        measured_device_ids.append(device_ids)
-        return 5 * GIB
-
-    server._get_gpu_memory_used = get_gpu_memory_used  # type: ignore[method-assign]
-
-    with pytest.raises(RuntimeError, match="Refusing to start"):
-        server._ensure_failed_gpu_cleanup_recovered()
-
-    assert GPU_SCOPE in RemoteVLLMServer._failed_gpu_cleanup
-    assert measured_device_ids == [("0",)]
-
-
-def test_render_server_has_no_gpu_cleanup_scope():
-    server = object.__new__(RemoteLaunchRenderServer)
-
-    assert server._get_gpu_device_ids(None) is None
-
-
-def test_failed_cleanup_keeps_lowest_recovery_target():
-    server = make_server(5 * GIB)
-    server._record_failed_gpu_cleanup(2 * GIB, 4 * GIB, 6 * GIB)
-    server._record_failed_gpu_cleanup(1 * GIB, 3 * GIB, 5 * GIB)
-
-    assert RemoteVLLMServer._failed_gpu_cleanup[GPU_SCOPE] == (
-        1 * GIB,
-        3 * GIB,
-        5 * GIB,
-    )
-
-
-def test_shutdown_many_waits_once_per_device_scope():
-    terminated = []
-    waited = []
-
-    def make_shutdown_server(
-        name: str,
-        scope: tuple[str, tuple[str, ...]],
-        baseline: float,
-        baselines_by_device: dict[str, float] | None = None,
-    ) -> RemoteVLLMServer:
-        server = make_server(0)
-        server._gpu_device_scope = scope
-        server._pre_server_gpu_memory = baseline
-        server._pre_server_gpu_memory_by_device = baselines_by_device or {
-            scope[1][0]: baseline
-        }
-        server.proc = SimpleNamespace(pid=name)  # type: ignore[assignment]
-        server._terminate_process_tree = (  # type: ignore[method-assign]
-            lambda: terminated.append(name)
-        )
-        server._wait_for_gpu_memory_release = (  # type: ignore[method-assign]
-            lambda **kwargs: waited.append((name, kwargs))
-        )
-        return server
-
-    first = make_shutdown_server("first", ("cuda", ("0",)), 1 * GIB)
-    later = make_shutdown_server("later", ("cuda", ("0",)), 2 * GIB)
-    other = make_shutdown_server("other", ("cuda", ("1",)), 1 * GIB)
-
-    RemoteVLLMServer.shutdown_many([later, other, first])
-
-    assert sorted(terminated) == ["first", "later", "other"]
-    assert sorted(name for name, _ in waited) == ["first", "other"]
-
-
-def test_shutdown_many_uses_per_device_baseline_for_overlapping_scopes():
-    waited = []
-
-    def make_shutdown_server(
-        name: str,
-        scope: tuple[str, tuple[str, ...]],
-        baselines: dict[str, float],
-    ) -> RemoteVLLMServer:
-        server = make_server(0)
-        server._gpu_device_scope = scope
-        server._pre_server_gpu_memory_by_device = baselines
-        server._pre_server_gpu_memory = sum(baselines.values())
-        server.proc = SimpleNamespace(pid=name)  # type: ignore[assignment]
-        server._terminate_process_tree = lambda: None  # type: ignore[method-assign]
-        server._wait_for_gpu_memory_release = (  # type: ignore[method-assign]
-            lambda **kwargs: waited.append(kwargs)
-        )
-        return server
-
-    first = make_shutdown_server("first", ("cuda", ("0",)), {"0": 1 * GIB})
-    broader = make_shutdown_server(
-        "broader",
-        ("cuda", ("0", "1")),
-        {"0": 10 * GIB, "1": 1 * GIB},
-    )
-
-    RemoteVLLMServer.shutdown_many([broader, first])
-
-    assert waited == [
-        {
-            "device_ids": ("0", "1"),
-            "baseline": 2 * GIB,
-            "cleanup_scope": ("cuda", ("0", "1")),
-        }
-    ]
-
-
-@pytest.mark.parametrize(
-    ("request_timeout", "process_timeout", "expected_timeout"),
-    [(0, 60.0, 75.0), (0, 0, 15.0), (30, 30, 45.0)],
-)
-def test_openai_server_wait_covers_engine_cleanup(
-    monkeypatch: pytest.MonkeyPatch,
-    request_timeout: float,
-    process_timeout: float,
-    expected_timeout: float,
 ):
     server = object.__new__(RemoteOpenAIServer)
-    server._request_shutdown_timeout = request_timeout
-    monkeypatch.setattr(
-        "tests.utils.get_engine_process_shutdown_timeout",
-        lambda request_timeout, manager_timeout: process_timeout,
-    )
+    server._request_shutdown_timeout = 0.0
+    server.proc = Mock(pid=1234)
+    engine_timeout_args = []
 
-    assert server._get_process_termination_timeout() == expected_timeout
+    def get_engine_timeout(request_timeout, process_timeout):
+        engine_timeout_args.append((request_timeout, process_timeout))
+        return 60.0
+
+    monkeypatch.setattr(
+        test_utils, "get_engine_process_shutdown_timeout", get_engine_timeout
+    )
+    monkeypatch.setattr(test_utils.os, "getpgid", lambda pid: pid)
+    monkeypatch.setattr(server, "_kill_process_group_survivors", Mock())
+
+    server._terminate_process_tree()
+
+    assert engine_timeout_args == [(0.0, 0.0)]
+    server.proc.wait.assert_called_once_with(timeout=75.0)

--- a/tests/entrypoints/unit_tests/test_remote_vllm_server.py
+++ b/tests/entrypoints/unit_tests/test_remote_vllm_server.py
@@ -184,10 +184,15 @@ def test_overlapping_scope_cannot_bypass_failed_cleanup():
     )
     server = make_server(5 * GIB)
     server._gpu_device_scope = ("cuda", ("0", "1"))
-    measured_device_ids = []
-    server._get_gpu_memory_used = (  # type: ignore[method-assign]
-        lambda device_ids=None: measured_device_ids.append(device_ids) or 5 * GIB
-    )
+    measured_device_ids: list[tuple[str, ...] | None] = []
+
+    def get_gpu_memory_used(
+        device_ids: tuple[str, ...] | None = None,
+    ) -> float:
+        measured_device_ids.append(device_ids)
+        return 5 * GIB
+
+    server._get_gpu_memory_used = get_gpu_memory_used  # type: ignore[method-assign]
 
     with pytest.raises(RuntimeError, match="Refusing to start"):
         server._ensure_failed_gpu_cleanup_recovered()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -63,6 +63,7 @@ from vllm.utils.network_utils import get_open_port
 from vllm.utils.torch_utils import (
     set_random_seed,  # noqa: F401 - re-exported for use in test files
 )
+from vllm.v1.engine.utils import get_engine_process_shutdown_timeout
 
 logger = init_logger(__name__)
 
@@ -214,6 +215,9 @@ class RemoteVLLMServer:
     _cleanup_hooks_registered = False
     _signal_hooks_registered = False
     _previous_signal_handlers: dict[int, Any] = {}
+    _failed_gpu_cleanup: dict[
+        tuple[str, tuple[str, ...]], tuple[float, float, float | None]
+    ] = {}
     proc: subprocess.Popen
 
     def _create_cli_subcommand(self):
@@ -236,6 +240,137 @@ class RemoteVLLMServer:
 
             model_loader = get_model_loader(load_config)
             model_loader.download_model(model_config)
+
+    def _requires_clean_gpu_memory(self) -> bool:
+        """Whether this server needs GPU cleanup from its predecessor."""
+        return True
+
+    def _get_gpu_device_ids(
+        self, env_dict: dict[str, str] | None
+    ) -> tuple[str, ...] | None:
+        """Return canonical device IDs that this process can measure."""
+        if not (
+            current_platform.is_rocm()
+            or current_platform.is_cuda()
+            or current_platform.is_xpu()
+        ):
+            return None
+
+        if current_platform.is_xpu():
+            # torch.xpu.mem_get_info takes parent-local logical ordinals, not
+            # ZE_AFFINITY_MASK physical/tile IDs. Preserve the existing
+            # parent-visible aggregate measurement until a physical-device
+            # management API is available here.
+            device_ids = tuple(str(i) for i in range(current_platform.device_count()))
+            return device_ids or None
+
+        child_env = os.environ.copy()
+        if env_dict is not None:
+            child_env.update(env_dict)
+        visibility = child_env.get(current_platform.device_control_env_var)
+        if visibility is None:
+            device_ids = tuple(str(i) for i in range(current_platform.device_count()))
+            return device_ids or None
+        device_ids = tuple(
+            sorted({device.strip() for device in visibility.split(",") if device})
+        )
+        return device_ids or None
+
+    def _ensure_failed_gpu_cleanup_recovered(self) -> None:
+        """Refuse to turn a known GPU leak into a new server baseline."""
+        scope = self._gpu_device_scope
+        if scope is None:
+            return
+
+        root_cls = RemoteVLLMServer
+        with root_cls._active_servers_lock:
+            platform, device_ids = scope
+            overlapping_failures = [
+                (failed_scope, failed_cleanup)
+                for failed_scope, failed_cleanup in root_cls._failed_gpu_cleanup.items()
+                if failed_scope[0] == platform
+                and not set(failed_scope[1]).isdisjoint(device_ids)
+            ]
+            if not overlapping_failures:
+                return
+
+            for failed_scope, failed_cleanup in overlapping_failures:
+                failed_device_ids = failed_scope[1]
+
+                # Parallel/distributed fixtures intentionally overlap server
+                # lifetimes. Their aggregate memory cannot prove whether an
+                # older cleanup failure has recovered, so retain the poison
+                # until no server using any affected device is active.
+                active_device_ids: set[str] = set()
+                for server in root_cls._active_servers:
+                    active_scope = getattr(server, "_gpu_device_scope", None)
+                    if active_scope is not None and active_scope[0] == platform:
+                        active_device_ids.update(active_scope[1])
+                affected_device_ids = set(device_ids).intersection(failed_device_ids)
+                active_device_ids.intersection_update(failed_device_ids)
+                if active_device_ids:
+                    if affected_device_ids.issubset(active_device_ids):
+                        continue
+                    raise RuntimeError(
+                        f"[{type(self).__name__}] Refusing to start because GPU "
+                        "cleanup recovery cannot be verified while active servers "
+                        "cover only part of the affected device scope."
+                    )
+
+                baseline, target, previous_used = failed_cleanup
+                current_used = self._get_gpu_memory_used(failed_device_ids)
+                if current_used is not None and current_used <= target:
+                    del root_cls._failed_gpu_cleanup[failed_scope]
+                    print(
+                        f"[{type(self).__name__}] GPU memory recovered after a "
+                        f"previous cleanup failure: {current_used / 1e9:.2f} GB "
+                        f"(target: {target / 1e9:.2f} GB)"
+                    )
+                    continue
+
+                current_text = (
+                    "unavailable"
+                    if current_used is None
+                    else f"{current_used / 1e9:.2f} GB"
+                )
+                previous_text = (
+                    "unavailable"
+                    if previous_used is None
+                    else f"{previous_used / 1e9:.2f} GB"
+                )
+                raise RuntimeError(
+                    f"[{type(self).__name__}] Refusing to start because GPU memory "
+                    f"has not recovered from a previous server cleanup failure. "
+                    f"Current: {current_text}, previous: {previous_text}, "
+                    f"target: {target / 1e9:.2f} GB, "
+                    f"baseline: {baseline / 1e9:.2f} GB."
+                )
+
+    def _record_failed_gpu_cleanup(
+        self,
+        baseline: float,
+        target: float,
+        observed: float | None,
+        scope: tuple[str, tuple[str, ...]] | None = None,
+    ) -> None:
+        if scope is None:
+            scope = self._gpu_device_scope
+        if scope is None:
+            return
+
+        root_cls = RemoteVLLMServer
+        with root_cls._active_servers_lock:
+            previous = root_cls._failed_gpu_cleanup.get(scope)
+            if previous is None or target < previous[1]:
+                root_cls._failed_gpu_cleanup[scope] = (
+                    baseline,
+                    target,
+                    observed,
+                )
+
+    def _get_process_termination_timeout(self) -> float:
+        """Maximum time to wait for the root server after SIGTERM."""
+        return 15.0
 
     def __init__(
         self,
@@ -288,13 +423,32 @@ class RemoteVLLMServer:
             getattr(args, "show_hidden_metrics_for_version", None) is not None
         )
 
+        self._request_shutdown_timeout = float(args.shutdown_timeout)
+        self._gpu_device_ids = self._get_gpu_device_ids(env_dict)
+        self._gpu_device_scope = (
+            None
+            if self._gpu_device_ids is None
+            else (current_platform.device_type, self._gpu_device_ids)
+        )
+
         with _temporarily_sanitized_pythonpath_env():
             self._pre_download_model(model, args)
         self._shutdown_complete = False
 
         # Record GPU memory before server start so we know what
-        # "released" looks like.
-        self._pre_server_gpu_memory = self._get_gpu_memory_used()
+        # "released" looks like. Keep the poison check and baseline capture
+        # atomic with respect to teardown failures recorded by other servers.
+        with RemoteVLLMServer._active_servers_lock:
+            if self._requires_clean_gpu_memory():
+                self._ensure_failed_gpu_cleanup_recovered()
+            self._pre_server_gpu_memory_by_device = (
+                self._get_gpu_memory_used_by_device()
+            )
+            self._pre_server_gpu_memory = (
+                None
+                if self._pre_server_gpu_memory_by_device is None
+                else sum(self._pre_server_gpu_memory_by_device.values())
+            )
         if self._pre_server_gpu_memory is not None:
             pre_gb = self._pre_server_gpu_memory / 1e9
             print(
@@ -415,8 +569,9 @@ class RemoteVLLMServer:
             self.proc.terminate()
             print(f"[RemoteOpenAIServer] Sent SIGTERM to process {pid}")
 
+        process_timeout = self._get_process_termination_timeout()
         try:
-            self.proc.wait(timeout=15)
+            self.proc.wait(timeout=process_timeout)
             print(f"[RemoteOpenAIServer] Server {pid} terminated gracefully")
         except subprocess.TimeoutExpired:
             # Phase 2: SIGKILL the entire process group
@@ -454,8 +609,8 @@ class RemoteVLLMServer:
         servers are still holding GPU memory.
 
         Instead, this method terminates every server's process tree in
-        parallel, then runs the GPU-memory-release wait once against the
-        earliest recorded baseline (memory before any server started).
+        parallel, merges overlapping device scopes, and runs one release wait
+        per connected scope using each device's earliest recorded baseline.
         """
         if not servers:
             return
@@ -476,22 +631,126 @@ class RemoteVLLMServer:
         for t in threads:
             t.join()
 
-        # Use the smallest pre-server baseline so the wait targets memory
-        # usage before *any* of these sibling servers started, not after
-        # earlier siblings had already allocated.
-        earliest = min(
-            servers,
-            key=lambda s: (
-                float("inf")
-                if s._pre_server_gpu_memory is None
-                else s._pre_server_gpu_memory
-            ),
-        )
+        # Merge overlapping device scopes into connected components. Within
+        # each component, use the smallest baseline observed for each physical
+        # device. This prevents a later multi-GPU server from incorporating an
+        # earlier sibling's allocation into its aggregate baseline and hiding a
+        # leak on another device.
+        cleanup_servers = [
+            server
+            for server in servers
+            if server._requires_clean_gpu_memory()
+            and server._gpu_device_scope is not None
+        ]
+        components_by_platform: dict[str, list[set[str]]] = {}
+        for server in cleanup_servers:
+            assert server._gpu_device_scope is not None
+            platform, device_ids = server._gpu_device_scope
+            components = components_by_platform.setdefault(platform, [])
+            merged = set(device_ids)
+            disjoint_components = []
+            for component in components:
+                if component.isdisjoint(merged):
+                    disjoint_components.append(component)
+                else:
+                    merged.update(component)
+            components[:] = [*disjoint_components, merged]
+
+        wait_specs: list[
+            tuple[
+                RemoteVLLMServer,
+                tuple[str, ...],
+                float,
+                tuple[str, tuple[str, ...]],
+            ]
+        ] = []
+        for platform, components in components_by_platform.items():
+            for component in components:
+                component_servers = [
+                    server
+                    for server in cleanup_servers
+                    if server._gpu_device_scope is not None
+                    and server._gpu_device_scope[0] == platform
+                    and not set(server._gpu_device_scope[1]).isdisjoint(component)
+                ]
+                earliest_by_device: dict[str, float] = {}
+                for server in component_servers:
+                    baselines = getattr(
+                        server, "_pre_server_gpu_memory_by_device", None
+                    )
+                    if baselines is None:
+                        continue
+                    for device_id, baseline in baselines.items():
+                        if device_id in component:
+                            earliest_by_device[device_id] = min(
+                                baseline,
+                                earliest_by_device.get(device_id, float("inf")),
+                            )
+
+                # Match the pre-existing behavior if baseline telemetry was
+                # unavailable: cleanup still runs, but there is no reliable
+                # memory value against which to wait.
+                if earliest_by_device.keys() != component:
+                    continue
+
+                device_ids = tuple(sorted(component))
+                representative = min(
+                    component_servers,
+                    key=lambda server: (
+                        float("inf")
+                        if server._pre_server_gpu_memory is None
+                        else server._pre_server_gpu_memory
+                    ),
+                )
+                wait_specs.append(
+                    (
+                        representative,
+                        device_ids,
+                        sum(earliest_by_device.values()),
+                        (platform, device_ids),
+                    )
+                )
+
+        errors: list[BaseException] = []
+        errors_lock = threading.Lock()
+
+        def wait_for_release(
+            server: RemoteVLLMServer,
+            device_ids: tuple[str, ...],
+            baseline: float,
+            scope: tuple[str, tuple[str, ...]],
+        ) -> None:
+            try:
+                server._wait_for_gpu_memory_release(
+                    device_ids=device_ids,
+                    baseline=baseline,
+                    cleanup_scope=scope,
+                )
+            except BaseException as e:
+                with errors_lock:
+                    errors.append(e)
+
+        wait_threads = [
+            threading.Thread(
+                target=wait_for_release,
+                args=spec,
+                name=f"gpu-release-{scope}",
+                daemon=True,
+            )
+            for spec in wait_specs
+            for scope in (spec[3],)
+        ]
         try:
-            earliest._wait_for_gpu_memory_release()
+            for thread in wait_threads:
+                thread.start()
+            for thread in wait_threads:
+                thread.join()
         finally:
             for server in servers:
                 server._unregister_active_server()
+
+        if errors:
+            raise errors[0]
 
     def _kill_process_group_survivors(
         self, pgid: int | None, timeout: float = 15.0
@@ -568,20 +827,26 @@ class RemoteVLLMServer:
                 continue
         return members
 
-    def _get_gpu_memory_used(self) -> float | None:
-        """Get total GPU memory used across all visible devices in bytes."""
+    def _get_gpu_memory_used_by_device(
+        self, device_ids: tuple[str, ...] | None = None
+    ) -> dict[str, float] | None:
+        """Get GPU memory used per selected device in bytes."""
         try:
+            if device_ids is None:
+                device_ids = getattr(self, "_gpu_device_ids", None)
+                if device_ids is None:
+                    device_ids = self._get_gpu_device_ids(None)
+            if device_ids is None:
+                return None
+
             if current_platform.is_rocm():
                 with _nvml():
                     handles = amdsmi_get_processor_handles()
-                    devices = get_physical_device_indices(
-                        list(range(current_platform.device_count()))
-                    )
-                    total_used_mib = 0
-                    for device in devices:
-                        handle = handles[device]
+                    used_by_device = {}
+                    for device_id in device_ids:
+                        handle = handles[int(device_id)]
                         vram_info = amdsmi_get_gpu_vram_usage(handle)
-                        total_used_mib += vram_info["vram_used"]
+                        used_by_device[device_id] = vram_info["vram_used"] * 1024 * 1024
                     # amdsmi reports VRAM in MiB; convert to bytes so this
                     # matches the CUDA/nvml branch (already bytes) and the
                     # byte-based target in _wait_for_gpu_memory_release. Without
@@ -589,30 +854,45 @@ class RemoteVLLMServer:
                     # is always satisfied instantly, and returns "released to
                     # 0.00 GB" while the previous server's VRAM is still
                     # resident -- OOMing the next server's startup on ROCm.
-                    return total_used_mib * 1024 * 1024
+                    return used_by_device
             elif current_platform.is_cuda():
                 with _nvml():
-                    total_used = 0
-                    device_count = current_platform.device_count()
-                    for i in range(device_count):
-                        handle = nvmlDeviceGetHandleByIndex(i)
+                    used_by_device = {}
+                    for device_id in device_ids:
+                        handle = (
+                            nvmlDeviceGetHandleByUUID(device_id)
+                            if device_id.startswith(("GPU-", "MIG-"))
+                            else nvmlDeviceGetHandleByIndex(int(device_id))
+                        )
                         mem_info = nvmlDeviceGetMemoryInfo(handle)
-                        total_used += mem_info.used
-                    return total_used
+                        used_by_device[device_id] = mem_info.used
+                    return used_by_device
             elif current_platform.is_xpu():
-                total_used = 0
-                device_count = current_platform.device_count()
-                for i in range(device_count):
-                    free, total = torch.xpu.mem_get_info(i)
-                    total_used += total - free
-                return total_used
+                used_by_device = {}
+                for device_id in device_ids:
+                    free, total = torch.xpu.mem_get_info(int(device_id))
+                    used_by_device[device_id] = total - free
+                return used_by_device
         except Exception as e:
             print(f"[RemoteOpenAIServer] Could not query GPU memory: {e}")
             return None
         return None
 
+    def _get_gpu_memory_used(
+        self, device_ids: tuple[str, ...] | None = None
+    ) -> float | None:
+        """Get total GPU memory used across selected devices in bytes."""
+        used_by_device = self._get_gpu_memory_used_by_device(device_ids)
+        return None if used_by_device is None else sum(used_by_device.values())
+
     def _wait_for_gpu_memory_release(
-        self, timeout: float = 120.0, log_interval: float = 10.0
+        self,
+        timeout: float = 120.0,
+        log_interval: float = 10.0,
+        *,
+        device_ids: tuple[str, ...] | None = None,
+        baseline: float | None = None,
+        cleanup_scope: tuple[str, tuple[str, ...]] | None = None,
     ):
         """Wait for GPU memory to drop back toward pre-server levels.
 
@@ -622,7 +902,8 @@ class RemoteVLLMServer:
         the test fails so the problem is surfaced immediately rather
         than causing cascading OOM failures in every subsequent test.
         """
-        baseline = self._pre_server_gpu_memory
+        if baseline is None:
+            baseline = self._pre_server_gpu_memory
         if baseline is None:
             # Can't query GPU memory - nothing to do
             return
@@ -636,10 +917,14 @@ class RemoteVLLMServer:
         next_log_time = start + log_interval
 
         while time.time() - start < timeout:
-            used = self._get_gpu_memory_used()
+            used = self._get_gpu_memory_used(device_ids)
 
             if used is None:
-                return  # Can't query, assume ok
+                # A transient telemetry failure is not proof that cleanup
+                # succeeded. Keep waiting so an unverified release cannot
+                # become the next server's baseline.
+                time.sleep(1.0)
+                continue
 
             used_gb = used / 1e9
             target_gb = target / 1e9
@@ -666,14 +951,19 @@ class RemoteVLLMServer:
 
         # Timeout -- raise so the current test fails with a clear
         # message instead of silently poisoning subsequent tests.
-        final_used = self._get_gpu_memory_used()
-        final_gb = final_used / 1e9 if final_used else 0.0
+        final_used = self._get_gpu_memory_used(device_ids)
+        self._record_failed_gpu_cleanup(
+            baseline, target, final_used, scope=cleanup_scope
+        )
+        final_text = (
+            "unavailable" if final_used is None else f"{final_used / 1e9:.2f} GB"
+        )
         raise RuntimeError(
             f"[RemoteOpenAIServer] GPU memory did not release within "
-            f"{timeout}s. Current: {final_gb:.2f} GB, "
+            f"{timeout}s. Current: {final_text}, "
             f"target: {target / 1e9:.2f} GB, "
             f"baseline: {baseline / 1e9:.2f} GB. "
-            f"Child processes may still be holding GPU memory."
+            f"A child process or another workload may be holding GPU memory."
         )
 
     def _poll(self) -> int | None:
@@ -758,6 +1048,15 @@ class RemoteVLLMServer:
 class RemoteOpenAIServer(RemoteVLLMServer):
     """Launches ``vllm serve`` for testing OpenAI-compatible endpoints."""
 
+    def _get_process_termination_timeout(self) -> float:
+        process_timeout = get_engine_process_shutdown_timeout(
+            self._request_shutdown_timeout, self._request_shutdown_timeout
+        )
+        assert process_timeout is not None
+        # Leave time for the API process to finish its own cleanup after its
+        # EngineCore manager has completed.
+        return max(super()._get_process_termination_timeout(), process_timeout + 15.0)
+
     def _create_cli_subcommand(self):
         return ServeSubcommand()
 
@@ -787,6 +1086,14 @@ class RemoteOpenAIServer(RemoteVLLMServer):
 
 class RemoteLaunchRenderServer(RemoteVLLMServer):
     """Launches ``vllm launch render`` for GPU-less serving tests."""
+
+    def _requires_clean_gpu_memory(self) -> bool:
+        return False
+
+    def _get_gpu_device_ids(
+        self, env_dict: dict[str, str] | None
+    ) -> tuple[str, ...] | None:
+        return None
 
     def _create_cli_subcommand(self):
         return ServeSubcommand()
@@ -889,7 +1196,7 @@ class RemoteOpenAIServerCustom(RemoteOpenAIServer):
             self.proc.terminate()
             print(f"[RemoteOpenAIServerCustom] Sent SIGTERM to process {pid}")
 
-        self.proc.join(15)
+        self.proc.join(self._get_process_termination_timeout())
         if self.proc.is_alive():
             print(
                 f"[RemoteOpenAIServerCustom] Server {pid} did not respond "

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -215,9 +215,6 @@ class RemoteVLLMServer:
     _cleanup_hooks_registered = False
     _signal_hooks_registered = False
     _previous_signal_handlers: dict[int, Any] = {}
-    _failed_gpu_cleanup: dict[
-        tuple[str, tuple[str, ...]], tuple[float, float, float | None]
-    ] = {}
     proc: subprocess.Popen
 
     def _create_cli_subcommand(self):
@@ -241,135 +238,7 @@ class RemoteVLLMServer:
             model_loader = get_model_loader(load_config)
             model_loader.download_model(model_config)
 
-    def _requires_clean_gpu_memory(self) -> bool:
-        """Whether this server needs GPU cleanup from its predecessor."""
-        return True
-
-    def _get_gpu_device_ids(
-        self, env_dict: dict[str, str] | None
-    ) -> tuple[str, ...] | None:
-        """Return canonical device IDs that this process can measure."""
-        if not (
-            current_platform.is_rocm()
-            or current_platform.is_cuda()
-            or current_platform.is_xpu()
-        ):
-            return None
-
-        if current_platform.is_xpu():
-            # torch.xpu.mem_get_info takes parent-local logical ordinals, not
-            # ZE_AFFINITY_MASK physical/tile IDs. Preserve the existing
-            # parent-visible aggregate measurement until a physical-device
-            # management API is available here.
-            device_ids = tuple(str(i) for i in range(current_platform.device_count()))
-            return device_ids or None
-
-        child_env = os.environ.copy()
-        if env_dict is not None:
-            child_env.update(env_dict)
-        visibility = child_env.get(current_platform.device_control_env_var)
-        if visibility is None:
-            device_ids = tuple(str(i) for i in range(current_platform.device_count()))
-            return device_ids or None
-        device_ids = tuple(
-            sorted({device.strip() for device in visibility.split(",") if device})
-        )
-        return device_ids or None
-
-    def _ensure_failed_gpu_cleanup_recovered(self) -> None:
-        """Refuse to turn a known GPU leak into a new server baseline."""
-        scope = self._gpu_device_scope
-        if scope is None:
-            return
-
-        root_cls = RemoteVLLMServer
-        with root_cls._active_servers_lock:
-            platform, device_ids = scope
-            overlapping_failures = [
-                (failed_scope, failed_cleanup)
-                for failed_scope, failed_cleanup in root_cls._failed_gpu_cleanup.items()
-                if failed_scope[0] == platform
-                and not set(failed_scope[1]).isdisjoint(device_ids)
-            ]
-            if not overlapping_failures:
-                return
-
-            for failed_scope, failed_cleanup in overlapping_failures:
-                failed_device_ids = failed_scope[1]
-
-                # Parallel/distributed fixtures intentionally overlap server
-                # lifetimes. Their aggregate memory cannot prove whether an
-                # older cleanup failure has recovered, so retain the poison
-                # until no server using any affected device is active.
-                active_device_ids: set[str] = set()
-                for server in root_cls._active_servers:
-                    active_scope = getattr(server, "_gpu_device_scope", None)
-                    if active_scope is not None and active_scope[0] == platform:
-                        active_device_ids.update(active_scope[1])
-                affected_device_ids = set(device_ids).intersection(failed_device_ids)
-                active_device_ids.intersection_update(failed_device_ids)
-                if active_device_ids:
-                    if affected_device_ids.issubset(active_device_ids):
-                        continue
-                    raise RuntimeError(
-                        f"[{type(self).__name__}] Refusing to start because GPU "
-                        "cleanup recovery cannot be verified while active servers "
-                        "cover only part of the affected device scope."
-                    )
-
-                baseline, target, previous_used = failed_cleanup
-                current_used = self._get_gpu_memory_used(failed_device_ids)
-                if current_used is not None and current_used <= target:
-                    del root_cls._failed_gpu_cleanup[failed_scope]
-                    print(
-                        f"[{type(self).__name__}] GPU memory recovered after a "
-                        f"previous cleanup failure: {current_used / 1e9:.2f} GB "
-                        f"(target: {target / 1e9:.2f} GB)"
-                    )
-                    continue
-
-                current_text = (
-                    "unavailable"
-                    if current_used is None
-                    else f"{current_used / 1e9:.2f} GB"
-                )
-                previous_text = (
-                    "unavailable"
-                    if previous_used is None
-                    else f"{previous_used / 1e9:.2f} GB"
-                )
-                raise RuntimeError(
-                    f"[{type(self).__name__}] Refusing to start because GPU memory "
-                    f"has not recovered from a previous server cleanup failure. "
-                    f"Current: {current_text}, previous: {previous_text}, "
-                    f"target: {target / 1e9:.2f} GB, "
-                    f"baseline: {baseline / 1e9:.2f} GB."
-                )
-
-    def _record_failed_gpu_cleanup(
-        self,
-        baseline: float,
-        target: float,
-        observed: float | None,
-        scope: tuple[str, tuple[str, ...]] | None = None,
-    ) -> None:
-        if scope is None:
-            scope = self._gpu_device_scope
-        if scope is None:
-            return
-
-        root_cls = RemoteVLLMServer
-        with root_cls._active_servers_lock:
-            previous = root_cls._failed_gpu_cleanup.get(scope)
-            if previous is None or target < previous[1]:
-                root_cls._failed_gpu_cleanup[scope] = (
-                    baseline,
-                    target,
-                    observed,
-                )
-
     def _get_process_termination_timeout(self) -> float:
-        """Maximum time to wait for the root server after SIGTERM."""
         return 15.0
 
     def __init__(
@@ -422,33 +291,15 @@ class RemoteVLLMServer:
         self.show_hidden_metrics = (
             getattr(args, "show_hidden_metrics_for_version", None) is not None
         )
-
         self._request_shutdown_timeout = float(args.shutdown_timeout)
-        self._gpu_device_ids = self._get_gpu_device_ids(env_dict)
-        self._gpu_device_scope = (
-            None
-            if self._gpu_device_ids is None
-            else (current_platform.device_type, self._gpu_device_ids)
-        )
 
         with _temporarily_sanitized_pythonpath_env():
             self._pre_download_model(model, args)
         self._shutdown_complete = False
 
         # Record GPU memory before server start so we know what
-        # "released" looks like. Keep the poison check and baseline capture
-        # atomic with respect to teardown failures recorded by other servers.
-        with RemoteVLLMServer._active_servers_lock:
-            if self._requires_clean_gpu_memory():
-                self._ensure_failed_gpu_cleanup_recovered()
-            self._pre_server_gpu_memory_by_device = (
-                self._get_gpu_memory_used_by_device()
-            )
-            self._pre_server_gpu_memory = (
-                None
-                if self._pre_server_gpu_memory_by_device is None
-                else sum(self._pre_server_gpu_memory_by_device.values())
-            )
+        # "released" looks like.
+        self._pre_server_gpu_memory = self._get_gpu_memory_used()
         if self._pre_server_gpu_memory is not None:
             pre_gb = self._pre_server_gpu_memory / 1e9
             print(
@@ -569,9 +420,8 @@ class RemoteVLLMServer:
             self.proc.terminate()
             print(f"[RemoteOpenAIServer] Sent SIGTERM to process {pid}")
 
-        process_timeout = self._get_process_termination_timeout()
         try:
-            self.proc.wait(timeout=process_timeout)
+            self.proc.wait(timeout=self._get_process_termination_timeout())
             print(f"[RemoteOpenAIServer] Server {pid} terminated gracefully")
         except subprocess.TimeoutExpired:
             # Phase 2: SIGKILL the entire process group
@@ -609,8 +459,8 @@ class RemoteVLLMServer:
         servers are still holding GPU memory.
 
         Instead, this method terminates every server's process tree in
-        parallel, merges overlapping device scopes, and runs one release wait
-        per connected scope using each device's earliest recorded baseline.
+        parallel, then runs the GPU-memory-release wait once against the
+        earliest recorded baseline (memory before any server started).
         """
         if not servers:
             return
@@ -631,126 +481,22 @@ class RemoteVLLMServer:
         for t in threads:
             t.join()
 
-        # Merge overlapping device scopes into connected components. Within
-        # each component, use the smallest baseline observed for each physical
-        # device. This prevents a later multi-GPU server from incorporating an
-        # earlier sibling's allocation into its aggregate baseline and hiding a
-        # leak on another device.
-        cleanup_servers = [
-            server
-            for server in servers
-            if server._requires_clean_gpu_memory()
-            and server._gpu_device_scope is not None
-        ]
-        components_by_platform: dict[str, list[set[str]]] = {}
-        for server in cleanup_servers:
-            assert server._gpu_device_scope is not None
-            platform, device_ids = server._gpu_device_scope
-            components = components_by_platform.setdefault(platform, [])
-            merged = set(device_ids)
-            disjoint_components = []
-            for component in components:
-                if component.isdisjoint(merged):
-                    disjoint_components.append(component)
-                else:
-                    merged.update(component)
-            components[:] = [*disjoint_components, merged]
-
-        wait_specs: list[
-            tuple[
-                RemoteVLLMServer,
-                tuple[str, ...],
-                float,
-                tuple[str, tuple[str, ...]],
-            ]
-        ] = []
-        for platform, components in components_by_platform.items():
-            for component in components:
-                component_servers = [
-                    server
-                    for server in cleanup_servers
-                    if server._gpu_device_scope is not None
-                    and server._gpu_device_scope[0] == platform
-                    and not set(server._gpu_device_scope[1]).isdisjoint(component)
-                ]
-                earliest_by_device: dict[str, float] = {}
-                for server in component_servers:
-                    baselines = getattr(
-                        server, "_pre_server_gpu_memory_by_device", None
-                    )
-                    if baselines is None:
-                        continue
-                    for device_id, baseline in baselines.items():
-                        if device_id in component:
-                            earliest_by_device[device_id] = min(
-                                baseline,
-                                earliest_by_device.get(device_id, float("inf")),
-                            )
-
-                # Match the pre-existing behavior if baseline telemetry was
-                # unavailable: cleanup still runs, but there is no reliable
-                # memory value against which to wait.
-                if earliest_by_device.keys() != component:
-                    continue
-
-                device_ids = tuple(sorted(component))
-                representative = min(
-                    component_servers,
-                    key=lambda server: (
-                        float("inf")
-                        if server._pre_server_gpu_memory is None
-                        else server._pre_server_gpu_memory
-                    ),
-                )
-                wait_specs.append(
-                    (
-                        representative,
-                        device_ids,
-                        sum(earliest_by_device.values()),
-                        (platform, device_ids),
-                    )
-                )
-
-        errors: list[BaseException] = []
-        errors_lock = threading.Lock()
-
-        def wait_for_release(
-            server: RemoteVLLMServer,
-            device_ids: tuple[str, ...],
-            baseline: float,
-            scope: tuple[str, tuple[str, ...]],
-        ) -> None:
-            try:
-                server._wait_for_gpu_memory_release(
-                    device_ids=device_ids,
-                    baseline=baseline,
-                    cleanup_scope=scope,
-                )
-            except BaseException as e:
-                with errors_lock:
-                    errors.append(e)
-
-        wait_threads = [
-            threading.Thread(
-                target=wait_for_release,
-                args=spec,
-                name=f"gpu-release-{scope}",
-                daemon=True,
-            )
-            for spec in wait_specs
-            for scope in (spec[3],)
-        ]
+        # Use the smallest pre-server baseline so the wait targets memory
+        # usage before *any* of these sibling servers started, not after
+        # earlier siblings had already allocated.
+        earliest = min(
+            servers,
+            key=lambda s: (
+                float("inf")
+                if s._pre_server_gpu_memory is None
+                else s._pre_server_gpu_memory
+            ),
+        )
         try:
-            for thread in wait_threads:
-                thread.start()
-            for thread in wait_threads:
-                thread.join()
+            earliest._wait_for_gpu_memory_release()
         finally:
             for server in servers:
                 server._unregister_active_server()
-
-        if errors:
-            raise errors[0]
 
     def _kill_process_group_survivors(
         self, pgid: int | None, timeout: float = 15.0
@@ -827,26 +573,20 @@ class RemoteVLLMServer:
                 continue
         return members
 
-    def _get_gpu_memory_used_by_device(
-        self, device_ids: tuple[str, ...] | None = None
-    ) -> dict[str, float] | None:
-        """Get GPU memory used per selected device in bytes."""
+    def _get_gpu_memory_used(self) -> float | None:
+        """Get total GPU memory used across all visible devices in bytes."""
         try:
-            if device_ids is None:
-                device_ids = getattr(self, "_gpu_device_ids", None)
-                if device_ids is None:
-                    device_ids = self._get_gpu_device_ids(None)
-            if device_ids is None:
-                return None
-
             if current_platform.is_rocm():
                 with _nvml():
                     handles = amdsmi_get_processor_handles()
-                    used_by_device = {}
-                    for device_id in device_ids:
-                        handle = handles[int(device_id)]
+                    devices = get_physical_device_indices(
+                        list(range(current_platform.device_count()))
+                    )
+                    total_used_mib = 0
+                    for device in devices:
+                        handle = handles[device]
                         vram_info = amdsmi_get_gpu_vram_usage(handle)
-                        used_by_device[device_id] = vram_info["vram_used"] * 1024 * 1024
+                        total_used_mib += vram_info["vram_used"]
                     # amdsmi reports VRAM in MiB; convert to bytes so this
                     # matches the CUDA/nvml branch (already bytes) and the
                     # byte-based target in _wait_for_gpu_memory_release. Without
@@ -854,45 +594,30 @@ class RemoteVLLMServer:
                     # is always satisfied instantly, and returns "released to
                     # 0.00 GB" while the previous server's VRAM is still
                     # resident -- OOMing the next server's startup on ROCm.
-                    return used_by_device
+                    return total_used_mib * 1024 * 1024
             elif current_platform.is_cuda():
                 with _nvml():
-                    used_by_device = {}
-                    for device_id in device_ids:
-                        handle = (
-                            nvmlDeviceGetHandleByUUID(device_id)
-                            if device_id.startswith(("GPU-", "MIG-"))
-                            else nvmlDeviceGetHandleByIndex(int(device_id))
-                        )
+                    total_used = 0
+                    device_count = current_platform.device_count()
+                    for i in range(device_count):
+                        handle = nvmlDeviceGetHandleByIndex(i)
                         mem_info = nvmlDeviceGetMemoryInfo(handle)
-                        used_by_device[device_id] = mem_info.used
-                    return used_by_device
+                        total_used += mem_info.used
+                    return total_used
             elif current_platform.is_xpu():
-                used_by_device = {}
-                for device_id in device_ids:
-                    free, total = torch.xpu.mem_get_info(int(device_id))
-                    used_by_device[device_id] = total - free
-                return used_by_device
+                total_used = 0
+                device_count = current_platform.device_count()
+                for i in range(device_count):
+                    free, total = torch.xpu.mem_get_info(i)
+                    total_used += total - free
+                return total_used
         except Exception as e:
             print(f"[RemoteOpenAIServer] Could not query GPU memory: {e}")
             return None
         return None
 
-    def _get_gpu_memory_used(
-        self, device_ids: tuple[str, ...] | None = None
-    ) -> float | None:
-        """Get total GPU memory used across selected devices in bytes."""
-        used_by_device = self._get_gpu_memory_used_by_device(device_ids)
-        return None if used_by_device is None else sum(used_by_device.values())
-
     def _wait_for_gpu_memory_release(
-        self,
-        timeout: float = 120.0,
-        log_interval: float = 10.0,
-        *,
-        device_ids: tuple[str, ...] | None = None,
-        baseline: float | None = None,
-        cleanup_scope: tuple[str, tuple[str, ...]] | None = None,
+        self, timeout: float = 120.0, log_interval: float = 10.0
     ):
         """Wait for GPU memory to drop back toward pre-server levels.
 
@@ -902,8 +627,7 @@ class RemoteVLLMServer:
         the test fails so the problem is surfaced immediately rather
         than causing cascading OOM failures in every subsequent test.
         """
-        if baseline is None:
-            baseline = self._pre_server_gpu_memory
+        baseline = self._pre_server_gpu_memory
         if baseline is None:
             # Can't query GPU memory - nothing to do
             return
@@ -917,14 +641,10 @@ class RemoteVLLMServer:
         next_log_time = start + log_interval
 
         while time.time() - start < timeout:
-            used = self._get_gpu_memory_used(device_ids)
+            used = self._get_gpu_memory_used()
 
             if used is None:
-                # A transient telemetry failure is not proof that cleanup
-                # succeeded. Keep waiting so an unverified release cannot
-                # become the next server's baseline.
-                time.sleep(1.0)
-                continue
+                return  # Can't query, assume ok
 
             used_gb = used / 1e9
             target_gb = target / 1e9
@@ -951,19 +671,14 @@ class RemoteVLLMServer:
 
         # Timeout -- raise so the current test fails with a clear
         # message instead of silently poisoning subsequent tests.
-        final_used = self._get_gpu_memory_used(device_ids)
-        self._record_failed_gpu_cleanup(
-            baseline, target, final_used, scope=cleanup_scope
-        )
-        final_text = (
-            "unavailable" if final_used is None else f"{final_used / 1e9:.2f} GB"
-        )
+        final_used = self._get_gpu_memory_used()
+        final_gb = final_used / 1e9 if final_used else 0.0
         raise RuntimeError(
             f"[RemoteOpenAIServer] GPU memory did not release within "
-            f"{timeout}s. Current: {final_text}, "
+            f"{timeout}s. Current: {final_gb:.2f} GB, "
             f"target: {target / 1e9:.2f} GB, "
             f"baseline: {baseline / 1e9:.2f} GB. "
-            f"A child process or another workload may be holding GPU memory."
+            f"Child processes may still be holding GPU memory."
         )
 
     def _poll(self) -> int | None:
@@ -1049,13 +764,12 @@ class RemoteOpenAIServer(RemoteVLLMServer):
     """Launches ``vllm serve`` for testing OpenAI-compatible endpoints."""
 
     def _get_process_termination_timeout(self) -> float:
-        process_timeout = get_engine_process_shutdown_timeout(
-            self._request_shutdown_timeout, self._request_shutdown_timeout
+        engine_timeout = get_engine_process_shutdown_timeout(
+            self._request_shutdown_timeout,
+            self._request_shutdown_timeout,
         )
-        assert process_timeout is not None
-        # Leave time for the API process to finish its own cleanup after its
-        # EngineCore manager has completed.
-        return max(super()._get_process_termination_timeout(), process_timeout + 15.0)
+        assert engine_timeout is not None
+        return engine_timeout + super()._get_process_termination_timeout()
 
     def _create_cli_subcommand(self):
         return ServeSubcommand()
@@ -1086,14 +800,6 @@ class RemoteOpenAIServer(RemoteVLLMServer):
 
 class RemoteLaunchRenderServer(RemoteVLLMServer):
     """Launches ``vllm launch render`` for GPU-less serving tests."""
-
-    def _requires_clean_gpu_memory(self) -> bool:
-        return False
-
-    def _get_gpu_device_ids(
-        self, env_dict: dict[str, str] | None
-    ) -> tuple[str, ...] | None:
-        return None
 
     def _create_cli_subcommand(self):
         return ServeSubcommand()
@@ -1130,13 +836,7 @@ class RemoteLaunchRenderServer(RemoteVLLMServer):
             )
 
     def _wait_for_gpu_memory_release(
-        self,
-        timeout: float = 30.0,
-        log_interval: float = 10.0,
-        *,
-        device_ids: tuple[str, ...] | None = None,
-        baseline: float | None = None,
-        cleanup_scope: tuple[str, tuple[str, ...]] | None = None,
+        self, timeout: float = 30.0, log_interval: float = 10.0
     ):
         pass  # No GPU used
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1130,7 +1130,13 @@ class RemoteLaunchRenderServer(RemoteVLLMServer):
             )
 
     def _wait_for_gpu_memory_release(
-        self, timeout: float = 30.0, log_interval: float = 10.0
+        self,
+        timeout: float = 30.0,
+        log_interval: float = 10.0,
+        *,
+        device_ids: tuple[str, ...] | None = None,
+        baseline: float | None = None,
+        cleanup_scope: tuple[str, tuple[str, ...]] | None = None,
     ):
         pass  # No GPU used
 

--- a/vllm/platforms/cpu.py
+++ b/vllm/platforms/cpu.py
@@ -181,13 +181,16 @@ class CpuPlatform(Platform):
                 "otherwise the performance is not optimized."
             )
 
-        # Accelerated GDN (AMX tiles or AVX-512BF16 VDPBF16PS) requires float32 SSM state.
+        # Accelerated GDN (AMX tiles or AVX-512BF16 VDPBF16PS) requires
+        # float32 SSM state.
         if (
             torch.cpu._is_avx512_bf16_supported()
             and cache_config.mamba_ssm_cache_dtype != "float32"
         ):
             cache_config.mamba_ssm_cache_dtype = "float32"
-            logger.warning("Reset SSM cache type to float32 for accelerated GDN mamba attention.")
+            logger.warning(
+                "Reset SSM cache type to float32 for accelerated GDN mamba attention."
+            )
 
         # Lagecy setting
         env_key = "VLLM_CPU_KVCACHE_SPACE"


### PR DESCRIPTION
- Preserve the parsed request shutdown timeout in `RemoteVLLMServer`.
- Keep the existing 15-second termination deadline for generic remote servers.
- For `RemoteOpenAIServer`, add that 15-second outer grace to the EngineCore process timeout returned by `get_engine_process_shutdown_timeout`.
- Use the derived deadline for both `subprocess.Popen.wait` and the custom multiprocessing server's `Process.join`.