### PR TITLE
[MRV2] Support attention-free models

### DIFF
--- a/tests/v1/e2e/general/test_mamba_prefix_cache.py
+++ b/tests/v1/e2e/general/test_mamba_prefix_cache.py
@@ -873,6 +873,10 @@ def get_mamba_prefix_cache_step_configs(
 def _run_mamba_prefix_cache_mrv1(
     monkeypatch: pytest.MonkeyPatch, async_scheduling: bool
 ):
+    # This test patches the V1 model runner, so pin V1 explicitly: MoE/hybrid
+    # models like Qwen3-Next now default to the V2 runner.
+    monkeypatch.setenv("VLLM_USE_V2_MODEL_RUNNER", "0")
+    envs.disable_envs_cache()
     global async_scheduling_mode
     async_scheduling_mode = async_scheduling
     run_ref_mamba_state_in_subprocess()

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -372,7 +372,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
 
         self.model_memory_usage = m.consumed_memory
         logger.info(
-            "Model loading took %s GiB and %.6f seconds",
+            "Model loading took %s GiB memory and %.6f seconds",
             format_gib(m.consumed_memory),
             time_after_load - time_before_load,
         )
@@ -1889,6 +1889,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         """Release GPU tensors (model weights, KV caches, workspace) so that
         memory is reclaimable when running in the same process."""
         torch.accelerator.synchronize()
+        self.cudagraph_manager = None
         if hasattr(self, "kv_caches"):
             self.kv_caches.clear()
         if hasattr(self, "attn_groups"):

--- a/vllm/v1/worker/gpu/model_states/__init__.py
+++ b/vllm/v1/worker/gpu/model_states/__init__.py
@@ -33,7 +33,7 @@ def init_model_state(
 
         return EncoderOnlyModelState(vllm_config, model, encoder_cache, device)
 
-    if vllm_config.model_config.is_hybrid:
+    if vllm_config.model_config.is_hybrid or vllm_config.model_config.is_attention_free:
         from vllm.v1.worker.gpu.model_states.mamba_hybrid import MambaHybridModelState
 
         return MambaHybridModelState(vllm_config, model, encoder_cache, device)


### PR DESCRIPTION
These use `MambaHybridModelState`

And other minor changes for CI compatibility when switching to MRV2 by default.

These are split out from https://github.com/vllm-project/vllm/pull/46646.