### PR TITLE
[Bugfix] Fall back Mamba cache 'all' mode to 'align' on Model Runner V2 (#52317)

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -31,6 +31,7 @@ from vllm.config.kernel import IrOpPriorityConfig
 from vllm.config.load import LoadConfig
 from vllm.config.utils import get_field
 from vllm.config.vllm import OPTIMIZATION_LEVEL_TO_CONFIG, OptimizationLevel
+from vllm.model_executor.models.config import MambaModelConfig
 from vllm.platforms import current_platform
 from vllm.v1.attention.backend import AttentionCGSupport
 
@@ -1385,6 +1386,53 @@ def test_validate_mamba_align_subblock_prefill():
     )
 
     VllmConfig.validate_block_size(config)
+
+
+def test_mamba_cache_mode_v2_model_runner_fallback():
+    """Verify that mamba_cache_mode='all' falls back to 'align' on MRv2."""
+
+    # Case 1: MRv2 enabled (e.g. dspark spec decode) -> falls back to align
+    vllm_config_v2 = SimpleNamespace(
+        model_config=SimpleNamespace(
+            architecture="NemotronHForCausalLM",
+            supports_mamba_prefix_caching=True,
+            max_model_len=4096,
+        ),
+        cache_config=SimpleNamespace(
+            enable_prefix_caching=True,
+            mamba_cache_mode="all",
+            mamba_block_size=None,
+            block_size=16,
+        ),
+        scheduler_config=SimpleNamespace(
+            enable_chunked_prefill=True,
+        ),
+        use_v2_model_runner=True,
+    )
+    MambaModelConfig.verify_and_update_config(vllm_config_v2)
+    assert vllm_config_v2.cache_config.mamba_cache_mode == "align"
+    assert vllm_config_v2.cache_config.mamba_block_size == 16
+
+    # Case 2: MRv1 with supports_mamba_prefix_caching=True -> preserves 'all'
+    vllm_config_v1 = SimpleNamespace(
+        model_config=SimpleNamespace(
+            architecture="NemotronHForCausalLM",
+            supports_mamba_prefix_caching=True,
+            max_model_len=4096,
+        ),
+        cache_config=SimpleNamespace(
+            enable_prefix_caching=True,
+            mamba_cache_mode="all",
+            mamba_block_size=None,
+            block_size=16,
+        ),
+        scheduler_config=SimpleNamespace(
+            enable_chunked_prefill=True,
+        ),
+        use_v2_model_runner=False,
+    )
+    MambaModelConfig.verify_and_update_config(vllm_config_v1)
+    assert vllm_config_v1.cache_config.mamba_cache_mode == "all"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1388,11 +1388,11 @@ def test_validate_mamba_align_subblock_prefill():
     VllmConfig.validate_block_size(config)
 
 
