### PR TITLE
[Bugfix][Frontend] Honor tool declarations on developer/system messages

### DIFF
--- a/tests/reasoning/test_kimi_k3_reasoning_parser.py
+++ b/tests/reasoning/test_kimi_k3_reasoning_parser.py
@@ -343,3 +343,60 @@ def test_reasoning_end_matches_reference_over_marker_dense_sequences(seed):
             assert parser.is_reasoning_end_streaming(
                 full, delta
             ) == _reference_is_reasoning_end(full), (head, delta)
+
+
+TOOLS_CHANNEL = f"{OPEN}tools{SEP}call{CLOSE}tools{SEP}"
+
+
+def _message_level_tools_request(
+    tool_choice: str, role: str = "developer"
+) -> ChatCompletionRequest:
+    return ChatCompletionRequest(
+        model="test-model",
+        messages=[
+            {
+                "role": role,
+                "content": "",
+                "tools": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "calc",
+                            "parameters": {"type": "object", "properties": {}},
+                        },
+                    }
+                ],
+            },
+            {"role": "user", "content": "hi"},
+        ],
+        tool_choice=tool_choice,
+    )
+
+
+@pytest.mark.parametrize("role", ["developer", "system"])
+def test_tool_channels_preserved_for_message_level_tools(role):
+    """The tools channel must survive for the tool parser even though the
+    tools were declared on a message rather than on the request."""
+    parser = KimiK3ReasoningParser(DummyTokenizer())
+    rest = f"{RESPONSE_OPEN}answer{CLOSE}response{SEP}{TOOLS_CHANNEL}"
+
+    reasoning, content = parser.extract_reasoning_content(
+        f"{THINK_OPEN}step{THINK_CLOSE}{rest}",
+        _message_level_tools_request("auto", role),
+    )
+
+    assert reasoning == "step"
+    assert content == rest
+
+
+def test_tool_channels_stripped_for_message_level_tools_with_choice_none():
+    parser = KimiK3ReasoningParser(DummyTokenizer())
+    rest = f"{RESPONSE_OPEN}answer{CLOSE}response{SEP}{TOOLS_CHANNEL}"
+
+    reasoning, content = parser.extract_reasoning_content(
+        f"{THINK_OPEN}step{THINK_CLOSE}{rest}",
+        _message_level_tools_request("none"),
+    )
+
+    assert reasoning == "step"
+    assert content == "answer"

--- a/tests/renderers/test_inkling.py
+++ b/tests/renderers/test_inkling.py
@@ -151,6 +151,29 @@ class TestRustFixtureParity:
             "<|message_model|>"
         )
 
+    def test_tool_declare_on_system_message(self, inkling_tokenizer):
+        """`developer` folds into `system`, so either role may declare."""
+        tool = {
+            "type": "function",
+            "function": {"name": "local_tool", "parameters": {"z": 1}},
+        }
+        rendered = render_text(
+            inkling_tokenizer,
+            [
+                {"role": "system", "content": "rules", "tools": [tool]},
+                {"role": "user", "content": "hi"},
+            ],
+        )
+
+        assert "local_tool" in rendered
+        assert rendered == render_text(
+            inkling_tokenizer,
+            [
+                {"role": "developer", "content": "rules", "tools": [tool]},
+                {"role": "user", "content": "hi"},
+            ],
+        )
+
     def test_text_image(self, inkling_tokenizer):
         messages = [
             {

--- a/tests/tool_use/test_chat_completion_request_validations.py
+++ b/tests/tool_use/test_chat_completion_request_validations.py
@@ -182,3 +182,115 @@ def test_multiple_structured_outputs_rejected():
                 },
             }
         )
