### PR TITLE
[CI][Bugfix] Lower gpu_memory_utilization for ViT cudagraph tests

### DIFF
--- a/tests/models/multimodal/generation/test_vit_cudagraph.py
+++ b/tests/models/multimodal/generation/test_vit_cudagraph.py
@@ -24,6 +24,10 @@ class VitCudagraphTestConfig:
     max_model_len: int = 4096
     max_tokens: int = 64
     max_num_seqs: int = 2
+    # Encoder CUDA graphs are captured after the KV cache is sized, and MRV2's
+    # profile_cudagraph_memory() reserves nothing for them, so they have to fit
+    # in whatever the utilization fraction leaves unclaimed.
+    gpu_memory_utilization: float = 0.85
     num_video_frames: int = 16
     needs_video_metadata: bool = False
     vllm_runner_kwargs: dict = field(default_factory=dict)
@@ -331,6 +335,7 @@ def test_vit_cudagraph_image(model_id, vllm_runner, image_assets):
         max_model_len=config.max_model_len,
         max_num_seqs=config.max_num_seqs,
         limit_mm_per_prompt={"image": 1},
+        gpu_memory_utilization=config.gpu_memory_utilization,
         compilation_config=get_compilation_config(config),
         **config.vllm_runner_kwargs,
     ) as vllm_model:
@@ -386,6 +391,7 @@ def test_vit_cudagraph_video(model_id, vllm_runner, video_assets):
         max_model_len=config.max_model_len,
         max_num_seqs=config.max_num_seqs,
         limit_mm_per_prompt={"video": 1},
+        gpu_memory_utilization=config.gpu_memory_utilization,
         compilation_config=get_compilation_config(config),
         **config.vllm_runner_kwargs,
     ) as vllm_model:


### PR DESCRIPTION
## Summary

`Multi-Modal Models (Standard) 4: other + whisper` has been failing on every `main` build since #49852 landed. `test_vit_cudagraph_image[gemma4]` and `test_vit_cudagraph_video[gemma4]` die during engine-core startup, deterministically.

<img width="1357" height="235" alt="image" src="https://github.com/user-attachments/assets/e1f06c0c-f9a6-49b5-9bb4-2ebb5b11b6af" />

This lowers `gpu_memory_utilization` for the tests in `test_vit_cudagraph.py` as a stopgap.

## The regression window is clean

Ordering every build I could pull by vLLM dev version — #49852 landed at **dev85** (`66728feb1f`, 85 commits past `v0.27.2rc0`):

| build | version | OOM lines | `[gemma4]` failed |
|---|---|---|---|
| [84067](https://buildkite.com/vllm/ci/builds/84067) | `0.26.1rc1.dev665` | 0 | 0 ✅ |
| [84000](https://buildkite.com/vllm/ci/builds/84000) | `0.27.2rc1.dev26` | 0 | 0 ✅ |
| | ← **#49852 merges at dev85** → | | |
| [84020](https://buildkite.com/vllm/ci/builds/84020) | `0.27.2rc1.dev113` | 10 | 2 ❌ |
| [84041](https://buildkite.com/vllm/ci/builds/84041) | `0.27.2rc1.dev117` | 8 | 1 ❌ |
| [84062](https://buildkite.com/vllm/ci/builds/84062) | `0.27.2rc1.dev121` | 10 | 2 ❌ |
| [84068](https://buildkite.com/vllm/ci/builds/84068) | `0.27.2rc1.dev124` (×3 retries) | 10 | 2 ❌ |
| [84064](https://buildkite.com/vllm/ci/builds/84064) | `0.27.2rc1.dev126` | 8 | 1 ❌ |
| [84066](https://buildkite.com/vllm/ci/builds/84066) | `0.27.2rc1.dev127` | 10 | 2 ❌ |
| [84060](https://buildkite.com/vllm/ci/builds/84060) | `0.27.2rc1.dev130` | 10 | 2 ❌ |
| [84050](https://buildkite.com/vllm/ci/builds/84050) | `0.27.2rc1.dev156` | 10 | 2 ❌ |

Every build before dev85 passes, every build after fails. 11 runs across 11 different Buildkite agents, 0 passes — including 3 retries on 84068 and the daily build 84041 on plain `main` (`ed0f4750f8`). This is not flaky and retrying does not help.

The graph-memory numbers the same job reports line up with the boundary:

```
dev26  (PASS):  0.0  0.07  0.08  0.09  0.33  0.69  1.27
dev124 (FAIL):  0.0        0.33  0.69  0.71  1.02  1.04  1.14  1.27  1.33
```

The `0.07`–`0.09 GiB` tier disappears and `1.02`–`1.33 GiB` entries appear — encoder graph capture taking over. gemma4 specifically goes from **0.09 → 2.24 GiB**.

## Why it OOM

The reason there is nothing left: MRV2's `profile_cudagraph_memory()` returns `0`. `gpu_worker` subtracts that estimate from the KV cache budget, so nothing is reserved for graph capture, and encoder CUDA graphs have to fit in whatever the utilization fraction leaves unclaimed. 

## The real fix

#49233 (*Reserve CUDA graph memory in V2 GPU model runner*) implements `profile_cudagraph_memory()` for MRV2 and is the actual fix. It is open and mergeable but has been on hold since July — @njhill [asked to hold off](https://github.com/vllm-project/vllm/pull/49233#issuecomment-3096962143):

> we may hold off on this because we're working on a different approach with model runner v2 based on #47363. As 》> the comment says, whether we add V1-style memory profiling is still TBD.

That direction is now #50779 (*Extensible (growable) KV cache*, draft, actively updated) — it sidesteps pre-capture estimation entirely by letting the KV cache grow on demand. #47363 itself is a self-described "Demo implementation" and has been untouched since 2026-07-21.