### PR TITLE
[Bugfix][Frontend] Responses streaming: tool-call argument tail interleaved with reasoning/content aborts SSE stream (nameless ResponseFunctionToolCallItem)

### DIFF
--- a/tests/entrypoints/openai/responses/test_streaming_events.py
+++ b/tests/entrypoints/openai/responses/test_streaming_events.py
@@ -124,3 +124,74 @@ class TestProcessorCompoundDeltas:
         types = [e.type for e in events]
         assert "response.reasoning_text.delta" in types
         assert "response.output_text.delta" in types
+
+
+class TestToolCallContinuationOrdering:
+    def test_split_delta_replays_argument_tail_before_state_switch(self):
+        """An argument-only group is the tail of the open tool call and must
+        come before reasoning/content; a named group is a new call and stays
+        after them."""
+        tail = _make_tool_call(0, arguments='"}')
+        new_call = _make_tool_call(1, name="g", arguments="{")
+        delta = DeltaMessage(reasoning="r", content="c", tool_calls=[new_call, tail])
+
+        result = split_delta(delta)
+
+        assert len(result) == 4
+        assert result[0].tool_calls == [tail]
+        assert result[1].reasoning == "r"
+        assert result[2].content == "c"
+        assert result[3].tool_calls == [new_call]
+
+    def test_argument_tail_interleaved_with_reasoning(self):
+        """Regression: one engine step can span the end of a tool call and
+        the start of the next reasoning segment (common with speculative
+        decoding). The argument tail must extend the open call instead of
+        reopening TOOL_CALL with name=None, which failed
+        ResponseFunctionToolCallItem validation and aborted the SSE stream
+        without a terminal response event."""
+        processor = SimpleStreamingEventProcessor()
+        _run_through_processor(
+            processor,
+            DeltaMessage(tool_calls=[_make_tool_call(0, name="f", arguments='{"a')]),
+        )
+        assert processor.state.current_state == _StateType.TOOL_CALL
+
+        events = _run_through_processor(
+            processor,
+            DeltaMessage(
+                reasoning="think",
+                tool_calls=[_make_tool_call(0, arguments='":1}')],
+            ),
+        )
+
+        types = [e.type for e in events]
+        tail_idx = types.index("response.function_call_arguments.delta")
+        reasoning_idx = types.index("response.reasoning_text.delta")
+        assert tail_idx < reasoning_idx
+
+        added = [e for e in events if e.type == "response.output_item.added"]
+        assert [e.item.type for e in added] == ["reasoning"]
+        done = [e for e in events if e.type == "response.function_call_arguments.done"]
+        assert len(done) == 1
+        assert done[0].arguments == '{"a":1}'
+        assert processor.state.current_state == _StateType.REASONING
+
+    def test_orphan_argument_delta_does_not_abort_stream(self):
+        """Defensive: an argument-only delta arriving while no tool call is
+        open must not crash item validation mid-stream."""
+        processor = SimpleStreamingEventProcessor()
+        events = _run_through_processor(
+            processor,
+            DeltaMessage(tool_calls=[_make_tool_call(0, arguments='{"a":1}')]),
+        )
+
+        added = [e for e in events if e.type == "response.output_item.added"]
+        assert len(added) == 1
+        assert added[0].item.type == "function_call"
+        assert added[0].item.name == ""
+        deltas = [
+            e for e in events if e.type == "response.function_call_arguments.delta"
+        ]
+        assert len(deltas) == 1
+        assert deltas[0].delta == '{"a":1}'

--- a/vllm/entrypoints/openai/responses/streaming_events.py
+++ b/vllm/entrypoints/openai/responses/streaming_events.py
@@ -1117,7 +1117,19 @@ def split_delta(delta: DeltaMessage) -> list[DeltaMessage]:
 
     The Responses API emits typed SSE events (one type per event), so a
     compound DeltaMessage must be split before entering the state machine.
