### PR TITLE
test(prefix cache): pin two mamba "align" + EAGLE prefix-cache defects

### DIFF
--- a/tests/v1/core/prefix_cache/test_eagle_mamba_drop_cost.py
+++ b/tests/v1/core/prefix_cache/test_eagle_mamba_drop_cost.py
@@ -1,0 +1,165 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""What the EAGLE/MTP block drop actually costs a hybrid mamba model.
+
+`prefix_match_unit` exists so the drop is one hash unit instead of one cache
+block. It does that for full attention. It does not do it for the reconciled
+hit, because the mamba group only materializes state at block boundaries: capped
+at the attention candidate, its lookup floors to the previous boundary and the
+joint hit gives up a whole block.
+
+Config below: block 16, hash unit 4, owner caches three blocks (48 tokens).
+
+    full attention alone   48 -> 44   one hash unit, as intended
+    mamba alone            48         (it ignores drop_eagle_block)
+    reconciled                  32    a whole block
+
+Neither group loses a block by itself. The block is lost in the reconciliation.
+"""
+
+import pytest
+import torch
+
+from tests.v1.core.test_prefix_caching import make_kv_cache_manager, make_request
+from vllm.utils.hashing import sha256
+from vllm.v1.core.kv_cache_utils import init_none_hash
+from vllm.v1.kv_cache_interface import (
+    FullAttentionSpec,
+    KVCacheConfig,
+    KVCacheGroupSpec,
+    MambaSpec,
+)
+
+BLOCK = 16
+HASH = 4  # prefix_match_unit: partial matching is ON
+OWNER = 48  # three whole blocks
+
+
+@pytest.fixture(autouse=True)
+def _auto_init_hash_fn():
+    init_none_hash(sha256)
+
+
+def _manager(use_eagle: bool):
+    kv_cache_config = KVCacheConfig(
+        num_blocks=128,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["full"],
+                FullAttentionSpec(
+                    block_size=BLOCK,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                ),
+            ),
+            KVCacheGroupSpec(
+                ["mamba"],
+                MambaSpec(
+                    block_size=BLOCK,
+                    shapes=(1, 1),
+                    dtypes=(torch.float32,),
+                    mamba_cache_mode="align",
+                ),
+            ),
+        ],
+    )
+    manager = make_kv_cache_manager(
+        kv_cache_config=kv_cache_config,
+        max_model_len=4096,
+        enable_caching=True,
+        hash_block_size=HASH,
+        use_eagle=use_eagle,
+    )
+    assert manager.coordinator.enable_partial_hash_hits, "partial matching must be on"
+    return manager
+
+
+def _seed_owner(manager):
+    """Prefill 48 tokens the way the scheduler splits them.
+
+    Stops on each block boundary, and also one hash unit below each -- the
+    position EAGLE resumes from. A chunk has to END there for the state to be
+    materializable, so the stop is what gives the fix something to register.
+    Today nothing is registered at those positions; the assertion below is what
+    changes when something is.
+    """
+    owner = make_request("owner", [7] * OWNER, HASH, sha256)
+    computed, num_computed, _ = manager.get_computed_blocks(owner)
+    done, first = 0, True
+    stops = sorted(
+        {b - HASH for b in range(BLOCK, OWNER + 1, BLOCK)}
+        | set(range(BLOCK, OWNER + 1, BLOCK))
+    )
+    for stop in stops:
+        step = stop - done
+        if step <= 0:
+            continue
+        ok = (
+            manager.allocate_slots(owner, step, num_computed, computed)
+            if first
+            else manager.allocate_slots(owner, step)
+        )
+        assert ok is not None
+        first, done = False, stop
+        owner.num_computed_tokens = done
+        manager.new_step_starts()
+    return owner
+
+
+def _follower(manager):
+    f = make_request("follower", [7] * OWNER + [9] * 8, HASH, sha256)
+    blocks, joint, _ = manager.get_computed_blocks(f)
+    _pg_blocks, per_group = manager.coordinator.find_longest_cache_hit_per_group(
+        f.block_hashes, OWNER + 7
+    )
+    return joint, tuple(per_group), blocks
+
+
+def test_full_attention_gives_up_only_one_hash_unit():
+    """The property `prefix_match_unit` is supposed to deliver. It holds."""
+    manager = _manager(use_eagle=True)
+    _seed_owner(manager)
+    _joint, per_group, _ = _follower(manager)
+    assert per_group[0] == OWNER - HASH == 44
+
+
+def test_mamba_alone_reaches_the_full_prefix():
+    """Evaluated on its own, mamba ignores drop_eagle_block and reaches 48."""
+    manager = _manager(use_eagle=True)
+    _seed_owner(manager)
+    _joint, per_group, _ = _follower(manager)
+    assert per_group[1] == OWNER == 48
+
+
+def test_without_eagle_nothing_is_given_up():
+    """Isolates the drop as the cause: no eagle, no loss."""
+    manager = _manager(use_eagle=False)
+    _seed_owner(manager)
+    joint, _per_group, _ = _follower(manager)
+    assert joint == OWNER == 48
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="mamba has no checkpoint at the position EAGLE resumes from, so the "
+    "reconciled hit floors to the previous block boundary",
+)
+def test_reconciled_hit_should_not_give_up_a_whole_block():
+    """The defect. Both groups individually reach at least 44, but the
+    reconciled hit is 32: mamba is capped at the attention candidate (44) and
+    its state exists only at 16/32/48, so it floors to 32.
+
+    Fails on main (32). Passes once a mamba checkpoint exists at the position
+    EAGLE resumes from, i.e. one hash unit below a block boundary.
+    """
+    manager = _manager(use_eagle=True)
+    _seed_owner(manager)
+    joint, per_group, blocks = _follower(manager)
+    assert min(per_group) >= OWNER - HASH, per_group
+    assert joint == OWNER - HASH, (
+        f"joint hit {joint} gave up a whole {BLOCK}-token block; full attention "
+        f"only gave up {OWNER - per_group[0]} (per-group hits {per_group})"
+    )
+    assert all(len(g) * BLOCK >= joint for g in blocks.blocks)

--- a/tests/v1/core/prefix_cache/test_eagle_mamba_shared_system_prompt.py
+++ b/tests/v1/core/prefix_cache/test_eagle_mamba_shared_system_prompt.py
@@ -1,0 +1,181 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""The EAGLE/MTP drop when the shared prefix ends before the owner's prompt.
+
+The sibling file pins the case where the shared prefix runs to the END of the
+owner's prompt. This one pins the other shape, which is what a served system
+prompt looks like: every request begins with the same preamble and then diverges
+into its own question. The owner's prompt tail therefore sits over tokens no
+sibling shares, so nothing cached there can serve them.
+
+Config below: block 16, hash unit 4. Owner prompt is 40 tokens -- a 24-token
+shared prefix followed by a 16-token private suffix. The follower shares the
+first 24 and then diverges.
+
+    full attention alone   16 -> 12   one hash unit below the shared boundary
+    mamba alone            16         (it ignores drop_eagle_block)
+    reconciled                   0    everything
+
+The shared prefix ends mid-block (24 % 16 = 8), so full attention's own match
+stops at the last whole shared block, 16, and the drop takes it to 12. Mamba has
+state only at 0 and 16; capped at 12 it can only fall back to 0, and the joint
+hit is nothing at all. Without EAGLE the same follower keeps 16.
+
+This is the shape where a check-point at the *prompt tail* cannot help: 40, and
+36 one hash unit below it, are both over the owner's private suffix.
+"""
+
+import pytest
+import torch
+
+from tests.v1.core.test_prefix_caching import make_kv_cache_manager, make_request
+from vllm.utils.hashing import sha256
+from vllm.v1.core.kv_cache_utils import init_none_hash
+from vllm.v1.kv_cache_interface import (
+    FullAttentionSpec,
+    KVCacheConfig,
+    KVCacheGroupSpec,
+    MambaSpec,
+)
+
+BLOCK = 16
+HASH = 4  # prefix_match_unit: partial matching is ON
+SHARED = 24  # the system prompt; ends mid-block on purpose
+SUFFIX = 16  # the owner's own question
+PROMPT = SHARED + SUFFIX
+
+
+@pytest.fixture(autouse=True)
+def _auto_init_hash_fn():
+    init_none_hash(sha256)
+
+
+def _manager(use_eagle: bool):
+    kv_cache_config = KVCacheConfig(
+        num_blocks=128,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["full"],
+                FullAttentionSpec(
+                    block_size=BLOCK,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                ),
+            ),
+            KVCacheGroupSpec(
+                ["mamba"],
+                MambaSpec(
+                    block_size=BLOCK,
+                    shapes=(1, 1),
+                    dtypes=(torch.float32,),
+                    mamba_cache_mode="align",
+                ),
+            ),
+        ],
+    )
+    manager = make_kv_cache_manager(
+        kv_cache_config=kv_cache_config,
+        max_model_len=4096,
+        enable_caching=True,
+        hash_block_size=HASH,
+        use_eagle=use_eagle,
+    )
+    assert manager.coordinator.enable_partial_hash_hits, "partial matching must be on"
+    return manager
+
+
+def _seed_owner(manager):
+    """Prefill the owner's 40 tokens, stopping everywhere state could be kept.
+
+    Block boundaries, one hash unit below each -- the position EAGLE resumes
+    from -- and the prompt tail. Stopping is what makes a position registrable;
+    which of them actually get an entry is what these tests report.
+    """
+    owner = make_request("owner", [7] * SHARED + [8] * SUFFIX, HASH, sha256)
+    computed, num_computed, _ = manager.get_computed_blocks(owner)
+    done, first = 0, True
+    stops = sorted(
+        {b - HASH for b in range(BLOCK, PROMPT + 1, BLOCK)}
+        | set(range(BLOCK, PROMPT + 1, BLOCK))
+        | {PROMPT}
+    )
+    for stop in stops:
+        step = stop - done
+        if step <= 0:
+            continue
+        ok = (
+            manager.allocate_slots(owner, step, num_computed, computed)
+            if first
+            else manager.allocate_slots(owner, step)
+        )
+        assert ok is not None
+        first, done = False, stop
+        owner.num_computed_tokens = done
+        manager.new_step_starts()
+    return owner
+
+
+def _follower(manager):
+    """A sibling that shares the system prompt and then asks something else."""
+    f = make_request("follower", [7] * SHARED + [9] * 8, HASH, sha256)
+    _blocks, joint, _ = manager.get_computed_blocks(f)
+    _pg_blocks, per_group = manager.coordinator.find_longest_cache_hit_per_group(
+        f.block_hashes, SHARED + 7
+    )
+    return joint, tuple(per_group)
+
+
+def test_full_attention_gives_up_only_one_hash_unit():
+    """Full attention matches the last whole shared block and drops one unit."""
+    manager = _manager(use_eagle=True)
+    _seed_owner(manager)
+    _joint, per_group = _follower(manager)
+    assert per_group[0] == BLOCK - HASH  # 12
+
+
+def test_mamba_alone_reaches_the_shared_block_boundary():
+    """Mamba never applies the drop, so on its own it keeps the whole block."""
+    manager = _manager(use_eagle=True)
+    _seed_owner(manager)
+    _joint, per_group = _follower(manager)
+    assert per_group[1] == BLOCK  # 16
+
+
+def test_without_eagle_the_hit_survives():
+    """No drop, so the two groups agree and the follower keeps the block."""
+    manager = _manager(use_eagle=False)
+    _seed_owner(manager)
+    joint, per_group = _follower(manager)
+    assert per_group == (BLOCK, BLOCK)
+    assert joint == BLOCK
+
+
+def test_reconciled_hit_is_currently_nothing():
+    """Today the two groups reconcile to zero: the follower recomputes it all.
+
+    Capped at full attention's 12, mamba's only lower position is 0.
+    """
+    manager = _manager(use_eagle=True)
+    _seed_owner(manager)
+    joint, _per_group = _follower(manager)
+    assert joint == 0
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="mamba materializes no state one hash unit below a block boundary, "
+    "so the reconciled hit falls to 0 even though both groups reached >= 12",
+)
+def test_reconciled_hit_should_reach_the_resume_point():
+    """What the follower should keep: the position EAGLE actually resumes from.
+
+    Both groups reach at least 12 on their own. A check-point at the owner's
+    prompt tail cannot supply this -- 40 and 36 are over the private suffix --
+    so the state has to exist one hash unit below the shared block boundary.
+    """
+    manager = _manager(use_eagle=True)
+    _seed_owner(manager)
+    joint, _per_group = _follower(manager)
+    assert joint == BLOCK - HASH  # 12

