### PR TITLE
Preserve deferred layerwise reload weights

### DIFF
--- a/tests/model_executor/model_loader/test_reload.py
+++ b/tests/model_executor/model_loader/test_reload.py
@@ -17,6 +17,7 @@ from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
 from vllm.model_executor.layers.linear import QKVParallelLinear
 from vllm.model_executor.layers.quantization.base_config import QuantizeMethodBase
 from vllm.model_executor.model_loader.reload.layerwise import (
+    detach_layerwise_weights_from_source,
     finalize_layerwise_reload,
     initialize_layerwise_reload,
     initialize_online_processing,
@@ -53,6 +54,30 @@ def _fp8_reload_unsupported() -> bool:
 
         return on_gfx90a()
     return False
+
+
+def test_detach_layerwise_weights_from_source_clones_only_pending_aliases():
+    layer = torch.nn.Linear(2, 2)
+    source = torch.arange(4)
+    owned = source.clone()
+
+    def load(param, loaded_weight):
+        pass
+
+    signature = inspect.signature(load)
+    info = reload_layerwise.get_layerwise_info(layer)
+    info.loaded_weights = [
+        ("source", signature.bind(layer.weight, source)),
+        ("owned", signature.bind(layer.weight, owned)),
+    ]
+
+    detach_layerwise_weights_from_source(layer, [source])
+
+    detached = info.loaded_weights[0][1].arguments["loaded_weight"]
+    retained = info.loaded_weights[1][1].arguments["loaded_weight"]
+    assert torch.equal(detached, source)
+    assert detached.untyped_storage().data_ptr() != source.untyped_storage().data_ptr()
+    assert retained is owned
 
 
 class _AliasedBufferLayer(torch.nn.Module):

--- a/tests/quantization/test_modelopt.py
+++ b/tests/quantization/test_modelopt.py
@@ -26,6 +26,7 @@ from vllm.model_executor.layers.quantization.modelopt import (
     ModelOptMixedPrecisionConfig,
     ModelOptMxFp8Config,
     ModelOptNvFp4Config,
+    ModelOptNvFp4FusedMoE,
     ModelOptNvFp4LinearMethod,
     ModelOptNvFp4W4A16LinearMethod,
 )
@@ -33,6 +34,8 @@ from vllm.model_executor.layers.vocab_parallel_embedding import (
     ParallelLMHead,
     VocabParallelEmbedding,
 )
+from vllm.model_executor.model_loader.reload.meta import capture_layer_to_meta
+from vllm.model_executor.model_loader.weight_utils import default_weight_loader
 from vllm.platforms import current_platform
 
 
@@ -98,6 +101,97 @@ def _mixed_precision_config(quantized_layers: dict) -> ModelOptMixedPrecisionCon
             exclude_modules=[],
         ),
     )
