### PR TITLE
[CI] Shard MoE refactor B200 eval

### DIFF
--- a/.buildkite/test_areas/lm_eval.yaml
+++ b/.buildkite/test_areas/lm_eval.yaml
@@ -178,13 +178,14 @@ steps:
   commands:
     - pytest -s -v evals/gsm8k/test_gsm8k_correctness.py --config-list-file=evals/gsm8k/configs/moe-refactor/config-h100.txt
   
-- label: MoE Refactor Integration Test (B200 - TEMPORARY)
+- label: MoE Refactor Integration Test (B200 - TEMPORARY) %N
   key: moe-refactor-integration-test-b200-temporary
   device: b200-k8s
   optional: true
   num_devices: 2
+  parallelism: 4
   commands:
-    - pytest -s -v evals/gsm8k/test_gsm8k_correctness.py --config-list-file=evals/gsm8k/configs/moe-refactor/config-b200.txt
+    - pytest -s -v evals/gsm8k/test_gsm8k_correctness.py --config-list-file=evals/gsm8k/configs/moe-refactor/config-b200-shard-$$BUILDKITE_PARALLEL_JOB.txt
 
 - label: MoE Refactor Integration Test (B200 DP - TEMPORARY)
   key: moe-refactor-integration-test-b200-dp-temporary

--- a/tests/evals/gsm8k/configs/moe-refactor/config-b200-shard-0.txt
+++ b/tests/evals/gsm8k/configs/moe-refactor/config-b200-shard-0.txt
@@ -1,0 +1,3 @@
+DeepSeek-V4-Flash-deepgemm-mega-moe.yaml
+Qwen3-30B-A3B-NvFp4-ModelOpt-marlin.yaml
+Qwen3-30B-A3B-NvFp4-ModelOpt-fi-trtllm.yaml

--- a/tests/evals/gsm8k/configs/moe-refactor/config-b200-shard-1.txt
+++ b/tests/evals/gsm8k/configs/moe-refactor/config-b200-shard-1.txt
@@ -1,0 +1,5 @@
+Nemotron-Nano-30B-Fp8-ModelOpt-fi-trtllm.yaml
+Nemotron-Nano-30B-NvFp4-ModelOpt-fi-cutlass.yaml
+Llama-4-Scout-Fp8-CT-vllm-cutlass.yaml
+Qwen3-30B-A3B-NvFp4-ModelOpt-fi-cutlass.yaml
+Qwen3-30B-A3B-NvFp4-CT-fi-cutlass.yaml

--- a/tests/evals/gsm8k/configs/moe-refactor/config-b200-shard-2.txt
+++ b/tests/evals/gsm8k/configs/moe-refactor/config-b200-shard-2.txt
@@ -1,0 +1,5 @@
+Llama-4-Scout-Fp8-ModelOpt-fi-trtllm.yaml
+Qwen3-30B-A3B-NvFp4-CT-fi-trtllm.yaml
+Qwen3-30B-A3B-NvFp4-CT-vllm-cutlass.yaml
+Llama-4-Scout-BF16-triton.yaml
+Qwen3-30B-A3B-NvFp4-ModelOpt-vllm-cutlass.yaml

--- a/tests/evals/gsm8k/configs/moe-refactor/config-b200-shard-3.txt
+++ b/tests/evals/gsm8k/configs/moe-refactor/config-b200-shard-3.txt
@@ -1,0 +1,6 @@
+Llama-4-Scout-BF16-fi-cutlass.yaml
+Qwen3-30B-A3B-Fp8-AutoFp8-fi-trtllm.yaml
+Nemotron-Nano-30B-NvFp4-ModelOpt-vllm-cutlass.yaml
+Mixtral-8x7B-BF16-fi-cutlass.yaml
+Qwen3-30B-A3B-NvFp4-CT-marlin.yaml
+Mixtral-8x7B-BF16-triton.yaml


### PR DESCRIPTION
## Why

`moe-refactor-integration-test-b200-temporary` took 81.3 minutes in full CI build 83851. Its 19 model configurations ran serially even though each evaluation is independent.

This does not duplicate an open pull request. Open PRs were searched by the exact step key and MoE/B200 sharding terms before implementation.

## What changed

- run the step with four Buildkite jobs
- partition all 19 configurations into four explicit lists using observed build 83851 per-config durations
- keep each configuration in exactly one shard

The measured baseline loads are 19.84, 19.94, 19.96, and 20.86 minutes of test work. Static lists are used instead of count-based sharding because the slowest configuration takes 13.31 minutes by itself.

## Validation

- baseline model evaluation: 19/19 configurations passed in build 83851
- config partition check: 19/19 unique entries, no omissions or duplicates, all referenced YAML files exist
- selected-step pipeline generation: four parallel B200 jobs with the image-build dependency
- targeted build 83896: all four shards passed; the executed tests exactly match each shard list and cover all 19/19 configurations with no omissions or duplicates
- targeted shard wall times: 19.47, 21.54, 20.23, and 22.26 minutes (2.79-minute max/min spread; 1.14x imbalance)
- outer job/bootstrap + teardown overhead around pytest: 0.55, 0.56, 0.57, and 0.59 minutes per shard
- critical path: 22.26 minutes versus 81.32 minutes in build 83851 (3.65x faster)
- observed total accelerator time: 167.01 versus 162.63 GPU-minutes in the single baseline run (+2.7%); each job reserves two GPUs
- `uvx pre-commit run --files ...`: passed
- `git diff --check`: passed

AI assistance was used. The submitter will review and validate the change before marking it ready.
