### PR TITLE
[Bugfix][Structured Output][Spec Decode] Validate accepted blocks before commit

### DIFF
--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -839,6 +839,172 @@ def test_stop_via_update_from_output():
     assert list(requests[0].output_token_ids) == [EOS_TOKEN_ID, 10, 11]
 
 
+@pytest.mark.parametrize("async_scheduling", [False, True])
+@pytest.mark.parametrize(
+    "filtered_tokens,num_grammar_rejected,expected_accepted",
+    [
+        ([10, 11, 12], 1, 3),
+        ([10, 11], 2, 2),
+        ([], 4, 0),
+    ],
+)
+def test_speculative_grammar_filter_rolls_back_scheduler_state_and_stats(
+    async_scheduling: bool,
+    filtered_tokens: list[int],
+    num_grammar_rejected: int,
+    expected_accepted: int,
+):
+    """Rejected suffix tokens remain schedulable and are not accepted drafts."""
+    scheduler = create_scheduler(
+        num_speculative_tokens=3,
+        speculative_method="ngram_gpu",
+        async_scheduling=async_scheduling,
+    )
+    request = create_requests(num_requests=1)[0]
+    request.structured_output_request = Mock()
+    request.status = RequestStatus.RUNNING
+    request.num_computed_tokens = request.num_tokens + 4
+    request.num_output_placeholders = 4 if async_scheduling else 0
+    scheduler.requests[request.request_id] = request
+    scheduler.running.append(request)
+
+    manager = Mock()
+    manager.filter_speculative_grammar_tokens.return_value = (
+        filtered_tokens,
+        num_grammar_rejected,
+    )
+    manager.should_advance.return_value = False
+    scheduler.structured_output_manager = manager
+
+    scheduler_output = SchedulerOutput(
+        scheduled_new_reqs=[],
+        scheduled_cached_reqs=CachedRequestData.make_empty(),
+        num_scheduled_tokens={request.request_id: 4},
+        total_num_scheduled_tokens=4,
+        scheduled_encoder_inputs={},
+        scheduled_spec_decode_tokens={request.request_id: [10, 11, 12]},
+        num_common_prefix_blocks=[],
+        finished_req_ids=set(),
+        free_encoder_mm_hashes=[],
+    )
+    model_output = ModelRunnerOutput(
+        req_ids=[request.request_id],
+        req_id_to_index={request.request_id: 0},
+        sampled_token_ids=[[10, 11, 12, 13]],
+        logprobs=None,
+        prompt_logprobs_dict={},
+        pooler_output=[],
+    )
+
+    outputs = scheduler.update_from_output(scheduler_output, model_output)
+
+    assert request.num_computed_tokens == request.num_tokens
+    assert request.num_output_placeholders == 0
+    assert list(request.output_token_ids) == filtered_tokens
+    if filtered_tokens:
+        assert outputs[0].outputs[0].new_token_ids == filtered_tokens
+    manager.filter_speculative_grammar_tokens.assert_called_once_with(
+        request, [10, 11, 12, 13]
+    )
+    stats = outputs[0].scheduler_stats.spec_decoding_stats
+    assert stats is not None
+    assert stats.num_drafts == 1
+    assert stats.num_draft_tokens == 3
+    assert stats.num_accepted_tokens == expected_accepted
+    assert stats.num_accepted_tokens_per_pos == [
+        int(position < expected_accepted) for position in range(3)
+    ]
+
+
+def test_speculative_grammar_filter_is_not_called_for_unstructured_requests():
+    """Unstructured speculative decoding does not enter grammar validation."""
+    scheduler = create_scheduler(num_speculative_tokens=2)
+    request = create_requests(num_requests=1)[0]
+    request.status = RequestStatus.RUNNING
+    request.num_computed_tokens = request.num_tokens + 3
+    scheduler.requests[request.request_id] = request
+    scheduler.running.append(request)
+
+    manager = Mock()
+    manager.should_advance.return_value = False
+    scheduler.structured_output_manager = manager
+    scheduler_output = SchedulerOutput(
+        scheduled_new_reqs=[],
+        scheduled_cached_reqs=CachedRequestData.make_empty(),
+        num_scheduled_tokens={request.request_id: 3},
+        total_num_scheduled_tokens=3,
+        scheduled_encoder_inputs={},
+        scheduled_spec_decode_tokens={request.request_id: [10, 11]},
+        num_common_prefix_blocks=[],
+        finished_req_ids=set(),
+        free_encoder_mm_hashes=[],
+    )
+    model_output = ModelRunnerOutput(
+        req_ids=[request.request_id],
+        req_id_to_index={request.request_id: 0},
+        sampled_token_ids=[[10, 11, 12]],
+        logprobs=None,
+        prompt_logprobs_dict={},
+        pooler_output=[],
+    )
+
+    scheduler.update_from_output(scheduler_output, model_output)
+
+    assert list(request.output_token_ids) == [10, 11, 12]
+    manager.filter_speculative_grammar_tokens.assert_not_called()
+
+
+def test_speculative_grammar_filter_commits_and_advances_only_valid_prefix():
+    """Scheduler output and grammar state share the filtered token prefix."""
+    scheduler = create_scheduler(num_speculative_tokens=2)
+    request = create_requests(num_requests=1)[0]
+    grammar = Mock(spec=StructuredOutputGrammar)
+    grammar.accept_tokens.side_effect = lambda request_id, tokens: tokens == [10, 11]
+    request.structured_output_request = Mock(grammar=grammar)
+    request.status = RequestStatus.RUNNING
+    request.num_computed_tokens = request.num_tokens + 3
+    scheduler.requests[request.request_id] = request
+    scheduler.running.append(request)
+
+    manager = Mock()
+    manager.filter_speculative_grammar_tokens.return_value = ([10, 11], 1)
+    manager.should_advance.return_value = True
+    manager.trim_reasoning_for_advance.return_value = [10, 11]
+    scheduler.structured_output_manager = manager
+
+    scheduler_output = SchedulerOutput(
+        scheduled_new_reqs=[],
+        scheduled_cached_reqs=CachedRequestData.make_empty(),
+        num_scheduled_tokens={request.request_id: 3},
+        total_num_scheduled_tokens=3,
+        scheduled_encoder_inputs={},
+        scheduled_spec_decode_tokens={request.request_id: [10, 11]},
+        num_common_prefix_blocks=[],
+        finished_req_ids=set(),
+        free_encoder_mm_hashes=[],
+    )
+    model_output = ModelRunnerOutput(
+        req_ids=[request.request_id],
+        req_id_to_index={request.request_id: 0},
+        sampled_token_ids=[[10, 11, 12]],
+        logprobs=None,
+        prompt_logprobs_dict={},
+        pooler_output=[],
+    )
+
+    outputs = scheduler.update_from_output(scheduler_output, model_output)
+
+    assert request.status == RequestStatus.RUNNING
+    assert request.num_computed_tokens == request.num_tokens
+    assert list(request.output_token_ids) == [10, 11]
+    assert outputs[0].outputs[0].new_token_ids == [10, 11]
+    grammar.accept_tokens.assert_called_once_with(request.request_id, [10, 11])
+    stats = outputs[0].scheduler_stats.spec_decoding_stats
+    assert stats is not None
+    assert stats.num_draft_tokens == 2
+    assert stats.num_accepted_tokens == 2
+
+
 def test_check_stop_min_tokens():
     """Test that requests don't stop when min_tokens requirement isn't met."""
     from vllm.v1.core.sched.utils import check_stop

