### PR TITLE
[hw-agnostic] Adding embedding layer and lm_head

### DIFF
--- a/tests/models/transformers/test_backend.py
+++ b/tests/models/transformers/test_backend.py
@@ -409,6 +409,23 @@ def test_replace_plain_embedding(vpe):
     assert type(replace(nn.Embedding(VOCAB_SIZE, HIDDEN_SIZE))) is vpe
 
 
+def test_replace_plain_embedding_hw_agnostic(monkeypatch, tp_init):
+    """With `VLLM_USE_HW_AGNOSTIC=1` the plain path builds the hw-agnostic class,
+    the same one `CausalMixin` resolves for its tie-weights check.
+
+    The MRO-rebasing path stays on vLLM's class (covered by the inherited/nested
+    tests above), so only the plain path is asserted here.
+    """
+    monkeypatch.setenv("VLLM_USE_HW_AGNOSTIC", "1")
+    from vllm.model_executor.models.transformers.layers import (
+        get_vocab_parallel_embedding_cls,
+    )
+
+    hw_vpe = get_vocab_parallel_embedding_cls()
+    assert "hw_agnostic.layers" in hw_vpe.__module__
+    assert type(replace(nn.Embedding(VOCAB_SIZE, HIDDEN_SIZE))) is hw_vpe
+
+
 def test_replace_infers_shape_and_dtype(tp_init):
     """Shape and dtype come from the replaced module, not from the config."""
     embedding = nn.Embedding(VOCAB_SIZE * 2, HIDDEN_SIZE + 1, dtype=torch.float16)

