### PR TITLE
[Bugfix][Spec Decode][Structured Output] Drive grammar masks from GPU logit counts

### DIFF
--- a/tests/v1/spec_decode/test_mtp_structured_output.py
+++ b/tests/v1/spec_decode/test_mtp_structured_output.py
@@ -68,7 +68,7 @@ def test_bitmask_with_padded_invalid_drafts(backend):
     )
 
     assert bitmask is not None
-    assert bitmask.shape[0] == len(padded) + 1
+    assert bitmask.shape[0] == NUM_SPEC_TOKENS + 1
     assert not grammar.is_terminated()
 
 
@@ -139,7 +139,7 @@ def test_bonus_position_constrained_after_invalid_drafts(backend):
         scheduled_spec_decode_tokens={request.request_id: drafts},
     )
     assert bitmask is not None
-    assert bitmask.shape[0] == len(drafts) + 1
+    assert bitmask.shape[0] == NUM_SPEC_TOKENS + 1
 
     assert not (bitmask[-1] == -1).all()
     assert not grammar.is_terminated()
@@ -180,11 +180,11 @@ def test_bitmask_constrained_when_reasoning_ends_midwindow(backend):
     )
 
     assert bitmask is not None
-    assert bitmask.shape[0] == len(drafts) + 1
+    assert bitmask.shape[0] == NUM_SPEC_TOKENS + 1
     assert (bitmask[0] == -1).all()
     assert (bitmask[1] == -1).all()
     assert not (bitmask[2] == -1).all()
-    assert not (bitmask[-1] == -1).all()
+    assert not (bitmask[len(drafts)] == -1).all()
     assert not grammar.is_terminated()
 
 
@@ -230,7 +230,7 @@ def test_bitmask_post_reasoning_end_drafts_skip_grammar_advance(backend):
     )
 
     assert bitmask is not None
-    assert bitmask.shape[0] == len(drafts) + 1
+    assert bitmask.shape[0] == NUM_SPEC_TOKENS + 1
     # Post-marker position is still bitmask-constrained.
     assert not (bitmask[2] == -1).all()
     # Grammar must not have advanced through the unvalidated draft.
@@ -258,7 +258,7 @@ def test_validate_tokens_then_bitmask_round_trip(backend):
         scheduled_spec_decode_tokens={request.request_id: padded},
     )
     assert bitmask is not None
-    assert bitmask.shape[0] == len(padded) + 1
+    assert bitmask.shape[0] == NUM_SPEC_TOKENS + 1
     assert not grammar.is_terminated()
 
 

--- a/vllm/v1/structured_output/__init__.py
+++ b/vllm/v1/structured_output/__init__.py
@@ -228,6 +228,8 @@ class StructuredOutputManager:
 
         # Covers both speculative decoding and diffusion LLMs (canvas_length).
         max_num_spec_tokens = self.vllm_config.num_speculative_tokens
+        num_bonus_tokens = 0 if self.vllm_config.model_config.is_diffusion else 1
+        max_masks_per_req = max_num_spec_tokens + num_bonus_tokens
 
         if self._grammar_bitmask is None:
             assert self.backend is not None
@@ -237,14 +239,14 @@ class StructuredOutputManager:
             # one for each speculative position, and one more for the
             # bonus token / non-speculative token.
             self._grammar_bitmask = self.backend.allocate_token_bitmask(
-                max_batch_size * (1 + max_num_spec_tokens)
+                max_batch_size * max_masks_per_req
             )
 
         # Generate a batched bitmask for all structured output requests.
         # When speculative decoding is enabled, we need to include multiple
         # masks for each request, one for each possible bonus token position.
-        # These are stored inline in the tensor and unpacked by the gpu runner.
-        cumulative_index = 0
+        # Each request owns a fixed-width block so the GPU can use the actual
+        # per-request logit counts without CPU-side mask compaction.
 
         # Optimized parallel filling of bitmasks for
         # non-spec, large-batch-size cases
@@ -254,7 +256,7 @@ class StructuredOutputManager:
         ):
             promises = []
             batch = []
