### PR TITLE
[CI] Shard Humming H100 eval

### DIFF
--- a/.buildkite/test_areas/lm_eval.yaml
+++ b/.buildkite/test_areas/lm_eval.yaml
@@ -224,12 +224,13 @@ steps:
   commands:
   - pytest -s -v evals/gsm8k/test_gsm8k_correctness.py --config-list-file=evals/gsm8k/configs/humming/config-act-int8.txt
 
-- label: LM Eval Humming f16 (H100 - TEMPORARY)
+- label: LM Eval Humming f16 (H100 - TEMPORARY) %N
   key: lm-eval-humming-f16-h100
   timeout_in_minutes: 70
   device: h100
   optional: true
   num_devices: 1
+  parallelism: 3
   source_file_dependencies:
   - vllm/model_executor/layers/quantization/humming.py
   - vllm/model_executor/layers/quantization/utils/humming_utils.py
@@ -237,7 +238,7 @@ steps:
   - vllm/model_executor/layers/fused_moe/oracle/
   - vllm/model_executor/kernels/linear/
   commands:
-  - pytest -s -v evals/gsm8k/test_gsm8k_correctness.py --config-list-file=evals/gsm8k/configs/humming/config.txt
+  - pytest -s -v evals/gsm8k/test_gsm8k_correctness.py --config-list-file=evals/gsm8k/configs/humming/config-h100-shard-$$BUILDKITE_PARALLEL_JOB.txt
 
 - label: LM Eval Humming Act fp8/int8 (H100 - TEMPORARY)
   key: lm-eval-humming-act-h100

--- a/tests/evals/gsm8k/configs/humming/config-h100-shard-0.txt
+++ b/tests/evals/gsm8k/configs/humming/config-h100-shard-0.txt
@@ -1,0 +1,5 @@
+Qwen3.5-35B-A3B-experts-int8-humming.yaml
+Qwen3-30B-A3B-Instruct-2507-quantized.w8a8-humming.yaml
+Qwen3-30B-A3B-Fp8-v1-humming.yaml
+Qwen3-30B-A3B-NVFP4-humming.yaml
+Qwen2-1.5B-Instruct-FP8W8-humming.yaml

--- a/tests/evals/gsm8k/configs/humming/config-h100-shard-1.txt
+++ b/tests/evals/gsm8k/configs/humming/config-h100-shard-1.txt
@@ -1,0 +1,5 @@
+Qwen3.6-35B-A3B-NVFP4-humming.yaml
+Qwen3-30B-A3B-AWQ-humming.yaml
+Qwen3-30B-A3B-GPTQ-Int4-humming.yaml
+Qwen3-30B-A3B-FP8-block-humming.yaml
+Qwen3-0.6B-MXFP8-humming.yaml

--- a/tests/evals/gsm8k/configs/humming/config-h100-shard-2.txt
+++ b/tests/evals/gsm8k/configs/humming/config-h100-shard-2.txt
@@ -1,0 +1,4 @@
+NVIDIA-Nemotron-3-Nano-30B-A3B-NVFP4-humming.yaml
+Qwen3.5-35B-A3B-FP8-humming.yaml
+Qwen3-30B-A3B-MXFP4A16-humming.yaml
+gpt-oss-20b-humming.yaml


### PR DESCRIPTION
## Why

`lm-eval-humming-f16-h100` took 62.6 minutes in full CI build 83851. Its 14 model configurations ran serially even though each evaluation is independent.

This does not duplicate an open pull request. Open PRs were searched by the exact step key and Humming/H100 sharding terms before implementation.

## What changed

- run the step with three Buildkite jobs
- partition all 14 configurations into three explicit H100 lists using observed build 83851 per-config durations
- keep each configuration in exactly one shard

The measured baseline loads are 20.52, 20.38, and 20.74 minutes of test work, leaving headroom below the 30-minute target.

## Validation

- baseline model evaluation: 14/14 configurations passed in build 83851
- config partition check: 14/14 unique entries, no omissions or duplicates, all referenced YAML files exist
- selected-step pipeline generation: three parallel H100 jobs with the image-build dependency
- targeted build 83895: all three shards passed, with exact 14/14 configuration coverage and no omissions or duplicates
- targeted shard wall times: 20.79, 20.33, and 19.33 minutes (1.48-minute max/min spread; 1.08x imbalance)
- outer job/bootstrap + teardown overhead around pytest: 0.83, 0.80, and 0.74 minutes per shard
- critical path: 20.79 minutes versus 62.63 minutes in build 83851 (3.01x faster)
- observed total GPU time: 60.45 versus 62.63 GPU-minutes in the single baseline run; the -2.18 minute delta is normal run-to-run variance, not negative sharding overhead
- `uvx pre-commit run --files ...`: passed
- `git diff --check`: passed

AI assistance was used. The submitter will review and validate the change before marking it ready.