+
+
+TOOL_DECLARING_ROLES = ["developer", "system"]
+
+
+def _message_level_tools_request(role="developer", **kwargs):
+    """A request whose only tool is declared on a message."""
+    return {
+        "messages": [
+            {"role": role, "content": "", "tools": [SAMPLE_TOOL]},
+            {"role": "user", "content": "What is the weather?"},
+        ],
+        "model": "facebook/opt-125m",
+        **kwargs,
+    }
+
+
+@pytest.mark.parametrize("role", TOOL_DECLARING_ROLES)
+def test_message_level_tools_do_not_change_tool_choice_default(role):
+    """A message declaration must not switch the request into tool mode."""
+    request = ChatCompletionRequest.model_validate(_message_level_tools_request(role))
+    assert request.tools is None
+    assert request.tool_choice == "none"
+
+
+@pytest.mark.parametrize("role", TOOL_DECLARING_ROLES)
+def test_message_level_tools_allow_auto_tool_choice(role):
+    """`auto` needs no tool schema, so a message declaration satisfies it."""
+    request = ChatCompletionRequest.model_validate(
+        _message_level_tools_request(role, tool_choice="auto")
+    )
+    assert request.tools is None
+    assert request.tool_choice == "auto"
+
+
+@pytest.mark.parametrize("role", TOOL_DECLARING_ROLES)
+def test_message_level_tools_with_tool_choice_none(role):
+    request = ChatCompletionRequest.model_validate(
+        _message_level_tools_request(role, tool_choice="none")
+    )
+    assert request.tool_choice == "none"
+
+
+@pytest.mark.parametrize("role", TOOL_DECLARING_ROLES)
+@pytest.mark.parametrize(
+    "tool_choice",
+    [
+        "required",
+        {"type": "function", "function": {"name": "get_weather"}},
+    ],
+)
+def test_message_level_tools_reject_constrained_tool_choice(tool_choice, role):
+    """These need a grammar built from the request-level tool schemas."""
+    with pytest.raises(VLLMValidationError, match='Only `tool_choice` "auto"'):
+        ChatCompletionRequest.model_validate(
+            _message_level_tools_request(role, tool_choice=tool_choice)
+        )
+
+
+@pytest.mark.parametrize("role", ["user", "assistant", "tool"])
+def test_tools_on_unsupported_role_ignored(role):
+    """Only roles forwarded to the chat template declare tools."""
+    request = ChatCompletionRequest.model_validate(
+        {
+            "messages": [
+                {"role": role, "content": "Hello", "tools": [SAMPLE_TOOL]},
+                {"role": "user", "content": "Hello"},
+            ],
+            "model": "facebook/opt-125m",
+        }
+    )
+    assert request.tool_choice == "none"
+
+
+@pytest.mark.parametrize("role", TOOL_DECLARING_ROLES)
+def test_empty_message_level_tools_do_not_enable_tools(role):
+    request = ChatCompletionRequest.model_validate(
+        {
+            "messages": [
+                {"role": role, "content": "", "tools": []},
+                {"role": "user", "content": "Hello"},
+            ],
+            "model": "facebook/opt-125m",
+        }
+    )
+    assert request.tool_choice == "none"
+
+
+@pytest.mark.parametrize("role", TOOL_DECLARING_ROLES)
+@pytest.mark.parametrize(
+    "tools",
+    [
+        "not-a-list",
+        ["not-a-dict"],
+        [{"type": "function"}],
+        [{"type": "function", "function": {}}],
+        [{"type": "function", "function": {"name": 5}}],
+        [{"type": "not-a-function", "function": {"name": "get_weather"}}],
+    ],
+)
+def test_malformed_message_level_tools_rejected(tools, role):
+    """Message-level tools follow the request-level tool schema."""
+    with pytest.raises(VLLMValidationError, match="Invalid tool declared on a message"):
+        ChatCompletionRequest.model_validate(
+            {
+                "messages": [
+                    {"role": role, "content": "", "tools": tools},
+                    {"role": "user", "content": "Hello"},
+                ],
+                "model": "facebook/opt-125m",
+            }
+        )

--- a/tests/tool_use/test_kimi_k3_tool_parser.py
+++ b/tests/tool_use/test_kimi_k3_tool_parser.py
@@ -604,3 +604,54 @@ def test_chat_params_keeps_template_tool_choice_when_api_auto():
 
     assert chat_params.chat_template_kwargs["tool_choice"] == "required"
     assert chat_params.tool_choice == "auto"
