### PR TITLE
[CI] Shard multimodal extended pooling tests

### DIFF
--- a/.buildkite/test_areas/models_multimodal.yaml
+++ b/.buildkite/test_areas/models_multimodal.yaml
@@ -191,7 +191,7 @@ steps:
   commands:
     - pytest -v -s models/multimodal/generation/test_common.py -m 'split(group=1) and not core_model'
 
-- label: Multi-Modal Models (Extended Pooling)
+- label: Multi-Modal Models (Extended Pooling) %N
   key: multi-modal-models-extended-pooling
   optional: true
   device: h200_18gb
@@ -200,11 +200,13 @@ steps:
   - "!vllm/distributed/kv_transfer/"
   - tests/models/multimodal/pooling
   commands:
-    - pytest -v -s models/multimodal/pooling -m 'not core_model'
+    - pytest -v -s models/multimodal/pooling -m 'not core_model' --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT --shard-id=$$BUILDKITE_PARALLEL_JOB
+  parallelism: 4
   mirror:
     amd:
       dind: false
       device: mi300_1
+      parallelism: 1
       timeout_in_minutes: 60
       depends_on:
       - image-build-amd


### PR DESCRIPTION
## Summary

- run `multi-modal-models-extended-pooling` as four deterministic pytest shards
- label parallel jobs with their shard number
- keep the AMD mirror at one job

## Why

Buildkite build #83851 took 45.196 minutes for this job, including 42.296 minutes in pytest and 2.900 minutes of outer fixed cost. Four shards target less than 20 minutes while retaining headroom for hash imbalance.

The AMD parallelism override depends on [ci-infra #473](https://github.com/vllm-project/ci-infra/pull/473). This PR must not merge first.

## Repeated model-initialization blocker

This PR is not in the accepted set. Two targeted runs at the exact head `3206c4b6f8c9ff58794f0c88d54bdcd2115e6eb7` reproduced the same shard-3 stall while initializing `vidore/colpali-v1.3-hf`:

- [Buildkite #83906](https://buildkite.com/vllm/ci/builds/83906) was operator-canceled after 22.185 minutes. It ran on `h200-ci-5-36`, passed the first two assigned ColPali nodes, and stopped logging after the third node reached the FlashInfer sampler initialization.
- [Buildkite #83929](https://buildkite.com/vllm/ci/builds/83929) was a clean unchanged-head rerun on a different agent, `h200-ci-5-34`, on the same physical `h200-ci-5` host. It passed the same first two nodes, began the same third node, and produced no log after the identical FlashInfer sampler line at 14:11:21 UTC. With no NVIDIA `timeout_in_minutes` declared and no platform timeout at 90 or 120 minutes, it was operator-canceled after a conclusive 123.158-minute stall. Its terminal state is `canceled`, exit status -1, with `timed_out_at=null`.

The repeated unchanged-head result is conclusive blocker evidence for this Phase 2 pass, but both attempts landed on the same physical host, so it does not establish a cross-host deterministic failure. No third blind retry or shard-count change was made.

## Validation

- parsed `.buildkite/test_areas/models_multimodal.yaml` with PyYAML
- `uvx pre-commit run --files .buildkite/test_areas/models_multimodal.yaml`
- `git diff --check`
- generated a full pipeline locally with ci-infra #473 head `e006ba64b39ffd4f179824f088ff10e88af5635f`; verified NVIDIA parallelism 4, AMD parallelism 1, and dependencies
- #83929's three completed shards passed with 12.081/7.267/10.640-minute walls and complete assigned manifests of 19/16/18 nodes, covering 53 nodes
- canceled shard 3 emitted its full 13-node assigned manifest and passed its first two nodes before stalling on the third; therefore only 55/66 nodes completed in the canonical run
- the four assigned manifests are disjoint and their 66/66 union exactly matches #83851 with zero missing, extra, or duplicate node IDs; this proves selection integrity, not successful execution
- #83906 and #83929 are explicitly excluded from acceptance; no terminal max-wall speedup or total GPU-minute claim is made

## Duplicate-work check

Searched open PRs by the exact step key and sharding keywords. Existing matches concern source dependencies and ROCm platform work, not execution sharding.

AI assistance was used to prepare and validate this CI-only change.
