### PR TITLE
[CI] Shard extended pooling model tests

### DIFF
--- a/.buildkite/test_areas/models_language.yaml
+++ b/.buildkite/test_areas/models_language.yaml
@@ -141,11 +141,11 @@ steps:
       dind: false
       device: mi300_1
       timeout_in_minutes: 95
-      parallelism: 1
+      parallelism: 2
       depends_on:
       - image-build-amd
       commands:
-      - pytest -v -s models/language/pooling -m 'not core_model'
+      - pytest -v -s models/language/pooling -m 'not core_model' --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT --shard-id=$$BUILDKITE_PARALLEL_JOB
 
 - label: Language Models Test (MTEB)
   key: language-models-test-mteb

--- a/.buildkite/test_areas/models_language.yaml
+++ b/.buildkite/test_areas/models_language.yaml
@@ -124,24 +124,28 @@ steps:
   commands:
     - pytest -v -s models/language/generation_ppl_test
 
-- label: Language Models Test (Extended Pooling)
+- label: Language Models Test (Extended Pooling) %N
   device: h200_35gb
   key: language-models-test-extended-pooling
   timeout_in_minutes: 120
+  parallelism: 4
   optional: true
   source_file_dependencies:
   - vllm/
   - "!vllm/distributed/kv_transfer/"
   - tests/models/language/pooling
   commands:
-    - pytest -v -s models/language/pooling -m 'not core_model'
+    - pytest -v -s models/language/pooling -m 'not core_model' --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT --shard-id=$$BUILDKITE_PARALLEL_JOB
   mirror:
     amd:
       dind: false
       device: mi300_1
       timeout_in_minutes: 95
+      parallelism: 1
       depends_on:
       - image-build-amd
+      commands:
+      - pytest -v -s models/language/pooling -m 'not core_model'
 
 - label: Language Models Test (MTEB)
   key: language-models-test-mteb


### PR DESCRIPTION
## Summary

- run `language-models-test-extended-pooling` as four deterministic pytest shards
- label the parallel jobs with their shard number
- keep the AMD mirror at one unsharded job with its original command

## Why

Buildkite build #83851 took 72 minutes for this job. Its recent passed-run distribution is 70 minutes median, 82 minutes p90, and 112 minutes max. Four shards leave substantially more headroom than three shards for the 30-minute target while preserving the same test selection.

The AMD behavior depends on [ci-infra #473](https://github.com/vllm-project/ci-infra/pull/473), which adds the backward-compatible `mirror.amd.parallelism` override. This PR must not merge before that prerequisite.

## Validation

- `uvx pre-commit run --files .buildkite/test_areas/models_language.yaml`
- parsed the YAML with PyYAML
- generated the selected pipeline locally with ECR authentication stubbed; verified four shards plus the `image-build` and `pre-commit` dependencies
- targeted Buildkite run #83898, pinned to vLLM `8f9a4d08e09b18d42d8d0ff3387a37ee77d4b53c` and ci-infra #473 `e006ba64b39ffd4f179824f088ff10e88af5635f`: passed
- shard walls: 14.128 / 15.324 / 19.486 / 18.860 minutes; max 19.486 minutes, 3.697x faster than #83851, with 0.82–0.97 minutes fixed outer overhead per shard
- exact coverage: shard manifests are pairwise disjoint and their union is 120/120 selected node IDs, with no missing, extra, or duplicate IDs
- separate full render at the same heads with step filtering disabled: NVIDIA `parallelism: 4`; AMD mirror `parallelism: 1`; AMD custom command remains unsharded with no `--num-shards`/`--shard-id` flags
- ci-infra #473 regression suite: 75/75 generator tests passed

## Duplicate-work check

Searched open PRs by the exact step key and sharding keywords. Existing PR #42222 changes source-dependency gating, not execution sharding, so this does not duplicate it.

AI assistance was used to prepare and validate this CI-only change.