### PR TITLE
Fix Responses message store aliasing

### DIFF
--- a/tests/entrypoints/openai/responses/test_serving_responses.py
+++ b/tests/entrypoints/openai/responses/test_serving_responses.py
@@ -96,6 +96,26 @@ def test_serialize_message_pydantic_model_returns_dict() -> None:
     assert serialized["message"] == "hello"
 
 
+def test_stored_input_messages_are_isolated_from_context_mutation() -> None:
+    serving = MagicMock(spec=OpenAIServingResponses)
+    serving.msg_store = {}
+    messages: list = [{"role": "user", "content": "Hello"}]
+
+    OpenAIServingResponses._store_input_messages(serving, "resp_test", messages)
+    messages.append(
+        ResponseReasoningItem(
+            id="rs_test",
+            type="reasoning",
+            summary=[],
+            content=[],
+        )
+    )
+
+    assert serving.msg_store["resp_test"] == [
+        {"role": "user", "content": "Hello"}
+    ]
+
+
 @pytest.fixture
 def mock_serving_responses():
     """Create a mock OpenAIServingResponses instance"""

--- a/vllm/entrypoints/openai/responses/serving.py
+++ b/vllm/entrypoints/openai/responses/serving.py
@@ -528,7 +528,7 @@ class OpenAIServingResponses(GenerateBaseServing):
 
         # Store the input messages.
         if request.store:
-            self.msg_store[request.request_id] = messages
+            self._store_input_messages(request.request_id, messages)
 
         if request.background:
             created_time = int(time.time())
@@ -605,6 +605,16 @@ class OpenAIServingResponses(GenerateBaseServing):
             tokenizer,
             request_metadata,
         )
+
+    def _store_input_messages(
+        self,
+        request_id: str,
+        messages: list[ChatCompletionMessageParam],
+    ) -> None:
+        # ParsableContext appends typed response items to `messages` during
+        # generation. Keep the stored input history isolated from that mutation
+        # because previous_response_id expects ChatCompletion message mappings.
+        self.msg_store[request_id] = copy(messages)
 
     async def _make_request(
         self,


### PR DESCRIPTION
## Summary

- isolate stored Responses input messages from `ParsableContext` mutations
- preserve the `msg_store` invariant that entries are Chat Completion message mappings
- add a regression test covering reasoning output appended after storage

## Root cause

The same `messages` list is passed to `ParsableContext` and stored in `msg_store`. During generation, `ParsableContext.append_output()` appends typed Responses output items such as `ResponseReasoningItem` to that list. A later request using `previous_response_id` replays the stored list through `construct_input_messages()`, which expects `ChatCompletionMessageParam` mappings and calls `.get("role")`. It therefore fails with:

```text
AttributeError: 'ResponseReasoningItem' object has no attribute 'get'
```

Copying the list at the storage boundary prevents later `append`/`extend` operations from changing the stored input history. A shallow copy is sufficient because the mutation is to list membership, and avoids copying the full contents of long conversations.

## Validation

- Added a unit regression test that stores input messages, appends a `ResponseReasoningItem` to the context-owned list, and verifies the stored history remains unchanged.
- `python -m py_compile` passes for both changed files.
- The equivalent fix was deployed against vLLM `0.27.2rc1.dev91+g1f7427bc0` with a Qwen reasoning parser. Before the fix, the first Responses request returned 200 and the second `previous_response_id` request returned 500. After the fix, a three-turn chain returned 200/200/200 with both reasoning and message items, and a streamed continuation returned 200.

The full pytest file could not be run in the local checkout because its test environment dependencies are not installed (`tblib` is the first missing dependency).
