### PR TITLE
[Bugfix] Muse Glimmer: apply structured outputs to the to=user answer

### DIFF
--- a/tests/tool_use/test_muse_glimmer.py
+++ b/tests/tool_use/test_muse_glimmer.py
@@ -1,25 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-"""Unit tests for the MuseGlimmer ATEM tool parser and reasoning parser.
+"""Low-level tests for MuseGlimmer reasoning and ATEM tool parsing.
 
-MuseGlimmer writes every turn as a sequence of channel-scoped messages rather
-than JSON, so the two parsers are tested together: the reasoning parser strips
-the reasoning span and forwards the remaining channels as content, and the tool
-parser reads ATEM markup out of those channels.
-
-Four areas, in order:
-
-  1. non-streaming tool-call extraction, including channel scoping (an
-     ``<atem:invoke>`` echoed inside reasoning must never become a call);
-  2. the reasoning -> tool-parser handoff, which regressed once by returning
-     ``content=None`` and starving the tool parser;
-  3. streaming, where markers routinely straddle chunk boundaries, plus
-     truncation isolation for an unterminated ``to=self`` block;
-  4. tool-name normalization against the tools registered on the request.
-
-These drive the parsers directly and need no checkpoint. The tests that require
-a real tokenizer live in ``test_muse_glimmer_parse_delta.py``.
+End-to-end streaming and tokenizer coverage lives in
+``test_muse_glimmer_parse_delta.py``.
 """
 
 import json
@@ -40,19 +25,6 @@ def _fresh_parsers():
     global R, T
     R = MuseGlimmerReasoningParser(object())
     T = MuseGlimmerToolParser(object())
-
-
-# Any framing token that must NEVER appear in surfaced reasoning/content.
-_FRAMING = [
-    "<|start|>",
-    "<|message|>",
-    "<|eom|>",
-    "<|eot|>",
-    "to=self",
-    "to=user",
-    "to=read.read",
-    "<atem:",
-]
 
 
 class _FakeReq:
@@ -99,7 +71,10 @@ def test_single_tool_call_after_reasoning():
     }
 
 
-def test_parallel_calls_across_eom_boundaries():
+def test_sequential_tool_channels_across_eom_boundaries():
+    # The model emits one tool call per channel; a turn may carry several
+    # consecutive tool channels (e.g. in assistant history). Not parallel
+    # generation -- the parser must segment each channel into its own call.
     raw = (
         "<|start|>assistant to=math.add<|message|>"
         '<atem:function_calls>\n<atem:invoke name="math.add">\n'
@@ -179,10 +154,11 @@ def test_reasoning_then_user_answer():
         " to=self<|message|>thinking<|eom|>"
         "<|start|>assistant to=user<|message|>The answer is 42.<|eot|>"
     )
-    reasoning, content = MuseGlimmerReasoningParser.extract_reasoning(R, raw, None)
+    reasoning, framed = MuseGlimmerReasoningParser.extract_reasoning(R, raw, None)
     assert reasoning == "thinking", repr(reasoning)
-    assert content == "The answer is 42.", repr(content)
-    assert not MuseGlimmerToolParser.extract_tool_calls(T, content, None).tools_called
+    out = MuseGlimmerToolParser.extract_tool_calls(T, framed, None)
+    assert out.content == "The answer is 42.", repr(out.content)
+    assert not out.tools_called
 
 
 def test_plain_content_without_framing_passes_through():
@@ -195,7 +171,7 @@ def test_plain_content_without_framing_passes_through():
     )
 
 
-def test_reasoning_then_parallel_calls():
+def test_reasoning_then_sequential_tool_channels():
     raw = (
         " to=self<|message|>need two calls<|eom|>"
         "<|start|>assistant to=math.add<|message|>"
@@ -215,58 +191,32 @@ def test_reasoning_then_parallel_calls():
     )
 
 
-# ----------------------------------------------------------------- streaming
+# ---------------------------------------------------------- reasoning boundary
 
 
-def _stream(raw: str, chunk: int):
-    """Feed ``raw`` incrementally in ``chunk``-char steps through BOTH streaming
-    parsers; return (reasoning, content, tool_calls)."""
-    reasoning, content, toolcalls = [], [], []
-    prev = ""
-    i = 0
-    while i < len(raw):
-        cur = raw[: i + chunk]
-        delta = cur[len(prev) :]
-        dm = MuseGlimmerReasoningParser.extract_reasoning_streaming(
-            R, prev, cur, delta, [], [], []
-        )
-        if dm is not None:
-            if getattr(dm, "reasoning", None):
-                reasoning.append(dm.reasoning)
-            content_delta = getattr(dm, "content", None)
-            # Tool-channel content is an internal handoff to the tool parser,
-            # not client-visible content from the unified parser.
-            if content_delta and "<atem:function_calls>" not in content_delta:
-                content.append(content_delta)
-        dt = MuseGlimmerToolParser.extract_tool_calls_streaming(
-            T, prev, cur, delta, [], [], [], _FakeReq()
-        )
-        if dt is not None and dt.tool_calls:
-            toolcalls.extend(dt.tool_calls)
-        prev = cur
-        i += chunk
-    return "".join(reasoning), "".join(content), toolcalls
+def test_reasoning_end_requires_a_post_reasoning_channel():
+    """``is_reasoning_end`` must fire once the turn leaves ``to=self`` for the
+    ``to=user`` answer OR a tool channel -- this is the gate the structured-
+    outputs backend uses to start applying the JSON grammar. It must NOT fire
+    while still reasoning, nor for a channel header the model merely quotes
+    inside an open reasoning span.
+    """
+    tokenizer = SimpleNamespace(decode=lambda token_ids: "".join(map(chr, token_ids)))
+    parser = MuseGlimmerReasoningParser(tokenizer)
 
+    def is_end(text):
+        return parser.is_reasoning_end(list(map(ord, text)))
 
-def _fn_of(tc):
-    fn = tc.function
-    if isinstance(fn, dict):
-        return fn.get("name"), fn.get("arguments")
-    return fn.name, fn.arguments
+    reasoning = " to=self<|message|>thinking"
+    answer = "<|eom|><|start|>assistant to=user<|message|>"
+    tool = "<|eom|><|start|>assistant to=weather.get<|message|>"
+    echoed = ' to=user<|message|> <atem:invoke name="weather.get">'
 
+    assert is_end(reasoning + answer)
+    assert is_end(reasoning + tool)
+    assert not is_end(reasoning)
+    assert not is_end(reasoning + echoed)
 
-RAW_TOOLCALL = (
-    " to=self<|message|>I should read the hostname file to answer.<|eom|>"
-    "<|start|>assistant to=read.read<|message|>"
-    '<atem:function_calls>\n<atem:invoke name="read.read">\n'
-    '<atem:parameter name="path">/etc/hostname</atem:parameter>\n'
-    "</atem:invoke>\n</atem:function_calls>"
-)
-
-RAW_ANSWER = (
-    " to=self<|message|>Think about it.<|eom|>"
-    "<|start|>assistant to=user<|message|>The answer is 42.<|eot|>"
-)
 
 # NO closing <|eom|> -> truncated CoT
 RAW_TRUNCATED = (
@@ -277,47 +227,6 @@ RAW_TRUNCATED = (
 )
 
 
-def _check_toolcall_stream(chunk):
-    reasoning, content, tcs = _stream(RAW_TOOLCALL, chunk)
-    # (a) no framing token leaks into reasoning or content
-    for f in _FRAMING:
-        assert f not in reasoning, (
-            f"framing {f!r} leaked into reasoning (chunk={chunk})"
-        )
-        assert f not in content, f"framing {f!r} leaked into content (chunk={chunk})"
-    # (b) exactly one tool_call with correct name + args
-    assert len(tcs) == 1, f"expected 1 tool_call, got {len(tcs)} (chunk={chunk})"
-    name, args = _fn_of(tcs[0])
-    assert name == "read.read", name
-    assert json.loads(args) == {"path": "/etc/hostname"}, args
-    assert tcs[0].index == 0 and tcs[0].type == "function" and tcs[0].id
-    # (c) reasoning captured separately and clean
-    assert reasoning == "I should read the hostname file to answer.", repr(reasoning)
-    assert content == "", repr(content)
-
-
-def test_streaming_toolcall_chunk3():
-    _check_toolcall_stream(3)
-
-
-def test_streaming_toolcall_charwise():
-    # worst case: markers arrive one char at a time (mid-marker deltas)
-    _check_toolcall_stream(1)
-
-
-def test_streaming_toolcall_bigchunks():
-    _check_toolcall_stream(17)
-
-
-def test_streaming_reasoning_then_content():
-    reasoning, content, tcs = _stream(RAW_ANSWER, 3)
-    for f in _FRAMING:
-        assert f not in reasoning and f not in content, f
-    assert reasoning == "Think about it.", repr(reasoning)
-    assert content == "The answer is 42.", repr(content)
-    assert tcs == []
-
-
 def test_truncated_cot_no_toolcall_nonstreaming():
     out = MuseGlimmerToolParser.extract_tool_calls(T, RAW_TRUNCATED, _FakeReq())
     assert not out.tools_called and out.tool_calls == []
@@ -326,11 +235,6 @@ def test_truncated_cot_no_toolcall_nonstreaming():
         R, RAW_TRUNCATED, _FakeReq()
     )
     assert reasoning and "Maybe I should call" in reasoning, repr(reasoning)
-
-
-def test_truncated_cot_no_toolcall_streaming():
-    _, _, tcs = _stream(RAW_TRUNCATED, 3)
-    assert tcs == [], f"truncated CoT invoke leaked as streaming tool call: {tcs}"
 
 
 # ------------------------------------------------------- name normalization

--- a/tests/tool_use/test_muse_glimmer_parse_delta.py
+++ b/tests/tool_use/test_muse_glimmer_parse_delta.py
@@ -1,31 +1,37 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-"""parse_delta-level regression tests for the MuseGlimmer parsers.
-
-These drive the UNIFIED parser-engine streaming API the serving layer actually
-uses (``DelegatingParser.parse_delta``), NOT the ``extract_*_streaming`` methods
-directly. This is the coverage that was missing when a live no-tools streaming
-request leaked raw harmony framing into ``content``: the phase machine marked
-``reasoning_ended=True`` at the prompt boundary (because ``is_reasoning_end`` on
-a prompt with no ``to=self`` wrongly returned True), skipping the reasoning
-phase for the whole generation.
-
-Requires a real MuseGlimmer tokenizer; skipped if the checkpoint is unavailable.
-"""
+"""parse_delta-level regressions for MuseGlimmer's unified channel parser."""
 
 import json
-import os
+from types import SimpleNamespace
 
 import pytest
 
-CKPT = os.environ.get("MUSE_GLIMMER_CKPT", "")
+from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
+from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
+from vllm.exceptions import VLLMValidationError
+from vllm.parser import ParserManager
+from vllm.reasoning.muse_glimmer_reasoning_parser import MuseGlimmerReasoningParser
+from vllm.reasoning.muse_glimmer_utils import advance_emitted
+from vllm.sampling_params import StructuredOutputsParams
 
