### PR TITLE
[Bugfix][MoE] Disable TRTLLM NVFP4 monolithic backend for non-gated MoE (corrupt output on SM100)

### DIFF
--- a/vllm/model_executor/layers/fused_moe/experts/trtllm_nvfp4_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/trtllm_nvfp4_moe.py
@@ -213,8 +213,13 @@ class TrtLlmNvFp4ExpertsBase:
 
     @staticmethod
     def _supports_no_act_and_mul() -> bool:
-        """Supports non-gated MoE (i.e. Nemotron-Nano)."""
-        return True
+        """Non-gated MoE is disabled: semantically corrupt output on SM100.
+
+        See https://github.com/vllm-project/vllm/issues/52308. Backend
+        selection falls back to FLASHINFER_CUTLASS for non-gated (ReLU^2)
+        models such as Nemotron-Nano; gated models are unaffected.
+        """
+        return False
 
     @staticmethod
     def _supports_quant_scheme(


### PR DESCRIPTION
## Purpose

Immediate mitigation for #52308: the `FLASHINFER_TRTLLM` monolithic NVFP4 MoE backend produces **semantically corrupt output for non-gated (ReLU²) MoE models on SM100** (e.g. `nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-NVFP4` on B200 — fluent but wrong output, 100% deterministic under greedy decoding).

This PR quarantines only the non-gated variant: `TrtLlmNvFp4ExpertsMonolithic._supports_no_act_and_mul()` returns False, so backend auto-selection falls through to `FLASHINFER_CUTLASS`, which is numerically correct for these models on both SM100 and SM120. The predicate is consulted only when `moe_config.is_act_and_mul` is False (`modular_kernel.py`), so **gated MoE models keep the monolithic backend unchanged**.

The kernel-level root cause inside the monolithic bundle (pad/scale-interleave contract, non-gated scale plumbing, in-kernel `n_group=1` routing — see the issue analysis) remains open and tracked in #52308; this change restores correct output for affected models by default while that is investigated.

## Evidence / model evaluation

A/B/A on the same B200, same checkpoint, vLLM v0.27.0, TP=1, greedy (`temperature=0`), prompt `The capital of France is`:

| Run | MoE backend | Top-1 logprob | Semantic probes (Paris / 2+2 / sequence) |
|---|---|---|---|
| A (default) | `FLASHINFER_TRTLLM` monolithic | `' **' -2.0724` (no content token in top-5) | 0/3 |
| B | `flashinfer_cutlass` (what this PR makes the default for non-gated) | `' Paris' -0.0278` | 3/3 |
| A′ (revert) | `FLASHINFER_TRTLLM` monolithic | broken logprobs reproduce **bit-identically** (10 decimals) | 0/3 |

The same checkpoint is correct out-of-the-box on SM120 (RTX PRO 4500 Blackwell), which never selects the monolithic path (`_supports_current_device()` requires `is_device_capability_family(100)`).

## Test plan

- On-GPU behavioral verification above: this PR's effect is exactly equivalent to `--moe-backend=flashinfer_cutlass`, which was verified to fully heal the model on B200 (and reverting reproduces the failure deterministically).
- Selection can be confirmed in server logs: `Using 'flashinfer_cutlass' NvFp4 MoE backend out of potential backends: [...]` replaces the trtllm selection for non-gated models; no log change for gated models.
- Change is a capability predicate flip + docstring only; no kernel or numeric code touched. I did not run the full unit suite locally (dev box has no CUDA GPU); happy to add/extend an oracle selection test asserting non-gated ⇒ not `FLASHINFER_TRTLLM` if maintainers want it in this PR rather than alongside the root-cause fix.

## Non-duplication

- `gh pr list --search "52308 in:body"` → none.
- Searched open PRs for `nvfp4 moe nemotron` and `trtllm_fp4_block_scale_moe`: nearest matches are #36039 (adds trtllm MoE unit tests — complementary) and historical #36725 ("Fix TRTLLM NVFP4 Routing Kernel Precision" — prior art showing this kernel family has had routing-precision issues; a revert draft #37945 exists). No open PR quarantines the non-gated monolithic path or otherwise addresses #52308.

## AI assistance disclosure

This change was developed with AI assistance (Claude Code). The submitter has reviewed every changed line, performed the on-GPU A/B/A verification, and can defend the change end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
