### PR TITLE
[Bugfix] Fix Qwen3 XML numeric fallback warnings

### DIFF
--- a/tests/tool_parsers/test_qwen3xml_tool_parser.py
+++ b/tests/tool_parsers/test_qwen3xml_tool_parser.py
@@ -4,10 +4,41 @@
 
 import pytest
 
+import vllm.tool_parsers.qwen3xml_tool_parser as qwen3xml_tool_parser
 from tests.tool_parsers.common_tests import (
     ToolParserTestConfig,
     ToolParserTests,
 )
+from vllm.tool_parsers.qwen3xml_tool_parser import StreamingXMLToolCallParser
+
+
+@pytest.mark.parametrize(
+    ("value", "param_type", "expected_warning"),
+    [
+        ("1/3", "float", "Parsed value '1/3' is not a float; falling back to string."),
+        (
+            "one",
+            "integer",
+            "Parsed value 'one' is not an integer; falling back to string.",
+        ),
+    ],
+)
+def test_invalid_numeric_argument_logs_clean_warning(
+    monkeypatch: pytest.MonkeyPatch,
+    value: str,
+    param_type: str,
+    expected_warning: str,
+) -> None:
+    warnings = []
+    monkeypatch.setattr(
+        qwen3xml_tool_parser.logger,
+        "warning",
+        lambda message, *args: warnings.append(message % args),
+    )
+    parser = StreamingXMLToolCallParser()
+
+    assert parser._convert_param_value(value, param_type) == value
+    assert warnings == [expected_warning]
 
 
 class TestQwen3xmlToolParser(ToolParserTests):

--- a/vllm/tool_parsers/qwen3xml_tool_parser.py
+++ b/vllm/tool_parsers/qwen3xml_tool_parser.py
@@ -1064,8 +1064,7 @@ class StreamingXMLToolCallParser:
                 return int(param_value)
             except (ValueError, TypeError):
                 logger.warning(
-                    "Parsed value '%s' of parameter '%s' is not an integer "
-                    "in tool '%s', degenerating to string.",
+                    "Parsed value '%s' is not an integer; falling back to string.",
                     param_value,
                 )
             return param_value
@@ -1079,8 +1078,7 @@ class StreamingXMLToolCallParser:
                 )
             except (ValueError, TypeError):
                 logger.warning(
-                    "Parsed value '%s' of parameter '%s' is not a float "
-                    "in tool '%s', degenerating to string.",
+                    "Parsed value '%s' is not a float; falling back to string.",
                     param_value,
                 )
             return param_value


### PR DESCRIPTION
## Summary

- fix Qwen3 XML numeric fallback warnings to match their single formatting argument
- cover invalid float and integer values with a regression that formats the emitted warning

## Bug

When a model emits a value such as `1/3` for a numeric tool parameter, conversion correctly falls back to the original string. The warning had three `%s` placeholders but supplied only the value, so Python logging raised `TypeError: not enough arguments for format string` and printed a traceback.

## Testing

```
PYTHONPATH=. python -m pytest -q tests/tool_parsers/test_qwen3xml_tool_parser.py -k invalid_numeric_argument
2 passed, 17 deselected
```

`ruff check` and `ruff format --check` pass for both changed files.