-            for req_id in structured_output_request_ids:
+            for grammar_idx, req_id in enumerate(structured_output_request_ids):
                 request = requests[req_id]
                 structured_output_request = request.structured_output_request
                 if TYPE_CHECKING:
@@ -264,12 +266,10 @@ class StructuredOutputManager:
                     assert isinstance(grammar, StructuredOutputGrammar)
 
                 apply_bitmask = self.should_fill_bitmask(request)
-                batch.append((grammar, cumulative_index, apply_bitmask))
+                batch.append((grammar, grammar_idx * max_masks_per_req, apply_bitmask))
                 if len(batch) == self.fill_bitmask_parallel_batch_size:
                     promises.append(self._async_submit_fill_bitmask(batch))
                     batch = []
-
-                cumulative_index += 1
             if batch:
                 promises.append(self._async_submit_fill_bitmask(batch))
 
@@ -278,7 +278,7 @@ class StructuredOutputManager:
                 promise.result()
         else:
             # Fallback to serial filling of bitmasks for small-batch-size cases
-            for req_id in structured_output_request_ids:
+            for grammar_idx, req_id in enumerate(structured_output_request_ids):
                 request = requests[req_id]
                 structured_output_request = request.structured_output_request
 
@@ -301,8 +301,9 @@ class StructuredOutputManager:
                 state_advancements = 0
                 post_reasoning_end_in_window = False
                 req_tokens = scheduled_spec_decode_tokens.get(req_id, ())
+                bitmask_index = grammar_idx * max_masks_per_req
                 for i, token in enumerate(req_tokens):
-                    self._fill_bitmasks(((grammar, cumulative_index, apply_bitmask),))
+                    self._fill_bitmasks(((grammar, bitmask_index + i, apply_bitmask),))
                     advance_grammar = apply_bitmask
                     if token == -1:
                         apply_bitmask = False
@@ -336,10 +337,9 @@ class StructuredOutputManager:
                             raise AssertionError(
                                 (token, req_id, scheduled_spec_decode_tokens)
                             )
-                    cumulative_index += 1
                 # Diffusion LLMs don't sample a bonus token after the
                 # scheduled positions, so skip its bitmask in that case.
-                if not (self.vllm_config.model_config.is_diffusion and req_tokens):
+                if num_bonus_tokens or not req_tokens:
                     # bonus_apply must be True when the bonus-row position
                     # should be grammar-constrained. Two triggers:
                     # - should_fill_bitmask(request): reasoning was already
@@ -351,14 +351,16 @@ class StructuredOutputManager:
                     #   reasoning_ended is only persisted later by
                     #   should_advance.
                     bonus_apply = self.should_fill_bitmask(request) or apply_bitmask
-                    self._fill_bitmasks(((grammar, cumulative_index, bonus_apply),))
-                    cumulative_index += 1
+                    self._fill_bitmasks(
+                        ((grammar, bitmask_index + len(req_tokens), bonus_apply),)
+                    )
                 if state_advancements > 0:
                     grammar.rollback(state_advancements)
 
         bitmask_tensor = self._grammar_bitmask
-        if cumulative_index < bitmask_tensor.shape[0]:
-            bitmask_tensor = bitmask_tensor[:cumulative_index]
+        num_masks = len(structured_output_request_ids) * max_masks_per_req
+        if num_masks < bitmask_tensor.shape[0]:
+            bitmask_tensor = bitmask_tensor[:num_masks]
 
         # After finishing with the xgrammar operations, we convert to
         # np.ndarray, because that is much more efficient for serialization

