### PR TITLE
[CI] Shard multimodal standard 4 tests

### DIFF
--- a/.buildkite/test_areas/models_multimodal.yaml
+++ b/.buildkite/test_areas/models_multimodal.yaml
@@ -70,7 +70,7 @@ steps:
   commands:
     - pytest -v -s models/multimodal -m core_model --ignore models/multimodal/generation/test_common.py --ignore models/multimodal/generation/test_ultravox.py --ignore models/multimodal/generation/test_qwen2_5_vl.py --ignore models/multimodal/generation/test_qwen2_vl.py --ignore models/multimodal/generation/test_whisper.py --ignore models/multimodal/generation/test_mm_prefix_lm.py --ignore models/multimodal/generation/test_memory_leak.py --ignore models/multimodal/generation/test_vit_cudagraph.py --ignore models/multimodal/processing --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT --shard-id=$$BUILDKITE_PARALLEL_JOB
     - pytest -v -s models/multimodal/generation/test_vit_cudagraph.py -m core_model --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT --shard-id=$$BUILDKITE_PARALLEL_JOB
-    - pytest -v -s models/multimodal/generation/test_memory_leak.py -m core_model --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT --shard-id=$$BUILDKITE_PARALLEL_JOB
+    - if [ "$$BUILDKITE_PARALLEL_JOB" -eq 0 ]; then pytest -v -s models/multimodal/generation/test_memory_leak.py -m core_model; fi
     - cd .. && VLLM_WORKER_MULTIPROC_METHOD=spawn pytest -v -s tests/models/multimodal/generation/test_whisper.py -m core_model --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT --shard-id=$$BUILDKITE_PARALLEL_JOB  # Otherwise, mp_method="spawn" doesn't work
   parallelism: 4
   mirror:

--- a/.buildkite/test_areas/models_multimodal.yaml
+++ b/.buildkite/test_areas/models_multimodal.yaml
@@ -59,7 +59,7 @@ steps:
       depends_on:
       - image-build-amd
 
-- label: "Multi-Modal Models (Standard) 4: other + whisper"
+- label: "Multi-Modal Models (Standard) 4: other + whisper %N"
   device: h200_35gb
   key: multi-modal-models-standard-4-other-whisper
   timeout_in_minutes: 75
@@ -68,14 +68,16 @@ steps:
   - "!vllm/distributed/kv_transfer/"
   - tests/models/multimodal
   commands:
-    - pytest -v -s models/multimodal -m core_model --ignore models/multimodal/generation/test_common.py --ignore models/multimodal/generation/test_ultravox.py --ignore models/multimodal/generation/test_qwen2_5_vl.py --ignore models/multimodal/generation/test_qwen2_vl.py --ignore models/multimodal/generation/test_whisper.py --ignore models/multimodal/generation/test_mm_prefix_lm.py --ignore models/multimodal/generation/test_memory_leak.py --ignore models/multimodal/generation/test_vit_cudagraph.py --ignore models/multimodal/processing
-    - pytest -v -s models/multimodal/generation/test_vit_cudagraph.py -m core_model
-    - pytest models/multimodal/generation/test_memory_leak.py -m core_model
-    - cd .. && VLLM_WORKER_MULTIPROC_METHOD=spawn pytest -v -s tests/models/multimodal/generation/test_whisper.py -m core_model  # Otherwise, mp_method="spawn" doesn't work
+    - pytest -v -s models/multimodal -m core_model --ignore models/multimodal/generation/test_common.py --ignore models/multimodal/generation/test_ultravox.py --ignore models/multimodal/generation/test_qwen2_5_vl.py --ignore models/multimodal/generation/test_qwen2_vl.py --ignore models/multimodal/generation/test_whisper.py --ignore models/multimodal/generation/test_mm_prefix_lm.py --ignore models/multimodal/generation/test_memory_leak.py --ignore models/multimodal/generation/test_vit_cudagraph.py --ignore models/multimodal/processing --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT --shard-id=$$BUILDKITE_PARALLEL_JOB
+    - pytest -v -s models/multimodal/generation/test_vit_cudagraph.py -m core_model --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT --shard-id=$$BUILDKITE_PARALLEL_JOB
+    - pytest -v -s models/multimodal/generation/test_memory_leak.py -m core_model --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT --shard-id=$$BUILDKITE_PARALLEL_JOB
+    - cd .. && VLLM_WORKER_MULTIPROC_METHOD=spawn pytest -v -s tests/models/multimodal/generation/test_whisper.py -m core_model --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT --shard-id=$$BUILDKITE_PARALLEL_JOB  # Otherwise, mp_method="spawn" doesn't work
+  parallelism: 4
   mirror:
     amd:
       dind: false
       device: mi300_1
