### PR TITLE
[Bugfix][Spec Decode] Keep EAGLE cache registration on the partial-hash-hit path

### DIFF
--- a/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
+++ b/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
@@ -261,6 +261,80 @@ def test_hybrid_mamba_align_partial_hash_hit():
     assert manager.get_blocks("1").blocks[1][1].block_hash_num_tokens == 8
 
 
+def test_eagle_group_registers_unaligned_tail_under_partial_hash_hits():
+    """An EAGLE group must not re-floor what partial hash hits leaves un-floored.
+
+    ``cache_blocks`` decides once how far a request may be registered, and with
+    fine-grained partial hash hits that bound is the raw token count. The EAGLE
+    branch then re-derives its own bound for the lookahead block; if it rounds
+    down to ``scheduler_block_size`` again, everything between the last aligned
+    boundary and the tail stops being registered -- ``(n % scheduler_block_size)
+    - manager.block_size`` tokens per call, which is most of a segment whenever
+    the group's own block is much smaller than the scheduler block.
+    """
+    hash_block_size = 2
+    mamba_block_size = 4 * hash_block_size
+    kv_cache_config = KVCacheConfig(
+        num_blocks=40,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["full"],
+                FullAttentionSpec(
+                    block_size=hash_block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                ),
+            ),
+            KVCacheGroupSpec(
+                ["mamba"],
+                MambaSpec(
+                    block_size=mamba_block_size,
+                    shapes=(1, 1),
+                    dtypes=(torch.float32,),
+                    mamba_cache_mode="align",
+                ),
+            ),
+        ],
+    )
+    manager = make_kv_cache_manager(
+        kv_cache_config=kv_cache_config,
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=hash_block_size,
+    )
+    coordinator = manager.coordinator
+    assert coordinator.enable_partial_hash_hits
+    # The full-attention group is the EAGLE one, and its block is smaller than
+    # the scheduler block -- the geometry where re-flooring loses tokens.
+    eagle_manager = coordinator.single_type_managers[0]
+    eagle_manager.use_eagle = True
+    assert eagle_manager.block_size < coordinator.scheduler_block_size
+
+    # Deliberately not a multiple of the scheduler block, so the two bounds
+    # differ: floor(22/8)*8 + 2 = 18 against 22.
+    num_tokens = coordinator.scheduler_block_size * 2 + hash_block_size * 3
+    req = make_request("0", list(range(num_tokens)), hash_block_size, sha256)
+
+    recorded: list[int] = []
+    for single_type_manager in coordinator.single_type_managers:
+        original = single_type_manager.cache_blocks
+
+        def spy(request, num_tokens_to_cache, *args, _orig=original, **kwargs):
+            recorded.append(num_tokens_to_cache)
+            return _orig(request, num_tokens_to_cache, *args, **kwargs)
+
+        single_type_manager.cache_blocks = spy
+
+    # allocate_slots caches on the way out, so this exercises the real path.
+    computed_blocks, num_computed, _ = manager.get_computed_blocks(req)
+    assert manager.allocate_slots(req, num_tokens, num_computed, computed_blocks)
+
+    # Every group, EAGLE or not, may register the whole unaligned tail.
+    assert recorded == [num_tokens] * len(coordinator.single_type_managers)
+
+
 def test_hybrid_mamba_partial_tail_owner_uses_cow_on_continue():
     hash_block_size = 2
     block_size = 2 * hash_block_size

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -6,7 +6,7 @@ from typing import NamedTuple
 
 from vllm import envs
 from vllm.logger import init_logger
