### PR TITLE
[MRV2][CUDA Graph] Guard attention metadata addresses before replay

### DIFF
--- a/tests/v1/cudagraph/test_cudagraph_manager.py
+++ b/tests/v1/cudagraph/test_cudagraph_manager.py
@@ -109,3 +109,49 @@ def test_full_capture_sets_graph_pool_id_before_cuda_graph(monkeypatch):
         manager.capture(create_forward_fn)
 
     mock_cuda_graph.assert_called_once()
+
+
+def test_collects_nested_cuda_tensor_addresses():
+    block_table = MagicMock(spec=torch.Tensor)
+    block_table.is_cuda = True
+    block_table.data_ptr.return_value = 123
+    host_tensor = MagicMock(spec=torch.Tensor)
+    host_tensor.is_cuda = False
+    metadata = {"layer": [(block_table, host_tensor)]}
+
+    addresses = gpu_cudagraph_utils._collect_attn_metadata_ptrs(metadata)
+
+    assert addresses == {"[layer][0][0]": 123}
+
+
+@pytest.mark.parametrize(
+    ("captured_ptrs", "error_match"),
+    [
+        ({"[layer].block_table": 1}, "tensor addresses changed"),
+        (None, "No attention metadata addresses"),
+    ],
+    ids=["address-mismatch", "missing-snapshot"],
+)
+def test_invalid_attn_metadata_binding_stops_before_full_graph_replay(
+    monkeypatch, captured_ptrs, error_match
+):
+    manager = object.__new__(gpu_cudagraph_utils.CudaGraphManager)
+    desc = BatchExecutionDescriptor(
+        cg_mode=CUDAGraphMode.FULL,
+        num_tokens=4,
+        num_reqs=4,
+        uniform_token_count=1,
+    )
+    graph = MagicMock()
+    manager.graphs = {desc: graph}
+    manager._captured_attn_metadata_ptrs = (
+        {} if captured_ptrs is None else {desc: captured_ptrs}
+    )
+    offloader = MagicMock()
+    monkeypatch.setattr(gpu_cudagraph_utils, "get_offloader", lambda: offloader)
+
+    with pytest.raises(AssertionError, match=error_match):
+        manager.run_fullgraph(desc, {})
+
+    offloader.sync_prev_onload.assert_not_called()
+    graph.replay.assert_not_called()

--- a/vllm/v1/worker/gpu/cudagraph_utils.py
+++ b/vllm/v1/worker/gpu/cudagraph_utils.py
@@ -1,8 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 from collections import defaultdict
-from collections.abc import Callable
-from dataclasses import dataclass
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, fields, is_dataclass
 from itertools import product
 from typing import Any, NamedTuple, Protocol
 
@@ -10,6 +10,7 @@ import torch
 import torch.nn as nn
 from tqdm import tqdm
 