--- a/tests/models/transformers/test_layer_registry.py
+++ b/tests/models/transformers/test_layer_registry.py
@@ -292,6 +292,9 @@ def test_hw_agnostic_matches_vllm_with_tied_lm_head(
 _HW_AGNOSTIC_LAYERS = (
     ("layernorm", "RMSNorm"),
     ("activation", "SiluAndMul"),
+    ("logits_processor", "LogitsProcessor"),
+    ("vocab_parallel_embedding", "VocabParallelEmbedding"),
+    ("vocab_parallel_embedding", "ParallelLMHead"),
 )
 
 

--- a/tests/models/transformers/test_layer_registry.py
+++ b/tests/models/transformers/test_layer_registry.py
@@ -9,9 +9,11 @@ is set and the symbol exists, and otherwise falls back to
 logging that reports which source was used.
 """
 
+import importlib
 import logging
 import sys
 import types
+from typing import Any
 
 import pytest
 import torch
@@ -175,3 +177,421 @@ def test_hw_agnostic_matches_vllm_end_to_end(monkeypatch, vllm_runner, tiny_llam
         name_0="vllm",
         name_1="hw_agnostic",
     )
+
+
+# --------------------------------------------------------------------------
+# Out-of-tree override reachability.
+#
+# --------------------------------------------------------------------------
+
+_HW_AGNOSTIC_LAYERS = (
+    ("layernorm", "RMSNorm"),
+    ("activation", "SiluAndMul"),
+)
+
+
+def _hw_layer(module: str, name: str) -> Any:
+    """The hw-agnostic class `name` from `hw_agnostic.layers.<module>`."""
+    return getattr(
+        importlib.import_module(f"vllm.model_executor.hw_agnostic.layers.{module}"),
+        name,
+    )
+
+
+def _vllm_layer(module: str, name: str) -> Any:
+    """The in-tree class `name` from `model_executor.layers.<module>`."""
+    return getattr(
+        importlib.import_module(f"vllm.model_executor.layers.{module}"), name
+    )
+
+
+def test_custom_op_plumbing_is_shared():
+    """One `CustomOp`, one `PluggableLayer`, one pair of registries.
+
+    A second copy of the plumbing is a second, disjoint `op_registry_oot`: a
+    plugin decorating the vLLM class writes into a registry the hw-agnostic
+    `__new__` never reads, and its override is skipped without an error.
+    """
+    from vllm.model_executor import custom_op as vllm_plumbing
+    from vllm.model_executor.hw_agnostic import custom_op as hw_plumbing
+
+    for attr in (
+        "CustomOp",
+        "PluggableLayer",
+        "op_registry",
+        "op_registry_oot",
+        "maybe_get_oot_by_class",
+    ):
+        assert getattr(hw_plumbing, attr) is getattr(vllm_plumbing, attr), attr
+
+
+@pytest.mark.parametrize("module,name", _HW_AGNOSTIC_LAYERS)
+def test_hw_agnostic_layer_is_standalone(module, name):
+    """Each hw-agnostic layer is an independent implementation, not a subclass.
+
+    The isolation is deliberate: the hw-agnostic path can be reshaped without
+    touching the in-tree layers. What it costs is that the two classes are
+    interchangeable only by name, which is what the rest of these tests are
+    about.
+    """
+    hw_cls = _hw_layer(module, name)
+    vllm_cls = _vllm_layer(module, name)
+
+    assert hw_cls is not vllm_cls
+    assert not issubclass(hw_cls, vllm_cls)
+    assert not issubclass(vllm_cls, hw_cls)
+    # No in-tree import anywhere in the hw-agnostic layer's own ancestry.
+    assert not any(
+        c.__module__.startswith("vllm.model_executor.layers.") for c in hw_cls.__mro__
+    )
+
+
+@pytest.mark.parametrize("module,name", _HW_AGNOSTIC_LAYERS)
+def test_hw_agnostic_layer_keeps_the_registered_names(module, name):
+    """`__name__` and `name` match the in-tree layer, without taking its entry.
+
+    `__name__` is what `__new__` keys the out-of-tree swap on, so drift there
+    unregisters every override of the layer. `name` is what identifies the op to
+    `CompilationConfig.custom_ops`. The single shared `op_registry` keeps
+    pointing at the in-tree class, because the hw-agnostic `register` claims the
+    name without writing the entry (see
+    `test_hw_agnostic_register_claims_the_name_only`).
+    """
+    from vllm.model_executor.custom_op import op_registry
+
+    hw_cls = _hw_layer(module, name)
+    vllm_cls = _vllm_layer(module, name)
+
+    assert hw_cls.__name__ == vllm_cls.__name__
+    # `name` may be inherited -- `MergedColumnParallelLinear` and
+    # `QKVParallelLinear` both report `column_parallel_linear` -- which is fine,
+    # because the swap keys on `__name__`.
+    assert hw_cls.name == vllm_cls.name
+    assert op_registry[vllm_cls.name] is not hw_cls
+    assert issubclass(vllm_cls, op_registry[vllm_cls.name])
+
+
+def test_hw_agnostic_register_claims_the_name_only():
+    """`register` on the wrappers: same effect on the class, no registry write.
+
+    This is what lets an hw-agnostic layer be written the way its in-tree
+    counterpart is -- `@CustomOp.register("rms_norm")` on a class whose name the
+    in-tree op already holds -- with no change in
+    `vllm.model_executor.custom_op`. Writing the entry instead would make the
+    owner depend on which module was imported first, and the loser would be the
+    in-tree decorator, whose assert aborts the import.
+    """
+    from vllm.model_executor.custom_op import CustomOp, PluggableLayer, op_registry
+    from vllm.model_executor.hw_agnostic.custom_op import (
+        HwAgnosticCustomOp,
+        HwAgnosticPluggableLayer,
+    )
+
+    before = dict(op_registry)
+
+    # Names the in-tree ops already own; neither call raises.
+    @HwAgnosticCustomOp.register("rms_norm", dynamic_arg_dims={"x": 0})
+    class _Op(HwAgnosticCustomOp):
+        pass
+
+    @HwAgnosticPluggableLayer.register("replicated_linear")
+    class _Layer(HwAgnosticPluggableLayer):
+        pass
+
+    # Everything `enabled()` and `dispatch_forward` read is set.
+    assert _Op.name == "rms_norm"
+    assert _Op._dynamic_arg_dims == {"x": 0}
+    assert _Layer.name == "replicated_linear"
+    # Nothing added, nothing overwritten.
+    assert op_registry == before
+    # The out-of-tree machinery is inherited untouched, so one `register_oot`
+    # still covers both paths.
+    assert HwAgnosticCustomOp.register_oot.__func__ is CustomOp.register_oot.__func__
+    assert HwAgnosticCustomOp.__new__ is CustomOp.__new__
+    assert (
+        HwAgnosticPluggableLayer.register_oot.__func__
+        is PluggableLayer.register_oot.__func__
+    )
+    assert HwAgnosticPluggableLayer.__new__ is PluggableLayer.__new__
+
+
+# --------------------------------------------------------------------------
+# Resolving the in-tree layer names to the hw-agnostic classes.
+#
+# --------------------------------------------------------------------------
+
+
+def test_layer_names_scope_is_a_noop_when_disabled(monkeypatch):
+    """Disabled: the in-tree names are untouched, so a plugin overrides vLLM."""
+    from vllm.model_executor.hw_agnostic.layers._layer_names import (
+        hw_agnostic_layer_names,
+    )
+
+    monkeypatch.setenv("VLLM_USE_HW_AGNOSTIC", "0")
+    with hw_agnostic_layer_names():
+        for module, name in _HW_AGNOSTIC_LAYERS:
+            assert _vllm_layer(module, name) is _vllm_layer(module, name)
+            assert _vllm_layer(module, name) is not _hw_layer(module, name)
+
+
+def test_layer_names_scope_rebinds_and_restores(monkeypatch):
+    """Enabled: every mirrored name resolves to the hw-agnostic class inside the
+    block, and to the in-tree class again outside it.
+
+    Restoring matters as much as rebinding: ~200 in-tree modules import from
+    these, and a permanent swap would leave `isinstance(x, LinearBase)` answering
+    differently depending on import order.
+    """
+    from vllm.model_executor.hw_agnostic.layers._layer_names import (
+        hw_agnostic_layer_names,
+    )
+
+    monkeypatch.setenv("VLLM_USE_HW_AGNOSTIC", "1")
+    before = {(m, n): _vllm_layer(m, n) for m, n in _HW_AGNOSTIC_LAYERS}
+
+    with hw_agnostic_layer_names():
+        for module, name in _HW_AGNOSTIC_LAYERS:
+            assert _vllm_layer(module, name) is _hw_layer(module, name)
+
+    for key, cls in before.items():
+        assert _vllm_layer(*key) is cls
+
+
+def test_layer_names_scope_restores_on_exception(monkeypatch):
+    """A plugin that raises mid-import must not leave the namespace rebound."""
+    from vllm.model_executor.hw_agnostic.layers._layer_names import (
+        hw_agnostic_layer_names,
+    )
+
+    monkeypatch.setenv("VLLM_USE_HW_AGNOSTIC", "1")
+    original = _vllm_layer("layernorm", "RMSNorm")
+
+    with (
+        pytest.raises(RuntimeError, match="plugin blew up"),
+        hw_agnostic_layer_names(),
+    ):
+        raise RuntimeError("plugin blew up")
+
+    assert _vllm_layer("layernorm", "RMSNorm") is original
+
+
+def test_layer_names_scope_leaves_unported_layers_alone(monkeypatch):
+    """Names with no hw-agnostic implementation keep their in-tree class.
+
+    The same fallback the modeling side takes in `_resolve`, so a plugin's
+    `GeluAndMul` override still lands on the class that gets built.
+    """
+    from vllm.model_executor.hw_agnostic.layers._layer_names import (
+        hw_agnostic_layer_names,
+    )
+
+    monkeypatch.setenv("VLLM_USE_HW_AGNOSTIC", "1")
+    unported = (("activation", "GeluAndMul"), ("layernorm", "GemmaRMSNorm"))
+    before = {(m, n): _vllm_layer(m, n) for m, n in unported}
+
+    with hw_agnostic_layer_names():
+        for key, cls in before.items():
+            assert _vllm_layer(*key) is cls
+
+
+@pytest.mark.parametrize("hw_agnostic", ["0", "1"])
+def test_general_plugins_open_the_scope_only_when_enabled(monkeypatch, hw_agnostic):
+    """`load_general_plugins` guards the scope on `VLLM_USE_HW_AGNOSTIC`.
+
+    With it off, the loading path must be what it is upstream: no scope opened,
+    and no hw-agnostic module imported at all.
+    """
+    import vllm.plugins as plugins
+
+    monkeypatch.setenv("VLLM_USE_HW_AGNOSTIC", hw_agnostic)
+    monkeypatch.setattr(plugins, "plugins_loaded", False)
+
+    seen: dict[tuple[str, str], Any] = {}
+    monkeypatch.setattr(
+        plugins,
+        "_run_general_plugins",
+        lambda: seen.update(
+            {(m, n): _vllm_layer(m, n) for m, n in _HW_AGNOSTIC_LAYERS}
+        ),
+    )
+    plugins.load_general_plugins()
+
+    assert seen, "the plugin-loading body never ran"
+    for module, name in _HW_AGNOSTIC_LAYERS:
+        expected = (
+            _hw_layer(module, name) if hw_agnostic == "1" else _vllm_layer(module, name)
+        )
+        assert seen[(module, name)] is expected
+
+
+@pytest.mark.parametrize("module,name", _HW_AGNOSTIC_LAYERS)
+@pytest.mark.parametrize("hw_agnostic", ["0", "1"])
+def test_plugin_import_pattern_reaches_the_entry_point(
+    monkeypatch, module, name, hw_agnostic
+):
+    """The end-to-end contract, both ways round.
+
+    A plugin does exactly one thing: subclass the name it imported from
+    `vllm.model_executor.layers.<mod>` while `hw_agnostic_layer_names()` is
+    active, and register that under the class name. This asserts the result is
+    swapped in for the class the modeling code on that path instantiates, with
+    `__init__` reachable -- which is the whole reason the plugin needs no
+    `VLLM_USE_HW_AGNOSTIC`-dependent imports of its own.
+    """
+    from vllm.model_executor.custom_op import op_registry_oot
+    from vllm.model_executor.hw_agnostic.layers._layer_names import (
+        hw_agnostic_layer_names,
+    )
+
+    monkeypatch.setenv("VLLM_USE_HW_AGNOSTIC", hw_agnostic)
+
+    with hw_agnostic_layer_names():
+        imported = _vllm_layer(module, name)  # what the plugin's import yields
+        plugin_cls = type(f"Plugin{name}", (imported,), {})
+
+    monkeypatch.setitem(op_registry_oot, name, plugin_cls)
+
+    # What the modeling code instantiates on this path.
+    entry_cls = _hw_layer(module, name) if hw_agnostic == "1" else imported
+    assert plugin_cls.__bases__ == (entry_cls,)
+
+    obj = entry_cls.__new__(entry_cls)
+    assert type(obj) is plugin_cls
+    # `type.__call__` runs `__init__` only because this holds.
+    assert isinstance(obj, entry_cls)
+
+
+@pytest.mark.parametrize("module,name", _HW_AGNOSTIC_LAYERS)
+def test_override_registered_against_wrong_base_raises(monkeypatch, module, name):
+    """A plugin that captured the other path's class is reported, not absorbed.
+
+    This is what happens without `hw_agnostic_layer_names()`: the override is a
+    sibling of the class being built, `type.__call__` skips `__init__`, and the
+    first symptom is an unrelated `AttributeError` on `_backward_hooks` far from
+    the registration that caused it. `__new__` cannot see the mismatch without a
+    check of its own, so `validate_registered_overrides` sweeps the registry once
+    after plugin loading and names both classes instead.
+    """
+    from vllm.model_executor.custom_op import op_registry_oot
+    from vllm.model_executor.hw_agnostic.custom_op import validate_registered_overrides
+
+    hw_cls = _hw_layer(module, name)
+    vllm_cls = _vllm_layer(module, name)
+    # Captured the in-tree class, but the hw-agnostic one gets instantiated.
+    plugin_cls = type(f"Plugin{name}", (vllm_cls,), {})
+    monkeypatch.setitem(op_registry_oot, name, plugin_cls)
+
+    # Correct on the in-tree path, and silently broken on the hw-agnostic one:
+    # `__new__` hands back the override either way, but only in the first case is
+    # it an instance of the class that was called, so only there runs `__init__`.
+    assert type(vllm_cls.__new__(vllm_cls)) is plugin_cls
+    assert isinstance(vllm_cls.__new__(vllm_cls), vllm_cls)
+    assert not isinstance(hw_cls.__new__(hw_cls), hw_cls)
+
+    mirrored = {
+        f"vllm.model_executor.layers.{module}": (
+            f"vllm.model_executor.hw_agnostic.layers.{module}"
+        )
+    }
+    with pytest.raises(TypeError, match=f"Plugin{name}.*not a subclass"):
+        validate_registered_overrides(mirrored)
+
+
+def test_correctly_based_override_passes_validation(monkeypatch):
+    """The sweep only rejects mismatches.
+
+    Every layer with no hw-agnostic implementation is registered against its
+    in-tree class on both paths, so validating the whole published set must leave
+    those alone -- otherwise the guard would reject the fallback it is supposed to
+    allow.
+    """
+    from vllm.model_executor.custom_op import op_registry_oot
+    from vllm.model_executor.hw_agnostic.custom_op import validate_registered_overrides
+    from vllm.model_executor.hw_agnostic.layers._layer_names import _MIRRORED_MODULES
+
+    # What a plugin loaded under `hw_agnostic_layer_names()` registers.
+    monkeypatch.setitem(
+        op_registry_oot,
+        "RMSNorm",
+        type("PluginRMSNorm", (_hw_layer("layernorm", "RMSNorm"),), {}),
+    )
+    # An unported layer: the in-tree class is what gets instantiated on both
+    # paths, so an override based on it is right and must not be flagged.
+    monkeypatch.setitem(
+        op_registry_oot,
+        "GeluAndMul",
+        type("PluginGeluAndMul", (_vllm_layer("activation", "GeluAndMul"),), {}),
+    )
+
+    validate_registered_overrides(_MIRRORED_MODULES)
+
+
+def test_hw_agnostic_ops_skip_vendor_forwards(monkeypatch):
+    """Dispatch stays on the portable implementation, and an out-of-tree subclass
+    inherits that discipline.
+
+    `CustomOp.forward_{hip,cpu,tpu,xpu,oot}` already delegate to
+    `forward_native`, so `forward_cuda` -- the one branch that raises -- is all
+    `HwAgnosticCustomOp` has to redirect. Expressing it that way keeps the
+    discipline out of `vllm.model_executor.custom_op` entirely.
+    """
+    from vllm.config import CompilationConfig, VllmConfig, set_current_vllm_config
+    from vllm.model_executor.custom_op import CustomOp, op_registry_oot
+    from vllm.model_executor.hw_agnostic.custom_op import HwAgnosticCustomOp
+    from vllm.model_executor.hw_agnostic.layers.layernorm import RMSNorm as HwRMSNorm
+    from vllm.model_executor.layers.layernorm import RMSNorm as VllmRMSNorm
+    from vllm.platforms import current_platform
+
+    assert issubclass(HwRMSNorm, HwAgnosticCustomOp)
+    assert not issubclass(VllmRMSNorm, HwAgnosticCustomOp)
+    # Inherited, so a plugin's override keeps it.
+    plugin_rms: Any = type("PluginRMSNorm", (HwRMSNorm,), {})
+    assert issubclass(plugin_rms, HwAgnosticCustomOp)
+
+    config = VllmConfig(compilation_config=CompilationConfig(custom_ops=["all"]))
+    # Register the hw-agnostic class as its own override, so this test builds the
+    # class under test whether or not an out-of-tree plugin is loaded in this
+    # process (on Spyre, "RMSNorm" resolves to `SpyreRMSNorm`, which is based on
+    # the in-tree class and would come back with its `__init__` skipped).
+    monkeypatch.setitem(op_registry_oot, "RMSNorm", HwRMSNorm)
+    with set_current_vllm_config(config):
+        op = HwRMSNorm(8)
+        x = torch.randn(2, 8)
+        expected = op.forward_native(x)
+        # The base class raises here; every vendor branch now lands on the
+        # portable implementation, `forward_hip` via `forward_cuda`.
+        with pytest.raises(NotImplementedError):
+            CustomOp.forward_cuda(op, x)
+        for vendor in ("cuda", "hip", "cpu", "tpu", "xpu", "oot"):
+            torch.testing.assert_close(getattr(op, f"forward_{vendor}")(x), expected)
+        # On an out-of-tree platform the chain is unchanged: `forward_oot`, which
+        # is where a plugin's override hooks in. `dispatch_forward` tests the
+        # vendor predicates before `is_out_of_tree`, so all of them have to be
+        # pinned for this to assert the dispatch chain rather than the host.
+        for vendor in ("is_rocm", "is_cpu", "is_tpu", "is_xpu"):
+            monkeypatch.setattr(current_platform, vendor, lambda: False)
+        monkeypatch.setattr(current_platform, "is_out_of_tree", lambda: True)
+        assert HwRMSNorm(8)._forward_method.__name__ == "forward_oot"
+
+
+def test_hw_agnostic_rms_norm_matches_vllm_native():
+    """The hw-agnostic `forward_native` computes what vLLM's does; it differs
+    only in bypassing the `vllm.ir` op registry, which can resolve to a vendor
+    kernel."""
+    from vllm.config import CompilationConfig, VllmConfig, set_current_vllm_config
+    from vllm.model_executor.hw_agnostic.layers.layernorm import RMSNorm as HwRMSNorm
+    from vllm.model_executor.layers.layernorm import RMSNorm as VllmRMSNorm
+
+    config = VllmConfig(compilation_config=CompilationConfig(custom_ops=["all"]))
+    with set_current_vllm_config(config):
+        vllm_norm, hw_norm = VllmRMSNorm(64), HwRMSNorm(64)
+    hw_norm.load_state_dict(vllm_norm.state_dict())
+
+    x = torch.randn(4, 64)
+    torch.testing.assert_close(vllm_norm.forward_native(x), hw_norm.forward_native(x))
+
+    residual = torch.randn(4, 64)
+    expected = vllm_norm.forward_native(x.clone(), residual.clone())
+    actual = hw_norm.forward_native(x.clone(), residual.clone())
+    for want, got in zip(expected, actual):
+        torch.testing.assert_close(want, got)

--- a/tests/models/transformers/test_layer_registry.py
+++ b/tests/models/transformers/test_layer_registry.py
@@ -80,8 +80,62 @@ def test_act_and_mul_falls_back_for_unknown_activation(
     assert isinstance(layers.get_act_and_mul_fn("gelu"), GeluAndMul)
 
 
-@pytest.fixture(scope="module")
-def tiny_llama_path(tmp_path_factory):
+# Each getter and the module/class name it resolves between the two trees.
+_CLASS_GETTERS = (
+    (
+        "get_vocab_parallel_embedding_cls",
+        "vocab_parallel_embedding",
+        "VocabParallelEmbedding",
+    ),
+    ("get_parallel_lm_head_cls", "vocab_parallel_embedding", "ParallelLMHead"),
+    ("get_logits_processor_cls", "logits_processor", "LogitsProcessor"),
+)
+
+
+@pytest.mark.parametrize("getter,module,name", _CLASS_GETTERS)
+def test_class_getter_falls_back_when_disabled(monkeypatch, getter, module, name):
+    """Disabled: each getter returns the vLLM class."""
+    monkeypatch.setenv("VLLM_USE_HW_AGNOSTIC", "0")
+    vllm_cls = getattr(
+        importlib.import_module(f"vllm.model_executor.layers.{module}"), name
+    )
+    assert getattr(layers, getter)() is vllm_cls
+
+
+@pytest.mark.parametrize("getter,module,name", _CLASS_GETTERS)
+def test_class_getter_uses_hw_agnostic_when_enabled(
+    monkeypatch, caplog, getter, module, name
+):
+    """Enabled: each getter returns the hw-agnostic class and logs it."""
+    monkeypatch.setenv("VLLM_USE_HW_AGNOSTIC", "1")
+    hw_cls = getattr(
+        importlib.import_module(f"vllm.model_executor.hw_agnostic.layers.{module}"),
+        name,
+    )
+    with caplog.at_level(logging.INFO):
+        resolved = getattr(layers, getter)()
+    assert resolved is hw_cls
+    assert f"Using hw-agnostic layer: {name}" in caplog.text
+
+
+@pytest.mark.parametrize("getter,module,name", _CLASS_GETTERS)
+def test_class_getter_falls_back_when_symbol_missing(
+    monkeypatch, caplog, getter, module, name
+):
+    """Enabled but the symbol is not ported: fall back to vLLM and warn."""
+    monkeypatch.setenv("VLLM_USE_HW_AGNOSTIC", "1")
+    hw_module = f"vllm.model_executor.hw_agnostic.layers.{module}"
+    monkeypatch.setitem(sys.modules, hw_module, types.ModuleType(hw_module))
+    vllm_cls = getattr(
+        importlib.import_module(f"vllm.model_executor.layers.{module}"), name
+    )
+    with caplog.at_level(logging.WARNING):
+        resolved = getattr(layers, getter)()
+    assert resolved is vllm_cls
+    assert "falling back to default" in caplog.text
+
+
+def _save_tiny_llama(tmp_path_factory, name: str, *, tie_word_embeddings: bool) -> str:
     """A randomly-initialized microscopic Llama saved to disk (with an ungated
     tokenizer) so vLLM can load it like any local checkpoint."""
     from transformers import AutoTokenizer, LlamaConfig, LlamaForCausalLM
@@ -95,19 +149,40 @@ def tiny_llama_path(tmp_path_factory):
         num_attention_heads=4,
         rms_norm_eps=1e-6,
         hidden_act="silu",
+        tie_word_embeddings=tie_word_embeddings,
     )
     torch.manual_seed(0)
     model = LlamaForCausalLM(config)
 
-    path = tmp_path_factory.mktemp("tiny_llama")
+    path = tmp_path_factory.mktemp(name)
     model.save_pretrained(path)
     tokenizer.save_pretrained(path)
     return str(path)
 
 
+@pytest.fixture(scope="module")
+def tiny_llama_path(tmp_path_factory):
+    """A tiny Llama with an untied `lm_head`."""
+    return _save_tiny_llama(tmp_path_factory, "tiny_llama", tie_word_embeddings=False)
+
+
+@pytest.fixture(scope="module")
+def tiny_llama_tied_path(tmp_path_factory):
+    """A tiny Llama whose `lm_head` is tied to the input embedding."""
+    return _save_tiny_llama(
+        tmp_path_factory, "tiny_llama_tied", tie_word_embeddings=True
+    )
+
+
 # Registered names of the layers the backend can
 # currently route to hw-agnostic implementations.
-_COVERED_LAYERS = ("rms_norm", "silu_and_mul")
+_COVERED_LAYERS = (
+    "rms_norm",
+    "silu_and_mul",
+    "vocab_parallel_embedding",
+    "parallel_lm_head",
+    "logits_processor",
+)
 
 
 def _layer_providers(model) -> dict[str, str]:
@@ -164,12 +239,42 @@ def test_hw_agnostic_matches_vllm_end_to_end(monkeypatch, vllm_runner, tiny_llam
 
     monkeypatch.setenv("VLLM_USE_HW_AGNOSTIC", "0")
     vllm_providers, vllm_outputs = _serve(vllm_runner, tiny_llama_path, prompts)
-    # Both replaceable layers present in a Llama block must be vLLM's here.
-    assert vllm_providers == {"rms_norm": "vllm", "silu_and_mul": "vllm"}
+    # Every replaceable layer present in the model must be vLLM's here.
+    assert vllm_providers == dict.fromkeys(_COVERED_LAYERS, "vllm")
 
     monkeypatch.setenv("VLLM_USE_HW_AGNOSTIC", "1")
     hw_providers, hw_outputs = _serve(vllm_runner, tiny_llama_path, prompts)
-    assert hw_providers == {"rms_norm": "hw_agnostic", "silu_and_mul": "hw_agnostic"}
+    assert hw_providers == dict.fromkeys(_COVERED_LAYERS, "hw_agnostic")
+
+    check_logprobs_close(
+        outputs_0_lst=vllm_outputs,
+        outputs_1_lst=hw_outputs,
+        name_0="vllm",
+        name_1="hw_agnostic",
+    )
+
+
+def test_hw_agnostic_matches_vllm_with_tied_lm_head(
+    monkeypatch, vllm_runner, tiny_llama_tied_path
+):
+    """Tied `lm_head`: the hw-agnostic embedding and head still match vLLM.
+
+    Exercises `ParallelLMHead.tie_weights` across the hw-agnostic classes and the
+    `isinstance` check that decides whether to tie; a class mismatch there would
+    silently drop the tie, so this guards it end to end.
+    """
+    monkeypatch.setenv("VLLM_WORKER_MULTIPROC_METHOD", "spawn")
+    monkeypatch.setenv("VLLM_ALLOW_INSECURE_SERIALIZATION", "1")
+    from ..utils import check_logprobs_close
+
+    prompts = ["The capital of France is", "vLLM is"]
+
+    monkeypatch.setenv("VLLM_USE_HW_AGNOSTIC", "0")
+    _, vllm_outputs = _serve(vllm_runner, tiny_llama_tied_path, prompts)
+
+    monkeypatch.setenv("VLLM_USE_HW_AGNOSTIC", "1")
+    hw_providers, hw_outputs = _serve(vllm_runner, tiny_llama_tied_path, prompts)
+    assert hw_providers == dict.fromkeys(_COVERED_LAYERS, "hw_agnostic")
 
     check_logprobs_close(
         outputs_0_lst=vllm_outputs,

--- a/vllm/model_executor/hw_agnostic/custom_op.py
+++ b/vllm/model_executor/hw_agnostic/custom_op.py
@@ -1,274 +1,69 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-import functools
-import inspect
+"""HW-agnostic view of the custom-op plumbing.
 
-import torch
-import torch.nn as nn
+This module holds no registry of its own: `CustomOp`, `PluggableLayer` and the
+two registries are identity-bearing, so `vllm.model_executor.custom_op` stays the
+single source of truth and they are re-exported from it unchanged.
 
-from vllm.config import get_cached_compilation_config
+What it adds are two thin wrappers, `HwAgnosticCustomOp` and
+`HwAgnosticPluggableLayer`, which the hw-agnostic layers import under the base
+classes' own names:
+
+    from vllm.model_executor.hw_agnostic.custom_op import (
+        HwAgnosticCustomOp as CustomOp,
+    )
+
+    @CustomOp.register("silu_and_mul")
+    class SiluAndMul(CustomOp): ...
+"""
+
+import importlib
+
 from vllm.logger import init_logger
-from vllm.model_executor.utils import maybe_disable_graph_partition
-from vllm.platforms import current_platform
+from vllm.model_executor.custom_op import (
+    CustomOp,
+    PluggableLayer,
+    maybe_get_oot_by_class,
+    op_registry,
+    op_registry_oot,
+)
 
 logger = init_logger(__name__)
 
-# Dictionary of all custom ops (classes, indexed by registered name).
-# To check if an op with a name is enabled, call .enabled() on the class.
-# Examples:
-# - MyOp.enabled()
-# - op_registry["my_op"].enabled()
-op_registry: dict[str, type["CustomOp"] | type["PluggableLayer"]] = {}
-op_registry_oot: dict[str, type["CustomOp"] | type["PluggableLayer"]] = {}
+__all__ = [
+    "CustomOp",
+    "HwAgnosticCustomOp",
+    "HwAgnosticPluggableLayer",
+    "PluggableLayer",
+    "maybe_get_oot_by_class",
+    "op_registry",
+    "op_registry_oot",
+    "validate_registered_overrides",
+]
 
 
-def maybe_get_oot_by_class(class_type: type) -> type:
-    class_name = class_type.__name__
-    if class_name in op_registry_oot:
-        return op_registry_oot[class_name]
-    return class_type
+def _claim_op_name(op_cls: type, name: str) -> type:
+    """Set the op name on `op_cls`, leaving `op_registry[name]` to the in-tree op.
 
-
-class PluggableLayer(nn.Module):
+    Only `cls.name` affects what runs: `enabled()` and `dispatch_forward` read it,
+    and the out-of-tree swap in either `__new__` keys on `cls.__name__`.
     """
-    Base class for pluggable layers.
-
-    A PluggableLayer is a *module-composing* abstraction: it may instantiate other
-    ``torch.nn.Module`` objects as sub-layers, and its functionality depends on
-    these sub-layers following a generalized invocation sequence. Also, it is stateful
-    and may hold parameters or buffers.
-
-    Unlike :class:`CustomOp`, PluggableLayer does NOT provide per-platform
-    ``forward_*`` dispatch. Instead, it supports out-of-tree (OOT) replacement
-    of the entire layer class at instantiation time, allowing customized
-    initialization and submodule composition.
-    """
-
-    def __new__(cls, *args, **kwargs):
-        try:
-            layer_class_name = cls.__name__
-        except AttributeError:
-            raise TypeError(
-                f"Cannot instantiate '{cls.__name__}': its 'name' attribute "
-                f"was not set, possibly because it was not decorated with "
-                f"@PluggableLayer.register, or it's the PluggableLayer itself."
-            ) from None
-
-        if layer_class_name not in op_registry_oot:
-            layer_cls_to_instantiate = cls
-        else:
-            layer_cls_to_instantiate = op_registry_oot[layer_class_name]
-            logger.debug(
-                "Instantiating pluggable layer: %s using %s",
-                layer_class_name,
-                str(layer_cls_to_instantiate),
-            )
-        return super().__new__(layer_cls_to_instantiate)
-
-    # Decorator to register pluggable layers.
-    @classmethod
-    def register(cls, name: str):
-        def decorator(op_cls):
-            assert name not in op_registry, f"Duplicate op name: {name}"
-            op_cls.name = name
-            op_registry[name] = op_cls
-            return op_cls
-
-        return decorator
-
-    # Decorator to register out-of-tree(oot) pluggable layers.
-    # For OOT pluggable layers:
-    #   if in-tree layer class is registered with an oot_custom_layer,
-    #   the oot_custom_layer will be used instead.
-    @classmethod
-    def register_oot(cls, _decorated_layer_cls=None, name: str | None = None):
-        def decorator(layer_cls):
-            reg_name = name if name is not None else cls.__name__
-            assert reg_name not in op_registry_oot, f"Duplicate layer name: {reg_name}"
-            layer_cls.name = reg_name
-            op_registry_oot[reg_name] = layer_cls
-            return layer_cls
-
-        if _decorated_layer_cls is None:
-            # Called with parentheses: @PluggableLayer.register_oot()
-            # or @PluggableLayer.register_oot(name="...")
-            return decorator
-        elif isinstance(_decorated_layer_cls, type):  # Check if it's a class
-            # Called without parentheses: @PluggableLayer.register_oot
-            return decorator(_decorated_layer_cls)
-        else:
-            raise TypeError("Decorator can only be applied to classes.")
-
-
-class CustomOp(nn.Module):
-    """
-    Base class for custom ops.
-    Dispatches the forward method to the appropriate backend.
-    """
-
-    def __new__(cls, *args, **kwargs):
-        try:
-            op_name = cls.__name__
-        except AttributeError:
-            raise TypeError(
-                f"Cannot instantiate '{cls.__name__}': its 'name' attribute "
-                f"was not set, possibly because it was not decorated with "
-                f"@CustomOp.register, or it's the CustomOp base class itself."
-            ) from None
-
-        if op_name not in op_registry_oot:
-            op_cls_to_instantiate = cls
-        else:
-            op_cls_to_instantiate = op_registry_oot[op_name]
-            logger.debug(
-                "Instantiating custom op: %s using %s",
-                op_name,
-                str(op_cls_to_instantiate),
-            )
-        return super().__new__(op_cls_to_instantiate)
-
-    def __init__(self, *, enforce_enable: bool = False, compile_native: bool = False):
-        super().__init__()
-        self._enforce_enable = enforce_enable
-        self._forward_method = self.dispatch_forward(compile_native=compile_native)
-
-    def forward(self, *args, **kwargs):
-        return self._forward_method(*args, **kwargs)
-
-    def forward_native(self, *args, **kwargs):
-        """PyTorch-native implementation; OOT plugins override via
-        :meth:`forward_oot`."""
-        raise NotImplementedError
-
-    def forward_oot(self, *args, **kwargs):
-        # By default, OOT ops fall back to the PyTorch-native implementation.
-        return self.forward_native(*args, **kwargs)
-
-    def dispatch_forward(self, compile_native: bool):
-        # The hw-agnostic CustomOp dispatches only between forward_native
-        # (in-tree, used on every platform) and forward_oot (overridden by
-        # an OOT plugin via register_oot).
-        compilation_config = get_cached_compilation_config()
-
-        # NOTE(shen-shanshan): CustomOp object can be enforce enabled, e.g.,
-        # enable device-specific kernels in ViT models when enabling graph
-        # mode. By default, it will follow the compilation_config to determine
-        # whether enable itself.
-        # This enforce_enable mechanism will be removed after we adding a
-        # separate compilation_config for multi-modal part.
-        enabled = self._enforce_enable or self.enabled()
-        if enabled:
-            compilation_config.enabled_custom_ops.update([self.__class__.name])
-        else:
-            compilation_config.disabled_custom_ops.update([self.__class__.name])
-
-        if not enabled:
-            # Compile forward_native to avoid eager torch ops if inside
-            # opaque torch custom op (e.g. fused_moe, unified_attention, etc.)
-            return self.maybe_compile(self.forward_native, enable=compile_native)
-
-        if current_platform.is_out_of_tree():
-            return self.forward_oot
-        return self.forward_native
-
-    def maybe_compile(self, fn, *, enable: bool = True):
-        """
-        Compile fn if compilation enabled.
-        Useful for CustomOp instances called from within a torch custom op,
-        meaning the forward call is hidden from the model-level torch.compile.
-
-        NOTE: this does not enable fusion across ops, so opaque custom ops
-        should still be unwrapped wherever possible.
-        """
-        from vllm.config.compilation import CompilationMode
-
-        # Do not compile if compilation disabled
-        if not enable:
-            return fn
-
-        # Do not compile if global compilation disabled
-        compilation_config = get_cached_compilation_config()
-        if compilation_config.mode == CompilationMode.NONE:
-            return fn
-
-        # If eager backend is used, do not compile either
-        if compilation_config.backend == "eager":
-            return fn
-
-        compile_options = maybe_disable_graph_partition(
-            current_platform.simple_compile_backend
+    op_cls.name = name  # type: ignore[attr-defined]
+    if name not in op_registry:
+        logger.debug(
+            "hw-agnostic op %s.%s claims %r, which no in-tree op registered; "
+            "`custom_ops` validation will report the name as non-existent.",
+            op_cls.__module__,
+            op_cls.__qualname__,
+            name,
         )
-        backend = current_platform.simple_compile_backend
+    return op_cls
 
-        dynamic_arg_dims = getattr(self.__class__, "_dynamic_arg_dims", None)
-        if dynamic_arg_dims is not None:
-            compiled_fn = torch.compile(
-                fn,
-                dynamic=False,
-                backend=backend,
-                options=compile_options,
-            )
-            sig = inspect.signature(fn)
 
-            @functools.wraps(fn)
-            def wrapper(*args, **kwargs):
-                bound = sig.bind(*args, **kwargs)
-                bound.apply_defaults()
-                for name, dims in dynamic_arg_dims.items():
-                    arg = bound.arguments.get(name)
-                    if arg is not None and isinstance(arg, torch.Tensor):
-                        dims_list = [dims] if isinstance(dims, int) else dims
-                        for d in dims_list:
-                            real_d = arg.ndim + d if d < 0 else d
-                            torch._dynamo.mark_dynamic(arg, real_d)
-                return compiled_fn(*args, **kwargs)
+class HwAgnosticCustomOp(CustomOp):
+    """HW-agnostic `CustomOp` wrapper, ensuring proper name registering."""
 
-            return wrapper
-
-        # dynamic=True to avoid recompilations
-        return torch.compile(
-            fn,
-            dynamic=True,
-            backend=backend,
-            options=compile_options,
-        )
-
-    @classmethod
-    def enabled(cls) -> bool:
-        # if no name, then it was not registered
-        compilation_config = get_cached_compilation_config()
-        custom_ops = compilation_config.custom_ops
-        if not hasattr(cls, "name"):
-            logger.warning_once(
-                "Custom op %s was not registered, which means it won't appear "
-                "in the op registry. It will be enabled/disabled based on the "
-                "global settings.",
-                cls.__name__,
-            )
-            return CustomOp.default_on()
-
-        enabled = f"+{cls.name}" in custom_ops
-        disabled = f"-{cls.name}" in custom_ops
-        assert not (enabled and disabled), f"Cannot enable and disable {cls.name}"
-
-        return (CustomOp.default_on() or enabled) and not disabled
-
-    @staticmethod
-    def default_on() -> bool:
-        """
-        Behavior controlled by `CompilationConfig.custom_ops`: On by default if
-        'all', off by default if 'none'.
-        When PyTorch Inductor is used, 'none' is the default value,
-        otherwise 'all'.
-        """
-        compilation_config = get_cached_compilation_config()
-        count_none = compilation_config.custom_ops.count("none")
-        count_all = compilation_config.custom_ops.count("all")
-        assert count_none + count_all == 1
-
-        return not count_none > 0 or count_all > 0
-
-    # Decorator to register custom ops.
     @classmethod
     def register(
         cls,
@@ -276,43 +71,47 @@ class CustomOp(nn.Module):
         dynamic_arg_dims: dict[str, int | list[int]] | None = None,
     ):
         def decorator(op_cls):
-            assert name not in op_registry, f"Duplicate op name: {name}"
-            op_cls.name = name
             op_cls._dynamic_arg_dims = dynamic_arg_dims
-            op_registry[name] = op_cls
-            return op_cls
+            return _claim_op_name(op_cls, name)
 
         return decorator
 
-    # Decorator to register out-of-tree(oot) custom ops.
-    # For OOT custom ops:
-    #   if in-tree layer class is registered with an oot_custom_op layer,
-    #   the oot_custom_op layer will be used instead.
-    # Example:
-    # - @UnquantizedFusedMoEMethod.register_oot
-    #   class HPUUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod)
-    # or
-    # - @CustomOP.register_oot(name="UnquantizedFusedMoEMethod")
-    @classmethod
-    def register_oot(cls, _decorated_op_cls=None, name: str | None = None):
-        def decorator(op_cls):
-            reg_name = name if name is not None else cls.__name__
-            assert reg_name not in op_registry_oot, f"Duplicate op name: {reg_name}"
-            op_cls.name = reg_name
-            op_registry_oot[reg_name] = op_cls
-            return op_cls
+    def forward_cuda(self, *args, **kwargs):
+        return self.forward_native(*args, **kwargs)
 
-        if _decorated_op_cls is None:
-            # Called with parentheses: @CustomOP.register_oot()
-            # or @CustomOP.register_oot(name="...")
-            # So, _decorated_op_cls is None.
-            # We return the actual decorator function.
-            return decorator
-        elif isinstance(_decorated_op_cls, type):  # Check if it's a class
-            # Called without parentheses: @CustomOP.register_oot
-            # The first argument is the class itself.
-            # We call the 'decorator' function immediately with the class.
-            return decorator(_decorated_op_cls)
-        else:
-            # Handle other unexpected cases if necessary
-            raise TypeError("Decorator can only be applied to classes.")
+
+class HwAgnosticPluggableLayer(PluggableLayer):
+    """HW-agnostic `PluggableLayer` wrapper, ensuring proper name registering."""
+
+    @classmethod
+    def register(cls, name: str):
+        def decorator(op_cls):
+            return _claim_op_name(op_cls, name)
+
+        return decorator
+
+
+def validate_registered_overrides(hw_modules: dict[str, str]) -> None:
+    """Check each registered override against the class it will replace.
+
+    Raises:
+        TypeError: If an override is not a subclass of the class published under
+            its name.
+    """
+    for hw_name in hw_modules.values():
+        hw_module = importlib.import_module(hw_name)
+        for name, hw_cls in vars(hw_module).items():
+            # Only classes the module defines itself were published.
+            if isinstance(hw_cls, type) and hw_cls.__module__ == hw_module.__name__:
+                oot_cls = op_registry_oot.get(name)
+                if oot_cls is not None and not issubclass(oot_cls, hw_cls):
+                    raise TypeError(
+                        f"out-of-tree layer {oot_cls.__module__}."
+                        f"{oot_cls.__qualname__} is registered under {name!r}, but "
+                        f"it is not a subclass of {hw_cls.__module__}."
+                        f"{hw_cls.__qualname__}, which is what this process "
+                        f"instantiates under that name (VLLM_USE_HW_AGNOSTIC is "
+                        f"set), so its __init__ would be skipped. It most likely "
+                        f"captured vllm.model_executor.layers.{name} through an "
+                        f"import that `hw_agnostic_layer_names()` does not cover."
+                    )

--- a/vllm/model_executor/hw_agnostic/layers/_layer_names.py
+++ b/vllm/model_executor/hw_agnostic/layers/_layer_names.py
@@ -32,6 +32,12 @@ _MIRRORED_MODULES: dict[str, str] = {
     "vllm.model_executor.layers.layernorm": (
         "vllm.model_executor.hw_agnostic.layers.layernorm"
     ),
+    "vllm.model_executor.layers.logits_processor": (
+        "vllm.model_executor.hw_agnostic.layers.logits_processor"
+    ),
+    "vllm.model_executor.layers.vocab_parallel_embedding": (
+        "vllm.model_executor.hw_agnostic.layers.vocab_parallel_embedding"
+    ),
 }
 
 

--- a/vllm/model_executor/hw_agnostic/layers/_layer_names.py
+++ b/vllm/model_executor/hw_agnostic/layers/_layer_names.py
@@ -1,0 +1,108 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Resolving `vllm.model_executor.layers.<mod>.X` to
+`vllm.model_executor.hw_agnostic.layers.<mod>.X`.
+
+The hw-agnostic layers are self-contained implementations, so a layer name
+denotes two unrelated classes, the hw-agnostic and the hw-specific.
+An out-of-tree plugin might subclass
+`from vllm.model_executor.layers.<mod> import X` or
+`from vllm.model_executor.hw_agnostic.layers.<mod> import X`.
+
+In case of `from vllm.model_executor.layers.<mod> import X`,
+`hw_agnostic_layer_names()` rebinds the in-tree names to the
+hw-agnostic classes.
+"""
+
+import importlib
+from types import ModuleType, TracebackType
+
+import vllm.envs as envs
+from vllm.logger import init_logger
+from vllm.model_executor.hw_agnostic.custom_op import validate_registered_overrides
+
+logger = init_logger(__name__)
+
+# In-tree layer module -> its hw-agnostic counterpart.
+# Layers with no hw-agnostic implementation, keep their in-tree class.
+_MIRRORED_MODULES: dict[str, str] = {
+    "vllm.model_executor.layers.activation": (
+        "vllm.model_executor.hw_agnostic.layers.activation"
+    ),
+    "vllm.model_executor.layers.layernorm": (
+        "vllm.model_executor.hw_agnostic.layers.layernorm"
+    ),
+}
+
+
+def _own_definitions(module: ModuleType) -> dict[str, object]:
+    """Public names `module` defines itself; a re-export is not an implementation."""
+    return {
+        name: obj
+        for name, obj in vars(module).items()
+        if not name.startswith("_")
+        and getattr(obj, "__module__", None) == module.__name__
+    }
+
+
+class _LayerNameScope:
+    """The context manager `hw_agnostic_layer_names()` hands out."""
+
+    def __init__(self) -> None:
+        self._saved: list[tuple[ModuleType, str, object]] = []
+        self._entered = False
+
+    def __enter__(self) -> None:
+        if not envs.VLLM_USE_HW_AGNOSTIC:
+            return
+        self._entered = True
+        try:
+            for vllm_name, hw_name in _MIRRORED_MODULES.items():
+                vllm_module = importlib.import_module(vllm_name)
+                hw_module = importlib.import_module(hw_name)
+
+                rebound = []
+                for name, hw_obj in _own_definitions(hw_module).items():
+                    if not hasattr(vllm_module, name):
+                        continue  # hw-agnostic-only helper
+                    self._saved.append((vllm_module, name, getattr(vllm_module, name)))
+                    setattr(vllm_module, name, hw_obj)
+                    rebound.append(name)
+
+                logger.debug(
+                    "Resolving %s to %s for: %s",
+                    vllm_name,
+                    hw_name,
+                    ", ".join(sorted(rebound)) or "(nothing)",
+                )
+        except BaseException:
+            self._restore()  # `__exit__` does not run if `__enter__` raises
+            raise
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        try:
+            # Skipped if the block raised: that exception is the useful one.
+            if self._entered and exc_type is None:
+                validate_registered_overrides(_MIRRORED_MODULES)
+        finally:
+            self._restore()
+
+    def _restore(self) -> None:
+        for module, name, original in reversed(self._saved):
+            setattr(module, name, original)
+        self._saved.clear()
+        self._entered = False
+
+
+def hw_agnostic_layer_names() -> _LayerNameScope:
+    """Resolve in-tree layer names to the hw-agnostic classes inside this block.
+
+    A no-op unless `VLLM_USE_HW_AGNOSTIC` is set. Restores every rebound name on
+    exit, including when the block raises.
+    """
+    return _LayerNameScope()

--- a/vllm/model_executor/hw_agnostic/layers/activation.py
+++ b/vllm/model_executor/hw_agnostic/layers/activation.py
@@ -3,7 +3,9 @@
 import torch
 import torch.nn.functional as F
 
-from vllm.model_executor.hw_agnostic.custom_op import CustomOp
+from vllm.model_executor.hw_agnostic.custom_op import (
+    HwAgnosticCustomOp as CustomOp,
+)
 
 
 @CustomOp.register("silu_and_mul")

--- a/vllm/model_executor/hw_agnostic/layers/layernorm.py
+++ b/vllm/model_executor/hw_agnostic/layers/layernorm.py
@@ -4,7 +4,9 @@ import torch
 import torch.nn as nn
 from torch import Tensor
 
-from vllm.model_executor.hw_agnostic.custom_op import CustomOp
+from vllm.model_executor.hw_agnostic.custom_op import (
+    HwAgnosticCustomOp as CustomOp,
+)
 
 
 @CustomOp.register("rms_norm")

--- a/vllm/model_executor/hw_agnostic/layers/logits_processor.py
+++ b/vllm/model_executor/hw_agnostic/layers/logits_processor.py
@@ -1,0 +1,179 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import torch
+import torch.nn.functional as F
+
+from vllm.config import get_current_vllm_config
+from vllm.distributed import (
+    tensor_model_parallel_all_gather,
+    tensor_model_parallel_gather,
+)
+from vllm.model_executor.hw_agnostic.custom_op import PluggableLayer
+from vllm.model_executor.hw_agnostic.layers.vocab_parallel_embedding import (
+    UnquantizedEmbeddingMethod,
+    VocabParallelEmbedding,
+)
+from vllm.platforms import current_platform
+
+
+@PluggableLayer.register("logits_processor")
+class LogitsProcessor(PluggableLayer):
+    """Process logits and apply logits processors from sampling metadata.
+
+    1. Gather logits from model hidden_states.
+    2. Scale logits if needed.
+    3. Apply logits processors (if any).
+    """
+
+    def __init__(
+        self,
+        vocab_size: int,
+        org_vocab_size: int | None = None,
+        scale: float = 1.0,
+        logits_as_input: bool = False,
+        soft_cap: float | None = None,
+    ) -> None:
+        super().__init__()
+        self.scale = scale
+        self.vocab_size = vocab_size
+        self.logits_as_input = logits_as_input
+        self.org_vocab_size = org_vocab_size or vocab_size
+        # Soft cap the logits. Used in Gemma 2.
+        self.soft_cap = soft_cap
+        self.use_all_gather = current_platform.use_all_gather()
+        # Dtype of the lm_head projection; an fp32 head (via
+        # `--hf-overrides '{"head_dtype": "float32"}'`) is required for
+        # RL training-inference consistency. Defaults to the model dtype.
+        model_config = get_current_vllm_config().model_config
+        self.head_dtype = model_config.head_dtype if model_config is not None else None
+
+    def forward(
+        self,
+        lm_head: VocabParallelEmbedding,
+        hidden_states: torch.Tensor,
+        embedding_bias: torch.Tensor | None = None,
+    ) -> torch.Tensor | None:
+        if self.logits_as_input:
+            logits = hidden_states
+        else:
+            logits = self._get_logits(hidden_states, lm_head, embedding_bias)
+        if logits is not None:
+            if self.soft_cap is not None:
+                logits = logits / self.soft_cap
+                logits = torch.tanh(logits)
+                logits = logits * self.soft_cap
+            if self.scale != 1.0:
+                logits *= self.scale
+        return logits
+
+    def _gather_logits(self, logits: torch.Tensor) -> torch.Tensor:
+        if self.use_all_gather:
+            # Gather isn't supported for some devices (e.g. TPUs); use
+            # all-gather to keep all ranks in lockstep.
+            logits = tensor_model_parallel_all_gather(logits)
+        else:
+            # None may be returned for rank > 0.
+            logits = tensor_model_parallel_gather(logits)
+        return logits
+
+    def _apply_head(
+        self,
+        lm_head: VocabParallelEmbedding,
+        hidden_states: torch.Tensor,
+        embedding_bias: torch.Tensor | None,
+    ) -> torch.Tensor:
+        """Project hidden states through the lm_head, honoring head_dtype."""
+        if self.head_dtype is None or self.head_dtype == hidden_states.dtype:
+            return lm_head.quant_method.apply(
+                lm_head, hidden_states, bias=embedding_bias
+            )
+
+        if not isinstance(lm_head.quant_method, UnquantizedEmbeddingMethod):
+            raise ValueError(
+                "A head_dtype different from the model dtype is only "
+                "supported for an unquantized lm_head."
+            )
+        if (
+            self.head_dtype == torch.float32
+            and (current_platform.is_cuda() or current_platform.is_rocm())
+            and hidden_states.is_cuda
+        ):
+            # Accumulate directly into fp32 to avoid materializing an fp32 copy
+            # of the lm_head weight each step. `torch.mm(out_dtype=...)` supports
+            # fp32 output for fp16/bf16 inputs only on CUDA and ROCm; other
+            # platforms fall back to the cast path below.
+            flat = hidden_states.reshape(-1, hidden_states.shape[-1])
+            logits = torch.mm(flat, lm_head.weight.t(), out_dtype=self.head_dtype)
+            if embedding_bias is not None:
+                logits = logits + embedding_bias.to(self.head_dtype)
+            return logits.reshape(*hidden_states.shape[:-1], -1)
+        return F.linear(
+            hidden_states.to(self.head_dtype),
+            lm_head.weight.to(self.head_dtype),
+            embedding_bias.to(self.head_dtype) if embedding_bias is not None else None,
+        )
+
+    def _get_logits(
+        self,
+        hidden_states: torch.Tensor,
+        lm_head: VocabParallelEmbedding,
+        embedding_bias: torch.Tensor | None,
+    ) -> torch.Tensor | None:
+        logits = self._apply_head(lm_head, hidden_states, embedding_bias)
+        if lm_head.tp_size > 1:
+            logits = self._gather_logits(logits)
+        if logits is not None:
+            logits = logits[..., : self.org_vocab_size]
+        return logits
+
+    def get_top_tokens(
+        self,
+        lm_head: VocabParallelEmbedding,
+        hidden_states: torch.Tensor,
+        embedding_bias: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """Vocab-parallel argmax without all-gathering full logits.
+
+        Each TP rank computes local argmax, then only the (value, index) pairs
+        are gathered and reduced: O(batch * 2 * tp_size) vs O(batch * vocab_size).
+        """
+        if self.scale <= 0.0 and self.scale != 1.0:
+            raise ValueError(
+                "The local argmax reduction optimization is not supported for "
+                "non-positive logit scaling factors."
+            )
+        tp_size = lm_head.tp_size
+
+        logits = self._apply_head(lm_head, hidden_states, embedding_bias)
+        if self.soft_cap is not None:
+            logits = torch.tanh(logits / self.soft_cap) * self.soft_cap
+        if self.scale != 1.0:
+            logits = logits * self.scale
+
+        num_pad = lm_head.shard_indices.num_org_vocab_padding
+        if num_pad > 0:
+            logits[..., -num_pad:] = -float("inf")
+
+        local_max_vals, local_max_indices = logits.max(dim=-1)
+        vocab_start = lm_head.shard_indices.org_vocab_start_index
+        global_indices = local_max_indices + vocab_start
+
+        if tp_size == 1:
+            return global_indices
+
+        # All-gather (value, index) pairs, then reduce to global argmax.
+        # float32 avoids bf16 precision loss on large vocab indices.
+        local_pair = torch.stack(
+            [local_max_vals.float(), global_indices.float()], dim=-1
+        )
+        gathered = tensor_model_parallel_all_gather(local_pair, dim=-1)
+        gathered = gathered.view(hidden_states.shape[0], tp_size, 2)
+        max_rank_idx = gathered[:, :, 0].argmax(dim=-1, keepdim=True)
+        top_tokens = gathered[:, :, 1].gather(dim=-1, index=max_rank_idx)
+        return top_tokens.squeeze(-1).to(torch.int64)
+
+    def extra_repr(self) -> str:
+        s = f"vocab_size={self.vocab_size}"
+        s += f", org_vocab_size={self.org_vocab_size}"
+        s += f", scale={self.scale}, logits_as_input={self.logits_as_input}"
+        return s

--- a/vllm/model_executor/hw_agnostic/layers/logits_processor.py
+++ b/vllm/model_executor/hw_agnostic/layers/logits_processor.py
@@ -8,7 +8,9 @@ from vllm.distributed import (
     tensor_model_parallel_all_gather,
     tensor_model_parallel_gather,
 )
-from vllm.model_executor.hw_agnostic.custom_op import PluggableLayer
+from vllm.model_executor.hw_agnostic.custom_op import (
+    HwAgnosticPluggableLayer as PluggableLayer,
+)
 from vllm.model_executor.hw_agnostic.layers.vocab_parallel_embedding import (
     UnquantizedEmbeddingMethod,
     VocabParallelEmbedding,

--- a/vllm/model_executor/hw_agnostic/layers/vocab_parallel_embedding.py
+++ b/vllm/model_executor/hw_agnostic/layers/vocab_parallel_embedding.py
@@ -15,7 +15,9 @@ from vllm.distributed import (
     get_tensor_model_parallel_world_size,
     tensor_model_parallel_all_reduce,
 )
-from vllm.model_executor.hw_agnostic.custom_op import PluggableLayer
+from vllm.model_executor.hw_agnostic.custom_op import (
+    HwAgnosticPluggableLayer as PluggableLayer,
+)
 from vllm.model_executor.layers.batch_invariant import (
     linear_batch_invariant,
 )

--- a/vllm/model_executor/hw_agnostic/layers/vocab_parallel_embedding.py
+++ b/vllm/model_executor/hw_agnostic/layers/vocab_parallel_embedding.py
@@ -1,0 +1,581 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+import torch
+import torch.nn.functional as F
+from torch.nn.parameter import Parameter
+
+import vllm.envs as envs
+from vllm.distributed import (
+    divide,
+    get_tensor_model_parallel_rank,
+    get_tensor_model_parallel_world_size,
+    tensor_model_parallel_all_reduce,
+)
+from vllm.model_executor.hw_agnostic.custom_op import PluggableLayer
+from vllm.model_executor.layers.batch_invariant import (
+    linear_batch_invariant,
+)
+from vllm.model_executor.layers.quantization.base_config import (
+    QuantizationConfig,
+    QuantizeMethodBase,
+    method_has_implemented_embedding,
+)
+from vllm.model_executor.layers.utils import dispatch_unquantized_gemm
+from vllm.model_executor.parameter import BasevLLMParameter
+from vllm.model_executor.utils import set_weight_attrs
+from vllm.platforms import current_platform
+
+DEFAULT_VOCAB_PADDING_SIZE = 64
+
+
+class UnquantizedEmbeddingMethod(QuantizeMethodBase):
+    """Unquantized method for embeddings."""
+
+    def create_weights(
+        self,
+        layer: torch.nn.Module,
+        input_size_per_partition: int,
+        output_partition_sizes: list[int],
+        input_size: int,
+        output_size: int,
+        params_dtype: torch.dtype,
+        **extra_weight_attrs,
+    ):
+        """Create weights for embedding layer."""
+        weight = Parameter(
+            torch.empty(
+                sum(output_partition_sizes),
+                input_size_per_partition,
+                dtype=params_dtype,
+            ),
+            requires_grad=False,
+        )
+        set_weight_attrs(weight, {"input_dim": 1, "output_dim": 0})
+        layer.register_parameter("weight", weight)
+        set_weight_attrs(weight, extra_weight_attrs)
+
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        if current_platform.is_cpu():
+            from vllm.model_executor.layers.utils import dispatch_cpu_unquantized_gemm
+
+            dispatch_cpu_unquantized_gemm(layer, remove_weight=False)
+
+    def apply(
+        self,
+        layer: torch.nn.Module,
+        x: torch.Tensor,
+        bias: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        if envs.VLLM_BATCH_INVARIANT and current_platform.is_cuda_alike():
+            return linear_batch_invariant(x, layer.weight, bias)
+        return dispatch_unquantized_gemm()(layer, x, layer.weight, bias)
+
+    def embedding(self, layer: torch.nn.Module, input_: torch.Tensor) -> torch.Tensor:
+        return F.embedding(input_, layer.weight)
+
+    def tie_weights(
+        self, layer: torch.nn.Module, embed_tokens: "VocabParallelEmbedding"
+    ):
+        layer.weight = embed_tokens.weight
+        return layer
+
+
+def pad_vocab_size(vocab_size: int, pad_to: int = DEFAULT_VOCAB_PADDING_SIZE) -> int:
+    """Pad the vocab size to the given value."""
+    return ((vocab_size + pad_to - 1) // pad_to) * pad_to
+
+
+def vocab_range_from_per_partition_vocab_size(
+    per_partition_vocab_size: int, rank: int, offset: int = 0
+) -> Sequence[int]:
+    index_f = rank * per_partition_vocab_size
+    index_l = index_f + per_partition_vocab_size
+    return index_f + offset, index_l + offset
+
+
+def vocab_range_from_global_vocab_size(
+    global_vocab_size: int, rank: int, world_size: int, offset: int = 0
+) -> Sequence[int]:
+    per_partition_vocab_size = divide(global_vocab_size, world_size)
+    return vocab_range_from_per_partition_vocab_size(
+        per_partition_vocab_size, rank, offset=offset
+    )
+
+
+@dataclass
+class VocabParallelEmbeddingShardIndices:
+    """Indices for a shard of a vocab parallel embedding."""
+
+    padded_org_vocab_start_index: int
+    padded_org_vocab_end_index: int
+    padded_added_vocab_start_index: int
+    padded_added_vocab_end_index: int
+
+    org_vocab_start_index: int
+    org_vocab_end_index: int
+    added_vocab_start_index: int
+    added_vocab_end_index: int
+
+    @property
+    def num_org_elements(self) -> int:
+        return self.org_vocab_end_index - self.org_vocab_start_index
+
+    @property
+    def num_added_elements(self) -> int:
+        return self.added_vocab_end_index - self.added_vocab_start_index
+
+    @property
+    def num_org_elements_padded(self) -> int:
+        return self.padded_org_vocab_end_index - self.padded_org_vocab_start_index
+
+    @property
+    def num_added_elements_padded(self) -> int:
+        return self.padded_added_vocab_end_index - self.padded_added_vocab_start_index
+
+    @property
+    def num_org_vocab_padding(self) -> int:
+        return self.num_org_elements_padded - self.num_org_elements
+
+    @property
+    def num_added_vocab_padding(self) -> int:
+        return self.num_added_elements_padded - self.num_added_elements
+
+    @property
+    def num_elements_padded(self) -> int:
+        return self.num_org_elements_padded + self.num_added_elements_padded
+
+    def __post_init__(self):
+        # sanity checks
+        assert self.padded_org_vocab_start_index <= self.padded_org_vocab_end_index
+        assert self.padded_added_vocab_start_index <= self.padded_added_vocab_end_index
+
+        assert self.org_vocab_start_index <= self.org_vocab_end_index
+        assert self.added_vocab_start_index <= self.added_vocab_end_index
+
+        assert self.org_vocab_start_index <= self.padded_org_vocab_start_index
+        assert self.added_vocab_start_index <= self.padded_added_vocab_start_index
+        assert self.org_vocab_end_index <= self.padded_org_vocab_end_index
+        assert self.added_vocab_end_index <= self.padded_added_vocab_end_index
+
+        assert self.num_org_elements <= self.num_org_elements_padded
+        assert self.num_added_elements <= self.num_added_elements_padded
+
+
+@torch.compile(dynamic=True, backend=current_platform.simple_compile_backend)
+def get_masked_input_and_mask(
+    input_: torch.Tensor,
+    org_vocab_start_index: int,
+    org_vocab_end_index: int,
+    num_org_vocab_padding: int,
+    added_vocab_start_index: int,
+    added_vocab_end_index: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    # torch.compile will fuse all of the pointwise ops below
+    # into a single kernel, making it very fast
+    org_vocab_mask = (input_ >= org_vocab_start_index) & (input_ < org_vocab_end_index)
+    added_vocab_mask = (input_ >= added_vocab_start_index) & (
+        input_ < added_vocab_end_index
+    )
+    added_offset = (
+        added_vocab_start_index
+        - (org_vocab_end_index - org_vocab_start_index)
+        - num_org_vocab_padding
+    )
+    valid_offset = (org_vocab_start_index * org_vocab_mask) + (
+        added_offset * added_vocab_mask
+    )
+    vocab_mask = org_vocab_mask | added_vocab_mask
+    input_ = vocab_mask * (input_ - valid_offset)
+    return input_, ~vocab_mask
+
+
+# --8<-- [start:vocab_parallel_embedding]
+@PluggableLayer.register("vocab_parallel_embedding")
+class VocabParallelEmbedding(PluggableLayer):
+    """Embedding parallelized in the vocabulary dimension.
+
+    Adapted from torch.nn.Embedding, note that we pad the vocabulary size to
+    make sure it is divisible by the number of model parallel GPUs.
+
+    In order to support various loading methods, we ensure that LoRA-added
+    embeddings are always at the end of TP-sharded tensors. In other words,
+    we shard base embeddings and LoRA embeddings separately (both padded),
+    and place them in the same tensor.
+    In this example, we will have the original vocab size = 1010,
+    added vocab size = 16 and padding to 64. Therefore, the total
+    vocab size with padding will be 1088 (because we first pad 1010 to
+    1024, add 16, and then pad to 1088).
+    Therefore, the tensor format looks like the following:
+    TP1, rank 0 (no sharding):
+                            |< --------BASE-------- >|< -BASE PADDING-- >|< -----LORA------ >|< -LORA PADDING-- >|
+    corresponding token_id: |  0  |  1  | ... | 1009 |  -1  | ... |  -1  | 1010 | ... | 1025 |  -1  | ... |  -1  |
+                     index: |  0  |  1  | ... | 1009 | 1010 | ... | 1023 | 1024 | ... | 1039 | 1040 | ... | 1087 |
+
+    TP2, rank 0:
+                            |< --------------------BASE--------------------- >|< -----LORA------ >|< -LORA PADDING- >|
+    corresponding token_id: |  0  |  1  |  2  | ... | 497  | 498 | ...  | 511 | 1010 | ... | 1025 |  -1  | ... |  -1 |
+                     index: |  0  |  1  |  2  | ... | 497  | 498 | ...  | 511 | 512  | ... | 527  |  528 | ... | 543 |
+    TP2, rank 1:
+                            |< -----------BASE----------- >|< -BASE PADDING- >|< -----------LORA PADDING----------- >|
+    corresponding token_id: | 512 | 513 | 514 | ... | 1009 | -1  | ...  | -1  |  -1  | ... |  -1  | -1  | ... |   -1 |
+                     index: |  0  |  1  |  2  | ... | 497  | 498 | ...  | 511 | 512  | ... | 527  | 528 | ... |  543 |
+
+    Args:
+        num_embeddings: vocabulary size.
+        embedding_dim: size of hidden state.
+        params_dtype: type of the parameters.
+        org_num_embeddings: original vocabulary size (without LoRA).
+        padding_size: padding size for the vocabulary.
+        quant_config: quant config for the layer
+        prefix: full name of the layer in the state dict
+        disable_tp: If true, tensor parallelism will be disabled for this layer.
+    """  # noqa: E501
+
+    # --8<-- [end:vocab_parallel_embedding]
+
+    def __init__(
+        self,
+        num_embeddings: int,
+        embedding_dim: int,
+        params_dtype: torch.dtype | None = None,
+        org_num_embeddings: int | None = None,
+        padding_size: int = DEFAULT_VOCAB_PADDING_SIZE,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
+        *,
+        disable_tp: bool = False,
+    ):
+        super().__init__()
+
+        # Keep the input dimensions.
+        self.disable_tp = disable_tp
+        if disable_tp:
+            tp_rank, self.tp_size = 0, 1
+        else:
+            tp_rank = get_tensor_model_parallel_rank()
+            self.tp_size = get_tensor_model_parallel_world_size()
+        self.tp_rank = tp_rank
+        self.num_embeddings = num_embeddings
+        self.padding_size = padding_size
+        self.org_vocab_size = org_num_embeddings or num_embeddings
+        num_added_embeddings = num_embeddings - self.org_vocab_size
+        self.org_vocab_size_padded = pad_vocab_size(
+            self.org_vocab_size, self.padding_size
+        )
+        self.num_embeddings_padded = pad_vocab_size(
+            self.org_vocab_size_padded + num_added_embeddings, self.padding_size
+        )
+        assert self.org_vocab_size_padded <= self.num_embeddings_padded
+
+        self.shard_indices = self._get_indices(
+            self.num_embeddings_padded,
+            self.org_vocab_size_padded,
+            self.num_embeddings,
+            self.org_vocab_size,
+            tp_rank,
+            self.tp_size,
+        )
+        self.embedding_dim = embedding_dim
+
+        quant_method = None
+        if quant_config is not None:
+            quant_method = quant_config.get_quant_method(self, prefix=prefix)
+        if quant_method is None:
+            quant_method = UnquantizedEmbeddingMethod()
+
+        # If we are making an embedding layer, then our quantization linear
+        # method must implement the embedding operation. If we are another
+        # layer type like ParallelLMHead, this is not important.
+        is_embedding_layer = not isinstance(self, ParallelLMHead)
+        quant_method_implements_embedding = method_has_implemented_embedding(
+            type(quant_method)
+        )
+        if is_embedding_layer and not quant_method_implements_embedding:
+            raise NotImplementedError(
+                f"The class {type(quant_method).__name__} must implement "
+                "the 'embedding' method, see UnquantizedEmbeddingMethod."
+            )
+
+        self.quant_method: QuantizeMethodBase = quant_method
+
+        if params_dtype is None:
+            params_dtype = torch.get_default_dtype()
+        self.params_dtype = params_dtype
+        # Divide the weight matrix along the vocabulary dimension.
+        self.num_added_embeddings = self.num_embeddings - self.org_vocab_size
+        self.num_embeddings_per_partition = divide(
+            self.num_embeddings_padded, self.tp_size
+        )
+        assert (
+            self.shard_indices.num_elements_padded == self.num_embeddings_per_partition
+        )
+        self.num_org_embeddings_per_partition = (
+            self.shard_indices.org_vocab_end_index
+            - self.shard_indices.org_vocab_start_index
+        )
+        self.num_added_embeddings_per_partition = (
+            self.shard_indices.added_vocab_end_index
+            - self.shard_indices.added_vocab_start_index
+        )
+
+        self.quant_method.create_weights(
+            self,
+            self.embedding_dim,
+            [self.num_embeddings_per_partition],
+            self.embedding_dim,
+            self.num_embeddings_padded,
+            params_dtype=params_dtype,
+            weight_loader=self.weight_loader,
+        )
+        self.update_param_tp_status()
+
+    def update_param_tp_status(self):
+        for param in self.parameters():
+            if isinstance(param, BasevLLMParameter):
+                param.tp_rank = self.tp_rank
+                param.tp_size = self.tp_size
+
+    @classmethod
+    def _get_indices(
+        cls,
+        vocab_size_padded: int,
+        org_vocab_size_padded: int,
+        vocab_size: int,
+        org_vocab_size: int,
+        tp_rank: int,
+        tp_size: int,
+    ) -> VocabParallelEmbeddingShardIndices:
+        """Get start and end indices for vocab parallel embedding, following the
+        layout outlined in the class docstring, based on the given tp_rank and
+        tp_size."""
+        num_added_embeddings_padded = vocab_size_padded - org_vocab_size_padded
+        padded_org_vocab_start_index, padded_org_vocab_end_index = (
+            vocab_range_from_global_vocab_size(org_vocab_size_padded, tp_rank, tp_size)
+        )
+        padded_added_vocab_start_index, padded_added_vocab_end_index = (
+            vocab_range_from_global_vocab_size(
+                num_added_embeddings_padded, tp_rank, tp_size, offset=org_vocab_size
+            )
+        )
+        # remove padding
+        org_vocab_start_index = min(padded_org_vocab_start_index, org_vocab_size)
+        org_vocab_end_index = min(padded_org_vocab_end_index, org_vocab_size)
+        added_vocab_start_index = min(padded_added_vocab_start_index, vocab_size)
+        added_vocab_end_index = min(padded_added_vocab_end_index, vocab_size)
+        return VocabParallelEmbeddingShardIndices(
+            padded_org_vocab_start_index,
+            padded_org_vocab_end_index,
+            padded_added_vocab_start_index,
+            padded_added_vocab_end_index,
+            org_vocab_start_index,
+            org_vocab_end_index,
+            added_vocab_start_index,
+            added_vocab_end_index,
+        )
+
+    def get_sharded_to_full_mapping(self) -> list[int] | None:
+        """Get a mapping that can be used to reindex the gathered
+        logits for sampling.
+
+        During sampling, we gather logits from all ranks. The relationship
+        of index->token_id will follow the same format as outlined in the class
+        docstring. However, after the gather, we want to reindex the final
+        logits tensor to map index->token_id one-to-one (the index is always
+        equal the token_id it corresponds to). The indices returned by this
+        method allow us to do that.
+        """
+        if self.tp_size < 2:
+            return None
+
+        base_embeddings: list[int] = []
+        added_embeddings: list[int] = []
+        padding: list[int] = []
+        for tp_rank in range(self.tp_size):
+            shard_indices = self._get_indices(
+                self.num_embeddings_padded,
+                self.org_vocab_size_padded,
+                self.num_embeddings,
+                self.org_vocab_size,
+                tp_rank,
+                self.tp_size,
+            )
+            range_start = self.num_embeddings_per_partition * tp_rank
+            range_end = self.num_embeddings_per_partition * (tp_rank + 1)
+            base_embeddings.extend(
+                range(range_start, range_start + shard_indices.num_org_elements)
+            )
+            padding.extend(
+                range(
+                    range_start + shard_indices.num_org_elements,
+                    range_start + shard_indices.num_org_elements_padded,
+                )
+            )
+            added_embeddings.extend(
+                range(
+                    range_start + shard_indices.num_org_elements_padded,
+                    range_start
+                    + shard_indices.num_org_elements_padded
+                    + shard_indices.num_added_elements,
+                )
+            )
+            padding.extend(
+                range(
+                    range_start
+                    + shard_indices.num_org_elements_padded
+                    + shard_indices.num_added_elements,
+                    range_start
+                    + shard_indices.num_org_elements_padded
+                    + shard_indices.num_added_elements_padded,
+                )
+            )
+            assert (
+                range_start
+                + shard_indices.num_org_elements_padded
+                + shard_indices.num_added_elements_padded
+                == range_end
+            )
+        ret = base_embeddings + added_embeddings + padding
+        assert len(ret) == self.num_embeddings_padded
+        return ret
+
+    def weight_loader(self, param: Parameter, loaded_weight: torch.Tensor):
+        output_dim = getattr(param, "output_dim", None)
+        packed_dim = getattr(param, "packed_dim", None)
+
+        # If parameter does not have output dim, then it should
+        # be copied onto all gpus (e.g. g_idx for act_order gptq).
+        if output_dim is None:
+            if (
+                loaded_weight.ndim == 0
+                and param.data.ndim == 1
+                and param.data.numel() == 1
+            ):
+                loaded_weight = loaded_weight.reshape(1)
+            assert param.data.shape == loaded_weight.shape
+            param.data.copy_(loaded_weight)
+            return
+
+        # Shard indexes for loading the weight
+        start_idx = self.shard_indices.org_vocab_start_index
+        shard_size = self.shard_indices.org_vocab_end_index - start_idx
+
+        # If param packed on the same dim we are sharding on, then
+        # need to adjust offsets of loaded weight by pack_factor.
+        if packed_dim is not None and packed_dim == output_dim:
+            packed_factor = (
+                param.packed_factor
+                if isinstance(param, BasevLLMParameter)
+                else param.pack_factor
+            )
+            assert loaded_weight.shape[output_dim] == (
+                self.org_vocab_size // param.packed_factor
+            )
+            start_idx = start_idx // packed_factor
+            shard_size = shard_size // packed_factor
+        else:
+            assert loaded_weight.shape[output_dim] == self.org_vocab_size
+
+        # Copy the data. Select chunk corresponding to current shard.
+        loaded_weight = loaded_weight.narrow(output_dim, start_idx, shard_size)
+        param[: loaded_weight.shape[0]].data.copy_(loaded_weight)
+        param[loaded_weight.shape[0] :].data.fill_(0)
+
+    def forward(self, input_):
+        if self.tp_size > 1:
+            # Build the mask.
+            masked_input, input_mask = get_masked_input_and_mask(
+                input_,
+                self.shard_indices.org_vocab_start_index,
+                self.shard_indices.org_vocab_end_index,
+                self.shard_indices.num_org_vocab_padding,
+                self.shard_indices.added_vocab_start_index,
+                self.shard_indices.added_vocab_end_index,
+            )
+        else:
+            masked_input = input_
+        # Get the embeddings.
+        output_parallel = self.quant_method.embedding(self, masked_input.long())
+        # Mask the output embedding.
+        if self.tp_size > 1:
+            output_parallel.masked_fill_(input_mask.unsqueeze(-1), 0)
+            # Reduce across all the model parallel GPUs.
+            return tensor_model_parallel_all_reduce(output_parallel)
+        return output_parallel
+
+    def extra_repr(self) -> str:
+        s = f"num_embeddings={self.num_embeddings}"
+        s += f", num_embeddings_per_partition={self.num_embeddings_per_partition}"
+        s += f", embedding_dim={self.embedding_dim}"
+        s += f", org_vocab_size={self.org_vocab_size}"
+        s += f", num_embeddings_padded={self.num_embeddings_padded}"
+        s += f", tp_size={self.tp_size}"
+        return s
+
+
+# --8<-- [start:parallel_lm_head]
+@PluggableLayer.register("parallel_lm_head")
+class ParallelLMHead(VocabParallelEmbedding):
+    """Parallelized LM head.
+
+    Output logits weight matrices used in the Sampler. The weight and bias
+    tensors are padded to make sure they are divisible by the number of
+    model parallel GPUs.
+
+    Args:
+        num_embeddings: vocabulary size.
+        embedding_dim: size of hidden state.
+        bias: whether to use bias.
+        params_dtype: type of the parameters.
+        org_num_embeddings: original vocabulary size (without LoRA).
+        padding_size: padding size for the vocabulary.
+        disable_tp: If true, tensor parallelism will be disabled for this layer.
+    """
+
+    # --8<-- [end:parallel_lm_head]
+
+    def __init__(
+        self,
+        num_embeddings: int,
+        embedding_dim: int,
+        bias: bool = False,
+        params_dtype: torch.dtype | None = None,
+        org_num_embeddings: int | None = None,
+        padding_size: int = DEFAULT_VOCAB_PADDING_SIZE,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
+        *,
+        disable_tp: bool = False,
+    ):
+        super().__init__(
+            num_embeddings,
+            embedding_dim,
+            params_dtype,
+            org_num_embeddings,
+            padding_size,
+            quant_config,
+            prefix,
+            disable_tp=disable_tp,
+        )
+        self.quant_config = quant_config
+        if bias:
+            self._register_bias()
+        else:
+            self.register_parameter("bias", None)
+
+    def _register_bias(self):
+        data = torch.empty(self.num_embeddings_per_partition, dtype=self.params_dtype)
+        self.bias = Parameter(data, requires_grad=False)
+        weight_attrs = dict(output_dim=0, weight_loader=self.weight_loader)
+        set_weight_attrs(weight=self.bias, weight_attrs=weight_attrs)
+
+    def tie_weights(self, embed_tokens: VocabParallelEmbedding):
+        """Tie the weights with word embeddings."""
+        return self.quant_method.tie_weights(self, embed_tokens)
+
+    def forward(self, input_):
+        del input_
+        raise RuntimeError("LMHead's weights should be used in the sampler.")

--- a/vllm/model_executor/models/transformers/causal.py
+++ b/vllm/model_executor/models/transformers/causal.py
@@ -19,12 +19,15 @@
 from collections.abc import Iterable
 from typing import TYPE_CHECKING
 
-from vllm.model_executor.layers.logits_processor import LogitsProcessor
 from vllm.model_executor.layers.vocab_parallel_embedding import (
-    ParallelLMHead,
-    VocabParallelEmbedding,
+    VocabParallelEmbedding as VllmVocabParallelEmbedding,
 )
 from vllm.model_executor.models.interfaces_base import VllmModelForTextGeneration
+from vllm.model_executor.models.transformers.layers import (
+    get_logits_processor_cls,
+    get_parallel_lm_head_cls,
+    get_vocab_parallel_embedding_cls,
+)
 from vllm.model_executor.models.utils import PPMissingLayer, maybe_prefix
 
 if TYPE_CHECKING:
@@ -47,19 +50,23 @@ class CausalMixin(VllmModelForTextGeneration):
             self.skip_prefixes.append("lm_head.")
 
         if self.pp_group.is_last_rank:
-            self.lm_head = ParallelLMHead(
+            self.lm_head = get_parallel_lm_head_cls()(
                 self.text_config.vocab_size,
                 self.text_config.hidden_size,
                 quant_config=self.quant_config,
                 prefix=maybe_prefix(prefix, "lm_head"),
             )
             if tie_word_embeddings:
+                vpe_classes = (
+                    get_vocab_parallel_embedding_cls(),
+                    VllmVocabParallelEmbedding,
+                )
                 for module in self.model.get_input_embeddings().modules():
-                    if isinstance(module, VocabParallelEmbedding):
+                    if isinstance(module, vpe_classes):
                         self.lm_head = self.lm_head.tie_weights(module)
                         break
 
-            self.logits_processor = LogitsProcessor(
+            self.logits_processor = get_logits_processor_cls()(
                 self.text_config.vocab_size,
                 scale=getattr(self.text_config, "logit_scale", 1.0),
                 soft_cap=getattr(self.text_config, "final_logit_softcapping", None),

--- a/vllm/model_executor/models/transformers/layers.py
+++ b/vllm/model_executor/models/transformers/layers.py
@@ -39,6 +39,21 @@ RMSNorm = _resolve("layernorm", "RMSNorm")
 GemmaRMSNorm = _resolve("layernorm", "GemmaRMSNorm")
 
 
+def get_vocab_parallel_embedding_cls():
+    """`VocabParallelEmbedding` class, preferring hw-agnostic. Resolved per call."""
+    return _resolve("vocab_parallel_embedding", "VocabParallelEmbedding")
+
+
+def get_parallel_lm_head_cls():
+    """`ParallelLMHead` class, preferring hw-agnostic. Resolved per call."""
+    return _resolve("vocab_parallel_embedding", "ParallelLMHead")
+
+
+def get_logits_processor_cls():
+    """`LogitsProcessor` class, preferring hw-agnostic. Resolved per call."""
+    return _resolve("logits_processor", "LogitsProcessor")
+
+
 def get_act_and_mul_fn(act_fn_name: str):
     """Fused activation-and-mul op for `act_fn_name`, preferring hw-agnostic.
 

--- a/vllm/model_executor/models/transformers/utils.py
+++ b/vllm/model_executor/models/transformers/utils.py
@@ -270,7 +270,11 @@ def replace_embedding_class(
     )
     # If `embedding` is a bare `nn.Embedding`, simple replace
     if type(embedding) is nn.Embedding:
-        return VocabParallelEmbedding(**kwargs)
+        from vllm.model_executor.models.transformers.layers import (
+            get_vocab_parallel_embedding_cls,
+        )
+
+        return get_vocab_parallel_embedding_cls()(**kwargs)
 
     # Otherwise `embedding` inherits `nn.Embedding`, rebase it in place
     embedding.__class__ = _rebase_on_vocab_parallel(type(embedding))

--- a/vllm/plugins/__init__.py
+++ b/vllm/plugins/__init__.py
@@ -74,6 +74,13 @@ def load_plugins_by_group(group: str) -> dict[str, Callable[[], Any]]:
     return plugins
 
 
+def _run_general_plugins():
+    plugins = load_plugins_by_group(group=DEFAULT_PLUGINS_GROUP)
+    # general plugins, we only need to execute the loaded functions
+    for func in plugins.values():
+        func()
+
+
 def load_general_plugins():
     """WARNING: plugins can be loaded for multiple times in different
     processes. They should be designed in a way that they can be loaded
@@ -84,10 +91,17 @@ def load_general_plugins():
         return
     plugins_loaded = True
 
-    plugins = load_plugins_by_group(group=DEFAULT_PLUGINS_GROUP)
-    # general plugins, we only need to execute the loaded functions
-    for func in plugins.values():
-        func()
+    if envs.VLLM_USE_HW_AGNOSTIC:
+        # Wrap the plugin loading to resolve in-tree layer names
+        # to the hw-agnostic classes.
+        from vllm.model_executor.hw_agnostic.layers._layer_names import (
+            hw_agnostic_layer_names,
+        )
+
+        with hw_agnostic_layer_names():
+            _run_general_plugins()
+    else:
+        _run_general_plugins()
 
 
 def load_endpoint_plugins(


### PR DESCRIPTION
## Purpose

Extends the hardware-agnostic layer path in the Transformers modeling backend to
cover the token-embedding boundary: input embedding (`VocabParallelEmbedding`),
LM head (`ParallelLMHead`), and the logits projection (`LogitsProcessor`).

When `VLLM_USE_HW_AGNOSTIC` is unset (the default), behavior is unchanged: every
site resolves to the same vLLM class it used before.

## Test Plan

I ran an `lm_eval` with the Granite3.3-8B model, to demonstrate that the new additional layers do not introduce numerical issues.

```
export VLLM_USE_HW_AGNOSTIC=1
lm_eval --model vllm \
  --model_args "pretrained=ibm-granite/granite-3.3-8b-instruct,model_impl=transformers,tensor_parallel_size=1,gpu_memory_utilization=0.85,max_model_len=4096,enforce_eager=True" \
  --tasks gsm8k \
  --num_fewshot 5 \
  --batch_size auto \
  --output_path /block/boh/vllm_dev/claude/granite_eval_logs/flag_on
```
In addition, I also added some new, specific tests for the layers.

## Test Result

lm_eval results:


Metric | OFF | ON | Δ
-- | -- | -- | --
flexible-extract | 0.7240 ± 0.0123 | 0.7225 ± 0.0123 | −0.0015
strict-match | 0.6710 ± 0.0129 | 0.6664 ± 0.0130 | −0.0046

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [X] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [X] The test plan, such as providing test command.
- [X] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

cc @tdoublep @hmellor @zou3519 