### PR TITLE
[Bugfix] Initialize FP8 partition metadata for ParallelLMHead

### DIFF
--- a/tests/quantization/test_compressed_tensors.py
+++ b/tests/quantization/test_compressed_tensors.py
@@ -692,6 +692,56 @@ def test_get_quant_method_returns_none_for_unmatched_parallel_lm_head():
     )
 
 
+def test_w8a8_fp8_sets_partition_sizes_for_parallel_lm_head(
+    default_vllm_config, monkeypatch
+):
+    """W8A8 FP8 must initialize partition metadata on ParallelLMHead."""
+    default_vllm_config.model_config = Mock(dtype=torch.bfloat16)
+    weight_quant = QuantizationArgs(
+        num_bits=8,
+        type=QuantizationType.FLOAT,
+        strategy=QuantizationStrategy.CHANNEL,
+        symmetric=True,
+        dynamic=False,
+    )
+    scheme = CompressedTensorsW8A8Fp8(
+        weight_quant=weight_quant,
+        is_static_input_scheme=False,
+    )
+    kernel = Mock()
+    kernel.input_quant_key.return_value = None
+    monkeypatch.setattr(
+        "vllm.model_executor.layers.quantization.compressed_tensors.schemes."
+        "compressed_tensors_w8a8_fp8.create_fp8_weight_parameter",
+        Mock(return_value=torch.nn.Parameter(torch.empty(1), requires_grad=False)),
+    )
+    monkeypatch.setattr(
+        "vllm.model_executor.layers.quantization.compressed_tensors.schemes."
+        "compressed_tensors_w8a8_fp8.create_fp8_scale_parameter",
+        Mock(return_value=torch.nn.Parameter(torch.empty(1), requires_grad=False)),
+    )
+    monkeypatch.setattr(
+        "vllm.model_executor.layers.quantization.compressed_tensors.schemes."
+        "compressed_tensors_w8a8_fp8.init_fp8_linear_kernel",
+        Mock(return_value=kernel),
+    )
+    layer = object.__new__(ParallelLMHead)
+    torch.nn.Module.__init__(layer)
+
+    scheme.create_weights(
+        layer=layer,
+        input_size_per_partition=16,
+        output_partition_sizes=[32],
+        input_size=16,
+        output_size=32,
+        params_dtype=torch.bfloat16,
+        weight_loader=Mock(),
+    )
+
+    assert layer.output_size_per_partition == 32
+    assert layer.input_size_per_partition == 16
+
+
 def test_find_matched_target_returns_none_on_no_match():
     result = find_matched_target(
         layer_name="model.layers.0.self_attn.qkv_proj",

--- a/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_fp8.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_fp8.py
@@ -101,6 +101,8 @@ class CompressedTensorsW8A8Fp8(CompressedTensorsScheme):
     ):
         output_size_per_partition = sum(output_partition_sizes)
         layer.logical_widths = output_partition_sizes
+        layer.input_size_per_partition = input_size_per_partition
+        layer.output_size_per_partition = output_size_per_partition
         layer.weight_block_size = None
         layer.orig_dtype = params_dtype
 


### PR DESCRIPTION
## Purpose

Fixes #52434

`CompressedTensorsW8A8Fp8.create_weights` did not initialize the partition metadata consumed by `ParallelLMHead` weight loading. Initialize both partition-size attributes and add a focused regression test using the real `ParallelLMHead` type while mocking allocation and kernel setup.

Duplicate-work check: on 2026-08-15, open-PR searches for `#52434`, the exact `ParallelLMHead` attribute failure, and the affected compressed-tensors FP8 scheme found no PR addressing this bug.

AI assistance was used for investigation, implementation, and test execution. The human submitter reviewed the resulting two-file diff and remains responsible for the change.

## Test Plan

- Run the focused regression test before and after the implementation change.
- Run the existing `ParallelLMHead`-related tests in `test_compressed_tensors.py`.
- Run Ruff format/static checks and Git whitespace validation on the changed files.

## Test Result

- Before the fix: focused regression failed as expected with `AttributeError: 'ParallelLMHead' object has no attribute 'output_size_per_partition'` (`1 failed, 47 deselected`).
- On latest `origin/main` (`d4801990a`) after the fix:
  - `VLLM_TARGET_DEVICE=cpu .venv-test/bin/python -m pytest tests/quantization/test_compressed_tensors.py -k w8a8_fp8_sets_partition_sizes_for_parallel_lm_head -q` -> `1 passed, 47 deselected`.
  - `VLLM_TARGET_DEVICE=cpu .venv-test/bin/python -m pytest tests/quantization/test_compressed_tensors.py -k parallel_lm_head -q` -> `4 passed, 44 deselected`.
  - `ruff format --check` on both changed files -> `2 files already formatted`.
  - `ruff check` on both changed files -> `All checks passed!`.
  - `git diff --check` -> passed.
- Model evaluation was not run: this change restores layer partition metadata during initialization and does not alter inference math or model outputs. The regression test mocks device allocation and kernel setup to isolate that behavior.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, including the issue it resolves.
- [x] The test plan and commands.
- [x] The before/after and related test results.
- [x] Documentation update considered; none is needed for this internal bug fix.

</details>