### PR TITLE
[Bugfix][Quark] Preserve structured quantization config lists

### DIFF
--- a/tests/quantization/test_quark.py
+++ b/tests/quantization/test_quark.py
@@ -35,6 +35,7 @@ from vllm.model_executor.layers.quantization.utils.mxfp4_utils import (
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     is_layer_skipped,
 )
+from vllm.model_executor.models.utils import WeightsMapper
 from vllm.platforms import current_platform
 from vllm.transformers_utils.repo_utils import hf_api
 
@@ -96,6 +97,24 @@ def test_quark_config_preserves_existing_packed_modules_mapping():
     config = CustomQuarkConfig({})
 
     assert config.packed_modules_mapping["custom_proj"] == ["a", "b"]
+
+
+def test_quark_mapper_preserves_structured_lists():
+    structured = [{"weight": {"dtype": "int4"}}]
+    config = QuarkConfig(
+        {
+            "exclude": ["model.layers.0.self_attn.q_proj"],
+            "weight_quant": structured,
+        }
+    )
+    mapper = WeightsMapper(orig_to_new_prefix={"model.": "language_model."})
+
+    config.apply_vllm_mapper(mapper)
+
+    assert config.quant_config["exclude"] == [
+        "language_model.layers.0.self_attn.q_proj"
+    ]
+    assert config.quant_config["weight_quant"] == structured
 
 
 def test_quark_fp8_w8a8_detects_per_block_config():

--- a/vllm/model_executor/layers/quantization/quark/quark.py
+++ b/vllm/model_executor/layers/quantization/quark/quark.py
@@ -139,7 +139,12 @@ class QuarkConfig(QuantizationConfig):
 
         for k, v in self.quant_config.items():
             if isinstance(v, list):
-                quant_config_with_hf_to_vllm_mapper[k] = hf_to_vllm_mapper.apply_list(v)
+                if all(isinstance(item, str) for item in v):
+                    quant_config_with_hf_to_vllm_mapper[k] = (
+                        hf_to_vllm_mapper.apply_list(v)
+                    )
+                else:
+                    quant_config_with_hf_to_vllm_mapper[k] = v
             elif isinstance(v, dict):
                 quant_config_with_hf_to_vllm_mapper[k] = hf_to_vllm_mapper.apply_dict(v)
             else:


### PR DESCRIPTION
## Purpose

Fixes #52454.

`QuarkConfig.apply_vllm_mapper()` currently sends every list-valued quantization config entry through `WeightsMapper.apply_list()`, which assumes every element is a string module name. Newer Quark configs can contain structured lists (for example dictionaries describing quantization settings), causing model loading to fail with `AttributeError: 'dict' object has no attribute 'endswith'`.

This change only applies the mapper to lists whose elements are all strings. Structured lists are preserved unchanged, while existing string-list mapping behavior remains intact.

## Duplicate check

Before submission, I checked open PRs referencing #52454 and the Quark mapper area. I did not find an existing open PR addressing structured list entries in `apply_vllm_mapper()`.

## Test Plan

Added `test_quark_mapper_preserves_structured_lists` covering both sides of the behavior:

- string module-name lists are still mapped
- structured list entries are preserved unchanged

## Test Result

Focused regression and lint checks passed in the fork CI:

```text
pytest tests/quantization/test_quark.py -k quark_mapper_preserves_structured_lists -q  # passed
ruff check vllm/model_executor/layers/quantization/quark/quark.py tests/quantization/test_quark.py  # passed
ruff format --check vllm/model_executor/layers/quantization/quark/quark.py tests/quantization/test_quark.py  # passed
git diff --check  # passed
```

## Model evaluation

Not applicable. This change only prevents string-only mapper logic from being applied to structured configuration lists; it does not change numerical kernels, sampling, or generated-output behavior.