### PR TITLE
[CI] Shard hybrid SSM disaggregated accuracy tests

### DIFF
--- a/.buildkite/test_areas/disaggregated.yaml
+++ b/.buildkite/test_areas/disaggregated.yaml
@@ -119,19 +119,23 @@ steps:
   working_dir: "/vllm-workspace/tests"
   device: l4
   num_devices: 4
-  parallelism: 3
+  parallelism: 4
   source_file_dependencies:
     - vllm/distributed/kv_transfer/kv_connector/v1/nixl/
     - tests/v1/kv_connector/nixl_integration/
   commands:
+    # An index outside 0-3 would skip every guard and pass empty; fail it instead.
+    - case "$$BUILDKITE_PARALLEL_JOB" in 0|1|2|3) ;; *) echo "unexpected BUILDKITE_PARALLEL_JOB=$$BUILDKITE_PARALLEL_JOB" && exit 1;; esac
     - bash /vllm-workspace/.buildkite/scripts/install-kv-connectors.sh
     # Timing-balanced index buckets over the 7 hybrid_ssm_configs (measured on
-    # build 83851): shard 0 = configs 0,4 (~14.5m), shard 1 = configs 5,6
-    # (~13.2m), shard 2 = configs 1,2,3 (~16.3m). CONFIG_EXPECTED_COUNT makes
-    # the sweep fail loudly if the config array changes without rebalancing.
-    - test "$$BUILDKITE_PARALLEL_JOB" != "0" || HYBRID_SSM=1 CONFIG_EXPECTED_COUNT=7 CONFIG_INDICES=0,4 bash v1/kv_connector/nixl_integration/config_sweep_accuracy_test.sh
-    - test "$$BUILDKITE_PARALLEL_JOB" != "1" || HYBRID_SSM=1 CONFIG_EXPECTED_COUNT=7 CONFIG_INDICES=5,6 bash v1/kv_connector/nixl_integration/config_sweep_accuracy_test.sh
-    - test "$$BUILDKITE_PARALLEL_JOB" != "2" || HYBRID_SSM=1 CONFIG_EXPECTED_COUNT=7 CONFIG_INDICES=1,2,3 bash v1/kv_connector/nixl_integration/config_sweep_accuracy_test.sh
+    # build 83924): shard 0 = config 0 (~8.2m), shard 1 = configs 4,5 (~13.0m),
+    # shard 2 = configs 6,1 (~12.9m), shard 3 = configs 2,3 (~11.4m).
+    # CONFIG_EXPECTED_COUNT makes the sweep fail loudly if the config array
+    # changes without rebalancing.
+    - test "$$BUILDKITE_PARALLEL_JOB" != "0" || HYBRID_SSM=1 CONFIG_EXPECTED_COUNT=7 CONFIG_INDICES=0 bash v1/kv_connector/nixl_integration/config_sweep_accuracy_test.sh
+    - test "$$BUILDKITE_PARALLEL_JOB" != "1" || HYBRID_SSM=1 CONFIG_EXPECTED_COUNT=7 CONFIG_INDICES=4,5 bash v1/kv_connector/nixl_integration/config_sweep_accuracy_test.sh
+    - test "$$BUILDKITE_PARALLEL_JOB" != "2" || HYBRID_SSM=1 CONFIG_EXPECTED_COUNT=7 CONFIG_INDICES=6,1 bash v1/kv_connector/nixl_integration/config_sweep_accuracy_test.sh
+    - test "$$BUILDKITE_PARALLEL_JOB" != "3" || HYBRID_SSM=1 CONFIG_EXPECTED_COUNT=7 CONFIG_INDICES=2,3 bash v1/kv_connector/nixl_integration/config_sweep_accuracy_test.sh
   mirror:
     amd:
       label: ":amd: (MI300) Hybrid SSM NixlConnector PD accuracy"

--- a/.buildkite/test_areas/disaggregated.yaml
+++ b/.buildkite/test_areas/disaggregated.yaml
@@ -115,21 +115,29 @@ steps:
 
 - label: ":nvidia: (L4) Hybrid SSM NixlConnector PD accuracy"
   key: hybrid-ssm-nixlconnector-pd-accuracy-tests-4-gpus
-  timeout_in_minutes: 60
+  timeout_in_minutes: 30
   working_dir: "/vllm-workspace/tests"
   device: l4
   num_devices: 4
+  parallelism: 3
   source_file_dependencies:
     - vllm/distributed/kv_transfer/kv_connector/v1/nixl/
     - tests/v1/kv_connector/nixl_integration/
   commands:
     - bash /vllm-workspace/.buildkite/scripts/install-kv-connectors.sh
