### PR TITLE
[CI] Shard PyTorch fullgraph tests

### DIFF
--- a/.buildkite/test_areas/pytorch.yaml
+++ b/.buildkite/test_areas/pytorch.yaml
@@ -110,10 +110,11 @@ steps:
   commands:
   - pytest -s -v compile/passes --ignore compile/passes/distributed
 
-- label: PyTorch Fullgraph Test
+- label: PyTorch Fullgraph Test %N
   device: h200_35gb
   key: pytorch-fullgraph-test
   timeout_in_minutes: 90
+  parallelism: 3
   source_file_dependencies:
   - vllm/__init__.py
   - vllm/_aiter_ops.py
@@ -146,7 +147,26 @@ steps:
   # as it is a heavy test that is covered in other steps.
   # Use `find` to launch multiple instances of pytest so that
   # they do not suffer from https://github.com/vllm-project/vllm/issues/28965
-  - "find compile/fullgraph/ -name 'test_*.py' -not -name 'test_full_cudagraph.py' -print0 | xargs -0 -n1 -I{} pytest -s -v '{}'"
+  - |-
+    shard_status=0
+    if [ "$$BUILDKITE_PARALLEL_JOB" = "0" ]; then
+      pytest -s -v 'compile/fullgraph/test_basic_correctness.py::test_compile_correctness[test_setting0]' || shard_status=1
+    elif [ "$$BUILDKITE_PARALLEL_JOB" = "2" ]; then
+      pytest -s -v 'compile/fullgraph/test_basic_correctness.py::test_compile_correctness[test_setting1]' || shard_status=1
+    fi
+    for test_file in $$(find compile/fullgraph/ -name 'test_*.py' \
+      -not -name 'test_full_cudagraph.py' \
+      -not -name 'test_basic_correctness.py' -print | sort); do
+      case "$$test_file" in
+        */test_full_graph.py) target_shard=1 ;;
+        */test_multimodal_compile.py|*/test_toy_llama.py) target_shard=2 ;;
+        *) target_shard=0 ;;
+      esac
+      if [ "$$BUILDKITE_PARALLEL_JOB" = "$$target_shard" ]; then
+        pytest -s -v "$$test_file" || shard_status=1
+      fi
+    done
+    [ "$$shard_status" -eq 0 ]
 
 # Hopper-only DeepSeek-V2-Lite cases in this file require two 29.3-GiB model
 # instances and cannot fit a 35GB MIG slice. L4 retains the original coverage:


### PR DESCRIPTION
## Why

`pytorch-fullgraph-test` took 47.7 minutes in full CI build 83851. The suite deliberately starts a fresh pytest process per file, and its two heaviest parametrized correctness cases ran in the same process.

This does not duplicate an open pull request. Open PRs were searched by the exact step key and PyTorch fullgraph sharding terms before implementation.

## What changed

- run the step with three Buildkite jobs
- split the two heavy basic-correctness parameters across shards 1 and 3
- assign the remaining test files to timing-balanced shard groups
- preserve the existing one-pytest-process-per-file isolation
- continue excluding `test_full_cudagraph.py`, which remains covered elsewhere

## Validation

- baseline build 83851: 47.67-minute wall time; exact 33-case selected union across six files
- baseline timing model: approximately 12.8, 17.4, and 17.0 minutes including observed per-file startup overhead
- selected-step render: three jobs with the `image-build` dependency
- `uvx pre-commit run --files .buildkite/test_areas/pytorch.yaml`: passed
- YAML parse, rendered shell syntax, and `git diff --check`: passed
- targeted build [83914](https://buildkite.com/vllm/ci/builds/83914) on exact head `4052a7e8e3d159c45bab8796af32397c1b97e21c`: all three jobs passed in 9.78, 12.67, and 13.85 minutes (min/median/max 9.78/12.67/13.85; 4.08-minute spread; 1.42x max/min)
- targeted coverage: exact 33-node baseline multiset, 33 unique nodes, no duplicates, missing nodes, or unexpected nodes; outcomes were 32 passed and one expected skip
- observed wall-clock speedup: 3.44x versus the 47.67-minute baseline
- fixed outer/setup time (job wall minus pytest summaries): 1.34, 0.90, and 1.22 minutes, 3.45 minutes total; repeated setup added 1.28 minutes versus the baseline outer time
- total accelerator time: 36.29 GPU-minutes, 11.38 minutes lower than the baseline run (-23.9%); the lower total is an observed runtime/cache variance, not negative setup overhead

AI assistance was used. The submitter will review and validate the change before marking it ready.
