### PR TITLE
[CI] Split long misc test groups by command

### DIFF
--- a/.buildkite/test_areas/misc.yaml
+++ b/.buildkite/test_areas/misc.yaml
@@ -2,11 +2,11 @@ group: Miscellaneous
 depends_on: 
   - image-build
 steps:
-- label: ":nvidia: (H200 MIG 18GB) V1 Sample + Logits"
-  key: v1-sample-logits
-  timeout_in_minutes: 83
+- label: ":nvidia: (H200 MIG 18GB) V1 Sample"
+  key: v1-sample
+  timeout_in_minutes: 35
   device: h200_18gb
-  source_file_dependencies:
+  source_file_dependencies: &v1-sample-logits-deps
     - vllm/config/
     - vllm/distributed/
     - "!vllm/distributed/kv_transfer/"
@@ -27,30 +27,42 @@ steps:
   commands:
     - export VLLM_WORKER_MULTIPROC_METHOD=spawn
     - pytest -v -s v1/sample
-    - pytest -v -s v1/logits_processors
-    - pytest -v -s v1/test_oracle.py
-    - pytest -v -s v1/test_request.py
-    - pytest -v -s v1/test_outputs.py
   mirror:
     amd:
-      label: ":amd: (MI300) V1 Sample + Logits"
+      label: ":amd: (MI300) V1 Sample"
       dind: false
       device: mi300_1
       timeout_in_minutes: 70
       depends_on:
       - image-build-amd
 
-- label: ":nvidia: (H200 MIG 35GB) V1 Core + KV + Metrics"
+- label: ":nvidia: (H200 MIG 18GB) V1 Logits + Oracle"
+  key: v1-logits-oracle
+  timeout_in_minutes: 35
+  device: h200_18gb
+  source_file_dependencies: *v1-sample-logits-deps
+  commands:
+    - export VLLM_WORKER_MULTIPROC_METHOD=spawn
+    # Keep these in separate pytest processes because the CUDA-initializing
+    # correctness tests interfere with the fork-based logits processor tests.
+    - pytest -v -s v1/logits_processors
+    - pytest -v -s v1/test_oracle.py
+    - pytest -v -s v1/test_request.py
+    - pytest -v -s v1/test_outputs.py
+  mirror:
+    amd:
+      label: ":amd: (MI300) V1 Logits + Oracle"
+      dind: false
+      device: mi300_1
+      timeout_in_minutes: 70
+      depends_on:
+      - image-build-amd
+
+- label: ":nvidia: (H200 MIG 35GB) V1 Core"
   device: h200_35gb
-  key: v1-core-kv-metrics
-  timeout_in_minutes: 100
-  env:
-    # GitHub intermittently rejects HTTP/2 upload-pack requests from the H200
-    # CI image. Force Git's smart protocol to use HTTP/1.1 for source installs.
-    GIT_CONFIG_COUNT: "1"
-    GIT_CONFIG_KEY_0: http.version
-    GIT_CONFIG_VALUE_0: HTTP/1.1
-  source_file_dependencies:
+  key: v1-core
+  timeout_in_minutes: 45
+  source_file_dependencies: &v1-core-kv-metrics-deps
     - vllm/config/
     - vllm/distributed/
     - "!vllm/distributed/kv_transfer/"
@@ -80,24 +92,95 @@ steps:
     - tests/v1/metrics
     - tests/entrypoints/openai/correctness/test_lmeval.py
   commands:
-    - bash /vllm-workspace/.buildkite/scripts/install-kv-connectors.sh
+    - export VLLM_WORKER_MULTIPROC_METHOD=spawn
+    - pytest -v -s -m 'not cpu_test' v1/core
+  mirror:
+    amd:
+      label: ":amd: (MI300) V1 Core"
+      dind: false
+      device: mi300_1
+      timeout_in_minutes: 45
+      depends_on:
+      - image-build-amd
+
+- label: ":nvidia: (H200 MIG 35GB) V1 Executor + Worker"
+  device: h200_35gb
+  key: v1-executor-worker
+  timeout_in_minutes: 45
+  source_file_dependencies: *v1-core-kv-metrics-deps
+  commands:
     - export VLLM_WORKER_MULTIPROC_METHOD=spawn
     # split the test to avoid interference
-    - pytest -v -s -m 'not cpu_test' v1/core
     - pytest -v -s v1/executor
-    - pytest -v -s v1/kv_offload
-    - pytest -v -s v1/simple_kv_offload
     - pytest -v -s v1/worker
     - pytest -v -s v1/streaming_input
