### PR TITLE
[CI] Shard entrypoints API-server tests

### DIFF
--- a/.buildkite/test_areas/entrypoints.yaml
+++ b/.buildkite/test_areas/entrypoints.yaml
@@ -48,10 +48,11 @@ steps:
       depends_on:
       - image-build-amd
 
-- label: ":nvidia: (H200 MIG 35GB) Entrypoints Integration (API Server)"
+- label: ":nvidia: (H200 MIG 35GB) Entrypoints Integration (API Server) %N"
   key: entrypoints-integration-api-server
   device: h200_35gb
   timeout_in_minutes: 75
+  parallelism: 4
   working_dir: "/vllm-workspace/tests"
   source_file_dependencies:
   - vllm/
@@ -60,12 +61,12 @@ steps:
   - tests/entrypoints/scale_out
   commands:
   - export VLLM_WORKER_MULTIPROC_METHOD=spawn
-  - pytest -v -s entrypoints/serve --ignore=entrypoints/serve/dev/rpc
-  - PYTHONPATH=/vllm-workspace pytest -v -s entrypoints/serve/dev/rpc
-  - pytest -v -s entrypoints/scale_out
+  - pytest -v -s entrypoints/serve --ignore=entrypoints/serve/dev/rpc --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT --shard-id=$$BUILDKITE_PARALLEL_JOB
+  - if [ "$$BUILDKITE_PARALLEL_JOB" = "1" ]; then PYTHONPATH=/vllm-workspace pytest -v -s entrypoints/serve/dev/rpc; fi
+  - pytest -v -s entrypoints/scale_out --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT --shard-id=$$BUILDKITE_PARALLEL_JOB
   mirror:
     amd:
-      label: ":amd: (MI300) Entrypoints Integration (API Server)"
+      label: ":amd: (MI300) Entrypoints Integration (API Server) %N"
       dind: false
       device: mi300_1
       timeout_in_minutes: 65


### PR DESCRIPTION
## Why

In the 24-hour dashboard window ending 2026-09-01 10:31 UTC:

- NVIDIA Entrypoints API Server: 2,735s P90 (42 runs)
- AMD Entrypoints API Server: 2,733s P90 (41 runs)

## What changed

Partition the main serve and scale-out collections across four pytest shards, run the RPC singleton once, and apply the identical partition to the AMD mirror.

No merged or active non-draft PR covers this job.

## Validation

- YAML parse
- current `ci-infra` Buildkite step schema
- all YAML command entries pass `bash -n`
- `git diff --check`


## Targeted CI

[Build #86570](https://buildkite.com/vllm/ci/builds/86570) passed. API Server shards 1–4: `18:54, 25:59, 21:43, 23:20`. The three changed sibling keys also passed: Generate `26:37`, OpenAI Part 1 `17:48`, and OpenAI Part 2 `32:16`.

This is a draft pending human review. AI assistance was used.
