### PR TITLE
[bot] Enable google/gemma-4-E2B-it-qat-mobile-ct inference on Intel XPU

### DIFF
--- a/vllm/model_executor/kernels/linear/__init__.py
+++ b/vllm/model_executor/kernels/linear/__init__.py
@@ -55,6 +55,7 @@ from vllm.model_executor.kernels.linear.mixed_precision.triton_w4a16 import (
     TritonW4A16LinearKernel,
 )
 from vllm.model_executor.kernels.linear.mixed_precision.xpu import (
+    XPUDequantLinearKernel,
     XPUW4A8IntLinearKernel,
     XPUwNa16LinearKernel,
 )
@@ -226,6 +227,7 @@ _POSSIBLE_KERNELS: dict[PlatformEnum, list[type[MPLinearKernel]]] = {
     PlatformEnum.XPU: [
         XPUW4A8IntLinearKernel,
         XPUwNa16LinearKernel,
+        XPUDequantLinearKernel,
     ],
     PlatformEnum.CPU: [
         Dynamic4bitLinearKernel,

--- a/vllm/model_executor/kernels/linear/mixed_precision/__init__.py
+++ b/vllm/model_executor/kernels/linear/mixed_precision/__init__.py
@@ -33,6 +33,7 @@ from vllm.model_executor.kernels.linear.mixed_precision.triton_w4a16 import (
     TritonW4A16LinearKernel,
 )
 from vllm.model_executor.kernels.linear.mixed_precision.xpu import (
+    XPUDequantLinearKernel,
     XPUW4A8IntLinearKernel,
     XPUwNa16LinearKernel,
 )
@@ -50,5 +51,6 @@ __all__ = [
     "MarlinLinearKernel",
     "TritonW4A16LinearKernel",
     "XPUW4A8IntLinearKernel",
+    "XPUDequantLinearKernel",
     "XPUwNa16LinearKernel",
 ]

--- a/vllm/model_executor/kernels/linear/mixed_precision/xpu.py
+++ b/vllm/model_executor/kernels/linear/mixed_precision/xpu.py
@@ -80,13 +80,17 @@ class XPUwNa16LinearKernel(MPLinearKernel):
         bias: torch.Tensor | None = None,
     ) -> torch.Tensor:
         reshaped_x = x.reshape(-1, x.shape[-1])
+        group_size = self.config.group_size
+        if group_size == -1:
+            # Channelwise: group_size = K (input dimension)
+            group_size = reshaped_x.shape[-1]
         out = torch.ops._xpu_C.int4_gemm_w4a16(
             reshaped_x,
             layer.weight_packed.t(),
             bias,
             layer.weight_scale,
             layer.weight_zero_point,
-            self.config.group_size,
+            group_size,
             layer.g_idx,
         )
         return out
@@ -199,3 +203,143 @@ class XPUW4A8IntLinearKernel(MPLinearKernel):
         )
 
         return out.to(x.dtype)