+  mirror:
+    amd:
+      label: ":amd: (MI300) V1 Executor + Worker"
+      dind: false
+      device: mi300_1
+      timeout_in_minutes: 45
+      depends_on:
+      - image-build-amd
+
+- label: ":nvidia: (H200 MIG 35GB) V1 KV Offload"
+  device: h200_35gb
+  key: v1-kv-offload
+  timeout_in_minutes: 45
+  source_file_dependencies: *v1-core-kv-metrics-deps
+  commands:
+    - export VLLM_WORKER_MULTIPROC_METHOD=spawn
+    - pytest -v -s v1/kv_offload
+    - pytest -v -s v1/simple_kv_offload
+  mirror:
+    amd:
+      label: ":amd: (MI300) V1 KV Offload"
+      dind: false
+      device: mi300_1
+      timeout_in_minutes: 45
+      depends_on:
+      - image-build-amd
+
+- label: ":nvidia: (H200 MIG 35GB) V1 KV Connectors"
+  device: h200_35gb
+  key: v1-kv-connectors
+  timeout_in_minutes: 45
+  source_file_dependencies: *v1-core-kv-metrics-deps
+  commands:
+    - bash /vllm-workspace/.buildkite/scripts/install-kv-connectors.sh
+    - export VLLM_WORKER_MULTIPROC_METHOD=spawn
     - pytest -v -s -m 'not cpu_test' v1/kv_connector/unit
     - pytest -v -s -m 'not cpu_test' v1/ec_connector/unit
+  mirror:
+    amd:
+      label: ":amd: (MI300) V1 KV Connectors"
+      dind: false
+      device: mi300_1
+      timeout_in_minutes: 45
+      depends_on:
+      - image-build-amd
+
+- label: ":nvidia: (H200 MIG 35GB) V1 Metrics + LM Eval"
+  device: h200_35gb
+  key: v1-metrics-lmeval
+  timeout_in_minutes: 45
+  env:
+    # GitHub intermittently rejects HTTP/2 upload-pack requests from the H200
+    # CI image. Force Git's smart protocol to use HTTP/1.1 for source installs.
+    GIT_CONFIG_COUNT: "1"
+    GIT_CONFIG_KEY_0: http.version
+    GIT_CONFIG_VALUE_0: HTTP/1.1
+    GIT_TERMINAL_PROMPT: "0"
+  source_file_dependencies: *v1-core-kv-metrics-deps
+  commands:
+    - export VLLM_WORKER_MULTIPROC_METHOD=spawn
     - pytest -v -s -m 'not cpu_test' v1/metrics
     # Integration test for streaming correctness (requires special branch).
     - pip install -U git+https://github.com/vllm-project/lm-evaluation-harness.git@streaming-api
     - pytest -v -s entrypoints/openai/correctness/test_lmeval.py::test_lm_eval_accuracy_v1_engine
   mirror:
     amd:
-      label: ":amd: (MI300) V1 Core + KV + Metrics"
+      label: ":amd: (MI300) V1 Metrics + LM Eval"
       dind: false
       device: mi300_1
       timeout_in_minutes: 65
@@ -336,12 +419,12 @@ steps:
       depends_on:
       - image-build-amd
 
-- label: ":computer: (CPU) Async Engine, Inputs, Utils, Worker, Config"
-  key: async-engine-inputs-utils-worker-config-cpu
+- label: ":computer: (CPU) Params, Env, Tokenizers, Parser"
+  key: cpu-params-env-tokenizers-parser
   depends_on:
   - image-build-cpu
-  timeout_in_minutes: 65
-  source_file_dependencies:
+  timeout_in_minutes: 35
+  source_file_dependencies: &cpu-async-engine-deps
   - vllm/assets/
   - vllm/config/
   - vllm/engine/arg_utils.py
@@ -389,14 +472,41 @@ steps:
   - pytest -v -s test_pooling_params.py
   - pytest -v -s test_ray_env.py
   - pytest -v -s test_sampling_params.py
-  - pytest -v -s -m 'cpu_test' multimodal
-  - pytest -v -s renderers
-  - pytest -v -s reasoning
-  - pytest -v -s tool_parsers
   - pytest -v -s tokenizers_
   - pytest -v -s parser
   - pytest -v -s transformers_utils
