### PR TITLE
[XPU][INC] Fix RuntimeError when loading INT4 checkpoints with symmetric (empty-qzeros) layers

### DIFF
--- a/vllm/model_executor/layers/quantization/inc/schemes/inc_wna16_linear.py
+++ b/vllm/model_executor/layers/quantization/inc/schemes/inc_wna16_linear.py
@@ -420,10 +420,21 @@ class INCARKLinearMethod(INCXPULinearBase):
                 # ARK consumes GPTQ-style packed nibbles; convert AWQ losslessly.
                 qweight_src = self._convert_awq_qweight_to_gptq(qweight_src)
             ark_linear.qweight.copy_(qweight_src)
-            if hasattr(layer, "qzeros") and layer.qzeros is not None:
+
+            # Safely handle qzeros to prevent empty/mismatched tensor copy crashes on symmetric layers
+            if (
+                hasattr(layer, "qzeros")
+                and layer.qzeros is not None
+                and layer.qzeros.numel() > 0
+                and hasattr(ark_linear, "qzeros")
+                and ark_linear.qzeros is not None
+                and ark_linear.qzeros.numel() > 0
+                and layer.qzeros.shape == ark_linear.qzeros.shape
+            ):
                 ark_linear.qzeros.copy_(layer.qzeros.detach())
             else:
                 ark_linear.qzeros = None
+
             ark_linear.scales.copy_(layer.scales.detach())
             if hasattr(layer, "bias") and layer.bias is not None:
                 ark_linear.bias.copy_(layer.bias.detach())


### PR DESCRIPTION
## Summary

Loading an Intel AutoRound INT4 checkpoint with symmetrically-quantized layers crashes in `INCARKLinearMethod.process_weights_after_loading`:

```
RuntimeError: copy_() shape mismatch,
copying tensor with shape [1, 1, 0, 1] to tensor with shape [1, 1, 4096, 1]
```

The code copies `layer.qzeros` into `ark_linear.qzeros` whenever `layer.qzeros is not None`. For symmetric layers the `qzeros` tensor exists but is empty (`numel() == 0`), so the guard passes and `copy_()` raises on the shape mismatch.

This affects any mixed-precision INT4 MoE checkpoint where some layers are asymmetric (non-empty `qzeros`) and others symmetric (empty `qzeros`) — which is what Intel AutoRound produces by design.

## Fix

Only copy when both tensors are present, non-empty, and shape-compatible; otherwise set `ark_linear.qzeros = None` (the existing symmetric path):

```python
if (
    hasattr(layer, "qzeros")
    and layer.qzeros is not None
    and layer.qzeros.numel() > 0
    and hasattr(ark_linear, "qzeros")
    and ark_linear.qzeros is not None
    and ark_linear.qzeros.numel() > 0
    and layer.qzeros.shape == ark_linear.qzeros.shape
):
    ark_linear.qzeros.copy_(layer.qzeros.detach())
else:
    ark_linear.qzeros = None
```

Strict superset of the existing guard: asymmetric layers behave exactly as before; symmetric layers fall through to `qzeros = None` instead of crashing.

## Reproduction

- Hardware: 4x Intel Arc Pro B70 (Battlemage, XPU), vLLM `0.26.1rc1.dev500+gc39076fef`
- Model: an Intel AutoRound INT4 MoE checkpoint with mixed symmetric/asymmetric layers, `--quantization auto-round`
- Command: `vllm serve <model> --quantization auto-round --tensor-parallel-size 4`
- Result: crashes during weight loading with the `copy_() shape mismatch` error above, before the server starts

## Verification

After the patch, the same model loads and serves on XPU. Verified locally on Arc Pro B70.

Happy to add a unit test under `tests/quantization/` that constructs a layer with an empty `qzeros` and asserts `process_weights_after_loading` does not raise, if maintainers want it.

## Notes

- The sibling XPU path `INCXPULinearMethod` is unaffected: it hard-codes a symmetric `qzeros = tensor([8])` and never copies from `layer.qzeros`.
- No behavior change for fully-asymmetric or fully-symmetric checkpoints.
