### PR TITLE
[CI] Split nightly MTP acceptance tests

### DIFF
--- a/.buildkite/test_areas/spec_decode.yaml
+++ b/.buildkite/test_areas/spec_decode.yaml
@@ -349,13 +349,19 @@ steps:
 
 - label: ":nvidia: (H200 MIG 35GB) Spec Decode AL MTP + Other Acceptance Nightly"
   key: spec-decode-mtp-other-acceptance-nightly
-  timeout_in_minutes: 60
+  timeout_in_minutes: 35
   device: h200_35gb
   optional: true
+  parallelism: 2
   source_file_dependencies:
     - vllm/v1/spec_decode/
     - vllm/v1/worker/gpu/spec_decode/
     - tests/v1/e2e/spec_decode/conftest.py
     - tests/v1/e2e/spec_decode/
   commands:
-    - pytest -v -s v1/e2e/spec_decode/acceptance_rates/mtp_other/
+    # The two parametrizations of test_gemma4_mtp_acceptance_lengths run ~24m
+    # each (build 83851), so <20m shards are impossible without splitting the
+    # test itself. Shard 0 runs the whole directory minus the [False] case
+    # (new tests land there by default); shard 1 runs only the [False] case.
+    - test "$$BUILDKITE_PARALLEL_JOB" != "0" || pytest -v -s v1/e2e/spec_decode/acceptance_rates/mtp_other/ --deselect "v1/e2e/spec_decode/acceptance_rates/mtp_other/test_mtp.py::test_gemma4_mtp_acceptance_lengths[False]"
+    - test "$$BUILDKITE_PARALLEL_JOB" != "1" || pytest -v -s "v1/e2e/spec_decode/acceptance_rates/mtp_other/test_mtp.py::test_gemma4_mtp_acceptance_lengths[False]"

--- a/.buildkite/test_areas/spec_decode.yaml
+++ b/.buildkite/test_areas/spec_decode.yaml
@@ -352,16 +352,16 @@ steps:
   timeout_in_minutes: 35
   device: h200_35gb
   optional: true
-  parallelism: 2
+  parallelism: 3
   source_file_dependencies:
     - vllm/v1/spec_decode/
     - vllm/v1/worker/gpu/spec_decode/
     - tests/v1/e2e/spec_decode/conftest.py
     - tests/v1/e2e/spec_decode/
   commands:
-    # The two parametrizations of test_gemma4_mtp_acceptance_lengths run ~24m
-    # each (build 83851), so <20m shards are impossible without splitting the
-    # test itself. Shard 0 runs the whole directory minus the [False] case
-    # (new tests land there by default); shard 1 runs only the [False] case.
-    - test "$$BUILDKITE_PARALLEL_JOB" != "0" || pytest -v -s v1/e2e/spec_decode/acceptance_rates/mtp_other/ --deselect "v1/e2e/spec_decode/acceptance_rates/mtp_other/test_mtp.py::test_gemma4_mtp_acceptance_lengths[False]"
+    # Each Gemma4 parametrization is an indivisible ~23m floor. Keep them in
+    # separate shards and put the remaining tests in shard 0, where new tests
+    # land by default.
+    - test "$$BUILDKITE_PARALLEL_JOB" != "0" || pytest -v -s v1/e2e/spec_decode/acceptance_rates/mtp_other/ --deselect "v1/e2e/spec_decode/acceptance_rates/mtp_other/test_mtp.py::test_gemma4_mtp_acceptance_lengths[False]" --deselect "v1/e2e/spec_decode/acceptance_rates/mtp_other/test_mtp.py::test_gemma4_mtp_acceptance_lengths[True]"
     - test "$$BUILDKITE_PARALLEL_JOB" != "1" || pytest -v -s "v1/e2e/spec_decode/acceptance_rates/mtp_other/test_mtp.py::test_gemma4_mtp_acceptance_lengths[False]"
+    - test "$$BUILDKITE_PARALLEL_JOB" != "2" || pytest -v -s "v1/e2e/spec_decode/acceptance_rates/mtp_other/test_mtp.py::test_gemma4_mtp_acceptance_lengths[True]"

--- a/.buildkite/test_areas/spec_decode.yaml
+++ b/.buildkite/test_areas/spec_decode.yaml
@@ -362,6 +362,6 @@ steps:
     # Each Gemma4 parametrization is an indivisible ~23m floor. Keep them in
     # separate shards and put the remaining tests in shard 0, where new tests
     # land by default.
-    - test "$$BUILDKITE_PARALLEL_JOB" != "0" || pytest -v -s v1/e2e/spec_decode/acceptance_rates/mtp_other/ --deselect "v1/e2e/spec_decode/acceptance_rates/mtp_other/test_mtp.py::test_gemma4_mtp_acceptance_lengths[False]" --deselect "v1/e2e/spec_decode/acceptance_rates/mtp_other/test_mtp.py::test_gemma4_mtp_acceptance_lengths[True]"
+    - test "$$BUILDKITE_PARALLEL_JOB" != "0" || pytest -v -s v1/e2e/spec_decode/acceptance_rates/mtp_other/ --deselect "tests/v1/e2e/spec_decode/acceptance_rates/mtp_other/test_mtp.py::test_gemma4_mtp_acceptance_lengths[False]" --deselect "tests/v1/e2e/spec_decode/acceptance_rates/mtp_other/test_mtp.py::test_gemma4_mtp_acceptance_lengths[True]"
     - test "$$BUILDKITE_PARALLEL_JOB" != "1" || pytest -v -s "v1/e2e/spec_decode/acceptance_rates/mtp_other/test_mtp.py::test_gemma4_mtp_acceptance_lengths[False]"
     - test "$$BUILDKITE_PARALLEL_JOB" != "2" || pytest -v -s "v1/e2e/spec_decode/acceptance_rates/mtp_other/test_mtp.py::test_gemma4_mtp_acceptance_lengths[True]"


### PR DESCRIPTION
## Why

`NVIDIA Spec Decode AL MTP + Other Acceptance Nightly` was 3,152s P90 across 2 runs in the 24-hour dashboard window ending 2026-09-01 10:31 UTC.

## What changed

Use three shards: one for the Medusa and Synthetic cases, and one for each long Gemma4 parametrization. Each Gemma4 case is an indivisible roughly 23-minute floor, so a strict 20-minute target is unattainable without splitting the test itself.

No merged or active non-draft PR covers this job.

## Validation

- YAML parse
- current `ci-infra` Buildkite step schema
- all four collected cases are covered once across three shards
- all YAML command entries pass `bash -n`
- `git diff --check`
- targeted H200 CI evidence linked below

## Targeted CI

[Build #86620](https://buildkite.com/vllm/ci/builds/86620) passed all three shards in `3:19, 23:50, 24:20`. Live collection confirmed exact `2+1+1` coverage: Medusa+Synthetic in shard 1 and one Gemma4 parametrization in each remaining shard, with no duplicate node.

This remains a draft pending human review. AI assistance was used.
