### PR TITLE
[Bugfix] Fix Mooncake heterogeneous TP with replicated GQA heads

### DIFF
--- a/tests/v1/kv_connector/unit/test_mooncake_connector.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_connector.py
@@ -26,6 +26,8 @@ from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.mooncake_connector im
     SendBlockMeta,
     TransferRegion,
     _align_transfer_regions,
+    _compute_sender_transfer_plan,
+    _validate_asymmetric_region_lengths,
     get_mooncake_bootstrap_addr,
     should_launch_bootstrap_server,
 )
@@ -42,6 +44,81 @@ from vllm.v1.kv_cache_interface import (
 from vllm.v1.request import RequestStatus
 
 from .utils import create_request, create_scheduler, create_vllm_config
+
+
+@pytest.mark.parametrize(
+    ("remote_tp_size", "expected_dst_offsets"),
+    [
+        (1, [0, None, 65536, None, 131072, None, 196608, None]),
+        (2, [0, None, 65536, None, 0, None, 65536, None]),
+    ],
+)
+@pytest.mark.parametrize("local_tp_rank", range(8))
+def test_sender_plan_replicated_gqa_tp8_to_smaller_tp(
+    remote_tp_size,
+    expected_dst_offsets,
+    local_tp_rank,
+):
+    expected_dst_offset = expected_dst_offsets[local_tp_rank]
+    plan = _compute_sender_transfer_plan(
+        local_tp_rank=local_tp_rank,
+        local_tp_size=8,
+        remote_tp_rank=local_tp_rank // (8 // remote_tp_size),
+        remote_tp_size=remote_tp_size,
+        local_kv_block_len=65536,
+        remote_kv_block_len=262144 // remote_tp_size,
+        producer_cache_replicated=True,
+        total_num_kv_heads=4,
+    )
+    if expected_dst_offset is None:
+        assert not plan[0]
+    else:
+        assert plan == (True, 0, expected_dst_offset, 65536)
+
+
+@pytest.mark.parametrize(
+    ("local_tp_size", "expected_src_offsets"),
+    [
+        (1, [0, 0, 65536, 65536, 131072, 131072, 196608, 196608]),
+        (2, [0, 0, 65536, 65536, 0, 0, 65536, 65536]),
+        (4, [0] * 8),
+    ],
+)
+@pytest.mark.parametrize("remote_tp_rank", range(8))
+def test_sender_plan_gqa_to_replicated_tp8(
+    local_tp_size,
+    expected_src_offsets,
+    remote_tp_rank,
+):
+    local_head_count = 4 // local_tp_size
+    plan = _compute_sender_transfer_plan(
+        local_tp_rank=remote_tp_rank // (8 // local_tp_size),
+        local_tp_size=local_tp_size,
+        remote_tp_rank=remote_tp_rank,
+        remote_tp_size=8,
+        local_kv_block_len=local_head_count * 65536,
+        remote_kv_block_len=65536,
+        producer_cache_replicated=False,
+        total_num_kv_heads=4,
+    )
+    assert plan == (True, expected_src_offsets[remote_tp_rank], 0, 65536)
+
+
+def test_region_length_validation_allows_replicated_consumer():
+    local_region = TransferRegion("layer", 0, 0, 262144, 262144)
+    remote_region = TransferRegion("layer", 0, 0, 65536, 65536)
+
+    assert (
+        _validate_asymmetric_region_lengths(
+            local_regions=[local_region],
+            remote_regions=[remote_region],
+            local_tp_size=1,
+            remote_tp_size=8,
+            producer_cache_replicated=False,
+            consumer_cache_replicated=True,
+        )
+        is None
+    )
 
 
 def _make_test_kv_cache_config() -> KVCacheConfig:
@@ -150,9 +227,13 @@ async def test_build_transfer_params_separates_prefill_pp_layers():
     worker.is_kv_producer = True
     worker.tp_rank = 0
     worker.tp_size = 1
+    worker.use_mla = False
     worker.kv_cache_config = _make_test_kv_cache_config()
     worker._physical_blocks_per_logical_kv_block = 1
-    worker.transfer_topo = SimpleNamespace(local_replicates_kv_cache=False)
+    worker.transfer_topo = SimpleNamespace(
+        local_replicates_kv_cache=False,
+        total_num_kv_heads=4,
+    )
 
     block_len = 256
     remote_regions = [

--- a/tests/v1/kv_connector/unit/test_mooncake_connector.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_connector.py
@@ -104,21 +104,33 @@ def test_sender_plan_gqa_to_replicated_tp8(
     assert plan == (True, expected_src_offsets[remote_tp_rank], 0, 65536)
 
 
-def test_region_length_validation_allows_replicated_consumer():
-    local_region = TransferRegion("layer", 0, 0, 262144, 262144)
-    remote_region = TransferRegion("layer", 0, 0, 65536, 65536)
+@pytest.mark.parametrize(
+    "local_tp,remote_tp,local_len,remote_len,valid",
+    [
+        (1, 8, 262144, 65536, True),
+        (8, 1, 65536, 262144, True),
+        (1, 8, 262144, 131072, False),
+        (8, 1, 131072, 262144, False),
+    ],
+)
+def test_region_length_validation_checks_replicated_gqa_heads(
+    local_tp, remote_tp, local_len, remote_len, valid
+):
+    """Replicated heads must have matching, whole per-head payloads."""
+    local_region = TransferRegion("layer", 0, 0, local_len, local_len)
+    remote_region = TransferRegion("layer", 0, 0, remote_len, remote_len)
 
     assert (
         _validate_asymmetric_region_lengths(
             local_regions=[local_region],
             remote_regions=[remote_region],
-            local_tp_size=1,
-            remote_tp_size=8,
-            producer_cache_replicated=False,
-            consumer_cache_replicated=True,
+            local_tp_size=local_tp,
+            remote_tp_size=remote_tp,
+            producer_cache_replicated=local_tp > 4,
+            total_num_kv_heads=4,
         )
         is None
-    )
+    ) == valid
 
 
 def _make_test_kv_cache_config() -> KVCacheConfig:

--- a/tests/v1/kv_connector/unit/test_mooncake_connector_hybrid_mamba.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_connector_hybrid_mamba.py
@@ -547,6 +547,28 @@ def test_hybrid_gdn_transfer_params_preserve_group_identity(monkeypatch):
         connector.connector_worker = None
 
 
+def test_hybrid_gdn_transfer_plan_preserves_legacy_tp_slicing():
+    worker = object.__new__(MooncakeConnectorWorker)
+    worker.shutdown = noop_shutdown
+    worker.tp_rank = 0
+    worker.tp_size = 2
+    worker.use_mla = False
+    worker.transfer_topo = SimpleNamespace(
+        local_replicates_kv_cache=False,
+        total_num_kv_heads=2,
+    )
+
+    plan = worker._get_sender_transfer_plan(
+        local_kv_block_len=2000,
+        remote_kv_block_len=1000,
+        remote_tp_rank=1,
+        remote_tp_size=4,
+        is_mamba_group=True,
+    )
+
+    assert plan == (True, 1000, 0, 1000)
+
+
 def test_logical_to_kernel_block_ids_expands_fa_not_gdn():
     worker = object.__new__(MooncakeConnectorWorker)
     worker.shutdown = noop_shutdown

--- a/tests/v1/kv_connector/unit/test_mooncake_connector_hybrid_mamba.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_connector_hybrid_mamba.py
@@ -547,28 +547,6 @@ def test_hybrid_gdn_transfer_params_preserve_group_identity(monkeypatch):
         connector.connector_worker = None
 
 
-def test_hybrid_gdn_transfer_plan_preserves_legacy_tp_slicing():
-    worker = object.__new__(MooncakeConnectorWorker)
-    worker.shutdown = noop_shutdown
-    worker.tp_rank = 0
-    worker.tp_size = 2
-    worker.use_mla = False
-    worker.transfer_topo = SimpleNamespace(
-        local_replicates_kv_cache=False,
-        total_num_kv_heads=2,
-    )
-
-    plan = worker._get_sender_transfer_plan(
-        local_kv_block_len=2000,
-        remote_kv_block_len=1000,
-        remote_tp_rank=1,
-        remote_tp_size=4,
-        is_mamba_group=True,
-    )
-
-    assert plan == (True, 1000, 0, 1000)
-
-
 def test_logical_to_kernel_block_ids_expands_fa_not_gdn():
     worker = object.__new__(MooncakeConnectorWorker)
     worker.shutdown = noop_shutdown

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py
@@ -1554,6 +1554,10 @@ class MooncakeConnectorWorker:
                     remote_kv_block_len=remote_region.kv_block_len,
                     remote_tp_rank=agent_meta.remote_tp_rank,
                     remote_tp_size=agent_meta.remote_tp_size,
+                    is_mamba_group=isinstance(
+                        group_specs[group_index].kv_cache_spec,
+                        MambaSpec,
+                    ),
                 )
                 if not should_transfer:
                     # Replicated KV cache: only one producer rank in the TP group
@@ -2087,6 +2091,7 @@ class MooncakeConnectorWorker:
         remote_kv_block_len: int,
         remote_tp_rank: int,
         remote_tp_size: int,
+        is_mamba_group: bool = False,
     ) -> tuple[bool, int, int, int]:
         return _compute_sender_transfer_plan(
             local_tp_rank=self.tp_rank,
@@ -2097,7 +2102,9 @@ class MooncakeConnectorWorker:
             remote_kv_block_len=remote_kv_block_len,
             producer_cache_replicated=self._producer_cache_is_replicated(),
             total_num_kv_heads=(
-                None if self.use_mla else self.transfer_topo.total_num_kv_heads
+                None
+                if self.use_mla or is_mamba_group
+                else self.transfer_topo.total_num_kv_heads
             ),
         )
 

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py
@@ -182,12 +182,30 @@ def _compute_sender_transfer_plan(
     local_kv_block_len: int,
     remote_kv_block_len: int,
     producer_cache_replicated: bool,
+    total_num_kv_heads: int | None = None,
 ) -> tuple[bool, int, int, int]:
     """Plan one producer-rank to one consumer-rank copy for heterogeneous TP."""
     tp_ratio = _get_tp_ratio(local_tp_size, remote_tp_size)
 
     if tp_ratio == 1:
         return True, 0, 0, local_kv_block_len
