### PR TITLE
[Bugfix][DSv4] SM12x Triton fallback for fp8_einsum / o_proj (#43743)

### DIFF
--- a/tests/models/test_dsv4_sm12x_fp8_einsum_dispatch.py
+++ b/tests/models/test_dsv4_sm12x_fp8_einsum_dispatch.py
@@ -1,0 +1,115 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Dispatch contract for DSv4 o_proj on SM12x (#43743).
+
+These tests do not run the Triton kernel. They lock the capability
+predicate so SM12x cannot select DeepGEMM's SM100 scale recipe
+(layout.hpp:97 / Unknown SF transformation).
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+
+
+@pytest.mark.parametrize(
+    ("major", "recipe", "tma"),
+    [
+        (9, (1, 128, 128), False),
+        (10, (1, 1, 128), True),
+        (12, (1, 128, 128), False),
+    ],
+)
+def test_fp8_einsum_recipe_is_per_capability(monkeypatch, major, recipe, tma):
+    from vllm.models.deepseek_v4.nvidia.ops import o_proj
+
+    monkeypatch.setattr(
+        o_proj.current_platform,
+        "get_device_capability",
+        lambda: SimpleNamespace(major=major, minor=1),
+    )
+    got_recipe, got_tma = o_proj.compute_fp8_einsum_recipe()
+    assert got_recipe == recipe
+    assert got_tma is tma
+
+
+def test_sm12x_triton_predicate_rejects_sm100_recipe(monkeypatch):
+    from vllm.models.deepseek_v4.nvidia.ops import fp8_einsum as fe
+
+    monkeypatch.setattr(
+        fe.current_platform,
+        "get_device_capability",
+        lambda: SimpleNamespace(major=12, minor=1),
+    )
+    scale = torch.zeros(1, dtype=torch.float32)
+    assert fe._use_deepseek_v4_sm12x_triton_fp8_einsum(
+        "bhr,hdr->bhd", [1, 128, 128], scale
+    )
+    assert not fe._use_deepseek_v4_sm12x_triton_fp8_einsum(
+        "bhr,hdr->bhd", [1, 1, 128], scale
+    )
+
+
+def test_sm100_does_not_take_triton_fallback(monkeypatch):
+    from vllm.models.deepseek_v4.nvidia.ops import fp8_einsum as fe
+
+    monkeypatch.setattr(
+        fe.current_platform,
+        "get_device_capability",
+        lambda: SimpleNamespace(major=10, minor=0),
+    )
+    scale = torch.zeros(1, dtype=torch.float32)
+    assert not fe._use_deepseek_v4_sm12x_triton_fp8_einsum(
+        "bhr,hdr->bhd", [1, 128, 128], scale
+    )
+
+
+def test_o_proj_calls_triton_not_deepgemm_on_sm12x(monkeypatch):
+    from vllm.models.deepseek_v4.nvidia.ops import o_proj
+
+    monkeypatch.setattr(
+        o_proj.current_platform,
+        "get_device_capability",
+        lambda: SimpleNamespace(major=12, minor=1),
+    )
+    monkeypatch.setattr(
+        o_proj,
+        "fused_inv_rope_fp8_quant",
+        lambda *a, **k: (MagicMock(), MagicMock()),
+    )
+    triton_calls = []
+    deepgemm_calls = []
+    monkeypatch.setattr(
+        o_proj,
+        "_use_deepseek_v4_sm12x_triton_fp8_einsum",
+        lambda *a, **k: True,
+    )
+    monkeypatch.setattr(
+        o_proj, "deepseek_v4_fp8_einsum", lambda *a, **k: triton_calls.append(1)
+    )
+    monkeypatch.setattr(o_proj, "fp8_einsum", lambda *a, **k: deepgemm_calls.append(1))
+
+    o = torch.empty(2, 8, 192)
+    wo_a = SimpleNamespace(
+        weight=torch.empty(4, 8),
+        weight_scale=torch.empty(1, dtype=torch.float32),
+    )
+    wo_b = lambda x: x  # noqa: E731
+    o_proj.deep_gemm_fp8_o_proj(
+        o,
+        torch.zeros(2, dtype=torch.long),
+        torch.zeros(1),
+        wo_a,
+        wo_b,
+        n_groups=1,
+        heads_per_group=8,
+        nope_dim=128,
+        rope_dim=64,
+        o_lora_rank=4,
+        einsum_recipe=(1, 128, 128),
+        tma_aligned_scales=False,
+    )
+    assert triton_calls == [1]
+    assert deepgemm_calls == []

--- a/vllm/models/deepseek_v4/nvidia/ops/fp8_einsum.py
+++ b/vllm/models/deepseek_v4/nvidia/ops/fp8_einsum.py
@@ -1,0 +1,517 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""SM12x Triton FP8 einsum kernels for DeepSeek V4.
+
+Ported from jasl/vllm (PR #41834 preview) to close #43743: mainline
+``fp8_einsum`` / ``o_proj`` has no SM12x fallback, so DeepGEMM's SM100
+recipe asserts in layout.hpp on GB10 / RTX 50. Dispatch is a per-kernel
+predicate (capability, equation, recipe, scale dtype) — not a blunt
+family-120 DeepGEMM enable.
+"""
+
+import torch
+
+from vllm.distributed import get_tensor_model_parallel_rank
+from vllm.model_executor.layers.quantization.utils.fp8_utils import (
+    _upcast_e8m0_to_fp32,
+)
+from vllm.platforms import current_platform
+from vllm.triton_utils import tl, triton
+from vllm.utils.deep_gemm import fp8_einsum
+
+
+# num_tokens and the token-count-dependent strides (a_stride_group == T*hidden,
+# and the two a_scale strides via align(T,4)) are passed as RUNTIME args (not
+# tl.constexpr) and marked do_not_specialize, so the kernel compiles to a SINGLE
+# cubin for every prefill chunk size. They are used only for masking and scalar
+# pointer offsets (never loop trip-counts/shapes), so this is numerically
+# identical and perf-neutral. As constexprs they baked the chunk token count into
+# the JIT key, so an unaligned chunked-prefill tail (e.g. 1131 tokens) JIT-loaded
+# a fresh cubin mid-inference; when that cuModuleLoad coincides with CUDA-graph
+# capture it raises cudaErrorNotPermitted and kills the worker (PR #41834).
+@triton.jit(
+    do_not_specialize=[
+        "num_tokens",
+        "a_stride_group",
+        "a_scale_stride_group",
+        "a_scale_stride_hidden",
+    ]
+)
+def _deepseek_v4_sm12x_fp8_einsum_kernel(
+    a_ptr,
+    a_scale_ptr,
+    b_ptr,
+    b_scale_ptr,
+    out_ptr,
+    num_tokens,
+    num_groups: tl.constexpr,
+    out_rank: tl.constexpr,
+    hidden_size: tl.constexpr,
+    a_stride_token: tl.constexpr,
+    a_stride_group,
+    a_stride_hidden: tl.constexpr,
+    a_scale_stride_token: tl.constexpr,
+    a_scale_stride_group,
+    a_scale_stride_hidden,
+    b_stride_group: tl.constexpr,
+    b_stride_out: tl.constexpr,
+    b_stride_hidden: tl.constexpr,
+    b_scale_stride_group: tl.constexpr,
+    b_scale_stride_out: tl.constexpr,
+    b_scale_stride_hidden: tl.constexpr,
+    out_stride_token: tl.constexpr,
+    out_stride_group: tl.constexpr,
+    out_stride_rank: tl.constexpr,
+    BLOCK_TOKENS: tl.constexpr,
+    BLOCK_OUT: tl.constexpr,
+    BLOCK_HIDDEN: tl.constexpr,
+) -> None:
+    # Keep the group strides runtime (avoids per-shape Triton recompile /
+    # host-memory leak on unified memory) but restore alignment: both are
+    # provably divisible by 16 -- a_stride_group = num_tokens * hidden_size
+    # (hidden_size % 128 == 0), a_scale_stride_group = num_tokens * 32. Without
+    # the hint Triton drops them to divisibility=1 and narrows the load, costing
+    # ~24% single-stream decode (reported by GanyX19, PR#41834).
+    a_stride_group = tl.multiple_of(a_stride_group, 16)
+    a_scale_stride_group = tl.multiple_of(a_scale_stride_group, 16)
+    token_block = tl.program_id(0)
+    out_block = tl.program_id(1)
+    group = tl.program_id(2)
+
+    token_offsets = token_block * BLOCK_TOKENS + tl.arange(0, BLOCK_TOKENS)
+    out_offsets = out_block * BLOCK_OUT + tl.arange(0, BLOCK_OUT)
+    hidden_offsets = tl.arange(0, BLOCK_HIDDEN)
+    accum = tl.zeros((BLOCK_TOKENS, BLOCK_OUT), dtype=tl.float32)
+
+    for hidden_start in range(0, hidden_size, BLOCK_HIDDEN):
+        hidden = hidden_start + hidden_offsets
+        a = tl.load(
+            a_ptr
+            + token_offsets[:, None] * a_stride_token
+            + group * a_stride_group
+            + hidden[None, :] * a_stride_hidden,
+            mask=(token_offsets[:, None] < num_tokens)
+            & (hidden[None, :] < hidden_size),
+            other=0.0,
+        )
+        b = tl.load(
+            b_ptr
+            + group * b_stride_group
+            + out_offsets[None, :] * b_stride_out
+            + hidden[:, None] * b_stride_hidden,
+            mask=(out_offsets[None, :] < out_rank) & (hidden[:, None] < hidden_size),
+            other=0.0,
+        )
+        raw = tl.dot(a, b, out_dtype=tl.float32)
+        hidden_scale_block = hidden_start // BLOCK_HIDDEN
+        a_scale = tl.load(
+            a_scale_ptr
+            + token_offsets * a_scale_stride_token
+            + group * a_scale_stride_group
+            + hidden_scale_block * a_scale_stride_hidden,
+            mask=token_offsets < num_tokens,
+            other=0.0,
+        )
+        b_scale = tl.load(
+            b_scale_ptr
+            + group * b_scale_stride_group
+            + (out_offsets // 128) * b_scale_stride_out
+            + hidden_scale_block * b_scale_stride_hidden,
+            mask=out_offsets < out_rank,
+            other=0.0,
+        )
+        accum += raw * a_scale[:, None] * b_scale[None, :]
+
+    tl.store(
+        out_ptr
+        + token_offsets[:, None] * out_stride_token
+        + group * out_stride_group
+        + out_offsets[None, :] * out_stride_rank,
+        accum,
+        mask=(token_offsets[:, None] < num_tokens) & (out_offsets[None, :] < out_rank),
+    )
+
+
+@triton.jit(
+    do_not_specialize=[
+        "num_tokens",
+        "a_stride_group",
+        "a_scale_stride_group",
+        "a_scale_stride_hidden",
+    ]
+)
+def _deepseek_v4_sm12x_fp8_einsum_quant_kernel(
+    a_ptr,
+    a_scale_ptr,
+    b_ptr,
+    b_scale_ptr,
+    out_fp8_ptr,
+    out_scale_ptr,
+    num_tokens,
+    num_groups: tl.constexpr,
+    out_rank: tl.constexpr,
+    hidden_size: tl.constexpr,
+    a_stride_token: tl.constexpr,
+    a_stride_group,
+    a_stride_hidden: tl.constexpr,
+    a_scale_stride_token: tl.constexpr,
+    a_scale_stride_group,
+    a_scale_stride_hidden,
+    b_stride_group: tl.constexpr,
+    b_stride_out: tl.constexpr,
+    b_stride_hidden: tl.constexpr,
+    b_scale_stride_group: tl.constexpr,
+    b_scale_stride_out: tl.constexpr,
+    b_scale_stride_hidden: tl.constexpr,
+    out_stride_token: tl.constexpr,
+    out_stride_k: tl.constexpr,
+    out_scale_stride_token: tl.constexpr,
+    out_scale_stride_block: tl.constexpr,
+    blocks_per_group: tl.constexpr,
+    fp8_max: tl.constexpr,
+    eps: tl.constexpr,
+    BLOCK_TOKENS: tl.constexpr,
+    BLOCK_OUT: tl.constexpr,
+    BLOCK_HIDDEN: tl.constexpr,
+) -> None:
+    """Same matmul as ``_deepseek_v4_sm12x_fp8_einsum_kernel``, with a fused
+    per-token-per-128-block FP8 quantization epilogue instead of a BF16 store.
+
+    ``BLOCK_OUT`` must equal the downstream GEMM's ``block_k`` (128) so the
+    per-token-per-block scale produced here lines up 1:1 with what
+    ``w8a8_triton_block_scaled_mm`` expects as its ``As`` argument: row-major
+    ``(tokens, K/128)`` FP32. This eliminates the separate
+    ``per_token_group_quant_fp8`` kernel launch that would otherwise quantize
+    this same accumulator's BF16 store right back down to FP8 one step later.
+    """
+    # Same alignment restoration as the BF16 einsum kernel above: both group
+    # strides are provably divisible by 16, so hint them while keeping them
+    # runtime (no per-shape recompile). Without this the runtime strides drop to
+    # divisibility=1 and narrow the load.
+    a_stride_group = tl.multiple_of(a_stride_group, 16)
+    a_scale_stride_group = tl.multiple_of(a_scale_stride_group, 16)
+    token_block = tl.program_id(0)
+    out_block = tl.program_id(1)
+    group = tl.program_id(2)
+
+    token_offsets = token_block * BLOCK_TOKENS + tl.arange(0, BLOCK_TOKENS)
+    out_offsets = out_block * BLOCK_OUT + tl.arange(0, BLOCK_OUT)
+    hidden_offsets = tl.arange(0, BLOCK_HIDDEN)
+    accum = tl.zeros((BLOCK_TOKENS, BLOCK_OUT), dtype=tl.float32)
+
+    for hidden_start in range(0, hidden_size, BLOCK_HIDDEN):
+        hidden = hidden_start + hidden_offsets
+        a = tl.load(
+            a_ptr
+            + token_offsets[:, None] * a_stride_token
+            + group * a_stride_group
+            + hidden[None, :] * a_stride_hidden,
+            mask=(token_offsets[:, None] < num_tokens)
+            & (hidden[None, :] < hidden_size),
+            other=0.0,
+        )
+        b = tl.load(
+            b_ptr
+            + group * b_stride_group
+            + out_offsets[None, :] * b_stride_out
+            + hidden[:, None] * b_stride_hidden,
+            mask=(out_offsets[None, :] < out_rank) & (hidden[:, None] < hidden_size),
+            other=0.0,
+        )
+        raw = tl.dot(a, b, out_dtype=tl.float32)
+        hidden_scale_block = hidden_start // BLOCK_HIDDEN
+        a_scale = tl.load(
+            a_scale_ptr
+            + token_offsets * a_scale_stride_token
+            + group * a_scale_stride_group
+            + hidden_scale_block * a_scale_stride_hidden,
+            mask=token_offsets < num_tokens,
+            other=0.0,
+        )
+        b_scale = tl.load(
+            b_scale_ptr
+            + group * b_scale_stride_group
+            + (out_offsets // 128) * b_scale_stride_out
+            + hidden_scale_block * b_scale_stride_hidden,
+            mask=out_offsets < out_rank,
+            other=0.0,
+        )
+        accum += raw * a_scale[:, None] * b_scale[None, :]
+
+    row_absmax = tl.maximum(tl.max(tl.abs(accum), axis=1), eps)
+    scale = row_absmax * (1.0 / fp8_max)
+    quant = tl.clamp(accum / scale[:, None], -fp8_max, fp8_max).to(tl.float8e4nv)
+
+    k_block = group * blocks_per_group + out_block
+    tl.store(
+        out_fp8_ptr
+        + token_offsets[:, None] * out_stride_token
+        + (out_offsets[None, :] + group * out_rank) * out_stride_k,
+        quant,
+        mask=(token_offsets[:, None] < num_tokens) & (out_offsets[None, :] < out_rank),
+    )
+    tl.store(
+        out_scale_ptr
+        + token_offsets * out_scale_stride_token
+        + k_block * out_scale_stride_block,
+        scale,
+        mask=token_offsets < num_tokens,
+    )
+
+
+def deepseek_v4_sm12x_fp8_einsum_quant(
+    a: torch.Tensor,
+    a_scale: torch.Tensor,
+    b: torch.Tensor,
+    b_scale: torch.Tensor,
+    out_fp8: torch.Tensor,
+    out_scale: torch.Tensor,
+) -> None:
+    """``bhr,hdr->bhd`` fused with FP8 block quantization of the result.
+
+    ``out_fp8`` / ``out_scale`` are the flattened ``(tokens, groups*out_rank)``
+    / ``(tokens, groups*out_rank // 128)`` views ready to pass directly as
+    ``A``/``As`` to ``w8a8_triton_block_scaled_mm``, skipping the separate
+    BF16-output-then-requantize step that ``deepseek_v4_sm12x_fp8_einsum``
+    plus a downstream ``per_token_group_quant_fp8`` call would otherwise need.
+    """
+    num_tokens, num_groups, hidden_size = a.shape
+    b_groups, out_rank, b_hidden_size = b.shape
+    assert b_groups == num_groups
+    assert b_hidden_size == hidden_size
+    assert hidden_size % 128 == 0
+    assert out_rank % 128 == 0
+    assert a.dtype == torch.float8_e4m3fn
+    assert b.dtype == torch.float8_e4m3fn
+    block_out = 128
+    assert out_fp8.shape == (num_tokens, num_groups * out_rank)
+    assert out_scale.shape == (num_tokens, num_groups * out_rank // block_out)
+    e8m0_dtype = getattr(torch, "float8_e8m0fnu", None)
+    if a_scale.dtype == e8m0_dtype:
+        a_scale = _upcast_e8m0_to_fp32(a_scale)
+    if b_scale.dtype == e8m0_dtype:
+        b_scale = _upcast_e8m0_to_fp32(b_scale)
+    assert a_scale.dtype == torch.float32
+    assert b_scale.dtype == torch.float32
+
+    if num_tokens == 0:
+        return
+
+    block_tokens = 16
+    block_hidden = 128
+    fp8_dtype = torch.float8_e4m3fn
+    fp8_max = float(torch.finfo(fp8_dtype).max)
+    blocks_per_group = out_rank // block_out
+    grid = (
+        triton.cdiv(num_tokens, block_tokens),
+        triton.cdiv(out_rank, block_out),
+        num_groups,
+    )
+    _deepseek_v4_sm12x_fp8_einsum_quant_kernel[grid](
+        a,
+        a_scale,
+        b,
+        b_scale,
+        out_fp8,
+        out_scale,
+        num_tokens,
+        num_groups,
+        out_rank,
+        hidden_size,
+        a.stride(0),
+        a.stride(1),
+        a.stride(2),
+        a_scale.stride(0),
+        a_scale.stride(1),
+        a_scale.stride(2),
+        b.stride(0),
+        b.stride(1),
+        b.stride(2),
+        b_scale.stride(0),
+        b_scale.stride(1),
+        b_scale.stride(2),
+        out_fp8.stride(0),
+        out_fp8.stride(1),
+        out_scale.stride(0),
+        out_scale.stride(1),
+        blocks_per_group=blocks_per_group,
+        fp8_max=fp8_max,
+        eps=1e-10,
+        BLOCK_TOKENS=block_tokens,
+        BLOCK_OUT=block_out,
+        BLOCK_HIDDEN=block_hidden,
+        num_warps=4,
+        num_stages=3,
+    )
+
+
+def deepseek_v4_sm12x_fp8_einsum(
+    a: torch.Tensor,
+    a_scale: torch.Tensor,
+    b: torch.Tensor,
+    b_scale: torch.Tensor,
+    out: torch.Tensor,
+) -> None:
+    """Compute ``bhr,hdr->bhd`` with FP32 block scales on SM12x.
+
+    ``a`` is the transposed output of ``fused_inv_rope_fp8_quant`` with shape
+    ``[tokens, groups, hidden]``. ``b`` is ``wo_a`` reshaped to
+    ``[groups, out_rank, hidden]``.
+    """
+    num_tokens, num_groups, hidden_size = a.shape
+    b_groups, out_rank, b_hidden_size = b.shape
+    assert b_groups == num_groups
+    assert b_hidden_size == hidden_size
+    assert out.shape == (num_tokens, num_groups, out_rank)
+    assert hidden_size % 128 == 0
+    assert out_rank % 128 == 0
+    assert a.dtype == torch.float8_e4m3fn
+    assert b.dtype == torch.float8_e4m3fn
+    e8m0_dtype = getattr(torch, "float8_e8m0fnu", None)
+    if a_scale.dtype == e8m0_dtype:
+        a_scale = _upcast_e8m0_to_fp32(a_scale)
+    if b_scale.dtype == e8m0_dtype:
+        b_scale = _upcast_e8m0_to_fp32(b_scale)
+    assert a_scale.dtype == torch.float32
+    assert b_scale.dtype == torch.float32
+
+    if num_tokens == 0:
+        return
+
+    block_tokens = 16
+    block_out = 128
+    block_hidden = 128
+    grid = (
+        triton.cdiv(num_tokens, block_tokens),
+        triton.cdiv(out_rank, block_out),
+        num_groups,
+    )
+    _deepseek_v4_sm12x_fp8_einsum_kernel[grid](
+        a,
+        a_scale,
+        b,
+        b_scale,
+        out,
+        num_tokens,
+        num_groups,
+        out_rank,
+        hidden_size,
+        a.stride(0),
+        a.stride(1),
+        a.stride(2),
+        a_scale.stride(0),
+        a_scale.stride(1),
+        a_scale.stride(2),
+        b.stride(0),
+        b.stride(1),
+        b.stride(2),
+        b_scale.stride(0),
+        b_scale.stride(1),
+        b_scale.stride(2),
+        out.stride(0),
+        out.stride(1),
+        out.stride(2),
+        BLOCK_TOKENS=block_tokens,
+        BLOCK_OUT=block_out,
+        BLOCK_HIDDEN=block_hidden,
+        num_warps=4,
+        num_stages=3,
+    )
+
+
+def deepseek_v4_fp8_einsum_config(
+    capability_major: int,
+) -> tuple[tuple[int, int, int], bool]:
+    if capability_major == 10:
+        return (1, 1, 128), True
+    return (1, 128, 128), False
+
+
+def _use_deepseek_v4_sm12x_triton_fp8_einsum(
+    equation: str,
+    recipe: list[int],
+    b_scale: torch.Tensor,
+) -> bool:
+    capability = current_platform.get_device_capability()
+    e8m0_dtype = getattr(torch, "float8_e8m0fnu", None)
+    return (
+        capability is not None
+        and capability.major == 12
+        and equation == "bhr,hdr->bhd"
+        and tuple(recipe) == (1, 128, 128)
+        and b_scale.dtype in (torch.float32, e8m0_dtype)
+    )
+
+
+def deepseek_v4_fp8_einsum(
+    a: torch.Tensor,
+    a_scale: torch.Tensor,
+    b: torch.Tensor,
+    b_scale: torch.Tensor,
+    out: torch.Tensor,
+    equation: str,
+    recipe: list[int],
+) -> None:
+    if equation == "bhr,hdr->bhd" and b.dim() == 2:
+        num_groups = out.shape[1]
+        out_rank = out.shape[2]
+        hidden_size = a.shape[2]
+        if b.shape[0] % out_rank != 0:
+            raise RuntimeError(
+                "DeepSeek V4 fp8 einsum weight rows must be divisible by "
+                f"out_rank={out_rank}, got {b.shape[0]}"
+            )
+        b_groups = b.shape[0] // out_rank
+        group_start = 0
+        if b_groups != num_groups:
+            if b_groups % num_groups != 0:
+                raise RuntimeError(
+                    "DeepSeek V4 fp8 einsum weight groups must match the "
+                    "TP-local output groups or be an integer multiple of "
+                    f"them, got weight_groups={b_groups}, "
+                    f"output_groups={num_groups}"
+                )
+            group_partitions = b_groups // num_groups
+            group_start = (
+                get_tensor_model_parallel_rank() % group_partitions
+            ) * num_groups
+        b = b.view(b_groups, out_rank, hidden_size)
+        if group_start != 0 or b_groups != num_groups:
+            b = b.narrow(0, group_start, num_groups)
+
+        if b_scale.dim() == 2:
+            scale_mn = recipe[1]
+            scale_k_pack = 4 if b_scale.dtype == torch.int32 else 1
+            scale_k = recipe[2] * scale_k_pack
+            scale_out_blocks = (out_rank + scale_mn - 1) // scale_mn
+            scale_hidden_blocks = (hidden_size + scale_k - 1) // scale_k
+            if b_scale.shape[0] % scale_out_blocks != 0:
+                raise RuntimeError(
+                    "DeepSeek V4 fp8 einsum scale rows must be divisible by "
+                    f"scale_out_blocks={scale_out_blocks}, "
+                    f"got {b_scale.shape[0]}"
+                )
+            scale_groups = b_scale.shape[0] // scale_out_blocks
+            if scale_groups not in (num_groups, b_groups):
+                raise RuntimeError(
+                    "DeepSeek V4 fp8 einsum scale groups must match the "
+                    "TP-local output groups or weight groups, got "
+                    f"scale_groups={scale_groups}, output_groups={num_groups}, "
+                    f"weight_groups={b_groups}"
+                )
+            b_scale = b_scale.view(
+                scale_groups,
+                scale_out_blocks,
+                scale_hidden_blocks,
+            )
+            if scale_groups == b_groups and scale_groups != num_groups:
+                b_scale = b_scale.narrow(0, group_start, num_groups)
+        elif b_scale.dim() == 3 and b_scale.shape[0] == b_groups:
+            if b_groups != num_groups:
+                b_scale = b_scale.narrow(0, group_start, num_groups)
+
+        if _use_deepseek_v4_sm12x_triton_fp8_einsum(equation, recipe, b_scale):
+            deepseek_v4_sm12x_fp8_einsum(a, a_scale, b, b_scale, out)
+            return
+
+    fp8_einsum(equation, (a, a_scale), (b, b_scale), out, recipe=tuple(recipe))

--- a/vllm/models/deepseek_v4/nvidia/ops/o_proj.py
+++ b/vllm/models/deepseek_v4/nvidia/ops/o_proj.py
@@ -6,6 +6,10 @@ import torch.nn as nn
 from vllm.models.deepseek_v4.common.ops.fused_inv_rope_fp8_quant import (
     fused_inv_rope_fp8_quant,
 )
+from vllm.models.deepseek_v4.nvidia.ops.fp8_einsum import (
+    _use_deepseek_v4_sm12x_triton_fp8_einsum,
+    deepseek_v4_fp8_einsum,
+)
 from vllm.platforms import current_platform
 from vllm.utils.deep_gemm import fp8_einsum
 
@@ -15,14 +19,19 @@ def compute_fp8_einsum_recipe() -> tuple[tuple[int, int, int], bool]:
 
     SM90: FP32 block scales stay [g, r/128, d/128] → sfb_gran_mn=128.
     SM100: INT32 packed scales become [g, r, ...] → sfb_gran_mn=1.
+    SM12x (GB10 / RTX 50): DeepGEMM's SM100 recipe asserts in layout.hpp
+    (``sf.size(-2) == ceil_div(mn, gran_mn)``). Use the SM90-shaped
+    FP32 recipe and the Triton SM12x fallback (see #43743), not family-120
+    as a blunt DeepGEMM enable.
 
     Returns ``(einsum_recipe, tma_aligned_scales)`` for ``deep_gemm_fp8_o_proj``.
     """
     cap = current_platform.get_device_capability()
     assert cap is not None, "DeepseekV4 attention requires a CUDA device"
-    einsum_recipe = (1, 128, 128) if cap.major <= 9 else (1, 1, 128)
-    tma_aligned_scales = cap.major >= 10
-    return einsum_recipe, tma_aligned_scales
+    if cap.major == 10:
+        return (1, 1, 128), True
+    # SM90 and SM12x share the FP32 (1, 128, 128) layout.
+    return (1, 128, 128), False
 
 
 def deep_gemm_fp8_o_proj(
@@ -63,11 +72,24 @@ def deep_gemm_fp8_o_proj(
     weight_scale = (
         wo_a.weight_scale if hasattr(wo_a, "weight_scale") else wo_a.weight_scale_inv
     )
-    fp8_einsum(
-        "bhr,hdr->bhd",
-        (o_fp8, o_scale),
-        (wo_a.weight, weight_scale),
-        z,
-        recipe=einsum_recipe,
-    )
+    if _use_deepseek_v4_sm12x_triton_fp8_einsum(
+        "bhr,hdr->bhd", list(einsum_recipe), weight_scale
+    ):
+        deepseek_v4_fp8_einsum(
+            o_fp8,
+            o_scale,
+            wo_a.weight,
+            weight_scale,
+            z,
+            equation="bhr,hdr->bhd",
+            recipe=list(einsum_recipe),
+        )
+    else:
+        fp8_einsum(
+            "bhr,hdr->bhd",
+            (o_fp8, o_scale),
+            (wo_a.weight, weight_scale),
+            z,
+            recipe=einsum_recipe,
+        )
     return wo_b(z.flatten(1))


### PR DESCRIPTION
## Purpose

Fixes #43743.

We're trying to intuit where you are already going on SM12x / GB10 and help
out with a small, reviewable slice — not a parallel stack.

On current `main`, DSv4 `o_proj` always calls DeepGEMM `fp8_einsum`.
`compute_fp8_einsum_recipe()` treats `cap.major >= 10` as the SM100
`(1, 1, 128)` layout. GB10 / RTX 50 report major=12, so they take that
recipe and die on the first forward (`layout.hpp` scale-factor assert —
the same class as "Unknown SF transformation").

#41834 already fixed `tf32_hc_prenorm_gemm`. This PR is the follow-up
pasta-paul described in #43743: port jasl's Triton SM12x `fp8_einsum`
fallback and dispatch it with a **per-kernel** predicate (capability,
equation, recipe, scale dtype), not `support_deep_gemm() |= family(120)`.

That last point is deliberate. We tried the blunt family-120 DeepGEMM
enable on a dual GB10 box; MoE selected `DEEPGEMM_MXFP4`, then linear
`o_proj` hit `layout.hpp:97`. The gate comment on `CudaPlatform` was
right. This PR does not open that gate.

## What this does / does not

Does:
- SM12x uses the SM90-shaped recipe `(1, 128, 128)` + Triton fallback
- SM100 path is unchanged
- CPU dispatch tests lock the predicate so SM12x cannot select the
  SM100 recipe

Does not:
- Enable DeepGEMM MoE on SM12x
- Claim end-to-end DeepSeek-V4-Flash serve
- Replace or rebase #41834

## Attribution

- Triton kernel: jasl/vllm (PR #41834 preview), Apache-2.0
- Issue + port plan: #43743 (pasta-paul)
- Dispatch invariant: AasthaPJoshi on #43743 (per-kernel capability
  predicates, not architecture-family assumptions)

We are integrators/validators on GB10 (DGX Spark). Draft while we attach
a silicon log from a single-node sm_121 probe (synthetic o_proj tensors;
no 156G load). Happy to adjust the predicate or split the kernel file if
that's a better fit for how you want this to land.

## Test Plan

```bash
pytest tests/models/test_dsv4_sm12x_fp8_einsum_dispatch.py -q
```

GB10 kernel probe (synthetic `bhr,hdr->bhd`, recipe `(1,128,128)`) still
in flight — will comment the log on this PR.

## Test Result

Dispatch tests exist; not yet run in CI. Silicon evidence forthcoming.

---
- [x] Purpose linked to #43743
- [x] Test plan
- [ ] Test results (draft until GB10 probe + CI)
- [x] No docs change needed (existing DSv4 path)
