### PR TITLE
[Bugfix][Spec Decode] DSpark: inherit the target's attention backend when the speculative config names none

### DIFF
--- a/vllm/v1/worker/gpu/spec_decode/dspark/utils.py
+++ b/vllm/v1/worker/gpu/spec_decode/dspark/utils.py
@@ -21,12 +21,18 @@ def load_dspark_model(target_model: nn.Module, vllm_config: VllmConfig) -> nn.Mo
     from vllm.model_executor.models.qwen3_dflash import dflash_has_any_non_causal
     from vllm.model_executor.models.utils import get_draft_quant_config
 
+    # None re-runs backend auto-selection for the draft, which can pick a
+    # different attention class than the target; fall back to the target's.
+    draft_attention_backend = (
+        speculative_config.attention_backend or vllm_config.attention_config.backend
+    )
+
     draft_vllm_config = replace(
         vllm_config,
         attention_config=replace(
             vllm_config.attention_config,
             use_non_causal=dflash_has_any_non_causal(draft_model_config.hf_config),
-            backend=speculative_config.attention_backend,
+            backend=draft_attention_backend,
         ),
         cache_config=(
             replace(


### PR DESCRIPTION
## Purpose

`load_dspark_model` passes `backend=speculative_config.attention_backend` when
building the draft's config. That field is `None` unless the user names a backend
inside `--speculative-config`, and `None` re-runs backend auto-selection rather
than meaning "same as target" — so an explicitly pinned target backend is silently
discarded and the draft can pick a different attention class.

On DeepSeek V4 with `--attention-config.backend FLASHINFER_MLA_SPARSE_DSV4`, the
target builds `DeepseekV4FlashInferMLAAttention` (plain 512B KV row) while the
draft falls back to `DeepseekV4FlashMLAAttention`, whose `__init__` rewrites the
shared `cache_config.cache_dtype` to `fp8_ds_mla`. The SWA cache is then allocated
at 584B/token but still reshaped at `head_dim`, on every rank at first forward:

```
RuntimeError: shape '[-1, 64, 512]' is invalid for input of size 4176917504
  vllm/models/deepseek_v4/attention.py, in _fused_qnorm_rope_kv_insert
```

`4176917504 = 111754 * 64 * 584`, the `fp8_ds_mla` geometry. Fall back to the
target's backend when the speculative config names none; an explicit
`attention_backend` still wins.

## Why this is not a duplicate

- **#40611** (open) lets the draft *deliberately differ* from the target. This
  fixes the *fallback* when nothing is specified; the explicit override still wins.
- **#51538** / **#51042** fix a different DSV4 + DSpark defect (`decode_swa_indices`
  width). Independent of this one and deliberately not included.

Each masks the other, verified on one config (DSV4-Pro-0813, TP8 × 2 GB300,
`FLASHINFER_MLA_SPARSE_DSV4`, DSpark k=7):

| fixes | result |
| --- | --- |
| neither | `shape '[-1, 64, 512]'` invalid (this bug) |
| this PR | passes, then fails in #51538's path: `shape '[7, 128]'` invalid |
| #51538 | `shape '[-1, 64, 512]'` invalid again (this bug) |
| both | engine initializes and serves |

## Test plan

`pytest tests/v1/spec_decode/test_dspark_topk.py` → **2 passed**.
`pre-commit run --files vllm/v1/worker/gpu/spec_decode/dspark/utils.py` → all pass
(incl. mypy, ruff).

## Model evaluation

aime25, 4 epochs (n=120), temperature 1.0 / top_p 0.95, thinking on,
`max_tokens=150000`, DSV4-Pro-0813 on TP8 × 2 GB300, same tree throughout.
DSpark rows need #51538 applied too, since both are required to start:

| configuration | exact_match | pass@4 | errors |
| --- | --- | --- | --- |
| `FLASHINFER_MLA_SPARSE_DSV4`, no spec | 1.0000 | 1.0 | 0 |
| `FLASHINFER_MLA_SPARSE_DSV4` + DSpark | 0.9917 | 1.0 | 0 |
| `FLASHMLA_SPARSE_DSV4` + DSpark (n=360) | 0.9778 | 1.0 | 0 |
| `FLASHMLA_SPARSE_DSV4`, no spec (n=360) | 0.9944 | 1.0 | 0 |

Mean acceptance length 3.16 at full concurrency. The DSpark row's single miss is a
`length` truncation on the one AIME problem that runs long in every configuration
tested, with no repetition loop. No unfixed baseline: the configuration cannot
start without this fix.

## AI assistance

This work was produced with AI assistance. The submitter has reviewed every changed
line, and the tests and evaluations above were executed on the hardware described.