+
+    if total_num_kv_heads is not None:
+        consumer_cache_replicated = remote_tp_size > total_num_kv_heads
+        if producer_cache_replicated != consumer_cache_replicated:
+            local_head_count = max(total_num_kv_heads // local_tp_size, 1)
+            local_replica_count = max(local_tp_size // total_num_kv_heads, 1)
+
+            local_head = local_tp_rank * total_num_kv_heads // local_tp_size
+            remote_head = remote_tp_rank * total_num_kv_heads // remote_tp_size
+            head_size = local_kv_block_len // local_head_count
+
+            return (
+                local_tp_rank % local_replica_count == 0,
+                max(remote_head - local_head, 0) * head_size,
+                max(local_head - remote_head, 0) * head_size,
+                head_size,
+            )
 
     if tp_ratio > 0:
         if producer_cache_replicated:
@@ -233,6 +251,7 @@ def _validate_asymmetric_region_lengths(
     local_tp_size: int,
     remote_tp_size: int,
     producer_cache_replicated: bool,
+    consumer_cache_replicated: bool,
 ) -> str | None:
     """Validate transfer-region metadata for a fixed producer/consumer pair.
 
@@ -246,7 +265,7 @@ def _validate_asymmetric_region_lengths(
             "producer and consumer."
         )
 
-    if producer_cache_replicated:
+    if producer_cache_replicated or consumer_cache_replicated:
         return None
 
     tp_ratio = _get_tp_ratio(local_tp_size, remote_tp_size)
@@ -1224,6 +1243,10 @@ class MooncakeConnectorWorker:
             local_tp_size=self.tp_size,
             remote_tp_size=meta.remote_tp_size,
             producer_cache_replicated=self._producer_cache_is_replicated(),
+            consumer_cache_replicated=(
+                self.use_mla
+                or meta.remote_tp_size > self.transfer_topo.total_num_kv_heads
+            ),
         )
         if validation_err is not None:
             response = MooncakeXferResponse(
@@ -2073,6 +2096,9 @@ class MooncakeConnectorWorker:
             local_kv_block_len=local_kv_block_len,
             remote_kv_block_len=remote_kv_block_len,
             producer_cache_replicated=self._producer_cache_is_replicated(),
+            total_num_kv_heads=(
+                None if self.use_mla else self.transfer_topo.total_num_kv_heads
+            ),
         )
 
     def _log_debug_cache_registration(

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py
@@ -251,7 +251,7 @@ def _validate_asymmetric_region_lengths(
     local_tp_size: int,
     remote_tp_size: int,
     producer_cache_replicated: bool,
-    consumer_cache_replicated: bool,
+    total_num_kv_heads: int | None = None,
 ) -> str | None:
     """Validate transfer-region metadata for a fixed producer/consumer pair.
 
@@ -265,7 +265,11 @@ def _validate_asymmetric_region_lengths(
             "producer and consumer."
         )
 
-    if producer_cache_replicated or consumer_cache_replicated:
+    if total_num_kv_heads is not None:
+        # TP ranks beyond the KV-head count replicate existing shards.
+        local_tp_size = min(local_tp_size, total_num_kv_heads)
+        remote_tp_size = min(remote_tp_size, total_num_kv_heads)
+    elif producer_cache_replicated:
         return None
 
     tp_ratio = _get_tp_ratio(local_tp_size, remote_tp_size)
@@ -1243,9 +1247,10 @@ class MooncakeConnectorWorker:
             local_tp_size=self.tp_size,
             remote_tp_size=meta.remote_tp_size,
             producer_cache_replicated=self._producer_cache_is_replicated(),
-            consumer_cache_replicated=(
-                self.use_mla
-                or meta.remote_tp_size > self.transfer_topo.total_num_kv_heads
+            total_num_kv_heads=(
+                None
+                if self.use_mla or self.kv_cache_config.has_mamba_layers
+                else self.transfer_topo.total_num_kv_heads
             ),
         )
         if validation_err is not None:
@@ -1554,10 +1559,6 @@ class MooncakeConnectorWorker:
                     remote_kv_block_len=remote_region.kv_block_len,
                     remote_tp_rank=agent_meta.remote_tp_rank,
                     remote_tp_size=agent_meta.remote_tp_size,
-                    is_mamba_group=isinstance(
-                        group_specs[group_index].kv_cache_spec,
-                        MambaSpec,
-                    ),
                 )
                 if not should_transfer:
                     # Replicated KV cache: only one producer rank in the TP group
@@ -2091,7 +2092,6 @@ class MooncakeConnectorWorker:
         remote_kv_block_len: int,
         remote_tp_rank: int,
         remote_tp_size: int,
-        is_mamba_group: bool = False,
     ) -> tuple[bool, int, int, int]:
         return _compute_sender_transfer_plan(
             local_tp_rank=self.tp_rank,
@@ -2103,7 +2103,7 @@ class MooncakeConnectorWorker:
             producer_cache_replicated=self._producer_cache_is_replicated(),
             total_num_kv_heads=(
                 None
-                if self.use_mla or is_mamba_group
+                if self.use_mla or self.kv_cache_config.has_mamba_layers
                 else self.transfer_topo.total_num_kv_heads
             ),
         )

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py
@@ -1241,7 +1241,9 @@ class MooncakeConnectorWorker:
             )
             await sock.send_multipart((identity, self._encoder.encode(response)))
             return
