### PR TITLE
[Model] Support ModelOpt FP8_PB_WO in Kimi-K3 attention

### DIFF
--- a/tests/models/kimi_k3/test_quantization.py
+++ b/tests/models/kimi_k3/test_quantization.py
@@ -1,0 +1,40 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+from vllm.models.kimi_k3.nvidia.quantization import (
+    pad_merged_output_sizes,
+    uses_modelopt_fp8_pb_wo,
+)
+
+
+def test_modelopt_fp8_pb_wo_resolution():
+    homogeneous = SimpleNamespace(quant_method="FP8_PB_WO")
+    mixed = SimpleNamespace(_resolve_quant_algo=lambda _prefix: "FP8_PB_WO")
+
+    assert uses_modelopt_fp8_pb_wo(homogeneous, "model.layers.0.proj")
+    assert uses_modelopt_fp8_pb_wo(mixed, "model.layers.0.proj")
+    assert not uses_modelopt_fp8_pb_wo(None, "model.layers.0.proj")
+
+
+def test_fp8_pb_wo_mla_padding():
+    output_sizes, padding = pad_merged_output_sizes(
+        [2048, 576], 8, disable_tp=True, alignment=128
+    )
+
+    assert output_sizes == [2048, 576, 64]
+    assert padding == 64
+
+
+def test_fp8_pb_wo_kda_padding():
+    output_sizes, padding = pad_merged_output_sizes(
+        [12288] * 4 + [128, 96],
+        8,
+        disable_tp=False,
+        alignment=128,
+        replicated_shard_ids=(4,),
+    )
+
+    assert output_sizes == [12288] * 4 + [128, 96, 928]
+    assert padding == 116

