### PR TITLE
[Doc] Fix diagram rendering in GitHub Markdown

### DIFF
--- a/docs/design/arch_overview.md
+++ b/docs/design/arch_overview.md
@@ -130,17 +130,13 @@ For example, a typical single-node deployment with 4 GPUs (`vllm serve -tp=4`) h
 
 - 1 API server + 1 engine core + 4 GPU workers = **6 processes**
 
-<figure markdown="1">
 ![V1 Process Architecture - TP=4](../assets/design/arch_overview/v1_process_architecture_tp4.png)
-</figure>
 
 A data parallel deployment with 8 GPUs (`vllm serve -tp=2 -dp=4`) has:
 
 - 4 API servers + 4 engine cores + 8 GPU workers + 1 DP coordinator = **17 processes**
 
-<figure markdown="1">
 ![V1 Process Architecture - TP=2, DP=4](../assets/design/arch_overview/v1_process_architecture_tp2_dp4.png)
-</figure>
 
 For CPU resource sizing recommendations, see
 [CPU Resources for GPU Deployments](../configuration/optimization.md#cpu-resources-for-gpu-deployments).

--- a/docs/serving/data_parallel_deployment.md
+++ b/docs/serving/data_parallel_deployment.md
@@ -76,9 +76,7 @@ Currently, the internal DP load balancing is done within the API server process(
 
 When deploying large DP sizes using this method, the API server process can become a bottleneck. In this case, the orthogonal `--api-server-count` command line option can be used to scale this out (for example `--api-server-count=4`). This is transparent to users - a single HTTP endpoint / port is still exposed. Note that this API server scale-out is "internal" and still confined to the "head" node.
 
-<figure markdown="1">
 ![DP Internal LB Diagram](../assets/deployment/dp_internal_lb.png)
-</figure>
 
 ## Hybrid Load Balancing
 
@@ -126,8 +124,6 @@ vllm serve $MODEL --data-parallel-size 2 --data-parallel-rank 1 \
 
 The coordinator process also runs in this scenario, co-located with the DP rank 0 engine.
 
-<figure markdown="1">
 ![DP External LB Diagram](../assets/deployment/dp_external_lb.png)
-</figure>
 
 In the above diagram, each of the dotted boxes corresponds to a separate launch of `vllm serve` - these could be separate Kubernetes pods, for example.


### PR DESCRIPTION


## Purpose

Remove four MkDocs-specific `<figure markdown="1">` wrappers from the
documentation:

- Two V1 process architecture diagrams in
  `docs/design/arch_overview.md`
- Two data-parallel deployment diagrams in
  `docs/serving/data_parallel_deployment.md`

GitHub does not render Markdown image syntax inside these HTML blocks, causing
the four diagrams to be missing when the source files are viewed on GitHub.

The `<figure>` wrappers do not provide captions, alignment, or other required
formatting. Removing them preserves the generated documentation while allowing
the diagrams to render correctly in GitHub Markdown.

I searched existing issues and open pull requests and did not find another pull
request addressing this problem.

## Test Plan

Verify the modified Markdown files with the repository's pre-commit checks:

```bash
pre-commit run --files \
  docs/design/arch_overview.md \
  docs/serving/data_parallel_deployment.md
```

Verify that the four diagrams render correctly in GitHub Markdown and remain
unchanged in the generated documentation.

## Test Result

- The pre-commit checks passed.
- All four diagrams render correctly in GitHub Markdown.
- The diagrams remain correctly rendered in the generated documentation.

## AI Assistance

OpenAI Codex was used to analyze the Markdown rendering incompatibility and
review the scope of the affected documentation. I reviewed and validated the
complete change.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results.
- [x] Documentation update: this PR is itself a documentation-only fix.

</details>