-    Order: reasoning -> content -> tool_calls (grouped by index).
+    Order: tool-call continuations (argument-only groups) -> reasoning ->
+    content -> named tool_calls (grouped by index).
+
+    A tool-call group whose first delta carries no function name can only be
+    the continuation of the tool call that is already open: a raw model
+    stream never interleaves reasoning or content inside a single tool-call
+    block, so when one engine step spans the end of a tool call and the start
+    of the following reasoning/content segment (e.g. with speculative
+    decoding, where a step can cross several structural boundaries), the
+    argument tail must be replayed before the state machine transitions away.
+    Emitting it after reasoning/content would close the open tool call and
+    then reopen TOOL_CALL through open() with name=None, which fails
+    ResponseFunctionToolCallItem validation mid-stream.
     """
     has_reasoning = delta.reasoning is not None
     has_content = delta.content is not None
@@ -1130,17 +1142,26 @@ def split_delta(delta: DeltaMessage) -> list[DeltaMessage]:
     ):
         return [delta]
 
-    deltas: list[DeltaMessage] = []
-    if has_reasoning:
-        deltas.append(DeltaMessage(reasoning=delta.reasoning))
-    if has_content:
-        deltas.append(DeltaMessage(content=delta.content))
+    continuations: list[DeltaMessage] = []
+    opens: list[DeltaMessage] = []
     if has_tools:
         groups: dict[int | None, list[DeltaToolCall]] = {}
         for tc in delta.tool_calls:
             groups.setdefault(tc.index, []).append(tc)
         for tcs in groups.values():
-            deltas.append(DeltaMessage(tool_calls=tcs))
+            first_fn = tcs[0].function
+            group = DeltaMessage(tool_calls=tcs)
+            if first_fn is not None and first_fn.name is None:
+                continuations.append(group)
+            else:
+                opens.append(group)
+
+    deltas: list[DeltaMessage] = list(continuations)
+    if has_reasoning:
+        deltas.append(DeltaMessage(reasoning=delta.reasoning))
+    if has_content:
+        deltas.append(DeltaMessage(content=delta.content))
+    deltas.extend(opens)
     return deltas or [delta]
 
 
@@ -1240,6 +1261,20 @@ class SimpleStreamingEventProcessor:
         handlers = self._STATE_HANDLERS[target_state]
         if target_state == _StateType.TOOL_CALL:
             assert tool_call is not None
+            if tool_call.function.name is None:
+                # Defensive: an argument-only continuation delta reached
+                # open() while no tool call was in progress (split_delta
+                # normally replays continuations before any state switch).
+                # Reuse the last opened call's identity instead of failing
+                # ResponseFunctionToolCallItem validation mid-stream, which
+                # would abort the SSE stream after headers are sent and leave
+                # the client without a terminal response event.
+                return handlers.open_fn(
+                    self.state,
+                    self.state.tool_call_name or "",
+                    tool_call.index,
+                    self.state.tool_call_namespace,
+                )
             call_name = resolve_responses_tool_call_name(
                 tool_call.function.name,
                 tool_call_name_map=self.tool_call_name_map,


### PR DESCRIPTION
## Purpose

Fix a mid-stream crash in the Responses API simple (non-harmony) streaming path when a single engine step spans the end of a tool call and the start of the following reasoning/content segment.

`split_delta()` decomposes a compound `DeltaMessage` in the fixed order reasoning → content → tool_calls. When the tool-call part of the compound delta is the *argument tail* of the already-open tool call (its first `DeltaToolCall` carries no function name — e.g. the flush emitted by the parser engine at `</tool_call>`), replaying it after reasoning/content means the state machine has already transitioned away and closed the call. The tail then forces `SimpleStreamingEventProcessor.open()` to construct `ResponseFunctionToolCallItem(name=None)`:

```
pydantic_core._pydantic_core.ValidationError: 1 validation error for ResponseFunctionToolCallItem
name
  Input should be a valid string [type=string_type, input_value=None, input_type=NoneType]
...
RuntimeError: Caught handled exception, but response already started.
```

Because the SSE response has already started, the exception aborts the stream with **no terminal `response.*` event**, leaving clients with a truncated stream they cannot classify. Observed in production with Qwen3.8-27B-FP8 + `--tool-call-parser qwen3_coder` + `--reasoning-parser qwen3` + MTP (`num_speculative_tokens=5`); speculative decoding makes multi-boundary steps common, so the failure is intermittent but recurrent in agentic (tool-heavy) workloads.

Fix, two layers:

1. `split_delta()` now replays argument-only tool-call groups **before** reasoning/content. An argument-only group can only be the continuation of the open call — a raw model stream never interleaves reasoning or content inside one tool-call block — so this both prevents the crash and restores the true semantic ordering of the stream. Named (new-call) groups keep their existing position after reasoning/content.
2. `open()` defensively handles a nameless tool-call delta that still reaches it (misbehaving parser): it reuses the last opened call's identity instead of failing pydantic validation and killing the stream after headers are sent.

## Test Plan

```
pytest tests/entrypoints/openai/responses/test_streaming_events.py -q
```

Three new regression tests in `TestToolCallContinuationOrdering`:
- `test_split_delta_replays_argument_tail_before_state_switch` — ordering contract of `split_delta`.
- `test_argument_tail_interleaved_with_reasoning` — reproduces the production crash: open tool call, then a compound delta of reasoning + argument tail; asserts the tail extends the open call (single `function_call` item, complete arguments) before the reasoning transition.
- `test_orphan_argument_delta_does_not_abort_stream` — defensive `open()` path.

## Test Result

Before (unpatched `vllm/vllm-openai` image, CPU-only container):

```
FAILED test_streaming_events.py::TestToolCallContinuationOrdering::test_split_delta_replays_argument_tail_before_state_switch
FAILED test_streaming_events.py::TestToolCallContinuationOrdering::test_argument_tail_interleaved_with_reasoning   (ValidationError at streaming_events.py:1040)
FAILED test_streaming_events.py::TestToolCallContinuationOrdering::test_orphan_argument_delta_does_not_abort_stream (ValidationError at streaming_events.py:1040)
3 failed
```

After (patched files overlaid on the same image):

```
9 passed in 6.94s
```

All 6 pre-existing tests in the file still pass; `ruff check` / `ruff format` clean on both touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
