### PR TITLE
[Model][Perf] Enable fused KDA decode for Ling-3.0 (H=32)

### DIFF
--- a/csrc/libtorch_stable/kimi_k3/fused_kda_decode_kernel.cu
+++ b/csrc/libtorch_stable/kimi_k3/fused_kda_decode_kernel.cu
@@ -329,6 +329,24 @@ __launch_bounds__(kThreads, 2) void kda_decode_fusion_many_heads_kernel(
   }
 
   constexpr int kLocalDim = kFixedHeads * kDimK;
+  // gdn_attn.py pads full CUDA-graph decode batches with NULL_BLOCK_ID (0).
+  // The unfused convolution and recurrent kernels skip those rows. Mirror that
+  // behavior here so padding neither races on slot 0 nor exposes stale output.
+  // `slot` is block-uniform, so returning before the synchronizations below is
+  // safe. Complete the programmatic-launch protocol before leaving the block.
+  if constexpr (kUseStaticDecodeLayout) {
+    if (slot <= 0) {
+      if (tid < kDimV) {
+        out[static_cast<int64_t>(i_n) * kLocalDim + i_hv * kDimV + tid] =
+            bf16_store(0.0f);
+      }
+      __syncthreads();
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
+      cudaTriggerProgrammaticLaunchCompletion();
+#endif
+      return;
+    }
+  }
   constexpr int kPackedDim = 3 * kLocalDim;
   const int hk_off = i_h * kDimK;
   const int hv_off = i_hv * kDimV;
