### PR TITLE
Fix `max_offload_tokens` assertion error.

### DIFF
--- a/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
+++ b/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
@@ -74,10 +74,11 @@ def _make_partial_tail_scheduler() -> OffloadingConnectorScheduler:
 
 def _make_partial_tail_request(
     scheduler: OffloadingConnectorScheduler,
+    kv_transfer_params: dict | None = None,
 ) -> MagicMock:
     request = MagicMock()
     request.request_id = "req"
-    request.kv_transfer_params = None
+    request.kv_transfer_params = kv_transfer_params
     request.num_prompt_tokens = 30
     request.num_tokens = 30
     request.block_hashes = [BlockHash(f"h{i}".encode()) for i in range(7)]
@@ -153,6 +154,48 @@ def test_partial_tail_store_uses_attention_and_recurrent_cow_sources():
     assert recurrent_event.token_ids == []
     assert len(recurrent_event.block_hashes) == 1
     assert recurrent_event.parent_block_hash is None
+
+
+@pytest.mark.parametrize("max_offload_tokens", [0, 16])
+def test_partial_tail_store_skipped_when_boundary_exceeds_cap(max_offload_tokens):
+    """A per-request offload cap below the core's boundary must skip, not raise.
+
+    The boundary is chosen by the core from the prompt length alone, so it can
+    legitimately exceed a cap the core never sees. ``max_offload_tokens=0``
+    means "offload nothing" and must not be read as "no cap".
+    """
+    scheduler = _make_partial_tail_scheduler()
+    _make_partial_tail_request(
+        scheduler, kv_transfer_params={"max_offload_tokens": max_offload_tokens}
+    )
+    req_status = scheduler._req_status["req"]
+    assert req_status.max_offload_tokens == max_offload_tokens
+    req_status.group_states[0].block_ids[:] = [11, 12]
+    req_status.group_states[1].block_ids[:] = [0, 21]
+    scheduler.manager.prepare_store.side_effect = (
+        lambda keys, req_context: generate_store_output(keys)
+    )
+
+    output = SimpleNamespace(partial_tail_offloads={"req": [(1, 99, 28)]})
+
+    assert scheduler._build_partial_tail_store_jobs(output) == {}
+    assert not scheduler._block_id_to_pending_jobs
+
+
+def test_partial_tail_store_honors_cap_at_boundary():
+    """A cap at or above the boundary still stores the tail."""
+    scheduler = _make_partial_tail_scheduler()
+    _make_partial_tail_request(scheduler, kv_transfer_params={"max_offload_tokens": 28})
+    req_status = scheduler._req_status["req"]
+    req_status.group_states[0].block_ids[:] = [11, 12]
+    req_status.group_states[1].block_ids[:] = [0, 21]
+    scheduler.manager.prepare_store.side_effect = (
+        lambda keys, req_context: generate_store_output(keys)
+    )
+
+    output = SimpleNamespace(partial_tail_offloads={"req": [(1, 99, 28)]})
+
+    assert len(scheduler._build_partial_tail_store_jobs(output)) == 1
 
 
 def test_partial_lookup_returns_exact_boundary_and_group_load_keys():

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
@@ -1167,13 +1167,13 @@ class OffloadingConnectorScheduler:
             assert len(boundaries) == 1
             boundary = boundaries.pop()
             req = req_status.req
-            max_boundary = min(
-                req.num_prompt_tokens,
-                req_status.max_offload_tokens or req.num_prompt_tokens,
-            )
             assert boundary > 0
+            assert boundary <= req.num_prompt_tokens
             assert boundary % self.config.tokens_per_hash == 0
-            assert boundary <= max_boundary
+            # If the boundary is past the offload cap, skip the tail.
+            cap = req_status.max_offload_tokens
+            if cap is not None and boundary > cap:
+                continue
 
             cow_blocks = {group_idx: block_id for group_idx, block_id, _ in entries}
             assert self._cow_source_groups.issubset(cow_blocks)


### PR DESCRIPTION
# [Bugfix][KV Offload] Assertion failure when `max_offload_tokens` is below the partial-tail boundary

