### PR TITLE
[CI] Shard Async Engine/Inputs/Utils/Worker/Config (CPU) into 4 timing-balanced groups

### DIFF
--- a/.buildkite/test_areas/misc.yaml
+++ b/.buildkite/test_areas/misc.yaml
@@ -315,7 +315,7 @@ steps:
   key: async-engine-inputs-utils-worker-config-cpu
   depends_on:
   - image-build-cpu
-  timeout_in_minutes: 65
+  timeout_in_minutes: 25
   source_file_dependencies:
   - vllm/assets/
   - vllm/config/
@@ -358,22 +358,25 @@ steps:
   - tests/transformers_utils
   - tests/config
   device: cpu-small
+  parallelism: 3
   commands:
-  - python3 standalone_tests/lazy_imports.py
-  - pytest -v -s test_envs.py
-  - pytest -v -s test_inputs.py
-  - pytest -v -s test_outputs.py
-  - pytest -v -s test_pooling_params.py
-  - pytest -v -s test_ray_env.py
-  - pytest -v -s test_sampling_params.py
-  - pytest -v -s -m 'cpu_test' multimodal
-  - pytest -v -s renderers
-  - pytest -v -s reasoning
-  - pytest -v -s tool_parsers
-  - pytest -v -s tokenizers_
-  - pytest -v -s parser
-  - pytest -v -s transformers_utils
-  - pytest -v -s config
+  # Timing-balanced static split (measured on build 83851): shard 0 ~17.1m,
+  # shard 1 ~17.1m, shard 2 ~16.8m. tokenizers_ (~16.5m) anchors shard 0.
+  - test "$$BUILDKITE_PARALLEL_JOB" != "0" || python3 standalone_tests/lazy_imports.py
+  - test "$$BUILDKITE_PARALLEL_JOB" != "0" || pytest -v -s test_envs.py
+  - test "$$BUILDKITE_PARALLEL_JOB" != "2" || pytest -v -s test_inputs.py
+  - test "$$BUILDKITE_PARALLEL_JOB" != "2" || pytest -v -s test_outputs.py
+  - test "$$BUILDKITE_PARALLEL_JOB" != "1" || pytest -v -s test_pooling_params.py
+  - test "$$BUILDKITE_PARALLEL_JOB" != "1" || pytest -v -s test_ray_env.py
+  - test "$$BUILDKITE_PARALLEL_JOB" != "2" || pytest -v -s test_sampling_params.py
+  - test "$$BUILDKITE_PARALLEL_JOB" != "1" || pytest -v -s -m 'cpu_test' multimodal
+  - test "$$BUILDKITE_PARALLEL_JOB" != "1" || pytest -v -s renderers
+  - test "$$BUILDKITE_PARALLEL_JOB" != "1" || pytest -v -s reasoning
+  - test "$$BUILDKITE_PARALLEL_JOB" != "2" || pytest -v -s tool_parsers
+  - test "$$BUILDKITE_PARALLEL_JOB" != "0" || pytest -v -s tokenizers_
+  - test "$$BUILDKITE_PARALLEL_JOB" != "2" || pytest -v -s parser
+  - test "$$BUILDKITE_PARALLEL_JOB" != "2" || pytest -v -s transformers_utils
+  - test "$$BUILDKITE_PARALLEL_JOB" != "2" || pytest -v -s config
 
 - label: Batch Invariance (A100)
   key: batch-invariance-a100

--- a/.buildkite/test_areas/misc.yaml
+++ b/.buildkite/test_areas/misc.yaml
@@ -358,24 +358,27 @@ steps:
   - tests/transformers_utils
   - tests/config
   device: cpu-small
-  parallelism: 3
+  parallelism: 4
   commands:
-  # Timing-balanced static split (measured on build 83851): shard 0 ~17.1m,
-  # shard 1 ~17.1m, shard 2 ~16.8m. tokenizers_ (~16.5m) anchors shard 0.
-  - test "$$BUILDKITE_PARALLEL_JOB" != "0" || python3 standalone_tests/lazy_imports.py
-  - test "$$BUILDKITE_PARALLEL_JOB" != "0" || pytest -v -s test_envs.py
-  - test "$$BUILDKITE_PARALLEL_JOB" != "2" || pytest -v -s test_inputs.py
-  - test "$$BUILDKITE_PARALLEL_JOB" != "2" || pytest -v -s test_outputs.py
+  # Timing-balanced static split (remeasured on build 83920). Total command
+  # time ~53m + ~1.9m setup means even a perfect 3-way split floors at ~19.6m,
+  # so tokenizers_ (17.4m, 1369 nodes, longest node 0.20m) is pytest-sharded
+  # across shards 0-1 and everything else is grouped for ~13m/shard.
+  - test "$$BUILDKITE_PARALLEL_JOB" != "1" || python3 standalone_tests/lazy_imports.py
+  - test "$$BUILDKITE_PARALLEL_JOB" != "1" || pytest -v -s test_envs.py
+  - test "$$BUILDKITE_PARALLEL_JOB" != "1" || pytest -v -s test_inputs.py
+  - test "$$BUILDKITE_PARALLEL_JOB" != "0" || pytest -v -s test_outputs.py
   - test "$$BUILDKITE_PARALLEL_JOB" != "1" || pytest -v -s test_pooling_params.py
