### PR TITLE
[CI] Shard Kernels Mamba Test — deterministic structural split (<20 min)

### DIFF
--- a/.buildkite/test_areas/kernels.yaml
+++ b/.buildkite/test_areas/kernels.yaml
@@ -221,16 +221,36 @@ steps:
       depends_on:
       - image-build-amd
 
-- label: Kernels Mamba Test
+- label: Kernels Mamba Test %N
   device: h200_35gb
   key: kernels-mamba-test
-  timeout_in_minutes: 60
+  timeout_in_minutes: 30
+  parallelism: 4
   source_file_dependencies:
   - csrc/mamba/
   - tests/kernels/mamba
   - vllm/model_executor/layers/mamba/ops
   commands:
-    - pytest -v -s kernels/mamba
+    - |
+      set -eu
+      # Deterministic structural split. test_mamba_ssm_ssd.py dominates the
+      # suite (~49m, 94 nodes), so it is sharded 3-way on shards 0-2
+      # (~16.4m each); shard 3 runs the ~17.4m complement once with that file
+      # ignored. One logical key; the 3-way SSD partition and the 820-node
+      # complement are disjoint and cover the exact 914-node union (stable:
+      # byte-identical to the pre-split baseline).
+      case "$$BUILDKITE_PARALLEL_JOB" in
+        0|1|2)
+          pytest -v -s kernels/mamba/test_mamba_ssm_ssd.py --num-shards=3 --shard-id=$$BUILDKITE_PARALLEL_JOB
+          ;;
+        3)
+          pytest -v -s kernels/mamba --ignore=kernels/mamba/test_mamba_ssm_ssd.py
+          ;;
+        *)
+          echo "unexpected BUILDKITE_PARALLEL_JOB=$$BUILDKITE_PARALLEL_JOB" >&2
+          exit 1
+          ;;
+      esac
 
 - label: Kernels DeepGEMM Test (H100)
   key: kernels-deepgemm-test-h100


### PR DESCRIPTION
## What
`Kernels Mamba Test` runs as a single job (~66.6 min). Split it to <20 min/shard **without** the pytest-shard hash lottery that made N=4 peak a shard at 20.74 min.

## Why structural (not higher-N hash)
From the #83902 logs: `test_mamba_ssm_ssd.py` dominates the suite — **~49 min across 94 nodes** — while the complement is **~17.4 min across 820 nodes**. There is **no single-test floor** (longest node 1.16 min); the N=4 miss was hash concentration of the many mid-weight ssd parametrizations onto one shard. Plain higher-N reshuffles non-monotonically, so pin the structure instead.

## How (`parallelism: 4`, one logical key)
- **shards 0–2:** `pytest -v -s kernels/mamba/test_mamba_ssm_ssd.py --num-shards=3 --shard-id=$BUILDKITE_PARALLEL_JOB` → the heavy file 3-way (~16.4 min each). The 94 ssd nodes are homogeneous (longest 1.16 min), so low per-shard spread is *expected* — not mathematically bounded; the strict <20 min result is determined empirically by the targeted run.
- **shard 3:** `pytest -v -s kernels/mamba --ignore=kernels/mamba/test_mamba_ssm_ssd.py` → the complement once (~17.4 min + ~0.8 min setup ≈ 18.2 min).
- `set -eu` POSIX fail-fast (dash-safe); unexpected shard index fails. Same accelerator count as today (4).

## Coverage — exact node union
`--ignore` makes SSD and its complement disjoint and jointly complete: **94 (ssd, partitioned 3-way) ⊎ 820 (complement) = 914** — the exact current node set (cross-checked against the four archived #83902 logs). No node dropped or double-run.

## Validation — build #83932 (targeted `kernels-mamba-test` on `7048f140`, 4/4 green)
- Per-shard wall (min): 12.97 / 14.69 / 13.90 / 16.73 — **max 16.73, all <20**.
- Structure/coverage: shards 0–2 run `test_mamba_ssm_ssd.py` 3-way (Running **32/31/31 = 94** = the full ssd collection this run); shard 3 runs the complement once (`--ignore` ssd, **820** nodes). **ssd ⊎ complement = 914 nodes, disjoint and complete (each exactly once).** The executed **914-node union is byte-identical to the #83902 baseline** (zero difference both directions; 94 ssd + 820 complement, no intersection — cross-parsed by @Cuong). The earlier "1,824" figure was a two-string-form double-count parsing artifact (each node logged as both `tests/kernels/mamba/…` and `kernels/mamba/…`), **not collection drift** — corrected throughout.
- Fixed setup: **0.91–1.05 min/shard**. Total GPU-min: **58.3 vs the 4-shard baseline 66.6 (−8.3)**; wall ~66→16.7 min (~4×). No AMD mirror.


Part of the Phase-2 CI-overhaul sharding pass, one PR per key.