--- a/tests/v1/spec_decode/test_mtp_structured_output.py
+++ b/tests/v1/spec_decode/test_mtp_structured_output.py
@@ -2,12 +2,17 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """grammar_bitmask under spec-decode draft padding (#44006)."""
 
+from collections.abc import Iterable, Sequence
+from typing import overload
+from unittest.mock import Mock
+
 import pytest
 from transformers import AutoTokenizer
 
 from vllm.config import StructuredOutputsConfig, VllmConfig
 from vllm.config.model import ModelConfig
 from vllm.config.speculative import SpeculativeConfig
+from vllm.reasoning.step3p5_reasoning_parser import Step3p5ReasoningParser
 from vllm.sampling_params import SamplingParams, StructuredOutputsParams
 from vllm.v1.request import Request
 from vllm.v1.structured_output import StructuredOutputManager
@@ -389,3 +394,154 @@ def test_trim_reasoning_for_advance():
     next_step = [post, post]
     request.append_output_token_ids(next_step)
     assert manager.trim_reasoning_for_advance(request, next_step) == next_step
+
+
+@pytest.mark.parametrize("backend", ["xgrammar", "guidance"])
+def test_speculative_grammar_filter_rejects_invalid_boundary_suffix(backend):
+    """Only the grammar-valid answer prefix may cross the commit boundary."""
+    tokenizer, manager, request, _, marker = _setup_boundary_request(backend)
+    reasoning_token = tokenizer.encode(" ")[0]
+    valid_answer_token = tokenizer.encode("{")[0]
+    invalid_answer_token = tokenizer.encode("z")[0]
+    sampled_tokens = [
+        reasoning_token,
+        marker,
+        valid_answer_token,
+        invalid_answer_token,
+    ]
+
+    filtered, rejected = manager.filter_speculative_grammar_tokens(
+        request, sampled_tokens
+    )
+
+    assert filtered == [reasoning_token, marker, valid_answer_token]
+    assert rejected == 1
+    grammar = request.structured_output_request.grammar
+    assert grammar.validate_tokens([valid_answer_token]) == [valid_answer_token]
+
+
+@pytest.mark.parametrize("backend", ["xgrammar", "guidance"])
+def test_speculative_grammar_filter_rejects_tokens_after_completion(backend):
+    """A sampled block cannot commit tokens past a completed grammar value."""
+    tokenizer, manager, request, _, _ = _setup_boundary_request(backend)
+    request.structured_output_request.reasoning_ended = True
+    complete_object = tokenizer.encode("{}")
+    invalid_suffix = tokenizer.encode("z")[0]
+
+    filtered, rejected = manager.filter_speculative_grammar_tokens(
+        request, [*complete_object, invalid_suffix]
+    )
+
+    assert filtered == complete_object
+    assert rejected == 1
+
+
+def test_reasoning_boundary_scan_does_not_copy_committed_history():
+    """Boundary detection can expose long history without materializing it."""
+    parser_calls = 0
+
+    class TokenHistory(Sequence[int]):
+        def __len__(self) -> int:
+            return 300_000
+
+        @overload
+        def __getitem__(self, index: int) -> int: ...
+
+        @overload
+        def __getitem__(self, index: slice) -> list[int]: ...
+
+        def __getitem__(self, index: int | slice) -> int | list[int]:
+            raise AssertionError("committed token history was materialized")
+
+    class EndTokenReasoner:
+        def is_reasoning_end_streaming(
+            self, input_ids: Sequence[int], delta_ids: Iterable[int]
+        ) -> bool:
+            nonlocal parser_calls
+            parser_calls += 1
+            assert len(input_ids) >= 300_000
+            return 99 in delta_ids
+
+    reasoner = EndTokenReasoner()
+    boundary = StructuredOutputManager._find_reasoning_end_offset(
+        reasoner, TokenHistory(), [10, 99, 20]
+    )
+
+    assert boundary == 1
+    assert parser_calls == 3
+
+
+def test_reasoning_boundary_scan_checks_nontransition_block_once():
+    """A sampled block without a transition requires one parser call."""
+    parser_calls = 0
+
+    class NoBoundaryReasoner:
+        def is_reasoning_end_streaming(
+            self, input_ids: Sequence[int], delta_ids: Iterable[int]
+        ) -> bool:
+            nonlocal parser_calls
+            parser_calls += 1
+            return False
+
+    reasoner = NoBoundaryReasoner()
+    boundary = StructuredOutputManager._find_reasoning_end_offset(
+        reasoner, [1, 2, 3], [10, 20, 30]
+    )
+
+    assert boundary is None
+    assert parser_calls == 1
+
+
+def test_reasoning_boundary_scan_preserves_stateful_parser():
+    """Pre-commit probing must not consume Step3.5's pending transition."""
+    tokenizer = Mock()
+    tokenizer.get_vocab.return_value = {"<think>": 1, "</think>": 2}
+    reasoner = Step3p5ReasoningParser(tokenizer)
+    reasoner._end_token_pending = True
+
+    boundary = StructuredOutputManager._find_reasoning_end_offset(
+        reasoner, [1, 2, 3], [10, 20]
+    )
+
+    assert boundary == 0
+    assert reasoner._end_token_pending
+
+
+def test_reasoning_boundary_scan_locates_multi_token_marker():
+    """A parser that examines cumulative deltas locates a multi-token marker."""
+
+    class MultiTokenReasoner:
+        def is_reasoning_end_streaming(
+            self, input_ids: Sequence[int], delta_ids: Iterable[int]
+        ) -> bool:
+            delta = list(delta_ids)
+            return any(
+                delta[index : index + 2] == [20, 30] for index in range(len(delta) - 1)
+            )
+
+    boundary = StructuredOutputManager._find_reasoning_end_offset(
+        MultiTokenReasoner(), [1, 2, 3], [20, 30, 40]
+    )
+
+    assert boundary == 1
+
+
+def test_reasoning_boundary_scan_handles_marker_across_blocks():
+    """A multi-token marker may start in history and finish in the new block."""
+
+    class CrossBlockReasoner:
+        def is_reasoning_end_streaming(
+            self, input_ids: Sequence[int], delta_ids: Iterable[int]
+        ) -> bool:
+            tokens = list(input_ids)
+            delta_len = len(list(delta_ids))
+            return any(
+                tokens[index : index + 3] == [7, 8, 9]
+                for index in range(max(0, len(tokens) - delta_len - 2), len(tokens))
+            )
+
+    boundary = StructuredOutputManager._find_reasoning_end_offset(
+        CrossBlockReasoner(), [1, 7, 8], [9, 10]
+    )
+
+    assert boundary == 0

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1834,9 +1834,13 @@ class Scheduler(SchedulerInterface):
             scheduled_spec_token_ids = (
                 scheduler_output.scheduled_spec_decode_tokens.get(req_id)
             )
