### PR TITLE
[Attention][MLA] Add GLM-5.2 TurboQuant sparse backend with DCP/MTP

### DIFF
--- a/vllm/benchmarks/datasets/datasets.py
+++ b/vllm/benchmarks/datasets/datasets.py
@@ -1898,6 +1898,10 @@ def add_dataset_parser(parser: FlexibleArgumentParser):
             "throughput_8k",
             "throughput_16k",
             "throughput_32k",
+            "throughput_128k",
+            "throughput_200k",
+            "throughput_500k",
+            "throughput_over_500k",
         },
         help="Subset of the SPEED-Bench dataset.",
     )

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -1320,8 +1320,11 @@ class SpeculativeConfig:
 
         This is mostly a copy of the target parallel config, except the tp_size.
         """
+        # PP+MTP port: draft model only runs on the last PP rank and never
+        # participates in pipeline-parallel communication, so pp_size is always 1.
+        _pp_size = 1
         draft_parallel_config = ParallelConfig(
-            pipeline_parallel_size=target_parallel_config.pipeline_parallel_size,
+            pipeline_parallel_size=_pp_size,
             tensor_parallel_size=speculative_draft_tensor_parallel_size,
             distributed_executor_backend=target_parallel_config.distributed_executor_backend,
             max_parallel_loading_workers=target_parallel_config.max_parallel_loading_workers,

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -554,6 +554,21 @@ class VllmConfig:
         if self.scheduler_config.async_scheduling:
             if self.use_v2_model_runner:
                 return pp_size + 1
+            # P1/M1 (flag-gated: VLLM_PPMTP_MCB_PLUS1): V1 PP + MTP spec decode.
+            # Give the batch queue the extra async-overlap slot (pp_size+1) that
+            # async scheduling needs to overlap CPU scheduling / MTP-token feedback
+            # across PP stages. The phase-1 async MTP handoff keeps
+            # execute_model/sample_tokens 1:1 regardless of queue depth, so the
+            # single-slot handoff invariant still holds. Prerequisite for
+            # cohort-cadence overlap (M3b); has no effect on its own without
+            # independent decode work to fill the slot (see
+            # prof/V2_PPMTP_why_no_speedup.md). Original-path fallback = mcb=pp_size.
+            if (
+                envs.VLLM_PPMTP_MCB_PLUS1
+                and pp_size > 1
+                and self.num_speculative_tokens > 0
+            ):
+                return pp_size + 1
             # V1 Model Runner does not fully support async scheduling with PP.
             if pp_size <= 1:
                 return 2

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -290,6 +290,14 @@ if TYPE_CHECKING:
     VLLM_MULTI_STREAM_GEMM_TOKEN_THRESHOLD: int = 1024
     VLLM_COMPILE_CACHE_SAVE_FORMAT: Literal["binary", "unpacked"] = "binary"
     VLLM_USE_V2_MODEL_RUNNER: bool | None = None
+    # PP+MTP pipeline-overlap flags (prof/HANDOFF_ppmtp_overlap_reimpl.md).
+    # Registered here so they propagate to EngineCore/worker subprocesses
+    # (unregistered VLLM_* vars are dropped when the engine subprocess re-execs).
+    VLLM_PPMTP_MCB_PLUS1: bool = False
+    VLLM_PPMTP_HANDOFF_RING: bool = False
+    VLLM_V1_PP_DECODE_CADENCE: bool = False
+    VLLM_PPMTP_COHORT_BALANCE: bool = False
+    VLLM_PPMTP_ASYNC_BCAST: bool = False
     VLLM_LOG_MODEL_INSPECTION: bool = False
     VLLM_DEBUG_MFU_METRICS: bool = False
     VLLM_WEIGHT_OFFLOADING_DISABLE_PIN_MEMORY: bool = False
@@ -2028,6 +2036,34 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Flag to control the v2 model runner. If unset, use config defaults.
     "VLLM_USE_V2_MODEL_RUNNER": lambda: maybe_convert_bool(
         os.getenv("VLLM_USE_V2_MODEL_RUNNER", None)
+    ),
+    # PP+MTP pipeline-overlap flags (prof/HANDOFF_ppmtp_overlap_reimpl.md).
+    # P1/M1: give the batch queue an extra async-overlap slot (mcb=pp_size+1)
+    # for V1 PP + MTP spec decode.
+    "VLLM_PPMTP_MCB_PLUS1": lambda: bool(int(os.getenv("VLLM_PPMTP_MCB_PLUS1", "0"))),
+    # P2/M3a: upgrade the inline PP+MTP handoff apply to a ring(deque)+deferred
+    # version so the extra mcb=3 batch slot is correction-safe (inline applies
+    # the per-req CPU correction immediately, which races the extra in-flight
+    # batch). ring depth=1 here; becomes pp_size under cadence (M3b).
+    "VLLM_PPMTP_HANDOFF_RING": lambda: bool(
+        int(os.getenv("VLLM_PPMTP_HANDOFF_RING", "0"))
+    ),
+    # P3/M3b: throttle each request's decode to once per pp_size steps so
+    # consecutive steps run independent cohorts that can overlap PP stages.
+    "VLLM_V1_PP_DECODE_CADENCE": lambda: bool(
+        int(os.getenv("VLLM_V1_PP_DECODE_CADENCE", "0"))
+    ),
+    # P4: round-robin the prefill->decode admission residue across pp_size so
+    # cohorts stay balanced (the missing piece that makes cadence a net win).
+    "VLLM_PPMTP_COHORT_BALANCE": lambda: bool(
+        int(os.getenv("VLLM_PPMTP_COHORT_BALANCE", "0"))
+    ),
+    # P7/Phase A: make the PP+MTP handoff broadcasts async (async_op=True) and
+    # relocate the wait + D2H derivation to the deferred ring consume, so the
+    # collective overlaps the next (independent) cohort's forward. Gated on
+    # _pp_decode_cadence (no independent cohort to overlap without cadence).
+    "VLLM_PPMTP_ASYNC_BCAST": lambda: bool(
+        int(os.getenv("VLLM_PPMTP_ASYNC_BCAST", "0"))
     ),
     # Log model inspection after loading.
     # If enabled, logs a transformers-style hierarchical view of the model

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -1169,6 +1169,7 @@ class MLAAttention(nn.Module, AttentionLayerBase):
         self._k_scale_cpu.fill_(self._k_scale_float)
         self._v_scale_cpu.fill_(self._v_scale_float)
         self.calculate_kv_scales = False
+
     def get_attn_backend(self) -> type[AttentionBackend]:
         return self.attn_backend
 

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -16,7 +16,7 @@ approach for "prefill" (i.e. the ratio Sq / Skv is relatively large, often near
 1) and the data-movement friendly approach for "decode" (i.e. the ratio
 Sq / Skv is small, often near 0).
 
-NOTE what we deem small and large is currently determined by if it is labelled
+NOTE what we deem small and large is currently determined by if its labelled
 prefill or decode by the scheduler, but this is something we should probably
 tune.
 
@@ -96,7 +96,7 @@ NOTE: in the actual code,
 Runtime
 q_c      = h_t @ W_DQ
 q_nope   = (q_c @ W_UQ).view(-1, N, P)
-ql_nope  = einsum("snh,lnh->snl", q_nope, W_UK)
+ql_nope  = einsum("snh,lnh->snl", q, W_UK)
 q_pe     = RoPE(q_c @ W_QR).view(Sq, N, R)
 new_kv_c = h_t @ W_DKV
 new_k_pe = RoPE(h_t @ W_KR)
@@ -1140,10 +1140,63 @@ class MLAAttention(nn.Module, AttentionLayerBase):
         if not should_load_quant_weights(quant_method):
             set_default_quant_scales(self, register_buffer=False)
 
+        # TurboQuant MSE: fold Hadamard Pi into W_UK_T / W_UV before the first
+        # decode bmm so we never need runtime q/o @ Pi in forward_mqa.
+        fold_pi_at_load = getattr(self.impl, "fold_pi_at_load", None)
+        if fold_pi_at_load is not None:
+            fold_pi_at_load(self)
+
+    def calc_kv_scales(
+        self, q: torch.Tensor, kv_c_normed: torch.Tensor, k_pe: torch.Tensor
+    ) -> None:
+        """Optional scale calculation for MLA inputs.
+
+        Mirrors Attention.calc_kv_scales. Not all MLA backends require this
+        """
+        # Use safe defaults if ranges are not present
+        q_range = getattr(self, "q_range", torch.tensor(1.0))
+        k_range = getattr(self, "k_range", torch.tensor(1.0))
+        v_range = getattr(self, "v_range", torch.tensor(1.0))
+
+        self._q_scale.copy_(torch.abs(q).max() / q_range)
+        # kv_c_normed is the compressed KV representation; use it for k/v
+        kv_abs_max = torch.abs(kv_c_normed).max()
+        self._k_scale.copy_(kv_abs_max / k_range)
+        self._v_scale.copy_(kv_abs_max / v_range)
+        self._q_scale_float = self._q_scale.item()
+        self._k_scale_float = self._k_scale.item()
+        self._v_scale_float = self._v_scale.item()
+        self._k_scale_cpu.fill_(self._k_scale_float)
+        self._v_scale_cpu.fill_(self._v_scale_float)
+        self.calculate_kv_scales = False
     def get_attn_backend(self) -> type[AttentionBackend]:
         return self.attn_backend
 
     def get_kv_cache_spec(self, vllm_config: VllmConfig) -> KVCacheSpec:
+        # TurboQuant MLA: cache is packed bytes per slot, not bf16 elements.
+        if self.kv_cache_dtype.startswith("turboquant_"):
+            from vllm.model_executor.layers.quantization.turboquant.config import (
+                TurboQuantConfig,
+            )
+            from vllm.v1.attention.ops.tq_mla_defaults import resolve_kpe_layout
+
+            tq_cfg = TurboQuantConfig.from_cache_dtype(
+                self.kv_cache_dtype, head_dim=self.kv_lora_rank
+            )
+            kv_c_bytes = tq_cfg.key_packed_size
+            _kpe_4bit, _kpe_fp8, k_pe_bytes = resolve_kpe_layout(
+                self.kv_cache_dtype,
+                tq_cfg,
+                self.qk_rope_head_dim,
+            )
+            packed_bytes = kv_c_bytes + k_pe_bytes
+            return MLAAttentionSpec(
+                block_size=vllm_config.cache_config.block_size,
+                num_kv_heads=1,
+                head_size=packed_bytes,
+                dtype=torch.uint8,
+                cache_dtype_str=self.kv_cache_dtype,
+            )
         kv_cache_dtype = kv_cache_dtype_str_to_dtype(
             self.kv_cache_dtype, vllm_config.model_config
         )

--- a/vllm/model_executor/layers/sparse_attn_indexer.py
+++ b/vllm/model_executor/layers/sparse_attn_indexer.py
@@ -2,10 +2,11 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Custom Sparse Attention Indexer layers."""
 
+import os
+
 import torch
 
 import vllm.envs as envs
-from vllm import _custom_ops as ops
 from vllm._aiter_ops import rocm_aiter_ops
 from vllm.compilation.breakable_cudagraph import eager_break_during_capture
 from vllm.config import CUDAGraphMode, get_current_vllm_config
@@ -31,13 +32,310 @@ from vllm.utils.torch_utils import (
     _resolve_layer_name,
     direct_register_custom_op,
 )
+from vllm.triton_utils import tl, triton
 from vllm.v1.attention.backends.mla.indexer import (
     DeepseekV32IndexerMetadata,
 )
 from vllm.v1.attention.ops.common import pack_seq_triton, unpack_seq_triton
+from vllm.v1.attention.ops.indexer_turboquant import (
+    INDEXER_FP8_SLOT_BYTES,
+    indexer_tq_cp_gather_dequant_fp8,
+    indexer_tq_store_and_cache,
+    is_indexer_tq_4bit_enabled,
+    sync_fp8_workspace_for_decode,
+    tq4_paged_mqa_logits_triton,
+    use_indexer_tq_fused_decode,
+)
 from vllm.v1.worker.workspace import current_workspace_manager
 
+if current_platform.is_cuda_alike():
+    from vllm import _custom_ops as ops
+elif current_platform.is_xpu():
+    from vllm._xpu_ops import xpu_ops
+
 logger = init_logger(__name__)
+
+
+@triton.jit
+def _dcp_scatter_indexer_logits_kernel(
+    local_ptr,
+    local_row_stride,
+    global_ptr,
+    global_row_stride,
+    seq_lens_local_ptr,  # int32 [num_rows], per-row LOCAL context length
+    N: tl.constexpr,  # dcp_world_size
+    RANK: tl.constexpr,  # dcp_rank
+    S: tl.constexpr,  # cp_kv_cache_interleave_size
+    max_local_cols,  # cdiv(global_width, N)
+    global_width,
+    BLOCK: tl.constexpr,
+):
+    # Scatter this rank's local-order logits to their global positions.
+    # The KV cache is sharded across `N` ranks by an interleaved round-robin at
+    # granularity `S` (mirrors block_table._compute_slot_mapping_kernel). The
+    # L-th local token on rank RANK lives in interleave-block ``L // S`` at
+    # offset ``L % S``, whose global position is
+    #     (L // S) * (N * S) + RANK * S + (L % S).
+    # With S == 1 this reduces to ``L * N + RANK`` (per-token round-robin).
+    row = tl.program_id(0)
+    llen = tl.load(seq_lens_local_ptr + row)
+    for i in range(0, max_local_cols, BLOCK):
+        L = i + tl.arange(0, BLOCK)
+        valid = L < llen
+        val = tl.load(local_ptr + row * local_row_stride + L, mask=valid, other=0.0)
+        gcol = (L // S) * (N * S) + RANK * S + (L % S)
+        gvalid = valid & (gcol < global_width)
+        tl.store(global_ptr + row * global_row_stride + gcol, val, mask=gvalid)
+
+
+def _dcp_allgather_indexer_logits(
+    local_logits: torch.Tensor,
+    local_seq_lens: torch.Tensor,
+    dcp_world_size: int,
+    dcp_rank: int,
+    cp_interleave_size: int = 1,
+) -> torch.Tensor:
+    """Reconstruct full-sequence indexer logits from per-rank shards under DCP.
+
+    Each rank computed ``local_logits`` over the KV tokens it physically holds
+    (local order). We scatter them back to their global sequence positions into
+    a zero-filled buffer (same shape/layout as the kernel output, so the
+    downstream top-k kernels see the exact layout they expect) and SUM-reduce
+    across the DCP group. Every global position is owned by exactly one rank
+    (the round-robin partition), so the other ranks contribute 0 and the sum
+    equals that rank's real logit; positions beyond the sequence are 0 on every
+    rank and are masked out by the global seq_lens in the top-k. The reduce uses
+    the DCP group coordinator (not a raw torch.distributed call) so it is issued
+    on vLLM's collective stream and stays compatible with CUDA graph capture.
+    """
+    from vllm.distributed import get_dcp_group
+
+    num_rows, width = local_logits.shape
+    global_logits = torch.zeros_like(local_logits)
+    seq_lens_local_flat = local_seq_lens.reshape(-1).to(torch.int32).contiguous()
+    max_local_cols = (width + dcp_world_size - 1) // dcp_world_size
+    _dcp_scatter_indexer_logits_kernel[(num_rows,)](
+        local_logits,
+        local_logits.stride(0),
+        global_logits,
+        global_logits.stride(0),
+        seq_lens_local_flat,
+        dcp_world_size,
+        dcp_rank,
+        cp_interleave_size,
+        max_local_cols,
+        width,
+        BLOCK=1024,
+    )
+    return get_dcp_group().all_reduce(global_logits)
+
+
+def indexer_dcp_distributed_topk_enabled() -> bool:
+    """Distributed indexer top-k under DCP (decode path only).
+
+    When enabled, replaces the full-width ``all_reduce`` + global top-k
+    (``_dcp_allgather_indexer_logits`` + ``persistent_topk`` over the whole
+    ``[R, max_model_len]`` buffer) with: per-rank local top-k -> all_gather of
+    only the ``k * dcp_world_size`` (global_col, value) candidates -> an N-way
+    merge. This turns the DCP indexer glue from O(max_model_len) traffic into
+    O(k * dcp_world_size), the dominant win at dcp>=4 / long context.
+
+    Correctness: the global top-k is a subset of the union of the per-rank
+    local top-k. Each rank returns k candidates and every globally-selected
+    column, on its owning rank, ranks among that rank's local top-k (its rank
+    only holds a subset of the sequence), so no winner is ever dropped. All
+    ranks all_gather the same candidate set and run an identical merge, so every
+    rank writes a bit-identical ``topk_indices_buffer`` -- exactly what the
+    downstream per-rank ``triton_convert_req_index_to_global_index`` filtering
+    and the LSE combine require.
+
+    Default off; falls back to the ``all_reduce`` path when unset.
+    """
+    return os.environ.get("VLLM_INDEXER_DCP_DISTRIBUTED_TOPK", "0") == "1"
+
+
+def _dcp_distributed_topk_indexer(
+    local_logits: torch.Tensor,
+    local_seq_lens: torch.Tensor,
+    topk_indices_buffer: torch.Tensor,
+    num_padded_tokens: int,
+    topk_tokens: int,
+    max_seq_len: int,
+    dcp_world_size: int,
+    dcp_rank: int,
+    cp_interleave_size: int,
+) -> None:
+    """Fill ``topk_indices_buffer[:R, :topk_tokens]`` with the GLOBAL top-k
+    column indices under DCP, without materializing the full-width all_reduce.
+
+    ``local_logits`` is ``[R, max_model_len]`` in this rank's LOCAL order (the
+    paged-MQA kernel wrote only this rank's KV shard, bounded by
+    ``local_seq_lens``); tail columns are stale and excluded by the per-row
+    seq_lens in the local top-k. See ``indexer_dcp_distributed_topk_enabled``
+    for the correctness argument.
+    """
+    from vllm.distributed import get_dcp_group
+
+    R = num_padded_tokens
+    N = dcp_world_size
+    S = cp_interleave_size
+    logits = local_logits[:R]
+    seq_lens_local = local_seq_lens.reshape(-1)[:R].to(torch.int32).contiguous()
+
+    # (1) local top-k -> local column indices [R, k] (int32; -1 pads short rows).
+    #     Reuse the same radix persistent_topk, but over this rank's shard only
+    #     (bounded by the LOCAL seq_lens), so it scans ~ctx/N per row. Pre-fill
+    #     with -1: persistent_topk writes only the valid entries and leaves the
+    #     pad slots (rows whose local context < topk_tokens) untouched, so the
+    #     -1 must already be there for the `valid` mask below to be correct.
+    local_topk = torch.full(
+        (R, topk_tokens), -1, dtype=torch.int32, device=logits.device
+    )
+    workspace_manager = current_workspace_manager()
+    (topk_workspace,) = workspace_manager.get_simultaneous(
+        ((RADIX_TOPK_WORKSPACE_SIZE,), torch.uint8),
+    )
+    torch.ops._C.persistent_topk(
+        logits,
+        seq_lens_local,
+        local_topk,
+        topk_workspace,
+        topk_tokens,
+        max_seq_len,
+    )
+
+    # (2) re-gather the local top-k VALUES from the local logits (persistent_topk
+    #     emits indices only). A -1 index (short row) -> most-negative so it never
+    #     wins the merge.
+    valid = local_topk >= 0
+    local_vals = torch.gather(logits, 1, local_topk.clamp_min(0).to(torch.int64))
+    neg_inf = torch.finfo(local_vals.dtype).min
+    local_vals = torch.where(valid, local_vals, neg_inf)
+
+    # (3) local column -> global column (round-robin the scatter kernel uses:
+    #     gcol=(L//S)*(N*S)+RANK*S+(L%S)); -1 for pads.
+    L = local_topk.to(torch.int64)
+    gcol = torch.where(
+        valid,
+        (L // S) * (N * S) + dcp_rank * S + (L % S),
+        torch.full_like(L, -1),
+    )
+
+    # (4) Build a DETERMINISTIC total-order key per candidate and exchange it in a
+    #     SINGLE all_gather (matches upstream #46076 FLASHINFER_MLA_SPARSE /
+    #     #46145). A plain value-only torch.topk breaks ties nondeterministically
+    #     per launch; DCP decode runs the fp8 indexer whose scores tie heavily,
+    #     so ranks could keep different tied candidates from the (identical)
+    #     all_gathered set -> each rank's downstream sparse filter sees a
+    #     different global token set -> inconsistent LSE merge -> intermittent
+    #     garbled output. The key packs a strict order into one int64: the
+    #     score's monotone-uint32 bits in the high 32 and ~global_col in the low
+    #     32 (lowest global column wins ties). Global columns are unique across
+    #     ranks (disjoint round-robin), so the key is a strict order -> topk has
+    #     no ties to break -> identical selection on every rank. Packing (score,
+    #     col) into this one key lets us all_gather ONE tensor instead of two
+    #     (value + column) and recover the column straight from the winning key.
+    sign64 = -9223372036854775808  # 1<<63: flip so signed topk sorts unsigned
+    sc_u32 = local_vals.contiguous().view(torch.int32).to(torch.int64) & 0xFFFFFFFF
+    # IEEE-754 fp32 bits -> order-preserving uint32: flip all bits if negative
+    # (sign set), else flip just the sign bit.
+    ordered = torch.where(
+        (sc_u32 >> 31) & 1 == 1,
+        (~sc_u32) & 0xFFFFFFFF,
+        sc_u32 ^ 0x80000000,
+    )
+    key_local = ((ordered << 32) | ((~gcol) & 0xFFFFFFFF))
+    key_local = key_local ^ torch.full_like(key_local, sign64)
+    all_keys = get_dcp_group().all_gather(key_local.contiguous(), dim=1)  # [R, N*k]
+
+    # (5) merge = global top-k over the exchanged keys; recover the global column
+    #     from each winning key's low 32 bits (col = ~low; pads decode to -1).
+    top_keys, _ = torch.topk(all_keys, topk_tokens, dim=1)
+    recovered_low = (top_keys ^ torch.full_like(top_keys, sign64)) & 0xFFFFFFFF
+    topk_indices_buffer[:R, :topk_tokens] = (~recovered_low).to(torch.int32)
+
+
+def _dcp_reconstruct_full_indexer_k(
+    kv_cache: torch.Tensor,
+    chunk,
+    values_width: int,
+    values_dtype: torch.dtype,
+    scales_width: int,
+    scales_dtype: torch.dtype,
+    device: torch.device,
+    cp_interleave_size: int = 1,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Reconstruct the full prefill context index-K from per-rank DCP shards.
+
+    Mirrors the dense MLA prefill path
+    (mla_attention._context_parallel_compute_prefill_context): each rank gathers
+    its LOCAL index-K (padded so every rank gathers the same number of tokens),
+    we all-gather across the DCP group, then reorg the shards back into global
+    token order. The KV cache is sharded by an interleaved round-robin at
+    granularity ``S = cp_kv_cache_interleave_size``: global position ``p`` is held
+    by rank ``(p // S) % n`` at local index ``(p // (n*S)) * S + (p % S)``. The
+    reorg therefore regroups the all-gathered shards ``[n, padded_len, W]`` into
+    ``[padded_len // S, n, S, W]`` (interleave-block major) before flattening to
+    global order. With S == 1 this is the original transpose-reshape
+    (rank-major -> per-token round-robin). Returns (k_quant, k_scale) over the
+    full context, in the same layout cp_gather_indexer_k_quant_cache produces
+    without DCP.
+    """
+    from vllm.distributed import get_dcp_group
+
+    n = chunk.dcp_world_size
+    s = cp_interleave_size
+    sum_padded = int(chunk.local_cu_seq_lens[-1].item())
+    local_k = torch.empty((sum_padded, values_width), dtype=values_dtype, device=device)
+    local_scale = torch.empty(
+        (sum_padded, scales_width), dtype=scales_dtype, device=device
+    )
+    # Local gather: padded local cu_seq_lens -> this rank's compact local tokens
+    # (plus a little block padding) for each request.
+    ops.cp_gather_indexer_k_quant_cache(
+        kv_cache, local_k, local_scale, chunk.block_table, chunk.local_cu_seq_lens
+    )
+    # All-gather across the DCP group (rank-major concatenation along dim 0).
+    ag_k = (
+        get_dcp_group()
+        .all_gather(local_k.view(torch.uint8), dim=0)
+        .view(values_dtype)
+        .view(n, sum_padded, values_width)
+    )
+    ag_scale = (
+        get_dcp_group()
+        .all_gather(local_scale, dim=0)
+        .view(n, sum_padded, scales_width)
+    )
+
+    # Reorg per request back into global token order, trimmed to ctx.
+    def _reorg(ag, width, padded_len, ctx_len):
+        seg = ag[:, offset : offset + padded_len, :]
+        if s == 1:
+            return seg.transpose(0, 1).reshape(padded_len * n, width)[:ctx_len]
+        assert padded_len % s == 0, (
+            f"padded local seq len {padded_len} must be a multiple of "
+            f"cp_kv_cache_interleave_size {s}"
+        )
+        return (
+            seg.reshape(n, padded_len // s, s, width)
+            .permute(1, 0, 2, 3)
+            .reshape(padded_len * n, width)[:ctx_len]
+        )
+
+    k_segments = []
+    s_segments = []
+    offset = 0
+    for padded_len, ctx_len in zip(
+        chunk.padded_local_seq_lens, chunk.global_seq_lens_lst
+    ):
+        k_segments.append(_reorg(ag_k, values_width, padded_len, ctx_len))
+        s_segments.append(_reorg(ag_scale, scales_width, padded_len, ctx_len))
+        offset += padded_len
+    k_full = torch.cat(k_segments, dim=0)
+    s_full = torch.cat(s_segments, dim=0)
+    return k_full, s_full
+
 
 RADIX_TOPK_WORKSPACE_SIZE = 1024 * 1024
 
@@ -292,7 +590,6 @@ def kv_cache_as_quant_view(
     return kv_cache.unsqueeze(-2)
 
 
-@eager_break_during_capture
 def sparse_attn_indexer(
     hidden_states: torch.Tensor,
     k_cache_prefix: LayerNameType,
@@ -334,6 +631,12 @@ def sparse_attn_indexer(
             scales_spec,
             ((RADIX_TOPK_WORKSPACE_SIZE,), torch.uint8),
         )
+        if is_indexer_tq_4bit_enabled() and kv_cache.numel() > 0:
+            # Decode paged DeepGEMM reads FP8-shaped workspace synced from TQ cache.
+            fp8_ws_shape = tuple(kv_cache.shape[:-1]) + (INDEXER_FP8_SLOT_BYTES,)
+            current_workspace_manager().get_simultaneous(
+                (fp8_ws_shape, torch.uint8),
+            )
 
         # Dummy allocation to simulate for peak logits tensor memory during inference.
         # FP8 elements so elements == bytes
@@ -361,6 +664,11 @@ def sparse_attn_indexer(
             use_pcp,
             dense_mha_metadata_layer_name,
             use_fp4_cache,
+        )
+    # torch.compile warmup when DSA disabled (buffer is None).
+    if topk_indices_buffer is None:
+        return torch.empty(
+            0, topk_tokens, dtype=torch.int32, device=hidden_states.device
         )
     attn_metadata_narrowed = attn_metadata[k_cache_prefix]
     assert isinstance(attn_metadata_narrowed, DeepseekV32IndexerMetadata)
@@ -394,16 +702,19 @@ def sparse_attn_indexer(
             num_decode_tokens,
             use_pcp,
         )
-        # scale_fmt can be None, but the function expects str
-        assert scale_fmt is not None
-        assert not use_fp4_cache, "Unfused FP4 Insert is not supported yet"
-        ops.indexer_k_quant_and_cache(
-            k,
-            kv_cache,
-            slot_mapping_for_cache,
-            quant_block_size,
-            scale_fmt,
-        )
+        if is_indexer_tq_4bit_enabled():
+            indexer_tq_store_and_cache(k, kv_cache, slot_mapping_for_cache)
+        else:
+            # scale_fmt can be None, but the function expects str.
+            assert scale_fmt is not None
+            assert not use_fp4_cache, "Unfused FP4 Insert is not supported yet"
+            ops.indexer_k_quant_and_cache(
+                k,
+                kv_cache,
+                slot_mapping_for_cache,
+                quant_block_size,
+                scale_fmt,
+            )
 
     # The indexer and main MLA may classify the same short extend differently
     # because they use independent decode thresholds. Only the main MLA route
@@ -467,6 +778,7 @@ def sparse_attn_indexer(
                 if q_scale is not None
                 else None
             )
+
             topk_indices = topk_indices_buffer[
                 chunk.token_start : chunk.token_end, :topk_tokens
             ]
@@ -530,7 +842,6 @@ def sparse_attn_indexer(
     if has_decode:
         decode_metadata = attn_metadata_narrowed.decode
         assert decode_metadata is not None
-        kv_cache = kv_cache_as_quant_view(kv_cache, head_dim, use_fp4_cache)
         decode_lens = decode_metadata.decode_lens
         if num_decode_tokens == 0:
             padded_q_quant_decode_tokens = q_quant[:1].reshape(1, 1, *q_quant.shape[1:])
@@ -579,30 +890,55 @@ def sparse_attn_indexer(
         # seq_lens is always 2D: (B, next_n) for native spec decode, (B, 1)
         # otherwise. deep_gemm fp8_fp4_paged_mqa_logits requires 2D context_lens;
         # the downstream topk kernels accept both 1D and 2D.
-        padded_q_quant_cast = (
-            padded_q_quant_decode_tokens.view(torch.int8)
-            if use_fp4_cache
-            else padded_q_quant_decode_tokens
+        use_tq_fused_decode = (
+            is_indexer_tq_4bit_enabled()
+            and use_indexer_tq_fused_decode()
+            and not use_fp4_cache
+            and next_n == 1
+            and q_scale is None
         )
-        if current_platform.is_xpu():
-            if padded_q_scale is not None:
-                raise RuntimeError("XPU fp8_paged_mqa_logits does not support FP4 Q")
-            seq_lens_xpu = (
-                seq_lens[:, -1].contiguous() if seq_lens.ndim == 2 else seq_lens
-            )
-            logits = torch.ops.vllm.xpu_fp8_paged_mqa_logits(
-                padded_q_quant_cast,
+        if use_tq_fused_decode:
+            q_decode = padded_q_quant_decode_tokens[:, 0]
+            if seq_lens.dim() > 1:
+                seq_lens_logits = seq_lens.squeeze(-1)
+            else:
+                seq_lens_logits = seq_lens
+            logits = tq4_paged_mqa_logits_triton(
+                q_decode,
+                weights[:batch_size],
                 kv_cache,
-                weights[:num_padded_tokens],
-                seq_lens_xpu,
                 decode_metadata.block_table,
-                decode_metadata.schedule_metadata,
+                seq_lens_logits,
                 max_model_len,
             )
         else:
+            decode_kv_cache = kv_cache
+            if is_indexer_tq_4bit_enabled():
+                num_blocks, block_size, _ = kv_cache.shape
+                workspace_manager = current_workspace_manager()
+                (fp8_workspace,) = workspace_manager.get_simultaneous(
+                    ((num_blocks, block_size, INDEXER_FP8_SLOT_BYTES), torch.uint8),
+                )
+                decode_kv_cache = sync_fp8_workspace_for_decode(
+                    kv_cache,
+                    fp8_workspace,
+                    decode_metadata.block_table,
+                    decode_metadata.seq_lens,
+                    scale_fmt,
+                    max_model_len=max_model_len,
+                    schedule_metadata=decode_metadata.schedule_metadata,
+                )
+            kv_cache_view = kv_cache_as_quant_view(
+                decode_kv_cache, head_dim, use_fp4_cache
+            )
+            padded_q_quant_cast = (
+                padded_q_quant_decode_tokens.view(torch.int8)
+                if use_fp4_cache
+                else padded_q_quant_decode_tokens
+            )
             logits = fp8_fp4_paged_mqa_logits(
                 (padded_q_quant_cast, padded_q_scale),
-                kv_cache,
+                kv_cache_view,
                 weights[:num_padded_tokens],
                 seq_lens,
                 decode_metadata.block_table,
@@ -611,6 +947,40 @@ def sparse_attn_indexer(
                 clean_logits=False,
                 indices=decode_metadata.indices,
             )
+
+        # Under DCP the logits kernels above read only this rank's KV shard (with
+        # local seq_lens), producing per-rank logits in local order. Scatter them
+        # back to global positions and reduce across the DCP group so every rank
+        # holds the full logits and selects an identical GLOBAL top-k, using the
+        # global seq_lens. DCP forces the FP8 indexer path (TQ4 fused decode is
+        # disabled under DCP, matching the prefill assert), so the cooperative TMA
+        # top-k -- already dropped by TQ in favor of persistent_topk -- is not a
+        # concern here.
+        # Distributed top-k (flag-gated): keep the per-rank LOCAL logits, do a
+        # local top-k, exchange only the k*N candidates, and merge -- instead of
+        # the full-width all_reduce below. Only the CUDA radix persistent_topk
+        # path is supported (topk_tokens in {512,1024,2048}); anything else falls
+        # back to the all_reduce path.
+        dcp_distributed_topk = (
+            decode_metadata.dcp_world_size > 1
+            and indexer_dcp_distributed_topk_enabled()
+            and current_platform.is_cuda()
+            and topk_tokens in (512, 1024, 2048)
+        )
+
+        if decode_metadata.dcp_world_size > 1 and not dcp_distributed_topk:
+            assert decode_metadata.global_seq_lens is not None
+            topk_seq_lens = decode_metadata.global_seq_lens[:batch_size]
+            logits = _dcp_allgather_indexer_logits(
+                logits,
+                seq_lens,
+                decode_metadata.dcp_world_size,
+                decode_metadata.dcp_rank,
+                decode_metadata.cp_interleave_size,
+            )
+        else:
+            topk_seq_lens = seq_lens
+
         num_rows = logits.shape[0]
         topk_indices = topk_indices_buffer[:num_padded_tokens, :topk_tokens]
 
@@ -635,35 +1005,50 @@ def sparse_attn_indexer(
             torch.ops._C.cooperative_topk(
                 logits,
                 seq_lens,
-                topk_indices,
-                topk_workspace,
+                topk_indices_buffer,
+                num_padded_tokens,
                 topk_tokens,
                 attn_metadata_narrowed.max_seq_len,
+                decode_metadata.dcp_world_size,
+                decode_metadata.dcp_rank,
+                decode_metadata.cp_interleave_size,
             )
-        elif use_persistent_topk:
+        elif current_platform.is_cuda() and topk_tokens in (512, 1024, 2048):
             workspace_manager = current_workspace_manager()
             (topk_workspace,) = workspace_manager.get_simultaneous(
                 ((RADIX_TOPK_WORKSPACE_SIZE,), torch.uint8),
             )
             torch.ops._C.persistent_topk(
                 logits,
-                seq_lens,
+                topk_seq_lens,
                 topk_indices,
                 topk_workspace,
                 topk_tokens,
                 logits.shape[1],
             )
         else:
-            ops.top_k_per_row_decode(
-                logits,
-                next_n,
-                seq_lens,
-                topk_indices,
-                num_rows,
-                logits.stride(0),
-                logits.stride(1),
-                topk_tokens,
-            )
+            if current_platform.is_xpu():
+                xpu_ops.top_k_per_row_decode(  # type: ignore[attr-defined]
+                    logits,
+                    next_n,
+                    topk_seq_lens,
+                    topk_indices,
+                    num_rows,
+                    logits.stride(0),
+                    logits.stride(1),
+                    topk_tokens,
+                )
+            else:
+                torch.ops._C.top_k_per_row_decode(
+                    logits,
+                    next_n,
+                    topk_seq_lens,
+                    topk_indices,
+                    num_rows,
+                    logits.stride(0),
+                    logits.stride(1),
+                    topk_tokens,
+                )
 
         if decode_metadata.global_seq_lens is not None:
             _merge_dcp_topk_global(
@@ -773,8 +1158,7 @@ class SparseAttnIndexer(CustomOp):
         self.use_pcp = parallel_config.prefill_context_parallel_size > 1
         if current_platform.is_cuda() and not has_deep_gemm():
             raise RuntimeError(
-                "Sparse Attention Indexer CUDA op requires DeepGEMM support in "
-                "the current vLLM environment."
+                "Sparse Attention Indexer CUDA op requires DeepGEMM to be installed."
             )
 
     def forward_native(
@@ -831,15 +1215,6 @@ class SparseAttnIndexer(CustomOp):
             self.cp_kv_cache_interleave_size,
         )
 
-    def forward_xpu(
-        self,
-        hidden_states: torch.Tensor,
-        q_fp8: torch.Tensor,
-        k: torch.Tensor,
-        weights: torch.Tensor,
-    ):
-        return self.forward_cuda(hidden_states, q_fp8, k, weights)
-
     def forward_hip(
         self,
         hidden_states: torch.Tensor,
@@ -847,6 +1222,9 @@ class SparseAttnIndexer(CustomOp):
         k: torch.Tensor,
         weights: torch.Tensor,
     ):
+        assert not self.skip_k_cache_insert, (
+            "AMD platform doesn't support skip cache insert yet"
+        )
         assert not self.use_fp4_cache, "AMD platform doesn't support fp4 cache yet"
         assert isinstance(q_quant, torch.Tensor), (
             "AMD sparse_attn_indexer expects a single FP8 q_quant tensor"
@@ -872,9 +1250,9 @@ class SparseAttnIndexer(CustomOp):
                 self.max_model_len,
                 self.max_total_seq_len,
                 self.topk_indices_buffer,
-                skip_k_cache_insert=self.skip_k_cache_insert,
             )
-        raise RuntimeError(
-            "Sparse attention indexer ROCm path is only supported on AITER. "
-            "Please enable aiter with VLLM_ROCM_USE_AITER=1"
-        )
+        else:
+            raise RuntimeError(
+                "Sparse attention indexer ROCm custom op requires ROCm "
+                "Aiter ops to be enabled."
+            )

--- a/vllm/model_executor/layers/sparse_attn_indexer.py
+++ b/vllm/model_executor/layers/sparse_attn_indexer.py
@@ -8,7 +8,6 @@ import torch
 
 import vllm.envs as envs
 from vllm._aiter_ops import rocm_aiter_ops
-from vllm.compilation.breakable_cudagraph import eager_break_during_capture
 from vllm.config import CUDAGraphMode, get_current_vllm_config
 from vllm.distributed import get_dcp_group, get_pcp_group
 from vllm.forward_context import get_forward_context
@@ -32,14 +31,12 @@ from vllm.utils.torch_utils import (
     _resolve_layer_name,
     direct_register_custom_op,
 )
-from vllm.triton_utils import tl, triton
 from vllm.v1.attention.backends.mla.indexer import (
     DeepseekV32IndexerMetadata,
 )
 from vllm.v1.attention.ops.common import pack_seq_triton, unpack_seq_triton
 from vllm.v1.attention.ops.indexer_turboquant import (
     INDEXER_FP8_SLOT_BYTES,
-    indexer_tq_cp_gather_dequant_fp8,
     indexer_tq_store_and_cache,
     is_indexer_tq_4bit_enabled,
     sync_fp8_workspace_for_decode,
@@ -81,7 +78,7 @@ def _dcp_scatter_indexer_logits_kernel(
     llen = tl.load(seq_lens_local_ptr + row)
     for i in range(0, max_local_cols, BLOCK):
         L = i + tl.arange(0, BLOCK)
-        valid = L < llen
+        valid = llen > L
         val = tl.load(local_ptr + row * local_row_stride + L, mask=valid, other=0.0)
         gcol = (L // S) * (N * S) + RANK * S + (L % S)
         gvalid = valid & (gcol < global_width)
@@ -244,7 +241,7 @@ def _dcp_distributed_topk_indexer(
         (~sc_u32) & 0xFFFFFFFF,
         sc_u32 ^ 0x80000000,
     )
-    key_local = ((ordered << 32) | ((~gcol) & 0xFFFFFFFF))
+    key_local = (ordered << 32) | ((~gcol) & 0xFFFFFFFF)
     key_local = key_local ^ torch.full_like(key_local, sign64)
     all_keys = get_dcp_group().all_gather(key_local.contiguous(), dim=1)  # [R, N*k]
 
@@ -303,9 +300,7 @@ def _dcp_reconstruct_full_indexer_k(
         .view(n, sum_padded, values_width)
     )
     ag_scale = (
-        get_dcp_group()
-        .all_gather(local_scale, dim=0)
-        .view(n, sum_padded, scales_width)
+        get_dcp_group().all_gather(local_scale, dim=0).view(n, sum_padded, scales_width)
     )
 
     # Reorg per request back into global token order, trimmed to ctx.
@@ -899,10 +894,7 @@ def sparse_attn_indexer(
         )
         if use_tq_fused_decode:
             q_decode = padded_q_quant_decode_tokens[:, 0]
-            if seq_lens.dim() > 1:
-                seq_lens_logits = seq_lens.squeeze(-1)
-            else:
-                seq_lens_logits = seq_lens
+            seq_lens_logits = seq_lens.squeeze(-1) if seq_lens.dim() > 1 else seq_lens
             logits = tq4_paged_mqa_logits_triton(
                 q_decode,
                 weights[:batch_size],
@@ -992,7 +984,7 @@ def sparse_attn_indexer(
             and current_platform.has_device_capability(90)
             and not current_platform.is_device_capability_family(120)
         )
-        use_persistent_topk = current_platform.is_cuda() and topk_tokens in (
+        current_platform.is_cuda() and topk_tokens in (
             512,
             1024,
             2048,

--- a/vllm/model_executor/layers/sparse_attn_indexer.py
+++ b/vllm/model_executor/layers/sparse_attn_indexer.py
@@ -1004,14 +1004,11 @@ def sparse_attn_indexer(
             )
             torch.ops._C.cooperative_topk(
                 logits,
-                seq_lens,
-                topk_indices_buffer,
-                num_padded_tokens,
+                topk_seq_lens,
+                topk_indices,
+                topk_workspace,
                 topk_tokens,
                 attn_metadata_narrowed.max_seq_len,
-                decode_metadata.dcp_world_size,
-                decode_metadata.dcp_rank,
-                decode_metadata.cp_interleave_size,
             )
         elif current_platform.is_cuda() and topk_tokens in (512, 1024, 2048):
             workspace_manager = current_workspace_manager()
@@ -1050,7 +1047,7 @@ def sparse_attn_indexer(
                     topk_tokens,
                 )
 
-        if decode_metadata.global_seq_lens is not None:
+        if dcp_distributed_topk:
             _merge_dcp_topk_global(
                 logits,
                 topk_indices,

--- a/vllm/model_executor/models/deepseek_mtp.py
+++ b/vllm/model_executor/models/deepseek_mtp.py
@@ -15,6 +15,7 @@ from vllm.model_executor.layers.fused_moe import (
     fused_moe_make_expert_params_mapping,
 )
 from vllm.model_executor.layers.layernorm import RMSNorm
+from vllm.model_executor.layers.linear import ReplicatedLinear
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
 from vllm.model_executor.layers.quantization import QuantizationConfig
 from vllm.model_executor.layers.vocab_parallel_embedding import (
@@ -75,7 +76,31 @@ class DeepSeekMultiTokenPredictorLayer(nn.Module):
 
         self.enorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.hnorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
-        self.eh_proj = nn.Linear(config.hidden_size * 2, config.hidden_size, bias=False)
+        # PP+MTP port: ReplicatedLinear (not nn.Linear) so quantized eh_proj
+        # weights load correctly under PP>1. If the quant backend returns
+        # UnquantizedLinearMethod for eh_proj (e.g. GLM-5.2-FP8 keeps eh_proj in
+        # bf16 via modules_to_not_convert), pass quant_config=None so a plain
+        # .weight parameter is created.
+        eh_proj_prefix = maybe_prefix(prefix, "eh_proj")
+        eh_proj_quant_config = quant_config
+        if quant_config is not None:
+            from vllm.model_executor.layers.linear import (
+                LinearBase,
+                UnquantizedLinearMethod,
+            )
+            qm = quant_config.get_quant_method(
+                LinearBase.__new__(LinearBase),
+                eh_proj_prefix,
+            )
+            if qm is None or isinstance(qm, UnquantizedLinearMethod):
+                eh_proj_quant_config = None
+        self.eh_proj = ReplicatedLinear(
+            config.hidden_size * 2,
+            config.hidden_size,
+            bias=False,
+            quant_config=eh_proj_quant_config,
+            prefix=eh_proj_prefix,
+        )
 
         self.device = current_platform.device_type
 
@@ -117,7 +142,7 @@ class DeepSeekMultiTokenPredictorLayer(nn.Module):
 
         hidden_states = self.eh_proj(
             torch.cat([inputs_embeds, previous_hidden_states], dim=-1)
-        )
+        )[0]
 
         hidden_states, residual = self.mtp_block(
             positions=positions,

--- a/vllm/model_executor/models/deepseek_mtp.py
+++ b/vllm/model_executor/models/deepseek_mtp.py
@@ -88,6 +88,7 @@ class DeepSeekMultiTokenPredictorLayer(nn.Module):
                 LinearBase,
                 UnquantizedLinearMethod,
             )
+
             qm = quant_config.get_quant_method(
                 LinearBase.__new__(LinearBase),
                 eh_proj_prefix,

--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -79,7 +79,6 @@ from vllm.model_executor.layers.sparse_attn_indexer import (
     SparseAttnIndexer,
     fused_indexer_q_rope_quant,
 )
-from vllm.v1.attention.ops.indexer_turboquant import indexer_packed_head_dim
 from vllm.model_executor.layers.vocab_parallel_embedding import (
     ParallelLMHead,
     VocabParallelEmbedding,
@@ -100,6 +99,7 @@ from vllm.v1.attention.backend import AttentionBackend
 from vllm.v1.attention.backends.mla.indexer import (
     DeepseekV32IndexerBackend,
 )
+from vllm.v1.attention.ops.indexer_turboquant import indexer_packed_head_dim
 from vllm.v1.kv_cache_interface import KVCacheSpec, MLAAttentionSpec
 
 from .interfaces import (
@@ -715,7 +715,7 @@ class Indexer(nn.Module):
             if is_indexer_tq_4bit_enabled() and not disable_dsa:
                 block_size = cache_config.block_size if cache_config else 64
                 warmup_indexer_tq_kernels(
-                    torch.cuda.current_device(),
+                    torch.accelerator.current_device_index(),
                     self.max_model_len,
                     self.n_head,
                     block_size,

--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -24,6 +24,7 @@
 # limitations under the License.
 """Inference-only DeepseekV2/DeepseekV3 model."""
 
+import os
 import typing
 from collections.abc import Callable, Iterable
 from itertools import islice
@@ -78,6 +79,7 @@ from vllm.model_executor.layers.sparse_attn_indexer import (
     SparseAttnIndexer,
     fused_indexer_q_rope_quant,
 )
+from vllm.v1.attention.ops.indexer_turboquant import indexer_packed_head_dim
 from vllm.model_executor.layers.vocab_parallel_embedding import (
     ParallelLMHead,
     VocabParallelEmbedding,
@@ -683,7 +685,7 @@ class Indexer(nn.Module):
         #       per self.quant_block_size element
         assert cache_config is not None
         self.k_cache = DeepseekV32IndexerCache(
-            head_dim=self.head_dim + self.head_dim // self.quant_block_size * 4,
+            head_dim=indexer_packed_head_dim(),
             dtype=torch.uint8,
             prefix=f"{prefix}.k_cache",
             cache_config=cache_config,
@@ -703,6 +705,21 @@ class Indexer(nn.Module):
             self.max_total_seq_len,
             self.topk_indices_buffer,
         )
+        if current_platform.is_cuda():
+            from vllm.v1.attention.ops.indexer_turboquant import (
+                is_indexer_tq_4bit_enabled,
+                warmup_indexer_tq_kernels,
+            )
+
+            disable_dsa = os.getenv("VLLM_FORCE_DISABLE_DSA", "0") == "1"
+            if is_indexer_tq_4bit_enabled() and not disable_dsa:
+                block_size = cache_config.block_size if cache_config else 64
+                warmup_indexer_tq_kernels(
+                    torch.cuda.current_device(),
+                    self.max_model_len,
+                    self.n_head,
+                    block_size,
+                )
 
         self.is_inplace_rope = is_inplace_rope
         self.n_head_scale = self.n_head**-0.5
@@ -713,6 +730,25 @@ class Indexer(nn.Module):
             and self.rope_dim == 64
             and self.scale_fmt is not None
         )
+
+    def process_weights_after_loading(self, act_dtype: torch.dtype) -> None:
+        """Fold Hadamard Pi into wq_b for TQ4 indexer (Q pre-rotated at score time)."""
+        del act_dtype  # unused; signature matches model loader hook
+        if not current_platform.is_cuda():
+            return
+        from vllm.v1.attention.ops.indexer_turboquant import (
+            fold_indexer_pi_at_load,
+            is_indexer_tq_4bit_enabled,
+            use_indexer_tq_hadamard,
+        )
+
+        if is_indexer_tq_4bit_enabled() and use_indexer_tq_hadamard():
+            fold_indexer_pi_at_load(self)
+            logger.info_once(
+                "Indexer TQ4: folded Hadamard Pi into wq_b (%d heads, D=%d).",
+                self.n_head,
+                self.head_dim,
+            )
 
     def forward(
         self, hidden_states: torch.Tensor, qr: torch.Tensor, positions, rotary_emb

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -115,6 +115,20 @@ def _get_backend_priorities(
                         AttentionBackendEnum.FLASHINFER_MLA_SPARSE,
                     ]
 
+            if kv_cache_dtype is not None and str(kv_cache_dtype).startswith(
+                "turboquant_"
+            ):
+                return [
+                    AttentionBackendEnum.TRITON_MLA_TURBOQUANT_SPARSE,
+                    AttentionBackendEnum.TRITON_MLA_TURBOQUANT,
+                    AttentionBackendEnum.FLASHINFER_MLA,
+                    AttentionBackendEnum.TOKENSPEED_MLA,
+                    AttentionBackendEnum.CUTLASS_MLA,
+                    AttentionBackendEnum.FLASH_ATTN_MLA,
+                    AttentionBackendEnum.FLASHMLA,
+                    AttentionBackendEnum.TRITON_MLA,
+                    *sparse_backends,
+                ]
             return [
                 AttentionBackendEnum.FLASHINFER_MLA,
                 # R1 dims + FP8 KV only; rejected by supports_combination
@@ -128,12 +142,34 @@ def _get_backend_priorities(
                 *sparse_backends,
             ]
         elif device_capability.major == 12:
+            if kv_cache_dtype is not None and str(kv_cache_dtype).startswith(
+                "turboquant_"
+            ):
+                return [
+                    AttentionBackendEnum.TRITON_MLA_TURBOQUANT_SPARSE,
+                    AttentionBackendEnum.TRITON_MLA_TURBOQUANT,
+                    AttentionBackendEnum.TRITON_MLA,
+                    AttentionBackendEnum.FLASHINFER_MLA_SPARSE_SM120,
+                ]
             return [
                 AttentionBackendEnum.TRITON_MLA,
                 AttentionBackendEnum.FLASHINFER_MLA_SPARSE_SM120,
             ]
         else:
+            if kv_cache_dtype is not None and str(kv_cache_dtype).startswith(
+                "turboquant_"
+            ):
+                return [
+                    AttentionBackendEnum.TRITON_MLA_TURBOQUANT_SPARSE,
+                    AttentionBackendEnum.TRITON_MLA_TURBOQUANT,
+                    AttentionBackendEnum.FLASH_ATTN_MLA,
+                    AttentionBackendEnum.FLASHMLA,
+                    AttentionBackendEnum.FLASHINFER_MLA,
+                    AttentionBackendEnum.TRITON_MLA,
+                    AttentionBackendEnum.FLASHMLA_SPARSE,
+                ]
             return [
+                AttentionBackendEnum.TRITON_MLA_TURBOQUANT,
                 AttentionBackendEnum.FLASH_ATTN_MLA,
                 AttentionBackendEnum.FLASHMLA,
                 AttentionBackendEnum.FLASHINFER_MLA,

--- a/vllm/v1/attention/backends/mla/flashmla_sparse.py
+++ b/vllm/v1/attention/backends/mla/flashmla_sparse.py
@@ -559,6 +559,22 @@ class FlashMLASparseImpl(SparseMLACommonImpl[FlashMLASparseMetadata]):
 
         vllm_config = get_current_vllm_config()
         max_tokens = vllm_config.scheduler_config.max_num_batched_tokens
+
+        # DCP wiring: under DCP the query is all-gathered over heads before the
+        # sparse decode kernel; these drive slot remapping + cross-rank LSE merge.
+        from vllm.distributed import get_dcp_group
+
+        _pc = vllm_config.parallel_config
+        self.dcp_world_size = _pc.decode_context_parallel_size
+        self.dcp_rank = (
+            get_dcp_group().rank_in_group if self.dcp_world_size > 1 else 0
+        )
+        # ★ Read-side interleave MUST match the write side. In 0.23 the KV write
+        # (block_table.py _compute_slot_mapping_kernel) uses
+        # cp_kv_cache_interleave_size, so we mirror that here (NOT
+        # dcp_kv_cache_interleave_size, which the --dcp-kv-cache-interleave-size
+        # flag sets but the 0.23 sparse write path does not consume).
+        self.dcp_interleave_size = _pc.cp_kv_cache_interleave_size
         q_concat_shape = (max_tokens, num_heads, head_size)
         if is_quantized_kv_cache(kv_cache_dtype):
             assert kv_cache_dtype == "fp8_ds_mla", (
@@ -590,7 +606,7 @@ class FlashMLASparseImpl(SparseMLACommonImpl[FlashMLASparseMetadata]):
         kv_c_and_k_pe_cache: torch.Tensor,
         topk_indices: torch.Tensor,
         attn_metadata: FlashMLASparseMetadata,
-    ) -> torch.Tensor:
+    ) -> tuple[torch.Tensor, torch.Tensor]:
         # Convert per-request indices to global slots (decode) or workspace
         # offsets (prefill). req_id_per_token covers the whole batch; slice it
         # to the MQA tokens (q may exclude prefill tokens routed to dense MHA).
@@ -600,8 +616,15 @@ class FlashMLASparseImpl(SparseMLACommonImpl[FlashMLASparseMetadata]):
             topk_indices,
             BLOCK_SIZE=attn_metadata.block_size,
             NUM_TOPK_TOKENS=topk_indices.shape[1],
-            return_valid_counts=True,
+            return_valid_counts=use_topk_length,
+            dcp_world_size=self.dcp_world_size,
+            dcp_rank=self.dcp_rank,
+            dcp_interleave_size=self.dcp_interleave_size,
         )
+        if use_topk_length:
+            topk_indices, topk_length = result
+        else:
+            topk_indices, topk_length = result, None
 
         return self._bf16_flash_mla_kernel(
             q,
@@ -805,35 +828,45 @@ class FlashMLASparseImpl(SparseMLACommonImpl[FlashMLASparseMetadata]):
         kv_c_and_k_pe_cache: torch.Tensor,
         topk_indices: torch.Tensor,
         topk_length: torch.Tensor | None = None,
-    ) -> torch.Tensor:
+    ) -> tuple[torch.Tensor, torch.Tensor]:
         num_tokens = q.shape[0]
+        # Under DCP the query has been all-gathered over heads (num_heads *
+        # dcp_world_size) before forward_mqa, so self.num_heads (per-rank) is
+        # wrong here; use the head count actually present in q.
+        actual_num_heads = q.shape[1]
         kv_c_and_k_pe_cache = kv_c_and_k_pe_cache.view(
             -1, 1, kv_c_and_k_pe_cache.shape[-1]
         )
 
         # NOTE(Chen): kernel requires num_local_head to be a multiple of
         # 64 on hopper and 128 on blackwell
-        if self.num_heads % self.prefill_padding != 0:
-            assert self.prefill_padding % self.num_heads == 0
+        if actual_num_heads % self.prefill_padding != 0:
+            padded_num_heads = (
+                (actual_num_heads + self.prefill_padding - 1) // self.prefill_padding
+            ) * self.prefill_padding
             logger.warning_once(
-                f"Padding num_heads from {self.num_heads} to "
-                f"{self.prefill_padding} for BF16 sparse prefill kernel"
+                f"Padding num_heads from {actual_num_heads} to "
+                f"{padded_num_heads} for BF16 sparse prefill kernel"
             )
-            q_padded = q.new_empty((q.shape[0], self.prefill_padding, q.shape[2]))
-            q_padded[:, : self.num_heads, :] = q
+            q_padded = q.new_empty((q.shape[0], padded_num_heads, q.shape[2]))
+            q_padded[:, :actual_num_heads, :] = q
             q = q_padded
 
         topk_indices = topk_indices.view(num_tokens, 1, -1)
-        output = flash_mla_sparse_fwd(
+        # flash_mla_sparse_fwd returns (output, max_logits, lse).
+        # output: [s_q, h_q, d_v]; lse: [s_q, h_q] -- already the [B, H] layout
+        # the DCP combine (cp_lse_ag_out_rs / dcp_a2a_lse_reduce) expects.
+        output, _max_logits, lse = flash_mla_sparse_fwd(
             q,
             kv_c_and_k_pe_cache,
             topk_indices,
             self.softmax_scale,
             topk_length=topk_length,
-        )[0]
+        )
 
-        output = output[:, : self.num_heads, :]
-        return output
+        output = output[:, :actual_num_heads, :]
+        lse = lse[:, :actual_num_heads]
+        return output, lse
 
     def forward_mqa(
         self,
@@ -860,9 +893,11 @@ class FlashMLASparseImpl(SparseMLACommonImpl[FlashMLASparseMetadata]):
         use_fp8_cache = self.kv_cache_dtype == "fp8_ds_mla"
 
         if not use_fp8_cache:
-            attn_out = self._forward_bf16_kv(
+            # BF16 sparse path returns the LSE so DCP can merge per-rank partials.
+            attn_out, lse = self._forward_bf16_kv(
                 q, kv_c_and_k_pe_cache, topk_indices, attn_metadata
             )
+            return attn_out, lse
         elif attn_metadata.fp8_use_mixed_batch:
             attn_out = self._forward_fp8_kv_mixed_batch(
                 q, kv_c_and_k_pe_cache, topk_indices, attn_metadata

--- a/vllm/v1/attention/backends/mla/flashmla_sparse.py
+++ b/vllm/v1/attention/backends/mla/flashmla_sparse.py
@@ -566,9 +566,7 @@ class FlashMLASparseImpl(SparseMLACommonImpl[FlashMLASparseMetadata]):
 
         _pc = vllm_config.parallel_config
         self.dcp_world_size = _pc.decode_context_parallel_size
-        self.dcp_rank = (
-            get_dcp_group().rank_in_group if self.dcp_world_size > 1 else 0
-        )
+        self.dcp_rank = get_dcp_group().rank_in_group if self.dcp_world_size > 1 else 0
         # ★ Read-side interleave MUST match the write side. In 0.23 the KV write
         # (block_table.py _compute_slot_mapping_kernel) uses
         # cp_kv_cache_interleave_size, so we mirror that here (NOT
@@ -616,15 +614,11 @@ class FlashMLASparseImpl(SparseMLACommonImpl[FlashMLASparseMetadata]):
             topk_indices,
             BLOCK_SIZE=attn_metadata.block_size,
             NUM_TOPK_TOKENS=topk_indices.shape[1],
-            return_valid_counts=use_topk_length,
+            return_valid_counts=True,
             dcp_world_size=self.dcp_world_size,
             dcp_rank=self.dcp_rank,
             dcp_interleave_size=self.dcp_interleave_size,
         )
-        if use_topk_length:
-            topk_indices, topk_length = result
-        else:
-            topk_indices, topk_length = result, None
 
         return self._bf16_flash_mla_kernel(
             q,

--- a/vllm/v1/attention/backends/mla/indexer.py
+++ b/vllm/v1/attention/backends/mla/indexer.py
@@ -1275,9 +1275,9 @@ def build_prefill_chunk_metadata(
     global_seq_lens_lst = None
     if dcp_world_size > 1:
         ctx_lens_cpu = compressed_seq_lens_cpu[start_idx:end_idx].to(torch.int32)
-        dcp_virtual_block = dcp_world_size * cp_interleave_size
+        dcp_virtual_block = dcp_world_size * cp_kv_cache_interleave_size
         padded_local_cpu = (
-            cdiv(ctx_lens_cpu, dcp_virtual_block) * cp_interleave_size
+            cdiv(ctx_lens_cpu, dcp_virtual_block) * cp_kv_cache_interleave_size
         ).to(torch.int32)
         local_cu_cpu = torch.zeros(num_reqs + 1, dtype=torch.int32)
         torch.cumsum(padded_local_cpu, dim=0, out=local_cu_cpu[1:])

--- a/vllm/v1/attention/backends/mla/indexer.py
+++ b/vllm/v1/attention/backends/mla/indexer.py
@@ -227,6 +227,10 @@ class DeepseekV32IndexerPrefillChunkMetadata:
     local_cu_seq_lens: torch.Tensor | None = None
     local_total_seq_lens: int = 0
     max_local_total_seq_lens: int = 0
+    # Per-request padded local lengths and original global lengths used to
+    # reconstruct the full index-K after the DCP all-gather.
+    padded_local_seq_lens: list[int] | None = None
+    global_seq_lens_lst: list[int] | None = None
 
 
 _BUILD_PREFILL_CHUNK_METADATA_INPUT_VARIANTS = (
@@ -726,9 +730,9 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
                 and num_decodes * max_decode_len == num_decode_tokens
             ):
                 # Uniform decode lengths with no cudagraph token padding.
-                expanded_block_table = self._get_expanded_block_table_buffer(
-                    num_decode_tokens, block_table.shape[1]
-                )
+                expanded_block_table = self.expanded_block_table_buffer[
+                    :num_decode_tokens
+                ]
                 copy_block_table_width = min(
                     block_table.shape[1], expanded_block_table.shape[1]
                 )
@@ -785,9 +789,9 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
                 # original request.
                 # B (DCP/TQ4bit): dynamically sized target buffer, width ==
                 # block_table.shape[1].
-                expanded_block_table = self._get_expanded_block_table_buffer(
-                    num_decode_tokens, block_table.shape[1]
-                )
+                expanded_block_table = self.expanded_block_table_buffer[
+                    :num_decode_tokens
+                ]
                 # A (PP+MTP): clamp the repeat_interleave to the target buffer
                 # width. Under B's sizing this equals the full width, so the
                 # column slices below are full-width and the tail zero-fill is a
@@ -804,9 +808,7 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
                     )
                 )
                 if copy_block_table_width < expanded_block_table.shape[1]:
-                    expanded_block_table[
-                        :actual_expanded, copy_block_table_width:
-                    ] = 0
+                    expanded_block_table[:actual_expanded, copy_block_table_width:] = 0
                 if actual_expanded < num_decode_tokens:
                     expanded_block_table[actual_expanded:num_decode_tokens, 0] = 0
                 block_table = expanded_block_table
@@ -946,9 +948,6 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
                 self.kv_cache_spec.storage_block_size,
                 self.compress_ratio,
                 out=self.compressed_slot_mapping_buffer,
-                dcp_world_size=self.dcp_world_size,
-                dcp_rank=self.dcp_rank,
-                cp_interleave_size=compressed_cp_interleave_size,
             )
             if self.pcp_world_size > 1:
                 compressed_slot_mapping = get_pcp_group().all_gather(
@@ -1114,7 +1113,6 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
             # must read with this rank's LOCAL lengths (it then produces logits
             # for the local tokens in local order); the GLOBAL lengths are kept
             # for the top-k selection after the cross-rank logits all-gather.
-            global_seq_lens = seq_lens
             kernel_seq_lens = seq_lens
             if self.dcp_world_size > 1:
                 local_flat = get_dcp_local_seq_lens(
@@ -1277,7 +1275,8 @@ def build_prefill_chunk_metadata(
         ctx_lens_cpu = compressed_seq_lens_cpu[start_idx:end_idx].to(torch.int32)
         dcp_virtual_block = dcp_world_size * cp_kv_cache_interleave_size
         padded_local_cpu = (
-            (ctx_lens_cpu + dcp_virtual_block - 1) // dcp_virtual_block
+            (ctx_lens_cpu + dcp_virtual_block - 1)
+            // dcp_virtual_block
             * cp_kv_cache_interleave_size
         ).to(torch.int32)
         local_cu_cpu = torch.zeros(num_reqs + 1, dtype=torch.int32)
@@ -1300,4 +1299,6 @@ def build_prefill_chunk_metadata(
         local_cu_seq_lens=local_cu_seq_lens,
         local_total_seq_lens=local_total_seq_lens,
         max_local_total_seq_lens=max_local_total_seq_lens,
+        padded_local_seq_lens=padded_local_seq_lens,
+        global_seq_lens_lst=global_seq_lens_lst,
     )

--- a/vllm/v1/attention/backends/mla/indexer.py
+++ b/vllm/v1/attention/backends/mla/indexer.py
@@ -71,6 +71,7 @@ def _prepare_uniform_decode_kernel(
     block_table_stride,
     expanded_block_table_ptr,
     expanded_bt_stride,
+    block_table_width: tl.constexpr,
     decode_lens_ptr,
     max_decode_len,
     BLOCK_SIZE: tl.constexpr,
@@ -90,9 +91,9 @@ def _prepare_uniform_decode_kernel(
     # Copy block table row.
     src = block_table_ptr + req_id * block_table_stride
     dst = expanded_block_table_ptr + idx * expanded_bt_stride
-    for i in tl.range(0, expanded_bt_stride, BLOCK_SIZE):
+    for i in tl.range(0, block_table_width, BLOCK_SIZE):
         off = i + tl.arange(0, BLOCK_SIZE)
-        mask = off < expanded_bt_stride
+        mask = off < block_table_width
         src_block = tl.load(src + off, mask=mask)
         tl.store(dst + off, src_block, mask=mask)
 
@@ -445,6 +446,8 @@ class DeepSeekV32IndexerDecodeMetadata:
     #   - flatten path / plain decode: 1D (batch_size,)
     #   - native MTP path: 2D (B, next_n) where [b,j] = L_b - next_n + j + 1
     # Both fp8_fp4_paged_mqa_logits and the topk kernels accept both shapes.
+    # Under DCP this holds the per-rank LOCAL context lengths used to read this
+    # rank's KV shard; the global lengths used for top-k are in global_seq_lens.
     seq_lens: torch.Tensor
     decode_lens: torch.Tensor
     requires_padding: bool
@@ -567,6 +570,28 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
         sm_count = num_compute_units(self.device.index)
         self.num_sms = sm_count
 
+        # DCP: the indexer's KV cache is sharded across dcp ranks, so each rank
+        # can only compute logits over its local shard. We read with local
+        # seq_lens, then scatter the per-rank logits back to global positions
+        # and all-reduce so every rank selects the same global top-k. See
+        # sparse_attn_indexer._dcp_allgather_indexer_logits.
+        parallel_config = self.vllm_config.parallel_config
+        self.dcp_world_size = parallel_config.decode_context_parallel_size
+        dcp_interleave_size = getattr(
+            parallel_config, "dcp_kv_cache_interleave_size", 1
+        )
+        self.cp_interleave_size = (
+            dcp_interleave_size
+            if self.dcp_world_size > 1 and dcp_interleave_size > 1
+            else parallel_config.cp_kv_cache_interleave_size
+        )
+        if self.dcp_world_size > 1:
+            from vllm.distributed import get_dcp_group
+
+            self.dcp_rank = get_dcp_group().rank_in_group
+        else:
+            self.dcp_rank = 0
+
         self.offsets_buffer = torch.arange(
             next_n, device=self.device, dtype=torch.int32
         )
@@ -601,6 +626,7 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
             dtype=torch.int32,
             device=self.device,
         )
+
         self.expanded_block_table_buffer = torch.zeros(
             (scheduler_config.max_num_batched_tokens, block_table_width),
             dtype=torch.int32,
@@ -611,6 +637,22 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
         # build() narrows it to whatever the kernel actually schedules.
         self.scheduler_metadata_buffer = torch.empty(
             (self.num_sms + 1, 2), dtype=torch.int32, device=self.device
+        )
+
+        # DCP + FULL cudagraph fix: under DCP the per-rank local seq_lens
+        # (context_lens consumed by the paged_mqa_logits kernel) are derived
+        # fresh each step via get_dcp_local_seq_lens(), so the tensor is NOT a
+        # static buffer. When the kernel is captured into a FULL cudagraph the
+        # baked context_lens pointer can read stale (capture-time) values at
+        # replay, which becomes inconsistent with the (persistent, refreshed)
+        # schedule_metadata_buffer and deadlocks the warpgroup mbarrier pipeline
+        # at batch>1 + long context. Copy the local seq_lens into this static
+        # buffer so the kernel always reads address-stable, up-to-date values.
+        next_n = 1 + self.num_speculative_tokens
+        self.dcp_local_seq_lens_buffer = torch.zeros(
+            (scheduler_config.max_num_batched_tokens,),
+            dtype=torch.int32,
+            device=self.device,
         )
 
         # KV compression. Default to 1 for no compression.
@@ -683,20 +725,29 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
                 and num_decodes * max_decode_len == num_decode_tokens
             ):
                 # Uniform decode lengths with no cudagraph token padding.
+                expanded_block_table = self._get_expanded_block_table_buffer(
+                    num_decode_tokens, block_table.shape[1]
+                )
+                copy_block_table_width = min(
+                    block_table.shape[1], expanded_block_table.shape[1]
+                )
                 _prepare_uniform_decode_kernel[(num_decode_tokens,)](
                     seq_lens,
                     self.decode_seq_lens_buffer,
                     block_table,
                     block_table.stride(0),
-                    self.expanded_block_table_buffer,
-                    self.expanded_block_table_buffer.stride(0),
+                    expanded_block_table,
+                    expanded_block_table.stride(0),
+                    copy_block_table_width,
                     self.decode_lens_buffer,
                     max_decode_len,
                     BLOCK_SIZE=1024,
                 )
+                if copy_block_table_width < expanded_block_table.shape[1]:
+                    expanded_block_table[:, copy_block_table_width:] = 0
                 self.decode_seq_lens_buffer[num_decode_tokens:] = 0
                 seq_lens = self.decode_seq_lens_buffer[:num_decode_tokens]
-                block_table = self.expanded_block_table_buffer[:num_decode_tokens]
+                block_table = expanded_block_table
                 decode_lens = self.decode_lens_buffer[:num_decode_tokens]
                 return seq_lens, block_table, decode_lens, num_decode_tokens, False
             else:
@@ -731,16 +782,33 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
 
                 # Give each of the flattened entries the same block table row as the
                 # original request.
-                self.expanded_block_table_buffer[:actual_expanded] = (
+                # B (DCP/TQ4bit): dynamically sized target buffer, width ==
+                # block_table.shape[1].
+                expanded_block_table = self._get_expanded_block_table_buffer(
+                    num_decode_tokens, block_table.shape[1]
+                )
+                # A (PP+MTP): clamp the repeat_interleave to the target buffer
+                # width. Under B's sizing this equals the full width, so the
+                # column slices below are full-width and the tail zero-fill is a
+                # no-op; kept as a defensive guard against a narrower buffer.
+                copy_block_table_width = min(
+                    block_table.shape[1], expanded_block_table.shape[1]
+                )
+                expanded_block_table[:actual_expanded, :copy_block_table_width] = (
                     torch.repeat_interleave(
-                        block_table, decode_lens, dim=0, output_size=actual_expanded
+                        block_table[:, :copy_block_table_width],
+                        decode_lens,
+                        dim=0,
+                        output_size=actual_expanded,
                     )
                 )
-                if actual_expanded < num_decode_tokens:
-                    self.expanded_block_table_buffer[
-                        actual_expanded:num_decode_tokens, 0
+                if copy_block_table_width < expanded_block_table.shape[1]:
+                    expanded_block_table[
+                        :actual_expanded, copy_block_table_width:
                     ] = 0
-                block_table = self.expanded_block_table_buffer[:num_decode_tokens]
+                if actual_expanded < num_decode_tokens:
+                    expanded_block_table[actual_expanded:num_decode_tokens, 0] = 0
+                block_table = expanded_block_table
 
                 # All reqs now have decode_len=1
                 self.decode_lens_buffer[:num_decode_tokens] = 1
@@ -852,6 +920,7 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
 
         compressed_slot_mapping = slot_mapping
         compressed_seq_lens = seq_lens
+        compressed_cp_interleave_size = self.cp_interleave_size
         if self.compress_ratio > 1:
             padded_num_tokens = num_tokens
             if self.pcp_world_size > 1:
@@ -864,6 +933,9 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
                 self.kv_cache_spec.storage_block_size,
                 self.compress_ratio,
                 out=self.compressed_slot_mapping_buffer,
+                dcp_world_size=self.dcp_world_size,
+                dcp_rank=self.dcp_rank,
+                cp_interleave_size=compressed_cp_interleave_size,
             )
             if self.pcp_world_size > 1:
                 compressed_slot_mapping = get_pcp_group().all_gather(
@@ -1024,11 +1096,34 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
             if seq_lens.dim() == 1:
                 seq_lens = seq_lens.unsqueeze(-1)
 
+            # `seq_lens` here are the GLOBAL (full) context lengths. Under DCP
+            # the indexer KV cache is sharded, so the paged-MQA-logits kernel
+            # must read with this rank's LOCAL lengths (it then produces logits
+            # for the local tokens in local order); the GLOBAL lengths are kept
+            # for the top-k selection after the cross-rank logits all-gather.
+            global_seq_lens = seq_lens
+            kernel_seq_lens = seq_lens
+            if self.dcp_world_size > 1:
+                local_flat = get_dcp_local_seq_lens(
+                    seq_lens.reshape(-1),
+                    self.dcp_world_size,
+                    self.dcp_rank,
+                    compressed_cp_interleave_size,
+                )
+                # Copy into a static buffer so the paged_mqa_logits kernel's
+                # context_lens has an address-stable, up-to-date source under
+                # FULL cudagraph capture/replay (see __init__ for rationale).
+                numel = seq_lens.numel()
+                self.dcp_local_seq_lens_buffer[:numel] = local_flat.reshape(-1)
+                kernel_seq_lens = self.dcp_local_seq_lens_buffer[:numel].view(
+                    seq_lens.shape
+                )
+
             # DeepGEMM is required for the paged MQA logits on CUDA devices
             schedule_metadata = self.scheduler_metadata_buffer
             if current_platform.is_cuda() and has_deep_gemm():
                 metadata = get_paged_mqa_logits_metadata(
-                    seq_lens,
+                    kernel_seq_lens,
                     self.kv_cache_spec.storage_block_size,
                     self.num_sms,
                     indices=decode_indices,
@@ -1038,7 +1133,7 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
 
             decode_metadata = DeepSeekV32IndexerDecodeMetadata(
                 block_table=block_table,
-                seq_lens=seq_lens,
+                seq_lens=kernel_seq_lens,
                 decode_lens=decode_lens,
                 requires_padding=requires_padding,
                 schedule_metadata=schedule_metadata,
@@ -1153,6 +1248,26 @@ def build_prefill_chunk_metadata(
         skip_kv_gather = skip_kv_gather or qs_start > 0
     else:
         token_end = query_start_loc_cpu[end_idx].item()
+
+    # DCP: build the metadata needed to (1) gather this rank's LOCAL index-K
+    # with a padded length identical across ranks, and (2) reorg the
+    # all-gathered shards back into global token order. With interleave size 1
+    # the per-request padded local length is ceil(ctx / dcp_world_size); the
+    # reorg in the op is a transpose-reshape interleave trimmed to ctx.
+    local_cu_seq_lens = None
+    padded_local_seq_lens = None
+    global_seq_lens_lst = None
+    if dcp_world_size > 1:
+        ctx_lens_cpu = compressed_seq_lens_cpu[start_idx:end_idx].to(torch.int32)
+        dcp_virtual_block = dcp_world_size * cp_interleave_size
+        padded_local_cpu = (
+            cdiv(ctx_lens_cpu, dcp_virtual_block) * cp_interleave_size
+        ).to(torch.int32)
+        local_cu_cpu = torch.zeros(num_reqs + 1, dtype=torch.int32)
+        torch.cumsum(padded_local_cpu, dim=0, out=local_cu_cpu[1:])
+        local_cu_seq_lens = local_cu_cpu.to(device, non_blocking=True)
+        padded_local_seq_lens = padded_local_cpu.tolist()
+        global_seq_lens_lst = ctx_lens_cpu.tolist()
 
     return DeepseekV32IndexerPrefillChunkMetadata(
         cu_seqlen_ks=cu_seq_len_ks,

--- a/vllm/v1/attention/backends/mla/indexer.py
+++ b/vllm/v1/attention/backends/mla/indexer.py
@@ -586,8 +586,6 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
             else parallel_config.cp_kv_cache_interleave_size
         )
         if self.dcp_world_size > 1:
-            from vllm.distributed import get_dcp_group
-
             self.dcp_rank = get_dcp_group().rank_in_group
         else:
             self.dcp_rank = 0

--- a/vllm/v1/attention/backends/mla/indexer.py
+++ b/vllm/v1/attention/backends/mla/indexer.py
@@ -454,6 +454,9 @@ class DeepSeekV32IndexerDecodeMetadata:
     schedule_metadata: torch.Tensor
     global_seq_lens: torch.Tensor | None = None
     indices: torch.Tensor | None = None
+    dcp_world_size: int = 1
+    dcp_rank: int = 0
+    cp_interleave_size: int = 1
 
 
 @dataclass
@@ -1137,6 +1140,9 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
                 schedule_metadata=schedule_metadata,
                 indices=decode_indices,
                 global_seq_lens=global_seq_lens_for_decode,
+                dcp_world_size=self.dcp_world_size,
+                dcp_rank=self.dcp_rank,
+                cp_interleave_size=self.cp_interleave_size,
             )
 
         attn_metadata = DeepseekV32IndexerMetadata(

--- a/vllm/v1/attention/backends/mla/indexer.py
+++ b/vllm/v1/attention/backends/mla/indexer.py
@@ -1277,7 +1277,8 @@ def build_prefill_chunk_metadata(
         ctx_lens_cpu = compressed_seq_lens_cpu[start_idx:end_idx].to(torch.int32)
         dcp_virtual_block = dcp_world_size * cp_kv_cache_interleave_size
         padded_local_cpu = (
-            cdiv(ctx_lens_cpu, dcp_virtual_block) * cp_kv_cache_interleave_size
+            (ctx_lens_cpu + dcp_virtual_block - 1) // dcp_virtual_block
+            * cp_kv_cache_interleave_size
         ).to(torch.int32)
         local_cu_cpu = torch.zeros(num_reqs + 1, dtype=torch.int32)
         torch.cumsum(padded_local_cpu, dim=0, out=local_cu_cpu[1:])

--- a/vllm/v1/attention/backends/mla/indexer.py
+++ b/vllm/v1/attention/backends/mla/indexer.py
@@ -855,8 +855,20 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
     ) -> torch.Tensor | None:
         if global_seq_lens is None:
             return None
-        if use_native or max_decode_len <= 1:
+        if max_decode_len <= 1:
             return global_seq_lens
+        if use_native:
+            num_decodes = global_seq_lens.shape[0]
+            global_buffer = self.global_decode_seq_lens_buffer[
+                : num_decodes * max_decode_len
+            ].view(num_decodes, max_decode_len)
+            global_buffer[:] = (
+                global_seq_lens.unsqueeze(1)
+                - max_decode_len
+                + 1
+                + self.offsets_buffer[:max_decode_len]
+            )
+            return global_buffer
 
         actual_expanded = int(decode_lens_cpu.sum().item())
         if actual_expanded > 0:

--- a/vllm/v1/attention/backends/mla/sparse_utils.py
+++ b/vllm/v1/attention/backends/mla/sparse_utils.py
@@ -162,6 +162,9 @@ def triton_convert_req_index_to_global_index(
     prefill_workspace_request_ids: torch.Tensor | None = None,
     prefill_workspace_starts: torch.Tensor | None = None,
     return_valid_counts: bool = False,
+    dcp_world_size: int = 1,
+    dcp_rank: int = 0,
+    dcp_interleave_size: int = 1,
 ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
     """
     out[token_id, indice_id] =
@@ -322,7 +325,6 @@ def triton_filter_and_convert_dcp_index(
             BLOCK_N=BLOCK_N,
             return_valid_counts=return_valid_counts,
         )
-
     num_tokens = req_id.shape[0]
     max_num_blocks_per_req = block_table.shape[1]
 

--- a/vllm/v1/attention/backends/mla/triton_mla_tq.py
+++ b/vllm/v1/attention/backends/mla/triton_mla_tq.py
@@ -48,13 +48,13 @@ import numpy as np
 import torch
 
 import vllm.envs as envs
+from vllm import _custom_ops as ops
 from vllm.config import get_current_vllm_config
 from vllm.config.cache import CacheDType
 from vllm.config.vllm import VllmConfig
 from vllm.logger import init_logger
 from vllm.model_executor.layers.attention.mla_attention import (
     MLACommonMetadata,
-    MLACommonMetadataBuilder,
 )
 from vllm.model_executor.layers.attention.sparse_mla_attention import (
     SparseMLACommonImpl,
@@ -65,8 +65,8 @@ from vllm.model_executor.layers.quantization.turboquant.centroids import (
 from vllm.model_executor.layers.quantization.turboquant.config import (
     TurboQuantConfig,
 )
+from vllm.platforms import current_platform
 from vllm.platforms.interface import DeviceCapability
-from vllm.triton_utils import triton
 from vllm.v1.attention.backend import (
     AttentionCGSupport,
     AttentionLayer,
@@ -77,15 +77,18 @@ from vllm.v1.attention.backends.mla.sparse_utils import (
     triton_convert_req_index_to_global_index,
     triton_filter_and_convert_dcp_index,
 )
-from vllm.v1.kv_cache_interface import AttentionSpec
-from vllm.v1.attention.ops.flashmla import flash_mla_sparse_fwd
-from vllm.platforms import current_platform
-from vllm import _custom_ops as ops
 from vllm.v1.attention.backends.mla.triton_mla import (
     TritonMLABackend,
     TritonMLAImpl,
+    TritonMLAMetadataBuilder,
 )
 from vllm.v1.attention.backends.turboquant_attn import _build_hadamard
+from vllm.v1.attention.ops.flashmla import flash_mla_sparse_fwd
+from vllm.v1.attention.ops.tq_mla_defaults import (
+    default_kpe_4bit,
+    default_kpe_fp8,
+    default_store_fwht,
+)
 from vllm.v1.attention.ops.triton_decode_attention import (
     _decode_softmax_reducev_fwd,
 )
@@ -98,17 +101,13 @@ from vllm.v1.attention.ops.triton_turboquant_mla_decode import (
     tq_mla_sparse_adaptive_enabled,
     tq_mla_sparse_split_count,
 )
-from vllm.v1.attention.ops.tq_mla_defaults import (
-    default_kpe_4bit,
-    default_kpe_fp8,
-    default_store_fwht,
-)
 from vllm.v1.attention.ops.triton_turboquant_mla_store import (
     kpe_mse_index_bytes,
     kpe_packed_bytes,
     tq_mla_fused_kv_cache_store,
     tq_mla_fused_store_enabled,
 )
+from vllm.v1.kv_cache_interface import AttentionSpec
 from vllm.v1.worker.workspace import (
     current_workspace_manager,
     is_workspace_manager_initialized,
@@ -132,10 +131,7 @@ _DEDUP_BUCKET_IDMAP_WS: dict[str, torch.Tensor] = {}
 
 
 def _in_cuda_graph_capture() -> bool:
-    return (
-        torch.cuda.is_available()
-        and torch.cuda.is_current_stream_capturing()
-    )
+    return torch.cuda.is_available() and torch.cuda.is_current_stream_capturing()
 
 
 def _sparse_topk_dedup_enabled() -> bool:
@@ -144,9 +140,7 @@ def _sparse_topk_dedup_enabled() -> bool:
         return False
     # torch.unique / Tensor.any() sync during CUDAGraph capture →
     # cudaErrorStreamCaptureUnsupported (breaks engine startup).
-    if _in_cuda_graph_capture():
-        return False
-    return True
+    return not _in_cuda_graph_capture()
 
 
 def _dedup_bucket_enabled() -> bool:
@@ -216,7 +210,9 @@ def _dedup_global_topk(
         present.fill_(False)
         present[safe_long] = True
         present[n_slots] = False  # drop invalid sentinel
-        unique_slots = present[:-1].nonzero(as_tuple=True)[0].to(torch.int32)  # ascending
+        unique_slots = (
+            present[:-1].nonzero(as_tuple=True)[0].to(torch.int32)
+        )  # ascending
         num_unique = int(unique_slots.numel())
         id_map.fill_(-1)
         id_map[unique_slots.to(torch.long)] = torch.arange(
@@ -228,14 +224,10 @@ def _dedup_global_topk(
 
     if not bool(valid.any()):
         empty = torch.empty(0, dtype=torch.int32, device=device)
-        remapped = torch.full(
-            (num_tokens, topk), -1, dtype=torch.int32, device=device
-        )
+        remapped = torch.full((num_tokens, topk), -1, dtype=torch.int32, device=device)
         return empty, remapped, 0
 
-    unique_slots, inverse = torch.unique(
-        flat[valid], sorted=True, return_inverse=True
-    )
+    unique_slots, inverse = torch.unique(flat[valid], sorted=True, return_inverse=True)
     remapped_flat = torch.full((flat.numel(),), -1, dtype=torch.int32, device=device)
     remapped_flat[valid] = inverse.to(torch.int32)
     remapped = remapped_flat.view(num_tokens, topk)
@@ -378,7 +370,7 @@ def _unpack_bits_rows(packed: torch.Tensor, bits: int, D: int) -> torch.Tensor:
     return out.to(torch.int64)
 
 
-class TritonMLATurboQuantMetadataBuilder(MLACommonMetadataBuilder[MLACommonMetadata]):
+class TritonMLATurboQuantMetadataBuilder(TritonMLAMetadataBuilder):
     """MLA metadata builder that advertises CUDA-graph support.
 
     Parent MLACommonMetadataBuilder defaults to AttentionCGSupport.NEVER.
@@ -452,7 +444,7 @@ class TritonMLATurboQuantBackend(TritonMLABackend):
         return TritonMLATurboQuantImpl
 
     @staticmethod
-    def get_builder_cls() -> type[TritonMLATurboQuantMetadataBuilder]:
+    def get_builder_cls() -> type[TritonMLAMetadataBuilder]:
         return TritonMLATurboQuantMetadataBuilder
 
 
@@ -491,7 +483,8 @@ class TritonMLATurboQuantImpl(TritonMLAImpl):
         # P3-2 / P6-4: k_pe FP8 (e4m3) compression (default on).
         # bf16 layout: 2*R bytes when VLLM_TQ_KPE_FP8=0.
         # fp8 layout:  R bytes fp8 + 2 bytes per-token fp16 scale.
-        # 4bit layout: ceil(R*4/8) index bytes + 2 bytes fp16 scale (VLLM_TQ_KPE_4BIT=1).
+        # 4bit: ceil(R*4/8) index bytes + 2-byte fp16 scale
+        # (VLLM_TQ_KPE_4BIT=1).
         # R=64 → 128B → 66B (~48% smaller k_pe, ~16% smaller 4bit_nc slot).
         # k_pe layout follows --kv-cache-dtype (NC presets → 4bit + FWHT store).
         self._kpe_4bit = default_kpe_4bit(self.kv_cache_dtype, self.tq_config)
@@ -607,8 +600,8 @@ class TritonMLATurboQuantImpl(TritonMLAImpl):
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         shapes_and_dtypes = (
             ((B, H_q, num_kv_splits, L + 1), torch.float32),  # attn_logits
-            ((B, H_q, L), out_dtype),                          # o_unrot
-            ((B, H_q), out_dtype),                             # lse
+            ((B, H_q, L), out_dtype),  # o_unrot
+            ((B, H_q), out_dtype),  # lse
         )
         if is_workspace_manager_initialized():
             attn_logits, o_unrot, lse = current_workspace_manager().get_simultaneous(
@@ -741,6 +734,7 @@ class TritonMLATurboQuantImpl(TritonMLAImpl):
             and self.qk_rope_head_dim == 64
         ):
             import flash_mla.cuda as _fm
+
             if not getattr(self, "_tq4_cuda_store_logged", False):
                 print("[TQ4-CUDA] store branch ACTIVE", flush=True)
                 self._tq4_cuda_store_logged = True
@@ -911,11 +905,13 @@ class TritonMLATurboQuantImpl(TritonMLAImpl):
 
         output = None
         output_lse = None
-        iters = len(prefill_metadata.chunked_context.seq_tot)
-        workspace = prefill_metadata.chunked_context.workspace
+        chunked_context = prefill_metadata.chunked_context
+        assert chunked_context is not None
+        assert prefill_metadata.prefill_backend is not None
+        workspace = chunked_context.workspace
 
-        for i in range(iters):
-            toks = prefill_metadata.chunked_context.seq_tot[i]
+        for chunk in chunked_context.chunks:
+            toks = chunk.num_context_tokens
             if toks <= 0:
                 continue
 
@@ -925,15 +921,13 @@ class TritonMLATurboQuantImpl(TritonMLAImpl):
             #   batch_offset  = token_id - batch_start + seq_starts[batch_id]
             #   block_id      = block_table[batch_id, batch_offset // block_size]
             #   slot_id       = batch_offset % block_size
-            num_tokens = int(prefill_metadata.chunked_context.chunk_total_token[i])
-            token_to_seq = prefill_metadata.chunked_context.token_to_seq[i][
-                :num_tokens
-            ].to(torch.int64)
-            cu_seq_lens = prefill_metadata.chunked_context.cu_seq_lens[i].to(
+            num_tokens = toks
+            token_to_seq = chunk.token_to_seq[:num_tokens].to(torch.int64)
+            cu_seq_lens = chunk.cu_seq_lens.to(torch.int64)
+            seq_starts_t = chunk.starts
+            block_table = prefill_metadata.block_table[chunk.request_slice].to(
                 torch.int64
             )
-            seq_starts_t = prefill_metadata.chunked_context.starts[i]
-            block_table = prefill_metadata.block_table.to(torch.int64)
 
             # All shape-dependent gather math stays on-device (CG-compatible).
             batch_ids = token_to_seq  # (num_tokens,)
@@ -972,11 +966,16 @@ class TritonMLATurboQuantImpl(TritonMLAImpl):
                 # we apply inverse Hadamard as the final bf16 GEMM.
                 if (
                     os.environ.get("VLLM_TQ_MLA_CUDA_DEQUANT") == "1"
-                    and self._kpe_4bit and L == 512 and R == 64
+                    and self._kpe_4bit
+                    and L == 512
+                    and R == 64
                 ):
                     import flash_mla.cuda as _fm
+
                     if not getattr(self, "_tq4_cuda_deq_dense_logged", False):
-                        print("[TQ4-CUDA] prefill dense dequant branch ACTIVE", flush=True)
+                        print(
+                            "[TQ4-CUDA] prefill dense dequant branch ACTIVE", flush=True
+                        )
                         self._tq4_cuda_deq_dense_logged = True
                     _fm.tq4_dequant_fwd(
                         cache_view.contiguous(),
@@ -1022,12 +1021,13 @@ class TritonMLATurboQuantImpl(TritonMLAImpl):
             k_nope, v = kv_nope.split([self.qk_nope_head_dim, self.v_head_dim], dim=-1)
             k = self._concat_k_nope_k_pe(k_nope, k_pe)
 
-            attn_output, attn_softmax_lse = self._run_prefill_context_chunk(
-                prefill=prefill_metadata,
-                chunk_idx=i,
-                q=q,
-                k=k,
-                v=v,
+            attn_output, attn_softmax_lse = (
+                prefill_metadata.prefill_backend.run_prefill_context_chunk(
+                    chunk=chunk,
+                    q=q[chunk.token_slice],
+                    k=k,
+                    v=v,
+                )
             )
             if output is None:
                 output = attn_output
@@ -1099,7 +1099,12 @@ class TritonMLATurboQuantImpl(TritonMLAImpl):
         # P0-2: pool scratch buffers via WorkspaceManager instead of
         # allocating fresh tensors every forward.
         attn_logits, o_unrot, lse = self._get_decode_workspaces(
-            B, H_q, num_kv_splits, L, q.dtype, device,
+            B,
+            H_q,
+            num_kv_splits,
+            L,
+            q.dtype,
+            device,
         )
 
         # 3) Fused stage1 directly on packed uint8 cache.
@@ -1170,7 +1175,12 @@ class TritonMLATurboQuantImpl(TritonMLAImpl):
 
         # P0-2: pool scratch buffers via WorkspaceManager.
         attn_logits, o_unrot, lse = self._get_decode_workspaces(
-            B, H_q, num_kv_splits, L, q.dtype, device,
+            B,
+            H_q,
+            num_kv_splits,
+            L,
+            q.dtype,
+            device,
         )
 
         # Empty centroid placeholder — KEY_FP8 branch never reads it; Triton
@@ -1424,13 +1434,8 @@ class TritonMLATurboQuantSparseMetadataBuilder(TritonMLATurboQuantMetadataBuilde
         vllm_config: VllmConfig,
         device: torch.device,
     ) -> None:
-        super().__init__(
-            kv_cache_spec,
-            layer_names,
-            vllm_config,
-            device,
-            metadata_cls=TritonMLATurboQuantSparseMetadata,
-        )
+        super().__init__(kv_cache_spec, layer_names, vllm_config, device)
+        self.metadata_cls = TritonMLATurboQuantSparseMetadata
         # DCP+MTP fix: the base helper resets reorder_batch_threshold back to 1
         # when decode_context_parallel_size>1 unless supports_dcp_with_varlen is
         # set. Without this, MTP spec-decode (uniform query_len = 1+num_spec) is
@@ -1469,7 +1474,9 @@ class TritonMLATurboQuantSparseMetadataBuilder(TritonMLATurboQuantMetadataBuilde
             torch.from_numpy(req_id_per_token), non_blocking=True
         )
 
-        sparse_fields = {f.name: getattr(base, f.name) for f in fields(MLACommonMetadata)}
+        sparse_fields = {
+            f.name: getattr(base, f.name) for f in fields(MLACommonMetadata)
+        }
         return TritonMLATurboQuantSparseMetadata(
             **sparse_fields,
             req_id_per_token=self.req_id_per_token_buffer[:num_tokens],
@@ -1501,7 +1508,7 @@ class TritonMLATurboQuantSparseBackend(TritonMLATurboQuantBackend):
         return TritonMLATurboQuantSparseImpl
 
     @staticmethod
-    def get_builder_cls() -> type[TritonMLATurboQuantSparseMetadataBuilder]:
+    def get_builder_cls() -> type[TritonMLAMetadataBuilder]:
         return TritonMLATurboQuantSparseMetadataBuilder
 
 
@@ -1517,7 +1524,6 @@ class TritonMLATurboQuantSparseImpl(
     no env toggles required.
     """
 
-    masked_mha_available: ClassVar[bool] = False
     supports_hybrid_prefill: ClassVar[bool] = False
 
     def __init__(
@@ -1552,10 +1558,11 @@ class TritonMLATurboQuantSparseImpl(
             **mla_args,
         )
         self.topk_indices_buffer = (
-            indexer.topk_indices_buffer  # type: ignore[union-attr]
+            indexer.topk_indices_buffer  # type: ignore[attr-defined]
             if indexer is not None
             else topk_indices_buffer
         )
+        self.masked_mha_available = False
         assert self.topk_indices_buffer is not None
         self.softmax_scale = float(scale)
         self.prefill_padding = (
@@ -1573,9 +1580,7 @@ class TritonMLATurboQuantSparseImpl(
         # stays FP8 under DCP; this wires the TQ *main* KV sparse path.
         _pc = vllm_config.parallel_config
         self.dcp_world_size = _pc.decode_context_parallel_size
-        self.dcp_rank = (
-            get_dcp_group().rank_in_group if self.dcp_world_size > 1 else 0
-        )
+        self.dcp_rank = get_dcp_group().rank_in_group if self.dcp_world_size > 1 else 0
         self.dcp_interleave_size = _pc.cp_kv_cache_interleave_size
 
         topk = self.topk_indices_buffer.shape[1]
@@ -1598,14 +1603,10 @@ class TritonMLATurboQuantSparseImpl(
             reserve_b = max(target, max_tokens)
             num_kv_splits = 1
         else:
-            num_kv_splits = tq_mla_sparse_split_count(
-                topk, self._sm_count * 2
-            )
+            num_kv_splits = tq_mla_sparse_split_count(topk, self._sm_count * 2)
             if envs.VLLM_BATCH_INVARIANT:
                 num_kv_splits = 1
-            num_kv_splits = max(
-                num_kv_splits, self._get_dense_decode_num_kv_splits()
-            )
+            num_kv_splits = max(num_kv_splits, self._get_dense_decode_num_kv_splits())
         # Grow the shared WorkspaceManager blob to decode peak BEFORE taking
         # q_concat_buffer views. Otherwise a later blob grow can reallocate the
         # underlying storage and leave cached q views dangling.
@@ -1619,9 +1620,9 @@ class TritonMLATurboQuantSparseImpl(
         (self.q_concat_buffer,) = current_workspace_manager().get_simultaneous(
             (q_concat_shape, torch.bfloat16),
         )
-        # Legacy prefill pool: do NOT prealloc here (model load time).  Growing workspace
-        # to max_tokens*topk during __init__ steals memory from KV profiling /
-        # sampler warmup.  It grows via _get_global_topk_dequant_workspace on
+        # Legacy prefill pool: do not preallocate at model load time. Growing
+        # the workspace here steals memory from KV profiling and sampler warmup.
+        # It grows via _get_global_topk_dequant_workspace on
         # first forward, before lock_workspace() after cudagraph capture.
         self._max_decode_tokens = max_tokens
         self._sparse_b_seqlen: torch.Tensor | None = None
@@ -1702,16 +1703,16 @@ class TritonMLATurboQuantSparseImpl(
                 gather_topk = unique_slots.unsqueeze(1)
                 num_out_slots = num_unique
 
-        out_view = self._get_topk_dequant_workspace(
-            num_out_slots, L, R, device
-        )
+        out_view = self._get_topk_dequant_workspace(num_out_slots, L, R, device)
 
         use_fused_topk_gather = not self.tq_config.key_fp8
 
         def _pytorch_gather_cache_view(topk_for_gather: torch.Tensor) -> torch.Tensor:
             cache_flat = packed_cache.view(-1, packed_bytes)
             valid = topk_for_gather >= 0
-            safe = torch.where(valid, topk_for_gather, torch.zeros_like(topk_for_gather))
+            safe = torch.where(
+                valid, topk_for_gather, torch.zeros_like(topk_for_gather)
+            )
             g_rows, g_cols = topk_for_gather.shape
             gathered = cache_flat[safe.reshape(-1)].view(g_rows, g_cols, packed_bytes)
             return gathered.view(g_rows * g_cols, 1, packed_bytes)
@@ -1719,9 +1720,7 @@ class TritonMLATurboQuantSparseImpl(
         if self.tq_config.key_fp8:
             k_scale = self._get_layer_k_scale(layer)
             cache_view = _pytorch_gather_cache_view(gather_topk)
-            kv_c_fp8 = (
-                cache_view[..., : self._kv_c_bytes].contiguous().view(_FP8_DTYPE)
-            )
+            kv_c_fp8 = cache_view[..., : self._kv_c_bytes].contiguous().view(_FP8_DTYPE)
             out_view[..., :L] = (kv_c_fp8.to(torch.float32) * k_scale).to(_BF16)
             self._write_kpe_into_workspace(cache_view, out_view, L, R)
         elif use_fused_topk_gather:
@@ -1730,9 +1729,12 @@ class TritonMLATurboQuantSparseImpl(
             # replaces the Triton dequant pass over the deduped unique slots.
             if (
                 os.environ.get("VLLM_TQ_MLA_CUDA_DEQUANT") == "1"
-                and self._kpe_4bit and L == 512 and R == 64
+                and self._kpe_4bit
+                and L == 512
+                and R == 64
             ):
                 import flash_mla.cuda as _fm
+
                 if not getattr(self, "_tq4_cuda_deq_sparse_logged", False):
                     print("[TQ4-CUDA] sparse gather-dequant branch ACTIVE", flush=True)
                     self._tq4_cuda_deq_sparse_logged = True
@@ -1760,9 +1762,7 @@ class TritonMLATurboQuantSparseImpl(
                 )
             if apply_pi_on_k:
                 kvc = out_view[..., :L].reshape(-1, L)
-                out_view[..., :L] = (kvc @ buf["Pi_bf16"]).view_as(
-                    out_view[..., :L]
-                )
+                out_view[..., :L] = (kvc @ buf["Pi_bf16"]).view_as(out_view[..., :L])
         else:
             cache_view = _pytorch_gather_cache_view(gather_topk)
             fused_mla_dequant_mse(
@@ -1779,9 +1779,7 @@ class TritonMLATurboQuantSparseImpl(
             )
             if apply_pi_on_k:
                 kvc = out_view[..., :L].reshape(-1, L)
-                out_view[..., :L] = (kvc @ buf["Pi_bf16"]).view_as(
-                    out_view[..., :L]
-                )
+                out_view[..., :L] = (kvc @ buf["Pi_bf16"]).view_as(out_view[..., :L])
 
         return out_view, remapped_local
 
@@ -1806,7 +1804,9 @@ class TritonMLATurboQuantSparseImpl(
                 torch.arange(topk, device=device, dtype=torch.int32)
                 .unsqueeze(0)
                 .expand(num_tokens, topk)
-                + torch.arange(num_tokens, device=device, dtype=torch.int32).unsqueeze(1)
+                + torch.arange(num_tokens, device=device, dtype=torch.int32).unsqueeze(
+                    1
+                )
                 * topk
             )
             local_topk = torch.where(
@@ -1815,8 +1815,7 @@ class TritonMLATurboQuantSparseImpl(
 
         if actual_num_heads % self.prefill_padding != 0:
             padded_num_heads = (
-                (actual_num_heads + self.prefill_padding - 1)
-                // self.prefill_padding
+                (actual_num_heads + self.prefill_padding - 1) // self.prefill_padding
             ) * self.prefill_padding
             q_padded = q.new_empty((q.shape[0], padded_num_heads, q.shape[2]))
             q_padded[:, :actual_num_heads, :] = q
@@ -1885,6 +1884,7 @@ class TritonMLATurboQuantSparseImpl(
             and not self.tq_config.key_fp8
         ):
             import flash_mla.cuda as _fm
+
             from vllm.v1.attention.ops.triton_turboquant_mla_decode import (
                 _rotate_qpe_for_kpe_4bit,
             )
@@ -1903,12 +1903,20 @@ class TritonMLATurboQuantSparseImpl(
                     print("[TQ4-CUDA] DCP topk compaction branch ACTIVE", flush=True)
                     self._dcp_compact_logged = True
             o, lse, _, _ = _fm.sparse_decode_tq4_fwd(
-                q_rot.unsqueeze(1),                  # [B, 1, H, 576]
-                kv_c_and_k_pe_cache.unsqueeze(2),    # [nb, page, 1, 292] uint8
-                global_topk.unsqueeze(1),            # [B, 1, topk]
-                _tlen, None, None, None, None, None, None,
-                L, self.softmax_scale,
-                buf["centroids_bf16"], buf["kpe_centroids_bf16"],
+                q_rot.unsqueeze(1),  # [B, 1, H, 576]
+                kv_c_and_k_pe_cache.unsqueeze(2),  # [nb, page, 1, 292] uint8
+                global_topk.unsqueeze(1),  # [B, 1, topk]
+                _tlen,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                L,
+                self.softmax_scale,
+                buf["centroids_bf16"],
+                buf["kpe_centroids_bf16"],
             )
             o = o.view(B, H_run, L)
             lse = lse.reshape(B, H_run)
@@ -1917,12 +1925,15 @@ class TritonMLATurboQuantSparseImpl(
         if envs.VLLM_BATCH_INVARIANT:
             num_kv_splits = 1
         else:
-            num_kv_splits = tq_mla_sparse_split_count(
-                topk, self._sm_count * 2, batch=B
-            )
+            num_kv_splits = tq_mla_sparse_split_count(topk, self._sm_count * 2, batch=B)
 
         attn_logits, o_unrot, lse = self._get_decode_workspaces(
-            B, H_run, num_kv_splits, L, q.dtype, device,
+            B,
+            H_run,
+            num_kv_splits,
+            L,
+            q.dtype,
+            device,
         )
         b_seqlen = self._get_sparse_b_seqlen(B, topk, device)
 
@@ -2010,7 +2021,7 @@ class TritonMLATurboQuantSparseImpl(
         self,
         q: torch.Tensor | tuple[torch.Tensor, torch.Tensor],
         kv_c_and_k_pe_cache: torch.Tensor,
-        attn_metadata: TritonMLATurboQuantSparseMetadata,
+        attn_metadata: MLACommonMetadata,
         layer: AttentionLayer,
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
         """Sparse MLA: prefill may use gather+flash; decode uses fused 2-stage.
@@ -2024,6 +2035,7 @@ class TritonMLATurboQuantSparseImpl(
         re-materializing the prefill query into that same buffer (a fresh write)
         means prefill never reads decode-corrupted data, with no extra copy.
         """
+        assert isinstance(attn_metadata, TritonMLATurboQuantSparseMetadata)
         if isinstance(q, tuple):
             q_nope_full, q_pe_full = q
             num_actual_toks = q_nope_full.shape[0]
@@ -2088,10 +2100,9 @@ class TritonMLATurboQuantSparseImpl(
             )
         assert isinstance(global_topk, torch.Tensor)
 
-        # Production sparse prefill: gather+flash (phase1). Opt-out: _TQ_SPARSE_WORKSPACE=0.
-        use_gather_flash_prefill = (
-            os.environ.get("_TQ_SPARSE_WORKSPACE", "1") != "0"
-        )
+        # Production sparse prefill: gather+flash (phase1).
+        # Set _TQ_SPARSE_WORKSPACE=0 to opt out.
+        use_gather_flash_prefill = os.environ.get("_TQ_SPARSE_WORKSPACE", "1") != "0"
         num_decode_tokens = attn_metadata.num_decode_tokens
         num_prefill_tokens = num_actual_toks - num_decode_tokens
         # Non-DCP callers ignore LSE; DCP combine in MLAAttention needs it.
@@ -2170,9 +2181,7 @@ class TritonMLATurboQuantSparseImpl(
         attn_out[num_decode_tokens:] = prefill_out
         if not want_lse:
             return attn_out, None
-        lse = decode_lse.new_empty(
-            (num_actual_toks, out_heads), dtype=torch.float32
-        )
+        lse = decode_lse.new_empty((num_actual_toks, out_heads), dtype=torch.float32)
         lse[:num_decode_tokens] = decode_lse.to(torch.float32)
         lse[num_decode_tokens:] = prefill_lse.to(torch.float32)
         return _dcp_finalize(attn_out, lse)

--- a/vllm/v1/attention/backends/mla/triton_mla_tq.py
+++ b/vllm/v1/attention/backends/mla/triton_mla_tq.py
@@ -684,12 +684,13 @@ class TritonMLATurboQuantImpl(TritonMLAImpl):
         Pi_f32 = Pi.to(torch.float32)
         # W_UK_T: (N, P, L). Fold along last dim.
         wuk = layer.W_UK_T
-        wuk_new = (wuk.to(torch.float32) @ Pi_f32).to(wuk.dtype)
-        layer.W_UK_T = wuk_new
-        # W_UV: (N, L, V). Fold along middle (L) dim: W_UV_new = Pi @ W_UV.
         wuv = layer.W_UV
-        wuv_new = (Pi_f32 @ wuv.to(torch.float32)).to(wuv.dtype)
-        layer.W_UV = wuv_new
+        with torch.no_grad():
+            # Preserve Parameter identity: v0.27.1 registers both tensors as
+            # parameters and rejects replacing them with plain tensors.
+            wuk.copy_((wuk.to(torch.float32) @ Pi_f32).to(wuk.dtype))
+            # W_UV: (N, L, V). Fold along middle (L): W_UV_new = Pi @ W_UV.
+            wuv.copy_((Pi_f32 @ wuv.to(torch.float32)).to(wuv.dtype))
         layer._tq_pi_folded = True
 
     def fold_pi_at_load(self, layer) -> None:

--- a/vllm/v1/attention/backends/mla/triton_mla_tq.py
+++ b/vllm/v1/attention/backends/mla/triton_mla_tq.py
@@ -56,6 +56,9 @@ from vllm.model_executor.layers.attention.mla_attention import (
     MLACommonMetadata,
     MLACommonMetadataBuilder,
 )
+from vllm.model_executor.layers.attention.sparse_mla_attention import (
+    SparseMLACommonImpl,
+)
 from vllm.model_executor.layers.quantization.turboquant.centroids import (
     get_centroids,
 )
@@ -69,13 +72,12 @@ from vllm.v1.attention.backend import (
     AttentionLayer,
     CommonAttentionMetadata,
     MultipleOf,
-    SparseMLAAttentionImpl,
 )
-from vllm.v1.kv_cache_interface import AttentionSpec
 from vllm.v1.attention.backends.mla.sparse_utils import (
     triton_convert_req_index_to_global_index,
-    triton_convert_and_compact,
+    triton_filter_and_convert_dcp_index,
 )
+from vllm.v1.kv_cache_interface import AttentionSpec
 from vllm.v1.attention.ops.flashmla import flash_mla_sparse_fwd
 from vllm.platforms import current_platform
 from vllm import _custom_ops as ops
@@ -1501,7 +1503,7 @@ class TritonMLATurboQuantSparseBackend(TritonMLATurboQuantBackend):
 
 
 class TritonMLATurboQuantSparseImpl(
-    SparseMLAAttentionImpl[TritonMLATurboQuantSparseMetadata],
+    SparseMLACommonImpl[TritonMLATurboQuantSparseMetadata],
     TritonMLATurboQuantImpl,
 ):
     """Sparse MLA over a TurboQuant byte-packed cache.
@@ -2059,15 +2061,15 @@ class TritonMLATurboQuantSparseImpl(
             and num_actual_toks == attn_metadata.num_decode_tokens
         )
         if self._dcp_compact_active:
-            global_topk, _ = triton_convert_and_compact(
+            global_topk = triton_filter_and_convert_dcp_index(
                 attn_metadata.req_id_per_token[:num_actual_toks],
                 attn_metadata.block_table,
                 topk_indices,
+                dcp_size=self.dcp_world_size,
+                dcp_rank=self.dcp_rank,
+                cp_kv_cache_interleave_size=self.dcp_interleave_size,
                 BLOCK_SIZE=attn_metadata.block_size,
                 NUM_TOPK_TOKENS=topk_indices.shape[1],
-                dcp_world_size=self.dcp_world_size,
-                dcp_rank=self.dcp_rank,
-                dcp_interleave_size=self.dcp_interleave_size,
             )
         else:
             global_topk = triton_convert_req_index_to_global_index(

--- a/vllm/v1/attention/backends/mla/triton_mla_tq.py
+++ b/vllm/v1/attention/backends/mla/triton_mla_tq.py
@@ -1409,6 +1409,7 @@ class TritonMLATurboQuantSparseMetadata(MLACommonMetadata):
     block_table: torch.Tensor | None = None
     block_size: int = 64
     topk_tokens: int = 2048
+    prefill_max_seq_len: int = 0
 
 
 class TritonMLATurboQuantSparseMetadataBuilder(TritonMLATurboQuantMetadataBuilder):
@@ -1475,6 +1476,7 @@ class TritonMLATurboQuantSparseMetadataBuilder(TritonMLATurboQuantMetadataBuilde
             block_table=common_attn_metadata.block_table_tensor,
             block_size=self.kv_cache_spec.block_size,
             topk_tokens=self.topk_tokens,
+            prefill_max_seq_len=base.max_seq_len if base.num_prefills else 0,
         )
 
 

--- a/vllm/v1/attention/backends/mla/triton_mla_tq.py
+++ b/vllm/v1/attention/backends/mla/triton_mla_tq.py
@@ -1517,6 +1517,7 @@ class TritonMLATurboQuantSparseImpl(
     no env toggles required.
     """
 
+    masked_mha_available: ClassVar[bool] = False
     supports_hybrid_prefill: ClassVar[bool] = False
 
     def __init__(

--- a/vllm/v1/attention/backends/mla/triton_mla_tq.py
+++ b/vllm/v1/attention/backends/mla/triton_mla_tq.py
@@ -1,0 +1,2172 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""TurboQuant TRITON_MLA backend for DeepSeek-style MLA.
+
+Supported presets (via --kv-cache-dtype):
+    turboquant_k8v4     — FP8 kv_c (8-bit, no Hadamard rotation)
+    turboquant_4bit_nc  — 4-bit MSE kv_c with Hadamard + Lloyd-Max + norm_correction
+    turboquant_k3v4_nc  — 3-bit MSE kv_c with Hadamard + Lloyd-Max + norm_correction
+    turboquant_3bit_nc  — 3-bit MSE kv_c with Hadamard + Lloyd-Max + norm_correction
+                          (in MLA, k/v bits collapse onto kv_c → same as k3v4_nc)
+
+Cache layout per token (uint8, byte-packed):
+    [ kv_c_packed (key_packed_size bytes) | k_pe (k_pe_bytes) ]
+
+k_pe bytes:
+  default: 2 * qk_rope_head_dim bytes, raw bf16
+  optional: qk_rope_head_dim fp8 bytes + 2-byte fp16 scale
+            when VLLM_TQ_KPE_FP8=1
+
+kv_c_packed:
+  FP8 path:  kv_lora_rank bytes (1 B/elem, e4m3)
+  MSE path:  ceil(kv_lora_rank * mse_bits / 8) index bytes
+             + 2 B fp16 per-token scale (vec_norm, or eff_scale if norm_correction)
+
+Implementation strategy:
+  - do_kv_cache_update: quantize latent kv_c / ctkv and scatter packed bytes
+    (MSE 4bit: fused Triton store by default — see triton_turboquant_mla_store.py)
+    into the uint8 KV cache.
+  - forward_mqa (sparse): prefill uses gather+dedup+flash_mla_sparse_fwd;
+    decode uses fused 2-stage sparse.  Selected by ``--kv-cache-dtype`` and
+    backend choice — no runtime env toggles required for production ``*_nc``.
+  - The legacy FP8 workspace path is kept behind _TQ_FP8_WORKSPACE=1 as a
+    regression anchor only.
+
+Reference material:
+  - #38479 general TurboQuant infrastructure
+  - vllm/v1/attention/backends/turboquant_attn.py
+  - vllm/model_executor/layers/quantization/turboquant/{config,centroids}.py
+  - vllm/v1/attention/ops/triton_turboquant_mla_decode.py
+"""
+
+import math
+import os
+from dataclasses import dataclass, fields
+from typing import ClassVar
+
+import numpy as np
+import torch
+
+import vllm.envs as envs
+from vllm.config import get_current_vllm_config
+from vllm.config.cache import CacheDType
+from vllm.config.vllm import VllmConfig
+from vllm.logger import init_logger
+from vllm.model_executor.layers.attention.mla_attention import (
+    MLACommonMetadata,
+    MLACommonMetadataBuilder,
+)
+from vllm.model_executor.layers.quantization.turboquant.centroids import (
+    get_centroids,
+)
+from vllm.model_executor.layers.quantization.turboquant.config import (
+    TurboQuantConfig,
+)
+from vllm.platforms.interface import DeviceCapability
+from vllm.triton_utils import triton
+from vllm.v1.attention.backend import (
+    AttentionCGSupport,
+    AttentionLayer,
+    CommonAttentionMetadata,
+    MultipleOf,
+    SparseMLAAttentionImpl,
+)
+from vllm.v1.kv_cache_interface import AttentionSpec
+from vllm.v1.attention.backends.mla.sparse_utils import (
+    triton_convert_req_index_to_global_index,
+    triton_convert_and_compact,
+)
+from vllm.v1.attention.ops.flashmla import flash_mla_sparse_fwd
+from vllm.platforms import current_platform
+from vllm import _custom_ops as ops
+from vllm.v1.attention.backends.mla.triton_mla import (
+    TritonMLABackend,
+    TritonMLAImpl,
+)
+from vllm.v1.attention.backends.turboquant_attn import _build_hadamard
+from vllm.v1.attention.ops.triton_decode_attention import (
+    _decode_softmax_reducev_fwd,
+)
+from vllm.v1.attention.ops.triton_turboquant_mla_decode import (
+    fused_mla_dequant_mse,
+    fused_mla_sparse_topk_gather_dequant_mse,
+    fused_mla_tq_decode_stage1,
+    fused_mla_tq_sparse_decode_stage1,
+    sparse_decode_softmax_reducev_fwd,
+    tq_mla_sparse_adaptive_enabled,
+    tq_mla_sparse_split_count,
+)
+from vllm.v1.attention.ops.tq_mla_defaults import (
+    default_kpe_4bit,
+    default_kpe_fp8,
+    default_store_fwht,
+)
+from vllm.v1.attention.ops.triton_turboquant_mla_store import (
+    kpe_mse_index_bytes,
+    kpe_packed_bytes,
+    tq_mla_fused_kv_cache_store,
+    tq_mla_fused_store_enabled,
+)
+from vllm.v1.worker.workspace import (
+    current_workspace_manager,
+    is_workspace_manager_initialized,
+)
+
+logger = init_logger(__name__)
+
+_FP8_DTYPE = torch.float8_e4m3fn
+_FP8_MAX = 448.0
+_BF16 = torch.bfloat16
+
+# One bf16 top-k dequant workspace per GPU for legacy sparse gather+flash.
+# All MLA layers share it (forward is sequential).  Do NOT pool on per-layer
+# ``self._tq_buffers`` — that would retain peak ``B*topk`` on every layer.
+_LEGACY_TOPK_DEQUANT_WS: dict[str, torch.Tensor] = {}
+
+# Reusable per-GPU buffers for bucket dedup (top-k sparse prefill).
+# Keyed by device string; grows on demand and is reused across layers/steps.
+_DEDUP_BUCKET_PRESENT_WS: dict[str, torch.Tensor] = {}
+_DEDUP_BUCKET_IDMAP_WS: dict[str, torch.Tensor] = {}
+
+
+def _in_cuda_graph_capture() -> bool:
+    return (
+        torch.cuda.is_available()
+        and torch.cuda.is_current_stream_capturing()
+    )
+
+
+def _sparse_topk_dedup_enabled() -> bool:
+    # Production default ON for sparse latent prefill. Opt-out: =0.
+    if os.environ.get("VLLM_TQ_MLA_SPARSE_TOPK_DEDUP", "1") == "0":
+        return False
+    # torch.unique / Tensor.any() sync during CUDAGraph capture →
+    # cudaErrorStreamCaptureUnsupported (breaks engine startup).
+    if _in_cuda_graph_capture():
+        return False
+    return True
+
+
+def _dedup_bucket_enabled() -> bool:
+    """Bucket dedup (presence-bitmap + nonzero) instead of ``torch.unique`` sort.
+
+    ``torch.unique(sorted=True)`` sorts the whole ``(T*K,)`` topk array
+    (O(N log N), N up to ~16M for an 8k prefill chunk).  Global slot ids are
+    bounded by the KV pool size, so a presence bitmap + ``nonzero`` (+ scatter
+    remap) computes the identical sorted-unique result in O(N + pool) with no
+    sort.  Set ``VLLM_TQ_DEDUP_BUCKET=0`` to fall back to ``torch.unique``.
+    """
+    return os.environ.get("VLLM_TQ_DEDUP_BUCKET", "1") == "1"
+
+
+def _dedup_global_topk(
+    global_topk: torch.Tensor,
+    num_cache_slots: int | None = None,
+) -> tuple[torch.Tensor, torch.Tensor, int]:
+    """Unique global slots + per-(token,topk) workspace row indices.
+
+    Returns ``(unique_slots, remapped_local_topk, num_unique)`` where
+    ``remapped_local_topk[token, k]`` indexes into the deduped workspace
+    (or -1 when invalid).
+    """
+    num_tokens, topk = global_topk.shape
+    device = global_topk.device
+    flat = global_topk.reshape(-1)
+    valid = flat >= 0
+
+    if _dedup_bucket_enabled():
+        # Bound the bitmap by the KV pool when known (avoids a max() reduction).
+        if num_cache_slots is not None and num_cache_slots > 0:
+            n_slots = int(num_cache_slots)
+        else:
+            # Fallback (rare): derive from data.
+            if not bool(valid.any()):
+                empty = torch.empty(0, dtype=torch.int32, device=device)
+                remapped = torch.full(
+                    (num_tokens, topk), -1, dtype=torch.int32, device=device
+                )
+                return empty, remapped, 0
+            n_slots = int(flat[valid].max().item()) + 1
+
+        key = str(device)
+        need = n_slots + 1  # +1 sentinel for invalid (-1) entries.
+        present = _DEDUP_BUCKET_PRESENT_WS.get(key)
+        if present is None or present.numel() < need:
+            present = torch.empty(need, dtype=torch.bool, device=device)
+            _DEDUP_BUCKET_PRESENT_WS[key] = present
+        else:
+            present = present[:need]
+        id_map = _DEDUP_BUCKET_IDMAP_WS.get(key)
+        if id_map is None or id_map.numel() < need:
+            id_map = torch.empty(need, dtype=torch.int32, device=device)
+            _DEDUP_BUCKET_IDMAP_WS[key] = id_map
+        else:
+            id_map = id_map[:need]
+
+        # Compaction-free path:
+        #   - map invalid indices to sentinel slot ``n_slots``
+        #   - build presence bitmap in one scatter
+        #   - remap by table lookup (sentinel maps to -1)
+        sentinel_i32 = torch.full_like(flat, n_slots)
+        safe_i32 = torch.where(valid, flat, sentinel_i32)
+        safe_long = safe_i32.to(torch.long)
+
+        present.fill_(False)
+        present[safe_long] = True
+        present[n_slots] = False  # drop invalid sentinel
+        unique_slots = present[:-1].nonzero(as_tuple=True)[0].to(torch.int32)  # ascending
+        num_unique = int(unique_slots.numel())
+        id_map.fill_(-1)
+        id_map[unique_slots.to(torch.long)] = torch.arange(
+            num_unique, dtype=torch.int32, device=device
+        )
+        remapped_flat = id_map[safe_long]
+        remapped = remapped_flat.view(num_tokens, topk)
+        return unique_slots, remapped, num_unique
+
+    if not bool(valid.any()):
+        empty = torch.empty(0, dtype=torch.int32, device=device)
+        remapped = torch.full(
+            (num_tokens, topk), -1, dtype=torch.int32, device=device
+        )
+        return empty, remapped, 0
+
+    unique_slots, inverse = torch.unique(
+        flat[valid], sorted=True, return_inverse=True
+    )
+    remapped_flat = torch.full((flat.numel(),), -1, dtype=torch.int32, device=device)
+    remapped_flat[valid] = inverse.to(torch.int32)
+    remapped = remapped_flat.view(num_tokens, topk)
+    return unique_slots, remapped, int(unique_slots.numel())
+
+
+def _get_global_topk_dequant_workspace(
+    num_slots: int,
+    L: int,
+    R: int,
+    device: torch.device,
+    max_slots: int,
+) -> torch.Tensor:
+    """Return legacy top-k dequant workspace view (one tensor per GPU).
+
+    Must NOT use WorkspaceManager here: growing that blob replaces the
+    underlying storage and invalidates the ``q_concat_buffer`` view allocated
+    earlier from the same manager (garbage outputs / UAF).
+
+    Memory cost is ``min(num_slots, max_slots) * (L+R) * 2`` bytes — cap with
+    ``--max-num-batched-tokens``.
+    """
+    need = min(num_slots, max_slots)
+    head_dim = L + R
+    key = str(device)
+    ws = _LEGACY_TOPK_DEQUANT_WS.get(key)
+    if ws is None or ws.shape[2] != head_dim or ws.shape[0] < need:
+        ws = torch.empty((need, 1, head_dim), dtype=_BF16, device=device)
+        _LEGACY_TOPK_DEQUANT_WS[key] = ws
+    return ws[:num_slots]
+
+
+def _enumerate_packed_sizes() -> list[int]:
+    """Return all head_size (=packed_bytes per slot) values this backend
+    accepts, across (L, R, preset, kpe_fp8) combinations supported by the
+    code paths in this module.
+
+    Concrete reasoning:
+      - L (kv_lora_rank): power of 2 in {128, 256, 512, 1024}
+      - R (qk_rope_head_dim): in {32, 64, 96, 128}
+      - kv_c_bytes for preset:
+          k8v4: L              (1 B/elem fp8)
+          4bit: ceil(L*4/8)+2 = L/2 + 2
+          3bit: ceil(L*3/8)+2
+      - k_pe_bytes: 2*R (bf16) or R+2 (fp8 + fp16 scale)
+
+    We enumerate the cross product so that any vLLM `get_supported_head_sizes`
+    membership check at startup will succeed.
+    """
+    import math as _math
+
+    sizes: set[int] = set()
+    for L in (128, 256, 512, 1024):
+        # k8v4 fp8 keys (1 byte/elem):
+        kv_c_options = [L]
+        # MSE 3-bit and 4-bit keys, +2 fp16 vec_norm:
+        for bits in (3, 4):
+            kv_c_options.append(_math.ceil(L * bits / 8) + 2)
+        for R in (32, 64, 96, 128):
+            k_pe_options = [2 * R, R + 2, kpe_mse_index_bytes(R, 4) + 2]
+            for k_pe in k_pe_options:
+                for kv_c in kv_c_options:
+                    sizes.add(kv_c + k_pe)
+    return sorted(sizes)
+
+
+# ----------------------------------------------------------------------
+# Bit-packing helpers (pure PyTorch, correctness-first).
+# ----------------------------------------------------------------------
+
+
+def _pack_bits_rows(idx: torch.Tensor, bits: int) -> torch.Tensor:
+    """Pack (N, D) int indices into (N, ceil(D*bits/8)) uint8 rows.
+
+    Because the `bits`-wide fields land in disjoint bit ranges within each
+    byte, we can use integer addition (scatter_add_) as a stand-in for
+    bitwise-OR and convert the int32 accumulator back to uint8 at the end.
+
+    Args:
+        idx: (N, D) integer tensor in [0, 2**bits).
+        bits: 3 or 4.
+
+    Returns:
+        (N, ceil(D*bits/8)) uint8 tensor.
+    """
+    assert bits in (3, 4), f"pack supports 3/4 bits only, got {bits}"
+    N, D = idx.shape
+    n_bytes = math.ceil(D * bits / 8)
+    device = idx.device
+
+    idx_i = idx.to(torch.int32)
+    out = torch.zeros((N, n_bytes), dtype=torch.int32, device=device)
+
+    d = torch.arange(D, device=device)
+    bit_off = d * bits
+    byte_idx = (bit_off // 8).to(torch.long)  # (D,)
+    bit_shift = (bit_off % 8).to(torch.int32)  # (D,)
+
+    # Low part: bits landing in byte_idx.
+    low = (idx_i << bit_shift.view(1, D)) & 0xFF
+    out.scatter_add_(1, byte_idx.view(1, D).expand(N, D), low)
+
+    # High part: spill bits to byte_idx+1 when bit_shift + bits > 8.
+    spans = (bit_shift + bits > 8).view(1, D).expand(N, D)
+    spill_shift = (8 - bit_shift).clamp(min=0)
+    high = (idx_i >> spill_shift.view(1, D)) & 0xFF
+    high = torch.where(spans, high, torch.zeros_like(high))
+    high_byte_idx = (byte_idx + 1).clamp(max=n_bytes - 1)
+    out.scatter_add_(1, high_byte_idx.view(1, D).expand(N, D), high)
+    return out.to(torch.uint8)
+
+
+def _unpack_bits_rows(packed: torch.Tensor, bits: int, D: int) -> torch.Tensor:
+    """Inverse of _pack_bits_rows.
+
+    Args:
+        packed: (..., n_bytes) uint8.
+        bits: 3 or 4.
+        D: expected output width.
+
+    Returns:
+        (..., D) int64 tensor of indices in [0, 2**bits).
+    """
+    assert bits in (3, 4), f"unpack supports 3/4 bits only, got {bits}"
+    device = packed.device
+    n_bytes = packed.shape[-1]
+
+    d = torch.arange(D, device=device)
+    bit_off = d * bits
+    byte_idx = (bit_off // 8).to(torch.long)
+    bit_shift = (bit_off % 8).to(torch.long)
+    mask = (1 << bits) - 1
+
+    raw0 = packed[..., byte_idx].to(torch.int32)
+    # byte_idx + 1 may equal n_bytes; pad by clamping and masking the spill.
+    safe_next = (byte_idx + 1).clamp(max=n_bytes - 1)
+    raw1 = packed[..., safe_next].to(torch.int32)
+    raw16 = raw0 | (raw1 << 8)
+    out = (raw16 >> bit_shift.view(*([1] * (packed.dim() - 1)), D)) & mask
+    return out.to(torch.int64)
+
+
+class TritonMLATurboQuantMetadataBuilder(MLACommonMetadataBuilder[MLACommonMetadata]):
+    """MLA metadata builder that advertises CUDA-graph support.
+
+    Parent MLACommonMetadataBuilder defaults to AttentionCGSupport.NEVER.
+    TurboQuant's decode path (after Step 2: no torch.unique, no host syncs)
+    is CG-safe for decode-only batches, so UNIFORM_BATCH is the correct
+    level — matching FlashMLA / FlashAttn MLA.
+
+    `build_for_cudagraph_capture` is inherited from MLACommonMetadataBuilder;
+    it asserts decode-only and calls self.build(0, m), which is fine here.
+    """
+
+    _cudagraph_support: ClassVar[AttentionCGSupport] = AttentionCGSupport.UNIFORM_BATCH
+
+
+class TritonMLATurboQuantBackend(TritonMLABackend):
+    """TurboQuant-aware MLA backend on top of TritonMLA."""
+
+    supported_dtypes: ClassVar[list[torch.dtype]] = [torch.float16, torch.bfloat16]
+    supported_kv_cache_dtypes: ClassVar[list[CacheDType]] = [
+        "turboquant_k8v4",
+        "turboquant_4bit_nc",
+        "turboquant_k3v4_nc",
+        "turboquant_3bit_nc",
+    ]
+
+    @staticmethod
+    def get_name() -> str:
+        return "TRITON_MLA_TURBOQUANT"
+
+    @classmethod
+    def get_supported_head_sizes(cls) -> list[int]:
+        # head_size in this backend == packed_bytes per slot (uint8 cache),
+        # so the value depends on (kv_lora_rank, qk_rope_head_dim, preset, kpe_fp8).
+        # DeepSeek-V2/V3 (L=512, R=64): bf16 k_pe → 576; fp8 k_pe → 514.
+        # Other models: see _enumerate_packed_sizes for the full set we accept.
+        return _enumerate_packed_sizes()
+
+    @staticmethod
+    def get_supported_kernel_block_sizes() -> list[int | MultipleOf]:
+        return [MultipleOf(16)]
+
+    @classmethod
+    def supports_block_size(cls, block_size: int | None) -> bool:
+        if block_size is None:
+            return True
+        return block_size % 16 == 0
+
+    @staticmethod
+    def get_kv_cache_shape(
+        num_blocks: int,
+        block_size: int,
+        num_kv_heads: int,
+        head_size: int,
+        cache_dtype_str: str = "turboquant_k8v4",
+    ) -> tuple[int, ...]:
+        # head_size is the packed byte count per token, computed by
+        # MLAAttention.get_kv_cache_spec using TurboQuantConfig.
+        return (num_blocks, block_size, head_size)
+
+    @classmethod
+    def supports_kv_cache_dtype(cls, kv_cache_dtype: CacheDType | None) -> bool:
+        return kv_cache_dtype in cls.supported_kv_cache_dtypes
+
+    @classmethod
+    def supports_compute_capability(cls, capability: DeviceCapability) -> bool:
+        # FP8 path needs SM89+; MSE path only needs SM80+. Gate at SM80.
+        return capability.major >= 8
+
+    @staticmethod
+    def get_impl_cls() -> type["TritonMLATurboQuantImpl"]:
+        return TritonMLATurboQuantImpl
+
+    @staticmethod
+    def get_builder_cls() -> type[TritonMLATurboQuantMetadataBuilder]:
+        return TritonMLATurboQuantMetadataBuilder
+
+
+class TritonMLATurboQuantImpl(TritonMLAImpl):
+    """TritonMLA impl with a TurboQuant byte-packed KV cache.
+
+    Supports FP8 keys (k8v4) and MSE Lloyd-Max keys (4bit_nc / k3v4_nc /
+    3bit_nc). Value compression is not applicable in MLA: V is recovered
+    from kv_c via W_UV, so there is no independent V slot to quantize.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # P3-1: kv_lora_rank can now be any power of 2 (Sylvester Hadamard
+        # requirement). qk_rope_head_dim can be any positive int (R is just a
+        # bf16 byte slice on the cache, no Hadamard, only BLOCK_R=next_pow2(R)
+        # masking inside the kernel).
+        L = self.kv_lora_rank
+        assert L > 0 and (L & (L - 1)) == 0, (
+            f"TritonMLATurboQuant requires kv_lora_rank to be a power of 2 "
+            f"(Sylvester Hadamard); got {L}"
+        )
+        assert self.qk_rope_head_dim > 0, (
+            f"qk_rope_head_dim must be positive; got {self.qk_rope_head_dim}"
+        )
+        # Build TQ config from the kv_cache_dtype string. self.kv_cache_dtype
+        # is set by the base impl (turboquant_{k8v4,4bit_nc,k3v4_nc,3bit_nc}).
+        self.tq_config: TurboQuantConfig = TurboQuantConfig.from_cache_dtype(
+            self.kv_cache_dtype, head_dim=self.kv_lora_rank
+        )
+        # Per-slot byte layout (parameterized on L = kv_lora_rank):
+        #   FP8  : L bytes (1 B/elem, no norm)
+        #   MSE  : ceil(L * bits / 8) + 2 bytes (indices + fp16 vec_norm)
+        # Concrete: L=512 → FP8 512B, 4bit 258B, 3bit 194B.
+        self._kv_c_bytes = self.tq_config.key_packed_size
+        # P3-2 / P6-4: k_pe FP8 (e4m3) compression (default on).
+        # bf16 layout: 2*R bytes when VLLM_TQ_KPE_FP8=0.
+        # fp8 layout:  R bytes fp8 + 2 bytes per-token fp16 scale.
+        # 4bit layout: ceil(R*4/8) index bytes + 2 bytes fp16 scale (VLLM_TQ_KPE_4BIT=1).
+        # R=64 → 128B → 66B (~48% smaller k_pe, ~16% smaller 4bit_nc slot).
+        # k_pe layout follows --kv-cache-dtype (NC presets → 4bit + FWHT store).
+        self._kpe_4bit = default_kpe_4bit(self.kv_cache_dtype, self.tq_config)
+        self._store_fwht = default_store_fwht(self.kv_cache_dtype, self.tq_config)
+        self._kpe_fp8 = default_kpe_fp8(
+            self.kv_cache_dtype,
+            self.tq_config,
+            kpe_4bit=self._kpe_4bit,
+        )
+        self._k_pe_bytes = kpe_packed_bytes(
+            self.qk_rope_head_dim,
+            kpe_4bit=self._kpe_4bit,
+            kpe_fp8=self._kpe_fp8,
+        )
+        self._packed_bytes = self._kv_c_bytes + self._k_pe_bytes
+        # For MSE path: number of "index bytes" before the 2-byte vec_norm.
+        self._mse_index_bytes = (
+            math.ceil(self.kv_lora_rank * self.tq_config.key_mse_bits / 8)
+            if not self.tq_config.key_fp8
+            else 0
+        )
+
+        # Override: TritonMLA sets supports_quant_query_input=False when
+        # is_quantized_kv_cache is True; we want the same.
+        self.supports_quant_query_input = False
+
+        # P0-1: cache layer._k_scale as a Python float on first use so we
+        # never call `.item()` inside CUDA Graph capture (host-device sync
+        # is forbidden during capture). First read happens during eager
+        # warmup, before capture, so this is safe. Assumes scale is fixed
+        # after weight load (true unless calculate_kv_scales=True with
+        # runtime recompute, which already breaks graph capture anyway).
+        self._cached_k_scale: float | None = None
+
+        # Fixed NUM_KV_SPLITS for dense decode (CUDA Graph requires constant
+        # grid dims). Do not derive from attn_metadata.max_seq_len — capture
+        # uses max_model_len and would bake 128 splits at 40k max_model_len.
+        vllm_config = get_current_vllm_config()
+        self.max_num_kv_splits = min(
+            vllm_config.attention_config.tq_max_kv_splits_for_cuda_graph,
+            self._sm_count * 2,
+        )
+
+    def _get_dense_decode_num_kv_splits(self) -> int:
+        if envs.VLLM_BATCH_INVARIANT:
+            return 1
+        return self.max_num_kv_splits
+
+    # ---------------- impl-level TQ buffers ----------------
+    # Hadamard + Lloyd-Max centroids depend only on (kv_lora_rank, device)
+    # and bit-width, not on any layer-specific state. Caching on `self`
+    # avoids threading `layer` through do_kv_cache_update (which has no
+    # layer argument in the unified dispatch path).
+    def _ensure_buffers(self, device: torch.device) -> None:
+        key = str(device)
+        if not hasattr(self, "_tq_buffers"):
+            self._tq_buffers: dict[str, dict] = {}
+        if key in self._tq_buffers:
+            return
+        D = self.kv_lora_rank  # power of 2 (e.g. 512 for DeepSeek-V2/V3)
+        H = _build_hadamard(D, str(device)).to(torch.float32)
+        buf: dict = {"Pi": H, "PiT": H, "Pi_bf16": H.to(_BF16)}
+        if not self.tq_config.key_fp8:
+            cents = get_centroids(D, self.tq_config.key_mse_bits).to(
+                device=device, dtype=torch.float32
+            )
+            c_sorted, _ = cents.sort()
+            buf["centroids"] = cents
+            buf["centroids_bf16"] = cents.to(_BF16)
+            buf["midpoints"] = (c_sorted[:-1] + c_sorted[1:]) / 2
+        if self._kpe_4bit:
+            R = self.qk_rope_head_dim
+            kpe_cents = get_centroids(R, 4).to(device=device, dtype=torch.float32)
+            kpe_sorted, _ = kpe_cents.sort()
+            buf["kpe_centroids"] = kpe_cents
+            buf["kpe_centroids_bf16"] = kpe_cents.to(_BF16)
+            buf["kpe_midpoints"] = (kpe_sorted[:-1] + kpe_sorted[1:]) / 2
+            buf["kpe_mse_bytes"] = kpe_mse_index_bytes(R, 4)
+        # P0-3: permanent v_shape_holder. `_decode_softmax_reducev_fwd` only
+        # reads `v_buffer.shape[-1]` (Lv); the content is never accessed. We
+        # used to `torch.empty((1, L), ...)` on every forward — wasted alloc
+        # since the dtype/shape never change. Stash one and reuse forever.
+        buf["v_shape_holder"] = torch.empty((1, D), device=device, dtype=_BF16)
+        self._tq_buffers[key] = buf
+
+    def _get_buffers(self, device: torch.device) -> dict:
+        self._ensure_buffers(device)
+        return self._tq_buffers[str(device)]
+
+    def _kpe_decode_kwargs(self, buf: dict) -> dict:
+        return {
+            "kpe_fp8": self._kpe_fp8,
+            "kpe_4bit": self._kpe_4bit,
+            "kpe_centroids_bf16": buf.get("kpe_centroids_bf16"),
+        }
+
+    # P0-2: pool the three per-forward decode scratch tensors
+    # (attn_logits, o_unrot, lse) through vLLM's WorkspaceManager so we
+    # don't pay a `torch.empty` (cudaMalloc / allocator hit) on every
+    # attention layer of every step. WorkspaceManager hands back views
+    # into a single growing buffer that is reused across layers and
+    # safely included in CUDA Graph captures. Attention layers run
+    # sequentially and each layer fully consumes attn_out/lse before
+    # the next layer's forward runs, so view aliasing is safe.
+    def _get_decode_workspaces(
+        self,
+        B: int,
+        H_q: int,
+        num_kv_splits: int,
+        L: int,
+        out_dtype: torch.dtype,
+        device: torch.device,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        shapes_and_dtypes = (
+            ((B, H_q, num_kv_splits, L + 1), torch.float32),  # attn_logits
+            ((B, H_q, L), out_dtype),                          # o_unrot
+            ((B, H_q), out_dtype),                             # lse
+        )
+        if is_workspace_manager_initialized():
+            attn_logits, o_unrot, lse = current_workspace_manager().get_simultaneous(
+                *shapes_and_dtypes
+            )
+            return attn_logits, o_unrot, lse
+        # Fallback for environments without an initialized WorkspaceManager
+        # (e.g. unit tests). Behaves like the original code.
+        return (
+            torch.empty(shapes_and_dtypes[0][0], dtype=torch.float32, device=device),
+            torch.empty(shapes_and_dtypes[1][0], dtype=out_dtype, device=device),
+            torch.empty(shapes_and_dtypes[2][0], dtype=out_dtype, device=device),
+        )
+
+    def _reserve_decode_workspace_peak(
+        self,
+        max_b: int,
+        max_h: int,
+        num_kv_splits: int,
+        device: torch.device,
+        out_dtype: torch.dtype = _BF16,
+    ) -> None:
+        """Grow WorkspaceManager to peak decode/sparse scratch before lock.
+
+        CUDA-graph warmup often exercises smaller batch descriptors than
+        ``max_num_batched_tokens``.  Prefill on the fused sparse path calls
+        ``_get_decode_workspaces(B, ...)`` with the live batch size; after
+        ``lock_workspace()`` that growth fails (e.g. 1536 MB reserved vs
+        1555 MB required for a slightly larger prefill chunk).
+        """
+        if not is_workspace_manager_initialized():
+            return
+        self._get_decode_workspaces(
+            max_b,
+            max_h,
+            num_kv_splits,
+            self.kv_lora_rank,
+            out_dtype,
+            device,
+        )
+
+    # P0-1: cache layer._k_scale as a Python float. Calling `.item()` inside
+    # a CUDA Graph capture triggers a host-device sync and fails with
+    # "operation not permitted when stream is capturing". The very first
+    # forward runs in eager mode during warmup (before capture), so the
+    # one-time `.item()` here is safe.
+    def _get_layer_k_scale(self, layer: AttentionLayer) -> float:
+        if self._cached_k_scale is not None:
+            return self._cached_k_scale
+        k_scale_t = getattr(layer, "_k_scale", None)
+        if k_scale_t is None:
+            self._cached_k_scale = 1.0
+        else:
+            self._cached_k_scale = float(k_scale_t.item())
+        return self._cached_k_scale
+
+    def _maybe_fold_pi_into_layer(self, layer) -> None:
+        """K2: fold Pi into layer.W_UK_T and layer.W_UV once, eliminating two
+        per-forward bf16 GEMMs (q-side rotation, V un-rotation).
+
+        Mathematical identity (Pi is self-inverse symmetric Hadamard):
+          - q_rot = q[..., :L] @ Pi  →  fold W_UK_T_new = W_UK_T @ Pi
+          - o_unrot @ Pi @ W_UV = o_unrot @ W_UV_new  with W_UV_new = Pi @ W_UV
+        Done in fp32 then cast back to weight dtype for precision; net effect
+        is *more* accurate than the runtime bf16 rotations.
+        """
+        if getattr(layer, "_tq_pi_folded", False):
+            return
+        if not (hasattr(layer, "W_UK_T") and hasattr(layer, "W_UV")):
+            layer._tq_pi_folded = False
+            return  # Backend supports only the absorbed-MLA decode path.
+        Pi = self._get_buffers(layer.W_UK_T.device)["Pi_bf16"]
+        Pi_f32 = Pi.to(torch.float32)
+        # W_UK_T: (N, P, L). Fold along last dim.
+        wuk = layer.W_UK_T
+        wuk_new = (wuk.to(torch.float32) @ Pi_f32).to(wuk.dtype)
+        layer.W_UK_T = wuk_new
+        # W_UV: (N, L, V). Fold along middle (L) dim: W_UV_new = Pi @ W_UV.
+        wuv = layer.W_UV
+        wuv_new = (Pi_f32 @ wuv.to(torch.float32)).to(wuv.dtype)
+        layer.W_UV = wuv_new
+        layer._tq_pi_folded = True
+
+    def fold_pi_at_load(self, layer) -> None:
+        """Fold Pi_L into W_UK_T / W_UV once at weight load (before any bmm).
+
+        Unified-576 uses the same W_UK / W_UV fold; q_pe still gets Pi_R inside
+        the sparse kernel (RoPE prevents folding Pi_R into W_QR).
+        """
+        if self.tq_config.key_fp8:
+            return
+        self._ensure_buffers(layer.W_UK_T.device)
+        self._maybe_fold_pi_into_layer(layer)
+
+    # ---------------- store ----------------
+    def do_kv_cache_update(
+        self,
+        kv_c_normed: torch.Tensor,  # (N, kv_lora_rank)
+        k_pe: torch.Tensor,  # (N, 1, qk_rope_head_dim) or (N, qk_rope_head_dim)
+        kv_cache: torch.Tensor,  # (num_blocks, block_size, packed_bytes) uint8
+        slot_mapping: torch.Tensor,
+        kv_cache_dtype: str,
+        k_scale: torch.Tensor,  # float scalar tensor
+    ) -> None:
+        if kv_cache.numel() == 0:
+            return
+        N = slot_mapping.shape[0]
+        if N <= 0:
+            return
+
+        device = kv_cache.device
+        buf = self._get_buffers(device)
+
+        k_pe_ = k_pe.squeeze(1) if k_pe.dim() == 3 else k_pe
+        kv_c_ = kv_c_normed[:N]
+        k_pe_ = k_pe_[:N]
+
+        # CUDA TQ4 store (opt-in via VLLM_TQ_MLA_CUDA_STORE=1). Replaces the Triton
+        # bf16-direct fused store with the FlashMLA warp-shuffle FWHT-512 kernel.
+        # Same 292B layout + numerics (gated bit-level: codes 100%, round-trip ==
+        # Triton). Only for the FWHT + 4bit-kpe + norm_correction (512/64) preset.
+        if (
+            os.environ.get("VLLM_TQ_MLA_CUDA_STORE") == "1"
+            and not self.tq_config.key_fp8
+            and self._store_fwht
+            and self._kpe_4bit
+            and self.tq_config.key_mse_bits == 4
+            and self.kv_lora_rank == 512
+            and self.qk_rope_head_dim == 64
+        ):
+            import flash_mla.cuda as _fm
+            if not getattr(self, "_tq4_cuda_store_logged", False):
+                print("[TQ4-CUDA] store branch ACTIVE", flush=True)
+                self._tq4_cuda_store_logged = True
+            _fm.tq4_store_fwd(
+                kv_c_.contiguous(),
+                k_pe_.contiguous(),
+                kv_cache,
+                slot_mapping[:N].to(torch.int32).contiguous(),
+                buf["centroids"],
+                buf["kpe_centroids"],
+                buf["midpoints"],
+                buf["kpe_midpoints"],
+                bool(self.tq_config.norm_correction),
+            )
+            return
+
+        if (
+            not self.tq_config.key_fp8
+            and tq_mla_fused_store_enabled()
+            and self.tq_config.key_mse_bits == 4
+        ):
+            tq_mla_fused_kv_cache_store(
+                kv_c_,
+                k_pe_,
+                kv_cache,
+                slot_mapping,
+                pi_t=buf["PiT"],
+                midpoints=buf["midpoints"],
+                centroids_fp32=buf["centroids"],
+                mse_bits=self.tq_config.key_mse_bits,
+                mse_bytes=self._mse_index_bytes,
+                kv_c_bytes=self._kv_c_bytes,
+                packed_bytes=self._packed_bytes,
+                kpe_fp8=self._kpe_fp8,
+                kpe_4bit=self._kpe_4bit,
+                use_fwht=self._store_fwht,
+                kpe_midpoints=buf.get("kpe_midpoints"),
+                kpe_centroids_fp32=buf.get("kpe_centroids"),
+                kpe_mse_bytes=buf.get("kpe_mse_bytes", 0),
+                norm_correction=bool(self.tq_config.norm_correction),
+            )
+            return
+
+        if self.tq_config.key_fp8:
+            kv_c_packed = self._quantize_kv_c_fp8(kv_c_, k_scale)
+        else:
+            kv_c_packed = self._quantize_kv_c_mse(kv_c_, buf)
+
+        if self._kpe_fp8:
+            # P3-2: per-token fp8 e4m3 + fp16 scale.
+            # scale = max_abs / FP8_MAX, with floor to avoid div-by-zero.
+            kpe_f32 = k_pe_.to(torch.float32)
+            max_abs = kpe_f32.abs().amax(dim=-1, keepdim=True).clamp(min=1e-8)
+            scale = max_abs / _FP8_MAX  # (N, 1)
+            inv_scale = torch.where(scale > 0, 1.0 / scale, torch.ones_like(scale))
+            x = (kpe_f32 * inv_scale).clamp(-_FP8_MAX, _FP8_MAX).to(_FP8_DTYPE)
+            kpe_data = x.view(torch.uint8).view(N, self.qk_rope_head_dim)  # R bytes
+            scale_fp16 = scale.squeeze(-1).to(torch.float16)  # (N,)
+            scale_bytes = scale_fp16.view(torch.uint8).view(N, 2)
+            k_pe_bytes = torch.cat([kpe_data, scale_bytes], dim=-1)  # (N, R+2)
+        else:
+            # bf16 k_pe as raw bytes.
+            k_pe_bf16 = k_pe_.to(_BF16).contiguous()
+            k_pe_bytes = k_pe_bf16.view(torch.uint8).view(N, -1)
+
+        combined = torch.cat([kv_c_packed, k_pe_bytes], dim=-1)  # (N, packed_bytes)
+        assert combined.shape[-1] == self._packed_bytes, (
+            f"combined bytes {combined.shape[-1]} != expected {self._packed_bytes}"
+        )
+
+        cache_flat = kv_cache.view(-1, self._packed_bytes)
+        slot = slot_mapping.flatten().to(torch.int64)
+        # Replace `if not bool(valid.all()): combined = combined[valid]` with
+        # a mask-based variant that has no host sync and fixed shapes:
+        #   * clamp invalid slots (-1) to 0
+        #   * for invalid rows, gather current slot-0 bytes and write them
+        #     back unchanged (torch.where); for valid rows, write `combined`.
+        # This avoids corrupting slot 0 with zeros and keeps every op CUDA-graph
+        # capturable. In the common all-valid case the where still picks
+        # `combined` row-wise, so correctness is preserved.
+        valid = slot >= 0
+        slot = slot.clamp(min=0)
+        current = cache_flat.index_select(0, slot)  # (N, packed_bytes) uint8
+        new = torch.where(valid.view(-1, 1), combined, current)
+        cache_flat.index_copy_(0, slot, new)
+
+    def _quantize_kv_c_fp8(
+        self, kv_c: torch.Tensor, k_scale: torch.Tensor
+    ) -> torch.Tensor:
+        """FP8 path: kv_c / k_scale → fp8_e4m3fn → reinterpret as bytes.
+
+        Output shape: (N, kv_lora_rank) uint8.
+        """
+        scale = k_scale.to(torch.float32)
+        inv_scale = torch.where(scale > 0, 1.0 / scale, torch.ones_like(scale))
+        x = kv_c.to(torch.float32) * inv_scale
+        x = x.clamp(-_FP8_MAX, _FP8_MAX).to(_FP8_DTYPE)
+        return x.view(torch.uint8)  # (N, kv_lora_rank)
+
+    def _quantize_kv_c_mse(self, kv_c: torch.Tensor, buf: dict) -> torch.Tensor:
+        """MSE path: Hadamard rotation + Lloyd-Max bucketize + pack + vec_norm.
+
+        Output shape: (N, key_packed_size) uint8 where
+            key_packed_size = mse_index_bytes + 2 (fp16 vec_norm)
+        """
+        N, D = kv_c.shape
+        bits = self.tq_config.key_mse_bits
+        kv_c_f = kv_c.to(torch.float32)
+        norms = kv_c_f.norm(dim=1, keepdim=True)  # (N, 1)
+        safe = norms.clamp(min=1e-8)
+        x_hat = kv_c_f / safe
+        # Post-rotation: y = x_hat @ PiT. Pi is symmetric (Hadamard), so PiT == Pi.
+        pi_t = buf["PiT"].to(torch.float32)
+        y = x_hat @ pi_t  # (N, D)
+        # Bucketize to midpoints -> integer index in [0, 2**bits).
+        idx = torch.bucketize(y.contiguous(), buf["midpoints"])  # (N, D) int64
+        idx = idx.clamp(max=(1 << bits) - 1)
+        packed_idx = _pack_bits_rows(idx, bits=bits)  # (N, mse_index_bytes)
+        vec_norm_f32 = norms.squeeze(1)  # (N,)
+        if self.tq_config.norm_correction:
+            # P6-3: fold norm_correction into store so decode skips 512-dim sum/sqrt.
+            # eff_scale = vec_norm / ||centroid(idx)||_2 (same 2B slot as vec_norm).
+            y_hat_raw = buf["centroids_bf16"][idx.to(torch.int64)]
+            c_norm = y_hat_raw.to(torch.float32).norm(dim=-1).clamp(min=1e-8)
+            scale_f32 = vec_norm_f32 / c_norm
+        else:
+            scale_f32 = vec_norm_f32
+        scale_fp16 = scale_f32.to(torch.float16)
+        scale_bytes = scale_fp16.view(torch.uint8).view(N, 2)
+        return torch.cat([packed_idx, scale_bytes], dim=-1)  # (N, key_packed_size)
+
+    # ---------------- prefix-caching prefill ----------------
+    # P3-3b: upstream's `ops.gather_and_maybe_dequant_cache` (C++) only knows
+    # {auto, fp8*} dtypes and raises a TORCH_CHECK on `turboquant_*`. Override the
+    # context-gather step so chunked_prefill + enable_prefix_caching works.
+    #
+    # Strategy: reproduce the C++ kernel's (token_id → block_id, slot_id)
+    # mapping in Python, gather packed rows from the uint8 cache, then reuse
+    # our fused dequant kernel (same one forward_mqa uses).
+    def _compute_prefill_context(
+        self,
+        q: torch.Tensor,
+        kv_c_and_k_pe_cache: torch.Tensor,
+        attn_metadata,
+        k_scale: torch.Tensor,
+    ):
+        from vllm.model_executor.layers.attention.mla_attention import (
+            merge_attn_states,
+        )
+        from vllm.platforms import current_platform
+
+        assert attn_metadata.prefill is not None
+        prefill_metadata = attn_metadata.prefill
+        assert prefill_metadata.chunked_context is not None
+
+        use_fp8_prefill = prefill_metadata.q_data_type == current_platform.fp8_dtype()
+        if use_fp8_prefill:
+            q = q.to(prefill_metadata.q_data_type)
+
+        device = kv_c_and_k_pe_cache.device
+        buf = self._get_buffers(device)
+        L = self.kv_lora_rank
+        R = self.qk_rope_head_dim
+        num_blocks, block_size, packed_bytes = kv_c_and_k_pe_cache.shape
+        assert packed_bytes == self._packed_bytes
+
+        cache_flat = kv_c_and_k_pe_cache.view(num_blocks * block_size, packed_bytes)
+
+        output = None
+        output_lse = None
+        iters = len(prefill_metadata.chunked_context.seq_tot)
+        workspace = prefill_metadata.chunked_context.workspace
+
+        for i in range(iters):
+            toks = prefill_metadata.chunked_context.seq_tot[i]
+            if toks <= 0:
+                continue
+
+            # Replicate C++ kernel address math:
+            #   batch_id      = token_to_seq[token_id]
+            #   batch_start   = cu_seq_lens[batch_id]
+            #   batch_offset  = token_id - batch_start + seq_starts[batch_id]
+            #   block_id      = block_table[batch_id, batch_offset // block_size]
+            #   slot_id       = batch_offset % block_size
+            num_tokens = int(prefill_metadata.chunked_context.chunk_total_token[i])
+            token_to_seq = prefill_metadata.chunked_context.token_to_seq[i][
+                :num_tokens
+            ].to(torch.int64)
+            cu_seq_lens = prefill_metadata.chunked_context.cu_seq_lens[i].to(
+                torch.int64
+            )
+            seq_starts_t = prefill_metadata.chunked_context.starts[i]
+            block_table = prefill_metadata.block_table.to(torch.int64)
+
+            # All shape-dependent gather math stays on-device (CG-compatible).
+            batch_ids = token_to_seq  # (num_tokens,)
+            batch_starts = cu_seq_lens.index_select(0, batch_ids)
+            tok_ids = torch.arange(num_tokens, device=device, dtype=torch.int64)
+            batch_offsets = tok_ids - batch_starts
+            if seq_starts_t is not None:
+                seq_starts_i = seq_starts_t.to(torch.int64).index_select(0, batch_ids)
+                batch_offsets = batch_offsets + seq_starts_i
+            block_table_ids = batch_offsets // block_size
+            slot_ids = batch_offsets % block_size
+            bt_stride = block_table.stride(0)
+            bt_flat_idx = batch_ids * bt_stride + block_table_ids
+            block_ids = block_table.view(-1).index_select(0, bt_flat_idx)
+            row_ids = block_ids * block_size + slot_ids  # (num_tokens,)
+
+            # Gather packed bytes → (num_tokens, packed_bytes) uint8.
+            gathered = cache_flat.index_select(0, row_ids).contiguous()
+
+            # Shape to what fused_mla_dequant_mse expects:
+            #   cache_view: (nb=toks, bs=1, packed_bytes)
+            #   out_view:   (nb=toks, bs=1, L+R) bf16
+            cache_view = gathered.view(num_tokens, 1, packed_bytes)
+            out_view = workspace[:num_tokens].view(num_tokens, 1, L + R)
+
+            if self.tq_config.key_fp8:
+                # FP8 kv_c: reinterpret bytes as fp8_e4m3 → bf16 * k_scale.
+                kv_c_fp8 = (
+                    cache_view[..., : self._kv_c_bytes].contiguous().view(_FP8_DTYPE)
+                )
+                scale_f32 = k_scale.to(torch.float32)
+                out_view[..., :L] = (kv_c_fp8.to(torch.float32) * scale_f32).to(_BF16)
+                self._write_kpe_into_workspace(cache_view, out_view, L, R)
+            else:
+                # MSE path: fused kernel writes (y*vec_norm) + k_pe, then
+                # we apply inverse Hadamard as the final bf16 GEMM.
+                if (
+                    os.environ.get("VLLM_TQ_MLA_CUDA_DEQUANT") == "1"
+                    and self._kpe_4bit and L == 512 and R == 64
+                ):
+                    import flash_mla.cuda as _fm
+                    if not getattr(self, "_tq4_cuda_deq_dense_logged", False):
+                        print("[TQ4-CUDA] prefill dense dequant branch ACTIVE", flush=True)
+                        self._tq4_cuda_deq_dense_logged = True
+                    _fm.tq4_dequant_fwd(
+                        cache_view.contiguous(),
+                        buf["centroids_bf16"],
+                        buf["kpe_centroids_bf16"],
+                        out_view,
+                    )
+                else:
+                    fused_mla_dequant_mse(
+                        cache_view,
+                        buf["centroids_bf16"],
+                        out_view,
+                        L=L,
+                        R=R,
+                        mse_bits=self.tq_config.key_mse_bits,
+                        mse_bytes=self._mse_index_bytes,
+                        kv_c_bytes=self._kv_c_bytes,
+                        norm_correction=bool(self.tq_config.norm_correction),
+                        **self._kpe_decode_kwargs(buf),
+                    )
+                kvc = out_view[..., :L].view(num_tokens, L)
+                out_view[..., :L] = (kvc @ buf["Pi_bf16"]).view(num_tokens, 1, L)
+
+            # Extract kv_c_normed / k_pe from workspace (shape matches base).
+            kv_c_normed = workspace[:toks][..., :L]
+            _kv_b_proj_w_dtype = (
+                self.kv_b_proj.weight.dtype
+                if hasattr(self.kv_b_proj, "weight")
+                else self.kv_b_proj.params_dtype
+            )
+            if (
+                use_fp8_prefill or _kv_b_proj_w_dtype != current_platform.fp8_dtype()
+            ) and _kv_b_proj_w_dtype != torch.uint8:
+                kv_c_normed = kv_c_normed.to(_kv_b_proj_w_dtype)
+
+            k_pe = workspace[:toks][..., L:].unsqueeze(1)
+            kv_nope = self.kv_b_proj(kv_c_normed)[0].view(
+                -1, self.num_heads, self.qk_nope_head_dim + self.v_head_dim
+            )
+            if use_fp8_prefill:
+                kv_nope = kv_nope.to(prefill_metadata.q_data_type)
+                k_pe = k_pe.to(prefill_metadata.q_data_type)
+            k_nope, v = kv_nope.split([self.qk_nope_head_dim, self.v_head_dim], dim=-1)
+            k = self._concat_k_nope_k_pe(k_nope, k_pe)
+
+            attn_output, attn_softmax_lse = self._run_prefill_context_chunk(
+                prefill=prefill_metadata,
+                chunk_idx=i,
+                q=q,
+                k=k,
+                v=v,
+            )
+            if output is None:
+                output = attn_output
+                output_lse = attn_softmax_lse
+            else:
+                output_tmp = torch.empty_like(output)
+                output_lse_tmp = torch.empty_like(output_lse)
+                merge_attn_states(
+                    output=output_tmp,
+                    output_lse=output_lse_tmp,
+                    prefix_output=output,
+                    prefix_lse=output_lse,
+                    suffix_output=attn_output,
+                    suffix_lse=attn_softmax_lse,
+                )
+                output = output_tmp
+                output_lse = output_lse_tmp
+
+        return output, output_lse
+
+    # ---------------- decode ----------------
+    def forward_mqa(
+        self,
+        q: torch.Tensor | tuple[torch.Tensor, torch.Tensor],
+        # (num_blocks, block_size, packed_bytes) uint8
+        kv_c_and_k_pe_cache: torch.Tensor,
+        attn_metadata: MLACommonMetadata,
+        layer: AttentionLayer,
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        assert kv_c_and_k_pe_cache.numel() > 0
+        assert attn_metadata.decode is not None
+
+        # FP8 path: K3 fused FP8 decode kernel (no bf16 staging). FP8 has
+        # no Hadamard rotation so the K2 weight fold must NOT run on this
+        # path. Set _TQ_FP8_WORKSPACE=1 to fall back to the legacy staging
+        # flow (kept for regression comparison).
+        if self.tq_config.key_fp8:
+            if os.environ.get("_TQ_FP8_WORKSPACE") == "1":
+                return self._forward_mqa_fp8_workspace(
+                    q, kv_c_and_k_pe_cache, attn_metadata, layer
+                )
+            return self._forward_mqa_fp8_fused(
+                q, kv_c_and_k_pe_cache, attn_metadata, layer
+            )
+
+        # K2: Pi was folded into W_UK_T / W_UV at load time (fold_pi_at_load).
+
+        # ----- MSE (3/4-bit) fused path -----
+        if isinstance(q, tuple):
+            q = torch.cat(q, dim=-1)
+        assert isinstance(q, torch.Tensor)
+
+        device = kv_c_and_k_pe_cache.device
+        buf = self._get_buffers(device)
+        L = self.kv_lora_rank
+        R = self.qk_rope_head_dim
+        B = q.shape[0]
+        H_q = q.shape[1]
+
+        # K2-a: q is already in rotated space because Pi has been folded into
+        # layer.W_UK_T (the projection that produced q[..., :L]). Skip runtime
+        # rotation.
+        q_rot = q
+
+        # 2) Allocate stage1 output (logits + LSE) and final output buffers.
+        decode_md = attn_metadata.decode
+        num_kv_splits = self._get_dense_decode_num_kv_splits()
+
+        # P0-2: pool scratch buffers via WorkspaceManager instead of
+        # allocating fresh tensors every forward.
+        attn_logits, o_unrot, lse = self._get_decode_workspaces(
+            B, H_q, num_kv_splits, L, q.dtype, device,
+        )
+
+        # 3) Fused stage1 directly on packed uint8 cache.
+        fused_mla_tq_decode_stage1(
+            q_rot,
+            kv_c_and_k_pe_cache,
+            buf["centroids_bf16"],
+            attn_logits,
+            decode_md.block_table,
+            decode_md.seq_lens,
+            sm_scale=self.scale,
+            page_size=kv_c_and_k_pe_cache.shape[1],
+            L=L,
+            R=R,
+            mse_bits=self.tq_config.key_mse_bits,
+            mse_bytes=self._mse_index_bytes,
+            kv_c_bytes=self._kv_c_bytes,
+            norm_correction=bool(self.tq_config.norm_correction),
+            **self._kpe_decode_kwargs(buf),
+            num_kv_splits=num_kv_splits,
+            logit_cap=0.0,
+        )
+
+        # 4) Stage2 reduce. v_buffer is only read for its last-dim size (Lv);
+        #    pass the permanent placeholder cached in `buf` (P0-3).
+        v_shape_holder = buf["v_shape_holder"]
+        _decode_softmax_reducev_fwd(
+            attn_logits,
+            q_rot,
+            o_unrot,
+            lse,
+            v_shape_holder,
+            decode_md.seq_lens,
+            num_kv_splits,
+        )
+
+        # K2-b: leave o in rotated kv_c space; Pi has been folded into
+        # layer.W_UV so the downstream BMM (`x @ W_UV`) un-rotates implicitly.
+        o = o_unrot.view(B, H_q, L)
+
+        return o, lse
+
+    def _forward_mqa_fp8_fused(
+        self,
+        q: torch.Tensor | tuple[torch.Tensor, torch.Tensor],
+        kv_c_and_k_pe_cache: torch.Tensor,
+        attn_metadata: MLACommonMetadata,
+        layer: AttentionLayer,
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        """K3: FP8 fused decode — `fused_mla_tq_decode_stage1(key_fp8=True)`
+        reads the fp8 cache directly inside the inner KV loop, eliminating
+        the bf16 workspace materialization that `_forward_mqa_fp8_workspace`
+        used to do. The layer's k_scale is passed as a kernel constexpr.
+        """
+        assert attn_metadata.decode is not None
+        if isinstance(q, tuple):
+            q = torch.cat(q, dim=-1)
+        assert isinstance(q, torch.Tensor)
+
+        device = kv_c_and_k_pe_cache.device
+        L = self.kv_lora_rank
+        R = self.qk_rope_head_dim
+        B = q.shape[0]
+        H_q = q.shape[1]
+
+        decode_md = attn_metadata.decode
+        num_kv_splits = self._get_dense_decode_num_kv_splits()
+
+        # P0-2: pool scratch buffers via WorkspaceManager.
+        attn_logits, o_unrot, lse = self._get_decode_workspaces(
+            B, H_q, num_kv_splits, L, q.dtype, device,
+        )
+
+        # Empty centroid placeholder — KEY_FP8 branch never reads it; Triton
+        # still requires a bf16 1-D tensor argument.
+        buf = self._get_buffers(device)
+        centroids_unused = buf.get(
+            "_fp8_centroid_placeholder",
+            torch.empty(0, device=device, dtype=_BF16),
+        )
+        buf["_fp8_centroid_placeholder"] = centroids_unused
+
+        # P0-1: cached float, no `.item()` on the hot path → CUDA Graph safe.
+        k_scale = self._get_layer_k_scale(layer)
+
+        fused_mla_tq_decode_stage1(
+            q,
+            kv_c_and_k_pe_cache,
+            centroids_unused,
+            attn_logits,
+            decode_md.block_table,
+            decode_md.seq_lens,
+            sm_scale=self.scale,
+            page_size=kv_c_and_k_pe_cache.shape[1],
+            L=L,
+            R=R,
+            mse_bits=0,
+            mse_bytes=0,
+            kv_c_bytes=L,
+            norm_correction=False,
+            **self._kpe_decode_kwargs(buf),
+            key_fp8=True,
+            k_scale=k_scale,
+            num_kv_splits=num_kv_splits,
+            logit_cap=0.0,
+        )
+
+        # P0-3: reuse permanent v_shape_holder (only shape is read).
+        v_shape_holder = buf["v_shape_holder"]
+        _decode_softmax_reducev_fwd(
+            attn_logits,
+            q,
+            o_unrot,
+            lse,
+            v_shape_holder,
+            decode_md.seq_lens,
+            num_kv_splits,
+        )
+        o = o_unrot.view(B, H_q, L)
+        return o, lse
+
+    def _forward_mqa_fp8_workspace(
+        self,
+        q: torch.Tensor | tuple[torch.Tensor, torch.Tensor],
+        kv_c_and_k_pe_cache: torch.Tensor,
+        attn_metadata: MLACommonMetadata,
+        layer: AttentionLayer,
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        """Legacy FP8 path — dequant fp8 → bf16 active-block workspace, then
+        call upstream `decode_attention_fwd_grouped`. Kept reachable via the
+        env `_TQ_FP8_WORKSPACE=1` for regression comparison against
+        `_forward_mqa_fp8_fused`.
+        """
+        device = kv_c_and_k_pe_cache.device
+        L = self.kv_lora_rank
+        R = self.qk_rope_head_dim
+        num_blocks, block_size, _ = kv_c_and_k_pe_cache.shape
+
+        active_block_ids = self._collect_active_blocks(attn_metadata, num_blocks)
+        if active_block_ids is None or active_block_ids.numel() == 0:
+            q_for_count = q[0] if isinstance(q, tuple) else q
+            if q_for_count.shape[0] == 0:
+                empty_ws = torch.empty(
+                    (num_blocks, block_size, L + R), dtype=_BF16, device=device
+                )
+                return super().forward_mqa(q, empty_ws, attn_metadata, layer)
+            raise RuntimeError(
+                "TRITON_MLA_TURBOQUANT (FP8) requires active block metadata."
+            )
+
+        n_active = int(active_block_ids.shape[0])
+        sub_ws = torch.empty((n_active, block_size, L + R), dtype=_BF16, device=device)
+        sub_cache = kv_c_and_k_pe_cache.index_select(0, active_block_ids)
+
+        self._dequant_kv_c_fp8(sub_cache, layer, sub_ws)
+        self._write_kpe_into_workspace(sub_cache, sub_ws, L, R)
+
+        workspace = torch.empty(
+            (num_blocks, block_size, L + R), dtype=_BF16, device=device
+        )
+        workspace.index_copy_(0, active_block_ids, sub_ws)
+        return super().forward_mqa(q, workspace, attn_metadata, layer)
+
+    @staticmethod
+    def _collect_active_blocks(
+        attn_metadata: MLACommonMetadata, num_blocks: int
+    ) -> torch.Tensor | None:
+        """Return block ids referenced by the current batch.
+
+        Deliberately does NOT call torch.unique — that op has a
+        data-dependent output shape which blocks CUDA-graph capture and
+        forces a CPU sync. Duplicate ids in the return value are fine:
+        dequanting the same block twice into the workspace is idempotent.
+
+        Pulls from whichever sub-metadata is populated (decode / prefill /
+        chunked_prefill). Returns None when no block_table is available.
+        """
+        ids: list[torch.Tensor] = []
+        for attr in ("decode", "prefill", "chunked_prefill"):
+            sub = getattr(attn_metadata, attr, None)
+            if sub is None:
+                continue
+            bt = getattr(sub, "block_table", None)
+            if bt is None or not isinstance(bt, torch.Tensor) or bt.numel() == 0:
+                continue
+            ids.append(bt.flatten())
+        # Fallback: top-level block_table if backend exposes one.
+        bt_top = getattr(attn_metadata, "block_table", None)
+        if isinstance(bt_top, torch.Tensor) and bt_top.numel() > 0:
+            ids.append(bt_top.flatten())
+        if not ids:
+            return None
+        flat = torch.cat(ids).to(torch.int64)
+        # Clamp out-of-range ids to 0 rather than filtering (fixed shape).
+        # Out-of-range is a fault condition that shouldn't happen in
+        # practice; clamping keeps the op CG-safe while turning any
+        # stray id into a harmless re-dequant of block 0.
+        flat = flat.clamp(min=0, max=num_blocks - 1)
+        if flat.numel() == 0:
+            return None
+        return flat
+
+    def _dequant_kv_c_fp8(self, cache, layer, workspace) -> None:
+        L = self.kv_lora_rank
+        kv_c_fp8 = cache[..., : self._kv_c_bytes].contiguous().view(_FP8_DTYPE)
+        scale = layer._k_scale.to(torch.float32)
+        workspace[..., :L] = (kv_c_fp8.to(torch.float32) * scale).to(_BF16)
+
+    def _dequant_kv_c_mse(self, cache, buf: dict, workspace) -> None:
+        """Fused Triton dequant: unpack + centroid gather + (optional) norm
+        correction + vec_norm multiply, plus inline k_pe bf16 copy.
+
+        Writes workspace[..., :L] = (y_normed * vec_norm), un-rotated.
+        Caller must follow with workspace[..., :L] @= Pi (bf16 GEMM) to
+        finish the inverse Hadamard. Also writes workspace[..., L:] = k_pe.
+
+        Set _TQ_USE_TORCH_DEQUANT=1 to fall back to the pure-PyTorch path
+        (used for numerical equivalence regression).
+        """
+        if os.environ.get("_TQ_USE_TORCH_DEQUANT") == "1":
+            self._dequant_kv_c_mse_torch_ref(cache, buf, workspace)
+            return
+
+        L = self.kv_lora_rank
+        R = self.qk_rope_head_dim
+        bits = self.tq_config.key_mse_bits
+
+        # Kernel writes (y_normed * vec_norm) into workspace[..., :L] and
+        # k_pe into workspace[..., L:]. Caller (e.g. _compute_prefill_context)
+        # is responsible for the inverse Hadamard `@ Pi`.
+        fused_mla_dequant_mse(
+            cache,
+            buf["centroids_bf16"],
+            workspace,
+            L=L,
+            R=R,
+            mse_bits=bits,
+            mse_bytes=self._mse_index_bytes,
+            kv_c_bytes=self._kv_c_bytes,
+            norm_correction=bool(self.tq_config.norm_correction),
+            **self._kpe_decode_kwargs(buf),
+        )
+
+    def _dequant_kv_c_mse_torch_ref(self, cache, buf: dict, workspace) -> None:
+        """Pure-PyTorch reference path. Pre-Step5 implementation kept here
+        for numerical regression: set _TQ_USE_TORCH_DEQUANT=1 to use it.
+        Also writes workspace[..., L:] = k_pe so the contract matches the
+        fused kernel.
+        """
+        L = self.kv_lora_rank
+        bits = self.tq_config.key_mse_bits
+        idx_bytes = cache[..., : self._mse_index_bytes].contiguous()
+        norms_bytes = cache[
+            ..., self._mse_index_bytes : self._mse_index_bytes + 2
+        ].contiguous()
+
+        # Unpack indices. int32 is enough for counts up to ~2B and halves
+        # the temporary footprint vs int64.
+        idx = _unpack_bits_rows(idx_bytes, bits=bits, D=L).to(torch.int32)
+
+        y_hat = buf["centroids_bf16"][idx.to(torch.int64)]  # (nb, bs, L) bf16
+        token_scale = norms_bytes.view(torch.float16).to(torch.float32).unsqueeze(-1)
+        kv_c_recovered = (y_hat.to(torch.float32) * token_scale).to(_BF16)
+
+        workspace[..., :L] = kv_c_recovered
+        # Match fused kernel contract: also write k_pe.
+        self._write_kpe_into_workspace(cache, workspace, L, self.qk_rope_head_dim)
+
+    # ------------------------------------------------------------------
+    # k_pe writer (handles both bf16 and fp8 layouts).
+    # P3-2: when VLLM_TQ_KPE_FP8=1, k_pe is stored as R fp8 e4m3 bytes
+    # followed by 2 bytes per-token fp16 scale; otherwise raw bf16 (2*R bytes).
+    # ------------------------------------------------------------------
+    def _write_kpe_into_workspace(self, cache, workspace, L, R) -> None:
+        if self._kpe_fp8:
+            # cache layout: [..., kv_c_bytes : kv_c_bytes + R] = fp8 data
+            #               [kv_c_bytes + R : kv_c_bytes + R + 2] = fp16 scale
+            kpe_fp8 = (
+                cache[..., self._kv_c_bytes : self._kv_c_bytes + R]
+                .contiguous()
+                .view(_FP8_DTYPE)
+            )
+            # (..., 2) bytes → (..., 1) fp16 → (..., 1) bf16 broadcast scalar
+            scale_fp16 = (
+                cache[..., self._kv_c_bytes + R : self._kv_c_bytes + R + 2]
+                .contiguous()
+                .view(torch.float16)
+            )
+            scale_bf = scale_fp16.to(_BF16)  # (..., 1)
+            workspace[..., L:] = kpe_fp8.to(_BF16) * scale_bf
+        else:
+            workspace[..., L:] = cache[..., self._kv_c_bytes :].contiguous().view(_BF16)
+
+
+# =============================================================================
+# Sparse DSA path: Indexer topk + TurboQuant packed MLA cache.
+# Sparse DSA path: indexer top-k + TurboQuant packed MLA cache.
+# Prefill: gather+dedup+flash_mla_sparse_fwd; decode: fused 2-stage sparse.
+# =============================================================================
+
+
+@dataclass
+class TritonMLATurboQuantSparseMetadata(MLACommonMetadata):
+    """MLACommonMetadata plus sparse top-k indexing fields."""
+
+    req_id_per_token: torch.Tensor | None = None
+    block_table: torch.Tensor | None = None
+    block_size: int = 64
+    topk_tokens: int = 2048
+
+
+class TritonMLATurboQuantSparseMetadataBuilder(TritonMLATurboQuantMetadataBuilder):
+    """Build MLA prefill/decode metadata and sparse top-k index fields."""
+
+    _cudagraph_support: ClassVar[AttentionCGSupport] = AttentionCGSupport.UNIFORM_BATCH
+
+    def __init__(
+        self,
+        kv_cache_spec: AttentionSpec,
+        layer_names: list[str],
+        vllm_config: VllmConfig,
+        device: torch.device,
+    ) -> None:
+        super().__init__(
+            kv_cache_spec,
+            layer_names,
+            vllm_config,
+            device,
+            metadata_cls=TritonMLATurboQuantSparseMetadata,
+        )
+        # DCP+MTP fix: the base helper resets reorder_batch_threshold back to 1
+        # when decode_context_parallel_size>1 unless supports_dcp_with_varlen is
+        # set. Without this, MTP spec-decode (uniform query_len = 1+num_spec) is
+        # forced to threshold=1 under DCP and full-cudagraph decode capture asserts
+        # `max_query_len <= reorder_batch_threshold`. The sparse TQ decode handles
+        # the flattened uniform multi-token queries, so keep the spec threshold.
+        self._init_reorder_batch_threshold(
+            1, supports_spec_as_decode=True, supports_dcp_with_varlen=True
+        )
+        self.topk_tokens = vllm_config.model_config.hf_config.index_topk
+        self.req_id_per_token_buffer = torch.empty(
+            (vllm_config.scheduler_config.max_num_batched_tokens,),
+            dtype=torch.int32,
+            device=device,
+        )
+
+    def build(
+        self,
+        common_prefix_len: int,
+        common_attn_metadata: CommonAttentionMetadata,
+        fast_build: bool = False,
+    ) -> TritonMLATurboQuantSparseMetadata:
+        saved_cls = self.metadata_cls
+        self.metadata_cls = MLACommonMetadata
+        base = super().build(common_prefix_len, common_attn_metadata, fast_build)
+        self.metadata_cls = saved_cls
+
+        num_tokens = common_attn_metadata.num_actual_tokens
+        starts = np.asarray(common_attn_metadata.query_start_loc_cpu, dtype=np.int32)
+        seg_lengths = np.diff(starts)
+        req_id_per_token = np.repeat(
+            np.arange(seg_lengths.shape[0], dtype=np.int32), seg_lengths
+        )
+        self.req_id_per_token_buffer.fill_(0)
+        self.req_id_per_token_buffer[: req_id_per_token.shape[0]].copy_(
+            torch.from_numpy(req_id_per_token), non_blocking=True
+        )
+
+        sparse_fields = {f.name: getattr(base, f.name) for f in fields(MLACommonMetadata)}
+        return TritonMLATurboQuantSparseMetadata(
+            **sparse_fields,
+            req_id_per_token=self.req_id_per_token_buffer[:num_tokens],
+            block_table=common_attn_metadata.block_table_tensor,
+            block_size=self.kv_cache_spec.block_size,
+            topk_tokens=self.topk_tokens,
+        )
+
+
+class TritonMLATurboQuantSparseBackend(TritonMLATurboQuantBackend):
+    """TurboQuant MLA backend with DSA (sparse top-k) support."""
+
+    @staticmethod
+    def get_name() -> str:
+        return "TRITON_MLA_TURBOQUANT_SPARSE"
+
+    @classmethod
+    def is_sparse(cls) -> bool:
+        return True
+
+    @classmethod
+    def supports_compute_capability(cls, capability: DeviceCapability) -> bool:
+        # flash_mla_sparse_fwd requires Hopper/Blackwell (same as FlashMLA sparse).
+        return capability.major in (9, 10)
+
+    @staticmethod
+    def get_impl_cls() -> type["TritonMLATurboQuantSparseImpl"]:
+        return TritonMLATurboQuantSparseImpl
+
+    @staticmethod
+    def get_builder_cls() -> type[TritonMLATurboQuantSparseMetadataBuilder]:
+        return TritonMLATurboQuantSparseMetadataBuilder
+
+
+class TritonMLATurboQuantSparseImpl(
+    SparseMLAAttentionImpl[TritonMLATurboQuantSparseMetadata],
+    TritonMLATurboQuantImpl,
+):
+    """Sparse MLA over a TurboQuant byte-packed cache.
+
+    Prefill and decode both run ``forward_mqa``.  Prefill uses gather+dedup+
+    ``flash_mla_sparse_fwd``; decode uses fused 2-stage inline dequant+attention.
+    Production ``turboquant_*_nc`` paths are enabled by ``--kv-cache-dtype`` —
+    no env toggles required.
+    """
+
+    supports_hybrid_prefill: ClassVar[bool] = False
+
+    def __init__(
+        self,
+        num_heads: int,
+        head_size: int,
+        scale: float,
+        num_kv_heads: int,
+        alibi_slopes: list[float] | None,
+        sliding_window: int | None,
+        kv_cache_dtype: str,
+        logits_soft_cap: float | None,
+        attn_type: str,
+        kv_sharing_target_layer_name: str | None,
+        topk_indices_buffer: torch.Tensor | None = None,
+        indexer: object | None = None,
+        **mla_args,
+    ) -> None:
+        mla_args.pop("topk_indices_buffer", None)
+        TritonMLATurboQuantImpl.__init__(
+            self,
+            num_heads=num_heads,
+            head_size=head_size,
+            scale=scale,
+            num_kv_heads=num_kv_heads,
+            alibi_slopes=alibi_slopes,
+            sliding_window=sliding_window,
+            kv_cache_dtype=kv_cache_dtype,
+            logits_soft_cap=logits_soft_cap,
+            attn_type=attn_type,
+            kv_sharing_target_layer_name=kv_sharing_target_layer_name,
+            **mla_args,
+        )
+        self.topk_indices_buffer = (
+            indexer.topk_indices_buffer  # type: ignore[union-attr]
+            if indexer is not None
+            else topk_indices_buffer
+        )
+        assert self.topk_indices_buffer is not None
+        self.softmax_scale = float(scale)
+        self.prefill_padding = (
+            128 if current_platform.is_device_capability_family(100) else 64
+        )
+        from vllm.config import get_current_vllm_config
+        from vllm.distributed import get_dcp_group
+
+        vllm_config = get_current_vllm_config()
+        max_tokens = vllm_config.scheduler_config.max_num_batched_tokens
+        from vllm.v1.worker.workspace import current_workspace_manager
+
+        # DCP: MLAAttention all-gathers Q over heads then merges per-rank
+        # partials via LSE (cp_lse_ag_out_rs / dcp_a2a_lse_reduce). Indexer
+        # stays FP8 under DCP; this wires the TQ *main* KV sparse path.
+        _pc = vllm_config.parallel_config
+        self.dcp_world_size = _pc.decode_context_parallel_size
+        self.dcp_rank = (
+            get_dcp_group().rank_in_group if self.dcp_world_size > 1 else 0
+        )
+        self.dcp_interleave_size = _pc.cp_kv_cache_interleave_size
+
+        topk = self.topk_indices_buffer.shape[1]
+        # Decode always uses fused 2-stage; _TQ_SPARSE_WORKSPACE only switches
+        # prefill to gather+flash+dedup.  Reserve peak 2-stage scratch either way.
+        # Under DCP, Q arrives with num_heads * dcp_world_size after all-gather.
+        max_h = (
+            self.prefill_padding
+            if os.environ.get("VLLM_TQ_SPARSE_Q_HEAD_PAD", "0") == "1"
+            else num_heads
+        )
+        if self.dcp_world_size > 1:
+            max_h = max_h * self.dcp_world_size
+        reserve_b = max_tokens
+        if tq_mla_sparse_adaptive_enabled():
+            # Adaptive caps B*splits at ~sm_count*8 (see tq_mla_sparse_split_count),
+            # so peak f32 scratch is max(sm_count*8, mnbt) * H * 1 * (L+1) instead
+            # of mnbt * H * 64.  Reserve with splits=1 so KV profiling matches tqa.
+            target = self._sm_count * 8
+            reserve_b = max(target, max_tokens)
+            num_kv_splits = 1
+        else:
+            num_kv_splits = tq_mla_sparse_split_count(
+                topk, self._sm_count * 2
+            )
+            if envs.VLLM_BATCH_INVARIANT:
+                num_kv_splits = 1
+            num_kv_splits = max(
+                num_kv_splits, self._get_dense_decode_num_kv_splits()
+            )
+        # Grow the shared WorkspaceManager blob to decode peak BEFORE taking
+        # q_concat_buffer views. Otherwise a later blob grow can reallocate the
+        # underlying storage and leave cached q views dangling.
+        self._reserve_decode_workspace_peak(
+            reserve_b,
+            max_h,
+            num_kv_splits,
+            self.topk_indices_buffer.device,
+        )
+        q_concat_shape = (max_tokens, num_heads, head_size)
+        (self.q_concat_buffer,) = current_workspace_manager().get_simultaneous(
+            (q_concat_shape, torch.bfloat16),
+        )
+        # Legacy prefill pool: do NOT prealloc here (model load time).  Growing workspace
+        # to max_tokens*topk during __init__ steals memory from KV profiling /
+        # sampler warmup.  It grows via _get_global_topk_dequant_workspace on
+        # first forward, before lock_workspace() after cudagraph capture.
+        self._max_decode_tokens = max_tokens
+        self._sparse_b_seqlen: torch.Tensor | None = None
+        self._sparse_topk_val: int | None = None
+
+    def do_kv_cache_update(
+        self,
+        kv_c_normed: torch.Tensor,
+        k_pe: torch.Tensor,
+        kv_cache: torch.Tensor,
+        slot_mapping: torch.Tensor,
+        kv_cache_dtype: str,
+        k_scale: torch.Tensor,
+    ) -> None:
+        return TritonMLATurboQuantImpl.do_kv_cache_update(
+            self,
+            kv_c_normed,
+            k_pe,
+            kv_cache,
+            slot_mapping,
+            kv_cache_dtype,
+            k_scale,
+        )
+
+    def _get_topk_dequant_workspace(
+        self,
+        num_slots: int,
+        L: int,
+        R: int,
+        device: torch.device,
+    ) -> torch.Tensor:
+        """Device-global bf16 workspace for legacy ``_gather_dequant_topk_workspace``.
+
+        Shared across all attention layers on this GPU; safe because layer
+        forwards are sequential and each layer fully consumes the view first.
+        """
+        assert self.topk_indices_buffer is not None
+        return _get_global_topk_dequant_workspace(
+            num_slots,
+            L,
+            R,
+            device,
+            self.topk_indices_buffer.numel(),
+        )
+
+    def _gather_dequant_topk_workspace(
+        self,
+        packed_cache: torch.Tensor,
+        global_topk: torch.Tensor,
+        layer: AttentionLayer,
+        *,
+        apply_pi_on_k: bool = False,
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        """Dequant top-k packed slots into bf16 workspace.
+
+        Returns ``(dequant_kv, remapped_local_topk)``.  When P3 dedup is off,
+        ``remapped_local_topk`` is None and workspace has shape ``(T*K, 1, L+R)``.
+        When dedup is on, workspace has ``(U, 1, L+R)`` and remapped indices
+        point into those ``U`` unique global slots.
+        """
+        num_tokens, topk = global_topk.shape
+        device = packed_cache.device
+        buf = self._get_buffers(device)
+        L = self.kv_lora_rank
+        R = self.qk_rope_head_dim
+        packed_bytes = self._packed_bytes
+        page_size = packed_cache.shape[1]
+
+        remapped_local: torch.Tensor | None = None
+        gather_topk = global_topk
+        num_out_slots = num_tokens * topk
+        if _sparse_topk_dedup_enabled():
+            num_cache_slots = packed_cache.shape[0] * packed_cache.shape[1]
+            unique_slots, remapped_local, num_unique = _dedup_global_topk(
+                global_topk, num_cache_slots=num_cache_slots
+            )
+            if num_unique > 0:
+                gather_topk = unique_slots.unsqueeze(1)
+                num_out_slots = num_unique
+
+        out_view = self._get_topk_dequant_workspace(
+            num_out_slots, L, R, device
+        )
+
+        use_fused_topk_gather = not self.tq_config.key_fp8
+
+        def _pytorch_gather_cache_view(topk_for_gather: torch.Tensor) -> torch.Tensor:
+            cache_flat = packed_cache.view(-1, packed_bytes)
+            valid = topk_for_gather >= 0
+            safe = torch.where(valid, topk_for_gather, torch.zeros_like(topk_for_gather))
+            g_rows, g_cols = topk_for_gather.shape
+            gathered = cache_flat[safe.reshape(-1)].view(g_rows, g_cols, packed_bytes)
+            return gathered.view(g_rows * g_cols, 1, packed_bytes)
+
+        if self.tq_config.key_fp8:
+            k_scale = self._get_layer_k_scale(layer)
+            cache_view = _pytorch_gather_cache_view(gather_topk)
+            kv_c_fp8 = (
+                cache_view[..., : self._kv_c_bytes].contiguous().view(_FP8_DTYPE)
+            )
+            out_view[..., :L] = (kv_c_fp8.to(torch.float32) * k_scale).to(_BF16)
+            self._write_kpe_into_workspace(cache_view, out_view, L, R)
+        elif use_fused_topk_gather:
+            # CUDA TQ4 sparse gather-dequant (opt-in VLLM_TQ_MLA_CUDA_DEQUANT=1).
+            # dedup stays in Python (_dedup_global_topk); the CUDA kernel only
+            # replaces the Triton dequant pass over the deduped unique slots.
+            if (
+                os.environ.get("VLLM_TQ_MLA_CUDA_DEQUANT") == "1"
+                and self._kpe_4bit and L == 512 and R == 64
+            ):
+                import flash_mla.cuda as _fm
+                if not getattr(self, "_tq4_cuda_deq_sparse_logged", False):
+                    print("[TQ4-CUDA] sparse gather-dequant branch ACTIVE", flush=True)
+                    self._tq4_cuda_deq_sparse_logged = True
+                _fm.tq4_sparse_gather_dequant_fwd(
+                    packed_cache,
+                    gather_topk.reshape(-1).to(torch.int32).contiguous(),
+                    buf["centroids_bf16"],
+                    buf["kpe_centroids_bf16"],
+                    out_view,
+                )
+            else:
+                fused_mla_sparse_topk_gather_dequant_mse(
+                    packed_cache,
+                    gather_topk,
+                    buf["centroids_bf16"],
+                    out_view,
+                    page_size=page_size,
+                    L=L,
+                    R=R,
+                    mse_bits=self.tq_config.key_mse_bits,
+                    mse_bytes=self._mse_index_bytes,
+                    kv_c_bytes=self._kv_c_bytes,
+                    norm_correction=bool(self.tq_config.norm_correction),
+                    **self._kpe_decode_kwargs(buf),
+                )
+            if apply_pi_on_k:
+                kvc = out_view[..., :L].reshape(-1, L)
+                out_view[..., :L] = (kvc @ buf["Pi_bf16"]).view_as(
+                    out_view[..., :L]
+                )
+        else:
+            cache_view = _pytorch_gather_cache_view(gather_topk)
+            fused_mla_dequant_mse(
+                cache_view,
+                buf["centroids_bf16"],
+                out_view,
+                L=L,
+                R=R,
+                mse_bits=self.tq_config.key_mse_bits,
+                mse_bytes=self._mse_index_bytes,
+                kv_c_bytes=self._kv_c_bytes,
+                norm_correction=bool(self.tq_config.norm_correction),
+                **self._kpe_decode_kwargs(buf),
+            )
+            if apply_pi_on_k:
+                kvc = out_view[..., :L].reshape(-1, L)
+                out_view[..., :L] = (kvc @ buf["Pi_bf16"]).view_as(
+                    out_view[..., :L]
+                )
+
+        return out_view, remapped_local
+
+    def _sparse_flash_mla(
+        self,
+        q: torch.Tensor,
+        dequant_kv: torch.Tensor,
+        global_topk: torch.Tensor,
+        *,
+        remapped_local_topk: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        num_tokens, topk = global_topk.shape
+        device = q.device
+        # Under DCP, Q was all-gathered over heads before forward_mqa, so
+        # self.num_heads (per-rank) is wrong; use the head count in q.
+        actual_num_heads = q.shape[1]
+
+        if remapped_local_topk is not None:
+            local_topk = remapped_local_topk
+        else:
+            local_topk = (
+                torch.arange(topk, device=device, dtype=torch.int32)
+                .unsqueeze(0)
+                .expand(num_tokens, topk)
+                + torch.arange(num_tokens, device=device, dtype=torch.int32).unsqueeze(1)
+                * topk
+            )
+            local_topk = torch.where(
+                global_topk >= 0, local_topk, torch.full_like(local_topk, -1)
+            )
+
+        if actual_num_heads % self.prefill_padding != 0:
+            padded_num_heads = (
+                (actual_num_heads + self.prefill_padding - 1)
+                // self.prefill_padding
+            ) * self.prefill_padding
+            q_padded = q.new_empty((q.shape[0], padded_num_heads, q.shape[2]))
+            q_padded[:, :actual_num_heads, :] = q
+            q = q_padded
+
+        # flash_mla_sparse_fwd -> (output, max_logits, lse); LSE needed for DCP.
+        output, _max_logits, lse = flash_mla_sparse_fwd(
+            q,
+            dequant_kv,
+            local_topk.view(num_tokens, 1, topk),
+            self.softmax_scale,
+            d_v=self.kv_lora_rank,
+        )
+        return output[:, :actual_num_heads, :], lse[:, :actual_num_heads]
+
+    def _get_sparse_b_seqlen(
+        self, batch: int, topk: int, device: torch.device
+    ) -> torch.Tensor:
+        if (
+            self._sparse_b_seqlen is None
+            or self._sparse_topk_val != topk
+            or self._sparse_b_seqlen.device != device
+            or self._sparse_b_seqlen.shape[0] < batch
+        ):
+            self._sparse_topk_val = topk
+            self._sparse_b_seqlen = torch.full(
+                (self._max_decode_tokens,),
+                topk,
+                dtype=torch.int32,
+                device=device,
+            )
+        return self._sparse_b_seqlen[:batch]
+
+    def _forward_mqa_sparse_fused(
+        self,
+        q: torch.Tensor,
+        kv_c_and_k_pe_cache: torch.Tensor,
+        global_topk: torch.Tensor,
+        layer: AttentionLayer,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Fused sparse decode: inline dequant over top-k global slots."""
+        # q is commonly a view into q_concat_buffer, and decode stage1 writes
+        # attn_logits from the same workspace blob. Clone to break potential
+        # q/attn_logits aliasing within a single fused pass.
+        q = q.clone()
+        device = kv_c_and_k_pe_cache.device
+        buf = self._get_buffers(device)
+        L = self.kv_lora_rank
+        R = self.qk_rope_head_dim
+        B = q.shape[0]
+        H_q = q.shape[1]
+        topk = global_topk.shape[1]
+
+        # K2-a (same as dense decode): q latent is already Pi-rotated because
+        # fold_pi_at_load folded Pi into layer.W_UK_T at weight load.
+        q_work = q
+        H_run = H_q
+
+        # FlashMLA native-TQ4 decode (opt-in via VLLM_TQ_MLA_FLASHMLA_DECODE=1).
+        # The CUDA producer reads the 292B cache and writes pre-Hadamard K; q_pe
+        # is rotated host-side here (nope is already Pi-rotated via the W_UK_T
+        # fold). Output is o_unrot (Hadamard space) + lse — identical contract to
+        # the Triton stage1+stage2 path below (Pi is folded into W_UV downstream).
+        if (
+            os.environ.get("VLLM_TQ_MLA_FLASHMLA_DECODE") == "1"
+            and not self.tq_config.key_fp8
+        ):
+            import flash_mla.cuda as _fm
+            from vllm.v1.attention.ops.triton_turboquant_mla_decode import (
+                _rotate_qpe_for_kpe_4bit,
+            )
+
+            if not getattr(self, "_tq4_flashmla_logged", False):
+                print("[FlashMLA-TQ4] sparse decode branch ACTIVE", flush=True)
+                self._tq4_flashmla_logged = True
+            q_rot = _rotate_qpe_for_kpe_4bit(q_work, L, R, self._kpe_4bit)
+            # DCP compaction: pass per-row topk_length so the kernel scans only the
+            # valid prefix. global_topk is already compacted (valid slots first,
+            # -1 tail), so (>=0).sum recovers the count as a pure-dataflow reduction.
+            _tlen = None
+            if getattr(self, "_dcp_compact_active", False):
+                _tlen = (global_topk >= 0).sum(dim=1).to(torch.int32)
+                if not getattr(self, "_dcp_compact_logged", False):
+                    print("[TQ4-CUDA] DCP topk compaction branch ACTIVE", flush=True)
+                    self._dcp_compact_logged = True
+            o, lse, _, _ = _fm.sparse_decode_tq4_fwd(
+                q_rot.unsqueeze(1),                  # [B, 1, H, 576]
+                kv_c_and_k_pe_cache.unsqueeze(2),    # [nb, page, 1, 292] uint8
+                global_topk.unsqueeze(1),            # [B, 1, topk]
+                _tlen, None, None, None, None, None, None,
+                L, self.softmax_scale,
+                buf["centroids_bf16"], buf["kpe_centroids_bf16"],
+            )
+            o = o.view(B, H_run, L)
+            lse = lse.reshape(B, H_run)
+            return o, lse
+
+        if envs.VLLM_BATCH_INVARIANT:
+            num_kv_splits = 1
+        else:
+            num_kv_splits = tq_mla_sparse_split_count(
+                topk, self._sm_count * 2, batch=B
+            )
+
+        attn_logits, o_unrot, lse = self._get_decode_workspaces(
+            B, H_run, num_kv_splits, L, q.dtype, device,
+        )
+        b_seqlen = self._get_sparse_b_seqlen(B, topk, device)
+
+        if self.tq_config.key_fp8:
+            k_scale = self._get_layer_k_scale(layer)
+            fused_mla_tq_sparse_decode_stage1(
+                q_work,
+                kv_c_and_k_pe_cache,
+                buf["centroids_bf16"],
+                attn_logits,
+                global_topk,
+                b_seqlen,
+                sm_scale=self.softmax_scale,
+                page_size=kv_c_and_k_pe_cache.shape[1],
+                topk=topk,
+                L=L,
+                R=R,
+                mse_bits=self.tq_config.key_mse_bits,
+                mse_bytes=self._mse_index_bytes,
+                kv_c_bytes=self._kv_c_bytes,
+                norm_correction=bool(self.tq_config.norm_correction),
+                **self._kpe_decode_kwargs(buf),
+                key_fp8=True,
+                k_scale=k_scale,
+                num_kv_splits=num_kv_splits,
+            )
+        else:
+            fused_mla_tq_sparse_decode_stage1(
+                q_work,
+                kv_c_and_k_pe_cache,
+                buf["centroids_bf16"],
+                attn_logits,
+                global_topk,
+                b_seqlen,
+                sm_scale=self.softmax_scale,
+                page_size=kv_c_and_k_pe_cache.shape[1],
+                topk=topk,
+                L=L,
+                R=R,
+                mse_bits=self.tq_config.key_mse_bits,
+                mse_bytes=self._mse_index_bytes,
+                kv_c_bytes=self._kv_c_bytes,
+                norm_correction=bool(self.tq_config.norm_correction),
+                **self._kpe_decode_kwargs(buf),
+                num_kv_splits=num_kv_splits,
+            )
+
+        sparse_decode_softmax_reducev_fwd(
+            attn_logits,
+            q_work,
+            o_unrot,
+            lse,
+            buf["v_shape_holder"],
+            b_seqlen,
+            num_kv_splits,
+        )
+
+        # K2-b: leave o in rotated kv_c space; Pi is folded into layer.W_UV.
+        # Return LSE so DCP can merge per-rank partials (invalid topk slots are
+        # already masked to -inf inside the fused sparse kernel).
+        o = o_unrot.view(B, H_run, L)
+        return o, lse
+
+    def _forward_mqa_gather_flash(
+        self,
+        q: torch.Tensor,
+        kv_c_and_k_pe_cache: torch.Tensor,
+        global_topk: torch.Tensor,
+        layer: AttentionLayer,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        dequant_kv, remapped_local = self._gather_dequant_topk_workspace(
+            kv_c_and_k_pe_cache,
+            global_topk,
+            layer,
+            apply_pi_on_k=False,
+        )
+        return self._sparse_flash_mla(
+            q,
+            dequant_kv,
+            global_topk,
+            remapped_local_topk=remapped_local,
+        )
+
+    def forward_mqa(
+        self,
+        q: torch.Tensor | tuple[torch.Tensor, torch.Tensor],
+        kv_c_and_k_pe_cache: torch.Tensor,
+        attn_metadata: TritonMLATurboQuantSparseMetadata,
+        layer: AttentionLayer,
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        """Sparse MLA: prefill may use gather+flash; decode uses fused 2-stage.
+
+        Decode (2-stage) and prefill (gather+flash) have different scratch
+        lifetimes, so each pass materializes its own query slice immediately
+        before use via ``_materialize_q`` instead of concatenating the whole
+        batch up front. The decode 2-stage scratch (``attn_logits`` from
+        ``_get_decode_workspaces``) is pooled in the same WorkspaceManager blob
+        as ``q_concat_buffer`` and may alias it; running decode first and then
+        re-materializing the prefill query into that same buffer (a fresh write)
+        means prefill never reads decode-corrupted data, with no extra copy.
+        """
+        if isinstance(q, tuple):
+            q_nope_full, q_pe_full = q
+            num_actual_toks = q_nope_full.shape[0]
+        else:
+            q_nope_full = q_pe_full = None
+            num_actual_toks = q.shape[0]
+
+        def _materialize_q(start: int, end: int) -> torch.Tensor:
+            # Concat the [start:end) query into the shared q_concat_buffer
+            # (zero-copy reuse) right before its consumer reads it, or slice a
+            # pre-concatenated tensor input. Writing the buffer immediately
+            # before each consumer guarantees a prior pass's WorkspaceManager
+            # scratch cannot corrupt this pass's query.
+            if q_nope_full is not None:
+                out = self.q_concat_buffer[: end - start]
+                ops.concat_mla_q(q_nope_full[start:end], q_pe_full[start:end], out)
+                return out
+            return q[start:end]
+
+        assert self.topk_indices_buffer is not None
+        assert attn_metadata.req_id_per_token is not None
+        assert attn_metadata.block_table is not None
+        topk_indices = self.topk_indices_buffer[:num_actual_toks]
+
+        # Under DCP: filter topk to tokens this rank holds and remap to local
+        # cache slots (others -> -1). Matches FLASHMLA_SPARSE / sparse_utils.
+        #
+        # DCP dead-slot compaction (opt-in VLLM_TQ_MLA_DCP_COMPACT_TOPK=1): on a
+        # PURE-DECODE step with FlashMLA decode + dcp>1, compact the scattered
+        # valid slots to a contiguous prefix (folded into the convert pass) so the
+        # decode kernel scans only ceil(valid/64) blocks via per-row topk_length,
+        # instead of the full topk. Falls back to the scattered convert otherwise
+        # (prefill/mixed steps are never compacted -> their correctness is intact).
+        self._dcp_compact_active = (
+            os.environ.get("VLLM_TQ_MLA_DCP_COMPACT_TOPK") == "1"
+            and os.environ.get("VLLM_TQ_MLA_FLASHMLA_DECODE") == "1"
+            and self.dcp_world_size > 1
+            and not self.tq_config.key_fp8
+            and num_actual_toks == attn_metadata.num_decode_tokens
+        )
+        if self._dcp_compact_active:
+            global_topk, _ = triton_convert_and_compact(
+                attn_metadata.req_id_per_token[:num_actual_toks],
+                attn_metadata.block_table,
+                topk_indices,
+                BLOCK_SIZE=attn_metadata.block_size,
+                NUM_TOPK_TOKENS=topk_indices.shape[1],
+                dcp_world_size=self.dcp_world_size,
+                dcp_rank=self.dcp_rank,
+                dcp_interleave_size=self.dcp_interleave_size,
+            )
+        else:
+            global_topk = triton_convert_req_index_to_global_index(
+                attn_metadata.req_id_per_token[:num_actual_toks],
+                attn_metadata.block_table,
+                topk_indices,
+                BLOCK_SIZE=attn_metadata.block_size,
+                NUM_TOPK_TOKENS=topk_indices.shape[1],
+                dcp_world_size=self.dcp_world_size,
+                dcp_rank=self.dcp_rank,
+                dcp_interleave_size=self.dcp_interleave_size,
+            )
+        assert isinstance(global_topk, torch.Tensor)
+
+        # Production sparse prefill: gather+flash (phase1). Opt-out: _TQ_SPARSE_WORKSPACE=0.
+        use_gather_flash_prefill = (
+            os.environ.get("_TQ_SPARSE_WORKSPACE", "1") != "0"
+        )
+        num_decode_tokens = attn_metadata.num_decode_tokens
+        num_prefill_tokens = num_actual_toks - num_decode_tokens
+        # Non-DCP callers ignore LSE; DCP combine in MLAAttention needs it.
+        want_lse = self.dcp_world_size > 1
+
+        def _dcp_finalize(
+            out: torch.Tensor, lse: torch.Tensor
+        ) -> tuple[torch.Tensor, torch.Tensor]:
+            # A query whose entire top-k missed this rank's shard has e_sum==0
+            # in the fused reduce-v -> NaN out + (-inf) lse. correct_attn_out
+            # weights this rank by exp(lse - lse_max) == 0, but NaN * 0 stays
+            # NaN, so zero the non-finite rows explicitly. lse == -inf already
+            # makes them contribute nothing. Upcast lse to fp32 to match the
+            # cross-rank combine (correct_attn_out / dcp_a2a_lse_reduce).
+            out = torch.nan_to_num(out, nan=0.0, posinf=0.0, neginf=0.0)
+            return out, lse.to(torch.float32)
+
+        if not use_gather_flash_prefill:
+            attn_out, lse = self._forward_mqa_sparse_fused(
+                _materialize_q(0, num_actual_toks),
+                kv_c_and_k_pe_cache,
+                global_topk,
+                layer,
+            )
+            if not want_lse:
+                return attn_out, None
+            return _dcp_finalize(attn_out, lse)
+
+        if num_prefill_tokens == 0:
+            attn_out, lse = self._forward_mqa_sparse_fused(
+                _materialize_q(0, num_actual_toks),
+                kv_c_and_k_pe_cache,
+                global_topk,
+                layer,
+            )
+            if not want_lse:
+                return attn_out, None
+            return _dcp_finalize(attn_out, lse)
+
+        if num_decode_tokens == 0:
+            attn_out, lse = self._forward_mqa_gather_flash(
+                _materialize_q(0, num_actual_toks),
+                kv_c_and_k_pe_cache,
+                global_topk,
+                layer,
+            )
+            if not want_lse:
+                return attn_out, None
+            return _dcp_finalize(attn_out, lse)
+
+        # Mixed batch: decode (2-stage) runs first and may write
+        # WorkspaceManager scratch that aliases q_concat_buffer; prefill
+        # (gather+flash) then re-materializes its own query into that same
+        # buffer (a fresh write) so it never reads decode-corrupted data.
+        q_decode = _materialize_q(0, num_decode_tokens)
+        # Under DCP, q may already be all-gathered over heads.
+        out_heads = q_decode.shape[1]
+        attn_out = q_decode.new_empty(
+            (num_actual_toks, out_heads, self.kv_lora_rank),
+            dtype=q_decode.dtype,
+            device=q_decode.device,
+        )
+        decode_out, decode_lse = self._forward_mqa_sparse_fused(
+            q_decode,
+            kv_c_and_k_pe_cache,
+            global_topk[:num_decode_tokens],
+            layer,
+        )
+        attn_out[:num_decode_tokens] = decode_out
+        prefill_out, prefill_lse = self._forward_mqa_gather_flash(
+            _materialize_q(num_decode_tokens, num_actual_toks),
+            kv_c_and_k_pe_cache,
+            global_topk[num_decode_tokens:],
+            layer,
+        )
+        attn_out[num_decode_tokens:] = prefill_out
+        if not want_lse:
+            return attn_out, None
+        lse = decode_lse.new_empty(
+            (num_actual_toks, out_heads), dtype=torch.float32
+        )
+        lse[:num_decode_tokens] = decode_lse.to(torch.float32)
+        lse[num_decode_tokens:] = prefill_lse.to(torch.float32)
+        return _dcp_finalize(attn_out, lse)

--- a/vllm/v1/attention/backends/registry.py
+++ b/vllm/v1/attention/backends/registry.py
@@ -82,8 +82,7 @@ class AttentionBackendEnum(Enum, metaclass=_AttentionBackendEnumMeta):
         "vllm.v1.attention.backends.mla.triton_mla_tq.TritonMLATurboQuantBackend"
     )
     TRITON_MLA_TURBOQUANT_SPARSE = (
-        "vllm.v1.attention.backends.mla.triton_mla_tq."
-        "TritonMLATurboQuantSparseBackend"
+        "vllm.v1.attention.backends.mla.triton_mla_tq.TritonMLATurboQuantSparseBackend"
     )
     CUTLASS_MLA = "vllm.v1.attention.backends.mla.cutlass_mla.CutlassMLABackend"
     FLASHMLA = "vllm.v1.attention.backends.mla.flashmla.FlashMLABackend"

--- a/vllm/v1/attention/backends/registry.py
+++ b/vllm/v1/attention/backends/registry.py
@@ -78,6 +78,13 @@ class AttentionBackendEnum(Enum, metaclass=_AttentionBackendEnumMeta):
         "FlashInferMLASparseSM120Backend"
     )
     TRITON_MLA = "vllm.v1.attention.backends.mla.triton_mla.TritonMLABackend"
+    TRITON_MLA_TURBOQUANT = (
+        "vllm.v1.attention.backends.mla.triton_mla_tq.TritonMLATurboQuantBackend"
+    )
+    TRITON_MLA_TURBOQUANT_SPARSE = (
+        "vllm.v1.attention.backends.mla.triton_mla_tq."
+        "TritonMLATurboQuantSparseBackend"
+    )
     CUTLASS_MLA = "vllm.v1.attention.backends.mla.cutlass_mla.CutlassMLABackend"
     FLASHMLA = "vllm.v1.attention.backends.mla.flashmla.FlashMLABackend"
     FLASHMLA_SPARSE = (

--- a/vllm/v1/attention/ops/indexer_turboquant.py
+++ b/vllm/v1/attention/ops/indexer_turboquant.py
@@ -1,0 +1,1438 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""TurboQuant 4bit MSE cache for DSA Indexer (Patch 08).
+
+Store: L2-normalize K, Hadamard rotate (y = x_hat @ Pi), Lloyd-Max 4bit in rotated
+space + eff_scale (norm correction). Decode/prefill score in rotated space; fold Pi
+into indexer.wq_b at load (same strategy as MLA W_UK_T fold).
+"""
+
+from __future__ import annotations
+
+import os
+
+import torch
+
+from vllm.logger import init_logger
+from vllm.model_executor.layers.quantization.turboquant.centroids import (
+    get_centroids,
+)
+from vllm.triton_utils import tl, triton
+from vllm.v1.attention.backends.mla.triton_mla_tq import (
+    _pack_bits_rows,
+    _unpack_bits_rows,
+)
+from vllm.v1.attention.backends.turboquant_attn import _build_hadamard
+from vllm.v1.attention.ops.triton_turboquant_mla_decode import (
+    _tq_mla_gather_centroids,
+    _tq_mla_gather_centroids_1d,
+)
+
+logger = init_logger(__name__)
+
+_BF16 = torch.bfloat16
+_FP8_DTYPE = torch.float8_e4m3fn
+
+INDEXER_HEAD_DIM = 128
+INDEXER_MSE_BITS = 4
+INDEXER_MSE_BYTES = 64
+INDEXER_PACKED_BYTES = 66
+INDEXER_FP8_SLOT_BYTES = 132
+
+_INDEXER_TQ_BUFFERS: dict[str, dict] = {}
+_INDEXER_TQ_FUSED_WARMED: set[str] = set()
+_INDEXER_TQ_STORE_WARMED: set[str] = set()
+_INDEXER_TQ_STORE_DISABLE_AUTOTUNE = (
+    os.environ.get("VLLM_INDEXER_TQ_STORE_AUTOTUNE", "0") != "1"
+)
+
+_INDEXER_TQ_STORE_AUTOTUNE_CONFIGS = (
+    [triton.Config({}, num_warps=4, num_stages=1)]
+    if _INDEXER_TQ_STORE_DISABLE_AUTOTUNE
+    else [
+        triton.Config({}, num_warps=1, num_stages=1),
+        triton.Config({}, num_warps=2, num_stages=1),
+        triton.Config({}, num_warps=4, num_stages=1),
+        triton.Config({}, num_warps=4, num_stages=2),
+        triton.Config({}, num_warps=8, num_stages=1),
+    ]
+)
+
+
+def is_indexer_tq_4bit_enabled() -> bool:
+    return os.environ.get("VLLM_INDEXER_KV_TQ_4BIT", "0") == "1"
+
+
+def use_indexer_tq_hadamard() -> bool:
+    """Hadamard @Pi before Lloyd-Max store; Q-side Pi fold in wq_b when enabled.
+
+    Set VLLM_INDEXER_TQ_HADAMARD=0 to use legacy direct 4bit (norm -> bucketize).
+    """
+    return os.environ.get("VLLM_INDEXER_TQ_HADAMARD", "1") == "1"
+
+
+def use_indexer_tq_fused_decode() -> bool:
+    """Fused TQ4 paged logits (skip sync + DeepGEMM decode bridge)."""
+    return os.environ.get("VLLM_INDEXER_TQ_FUSED_DECODE", "1") == "1"
+
+
+INDEXER_DECODE_TILE = 64
+# CUDA grid-Y cap is 65535; fixed launch width for long-context sync/decode.
+INDEXER_SYNC_FIXED_GRID = 40960
+
+
+def indexer_sync_fixed_grid() -> int:
+    return max(
+        1,
+        int(os.environ.get("VLLM_INDEXER_TQ_SYNC_FIXED_GRID", str(INDEXER_SYNC_FIXED_GRID))),
+    )
+
+
+def indexer_sync_inner_tile(max_model_len: int) -> int:
+    """Tokens per program when grid-Y is fixed (e.g. 128k -> 4, 200k -> 8).
+
+    Rounded up to a power of two because Triton ``tl.arange(0, TILE)`` requires it.
+    """
+    fg = indexer_sync_fixed_grid()
+    needed = (max_model_len + fg - 1) // fg
+    tile = 1
+    while tile < needed:
+        tile <<= 1
+    return tile
+
+
+def indexer_sync_num_chunks(max_model_len: int) -> int:
+    fg = indexer_sync_fixed_grid()
+    return (max_model_len + fg - 1) // fg
+
+
+def indexer_decode_grid_n(max_model_len: int) -> int:
+    """Fixed tile grid width for CUDA graph (40960 -> 640)."""
+    return (max_model_len + INDEXER_DECODE_TILE - 1) // INDEXER_DECODE_TILE
+
+
+# SM90 fp8_fp4_paged_mqa_logits (Hopper): BLOCK_KV=64, kNumMathWarpGroups=2.
+INDEXER_DG_SYNC_BLOCK_KV = 64
+INDEXER_DG_SYNC_BLOCKS_PER_SPLIT = 2
+
+
+def indexer_tq_sync_mode() -> str:
+    """TQ4 decode FP8 workspace sync: fixed | pos | tile | chunk | sm."""
+    return os.environ.get("VLLM_INDEXER_TQ_SYNC_MODE", "fixed").lower()
+
+
+def resolve_indexer_tq_sync_mode(max_model_len: int | None) -> str:
+    """Pick sync launch mode; auto-fallback when pos grid would exceed CUDA limit."""
+    mode = indexer_tq_sync_mode()
+    if mode == "pos" and max_model_len is not None and max_model_len > 65535:
+        return "fixed"
+    return mode
+
+
+_INDEXER_TQ_SYNC_LOGGED: set[str] = set()
+
+
+def _log_indexer_tq_sync_config_once(mode: str, max_model_len: int | None) -> None:
+    env_mode = indexer_tq_sync_mode()
+    key = f"{mode}:{max_model_len}:{env_mode}"
+    if key in _INDEXER_TQ_SYNC_LOGGED:
+        return
+    _INDEXER_TQ_SYNC_LOGGED.add(key)
+    if mode == "fixed":
+        fg = indexer_sync_fixed_grid()
+        inner = indexer_sync_inner_tile(max_model_len or 0)
+        logger.info_once(
+            "Indexer TQ4 decode sync: mode=%s (env VLLM_INDEXER_TQ_SYNC_MODE=%s), "
+            "grid=(batch,%d), inner_tile=%d, max_model_len=%s.",
+            mode,
+            env_mode,
+            fg,
+            inner,
+            max_model_len,
+        )
+    elif mode == "chunk":
+        fg = indexer_sync_fixed_grid()
+        nc = indexer_sync_num_chunks(max_model_len or 0)
+        logger.info_once(
+            "Indexer TQ4 decode sync: mode=%s (env VLLM_INDEXER_TQ_SYNC_MODE=%s), "
+            "%d launches x grid=(batch,%d), max_model_len=%s.",
+            mode,
+            env_mode,
+            nc,
+            fg,
+            max_model_len,
+        )
+    elif mode == "tile":
+        gn = indexer_decode_grid_n(max_model_len or 0)
+        logger.info_once(
+            "Indexer TQ4 decode sync: mode=%s (env VLLM_INDEXER_TQ_SYNC_MODE=%s), "
+            "grid=(batch,%d), tile=%d, max_model_len=%s.",
+            mode,
+            env_mode,
+            gn,
+            INDEXER_DECODE_TILE,
+            max_model_len,
+        )
+    else:
+        logger.info_once(
+            "Indexer TQ4 decode sync: mode=%s (env VLLM_INDEXER_TQ_SYNC_MODE=%s), "
+            "max_model_len=%s.",
+            mode,
+            env_mode,
+            max_model_len,
+        )
+
+
+def indexer_tq_sync_blocks_per_split() -> int:
+    return max(
+        1,
+        int(
+            os.environ.get(
+                "VLLM_INDEXER_TQ_SYNC_DG_BLOCKS_PER_SPLIT",
+                str(INDEXER_DG_SYNC_BLOCKS_PER_SPLIT),
+            )
+        ),
+    )
+
+
+def indexer_packed_head_dim() -> int:
+    return INDEXER_PACKED_BYTES if is_indexer_tq_4bit_enabled() else INDEXER_FP8_SLOT_BYTES
+
+
+def _get_indexer_tq_buffers(device: torch.device) -> dict:
+    key = str(device)
+    if key not in _INDEXER_TQ_BUFFERS:
+        D = INDEXER_HEAD_DIM
+        cents = get_centroids(D, INDEXER_MSE_BITS).to(device=device, dtype=torch.float32)
+        c_sorted, _ = cents.sort()
+        buf: dict = {
+            "centroids_bf16": cents.to(_BF16),
+            "centroids_fp32": cents,
+            "midpoints": (c_sorted[:-1] + c_sorted[1:]) / 2,
+        }
+        if use_indexer_tq_hadamard():
+            pi = _build_hadamard(D, key).to(device=device, dtype=torch.float32)
+            buf["Pi"] = pi
+            buf["PiT"] = pi
+            buf["Pi_bf16"] = pi.to(_BF16)
+            logger.info_once(
+                "Indexer TurboQuant 4bit + Hadamard: %d B/token (FP8 legacy %d B).",
+                INDEXER_PACKED_BYTES,
+                INDEXER_FP8_SLOT_BYTES,
+            )
+        else:
+            logger.info_once(
+                "Indexer TurboQuant 4bit direct (no Hadamard): %d B/token.",
+                INDEXER_PACKED_BYTES,
+            )
+        _INDEXER_TQ_BUFFERS[key] = buf
+    return _INDEXER_TQ_BUFFERS[key]
+
+
+def fold_indexer_pi_at_load(indexer) -> None:
+    """Fold Pi into indexer.wq_b so Q is pre-rotated (decode + prefill score path).
+
+    out_head = qr @ W_h^T; out_head_rot = out_head @ Pi = qr @ (Pi @ W_h)^T.
+    """
+    if getattr(indexer, "_indexer_tq_pi_folded", False):
+        return
+    if not is_indexer_tq_4bit_enabled() or not use_indexer_tq_hadamard():
+        indexer._indexer_tq_pi_folded = True
+        return
+
+    w = indexer.wq_b.weight
+    if w is None or w.numel() == 0:
+        indexer._indexer_tq_pi_folded = False
+        return
+
+    device = w.device
+    buf = _get_indexer_tq_buffers(device)
+    pi = buf["Pi"].to(device=device, dtype=torch.float32)
+    d = indexer.head_dim
+    n_head = indexer.n_head
+    w_f = w.data.to(torch.float32)
+    w_new = w_f.clone()
+    for h in range(n_head):
+        sl = slice(h * d, (h + 1) * d)
+        w_new[sl, :] = pi @ w_f[sl, :]
+    indexer.wq_b.weight.data.copy_(w_new.to(dtype=w.dtype))
+    indexer._indexer_tq_pi_folded = True
+
+
+def _get_scores_workspace(
+    device: torch.device,
+    batch_size: int,
+    max_model_len: int,
+) -> torch.Tensor:
+    """Persistent float32 scores buffer for fused decode+topk (CUDA-graph friendly)."""
+    buf = _get_indexer_tq_buffers(device)
+    ws = buf.get("scores_ws")
+    if (
+        ws is None
+        or ws.shape[0] < batch_size
+        or ws.shape[1] < max_model_len
+        or ws.device != device
+    ):
+        ws = torch.empty(
+            batch_size,
+            max_model_len,
+            device=device,
+            dtype=torch.float32,
+        )
+        ws.fill_(float("-inf"))
+        buf["scores_ws"] = ws
+    return ws[:batch_size, :max_model_len]
+
+
+def _launch_tq4_paged_mqa_scores(
+    q_fp8: torch.Tensor,
+    weights: torch.Tensor,
+    packed_cache: torch.Tensor,
+    block_table: torch.Tensor,
+    seq_lens_1d: torch.Tensor,
+    scores: torch.Tensor,
+    max_model_len: int,
+) -> None:
+    batch_size, num_heads, head_dim = q_fp8.shape
+    assert head_dim == INDEXER_HEAD_DIM
+    _, block_size, _ = packed_cache.shape
+    buf = _get_indexer_tq_buffers(q_fp8.device)
+    block_d = triton.next_power_of_2(INDEXER_HEAD_DIM)
+
+    _tq4_paged_mqa_logits_kernel[(batch_size, max_model_len)](
+        q_fp8,
+        weights,
+        packed_cache,
+        block_table,
+        seq_lens_1d,
+        scores,
+        buf["centroids_bf16"],
+        q_fp8.stride(0),
+        q_fp8.stride(1),
+        weights.stride(0),
+        scores.stride(0),
+        block_table.stride(0),
+        packed_cache.stride(0),
+        packed_cache.stride(1),
+        block_size,
+        INDEXER_HEAD_DIM,
+        num_heads,
+        INDEXER_MSE_BITS,
+        INDEXER_MSE_BYTES,
+        block_d,
+    )
+
+
+def pack_k_mse_torch(k: torch.Tensor, buf: dict) -> torch.Tensor:
+    """bf16 k [N,128] -> uint8 [N,66]: norm -> [@Pi] -> Lloyd-Max + eff_scale."""
+    k_f = k.to(torch.float32)
+    norms = k_f.norm(dim=-1, keepdim=True).clamp(min=1e-8)
+    x_hat = k_f / norms
+    if use_indexer_tq_hadamard():
+        pi = buf["Pi"].to(device=k.device, dtype=torch.float32)
+        y = x_hat @ pi
+    else:
+        y = x_hat
+    idx = torch.bucketize(y.contiguous(), buf["midpoints"].to(k.device))
+    idx = idx.clamp(max=(1 << INDEXER_MSE_BITS) - 1)
+    y_hat = buf["centroids_bf16"][idx.to(torch.int64)].to(torch.float32)
+    c_norm = y_hat.norm(dim=-1).clamp(min=1e-8)
+    eff_scale = (norms.squeeze(-1) / c_norm).to(torch.float16)
+    packed_idx = _pack_bits_rows(idx.to(torch.int32), bits=INDEXER_MSE_BITS)
+    scale_bytes = eff_scale.view(torch.uint8).view(k.shape[0], 2)
+    return torch.cat([packed_idx, scale_bytes], dim=-1)
+
+
+def dequant_packed_rows_torch(packed: torch.Tensor, buf: dict) -> torch.Tensor:
+    """uint8 [T,66] -> fp32 [T,128]."""
+    idx = _unpack_bits_rows(
+        packed[:, :INDEXER_MSE_BYTES].contiguous(),
+        bits=INDEXER_MSE_BITS,
+        D=INDEXER_HEAD_DIM,
+    )
+    y_hat = buf["centroids_bf16"][idx.to(torch.int64)].to(torch.float32)
+    scale = (
+        packed[:, INDEXER_MSE_BYTES : INDEXER_PACKED_BYTES]
+        .contiguous()
+        .view(torch.float16)
+        .to(torch.float32)
+    )
+    if scale.dim() == 1:
+        scale = scale.unsqueeze(-1)
+    return y_hat * scale
+
+
+def _dequant_packed_slot_torch(
+    packed_cache: torch.Tensor,
+    block_id: int,
+    slot_in_block: int,
+    block_size: int,
+    buf: dict,
+) -> torch.Tensor:
+    packed_base = block_id * block_size + slot_in_block
+    packed = packed_cache.view(-1, INDEXER_PACKED_BYTES)[packed_base]
+    return dequant_packed_rows_torch(packed.unsqueeze(0), buf).squeeze(0)
+
+
+def tq4_paged_mqa_logits_torch(
+    q_fp8: torch.Tensor,
+    weights: torch.Tensor,
+    packed_cache: torch.Tensor,
+    block_table: torch.Tensor,
+    seq_lens: torch.Tensor,
+    max_model_len: int,
+) -> torch.Tensor:
+    """Reference: paged TQ4 cache -> logits (next_n=1 decode)."""
+    batch_size, num_heads, head_dim = q_fp8.shape
+    assert head_dim == INDEXER_HEAD_DIM
+    block_size = packed_cache.shape[1]
+    device = q_fp8.device
+    buf = _get_indexer_tq_buffers(device)
+    if seq_lens.dim() > 1:
+        seq_lens = seq_lens.squeeze(-1)
+
+    logits = torch.full(
+        (batch_size, max_model_len),
+        float("-inf"),
+        device=device,
+        dtype=torch.float32,
+    )
+    q_f = q_fp8.to(torch.float32)
+    for batch_id in range(batch_size):
+        seq_len = int(seq_lens[batch_id].item())
+        if seq_len <= 0:
+            continue
+        q_h = q_f[batch_id]
+        w_h = weights[batch_id]
+        for pos in range(seq_len):
+            block_table_id = pos // block_size
+            slot_in_block = pos % block_size
+            block_id = int(block_table[batch_id, block_table_id].item())
+            k_f = _dequant_packed_slot_torch(
+                packed_cache, block_id, slot_in_block, block_size, buf
+            )
+            scores = torch.relu(torch.matmul(q_h, k_f))
+            logits[batch_id, pos] = (scores * w_h).sum()
+    return logits
+
+
+def _bf16_to_fp8_indexer(
+    k_bf16: torch.Tensor,
+    scale_fmt: str | None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    k_f = k_bf16.to(torch.float32)
+    amax = k_f.abs().max(dim=-1, keepdim=True).values.clamp(min=1e-4)
+    scale = amax / 448.0
+    if scale_fmt == "ue8m0":
+        scale = torch.exp2(torch.ceil(torch.log2(scale.clamp(min=1e-8))))
+    k_fp8 = (k_f / scale).clamp(-448.0, 448.0).to(_FP8_DTYPE)
+    k_scale = scale.squeeze(-1).to(torch.float32)
+    return k_fp8, k_scale.view(torch.uint8).view(-1, 4)
+
+
+@triton.autotune(
+    configs=_INDEXER_TQ_STORE_AUTOTUNE_CONFIGS,
+    key=["D", "MSE_BITS"],
+)
+@triton.jit
+def _indexer_tq_fused_store_kernel(
+    K_ptr,
+    KV_cache_ptr,
+    Slot_mapping_ptr,
+    Midpoints_ptr,
+    Centroids_ptr,
+    Pi_ptr,
+    stride_k,
+    stride_cache_row,
+    D: tl.constexpr,
+    MSE_BITS: tl.constexpr,
+    MSE_BYTES: tl.constexpr,
+    PACKED_BYTES: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+    N_CENTROIDS: tl.constexpr,
+    USE_HADAMARD: tl.constexpr,
+):
+    """Fused Indexer TQ4 store: norm -> [@Pi] -> bucketize -> pack -> scatter."""
+    tid = tl.program_id(0)
+    slot = tl.load(Slot_mapping_ptr + tid)
+    if slot < 0:
+        return
+
+    d_offs = tl.arange(0, BLOCK_D)
+    d_mask = d_offs < D
+    k_base = K_ptr + tid * stride_k
+    k_vec = tl.load(k_base + d_offs, mask=d_mask, other=0.0).to(tl.float32)
+
+    norm_sq = tl.sum(k_vec * k_vec, axis=0)
+    norm = tl.sqrt(norm_sq)
+    norm_safe = tl.maximum(norm, 1e-8)
+    x_hat = k_vec / norm_safe
+
+    if USE_HADAMARD:
+        offs_i = tl.arange(0, BLOCK_D)
+        offs_j = tl.arange(0, BLOCK_D)
+        pi_mask = (offs_i[:, None] < D) & (offs_j[None, :] < D)
+        pi_block = tl.load(
+            Pi_ptr + offs_i[:, None] * D + offs_j[None, :],
+            mask=pi_mask,
+            other=0.0,
+        ).to(tl.float32)
+        y_row = tl.dot(x_hat[None, :], pi_block)
+        y = tl.reshape(y_row, [BLOCK_D])
+    else:
+        y = x_hat
+
+    lo = tl.zeros([BLOCK_D], dtype=tl.int32)
+    hi = tl.full([BLOCK_D], N_CENTROIDS - 1, dtype=tl.int32)
+    for _ in range(MSE_BITS):
+        mid = (lo + hi) >> 1
+        safe_mid = tl.minimum(mid, N_CENTROIDS - 2)
+        mid_val = tl.load(Midpoints_ptr + safe_mid, mask=d_mask, other=0.0)
+        lo = tl.where(y >= mid_val, mid + 1, lo)
+        hi = tl.where(y >= mid_val, hi, mid)
+    idx = tl.minimum(lo, N_CENTROIDS - 1)
+
+    y_hat = _tq_mla_gather_centroids_1d(
+        Centroids_ptr, idx, d_mask, BLOCK_D, MSE_BITS
+    )
+    c_norm_sq = tl.sum(y_hat * y_hat, axis=0)
+    c_norm = tl.sqrt(tl.maximum(c_norm_sq, 1e-8))
+    eff_scale = (norm / c_norm).to(tl.float16)
+    scale_u16 = eff_scale.to(tl.uint16, bitcast=True)
+
+    idx_pairs = tl.reshape(idx, [BLOCK_D // 2, 2])
+    shifts_4 = tl.arange(0, 2) * 4
+    packed = tl.sum((idx_pairs & 0xF) << shifts_4[None, :], axis=1).to(tl.uint8)
+    mse_offs = tl.arange(0, BLOCK_D // 2)
+    mse_mask = mse_offs < MSE_BYTES
+
+    slot_base = slot.to(tl.int64) * stride_cache_row
+    tl.store(KV_cache_ptr + slot_base + mse_offs, packed, mask=mse_mask)
+    tl.store(KV_cache_ptr + slot_base + MSE_BYTES, (scale_u16 & 0xFF).to(tl.uint8))
+    tl.store(
+        KV_cache_ptr + slot_base + MSE_BYTES + 1,
+        ((scale_u16 >> 8) & 0xFF).to(tl.uint8),
+    )
+
+
+def indexer_tq_store_and_cache_triton(
+    k: torch.Tensor,
+    kv_cache: torch.Tensor,
+    slot_mapping: torch.Tensor,
+) -> None:
+    """Triton fused TQ4 pack + scatter (replaces pack_k_mse_torch hot path)."""
+    N = slot_mapping.shape[0]
+    if N == 0:
+        return
+    buf = _get_indexer_tq_buffers(k.device)
+    block_d = triton.next_power_of_2(INDEXER_HEAD_DIM)
+    cache_flat = kv_cache.view(-1, INDEXER_PACKED_BYTES)
+    slots = slot_mapping[:N].to(torch.int32)
+
+    use_hadamard = use_indexer_tq_hadamard()
+    pi_bf16 = buf.get("Pi_bf16")
+    if pi_bf16 is None:
+        pi_bf16 = torch.eye(INDEXER_HEAD_DIM, device=k.device, dtype=_BF16)
+
+    grid = (N,)
+    _indexer_tq_fused_store_kernel[grid](
+        k[:N],
+        cache_flat,
+        slots,
+        buf["midpoints"],
+        buf["centroids_fp32"],
+        pi_bf16,
+        k.stride(0),
+        INDEXER_PACKED_BYTES,
+        INDEXER_HEAD_DIM,
+        INDEXER_MSE_BITS,
+        INDEXER_MSE_BYTES,
+        INDEXER_PACKED_BYTES,
+        block_d,
+        1 << INDEXER_MSE_BITS,
+        use_hadamard,
+    )
+
+
+def indexer_tq_store_and_cache(
+    k: torch.Tensor,
+    kv_cache: torch.Tensor,
+    slot_mapping: torch.Tensor,
+) -> None:
+    if k.numel() == 0:
+        return
+    N = slot_mapping.shape[0]
+    if N == 0:
+        return
+    if k.is_cuda:
+        indexer_tq_store_and_cache_triton(k, kv_cache, slot_mapping)
+        return
+    buf = _get_indexer_tq_buffers(k.device)
+    k = k[:N]
+    packed = pack_k_mse_torch(k, buf)
+    cache_flat = kv_cache.view(-1, INDEXER_PACKED_BYTES)
+    slots = slot_mapping[:N].to(torch.int64)
+    valid = slots >= 0
+    slots = slots.clamp(min=0)
+    current = cache_flat.index_select(0, slots)
+    new = torch.where(valid.view(-1, 1), packed, current)
+    cache_flat.index_copy_(0, slots, new)
+
+
+@triton.jit
+def _tq4_prefill_gather_dequant_fp8_kernel(
+    Packed_cache_ptr,
+    Block_table_ptr,
+    Token_to_seq_ptr,
+    Cu_seq_lens_ptr,
+    Dst_k_ptr,
+    Dst_scale_ptr,
+    Centroids_ptr,
+    N,
+    dst_k_stride_n,
+    dst_scale_stride_n,
+    block_table_stride_r,
+    stride_packed_nb,
+    stride_packed_bs,
+    block_size: tl.constexpr,
+    D: tl.constexpr,
+    MSE_BITS: tl.constexpr,
+    MSE_BYTES: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+    FP8_MAX: tl.constexpr,
+    USE_UE8M0: tl.constexpr,
+):
+    """TQ4 paged K -> linear FP8 + per-token UE8M0 scale (DeepGEMM input format)."""
+    n_j = tl.program_id(0)
+    if n_j >= N:
+        return
+    b_id = tl.load(Token_to_seq_ptr + n_j)
+    s_start = tl.load(Cu_seq_lens_ptr + b_id)
+    pos = n_j - s_start
+    bt_id = pos // block_size
+    slot = pos % block_size
+    blk = tl.load(Block_table_ptr + b_id * block_table_stride_r + bt_id)
+    p_base = blk * stride_packed_nb + slot * stride_packed_bs
+
+    d_offs = tl.arange(0, BLOCK_D)
+    d_mask = d_offs < D
+    bit_off = d_offs * MSE_BITS
+    byte_idx = bit_off // 8
+    bit_shift = bit_off % 8
+    umask = (1 << MSE_BITS) - 1
+
+    raw0 = tl.load(
+        Packed_cache_ptr + p_base + byte_idx, mask=d_mask, other=0
+    ).to(tl.int32)
+    raw1 = tl.load(
+        Packed_cache_ptr + p_base + byte_idx + 1, mask=d_mask, other=0
+    ).to(tl.int32)
+    raw16 = raw0 | (raw1 << 8)
+    cidx = (raw16 >> bit_shift) & umask
+    y_hat = _tq_mla_gather_centroids_1d(
+        Centroids_ptr, cidx, d_mask, BLOCK_D, MSE_BITS
+    )
+    n_lo = tl.load(Packed_cache_ptr + p_base + MSE_BYTES).to(tl.uint16)
+    n_hi = tl.load(Packed_cache_ptr + p_base + MSE_BYTES + 1).to(tl.uint16)
+    token_scale = (n_lo | (n_hi << 8)).to(tl.float16, bitcast=True).to(tl.float32)
+    k_f = y_hat.to(tl.float32) * token_scale
+
+    amax = tl.max(tl.where(d_mask, tl.abs(k_f), 0.0), axis=0)
+    amax = tl.maximum(amax, 1e-4)
+    scale = amax / FP8_MAX
+    if USE_UE8M0:
+        scale = tl.exp2(tl.ceil(tl.log2(scale)))
+    fp8_val = (k_f / scale).to(tl.float8e4nv)
+    tl.store(Dst_k_ptr + n_j * dst_k_stride_n + d_offs, fp8_val, mask=d_mask)
+
+    scale_u32 = scale.to(tl.uint32, bitcast=True)
+    base = Dst_scale_ptr + n_j * dst_scale_stride_n
+    tl.store(base + 0, ((scale_u32 >> 0) & 0xFF).to(tl.uint8))
+    tl.store(base + 1, ((scale_u32 >> 8) & 0xFF).to(tl.uint8))
+    tl.store(base + 2, ((scale_u32 >> 16) & 0xFF).to(tl.uint8))
+    tl.store(base + 3, ((scale_u32 >> 24) & 0xFF).to(tl.uint8))
+
+
+def indexer_tq_cp_gather_dequant_fp8(
+    kv_cache: torch.Tensor,
+    dst_k: torch.Tensor,
+    dst_scale: torch.Tensor,
+    block_table: torch.Tensor,
+    cu_seq_lens: torch.Tensor,
+    block_size: int,
+    scale_fmt: str | None,
+) -> None:
+    """Prefill gather: TQ paged cache -> linear FP8 (Triton, cp_gather replacement)."""
+    total_tokens = dst_k.shape[0]
+    if total_tokens == 0:
+        return
+    device = kv_cache.device
+    buf = _get_indexer_tq_buffers(device)
+
+    # token_to_seq[n] = batch index for token n (precompute via searchsorted on GPU)
+    token_to_seq = torch.searchsorted(
+        cu_seq_lens[1:].contiguous(),
+        torch.arange(total_tokens, device=device, dtype=cu_seq_lens.dtype),
+        right=True,
+    ).to(torch.int32)
+
+    block_d = triton.next_power_of_2(INDEXER_HEAD_DIM)
+    _tq4_prefill_gather_dequant_fp8_kernel[(total_tokens,)](
+        kv_cache,
+        block_table,
+        token_to_seq,
+        cu_seq_lens,
+        dst_k,
+        dst_scale,
+        buf["centroids_bf16"],
+        total_tokens,
+        dst_k.stride(0),
+        dst_scale.stride(0),
+        block_table.stride(0),
+        kv_cache.stride(0),
+        kv_cache.stride(1),
+        block_size,
+        INDEXER_HEAD_DIM,
+        INDEXER_MSE_BITS,
+        INDEXER_MSE_BYTES,
+        block_d,
+        448.0,
+        scale_fmt == "ue8m0",
+        num_warps=4,
+    )
+
+
+@triton.jit
+def _indexer_tq_sync_decode_kernel(
+    Packed_cache_ptr,
+    Fp8_ws_ptr,
+    Block_table_ptr,
+    Seq_lens_ptr,
+    Centroids_ptr,
+    block_table_stride,
+    stride_packed_nb,
+    stride_packed_bs,
+    stride_ws_nb,
+    stride_ws_bs,
+    block_size: tl.constexpr,
+    D: tl.constexpr,
+    MSE_BITS: tl.constexpr,
+    MSE_BYTES: tl.constexpr,
+    PACKED_BYTES: tl.constexpr,
+    FP8_SLOT_BYTES: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+    FP8_MAX: tl.constexpr,
+    USE_UE8M0: tl.constexpr,
+    KV_OFFSET: tl.constexpr,
+):
+    batch_id = tl.program_id(0)
+    pos = tl.program_id(1) + KV_OFFSET
+    seq_len = tl.load(Seq_lens_ptr + batch_id)
+    if pos >= seq_len:
+        return
+
+    block_table_id = pos // block_size
+    slot_in_block = pos % block_size
+    block_id = tl.load(
+        Block_table_ptr + batch_id * block_table_stride + block_table_id
+    )
+
+    packed_base = block_id * stride_packed_nb + slot_in_block * stride_packed_bs
+    fp8_base = block_id * stride_ws_nb + slot_in_block * stride_ws_bs
+
+    d_offs = tl.arange(0, BLOCK_D)
+    d_mask = d_offs < D
+    bit_off = d_offs * MSE_BITS
+    byte_idx = bit_off // 8
+    bit_shift = bit_off % 8
+    umask = (1 << MSE_BITS) - 1
+
+    raw0 = tl.load(
+        Packed_cache_ptr + packed_base + byte_idx, mask=d_mask, other=0
+    ).to(tl.int32)
+    raw1 = tl.load(
+        Packed_cache_ptr + packed_base + byte_idx + 1, mask=d_mask, other=0
+    ).to(tl.int32)
+    raw16 = raw0 | (raw1 << 8)
+    idx = (raw16 >> bit_shift) & umask
+
+    y_hat = _tq_mla_gather_centroids_1d(
+        Centroids_ptr, idx, d_mask, BLOCK_D, MSE_BITS
+    )
+    n_lo = tl.load(Packed_cache_ptr + packed_base + MSE_BYTES).to(tl.uint16)
+    n_hi = tl.load(Packed_cache_ptr + packed_base + MSE_BYTES + 1).to(tl.uint16)
+    token_scale = (n_lo | (n_hi << 8)).to(tl.float16, bitcast=True).to(tl.float32)
+    k_f = y_hat.to(tl.float32) * token_scale
+
+    amax = tl.max(tl.where(d_mask, tl.abs(k_f), 0.0), axis=0)
+    amax = tl.maximum(amax, 1e-4)
+    scale = amax / FP8_MAX
+    if USE_UE8M0:
+        scale = tl.exp2(tl.ceil(tl.log2(scale)))
+    fp8_val = (k_f / scale).to(tl.float8e4nv)
+
+    fp8_u8 = fp8_val.to(tl.uint8, bitcast=True)
+    tl.store(Fp8_ws_ptr + fp8_base + d_offs, fp8_u8, mask=d_mask)
+
+    scale_u32 = scale.to(tl.uint32, bitcast=True)
+    tl.store(Fp8_ws_ptr + fp8_base + D + 0, ((scale_u32 >> 0) & 0xFF).to(tl.uint8))
+    tl.store(Fp8_ws_ptr + fp8_base + D + 1, ((scale_u32 >> 8) & 0xFF).to(tl.uint8))
+    tl.store(Fp8_ws_ptr + fp8_base + D + 2, ((scale_u32 >> 16) & 0xFF).to(tl.uint8))
+    tl.store(Fp8_ws_ptr + fp8_base + D + 3, ((scale_u32 >> 24) & 0xFF).to(tl.uint8))
+
+
+@triton.jit
+def _indexer_tq_sync_block_vectorized(
+    Packed_cache_ptr,
+    Fp8_ws_ptr,
+    Centroids_ptr,
+    block_id,
+    stride_packed_nb,
+    stride_packed_bs,
+    stride_ws_nb,
+    stride_ws_bs,
+    slot_offs,
+    slot_mask,
+    D: tl.constexpr,
+    MSE_BITS: tl.constexpr,
+    MSE_BYTES: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+    BLOCK_KV: tl.constexpr,
+    FP8_MAX: tl.constexpr,
+    USE_UE8M0: tl.constexpr,
+):
+    """Sync up to BLOCK_KV slots in one physical page block (vectorized)."""
+    d_offs = tl.arange(0, BLOCK_D)[:, None]
+    n_offs = slot_offs[None, :]
+    d_mask = d_offs < D
+    full_mask = d_mask & slot_mask[None, :]
+
+    packed_base = (
+        block_id * stride_packed_nb + n_offs * stride_packed_bs
+    )
+    fp8_base = block_id * stride_ws_nb + n_offs * stride_ws_bs
+
+    bit_off = d_offs * MSE_BITS
+    byte_idx = bit_off // 8
+    bit_shift = bit_off % 8
+    umask = (1 << MSE_BITS) - 1
+
+    raw0 = tl.load(
+        Packed_cache_ptr + packed_base + byte_idx, mask=full_mask, other=0
+    ).to(tl.int32)
+    raw1 = tl.load(
+        Packed_cache_ptr + packed_base + byte_idx + 1, mask=full_mask, other=0
+    ).to(tl.int32)
+    raw16 = raw0 | (raw1 << 8)
+    idx = (raw16 >> bit_shift) & umask
+    y_hat = _tq_mla_gather_centroids(
+        Centroids_ptr, idx, full_mask, BLOCK_D, BLOCK_KV, MSE_BITS
+    )
+    n_lo = tl.load(
+        Packed_cache_ptr + packed_base + MSE_BYTES, mask=slot_mask, other=0
+    ).to(tl.uint16)
+    n_hi = tl.load(
+        Packed_cache_ptr + packed_base + MSE_BYTES + 1, mask=slot_mask, other=0
+    ).to(tl.uint16)
+    token_scale = (n_lo | (n_hi << 8)).to(tl.float16, bitcast=True).to(tl.float32)
+    k_f = y_hat.to(tl.float32) * token_scale
+
+    amax = tl.max(tl.where(d_mask, tl.abs(k_f), 0.0), axis=0)
+    amax = tl.maximum(amax, 1e-4)
+    scale = amax / FP8_MAX
+    if USE_UE8M0:
+        scale = tl.exp2(tl.ceil(tl.log2(scale)))
+    fp8_val = (k_f / scale).to(tl.float8e4nv)
+    fp8_u8 = fp8_val.to(tl.uint8, bitcast=True)
+    tl.store(Fp8_ws_ptr + fp8_base + d_offs, fp8_u8, mask=full_mask)
+
+    scale_u32 = scale.to(tl.uint32, bitcast=True)
+    tl.store(
+        Fp8_ws_ptr + fp8_base + D + 0,
+        ((scale_u32 >> 0) & 0xFF).to(tl.uint8),
+        mask=slot_mask,
+    )
+    tl.store(
+        Fp8_ws_ptr + fp8_base + D + 1,
+        ((scale_u32 >> 8) & 0xFF).to(tl.uint8),
+        mask=slot_mask,
+    )
+    tl.store(
+        Fp8_ws_ptr + fp8_base + D + 2,
+        ((scale_u32 >> 16) & 0xFF).to(tl.uint8),
+        mask=slot_mask,
+    )
+    tl.store(
+        Fp8_ws_ptr + fp8_base + D + 3,
+        ((scale_u32 >> 24) & 0xFF).to(tl.uint8),
+        mask=slot_mask,
+    )
+
+
+@triton.jit
+def _indexer_tq_sync_decode_tile_kernel(
+    Packed_cache_ptr,
+    Fp8_ws_ptr,
+    Block_table_ptr,
+    Seq_lens_ptr,
+    Centroids_ptr,
+    block_table_stride,
+    stride_packed_nb,
+    stride_packed_bs,
+    stride_ws_nb,
+    stride_ws_bs,
+    block_size: tl.constexpr,
+    D: tl.constexpr,
+    MSE_BITS: tl.constexpr,
+    MSE_BYTES: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+    TILE: tl.constexpr,
+    FP8_MAX: tl.constexpr,
+    USE_UE8M0: tl.constexpr,
+):
+    batch_id = tl.program_id(0)
+    tile_id = tl.program_id(1)
+    seq_len = tl.load(Seq_lens_ptr + batch_id)
+    tile_start = tile_id * TILE
+    if tile_start >= seq_len:
+        return
+
+    n_pos = tile_start + tl.arange(0, TILE)
+    pos_ok = n_pos < seq_len
+    block_table_id = n_pos // block_size
+    slot_in_block = n_pos % block_size
+    block_id = tl.load(
+        Block_table_ptr + batch_id * block_table_stride + block_table_id,
+        mask=pos_ok,
+        other=0,
+    )
+
+    d_offs = tl.arange(0, BLOCK_D)[:, None]
+    n_offs = tl.arange(0, TILE)[None, :]
+    d_mask = d_offs < D
+    full_mask = d_mask & pos_ok[None, :]
+    bit_off = d_offs * MSE_BITS
+    byte_idx = bit_off // 8
+    bit_shift = bit_off % 8
+    umask = (1 << MSE_BITS) - 1
+
+    packed_base = block_id * stride_packed_nb + slot_in_block * stride_packed_bs
+    fp8_base = block_id * stride_ws_nb + slot_in_block * stride_ws_bs
+
+    raw0 = tl.load(
+        Packed_cache_ptr + packed_base + byte_idx, mask=full_mask, other=0
+    ).to(tl.int32)
+    raw1 = tl.load(
+        Packed_cache_ptr + packed_base + byte_idx + 1, mask=full_mask, other=0
+    ).to(tl.int32)
+    raw16 = raw0 | (raw1 << 8)
+    idx = (raw16 >> bit_shift) & umask
+    y_hat = _tq_mla_gather_centroids(
+        Centroids_ptr, idx, full_mask, BLOCK_D, TILE, MSE_BITS
+    )
+    n_lo = tl.load(
+        Packed_cache_ptr + packed_base + MSE_BYTES, mask=pos_ok, other=0
+    ).to(tl.uint16)
+    n_hi = tl.load(
+        Packed_cache_ptr + packed_base + MSE_BYTES + 1, mask=pos_ok, other=0
+    ).to(tl.uint16)
+    token_scale = (n_lo | (n_hi << 8)).to(tl.float16, bitcast=True).to(tl.float32)
+    k_f = y_hat.to(tl.float32) * token_scale
+
+    amax = tl.max(tl.where(d_mask, tl.abs(k_f), 0.0), axis=0)
+    amax = tl.maximum(amax, 1e-4)
+    scale = amax / FP8_MAX
+    if USE_UE8M0:
+        scale = tl.exp2(tl.ceil(tl.log2(scale)))
+    fp8_val = (k_f / scale).to(tl.float8e4nv)
+    fp8_u8 = fp8_val.to(tl.uint8, bitcast=True)
+    tl.store(Fp8_ws_ptr + fp8_base + d_offs, fp8_u8, mask=full_mask)
+
+    scale_u32 = scale.to(tl.uint32, bitcast=True)
+    tl.store(
+        Fp8_ws_ptr + fp8_base + D + 0,
+        ((scale_u32 >> 0) & 0xFF).to(tl.uint8),
+        mask=pos_ok,
+    )
+    tl.store(
+        Fp8_ws_ptr + fp8_base + D + 1,
+        ((scale_u32 >> 8) & 0xFF).to(tl.uint8),
+        mask=pos_ok,
+    )
+    tl.store(
+        Fp8_ws_ptr + fp8_base + D + 2,
+        ((scale_u32 >> 16) & 0xFF).to(tl.uint8),
+        mask=pos_ok,
+    )
+    tl.store(
+        Fp8_ws_ptr + fp8_base + D + 3,
+        ((scale_u32 >> 24) & 0xFF).to(tl.uint8),
+        mask=pos_ok,
+    )
+
+
+@triton.jit
+def _indexer_tq_sync_decode_sm_kernel(
+    Packed_cache_ptr,
+    Fp8_ws_ptr,
+    Block_table_ptr,
+    Seq_lens_ptr,
+    Centroids_ptr,
+    Schedule_ptr,
+    block_table_stride,
+    stride_packed_nb,
+    stride_packed_bs,
+    stride_ws_nb,
+    stride_ws_bs,
+    block_size: tl.constexpr,
+    D: tl.constexpr,
+    MSE_BITS: tl.constexpr,
+    MSE_BYTES: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+    BLOCK_KV: tl.constexpr,
+    NUM_BLOCKS_PER_SPLIT: tl.constexpr,
+    FP8_MAX: tl.constexpr,
+    USE_UE8M0: tl.constexpr,
+):
+    """Sync KV slots assigned to this SM (same schedule_meta as DeepGEMM)."""
+    sm_idx = tl.program_id(0)
+    start_q = tl.load(Schedule_ptr + sm_idx * 2)
+    start_kv_s = tl.load(Schedule_ptr + sm_idx * 2 + 1)
+    end_q = tl.load(Schedule_ptr + (sm_idx + 1) * 2)
+    end_kv_s = tl.load(Schedule_ptr + (sm_idx + 1) * 2 + 1)
+
+    cur_q = start_q
+    cur_kv = start_kv_s * NUM_BLOCKS_PER_SPLIT
+    end_kv = end_kv_s * NUM_BLOCKS_PER_SPLIT
+
+    slot_offs = tl.arange(0, BLOCK_KV)
+
+    while cur_q < end_q or (cur_q == end_q and cur_kv < end_kv):
+        q_row = cur_q
+        seq_len = tl.load(Seq_lens_ptr + q_row)
+        num_kv = (seq_len + BLOCK_KV - 1) // BLOCK_KV
+
+        for kv_b in tl.static_range(NUM_BLOCKS_PER_SPLIT):
+            kv_idx = cur_kv + kv_b
+            if kv_idx < num_kv:
+                block_id = tl.load(
+                    Block_table_ptr + q_row * block_table_stride + kv_idx
+                )
+                token_base = kv_idx * BLOCK_KV
+                slot_mask = slot_offs + token_base < seq_len
+                _indexer_tq_sync_block_vectorized(
+                    Packed_cache_ptr,
+                    Fp8_ws_ptr,
+                    Centroids_ptr,
+                    block_id,
+                    stride_packed_nb,
+                    stride_packed_bs,
+                    stride_ws_nb,
+                    stride_ws_bs,
+                    slot_offs,
+                    slot_mask,
+                    D,
+                    MSE_BITS,
+                    MSE_BYTES,
+                    BLOCK_D,
+                    BLOCK_KV,
+                    FP8_MAX,
+                    USE_UE8M0,
+                )
+
+        cur_kv += NUM_BLOCKS_PER_SPLIT
+        if cur_kv >= num_kv:
+            cur_kv = 0
+            cur_q += 1
+
+
+def sync_fp8_workspace_for_decode(
+    packed_cache: torch.Tensor,
+    fp8_workspace: torch.Tensor,
+    block_table: torch.Tensor,
+    seq_lens: torch.Tensor,
+    scale_fmt: str | None,
+    max_model_len: int | None = None,
+    schedule_metadata: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Fill FP8-shaped workspace slots used by decode paged DeepGEMM."""
+    _, block_size, _ = packed_cache.shape
+    if seq_lens.dim() == 2:
+        seq_lens_1d = seq_lens.max(dim=-1).values.to(torch.int32)
+    else:
+        seq_lens_1d = seq_lens.to(torch.int32)
+    batch_size = seq_lens_1d.shape[0]
+    if batch_size == 0:
+        return fp8_workspace
+
+    buf = _get_indexer_tq_buffers(packed_cache.device)
+    block_d = triton.next_power_of_2(INDEXER_HEAD_DIM)
+    use_ue8m0 = scale_fmt == "ue8m0"
+    if max_model_len is None:
+        max_seq_for_mode = block_table.shape[1] * block_size
+    else:
+        max_seq_for_mode = max_model_len
+    mode = resolve_indexer_tq_sync_mode(max_seq_for_mode)
+    _log_indexer_tq_sync_config_once(mode, max_seq_for_mode)
+    blocks_per_split = indexer_tq_sync_blocks_per_split()
+
+    stride_args = (
+        block_table.stride(0),
+        packed_cache.stride(0),
+        packed_cache.stride(1),
+        fp8_workspace.stride(0),
+        fp8_workspace.stride(1),
+    )
+    ptr_args = (
+        packed_cache,
+        fp8_workspace,
+        block_table,
+        seq_lens_1d,
+        buf["centroids_bf16"],
+    )
+
+    if mode == "sm":
+        if schedule_metadata is None:
+            from vllm.utils.deep_gemm import get_paged_mqa_logits_metadata
+
+            num_sms = torch.cuda.get_device_properties(
+                packed_cache.device
+            ).multi_processor_count
+            sl_for_meta = (
+                seq_lens if seq_lens.dim() == 2 else seq_lens.unsqueeze(-1)
+            )
+            schedule_metadata = get_paged_mqa_logits_metadata(
+                sl_for_meta, block_size, num_sms
+            )
+        num_sms = schedule_metadata.shape[0] - 1
+        _indexer_tq_sync_decode_sm_kernel[(num_sms,)](
+            *ptr_args,
+            schedule_metadata,
+            *stride_args,
+            block_size,
+            INDEXER_HEAD_DIM,
+            INDEXER_MSE_BITS,
+            INDEXER_MSE_BYTES,
+            block_d,
+            INDEXER_DG_SYNC_BLOCK_KV,
+            blocks_per_split,
+            448.0,
+            use_ue8m0,
+            num_warps=4,
+        )
+    elif mode == "tile":
+        if max_model_len is None:
+            max_seq = block_table.shape[1] * block_size
+        else:
+            max_seq = max_model_len
+        grid_n = (max_seq + INDEXER_DECODE_TILE - 1) // INDEXER_DECODE_TILE
+        _indexer_tq_sync_decode_tile_kernel[(batch_size, grid_n)](
+            *ptr_args,
+            *stride_args,
+            block_size,
+            INDEXER_HEAD_DIM,
+            INDEXER_MSE_BITS,
+            INDEXER_MSE_BYTES,
+            block_d,
+            INDEXER_DECODE_TILE,
+            448.0,
+            use_ue8m0,
+            num_warps=4,
+        )
+    elif mode == "chunk":
+        if max_model_len is None:
+            max_seq = block_table.shape[1] * block_size
+        else:
+            max_seq = max_model_len
+        if max_seq == 0:
+            return fp8_workspace
+        fixed_grid = indexer_sync_fixed_grid()
+        num_chunks = indexer_sync_num_chunks(max_seq)
+        kernel_tail = (
+            block_size,
+            INDEXER_HEAD_DIM,
+            INDEXER_MSE_BITS,
+            INDEXER_MSE_BYTES,
+            INDEXER_PACKED_BYTES,
+            INDEXER_FP8_SLOT_BYTES,
+            block_d,
+            448.0,
+            use_ue8m0,
+        )
+        for ci in range(num_chunks):
+            kv_offset = ci * fixed_grid
+            remaining = max_seq - kv_offset
+            if remaining <= 0:
+                break
+            grid_y = min(fixed_grid, remaining)
+            _indexer_tq_sync_decode_kernel[(batch_size, grid_y)](
+                packed_cache,
+                fp8_workspace,
+                block_table,
+                seq_lens_1d,
+                buf["centroids_bf16"],
+                block_table.stride(0),
+                packed_cache.stride(0),
+                packed_cache.stride(1),
+                fp8_workspace.stride(0),
+                fp8_workspace.stride(1),
+                *kernel_tail,
+                KV_OFFSET=kv_offset,
+            )
+    elif mode == "fixed":
+        if max_model_len is None:
+            max_seq = block_table.shape[1] * block_size
+        else:
+            max_seq = max_model_len
+        if max_seq == 0:
+            return fp8_workspace
+        fixed_grid = indexer_sync_fixed_grid()
+        inner_tile = indexer_sync_inner_tile(max_seq)
+        _indexer_tq_sync_decode_tile_kernel[(batch_size, fixed_grid)](
+            *ptr_args,
+            *stride_args,
+            block_size,
+            INDEXER_HEAD_DIM,
+            INDEXER_MSE_BITS,
+            INDEXER_MSE_BYTES,
+            block_d,
+            inner_tile,
+            448.0,
+            use_ue8m0,
+            num_warps=4,
+        )
+    else:
+        if max_model_len is None:
+            max_seq = block_table.shape[1] * block_size
+        else:
+            max_seq = max_model_len
+        if max_seq == 0:
+            return fp8_workspace
+        _indexer_tq_sync_decode_kernel[(batch_size, max_seq)](
+            packed_cache,
+            fp8_workspace,
+            block_table,
+            seq_lens_1d,
+            buf["centroids_bf16"],
+            block_table.stride(0),
+            packed_cache.stride(0),
+            packed_cache.stride(1),
+            fp8_workspace.stride(0),
+            fp8_workspace.stride(1),
+            block_size,
+            INDEXER_HEAD_DIM,
+            INDEXER_MSE_BITS,
+            INDEXER_MSE_BYTES,
+            INDEXER_PACKED_BYTES,
+            INDEXER_FP8_SLOT_BYTES,
+            block_d,
+            448.0,
+            use_ue8m0,
+            KV_OFFSET=0,
+        )
+    return fp8_workspace
+
+
+@triton.jit
+def _tq4_paged_mqa_logits_kernel(
+    Q_ptr,
+    Weights_ptr,
+    Packed_cache_ptr,
+    Block_table_ptr,
+    Seq_lens_ptr,
+    Logits_ptr,
+    Centroids_ptr,
+    q_stride_b,
+    q_stride_h,
+    weights_stride_b,
+    logits_stride,
+    block_table_stride,
+    stride_packed_nb,
+    stride_packed_bs,
+    block_size: tl.constexpr,
+    D: tl.constexpr,
+    NUM_HEADS: tl.constexpr,
+    MSE_BITS: tl.constexpr,
+    MSE_BYTES: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+):
+    batch_id = tl.program_id(0)
+    pos = tl.program_id(1)
+    seq_len = tl.load(Seq_lens_ptr + batch_id)
+    if pos >= seq_len:
+        return
+
+    block_table_id = pos // block_size
+    slot_in_block = pos % block_size
+    block_id = tl.load(
+        Block_table_ptr + batch_id * block_table_stride + block_table_id
+    )
+
+    packed_base = block_id * stride_packed_nb + slot_in_block * stride_packed_bs
+
+    d_offs = tl.arange(0, BLOCK_D)
+    d_mask = d_offs < D
+    bit_off = d_offs * MSE_BITS
+    byte_idx = bit_off // 8
+    bit_shift = bit_off % 8
+    umask = (1 << MSE_BITS) - 1
+
+    raw0 = tl.load(
+        Packed_cache_ptr + packed_base + byte_idx, mask=d_mask, other=0
+    ).to(tl.int32)
+    raw1 = tl.load(
+        Packed_cache_ptr + packed_base + byte_idx + 1, mask=d_mask, other=0
+    ).to(tl.int32)
+    raw16 = raw0 | (raw1 << 8)
+    idx = (raw16 >> bit_shift) & umask
+
+    y_hat = _tq_mla_gather_centroids_1d(
+        Centroids_ptr, idx, d_mask, BLOCK_D, MSE_BITS
+    )
+    n_lo = tl.load(Packed_cache_ptr + packed_base + MSE_BYTES).to(tl.uint16)
+    n_hi = tl.load(Packed_cache_ptr + packed_base + MSE_BYTES + 1).to(tl.uint16)
+    token_scale = (n_lo | (n_hi << 8)).to(tl.float16, bitcast=True).to(tl.float32)
+    k_f = y_hat.to(tl.float32) * token_scale
+
+    acc = tl.zeros((), dtype=tl.float32)
+    for h in tl.static_range(NUM_HEADS):
+        q_base = Q_ptr + batch_id * q_stride_b + h * q_stride_h
+        q_val = tl.load(q_base + d_offs, mask=d_mask, other=0.0).to(tl.float32)
+        dot = tl.sum(q_val * k_f, axis=0)
+        w = tl.load(Weights_ptr + batch_id * weights_stride_b + h).to(tl.float32)
+        acc += tl.maximum(dot, 0.0) * w
+
+    tl.store(Logits_ptr + batch_id * logits_stride + pos, acc)
+
+
+def tq4_paged_mqa_logits_triton(
+    q_fp8: torch.Tensor,
+    weights: torch.Tensor,
+    packed_cache: torch.Tensor,
+    block_table: torch.Tensor,
+    seq_lens: torch.Tensor,
+    max_model_len: int,
+) -> torch.Tensor:
+    """Fused TQ4 paged gather + dequant + MQA logits (next_n=1 decode)."""
+    batch_size, num_heads, head_dim = q_fp8.shape
+    assert head_dim == INDEXER_HEAD_DIM
+    if batch_size == 0:
+        return torch.empty((0, max_model_len), device=q_fp8.device, dtype=torch.float32)
+
+    if seq_lens.dim() > 1:
+        seq_lens_1d = seq_lens.max(dim=-1).values.to(torch.int32)
+    else:
+        seq_lens_1d = seq_lens.to(torch.int32)
+
+    # Reuse persistent workspace so FULL CUDA graph replay and Python
+    # consumers (persistent_topk) see the same buffer address each step.
+    logits = _get_scores_workspace(q_fp8.device, batch_size, max_model_len)
+    logits.fill_(float("-inf"))
+    _launch_tq4_paged_mqa_scores(
+        q_fp8,
+        weights,
+        packed_cache,
+        block_table,
+        seq_lens_1d,
+        logits,
+        max_model_len,
+    )
+    return logits
+
+
+def warmup_indexer_tq_store(
+    device: torch.device | int,
+    block_size: int = 64,
+) -> None:
+    """Compile fused store Triton kernel before CUDA graph capture."""
+    if not is_indexer_tq_4bit_enabled():
+        return
+    if not torch.cuda.is_available():
+        return
+    if isinstance(device, int):
+        device = torch.device(f"cuda:{device}")
+    key = str(device)
+    if key in _INDEXER_TQ_STORE_WARMED:
+        return
+
+    _get_indexer_tq_buffers(device)
+    k = torch.zeros(1, INDEXER_HEAD_DIM, device=device, dtype=_BF16)
+    kv_cache = torch.zeros(
+        1,
+        block_size,
+        INDEXER_PACKED_BYTES,
+        device=device,
+        dtype=torch.uint8,
+    )
+    slot_mapping = torch.zeros(1, device=device, dtype=torch.int32)
+    for _ in range(8):
+        indexer_tq_store_and_cache_triton(k, kv_cache, slot_mapping)
+    torch.cuda.synchronize(device)
+    _INDEXER_TQ_STORE_WARMED.add(key)
+    logger.info_once("Indexer TQ4 fused store kernel warmed up.")
+
+
+def warmup_indexer_tq_kernels(
+    device: torch.device | int,
+    max_model_len: int,
+    num_heads: int,
+    block_size: int = 64,
+) -> None:
+    """Warm up Indexer TQ4 Triton kernels for CUDA graph capture."""
+    warmup_indexer_tq_store(device, block_size)
+    warmup_indexer_tq_fused_decode(device, max_model_len, num_heads, block_size)
+
+
+def warmup_indexer_tq_fused_decode(
+    device: torch.device | int,
+    max_model_len: int,
+    num_heads: int,
+    block_size: int = 64,
+) -> None:
+    """Compile fused decode Triton kernel before CUDA graph capture."""
+    if not is_indexer_tq_4bit_enabled() or not use_indexer_tq_fused_decode():
+        return
+    if not torch.cuda.is_available():
+        return
+    if isinstance(device, int):
+        device = torch.device(f"cuda:{device}")
+    key = str(device)
+    if key in _INDEXER_TQ_FUSED_WARMED:
+        return
+
+    _get_indexer_tq_buffers(device)
+    batch_size = 1
+    q_fp8 = torch.zeros(
+        batch_size,
+        num_heads,
+        INDEXER_HEAD_DIM,
+        device=device,
+        dtype=_FP8_DTYPE,
+    )
+    weights = torch.zeros(batch_size, num_heads, device=device, dtype=torch.float32)
+    packed_cache = torch.zeros(
+        1,
+        block_size,
+        INDEXER_PACKED_BYTES,
+        device=device,
+        dtype=torch.uint8,
+    )
+    num_blocks = max(1, (max_model_len + block_size - 1) // block_size)
+    block_table = torch.zeros(
+        batch_size,
+        num_blocks,
+        device=device,
+        dtype=torch.int32,
+    )
+    seq_lens = torch.ones(batch_size, device=device, dtype=torch.int32)
+    tq4_paged_mqa_logits_triton(
+        q_fp8,
+        weights,
+        packed_cache,
+        block_table,
+        seq_lens,
+        max_model_len,
+    )
+    torch.cuda.synchronize(device)
+    _INDEXER_TQ_FUSED_WARMED.add(key)
+    logger.info_once("Indexer TQ4 fused decode logits kernel warmed up.")

--- a/vllm/v1/attention/ops/indexer_turboquant.py
+++ b/vllm/v1/attention/ops/indexer_turboquant.py
@@ -84,7 +84,11 @@ INDEXER_SYNC_FIXED_GRID = 40960
 def indexer_sync_fixed_grid() -> int:
     return max(
         1,
-        int(os.environ.get("VLLM_INDEXER_TQ_SYNC_FIXED_GRID", str(INDEXER_SYNC_FIXED_GRID))),
+        int(
+            os.environ.get(
+                "VLLM_INDEXER_TQ_SYNC_FIXED_GRID", str(INDEXER_SYNC_FIXED_GRID)
+            )
+        ),
     )
 
 
@@ -196,14 +200,18 @@ def indexer_tq_sync_blocks_per_split() -> int:
 
 
 def indexer_packed_head_dim() -> int:
-    return INDEXER_PACKED_BYTES if is_indexer_tq_4bit_enabled() else INDEXER_FP8_SLOT_BYTES
+    return (
+        INDEXER_PACKED_BYTES if is_indexer_tq_4bit_enabled() else INDEXER_FP8_SLOT_BYTES
+    )
 
 
 def _get_indexer_tq_buffers(device: torch.device) -> dict:
     key = str(device)
     if key not in _INDEXER_TQ_BUFFERS:
         D = INDEXER_HEAD_DIM
-        cents = get_centroids(D, INDEXER_MSE_BITS).to(device=device, dtype=torch.float32)
+        cents = get_centroids(D, INDEXER_MSE_BITS).to(
+            device=device, dtype=torch.float32
+        )
         c_sorted, _ = cents.sort()
         buf: dict = {
             "centroids_bf16": cents.to(_BF16),
@@ -352,7 +360,7 @@ def dequant_packed_rows_torch(packed: torch.Tensor, buf: dict) -> torch.Tensor:
     )
     y_hat = buf["centroids_bf16"][idx.to(torch.int64)].to(torch.float32)
     scale = (
-        packed[:, INDEXER_MSE_BYTES : INDEXER_PACKED_BYTES]
+        packed[:, INDEXER_MSE_BYTES:INDEXER_PACKED_BYTES]
         .contiguous()
         .view(torch.float16)
         .to(torch.float32)
@@ -492,9 +500,7 @@ def _indexer_tq_fused_store_kernel(
         hi = tl.where(y >= mid_val, hi, mid)
     idx = tl.minimum(lo, N_CENTROIDS - 1)
 
-    y_hat = _tq_mla_gather_centroids_1d(
-        Centroids_ptr, idx, d_mask, BLOCK_D, MSE_BITS
-    )
+    y_hat = _tq_mla_gather_centroids_1d(Centroids_ptr, idx, d_mask, BLOCK_D, MSE_BITS)
     c_norm_sq = tl.sum(y_hat * y_hat, axis=0)
     c_norm = tl.sqrt(tl.maximum(c_norm_sq, 1e-8))
     eff_scale = (norm / c_norm).to(tl.float16)
@@ -621,17 +627,15 @@ def _tq4_prefill_gather_dequant_fp8_kernel(
     bit_shift = bit_off % 8
     umask = (1 << MSE_BITS) - 1
 
-    raw0 = tl.load(
-        Packed_cache_ptr + p_base + byte_idx, mask=d_mask, other=0
-    ).to(tl.int32)
-    raw1 = tl.load(
-        Packed_cache_ptr + p_base + byte_idx + 1, mask=d_mask, other=0
-    ).to(tl.int32)
+    raw0 = tl.load(Packed_cache_ptr + p_base + byte_idx, mask=d_mask, other=0).to(
+        tl.int32
+    )
+    raw1 = tl.load(Packed_cache_ptr + p_base + byte_idx + 1, mask=d_mask, other=0).to(
+        tl.int32
+    )
     raw16 = raw0 | (raw1 << 8)
     cidx = (raw16 >> bit_shift) & umask
-    y_hat = _tq_mla_gather_centroids_1d(
-        Centroids_ptr, cidx, d_mask, BLOCK_D, MSE_BITS
-    )
+    y_hat = _tq_mla_gather_centroids_1d(Centroids_ptr, cidx, d_mask, BLOCK_D, MSE_BITS)
     n_lo = tl.load(Packed_cache_ptr + p_base + MSE_BYTES).to(tl.uint16)
     n_hi = tl.load(Packed_cache_ptr + p_base + MSE_BYTES + 1).to(tl.uint16)
     token_scale = (n_lo | (n_hi << 8)).to(tl.float16, bitcast=True).to(tl.float32)
@@ -733,9 +737,7 @@ def _indexer_tq_sync_decode_kernel(
 
     block_table_id = pos // block_size
     slot_in_block = pos % block_size
-    block_id = tl.load(
-        Block_table_ptr + batch_id * block_table_stride + block_table_id
-    )
+    block_id = tl.load(Block_table_ptr + batch_id * block_table_stride + block_table_id)
 
     packed_base = block_id * stride_packed_nb + slot_in_block * stride_packed_bs
     fp8_base = block_id * stride_ws_nb + slot_in_block * stride_ws_bs
@@ -747,18 +749,16 @@ def _indexer_tq_sync_decode_kernel(
     bit_shift = bit_off % 8
     umask = (1 << MSE_BITS) - 1
 
-    raw0 = tl.load(
-        Packed_cache_ptr + packed_base + byte_idx, mask=d_mask, other=0
-    ).to(tl.int32)
+    raw0 = tl.load(Packed_cache_ptr + packed_base + byte_idx, mask=d_mask, other=0).to(
+        tl.int32
+    )
     raw1 = tl.load(
         Packed_cache_ptr + packed_base + byte_idx + 1, mask=d_mask, other=0
     ).to(tl.int32)
     raw16 = raw0 | (raw1 << 8)
     idx = (raw16 >> bit_shift) & umask
 
-    y_hat = _tq_mla_gather_centroids_1d(
-        Centroids_ptr, idx, d_mask, BLOCK_D, MSE_BITS
-    )
+    y_hat = _tq_mla_gather_centroids_1d(Centroids_ptr, idx, d_mask, BLOCK_D, MSE_BITS)
     n_lo = tl.load(Packed_cache_ptr + packed_base + MSE_BYTES).to(tl.uint16)
     n_hi = tl.load(Packed_cache_ptr + packed_base + MSE_BYTES + 1).to(tl.uint16)
     token_scale = (n_lo | (n_hi << 8)).to(tl.float16, bitcast=True).to(tl.float32)
@@ -807,9 +807,7 @@ def _indexer_tq_sync_block_vectorized(
     d_mask = d_offs < D
     full_mask = d_mask & slot_mask[None, :]
 
-    packed_base = (
-        block_id * stride_packed_nb + n_offs * stride_packed_bs
-    )
+    packed_base = block_id * stride_packed_nb + n_offs * stride_packed_bs
     fp8_base = block_id * stride_ws_nb + n_offs * stride_ws_bs
 
     bit_off = d_offs * MSE_BITS
@@ -908,7 +906,7 @@ def _indexer_tq_sync_decode_tile_kernel(
     )
 
     d_offs = tl.arange(0, BLOCK_D)[:, None]
-    n_offs = tl.arange(0, TILE)[None, :]
+    tl.arange(0, TILE)[None, :]
     d_mask = d_offs < D
     full_mask = d_mask & pos_ok[None, :]
     bit_off = d_offs * MSE_BITS
@@ -930,9 +928,9 @@ def _indexer_tq_sync_decode_tile_kernel(
     y_hat = _tq_mla_gather_centroids(
         Centroids_ptr, idx, full_mask, BLOCK_D, TILE, MSE_BITS
     )
-    n_lo = tl.load(
-        Packed_cache_ptr + packed_base + MSE_BYTES, mask=pos_ok, other=0
-    ).to(tl.uint16)
+    n_lo = tl.load(Packed_cache_ptr + packed_base + MSE_BYTES, mask=pos_ok, other=0).to(
+        tl.uint16
+    )
     n_hi = tl.load(
         Packed_cache_ptr + packed_base + MSE_BYTES + 1, mask=pos_ok, other=0
     ).to(tl.uint16)
@@ -1098,9 +1096,7 @@ def sync_fp8_workspace_for_decode(
             num_sms = torch.cuda.get_device_properties(
                 packed_cache.device
             ).multi_processor_count
-            sl_for_meta = (
-                seq_lens if seq_lens.dim() == 2 else seq_lens.unsqueeze(-1)
-            )
+            sl_for_meta = seq_lens if seq_lens.dim() == 2 else seq_lens.unsqueeze(-1)
             schedule_metadata = get_paged_mqa_logits_metadata(
                 sl_for_meta, block_size, num_sms
             )
@@ -1264,9 +1260,7 @@ def _tq4_paged_mqa_logits_kernel(
 
     block_table_id = pos // block_size
     slot_in_block = pos % block_size
-    block_id = tl.load(
-        Block_table_ptr + batch_id * block_table_stride + block_table_id
-    )
+    block_id = tl.load(Block_table_ptr + batch_id * block_table_stride + block_table_id)
 
     packed_base = block_id * stride_packed_nb + slot_in_block * stride_packed_bs
 
@@ -1277,18 +1271,16 @@ def _tq4_paged_mqa_logits_kernel(
     bit_shift = bit_off % 8
     umask = (1 << MSE_BITS) - 1
 
-    raw0 = tl.load(
-        Packed_cache_ptr + packed_base + byte_idx, mask=d_mask, other=0
-    ).to(tl.int32)
+    raw0 = tl.load(Packed_cache_ptr + packed_base + byte_idx, mask=d_mask, other=0).to(
+        tl.int32
+    )
     raw1 = tl.load(
         Packed_cache_ptr + packed_base + byte_idx + 1, mask=d_mask, other=0
     ).to(tl.int32)
     raw16 = raw0 | (raw1 << 8)
     idx = (raw16 >> bit_shift) & umask
 
-    y_hat = _tq_mla_gather_centroids_1d(
-        Centroids_ptr, idx, d_mask, BLOCK_D, MSE_BITS
-    )
+    y_hat = _tq_mla_gather_centroids_1d(Centroids_ptr, idx, d_mask, BLOCK_D, MSE_BITS)
     n_lo = tl.load(Packed_cache_ptr + packed_base + MSE_BYTES).to(tl.uint16)
     n_hi = tl.load(Packed_cache_ptr + packed_base + MSE_BYTES + 1).to(tl.uint16)
     token_scale = (n_lo | (n_hi << 8)).to(tl.float16, bitcast=True).to(tl.float32)
@@ -1367,7 +1359,7 @@ def warmup_indexer_tq_store(
     slot_mapping = torch.zeros(1, device=device, dtype=torch.int32)
     for _ in range(8):
         indexer_tq_store_and_cache_triton(k, kv_cache, slot_mapping)
-    torch.cuda.synchronize(device)
+    torch.accelerator.synchronize(device)
     _INDEXER_TQ_STORE_WARMED.add(key)
     logger.info_once("Indexer TQ4 fused store kernel warmed up.")
 
@@ -1433,6 +1425,6 @@ def warmup_indexer_tq_fused_decode(
         seq_lens,
         max_model_len,
     )
-    torch.cuda.synchronize(device)
+    torch.accelerator.synchronize(device)
     _INDEXER_TQ_FUSED_WARMED.add(key)
     logger.info_once("Indexer TQ4 fused decode logits kernel warmed up.")

--- a/vllm/v1/attention/ops/tq_mla_defaults.py
+++ b/vllm/v1/attention/ops/tq_mla_defaults.py
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Production defaults for TurboQuant MLA (driven by ``--kv-cache-dtype``).
+
+``turboquant_*_nc`` presets automatically enable the validated production
+bundle: FWHT store, k_pe 4-bit, fused sparse prefill (gather+flash+dedup),
+and adaptive decode splits.  Environment variables remain **opt-out** regression
+anchors only (set ``=0`` to disable a feature).
+"""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from vllm.model_executor.layers.quantization.turboquant.config import (
+        TurboQuantConfig,
+    )
+
+NC_PRODUCTION_CACHE_DTYPES = frozenset(
+    {
+        "turboquant_4bit_nc",
+        "turboquant_k3v4_nc",
+        "turboquant_3bit_nc",
+    }
+)
+
+
+def is_nc_production_cache_dtype(cache_dtype: str) -> bool:
+    return cache_dtype in NC_PRODUCTION_CACHE_DTYPES
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    return raw == "1"
+
+
+def default_store_fwht(cache_dtype: str, tq_config: TurboQuantConfig) -> bool:
+    default = is_nc_production_cache_dtype(cache_dtype) and not tq_config.key_fp8
+    return _env_bool("VLLM_TQ_MLA_STORE_FWHT", default)
+
+
+def default_kpe_4bit(cache_dtype: str, tq_config: TurboQuantConfig) -> bool:
+    default = is_nc_production_cache_dtype(cache_dtype) and not tq_config.key_fp8
+    return _env_bool("VLLM_TQ_KPE_4BIT", default)
+
+
+def default_kpe_fp8(
+    cache_dtype: str,
+    tq_config: TurboQuantConfig,
+    *,
+    kpe_4bit: bool,
+) -> bool:
+    if kpe_4bit:
+        return False
+    default = not is_nc_production_cache_dtype(cache_dtype)
+    return _env_bool("VLLM_TQ_KPE_FP8", default)
+
+
+def resolve_kpe_layout(
+    cache_dtype: str,
+    tq_config: TurboQuantConfig,
+    rope_dim: int,
+) -> tuple[bool, bool, int]:
+    """Return ``(kpe_4bit, kpe_fp8, k_pe_bytes)`` for cache spec / impl init."""
+    from vllm.v1.attention.ops.triton_turboquant_mla_store import kpe_packed_bytes
+
+    kpe_4bit = default_kpe_4bit(cache_dtype, tq_config)
+    kpe_fp8 = default_kpe_fp8(cache_dtype, tq_config, kpe_4bit=kpe_4bit)
+    k_pe_bytes = kpe_packed_bytes(
+        rope_dim,
+        kpe_4bit=kpe_4bit,
+        kpe_fp8=kpe_fp8,
+    )
+    return kpe_4bit, kpe_fp8, k_pe_bytes

--- a/vllm/v1/attention/ops/triton_decode_attention.py
+++ b/vllm/v1/attention/ops/triton_decode_attention.py
@@ -621,9 +621,7 @@ def _fwd_kernel_stage2(
             # (old_scale==1 only when e_max==-inf, where acc/e_sum are still 0).
             active = tlogic > -float("inf")
             n_e_max = tl.maximum(tlogic, e_max)
-            old_scale = tl.where(
-                e_max > -float("inf"), tl.exp(e_max - n_e_max), 1.0
-            )
+            old_scale = tl.where(e_max > -float("inf"), tl.exp(e_max - n_e_max), 1.0)
             acc *= old_scale
             exp_logic = tl.where(active, tl.exp(tlogic - n_e_max), 0.0)
             acc += exp_logic * tv

--- a/vllm/v1/attention/ops/triton_decode_attention.py
+++ b/vllm/v1/attention/ops/triton_decode_attention.py
@@ -614,11 +614,18 @@ def _fwd_kernel_stage2(
                 Mid_O + offs_v + split_kv_id * stride_mid_os, mask=mask_d, other=0.0
             )
             tlogic = tl.load(Mid_O + offs_logic + split_kv_id * stride_mid_os)
+            # Skip empty splits branchlessly. Under DCP a leading split can be
+            # all -1 (tlogic=-inf) while running e_max is still -inf; then
+            # exp(e_max - n_e_max) = exp(-inf - (-inf)) = NaN and poisons LSE.
+            # For finite lse this is identical to the original
+            # (old_scale==1 only when e_max==-inf, where acc/e_sum are still 0).
+            active = tlogic > -float("inf")
             n_e_max = tl.maximum(tlogic, e_max)
-
-            old_scale = tl.exp(e_max - n_e_max)
+            old_scale = tl.where(
+                e_max > -float("inf"), tl.exp(e_max - n_e_max), 1.0
+            )
             acc *= old_scale
-            exp_logic = tl.exp(tlogic - n_e_max)
+            exp_logic = tl.where(active, tl.exp(tlogic - n_e_max), 0.0)
             acc += exp_logic * tv
 
             e_sum = e_sum * old_scale + exp_logic

--- a/vllm/v1/attention/ops/triton_turboquant_mla_decode.py
+++ b/vllm/v1/attention/ops/triton_turboquant_mla_decode.py
@@ -99,6 +99,7 @@ def _rotate_qpe_for_kpe_4bit(
     q_pe_rot = q[..., L : L + R] @ pi
     return torch.cat([q[..., :L], q_pe_rot], dim=-1)
 
+
 # P1: Triton autotune for the fused stage1 decode kernel.
 # Original PR hardcoded BLOCK_N=32, BLOCK_H=16, num_warps=4, num_stages=2 (mirrored
 # from upstream `_fwd_grouped_kernel_stage1` defaults). For the TurboQuant 4bit /
@@ -119,7 +120,9 @@ _TQ_MLA_DECODE_AUTOTUNE_CONFIGS = (
     [
         # PR default; identical to pre-P1 behaviour.
         triton.Config(
-            {"BLOCK_N": 32, "BLOCK_H": 16}, num_warps=4, num_stages=2,
+            {"BLOCK_N": 32, "BLOCK_H": 16},
+            num_warps=4,
+            num_stages=2,
         ),
     ]
     if _TQ_MLA_DECODE_DISABLE_AUTOTUNE
@@ -332,15 +335,9 @@ def _load_kpe_4bit_1d_bulk(
     idx = (row >> shift) & 0xF
     idx = tl.where(r_mask, idx, 0)
 
-    y_hat = _tq_mla_gather_centroids_1d(
-        Kpe_centroids_ptr, idx, r_mask, BLOCK_R, 4
-    )
-    n_lo = tl.load(
-        Cache_ptr + slot_base + KV_C_BYTES + KPE_MSE_BYTES
-    ).to(tl.uint16)
-    n_hi = tl.load(
-        Cache_ptr + slot_base + KV_C_BYTES + KPE_MSE_BYTES + 1
-    ).to(tl.uint16)
+    y_hat = _tq_mla_gather_centroids_1d(Kpe_centroids_ptr, idx, r_mask, BLOCK_R, 4)
+    n_lo = tl.load(Cache_ptr + slot_base + KV_C_BYTES + KPE_MSE_BYTES).to(tl.uint16)
+    n_hi = tl.load(Cache_ptr + slot_base + KV_C_BYTES + KPE_MSE_BYTES + 1).to(tl.uint16)
     kpe_scale = (n_lo | (n_hi << 8)).to(tl.float16, bitcast=True).to(tl.float32)
     return (y_hat * kpe_scale).to(tl.bfloat16)
 
@@ -369,15 +366,9 @@ def _load_kpe_4bit_1d(
     ).to(tl.int32)
     raw16 = raw0 | (raw1 << 8)
     idx = (raw16 >> bit_shift) & umask
-    y_hat = _tq_mla_gather_centroids_1d(
-        Kpe_centroids_ptr, idx, r_mask, BLOCK_R, 4
-    )
-    n_lo = tl.load(
-        Cache_ptr + slot_base + KV_C_BYTES + KPE_MSE_BYTES
-    ).to(tl.uint16)
-    n_hi = tl.load(
-        Cache_ptr + slot_base + KV_C_BYTES + KPE_MSE_BYTES + 1
-    ).to(tl.uint16)
+    y_hat = _tq_mla_gather_centroids_1d(Kpe_centroids_ptr, idx, r_mask, BLOCK_R, 4)
+    n_lo = tl.load(Cache_ptr + slot_base + KV_C_BYTES + KPE_MSE_BYTES).to(tl.uint16)
+    n_hi = tl.load(Cache_ptr + slot_base + KV_C_BYTES + KPE_MSE_BYTES + 1).to(tl.uint16)
     kpe_scale = (n_lo | (n_hi << 8)).to(tl.float16, bitcast=True).to(tl.float32)
     return (y_hat * kpe_scale).to(tl.bfloat16)
 
@@ -437,9 +428,7 @@ def _tq_mla_dequant_mse(
     raw16 = raw0 | (raw1 << 8)
     idx = (raw16 >> bit_shift) & umask
 
-    y_hat = _tq_mla_gather_centroids_1d(
-        Centroids_ptr, idx, d_mask, BLOCK_D, MSE_BITS
-    )
+    y_hat = _tq_mla_gather_centroids_1d(Centroids_ptr, idx, d_mask, BLOCK_D, MSE_BITS)
 
     # ----- Per-token scale (fp16 @ MSE_BYTES) -----
     # NORM_CORRECTION=1: store wrote eff_scale = vec_norm / ||y_hat_raw||.
@@ -554,18 +543,16 @@ def _tq_mla_sparse_topk_gather_dequant_mse(
     bit_shift = bit_off % 8
     umask = (1 << MSE_BITS) - 1
 
-    raw0 = tl.load(
-        Paged_cache_ptr + slot_base + byte_idx, mask=d_mask, other=0
-    ).to(tl.int32)
-    raw1 = tl.load(
-        Paged_cache_ptr + slot_base + byte_idx + 1, mask=d_mask, other=0
-    ).to(tl.int32)
+    raw0 = tl.load(Paged_cache_ptr + slot_base + byte_idx, mask=d_mask, other=0).to(
+        tl.int32
+    )
+    raw1 = tl.load(Paged_cache_ptr + slot_base + byte_idx + 1, mask=d_mask, other=0).to(
+        tl.int32
+    )
     raw16 = raw0 | (raw1 << 8)
     idx = (raw16 >> bit_shift) & umask
 
-    y_hat = _tq_mla_gather_centroids_1d(
-        Centroids_ptr, idx, d_mask, BLOCK_D, MSE_BITS
-    )
+    y_hat = _tq_mla_gather_centroids_1d(Centroids_ptr, idx, d_mask, BLOCK_D, MSE_BITS)
 
     n_lo = tl.load(Paged_cache_ptr + slot_base + MSE_BYTES).to(tl.uint16)
     n_hi = tl.load(Paged_cache_ptr + slot_base + MSE_BYTES + 1).to(tl.uint16)
@@ -601,9 +588,7 @@ def _tq_mla_sparse_topk_gather_dequant_mse(
         kpe_fp8 = fp8_byte.to(tl.float8e4nv, bitcast=True)
         kpe_f32 = kpe_fp8.to(tl.float32)
         s_lo = tl.load(Paged_cache_ptr + slot_base + KV_C_BYTES + R).to(tl.uint16)
-        s_hi = tl.load(Paged_cache_ptr + slot_base + KV_C_BYTES + R + 1).to(
-            tl.uint16
-        )
+        s_hi = tl.load(Paged_cache_ptr + slot_base + KV_C_BYTES + R + 1).to(tl.uint16)
         scale_u16 = s_lo | (s_hi << 8)
         scale_f32 = scale_u16.to(tl.float16, bitcast=True).to(tl.float32)
         kpe_bf = (kpe_f32 * scale_f32).to(tl.bfloat16)
@@ -654,9 +639,7 @@ def fused_mla_sparse_topk_gather_dequant_mse(
         return
 
     kpe_cents = (
-        kpe_centroids_bf16
-        if kpe_centroids_bf16 is not None
-        else centroids_bf16[:1]
+        kpe_centroids_bf16 if kpe_centroids_bf16 is not None else centroids_bf16[:1]
     )
     kpe_mse_bytes = math.ceil(R * 4 / 8) if kpe_4bit else 0
     BLOCK_D = triton.next_power_of_2(L)
@@ -726,9 +709,7 @@ def fused_mla_dequant_mse(
         return
 
     kpe_cents = (
-        kpe_centroids_bf16
-        if kpe_centroids_bf16 is not None
-        else centroids_bf16[:1]
+        kpe_centroids_bf16 if kpe_centroids_bf16 is not None else centroids_bf16[:1]
     )
     kpe_mse_bytes = math.ceil(R * 4 / 8) if kpe_4bit else 0
 
@@ -873,9 +854,7 @@ def _fwd_grouped_kernel_stage1_tq(
         cache_modifier=".ca",
     )
     if KPE_4BIT and QPE_FWHT_IN_KERNEL:
-        qpe = _fwht_qpe_tile(
-            qpe, mask_h, BLOCK_H, BLOCK_DPE, R, LOG2N_R, INV_SQRT_R
-        )
+        qpe = _fwht_qpe_tile(qpe, mask_h, BLOCK_H, BLOCK_DPE, R, LOG2N_R, INV_SQRT_R)
 
     kv_len_per_split = tl.cdiv(cur_batch_seq_len, NUM_KV_SPLITS)
     split_kv_start = kv_len_per_split * split_kv_id
@@ -1119,9 +1098,7 @@ def fused_mla_tq_decode_stage1(
     BLOCK_DPE = triton.next_power_of_2(R)
     BLOCK_DV = BLOCK_DMODEL
     kpe_cents = (
-        kpe_centroids_bf16
-        if kpe_centroids_bf16 is not None
-        else centroids_bf16[:1]
+        kpe_centroids_bf16 if kpe_centroids_bf16 is not None else centroids_bf16[:1]
     )
     kpe_mse_bytes = math.ceil(R * 4 / 8) if kpe_4bit else 0
 
@@ -1192,7 +1169,16 @@ def fused_mla_tq_decode_stage1(
 
 @triton.autotune(
     configs=_TQ_MLA_SPARSE_DECODE_AUTOTUNE_CONFIGS,
-    key=["L", "R", "MSE_BITS", "KEY_FP8", "KPE_FP8", "q_head_num", "TOPK", "NUM_KV_SPLITS"],
+    key=[
+        "L",
+        "R",
+        "MSE_BITS",
+        "KEY_FP8",
+        "KPE_FP8",
+        "q_head_num",
+        "TOPK",
+        "NUM_KV_SPLITS",
+    ],
 )
 @triton.jit
 def _fwd_grouped_kernel_stage1_tq_sparse(
@@ -1265,9 +1251,7 @@ def _fwd_grouped_kernel_stage1_tq_sparse(
         cache_modifier=".ca",
     )
     if KPE_4BIT and QPE_FWHT_IN_KERNEL:
-        qpe = _fwht_qpe_tile(
-            qpe, mask_h, BLOCK_H, BLOCK_DPE, R, LOG2N_R, INV_SQRT_R
-        )
+        qpe = _fwht_qpe_tile(qpe, mask_h, BLOCK_H, BLOCK_DPE, R, LOG2N_R, INV_SQRT_R)
 
     kv_len_per_split = tl.cdiv(cur_batch_seq_len, NUM_KV_SPLITS)
     split_kv_start = kv_len_per_split * split_kv_id
@@ -1501,9 +1485,7 @@ def fused_mla_tq_sparse_decode_stage1(
     BLOCK_DPE = triton.next_power_of_2(R)
     BLOCK_DV = BLOCK_DMODEL
     kpe_cents = (
-        kpe_centroids_bf16
-        if kpe_centroids_bf16 is not None
-        else centroids_bf16[:1]
+        kpe_centroids_bf16 if kpe_centroids_bf16 is not None else centroids_bf16[:1]
     )
     kpe_mse_bytes = math.ceil(R * 4 / 8) if kpe_4bit else 0
 
@@ -1601,6 +1583,4 @@ def sparse_decode_softmax_reducev_fwd(
         _decode_softmax_reducev_fwd,
     )
 
-    _decode_softmax_reducev_fwd(
-        logits, q, o, lse, v_buffer, b_seq_len, num_kv_splits
-    )
+    _decode_softmax_reducev_fwd(logits, q, o, lse, v_buffer, b_seq_len, num_kv_splits)

--- a/vllm/v1/attention/ops/triton_turboquant_mla_decode.py
+++ b/vllm/v1/attention/ops/triton_turboquant_mla_decode.py
@@ -1,0 +1,1606 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Fused TurboQuant MSE dequant for MLA decode.
+
+This module provides a single Triton kernel `_tq_mla_dequant_mse` that
+collapses the per-layer hot path:
+    {bit-unpack → centroid gather → optional norm-correction → vec_norm mul}
+into one launch, writing the un-rotated reconstruction (`y_hat * vec_norm`)
+plus the k_pe bf16 slice into a dense workspace.
+
+The final inverse-Hadamard rotation `y_normed @ Pi` is left as a single
+cuBLAS bf16 GEMM in Python — that one is already a single fast kernel
+and would only complicate the Triton kernel.
+
+Reference for the unpack + centroid gather pattern:
+    `vllm/v1/attention/ops/triton_turboquant_decode.py::_tq_full_dequant_kv`
+(non-MLA backend; we mirror its K-dequant branch).
+
+Numerical equivalence with `_dequant_kv_c_mse` (PyTorch reference in
+`triton_mla_tq.py`) is bit-for-bit at fp32 round-trip; bf16 ULP-level
+deviations are allowed.
+"""
+
+import math
+import os
+
+import torch
+
+from vllm.triton_utils import tl, triton
+from vllm.v1.attention.backends.turboquant_attn import _build_hadamard
+from vllm.v1.attention.ops.triton_turboquant_mla_store import (
+    _fwht_1d,
+)
+
+_BF16 = torch.bfloat16
+
+_PI_CACHE: dict[tuple[int, str, torch.dtype], torch.Tensor] = {}
+
+
+def _get_pi(R: int, device: torch.device | str, dtype: torch.dtype) -> torch.Tensor:
+    key = (R, str(device), dtype)
+    pi = _PI_CACHE.get(key)
+    if pi is None:
+        pi = _build_hadamard(R, str(device)).to(dtype)
+        _PI_CACHE[key] = pi
+    return pi
+
+
+def _log2_const(n: int) -> int:
+    assert n > 0 and (n & (n - 1)) == 0, f"n must be power of 2, got {n}"
+    return n.bit_length() - 1
+
+
+def tq_mla_qpe_fwht_in_kernel_enabled() -> bool:
+    """Apply Pi_R / FWHT to q_pe inside stage1 (skip Python q_pe @ Pi)."""
+    return os.environ.get("VLLM_TQ_MLA_QPE_FWHT_IN_KERNEL", "1") == "1"
+
+
+def _qpe_fwht_in_kernel_flag(kpe_4bit: bool) -> int:
+    return 1 if kpe_4bit and tq_mla_qpe_fwht_in_kernel_enabled() else 0
+
+
+@triton.jit
+def _fwht_qpe_tile(
+    qpe,
+    mask_h,
+    BLOCK_H: tl.constexpr,
+    BLOCK_DPE: tl.constexpr,
+    R: tl.constexpr,
+    LOG2N_R: tl.constexpr,
+    INV_SQRT_R: tl.constexpr,
+):
+    """FWHT each head row of q_pe (matches ``q_pe @ Pi_R`` for orthonormal Pi)."""
+    qpe_rot = tl.zeros([BLOCK_H, BLOCK_DPE], dtype=tl.float32)
+    r_offs = tl.arange(0, BLOCK_DPE)
+    r_mask = r_offs < R
+    for h in tl.static_range(BLOCK_H):
+        h_mask = tl.arange(0, BLOCK_H) == h
+        row = tl.sum(
+            tl.where(h_mask[:, None] & r_mask[None, :], qpe.to(tl.float32), 0.0),
+            axis=0,
+        )
+        row_rot = _fwht_1d(row, BLOCK_DPE, LOG2N_R, INV_SQRT_R)
+        qpe_rot = tl.where(
+            h_mask[:, None] & r_mask[None, :],
+            row_rot[None, :],
+            qpe_rot,
+        )
+    return qpe_rot.to(qpe.dtype)
+
+
+def _rotate_qpe_for_kpe_4bit(
+    q: torch.Tensor, L: int, R: int, kpe_4bit: bool
+) -> torch.Tensor:
+    """Map q_pe to Hadamard space: dot(q_pe, k) = dot(q_pe @ Pi_R, k_hadamard)."""
+    if not kpe_4bit:
+        return q
+    pi = _get_pi(R, q.device, q.dtype)
+    q_pe_rot = q[..., L : L + R] @ pi
+    return torch.cat([q[..., :L], q_pe_rot], dim=-1)
+
+# P1: Triton autotune for the fused stage1 decode kernel.
+# Original PR hardcoded BLOCK_N=32, BLOCK_H=16, num_warps=4, num_stages=2 (mirrored
+# from upstream `_fwd_grouped_kernel_stage1` defaults). For the TurboQuant 4bit /
+# FP8 paths the optimal tile depends on register pressure (4bit dequant is heavy)
+# and on q_head_num (varies with TP). Let Triton benchmark a small candidate set
+# during warmup and pick the best per (L, R, MSE_BITS, KEY_FP8, KPE_FP8,
+# q_head_num) key — these are static for a given deployment, so the choice is
+# cached for the lifetime of the process and never re-benchmarked inside CUDA
+# Graph capture.
+#
+# Set VLLM_TQ_MLA_DISABLE_AUTOTUNE=1 to fall back to the original single-config
+# behaviour (useful for benchmarking before/after, or as a fast rollback).
+_TQ_MLA_DECODE_DISABLE_AUTOTUNE = (
+    os.environ.get("VLLM_TQ_MLA_DISABLE_AUTOTUNE", "0") == "1"
+)
+
+_TQ_MLA_DECODE_AUTOTUNE_CONFIGS = (
+    [
+        # PR default; identical to pre-P1 behaviour.
+        triton.Config(
+            {"BLOCK_N": 32, "BLOCK_H": 16}, num_warps=4, num_stages=2,
+        ),
+    ]
+    if _TQ_MLA_DECODE_DISABLE_AUTOTUNE
+    else [
+        # PR default — always kept so autotune never picks something worse.
+        triton.Config({"BLOCK_N": 32, "BLOCK_H": 16}, num_warps=4, num_stages=2),
+        # Smaller BLOCK_N: reduces register pressure when 4bit dequant is heavy.
+        triton.Config({"BLOCK_N": 16, "BLOCK_H": 16}, num_warps=4, num_stages=2),
+        # Deeper pipeline to hide global-load latency behind dequant compute.
+        triton.Config({"BLOCK_N": 32, "BLOCK_H": 16}, num_warps=4, num_stages=3),
+        # More warps for higher SM occupancy on long sequences.
+        triton.Config({"BLOCK_N": 32, "BLOCK_H": 16}, num_warps=8, num_stages=2),
+        # Larger BLOCK_N: fewer iterations when memory-bound on long KV.
+        triton.Config({"BLOCK_N": 64, "BLOCK_H": 16}, num_warps=4, num_stages=2),
+        triton.Config({"BLOCK_N": 64, "BLOCK_H": 16}, num_warps=8, num_stages=2),
+        # Larger BLOCK_H: only useful when q_head_num is big (small TP);
+        # otherwise mask-wasted but still correct.
+        triton.Config({"BLOCK_N": 32, "BLOCK_H": 32}, num_warps=8, num_stages=2),
+    ]
+)
+
+_TQ_MLA_SPARSE_DECODE_AUTOTUNE_CONFIGS = (
+    [triton.Config({"BLOCK_N": 32, "BLOCK_H": 16}, num_warps=4, num_stages=2)]
+    if _TQ_MLA_DECODE_DISABLE_AUTOTUNE
+    else [
+        # split64 → 32 tokens/split with BLOCK_N=32 (single inner iteration).
+        triton.Config({"BLOCK_N": 32, "BLOCK_H": 8}, num_warps=4, num_stages=2),
+        triton.Config({"BLOCK_N": 32, "BLOCK_H": 16}, num_warps=4, num_stages=2),
+        triton.Config({"BLOCK_N": 32, "BLOCK_H": 16}, num_warps=8, num_stages=2),
+        triton.Config({"BLOCK_N": 32, "BLOCK_H": 16}, num_warps=4, num_stages=3),
+        triton.Config({"BLOCK_N": 64, "BLOCK_H": 8}, num_warps=8, num_stages=2),
+        triton.Config({"BLOCK_N": 64, "BLOCK_H": 16}, num_warps=8, num_stages=2),
+        triton.Config({"BLOCK_N": 16, "BLOCK_H": 8}, num_warps=4, num_stages=2),
+    ]
+)
+
+
+@triton.jit
+def _tq_mla_load_fp16_scale(
+    K_Cache,
+    slot_base,
+    byte_off,
+    n_mask,
+):
+    """Load one fp16 scalar per token from cache[slot + byte_off : +2]."""
+    lo = tl.load(K_Cache + slot_base + byte_off, mask=n_mask, other=0).to(tl.uint16)
+    hi = tl.load(K_Cache + slot_base + byte_off + 1, mask=n_mask, other=0).to(tl.uint16)
+    u16 = lo | (hi << 8)
+    return u16.to(tl.float16, bitcast=True).to(tl.float32)
+
+
+@triton.jit
+def _tq_mla_gather_centroids(
+    Centroids_ptr,
+    idx,
+    mask,
+    BLOCK_DMODEL: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    MSE_BITS: tl.constexpr,
+):
+    """Gather bf16 centroids via a 2**MSE_BITS entry table loaded once per tile.
+
+    Uses tl.gather (not c[idx] — dynamic [] indexing fails in Triton). Compared
+    to tl.load(Centroids_ptr + idx), the table usually stays in registers/L1.
+    """
+    n_centroids: tl.constexpr = 1 << MSE_BITS
+    centroids = tl.load(Centroids_ptr + tl.arange(0, n_centroids))
+    idx_flat = idx.reshape(BLOCK_DMODEL * BLOCK_N)
+    y_flat = tl.gather(centroids, idx_flat, 0)
+    y_hat = y_flat.reshape(BLOCK_DMODEL, BLOCK_N)
+    return tl.where(mask, y_hat, 0.0)
+
+
+@triton.jit
+def _tq_mla_gather_centroids_1d(
+    Centroids_ptr,
+    idx,
+    d_mask,
+    BLOCK_D: tl.constexpr,
+    MSE_BITS: tl.constexpr,
+):
+    n_centroids: tl.constexpr = 1 << MSE_BITS
+    centroids = tl.load(Centroids_ptr + tl.arange(0, n_centroids))
+    y_hat = tl.gather(centroids, idx, 0)
+    return tl.where(d_mask, y_hat, 0.0)
+
+
+@triton.jit
+def _load_kpe_4bit_tile_bulk(
+    K_Cache,
+    sb,
+    slot_base,
+    KV_C_BYTES,
+    KPE_MSE_BYTES,
+    BLOCK_R,
+    BLOCK_N,
+    R,
+    Kpe_centroids_ptr,
+    r_mask,
+    n_mask,
+):
+    """Bulk-load 32B packed k_pe indices per slot, unpack in registers."""
+    byte_offs = tl.arange(0, KPE_MSE_BYTES)
+    pack_mask = (byte_offs[:, None] < KPE_MSE_BYTES) & n_mask[None, :]
+    packed = tl.load(
+        K_Cache + sb + KV_C_BYTES + byte_offs[:, None],
+        mask=pack_mask,
+        other=0,
+        cache_modifier=".cg",
+    ).to(tl.int32)
+
+    r = tl.arange(0, BLOCK_R)[:, None]
+    b = r // 2
+    shift = (r % 2) * 4
+    b_safe = tl.minimum(b, KPE_MSE_BYTES - 1)
+    b_idx = tl.broadcast_to(b_safe, (BLOCK_R, BLOCK_N))
+    row = tl.gather(packed, b_idx, axis=0)
+    shift_b = tl.broadcast_to(shift, (BLOCK_R, BLOCK_N))
+    idx = (row >> shift_b) & 0xF
+    r_full_mask = r_mask[:, None] & n_mask[None, :]
+    idx = tl.where(r_full_mask, idx, 0)
+
+    y_hat = _tq_mla_gather_centroids(
+        Kpe_centroids_ptr,
+        idx,
+        r_full_mask,
+        BLOCK_R,
+        BLOCK_N,
+        4,
+    )
+    kpe_scale = _tq_mla_load_fp16_scale(
+        K_Cache, slot_base, KV_C_BYTES + KPE_MSE_BYTES, n_mask
+    )
+    return (y_hat * kpe_scale[None, :]).to(tl.bfloat16)
+
+
+@triton.jit
+def _load_kpe_4bit_tile(
+    K_Cache,
+    sb,
+    slot_base,
+    KV_C_BYTES,
+    KPE_MSE_BYTES,
+    BLOCK_R,
+    BLOCK_N,
+    R,
+    Kpe_centroids_ptr,
+    r_offs,
+    r_mask,
+    n_mask,
+):
+    bit_off = r_offs[:, None] * 4
+    byte_idx = bit_off // 8
+    bit_shift = bit_off % 8
+    umask = 15
+    r_full_mask = r_mask[:, None] & n_mask[None, :]
+    raw0 = tl.load(
+        K_Cache + sb + KV_C_BYTES + byte_idx,
+        mask=r_full_mask,
+        other=0,
+        cache_modifier=".cg",
+    ).to(tl.int32)
+    raw1 = tl.load(
+        K_Cache + sb + KV_C_BYTES + byte_idx + 1,
+        mask=r_full_mask,
+        other=0,
+        cache_modifier=".cg",
+    ).to(tl.int32)
+    raw16 = raw0 | (raw1 << 8)
+    idx = (raw16 >> bit_shift) & umask
+    y_hat = _tq_mla_gather_centroids(
+        Kpe_centroids_ptr,
+        idx,
+        r_full_mask,
+        BLOCK_R,
+        BLOCK_N,
+        4,
+    )
+    kpe_scale = _tq_mla_load_fp16_scale(
+        K_Cache, slot_base, KV_C_BYTES + KPE_MSE_BYTES, n_mask
+    )
+    return (y_hat * kpe_scale[None, :]).to(tl.bfloat16)
+
+
+@triton.jit
+def _load_kpe_4bit_1d_bulk(
+    Cache_ptr,
+    slot_base,
+    KV_C_BYTES,
+    KPE_MSE_BYTES,
+    BLOCK_R,
+    R,
+    Kpe_centroids_ptr,
+    r_offs,
+    r_mask,
+):
+    """Bulk-load 32B k_pe indices for one slot, unpack in registers."""
+    byte_offs = tl.arange(0, KPE_MSE_BYTES)
+    packed = tl.load(
+        Cache_ptr + slot_base + KV_C_BYTES + byte_offs,
+        mask=byte_offs < KPE_MSE_BYTES,
+        other=0,
+        cache_modifier=".cg",
+    ).to(tl.int32)
+
+    b = r_offs // 2
+    shift = (r_offs % 2) * 4
+    b_safe = tl.minimum(b, KPE_MSE_BYTES - 1)
+    row = tl.gather(packed, b_safe, axis=0)
+    idx = (row >> shift) & 0xF
+    idx = tl.where(r_mask, idx, 0)
+
+    y_hat = _tq_mla_gather_centroids_1d(
+        Kpe_centroids_ptr, idx, r_mask, BLOCK_R, 4
+    )
+    n_lo = tl.load(
+        Cache_ptr + slot_base + KV_C_BYTES + KPE_MSE_BYTES
+    ).to(tl.uint16)
+    n_hi = tl.load(
+        Cache_ptr + slot_base + KV_C_BYTES + KPE_MSE_BYTES + 1
+    ).to(tl.uint16)
+    kpe_scale = (n_lo | (n_hi << 8)).to(tl.float16, bitcast=True).to(tl.float32)
+    return (y_hat * kpe_scale).to(tl.bfloat16)
+
+
+@triton.jit
+def _load_kpe_4bit_1d(
+    Cache_ptr,
+    slot_base,
+    KV_C_BYTES,
+    KPE_MSE_BYTES,
+    BLOCK_R,
+    R,
+    Kpe_centroids_ptr,
+    r_offs,
+    r_mask,
+):
+    bit_off = r_offs * 4
+    byte_idx = bit_off // 8
+    bit_shift = bit_off % 8
+    umask = 15
+    raw0 = tl.load(
+        Cache_ptr + slot_base + KV_C_BYTES + byte_idx, mask=r_mask, other=0
+    ).to(tl.int32)
+    raw1 = tl.load(
+        Cache_ptr + slot_base + KV_C_BYTES + byte_idx + 1, mask=r_mask, other=0
+    ).to(tl.int32)
+    raw16 = raw0 | (raw1 << 8)
+    idx = (raw16 >> bit_shift) & umask
+    y_hat = _tq_mla_gather_centroids_1d(
+        Kpe_centroids_ptr, idx, r_mask, BLOCK_R, 4
+    )
+    n_lo = tl.load(
+        Cache_ptr + slot_base + KV_C_BYTES + KPE_MSE_BYTES
+    ).to(tl.uint16)
+    n_hi = tl.load(
+        Cache_ptr + slot_base + KV_C_BYTES + KPE_MSE_BYTES + 1
+    ).to(tl.uint16)
+    kpe_scale = (n_lo | (n_hi << 8)).to(tl.float16, bitcast=True).to(tl.float32)
+    return (y_hat * kpe_scale).to(tl.bfloat16)
+
+
+@triton.jit
+def _tq_mla_dequant_mse(
+    Cache_ptr,  # uint8: (n_active, block_size, packed_bytes)
+    Centroids_ptr,  # bf16: (2**bits,) sorted Lloyd-Max codebook
+    Kpe_centroids_ptr,  # bf16: (16,) when KPE_4BIT
+    Out_ptr,  # bf16: (n_active, block_size, L+R)
+    # Strides (in elements; cache stride in bytes since uint8)
+    stride_cache_n,
+    stride_cache_p,
+    stride_out_n,
+    stride_out_p,
+    # Compile-time constants
+    L: tl.constexpr,  # kv_lora_rank, e.g. 512
+    R: tl.constexpr,  # qk_rope_head_dim, e.g. 64
+    BLOCK_SIZE: tl.constexpr,  # cache block_size (page count)
+    BLOCK_D: tl.constexpr,  # next_pow2(L)
+    BLOCK_R: tl.constexpr,  # next_pow2(R)
+    MSE_BITS: tl.constexpr,  # 3 or 4
+    MSE_BYTES: tl.constexpr,  # ceil(L * MSE_BITS / 8)
+    KV_C_BYTES: tl.constexpr,  # MSE_BYTES + 2 (vec_norm fp16)
+    NORM_CORRECTION: tl.constexpr,  # 0/1
+    KPE_FP8: tl.constexpr,  # 0=bf16, 1=fp8 e4m3 + per-token fp16 scale
+    KPE_4BIT: tl.constexpr,
+    KPE_MSE_BYTES: tl.constexpr,
+    LOG2N_R: tl.constexpr,
+    INV_SQRT_R: tl.constexpr,
+):
+    """One program = one (active_block, page).
+
+    Writes to Out_ptr[active_idx, page, :L+R]:
+      out[:L] = y_hat_normed * vec_norm   (un-rotated; caller applies @ Pi)
+      out[L:] = k_pe (bf16 reinterpret of cache[..., KV_C_BYTES:])
+    """
+    n_idx = tl.program_id(0)  # active block index
+    p_idx = tl.program_id(1)  # page within block
+
+    d_offs = tl.arange(0, BLOCK_D)
+    d_mask = d_offs < L
+
+    # ----- Address of this slot's packed bytes in the cache -----
+    slot_base = n_idx * stride_cache_n + p_idx * stride_cache_p
+
+    # ----- Bit-unpack (1 token/program — per-dim load) -----
+    bit_off = d_offs * MSE_BITS
+    byte_idx = bit_off // 8
+    bit_shift = bit_off % 8
+    umask = (1 << MSE_BITS) - 1
+
+    raw0 = tl.load(Cache_ptr + slot_base + byte_idx, mask=d_mask, other=0).to(tl.int32)
+    raw1 = tl.load(Cache_ptr + slot_base + byte_idx + 1, mask=d_mask, other=0).to(
+        tl.int32
+    )
+    raw16 = raw0 | (raw1 << 8)
+    idx = (raw16 >> bit_shift) & umask
+
+    y_hat = _tq_mla_gather_centroids_1d(
+        Centroids_ptr, idx, d_mask, BLOCK_D, MSE_BITS
+    )
+
+    # ----- Per-token scale (fp16 @ MSE_BYTES) -----
+    # NORM_CORRECTION=1: store wrote eff_scale = vec_norm / ||y_hat_raw||.
+    # NORM_CORRECTION=0: raw vec_norm.
+    n_lo = tl.load(Cache_ptr + slot_base + MSE_BYTES).to(tl.uint16)
+    n_hi = tl.load(Cache_ptr + slot_base + MSE_BYTES + 1).to(tl.uint16)
+    token_scale = (n_lo | (n_hi << 8)).to(tl.float16, bitcast=True).to(tl.float32)
+    out_kvc = (y_hat.to(tl.float32) * token_scale).to(tl.bfloat16)
+
+    # ----- Store y_hat * vec_norm into Out[..., :L] -----
+    out_base = n_idx * stride_out_n + p_idx * stride_out_p
+    tl.store(Out_ptr + out_base + d_offs, out_kvc, mask=d_mask)
+
+    # ----- Inline copy k_pe -----
+    # bf16 layout: cache[KV_C_BYTES : KV_C_BYTES + 2*R] = R bf16 elems.
+    # fp8 layout:  cache[KV_C_BYTES : KV_C_BYTES + R]   = R fp8 e4m3 elems,
+    #              cache[KV_C_BYTES + R : KV_C_BYTES + R + 2] = fp16 scale.
+    r_offs = tl.arange(0, BLOCK_R)
+    r_mask = r_offs < R
+    if KPE_4BIT:
+        kpe_y = _load_kpe_4bit_1d(
+            Cache_ptr,
+            slot_base,
+            KV_C_BYTES,
+            KPE_MSE_BYTES,
+            BLOCK_R,
+            R,
+            Kpe_centroids_ptr,
+            r_offs,
+            r_mask,
+        )
+        kpe_bf = _fwht_1d(kpe_y, BLOCK_R, LOG2N_R, INV_SQRT_R).to(tl.bfloat16)
+    elif KPE_FP8:
+        # Reload fp8 byte and bitcast to fp8e4m3 → fp32 → bf16.
+        # Then multiply per-token scale.
+        fp8_byte = tl.load(
+            Cache_ptr + slot_base + KV_C_BYTES + r_offs,
+            mask=r_mask,
+            other=0,
+        ).to(tl.uint8)
+        # bitcast uint8 → fp8 e4m3
+        kpe_fp8 = fp8_byte.to(tl.float8e4nv, bitcast=True)
+        kpe_f32 = kpe_fp8.to(tl.float32)
+        # Per-token fp16 scale at cache[KV_C_BYTES + R : KV_C_BYTES + R + 2]
+        s_lo = tl.load(Cache_ptr + slot_base + KV_C_BYTES + R).to(tl.uint16)
+        s_hi = tl.load(Cache_ptr + slot_base + KV_C_BYTES + R + 1).to(tl.uint16)
+        scale_u16 = s_lo | (s_hi << 8)
+        scale_f32 = scale_u16.to(tl.float16, bitcast=True).to(tl.float32)
+        kpe_bf = (kpe_f32 * scale_f32).to(tl.bfloat16)
+    else:
+        # bf16 path: reinterpret 2 consecutive uint8 as one bf16.
+        kpe_lo = tl.load(
+            Cache_ptr + slot_base + KV_C_BYTES + r_offs * 2,
+            mask=r_mask,
+            other=0,
+        ).to(tl.uint16)
+        kpe_hi = tl.load(
+            Cache_ptr + slot_base + KV_C_BYTES + r_offs * 2 + 1,
+            mask=r_mask,
+            other=0,
+        ).to(tl.uint16)
+        kpe_u16 = kpe_lo | (kpe_hi << 8)
+        kpe_bf = kpe_u16.to(tl.bfloat16, bitcast=True)
+    tl.store(Out_ptr + out_base + L + r_offs, kpe_bf, mask=r_mask)
+
+
+@triton.jit
+def _tq_mla_sparse_topk_gather_dequant_mse(
+    Paged_cache_ptr,  # uint8: (num_blocks, page_size, packed_bytes)
+    Topk_slots_ptr,  # int32: (batch, topk) global flat cache indices; -1 invalid
+    Centroids_ptr,
+    Kpe_centroids_ptr,
+    Out_ptr,  # bf16: (batch * topk, 1, L+R)
+    stride_cache_n,
+    stride_cache_p,
+    stride_topk_b,
+    stride_topk_k,
+    stride_out_n,
+    stride_out_p,
+    L: tl.constexpr,
+    R: tl.constexpr,
+    TOPK: tl.constexpr,
+    PAGE_SIZE: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+    BLOCK_R: tl.constexpr,
+    MSE_BITS: tl.constexpr,
+    MSE_BYTES: tl.constexpr,
+    KV_C_BYTES: tl.constexpr,
+    NORM_CORRECTION: tl.constexpr,
+    KPE_FP8: tl.constexpr,
+    KPE_4BIT: tl.constexpr,
+    KPE_MSE_BYTES: tl.constexpr,
+    LOG2N_R: tl.constexpr,
+    INV_SQRT_R: tl.constexpr,
+):
+    """One program = one (query_token, topk_slot): paged gather + MSE dequant."""
+    b_idx = tl.program_id(0)
+    k_idx = tl.program_id(1)
+
+    global_slot = tl.load(
+        Topk_slots_ptr + b_idx * stride_topk_b + k_idx * stride_topk_k
+    )
+    safe_slot = tl.where(global_slot >= 0, global_slot, 0)
+    block_idx = safe_slot // PAGE_SIZE
+    in_page = safe_slot % PAGE_SIZE
+    slot_base = block_idx * stride_cache_n + in_page * stride_cache_p
+
+    d_offs = tl.arange(0, BLOCK_D)
+    d_mask = d_offs < L
+    bit_off = d_offs * MSE_BITS
+    byte_idx = bit_off // 8
+    bit_shift = bit_off % 8
+    umask = (1 << MSE_BITS) - 1
+
+    raw0 = tl.load(
+        Paged_cache_ptr + slot_base + byte_idx, mask=d_mask, other=0
+    ).to(tl.int32)
+    raw1 = tl.load(
+        Paged_cache_ptr + slot_base + byte_idx + 1, mask=d_mask, other=0
+    ).to(tl.int32)
+    raw16 = raw0 | (raw1 << 8)
+    idx = (raw16 >> bit_shift) & umask
+
+    y_hat = _tq_mla_gather_centroids_1d(
+        Centroids_ptr, idx, d_mask, BLOCK_D, MSE_BITS
+    )
+
+    n_lo = tl.load(Paged_cache_ptr + slot_base + MSE_BYTES).to(tl.uint16)
+    n_hi = tl.load(Paged_cache_ptr + slot_base + MSE_BYTES + 1).to(tl.uint16)
+    token_scale = (n_lo | (n_hi << 8)).to(tl.float16, bitcast=True).to(tl.float32)
+    out_kvc = (y_hat.to(tl.float32) * token_scale).to(tl.bfloat16)
+
+    out_row = b_idx * TOPK + k_idx
+    out_base = out_row * stride_out_n
+
+    tl.store(Out_ptr + out_base + d_offs, out_kvc, mask=d_mask)
+
+    r_offs = tl.arange(0, BLOCK_R)
+    r_mask = r_offs < R
+    if KPE_4BIT:
+        kpe_y = _load_kpe_4bit_1d(
+            Paged_cache_ptr,
+            slot_base,
+            KV_C_BYTES,
+            KPE_MSE_BYTES,
+            BLOCK_R,
+            R,
+            Kpe_centroids_ptr,
+            r_offs,
+            r_mask,
+        )
+        kpe_bf = _fwht_1d(kpe_y, BLOCK_R, LOG2N_R, INV_SQRT_R).to(tl.bfloat16)
+    elif KPE_FP8:
+        fp8_byte = tl.load(
+            Paged_cache_ptr + slot_base + KV_C_BYTES + r_offs,
+            mask=r_mask,
+            other=0,
+        ).to(tl.uint8)
+        kpe_fp8 = fp8_byte.to(tl.float8e4nv, bitcast=True)
+        kpe_f32 = kpe_fp8.to(tl.float32)
+        s_lo = tl.load(Paged_cache_ptr + slot_base + KV_C_BYTES + R).to(tl.uint16)
+        s_hi = tl.load(Paged_cache_ptr + slot_base + KV_C_BYTES + R + 1).to(
+            tl.uint16
+        )
+        scale_u16 = s_lo | (s_hi << 8)
+        scale_f32 = scale_u16.to(tl.float16, bitcast=True).to(tl.float32)
+        kpe_bf = (kpe_f32 * scale_f32).to(tl.bfloat16)
+    else:
+        kpe_lo = tl.load(
+            Paged_cache_ptr + slot_base + KV_C_BYTES + r_offs * 2,
+            mask=r_mask,
+            other=0,
+        ).to(tl.uint16)
+        kpe_hi = tl.load(
+            Paged_cache_ptr + slot_base + KV_C_BYTES + r_offs * 2 + 1,
+            mask=r_mask,
+            other=0,
+        ).to(tl.uint16)
+        kpe_u16 = kpe_lo | (kpe_hi << 8)
+        kpe_bf = kpe_u16.to(tl.bfloat16, bitcast=True)
+    tl.store(Out_ptr + out_base + L + r_offs, kpe_bf, mask=r_mask)
+
+
+def fused_mla_sparse_topk_gather_dequant_mse(
+    paged_cache: torch.Tensor,  # (num_blocks, page_size, packed_bytes) uint8
+    global_topk: torch.Tensor,  # (batch, topk) int32 global flat indices
+    centroids_bf16: torch.Tensor,
+    out: torch.Tensor,  # (batch * topk, 1, L+R) bf16
+    *,
+    page_size: int,
+    L: int,
+    R: int,
+    mse_bits: int,
+    mse_bytes: int,
+    kv_c_bytes: int,
+    norm_correction: bool,
+    kpe_fp8: bool = False,
+    kpe_4bit: bool = False,
+    kpe_centroids_bf16: torch.Tensor | None = None,
+) -> None:
+    """Gather top-k paged slots and dequant to bf16 in one Triton launch."""
+    assert paged_cache.dtype == torch.uint8
+    assert global_topk.dtype == torch.int32
+    assert out.dtype == _BF16
+    assert centroids_bf16.dtype == _BF16
+    batch, topk = global_topk.shape
+    num_slots = batch * topk
+    assert out.shape == (num_slots, 1, L + R), (
+        f"out shape mismatch: {out.shape} vs ({num_slots}, 1, {L + R})"
+    )
+    if num_slots == 0:
+        return
+
+    kpe_cents = (
+        kpe_centroids_bf16
+        if kpe_centroids_bf16 is not None
+        else centroids_bf16[:1]
+    )
+    kpe_mse_bytes = math.ceil(R * 4 / 8) if kpe_4bit else 0
+    BLOCK_D = triton.next_power_of_2(L)
+    BLOCK_R = triton.next_power_of_2(R)
+    grid = (batch, topk)
+    _tq_mla_sparse_topk_gather_dequant_mse[grid](
+        paged_cache,
+        global_topk,
+        centroids_bf16,
+        kpe_cents,
+        out,
+        paged_cache.stride(0),
+        paged_cache.stride(1),
+        global_topk.stride(0),
+        global_topk.stride(1),
+        out.stride(0),
+        out.stride(1),
+        L=L,
+        R=R,
+        TOPK=topk,
+        PAGE_SIZE=page_size,
+        BLOCK_D=BLOCK_D,
+        BLOCK_R=BLOCK_R,
+        MSE_BITS=mse_bits,
+        MSE_BYTES=mse_bytes,
+        KV_C_BYTES=kv_c_bytes,
+        NORM_CORRECTION=1 if norm_correction else 0,
+        KPE_FP8=1 if kpe_fp8 and not kpe_4bit else 0,
+        KPE_4BIT=1 if kpe_4bit else 0,
+        KPE_MSE_BYTES=kpe_mse_bytes,
+        LOG2N_R=_log2_const(BLOCK_R),
+        INV_SQRT_R=1.0 / math.sqrt(BLOCK_R),
+        num_warps=int(os.environ.get("VLLM_TQ_GATHER_WARPS", "2")),
+        num_stages=int(os.environ.get("VLLM_TQ_GATHER_STAGES", "2")),
+    )
+
+
+def fused_mla_dequant_mse(
+    cache: torch.Tensor,  # (n_active, block_size, packed_bytes) uint8
+    centroids_bf16: torch.Tensor,  # (2**bits,) bf16
+    out: torch.Tensor,  # (n_active, block_size, L+R) bf16 (un-rotated)
+    *,
+    L: int,
+    R: int,
+    mse_bits: int,
+    mse_bytes: int,
+    kv_c_bytes: int,
+    norm_correction: bool,
+    kpe_fp8: bool = False,
+    kpe_4bit: bool = False,
+    kpe_centroids_bf16: torch.Tensor | None = None,
+) -> None:
+    """Launch the fused MSE dequant kernel.
+
+    `out[..., :L]` receives `y_hat_normed * vec_norm` — the caller must
+    apply `out[..., :L] @ Pi` (cuBLAS bf16 GEMM) to finish the inverse
+    Hadamard rotation. `out[..., L:]` receives `k_pe`.
+    """
+    assert cache.dtype == torch.uint8
+    assert out.dtype == _BF16
+    assert centroids_bf16.dtype == _BF16
+    n_active, block_size, _packed = cache.shape
+    assert out.shape == (n_active, block_size, L + R), (
+        f"out shape mismatch: {out.shape} vs ({n_active}, {block_size}, {L + R})"
+    )
+    if n_active == 0:
+        return
+
+    kpe_cents = (
+        kpe_centroids_bf16
+        if kpe_centroids_bf16 is not None
+        else centroids_bf16[:1]
+    )
+    kpe_mse_bytes = math.ceil(R * 4 / 8) if kpe_4bit else 0
+
+    BLOCK_D = triton.next_power_of_2(L)
+    BLOCK_R = triton.next_power_of_2(R)
+    grid = (n_active, block_size)
+    _tq_mla_dequant_mse[grid](
+        cache,
+        centroids_bf16,
+        kpe_cents,
+        out,
+        cache.stride(0),
+        cache.stride(1),
+        out.stride(0),
+        out.stride(1),
+        L=L,
+        R=R,
+        BLOCK_SIZE=block_size,
+        BLOCK_D=BLOCK_D,
+        BLOCK_R=BLOCK_R,
+        MSE_BITS=mse_bits,
+        MSE_BYTES=mse_bytes,
+        KV_C_BYTES=kv_c_bytes,
+        NORM_CORRECTION=1 if norm_correction else 0,
+        KPE_FP8=1 if kpe_fp8 and not kpe_4bit else 0,
+        KPE_4BIT=1 if kpe_4bit else 0,
+        KPE_MSE_BYTES=kpe_mse_bytes,
+        LOG2N_R=_log2_const(BLOCK_R),
+        INV_SQRT_R=1.0 / math.sqrt(BLOCK_R),
+        num_warps=int(os.environ.get("VLLM_TQ_GATHER_WARPS", "2")),
+        num_stages=int(os.environ.get("VLLM_TQ_GATHER_STAGES", "2")),
+    )
+
+
+# =============================================================================
+# Fused decode stage1: dequant + grouped attention in a single kernel.
+#
+# Mirrors `_fwd_grouped_kernel_stage1` in
+# `vllm/v1/attention/ops/triton_decode_attention.py` (L261-443) but consumes
+# a packed-uint8 paged TurboQuant cache directly. At each K-load site we
+# inline {bit-unpack → centroid gather → vec_norm scale} instead of reading
+# bf16, eliminating the per-layer bf16 dequant workspace. The query is
+# expected to be pre-rotated (Πq) on the caller side — see
+# `tests/kernels/attention/test_mla_turboquant_qside_rotation.py` for the
+# math identity.
+#
+# Cache slot layout (per token in `(num_blocks, block_size, packed_bytes)`):
+#     bytes [0 ... MSE_BYTES)              packed kv_c indices (MSE_BITS each)
+#     bytes [MSE_BYTES ... KV_C_BYTES)     fp16 per-token scale (MSE_BYTES + 2):
+#         norm_correction off: vec_norm
+#         norm_correction on: eff_scale = vec_norm / ||centroid(idx)||
+#     bytes [KV_C_BYTES ... )              k_pe (bf16) or k_pe (fp8 + fp16 scale)
+# =============================================================================
+
+
+@triton.autotune(
+    configs=_TQ_MLA_DECODE_AUTOTUNE_CONFIGS,
+    # Bench only when *static* deployment shape changes. batch / seq_len / etc.
+    # intentionally excluded — those vary every step and re-benchmarking inside
+    # CUDA Graph capture would error out.
+    key=["L", "R", "MSE_BITS", "KEY_FP8", "KPE_FP8", "q_head_num"],
+)
+@triton.jit
+def _fwd_grouped_kernel_stage1_tq(
+    Q,  # bf16: (batch, q_head_num, Lk) Lk=L+R; q is Π-rotated on the L slice
+    K_Cache,  # uint8: (num_blocks, block_size, packed_bytes)
+    Centroids_ptr,  # bf16: (2**MSE_BITS,) Lloyd-Max codebook
+    Kpe_centroids_ptr,  # bf16: (16,) for k_pe 4-bit
+    sm_scale,
+    Req_to_tokens,  # int32: (batch, max_kv_pages) -> page index
+    B_Seqlen,
+    Att_Out,
+    stride_req_to_tokens_b,
+    stride_qbs,
+    stride_qh,
+    stride_cache_n,  # bytes per page block (block_size * packed_bytes)
+    stride_cache_p,  # bytes per token slot (packed_bytes)
+    stride_mid_ob,
+    stride_mid_oh,
+    stride_mid_os,
+    q_head_num: tl.constexpr,
+    BLOCK_DMODEL: tl.constexpr,  # next_pow2(L)
+    BLOCK_DPE: tl.constexpr,  # next_pow2(R)
+    BLOCK_DV: tl.constexpr,  # = BLOCK_DMODEL (MLA: V is L slice of kv_c)
+    BLOCK_N: tl.constexpr,
+    BLOCK_H: tl.constexpr,
+    NUM_KV_SPLITS: tl.constexpr,
+    PAGE_SIZE: tl.constexpr,
+    logit_cap: tl.constexpr,
+    L: tl.constexpr,  # kv_lora_rank
+    R: tl.constexpr,  # qk_rope_head_dim
+    MSE_BITS: tl.constexpr,
+    MSE_BYTES: tl.constexpr,
+    KV_C_BYTES: tl.constexpr,
+    NORM_CORRECTION: tl.constexpr,
+    KPE_FP8: tl.constexpr,
+    KPE_4BIT: tl.constexpr,
+    KPE_MSE_BYTES: tl.constexpr,
+    QPE_FWHT_IN_KERNEL: tl.constexpr,
+    LOG2N_R: tl.constexpr,
+    INV_SQRT_R: tl.constexpr,
+    KEY_FP8: tl.constexpr,
+    K_SCALE: tl.constexpr,
+):
+    """One program = (batch, head_block, kv_split). Heads are grouped via BLOCK_H
+    just like the upstream stage1; KV is reduced one BLOCK_N tile at a time.
+
+    KEY_FP8=1: kv_c bytes are L fp8 e4m3 elems (no Hadamard, no vec_norm,
+    no centroid). The layer-global K_SCALE compile-time constant is multiplied
+    into the bf16 K tile (and therefore into V via the MLA K==V identity)
+    so output magnitude matches the bf16-workspace baseline that pre-scales
+    the cache.
+    """
+    cur_batch = tl.program_id(0)
+    cur_head_id = tl.program_id(1)
+    split_kv_id = tl.program_id(2)
+
+    # MLA: kv_group_num == q_head_num (single shared kv_c).
+    cur_head = cur_head_id * BLOCK_H + tl.arange(0, BLOCK_H)
+    mask_h = cur_head < q_head_num
+
+    offs_d = tl.arange(0, BLOCK_DMODEL)
+    mask_d = offs_d < L
+    offs_dpe = L + tl.arange(0, BLOCK_DPE)
+    mask_dpe = offs_dpe < (L + R)
+
+    cur_batch_seq_len = tl.load(B_Seqlen + cur_batch)
+
+    # Load the (already Π-rotated) query.
+    offs_q = cur_batch * stride_qbs + cur_head[:, None] * stride_qh + offs_d[None, :]
+    q = tl.load(
+        Q + offs_q,
+        mask=mask_h[:, None] & mask_d[None, :],
+        other=0.0,
+        cache_modifier=".ca",
+    )
+    off_qpe = cur_batch * stride_qbs + cur_head[:, None] * stride_qh + offs_dpe[None, :]
+    qpe = tl.load(
+        Q + off_qpe,
+        mask=mask_h[:, None] & mask_dpe[None, :],
+        other=0.0,
+        cache_modifier=".ca",
+    )
+    if KPE_4BIT and QPE_FWHT_IN_KERNEL:
+        qpe = _fwht_qpe_tile(
+            qpe, mask_h, BLOCK_H, BLOCK_DPE, R, LOG2N_R, INV_SQRT_R
+        )
+
+    kv_len_per_split = tl.cdiv(cur_batch_seq_len, NUM_KV_SPLITS)
+    split_kv_start = kv_len_per_split * split_kv_id
+    split_kv_end = tl.minimum(split_kv_start + kv_len_per_split, cur_batch_seq_len)
+
+    e_max = tl.zeros([BLOCK_H], dtype=tl.float32) - float("inf")
+    e_sum = tl.zeros([BLOCK_H], dtype=tl.float32)
+    acc = tl.zeros([BLOCK_H, BLOCK_DV], dtype=tl.float32)
+
+    # Bit-unpack constants.
+    bit_off = offs_d * MSE_BITS  # (BLOCK_DMODEL,)
+    byte_idx = bit_off // 8
+    bit_shift = bit_off % 8
+    umask = (1 << MSE_BITS) - 1
+
+    if split_kv_end > split_kv_start:
+        for start_n in tl.range(split_kv_start, split_kv_end, BLOCK_N):
+            offs_n = start_n + tl.arange(0, BLOCK_N)
+            n_mask = offs_n < split_kv_end
+
+            kv_page = tl.load(
+                Req_to_tokens
+                + stride_req_to_tokens_b * cur_batch
+                + offs_n // PAGE_SIZE,
+                mask=n_mask,
+                other=0,
+                cache_modifier=".ca",
+            )
+            kv_in_page = offs_n % PAGE_SIZE
+            slot_base = kv_page * stride_cache_n + kv_in_page * stride_cache_p
+            # slot_base shape (BLOCK_N,); we need (BLOCK_DMODEL, BLOCK_N).
+            sb = slot_base[None, :]
+            bi = byte_idx[:, None]
+            bs = bit_shift[:, None]
+            d_full_mask = mask_d[:, None] & n_mask[None, :]
+            token_scale = tl.full([BLOCK_N], 1.0, dtype=tl.float32)
+
+            if KEY_FP8:
+                # K3: FP8 keys — load fp8 byte directly, bitcast to fp8e4nv,
+                # cast to fp32, multiply by layer-global K_SCALE, cast to bf16.
+                # Both qk and v share this scaled K (MLA K==V), matching the
+                # bf16-workspace baseline that bakes k_scale into the cache.
+                fp8_k = tl.load(
+                    K_Cache + sb + offs_d[:, None],
+                    mask=d_full_mask,
+                    other=0,
+                    cache_modifier=".cg",
+                ).to(tl.uint8)
+                y_hat = fp8_k.to(tl.float8e4nv, bitcast=True).to(tl.float32)
+                y_hat = y_hat * K_SCALE
+                k = y_hat.to(q.dtype)
+                qk = tl.dot(q, k)
+            else:
+                # Bit-unpack (per-dim loads; bulk pack[idx] unsupported in Triton).
+                raw0 = tl.load(
+                    K_Cache + sb + bi,
+                    mask=d_full_mask,
+                    other=0,
+                    cache_modifier=".cg",
+                ).to(tl.int32)
+                raw1 = tl.load(
+                    K_Cache + sb + bi + 1,
+                    mask=d_full_mask,
+                    other=0,
+                    cache_modifier=".cg",
+                ).to(tl.int32)
+                raw16 = raw0 | (raw1 << 8)
+                idx = (raw16 >> bs) & umask
+
+                y_hat = _tq_mla_gather_centroids(
+                    Centroids_ptr,
+                    idx,
+                    d_full_mask,
+                    BLOCK_DMODEL,
+                    BLOCK_N,
+                    MSE_BITS,
+                )
+
+                # fp16 @ MSE_BYTES: vec_norm, or eff_scale if NC precomputed at store.
+                token_scale = _tq_mla_load_fp16_scale(
+                    K_Cache, slot_base, MSE_BYTES, n_mask
+                )
+
+                k = y_hat
+                qk = tl.dot(q, k)
+                qk = qk * token_scale[None, :]
+
+            # ----- k_pe path -----
+            r_offs = tl.arange(0, BLOCK_DPE)
+            r_mask = r_offs < R
+            r_full_mask = r_mask[:, None] & n_mask[None, :]
+            if KPE_4BIT:
+                kpe = _load_kpe_4bit_tile(
+                    K_Cache,
+                    sb,
+                    slot_base,
+                    KV_C_BYTES,
+                    KPE_MSE_BYTES,
+                    BLOCK_DPE,
+                    BLOCK_N,
+                    R,
+                    Kpe_centroids_ptr,
+                    r_offs,
+                    r_mask,
+                    n_mask,
+                )
+            elif KPE_FP8:
+                fp8_byte = tl.load(
+                    K_Cache + sb + KV_C_BYTES + r_offs[:, None],
+                    mask=r_full_mask,
+                    other=0,
+                    cache_modifier=".cg",
+                ).to(tl.uint8)
+                kpe_f32 = fp8_byte.to(tl.float8e4nv, bitcast=True).to(tl.float32)
+                s_lo = tl.load(
+                    K_Cache + slot_base + KV_C_BYTES + R, mask=n_mask, other=0
+                ).to(tl.uint16)
+                s_hi = tl.load(
+                    K_Cache + slot_base + KV_C_BYTES + R + 1, mask=n_mask, other=0
+                ).to(tl.uint16)
+                scale = (s_lo | (s_hi << 8)).to(tl.float16, bitcast=True).to(tl.float32)
+                kpe = (kpe_f32 * scale[None, :]).to(qpe.dtype)
+            else:
+                kpe_lo = tl.load(
+                    K_Cache + sb + KV_C_BYTES + r_offs[:, None] * 2,
+                    mask=r_full_mask,
+                    other=0,
+                    cache_modifier=".cg",
+                ).to(tl.uint16)
+                kpe_hi = tl.load(
+                    K_Cache + sb + KV_C_BYTES + r_offs[:, None] * 2 + 1,
+                    mask=r_full_mask,
+                    other=0,
+                    cache_modifier=".cg",
+                ).to(tl.uint16)
+                kpe_u16 = kpe_lo | (kpe_hi << 8)
+                kpe = kpe_u16.to(tl.bfloat16, bitcast=True).to(qpe.dtype)
+
+            qk += tl.dot(qpe, kpe)
+            qk *= sm_scale
+
+            if logit_cap > 0:
+                qk = logit_cap * (
+                    (tl.exp(qk / logit_cap) - tl.exp(-qk / logit_cap))
+                    / (tl.exp(qk / logit_cap) + tl.exp(-qk / logit_cap))
+                )
+
+            qk = tl.where(mask_h[:, None] & n_mask[None, :], qk, float("-inf"))
+
+            # MLA reuses k as v (transposed).
+            v = tl.trans(k)
+
+            n_e_max = tl.maximum(tl.max(qk, 1), e_max)
+            re_scale = tl.exp(e_max - n_e_max)
+            p = tl.exp(qk - n_e_max[:, None])
+            acc *= re_scale[:, None]
+            # K1-a value-path correction: in the MSE branch K is stored as
+            # un-scaled centroid `y_hat` (vec_norm is folded into qk *after*
+            # the dot to save a (BLOCK_DMODEL, BLOCK_N) multiply). Since
+            # `v = trans(k) = trans(y_hat)` is also missing vec_norm, the
+            # accumulator must apply vec_norm here — mathematically:
+            #   sum_n p_n * (y_hat_n * vn_n) = sum_n (p_n * vn_n) * y_hat_n
+            # so we scale p (shape (BLOCK_H, BLOCK_N), small) instead of v.
+            # KEY_FP8 path bakes K_SCALE into y_hat before the cast, so v
+            # already carries the correct scale and no correction is needed.
+            if KEY_FP8:
+                p_for_v = p.to(v.dtype)
+            else:
+                p_for_v = (p * token_scale[None, :]).to(v.dtype)
+            acc += tl.dot(p_for_v, v)
+            e_sum = e_sum * re_scale + tl.sum(p, 1)
+            e_max = n_e_max
+
+        offs_mid_o = (
+            cur_batch * stride_mid_ob
+            + cur_head[:, None] * stride_mid_oh
+            + split_kv_id * stride_mid_os
+            + offs_d[None, :]
+        )
+        tl.store(
+            Att_Out + offs_mid_o,
+            acc / e_sum[:, None],
+            mask=mask_h[:, None] & mask_d[None, :],
+        )
+        offs_lse = (
+            cur_batch * stride_mid_ob
+            + cur_head * stride_mid_oh
+            + split_kv_id * stride_mid_os
+            + L
+        )
+        tl.store(Att_Out + offs_lse, e_max + tl.log(e_sum), mask=mask_h)
+
+
+def fused_mla_tq_decode_stage1(
+    q: torch.Tensor,  # bf16: (batch, q_head_num, L+R), Π-rotated on [:L]
+    cache: torch.Tensor,  # uint8: (num_blocks, block_size, packed_bytes)
+    centroids_bf16: torch.Tensor,  # bf16: (2**MSE_BITS,) or empty when key_fp8
+    att_out: torch.Tensor,  # fp32: (batch, q_head_num, NUM_KV_SPLITS, L+1)
+    req_to_tokens: torch.Tensor,  # int32: (batch, max_kv_pages)
+    b_seqlen: torch.Tensor,  # int32: (batch,)
+    *,
+    sm_scale: float,
+    page_size: int,
+    L: int,
+    R: int,
+    mse_bits: int,
+    mse_bytes: int,
+    kv_c_bytes: int,
+    norm_correction: bool,
+    kpe_fp8: bool,
+    kpe_4bit: bool = False,
+    kpe_centroids_bf16: torch.Tensor | None = None,
+    key_fp8: bool = False,
+    k_scale: float = 1.0,
+    num_kv_splits: int = 4,
+    logit_cap: float = 0.0,
+) -> None:
+    """Launch the fused TurboQuant MLA decode stage1.
+
+    MSE keys (default): `q` must be the standard MLA decode query with the
+    Hadamard rotation applied to its first L (kv_lora_rank) elements; the
+    kernel does no rotation internally.
+
+    FP8 keys (`key_fp8=True`): cache layout is `[L bytes fp8 e4m3 | k_pe...]`.
+    No Hadamard rotation; q is consumed as-is. The layer-global `k_scale`
+    is passed as a kernel constexpr and multiplied into the bf16 K tile
+    inside the kernel (so V = trans(K) inherits the same scale, preserving
+    MLA K==V semantics). centroids_bf16 is unused in this mode (pass any
+    bf16 1-D tensor; e.g. an empty one).
+    """
+    assert cache.dtype == torch.uint8
+    assert q.dtype == torch.bfloat16
+    assert centroids_bf16.dtype == torch.bfloat16
+    batch, q_head_num, head_dim = q.shape
+    assert head_dim == L + R, f"q head_dim {head_dim} != L+R {L + R}"
+
+    if kpe_4bit and not tq_mla_qpe_fwht_in_kernel_enabled():
+        q = _rotate_qpe_for_kpe_4bit(q, L, R, kpe_4bit)
+
+    BLOCK_DMODEL = triton.next_power_of_2(L)
+    BLOCK_DPE = triton.next_power_of_2(R)
+    BLOCK_DV = BLOCK_DMODEL
+    kpe_cents = (
+        kpe_centroids_bf16
+        if kpe_centroids_bf16 is not None
+        else centroids_bf16[:1]
+    )
+    kpe_mse_bytes = math.ceil(R * 4 / 8) if kpe_4bit else 0
+
+    # P1: BLOCK_N / BLOCK_H / num_warps / num_stages are now provided by the
+    # autotune Config chosen at first call. Grid's second dim depends on the
+    # autotuned BLOCK_H, so it must be a callable (`meta` carries the picked
+    # config). Same pattern as vllm/model_executor/layers/fla/ops/chunk_o.py.
+    def _grid(meta):
+        return (
+            batch,
+            triton.cdiv(q_head_num, meta["BLOCK_H"]),
+            num_kv_splits,
+        )
+
+    # FP8 path: K_SCALE is a constexpr multiplied into the K tile (and so
+    # into V) inside the kernel. MSE path: K_SCALE unused (DCE'd by Triton).
+    _fwd_grouped_kernel_stage1_tq[_grid](
+        q,
+        cache,
+        centroids_bf16,
+        kpe_cents,
+        sm_scale,
+        req_to_tokens,
+        b_seqlen,
+        att_out,
+        req_to_tokens.stride(0),
+        q.stride(0),
+        q.stride(1),
+        cache.stride(0),
+        cache.stride(1),
+        att_out.stride(0),
+        att_out.stride(1),
+        att_out.stride(2),
+        q_head_num=q_head_num,
+        BLOCK_DMODEL=BLOCK_DMODEL,
+        BLOCK_DPE=BLOCK_DPE,
+        BLOCK_DV=BLOCK_DV,
+        # BLOCK_N, BLOCK_H, num_warps, num_stages: injected by autotune Config.
+        NUM_KV_SPLITS=num_kv_splits,
+        PAGE_SIZE=page_size,
+        logit_cap=logit_cap,
+        L=L,
+        R=R,
+        MSE_BITS=mse_bits,
+        MSE_BYTES=mse_bytes,
+        KV_C_BYTES=kv_c_bytes,
+        NORM_CORRECTION=1 if norm_correction else 0,
+        KPE_FP8=1 if kpe_fp8 and not kpe_4bit else 0,
+        KPE_4BIT=1 if kpe_4bit else 0,
+        KPE_MSE_BYTES=kpe_mse_bytes,
+        QPE_FWHT_IN_KERNEL=_qpe_fwht_in_kernel_flag(kpe_4bit),
+        LOG2N_R=_log2_const(BLOCK_DPE),
+        INV_SQRT_R=1.0 / math.sqrt(BLOCK_DPE),
+        KEY_FP8=1 if key_fp8 else 0,
+        K_SCALE=k_scale,
+    )
+
+
+# =============================================================================
+# Fused sparse decode stage1: inline dequant over indexer top-k global slots.
+#
+# Same inner dequant/attention loop as `_fwd_grouped_kernel_stage1_tq`, but
+# KV positions come from `Topk_slots` (global flat cache indices from
+# `triton_convert_req_index_to_global_index`) instead of a dense page table +
+# seq_len walk. Invalid slots (-1) are masked out of the softmax.
+# =============================================================================
+
+
+@triton.autotune(
+    configs=_TQ_MLA_SPARSE_DECODE_AUTOTUNE_CONFIGS,
+    key=["L", "R", "MSE_BITS", "KEY_FP8", "KPE_FP8", "q_head_num", "TOPK", "NUM_KV_SPLITS"],
+)
+@triton.jit
+def _fwd_grouped_kernel_stage1_tq_sparse(
+    Q,
+    K_Cache,
+    Centroids_ptr,
+    Kpe_centroids_ptr,
+    sm_scale,
+    Topk_slots,  # int32: (batch, TOPK) global flat cache indices; -1 = invalid
+    Att_Out,
+    stride_topk_b,
+    stride_qbs,
+    stride_qh,
+    stride_cache_n,
+    stride_cache_p,
+    stride_mid_ob,
+    stride_mid_oh,
+    stride_mid_os,
+    q_head_num: tl.constexpr,
+    BLOCK_DMODEL: tl.constexpr,
+    BLOCK_DPE: tl.constexpr,
+    BLOCK_DV: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_H: tl.constexpr,
+    NUM_KV_SPLITS: tl.constexpr,
+    PAGE_SIZE: tl.constexpr,
+    TOPK: tl.constexpr,
+    logit_cap: tl.constexpr,
+    L: tl.constexpr,
+    R: tl.constexpr,
+    MSE_BITS: tl.constexpr,
+    MSE_BYTES: tl.constexpr,
+    KV_C_BYTES: tl.constexpr,
+    NORM_CORRECTION: tl.constexpr,
+    KPE_FP8: tl.constexpr,
+    KPE_4BIT: tl.constexpr,
+    KPE_MSE_BYTES: tl.constexpr,
+    QPE_FWHT_IN_KERNEL: tl.constexpr,
+    LOG2N_R: tl.constexpr,
+    INV_SQRT_R: tl.constexpr,
+    KEY_FP8: tl.constexpr,
+    K_SCALE: tl.constexpr,
+):
+    cur_batch = tl.program_id(0)
+    cur_head_id = tl.program_id(1)
+    split_kv_id = tl.program_id(2)
+
+    cur_head = cur_head_id * BLOCK_H + tl.arange(0, BLOCK_H)
+    mask_h = cur_head < q_head_num
+
+    offs_d = tl.arange(0, BLOCK_DMODEL)
+    mask_d = offs_d < L
+    offs_dpe = L + tl.arange(0, BLOCK_DPE)
+    mask_dpe = offs_dpe < (L + R)
+
+    cur_batch_seq_len = TOPK
+
+    offs_q = cur_batch * stride_qbs + cur_head[:, None] * stride_qh + offs_d[None, :]
+    q = tl.load(
+        Q + offs_q,
+        mask=mask_h[:, None] & mask_d[None, :],
+        other=0.0,
+        cache_modifier=".ca",
+    )
+    off_qpe = cur_batch * stride_qbs + cur_head[:, None] * stride_qh + offs_dpe[None, :]
+    qpe = tl.load(
+        Q + off_qpe,
+        mask=mask_h[:, None] & mask_dpe[None, :],
+        other=0.0,
+        cache_modifier=".ca",
+    )
+    if KPE_4BIT and QPE_FWHT_IN_KERNEL:
+        qpe = _fwht_qpe_tile(
+            qpe, mask_h, BLOCK_H, BLOCK_DPE, R, LOG2N_R, INV_SQRT_R
+        )
+
+    kv_len_per_split = tl.cdiv(cur_batch_seq_len, NUM_KV_SPLITS)
+    split_kv_start = kv_len_per_split * split_kv_id
+    split_kv_end = tl.minimum(split_kv_start + kv_len_per_split, cur_batch_seq_len)
+
+    e_max = tl.zeros([BLOCK_H], dtype=tl.float32) - float("inf")
+    e_sum = tl.zeros([BLOCK_H], dtype=tl.float32)
+    acc = tl.zeros([BLOCK_H, BLOCK_DV], dtype=tl.float32)
+
+    bit_off = offs_d * MSE_BITS
+    byte_idx = bit_off // 8
+    bit_shift = bit_off % 8
+    umask = (1 << MSE_BITS) - 1
+
+    if split_kv_end > split_kv_start:
+        for start_n in tl.range(split_kv_start, split_kv_end, BLOCK_N):
+            offs_n = start_n + tl.arange(0, BLOCK_N)
+            n_mask = offs_n < split_kv_end
+
+            global_slot = tl.load(
+                Topk_slots + cur_batch * stride_topk_b + offs_n,
+                mask=n_mask,
+                other=-1,
+            )
+            valid_slot = global_slot >= 0
+            n_mask = n_mask & valid_slot
+            safe_slot = tl.where(valid_slot, global_slot, 0)
+            block_idx = safe_slot // PAGE_SIZE
+            in_page = safe_slot % PAGE_SIZE
+            slot_base = block_idx * stride_cache_n + in_page * stride_cache_p
+            sb = slot_base[None, :]
+            bi = byte_idx[:, None]
+            bs = bit_shift[:, None]
+            d_full_mask = mask_d[:, None] & n_mask[None, :]
+            token_scale = tl.full([BLOCK_N], 1.0, dtype=tl.float32)
+
+            if KEY_FP8:
+                fp8_k = tl.load(
+                    K_Cache + sb + offs_d[:, None],
+                    mask=d_full_mask,
+                    other=0,
+                    cache_modifier=".cg",
+                ).to(tl.uint8)
+                y_hat = fp8_k.to(tl.float8e4nv, bitcast=True).to(tl.float32)
+                y_hat = y_hat * K_SCALE
+                k = y_hat.to(q.dtype)
+                qk = tl.dot(q, k)
+            else:
+                raw0 = tl.load(
+                    K_Cache + sb + bi,
+                    mask=d_full_mask,
+                    other=0,
+                    cache_modifier=".cg",
+                ).to(tl.int32)
+                raw1 = tl.load(
+                    K_Cache + sb + bi + 1,
+                    mask=d_full_mask,
+                    other=0,
+                    cache_modifier=".cg",
+                ).to(tl.int32)
+                raw16 = raw0 | (raw1 << 8)
+                idx = (raw16 >> bs) & umask
+
+                y_hat = _tq_mla_gather_centroids(
+                    Centroids_ptr,
+                    idx,
+                    d_full_mask,
+                    BLOCK_DMODEL,
+                    BLOCK_N,
+                    MSE_BITS,
+                )
+
+                token_scale = _tq_mla_load_fp16_scale(
+                    K_Cache, slot_base, MSE_BYTES, n_mask
+                )
+
+                # Hybrid sparse: caller pre-rotates q with Pi; keep y_hat unrotated
+                # here (equiv. to legacy apply_pi_on_k on K outside the kernel).
+                k = y_hat
+                qk = tl.dot(q, k)
+                qk = qk * token_scale[None, :]
+
+            r_offs = tl.arange(0, BLOCK_DPE)
+            r_mask = r_offs < R
+            r_full_mask = r_mask[:, None] & n_mask[None, :]
+            if KPE_4BIT:
+                kpe = _load_kpe_4bit_tile(
+                    K_Cache,
+                    sb,
+                    slot_base,
+                    KV_C_BYTES,
+                    KPE_MSE_BYTES,
+                    BLOCK_DPE,
+                    BLOCK_N,
+                    R,
+                    Kpe_centroids_ptr,
+                    r_offs,
+                    r_mask,
+                    n_mask,
+                )
+            elif KPE_FP8:
+                fp8_byte = tl.load(
+                    K_Cache + sb + KV_C_BYTES + r_offs[:, None],
+                    mask=r_full_mask,
+                    other=0,
+                    cache_modifier=".cg",
+                ).to(tl.uint8)
+                kpe_f32 = fp8_byte.to(tl.float8e4nv, bitcast=True).to(tl.float32)
+                s_lo = tl.load(
+                    K_Cache + slot_base + KV_C_BYTES + R, mask=n_mask, other=0
+                ).to(tl.uint16)
+                s_hi = tl.load(
+                    K_Cache + slot_base + KV_C_BYTES + R + 1, mask=n_mask, other=0
+                ).to(tl.uint16)
+                scale = (s_lo | (s_hi << 8)).to(tl.float16, bitcast=True).to(tl.float32)
+                kpe = (kpe_f32 * scale[None, :]).to(qpe.dtype)
+            else:
+                kpe_lo = tl.load(
+                    K_Cache + sb + KV_C_BYTES + r_offs[:, None] * 2,
+                    mask=r_full_mask,
+                    other=0,
+                    cache_modifier=".cg",
+                ).to(tl.uint16)
+                kpe_hi = tl.load(
+                    K_Cache + sb + KV_C_BYTES + r_offs[:, None] * 2 + 1,
+                    mask=r_full_mask,
+                    other=0,
+                    cache_modifier=".cg",
+                ).to(tl.uint16)
+                kpe_u16 = kpe_lo | (kpe_hi << 8)
+                kpe = kpe_u16.to(tl.bfloat16, bitcast=True).to(qpe.dtype)
+
+            qk += tl.dot(qpe, kpe)
+            qk *= sm_scale
+
+            if logit_cap > 0:
+                qk = logit_cap * (
+                    (tl.exp(qk / logit_cap) - tl.exp(-qk / logit_cap))
+                    / (tl.exp(qk / logit_cap) + tl.exp(-qk / logit_cap))
+                )
+
+            qk = tl.where(mask_h[:, None] & n_mask[None, :], qk, float("-inf"))
+
+            v = tl.trans(k)
+
+            # Skip softmax update when a row's tile is all masked (-inf only).
+            # Otherwise exp(e_max - n_e_max) becomes exp(-inf - (-inf)) = NaN.
+            row_max = tl.max(qk, 1)
+            has_active = row_max > float("-inf")
+            n_e_max = tl.maximum(row_max, e_max)
+            safe_n_e_max = tl.where(has_active, n_e_max, 0.0)
+            re_scale = tl.where(has_active, tl.exp(e_max - safe_n_e_max), 1.0)
+            p = tl.where(
+                has_active[:, None],
+                tl.exp(qk - safe_n_e_max[:, None]),
+                0.0,
+            )
+            acc *= re_scale[:, None]
+            if KEY_FP8:
+                p_for_v = p.to(v.dtype)
+            else:
+                p_for_v = (p * token_scale[None, :]).to(v.dtype)
+            acc += tl.dot(p_for_v, v)
+            e_sum = tl.where(has_active, e_sum * re_scale + tl.sum(p, 1), e_sum)
+            e_max = tl.where(has_active, n_e_max, e_max)
+
+        safe_e_sum = tl.maximum(e_sum, 1e-6)
+        valid_split = e_max > float("-inf")
+        offs_mid_o = (
+            cur_batch * stride_mid_ob
+            + cur_head[:, None] * stride_mid_oh
+            + split_kv_id * stride_mid_os
+            + offs_d[None, :]
+        )
+        tl.store(
+            Att_Out + offs_mid_o,
+            tl.where(valid_split[:, None], acc / safe_e_sum[:, None], 0.0),
+            mask=mask_h[:, None] & mask_d[None, :],
+        )
+        offs_lse = (
+            cur_batch * stride_mid_ob
+            + cur_head * stride_mid_oh
+            + split_kv_id * stride_mid_os
+            + L
+        )
+        tl.store(
+            Att_Out + offs_lse,
+            tl.where(valid_split, e_max + tl.log(safe_e_sum), float("-inf")),
+            mask=mask_h,
+        )
+
+
+def fused_mla_tq_sparse_decode_stage1(
+    q: torch.Tensor,  # bf16: (batch, q_head_num, L+R)
+    cache: torch.Tensor,  # uint8: (num_blocks, block_size, packed_bytes)
+    centroids_bf16: torch.Tensor,
+    att_out: torch.Tensor,  # fp32: (batch, q_head_num, NUM_KV_SPLITS, L+1)
+    topk_slots: torch.Tensor,  # int32: (batch, TOPK) global flat cache indices
+    b_seqlen: torch.Tensor,  # int32: (batch,) — should be TOPK for stage2 splits
+    *,
+    sm_scale: float,
+    page_size: int,
+    topk: int,
+    L: int,
+    R: int,
+    mse_bits: int,
+    mse_bytes: int,
+    kv_c_bytes: int,
+    norm_correction: bool,
+    kpe_fp8: bool,
+    kpe_4bit: bool = False,
+    kpe_centroids_bf16: torch.Tensor | None = None,
+    key_fp8: bool = False,
+    k_scale: float = 1.0,
+    num_kv_splits: int = 4,
+    logit_cap: float = 0.0,
+) -> None:
+    """Launch fused TurboQuant MLA sparse decode stage1 over top-k slots."""
+    assert cache.dtype == torch.uint8
+    assert q.dtype == torch.bfloat16
+    assert centroids_bf16.dtype == torch.bfloat16
+    assert topk_slots.dtype == torch.int32
+    batch, q_head_num, head_dim = q.shape
+    assert head_dim == L + R, f"q head_dim {head_dim} != L+R {L + R}"
+    assert topk_slots.shape == (batch, topk)
+
+    if kpe_4bit and not tq_mla_qpe_fwht_in_kernel_enabled():
+        q = _rotate_qpe_for_kpe_4bit(q, L, R, kpe_4bit)
+
+    BLOCK_DMODEL = triton.next_power_of_2(L)
+    BLOCK_DPE = triton.next_power_of_2(R)
+    BLOCK_DV = BLOCK_DMODEL
+    kpe_cents = (
+        kpe_centroids_bf16
+        if kpe_centroids_bf16 is not None
+        else centroids_bf16[:1]
+    )
+    kpe_mse_bytes = math.ceil(R * 4 / 8) if kpe_4bit else 0
+
+    def _grid(meta):
+        return (
+            batch,
+            triton.cdiv(q_head_num, meta["BLOCK_H"]),
+            num_kv_splits,
+        )
+
+    _fwd_grouped_kernel_stage1_tq_sparse[_grid](
+        q,
+        cache,
+        centroids_bf16,
+        kpe_cents,
+        sm_scale,
+        topk_slots,
+        att_out,
+        topk_slots.stride(0),
+        q.stride(0),
+        q.stride(1),
+        cache.stride(0),
+        cache.stride(1),
+        att_out.stride(0),
+        att_out.stride(1),
+        att_out.stride(2),
+        q_head_num=q_head_num,
+        BLOCK_DMODEL=BLOCK_DMODEL,
+        BLOCK_DPE=BLOCK_DPE,
+        BLOCK_DV=BLOCK_DV,
+        NUM_KV_SPLITS=num_kv_splits,
+        PAGE_SIZE=page_size,
+        TOPK=topk,
+        logit_cap=logit_cap,
+        L=L,
+        R=R,
+        MSE_BITS=mse_bits,
+        MSE_BYTES=mse_bytes,
+        KV_C_BYTES=kv_c_bytes,
+        NORM_CORRECTION=1 if norm_correction else 0,
+        KPE_FP8=1 if kpe_fp8 and not kpe_4bit else 0,
+        KPE_4BIT=1 if kpe_4bit else 0,
+        KPE_MSE_BYTES=kpe_mse_bytes,
+        QPE_FWHT_IN_KERNEL=_qpe_fwht_in_kernel_flag(kpe_4bit),
+        LOG2N_R=_log2_const(BLOCK_DPE),
+        INV_SQRT_R=1.0 / math.sqrt(BLOCK_DPE),
+        KEY_FP8=1 if key_fp8 else 0,
+        K_SCALE=k_scale,
+    )
+
+
+def tq_mla_sparse_adaptive_enabled() -> bool:
+    return os.environ.get("VLLM_TQ_MLA_SPARSE_ADAPTIVE", "1") == "1"
+
+
+def tq_mla_sparse_split_count(
+    topk: int, sm_count: int, batch: int | None = None
+) -> int:
+    """Resolve sparse decode split count (aligned with vllm-tqa).
+
+    Priority:
+      1) fixed override (``VLLM_TQ_MLA_SPARSE_SPLITS``)
+      2) adaptive policy (when ``batch`` given): keep ``B * splits`` bounded
+      3) static default (~64 for topk=2048, bounded by ``2*SM``)
+    """
+    fixed = os.environ.get("VLLM_TQ_MLA_SPARSE_SPLITS", "")
+    if fixed.isdigit() and int(fixed) > 0:
+        return max(1, min(int(fixed), topk, sm_count * 2))
+
+    if batch is not None and tq_mla_sparse_adaptive_enabled():
+        # Adaptive: target ~OVERSUB*sm_count total grid programs (B x splits).
+        # batch large -> splits small; batch small -> splits up to 64.
+        # f32 scratch scales with B*splits, not B*64.
+        target = sm_count * 4  # caller passes sm_count*2 => ~8x SM oversubscribe
+        ideal = max(1, target // max(1, batch))
+        ideal = 1 << (ideal.bit_length() - 1)  # floor to power of 2
+        return max(1, min(ideal, 64, topk))
+
+    ideal = max(1, topk // 32)
+    ideal = 1 << (ideal - 1).bit_length()
+    return min(ideal, sm_count * 2)
+
+
+def sparse_decode_softmax_reducev_fwd(
+    logits: torch.Tensor,
+    q: torch.Tensor,
+    o: torch.Tensor,
+    lse: torch.Tensor,
+    v_buffer: torch.Tensor,
+    b_seq_len: torch.Tensor,
+    num_kv_splits: int,
+) -> None:
+    """Serial sparse stage2 softmax + reduce-v."""
+    from vllm.v1.attention.ops.triton_decode_attention import (
+        _decode_softmax_reducev_fwd,
+    )
+
+    _decode_softmax_reducev_fwd(
+        logits, q, o, lse, v_buffer, b_seq_len, num_kv_splits
+    )

--- a/vllm/v1/attention/ops/triton_turboquant_mla_store.py
+++ b/vllm/v1/attention/ops/triton_turboquant_mla_store.py
@@ -1,0 +1,706 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Fused TurboQuant MLA KV-cache store (decode hot path).
+
+Hybrid launch (default): one batched ``y = x_hat @ Pi`` GEMM plus a single
+Triton kernel for bucketize -> pack -> scale -> k_pe -> scatter.
+
+``turboquant_*_nc`` presets enable FWHT store + k_pe 4-bit automatically
+(see ``tq_mla_defaults.py``).  Env vars ``VLLM_TQ_MLA_STORE_FWHT`` /
+``VLLM_TQ_KPE_4BIT`` are opt-out regression anchors only (``=0``).
+
+Set ``VLLM_TQ_MLA_FUSED_STORE=0`` to fall back to the legacy PyTorch path.
+"""
+
+from __future__ import annotations
+
+import math
+import os
+
+import torch
+
+from vllm.triton_utils import tl, triton
+
+_TQ_MLA_STORE_DISABLE_AUTOTUNE = (
+    os.environ.get("VLLM_TQ_MLA_STORE_AUTOTUNE", "0") != "1"
+)
+
+_TQ_MLA_STORE_AUTOTUNE_CONFIGS = (
+    [triton.Config({}, num_warps=4, num_stages=1)]
+    if _TQ_MLA_STORE_DISABLE_AUTOTUNE
+    else [
+        triton.Config({}, num_warps=1, num_stages=1),
+        triton.Config({}, num_warps=2, num_stages=1),
+        triton.Config({}, num_warps=4, num_stages=1),
+        triton.Config({}, num_warps=4, num_stages=2),
+        triton.Config({}, num_warps=8, num_stages=1),
+        triton.Config({}, num_warps=8, num_stages=2),
+    ]
+)
+
+
+def tq_mla_fused_store_enabled() -> bool:
+    return os.environ.get("VLLM_TQ_MLA_FUSED_STORE", "1") != "0"
+
+
+def tq_mla_store_fwht_enabled() -> bool:
+    return os.environ.get("VLLM_TQ_MLA_STORE_FWHT", "0") == "1"
+
+
+def tq_mla_store_bf16_direct_enabled() -> bool:
+    """Fuse bf16->norm->FWHT into the store kernel (skip Python fp32 preamble).
+
+    Requires ``use_fwht=True`` and 4-bit k_pe; falls back to the legacy launch
+    when disabled or unsupported.
+    """
+    return os.environ.get("VLLM_TQ_MLA_STORE_BF16_DIRECT", "1") == "1"
+
+
+def tq_mla_kpe_4bit_enabled() -> bool:
+    return os.environ.get("VLLM_TQ_KPE_4BIT", "0") == "1"
+
+
+def kpe_mse_index_bytes(rope_dim: int, bits: int = 4) -> int:
+    return math.ceil(rope_dim * bits / 8)
+
+
+def kpe_packed_bytes(rope_dim: int, *, kpe_4bit: bool, kpe_fp8: bool) -> int:
+    if kpe_4bit:
+        return kpe_mse_index_bytes(rope_dim, 4) + 2
+    if kpe_fp8:
+        return rope_dim + 2
+    return 2 * rope_dim
+
+
+@triton.jit
+def _fwht_1d(x, N: tl.constexpr, LOG2N: tl.constexpr, INV_SQRT_N: tl.constexpr):
+    """Sylvester FWHT matching ``_build_hadamard(N) @ x`` (orthonormal)."""
+    idx = tl.arange(0, N)
+    v = x.to(tl.float32)
+    if LOG2N >= 1:
+        partner = idx ^ 1
+        v_p = tl.gather(v, partner, 0)
+        v = tl.where((idx & 1) == 0, v + v_p, v_p - v)
+    if LOG2N >= 2:
+        partner = idx ^ 2
+        v_p = tl.gather(v, partner, 0)
+        v = tl.where((idx & 2) == 0, v + v_p, v_p - v)
+    if LOG2N >= 3:
+        partner = idx ^ 4
+        v_p = tl.gather(v, partner, 0)
+        v = tl.where((idx & 4) == 0, v + v_p, v_p - v)
+    if LOG2N >= 4:
+        partner = idx ^ 8
+        v_p = tl.gather(v, partner, 0)
+        v = tl.where((idx & 8) == 0, v + v_p, v_p - v)
+    if LOG2N >= 5:
+        partner = idx ^ 16
+        v_p = tl.gather(v, partner, 0)
+        v = tl.where((idx & 16) == 0, v + v_p, v_p - v)
+    if LOG2N >= 6:
+        partner = idx ^ 32
+        v_p = tl.gather(v, partner, 0)
+        v = tl.where((idx & 32) == 0, v + v_p, v_p - v)
+    if LOG2N >= 7:
+        partner = idx ^ 64
+        v_p = tl.gather(v, partner, 0)
+        v = tl.where((idx & 64) == 0, v + v_p, v_p - v)
+    if LOG2N >= 8:
+        partner = idx ^ 128
+        v_p = tl.gather(v, partner, 0)
+        v = tl.where((idx & 128) == 0, v + v_p, v_p - v)
+    if LOG2N >= 9:
+        partner = idx ^ 256
+        v_p = tl.gather(v, partner, 0)
+        v = tl.where((idx & 256) == 0, v + v_p, v_p - v)
+    if LOG2N >= 10:
+        partner = idx ^ 512
+        v_p = tl.gather(v, partner, 0)
+        v = tl.where((idx & 512) == 0, v + v_p, v_p - v)
+    return v * INV_SQRT_N
+
+
+@triton.jit
+def _tq_mla_bucketize_1d(
+    vals,
+    Midpoints_ptr,
+    d_mask,
+    BLOCK_D: tl.constexpr,
+    MSE_BITS: tl.constexpr,
+    N_CENTROIDS: tl.constexpr,
+):
+    lo = tl.zeros([BLOCK_D], dtype=tl.int32)
+    hi = tl.full([BLOCK_D], N_CENTROIDS - 1, dtype=tl.int32)
+    for _ in tl.static_range(MSE_BITS):
+        mid = (lo + hi) >> 1
+        safe_mid = tl.minimum(mid, N_CENTROIDS - 2)
+        mid_val = tl.load(Midpoints_ptr + safe_mid, mask=d_mask, other=0.0)
+        lo = tl.where(vals >= mid_val, mid + 1, lo)
+        hi = tl.where(vals >= mid_val, hi, mid)
+    return tl.minimum(lo, N_CENTROIDS - 1)
+
+
+@triton.jit
+def _tq_mla_gather_centroids_1d(
+    Centroids_ptr,
+    idx,
+    d_mask,
+    BLOCK_D: tl.constexpr,
+    MSE_BITS: tl.constexpr,
+):
+    n_centroids: tl.constexpr = 1 << MSE_BITS
+    centroids = tl.load(Centroids_ptr + tl.arange(0, n_centroids))
+    y_hat = tl.gather(centroids, idx, 0)
+    return tl.where(d_mask, y_hat, 0.0)
+
+
+@triton.jit
+def _tq_mla_pack_4bit(
+    idx,
+    MSE_BYTES: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+):
+    idx_pairs = tl.reshape(idx, [BLOCK_D // 2, 2])
+    shifts_4 = tl.arange(0, 2) * 4
+    packed = tl.sum((idx_pairs & 0xF) << shifts_4[None, :], axis=1).to(tl.uint8)
+    mse_offs = tl.arange(0, BLOCK_D // 2)
+    mse_mask = mse_offs < MSE_BYTES
+    return packed, mse_offs, mse_mask
+
+
+@triton.jit
+def _tq_mla_store_mse_1d(
+    y,
+    norm,
+    d_mask,
+    Midpoints_ptr,
+    Centroids_ptr,
+    KV_cache_ptr,
+    slot_base,
+    MSE_BITS: tl.constexpr,
+    MSE_BYTES: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+    N_CENTROIDS: tl.constexpr,
+    NORM_CORRECTION: tl.constexpr,
+):
+    idx = _tq_mla_bucketize_1d(
+        y, Midpoints_ptr, d_mask, BLOCK_D, MSE_BITS, N_CENTROIDS
+    )
+
+    if NORM_CORRECTION:
+        y_hat = _tq_mla_gather_centroids_1d(
+            Centroids_ptr, idx, d_mask, BLOCK_D, MSE_BITS
+        )
+        c_norm_sq = tl.sum(y_hat * y_hat, axis=0)
+        c_norm = tl.sqrt(tl.maximum(c_norm_sq, 1e-8))
+        eff_scale = (norm / c_norm).to(tl.float16)
+    else:
+        eff_scale = norm.to(tl.float16)
+
+    scale_u16 = eff_scale.to(tl.uint16, bitcast=True)
+
+    if MSE_BITS == 4:
+        packed, mse_offs, mse_mask = _tq_mla_pack_4bit(idx, MSE_BYTES, BLOCK_D)
+        tl.store(KV_cache_ptr + slot_base + mse_offs, packed, mask=mse_mask)
+
+    tl.store(KV_cache_ptr + slot_base + MSE_BYTES, (scale_u16 & 0xFF).to(tl.uint8))
+    tl.store(
+        KV_cache_ptr + slot_base + MSE_BYTES + 1,
+        ((scale_u16 >> 8) & 0xFF).to(tl.uint8),
+    )
+
+
+@triton.autotune(
+    configs=_TQ_MLA_STORE_AUTOTUNE_CONFIGS,
+    key=[
+        "D",
+        "R",
+        "MSE_BITS",
+        "KPE_MODE",
+        "NORM_CORRECTION",
+        "USE_FWHT",
+    ],
+)
+@triton.jit
+def _tq_mla_fused_store_kernel(
+    Y_ptr,
+    X_hat_ptr,
+    Norm_ptr,
+    KPE_ptr,
+    KV_cache_ptr,
+    Slot_mapping_ptr,
+    Midpoints_ptr,
+    Centroids_ptr,
+    Kpe_midpoints_ptr,
+    Kpe_centroids_ptr,
+    stride_y,
+    stride_xhat,
+    stride_norm,
+    stride_kpe,
+    stride_cache_row,
+    D: tl.constexpr,
+    R: tl.constexpr,
+    MSE_BITS: tl.constexpr,
+    MSE_BYTES: tl.constexpr,
+    KV_C_BYTES: tl.constexpr,
+    KPE_MSE_BYTES: tl.constexpr,
+    KPE_BYTES: tl.constexpr,
+    PACKED_BYTES: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+    BLOCK_R: tl.constexpr,
+    LOG2N_D: tl.constexpr,
+    LOG2N_R: tl.constexpr,
+    INV_SQRT_D: tl.constexpr,
+    INV_SQRT_R: tl.constexpr,
+    N_CENTROIDS: tl.constexpr,
+    KPE_MODE: tl.constexpr,  # 0=bf16, 1=fp8, 2=4bit
+    NORM_CORRECTION: tl.constexpr,
+    USE_FWHT: tl.constexpr,
+):
+    """Fused MLA TQ4 store: rotate -> bucketize -> pack -> k_pe -> scatter."""
+    tid = tl.program_id(0)
+    slot = tl.load(Slot_mapping_ptr + tid)
+    if slot < 0:
+        return
+
+    d_offs = tl.arange(0, BLOCK_D)
+    d_mask = d_offs < D
+    norm = tl.load(Norm_ptr + tid * stride_norm).to(tl.float32)
+
+    if USE_FWHT:
+        x_hat = tl.load(
+            X_hat_ptr + tid * stride_xhat + d_offs,
+            mask=d_mask,
+            other=0.0,
+        ).to(tl.float32)
+        y = _fwht_1d(x_hat, BLOCK_D, LOG2N_D, INV_SQRT_D)
+    else:
+        y = tl.load(
+            Y_ptr + tid * stride_y + d_offs,
+            mask=d_mask,
+            other=0.0,
+        ).to(tl.float32)
+
+    slot_base = slot.to(tl.int64) * stride_cache_row
+    _tq_mla_store_mse_1d(
+        y,
+        norm,
+        d_mask,
+        Midpoints_ptr,
+        Centroids_ptr,
+        KV_cache_ptr,
+        slot_base,
+        MSE_BITS,
+        MSE_BYTES,
+        BLOCK_D,
+        N_CENTROIDS,
+        NORM_CORRECTION,
+    )
+
+    r_offs = tl.arange(0, BLOCK_R)
+    r_mask = r_offs < R
+    kpe_base = KPE_ptr + tid * stride_kpe
+    kpe_vec = tl.load(kpe_base + r_offs, mask=r_mask, other=0.0).to(tl.float32)
+
+    if KPE_MODE == 2:
+        kpe_norm_sq = tl.sum(tl.where(r_mask, kpe_vec * kpe_vec, 0.0), axis=0)
+        kpe_norm = tl.sqrt(tl.maximum(kpe_norm_sq, 1e-8))
+        kpe_x_hat = tl.where(r_mask, kpe_vec / kpe_norm, 0.0)
+        kpe_y = _fwht_1d(kpe_x_hat, BLOCK_R, LOG2N_R, INV_SQRT_R)
+        kpe_base_off = slot_base + KV_C_BYTES
+        _tq_mla_store_mse_1d(
+            kpe_y,
+            kpe_norm,
+            r_mask,
+            Kpe_midpoints_ptr,
+            Kpe_centroids_ptr,
+            KV_cache_ptr,
+            kpe_base_off,
+            4,
+            KPE_MSE_BYTES,
+            BLOCK_R,
+            16,
+            NORM_CORRECTION,
+        )
+    elif KPE_MODE == 1:
+        max_abs = tl.max(tl.where(r_mask, tl.abs(kpe_vec), 0.0), axis=0)
+        max_safe = tl.maximum(max_abs, 1e-8)
+        kpe_scale = max_safe / 448.0
+        inv_scale = tl.where(kpe_scale > 0.0, 1.0 / kpe_scale, 1.0)
+        kpe_scaled = tl.minimum(
+            tl.maximum(kpe_vec * inv_scale, -448.0), 448.0
+        )
+        kpe_fp8 = kpe_scaled.to(tl.float8e4nv)
+        kpe_u8 = kpe_fp8.to(tl.uint8, bitcast=True)
+        kpe_scale_u16 = kpe_scale.to(tl.float16).to(tl.uint16, bitcast=True)
+        tl.store(
+            KV_cache_ptr + slot_base + KV_C_BYTES + r_offs,
+            kpe_u8,
+            mask=r_mask,
+        )
+        tl.store(
+            KV_cache_ptr + slot_base + KV_C_BYTES + R,
+            (kpe_scale_u16 & 0xFF).to(tl.uint8),
+        )
+        tl.store(
+            KV_cache_ptr + slot_base + KV_C_BYTES + R + 1,
+            ((kpe_scale_u16 >> 8) & 0xFF).to(tl.uint8),
+        )
+    else:
+        kpe_bf16 = kpe_vec.to(tl.bfloat16)
+        kpe_u16 = kpe_bf16.to(tl.uint16, bitcast=True)
+        tl.store(
+            KV_cache_ptr + slot_base + KV_C_BYTES + r_offs * 2,
+            (kpe_u16 & 0xFF).to(tl.uint8),
+            mask=r_mask,
+        )
+        tl.store(
+            KV_cache_ptr + slot_base + KV_C_BYTES + r_offs * 2 + 1,
+            ((kpe_u16 >> 8) & 0xFF).to(tl.uint8),
+            mask=r_mask,
+        )
+
+
+@triton.autotune(
+    configs=_TQ_MLA_STORE_AUTOTUNE_CONFIGS,
+    key=[
+        "D",
+        "R",
+        "MSE_BITS",
+        "KPE_MODE",
+        "NORM_CORRECTION",
+    ],
+)
+@triton.jit
+def _tq_mla_fused_store_kernel_bf16_direct(
+    KV_C_ptr,
+    KPE_ptr,
+    KV_cache_ptr,
+    Slot_mapping_ptr,
+    Midpoints_ptr,
+    Centroids_ptr,
+    Kpe_midpoints_ptr,
+    Kpe_centroids_ptr,
+    stride_kvc,
+    stride_kpe,
+    stride_cache_row,
+    D: tl.constexpr,
+    R: tl.constexpr,
+    MSE_BITS: tl.constexpr,
+    MSE_BYTES: tl.constexpr,
+    KV_C_BYTES: tl.constexpr,
+    KPE_MSE_BYTES: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+    BLOCK_R: tl.constexpr,
+    LOG2N_D: tl.constexpr,
+    LOG2N_R: tl.constexpr,
+    INV_SQRT_D: tl.constexpr,
+    INV_SQRT_R: tl.constexpr,
+    N_CENTROIDS: tl.constexpr,
+    KPE_MODE: tl.constexpr,
+    NORM_CORRECTION: tl.constexpr,
+):
+    """FWHT store with inline bf16 kv_c norm (no Python fp32 x_hat buffer)."""
+    tid = tl.program_id(0)
+    slot = tl.load(Slot_mapping_ptr + tid)
+    if slot < 0:
+        return
+
+    d_offs = tl.arange(0, BLOCK_D)
+    d_mask = d_offs < D
+    kv_c_f = (
+        tl.load(
+            KV_C_ptr + tid * stride_kvc + d_offs,
+            mask=d_mask,
+            other=0.0,
+        )
+        .to(tl.float32)
+    )
+    norm_sq = tl.sum(tl.where(d_mask, kv_c_f * kv_c_f, 0.0), axis=0)
+    norm = tl.sqrt(tl.maximum(norm_sq, 1e-8))
+    x_hat = tl.where(d_mask, kv_c_f / norm, 0.0)
+    y = _fwht_1d(x_hat, BLOCK_D, LOG2N_D, INV_SQRT_D)
+
+    slot_base = slot.to(tl.int64) * stride_cache_row
+    _tq_mla_store_mse_1d(
+        y,
+        norm,
+        d_mask,
+        Midpoints_ptr,
+        Centroids_ptr,
+        KV_cache_ptr,
+        slot_base,
+        MSE_BITS,
+        MSE_BYTES,
+        BLOCK_D,
+        N_CENTROIDS,
+        NORM_CORRECTION,
+    )
+
+    r_offs = tl.arange(0, BLOCK_R)
+    r_mask = r_offs < R
+    kpe_vec = (
+        tl.load(
+            KPE_ptr + tid * stride_kpe + r_offs,
+            mask=r_mask,
+            other=0.0,
+        )
+        .to(tl.float32)
+    )
+
+    if KPE_MODE == 2:
+        kpe_norm_sq = tl.sum(tl.where(r_mask, kpe_vec * kpe_vec, 0.0), axis=0)
+        kpe_norm = tl.sqrt(tl.maximum(kpe_norm_sq, 1e-8))
+        kpe_x_hat = tl.where(r_mask, kpe_vec / kpe_norm, 0.0)
+        kpe_y = _fwht_1d(kpe_x_hat, BLOCK_R, LOG2N_R, INV_SQRT_R)
+        kpe_base_off = slot_base + KV_C_BYTES
+        _tq_mla_store_mse_1d(
+            kpe_y,
+            kpe_norm,
+            r_mask,
+            Kpe_midpoints_ptr,
+            Kpe_centroids_ptr,
+            KV_cache_ptr,
+            kpe_base_off,
+            4,
+            KPE_MSE_BYTES,
+            BLOCK_R,
+            16,
+            NORM_CORRECTION,
+        )
+    elif KPE_MODE == 1:
+        max_abs = tl.max(tl.where(r_mask, tl.abs(kpe_vec), 0.0), axis=0)
+        max_safe = tl.maximum(max_abs, 1e-8)
+        kpe_scale = max_safe / 448.0
+        inv_scale = tl.where(kpe_scale > 0.0, 1.0 / kpe_scale, 1.0)
+        kpe_scaled = tl.minimum(
+            tl.maximum(kpe_vec * inv_scale, -448.0), 448.0
+        )
+        kpe_fp8 = kpe_scaled.to(tl.float8e4nv)
+        kpe_u8 = kpe_fp8.to(tl.uint8, bitcast=True)
+        kpe_scale_u16 = kpe_scale.to(tl.float16).to(tl.uint16, bitcast=True)
+        tl.store(
+            KV_cache_ptr + slot_base + KV_C_BYTES + r_offs,
+            kpe_u8,
+            mask=r_mask,
+        )
+        tl.store(
+            KV_cache_ptr + slot_base + KV_C_BYTES + R,
+            (kpe_scale_u16 & 0xFF).to(tl.uint8),
+        )
+        tl.store(
+            KV_cache_ptr + slot_base + KV_C_BYTES + R + 1,
+            ((kpe_scale_u16 >> 8) & 0xFF).to(tl.uint8),
+        )
+    else:
+        kpe_bf16 = kpe_vec.to(tl.bfloat16)
+        kpe_u16 = kpe_bf16.to(tl.uint16, bitcast=True)
+        tl.store(
+            KV_cache_ptr + slot_base + KV_C_BYTES + r_offs * 2,
+            (kpe_u16 & 0xFF).to(tl.uint8),
+            mask=r_mask,
+        )
+        tl.store(
+            KV_cache_ptr + slot_base + KV_C_BYTES + r_offs * 2 + 1,
+            ((kpe_u16 >> 8) & 0xFF).to(tl.uint8),
+            mask=r_mask,
+        )
+
+
+def _log2_const(n: int) -> int:
+    assert n > 0 and (n & (n - 1)) == 0, f"n must be power of 2, got {n}"
+    return n.bit_length() - 1
+
+
+def _launch_fused_store_bf16_direct(
+    kv_c: torch.Tensor,
+    k_pe: torch.Tensor,
+    kv_cache: torch.Tensor,
+    slot_mapping: torch.Tensor,
+    *,
+    midpoints: torch.Tensor,
+    centroids_fp32: torch.Tensor,
+    mse_bits: int,
+    mse_bytes: int,
+    kv_c_bytes: int,
+    packed_bytes: int,
+    kpe_fp8: bool,
+    kpe_4bit: bool,
+    kpe_midpoints: torch.Tensor | None,
+    kpe_centroids_fp32: torch.Tensor | None,
+    kpe_mse_bytes: int,
+    norm_correction: bool,
+) -> None:
+    N = slot_mapping.shape[0]
+    D = kv_c.shape[-1]
+    R = k_pe.shape[-1]
+    block_d = triton.next_power_of_2(D)
+    block_r = triton.next_power_of_2(R)
+
+    if kpe_4bit:
+        kpe_mode = 2
+        if kpe_midpoints is None or kpe_centroids_fp32 is None:
+            raise ValueError("kpe_4bit requires kpe_midpoints and kpe_centroids_fp32")
+    elif kpe_fp8:
+        kpe_mode = 1
+    else:
+        kpe_mode = 0
+
+    if kpe_mse_bytes == 0 and kpe_4bit:
+        kpe_mse_bytes = kpe_mse_index_bytes(R, 4)
+
+    cache_flat = kv_cache.view(-1, packed_bytes)
+    slots = slot_mapping[:N].to(torch.int32)
+    _tq_mla_fused_store_kernel_bf16_direct[(N,)](
+        kv_c[:N],
+        k_pe[:N],
+        cache_flat,
+        slots,
+        midpoints,
+        centroids_fp32,
+        kpe_midpoints if kpe_midpoints is not None else midpoints,
+        kpe_centroids_fp32 if kpe_centroids_fp32 is not None else centroids_fp32,
+        kv_c.stride(0),
+        k_pe.stride(0),
+        packed_bytes,
+        D,
+        R,
+        mse_bits,
+        mse_bytes,
+        kv_c_bytes,
+        kpe_mse_bytes,
+        block_d,
+        block_r,
+        _log2_const(block_d),
+        _log2_const(block_r),
+        1.0 / math.sqrt(block_d),
+        1.0 / math.sqrt(block_r),
+        1 << mse_bits,
+        kpe_mode,
+        norm_correction,
+    )
+
+
+def tq_mla_fused_kv_cache_store(
+    kv_c: torch.Tensor,
+    k_pe: torch.Tensor,
+    kv_cache: torch.Tensor,
+    slot_mapping: torch.Tensor,
+    *,
+    pi_t: torch.Tensor,
+    midpoints: torch.Tensor,
+    centroids_fp32: torch.Tensor,
+    mse_bits: int,
+    mse_bytes: int,
+    kv_c_bytes: int,
+    packed_bytes: int,
+    kpe_fp8: bool,
+    kpe_4bit: bool = False,
+    use_fwht: bool = False,
+    kpe_midpoints: torch.Tensor | None = None,
+    kpe_centroids_fp32: torch.Tensor | None = None,
+    kpe_mse_bytes: int = 0,
+    norm_correction: bool,
+) -> None:
+    """Launch fused MLA store into ``kv_cache`` (uint8, flat or blocked)."""
+    N = slot_mapping.shape[0]
+    if N == 0:
+        return
+    if mse_bits != 4:
+        raise ValueError(
+            f"fused MLA store supports 4-bit MSE only (got {mse_bits}-bit); "
+            "set VLLM_TQ_MLA_FUSED_STORE=0 for PyTorch fallback"
+        )
+
+    D = kv_c.shape[-1]
+    R = k_pe.shape[-1]
+    block_d = triton.next_power_of_2(D)
+    block_r = triton.next_power_of_2(R)
+    assert block_d == D, f"kv_lora_rank must be power of 2, got {D}"
+    assert block_r == R, f"qk_rope_head_dim must be power of 2 for FWHT, got {R}"
+
+    if use_fwht and tq_mla_store_bf16_direct_enabled():
+        _launch_fused_store_bf16_direct(
+            kv_c,
+            k_pe,
+            kv_cache,
+            slot_mapping,
+            midpoints=midpoints,
+            centroids_fp32=centroids_fp32,
+            mse_bits=mse_bits,
+            mse_bytes=mse_bytes,
+            kv_c_bytes=kv_c_bytes,
+            packed_bytes=packed_bytes,
+            kpe_fp8=kpe_fp8,
+            kpe_4bit=kpe_4bit,
+            kpe_midpoints=kpe_midpoints,
+            kpe_centroids_fp32=kpe_centroids_fp32,
+            kpe_mse_bytes=kpe_mse_bytes,
+            norm_correction=norm_correction,
+        )
+        return
+
+    kv_c_f = kv_c[:N].to(torch.float32)
+    norms = kv_c_f.norm(dim=1).clamp(min=1e-8)
+    x_hat = (kv_c_f / norms.unsqueeze(1)).contiguous()
+    norms = norms.contiguous()
+
+    if use_fwht:
+        y = x_hat  # placeholder; kernel reads x_hat directly
+        stride_y = x_hat.stride(0)
+    else:
+        y = (x_hat @ pi_t.to(torch.float32)).contiguous()
+        stride_y = y.stride(0)
+
+    if kpe_4bit:
+        kpe_mode = 2
+        if kpe_midpoints is None or kpe_centroids_fp32 is None:
+            raise ValueError("kpe_4bit requires kpe_midpoints and kpe_centroids_fp32")
+    elif kpe_fp8:
+        kpe_mode = 1
+    else:
+        kpe_mode = 0
+
+    kpe_bytes = kpe_packed_bytes(R, kpe_4bit=kpe_4bit, kpe_fp8=kpe_fp8 and not kpe_4bit)
+    if kpe_mse_bytes == 0 and kpe_4bit:
+        kpe_mse_bytes = kpe_mse_index_bytes(R, 4)
+
+    cache_flat = kv_cache.view(-1, packed_bytes)
+    slots = slot_mapping[:N].to(torch.int32)
+
+    grid = (N,)
+    _tq_mla_fused_store_kernel[grid](
+        y,
+        x_hat,
+        norms,
+        k_pe[:N],
+        cache_flat,
+        slots,
+        midpoints,
+        centroids_fp32,
+        kpe_midpoints if kpe_midpoints is not None else midpoints,
+        kpe_centroids_fp32 if kpe_centroids_fp32 is not None else centroids_fp32,
+        stride_y,
+        x_hat.stride(0),
+        norms.stride(0),
+        k_pe.stride(0),
+        packed_bytes,
+        D,
+        R,
+        mse_bits,
+        mse_bytes,
+        kv_c_bytes,
+        kpe_mse_bytes,
+        kpe_bytes,
+        packed_bytes,
+        block_d,
+        block_r,
+        _log2_const(block_d),
+        _log2_const(block_r),
+        1.0 / math.sqrt(block_d),
+        1.0 / math.sqrt(block_r),
+        1 << mse_bits,
+        kpe_mode,
+        norm_correction,
+        use_fwht,
+    )

--- a/vllm/v1/attention/ops/triton_turboquant_mla_store.py
+++ b/vllm/v1/attention/ops/triton_turboquant_mla_store.py
@@ -183,9 +183,7 @@ def _tq_mla_store_mse_1d(
     N_CENTROIDS: tl.constexpr,
     NORM_CORRECTION: tl.constexpr,
 ):
-    idx = _tq_mla_bucketize_1d(
-        y, Midpoints_ptr, d_mask, BLOCK_D, MSE_BITS, N_CENTROIDS
-    )
+    idx = _tq_mla_bucketize_1d(y, Midpoints_ptr, d_mask, BLOCK_D, MSE_BITS, N_CENTROIDS)
 
     if NORM_CORRECTION:
         y_hat = _tq_mla_gather_centroids_1d(
@@ -327,9 +325,7 @@ def _tq_mla_fused_store_kernel(
         max_safe = tl.maximum(max_abs, 1e-8)
         kpe_scale = max_safe / 448.0
         inv_scale = tl.where(kpe_scale > 0.0, 1.0 / kpe_scale, 1.0)
-        kpe_scaled = tl.minimum(
-            tl.maximum(kpe_vec * inv_scale, -448.0), 448.0
-        )
+        kpe_scaled = tl.minimum(tl.maximum(kpe_vec * inv_scale, -448.0), 448.0)
         kpe_fp8 = kpe_scaled.to(tl.float8e4nv)
         kpe_u8 = kpe_fp8.to(tl.uint8, bitcast=True)
         kpe_scale_u16 = kpe_scale.to(tl.float16).to(tl.uint16, bitcast=True)
@@ -408,14 +404,11 @@ def _tq_mla_fused_store_kernel_bf16_direct(
 
     d_offs = tl.arange(0, BLOCK_D)
     d_mask = d_offs < D
-    kv_c_f = (
-        tl.load(
-            KV_C_ptr + tid * stride_kvc + d_offs,
-            mask=d_mask,
-            other=0.0,
-        )
-        .to(tl.float32)
-    )
+    kv_c_f = tl.load(
+        KV_C_ptr + tid * stride_kvc + d_offs,
+        mask=d_mask,
+        other=0.0,
+    ).to(tl.float32)
     norm_sq = tl.sum(tl.where(d_mask, kv_c_f * kv_c_f, 0.0), axis=0)
     norm = tl.sqrt(tl.maximum(norm_sq, 1e-8))
     x_hat = tl.where(d_mask, kv_c_f / norm, 0.0)
@@ -439,14 +432,11 @@ def _tq_mla_fused_store_kernel_bf16_direct(
 
     r_offs = tl.arange(0, BLOCK_R)
     r_mask = r_offs < R
-    kpe_vec = (
-        tl.load(
-            KPE_ptr + tid * stride_kpe + r_offs,
-            mask=r_mask,
-            other=0.0,
-        )
-        .to(tl.float32)
-    )
+    kpe_vec = tl.load(
+        KPE_ptr + tid * stride_kpe + r_offs,
+        mask=r_mask,
+        other=0.0,
+    ).to(tl.float32)
 
     if KPE_MODE == 2:
         kpe_norm_sq = tl.sum(tl.where(r_mask, kpe_vec * kpe_vec, 0.0), axis=0)
@@ -473,9 +463,7 @@ def _tq_mla_fused_store_kernel_bf16_direct(
         max_safe = tl.maximum(max_abs, 1e-8)
         kpe_scale = max_safe / 448.0
         inv_scale = tl.where(kpe_scale > 0.0, 1.0 / kpe_scale, 1.0)
-        kpe_scaled = tl.minimum(
-            tl.maximum(kpe_vec * inv_scale, -448.0), 448.0
-        )
+        kpe_scaled = tl.minimum(tl.maximum(kpe_vec * inv_scale, -448.0), 448.0)
         kpe_fp8 = kpe_scaled.to(tl.float8e4nv)
         kpe_u8 = kpe_fp8.to(tl.uint8, bitcast=True)
         kpe_scale_u16 = kpe_scale.to(tl.float16).to(tl.uint16, bitcast=True)

--- a/vllm/v1/core/sched/async_scheduler.py
+++ b/vllm/v1/core/sched/async_scheduler.py
@@ -47,6 +47,58 @@ class AsyncScheduler(Scheduler):
                 # Set the next step index in which this request is eligible to be
                 # scheduled for decode (for PP microbatching).
                 request.next_decode_eligible_step = self.current_step + self.pp_size
+            elif self._pp_decode_cadence:
+                # P3/M3b (flag VLLM_V1_PP_DECODE_CADENCE): throttle this request's
+                # decode to once per pp_size steps so each step runs one
+                # independent cohort the worker handoff ring overlaps across PP
+                # stages. Gap == pp_size == worker ring depth (INV-RING).
+                #
+                # P7 Phase B (flag VLLM_PPMTP_COHORT_BALANCE): the residue
+                # (next_decode_eligible_step % pp_size) is FIXED at a request's
+                # first decode. [PPB-DIAG 2026-07-25] confirmed the first decode ==
+                # prefill completion (ncomp==nprompt, spec=0) and a synchronized
+                # burst all completes prefill on the SAME step -> all one residue ->
+                # one cadence cohort full, the other empty -> the overlap window is
+                # half empty (why cadence is a net loss). Rotate the residue ONLY at
+                # the first decode (or preempt-resume, both marked by next==0) via
+                # an engine-level admit counter; keep the +pp_size base so no gap is
+                # ever shorter than pp_size (the < pp_size "runs before the slot
+                # lands" corruption). offset in [0, pp_size-1] lands the first decode
+                # on residue r. Subsequent decodes fall through to the plain
+                # +pp_size (gap == pp_size). P4's decode-layer shift (offset on
+                # EVERY decode) is the wrong version and corrupts; this rotates only
+                # the first.
+                #
+                # P7 Phase C low-concurrency guard: only rotate when there are at
+                # least pp_size running requests (enough to fill >1 cadence cohort).
+                # Below that, residues already alternate naturally (no imbalance),
+                # so rotating only pays the offset>0 gap-shift's one-time draft loss
+                # for zero benefit ([PPB-BAL] at conc1 showed EVERY request forced
+                # offset=1). len(self.running) includes the just-transitioned req.
+                if (
+                    self._pp_cohort_balance
+                    and request.next_decode_eligible_step == 0
+                    and len(self.running) >= self.pp_size
+                ):
+                    r = self._admit_counter % self.pp_size
+                    self._admit_counter += 1
+                    offset = (r - self.current_step % self.pp_size) % self.pp_size
+                    request.next_decode_eligible_step = (
+                        self.current_step + self.pp_size + offset
+                    )
+                    _n = getattr(self, "_ppb_bal_n", 0)
+                    if _n < 80:
+                        self._ppb_bal_n = _n + 1
+                        logger.info(
+                            "[PPB-BAL] step=%d req=%s r=%d offset=%d next=%d "
+                            "residue=%d admit=%d",
+                            self.current_step, str(request.request_id)[-6:], r,
+                            offset, request.next_decode_eligible_step,
+                            request.next_decode_eligible_step % self.pp_size,
+                            self._admit_counter,
+                        )
+                else:
+                    request.next_decode_eligible_step = self.current_step + self.pp_size
 
     def _update_request_with_output(
         self, request: Request, new_token_ids: list[int], is_stale: bool = False

--- a/vllm/v1/core/sched/async_scheduler.py
+++ b/vllm/v1/core/sched/async_scheduler.py
@@ -92,8 +92,11 @@ class AsyncScheduler(Scheduler):
                         logger.info(
                             "[PPB-BAL] step=%d req=%s r=%d offset=%d next=%d "
                             "residue=%d admit=%d",
-                            self.current_step, str(request.request_id)[-6:], r,
-                            offset, request.next_decode_eligible_step,
+                            self.current_step,
+                            str(request.request_id)[-6:],
+                            r,
+                            offset,
+                            request.next_decode_eligible_step,
                             request.next_decode_eligible_step % self.pp_size,
                             self._admit_counter,
                         )

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -7,6 +7,8 @@ from collections.abc import Iterable
 from dataclasses import replace
 from typing import Any
 
+import vllm.envs as envs
+
 from vllm.compilation.cuda_graph import CUDAGraphStat
 from vllm.config import KVEventsConfig, VllmConfig
 from vllm.distributed.ec_transfer.ec_connector.base import (
@@ -300,6 +302,34 @@ class Scheduler(SchedulerInterface):
         # Scheduler iteration counter. Drives the V2+PP+async decode-throttle
         # cadence (`next_decode_eligible_step`).
         self.current_step = 0
+        # P3/M3b (flag VLLM_V1_PP_DECODE_CADENCE): opt-in V1 PP+MTP decode
+        # cadence. Only meaningful for V1 (non-v2) + PP + spec(MTP) + async. When
+        # on, each request's decode is throttled to once per pp_size steps (via
+        # next_decode_eligible_step, enforced at the consume gate below) so each
+        # step schedules one independent cohort that the worker's deep handoff
+        # ring (depth == pp_size, set on the same flag) can overlap across PP
+        # stages. INV-RING: the cadence gap must be EXACTLY pp_size (== worker
+        # ring depth). Requires the worker M3b (ring depth -> pp_size); until that
+        # lands the worker ring stays at depth 1, so keep the flag unset.
+        self._pp_decode_cadence = (
+            envs.VLLM_V1_PP_DECODE_CADENCE
+            and self.use_pp
+            and not self.use_v2_model_runner
+            and self.num_spec_tokens > 0
+            and self.scheduler_config.async_scheduling
+        )
+        # P4 (flag VLLM_PPMTP_COHORT_BALANCE): round-robin the prefill->decode
+        # admission residue across pp_size so bursty synchronized prefill
+        # completions spread across cadence cohorts instead of all landing on the
+        # same residue (which would make one step's cohort full and the next near
+        # empty -- the "coin-flip" that can make cadence a net loss). Only
+        # meaningful with cadence on. Engine-level rotating counter drives the
+        # residue; a request's residue is fixed at its first decode admission
+        # (and re-rotated on preemption resume).
+        self._pp_cohort_balance = (
+            envs.VLLM_PPMTP_COHORT_BALANCE and self._pp_decode_cadence
+        )
+        self._admit_counter = 0
         # DP prefill balancing: Flag to track whether the last cadence-aligned
         # prefill batch fully drained the waiting queue. Prefill throttling
         # is disabled in this case.
@@ -1121,6 +1151,11 @@ class Scheduler(SchedulerInterface):
                     scheduled_new_reqs.append(request)
                 elif request.status == RequestStatus.PREEMPTED:
                     scheduled_resumed_reqs.append(request)
+                    if self._pp_decode_cadence:
+                        # P3/M3b: a resumed request re-enters the cadence fresh
+                        # (immediately schedulable, then re-throttled on its next
+                        # decode) so preemption churn doesn't strand its residue.
+                        request.next_decode_eligible_step = 0
                 else:
                     raise RuntimeError(f"Invalid request status: {request.status}")
 

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -8,7 +8,6 @@ from dataclasses import replace
 from typing import Any
 
 import vllm.envs as envs
-
 from vllm.compilation.cuda_graph import CUDAGraphStat
 from vllm.config import KVEventsConfig, VllmConfig
 from vllm.distributed.ec_transfer.ec_connector.base import (

--- a/vllm/v1/spec_decode/llm_base_proposer.py
+++ b/vllm/v1/spec_decode/llm_base_proposer.py
@@ -108,29 +108,28 @@ def _load_embedding_from_target_checkpoint(
         raise FileNotFoundError(f"No safetensors found in {model_path}")
 
     with safe_open(shard_path, framework="pt") as _f:
-        if emb_key not in _f.keys():
-            for _alt in ("language_model.model.embed_tokens.weight",
-                         "transformer.embed_tokens.weight",
-                         "transformer.wte.weight"):
-                if _alt in _f.keys():
+        if emb_key not in _f:
+            for _alt in (
+                "language_model.model.embed_tokens.weight",
+                "transformer.embed_tokens.weight",
+                "transformer.wte.weight",
+            ):
+                if _alt in _f:
                     emb_key = _alt
                     break
             else:
-                raise KeyError(
-                    f"Embedding key not found in {shard_path}"
-                )
+                raise KeyError(f"Embedding key not found in {shard_path}")
         _emb_weight = _f.get_tensor(emb_key)
 
-    from vllm.distributed.parallel_state import get_tp_group
     import torch.distributed as dist
+
+    from vllm.distributed.parallel_state import get_tp_group
 
     tp_size = get_tp_group().world_size
     tp_rank = dist.get_rank() % tp_size
     vocab_size = _emb_weight.shape[0]
     if vocab_size % tp_size != 0:
-        raise ValueError(
-            f"vocab_size {vocab_size} not divisible by tp_size {tp_size}"
-        )
+        raise ValueError(f"vocab_size {vocab_size} not divisible by tp_size {tp_size}")
     chunk = vocab_size // tp_size
     _tp_weight = _emb_weight[tp_rank * chunk : (tp_rank + 1) * chunk]
     _tp_weight = _tp_weight.to(device=device, dtype=mtp_embed_tokens.weight.dtype)
@@ -141,7 +140,9 @@ def _load_embedding_from_target_checkpoint(
     logger.info(
         "Loaded draft model embedding from target checkpoint: "
         "shape=%s tp_rank=%d/%d norm=%.4f",
-        list(_tp_weight.shape), tp_rank, tp_size,
+        list(_tp_weight.shape),
+        tp_rank,
+        tp_size,
         _tp_weight.float().norm().item(),
     )
 

--- a/vllm/v1/spec_decode/llm_base_proposer.py
+++ b/vllm/v1/spec_decode/llm_base_proposer.py
@@ -68,6 +68,84 @@ from vllm.v1.worker.utils import AttentionGroup
 logger = init_logger(__name__)
 
 
+def _get_mtp_embed_tokens(model: nn.Module) -> nn.Module | None:
+    """Extract the embed_tokens module from an MTP draft model."""
+    _inner = getattr(model, "model", model)
+    _emb = getattr(_inner, "embed_tokens", None)
+    if _emb is None:
+        _emb = getattr(_inner, "embedding", None)
+    return _emb
+
+
+def _load_embedding_from_target_checkpoint(
+    vllm_config: "VllmConfig",
+    mtp_embed_tokens: nn.Module,
+    device: torch.device,
+) -> None:
+    """Load target model embedding weights from safetensors into MTP model."""
+    import glob
+    import json
+    import os as _os
+
+    from safetensors import safe_open
+
+    model_path = vllm_config.model_config.model
+    weight_map: dict[str, str] | None = None
+    index_path = _os.path.join(model_path, "model.safetensors.index.json")
+    if _os.path.exists(index_path):
+        with open(index_path) as _f:
+            weight_map = json.load(_f).get("weight_map", {})
+
+    emb_key = "model.embed_tokens.weight"
+    shard_path: str | None = None
+    if weight_map and emb_key in weight_map:
+        shard_path = _os.path.join(model_path, weight_map[emb_key])
+    else:
+        st_files = sorted(glob.glob(_os.path.join(model_path, "*.safetensors")))
+        shard_path = st_files[0] if st_files else None
+
+    if shard_path is None:
+        raise FileNotFoundError(f"No safetensors found in {model_path}")
+
+    with safe_open(shard_path, framework="pt") as _f:
+        if emb_key not in _f.keys():
+            for _alt in ("language_model.model.embed_tokens.weight",
+                         "transformer.embed_tokens.weight",
+                         "transformer.wte.weight"):
+                if _alt in _f.keys():
+                    emb_key = _alt
+                    break
+            else:
+                raise KeyError(
+                    f"Embedding key not found in {shard_path}"
+                )
+        _emb_weight = _f.get_tensor(emb_key)
+
+    from vllm.distributed.parallel_state import get_tp_group
+    import torch.distributed as dist
+
+    tp_size = get_tp_group().world_size
+    tp_rank = dist.get_rank() % tp_size
+    vocab_size = _emb_weight.shape[0]
+    if vocab_size % tp_size != 0:
+        raise ValueError(
+            f"vocab_size {vocab_size} not divisible by tp_size {tp_size}"
+        )
+    chunk = vocab_size // tp_size
+    _tp_weight = _emb_weight[tp_rank * chunk : (tp_rank + 1) * chunk]
+    _tp_weight = _tp_weight.to(device=device, dtype=mtp_embed_tokens.weight.dtype)
+
+    mtp_embed_tokens.weight = torch.nn.Parameter(_tp_weight.contiguous())
+    if hasattr(mtp_embed_tokens, "num_embeddings"):
+        mtp_embed_tokens.num_embeddings = chunk
+    logger.info(
+        "Loaded draft model embedding from target checkpoint: "
+        "shape=%s tp_rank=%d/%d norm=%.4f",
+        list(_tp_weight.shape), tp_rank, tp_size,
+        _tp_weight.float().norm().item(),
+    )
+
+
 class SpecDecodeBaseProposer:
     def __init__(
         self,
@@ -1515,10 +1593,26 @@ class SpecDecodeBaseProposer:
                     del self.model.model.embed_tokens
                 self.model.model.embed_tokens = target_embed_tokens
         else:
+            # PP+MTP port: PP>1 -> target embedding lives on a different PP rank.
+            # MTP models have no standalone embedding checkpoint (embed_tokens
+            # loaded as zeros), so reload the real weights from the target
+            # model's safetensors on the local GPU.
             logger.info(
-                "The draft model's vocab embedding will be loaded separately"
-                " from the target model."
+                "The draft model's vocab embedding will be loaded from"
+                " the target model checkpoint for PP>1."
             )
+            try:
+                _mtp_emb = _get_mtp_embed_tokens(self.model)
+                if _mtp_emb is not None and _mtp_emb.weight is not None:
+                    _load_embedding_from_target_checkpoint(
+                        self.vllm_config, _mtp_emb, self.device
+                    )
+            except Exception as _e:
+                logger.warning(
+                    "Failed to reload embedding weights for draft model: %s."
+                    " Draft token quality may be degraded.",
+                    str(_e),
+                )
 
     def _maybe_share_lm_head(self, target_language_model: nn.Module) -> None:
         """

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -6,7 +6,7 @@ import gc
 import itertools
 import threading
 import time
-from collections import defaultdict
+from collections import defaultdict, deque
 from collections.abc import Callable, Iterable, Iterator, Sequence
 from contextlib import AbstractContextManager, contextmanager, nullcontext
 from copy import copy, deepcopy
@@ -497,6 +497,41 @@ class ExecuteModelState(NamedTuple):
     slot_mappings: dict[str, torch.Tensor] | list[dict[str, torch.Tensor]] | None
 
 
+@dataclass
+class MTPHandoffSlot:
+    """One in-flight PP+MTP handoff (P2/M3a ring, flag VLLM_PPMTP_HANDOFF_RING).
+
+    Received on a non-last PP rank in sample_tokens and applied at the top of a
+    later _update_states, deferred by ``ring_depth`` steps (=1 for M3a; =pp_size
+    once cohort cadence lands in M3b). The GPU tensors + per-req CPU snapshots
+    are stashed here instead of written straight into input_batch at receive
+    time, so the extra mcb=pp_size+1 in-flight batch cannot race the correction
+    (the inline version mutates input_batch at receive time, which the extra
+    batch's CPU-side advance can clobber). All fields are the exact values the
+    inline _pp_apply_mtp_handoff would have applied at receive time.
+    """
+
+    num_reqs: int
+    # Derived handoff fields. Under VLLM_PPMTP_ASYNC_BCAST the non-last rank
+    # stashes these as None at receive (broadcast still in flight) and fills them
+    # at consume time (_apply_pending_mtp_handoff) after bcast_work.wait().
+    prev_sampled_token_ids: "torch.Tensor | None"  # [num_reqs, 1] last valid sampled
+    valid_sampled_token_count_gpu: "torch.Tensor | None"  # [num_reqs] int32
+    draft_token_ids: "torch.Tensor | None"  # [num_reqs, num_spec]
+    nts: "np.ndarray | None"  # [num_reqs] authoritative num_tokens_no_spec (last rank)
+    req_ids: list  # snapshot of input_batch.req_ids at receive
+    num_prompt_tokens: "np.ndarray"  # snapshot [num_reqs]
+    discard_mask: "np.ndarray"  # snapshot of discard_request_mask[:num_reqs]
+    # P7/Phase A async broadcast (VLLM_PPMTP_ASYNC_BCAST). bcast_work: the async
+    # collective handle, waited (both ranks, for symmetry) at consume. raw_handoff:
+    # the receive/send buffer kept alive until the wait (prevents early free); on
+    # the non-last rank it is also the source the deferred derivation reads.
+    # derive_pending: non-last rank must run _derive_mtp_handoff at consume.
+    bcast_work: object = None
+    raw_handoff: "torch.Tensor | None" = None
+    derive_pending: bool = False
+
+
 class GPUModelRunner(
     LoRAModelRunnerMixin, KVConnectorModelRunnerMixin, ECConnectorModelRunnerMixin
 ):
@@ -629,6 +664,10 @@ class GPUModelRunner(
         # NOTE(Jiayi): currently we put the entire draft model on
         # the last PP rank. This is not ideal if there are many
         # layers in the draft model.
+        # PP+MTP port: the entire draft model lives only on the last PP rank.
+        # On every other rank set drafter=None so the guards below skip it.
+        if self.speculative_config and not get_pp_group().is_last_rank:
+            self.drafter = None
         if self.speculative_config and get_pp_group().is_last_rank:
             self.drafter: (
                 NgramProposer  # noqa: F823
@@ -944,6 +983,20 @@ class GPUModelRunner(
             self._num_valid_draft_tokens_copy_stream = torch.cuda.Stream()
 
         self._draft_token_req_ids: list[str] | None = None
+        # P2/M3a PP+MTP handoff ring (flag VLLM_PPMTP_HANDOFF_RING). Deferred
+        # apply decouples the correction from the receive so the extra mcb batch
+        # cannot race it. Ring depth is a property (1 for M3a; pp_size under M3b
+        # cadence). See _mtp_handoff_ring_depth / _pp_decode_cadence.
+        self._mtp_ring: deque = deque()
+        # M3b cadence per-req_id state, stashed at ring-pop, drained on re-add.
+        self._mtp_pending_nts: dict[str, int] = {}
+        self._mtp_pending_valid: dict[str, int] = {}
+        # M3b draft/bonus scatter map {req_id: slot_row} for the re-added cohort.
+        self._mtp_cadence_scatter_index: dict[str, int] | None = None
+        # P7/Phase A one-time engagement diag (forkserver+numactl subprocs drop
+        # unregistered VLLM_* vars and /proc/environ is unreliable -> log the
+        # resolved property values from inside the worker to confirm the flags).
+        self._ppmtp_diag_logged = False
         self.transfer_event = torch.Event()
         self.sampled_token_ids_pinned_cpu = torch.empty(
             (self.max_num_reqs, 1),
@@ -999,8 +1052,52 @@ class GPUModelRunner(
             )
         self.layerwise_nvtx_hooks_registered = False
 
+    @property
+    def _is_pp_spec_decode(self) -> bool:
+        """PP>1 + speculative decoding: the case requiring MTP handoff."""
+        return self.num_spec_tokens > 0 and get_pp_group().world_size > 1
+
+    @property
+    def _pp_decode_cadence(self) -> bool:
+        """P3/M3b (flag VLLM_V1_PP_DECODE_CADENCE): throttle each request's decode
+        to once per pp_size steps so consecutive steps run independent cohorts the
+        handoff ring overlaps across PP stages. Must match the scheduler-side
+        Scheduler._pp_decode_cadence gate. Only meaningful for V1 PP + MTP + async;
+        the worker handoff ring deepens to pp_size when on (INV-RING)."""
+        return (
+            envs.VLLM_V1_PP_DECODE_CADENCE
+            and self._is_pp_spec_decode
+            and self.use_async_scheduling
+        )
+
+    @property
+    def _mtp_handoff_ring_depth(self) -> int:
+        """Handoff ring depth: 1 for M3a (apply 1 step after receive == inline
+        timing); pp_size under M3b cadence (defer the correction across the whole
+        cadence gap so it lands when the cohort is re-added). Cadence off -> 1."""
+        return get_pp_group().world_size if self._pp_decode_cadence else 1
+
+    @property
+    def _pp_async_bcast(self) -> bool:
+        """P7/Phase A (flag VLLM_PPMTP_ASYNC_BCAST): issue the PP+MTP handoff
+        broadcasts with async_op=True and relocate the wait + D2H derivation to
+        the deferred ring consume, so the collective overlaps the next
+        (independent) cohort's forward. Gated on _pp_decode_cadence: with cadence
+        off there is no independent cohort to overlap, so async only adds a race
+        surface for zero benefit (and the flag-off path must stay byte-identical).
+        Also requires the handoff ring (VLLM_PPMTP_HANDOFF_RING): the deferred
+        wait + derivation live in _apply_pending_mtp_handoff, so async without the
+        ring would issue collectives that never get waited."""
+        return (
+            envs.VLLM_PPMTP_ASYNC_BCAST
+            and envs.VLLM_PPMTP_HANDOFF_RING
+            and self._pp_decode_cadence
+        )
+
     def update_max_model_len(self, max_model_len: int) -> None:
         self.max_model_len = max_model_len
+        self.model_config.max_model_len = max_model_len
+        self.vllm_config.model_config.max_model_len = max_model_len
         if self.speculative_config:
             draft_config = self.speculative_config.draft_model_config
             if draft_config is None or draft_config.max_model_len is None:
@@ -1248,6 +1345,15 @@ class GPUModelRunner(
         The SamplingMetadata is updated and copied to the GPU if there is a
         new/resumed/paused/finished request in the batch.
         """
+        # P2/M3a ring (flag VLLM_PPMTP_HANDOFF_RING): apply the due deferred
+        # PP+MTP handoff before any composition change, while input_batch still
+        # matches the slot snapshot. No-op on the last PP rank / when the ring is
+        # empty (inline path never populates it).
+        if envs.VLLM_PPMTP_HANDOFF_RING:
+            # Rotate the handoff ring every step (see _apply_pending_mtp_handoff):
+            # the step-based defer must advance even on empty (no-stash) steps.
+            self._apply_pending_mtp_handoff()
+
         # Remove finished requests from the cached states.
         for req_id in scheduler_output.finished_req_ids:
             req_state = self.requests.pop(req_id, None)
@@ -1409,6 +1515,29 @@ class GPUModelRunner(
             num_output_tokens = req_data.num_output_tokens[i]
             req_index = self.input_batch.req_id_to_index.get(req_id)
 
+            if (
+                self._pp_decode_cadence
+                and req_index is None
+                and req_id in self._mtp_pending_valid
+            ):
+                # continue34 frontier-fix (M3b): under cadence the re-added cohort
+                # bypasses both the in-batch deferred spec correction and the
+                # (disabled) GPU kernel, so the scheduler's optimistic
+                # num_computed_tokens / num_output_tokens run num_rejected_prev
+                # ahead of the true frontier. Correct BOTH by the same delta using
+                # the handoff ring's authoritative accept count for the previous
+                # decode (_mtp_pending_valid == 1 bonus + accepted drafts). Read
+                # prev_num_draft_len before the block below resets it to 0 -- it
+                # still holds the previous decode's draft count (untouched across
+                # the throttle window since a throttled req is absent from
+                # scheduled_cached_reqs).
+                num_rejected_prev = req_state.prev_num_draft_len - (
+                    self._mtp_pending_valid[req_id] - 1
+                )
+                if num_rejected_prev > 0:
+                    num_computed_tokens -= num_rejected_prev
+                    num_output_tokens -= num_rejected_prev
+
             if req_state.prev_num_draft_len and self.use_async_scheduling:
                 # prev_num_draft_len is used in async scheduling mode with
                 # spec decode. it indicates if need to update num_computed_tokens
@@ -1545,7 +1674,14 @@ class GPUModelRunner(
                     self.input_batch.is_token_ids[
                         req_index, start_token_index:end_token_index
                     ] = True
-                    self.input_batch.num_tokens_no_spec[req_index] = end_token_index
+                    # PP+MTP H3: under async + _is_pp_spec_decode, num_computed_tokens
+                    # (hence end_token_index) is OPTIMISTIC (assumes all drafts
+                    # accepted). Skip this local nts write so nts holds the previous
+                    # step's authoritative value through this forward; the handoff
+                    # sets the correct nts and the GPU kernel corrects
+                    # num_computed_tokens via valid_sampled_token_count_gpu.
+                    if not (self._is_pp_spec_decode and self.use_async_scheduling):
+                        self.input_batch.num_tokens_no_spec[req_index] = end_token_index
 
             # Add spec_token_ids to token_ids_cpu.
             self.input_batch.update_req_spec_token_ids(req_state, scheduled_spec_tokens)
@@ -1820,7 +1956,17 @@ class GPUModelRunner(
 
         Populates self.prev_positions.np[:num_reqs] with the mapping.
         """
-        prev_req_id_to_index = self.input_batch.prev_req_id_to_index
+        # M3b: on a cadence step re-adding a churned cohort, the draft/bonus
+        # scatter must index the slot-row layout (matching the landed
+        # prev_sampled_token_ids / _draft_token_ids), so use the dedicated slot-row
+        # scatter map. prev_req_id_to_index is deliberately kept at the this-step
+        # layout on the sample rank (for update_async_*), so it cannot be used
+        # here. Off cadence / non-re-add steps: fall back to the normal map.
+        prev_req_id_to_index = (
+            self._mtp_cadence_scatter_index
+            if (self._pp_decode_cadence and self._mtp_cadence_scatter_index)
+            else self.input_batch.prev_req_id_to_index
+        )
         prev_positions = self.prev_positions.np[:num_reqs]
 
         if not prev_req_id_to_index:
@@ -1959,6 +2105,12 @@ class GPUModelRunner(
         # because input_ids dtype is torch.int32,
         # so convert draft_token_ids to torch.int32 here.
         draft_token_ids = self._draft_token_ids.to(dtype=torch.int32)
+        if self._pp_decode_cadence:
+            # M3b: a re-added cohort's draft slots may hold a stale / -1
+            # placeholder id; scattered into input_ids and later read as a vocab
+            # offset an OOB id -> illegal memory (only bites at high-conc + 32k
+            # chunked-prefill). Clamp to [0, vocab).
+            draft_token_ids = draft_token_ids.clamp(0, self.input_batch.vocab_size - 1)
 
         self.input_ids.gpu.scatter_(
             dim=0,
@@ -2208,10 +2360,15 @@ class GPUModelRunner(
         # CPU values are optimistic (all drafts accepted). The kernel
         # corrects on GPU using the previous step's
         # valid_sampled_token_count_gpu. Otherwise, just copy from CPU.
+        # M3b: under decode cadence the batch churns (cohort re-added each step),
+        # so this kernel's row layout (prev_positions / prev_req_id_to_index)
+        # assumptions break; the CPU frontier-fix in _update_states corrects
+        # num_computed instead. Disable the GPU correction under cadence.
         if (
             self.use_async_spec_decode
             and self.valid_sampled_token_count_gpu is not None
             and prev_req_id_to_index
+            and not self._pp_decode_cadence
         ):
             self.prev_positions.copy_to_gpu(num_reqs)
             self.prev_num_draft_tokens.copy_to_gpu()
@@ -2640,7 +2797,11 @@ class GPUModelRunner(
                 cm.block_table_tensor = _get_block_table(kv_cache_gid)
                 cm.slot_mapping = slot_mappings[kv_cache_gid]
 
-            if self.speculative_config and spec_decode_common_attn_metadata is None:
+            if (
+                self.speculative_config
+                and spec_decode_common_attn_metadata is None
+                and self.drafter is not None
+            ):
                 if isinstance(
                     self.drafter,
                     (
@@ -4673,7 +4834,11 @@ class GPUModelRunner(
             self.kv_connector_output = None
             # receive sampled token ids from the last PP rank.
             if self.use_async_scheduling and not get_pp_group().is_last_rank:
-                self._pp_receive_prev_sampled_token_ids_to_input_batch()
+                if self._is_pp_spec_decode:
+                    # PP+MTP port: receive the packed MTP handoff.
+                    self._pp_apply_mtp_handoff()
+                else:
+                    self._pp_receive_prev_sampled_token_ids_to_input_batch()
             # In case of PP with kv transfer, we need to pass through the
             # kv_connector_output
             return ModelRunnerOutput.with_kv_conn_output_only(kv_connector_output)
@@ -4712,9 +4877,14 @@ class GPUModelRunner(
             # PP outputs have been broadcasted to all ranks at logits computation.
             # Therefore, here is no need to send sampled token ids again in this case.
             if not self.broadcast_pp_output and pp.world_size > 1 and pp.is_last_rank:
-                self._pp_broadcast_prev_sampled_token_ids(
-                    sampler_output.sampled_token_ids
-                )
+                if self._is_pp_spec_decode:
+                    # PP+MTP port: MTP handoff (sent after propose) supersedes
+                    # this broadcast; skip to avoid duplicate communication.
+                    pass
+                else:
+                    self._pp_broadcast_prev_sampled_token_ids(
+                        sampler_output.sampled_token_ids
+                    )
 
         self._draft_token_ids = None
         self._draft_probs = None
@@ -4866,6 +5036,18 @@ class GPUModelRunner(
                 )
                 self.drafter.dummy_run(num_tokens=1)
 
+        # PP+MTP port: after the drafter produced _draft_token_ids (either at the
+        # use_gpu_toks call above or here after bookkeeping), the last PP rank
+        # packs sampled+draft+nts into one tensor and broadcasts to non-last
+        # ranks. Placed after the whole propose block so it fires regardless of
+        # which propose branch ran.
+        if (
+            self._is_pp_spec_decode
+            and self.use_async_scheduling
+            and get_pp_group().is_last_rank
+        ):
+            self._pp_send_mtp_handoff(sampler_output.sampled_token_ids)
+
         # Finalize KV connector (wait_for_save + clear metadata) after
         # draft model runs. Deferred from target model forward to allow
         # draft model to also save its KV cache.
@@ -4958,12 +5140,11 @@ class GPUModelRunner(
         assert sampled_token_ids.dim() == 2 and sampled_token_ids.shape[-1] == 1, (
             "PP+async expects sampled_token_ids to have shape [num_reqs, 1]"
         )
-        # Skip for chunked prefill: sampled tokens are dummy
-        # and will be discarded, no need to broadcast.
-        if not self._is_all_reqs_chunked_prefill():
-            torch.distributed.broadcast(
-                sampled_token_ids, src=pp.rank, group=pp.device_group
-            )
+        # PP+MTP port: always broadcast (even for chunked prefill) so the
+        # non-last ranks' matching receive stays NCCL-paired.
+        torch.distributed.broadcast(
+            sampled_token_ids, src=pp.rank, group=pp.device_group
+        )
 
     def _pp_receive_prev_sampled_token_ids_to_input_batch(self) -> None:
         """Receive sampled token ids broadcast from last PP stage"""
@@ -4995,6 +5176,379 @@ class GPUModelRunner(
             pos = self.input_batch.num_tokens_no_spec[i]
             self.input_batch.is_token_ids[i, pos] = True
             self.input_batch.num_tokens_no_spec[i] = pos + 1
+        self.input_batch.prev_req_id_to_index = prev_req_id_to_index
+
+    def _pp_send_mtp_handoff(self, sampled_token_ids):
+        """PP last rank: pack MTP handoff and broadcast to non-last ranks.
+
+        layout [num_reqs, 2 + 2*num_spec]:
+          sampled_token_ids [num_reqs, 1+num_spec] | draft [num_reqs, num_spec]
+          | nts [num_reqs, 1]. Always broadcasts (zeros during chunked prefill)
+        to keep NCCL paired.
+        """
+        pp = get_pp_group()
+        assert pp.is_last_rank
+        num_reqs = self.input_batch.num_reqs
+        num_spec = self.num_spec_tokens
+
+        if sampled_token_ids.shape[-1] > 1:
+            stid = sampled_token_ids[:num_reqs].to(torch.int32)
+        else:
+            stid = torch.full(
+                (num_reqs, 1 + num_spec), -1,
+                dtype=torch.int32, device=self.device,
+            )
+            stid[:, 0] = sampled_token_ids[:num_reqs, 0]
+
+        if self._draft_token_ids is not None and isinstance(
+            self._draft_token_ids, torch.Tensor
+        ):
+            did = self._draft_token_ids[:num_reqs].to(torch.int32)
+        else:
+            did = torch.zeros(
+                (num_reqs, num_spec), dtype=torch.int32, device=self.device,
+            )
+
+        nts = torch.tensor(
+            self.input_batch.num_tokens_no_spec[:num_reqs],
+            dtype=torch.int32, device=self.device,
+        ).unsqueeze(1)
+
+        handoff = torch.cat([stid, did, nts], dim=1)
+        send_work = None
+        if self._pp_async_bcast:
+            # Phase A: issue async so the collective overlaps the next cohort's
+            # forward. Keep `handoff` alive via raw_handoff on the slot and wait
+            # at consume (symmetric with the non-last recv wait; NCCL pairing).
+            send_work = torch.distributed.broadcast(
+                handoff, src=pp.rank, group=pp.device_group, async_op=True
+            )
+        else:
+            torch.distributed.broadcast(handoff, src=pp.rank, group=pp.device_group)
+
+        if self._pp_decode_cadence:
+            # Last-rank self-handoff (M3b): stash the same packed data locally so
+            # the sample rank lands its own draft/prev_sampled at the deferred
+            # apply pp_size steps later and reconciles num_computed/output at
+            # re-add, mirroring the non-last-rank receive. Derive prev_sampled /
+            # valid_counts from stid (this rank's own sampled ids), not a broadcast.
+            valid_mask = stid != -1
+            valid_counts = valid_mask.sum(dim=1)
+            last_valid_pos = (valid_counts - 1).clamp(min=0)
+            prev_sampled = stid.gather(1, last_valid_pos.unsqueeze(1))
+            nts_np = nts.squeeze(1).cpu().numpy()
+            # Derivation reads this rank's own stid (ready) -> derive_pending stays
+            # False; only the send collective is deferred. Store send_work (consume
+            # waits it) and raw_handoff (keeps the send buffer alive until then).
+            self._stash_mtp_handoff_slot(
+                num_reqs, prev_sampled, valid_counts.to(torch.int32), did, nts_np,
+                bcast_work=send_work,
+                raw_handoff=handoff if self._pp_async_bcast else None,
+            )
+
+    def _pp_apply_mtp_handoff(self):
+        """Non-last PP rank: receive MTP handoff and apply to input_batch.
+
+        Always communicates (NCCL pairing). During chunked prefill the received
+        tensor is discarded downstream. Two paths:
+          * inline (default): receive + apply immediately (original behavior).
+          * ring (VLLM_PPMTP_HANDOFF_RING): receive + stash into _mtp_ring; the
+            per-req correction is deferred to the top of the next _update_states
+            (_apply_pending_mtp_handoff), so the extra mcb=pp_size+1 in-flight
+            batch cannot race the correction. See P2/M3a in
+            prof/HANDOFF_ppmtp_overlap_reimpl.md.
+        """
+        if envs.VLLM_PPMTP_HANDOFF_RING:
+            self._pp_receive_mtp_handoff_to_ring()
+        else:
+            self._pp_apply_mtp_handoff_inline()
+
+    def _derive_mtp_handoff(self, handoff):
+        """Unpack a received/packed handoff tensor into the per-req fields.
+
+        Reads `handoff` (incl. a blocking nts D2H), so under async broadcast this
+        must run only after the collective completes (bcast_work.wait()). Returns
+        (prev_sampled[num_reqs,1], valid_counts[num_reqs] int32,
+        draft[num_reqs,num_spec], nts_np[num_reqs]).
+        """
+        num_spec = self.num_spec_tokens
+        sampled, draft, nts_col = handoff.split([1 + num_spec, num_spec, 1], dim=1)
+
+        # prev_sampled_token_ids: last valid token per request
+        valid_mask = sampled != -1
+        valid_counts = valid_mask.sum(dim=1)
+        last_valid_pos = (valid_counts - 1).clamp(min=0)
+        prev_sampled = sampled.gather(1, last_valid_pos.unsqueeze(1))
+        # nts (authoritative value from last rank) -- blocking D2H
+        nts = nts_col.squeeze(1).cpu().numpy()
+        return prev_sampled, valid_counts.to(torch.int32), draft, nts
+
+    def _pp_recv_mtp_handoff(self):
+        """Sync receive + unpack the broadcast handoff (inline + ring sync path).
+
+        Returns (num_reqs, prev_sampled[num_reqs,1], valid_counts[num_reqs],
+        draft[num_reqs,num_spec], nts_np[num_reqs]).
+        """
+        pp = get_pp_group()
+        assert not pp.is_last_rank
+        num_reqs = self.input_batch.num_reqs
+        num_spec = self.num_spec_tokens
+
+        handoff = torch.empty(
+            (num_reqs, 2 + 2 * num_spec), dtype=torch.int32, device=self.device,
+        )
+        torch.distributed.broadcast(
+            handoff, src=pp.last_rank, group=pp.device_group
+        )
+        prev_sampled, valid_counts, draft, nts = self._derive_mtp_handoff(handoff)
+        return num_reqs, prev_sampled, valid_counts, draft, nts
+
+    def _pp_apply_mtp_handoff_inline(self):
+        """Original inline path: receive + apply immediately (fallback)."""
+        num_reqs, prev_sampled, valid_counts, draft, nts = (
+            self._pp_recv_mtp_handoff()
+        )
+        self._apply_mtp_handoff_fields(
+            num_reqs, prev_sampled, valid_counts, draft, nts,
+            list(self.input_batch.req_ids),
+            self.input_batch.num_prompt_tokens[:num_reqs],
+            self.discard_request_mask.np[:num_reqs],
+        )
+
+    def _stash_mtp_handoff_slot(
+        self, num_reqs, prev_sampled, valid_counts, draft, nts,
+        bcast_work=None, raw_handoff=None, derive_pending=False,
+    ):
+        """Build an MTPHandoffSlot from handoff fields and append it to the ring
+        (deferred apply). Shared by the non-last-rank receive and (under cadence)
+        the last-rank self-handoff. Snapshots the receive-time per-req CPU state so
+        a deferred apply reproduces the receive-time view. Under async broadcast the
+        derived GPU fields may be None (derive_pending=True on the non-last rank);
+        they are filled at consume after bcast_work.wait()."""
+        slot = MTPHandoffSlot(
+            num_reqs=num_reqs,
+            prev_sampled_token_ids=prev_sampled,
+            valid_sampled_token_count_gpu=valid_counts,
+            draft_token_ids=draft,
+            nts=nts,
+            req_ids=list(self.input_batch.req_ids),
+            num_prompt_tokens=np.asarray(
+                self.input_batch.num_prompt_tokens[:num_reqs]
+            ).copy(),
+            discard_mask=np.asarray(
+                self.discard_request_mask.np[:num_reqs]
+            ).copy(),
+            bcast_work=bcast_work,
+            raw_handoff=raw_handoff,
+            derive_pending=derive_pending,
+        )
+        # Write into the None slot the dispatcher reserved at ring[-1] this step
+        # (1:1 receive/send : consume ordering, holds at any depth). The ring is
+        # sized by _apply_pending_mtp_handoff, which runs earlier this step.
+        assert self._mtp_ring and self._mtp_ring[-1] is None, (
+            "MTP handoff ring slot overwritten before consumption; "
+            "execute_model/sample_tokens ordering assumption violated"
+        )
+        self._mtp_ring[-1] = slot
+
+    def _pp_receive_mtp_handoff_to_ring(self):
+        """Ring path: receive + stash a slot; no apply here (deferred to
+        _apply_pending_mtp_handoff at the next _update_states).
+
+        Under async broadcast (VLLM_PPMTP_ASYNC_BCAST) only ISSUE the collective
+        here and stash the raw buffer + work handle; the wait + derivation run at
+        consume, so this returns immediately and the broadcast overlaps the next
+        (independent) cohort's forward."""
+        if self._pp_async_bcast:
+            pp = get_pp_group()
+            assert not pp.is_last_rank
+            num_reqs = self.input_batch.num_reqs
+            num_spec = self.num_spec_tokens
+            handoff = torch.empty(
+                (num_reqs, 2 + 2 * num_spec), dtype=torch.int32, device=self.device,
+            )
+            work = torch.distributed.broadcast(
+                handoff, src=pp.last_rank, group=pp.device_group, async_op=True
+            )
+            # Stash raw buffer + work; derived fields filled at consume post-wait.
+            self._stash_mtp_handoff_slot(
+                num_reqs, None, None, None, None,
+                bcast_work=work, raw_handoff=handoff, derive_pending=True,
+            )
+            return
+        num_reqs, prev_sampled, valid_counts, draft, nts = (
+            self._pp_recv_mtp_handoff()
+        )
+        self._stash_mtp_handoff_slot(num_reqs, prev_sampled, valid_counts, draft, nts)
+
+    def _apply_pending_mtp_handoff(self):
+        """Advance the handoff ring by one step and apply the due slot at the top
+        of _update_states (before any composition change / consumption).
+
+        Resets the per-step cadence scatter map + pending dicts (repopulated only
+        by a cadence landing this step), then pops the slot buffered
+        _mtp_handoff_ring_depth steps ago (depth 1 = M3a inline timing; pp_size =
+        M3b cadence) and dispatches to the M3a or M3b landing routine.
+        """
+        if not self._ppmtp_diag_logged:
+            self._ppmtp_diag_logged = True
+            logger.info(
+                "[PPMTP-DIAG] rank=%d last=%s cadence=%s async_bcast=%s "
+                "ring_depth=%d (VLLM_PPMTP_ASYNC_BCAST=%s)",
+                get_pp_group().rank_in_group, get_pp_group().is_last_rank,
+                self._pp_decode_cadence, self._pp_async_bcast,
+                self._mtp_handoff_ring_depth, envs.VLLM_PPMTP_ASYNC_BCAST,
+            )
+        # continue31: reset per-step cadence state; a cadence landing repopulates
+        # it. Stale values would misroute the next step's draft scatter / frontier.
+        self._mtp_cadence_scatter_index = None
+        self._mtp_pending_nts = {}
+        self._mtp_pending_valid = {}
+        # Fixed-size ring of `depth` None-placeholder slots, rotated by EXACTLY one
+        # every step (not per-stash). The defer must be step-based so a slot lands
+        # pp_size steps later == when its cohort re-decodes, even when
+        # low-concurrency cadence produces empty (no-stash) steps in between. Size
+        # lazily: depth is a property needing the PP group (unavailable in __init__).
+        depth = self._mtp_handoff_ring_depth
+        if len(self._mtp_ring) != depth:
+            self._mtp_ring = deque([None] * depth, maxlen=depth)
+        slot = self._mtp_ring.popleft()
+        self._mtp_ring.append(None)
+        if slot is None:
+            return
+        # P7/Phase A (VLLM_PPMTP_ASYNC_BCAST): finalize the async handoff. The
+        # collective was issued _mtp_handoff_ring_depth steps ago and has been
+        # overlapping the intervening (independent) cohort forward(s), so this wait
+        # is ~free. Both ranks wait (NCCL symmetry / buffer safety). Then run the
+        # non-last rank's deferred derivation (reads raw_handoff) before applying.
+        # No-op on the sync path (bcast_work is None, derive_pending is False).
+        if slot.bcast_work is not None:
+            slot.bcast_work.wait()
+            slot.bcast_work = None
+        if slot.derive_pending:
+            prev_sampled, valid_counts, draft, nts = self._derive_mtp_handoff(
+                slot.raw_handoff
+            )
+            slot.prev_sampled_token_ids = prev_sampled
+            slot.valid_sampled_token_count_gpu = valid_counts
+            slot.draft_token_ids = draft
+            slot.nts = nts
+            slot.derive_pending = False
+        slot.raw_handoff = None  # release keepalive (draft view retains storage)
+        if self._pp_decode_cadence:
+            self._apply_pending_mtp_handoff_cadence(slot)
+        else:
+            self._apply_pending_mtp_handoff_m3a(slot)
+
+    def _apply_pending_mtp_handoff_m3a(self, slot: "MTPHandoffSlot") -> None:
+        """M3a (cadence off, ring depth 1): land against the still-current (==
+        sender) batch layout. Raw-index writes are valid because nothing churns
+        the batch between receive and this next-step apply."""
+        self._apply_mtp_handoff_fields(
+            slot.num_reqs,
+            slot.prev_sampled_token_ids,
+            slot.valid_sampled_token_count_gpu,
+            slot.draft_token_ids,
+            slot.nts,
+            slot.req_ids,
+            slot.num_prompt_tokens,
+            slot.discard_mask,
+        )
+
+    def _apply_pending_mtp_handoff_cadence(self, slot: "MTPHandoffSlot") -> None:
+        """M3b (cadence on, ring depth pp_size): the cohort this slot belongs to
+        was churned out of the batch and is being re-added THIS step, so nothing
+        can be keyed by raw slot row against the current batch.
+
+        Land the GPU tensors (draft + prev_sampled) so _prepare_input_ids scatters
+        the ring-delivered drafts into the verify input_ids (else the last
+        (sample) rank's draft slots stay -1 -> target verifies against -1 ->
+        acceptance collapses to 1.0). Stash per-req_id authoritative nts + accept
+        count for the re-add frontier-fix (drained in _update_states' cached-req
+        loop). Build the slot-row draft/bonus scatter map. Deliberately does NOT
+        touch output_token_ids / num_computed here: the cohort is re-added via the
+        resumed path this step, which restores output_token_ids from the
+        scheduler's authoritative all_token_ids; the frontier is corrected in the
+        cached-req loop via _mtp_pending_valid.
+        """
+        num_reqs = slot.num_reqs
+        req_ids = slot.req_ids
+        nts = slot.nts
+        valid_counts = slot.valid_sampled_token_count_gpu[:num_reqs].cpu().numpy()
+        discard_set = set(np.nonzero(slot.discard_mask)[0])
+        pending_nts: dict[str, int] = {}
+        pending_valid: dict[str, int] = {}
+        scatter_index: dict[str, int] = {}
+        for i, req_id in enumerate(req_ids):
+            if req_id is None or i in discard_set:
+                continue
+            pending_nts[req_id] = int(nts[i])
+            pending_valid[req_id] = int(valid_counts[i])
+            scatter_index[req_id] = i
+        self._mtp_pending_nts = pending_nts
+        self._mtp_pending_valid = pending_valid
+        # Land draft + prev_sampled (both ranks) so _prepare_input_ids' async path
+        # scatters ring-delivered drafts (prev_sampled bonus + _draft_token_ids)
+        # into the verify slots using the slot-row scatter map below.
+        self._draft_token_ids = slot.draft_token_ids
+        self.input_batch.prev_sampled_token_ids = slot.prev_sampled_token_ids
+        self._mtp_cadence_scatter_index = scatter_index
+        # Last (sample) rank keeps its own this-step prev_req_id_to_index (built by
+        # _bookkeeping_sync, indexed by update_async_* -> a slot-row value there is
+        # out of bounds when cohort size != this-step batch => IndexError). The
+        # non-last rank never samples, so keep its prev_req_id_to_index at slot-row
+        # and land vstc there.
+        if get_pp_group().is_last_rank:
+            return
+        self.input_batch.prev_req_id_to_index = scatter_index
+        self.valid_sampled_token_count_gpu = slot.valid_sampled_token_count_gpu
+
+    def _apply_mtp_handoff_fields(
+        self, num_reqs, prev_sampled, valid_counts, draft, nts,
+        req_ids, num_prompt_tokens, discard_mask,
+    ):
+        """Shared apply body for inline + ring paths (mutates input_batch).
+
+        All args are the values captured at handoff-receive time; the ring path
+        snapshots them so a deferred apply reproduces the inline apply exactly.
+        """
+        self.input_batch.prev_sampled_token_ids = prev_sampled
+        # vstc (derived from sampled_token_ids)
+        self.valid_sampled_token_count_gpu = valid_counts
+        # draft_token_ids
+        self._draft_token_ids = draft
+        # nts (authoritative value from last rank)
+        self.input_batch.num_tokens_no_spec[:num_reqs] = nts
+
+        # Trim output_token_ids (correct length = nts - num_prompt_tokens)
+        for i in range(num_reqs):
+            req_id = req_ids[i]
+            if req_id is None:
+                continue
+            req_state = self.requests.get(req_id)
+            if req_state is None:
+                continue
+            npp = num_prompt_tokens[i]
+            correct_len = int(nts[i]) - npp
+            if 0 <= correct_len < len(req_state.output_token_ids):
+                del req_state.output_token_ids[correct_len:]
+
+        # Construct prev_req_id_to_index
+        discard_req_indices = np.nonzero(discard_mask)[0]
+        discard_req_indices_set = set(discard_req_indices)
+        prev_req_id_to_index: dict[str, int] = {}
+        for i, req_id in enumerate(req_ids):
+            if i in discard_req_indices_set:
+                continue
+            prev_req_id_to_index[req_id] = i
+            if (req_state := self.requests.get(req_id)) is not None:
+                req_state.output_token_ids.append(-1)
+            # PP+MTP §5-C (resolved): stock _pp_receive advances is_token_ids
+            # here, but is_token_ids is only consulted when enable_prompt_embeds
+            # is True (gpu_model_runner.py ~1972 / ~3494). GLM-5.2 is pure text
+            # (enable_prompt_embeds=False) -> is_token_ids is unused on this path,
+            # so this is a no-op for the target. Only prompt-embeds/multimodal
+            # draft models would need it (out of scope).
         self.input_batch.prev_req_id_to_index = prev_req_id_to_index
 
     def take_draft_token_ids(self) -> DraftTokenIds | None:
@@ -5439,7 +5993,7 @@ class GPUModelRunner(
                     self.model = self.load_lora_model(
                         self.model, self.vllm_config, self.device
                     )
-                if hasattr(self, "drafter"):
+                if hasattr(self, "drafter") and self.drafter is not None:
                     logger.info_once("Loading drafter model...")
                     if hasattr(self.drafter, "load_model"):
                         self.drafter.load_model(self.model)
@@ -6276,7 +6830,7 @@ class GPUModelRunner(
             else:
                 hidden_states = outputs
 
-            if self.speculative_config and (
+            if self.speculative_config and self.drafter is not None and (
                 self.speculative_config.use_eagle()
                 or self.speculative_config.uses_draft_model()
                 or self.speculative_config.uses_extract_hidden_states()
@@ -7283,7 +7837,7 @@ class GPUModelRunner(
         self.calculate_reorder_batch_threshold()
 
         # Initialize drafter attention backend
-        if self.speculative_config and (
+        if self.speculative_config and self.drafter is not None and (
             self.speculative_config.use_eagle()
             or self.speculative_config.uses_draft_model()
         ):
@@ -7337,7 +7891,7 @@ class GPUModelRunner(
         )
 
         # Initialize drafter's cudagraph dispatcher if using spec decode.
-        if self.speculative_config and (
+        if self.speculative_config and self.drafter is not None and (
             self.speculative_config.use_eagle()
             or self.speculative_config.uses_draft_model()
             or self.speculative_config.uses_extract_hidden_states()
@@ -7786,17 +8340,19 @@ class GPUModelRunner(
         )
         self._kernel_block_sizes = kernel_block_sizes
 
-        # create metadata builders
-        self.initialize_metadata_builders(kv_cache_config, kernel_block_sizes)
-
         # Reinitialize need to after initialize_attn_backend
         self.may_reinitialize_input_batch(kv_cache_config, kernel_block_sizes)
+
+        # Create metadata builders after InputBatch has the final max_model_len.
+        self.initialize_metadata_builders(kv_cache_config, kernel_block_sizes)
+
         kv_caches = self.initialize_kv_cache_tensors(
             kv_cache_config, kernel_block_sizes
         )
 
         if (
             self.speculative_config
+            and self.drafter is not None
             and self.speculative_config.uses_extract_hidden_states()
         ):
             assert isinstance(self.drafter, ExtractHiddenStatesProposer)

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -10,7 +10,7 @@ from collections import defaultdict, deque
 from collections.abc import Callable, Iterable, Iterator, Sequence
 from contextlib import AbstractContextManager, contextmanager, nullcontext
 from copy import copy, deepcopy
-from dataclasses import replace
+from dataclasses import dataclass, replace
 from functools import reduce
 from typing import TYPE_CHECKING, Any, NamedTuple, TypeAlias, cast
 
@@ -666,21 +666,20 @@ class GPUModelRunner(
         # layers in the draft model.
         # PP+MTP port: the entire draft model lives only on the last PP rank.
         # On every other rank set drafter=None so the guards below skip it.
-        if self.speculative_config and not get_pp_group().is_last_rank:
-            self.drafter = None
+        self.drafter: (
+            NgramProposer  # noqa: F823
+            | NgramProposerGPU
+            | SuffixDecodingProposer
+            | EagleProposer
+            | DFlashProposer
+            | DraftModelProposer
+            | MedusaProposer
+            | ExtractHiddenStatesProposer
+            | Gemma4Proposer
+            | Step3p5MTPProposer
+            | None
+        ) = None
         if self.speculative_config and get_pp_group().is_last_rank:
-            self.drafter: (
-                NgramProposer  # noqa: F823
-                | NgramProposerGPU
-                | SuffixDecodingProposer
-                | EagleProposer
-                | DFlashProposer
-                | DraftModelProposer
-                | MedusaProposer
-                | ExtractHiddenStatesProposer
-                | Gemma4Proposer
-                | Step3p5MTPProposer
-            )
             if self.speculative_config.method == "custom_class":
                 self.drafter = create_custom_proposer(  # type: ignore[assignment]
                     self.vllm_config
@@ -1064,7 +1063,7 @@ class GPUModelRunner(
         handoff ring overlaps across PP stages. Must match the scheduler-side
         Scheduler._pp_decode_cadence gate. Only meaningful for V1 PP + MTP + async;
         the worker handoff ring deepens to pp_size when on (INV-RING)."""
-        return (
+        return bool(
             envs.VLLM_V1_PP_DECODE_CADENCE
             and self._is_pp_spec_decode
             and self.use_async_scheduling
@@ -5195,8 +5194,10 @@ class GPUModelRunner(
             stid = sampled_token_ids[:num_reqs].to(torch.int32)
         else:
             stid = torch.full(
-                (num_reqs, 1 + num_spec), -1,
-                dtype=torch.int32, device=self.device,
+                (num_reqs, 1 + num_spec),
+                -1,
+                dtype=torch.int32,
+                device=self.device,
             )
             stid[:, 0] = sampled_token_ids[:num_reqs, 0]
 
@@ -5206,12 +5207,15 @@ class GPUModelRunner(
             did = self._draft_token_ids[:num_reqs].to(torch.int32)
         else:
             did = torch.zeros(
-                (num_reqs, num_spec), dtype=torch.int32, device=self.device,
+                (num_reqs, num_spec),
+                dtype=torch.int32,
+                device=self.device,
             )
 
         nts = torch.tensor(
             self.input_batch.num_tokens_no_spec[:num_reqs],
-            dtype=torch.int32, device=self.device,
+            dtype=torch.int32,
+            device=self.device,
         ).unsqueeze(1)
 
         handoff = torch.cat([stid, did, nts], dim=1)
@@ -5241,7 +5245,11 @@ class GPUModelRunner(
             # False; only the send collective is deferred. Store send_work (consume
             # waits it) and raw_handoff (keeps the send buffer alive until then).
             self._stash_mtp_handoff_slot(
-                num_reqs, prev_sampled, valid_counts.to(torch.int32), did, nts_np,
+                num_reqs,
+                prev_sampled,
+                valid_counts.to(torch.int32),
+                did,
+                nts_np,
                 bcast_work=send_work,
                 raw_handoff=handoff if self._pp_async_bcast else None,
             )
@@ -5295,29 +5303,38 @@ class GPUModelRunner(
         num_spec = self.num_spec_tokens
 
         handoff = torch.empty(
-            (num_reqs, 2 + 2 * num_spec), dtype=torch.int32, device=self.device,
+            (num_reqs, 2 + 2 * num_spec),
+            dtype=torch.int32,
+            device=self.device,
         )
-        torch.distributed.broadcast(
-            handoff, src=pp.last_rank, group=pp.device_group
-        )
+        torch.distributed.broadcast(handoff, src=pp.last_rank, group=pp.device_group)
         prev_sampled, valid_counts, draft, nts = self._derive_mtp_handoff(handoff)
         return num_reqs, prev_sampled, valid_counts, draft, nts
 
     def _pp_apply_mtp_handoff_inline(self):
         """Original inline path: receive + apply immediately (fallback)."""
-        num_reqs, prev_sampled, valid_counts, draft, nts = (
-            self._pp_recv_mtp_handoff()
-        )
+        num_reqs, prev_sampled, valid_counts, draft, nts = self._pp_recv_mtp_handoff()
         self._apply_mtp_handoff_fields(
-            num_reqs, prev_sampled, valid_counts, draft, nts,
+            num_reqs,
+            prev_sampled,
+            valid_counts,
+            draft,
+            nts,
             list(self.input_batch.req_ids),
             self.input_batch.num_prompt_tokens[:num_reqs],
             self.discard_request_mask.np[:num_reqs],
         )
 
     def _stash_mtp_handoff_slot(
-        self, num_reqs, prev_sampled, valid_counts, draft, nts,
-        bcast_work=None, raw_handoff=None, derive_pending=False,
+        self,
+        num_reqs,
+        prev_sampled,
+        valid_counts,
+        draft,
+        nts,
+        bcast_work=None,
+        raw_handoff=None,
+        derive_pending=False,
     ):
         """Build an MTPHandoffSlot from handoff fields and append it to the ring
         (deferred apply). Shared by the non-last-rank receive and (under cadence)
@@ -5335,9 +5352,7 @@ class GPUModelRunner(
             num_prompt_tokens=np.asarray(
                 self.input_batch.num_prompt_tokens[:num_reqs]
             ).copy(),
-            discard_mask=np.asarray(
-                self.discard_request_mask.np[:num_reqs]
-            ).copy(),
+            discard_mask=np.asarray(self.discard_request_mask.np[:num_reqs]).copy(),
             bcast_work=bcast_work,
             raw_handoff=raw_handoff,
             derive_pending=derive_pending,
@@ -5365,20 +5380,26 @@ class GPUModelRunner(
             num_reqs = self.input_batch.num_reqs
             num_spec = self.num_spec_tokens
             handoff = torch.empty(
-                (num_reqs, 2 + 2 * num_spec), dtype=torch.int32, device=self.device,
+                (num_reqs, 2 + 2 * num_spec),
+                dtype=torch.int32,
+                device=self.device,
             )
             work = torch.distributed.broadcast(
                 handoff, src=pp.last_rank, group=pp.device_group, async_op=True
             )
             # Stash raw buffer + work; derived fields filled at consume post-wait.
             self._stash_mtp_handoff_slot(
-                num_reqs, None, None, None, None,
-                bcast_work=work, raw_handoff=handoff, derive_pending=True,
+                num_reqs,
+                None,
+                None,
+                None,
+                None,
+                bcast_work=work,
+                raw_handoff=handoff,
+                derive_pending=True,
             )
             return
-        num_reqs, prev_sampled, valid_counts, draft, nts = (
-            self._pp_recv_mtp_handoff()
-        )
+        num_reqs, prev_sampled, valid_counts, draft, nts = self._pp_recv_mtp_handoff()
         self._stash_mtp_handoff_slot(num_reqs, prev_sampled, valid_counts, draft, nts)
 
     def _apply_pending_mtp_handoff(self):
@@ -5395,9 +5416,12 @@ class GPUModelRunner(
             logger.info(
                 "[PPMTP-DIAG] rank=%d last=%s cadence=%s async_bcast=%s "
                 "ring_depth=%d (VLLM_PPMTP_ASYNC_BCAST=%s)",
-                get_pp_group().rank_in_group, get_pp_group().is_last_rank,
-                self._pp_decode_cadence, self._pp_async_bcast,
-                self._mtp_handoff_ring_depth, envs.VLLM_PPMTP_ASYNC_BCAST,
+                get_pp_group().rank_in_group,
+                get_pp_group().is_last_rank,
+                self._pp_decode_cadence,
+                self._pp_async_bcast,
+                self._mtp_handoff_ring_depth,
+                envs.VLLM_PPMTP_ASYNC_BCAST,
             )
         # continue31: reset per-step cadence state; a cadence landing repopulates
         # it. Stale values would misroute the next step's draft scatter / frontier.
@@ -5474,6 +5498,8 @@ class GPUModelRunner(
         num_reqs = slot.num_reqs
         req_ids = slot.req_ids
         nts = slot.nts
+        assert slot.valid_sampled_token_count_gpu is not None
+        assert nts is not None
         valid_counts = slot.valid_sampled_token_count_gpu[:num_reqs].cpu().numpy()
         discard_set = set(np.nonzero(slot.discard_mask)[0])
         pending_nts: dict[str, int] = {}
@@ -5504,8 +5530,15 @@ class GPUModelRunner(
         self.valid_sampled_token_count_gpu = slot.valid_sampled_token_count_gpu
 
     def _apply_mtp_handoff_fields(
-        self, num_reqs, prev_sampled, valid_counts, draft, nts,
-        req_ids, num_prompt_tokens, discard_mask,
+        self,
+        num_reqs,
+        prev_sampled,
+        valid_counts,
+        draft,
+        nts,
+        req_ids,
+        num_prompt_tokens,
+        discard_mask,
     ):
         """Shared apply body for inline + ring paths (mutates input_batch).
 
@@ -6830,10 +6863,14 @@ class GPUModelRunner(
             else:
                 hidden_states = outputs
 
-            if self.speculative_config and self.drafter is not None and (
-                self.speculative_config.use_eagle()
-                or self.speculative_config.uses_draft_model()
-                or self.speculative_config.uses_extract_hidden_states()
+            if (
+                self.speculative_config
+                and self.drafter is not None
+                and (
+                    self.speculative_config.use_eagle()
+                    or self.speculative_config.uses_draft_model()
+                    or self.speculative_config.uses_extract_hidden_states()
+                )
             ):
                 assert isinstance(
                     self.drafter,
@@ -7837,9 +7874,13 @@ class GPUModelRunner(
         self.calculate_reorder_batch_threshold()
 
         # Initialize drafter attention backend
-        if self.speculative_config and self.drafter is not None and (
-            self.speculative_config.use_eagle()
-            or self.speculative_config.uses_draft_model()
+        if (
+            self.speculative_config
+            and self.drafter is not None
+            and (
+                self.speculative_config.use_eagle()
+                or self.speculative_config.uses_draft_model()
+            )
         ):
             assert isinstance(
                 self.drafter,
@@ -7891,10 +7932,14 @@ class GPUModelRunner(
         )
 
         # Initialize drafter's cudagraph dispatcher if using spec decode.
-        if self.speculative_config and self.drafter is not None and (
-            self.speculative_config.use_eagle()
-            or self.speculative_config.uses_draft_model()
-            or self.speculative_config.uses_extract_hidden_states()
+        if (
+            self.speculative_config
+            and self.drafter is not None
+            and (
+                self.speculative_config.use_eagle()
+                or self.speculative_config.uses_draft_model()
+                or self.speculative_config.uses_extract_hidden_states()
+            )
         ):
             assert isinstance(
                 self.drafter,


### PR DESCRIPTION
## Summary

- extends the TurboQuant MLA work in #41803 with the GLM-5.2 sparse MLA path on current main
- adds packed 4-bit latent KV storage, fused sparse decode, sparse prefill, and GLM-4 MoE MTP plumbing
- adds DCP/MTP/PP correctness fixes, canonical DCP interleave handling, CUDA-graph-safe workspaces, and asynchronous MTP handoff

## Validation

- end-to-end cold and hot inference workloads completed successfully
- hot-cache median TTFT improved by 31x and median end-to-end latency improved by 8.26x in the validation workload
- all requests completed without connector, engine, worker, or completion errors
- changed-file pre-commit suite passes, including Ruff, mypy, configuration validation, and forbidden CUDA API checks

## Relationship to existing work

#41803 provides the dense Triton-fused TurboQuant MLA decode foundation. This PR adds GLM-5.2 sparse attention, DCP/MTP/PP integration, and the end-to-end sparse prefill/decode path. Opened as draft because the change should likely be split for review.
