### PR TITLE
[Bugfix][Frontend] Normalize reasoning_content on tokenize and pooling chat requests

### DIFF
--- a/tests/tool_use/test_chat_completion_request_validations.py
+++ b/tests/tool_use/test_chat_completion_request_validations.py
@@ -4,7 +4,17 @@
 import pytest
 
 from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
+from vllm.entrypoints.pooling.classify.protocol import ClassificationChatRequest
+from vllm.entrypoints.serve.tokenize.protocol import TokenizeChatRequest
 from vllm.exceptions import VLLMValidationError
+
+# Renderers read only `reasoning`, so every request type carrying chat
+# messages must normalize the deprecated name or drop thinking silently.
+CHAT_MESSAGE_REQUESTS = [
+    ChatCompletionRequest,
+    TokenizeChatRequest,
+    ClassificationChatRequest,
+]
 
 
 def test_chat_completion_request_with_no_tools():
@@ -64,8 +74,9 @@ def test_chat_completion_request_with_tool_choice_but_no_tools(tool_choice):
         )
 
 
-def test_reasoning_content_normalized_to_reasoning():
-    request = ChatCompletionRequest.model_validate(
+@pytest.mark.parametrize("request_cls", CHAT_MESSAGE_REQUESTS)
+def test_reasoning_content_normalized_to_reasoning(request_cls):
+    request = request_cls.model_validate(
         {
             "messages": [
                 {"role": "user", "content": "What is 2+2?"},
@@ -84,8 +95,9 @@ def test_reasoning_content_normalized_to_reasoning():
     assert "reasoning_content" not in assistant_msg
 
 
-def test_reasoning_takes_precedence_over_reasoning_content():
-    request = ChatCompletionRequest.model_validate(
+@pytest.mark.parametrize("request_cls", CHAT_MESSAGE_REQUESTS)
+def test_reasoning_takes_precedence_over_reasoning_content(request_cls):
+    request = request_cls.model_validate(
         {
             "messages": [
                 {"role": "user", "content": "What is 2+2?"},
@@ -104,8 +116,9 @@ def test_reasoning_takes_precedence_over_reasoning_content():
     assert "reasoning_content" not in assistant_msg
 
 
-def test_no_reasoning_fields_unchanged():
-    request = ChatCompletionRequest.model_validate(
+@pytest.mark.parametrize("request_cls", CHAT_MESSAGE_REQUESTS)
+def test_no_reasoning_fields_unchanged(request_cls):
+    request = request_cls.model_validate(
         {
             "messages": [
                 {"role": "user", "content": "Hello"},

--- a/vllm/entrypoints/chat_utils.py
+++ b/vllm/entrypoints/chat_utils.py
@@ -402,6 +402,33 @@ class ConversationMessage(TypedDict, total=False):
     """Model-specific task marker. Currently passed through for DeepSeek V4."""
 
 
+def normalize_reasoning_content(data: Any) -> Any:
+    """Rename the deprecated ``reasoning_content`` message field to ``reasoning``.
+
+    Renderers only read ``reasoning``, so every request type carrying chat
+    messages must run this or the thinking of clients using the old name is
+    silently dropped from the rendered prompt.
+
+    Args:
+        data: Raw request payload, as passed to a "before" model validator.
+
+    Returns:
+        The payload, with assistant messages normalized in place.
+    """
+    if not isinstance(data, dict):
+        return data
+    messages = data.get("messages")
+    if not isinstance(messages, list):
+        return data
+    for msg in messages:
+        if not isinstance(msg, dict):
+            continue
+        reasoning_content = msg.pop("reasoning_content", None)
+        if reasoning_content is not None and msg.get("reasoning") is None:
+            msg["reasoning"] = reasoning_content
+    return data
+
+
 # Passed in by user
 ChatTemplateContentFormatOption = Literal["auto", "string", "openai"]
 

--- a/vllm/entrypoints/openai/chat_completion/protocol.py
+++ b/vllm/entrypoints/openai/chat_completion/protocol.py
@@ -22,6 +22,7 @@ from vllm.config import ModelConfig
 from vllm.entrypoints.chat_utils import (
     ChatCompletionMessageParam,
     ChatTemplateContentFormatOption,
+    normalize_reasoning_content,
 )
 from vllm.entrypoints.openai.engine.protocol import (
     AnyResponseFormat,
@@ -524,11 +525,9 @@ class ChatCompletionRequest(OpenAIBaseModel):
     def _normalize_messages_before(cls, data: Any) -> Any:
         """Pre-process message dicts before Pydantic field validation.
 
-        Performs two normalizations in a single pass:
-        - Converts tool_calls generators/iterators to lists so one-shot
-          generators are not consumed during union type matching.
-        - Renames the deprecated ``reasoning_content`` field to
-          ``reasoning`` so downstream code only needs to check one field.
+        Converts tool_calls generators/iterators to lists so one-shot
+        generators are not consumed during union type matching, then
+        normalizes the deprecated ``reasoning_content`` field.
         """
         if not isinstance(data, dict):
             return data
@@ -541,10 +540,7 @@ class ChatCompletionRequest(OpenAIBaseModel):
             tool_calls = msg.get("tool_calls")
             if tool_calls is not None and not isinstance(tool_calls, list):
                 msg["tool_calls"] = list(tool_calls)
-            reasoning_content = msg.pop("reasoning_content", None)
-            if reasoning_content is not None and msg.get("reasoning") is None:
-                msg["reasoning"] = reasoning_content
-        return data
+        return normalize_reasoning_content(data)
 
     @model_validator(mode="after")
     def _materialize_tool_calls_after(self) -> "ChatCompletionRequest":

--- a/vllm/entrypoints/pooling/base/protocol.py
+++ b/vllm/entrypoints/pooling/base/protocol.py
@@ -10,6 +10,7 @@ from vllm.config import ModelConfig
 from vllm.entrypoints.chat_utils import (
     ChatCompletionMessageParam,
     ChatTemplateContentFormatOption,
+    normalize_reasoning_content,
 )
 from vllm.entrypoints.openai.engine.protocol import OpenAIBaseModel
 from vllm.exceptions import VLLMValidationError
@@ -269,6 +270,11 @@ class ChatRequestMixin(ChatRequestOptionsMixin):
     # --8<-- [start:chat-params]
     messages: list[ChatCompletionMessageParam]
     # --8<-- [end:chat-params]
+
+    @model_validator(mode="before")
+    @classmethod
+    def _normalize_reasoning_before(cls, data: Any) -> Any:
+        return normalize_reasoning_content(data)
 
 
 class EncodingRequestMixin(OpenAIBaseModel):

--- a/vllm/entrypoints/serve/tokenize/protocol.py
+++ b/vllm/entrypoints/serve/tokenize/protocol.py
@@ -10,6 +10,7 @@ from vllm.config import ModelConfig
 from vllm.entrypoints.chat_utils import (
     ChatCompletionMessageParam,
     ChatTemplateContentFormatOption,
+    normalize_reasoning_content,
 )
 from vllm.entrypoints.openai.chat_completion.protocol import (
     ChatCompletionToolsParam,
@@ -116,6 +117,11 @@ class TokenizeChatRequest(OpenAIBaseModel):
         default=None,
         description="A list of tools the model may call.",
     )
+
+    @model_validator(mode="before")
+    @classmethod
+    def _normalize_reasoning_before(cls, data: Any) -> Any:
+        return normalize_reasoning_content(data)
 
     @model_validator(mode="before")
     @classmethod


### PR DESCRIPTION

## Purpose

`_normalize_messages_before` renames the deprecated `reasoning_content` message field to
`reasoning`, but it is defined on `ChatCompletionRequest` only. Renderers read `reasoning`
exclusively (`chat_utils.py`, `_parse_chat_message_content`), so `/tokenize` and the pooling
chat endpoints silently drop the thinking of clients still using the old name.

Same messages, two different prompts (Qwen3.8-27B, `return_token_ids` + `/detokenize`):

```
/v1/chat/completions : <|im_start|>assistant\n<think>\nMARKER\n</think>\n\nHi   (37 tokens)
/tokenize            : <|im_start|>assistant\n<think>\n\n</think>\n\nHi        (30 tokens)
```

`/tokenize` therefore under-reports prompt length, which is what clients use to budget
context. Follow-up to #42664, which fixed the same bug on the chat path.

## Changes

Extract the rename into `normalize_reasoning_content` (`chat_utils.py`, which both protocol
modules already import from — no new module import, no import cycle) and apply it to
`TokenizeChatRequest` and `ChatRequestMixin`. `ChatCompletionRequest` now delegates instead
of carrying its own copy.

## Test Plan

The three existing `reasoning_content` normalization tests are parametrized over the request
types carrying chat messages, rather than adding new ones — any future request type added to
that list is covered by construction.

```
pytest tests/tool_use/test_chat_completion_request_validations.py
```

## Test Result

Before the fix, 4 failures on exactly the unpatched paths:

```
FAILED test_reasoning_content_normalized_to_reasoning[TokenizeChatRequest]
FAILED test_reasoning_content_normalized_to_reasoning[ClassificationChatRequest]
FAILED test_reasoning_takes_precedence_over_reasoning_content[TokenizeChatRequest]
FAILED test_reasoning_takes_precedence_over_reasoning_content[ClassificationChatRequest]
4 failed, 5 passed
```

After: `15 passed`. Lint/mypy via `pre-commit run --files` pass.

`tests/renderers/test_hf.py`: 60 passed, 3 pre-existing failures
(`test_resolve_content_format_*`, remote/gated HF configs) — identical on `main` without
this patch.

No model evaluation: this changes prompt assembly for a previously dropped field, not model
output or decoding.

## Not a duplicate

No open issue or PR covers this. Searched `TokenizeChatRequest`, `tokenize normalize
messages`, `reasoning_content tokenize`, `_normalize_messages_before`. #51892 is the only
open PR touching tokenize and is unrelated (bounding memory costs).

## AI assistance

Issue observed by me on a production deployment. Investigation, patch and tests were produced
by Claude (Claude Code) under my direction, with explicit instructions to touch existing tests
as little as possible and keep the fix minimal. I have reviewed every changed line and run the
tests above.
