### PR TITLE
[MoE] Fuse SwiGLU into Triton W13 epilogue

### DIFF
--- a/tests/kernels/moe/test_triton_moe_fused_w13_silu.py
+++ b/tests/kernels/moe/test_triton_moe_fused_w13_silu.py
@@ -1,0 +1,207 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+
+from tests.kernels.moe.utils import make_dummy_moe_config
+from vllm.model_executor.layers.fused_moe.activation import MoEActivation
+from vllm.model_executor.layers.fused_moe.config import (
+    FUSED_MOE_UNQUANTIZED_CONFIG,
+)
+from vllm.model_executor.layers.fused_moe.experts.triton_moe import TritonExperts
+from vllm.model_executor.layers.fused_moe.oracle.unquantized import (
+    UnquantizedMoeBackend,
+    convert_to_unquantized_kernel_format,
+)
+from vllm.platforms import current_platform
+
+
+def _interleave_w13(w13: torch.Tensor) -> torch.Tensor:
+    gate, up = w13.chunk(2, dim=1)
+    return torch.stack((gate, up), dim=2).flatten(1, 2)
+
+
+def _run_experts(
+    hidden_states: torch.Tensor,
+    w13: torch.Tensor,
+    w2: torch.Tensor,
+    topk_weights: torch.Tensor,
+    topk_ids: torch.Tensor,
+    fuse_w13_silu: bool,
+    global_num_experts: int | None = None,
+    expert_map: torch.Tensor | None = None,
+) -> torch.Tensor:
+    num_tokens, hidden_size = hidden_states.shape
+    num_local_experts, w13_size, _ = w13.shape
+    if global_num_experts is None:
+        global_num_experts = num_local_experts
+    topk = topk_ids.shape[1]
+    intermediate_size = w13_size // 2
+    moe_config = make_dummy_moe_config(
+        num_experts=global_num_experts,
+        num_local_experts=num_local_experts,
+        experts_per_token=topk,
+        hidden_dim=hidden_size,
+        intermediate_size=intermediate_size,
+        max_num_tokens=num_tokens,
+    )
+    moe_config.w13_swiglu_interleaved = fuse_w13_silu
+    experts = TritonExperts(moe_config, FUSED_MOE_UNQUANTIZED_CONFIG)
+    workspace13_shape, workspace2_shape, _ = experts.workspace_shapes(
+        num_tokens,
+        w13_size,
+        hidden_size,
+        topk,
+        global_num_experts,
+        num_local_experts,
+        None,
+        MoEActivation.SILU,
+    )
+    workspace13 = torch.empty(
+        workspace13_shape,
+        dtype=hidden_states.dtype,
+        device=hidden_states.device,
+    )
+    workspace2 = torch.empty(
+        workspace2_shape,
+        dtype=hidden_states.dtype,
+        device=hidden_states.device,
+    )
+    output = torch.zeros_like(hidden_states)
+    experts.apply(
+        output=output,
+        hidden_states=hidden_states,
+        w1=w13,
+        w2=w2,
+        topk_weights=topk_weights,
+        topk_ids=topk_ids,
+        activation=MoEActivation.SILU,
+        global_num_experts=global_num_experts,
+        expert_map=expert_map,
+        a1q_scale=None,
+        a2_scale=None,
+        workspace13=workspace13,
+        workspace2=workspace2,
+        expert_tokens_meta=None,
+        apply_router_weight_on_input=False,
+    )
+    return output
+
+
+@pytest.mark.skipif(not current_platform.is_cuda(), reason="Requires CUDA")
+@pytest.mark.parametrize("num_tokens", [1, 13, 128])
+@torch.inference_mode()
+def test_fused_w13_silu_matches_standalone_activation_bitwise(num_tokens: int):
+    """The epilogue must preserve both CUDA fast math and its BF16 rounding."""
+    torch.manual_seed(0)
+    num_experts, hidden_size, intermediate_size, topk = 16, 256, 128, 4
+    hidden_states = torch.randn(
+        num_tokens, hidden_size, device="cuda", dtype=torch.bfloat16
+    )
+    w13 = torch.randn(
+        num_experts,
+        2 * intermediate_size,
+        hidden_size,
+        device="cuda",
+        dtype=torch.bfloat16,
+    ) / (hidden_size**0.5)
+    w2 = torch.randn(
+        num_experts,
+        hidden_size,
+        intermediate_size,
+        device="cuda",
+        dtype=torch.bfloat16,
+    ) / (intermediate_size**0.5)
+    topk_ids = torch.stack(
+        [torch.randperm(num_experts, device="cuda")[:topk] for _ in range(num_tokens)]
+    )
+    topk_weights = torch.softmax(
+        torch.randn(num_tokens, topk, device="cuda", dtype=torch.float32), dim=-1
+    )
+
+    reference = _run_experts(hidden_states, w13, w2, topk_weights, topk_ids, False)
+    actual = _run_experts(
+        hidden_states, _interleave_w13(w13), w2, topk_weights, topk_ids, True
+    )
+
+    torch.testing.assert_close(actual, reference, rtol=0, atol=0)
+
+
+@pytest.mark.skipif(not current_platform.is_cuda(), reason="Requires CUDA")
+@torch.inference_mode()
+def test_fused_w13_silu_expert_parallel_zero_fill_bitwise():
+    """Remote experts must zero the half-width fused output, not adjacent rows."""
+    torch.manual_seed(1)
+    num_tokens, hidden_size, intermediate_size, topk = 13, 256, 128, 4
+    num_global_experts, num_local_experts = 8, 4
+    hidden_states = torch.randn(
+        num_tokens, hidden_size, device="cuda", dtype=torch.bfloat16
+    )
+    w13 = torch.randn(
+        num_local_experts,
+        2 * intermediate_size,
+        hidden_size,
+        device="cuda",
+        dtype=torch.bfloat16,
+    ) / (hidden_size**0.5)
+    w2 = torch.randn(
+        num_local_experts,
+        hidden_size,
+        intermediate_size,
+        device="cuda",
+        dtype=torch.bfloat16,
+    ) / (intermediate_size**0.5)
+    topk_ids = torch.randint(num_global_experts, (num_tokens, topk), device="cuda")
+    topk_weights = torch.softmax(
+        torch.randn(num_tokens, topk, device="cuda", dtype=torch.float32), dim=-1
+    )
+    expert_map = torch.tensor(
+        [0, 1, 2, 3, -1, -1, -1, -1], device="cuda", dtype=torch.int32
+    )
+
+    reference = _run_experts(
+        hidden_states,
+        w13,
+        w2,
+        topk_weights,
+        topk_ids,
+        False,
+        num_global_experts,
+        expert_map,
+    )
+    actual = _run_experts(
+        hidden_states,
+        _interleave_w13(w13),
+        w2,
+        topk_weights,
+        topk_ids,
+        True,
+        num_global_experts,
+        expert_map,
+    )
+
+    torch.testing.assert_close(actual, reference, rtol=0, atol=0)
+
+
+@pytest.mark.skipif(not current_platform.is_cuda(), reason="Requires CUDA")
+def test_unquantized_kernel_conversion_interleaves_eligible_weights():
+    torch.manual_seed(0)
+    w13 = torch.randn(4, 64, 32, device="cuda", dtype=torch.bfloat16)
+    w2 = torch.randn(4, 32, 32, device="cuda", dtype=torch.bfloat16)
+    moe_config = make_dummy_moe_config(
+        num_experts=4, hidden_dim=32, intermediate_size=32
+    )
+
+    converted, _ = convert_to_unquantized_kernel_format(
+        UnquantizedMoeBackend.TRITON, moe_config, w13, w2
+    )
+    assert moe_config.w13_swiglu_interleaved
+    torch.testing.assert_close(converted, _interleave_w13(w13), rtol=0, atol=0)
+
+    moe_config.activation = MoEActivation.GELU
+    converted, _ = convert_to_unquantized_kernel_format(
+        UnquantizedMoeBackend.TRITON, moe_config, w13, w2
+    )
+    assert not moe_config.w13_swiglu_interleaved
+    assert converted is w13