+            observed_spec_decode = False
+            num_draft_tokens = 0
+            num_accepted = 0
             if scheduled_spec_token_ids and (
                 generated_token_ids or self.num_sampled_tokens_per_step == 0
             ):
+                observed_spec_decode = True
                 num_draft_tokens = len(scheduled_spec_token_ids)
                 num_sampled = self.num_sampled_tokens_per_step
                 num_accepted = max(len(generated_token_ids) - num_sampled, 0)
@@ -1850,13 +1854,6 @@ class Scheduler(SchedulerInterface):
                         request.num_computed_tokens -= num_rejected
                     if request.num_output_placeholders > 0:
                         request.num_output_placeholders -= num_rejected
-                spec_decoding_stats = self.make_spec_decoding_stats(
-                    spec_decoding_stats,
-                    num_draft_tokens=num_draft_tokens,
-                    num_accepted_tokens=num_accepted,
-                    num_invalid_spec_tokens=scheduler_output.num_invalid_spec_tokens,
-                    request_id=req_id,
-                )
 
             # Free encoder inputs only after the step has actually executed.
             if request.has_encoder_inputs:
@@ -1872,6 +1869,40 @@ class Scheduler(SchedulerInterface):
             prefill_stats = None
             status_before_stop = request.status
             num_output_tokens_before = len(request._output_token_ids)
