### PR TITLE
[Bugfix][Mamba] Avoid causal conv1d metadata alignment specialization

### DIFF
--- a/vllm/model_executor/layers/mamba/ops/causal_conv1d.py
+++ b/vllm/model_executor/layers/mamba/ops/causal_conv1d.py
@@ -13,7 +13,20 @@ from vllm.triton_utils import tl, triton
 from vllm.v1.attention.backends.utils import NULL_BLOCK_ID, PAD_SLOT_ID
 
 
-@triton.jit(do_not_specialize_on_alignment=["num_cache_lines"])
+@triton.jit(
+    do_not_specialize_on_alignment=[
+        "num_cache_lines",
+        "cache_indices_ptr",
+        "has_initial_states_ptr",
+        "query_start_loc_ptr",
+        "batch_ptr",
+        "token_chunk_offset_ptr",
+        "block_idx_first_scheduled_token",
+        "block_idx_last_scheduled_token",
+        "initial_state_idx",
+        "num_computed_tokens",
+    ]
+)
 def _causal_conv1d_fwd_kernel(  # continuous batching
     # Pointers to matrices
     x_ptr,  # (dim, cu_seqlen) holding `batch` of actual sequences + padded sequences
@@ -759,7 +772,17 @@ def causal_conv1d_fn(
     return out.to(original_x_dtype)
 
 
-@triton.jit(do_not_specialize_on_alignment=["num_cache_lines"])
+@triton.jit(
+    do_not_specialize_on_alignment=[
+        "num_cache_lines",
+        "batch",
+        "conv_state_indices_ptr",
+        "num_accepted_tokens_ptr",
+        "query_start_loc_ptr",
+        "block_idx_last_scheduled_token",
+        "initial_state_idx",
+    ]
+)
 def _causal_conv1d_update_kernel(
     # Pointers to matrices
     x_ptr,  # (batch, dim, seqlen)


### PR DESCRIPTION
## Purpose

Fixes #52413.

The causal-conv1d Triton kernels currently opt only `num_cache_lines` out of alignment specialization. Several other arguments are scalar metadata pointers whose addresses can vary with runtime slicing and batching even though the kernels only use scalar loads from them. Treating those metadata pointers as alignment-specialized creates redundant JIT variants and can move compilation into inference-time paths that warmup did not cover.

This change excludes only those scalar metadata arguments from alignment specialization in `_causal_conv1d_fwd_kernel` and `_causal_conv1d_update_kernel`. Wide/vectorized data pointers such as `x_ptr`, `w_ptr`, and `conv_state_ptr` remain alignment-specialized.

The kernel body and numerical operations are unchanged.

## Duplicate check

Immediately before submission I checked open PRs referencing #52413 and the issue comments. There was no open PR for #52413 and no contributor claim in the issue thread.

## Test Plan

Per `AGENTS.md`, I did not keep a synthetic AST test that only asserted decorator wiring. The meaningful failure mode is Triton specialization/cache behavior, not a Python public-API behavior that can be reproduced on CPU.

I validated the changed source under the repository's `uv`/pre-commit workflow:

```text
uv venv --python 3.12
uv pip install -r requirements/lint.txt
.venv/bin/pre-commit install
.venv/bin/pre-commit run ruff-check --files vllm/model_executor/layers/mamba/ops/causal_conv1d.py
.venv/bin/pre-commit run ruff-format --files vllm/model_executor/layers/mamba/ops/causal_conv1d.py
git diff --check
```

## Test Result

The focused source checks passed. The same branch was also inspected to confirm that only the two Triton specialization lists changed and that the wide data pointers remain specialized.

I do not have the multi-GPU environment needed to reproduce the reporter's inference-time JIT/shared-cache race, so I am not claiming hardware reproduction of the variant collapse.

## Model evaluation

Not run. This patch changes Triton specialization keys only; it does not change kernel arithmetic, model weights, sampling, or the generated-output computation itself. A normal model eval would not exercise the reported shared compile-cache race.