### PR TITLE
[Bugfix] Reload speculative draft weights after Level 2 sleep wake

### DIFF
--- a/tests/v1/worker/test_gpu_model_runner.py
+++ b/tests/v1/worker/test_gpu_model_runner.py
@@ -2110,6 +2110,73 @@ class TestReloadDraftWeights:
         assert torch.equal(draft_model.lm_head.weight, head_from_ckpt)
         assert torch.equal(draft_model.proj.weight, draft_proj)
 
+    def test_disk_reload_discards_vocab_mismatched_shared_embed(self):
+        """A head narrower on the vocab axis (EAGLE3 low-rank layout) is a real
+        projection, not a tied placeholder: embed tensors are discarded and the
+        head still loads from its own checkpoint entry.
+        """
+
+        class _Head(nn.Module):
+            def __init__(self, weight: nn.Parameter):
+                super().__init__()
+                self.weight = weight
+
+        class _TinyLM(nn.Module):
+            def __init__(self, embed_dim: int, head_vocab: int):
+                super().__init__()
+                self.embed_tokens = nn.Embedding(8, embed_dim)
+                self.lm_head = _Head(nn.Parameter(torch.zeros(head_vocab, embed_dim)))
+                self.proj = nn.Linear(4, 4, bias=False)
+
+            def load_weights(self, weights):
+                from vllm.model_executor.models.utils import AutoWeightsLoader
+
+                return AutoWeightsLoader(self).load_weights(weights)
+
+        target_model = _TinyLM(embed_dim=8, head_vocab=8)
+        draft_model = _TinyLM(embed_dim=8, head_vocab=4)
+        original_embed = target_model.embed_tokens.weight.detach().clone()
+        draft_model.embed_tokens = target_model.embed_tokens
+
+        runner = self._make_runner()
+        runner.get_draft_model = Mock(return_value=draft_model)
+        runner.get_model = Mock(return_value=target_model)
+        embed_placeholder = torch.full((8, 8), 7.0)
+        head_from_ckpt = torch.full((4, 8), 3.0)
+        draft_proj = torch.eye(4)
+        target_weights = iter([("proj.weight", torch.eye(4))])
+
+        def get_loader(_load_config):
+            loader = Mock()
+
+            def get_all_weights(_config, model):
+                if model is draft_model:
+                    return iter(
+                        [
+                            ("embed_tokens.weight", embed_placeholder),
+                            ("lm_head.weight", head_from_ckpt),
+                            ("proj.weight", draft_proj),
+                        ]
+                    )
+                return target_weights
+
+            loader.get_all_weights.side_effect = get_all_weights
+            return loader
+
+        with (
+            patch.object(
+                gpu_model_runner_module, "get_model_loader", side_effect=get_loader
+            ),
+            patch.object(gpu_model_runner_module, "initialize_layerwise_reload"),
+            patch.object(gpu_model_runner_module, "finalize_layerwise_reload"),
+        ):
+            runner.reload_weights()
+
+        assert draft_model.embed_tokens is target_model.embed_tokens
+        assert torch.equal(target_model.embed_tokens.weight, original_embed)
+        assert torch.equal(draft_model.lm_head.weight, head_from_ckpt)
+        assert torch.equal(draft_model.proj.weight, draft_proj)
+
     def test_disk_reload_detaches_repeated_lm_head_aliases(self):
         """MTP shares one target lm_head at draft.lm_head and each shared_head."""
 

--- a/tests/v1/worker/test_gpu_model_runner.py
+++ b/tests/v1/worker/test_gpu_model_runner.py
@@ -2177,6 +2177,77 @@ class TestReloadDraftWeights:
         assert torch.equal(draft_model.lm_head.weight, head_from_ckpt)
         assert torch.equal(draft_model.proj.weight, draft_proj)
 
