### PR TITLE
[Bugfix][Spec Decode][Structured Output] DSpark: fix the grammar bitmask mapping when the draft budget is zero

### DIFF
--- a/tests/v1/spec_decode/test_adaptive_verification.py
+++ b/tests/v1/spec_decode/test_adaptive_verification.py
@@ -9,6 +9,7 @@ from vllm.v1.worker.gpu.async_utils import StepTimingSample
 from vllm.v1.worker.gpu.spec_decode.adaptive_verification import (
     AdaptiveVerificationManager,
 )
+from vllm.v1.worker.gpu.structured_outputs import _build_grammar_mapping
 
 
 def make_manager(
@@ -168,3 +169,51 @@ def test_zero_budget_rebuilds_cpu_cu_num_logits():
     assert cu_num_logits_np.dtype == scheduled_cu_num_logits.dtype
     # The prefill keeps its scheduled tokens; only drafts are dropped.
     assert np.array_equal(compacted, np.array([1, 1, 40], dtype=np.int32))
+
+
+def test_zero_budget_keeps_one_grammar_row_per_scheduled_draft():
+    # The scheduler sizes the grammar bitmask from the *scheduled* drafts
+    # (len(drafts) + 1 rows per request), but a zero budget rewrites
+    # cu_num_logits_np to bonus-only. Deriving the bitmask -> logits mapping
+    # from those rewritten offsets drops rows and trips the
+    # `num_masks == len(mapping)` assert in apply_grammar_bitmask.
+    manager = make_manager(
+        np.array([[0.9, 0.9], [0.9, 0.9], [1.0, 1.0]], dtype=np.float32),
+        np.ones(64),
+    )
+    manager.req_states.req_id_to_index["prefill"] = 2
+    manager.req_states.num_computed_tokens_np = np.zeros(3, dtype=np.int32)
+    manager.req_states.prefill_len.np = np.array([0, 0, 60], dtype=np.int32)
+    manager._max_total_logits = 2  # < 3 requests * 1 bonus token
+
+    scheduled_spec_decode_tokens = {"low": [1, 2], "high": [3, 4]}
+    manager.get_num_tokens(
+        {"low": 3, "high": 3, "prefill": 40}, scheduled_spec_decode_tokens
+    )
+    assert manager._batch_budget[2] == 0
+
+    req_ids = ["low", "high", "prefill"]
+    num_draft_tokens_per_req = np.array([2, 2, 0], dtype=np.int32)
+    _, cu_num_logits_np = manager.compact_batch(
+        num_draft_tokens_per_req,
+        np.array([3, 3, 40], dtype=np.int32),
+        np.array([0, 3, 6, 7], dtype=np.int32),
+    )
+
+    mask_stride = manager.num_speculative_steps + manager.num_bonus_tokens
+    mapping = _build_grammar_mapping(
+        req_ids,
+        req_ids,
+        cu_num_logits_np,
+        num_draft_tokens_per_req,
+        manager.num_bonus_tokens,
+        mask_stride,
+    )
+
+    num_bitmask_rows = sum(
+        len(scheduled_spec_decode_tokens.get(req_id, ())) + 1 for req_id in req_ids
+    )
+    assert len(mapping) == num_bitmask_rows
+    # (request, position) keys, so the kernel can mask rows the compacted
+    # device layout no longer has room for.
+    assert mapping == [0, 1, 2, 3, 4, 5, 6]

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -419,6 +419,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                 vocab_size=self.vocab_size,
                 device=self.device,
                 mask_stride=self.decode_query_len,
+                num_bonus_tokens=self.model_state.num_new_sampled_tokens_per_step,
             )
 
         if self.is_pooling_model and self.is_last_pp_rank:

--- a/vllm/v1/worker/gpu/structured_outputs.py
+++ b/vllm/v1/worker/gpu/structured_outputs.py
@@ -10,6 +10,32 @@ from vllm.v1.worker.gpu.buffer_utils import async_copy_to_gpu
 from vllm.v1.worker.gpu.input_batch import InputBatch
 
 