--- a/tests/v1/core/prefix_cache/test_mamba_align_sparse_keys.py
+++ b/tests/v1/core/prefix_cache/test_mamba_align_sparse_keys.py
@@ -1,0 +1,243 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Mamba "align" stores keys only at sparse boundaries; the KV-cache event
+stream indexes the hit list as a dense grid.
+
+Interior mamba blocks are null and carry no block hash -- that part is by design
+(``reachable_block_mask``). ``emit_cached_block_events`` then walks the hit list
+positionally, so for the mamba group it publishes a key per hit block. The keys
+it publishes are the wrong ones: the interior block that was never stored, and
+one past the end of the hit, while the group's only real key is omitted. When
+the consumer's prompt is not mamba-block-aligned the same walk indexes past the
+block-hash view and raises IndexError inside ``get_computed_blocks``.
+
+Requires ``kv_cache_report_mode = "full"`` (KV-cache events). CPU only.
+"""
+
+import pytest
+import torch
+
+from tests.v1.core.test_prefix_caching import make_kv_cache_manager, make_request
+from vllm.utils.hashing import sha256
+from vllm.v1.core.kv_cache_utils import (
+    get_block_hash,
+    get_group_id,
+    init_none_hash,
+    maybe_convert_block_hash,
+)
+from vllm.v1.kv_cache_interface import (
+    FullAttentionSpec,
+    KVCacheConfig,
+    KVCacheGroupSpec,
+    MambaSpec,
+)
+
+# (hash_block_size, full_attn_block_size, mamba_block_size)
+SIZES = [
+    pytest.param(2, 2, 4, id="toy"),
+    pytest.param(16, 64, 64, id="large-block"),
+]
+
+
+@pytest.fixture(autouse=True)
+def _auto_init_hash_fn():
+    init_none_hash(sha256)
+
+
+def _manager(hash_bs, fa_bs, mamba_bs, events=True, num_blocks=64):
+    cfg = KVCacheConfig(
+        num_blocks=num_blocks,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["full"],
+                FullAttentionSpec(
+                    block_size=fa_bs, num_kv_heads=1, head_size=1, dtype=torch.float32
+                ),
+            ),
+            KVCacheGroupSpec(
+                ["mamba"],
+                MambaSpec(
+                    block_size=mamba_bs,
+                    shapes=(1, 1),
+                    dtypes=(torch.float32,),
+                    mamba_cache_mode="align",
+                ),
+            ),
+        ],
+    )
+    return make_kv_cache_manager(
+        kv_cache_config=cfg,
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=hash_bs,
+        enable_kv_cache_events=events,
+    )
+
+
+def _produce(manager, tokens, hash_bs):
+    req = make_request("producer", tokens, hash_bs, sha256)
+    computed, num_computed, _ = manager.get_computed_blocks(req)
+    assert num_computed == 0
+    assert manager.allocate_slots(req, len(tokens), num_computed, computed) is not None
+    manager.free(req)
+    manager.new_step_starts()
+    manager.take_events()
+    return req
+
+
+# ---------------------------------------------------------------- PART 1 ----
+@pytest.mark.parametrize("hash_bs,fa_bs,mamba_bs", SIZES)
+def test_mamba_group_grid_is_sparse(hash_bs, fa_bs, mamba_bs):
+    """The mamba group stores ONE key (the prompt tail). Every interior mamba
+    block index of the same request carries no key at all."""
+    manager = _manager(hash_bs, fa_bs, mamba_bs, events=False)
+    n = mamba_bs + hash_bs  # 6 / 80: just over one mamba block
+    req = _produce(manager, list(range(n)), hash_bs)
+
+    key_at = {
+        t: req.block_hashes[t // hash_bs - 1] for t in range(hash_bs, n + 1, hash_bs)
+    }
+
+    # mamba: only the prompt-tail key exists.
+    have = [t for t, h in key_at.items() if manager.block_pool.get_cached_block(h, [1])]
+    assert have == [n], have
+    hit = manager.block_pool.get_cached_block(key_at[n], [1])[0]
+    assert get_group_id(hit.block_hash) == 1
+    assert get_block_hash(hit.block_hash) == key_at[n]
+    assert hit.block_hash_num_tokens == n
+
+    # mamba block index 0 covers tokens [0, mamba_bs) and would be keyed by the
+    # hash at mamba_bs tokens: never written (intermediate state snapshot).
+    assert manager.block_pool.get_cached_block(key_at[mamba_bs], [1]) is None
+
+
+# ---------------------------------------------------------------- PART 2 ----
+@pytest.mark.parametrize("hash_bs,fa_bs,mamba_bs", SIZES)
+@pytest.mark.xfail(
+    strict=True,
+    reason="emit_cached_block_events walks the hit list positionally: it publishes "
+    "mamba keys that were never stored and omits the one that was",
+)
+def test_emit_cached_block_events_invents_mamba_keys(hash_bs, fa_bs, mamba_bs):
+    """kv_cache_report_mode='full' publishes mamba keys that were never stored,
+    over a token range that was never hit."""
+    manager = _manager(hash_bs, fa_bs, mamba_bs)
+    n = mamba_bs + hash_bs
+    _produce(manager, list(range(n)), hash_bs)
+
+    req1 = make_request("consumer", list(range(2 * mamba_bs)), hash_bs, sha256)
+    req1.kv_cache_report_mode = "full"
+    blocks, num_computed, _ = manager.get_computed_blocks(req1)
+    assert num_computed == n, num_computed
+    assert len(blocks.blocks[1]) == 2  # [null, hit] -- 2 blocks for an n-token hit
+
+    stored = [e for e in manager.take_events() if type(e).__name__ == "BlockStored"]
+    mamba_event = {e.group_idx: e for e in stored}[1]
+    emitted = list(mamba_event.block_hashes)
+
+    real_key = maybe_convert_block_hash(req1.block_hashes[n // hash_bs - 1])
+    beyond_the_hit = maybe_convert_block_hash(
+        req1.block_hashes[2 * mamba_bs // hash_bs - 1]
+    )
+    assert manager.block_pool.get_cached_block(req1.block_hashes[n // hash_bs - 1], [1])
+    assert (
+        manager.block_pool.get_cached_block(
+            req1.block_hashes[mamba_bs // hash_bs - 1], [1]
+        )
+        is None
+    )
+    assert (
+        manager.block_pool.get_cached_block(
+            req1.block_hashes[2 * mamba_bs // hash_bs - 1], [1]
+        )
+        is None
+    )
+
+    assert real_key in emitted, (
+        f"mamba group's only stored key (at {n} tokens) was not published"
+    )
+    assert beyond_the_hit not in emitted, (
+        f"published a key at {2 * mamba_bs} tokens; hit was only {n}"
+    )
+
+
+@pytest.mark.parametrize("hash_bs,fa_bs,mamba_bs", SIZES)
+def test_emit_cached_block_events_current_shape(hash_bs, fa_bs, mamba_bs):
+    """What main emits today. Unmarked, so it goes red when the shape changes."""
+    manager = _manager(hash_bs, fa_bs, mamba_bs)
+    n = mamba_bs + hash_bs
+    _produce(manager, list(range(n)), hash_bs)
+
+    req1 = make_request("consumer", list(range(2 * mamba_bs)), hash_bs, sha256)
+    req1.kv_cache_report_mode = "full"
+    manager.get_computed_blocks(req1)
+    stored = [e for e in manager.take_events() if type(e).__name__ == "BlockStored"]
+    mamba_event = {e.group_idx: e for e in stored}[1]
+
+    never_stored_interior = maybe_convert_block_hash(
+        req1.block_hashes[mamba_bs // hash_bs - 1]
+    )
+    beyond_the_hit = maybe_convert_block_hash(
+        req1.block_hashes[2 * mamba_bs // hash_bs - 1]
+    )
+    assert list(mamba_event.block_hashes) == [never_stored_interior, beyond_the_hit]
+    assert len(mamba_event.token_ids) == 2 * mamba_bs
+
+
+@pytest.mark.parametrize("hash_bs,fa_bs,mamba_bs", SIZES)
+@pytest.mark.xfail(
+    strict=True,
+    raises=IndexError,
+    reason="the same positional walk indexes past the block-hash view and raises "
+    "IndexError inside get_computed_blocks",
+)
+def test_emit_cached_block_events_indexerror_on_unaligned_prompt(
+    hash_bs, fa_bs, mamba_bs
+):
+    """The dense-grid index walks off the end of the block-hash view -> crash
+    inside Scheduler.schedule()."""
+    manager = _manager(hash_bs, fa_bs, mamba_bs)
+    n = mamba_bs + hash_bs
+    _produce(manager, list(range(n)), hash_bs)
+
+    # Consumer prompt = n + 1 tokens: floor(len/mamba_bs) == 1 mamba-granular
+    # hash, but the mamba hit list is 2 long.
+    req1 = make_request("consumer", list(range(n + 1)), hash_bs, sha256)
+    req1.kv_cache_report_mode = "full"
+    blocks, num_computed, _ = manager.get_computed_blocks(req1)
+    assert num_computed == n, num_computed
+
+
+# ---------------------------------------------------------------- PART 3 ----
+@pytest.mark.xfail(
+    strict=True,
+    reason="invented keys are not specific to partial matching; reproduces with "
+    "no prefix_match_unit set",
+)
+def test_plain_mamba_align_no_partial_hash_also_invents_keys():
+    """No prefix_match_unit at all (hash_block_size == every block_size):
+    align mode still leaves interior mamba blocks null/unkeyed, and the event
+    stream still publishes a key for each of them."""
+    bs = 4
+    manager = _manager(bs, bs, bs, events=True)
+    _produce(manager, list(range(2 * bs)), bs)  # 8 tokens
+
+    assert not manager.coordinator.enable_partial_hash_hits
+
+    req1 = make_request("consumer", list(range(3 * bs)), bs, sha256)
+    req1.kv_cache_report_mode = "full"
+    blocks, num_computed, _ = manager.get_computed_blocks(req1)
+    assert num_computed == 2 * bs
+    assert len(blocks.blocks[1]) == 2
+    assert blocks.blocks[1][0].is_null  # interior mamba block: null, no key
+
+    h4, h8 = req1.block_hashes[0], req1.block_hashes[1]
+    assert manager.block_pool.get_cached_block(h8, [1]) is not None
+    assert manager.block_pool.get_cached_block(h4, [1]) is None  # never stored
+
+    stored = [e for e in manager.take_events() if type(e).__name__ == "BlockStored"]
+    emitted = list({e.group_idx: e for e in stored}[1].block_hashes)
+    assert maybe_convert_block_hash(h4) not in emitted, (
+        "published a mamba key for a null (never-written) block"
+    )


### PR DESCRIPTION
Tests only, no production change. Three properties of mamba `align` + EAGLE/MTP prefix caching, pinned as executable assertions so a fix can be judged against them.

CPU only: drives the KV-cache manager through the existing `make_kv_cache_manager` / `make_request` harness. No model execution, no GPU.

```
11 passed, 7 xfailed
```

**How to read the table.** A test that **passes** on `main` is pinning behaviour as it is today — it goes red if that behaviour changes, intentionally or not. A test marked **xfail** is asserting the behaviour we want and does not get it; it carries `xfail(strict=True)`, so CI stays green now, and when a fix lands the test XPASSes and `strict` turns that into a failure — the marker has to be removed together with the fix. Nothing here is expected to be red on `main`.

---

## 1. The EAGLE drop costs a whole block, not one hash unit

`tests/v1/core/prefix_cache/test_eagle_mamba_drop_cost.py` — block 16, hash unit 4, producer caches 48 tokens (three whole blocks), consumer shares all 48.

`prefix_match_unit` exists so the drop costs one hash unit rather than one cache block. It does that for full attention, but not for the reconciled hit: mamba is capped at the attention candidate (44) and its state exists only at 16/32/48, so its lookup falls back to 32.

| test | what it measures | on `main` |
|------|------------------|-----------|
| `test_full_attention_gives_up_only_one_hash_unit` | full attention's own hit is `48 - 4 = 44` — the drop is one hash unit, as designed | **passes** |
| `test_mamba_alone_reaches_the_full_prefix` | mamba's own hit is `48` — `MambaManager` ignores `drop_eagle_block` | **passes** |
| `test_without_eagle_nothing_is_given_up` | with EAGLE off the joint hit is `48`, isolating the drop as the cause | **passes** |
| `test_reconciled_hit_should_not_give_up_a_whole_block` | joint hit should be `44`; it is `32`. Also asserts every group returned enough blocks to cover the hit | **xfail** |

Neither group gives up a block on its own — it is given up in the reconciliation.

---

## 2. Sparse mamba keys walked as if they were a dense grid

`tests/v1/core/prefix_cache/test_mamba_align_sparse_keys.py` — parametrised over two shapes, `[toy]` (hash 2, attention block 2, mamba block 4) and `[large-block]` (hash 16, attention block 64, mamba block 64), so nothing depends on one set of sizes.

Under `align`, interior mamba blocks are null and carry no key on purpose — the group's only hittable positions are chunk ends. `emit_cached_block_events` walks the hit list positionally, as though every index carried a key.

| test | what it measures | on `main` |
|------|------------------|-----------|
| `test_mamba_group_grid_is_sparse[toy]` / `[large-block]` | the mamba group stores exactly one key (the prompt tail); the interior block index has none | **passes** |
| `test_emit_cached_block_events_current_shape[toy]` / `[large-block]` | what the event stream emits today — the two invented keys, and a `token_ids` span twice the length of the hit. Unmarked, so it goes red the moment the shape changes | **passes** |
| `test_emit_cached_block_events_invents_mamba_keys[toy]` / `[large-block]` | the published set should contain the one key that was stored and should not contain a key beyond the hit; today it is the reverse | **xfail** |
| `test_emit_cached_block_events_indexerror_on_unaligned_prompt[toy]` / `[large-block]` | on a prompt not aligned to the mamba block the same walk runs off the end of the block-hash view and raises `IndexError` inside `get_computed_blocks`. Pinned with `raises=IndexError` so a different exception is a failure, not a silent pass | **xfail** |
| `test_plain_mamba_align_no_partial_hash_also_invents_keys` | the same invented key with **no** `prefix_match_unit` set at all (`hash_block_size == block_size`), so this is not a partial-matching-only problem | **xfail** |

Requires `kv_cache_report_mode="full"` to observe, except the last, which needs only `align`.

---

## 3. The same drop, when the shared prefix ends before the producer's prompt

`tests/v1/core/prefix_cache/test_eagle_mamba_shared_system_prompt.py` — block 16, hash unit 4, producer prompt 40 = 24 shared + 16 private, consumer shares the first 24.

Section 1 uses a producer whose whole prompt _is_ the shared prefix. A served system prompt is the other shape: every request opens with the same preamble and then diverges, so the producer's prompt tail sits over tokens no consumer shares. The shared prefix ends mid-block (`24 % 16 = 8`), so full attention stops at the last whole shared block (16) and the drop takes it to 12; mamba has state at 0 and 16 only, and capped at 12 it can only fall back to 0.

| test | what it measures | on `main` |
|------|------------------|-----------|
| `test_full_attention_gives_up_only_one_hash_unit` | full attention's own hit is `16 - 4 = 12` | **passes** |
| `test_mamba_alone_reaches_the_shared_block_boundary` | mamba's own hit is `16` | **passes** |
| `test_without_eagle_the_hit_survives` | with EAGLE off both groups reach 16 and the joint hit is `16` | **passes** |
| `test_reconciled_hit_is_currently_nothing` | the joint hit today is `0` — the consumer recomputes the entire shared prefix. Unmarked, so it goes red when this improves | **passes** |
| `test_reconciled_hit_should_reach_the_resume_point` | joint hit should be `12`, the position EAGLE resumes from | **xfail** |

Here the drop does not cost a block — it costs the **entire** hit, while both groups independently reach at least 12.

The distinction between this and section 1 matters for where a fix puts the state: a check-point at the producer's prompt **tail** cannot serve this shape, because 40 — and 36, one hash unit below it — are both over the private suffix. The state has to exist one hash unit below the shared _block_ boundary.