### PR TITLE
[CI] Expand Basic Models (Extra Initialization) to 14 shards (<20 min)

### DIFF
--- a/.buildkite/test_areas/models_basic.yaml
+++ b/.buildkite/test_areas/models_basic.yaml
@@ -18,7 +18,7 @@ steps:
 - label: Basic Models Tests (Extra Initialization) %N
   device: h200_35gb
   key: basic-models-tests-extra-initialization
-  timeout_in_minutes: 100
+  timeout_in_minutes: 30
   source_file_dependencies:
   - vllm/model_executor/models/
   - tests/models/test_initialization.py
@@ -28,7 +28,7 @@ steps:
     # subset of supported models (the complement of the small subset in the above
     # test.) Also run if model initialization test file is modified
     - pytest -v -s models/test_initialization.py -k 'not test_can_initialize_small_subset' --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT --shard-id=$$BUILDKITE_PARALLEL_JOB
-  parallelism: 4
+  parallelism: 14
 
 - label: Basic Models Tests (Other)
   device: h200_35gb


### PR DESCRIPTION
## What
`basic-models-tests-extra-initialization` currently runs **4 shards at ~53–60 min each** (~224 GPU-min of large-model-init tests) — well over the Phase-2 <20 min target. Expand it to 14 shards.

## Structural analysis (why higher N, not a peel)
Parsed per-model init durations from the #83851 shard-3 log (105 models, 58.8 min, matching the wall):
- Broad, flat distribution — slowest single model `Qwen3_5ForConditionalGeneration` ~124 s (~2 min); then a 50–83 s tail; mean ~35 s/model.
- **No single-test floor** (nothing near 20 min) and **no dominant peelable family** — the hot shard is just a few heavy multimodal (`*ForConditionalGeneration`) inits landing there by nodeid hash.

So peeling a family can't cut the 224 GPU-min; the clean split is a higher pytest-shard count (the step already uses `--num-shards/--shard-id`).

## Sizing
Floor = 224 min ÷ 20 = 12 shards; with the observed ~1.13× hash imbalance, **N=14** lands the worst shard ~18 min (N=12 would peak ~21 min). `parallelism: 4 → 14`, per-shard `timeout_in_minutes` 100 → 30, no mirror. This adds 10 h200 copies — the repeated per-shard setup / total GPU-min will be recorded from the run.

## Validation — build #83919 (targeted `basic-models-tests-extra-initialization`, 14/14 green)
- Per-shard wall (min): 12.66 / 8.53 / 13.63 / 10.08 / 12.13 / 11.04 / 9.37 / 15.02 / 17.59 / 9.48 / 17.03 / 17.35 / 13.55 / 13.84 — **max 17.59, all <20**. Max ≥17 min, so N=14 stands (no trim to 13).
- Fixed setup: **0.67–1.01 min/shard** (job wall − pytest runtime) — small, because model-init has no kernel build.
- Total GPU-min: **181.3 vs the 4-shard baseline 224.1 (−42.8)** — 14-way did **not** balloon GPU-min (each added shard re-pays only ~0.9 min setup); wall dropped ~56→17.6 min (~3.2×).
- Node coverage: the 14 shards are **pairwise disjoint**, and their executed nodeid set is **byte-identical to the #83851 4-shard baseline — 374 = 374, verified from the `Running N items in this shard` manifests on both sides, set-difference 0 in both directions** (cross-checked by @Cuong). Resharding changes no coverage. The collected-386 / selected-385 line is runtime deselection that varies per machine (1–2 shards here; 1/6/2/1 in the baseline) and is present in both configurations — not a gap introduced here.


Part of the Phase-2 CI-overhaul sharding pass (kernels/basic-models workstream), one PR per key.


