### PR TITLE
[bot] Enable Gemma4 E4B (google/gemma-4-E4B-it-qat-w4a16-ct) on Intel XPU with mixed attention backends

### DIFF
--- a/vllm/model_executor/models/config.py
+++ b/vllm/model_executor/models/config.py
@@ -76,6 +76,11 @@ class Gemma4Config(VerifyAndUpdateConfig):
         with different head dimensions for prefill-decode disaggregation.
         """
         hf_text_config = vllm_config.model_config.hf_text_config
+        # Enable global access for heterogeneous per-layer configs
+        # (e.g., E4B variant). vLLM handles heterogeneous head dims
+        # via per-layer attention backend routing.
+        if getattr(hf_text_config, "is_heterogeneous", False):
+            hf_text_config.allow_global_per_layer_attribute_access = True
         head_dim = getattr(hf_text_config, "head_dim", None)
         global_head_dim = getattr(hf_text_config, "global_head_dim", None)
 
@@ -92,18 +97,35 @@ class Gemma4Config(VerifyAndUpdateConfig):
             and max_head_dim > 256
             and vllm_config.attention_config.backend is None
         ):
+            from vllm.platforms import current_platform
             from vllm.v1.attention.backends.registry import (
                 AttentionBackendEnum,
             )
 
-            vllm_config.attention_config.backend = AttentionBackendEnum.TRITON_ATTN
-            logger.info(
-                "Gemma4 model has heterogeneous head dimensions "
-                "(head_dim=%d, global_head_dim=%d). Forcing TRITON_ATTN "
-                "backend to prevent mixed-backend numerical divergence.",
-                head_dim,
-                global_head_dim,
-            )
+            if current_platform.is_xpu():
+                # On XPU, don't force TRITON_ATTN globally. Instead,
+                # per-layer routing in XPUPlatform.get_attn_backend_cls()
+                # routes head_size>256 layers to Triton and head_size<=256
+                # layers to Flash Attention for optimal performance.
+                logger.info(
+                    "Gemma4 model has heterogeneous head dimensions "
+                    "(head_dim=%d, global_head_dim=%d). XPU will use "
+                    "per-layer mixed backend: FA for head_dim<=256, "
+                    "Triton for head_dim>256.",
+                    head_dim,
+                    global_head_dim,
+                )
+            else:
+                vllm_config.attention_config.backend = (
+                    AttentionBackendEnum.TRITON_ATTN
+                )
+                logger.info(
+                    "Gemma4 model has heterogeneous head dimensions "
+                    "(head_dim=%d, global_head_dim=%d). Forcing TRITON_ATTN "
+                    "backend to prevent mixed-backend numerical divergence.",
+                    head_dim,
+                    global_head_dim,
+                )
 
 
 class DeepseekV4ForCausalLMConfig(VerifyAndUpdateConfig):

--- a/vllm/model_executor/models/gemma4.py
+++ b/vllm/model_executor/models/gemma4.py
@@ -559,7 +559,12 @@ class Gemma4DecoderLayer(nn.Module):
         # Gemma4 uses different head dimensions for sliding vs full attention
         layer_type = config.layer_types[layer_idx]
         self.is_full_attention = layer_type == "full_attention"
-        if self.is_full_attention:
+        # For heterogeneous configs (E4B), head_dim varies per layer.
+        # Use per_layer_config if available, otherwise fall back to
+        # global_head_dim / head_dim.
+        if hasattr(config, "per_layer_config") and config.per_layer_config:
+            head_dim = config.per_layer_config[layer_idx].head_dim
+        elif self.is_full_attention:
             head_dim = getattr(config, "global_head_dim", config.head_dim)
         else:
             head_dim = config.head_dim

--- a/vllm/model_executor/models/gemma4_mtp.py
+++ b/vllm/model_executor/models/gemma4_mtp.py
@@ -274,9 +274,13 @@ class Gemma4MTPDecoderLayer(nn.Module):
         layer_type = config.layer_types[layer_idx]
         is_full_attention = layer_type == "full_attention"
         head_dim = (
-            getattr(config, "global_head_dim", config.head_dim)
-            if is_full_attention
-            else config.head_dim
+            config.per_layer_config[layer_idx].head_dim
+            if hasattr(config, "per_layer_config") and config.per_layer_config
+            else (
+                getattr(config, "global_head_dim", config.head_dim)
+                if is_full_attention
+                else config.head_dim
+            )
         )
 
         use_k_eq_v = is_full_attention and getattr(config, "attention_k_eq_v", False)

--- a/vllm/platforms/xpu.py
+++ b/vllm/platforms/xpu.py
@@ -83,7 +83,20 @@ class XPUPlatform(Platform):
                 "Falling back to Triton Attention backend."
             )
             return AttentionBackendEnum.TRITON_ATTN.get_path()
-        elif selected_backend == AttentionBackendEnum.FLASH_ATTN:
+
+        # XPU Flash Attention SYCL kernel supports head_size <= 256.
+        # Route larger head sizes to Triton (e.g., Gemma4 global attention
+        # layers with head_dim=512). Must check before returning FA below.
+        head_size = attn_selector_config.head_size
+        if head_size is not None and head_size > 256:
+            logger.info(
+                "head_size=%d exceeds XPU Flash Attention limit (256). "
+                "Falling back to Triton Attention for this layer.",
+                head_size,
+            )
+            return AttentionBackendEnum.TRITON_ATTN.get_path()
+
+        if selected_backend == AttentionBackendEnum.FLASH_ATTN:
             logger.info_once("Using Flash Attention backend.")
             return AttentionBackendEnum.FLASH_ATTN.get_path()
         elif selected_backend:

--- a/vllm/transformers_utils/model_arch_config_convertor.py
+++ b/vllm/transformers_utils/model_arch_config_convertor.py
@@ -572,8 +572,21 @@ class Gemma4ModelArchConfigConvertor(ModelArchConfigConvertorBase):
         # Gemma4 uses dual head dimensions: head_dim (sliding attention)
         # and global_head_dim (full attention).  Return the largest so
         # that attention backends allocate buffers large enough for both.
-        head_dim = getattr(self.hf_text_config, "head_dim", 0)
-        global_head_dim = getattr(self.hf_text_config, "global_head_dim", 0)
+        #
+        # Newer transformers versions mark head_dim as a per-layer
+        # attribute on heterogeneous configs (E4B variant), which raises
+        # AmbiguousGlobalPerLayerAttributeError on direct access.
+        # Enable global access since vLLM handles heterogeneous head
+        # dims via per-layer attention backend routing.
+        tc = self.hf_text_config
+        if getattr(tc, "is_heterogeneous", False):
+            tc.allow_global_per_layer_attribute_access = True
+            # For heterogeneous configs, get max head_dim across layers
+            per_layer = getattr(tc, "per_layer_config", None)
+            if per_layer:
+                return max(lc.head_dim for lc in per_layer)
+        head_dim = getattr(tc, "head_dim", 0)
+        global_head_dim = getattr(tc, "global_head_dim", 0)
         return max(head_dim, global_head_dim) or super().get_head_size()
 
 


### PR DESCRIPTION
## Motivation

Gemma4 E4B is a heterogeneous model with per-layer varying head dimensions (head_dim=256 for sliding attention, head_dim=512 for global attention). On Intel XPU, the Flash Attention SYCL kernel only supports head_size <= 256, so running this model requires per-layer attention backend routing.

## Technical Details

1. **Per-layer mixed attention backend on XPU** (`vllm/platforms/xpu.py`): Added head_size check before Flash Attention selection — layers with head_size > 256 are routed to Triton Attention, while head_size <= 256 layers use the faster Flash Attention SYCL kernel.

2. **Skip forced TRITON_ATTN on XPU** (`vllm/model_executor/models/config.py`): The existing Gemma4 config forces TRITON_ATTN globally for heterogeneous models. On XPU, we skip this to allow per-layer routing (FA for sliding layers, Triton for global layers).

3. **Handle heterogeneous per-layer configs** (`gemma4.py`, `gemma4_mtp.py`): Use `per_layer_config[layer_idx].head_dim` when available (newer transformers with heterogeneous config support).

4. **Fix AmbiguousGlobalPerLayerAttributeError** (`model_arch_config_convertor.py`, `config.py`): Enable `allow_global_per_layer_attribute_access` for heterogeneous configs and compute max head_dim across layers for buffer allocation.

## Performance Impact

- **Hardware**: Intel Arc Pro B60 (24 GB), TP=1
- **Model**: google/gemma-4-E4B-it-qat-w4a16-ct (W4A16 quantized)
- Mixed backend approach gives optimal decode performance: Flash Attention (SYCL) for 256-dim sliding layers, Triton for 512-dim global layers

## Testing

Verified model loads and generates coherent output on Intel XPU with the mixed attention backend routing.