### PR TITLE
[Bugfix][KV Offload] Coordinate mmap host registration

### DIFF
--- a/tests/v1/kv_offload/cpu/test_gpu_worker.py
+++ b/tests/v1/kv_offload/cpu/test_gpu_worker.py
@@ -4,7 +4,10 @@ import logging
 import random
 import time
 import uuid
-from unittest.mock import MagicMock
+from datetime import timedelta
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock, patch
 
 import pytest
 import torch
@@ -47,6 +50,270 @@ def test_rocm_cpu_to_gpu_uses_dma(monkeypatch: pytest.MonkeyPatch) -> None:
     assert gpu_worker._select_swap_blocks_fn(refs, gpu_to_cpu=False) is (
         ops.swap_blocks_batch
     )
+
+
+def test_unpinned_cpu_to_gpu_uses_dma(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(gpu_worker, "HAS_TRITON", True)
+    monkeypatch.setattr(gpu_worker.current_platform, "is_xpu", lambda: False)
+    monkeypatch.setattr(gpu_worker.current_platform, "is_rocm", lambda: False)
+
+    refs = [[CanonicalKVCacheRef(tensor_idx=0, page_size_bytes=512)]]
+    assert gpu_worker._select_swap_blocks_fn(
+        refs, gpu_to_cpu=False, host_memory_is_pinned=False
+    ) is ops.swap_blocks_batch
+
+
+def _pin_mmap_coordination(group: Any) -> gpu_worker._ModelParallelCoordination:
+    singleton = SimpleNamespace(
+        rank_in_group=0,
+        world_size=1,
+        cpu_group=None,
+        barrier=lambda: None,
+    )
+    return gpu_worker._ModelParallelCoordination((group, singleton, singleton))
+
+
+def _pin_mmap_region_worker(
+    rank: int, init_method: str, result_queue: Any, failure_mode: str
+) -> None:
+    torch.distributed.init_process_group(
+        backend="gloo",
+        init_method=init_method,
+        rank=rank,
+        world_size=2,
+        timeout=timedelta(seconds=30),
+    )
+    try:
+        group = SimpleNamespace(
+            rank_in_group=rank,
+            world_size=2,
+            cpu_group=torch.distributed.group.WORLD,
+            barrier=lambda: torch.distributed.barrier(),
+        )
+        region = MagicMock()
+        # Replicated layouts use mmap rank zero in every process, so the
+        # registration turn must be selected with rank_in_group instead.
+        region.rank = 0
+        region._base.data_ptr.return_value = 4096 + rank
+        region.total_size_bytes = 8192
+        region.is_pinned = False
+
+        cudart = MagicMock()
+        cudart.cudaHostRegister.return_value = SimpleNamespace(
+            value=int(failure_mode == "return" and rank == 1)
+        )
+        cudart.cudaHostUnregister.return_value = SimpleNamespace(value=0)
+        if failure_mode == "setup" and rank == 1:
+            region._base.data_ptr.side_effect = RuntimeError("setup failed")
+        if failure_mode == "register" and rank == 1:
+            cudart.cudaHostRegister.side_effect = RuntimeError("register failed")
+
+        with (
+            patch.object(
+                gpu_worker.current_platform, "is_cuda_alike", return_value=True
+            ),
+            patch.object(torch.cuda, "cudart", return_value=cudart),
+        ):
+            raised = False
+            try:
+                gpu_worker.pin_mmap_region(region, _pin_mmap_coordination(group))
+            except RuntimeError:
+                raised = True
+
+        result_queue.put(
+            (
+                rank,
+                region.is_pinned,
+                cudart.cudaHostRegister.call_count,
+                cudart.cudaHostUnregister.call_count,
+                raised,
+            )
+        )
+    finally:
+        torch.distributed.destroy_process_group()
+
+
+@pytest.mark.parametrize(
+    ("failure_mode", "expected"),
+    [
+        (
+            "success",
+            [
+                (0, True, 1, 0, False),
+                (1, True, 1, 0, False),
+            ],
+        ),
+        (
+            "return",
+            [
+                (0, False, 1, 1, False),
+                (1, False, 1, 0, False),
+            ],
+        ),
+        (
+            "setup",
+            [
+                (0, False, 1, 1, True),
+                (1, False, 0, 0, True),
+            ],
+        ),
+        (
+            "register",
+            [
+                (0, False, 1, 1, True),
+                (1, False, 1, 0, True),
+            ],
+        ),
+    ],
+)
+def test_pin_mmap_region_coordinates_failures(
+    tmp_path,
+    failure_mode: str,
+    expected: list[tuple[int, bool, int, int, bool]],
+) -> None:
+    context = torch.multiprocessing.get_context("spawn")
+    result_queue = context.SimpleQueue()
+
+    torch.multiprocessing.spawn(
+        _pin_mmap_region_worker,
+        args=(
+            f"file://{tmp_path / f'pin-mmap-{failure_mode}'}",
+            result_queue,
+            failure_mode,
+        ),
+        nprocs=2,
+        join=True,
+    )
+
+    results = sorted(result_queue.get() for _ in range(2))
+    assert results == expected
+
+
+def test_model_parallel_coordination_excludes_dp(monkeypatch) -> None:
+    events: list[str] = []
+
+    def group(name: str, rank: int, size: int) -> SimpleNamespace:
+        return SimpleNamespace(
+            rank_in_group=rank,
+            world_size=size,
+            cpu_group=name,
+            barrier=lambda: events.append(name),
+        )
+
+    tp = group("tp", 1, 2)
+    pcp = group("pcp", 1, 2)
+    pp = group("pp", 1, 2)
+    monkeypatch.setattr(gpu_worker, "get_tp_group", lambda: tp)
+    monkeypatch.setattr(gpu_worker, "get_pcp_group", lambda: pcp)
+    monkeypatch.setattr(gpu_worker, "get_pp_group", lambda: pp)
+
+    coordination = gpu_worker._model_parallel_coordination()
+    coordination.barrier()
+
+    assert coordination.groups == (tp, pcp, pp)
+    assert coordination.rank == 7
+    assert coordination.world_size == 8
+    assert events == ["tp", "pcp", "pp"]
+
+
+def test_pin_mmap_region_uses_group_rank_for_registration_turn(monkeypatch) -> None:
+    events: list[str] = []
+    group = SimpleNamespace(
+        rank_in_group=1,
+        world_size=2,
+        cpu_group=MagicMock(),
+        barrier=lambda: events.append("barrier"),
+    )
+    region = MagicMock()
+    region.rank = 0
+    region._base.data_ptr.return_value = 4096
+    region.total_size_bytes = 8192
+    region.is_pinned = False
+    cudart = MagicMock()
+
+    def register(*_args: Any) -> SimpleNamespace:
+        events.append("register")
+        return SimpleNamespace(value=0)
+
+    cudart.cudaHostRegister.side_effect = register
+    monkeypatch.setattr(gpu_worker.current_platform, "is_cuda_alike", lambda: True)
+    monkeypatch.setattr(torch.cuda, "cudart", lambda: cudart)
+    monkeypatch.setattr(gpu_worker, "_group_max", lambda *_args: 0)
+
+    gpu_worker.pin_mmap_region(region, _pin_mmap_coordination(group))
+
+    assert events == ["barrier", "barrier", "register", "barrier"]
+    assert region.is_pinned
+    cudart.cudaHostUnregister.assert_not_called()
+
+
+def test_pin_mmap_region_fails_after_rollback_error(monkeypatch) -> None:
+    group = SimpleNamespace(
+        rank_in_group=0,
+        world_size=2,
+        cpu_group=MagicMock(),
+        barrier=MagicMock(),
+    )
+    region = MagicMock()
+    region.rank = 0
+    region._base.data_ptr.return_value = 4096
+    region.total_size_bytes = 8192
+    region.is_pinned = False
+    cudart = MagicMock()
+    cudart.cudaHostRegister.return_value = SimpleNamespace(value=0)
+    cudart.cudaHostUnregister.return_value = SimpleNamespace(value=1)
+
+    monkeypatch.setattr(gpu_worker.current_platform, "is_cuda_alike", lambda: True)
+    monkeypatch.setattr(torch.cuda, "cudart", lambda: cudart)
+    monkeypatch.setattr(gpu_worker, "_group_max", MagicMock(side_effect=[1, 1]))
+
+    with pytest.raises(RuntimeError, match="could not roll back"):
+        gpu_worker.pin_mmap_region(region, _pin_mmap_coordination(group))
+
+    # Leave ownership marked so constructor cleanup can retry the failed
+    # unregister before releasing the mmap.
+    assert region.is_pinned
+    cudart.cudaHostUnregister.assert_called_once_with(4096)
+
+
+def test_worker_uses_model_parallel_coordination(monkeypatch) -> None:
+    coordination = MagicMock()
+    region = MagicMock()
+    region.is_pinned = False
+    region.create_next_worker_view.return_value = torch.zeros((1, 8), dtype=torch.int8)
+    pin_region = MagicMock()
+    handler = MagicMock()
+
+    monkeypatch.setattr(gpu_worker, "PIN_MEMORY", True)
+    monkeypatch.setattr(
+        gpu_worker, "model_parallel_is_initialized", lambda: True
+    )
+    monkeypatch.setattr(
+        gpu_worker, "_model_parallel_coordination", lambda: coordination
+    )
+    monkeypatch.setattr(gpu_worker, "pin_mmap_region", pin_region)
+    monkeypatch.setattr(gpu_worker, "SingleDirectionOffloadingHandler", handler)
+
+    CPUOffloadingWorker(
+        kv_caches=CanonicalKVCaches(
+            tensors=[
+                CanonicalKVCacheTensor(
+                    tensor=torch.zeros((1, 8), dtype=torch.int8),
+                    page_size_bytes=8,
+                )
+            ],
+            group_data_refs=[
+                [CanonicalKVCacheRef(tensor_idx=0, page_size_bytes=8)]
+            ],
+        ),
+        blocks_per_chunk=1,
+        num_cpu_blocks=1,
+        mmap_region=region,
+    )
+
+    pin_region.assert_called_once_with(region, coordination)
+    assert handler.call_count == 2
+    assert not handler.call_args_list[1].kwargs["host_memory_is_pinned"]
 
 
 def test_worker_shutdown_releases_region_and_runs_both_handlers() -> None:

--- a/vllm/v1/kv_offload/cpu/gpu_worker.py
+++ b/vllm/v1/kv_offload/cpu/gpu_worker.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import functools
+import math
 import time
 from collections import deque
 from collections.abc import Sequence
@@ -11,6 +12,13 @@ import numpy as np
 import torch
 
 from vllm import _custom_ops as ops
+from vllm.distributed.parallel_state import (
+    GroupCoordinator,
+    get_pcp_group,
+    get_pp_group,
+    get_tp_group,
+    model_parallel_is_initialized,
+)
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
 from vllm.triton_utils import HAS_TRITON, triton
@@ -38,10 +46,11 @@ logger = init_logger(__name__)
 def _select_swap_blocks_fn(
     layer_refs_per_group: list[list[CanonicalKVCacheRef]],
     gpu_to_cpu: bool,
+    host_memory_is_pinned: bool = True,
 ):
     """Resolve the swap_blocks function for a handler at init time."""
     # GPU->CPU is bandwidth-bound; the dedicated copy engine beats Triton.
-    if gpu_to_cpu:
+    if gpu_to_cpu or not host_memory_is_pinned:
         return ops.swap_blocks_batch
     # Fall back to the C++ DMA path on platforms where Triton isn't usable
     # (e.g. ROCm host mappings) or where GPU kernels cannot directly
@@ -190,8 +199,52 @@ def _canonical_block_sizes(
     return canonical_bytes_per_block
 
 
-def pin_mmap_region(region: SharedOffloadRegion) -> None:
-    """Register the entire mmap as CUDA pinned memory via cudaHostRegister."""
+@dataclass(frozen=True)
+class _ModelParallelCoordination:
+    groups: tuple[GroupCoordinator, GroupCoordinator, GroupCoordinator]
+
+    @property
+    def rank(self) -> int:
+        tp, pcp, pp = self.groups
+        return (
+            (pp.rank_in_group * pcp.world_size + pcp.rank_in_group) * tp.world_size
+            + tp.rank_in_group
+        )
+
+    @property
+    def world_size(self) -> int:
+        return math.prod(group.world_size for group in self.groups)
+
+    def barrier(self) -> None:
+        for group in self.groups:
+            if group.world_size > 1:
+                group.barrier()
+
+
+def _model_parallel_coordination() -> _ModelParallelCoordination:
+    # The mmap is shared by all TP x PCP x PP workers of one engine. These
+    # axis groups keep a DP coordinate fixed, unlike the global world group.
+    return _ModelParallelCoordination((get_tp_group(), get_pcp_group(), get_pp_group()))
+
+
+def _group_max(status: int, groups: Sequence[GroupCoordinator]) -> int:
+    status_tensor = torch.tensor([status], dtype=torch.int32, device="cpu")
+    for group in groups:
+        if group.world_size == 1:
+            continue
+        torch.distributed.all_reduce(
+            status_tensor,
+            op=torch.distributed.ReduceOp.MAX,
+            group=group.cpu_group,
+        )
+    return int(status_tensor.item())
+
+
+def pin_mmap_region(
+    region: SharedOffloadRegion,
+    coordination: _ModelParallelCoordination | None = None,
+) -> None:
+    """Register an mmap consistently across all workers sharing it."""
     if not current_platform.is_cuda_alike():
         logger.info(
             "Skipping mmap host registration on %s; cudaHostRegister is only "
@@ -200,24 +253,127 @@ def pin_mmap_region(region: SharedOffloadRegion) -> None:
         )
         return
 
-    rank = region.rank
-
-    base_ptr = region._base.data_ptr()
-    result = torch.cuda.cudart().cudaHostRegister(base_ptr, region.total_size_bytes, 0)
-    if result.value != 0:
-        logger.warning(
-            "cudaHostRegister failed for rank=%d (code=%d) — "
-            "transfers will still work but may be slower (unpinned DMA)",
-            rank,
-            result,
-        )
-    else:
+    if coordination is None:
+        base_ptr = region._base.data_ptr()
+        cudart = torch.cuda.cudart()
+        result = cudart.cudaHostRegister(base_ptr, region.total_size_bytes, 0)
+        if result.value != 0:
+            logger.warning(
+                "cudaHostRegister failed for rank=%d (code=%d) — "
+                "transfers will still work but may be slower (unpinned DMA)",
+                region.rank,
+                result.value,
+            )
+            return
+        region.is_pinned = True
         logger.debug(
             "cudaHostRegister rank=%d %.2f GB",
-            rank,
+            region.rank,
             region.total_size_bytes / 1e9,
         )
-        region.is_pinned = True
+        return
+
+    rank = coordination.rank
+    local_registration_status = 0
+    local_registration_error: Exception | None = None
+    base_ptr: int | None = None
+    cudart = None
+
+    try:
+        base_ptr = region._base.data_ptr()
+        cudart = torch.cuda.cudart()
+    except Exception as error:
+        local_registration_status = 2
+        local_registration_error = error
+        logger.exception("Failed to prepare mmap host registration for rank=%d", rank)
+
+    # Every rank must finish mapping and pre-faulting the shared region before
+    # registration begins. Register one process VA at a time so the driver
+    # never sees concurrent registrations of the same shared backing pages.
+    coordination.barrier()
+    for turn in range(coordination.world_size):
+        if rank == turn and local_registration_status == 0:
+            assert base_ptr is not None and cudart is not None
+            try:
+                result = cudart.cudaHostRegister(
+                    base_ptr, region.total_size_bytes, 0
+                )
+                if result.value == 0:
+                    region.is_pinned = True
+                else:
+                    local_registration_status = 1
+                    logger.warning(
+                        "cudaHostRegister failed for group rank=%d, mmap rank=%d "
+                        "(code=%d)",
+                        rank,
+                        region.rank,
+                        result.value,
+                    )
+            except Exception as error:
+                local_registration_status = 2
+                local_registration_error = error
+                logger.exception(
+                    "cudaHostRegister raised for group rank=%d, mmap rank=%d",
+                    rank,
+                    region.rank,
+                )
+        coordination.barrier()
+
+    group_registration_status = _group_max(
+        local_registration_status, coordination.groups
+    )
+    if group_registration_status == 0:
+        logger.debug(
+            "cudaHostRegister group rank=%d, mmap rank=%d %.2f GB",
+            rank,
+            region.rank,
+            region.total_size_bytes / 1e9,
+        )
+        return
+
+    local_rollback_status = 0
+    for turn in range(coordination.world_size):
+        if rank == turn and region.is_pinned:
+            assert base_ptr is not None and cudart is not None
+            try:
+                result = cudart.cudaHostUnregister(base_ptr)
+                if result.value != 0:
+                    local_rollback_status = 1
+                    logger.error(
+                        "cudaHostUnregister rollback failed for group rank=%d, "
+                        "mmap rank=%d (code=%d)",
+                        rank,
+                        region.rank,
+                        result.value,
+                    )
+                else:
+                    region.is_pinned = False
+            except Exception:
+                local_rollback_status = 1
+                logger.exception(
+                    "cudaHostUnregister rollback raised for group rank=%d, "
+                    "mmap rank=%d",
+                    rank,
+                    region.rank,
+                )
+        coordination.barrier()
+
+    group_rollback_status = _group_max(local_rollback_status, coordination.groups)
+    if group_registration_status == 1 and group_rollback_status == 0:
+        if rank == 0:
+            logger.warning(
+                "cudaHostRegister failed on at least one worker; all workers "
+                "will use unpinned DMA"
+            )
+        return
+
+    error = RuntimeError(
+        "Coordinated cudaHostRegister failed because a CUDA call raised or "
+        "the group could not roll back every successful registration"
+    )
+    if local_registration_error is not None:
+        raise error from local_registration_error
+    raise error
 
 
 def _new_descriptor_buffers(
@@ -249,6 +405,7 @@ class SingleDirectionOffloadingHandler:
         layer_refs_per_group: list[list[CanonicalKVCacheRef]],
         gpu_to_cpu: bool,
         canonical_layout: bool = False,
+        host_memory_is_pinned: bool = True,
     ):
         """
         Initialize a SingleDirectionOffloadingHandler.
@@ -263,6 +420,8 @@ class SingleDirectionOffloadingHandler:
             gpu_to_cpu: if True, transfer from GPU to CPU; otherwise CPU to GPU.
             canonical_layout: if True, CPU pages use the canonical layout
                 described by the refs' mappings.
+            host_memory_is_pinned: whether GPU kernels may dereference the
+                host tensors directly.
         """
         assert len(gpu_tensors) == len(cpu_tensors)
         assert len(gpu_tensors) > 0
@@ -299,7 +458,9 @@ class SingleDirectionOffloadingHandler:
         self.gpu_to_cpu: bool = gpu_to_cpu
         self.layer_refs_per_group = layer_refs_per_group
         self._swap_blocks_batch = _select_swap_blocks_fn(
-            layer_refs_per_group, gpu_to_cpu
+            layer_refs_per_group,
+            gpu_to_cpu,
+            host_memory_is_pinned=host_memory_is_pinned,
         )
 
         # GPU blocks may be smaller
@@ -761,7 +922,16 @@ class CPUOffloadingWorker(OffloadingWorker):
         pin_memory = PIN_MEMORY
         logger.info("Allocating %d CPU tensors...", len(kv_caches.tensors))
         if mmap_region is not None and pin_memory:
-            pin_mmap_region(mmap_region)
+            coordination = (
+                _model_parallel_coordination()
+                if model_parallel_is_initialized()
+                else None
+            )
+            pin_mmap_region(mmap_region, coordination)
+
+        host_memory_is_pinned = pin_memory and (
+            mmap_region is None or mmap_region.is_pinned
+        )
 
         canonical_bytes_per_block = (
             _canonical_block_sizes(kv_caches.group_data_refs, len(kv_caches.tensors))
@@ -811,6 +981,7 @@ class CPUOffloadingWorker(OffloadingWorker):
             layer_refs_per_group=kv_caches.group_data_refs,
             gpu_to_cpu=True,
             canonical_layout=canonical_layout,
+            host_memory_is_pinned=host_memory_is_pinned,
         )
 
         self._load_handler = SingleDirectionOffloadingHandler(
@@ -820,6 +991,7 @@ class CPUOffloadingWorker(OffloadingWorker):
             layer_refs_per_group=kv_caches.group_data_refs,
             gpu_to_cpu=False,
             canonical_layout=canonical_layout,
+            host_memory_is_pinned=host_memory_is_pinned,
         )
 
     def submit_store(


### PR DESCRIPTION
## Purpose

Fixes #51762.

Coordinate host registration across all TP x PCP x PP workers that map the
same CPU KV-offload region. Workers now wait for a mapping fence, register in
deterministic model-rank order, and make one group-wide decision from the
registration results.

If a normal registration call fails, every successful worker unregisters and
the whole group keeps the existing unpinned fallback. Setup or registration
exceptions and incomplete rollbacks fail startup only after all workers have
finished the transaction. The unpinned fallback also forces the DMA copy path
so a GPU kernel never dereferences pageable host memory.

## Related Work

This does not duplicate the existing host-registration PRs:

- #50070 keeps registration and pending-error cleanup on the same CUDA runtime
  handle, but does not coordinate workers or make their pinning state coherent.
- #51081 splits very large registrations into chunks to avoid the 512 GiB
  registration ceiling, but does not coordinate concurrent worker outcomes.
- #51956 adds XPU host registration and platform dispatch, but does not address
  mixed pinned and unpinned CUDA/ROCm workers sharing one mmap region.

This PR is scoped to serializing registration across the TP x PCP x PP workers
that share an engine mmap, making one group-wide decision, rolling back partial
success, and selecting a safe DMA path after an unpinned fallback.

## Test Plan

- Exercise two local Gloo processes for all-success, return-code failure,
  registration setup exception, and registration exception outcomes.
- Verify ordinary fallback unregisters successful workers exactly once and
  rollback failures retain registration ownership for cleanup.
- Verify model-rank ordering spans TP x PCP x PP without crossing DP engines.
- Verify unpinned CPU-to-GPU transfers select the DMA implementation.

## Test Result

- Diff whitespace validation passed.
- Python AST parsing passed for both changed files.
- An isolated semantic smoke test passed for model-rank ordering, collective
  ordering, coherent rollback, setup failure, and rollback failure.
- The focused pytest suite could not start because the prepared checkout did
  not contain pytest, and dependency installation was unavailable. The added
  tests should be run in CI with:

  ```bash
  .venv/bin/python -m pytest tests/v1/kv_offload/cpu/test_gpu_worker.py \
    -k "pin_mmap_region or model_parallel_coordination or unpinned_cpu_to_gpu or worker_uses_model_parallel_coordination" \
    -q
  ```
