### PR TITLE
[Kimi-K3][Perf] Update FlashKDA for automatic K2 V-split

### DIFF
--- a/cmake/external_projects/flashkda.cmake
+++ b/cmake/external_projects/flashkda.cmake
@@ -13,7 +13,7 @@ else()
   FetchContent_Declare(
     flashkda
     GIT_REPOSITORY https://github.com/vllm-project/FlashKDA.git
-    GIT_TAG b5d11010ff01c1d4a683c0dde42e76cbeaa8107f
+    GIT_TAG 053de1b716ef3255873e02d2d28f4adf09951978
     GIT_PROGRESS TRUE
     GIT_SUBMODULES cutlass
   )


### PR DESCRIPTION
## Purpose

Update the pinned FlashKDA revision from `b5d1101` to `053de1b` in one
CMake line.

The new revision:

- automatically splits K2's value dimension when
  `2 * local_heads * sequences <= SM count`, increasing CTA-level parallelism
  for low-parallelism workloads;
- keeps the existing K2 path for shapes rejected by the heuristic; and
- includes the upstream TMA proxy-fence fixes.

There is no vLLM API or model-code change. I searched open PRs and issues for
the exact revision and FlashKDA V-split keywords; no duplicate was found.

## Test Plan

I built both exact revisions with vLLM's production stable-ABI flags for
SM120 and SM90a, then tested the complete FlashKDA forward call (beta
materialization, K1, and K2) using Kimi-K3's TP8 rank-local geometry
(`H=12`, `D=128`, production beta row stride 6288).

The main long/mixed comparison uses an old-new-new-old schedule, a 512 MiB L2 scrub before
each sample, and two 60-sample slots per revision.

<details>
<summary>Commands run</summary>

RTX PRO 6000:

```bash
PYTHONPATH=/root/r24/runtime_overlay:/root/r25/vllm-main \
  /root/vllm/.venv/bin/python - <<'PY'
import importlib.util
import sys
import pytest

path = "/root/r25/build-sm120-flash-new/_flashkda_C.abi3.so"
spec = importlib.util.spec_from_file_location("vllm._flashkda_C", path)
module = importlib.util.module_from_spec(spec)
sys.modules["vllm._flashkda_C"] = module
spec.loader.exec_module(module)
raise SystemExit(pytest.main(["-q", "tests/models/kimi_k3/test_kda.py"]))
PY

cd /root/r25/experiments/flashkda_vsplit
CUDA_VISIBLE_DEVICES=0 ./run_matrix.sh \
  /root/r25/results/flashkda-vsplit-pro6000-v3

cd /root/r24/experiments/flashkda_pin_bump_sm120
/root/vllm/.venv/bin/python run_balanced.py \
  --old-extension build/cmake-old/_flashkda_C.abi3.so \
  --new-extension build/cmake-new/_flashkda_C.abi3.so \
  --output-dir /root/r24/results/flashkda-pin-sm120-short-v2
```

NVIDIA H20:

```bash
cd /root/pr52458_exp
PY=/root/pr52229_exp/venv/bin/python

./kernel_build/build.sh old _fkda_old_C
./kernel_build/build.sh new _fkda_new_C
./kernel_build/build.sh old _flashkda_C
./kernel_build/build.sh new _flashkda_C

cd testtree
FKDA_ARM=old $PY -m pytest -q -p no:randomly \
  tests/models/kimi_k3/test_kda.py
FKDA_ARM=new $PY -m pytest -q -p no:randomly \
  tests/models/kimi_k3/test_kda.py
cd ..

$PY exp_correct.py --part A
$PY exp_correct.py --part B --replays 20
$PY exp_correct.py --part C
$PY exp_correct.py --part D
$PY exp_perf.py --samples 60 --warmup 15 --group all
$PY exp_sweep.py --samples 40 --warmup 10
```

Repository checks:

```bash
cd /root/r25/vllm-main
/root/vllm/.venv/bin/pre-commit run --files \
  cmake/external_projects/flashkda.cmake
git diff --check
```

</details>

## Test Result

### Correctness

- RTX PRO 6000: `tests/models/kimi_k3/test_kda.py` passed with the new pin
  (**51 passed**). Old/new outputs and final recurrent states were bitwise
  identical across the tested long- and short-sequence eager/CUDA Graph
  matrices, including deterministic replay and empty-sequence checks.
- NVIDIA H20: the same test passed with both pins (**51 passed each**). All
  **133** workload shapes, including **76** that selected V-split, produced
  bitwise-identical output and final recurrent state between the pins.
- On H20, 10 CUDA Graph workloads remained bitwise deterministic over 20
  replays and matched eager execution. All 20 focused empty-sequence cases
  preserved final-state semantics and neighboring sequences.
- The locally built old SM90a extension matched the wheel's current-pin
  extension bitwise in output and final state for six representative cases.
- Relevant pre-commit hooks and `git diff --check` passed.

### Performance

The dispatch boundary is relative to the GPU's SM count. For `H=12`, it
selects `N <= 7` on the 188-SM RTX PRO 6000 and `N <= 3` on the 78-SM H20.
The two platforms therefore use different selected workload sets.

These are complete FlashKDA forward timings, not isolated K2 timings:

| GPU | Selected `H=12` prefill/mixed cases | Eager speedup | CUDA Graph speedup | Paired wins |
|---|---:|---:|---:|---:|
| RTX PRO 6000 (SM120) | 4 | **1.202x-1.434x** | **1.198x-1.433x** | 120/120 per case |
| NVIDIA H20 (SM90) | 4 | **1.453x-1.613x** | **1.501x-1.652x** | 120/120 per case |

For the workload selected on both GPUs (`H=12, N=1, T=4096`), the complete
forward speedup was **1.434x eager / 1.433x graph** on PRO 6000 and
**1.613x eager / 1.652x graph** on H20.

A separate synchronized short-sequence sweep also showed consistent gains:

- PRO 6000: all 12 selected cases improved by **5.576%-10.571%**.
- H20: all 12 selected cases improved by **9.704%-17.905%**.

Long H20 cases rejected by the heuristic remained approximately unchanged
(`0.999x-1.002x`). In very short rejected H20 cases (roughly 50-57 us per
call), synchronized wall time stayed within about +/-1%; the slowest case was
approximately **1.0%** slower. A standalone multiprocessor-count query
measured about **0.35 us**, consistent with the host overhead of querying
`cudaDeviceGetAttribute` on every eager call. Caching this device property is
a possible upstream follow-up; CUDA Graph replay does not pay the query cost
on every replay.

These local results are operator-level measurements, not full-model
throughput claims. The
[upstream full Kimi-K3 TEP8 evaluation on GB300](https://github.com/vllm-project/FlashKDA/pull/6#issuecomment-5262066533)
reported GSM8K accuracy of `96.47% -> 96.82%` and OCRBench accuracy of
`88.8% -> 90.0%`, while runtime improved from `1075.8 -> 1044.3 s` and
`610.1 -> 596.5 s`, respectively.

AI assistance: Codex was used for the pin update, experiment harnesses, and
result analysis.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR is described.
- [x] Test commands are provided.
- [x] Correctness, performance, and model-evaluation results are provided.
- [x] Documentation is not required for this dependency-only change.

</details>

**BEFORE SUBMITTING, PLEASE READ <https://docs.vllm.ai/en/latest/contributing>** (anything written below this line will be removed by GitHub Actions)

