### PR TITLE
Instrument selected CI jobs with OTel command and pytest spans

### DIFF
--- a/.buildkite/scripts/ci_otel.py
+++ b/.buildkite/scripts/ci_otel.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Dependency-free OTLP exporter for command and pytest CI spans."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+import secrets
+import struct
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+ENDPOINT = os.getenv("VLLM_CI_OTEL_ENDPOINT", "https://ci.vllm.ai/api/otel/v1/traces")
+AUDIENCE = os.getenv("VLLM_CI_OTEL_AUDIENCE", "https://ci.vllm.ai/api/otel")
+MAX_BATCH_SIZE = 250
+
+
+@dataclass(frozen=True)
+class Span:
+    trace_id: str
+    span_id: str
+    parent_span_id: str | None
+    name: str
+    start_ns: int
+    end_ns: int
+    attributes: dict[str, str | int | bool]
+    status_code: int = 1
+
+
+def _varint(value: int) -> bytes:
+    if value < 0:
+        value += 1 << 64
+    encoded = bytearray()
+    while value > 0x7F:
+        encoded.append((value & 0x7F) | 0x80)
+        value >>= 7
+    encoded.append(value)
+    return bytes(encoded)
+
+
+def _key(field: int, wire_type: int) -> bytes:
+    return _varint((field << 3) | wire_type)
+
+
+def _bytes_field(field: int, value: bytes) -> bytes:
+    return _key(field, 2) + _varint(len(value)) + value
+
+
+def _string_field(field: int, value: str) -> bytes:
+    return _bytes_field(field, value.encode())
+
+
+def _varint_field(field: int, value: int) -> bytes:
+    return _key(field, 0) + _varint(value)
+
+
+def _fixed64_field(field: int, value: int) -> bytes:
+    return _key(field, 1) + struct.pack("<Q", value)
+
+
+def _fixed32_field(field: int, value: int) -> bytes:
+    return _key(field, 5) + struct.pack("<I", value)
+
+
+def _any_value(value: str | int | bool) -> bytes:
+    if isinstance(value, bool):
+        return _varint_field(2, int(value))
+    if isinstance(value, int):
+        return _varint_field(3, value)
+    return _string_field(1, value)
+
+
+def _attribute(key: str, value: str | int | bool) -> bytes:
+    return _string_field(1, key) + _bytes_field(2, _any_value(value))
+
+
+def _resource_attributes() -> dict[str, str | int | bool]:
+    build_number = os.getenv("BUILDKITE_BUILD_NUMBER", "0")
+    attributes: dict[str, str | int | bool] = {
+        "service.name": "vllm-ci",
+        "buildkite.organization.slug": os.getenv("BUILDKITE_ORGANIZATION_SLUG", ""),
+        "buildkite.pipeline.slug": os.getenv("BUILDKITE_PIPELINE_SLUG", ""),
+        "buildkite.build.id": os.getenv("BUILDKITE_BUILD_ID", ""),
+        "buildkite.build.number": int(build_number) if build_number.isdigit() else 0,
+        "buildkite.build.branch": os.getenv("BUILDKITE_BRANCH", ""),
+        "buildkite.build.commit": os.getenv("BUILDKITE_COMMIT", ""),
+        "buildkite.job.id": os.getenv("BUILDKITE_JOB_ID", ""),
+        "buildkite.job.label": os.getenv("BUILDKITE_LABEL", ""),
+        "buildkite.step.key": os.getenv("BUILDKITE_STEP_KEY", ""),
+        "buildkite.agent.queue": os.getenv("BUILDKITE_AGENT_META_DATA_QUEUE", ""),
+    }
+    return {key: value for key, value in attributes.items() if value != ""}
+
+
+def _encode_span(span: Span) -> bytes:
+    encoded = b"".join(
+        [
+            _bytes_field(1, bytes.fromhex(span.trace_id)),
+            _bytes_field(2, bytes.fromhex(span.span_id)),
+            _bytes_field(4, bytes.fromhex(span.parent_span_id))
+            if span.parent_span_id
+            else b"",
+            _string_field(5, span.name),
+            _varint_field(6, 1),
+            _fixed64_field(7, span.start_ns),
+            _fixed64_field(8, span.end_ns),
+        ]
+    )
+    attributes = dict(span.attributes)
+    build_url = os.getenv("BUILDKITE_BUILD_URL")
+    job_id = os.getenv("BUILDKITE_JOB_ID")
+    if build_url and job_id:
+        attributes.setdefault("buildkite.job.web_url", f"{build_url}#{job_id}")
+    for key, value in attributes.items():
+        encoded += _bytes_field(9, _attribute(key, value))
+    encoded += _bytes_field(15, _varint_field(3, span.status_code))
+    encoded += _fixed32_field(16, 1)
+    return encoded
+
+
+def encode_request(spans: Iterable[Span]) -> bytes:
+    resource = b"".join(
+        _bytes_field(1, _attribute(key, value))
+        for key, value in _resource_attributes().items()
+    )
+    scope = _string_field(1, "vllm.ci") + _string_field(2, "1")
+    scope_spans = _bytes_field(1, scope)
+    for span in spans:
+        scope_spans += _bytes_field(2, _encode_span(span))
+    resource_spans = _bytes_field(1, resource) + _bytes_field(2, scope_spans)
+    return _bytes_field(1, resource_spans)
+
+
+def new_context() -> tuple[str, str, str | None]:
+    traceparent = os.getenv("TRACEPARENT", "").lower()
+    parts = traceparent.split("-")
+    valid_lengths = len(parts) == 4 and [len(part) for part in parts] == [2, 32, 16, 2]
+    valid_hex = valid_lengths and all(
+        all(character in "0123456789abcdef" for character in part) for part in parts
+    )
+    if valid_hex and parts[1] != "0" * 32 and parts[2] != "0" * 16:
+        trace_id = parts[1]
+        parent_span_id = parts[2]
+    else:
+        build_id = os.getenv("BUILDKITE_BUILD_ID", "local")
+        trace_id = hashlib.sha256(build_id.encode()).hexdigest()[:32]
+        parent_span_id = None
+    return trace_id, secrets.token_hex(8), parent_span_id
+
+
+def _oidc_token() -> str:
+    result = subprocess.run(
+        [
+            "buildkite-agent",
+            "oidc",
+            "request-token",
+            "--audience",
+            AUDIENCE,
+            "--lifetime",
+            "300",
+            "--claim",
+            "build_id",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=20,
+    )
+    return result.stdout.strip()
+
+
+def export_spans(spans: list[Span]) -> bool:
+    if not spans or os.getenv("BUILDKITE", "") != "true":
+        return False
+    required = (
+        "BUILDKITE_ORGANIZATION_SLUG",
+        "BUILDKITE_PIPELINE_SLUG",
+        "BUILDKITE_BUILD_ID",
+        "BUILDKITE_BUILD_NUMBER",
+        "BUILDKITE_JOB_ID",
+        "BUILDKITE_BRANCH",
+    )
+    if any(not os.getenv(name) for name in required):
+        return False
+
+    try:
+        token = _oidc_token()
+        for offset in range(0, len(spans), MAX_BATCH_SIZE):
+            payload = encode_request(spans[offset : offset + MAX_BATCH_SIZE])
+            request = urllib.request.Request(
+                ENDPOINT,
+                data=payload,
+                method="POST",
+                headers={
+                    "Authorization": f"Bearer {token}",
+                    "Content-Type": "application/x-protobuf",
+                    "User-Agent": "vllm-ci-otel/1",
+                },
+            )
+            with urllib.request.urlopen(request, timeout=20) as response:
+                if response.status != 200:
+                    raise RuntimeError(f"OTLP endpoint returned {response.status}")
+        return True
+    except (
+        OSError,
+        RuntimeError,
+        subprocess.SubprocessError,
+        urllib.error.URLError,
+    ) as error:
+        print(f"CI timing upload skipped: {error}", file=sys.stderr)
+        return False
+
+
+def _command_span(args: argparse.Namespace) -> Span:
+    attributes: dict[str, str | int | bool] = {
+        "ci.span.kind": "command",
+        "ci.command.index": args.index,
+        "ci.command.label": args.label,
+        "process.exit.code": args.exit_code,
+    }
+    return Span(
+        trace_id=args.trace_id,
+        span_id=args.span_id,
+        parent_span_id=args.parent_span_id or None,
+        name="ci.command",
+        start_ns=args.start_ns,
+        end_ns=args.end_ns,
+        attributes=attributes,
+        status_code=1 if args.exit_code == 0 else 2,
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    subparsers.add_parser("new-context")
+    command = subparsers.add_parser("command")
+    command.add_argument("--trace-id", required=True)
+    command.add_argument("--span-id", required=True)
+    command.add_argument("--parent-span-id", default="")
+    command.add_argument("--start-ns", required=True, type=int)
+    command.add_argument("--end-ns", required=True, type=int)
+    command.add_argument("--index", required=True, type=int)
+    command.add_argument("--label", required=True)
+    command.add_argument("--exit-code", required=True, type=int)
+    args = parser.parse_args()
+
+    if args.command == "new-context":
+        trace_id, span_id, parent_span_id = new_context()
+        print(trace_id, span_id, parent_span_id or "-")
+        return 0
+    export_spans([_command_span(args)])
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.buildkite/scripts/ci_otel.sh
+++ b/.buildkite/scripts/ci_otel.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+_VLLM_CI_OTEL_DIR="${VLLM_CI_OTEL_DIR:-/vllm-workspace/.buildkite/scripts}"
+export PYTHONPATH="${_VLLM_CI_OTEL_DIR}${PYTHONPATH:+:${PYTHONPATH}}"
+export PYTEST_ADDOPTS="${PYTEST_ADDOPTS:-} -p ci_pytest_otel"
+
+ci_otel_run() {
+  local command_index="$1"
+  local encoded_label="$2"
+  local encoded_command="$3"
+  local command_label
+  local command_text
+  local context
+  local trace_id
+  local span_id
+  local parent_span_id
+  local start_ns
+  local end_ns
+  local command_status
+
+  if ! command_label="$(printf '%s' "${encoded_label}" | base64 --decode)" ||
+    ! command_text="$(printf '%s' "${encoded_command}" | base64 --decode)"; then
+    echo "vLLM CI OTel: could not decode generated command metadata" >&2
+    return 1
+  fi
+
+  if ! context="$(python3 "${_VLLM_CI_OTEL_DIR}/ci_otel.py" new-context)"; then
+    eval "${command_text}"
+    return $?
+  fi
+  read -r trace_id span_id parent_span_id <<<"${context}"
+  [[ "${parent_span_id}" == "-" ]] && parent_span_id=""
+  start_ns="$(date +%s%N)"
+
+  local VLLM_CI_TRACE_ID="${trace_id}"
+  local VLLM_CI_COMMAND_SPAN_ID="${span_id}"
+  export VLLM_CI_TRACE_ID VLLM_CI_COMMAND_SPAN_ID
+  if eval "${command_text}"; then
+    command_status=0
+  else
+    command_status=$?
+  fi
+  end_ns="$(date +%s%N)"
+
+  python3 "${_VLLM_CI_OTEL_DIR}/ci_otel.py" command \
+    --trace-id "${trace_id}" \
+    --span-id "${span_id}" \
+    --parent-span-id "${parent_span_id}" \
+    --start-ns "${start_ns}" \
+    --end-ns "${end_ns}" \
+    --index "${command_index}" \
+    --label "${command_label}" \
+    --exit-code "${command_status}" || true
+  return "${command_status}"
+}

--- a/.buildkite/scripts/ci_pytest_otel.py
+++ b/.buildkite/scripts/ci_pytest_otel.py
@@ -1,0 +1,81 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Pytest plugin that emits one OTLP span per collected test."""
+
+from __future__ import annotations
+
+import os
+import time
+from dataclasses import dataclass
+
+from ci_otel import Span, export_spans
+
+
+@dataclass
+class TestRun:
+    start_ns: int
+    end_ns: int = 0
+    outcome: str = "unknown"
+
+
+_runs: dict[str, TestRun] = {}
+_spans: list[Span] = []
+
+
+def _enabled() -> bool:
+    return bool(os.getenv("VLLM_CI_TRACE_ID") and os.getenv("VLLM_CI_COMMAND_SPAN_ID"))
+
+
+def pytest_runtest_logstart(nodeid: str, location: tuple[str, int | None, str]):
+    if _enabled():
+        _runs[nodeid] = TestRun(start_ns=time.time_ns())
+
+
+def pytest_runtest_logreport(report):
+    run = _runs.get(report.nodeid)
+    if not run:
+        return
+    if report.failed:
+        run.outcome = "failed"
+    elif report.skipped and run.outcome != "failed":
+        run.outcome = "skipped"
+    elif report.when == "call" and run.outcome == "unknown":
+        run.outcome = "passed"
+
+
+def pytest_runtest_logfinish(nodeid: str, location: tuple[str, int | None, str]):
+    run = _runs.pop(nodeid, None)
+    if not run:
+        return
+    run.end_ns = time.time_ns()
+    _spans.append(_test_span(nodeid, run))
+
+
+def _test_span(nodeid: str, run: TestRun) -> Span:
+    outcome = run.outcome
+    return Span(
+        trace_id=os.environ["VLLM_CI_TRACE_ID"],
+        span_id=os.urandom(8).hex(),
+        parent_span_id=os.environ["VLLM_CI_COMMAND_SPAN_ID"],
+        name="pytest.test",
+        start_ns=run.start_ns,
+        end_ns=run.end_ns or time.time_ns(),
+        attributes={
+            "ci.span.kind": "test",
+            "test.nodeid": nodeid,
+            "test.file": nodeid.split("::", 1)[0],
+            "test.outcome": outcome,
+        },
+        status_code=2 if outcome == "failed" else 1,
+    )
+
+
+def pytest_sessionfinish(session, exitstatus: int):
+    if not _enabled():
+        return
+    for nodeid, run in list(_runs.items()):
+        _spans.append(_test_span(nodeid, run))
+    _runs.clear()
+    export_spans(_spans)
+    _spans.clear()

--- a/.buildkite/test_areas/misc.yaml
+++ b/.buildkite/test_areas/misc.yaml
@@ -183,6 +183,7 @@ steps:
 - label: Examples
   device: h200_35gb
   key: examples
+  otel_trace: true
   timeout_in_minutes: 40
   working_dir: "/vllm-workspace/examples"
   source_file_dependencies:

--- a/.buildkite/test_areas/model_runner_v2.yaml
+++ b/.buildkite/test_areas/model_runner_v2.yaml
@@ -5,6 +5,7 @@ steps:
 - label: Model Runner V2 Core Tests
   device: h200_35gb
   key: model-runner-v2-core-tests
+  otel_trace: true
   timeout_in_minutes: 35
   source_file_dependencies:
   - vllm/v1/worker/gpu/

--- a/.buildkite/tests/test_ci_otel.py
+++ b/.buildkite/tests/test_ci_otel.py
@@ -1,0 +1,82 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+import binascii
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1] / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+from ci_otel import Span, encode_request, export_spans, new_context  # noqa: E402
+
+
+def _encoded(value: str) -> str:
+    return binascii.b2a_base64(value.encode(), newline=False).decode()
+
+
+def test_new_context_continues_w3c_traceparent(monkeypatch):
+    monkeypatch.setenv(
+        "TRACEPARENT",
+        "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+    )
+
+    trace_id, span_id, parent_span_id = new_context()
+
+    assert trace_id == "4bf92f3577b34da6a3ce929d0e0e4736"
+    assert len(span_id) == 16
+    assert parent_span_id == "00f067aa0ba902b7"
+
+
+def test_otlp_payload_contains_span_and_build_identity(monkeypatch):
+    monkeypatch.setenv("BUILDKITE_ORGANIZATION_SLUG", "vllm")
+    monkeypatch.setenv("BUILDKITE_PIPELINE_SLUG", "ci")
+    monkeypatch.setenv("BUILDKITE_BUILD_ID", "build-id")
+    monkeypatch.setenv("BUILDKITE_BUILD_NUMBER", "42")
+    monkeypatch.setenv("BUILDKITE_BRANCH", "main")
+    monkeypatch.setenv("BUILDKITE_JOB_ID", "job-id")
+    span = Span(
+        trace_id="01" * 16,
+        span_id="02" * 8,
+        parent_span_id="03" * 8,
+        name="ci.command",
+        start_ns=100,
+        end_ns=200,
+        attributes={"ci.span.kind": "command"},
+    )
+
+    payload = encode_request([span])
+
+    assert b"ci.command" in payload
+    assert b"ci.span.kind" in payload
+    assert b"buildkite.job.id" in payload
+    assert b"job-id" in payload
+
+
+def test_export_is_disabled_outside_buildkite(monkeypatch):
+    monkeypatch.delenv("BUILDKITE", raising=False)
+
+    assert export_spans([]) is False
+
+
+def test_shell_wrapper_preserves_command_state_and_quoting():
+    script = SCRIPTS_DIR / "ci_otel.sh"
+    first = "ci_otel_run 1 {} {}".format(
+        _encoded("export VALUE=ready"),
+        _encoded("export VALUE=ready"),
+    )
+    second_command = 'test "$VALUE" = ready'
+    second = f"ci_otel_run 2 {_encoded('check VALUE')} {_encoded(second_command)}"
+    result = subprocess.run(
+        ["bash", "-c", f'source "{script}"; {first}; {second}'],
+        check=False,
+        capture_output=True,
+        text=True,
+        env={**os.environ, "VLLM_CI_OTEL_DIR": str(SCRIPTS_DIR)},
+    )
+
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## What changed

- Add a dependency-free OTLP/HTTP protobuf exporter for vLLM CI commands.
- Add a lightweight pytest plugin that emits one child span for every completed test node ID, including duration and outcome.
- Preserve shell state across generated commands while recording command duration and exit status.
- Mint a short-lived Buildkite OIDC token only when a batch is uploaded; no static dashboard ingest token is exposed to test code.
- Opt the `Examples` and `Model Runner V2 Core Tests` jobs into the initial pilot.
- Fail open when telemetry cannot be uploaded so observability never changes CI outcomes.

## Why

Buildkite's OpenTelemetry notification service shows build and job timing but cannot observe commands or individual pytest tests inside a job. These spans let the existing CI dashboard expand a job into its commands and a pytest command into every test on the same build timeline.

## Safety

The corresponding ci-infra generator change enables this only for trusted `main` builds and excludes pull requests and AMD mirrors. The dashboard verifies Buildkite's OIDC signature and requires organization, pipeline, branch, build, and job claims to match every uploaded span.

## Duplicate search

I searched open `vllm-project/vllm` pull requests for OpenTelemetry command and pytest timing work and found no overlapping PR.

## Validation

- `uv run --no-project --with pytest pytest -q .buildkite/tests/test_ci_otel.py` — 4 passed
- focused Ruff check on the exporter, pytest plugin, and tests — passed
- `bash -n .buildkite/scripts/ci_otel.sh` — passed
- `uvx --from pre-commit pre-commit run --from-ref origin/main --to-ref HEAD` — all applicable hooks passed, including Ruff formatting, mypy, shell lint, SPDX, forbidden imports, and sign-off
- cross-language OTLP wire compatibility was verified against the dashboard decoder
- model evaluation: not applicable; this changes CI observability only

## Dependencies and rollout

1. Merge and deploy vllm-project/vllm-dashboard#58.
2. Merge vllm-project/ci-infra#472.
3. Merge this PR last, then run the two pilot jobs and verify command/test rows on ci.vllm.ai.

## AI assistance disclosure

AI assistance was used to research, implement, and validate this change. This PR is intentionally draft pending the submitting human's required line-by-line review.