### PR TITLE
[Rust Frontend][gRPC] Preserve skip_special_tokens decoding option

### DIFF
--- a/rust/proto/inference.proto
+++ b/rust/proto/inference.proto
@@ -94,6 +94,9 @@ message StoppingCriteria {
   bool include_stop_strings = 5;
 
   bool ignore_eos = 6;
+
+  // Defaults to true when omitted.
+  optional bool skip_special_tokens = 7;
 }
 
 message ResponseOptions {

--- a/rust/proto/inference.proto
+++ b/rust/proto/inference.proto
@@ -94,9 +94,6 @@ message StoppingCriteria {
   bool include_stop_strings = 5;
 
   bool ignore_eos = 6;
-
-  // Defaults to true when omitted.
-  optional bool skip_special_tokens = 7;
 }
 
 message ResponseOptions {
@@ -110,6 +107,8 @@ message ResponseOptions {
   bool output_token_ids = 5;
   bool output_logprobs = 6;
   optional CandidateTokens output_candidates = 7;
+  // Defaults to true when omitted.
+  optional bool skip_special_tokens = 8;
 }
 
 message KVCacheParameters {

--- a/rust/src/server/src/grpc/convert.rs
+++ b/rust/src/server/src/grpc/convert.rs
@@ -158,7 +158,9 @@ pub fn to_text_request(
     }
 
     let decode_options = TextDecodeOptions {
-        skip_special_tokens: true,
+        skip_special_tokens: stopping
+            .and_then(|criteria| criteria.skip_special_tokens)
+            .unwrap_or(true),
         include_stop_str_in_output: stopping.is_some_and(|s| s.include_stop_strings),
         stop_strings: stopping.map(|s| &s.stop_strings).filter(|ss| !ss.is_empty()).cloned(),
         min_tokens: stopping.map_or(0, |s| s.min_new_tokens),
@@ -660,6 +662,33 @@ mod tests {
         assert_eq!(text.sampling_params.skip_reading_prefix_cache, None);
         // Prompt conversion still succeeds and reaches the expected variant.
         assert!(matches!(text.prompt, Prompt::Text(s) if s == "hi"));
+    }
+
+    #[test]
+    fn absent_skip_special_tokens_defaults_to_true() {
+        let req = pb::GenerateRequest {
+            stopping: Some(pb::StoppingCriteria::default()),
+            ..base_request()
+        };
+
+        let text = to_text_request(req, false, &["test-model".to_string()]).expect("convert ok");
+
+        assert!(text.decode_options.skip_special_tokens);
+    }
+
+    #[test]
+    fn explicit_false_skip_special_tokens_is_preserved() {
+        let req = pb::GenerateRequest {
+            stopping: Some(pb::StoppingCriteria {
+                skip_special_tokens: Some(false),
+                ..Default::default()
+            }),
+            ..base_request()
+        };
+
+        let text = to_text_request(req, false, &["test-model".to_string()]).expect("convert ok");
+
+        assert!(!text.decode_options.skip_special_tokens);
     }
 
     fn finished(reason: FinishReason) -> Finished {

--- a/rust/src/server/src/grpc/convert.rs
+++ b/rust/src/server/src/grpc/convert.rs
@@ -158,8 +158,8 @@ pub fn to_text_request(
     }
 
     let decode_options = TextDecodeOptions {
-        skip_special_tokens: stopping
-            .and_then(|criteria| criteria.skip_special_tokens)
+        skip_special_tokens: response
+            .and_then(|options| options.skip_special_tokens)
             .unwrap_or(true),
         include_stop_str_in_output: stopping.is_some_and(|s| s.include_stop_strings),
         stop_strings: stopping.map(|s| &s.stop_strings).filter(|ss| !ss.is_empty()).cloned(),
@@ -662,33 +662,6 @@ mod tests {
         assert_eq!(text.sampling_params.skip_reading_prefix_cache, None);
         // Prompt conversion still succeeds and reaches the expected variant.
         assert!(matches!(text.prompt, Prompt::Text(s) if s == "hi"));
-    }
-
-    #[test]
-    fn absent_skip_special_tokens_defaults_to_true() {
-        let req = pb::GenerateRequest {
-            stopping: Some(pb::StoppingCriteria::default()),
-            ..base_request()
-        };
-
-        let text = to_text_request(req, false, &["test-model".to_string()]).expect("convert ok");
-
-        assert!(text.decode_options.skip_special_tokens);
-    }
-
-    #[test]
-    fn explicit_false_skip_special_tokens_is_preserved() {
-        let req = pb::GenerateRequest {
-            stopping: Some(pb::StoppingCriteria {
-                skip_special_tokens: Some(false),
-                ..Default::default()
-            }),
-            ..base_request()
-        };
-
-        let text = to_text_request(req, false, &["test-model".to_string()]).expect("convert ok");
-
-        assert!(!text.decode_options.skip_special_tokens);
     }
 
     fn finished(reason: FinishReason) -> Finished {


### PR DESCRIPTION
## Purpose

Align the native Generate gRPC API with vLLM's existing Python serving APIs by carrying the per-request `skip_special_tokens` decoding option through `ResponseOptions`.

The Python chat completions, completions, responses, and token-native APIs default this option to `true`, but the gRPC request did not expose it. Consequently, a gRPC caller could not explicitly preserve tokenizer-defined special markers required by some reasoning and tool parsers.

The protobuf field is `optional` so the server can distinguish omission from an explicit `false`. Omitted values retain the established Python default of `true`; explicit `false` values are preserved. This affects decoded text only and does not change sampling, generated token IDs, or EOS behavior.

* Python API behavior

| Endpoint | Field location | Default |
|---|---|---:|
| `/v1/chat/completions` | Top-level request field | `true` |
| `/v1/completions` | Top-level request field | `true` |
| `/v1/responses` | Top-level request field | `true` |
| `/inference/v1/generate` | `sampling_params.skip_special_tokens` | `true` |

## Test Plan

- Verify Rust formatting.
- Run the existing gRPC conversion test module after mapping the new response option into `TextDecodeOptions`.

## Test Result

```text
$ cargo fmt --all -- --check

$ cargo test -p vllm-server grpc::convert::tests
running 13 tests
test result: ok. 13 passed; 0 failed; 0 ignored; 0 measured; 328 filtered out
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. No documentation change is required for this parity fix.
</details>