+
+- label: ":computer: (CPU) Multimodal + Config"
+  key: cpu-multimodal-config
+  depends_on:
+  - image-build-cpu
+  timeout_in_minutes: 35
+  source_file_dependencies: *cpu-async-engine-deps
+  device: cpu-small
+  commands:
+  - pytest -v -s -m 'cpu_test' multimodal
   - pytest -v -s config
+
+- label: ":computer: (CPU) Reasoning + Renderers"
+  key: cpu-reasoning-renderers
+  depends_on:
+  - image-build-cpu
+  timeout_in_minutes: 35
+  source_file_dependencies: *cpu-async-engine-deps
+  device: cpu-small
+  commands:
+  - pytest -v -s reasoning
+  - pytest -v -s renderers
+
+- label: ":computer: (CPU) Tool Parsers"
+  key: cpu-tool-parsers
+  depends_on:
+  - image-build-cpu
+  timeout_in_minutes: 35
+  source_file_dependencies: *cpu-async-engine-deps
+  device: cpu-small
+  commands:
+  - pytest -v -s tool_parsers
 
 - label: ":nvidia: (A100) Batch Invariance"
   key: batch-invariance-a100


### PR DESCRIPTION
## Why

The miscellaneous CI groups are on the critical path. In the 24-hour dashboard window ending 2026-09-01 10:31 UTC, their P90 durations were 3,975s for NVIDIA V1 Core + KV + Metrics (37 runs), 3,330s for the CPU misc group (35 runs), and 2,917s for AMD V1 Sample + Logits (36 runs).

## What changed

Split the three long groups into separate jobs by pytest command:

- V1 Sample + Logits → V1 Sample; V1 Logits + Oracle.
- V1 Core + KV + Metrics → V1 Core; V1 Executor + Worker; V1 KV Offload; V1 KV Connectors; V1 Metrics + LM Eval.
- CPU misc → Params, Env, Tokenizers, Parser; Multimodal + Config; Reasoning + Renderers; Tool Parsers.

All pytest commands, test-selection dependencies, devices, and seven AMD mirrors are preserved. Separate pytest processes preserve CUDA/fork isolation. Shared dependency lists use YAML anchors; the final change adds no pytest sharding or exit-code suppression.

The LM Eval job retains main's HTTP/1.1 Git workaround and sets `GIT_TERMINAL_PROMPT=0` in its environment. This prevents an interactive Git credential prompt from consuming the job timeout.

This consolidates the now-closed #52348. The open-PR overlap check found no other PR implementing this misc-group split. The change addresses the review request to split coherent groups without sharding scaffolding. AI assistance was used.

## Validation

On rebased head `fd2e5d0ae4`:

- `pre-commit run --files .buildkite/test_areas/misc.yaml` — passed.
- `git diff --check` — passed.
- YAML duplicate-key check and current ci-infra `Step` schema — passed for all 23 source steps.
- Exact comparison of pytest-command multisets against current main — passed; no commands dropped or duplicated.
- Test-selection dependency, device, and AMD mirror comparison against main — passed.
- `bash -n` for every source command and affected rendered command — passed.
- End-to-end current pipeline-generator run — 646 rendered steps, unique keys, all 18 affected jobs runnable, Git environment preserved on NVIDIA and AMD.

No model/runtime implementation changes are included; existing accuracy coverage remains in the LM Eval job.

## CI evidence

[Build #86987](https://buildkite.com/vllm/ci/builds/86987) tested the command-based split at `ad746d42d8`: 17/18 affected jobs passed. The remaining NVIDIA Metrics + LM Eval job passed all 80 metrics tests, then timed out at a Git credential prompt while installing the evaluation harness. That prompt is now disabled, and the HTTP/1.1 workaround is retained.

Representative passing wall times from that build:

| Jobs | NVIDIA | AMD |
| --- | --- | --- |
| V1 Sample | 26m38s | 34m37s |
| V1 Logits + Oracle | 15m33s | 17m57s |
| V1 Core | 3m06s | 5m10s |
| V1 Executor + Worker | 10m21s | 11m27s |
| V1 KV Offload | 6m28s | 8m16s |
| V1 KV Connectors | 36m17s | 22m46s |

The four CPU jobs passed in 10m04s–23m17s. These are individual validation runs, not a new P90 measurement.

[Build #87661](https://buildkite.com/vllm/ci/builds/87661) validates the misc jobs, including all 18 affected NVIDIA/AMD/CPU jobs, at `fd2e5d0ae4` using normal file-based selection; results are pending. Build #87660 failed before running tests because the manually supplied selector included generated AMD mirror keys, which the generator does not accept; the replacement build removes that selector.
