### PR TITLE
[CI] Shard Kernels (B200) into 3 timing-balanced command buckets (<20 min)

### DIFF
--- a/.buildkite/test_areas/kernels.yaml
+++ b/.buildkite/test_areas/kernels.yaml
@@ -307,7 +307,7 @@ steps:
   commands:
     - nvidia-smi
     - |
-      set -euo pipefail
+      set -eu
       case "$$BUILDKITE_PARALLEL_JOB" in
         0)
           pytest -v -s tests/kernels/attention/test_attention_selector.py

--- a/.buildkite/test_areas/kernels.yaml
+++ b/.buildkite/test_areas/kernels.yaml
@@ -261,7 +261,8 @@ steps:
 
 - label: Kernels (B200)
   key: kernels-b200
-  timeout_in_minutes: 80
+  timeout_in_minutes: 30
+  parallelism: 3
   working_dir: "/vllm-workspace/"
   device: b200-k8s
   # optional: true
@@ -305,39 +306,49 @@ steps:
   - tests/kernels/test_top_k_per_row.py
   commands:
     - nvidia-smi
-    - python3 examples/basic/offline_inference/chat.py
-    # Attention
-    # num_heads2 broken by https://github.com/flashinfer-ai/flashinfer/issues/1353
-    - pytest -v -s tests/kernels/attention/test_attention_selector.py
-    - pytest -v -s tests/kernels/attention/test_flashinfer.py -k 'not num_heads2'
-    - pytest -v -s tests/kernels/attention/test_flashinfer_trtllm_attention.py
-    - pytest -v -s tests/kernels/attention/test_cutlass_mla_decode.py
-    - pytest -v -s tests/kernels/attention/test_flashinfer_mla_decode.py
-    - pytest -v -s tests/kernels/attention/test_minimax_m3_msa_cutlass_sparse_decode.py
-    - pytest -v -s tests/kernels/test_fused_minimax_m3_qknorm_rope_kv_insert.py
-    - pytest -v -s tests/kernels/test_top_k_per_row.py
-    # Quantization
-    - pytest -v -s tests/kernels/quantization/test_cutlass_scaled_mm.py -k 'fp8'
-    - pytest -v -s tests/kernels/quantization/test_nvfp4_quant.py
-    - pytest -v -s tests/kernels/quantization/test_silu_mul_nvfp4_quant.py
-    - pytest -v -s tests/kernels/quantization/test_nvfp4_scaled_mm.py
-    - pytest -v -s tests/kernels/quantization/test_flashinfer_scaled_mm.py
-    - pytest -v -s tests/kernels/quantization/test_flashinfer_nvfp4_scaled_mm.py
-    - pytest -v -s tests/kernels/quantization/test_nvfp4_qutlass.py
-    - pytest -v -s tests/kernels/quantization/test_mxfp4_qutlass.py
-    - pytest -v -s tests/kernels/moe/test_nvfp4_moe.py
-    - pytest -v -s tests/kernels/moe/test_mxfp4_moe.py
-    - pytest -v -s tests/kernels/moe/test_ocp_mx_moe.py
-    - pytest -v -s tests/kernels/moe/test_flashinfer.py
-    - pytest -v -s tests/kernels/moe/test_flashinfer_moe.py
-    - pytest -v -s tests/kernels/moe/test_trtllm_nvfp4_moe.py
-    - pytest -v -s tests/kernels/moe/test_cutedsl_moe.py
-    - pytest -v -s tests/kernels/mamba/test_gdn_prefill_cutedsl.py
-    - pytest -v -s tests/kernels/test_bf16x3_router_gemm_cutedsl.py
-    - pytest -v -s tests/kernels/attention/test_minimax_m3.py
-    - pytest -v -s tests/kernels/test_ll_bf16_gemm.py
-    # e2e
-    - pytest -v -s tests/models/quantization/test_nvfp4.py
+    - |
+      set -euo pipefail
+      case "$$BUILDKITE_PARALLEL_JOB" in
+        0)
+          pytest -v -s tests/kernels/attention/test_attention_selector.py
+          pytest -v -s tests/kernels/attention/test_flashinfer_trtllm_attention.py
+          pytest -v -s tests/kernels/attention/test_flashinfer_mla_decode.py
+          pytest -v -s tests/kernels/test_top_k_per_row.py
+          pytest -v -s tests/kernels/quantization/test_silu_mul_nvfp4_quant.py
+          pytest -v -s tests/kernels/quantization/test_flashinfer_scaled_mm.py
+          pytest -v -s tests/kernels/moe/test_nvfp4_moe.py
+          pytest -v -s tests/kernels/moe/test_ocp_mx_moe.py
+          pytest -v -s tests/kernels/test_bf16x3_router_gemm_cutedsl.py
+          pytest -v -s tests/kernels/test_ll_bf16_gemm.py
+          ;;
+        1)
+          python3 examples/basic/offline_inference/chat.py
+          pytest -v -s tests/kernels/attention/test_minimax_m3_msa_cutlass_sparse_decode.py
+          pytest -v -s tests/kernels/test_fused_minimax_m3_qknorm_rope_kv_insert.py
+          pytest -v -s tests/kernels/quantization/test_flashinfer_nvfp4_scaled_mm.py
+          pytest -v -s tests/kernels/quantization/test_nvfp4_qutlass.py
+          pytest -v -s tests/kernels/moe/test_mxfp4_moe.py
+          pytest -v -s tests/kernels/moe/test_flashinfer_moe.py
+          pytest -v -s tests/kernels/moe/test_cutedsl_moe.py
+          pytest -v -s tests/models/quantization/test_nvfp4.py
+          ;;
+        2)
+          pytest -v -s tests/kernels/attention/test_flashinfer.py -k 'not num_heads2'
+          pytest -v -s tests/kernels/attention/test_cutlass_mla_decode.py
+          pytest -v -s tests/kernels/quantization/test_cutlass_scaled_mm.py -k 'fp8'
+          pytest -v -s tests/kernels/quantization/test_nvfp4_quant.py
+          pytest -v -s tests/kernels/quantization/test_nvfp4_scaled_mm.py
+          pytest -v -s tests/kernels/quantization/test_mxfp4_qutlass.py
+          pytest -v -s tests/kernels/moe/test_flashinfer.py
+          pytest -v -s tests/kernels/moe/test_trtllm_nvfp4_moe.py
+          pytest -v -s tests/kernels/mamba/test_gdn_prefill_cutedsl.py
+          pytest -v -s tests/kernels/attention/test_minimax_m3.py
+          ;;
+        *)
+          echo "unexpected BUILDKITE_PARALLEL_JOB=$$BUILDKITE_PARALLEL_JOB" >&2
+          exit 1
+          ;;
+      esac
 
 - label: Kernels Helion Test
   key: kernels-helion-test