+      parallelism: 1
       timeout_in_minutes: 50
       depends_on:
       - image-build-amd

--- a/.buildkite/test_areas/models_multimodal.yaml
+++ b/.buildkite/test_areas/models_multimodal.yaml
@@ -69,8 +69,11 @@ steps:
   - tests/models/multimodal
   commands:
     - pytest -v -s models/multimodal -m core_model --ignore models/multimodal/generation/test_common.py --ignore models/multimodal/generation/test_ultravox.py --ignore models/multimodal/generation/test_qwen2_5_vl.py --ignore models/multimodal/generation/test_qwen2_vl.py --ignore models/multimodal/generation/test_whisper.py --ignore models/multimodal/generation/test_mm_prefix_lm.py --ignore models/multimodal/generation/test_memory_leak.py --ignore models/multimodal/generation/test_vit_cudagraph.py --ignore models/multimodal/processing --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT --shard-id=$$BUILDKITE_PARALLEL_JOB
-    - pytest -v -s models/multimodal/generation/test_vit_cudagraph.py -m core_model --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT --shard-id=$$BUILDKITE_PARALLEL_JOB
-    - if [ "$$BUILDKITE_PARALLEL_JOB" -eq 0 ]; then pytest -v -s models/multimodal/generation/test_memory_leak.py -m core_model; fi
+    - >-
+      case "$$BUILDKITE_PARALLEL_JOB" in 0) pytest -v -s 'models/multimodal/generation/test_vit_cudagraph.py::test_vit_cudagraph_image[gemma4]' -m core_model && pytest -v -s 'models/multimodal/generation/test_vit_cudagraph.py::test_vit_cudagraph_video[gemma4]' -m core_model ;; 1|2|3) : ;; *) echo "Unexpected shard index $$BUILDKITE_PARALLEL_JOB" >&2; exit 2 ;; esac
+    - pytest -v -s models/multimodal/generation/test_vit_cudagraph.py -m core_model -k 'not gemma4' --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT --shard-id=$$BUILDKITE_PARALLEL_JOB
+    - >-
+      case "$$BUILDKITE_PARALLEL_JOB" in 0) pytest -v -s models/multimodal/generation/test_memory_leak.py -m core_model ;; 1|2|3) : ;; *) echo "Unexpected shard index $$BUILDKITE_PARALLEL_JOB" >&2; exit 2 ;; esac
     - cd .. && VLLM_WORKER_MULTIPROC_METHOD=spawn pytest -v -s tests/models/multimodal/generation/test_whisper.py -m core_model --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT --shard-id=$$BUILDKITE_PARALLEL_JOB  # Otherwise, mp_method="spawn" doesn't work
   parallelism: 4
   mirror:


### PR DESCRIPTION
## Summary

- run three pytest commands in `multi-modal-models-standard-4-other-whisper` as four deterministic shards
- isolate the Gemma4 image and video CUDA-graph nodes as two one-node pytest processes on shard 0, preserving them without retries, skips, or xfails
- run the singleton memory-leak test exactly once on shard 0, avoiding empty-selection exit 5 and duplicate coverage
- keep the AMD mirror at one job

