### PR TITLE
[CI] Shard long language-model test groups

### DIFF
--- a/.buildkite/scripts/check-hybrid-test-deps.py
+++ b/.buildkite/scripts/check-hybrid-test-deps.py
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import json
+from importlib.metadata import distribution, version
+
+import causal_conv1d
+import mamba_ssm
+
+
+def vcs_identity(
+    distribution_name: str,
+    expected_url: str,
+    expected_revision: str,
+) -> str:
+    direct_url_text = distribution(distribution_name).read_text("direct_url.json")
+    assert direct_url_text is not None
+    direct_url = json.loads(direct_url_text)
+    assert direct_url["url"].removesuffix(".git") == expected_url
+    vcs_info = direct_url["vcs_info"]
+    assert vcs_info["requested_revision"] == expected_revision
+    commit_id = vcs_info["commit_id"]
+    assert len(commit_id) == 40
+    assert all(character in "0123456789abcdefABCDEF" for character in commit_id)
+    return commit_id
+
+
+def main() -> None:
+    assert version("mamba_ssm") == "2.3.0"
+    assert version("causal_conv1d") == "1.6.0"
+    mamba_commit = vcs_identity(
+        "mamba_ssm",
+        "https://github.com/state-spaces/mamba",
+        "v2.3.0",
+    )
+    causal_conv_commit = vcs_identity(
+        "causal_conv1d",
+        "https://github.com/Dao-AILab/causal-conv1d",
+        "v1.6.0",
+    )
+    print(
+        "Verified hybrid test dependencies:",
+        f"mamba_ssm==2.3.0@{mamba_commit} ({mamba_ssm.__file__})",
+        f"causal_conv1d==1.6.0@{causal_conv_commit} ({causal_conv1d.__file__})",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/.buildkite/test_areas/models_language.yaml
+++ b/.buildkite/test_areas/models_language.yaml
@@ -66,19 +66,17 @@ steps:
   - "!vllm/distributed/kv_transfer/"
   - tests/models/language/generation
   commands:
-    # Install fast path packages for testing against transformers
-    # torch>=2.14 nightly requires C++20 for ATen headers (pytorch/pytorch#178150);
-    # mamba@v2.3.0 pins -std=c++17, so build from a patched checkout instead of the git URL.
-    - rm -rf /tmp/mamba-src && git clone --depth 1 --branch v2.3.0 https://github.com/state-spaces/mamba /tmp/mamba-src && sed -i 's/-std=c++17/-std=c++20/g' /tmp/mamba-src/setup.py && MAMBA_FORCE_BUILD=TRUE uv pip install --system --no-build-isolation /tmp/mamba-src
-    - CAUSAL_CONV1D_FORCE_BUILD=TRUE uv pip install --system --no-build-isolation 'git+https://github.com/Dao-AILab/causal-conv1d@v1.6.0'
+    # The H200 test image prebuilds these exact CUDA extensions.
+    - python3 ../.buildkite/scripts/check-hybrid-test-deps.py
     # Shard the hybrid language model tests that are numerically stable on Hopper.
     - pytest -v -s models/language/generation -m hybrid_model -k 'not granite-4.0-tiny-preview' --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT --shard-id=$$BUILDKITE_PARALLEL_JOB
-  parallelism: 2
+  parallelism: 6
   mirror:
     amd:
       label: ":amd: (MI300) Language Models (Hybrid) Shard %N"
       dind: false
       device: mi300_1
+      parallelism: 2
       timeout_in_minutes: 60
       depends_on:
       - image-build-amd
@@ -106,10 +104,11 @@ steps:
     - CAUSAL_CONV1D_FORCE_BUILD=TRUE uv pip install --system --no-build-isolation 'git+https://github.com/Dao-AILab/causal-conv1d@v1.6.0'
     - pytest -v -s models/language/generation -m hybrid_model -k 'granite-4.0-tiny-preview'
 
-- label: ":nvidia: (H200 MIG 35GB) Language Models (Extended Generation)"
+- label: ":nvidia: (H200 MIG 35GB) Language Models (Extended Generation) %N"
   device: h200_35gb
   key: language-models-test-extended-generation
   timeout_in_minutes: 80
+  parallelism: 4
   optional: true
   source_file_dependencies:
   - vllm/
@@ -121,10 +120,10 @@ steps:
     # mamba@v2.3.0 pins -std=c++17, so build from a patched checkout instead of the git URL.
     - rm -rf /tmp/mamba-src && git clone --depth 1 --branch v2.3.0 https://github.com/state-spaces/mamba /tmp/mamba-src && sed -i 's/-std=c++17/-std=c++20/g' /tmp/mamba-src/setup.py && MAMBA_FORCE_BUILD=TRUE uv pip install --system --no-build-isolation /tmp/mamba-src
     - CAUSAL_CONV1D_FORCE_BUILD=TRUE uv pip install --system --no-build-isolation 'git+https://github.com/Dao-AILab/causal-conv1d@v1.6.0'
-    - pytest -v -s models/language/generation -m '(not core_model) and (not hybrid_model)'
+    - pytest -v -s models/language/generation -m '(not core_model) and (not hybrid_model)' --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT --shard-id=$$BUILDKITE_PARALLEL_JOB
   mirror:
     amd:
-      label: ":amd: (MI355) Language Models (Extended Generation)"
+      label: ":amd: (MI355) Language Models (Extended Generation) %N"
       dind: false
       device: mi355_1
       timeout_in_minutes: 70
@@ -133,7 +132,7 @@ steps:
       commands:
       - MAMBA_FORCE_BUILD=TRUE uv pip install --system --no-build-isolation 'git+https://github.com/AndreasKaratzas/mamba@fix-rocm-7.0-warp-size-constexpr'
       - CAUSAL_CONV1D_FORCE_BUILD=TRUE uv pip install --system --no-build-isolation 'git+https://github.com/Dao-AILab/causal-conv1d@v1.6.0'
-      - pytest -v -s models/language/generation -m '(not core_model) and (not hybrid_model)'
+      - pytest -v -s models/language/generation -m '(not core_model) and (not hybrid_model)' --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT --shard-id=$$BUILDKITE_PARALLEL_JOB
 
 - label: ":nvidia: (H200 MIG 18GB) Language Models (PPL)"
   key: language-models-test-ppl

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1106,6 +1106,16 @@ RUN --mount=type=cache,target=/opt/uv/cache \
         fi \
     fi
 
+# Hybrid-model tests require the CUDA extensions from these exact upstream
+# tags. Build them once in the stable test-dependency layer instead of once per
+# parallel GPU shard.
+RUN --mount=type=cache,target=/opt/uv/cache \
+    MAMBA_FORCE_BUILD=TRUE uv pip install --system --no-build-isolation \
+        'git+https://github.com/state-spaces/mamba@v2.3.0' \
+    && CAUSAL_CONV1D_FORCE_BUILD=TRUE uv pip install --system --no-build-isolation \
+        'git+https://github.com/Dao-AILab/causal-conv1d@v1.6.0' \
+    && python3 -c "from importlib.metadata import version; import causal_conv1d, mamba_ssm; assert version('mamba_ssm') == '2.3.0'; assert version('causal_conv1d') == '1.6.0'"
+
 # image to run unit testing suite
 # note that this uses vllm installed by `pip`
 FROM test-deps AS test


### PR DESCRIPTION
## Why

In the 24-hour dashboard window ending 2026-09-01 10:31 UTC:

- `NVIDIA Language Models Extended Generation`: 3,526s P90 (2 runs)
- `NVIDIA Language Models Hybrid shard 2`: 3,199s P90 (42 runs)

## What changed

- partition Extended Generation across four pytest shards; the AMD mirror inherits the same partition
- expand Hybrid from two to six pytest shards
- prebuild and verify the Hybrid CUDA extensions in the test image so each shard does not rebuild them

This consolidates and replaces draft #52337. No merged or active non-draft PR covers these jobs.

## Validation

- YAML parse and current `ci-infra` Buildkite step schema
- all YAML command entries pass `bash -n`
- dependency verifier passes Python AST parse and Ruff
- `git diff --check`


## Targeted CI

[Build #86568](https://buildkite.com/vllm/ci/builds/86568) passed. Extended Generation shards: `15:18, 16:26, 16:30, 21:32`. Hybrid shards: `5:00, 5:38, 10:40, 11:29, 15:32, 17:01`.

This is a draft pending human review. AI assistance was used.