--- a/vllm/model_executor/layers/fused_moe/config.py
+++ b/vllm/model_executor/layers/fused_moe/config.py
@@ -1336,6 +1336,11 @@ class FusedMoEConfig:
     rocm_aiter_fmoe_enabled: bool = False
     aiter_fmoe_shared_expert_enabled: bool = False
 
+    # Runtime-only weight layout used by the Triton fused W13 SwiGLU epilogue.
+    # Set during unquantized kernel-format conversion; checkpoint weights are
+    # always loaded in the standard separated gate/up layout.
+    w13_swiglu_interleaved: bool = False
+
     def __post_init__(self):
         from vllm._aiter_ops import rocm_aiter_ops
 

--- a/vllm/model_executor/layers/fused_moe/experts/triton_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/triton_moe.py
@@ -313,6 +313,19 @@ class TritonExperts(LoRAExpertsMixin, mk.FusedMoEExpertsModular):
         )
         intermediate_cache3 = _resize_cache(workspace2, (num_tokens, top_k_num, K))
 
+        fuse_w13_silu = self.moe_config.w13_swiglu_interleaved
+        if fuse_w13_silu:
+            assert (
+                self.quant_dtype is None
+                and hidden_states.dtype == torch.bfloat16
+                and activation == MoEActivation.SILU
+                and self.activation_config.clamp_limit is None
+                and self.activation_config.alpha == 1.0
+                and self.activation_config.beta == 0.0
+                and self._lora_context is None
+                and self.w1_bias is None
+            )
+
         sorted_token_ids, expert_ids, num_tokens_post_padded = (
             _prepare_expert_assignment(
                 topk_ids,
@@ -370,7 +383,11 @@ class TritonExperts(LoRAExpertsMixin, mk.FusedMoEExpertsModular):
             invoke_fused_moe_triton_kernel(
                 hidden_states,
                 w1,
-                intermediate_cache1,
+                (
+                    intermediate_cache2.view(num_tokens, top_k_num, cache2_dim)
+                    if fuse_w13_silu
+                    else intermediate_cache1
+                ),
                 input_scale,
                 self.w1_scale,
                 None,  # topk_weights
@@ -388,6 +405,7 @@ class TritonExperts(LoRAExpertsMixin, mk.FusedMoEExpertsModular):
                 per_channel_quant=self.per_act_token_quant,
                 block_shape=self.block_shape,
                 B_bias=self.w1_bias,
+                fuse_w13_silu=fuse_w13_silu,
             )
 
         if lora_context is not None and lora_context.aux_stream is not None:
@@ -453,7 +471,9 @@ class TritonExperts(LoRAExpertsMixin, mk.FusedMoEExpertsModular):
         # Fuse SiLU+Mul + FP8 block quantize into a single kernel
         # when conditions permit (gated SiLU, fp8 block quant with
         # group_size=128, no LoRA requiring the BF16 intermediate).
-        if (
+        if fuse_w13_silu:
+            qintermediate_cache2 = intermediate_cache2
+        elif (
             activation == MoEActivation.SILU
             and self.quant_config.use_fp8_w8a8
             and self.block_shape == [128, 128]

--- a/vllm/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe.py
@@ -352,6 +352,8 @@ def fused_moe_kernel(
     SWAP_AB: tl.constexpr,
     # Tensor-descriptor path for the A gather and B load in the K-loop.
     USE_TD: tl.constexpr = False,
+    # W13 rows are [gate0, up0, gate1, up1, ...]; apply SwiGLU in epilogue.
+    FUSE_W13_SILU: tl.constexpr = False,
 ):
     """
     Implements the fused computation for a Mixture of Experts (MOE) using
@@ -425,18 +427,29 @@ def fused_moe_kernel(
         # -----------------------------------------------------------
         # Write back zeros to the output when the expert is not
         # in the current expert parallel rank.
-        write_zeros_to_output(
-            c_ptr,
-            stride_cm,
-            stride_cn,
-            pid_n,
-            N,
-            offs_token,
-            token_mask,
-            BLOCK_SIZE_M,
-            BLOCK_SIZE_N,
-            compute_type,
-        )
+        if FUSE_W13_SILU:
+            offs_cn = pid_n * (BLOCK_SIZE_N // 2) + tl.arange(0, BLOCK_SIZE_N // 2)
+            c_ptrs = (
+                c_ptr + stride_cm * offs_token[:, None] + stride_cn * offs_cn[None, :]
+            )
+            tl.store(
+                c_ptrs,
+                0.0,
+                mask=token_mask[:, None] & (offs_cn[None, :] < N // 2),
+            )
+        else:
+            write_zeros_to_output(
+                c_ptr,
+                stride_cm,
+                stride_cn,
+                pid_n,
+                N,
+                offs_token,
+                token_mask,
+                BLOCK_SIZE_M,
+                BLOCK_SIZE_N,
+                compute_type,
+            )
         return
 
     offs_bn = (pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N).to(tl.int64)) % N
@@ -605,9 +618,43 @@ def fused_moe_kernel(
     # -----------------------------------------------------------
     # Write back the block of the output
     offs_cn = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
-    c_ptrs = c_ptr + stride_cm * offs_token[:, None] + stride_cn * offs_cn[None, :]
-    c_mask = token_mask[:, None] & (offs_cn[None, :] < N)
-    tl.store(c_ptrs, accumulator, mask=c_mask)
+    if FUSE_W13_SILU:
+        tl.static_assert(BLOCK_SIZE_N % 2 == 0)
+        pairs = tl.reshape(accumulator, (BLOCK_SIZE_M, BLOCK_SIZE_N // 2, 2))
+        gate, up = tl.split(pairs)
+        gate = gate.to(tl.float32)
+        # Match the fast-math contract of the CUDA silu_and_mul kernel this
+        # replaces. Triton's regular sigmoid uses more accurate operations,
+        # whose small difference can cross a BF16 rounding boundary.
+        exp_neg = tl.inline_asm_elementwise(
+            "{ mul.ftz.f32 $0, $1, 0fBFB8AA3B; ex2.approx.ftz.f32 $0, $0; }",
+            "=f,f",
+            [gate],
+            dtype=tl.float32,
+            is_pure=True,
+            pack=1,
+        )
+        silu = tl.inline_asm_elementwise(
+            "div.approx.ftz.f32 $0, $1, $2;",
+            "=f,f,f",
+            [gate, 1.0 + exp_neg],
+            dtype=tl.float32,
+            is_pure=True,
+            pack=1,
+        )
+        # silu_kernel returns the input scalar type before the gated multiply,
+        # so preserve that BF16 rounding point as well as the fast exp/div.
+        activated = silu.to(compute_type).to(tl.float32) * up.to(tl.float32)
+        offs_half = pid_n * (BLOCK_SIZE_N // 2) + tl.arange(0, BLOCK_SIZE_N // 2)
+        c_ptrs = (
+            c_ptr + stride_cm * offs_token[:, None] + stride_cn * offs_half[None, :]
+        )
+        c_mask = token_mask[:, None] & (offs_half[None, :] < N // 2)
+        tl.store(c_ptrs, activated.to(compute_type), mask=c_mask)
+    else:
+        c_ptrs = c_ptr + stride_cm * offs_token[:, None] + stride_cn * offs_cn[None, :]
+        c_mask = token_mask[:, None] & (offs_cn[None, :] < N)
+        tl.store(c_ptrs, accumulator, mask=c_mask)
 
 
 # NOTE(zyongye): we can remove all the wna16 kernel
@@ -781,10 +828,18 @@ def invoke_fused_moe_triton_kernel(
     per_channel_quant: bool,
     block_shape: list[int] | None = None,
     B_bias: torch.Tensor | None = None,
+    fuse_w13_silu: bool = False,
 ):
     assert topk_weights is not None or not mul_routed_weight
     assert topk_weights is None or topk_weights.stride(1) == 1
     assert sorted_token_ids is None or sorted_token_ids.stride(0) == 1
+    if fuse_w13_silu:
+        assert not (use_fp8_w8a8 or use_int8_w8a8 or use_int8_w8a16 or use_int4_w4a16)
+        assert B_bias is None
+        assert not mul_routed_weight
+        assert compute_type == tl.bfloat16
+        assert B.size(1) % 2 == 0
+        assert config["BLOCK_SIZE_N"] % 2 == 0
 
     if use_fp8_w8a8:
         SWAP_AB = enable_swap_ab(config["BLOCK_SIZE_M"], config["BLOCK_SIZE_N"])
@@ -900,6 +955,7 @@ def invoke_fused_moe_triton_kernel(
         BLOCK_SIZE_K=BLOCK_SIZE_K,
         SWAP_AB=SWAP_AB,
         USE_TD=use_td,
+        FUSE_W13_SILU=fuse_w13_silu,
         **config,
     )
 

--- a/vllm/model_executor/layers/fused_moe/oracle/unquantized.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/unquantized.py
@@ -330,6 +330,30 @@ def convert_to_unquantized_kernel_format(
     w13_weight: torch.Tensor,
     w2_weight: torch.Tensor,
 ) -> tuple[torch.Tensor, torch.Tensor]:
+    # Kernel-format conversion can be called again after a runtime weight
+    # update. Never let a layout bit from an earlier conversion leak into a
+    # later, ineligible one.
+    moe_config.w13_swiglu_interleaved = False
+    if (
+        unquantized_backend == UnquantizedMoeBackend.TRITON
+        and current_platform.is_cuda()
+        and moe_config.in_dtype == torch.bfloat16
+        and moe_config.activation == MoEActivation.SILU
+        and moe_config.is_act_and_mul
+        and not moe_config.has_bias
+        and not moe_config.is_lora_enabled
+        and not moe_config.moe_parallel_config.enable_eplb
+        and moe_config.swiglu_limit is None
+        and moe_config.swiglu_alpha in (None, 1.0)
+        and moe_config.swiglu_beta in (None, 0.0)
+    ):
+        gate, up = w13_weight.chunk(2, dim=1)
+        w13_weight = torch.stack((gate, up), dim=2).flatten(1, 2)
+        moe_config.w13_swiglu_interleaved = True
+        logger.info_once(
+            "Using fused Triton W13 SwiGLU epilogue with interleaved weights."
+        )
+
     if unquantized_backend == UnquantizedMoeBackend.AITER:
         w13_weight, w2_weight = rocm_aiter_ops.shuffle_weights(w13_weight, w2_weight)
         w13_weight.is_shuffled = True


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose

Interleave BF16 W13 gate/up rows at load time so each pair lands in one GEMM output tile, then apply the CUDA-compatible SwiGLU calculation directly in the Triton epilogue and store only the half-width result. This removes the routed-MoE activation launch and the full-width intermediate HBM round trip while preserving bitwise output parity, including expert-parallel zero-fill.

Discovered by AI Agent and I have reviewed the details.

## Test Plan

```
lm_eval run \
    --model vllm \
    --model_args pretrained=Qwen/Qwen3.6-35B-A3B,dtype=bfloat16,max_model_len=8192,max_gen_toks=256,enable_thinking=False \
    --tasks gsm8k \
    --num_fewshot 5 \
    --batch_size auto \
    --apply_chat_template \
    --fewshot_as_multiturn
```

## Test Result

MoE Kernel:

| M | Baseline | Fused | Speedup |
| ---: | ---: | ---: | ---: |
| 1 | 0.179888 ms | 0.167616 ms | 7.32% |
| 8 | 0.209408 ms | 0.210400 ms | -0.47% |
| 32 | 0.365856 ms | 0.366880 ms | -0.28% |
| 128 | 0.519168 ms | 0.519376 ms | -0.04% |
| 512 | 0.543024 ms | 0.539008 ms | 0.75% |
| 1024 | 0.609920 ms | 0.609968 ms | -0.01% |
| 4096 | 0.854848 ms | 0.837744 ms | 2.04% |

```text
Performance: Qwen3.6-35B-A3B BF16, H200, input_len=4096, output_len=1

Production compile + CUDA Graph, 20 iterations:
Baseline mean / median: 87.946 / 87.903 ms
Fused mean / median:    85.810 / 85.702 ms
Mean speedup:           2.49%
Median speedup:         2.57%

Eager mode, 100 iterations:
Baseline mean / median: 97.019 / 96.084 ms
Fused mean / median:    96.305 / 95.665 ms
Mean speedup:           0.74%
Median speedup:         0.44%

Kernel correctness:
5 passed in tests/kernels/moe/test_triton_moe_fused_w13_silu.py
M=1/13/128 and expert-parallel paths are bitwise identical to the unfused path.
```

Acc:

```console
INFO 08-15 14:02:26 [unquantized.py:317] Using TRITON Unquantized MoE backend out of potential backends: ['TRITON', 'BATCHED_TRITON', 'FlashInfer TRTLLM', 'FlashInfer CUTLASS'].
INFO 08-15 14:02:38 [unquantized.py:353] Using fused Triton W13 SwiGLU epilogue with interleaved weights.
INFO 08-15 14:02:38 [unquantized.py:422] Using MoEPrepareAndFinalizeNoDPEPModular
INFO 08-15 14:02:38 [unquantized.py:423] Using TritonExperts MoE backend
Processed prompts: 100%|██████████| 1319/1319 [00:44<00:00, 29.49it/s, est. speed input: 31424.92 toks/s, output: 4516.11 toks/s]
vllm ({'pretrained': '/mnt/huggingface/hub/models--Qwen--Qwen3.6-35B-A3B/snapshots/995ad96eacd98c81ed38be0c5b274b04031597b0', 'dtype': 'bfloat16', 'gpu_memory_utilization': 0.9, 'max_model_len': 8192, 'max_gen_toks': 256, 'enable_thinking': False}), gen_kwargs: ({}), limit: None, num_fewshot: 5, batch_size: auto
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.8863|±  |0.0087|
|     |       |strict-match    |     5|exact_match|↑  |0.8757|±  |0.0091|
```


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://docs.vllm.ai/en/latest/contributing>** (anything written below this line will be removed by GitHub Actions)
