### PR TITLE
[CI] Prebuild hybrid model test dependencies

### DIFF
--- a/.buildkite/scripts/check-hybrid-test-deps.py
+++ b/.buildkite/scripts/check-hybrid-test-deps.py
@@ -1,20 +1,47 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-from importlib.metadata import version
+import json
+from importlib.metadata import distribution, version
 
 import causal_conv1d
 import mamba_ssm
 
 
+def vcs_identity(
+    distribution_name: str,
+    expected_url: str,
+    expected_revision: str,
+) -> str:
+    direct_url_text = distribution(distribution_name).read_text("direct_url.json")
+    assert direct_url_text is not None
+    direct_url = json.loads(direct_url_text)
+    assert direct_url["url"].removesuffix(".git") == expected_url
+    vcs_info = direct_url["vcs_info"]
+    assert vcs_info["requested_revision"] == expected_revision
+    commit_id = vcs_info["commit_id"]
+    assert len(commit_id) == 40
+    assert all(character in "0123456789abcdefABCDEF" for character in commit_id)
+    return commit_id
+
+
 def main() -> None:
     assert version("mamba_ssm") == "2.3.0"
     assert version("causal_conv1d") == "1.6.0"
+    mamba_commit = vcs_identity(
+        "mamba_ssm",
+        "https://github.com/state-spaces/mamba",
+        "v2.3.0",
+    )
+    causal_conv_commit = vcs_identity(
+        "causal_conv1d",
+        "https://github.com/Dao-AILab/causal-conv1d",
+        "v1.6.0",
+    )
     print(
         "Verified hybrid test dependencies:",
-        mamba_ssm.__file__,
-        causal_conv1d.__file__,
+        f"mamba_ssm==2.3.0@{mamba_commit} ({mamba_ssm.__file__})",
+        f"causal_conv1d==1.6.0@{causal_conv_commit} ({causal_conv1d.__file__})",
     )
 
 

--- a/.buildkite/scripts/check-hybrid-test-deps.py
+++ b/.buildkite/scripts/check-hybrid-test-deps.py
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from importlib.metadata import version
+
+import causal_conv1d
+import mamba_ssm
+
+
+def main() -> None:
+    assert version("mamba_ssm") == "2.3.0"
+    assert version("causal_conv1d") == "1.6.0"
+    print(
+        "Verified hybrid test dependencies:",
+        mamba_ssm.__file__,
+        causal_conv1d.__file__,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -908,6 +908,16 @@ RUN --mount=type=cache,target=/opt/uv/cache \
         fi \
     fi
 
+# Hybrid-model tests require the CUDA extensions from these exact upstream
+# tags. Build them once in the stable test-dependency layer instead of once per
+# parallel GPU shard.
+RUN --mount=type=cache,target=/opt/uv/cache \
+    MAMBA_FORCE_BUILD=TRUE uv pip install --system --no-build-isolation \
+        'git+https://github.com/state-spaces/mamba@v2.3.0' \
+    && CAUSAL_CONV1D_FORCE_BUILD=TRUE uv pip install --system --no-build-isolation \
+        'git+https://github.com/Dao-AILab/causal-conv1d@v1.6.0' \
+    && python3 -c "from importlib.metadata import version; import causal_conv1d, mamba_ssm; assert version('mamba_ssm') == '2.3.0'; assert version('causal_conv1d') == '1.6.0'"
+
 # image to run unit testing suite
 # note that this uses vllm installed by `pip`
 FROM test-deps AS test


### PR DESCRIPTION
## Summary

- build the pinned `mamba-ssm` v2.3.0 and `causal-conv1d` v1.6.0 CUDA extensions once in the stable H200 test-image dependency layer
- assert both distribution versions and import their compiled modules during the image build
- add a runtime verifier for the dependent hybrid-model job, including auditable PEP 610 VCS identities

## Why

`language-models-tests-hybrid` previously spent 16.132-17.138 minutes per GPU shard outside pytest, dominated by rebuilding these same two pinned git packages from source. Its two #83851 shards spent only 17.779 / 35.330 minutes in pytest but 33.911 / 52.467 minutes wall-clock overall.

Prebuilding the identical pinned sources once in the shared image removes that repeated per-shard floor. The dependent hybrid-job PR keeps the distinct ROCm package commands unchanged and is validated against this exact prerequisite head.

## Validation

- `uvx pre-commit run --files docker/Dockerfile .buildkite/scripts/check-hybrid-test-deps.py`
- `git diff --check`
- Docker dependency graph and `docker/versions.json` hooks passed
- Buildkite image build succeeded at the exact stacked head in [#83907](https://buildkite.com/vllm/ci/builds/83907) and [#83927](https://buildkite.com/vllm/ci/builds/83927)
- all six #83927 runtime verifiers imported the compiled modules and reported `mamba_ssm==2.3.0` from requested tag `v2.3.0`, resolved commit `f1493ff6e9335160eb134eb67e59f8e4d9adefd6`, and `causal_conv1d==1.6.0` from requested tag `v1.6.0`, resolved commit `da6dbaa9fd5a919967f14d3fd031da1288ad5025`
- cold image build #83907 took 21.545 minutes versus 19.688 minutes for the Dockerfile-unchanged #83903 build in the same batch, an observed one-time delta of 1.857 minutes
- cached replacement image build #83927 took 18.725 minutes, showing no recurring positive bake delta once the dependency layer was cached
- the dependent six-shard job removed the old 16-17 minute per-shard source-build floor; total fixed setup fell from 33.270 GPU-minutes across two baseline shards to 6.893 GPU-minutes across six shards
- local Docker build was unavailable because this host cannot access the Docker daemon; Buildkite is the authoritative image build

## Duplicate-work check

Searched open PRs for the exact hybrid step key and package pins. PR #49600 changes nightly-build C++ compatibility, not stable H200 test-image prebuilding for this job.

AI assistance was used to prepare and validate this CI change.