+
+
+class XPUDequantLinearKernel(MPLinearKernel):
+    """Generic dequantization-based fallback kernel for XPU.
+
+    For 2-bit weights: re-packs into 4-bit format and uses int4_gemm_w4a16.
+    For 8-bit weights: dequantizes to bf16 at load time (small layers only).
+    """
+
+    @classmethod
+    def get_min_capability(cls) -> int:
+        return -1
+
+    @classmethod
+    def can_implement(cls, c: MPLinearLayerConfig) -> tuple[bool, str | None]:
+        if not current_platform.is_xpu():
+            return False, "XPUDequantLinear only supported on XPU"
+        if c.act_type not in (torch.bfloat16, torch.float16):
+            return False, "XPUDequantLinear only supports BF16/FP16 activations"
+        return True, None
+
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        import sys
+        num_bits = self.config.weight_type.size_bits
+        w_packed = layer.weight_packed.data  # [out, in_packed] int32
+        print(f'[DEQUANT] bits={num_bits}, w_packed={list(w_packed.shape)}, dtype={w_packed.dtype}', file=sys.stderr, flush=True)
+
+        if num_bits <= 4:
+            # Re-pack into 4-bit format for int4_gemm_w4a16
+            # First unpack from N-bit to individual values
+            pack_factor = 32 // num_bits
+            mask = (1 << num_bits) - 1
+            out_features = w_packed.shape[0]
+            in_packed = w_packed.shape[1]
+            in_features = in_packed * pack_factor
+
+            w_int32 = w_packed.to(torch.int32)
+            shifts = torch.arange(
+                0, 32, num_bits, dtype=torch.int32, device=w_packed.device
+            )
+            w_unpacked = ((w_int32.unsqueeze(-1) >> shifts) & mask).reshape(
+                out_features, in_features
+            )
+
+            if num_bits == 2:
+                # Re-center 2-bit values for 4-bit zero point.
+                # 2-bit symmetric: zp=2, values [0,1,2,3] → dequant [-2,-1,0,1]*s
+                # 4-bit oneDNN:    zp=8, values [0..15]   → dequant [v-8]*s
+                # To preserve: (v2-2)*s = (v4-8)*s  →  v4 = v2 + 6
+                w_unpacked = w_unpacked + 6
+
+            # Re-pack into 4-bit (int4) packed format [out, in/8] int32
+            new_pack_factor = 8  # 32 / 4
+            if in_features % new_pack_factor != 0:
+                # Pad to multiple of 8
+                pad_size = new_pack_factor - (in_features % new_pack_factor)
+                w_unpacked = torch.nn.functional.pad(
+                    w_unpacked, (0, pad_size), value=0
+                )
+                in_features = w_unpacked.shape[1]
+
+            w_4bit = w_unpacked.reshape(out_features, in_features // new_pack_factor, new_pack_factor)
+            shifts_4 = torch.arange(0, 32, 4, dtype=torch.int32, device=w_packed.device)
+            w_repacked = ((w_4bit & 0xF) << shifts_4[None, None, :]).sum(dim=2).to(torch.int32)
+
+            replace_parameter(
+                layer,
+                self.w_q_name,
+                torch.nn.Parameter(w_repacked, requires_grad=False),
+            )
+
+            # Transpose scales for oneDNN format [n, groups] -> [groups, n]
+            layer.weight_scale.data = layer.weight_scale.t().contiguous()
+
+            # Set zero point (always 8 for int4 kernel, regardless of
+            # original num_bits, since we re-center values during repacking)
+            if not self.config.zero_points or not hasattr(layer, "weight_zero_point"):
+                weight_zero_point = torch.tensor(
+                    [8], dtype=torch.int8, device=w_packed.device
+                )
+                layer.weight_zero_point = Parameter(
+                    weight_zero_point, requires_grad=False
+                )
+            else:
+                layer.weight_zero_point.data = layer.weight_zero_point.t().contiguous()
+
+            if hasattr(layer, 'g_idx') and layer.g_idx is not None:
+                layer.g_idx.data = layer.g_idx.t().contiguous()
+            else:
+                layer.g_idx = None
+
+            self._use_int4 = True
+            self._in_features = in_features
+        else:
+            # 8-bit: dequantize to bf16 (for small layers like per_layer_*)
+            out_features = w_packed.shape[0]
+
+            # For int-quantized 8-bit, weight is stored as int8 directly
+            w_float = w_packed.to(torch.float32)
+            scale = layer.weight_scale.data
+            if self.config.zero_points and hasattr(layer, "weight_zero_point"):
+                zp = layer.weight_zero_point.data.to(torch.float32)
+            else:
+                zp = torch.tensor(
+                    [128.0], dtype=torch.float32, device=w_packed.device
+                )
+            w_float = (w_float - zp) * scale.to(torch.float32)
+
+            act_dtype = self.config.act_type
+            replace_parameter(
+                layer,
+                self.w_q_name,
+                torch.nn.Parameter(w_float.to(act_dtype), requires_grad=False),
+            )
+            self._use_int4 = False
+
+    def apply_weights(
+        self,
+        layer: torch.nn.Module,
+        x: torch.Tensor,
+        bias: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        if getattr(self, '_use_int4', False):
+            reshaped_x = x.reshape(-1, x.shape[-1])
+            group_size = self.config.group_size
+            if group_size == -1:
+                group_size = self._in_features
+            out = torch.ops._xpu_C.int4_gemm_w4a16(
+                reshaped_x,
+                layer.weight_packed.t(),
+                bias,
+                layer.weight_scale,
+                layer.weight_zero_point,
+                group_size,
+                layer.g_idx,
+            )
+            return out
+        else:
+            w = layer.weight_packed
+            return torch.nn.functional.linear(x, w, bias)

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
@@ -160,7 +160,11 @@ class CompressedTensorsConfig(QuantizationConfig):
     ) -> "QuantizeMethodBase | None":
         if isinstance(layer, LinearBase):
             # collect schemes
-            quant_scheme = self.get_scheme(layer=layer, layer_name=prefix)
+            try:
+                quant_scheme = self.get_scheme(layer=layer,
+                                               layer_name=prefix)
+            except (ValueError, NotImplementedError):
+                quant_scheme = None
             input_tfms, output_tfms = get_linear_transform_schemes(
                 layer, prefix, self.transform_config, self.packed_modules_mapping
             )
@@ -183,7 +187,7 @@ class CompressedTensorsConfig(QuantizationConfig):
         if isinstance(layer, ParallelLMHead):
             try:
                 quant_scheme = self.get_scheme(layer=layer, layer_name=prefix)
-            except ValueError:
+            except (ValueError, NotImplementedError):
                 quant_scheme = None
             if quant_scheme is not None:
                 layer.scheme = quant_scheme
@@ -599,6 +603,32 @@ class CompressedTensorsConfig(QuantizationConfig):
         # use the per-layer format if defined, otherwise, use global format
         format = format if format is not None else self.quant_format
 
+        # XPU early fallback: for quantization types not supported by XPU
+        # kernels, fall back to WNA16 with dequantization at load time.
+        # This handles 2-bit and 4-bit pack-quantized weights.
+        # For int-quantized 8-bit (W8A8), return None to use unquantized
+        # since WNA16 assumes bit-packing which doesn't apply to int8.
+        if current_platform.is_xpu() and weight_quant is not None:
+            is_pack_quant = (format == CompressionFormat.pack_quantized.value)
+            is_int_quant = (format == CompressionFormat.int_quantized.value)
+
+            if is_int_quant and weight_quant.num_bits == 8:
+                # int-quantized 8-bit: store as unquantized (small layers)
+                return None
+
+            if (
+                (is_pack_quant or is_int_quant)
+                and weight_quant.num_bits in WNA16_SUPPORTED_BITS
+            ):
+                return CompressedTensorsWNA16(
+                    num_bits=weight_quant.num_bits,
+                    strategy=weight_quant.strategy,
+                    symmetric=weight_quant.symmetric,
+                    group_size=weight_quant.group_size,
+                    actorder=weight_quant.actorder,
+                    layer_name=layer_name,
+                )
+
         # Detect If Mixed Precision
         if self._is_nvfp4_format(weight_quant) and input_quant is None:
             return CompressedTensorsW4A16Fp4()
@@ -617,7 +647,8 @@ class CompressedTensorsConfig(QuantizationConfig):
 
         if (
             self._is_wNa16_group_channel(weight_quant, input_quant)
-            and (format == CompressionFormat.pack_quantized.value)
+            and (format in (CompressionFormat.pack_quantized.value,
+                            CompressionFormat.int_quantized.value))
             and (weight_quant.num_bits in WNA16_SUPPORTED_BITS)
         ):
             return CompressedTensorsWNA16(
@@ -762,6 +793,10 @@ class CompressedTensorsConfig(QuantizationConfig):
                 format=format,
                 layer_name=layer_name,
             )
+
+        if scheme is None:
+            # Falling back to UnquantizedLinearMethod
+            return None
 
         # Raise error if device does not support the scheme
         # (e.g. fp8 needs ada lovelace)

--- a/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_wNa16.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_wNa16.py
@@ -32,8 +32,8 @@ from vllm.scalar_type import scalar_types
 logger = init_logger(__name__)
 
 __all__ = ["CompressedTensorsWNA16"]
-WNA16_SUPPORTED_TYPES_MAP = {4: scalar_types.uint4b8, 8: scalar_types.uint8b128}
-WNA16_ZP_SUPPORTED_TYPES_MAP = {4: scalar_types.uint4, 8: scalar_types.uint8}
+WNA16_SUPPORTED_TYPES_MAP = {2: scalar_types.uint2b2, 4: scalar_types.uint4b8, 8: scalar_types.uint8b128}
+WNA16_ZP_SUPPORTED_TYPES_MAP = {2: scalar_types.uint2b2, 4: scalar_types.uint4, 8: scalar_types.uint8}
 WNA16_SUPPORTED_BITS = list(WNA16_SUPPORTED_TYPES_MAP.keys())
 
 

--- a/vllm/model_executor/models/gemma4.py
+++ b/vllm/model_executor/models/gemma4.py
@@ -1296,6 +1296,8 @@ class Gemma4Model(nn.Module, EagleModelMixin):
         # Include buffers (e.g. layer_scalar) so they can be loaded too
         params_dict.update(dict(self.named_buffers()))
         loaded_params: set[str] = set()
+        # Store scales for deferred dequantization of packed embeddings
+        _deferred_scales: dict[str, torch.Tensor] = {}
         for name, loaded_weight in weights:
             if self.quant_config is not None and (
                 scale_name := self.quant_config.get_cache_scale(name)
@@ -1384,7 +1386,90 @@ class Gemma4Model(nn.Module, EagleModelMixin):
                         continue
                     if is_pp_missing_parameter(name, self):
                         continue
+                    # Skip quantization params not present in the model
+                    # (e.g., for layers treated as unquantized on XPU)
+                    if name not in params_dict:
+                        # Defer packed embedding/lm_head weights for
+                        # dequantization once both packed + scale are seen
+                        if name.endswith((".weight_packed", ".weight_scale")):
+                            base = name.rsplit(".", 1)[0]
+                            weight_name = base + ".weight"
+                            if weight_name in params_dict:
+                                _deferred_scales[name] = loaded_weight
+                                pk = base + ".weight_packed"
+                                sk = base + ".weight_scale"
+                                if pk in _deferred_scales and sk in _deferred_scales:
+                                    w_packed = _deferred_scales.pop(pk)
+                                    scale = _deferred_scales.pop(sk)
+                                    param = params_dict[weight_name]
+                                    expected_cols = param.shape[1] if param.dim() > 1 else param.shape[0]
+                                    if w_packed.dtype == torch.int32:
+                                        pack_factor = expected_cols // w_packed.shape[-1] if w_packed.shape[-1] > 0 else 16
+                                        num_bits = 32 // pack_factor
+                                        mask = (1 << num_bits) - 1
+                                        shifts = torch.arange(0, 32, num_bits, dtype=torch.int32, device=w_packed.device)
+                                        w_unpacked = ((w_packed.to(torch.int32).unsqueeze(-1) >> shifts) & mask)
+                                        w_unpacked = w_unpacked.reshape(w_packed.shape[0], -1)
+                                        if w_unpacked.shape[-1] > expected_cols:
+                                            w_unpacked = w_unpacked[..., :expected_cols]
+                                        zp = 1 << (num_bits - 1)
+                                        w_float = w_unpacked.to(torch.float32) - zp
+                                        # Apply grouped scales
+                                        s = scale.to(torch.float32)
+                                        if s.shape[-1] == 1:
+                                            # Per-channel scale
+                                            w_float = w_float * s
+                                        else:
+                                            # Group scale: reshape weight
+                                            # into [rows, num_groups, group_size]
+                                            num_groups = s.shape[-1]
+                                            in_dim = w_float.shape[-1]
+                                            gs = in_dim // num_groups
+                                            w_float = w_float.reshape(
+                                                w_float.shape[0], num_groups, gs
+                                            ) * s.unsqueeze(-1)
+                                            w_float = w_float.reshape(
+                                                w_float.shape[0], in_dim
+                                            )
+                                        dequant_w = w_float.to(param.dtype)
+                                    else:
+                                        dequant_w = w_packed.to(param.dtype)
+                                    weight_loader = getattr(param, "weight_loader", default_weight_loader)
+                                    weight_loader(param, dequant_w)
+                                    loaded_params.add(weight_name)
+                                # Also check for int8 weight + scale
+                                elif weight_name in _deferred_scales and sk in _deferred_scales:
+                                    w_int = _deferred_scales.pop(weight_name)
+                                    scale = _deferred_scales.pop(sk)
+                                    param = params_dict[weight_name]
+                                    dequant_w = (w_int.to(torch.float32)
+                                                 * scale.to(torch.float32))
+                                    dequant_w = dequant_w.to(param.dtype)
+                                    weight_loader = getattr(param, "weight_loader", default_weight_loader)
+                                    weight_loader(param, dequant_w)
+                                    loaded_params.add(weight_name)
+                                continue
+                        continue
                     param = params_dict[name]
+                    # Handle int8 quantized weights: defer until scale
+                    # is available, then dequantize
+                    if (loaded_weight.dtype == torch.int8
+                            and name.endswith(".weight")):
+                        base = name.rsplit(".", 1)[0]
+                        sk = base + ".weight_scale"
+                        _deferred_scales[name] = loaded_weight
+                        if sk in _deferred_scales:
+                            scale = _deferred_scales.pop(sk)
+                            w_int = _deferred_scales.pop(name)
+                            dequant_w = (w_int.to(torch.float32)
+                                         * scale.to(torch.float32))
+                            dequant_w = dequant_w.to(param.dtype)
+                            weight_loader = getattr(
+                                param, "weight_loader",
+                                default_weight_loader)
+                            weight_loader(param, dequant_w)
+                            loaded_params.add(name)
+                        continue
                     weight_loader = getattr(
                         param, "weight_loader", default_weight_loader
                     )

--- a/vllm/model_executor/models/gemma4_mm.py
+++ b/vllm/model_executor/models/gemma4_mm.py
@@ -1207,6 +1207,8 @@ class Gemma4ForConditionalGeneration(
                     self._process_video_input(multimodal_input)
                 )
             elif modality == "audio":
+                if self.audio_tower is None:
+                    continue
                 multimodal_embeddings.extend(
                     self._process_audio_input(multimodal_input)
                 )
@@ -1322,6 +1324,11 @@ class Gemma4ForConditionalGeneration(
         loader = AutoWeightsLoader(
             self,
             ignore_unexpected_prefixes=ignore_prefixes,
+            ignore_unexpected_suffixes=[
+                ".input_scale",
+                ".output_scale",
+                ".weight_shape",
+            ],
         )
         return loader.load_weights(weights, mapper=self.hf_to_vllm_mapper)
 


### PR DESCRIPTION
## Motivation

The `google/gemma-4-E2B-it-qat-mobile-ct` model uses mixed-precision compressed tensors quantization (2-bit, 4-bit, and 8-bit weights) which is not natively supported on Intel XPU. This PR enables running this model on XPU hardware.

## Technical Details

### New XPUDequantLinearKernel
- Generic dequantization-based fallback kernel for XPU that handles arbitrary bit widths
- **2-bit/4-bit weights**: Re-packs into 4-bit format and dispatches to oneDNN `int4_gemm_w4a16` kernel
- **8-bit weights**: Dequantizes to bf16 at load time (used for small per-layer quantized layers)

### CompressedTensors XPU Integration
- Extended `CompressedTensorsConfig.get_scheme()` with XPU early-fallback path that routes `pack_quantized` and `int_quantized` formats through the WNA16 scheme
- Added 2-bit support to `WNA16_SUPPORTED_TYPES_MAP` and `WNA16_ZP_SUPPORTED_TYPES_MAP`
- Graceful error handling: unsupported schemes fall back to `UnquantizedLinearMethod` instead of crashing
- `int_quantized` format now accepted alongside `pack_quantized` for WNA16 path

### Gemma4 Model Loader Fixes
- Deferred dequantization of packed embedding/lm_head weights when quantized parameter names are absent from model state dict (XPU unquantized fallback path)
- Handles int8 quantized weights by deferring until scale tensor is available
- Added `ignore_unexpected_suffixes` for `.input_scale`, `.output_scale`, `.weight_shape` metadata tensors
- Guard `audio_tower` access to prevent NoneType error on text-only models

### Bug Fix
- Fixed `group_size=-1` (channelwise) handling in `XPUwNa16LinearKernel.apply_weights()` — now correctly resolves to input dimension K

## Hardware
- Intel Data Center GPU Max 1550 / Intel Arc Pro B60
- TP=1