+    def test_disk_reload_rebuilds_fused_state_after_finalization(self):
+        """Drafters whose load_weights rebuilds fused buffers mid-lifecycle
+        (dflash/dspark) capture the temporarily meta-derived rotary buffer;
+        the runner must re-run that rebuild after finalize restores the tree.
+        """
+
+        class _Rotary(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.cache = torch.zeros(4)
+
+        class _Inner(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.rotary_emb = _Rotary()
+                self.captured = None
+                self.rebuild_calls = 0
+
+            def _build_fused_kv_buffers(self) -> None:
+                self.rebuild_calls += 1
+                self.captured = self.rotary_emb.cache
+
+            def load_weights(self, weights):
+                self._build_fused_kv_buffers()
+                return set()
+
+        class _Draft(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.model = _Inner()
+
+            def load_weights(self, weights):
+                return self.model.load_weights(weights)
+
+        draft_model = _Draft()
+        target_model = Mock()
+        target_model.named_parameters.return_value = []
+        target_model.load_weights.return_value = set()
+        runner = self._make_runner()
+        runner.get_draft_model = Mock(return_value=draft_model)
+        runner.get_model = Mock(return_value=target_model)
+        model_loader = Mock()
+        model_loader.get_all_weights.return_value = iter([])
+        restored = _Rotary()
+
+        def finalize(model, _config):
+            # Emulate the real finalize: the module tree ends up holding a
+            # different, healthy buffer object than the meta one load_weights
+            # saw mid-lifecycle.
+            model.model.rotary_emb = restored
+
+        with (
+            patch.object(
+                gpu_model_runner_module,
+                "get_model_loader",
+                return_value=model_loader,
+            ),
+            patch.object(gpu_model_runner_module, "initialize_layerwise_reload"),
+            patch.object(
+                gpu_model_runner_module,
+                "finalize_layerwise_reload",
+                side_effect=finalize,
+            ),
+        ):
+            runner.reload_weights()
+
+        # Mid-lifecycle rebuild from load_weights, then the post-finalize
+        # re-run: the cached reference must be the restored tree object.
+        assert draft_model.model.rebuild_calls == 2
+        assert draft_model.model.captured is restored.cache
+
     def test_disk_reload_detaches_repeated_lm_head_aliases(self):
         """MTP shares one target lm_head at draft.lm_head and each shared_head."""
 

--- a/tests/v1/worker/test_gpu_model_runner.py
+++ b/tests/v1/worker/test_gpu_model_runner.py
@@ -9,6 +9,7 @@ from unittest.mock import Mock, call, patch
 import numpy as np
 import pytest
 import torch
+import torch.nn as nn
 
 import vllm.v1.worker.gpu_model_runner as gpu_model_runner_module
 from vllm.config import (
@@ -1961,3 +1962,254 @@ class TestReloadDraftWeights:
         get_loader.assert_not_called()
         runner.get_draft_model.assert_not_called()
         target_model.load_weights.assert_called_once_with(weights)
+
+    def test_disk_reload_skips_dim_mismatched_aliased_embeddings(self):
+        """Skip shared embed load; still fill the tied draft-dim lm_head."""
+
+        class _TiedHead(nn.Module):
+            def __init__(self, weight: nn.Parameter):
+                super().__init__()
+                self.weight = weight
+
+        class _TinyLM(nn.Module):
+            def __init__(self, embed_dim: int):
+                super().__init__()
+                self.embed_tokens = nn.Embedding(8, embed_dim)
+                self.lm_head = _TiedHead(self.embed_tokens.weight)
+                self.proj = nn.Linear(4, 4, bias=False)
+
+            def load_weights(self, weights):
+                from vllm.model_executor.models.utils import AutoWeightsLoader
+
+                return AutoWeightsLoader(self).load_weights(weights)
+
+        target_model = _TinyLM(embed_dim=8)
+        draft_model = _TinyLM(embed_dim=2)
+        original_embed = target_model.embed_tokens.weight.detach().clone()
+        original_lm_head = draft_model.lm_head.weight
+        draft_model.embed_tokens = target_model.embed_tokens
+
+        runner = self._make_runner()
+        runner.get_draft_model = Mock(return_value=draft_model)
+        runner.get_model = Mock(return_value=target_model)
+        draft_placeholder = torch.full((8, 2), 7.0)
+        draft_proj = torch.eye(4)
+        target_weights = iter([("proj.weight", torch.eye(4))])
+        seen_during_draft_init: list[nn.Module] = []
+
+        def get_loader(_load_config):
+            loader = Mock()
+
+            def get_all_weights(_config, model):
+                if model is draft_model:
+                    return iter(
+                        [
+                            ("embed_tokens.weight", draft_placeholder),
+                            ("proj.weight", draft_proj),
+                        ]
+                    )
+                return target_weights
+
+            loader.get_all_weights.side_effect = get_all_weights
+            return loader
+
+        def capture_init(model):
+            if model is not draft_model:
+                return
+            seen_during_draft_init.extend(
+                module
+                for _name, module in model.named_modules(remove_duplicate=False)
+                if _name
+            )
+
+        with (
+            patch.object(
+                gpu_model_runner_module, "get_model_loader", side_effect=get_loader
+            ),
+            patch.object(
+                gpu_model_runner_module,
+                "initialize_layerwise_reload",
+                side_effect=capture_init,
+            ),
+            patch.object(gpu_model_runner_module, "finalize_layerwise_reload"),
+        ):
+            runner.reload_weights()
+
+        assert draft_model.embed_tokens is target_model.embed_tokens
+        assert torch.equal(target_model.embed_tokens.weight, original_embed)
+        assert draft_model.lm_head.weight is original_lm_head
+        assert torch.equal(draft_model.lm_head.weight, draft_placeholder)
+        assert torch.equal(draft_model.proj.weight, draft_proj)
+        assert target_model.embed_tokens not in seen_during_draft_init
+
+    def test_disk_reload_keeps_untied_head_off_shared_embed(self):
+        """Same-width shared embed is discarded.
+        A distinct lm_head loads from its own checkpoint tensor, not embed_tokens.
+        """
+
+        class _Head(nn.Module):
+            def __init__(self, weight: nn.Parameter):
+                super().__init__()
+                self.weight = weight
+
+        class _TinyLM(nn.Module):
+            def __init__(self, embed_dim: int):
+                super().__init__()
+                self.embed_tokens = nn.Embedding(8, embed_dim)
+                self.lm_head = _Head(nn.Parameter(torch.zeros(8, embed_dim)))
+                self.proj = nn.Linear(4, 4, bias=False)
+
+            def load_weights(self, weights):
+                from vllm.model_executor.models.utils import AutoWeightsLoader
+
+                return AutoWeightsLoader(self).load_weights(weights)
+
+        target_model = _TinyLM(embed_dim=8)
+        draft_model = _TinyLM(embed_dim=8)
+        original_embed = target_model.embed_tokens.weight.detach().clone()
+        original_head = draft_model.lm_head.weight.detach().clone()
+        draft_model.embed_tokens = target_model.embed_tokens
+
+        runner = self._make_runner()
+        runner.get_draft_model = Mock(return_value=draft_model)
+        runner.get_model = Mock(return_value=target_model)
+        embed_placeholder = torch.full((8, 8), 7.0)
+        head_from_ckpt = torch.full((8, 8), 3.0)
+        draft_proj = torch.eye(4)
+        target_weights = iter([("proj.weight", torch.eye(4))])
+
+        def get_loader(_load_config):
+            loader = Mock()
+
+            def get_all_weights(_config, model):
+                if model is draft_model:
+                    return iter(
+                        [
+                            ("embed_tokens.weight", embed_placeholder),
+                            ("lm_head.weight", head_from_ckpt),
+                            ("proj.weight", draft_proj),
+                        ]
+                    )
+                return target_weights
+
+            loader.get_all_weights.side_effect = get_all_weights
+            return loader
+
+        with (
+            patch.object(
+                gpu_model_runner_module, "get_model_loader", side_effect=get_loader
+            ),
+            patch.object(gpu_model_runner_module, "initialize_layerwise_reload"),
+            patch.object(gpu_model_runner_module, "finalize_layerwise_reload"),
+        ):
+            runner.reload_weights()
+
+        assert draft_model.embed_tokens is target_model.embed_tokens
+        assert torch.equal(target_model.embed_tokens.weight, original_embed)
+        assert not torch.equal(draft_model.lm_head.weight, original_head)
+        assert torch.equal(draft_model.lm_head.weight, head_from_ckpt)
+        assert torch.equal(draft_model.proj.weight, draft_proj)
+
+    def test_disk_reload_detaches_repeated_lm_head_aliases(self):
+        """MTP shares one target lm_head at draft.lm_head and each shared_head."""
+
+        class _SharedHead(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.head = nn.Linear(2, 8, bias=False)
+
+        class _Layer(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.shared_head = _SharedHead()
+
+        class _Inner(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.layers = nn.ModuleList([_Layer(), _Layer()])
+
+        class _Draft(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.lm_head = nn.Linear(2, 8, bias=False)
+                self.model = _Inner()
+                self.proj = nn.Linear(4, 4, bias=False)
+
+            def load_weights(self, weights):
+                from vllm.model_executor.models.utils import AutoWeightsLoader
+
+                return AutoWeightsLoader(self).load_weights(weights)
+
+        class _Target(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.lm_head = nn.Linear(8, 8, bias=False)
+                self.proj = nn.Linear(4, 4, bias=False)
+
+            def load_weights(self, weights):
+                from vllm.model_executor.models.utils import AutoWeightsLoader
+
+                return AutoWeightsLoader(self).load_weights(weights)
+
+        target_model = _Target()
+        draft_model = _Draft()
+        original_head = target_model.lm_head.weight.detach().clone()
+        draft_model.lm_head = target_model.lm_head
+        for layer in draft_model.model.layers:
+            layer.shared_head.head = target_model.lm_head
+
+        runner = self._make_runner()
+        runner.get_draft_model = Mock(return_value=draft_model)
+        runner.get_model = Mock(return_value=target_model)
+        placeholder = torch.full((8, 2), 7.0)
+        draft_proj = torch.eye(4)
+        target_weights = iter([("proj.weight", torch.eye(4))])
+        seen_target_head: list[bool] = []
+
+        def get_loader(_load_config):
+            loader = Mock()
+
+            def get_all_weights(_config, model):
+                if model is draft_model:
+                    return iter(
+                        [
+                            ("lm_head.weight", placeholder),
+                            ("model.layers.0.shared_head.head.weight", placeholder),
+                            ("model.layers.1.shared_head.head.weight", placeholder),
+                            ("proj.weight", draft_proj),
+                        ]
+                    )
+                return target_weights
+
+            loader.get_all_weights.side_effect = get_all_weights
+            return loader
+
+        def capture_init(model):
+            if model is not draft_model:
+                return
+            seen_target_head.append(
+                any(
+                    module is target_model.lm_head
+                    for _name, module in model.named_modules(remove_duplicate=False)
+                )
+            )
+
+        with (
+            patch.object(
+                gpu_model_runner_module, "get_model_loader", side_effect=get_loader
+            ),
+            patch.object(
+                gpu_model_runner_module,
+                "initialize_layerwise_reload",
+                side_effect=capture_init,
+            ),
+            patch.object(gpu_model_runner_module, "finalize_layerwise_reload"),
+        ):
+            runner.reload_weights()
+
+        assert seen_target_head == [False]
+        assert draft_model.lm_head is target_model.lm_head
+        assert draft_model.model.layers[0].shared_head.head is target_model.lm_head
+        assert draft_model.model.layers[1].shared_head.head is target_model.lm_head
+        assert torch.equal(target_model.lm_head.weight, original_head)
+        assert torch.equal(draft_model.proj.weight, draft_proj)

--- a/tests/v1/worker/test_gpu_model_runner.py
+++ b/tests/v1/worker/test_gpu_model_runner.py
@@ -4,7 +4,7 @@
 import gc
 from contextlib import nullcontext
 from types import SimpleNamespace
-from unittest.mock import Mock
+from unittest.mock import Mock, call, patch
 
 import numpy as np
 import pytest
@@ -60,6 +60,7 @@ from vllm.v1.worker.block_table import (
 from vllm.v1.worker.gpu.lora_utils import LoraState
 from vllm.v1.worker.gpu.mm.encoder_cache import EncoderCache
 from vllm.v1.worker.gpu.mm.lora import set_active_mm_loras
+from vllm.v1.worker.gpu.model_runner import GPUModelRunner as GPUModelRunnerV2
 from vllm.v1.worker.gpu_input_batch import InputBatch
 from vllm.v1.worker.gpu_model_runner import GPUModelRunner
 from vllm.v1.worker.utils import select_common_block_size
@@ -1827,3 +1828,136 @@ def test_mamba_cache_raises_when_max_num_seqs_exceeds_blocks():
 
         with pytest.raises(ValueError, match="max_num_seqs"):
             runner.initialize_kv_cache(kv_cache_config)
+
+
+class TestReloadDraftWeights:
+    """Disk-backed reload restores draft parameters before the target."""
+
+    def _make_runner(self, cls=GPUModelRunner):
+        runner = object.__new__(cls)
+        runner.load_config = Mock()
+        runner.load_config.load_format = "safetensors"
+        runner.lora_config = None
+        runner.model_config = Mock()
+        runner.model_config.quantization = None
+        runner.speculative_config = SimpleNamespace(
+            draft_model_config=Mock(),
+            draft_load_config=None,
+        )
+        runner.reset_lora_state = Mock()
+        runner.reset_encoder_cache = Mock()
+        runner.reset_mm_cache = Mock()
+        return runner
+
+    def _assert_disk_reload_restores_draft(self, runner):
+        draft_model = Mock()
+        target_model = Mock()
+        target_model.named_parameters.return_value = []
+        runner.get_draft_model = Mock(return_value=draft_model)
+        runner.get_model = Mock(return_value=target_model)
+        reload_order = []
+        draft_weights = iter([("draft", torch.zeros(1))])
+        target_weights = iter([("target", torch.zeros(1))])
+
+        def load_draft(_weights):
+            reload_order.append("draft")
+
+        def load_target(_weights):
+            reload_order.append("target")
+            return set()
+
+        draft_model.load_weights.side_effect = load_draft
+        target_model.load_weights.side_effect = load_target
+
+        def get_loader(_load_config):
+            loader = Mock()
+
+            def get_all_weights(_config, model):
+                return draft_weights if model is draft_model else target_weights
+
+            loader.get_all_weights.side_effect = get_all_weights
+            return loader
+
+        with (
+            patch.object(
+                gpu_model_runner_module, "get_model_loader", side_effect=get_loader
+            ) as get_loader_mock,
+            patch.object(
+                gpu_model_runner_module, "initialize_layerwise_reload"
+            ) as initialize_reload,
+            patch.object(
+                gpu_model_runner_module, "finalize_layerwise_reload"
+            ) as finalize_reload,
+        ):
+            runner.reload_weights()
+
+        assert reload_order == ["draft", "target"]
+        assert get_loader_mock.call_args_list == [
+            call(runner.load_config),
+            call(runner.load_config),
+        ]
+        draft_model.load_weights.assert_called_once_with(draft_weights)
+        target_model.load_weights.assert_called_once_with(target_weights)
+        assert initialize_reload.call_args_list == [
+            call(draft_model),
+            call(target_model),
+        ]
+        assert finalize_reload.call_args_list == [
+            call(draft_model, runner.speculative_config.draft_model_config),
+            call(target_model, runner.model_config),
+        ]
+
+    def test_disk_reload_restores_draft_model(self):
+        self._assert_disk_reload_restores_draft(self._make_runner())
+
+    def test_v2_disk_reload_delegates_to_v1_helper(self):
+        self._assert_disk_reload_restores_draft(self._make_runner(GPUModelRunnerV2))
+
+    def test_disk_reload_without_draft_only_reloads_target(self):
+        runner = self._make_runner()
+        target_model = Mock()
+        target_model.named_parameters.return_value = []
+        target_model.load_weights.return_value = set()
+        runner.get_draft_model = Mock(return_value=None)
+        runner.get_model = Mock(return_value=target_model)
+        target_weights = iter([("target", torch.zeros(1))])
+        model_loader = Mock()
+        model_loader.get_all_weights.return_value = target_weights
+
+        with (
+            patch.object(
+                gpu_model_runner_module,
+                "get_model_loader",
+                return_value=model_loader,
+            ) as get_loader,
+            patch.object(gpu_model_runner_module, "initialize_layerwise_reload"),
+            patch.object(gpu_model_runner_module, "finalize_layerwise_reload"),
+        ):
+            runner.reload_weights()
+
+        get_loader.assert_called_once_with(runner.load_config)
+        model_loader.get_all_weights.assert_called_once_with(
+            runner.model_config, target_model
+        )
+        target_model.load_weights.assert_called_once_with(target_weights)
+        runner.get_draft_model.assert_called_once_with()
+
+    def test_iterator_reload_does_not_reload_draft_model(self):
+        runner = self._make_runner()
+        target_model = Mock()
+        target_model.named_parameters.return_value = []
+        target_model.load_weights.return_value = set()
+        runner.get_draft_model = Mock()
+        runner.get_model = Mock(return_value=target_model)
+        weights = iter([("weight", torch.zeros(1))])
+
+        with (
+            patch.object(gpu_model_runner_module, "get_model_loader") as get_loader,
+            patch.object(gpu_model_runner_module, "initialize_layerwise_reload"),
+            patch.object(gpu_model_runner_module, "finalize_layerwise_reload"),
+        ):
+            runner.reload_weights(weights_iterator=weights)
+
+        get_loader.assert_not_called()
+        runner.get_draft_model.assert_not_called()
+        target_model.load_weights.assert_called_once_with(weights)

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -5609,12 +5609,8 @@ class GPUModelRunner(
 
         # load weights from disk if none are provided
         if weights_iterator is None:
-            # Speculative drafts are a separate module. Level 2 sleep discards
-            # their parameters with the target's; wake_up only restores draft
-            # buffers. Reload the configured draft checkpoint first so the
-            # target remains authoritative for any shared storage.
-            # Call unbound: Model Runner V2 delegates this method with a V2
-            # `self` and does not inherit the helper.
+            # Reload draft weights (dropped by L2 sleep) before the target so it
+            # stays authoritative for shared storage. Unbound: MRV2 passes a V2 self.
             GPUModelRunner._reload_draft_weights_from_disk(self)
 
             model_loader = get_model_loader(self.load_config)

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -495,6 +495,97 @@ class ExecuteModelState(NamedTuple):
     slot_mappings: dict[str, torch.Tensor] | list[dict[str, torch.Tensor]] | None
 
 
+class _DiscardSharedDraftWeights(nn.Module):
+    """Drop tensors for draft submodules that are the live target object."""
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        for _name, _weight in weights:
+            pass
+        return set()
+
+
+class _TiedDraftWeightSink(nn.Module):
+    """Fill draft lm_head from tied embed tensors; do not write the target embed.
+    Uses load_weights so AutoWeightsLoader can dispatch without dual-registering.
+    """
+
+    def __init__(self, src: nn.Module):
+        super().__init__()
+        self._dst = src
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        loaded: set[str] = set()
+        dst = self._dst
+        for name, tensor in weights:
+            leaf = name.split(".")[-1]
+            param = getattr(dst, leaf, None)
+            if not isinstance(param, nn.Parameter):
+                continue
+            loader = getattr(param, "weight_loader", None)
+            if callable(loader):
+                loader(param, tensor)
+            else:
+                param.data.copy_(tensor)
+            loaded.add(name)
+        return loaded
+
+
+def _replacement_for_detached_draft_module(
+    attr: str, module: nn.Module, draft_model: nn.Module
+) -> nn.Module:
+    if attr == "embed_tokens":
+        lm_head = getattr(draft_model, "lm_head", None)
+        detached_weight = getattr(module, "weight", None)
+        head_weight = getattr(lm_head, "weight", None) if lm_head is not None else None
+        if (
+            isinstance(detached_weight, nn.Parameter)
+            and isinstance(head_weight, nn.Parameter)
+            and head_weight is not detached_weight
+            and head_weight.shape != detached_weight.shape
+        ):
+            return _TiedDraftWeightSink(lm_head)
+    return _DiscardSharedDraftWeights()
+
+
+@contextmanager
+def _temporarily_detach_target_owned_draft_modules(
+    draft_model: object, target_model: object
+) -> Iterator[None]:
+    """Unbind target-owned draft aliases for the duration of draft load_weights.
+    Dim-mismatched shared embeds (Gemma4 MTP after embed replace) mismatch otherwise.
+    """
+    if not isinstance(draft_model, nn.Module) or not isinstance(
+        target_model, nn.Module
+    ):
+        yield
+        return
+
+    target_module_ids = {id(module) for module in target_model.modules()}
+    attachments: list[tuple[nn.Module, str, nn.Module]] = []
+    # remove_duplicate=False: MTP aliases the same target lm_head at
+    # draft.lm_head and every layer.shared_head.head.
+    for name, module in draft_model.named_modules(remove_duplicate=False):
+        if not name or id(module) not in target_module_ids:
+            continue
+        parent_name, sep, attr = name.rpartition(".")
+        parent = draft_model if not sep else draft_model.get_submodule(parent_name)
+        if id(parent) in target_module_ids:
+            continue
+        attachments.append((parent, attr, module))
+
+    for parent, attr, module in attachments:
+        setattr(
+            parent,
+            attr,
+            _replacement_for_detached_draft_module(attr, module, draft_model),
+        )
+    try:
+        yield
+    finally:
+        for parent, attr, module in attachments:
+            setattr(parent, attr, module)
+
+
 class GPUModelRunner(
     LoRAModelRunnerMixin, KVConnectorModelRunnerMixin, ECConnectorModelRunnerMixin
 ):
@@ -5569,11 +5660,13 @@ class GPUModelRunner(
                 f"Draft model reloading with `{load_config.load_format}` format"
             )
 
-        initialize_layerwise_reload(draft_model)
-        draft_model.load_weights(
-            model_loader.get_all_weights(draft_model_config, draft_model)
-        )
-        finalize_layerwise_reload(draft_model, draft_model_config)
+        target_model = self.get_model()
+        with _temporarily_detach_target_owned_draft_modules(draft_model, target_model):
+            initialize_layerwise_reload(draft_model)
+            draft_model.load_weights(
+                model_loader.get_all_weights(draft_model_config, draft_model)
+            )
+            finalize_layerwise_reload(draft_model, draft_model_config)
 
     def reload_weights(
         self,
@@ -5609,8 +5702,8 @@ class GPUModelRunner(
 
         # load weights from disk if none are provided
         if weights_iterator is None:
-            # Reload draft weights (dropped by L2 sleep) before the target so it
-            # stays authoritative for shared storage. Unbound: MRV2 passes a V2 self.
+            # Draft first (L2 dropped its params). Target-owned aliases are
+            # detached during that load. Unbound: MRV2 passes a V2 self.
             GPUModelRunner._reload_draft_weights_from_disk(self)
 
             model_loader = get_model_loader(self.load_config)

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -5551,6 +5551,30 @@ class GPUModelRunner(
 
         return None
 
+    def _reload_draft_weights_from_disk(self) -> None:
+        get_draft_model = getattr(self, "get_draft_model", None)
+        if not callable(get_draft_model):
+            return
+        draft_model = get_draft_model()
+        speculative_config = getattr(self, "speculative_config", None)
+        if draft_model is None or speculative_config is None:
+            return
+
+        draft_model_config = speculative_config.draft_model_config
+        assert draft_model_config is not None
+        load_config = speculative_config.draft_load_config or self.load_config
+        model_loader = get_model_loader(load_config)
+        if not hasattr(model_loader, "get_all_weights"):
+            raise NotImplementedError(
+                f"Draft model reloading with `{load_config.load_format}` format"
+            )
+
+        initialize_layerwise_reload(draft_model)
+        draft_model.load_weights(
+            model_loader.get_all_weights(draft_model_config, draft_model)
+        )
+        finalize_layerwise_reload(draft_model, draft_model_config)
+
     def reload_weights(
         self,
         weights_iterator: Iterable[tuple[str, torch.Tensor]] | None = None,
@@ -5585,6 +5609,14 @@ class GPUModelRunner(
 
         # load weights from disk if none are provided
         if weights_iterator is None:
+            # Speculative drafts are a separate module. Level 2 sleep discards
+            # their parameters with the target's; wake_up only restores draft
+            # buffers. Reload the configured draft checkpoint first so the
+            # target remains authoritative for any shared storage.
+            # Call unbound: Model Runner V2 delegates this method with a V2
+            # `self` and does not inherit the helper.
+            GPUModelRunner._reload_draft_weights_from_disk(self)
+
             model_loader = get_model_loader(self.load_config)
             if not hasattr(model_loader, "get_all_weights"):
                 raise NotImplementedError(

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -5673,6 +5673,21 @@ class GPUModelRunner(
             )
             finalize_layerwise_reload(draft_model, draft_model_config)
 
+        # The dflash/dspark drafters rebuild fused buffers (a stacked copy of
+        # layer weights plus a cached rotary embedding reference) at the end of
+        # load_weights. Inside the layerwise lifecycle that rebuild captures
+        # the temporarily meta-derived rotary buffer; finalization then
+        # restores the real buffer on the module tree, leaving the cached
+        # reference on meta. Re-running the drafter's own rebuild after
+        # finalization re-captures the restored objects. No-op elsewhere.
+        rebuild_fused_state = getattr(
+            getattr(draft_model, "model", None) or draft_model,
+            "_build_fused_kv_buffers",
+            None,
+        )
+        if callable(rebuild_fused_state):
+            rebuild_fused_state()
+
     def reload_weights(
         self,
         weights_iterator: Iterable[tuple[str, torch.Tensor]] | None = None,

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -537,10 +537,15 @@ def _replacement_for_detached_draft_module(
         lm_head = getattr(draft_model, "lm_head", None)
         detached_weight = getattr(module, "weight", None)
         head_weight = getattr(lm_head, "weight", None) if lm_head is not None else None
+        # A tied placeholder head (Gemma4 MTP) keeps the embedding's vocab
+        # width and differs only on the hidden axis; a head that differs on
+        # the vocab axis (EAGLE3 low-rank heads) is a real projection with
+        # its own checkpoint entry, so its embed tensors are discarded.
         if (
             isinstance(detached_weight, nn.Parameter)
             and isinstance(head_weight, nn.Parameter)
             and head_weight is not detached_weight
+            and head_weight.shape[0] == detached_weight.shape[0]
             and head_weight.shape != detached_weight.shape
         ):
             return _TiedDraftWeightSink(lm_head)


### PR DESCRIPTION

Addresses #52479

## Problem

After the documented Level 2 sleep/wake sequence, MTP speculative decoding
silently stops helping: every drafted token is rejected
(`Mean acceptance length: 1.00`, `Accepted throughput: 0.00`) and decode
throughput falls to approximately the no-speculation rate. Target-model outputs
remain correct, so the failure appears only as a large performance regression.

Level 2 sleep discards draft parameters together with the target parameters.
`wake_up()` restores the saved draft buffers, but the documented subsequent
`reload_weights()` call reloaded only the target model. The drafter is a
separate module and therefore continued with discarded parameter storage.

## Fix

Put the disk-backed draft reload in `GPUModelRunner.reload_weights`
(`vllm/v1/worker/gpu_model_runner.py`), on the existing
`weights_iterator is None` path, before the target load:

- Resolve the draft through the existing `get_draft_model()` accessor.
- Read the configured draft checkpoint with its model loader. MTP configurations
  without a separate `draft_load_config` use the target load configuration.
- Load in place through `initialize_layerwise_reload` /
  `finalize_layerwise_reload`, preserving the parameter addresses captured by
  the compiled runtime.
- Invoke the helper unbound (`GPUModelRunner._reload_draft_weights_from_disk(self)`)
  because Model Runner V2 already delegates this method with a V2 `self` and
  does not inherit the helper.
- During that draft load, temporarily unbind any draft submodule that is the
  same object as a target module. A discard dummy swallows checkpoint tensors
  for those aliases so layerwise reload and `load_weights` cannot shape-mismatch
  or rewrite live target storage (Gemma4 MTP after `_maybe_share_embeddings`).
- If a detached `embed_tokens` keeps the same vocab-axis width as the draft
  `lm_head` but differs on the hidden axis (the Gemma4 MTP tied-placeholder
  layout), load those embed tensors into the still-live `lm_head`. Heads that
  differ on the vocab axis (EAGLE3 low-rank heads) are real projections with
  their own checkpoint entries and take the discard path; same-width shared
  embeds are discarded and restored by the target reload.
- After `finalize_layerwise_reload`, re-run the drafter's fused-buffer rebuild
  (`_build_fused_kv_buffers`) if it defines one. The dflash/dspark drafters
  rebuild derived state (a stacked copy of layer weights plus a cached
  rotary-embedding reference) at the end of `load_weights`; inside the layerwise
  window that rebuild captures the temporarily meta-derived rotary buffer, so
  it is re-run after finalization restores the real buffers. No-op for
  drafters without the builder.
- Reload the target last so same-width shared storage (typical Qwen MTP /
  EAGLE) is restored from the target checkpoint.
- Leave iterator-based reloads unchanged; those weights are supplied by their
  caller and are not assumed to contain a second draft checkpoint.

Model Runner V2 keeps its existing one-line delegate into that method. There is
no V2 wrapper and no production-file diff under `vllm/v1/worker/gpu/`.

This mirrors Level 1 sleep semantics: both paths restore the existing target
and draft modules in place. Level 1 restores their tagged allocations from host
RAM, while Level 2 restores saved buffers during `wake_up()` and reloads model
parameters from their disk checkpoints during `reload_weights()`.

### Why not `start_draft_weight_update()`?

The draft weight-update API added by #46725 selects the draft as the destination
of an already-configured `WeightTransferEngine`. Its built-in NCCL and IPC
backends receive weights supplied by an external trainer; they do not accept a
checkpoint path or read weights from disk. The API also requires the server to
start with `weight_transfer_config`. It remains the correct path for runtime
trainer/RL weight transfer; this PR does not replace it.

The failing workflow is the separate, documented disk-restore path and does not
require a trainer or weight-transfer engine:

```python
llm.sleep(level=2)
llm.wake_up(tags=["weights"])
llm.collective_rpc("reload_weights")
llm.wake_up(tags=["kv_cache"])
```

This change reuses #46725's `get_draft_model()` accessor and the same layerwise
reload lifecycle used by checkpoint-format transfer engines, while keeping the
checkpoint source appropriate to this workflow.

This is not a duplicate of #46725: that change added externally supplied
runtime draft updates, while this PR completes the separate documented
disk-backed `reload_weights()` recovery path.

## Live evidence

### Qwen3.8 MTP (same-checkpoint, same-width share)

Measured on an earlier MRV2-wrapper revision of this PR (same disk draft
loader, layerwise lifecycle, and draft-first / target-last order) on 2x RTX
5090, TP=2, Qwen3.8-27B-FP8, MTP `num_speculative_tokens=2`, with sleep mode
enabled. Each throughput entry is the median of three 256-token HTTP
generations.

| State | Throughput | Mean acceptance length | Reload RPC |
| --- | ---: | ---: | ---: |
| Cold baseline | 109.4 tok/s | not recorded | — |
| L2 wake cycle 1 | 108.9 tok/s (100% of baseline) | 2.17 | 4.18 s |
| L2 wake cycle 2 | 104.9 tok/s (96% of baseline) | 2.43 | 4.11 s |

Unpatched reproduction on that stack: 51.8 tok/s, acceptance length 1.00, zero
accepted draft tokens.

### Gemma4 E2B MTP (dim-mismatched shared embeddings)

Measured on this branch (identity detach + tied-embed sink) on the same
2x RTX 5090, TP=2, `google/gemma-4-E2B-it` + `google/gemma-4-E2B-it-assistant`,
MTP `num_speculative_tokens=1`, sleep mode enabled. Each throughput entry is
the median of three 64-token HTTP generations. Assistant `hidden_size=256`,
`backbone_hidden_size=1536`.

| State | Throughput | Mean acceptance length | Reload RPC |
| --- | ---: | ---: | ---: |
| Cold baseline | 297.5 tok/s | 1.50 | — |
| L2 wake cycle 1 | 293.0 tok/s (98% of baseline) | 1.50 | 1.15 s |
| L2 wake cycle 2 | 304.6 tok/s (102% of baseline) | 1.50 | 1.08 s |

Both models used the documented staged sequence plus a prefix-cache reset.
Outputs were coherent. No shape-mismatch traceback. A discard-only detach
avoided the crash but left acceptance at 1.00 (tied `lm_head` never refilled);
the sink is what restored 1.50.

### EAGLE3 (separate draft checkpoint, low-rank draft head)

Llama-3.1-8B-Instruct + yuhuili/EAGLE3-LLaMA3.1-Instruct-8B, 2x RTX 5090,
TP=2, `num_speculative_tokens=3`, sleep mode enabled, `--enforce-eager`,
median of three 64-token generations. The head ships no `embed_tokens`
tensors, so the target's embedding module is installed in the draft (one
detached alias at reload); it keeps its own low-rank `lm_head` (draft vocab
32000).

| State | Throughput | Mean acceptance length | Reload RPC |
| --- | ---: | ---: | ---: |
| Cold baseline | 93.9 tok/s | 2.17 | — |
| L2 wake cycle 1 | 94.1 tok/s | 2.17 | 2.8 s |
| L2 wake cycle 2 | 97.1 tok/s | 2.17 | 2.8 s |

No draft parameters remain on meta after the reload; outputs coherent. On the
pre-guard revision used for this validation the tied-embed sink engaged on the
vocab-axis mismatch but consumed no tensors (the checkpoint ships none); the
hidden-axis guard added in a follow-up commit now sends this layout directly to
the discard path.

With CUDA graphs enabled (default), the same cycle instead fails at the first
post-wake step with a CUDA illegal memory access that under
`CUDA_LAUNCH_BLOCKING=1` raises synchronously inside the draft speculator's
fused multi-step decode CUDA-graph replay. This failure is reproduced without
this PR on the stock nightly (identical synchronous site, same machine), so it
was not introduced by this change; eager mode with this PR fully works. The
specific stale pointer inside the captured graph is not identified here.

### DSpark (draft ships neither embed nor lm_head)

Qwen3.8-27B-FP8 + its DSpark drafter (checkpoint of 62 tensors, no
`embed_tokens`/`lm_head` — both modules are the target's and are the two
detached aliases at reload), TP=2, `num_speculative_tokens=7`, median of three
64-token generations. The drafter rebuilds fused buffers at the end of
`load_weights`; inside the layerwise window that rebuild captured the
temporarily meta-derived rotary buffer while finalization restored the real
one, crashing the first fused RoPE dispatch. The follow-up commit re-runs that
rebuild after finalization.

| State | Throughput | Mean acceptance length | Reload RPC |
| --- | ---: | ---: | ---: |
| Cold baseline | 86.6 tok/s | 2.26 | — |
| L2 wake cycle 1 | 84.9 tok/s | 2.26 | 4.6 s |
| L2 wake cycle 2 | 85.4 tok/s | 2.26 | 4.6 s |

Zero draft parameters on meta after the reload; outputs coherent; clean worker
logs.

## Tests

Nine focused unit tests cover:

1. A disk-backed reload restores the draft through its configured loader and
   the layerwise lifecycle before reloading the target.
2. The same disk path through Model Runner V2's existing
   `GPUModelRunnerV1.reload_weights(self, ...)` delegate.
3. A disk-backed reload without a draft still reloads the target normally.
4. A caller-supplied weight iterator does not trigger an implicit draft reload.
5. A dim-mismatched aliased `embed_tokens` (same vocab width, differing
   hidden) is not written; the tied draft-dim `lm_head` still receives the
   embed checkpoint tensor.
6. A same-width shared embed is discarded; a distinct `lm_head` is not filled
   from `embed_tokens`.
7. A vocab-mismatched shared embed (low-rank draft head) is discarded, and the
   head still loads from its own checkpoint entry.
8. A drafter whose `load_weights` rebuilds fused state mid-lifecycle has that
   rebuild re-run after finalization.
9. The same target `lm_head` aliased at `draft.lm_head` and every
   `shared_head.head` is detached (`named_modules(remove_duplicate=False)`).

```text
.venv/bin/python -m pytest \
  tests/v1/worker/test_gpu_model_runner.py::TestReloadDraftWeights -q
# 9 passed
```

## Scope and limitations

- The serving path of interest is Model Runner V2. The implementation lives in
  the shared `GPUModelRunner.reload_weights` that V2 already calls, so a
  legacy V1 engine using that method also gets the disk draft reload.
- Live validation covers Qwen3.8 same-checkpoint MTP, Gemma4 E2B MTP with a
  separate assistant checkpoint, EAGLE3 under `--enforce-eager`, and DSpark
  end-to-end, all TP=2. Graphed-mode EAGLE3 fails at the first post-wake step
  inside the draft's multi-step CUDA-graph replay; that failure is reproduced
  without this PR on the stock nightly and is not addressed here. Independent
  drafts are unbound only when a module is the same object as the target:
  EAGLE3 shares the target's embedding, DSpark shares both the embedding and
  the output head, and both detach as expected.
- The configured draft checkpoint remains the source of draft weights. This
  change does not redefine draft selection during `weights_path` model swaps.
- Draft formats whose loaders do not implement `get_all_weights` raise
  `NotImplementedError`, matching the existing target-model disk reload.

## AI assistance

AI assistance was used for investigation, implementation, review-response
analysis, and test orchestration. The submitter reviewed the changes and the
live validation described above.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved checkpoint reloading for models that use draft-model decoding.
  - Draft-model parameters are now restored in the correct order before target-model parameters.
  - Improved handling of shared, tied, aliased, and fused weights during reloads.
  - Fixed reload behavior for mismatched embedding dimensions and vocabulary sizes.
  - Added safeguards for models without draft components and reloads using iterators.
  - Improved compatibility across both supported model-runner versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->