### PR TITLE
[CI] Shard hybrid language model tests

### DIFF
--- a/.buildkite/test_areas/models_language.yaml
+++ b/.buildkite/test_areas/models_language.yaml
@@ -65,7 +65,7 @@ steps:
   - tests/models/language/generation
   commands:
     # The H200 test image prebuilds these exact CUDA extensions.
-    - python ../.buildkite/scripts/check-hybrid-test-deps.py
+    - python3 ../.buildkite/scripts/check-hybrid-test-deps.py
     # Shard the hybrid language model tests that are numerically stable on Hopper.
     - pytest -v -s models/language/generation -m hybrid_model -k 'not granite-4.0-tiny-preview' --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT --shard-id=$$BUILDKITE_PARALLEL_JOB
   parallelism: 6

--- a/.buildkite/test_areas/models_language.yaml
+++ b/.buildkite/test_areas/models_language.yaml
@@ -64,16 +64,16 @@ steps:
   - "!vllm/distributed/kv_transfer/"
   - tests/models/language/generation
   commands:
-    # Install fast path packages for testing against transformers
-    - MAMBA_FORCE_BUILD=TRUE uv pip install --system --no-build-isolation 'git+https://github.com/state-spaces/mamba@v2.3.0'
-    - CAUSAL_CONV1D_FORCE_BUILD=TRUE uv pip install --system --no-build-isolation 'git+https://github.com/Dao-AILab/causal-conv1d@v1.6.0'
+    # The H200 test image prebuilds these exact CUDA extensions.
+    - python ../.buildkite/scripts/check-hybrid-test-deps.py
     # Shard the hybrid language model tests that are numerically stable on Hopper.
     - pytest -v -s models/language/generation -m hybrid_model -k 'not granite-4.0-tiny-preview' --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT --shard-id=$$BUILDKITE_PARALLEL_JOB
-  parallelism: 2
+  parallelism: 6
   mirror:
     amd:
       dind: false
       device: mi300_1
+      parallelism: 2
       timeout_in_minutes: 60
       depends_on:
       - image-build-amd


### PR DESCRIPTION
## Summary

- run `language-models-tests-hybrid` as six deterministic NVIDIA shards
- consume the prebuilt H200 CUDA extensions from prerequisite PR #52333 instead of rebuilding them per shard
- keep the AMD mirror at two shards with its distinct ROCm mamba fork and source-build commands unchanged

## Why

The prior two-way #83851 run has an exact disjoint 39-node union (17 + 22) but takes 33.911 / 52.467 minutes. Pytest itself takes only 17.779 / 35.330 minutes; 16.132 / 17.138 minutes per shard are fixed, dominated by forced source builds of `mamba-ssm` and `causal-conv1d`.

Prerequisite PR #52333 moves the identical pinned NVIDIA packages into the test image once per build. Six shards distribute the 39 selected nodes as 5 / 6 / 7 / 7 / 5 / 9 by the actual pytest-shard hash, giving headroom for the less-than-20-minute target.

The AMD parallelism override depends on [ci-infra #473](https://github.com/vllm-project/ci-infra/pull/473), and this stacked PR depends on #52333. Neither prerequisite may merge after this PR.

## Validation

- parsed `.buildkite/test_areas/models_language.yaml` with PyYAML
- `uvx pre-commit run --files .buildkite/test_areas/models_language.yaml .buildkite/scripts/check-hybrid-test-deps.py docker/Dockerfile`
- `git diff --check`
- generated a full pipeline locally with ci-infra #473 head `e006ba64b39ffd4f179824f088ff10e88af5635f`; verified NVIDIA parallelism 6 with no source-build commands, AMD parallelism 2 with the ROCm fork/source builds preserved, and dependencies
- targeted Buildkite build [#83927](https://buildkite.com/vllm/ci/builds/83927) passed all six shards at exact stacked head `540f53bb2cb12efde84f361de7d4c5e309961856`
- shard walls were 5.094, 9.364, 9.762, 12.862, 4.948, and 14.877 minutes; the slowest is 14.877 minutes versus the 52.467-minute baseline maximum, a 3.527x wall-clock speedup
- manifests contain 5/6/7/7/5/9 nodes and form an exact, disjoint 39/39 union matching #83851, with zero missing, extra, or duplicate node IDs
- every shard verified `mamba_ssm==2.3.0@f1493ff6e9335160eb134eb67e59f8e4d9adefd6` and `causal_conv1d==1.6.0@da6dbaa9fd5a919967f14d3fd031da1288ad5025` from the runtime image
- fixed setup was 1.058-1.223 minutes per shard; total fixed setup fell from 33.270 to 6.893 GPU-minutes, and total job GPU time fell from 86.378 to 56.906 minutes
- cold image-build evidence from #83907 shows an observed one-time 1.857-minute delta versus same-batch Dockerfile-unchanged #83903; cached #83927 took 18.725 minutes and showed no recurring positive bake delta
- #83907 is superseded for test evidence because its original verifier command used unavailable bare `python`; it remains image-build-delta evidence only

## Duplicate-work check

Searched open PRs by the exact step key and package pins. Existing matches concern nightly C++ compatibility, source dependencies, or model features, not this stacked stable-image plus sharding change.

AI assistance was used to prepare and validate this CI-only change.