+
+            if (
+                len(new_token_ids) > 1
+                and scheduled_spec_token_ids
+                and request.use_structured_output
+                and not output_is_stale
+            ):
+                new_token_ids, num_grammar_rejected = (
+                    self.structured_output_manager.filter_speculative_grammar_tokens(
+                        request, new_token_ids
+                    )
+                )
+                if num_grammar_rejected > 0:
+                    if request.num_computed_tokens > 0:
+                        request.num_computed_tokens -= num_grammar_rejected
+                    if request.num_output_placeholders > 0:
+                        request.num_output_placeholders -= num_grammar_rejected
+                    # Target-sampled tokens occupy the end of the output block.
+                    # Removing that tail changes the accepted-draft count only
+                    # when the rejected suffix extends into draft positions.
+                    num_accepted -= max(
+                        num_grammar_rejected - self.num_sampled_tokens_per_step,
+                        0,
+                    )
+                    assert num_accepted >= 0
+
+            if observed_spec_decode:
+                spec_decoding_stats = self.make_spec_decoding_stats(
+                    spec_decoding_stats,
+                    num_draft_tokens=num_draft_tokens,
+                    num_accepted_tokens=num_accepted,
+                    num_invalid_spec_tokens=scheduler_output.num_invalid_spec_tokens,
+                    request_id=req_id,
+                )
 
             # Check for stop and update request status.
             if new_token_ids:

