### PR TITLE
[CI] Shard entrypoints pooling

### DIFF
--- a/.buildkite/test_areas/entrypoints.yaml
+++ b/.buildkite/test_areas/entrypoints.yaml
@@ -166,10 +166,11 @@ steps:
   - export VLLM_WORKER_MULTIPROC_METHOD=spawn
   - pytest -v -s entrypoints/multimodal
 
-- label: Entrypoints Integration (Pooling)
+- label: Entrypoints Integration (Pooling) %N
   device: h200_35gb
   key: entrypoints-integration-pooling
   timeout_in_minutes: 75
+  parallelism: 5
   working_dir: "/vllm-workspace/tests"
   source_file_dependencies:
   - vllm/
@@ -177,7 +178,70 @@ steps:
   - tests/entrypoints/pooling
   commands:
   - export VLLM_WORKER_MULTIPROC_METHOD=spawn
-  - pytest -v -s entrypoints/pooling
+  - |-
+    shard_0_files="
+      entrypoints/pooling/scoring/test_late_interaction_online_vision.py
+      entrypoints/pooling/embed/test_online.py
+      entrypoints/pooling/scoring/test_late_interaction_offline_vision.py
+      entrypoints/pooling/embed/test_online_dimensions.py
+      entrypoints/pooling/token_classify/test_offline.py
+      entrypoints/pooling/embed/test_io_processor.py
+    "
+    shard_1_files="
+      entrypoints/pooling/scoring/test_late_interaction_online.py
+      entrypoints/pooling/scoring/test_bi_encoder_online.py
+      entrypoints/pooling/scoring/test_cross_encoder_correctness_mteb.py
+      entrypoints/pooling/token_embed/test_online.py
+      entrypoints/pooling/embed/test_cohere_openai_parity.py
+      entrypoints/pooling/scoring/test_late_interaction_offline.py
+    "
+    shard_2_files="
+      entrypoints/pooling/scoring/test_cross_encoder_online_vision.py
+      entrypoints/pooling/reward/test_token_reward_online.py
+      entrypoints/pooling/classify/test_online.py
+      entrypoints/pooling/embed/test_cohere_online_vision.py
+      entrypoints/pooling/token_embed/test_offline.py
+      entrypoints/pooling/basic/test_encode.py
+      entrypoints/pooling/embed/test_protocol.py
+      entrypoints/pooling/test_io_processor.py
+      entrypoints/pooling/scoring/test_jina_ranking_io_processor_unit.py
+    "
+    shard_3_files="
+      entrypoints/pooling/scoring/test_cross_encoder_online.py
+      entrypoints/pooling/token_classify/test_online.py
+      entrypoints/pooling/classify/test_offline.py
+      entrypoints/pooling/basic/test_truncation.py
+      entrypoints/pooling/scoring/test_cross_encoder_offline.py
+      entrypoints/pooling/scoring/test_bi_encoder_offline.py
+      entrypoints/pooling/scoring/test_utils.py
+      entrypoints/pooling/test_utils.py
+    "
+    shard_4_files="
+      entrypoints/pooling/embed/test_online_vision.py
+      entrypoints/pooling/embed/test_cohere_online.py
+      entrypoints/pooling/classify/test_online_vision.py
+      entrypoints/pooling/embed/test_online_long_text.py
+      entrypoints/pooling/basic/test_tiling_engine.py
+      entrypoints/pooling/embed/test_offline.py
+      entrypoints/pooling/embed/test_correctness_mteb.py
+    "
+    known_files="$$shard_0_files $$shard_1_files $$shard_2_files $$shard_3_files $$shard_4_files"
+    case "$$BUILDKITE_PARALLEL_JOB" in
+      0) shard_files="$$shard_0_files" ;;
+      1) shard_files="$$shard_1_files" ;;
+      2) shard_files="$$shard_2_files" ;;
+      3) shard_files="$$shard_3_files" ;;
+      4) shard_files="$$shard_4_files" ;;
+      *) echo "Unexpected shard index: $$BUILDKITE_PARALLEL_JOB" >&2; exit 1 ;;
+    esac
+    if [ "$$BUILDKITE_PARALLEL_JOB" = "0" ]; then
+      for test_file in $$(find entrypoints/pooling -name 'test_*.py' -print | sort); do
+        if ! printf '%s\n' $$known_files | grep -Fqx "$$test_file"; then
+          shard_files="$$shard_files $$test_file"
+        fi
+      done
+    fi
+    pytest -v -s $$shard_files
 
 - label: OpenAI API Correctness
   key: openai-api-correctness


### PR DESCRIPTION
## Why

`entrypoints-integration-pooling` took 45.7 minutes in full CI build 83851. Its 320 collected pytest cases ran serially; the current head collects 325 after five intervening additions.

This does not duplicate an open pull request. Open PRs were searched by the exact step key and entrypoints pooling sharding terms before implementation.

## What changed

- run the step with five Buildkite jobs
- partition the current files into deterministic timing-balanced groups using measured build 83913 runtimes
- make zero-based shard 0 run its assigned files plus every current or future pooling test file not assigned to shards 1-4, so new files cannot be omitted or duplicated
- preserve the original source dependencies, environment, and device

## Validation

- baseline build 83851: 45.67-minute wall time; 320 cases collected and 320 passed/handled as expected
- rejected N=3 targeted build [83913](https://buildkite.com/vllm/ci/builds/83913) on superseded head `665e36ebae96813c262a7701557d6dc49d66a147`: all jobs passed and formed an exact disjoint 325/325 current-head union, but 24.19/27.00/27.03-minute walls missed the performance gate
- build 83913 fixed outer/setup time (job wall minus pytest summary): 0.93, 1.11, and 1.02 minutes
- accepted N=5 targeted build [83934](https://buildkite.com/vllm/ci/builds/83934) at exact head `8513a19f3b200040f6999a49863617b83e139ab4`: all five jobs passed in 9.78, 6.40, 6.96, 6.05, and 7.92 minutes
- wall minimum/median/maximum: 6.05/6.96/9.78 minutes; 3.73-minute spread, 1.62 max/min ratio, and 4.67x maximum-wall speedup versus the 45.67-minute baseline
- exact executed union: 325/325 current-head nodes, all unique and passed, with no duplicate, missing, or unexpected nodes; per-shard counts are 87/44/79/55/60
- fixed/outer time: 0.95, 0.83, 0.88, 0.87, and 0.92 minutes, 4.45 minutes total (+3.13 GPU-minutes versus the baseline outer component)
- total accelerator time: 37.10 GPU-minutes, 8.57 minutes lower than the 45.67-minute baseline run (-18.8%, an observed one-run delta rather than negative setup cost)
- assignment harness: all 37 discovered pooling test files route exactly once (36 collected/timed files plus one zero-node discovery file); the 325 current nodes map 87/44/79/55/60 with no duplicates or omissions; an unexpected shard index exits nonzero
- targeted shard 0 executed the accepted-head `find`/exact-membership catch-all path, preserving coverage for every current or future unassigned pooling test file
- selected-step render: five jobs with the `image-build` dependency; source and rendered shell both pass `sh -n`
- `uvx pre-commit run --files .buildkite/test_areas/entrypoints.yaml`: passed
- YAML parse, rendered shell syntax, and `git diff --check`: passed

AI assistance was used. The submitter will review and validate the change before marking it ready.
