### PR TITLE
[Bugfix] Don't split a multimodal item that a prefill chunk starts exactly on

### DIFF
--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -591,6 +591,40 @@ def test_no_mm_input_chunking():
         )
 
 
+def test_no_mm_input_chunking_at_item_boundary():
+    """A chunk starting exactly at a multimodal item must not split it.
+
+    Regression test for issue #52306: the rollback guard only fired while
+    ``num_computed_tokens < start_pos``, so a chunk beginning exactly at the
+    item skipped the check and could cover only part of it - silently breaking
+    models with bidirectional attention over the item.
+    """
+    mm_positions = [[PlaceholderRange(offset=400, length=800)]]
+
+    def ask(num_computed_tokens: int, num_new_tokens: int) -> int:
+        # A fresh scheduler per call: the encoder cache is stateful.
+        scheduler = create_scheduler(
+            model="llava-hf/llava-1.5-7b-hf",
+            max_num_batched_tokens=1024,
+            disable_chunked_mm_input=True,
+            max_model_len=2048,
+        )
+        request = create_requests(
+            num_requests=1, num_tokens=1200, mm_positions=mm_positions
+        )[0]
+        return scheduler._try_schedule_encoder_inputs(
+            request, num_computed_tokens, num_new_tokens, encoder_compute_budget=100_000
+        )[1]
+
+    # Starts before the item and cannot reach past it: stop just before it.
+    assert ask(0, 500) == 400
+    # Starts exactly at the item and cannot cover it: schedule nothing rather
+    # than half an item.
+    assert ask(400, 500) == 0
+    # Starts exactly at the item and covers it: schedule it.
+    assert ask(400, 800) == 800
+
+
 @pytest.mark.parametrize("enable_prefix_caching", [True, False])
 def test_schedule_concurrent_partial_requests(enable_prefix_caching: bool):
     """Test scheduling behavior with concurrent partial requests.

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1623,7 +1623,9 @@ class Scheduler(SchedulerInterface):
             # only cover part of the mm input, roll back to before the mm item.
             if (
                 self.scheduler_config.disable_chunked_mm_input
-                and num_computed_tokens < start_pos
+                # `<=`, not `<`: a chunk that starts exactly at the item still
+                # splits it when it cannot cover the whole item.
+                and num_computed_tokens <= start_pos
                 and (num_computed_tokens + num_new_tokens)
                 < (start_pos + num_encoder_tokens)
             ):


### PR DESCRIPTION
FIX #52306

## Purpose

Under `disable_chunked_mm_input=True` the scheduler still splits a multimodal item when the chunk begins exactly on it.

`_try_schedule_encoder_inputs` guards the split with

```python
self.scheduler_config.disable_chunked_mm_input
and num_computed_tokens < start_pos                                            # (A)
and (num_computed_tokens + num_new_tokens) < (start_pos + num_encoder_tokens)  # (B)
```

(A) is false when `num_computed_tokens == start_pos`, so (B) never runs and a chunk too small to cover the item is allowed through. That equality is not an exotic state — it is exactly what the guard itself produces: the rollback sets `num_new_tokens = start_pos - num_computed_tokens`, so the next step starts on the item. If the budget cannot fit the whole item on that step, the item is split at the precise point the flag exists to prevent. For models with bidirectional attention over the item, the tokens that should cross-attend silently cannot.

The fix is `<=` in (A). Only the equality case changes:

- `num_computed_tokens < start_pos` — unchanged, rolls back to just before the item.
- `num_computed_tokens == start_pos` and the chunk does not cover the item — now yields `num_new_tokens = 0`, so the request waits for a step that can fit it. This matches the neighbouring `can_allocate` branch, which already returns 0 rather than scheduling a partial item.
- `num_computed_tokens > start_pos` (prefix caching landing mid-item) — unchanged.

Returning 0 cannot starve the request: `_verify_args` already rejects a `max_num_batched_tokens` smaller than the longest multimodal item when this flag is set (`test_no_mm_input_chunking` asserts that `ValueError`), so a step that can fit the item always exists.

## Test Plan

`tests/v1/core/test_scheduler.py::test_no_mm_input_chunking_at_item_boundary` drives `_try_schedule_encoder_inputs` on a real scheduler and request (mm item at offset 400, length 800) across the three cases: starting before the item, starting on it without room, and starting on it with room. The existing `test_no_mm_input_chunking` only exercises the first, which is why this went unnoticed.

## Test Result

I have no GPU or vLLM build on this machine, so I could not execute the suite — that run is CI's, and I will follow it. What I verified locally: the condition and the surrounding branches on current `main`, the neighbouring `can_allocate` handling that this now matches, and the `max_num_batched_tokens` validation that rules out starvation. `ruff check` and `ruff format --check` are clean on both files.

The reporter's direct-call reproduction on unpatched `main` shows the failure this fixes:

```
print(ask(0, 500))    # 3    - correct, stops before the item
print(ask(3, 500))    # 500  - wrong, splits the 766-token item
```

## Contribution notes (per `AGENTS.md`)

- Not a duplicate: `gh pr list --repo vllm-project/vllm --state open --search "52306 in:body"` and `--search "disable_chunked_mm_input"` return nothing; the issue has no linked PR.
- Not model-affecting in the eval sense (a scheduling boundary), so no eval numbers apply — though the user-visible symptom is degraded output for bidirectional-attention multimodal models, which is why the regression test asserts the boundary directly.
- AI assistance was used in preparing this change. I read every changed line, checked the branch behaviour against `main` myself, and can defend it. The judgement call worth a reviewer's eye: the equality case now returns 0 rather than a partial schedule, which costs one scheduling step in exchange for never splitting the item.
