### PR TITLE
[Attention] Move GDN common metadata compute out of per-group build

### DIFF
--- a/tests/v1/attention/test_gdn_metadata_builder.py
+++ b/tests/v1/attention/test_gdn_metadata_builder.py
@@ -22,6 +22,7 @@ from vllm.v1.attention.backends.gdn_attn import (
     GDNAttentionMetadataBuilder,
 )
 from vllm.v1.kv_cache_interface import MambaSpec
+from vllm.v1.worker.gpu.attn_utils import compute_spec_metadata
 
 BLOCK_SIZE = 16
 DEVICE = torch.device("cpu")
@@ -160,12 +161,49 @@ def _build(
     common = create_common_attn_metadata(batch_spec, BLOCK_SIZE, DEVICE)
     kwargs: dict = {}
     if num_decode_draft_tokens is not None:
-        kwargs["num_decode_draft_tokens_cpu"] = torch.tensor(
+        num_decode_draft_tokens_cpu = torch.tensor(
             num_decode_draft_tokens, dtype=torch.int32
         )
-        kwargs["num_accepted_tokens"] = torch.ones(
+        num_accepted_tokens = torch.ones(
             batch_spec.batch_size, dtype=torch.int32, device=DEVICE
         )
+        (
+            spec_sequence_masks_cpu,
+            spec_sequence_masks,
+            num_spec_decodes,
+            num_decodes,
+            num_prefills,
+            num_decode_tokens,
+            num_prefill_tokens,
+            num_spec_decode_tokens,
+            spec_token_indx,
+            non_spec_token_indx,
+            spec_query_start_loc,
+            non_spec_query_start_loc,
+            non_spec_query_start_loc_cpu,
+            num_accepted_tokens,
+        ) = compute_spec_metadata(
+            num_decode_draft_tokens_cpu,
+            num_accepted_tokens,
+            common.query_start_loc,
+            common.query_start_loc_cpu,
+            builder.num_spec,
+        )
+        kwargs["num_decode_draft_tokens_cpu"] = num_decode_draft_tokens_cpu
+        kwargs["num_accepted_tokens"] = num_accepted_tokens
+        kwargs["spec_sequence_masks_cpu"] = spec_sequence_masks_cpu
+        kwargs["spec_sequence_masks"] = spec_sequence_masks
+        kwargs["num_spec_decodes"] = num_spec_decodes
+        kwargs["num_decodes"] = num_decodes
+        kwargs["num_prefills"] = num_prefills
+        kwargs["num_decode_tokens"] = num_decode_tokens
+        kwargs["num_prefill_tokens"] = num_prefill_tokens
+        kwargs["num_spec_decode_tokens"] = num_spec_decode_tokens
+        kwargs["spec_token_indx"] = spec_token_indx
+        kwargs["non_spec_token_indx"] = non_spec_token_indx
+        kwargs["spec_query_start_loc"] = spec_query_start_loc
+        kwargs["non_spec_query_start_loc"] = non_spec_query_start_loc
+        kwargs["non_spec_query_start_loc_cpu"] = non_spec_query_start_loc_cpu
     return builder.build(common_prefix_len=0, common_attn_metadata=common, **kwargs)
 
 

--- a/tests/v1/attention/test_gdn_metadata_builder.py
+++ b/tests/v1/attention/test_gdn_metadata_builder.py
@@ -22,7 +22,7 @@ from vllm.v1.attention.backends.gdn_attn import (
     GDNAttentionMetadataBuilder,
 )
 from vllm.v1.kv_cache_interface import MambaSpec
-from vllm.v1.worker.gpu.attn_utils import compute_spec_metadata
+from vllm.v1.worker.gpu.attn_utils import compute_common_gdn_attn_metadata
 
 BLOCK_SIZE = 16
 DEVICE = torch.device("cpu")
@@ -168,21 +168,22 @@ def _build(
             batch_spec.batch_size, dtype=torch.int32, device=DEVICE
         )
         (
-            spec_sequence_masks_cpu,
-            spec_sequence_masks,
-            num_spec_decodes,
-            num_decodes,
             num_prefills,
-            num_decode_tokens,
             num_prefill_tokens,
+            num_decodes,
+            num_decode_tokens,
+            num_spec_decodes,
             num_spec_decode_tokens,
-            spec_token_indx,
-            non_spec_token_indx,
             spec_query_start_loc,
             non_spec_query_start_loc,
             non_spec_query_start_loc_cpu,
+            spec_sequence_masks_cpu,
+            spec_sequence_masks,
+            non_spec_sequence_masks_cpu,
+            spec_token_indx,
+            non_spec_token_indx,
             num_accepted_tokens,
-        ) = compute_spec_metadata(
+        ) = compute_common_gdn_attn_metadata(
             num_decode_draft_tokens_cpu,
             num_accepted_tokens,
             common.query_start_loc,
@@ -191,19 +192,20 @@ def _build(
         )
         kwargs["num_decode_draft_tokens_cpu"] = num_decode_draft_tokens_cpu
         kwargs["num_accepted_tokens"] = num_accepted_tokens
-        kwargs["spec_sequence_masks_cpu"] = spec_sequence_masks_cpu
-        kwargs["spec_sequence_masks"] = spec_sequence_masks
-        kwargs["num_spec_decodes"] = num_spec_decodes
-        kwargs["num_decodes"] = num_decodes
         kwargs["num_prefills"] = num_prefills
-        kwargs["num_decode_tokens"] = num_decode_tokens
         kwargs["num_prefill_tokens"] = num_prefill_tokens
+        kwargs["num_decodes"] = num_decodes
+        kwargs["num_decode_tokens"] = num_decode_tokens
+        kwargs["num_spec_decodes"] = num_spec_decodes
         kwargs["num_spec_decode_tokens"] = num_spec_decode_tokens
-        kwargs["spec_token_indx"] = spec_token_indx
-        kwargs["non_spec_token_indx"] = non_spec_token_indx
         kwargs["spec_query_start_loc"] = spec_query_start_loc
         kwargs["non_spec_query_start_loc"] = non_spec_query_start_loc
         kwargs["non_spec_query_start_loc_cpu"] = non_spec_query_start_loc_cpu
+        kwargs["spec_sequence_masks_cpu"] = spec_sequence_masks_cpu
+        kwargs["spec_sequence_masks"] = spec_sequence_masks
+        kwargs["non_spec_sequence_masks_cpu"] = non_spec_sequence_masks_cpu
+        kwargs["spec_token_indx"] = spec_token_indx
+        kwargs["non_spec_token_indx"] = non_spec_token_indx
     return builder.build(common_prefix_len=0, common_attn_metadata=common, **kwargs)
 
 

--- a/vllm/v1/attention/backends/gdn_attn.py
+++ b/vllm/v1/attention/backends/gdn_attn.py
@@ -22,6 +22,7 @@ from vllm.v1.attention.backends.utils import (
     split_decodes_and_prefills,
 )
 from vllm.v1.kv_cache_interface import MambaSpec
+from vllm.v1.worker.gpu.attn_utils import compute_common_gdn_attn_metadata
 
 
 class GDNAttentionBackend(AttentionBackend):
@@ -214,6 +215,20 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
         num_accepted_tokens: torch.Tensor | None = None,
         num_decode_draft_tokens_cpu: torch.Tensor | None = None,
         fast_build: bool = False,
+        num_prefills: int = 0,
+        num_prefill_tokens: int = 0,
+        num_decodes: int = 0,
+        num_decode_tokens: int = 0,
+        num_spec_decodes: int = 0,
+        num_spec_decode_tokens: int = 0,
+        spec_query_start_loc: torch.Tensor | None = None,
+        non_spec_query_start_loc: torch.Tensor | None = None,
+        non_spec_query_start_loc_cpu: torch.Tensor | None = None,
+        spec_sequence_masks_cpu: torch.Tensor | None = None,
+        spec_sequence_masks: torch.Tensor | None = None,
+        non_spec_sequence_masks_cpu: torch.Tensor | None = None,
+        spec_token_indx: torch.Tensor | None = None,
+        non_spec_token_indx: torch.Tensor | None = None,
     ) -> GDNAttentionMetadata:
         m = common_attn_metadata
 
@@ -226,26 +241,6 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
             self.kv_cache_spec,
             self.vllm_config.cache_config.mamba_cache_mode,
         )
-
-        spec_sequence_masks_cpu: torch.Tensor | None = None
-        if not self.use_spec_decode or num_decode_draft_tokens_cpu is None:
-            spec_sequence_masks = None
-            num_spec_decodes = 0
-        else:
-            spec_sequence_masks_cpu = num_decode_draft_tokens_cpu >= 0
-            num_spec_decodes = spec_sequence_masks_cpu.sum().item()
-            if (
-                num_spec_decodes == 0
-                or num_decode_draft_tokens_cpu[spec_sequence_masks_cpu].sum().item()
-                == 0
-            ):
-                num_spec_decodes = 0
-                spec_sequence_masks = None
-                spec_sequence_masks_cpu = None
-            else:
-                spec_sequence_masks = async_tensor_h2d(
-                    spec_sequence_masks_cpu, device=query_start_loc.device
-                )
 
         if spec_sequence_masks is None:
             num_decodes, num_prefills, num_decode_tokens, num_prefill_tokens = (
@@ -261,109 +256,19 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
             non_spec_query_start_loc_cpu = query_start_loc_cpu
             num_accepted_tokens = None
         else:
-            query_lens = query_start_loc[1:] - query_start_loc[:-1]
-            assert spec_sequence_masks_cpu is not None
-            non_spec_sequence_masks_cpu = ~spec_sequence_masks_cpu
-            query_lens_cpu = query_start_loc_cpu[1:] - query_start_loc_cpu[:-1]
-
-            # Use CPU tensors to avoid CPU-GPU sync
-            non_spec_query_lens_cpu = query_lens_cpu[non_spec_sequence_masks_cpu]
-            num_decodes = (non_spec_query_lens_cpu == 1).sum().item()
-            # Exclude zero-length padded sequences from prefill count.
-            num_zero_len = (non_spec_query_lens_cpu == 0).sum().item()
-            num_prefills = non_spec_query_lens_cpu.size(0) - num_decodes - num_zero_len
-            num_decode_tokens = num_decodes
-            num_prefill_tokens = (
-                non_spec_query_lens_cpu.sum().item() - num_decode_tokens
-            )
-            num_spec_decode_tokens = (
-                query_lens_cpu.sum().item() - num_prefill_tokens - num_decode_tokens
-            )
-
-            # num_decodes and num_spec_decodes are mutually exclusive.
-            # Reclassify non-spec decodes as prefills when spec decodes
-            # exist — the prefill kernel handles 1-token sequences with
-            # initial state correctly, producing identical results.
-            if num_decodes > 0 and num_spec_decodes > 0:
-                num_prefills += num_decodes
-                num_prefill_tokens += num_decode_tokens
-                num_decodes = 0
-                num_decode_tokens = 0
-
             if num_prefills == 0 and num_decodes == 0:
-                spec_token_size = min(
-                    num_spec_decodes * (self.num_spec + 1),
-                    query_start_loc_cpu[-1].item(),
-                )
-                spec_token_indx = torch.arange(
-                    spec_token_size,
-                    dtype=torch.int32,
-                    device=query_start_loc.device,
-                )
-                non_spec_token_indx = torch.empty(
-                    0, dtype=torch.int32, device=query_start_loc.device
-                )
                 # Filter by spec_sequence_masks to exclude padded sequences
                 spec_state_indices_tensor = block_table_tensor[
                     spec_sequence_masks_cpu, : self.num_spec + 1
                 ]
                 non_spec_state_indices_tensor = None
-                # Padded sequences are always at the back, so the first
-                # num_spec_decodes + 1 entries of query_start_loc already
-                # contain the correct cumulative token counts.
-                spec_query_start_loc = query_start_loc[: num_spec_decodes + 1]
-                non_spec_query_start_loc = None
-                non_spec_query_start_loc_cpu = None
             else:
-                spec_token_masks = torch.repeat_interleave(
-                    spec_sequence_masks,
-                    query_lens,
-                    output_size=query_start_loc_cpu[-1].item(),
-                )
-                index = torch.argsort(spec_token_masks, stable=True)
-                num_non_spec_tokens = num_prefill_tokens + num_decode_tokens
-                non_spec_token_indx = index[:num_non_spec_tokens]
-                spec_token_indx = index[num_non_spec_tokens:]
-
                 spec_state_indices_tensor = block_table_tensor[
                     spec_sequence_masks_cpu, : self.num_spec + 1
                 ]
                 non_spec_state_indices_tensor = block_table_tensor[
                     non_spec_sequence_masks_cpu, 0
                 ]
-
-                spec_query_start_loc = torch.zeros(
-                    num_spec_decodes + 1,
-                    dtype=torch.int32,
-                    device=query_start_loc.device,
-                )
-                torch.cumsum(
-                    query_lens[spec_sequence_masks_cpu],
-                    dim=0,
-                    out=spec_query_start_loc[1:],
-                )
-                non_spec_query_start_loc = torch.zeros(
-                    query_lens.size(0) - num_spec_decodes + 1,
-                    dtype=torch.int32,
-                    device=query_start_loc.device,
-                )
-                torch.cumsum(
-                    query_lens[non_spec_sequence_masks_cpu],
-                    dim=0,
-                    out=non_spec_query_start_loc[1:],
-                )
-                non_spec_query_start_loc_cpu = torch.zeros(
-                    query_lens_cpu.size(0) - num_spec_decodes + 1,
-                    dtype=torch.int32,
-                )
-                torch.cumsum(
-                    query_lens_cpu[non_spec_sequence_masks_cpu],
-                    dim=0,
-                    out=non_spec_query_start_loc_cpu[1:],
-                )
-
-            assert num_accepted_tokens is not None
-            num_accepted_tokens = num_accepted_tokens[spec_sequence_masks_cpu]
 
         chunk_indices: torch.Tensor | None = None
         chunk_offsets: torch.Tensor | None = None
@@ -545,4 +450,47 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
         num_accepted_tokens = torch.diff(m.query_start_loc)
         num_decode_draft_tokens_cpu = (num_accepted_tokens - 1).cpu()
 
-        return self.build(0, m, num_accepted_tokens, num_decode_draft_tokens_cpu)
+        (
+            num_prefills,
+            num_prefill_tokens,
+            num_decodes,
+            num_decode_tokens,
+            num_spec_decodes,
+            num_spec_decode_tokens,
+            spec_query_start_loc,
+            non_spec_query_start_loc,
+            non_spec_query_start_loc_cpu,
+            spec_sequence_masks_cpu,
+            spec_sequence_masks,
+            non_spec_sequence_masks_cpu,
+            spec_token_indx,
+            non_spec_token_indx,
+            num_accepted_tokens,
+        ) = compute_common_gdn_attn_metadata(
+            num_decode_draft_tokens_cpu,
+            num_accepted_tokens,
+            m.query_start_loc,
+            m.query_start_loc_cpu,
+            self.num_spec,
+        )
+
+        return self.build(
+            0,
+            m,
+            num_accepted_tokens,
+            num_decode_draft_tokens_cpu,
+            num_prefills=num_prefills,
+            num_prefill_tokens=num_prefill_tokens,
+            num_decodes=num_decodes,
+            num_decode_tokens=num_decode_tokens,
+            num_spec_decodes=num_spec_decodes,
+            num_spec_decode_tokens=num_spec_decode_tokens,
+            spec_query_start_loc=spec_query_start_loc,
+            non_spec_query_start_loc=non_spec_query_start_loc,
+            non_spec_query_start_loc_cpu=non_spec_query_start_loc_cpu,
+            spec_sequence_masks_cpu=spec_sequence_masks_cpu,
+            spec_sequence_masks=spec_sequence_masks,
+            non_spec_sequence_masks_cpu=non_spec_sequence_masks_cpu,
+            spec_token_indx=spec_token_indx,
+            non_spec_token_indx=non_spec_token_indx,
+        )

--- a/vllm/v1/worker/gpu/attn_utils.py
+++ b/vllm/v1/worker/gpu/attn_utils.py
@@ -358,10 +358,10 @@ def compute_mm_prefix_ranges(
     return req_doc_ranges
 
 
-def compute_spec_metadata(
+def compute_common_gdn_attn_metadata(
     num_decode_draft_tokens_cpu: torch.Tensor,
     num_accepted_tokens: torch.Tensor,
-    query_start_loc_gpu: torch.Tensor,
+    query_start_loc: torch.Tensor,
     query_start_loc_cpu: torch.Tensor,
     num_spec: int,
 ) -> tuple[Any, ...]:
@@ -373,108 +373,143 @@ def compute_spec_metadata(
     shared. Only the block_table-dependent state-index gathers stay per-group in
     GDN build().
     """
-    if num_decode_draft_tokens_cpu is None:
-        return (None, None, 0, 0, 0, 0, 0, 0, None, None, None, None, None, None)
-
-    spec_sequence_masks_cpu = num_decode_draft_tokens_cpu >= 0
-    if num_decode_draft_tokens_cpu[spec_sequence_masks_cpu].sum().item() == 0:
-        return (None, None, 0, 0, 0, 0, 0, 0, None, None, None, None, None, None)
-
-    device = query_start_loc_gpu.device
-    num_spec_decodes = int(spec_sequence_masks_cpu.sum().item())
-    spec_sequence_masks = async_tensor_h2d(spec_sequence_masks_cpu, device=device)
-
-    query_lens = query_start_loc_gpu[1:] - query_start_loc_gpu[:-1]
-    query_lens_cpu = query_start_loc_cpu[1:] - query_start_loc_cpu[:-1]
-
-    # Use CPU tensors to avoid CPU-GPU sync
-    non_spec_query_lens_cpu = query_lens_cpu[~spec_sequence_masks_cpu]
-    num_decodes = int((non_spec_query_lens_cpu == 1).sum().item())
-    # Exclude zero-length padded sequences from prefill count.
-    num_zero_len = int((non_spec_query_lens_cpu == 0).sum().item())
-    num_prefills = non_spec_query_lens_cpu.size(0) - num_decodes - num_zero_len
-    num_decode_tokens = num_decodes
-    num_prefill_tokens = int(non_spec_query_lens_cpu.sum().item()) - num_decode_tokens
-    num_spec_decode_tokens = (
-        int(query_lens_cpu.sum().item()) - num_prefill_tokens - num_decode_tokens
-    )
-
-    if num_decodes > 0 and num_spec_decodes > 0:
-        num_prefills += num_decodes
-        num_prefill_tokens += num_decode_tokens
-        num_decodes = 0
-        num_decode_tokens = 0
-
-    if num_prefills == 0 and num_decodes == 0:
-        spec_token_size = min(
-            num_spec_decodes * (num_spec + 1),
-            int(query_start_loc_cpu[-1].item()),
-        )
-        spec_token_indx = torch.arange(
-            spec_token_size, dtype=torch.int32, device=device
-        )
-        non_spec_token_indx = torch.empty(0, dtype=torch.int32, device=device)
-        # Padded sequences are always at the back, so the first
-        # num_spec_decodes + 1 entries of query_start_loc already
-        # contain the correct cumulative token counts.
-        spec_query_start_loc = query_start_loc_gpu[: num_spec_decodes + 1]
-        non_spec_query_start_loc = None
-        non_spec_query_start_loc_cpu = None
+    spec_sequence_masks_cpu: torch.Tensor | None = None
+    non_spec_sequence_masks_cpu: torch.Tensor | None = None
+    if num_spec <= 0 or num_decode_draft_tokens_cpu is None:
+        spec_sequence_masks = None
+        num_spec_decodes = 0
     else:
-        spec_token_masks = torch.repeat_interleave(
-            spec_sequence_masks,
-            query_lens,
-            output_size=int(query_start_loc_cpu[-1].item()),
-        )
-        index = torch.argsort(spec_token_masks, stable=True)
-        num_non_spec_tokens = num_prefill_tokens + num_decode_tokens
-        non_spec_token_indx = index[:num_non_spec_tokens]
-        spec_token_indx = index[num_non_spec_tokens:]
+        spec_sequence_masks_cpu = num_decode_draft_tokens_cpu >= 0
+        num_spec_decodes = spec_sequence_masks_cpu.sum().item()
+        if (
+            num_spec_decodes == 0
+            or num_decode_draft_tokens_cpu[spec_sequence_masks_cpu].sum().item() == 0
+        ):
+            spec_sequence_masks = None
+            spec_sequence_masks_cpu = None
+            num_spec_decodes = 0
+        else:
+            spec_sequence_masks = async_tensor_h2d(
+                spec_sequence_masks_cpu, device=query_start_loc.device
+            )
 
-        spec_query_start_loc = torch.zeros(
-            num_spec_decodes + 1, dtype=torch.int32, device=device
-        )
-        torch.cumsum(
-            query_lens[spec_sequence_masks_cpu],
-            dim=0,
-            out=spec_query_start_loc[1:],
-        )
-        non_spec_query_start_loc = torch.zeros(
-            query_lens.size(0) - num_spec_decodes + 1,
-            dtype=torch.int32,
-            device=device,
-        )
-        torch.cumsum(
-            query_lens[~spec_sequence_masks_cpu],
-            dim=0,
-            out=non_spec_query_start_loc[1:],
-        )
-        non_spec_query_start_loc_cpu = torch.zeros(
-            query_lens_cpu.size(0) - num_spec_decodes + 1,
-            dtype=torch.int32,
-        )
-        torch.cumsum(
-            query_lens_cpu[~spec_sequence_masks_cpu],
-            dim=0,
-            out=non_spec_query_start_loc_cpu[1:],
+    num_prefills = 0
+    num_prefill_tokens = 0
+    num_decodes = 0
+    num_decode_tokens = 0
+    if spec_sequence_masks is None:
+        num_spec_decode_tokens = 0
+        spec_token_indx = None
+        non_spec_token_indx = None
+        spec_query_start_loc = None
+        non_spec_query_start_loc = query_start_loc
+        non_spec_query_start_loc_cpu = query_start_loc_cpu
+        num_accepted_tokens = None
+    else:
+        query_lens = query_start_loc[1:] - query_start_loc[:-1]
+        assert spec_sequence_masks_cpu is not None
+        non_spec_sequence_masks_cpu = ~spec_sequence_masks_cpu
+        query_lens_cpu = query_start_loc_cpu[1:] - query_start_loc_cpu[:-1]
+
+        # Use CPU tensors to avoid CPU-GPU sync
+        non_spec_query_lens_cpu = query_lens_cpu[non_spec_sequence_masks_cpu]
+        num_decodes = (non_spec_query_lens_cpu == 1).sum().item()
+        # Exclude zero-length padded sequences from prefill count.
+        num_zero_len = (non_spec_query_lens_cpu == 0).sum().item()
+        num_prefills = non_spec_query_lens_cpu.size(0) - num_decodes - num_zero_len
+        num_decode_tokens = num_decodes
+        num_prefill_tokens = non_spec_query_lens_cpu.sum().item() - num_decode_tokens
+        num_spec_decode_tokens = (
+            query_lens_cpu.sum().item() - num_prefill_tokens - num_decode_tokens
         )
 
-    assert num_accepted_tokens is not None
-    num_accepted_tokens = num_accepted_tokens[spec_sequence_masks_cpu]
+        # num_decodes and num_spec_decodes are mutually exclusive.
+        # Reclassify non-spec decodes as prefills when spec decodes
+        # exist — the prefill kernel handles 1-token sequences with
+        # initial state correctly, producing identical results.
+        if num_decodes > 0 and num_spec_decodes > 0:
+            num_prefills += num_decodes
+            num_prefill_tokens += num_decode_tokens
+            num_decodes = 0
+            num_decode_tokens = 0
+
+        if num_prefills == 0 and num_decodes == 0:
+            spec_token_size = min(
+                num_spec_decodes * (num_spec + 1),
+                query_start_loc_cpu[-1].item(),
+            )
+            spec_token_indx = torch.arange(
+                spec_token_size,
+                dtype=torch.int32,
+                device=query_start_loc.device,
+            )
+            non_spec_token_indx = torch.empty(
+                0, dtype=torch.int32, device=query_start_loc.device
+            )
+            # Padded sequences are always at the back, so the first
+            # num_spec_decodes + 1 entries of query_start_loc already
+            # contain the correct cumulative token counts.
+            spec_query_start_loc = query_start_loc[: num_spec_decodes + 1]
+            non_spec_query_start_loc = None
+            non_spec_query_start_loc_cpu = None
+        else:
+            spec_token_masks = torch.repeat_interleave(
+                spec_sequence_masks,
+                query_lens,
+                output_size=query_start_loc_cpu[-1].item(),
+            )
+            index = torch.argsort(spec_token_masks, stable=True)
+            num_non_spec_tokens = num_prefill_tokens + num_decode_tokens
+            non_spec_token_indx = index[:num_non_spec_tokens]
+            spec_token_indx = index[num_non_spec_tokens:]
+
+            spec_query_start_loc = torch.zeros(
+                num_spec_decodes + 1,
+                dtype=torch.int32,
+                device=query_start_loc.device,
+            )
+            torch.cumsum(
+                query_lens[spec_sequence_masks_cpu],
+                dim=0,
+                out=spec_query_start_loc[1:],
+            )
+            non_spec_query_start_loc = torch.zeros(
+                query_lens.size(0) - num_spec_decodes + 1,
+                dtype=torch.int32,
+                device=query_start_loc.device,
+            )
+            torch.cumsum(
+                query_lens[non_spec_sequence_masks_cpu],
+                dim=0,
+                out=non_spec_query_start_loc[1:],
+            )
+            non_spec_query_start_loc_cpu = torch.zeros(
+                query_lens_cpu.size(0) - num_spec_decodes + 1,
+                dtype=torch.int32,
+            )
+            torch.cumsum(
+                query_lens_cpu[non_spec_sequence_masks_cpu],
+                dim=0,
+                out=non_spec_query_start_loc_cpu[1:],
+            )
+
+        assert num_accepted_tokens is not None
+        num_accepted_tokens = num_accepted_tokens[spec_sequence_masks_cpu]
 
     return (
-        spec_sequence_masks_cpu,
-        spec_sequence_masks,
-        num_spec_decodes,
-        num_decodes,
         num_prefills,
-        num_decode_tokens,
         num_prefill_tokens,
+        num_decodes,
+        num_decode_tokens,
+        num_spec_decodes,
         num_spec_decode_tokens,
-        spec_token_indx,
-        non_spec_token_indx,
         spec_query_start_loc,
         non_spec_query_start_loc,
         non_spec_query_start_loc_cpu,
+        spec_sequence_masks_cpu,
+        spec_sequence_masks,
+        non_spec_sequence_masks_cpu,
+        spec_token_indx,
+        non_spec_token_indx,
         num_accepted_tokens,
     )

--- a/vllm/v1/worker/gpu/attn_utils.py
+++ b/vllm/v1/worker/gpu/attn_utils.py
@@ -10,6 +10,7 @@ from vllm.config import VllmConfig, get_layers_from_vllm_config
 from vllm.model_executor.layers.attention import Attention
 from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
 from vllm.multimodal.inputs import MultiModalFeatureSpec
+from vllm.utils.torch_utils import async_tensor_h2d
 from vllm.v1.attention.backend import (
     AttentionCGSupport,
     CommonAttentionMetadata,
@@ -355,3 +356,125 @@ def compute_mm_prefix_ranges(
                 image_doc_ranges.append(r)
         req_doc_ranges[req_idx] = image_doc_ranges
     return req_doc_ranges
+
+
+def compute_spec_metadata(
+    num_decode_draft_tokens_cpu: torch.Tensor,
+    num_accepted_tokens: torch.Tensor,
+    query_start_loc_gpu: torch.Tensor,
+    query_start_loc_cpu: torch.Tensor,
+    num_spec: int,
+) -> tuple[Any, ...]:
+    """Compute the batch-level spec-decode metadata once per step.
+
+    This metadata (masks, decode/prefill/spec split, token indices,
+    query_start_loc cumsums, spec-row-gathered num_accepted_tokens) is identical
+    for every GDN kv-cache group in a step, so it is computed once here and
+    shared. Only the block_table-dependent state-index gathers stay per-group in
+    GDN build().
+    """
+    if num_decode_draft_tokens_cpu is None:
+        return (None, None, 0, 0, 0, 0, 0, 0, None, None, None, None, None, None)
+
+    spec_sequence_masks_cpu = num_decode_draft_tokens_cpu >= 0
+    if num_decode_draft_tokens_cpu[spec_sequence_masks_cpu].sum().item() == 0:
+        return (None, None, 0, 0, 0, 0, 0, 0, None, None, None, None, None, None)
+
+    device = query_start_loc_gpu.device
+    num_spec_decodes = int(spec_sequence_masks_cpu.sum().item())
+    spec_sequence_masks = async_tensor_h2d(spec_sequence_masks_cpu, device=device)
+
+    query_lens = query_start_loc_gpu[1:] - query_start_loc_gpu[:-1]
+    query_lens_cpu = query_start_loc_cpu[1:] - query_start_loc_cpu[:-1]
+
+    # Use CPU tensors to avoid CPU-GPU sync
+    non_spec_query_lens_cpu = query_lens_cpu[~spec_sequence_masks_cpu]
+    num_decodes = int((non_spec_query_lens_cpu == 1).sum().item())
+    # Exclude zero-length padded sequences from prefill count.
+    num_zero_len = int((non_spec_query_lens_cpu == 0).sum().item())
+    num_prefills = non_spec_query_lens_cpu.size(0) - num_decodes - num_zero_len
+    num_decode_tokens = num_decodes
+    num_prefill_tokens = int(non_spec_query_lens_cpu.sum().item()) - num_decode_tokens
+    num_spec_decode_tokens = (
+        int(query_lens_cpu.sum().item()) - num_prefill_tokens - num_decode_tokens
+    )
+
+    if num_decodes > 0 and num_spec_decodes > 0:
+        num_prefills += num_decodes
+        num_prefill_tokens += num_decode_tokens
+        num_decodes = 0
+        num_decode_tokens = 0
+
+    if num_prefills == 0 and num_decodes == 0:
+        spec_token_size = min(
+            num_spec_decodes * (num_spec + 1),
+            int(query_start_loc_cpu[-1].item()),
+        )
+        spec_token_indx = torch.arange(
+            spec_token_size, dtype=torch.int32, device=device
+        )
+        non_spec_token_indx = torch.empty(0, dtype=torch.int32, device=device)
+        # Padded sequences are always at the back, so the first
+        # num_spec_decodes + 1 entries of query_start_loc already
+        # contain the correct cumulative token counts.
+        spec_query_start_loc = query_start_loc_gpu[: num_spec_decodes + 1]
+        non_spec_query_start_loc = None
+        non_spec_query_start_loc_cpu = None
+    else:
+        spec_token_masks = torch.repeat_interleave(
+            spec_sequence_masks,
+            query_lens,
+            output_size=int(query_start_loc_cpu[-1].item()),
+        )
+        index = torch.argsort(spec_token_masks, stable=True)
+        num_non_spec_tokens = num_prefill_tokens + num_decode_tokens
+        non_spec_token_indx = index[:num_non_spec_tokens]
+        spec_token_indx = index[num_non_spec_tokens:]
+
+        spec_query_start_loc = torch.zeros(
+            num_spec_decodes + 1, dtype=torch.int32, device=device
+        )
+        torch.cumsum(
+            query_lens[spec_sequence_masks_cpu],
+            dim=0,
+            out=spec_query_start_loc[1:],
+        )
+        non_spec_query_start_loc = torch.zeros(
+            query_lens.size(0) - num_spec_decodes + 1,
+            dtype=torch.int32,
+            device=device,
+        )
+        torch.cumsum(
+            query_lens[~spec_sequence_masks_cpu],
+            dim=0,
+            out=non_spec_query_start_loc[1:],
+        )
+        non_spec_query_start_loc_cpu = torch.zeros(
+            query_lens_cpu.size(0) - num_spec_decodes + 1,
+            dtype=torch.int32,
+        )
+        torch.cumsum(
+            query_lens_cpu[~spec_sequence_masks_cpu],
+            dim=0,
+            out=non_spec_query_start_loc_cpu[1:],
+        )
+
+    assert num_accepted_tokens is not None
+    num_accepted_tokens = num_accepted_tokens[spec_sequence_masks_cpu]
+
+    return (
+        spec_sequence_masks_cpu,
+        spec_sequence_masks,
+        num_spec_decodes,
+        num_decodes,
+        num_prefills,
+        num_decode_tokens,
+        num_prefill_tokens,
+        num_spec_decode_tokens,
+        spec_token_indx,
+        non_spec_token_indx,
+        spec_query_start_loc,
+        non_spec_query_start_loc,
+        non_spec_query_start_loc_cpu,
+        num_accepted_tokens,
+    )

--- a/vllm/v1/worker/gpu/model_states/mamba_hybrid.py
+++ b/vllm/v1/worker/gpu/model_states/mamba_hybrid.py
@@ -16,7 +16,7 @@ from vllm.v1.attention.backends.short_conv_attn import ShortConvAttentionMetadat
 from vllm.v1.core.sched.output import NewRequestData
 from vllm.v1.kv_cache_interface import KVCacheConfig, MambaSpec
 from vllm.v1.utils import CpuGpuBuffer
-from vllm.v1.worker.gpu.attn_utils import build_attn_metadata
+from vllm.v1.worker.gpu.attn_utils import build_attn_metadata, compute_spec_metadata
 from vllm.v1.worker.gpu.input_batch import InputBatch
 from vllm.v1.worker.gpu.mm.encoder_cache import EncoderCache
 from vllm.v1.worker.gpu.model_states.default import DefaultModelState
@@ -34,6 +34,19 @@ class MambaHybridAttnMetadata(ModelSpecificAttnMetadata):
     is_prefilling: torch.Tensor
     num_accepted_tokens: torch.Tensor | None = None
     num_decode_draft_tokens_cpu: torch.Tensor | None = None
+    spec_sequence_masks_cpu: torch.Tensor | None = None
+    spec_sequence_masks: torch.Tensor | None = None
+    num_spec_decodes: int = 0
+    num_decodes: int = 0
+    num_prefills: int = 0
+    num_decode_tokens: int = 0
+    num_prefill_tokens: int = 0
+    num_spec_decode_tokens: int = 0
+    spec_token_indx: torch.Tensor | None = None
+    non_spec_token_indx: torch.Tensor | None = None
+    spec_query_start_loc: torch.Tensor | None = None
+    non_spec_query_start_loc: torch.Tensor | None = None
+    non_spec_query_start_loc_cpu: torch.Tensor | None = None
 
     def get_extra_common_attn_kwargs(
         self,
@@ -63,6 +76,23 @@ class MambaHybridAttnMetadata(ModelSpecificAttnMetadata):
             "num_decode_draft_tokens_cpu": None
             if self.num_decode_draft_tokens_cpu is None
             else self.num_decode_draft_tokens_cpu[:num_reqs],
+            "spec_sequence_masks_cpu": None
+            if self.spec_sequence_masks_cpu is None
+            else self.spec_sequence_masks_cpu[:num_reqs],
+            "spec_sequence_masks": None
+            if self.spec_sequence_masks is None
+            else self.spec_sequence_masks[:num_reqs],
+            "num_spec_decodes": self.num_spec_decodes,
+            "num_decodes": self.num_decodes,
+            "num_prefills": self.num_prefills,
+            "num_decode_tokens": self.num_decode_tokens,
+            "num_prefill_tokens": self.num_prefill_tokens,
+            "num_spec_decode_tokens": self.num_spec_decode_tokens,
+            "spec_token_indx": self.spec_token_indx,
+            "non_spec_token_indx": self.non_spec_token_indx,
+            "spec_query_start_loc": self.spec_query_start_loc,
+            "non_spec_query_start_loc": self.non_spec_query_start_loc,
+            "non_spec_query_start_loc_cpu": self.non_spec_query_start_loc_cpu,
         }
 
 
@@ -81,6 +111,7 @@ class MambaHybridModelState(DefaultModelState):
         self.num_accepted_tokens_gpu = torch.ones(
             self.max_num_reqs, dtype=torch.int32, device=self.device
         )
+        self._is_gdn: bool | None = None
         # Pre-copy "align" prefix-cache state (V2). The migration of each
         # request's mamba state across block boundaries runs as a fused GPU
         # kernel reusing the postprocess copy machinery, so the per-step src
@@ -166,6 +197,15 @@ class MambaHybridModelState(DefaultModelState):
             )
         return ctx
 
+    def is_gdn(self, attn_groups: list[list[AttentionGroup]]) -> bool:
+        if self._is_gdn is None:
+            self._is_gdn = any(
+                isinstance(g.get_metadata_builder(0), GDNAttentionMetadataBuilder)
+                for groups in attn_groups
+                for g in groups
+            )
+        return self._is_gdn
+
     def preprocess_state(
         self,
         input_batch: InputBatch,
@@ -249,6 +289,19 @@ class MambaHybridModelState(DefaultModelState):
         # compute them during actual (non-capture) forward execution.
         num_accepted_tokens = None
         num_decode_draft_tokens_cpu = None
+        spec_sequence_masks_cpu = None
+        spec_sequence_masks = None
+        num_prefills = 0
+        num_prefill_tokens = 0
+        num_decodes = 0
+        num_decode_tokens = 0
+        num_spec_decodes = 0
+        num_spec_decode_tokens = 0
+        spec_token_indx = None
+        non_spec_token_indx = None
+        spec_query_start_loc = None
+        non_spec_query_start_loc = None
+        non_spec_query_start_loc_cpu = None
         if not for_capture and self.vllm_config.num_speculative_tokens > 0:
             num_accepted_tokens = self.num_accepted_tokens_gpu.new_ones(num_reqs)
             num_accepted_tokens[: input_batch.num_reqs] = self.num_accepted_tokens_gpu[
@@ -271,6 +324,32 @@ class MambaHybridModelState(DefaultModelState):
                 )
             num_decode_draft_tokens_cpu = torch.from_numpy(num_decode_draft_tokens_np)
 
+            # Spec metadata only consumed by GDN. Skip the compute for Mamba2
+            # hybrids, which read only num_accepted_tokens.
+            if self.is_gdn(attn_groups):
+                (
+                    spec_sequence_masks_cpu,
+                    spec_sequence_masks,
+                    num_spec_decodes,
+                    num_decodes,
+                    num_prefills,
+                    num_decode_tokens,
+                    num_prefill_tokens,
+                    num_spec_decode_tokens,
+                    spec_token_indx,
+                    non_spec_token_indx,
+                    spec_query_start_loc,
+                    non_spec_query_start_loc,
+                    non_spec_query_start_loc_cpu,
+                    num_accepted_tokens,
+                ) = compute_spec_metadata(
+                    num_decode_draft_tokens_cpu,
+                    num_accepted_tokens,
+                    input_batch.query_start_loc,
+                    query_start_loc_cpu,
+                    self.vllm_config.num_speculative_tokens,
+                )
+                
         if self._align_mode:
             mamba_group_ids, _ = self._get_mamba_group_info(kv_cache_config)
             aligned_index_builders = []
@@ -289,10 +368,24 @@ class MambaHybridModelState(DefaultModelState):
                 for group_idx, builder in aligned_index_builders:
                     builder.mamba_aligned_state_indices = all_group_indices[group_idx]
 
+
         mamba_attn_metadata = MambaHybridAttnMetadata(
             is_prefilling=is_prefilling,
             num_accepted_tokens=num_accepted_tokens,
             num_decode_draft_tokens_cpu=num_decode_draft_tokens_cpu,
+            spec_sequence_masks_cpu=spec_sequence_masks_cpu,
+            spec_sequence_masks=spec_sequence_masks,
+            num_spec_decodes=num_spec_decodes,
+            num_decodes=num_decodes,
+            num_prefills=num_prefills,
+            num_decode_tokens=num_decode_tokens,
+            num_prefill_tokens=num_prefill_tokens,
+            num_spec_decode_tokens=num_spec_decode_tokens,
+            spec_token_indx=spec_token_indx,
+            non_spec_token_indx=non_spec_token_indx,
+            spec_query_start_loc=spec_query_start_loc,
+            non_spec_query_start_loc=non_spec_query_start_loc,
+            non_spec_query_start_loc_cpu=non_spec_query_start_loc_cpu,
         )
         attn_metadata = build_attn_metadata(
             attn_groups=attn_groups,

--- a/vllm/v1/worker/gpu/model_states/mamba_hybrid.py
+++ b/vllm/v1/worker/gpu/model_states/mamba_hybrid.py
@@ -16,7 +16,10 @@ from vllm.v1.attention.backends.short_conv_attn import ShortConvAttentionMetadat
 from vllm.v1.core.sched.output import NewRequestData
 from vllm.v1.kv_cache_interface import KVCacheConfig, MambaSpec
 from vllm.v1.utils import CpuGpuBuffer
-from vllm.v1.worker.gpu.attn_utils import build_attn_metadata, compute_spec_metadata
+from vllm.v1.worker.gpu.attn_utils import (
+    build_attn_metadata,
+    compute_common_gdn_attn_metadata,
+)
 from vllm.v1.worker.gpu.input_batch import InputBatch
 from vllm.v1.worker.gpu.mm.encoder_cache import EncoderCache
 from vllm.v1.worker.gpu.model_states.default import DefaultModelState
@@ -34,19 +37,20 @@ class MambaHybridAttnMetadata(ModelSpecificAttnMetadata):
     is_prefilling: torch.Tensor
     num_accepted_tokens: torch.Tensor | None = None
     num_decode_draft_tokens_cpu: torch.Tensor | None = None
-    spec_sequence_masks_cpu: torch.Tensor | None = None
-    spec_sequence_masks: torch.Tensor | None = None
-    num_spec_decodes: int = 0
-    num_decodes: int = 0
     num_prefills: int = 0
-    num_decode_tokens: int = 0
     num_prefill_tokens: int = 0
+    num_decodes: int = 0
+    num_decode_tokens: int = 0
+    num_spec_decodes: int = 0
     num_spec_decode_tokens: int = 0
-    spec_token_indx: torch.Tensor | None = None
-    non_spec_token_indx: torch.Tensor | None = None
     spec_query_start_loc: torch.Tensor | None = None
     non_spec_query_start_loc: torch.Tensor | None = None
     non_spec_query_start_loc_cpu: torch.Tensor | None = None
+    spec_sequence_masks_cpu: torch.Tensor | None = None
+    spec_sequence_masks: torch.Tensor | None = None
+    non_spec_sequence_masks_cpu: torch.Tensor | None = None
+    spec_token_indx: torch.Tensor | None = None
+    non_spec_token_indx: torch.Tensor | None = None
 
     def get_extra_common_attn_kwargs(
         self,
@@ -82,17 +86,20 @@ class MambaHybridAttnMetadata(ModelSpecificAttnMetadata):
             "spec_sequence_masks": None
             if self.spec_sequence_masks is None
             else self.spec_sequence_masks[:num_reqs],
-            "num_spec_decodes": self.num_spec_decodes,
-            "num_decodes": self.num_decodes,
+            "non_spec_sequence_masks_cpu": None
+            if self.non_spec_sequence_masks_cpu is None
+            else self.non_spec_sequence_masks_cpu[:num_reqs],
             "num_prefills": self.num_prefills,
-            "num_decode_tokens": self.num_decode_tokens,
             "num_prefill_tokens": self.num_prefill_tokens,
+            "num_decodes": self.num_decodes,
+            "num_decode_tokens": self.num_decode_tokens,
+            "num_spec_decodes": self.num_spec_decodes,
             "num_spec_decode_tokens": self.num_spec_decode_tokens,
-            "spec_token_indx": self.spec_token_indx,
-            "non_spec_token_indx": self.non_spec_token_indx,
             "spec_query_start_loc": self.spec_query_start_loc,
             "non_spec_query_start_loc": self.non_spec_query_start_loc,
             "non_spec_query_start_loc_cpu": self.non_spec_query_start_loc_cpu,
+            "spec_token_indx": self.spec_token_indx,
+            "non_spec_token_indx": self.non_spec_token_indx,
         }
 
 
@@ -289,67 +296,71 @@ class MambaHybridModelState(DefaultModelState):
         # compute them during actual (non-capture) forward execution.
         num_accepted_tokens = None
         num_decode_draft_tokens_cpu = None
-        spec_sequence_masks_cpu = None
-        spec_sequence_masks = None
         num_prefills = 0
         num_prefill_tokens = 0
         num_decodes = 0
         num_decode_tokens = 0
         num_spec_decodes = 0
         num_spec_decode_tokens = 0
-        spec_token_indx = None
-        non_spec_token_indx = None
         spec_query_start_loc = None
         non_spec_query_start_loc = None
         non_spec_query_start_loc_cpu = None
-        if not for_capture and self.vllm_config.num_speculative_tokens > 0:
-            num_accepted_tokens = self.num_accepted_tokens_gpu.new_ones(num_reqs)
-            num_accepted_tokens[: input_batch.num_reqs] = self.num_accepted_tokens_gpu[
-                input_batch.idx_mapping
-            ]
-
-            # GDN uses >= 0 to select spec-decode rows, so non-decode rows
-            # need the -1 sentinel rather than a raw zero draft count.
-            num_decode_draft_tokens_np = np.full(num_reqs, -1, dtype=np.int32)
-            num_draft_tokens_per_req = input_batch.num_draft_tokens_per_req
-            if num_draft_tokens_per_req is not None:
-                # A row is a spec-decode row only when its whole prompt is already
-                # computed, i.e. exactly one non-draft (decode) token is scheduled.
-                is_decode = (
-                    input_batch.num_scheduled_tokens == num_draft_tokens_per_req + 1
+        spec_sequence_masks_cpu = None
+        spec_sequence_masks = None
+        non_spec_sequence_masks_cpu = None
+        spec_token_indx = None
+        non_spec_token_indx = None
+        if not for_capture:
+            if self.vllm_config.num_speculative_tokens > 0:
+                num_accepted_tokens = self.num_accepted_tokens_gpu.new_ones(num_reqs)
+                num_accepted_tokens[: input_batch.num_reqs] = (
+                    self.num_accepted_tokens_gpu[input_batch.idx_mapping]
                 )
-                spec_decode_mask = (num_draft_tokens_per_req > 0) & is_decode
-                num_decode_draft_tokens_np[: input_batch.num_reqs] = np.where(
-                    spec_decode_mask, num_draft_tokens_per_req, -1
-                )
-            num_decode_draft_tokens_cpu = torch.from_numpy(num_decode_draft_tokens_np)
 
-            # Spec metadata only consumed by GDN. Skip the compute for Mamba2
-            # hybrids, which read only num_accepted_tokens.
+                # GDN uses >= 0 to select spec-decode rows, so non-decode rows
+                # need the -1 sentinel rather than a raw zero draft count.
+                num_decode_draft_tokens_np = np.full(num_reqs, -1, dtype=np.int32)
+                num_draft_tokens_per_req = input_batch.num_draft_tokens_per_req
+                if num_draft_tokens_per_req is not None:
+                    # A row is a spec-decode row only when its whole prompt is already
+                    # computed, i.e. exactly one non-draft (decode) token is scheduled.
+                    is_decode = (
+                        input_batch.num_scheduled_tokens == num_draft_tokens_per_req + 1
+                    )
+                    spec_decode_mask = (num_draft_tokens_per_req > 0) & is_decode
+                    num_decode_draft_tokens_np[: input_batch.num_reqs] = np.where(
+                        spec_decode_mask, num_draft_tokens_per_req, -1
+                    )
+                num_decode_draft_tokens_cpu = torch.from_numpy(
+                    num_decode_draft_tokens_np
+                )
+
+            # Compute GDN common metadata
             if self.is_gdn(attn_groups):
                 (
-                    spec_sequence_masks_cpu,
-                    spec_sequence_masks,
-                    num_spec_decodes,
-                    num_decodes,
                     num_prefills,
-                    num_decode_tokens,
                     num_prefill_tokens,
+                    num_decodes,
+                    num_decode_tokens,
+                    num_spec_decodes,
                     num_spec_decode_tokens,
-                    spec_token_indx,
-                    non_spec_token_indx,
                     spec_query_start_loc,
                     non_spec_query_start_loc,
                     non_spec_query_start_loc_cpu,
+                    spec_sequence_masks_cpu,
+                    spec_sequence_masks,
+                    non_spec_sequence_masks_cpu,
+                    spec_token_indx,
+                    non_spec_token_indx,
                     num_accepted_tokens,
-                ) = compute_spec_metadata(
+                ) = compute_common_gdn_attn_metadata(
                     num_decode_draft_tokens_cpu,
                     num_accepted_tokens,
                     input_batch.query_start_loc,
                     query_start_loc_cpu,
                     self.vllm_config.num_speculative_tokens,
                 )
-                
+
         if self._align_mode:
             mamba_group_ids, _ = self._get_mamba_group_info(kv_cache_config)
             aligned_index_builders = []
@@ -368,24 +379,24 @@ class MambaHybridModelState(DefaultModelState):
                 for group_idx, builder in aligned_index_builders:
                     builder.mamba_aligned_state_indices = all_group_indices[group_idx]
 
-
         mamba_attn_metadata = MambaHybridAttnMetadata(
             is_prefilling=is_prefilling,
             num_accepted_tokens=num_accepted_tokens,
             num_decode_draft_tokens_cpu=num_decode_draft_tokens_cpu,
-            spec_sequence_masks_cpu=spec_sequence_masks_cpu,
-            spec_sequence_masks=spec_sequence_masks,
-            num_spec_decodes=num_spec_decodes,
-            num_decodes=num_decodes,
             num_prefills=num_prefills,
-            num_decode_tokens=num_decode_tokens,
             num_prefill_tokens=num_prefill_tokens,
+            num_decodes=num_decodes,
+            num_decode_tokens=num_decode_tokens,
+            num_spec_decodes=num_spec_decodes,
             num_spec_decode_tokens=num_spec_decode_tokens,
-            spec_token_indx=spec_token_indx,
-            non_spec_token_indx=non_spec_token_indx,
             spec_query_start_loc=spec_query_start_loc,
             non_spec_query_start_loc=non_spec_query_start_loc,
             non_spec_query_start_loc_cpu=non_spec_query_start_loc_cpu,
+            spec_sequence_masks_cpu=spec_sequence_masks_cpu,
+            spec_sequence_masks=spec_sequence_masks,
+            non_spec_sequence_masks_cpu=non_spec_sequence_masks_cpu,
+            spec_token_indx=spec_token_indx,
+            non_spec_token_indx=non_spec_token_indx,
         )
         attn_metadata = build_attn_metadata(
             attn_groups=attn_groups,


### PR DESCRIPTION
## Purpose

During profiling I notice GDNAttentionMetadataBuilder.build() takes a long time (~900µs), because the batch level GDN spec decode metadata (masks, decode/prefill/spec split, token indices, query_start_loc cumsums) is computed repeatedly in each group build(). This compute can be moved one level up out of each group build().

* Compute the batch level GDN spec decode metadata once per step in `compute_spec_metadata` and store it on model_specific_attn_metadata, instead of recomputing it inside each GDN group's build(). Only the block_table dependent state index gathers stay per-group in build().
* e2e output throughput improves 61% at batch size 1,  12% at batch size 16 with DFlash (tested on H200).

## Test Plan
```
pytest -s -v tests/v1/attention/test_gdn_metadata_builder.py
```
## Test Result

Unit test passed.

## Profiling

<img width="1910" height="748" alt="Screenshot 2026-08-14 at 12 56 28 AM" src="https://github.com/user-attachments/assets/7cb2d7ff-407e-4789-9d41-71027fc50bf6" />

Main: GDNAttentionMetadataBuilder.build() takes ~900µs

PR: GDNAttentionMetadataBuilder.build() takes ~300µs

## Benchmark

```
vllm serve Qwen/Qwen3.6-35B-A3B \
  --tensor-parallel-size 1 \
  --max-num-seqs 16 \
  --speculative-config '{"model":"z-lab/Qwen3.6-35B-A3B-DFlash","method":"dflash","num_speculative_tokens":8}' \
  --no-enable-prefix-caching
```

```
vllm bench serve \
        --model Qwen/Qwen3.6-35B-A3B \
        --dataset-name sharegpt \
        --dataset-path /tmp/ShareGPT_V3_unfiltered_cleaned_split.json \
        --sharegpt-output-len 300 \
        --num-prompts ${num_prompts} \
        --max-concurrency ${concurrency} \
        --num-warmups 200 \
        --ignore-eos
```

Main:

* concurrency 1

```
============ Serving Benchmark Result ============
Successful requests:                     60        
Failed requests:                         0         
Maximum request concurrency:             1         
Benchmark duration (s):                  84.82     
Total input tokens:                      16410     
Total generated tokens:                  18000     
Request throughput (req/s):              0.71      
Output token throughput (tok/s):         212.22    
Peak output token throughput (tok/s):    62.00     
Peak concurrent requests:                2.00      
Total token throughput (tok/s):          405.69    
---------------Time to First Token----------------
Mean TTFT (ms):                          113.86    
Median TTFT (ms):                        131.82    
P99 TTFT (ms):                           142.84    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          4.35      
Median TPOT (ms):                        4.45      
P99 TPOT (ms):                           5.99      
---------------Inter-token Latency----------------
Mean ITL (ms):                           16.15     
Median ITL (ms):                         16.15     
P99 ITL (ms):                            16.64     
---------------Speculative Decoding---------------
Acceptance rate (%):                     34.34     
Acceptance length:                       3.75      
Drafts:                                  4827      
Draft tokens:                            38616     
Accepted tokens:                         13260     
Per-position acceptance (%):
  Position 0:                            75.08     
  Position 1:                            55.13     
  Position 2:                            41.06     
  Position 3:                            31.32     
  Position 4:                            24.72     
  Position 5:                            19.23     
  Position 6:                            15.66     
  Position 7:                            12.51     
==================================================
```

* concurrency 16
```
============ Serving Benchmark Result ============
Successful requests:                     960       
Failed requests:                         0         
Maximum request concurrency:             16        
Benchmark duration (s):                  206.67    
Total input tokens:                      227546    
Total generated tokens:                  288000    
Request throughput (req/s):              4.65      
Output token throughput (tok/s):         1393.52   
Peak output token throughput (tok/s):    585.00    
Peak concurrent requests:                25.00     
Total token throughput (tok/s):          2494.53   
---------------Time to First Token----------------
Mean TTFT (ms):                          209.36    
Median TTFT (ms):                        193.29    
P99 TTFT (ms):                           414.69    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          10.76     
Median TPOT (ms):                        10.80     
P99 TPOT (ms):                           17.09     
---------------Inter-token Latency----------------
Mean ITL (ms):                           38.40     
Median ITL (ms):                         22.08     
P99 ITL (ms):                            156.83    
---------------Speculative Decoding---------------
Acceptance rate (%):                     32.45     
Acceptance length:                       3.60      
Drafts:                                  80447     
Draft tokens:                            643576    
Accepted tokens:                         208834    
Per-position acceptance (%):
  Position 0:                            74.47     
  Position 1:                            52.20     
  Position 2:                            37.66     
  Position 3:                            28.59     
  Position 4:                            22.55     
  Position 5:                            17.95     
  Position 6:                            14.43     
  Position 7:                            11.74     
==================================================
```

PR:

* concurrency 1

```
============ Serving Benchmark Result ============
Successful requests:                     60        
Failed requests:                         0         
Maximum request concurrency:             1         
Benchmark duration (s):                  52.43     
Total input tokens:                      16410     
Total generated tokens:                  18000     
Request throughput (req/s):              1.14      
Output token throughput (tok/s):         343.30    
Peak output token throughput (tok/s):    101.00    
Peak concurrent requests:                3.00      
Total token throughput (tok/s):          656.28    
---------------Time to First Token----------------
Mean TTFT (ms):                          112.91    
Median TTFT (ms):                        126.85    
P99 TTFT (ms):                           257.44    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          2.54      
Median TPOT (ms):                        2.61      
P99 TPOT (ms):                           3.52      
---------------Inter-token Latency----------------
Mean ITL (ms):                           9.46      
Median ITL (ms):                         9.46      
P99 ITL (ms):                            10.00     
---------------Speculative Decoding---------------
Acceptance rate (%):                     34.34     
Acceptance length:                       3.75      
Drafts:                                  4827      
Draft tokens:                            38616     
Accepted tokens:                         13260     
Per-position acceptance (%):
  Position 0:                            75.08     
  Position 1:                            55.13     
  Position 2:                            41.06     
  Position 3:                            31.32     
  Position 4:                            24.72     
  Position 5:                            19.23     
  Position 6:                            15.66     
  Position 7:                            12.51     
==================================================
```

* concurrency 16

```
============ Serving Benchmark Result ============
Successful requests:                     960       
Failed requests:                         0         
Maximum request concurrency:             16        
Benchmark duration (s):                  184.12    
Total input tokens:                      227546    
Total generated tokens:                  288000    
Request throughput (req/s):              5.21      
Output token throughput (tok/s):         1564.18   
Peak output token throughput (tok/s):    621.00    
Peak concurrent requests:                25.00     
Total token throughput (tok/s):          2800.03   
---------------Time to First Token----------------
Mean TTFT (ms):                          179.13    
Median TTFT (ms):                        168.03    
P99 TTFT (ms):                           363.03    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          9.62      
Median TPOT (ms):                        9.61      
P99 TPOT (ms):                           15.26     
---------------Inter-token Latency----------------
Mean ITL (ms):                           34.32     
Median ITL (ms):                         21.51     
P99 ITL (ms):                            139.09    
---------------Speculative Decoding---------------
Acceptance rate (%):                     32.45     
Acceptance length:                       3.60      
Drafts:                                  80447     
Draft tokens:                            643576    
Accepted tokens:                         208834    
Per-position acceptance (%):
  Position 0:                            74.47     
  Position 1:                            52.20     
  Position 2:                            37.66     
  Position 3:                            28.59     
  Position 4:                            22.55     
  Position 5:                            17.95     
  Position 6:                            14.43     
  Position 7:                            11.74     
==================================================
```

e2e output throughput improves ~61% at batch size 1,  12% at batch size 16 with DFlash (tested on H200).

## Accuracy Testing

```
python3 -m lm_eval --model local-completions \
  --model_args model=Qwen/Qwen3.6-35B-A3B,base_url=http://127.0.0.1:8000/v1/completions,num_concurrent=16 \
  --tasks gsm8k
```

Main:

```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.3533|±  |0.0132|
|     |       |strict-match    |     5|exact_match|↑  |0.3290|±  |0.0129|
```

PR:

```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.3541|±  |0.0132|
|     |       |strict-match    |     5|exact_match|↑  |0.3306|±  |0.0130|
```


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

