### PR TITLE
[Bugfix][ROCm] Skip FP8 MLA prefill PS-metadata build for chunked-context batches

### DIFF
--- a/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
+++ b/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
@@ -777,7 +777,11 @@ class AiterMLAMetadataBuilder(MLACommonMetadataBuilder[AiterMLAMetadata]):
             attn_metadata.reduce_indptr = self._mla_reduce_indptr
             attn_metadata.reduce_final_map = self._mla_reduce_final_map
             attn_metadata.reduce_partial_map = self._mla_reduce_partial_map
-        if self._fp8_prefill_enabled and attn_metadata.prefill is not None:
+        if (
+            self._fp8_prefill_enabled
+            and attn_metadata.prefill is not None
+            and attn_metadata.prefill.chunked_context is None
+        ):
             self._build_fp8_prefill_ps_metadata(attn_metadata, common_attn_metadata)
         return attn_metadata
 


### PR DESCRIPTION
## Purpose

FP8 MLA PS ASM kernel is run only on non-chunked (causal) prefills. However, its persistent metadata is always built, even during chunked prefills (unnecessarily).

This PR fixes it so metadata is only computed when it's actually needed.

## Test Plan

Unit test for the exact guarded call site:

```bash
python3 -m pytest -v tests/kernels/attention/test_rocm_aiter_mla_fp8_prefill.py
```

Formatting/lint:

```bash
ruff format --check vllm/v1/attention/backends/mla/rocm_aiter_mla.py
ruff check vllm/v1/attention/backends/mla/rocm_aiter_mla.py
```

End-to-end serving benchmark comparing an unpatched build against this PR applied on
top of the identical base image, so this fix is the only variable:

```bash
docker pull vllm/vllm-openai-rocm:nightly-ac7509e2b1db40fec2f03dde1ed4e9dfdc2338c9

# Build the patched image by swapping in only this PR's file
FILE_PATH=$(docker run --rm --entrypoint python3 \
  vllm/vllm-openai-rocm:nightly-ac7509e2b1db40fec2f03dde1ed4e9dfdc2338c9 \
  -c "import vllm.v1.attention.backends.mla.rocm_aiter_mla as m; print(m.__file__)")
docker create --name patch-pinned vllm/vllm-openai-rocm:nightly-ac7509e2b1db40fec2f03dde1ed4e9dfdc2338c9
docker cp vllm/v1/attention/backends/mla/rocm_aiter_mla.py patch-pinned:$FILE_PATH
docker commit patch-pinned vllm/vllm-openai-rocm:fix327-patched
docker rm patch-pinned
```

Serve DeepSeek-V3-0324 with MTP + expert parallel (TP8) on each image, then:

```bash
vllm bench serve --backend vllm \
  --model deepseek-ai/DeepSeek-V3-0324 \
  --dataset-name sonnet --dataset-path sonnet.txt \
  --sonnet-input-len 5600 --sonnet-output-len 140 \
  --num-prompts 300 --request-rate 5 \
  --percentile-metrics ttft,tpot,itl,e2el
```

## Test Result

**Unit test:**

```
tests/kernels/attention/test_rocm_aiter_mla_fp8_prefill.py::test_fp8_prefill_matches_reference[128] PASSED
tests/kernels/attention/test_rocm_aiter_mla_fp8_prefill.py::test_fp8_prefill_matches_reference[512] PASSED
2 passed
```

**Lint/format:** `ruff format --check` and `ruff check` both pass on the changed file.

**Serving benchmark** (MI350, gfx950, DeepSeek-V3-0324, TP8, MTP, sonnet dataset,
300 prompts, request-rate 5). Both runs use the identical base image
`vllm/vllm-openai-rocm:nightly-ac7509e2b1db40fec2f03dde1ed4e9dfdc2338c9`
(commit `ac7509e2b1db40fec2f03dde1ed4e9dfdc2338c9`); the "patched" build differs only in
`vllm/v1/attention/backends/mla/rocm_aiter_mla.py`, replaced with this PR's version:

| Metric | Unpatched | Patched (this PR) | Δ |
|---|---:|---:|---:|
| Median TTFT (ms) | 5424.92 | 4018.48 | -25.9% (better) |
| P99 TTFT (ms) | 10527.36 | 9007.84 | -14.4% (better) |
| Median TPOT (ms) | 131.88 | 123.69 | -6.2% (better) |
| P99 TPOT (ms) | 359.58 | 342.81 | -4.7% (better) |
| Median E2EL (ms) | 27109.28 | 24722.94 | -8.8% (better) |
| Request throughput (req/s) | 4.04 | 4.17 | +3.2% (better) |
| Spec decode acceptance rate (%) | 89.98 | 90.83 | unchanged (expected) |

Median TTFT improved 25.9% with this fix, consistent with removing the wasted
GPU->CPU sync in `_build_fp8_prefill_ps_metadata()` for chunked-context prefill
batches. The unchanged acceptance rate confirms the fix does not affect decode
correctness or MTP verification, only the prefill metadata build.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>


