### PR TITLE
[Bugfix][Multimodal] Keep Gemma 4 video frame counts on CPU

### DIFF
--- a/tests/models/multimodal/generation/test_vit_cudagraph.py
+++ b/tests/models/multimodal/generation/test_vit_cudagraph.py
@@ -286,6 +286,12 @@ MODEL_CONFIGS: dict[str, VitCudagraphTestConfig] = {
             "<bos><start_of_turn>user\n<|video|>\nDescribe this video in one sentence."
             "<end_of_turn>\n<start_of_turn>model\n"
         ),
+        # The 16-frame test video produces 1056 vision tokens. Capture only
+        # the smallest supported bucket that covers it instead of all default
+        # buckets through max_model_len, which adds unrelated memory pressure.
+        compilation_config_overrides={
+            "encoder_cudagraph_token_budgets": [1120],
+        },
         needs_video_metadata=True,
         marks=[pytest.mark.core_model],
     ),

--- a/vllm/model_executor/models/gemma4_mm.py
+++ b/vllm/model_executor/models/gemma4_mm.py
@@ -801,7 +801,7 @@ class Gemma4MultiModalProcessor(BaseMultiModalProcessor[Gemma4ProcessingInfo]):
                     MultiModalFieldConfig.flat_from_sizes("video", vfc)
                 ),
                 video_frame_counts=MultiModalFieldConfig.batched(
-                    "video",
+                    "video", keep_on_cpu=True
                 ),
                 video_num_soft_tokens=MultiModalFieldConfig.batched(
                     "video", keep_on_cpu=True


### PR DESCRIPTION



## Purpose
FIX https://buildkite.com/vllm/ci/builds/84014#01a0041b-4750-418e-aab2-15f6f61ebfaf

```

(EngineCore pid=18850) ERROR 08-15 07:10:27 [dump_input.py:72] Dumping input data for V1 LLM engine (v0.27.2rc1.dev119+ga67d4e226) with config: model='google/gemma-4-E2B-it', speculative_config=None, tokenizer='google/gemma-4-E2B-it', skip_tokenizer_init=False, tokenizer_mode=auto, revision=main, tokenizer_revision=main, trust_remote_code=True, dtype=torch.bfloat16, max_seq_len=4096, download_dir=None, load_format=auto, tensor_parallel_size=1, pipeline_parallel_size=1, data_parallel_size=1, decode_context_parallel_size=1, dcp_comm_backend=ag_rs, disable_custom_all_reduce=False, quantization=None, quantization_config=None, enforce_eager=False, enable_return_routed_experts=False, kv_cache_dtype=auto, device_config=cuda, structured_outputs_config=StructuredOutputsConfig(backend='auto', disable_any_whitespace=False, disable_additional_properties=False, reasoning_parser='', reasoning_parser_plugin='', enable_in_reasoning=False), observability_config=ObservabilityConfig(show_hidden_metrics_for_version=None, otlp_traces_endpoint=None, collect_detailed_traces=None, kv_cache_metrics=False, kv_cache_metrics_sample=0.01, cudagraph_metrics=False, enable_layerwise_nvtx_tracing=False, enable_mfu_metrics=False, enable_mm_processor_stats=False, enable_logging_iteration_details=False, jit_monitor_mode='warn', jit_monitor_verbose=False), seed=0, served_model_name=google/gemma-4-E2B-it, enable_prefix_caching=True, enable_chunked_prefill=False, pooler_config=None, compilation_config={'mode': <CompilationMode.VLLM_COMPILE: 3>, 'debug_dump_path': None, 'cache_dir': '', 'compile_cache_save_format': 'binary', 'backend': 'inductor', 'custom_ops': ['none'], 'ir_enable_torch_wrap': True, 'splitting_ops': ['vllm::unified_attention_with_output', 'vllm::unified_mla_attention_with_output', 'vllm::mamba_mixer2', 'vllm::mamba_mixer', 'vllm::short_conv', 'vllm::linear_attention', 'vllm::qwen_gdn_attention_core', 'vllm::qwen_gdn_attention_core_fused_norm_packed', 'vllm::gdn_attention_core_xpu', 'vllm::olmo_hybrid_gdn_full_forward', 'vllm::sparse_attn_indexer', 'vllm::rocm_aiter_sparse_attn_indexer', 'vllm::deepseek_v4_attention', 'vllm::hpc_rope_norm_forward', 'vllm::unified_kv_cache_update', 'vllm::unified_mla_kv_cache_update'], 'compile_mm_encoder': False, 'cudagraph_mm_encoder': True, 'encoder_cudagraph_token_budgets': [], 'encoder_cudagraph_max_vision_items_per_batch': 1, 'encoder_cudagraph_max_frames_per_batch': 16, 'compile_sizes': [], 'compile_ranges_endpoints': [8192], 'inductor_compile_config': {'enable_auto_functionalized_v2': False, 'combo_kernels': True, 'benchmark_combo_kernel': True}, 'inductor_passes': {}, 'cudagraph_mode': <CUDAGraphMode.FULL_AND_PIECEWISE: (2, 1)>, 'cudagraph_num_of_warmups': 1, 'cudagraph_capture_sizes': [1, 2, 4], 'cudagraph_copy_inputs': False, 'cudagraph_specialize_lora': True, 'use_inductor_graph_partition': False, 'pass_config': {'fuse_norm_quant': False, 'fuse_act_quant': False, 'fuse_attn_quant': False, 'enable_sp': False, 'fuse_gemm_comms': False, 'fuse_allreduce_rms': False, 'enable_qk_norm_rope_fusion': False, 'fuse_rope_kvcache_cat_mla': False, 'fuse_act_padding': False, 'fuse_qk_norm_rope_kvcache': False}, 'max_cudagraph_capture_size': 4, 'dynamic_shapes_config': {'type': <DynamicShapesType.BACKED: 'backed'>, 'evaluate_guards': False, 'assume_32_bit_indexing': False}, 'local_cache_dir': '/root/.cache/vllm/torch_compile_cache/torch_aot_compile/6e20855329b34430a087d106cdf55b1b45c7aa59e104135b9e0a645a89bc2436', 'fast_moe_cold_start': False, 'static_all_moe_layers': []}, kernel_config=KernelConfig(ir_op_priority=IrOpPriorityConfig(rms_norm=['native'], fused_add_rms_norm=['native']), enable_flashinfer_autotune=True, enable_cutedsl_warmup=True, enable_jit_warmup=True, enable_bf16x3_router_gemm=False, moe_backend='auto', linear_backend='auto'),
--
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [dump_input.py:79] Dumping scheduler output for model execution: SchedulerOutput(scheduled_new_reqs=[NewRequestData(req_id=0-896413e1,prompt_token_ids_len=1233,prefill_token_ids_len=1233,mm_features=[MultiModalFeatureSpec(data={'video_timestamps': MultiModalFieldElem(data=[0.0, 1.6460905349794237, 3.2921810699588474, 4.938271604938271, 6.584362139917695, 8.23045267489712, 9.876543209876543, 11.522633744855966, 13.16872427983539, 14.814814814814813, 16.46090534979424, 18.10699588477366, 19.753086419753085, 21.39917695473251, 23.045267489711932, 24.691358024691358], field=MultiModalBatchedField(keep_on_cpu=True)), 'pixel_position_ids_videos': MultiModalFieldElem(data=tensor([[[ 0,  0],
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [dump_input.py:79]          [ 1,  0],
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [dump_input.py:79]          [ 2,  0],
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [dump_input.py:79]          ...,
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [dump_input.py:79]          [-1, -1],
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [dump_input.py:79]          [-1, -1],
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [dump_input.py:79]          [-1, -1]],
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [dump_input.py:79]
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [dump_input.py:79]         [[ 0,  0],
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [dump_input.py:79]          [ 1,  0],
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [dump_input.py:79]          [ 2,  0],
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [dump_input.py:79]          ...,
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [dump_input.py:79]          [-1, -1],
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [dump_input.py:79]          [-1, -1],
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [dump_input.py:79]          [-1, -1]],
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [dump_input.py:79]
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [dump_input.py:79]         [[ 0,  0],
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [dump_input.py:79]          [ 1,  0],
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [dump_input.py:79]          [ 2,  0],
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [dump_input.py:79]          ...,
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [dump_input.py:79]          [-1, -1],
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [dump_input.py:79]          [-1, -1],
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [dump_input.py:79]          [-1, -1]],
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [dump_input.py:79]
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [dump_input.py:79]         ...,
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [dump_input.py:79]
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [dump_input.py:79]         [[ 0,  0],
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [dump_input.py:79]          [ 1,  0],
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [dump_input.py:79]          [ 2,  0],
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [dump_input.py:79]          ...,
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [dump_input.py:79]          [-1, -1],
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [dump_input.py:79]          [-1, -1],
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [dump_input.py:79]          [-1, -1]],
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [dump_input.py:79]
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [dump_input.py:79]         [[ 0,  0],
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [dump_input.py:79]          [ 1,  0],
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [dump_input.py:79]          [ 2,  0],
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [dump_input.py:79]          ...,
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [dump_input.py:79]          [-1, -1],
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [dump_input.py:79]          [-1, -1],
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [dump_input.py:79]          [-1, -1]],
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [dump_input.py:79]
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [dump_input.py:79]         [[ 0,  0],
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [dump_input.py:79]          [ 1,  0],
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [dump_input.py:79]          [ 2,  0],
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [dump_input.py:79]          ...,
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [dump_input.py:79]          [-1, -1],
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [dump_input.py:79]          [-1, -1],
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [dump_input.py:79]          [-1, -1]]]), field=MultiModalFlatField(keep_on_cpu=False, slices=[[slice(0, 16, None)]], dim=0)), 'video_frame_counts': MultiModalFieldElem(data=tensor(16), field=MultiModalBatchedField(keep_on_cpu=False)), 'pixel_values_videos': MultiModalFieldElem(data=tensor([[[0.1216, 0.0825, 0.0747,  ..., 0.3145, 0.2715, 0.2471],
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [dump_input.py:79]          [0.3535, 0.2988, 0.2949,  ..., 0.1299, 0.0747, 0.0630],
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [dump_input.py:79]          [0.3535, 0.2988, 0.2949,  ..., 0.3418, 0.2871, 0.2832],
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [dump_input.py:79]          ...,
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [dump_input.py:79]          [0.0000, 0.0000, 0.0000,  ..., 0.0000, 0.0000, 0.0000],
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [dump_input.py:79]          [0.0000, 0.0000, 0.0000,  ..., 0.0000, 0.0000, 0.0000],
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [dump_input.py:79]          [0.0000, 0.0000, 0.0000,  ..., 0.0000, 0.0000, 0.0000]],
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [dump_input.py:79]
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [dump_input.py:79]         [[0.1260, 0.0825, 0.0747,  ..., 0.1260, 0.0825, 0.0669],
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [dump_input.py:79]          [0.1846, 0.1299, 0.1260,  ..., 0.1650, 0.1099, 0.1060],
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [dump_input.py:79]          [0.1611, 0.1060, 0.1021,  ..., 0.3379, 0.2871, 0.2559],
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [dump_input.py:79]          ...,
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [dump_input.py:79]          [0.0000, 0.0000, 0.0000,  ..., 0.0000, 0.0000, 0.0000],
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [dump_input.py:79]          [0.0000, 0.0000, 0.0000,  ..., 0.0000, 0.0000, 0.0000],
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [dump_input.py:79]          [0.0000, 0.0000, 0.0000,  ..., 0.0000, 0.0000, 0.0000]],
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [dump_input.py:79]
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [dump_input.py:79]         [[0.1216, 0.0825, 0.0747,  ..., 0.1299, 0.0864, 0.0708],
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [dump_input.py:79]          [0.1299, 0.0747, 0.0708,  ..., 0.1611, 0.1060, 0.1021],
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [dump_input.py:79]          [0.1650, 0.1099, 0.1060,  ..., 0.3457, 0.2910, 0.2715],
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [dump_input.py:79]          ...,
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [dump_input.py:79]          [0.0000, 0.0000, 0.0000,  ..., 0.0000, 0.0000, 0.0000],
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [dump_input.py:79]          [0.0000, 0.0000, 0.0000,  ..., 0.0000, 0.0000, 0.0000],
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [dump_input.py:79]          [0.0000, 0.0000, 0.0000,  ..., 0.0000, 0.0000, 0.0000]],
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [dump_input.py:79]
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [dump_input.py:79]         ...,
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [dump_input.py:79]
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [dump_input.py:79]         [[0.2314, 0.1924, 0.1846,  ..., 0.3301, 0.2871, 0.2637],
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [dump_input.py:79]          [0.3809, 0.3262, 0.3223,  ..., 0.1416, 0.1021, 0.1021],
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [dump_input.py:79]          [0.1338, 0.0903, 0.0903,  ..., 0.1885, 0.1338, 0.1216],
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [dump_input.py:79]          ...,
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [dump_input.py:79]          [0.0000, 0.0000, 0.0000,  ..., 0.0000, 0.0000, 0.0000],
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [dump_input.py:79]          [0.0000, 0.0000, 0.0000,  ..., 0.0000, 0.0000, 0.0000],
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [dump_input.py:79]          [0.0000, 0.0000, 0.0000,  ..., 0.0000, 0.0000, 0.0000]],
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [dump_input.py:79]
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [dump_input.py:79]         [[0.1768, 0.1377, 0.1299,  ..., 0.3262, 0.2715, 0.2598],
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [dump_input.py:79]          [0.2910, 0.2354, 0.2314,  ..., 0.1260, 0.0825, 0.0942],
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [dump_input.py:79]          [0.1572, 0.1138, 0.1177,  ..., 0.1572, 0.1021, 0.0903],
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [dump_input.py:79]          ...,
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [dump_input.py:79]          [0.0000, 0.0000, 0.0000,  ..., 0.0000, 0.0000, 0.0000],
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [dump_input.py:79]          [0.0000, 0.0000, 0.0000,  ..., 0.0000, 0.0000, 0.0000],
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [dump_input.py:79]          [0.0000, 0.0000, 0.0000,  ..., 0.0000, 0.0000, 0.0000]],
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [dump_input.py:79]
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [dump_input.py:79]         [[0.1611, 0.1216, 0.1138,  ..., 0.3223, 0.2676, 0.2559],
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [dump_input.py:79]          [0.2559, 0.2119, 0.2041,  ..., 0.1416, 0.0942, 0.1138],
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [dump_input.py:79]          [0.1611, 0.1177, 0.1099,  ..., 0.1689, 0.1138, 0.1021],
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [dump_input.py:79]          ...,
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [dump_input.py:79]          [0.0000, 0.0000, 0.0000,  ..., 0.0000, 0.0000, 0.0000],
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [dump_input.py:79]          [0.0000, 0.0000, 0.0000,  ..., 0.0000, 0.0000, 0.0000],
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [dump_input.py:79]          [0.0000, 0.0000, 0.0000,  ..., 0.0000, 0.0000, 0.0000]]],
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [dump_input.py:79]        dtype=torch.bfloat16), field=MultiModalFlatField(keep_on_cpu=False, slices=[[slice(0, 16, None)]], dim=0)), 'video_num_soft_tokens': MultiModalFieldElem(data=[66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66], field=MultiModalBatchedField(keep_on_cpu=True))}, modality='video', identifier='d862a0a3baea6abba049e76a211f7c1a0b4b5a77268aa7f223aa0350630a3136', mm_position=PlaceholderRange(offset=10, length=1199, is_embed=tensor([False, False, False,  ...,  True,  True, False])), mm_hash='d862a0a3baea6abba049e76a211f7c1a0b4b5a77268aa7f223aa0350630a3136')],sampling_params=SamplingParams(n=1, presence_penalty=0.0, frequency_penalty=0.0, repetition_penalty=1.0, temperature=0.0, top_p=1.0, top_k=0, min_p=0.0, seed=None, stop=[], stop_token_ids=[106, 50], bad_words=[], thinking_token_budget=None, include_stop_str_in_output=False, ignore_eos=False, max_tokens=64, min_tokens=0, logprobs=None, prompt_logprobs=None, skip_special_tokens=True, spaces_between_special_tokens=True, structured_outputs=None, extra_args=None),block_ids=([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39], [40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78], [79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117], [118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 149, 150, 151, 152, 153, 154, 155, 156], [157, 158, 159, 160, 161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191, 192, 193, 194, 195, 196, 197, 198, 199, 200, 201, 202, 203, 204, 205, 206, 207, 208, 209, 210, 211, 212, 213, 214, 215, 216, 217, 218, 219, 220, 221, 222, 223, 224, 225, 226, 227, 228, 229, 230, 231, 232, 233, 234]),num_computed_tokens=0,lora_request=None,prompt_embeds_shape=None)], scheduled_cached_reqs=CachedRequestData(req_ids=[],resumed_req_ids=set(),new_token_ids_lens=[],all_token_ids_lens={},new_block_ids=[],num_computed_tokens=[],num_output_tokens=[]), num_scheduled_tokens={0-896413e1: 1233}, total_num_scheduled_tokens=1233, scheduled_spec_decode_tokens={}, scheduled_encoder_inputs={0-896413e1: [0]}, num_common_prefix_blocks=[0, 0, 0, 0, 78], finished_req_ids=[], free_encoder_mm_hashes=[], scheduled_encoder_input_stats=null, preempted_req_ids=[], has_structured_output_requests=false, pending_structured_output_tokens=false, num_invalid_spec_tokens=null, kv_connector_metadata=null, ec_connector_metadata=null, ec_manager_metadata=null, new_block_ids_to_zero=null, kv_cache_block_copies=null, partial_tail_offloads=null, num_spec_tokens_to_schedule=0)
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [core.py:1346] EngineCore encountered a fatal error.
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [core.py:1346] Traceback (most recent call last):
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [core.py:1346]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/engine/core.py", line 1337, in run_engine_core
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [core.py:1346]     engine_core.run_busy_loop()
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [core.py:1346]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/fault_tolerance/engine_core_sentinel.py", line 179, in run_with_fault_tolerance
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [core.py:1346]     busy_loop_func(self)
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [core.py:1346]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/engine/core.py", line 1381, in run_busy_loop
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [core.py:1346]     self._process_engine_step()
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [core.py:1346]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/engine/core.py", line 1434, in _process_engine_step
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [core.py:1346]     outputs, model_executed = self.step_fn()
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [core.py:1346]                               ^^^^^^^^^^^^^^
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [core.py:1346]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/engine/core.py", line 652, in step_with_batch_queue
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [core.py:1346]     exec_future = self.model_executor.execute_model(
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [core.py:1346]                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [core.py:1346]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/executor/uniproc_executor.py", line 131, in execute_model
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [core.py:1346]     output.result()
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [core.py:1346]   File "/usr/lib/python3.12/concurrent/futures/_base.py", line 449, in result
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [core.py:1346]     return self.__get_result()
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [core.py:1346]            ^^^^^^^^^^^^^^^^^^^
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [core.py:1346]   File "/usr/lib/python3.12/concurrent/futures/_base.py", line 401, in __get_result
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [core.py:1346]     raise self._exception
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [core.py:1346]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/executor/uniproc_executor.py", line 109, in collective_rpc
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [core.py:1346]     result = run_method(self.driver_worker, method, args, kwargs)
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [core.py:1346]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [core.py:1346]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/serial_utils.py", line 510, in run_method
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [core.py:1346]     return func(*args, **kwargs)
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [core.py:1346]            ^^^^^^^^^^^^^^^^^^^^^
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [core.py:1346]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/worker/worker_base.py", line 355, in execute_model
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [core.py:1346]     return self.worker.execute_model(scheduler_output)
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [core.py:1346]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [core.py:1346]   File "/usr/local/lib/python3.12/dist-packages/torch/utils/_contextlib.py", line 124, in decorate_context
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [core.py:1346]     return func(*args, **kwargs)
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [core.py:1346]            ^^^^^^^^^^^^^^^^^^^^^
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [core.py:1346]   File "/usr/local/lib/python3.12/dist-packages/vllm/utils/gpu_sync_debug.py", line 232, in wrapper
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [core.py:1346]     return fn(*args, **kwargs)
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [core.py:1346]            ^^^^^^^^^^^^^^^^^^^
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [core.py:1346]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/worker/gpu_worker.py", line 1099, in execute_model
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [core.py:1346]     output = self.model_runner.execute_model(
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [core.py:1346]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [core.py:1346]   File "/usr/local/lib/python3.12/dist-packages/torch/utils/_contextlib.py", line 124, in decorate_context
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [core.py:1346]     return func(*args, **kwargs)
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [core.py:1346]            ^^^^^^^^^^^^^^^^^^^^^
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [core.py:1346]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/worker/gpu/model_runner.py", line 1561, in execute_model
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [core.py:1346]     inputs_embeds = self.model_state.get_mm_embeddings(
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [core.py:1346]                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [core.py:1346]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/worker/gpu/model_states/default.py", line 73, in get_mm_embeddings
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [core.py:1346]     self.execute_mm_encoder(scheduled_encoder_inputs)
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [core.py:1346]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/worker/gpu/model_states/interface.py", line 183, in execute_mm_encoder
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [core.py:1346]     encoder_outputs = self.encoder_runner.execute_mm_encoder(mm_kwargs)
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [core.py:1346]                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [core.py:1346]   File "/usr/local/lib/python3.12/dist-packages/torch/utils/_contextlib.py", line 124, in decorate_context
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [core.py:1346]     return func(*args, **kwargs)
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [core.py:1346]            ^^^^^^^^^^^^^^^^^^^^^
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [core.py:1346]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/worker/gpu/mm/encoder_runner.py", line 148, in execute_mm_encoder
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [core.py:1346]     cg_manager.execute(mm_kwargs_batch)
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [core.py:1346]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/worker/encoder_cudagraph.py", line 630, in execute
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [core.py:1346]     result = self._execute_local(mm_kwargs)
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [core.py:1346]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [core.py:1346]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/worker/encoder_cudagraph.py", line 448, in _execute_local
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [core.py:1346]     output = self._run_budget_graph(
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [core.py:1346]              ^^^^^^^^^^^^^^^^^^^^^^^
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [core.py:1346]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/worker/encoder_cudagraph.py", line 352, in _run_budget_graph
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [core.py:1346]     replay = self.model.prepare_encoder_cudagraph_replay_buffers(
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [core.py:1346]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [core.py:1346]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/models/gemma4_mm.py", line 1884, in prepare_encoder_cudagraph_replay_buffers
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [core.py:1346]     item_specs = self.get_encoder_cudagraph_item_specs(mm_kwargs)
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [core.py:1346]                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [core.py:1346]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/models/gemma4_mm.py", line 1689, in get_encoder_cudagraph_item_specs
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [core.py:1346]     video_frame_counts.tolist()
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [core.py:1346]   File "/usr/lib/python3.12/warnings.py", line 110, in _showwarnmsg
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [core.py:1346]     sw(msg.message, msg.category, msg.filename, msg.lineno,
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [core.py:1346]   File "/usr/local/lib/python3.12/dist-packages/vllm/utils/gpu_sync_debug.py", line 74, in _sync_warning_hook
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [core.py:1346]     raise RuntimeError(SYNC_ERROR_MESSAGE)
  | (EngineCore pid=18850) ERROR 08-15 07:10:27 [core.py:1346] RuntimeError: GPU<->CPU sync detected - avoid it or wrap with gpu_sync_allowed()



```
## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

