### PR TITLE
[bot] Enable Gemma4-E4B inference on Intel XPU with per-layer head_dim routing

### DIFF
--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -735,7 +735,7 @@ class ModelConfig:
         `model_impl` is set to `transformers` or `auto`."""
         cls = "Transformers"
         # If 'hf_config != hf_text_config' it's a nested config, i.e. multimodal
-        cls += "MultiModal" if self.hf_config != self.hf_text_config else ""
+        cls += "MultiModal" if self.hf_config is not self.hf_text_config else ""
         cls += "MoE" if self.is_moe else ""
         # Check if the architecture we're wrapping has defaults
         runner = None

--- a/vllm/model_executor/models/config.py
+++ b/vllm/model_executor/models/config.py
@@ -77,14 +77,23 @@ class Gemma4Config(VerifyAndUpdateConfig):
         with different head dimensions for prefill-decode disaggregation.
         """
         hf_text_config = vllm_config.model_config.hf_text_config
-        head_dim = getattr(hf_text_config, "head_dim", None)
-        global_head_dim = getattr(hf_text_config, "global_head_dim", None)
+        try:
+            head_dim = getattr(hf_text_config, "head_dim", None)
+        except Exception:
+            # Transformers >=5.15 raises for heterogeneous per-layer attrs
+            per_layer = getattr(hf_text_config, "per_layer_config", None)
+            head_dim = min(lc.head_dim for lc in per_layer) if per_layer else None
+        try:
+            global_head_dim = getattr(hf_text_config, "global_head_dim", None)
+        except Exception:
+            per_layer = getattr(hf_text_config, "per_layer_config", None)
+            global_head_dim = max(lc.head_dim for lc in per_layer) if per_layer else None
 
         # Only force Triton when head dimensions actually differ AND the
         # larger one exceeds FlashAttention's kernel limit (head_size <= 256).