+from vllm import envs
 from vllm.compilation.breakable_cudagraph import (
     BreakableCUDAGraphWrapper,
     is_breakable_cudagraph_enabled,
@@ -43,6 +44,30 @@ logger = init_logger(__name__)
 class AttentionState(NamedTuple):
     attn_metadata: dict[str, Any] | None
     slot_mappings: dict[str, torch.Tensor]
+
+
+def _collect_attn_metadata_ptrs(value: Any) -> dict[str, int]:
+    addresses: dict[str, int] = {}
+
+    def visit(value: Any, path: str) -> None:
+        if isinstance(value, torch.Tensor):
+            if value.is_cuda:
+                addresses[path] = value.data_ptr()
+            return
+
+        if is_dataclass(value):
+            for field in fields(value):
+                field_path = f"{path}.{field.name}" if path else field.name
+                visit(getattr(value, field.name), field_path)
+        elif isinstance(value, Mapping):
+            for key, child in value.items():
+                visit(child, f"{path}[{key}]")
+        elif isinstance(value, (list, tuple)):
+            for index, child in enumerate(value):
+                visit(child, f"{path}[{index}]")
+
+    visit(value, "")
+    return addresses
 
 
 @dataclass(frozen=True)
@@ -128,6 +153,9 @@ class CudaGraphManager:
         self._lora_dispatch_map, self._max_lora_case = self._build_lora_dispatch_map()
 
         self.graphs: dict[BatchExecutionDescriptor, torch.cuda.CUDAGraph] = {}
+        self._captured_attn_metadata_ptrs: (
+            dict[BatchExecutionDescriptor, dict[str, int]] | None
+        ) = {} if envs.VLLM_LOGGING_LEVEL == "DEBUG" else None
         self.pool = current_platform.get_global_graph_pool() if cudagraph_mode else None
 
         self._graphs_captured = False
@@ -303,6 +331,20 @@ class CudaGraphManager:
     def needs_capture(self) -> bool:
         return len(self._capture_descs) > 0
 
+    def _record_attn_metadata_ptrs(
+        self,
+        desc: BatchExecutionDescriptor,
+        attn_metadata: dict[str, Any] | None,
+    ) -> None:
+        if (
+            self._captured_attn_metadata_ptrs is None
+            or desc.cg_mode != CUDAGraphMode.FULL
+        ):
+            return
+        self._captured_attn_metadata_ptrs[desc] = _collect_attn_metadata_ptrs(
+            attn_metadata
+        )
+
     @torch.inference_mode()
     def capture(
         self,
@@ -409,12 +451,35 @@ class CudaGraphManager:
             num_active_loras=effective_loras,
         )
 
-    def run_fullgraph(self, desc: BatchExecutionDescriptor):
+    def run_fullgraph(
+        self,
+        desc: BatchExecutionDescriptor,
+        attn_metadata: dict[str, Any] | None,
+    ) -> Any:
         """Replay a captured FULL cudagraph."""
         assert desc.cg_mode == CUDAGraphMode.FULL, (
             f"Expected FULL mode, got {desc.cg_mode}"
         )
         assert desc in self.graphs, f"No cudagraph for {desc}"
+        if self._captured_attn_metadata_ptrs is not None:
+            assert desc in self._captured_attn_metadata_ptrs, (
+                f"No attention metadata addresses recorded for CUDA graph {desc}"
+            )
+            captured_ptrs = self._captured_attn_metadata_ptrs[desc]
+            runtime_ptrs = _collect_attn_metadata_ptrs(attn_metadata)
+            mismatched_paths = (
+                None
+                if runtime_ptrs == captured_ptrs
+                else sorted(
+                    path
+                    for path in captured_ptrs.keys() | runtime_ptrs.keys()
+                    if captured_ptrs.get(path) != runtime_ptrs.get(path)
+                )
+            )
+            assert mismatched_paths is None, (
+                "Attention metadata tensor addresses changed for CUDA graph "
+                f"{desc}: {mismatched_paths}"
+            )
         # Sync offloader before replay - needed when transitioning from
         # eager/piecewise to full cudagraph (e.g., prefill → decode).
         # The previous eager iteration's start_prefetch may have queued
@@ -523,6 +588,9 @@ class ModelCudaGraphManager(CudaGraphManager):
                 max_query_len=desc.max_query_len,
             )
 
+            if not warmup:
+                self._record_attn_metadata_ptrs(desc, attn_metadata)
+
             # Capture with dummy rows marked as padding.
             input_buffers.is_padding.fill_(True)
 
@@ -588,10 +656,12 @@ class ModelCudaGraphManager(CudaGraphManager):
         super().capture(create_forward_fn, progress_bar_desc)
 
     def run_fullgraph(
-        self, desc: BatchExecutionDescriptor
+        self,
+        desc: BatchExecutionDescriptor,
+        attn_metadata: dict[str, Any] | None,
     ) -> torch.Tensor | tuple[torch.Tensor, list[torch.Tensor]] | IntermediateTensors:
         """Replay a captured FULL cudagraph and return hidden states."""
-        super().run_fullgraph(desc)
+        super().run_fullgraph(desc, attn_metadata)
         if not self.is_last_pp_rank:
             assert self.intermediate_tensors is not None
             return self.intermediate_tensors[: desc.num_tokens]

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -1611,7 +1611,9 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             # because they are already copied to the CUDA graph input buffers.
             assert self.cudagraph_manager is not None
             self.kv_connector.pre_forward(scheduler_output)
-            model_output = self.cudagraph_manager.run_fullgraph(batch_desc)
+            model_output = self.cudagraph_manager.run_fullgraph(
+                batch_desc, attn_metadata
+            )
         else:
             # For piecewise and eager mode, just call model().
             batch_descriptor = BatchDescriptor(

--- a/vllm/v1/worker/gpu/spec_decode/autoregressive/cudagraph_utils.py
+++ b/vllm/v1/worker/gpu/spec_decode/autoregressive/cudagraph_utils.py
@@ -58,6 +58,8 @@ class SpeculatorCudaGraphManager(CudaGraphManager):
                 kv_cache_config,
                 full_cudagraph=desc.cg_mode == CUDAGraphMode.FULL,
             )
