### PR TITLE
fix(kv_transfer): abort async store jobs on preemption in Mooncake connector

### DIFF
--- a/tests/v1/kv_connector/unit/test_mooncake_store_connector.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_connector.py
@@ -802,3 +802,28 @@ def test_shutdown_scheduler_role_is_noop():
     # Scheduler role holds no store handle, so shutdown must be a safe no-op.
     assert connector.connector_worker is None
     connector.shutdown()
+
+
+def test_handle_preemptions_delegates_to_worker():
+    """MooncakeStoreConnector.handle_preemptions delegates to the worker."""
+    vllm_config = _make_vllm_config()
+    kv_cache_config = _make_kv_cache_config()
+
+    with (
+        set_current_vllm_config(vllm_config),
+        patch(
+            "vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store."
+            "connector.MooncakeStoreWorker"
+        ) as mock_worker_cls,
+    ):
+        connector = mooncake_store_connector.MooncakeStoreConnector(
+            vllm_config, KVConnectorRole.WORKER, kv_cache_config
+        )
+
+    meta = MooncakeStoreConnectorMetadata(
+        unfinished_req_ids=set(),
+        preempted_req_ids={"req-preempt-test"},
+    )
+    connector.handle_preemptions(meta)
+
+    mock_worker_cls.return_value.handle_preemptions.assert_called_once_with(meta)

--- a/tests/v1/kv_connector/unit/test_mooncake_store_worker.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_worker.py
@@ -1957,8 +1957,8 @@ def test_store_sending_thread_only_stores_swa_blocks_in_window():
 
     store = MagicMock()
     store.batch_is_exist.side_effect = lambda keys: [0] * len(keys)
