### PR TITLE
[Bugfix][Spec Decode] Skip multimodal registry check for draft model configs

### DIFF
--- a/tests/config/test_multimodal_config.py
+++ b/tests/config/test_multimodal_config.py
@@ -128,6 +128,20 @@ def test_supports_multimodal_for_mm_prefix_before_multimodal_config():
     assert not hasattr(model_config, "_supports_multimodal_inputs_cached")
 
 
+def test_supports_multimodal_for_mm_prefix_skips_registry_for_draft():
+    """Draft models never process multimodal inputs directly, so querying the
+    registry misfires ("no registered multimodal processor") on MTP drafts."""
+    model_config = _make_mm_prefix_model_config()
+    model_config.runner_type = "draft"
+
+    with patch(
+        "vllm.multimodal.MULTIMODAL_REGISTRY.supports_multimodal_inputs",
+        side_effect=AssertionError("draft must not query the registry"),
+    ):
+        assert model_config._supports_multimodal_for_mm_prefix() is False
+    assert not hasattr(model_config, "_supports_multimodal_inputs_cached")
+
+
 def test_language_model_only_disables_via_supports_multimodal_inputs():
     """language_model_only zeros all limits, so registry reports text-only."""
     model_config = _make_mm_prefix_model_config(language_model_only=True)

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -863,6 +863,11 @@ class ModelConfig:
         if cached is not None:
             return cached
 
+        # Draft models never process multimodal inputs directly (embeddings
+        # are produced target-side), so they are always text-only here.
+        if getattr(self, "runner_type", None) == "draft":
+            return False
+
         if self.multimodal_config is None:
             # Early call before multimodal init — do not clear mm_prefix yet.
             return True


### PR DESCRIPTION
Fixes #52481

## Description

MTP draft `ModelConfig`s (e.g. `Qwen3_5MTP` for the `qwen3_5` family) are built with `runner="draft"` reusing the target's model path, and their resolved model class implements `SupportsMultiModal` — intentionally, since drafts merge target-side multimodal embeddings. `ModelConfig.__post_init__` therefore creates a `multimodal_config` for drafts, and since #48796 `get_model_arch_config` queries `MULTIMODAL_REGISTRY.supports_multimodal_inputs()` on every config. For drafts the registry lookup misfires (`_get_model_cls` finds no `@register_processor`) and users see, under the *target* model's name:

```
WARNING [registry.py:117] Model Qwen/Qwen3.8-27B-FP8 is treated as multimodal but has no registered multimodal processor; running in text-only mode.
INFO [model.py:842] Disabled mm_prefix attention mode because multimodal inputs are configuration-disabled. ...
```

Drafts never process multimodal inputs directly (embeddings are produced target-side; the proposer already consults the target config for `supports_mm_inputs`), so the query can only misfire. This PR returns text-only for draft runner configs before the registry query. It also avoids a hazard of the alternative "gate `multimodal_config` creation" fix: with `multimodal_config = None`, the early-return-`True` path would evaluate `is_mm_prefix_lm(supports_multimodal=True)` for the draft, flipping draft `is_mm_prefix_lm` from `False` to `True` for families whose HF config declares it (e.g. Gemma4-style VL drafts).

No functional change: draft arch configs already end up text-only; this removes the failing lookup that produces the log noise.

## Verification

- Unit test `test_supports_multimodal_for_mm_prefix_skips_registry_for_draft` asserts the registry is not consulted for draft configs; verified it fails without the source change (red) and passes with it (green):
  - `pytest tests/config/test_multimodal_config.py -k "mm_prefix or draft"` → 5 passed with fix; 1 failed / 4 passed without.
- End-to-end (2× RTX 5090, `Qwen/Qwen3.8-27B-FP8` + `--speculative-config '{"method":"mtp","num_speculative_tokens":3}'`, v0.27.1 wheel with this patch applied): both log lines disappear; text and image request outputs are byte-identical to the unpatched deployment; MTP acceptance unchanged (83.4% → 87.8%, run-to-run variance). Details in the linked issue.

## Not duplicating existing work

Searched open PRs for draft / multimodal-processor / mm_prefix fixes — none address this; issue #52481 had no linked PR at the time of submission.

## AI assistance

Root-cause analysis, the patch, and the tests were developed with AI assistance. Every changed line was reviewed by the human submitter; the test commands and end-to-end verification above were executed on a Linux host (RTX 5090) as part of the AI-assisted verification.
