### PR TITLE
[Bugfix] Raise ValueError instead of bare assert for expert-parallel divisibility check

### DIFF
--- a/.buildkite/test_areas/models_basic.yaml
+++ b/.buildkite/test_areas/models_basic.yaml
@@ -89,6 +89,7 @@ steps:
   - tests/models/test_vision.py
   - tests/models/test_adapters.py
   - tests/models/transformers/fusers/
+  - tests/models/test_deepseek_v4_expert_divisibility.py
   device: cpu-small
   commands:
-    - pytest -v -s models/test_utils.py models/test_vision.py models/test_adapters.py models/transformers/fusers/
+    - pytest -v -s models/test_utils.py models/test_vision.py models/test_adapters.py models/transformers/fusers/ models/test_deepseek_v4_expert_divisibility.py

--- a/tests/models/test_deepseek_v4_expert_divisibility.py
+++ b/tests/models/test_deepseek_v4_expert_divisibility.py
@@ -1,0 +1,82 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Regression tests for https://github.com/vllm-project/vllm/issues/52435.
+
+DeepseekV4MoE crashes deep inside every worker process with a bare
+``AssertionError`` when the number of physical experts (routed + redundant)
+isn't evenly divisible by the expert/tensor parallel size — e.g. 256 routed
+experts with ``--tensor-parallel-size 3 --enable-expert-parallel`` and no
+redundant experts configured. Bare asserts are stripped under ``python -O``
+and don't match the ``ValueError``-based validation convention used
+elsewhere for user-facing config errors (see vllm/config/parallel.py), so
+this should raise ``ValueError`` instead.
+
+These tests exercise the private ``_init_mega_moe_experts`` /
+``_init_fused_moe_experts`` helpers directly (constructing the module via
+``__new__`` to avoid needing a real distributed process group), since the
+existing tests/models/test_deepseek_v4_mega_moe.py suite is CUDA-only.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from vllm.models.deepseek_v4.nvidia import model as deepseek_v4_model
+
+
+class _FakeEpGroup:
+    def __init__(self, world_size: int, rank_in_group: int = 0):
+        self.world_size = world_size
+        self.rank_in_group = rank_in_group
+
+
+def _make_moe() -> deepseek_v4_model.DeepseekV4MoE:
+    moe = deepseek_v4_model.DeepseekV4MoE.__new__(deepseek_v4_model.DeepseekV4MoE)
+    torch.nn.Module.__init__(moe)
+    return moe
+
+
+@pytest.mark.cpu_test
+def test_mega_moe_experts_raises_value_error_when_not_divisible_by_ep_size(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        deepseek_v4_model, "get_ep_group", lambda: _FakeEpGroup(world_size=3)
+    )
+
+    moe = _make_moe()
+    vllm_config = SimpleNamespace(
+        parallel_config=SimpleNamespace(
+            eplb_config=SimpleNamespace(num_redundant_experts=0)
+        )
+    )
+    config = SimpleNamespace(n_routed_experts=256, n_shared_experts=None)
+
+    with pytest.raises(ValueError, match="n_physical_experts=256"):
+        moe._init_mega_moe_experts(vllm_config, config, prefix="layers.0.ffn")
+
+
+@pytest.mark.cpu_test
+def test_fused_moe_experts_raises_value_error_when_not_divisible_by_tp_size(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        deepseek_v4_model, "get_tensor_model_parallel_rank", lambda: 0
+    )
+
+    moe = _make_moe()
+    moe.tp_size = 3
+    moe.n_routed_experts = 256
+
+    vllm_config = SimpleNamespace(
+        parallel_config=SimpleNamespace(
+            eplb_config=SimpleNamespace(num_redundant_experts=0)
+        )
+    )
+    config = SimpleNamespace(n_shared_experts=None)
+
+    with pytest.raises(ValueError, match="n_physical_experts=256"):
+        moe._init_fused_moe_experts(
+            vllm_config, config, quant_config=None, prefix="layers.0.ffn"
+        )

