### PR TITLE
[Bugfix] Skip XCCL warmup for single-device XPU

### DIFF
--- a/tests/v1/worker/test_xpu_worker.py
+++ b/tests/v1/worker/test_xpu_worker.py
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from unittest import mock
+
+from vllm.v1.worker.xpu_worker import _should_warm_up_xccl
+
+
+def test_single_device_skips_xccl_probe():
+    with mock.patch(
+        "vllm.v1.worker.xpu_worker.torch.distributed.is_xccl_available"
+    ) as is_xccl_available:
+        assert not _should_warm_up_xccl(1)
+
+    is_xccl_available.assert_not_called()
+
+
+def test_multi_device_warms_up_when_xccl_is_available():
+    with mock.patch(
+        "vllm.v1.worker.xpu_worker.torch.distributed.is_xccl_available",
+        return_value=True,
+    ) as is_xccl_available:
+        assert _should_warm_up_xccl(2)
+
+    is_xccl_available.assert_called_once_with()
+
+
+def test_multi_device_skips_warmup_when_xccl_is_unavailable():
+    with mock.patch(
+        "vllm.v1.worker.xpu_worker.torch.distributed.is_xccl_available",
+        return_value=False,
+    ) as is_xccl_available:
+        assert not _should_warm_up_xccl(2)
+
+    is_xccl_available.assert_called_once_with()

--- a/vllm/v1/worker/xpu_worker.py
+++ b/vllm/v1/worker/xpu_worker.py
@@ -21,6 +21,10 @@ from .utils import request_memory
 logger = init_logger(__name__)
 
 
+def _should_warm_up_xccl(world_size: int) -> bool:
+    return world_size > 1 and torch.distributed.is_xccl_available()
+
+
 class XPUWorker(Worker):
     """A XPU worker class."""
 
@@ -101,7 +105,7 @@ class XPUWorker(Worker):
         )
 
         # global all_reduce needed for overall oneccl warm up
-        if torch.distributed.is_xccl_available():
+        if _should_warm_up_xccl(self.parallel_config.world_size):
             torch.distributed.all_reduce(torch.zeros(1).xpu())
 
         if self.use_v2_model_runner:


### PR DESCRIPTION
Fixes #52386.

`XPUWorker.init_device()` currently performs a global XCCL `all_reduce` warm-up whenever XCCL is available, including when `world_size == 1`. A single-device deployment never needs a collective during inference, so this unnecessary warm-up can prevent the engine from starting on virtualized or restricted XPU environments where oneCCL cannot initialize its topology.

This change skips the XCCL warm-up for single-device runs while preserving the existing warm-up behavior for multi-device XPU deployments.

Regression coverage verifies that:
- `world_size == 1` short-circuits without even querying XCCL availability;
- multi-device runs warm up when XCCL is available;
- multi-device runs skip warm-up when XCCL is unavailable.

The change is limited to XPU worker initialization and does not alter distributed initialization itself.