### PR TITLE
[CI Perf] Trimming the tests for the hybrid models

### DIFF
--- a/tests/kernels/mamba/test_mamba_ssm_ssd.py
+++ b/tests/kernels/mamba/test_mamba_ssm_ssd.py
@@ -200,7 +200,7 @@ def generate_continuous_batched_examples(
 
 @pytest.mark.parametrize("itype", [torch.float32, torch.bfloat16])
 @pytest.mark.parametrize("n_heads", [4, 16, 32])
-@pytest.mark.parametrize("d_head", [5, 8, 32, 128])
+@pytest.mark.parametrize("d_head", [5, 32, 128])
 @pytest.mark.parametrize("seq_len_chunk_size", [(112, 16), (128, 32)])
 def test_mamba_chunk_scan_single_example(d_head, n_heads, seq_len_chunk_size, itype):
     # this tests the kernels on a single example (bs=1)
@@ -280,8 +280,6 @@ def test_mamba_chunk_scan_single_example(d_head, n_heads, seq_len_chunk_size, it
             [(4, 4), (4, 4), (4, 4), (4, 4)],
         ),  # chunk_size larger than cont batches
         (64, 8, 5, [(64, 32, 16, 8, 8)]),
-        # large-ish chunk_size (256)
-        (64, 256, 1, [(5,), (1,), (1,), (1,)]),  # irregular sizes with small sequences
         (
             64,
             256,


### PR DESCRIPTION
## Purpose

`kernels-mamba-test` sits right at the 40-min Buildkite budget. Build 82371 was cancelled at 40:13 with 976/1041 tests finished due to timeout; `test_mamba_ssm_ssd.py` alone contributes ~1378s (~23 min) — 25 of its 94 tests exceed 30s each. This PR removes two parametrization entries in that file whose coverage is made redoundant by neighbouring cases or existing values, buying **~347s** (~5.8 min, measured on build 82371) of headroom without losing kernel coverage.

The runtime is not uniformly distributed. From build 82371's timing analysis:

| File | Total | Count | Avg |
|---|---:|---:|---:|
| `test_mamba_ssm_ssd.py` | **1377.6 s** | 94 | 14.66 s |
| `test_replayssm_prefill_decode_equivalence_mamba2.py` | 235.7 s (partial) | 12 | 19.65 s |
| `test_mamba_ssm.py` | 214.3 s | 304 | 0.70 s |
| `test_memcpy_u64_tiled.py` | 162.0 s | 180 | 0.90 s |
| `test_precopy_mamba_align.py` | 134.1 s | 147 | 0.91 s |
| `test_causal_conv1d.py` | 123.4 s | 164 | 0.75 s |

Two files (`test_mamba_ssm_ssd.py` and `test_replayssm_prefill_decode_equivalence_mamba2.py`) account for ~27 min of the 40-min budget. Within `test_mamba_ssm_ssd.py`, 25 of 94 tests exceed 30 s each and together consume **~1237 s (~21 min)**. The observed top-10 individual tests each cost **60–77 s**:

| Wallclock | Top-10 Test |
|---:|---|
| 76.9 s | `test_mamba_ssm_ssd::test_mamba_chunk_scan_cont_batch[seq_len_chunk_size_cases0-5-4-itype0]` |
| 74.0 s | `test_mamba_ssm_ssd::test_mamba_chunk_scan_cont_batch[seq_len_chunk_size_cases6-5-4-itype0]` |
| 70.3 s | `test_mamba_ssm_ssd::test_mamba_chunk_scan_cont_batch[seq_len_chunk_size_cases4-5-4-itype0]` |
| 68.1 s | `test_mamba_ssm_ssd::test_mamba_chunk_scan_cont_batch_prefill_chunking[seqlens0-8]` |
| 63.3 s | `test_mamba_ssm_ssd::test_mamba_chunk_scan_cont_batch[seq_len_chunk_size_cases6-16-4-itype0]` |
| 62.6 s | `test_mamba_ssm_ssd::test_mamba_chunk_scan_cont_batch[seq_len_chunk_size_cases0-32-4-itype0]` |
| 62.4 s | `test_mamba_ssm_ssd::test_mamba_chunk_scan_cont_batch[seq_len_chunk_size_cases0-16-4-itype0]` |
| 60.9 s | `test_mamba_ssm_ssd::test_mamba_chunk_scan_cont_batch_prefill_chunking[seqlens0-256]` |
| 60.0 s | `test_mamba_ssm_ssd::test_mamba_chunk_scan_cont_batch[seq_len_chunk_size_cases6-32-4-itype0]` |
| 54.2 s | `test_mamba_ssm_ssd::test_mamba_chunk_scan_cont_batch[seq_len_chunk_size_cases4-32-4-itype0]` |

This PR therefore targets only entries in `test_mamba_ssm_ssd.py`'s slow tail: the removed `cont_batch case[4]` contains three top-10 slowest individual tests (70.3 s, 54.2 s, 52.4 s), and the removed `d_head=8` group contributes four tests to the top-30 at 33–46 s each.

## What is removed and why

### 1. `test_mamba_chunk_scan_cont_batch`: drop `seq_len_chunk_size_cases[4]`

`case[4] = (64, 256, 1, [(5,), (1,), (1,), (1,)])` — 1 example, 4 batches of 1-5 tokens under `chunk_size=256`.

Strict subset of `case[5] = (64, 256, 2, [(5, 30), (1, 2), (1, 2), (1, 2)])` on every coverage axis:

| Axis | case[4] | case[5] |
|---|:-:|:-:|
| Sub-chunk sequences (all tokens < chunk_size) | ✓ | ✓ |
| Mid-physical-chunk sequence boundaries | · | ✓ |
| Multi-example continuous batching | · | ✓ (2 examples) |
| State passing across batches | ✓ | ✓ |

Case[5] catches everything case[4] catches, plus mid-chunk sequence boundaries and multi-example batching.

**Measured savings (build 82371):** 182.58 s across 6 tests. Three of those hit the observed top-10 slowest (70.3 s, 54.2 s, 52.4 s — all `n_heads=4`); the other three (`n_heads=8`) run at ≤3.6 s each.

### 2. `test_mamba_chunk_scan_single_example`: drop `d_head=8`

`d_head` currently sweeps `[5, 8, 32, 128]`:

`d_head=8` is the weakest independent value: `5` uniquely covers the unaligned case, and `32`/`128` cover the power-of-2 regime at two scales. `d_head=8` sits between them in shape without exercising a distinct autotune tile size that `32` doesn't already touch.

Empirically confirmed against the underlying kernels inc`vllm/model_executor/layers/mamba/ops/`:

- No `hdim == 8` / `head_dim == 8` branches in `ssd_chunk_scan.py`, `ssd_chunk_state.py`, or `ssd_bmm.py`.
- Autotune `BLOCK_SIZE_M/N` configs in those kernels start at ≥ 32; head-dim is padded to the block size and masked, so `hdim=5`, `hdim=8`, `hdim=32` all execute the same masked path. `hdim=5` already exercises the "hdim < BLOCK_SIZE" regime that `hdim=8` was covering.

This removal captures four tests in the observed top-30 slowest (`d_head=8, n_heads=4` variants at 33-46s each).

**Measured savings (build 82371):** 164.68 s across 12 tests. Four `n_heads=4` variants dominate at 33–46 s each (all in the observed top-30); the other 8 (`n_heads ∈ {16, 32}`) run at ~1 s each.

## Test Plan

- [x] `pytest -v tests/kernels/mamba/test_mamba_ssm_ssd.py` — all remaining tests pass on H200.
- [x] Test-count deltas verified with `pytest --collect-only` (see below).
  
## Test Result


### Verified test-count deltas (`pytest --collect-only`)

Ran `pytest --collect-only tests/kernels/mamba/test_mamba_ssm_ssd.py` on `main` and on this branch:

| Test | main | branch | Δ |
|---|---:|---:|---:|
| `test_mamba_chunk_scan_single_example` | 48 | 36 | **−12** |
| `test_mamba_chunk_scan_cont_batch` | 42 | 36 | **−6** |
| `test_mamba_chunk_scan_cont_batch_prefill_chunking` | 4 | 4 | 0 |
| **Total** | **94** | **76** | **−18** |

The 18 removed test IDs (diff of the two collected sets):

**`test_mamba_chunk_scan_single_example` — `d_head=8` group (12 tests)**

```
[seq_len_chunk_size0-8-{4,16,32}-itype{0,1}]   (6 tests)
[seq_len_chunk_size1-8-{4,16,32}-itype{0,1}]   (6 tests)
```

**`test_mamba_chunk_scan_cont_batch` — `cases4` group (6 tests)**

Pre-trim `cases4 = (64, 256, 1, [(5,), (1,), (1,), (1,)])`. Post-trim
collection re-indexes (pre `cases5` → post `cases4`, pre `cases6` → post
`cases5`) — those are renames, not removals. The 6 actually-removed IDs:

```
[seq_len_chunk_size_cases4-{5,16,32}-{4,8}-itype0]
```

## Duplicate work check

**Open-PR search:**

```
gh pr list --repo vllm-project/vllm --state open --search "test_mamba_ssm_ssd"
gh pr list --repo vllm-project/vllm --state open --search "kernels-mamba-test timeout"
gh pr list --repo vllm-project/vllm --state open --search "CI Perf mamba"
gh pr list --repo vllm-project/vllm --state open --search "mamba parametrize"
```

No open PR trims `tests/kernels/mamba/test_mamba_ssm_ssd.py` or targets the `kernels-mamba-test` timeout.

**Prior in-tree work:**

- **#26538** (Fardin Hoque, Amazon) — `[CI Perf] Prune Tests in kernel/mamba` (merged as `577c72a227`). Pruned the same file's parametrization once before, removing overlapping combinations from `test_mamba_chunk_scan_cont_batch` and simplifying other kernel tests. This PR continues the same work on a *disjoint* set of remaining redundancies — the entries removed here were not touched by #26538, and the new build-82371 timing data (top-K analysis in `trim_testing.md`) identifies them as the highest-leverage remaining targets.
  
  
## AI assistance

This PR was drafted with Claude Code assistance.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

