### PR TITLE
[CI] Shard multimodal extended generation 3

### DIFF
--- a/.buildkite/test_areas/models_multimodal.yaml
+++ b/.buildkite/test_areas/models_multimodal.yaml
@@ -180,7 +180,7 @@ steps:
   commands:
     - pytest -v -s models/multimodal/generation/test_common.py -m 'split(group=0) and not core_model'
 
-- label: Multi-Modal Models (Extended Generation 3)
+- label: Multi-Modal Models (Extended Generation 3) %N
   device: h200_35gb
   key: multi-modal-models-extended-generation-3
   optional: true
@@ -189,7 +189,8 @@ steps:
   - "!vllm/distributed/kv_transfer/"
   - tests/models/multimodal/generation
   commands:
-    - pytest -v -s models/multimodal/generation/test_common.py -m 'split(group=1) and not core_model'
+    - pytest -v -s models/multimodal/generation/test_common.py -m 'split(group=1) and not core_model' --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT --shard-id=$$BUILDKITE_PARALLEL_JOB
+  parallelism: 6
 
 - label: Multi-Modal Models (Extended Pooling)
   key: multi-modal-models-extended-pooling


### PR DESCRIPTION
## Summary

- run `multi-modal-models-extended-generation-3` as six deterministic pytest shards
- label parallel jobs with their shard number
- preserve the exact `split(group=1) and not core_model` selection

## Why

Buildkite build #83851 took 50.792 minutes for this job, including 50.053 minutes in pytest and only 0.739 minutes of outer fixed cost. Recent passed runs have reached roughly 101 minutes, so six shards are sized against the heavy tail rather than the baseline median or node counts; the target is less than 20 minutes for the slowest shard.

## Validation

- parsed `.buildkite/test_areas/models_multimodal.yaml` with PyYAML
- `uvx pre-commit run --files .buildkite/test_areas/models_multimodal.yaml`
- `git diff --check`
- generated the selected pipeline locally with ECR authentication stubbed; verified six shards plus `image-build` and `pre-commit` dependencies
- targeted Buildkite build [#83905](https://buildkite.com/vllm/ci/builds/83905) passed all six shards at exact head `33b9f6d4a048e6e203f8555c06c53415f9930408`
- shard walls were 3.754, 11.410, 4.426, 15.516, 8.003, and 8.010 minutes; the slowest is 15.516 minutes versus the 50.792-minute baseline, a 3.274x wall-clock speedup
- manifests contain 17/16/16/15/20/17 nodes and form an exact, disjoint 101/101 union matching build #83851, with zero missing, extra, or duplicate node IDs
- outer fixed cost was 0.833-1.040 minutes per shard; total shard GPU time was 51.119 minutes versus 50.792 minutes unsharded

## Duplicate-work check

Searched open PRs by the exact step key and sharding keywords. Existing matches concern ROCm gating, source dependencies, or the separate generation-2 job, not this key.

AI assistance was used to prepare and validate this CI-only change.
