### PR TITLE
[Model] Register model capabilities directly

### DIFF
--- a/tests/models/test_registry.py
+++ b/tests/models/test_registry.py
@@ -6,6 +6,7 @@ import warnings
 import pytest
 import torch.cuda
 
+import vllm.model_executor.models.registry as model_registry
 from vllm.model_executor.models import (
     is_pooling_model,
     is_text_generation_model,
@@ -63,6 +64,17 @@ def test_registry_imports(model_arch):
     model_cls = ModelRegistry._try_load_model_cls(model_arch)
     assert model_cls is not None
 
+    registered_model = ModelRegistry.models[model_arch]
+    if isinstance(registered_model, _LazyRegisteredModel) and (
+        model_registry._get_builtin_model_info(
+            registered_model.module_name, registered_model.class_name
+        )
+        is not None
+    ):
+        assert registered_model.inspect_model_cls() == (
+            model_registry._ModelInfo.from_model_cls(model_cls)
+        )
+
     if model_arch in _SPECULATIVE_DECODING_MODELS:
         return  # Ignore these models which do not have a unified format
 
@@ -75,6 +87,16 @@ def test_registry_imports(model_arch):
 
     if model_arch in _MULTIMODAL_MODELS:
         assert supports_multimodal(model_cls)
+
+
+def test_builtin_model_info_skips_dynamic_inspection(monkeypatch):
+    monkeypatch.setattr(
+        _LazyRegisteredModel, "_load_modelinfo_from_cache", lambda *_: pytest.fail()
+    )
+    monkeypatch.setattr(model_registry, "_run_in_subprocess", lambda _: pytest.fail())
+    model_info = ModelRegistry._try_inspect_model_cls("Qwen2ForCausalLM")
+    assert model_info is not None
+    assert model_info.architecture == "Qwen2ForCausalLM"
 
 
 @create_new_process_for_each_test()
@@ -192,8 +214,8 @@ def test_lazy_modelinfo_package_attempts_cache_load(monkeypatch):
     )
 
     registered_model = _LazyRegisteredModel(
-        module_name="vllm.model_executor.models.transformers",
-        class_name="TransformersForCausalLM",
+        module_name="vllm.models.deepseek_v32",
+        class_name="DeepseekV32ForCausalLM",
     )
 
     result = registered_model.inspect_model_cls()

--- a/tests/models/test_registry.py
+++ b/tests/models/test_registry.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import dataclasses
 import warnings
 
 import pytest
@@ -71,9 +72,14 @@ def test_registry_imports(model_arch):
         )
         is not None
     ):
-        assert registered_model.inspect_model_cls() == (
-            model_registry._ModelInfo.from_model_cls(model_cls)
-        )
+        direct_info = registered_model.inspect_model_cls()
+        dynamic_info = model_registry._ModelInfo.from_model_cls(model_cls)
+
+        for field in dataclasses.fields(dynamic_info):
+            direct_value = getattr(direct_info, field.name)
+            dynamic_value = getattr(dynamic_info, field.name)
+            assert type(direct_value) is type(dynamic_value), field.name
+            assert direct_value == dynamic_value, field.name
 
     if model_arch in _SPECULATIVE_DECODING_MODELS:
         return  # Ignore these models which do not have a unified format

