### PR TITLE
[Perf][Nemotron] Skip redundant latent-MoE all-reduce at TP>1 (~13% decode win)

### DIFF
--- a/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
+++ b/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
@@ -470,9 +470,18 @@ class MoERunner(MoERunnerInterface):
         Latent MoE output transforms may contain non-linear ops, e.g. RMSNorm.
         TP partial routed outputs must be summed in latent space before such
         transforms are applied.
+
+        A transform that commutes with the TP sum is exempt: if
+        ``sum_r T(x_r) == T(sum_r x_r)``, applying the transform to the local
+        partial output and letting the existing late all-reduce sum the
+        combined result is equivalent, and costs one collective instead of two.
+        Such a transform opts out by setting ``reduce_commutative = True``.
+        The default is False, so transforms that do not declare themselves
+        keep being reduced early.
         """
         if (
             self.routed_output_transform is not None
+            and not getattr(self.routed_output_transform, "reduce_commutative", False)
             and not self.moe_config.is_sequence_parallel
             and (self.moe_config.tp_size > 1 or self.moe_config.ep_size > 1)
             and not fused_output_is_reduced

--- a/vllm/model_executor/models/nemotron_h.py
+++ b/vllm/model_executor/models/nemotron_h.py
@@ -199,6 +199,11 @@ class NemotronHMoE(nn.Module):
                 disable_tp=self.is_sequence_parallel,
                 prefix=f"{prefix}.fc2_latent_proj",
             )
+            # A bias-free linear transform commutes with the tensor-parallel sum,
+            # since sum_r W x_r == W sum_r x_r, so the routed output can be reduced
+            # once after the transform instead of twice. With a bias it does not:
+            # sum_r (W x_r + b) == W sum_r x_r + R*b, so the early reduce is kept.
+            self.fc2_latent_proj.reduce_commutative = not config.mlp_bias
         else:
             self.fc1_latent_proj = None
             self.fc2_latent_proj = None

--- a/vllm/model_executor/models/nemotron_h.py
+++ b/vllm/model_executor/models/nemotron_h.py
@@ -44,6 +44,7 @@ from vllm.model_executor.layers.linear import (
     QKVParallelLinear,
     ReplicatedLinear,
     RowParallelLinear,
+    UnquantizedLinearMethod,
 )
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
 from vllm.model_executor.layers.mamba.mamba_mixer2 import MambaMixer2
@@ -199,11 +200,17 @@ class NemotronHMoE(nn.Module):
                 disable_tp=self.is_sequence_parallel,
                 prefix=f"{prefix}.fc2_latent_proj",
             )
-            # A bias-free linear transform commutes with the tensor-parallel sum,
-            # since sum_r W x_r == W sum_r x_r, so the routed output can be reduced
-            # once after the transform instead of twice. With a bias it does not:
-            # sum_r (W x_r + b) == W sum_r x_r + R*b, so the early reduce is kept.
-            self.fc2_latent_proj.reduce_commutative = not config.mlp_bias
+            # A bias-free, unquantized linear commutes with the TP sum
+            # (sum_r W x_r == W sum_r x_r), so one reduce after the transform
+            # suffices. Test the layer, not the model-wide `quant_config`: ModelOpt
+            # excludes the latent projections, so quantized checkpoints still get
+            # an UnquantizedLinearMethod here.
+            self.fc2_latent_proj.reduce_commutative = (
+                not config.mlp_bias
+                and isinstance(
+                    self.fc2_latent_proj.quant_method, UnquantizedLinearMethod
+                )
+            )
         else:
             self.fc1_latent_proj = None
             self.fc2_latent_proj = None


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

**Nemotron-3 decode regressed ~14% between v0.26.0 and v0.27.x at TP>1. This PR restores it.** The mechanism is generic but `NemotronH` is the only model that opts in, so it is the only one whose behaviour changes. No existing issue found.

| tp4, concurrency 1, inter-token latency | v0.26.0 | v0.27.1 | + this PR |
|---|---|---|---|
| Super 120B-A12B BF16 (n=4/arm) | 4.07 ms | 4.64 ms (**+13.8%**) | **4.08 ms** (+0.15%) |
| Ultra 550B-A55B NVFP4 | 6.86 ms† | 7.21 ms | **6.79 ms** (−5.8% same-node) |

† cross-node, directional only — see Test Result.

### Root cause

[`_maybe_reduce_routed_output_before_transform()`](https://github.com/vllm-project/vllm/blob/d4c24e6f5d1864bc81ad0769097e00b9042178ca/vllm/model_executor/layers/fused_moe/runner/moe_runner.py#L434-L453) (added in v0.27.0rc1) all-reduces the routed output in latent space before the transform is applied, and [the combined output is all-reduced again](https://github.com/vllm-project/vllm/blob/d4c24e6f5d1864bc81ad0769097e00b9042178ca/vllm/model_executor/layers/fused_moe/runner/moe_runner.py#L455-L495) on the late path ([call site](https://github.com/vllm-project/vllm/blob/d4c24e6f5d1864bc81ad0769097e00b9042178ca/vllm/model_executor/layers/fused_moe/runner/moe_runner.py#L742-L749)).
So **every latent-MoE layer at TP>1 or EP>1 issues two tensor-parallel all-reduces per token instead of one.** The function does not exist in v0.26.0.
`NemotronH` is hit because it passes [`fc2_latent_proj` as its `routed_output_transform`](https://github.com/vllm-project/vllm/blob/d4c24e6f5d1864bc81ad0769097e00b9042178ca/vllm/model_executor/models/nemotron_h.py#L226).

### The fix

Adds an opt-in `reduce_commutative` attribute, **defaulting to `False` so every model that does not set it is byte-for-byte unchanged.**
`NemotronH` sets it when the transform is bias-free **and** unquantised — then `sum_r W x_r == W sum_r x_r`, so reducing once *after* the transform is equivalent and costs one collective instead of two.
Quantisation is judged from the **constructed layer**, not the model-wide `quant_config`: ModelOpt excludes the latent projections, so a quantised Nemotron-3 checkpoint has `quant_config != None` yet still gets an `UnquantizedLinearMethod` here. Testing the model-wide config would disable this on exactly the quantised checkpoints where the regression is largest.

**Kimi K3 is unchanged.** Its [`KimiRoutedOutputTransform`](https://github.com/vllm-project/vllm/blob/d4c24e6f5d1864bc81ad0769097e00b9042178ca/vllm/models/kimi_k3/nvidia/model.py#L295-L302) wraps an `RMSNorm`, never sets the flag, and keeps both collectives.

<details>
<summary>Interactions checked, and the alternative considered</summary>

- [`skip_final_all_reduce`](https://github.com/vllm-project/vllm/blob/d4c24e6f5d1864bc81ad0769097e00b9042178ca/vllm/model_executor/layers/fused_moe/runner/moe_runner.py#L468-L473) asserts against [`_fused_output_is_reduced`](https://github.com/vllm-project/vllm/blob/d4c24e6f5d1864bc81ad0769097e00b9042178ca/vllm/model_executor/layers/fused_moe/runner/moe_runner.py#L403-L408), a combine-kernel property this PR does not touch.
- For `NemotronH`, `reduce_results` defaults to `True` — the [`reduce_results=False`](https://github.com/vllm-project/vllm/blob/d4c24e6f5d1864bc81ad0769097e00b9042178ca/vllm/model_executor/models/nemotron_h.py#L180) nearby is on *shared_experts*, not the FusedMoE — so the late all-reduce always fires.
- Runtime check on Ultra NVFP4: `quant_config=ModelOptMixedPrecisionConfig` (non-None) while `fc2_latent_proj.quant_method=UnquantizedLinearMethod`, confirming the layer-level test is the correct one.
- Alternative: [`LatentMoERunner`](https://github.com/vllm-project/vllm/blob/d4c24e6f5d1864bc81ad0769097e00b9042178ca/vllm/models/kimi_k3/nvidia/latent_moe_runner.py#L52) already fuses to one collective, but it now lives under `vllm/models/kimi_k3/` (moved by [#50678](https://github.com/vllm-project/vllm/pull/50678)) and reads [`transform.norm`/`up_proj`](https://github.com/vllm-project/vllm/blob/d4c24e6f5d1864bc81ad0769097e00b9042178ca/vllm/models/kimi_k3/nvidia/latent_moe_runner.py#L216-L224), which `NemotronH` does not have. Happy to go that way if preferred.

</details>

## Test Plan

4x GB300 (sm_103), stock upstream containers `vllm/vllm-openai:v0.26.0` and `:v0.27.1`, no NCCL env overrides. Public checkpoints [Super BF16](https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16) and [Ultra NVFP4](https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4). Every flag exists in both releases, so arms differ only by vLLM version; the `+ this PR` arms patch the same container in place.

```bash
vllm serve <ckpt> --served-model-name nemotron --gpu-memory-utilization 0.9 \
    --tensor-parallel-size 4 --max-model-len 2200 --max-num-seqs 128 \
    --attention-backend FLASHINFER --trust-remote-code --enable-prefix-caching \
    --mamba-cache-mode align --enable-chunked-prefill --max-num-batched-tokens 16384

aiperf profile --url localhost:8000 --model nemotron --tokenizer <ckpt> \
    --endpoint-type completions --tokenizer-trust-remote-code --streaming \
    --extra-inputs "min_tokens:1000" --extra-inputs "max_tokens:1000" \
    --extra-inputs "ignore_eos:true" --synthetic-input-tokens-mean 1000 \
    --output-tokens-mean 1000 --concurrency $C --request-count $((5*C)) --warmup-request-count 1

lm_eval --model local-completions --tasks gsm8k --num_fewshot 5 --batch_size 32 \
    --model_args model=nemotron,base_url=http://localhost:8000/v1/completions,num_concurrent=32,tokenized_requests=False,tokenizer=<ckpt>
```

## Test Result

### Super BF16, tp4, c=1 — four samples per arm, two server loads each

| arm | ITL (ms) | n | spread | tok/s per user |
|---|---|---|---|---|
| v0.26.0 | 4.07 | 4 | 0.03 | 245.56 |
| v0.27.1 | **4.64** | 4 | 0.02 | 215.73 |
| + this PR | **4.08** | 4 | 0.01 | 245.21 |

Regression **+13.8% ITL / −12.2% tok/s**; with this PR **+0.15% vs v0.26.0**. The v0.26.0 and patched arms ran on *different* nodes and still agree to 0.15%.

### Concurrency sweep, Super BF16 (single run per point)

| ITL (ms) | c=1 | c=8 | c=32 | c=64 |
|---|---|---|---|---|
| v0.26.0 | 4.08 | 6.23 | 9.88 | 12.18 |
| v0.27.1 | 4.60 | 6.63 | 10.39 | 13.09 |
| + this PR | **4.07** | **6.11** | **9.88** | **12.21** |

Restored at every concurrency. The win shrinks as batch grows — at small batch the collectives are latency-bound so their *count* dominates; at large batch they are bandwidth-bound and the surviving reduce (4096-wide) exceeds the removed one (1024-wide). Not a trade-off at any measured point.

### Ultra NVFP4, tp4, c=1 — confirms the fix on a quantised checkpoint

| arm | ITL (ms) | n | tok/s per user | vs v0.26.0 |
|---|---|---|---|---|
| v0.26.0 | 6.86 | 3 | 145.68 | — |
| v0.27.1 | 7.21 | 2 | 138.71 | +5.0% |
| + this PR | **6.79** | 3 | **147.22** | **−1.1%** |

**v0.27.1 → +this PR is same-node, same-container: −5.8% ITL / +6.1% tok/s.** That is the quantitative claim here.
Read the v0.26.0 row directionally: it is cross-node, and this checkpoint shows ~8% node-to-node variation (v0.27.1 stock measured 7.78 and 7.20 ms on two nodes, stable within each, identical clock/power caps — likely co-tenancy on the 72-GPU chassis). Super BF16 has no such issue, reproducing to 0.03 ms across four nodes.

### Controls

| control | result |
|---|---|
| tp1 negative control (early reduce is TP-gated) | 6.22 vs 6.20 ms, **−0.3% — no difference** |
| node-to-node variation, Super BF16 | 4.63 vs 4.60 ms, **0.65%** |

### Accuracy — gsm8k, 5-shot, greedy, tp4, full 1319 questions

| checkpoint | arm | flexible-extract | strict-match |
|---|---|---|---|
| Super BF16 | v0.27.1 | 0.9310 ± 0.0070 | 0.9181 ± 0.0076 |
| Super BF16 | + this PR | 0.9318 ± 0.0069 | 0.9166 ± 0.0076 |
| Ultra NVFP4 | v0.27.1 | 0.9363 ± 0.0067 | 0.9340 ± 0.0068 |
| Ultra NVFP4 | + this PR | 0.9431 ± 0.0064 | 0.9401 ± 0.0065 |

All four deltas within one standard error. Bitwise identity is not expected — moving the all-reduce past a linear map changes float summation order. The Ultra pair covers the quantised case this PR newly enables.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.

No doc update needed: no public API change, no new model; the `reduce_commutative` contract is documented in the guard's docstring.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://docs.vllm.ai/en/latest/contributing>**
