### PR TITLE
[CI] Shard Humming A100 eval

### DIFF
--- a/.buildkite/test_areas/lm_eval.yaml
+++ b/.buildkite/test_areas/lm_eval.yaml
@@ -194,12 +194,13 @@ steps:
   commands:
     - pytest -s -v evals/gsm8k/test_gsm8k_correctness.py --config-list-file=evals/gsm8k/configs/moe-refactor-dp-ep/config-b200.txt
 
-- label: LM Eval Humming f16 (A100 - TEMPORARY)
+- label: LM Eval Humming f16 (A100 - TEMPORARY) %N
   key: lm-eval-humming-f16-a100
   timeout_in_minutes: 75
   device: a100
   optional: true
   num_devices: 1
+  parallelism: 3
   source_file_dependencies:
   - vllm/model_executor/layers/quantization/humming.py
   - vllm/model_executor/layers/quantization/utils/humming_utils.py
@@ -207,7 +208,7 @@ steps:
   - vllm/model_executor/layers/fused_moe/oracle/
   - vllm/model_executor/kernels/linear/
   commands:
-  - pytest -s -v evals/gsm8k/test_gsm8k_correctness.py --config-list-file=evals/gsm8k/configs/humming/config.txt
+  - pytest -s -v evals/gsm8k/test_gsm8k_correctness.py --config-list-file=evals/gsm8k/configs/humming/config-a100-shard-$$BUILDKITE_PARALLEL_JOB.txt
 
 - label: LM Eval Humming Act int8 (A100 - TEMPORARY)
   key: lm-eval-humming-act-a100

--- a/tests/evals/gsm8k/configs/humming/config-a100-shard-0.txt
+++ b/tests/evals/gsm8k/configs/humming/config-a100-shard-0.txt
@@ -1,0 +1,4 @@
+Qwen3.5-35B-A3B-experts-int8-humming.yaml
+gpt-oss-20b-humming.yaml
+Qwen3-30B-A3B-GPTQ-Int4-humming.yaml
+Qwen3-30B-A3B-FP8-block-humming.yaml

--- a/tests/evals/gsm8k/configs/humming/config-a100-shard-1.txt
+++ b/tests/evals/gsm8k/configs/humming/config-a100-shard-1.txt
@@ -1,0 +1,5 @@
+Qwen3.6-35B-A3B-NVFP4-humming.yaml
+Qwen3-30B-A3B-Instruct-2507-quantized.w8a8-humming.yaml
+Qwen3-30B-A3B-Fp8-v1-humming.yaml
+Qwen3-30B-A3B-AWQ-humming.yaml
+Qwen3-0.6B-MXFP8-humming.yaml

--- a/tests/evals/gsm8k/configs/humming/config-a100-shard-2.txt
+++ b/tests/evals/gsm8k/configs/humming/config-a100-shard-2.txt
@@ -1,0 +1,5 @@
+Qwen3.5-35B-A3B-FP8-humming.yaml
+NVIDIA-Nemotron-3-Nano-30B-A3B-NVFP4-humming.yaml
+Qwen3-30B-A3B-MXFP4A16-humming.yaml
+Qwen3-30B-A3B-NVFP4-humming.yaml
+Qwen2-1.5B-Instruct-FP8W8-humming.yaml


### PR DESCRIPTION
## Why

`lm-eval-humming-f16-a100` took 64.3 minutes in full CI build 83851. Its 14 model configurations ran serially even though each evaluation is independent.

This does not duplicate an open pull request. Open PRs were searched by the exact step key and Humming/A100 sharding terms before implementation.

## What changed

- run the step with three Buildkite jobs
- partition all 14 configurations into three explicit A100 lists using observed build 83851 per-config durations
- keep each configuration in exactly one shard

The measured baseline loads are 20.20, 21.47, and 21.60 minutes of test work, leaving headroom below the 30-minute target.

## Validation

- baseline model evaluation: 14/14 configurations passed in build 83851
- config partition check: 14/14 unique entries, no omissions or duplicates, all referenced YAML files exist
- selected-step pipeline generation: three parallel A100 jobs with the image-build dependency
- targeted build 83894: all three shards passed; the executed tests exactly match each shard list and cover all 14/14 configurations with no omissions or duplicates
- targeted shard wall times: 24.09, 22.07, and 24.44 minutes (2.37-minute max/min spread; 1.11x imbalance)
- outer job/bootstrap + teardown overhead around pytest: 0.82, 0.81, and 0.82 minutes per shard
- critical path: 24.44 minutes versus 64.27 minutes in build 83851 (2.63x faster)
- observed total GPU time: 70.59 versus 64.27 GPU-minutes in the single baseline run (+9.8%)
- `uvx pre-commit run --files ...`: passed
- `git diff --check`: passed

AI assistance was used. The submitter will review and validate the change before marking it ready.