-    store.batch_put_from_multi_buffers.side_effect = (
-        lambda keys, addrs, sizes, *_args: [256] * len(keys)
+    store.batch_put_from_multi_buffers.side_effect = lambda keys, addrs, sizes, *_args: (
+        [256] * len(keys)
     )
 
     full_spec = FullAttentionSpec(
@@ -3251,3 +3251,115 @@ def test_blob_block_hashes_empty():
     view = BlobBlockHashes(memoryview(b""), 0)
     assert len(view) == 0
     assert list(view) == []
+
+
+def test_handle_preemptions_cancels_queued_store_job():
+    """When handle_preemptions is invoked prior to forward pass, queued store jobs
+    for the preempted request must be aborted without calling batch_put_from_multi_buffers."""
+    store = MagicMock()
+    store.batch_is_exist.return_value = [0, 0]
+    store.batch_put_from_multi_buffers.return_value = [256, 256]
+    thread = _make_store_sending_thread(store)
+
+    thread.add_stored_request("req-preempt-q")
+    # Synchronous preemption notification before forward pass
+    thread.handle_preempted_requests({"req-preempt-q"})
+
+    # Store thread attempts to process the queued job
+    thread._handle_request(_make_store_req("req-preempt-q", [b"p0", b"p1"]))
+
+    assert store.batch_put_from_multi_buffers.call_count == 0
+    assert thread.request_queue.task_done.call_count == 1
+
+
+def test_handle_preemptions_waits_for_active_in_flight_put():
+    """If an active batch_put_from_multi_buffers is currently reading GPU memory,
+    handle_preemptions must wait for it to complete before returning, ensuring
+    device memory is not overwritten mid-transfer by the upcoming forward pass."""
+    store = MagicMock()
+    store.batch_is_exist.return_value = [0, 0]
+
+    put_started = threading.Event()
+    finish_put = threading.Event()
+
+    def _slow_batch_put(*args, **kwargs):
+        put_started.set()
+        finish_put.wait(timeout=2.0)
+        return [256, 256]
+
+    store.batch_put_from_multi_buffers.side_effect = _slow_batch_put
+    thread = _make_store_sending_thread(store)
+    thread.add_stored_request("req-active-put")
+
+    # Start store in background thread
+    store_exec_thread = threading.Thread(
+        target=thread._handle_request,
+        args=(_make_store_req("req-active-put", [b"a0", b"a1"]),),
+    )
+    store_exec_thread.start()
+
+    # Wait until batch_put is actively executing
+    assert put_started.wait(timeout=2.0)
+
+    preempt_completed = threading.Event()
+
+    def _run_handle_preemptions():
+        thread.handle_preempted_requests({"req-active-put"})
+        preempt_completed.set()
+
+    preempt_thread = threading.Thread(target=_run_handle_preemptions)
+    preempt_thread.start()
+
+    # Preemption handler must block while active batch_put is running
+    assert not preempt_completed.wait(timeout=0.1)
+
+    # Let the active put finish
+    finish_put.set()
+    store_exec_thread.join(timeout=2.0)
+
+    # Now handle_preemptions finishes
+    assert preempt_completed.wait(timeout=2.0)
+    preempt_thread.join(timeout=2.0)
+
+    assert store.batch_put_from_multi_buffers.call_count == 1
+
+
+def test_preemption_guard_before_batch_put():
+    """If preemption occurs during key preparation/event sync, the pre-put
+    guard must abort before issuing batch_put_from_multi_buffers."""
+    store = MagicMock()
+    store.batch_is_exist.return_value = [0, 0]
+    store.batch_put_from_multi_buffers.return_value = [256, 256]
+    thread = _make_store_sending_thread(store)
+
+    thread.add_stored_request("req-preempt-mid")
+
+    def _simulate_preempt_during_prep(*args, **kwargs):
+        thread.handle_preempted_requests({"req-preempt-mid"})
+        return [0, 0]
+
+    store.batch_is_exist.side_effect = _simulate_preempt_during_prep
+
+    thread._handle_request(_make_store_req("req-preempt-mid", [b"p0", b"p1"]))
+
+    assert store.batch_put_from_multi_buffers.call_count == 0
+
+
+def test_resumed_request_clears_preemption_status():
+    """Resuming a request in a new generation clears preemption status so
+    new store operations succeed."""
+    store = MagicMock()
+    store.batch_is_exist.return_value = [0, 0]
+    store.batch_put_from_multi_buffers.return_value = [256, 256]
+    thread = _make_store_sending_thread(store)
+
+    thread.add_stored_request("req-resumed")
+    thread.handle_preempted_requests({"req-resumed"})
+    assert "req-resumed" in thread._preempted_requests
+
+    # Resumed request arrives
+    thread.add_stored_request("req-resumed")
+    assert "req-resumed" not in thread._preempted_requests
+
+    thread._handle_request(_make_store_req("req-resumed", [b"r0", b"r1"]))
+    assert store.batch_put_from_multi_buffers.call_count == 1

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/connector.py
@@ -298,6 +298,13 @@ class MooncakeStoreConnector(KVConnectorBase_V1, SupportsHMA):
         ), "Cross-layer KV cache does not supported with hybrid models"
         self.connector_worker.register_cross_layers_kv_caches(kv_cache)
 
+    def handle_preemptions(self, kv_connector_metadata: KVConnectorMetadata):
+        """Handle preempted requests before GPU blocks are overwritten."""
+        if self.connector_worker is not None and isinstance(
+            kv_connector_metadata, MooncakeStoreConnectorMetadata
+        ):
+            self.connector_worker.handle_preemptions(kv_connector_metadata)
+
     def start_load_kv(self, forward_context: ForwardContext, **kwargs: Any) -> None:
         # No-op: loads are issued in get_finished() for compute overlap.
         pass

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
@@ -530,6 +530,10 @@ class KVCacheStoreSendingThread(KVTransferThread):
         # Per-request high-water mark of tokens actually persisted; the next
         # batch resumes here, so pressure-skipped or failed ranges are retried.
         self._saved_offset: dict[str, int] = {}
+        self._preempted_requests: set[str] = set()
+        self._active_put_req_id: str | None = None
+        self._active_put_event = threading.Event()
+        self._active_put_event.set()
 
     def add_request(self, request: ReqMeta) -> None:
         # Register before enqueueing so a job is never picked up unledgered.
@@ -538,10 +542,13 @@ class KVCacheStoreSendingThread(KVTransferThread):
             self.stored_requests.setdefault(request.req_id, set()).add(
                 request.store_job_id
             )
+            self._preempted_requests.discard(request.req_id)
         super().add_request(request)
 
     def is_live_store_job(self, req_meta: ReqMeta) -> bool:
         with self.done_task_lock:
+            if req_meta.req_id in self._preempted_requests:
+                return False
             return req_meta.store_job_id in self.stored_requests.get(
                 req_meta.req_id, ()
             )
@@ -552,6 +559,29 @@ class KVCacheStoreSendingThread(KVTransferThread):
                 del self.stored_requests[req_id]
             self._skip_store_requests.discard(req_id)
             self._saved_offset.pop(req_id, None)
+            self._preempted_requests.add(req_id)
+
+    def handle_preempted_requests(self, preempted_req_ids: set[str]) -> None:
+        """Cancel queued store jobs and synchronously wait for any active
+        in-flight batch_put reading GPU device memory to complete before the
+        upcoming forward pass overwrites those physical GPU blocks."""
+        with self.done_task_lock:
+            for req_id in preempted_req_ids:
+                self._preempted_requests.add(req_id)
+                self.stored_requests.pop(req_id, None)
+                self._skip_store_requests.discard(req_id)
+                self._saved_offset.pop(req_id, None)
+
+        self._wait_active_put_for_preempted(preempted_req_ids)
+
+    def _wait_active_put_for_preempted(self, preempted_req_ids: set[str]) -> None:
+        while True:
+            with self.done_task_lock:
+                active_req = self._active_put_req_id
+                if active_req is None or active_req not in preempted_req_ids:
+                    break
+                event = self._active_put_event
+            event.wait(timeout=0.5)
 
     def finish_store_job(self, req_meta: ReqMeta) -> None:
         """Retire a job from the ledger and report its blocks as no longer read.
@@ -960,6 +990,15 @@ class KVCacheStoreSendingThread(KVTransferThread):
             if current_event is not None:
                 current_event.synchronize()
 
+            with self.done_task_lock:
+                if (
+                    req_id not in self.stored_requests
+                    or req_id in self._preempted_requests
+                ):
+                    return
+                self._active_put_req_id = req_id
+                self._active_put_event.clear()
+
             if group_ids is not None:
                 assert len(group_ids) == len(keys)
                 self.replicate_config.group_ids = group_ids
@@ -1023,6 +1062,10 @@ class KVCacheStoreSendingThread(KVTransferThread):
                     num_failed_keys=len(keys),
                 )
                 logger.error("Failed to put key %s, error: %s", keys, e)
+            finally:
+                with self.done_task_lock:
+                    self._active_put_req_id = None
+                    self._active_put_event.set()
 
             if self.enable_kv_event and stored_events:
                 self.update_kv_event(stored_events)
@@ -1674,6 +1717,14 @@ class MooncakeStoreWorker:
     ):
         """No-op: stores are issued in get_finished() for overlap."""
         pass
+
+    def handle_preemptions(self, metadata: MooncakeStoreConnectorMetadata) -> None:
+        """Synchronously handle preemption before the forward pass runs."""
+        if not metadata.preempted_req_ids or self.kv_send_thread is None:
+            return
+        self.kv_send_thread.handle_preempted_requests(metadata.preempted_req_ids)
+        for req_id in metadata.preempted_req_ids:
+            self.finished_store_req.discard(req_id)
 
     def get_finished(
         self,


### PR DESCRIPTION
### Problem

When a request is preempted under GPU memory pressure, `MooncakeStoreConnector` could store corrupted KV data that does not belong to the request's key hashes.

1. During a step, the worker enqueues store jobs onto `KVCacheStoreSendingThread`'s queue.
2. In a subsequent step (or during async scheduling), the scheduler preempts the request and immediately returns its GPU blocks to the free pool, which are reallocated to another request.
3. Because `MooncakeStoreConnector` did not implement `handle_preemptions`, the preemption notification was only processed after the model forward pass in `get_finished()`. This created a window where the new request's forward pass ran on the GPU and overwrote the reallocated blocks while the background store thread was reading them via `batch_put_from_multi_buffers`.
4. This caused `MooncakeStoreConnector` to store the new request's KV data under the preempted request's token key hashes. When later requests hit the prefix cache for those hashes, they loaded corrupted KV blocks, leading to silent output drift and generation corruption.

### Root Cause

- `MooncakeStoreConnector` lacked an implementation of `handle_preemptions(kv_connector_metadata)` (inheriting the empty no-op from `KVConnectorBase_V1`), causing preemption handling to be delayed until `post_forward()` after the forward pass had already overwritten the physical device memory.
- `KVCacheStoreSendingThread` did not have preemption tracking or an active put synchronization barrier to ensure ongoing RDMA device memory reads complete before a new forward pass overwrites physical GPU blocks.
- `_handle_request` lacked a thread-safe pre-put guard before calling `batch_put_from_multi_buffers`.

### Solution

1. **Pre-Forward Preemption Synchronization**: Implemented `MooncakeStoreConnector.handle_preemptions` (called by `ActiveKVConnector.pre_forward` before the model forward pass) to synchronously process `metadata.preempted_req_ids` on `MooncakeStoreWorker`.
2. **Preemption Tracking & Cancellation**: Added `self._preempted_requests: set[str]` inside `KVCacheStoreSendingThread` guarded by `self.done_task_lock`.
3. **Active Put Barrier**: In `KVCacheStoreSendingThread.handle_preempted_requests`, if an active `batch_put_from_multi_buffers` is currently reading device memory for any preempted request, it blocks until that transfer finishes, ensuring it reads valid pre-preemption data before the upcoming forward pass overwrites the GPU memory.
4. **Pre-Put Guard**: Added a thread-safe check in `_handle_request` immediately before `batch_put_from_multi_buffers` (after CUDA event synchronization) to abort if the request was preempted while preparation was in flight.
5. **Unit Tests**:
   - `test_handle_preemptions_cancels_queued_store_job`: verifies preemption prior to forward pass cancels queued store jobs before device memory access.
   - `test_handle_preemptions_waits_for_active_in_flight_put`: verifies `handle_preemptions` waits for an active in-flight `batch_put` to finish before returning so device memory is not overwritten mid-transfer.
   - `test_preemption_guard_before_batch_put`: verifies pre-put guard aborts before `batch_put_from_multi_buffers` if preemption occurs during preparation.
   - `test_resumed_request_clears_preemption_status`: verifies resumed requests clear preemption state.
   - `test_handle_preemptions_delegates_to_worker`: verifies `MooncakeStoreConnector.handle_preemptions` delegates to the worker.

### Test Plan

- Unit tests in `tests/v1/kv_connector/unit/test_mooncake_store_worker.py`:
  - `test_handle_preemptions_cancels_queued_store_job`
  - `test_handle_preemptions_waits_for_active_in_flight_put`
  - `test_preemption_guard_before_batch_put`
  - `test_resumed_request_clears_preemption_status`
- Unit test in `tests/v1/kv_connector/unit/test_mooncake_store_connector.py`:
  - `test_handle_preemptions_delegates_to_worker`

Fixes #52360
