### PR TITLE
[Bugfix][Quantization] Move the E2M1 lookup table to the input device in break_fp4_bytes

### DIFF
--- a/tests/kernels/quantization/test_nvfp4_emulation.py
+++ b/tests/kernels/quantization/test_nvfp4_emulation.py
@@ -770,3 +770,22 @@ def test_nvfp4_moe_correctness(
         atol=0.0 if on_gfx950() else 0.02,
         rtol=0,
     )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_break_fp4_bytes_cuda_input():
+    """Regression test for #52407: ``break_fp4_bytes`` must move the E2M1
+    lookup table to the input tensor's device instead of indexing a CPU
+    tensor with CUDA indices, which raises a device mismatch error."""
+    from vllm.model_executor.layers.quantization.utils.nvfp4_emulation_utils import (
+        break_fp4_bytes,
+    )
+
+    x = torch.randint(0, 256, (2, 8), dtype=torch.uint8, device="cuda")
+    out = break_fp4_bytes(x, torch.float32)
+    assert out.device.type == "cuda"
+    assert out.shape == (2, 16)
+
+    # Numerical parity with the CPU reference on the same data.
+    ref = break_fp4_bytes(x.cpu(), torch.float32)
+    torch.testing.assert_close(out.cpu(), ref)

--- a/vllm/model_executor/layers/quantization/utils/nvfp4_emulation_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/nvfp4_emulation_utils.py
@@ -313,7 +313,7 @@ def break_fp4_bytes(a, dtype):
     signs = (combined & 0x08).to(torch.bool)  # Sign bits
     abs_vals = (combined & 0x07).to(torch.long)
 
-    kE2M1 = kE2M1ToFloat_handle.val
+    kE2M1 = kE2M1ToFloat_handle.val.to(abs_vals.device)
     # Device-aware lookup and sign application
     values = kE2M1[abs_vals] * torch.where(signs, -1.0, 1.0)
     # Reshape to final form


### PR DESCRIPTION
## Purpose

Fixes #52407.

`VLLM_BATCH_INVARIANT=1` enables the batch-invariant NVFP4 path, which dequantizes
weights on the GPU. The module-level E2M1 lookup table
(`kE2M1ToFloat_handle.val`) lives on CPU, so `break_fp4_bytes` indexed a CPU tensor
with GPU indices and raised a device mismatch.

## Changes

- `vllm/model_executor/layers/quantization/utils/nvfp4_emulation_utils.py`: move the
  E2M1 lookup table to the input tensor's device before indexing.
- Add regression test `test_break_fp4_bytes_cuda_input` (CUDA input + numerical parity
  against the CPU reference).

## Test Plan

```bash
pytest tests/kernels/quantization/test_nvfp4_emulation.py -k break_fp4_bytes   # CUDA required
ruff check vllm/model_executor/layers/quantization/utils/nvfp4_emulation_utils.py
ruff format --check vllm/model_executor/layers/quantization/utils/nvfp4_emulation_utils.py
```

## Test Result

<!-- TODO: paste the CUDA pytest output and ruff results -->
- new test asserts `out.device.type == "cuda"`, shape `(2, 16)`, and parity with the CPU reference.

## Notes

- Includes a `needs-rebase` fixup: rebased onto latest `main`.
- AI-assisted; reviewed by me. DCO `Signed-off-by:` present.