### PR TITLE
[Bugfix][Model] Kimi-K3 MegaMoE: pass situ_beta/situ_linear_beta to fp8_fp4_mega_moe

### DIFF
--- a/vllm/models/kimi_k3/nvidia/model.py
+++ b/vllm/models/kimi_k3/nvidia/model.py
@@ -486,8 +486,8 @@ class KimiK3MegaMoEExperts(DeepseekV4MegaMoEExperts):
             symm_buffer,
             activation_clamp=activation_clamp,
             activation=self.activation,
-            activation_beta=self.activation_beta,
-            activation_linear_beta=self.activation_linear_beta,
+            situ_beta=self.activation_beta,
+            situ_linear_beta=self.activation_linear_beta,
             fast_math=fast_math,
         )
         return y


### PR DESCRIPTION
## Purpose

`KimiMegaMoEExperts.forward` passed `activation_beta=`/`activation_linear_beta=` as keyword arguments to `deep_gemm.fp8_fp4_mega_moe`. Neither name exists in the signature of deepseek-ai/DeepGEMM at the pinned commit 8b1392b (`nv_dev` tip), which declares them as `situ_beta` and `situ_linear_beta`:

https://github.com/deepseek-ai/DeepGEMM/blob/8b1392b978f5a03c828dd1711090d7fb50958b8a/deep_gemm/mega/__init__.py

The first mega-MoE forward therefore raises `TypeError: fp8_fp4_mega_moe() got an unexpected keyword argument 'activation_beta'`. This renames the two kwargs; the internal class attribute names are untouched.

Duplicate-work check: searched open upstream PRs for `fp8_fp4_mega_moe`, `activation_beta`, `situ_beta`, `kimi_k3` — the only MegaMoE-related PR (#42844) is DeepSeek-V4 feature work and does not touch this call site.

## Test Plan and Results

- `py_compile` on the file: pass
- `pre-commit run` on commit (ruff check/format, mypy, sign-off, etc.): all pass
- The only other `fp8_fp4_mega_moe` call sites (`deepseek_v4` nvidia/xpu) do not pass these kwargs and are unaffected.
- This path requires an NVIDIA GPU with the mega-MoE backend to execute; no GPU was available in this environment, so no model eval was run. The fix restores the intended behavior (crash at call time -> correct kwargs).

## Notes

This change was written with AI assistance (Claude).

---

<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some existing bug" and more.
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzqRs/edit?tab=t.0).
</details>
