### PR TITLE
[Bugfix] Keep every reasoning block in the Muse Glimmer parser

### DIFF
--- a/tests/reasoning/test_muse_glimmer_reasoning_parser.py
+++ b/tests/reasoning/test_muse_glimmer_reasoning_parser.py
@@ -1,0 +1,84 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from unittest.mock import Mock
+
+import pytest
+
+from tests.reasoning.utils import run_reasoning_extraction
+from vllm.reasoning.muse_glimmer_reasoning_parser import MuseGlimmerReasoningParser
+
+TURN = "<|start|>assistant "
+OPEN = "to=self<|message|>"
+EOM = "<|eom|>"
+
+# A single truncated block: unaffected by the multi-block handling, kept as a
+# control so the fix cannot regress the common shape.
+SINGLE_BLOCK_TRUNCATED = {
+    "output": f" {OPEN}Only thought",
+    "reasoning": "Only thought",
+    "content": None,
+}
+TWO_BLOCKS_CLOSED = {
+    "output": f" {OPEN}First thought{EOM}{TURN}{OPEN}Second thought{EOM}",
+    "reasoning": "First thought\nSecond thought",
+    "content": None,
+}
+TWO_BLOCKS_LAST_TRUNCATED = {
+    "output": f" {OPEN}First thought{EOM}{TURN}{OPEN}Second thought",
+    "reasoning": "First thought\nSecond thought",
+    "content": None,
+}
+THREE_BLOCKS_LAST_TRUNCATED = {
+    "output": f" {OPEN}A{EOM}{TURN}{OPEN}B{EOM}{TURN}{OPEN}C",
+    "reasoning": "A\nB\nC",
+    "content": None,
+}
+
+TEST_CASES = [
+    SINGLE_BLOCK_TRUNCATED,
+    TWO_BLOCKS_CLOSED,
+    TWO_BLOCKS_LAST_TRUNCATED,
+    THREE_BLOCKS_LAST_TRUNCATED,
+]
+TEST_IDS = [
+    "single_block_truncated",
+    "two_blocks_closed",
+    "two_blocks_last_truncated",
+    "three_blocks_last_truncated",
+]
+
+
+def _parser() -> MuseGlimmerReasoningParser:
+    # The parser works on decoded text, so the tokenizer is only needed to
+    # satisfy the streaming helper.
+    tokenizer = Mock()
+    tokenizer.get_vocab.return_value = {}
+    tokenizer.tokenize.return_value = []
+    return MuseGlimmerReasoningParser(tokenizer)
+
+
+@pytest.mark.parametrize("streaming", [True, False], ids=["streaming", "nonstreaming"])
+@pytest.mark.parametrize("case", TEST_CASES, ids=TEST_IDS)
+def test_multiple_reasoning_blocks(case: dict, streaming: bool):
+    """Every to=self block survives, in both modes and with either framing.
+
+    Generation that stops inside a later block used to return only that block,
+    and the streaming path used to glue consecutive blocks together with no
+    separator.
+    """
+    reasoning, content = run_reasoning_extraction(
+        _parser(), [case["output"]], streaming=streaming
+    )
+    assert reasoning == case["reasoning"]
+    assert content == case["content"]
+
+
+@pytest.mark.parametrize("case", TEST_CASES, ids=TEST_IDS)
+def test_multiple_reasoning_blocks_token_by_token(case: dict):
+    """The streamed result must not depend on where the deltas land."""
+    reasoning, content = run_reasoning_extraction(
+        _parser(), list(case["output"]), streaming=True
+    )
+    assert reasoning == case["reasoning"]
+    assert content == case["content"]

--- a/vllm/reasoning/muse_glimmer_reasoning_parser.py
+++ b/vllm/reasoning/muse_glimmer_reasoning_parser.py
@@ -224,7 +224,10 @@ class MuseGlimmerReasoningParser(ReasoningParser):
                 pos = body_end + len(_EOM if body_end == eom else _EOT)
             else:
                 pos = body_end
