### PR TITLE
[Bugfix][XPU] Use 64-bit qnorm RoPE offsets

### DIFF
--- a/vllm/models/deepseek_v4/xpu/xpu_qnorm_rope_kv_fp8_insert.py
+++ b/vllm/models/deepseek_v4/xpu/xpu_qnorm_rope_kv_fp8_insert.py
@@ -37,8 +37,8 @@ def _xpu_qnorm_rope_kernel(
     cos_sin_cache layout: [max_pos, ROPE_DIM] with first HALF_ROPE=cos,
     second HALF_ROPE=sin.
     """
-    token_idx = tl.program_id(0)
-    head_idx = tl.program_id(1)
+    token_idx = tl.program_id(0).to(tl.int64)
+    head_idx = tl.program_id(1).to(tl.int64)
 
     if token_idx >= num_tokens:
         return


### PR DESCRIPTION
## Purpose

Fixes #52416.

Thanks to @cheersluvs for identifying the overflow boundary, providing the reproduction data, and proposing the fix.

The XPU DeepSeek V4 qnorm/RoPE Triton kernel used 32-bit program IDs in pointer-offset arithmetic. `token_idx * num_heads * HEAD_DIM` therefore wrapped once the Q tensor exceeded `2^31` elements, producing invalid memory accesses at long-prefill shapes.

Cast both grid indices to `tl.int64` before any address computation. This keeps Q, KV, position, and output offsets in 64-bit arithmetic without changing the normalization, RoPE, or quantization algorithms.


