### PR TITLE
fix(missing_documentation): Class `SamplingType` in vllm/sampling_params.py has no docst

### DIFF
--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -78,6 +78,28 @@ ThinkingTokenBudget = Annotated[
 
 
 class SamplingType(IntEnum):
+    """Enum of sampling strategies used to select the next token.
+
+    Each member corresponds to a distinct decoding algorithm:
+
+    - ``GREEDY`` – always pick the single highest-probability token
+      (equivalent to ``temperature=0``).
+    - ``RANDOM`` – sample from the probability distribution, optionally
+      shaped by ``temperature``, ``top_p``, ``top_k``, etc.
+    - ``RANDOM_SEED`` – same as ``RANDOM`` but with a fixed random seed,
+      enabling reproducible outputs.
+
+    Example::
+
+        >>> from vllm.sampling_params import SamplingParams, SamplingType
+        >>> params = SamplingParams(temperature=0.0)
+        >>> params.sampling_type
+        <SamplingType.GREEDY: 0>
+        >>> params = SamplingParams(temperature=0.8)
+        >>> params.sampling_type
+        <SamplingType.RANDOM: 1>
+    """
+
     GREEDY = 0
     RANDOM = 1
     RANDOM_SEED = 2


### PR DESCRIPTION
## TLDR

**Gap:** Class `SamplingType` in vllm/sampling_params.py has no docstring — add parameter docs, return type, and example

**Wedge type:** `missing_documentation`

**Issue:** https://github.com/vllm-project/vllm/blob/main/vllm/sampling_params.py#L64

## Changes

- `vllm/sampling_params.py`

**Diff size:** 22 lines across 1 file(s)

## Pre-submission checklist

- [x] Minimal change — touches at most 3 files
- [x] Tests updated (if test suite present)
- [x] No CI/CD, Dockerfile, or lock file modifications
- [x] Diff reviewed for secrets

## AI Assistance Disclosure

This contribution was AI-assisted using Hermes Agent (Nous Research).

Co-authored-by: Hermes Agent <hermes-agent@nousresearch.com>