### PR DESCRIPTION
## What
`Kernels (B200)` runs ~30 curated `pytest <file>` commands as one b200-k8s job (~48 min wall). Keep it a **single logical key/PR** and split into 3 shards so each lands <20 min, without collapsing the per-file `-k` filters.

## How
- `parallelism: 3` on `kernels-b200`. The command list is partitioned by `$BUILDKITE_PARALLEL_JOB` into 3 timing-balanced buckets (greedy longest-processing-time from the measured per-command walls). Each command — with its exact `-k` filter — runs on **exactly one** shard. `nvidia-smi` stays a per-shard diagnostic. `set -eu` preserves fail-fast: any command failing fails that shard. Per-shard `timeout_in_minutes` 80 → 30. 2-way was rejected (~24 min > target).

## Bucket balance (measured per-command minutes)
| shard | load | commands |
|---|---|---|
| 0 | 16.06 m | 10 |
| 1 | 15.88 m | 9 |
| 2 | 16.01 m | 10 |

Max static load 16.06 min (≤16.5 target); leaves ordinary setup under 20 min.

## Coverage — exact command union
The 29 test/smoke commands (all except `nvidia-smi`) are partitioned disjointly and completely: **executed union == the current 29-command baseline, verified** (no command dropped or double-run, every `-k` preserved). `nvidia-smi` runs on all 3 shards as a diagnostic only.

## Validation — build #83931 (targeted `kernels-b200` on `eda9a0a1`, 3/3 green)
- Per-shard wall (min): 16.30 / 14.96 / 16.82 — **max 16.82, all <20**.
- Command coverage: the 3 shards run **disjoint** command buckets (no command double-run); the exact **29-command each-once partition was verified statically pre-launch** (executed union == origin/main's 29 baseline commands) and lead-reviewed. `nvidia-smi` is a per-shard diagnostic only.
- Total GPU-min: **48.1 vs the single-job baseline 48.9 (≈equal)** — the 3-way split adds essentially no GPU-min; wall ~49→16.8 min (~2.9×). No AMD mirror.


Part of the Phase-2 CI-overhaul sharding pass (kernels/basic-models workstream), one PR per key.

