### PR TITLE
[ci] fix wheels.vllm.ai nightly page link

### DIFF
--- a/.buildkite/scripts/generate-nightly-index.py
+++ b/.buildkite/scripts/generate-nightly-index.py
@@ -110,14 +110,29 @@ def parse_from_filename(file: str) -> WheelFileInfo:
     )
 
 
-def generate_project_list(subdir_names: list[str], comment: str = "") -> str:
+def generate_project_list(
+    subdir_names: list[str], comment: str = "", url_prefix: str = ""
+) -> str:
     """
     Generate project list HTML content linking to each project & variant subdirectory.
+
+    Args:
+        subdir_names: List of subdirectory names to link to.
+        comment: Optional comment to include in the generated HTML.
+        url_prefix: Root-relative URL prefix of this index (e.g. "nightly",
+            "rocm/nightly" or a commit hash). When set, links are generated as
+            root-relative paths ("/{url_prefix}/{name}/") so they resolve correctly
+            even when the page is accessed without a trailing slash (the S3 REST
+            endpoint does not redirect directory URLs lacking a trailing slash).
+            When empty, plain relative links are generated.
     """
     href_tags = []
     for name in sorted(subdir_names):
         name = name.strip("/").strip(".")
-        href_tags.append(f'    <a href="{name}/">{name}/</a><br/>')
+        if url_prefix:
+            href_tags.append(f'    <a href="/{url_prefix}/{name}/">{name}/</a><br/>')
+        else:
+            href_tags.append(f'    <a href="{name}/">{name}/</a><br/>')
     return INDEX_HTML_TEMPLATE.format(items="\n".join(href_tags), comment=comment)
 
 
@@ -155,6 +170,7 @@ def generate_index_and_metadata(
     default_variant: str | None = None,
     alias_to_default: str | None = None,
     comment: str = "",
+    url_prefix: str = "",
 ):
     """
     Generate index for all wheel files.
@@ -302,7 +318,9 @@ def generate_index_and_metadata(
             subdir_names = subdir_names.union(packages)
         else:
             # generate project list for this variant directly
-            project_list_str = generate_project_list(sorted(packages), comment_tmpl)
+            project_list_str = generate_project_list(
+                sorted(packages), comment_tmpl, f"{url_prefix}/{variant}"
+            )
             with open(variant_dir / "index.html", "w") as f:
                 f.write(project_list_str)
 
@@ -322,7 +340,9 @@ def generate_index_and_metadata(
                 f.write(metadata_str)
 
     # Generate top-level project list index
-    project_list_str = generate_project_list(sorted(subdir_names), comment_tmpl)
+    project_list_str = generate_project_list(
+        sorted(subdir_names), comment_tmpl, url_prefix
+    )
     with open(index_base_dir / "index.html", "w") as f:
         f.write(project_list_str)
 
@@ -468,5 +488,6 @@ if __name__ == "__main__":
         default_variant=None,
         alias_to_default=args.alias_to_default,
         comment=args.comment.strip(),
+        url_prefix=version.strip("/"),
     )
     print(f"Successfully generated index and metadata in {output_dir}")


### PR DESCRIPTION



## Purpose
For now, https://wheels.vllm.ai/nightly sub dir will result in an not found error. For example, `cu130` will link to https://wheels.vllm.ai/cu130/ instead of https://wheels.vllm.ai/nightly/cu130/ and will get response:
```
This XML file does not appear to have any style information associated with it. The document tree is shown below.
<Error>
<Code>NoSuchKey</Code>
<Message>The specified key does not exist.</Message>
<Key>index.html</Key>
<RequestId>8ZE4E52SGHAVJN5K</RequestId>
<HostId>aAZbNbcflXTsFY7I9LGpMZ+fs2ihvreKiL2yRI5vOucC9XM8dE06yl8zWMcsi6ECT0I67DVZXTzrHa0SLBcmNQaREJsbsLQy</HostId>
</Error>
```

The reason is that the generated `href` for different variant only contains variant and lack current dir name.

if access https://wheels.vllm.ai/nightly/ with a `/` as the ending, `cu130` will link to https://wheels.vllm.ai/nightly/cu130/. After consulting ai, this is related to s3 rest endpoint. The S3 REST endpoint does not redirect directory URLs lacking a trailing slash.

## Test Plan
NA
## Test Result
NA

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

