### PR TITLE
[Perf] Scale num_warps with tile size in Triton reshape-and-cache kernels

### DIFF
--- a/tests/kernels/attention/test_cache.py
+++ b/tests/kernels/attention/test_cache.py
@@ -44,6 +44,9 @@ KV_CACHE_DTYPE = ["auto", "fp8"]
 
 RESHAPE_FLASH_IMPLEMENTATIONS = ["cuda", "triton"]
 
+# (head_size_k, head_size_v); 192/128 is the MiMo-V2 shape.
+DIFFKV_HEAD_SIZES = [(192, 128), (128, 128), (64, 64)]
+
 
 @pytest.mark.parametrize("num_tokens", NUM_TOKENS)
 @pytest.mark.parametrize("num_heads", NUM_HEADS)
@@ -424,6 +427,115 @@ def test_reshape_and_cache_flash(
     else:
         torch.testing.assert_close(key_cache_compact, cloned_key_cache)
         torch.testing.assert_close(value_cache_compact, cloned_value_cache)
+
+
+@pytest.mark.parametrize("num_tokens", NUM_TOKENS)
+@pytest.mark.parametrize("num_heads", NUM_HEADS)
+@pytest.mark.parametrize("head_sizes", DIFFKV_HEAD_SIZES)
+@pytest.mark.parametrize("block_size", BLOCK_SIZES)
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("seed", SEEDS)
+@pytest.mark.parametrize("device", CUDA_DEVICES)
+@pytest.mark.parametrize("kv_cache_dtype", KV_CACHE_DTYPE)
+@torch.inference_mode()
+def test_triton_reshape_and_cache_flash_diffkv(
+    num_tokens: int,
+    num_heads: int,
+    head_sizes: tuple[int, int],
+    block_size: int,
+    dtype: torch.dtype,
+    seed: int,
+    device: str,
+    kv_cache_dtype: str,
+) -> None:
+    """Key and value land in their own halves of the shared DiffKV cache row.
+
+    The DiffKV kernel packs both projections into one
+    [num_blocks, block_size, num_heads, head_size_k + head_size_v] tensor, so a
+    wrong tile bound writes value bytes over key bytes (or past the row) rather
+    than failing loudly, and a padded token can scribble on a live slot.
+    Nothing else in the suite covers it.
+    """
+    from vllm.v1.attention.ops.triton_reshape_and_cache_flash import (
+        triton_reshape_and_cache_flash_diffkv,
+    )
+
+    head_size_k, head_size_v = head_sizes
+    if kv_cache_dtype == "fp8" and not current_platform.has_device_capability(89):
+        pytest.skip("Triton fp8 KV cache needs native fp8e4nv (SM89+).")
+
+    set_random_seed(seed)
+    torch.set_default_device(device)
+    torch.accelerator.set_device_index(device)
+
+    num_blocks = 128
+    num_slots = block_size * num_blocks
+    slot_mapping_lst = random.sample(range(num_slots), num_tokens)
+    # Padded tokens carry slot -1 and must leave the cache untouched; the
+    # whole-tensor comparison below is what catches a stray write.
+    slot_mapping_lst[-2:] = [-1, -1]
+    slot_mapping = torch.tensor(slot_mapping_lst, dtype=torch.long, device=device)
+
+    key = torch.randn(num_tokens, num_heads, head_size_k, dtype=dtype, device=device)
+    value = torch.randn(num_tokens, num_heads, head_size_v, dtype=dtype, device=device)
+    k_scale = (key.amax() / 64.0).to(torch.float32)
+    v_scale = (value.amax() / 64.0).to(torch.float32)
+
+    cache_dtype = current_platform.fp8_dtype() if kv_cache_dtype == "fp8" else dtype
+    kv_cache = torch.randn(
+        num_blocks,
+        block_size,
+        num_heads,
+        head_size_k + head_size_v,
+        dtype=torch.float32,
+        device=device,
+    ).to(cache_dtype)
+
+    def dequant(x: torch.Tensor) -> torch.Tensor:
+        """Each half of the row carries its own scale, so dequantize halves."""
+        if kv_cache_dtype != "fp8":
+            return x.clone()
+        halves = [
+            scaled_dequantize(
+                half.flatten(0, 2).contiguous(),
+                scale,
+                group_shape=None,
+                out_dtype=torch.float16,
+            ).reshape(half.shape)
+            for half, scale in (
+                (x[..., :head_size_k], k_scale),
+                (x[..., head_size_k:], v_scale),
+            )
+        ]
+        return torch.cat(halves, dim=-1)
+
+    # Reference: the unquantized rows written into a dequantized copy, then
+    # compared against the dequantized kernel result (same pattern as
+    # test_reshape_and_cache_flash).
+    expected = dequant(kv_cache)
+
+    triton_reshape_and_cache_flash_diffkv(
+        key,
+        value,
+        kv_cache,
+        slot_mapping,
+        kv_cache_dtype,
+        k_scale,
+        v_scale,
+    )
+
+    for i, slot in enumerate(slot_mapping_lst):
+        if slot < 0:
+            continue
+        block_idx, block_offset = slot // block_size, slot % block_size
+        expected[block_idx, block_offset, :, :head_size_k] = key[i]
+        expected[block_idx, block_offset, :, head_size_k:] = value[i]
+
+    result = dequant(kv_cache)
+    if kv_cache_dtype == "fp8":
+        torch.testing.assert_close(result, expected, atol=0.001, rtol=0.1)
+    else:
+        torch.testing.assert_close(result, expected)
 
 
 @torch.inference_mode()

--- a/vllm/v1/attention/ops/triton_reshape_and_cache_flash.py
+++ b/vllm/v1/attention/ops/triton_reshape_and_cache_flash.py
@@ -420,9 +420,10 @@ def triton_reshape_and_cache_flash(
         num_warps = 8
     else:  # cuda
         num_stages = 10
-        num_warps = 16
         if torch.cuda.get_device_capability(key.device)[0] < 9:
             TILE_SIZE = min(512, TILE_SIZE)
+        # Use only the warps this tile needs, capped at the previous 16.
+        num_warps = min(16, max(1, TILE_SIZE // 32))
 
     # TODO(ngl): maybe replace with static launch grid to avoid overhead if
     #   using cudagraphs
@@ -578,7 +579,8 @@ def triton_reshape_and_cache_flash_diffkv(
         num_warps = 8
     else:  # cuda
         num_stages = 10
-        num_warps = 16
+        # Use only the warps this tile needs, capped at the previous 16.
+        num_warps = min(16, max(1, TILE_SIZE // 32))
 
     # TODO(ngl): maybe replace with static launch grid to avoid overhead if
     #   using cudagraphs


### PR DESCRIPTION
## Purpose

Both CUDA launch sites in `triton_reshape_and_cache_flash.py` hardcode `num_warps = 16` (512 threads) regardless of tile size. When the tile is smaller, the surplus warps hold thread slots without doing work, which limits how many blocks stay resident on an SM. `_reshape_cache_per_token_head` in the same file already derives the count from the shape — `min(16, max(1, head_size_padded // 32))` — and so does the CUDA version (`dim3 block(std::min(num_heads * head_size, 512))`). This applies that rule at the two remaining sites.

Only the launch geometry changes; the kernels write the same bytes to the same slots. Tiles of 512 elements or more still get 16 warps, so the shapes the original benchmarks covered are unaffected. ROCm and XPU take a separate branch and are untouched.

## Test plan

```
pytest tests/kernels/attention/test_cache.py -k diffkv
python benchmarks/kernels/benchmark_reshape_and_cache_flash.py --implementation triton --mode cudagraph --num-heads 2 --head-size 64
```

The DiffKV kernel had no direct coverage, so the new test checks against a PyTorch reference that key and value land in their own halves of the packed cache row — three `(head_size_k, head_size_v)` pairs, three block sizes, two dtypes, both cache dtypes — and that padded tokens leave the cache untouched. `--num-heads 8 --head-size 64` gives n = 512, where both versions launch identically, so that row is the control.

## Test result

18 tests pass on an A100 on both the patched and the unpatched kernel (18 more skip below SM89, where the Triton fp8 path is unsupported).

Kernel latency on an A100-SXM4-80GB, median of 5 repetitions alternating patched and unpatched, CUDA graph mode. Negative means faster. Rows are labelled by `n = num_kv_heads * head_size`, which sets `TILE_SIZE`.

| config | 1024 tok | 4096 | 16384 | 65536 |
|---|---|---|---|---|
| n=512 (control) | −0.6% | +0.2% | +0.3% | −0.05% |
| n=256 | −11.2% | −26.0% | −33.5% | −45.1% |
| n=128 | −10.6% | −29.6% | −50.9% | −67.7% |
| n=64 | −9.2% | −27.3% | −49.1% | −73.0% |
| DiffKV 192/128 (MiMo-V2 shape) | −29.8% | −40.9% | −44.6% | −47.1% |
| DiffKV 256/256 | −31.9% | −41.5% | −45.2% | −46.2% |

Below ~1000 tokens there are fewer blocks than the GPU has SMs, so nothing overlaps and there is no effect. Above that the gain grows with the token count, as more blocks fit per SM and more stores are in flight. Repeated three times across two A100 variants: the control stayed within 0.08% and varying the DiffKV cache strides or slot pattern moved results by under 0.15 points.

End-to-end, gpt-oss on A100 (sinks need FA3/4, so Triton is the only backend vLLM can pick on sm80). `n` is per rank, so TP is what brings gpt-oss into range: 512 at TP=1 (unchanged), 256 at TP=2, 128 at TP=4. Each cell is the mean of 3 runs of `llm.generate()` over 128 prompts of 2048 token ids, `max_tokens=1`, prefix caching off, order alternating.

| config | `num_warps = 16` | scaled | delta |
|---|---|---|---|
| gpt-oss-20b, 2×A100, TP=2, 16384-token steps | 7.2094 s | 7.1951 s | −0.198% |
| gpt-oss-120b, 4×A100, TP=4, 16384-token steps | 6.7100 s | 6.6816 s | −0.424% |
| gpt-oss-120b, 4×A100, TP=4, 65536-token steps | 6.5420 s | 6.5191 s | −0.349% |

Every scaled run beat every `num_warps = 16` run. Larger steps do not help: the per-call saving is superlinear in tokens (25.1 µs at 16384, 171.4 µs at 65536) but the step count falls by the same factor. The DiffKV path has no e2e number — MiMo-V2-Flash does not fit in 4×A100.

`ncu` at three shapes confirms the change does what it claims and nothing else: `launch__block_size` and `waves_per_multiprocessor` scale exactly as `min(16, TILE_SIZE // 32) * 32` predicts (unchanged at the control, −75% at n=128, −50% for DiffKV), while DRAM bytes move 0.1% and global store sectors are identical. Correctness rests on the new test rather than those counters, which is also why I ran no accuracy evals.

## Notes

Developed with Claude Code. I reviewed every line and ran the tests myself.

Duplicate check: no open or merged PR changes `num_warps` at either site. #46060 rewrites the capability check in both launch blocks of this file — I will rebase if it lands first. #47535 adds an opt-in CUDA DiffKV op and keeps Triton as the default, which is the path this speeds up.
