### PR TITLE
[Bugfix][LoRA] Disable encoder graphs for tower LoRA

### DIFF
--- a/.buildkite/test_areas/lora.yaml
+++ b/.buildkite/test_areas/lora.yaml
@@ -8,6 +8,9 @@ steps:
   timeout_in_minutes: 40
   source_file_dependencies:
   - vllm/lora
+  - vllm/v1/worker/encoder_cudagraph.py
+  - vllm/v1/worker/gpu_model_runner.py
+  - vllm/v1/worker/gpu/model_states/interface.py
   - tests/lora
   commands:
     - pytest -v -s lora --shard-id=$$BUILDKITE_PARALLEL_JOB --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT --ignore=lora/test_chatglm3_tp.py --ignore=lora/test_llama_tp.py --ignore=lora/test_qwen3_with_multi_loras.py --ignore=lora/test_olmoe_tp.py --ignore=lora/test_deepseekv2_tp.py --ignore=lora/test_gptoss_tp.py --ignore=lora/test_qwen3moe_tp.py --ignore=lora/test_qwen35_densemodel_lora.py 
@@ -20,6 +23,9 @@ steps:
       timeout_in_minutes: 85
       source_file_dependencies:
       - vllm/lora
+      - vllm/v1/worker/encoder_cudagraph.py
+      - vllm/v1/worker/gpu_model_runner.py
+      - vllm/v1/worker/gpu/model_states/interface.py
       - tests/lora
       - vllm/platforms/rocm.py
       depends_on:

--- a/tests/lora/test_qwenvl.py
+++ b/tests/lora/test_qwenvl.py
@@ -22,6 +22,7 @@ class TestConfig:
     max_loras: int = 2
     max_lora_rank: int = 32
     enable_tower_connector_lora: bool = False
+    compilation_config: dict[str, object] | None = None
     max_model_len: int = 8192
     gpu_memory_utilization: float = 0.85
     mm_processor_kwargs: dict[str, object] | None = None
@@ -45,6 +46,10 @@ class TestConfig:
                 }
 
 
+def _has_v2_encoder_cudagraph(worker) -> bool:
+    return worker.model_runner.model_state.encoder_runner.has_cudagraph()
+
+
 class Qwen2VLTester:
     """Test helper for Qwen2 VL models with LoRA"""
 
@@ -64,6 +69,7 @@ class Qwen2VLTester:
             max_loras=config.max_loras,
             max_lora_rank=config.max_lora_rank,
             enable_tower_connector_lora=config.enable_tower_connector_lora,
+            compilation_config=config.compilation_config,
             gpu_memory_utilization=config.gpu_memory_utilization,
             mm_processor_kwargs=config.mm_processor_kwargs,
             mm_processor_cache_gb=config.mm_processor_cache_gb,
@@ -73,6 +79,9 @@ class Qwen2VLTester:
     @property
     def llm(self) -> vllm.LLM:
         return self._runner.get_llm()
+
+    def has_v2_encoder_cudagraph(self) -> list[bool]:
+        return self._runner.collective_rpc(_has_v2_encoder_cudagraph)
 
     def __enter__(self) -> "Qwen2VLTester":
         return self
@@ -185,6 +194,13 @@ QWEN2VL_MODEL_PATH = "Qwen/Qwen2-VL-2B-Instruct"
 QWEN25VL_MODEL_PATH = "Qwen/Qwen2.5-VL-3B-Instruct"
 QWEN3VL_MODEL_PATH = "Qwen/Qwen3-VL-4B-Instruct"
 
+ENCODER_CUDAGRAPH_COMPILATION_CONFIG: dict[str, object] = {
+    "cudagraph_mm_encoder": True,
+    "cudagraph_capture_sizes": [4],
+    "encoder_cudagraph_token_budgets": [2048],
+    "encoder_cudagraph_max_vision_items_per_batch": 2,
+}
+
 
 def _enable_deterministic_lora_shrink(monkeypatch: pytest.MonkeyPatch) -> None:
     # These tests assert exact greedy outputs. Force the Triton LoRA shrink