-        return "".join(reasoning_parts), "".join(content_parts)
+        # Consecutive to=self blocks are separate thoughts, so join them the
+        # way extract_reasoning does. Concatenating them glued the last word of
+        # one block to the first word of the next.
+        return "\n".join(reasoning_parts), "".join(content_parts)
 
     def get_streaming_fallback_content(
         self,
@@ -252,7 +255,12 @@ class MuseGlimmerReasoningParser(ReasoningParser):
         # there is no closing <|eom|>. Bounded at the next channel header so a
         # real tool call that follows a header-less channel switch is not
         # absorbed into the reasoning field.
-        open_match = _OPEN_REASONING_RE.search(model_output)
+        #
+        # Search the COLLAPSED text, not model_output: collapsing consumes the
+        # <|eom|> that closed each earlier block, so on model_output the only
+        # span without a terminator is the last one and every completed block
+        # before it is dropped.
+        open_match = _OPEN_REASONING_RE.search(collapsed)
         if open_match and open_match.group(1):
             partial = open_match.group(1)
             reasoning = f"{reasoning}\n{partial}" if reasoning else partial


### PR DESCRIPTION
## Purpose

The Muse Glimmer reasoning parser loses reasoning content when a turn contains more than one `to=self` block, and its streaming and non-streaming paths disagree about the same generation.

**1. Completed reasoning blocks are dropped when generation is truncated.**

In `extract_reasoning`, the closed-block match runs on `collapsed` but the truncation fallback one line later runs on `model_output`:

```python
collapsed = _COLLAPSE_RE.sub("\n", model_output)
matches = _REASONING_RE.findall(collapsed)
reasoning = "\n".join(matches) if matches else None
open_match = _OPEN_REASONING_RE.search(model_output)   # different string
```

`_COLLAPSE_RE` rewrites the gap between consecutive reasoning blocks to a newline, which consumes the `<|eom|>` that closed each earlier block. So when the last block is unterminated (max_tokens, abort), the merged span has no `<|eom|>` at all, `_REASONING_RE` matches nothing, and `reasoning` is `None`. The fallback then searches the un-collapsed text, where the only span satisfying the `(?=header|$)` lookahead is the last, still-open block. With three blocks A/B/C truncated inside C, the client receives `"C"` and A and B are gone.

Searching `collapsed` in the fallback too makes both statements read the same string. When the second block is empty (the header arrived but no body yet) the old code returned no reasoning at all; it now returns the first block.

**2. Streaming glues consecutive blocks together.**

`_classify_bodies` returns `"".join(reasoning_parts)`, so the streamed reasoning for two blocks is `"First thoughtSecond thought"` while the non-streaming path returns `"First thought\nSecond thought"`. Same generation, two different answers depending on `stream`. The non-streaming path inserts the separator deliberately in two places (the `_COLLAPSE_RE` comment says "Collapse the gap between reasoning blocks so multiple to=self spans join", and `reasoning = "\n".join(matches)`), and multiple interleaved `to=self` blocks are an explicitly supported shape per the module docstring, so the streaming side is the one that is wrong.

This stays monotone for the incremental cursor in `extract_reasoning_streaming`: when a new `to=self` header completes, its body is initially empty, so the classified reasoning grows from `"First thought"` to `"First thought\n"`. That is still a prefix-extension, the `curr_reason.startswith(self._emitted_reasoning)` guard holds, and the separator goes out as a normal delta.

Both fixes are needed for the two paths to agree: fixing only the truncation bug would leave non-streaming returning `"A\nB\nC"` where streaming returns `"ABC"`.

## Test Plan

New `tests/reasoning/test_muse_glimmer_reasoning_parser.py` (the parser had no test file). It uses the existing `tests/reasoning/utils.py` helper and covers four shapes, each in streaming and non-streaming mode, plus a token-by-token streaming variant so the result cannot depend on where the deltas land:

- `single_block_truncated`, unaffected by this change, included as a control
- `two_blocks_closed`
- `two_blocks_last_truncated`
- `three_blocks_last_truncated`

```
pytest tests/reasoning/test_muse_glimmer_reasoning_parser.py
```

## Test Result

12 passed after the change. Before it, 8 of the 12 fail:

```
FAILED test_multiple_reasoning_blocks[two_blocks_closed-streaming]
FAILED test_multiple_reasoning_blocks[two_blocks_last_truncated-streaming]
FAILED test_multiple_reasoning_blocks[two_blocks_last_truncated-nonstreaming]
FAILED test_multiple_reasoning_blocks[three_blocks_last_truncated-streaming]
FAILED test_multiple_reasoning_blocks[three_blocks_last_truncated-nonstreaming]
FAILED test_multiple_reasoning_blocks_token_by_token[two_blocks_closed]
FAILED test_multiple_reasoning_blocks_token_by_token[two_blocks_last_truncated]
FAILED test_multiple_reasoning_blocks_token_by_token[three_blocks_last_truncated]
8 failed, 4 passed
```

Shapes checked for no change, before and after: single open block, both blocks closed followed by a `to=user` answer, reasoning followed by a tool call, answer only, and unframed text. All byte-identical. `ruff check` and `ruff format` report no new findings against a pristine-tree control.

This is text-level parser correctness on CPU, so no model evaluation was needed.

AI assistance was used in preparing this change.