+def _build_grammar_mapping(
+    req_ids: list[str],
+    grammar_req_ids: list[str],
+    cu_num_logits_np: np.ndarray,
+    num_draft_tokens_per_req: np.ndarray | None,
+    num_bonus_tokens: int,
+    mask_stride: int,
+) -> list[int]:
+    mapping: list[int] = []
+    req_id_to_idx = {req_id: i for i, req_id in enumerate(req_ids)}
+    for grammar_req_id in grammar_req_ids:
+        req_idx = req_id_to_idx[grammar_req_id]
+        if num_draft_tokens_per_req is None:
+            num_positions = int(
+                cu_num_logits_np[req_idx + 1] - cu_num_logits_np[req_idx]
+            )
+        else:
+            # Grammar masks follow the scheduled layout even when adaptive
+            # verification compacts the actual CPU logit offsets to bonus-only.
+            num_positions = int(num_draft_tokens_per_req[req_idx]) + num_bonus_tokens
+        mapping.extend(
+            req_idx * mask_stride + position for position in range(num_positions)
+        )
+    return mapping
+
+
 class StructuredOutputsWorker:
     def __init__(
         self,
@@ -17,6 +43,7 @@ class StructuredOutputsWorker:
         vocab_size: int,
         device: torch.device,
         mask_stride: int,
+        num_bonus_tokens: int,
     ):
         self.logits_indices = torch.zeros(
             max_num_logits, dtype=torch.int32, device=device
@@ -27,6 +54,7 @@ class StructuredOutputsWorker:
         self.device = device
         self.copy_stream = torch.cuda.Stream()
         self.mask_stride = mask_stride
+        self.num_bonus_tokens = num_bonus_tokens
 
     def apply_grammar_bitmask(
         self,
@@ -45,21 +73,17 @@ class StructuredOutputsWorker:
             )
 
         # Construct bitmask -> logits mapping
-        mapping: list[int] = []
-        req_ids = input_batch.req_ids
-        cu_num_logits = input_batch.cu_num_logits_np.tolist()
-        req_id_to_idx = {req_id: i for i, req_id in enumerate(req_ids)}
-        for grammar_req_id in grammar_req_ids:
-            req_idx = req_id_to_idx[grammar_req_id]
-            logits_start_idx = cu_num_logits[req_idx]
-            logits_end_idx = cu_num_logits[req_idx + 1]
-            # Key by (request, position) rather than absolute logit index:
-            # adaptive verification finalizes per-request logit offsets on
-            # device, so the kernel resolves them from the GPU cu_num_logits.
-            mapping.extend(
-                req_idx * self.mask_stride + position
-                for position in range(logits_end_idx - logits_start_idx)
-            )
+        # Key by (request, position) rather than absolute logit index:
+        # adaptive verification finalizes per-request logit offsets on
+        # device, so the kernel resolves them from the GPU cu_num_logits.
+        mapping = _build_grammar_mapping(
+            input_batch.req_ids,
+            grammar_req_ids,
+            input_batch.cu_num_logits_np,
+            input_batch.num_draft_tokens_per_req,
+            self.num_bonus_tokens,
+            self.mask_stride,
+        )
 
         # Asynchronously copy the mapping to GPU.
         with torch.cuda.stream(self.copy_stream):


### PR DESCRIPTION
## Purpose

Fixes a crash when DSpark adaptive verification (`enable_adaptive_verification`, added in #47808) is combined with structured outputs and the chosen draft budget is zero.

```
assert num_masks == len(mapping)  // fails when draft_budget == 0
```

**Scenario:** serving a structured-outputs request (JSON schema / grammar) with DSpark adaptive verification enabled crashes on an assert as soon as the drafter's confidence drops far enough that adaptive verification decides to verify zero drafts this step.

### When is `draft_budget == 0`? (not an edge case)

That is not an exotic corner. Zero is the routine choice whenever drafts stop paying for their verification cost. Per step, the controller picks `draft_budget = argmax_b (est_accepted_tokens(b)/cost(b))` over `b ∈ [0, max_draft_budget]` (`adaptive_verification.py:329`). `b = 0` ("verify no drafts, sample only the bonus token") is a normal output of that argmax, selected whenever verifying even the most-confident draft is net-negative for throughput — i.e. whenever the drafter's confidence is low. That happens routinely (high-entropy tokens, warm-up, grammar-constrained steps), so a sustained DSpark + structured-outputs workload hits it repeatedly and the crash reproduces under ordinary load. This is exactly the behavior #47808 introduced.

### Root cause

The scheduler and the worker disagree on how many grammar bitmask rows exist:

  - The scheduler sizes the bitmask from the **scheduled** drafts — `len(drafts) + 1` rows per request (`vllm/v1/structured_output/__init__.py`), and it has no knowledge of the device-side budget trimming.
  - `compact_batch()`'s zero-budget branch rewrites `cu_num_logits_np` to the exact bonus-only layout (`adaptive_verification.py:361`). That rewrite exists to serve `_iter_request_chunks`, which slices the compacted logits with these offsets.

 `apply_grammar_bitmask` derived its bitmask → logits mapping from those rewritten offsets, so it produced one row per request instead of one per scheduled draft and tripped `assert num_masks == len(mapping)` (`structured_outputs.py:102`).

For a batch of 2 verification requests with 2 drafts each plus 1 bonus token, the scheduler emits 6 rows while the old expression yields 2:

 ```
 bitmask rows = 6,  mapping = [0, 3]  (len 2)  ->  assert fails
 ```

 ### Why the other two budget regimes were unaffected

Only the zero-budget branch rewrites `cu_num_logits_np`; the other two return it untouched, still holding the scheduled layout that the scheduler used. Exercising all three branches through the real `compact_batch`:

 | regime | `cu_num_logits_np` | rewritten | old mapping len | bitmask rows | |
 |---|---|---|---|---|---|
 | `budget == num_drafts` | `[0, 3, 6]` | no | 6 | 6 | OK |
 | `0 < budget < num_drafts` | `[0, 3, 6]` | no | 6 | 6 | OK |
 | `budget == 0` | `[0, 1, 2]` | **yes** | **2** | 6 | **assert fails** |

 So the old code was correct in two regimes only because that field happened to carry scheduled-layout semantics there.

 ### Fix

Size the mapping from `num_draft_tokens_per_req + num_bonus_tokens` instead. That array comes from the same `scheduled_spec_decode_tokens` the scheduler used (`model_runner.py:1132`) and is never touched by compaction, so all three regimes agree and the row count no longer depends on a field whose meaning shifts.

 Rows that the compacted device layout has no room for are already masked by  `position_is_active` in the kernel (`structured_outputs.py:144`), which resolves true per-request offsets from the GPU-side `cu_num_logits`. This is the mechanism #47808 introduced; the fix just stops the host side from second-guessing it.

 ## Test Plan

 Added `test_zero_budget_keeps_one_grammar_row_per_scheduled_draft` to `tests/v1/spec_decode/test_adaptive_verification.py`. 

  ```bash
  .venv/bin/python -m pytest tests/v1/spec_decode/test_adaptive_verification.py -v
  # related suites touching the same cu_num_logits_np contract:
  .venv/bin/python -m pytest tests/v1/worker/test_gpu_rejection_sampler_chunking.py \
                             tests/v1/worker/test_gpu_batch_ordering.py -v
  pre-commit run --all-files
  ```

  ## Test Result

  ```
  tests/v1/spec_decode/test_adaptive_verification.py  6 passed
  + test_gpu_rejection_sampler_chunking.py, test_gpu_batch_ordering.py
                                                    17 passed, 4 skipped
  pre-commit                                        all hooks passed (incl. mypy, ruff format)
  ```

  Verified the new test actually fails without the fix by reverting only the helper body while keeping its signature:

  ```
  without fix:  E   assert 3 == 7
                    where 3 = len([0, 3, 6])
  with fix:     6 passed