### PR TITLE
[Bugfix][ROCm] Fix DeepSeek-V4 regression caused by moving to MRV2

### DIFF
--- a/vllm/model_executor/layers/fused_moe/experts/rocm_aiter_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/rocm_aiter_moe.py
@@ -248,6 +248,29 @@ def rocm_aiter_fused_experts(
     moe_sorting_dispatch_policy: int = 0,
 ) -> torch.Tensor:
     """ROCm AITER fused MoE expert computation."""
+    # Guard: MRV2 dummy/profile/capture runs mark all tokens as padding, causing
+    # the hash router to write -1 into topk_ids. rocm_aiter_ops.fused_moe with
+    # quant_method=BLOCK_1X32 crashes on -1 expert indices (OOB access).
+    #
+    # TODO: remove this workaround once rocm_aiter_ops.fused_moe handles
+    # all-padding input gracefully (i.e. skips or no-ops for topk_ids == -1).
+    #
+    # Two cases handled here:
+    #   1. Eager / profile run (not capturing): int(topk_ids.max()) is safe;
+    #      return zeros immediately;
+    #   2. CUDA graph capture: int() would cause "operation not permitted when
+    #      stream is capturing". So we have to clamp -1 -> 0 and zero the
+    #      corresponding weights. The captured graph replays correctly because
+    #      at replay time the routing kernel fills topk_ids with real values(>=0),
+    #      making the clamp and mask no-ops.
+    if topk_ids.numel() > 0:
+        if torch.cuda.is_current_stream_capturing():
+            _valid = topk_ids >= 0
+            topk_ids = topk_ids.clamp(min=0)
+            topk_weights = topk_weights * _valid.to(topk_weights.dtype)
+        elif int(topk_ids.max()) < 0:
+            return torch.zeros_like(hidden_states)
+
     if quant_config is None:
         quant_config = FUSED_MOE_UNQUANTIZED_CONFIG
 


### PR DESCRIPTION
## Purpose
The 2 PRs (#51430 and #51768) switching DSv4 from MRV1 to MRV2 broke it on ROCm platform. This PR is to fix this issue.

## Test Plan
1. Running DSv4-Pro-0813 on ROCm platform:
VLLM_ROCM_USE_AITER=1 vllm serve /data/DeepSeek-V4-Pro-0813/   --dtype auto   --kv-cache-dtype fp8   --tensor-parallel-size 8   --max-num-seqs 512   --max-num-batched-tokens 8192   --distributed-executor-backend mp   --trust-remote-code   --gpu-memory-utilization 0.9   --tokenizer-mode deepseek_v4   --reasoning-parser deepseek_v4   --tool-call-parser deepseek_v4   --enable-auto-tool-choice   --compilation-config '{"mode": 3, "cudagraph_mode": "FULL_DECODE_ONLY"}'

2. Running lm_eval on gsm8k:
lm_eval --model local-completions \
  --tasks gsm8k \
  --output_path ./results \
  --log_samples \
  --num_fewshot 5 \
  --model_args model=/data/DeepSeek-V4-Pro-0813/,base_url=http://localhost:8000/v1/completions,num_concurrent=5,max_retries=3,timeout=3000,seed=1234,temperature=0


## Test Result
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9378|±  |0.0067|
|     |       |strict-match    |     5|exact_match|↑  |0.9378|±  |0.0067|

