### PR TITLE
[Bugfix][MRV2] Apply thinking budget to greedy requests

### DIFF
--- a/tests/v1/worker/test_gpu_thinking_budget.py
+++ b/tests/v1/worker/test_gpu_thinking_budget.py
@@ -12,6 +12,7 @@ if not torch.cuda.is_available():
     )
 
 from vllm.sampling_params import SamplingParams
+from vllm.v1.worker.gpu.sample.sampler import Sampler
 from vllm.v1.worker.gpu.sample.thinking_budget import ThinkingBudgetState
 from vllm.v1.worker.gpu.states import RequestState
 
@@ -183,6 +184,44 @@ def test_v2_thinking_budget_ignores_plain_request():
     out = _apply(state, logits, input_ids=[12], local_pos=[0])
 
     assert torch.all(out == 0)
+
+
+def test_v2_greedy_sampling_applies_thinking_budget():
+    """Greedy-only requests must not bypass thinking-budget processing."""
+    req_states = _make_req_states([1, START, 10, 11, 12], prompt_len=1)
+    sampler = Sampler(
+        max_num_reqs=4,
+        vocab_size=VOCAB_SIZE,
+        device=DEVICE,
+        req_states=req_states,
+        reasoning_config=MockReasoningConfig(),
+    )
+    sampler.add_request(
+        req_idx=3,
+        prompt_len=1,
+        sampling_params=SamplingParams(
+            temperature=0.0,
+            thinking_token_budget=3,
+        ),
+    )
+    sampler.apply_staged_writes()
+
+    idx_mapping = torch.tensor([3], dtype=torch.int32, device=DEVICE)
+    idx_mapping_np = idx_mapping.cpu().numpy()
+    expanded_idx_mapping = idx_mapping.clone()
+    input_ids = torch.tensor([12], dtype=torch.int32, device=DEVICE)
+    logits = torch.zeros((1, VOCAB_SIZE), device=DEVICE)
+    out = sampler.apply_sampling_params(
+        logits,
+        expanded_idx_mapping,
+        idx_mapping,
+        idx_mapping_np,
+        torch.tensor([4], dtype=torch.int32, device=DEVICE),
+        input_ids,
+        torch.tensor([0], dtype=torch.int32, device=DEVICE),
+    )
+
+    assert out[0, END].item() == pytest.approx(1.0e9)
 
 
 def test_v2_thinking_budget_latest_prefill_end_disables_forcing():

--- a/vllm/v1/worker/gpu/sample/sampler.py
+++ b/vllm/v1/worker/gpu/sample/sampler.py
@@ -235,6 +235,10 @@ class Sampler:
             return True
         if np.any(self.bad_words_state.num_bad_words.np[idx_mapping_np] > 0):
             return True
+        if self.thinking_budget_state.enabled and np.any(
+            self.thinking_budget_state.use_thinking_budget[idx_mapping_np]
+        ):
+            return True
 
         states = self.sampling_states
         temperatures = states.temperature.np[idx_mapping_np]


### PR DESCRIPTION
## Summary

- Ensure Model Runner V2 does not take the no-logits-processing fast path when a scheduled request has an active thinking token budget.
- Add focused GPU regression coverage for greedy sampling.

## Problem

The Model Runner V2 sampler returns logits unchanged when `_requires_logits_processing()` is false. The predicate covered penalties, bad words, and non-default sampling, but did not cover `ThinkingBudgetState`.

As a result, a greedy request with only `thinking_token_budget` enabled could bypass `apply_thinking_budget()` entirely. This made the budget ineffective even though the request state was configured correctly.

This change includes active thinking-budget rows in the predicate. Requests without a thinking budget keep the existing fast path.

## Why this is not a duplicate

The thinking-budget implementation was added in #46727, while the logits-processing fast path was introduced in #47711. This PR fixes the interaction between those changes.

Immediately before submission, open-PR searches for `thinking_token_budget greedy` and `_requires_logits_processing` returned no matches. Broader sampler searches only returned speculative-decoding and frontend changes that do not modify this predicate.

## Tests

- `uv run ruff check vllm/v1/worker/gpu/sample/sampler.py tests/v1/worker/test_gpu_thinking_budget.py`
  - Passed
- `uv run ruff format --check vllm/v1/worker/gpu/sample/sampler.py tests/v1/worker/test_gpu_thinking_budget.py`
  - Passed
- `uv run pre-commit run mypy-3.12 --hook-stage manual --files vllm/v1/worker/gpu/sample/sampler.py tests/v1/worker/test_gpu_thinking_budget.py`
  - Passed
- `python -m pytest tests/v1/worker/test_gpu_thinking_budget.py -v` in the CUDA validation container
  - Baseline plus the new regression test: failed as expected because the end-reasoning logit remained `0.0` instead of `1.0e9`
  - Patched source: `13 passed`

## Model validation

Validated on a task-owned GPU with ModelScope Qwen3.5-9B:

- Greedy request without thinking returned the exact expected response.
- Greedy request with `thinking_token_budget=5` stopped reasoning and produced the final answer successfully.
- Existing service workloads on the other GPU were not modified.

The GPU source-overlay baseline was `ac7509e2`. The submitted base is `8e6d8e4f`; the intervening upstream change only touches XPU/release files and does not overlap this sampler or test. Static checks were rerun on the submitted base.

## AI assistance

AI assistance was used. The human submitter reviewed every changed line and the validation evidence and can defend the change end-to-end.