--- a/vllm/v1/structured_output/__init__.py
+++ b/vllm/v1/structured_output/__init__.py
@@ -4,7 +4,8 @@ import itertools
 import multiprocessing
 from collections.abc import Iterable, Sequence
 from concurrent.futures import Future, ThreadPoolExecutor
-from typing import TYPE_CHECKING
+from copy import copy
+from typing import TYPE_CHECKING, overload
 
 from vllm.config import VllmConfig
 from vllm.logger import init_logger
@@ -30,6 +31,34 @@ else:
 
 
 logger = init_logger(__name__)
+
+
+class _TokenSequenceView(Sequence[int]):
+    """Read-only concatenation that does not copy committed token history."""
+
+    def __init__(self, prefix: Sequence[int], suffix: Sequence[int]) -> None:
+        self.prefix = prefix
+        self.suffix = suffix
+
+    def __len__(self) -> int:
+        return len(self.prefix) + len(self.suffix)
+
+    @overload
+    def __getitem__(self, index: int) -> int: ...
+
+    @overload
+    def __getitem__(self, index: slice) -> list[int]: ...
+
+    def __getitem__(self, index: int | slice) -> int | list[int]:
+        if isinstance(index, slice):
+            return [self[i] for i in range(*index.indices(len(self)))]
+        if index < 0:
+            index += len(self)
+        if index < 0 or index >= len(self):
+            raise IndexError(index)
+        if index < len(self.prefix):
+            return self.prefix[index]
+        return self.suffix[index - len(self.prefix)]
 
 
 class StructuredOutputManager:
@@ -491,6 +520,106 @@ class StructuredOutputManager:
         if num_reasoning <= 0:
             return new_token_ids
         return new_token_ids[num_reasoning:]
