### PR TITLE
[Bugfix][Frontend] Return all n choices from /inference/v1/generate

### DIFF
--- a/tests/entrypoints/scale_out/token_in_token_out/test_serving_tokens.py
+++ b/tests/entrypoints/scale_out/token_in_token_out/test_serving_tokens.py
@@ -154,6 +154,28 @@ async def test_generate_sampling_mask(client):
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("n", [2, 4])
+async def test_generate_returns_all_choices(client, n):
+    """Regression: ``n > 1`` must not silently return fewer than ``n`` choices.
+
+    Non-streaming requests used to keep ``RequestOutputKind.CUMULATIVE``, so
+    the full generator only saw the sequences updated in the final step and
+    sequences that finished earlier never reached ``choices``.
+    """
+    payload = {
+        "model": MODEL_NAME,
+        "token_ids": [1, 2, 3],
+        "sampling_params": {"max_tokens": 5, "temperature": 1.0, "n": n},
+        "stream": False,
+    }
+    resp = await client.post(GEN_ENDPOINT, json=payload)
+    resp.raise_for_status()
+    choices = resp.json()["choices"]
+    assert len(choices) == n
+    assert sorted(choice["index"] for choice in choices) == list(range(n))
+
+
+@pytest.mark.asyncio
 async def test_generate_defaults_max_tokens_when_omitted(client):
     """Regression: omitting ``max_tokens`` must not silently cap at 16.
 

--- a/vllm/entrypoints/scale_out/token_in_token_out/serving.py
+++ b/vllm/entrypoints/scale_out/token_in_token_out/serving.py
@@ -218,8 +218,14 @@ class ServingTokens(GenerateBaseServing):
 
         if self.force_no_detokenize:
             sampling_params.detokenize = False
-        if request.stream:
-            sampling_params.output_kind = RequestOutputKind.DELTA
+        # Matches the OpenAI-compat endpoints. Leaving the ``CUMULATIVE``
+        # default on the non-streaming path drops sequences: the full
+        # generator keeps only the last streamed ``RequestOutput``, which
+        # carries just the sequences updated in that step, so an ``n > 1``
+        # request silently returns fewer than ``n`` choices.
+        sampling_params.output_kind = (
+            RequestOutputKind.DELTA if request.stream else RequestOutputKind.FINAL_ONLY
+        )
 
         self._log_inputs(
             request_id,


### PR DESCRIPTION
FIX #52398

## Purpose

A non-streaming `POST /inference/v1/generate` with `sampling_params.n > 1` returns fewer than `n` choices, non-deterministically and without an error — the response is a well-formed `GenerateResponse`, the completions are simply missing. `/v1/completions` with the same `n` always returns `n`.

Root cause, as diagnosed in the issue and confirmed here on `main`: `serve_tokens` set `output_kind` only for streaming,

```python
if request.stream:
    sampling_params.output_kind = RequestOutputKind.DELTA
```

so non-streaming requests kept the `SamplingParams` default, `RequestOutputKind.CUMULATIVE`. `serve_tokens_full_generator` keeps only the last output it sees (`final_res = res` in the `async for`) and then iterates `final_res.outputs`. Under `CUMULATIVE` that last output carries only the sequences updated in that step, so sequences that finished earlier never reach `choices`.

This is the outlier: `openai/completion/protocol.py:392`, `openai/chat_completion/protocol.py:738`, `openai/responses/protocol.py:448`, both speech-to-text protocols and `offline_utils.py:561` all use `DELTA if stream else FINAL_ONLY`.

## Test Plan

`tests/entrypoints/scale_out/token_in_token_out/test_serving_tokens.py::test_generate_returns_all_choices`, parametrized over `n = 2, 4`, asserts `len(choices) == n` and that the indices are exactly `0..n-1`. The existing tests in that file only ever request `n = 1`, which is why this went unnoticed.

## Test Result

I have no GPU on this machine, so I could not run the `RemoteOpenAIServer`-backed suite locally — that run is CI's. What I did verify locally: the diagnosis against current `main` (the `CUMULATIVE` default reaching `serve_tokens_full_generator`, and the sibling entrypoints that already do this correctly), and `ruff check` / `ruff format --check` clean on both files.

The reporter's own numbers on the unpatched server, 10 runs per `n`, expected `{n: 10}`:

```
2 {1: 6, 2: 4}
4 {2: 5, 3: 3, 4: 2}
8 {5: 2, 7: 5, 3: 1, 6: 2}
```

and they confirmed 10/10 correct for `n = 2/4/8` when `output_kind` is forced to `FINAL_ONLY` through the request body, which is exactly what this patch makes the default.

## Contribution notes (per `AGENTS.md`)

- Not a duplicate: `gh pr list --repo vllm-project/vllm --state open --search "52398 in:body"`, `--search "output_kind"` and `--search "serve_tokens output_kind"` all return nothing; no other PR touches `scale_out/token_in_token_out/serving.py` for this.
- Not a model-affecting change: it selects the `RequestOutputKind` used to assemble the response, so no eval results apply.
- AI assistance was used in preparing this change. I reviewed every changed line, confirmed the root cause against `main` myself, and can defend it end-to-end. The uncertain part I want a reviewer's eye on is whether any caller depends on passing `output_kind` explicitly in `sampling_params` (the workaround in the issue); this makes `FINAL_ONLY` the default, and unlike the OpenAI-compat endpoints it still overrides an explicitly supplied value, which I kept for consistency with those endpoints rather than changing here.
