### PR TITLE
[CI] Shard model runner v2 spec decode tests

### DIFF
--- a/.buildkite/test_areas/model_runner_v2.yaml
+++ b/.buildkite/test_areas/model_runner_v2.yaml
@@ -128,10 +128,11 @@ steps:
     - pytest -v -s distributed/test_pp_cudagraph.py -k "not ray"
     - pytest -v -s v1/distributed/test_pp_dp_v2.py
 
-- label: ":nvidia: (H200 MIG 35GB) Model Runner V2 Spec Decode"
+- label: ":nvidia: (H200 MIG 35GB) Model Runner V2 Spec Decode %N"
   device: h200_35gb
   key: model-runner-v2-spec-decode
   timeout_in_minutes: 50
+  parallelism: 4
   working_dir: "/vllm-workspace/tests"
   source_file_dependencies:
   - vllm/v1/worker/gpu/
@@ -143,17 +144,15 @@ steps:
   commands:
   - set -x
   - export VLLM_USE_V2_MODEL_RUNNER=1
-  - pytest -v -s v1/spec_decode/test_max_len.py -k "eagle or mtp"
-  - pytest -v -s v1/spec_decode/test_rejection_sampler_utils.py
-  - pytest -v -s v1/spec_decode/test_synthetic_rejection_sampler_utils.py
-  - pytest -v -s v1/e2e/spec_decode/eagle/
-  - pytest -v -s v1/e2e/spec_decode/speculators/
-  - >-
-    pytest -v -s
-    'v1/e2e/spec_decode/mtp/test_mtp.py::test_mtp_correctness[qwen3_5-hybrid]'
+  - pytest -v -s v1/spec_decode/test_max_len.py -k "eagle or mtp" --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT --shard-id=$$BUILDKITE_PARALLEL_JOB
+  - pytest -v -s v1/spec_decode/test_rejection_sampler_utils.py --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT --shard-id=$$BUILDKITE_PARALLEL_JOB
+  - pytest -v -s v1/spec_decode/test_synthetic_rejection_sampler_utils.py --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT --shard-id=$$BUILDKITE_PARALLEL_JOB
+  - pytest -v -s v1/e2e/spec_decode/eagle/ --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT --shard-id=$$BUILDKITE_PARALLEL_JOB
+  - if [ "$$BUILDKITE_PARALLEL_JOB" = "0" ]; then pytest -v -s v1/e2e/spec_decode/speculators/; fi
+  - if [ "$$BUILDKITE_PARALLEL_JOB" = "1" ]; then pytest -v -s 'v1/e2e/spec_decode/mtp/test_mtp.py::test_mtp_correctness[qwen3_5-hybrid]'; fi
   mirror:
     amd:
-      label: ":amd: (MI355) Model Runner V2 Spec Decode"
+      label: ":amd: (MI355) Model Runner V2 Spec Decode %N"
       dind: false
       device: mi355_1
       timeout_in_minutes: 75


### PR DESCRIPTION
## Why

`NVIDIA Model Runner V2 Spec Decode` was 2,812s P90 across 12 runs in the 24-hour dashboard window ending 2026-09-01 10:31 UTC.

## What changed

Use the step's existing four-way parallelism to partition the four pytest collections, and run the two singleton groups once. The AMD mirror inherits the same partition instead of repeating the full suite in every parallel job. Labels are shard-qualified.

No merged or active non-draft PR covers this job.

## Validation

- YAML parse
- current `ci-infra` Buildkite step schema
- all YAML command entries pass `bash -n`
- `git diff --check`
- targeted NVIDIA/AMD CI and measured shard timings pending

This is a draft pending human review and targeted CI. AI assistance was used.
