### PR TITLE
[Bugfix] Don't raise on non-dict hf_overrides when resolving draft quant config

### DIFF
--- a/vllm/model_executor/model_loader/weight_utils.py
+++ b/vllm/model_executor/model_loader/weight_utils.py
@@ -290,10 +290,11 @@ def get_quant_config(
     # hf_overrides
     hf_overrides = model_config.hf_overrides
     if not isinstance(hf_overrides, dict):
-        raise ValueError(
-            "hf_overrides must be a dict for get_quant_config "
-            "to get the quantization config from it."
-        )
+        # A non-dict hf_overrides (e.g. a callable draft-config transform used
+        # by DSpark/EAGLE speculative drafts) carries no quantization_config_file
+        # or _dict_json to read; treat it as no quant override so unquantized
+        # draft models resolve to None here instead of raising.
+        hf_overrides = {}
     quantization_config_file = hf_overrides.get("quantization_config_file", None)
     if quantization_config_file is not None:
         if hasattr(quant_cls, "from_config_file"):


### PR DESCRIPTION
## Purpose

Enabling DSpark speculative decoding with an **unquantized draft** crashes at engine init:

```
File "vllm/v1/worker/gpu/spec_decode/dspark/utils.py", load_dspark_model
  draft_vllm_config.quant_config = get_draft_quant_config(vllm_config)
File "vllm/model_executor/models/utils.py", get_draft_quant_config
  VllmConfig.get_quantization_config(draft_model_config, draft_load_config)
File "vllm/model_executor/model_loader/weight_utils.py", get_quant_config
ValueError: hf_overrides must be a dict for get_quant_config to get the quantization config from it.
```

### Root cause

`get_draft_quant_config()` calls `get_quant_config()` for the draft. The draft has no checkpoint quant config, so `get_quant_config` falls through to read a quant override from `model_config.hf_overrides`. For a speculative draft, `hf_overrides` is a **callable** (a draft-config transform), not a dict, so the strict `isinstance(..., dict)` check raises — even though an unquantized draft simply has no quant override to read and should resolve to `None`.

### Fix

Treat a non-dict `hf_overrides` as `{}` (no override) instead of raising. A callable override carries no `quantization_config_file` / `_dict_json` to read, so the function then continues to the `model_config.quantization_config` (online-quant) check and returns `None` for an unquantized draft. No behavior change when `hf_overrides` is already a dict.

## Test

Reproduced on Kimi-K3 (2.8T MXFP4) / 8× MI350X (gfx950), `vllm/vllm-openai-rocm:nightly`, with:
`--speculative-config '{"method":"dspark","model":"/draft","num_speculative_tokens":3}'` and an unquantized (`Qwen3DSparkModel`) draft. Before: the `ValueError` above at engine init. After: draft quant resolves to `None` and DSpark init proceeds past this point.

Signed-off-by: Asan Stefanski <asan.stefanski@gmail.com>