--- a/tests/models/test_deepseek_v4_expert_divisibility.py
+++ b/tests/models/test_deepseek_v4_expert_divisibility.py
@@ -61,9 +61,7 @@ def test_mega_moe_experts_raises_value_error_when_not_divisible_by_ep_size(
 def test_fused_moe_experts_raises_value_error_when_not_divisible_by_tp_size(
     monkeypatch,
 ):
-    monkeypatch.setattr(
-        deepseek_v4_model, "get_tensor_model_parallel_rank", lambda: 0
-    )
+    monkeypatch.setattr(deepseek_v4_model, "get_tensor_model_parallel_rank", lambda: 0)
 
     moe = _make_moe()
     moe.tp_size = 3

--- a/vllm/models/deepseek_v4/nvidia/model.py
+++ b/vllm/models/deepseek_v4/nvidia/model.py
@@ -636,10 +636,11 @@ class DeepseekV4MoE(nn.Module):
         self.n_shared_experts = config.n_shared_experts or 0
         self.n_logical_experts = self.n_routed_experts
         self.n_physical_experts = self.n_logical_experts + self.n_redundant_experts
-        assert self.n_physical_experts % self.ep_size == 0, (
-            f"n_physical_experts={self.n_physical_experts} must be divisible by "
-            f"ep_size={self.ep_size}. Adjust num_redundant_experts."
-        )
+        if self.n_physical_experts % self.ep_size != 0:
+            raise ValueError(
+                f"n_physical_experts={self.n_physical_experts} must be divisible by "
+                f"ep_size={self.ep_size}. Adjust num_redundant_experts."
+            )
         self.n_local_physical_experts = self.n_physical_experts // self.ep_size
         self.physical_expert_start = self.ep_rank * self.n_local_physical_experts
         self.physical_expert_end = (
@@ -677,10 +678,11 @@ class DeepseekV4MoE(nn.Module):
         self.n_shared_experts = config.n_shared_experts or 0
         self.n_logical_experts = self.n_routed_experts
         self.n_physical_experts = self.n_logical_experts + self.n_redundant_experts
-        assert self.n_physical_experts % self.tp_size == 0, (
-            f"n_physical_experts={self.n_physical_experts} must be divisible by "
-            f"tp_size={self.tp_size}. Adjust num_redundant_experts."
-        )
+        if self.n_physical_experts % self.tp_size != 0:
+            raise ValueError(
+                f"n_physical_experts={self.n_physical_experts} must be divisible by "
+                f"tp_size={self.tp_size}. Adjust num_redundant_experts."
+            )
         self.n_local_physical_experts = self.n_physical_experts // self.tp_size
         self.n_local_experts = self.n_local_physical_experts
         self.experts_start_idx = self.tp_rank * self.n_local_experts


### PR DESCRIPTION
## Purpose

Fixes #52435.

`DeepseekV4MoE._init_mega_moe_experts` / `_init_fused_moe_experts` used a bare
`assert n_physical_experts % ep_size == 0` (and the `tp_size` equivalent) to
validate that the physical expert count divides evenly across the
expert/tensor-parallel size. This crashes every worker process with an
unhandled `AssertionError` when serving DeepSeek V4 with
`--enable-expert-parallel` and a routed-expert / redundant-expert
configuration that isn't evenly divisible by the parallel size (e.g. 256
experts, `ep_size=3`, `num_redundant_experts=0`).

This PR converts both checks to `if ...: raise ValueError(...)`, preserving
the exact same message, so the check (a) isn't stripped under `python -O`
and (b) surfaces as `ValueError`, matching the validation convention already
used elsewhere in this class for user-facing config errors.

Also wires the new regression test into the CPU-only
"Basic Models Test (Other CPU)" Buildkite job so it actually runs in CI.

## Test Plan

```
pytest -v tests/models/test_deepseek_v4_expert_divisibility.py
```

Two new CPU-only unit tests construct `DeepseekV4MoE` directly (mocking the
expert-parallel group, mirroring the existing pattern in
`test_deepseek_v4_mega_moe.py`) and assert `ValueError` is raised for both
the mega-MoE and fused-MoE init paths when experts aren't evenly divisible.
No GPU/distributed process group needed.

## Test Result

```
tests/models/test_deepseek_v4_expert_divisibility.py::test_mega_moe_experts_raises_value_error_when_not_divisible_by_ep_size PASSED
tests/models/test_deepseek_v4_expert_divisibility.py::test_fused_moe_experts_raises_value_error_when_not_divisible_by_tp_size PASSED
2 passed
```

`ruff check` / `ruff format --check` clean on all changed files.

---

## AI assistance disclosure

Per [`AGENTS.md`](https://github.com/vllm-project/vllm/blob/main/AGENTS.md):

- **AI assistance was used** to help write this change and its regression test. The commits carry a
  `Co-authored-by:` trailer accordingly.
- **Not a duplicate.** Checked before opening via
  `gh pr list --repo vllm-project/vllm --state open --search "52435 in:body"` and a search for
  `n_physical_experts` — no other open PR addresses this.
- **Tests run:** `pytest -v tests/models/test_deepseek_v4_expert_divisibility.py` → 2 passed;
  `ruff check` and `ruff format --check` clean on all changed files. Results in the Test Result
  section above.
- **Model evaluation:** not applicable — this changes only the exception *type* raised by an
  existing config-validation guard on a startup path. It cannot affect model output, accuracy, or
  serving behavior; the condition and message text are unchanged.
- **Human accountability:** I have reviewed every changed line and understand and stand behind the
  change end-to-end.

### Scope note

To be explicit about what this does and does not fix: this does **not** make
`--tensor-parallel-size 3` work for DeepSeek V4. That configuration is independently blocked by the
attention-head check (`total_num_attention_heads=64` is not divisible by 3, and
`ModelConfig.get_num_attention_heads` divides evenly with no padding), which is architectural and
out of scope here.

What it fixes is the guard itself: a bare `assert` is stripped under `python -O`, so in an optimized
deployment this check silently disappears and the invalid configuration proceeds into incorrect
expert-index arithmetic instead of failing fast. Converting it to `raise ValueError` makes the guard
unconditional and matches the validation convention already used for user-facing config errors
elsewhere in this class.
