### PR TITLE
[Bugfix] Fix --help=<keyword> state leaking between parse_args() calls

### DIFF
--- a/tests/utils_/test_argparse_utils.py
+++ b/tests/utils_/test_argparse_utils.py
@@ -468,6 +468,30 @@ def test_compilation_mode_string_values(parser):
     args = parser.parse_args(["-cc.mode=none"])
     assert args.compilation_config == {"mode": "none"}
 
+
+def test_help_keyword_does_not_leak_between_parse_calls(parser, capsys):
+    """A `--help=<keyword>` on one parse_args() call must not affect a
+    later plain `--help` (or `--help=<other keyword>`) call, whether on
+    the same parser instance or a different one."""
+    with pytest.raises(SystemExit):
+        parser.parse_args(["--help=image-input-type"])
+    filtered_help = capsys.readouterr().out
+    assert "--image-input-type" in filtered_help
+    assert "--batch-size" not in filtered_help
+
+    with pytest.raises(SystemExit):
+        parser.parse_args(["--help"])
+    full_help = capsys.readouterr().out
+    assert "--image-input-type" in full_help
+    assert "--batch-size" in full_help
+
+    other_parser = FlexibleArgumentParser()
+    other_parser.add_argument("--unrelated-flag", action="store_true")
+    with pytest.raises(SystemExit):
+        other_parser.parse_args(["--help"])
+    other_help = capsys.readouterr().out
+    assert "--unrelated-flag" in other_help
+
     args = parser.parse_args(["-cc.mode=vllm_compile"])
     assert args.compilation_config == {"mode": "vllm_compile"}
 

--- a/vllm/utils/argparse_utils.py
+++ b/vllm/utils/argparse_utils.py
@@ -248,6 +248,10 @@ class FlexibleArgumentParser(ArgumentParser):
         if args is None:
             args = sys.argv[1:]
 
+        # Reset from any previous parse_args() call on this instance so a
+        # `--help=<keyword>` from an earlier call can't leak into this one.
+        self._search_keyword = None
+
         if args and args[0] == "serve":
             # Check for --model in command line arguments first
             try:
@@ -309,7 +313,7 @@ class FlexibleArgumentParser(ArgumentParser):
         processed_args = list[str]()
         for i, arg in enumerate(args):
             if arg.startswith("--help="):
-                FlexibleArgumentParser._search_keyword = arg.split("=", 1)[-1].lower()
+                self._search_keyword = arg.split("=", 1)[-1].lower()
                 processed_args.append("--help")
             elif arg.startswith("--"):
                 if "=" in arg:


### PR DESCRIPTION
## Purpose

`FlexibleArgumentParser` stores the `--help=<keyword>` search term as a
**class** attribute:

```python
FlexibleArgumentParser._search_keyword = arg.split("=", 1)[-1].lower()
```

Because it's written on the class rather than the instance, once any
parser anywhere in the process runs `--help=<keyword>`, every later
`parse_args()` call on *any* `FlexibleArgumentParser` instance sees
that same keyword and returns the filtered help instead of the full
help — until some other call overwrites it. A plain `--help` after a
`--help=<keyword>` call silently returns a truncated help listing.

This was previously found and fixed in #39621 by @lnvitesace, which
got auto-closed by the stale-PR bot before a maintainer reviewed it.
The underlying bug is still present on current `main` — verified with
a standalone repro before applying the fix (see Test Result below).
Re-submitting the same fix with a regression test.

## Fix

- Reset `self._search_keyword = None` at the top of `parse_args()`.
- Write the keyword as an instance attribute (`self._search_keyword =
  ...`) instead of a class attribute, so it no longer leaks across
  instances or calls.

## Test Plan

- Added `test_help_keyword_does_not_leak_between_parse_calls` to
  `tests/utils_/test_argparse_utils.py`: calls `--help=<keyword>`,
  then a plain `--help` on the same parser instance, then `--help` on
  a *different* parser instance, asserting no cross-contamination.
- Manually reproduced the bug against `main` (before the fix) with a
  standalone script, confirmed the fix resolves it, and ran `ruff
  check` on both changed files. Did not have a working local pytest
  environment (missing `tblib`/other test deps, no `.venv` set up) to
  run the full suite, so this was verified via direct script execution
  instead of `pytest`.

## Test Result

Before the fix — a plain `--help` after an earlier `--help=<keyword>`
call was missing unrelated arguments (state leaked):

```text
batch-size present in full help (pre-fix): False
```

After the fix:

```text
filtered help OK (scoped)
full help OK (no leak) — bug is fixed
```

**AI assistance disclosure:** this PR description was drafted with Claude Code,
picking up and re-verifying the fix from the auto-closed #39621. I
reviewed the diff and reasoning myself.

- [x] The purpose of the PR: fixes the `--help=<keyword>` state leak.
- [x] The test plan: see above.
- [x] The test results: see above.
- [ ] No documentation update needed — internal parser bugfix.
