### PR TITLE
[CI] Shard multimodal extended generation 2

### DIFF
--- a/.buildkite/test_areas/models_multimodal.yaml
+++ b/.buildkite/test_areas/models_multimodal.yaml
@@ -169,16 +169,17 @@ steps:
       depends_on:
       - image-build-amd
 
-- label: Multi-Modal Models (Extended Generation 2)
+- label: Multi-Modal Models (Extended Generation 2) %N
   device: h200_35gb
   key: multi-modal-models-extended-generation-2
+  parallelism: 4
   optional: true
   source_file_dependencies:
   - vllm/
   - "!vllm/distributed/kv_transfer/"
   - tests/models/multimodal/generation
   commands:
-    - pytest -v -s models/multimodal/generation/test_common.py -m 'split(group=0) and not core_model'
+    - pytest -v -s models/multimodal/generation/test_common.py -m 'split(group=0) and not core_model' --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT --shard-id=$$BUILDKITE_PARALLEL_JOB
 
 - label: Multi-Modal Models (Extended Generation 3)
   device: h200_35gb


### PR DESCRIPTION
## Summary

- run `multi-modal-models-extended-generation-2` as four deterministic pytest shards
- label the parallel jobs with their shard number
- preserve the existing `split(group=0) and not core_model` selection

## Why

Buildkite build #83851 took 71 minutes for this job. Its recent passed-run distribution is 68 minutes median, 75 minutes p90, and 131 minutes max. Four shards provide p90 headroom and reduce sensitivity to imbalanced model cases while targeting less than 30 minutes for the slowest shard.

## Validation

- `uvx pre-commit run --files .buildkite/test_areas/models_multimodal.yaml`
- parsed the YAML with PyYAML
- generated the selected pipeline locally with ECR authentication stubbed; verified four shards plus the `image-build` and `pre-commit` dependencies
- targeted Buildkite run #83888: passed
- shard walls: 11.587 / 12.103 / 19.520 / 20.678 minutes; max 20.678 minutes, 3.448x faster than #83851
- fixed outer overhead: 1.02–1.13 minutes per shard; accelerator total 63.885 GPU-minutes versus 71.304 minutes for the unsharded baseline
- exact coverage: shard manifests contain 29 / 33 / 21 / 33 selected node IDs; their pairwise-disjoint union is 116/116 baseline-selected IDs, with no missing, extra, or duplicate IDs

## Duplicate-work check

Searched open PRs by the exact step key and sharding keywords. Existing matches change ROCm gating or source dependencies, not this job's execution sharding.

AI assistance was used to prepare and validate this CI-only change.