-from vllm.utils.math_utils import cdiv
+from vllm.utils.math_utils import cdiv, round_down
 from vllm.v1.core.block_pool import BlockPool
 from vllm.v1.core.kv_cache_metrics import KVCacheMetricsCollector
 from vllm.v1.core.kv_cache_utils import (
@@ -704,39 +704,37 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
                 for gid in group.group_ids:
                     self.single_type_managers[gid].use_eagle = True
 
-    def cache_blocks(self, request: Request, num_computed_tokens: int) -> None:
+    def _align_cacheable(self, num_tokens: int) -> int:
+        """Largest prefix of ``num_tokens`` a future cache hit could match.
+
+        Hits are ``scheduler_block_size``-aligned (see
+        ``find_longest_cache_hit``) unless fine-grained partial hash hits are
+        enabled, in which case no rounding applies -- rounding even to
+        ``hash_block_size`` would re-register a privatized Mamba tail.
+        """
         if self.enable_partial_hash_hits:
-            aligned_num_computed_tokens = num_computed_tokens
-        else:
-            # Cache hits in this coordinator are always a multiple of
-            # ``scheduler_block_size`` tokens (see ``find_longest_cache_hit``).
-            # Within an aligned region, SWA groups may only consult a subset of
-            # blocks per ``scheduler_block_size``-segment so the unused blocks
-            # also stay out of the prefix-cache hash map.
-            aligned_num_computed_tokens = (
-                num_computed_tokens
-                // self.scheduler_block_size
-                * self.scheduler_block_size
-            )
+            return num_tokens
+        return round_down(num_tokens, self.scheduler_block_size)
+
+    def cache_blocks(self, request: Request, num_computed_tokens: int) -> None:
+        cached_num_computed_tokens = self._align_cacheable(num_computed_tokens)
         for manager in self.single_type_managers:
-            num_tokens_to_cache = aligned_num_computed_tokens
+            num_tokens_to_cache = cached_num_computed_tokens
             # EAGLE groups match one block past each aligned boundary and drop
             # it, so make that lookahead block eligible to be cached.
-            if manager.use_eagle and aligned_num_computed_tokens > 0:
+            if manager.use_eagle and cached_num_computed_tokens > 0:
                 # Only cache tokens with finalized KV. The last
                 # num_reprefillable_tokens tokens can be re-prefilled during
                 # multi-module MTP.
                 num_finalized_computed_tokens = max(
                     0, num_computed_tokens - self.num_reprefillable_tokens
                 )
-                aligned_num_finalized_computed_tokens = (
+                cached_num_finalized_computed_tokens = self._align_cacheable(
                     num_finalized_computed_tokens
-                    // self.scheduler_block_size
-                    * self.scheduler_block_size
                 )
                 num_tokens_to_cache = min(
                     num_finalized_computed_tokens,
-                    aligned_num_finalized_computed_tokens + manager.block_size,
+                    cached_num_finalized_computed_tokens + manager.block_size,
                 )
             # The manager already knows the fine hit granularity
             # (``scheduler_block_size``); retention is passed separately so it


### PR DESCRIPTION
## Purpose

`HybridKVCacheCoordinator.cache_blocks` decides once how far a request may be
registered in the prefix-cache hash map. With fine-grained partial hash hits that
bound is the raw token count, because a hit no longer has to land on a
`scheduler_block_size` boundary.

#50062 rewrote the EAGLE branch to re-derive its own bound from
`num_finalized_computed_tokens` with an unconditional

```python
// self.scheduler_block_size * self.scheduler_block_size
```

so the rounding comes back on the one path that had removed it. Registration is
then capped at `floor(n / scheduler_block_size) * scheduler_block_size +
manager.block_size` instead of `n`, and everything between the last aligned
boundary and the tail stops being registered — `(n % scheduler_block_size) -
manager.block_size` tokens per call, which is most of a segment whenever the
group's own block is much smaller than the scheduler block. Only EAGLE-family
groups take that branch, so a model without speculative decoding never sees it.

This routes both bounds through one helper, `_align_cacheable`, so the exemption
cannot be lost again by re-deriving it in a second place.

**Reachability.** `enable_partial_hash_hits` requires a Mamba `"align"` group
with `block_size > hash_block_size`, prefix caching, and `dcp_world_size == 1`.
`mamba_cache_mode` is a `cache_config` knob rather than a model property, so any
hybrid Mamba model served with `--mamba-cache-mode align` and an EAGLE-family
drafter reaches this path; the remaining condition — every group's manager
supporting fine-grained lookup — holds automatically for the
full-attention + Mamba pair.
A stock `dcp_world_size == 1` hybrid model with EAGLE-family speculative decoding
is affected as written. We run that path under DCP > 1 through a local carry,
which is why we hit it on every run.

**Out of scope, flagged for a reviewer.** The soundness guard
`scheduler_block_size >= num_prefill_lookahead` is justified in its comment by
"hits land on scheduler-block boundaries", which holds only when
`enable_partial_hash_hits` is off — `_cache_hit_alignment_tokens` returns
`hash_block_size` when it is on. That guard predates this change and only matters
for multi-module MTP on a hybrid Mamba model, a combination we do not run and
cannot measure, so it is left alone rather than adjusted on a guess.

### Not a duplicate

No open PR addresses this. The nearest neighbours, checked before opening:

- #46384 — the partial prefix-cache hit feature itself
- #45702 — its design RFC
- #50438 — RFC: lookahead-aware prefix-cache hashing for EAGLE-style drafters,
  the closest in subject but a proposal for different hashing, not this bug
- #49125 — a different bug in the same area (stale partial hash revival)

### AI assistance

This change was developed with AI assistance (Claude). I reviewed every changed
line, ran the tests below myself, and can defend the change end to end.

## Test Plan

```bash
pytest tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py        -k eagle_group_registers_unaligned_tail
pytest tests/v1/core/prefix_cache/
pytest tests/v1/core/test_prefix_caching.py -k clamped_to_lcm
pytest tests/v1/core/          # before/after, to check nothing else moves
```

End to end: Kimi-K3 MXFP4 (hybrid, 24 MLA + 69 KDA layers), 8x B300, TP8, DSpark
speculative decoding with `num_speculative_tokens=7`, agentic replay workload,
60 minutes per point.

## Test Result

The new test fails on the parent commit (`acb0f1dcdb`) and passes with the fix.
The failure is the arithmetic above: the EAGLE group registers
`floor(22/8)*8 + 2 = 18` tokens where it should register 22.

```
>       assert recorded == [num_tokens] * len(coordinator.single_type_managers)
E       assert [18, 22] == [22, 22]
E         At index 0 diff: 18 != 22

1 failed, 24 deselected
```

```
tests/v1/core/prefix_cache/                      25 passed
tests/v1/core/test_prefix_caching.py -k clamped_to_lcm    1 passed
```

`tests/v1/core/` in full, same command on both trees: **+1 passed, −1 failed,
no other test changes state.** The one that moves is the new test. My sandbox
cannot import the compiled extensions, so a large fixed set of tests in that
directory errors out identically on both trees and is not informative here;
the targeted suites above are the ones that run clean.

End to end, one 60-minute run per cell:

| concurrency | before #50062 | with #50062 | with this fix |
|---|---|---|---|
| 8 | 5,146 tok/s/GPU | 4,767 (−7.4%) | **5,183** (+0.7%) |
| 16 | 7,669 tok/s/GPU | 6,611 (−13.8%) | **7,654** (−0.2%) |

GPU prefix-cache hit rate at concurrency 16: **86.3% → 77.4% → 86.2%**. The
non-speculative arm of the same ladder is unaffected throughout (13 points from
concurrency 1 to 78, all within −1.3% to +1.8%). The regressed pair was repeated
and the two runs agreed to within 0.3%.

### Effect on output

The change only widens which already-computed tokens may be registered in the
hash map; it does not alter what is computed, what a hit returns, or the
correctness conditions #50062 added (`num_reprefillable_tokens` still excludes
re-prefillable tail tokens, and the EAGLE last-block drop is untouched). Output
is bit-identical in the sense that no sampling path changes; the measured effect
is throughput and prefix-hit rate only. No accuracy evaluation was run, and none
is claimed.

For scale on this model: `TOKENSPEED_MLA` sets `block_size=32` and the attention
block is forced to 1536 to cover the mamba page. The unregistered part of a
prefix tail is `(n % 1536) - 32`, so up to **1,503** tokens go unregistered per
call — 1,472 when `n` is a multiple of 32.