@@ -805,6 +823,9 @@ void launch_kda_decode_many_heads_selected(
     case 24:
       LAUNCH_KDA_DECODE(24);
       break;
+    case 32:
+      LAUNCH_KDA_DECODE(32);
+      break;
     case 48:
       LAUNCH_KDA_DECODE(48);
       break;
@@ -989,9 +1010,9 @@ void fused_kda_decode(
   STD_TORCH_CHECK(qkv_width % (3 * kHeadDim) == 0,
                   "x must have shape [B, 3 * H * 128]");
   int64_t const num_heads = qkv_width / (3 * kHeadDim);
-  STD_TORCH_CHECK(
-      num_heads == 12 || num_heads == 24 || num_heads == 48 || num_heads == 96,
-      "H must be 12, 24, 48, or 96, got ", num_heads);
+  STD_TORCH_CHECK(num_heads == 12 || num_heads == 24 || num_heads == 32 ||
+                      num_heads == 48 || num_heads == 96,
+                  "H must be 12, 24, 32, 48, or 96, got ", num_heads);
   STD_TORCH_CHECK(batch_size > 0,
                   "KDA decode fusion requires at least one row");
   int const dim = num_heads * kHeadDim;

--- a/tests/models/kimi_k3/test_kda.py
+++ b/tests/models/kimi_k3/test_kda.py
@@ -6,6 +6,7 @@ Compares chunk_kda against a naive recurrent reference (float32).
 Uses torch.rand for q/k/v to match FLA's test pattern.
 """
 
+from dataclasses import dataclass
 from types import SimpleNamespace
 
 import pytest
@@ -900,6 +901,7 @@ def test_kda_recoverssm_verify_and_group_commit(
         (12, 1, -5.0, True),
         (12, 4, None, False),
         (24, 4, None, False),
+        (32, 4, -5.0, True),
         (48, 1, -5.0, True),
         (96, 1, -5.0, True),
     ],
@@ -1048,6 +1050,235 @@ def test_fused_kda_decode_correctness(
     torch.testing.assert_close(actual, expected, atol=3e-2, rtol=3e-2)
     torch.testing.assert_close(conv_actual, conv_ref, atol=0, rtol=0)
     torch.testing.assert_close(state_actual, state_ref, atol=3e-2, rtol=3e-2)
+
+
+@dataclass(frozen=True)
+class _FusedKdaDecodeCase:
+    x: torch.Tensor
+    conv_weight: torch.Tensor
+    fused_weight: torch.Tensor
+    raw_g: torch.Tensor
+    raw_beta: torch.Tensor
+    output_gate: torch.Tensor
+    a_log: torch.Tensor
+    dt_bias: torch.Tensor
+    norm_weight: torch.Tensor
+    state_indices: torch.Tensor
+    conv_seed: torch.Tensor
+    state_seed: torch.Tensor
+    norm_eps: float = 1e-5
+    lower_bound: float = -5.0
+
+
+def _make_fused_kda_decode_case(
+    *,
+    num_steps: int,
+    slots: int,
+    state_indices: list[int],
+    seed: int,
+) -> _FusedKdaDecodeCase:
+    num_heads, head_dim, conv_width = 32, 128, 4
+    if not is_fused_kda_decode_supported(
+        num_heads,
+        head_dim,
+        conv_width,
+        num_spec=0,
+        input_dtype=torch.bfloat16,
+        conv_state_dtype=torch.bfloat16,
+    ):
+        pytest.skip("Fused KDA decode is not supported on this platform")
+
+    torch.manual_seed(seed)
+    dim = num_heads * head_dim
+    num_rows = len(state_indices)
+
+    def randn(*shape: int, dtype: torch.dtype = torch.bfloat16) -> torch.Tensor:
+        return torch.randn(*shape, dtype=dtype, device=DEVICE)
+
+    conv_weight = 0.1 * randn(3 * dim, conv_width, dtype=torch.float32)
+    a_log = (0.5 * randn(num_heads, dtype=torch.float32)).contiguous()
+    dt_bias = (0.1 * randn(dim, dtype=torch.float32)).contiguous()
+    conv_seed = (0.1 * randn(slots, conv_width - 1, 3 * dim)).transpose(1, 2)
+    return _FusedKdaDecodeCase(
+        x=randn(num_steps, num_rows, 3 * dim),
+        conv_weight=conv_weight,
+        fused_weight=conv_weight.reshape(3, dim, conv_width)
+        .transpose(1, 2)
+        .contiguous(),
+        raw_g=randn(num_steps, 1, num_rows, num_heads, head_dim),
+        raw_beta=randn(num_steps, 1, num_rows, num_heads),
+        output_gate=randn(num_steps, num_rows, num_heads, head_dim),
+        a_log=a_log,
+        dt_bias=dt_bias,
+        norm_weight=randn(head_dim, dtype=torch.float32),
+        state_indices=torch.tensor(state_indices, dtype=torch.int32, device=DEVICE),
+        conv_seed=conv_seed,
+        state_seed=0.01
+        * randn(slots, num_heads, head_dim, head_dim, dtype=torch.float32),
+    )
+
+
+def _run_fused_kda_decode_reference(
+    case: _FusedKdaDecodeCase,
+    active_rows: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    if active_rows is None:
+        active_rows = torch.arange(
+            case.state_indices.numel(), dtype=torch.long, device=DEVICE
+        )
+    state_indices = case.state_indices.index_select(0, active_rows)
+    conv_state = case.conv_seed.clone()
+    state = case.state_seed.clone()
+    outputs = torch.zeros_like(case.raw_g)
+
+    for step in range(case.x.shape[0]):
+        x = case.x[step].index_select(0, active_rows)
+        mixed_qkv = causal_conv1d_update(
+            x,
+            conv_state,
+            case.conv_weight,
+            activation="silu",
+            conv_state_indices=state_indices,
+            validate_data=True,
+            out=torch.empty_like(x),
+        )
+        output, _ = fused_recurrent_kda_packed_decode(
+            mixed_qkv=mixed_qkv,
+            raw_g=case.raw_g[step].index_select(1, active_rows),
+            raw_beta=case.raw_beta[step].index_select(1, active_rows),
+            A_log=case.a_log,
+            dt_bias=case.dt_bias,
+            lower_bound=case.lower_bound,
+            initial_state=state,
+            state_indices=state_indices,
+        )
+        output_float = output.float()
+        output = (
+            output_float
+            * torch.rsqrt(
+                output_float.square().mean(dim=-1, keepdim=True) + case.norm_eps
+            )
+            * case.norm_weight
+            * case.output_gate[step]
+            .index_select(0, active_rows)
+            .float()
+            .sigmoid()
+            .unsqueeze(0)
+        ).to(output.dtype)
+        outputs[step].index_copy_(1, active_rows, output)
+    return outputs, conv_state, state
+
+
+def _run_fused_kda_decode_steps(
+    case: _FusedKdaDecodeCase,
+    conv_state: torch.Tensor,
+    state: torch.Tensor,
+    outputs: torch.Tensor,
+) -> None:
+    for step in range(case.x.shape[0]):
+        ops.fused_kda_decode(
+            x=case.x[step],
+            weight=case.fused_weight,
+            bias=None,
+            conv_state=conv_state,
+            raw_g=case.raw_g[step],
+            raw_beta=case.raw_beta[step],
+            A_log=case.a_log,
+            dt_bias=case.dt_bias,
+            state_indices=case.state_indices,
+            state=state,
+            out=outputs[step],
+            lower_bound=case.lower_bound,
+            output_gate=case.output_gate[step],
+            norm_weight=case.norm_weight,
+            norm_eps=case.norm_eps,
+        )
+
+
+@torch.inference_mode()
+def test_fused_kda_decode_h32_skips_padded_rows():
+    case = _make_fused_kda_decode_case(
+        num_steps=1,
+        slots=4,
+        state_indices=[2, 0, 1, 0],
+        seed=3200,
+    )
+    valid_rows = torch.tensor([0, 2], dtype=torch.long, device=DEVICE)
+    padded_rows = torch.tensor([1, 3], dtype=torch.long, device=DEVICE)
+    expected, conv_ref, state_ref = _run_fused_kda_decode_reference(case, valid_rows)
+
+    conv_actual = case.conv_seed.clone()
+    state_actual = case.state_seed.clone()
+    actual = torch.full_like(case.raw_g, torch.nan)
+    _run_fused_kda_decode_steps(case, conv_actual, state_actual, actual)
+
+    torch.testing.assert_close(
+        actual[0].index_select(1, valid_rows),
+        expected[0].index_select(1, valid_rows),
+        atol=3e-2,
+        rtol=3e-2,
+    )
+    torch.testing.assert_close(
+        actual[0].index_select(1, padded_rows),
+        torch.zeros_like(actual[0].index_select(1, padded_rows)),
+        atol=0,
+        rtol=0,
+    )
+    torch.testing.assert_close(conv_actual, conv_ref, atol=0, rtol=0)
+    torch.testing.assert_close(state_actual, state_ref, atol=3e-2, rtol=3e-2)
+    torch.testing.assert_close(conv_actual[0], case.conv_seed[0], atol=0, rtol=0)
+    torch.testing.assert_close(state_actual[0], case.state_seed[0], atol=0, rtol=0)
+
+
+@torch.inference_mode()
+def test_fused_kda_decode_h32_multistep_cudagraph_replay():
+    """Exercise Ling's H=32 decode shape across repeated updates to one slot."""
+    case = _make_fused_kda_decode_case(
+        num_steps=4,
+        slots=3,
+        state_indices=[1],
+        seed=3204,
+    )
+    expected, conv_ref, state_ref = _run_fused_kda_decode_reference(case)
+    conv_eager = case.conv_seed.clone()
+    state_eager = case.state_seed.clone()
+    eager_outputs = torch.empty_like(case.raw_g)
+    _run_fused_kda_decode_steps(case, conv_eager, state_eager, eager_outputs)
+
+    torch.testing.assert_close(eager_outputs, expected, atol=3e-2, rtol=3e-2)
+    torch.testing.assert_close(conv_eager, conv_ref, atol=0, rtol=0)
+    torch.testing.assert_close(state_eager, state_ref, atol=4e-2, rtol=4e-2)
+
+    conv_graph = case.conv_seed.clone()
+    state_graph = case.state_seed.clone()
+    graph_outputs = torch.empty_like(eager_outputs)
+    graph = torch.cuda.CUDAGraph()
+    torch.accelerator.synchronize()
+    with torch.cuda.graph(graph):
+        _run_fused_kda_decode_steps(case, conv_graph, state_graph, graph_outputs)
+
+    conv_graph.copy_(case.conv_seed)
+    state_graph.copy_(case.state_seed)
+    graph_outputs.fill_(torch.nan)
+    graph.replay()
+    torch.accelerator.synchronize()
+    first_outputs = graph_outputs.clone()
+    first_conv_state = conv_graph.clone()
+    first_kda_state = state_graph.clone()
+
+    torch.testing.assert_close(first_outputs, eager_outputs, atol=0, rtol=0)
+    torch.testing.assert_close(first_conv_state, conv_eager, atol=0, rtol=0)
+    torch.testing.assert_close(first_kda_state, state_eager, atol=0, rtol=0)
+
+    conv_graph.copy_(case.conv_seed)
+    state_graph.copy_(case.state_seed)
+    graph_outputs.fill_(torch.nan)
+    graph.replay()
+    torch.accelerator.synchronize()
+
+    torch.testing.assert_close(graph_outputs, first_outputs, atol=0, rtol=0)
+    torch.testing.assert_close(conv_graph, first_conv_state, atol=0, rtol=0)
+    torch.testing.assert_close(state_graph, first_kda_state, atol=0, rtol=0)
 
 
 def test_fused_kda_decode_rejects_speculative_conv_state():

--- a/tests/models/test_bailing_moe_v3.py
+++ b/tests/models/test_bailing_moe_v3.py
@@ -1,0 +1,203 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Focused tests for Ling's fused KDA decode weight shadows."""
+
+import gc
+import weakref
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.nn as nn
+
+from vllm.config import ModelConfig
+from vllm.model_executor.layers.attention import is_deferred_attention_layer
+from vllm.model_executor.model_loader.reload.layerwise import (
+    finalize_layerwise_reload,
+    initialize_layerwise_reload,
+    record_metadata_for_reloading,
+)
+from vllm.model_executor.model_loader.weight_utils import default_weight_loader
+from vllm.model_executor.models import bailing_moe_v3
+from vllm.model_executor.models.bailing_moe_v3 import (
+    BailingMoeV3KimiDeltaAttention,
+    _make_decode_conv1d_weight_loader,
+    _make_decode_norm_weight_loader,
+)
+
+_CONV_NAMES = ("q_conv1d", "k_conv1d", "v_conv1d")
+
+
+def test_fused_kda_warmup_skips_missing_metadata(monkeypatch) -> None:
+    monkeypatch.setattr(
+        bailing_moe_v3,
+        "get_forward_context",
+        lambda: SimpleNamespace(attn_metadata={}),
+    )
+    layer = BailingMoeV3KimiDeltaAttention.__new__(BailingMoeV3KimiDeltaAttention)
+    nn.Module.__init__(layer)
+    layer.prefix = "model.layers.0.attention"
+    empty = torch.empty(0)
+
+    layer._forward_fused_kda(empty, empty, empty, empty, empty)
+
+
+def _conv1d_modules(
+    layer: BailingMoeV3KimiDeltaAttention,
+) -> tuple[nn.Conv1d, ...]:
+    return tuple(getattr(layer, name) for name in _CONV_NAMES)
+
+
+def _assert_decode_shadows(
+    layer: BailingMoeV3KimiDeltaAttention,
+    expected_conv: torch.Tensor | None = None,
+    expected_norm: torch.Tensor | None = None,
+) -> None:
+    if expected_conv is None:
+        expected_conv = torch.stack(
+            [conv.weight.squeeze(1).transpose(0, 1) for conv in _conv1d_modules(layer)]
+        )
+    if expected_norm is None:
+        expected_norm = layer.o_norm.weight.float()
+    torch.testing.assert_close(layer.decode_conv1d_weight, expected_conv)
+    torch.testing.assert_close(layer.decode_norm_weight, expected_norm)
+
+
+def _make_fused_kda_layer() -> BailingMoeV3KimiDeltaAttention:
+    layer = BailingMoeV3KimiDeltaAttention.__new__(BailingMoeV3KimiDeltaAttention)
+    nn.Module.__init__(layer)
+    layer.use_fused_kda_decode = True
+    layer.conv_size = 2
+    layer.head_dim = 4
+    layer.projection_size_per_partition = 4
+
+    for name, value in zip(_CONV_NAMES, (1.0, 2.0, 3.0), strict=True):
+        conv1d = nn.Conv1d(1, 4, 2, bias=False)
+        conv1d.weight.data.fill_(value)
+        setattr(layer, name, conv1d)
+
+    layer.o_norm = nn.RMSNorm(4)
+    layer.o_norm.weight.data.copy_(torch.arange(4.0))
+    layer.register_buffer(
+        "decode_conv1d_weight", torch.empty(3, 2, 4), persistent=False
+    )
+    layer.register_buffer("decode_norm_weight", torch.empty(4), persistent=False)
+
+    layer_ref = weakref.ref(layer)
+    for shard_id, conv1d in enumerate(_conv1d_modules(layer)):
+        conv1d.weight.weight_loader = _make_decode_conv1d_weight_loader(
+            layer_ref,
+            shard_id,
+            default_weight_loader,
+        )
+    layer.o_norm.weight.weight_loader = _make_decode_norm_weight_loader(
+        layer_ref,
+        default_weight_loader,
+    )
+    return layer
+
+
+@pytest.mark.parametrize(
+    "meta_shadows",
+    [False, True],
+    ids=["refresh-existing", "materialize-meta"],
+)
+def test_fused_kda_post_load_refreshes_shadow_buffers(meta_shadows: bool) -> None:
+    """Deferred post-load processing refreshes or materializes shadows."""
+    layer = _make_fused_kda_layer()
+    if meta_shadows:
+        layer.decode_conv1d_weight = torch.empty(
+            3, 2, 4, device="meta", dtype=layer.q_conv1d.weight.dtype
+        )
+        layer.decode_norm_weight = torch.empty(4, device="meta", dtype=torch.float32)
+    else:
+        layer.decode_conv1d_weight.fill_(float("nan"))
+        layer.decode_norm_weight.fill_(float("nan"))
+
+    assert is_deferred_attention_layer(layer)
+    layer.process_weights_after_loading(torch.bfloat16)
+
+    assert not layer.decode_conv1d_weight.is_meta
+    assert not layer.decode_norm_weight.is_meta
+    _assert_decode_shadows(layer)
+    if meta_shadows:
+        loaded_weight = torch.full_like(layer.q_conv1d.weight, 9.0)
+        layer.q_conv1d.weight.weight_loader(layer.q_conv1d.weight, loaded_weight)
+        _assert_decode_shadows(layer)
+
+
+def test_fused_kda_loader_updates_live_shadow_in_place() -> None:
+    """Reloading must retain CUDA-graph-visible storage and avoid stale buffers."""
+    layer = _make_fused_kda_layer()
+    layer.refresh_fused_kda_decode_weights()
+    shadow_ptr = layer.decode_conv1d_weight.data_ptr()
+
+    loader = layer.q_conv1d.weight.weight_loader
+    loaded_weight = torch.full_like(layer.q_conv1d.weight, 7.0)
+    loader(layer.q_conv1d.weight, loaded_weight)
+
+    assert layer.decode_conv1d_weight.data_ptr() == shadow_ptr
+    torch.testing.assert_close(
+        layer.decode_conv1d_weight[0],
+        loaded_weight.squeeze(1).transpose(0, 1),
+    )
+
+    norm_shadow_ptr = layer.decode_norm_weight.data_ptr()
+    loaded_norm = torch.arange(4.0) + 20
+    layer.o_norm.weight.weight_loader(layer.o_norm.weight, loaded_norm)
+    assert layer.decode_norm_weight.data_ptr() == norm_shadow_ptr
+    _assert_decode_shadows(layer)
+
+
+def test_fused_kda_loader_weakref_does_not_retain_layer() -> None:
+    layer = _make_fused_kda_layer()
+    layer_ref = weakref.ref(layer)
+    param = layer.q_conv1d.weight
+    loader = param.weight_loader
+
+    del layer
+    gc.collect()
+
+    assert layer_ref() is None
+    loaded_weight = torch.full_like(param, 11.0)
+    loader(param, loaded_weight)
+    torch.testing.assert_close(param, loaded_weight)
+
+
+def test_fused_kda_layerwise_reload_refreshes_shadows() -> None:
+    """Layerwise reload must refresh shadows without changing live storage."""
+    layer = _make_fused_kda_layer()
+    layer.refresh_fused_kda_decode_weights()
+    model_config = ModelConfig()
+    conv_shadow_ptr = layer.decode_conv1d_weight.data_ptr()
+    norm_shadow_ptr = layer.decode_norm_weight.data_ptr()
+
+    record_metadata_for_reloading(layer)
+    initialize_layerwise_reload(layer)
+    conv_values = (4.0, 5.0, 6.0)
+    for conv1d, value in zip(_conv1d_modules(layer), conv_values, strict=True):
+        loaded = torch.full((4, 1, 2), value)
+        conv1d.weight.weight_loader(conv1d.weight, loaded)
+    loaded_norm = torch.arange(4.0) + 10
+    layer.o_norm.weight.weight_loader(layer.o_norm.weight, loaded_norm)
+
+    finalize_layerwise_reload(layer, model_config)
+
+    assert layer.decode_conv1d_weight.data_ptr() == conv_shadow_ptr
+    assert layer.decode_norm_weight.data_ptr() == norm_shadow_ptr
+    expected_conv = torch.stack([torch.full((2, 4), value) for value in conv_values])
+    _assert_decode_shadows(layer, expected_conv, loaded_norm)
+
+
+def test_fused_kda_disabled_layer_has_no_shadow_buffers() -> None:
+    """Unsupported TP/shape configurations must retain the original path only."""
+    layer = BailingMoeV3KimiDeltaAttention.__new__(BailingMoeV3KimiDeltaAttention)
+    nn.Module.__init__(layer)
+    layer.use_fused_kda_decode = False
+    layer.register_buffer("decode_conv1d_weight", None, persistent=False)
+    layer.register_buffer("decode_norm_weight", None, persistent=False)
+
+    layer.refresh_fused_kda_decode_weights()
+
+    assert layer.decode_conv1d_weight is None
+    assert layer.decode_norm_weight is None

--- a/vllm/model_executor/layers/mamba/ops/kda_decode.py
+++ b/vllm/model_executor/layers/mamba/ops/kda_decode.py
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import torch
+
+from vllm.model_executor.layers.mamba.mamba_utils import is_conv_state_dim_first
+from vllm.platforms import current_platform
+
+
+def is_fused_kda_decode_supported(
+    num_heads: int,
+    head_dim: int,
+    conv_width: int,
+    num_spec: int,
+    input_dtype: torch.dtype,
+    conv_state_dtype: torch.dtype,
+) -> bool:
+    if (
+        num_heads not in (12, 24, 32, 48, 96)
+        or head_dim != 128
+        or conv_width != 4
+        or num_spec != 0
+        or input_dtype != torch.bfloat16
+        or conv_state_dtype != torch.bfloat16
+        or is_conv_state_dim_first()
+        or not hasattr(torch.ops._C, "fused_kda_decode")
+    ):
+        return False
+    # SM90 is architecture-specific; SM10x and SM12x use family binaries.
+    return (
+        current_platform.is_device_capability(90)
+        or current_platform.is_device_capability_family(100)
+        or current_platform.is_device_capability_family(120)
+    )

--- a/vllm/model_executor/models/bailing_moe_v3.py
+++ b/vllm/model_executor/models/bailing_moe_v3.py
@@ -9,6 +9,7 @@ vLLM's parallel linear layers, MLA kernel, KDA kernel and fused MoE loader.
 """
 
 import copy
+import weakref
 from collections.abc import Callable, Iterable
 from math import lcm
 from typing import TypeGuard
@@ -20,6 +21,7 @@ import torch.nn.functional as F
 from einops import rearrange
 from transformers.configuration_utils import PretrainedConfig
 
+from vllm import _custom_ops as ops
 from vllm.compilation.decorators import support_torch_compile
 from vllm.config import CacheConfig, ModelConfig, VllmConfig, get_current_vllm_config
 from vllm.distributed import (
@@ -52,6 +54,9 @@ from vllm.model_executor.layers.mamba.mamba_utils import (
 from vllm.model_executor.layers.mamba.ops.causal_conv1d import (
     causal_conv1d_fn,
     causal_conv1d_update,
+)
+from vllm.model_executor.layers.mamba.ops.kda_decode import (
+    is_fused_kda_decode_supported,
 )
 from vllm.model_executor.layers.mla import (
     MLAModules,
@@ -135,6 +140,45 @@ direct_register_custom_op(
 )
 
 
+def bailing_v3_fused_kda_attention(
+    mixed_qkv: torch.Tensor,
+    raw_g: torch.Tensor,
+    raw_beta: torch.Tensor,
+    output_gate: torch.Tensor,
+    core_attn_out: torch.Tensor,
+    layer_name: str,
+) -> None:
+    """Use fused KDA decode when possible, otherwise run the original path."""
+    forward_context: ForwardContext = get_forward_context()
+    layer = forward_context.no_compile_layers[layer_name]
+    layer._forward_fused_kda(
+        mixed_qkv=mixed_qkv,
+        raw_g=raw_g,
+        raw_beta=raw_beta,
+        output_gate=output_gate,
+        core_attn_out=core_attn_out,
+    )
+
+
+def bailing_v3_fused_kda_attention_fake(
+    mixed_qkv: torch.Tensor,
+    raw_g: torch.Tensor,
+    raw_beta: torch.Tensor,
+    output_gate: torch.Tensor,
+    core_attn_out: torch.Tensor,
+    layer_name: str,
+) -> None:
+    return
+
+
+direct_register_custom_op(
+    op_name="bailing_v3_fused_kda_attention",
+    op_func=bailing_v3_fused_kda_attention,
+    mutates_args=["core_attn_out"],
+    fake_impl=bailing_v3_fused_kda_attention_fake,
+)
+
+
 def _is_kda_layer(
     layer_idx: int, layer_group_size: int, num_hidden_layers: int
 ) -> bool:
@@ -202,6 +246,39 @@ def _load_a_log(param: torch.nn.Parameter, loaded_weight: torch.Tensor) -> None:
         param.data.copy_(shard.view_as(param.data))
     else:
         sharded_weight_loader(2)(param, loaded_weight)
+
+
+def _make_decode_conv1d_weight_loader(
+    layer_ref: weakref.ReferenceType,
+    shard_id: int,
+    base_loader: Callable[[torch.Tensor, torch.Tensor], None],
+) -> Callable[[torch.Tensor, torch.Tensor], None]:
+    def weight_loader(param: torch.Tensor, loaded_weight: torch.Tensor) -> None:
+        base_loader(param, loaded_weight)
+        layer = layer_ref()
+        if layer is None or param.is_meta:
+            return
+        decode_conv1d_weight = layer.decode_conv1d_weight
+        if decode_conv1d_weight is not None and not decode_conv1d_weight.is_meta:
+            decode_conv1d_weight[shard_id].copy_(param.data.squeeze(1).transpose(0, 1))
+
+    return weight_loader
+
+
+def _make_decode_norm_weight_loader(
+    layer_ref: weakref.ReferenceType,
+    base_loader: Callable[[torch.Tensor, torch.Tensor], None],
+) -> Callable[[torch.Tensor, torch.Tensor], None]:
+    def weight_loader(param: torch.Tensor, loaded_weight: torch.Tensor) -> None:
+        base_loader(param, loaded_weight)
+        layer = layer_ref()
+        if layer is None or param.is_meta:
+            return
+        decode_norm_weight = layer.decode_norm_weight
+        if decode_norm_weight is not None and not decode_norm_weight.is_meta:
+            decode_norm_weight.copy_(param.data.float())
+
+    return weight_loader
 
 
 def _is_block_fp8_config(
@@ -713,6 +790,53 @@ class BailingMoeV3KimiDeltaAttention(PluggableLayer, MambaBase):
         self.k_conv1d.weight.data = self.k_conv1d.weight.data.unsqueeze(1)
         self.v_conv1d.weight.data = self.v_conv1d.weight.data.unsqueeze(1)
 
+        self.use_fused_kda_decode = False
+        decode_conv1d_weight = None
+        if (
+            self.local_num_heads == 32
+            and self.model_config is not None
+            and self.cache_config is not None
+        ):
+            conv_state_dtype, _ = self.get_state_dtype()
+            self.use_fused_kda_decode = is_fused_kda_decode_supported(
+                self.local_num_heads,
+                self.head_dim,
+                self.conv_size,
+                self.num_speculative_tokens,
+                self.model_config.dtype,
+                conv_state_dtype,
+            )
+            if self.use_fused_kda_decode:
+                decode_conv1d_weight = torch.empty(
+                    3,
+                    self.conv_size,
+                    self.projection_size_per_partition,
+                    dtype=self.q_conv1d.weight.dtype,
+                    device=self.q_conv1d.weight.device,
+                )
+        self.decode_conv1d_weight: torch.Tensor | None
+        self.register_buffer(
+            "decode_conv1d_weight", decode_conv1d_weight, persistent=False
+        )
+        if decode_conv1d_weight is not None:
+            layer_ref = weakref.ref(self)
+            for shard_id, conv1d in enumerate(
+                (self.q_conv1d, self.k_conv1d, self.v_conv1d)
+            ):
+                base_loader = getattr(
+                    conv1d.weight, "weight_loader", default_weight_loader
+                )
+                if hasattr(conv1d.weight, "weight_loader"):
+                    delattr(conv1d.weight, "weight_loader")
+                set_weight_attrs(
+                    conv1d.weight,
+                    {
+                        "weight_loader": _make_decode_conv1d_weight_loader(
+                            layer_ref, shard_id, base_loader
+                        )
+                    },
+                )
+
         self.A_log = nn.Parameter(
             torch.empty(1, 1, self.local_num_heads, 1, dtype=torch.float32)
         )
@@ -728,6 +852,30 @@ class BailingMoeV3KimiDeltaAttention(PluggableLayer, MambaBase):
         self.o_norm = FusedRMSNormGated(
             self.head_dim, eps=config.rms_norm_eps, activation="sigmoid"
         )
+        decode_norm_weight = None
+        if decode_conv1d_weight is not None:
+            decode_norm_weight = torch.empty(
+                self.head_dim,
+                dtype=torch.float32,
+                device=self.o_norm.weight.device,
+            )
+        self.decode_norm_weight: torch.Tensor | None
+        self.register_buffer("decode_norm_weight", decode_norm_weight, persistent=False)
+        if decode_norm_weight is not None:
+            layer_ref = weakref.ref(self)
+            base_loader = getattr(
+                self.o_norm.weight, "weight_loader", default_weight_loader
+            )
+            if hasattr(self.o_norm.weight, "weight_loader"):
+                delattr(self.o_norm.weight, "weight_loader")
+            set_weight_attrs(
+                self.o_norm.weight,
+                {
+                    "weight_loader": _make_decode_norm_weight_loader(
+                        layer_ref, base_loader
+                    )
+                },
+            )
         self.o_proj = RowParallelLinear(
             projection_size,
             self.hidden_size,
@@ -740,12 +888,60 @@ class BailingMoeV3KimiDeltaAttention(PluggableLayer, MambaBase):
         if prefix in compilation_config.static_forward_context:
             raise ValueError(f"Duplicate layer name: {prefix}")
         compilation_config.static_forward_context[prefix] = self
-        splitting_op = "vllm::bailing_v3_kda_attention"
+        splitting_ops = ["vllm::bailing_v3_kda_attention"]
+        if self.use_fused_kda_decode:
+            splitting_ops.append("vllm::bailing_v3_fused_kda_attention")
+        if compilation_config.splitting_ops is not None:
+            for splitting_op in splitting_ops:
+                if splitting_op not in compilation_config.splitting_ops:
+                    compilation_config.splitting_ops.append(splitting_op)
+
+    @torch.no_grad()
+    def refresh_fused_kda_decode_weights(self) -> None:
+        """Refresh non-persistent fused-decode buffers from loaded weights."""
+        if not self.use_fused_kda_decode:
+            return
+
+        decode_conv1d_weight = self.decode_conv1d_weight
+        decode_norm_weight = self.decode_norm_weight
+        conv1d_weights = (
+            self.q_conv1d.weight,
+            self.k_conv1d.weight,
+            self.v_conv1d.weight,
+        )
         if (
-            compilation_config.splitting_ops is not None
-            and splitting_op not in compilation_config.splitting_ops
+            any(weight.is_meta for weight in conv1d_weights)
+            or self.o_norm.weight.is_meta
         ):
-            compilation_config.splitting_ops.append(splitting_op)
+            return
+
+        if decode_conv1d_weight is None or decode_conv1d_weight.is_meta:
+            decode_conv1d_weight = torch.empty(
+                3,
+                self.conv_size,
+                self.projection_size_per_partition,
+                dtype=conv1d_weights[0].dtype,
+                device=conv1d_weights[0].device,
+            )
+            self.decode_conv1d_weight = decode_conv1d_weight
+        if decode_norm_weight is None or decode_norm_weight.is_meta:
+            decode_norm_weight = torch.empty(
+                self.head_dim,
+                dtype=torch.float32,
+                device=self.o_norm.weight.device,
+            )
+            self.decode_norm_weight = decode_norm_weight
+
+        for shard_id, conv1d_weight in enumerate(conv1d_weights):
+            decode_conv1d_weight[shard_id].copy_(
+                conv1d_weight.data.squeeze(1).transpose(0, 1)
+            )
+        decode_norm_weight.copy_(self.o_norm.weight.data.float())
+
+    def process_weights_after_loading(self, act_dtype: torch.dtype) -> None:
+        """Refresh fused-decode weights after initial or layerwise loading."""
+        del act_dtype
+        self.refresh_fused_kda_decode_weights()
 
     def forward(
         self,
@@ -755,6 +951,40 @@ class BailingMoeV3KimiDeltaAttention(PluggableLayer, MambaBase):
     ) -> None:
         del positions
         num_tokens = hidden_states.size(0)
+        if self.use_fused_kda_decode:
+            if self.separate_b_proj:
+                assert self.qkv_proj is not None and self.b_proj is not None
+                mixed_qkv = self.qkv_proj(hidden_states)[0]
+                beta_logits = self.b_proj(hidden_states)[0]
+            else:
+                assert self.qkvb_proj is not None
+                qkvb = self.qkvb_proj(hidden_states)[0]
+                mixed_qkv = qkvb[:, : 3 * self.projection_size_per_partition]
+                beta_logits = qkvb[:, 3 * self.projection_size_per_partition :]
+            raw_g = self.f_proj(hidden_states)[0]
+            output_gate = rearrange(
+                self.g_proj(hidden_states)[0],
+                "... (h d) -> ... h d",
+                d=self.head_dim,
+            )
+
+            core_attn_out = torch.zeros(
+                (1, num_tokens, self.local_num_heads, self.head_dim),
+                dtype=hidden_states.dtype,
+                device=hidden_states.device,
+            )
+            torch.ops.vllm.bailing_v3_fused_kda_attention(
+                mixed_qkv,
+                raw_g,
+                beta_logits.unsqueeze(0),
+                output_gate,
+                core_attn_out,
+                self.prefix,
+            )
+            core_attn_out = rearrange(core_attn_out, "1 n h d -> n (h d)")
+            output[:] = self.o_proj(core_attn_out)[0]
+            return
+
         if self.separate_b_proj:
             assert self.qkv_proj is not None and self.b_proj is not None
             qkv = self.qkv_proj(hidden_states)[0]
@@ -797,6 +1027,84 @@ class BailingMoeV3KimiDeltaAttention(PluggableLayer, MambaBase):
         core_attn_out = self.o_norm(core_attn_out, g2)
         core_attn_out = rearrange(core_attn_out, "1 n h d -> n (h d)")
         output[:] = self.o_proj(core_attn_out)[0]
+
+    def _forward_fused_kda(
+        self,
+        mixed_qkv: torch.Tensor,
+        raw_g: torch.Tensor,
+        raw_beta: torch.Tensor,
+        output_gate: torch.Tensor,
+        core_attn_out: torch.Tensor,
+    ) -> None:
+        forward_context = get_forward_context()
+        attn_metadata_map = forward_context.attn_metadata
+        if attn_metadata_map is None:
+            return
+
+        assert isinstance(attn_metadata_map, dict)
+        attn_metadata = attn_metadata_map.get(self.prefix)
+        if attn_metadata is None:
+            # Profile/warmup dummy runs skip mamba-family metadata.
+            return
+        assert isinstance(attn_metadata, GDNAttentionMetadata)
+        state_indices = attn_metadata.non_spec_state_indices_tensor
+        spec_sequence_masks = attn_metadata.spec_sequence_masks
+        num_actual_tokens = attn_metadata.num_actual_tokens
+        conv_state, recurrent_state = self.kv_cache
+        recurrent_state_active = recurrent_state[..., : self.head_dim]
+        if not is_conv_state_dim_first():
+            conv_state = conv_state.transpose(-1, -2)
+
+        if (
+            spec_sequence_masks is None
+            and attn_metadata.num_prefills == 0
+            and attn_metadata.num_decodes > 0
+        ):
+            assert self.decode_conv1d_weight is not None
+            assert self.decode_norm_weight is not None
+            assert state_indices is not None
+            ops.fused_kda_decode(
+                x=mixed_qkv[:num_actual_tokens],
+                weight=self.decode_conv1d_weight,
+                bias=None,
+                conv_state=conv_state,
+                raw_g=raw_g[:num_actual_tokens].view(
+                    1, num_actual_tokens, self.local_num_heads, self.head_dim
+                ),
+                raw_beta=raw_beta[:, :num_actual_tokens],
+                A_log=self.A_log,
+                dt_bias=self.dt_bias,
+                state_indices=state_indices[:num_actual_tokens].contiguous(),
+                state=recurrent_state_active,
+                out=core_attn_out[:, :num_actual_tokens],
+                lower_bound=self.lower_bound if self.safe_gate else None,
+                output_gate=output_gate[:num_actual_tokens],
+                norm_weight=self.decode_norm_weight,
+                norm_eps=self.o_norm.eps,
+            )
+            return
+
+        q_proj_states, k_proj_states, v_proj_states = mixed_qkv.split(
+            self.projection_size_per_partition, dim=-1
+        )
+        g1 = fused_kda_gate(
+            raw_g,
+            self.A_log,
+            self.head_dim,
+            g_bias=self.dt_bias,
+            lower_bound=self.lower_bound if self.safe_gate else None,
+        ).unsqueeze(0)
+        beta = raw_beta.float().sigmoid()
+
+        self._forward(
+            q_proj_states=q_proj_states,
+            k_proj_states=k_proj_states,
+            v_proj_states=v_proj_states,
+            g1=g1,
+            beta=beta,
+            core_attn_out=core_attn_out,
+        )
+        core_attn_out.copy_(self.o_norm(core_attn_out, output_gate))
 
     def _forward(
         self,

--- a/vllm/models/kimi_k3/nvidia/kda.py
+++ b/vllm/models/kimi_k3/nvidia/kda.py
@@ -33,6 +33,9 @@ from vllm.model_executor.layers.mamba.ops.causal_conv1d import (
 from vllm.model_executor.layers.mamba.ops.gather_initial_states import (
     gather_initial_states,
 )
+from vllm.model_executor.layers.mamba.ops.kda_decode import (
+    is_fused_kda_decode_supported,
+)
 from vllm.model_executor.model_loader.weight_utils import (
     default_weight_loader,
     sharded_weight_loader,
@@ -143,33 +146,6 @@ class _KimiGDNMergedColumnParallelLinear(MergedColumnParallelLinear):
             self.tp_rank = tp_rank
             if param_tp_rank is not None:
                 param.tp_rank = param_tp_rank
-
-
-def is_fused_kda_decode_supported(
-    num_heads: int,
-    head_dim: int,
-    conv_width: int,
-    num_spec: int,
-    input_dtype: torch.dtype,
-    conv_state_dtype: torch.dtype,
-) -> bool:
-    if (
-        num_heads not in (12, 24, 48, 96)
-        or head_dim != 128
-        or conv_width != 4
-        or num_spec != 0
-        or input_dtype != torch.bfloat16
-        or conv_state_dtype != torch.bfloat16
-        or is_conv_state_dim_first()
-        or not hasattr(torch.ops._C, "fused_kda_decode")
-    ):
-        return False
-    # SM90 is architecture-specific; SM10x and SM12x use family binaries.
-    return (
-        current_platform.is_device_capability(90)
-        or current_platform.is_device_capability_family(100)
-        or current_platform.is_device_capability_family(120)
-    )
 
 
 def is_flashkda_supported(


### PR DESCRIPTION
## Summary

Ling-3.0-flash has 35 KDA layers and 32 local heads at TP=1, but the NVIDIA
fused KDA decode kernel did not support H=32. This PR adds that specialization
and enables it for `BailingMoeV3KimiDeltaAttention`, combining the convolution
update, recurrent KDA update, and gated RMSNorm into one decode kernel.

Unsupported configurations continue to use the existing implementation.

I searched open vLLM issues and PRs for Ling/Bailing, KDA decode, and H=32 CUDA
fusion; none implements this specialization together with the Bailing
integration.

## Implementation

- Add H=32 validation and dispatch to the existing stable-ABI CUDA kernel.
- Share fused-path eligibility checks between Kimi-K3 and Bailing.
- Add a separate Bailing fused-decode op. Prefill, speculative decoding, and
  unsupported configurations retain the original path.
- Refresh the kernel-layout convolution and norm-weight buffers after loading
  and layerwise reload.
- Fix full-CUDA-graph NULL-row handling for both the existing H=12/24/48/96
  specializations and the new H=32 path: padded rows produce zero output and no
  longer write concurrently to reserved slot 0.

## Validation

The same test suites pass on both tested architectures:

| GPU | `test_kda.py` | `test_bailing_moe_v3.py` |
| --- | ---: | ---: |
| RTX PRO 6000 Blackwell (sm120) | 54 passed | 6 passed |
| NVIDIA H20 (sm90) | 54 passed | 6 passed |

```bash
cd /root/r23/vllm-main

PYTHONPATH=/root/r23/runtime_overlay:/root/r23/vllm-main \
  /root/vllm/.venv/bin/python -m pytest -q \
  tests/models/kimi_k3/test_kda.py

PYTHONPATH=/root/r23/runtime_overlay:/root/r23/vllm-main \
  /root/vllm/.venv/bin/python -m pytest -q \
  tests/models/test_bailing_moe_v3.py

/root/vllm/.venv/bin/pre-commit run --files \
  csrc/libtorch_stable/kimi_k3/fused_kda_decode_kernel.cu \
  vllm/model_executor/layers/mamba/ops/kda_decode.py \
  vllm/model_executor/models/bailing_moe_v3.py \
  vllm/models/kimi_k3/nvidia/kda.py \
  tests/models/kimi_k3/test_kda.py \
  tests/models/test_bailing_moe_v3.py
# all hooks passed
```

The tests cover H=32 correctness, repeated state updates, eager/CUDA-graph
replay, padded rows, and post-load buffer refresh.

On H20, an FP64 operator oracle also showed lower numerical error for the fused
H=32 path in the tested synthetic cases (B=1-128): output RMS error was
`6.7e-5`-`8.8e-5` versus `1.37e-4`-`1.74e-4` for the fallback, and final
recurrent-state max error after 64 decode steps was `4.28e-8` versus `4.66e-4`.
This is kernel-level numerical evidence, not a model-quality or universal
equivalence claim.

### Model evaluation

GSM8K was evaluated on the full FP4 checkpoint using 500 fixed questions with
5-shot greedy decoding on the RTX PRO 6000:

| Arm | Correct | Accuracy |
| --- | ---: | ---: |
| Base | 465 / 500 | 93.0% |
| Fused | 461 / 500 | 92.2% |

The exact two-sided McNemar result is `p=0.424`. This run does not detect a
statistically significant difference, but it does not establish equivalence.
Both arms used the same UE8M0-to-FP32 scale-loading workaround, which is
orthogonal to this diff.

## Performance

Each cell is an independent within-device patched-fallback-to-fused comparison.
Both platforms used a balanced six-process schedule with 3 warmups and 15
samples per slot and a fixed 64-token decode workload.

| Mode | RTX PRO 6000 (sm120) | NVIDIA H20 (sm90) |
| --- | ---: | ---: |
| Eager / B1 | **-25.717% (1.346x)** | **-24.820% (1.330x)** |
| FULL CG / B1 | **-4.246% (1.044x)** | **-4.215% (1.044x)** |
| FULL CG / B8 | **-6.113% (1.065x)** | **-8.039% (1.087x)** |

All 30/30 paired wall-time samples improved in every case on both GPUs.

The H20 run used a 12-layer random-weight proxy with 10 KDA layers while
preserving Ling's production KDA geometry (H=32, head dimension 128,
convolution width 4). It validates the sm90 path and performance direction, but
is not an absolute cross-GPU or model-quality comparison.

On H20, the fused kernel replaced a measured 13-launch convolution/recurrent/
norm subset with one launch and was 1.41-2.39x faster under CUDA Graph and
1.56-8.61x faster in eager mode for B=1-256.

The NULL-row fix also affects existing H=12/24/48/96 paths. H20 testing found
no measurable overhead without padding; at B=128 with 25%, 50%, and 75%
padding, H=48/H=96 kernel latency improved by about 1.31x, 2.35-2.38x, and
4.58-4.95x respectively.