-def test_mamba_cache_mode_v2_model_runner_fallback():
-    """Verify that mamba_cache_mode='all' falls back to 'align' on MRv2."""
-
-    # Case 1: MRv2 enabled (e.g. dspark spec decode) -> falls back to align
-    vllm_config_v2 = SimpleNamespace(
+def test_mamba_cache_mode_all_falls_back_to_align_on_v2_model_runner():
+    """When Model Runner V2 is active, mamba_cache_mode='all' falls back
+    to 'align' and aligns mamba_block_size to block_size.
+    """
+    vllm_config = SimpleNamespace(
         model_config=SimpleNamespace(
             architecture="NemotronHForCausalLM",
             supports_mamba_prefix_caching=True,
@@ -1409,12 +1409,48 @@ def test_mamba_cache_mode_v2_model_runner_fallback():
         ),
         use_v2_model_runner=True,
     )
-    MambaModelConfig.verify_and_update_config(vllm_config_v2)
-    assert vllm_config_v2.cache_config.mamba_cache_mode == "align"
-    assert vllm_config_v2.cache_config.mamba_block_size == 16
+    MambaModelConfig.verify_and_update_config(vllm_config)
+    assert vllm_config.cache_config.mamba_cache_mode == "align"
+    assert vllm_config.cache_config.mamba_block_size == 16
 
-    # Case 2: MRv1 with supports_mamba_prefix_caching=True -> preserves 'all'
-    vllm_config_v1 = SimpleNamespace(
+
+def test_mamba_cache_mode_verification_is_idempotent_on_repeated_runs():
+    """Running MambaModelConfig.verify_and_update_config multiple times
+    is strictly idempotent and produces identical configuration state.
+    """
+    vllm_config = SimpleNamespace(
+        model_config=SimpleNamespace(
+            architecture="NemotronHForCausalLM",
+            supports_mamba_prefix_caching=True,
+            max_model_len=4096,
+        ),
+        cache_config=SimpleNamespace(
+            enable_prefix_caching=True,
+            mamba_cache_mode="all",
+            mamba_block_size=None,
+            block_size=16,
+        ),
+        scheduler_config=SimpleNamespace(
+            enable_chunked_prefill=True,
+        ),
+        use_v2_model_runner=True,
+    )
+    # First pass
+    MambaModelConfig.verify_and_update_config(vllm_config)
+    assert vllm_config.cache_config.mamba_cache_mode == "align"
+    assert vllm_config.cache_config.mamba_block_size == 16
+
+    # Second pass
+    MambaModelConfig.verify_and_update_config(vllm_config)
+    assert vllm_config.cache_config.mamba_cache_mode == "align"
+    assert vllm_config.cache_config.mamba_block_size == 16
+
+
+def test_mamba_cache_mode_all_is_preserved_on_v1_model_runner_when_supported():
+    """On Model Runner V1, architectures declaring supports_mamba_prefix_caching
+    preserve 'all' mode.
+    """
+    vllm_config = SimpleNamespace(
         model_config=SimpleNamespace(
             architecture="NemotronHForCausalLM",
             supports_mamba_prefix_caching=True,
@@ -1431,8 +1467,34 @@ def test_mamba_cache_mode_v2_model_runner_fallback():
         ),
         use_v2_model_runner=False,
     )
-    MambaModelConfig.verify_and_update_config(vllm_config_v1)
-    assert vllm_config_v1.cache_config.mamba_cache_mode == "all"
+    MambaModelConfig.verify_and_update_config(vllm_config)
+    assert vllm_config.cache_config.mamba_cache_mode == "all"
+
+
+def test_mamba_cache_mode_all_falls_back_to_align_on_v1_when_unsupported():
+    """On Model Runner V1, architectures without supports_mamba_prefix_caching
+    fall back to 'align' mode.
+    """
+    vllm_config = SimpleNamespace(
+        model_config=SimpleNamespace(
+            architecture="MambaForCausalLM",
+            supports_mamba_prefix_caching=False,
+            max_model_len=4096,
+        ),
+        cache_config=SimpleNamespace(
+            enable_prefix_caching=True,
+            mamba_cache_mode="all",
+            mamba_block_size=None,
+            block_size=16,
+        ),
+        scheduler_config=SimpleNamespace(
+            enable_chunked_prefill=True,
+        ),
+        use_v2_model_runner=False,
+    )
+    MambaModelConfig.verify_and_update_config(vllm_config)
+    assert vllm_config.cache_config.mamba_cache_mode == "align"
+    assert vllm_config.cache_config.mamba_block_size == 16
 
 
 @pytest.mark.parametrize(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1388,14 +1388,30 @@ def test_validate_mamba_align_subblock_prefill():
     VllmConfig.validate_block_size(config)
 
 
-def test_mamba_cache_mode_all_falls_back_to_align_on_v2_model_runner():
-    """When Model Runner V2 is active, mamba_cache_mode='all' falls back
-    to 'align' and aligns mamba_block_size to block_size.
+@pytest.mark.parametrize(
+    ("architecture", "supports_prefix_caching", "use_v2_model_runner", "expected_mode"),
+    [
+        ("NemotronHForCausalLM", True, True, "align"),
+        ("NemotronHForCausalLM", True, False, "all"),
+        ("MambaForCausalLM", False, False, "align"),
+    ],
+    ids=[
+        "mrv2_falls_back",
+        "mrv1_supported_keeps_all",
+        "mrv1_unsupported_falls_back",
+    ],
+)
+def test_mamba_cache_mode_all_fallback(
+    architecture, supports_prefix_caching, use_v2_model_runner, expected_mode
+):
+    """Mamba cache mode 'all' falls back to 'align' unless Model Runner V1 is
+    paired with an architecture declaring Mamba prefix caching support. MRv2
+    only implements 'align' state tracking, so it always falls back.
     """
     vllm_config = SimpleNamespace(
         model_config=SimpleNamespace(
-            architecture="NemotronHForCausalLM",
-            supports_mamba_prefix_caching=True,
+            architecture=architecture,
+            supports_mamba_prefix_caching=supports_prefix_caching,
             max_model_len=4096,
         ),
         cache_config=SimpleNamespace(
@@ -1404,97 +1420,15 @@ def test_mamba_cache_mode_all_falls_back_to_align_on_v2_model_runner():
             mamba_block_size=None,
             block_size=16,
         ),
-        scheduler_config=SimpleNamespace(
-            enable_chunked_prefill=True,
-        ),
-        use_v2_model_runner=True,
+        scheduler_config=SimpleNamespace(enable_chunked_prefill=True),
+        use_v2_model_runner=use_v2_model_runner,
     )
-    MambaModelConfig.verify_and_update_config(vllm_config)
-    assert vllm_config.cache_config.mamba_cache_mode == "align"
-    assert vllm_config.cache_config.mamba_block_size == 16
 
-
-def test_mamba_cache_mode_verification_is_idempotent_on_repeated_runs():
-    """Running MambaModelConfig.verify_and_update_config multiple times
-    is strictly idempotent and produces identical configuration state.
-    """
-    vllm_config = SimpleNamespace(
-        model_config=SimpleNamespace(
-            architecture="NemotronHForCausalLM",
-            supports_mamba_prefix_caching=True,
-            max_model_len=4096,
-        ),
-        cache_config=SimpleNamespace(
-            enable_prefix_caching=True,
-            mamba_cache_mode="all",
-            mamba_block_size=None,
-            block_size=16,
-        ),
-        scheduler_config=SimpleNamespace(
-            enable_chunked_prefill=True,
-        ),
-        use_v2_model_runner=True,
-    )
-    # First pass
-    MambaModelConfig.verify_and_update_config(vllm_config)
-    assert vllm_config.cache_config.mamba_cache_mode == "align"
-    assert vllm_config.cache_config.mamba_block_size == 16
-
-    # Second pass
-    MambaModelConfig.verify_and_update_config(vllm_config)
-    assert vllm_config.cache_config.mamba_cache_mode == "align"
-    assert vllm_config.cache_config.mamba_block_size == 16
-
-
-def test_mamba_cache_mode_all_is_preserved_on_v1_model_runner_when_supported():
-    """On Model Runner V1, architectures declaring supports_mamba_prefix_caching
-    preserve 'all' mode.
-    """
-    vllm_config = SimpleNamespace(
-        model_config=SimpleNamespace(
-            architecture="NemotronHForCausalLM",
-            supports_mamba_prefix_caching=True,
-            max_model_len=4096,
-        ),
-        cache_config=SimpleNamespace(
-            enable_prefix_caching=True,
-            mamba_cache_mode="all",
-            mamba_block_size=None,
-            block_size=16,
-        ),
-        scheduler_config=SimpleNamespace(
-            enable_chunked_prefill=True,
-        ),
-        use_v2_model_runner=False,
-    )
-    MambaModelConfig.verify_and_update_config(vllm_config)
-    assert vllm_config.cache_config.mamba_cache_mode == "all"
-
-
-def test_mamba_cache_mode_all_falls_back_to_align_on_v1_when_unsupported():
-    """On Model Runner V1, architectures without supports_mamba_prefix_caching
-    fall back to 'align' mode.
-    """
-    vllm_config = SimpleNamespace(
-        model_config=SimpleNamespace(
-            architecture="MambaForCausalLM",
-            supports_mamba_prefix_caching=False,
-            max_model_len=4096,
-        ),
-        cache_config=SimpleNamespace(
-            enable_prefix_caching=True,
-            mamba_cache_mode="all",
-            mamba_block_size=None,
-            block_size=16,
-        ),
-        scheduler_config=SimpleNamespace(
-            enable_chunked_prefill=True,
-        ),
-        use_v2_model_runner=False,
-    )
-    MambaModelConfig.verify_and_update_config(vllm_config)
-    assert vllm_config.cache_config.mamba_cache_mode == "align"
-    assert vllm_config.cache_config.mamba_block_size == 16
+    # Verification must be idempotent: repeated runs converge on the same state.
+    for _ in range(2):
+        MambaModelConfig.verify_and_update_config(vllm_config)
+        assert vllm_config.cache_config.mamba_cache_mode == expected_mode
+        assert vllm_config.cache_config.mamba_block_size == 16
 
 
 @pytest.mark.parametrize(

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -2373,13 +2373,6 @@ class VllmConfig:
         model_config = self.model_config
         speculative_config = self.speculative_config
 
-        if (
-            model_config is not None
-            and getattr(model_config, "is_hybrid", False)
-            and self.cache_config.mamba_cache_mode == "all"
-        ):
-            unsupported.append("Mamba cache 'all' mode")
-
         if self.parallel_config.prefill_context_parallel_size > 1 and not (
             model_config is not None and model_config.use_mla
         ):

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -2373,6 +2373,13 @@ class VllmConfig:
         model_config = self.model_config
         speculative_config = self.speculative_config
 
+        if (
+            model_config is not None
+            and getattr(model_config, "is_hybrid", False)
+            and self.cache_config.mamba_cache_mode == "all"
+        ):
+            unsupported.append("Mamba cache 'all' mode")
+
         if self.parallel_config.prefill_context_parallel_size > 1 and not (
             model_config is not None and model_config.use_mla
         ):

--- a/vllm/model_executor/models/config.py
+++ b/vllm/model_executor/models/config.py
@@ -608,16 +608,20 @@ class MambaModelConfig(VerifyAndUpdateConfig):
                     cache_config.mamba_cache_mode,
                     model_config.architecture,
                 )
-            if (
-                cache_config.mamba_cache_mode == "all"
-                and not model_config.supports_mamba_prefix_caching
-            ):
-                cache_config.mamba_cache_mode = "align"
-                logger.warning(
-                    "Hybrid or mamba-based model detected without support "
-                    "for prefix caching with Mamba cache 'all' mode: "
-                    "falling back to 'align' mode."
-                )
+            if cache_config.mamba_cache_mode == "all":
+                if vllm_config.use_v2_model_runner:
+                    cache_config.mamba_cache_mode = "align"
+                    logger.warning(
+                        "Model Runner V2 only supports Mamba cache 'align' mode "
+                        "for prefix caching: falling back to 'align' mode."
+                    )
+                elif not model_config.supports_mamba_prefix_caching:
+                    cache_config.mamba_cache_mode = "align"
+                    logger.warning(
+                        "Hybrid or mamba-based model detected without support "
+                        "for prefix caching with Mamba cache 'all' mode: "
+                        "falling back to 'align' mode."
+                    )
             if cache_config.mamba_cache_mode == "align":
                 assert vllm_config.scheduler_config.enable_chunked_prefill, (
                     "Chunked prefill is required for mamba cache mode 'align'."


### PR DESCRIPTION
## Purpose
Fixes #52317

When running hybrid Mamba models like `nvidia/Nemotron-H-4B-Base-8K` with prefix caching and `--mamba-cache-mode all` under configurations that trigger Model Runner V2 (such as DSpark/DFlash speculative decoding or Context Parallelism), vLLM crashes on startup during warmup:

```
File "vllm/model_executor/layers/mamba/mamba_mixer2.py", line 990, in _forward_core
    assert block_idx_last_scheduled_token_prev_step_d is not None
AssertionError
```

### Why this happens
- In Model Runner V1, Mamba prefix caching in `"all"` mode works by having the runner allocate and pass `block_idx_last_scheduled_token_prev_step_d` down to the mixer layers.
- Model Runner V2 (`GPUModelRunnerV2`) only implements `_align_mode` Mamba state tracking (`vllm/v1/worker/gpu/model_states/mamba_hybrid.py`) and does not construct `block_idx_last_scheduled_token_prev_step_d`.
- In `MambaModelConfig.verify_and_update_config`, we only checked if the model architecture supported prefix caching (`model_config.supports_mamba_prefix_caching`). Since Nemotron-H supports it on MRv1, it passed validation, but when MRv2 was selected by the engine, the missing tensor caused an assertion failure at runtime.

### What this PR does
1. **Fallback in `MambaModelConfig`**: In `vllm/model_executor/models/config.py`, check `vllm_config.use_v2_model_runner`. When MRv2 is active and `mamba_cache_mode == "all"`, fall back to `"align"` mode with a warning. On MRv1, `"all"` mode is preserved for supported models.
2. **Unit test suite**: Added unit tests in `tests/test_config.py` verifying MRv2 fallback, verification idempotency, and MRv1 preservation.

---

### Update
- **MRv2 Behavior**: Automatically falls back `mamba_cache_mode="all"` → `"align"` mode (logging an informative warning) since MRv2 only implements `_align_mode` state tracking and does not construct `block_idx_last_scheduled_token_prev_step_d`.
- **MRv1 Behavior**: Retains `"all"` mode behavior as-is for supported hybrid models (e.g. `Nemotron-H`), keeping existing V1 prefix caching fully intact.

## Test Plan

- **Unit tests**:
  ```bash
  pytest tests/test_config.py -k "test_mamba_cache_mode or test_validate_mamba" -v
  ```
- **Linting**:
  ```bash
  pre-commit run --files vllm/model_executor/models/config.py tests/test_config.py --hook-stage manual
  ```
- **End-to-End Verification (4x A100 GPUs)**:
  Reproduced the crash and verified the fix by starting `nvidia/Nemotron-H-4B-Base-8K` with DSpark speculative decoding:
  ```bash
  vllm serve nvidia/Nemotron-H-4B-Base-8K \
    --enable-prefix-caching \
    --mamba-cache-mode all \
    --speculative-config '{"method":"dspark", "draft_model":"nvidia/Nemotron-H-4B-Base-8K", "num_speculative_tokens": 1}' \
    --tensor-parallel-size 4
  ```

## Test Result

- `pytest tests/test_config.py -k "test_mamba_cache_mode or test_validate_mamba"`:
  ```
  tests/test_config.py::test_validate_mamba_align_subblock_prefill PASSED
  tests/test_config.py::test_mamba_cache_mode_all_fallback[mrv2_falls_back] PASSED
  tests/test_config.py::test_mamba_cache_mode_all_fallback[mrv1_supported_keeps_all] PASSED
  tests/test_config.py::test_mamba_cache_mode_all_fallback[mrv1_unsupported_falls_back] PASSED
  ================ 4 passed, 188 deselected in 4.18s ================
  ```
- `pre-commit run --hook-stage manual` on both changed files: all hooks pass, including `ruff check`, `ruff format`, `typos`, and `mypy` for Python 3.10–3.13.
- End-to-end server: confirmed warning `Model Runner V2 only supports Mamba cache 'align' mode for prefix caching: falling back to 'align' mode.` is logged and server finishes warmup and handles inference without crashing.

---
<sub>*AI assistance was used for drafting unit test cases and code review.*</sub>