### PR TITLE
[CI] Shard Kernels Quantization Test to 6 shards, pin AMD mirror at 2 (<20 min)

### DIFF
--- a/.buildkite/test_areas/kernels.yaml
+++ b/.buildkite/test_areas/kernels.yaml
@@ -163,18 +163,21 @@ steps:
 
 - label: Kernels Quantization Test %N
   key: kernels-quantization-test
-  timeout_in_minutes: 60
+  timeout_in_minutes: 30
   source_file_dependencies:
   - csrc/quantization/
   - vllm/model_executor/layers/quantization
   - tests/kernels/quantization
   commands:
     - pytest -v -s kernels/quantization --shard-id=$$BUILDKITE_PARALLEL_JOB --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT
-  parallelism: 2
+  parallelism: 6
   mirror:
     amd:
       dind: false
       device: mi300_1
+      # Pin the AMD mirror at its current 2 shards so raising NVIDIA
+      # parallelism does not multiply AMD copies (needs ci-infra #473).
+      parallelism: 2
       timeout_in_minutes: 120
       source_file_dependencies:
       - csrc/quantization/


### PR DESCRIPTION
## What
`kernels-quantization-test` runs 2 NVIDIA shards at ~40–45 min each (~85 min logical) — a Phase-2 long pole. Raise NVIDIA `parallelism` 2 → 6 to land each shard ~14 min (<20 min target), keeping the AMD mirror at its current 2 shards.

## How
- NVIDIA `parallelism: 2 → 6` (the `pytest -v -s kernels/quantization --shard-id/--num-shards` command already shards). Per-shard `timeout_in_minutes` 60 → 30. Coverage/selection unchanged.
- **Pin `mirror.amd.parallelism: 2`** so the higher NVIDIA count does not multiply the AMD mirror. Depends on the ci-infra AMD-mirror parallelism override — **vllm-project/ci-infra#473** (`amd-mirror-parallelism-override`); without it the field is ignored (AMD would inherit 6), with it AMD stays 2. AMD command/coverage unchanged.

## Sizing
~85 min logical ÷ 6 ≈ 14 min/shard; headroom under 20 min for nodeid-hash imbalance. **Provisional** — confirm/trim from the targeted run.

## Validation — build #83916 (targeted `kernels-quantization-test` on #473, 6/6 green)
- Per-shard NVIDIA wall (min): 10.27 / 11.72 / 11.85 / 10.47 / 16.15 / 13.55 — **max 16.15, all <20**.
- Exact node union: per-shard "Running N" = 1032/992/1027/1004/1002/1026, **Σ = 6083 = collected 6083** (disjoint partition).
- Fixed setup: 4.30–4.36 min/shard.
- Total GPU-min: **74.0 vs the 2-shard baseline 85 (−11)** (within run variance; added per-shard setup offset by lower test time this run); wall dropped ~48→16.15 min (~3×).
- **AMD2 selector-off render** (real #473 generator, head `e006ba64`): NVIDIA renders **6**, AMD mirror pinned to exactly **2** (un-pinned it would inherit 6); AMD command byte-identical.


Part of the Phase-2 CI-overhaul sharding pass (kernels/basic-models workstream), one PR per key.
