### PR TITLE
Harden Kimi K3 packed decode grid

### DIFF
--- a/tests/models/kimi_k3/test_kda.py
+++ b/tests/models/kimi_k3/test_kda.py
@@ -388,6 +388,29 @@ def test_packed_kda_decode_correctness(
     assert_close("ht", dense_state, packed_state, 1e-3, err_atol=1e-3)
 
 
+@pytest.mark.parametrize("impl", PACKED_DECODE_IMPLS.keys())
+@torch.inference_mode()
+def test_packed_kda_decode_supports_large_batch_head_grid(impl: str):
+    H, D = 96, 128
+    num_seqs = 65535 // H + 1
+
+    def empty(*shape: int, dtype: torch.dtype = torch.bfloat16):
+        return torch.empty(*shape, dtype=dtype, device=DEVICE)
+
+    packed_out, _ = PACKED_DECODE_IMPLS[impl](
+        mixed_qkv=empty(num_seqs, 3 * H * D),
+        raw_g=empty(1, num_seqs, H, D),
+        raw_beta=empty(1, num_seqs, H),
+        A_log=empty(H, dtype=torch.float32),
+        dt_bias=empty(H, D, dtype=torch.float32),
+        lower_bound=-5.0,
+        initial_state=empty(1, H, D, D, dtype=torch.float32),
+        state_indices=torch.zeros(num_seqs, dtype=torch.int32, device=DEVICE),
+    )
+
+    assert packed_out.count_nonzero().item() == 0
+
+
 @pytest.mark.parametrize(
     ("H", "fuse_gate"),
     [(12, True), (12, False), (12, None), (96, None)],

--- a/vllm/models/kimi_k3/amd/ops/third_party/kda/fused_recurrent.py
+++ b/vllm/models/kimi_k3/amd/ops/third_party/kda/fused_recurrent.py
@@ -468,7 +468,9 @@ def fused_recurrent_kda_packed_decode_kernel(
     SOFTPLUS_THRESHOLD: tl.constexpr,
     USE_LOWER_BOUND: tl.constexpr,
 ):
-    i_v, i_nh = tl.program_id(0), tl.program_id(1)
+    pid = tl.program_id(0)
+    i_v = pid % tl.cdiv(V, BV)
+    i_nh = pid // tl.cdiv(V, BV)
     i_n, i_h = i_nh // H, i_nh % H
 
     o_k = tl.arange(0, BK)
@@ -593,7 +595,7 @@ def fused_recurrent_kda_packed_decode(
         scale = K**-0.5
 
     out = torch.empty((1, B, H, V), dtype=mixed_qkv.dtype, device=device)
-    grid = (cdiv(V, BV), B * H)
+    grid = (cdiv(V, BV) * B * H,)
     fused_recurrent_kda_packed_decode_kernel[grid](
         mixed_qkv=mixed_qkv,
         raw_g=raw_g,

--- a/vllm/models/kimi_k3/nvidia/ops/third_party/kda/fused_recurrent.py
+++ b/vllm/models/kimi_k3/nvidia/ops/third_party/kda/fused_recurrent.py
@@ -511,7 +511,9 @@ def fused_recurrent_kda_packed_decode_kernel(
     USE_LOWER_BOUND: tl.constexpr,
     launch_pdl: tl.constexpr,
 ):
-    i_v, i_nh = tl.program_id(0), tl.program_id(1)
+    pid = tl.program_id(0)
+    i_v = pid % tl.cdiv(V, BV)
+    i_nh = pid // tl.cdiv(V, BV)
     i_n, i_h = i_nh // H, i_nh % H
 
     o_k = tl.arange(0, BK)
@@ -640,7 +642,7 @@ def fused_recurrent_kda_packed_decode(
         scale = K**-0.5
 
     out = torch.empty((1, B, H, V), dtype=mixed_qkv.dtype, device=device)
-    grid = (cdiv(V, BV), B * H)
+    grid = (cdiv(V, BV) * B * H,)
     fused_recurrent_kda_packed_decode_kernel[grid](
         mixed_qkv=mixed_qkv,
         raw_g=raw_g,


### PR DESCRIPTION

## Purpose

The Kimi K3 packed KDA decode Triton kernels launch a two-dimensional
`(value_tiles, batch * heads)` grid. Encoding all token-head pairs in `grid.y`
creates a latent reliability limit because CUDA caps that dimension at 65,535
blocks.

This is defensive hardening rather than a bug expected under normal production
conditions. Typical Kimi K3 deployments shard the 96 heads across TP ranks,
schedule far fewer sequences than the resulting boundary, and use the native
fused-decode path for standard BF16 B300 serving. The limit can still matter to
non-default fallback configurations or future deployments with larger batch
limits, so the Triton path should not rely on it.

Flatten the launch onto `grid.x` and recover the value-tile and token-head
indices from the linear program ID. This removes the restrictive grid
dimension without changing the original value-tile-major program ordering.
Apply the same change to the separately vendored NVIDIA and AMD kernels.

Add a synthetic boundary regression at `B=683`, `H=96`, where the previous
layout requires 65,568 `grid.y` blocks. This is intentionally not presented as
a representative production configuration. It uses null state slots to check
the launch reliability guarantee without requiring a recurrent cache
proportional to the number of sequences. The test covers both packed-decode
implementations.

This does not duplicate an existing PR. Searches for open Kimi K3/KDA packed
decode grid fixes found none. #51183 modifies the same two kernel files to add
an output-buffer parameter, but retains the affected launch grid and addresses
a separate device-copy optimization.

## Test Plan

Run the modified-file hooks:

```bash
.venv/bin/pre-commit run --files \
  tests/models/kimi_k3/test_kda.py \
  vllm/models/kimi_k3/nvidia/ops/third_party/kda/fused_recurrent.py \
  vllm/models/kimi_k3/amd/ops/third_party/kda/fused_recurrent.py
```

Run the packed KDA decode correctness and launch-boundary tests on a GPU:

```bash
.venv/bin/python -m pytest tests/models/kimi_k3/test_kda.py -v \
  -k packed_kda_decode
```

No full-model evaluation is planned. This change only remaps independent
Triton program IDs and does not change the KDA math, tensor layouts, or kernel
selection. A standard BF16 B300 model run would take the native fused-decode
path and would not exercise this fallback kernel; the targeted GPU tests above
provide the relevant coverage.

## Test Result

- Modified-file pre-commit hooks: passed, including Ruff, formatting, typos,
  mypy, SPDX, and repository-specific checks.
- `git diff --check`: passed.
- Pytest collection: 26 packed-decode cases collected successfully, including
  the NVIDIA and AMD large-batch boundary cases.
- GPU pytest execution on NVIDIA B300 SXM6 AC: 26 passed, 27 deselected in
  33.67 seconds. This includes both synthetic large-batch boundary cases and
  both vendored Triton implementations. The AMD implementation was JIT-compiled
  with Triton's CUDA backend on the B300; ROCm/HIP code generation was not
  tested locally and remains covered by ROCm CI.
- Model evaluation: not applicable. The launch topology changes, but the KDA
  computation and model outputs do not; the direct kernel correctness tests
  compare outputs and recurrent state for both vendored implementations.

## AI Assistance

AI assistance was used.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR and the non-duplication check are documented.
- [x] The test plan includes concrete commands.
- [x] GPU test results are recorded; model evaluation is documented as not
  applicable.
- [x] No documentation update is needed because this changes only an internal
  kernel launch layout.

</details>