-  - test "$$BUILDKITE_PARALLEL_JOB" != "1" || pytest -v -s test_ray_env.py
-  - test "$$BUILDKITE_PARALLEL_JOB" != "2" || pytest -v -s test_sampling_params.py
-  - test "$$BUILDKITE_PARALLEL_JOB" != "1" || pytest -v -s -m 'cpu_test' multimodal
-  - test "$$BUILDKITE_PARALLEL_JOB" != "1" || pytest -v -s renderers
+  - test "$$BUILDKITE_PARALLEL_JOB" != "0" || pytest -v -s test_ray_env.py
+  - test "$$BUILDKITE_PARALLEL_JOB" != "0" || pytest -v -s test_sampling_params.py
+  - test "$$BUILDKITE_PARALLEL_JOB" != "2" || pytest -v -s -m 'cpu_test' multimodal
+  - test "$$BUILDKITE_PARALLEL_JOB" != "3" || pytest -v -s renderers
   - test "$$BUILDKITE_PARALLEL_JOB" != "1" || pytest -v -s reasoning
-  - test "$$BUILDKITE_PARALLEL_JOB" != "2" || pytest -v -s tool_parsers
-  - test "$$BUILDKITE_PARALLEL_JOB" != "0" || pytest -v -s tokenizers_
-  - test "$$BUILDKITE_PARALLEL_JOB" != "2" || pytest -v -s parser
-  - test "$$BUILDKITE_PARALLEL_JOB" != "2" || pytest -v -s transformers_utils
+  - test "$$BUILDKITE_PARALLEL_JOB" != "3" || pytest -v -s tool_parsers
+  - test "$$BUILDKITE_PARALLEL_JOB" != "0" || pytest -v -s tokenizers_ --num-shards=2 --shard-id=0
+  - test "$$BUILDKITE_PARALLEL_JOB" != "1" || pytest -v -s tokenizers_ --num-shards=2 --shard-id=1
+  - test "$$BUILDKITE_PARALLEL_JOB" != "0" || pytest -v -s parser
+  - test "$$BUILDKITE_PARALLEL_JOB" != "0" || pytest -v -s transformers_utils
   - test "$$BUILDKITE_PARALLEL_JOB" != "2" || pytest -v -s config
 
 - label: Batch Invariance (A100)

--- a/.buildkite/test_areas/misc.yaml
+++ b/.buildkite/test_areas/misc.yaml
@@ -364,6 +364,8 @@ steps:
   # time ~53m + ~1.9m setup means even a perfect 3-way split floors at ~19.6m,
   # so tokenizers_ (17.4m, 1369 nodes, longest node 0.20m) is pytest-sharded
   # across shards 0-1 and everything else is grouped for ~13m/shard.
+  # An index outside 0-3 would skip every guard and pass empty; fail it instead.
+  - case "$$BUILDKITE_PARALLEL_JOB" in 0|1|2|3) ;; *) echo "unexpected BUILDKITE_PARALLEL_JOB=$$BUILDKITE_PARALLEL_JOB" && exit 1;; esac
   - test "$$BUILDKITE_PARALLEL_JOB" != "1" || python3 standalone_tests/lazy_imports.py
   - test "$$BUILDKITE_PARALLEL_JOB" != "1" || pytest -v -s test_envs.py
   - test "$$BUILDKITE_PARALLEL_JOB" != "1" || pytest -v -s test_inputs.py


### PR DESCRIPTION
## Purpose

Phase 2 of the CI job-splitting effort (45–60m jobs → shards <20m). `async-engine-inputs-utils-worker-config-cpu` ran **53.0m** in build [83851](https://buildkite.com/vllm/ci/builds/83851).

## Validation (terminal, build 83933)

Targeted build [83933](https://buildkite.com/vllm/ci/builds/83933) on this exact head: **4/4 passed, walls 14.33 / 14.68 / 15.17 / 15.52m — max 15.52m** with real margin (3.4× vs baseline).

- **tokenizers_ split (pytest-shard 2-way):** both halves collected the full 926-item suite and ran disjoint manifests — shard 0 `Running 450`, shard 1 `Running 476`, **450 + 476 = 926 = collected**, exact and disjoint by construction.
- **All 14 non-tokenizer commands executed exactly once** (per-session collection from the logs): shard 0 = outputs(1), ray_env(16), sampling(11), parser(4067), transformers_utils(53); shard 1 = lazy_imports, envs(55), inputs(2), pooling(12), reasoning(460); shard 2 = multimodal cpu_test(258 selected/256 deselected by marker), config(128); shard 3 = renderers(426), tool_parsers(1072).
- **Fail-closed index guard** ran first on every shard (0|1|2|3 validator).
- **Fixed setup:** 1.85–1.87m/shard. **Total CPU-min:** 59.7 vs 53.0 baseline (**+12.6%**, cpu-small queue, no GPU); wall 53.0 → 15.52m.

## History

First head (3-way) validated green in build [83920](https://buildkite.com/vllm/ci/builds/83920) but was rejected on the strict gate (walls 20.48/19.54/19.17m): total command time ≈53m + ~1.9m setup means even a perfectly balanced 3-way split floors at ≈19.6m. `tokenizers_` (longest node 0.20m — no single-test floor) was therefore split 2-way and the job moved to `parallelism: 4`.

## Notes

- No open PR shards this job (checked `gh pr list` for the step key and file).
- AI assistance was used for this change.