+
+    @staticmethod
+    def _find_reasoning_end_offset(
+        reasoner: "ReasoningParser",
+        prior_token_ids: Sequence[int],
+        new_token_ids: list[int],
+    ) -> int | None:
+        """Return where a reasoning-end marker completes in a sampled block.
+
+        The first parser call keeps reasoning-only blocks at one check. When
+        the block contains a transition, cumulative delta prefixes locate
+        single-token and multi-token markers, including markers that start in
+        ``prior_token_ids`` and finish in ``new_token_ids``.
+
+        Args:
+            reasoner: Request-scoped parser that identifies the transition.
+            prior_token_ids: Tokens committed before the sampled block.
+            new_token_ids: Accepted tokens awaiting commit.
+
+        Returns:
+            The zero-based offset where the marker completes, or ``None`` if
+            the sampled block remains inside reasoning.
+        """
+        complete_tokens = _TokenSequenceView(prior_token_ids, new_token_ids)
+        if not copy(reasoner).is_reasoning_end_streaming(
+            complete_tokens, new_token_ids
+        ):
+            return None
+
+        for offset in range(len(new_token_ids)):
+            delta_ids = new_token_ids[: offset + 1]
+            token_ids = _TokenSequenceView(prior_token_ids, delta_ids)
+            # Streaming parsers may retain request-local transition state.
+            # A probe must not consume that state before the normal commit path.
+            if copy(reasoner).is_reasoning_end_streaming(token_ids, delta_ids):
+                return offset
+
+        # Some parsers report only that the complete block crossed a boundary.
+        # Treating the full block as reasoning avoids exposing an unknown suffix
+        # to the answer grammar.
+        return len(new_token_ids) - 1
+
+    def filter_speculative_grammar_tokens(
+        self,
+        request: "Request",
+        new_token_ids: list[int],
+    ) -> tuple[list[int], int]:
+        """Validate an accepted speculative block before it is committed.
+
+        Grammar masks cover scheduled draft positions, but an accepted block
+        can contain an unconstrained token immediately after a reasoning
+        transition or after the grammar completes. The filter retains the
+        grammar-valid prefix and reports the trailing tokens that must be
+        resampled. ``validate_tokens`` restores the grammar state before
+        returning, so the scheduler's normal commit path remains the only
+        operation that advances the matcher.
+
+        Args:
+            request: Request that owns the grammar and reasoning state.
+            new_token_ids: Accepted tokens awaiting scheduler commit.
+
+        Returns:
+            The tokens that are safe to commit and the rejected suffix length.
+        """
+        if self.vllm_config.speculative_config is None:
+            return new_token_ids, 0
+        if len(new_token_ids) < 2 or not request.use_structured_output:
+            return new_token_ids, 0
+
+        structured_request = request.structured_output_request
+        if structured_request is None:
+            return new_token_ids, 0
+        grammar = structured_request.grammar
+        if not isinstance(grammar, StructuredOutputGrammar):
+            return new_token_ids, 0
+
+        reasoner = self._get_reasoner(request)
+        grammar_start = 0
+        if (
+            reasoner is not None
+            and not self.enable_in_reasoning
+            and not structured_request.reasoning_ended
+        ):
+            boundary = self._find_reasoning_end_offset(
+                reasoner,
+                request.all_token_ids,
+                new_token_ids,
+            )
+            if boundary is None:
+                return new_token_ids, 0
+            grammar_start = boundary + 1
+
+        grammar_tokens = new_token_ids[grammar_start:]
+        if not grammar_tokens:
+            return new_token_ids, 0
+        valid_grammar_tokens = grammar.validate_tokens(grammar_tokens)
+        rejected = len(grammar_tokens) - len(valid_grammar_tokens)
+        if rejected == 0:
+            return new_token_ids, 0
+        return new_token_ids[:grammar_start] + valid_grammar_tokens, rejected
 
     def clear_backend(self) -> None:
         if self.backend is not None:


### PR DESCRIPTION
## Purpose

Fixes #43338.

Structured-output requests using speculative decoding must satisfy this commit
invariant:

> Request history and grammar state advance through the same longest
> grammar-valid token prefix. Any rejected suffix remains schedulable for
> resampling.

At `main@4666a8ba9ed5d271bf751cf1384cab2d2dcc0cfa`, the scheduler appends the
verifier's accepted token block to request history before
`StructuredOutputGrammar.accept_tokens()` checks the block. Prospective grammar
masks reduce the chance of an invalid token, but they cannot establish the
commit invariant when one accepted block crosses either of these state
transitions:

1. deferred grammar activation at the end of model reasoning;
2. grammar termination before the final accepted token in the block.

The invalid suffix is therefore already visible in request state when
`accept_tokens()` rejects it. Depending on the serving path, that produces an
invalid structured response or terminates the request with `FINISHED_ERROR`.

This PR validates accepted multi-token structured-output blocks before
`Scheduler._update_request_with_output()` mutates request history. It uses the
non-advancing `StructuredOutputGrammar.validate_tokens()` interface, commits
only the valid prefix, and leaves the existing post-commit path as the sole
grammar-state advancement operation.

### Resulting behavior

- Reasoning content through a deferred end marker remains unconstrained.
- Tokens after the marker must form a valid grammar prefix.
- Blocks sampled after reasoning has ended are validated in full, including
  suffixes that follow grammar termination.
- Rejected suffix tokens decrement `num_computed_tokens` and asynchronous
  output placeholders so they can be sampled again.
- Speculative metrics count only committed draft tokens. Rejecting only the
  target-sampled tail does not reduce the accepted-draft count.
