### PR TITLE
[Bugfix][Hardware][NVIDIA] Add VLLM_DISABLE_CUTEDSL kill-switch for CuTeDSL kernels

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -129,6 +129,7 @@ if TYPE_CHECKING:
     VLLM_ENABLE_FLA_PACKED_RECURRENT_DECODE: bool = True
     VLLM_GDN_DECODE_KERNEL: Literal["cuda", "triton"] = "cuda"
     VLLM_DISABLE_PYNCCL: bool = False
+    VLLM_DISABLE_CUTEDSL: bool = False
     VLLM_USE_OINK_OPS: bool = False
     VLLM_MXFP8_EMULATION_DEQUANT_AT_LOAD: bool = True
     VLLM_ROCM_USE_AITER: bool = False
@@ -1222,6 +1223,13 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Disable pynccl (using torch.distributed instead)
     "VLLM_DISABLE_PYNCCL": lambda: (
         os.getenv("VLLM_DISABLE_PYNCCL", "False").lower() in ("true", "1")
+    ),
+    # Treat CuTeDSL as unavailable even if the `cutlass` package is
+    # installed, falling back to non-CuTeDSL kernels. Escape hatch for
+    # platforms where CuTeDSL kernels fail to compile (e.g. internal
+    # compiler errors on GB10 / SM12.1).
+    "VLLM_DISABLE_CUTEDSL": lambda: (
+        os.getenv("VLLM_DISABLE_CUTEDSL", "False").lower() in ("true", "1")
     ),
     # Optional: enable external Oink custom ops (e.g., Blackwell RMSNorm).
     # Disabled by default.

--- a/vllm/model_executor/kernels/linear/cute_dsl/ll_bf16.py
+++ b/vllm/model_executor/kernels/linear/cute_dsl/ll_bf16.py
@@ -20,6 +20,12 @@ def is_available() -> bool:
     global _cutedsl_available
     if _cutedsl_available is not None:
         return _cutedsl_available
+    # Central gate honors VLLM_DISABLE_CUTEDSL=1 (CuTeDSL ICEs on SM12.1/GB10).
+    from vllm.utils.import_utils import has_cutedsl
+
+    if not has_cutedsl():
+        _cutedsl_available = False
+        return False
     try:
         import cutlass  # noqa: F401
         import cutlass.cute  # noqa: F401

--- a/vllm/models/deepseek_v4/compressor.py
+++ b/vllm/models/deepseek_v4/compressor.py
@@ -41,7 +41,14 @@ if TYPE_CHECKING:
 
 def _prefer_two_stage_compressor() -> bool:
     # Platforms that favor the triton variant of two-stage compressor split.
-    # Currently only tested on ROCm
+    # Currently only tested on ROCm. Also used on CUDA when CuTeDSL is
+    # unavailable/disabled (VLLM_DISABLE_CUTEDSL=1): the cutedsl compressor
+    # ICEs on SM12.1/GB10, and the head=512 triton two-stage is the only
+    # non-cutedsl compressor for that head dim.
+    from vllm.utils.import_utils import has_cutedsl
+
+    if current_platform.is_cuda() and not has_cutedsl():
+        return True
     return current_platform.is_rocm()
 
 
@@ -419,7 +426,9 @@ class DeepseekCompressor(nn.Module):
         # cutedsl (head=512) accepts the full-cache flags; triton (indexer/AMD)
         # does not, so the two callables have different signatures.
         compress_norm_rope_store_fn: Any
-        if current_platform.is_cuda() and self.head_dim == 512:
+        from vllm.utils.import_utils import has_cutedsl
+
+        if current_platform.is_cuda() and self.head_dim == 512 and has_cutedsl():
             from .nvidia.ops.sparse_attn_compress_cutedsl import (
                 compress_norm_rope_store_cutedsl,
             )

--- a/vllm/utils/import_utils.py
+++ b/vllm/utils/import_utils.py
@@ -576,7 +576,16 @@ def has_fbgemm_gpu() -> bool:
 
 
 def has_cutedsl() -> bool:
-    """Whether the optional `cutelass` package is available."""
+    """Whether the optional `cutelass` package is available.
+
+    VLLM_DISABLE_CUTEDSL=1 force-disables it: on GB10/SM12.1 the CuTeDSL
+    kernels (e.g. DSV4 fused_indexer_q_cutedsl) fail with an internal
+    compiler error; the non-cutedsl fallbacks work.
+    """
+    from vllm import envs
+
+    if envs.VLLM_DISABLE_CUTEDSL:
+        return False
     return _has_module("cutlass")
 
 


### PR DESCRIPTION
## Purpose

Add a `VLLM_DISABLE_CUTEDSL` environment kill-switch for CuTeDSL kernels.

On GB10 (SM12.1), CuTeDSL kernels fail with internal compiler errors (e.g. the DSV4 `fused_indexer_q_cutedsl` indexer kernel), while the non-CuTeDSL fallbacks work fine. Today there is no way to opt out of CuTeDSL when the `cutlass` package is installed — availability probes only check importability, so every affected code path has to be patched by hand.

Changes:

- `vllm/envs.py`: register `VLLM_DISABLE_CUTEDSL` (default off), documented as an escape hatch for platforms where CuTeDSL kernels fail to compile.
- `import_utils.has_cutedsl()`: return `False` when the switch is set — single central gate.
- DSV4 compressor: fall back to the Triton two-stage compressor for `head_dim=512` on CUDA when CuTeDSL is unavailable/disabled (it is the only non-CuTeDSL compressor for that head dim).
- `cute_dsl/ll_bf16.is_available()`: consult `has_cutedsl()` before probing the `cutlass` import, so the cached probe honors the switch.

Not a duplicate: no open PR adds a CuTeDSL opt-out (searched `cutedsl disable`, `VLLM_DISABLE_CUTEDSL`); existing `VLLM_DISABLED_KERNELS` only filters quantization kernel classes by name and does not gate CuTeDSL availability probes.

## Test Plan

- `python -m py_compile` on all four touched files.
- End-to-end: 2× DGX Spark (GB10, SM12.1), TP=2, serving DeepSeek-V4-Flash-0731 with `VLLM_DISABLE_CUTEDSL=1`: verify the Triton two-stage compressor is selected, `ll_bf16` reports unavailable, and no CuTeDSL compilation is attempted.
- Default-path regression: without the env var, behavior is byte-identical (`has_cutedsl()` still just probes the `cutlass` module).

## Test Result

- Before: DSV4 startup on GB10 dies in CuTeDSL internal compiler errors with no opt-out.
- After: `VLLM_DISABLE_CUTEDSL=1` serves DeepSeek-V4-Flash-0731 stably on 2× DGX Spark GB10 TP=2 via the non-CuTeDSL fallbacks; unset, nothing changes.

---

AI assistance was used for this PR (rebasing from a v0.26.0-based production branch onto `main`, plus moving the env read into `vllm/envs.py` per project convention); every changed line was reviewed and validated end-to-end by the submitter on the hardware above.