+
+
+def _message_level_tools_request(
+    *, tool_choice="auto", role="developer"
+) -> ChatCompletionRequest:
+    """A request whose only tool is declared on a message, so ``request.tools``
+    stays empty."""
+    return ChatCompletionRequest(
+        model="test-model",
+        messages=[
+            {
+                "role": role,
+                "content": "",
+                "tools": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "calc",
+                            "parameters": {"type": "object", "properties": {}},
+                        },
+                    }
+                ],
+            },
+            {"role": "user", "content": "Call the calc tool."},
+        ],
+        tool_choice=tool_choice,
+    )
+
+
+@pytest.mark.parametrize("role", ["developer", "system"])
+def test_delegating_parser_extracts_message_level_tool_calls(role):
+    """A tool declared on a message is callable: the call comes back
+    structured instead of leaking into the content as raw XTML."""
+    parser = KimiK3DelegatingParser(DummyTokenizer())
+    request = _message_level_tools_request(tool_choice="auto", role=role)
+    output = (
+        f"{THINK_OPEN}step{THINK_CLOSE}"
+        + _response("")
+        + _tools(_call("calc", 1, _arg("x", "number", "1")))
+    )
+
+    reasoning, content, tool_calls = parser.parse(
+        output, request, enable_auto_tools=True
+    )
+
+    assert request.tools is None
+    assert reasoning == "step"
+    assert tool_calls is not None
+    assert len(tool_calls) == 1
+    assert tool_calls[0].name == "calc"
+    assert json.loads(tool_calls[0].arguments) == {"x": 1}

--- a/vllm/entrypoints/chat_utils.py
+++ b/vllm/entrypoints/chat_utils.py
@@ -359,7 +359,7 @@ class CustomChatCompletionMessageParam(TypedDict, total=False):
     """The reasoning content for interleaved thinking."""
 
     tools: list[ChatCompletionFunctionToolParam] | None
-    """The tools for developer role."""
+    """Tools declared on this message, for the `developer`/`system` roles."""
 
     task: str | None
     """Model-specific task marker. Currently passed through for DeepSeek V4."""
@@ -396,7 +396,7 @@ class ConversationMessage(TypedDict, total=False):
     """Deprecated: The reasoning content for interleaved thinking."""
 
     tools: list[ChatCompletionFunctionToolParam] | None
-    """The tools for developer role."""
+    """Tools declared on this message, for the `developer`/`system` roles."""
 
     task: str | None
     """Model-specific task marker. Currently passed through for DeepSeek V4."""