+            if not warmup:
+                self._record_attn_metadata_ptrs(desc, attn_metadata)
 
             return lambda cg_mode: forward_fn(
                 num_reqs,

--- a/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
@@ -295,7 +295,9 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
         if prefill_batch_desc.cg_mode == CUDAGraphMode.FULL:
             # Replay the full graph for draft prefill.
             assert self.prefill_cudagraph_manager is not None
-            self.prefill_cudagraph_manager.run_fullgraph(prefill_batch_desc)
+            self.prefill_cudagraph_manager.run_fullgraph(
+                prefill_batch_desc, attn_metadata
+            )
         else:
             # The target model's attention metadata and slot mappings
             # can directly be used for draft prefill, because of the
@@ -494,7 +496,7 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
 
             if batch_desc.cg_mode == CUDAGraphMode.FULL:
                 assert self.decode_cudagraph_manager is not None
-                self.decode_cudagraph_manager.run_fullgraph(batch_desc)
+                self.decode_cudagraph_manager.run_fullgraph(batch_desc, attn_metadata)
             else:
                 self._generate_draft(
                     num_reqs,
@@ -540,7 +542,7 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
 
         if batch_desc.cg_mode == CUDAGraphMode.FULL:
             assert self.decode_cudagraph_manager is not None
-            self.decode_cudagraph_manager.run_fullgraph(batch_desc)
+            self.decode_cudagraph_manager.run_fullgraph(batch_desc, attn_metadata)
             return
 
         self._generate_fused_drafts(

--- a/vllm/v1/worker/gpu/spec_decode/dflash/cudagraph.py
+++ b/vllm/v1/worker/gpu/spec_decode/dflash/cudagraph.py
@@ -97,6 +97,8 @@ class DFlashCudaGraphManager(CudaGraphManager):
                 causal=causal,
             )
             attn_metadata, slot_mappings = attn_state
+            if not warmup:
+                self._record_attn_metadata_ptrs(desc, attn_metadata)
 
             return lambda cg_mode: forward_fn(
                 num_reqs,

--- a/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
@@ -454,7 +454,7 @@ class DFlashSpeculator(DraftModelSpeculator):
 
         if batch_desc.cg_mode == CUDAGraphMode.FULL:
             assert self.query_cudagraph_manager is not None
-            self.query_cudagraph_manager.run_fullgraph(batch_desc)
+            self.query_cudagraph_manager.run_fullgraph(batch_desc, draft_attn_metadata)
         else:
             self._generate_draft(
                 num_reqs,

--- a/vllm/v1/worker/gpu/spec_decode/multi_module_mtp/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/multi_module_mtp/speculator.py
@@ -237,7 +237,7 @@ class MultiModuleMTPSpeculator(DraftModelSpeculator):
 
         if batch_desc.cg_mode == CUDAGraphMode.FULL:
             assert self.cudagraph_manager is not None
-            self.cudagraph_manager.run_fullgraph(batch_desc)
+            self.cudagraph_manager.run_fullgraph(batch_desc, attn_metadata)
         else:
             self._generate_drafts(
                 num_reqs,


### PR DESCRIPTION
## Purpose

CUDA Graph replay captures the tensor addresses used by attention metadata. This change reimplements the address-binding diagnostic from #35605 for the current MRV2 CUDA Graph managers and replay surfaces.

- Collect CUDA tensor `data_ptr()` values from nested attention metadata in DEBUG mode.
- Store snapshots per FULL CUDA Graph descriptor at the three metadata capture owners.
- Validate runtime attention metadata before offloader synchronization and graph replay.
- Fail closed when a snapshot is missing or a tensor address changes.
- Cover the main model runner, autoregressive prefill/decode/fused paths, DFlash, and Multi-Module MTP.
- Keep PIECEWISE replay and non-DEBUG execution unchanged.
- Avoid exposing raw pointer values in assertion messages.
- Add focused coverage to the existing CUDA Graph manager test suite.

## Test Plan

Model evaluation is not applicable because this is a DEBUG-only diagnostic.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