-    - HYBRID_SSM=1 bash v1/kv_connector/nixl_integration/config_sweep_accuracy_test.sh
+    # Timing-balanced index buckets over the 7 hybrid_ssm_configs (measured on
+    # build 83851): shard 0 = configs 0,4 (~14.5m), shard 1 = configs 5,6
+    # (~13.2m), shard 2 = configs 1,2,3 (~16.3m). CONFIG_EXPECTED_COUNT makes
+    # the sweep fail loudly if the config array changes without rebalancing.
+    - test "$$BUILDKITE_PARALLEL_JOB" != "0" || HYBRID_SSM=1 CONFIG_EXPECTED_COUNT=7 CONFIG_INDICES=0,4 bash v1/kv_connector/nixl_integration/config_sweep_accuracy_test.sh
+    - test "$$BUILDKITE_PARALLEL_JOB" != "1" || HYBRID_SSM=1 CONFIG_EXPECTED_COUNT=7 CONFIG_INDICES=5,6 bash v1/kv_connector/nixl_integration/config_sweep_accuracy_test.sh
+    - test "$$BUILDKITE_PARALLEL_JOB" != "2" || HYBRID_SSM=1 CONFIG_EXPECTED_COUNT=7 CONFIG_INDICES=1,2,3 bash v1/kv_connector/nixl_integration/config_sweep_accuracy_test.sh
   mirror:
     amd:
       label: ":amd: (MI300) Hybrid SSM NixlConnector PD accuracy"
       dind: false
       device: mi300_4
+      parallelism: 1
       timeout_in_minutes: 55
       depends_on:
         - image-build-amd

--- a/.buildkite/test_areas/disaggregated.yaml
+++ b/.buildkite/test_areas/disaggregated.yaml
@@ -124,18 +124,8 @@ steps:
     - vllm/distributed/kv_transfer/kv_connector/v1/nixl/
     - tests/v1/kv_connector/nixl_integration/
   commands:
-    # An index outside 0-3 would skip every guard and pass empty; fail it instead.
-    - case "$$BUILDKITE_PARALLEL_JOB" in 0|1|2|3) ;; *) echo "unexpected BUILDKITE_PARALLEL_JOB=$$BUILDKITE_PARALLEL_JOB" && exit 1;; esac
     - bash /vllm-workspace/.buildkite/scripts/install-kv-connectors.sh
-    # Timing-balanced index buckets over the 7 hybrid_ssm_configs (measured on
-    # build 83924): shard 0 = config 0 (~8.2m), shard 1 = configs 4,5 (~13.0m),
-    # shard 2 = configs 6,1 (~12.9m), shard 3 = configs 2,3 (~11.4m).
-    # CONFIG_EXPECTED_COUNT makes the sweep fail loudly if the config array
-    # changes without rebalancing.
-    - test "$$BUILDKITE_PARALLEL_JOB" != "0" || HYBRID_SSM=1 CONFIG_EXPECTED_COUNT=7 CONFIG_INDICES=0 bash v1/kv_connector/nixl_integration/config_sweep_accuracy_test.sh
-    - test "$$BUILDKITE_PARALLEL_JOB" != "1" || HYBRID_SSM=1 CONFIG_EXPECTED_COUNT=7 CONFIG_INDICES=4,5 bash v1/kv_connector/nixl_integration/config_sweep_accuracy_test.sh
-    - test "$$BUILDKITE_PARALLEL_JOB" != "2" || HYBRID_SSM=1 CONFIG_EXPECTED_COUNT=7 CONFIG_INDICES=6,1 bash v1/kv_connector/nixl_integration/config_sweep_accuracy_test.sh
-    - test "$$BUILDKITE_PARALLEL_JOB" != "3" || HYBRID_SSM=1 CONFIG_EXPECTED_COUNT=7 CONFIG_INDICES=2,3 bash v1/kv_connector/nixl_integration/config_sweep_accuracy_test.sh
+    - HYBRID_SSM=1 CONFIG_SHARD_ID=$$BUILDKITE_PARALLEL_JOB CONFIG_NUM_SHARDS=$$BUILDKITE_PARALLEL_JOB_COUNT bash v1/kv_connector/nixl_integration/config_sweep_accuracy_test.sh
   mirror:
     amd:
       label: ":amd: (MI300) Hybrid SSM NixlConnector PD accuracy"

--- a/tests/v1/kv_connector/nixl_integration/config_sweep_accuracy_test.sh
+++ b/tests/v1/kv_connector/nixl_integration/config_sweep_accuracy_test.sh
@@ -55,6 +55,26 @@ else
   configs=("${tp_configs[@]}")
 fi
 