--- a/tests/quantization/test_modelopt.py
+++ b/tests/quantization/test_modelopt.py
@@ -23,11 +23,15 @@ from vllm.model_executor.layers.linear import UnquantizedLinearMethod
 from vllm.model_executor.layers.quantization.modelopt import (
     ModelOptFp8Config,
     ModelOptFp8LinearMethod,
+    ModelOptFp8PbWoLinearMethod,
     ModelOptMixedPrecisionConfig,
     ModelOptMxFp8Config,
     ModelOptNvFp4Config,
     ModelOptNvFp4LinearMethod,
     ModelOptNvFp4W4A16LinearMethod,
+)
+from vllm.model_executor.layers.quantization.utils.quant_utils import (
+    get_and_maybe_dequant_weights,
 )
 from vllm.model_executor.layers.vocab_parallel_embedding import (
     ParallelLMHead,
@@ -135,6 +139,18 @@ def test_modelopt_fp8_updates_weight_dims_after_transpose():
     assert layer.weight.input_dim == 0
     assert layer.weight.output_dim == 1
     method.fp8_linear.process_weights_after_loading.assert_called_once_with(layer)
+
+
+def test_modelopt_fp8_pb_wo_dequantizes_standard_block_scales():
+    layer = torch.nn.Module()
+    layer.quant_method = object.__new__(ModelOptFp8PbWoLinearMethod)
+    layer.weight = torch.ones((128, 128), dtype=torch.float8_e4m3fn)
+    layer.weight_scale = torch.full((1, 1), 0.25, dtype=torch.float32)
+    layer.weight_block_size = [128, 128]
+
+    weight = get_and_maybe_dequant_weights(layer)
+
+    torch.testing.assert_close(weight, torch.full((128, 128), 0.25))
 
 
 def test_modelopt_nvfp4_leaves_excluded_parallel_lm_head_unquantized():

--- a/tests/quantization/test_modelopt.py
+++ b/tests/quantization/test_modelopt.py
@@ -144,13 +144,16 @@ def test_modelopt_fp8_updates_weight_dims_after_transpose():
 def test_modelopt_fp8_pb_wo_dequantizes_standard_block_scales():
     layer = torch.nn.Module()
     layer.quant_method = object.__new__(ModelOptFp8PbWoLinearMethod)
-    layer.weight = torch.ones((128, 128), dtype=torch.float8_e4m3fn)
-    layer.weight_scale = torch.full((1, 1), 0.25, dtype=torch.float32)
+    layer.weight = torch.ones((256, 256), dtype=torch.float8_e4m3fn)
+    layer.weight_scale = torch.tensor([[0.25, 0.5], [0.75, 1.0]], dtype=torch.float32)
     layer.weight_block_size = [128, 128]
 
     weight = get_and_maybe_dequant_weights(layer)
+    expected = layer.weight_scale.repeat_interleave(128, dim=0).repeat_interleave(
+        128, dim=1
+    )
 
-    torch.testing.assert_close(weight, torch.full((128, 128), 0.25))
+    torch.testing.assert_close(weight, expected)
 
 
 def test_modelopt_nvfp4_leaves_excluded_parallel_lm_head_unquantized():

--- a/vllm/model_executor/layers/quantization/utils/quant_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/quant_utils.py
@@ -499,6 +499,9 @@ def get_and_maybe_dequant_weights(
     """Return layer's unquantized weights in [out, in] layout"""
     from vllm.model_executor.layers.linear import UnquantizedLinearMethod
     from vllm.model_executor.layers.quantization.fp8 import Fp8LinearMethod
+    from vllm.model_executor.layers.quantization.modelopt import (
+        ModelOptFp8PbWoLinearMethod,
+    )
     from vllm.model_executor.layers.quantization.online.fp8 import (
         Fp8PerTensorOnlineLinearMethod,
     )
@@ -516,6 +519,27 @@ def get_and_maybe_dequant_weights(
         layer.quant_method, UnquantizedLinearMethod
     ):
         return weight.to(out_dtype)
+
+    # ModelOpt's per-block FP8 scales remain directly dequantizable when the
+    # selected kernel keeps the checkpoint's ordinary 2D block layout. Some
+    # kernels replace that layout during post-processing; those use the generic
+    # apply-to-identity fallback below.
+    if isinstance(layer.quant_method, ModelOptFp8PbWoLinearMethod):
+        weight_scale = layer.weight_scale
+        block_size = tuple(layer.weight_block_size)
+        expected_scale_shape = (
+            weight.shape[-2] // block_size[0],
+            weight.shape[-1] // block_size[1],
+        )
+        if weight_scale.dtype == torch.float32 and tuple(weight_scale.shape) == (
+            expected_scale_shape
+        ):
+            return scaled_dequantize(
+                weight,
+                weight_scale,
+                group_shape=GroupShape(*block_size),
+                out_dtype=out_dtype,
+            )
 
     # Simple Fp8 case: rescale with tensor or block weight scales
     if (

--- a/vllm/models/kimi_k3/nvidia/kda.py
+++ b/vllm/models/kimi_k3/nvidia/kda.py
@@ -42,6 +42,10 @@ from vllm.models.kimi_k3.nvidia.kda_metadata import (
     KimiK3KDAAttentionBackend,
     KimiK3KDAMetadata,
 )
+from vllm.models.kimi_k3.nvidia.quantization import (
+    pad_merged_output_sizes,
+    uses_modelopt_fp8_pb_wo,
+)
 from vllm.platforms import current_platform
 from vllm.third_party.flash_linear_attention.ops.kda import FusedRMSNormGated
 from vllm.transformers_utils.configs.kimi_linear import KimiLinearConfig
@@ -322,19 +326,25 @@ class KimiK3DeltaAttention(GatedDeltaNetAttention):
             "KimiK3DeltaAttention requires a full-rank gate"
         )
 
-        # Keep f_a before the narrow beta shard, then pad each TP-local row
-        # to select the aligned BF16 GEMM path.
+        # Keep f_a before the narrow beta shard, then pad each TP-local row.
+        # ModelOpt FP8_PB_WO requires a complete 128-row output block; other
+        # formats retain the 16-row alignment used by the BF16 GEMM path.
         qkvg_output_sizes = [self.projection_size] * 4
         in_proj_output_sizes = qkvg_output_sizes + [
             self.head_dim,
             self.num_heads,
         ]
-        local_output_size = (
-            4 * self.local_projection_size + self.head_dim + self.local_num_heads
+        in_proj_prefix = f"{prefix}.in_proj_qkvgfab"
+        alignment = (
+            128 if uses_modelopt_fp8_pb_wo(self.quant_config, in_proj_prefix) else 16
         )
-        self.in_proj_padding = -local_output_size % 16
-        if self.in_proj_padding:
-            in_proj_output_sizes.append(self.in_proj_padding * self.tp_size)
+        in_proj_output_sizes, self.in_proj_padding = pad_merged_output_sizes(
+            in_proj_output_sizes,
+            self.tp_size,
+            disable_tp=False,
+            alignment=alignment,
+            replicated_shard_ids=(4,),
+        )
         self.in_proj_qkvgfab = _KimiGDNMergedColumnParallelLinear(
             self.hidden_size,
             in_proj_output_sizes,
@@ -342,7 +352,7 @@ class KimiK3DeltaAttention(GatedDeltaNetAttention):
             tp_size=self.tp_size,
             bias=False,
             quant_config=self.quant_config,
-            prefix=f"{prefix}.in_proj_qkvgfab",
+            prefix=in_proj_prefix,
         )
         if self.in_proj_padding:
             self.in_proj_qkvgfab.weight.data[-self.in_proj_padding :].zero_()

--- a/vllm/models/kimi_k3/nvidia/mla.py
+++ b/vllm/models/kimi_k3/nvidia/mla.py
@@ -79,6 +79,10 @@ from vllm.models.kimi_k3.nvidia.ops.fused_mla_key_concat_kv_cache import (
     fused_mla_kv_concat_quant_fp8,
     fused_mla_qkv_quant_kv_cache_fp8_insert,
 )
+from vllm.models.kimi_k3.nvidia.quantization import (
+    pad_merged_output_sizes,
+    uses_modelopt_fp8_pb_wo,
+)
 from vllm.platforms import current_platform
 from vllm.transformers_utils.configs.kimi_linear import KimiLinearConfig
 from vllm.utils.multi_stream_utils import maybe_execute_in_parallel
@@ -200,14 +204,31 @@ class MultiHeadLatentAttention(nn.Module, AttentionLayerBase):
             # the low-rank latents are shared across TP ranks; TP splitting
             # happens at q_b_proj / kv_b_proj. Checkpoint weights ``q_a_proj``
             # and ``kv_a_proj_with_mqa`` map onto shards 0 and 1 respectively.
+            fused_qkv_a_prefix = f"{prefix}.fused_qkv_a_proj"
+            fused_qkv_a_output_sizes = [
+                self.q_lora_rank,
+                self.kv_lora_rank + self.qk_rope_head_dim,
+            ]
+            self.fused_qkv_a_padding = 0
+            if uses_modelopt_fp8_pb_wo(quant_config, fused_qkv_a_prefix):
+                fused_qkv_a_output_sizes, self.fused_qkv_a_padding = (
+                    pad_merged_output_sizes(
+                        fused_qkv_a_output_sizes,
+                        tp_size,
+                        disable_tp=True,
+                        alignment=128,
+                    )
+                )
             self.fused_qkv_a_proj = MergedColumnParallelLinear(
                 self.hidden_size,
-                [self.q_lora_rank, self.kv_lora_rank + self.qk_rope_head_dim],
+                fused_qkv_a_output_sizes,
                 bias=False,
                 quant_config=quant_config,
-                prefix=f"{prefix}.fused_qkv_a_proj",
+                prefix=fused_qkv_a_prefix,
                 disable_tp=True,
             )
+            if self.fused_qkv_a_padding:
+                self.fused_qkv_a_proj.weight.data[-self.fused_qkv_a_padding :].zero_()
             self.q_a_layernorm = RMSNorm(self.q_lora_rank, eps=config.rms_norm_eps)
             self.q_b_proj = ColumnParallelLinear(
                 self.q_lora_rank,
@@ -493,6 +514,8 @@ class MultiHeadLatentAttention(nn.Module, AttentionLayerBase):
         """
         if self.q_lora_rank is not None:
             qkv_lora = self.fused_qkv_a_proj(hidden_states)[0]
+            if self.fused_qkv_a_padding:
+                qkv_lora = qkv_lora[..., : -self.fused_qkv_a_padding]
             q_c, kv_c, k_pe = qkv_lora.split(
                 [self.q_lora_rank, self.kv_lora_rank, self.qk_rope_head_dim], dim=-1
             )

--- a/vllm/models/kimi_k3/nvidia/quantization.py
+++ b/vllm/models/kimi_k3/nvidia/quantization.py
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from vllm.model_executor.layers.quantization import QuantizationConfig
+
+
+def uses_modelopt_fp8_pb_wo(
+    quant_config: QuantizationConfig | None, prefix: str
+) -> bool:
+    if quant_config is None:
+        return False
+    resolve = getattr(quant_config, "_resolve_quant_algo", None)
+    quant_algo = resolve(prefix) if callable(resolve) else None
+    if quant_algo is None:
+        quant_algo = getattr(quant_config, "quant_method", None)
+    return str(quant_algo).upper() == "FP8_PB_WO"
+
+
+def pad_merged_output_sizes(
+    output_sizes: list[int],
+    tp_size: int,
+    *,
+    disable_tp: bool,
+    alignment: int,
+    replicated_shard_ids: tuple[int, ...] = (),
+) -> tuple[list[int], int]:
+    partition_size = 1 if disable_tp else tp_size
+    local_output_size = sum(
+        size if idx in replicated_shard_ids else size // partition_size
+        for idx, size in enumerate(output_sizes)
+    )
+    padding = -local_output_size % alignment
+    if padding == 0:
+        return output_sizes, 0
+    return [*output_sizes, padding * partition_size], padding


### PR DESCRIPTION
## Summary

- support ModelOpt `FP8_PB_WO` weights in Kimi-K3 MLA and KDA attention
- pad fused projection outputs to the 128-row granularity required by per-block FP8, then remove the zero padding before attention consumes them
- directly dequantize standard 2D ModelOpt FP8 block-scale layouts during MLA weight absorption, while retaining the generic fallback for post-kernel layouts
- cover homogeneous and mixed ModelOpt algorithms plus TP=8 projection shapes

## Root cause

Kimi-K3 fuses several attention projections whose per-rank output sizes are not always multiples of the 128-row FP8 block. ModelOpt exports valid per-block weights by padding those projections, but vLLM previously built the fused layers at their unpadded sizes and did not trim the padding before splitting the outputs. MLA weight absorption also needs a deterministic path for the standard 2D block-scale layout present in exported checkpoints.

## Relationship to existing work

This does not duplicate #50617. That PR adds generic mixed-ModelOpt dispatch, DeepGEMM, and warmup support. This PR is limited to Kimi-K3 architecture-specific fused-projection padding/trimming and MLA absorption of the exported block scales. The changes are complementary and this PR does not add another generic mixed-dispatch implementation.

## Validation

- `.venv/bin/python -m pytest tests/models/kimi_k3/test_quantization.py -q` — 3 passed
- `.venv/bin/python -m pytest tests/quantization/test_modelopt.py -q -k fp8_pb_wo_dequantizes_standard_block_scales` — 1 passed, 23 deselected
- pre-commit hooks on all changed files — passed, including Ruff, mypy, SPDX, and forbidden-import checks

The equivalent compatibility logic has served the target Kimi-K3 NVFP4-expert + FP8-attention checkpoint on 8 B300 GPUs during evaluation. This native branch itself was validated with the unit and static checks listed above.

## AI assistance

OpenAI Codex assisted with implementation, tests, and PR preparation. The human submitter reviewed every changed line and reviewed the validation results before publication.
