### PR TITLE
feat: use safetensors prefetch

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -10,7 +10,7 @@ py-cpuinfo
 transformers >= 5.5.3
 huggingface_hub >= 1.28.0
 tokenizers >= 0.21.1  # Required for fast incremental detokenization.
-safetensors >= 0.6.2  # MXFP4/MXFP6 dtype support (F8_E8M0, F4) added in 0.6.0: https://github.com/huggingface/safetensors/pull/611
+safetensors @ git+https://github.com/huggingface/safetensors@poc/prefetch_cuda_fast_path#subdirectory=bindings/python
 protobuf >= 5.29.6, !=6.30.*, !=6.31.*, !=6.32.*, !=6.33.0.*, !=6.33.1.*, !=6.33.2.*, !=6.33.3.*, !=6.33.4.* # Required by LlamaTokenizer, gRPC. CVE-2026-0994
 fastapi[standard] >= 0.133.0, < 0.137.0 # First version supporting Starlette 1.0; < 0.137.0 avoids route-tree change that breaks model-hosting-container-standards handler overrides.
 starlette >= 1.0.1 # CVE-2026-48710: Host header injection in < 1.0.1

--- a/vllm/model_executor/model_loader/default_loader.py
+++ b/vllm/model_executor/model_loader/default_loader.py
@@ -33,6 +33,7 @@ from vllm.model_executor.model_loader.weight_utils import (
     np_cache_weights_iterator,
     pt_weights_iterator,
     safetensors_weights_iterator,
+    st_prefetch_safetensors_weights_iterator,
 )
 from vllm.tracing import instrument
 from vllm.transformers_utils.repo_utils import list_filtered_repo_files
@@ -85,6 +86,7 @@ class DefaultModelLoader(BaseModelLoader):
             "enable_multithread_load",
             "num_threads",
             "enable_weights_track",
+            "st_load_mode",
         }
         unexpected_keys = set(extra_config.keys()) - allowed_keys
 
@@ -112,6 +114,22 @@ class DefaultModelLoader(BaseModelLoader):
         self.enable_weights_track: bool | None = extra_config.get(
             "enable_weights_track", None
         )
+
+        st_load_mode = extra_config.get("st_load_mode")
+        if st_load_mode not in (None, "prefetch"):
+            raise ValueError(f"st_load_mode must be 'prefetch', got {st_load_mode!r}")
+        if st_load_mode and enable_multithread_load:
+            raise ValueError(
+                "st_load_mode and enable_multithread_load are mutually exclusive"
+            )
+        if st_load_mode and load_config.safetensors_load_strategy not in (
+            None,
+            "lazy",
+        ):
+            raise ValueError(
+                "st_load_mode does not support safetensors_load_strategy="
+                f"{load_config.safetensors_load_strategy!r}"
+            )
 
         # The multi-thread loader ignores safetensors_load_strategy, so reject
         # the combination instead of silently dropping the requested strategy.
@@ -271,6 +289,11 @@ class DefaultModelLoader(BaseModelLoader):
                 )
             elif self.load_config.load_format == "instanttensor":
                 weights_iterator = instanttensor_weights_iterator(
+                    hf_weights_files,
+                    self.load_config.use_tqdm_on_load,
+                )
+            elif extra_config.get("st_load_mode") == "prefetch":
+                weights_iterator = st_prefetch_safetensors_weights_iterator(
                     hf_weights_files,
                     self.load_config.use_tqdm_on_load,
                 )

--- a/vllm/model_executor/model_loader/weight_utils.py
+++ b/vllm/model_executor/model_loader/weight_utils.py
@@ -14,7 +14,7 @@ import threading
 import time
 from collections import defaultdict
 from collections.abc import Callable, Generator, Iterable
-from contextlib import contextmanager
+from contextlib import ExitStack, contextmanager
 from pathlib import Path
 from typing import IO, Any
 
