### PR TITLE
[Bugfix] Enforce deterministic cuDNN convolution under VLLM_BATCH_INVARIANT

### DIFF
--- a/tests/model_executor/layers/test_batch_invariant_conv_determinism.py
+++ b/tests/model_executor/layers/test_batch_invariant_conv_determinism.py
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import torch
+
+from vllm.model_executor.layers import batch_invariant as bi
+
+
+def test_init_batch_invariance_sets_cudnn_deterministic(monkeypatch):
+    """VLLM_BATCH_INVARIANT=1 must force deterministic cuDNN/MIOpen conv
+    algorithm selection, not just constrain rounding precision, so that
+    models with a convolution in their forward path (e.g. vision
+    patch-embed conv3d, diffusion VAE blocks) stay batch-invariant."""
+    monkeypatch.setenv("VLLM_BATCH_INVARIANT", "1")
+    monkeypatch.setattr(bi, "_batch_invariant_MODE", False)
+    prev_deterministic = torch.backends.cudnn.deterministic
+    try:
+        bi.init_batch_invariance()
+        assert torch.backends.cudnn.deterministic is True
+    finally:
+        torch.backends.cudnn.deterministic = prev_deterministic

--- a/vllm/model_executor/layers/batch_invariant.py
+++ b/vllm/model_executor/layers/batch_invariant.py
@@ -991,3 +991,8 @@ def init_batch_invariance():
         torch.backends.cuda.matmul.fp32_precision = "ieee"
         torch.backends.cudnn.conv.fp32_precision = "ieee"
         torch.backends.cudnn.rnn.fp32_precision = "ieee"
+
+        # fp32_precision only constrains rounding, not algorithm selection:
+        # cuDNN/MIOpen can still pick a nondeterministic reduction order for
+        # convolution (e.g. vision patch-embed conv3d, diffusion VAE blocks).
+        torch.backends.cudnn.deterministic = True


### PR DESCRIPTION
## Purpose

`VLLM_BATCH_INVARIANT=1` is meant to make model execution deterministic
across batch sizes/shapes. `init_batch_invariance()` disables TF32 and
forces IEEE rounding for matmul/conv/RNN via `fp32_precision = "ieee"`,
but that setting only constrains numeric *precision* — it does not pin
cuDNN/MIOpen's *algorithm selection* for convolution. cuDNN can still
choose a nondeterministic reduction order for `conv2d`/`conv3d`, so any
model with a convolution in its forward path (e.g. Qwen2.5-VL's conv3d
patch-embed, diffusion VAE blocks) stayed non-deterministic under batch
invariance despite the flag being set.

This PR sets `torch.backends.cudnn.deterministic = True` alongside the
existing `fp32_precision` overrides in `init_batch_invariance()`, so
convolution algorithm selection is pinned as well. The change is inside
the existing `if envs.VLLM_BATCH_INVARIANT:` guard, so it has no effect
on the default (non-batch-invariant) path, and no effect on models
without a convolution in their forward pass.

Fixes #52155.

## Test Plan

- Added `tests/model_executor/layers/test_batch_invariant_conv_determinism.py`,
  a CPU-only unit test that calls `init_batch_invariance()` with
  `VLLM_BATCH_INVARIANT=1` and asserts `torch.backends.cudnn.deterministic`
  is set to `True`.
- Manually exercised the same code path with a standalone repro script
  since I did not have GPU access to run the existing GPU-gated e2e
  determinism suite in `tests/v1/determinism/`.

```python
import os
os.environ["VLLM_BATCH_INVARIANT"] = "1"
import torch
from vllm.model_executor.layers import batch_invariant as bi
bi._batch_invariant_MODE = False
bi.init_batch_invariance()
assert torch.backends.cudnn.deterministic is True
```

- `ruff check` passes on both changed files.

## Test Result

Before the fix, `torch.backends.cudnn.deterministic` remained at its
PyTorch default (`False`) after calling `init_batch_invariance()` with
`VLLM_BATCH_INVARIANT=1`. After the fix, it is `True`, matching the
`fp32_precision = "ieee"` overrides already applied to matmul/conv/RNN.

```text
cudnn.deterministic after init: True
OK
```

**Note on AI assistance:** this PR was drafted with Claude Code. I (the
submitter) reviewed every changed line and the reasoning above myself.
I do not have GPU hardware available to run the existing GPU-gated
batch-invariance e2e suite (`tests/v1/determinism/test_batch_invariance.py`
and related), so that suite was not exercised for this change — only the
new CPU-only unit test and the manual repro above. Flagging this
explicitly so reviewers can decide whether to run that suite in CI
before merging.

- [x] The purpose of the PR: fixes #52155 (convolution not covered by `VLLM_BATCH_INVARIANT`).
- [x] The test plan: see above.
- [x] The test results: see above.
- [ ] No documentation update needed — this is an internal determinism fix, not a new model/feature.