### PR TITLE
[CI] Shard Quantization job into 4 parallel shards (≤30 min target)

### DIFF
--- a/.buildkite/test_areas/quantization.yaml
+++ b/.buildkite/test_areas/quantization.yaml
@@ -2,10 +2,11 @@ group: Quantization
 depends_on:
   - image-build
 steps:
-- label: Quantization
+- label: Quantization %N
   device: h200_35gb
   key: quantization
-  timeout_in_minutes: 75
+  timeout_in_minutes: 40
+  parallelism: 4
   env:
     VLLM_USE_V2_MODEL_RUNNER: "0"
   source_file_dependencies:
@@ -18,7 +19,7 @@ steps:
   - uv pip install --system conch-triton-kernels
   # The SM90-only checkpoint currently contains a removed weight_chan_scale
   # parameter. It was not exercised by the previous L4 job.
-  - VLLM_TEST_FORCE_LOAD_FORMAT=auto pytest -v -s quantization/ --ignore quantization/test_blackwell_moe.py -k 'not test_compressed_tensors_w4a8_fp8'
+  - VLLM_TEST_FORCE_LOAD_FORMAT=auto pytest -v -s quantization/ --ignore quantization/test_blackwell_moe.py -k 'not test_compressed_tensors_w4a8_fp8' --shard-id=$$BUILDKITE_PARALLEL_JOB --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT
 
 - label: Quantized Fusions
   device: h200_35gb


### PR DESCRIPTION
## What
Shard the long-pole `Quantization` CI job (single job, ~71–75 min wall in build #83851; 90-day 68/73/75 min) into 4 parallel Buildkite shards so each shard lands ≤30 min. Rebased onto current `main`, preserving the live `device`/`key`/V2 env/torchao 0.17+CUDA13 pin and the `-k 'not test_compressed_tensors_w4a8_fp8'` selection.

## How
- `parallelism: 4` on the `Quantization` step + pytest-shard (`--shard-id=$BUILDKITE_PARALLEL_JOB --num-shards=$BUILDKITE_PARALLEL_JOB_COUNT`), mirroring the existing `Kernels Quantization Test %N` pattern. No test files moved — shards are disjoint slices of `tests/quantization/` chosen by pytest-shard at collection time.
- Label → `Quantization %N`; per-shard `timeout_in_minutes` lowered 75 → 40. `key: quantization` unchanged so targeted `VLLM_CI_ONLY_STEP_KEYS` launches keep working.

## Validation — targeted build #83897 (only `quantization` + image-build dep, head `579902220`, terminal green)
Per-shard wall (4 shards): **17.03 / 13.43 / 10.52 / 23.10 min** — all four **< 30 min** (max 23.10, ~7 min headroom). min/median/max = 10.52 / 15.23 / 23.10 min. **3.075× critical-path speedup** vs the 71m01s single-job baseline. Sum = 64.07 GPU-min (−6.9 vs the single baseline run → within run-to-run variance; the split does not inflate GPU-minutes).

**Coverage — exact node-ID union.** Shard manifests report 139 / 142 / 115 / 140 selected node IDs; all pairwise intersections are 0 and the union = 536, exactly matching the `collected 537 items / 1 deselected / 2 skipped / 536 selected` line (the single deselection is the intended `-k` filter). No test is dropped or double-run.

**Overhead (Kevin's Q2).** Fixed per-shard repeated cost = job wall − pytest runtime (container/setup re-pay + teardown): **0.90–1.04 min/shard**. That ~1 min/shard is the only thing the split re-pays; cached wheels keep the torchao/conch installs cheap.

## Why 4 shards
~71 min single-job wall with ~1 min/shard fixed overhead → 4-way lands the worst shard at 23.1 min, comfortably ≤30 with headroom for the 68–75 min spread and pytest-shard's nodeid-hash imbalance. 5 shards were unnecessary.

Part of the CI-overhaul sharding pass, one PR per long-pole job.
