### PR TITLE
[Bugfix] Unwrap multimodal target only when needed in DSpark

### DIFF
--- a/vllm/v1/worker/gpu/spec_decode/dspark/utils.py
+++ b/vllm/v1/worker/gpu/spec_decode/dspark/utils.py
@@ -54,7 +54,11 @@ def load_dspark_model(target_model: nn.Module, vllm_config: VllmConfig) -> nn.Mo
         if hasattr(target_model, "get_language_model")
         else target_model
     )
-    target_inner = target_language_model.model
+    # A multimodal target whose get_language_model() already returns the inner
+    # decoder (e.g. Muse Glimmer) has no further `.model` to unwrap. The dflash
+    # path applies the same rule; without it DSpark raises AttributeError before
+    # any weights are shared.
+    target_inner = getattr(target_language_model, "model", target_language_model)
     draft_inner = draft_model.model
 
     target_embed = getattr(target_inner, "embed_tokens", None)


### PR DESCRIPTION
## Purpose
`load_dspark_model()` unconditionally calls `target_language_model.model`. For a multimodal target whose `get_language_model()` already returns the inner decoder, there is no further `.model` (e.g. Muse Glimmer), so DSpark speculative decoding can't start at all.

My comment didn't make it in the original Muse Glimmer PR (https://github.com/vllm-project/vllm/pull/51655#discussion_r3774076590) where this exact logic was added on the DFlash path. 

Ultimate goal is to support DSpark together with Muse Glimmer.

## Test Plan
```
vllm serve /models/Muse-Glimmer-30B-NVFP4 \
  --max-model-len 4096 --max-num-seqs 1 --gpu-memory-utilization 0.45 \
  --speculative-config '{"method":"dspark","model":"abstract-extraordinary/Muse-Glimmer-30B-DSpark","num_speculative_tokens":16}'
```

## Test Result
### Before
```
File "vllm/v1/worker/gpu/spec_decode/dspark/speculator.py", line 84, in load_draft_model
  model = load_dspark_model(target_model, self.vllm_config)
File "vllm/v1/worker/gpu/spec_decode/dspark/utils.py", line 61, in load_dspark_model
  target_inner = target_language_model.model
AttributeError: 'MuseGlimmerModel' object has no attribute 'model'
```
### After
```
Resolved architecture: Qwen3DSparkModel
speculative_config=SpeculativeConfig(method='dspark', num_spec_tokens=16)
Application startup complete.
SpecDecoding metrics: Mean acceptance length: 4.90, Accepted: 113 tokens, Drafted: 464 tokens
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

