### PR TITLE
[Bugfix] Validate guidance tokenizer compatibility before EngineCore

### DIFF
--- a/tests/v1/structured_output/test_validation.py
+++ b/tests/v1/structured_output/test_validation.py
@@ -2,13 +2,22 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Request-time validation of structured output requests."""
 
+from unittest.mock import Mock
+
 import pytest
+from transformers import MistralCommonBackend, PreTrainedTokenizerFast
 
 from vllm.config import StructuredOutputsConfig
 from vllm.exceptions import VLLMValidationError
 from vllm.sampling_params import SamplingParams, StructuredOutputsParams
+from vllm.tokenizers import mistral as mistral_tokenizers
+from vllm.v1.structured_output import (
+    backend_guidance,
+    backend_outlines,
+    backend_xgrammar,
+)
 
-pytestmark = pytest.mark.cpu_test
+pytestmark = [pytest.mark.cpu_test, pytest.mark.skip_global_cleanup]
 
 JSON_SCHEMA = {
     "type": "object",
@@ -24,6 +33,37 @@ JSON_SCHEMA = {
 class _StubModelConfig:
     def __init__(self, is_diffusion: bool):
         self.is_diffusion = is_diffusion
+
+
+class _StubSlowTokenizer:
+    is_fast = False
+
+
+class _StubVllmMistralTokenizer:
+    IS_MISTRAL_TOKENIZER = True
+
+    def __init__(self, is_tekken: bool):
+        self.is_tekken = is_tekken
+
+
+def _validate(tokenizer, backend):
+    params = SamplingParams(
+        structured_outputs=StructuredOutputsParams(json=JSON_SCHEMA)
+    )
+    params._validate_structured_outputs(
+        _StubModelConfig(is_diffusion=False),
+        StructuredOutputsConfig(backend=backend),
+        tokenizer=tokenizer,
+    )
+    return params
+
+
+def _guidance_must_not_run(*_args, **_kwargs):
+    pytest.fail("grammar validation must not run for an unsupported tokenizer")
+
+
+def _reject_xgrammar(*_args, **_kwargs):
+    raise ValueError("unsupported schema")
 
 
 def test_structured_outputs_rejected_for_diffusion_models():
@@ -70,3 +110,115 @@ def test_degenerate_structured_outputs_rejected(structured_outputs, match):
             StructuredOutputsConfig(),
             tokenizer=object(),
         )
+
+
+@pytest.mark.parametrize(
+    "tokenizer_factory, raw_mistral",
+    [
+        pytest.param(_StubSlowTokenizer, False, id="slow-hf"),
+        pytest.param(
+            lambda: object.__new__(MistralCommonBackend),
+            True,
+            id="raw-mistral-spm",
+        ),
+    ],
+)
+def test_guidance_rejects_unsupported_tokenizers(
+    monkeypatch, tokenizer_factory, raw_mistral
+):
+    """Unsupported tokenizers must fail before EngineCore initializes guidance."""
+    if raw_mistral:
+        monkeypatch.setattr(
+            mistral_tokenizers,
+            "mistral_common_tekkenizer",
+            lambda tokenizer: None,
+        )
+    monkeypatch.setattr(
+        backend_guidance,
+        "validate_guidance_grammar",
+        _guidance_must_not_run,
+    )
+
+    with pytest.raises(VLLMValidationError, match="only supports fast"):
+        _validate(tokenizer_factory(), backend="guidance")
+
+
+@pytest.mark.parametrize(
+    "tokenizer_factory, raw_mistral",
+    [
+        pytest.param(
+            lambda: object.__new__(PreTrainedTokenizerFast),
+            False,
+            id="fast-hf",
+        ),
+        pytest.param(
+            lambda: object.__new__(MistralCommonBackend),
+            True,
+            id="raw-mistral-tekken",
+        ),
+    ],
+)
+def test_guidance_allows_supported_tokenizers(
+    monkeypatch, tokenizer_factory, raw_mistral
+):
+    """The early guard must preserve all supported tokenizer paths."""
+    if raw_mistral:
+        monkeypatch.setattr(
+            mistral_tokenizers,
+            "mistral_common_tekkenizer",
+            lambda tokenizer: object(),
+        )
+    validate_guidance = Mock()
+    monkeypatch.setattr(
+        backend_guidance,
+        "validate_guidance_grammar",
+        validate_guidance,
+    )
+
+    params = _validate(tokenizer_factory(), backend="guidance")
+    validate_guidance.assert_called_once()
+    assert params.structured_outputs._backend == "guidance"
+
+
+def test_auto_preserves_non_tekken_mistral_outlines_fallback(monkeypatch):
+    """Preserve the existing auto fallback for vLLM non-Tekken Mistral."""
+    monkeypatch.setattr(
+        mistral_tokenizers,
+        "MistralTokenizer",
+        _StubVllmMistralTokenizer,
+    )
+    monkeypatch.setattr(
+        backend_xgrammar,
+        "validate_xgrammar_grammar",
+        _reject_xgrammar,
+    )
+    validate_outlines = Mock()
+    monkeypatch.setattr(
+        backend_outlines,
+        "validate_structured_output_request_outlines",
+        validate_outlines,
+    )
+
+    params = _validate(
+        _StubVllmMistralTokenizer(is_tekken=False),
+        backend="auto",
+    )
+    validate_outlines.assert_called_once()
+    assert params.structured_outputs._backend == "outlines"
+
+
+def test_auto_excludes_guidance_for_slow_tokenizer(monkeypatch):
+    """Auto must fail safely when no compatible backend can handle the request."""
+    monkeypatch.setattr(
+        backend_xgrammar,
+        "validate_xgrammar_grammar",
+        _reject_xgrammar,
+    )
+    monkeypatch.setattr(
+        backend_guidance,
+        "validate_guidance_grammar",
+        _guidance_must_not_run,
+    )
+
+    with pytest.raises(VLLMValidationError, match="No compatible"):
+        _validate(_StubSlowTokenizer(), backend="auto")

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -1030,6 +1030,7 @@ class SamplingParams(
 
         from vllm.v1.structured_output.backend_guidance import (
             has_guidance_unsupported_json_features,
+            is_guidance_tokenizer_supported,
             validate_guidance_grammar,
         )
         from vllm.v1.structured_output.backend_lm_format_enforcer import (
@@ -1050,6 +1051,13 @@ class SamplingParams(
                     " structured output backend. Please either use a more recent "
                     "Mistral model, the ['xgrammar', 'outlines'] "
                     "backends or tokenizer_mode='hf' instead."
+                )
+            if not is_guidance_tokenizer_supported(tokenizer):
+                raise VLLMValidationError(
+                    "The 'guidance' structured output backend only supports fast "
+                    "Hugging Face tokenizers and Tekken-based Mistral tokenizers. "
+                    "Please use the 'xgrammar' backend or configure a fast "
+                    "tokenizer instead."
                 )
             # TODO: ideally we would have the LLTokenizer here as Lark syntax
             # allows <|special_token|> and similar, see
@@ -1087,6 +1095,13 @@ class SamplingParams(
                 # are not supported in xgrammar.
 
                 skip_guidance = _is_non_tekken_mistral(tokenizer)
+                if not skip_guidance and not is_guidance_tokenizer_supported(tokenizer):
+                    raise VLLMValidationError(
+                        "No compatible structured output backend was found for "
+                        "this request. XGrammar rejected the constraint, and "
+                        "Guidance does not support this tokenizer. Configure a "
+                        "fast tokenizer or select a compatible backend explicitly."
+                    ) from None
 
                 # Check if schema has features unsupported by guidance
                 so_params = self.structured_outputs
@@ -1098,8 +1113,8 @@ class SamplingParams(
                     skip_guidance = has_guidance_unsupported_json_features(schema)
 
                 if skip_guidance:
-                    # Fall back to outlines if the tokenizer is non-tekken Mistral or
-                    # the schema contains features unsupported by guidance
+                    # Fall back to outlines for non-Tekken Mistral tokenizers or
+                    # schemas containing features unsupported by guidance.
                     validate_structured_output_request_outlines(self)
                     self.structured_outputs._backend = "outlines"
                 else:

--- a/vllm/v1/structured_output/backend_guidance.py
+++ b/vllm/v1/structured_output/backend_guidance.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 import torch
-from transformers import MistralCommonBackend
+from transformers import MistralCommonBackend, PreTrainedTokenizerFast
 
 from vllm.logger import init_logger
 from vllm.sampling_params import SamplingParams
@@ -31,6 +31,17 @@ else:
     llguidance_torch = LazyLoader("llguidance.torch", globals(), "llguidance.torch")
 
 logger = init_logger(__name__)
+
+
+def is_guidance_tokenizer_supported(tokenizer: Any) -> bool:
+    """Return whether GuidanceBackend can construct an LLTokenizer."""
+    if is_mistral_tokenizer(tokenizer):
+        return tokenizer.is_tekken
+    if isinstance(tokenizer, MistralCommonBackend):
+        from vllm.tokenizers.mistral import mistral_common_tekkenizer
+
+        return mistral_common_tekkenizer(tokenizer) is not None
+    return isinstance(tokenizer, PreTrainedTokenizerFast)
 
 
 def _walk_json_for_additional_properties(data: object):


### PR DESCRIPTION
## Purpose

Related to #51660.

Guidance only constructs its tokenizer adapter after a request reaches the
structured-output manager. For unsupported slow Hugging Face tokenizers, that
currently raises from EngineCore instead of returning a request validation error.

This change mirrors GuidanceBackend's actual tokenizer conversion paths during
request validation. Explicit `guidance` requests now reject unsupported
tokenizers before EngineCore initialization. When `auto` cannot use xgrammar, it
also excludes guidance for unsupported tokenizers without introducing a new
automatic fallback to outlines. Existing Mistral behavior is preserved, including
Tekken support and the non-Tekken auto fallback.

The controller snapshot found no related pull request or active ownership claim.

## Test Plan

- Run the structured-output request validation unit tests.
- Run the repository's Ruff checks and formatting check on the changed files.
- Run the applicable typo, SPDX header, forbidden-import, and diff checks.

## Test Result

- `tests/v1/structured_output/test_validation.py`: 10 passed.
- Ruff check: passed.
- Ruff format check: passed; all 3 files already formatted.
- Typos, SPDX header, forbidden-import, and `git diff --check`: passed.
- Full pre-commit was not run because an uncached hook would require network
  access in the controller-isolated workspace.

This is a request-validation-only change and does not alter model output, so no
model evaluation was run. It does not address the separate xgrammar or outlines
failures described in the issue.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