## Purpose

The issue is in `OffloadingConnector` — the native CPU/tiered KV offload path (not P/D
disaggregation, not the Mooncake store connector) — on a hybrid Mamba attention model, like the Qwen3.5 series. On those models a physical KV block has to be large enough to hold the Mamba
state (e.g. 528 tokens on Qwen3.5-4B at TP1), so a prompt that ends mid-block used to lose everything after the last
block boundary. #50507
fixed that by letting the connector store the partial tail: the sub-block piece
of a prompt between the last complete block checkpoint, saved under its own key so a later request can reuse it.

Separately, a request can cap how much of itself is eligible for offload by setting
`max_offload_tokens` in `kv_transfer_params`
(`docs/features/kv_offloading_usage.md:303-324`). These two features together can cause an issue:
a request that sets `max_offload_tokens` can fail an assertion and thus kill the scheduler if that cap is below the partial-tail boundary.

`_build_partial_tail_store_jobs` checks the partial-tail boundary
against that per-request cap with an assert:

```python
max_boundary = min(
    req.num_prompt_tokens,
    req_status.max_offload_tokens or req.num_prompt_tokens,
)
assert boundary <= max_boundary
```

The boundary is chosen by the core as
`(num_prompt_tokens // hash_block_size) * hash_block_size`, and the core has no
knowledge of `max_offload_tokens`. So any cap below the boundary fails the assert, leaving an error like:

```
File "vllm/v1/core/sched/scheduler.py", line 1298, in schedule
File "vllm/v1/core/sched/scheduler.py", line 1320, in _build_kv_connector_meta
File ".../offloading/scheduler.py", line 1476, in build_connector_meta
File ".../offloading/scheduler.py", line 1176, in _build_partial_tail_store_jobs
AssertionError
```

The same expression has a second bug: `or` treats a falsy `max_offload_tokens=0` as
"no cap", but the documented meaning is the opposite — "`0` disables offload for the
request entirely" (`docs/features/kv_offloading_usage.md:309`).

Fix: skip the tail if the boundary exceeds the cap, instead of asserting.

## Test Plan

New in `tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py`:

- `test_partial_tail_store_skipped_when_boundary_exceeds_cap[0|16]` — a cap below
  the boundary, and a cap of `0`, both produce no store job and no pending
  transfers.
- `test_partial_tail_store_honors_cap_at_boundary` — a cap at the boundary still
  stores, so the fix doesn't disable the feature.

`_make_partial_tail_request` gains an optional `kv_transfer_params` argument.
The existing `test_max_offload_tokens_validation` can't cover this path: it builds
its runner with `blocks_per_chunk=3`, and `supports_partial_tail` requires
`blocks_per_chunk == 1`.

```bash
.venv/bin/python -m pytest tests/v1/kv_connector/unit/offloading_connector/ -q
pre-commit run --files vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py \
                       tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
```

End-to-end, `Qwen/Qwen3.5-4B` on 1×L40S:

```bash
vllm serve Qwen/Qwen3.5-4B --max-model-len 16384 --enforce-eager \
  --enable-prefix-caching --prefix-match-unit 16 \
  --kv-transfer-config '{"kv_connector":"OffloadingConnector","kv_role":"kv_both",
    "kv_connector_extra_config":{"spec_name":"CPUOffloadingSpec","cpu_bytes_to_use":8000000000}}'
```

then three distinct 1000-token prompts (boundary `1000 // 16 * 16 = 992`), the
middle one carrying `"kv_transfer_params": {"max_offload_tokens": 512}`.

## Test Result

Unit tests: `254 passed`. ruff-check, ruff-format and mypy-3.12 all pass.

End-to-end, HTTP status of the three requests, same script on both builds:

| # | request | before | after |
| --- | --- | --- | --- |
| 1 | no cap | 200 | 200 |
| 2 | `max_offload_tokens=512` | **500** | 200 |

Before the fix, request 2 fails the assertion. After the fix, there's no such issue.
Note: parts of this change were written with AI assistance.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

