### PR TITLE
[ROCm]: Drop pybind11 from Dockerfile.rocm to prevent version mismatch

### DIFF
--- a/docker/Dockerfile.rocm
+++ b/docker/Dockerfile.rocm
@@ -397,7 +397,7 @@ RUN apt-get -y update && apt-get -y install autoconf libtool pkg-config \
     && rm -rf /var/lib/apt/lists/*
 
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv pip install --system meson meson-python pybind11 pyyaml types-PyYAML \
+    uv pip install --system meson meson-python pyyaml types-PyYAML \
         auditwheel build patchelf pytest tomlkit "setuptools>=80.9.0"
 
 RUN --mount=type=cache,target=/root/.cache/ccache \


### PR DESCRIPTION
## Purpose
Currently, the AITER kernels in `Dockerfile.rocm_base` were built with pybind11 3.0.4, whereas the pybind11 install in `Dockerfile.rocm` installs pybind 3.1.0 (released 08/08/2026). The API incompatibility breaks Kimi K2.6/K3 among other models: https://github.com/ROCm/aiter/issues/4770

Quick fix: remove the pybind11 rebuild from the latter; we'll eventually unify the Dockerfiles as part of the ROCk effort e.g. #49925.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