- Unstructured requests, stale outputs, non-speculative output, and
  single-token output blocks retain their existing fast paths.

Reasoning-boundary detection exposes prior request tokens through a read-only
concatenated `Sequence`; it does not copy the committed history. A block that
does not contain a boundary requires one parser call. A block that contains a
boundary is scanned through cumulative delta prefixes, which supports
single-token markers, multi-token markers, and markers split across scheduler
steps. Each detection call uses an isolated copy of the request-scoped parser,
so a stateful parser cannot consume its transition before the standard
post-commit path observes it.

## Provenance and related work

The state boundary is produced by the composition of two supported features,
not by a single isolated regression:

- #14702, merge commit
  `34120f5acd693924cc783dfaa33733afbe9ae8b0`, enabled structured output with
  speculative decoding and introduced per-position grammar-mask simulation.
- #16577, merge commit
  `2fc9075b82e05007f460992b3f9d42d2746c41cb`, deferred structured-output
  grammar activation while a request is reasoning.

Several changes cover narrower parts of the lifecycle:

- #36138, head commit
  `94f4dc2e98d63dc1a3ff7cca2b35a9235df667e1`, detects reasoning activation
  inside a speculative window but does not establish pre-commit validation.
- #44297, merge commit
  `e7c9df944969c251bdceed7b9d7bbcc7fec3639b`, constrains scheduled rows after
  a reasoning boundary, including the bonus row. It operates prospectively on
  scheduled draft candidates, not on the authoritative verifier result.
- #44993, merge commit
  `0416dab275d51327b331a1c6baaec754a68d7764`, advances grammar state across an
  accepted reasoning boundary. The accepted block is still appended before
  grammar acceptance.
- #45560, merge commit
  `dc818c198d3ff50a16f38eba567da006478239c8`, constrains GPT-OSS through a
  Harmony structural-tag grammar active from token zero. It is specific to the
  GPT-OSS path and does not cover deferred reasoning parsers or grammar
  termination for other models.
- #43424, commit
  `4e96809853442f1cf9dacf83f166fc32482b6632`, supplies the pre-commit design
  used for the reasoning-boundary case. This PR credits its author and extends
  the contract to every accepted structured speculative block, avoids copying
  committed history, isolates stateful reasoning probes, updates speculative
  metrics, and covers grammar termination. A boundary-only build still fails
  the qualified runtime test.
- #51870, commit
  `c3573d92f69cda2d42d3e74f80f00d0e932e5010`, replaces a mutating operation
  during draft-window mask simulation. It intentionally does not alter accepted
  output or scheduler accounting.
- #48200, commit
  `21265a9a4841812b5088cb062fc5356abcb979d9`, refactors structured-output
  management. Its scheduler still appends `new_token_ids` before accepting them
  into the grammar, so the commit invariant remains separate from that
  refactor.

The scope difference from #43424 is also recorded in #43338:
https://github.com/vllm-project/vllm/issues/43338#issuecomment-5302532715

## Compatibility and limitations

- The patch changes Python scheduler and grammar-management code only. It does
  not change model kernels, sampling distributions, API schemas, or compiled
  components.
- XGrammar and Guidance have direct backend tests. Outlines and
  LM Format Enforcer implement the same non-advancing, longest-prefix
  `validate_tokens()` interface but do not have model-serving qualification in
  this PR.
- Runtime qualification uses XGrammar 0.2.5 with DeepSeek-V4-Flash-0731 and
  DSpark K5. Other speculative methods exercise the same scheduler interface,
  but their model-serving behavior was not separately benchmarked.
- The additional work is bounded by the accepted speculative block length. The
  reasoning-only path performs one parser check, and request history is not
  copied by the manager.
- A direct Step3.5 parser test verifies that pre-commit boundary detection does
  not consume the parser's pending-transition state.

## Test Plan

