### PR TITLE
[Bugfix][Hardware][NVIDIA] Fix DSV4 sparse MLA spec-decode shapes on SM120 FlashInfer path

### DIFF
--- a/vllm/models/deepseek_v4/nvidia/flashinfer_sparse.py
+++ b/vllm/models/deepseek_v4/nvidia/flashinfer_sparse.py
@@ -784,13 +784,38 @@ class DeepseekV4FlashInferSM120Attention(DeepseekV4Attention):
             raise RuntimeError(
                 "Compressed sparse MLA decode requires compressed sparse indices."
             )
+        # flashinfer's dsv4 decode API expects query as
+        # [batch, q_len_per_request, heads, 512]. With speculative decoding
+        # (next_n = k+1 tokens per request) a flattened [tokens, heads, 512]
+        # is ambiguous: flashinfer's normalizer misroutes it to the varlen
+        # prefill kernel, whose SM120 build asserts num_tokens > 64
+        # ("Decode ... must go through sparse_mla_sm120_decode_dsv4").
+        out_arg = output
+        if num_decodes > 0 and num_decode_tokens > num_decodes:
+            assert num_decode_tokens % num_decodes == 0, (
+                f"ragged spec decode batch: {num_decode_tokens} tokens over "
+                f"{num_decodes} requests"
+            )
+            next_n = num_decode_tokens // num_decodes
+            q = q.view(num_decodes, next_n, *q.shape[1:])
+            out_arg = output.view(num_decodes, next_n, *output.shape[1:])
+            # Companion tensors must match the [batch, next_n, ...] layout the
+            # 4-D query implies (flashinfer validates indices against it).
+            swa_indices = swa_indices.reshape(num_decodes, next_n, -1)
+            swa_lens = swa_lens.reshape(num_decodes, next_n)
+            if extra_sparse_indices is not None:
+                extra_sparse_indices = extra_sparse_indices.reshape(
+                    num_decodes, next_n, -1
+                )
+            if extra_sparse_lengths is not None:
+                extra_sparse_lengths = extra_sparse_lengths.reshape(num_decodes, next_n)
         flashinfer_trtllm_batch_decode_sparse_mla_dsv4(
             query=q,
             swa_kv_cache=swa_cache,
             workspace_buffer=self._get_workspace(q.device),
             sparse_indices=swa_indices,
             compressed_kv_cache=extra_cache,
-            out=output,
+            out=out_arg,
             bmm1_scale=self.scale,
             sinks=self.attn_sink,
             kv_layout="NHD",
@@ -898,12 +923,59 @@ class DeepseekV4FlashInferSM120Attention(DeepseekV4Attention):
             )
 
             q_chunk = q[query_start:query_end]
+            if q_chunk.shape[0] == 0:
+                # Empty chunk (zero-token span in query_start_loc): the
+                # flashinfer sparse kernel crashes reshaping 0 elements.
+                continue
             swa_indices_chunk = swa_metadata.prefill_swa_indices[query_start:query_end]
             swa_lens_chunk = swa_metadata.prefill_swa_lens[query_start:query_end]
             if extra_kv_paged is not None and extra_sparse_indices_chunk is None:
                 raise RuntimeError(
                     "Compressed sparse MLA prefill requires compressed sparse indices."
                 )