--- a/vllm/v1/structured_output/utils.py
+++ b/vllm/v1/structured_output/utils.py
@@ -101,8 +101,7 @@ def apply_grammar_bitmask(
     # so we receive it in that format.
     grammar_bitmask = grammar_output.grammar_bitmask
 
-    # We receive the structured output bitmask from the scheduler,
-    # compacted to contain bitmasks only for structured output requests.
+    # We receive fixed-width mask blocks only for structured output requests.
     # The order of the requests in the bitmask is not guaranteed to be the
     # same as the order of the requests in the gpu runner's batch. We need
     # to sort the bitmask to match the order of the requests used here.
@@ -130,15 +129,17 @@ def apply_grammar_bitmask(
         pin_memory=PIN_MEMORY,
     )
     sorted_bitmask = sorted_bitmask_tensor.numpy()
-    cumulative_index = 0
-    for req_id in grammar_output.structured_output_request_ids:
+    num_structured_reqs = len(grammar_output.structured_output_request_ids)
+    assert grammar_bitmask.shape[0] % num_structured_reqs == 0
+    mask_stride = grammar_bitmask.shape[0] // num_structured_reqs
+    for grammar_idx, req_id in enumerate(grammar_output.structured_output_request_ids):
         num_spec_tokens = len(spec_tokens.get(req_id, ()))
         if (logit_idx := struct_out_req_batch_indices.get(req_id)) is not None:
             for i in range(1 + num_spec_tokens):
                 bitmask_index = logit_idx + i
-                sorted_bitmask[bitmask_index] = grammar_bitmask[cumulative_index + i]
+                source_index = grammar_idx * mask_stride + i
+                sorted_bitmask[bitmask_index] = grammar_bitmask[source_index]
                 out_indices.append(bitmask_index)
-        cumulative_index += 1 + num_spec_tokens
 
     # Copy async to device.
     grammar_bitmask = sorted_bitmask_tensor.to(logits.device, non_blocking=True)

--- a/vllm/v1/worker/gpu/structured_outputs.py
+++ b/vllm/v1/worker/gpu/structured_outputs.py
@@ -38,51 +38,40 @@ class StructuredOutputsWorker:
         if not grammar_req_ids:
             return
 
+        num_grammar_reqs = len(grammar_req_ids)
+        assert grammar_bitmask.shape[0] == num_grammar_reqs * self.mask_stride
+
         # Asynchronously copy the bitmask to GPU.
         with torch.cuda.stream(self.copy_stream):
             bitmask = async_copy_to_gpu(
                 grammar_bitmask, out=self.grammar_bitmask[: grammar_bitmask.shape[0]]
             )
 
-        # Construct bitmask -> logits mapping
-        mapping: list[int] = []
-        req_ids = input_batch.req_ids
-        cu_num_logits = input_batch.cu_num_logits_np.tolist()
-        req_id_to_idx = {req_id: i for i, req_id in enumerate(req_ids)}
-        for grammar_req_id in grammar_req_ids:
-            req_idx = req_id_to_idx[grammar_req_id]
-            logits_start_idx = cu_num_logits[req_idx]
-            logits_end_idx = cu_num_logits[req_idx + 1]
-            # Key by (request, position) rather than absolute logit index:
-            # adaptive verification finalizes per-request logit offsets on
-            # device, so the kernel resolves them from the GPU cu_num_logits.
-            mapping.extend(
-                req_idx * self.mask_stride + position
-                for position in range(logits_end_idx - logits_start_idx)
-            )
+        req_id_to_idx = {
+            req_id: req_idx for req_idx, req_id in enumerate(input_batch.req_ids)
+        }
+        req_indices = [req_id_to_idx[req_id] for req_id in grammar_req_ids]
 
-        # Asynchronously copy the mapping to GPU.
+        # Asynchronously copy the request indices to GPU.
         with torch.cuda.stream(self.copy_stream):
-            logits_indices = torch.tensor(
-                mapping, dtype=torch.int32, device="cpu", pin_memory=PIN_MEMORY
+            req_indices_tensor = torch.tensor(
+                req_indices, dtype=torch.int32, device="cpu", pin_memory=PIN_MEMORY
             )
-            logits_indices = self.logits_indices[: len(mapping)].copy_(
-                logits_indices, non_blocking=True
+            req_indices_tensor = self.logits_indices[:num_grammar_reqs].copy_(
+                req_indices_tensor, non_blocking=True
             )
 
         # Ensure all async copies are complete before launching the kernel.
         current_stream = torch.cuda.current_stream()
         current_stream.wait_stream(self.copy_stream)
 
-        num_masks = bitmask.shape[0]
-        assert num_masks == len(mapping)
         vocab_size = logits.shape[-1]
         BLOCK_SIZE = 8192
-        grid = (num_masks, triton.cdiv(vocab_size, BLOCK_SIZE))
+        grid = (num_grammar_reqs, triton.cdiv(vocab_size, BLOCK_SIZE))
         _apply_grammar_bitmask_kernel[grid](
             logits,
             logits.stride(0),
-            logits_indices,
+            req_indices_tensor,
             input_batch.cu_num_logits,
             bitmask,
             bitmask.stride(0),
@@ -102,7 +91,7 @@ class StructuredOutputsWorker:
 def _apply_grammar_bitmask_kernel(
     logits_ptr,
     logits_stride,
-    logits_indices_ptr,
+    req_indices_ptr,
     cu_num_logits_ptr,
     bitmask_ptr,
     bitmask_stride,
@@ -110,30 +99,28 @@ def _apply_grammar_bitmask_kernel(
     MASK_STRIDE: tl.constexpr,
     BLOCK_SIZE: tl.constexpr,
 ):
-    bitmask_idx = tl.program_id(0)
-    mapping_idx = tl.load(logits_indices_ptr + bitmask_idx)
-    req_idx = mapping_idx // MASK_STRIDE
-    position_idx = mapping_idx % MASK_STRIDE
-    logits_idx = tl.load(cu_num_logits_ptr + req_idx)
-    num_req_logits = tl.load(cu_num_logits_ptr + req_idx + 1) - logits_idx
-    logits_idx += position_idx
-    position_is_active = position_idx < num_req_logits
+    grammar_idx = tl.program_id(0)
+    req_idx = tl.load(req_indices_ptr + grammar_idx)
+    logits_start_idx = tl.load(cu_num_logits_ptr + req_idx)
+    num_req_logits = tl.load(cu_num_logits_ptr + req_idx + 1) - logits_start_idx
 
-    # Load the bitmask.
     block_id = tl.program_id(1)
     bitmask_offset = (block_id * BLOCK_SIZE) // 32 + tl.arange(0, BLOCK_SIZE // 32)
-    packed_bitmask = tl.load(
-        bitmask_ptr + bitmask_idx * bitmask_stride + bitmask_offset,
-        mask=bitmask_offset < bitmask_stride,
-    )
-    # Unpack the bitmask.
-    bitmask = ((packed_bitmask[:, None] >> (tl.arange(0, 32)[None, :])) & 1) == 0
-    bitmask = bitmask.reshape(BLOCK_SIZE)
-
-    # Apply the bitmask to the logits.
     block_offset = block_id * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
-    tl.store(
-        logits_ptr + logits_idx * logits_stride + block_offset,
-        -float("inf"),
-        mask=position_is_active & bitmask & (block_offset < vocab_size),
-    )
+    for position_idx in range(MASK_STRIDE):
+        position_is_active = position_idx < num_req_logits
+        bitmask_idx = grammar_idx * MASK_STRIDE + position_idx
+        packed_bitmask = tl.load(
+            bitmask_ptr + bitmask_idx * bitmask_stride + bitmask_offset,
+            mask=position_is_active & (bitmask_offset < bitmask_stride),
+            other=0,
+        )
+        bitmask = ((packed_bitmask[:, None] >> (tl.arange(0, 32)[None, :])) & 1) == 0
+        bitmask = bitmask.reshape(BLOCK_SIZE)
+
+        logits_idx = logits_start_idx + position_idx
+        tl.store(
+            logits_ptr + logits_idx * logits_stride + block_offset,
+            -float("inf"),
+            mask=(position_is_active & bitmask & (block_offset < vocab_size)),
+        )

--- a/vllm/v1/worker/gpu/warmup.py
+++ b/vllm/v1/worker/gpu/warmup.py
@@ -328,10 +328,13 @@ def warmup_kernels(
             vocab_size = model_runner.model_config.get_vocab_size()
             bitmask_width = (vocab_size + 31) // 32
             grammar_bitmask = np.full(
-                (len(req_ids), bitmask_width), fill_value=-1, dtype=np.int32
+                (len(req_ids) * model_runner.decode_query_len, bitmask_width),
+                fill_value=-1,
+                dtype=np.int32,
             )
             grammar_output = GrammarOutput(
-                structured_output_request_ids=req_ids, grammar_bitmask=grammar_bitmask
+                structured_output_request_ids=req_ids,
+                grammar_bitmask=grammar_bitmask,
             )
 
         worker_sample_tokens(grammar_output)


### PR DESCRIPTION
## Purpose

Fix the DSpark adaptive-verification zero-budget crash with structured outputs by making the grammar-mask application depend on the GPU's finalized per-request logit counts.

The scheduler generates masks from scheduled drafts, but adaptive verification can compact the active logits to bonus-only on the GPU. The existing worker builds one CPU mapping entry per CPU logit row, so the zero-budget compaction makes that mapping shorter than the generated mask and trips `assert num_masks == len(mapping)`.

This change gives every structured-output request a fixed-width mask block. The MRV2 Triton kernel launches per grammar request, reads its actual width from device-side `cu_num_logits`, and applies only those active positions. It no longer needs CPU `cu_num_logits_np`, scheduled-draft counts, bonus counts, or new metadata on `InputBatch`/`GrammarOutput`.

MRV1 shares the mask producer but uses packed logits. Its existing repacking path now indexes each request's fixed-width block before applying xgrammar.

### Relationship to #52436

This is a materially different replacement for #52436, not an independent duplicate: #52436 makes the CPU mapping follow scheduled draft counts, whereas this version removes the per-mask CPU mapping and makes the GPU's finalized counts authoritative. It carries forward the original root-cause work, and #52436's author `oops-oom` is credited as a co-author.

Duplicate searches for `52436 in:body` and `adaptive verification structured output grammar bitmask` found no other implementation of this GPU-driven design. There is no linked issue on #52436 in which to record the design difference.

## Test Plan

```bash
.venv/bin/python -m pytest \
  tests/v1/spec_decode/test_adaptive_verification.py \
  tests/v1/spec_decode/test_mtp_structured_output.py -q

.venv/bin/python -m pytest \
  tests/v1/structured_output/test_backend_guidance.py -q

.venv/bin/python -m pytest \
  tests/v1/worker/test_gpu_rejection_sampler_chunking.py \
  tests/v1/worker/test_gpu_batch_ordering.py -q

.venv/bin/pre-commit run --files \
  tests/v1/spec_decode/test_mtp_structured_output.py \
  vllm/v1/structured_output/__init__.py \
  vllm/v1/structured_output/utils.py \
  vllm/v1/worker/gpu/structured_outputs.py \
  vllm/v1/worker/gpu/warmup.py
```

MRV1 model smoke:

```bash
VLLM_USE_V2_MODEL_RUNNER=0 CUDA_VISIBLE_DEVICES=0 \
  .venv/bin/python .venv/mrv1_structured_spec_smoke.py
```

The local smoke used OPT-125M, prompt-lookup ngram speculation with five speculative tokens, xgrammar, and two simultaneous JSON-schema requests.

A direct MRV2 Triton smoke used two requests with stride four and GPU counts `[1, 1]`. It verified that mask rows 0 and 4 were applied while an inactive mask row was ignored.

## Test Result

```text
adaptive verification + MTP structured output: 21 passed
backend guidance:                           6 passed
rejection sampler chunking + batch order: 15 passed
pre-commit:                         all hooks passed
```

MRV1 initialized `vllm/v1/worker/gpu_model_runner.py`, ran speculative structured generation, and returned valid outputs:

```text
{"answer": 2}
{"answer": 3}
```

The same fixed-stride implementation was also exercised with a full DeepSeek-V4-Flash-0731 TP=4 run, adaptive verification forced to a zero draft budget, and two simultaneous JSON-schema requests. It completed with the same valid outputs instead of the mask/mapping assertion.

## AI assistance

AI assistance was used to analyze the bug, implement the alternative, audit MRV1/MRV2, and run the tests above. This remains a draft pending human review of every changed line before it is marked ready.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. No documentation change is needed for this internal correctness fix.
</details>