--- a/vllm/model_executor/models/_model_info.py
+++ b/vllm/model_executor/models/_model_info.py
@@ -1,0 +1,900 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Checked metadata catalog for built-in models.
+
+Unlisted implementations fall back to dynamic inspection.
+"""
+
+from typing import Any, TypeAlias
+
+_Profile: TypeAlias = dict[str, Any]
+
+_MODEL_INFO_DEFAULTS: _Profile = {
+    "is_text_generation_model": False,
+    "is_pooling_model": False,
+    "attn_type": "decoder",
+    "default_seq_pooling_type": "LAST",
+    "default_tok_pooling_type": "ALL",
+    "score_type": "bi-encoder",
+    "supports_multimodal": False,
+    "supports_multimodal_raw_input_only": False,
+    "requires_raw_input_tokens": False,
+    "supports_multimodal_encoder_tp_data": False,
+    "supports_pp": False,
+    "has_inner_state": False,
+    "is_attention_free": False,
+    "is_hybrid": False,
+    "has_noops": False,
+    "supports_mamba_prefix_caching": False,
+    "supports_replayssm": False,
+    "supports_transcription": False,
+    "supports_transcription_only": False,
+    "supported_video_pruning_methods": (),
+    "supports_mm_device_do_normalize": False,
+}
+
+
+_TEXT_GENERATION_PP = dict(
+    is_text_generation_model=True,
+    supports_pp=True,
+)
+
+_MULTIMODAL_GENERATION_PP = dict(
+    is_text_generation_model=True,
+    supports_multimodal=True,
+    supports_pp=True,
+)
+
+_TEXT_GENERATION = dict(
+    is_text_generation_model=True,
+)
+
+_MULTIMODAL_ENCODER_TP_GENERATION_PP = dict(
+    is_text_generation_model=True,
+    supports_multimodal=True,
+    supports_multimodal_encoder_tp_data=True,
+    supports_pp=True,
+)
+
+_MULTIMODAL_GENERATION = dict(
+    is_text_generation_model=True,
+    supports_multimodal=True,
+)
+
+_HYBRID_GENERATION_PP = dict(
+    is_text_generation_model=True,
+    supports_pp=True,
+    has_inner_state=True,
+    is_hybrid=True,
+)
+
+_TRANSCRIPTION_GENERATION_PP = dict(
+    is_text_generation_model=True,
+    supports_multimodal=True,
+    supports_pp=True,
+    supports_transcription=True,
+)
+
+_DEFAULT_PROFILE: _Profile = {}
+
+_ENCODER_POOLING = dict(
+    is_pooling_model=True,
+    attn_type="encoder_only",
+)
+
+_TRANSCRIPTION_ONLY_MULTIMODAL_GENERATION = dict(
+    is_text_generation_model=True,
+    supports_multimodal=True,
+    supports_transcription=True,
+    supports_transcription_only=True,
+)
+
+_CLS_DEFAULT = dict(
+    default_seq_pooling_type="CLS",
+)
+
+_CLS_POOLING = dict(
+    is_pooling_model=True,
+    default_seq_pooling_type="CLS",
+)
+
+_CLS_CROSS_ENCODER = dict(
+    is_pooling_model=True,
+    default_seq_pooling_type="CLS",
+    score_type="cross-encoder",
+)
+
+_HYBRID_VIDEO_PRUNING_MULTIMODAL_ENCODER_TP_GENERATION_PP = dict(
+    is_text_generation_model=True,
+    supports_multimodal=True,
+    supports_multimodal_encoder_tp_data=True,
+    supports_pp=True,
+    is_hybrid=True,
+    supported_video_pruning_methods=("evs", "vidcom2"),
+)
+
+_VIDEO_PRUNING_MULTIMODAL_ENCODER_TP_GENERATION_PP = dict(
+    is_text_generation_model=True,
+    supports_multimodal=True,
+    supports_multimodal_encoder_tp_data=True,
+    supports_pp=True,
+    supported_video_pruning_methods=("evs", "vidcom2"),
+)
+
+_CLS_LATE_INTERACTION = dict(
+    is_pooling_model=True,
+    default_seq_pooling_type="CLS",
+    score_type="late-interaction",
+)
+
+_MAMBA_HYBRID_GENERATION_PP = dict(
+    is_text_generation_model=True,
+    supports_pp=True,
+    has_inner_state=True,
+    is_hybrid=True,
+    supports_mamba_prefix_caching=True,
+)
+
+_GENERATION_POOLING_PP = dict(
+    is_text_generation_model=True,
+    is_pooling_model=True,
+    supports_pp=True,
+)
+
+_EVS_NORMALIZED_MULTIMODAL_ENCODER_TP_GENERATION_PP = dict(
+    is_text_generation_model=True,
+    supports_multimodal=True,
+    supports_multimodal_encoder_tp_data=True,
+    supports_pp=True,
+    supported_video_pruning_methods=("evs",),
+    supports_mm_device_do_normalize=True,
+)
+
+_CLS_CROSS_ENCODER_PP = dict(
+    is_pooling_model=True,
+    default_seq_pooling_type="CLS",
+    score_type="cross-encoder",
+    supports_pp=True,
+)
+
+_CLS_POOLING_PP = dict(
+    is_pooling_model=True,
+    default_seq_pooling_type="CLS",
+    supports_pp=True,
+)
+
+_HYBRID_MULTIMODAL_ENCODER_TP_GENERATION_PP = dict(
+    is_text_generation_model=True,
+    supports_multimodal=True,
+    supports_multimodal_encoder_tp_data=True,
+    supports_pp=True,
+    has_inner_state=True,
+    is_hybrid=True,
+)
+
+_ModelInfoImplementation = tuple[str, str]
+_ProfileGroup = tuple[_Profile, tuple[_ModelInfoImplementation, ...]]
+
+_DECI_LM_PROFILE_GROUP: _ProfileGroup = (
+    dict(
+        is_text_generation_model=True,
+        supports_pp=True,
+        has_noops=True,
+    ),
+    (("nemotron_nas", "DeciLMForCausalLM"),),
+)
+
+_MODEL_INFO_PROFILE_GROUPS: tuple[_ProfileGroup, ...] = (
+    (
+        _ENCODER_POOLING,
+        (
+            ("bert", "BertForMaskedLM"),
+            ("bert", "BertForTokenClassification"),
+            ("modernbert", "ModernBertForTokenClassification"),
+            ("openai_privacy_filter", "OpenAIPrivacyFilterForTokenClassification"),
+            ("roberta", "RobertaForTokenClassification"),
+        ),
+    ),
+    (
+        dict(
+            is_pooling_model=True,
+            default_seq_pooling_type="CLS",
+            score_type="late-interaction",
+            has_inner_state=True,
+            is_hybrid=True,
+        ),
+        (("colbert", "ColBERTLfm2Model"),),
+    ),
+    (
+        dict(
+            is_text_generation_model=True,
+            is_pooling_model=True,
+            default_seq_pooling_type="CLS",
+            score_type="late-interaction",
+            supports_multimodal=True,
+            supports_multimodal_encoder_tp_data=True,
+            supports_pp=True,
+            is_hybrid=True,
+            supported_video_pruning_methods=("evs", "vidcom2"),
+        ),
+        (("colqwen3_5", "ColQwen3_5Model"),),
+    ),
+    (
+        dict(
+            is_text_generation_model=True,
+            is_pooling_model=True,
+            default_seq_pooling_type="CLS",
+            score_type="late-interaction",
+            supports_multimodal=True,
+            supports_multimodal_encoder_tp_data=True,
+            supports_pp=True,
+            supported_video_pruning_methods=("evs", "vidcom2"),
+        ),
+        (("colqwen3", "ColQwen3Model"),),
+    ),
+    (
+        dict(
+            is_text_generation_model=True,
+            is_pooling_model=True,
+            default_seq_pooling_type="CLS",
+            score_type="late-interaction",
+            supports_multimodal=True,
+            supports_pp=True,
+        ),
+        (("colpali", "ColPaliModel"),),
+    ),
+    (
+        dict(
+            is_pooling_model=True,
+            default_seq_pooling_type="CLS",
+            score_type="cross-encoder",
+            supports_multimodal=True,
+            supports_pp=True,
+        ),
+        (("transformers", "TransformersMultiModalForSequenceClassification"),),
+    ),
+    (
+        _CLS_CROSS_ENCODER_PP,
+        (
+            ("transformers", "TransformersForSequenceClassification"),
+            ("transformers", "TransformersMoEForSequenceClassification"),
+        ),
+    ),
+    (
+        _CLS_CROSS_ENCODER,
+        (
+            ("bert", "BertForSequenceClassification"),
+            ("bert_with_rope", "GteNewForSequenceClassification"),
+            ("modernbert", "ModernBertForSequenceClassification"),
+            ("roberta", "RobertaForSequenceClassification"),
+        ),
+    ),
+    (
+        dict(
+            is_pooling_model=True,
+            default_seq_pooling_type="CLS",
+            score_type="late-interaction",
+            supports_multimodal=True,
+        ),
+        (("colmodernvbert", "ColModernVBertForRetrieval"),),
+    ),
+    (
+        _CLS_LATE_INTERACTION,
+        (
+            ("colbert", "ColBERTJinaRobertaModel"),
+            ("colbert", "ColBERTModel"),
+            ("colbert", "ColBERTModernBertModel"),
+        ),
+    ),
+    (
+        dict(
+            is_pooling_model=True,
+            default_seq_pooling_type="CLS",
+            supports_multimodal=True,
+            supports_pp=True,
+        ),
+        (("transformers", "TransformersMultiModalEmbeddingModel"),),
+    ),
+    (
+        dict(
+            is_pooling_model=True,
+            default_seq_pooling_type="CLS",
+            supports_multimodal=True,
+        ),
+        (("siglip", "SiglipEmbeddingModel"),),
+    ),
+    (
+        _CLS_POOLING_PP,
+        (
+            ("transformers", "TransformersEmbeddingModel"),
+            ("transformers", "TransformersMoEEmbeddingModel"),
+        ),
+    ),
+    (
+        _CLS_POOLING,
+        (
+            ("bert", "BertEmbeddingModel"),
+            ("bert", "BertSpladeSparseEmbeddingModel"),
+            ("roberta", "BgeM3EmbeddingModel"),
+            ("roberta", "RobertaEmbeddingModel"),
+        ),
+    ),
+    (
+        _CLS_DEFAULT,
+        (
+            ("bert_with_rope", "GteNewModel"),
+            ("bert_with_rope", "NomicBertModel"),
+            ("bert_with_rope", "SnowflakeGteNewModel"),
+            ("modernbert", "ModernBertModel"),
+        ),
+    ),
+    (
+        dict(
+            is_text_generation_model=True,
+            is_pooling_model=True,
+            default_seq_pooling_type="MEAN",
+            supports_pp=True,
+        ),
+        (("gritlm", "GritLM"),),
+    ),
+    (
+        dict(
+            is_pooling_model=True,
+            default_tok_pooling_type="STEP",
+            supports_pp=True,
+        ),
+        (("qwen2_rm", "Qwen2ForProcessRewardModel"),),
+    ),
+    (
+        dict(
+            is_text_generation_model=True,
+            supports_pp=True,
+            has_inner_state=True,
+            is_attention_free=True,
+            supports_mamba_prefix_caching=True,
+        ),
+        (("mamba", "MambaForCausalLM"),),
+    ),
+    (
+        dict(
+            is_text_generation_model=True,
+            has_inner_state=True,
+            is_attention_free=True,
+            supports_mamba_prefix_caching=True,
+        ),
+        (("mamba2", "Mamba2ForCausalLM"),),
+    ),
+    (
+        dict(
+            is_text_generation_model=True,
+            is_pooling_model=True,
+            supports_pp=True,
+            has_inner_state=True,
+            is_hybrid=True,
+            supports_mamba_prefix_caching=True,
+        ),
+        (("jamba", "JambaForSequenceClassification"),),
+    ),
+    (
+        dict(
+            is_text_generation_model=True,
+            supports_multimodal=True,
+            has_inner_state=True,
+            is_hybrid=True,
+            supported_video_pruning_methods=("evs",),
+        ),
+        (("nano_nemotron_vl", "NemotronH_Nano_VL_V2"),),
+    ),
+    (
+        dict(
+            is_text_generation_model=True,
+            supports_pp=True,
+            has_inner_state=True,
+            is_hybrid=True,
+            supports_mamba_prefix_caching=True,
+            supports_replayssm=True,
+        ),
+        (("nemotron_h", "NemotronHForCausalLM"),),
+    ),
+    (
+        _MAMBA_HYBRID_GENERATION_PP,
+        (
+            ("falcon_h1", "FalconH1ForCausalLM"),
+            ("granitemoehybrid", "GraniteMoeHybridForCausalLM"),
+            ("jamba", "JambaForCausalLM"),
+        ),
+    ),
+    (
+        dict(
+            is_text_generation_model=True,
+            has_inner_state=True,
+            is_hybrid=True,
+            supports_mamba_prefix_caching=True,
+        ),
+        (("zamba2", "Zamba2ForCausalLM"),),
+    ),
+    (
+        _HYBRID_MULTIMODAL_ENCODER_TP_GENERATION_PP,
+        (("minicpmv4_6", "MiniCPMV4_6ForConditionalGeneration"),),
+    ),
+    (
+        _HYBRID_GENERATION_PP,
+        (
+            ("bailing_moe_linear", "BailingMoeV25ForCausalLM"),
+            ("bailing_moe_v3", "BailingMoeV3ForCausalLM"),
+            ("lfm2", "Lfm2ForCausalLM"),
+            ("lfm2_moe", "Lfm2MoeForCausalLM"),
+            ("olmo_hybrid", "OlmoHybridForCausalLM"),
+            ("qwen3_5", "Qwen3_5ForCausalLM"),
+            ("qwen3_5", "Qwen3_5MoeForCausalLM"),
+            ("qwen3_next", "Qwen3NextForCausalLM"),
+        ),
+    ),
+    _DECI_LM_PROFILE_GROUP,
+    (
+        _HYBRID_VIDEO_PRUNING_MULTIMODAL_ENCODER_TP_GENERATION_PP,
+        (
+            ("interns2_mobius", "InternS2MobiusForConditionalGeneration"),
+            ("interns2_preview", "InternS2PreviewForConditionalGeneration"),
+            ("qwen3_5", "Qwen3_5ForConditionalGeneration"),
+            ("qwen3_5", "Qwen3_5MoeForConditionalGeneration"),
+        ),
+    ),
+    (
+        dict(
+            is_text_generation_model=True,
+            supports_multimodal=True,
+            supports_pp=True,
+            is_hybrid=True,
+        ),
+        (("lfm2_vl", "Lfm2VLForConditionalGeneration"),),
+    ),
+    (
+        dict(
+            is_text_generation_model=True,
+            is_pooling_model=True,
+            score_type="cross-encoder",
+            supports_multimodal=True,
+            supports_multimodal_encoder_tp_data=True,
+            supports_pp=True,
+            supports_mm_device_do_normalize=True,
+        ),
+        (("jina_vl", "JinaVLForSequenceClassification"),),
+    ),
+    (
+        dict(
+            is_text_generation_model=True,
+            is_pooling_model=True,
+            score_type="cross-encoder",
+            supports_multimodal=True,
+            supports_pp=True,
+        ),
+        (("nemotron_vl", "LlamaNemotronVLForSequenceClassification"),),
+    ),
+    (
+        dict(
+            is_text_generation_model=True,
+            is_pooling_model=True,
+            score_type="cross-encoder",
+            supports_pp=True,
+        ),
+        (("llama", "LlamaBidirectionalForSequenceClassification"),),
+    ),
+    (
+        dict(
+            is_text_generation_model=True,
+            is_pooling_model=True,
+            supports_multimodal=True,
+            supports_pp=True,
+            supports_transcription=True,
+        ),
+        (("qwen3_asr_forced_aligner", "Qwen3ASRForcedAlignerForTokenClassification"),),
+    ),
+    (
+        dict(
+            is_text_generation_model=True,
+            is_pooling_model=True,
+            supports_multimodal=True,
+            supports_pp=True,
+        ),
+        (("nemotron_vl", "LlamaNemotronVLForEmbedding"),),
+    ),
+    (
+        _GENERATION_POOLING_PP,
+        (
+            ("internlm2", "InternLM2ForRewardModel"),
+            ("jina", "JinaEmbeddingsV5Model"),
+            ("llama", "LlamaBidirectionalModel"),
+        ),
+    ),
+    (
+        dict(
+            is_pooling_model=True,
+            score_type="cross-encoder",
+        ),
+        (("gpt2", "GPT2ForSequenceClassification"),),
+    ),
+    (
+        dict(
+            is_pooling_model=True,
+            score_type="late-interaction",
+        ),
+        (("jina", "JinaForRanking"),),
+    ),
+    (
+        dict(
+            is_pooling_model=True,
+            supports_multimodal=True,
+        ),
+        (("clip", "CLIPEmbeddingModel"),),
+    ),
+    (
+        dict(
+            is_pooling_model=True,
+            supports_pp=True,
+        ),
+        (("qwen2_rm", "Qwen2ForRewardModel"),),
+    ),
+    (
+        dict(
+            is_text_generation_model=True,
+            supports_multimodal=True,
+            requires_raw_input_tokens=True,
+            supports_pp=True,
+            supports_transcription=True,
+        ),
+        (("voxtral_realtime", "VoxtralRealtimeGeneration"),),
+    ),
+    (
+        dict(
+            is_text_generation_model=True,
+            supports_multimodal=True,
+            requires_raw_input_tokens=True,
+            supports_pp=True,
+        ),
+        (("cheers", "CheersForConditionalGeneration"),),
+    ),
+    (
+        _VIDEO_PRUNING_MULTIMODAL_ENCODER_TP_GENERATION_PP,
+        (
+            ("cosmos3", "Cosmos3ForConditionalGeneration"),
+            ("interns1_pro", "InternS1ProForConditionalGeneration"),
+            ("qwen3_vl", "Qwen3VLForConditionalGeneration"),
+            ("qwen3_vl_moe", "Qwen3VLMoeForConditionalGeneration"),
+        ),
+    ),
+    (
+        _EVS_NORMALIZED_MULTIMODAL_ENCODER_TP_GENERATION_PP,
+        (
+            ("exaone4_5", "Exaone4_5_ForConditionalGeneration"),
+            ("opencua", "OpenCUAForConditionalGeneration"),
+            ("qwen2_5_vl", "Qwen2_5_VLForConditionalGeneration"),
+        ),
+    ),
+    (
+        dict(
+            is_text_generation_model=True,
+            supports_multimodal=True,
+            supports_multimodal_encoder_tp_data=True,
+            supports_pp=True,
+            supports_mm_device_do_normalize=True,
+        ),
+        (("qwen2_vl", "Qwen2VLForConditionalGeneration"),),
+    ),
+    (
+        _MULTIMODAL_ENCODER_TP_GENERATION_PP,
+        (
+            ("cosmos3_edge", "Cosmos3EdgeForConditionalGeneration"),
+            ("dots_ocr", "DotsOCRForCausalLM"),
+            ("eagle2_5_vl", "Eagle2_5_VLForConditionalGeneration"),
+            ("glm4_1v", "Glm4vForConditionalGeneration"),
+            ("glm4_1v", "Glm4vMoeForConditionalGeneration"),
+            ("glm_ocr", "GlmOcrForConditionalGeneration"),
+            ("h2ovl", "H2OVLChatModel"),
+            ("internvl", "InternVLChatModel"),
+            ("isaac", "IsaacForConditionalGeneration"),
+            ("kimi_k25", "KimiK25ForConditionalGeneration"),
+            ("kimi_vl", "KimiVLForConditionalGeneration"),
+            ("minicpmo", "MiniCPMO"),
+            ("minicpmv", "MiniCPMV"),
+            ("mllama4", "Llama4ForConditionalGeneration"),
+            ("nvlm_d", "NVLM_D_Model"),
+            ("qianfan_ocr", "QianfanOCRForConditionalGeneration"),
+            ("step3_vl", "Step3VLForConditionalGeneration"),
+            ("step3p7", "Step3p7ForConditionalGeneration"),
+            ("step_vl", "StepVLForConditionalGeneration"),
+            ("vllm.models.minimax_m3", "MiniMaxM3SparseForConditionalGeneration"),
+        ),
+    ),
+    (
+        dict(
+            is_text_generation_model=True,
+            supports_multimodal=True,
+            supports_pp=True,
+            supports_transcription=True,
+            supports_transcription_only=True,
+        ),
+        (("moss_transcribe_diarize", "MossTranscribeDiarizeForConditionalGeneration"),),
+    ),
+    (
+        _TRANSCRIPTION_GENERATION_PP,
+        (
+            ("glmasr", "GlmAsrForConditionalGeneration"),
+            ("granite_speech", "GraniteSpeechForConditionalGeneration"),
+            ("granite_speech_plus", "GraniteSpeechPlusForConditionalGeneration"),
+            ("kimi_audio", "KimiAudioForConditionalGeneration"),
+            ("qwen3_asr", "Qwen3ASRForConditionalGeneration"),
+            ("qwen3_asr_realtime", "Qwen3ASRRealtimeGeneration"),
+            ("qwen3_omni_moe_thinker", "Qwen3OmniMoeThinkerForConditionalGeneration"),
+            ("voxtral", "VoxtralForConditionalGeneration"),
+        ),
+    ),
+    (
+        _MULTIMODAL_GENERATION_PP,
+        (
+            ("audioflamingo3", "AudioFlamingo3ForConditionalGeneration"),
+            ("bagel", "BagelForConditionalGeneration"),
+            ("bee", "BeeForConditionalGeneration"),
+            ("blip2", "Blip2ForConditionalGeneration"),
+            ("chameleon", "ChameleonForConditionalGeneration"),
+            ("cohere2_vision", "Cohere2VisionForConditionalGeneration"),
+            ("deepseek_ocr", "DeepseekOCRForCausalLM"),
+            ("deepseek_ocr2", "DeepseekOCR2ForCausalLM"),
+            ("deepseek_vl2", "DeepseekVLV2ForCausalLM"),
+            ("ernie45_vl", "Ernie4_5_VLMoeForConditionalGeneration"),
+            ("funaudiochat", "FunAudioChatForConditionalGeneration"),
+            ("gemma3_mm", "Gemma3ForConditionalGeneration"),
+            ("gemma4_mm", "Gemma4ForConditionalGeneration"),
+            ("gemma4_unified", "Gemma4UnifiedForConditionalGeneration"),
+            ("glm4v", "GLM4VForCausalLM"),
+            ("granite4_vision", "Granite4VisionForConditionalGeneration"),
+            ("hyperclovax_vision_v2", "HCXVisionV2ForCausalLM"),
+            ("interns1", "InternS1ForConditionalGeneration"),
+            ("keye", "KeyeForConditionalGeneration"),
+            ("keye_vl1_5", "KeyeVL1_5ForConditionalGeneration"),
+            ("lightonocr", "LightOnOCRForConditionalGeneration"),
+            ("llava", "LlavaForConditionalGeneration"),
+            ("llava_next", "LlavaNextForConditionalGeneration"),
+            ("llava_next_video", "LlavaNextVideoForConditionalGeneration"),
+            ("llava_onevision", "LlavaOnevisionForConditionalGeneration"),
+            ("llava_onevision2", "LlavaOnevision2ForConditionalGeneration"),
+            ("midashenglm", "MiDashengLMModel"),
+            ("mimo_v2_omni", "MiMoV2OmniForCausalLM"),
+            ("mistral3", "Mistral3ForConditionalGeneration"),
+            ("molmo", "MolmoForCausalLM"),
+            ("molmo2", "Molmo2ForConditionalGeneration"),
+            ("moondream3", "Moondream3ForCausalLM"),
+            ("moss_audio", "MossAudioModel"),
+            ("muse_glimmer", "MuseGlimmerForCausalLM"),
+            ("nemotron_vl", "LlamaNemotronVLChatModel"),
+            ("openpangu_vl", "OpenPanguVLForConditionalGeneration"),
+            ("openvla", "OpenVLAForActionPrediction"),
+            ("ovis", "Ovis"),
+            ("ovis2_5", "Ovis2_5"),
+            ("paligemma", "PaliGemmaForConditionalGeneration"),
+            ("phi3v", "Phi3VForCausalLM"),
+            ("phi4siglip", "Phi4ForCausalLMV"),
+            ("pixtral", "PixtralForConditionalGeneration"),
+            ("qwen2_5_omni_thinker", "Qwen2_5OmniThinkerForConditionalGeneration"),
+            ("qwen2_audio", "Qwen2AudioForConditionalGeneration"),
+            ("rvl", "RForConditionalGeneration"),
+            ("skyworkr1v", "SkyworkR1VChatModel"),
+            ("transformers", "TransformersMultiModalForCausalLM"),
+            ("transformers", "TransformersMultiModalMoEForCausalLM"),
+            ("ultravox", "UltravoxModel"),
+            ("unlimited_ocr", "UnlimitedOCRForCausalLM"),
+            ("vllm.models.inkling", "InklingForConditionalGeneration"),
+        ),
+    ),
+    (
+        _TRANSCRIPTION_ONLY_MULTIMODAL_GENERATION,
+        (
+            ("cohere_asr", "CohereAsrForConditionalGeneration"),
+            ("fireredasr2", "FireRedASR2ForConditionalGeneration"),
+            ("fireredlid", "FireRedLIDForConditionalGeneration"),
+            ("funasr", "FunASRForConditionalGeneration"),
+            ("whisper", "WhisperForConditionalGeneration"),
+        ),
+    ),
+    (
+        dict(
+            is_text_generation_model=True,
+            supports_multimodal=True,
+            supports_transcription=True,
+        ),
+        (("gemma3n_mm", "Gemma3nForConditionalGeneration"),),
+    ),
+    (
+        _MULTIMODAL_GENERATION,
+        (
+            ("aria", "AriaForConditionalGeneration"),
+            ("diffusion_gemma", "DiffusionGemmaForConditionalGeneration"),
+            ("exaone4_5_mtp", "Exaone4_5_MTP"),
+            ("idefics3", "Idefics3ForConditionalGeneration"),
+            ("interns2_mobius", "InternS2MobiusMTP"),
+            ("mimo_v2_mtp", "MiMoV2OmniMTP"),
+            ("nemotron_parse", "NemotronParseForConditionalGeneration"),
+            ("paddleocr_vl", "PaddleOCRVLForConditionalGeneration"),
+            ("phi4mm", "Phi4MMForCausalLM"),
+            ("qwen3_5_mtp", "Qwen3_5MTP"),
+            ("qwen3_5_mtp", "Qwen3_5MoeMTP"),
+            ("smolvlm", "SmolVLMForConditionalGeneration"),
+        ),
+    ),
+    (
+        _TEXT_GENERATION_PP,
+        (
+            ("AXK1", "AXK1ForCausalLM"),
+            ("afmoe", "AfmoeForCausalLM"),
+            ("apertus", "ApertusForCausalLM"),
+            ("arcee", "ArceeForCausalLM"),
+            ("arctic", "ArcticForCausalLM"),
+            ("bailing_moe", "BailingMoeForCausalLM"),
+            ("bailing_moe", "BailingMoeV2ForCausalLM"),
+            ("bailing_moe_v3_mtp", "BailingMoeV3MTPModel"),
+            ("bloom", "BloomForCausalLM"),
+            ("chatglm", "ChatGLMForCausalLM"),
+            ("cohere2_moe", "Cohere2MoeForCausalLM"),
+            ("commandr", "CohereForCausalLM"),
+            ("dbrx", "DbrxForCausalLM"),
+            ("deepseek_v2", "DeepseekForCausalLM"),
+            ("deepseek_v2", "DeepseekV2ForCausalLM"),
+            ("deepseek_v2", "DeepseekV3ForCausalLM"),
+            ("ernie45", "Ernie4_5ForCausalLM"),
+            ("ernie45_moe", "Ernie4_5_MoeForCausalLM"),
+            ("exaone", "ExaoneForCausalLM"),
+            ("exaone4", "Exaone4ForCausalLM"),
+            ("exaone_moe", "ExaoneMoeForCausalLM"),
+            ("fairseq2_llama", "Fairseq2LlamaForCausalLM"),
+            ("falcon", "FalconForCausalLM"),
+            ("flex_olmo", "FlexOlmoForCausalLM"),
+            ("gemma", "GemmaForCausalLM"),
+            ("gemma2", "Gemma2ForCausalLM"),
+            ("gemma3", "Gemma3ForCausalLM"),
+            ("gemma4", "Gemma4ForCausalLM"),
+            ("glm", "GlmForCausalLM"),
+            ("glm4", "Glm4ForCausalLM"),
+            ("glm4_moe", "Glm4MoeForCausalLM"),
+            ("glm4_moe_lite", "Glm4MoeLiteForCausalLM"),
+            ("glm4_moe_lite_mtp", "Glm4MoeLiteMTP"),
+            ("glm_ocr_mtp", "GlmOcrMTP"),
+            ("gpt2", "GPT2LMHeadModel"),
+            ("gpt_j", "GPTJForCausalLM"),
+            ("gpt_neox", "GPTNeoXForCausalLM"),
+            ("gpt_oss", "GptOssForCausalLM"),
+            ("granite", "GraniteForCausalLM"),
+            ("granitemoe", "GraniteMoeForCausalLM"),
+            ("granitemoeshared", "GraniteMoeSharedForCausalLM"),
+            ("hy_v3", "HYV3ForCausalLM"),
+            ("hyperclovax", "HyperCLOVAXForCausalLM"),
+            ("internlm2", "InternLM2ForCausalLM"),
+            ("jais2", "Jais2ForCausalLM"),
+            ("laguna", "LagunaForCausalLM"),
+            ("llama", "LlamaForCausalLM"),
+            ("llama4", "Llama4ForCausalLM"),
+            ("longcat_flash", "LongcatFlashForCausalLM"),
+            ("longcat_flash_ngram", "LongcatFlashNgramForCausalLM"),
+            ("mellum", "MellumForCausalLM"),
+            ("mimo", "MiMoForCausalLM"),
+            ("mimo_v2", "MiMoV2FlashForCausalLM"),
+            ("mimo_v2", "MiMoV2ForCausalLM"),
+            ("minicpm", "MiniCPMForCausalLM"),
+            ("minicpm3", "MiniCPM3ForCausalLM"),
+            ("minimax_m2", "MiniMaxM2ForCausalLM"),
+            ("mistral", "MistralForCausalLM"),
+            ("mistral_large_3", "MistralLarge3ForCausalLM"),
+            ("mixtral", "MixtralForCausalLM"),
+            ("mpt", "MPTForCausalLM"),
+            ("nemotron", "NemotronForCausalLM"),
+            ("olmo3", "Olmo3ForCausalLM"),
+            ("olmoe", "OlmoeForCausalLM"),
+            ("openpangu", "PanguEmbeddedForCausalLM"),
+            ("openpangu", "PanguProMoEV2ForCausalLM"),
+            ("openpangu", "PanguUltraMoEForCausalLM"),
+            ("opt", "OPTForCausalLM"),
+            ("orion", "OrionForCausalLM"),
+            ("param2moe", "Param2MoEForCausalLM"),
+            ("phi", "PhiForCausalLM"),
+            ("phi3", "Phi3ForCausalLM"),
+            ("phimoe", "PhiMoEForCausalLM"),
+            ("plamo3", "Plamo3ForCausalLM"),
+            ("qwen2", "Qwen2ForCausalLM"),
+            ("qwen2_moe", "Qwen2MoeForCausalLM"),
+            ("qwen3", "Qwen3ForCausalLM"),
+            ("qwen3_moe", "Qwen3MoeForCausalLM"),
+            ("rnj1", "Rnj1ForCausalLM"),
+            ("sarvam", "SarvamMLAForCausalLM"),
+            ("sarvam", "SarvamMoEForCausalLM"),
+            ("seed_oss", "SeedOssForCausalLM"),
+            ("solar", "SolarForCausalLM"),
+            ("stablelm", "StablelmForCausalLM"),
+            ("step1", "Step1ForCausalLM"),
+            ("step3_text", "Step3TextForCausalLM"),
+            ("step3p5", "Step3p5ForCausalLM"),
+            ("telechat2", "TeleChat2ForCausalLM"),
+            ("teleflm", "TeleFLMForCausalLM"),
+            ("transformers", "TransformersForCausalLM"),
+            ("transformers", "TransformersMoEForCausalLM"),
+            ("vllm.models.deepseek_v4", "DeepseekV4ForCausalLM"),
+            ("vllm.models.inkling", "InklingForCausalLM"),
+            ("vllm.models.minimax_m3", "MiniMaxM3SparseForCausalLM"),
+        ),
+    ),
+    (
+        _TEXT_GENERATION,
+        (
+            ("bailing_moe_mtp", "BailingMoeV25MTPModel"),
+            ("cohere_eagle", "EagleCohereForCausalLM"),
+            ("deepseek_eagle", "EagleDeepseekV3ForCausalLM"),
+            ("deepseek_eagle3", "Eagle3DeepseekV2ForCausalLM"),
+            ("deepseek_mtp", "DeepSeekMTP"),
+            ("ernie_mtp", "ErnieMTP"),
+            ("gemma3n", "Gemma3nForCausalLM"),
+            ("gemma4_dspark", "Gemma4DSparkForCausalLM"),
+            ("gemma4_mtp", "Gemma4MTP"),
+            ("glm4_moe_mtp", "Glm4MoeMTP"),
+            ("hrm_text", "HrmTextForCausalLM"),
+            ("iquest_loopcoder", "IQuestLoopCoderForCausalLM"),
+            ("laguna_dflash", "DFlashLagunaForCausalLM"),
+            ("llama4_eagle", "EagleLlama4ForCausalLM"),
+            ("llama_eagle", "EagleLlamaForCausalLM"),
+            ("llama_eagle3", "Eagle3LlamaForCausalLM"),
+            ("mimo_mtp", "MiMoMTP"),
+            ("mimo_v2_mtp", "MiMoV2MTP"),
+            ("minicpm_eagle", "EagleMiniCPMForCausalLM"),
+            ("mistral_eagle", "EagleMistralForCausalLM"),
+            ("mistral_large_3_eagle", "EagleMistralLarge3ForCausalLM"),
+            ("openpangu_mtp", "OpenPanguMTP"),
+            ("qwen3_dflash", "DFlashQwen3ForCausalLM"),
+            ("qwen3_dspark", "Qwen3DSparkForCausalLM"),
+            ("qwen3_eagle3", "Eagle3Qwen3ForCausalLM"),
+            ("qwen3_next_mtp", "Qwen3NextMTP"),
+            ("step3p5_mtp", "Step3p5MTP"),
+            ("vllm.models.deepseek_v4", "DSparkDeepseekV4ForCausalLM"),
+            ("vllm.models.deepseek_v4", "DeepSeekV4MTP"),
+            ("vllm.models.inkling", "InklingMTP"),
+            ("vllm.models.kimi_k3", "KimiK3MTP"),
+            ("vllm.models.kimi_k3.nvidia.dspark_mla", "K3DSparkForCausalLM"),
+            ("vllm.models.minimax_m3", "MiniMaxM3MTP"),
+        ),
+    ),
+    (
+        dict(
+            supports_pp=True,
+        ),
+        (("nemotron_h_mtp", "NemotronHMTP"),),
+    ),
+    (
+        _DEFAULT_PROFILE,
+        (
+            ("exaone_moe_mtp", "ExaoneMoeMTP"),
+            ("extract_hidden_states", "ExtractHiddenStatesModel"),
+            ("gemma3", "Gemma3Model"),
+            ("hy_v3_mtp", "HYV3MTP"),
+            ("longcat_flash_mtp", "LongCatFlashMTP"),
+            ("medusa", "Medusa"),
+            ("voyage", "VoyageQwen3BidirectionalEmbedModel"),
+        ),
+    ),
+)
+
+
+def _build_builtin_model_info_profiles() -> dict[_ModelInfoImplementation, _Profile]:
+    profiles: dict[_ModelInfoImplementation, _Profile] = {}
+    for profile, implementations in _MODEL_INFO_PROFILE_GROUPS:
+        for implementation in implementations:
+            if implementation in profiles:
+                raise RuntimeError(
+                    f"duplicate model info profile for {implementation!r}"
+                )
+            profiles[implementation] = profile
+    return profiles
+
+
+_BUILTIN_MODEL_INFO_PROFILES = _build_builtin_model_info_profiles()
+
+
+def _get_builtin_model_info(module_name: str, class_name: str) -> _Profile | None:
+    module_name = module_name.removeprefix("vllm.model_executor.models.")
+    profile = _BUILTIN_MODEL_INFO_PROFILES.get((module_name, class_name))
+    return None if profile is None else _MODEL_INFO_DEFAULTS | profile

--- a/vllm/model_executor/models/registry.py
+++ b/vllm/model_executor/models/registry.py
@@ -44,6 +44,10 @@ else:
     TokenPoolingType = Any
 
 
+from ._model_info import (
+    _BUILTIN_MODEL_INFO_PROFILES,
+    _get_builtin_model_info,
+)
 from .interfaces import (
     has_inner_state,
     has_noops,
@@ -764,6 +768,9 @@ _VLLM_MODELS = {
     **_TRANSFORMERS_BACKEND_MODELS,
 }
 
+if stale_entries := set(_BUILTIN_MODEL_INFO_PROFILES) - set(_VLLM_MODELS.values()):
+    raise RuntimeError(f"stale model info entries: {sorted(stale_entries)}")
+
 # This variable is used as the args for subprocess.run(). We
 # can modify  this variable to alter the args if needed. e.g.
 # when we use par format to pack things together, sys.executable
@@ -1003,6 +1010,10 @@ class _LazyRegisteredModel(_BaseRegisteredModel):
 
     @logtime(logger=logger, msg="Registry inspect model class")
     def inspect_model_cls(self) -> _ModelInfo:
+        profile = _get_builtin_model_info(self.module_name, self.class_name)
+        if profile is not None:
+            return _ModelInfo(architecture=self.class_name, **profile)
+
         # Modules registered with a non-default location (e.g. the
         # hardware-isolated ``vllm.models.<name>`` layout) live outside
         # ``vllm/model_executor/models``. Resolve the module spec directly


### PR DESCRIPTION
<!-- markdownlint-disable MD013 MD018 MD041 -->

## Purpose

#9233 consolidated model capability inspection into one subprocess per implementation, #23558 added the runtime result cache, and #51746 explored explicit cache preparation. #42770 proposes a future vLLM `ModelConfig` as the single source of truth and explicitly identifies this subprocess cost. This PR is a private bridge for current built-ins, not a competing public metadata API.

Built-in model capability inspection currently resolves each lazy implementation dynamically before the result can be reused. The inspection result contains metadata derived from the model class, not weights or an initialized engine.

This PR adds a private, checked catalog for built-in implementation metadata. It does not add a public API. Plugin registration remains the existing two-argument `ModelRegistry.register_model(model_arch, model_cls)` call and continues to use dynamic inspection.

## Design

The current registry has 383 architecture names backed by 328 unique implementations. Of those implementations, 314 use 55 shared direct profiles. The remaining 14 have no catalog row and use the existing dynamic fallback. A missing row is valid, not an error.

The fallback set includes the divergent Kimi K3 facades and the three new HunYuan implementations. Their metadata remains derived from the loaded class rather than being inferred or copied into an unverified profile.

For a cataloged built-in, `_LazyRegisteredModel.inspect_model_cls()` checks the exact `(module, class)` pair before source resolution, model import, cache lookup, or subprocess inspection. It constructs the existing private `_ModelInfo` result. This changes capability discovery only. Dependency and implementation-loading failures are still deferred to class resolution.

Catalog construction rejects duplicate rows, and registry import rejects rows that no longer correspond to a registered implementation. New or intentionally dynamic implementations continue to work without catalog changes.

## Verification

`test_registry_imports` is parameterized over every supported architecture. Wherever the existing platform and dependency guards permit an import, each direct catalog row independently derives `_ModelInfo` from the loaded class and compares every dataclass field by both value and exact runtime type. This catches stale capability values, tuple/list drift, enum/string drift, and architecture mismatches.

The focused mechanism test makes both the cache and subprocess paths fail if reached, then verifies that a cataloged Qwen implementation is inspected directly. The full local registry suite passed with 382 passed and 20 skipped. Ruff, Python 3.10 mypy, the root lazy-import check, and `git diff --check` also passed on the changed files.

AI assistance was used. I take responsibility for the implementation and compatibility boundary.