@@ -991,6 +991,55 @@ def multi_thread_safetensors_weights_iterator(
             del future
             for key in list(state_dict):
                 yield key, state_dict.pop(key)
+
+
+def st_prefetch_safetensors_weights_iterator(
+    hf_weights_files: list[str],
+    use_tqdm_on_load: bool,
+) -> Generator[tuple[str, torch.Tensor], None, None]:
+    """Stream whole shards to the current GPU via safetensors' CUDA prefetch.
+
+    All shards are opened upfront so reads pipeline across files, bounded by
+    safetensors' in-flight budget; tensors are yielded in completion order and
+    freed by the weight loaders as they copy their slices out. Ranks start at
+    different files so their cold-cache reads do not collide.
+    """
+    device_str = f"cuda:{current_platform.current_device()}"
+    sorted_files = sorted(hf_weights_files, key=_natural_sort_key)
+    if torch.distributed.is_available() and torch.distributed.is_initialized():
+        world_size = torch.distributed.get_world_size()
+        if world_size > 1 and len(sorted_files) > 1:
+            start = torch.distributed.get_rank() * len(sorted_files) // world_size
+            sorted_files = sorted_files[start:] + sorted_files[:start]
+    with ExitStack() as stack:
+        try:
+            handles = [
+                stack.enter_context(
+                    safe_open(
+                        st_file,
+                        framework="pt",
+                        device=device_str,
+                        backend="pread",
+                        prefetch=True,
+                    )
+                )
+                for st_file in sorted_files
+            ]
+        except TypeError as err:
+            raise RuntimeError(
+                'st_load_mode="prefetch" needs a safetensors build with the CUDA '
+                "prefetch API, which is not released yet. Install it with: "
+                "pip install 'safetensors @ git+https://github.com/huggingface/"
+                "safetensors@poc/prefetch_cuda_fast_path#subdirectory="
+                "bindings/python' (builds from source, needs a Rust toolchain)."
+            ) from err
+        for f in tqdm(
+            handles,
+            desc="Loading safetensors (CUDA prefetch)",
+            disable=not enable_tqdm(use_tqdm_on_load),
+            bar_format=_BAR_FORMAT,
+        ):
+            yield from f.tensor_stream()
 
 
 def runai_safetensors_weights_iterator(


### PR DESCRIPTION
Sister PR: https://github.com/safetensors/safetensors/pull/827

## Purpose

Integrate the new safetensors prefetch API. This is a PoC atm, but performance is promising.

#### benchmark setup

  4×H100-80GB, local NVMe (8-drive LVM stripe). `load_weights` seconds from the server
  startup log. Page cache evicted before every round via `posix_fadvise(DONTNEED)`,
  verified with `fincore`; values are the mean of 2 reps (rep-to-rep spread < 3%).

#### results

  | Model | Arch | GB | Tensors | TP | prefetch cold | fastsafetensors cold | prefetch warm | fastsafetensors warm |
  |---|---|---|---|---|---|---|---|---|
  | Qwen2.5-0.5B-Instruct | dense bf16 | 1.0 | 290 | 1 | 0.52 | 0.98 | 0.34 | 0.67 |
  | Qwen2.5-0.5B-Instruct | dense bf16 | 1.0 | 290 | 2 | 0.58 | 0.94 | 0.34 | 0.69 |
  | Qwen2.5-14B-Instruct | dense bf16 | 29.5 | 579 | 1 | 8.06 | 15.11 | 2.34 | 5.54 |
  | Qwen2.5-14B-Instruct | dense bf16 | 29.5 | 579 | 4 | 4.67 | 4.41 | 4.15 | 1.70 |
  | Qwen2.5-32B-Instruct | dense bf16 | 65.5 | 771 | 2 | 8.75 | 16.90 | 5.13 | 6.04 |
  | Qwen2.5-32B-Instruct | dense bf16 | 65.5 | 771 | 4 | 9.29 | 9.60 | 8.79 | 3.65 |
  | Qwen2.5-72B-Instruct | dense bf16 | 145.4 | 963 | 4 | 20.21 | 22.42 | 23.21 | 8.51 |
  | Qwen3-30B-A3B | MoE bf16 | 61.1 | 18867 | 1 | 13.43 | 32.05 | 4.57 | 12.36 |
  | Qwen3-30B-A3B | MoE bf16 | 61.1 | 18867 | 4 | 8.55 | 10.27 | 8.44 | 7.27 |
  | Qwen3-30B-A3B-FP4 | MoE NVFP4 | 18.1 | 74835 | 1 | 9.49 | 15.52 | 9.53 | 13.81 |
  | Qwen3-30B-A3B-FP4 | MoE NVFP4 | 18.1 | 74835 | 4 | 9.81 | 25.07 | 10.22 | 24.29 |
  | Qwen3-235B-A22B-FP8 | MoE FP8 | 239.0 | 73417 | 4 | 35.76 | 36.88 | 41.68 | 27.97 |