-pytestmark = pytest.mark.skipif(
-    not os.path.isdir(CKPT), reason=f"MuseGlimmer checkpoint not found at {CKPT}"
+REASONING_MODEL_NAME = "meta-models/Muse-Glimmer-30B"
+PROMPT = "<|start|>user<|message|>hi<|eom|><|start|>assistant"
+TOOL_XML = (
+    "<atem:function_calls>\n"
+    '<atem:invoke name="weather.get">\n'
+    '<atem:parameter name="city">Paris</atem:parameter>\n'
+    "</atem:invoke>\n"
+    "</atem:function_calls>"
 )
-
-_FRAMING = [
+EMPTY_TOOL_XML = (
+    "<atem:function_calls>\n"
+    '<atem:invoke name="weather.get">\n'
+    "</atem:invoke>\n"
+    "</atem:function_calls>"
+)
+FRAMING = (
     "<|start|>",
     "<|message|>",
     "<|eom|>",
@@ -33,155 +39,796 @@ _FRAMING = [
     "to=self",
     "to=user",
     "<atem:",
-]
-
-PROMPT = "<|start|>user<|message|>hi<|eom|><|start|>assistant"
+)
 
 
-class _Req:
-    tools = None
-    tool_choice = None
-    include_reasoning = True
+class CharTokenizer:
+    def encode(self, text, add_special_tokens=False):
+        return list(map(ord, text))
+
+    def decode(self, ids):
+        return "".join(chr(token_id) for token_id in ids)
+
+    def get_vocab(self):
+        return {}
 
 
-@pytest.fixture(scope="module")
-def tok():
+@pytest.fixture(scope="module", params=("char", "real"))
+def tokenizer(request):
+    if request.param == "char":
+        return CharTokenizer()
+
     from transformers import AutoTokenizer
 
-    return AutoTokenizer.from_pretrained(CKPT, trust_remote_code=True)
-
-
-@pytest.fixture(scope="module")
-def parser_cls():
-    from vllm.parser import ParserManager
-
-    return ParserManager.get_parser(
-        tool_parser_name="muse_glimmer",
-        reasoning_parser_name="muse_glimmer",
-        enable_auto_tools=True,
-    )
-
-
-def _drive(parser_cls, tok, gen_text, req=None):
-    """Feed gen_text token-by-token through parse_delta (as serving does)."""
-    from vllm.parser.abstract_parser import StreamState
-
-    if req is None:
-        req = _Req()
-    parser = parser_cls(tok)
-    parser._stream_state = StreamState()
-    prompt_ids = tok.encode(PROMPT, add_special_tokens=False)
-    gen_ids = tok.encode(gen_text, add_special_tokens=False)
-    reasoning, content, tools = [], [], []
-    for i, tid in enumerate(gen_ids):
-        dm = parser.parse_delta(
-            tok.decode([tid]),
-            [tid],
-            req,
-            prompt_token_ids=prompt_ids if i == 0 else None,
-            finished=(i == len(gen_ids) - 1),
+    # meta-models/Muse-Glimmer-30B is public, but CI/dev without network (or an
+    # empty HF cache) cannot fetch it. Skip rather than hard-error so the
+    # checkpoint-free ``char`` variants still exercise every case.
+    try:
+        return AutoTokenizer.from_pretrained(
+            REASONING_MODEL_NAME, trust_remote_code=True
         )
-        if dm is None:
-            continue
-        if getattr(dm, "reasoning", None):
-            reasoning.append(dm.reasoning)
-        if getattr(dm, "content", None):
-            content.append(dm.content)
-        for tc in getattr(dm, "tool_calls", None) or []:
-            fn = tc.function
-            name = fn.get("name") if isinstance(fn, dict) else getattr(fn, "name", None)
-            args = (
-                fn.get("arguments")
-                if isinstance(fn, dict)
-                else getattr(fn, "arguments", None)
+    except Exception as exc:  # noqa: BLE001 - any load failure -> skip
+        pytest.skip(f"MuseGlimmer tokenizer unavailable: {exc}")
+
+
+def encode(tokenizer, text):
+    return tokenizer.encode(text, add_special_tokens=False)
+
+
+def tool_names(tools):
+    return [name for _index, name, _arguments in tools]
+
+
+def drive(
+    tokenizer,
+    chunks,
+    *,
+    prompt=PROMPT,
+    with_tool_parser=True,
+    tool_parser_name="muse_glimmer",
+    request=None,
+):
+    parser_kwargs = {"reasoning_parser_name": "muse_glimmer"}
+    if with_tool_parser:
+        parser_kwargs.update(
+            tool_parser_name=tool_parser_name,
+            enable_auto_tools=True,
+        )
+    parser = ParserManager.get_parser(**parser_kwargs)(tokenizer)
+    if request is None:
+        request = SimpleNamespace(
+            tools=None,
+            tool_choice="auto",
+            include_reasoning=True,
+        )
+
+    prompt_ids = encode(tokenizer, prompt)
+    messages = []
+    for index, chunk in enumerate(chunks):
+        message = parser.parse_delta(
+            chunk,
+            encode(tokenizer, chunk),
+            request,
+            prompt_token_ids=prompt_ids if index == 0 else None,
+            finished=index == len(chunks) - 1,
+        )
+        if message is not None:
+            messages.append(message)
+
+    reasoning = "".join(message.reasoning or "" for message in messages)
+    content = "".join(message.content or "" for message in messages)
+    tools = []
+    for message in messages:
+        for tool in message.tool_calls or []:
+            function = tool.function
+            name = function.get("name") if isinstance(function, dict) else function.name
+            arguments = (
+                function.get("arguments")
+                if isinstance(function, dict)
+                else function.arguments
             )
-            tools.append((tc.index, name, args))
-    return "".join(reasoning), "".join(content), tools
+            tools.append((tool.index, name, arguments))
+    return reasoning, content, tools
 
 
-def _assert_no_framing(text):
-    for f in _FRAMING:
-        assert f not in text, f"framing {f!r} leaked: {text!r}"
+def drive_tokenwise(tokenizer, text, **kwargs):
+    ids = encode(tokenizer, text)
+    chunks = [tokenizer.decode([token_id]) for token_id in ids]
+    return drive(tokenizer, chunks, **kwargs)
 
 
-def test_parse_delta_no_tools_reasoning_then_answer(parser_cls, tok):
-    # The core regression: reasoning phase must stay active for a no-tools turn.
-    reasoning, content, tools = _drive(
-        parser_cls,
-        tok,
-        " to=self<|message|>Let me think step by step about the sum.<|eom|>"
+def assert_no_framing(text):
+    for marker in FRAMING:
+        assert marker not in text, f"framing {marker!r} leaked: {text!r}"
+
+
+def test_reasoning_then_answer(tokenizer):
+    reasoning, content, tools = drive_tokenwise(
+        tokenizer,
+        " to=self<|message|>Let me think step by step.<|eom|>"
         "<|start|>assistant to=user<|message|>The answer is 42.<|eot|>",
     )
-    _assert_no_framing(content)
-    assert reasoning == "Let me think step by step about the sum.", repr(reasoning)
-    assert content == "The answer is 42.", repr(content)
+    assert reasoning == "Let me think step by step."
+    assert content == "The answer is 42."
     assert tools == []
+    assert_no_framing(reasoning + content)
 
 
-def test_parse_delta_content_only(parser_cls, tok):
-    reasoning, content, tools = _drive(
-        parser_cls,
-        tok,
-        " to=user<|message|>Just a direct answer.<|eot|>",
+def test_nonstreaming_multiple_reasoning_blocks(tokenizer):
+    parser = ParserManager.get_parser(
+        reasoning_parser_name="muse_glimmer",
+        tool_parser_name="muse_glimmer",
+        enable_auto_tools=True,
+    )(tokenizer)
+    request = SimpleNamespace(
+        tools=None,
+        tool_choice="auto",
+        include_reasoning=True,
     )
-    _assert_no_framing(content)
-    assert content == "Just a direct answer.", repr(content)
+    reasoning, content, tools = parser.parse(
+        "<|start|>assistant to=self<|message|>step one<|eom|>"
+        "<|start|>assistant to=self<|message|>step two<|eom|>"
+        "<|start|>assistant to=user<|message|>done.<|eot|>",
+        request,
+        enable_auto_tools=True,
+    )
+    assert reasoning == "step one\nstep two"
+    assert content == "done."
+    assert not tools
+
+
+def test_streaming_multiple_reasoning_blocks(tokenizer):
+    reasoning, content, tools = drive_tokenwise(
+        tokenizer,
+        "<|start|>assistant to=self<|message|>step one<|eom|>"
+        "<|start|>assistant to=self<|message|>step two<|eom|>"
+        "<|start|>assistant to=user<|message|>done.<|eot|>",
+    )
+    assert reasoning == "step one\nstep two"
+    assert content == "done."
     assert tools == []
 
 
-def test_parse_delta_tool_call(parser_cls, tok):
-    reasoning, content, tools = _drive(
-        parser_cls,
-        tok,
+def test_tool_choice_none_streams_clean_answer(tokenizer):
+    request = SimpleNamespace(
+        tools=None,
+        tool_choice="none",
+        include_reasoning=True,
+    )
+    reasoning, content, tools = drive_tokenwise(
+        tokenizer,
+        " to=self<|message|>Check the result.<|eom|>"
+        "<|start|>assistant to=user<|message|>The answer is 42.<|eot|>",
+        request=request,
+    )
+    assert reasoning == "Check the result."
+    assert content == "The answer is 42."
+    assert tools == []
+    assert_no_framing(reasoning + content)
+
+
+def test_content_only(tokenizer):
+    reasoning, content, tools = drive_tokenwise(
+        tokenizer, " to=user<|message|>Just a direct answer.<|eot|>"
+    )
+    assert reasoning == ""
+    assert content == "Just a direct answer."
+    assert tools == []
+    assert_no_framing(content)
+
+
+def test_tool_call(tokenizer):
+    reasoning, content, tools = drive_tokenwise(
+        tokenizer,
         " to=self<|message|>I should read the hostname.<|eom|>"
         "<|start|>assistant to=read.read<|message|>"
         '<atem:function_calls>\n<atem:invoke name="read.read">\n'
         '<atem:parameter name="path">/etc/hostname</atem:parameter>\n'
         "</atem:invoke>\n</atem:function_calls>",
     )
-    _assert_no_framing(content)
-    assert reasoning == "I should read the hostname.", repr(reasoning)
-    assert len(tools) == 1, tools
-    idx, name, args = tools[0]
-    assert idx == 0 and name == "read.read"
-    assert json.loads(args) == {"path": "/etc/hostname"}
+    assert reasoning == "I should read the hostname."
+    assert content == ""
+    assert len(tools) == 1
+    index, name, arguments = tools[0]
+    assert index == 0
+    assert name == "read.read"
+    assert json.loads(arguments) == {"path": "/etc/hostname"}
 
 
-def test_parse_delta_truncated_cot_no_toolcall(parser_cls, tok):
-    # Contemplated invoke inside an unterminated to=self block: no tool call,
-    # no framing leak into content, partial reasoning recovered.
-    reasoning, content, tools = _drive(
-        parser_cls,
-        tok,
+def test_streaming_tool_call_carries_id_and_type(tokenizer):
+    """The streamed tool call must expose a nonempty id and ``type="function"``
+    alongside its index, name, and arguments. ``drive`` flattens tool calls to
+    ``(index, name, arguments)``, so assert the full metadata on the raw
+    ``DeltaMessage`` objects here.
+    """
+    parser = ParserManager.get_parser(
+        reasoning_parser_name="muse_glimmer",
+        tool_parser_name="muse_glimmer",
+        enable_auto_tools=True,
+    )(tokenizer)
+    request = SimpleNamespace(tools=None, tool_choice="auto", include_reasoning=True)
+    text = (
+        " to=self<|message|>I should read the hostname.<|eom|>"
+        "<|start|>assistant to=read.read<|message|>"
+        '<atem:function_calls>\n<atem:invoke name="read.read">\n'
+        '<atem:parameter name="path">/etc/hostname</atem:parameter>\n'
+        "</atem:invoke>\n</atem:function_calls>"
+    )
+    prompt_ids = encode(tokenizer, PROMPT)
+    token_ids = encode(tokenizer, text)
+    collected = []
+    for position, token_id in enumerate(token_ids):
+        message = parser.parse_delta(
+            tokenizer.decode([token_id]),
+            [token_id],
+            request,
+            prompt_token_ids=prompt_ids if position == 0 else None,
+            finished=position == len(token_ids) - 1,
+        )
+        if message is not None:
+            collected.extend(message.tool_calls or [])
+    assert len(collected) == 1
+    call = collected[0]
+    assert call.index == 0
+    assert call.type == "function"
+    assert call.id
+    function = call.function
+    name = function.get("name") if isinstance(function, dict) else function.name
+    assert name == "read.read"
+
+
+def test_truncated_cot_does_not_parse_contemplated_call(tokenizer):
+    reasoning, content, tools = drive_tokenwise(
+        tokenizer,
         " to=self<|message|>Maybe I should call "
         '<atem:function_calls>\n<atem:invoke name="read.read">\n'
         '<atem:parameter name="path">/etc/hostname</atem:parameter>\n'
         "</atem:invoke>\n</atem:function_calls> but wait",
     )
-    _assert_no_framing(content)
-    assert tools == [], f"contemplated invoke leaked as tool call: {tools}"
-    assert "Maybe I should call" in reasoning, repr(reasoning)
+    assert tools == []
+    assert content == ""
+    assert "Maybe I should call" in reasoning
 
 
-def test_parse_delta_reasoning_suppressed_when_not_requested(parser_cls, tok):
-    class _NoReasonReq:
-        tools = None
-        tool_choice = None
-        include_reasoning = False
-
-    reasoning, content, tools = _drive(
-        parser_cls,
-        tok,
+def test_reasoning_can_be_suppressed(tokenizer):
+    request = SimpleNamespace(
+        tools=None,
+        tool_choice="auto",
+        include_reasoning=False,
+    )
+    reasoning, content, tools = drive_tokenwise(
+        tokenizer,
         " to=self<|message|>secret thoughts<|eom|>"
         "<|start|>assistant to=user<|message|>Public answer.<|eot|>",
-        req=_NoReasonReq(),
+        request=request,
     )
-    assert reasoning == "", repr(reasoning)  # suppressed
-    assert content == "Public answer.", repr(content)
-    _assert_no_framing(content)
+    assert reasoning == ""
+    assert content == "Public answer."
+    assert tools == []
 
 
-if __name__ == "__main__":
-    import sys
+def test_continued_user_channel_surfaces_clean_content(tokenizer):
+    prompt = PROMPT + " to=user<|message|>"
+    reasoning, content, tools = drive(
+        tokenizer,
+        ['{"value":"x"}<|eot|>'],
+        prompt=prompt,
+    )
+    bare_reasoner = MuseGlimmerReasoningParser(tokenizer)
+    assert bare_reasoner.is_reasoning_end(encode(tokenizer, prompt))
+    assert reasoning == ""
+    assert content == '{"value":"x"}'
+    assert tools == []
 
-    sys.exit(pytest.main([__file__, "-v"]))
+
+def test_continued_user_channel_surfaces_clean_content_reasoning_only(tokenizer):
+    # Same as above but with no tool parser: the reasoning-only composite must
+    # still stream the continued to=user body as clean content.
+    prompt = PROMPT + " to=user<|message|>"
+    reasoning, content, tools = drive(
+        tokenizer,
+        ['{"value":"x"}<|eot|>'],
+        prompt=prompt,
+        with_tool_parser=False,
+    )
+    assert reasoning == ""
+    assert content == '{"value":"x"}'
+    assert tools == []
+
+
+def test_nonstreaming_answer_with_tools_auto_is_clean(tokenizer):
+    # Non-streaming parse(): tools registered + tool_choice="auto", but the model
+    # answers without calling a tool. The final content must be the clean answer,
+    # with no channel framing leaked (regression guard: extract_reasoning returns
+    # the raw framed turn, and the composite must strip it when no call fires).
+    parser = ParserManager.get_parser(
+        reasoning_parser_name="muse_glimmer",
+        tool_parser_name="muse_glimmer",
+        enable_auto_tools=True,
+    )(tokenizer)
+    request = SimpleNamespace(
+        tools=[
+            {
+                "type": "function",
+                "function": {"name": "weather.get", "parameters": {"type": "object"}},
+            }
+        ],
+        tool_choice="auto",
+        include_reasoning=True,
+    )
+    model_output = (
+        " to=self<|message|>Simple. 3+3 = 6. No tool needed.<|eom|>"
+        "<|start|>assistant to=user<|message|>3 + 3 = 6<|eot|>"
+    )
+    reasoning, content, tools = parser.parse(
+        model_output, request, enable_auto_tools=True
+    )
+    assert reasoning == "Simple. 3+3 = 6. No tool needed."
+    assert content == "3 + 3 = 6"
+    for marker in FRAMING:
+        assert marker not in (content or ""), (marker, content)
+    assert not tools
+
+
+def test_quoted_bare_tool_header_stays_in_reasoning(tokenizer):
+    quoted = "I am quoting: to=weather.get<|message|> as plain text."
+    reasoning, content, tools = drive(tokenizer, [" to=self<|message|>" + quoted])
+    assert reasoning == quoted
+    assert content == ""
+    assert tools == []
+
+
+def test_bare_tool_switch_with_atem_after_open_reasoning_parses(tokenizer):
+    reasoning, content, tools = drive(
+        tokenizer,
+        [
+            " to=self<|message|>think then to=weather.get<|message|>"
+            + EMPTY_TOOL_XML
+            + "<|eot|>"
+        ],
+    )
+    assert reasoning == "think then "
+    assert content == ""
+    assert tool_names(tools) == ["weather.get"]
+
+
+def test_framed_answer_closes_open_reasoning(tokenizer):
+    reasoning, content, tools = drive(
+        tokenizer,
+        [
+            " to=self<|message|>think"
+            "<|start|>assistant to=user<|message|>The answer is 42.<|eot|>"
+        ],
+    )
+    assert reasoning == "think"
+    assert content == "The answer is 42."
+    assert tools == []
+
+
+def test_closed_prompt_reasoning_does_not_seed_generation(tokenizer):
+    prompt = PROMPT + " to=self<|message|>Prior.<|eom|>"
+    reasoner = MuseGlimmerReasoningParser(tokenizer)
+    reasoner.adjust_initial_state_from_prompt(encode(tokenizer, prompt))
+    reasoning, content, tools = drive(
+        tokenizer,
+        [" <|start|>assistant to=user<|message|>The answer is 42.<|eot|>"],
+        prompt=prompt,
+    )
+    assert reasoner._initial_recipient is None
+    assert reasoning == ""
+    assert content == "The answer is 42."
+    assert tools == []
+
+
+def test_fully_framed_tool_switch_after_open_reasoning_still_parses(tokenizer):
+    reasoning, content, tools = drive(
+        tokenizer,
+        [
+            " to=self<|message|>Need weather.",
+            "<|start|>assistant to=weather.get<|message|>" + TOOL_XML,
+        ],
+    )
+    assert reasoning == "Need weather."
+    assert content == ""
+    assert tool_names(tools) == ["weather.get"]
+
+
+def test_answer_tail_is_emitted_before_straddled_tool_call(tokenizer):
+    reasoning, content, tools = drive(
+        tokenizer,
+        [
+            " to=user<|message|>The answer",
+            " tail.<|start|>assistant to=weather.get<|message|>",
+            TOOL_XML,
+        ],
+    )
+    assert reasoning == ""
+    assert content == "The answer tail."
+    assert tool_names(tools) == ["weather.get"]
+
+
+def test_sequential_tool_channels_in_one_delta_are_preserved(tokenizer):
+    second = TOOL_XML.replace("weather.get", "weather.forecast")
+    reasoning, content, tools = drive(
+        tokenizer,
+        [
+            " to=self<|message|>Need both.<|eom|>"
+            "<|start|>assistant to=weather.get<|message|>"
+            + TOOL_XML
+            + "<|eom|><|start|>assistant to=weather.forecast<|message|>"
+            + second
+            + "<|eot|>"
+        ],
+    )
+    assert reasoning == "Need both."
+    assert content == ""
+    assert tool_names(tools) == ["weather.get", "weather.forecast"]
+
+
+def test_truncated_user_body_drops_partial_marker(tokenizer):
+    reasoning, content, tools = drive(
+        tokenizer,
+        [" to=user<|message|>answer<|eo"],
+    )
+    assert reasoning == ""
+    assert content == "answer"
+    assert tools == []
+
+
+def test_truncated_reasoning_flushes_held_tail(tokenizer):
+    reasoning, content, tools = drive_tokenwise(
+        tokenizer,
+        " to=self<|message|>thinking hard about to",
+        with_tool_parser=False,
+    )
+    assert reasoning == "thinking hard about to"
+    assert content == ""
+    assert tools == []
+
+
+@pytest.mark.parametrize(
+    "preamble",
+    [
+        "Some preamble ",
+        "This deliberately long preamble extends beyond the final answer ",
+    ],
+    ids=("short", "long"),
+)
+def test_untagged_atem_does_not_hide_following_answer(tokenizer, preamble):
+    reasoning, content, tools = drive_tokenwise(
+        tokenizer,
+        "<|message|>"
+        + preamble
+        + TOOL_XML
+        + "<|eot|><|start|>assistant to=user<|message|>real answer<|eot|>",
+    )
+    assert reasoning == ""
+    assert content == "real answer"
+    assert tools == []
+    assert_no_framing(content)
+
+
+def test_mixed_hermes_tool_parser_keeps_muse_channels_clean(tokenizer):
+    reasoning, content, tools = drive_tokenwise(
+        tokenizer,
+        " to=self<|message|>think<|eom|>"
+        "<|start|>assistant to=user<|message|>The answer.<|eot|>",
+        tool_parser_name="hermes",
+    )
+    assert reasoning == "think"
+    assert content == "The answer."
+    assert not tools
+    assert_no_framing(reasoning + content)
+
+
+def test_nonstreaming_mixed_hermes_tool_parser_keeps_muse_channels_clean(tokenizer):
+    parser = ParserManager.get_parser(
+        reasoning_parser_name="muse_glimmer",
+        tool_parser_name="hermes",
+        enable_auto_tools=True,
+    )(tokenizer)
+    reasoning, content, tools = parser.parse(
+        " to=self<|message|>think<|eom|>"
+        "<|start|>assistant to=user<|message|>The answer.<|eot|>",
+        SimpleNamespace(tools=None, tool_choice="auto", include_reasoning=True),
+        enable_auto_tools=True,
+    )
+    assert reasoning == "think"
+    assert content == "The answer."
+    assert not tools
+    assert_no_framing(reasoning + content)
+
+
+def test_closed_body_preserves_quoted_start_marker(tokenizer):
+    reasoning, content, tools = drive_tokenwise(
+        tokenizer,
+        " to=self<|message|>quote <|start|>garbage here<|eom|>"
+        "<|start|>assistant to=user<|message|>done<|eot|>",
+    )
+    assert reasoning == "quote <|start|>garbage here"
+    assert content == "done"
+    assert tools == []
+
+
+def test_reasoning_only_keeps_straddled_answer_tail(tokenizer):
+    reasoning, content, tools = drive(
+        tokenizer,
+        [
+            " to=self<|message|>think<|eom|>"
+            "<|start|>assistant to=user<|message|>answer before ",
+            "tool<|eom|><|start|>assistant to=weather.get<|message|>"
+            + TOOL_XML
+            + "<|eot|>",
+        ],
+        with_tool_parser=False,
+    )
+    assert reasoning == "think"
+    assert content == "answer before tool"
+    assert tools == []
+    assert_no_framing(content)
+
+
+def test_reasoning_only_tool_channel_yields_no_content(tokenizer):
+    reasoning, content, tools = drive(
+        tokenizer,
+        [
+            " to=self<|message|>think<|eom|>"
+            "<|start|>assistant to=weather.get<|message|>" + TOOL_XML + "<|eot|>"
+        ],
+        with_tool_parser=False,
+    )
+    assert reasoning == "think"
+    assert content == ""
+    assert tools == []
+
+
+def test_streaming_never_leaks_partial_tool_header(tokenizer):
+    generation = (
+        " to=self<|message|>maybe to=weather.get<|message|>"
+        + EMPTY_TOOL_XML
+        + "<|eot|>"
+    )
+    reasoning, content, tools = drive_tokenwise(tokenizer, generation)
+    assert reasoning == "maybe "
+    assert content == ""
+    assert tool_names(tools) == ["weather.get"]
+    assert_no_framing(reasoning)
+
+
+def test_streaming_preserves_words_ending_in_t(tokenizer):
+    reasoning, content, tools = drive_tokenwise(
+        tokenizer, " to=self<|message|>the most important point"
+    )
+    assert reasoning == "the most important point"
+    assert content == ""
+    assert tools == []
+
+
+def test_answer_may_quote_atem_markup(tokenizer):
+    """An answer addressed to the user may legitimately quote ATEM markup, e.g.
+    when the question is about tool-call syntax. Withholding such a body loses
+    the whole answer, and tool-call parsing is scoped to recipient-tagged
+    bodies, so the quoted markup can never become a call.
+    """
+    answer = 'Call it like <atem:invoke name="weather.get"> and close it.'
+    reasoning, content, tools = drive(
+        tokenizer,
+        [
+            " to=self<|message|>explain the syntax<|eom|>"
+            "<|start|>assistant to=user<|message|>" + answer + "<|eot|>"
+        ],
+    )
+    assert reasoning == "explain the syntax"
+    assert content == answer
+    assert tools == []
+
+
+def test_framed_header_without_space_still_bounds_a_body(tokenizer):
+    """``MSG_HEADER_RE`` accepts a framed header with no space before
+    ``<|message|>``, so the body-boundary pattern must too. If it did not, the
+    preceding body would be cut at the stray ``<|start|>`` and this message
+    would be skipped entirely, dropping its body.
+    """
+    reasoning, content, tools = drive(
+        tokenizer,
+        [
+            " to=self<|message|>think"
+            "<|start|>assistant<|message|>The answer is 42.<|eot|>"
+        ],
+    )
+    assert reasoning == "think"
+    assert content == "The answer is 42."
+    assert tools == []
+    assert_no_framing(content)
+
+
+@pytest.mark.parametrize(
+    ("emitted", "current", "expected"),
+    [
+        ("abc", "abcdef", ("def", "abcdef")),
+        ("", "new", ("new", "new")),
+        ("abc", "abc", ("", "abc")),
+        # A reclassified body legitimately shrinks -- a partial header becomes
+        # recognisable and is trimmed, or a body stops qualifying as content.
+        # The cursor must hold so already-streamed text is not re-emitted.
+        ("abcdef", "abc", ("", "abcdef")),
+        ("abc", "", ("", "abc")),
+        # A body that shrank and regrew with a different prefix must not have
+        # the old cursor applied to the new text.
+        ("abc", "xyz", ("", "abc")),
+    ],
+)
+def test_advance_emitted_never_moves_cursor_backwards(emitted, current, expected):
+    assert advance_emitted(emitted, current) == expected
+
+
+@pytest.mark.parametrize("constraint", ["response_format", "structured_outputs"])
+def test_active_tools_reject_caller_output_constraint(constraint):
+    request_kwargs = {}
+    if constraint == "response_format":
+        request_kwargs["response_format"] = {
+            "type": "json_schema",
+            "json_schema": {"name": "answer", "schema": {"type": "object"}},
+        }
+    else:
+        request_kwargs["structured_outputs"] = StructuredOutputsParams(
+            json={"type": "object"}
+        )
+    request = ChatCompletionRequest(
+        messages=[{"role": "user", "content": "hi"}],
+        tools=[
+            {
+                "type": "function",
+                "function": {"name": "weather.get", "parameters": {"type": "object"}},
+            }
+        ],
+        tool_choice="auto",
+        **request_kwargs,
+    )
+    parser = ParserManager.get_parser(
+        reasoning_parser_name="muse_glimmer",
+        tool_parser_name="muse_glimmer",
+        enable_auto_tools=True,
+    )(CharTokenizer())
+    with pytest.raises(VLLMValidationError, match="cannot be combined"):
+        parser.adjust_request(request)
+
+
+def test_responses_text_format_rejected_with_tools():
+    request = ResponsesRequest.model_validate(
+        {
+            "model": "test-model",
+            "input": "hi",
+            "tools": [
+                {
+                    "type": "function",
+                    "name": "weather.get",
+                    "parameters": {"type": "object"},
+                    "strict": True,
+                }
+            ],
+            "tool_choice": "auto",
+            "text": {"format": {"type": "json_object"}, "verbosity": "high"},
+        }
+    )
+    parser = ParserManager.get_parser(
+        reasoning_parser_name="muse_glimmer",
+        tool_parser_name="muse_glimmer",
+        enable_auto_tools=True,
+    )(CharTokenizer())
+    with pytest.raises(VLLMValidationError, match="cannot be combined"):
+        parser.adjust_request(request)
+
+
+def test_responses_stray_response_format_rejected_with_tools():
+    request = ResponsesRequest.model_validate(
+        {
+            "model": "test-model",
+            "input": "hi",
+            "tools": [
+                {
+                    "type": "function",
+                    "name": "weather.get",
+                    "parameters": {"type": "object"},
+                    "strict": True,
+                }
+            ],
+            "tool_choice": "auto",
+            "response_format": {"type": "json_object"},
+        }
+    )
+    parser = ParserManager.get_parser(
+        reasoning_parser_name="muse_glimmer",
+        tool_parser_name="muse_glimmer",
+        enable_auto_tools=True,
+    )(CharTokenizer())
+    with pytest.raises(
+        VLLMValidationError,
+        match="cannot be combined",
+    ) as exc_info:
+        parser.adjust_request(request)
+    assert exc_info.value.parameter == "response_format"
+
+
+def test_active_tools_allow_plain_text_response_format():
+    request = ChatCompletionRequest(
+        messages=[{"role": "user", "content": "hi"}],
+        tools=[
+            {
+                "type": "function",
+                "function": {"name": "weather.get", "parameters": {"type": "object"}},
+            }
+        ],
+        tool_choice="auto",
+        response_format={"type": "text"},
+    )
+    parser = ParserManager.get_parser(
+        reasoning_parser_name="muse_glimmer",
+        tool_parser_name="muse_glimmer",
+        enable_auto_tools=True,
+    )(CharTokenizer())
+    adjusted = parser.adjust_request(request)
+    assert adjusted.response_format is not None
+    assert adjusted.response_format.type == "text"
+
+
+def test_responses_tools_allow_plain_text_format_and_preserve_text_fields():
+    request = ResponsesRequest.model_validate(
+        {
+            "model": "test-model",
+            "input": "hi",
+            "tools": [
+                {
+                    "type": "function",
+                    "name": "weather.get",
+                    "parameters": {"type": "object"},
+                    "strict": True,
+                }
+            ],
+            "tool_choice": "auto",
+            "text": {"format": {"type": "text"}, "verbosity": "high"},
+        }
+    )
+    parser = ParserManager.get_parser(
+        reasoning_parser_name="muse_glimmer",
+        tool_parser_name="muse_glimmer",
+        enable_auto_tools=True,
+    )(CharTokenizer())
+    adjusted = parser.adjust_request(request)
+    assert adjusted.text is not None
+    assert adjusted.text.format is not None
+    assert adjusted.text.format.type == "text"
+    assert adjusted.text.verbosity == "high"
+
+
+@pytest.mark.parametrize("constraint", ["response_format", "structured_outputs"])
+def test_reasoning_only_parser_preserves_output_constraint(constraint):
+    request_kwargs = {}
+    if constraint == "response_format":
+        request_kwargs["response_format"] = {
+            "type": "json_schema",
+            "json_schema": {"name": "answer", "schema": {"type": "object"}},
+        }
+    else:
+        request_kwargs["structured_outputs"] = StructuredOutputsParams(
+            json={"type": "object"}
+        )
+    request = ChatCompletionRequest(
+        messages=[{"role": "user", "content": "hi"}],
+        tools=[
+            {
+                "type": "function",
+                "function": {"name": "weather.get", "parameters": {"type": "object"}},
+            }
+        ],
+        tool_choice="auto",
+        **request_kwargs,
+    )
+    parser = ParserManager.get_parser(reasoning_parser_name="muse_glimmer")(
+        CharTokenizer()
+    )
+    parser.adjust_request(request)
+    if constraint == "response_format":
+        assert request.response_format is not None
+    else:
+        assert request.structured_outputs is not None

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -361,7 +361,9 @@ class OpenAIServingChat(GenerateBaseServing):
                     # non-reasoning outputs.
                     reasoning_ended = True
                 elif parser is not None and parser.reasoning_parser is not None:
-                    reasoning_ended = parser.is_reasoning_end(prompt_token_ids or [])
+                    reasoning_ended = parser.reasoning_parser.is_reasoning_end(
+                        prompt_token_ids or []
+                    )
                 else:
                     reasoning_ended = None
 

--- a/vllm/parser/muse_glimmer.py
+++ b/vllm/parser/muse_glimmer.py
@@ -1,0 +1,231 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import TYPE_CHECKING
+
+from vllm.entrypoints.generate.base.protocol import DeltaMessage, FunctionCall
+from vllm.exceptions import VLLMValidationError
+from vllm.parser.abstract_parser import DelegatingParser, StreamState
+from vllm.reasoning.muse_glimmer_reasoning_parser import MuseGlimmerReasoningParser
+from vllm.reasoning.muse_glimmer_utils import (
+    advance_emitted,
+    current_assistant_turn,
+    open_recipient,
+    safe_open_body,
+    visible_channels,
+)
+from vllm.tool_parsers.muse_glimmer_tool_parser import MuseGlimmerToolParser
+
+if TYPE_CHECKING:
+    from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
+    from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
+
+
+class MuseGlimmerParser(DelegatingParser):
+    """Compose MuseGlimmer reasoning, answer, and tool channels."""
+
+    def adjust_request(
+        self, request: ChatCompletionRequest | ResponsesRequest
+    ) -> ChatCompletionRequest | ResponsesRequest:
+        """Reject caller output constraints that collide with ATEM tools."""
+        if (
+            self._tool_parser is not None
+            and request.tools
+            and request.tool_choice != "none"
+        ):
+            constraint = None
+            if request.structured_outputs is not None:
+                constraint = "structured_outputs"
+            elif (
+                response_format := getattr(request, "response_format", None)
+            ) is not None and getattr(response_format, "type", None) != "text":
+                constraint = "response_format"
+            elif (
+                (text := getattr(request, "text", None)) is not None
+                and (fmt := getattr(text, "format", None)) is not None
+                and getattr(fmt, "type", None) != "text"
+            ):
+                constraint = "text.format"
+            if constraint is not None:
+                raise VLLMValidationError(
+                    "MuseGlimmer tool calling cannot be combined with "
+                    "response_format, text.format, or structured_outputs.",
+                    parameter=constraint,
+                )
+        return super().adjust_request(request)
+
+    def parse_delta(
+        self,
+        delta_text: str,
+        delta_token_ids: list[int],
+        request: ChatCompletionRequest | ResponsesRequest,
+        prompt_token_ids: list[int] | None = None,
+        *,
+        finished: bool,
+    ) -> DeltaMessage | None:
+        """Let the ATEM segmenter own streams paired with its tool parser."""
+        state = self._stream_state
+        if isinstance(self._tool_parser, MuseGlimmerToolParser):
+            if not state.prompt_reasoning_checked and prompt_token_ids is not None:
+                reasoner = self._reasoning_parser
+                if isinstance(reasoner, MuseGlimmerReasoningParser):
+                    reasoner.adjust_initial_state_from_prompt(prompt_token_ids)
+                    if reasoner._initial_recipient is not None:
+                        state.previous_text = (
+                            f"to={reasoner._initial_recipient}<|message|>"
+                        )
+            state.reasoning_ended = True
+            state.prompt_reasoning_checked = True
+        return super().parse_delta(
+            delta_text,
+            delta_token_ids,
+            request,
+            prompt_token_ids=prompt_token_ids,
+            finished=finished,
+        )
+
+    def is_reasoning_end(self, input_ids: list[int]) -> bool:
+        """Bypass frontend reasoning only for the paired ATEM tool parser."""
+        if isinstance(self._tool_parser, MuseGlimmerToolParser):
+            return True
+        if isinstance(self._reasoning_parser, MuseGlimmerReasoningParser):
+            try:
+                text = self.model_tokenizer.decode(input_ids)
+            except Exception:
+                return False
+            recipient = open_recipient(current_assistant_turn(text))
+            return self._tool_parser is not None and recipient not in (
+                None,
+                "self",
+                "user",
+            )
+        return super().is_reasoning_end(input_ids)
+
+    def is_reasoning_end_streaming(
+        self, input_ids: list[int], delta_ids: list[int]
+    ) -> bool:
+        return self.is_reasoning_end(input_ids)
+
+    def finalize_generation(
+        self,
+        delta_message: DeltaMessage | None,
+        request: ChatCompletionRequest | ResponsesRequest,
+        state: StreamState,
+    ) -> DeltaMessage | None:
+        delta_message = super().finalize_generation(delta_message, request, state)
+        reasoner = self._reasoning_parser
+        tool_parser = self._tool_parser
+
+        if isinstance(reasoner, MuseGlimmerReasoningParser) and not isinstance(
+            tool_parser, MuseGlimmerToolParser
+        ):
+            reasoning_remainder = reasoner.get_streaming_fallback_reasoning(
+                state.previous_text
+            )
+            if reasoning_remainder:
+                if delta_message is None:
+                    delta_message = DeltaMessage()
+                delta_message.reasoning = (
+                    delta_message.reasoning or ""
+                ) + reasoning_remainder
+
+        if not isinstance(tool_parser, MuseGlimmerToolParser):
+            return delta_message
+
+        content, reasoning, content_open, _reasoning_open = visible_channels(
+            state.previous_text
+        )
+        if content_open:
+            content = safe_open_body(content)
+        content_remainder, emitted_content = advance_emitted(
+            tool_parser._emitted_content, content
+        )
+        reasoning_remainder, emitted_reasoning = advance_emitted(
+            tool_parser._emitted_reasoning, reasoning
+        )
+        if not content_remainder and not reasoning_remainder:
+            return delta_message
+
+        if delta_message is None:
+            delta_message = DeltaMessage()
+        if content_remainder:
+            delta_message.content = (delta_message.content or "") + content_remainder
+            tool_parser._emitted_content = emitted_content
+        if reasoning_remainder:
+            delta_message.reasoning = (
+                delta_message.reasoning or ""
+            ) + reasoning_remainder
+            tool_parser._emitted_reasoning = emitted_reasoning
+        return delta_message
+
+    def _extract_tool_calls(
+        self,
+        content: str | None,
+        request: ChatCompletionRequest | ResponsesRequest,
+        enable_auto_tools: bool = False,
+    ) -> tuple[list[FunctionCall] | None, str | None]:
+        if self._tool_parser is None and isinstance(
+            self._reasoning_parser, MuseGlimmerReasoningParser
+        ):
+            return [], MuseGlimmerToolParser._extract_content(content or "")
+
+        tool_calls, out_content = super()._extract_tool_calls(
+            content, request, enable_auto_tools
+        )
+        # ``extract_reasoning`` returns the raw framed turn as ``content`` so the
+        # tool parser can segment it. When no tool call fires (the model wrote a
+        # ``to=user`` answer), the base path returns that raw input unchanged, so
+        # strip the channel framing before it reaches the client.
+        if (
+            not tool_calls
+            and out_content
+            and isinstance(self._reasoning_parser, MuseGlimmerReasoningParser)
+        ):
+            out_content = MuseGlimmerToolParser._extract_content(out_content)
+        return tool_calls, out_content
+
+    def _extract_tool_calls_streaming(
+        self,
+        previous_text: str,
+        current_text: str,
+        delta_text: str,
+        previous_token_ids: Sequence[int],
+        current_token_ids: Sequence[int],
+        delta_token_ids: Sequence[int],
+        request: ChatCompletionRequest | ResponsesRequest,
+        tool_call_idx: int | None = None,
+        tool_call_id_type: str = "random",
+        function_name_returned: bool = False,
+    ) -> tuple[DeltaMessage | None, bool]:
+        if not (
+            isinstance(self._tool_parser, MuseGlimmerToolParser)
+            and request.tool_choice == "none"
+        ):
+            return super()._extract_tool_calls_streaming(
+                previous_text,
+                current_text,
+                delta_text,
+                previous_token_ids,
+                current_token_ids,
+                delta_token_ids,
+                request,
+                tool_call_idx=tool_call_idx,
+                tool_call_id_type=tool_call_id_type,
+                function_name_returned=function_name_returned,
+            )
+
+        delta_message = self.extract_tool_calls_streaming(
+            previous_text,
+            current_text,
+            delta_text,
+            previous_token_ids,
+            current_token_ids,
+            delta_token_ids,
+            request,
+        )
+        if delta_message is not None:
+            delta_message.tool_calls = []
+        return delta_message, False

--- a/vllm/parser/parser_manager.py
+++ b/vllm/parser/parser_manager.py
@@ -126,6 +126,21 @@ class ParserManager:
 
             return _KimiK3Parser
 
+        if (
+            reasoning_parser_name == "muse_glimmer"
+            or tool_parser_name == "muse_glimmer"
+        ):
+            from vllm.parser.muse_glimmer import MuseGlimmerParser
+
+            r_cls = reasoning_parser_cls
+            t_cls = tool_parser_cls
+
+            class _MuseGlimmerParser(MuseGlimmerParser):
+                reasoning_parser_cls = r_cls
+                tool_parser_cls = t_cls
+
+            return _MuseGlimmerParser
+
         from vllm.parser.abstract_parser import DelegatingParser
 
         r_cls = reasoning_parser_cls

--- a/vllm/reasoning/muse_glimmer_reasoning_parser.py
+++ b/vllm/reasoning/muse_glimmer_reasoning_parser.py
@@ -1,243 +1,93 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""Reasoning-content parser for MuseGlimmer.
-Port of the ``reasoning_content`` rule from the HuggingFace MuseGlimmer
-``MUSE_GLIMMER_RESPONSE_SCHEMA`` (synced with internal master). MuseGlimmer emits
-chain-of-thought in ``to=self`` channels delimited by ``<|message|>`` ... ``<|eom|>``:
-    to=self<|message|>...reasoning...<|eom|>
-A turn may contain several ``to=self`` blocks interleaved with tool calls, and a
-tool call or final answer follows in its own channel.
-Because MuseGlimmer's framing markers (``<|message|>``, ``<|eom|>``) are not guaranteed
-to be single vocab tokens across every checkpoint's tokenizer, this parser works
-on the decoded text with regexes rather than the single start/end-token base class.
-Usage: ``--reasoning-parser muse_glimmer``
-"""
+"""Reasoning-content parser for MuseGlimmer channel-scoped output."""
 
 from __future__ import annotations
 
 from collections.abc import Iterable, Sequence
 
-import regex as re
-
 from vllm.entrypoints.generate.base.protocol import DeltaMessage
 from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
 from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
 from vllm.reasoning.abs_reasoning_parsers import ReasoningParser
-
-_EOM = "<|eom|>"
-_EOT = "<|eot|>"
-_FUNCTION_CALLS_OPEN = "<atem:function_calls>"
-_REASONING_OPEN = "to=self<|message|>"
-_ASSISTANT_TURN_OPEN = "<|start|>assistant"
-# A channel header: ``to=<recipient><|message|>`` where recipient is ``self``
-# (reasoning), ``user`` (final answer) or ``<tool>[.<fn>]`` (tool call).
-_CHANNEL_HEADER_RE = re.compile(r"to=(?P<recipient>[^\s<]+)<\|message\|>")
-_HEADER_PAT = r"to=[^\s<]+<\|message\|>"
-# Collapse the gap between reasoning blocks so multiple to=self spans join.
-_COLLAPSE_RE = re.compile(
-    r"<\|eom\|>(?:(?!to=self<\|message\|>).)*?to=self<\|message\|>", re.DOTALL
+from vllm.reasoning.muse_glimmer_utils import (
+    advance_emitted,
+    current_assistant_turn,
+    open_recipient,
+    safe_open_body,
+    visible_channels,
 )
-_REASONING_RE = re.compile(r"to=self<\|message\|>(.*?)<\|eom\|>", re.DOTALL)
-_CONTENT_RE = re.compile(
-    r"to=user<\|message\|>(.*?)(?=<\|eot\|>|<\|eom\|>|$)", re.DOTALL
-)
-# Strip a CLOSED reasoning span (header .. <|eom|>).
-_STRIP_REASONING_RE = re.compile(
-    r"(?:<\|start\|>assistant\s*)?to=self<\|message\|>.*?<\|eom\|>", re.DOTALL
-)
-# An UNTERMINATED trailing reasoning span. The model sometimes leaves the
-# analysis channel WITHOUT emitting <|eom|>, writing a bare
-# ``to=<tool><|message|>`` header instead (observed deterministically for a call
-# with EMPTY arguments on a tool that has optional parameters; reproduced on
-# other engines too, so it is a model-side defect, not engine-specific).
-#
-# These two patterns MUST therefore stop at the next channel header rather than
-# running to end-of-text. An unbounded ``...$`` version consumes the real tool
-# call along with the reasoning: `is_reasoning_end` then never fires, the parser
-# never leaves the reasoning phase, the tool parser is never invoked, and the
-# entire generation is dropped (empty reasoning, empty content, no tool call).
-_STRIP_OPEN_REASONING_RE = re.compile(
-    r"(?:<\|start\|>assistant\s*)?to=self<\|message\|>"
-    r"(?:(?!<\|eom\|>)(?!" + _HEADER_PAT + r").)*"
-    r"(?=" + _HEADER_PAT + r"|$)",
-    re.DOTALL,
-)
-_OPEN_REASONING_RE = re.compile(
-    r"to=self<\|message\|>((?:(?!<\|eom\|>)(?!" + _HEADER_PAT + r").)*)"
-    r"(?=" + _HEADER_PAT + r"|$)",
-    re.DOTALL,
-)
-# Markers whose PREFIX could appear at the tail of an OPEN (still-streaming) body.
-_HOLDBACK_MARKERS = (_EOM, _EOT, "<|start|>", "<|message|>")
-# A trailing fragment that could still grow into a channel header (" t", " to",
-# " to=", " to=skill"). Without this the recipient name leaks into reasoning and
-# then has to be un-emitted once ``<|message|>`` arrives.
-_OPEN_TAIL_HEADER_RE = re.compile(r"[\s](?:t|to|to=[^\s<]*)$")
-
-
-def _current_assistant_turn(text: str) -> str:
-    """Return only the text generated in the current assistant turn.
-    ``is_reasoning_end`` is evaluated on the PROMPT token-ids at stream start,
-    and an MuseGlimmer prompt legitimately contains ATEM markers (``render_tool_defs``
-    writes a literal ``<atem:function_calls>`` example into the system message,
-    and prior assistant turns may carry real tool calls). Anchoring on the last
-    channel-open keeps prompt text from deciding the phase.
-    """
-    idx = text.rfind(_ASSISTANT_TURN_OPEN)
-    return text[idx + len(_ASSISTANT_TURN_OPEN) :] if idx != -1 else text
-
-
-def _trim_open_body(body: str) -> str:
-    """Hold back any tail of a still-growing body that could still be framing.
-    Iterated to a fixpoint because the two cases compose: `" to=skill<"` needs
-    the partial-marker trim (``<``) before the partial-header trim can see
-    `" to=skill"`. Trimming only once leaks the recipient name as reasoning.
-    """
-    while True:
-        trimmed = body
-        for marker in _HOLDBACK_MARKERS:
-            for k in range(min(len(marker) - 1, len(trimmed)), 0, -1):
-                if trimmed.endswith(marker[:k]):
-                    trimmed = trimmed[:-k]
-                    break
-            else:
-                continue
-            break
-        header_tail = _OPEN_TAIL_HEADER_RE.search(trimmed)
-        if header_tail is not None:
-            trimmed = trimmed[: header_tail.start()]
-        if trimmed == body:
-            return body
-        body = trimmed
 
 
 class MuseGlimmerReasoningParser(ReasoningParser):
     def __init__(self, tokenizer, *args, **kwargs) -> None:
         super().__init__(tokenizer, *args, **kwargs)
-        # Cursors over what was ACTUALLY emitted. Diffing a freshly reclassified
-        # `previous_text` is unsafe: a classified body legitimately shrinks when
-        # a partial header becomes recognisable, and diffing against the shrunken
-        # value re-emits text that already went out.
-        self._emitted_reasoning: str = ""
-        self._emitted_content: str = ""
-        self._tool_handoff_done: bool = False
+        self._emitted_reasoning = ""
+        self._emitted_content = ""
+        self._initial_recipient: str | None = None
 
     def adjust_request(
         self, request: ChatCompletionRequest | ResponsesRequest
     ) -> ChatCompletionRequest | ResponsesRequest:
-        """Preserve MuseGlimmer's ATEM framing tokens in the decoded output.
-        vLLM's serving default is ``skip_special_tokens=True``, which strips
-        ``<|start|>`` / ``<|message|>`` / ``<|eom|>`` / ``<|eot|>`` before the
-        parsers run, collapsing reasoning into content and breaking channel
-        scoping. Unlike the base tool-parser hook we do NOT touch
-        ``structured_outputs`` -- MuseGlimmer emits native ATEM, not JSON.
-        """
+        """Preserve MuseGlimmer framing so channel parsing remains possible."""
         request.skip_special_tokens = False
         return request
 
     def is_reasoning_end(self, input_ids: Sequence[int]) -> bool:
-        """Whether the model has left reasoning and opened a TOOL channel.
-        A ``to=user`` answer is NOT a reason to leave the reasoning phase -- this
-        parser surfaces that content itself. Only a real tool channel switches
-        the ``DelegatingParser`` phase machine over to the tool parser.
-        Both closed and unterminated reasoning spans are stripped before the
-        check, so an ``<atem:invoke>`` the model merely echoes inside its CoT
-        never flips the phase.
-        """
+        """Report an open answer or tool channel to engine-side callers."""
         try:
             text = self.model_tokenizer.decode(input_ids)
         except Exception:
             return False
-        remainder = self._tool_channel_remainder(text)
-        return _FUNCTION_CALLS_OPEN in remainder or "<atem:invoke" in remainder
+        recipient = open_recipient(current_assistant_turn(text))
+        return recipient not in (None, "self")
 
     def is_reasoning_end_streaming(
         self, input_ids: Sequence[int], delta_ids: Iterable[int]
     ) -> bool:
-        return self.is_reasoning_end(list(input_ids))
+        return self.is_reasoning_end(input_ids)
+
+    def adjust_initial_state_from_prompt(self, prompt_token_ids: Sequence[int]) -> None:
+        """Continue classifying generation in the prompt's open channel."""
+        try:
+            text = self.model_tokenizer.decode(prompt_token_ids)
+        except Exception:
+            return
+        self._initial_recipient = open_recipient(current_assistant_turn(text))
 
     def extract_content_ids(self, input_ids: list[int]) -> list[int]:
-        # Content-id slicing is unreliable for multi-token markers; the serving
-        # path uses extract_reasoning() for the final split.
+        # Content-id slicing is unreliable for multi-token markers.
         return []
 
-    @classmethod
-    def _scoped_turn(cls, text: str) -> str:
-        """Current assistant turn with reasoning spans removed."""
-        scoped = _current_assistant_turn(text)
-        scoped = _STRIP_REASONING_RE.sub("", scoped)
-        return _STRIP_OPEN_REASONING_RE.sub("", scoped)
-
-    @classmethod
-    def _tool_channel_remainder(cls, text: str) -> str:
-        """Text from the first tool-channel header onward, framing INCLUDED.
-        ``DelegatingParser.parse_delta`` rebuilds ``current_text`` from whatever
-        this parser returns as ``.content`` on the transition delta and commits
-        it; anything not returned is destroyed. It must start AT the
-        ``to=<name><|message|>`` header -- handing over the text after the header
-        loses the recipient, and the tool parser then sees a bare ``<|message|>``,
-        classifies it as the content channel, and leaks the ATEM markup.
-        """
-        scoped = cls._scoped_turn(text)
-        for match in _CHANNEL_HEADER_RE.finditer(scoped):
-            if match.group("recipient") not in ("self", "user"):
-                return scoped[match.start() :]
-        return ""
-
-    @staticmethod
-    def _classify_bodies(text: str) -> tuple[str, str]:
-        """Split ``text`` into (reasoning_body, content_body), channel-aware.
-        Framing markers and tool channels contribute nothing -- the tool parser
-        owns those. A body ends at ``<|eom|>`` / ``<|eot|>``, at the next channel
-        header, or at end-of-text (an OPEN body, which is held back).
-        """
-        reasoning_parts: list[str] = []
-        content_parts: list[str] = []
-        pos = 0
-        n = len(text)
-        while pos < n:
-            match = _CHANNEL_HEADER_RE.search(text, pos)
-            if not match:
-                break
-            recipient = match.group("recipient")
-            body_start = match.end()
-            eom = text.find(_EOM, body_start)
-            eot = text.find(_EOT, body_start)
-            terminators = [p for p in (eom, eot) if p != -1]
-            next_header = _CHANNEL_HEADER_RE.search(text, body_start)
-            if next_header is not None:
-                terminators.append(next_header.start())
-            body_end = min(terminators) if terminators else n
-            body = text[body_start:body_end]
-            if not terminators:
-                body = _trim_open_body(body)
-            if recipient == "self":
-                reasoning_parts.append(body)
-            elif (
-                # Never surface tool XML echoed into a user channel.
-                recipient == "user"
-                and _FUNCTION_CALLS_OPEN not in body
-                and "<atem:invoke" not in body
-            ):
-                content_parts.append(body)
-            if terminators and body_end in (eom, eot):
-                pos = body_end + len(_EOM if body_end == eom else _EOT)
-            else:
-                pos = body_end
-        return "".join(reasoning_parts), "".join(content_parts)
+    def _seeded_text(self, text: str) -> str:
+        if self._initial_recipient is None:
+            return text
+        return f"to={self._initial_recipient}<|message|>{text}"
 
     def get_streaming_fallback_content(
         self,
         previous_text: str,
         request: ChatCompletionRequest | ResponsesRequest,
     ) -> str | None:
-        """Promote un-surfaced content when the stream ends mid-reasoning.
-        ``DelegatingParser.finalize_generation`` calls this when
-        ``reasoning_ended`` is still False. Returns only the channel-classified
-        ``to=user`` body, and only the portion not already streamed.
-        """
-        _, content_body = self._classify_bodies(previous_text)
-        remainder = content_body[len(self._emitted_content) :]
+        """Promote any unstreamed answer body when generation is truncated."""
+        content, _reasoning, content_open, _reasoning_open = visible_channels(
+            self._seeded_text(previous_text)
+        )
+        if content_open:
+            content = safe_open_body(content)
+        remainder, self._emitted_content = advance_emitted(
+            self._emitted_content, content
+        )
+        return remainder or None
+
+    def get_streaming_fallback_reasoning(self, previous_text: str) -> str | None:
+        """Flush reasoning text held back while its channel was still open."""
+        _content, reasoning, _content_open, _reasoning_open = visible_channels(
+            self._seeded_text(previous_text)
+        )
+        remainder, self._emitted_reasoning = advance_emitted(
+            self._emitted_reasoning, reasoning
+        )
         return remainder or None
 
     def extract_reasoning(
@@ -245,34 +95,11 @@ class MuseGlimmerReasoningParser(ReasoningParser):
         model_output: str,
         request: ChatCompletionRequest | ResponsesRequest,
     ) -> tuple[str | None, str | None]:
-        collapsed = _COLLAPSE_RE.sub("\n", model_output)
-        matches = _REASONING_RE.findall(collapsed)
-        reasoning = "\n".join(matches) if matches else None
-        # Truncation fallback: generation stopped inside a to=self block, so
-        # there is no closing <|eom|>. Bounded at the next channel header so a
-        # real tool call that follows a header-less channel switch is not
-        # absorbed into the reasoning field.
-        open_match = _OPEN_REASONING_RE.search(model_output)
-        if open_match and open_match.group(1):
-            partial = open_match.group(1)
-            reasoning = f"{reasoning}\n{partial}" if reasoning else partial
-        # Content is everything that is not a reasoning block. In a
-        # reasoning+tool-call turn there is no to=user answer, but the tool
-        # channels MUST be forwarded -- the unified parser runs the tool parser
-        # on this returned `content`, not on the original model_output.
-        remainder = _STRIP_REASONING_RE.sub("", model_output)
-        remainder = _STRIP_OPEN_REASONING_RE.sub("", remainder)
-        if "<atem:invoke" in remainder or _FUNCTION_CALLS_OPEN in remainder:
-            return reasoning, (remainder or None)
-        content_match = _CONTENT_RE.search(model_output)
-        if content_match:
-            content = content_match.group(1) or None
-        elif _REASONING_OPEN in model_output:
-            content = None
-        else:
-            content = model_output or None
-            reasoning = None
-        return reasoning, content
+        """Extract reasoning while preserving framed text for channel consumers."""
+        _content, reasoning, _content_open, _reasoning_open = visible_channels(
+            model_output
+        )
+        return reasoning or None, model_output or None
 
     def extract_reasoning_streaming(
         self,
@@ -283,45 +110,25 @@ class MuseGlimmerReasoningParser(ReasoningParser):
         current_token_ids: Sequence[int],
         delta_token_ids: Sequence[int],
     ) -> DeltaMessage | None:
-        """Channel-aware streaming split of reasoning vs content.
-        Classifies the full ``current_text`` and emits only what has not been
-        emitted yet, so no framing token is ever surfaced and a delta straddling
-        a channel boundary only contributes the portion inside a real body.
-        """
-        curr_reason, curr_content = self._classify_bodies(current_text)
-        reasoning_delta = ""
-        if curr_reason.startswith(self._emitted_reasoning) and len(curr_reason) > len(
-            self._emitted_reasoning
-        ):
-            reasoning_delta = curr_reason[len(self._emitted_reasoning) :]
-            self._emitted_reasoning = curr_reason
-        content_delta = ""
-        if curr_content.startswith(self._emitted_content) and len(curr_content) > len(
-            self._emitted_content
-        ):
-            content_delta = curr_content[len(self._emitted_content) :]
-            self._emitted_content = curr_content
-        # Hand the tool channel to the tool parser exactly once, starting at its
-        # header. parse_delta discards anything not returned here.
-        #
-        # This MUST fire on the same delta where is_reasoning_end() flips, i.e.
-        # only once the tool channel actually contains ATEM. Emitting it earlier
-        # -- when only the bare `to=<name><|message|>` header has arrived -- keeps
-        # the parser in the reasoning phase, so parse_delta never replaces this
-        # DeltaMessage with the tool parser's and the header is delivered to the
-        # client as visible content.
-        handoff = ""
-        if not self._tool_handoff_done:
-            remainder = self._tool_channel_remainder(current_text)
-            if _FUNCTION_CALLS_OPEN in remainder or "<atem:invoke" in remainder:
-                handoff = remainder
-                self._tool_handoff_done = True
-        if handoff:
-            return DeltaMessage(reasoning=reasoning_delta or None, content=handoff)
-        if reasoning_delta and content_delta:
-            return DeltaMessage(reasoning=reasoning_delta, content=content_delta)
-        if reasoning_delta:
-            return DeltaMessage(reasoning=reasoning_delta)
-        if content_delta:
-            return DeltaMessage(content=content_delta)
-        return None
+        """Stream clean reasoning and answer bodies from the shared segmenter."""
+        content, reasoning, content_open, reasoning_open = visible_channels(
+            self._seeded_text(current_text), withhold_open_untagged=True
+        )
+        if content_open:
+            content = safe_open_body(content)
+        if reasoning_open:
+            reasoning = safe_open_body(reasoning)
+
+        reasoning_delta, self._emitted_reasoning = advance_emitted(
+            self._emitted_reasoning, reasoning
+        )
+        content_delta, self._emitted_content = advance_emitted(
+            self._emitted_content, content
+        )
+        if not reasoning_delta and not content_delta:
+            return None
+
+        return DeltaMessage(
+            reasoning=reasoning_delta or None,
+            content=content_delta or None,
+        )

--- a/vllm/reasoning/muse_glimmer_utils.py
+++ b/vllm/reasoning/muse_glimmer_utils.py
@@ -1,0 +1,194 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Pure-text channel segmentation utilities for MuseGlimmer output."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import regex as re
+
+EOM = "<|eom|>"
+EOT = "<|eot|>"
+ASSISTANT_TURN_OPEN = "<|start|>assistant"
+FUNCTION_CALLS_OPEN = "<atem:function_calls>"
+REASONING_RECIPIENT = "self"
+USER_RECIPIENT = "user"
+
+# All parts except <|message|> are optional. The bare form is used for public
+# chain-of-thought or untagged content.
+MSG_HEADER_RE = re.compile(
+    r"(?:<\|start\|>\s*assistant)?[^\S\n]*"
+    r"(?:to=(?P<recipient>[A-Za-z0-9_.\-]+))?<\|message\|>"
+)
+MSG_END_RE = re.compile(r"<\|eom\|>|<\|eot\|>")
+
+# Whitespace handling must match MSG_HEADER_RE exactly. If this pattern were
+# stricter, a header it rejected but MSG_HEADER_RE accepted would be recognised
+# as a header yet not as a body boundary: iter_messages would then cut the
+# preceding body at the stray <|start|> and skip past the header, silently
+# dropping that message's body.
+FRAMED_HEADER_PATTERN = (
+    r"<\|start\|>\s*assistant[^\S\n]*"
+    r"(?:to=[A-Za-z0-9_.\-]+)?<\|message\|>"
+)
+BARE_HEADER_WITH_ATEM_PATTERN = (
+    r"to=(?!(?:self|user)<\|message\|>)[A-Za-z0-9_.\-]+<\|message\|>"
+    r"(?=\s*<atem:(?:function_calls>|invoke(?:\s|>)))"
+)
+BODY_BOUNDARY_PATTERN = rf"(?:{FRAMED_HEADER_PATTERN}|{BARE_HEADER_WITH_ATEM_PATTERN})"
+BODY_BOUNDARY_RE = re.compile(BODY_BOUNDARY_PATTERN)
+
+_STRUCTURAL_MARKERS = (EOM, EOT, "<|start|>", "<|message|>")
+_MAX_MARKER_LEN = max(len(marker) for marker in _STRUCTURAL_MARKERS)
+_OPEN_TAIL_HEADER_RE = re.compile(r"[^\S\n]+(?:t|to|to=[A-Za-z0-9_.\-]*)$")
+
+
+def current_assistant_turn(text: str) -> str:
+    """Return the text following the latest framed assistant marker."""
+    index = text.rfind(ASSISTANT_TURN_OPEN)
+    if index == -1:
+        return text
+    return text[index + len(ASSISTANT_TURN_OPEN) :]
+
+
+def iter_messages(text: str) -> Iterator[tuple[str | None, str, bool]]:
+    """Yield ``(recipient, body, closed)`` for each MuseGlimmer message.
+
+    A body ends at an explicit end marker, a fully framed assistant header, or
+    a bare recipient header immediately followed by ATEM tool-call markup.
+    """
+    pos = 0
+    while pos < len(text):
+        header = MSG_HEADER_RE.search(text, pos)
+        if header is None:
+            return
+
+        body_start = header.end()
+        end = MSG_END_RE.search(text, body_start)
+        boundary = BODY_BOUNDARY_RE.search(text, body_start)
+        body_end = end.start() if end is not None else len(text)
+        closed = end is not None
+
+        if boundary is not None and boundary.start() < body_end:
+            body_end = boundary.start()
+            closed = False
+            next_pos = boundary.start()
+        else:
+            next_pos = end.end() if end is not None else len(text)
+
+        body = text[body_start:body_end]
+        # Hold back only a trailing prefix of a framed header. A literal
+        # <|start|> inside a closed body is user text and must be preserved.
+        start_token = body.find("<|start|>")
+        while start_token != -1:
+            candidate = body[start_token:]
+            partial_header = re.fullmatch(
+                FRAMED_HEADER_PATTERN, candidate, partial=True
+            )
+            if partial_header is not None and partial_header.partial:
+                body = body[:start_token]
+                closed = False
+                break
+            start_token = body.find("<|start|>", start_token + 1)
+
+        yield header.group("recipient"), body, closed
+        pos = next_pos
+
+
+def _trailing_partial_marker_len(text: str) -> int:
+    """Return the longest suffix that prefixes a structural marker."""
+    max_overlap = min(len(text), _MAX_MARKER_LEN - 1)
+    for overlap in range(max_overlap, 0, -1):
+        suffix = text[-overlap:]
+        if any(marker.startswith(suffix) for marker in _STRUCTURAL_MARKERS):
+            return overlap
+    return 0
+
+
+def safe_open_body(body: str) -> str:
+    """Trim a growing body's suffix until it is safe to emit."""
+    while True:
+        trimmed = body
+
+        partial_marker = _trailing_partial_marker_len(trimmed)
+        if partial_marker:
+            trimmed = trimmed[:-partial_marker]
+
+        header_tail = _OPEN_TAIL_HEADER_RE.search(trimmed)
+        if header_tail is not None:
+            trimmed = trimmed[: header_tail.start()]
+
+        boundary = BODY_BOUNDARY_RE.search(trimmed, partial=True)
+        if boundary is not None and boundary.partial and boundary.end() == len(trimmed):
+            candidate = trimmed[boundary.start() :]
+            if candidate.startswith(("to=", "<|start|>")):
+                trimmed = trimmed[: boundary.start()]
+
+        if trimmed == body:
+            return body
+        body = trimmed
+
+
+def visible_channels(
+    text: str, *, withhold_open_untagged: bool = False
+) -> tuple[str, str, bool, bool]:
+    """Return content, reasoning, and whether each last body is still open.
+
+    Open untagged bodies may later become ATEM tool channels, so streaming
+    callers withhold them until their classification can no longer shrink.
+    """
+    content_parts: list[str] = []
+    reasoning_parts: list[str] = []
+    content_open = False
+    reasoning_open = False
+
+    for recipient, body, closed in iter_messages(text):
+        if recipient == REASONING_RECIPIENT:
+            reasoning_parts.append(body)
+            reasoning_open = not closed
+        elif recipient is None or recipient == USER_RECIPIENT:
+            # An UNTAGGED body carrying ATEM markup is a tool channel whose
+            # ``to=`` never arrived, so surfacing it would leak markup that
+            # tool-call parsing (scoped to recipient-tagged bodies) never
+            # claims. A ``to=user`` body is addressed to the client and may
+            # legitimately quote ATEM -- e.g. answering a question about
+            # tool-call syntax -- so it is surfaced as written.
+            if recipient is None and (
+                FUNCTION_CALLS_OPEN in body or "<atem:invoke" in body
+            ):
+                continue
+            if recipient is None and not closed and withhold_open_untagged:
+                continue
+            content_parts.append(body)
+            content_open = not closed
+
+    return (
+        "".join(content_parts),
+        "\n".join(reasoning_parts),
+        content_open,
+        reasoning_open,
+    )
+
+
+def advance_emitted(emitted: str, current: str) -> tuple[str, str]:
+    """Return ``(delta, new_emitted)`` for a body that must only ever grow.
+
+    A reclassified body legitimately SHRINKS between deltas: a partial header
+    becomes recognisable and is trimmed, or a body stops qualifying as content.
+    Storing a shrunken value would move the cursor backwards and re-emit text
+    that already went out, so a non-extending value yields no delta and leaves
+    the cursor untouched.
+    """
+    if not current.startswith(emitted) or len(current) <= len(emitted):
+        return "", emitted
+    return current[len(emitted) :], current
+
+
+def open_recipient(text: str) -> str | None:
+    """Return the recipient of the last open message, if one exists."""
+    recipient: str | None = None
+    is_open = False
+    for recipient, _body, closed in iter_messages(text):
+        is_open = not closed
+    return recipient if is_open else None

--- a/vllm/tool_parsers/muse_glimmer_tool_parser.py
+++ b/vllm/tool_parsers/muse_glimmer_tool_parser.py
@@ -2,9 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """ATEM tool-call parser for MuseGlimmer.
 
-Faithful port of the MuseGlimmer ``response_schema`` tool-call contract from the
-HuggingFace MuseGlimmer export (``convert_muse_glimmer_weights_to_hf.py``:
-``MUSE_GLIMMER_RESPONSE_SCHEMA``).
+Implements the MuseGlimmer response schema's tool-call contract.
 
 MuseGlimmer emits tool calls in an XML-ish ATEM format inside channel-scoped messages:
 
@@ -35,7 +33,7 @@ Usage: ``--enable-auto-tool-choice --tool-call-parser muse_glimmer``
 from __future__ import annotations
 
 import json
-from collections.abc import Iterator, Sequence
+from collections.abc import Sequence
 
 import regex as re
 from openai.types.responses import ToolChoiceFunction
@@ -56,6 +54,24 @@ from vllm.entrypoints.openai.chat_completion.protocol import (
 )
 from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
 from vllm.logger import init_logger
+from vllm.reasoning.muse_glimmer_utils import (
+    FUNCTION_CALLS_OPEN as _FUNCTION_CALLS_OPEN,
+)
+from vllm.reasoning.muse_glimmer_utils import (
+    MSG_HEADER_RE as _MSG_HEADER_RE,
+)
+from vllm.reasoning.muse_glimmer_utils import (
+    REASONING_RECIPIENT as _REASONING_RECIPIENT,
+)
+from vllm.reasoning.muse_glimmer_utils import (
+    USER_RECIPIENT as _USER_RECIPIENT,
+)
+from vllm.reasoning.muse_glimmer_utils import (
+    advance_emitted,
+    iter_messages,
+    safe_open_body,
+    visible_channels,
+)
 from vllm.tool_parsers.abstract_tool_parser import (
     Tool,
     ToolParser,
@@ -63,42 +79,13 @@ from vllm.tool_parsers.abstract_tool_parser import (
 
 logger = init_logger(__name__)
 
-# --- Message framing -------------------------------------------------------
-# An assistant message header. All three parts are optional except the
-# <|message|> terminator:
-#   "<|start|>assistant to=get_weather<|message|>"  -- after an <|eom|> boundary
-#   " to=self<|message|>"                           -- first message of a turn
-#                                                      (the prompt already ended
-#                                                      with "<|start|>assistant")
-#   "<|message|>"                                   -- bare recipient (public CoT
-#                                                      / untagged content)
-_MSG_HEADER_RE = re.compile(
-    r"(?:<\|start\|>\s*assistant)?[^\S\n]*(?:to=(?P<rcpt>[A-Za-z0-9_.\-]+))?<\|message\|>"
-)
-_MSG_END_RE = re.compile(r"<\|eom\|>|<\|eot\|>")
-
-# Recipients whose bodies are NOT tool calls.
-_REASONING_RECIPIENT = "self"
-_USER_RECIPIENT = "user"
-
-# Structural markers that must never reach the client. A streamed body is held
-# back by up to len(marker)-1 characters so a marker split across two chunks is
-# not emitted as content.
-_STRUCTURAL_MARKERS = ("<|eom|>", "<|eot|>", "<|start|>", "<|message|>")
-_MAX_MARKER_LEN = max(len(m) for m in _STRUCTURAL_MARKERS)
-# A trailing " to=NAME" that could still grow into a bare message header (the
-# first message of a turn has no <|start|> prefix -- the prompt ends with
-# "<|start|>assistant", so the model's first emitted text is " to=self<|message|>").
-_OPEN_TAIL_TO_RE = re.compile(r"[^\S\n]+to=[A-Za-z0-9_.\-]*$")
-
-# --- Tool-call extraction (unchanged from MUSE_GLIMMER_RESPONSE_SCHEMA) -------------
+# --- Tool-call extraction --------------------------------------------------
 _INVOKE_RE = re.compile(r"(<atem:invoke\b.*?</atem:invoke>)", re.DOTALL)
 _NAME_RE = re.compile(r'<atem:invoke\b[^>]*?\bname="([^"]+)"')
 _PARAM_RE = re.compile(
     r'<atem:parameter\b[^>]*?\bname="(?P<key>[^"]+)"[^>]*?>(?P<value>.*?)</atem:parameter>',
     re.DOTALL,
 )
-_FUNCTION_CALLS_OPEN = "<atem:function_calls>"
 
 
 def _decode_value(raw: str):
@@ -110,73 +97,6 @@ def _decode_value(raw: str):
         return json.loads(raw)
     except (json.JSONDecodeError, ValueError):
         return raw
-
-
-def _iter_messages(text: str) -> Iterator[tuple[str | None, str, bool]]:
-    """Segment *text* into assistant messages.
-
-    Yields ``(recipient, body, closed)`` per message, where ``recipient`` is
-    ``None`` for a bare ``<|message|>`` header and ``closed`` is False for a
-    message that has not (yet) seen ``<|eom|>`` / ``<|eot|>``.
-
-    A message is also terminated by the start of the NEXT header. Without that,
-    a reasoning block whose ``<|eom|>`` is missing (truncation, or a chunk
-    dropped at the reasoning -> tool transition) would absorb the tool-call
-    message that follows it and the call would be lost -- the same defect the
-    subtractive regexes have.
-    """
-    pos = 0
-    while pos < len(text):
-        header = _MSG_HEADER_RE.search(text, pos)
-        if header is None:
-            return
-        body_start = header.end()
-        end = _MSG_END_RE.search(text, body_start)
-        nxt = _MSG_HEADER_RE.search(text, body_start)
-        body_end = end.start() if end is not None else len(text)
-        closed = end is not None
-        if nxt is not None and nxt.start() < body_end:
-            body_end = nxt.start()
-            closed = False
-            next_pos = nxt.start()
-        else:
-            next_pos = end.end() if end is not None else len(text)
-        body = text[body_start:body_end]
-        # A body can never legitimately contain <|start|>. Seeing one means the
-        # next header is only partially generated (its <|message|> has not
-        # arrived), so the regex above could not recognise it yet. Cut there,
-        # otherwise the streamed body would grow to include the next header and
-        # then shrink back once it completes.
-        start_tok = body.find("<|start|>")
-        if start_tok != -1:
-            body = body[:start_tok]
-            closed = False
-        yield header.group("rcpt"), body, closed
-        pos = next_pos
-
-
-def _trailing_partial_marker_len(text: str) -> int:
-    """Length of the longest suffix of *text* that prefixes a structural marker."""
-    max_overlap = min(len(text), _MAX_MARKER_LEN - 1)
-    for overlap in range(max_overlap, 0, -1):
-        suffix = text[-overlap:]
-        if any(marker.startswith(suffix) for marker in _STRUCTURAL_MARKERS):
-            return overlap
-    return 0
-
-
-def _safe_open_body(body: str) -> str:
-    """Trim the tail of a still-growing body to what is safe to emit now.
-
-    Holds back anything that could still turn out to be structural, so the
-    emitted prefix only ever grows. Chunks under speculative decoding are large
-    enough that markers routinely straddle them.
-    """
-    tail_to = _OPEN_TAIL_TO_RE.search(body)
-    if tail_to is not None:
-        return body[: tail_to.start()]
-    partial = _trailing_partial_marker_len(body)
-    return body[: len(body) - partial] if partial else body
 
 
 class MuseGlimmerToolParser(ToolParser):
@@ -197,8 +117,8 @@ class MuseGlimmerToolParser(ToolParser):
         super().__init__(tokenizer, tools)
         # Streaming cursors. vLLM constructs one ToolParser per request, so
         # instance state is per-stream.
-        self._streamed_content_len: int = 0
-        self._streamed_reasoning_len: int = 0
+        self._emitted_content = ""
+        self._emitted_reasoning = ""
         self._emitted_tool_calls: int = 0
 
     def adjust_request(
@@ -247,7 +167,7 @@ class MuseGlimmerToolParser(ToolParser):
         """
         bodies = [
             body
-            for rcpt, body, _closed in _iter_messages(text)
+            for rcpt, body, _closed in iter_messages(text)
             if rcpt is not None
             and rcpt != _REASONING_RECIPIENT
             and rcpt != _USER_RECIPIENT
@@ -263,34 +183,6 @@ class MuseGlimmerToolParser(ToolParser):
             )
             return text
         return ""
-
-    @classmethod
-    def _visible_channels(cls, text: str) -> tuple[str, str, bool, bool]:
-        """Return ``(content, reasoning, content_open, reasoning_open)``.
-
-        The ``*_open`` flags say whether that channel's LAST message is still
-        being generated; only then must the caller hold back a partial
-        structural marker. Tracking them per channel matters: a closed
-        reasoning block whose text happens to end in ``<`` would otherwise stay
-        permanently truncated while a later content message is open.
-        """
-        content_parts: list[str] = []
-        reasoning_parts: list[str] = []
-        content_open = False
-        reasoning_open = False
-        for rcpt, body, closed in _iter_messages(text):
-            if rcpt == _REASONING_RECIPIENT:
-                reasoning_parts.append(body)
-                reasoning_open = not closed
-            elif rcpt is None or rcpt == _USER_RECIPIENT:
-                content_parts.append(body)
-                content_open = not closed
-        return (
-            "".join(content_parts),
-            "".join(reasoning_parts),
-            content_open,
-            reasoning_open,
-        )
 
     # ---------------- tool name binding ----------------
 
@@ -363,7 +255,7 @@ class MuseGlimmerToolParser(ToolParser):
     @classmethod
     def _extract_content(cls, text: str) -> str | None:
         """Return the user-facing body, or the raw text when unframed."""
-        content, reasoning, _c_open, _r_open = cls._visible_channels(text)
+        content, reasoning, _c_open, _r_open = visible_channels(text)
         if content:
             return content
         # No framing at all -> the whole thing is plain content.
@@ -445,26 +337,30 @@ class MuseGlimmerToolParser(ToolParser):
         if not previous_text:
             # First delta of the tool phase (parse_delta resets previous_text
             # to "" when it hands the stream over). Reset the cursors.
-            self._streamed_content_len = 0
-            self._streamed_reasoning_len = 0
+            self._emitted_content = ""
+            self._emitted_reasoning = ""
             self._emitted_tool_calls = 0
 
         try:
             registered = self._registered_names(request)
             calls = self._parse_tool_calls(current_text, registered)
-            content, reasoning, content_open, reasoning_open = self._visible_channels(
-                current_text
+            content, reasoning, content_open, reasoning_open = visible_channels(
+                current_text, withhold_open_untagged=True
             )
 
             # Trim the tail of a channel that is still growing, so the emitted
             # prefix never shrinks between deltas.
             if content_open:
-                content = _safe_open_body(content)
+                content = safe_open_body(content)
             if reasoning_open:
-                reasoning = _safe_open_body(reasoning)
+                reasoning = safe_open_body(reasoning)
 
-            content_delta = content[self._streamed_content_len :]
-            reasoning_delta = reasoning[self._streamed_reasoning_len :]
+            content_delta, self._emitted_content = advance_emitted(
+                self._emitted_content, content
+            )
+            reasoning_delta, self._emitted_reasoning = advance_emitted(
+                self._emitted_reasoning, reasoning
+            )
 
             tool_deltas: list[DeltaToolCall] = []
             for i in range(self._emitted_tool_calls, len(calls)):
@@ -484,8 +380,6 @@ class MuseGlimmerToolParser(ToolParser):
             if not content_delta and not reasoning_delta and not tool_deltas:
                 return None
 
-            self._streamed_content_len = len(content)
-            self._streamed_reasoning_len = len(reasoning)
             self._emitted_tool_calls = len(calls)
 
             message = DeltaMessage()


### PR DESCRIPTION
## Purpose

`response_format: json_schema` (and other guided-decoding requests) are silently ignored for Muse Glimmer: the model free-generates prose instead of schema-constrained JSON. `json_object` works, so the gap is specific to schema-constrained output.

**Root cause:** the structured-outputs backend only applies the grammar after the reasoning parser reports reasoning-end, but `MuseGlimmerReasoningParser.is_reasoning_end` only returned `True` when a *tool* channel opened — a `to=user` final answer was never treated as reasoning-end. On a no-tool request the grammar was therefore never engaged.

## Approach

Muse Glimmer's channel handling is kept out of the shared `DelegatingParser`. A dedicated composite `MuseGlimmerParser(DelegatingParser)` (mirroring `KimiK3Parser`) owns the model-specific routing, and grammar activation is separated from stream ownership:

- **Grammar activation** lives in `MuseGlimmerReasoningParser.is_reasoning_end`, which the structured-outputs backend calls directly. It fires once the current turn opens any non-`self` channel (the `to=user` answer **or** a `to=<tool>` call), detected on the *last* channel header so a turn that answers the user and then calls a tool is not pinned to the answer channel. This is what lets `response_format` engage on a no-tool request.

- **Stream ownership** lives in `MuseGlimmerParser`: `is_reasoning_end_streaming` only transitions the phase machine when a tool channel opens, so the reasoning parser keeps emitting the `to=user` answer body itself and never hands it to the tool parser prematurely (which would otherwise drop the body or leak the channel header). The `tool_choice="none"` and no-tool-parser paths are handled locally in the composite, stripping channel framing rather than leaking it into content.

The shared `vllm/parser/abstract_parser.py` and `vllm/reasoning/abs_reasoning_parsers.py` are unchanged, so other models are unaffected.

## Test Plan

```bash
# focused unit tests for this fix
pytest tests/tool_use/test_muse_glimmer.py tests/tool_use/test_muse_glimmer_parse_delta.py

# regression for the shared DelegatingParser / parser registry
pytest tests/parser/ tests/reasoning/
```

E2E against a served `meta-models/Muse-Glimmer-30B` (bf16, 2x H100) with `--tool-call-parser muse_glimmer --reasoning-parser muse_glimmer`:

```bash
SCHEMA='{"type":"object","properties":{"name":{"type":"string"},"capital":{"type":"string"}},"required":["name","capital"],"additionalProperties":false}'
curl -s localhost:8000/v1/chat/completions -H 'Content-Type: application/json' \
  -d "{\"model\":\"muse-glimmer\",\"temperature\":0,\"max_tokens\":2048,\"messages\":[{\"role\":\"user\",\"content\":\"What is France?\"}],\"response_format\":{\"type\":\"json_schema\",\"json_schema\":{\"name\":\"country\",\"schema\":$SCHEMA}}}"
```

Also tested `response_format: json_object`, plain chat, and `tool_choice` auto/required/named, streaming and non-streaming.

## Test Result

**`json_schema`** returns schema-conformant JSON, non-streaming and streaming:

```json
{ "name": "France", "capital": "Paris" }
```

- Unit tests pass (`tests/tool_use/test_muse_glimmer*.py`).
- Live-server E2E: `json_schema` is schema-conformant across several schema shapes, streaming and non-streaming; `json_object`, plain chat, and `tool_choice` auto/required/named remain correct with no channel framing leaked into content.

---

This PR was developed with AI assistance. All changed lines were reviewed by the submitter and validated end-to-end on a live Muse-Glimmer-30B server as above.

Co-authored-by: OpenAI Codex