-        validation_err = _validate_asymmetric_region_lengths(
+        validation_err = self._validate_head_resharding_layout(
+            meta.remote_tp_size, local_regions
+        ) or _validate_asymmetric_region_lengths(
             local_regions=local_regions,
             remote_regions=remote_regions,
             local_tp_size=self.tp_size,
@@ -2062,6 +2064,31 @@ class MooncakeConnectorWorker:
 
     def _producer_cache_is_replicated(self) -> bool:
         return self.transfer_topo.local_replicates_kv_cache
+
+    def _validate_head_resharding_layout(
+        self, remote_tp_size: int, local_regions: list[TransferRegion]
+    ) -> str | None:
+        """Reject unsupported layouts before splitting or gathering KV heads."""
+        if self.use_mla or self.kv_cache_config.has_mamba_layers:
+            return None
+        num_kv_heads = self.transfer_topo.total_num_kv_heads
+        if min(self.tp_size, num_kv_heads) == min(remote_tp_size, num_kv_heads):
+            return None
+
+        for region in local_regions:
+            spec = self._layer_specs[region.layer_name]
+            if not isinstance(spec, AttentionSpec):
+                continue
+            if spec.page_size_bytes > spec.unpadded_page_size_bytes:
+                return (
+                    "Mooncake KV-head re-sharding is not supported for padded "
+                    f"KV pages (layer {region.layer_name})."
+                )
+            if spec.kv_quant_mode.is_nvfp4:
+                return (
+                    "Mooncake KV-head re-sharding is not supported for NVFP4 KV cache."
+                )
+        return None
 
     def _get_transfer_regions(
         self,

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py
@@ -198,13 +198,13 @@ def _compute_sender_transfer_plan(
 
             local_head = local_tp_rank * total_num_kv_heads // local_tp_size
             remote_head = remote_tp_rank * total_num_kv_heads // remote_tp_size
-            head_size = local_kv_block_len // local_head_count
+            bytes_per_head = local_kv_block_len // local_head_count
 
             return (
                 local_tp_rank % local_replica_count == 0,
-                max(remote_head - local_head, 0) * head_size,
-                max(local_head - remote_head, 0) * head_size,
-                head_size,
+                max(remote_head - local_head, 0) * bytes_per_head,
+                max(local_head - remote_head, 0) * bytes_per_head,
+                bytes_per_head,
             )
 
     if tp_ratio > 0:


### PR DESCRIPTION
## Purpose

Fix Mooncake heterogeneous-TP KV transfer when a standard GQA layout crosses the KV-head replication boundary. This includes both:

- Prefill TP > `num_kv_heads` >= Decode TP, where producer ranks contain replicated head slices that must be gathered into the Decode KV block;
- Prefill TP <= `num_kv_heads` < Decode TP, where unique Prefill head slices must be fanned out to replicated Decode ranks.

The heterogeneous-TP planner previously treated `producer_cache_replicated=True` as if every producer rank held a full copy of the KV block. That is not true when `num_kv_heads < producer_tp_size`: each unique KV head is replicated, but a rank still owns only one head-sized slice. The reverse direction also used TP-ratio offsets after the consumer crossed into head replication, which selected the wrong source slice and failed the pre-transfer region-length validation.

For example, with four KV heads, TP8 Prefill, and TP1 Decode:

- each Prefill rank has one 65,536-byte head slice, replicated twice;
- Decode expects a 262,144-byte block containing all four heads;
- the old planner selects only rank 0 and writes offset 0;
- the remaining 196,608 bytes are not transferred, but Decode still marks the request KV-ready because Mooncake reports the selected copy as successful.

We originally observed this with a custom-quantized MiniMax M3 deployment, but reproduced it on official vLLM v0.27.1 with the upstream-supported Qwen3-235B-A22B-FP8 model. The issue is therefore in the generic Mooncake
heterogeneous-TP planner, not the custom model or quantization.

This change:

- detects when producer and consumer cache replication states differ;
- maps each paired producer/consumer rank through its global KV-head index;
- selects one canonical producer for each replicated producer head;
- applies the corresponding source or destination head offset in both transfer directions;
- avoids applying pure TP-ratio region-length validation when either side is replicated;
- leaves MLA and TP relationships with matching replication states on the
  existing planner path.

### Duplicate-work check

I searched open PRs for `Mooncake heterogeneous TP GQA`, `Mooncake replicated KV heads`, and `Mooncake tensor parallel`. No other PR addresses this defect. The closest open work covers PP/PCP metadata (#46004 and #49109) or RDMA device discovery (#44919), not replicated GQA-head transfer across heterogeneous TP.

#53078 fixes heterogeneous-TP state transfer for hybrid Mamba/GDN models, while this PR fixes replicated-GQA head mapping across heterogeneous TP configurations. If #53078 lands first, I would consider stacking/rebasing this PR on top of it and reconciling the two paths there.

## Test Plan

Focused unit tests:

```bash
VLLM_TARGET_DEVICE=cpu PYTHONPATH=. .venv/bin/python -m pytest -q \
  tests/v1/kv_connector/unit/test_mooncake_connector.py \
  --confcutdir=tests/v1/kv_connector/unit \
  -k 'sender_plan or region_length_validation'
```

Lint and static checks:

```bash
pre-commit run --files \
  vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py \
  tests/v1/kv_connector/unit/test_mooncake_connector.py
```

End-to-end fan-in reproduction:

- official vLLM v0.27.1 code and image;
- Qwen3-235B-A22B-FP8 with four KV heads;
- TP8 Prefill to DP8/TP1 Decode through Mooncake RDMA;
- deterministic one-token request through the PD router.

## Test Result

- Focused sender-plan and region-validation tests: `41 passed, 30 deselected`.
- All selected pre-commit hooks passed, including ruff, format, mypy, SPDX, forbidden-import, and lazy-import checks.
- A local reference-mapping check validated all 125 combinations where Prefill TP, Decode TP, and KV-head count were selected from `{1, 2, 4, 8, 16}` under the existing divisibility constraints.

### Qwen3-235B-A22B-FP8 reproduction

Without the fix, Decode receives only one of the four unique KV-head slices. The other three destination regions remain unwritten, but Decode treats the block as complete and uses it for attention. The request does not fail at the
API or transport layer, so the resulting token corruption is silent.

The pre-fix transfer log for the first attention layer shows that rank 0 is the only sender:

```text
rank=0 should_transfer=true  dst_offset=0      transfer_len=65536
rank=2 should_transfer=false dst_offset=0      transfer_len=65536
rank=4 should_transfer=false dst_offset=0      transfer_len=65536
rank=6 should_transfer=false dst_offset=0      transfer_len=65536
```

Decode then marks the request ready without reporting an error:

```text
pull_tasks_count=0 response_status=0
KV Transfer metrics: Num successful transfers=1, Num failed transfers=0, Num failed recvs=0
```

This means only 65,536 of the expected 262,144 bytes are written, for 25% destination coverage. In the deterministic one-token smoke test, the API still returned HTTP 200, but Qwen3 produced a newline as its first token:

```json
{"content":"\n","finish_reason":"length"}
```

After the fix, one canonical replica for each unique KV head contributes its slice:

```text
rank=0 should_transfer=true dst_offset=0      transfer_len=65536
rank=2 should_transfer=true dst_offset=65536  transfer_len=65536
rank=4 should_transfer=true dst_offset=131072 transfer_len=65536
rank=6 should_transfer=true dst_offset=196608 transfer_len=65536
```

The four writes cover the full 262,144-byte destination block. Mooncake reports four successful transfers with no failures:

```text
KV Transfer metrics: Num successful transfers=4, Num failed transfers=0, Num failed recvs=0
```

The same deterministic request returned HTTP 200 and produced Qwen3's
`<think>` token:

```json
{"content":"<think>","finish_reason":"length"}
```

The one-token result is a smoke test rather than an accuracy benchmark. Its purpose is to show that the incomplete KV block affected Qwen3 decoding even though the request appeared successful. The reverse fan-out direction is
covered by the focused unit tests; it has not been rerun in a multi-node Mooncake deployment.

The equivalent mapping fix was also evaluated in the original custom-quantized MiniMax M3 deployment:

- GSM8K 0-shot: 1274 / 1319 (96.59%).
- AIME25 repeat-4: 97 / 120 (80.83%).
- GPQA Diamond: 177 / 198 (89.39%).

Before the mapping fix, a focused GSM8K run produced 0 / 8 correct responses and all eight generations hit the 65,536-token limit. After the fix, the systematic corruption and truncation behavior disappeared. The Qwen3
reproduction above independently verifies that the underlying bug and fix are not MiniMax-specific.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR is described.
- [x] The test plan and commands are included.
- [x] Unit and end-to-end results are included.
- [x] No documentation update is required; behavior is corrected without a
  user-facing configuration change.
</details>