@@ -290,6 +306,7 @@ def test_qwen2vl_multiple_lora_types(
     qwen2vl_language_lora_files,
     qwen2vl_vision_tower_connector_lora_files,
     qwen2vl_vision_tower_lora_files,
+    enable_pickle,
     monkeypatch: pytest.MonkeyPatch,
 ):
     """
@@ -302,6 +319,9 @@ def test_qwen2vl_multiple_lora_types(
     language-only and vision-enabled LoRA adapters.
     """
     _enable_deterministic_lora_shrink(monkeypatch)
+    test_encoder_cudagraph = current_platform.is_cuda()
+    if test_encoder_cudagraph:
+        monkeypatch.setenv("VLLM_USE_V2_MODEL_RUNNER", "1")
 
     config = TestConfig(
         model_path=QWEN2VL_MODEL_PATH,
@@ -313,6 +333,9 @@ def test_qwen2vl_multiple_lora_types(
         # TODO: Remove this restriction
         mm_processor_cache_gb=0,
         enable_tower_connector_lora=True,
+        compilation_config=(
+            ENCODER_CUDAGRAPH_COMPILATION_CONFIG if test_encoder_cudagraph else None
+        ),
     )
     with Qwen2VLTester(config) as tester:
         # Test 1: Language-only LoRA adapter
@@ -344,3 +367,8 @@ def test_qwen2vl_multiple_lora_types(
                 lora_id=lora_id,
                 lora_name="vision_tower",
             )
+
+        if test_encoder_cudagraph:
+            graph_states = tester.has_v2_encoder_cudagraph()
+            assert graph_states, "collective_rpc returned no workers"
+            assert not any(graph_states)

--- a/tests/v1/worker/test_encoder_runner.py
+++ b/tests/v1/worker/test_encoder_runner.py
@@ -1,23 +1,26 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""Tests for EncoderRunner.gather_mm_embeddings (model runner V2).
+"""Tests for multimodal encoder execution in model runner V2.
 
-Covers the speculative-drafter encoder-cache handling: the drafter reads one
-position ahead of the target model (``draft_lookahead``). The +1 look-ahead
-feature past the processed boundary is used when its encoder output is present
-and tolerated (token-embedding fallback) when it is not, while a miss within
-the processed range still fails loudly.
+Covers encoder CUDA graph selection, encoder cache execution and gathering,
+speculative-drafter look-ahead, and encoder timing.
 """
 
-from unittest.mock import MagicMock
+from types import SimpleNamespace
+from unittest.mock import MagicMock, Mock
 
 import numpy as np
 import pytest
 import torch
+from torch import nn
 
 from vllm.multimodal.inputs import MultiModalFeatureSpec, PlaceholderRange
+from vllm.v1.worker.encoder_cudagraph import (
+    ENCODER_CUDAGRAPH_TOWER_CONNECTOR_LORA_WARNING,
+)
 from vllm.v1.worker.gpu.mm.encoder_cache import EncoderCache
 from vllm.v1.worker.gpu.mm.encoder_runner import EncoderRunner
+from vllm.v1.worker.gpu.model_states import interface as model_state_module
 from vllm.v1.worker.gpu.model_states.interface import ModelState
 
 pytestmark = pytest.mark.cpu_test
@@ -184,6 +187,77 @@ def test_gather_preserves_mixed_modalities():
     assert len(mm_embeds) == 2
     assert [e.modality for e in mm_embeds] == ["video", "audio"]
     assert int(is_mm_embed.sum()) == 8
+
+
+class _TestModelState(ModelState):
+    def get_mm_embeddings(self, *args, **kwargs):
+        return None
+
+    def prepare_inputs(self, *args, **kwargs):
+        return {}
+
+    def prepare_dummy_inputs(self, *args, **kwargs):
+        return {}
+
+    def prepare_attn(self, *args, **kwargs):
+        return {}
+
+
+@pytest.mark.parametrize(
+    "supports_tower_connector_lora",
+    [None, False, True],
+    ids=["no-mm-lora-support", "language-only", "tower-connector"],
+)
+def test_model_state_encoder_cudagraph_respects_tower_connector_lora(
+    monkeypatch: pytest.MonkeyPatch,
+    supports_tower_connector_lora: bool | None,
+):
+    model = nn.Module()
+    lora_manager = SimpleNamespace()
+    if supports_tower_connector_lora is not None:
+        lora_manager.supports_tower_connector_lora = supports_tower_connector_lora
+    model.lora_manager = lora_manager
+    vllm_config = SimpleNamespace(
+        model_config=SimpleNamespace(
+            dtype=torch.float32,
+            enforce_eager=False,
+            max_model_len=64,
+            get_inputs_embeds_size=lambda: HIDDEN,
+        ),
+        scheduler_config=SimpleNamespace(
+            max_num_seqs=2,
+            max_num_batched_tokens=64,
+        ),
+        compilation_config=SimpleNamespace(cudagraph_mm_encoder=True),
+        observability_config=None,
+    )
+    cudagraph_manager = object()
+    manager_cls = Mock(return_value=cudagraph_manager)
+    warning_once = Mock()
+
+    monkeypatch.setattr(
+        model_state_module, "supports_encoder_cudagraph", lambda model: True
+    )
+    monkeypatch.setattr(model_state_module, "EncoderCudaGraphManager", manager_cls)
+    monkeypatch.setattr(model_state_module.logger, "warning_once", warning_once)
+
+    state = _TestModelState(
+        vllm_config=vllm_config,
+        model=model,
+        encoder_cache=EncoderCache(),
+        device=torch.device("cpu"),
+    )
+
+    if supports_tower_connector_lora:
+        manager_cls.assert_not_called()
+        warning_once.assert_called_once_with(
+            ENCODER_CUDAGRAPH_TOWER_CONNECTOR_LORA_WARNING
+        )
+        assert not state.encoder_runner.has_cudagraph()
+    else:
+        manager_cls.assert_called_once()
+        warning_once.assert_not_called()
+        assert state.encoder_runner.cudagraph_manager is cudagraph_manager
 
 
 def test_execute_mm_encoder_caches_outputs_without_gathering():

--- a/tests/v1/worker/test_gpu_model_runner.py
+++ b/tests/v1/worker/test_gpu_model_runner.py
@@ -9,6 +9,8 @@ import numpy as np
 import pytest
 import torch
 
+import vllm.model_executor.models.interfaces as model_interfaces
+import vllm.v1.worker.encoder_cudagraph as encoder_cudagraph_module
 import vllm.v1.worker.gpu_model_runner as gpu_model_runner_module
 from vllm.config import (
     AttentionConfig,
@@ -51,6 +53,9 @@ from vllm.v1.worker.block_table import (
     MultiGroupBlockTable,
     SlotMappingMode,
     get_block_table_width,
+)
+from vllm.v1.worker.encoder_cudagraph import (
+    ENCODER_CUDAGRAPH_TOWER_CONNECTOR_LORA_WARNING,
 )
 from vllm.v1.worker.gpu.lora_utils import LoraState
 from vllm.v1.worker.gpu.mm.encoder_cache import EncoderCache
@@ -368,6 +373,71 @@ def test_sample_tokens_skips_pp_group_lookup_without_async_scheduling(
 
     output = GPUModelRunner.sample_tokens(runner, None)
     assert output in (EMPTY_MODEL_RUNNER_OUTPUT, None)
+
+
+@pytest.mark.skip_global_cleanup
+@pytest.mark.parametrize(
+    ("model_supports_cudagraph", "supports_tower_connector_lora"),
+    [(False, True), (True, False), (True, True)],
+    ids=["unsupported-model", "language-only", "tower-connector"],
+)
+def test_encoder_cudagraph_manager_respects_model_and_lora_support(
+    monkeypatch: pytest.MonkeyPatch,
+    model_supports_cudagraph: bool,
+    supports_tower_connector_lora: bool,
+):
+    runner = GPUModelRunner.__new__(GPUModelRunner)
+    runner.compilation_config = SimpleNamespace(cudagraph_mm_encoder=True)
+    runner.supports_mm_inputs = True
+    runner.vllm_config = object()
+    runner.device = torch.device("cpu")
+    runner.dtype = torch.float32
+    runner.lora_config = object()
+    runner.lora_manager = Mock()
+    runner.lora_manager.supports_tower_connector_lora.return_value = (
+        supports_tower_connector_lora
+    )
+    model = object()
+    runner.get_model = Mock(return_value=model)
+    supports_cudagraph = Mock(return_value=model_supports_cudagraph)
+    cudagraph_manager = object()
+    manager_cls = Mock(return_value=cudagraph_manager)
+    warning_once = Mock()
+
+    monkeypatch.setattr(
+        model_interfaces, "supports_encoder_cudagraph", supports_cudagraph
+    )
+    monkeypatch.setattr(
+        encoder_cudagraph_module, "EncoderCudaGraphManager", manager_cls
+    )
+    monkeypatch.setattr(gpu_model_runner_module.logger, "warning_once", warning_once)
+
+    result = runner._create_encoder_cudagraph_manager()
+
+    runner.get_model.assert_called_once_with()
+    supports_cudagraph.assert_called_once_with(model)
+    if not model_supports_cudagraph:
+        assert result is None
+        runner.lora_manager.supports_tower_connector_lora.assert_not_called()
+        manager_cls.assert_not_called()
+        warning_once.assert_not_called()
+    elif supports_tower_connector_lora:
+        assert result is None
+        runner.lora_manager.supports_tower_connector_lora.assert_called_once_with()
+        manager_cls.assert_not_called()
+        warning_once.assert_called_once_with(
+            ENCODER_CUDAGRAPH_TOWER_CONNECTOR_LORA_WARNING
+        )
+    else:
+        assert result is cudagraph_manager
+        runner.lora_manager.supports_tower_connector_lora.assert_called_once_with()
+        manager_cls.assert_called_once_with(
+            vllm_config=runner.vllm_config,
+            device=runner.device,
+            dtype=runner.dtype,
+            model=model,
+        )
+        warning_once.assert_not_called()
 
 
 def test_select_common_block_size_no_valid_option():

--- a/vllm/v1/worker/encoder_cudagraph.py
+++ b/vllm/v1/worker/encoder_cudagraph.py
@@ -26,6 +26,11 @@ from vllm.v1.worker.encoder_cudagraph_defs import (
 
 logger = init_logger(__name__)
 
+ENCODER_CUDAGRAPH_TOWER_CONNECTOR_LORA_WARNING = (
+    "`cudagraph_mm_encoder` is incompatible with "
+    "`enable_tower_connector_lora`; using eager encoder execution."
+)
+
 
 @dataclass
 class BudgetGraphMetadata:

--- a/vllm/v1/worker/gpu/model_states/interface.py
+++ b/vllm/v1/worker/gpu/model_states/interface.py
@@ -8,6 +8,7 @@ import torch.nn as nn
 
 from vllm.config import VllmConfig
 from vllm.config.compilation import CUDAGraphMode
+from vllm.logger import init_logger
 from vllm.model_executor.models.interfaces import (
     SupportsEncoderCudaGraph,
     supports_encoder_cudagraph,
@@ -16,12 +17,17 @@ from vllm.tasks import GenerationTask
 from vllm.v1.attention.backend import AttentionCGSupport
 from vllm.v1.core.sched.output import NewRequestData
 from vllm.v1.kv_cache_interface import KVCacheConfig
-from vllm.v1.worker.encoder_cudagraph import EncoderCudaGraphManager
+from vllm.v1.worker.encoder_cudagraph import (
+    ENCODER_CUDAGRAPH_TOWER_CONNECTOR_LORA_WARNING,
+    EncoderCudaGraphManager,
+)
 from vllm.v1.worker.gpu.input_batch import InputBatch
 from vllm.v1.worker.gpu.mm.encoder_cache import EncoderCache
 from vllm.v1.worker.gpu.mm.encoder_runner import EncoderRunner
 from vllm.v1.worker.gpu.states import RequestState
 from vllm.v1.worker.utils import AttentionGroup
+
+logger = init_logger(__name__)
 
 
 class ModelSpecificAttnMetadata:
@@ -69,6 +75,19 @@ class ModelState(ABC):
                 and vllm_config.compilation_config.cudagraph_mm_encoder
                 and supports_encoder_cudagraph(model)
             )
+            # The model-attached LoRAModelManager exposes this as a bool;
+            # WorkerLoRAManager exposes the same name as a method in V1.
+            lora_manager = getattr(model, "lora_manager", None)
+            if (
+                enable_encoder_cuda_graph
+                and lora_manager is not None
+                and getattr(lora_manager, "supports_tower_connector_lora", False)
+            ):
+                # Capture does not install a valid tower/connector mapping,
+                # while replay may reorder or split media independently of it.
+                logger.warning_once(ENCODER_CUDAGRAPH_TOWER_CONNECTOR_LORA_WARNING)
+                enable_encoder_cuda_graph = False
+
             cudagraph_manager = (
                 EncoderCudaGraphManager(
                     vllm_config=vllm_config,

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -6749,11 +6749,20 @@ class GPUModelRunner(
             supports_encoder_cudagraph,
         )
         from vllm.v1.worker.encoder_cudagraph import (
+            ENCODER_CUDAGRAPH_TOWER_CONNECTOR_LORA_WARNING,
             EncoderCudaGraphManager,
         )
 
         raw_model = self.get_model()
         if not supports_encoder_cudagraph(raw_model):
+            return None
+
+        # Encoder graph capture has no explicit tower/connector-LoRA setup,
+        # and replay may reorder or split the scheduler-ordered LoRA mapping.
+        # Keep this configuration on the eager encoder path until capture and
+        # per-graph-batch mappings both support it.
+        if self.lora_config and self.lora_manager.supports_tower_connector_lora():
+            logger.warning_once(ENCODER_CUDAGRAPH_TOWER_CONNECTOR_LORA_WARNING)
             return None
 
         return EncoderCudaGraphManager(


### PR DESCRIPTION
## Purpose

Tower/connector LoRA mappings are installed in scheduler order, while encoder
CUDA-graph execution may reorder and split variable-sized multimodal items.
Graph capture also does not establish a valid tower/connector LoRA mapping.
Replaying a graph with this combination can therefore silently apply incorrect
adapter state or omit adapter effects.

Disable encoder CUDA-graph manager creation whenever tower/connector LoRA is
enabled, for both the legacy and V2 model runners, this falls back to the
existing eager encoder path while preserving encoder graphs for language-only
LoRA.

Add focused unit coverage for both runner paths and extend the existing
Qwen2-VL LoRA integration test to request encoder CUDA graphs, validate all
three adapter types, and verify that V2 does not create an encoder graph
manager. Wire the affected runtime files into the existing Buildkite LoRA jobs.

## Test Plan

```bash
pytest tests/v1/worker/test_gpu_model_runner.py -q \
  -k encoder_cudagraph_manager_respects_model_and_lora_support

pytest tests/v1/worker/test_encoder_runner.py -q \
  -k "not encoder_timing_stats_registry"

pytest -v -s \
  tests/lora/test_qwenvl.py::test_qwen2vl_multiple_lora_types
```

## Test Result

- Legacy-runner guard matrix: `3 passed`.
- V2 encoder-runner suite: `12 passed, 1 deselected`.
- Qwen2-VL integration on an RTX 3090: `1 passed in 320.93s`; language-only,
  tower+connector, and tower-only adapters produced the expected outputs, and
  every worker reported that no encoder graph manager was created.
- Pre-commit checks passed.

No documentation update is needed because this changes internal graph
selection only.

---
<details>
<summary>Essential Elements of an Effective PR Description Checklist</summary>

- [x] The purpose of the PR is described.
- [x] The test plan is provided.
- [x] The test results are provided.
- [x] No documentation update is required.

</details>

AI assistance was used in developing this change. I reviewed and understand
every submitted line.

