### PR TITLE
[CI/Build] Use file rendezvous for UniProc loader fixtures

### DIFF
--- a/tests/model_executor/model_loader/runai_streamer_loader/conftest.py
+++ b/tests/model_executor/model_loader/runai_streamer_loader/conftest.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-from vllm.utils.network_utils import get_distributed_init_method, get_ip, get_open_port
+from vllm.utils.network_utils import get_file_store_init_method
 from vllm.v1.executor import UniProcExecutor
 from vllm.v1.worker.worker_base import WorkerWrapperBase
 
@@ -11,7 +11,7 @@ from vllm.v1.worker.worker_base import WorkerWrapperBase
 # The worker process reimports the patched entities, and the patch is not applied.
 class RunaiDummyExecutor(UniProcExecutor):
     def _init_executor(self) -> None:
-        distributed_init_method = get_distributed_init_method(get_ip(), get_open_port())
+        distributed_init_method = get_file_store_init_method()
 
         local_rank = 0
         rank = 0

--- a/tests/model_executor/model_loader/tensorizer_loader/conftest.py
+++ b/tests/model_executor/model_loader/tensorizer_loader/conftest.py
@@ -8,7 +8,7 @@ from vllm import LLM, EngineArgs
 from vllm.distributed import cleanup_dist_env_and_memory
 from vllm.model_executor.model_loader import tensorizer as tensorizer_mod
 from vllm.model_executor.model_loader.tensorizer import TensorizerConfig
-from vllm.utils.network_utils import get_distributed_init_method, get_ip, get_open_port
+from vllm.utils.network_utils import get_file_store_init_method
 from vllm.v1.executor import UniProcExecutor
 from vllm.v1.worker.worker_base import WorkerWrapperBase
 
@@ -68,7 +68,7 @@ class DummyExecutor(UniProcExecutor):
     def _init_executor(self) -> None:
         """Initialize the worker and load the model."""
         self.driver_worker = WorkerWrapperBase(rpc_rank=0)
-        distributed_init_method = get_distributed_init_method(get_ip(), get_open_port())
+        distributed_init_method = get_file_store_init_method()
         local_rank = 0
         # set local rank as the device index if specified
         device_info = self.vllm_config.device_config.device.__str__().split(":")


### PR DESCRIPTION
## Purpose

Replace the probe-and-release TCP rendezvous in the RunAI streamer and tensorizer UniProcExecutor fixtures with the existing unique file-store helper.

Both fixtures run with rank 0 and world size 1, so they do not need a network-reachable TCPStore. Using file stores removes an unnecessary port race without changing production code or fixture behavior.

Related to #51275.

AI assistance was used for investigation and implementation.

## Test Plan

- Run all pre-commit hooks applicable to the two changed fixture files.
- Generate 32 unique file-store init methods and initialize/destroy a CPU Gloo process group with each one.

## Test Result

- All applicable pre-commit hooks passed, including ruff, formatting, mypy, SPDX, forbidden-import, and configuration checks.
- CPU/Gloo file-store rendezvous smoke test passed for all 32 unique init methods.
- The full GPU-backed model-loader suites were not run locally.