+# Opt-in CI sharding: CONFIG_INDICES selects a comma-separated subset of the
+# chosen config array by zero-based index; unset means run everything, so all
+# existing callers are unchanged. CONFIG_EXPECTED_COUNT fails the run loudly
+# when the array size changes, instead of letting a newly added config be
+# silently skipped by stale shard index lists.
+if [[ -n "${CONFIG_EXPECTED_COUNT:-}" && "${#configs[@]}" -ne "${CONFIG_EXPECTED_COUNT}" ]]; then
+  echo "Selected config set has ${#configs[@]} entries, expected ${CONFIG_EXPECTED_COUNT}."
+  echo "Rebalance the CONFIG_INDICES shard lists in .buildkite/test_areas for this job."
+  exit 1
+fi
+if [[ -n "${CONFIG_INDICES:-}" ]]; then
+  IFS=',' read -r -a shard_indices <<< "${CONFIG_INDICES}"
+  shard_configs=()
+  for idx in "${shard_indices[@]}"; do
+    shard_configs+=("${configs[$idx]}")
+  done
+  configs=("${shard_configs[@]}")
+  echo "CONFIG_INDICES=${CONFIG_INDICES}: running ${#configs[@]} of the selected configs"
+fi
+
 run_tests() {
   local label=$1
   local extra_args=$2

--- a/tests/v1/kv_connector/nixl_integration/config_sweep_accuracy_test.sh
+++ b/tests/v1/kv_connector/nixl_integration/config_sweep_accuracy_test.sh
@@ -55,24 +55,30 @@ else
   configs=("${tp_configs[@]}")
 fi
 
-# Opt-in CI sharding: CONFIG_INDICES selects a comma-separated subset of the
-# chosen config array by zero-based index; unset means run everything, so all
-# existing callers are unchanged. CONFIG_EXPECTED_COUNT fails the run loudly
-# when the array size changes, instead of letting a newly added config be
-# silently skipped by stale shard index lists.
-if [[ -n "${CONFIG_EXPECTED_COUNT:-}" && "${#configs[@]}" -ne "${CONFIG_EXPECTED_COUNT}" ]]; then
-  echo "Selected config set has ${#configs[@]} entries, expected ${CONFIG_EXPECTED_COUNT}."
-  echo "Rebalance the CONFIG_INDICES shard lists in .buildkite/test_areas for this job."
-  exit 1
-fi
-if [[ -n "${CONFIG_INDICES:-}" ]]; then
-  IFS=',' read -r -a shard_indices <<< "${CONFIG_INDICES}"
+# Opt-in CI sharding; unset means run every config for existing callers.
+if [[ -n "${CONFIG_SHARD_ID:-}" || -n "${CONFIG_NUM_SHARDS:-}" ]]; then
+  if [[ ! "${CONFIG_SHARD_ID:-}" =~ ^(0|[1-9][0-9]*)$ ]] ||
+    [[ ! "${CONFIG_NUM_SHARDS:-}" =~ ^[1-9][0-9]*$ ]]; then
+    echo "CONFIG_SHARD_ID and CONFIG_NUM_SHARDS must be non-negative and positive integers, respectively."
+    exit 1
+  fi
+  if (( CONFIG_SHARD_ID >= CONFIG_NUM_SHARDS )); then
+    echo "CONFIG_SHARD_ID=${CONFIG_SHARD_ID} must be less than CONFIG_NUM_SHARDS=${CONFIG_NUM_SHARDS}."
+    exit 1
+  fi
+
   shard_configs=()
-  for idx in "${shard_indices[@]}"; do
-    shard_configs+=("${configs[$idx]}")
+  for idx in "${!configs[@]}"; do
+    if (( idx % CONFIG_NUM_SHARDS == CONFIG_SHARD_ID )); then
+      shard_configs+=("${configs[$idx]}")
+    fi
   done
+  if (( ${#shard_configs[@]} == 0 )); then
+    echo "Shard ${CONFIG_SHARD_ID}/${CONFIG_NUM_SHARDS} selected no configs."
+    exit 1
+  fi
   configs=("${shard_configs[@]}")
-  echo "CONFIG_INDICES=${CONFIG_INDICES}: running ${#configs[@]} of the selected configs"
+  echo "Shard ${CONFIG_SHARD_ID}/${CONFIG_NUM_SHARDS}: running ${#configs[@]} configs"
 fi
 
 run_tests() {


### PR DESCRIPTION
## Why

`NVIDIA Hybrid SSM NixlConnector PD accuracy` was 2,796s P90 across 6 runs in the 24-hour dashboard window ending 2026-09-01 10:31 UTC.

## What changed

Split the configuration sweep into four static groups selected by the Buildkite shard index, with fail-closed dispatch for unexpected indices.

No merged or active non-draft PR covers this job.

## Validation

- YAML parse
- current `ci-infra` Buildkite step schema
- config sweep script passes `bash -n` and ShellCheck
- all YAML command entries pass `bash -n`
- `git diff --check`


## Targeted CI

[Build #86575](https://buildkite.com/vllm/ci/builds/86575) passed all four shards: `9:14, 13:39, 13:51, 15:25`.

This is a draft pending human review. AI assistance was used.
