### PR TITLE
[Bugfix][Humming] Ignore invalid rows in fused MoE reduction

### DIFF
--- a/tests/kernels/moe/test_moe_fused_mul_sum.py
+++ b/tests/kernels/moe/test_moe_fused_mul_sum.py
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for the fused MoE topk weight-and-reduce kernel.
+
+Run `pytest tests/kernels/moe/test_moe_fused_mul_sum.py`.
+"""
+
+import pytest
+import torch
+
+from vllm.model_executor.layers.fused_moe.moe_fused_mul_sum import moe_fused_mul_sum
+from vllm.utils.torch_utils import set_random_seed
+
+NUM_TOKENS = [1, 17, 256]
+TOP_KS = [2, 8]
+HIDDEN_SIZE = 512
+NUM_EXPERTS = 16
+
+
+def _reference(
+    inputs: torch.Tensor,
+    topk_weights: torch.Tensor,
+    topk_ids: torch.Tensor,
+    expert_map: torch.Tensor | None,
+) -> torch.Tensor:
+    valid = topk_ids >= 0
+    if expert_map is not None:
+        valid &= expert_map[topk_ids.clamp(min=0)] >= 0
+    weights = torch.where(valid, topk_weights, torch.zeros_like(topk_weights))
+    return (inputs.float() * weights.float().unsqueeze(-1)).sum(dim=1)
+
+
+@pytest.mark.parametrize("num_tokens", NUM_TOKENS)
+@pytest.mark.parametrize("top_k", TOP_KS)
+@pytest.mark.parametrize("use_expert_map", [True, False])
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_invalid_slots_excluded(num_tokens: int, top_k: int, use_expert_map: bool):
+    """Slots marked -1 must not contribute, and must not be dereferenced.
+
+    The expert GEMM never writes rows for topk slots whose expert id is -1
+    (a non-local expert under EP, or an all2all padding row), so those rows
+    hold stale workspace data. Filling them with NaN here means any failure to
+    mask them shows up as NaN in the output rather than a small numeric drift.
+    Indexing `expert_map` with -1 is also an out-of-bounds read.
+    """
+    set_random_seed(0)
+    device = "cuda"
+
+    inputs = torch.randn(
+        num_tokens, top_k, HIDDEN_SIZE, dtype=torch.bfloat16, device=device
+    )
+    topk_weights = torch.rand(num_tokens, top_k, dtype=torch.bfloat16, device=device)
+    topk_ids = torch.randint(
+        0, NUM_EXPERTS, (num_tokens, top_k), dtype=torch.int32, device=device
+    )
+
+    # Mark roughly half the slots invalid and poison the rows behind them.
+    invalid = torch.rand(num_tokens, top_k, device=device) < 0.5
+    topk_ids[invalid] = -1
+    inputs[invalid] = float("nan")
+
+    expert_map = None
+    if use_expert_map:
+        # Second half of the experts is non-local, so valid ids can still map
+        # to -1 -- exercising the second masking condition.
+        expert_map = torch.full((NUM_EXPERTS,), -1, dtype=torch.int32, device=device)
+        local = NUM_EXPERTS // 2
+        expert_map[:local] = torch.arange(local, dtype=torch.int32, device=device)
+        inputs[(topk_ids >= 0) & (expert_map[topk_ids.clamp(min=0)] < 0)] = float("nan")
+
+    out = moe_fused_mul_sum(
+        inputs=inputs,
+        topk_weights=topk_weights,
+        topk_ids=topk_ids,
+        expert_map=expert_map,
+    )
+
+    assert not out.isnan().any(), "invalid slots leaked into the reduction"
+    ref = _reference(inputs.nan_to_num(), topk_weights, topk_ids, expert_map)
+    torch.testing.assert_close(out.float(), ref, atol=1e-2, rtol=1e-2)

--- a/vllm/model_executor/layers/fused_moe/moe_fused_mul_sum.py
+++ b/vllm/model_executor/layers/fused_moe/moe_fused_mul_sum.py
@@ -16,6 +16,7 @@ def moe_fused_mul_sum_kernel(
     expert_map_ptr,
     num_tokens,
     stride_m,
+    has_topk_ids: tl.constexpr,
     has_expert_map: tl.constexpr,
     top_k: tl.constexpr,
     size: tl.constexpr,
@@ -39,20 +40,28 @@ def moe_fused_mul_sum_kernel(
 
     for n in tl.static_range(top_k):
         b_val = tl.load(b_base + n, mask=m_mask, other=0.0).to(tl.float32)
-        if has_expert_map:
-            id_val = tl.load(top_ids_ptr + offs_m * top_k + n, mask=m_mask, other=0)
-            expert_mask = tl.load(expert_map_ptr + id_val) >= 0
-            a_vec = tl.load(
-                a_base + n * size,
-                mask=mask & expert_mask[:, None],
-                other=0.0,
-            ).to(tl.float32)
+        if has_topk_ids:
+            # -1 marks a slot the expert GEMM skipped (non-local expert under
+            # EP, or an all2all padding row), so `inputs` was never written
+            # there. Both the map lookup and the value load must be masked off:
+            # indexing the map with -1 reads out of bounds.
+            id_val = tl.load(top_ids_ptr + offs_m * top_k + n, mask=m_mask, other=-1)
+            valid = id_val >= 0
+            if has_expert_map:
+                local_id = tl.load(
+                    expert_map_ptr + tl.where(valid, id_val, 0),
+                    mask=valid,
+                    other=-1,
+                )
+                valid = valid & (local_id >= 0)
+            row_mask = mask & valid[:, None]
         else:
-            a_vec = tl.load(
-                a_base + n * size,
-                mask=mask,
-                other=0.0,
-            ).to(tl.float32)
+            row_mask = mask
+        a_vec = tl.load(
+            a_base + n * size,
+            mask=row_mask,
+            other=0.0,
+        ).to(tl.float32)
         acc += a_vec * b_val[:, None]
 
     out_ptrs = outputs_ptr + (offs_m * size)[:, None] + offs_k[None, :]
@@ -150,8 +159,10 @@ def moe_fused_mul_sum(
             Shape: (num_tokens, top_k).
         outputs: Optional pre-allocated output tensor.
             Shape: (num_tokens, hidden_size).
-        topk_ids: Optional indices of the top-k experts. Used when
-            `expert_map` is provided. Shape: (num_tokens, top_k).
+        topk_ids: Optional indices of the top-k experts. Shape:
+            (num_tokens, top_k). A value of -1 marks a slot the expert GEMM
+            skipped; those slots are excluded from the sum. Required when
+            `expert_map` is provided.
         expert_map: Optional mapping for Expert Parallelism. A value < 0
             indicates an invalid token/expert pair that will be skipped.
 
@@ -173,6 +184,9 @@ def moe_fused_mul_sum(
 
     assert outputs.shape == output_shape
     assert topk_weights.shape == (num_tokens, top_k)
+    assert expert_map is None or topk_ids is not None, (
+        "topk_ids is required to interpret expert_map"
+    )
 
     if not isinstance(inputs, FakeTensor):
         BLOCK_M, BLOCK_K, num_warps, num_stages = _heuristic_config(
@@ -190,6 +204,7 @@ def moe_fused_mul_sum(
             expert_map,
             num_tokens,
             top_k * size,
+            topk_ids is not None,
             expert_map is not None,
             top_k,
             size,


### PR DESCRIPTION
## Summary

- exclude expert output slots whose `topk_ids` are negative from `moe_fused_mul_sum`
- validate IDs before reading `expert_map`, avoiding an out-of-bounds `expert_map[-1]` access
- add a focused CUDA regression that poisons invalid expert rows and checks both mapped and unmapped Humming-style reductions

## Why

Humming indexed experts call `moe_fused_mul_sum` after writing only rows assigned to valid experts. DeepEP v2 marks padding rows with `topk_ids == -1`, leaving their output storage unwritten. The reduction previously included those stale rows when no expert map was present; with an expert map, it dereferenced the negative ID before masking. Both cases can corrupt the final MoE output.

This is the Humming-specific portion extracted from #50511. The DeepEP metadata and dynamic activation-quantization fixes remain in that PR.

## Duplicate-work check

Open-PR searches for `50511 in:body`, `moe_fused_mul_sum invalid padding`, and `Humming invalid expert topk` found no competing implementation. #51217 changes Humming's permute and masked-activation paths, while #49670 optimizes `TopKWeightAndReduceContiguous`; neither fixes this indexed fused reduction.

## Tests

```bash
/Users/tms/code/vllm/.venv/bin/pre-commit run --files \
  vllm/model_executor/layers/fused_moe/moe_fused_mul_sum.py \
  tests/kernels/moe/test_moe_fused_mul_sum.py
# passed

/Users/tms/code/vllm/.venv/bin/python -m pytest \
  tests/kernels/moe/test_moe_fused_mul_sum.py -q
# 12 skipped in this shard: local host has no CUDA
```

## Model evaluation

Not run: the local host has no CUDA. The change is limited to excluding slots that the expert GEMM marked invalid and did not write; the valid-ID path is unchanged. The PR is left as a draft pending human review and GPU validation.

## AI assistance

AI assistance was used to extract, adapt, and validate this change. Before marking the PR ready, the human submitter must review every changed line, run the CUDA regression, and understand and be able to defend the change end to end.