-        # This avoids unnecessary backend forcing on smaller models where
-        # the config carries global_head_dim but all layers can still use
-        # the same FA backend.
+        # On XPU, per-layer backend routing is handled in xpu.py's
+        # get_attn_backend_cls, so skip the global forcing.
+        from vllm.platforms import current_platform
         max_head_dim = max(head_dim or 0, global_head_dim or 0)
         if (
             head_dim is not None
@@ -92,6 +101,7 @@ class Gemma4Config(VerifyAndUpdateConfig):
             and head_dim != global_head_dim
             and max_head_dim > 256
             and vllm_config.attention_config.backend is None
+            and current_platform.device_type != "xpu"
         ):
             from vllm.v1.attention.backends.registry import (
                 AttentionBackendEnum,

--- a/vllm/model_executor/models/gemma4.py
+++ b/vllm/model_executor/models/gemma4.py
@@ -86,7 +86,13 @@ def _get_text_config(config):
     transparently returns the text config regardless of nesting.
     """
     if hasattr(config, "text_config"):
-        return config.text_config
+        config = config.text_config
+    # Transformers >=5.15 raises AmbiguousGlobalPerLayerAttributeError
+    # for heterogeneous per-layer attributes (e.g. head_dim on E4B).
+    # Gemma4 already handles per-layer head_dim via layer_types, so
+    # enable global access to avoid the exception.
+    if hasattr(config, "allow_global_per_layer_attribute_access"):
+        config.allow_global_per_layer_attribute_access = True
     return config
 
 
@@ -448,7 +454,12 @@ class Gemma4DecoderLayer(nn.Module):
         # Gemma4 uses different head dimensions for sliding vs full attention
         layer_type = config.layer_types[layer_idx]
         self.is_full_attention = layer_type == "full_attention"
-        if self.is_full_attention:
+        # Use per-layer config if available (transformers >=5.15
+        # heterogeneous configs, e.g. E4B where global_head_dim is absent)
+        per_layer = getattr(config, "per_layer_config", None)
+        if per_layer is not None:
+            head_dim = per_layer[layer_idx].head_dim
+        elif self.is_full_attention:
             head_dim = getattr(config, "global_head_dim", config.head_dim)
         else:
             head_dim = config.head_dim

--- a/vllm/platforms/xpu.py
+++ b/vllm/platforms/xpu.py
@@ -86,6 +86,17 @@ class XPUPlatform(Platform):
                 f"with use_mla: {attn_selector_config.use_mla}"
             )
 
+        # XPU Flash Attention SYCL kernel supports head_size <= 256.
+        # Route larger head sizes (e.g. Gemma4 global attention) to Triton.
+        head_size = attn_selector_config.head_size
+        if head_size is not None and head_size > 256:
+            logger.info(
+                "head_size=%d exceeds XPU Flash Attention limit (256). "
+                "Falling back to Triton Attention for this layer.",
+                head_size,
+            )
+            return AttentionBackendEnum.TRITON_ATTN.get_path()
+
         logger.info("Using Flash Attention backend.")
         return AttentionBackendEnum.FLASH_ATTN.get_path()
 

--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -1052,6 +1052,12 @@ def get_hf_text_config(config: PretrainedConfig):
     """
     text_config = config.get_text_config()
 
+    # Transformers >=5.15 raises AmbiguousGlobalPerLayerAttributeError for
+    # heterogeneous per-layer attributes (e.g. head_dim on Gemma4-E4B).
+    # vLLM handles per-layer differences explicitly, so enable global access.
+    if hasattr(text_config, "allow_global_per_layer_attribute_access"):
+        text_config.allow_global_per_layer_attribute_access = True
+
     if text_config is not config and not hasattr(text_config, "num_attention_heads"):
         raise ValueError(
             "The text_config extracted from the model config does not have "

--- a/vllm/transformers_utils/model_arch_config_convertor.py
+++ b/vllm/transformers_utils/model_arch_config_convertor.py
@@ -453,8 +453,21 @@ class Gemma4ModelArchConfigConvertor(ModelArchConfigConvertorBase):
         # Gemma4 uses dual head dimensions: head_dim (sliding attention)
         # and global_head_dim (full attention).  Return the largest so
         # that attention backends allocate buffers large enough for both.
-        head_dim = getattr(self.hf_text_config, "head_dim", 0)
-        global_head_dim = getattr(self.hf_text_config, "global_head_dim", 0)
+        # Transformers >=5.15 raises AmbiguousGlobalPerLayerAttributeError
+        # for heterogeneous per-layer attributes; handle gracefully.
+        try:
+            head_dim = getattr(self.hf_text_config, "head_dim", 0)
+        except Exception:
+            # Fall back to per_layer_config if available
+            per_layer = getattr(self.hf_text_config, "per_layer_config", None)
+            if per_layer:
+                head_dim = max(lc.head_dim for lc in per_layer)
+            else:
+                head_dim = 0
+        try:
+            global_head_dim = getattr(self.hf_text_config, "global_head_dim", 0)
+        except Exception:
+            global_head_dim = 0
         return max(head_dim, global_head_dim) or super().get_head_size()
 
 


### PR DESCRIPTION
## Motivation

Gemma4-E4B (google/gemma-4-E4B-it) uses heterogeneous head dimensions across layers: 256 for sliding-window attention and 512 for global/full attention. This causes two issues on Intel XPU:

1. **Transformers >=5.15 compatibility**: The new per-layer config system raises `AmbiguousGlobalPerLayerAttributeError` when accessing `head_dim` globally, since it differs across layers.
2. **Attention backend routing**: XPU Flash Attention (SYCL) only supports head_size ≤ 256, so global attention layers (head_dim=512) need Triton backend, while sliding layers can use the faster Flash Attention.

## Technical Details

### 1. Handle heterogeneous per-layer config (`config.py`, `gemma4.py`, `model_arch_config_convertor.py`, `transformers_utils/config.py`)
- Enable `allow_global_per_layer_attribute_access` on text configs that support it
- Fall back to `per_layer_config[layer_idx].head_dim` when global `head_dim` access raises
- Wrap `getattr(config, 'head_dim')` in try/except for robust fallback

### 2. Per-layer attention backend routing on XPU (`xpu.py`)
- Added head_size check in `get_attn_backend_cls`: routes head_size > 256 to Triton, ≤ 256 to Flash Attention
- This enables mixed-backend inference where each layer uses the optimal backend

### 3. Skip global Triton forcing on XPU (`models/config.py`)
- The existing `Gemma4Config.verify_and_update` forces Triton globally when head dims differ. On XPU, per-layer routing handles this, so skip the global override.

### 4. Fix multimodal detection (`model.py`)
- Changed `hf_config != hf_text_config` to `hf_config is not hf_text_config` (identity check) to correctly detect nested configs.

## Hardware
- Intel Data Center GPU Max 1550 (Xe-HPC, 68.7 GB HBM)
- TP=1