+            if q_chunk.shape[0] <= 64:
+                # SM120's sparse prefill kernel asserts num_tokens > 64.
+                # Small segments (the DSpark draft's k-token pass, short
+                # chunked-prefill tails) must use the uniform decode-form
+                # [1, q_len, ...] call, which flashinfer routes to its
+                # sparse_mla_sm120_decode_dsv4 kernels (q_len <= 64 legal).
+                for ri in range(chunk_start, chunk_end):
+                    rs = int(query_start_loc_cpu[num_decodes + ri] - prefill_token_base)
+                    re_ = int(
+                        query_start_loc_cpu[num_decodes + ri + 1] - prefill_token_base
+                    )
+                    if re_ <= rs:
+                        continue
+                    ql = re_ - rs
+                    esi = (
+                        extra_sparse_indices[rs:re_].reshape(1, ql, -1)
+                        if extra_sparse_indices is not None
+                        else None
+                    )
+                    esl = (
+                        extra_sparse_lengths[rs:re_].reshape(1, ql)
+                        if extra_sparse_lengths is not None
+                        else None
+                    )
+                    flashinfer_trtllm_batch_decode_sparse_mla_dsv4(
+                        query=q[rs:re_].reshape(1, ql, *q.shape[1:]),
+                        swa_kv_cache=swa_kv_paged,
+                        workspace_buffer=self._get_workspace(q.device),
+                        sparse_indices=swa_metadata.prefill_swa_indices[rs:re_].reshape(
+                            1, ql, -1
+                        ),
+                        compressed_kv_cache=extra_kv_paged,
+                        out=output[rs:re_].reshape(1, ql, *output.shape[1:]),
+                        bmm1_scale=self.scale,
+                        sinks=self.attn_sink,
+                        kv_layout="NHD",
+                        swa_topk_lens=swa_metadata.prefill_swa_lens[rs:re_].reshape(
+                            1, ql
+                        ),
+                        extra_sparse_indices=esi,
+                        extra_sparse_topk_lens=esl,
+                    )
+                continue
             flashinfer_trtllm_batch_decode_sparse_mla_dsv4(
                 query=q_chunk,
                 swa_kv_cache=swa_kv_paged,

--- a/vllm/models/deepseek_v4/nvidia/flashinfer_sparse.py
+++ b/vllm/models/deepseek_v4/nvidia/flashinfer_sparse.py
@@ -801,14 +801,22 @@ class DeepseekV4FlashInferSM120Attention(DeepseekV4Attention):
             out_arg = output.view(num_decodes, next_n, *output.shape[1:])
             # Companion tensors must match the [batch, next_n, ...] layout the
             # 4-D query implies (flashinfer validates indices against it).
-            swa_indices = swa_indices.reshape(num_decodes, next_n, -1)
-            swa_lens = swa_lens.reshape(num_decodes, next_n)
+            # .contiguous() is required, not cosmetic: c128a_global_decode_
+            # topk_indices can be a slice of a larger, alignment-padded
+            # workspace buffer (kept fixed-size for CUDA graph capture), so
+            # its reshape()-compatible view may not satisfy flashinfer's
+            # CHECK_INPUT_AND_TYPE contiguity check on the C++ side even
+            # though the shape matches.
+            swa_indices = swa_indices.reshape(num_decodes, next_n, -1).contiguous()
+            swa_lens = swa_lens.reshape(num_decodes, next_n).contiguous()
             if extra_sparse_indices is not None:
                 extra_sparse_indices = extra_sparse_indices.reshape(
                     num_decodes, next_n, -1
-                )
+                ).contiguous()
             if extra_sparse_lengths is not None:
-                extra_sparse_lengths = extra_sparse_lengths.reshape(num_decodes, next_n)
+                extra_sparse_lengths = extra_sparse_lengths.reshape(
+                    num_decodes, next_n
+                ).contiguous()
         flashinfer_trtllm_batch_decode_sparse_mla_dsv4(
             query=q,
             swa_kv_cache=swa_cache,


### PR DESCRIPTION
## Purpose

Fix DeepSeek-V4 sparse MLA speculative decoding (DSpark) on SM120/SM121 (GB10 / DGX Spark) with the `FLASHINFER_MLA_SPARSE_DSV4` backend.

FlashInfer's `trtllm_batch_decode_sparse_mla_dsv4` API disambiguates decode-vs-prefill by query rank. With speculative decoding (`next_n > 1` tokens per request), `DeepseekV4FlashInferSM120Attention` passes a flattened 3-D `[tokens, heads, 512]` query, which FlashInfer's normalizer misroutes to the varlen prefill kernel. The SM120 prefill build asserts `num_tokens > 64` and the server crashes with the cryptic `"Decode ... must go through sparse_mla_sm120_decode_dsv4"` assertion.

Four related fixes, all confined to `DeepseekV4FlashInferSM120Attention`:

1. **4-D spec-decode query**: pass `[batch, next_n, heads, 512]` query (and matching output view) for spec decode batches so FlashInfer routes them to the decode kernels.
2. **Companion index reshape**: reshape sparse indices/lens to `[batch, next_n, ...]` alongside the 4-D query (FlashInfer validates their layout against the query).
3. **≤64-token prefill segments**: route them through per-request decode-form `[1, q_len, ...]` calls (the DSpark draft's k-token pass and short chunked-prefill tails hit the same `num_tokens > 64` prefill assert).
4. **Empty prefill chunks**: skip zero-token spans in `query_start_loc` — the FlashInfer sparse kernel crashes reshaping 0 elements. (FlashMLA-side counterpart of the same class of bug: #51489.)

Not a duplicate: #51538 (merged) fixes the SM120 top-k specialization selection and adds an init-time check, but the decode call on `main` still passes flat 3-D queries for spec batches, and the prefill chunk loop still has neither the ≤64-token routing nor the empty-chunk skip. #41834 (SM12x DSV4 enablement) does not touch `flashinfer_sparse.py` spec-decode shapes.

## Test Plan

- `python -m py_compile vllm/models/deepseek_v4/nvidia/flashinfer_sparse.py`
- End-to-end: 2× DGX Spark (GB10, SM121), TP=2, serving DeepSeek-V4-Flash-0731 with DSpark speculative decoding enabled; mixed short/long prompt load including chunked prefill.

## Test Result

- Before: server crashes on the first spec-decode batch with the SM120 prefill `num_tokens > 64` assertion.
- After: DSpark spec decode serves stably on 2× DGX Spark GB10 TP=2 (DeepSeek-V4-Flash-0731); draft k-token passes, short chunk tails, and empty chunks all handled; output spot-checked against non-spec decoding.

---

AI assistance was used for this PR (rebasing/porting the fixes from a v0.26.0-based production branch onto `main`); every changed line was reviewed and validated end-to-end by the submitter on the hardware above.
