### PR TITLE
[CI] Shard Kernels Attention Test to 7 shards, pin AMD mirror at 2 (<20 min)

### DIFF
--- a/.buildkite/test_areas/kernels.yaml
+++ b/.buildkite/test_areas/kernels.yaml
@@ -103,7 +103,7 @@ steps:
 
 - label: Kernels Attention Test %N
   key: kernels-attention-test
-  timeout_in_minutes: 65
+  timeout_in_minutes: 30
   source_file_dependencies:
   - csrc/attention/
   - vllm/v1/attention
@@ -113,11 +113,14 @@ steps:
   - tests/kernels/attention
   commands:
     - pytest -v -s kernels/attention --shard-id=$$BUILDKITE_PARALLEL_JOB --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT
-  parallelism: 2
+  parallelism: 7
   mirror:
     amd:
       dind: false
       device: mi300_1
+      # Pin the AMD mirror at its current 2 shards so raising NVIDIA
+      # parallelism does not multiply AMD copies (needs ci-infra #473).
+      parallelism: 2
       timeout_in_minutes: 90
       depends_on:
       - image-build-amd


### PR DESCRIPTION
## What
`kernels-attention-test` runs 2 NVIDIA shards at ~48–49 min each (~96 min logical) — a Phase-2 long pole. Raise NVIDIA `parallelism` 2 → 7 to land each shard ~13–14 min (<20 min target), while keeping the AMD mirror at its current 2 shards.

## How
- NVIDIA `parallelism: 2 → 7` (the `pytest -v -s kernels/attention --shard-id/--num-shards` command already shards). Per-shard `timeout_in_minutes` 65 → 30. Coverage/selection unchanged.
- **Pin `mirror.amd.parallelism: 2`** so the higher NVIDIA count does not multiply the AMD mirror. This depends on the ci-infra AMD-mirror parallelism override — **vllm-project/ci-infra#473** (`amd-mirror-parallelism-override`). Without #473 the field is ignored (AMD would inherit 7); with #473 it stays at 2. AMD command/coverage unchanged.

## Sizing
~96 min logical ÷ 7 ≈ 13.7 min/shard; leaves headroom under 20 min for pytest-shard's nodeid-hash imbalance. **Provisional** — will confirm from the targeted run and trim if there's excess headroom.

## Validation — build #83915 (targeted `kernels-attention-test` on #473, 7/7 green)
- Per-shard NVIDIA wall (min): 16.52 / 16.30 / 16.28 / 16.32 / 17.50 / 17.48 / 17.23 — **max 17.50, all <20**.
- Exact node union: pytest-shard partitions the full collection disjointly — per-shard "Running N" = 1131/1155/1142/1101/1166/1161/1153, **Σ = 8009 = collected 8009** (each item on exactly one shard).
- Fixed setup: 4.28–4.31 min/shard (job wall − pytest runtime).
- Total GPU-min: **117.6 vs the 2-shard baseline 96 (+21.6)** — the increase is exactly the 5 added shards × ~4.3 min fixed setup; wall dropped ~49→17.5 min (~2.8×).
- **AMD2 selector-off render** (real #473 generator, head `e006ba64`): NVIDIA renders **7**, AMD mirror pinned to exactly **2** (un-pinned it would inherit 7); AMD command byte-identical.


Part of the Phase-2 CI-overhaul sharding pass (kernels/basic-models workstream), one PR per key.