+
+
+@pytest.fixture
+def single_rank_tp(monkeypatch):
+    monkeypatch.setattr(
+        "vllm.model_executor.parameter.get_tensor_model_parallel_rank", lambda: 0
+    )
+    monkeypatch.setattr(
+        "vllm.model_executor.parameter.get_tensor_model_parallel_world_size", lambda: 1
+    )
+
+
+def _nvfp4_linear_for_reload(quant_method: str) -> torch.nn.Module:
+    config = ModelOptNvFp4Config(
+        quant_method=quant_method,
+        is_checkpoint_nvfp4_serialized=True,
+        group_size=16,
+    )
+    method = object.__new__(config.LinearMethodCls)
+    method.quant_config = config
+    method.kernel = MagicMock()
+    layer = torch.nn.Module()
+    method.create_weights(
+        layer,
+        input_size_per_partition=16,
+        output_partition_sizes=[8],
+        input_size=16,
+        output_size=8,
+        params_dtype=torch.bfloat16,
+        weight_loader=default_weight_loader,
+    )
+    return layer
+
+
+def _nvfp4_moe_for_reload(quant_method: str) -> torch.nn.Module:
+    config = ModelOptNvFp4Config(
+        quant_method=quant_method,
+        is_checkpoint_nvfp4_serialized=True,
+        group_size=16,
+    )
+    method = object.__new__(ModelOptNvFp4FusedMoE)
+    method.quant_config = config
+    method.moe = MagicMock(is_act_and_mul=False)
+    method.use_a16 = quant_method == "W4A16_NVFP4"
+    method.use_global_sf = False
+    layer = torch.nn.Module()
+    method.create_weights(
+        layer,
+        num_experts=2,
+        hidden_size=16,
+        intermediate_size_per_partition=16,
+        params_dtype=torch.bfloat16,
+        weight_loader=default_weight_loader,
+        global_num_experts=2,
+    )
+    return layer
+
+
+def test_modelopt_w4a16_reload_metadata_omits_only_unused_input_scales(
+    single_rank_tp,
+):
+    model = torch.nn.ModuleDict(
+        {
+            "w4a4_dense": _nvfp4_linear_for_reload("NVFP4"),
+            "w4a16_dense": _nvfp4_linear_for_reload("W4A16_NVFP4"),
+            "w4a4_moe": _nvfp4_moe_for_reload("NVFP4"),
+            "w4a16_moe": _nvfp4_moe_for_reload("W4A16_NVFP4"),
+        }
+    )
+
+    captured = {name: capture_layer_to_meta(layer)[0] for name, layer in model.items()}
+
+    assert "input_scale" in captured["w4a4_dense"]
+    assert "input_scale" not in captured["w4a16_dense"]
+    assert "w13_input_scale" in captured["w4a4_moe"]
+    assert "w2_input_scale" in captured["w4a4_moe"]
+    assert "w13_input_scale" not in captured["w4a16_moe"]
+    assert "w2_input_scale" not in captured["w4a16_moe"]
+
+
+def test_modelopt_w4a16_reload_metadata_preserves_loadable_placeholder(single_rank_tp):
+    layer = _nvfp4_linear_for_reload("W4A16_NVFP4")
+    placeholder = layer.input_scale
+
+    params, _ = capture_layer_to_meta(layer)
+
+    assert "input_scale" not in params
+    assert layer.input_scale is placeholder
+    loaded_scale = torch.full_like(placeholder, 3.0)
+    placeholder.weight_loader(placeholder, loaded_scale)
+    assert torch.equal(layer.input_scale, loaded_scale)
 
 
 def test_modelopt_nvfp4_quantizes_parallel_lm_head():

--- a/vllm/model_executor/layers/quantization/modelopt.py
+++ b/vllm/model_executor/layers/quantization/modelopt.py
@@ -1329,6 +1329,7 @@ class ModelOptNvFp4W4A16LinearMethod(LinearMethodBase):
             data=torch.empty(len(output_partition_sizes), dtype=torch.float32),
             weight_loader=weight_loader,
         )
+        set_weight_attrs(input_scale, {"skip_layerwise_reload": True})
         layer.register_parameter("input_scale", input_scale)
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
@@ -1514,12 +1515,16 @@ class ModelOptNvFp4FusedMoE(FusedMoEMethodBase):
             ),
             weight_loader=weight_loader,
         )
+        if self.use_a16:
+            set_weight_attrs(w13_input_scale, {"skip_layerwise_reload": True})
         layer.register_parameter("w13_input_scale", w13_input_scale)
 
         w2_input_scale = PerTensorScaleParameter(
             data=torch.empty(global_sf_num_experts, dtype=torch.float32),
             weight_loader=weight_loader,
         )
+        if self.use_a16:
+            set_weight_attrs(w2_input_scale, {"skip_layerwise_reload": True})
         layer.register_parameter("w2_input_scale", w2_input_scale)
 
     def process_weights_after_loading(self, layer: RoutedExperts) -> None:

--- a/vllm/model_executor/model_loader/reload/__init__.py
+++ b/vllm/model_executor/model_loader/reload/__init__.py
@@ -18,6 +18,7 @@ Limitations:
 """
 
 __all__ = [
+    "detach_layerwise_weights_from_source",
     "record_metadata_for_reloading",
     "initialize_layerwise_reload",
     "finalize_layerwise_processing",
@@ -27,6 +28,7 @@ __all__ = [
 ]
 
 from .layerwise import (
+    detach_layerwise_weights_from_source,
     finalize_layerwise_processing,
     finalize_layerwise_reload,
     initialize_layerwise_reload,

--- a/vllm/model_executor/model_loader/reload/layerwise.py
+++ b/vllm/model_executor/model_loader/reload/layerwise.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import inspect
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from functools import wraps
 from weakref import WeakKeyDictionary, WeakSet
 
@@ -32,6 +32,7 @@ from .utils import (
 logger = init_logger(__name__)
 
 __all__ = [
+    "detach_layerwise_weights_from_source",
     "get_layerwise_info",
     "record_metadata_for_reloading",
     "initialize_layerwise_reload",
@@ -65,6 +66,31 @@ def get_layerwise_info(layer: torch.nn.Module) -> LayerReloadingInfo:
         )
 
     return LAYERWISE_INFO[layer]
+
+
+def detach_layerwise_weights_from_source(
+    model: torch.nn.Module, source_tensors: Iterable[torch.Tensor]
+) -> None:
+    """Own buffered reload weights that alias reusable source storage.
+
+    Layerwise loading may defer a layer until a later input batch. Clone only
+    those pending weights that still share storage with the current batch so
+    callers may safely reuse their transport buffers.
+    """
+    source_storage_ptrs = {
+        tensor.untyped_storage().data_ptr() for tensor in source_tensors
+    }
+    if not source_storage_ptrs:
+        return
+
+    for layer in model.modules():
+        for _, arguments in get_layerwise_info(layer).loaded_weights:
+            loaded_weight = arguments.arguments.get("loaded_weight")
+            if (
+                isinstance(loaded_weight, torch.Tensor)
+                and loaded_weight.untyped_storage().data_ptr() in source_storage_ptrs
+            ):
+                arguments.arguments["loaded_weight"] = loaded_weight.clone()
 
 
 def record_metadata_for_reloading(model: torch.nn.Module):

--- a/vllm/model_executor/model_loader/reload/meta.py
+++ b/vllm/model_executor/model_loader/reload/meta.py
@@ -38,6 +38,12 @@ SKIP_LOAD_TENSORS: set[str] = {
 SKIP_TENSORS: set[str] = SKIP_LOAD_TENSORS | {"bias"}
 
 
+def _capture_for_layerwise_reload(name: str, tensor: torch.Tensor) -> bool:
+    return name not in SKIP_TENSORS and not getattr(
+        tensor, "skip_layerwise_reload", False
+    )
+
+
 def to_meta_tensor(tensor: torch.Tensor) -> torch.Tensor:
     """Convert a tensor to a meta tensor while preserving class and attributes."""
     meta_tensor = tensor.data.to("meta")
@@ -105,12 +111,12 @@ def capture_layer_to_meta(layer: torch.nn.Module) -> LayerTensors:
         {
             name: sanitize_layer_refs(to_meta_tensor(param), layer)
             for name, param in params.items()
-            if name not in SKIP_TENSORS
+            if _capture_for_layerwise_reload(name, param)
         },
         {
             name: sanitize_layer_refs(to_meta_tensor(buffer), layer)
             for name, buffer in buffers.items()
-            if name not in SKIP_TENSORS
+            if _capture_for_layerwise_reload(name, buffer)
             and not _is_non_persistent_parameter_alias_buffer(
                 layer, name, buffer, parameter_storage_ptrs
             )


### PR DESCRIPTION
## Summary
- make W4A16 input-scale placeholders opt out of layerwise reload metadata when no serialized tensor exists
- expose a narrow helper that detaches only deferred reload tensors aliasing caller-owned transport storage
- preserve W4A4 and ordinary loader behavior

## Motivation
The canonical NeMo-RL ModelOpt refit path streams reusable transport tensors. Deferred W4A16 tensors must own their storage before the next refit overwrites that transport buffer, while non-materialized input-scale placeholders must not be requested from the stream.

## Validation
- focused reload and ModelOpt unit tests
- exact vLLM 0.25.1 dense/MoE characterization: Slurm job 329665
- two-step Nano3 W4A16 real-quant NeMo-RL smoke with two refits: Slurm job 329693

This is a draft and is part of the canonical ModelOpt real-quant refit dependency chain.