### PR TITLE
[Bugfix][Frontend] Convert Anthropic tool_reference items to text blocks

### DIFF
--- a/tests/entrypoints/anthropic/test_anthropic_messages_conversion.py
+++ b/tests/entrypoints/anthropic/test_anthropic_messages_conversion.py
@@ -48,6 +48,8 @@ from vllm.entrypoints.serve.exception_handling.handlers.validation import (
     validation_exception_handler,
 )
 
+pytestmark = pytest.mark.skip_global_cleanup
+
 _convert = AnthropicServingMessages._convert_anthropic_to_openai_request
 _img_url = AnthropicServingMessages._convert_image_source_to_url
 
@@ -237,6 +239,20 @@ class TestToolResultContent:
         tool_msg = [m for m in result.messages if m["role"] == "tool"]
         assert len(tool_msg) == 1
         assert tool_msg[0]["content"] == "line 1\nline 2"
+
+    def test_tool_result_with_tool_reference(self):
+        request = self._make_tool_result_request(
+            [
+                {"type": "tool_reference", "tool_name": "list_files"},
+            ]
+        )
+        result = _convert(request)
+
+        tool_msg = [m for m in result.messages if m["role"] == "tool"]
+        assert len(tool_msg) == 2
+        assert tool_msg[1]["content"] == [
+            {"type": "text", "text": "[tool reference: list_files]"}
+        ]
 
     def test_tool_result_with_image(self):
         """Image in tool_result should produce a follow-up user message."""

--- a/vllm/entrypoints/anthropic/serving.py
+++ b/vllm/entrypoints/anthropic/serving.py
@@ -431,7 +431,10 @@ class AnthropicServingMessages(OpenAIServingChat):
                     ref_name = item.get("tool_name") or item.get("name")
                     if ref_name:
                         tool_reference.append(
-                            {"type": "tool_reference", "name": ref_name}
+                            {
+                                "type": "text",
+                                "text": f"[tool reference: {ref_name}]",
+                            }
                         )
             tool_text = "\n".join(text_parts)
 


### PR DESCRIPTION
## Purpose

Fixes #52489.

`_convert_user_tool_result` normalises `text` and `image` items inside a `tool_result` block into OpenAI-shaped content items, but for `tool_reference` it appended the Anthropic-shaped dict unchanged:

```python
{"type": "tool_reference", "name": ref_name}
```

That dict becomes the `content` of a `tool`-role message and is passed to the model's chat template. Templates that enumerate known content types (Qwen3's among them) fall through to their catch-all `raise_exception` branch on the unknown `tool_reference` type, so the request fails for whichever model is being served. Because the offending block stays in the conversation history, every subsequent request in that session fails as well — which is why this surfaces as an agent session going permanently dead rather than a single bad request.

The fix converts the item to a `text` block, mirroring how `text` and `image` are already handled. This is the fix suggested by the reporter in the issue.

**Duplicate check.** Searched open PRs for `52489 in:body`, `tool_reference`, and `anthropic tool_result`. The other open Anthropic-frontend PRs — #47877 / #47747 (per-type `AnthropicContentBlock` field validation), #45653 (`search_result` blocks), #46162 (streaming error forwarding), #34053 (protocol compliance) — touch different code paths and none change `tool_reference` handling in `_convert_user_tool_result`.

**One scope note.** The test file gains `pytestmark = pytest.mark.skip_global_cleanup` so this pure-conversion suite can run on a machine with no GPU; without it the run aborts during global cleanup. Five other files under `tests/entrypoints/` already set it. Happy to drop it if you would rather the diff stay strictly on the fix.

## Test Plan

New case `TestToolResultContent::test_tool_result_with_tool_reference`. The malformed content shape *is* the bug, so the test asserts the converted `tool` message directly rather than going through a template.

```
.venv/bin/python -m pytest tests/entrypoints/anthropic/test_anthropic_messages_conversion.py
```

## Test Result

- With the new test but `serving.py` reverted: 1 failed — content came back as `[{'type': 'tool_reference', 'name': 'list_files'}]`.
- With the fix applied: **52 passed**.
- `ruff check` and `ruff format --diff` clean on both changed files.

No model evaluation is included: this changes neither weights, sampling, nor kernels, and only affects how a request is translated ahead of templating. A before/after quality comparison isn't meaningful here because the affected requests currently fail outright at template rendering.

---

Per the AI-assisted contribution policy: this change was developed with AI assistance (GitHub Copilot), noted in the commit trailer. I reviewed every changed line, ran the tests above, and can speak to the change.
