### PR TITLE
[Bugfix] Add opt-out for synchronized FlashInfer autotune (multi-node deadlock without GPUDirect RDMA)

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -210,6 +210,7 @@ if TYPE_CHECKING:
     VLLM_USE_FLASHINFER_MOE_INT4: bool = False
     VLLM_FLASHINFER_AUTOTUNE_CACHE_DIR: str | None = None
     VLLM_FLASHINFER_AUTOTUNE_SKIP_OPS: list[str] | None = None
+    VLLM_FLASHINFER_AUTOTUNE_DISTRIBUTED_SYNC: bool = True
     VLLM_FLASHINFER_ALLREDUCE_BACKEND: Literal["auto", "trtllm", "mnnvl"] = "auto"
     VLLM_FLASHINFER_WORKSPACE_BUFFER_SIZE: int = 394 * 1024 * 1024
     VLLM_XGRAMMAR_CACHE_MB: int = 0
@@ -1704,6 +1705,16 @@ environment_variables: dict[str, Callable[[], Any]] = {
             for v in os.environ["VLLM_FLASHINFER_AUTOTUNE_SKIP_OPS"].split(",")
             if v.strip()
         ]
+    ),
+    # Synchronize FlashInfer autotuning across ranks: per-tactic timings are
+    # averaged over the world CPU group so every rank selects the same tactic,
+    # and the tuned config cache is persisted and broadcast from rank 0. Set to
+    # 0 to instead tune independently on every rank with no cross-rank
+    # collectives during tuning (restores the pre-synchronization behavior;
+    # workaround for multi-node deployments where the synchronized flow
+    # deadlocks, e.g. GB10/DGX Spark clusters without GPUDirect RDMA).
+    "VLLM_FLASHINFER_AUTOTUNE_DISTRIBUTED_SYNC": lambda: bool(
+        int(os.getenv("VLLM_FLASHINFER_AUTOTUNE_DISTRIBUTED_SYNC", "1"))
     ),
     # Flashinfer fused allreduce backend.
     "VLLM_FLASHINFER_ALLREDUCE_BACKEND": env_with_choices(

--- a/vllm/model_executor/warmup/kernel_warmup.py
+++ b/vllm/model_executor/warmup/kernel_warmup.py
@@ -232,6 +232,13 @@ def flashinfer_autotune(runner: "GPUModelRunner") -> None:
     Every rank profiles the same tactics. When distributed, per-tactic
     timings are averaged over the world CPU group so all ranks select the
     same tactic.
+
+    Setting ``VLLM_FLASHINFER_AUTOTUNE_DISTRIBUTED_SYNC=0`` disables the
+    cross-rank synchronization and the persistent-cache broadcast: every rank
+    tunes independently with no CPU-group collectives during tuning. This is
+    a workaround for multi-node deployments where the synchronized flow
+    deadlocks (ranks can desynchronize between tuning rounds and block
+    forever in the timing all-reduce).
     """
     from flashinfer.autotuner import AutoTuner, set_autotune_process_group
 
@@ -269,6 +276,18 @@ def flashinfer_autotune(runner: "GPUModelRunner") -> None:
         is_profile=True,
         randomize_inputs=True,
     )
+
+    if world.world_size > 1 and not envs.VLLM_FLASHINFER_AUTOTUNE_DISTRIBUTED_SYNC:
+        # Tune independently on every rank. No autotune process group is set,
+        # so no cross-rank collectives run during tuning, and the persistent
+        # cache stays disabled because ranks may select different tactics.
+        with (
+            torch.inference_mode(),
+            fi_utils.autotune(tune_mode=True, **autotune_kwargs),
+        ):
+            runner._dummy_run(**dummy_run_kwargs)
+        world.barrier()
+        return
 
     # Read cached autotune results and broadcast to all ranks.
     cached_results: bytes | None = None


### PR DESCRIPTION
## Purpose

Fixes #52291.

Since the FlashInfer 0.6.16.post3 bump (#50892) wired `set_autotune_process_group` into
`kernel_warmup.flashinfer_autotune` (design from #48714), multi-node startup deadlocks
deterministically during autotuning on clusters whose inter-node transport is host-staged
NCCL without GPUDirect RDMA (reproduced on 6× GB10 / DGX Spark class, TP=2 × PP=3): ranks
desynchronize between tuning rounds, after which the cross-rank per-tactic timing collective
blocks forever — one TP rank enters the next tuning round, its peer never does, both sit in
futex wait at 0% GPU and startup never completes (full matrix in the issue: reproduced across
FlashInfer 0.6.16.post3 / 0.6.17 / 0.6.18, pip and system NCCL, warm and cold JIT caches;
the last pre-#50892 build tunes the identical workload cleanly every time).

This PR adds `VLLM_FLASHINFER_AUTOTUNE_DISTRIBUTED_SYNC` (default `1`, current behavior
unchanged). Setting it to `0` restores the previous per-rank flow for distributed runs: every
rank tunes independently, no autotune process group is set (so no cross-rank collectives run
during tuning), and the persistent-cache broadcast is skipped because ranks may select
different tactics.

## Test Plan

- Deployed on the affected cluster (6× GB10, `MiniMaxAI/MiniMax-M3-MXFP8`, TP=2 × PP=3,
  vLLM `0.27.2rc1.dev54+gb96bcd0b4`, FlashInfer 0.6.18) with the opt-out active.
- Compared against the same deployment with default settings, and with
  `VLLM_FLASHINFER_AUTOTUNE_SKIP_OPS=mxfp8_gemm`.

## Test Result

- Default (synchronized): startup deadlocks in autotune every time (6/6 attempts across
  image/library permutations).
- `VLLM_FLASHINFER_AUTOTUNE_DISTRIBUTED_SYNC=0`: autotune completes on all ranks, startup
  succeeds, serving verified end-to-end; single-stream throughput 14.4–14.5 tok/s (vs
  9.0 tok/s with the op skipped un-tuned) — matching the pre-#50892 baseline.
- Single-node and default-path behavior unchanged (the new branch is only taken when
  `world_size > 1` and the env is explicitly disabled).