@@ -1830,6 +1830,31 @@ def _parse_chat_message_content_part(
 _AssistantParser = partial(cast, ChatCompletionAssistantMessageParam)
 _ToolParser = partial(cast, ChatCompletionToolMessageParam)
 
+MESSAGE_LEVEL_TOOL_ROLES = ("developer", "system")
+
+
+def iter_message_level_tools(messages: Any) -> Iterable[Any]:
+    """Yield every tool declared on an individual message, unvalidated."""
+    if not isinstance(messages, list):
+        return
+    for message in messages:
+        if not isinstance(message, dict):
+            continue
+        if message.get("role") not in MESSAGE_LEVEL_TOOL_ROLES:
+            continue
+        tools = message.get("tools")
+        if tools is None:
+            continue
+        if isinstance(tools, list):
+            yield from tools
+        else:
+            yield tools
+
+
+def has_message_level_tools(messages: Any) -> bool:
+    """Whether any message carries a tool declaration."""
+    return any(True for _ in iter_message_level_tools(messages))
+
 
 def _parse_chat_message_content(
     message: ChatCompletionMessageParam,
@@ -1903,7 +1928,7 @@ def _parse_chat_message_content(
         if "task" in message and isinstance(message["task"], str):
             result_msg["task"] = message["task"]
 
-        if role == "developer":
+        if role in MESSAGE_LEVEL_TOOL_ROLES:
             result_msg["tools"] = message.get("tools", None)
     return result
 

--- a/vllm/entrypoints/openai/chat_completion/protocol.py
+++ b/vllm/entrypoints/openai/chat_completion/protocol.py
@@ -14,6 +14,7 @@ from pydantic import (
     Field,
     PrivateAttr,
     SerializeAsAny,
+    ValidationError,
     model_serializer,
     model_validator,
 )
@@ -22,6 +23,7 @@ from vllm.config import ModelConfig
 from vllm.entrypoints.chat_utils import (
     ChatCompletionMessageParam,
     ChatTemplateContentFormatOption,
+    iter_message_level_tools,
 )
 from vllm.entrypoints.openai.engine.protocol import (
     AnyResponseFormat,
@@ -912,6 +914,16 @@ class ChatCompletionRequest(OpenAIBaseModel):
                 parameter="tools",
             )
 
+        message_level_tools = list(iter_message_level_tools(data.get("messages")))
+        for tool in message_level_tools:
+            try:
+                ChatCompletionToolsParam.model_validate(tool)
+            except ValidationError as exc:
+                raise VLLMValidationError(
+                    f"Invalid tool declared on a message: {exc}",
+                    parameter="messages.tools",
+                ) from exc
+
         # if "tool_choice" is not specified but tools are provided,
         # default to "auto" tool_choice
         if "tool_choice" not in data and data.get("tools"):
@@ -925,10 +937,18 @@ class ChatCompletionRequest(OpenAIBaseModel):
         if "tool_choice" in data and data["tool_choice"] is not None:
             # ensure that if "tool choice" is specified, tools are present
             if "tools" not in data or data["tools"] is None:
-                raise VLLMValidationError(
-                    "When using `tool_choice`, `tools` must be set.",
-                    parameter="tool_choice",
-                )
+                if not message_level_tools:
+                    raise VLLMValidationError(
+                        "When using `tool_choice`, `tools` must be set.",
+                        parameter="tool_choice",
+                    )
+                if data["tool_choice"] != "auto":
+                    raise VLLMValidationError(
+                        'Only `tool_choice` "auto" is supported when `tools` are '
+                        "declared on a message. Set `tools` at the request level "
+                        'to use "required" or a named tool.',
+                        parameter="tool_choice",
+                    )
 
             # make sure that tool choice is either a named tool
             # OR that it's set to "auto" or "required"

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -14,6 +14,7 @@ from vllm.engine.protocol import EngineClient
 from vllm.entrypoints.chat_utils import (
     ChatTemplateContentFormatOption,
     ConversationMessage,
+    has_message_level_tools,
     make_tool_call_id,
 )
 from vllm.entrypoints.generate.base.serving import (
@@ -954,7 +955,7 @@ class OpenAIServingChat(GenerateBaseServing):
 
             # handle when there are tools and tool choice is auto
             elif (
-                request.tools
+                (request.tools or has_message_level_tools(request.messages))
                 and (request.tool_choice == "auto" or request.tool_choice is None)
                 and self.enable_auto_tools
                 and tool_parser_cls

--- a/vllm/reasoning/kimi_k3_reasoning_parser.py
+++ b/vllm/reasoning/kimi_k3_reasoning_parser.py
@@ -28,6 +28,7 @@ from typing import TYPE_CHECKING
 import regex as re
 from transformers import PreTrainedTokenizerBase
 
+from vllm.entrypoints.chat_utils import has_message_level_tools
 from vllm.entrypoints.openai.engine.protocol import DeltaMessage
 from vllm.reasoning import ReasoningParser
 
@@ -238,8 +239,10 @@ class KimiK3ReasoningParser(ReasoningParser):
     def _should_preserve_tool_channels(
         request: "ChatCompletionRequest | ResponsesRequest",
     ) -> bool:
-        return bool(getattr(request, "tools", None)) and (
-            getattr(request, "tool_choice", None) != "none"
+        if getattr(request, "tool_choice", None) == "none":
+            return False
+        return bool(getattr(request, "tools", None)) or has_message_level_tools(
+            getattr(request, "messages", None)
         )
 
     def _content_after_reasoning(

--- a/vllm/renderers/inkling_encoding.py
+++ b/vllm/renderers/inkling_encoding.py
@@ -108,11 +108,11 @@ def render_inkling_messages(
     input_ids: list[int] = []
     tool_call_id_to_name: dict[str, str] = {}
 
-    # Request-level tools plus per-developer-message tools (Rust renderer
+    # Request-level tools plus per-message tools (Rust renderer
     # semantics) are declared in a single leading system block.
     all_tools = list(tools or [])
     for message in messages:
-        if message.get("role") == "developer":
+        if message.get("role") in {"developer", "system"}:
             all_tools.extend(message.get("tools") or [])
 
     if all_tools:


### PR DESCRIPTION
## Purpose

`ChatCompletionRequest` accepts a `tools` array on an individual message, in addition to the request-level `tools` parameter. `_parse_chat_message_content` forwards those declarations to the chat template, and renderers such as the Inkling encoding render them into the prompt — so the model sees the tools and may call them. But nothing downstream of the renderer knows they exist: every consumer keys off `request.tools`, which stays empty. The feature is only half wired up.

Two user-visible symptoms:

1. `tool_choice: "auto"` is rejected with ``When using `tool_choice`, `tools` must be set.`` even though tools were declared.
2. Left at the default, `tool_choice` resolves to `"none"`, the tool parser never runs, and a tool call the model does emit is returned as plain text in `content` instead of a structured `tool_calls` entry.

### Changes, one per layer

| File | Change |
| --- | --- |
| `entrypoints/chat_utils.py` | Add `iter_message_level_tools` / `has_message_level_tools` next to the code that forwards these declarations, so the set of roles that may declare tools has a single definition. |
| `.../chat_completion/protocol.py` | Accept `tool_choice: "auto"` when tools are declared on a message; validate those tools against the request-level schema. |
| `.../chat_completion/serving.py` | Run the auto tool-call branch for message-level declarations. |
| `reasoning/kimi_k3_reasoning_parser.py` | Stop stripping the tools channel, which destroyed the call before the tool parser could see it. |
| `renderers/inkling_encoding.py` | Collect declarations from `system` as well as `developer`. |

### Why both `developer` and `system`

The two roles are aliases. OpenAI documents `developer` as the successor to `system`, and vLLM already treats them interchangeably when building prompts: `inkling_encoding.py` maps both to `MESSAGE_SYSTEM`, the Cohere renderer aliases one to the other, and the HF renderer converts `developer` to `system` when a template does not support it. Two messages with the same content therefore render to identical prompts, and honoring a tool declaration on one but silently discarding it on the other was an inconsistency rather than a contract.

Roles that are *not* forwarded to the chat template, such as `user` and `assistant`, continue to ignore the field.

### Why only `tool_choice: "auto"`

`required` and named tool choices are still rejected when tools appear only on a message, with an error that says so. They are enforced with a grammar that `get_model_structural_tag` builds from the request-level tool schemas, and that function returns early on `if not tools`:

| `tool_choice` | request-level `tools` | message-level only |
| --- | --- | --- |
| `required` | grammar built | **no grammar** |
| named | grammar built | **no grammar** |
| `auto` | no grammar | no grammar |

Accepting `required` or a named choice here would return no constraint at all, silently dropping the guarantee the API makes to the caller. `auto` builds no grammar in either case — it only asks for the output to be parsed for tool calls — so a message-level declaration is sufficient for it.

### Why the tools are validated

Pydantic does not validate inside a message's `tools` field. Declarations that are rejected with a 400 at the request level — missing `function`, a non-string `name`, an unknown `type`, a non-list value — were accepted and passed on to the chat template. They are now checked against `ChatCompletionToolsParam`, the same model used for request-level tools, so both paths agree.

### Compatibility

- Behavior for request-level `tools` is unchanged, including the rule that `tool_choice` requires tools and the test covering it.
- The `tool_choice` default is still `"none"`; a message-level declaration never switches a request into tool-calling mode on its own. Enabling it is an explicit `tool_choice: "auto"`.
- No new files; all changes are to existing ones.

## Test Plan

```bash
pytest tests/tool_use/test_chat_completion_request_validations.py \
       tests/tool_use/test_kimi_k3_tool_parser.py \
       tests/reasoning/test_kimi_k3_reasoning_parser.py \
       tests/renderers/test_inkling.py

# wider regression over the touched areas
pytest tests/parser/ tests/entrypoints/tool_parsers/ tests/reasoning/ tests/renderers/ \
       tests/tool_parsers/test_kimi_k3_named_tool_choice.py
```

New coverage, parameterized over `developer` and `system`:

- the `tool_choice` default is unchanged, `"auto"` is accepted, `required` and named are rejected;
- malformed declarations are rejected, and tools on `user`/`assistant`/`tool` are ignored;
- the tools channel survives the reasoning parser and the call comes back as a structured `tool_calls` entry;
- a `system` message and a `developer` message with the same tool render to byte-identical prompts.

## Test Result

`4972 passed, 2 skipped` across the suites above.

The 5 remaining failures and 9 errors are pre-existing and environmental — `tests/renderers/test_hf.py` needs access to gated Hugging Face repos (401), and the `hermes`/`granite4` tool-parser tests start a real server. They reproduce identically with these changes stashed.