## Why

Buildkite build #83851 took 50.857 minutes for this job, including 49.171 minutes across its four pytest commands and 1.687 minutes of outer fixed cost. Four shards target less than 20 minutes with headroom for model imbalance.

The AMD parallelism override depends on [ci-infra #473](https://github.com/vllm-project/ci-infra/pull/473). This PR must not merge first.

## Current-main blocker

Targeted [Buildkite #83935](https://buildkite.com/vllm/ci/builds/83935) is rejected for acceptance. The isolated `test_vit_cudagraph_image[gemma4]` process loaded the model and compiled its graph, then repeatedly failed 249,561,088-byte allocations with only 160/94/28 MiB free on the 33,280-MiB device. It ended in the same PyTorch `NVML_SUCCESS == r` allocator assertion seen in the earlier sharded attempts. Because the image and video commands are intentionally joined with `&&`, the image failure prevented the independently isolated video node from executing in this run.

The build is also a false green under this draft command shape. All four jobs finished with exit status 0 and 13.461/7.940/10.397/8.088-minute walls even though shard 0 contains the failed pytest. The failing image command is the left side of an AND-list, so shell `-e` does not stop there; the generated command continued through the remaining test commands and returned the last successful status. The green Buildkite state therefore is not valid acceptance evidence.

This is a current-main resource regression rather than a sharding defect or smaller worker allocation:

- baseline #83851 and #83935 both used H200 MIG workers with driver 580.159.03, CUDA 13.0, 15 MiB / 33,280 MiB visible at startup, `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:False`, and the same 18.92-GiB post-load KV-cache figure for Gemma4
- the failure reproduces cross-host: baseline used `h200-ci-4-12` GPU 2 slot 3, while #83935 used `h200-ci-4-15` GPU 3 slot 2
- baseline #83851 ran `v0.27.2rc1.dev78+g8e6d8e4f6` and passed its 20-node vit command; current #83935 ran `v0.27.2rc1.dev92+g27f27c530`
- the relevant behavioral boundary between those revisions is upstream #49852 / `66728fe`, “Enable encoder cuda graph for model runner v2,” which changes the encoder-cudagraph path this exact test exercises

Keep this PR draft and do not skip, xfail, or change the resource semantics. It is not ready for the accepted set until current main can run the underlying Gemma4 case on the existing worker allocation.

## Validation

- parsed `.buildkite/test_areas/models_multimodal.yaml` with PyYAML
- `uvx pre-commit run --files .buildkite/test_areas/models_multimodal.yaml`
- `git diff --check`
- generated a full pipeline locally with ci-infra #473 head `e006ba64b39ffd4f179824f088ff10e88af5635f`; verified NVIDIA parallelism 4, AMD parallelism 1, three deterministic sharded commands, Gemma4 coverage 2/2 as separate one-node processes, singleton memory-leak coverage 1/1 exactly once, fail-closed unexpected-index handling, and dependency preservation
- #83935 runtime manifests cover the complete complementary non-Gemma vit union 18/18 across shards as 5/2/6/5 with zero duplicates
- #83935 additionally emitted the isolated image-Gemma manifest, for 19 observed unique vit IDs; the video-Gemma manifest was not emitted because the preceding isolated image process failed and the two commands are intentionally joined with `&&`
- all four #83935 jobs finished with exit status 0, but shard 0's log contains `1 failed` for the isolated image-Gemma command; this terminal false-green result is explicitly rejected
- source selection and the full ci-infra #473 render preserve the intended exact 2 Gemma4 + 18 complementary vit IDs without skips, xfails, retries, or duplication

## Duplicate-work check

Searched open PRs by the exact step key and sharding keywords. No open PR shards this job; source-dependency and ROCm-gating changes are unrelated.

AI assistance was used to prepare and validate this CI-only change.