```bash
uvx --from pre-commit pre-commit run --files \
  vllm/v1/structured_output/__init__.py \
  vllm/v1/core/sched/scheduler.py \
  tests/v1/spec_decode/test_mtp_structured_output.py \
  tests/v1/core/test_scheduler.py

.venv/bin/python -m pytest -q \
  tests/v1/core/test_scheduler.py \
  tests/v1/core/test_async_scheduler.py \
  tests/v1/spec_decode/test_mtp_structured_output.py \
  tests/v1/structured_output/test_reasoning_structured_output.py
```

The tests cover:

- XGrammar and Guidance rejection at a reasoning boundary;
- rejection after grammar completion;
- multi-token markers within a block and across committed/new token storage;
- constant-history sequence access and one-check reasoning-only behavior;
- preservation of request-local state in a Step3.5 reasoning parser;
- synchronous and asynchronous rollback for bonus-only, partial-draft, and
  complete-block rejection;
- speculative acceptance totals and per-position metrics;
- scheduler commit, emitted output, and grammar advancement through one
  identical filtered prefix;
- bypass behavior for unstructured requests.

## Test Result

### Source qualification

- Repository pre-commit hooks: passed, including Ruff, formatting, typos,
  mypy, SPDX, forbidden imports, and configuration checks.
- Four relevant pytest modules: `211 passed` in 170.56 seconds.
- `git diff --check`: passed.

Negative control at
`main@ac2ae8798c7ef59c1924d5c0447a4279fa645770`:

- four XGrammar/Guidance boundary and termination tests fail because accepted
  blocks have no pre-commit validation;
- the scheduler behavior test commits `[10, 11, 12]` instead of the valid
  prefix `[10, 11]`.

The same five discriminator cases pass with commit
`fa0777ff775a870a5d6a6ff187f769e50b38c4ad`.

### Model-serving qualification

Runtime conditions:

```text
model: deepseek-ai/DeepSeek-V4-Flash-0731
topology: TP2 / DCP1
target backend: B12X W4A8
speculative decoding: fixed probabilistic DSpark K5
structured-output backend: XGrammar 0.2.5
scheduler: asynchronous
CUDA graph row cap: 48
concurrency: 8
```

The runtime branch contains #44297 and #44993. The accepted-block validation is
the source change in local-inference-lab/vllm#320.

- Unfiltered source fails the deterministic growing strict-tool test by round
  11.
- A boundary-only filter fails at round 29 when a speculative suffix follows
  grammar termination.
- Complete-block validation finishes 32 rounds and 256 HTTP requests at up to
  225,634 prompt tokens per request. Of those responses, 255 contain one
  schema-valid tool call. One response reaches its configured 768-token output
  limit while still reasoning and reproduces that output-limit result on retry.
- The committed source composition passes 24/24 deterministic strict-tool
  requests: eight buffered or streaming requests at C1 and 16 requests at C8.
- An independently supplied 282,817-byte request payload returns one valid JSON
  tool call in each of eight concurrent replays.
- Ordinary no-tool C1 decode measures 194.3 tok/s. Same-host controls with the
  same launch profile measure 194.02-194.81 tok/s, so no throughput regression
  is measurable at the precision of those runs.

Reproducible image:

```text
tag: voipmonitor/vllm:infernal-invocation-vllm91e2adf-b12xec2f97d-fi1ac6942-cu133-torch213-20260815-r14
digest: sha256:9fe1d1b0e8370df578f92c6431af41a9fc36076ccbebac18c77a8ae99a3454e3
```

Detailed serving evidence:

- https://github.com/local-inference-lab/vllm/pull/320
- https://github.com/local-inference-lab/rtx6kpro/blob/master/models/ds4dspark-infernal-invocation-r14.md
- https://github.com/local-inference-lab/rtx6kpro/issues/67

## AI assistance disclosure

OpenAI Codex assisted with source analysis, implementation, tests, negative
controls, and PR drafting. The submitted patch is supported by the source and
model-serving qualification documented above.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] Purpose and affected invariant are specified.
- [x] Test commands and results are included.
- [x] Model-serving evaluation is included because output correctness changes.
- [x] Related and partially overlapping PRs are distinguished.
- [x] No user documentation change is required; the patch preserves the public
  API and corrects an internal commit invariant.

</details>

