### PR TITLE
[Kernel] Add fused situ_and_mul_quant kernel (SITU activation + block-FP8 quant)

### DIFF
--- a/csrc/libtorch_stable/activation_kernels.cu
+++ b/csrc/libtorch_stable/activation_kernels.cu
@@ -1,9 +1,17 @@
 #include <cuda.h>
+#include <cuda_runtime.h>
 #include <torch/csrc/stable/tensor.h>
+#include <torch/headeronly/util/Float8_e4m3fn.h>
+
+#ifndef USE_ROCM
+  #include <cuda_fp8.h>
+#endif
 
 #include <cmath>
+#include <type_traits>
 
 #include "../cuda_compat.h"
+#include "async_util.cuh"
 #include "cuda_vec_utils.cuh"
 #include "dispatch_utils.h"
 #include "torch_utils.h"
@@ -474,12 +482,44 @@ __global__ void swigluoai_and_mul_kernel(
 // Compute is done in fp32 and written straight to `out` -- no intermediate
 // tensors and no full-tensor fp32 upcast (the pure-torch forward_native
 // allocated ~8 fp32 temporaries per call, which blows up MoE profiling).
+// Single shared implementation of the SITU math, called from every kernel
+// below. __forceinline__ since it runs inside #pragma-unrolled per-element
+// loops, where an out-of-line call would spike register pressure for no gain.
+//
+// tanh via the sm_75+ hardware tanh.approx.f32 (single MUFU). Both tanhf and
+// libdevice __tanhf compile to an out-of-line range-reduction CALL, which drags
+// in a stack frame and ABI register spills; the PTX intrinsic has no slow path.
+__device__ __forceinline__ float tanh_approx(float x) {
+  float r;
+  asm("tanh.approx.f32 %0, %1;" : "=f"(r) : "f"(x));
+  return r;
+}
+
+// Kimi-K3 SITU activation params (config.json text_config). The pipelined
+// kernel bakes these so its reciprocals and up-clamp fold at compile time; the
+// host launch falls back to the runtime scalar kernel if a model differs.
+static constexpr float SITU_BETA = 4.0f;
+static constexpr float SITU_LINEAR_BETA = 25.0f;
+__device__ __forceinline__ float situ_activation(float g, float u, float beta,
+                                                 float linear_beta,
+                                                 bool clamp_up, float inv_beta,
+                                                 float inv_linear_beta) {
+  // __fdividef: fast MUFU.RCP + FMUL, no FCHK range-check / slow-path branch.
+  const float gate_out =
+      __fdividef(beta * tanh_approx(g * inv_beta), 1.0f + __expf(-g));
+  const float up_out =
+      clamp_up ? linear_beta * tanh_approx(u * inv_linear_beta) : u;
+  return gate_out * up_out;
+}
+
 template <typename scalar_t>
 __global__ void situ_and_mul_kernel(
     scalar_t* __restrict__ out,          // [..., d]
     const scalar_t* __restrict__ input,  // [..., 2, d]
-    const int d, const float beta, const float linear_beta) {
+    const int d, const float beta, const float linear_beta,
+    const int64_t* __restrict__ valid_rows_ptr) {
   const int64_t row = blockIdx.x;
+  if (valid_rows_ptr != nullptr && row >= *valid_rows_ptr) return;
   const scalar_t* gate_ptr = input + row * 2 * d;
   const scalar_t* up_ptr = gate_ptr + d;
   scalar_t* out_ptr = out + row * d;
@@ -489,10 +529,310 @@ __global__ void situ_and_mul_kernel(
   for (int64_t idx = threadIdx.x; idx < d; idx += blockDim.x) {
     const float g = (float)VLLM_LDG(&gate_ptr[idx]);
     const float u = (float)VLLM_LDG(&up_ptr[idx]);
-    const float gate_out = beta * tanhf(g * inv_beta) / (1.0f + expf(-g));
-    const float up_out =
-        clamp_up ? linear_beta * tanhf(u * inv_linear_beta) : u;
-    out_ptr[idx] = (scalar_t)(gate_out * up_out);
+    out_ptr[idx] = (scalar_t)situ_activation(g, u, beta, linear_beta, clamp_up,
+                                             inv_beta, inv_linear_beta);
+  }
+}
+
+// Saturating float -> fp8 conversion. `inv_scale = 1 / scale`, so this computes
+// clamp(val / scale) and casts (round-to-nearest-even) to fp8. `fp8_max` is the
+// representable max for the target fp8 type (448 for e4m3fn), passed from the
+// host to avoid device-side numeric_limits.
+// c10::Float8_e4m3fn's `static_cast` operator is a software/bit-manipulation
+// implementation of float->fp8 rounding; it does NOT necessarily round ties
+// the same way as the hardware cvt instruction (`__nv_cvt_float_to_fp8`,
+// PTX `cvt.rn.satfinite.e4m3.f32`) that scaled_fp8_conversion (see
+// quantization/w8a8/fp8/common.cuh + nvidia/quant_utils.cuh) uses on SM80+,
+// and that Triton's `.to(tl.float8e4nv)` also lowers to -- humming's
+// quant_input is a Triton kernel. Using `static_cast` here instead of the
+// hardware instruction was the root cause of a ~0.1-0.2%-of-elements
+// quantization mismatch against humming's output: on exact or near-exact
+// ties between two representable fp8 values, the two implementations
+// occasionally round to different buckets.
+__device__ __forceinline__ c10::Float8_e4m3fn cvt_fp8_hw(float x) {
+#if !defined(USE_ROCM) && defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 800
+  return c10::Float8_e4m3fn(__nv_cvt_float_to_fp8(x, __NV_SATFINITE, __NV_E4M3),
+                            c10::Float8_e4m3fn::from_bits());
+#else
+  return static_cast<c10::Float8_e4m3fn>(x);
+#endif
+}
+
+template <typename fp8_type>
+__device__ __forceinline__ fp8_type quant_to_fp8(float val, float inv_scale,
+                                                 float fp8_max) {
+  float x = val * inv_scale;
+  x = fmaxf(-fp8_max, fminf(x, fp8_max));
+  if constexpr (std::is_same_v<fp8_type, c10::Float8_e4m3fn>) {
+    return cvt_fp8_hw(x);
+  } else {
+    return static_cast<fp8_type>(x);
+  }
+}
+
+__device__ __forceinline__ float warp_reduce_max(float v) {
+#pragma unroll
+  for (int offset = 16; offset > 0; offset >>= 1) {
+    v = fmaxf(v, __shfl_xor_sync(0xffffffffu, v, offset));
+  }
+  return v;
+}
+
+// Fused SITU + block-FP8 (per-128-group) quant, one warp per group. Persistent
+// grid: each block strides over valid rows only, so padding rows past
+// *valid_rows are never touched. cp.async stages gate+up into smem per group.
+template <typename scalar_t, typename fp8_type, int THREADS, int NUM_STAGES,
+          int GROUP_SIZE, int GRID_DIM, int D>
+__global__ void situ_and_mul_quant_group_pipelined_kernel(
+    fp8_type* __restrict__ out,          // [num_tokens, D]
+    float* __restrict__ scale_out,       // [num_tokens, NUM_GROUPS]
+    const scalar_t* __restrict__ input,  // [num_tokens, 2, D]
+    const int64_t num_rows, const int64_t* __restrict__ valid_rows_ptr) {
+  const int tid = threadIdx.x;
+  const int warp_id = tid / WARP_SIZE;
+  const int lane_id = tid % WARP_SIZE;
+  static constexpr int NUM_WARPS = THREADS / WARP_SIZE;
+  static constexpr int NUM_GROUPS = D / GROUP_SIZE;
+  const int64_t row_bound =
+      valid_rows_ptr != nullptr ? *valid_rows_ptr : num_rows;
+
+  // Padding rows past *valid_rows are never streamed below; fill their scales
+  // with 1.0 so masked-out rows don't feed NaN/Inf into the w2 GEMM. NUM_GROUPS
+  // is a multiple of 4, so the run is float4-aligned and exact (scale_out is a
+  // tensor base, >=16B aligned).
+  static_assert(NUM_GROUPS % 4 == 0,
+                "float4 scale fill needs NUM_GROUPS % 4 == 0");
+  static constexpr int NG4 = NUM_GROUPS / 4;
+  const int64_t pad_start4 = row_bound * NG4;
+  const int64_t pad_end4 = num_rows * NG4;
+  float4* scale4 = reinterpret_cast<float4*>(scale_out);
+  constexpr float4 ones{1.0f, 1.0f, 1.0f, 1.0f};
+  for (int64_t i = pad_start4 + (int64_t)blockIdx.x * THREADS + tid;
+       i < pad_end4; i += (int64_t)GRID_DIM * THREADS) {
+    scale4[i] = ones;
+  }
+
+  // Vectorized loads/stores assume a 2-byte scalar_t; the fp32 dispatch branch
+  // is compiled out here and served by the scalar group kernel instead.
+  if constexpr (sizeof(scalar_t) == 2) {
+    static constexpr int LD_ELTS = 16 / sizeof(scalar_t);         // 8 (load)
+    static constexpr int ELTS_PER_LANE = GROUP_SIZE / WARP_SIZE;  // 4 (compute)
+    static constexpr int STAGE_ELTS = 2 * GROUP_SIZE;  // gate+up per stage/warp
+
+    extern __shared__ __align__(16) unsigned char smem_raw[];
+    scalar_t* warp_smem = reinterpret_cast<scalar_t*>(smem_raw) +
+                          (size_t)warp_id * NUM_STAGES * STAGE_ELTS;
+
+    // beta/linear_beta are baked (Kimi-K3): every reciprocal and the up-clamp
+    // fold at compile time. The host gates this launch on the runtime values
+    // matching, else falls back to the scalar kernel.
+    static constexpr float beta = SITU_BETA;
+    static constexpr float linear_beta = SITU_LINEAR_BETA;
+    static constexpr bool clamp_up = linear_beta > 0.0f;
+    static constexpr float inv_beta = 1.0f / beta;
+    static constexpr float inv_linear_beta =
+        clamp_up ? 1.0f / linear_beta : 0.0f;
+    // fp8_max is fixed by the output type -> compile-time reciprocal, no RCP.
+    static constexpr float FP8_MAX =
+        std::is_same_v<fp8_type, c10::Float8_e4m3fn> ? 448.0f : 224.0f;
+    static constexpr float inv_fp8_max = 1.0f / FP8_MAX;
+
+    // Groups per warp. When NUM_GROUPS splits evenly across warps every warp
+    // does the same count, so this folds to a constant (no per-warp register,
+    // compile-time loop bound). D=SITU_D satisfies this.
+    static_assert(
+        NUM_GROUPS % NUM_WARPS == 0,
+        "constexpr num_iters requires groups evenly split across warps");
+    static constexpr int num_iters = NUM_GROUPS / NUM_WARPS;
+
+    // Per-lane load offsets, hoisted out of the loops: lanes 0..15 take the
+    // gate half, 16..31 the up half (+D), each a 16B cp.async. Only the base
+    // bumps.
+    const bool up_half = lane_id >= WARP_SIZE / 2;
+    const int lane_l = up_half ? lane_id - WARP_SIZE / 2 : lane_id;
+    const int lane_src_off = (up_half ? D : 0) + lane_l * LD_ELTS;
+    const int lane_dst_off = (up_half ? GROUP_SIZE : 0) + lane_l * LD_ELTS;
+    static constexpr int warp_stride = NUM_WARPS * GROUP_SIZE;
+
+    // Invariant per-lane source base; the row term folds into the running
+    // pointer so the loop bumps by a compile-time stride instead of
+    // recomputing row * 2 * D each iteration. All offsets fit int32 (stride
+    // GRID_DIM*2*D ~6.5M); the pointer stays 64-bit, so num_tokens is
+    // unbounded.
+    const scalar_t* src_ptr = input + warp_id * GROUP_SIZE + lane_src_off;
+    static constexpr int src_row_stride = GRID_DIM * 2 * D;
+    const scalar_t* row_src = src_ptr + blockIdx.x * 2 * D;
+
+    // Same reduction for the store bases (out uint32 view = 4 fp8/lane, and
+    // scale). Per-row strides fit int32 (out ~0.8M, scale ~25K); ptrs stay 64b.
+    uint32_t* out_ptr =
+        reinterpret_cast<uint32_t*>(out + warp_id * GROUP_SIZE) + lane_id;
+    static constexpr int out_row_stride = GRID_DIM * D / 4;
+    uint32_t* row_out = out_ptr + blockIdx.x * (D / 4);
+    float* scale_ptr = scale_out + warp_id;
+    static constexpr int scale_row_stride = GRID_DIM * NUM_GROUPS;
+    float* row_scale = scale_ptr + blockIdx.x * NUM_GROUPS;
+
+    // Persistent outer loop kept sequential (nounroll): it wraps the whole
+    // pipeline, and GRID_DIM is compile-time so the stride folds to a constant.
+#pragma unroll 1
+    for (int64_t row = blockIdx.x; row < row_bound; row += GRID_DIM,
+                 row_src += src_row_stride, row_out += out_row_stride,
+                 row_scale += scale_row_stride) {
+      // Per-lane source for this row; issue_load bumps `src` by warp_stride.
+      const scalar_t* src = row_src;
+
+      // Stage the next group into `slot` (rotating 0..NUM_STAGES-1). Called
+      // once per group in increasing order, so the bumping load pointer stays
+      // in step.
+      auto issue_load = [&](int it, int slot) {
+        if (it < num_iters) {
+          cuda_async::cp_async_shared_global_16_cg(
+              warp_smem + (size_t)slot * STAGE_ELTS + lane_dst_off, src);
+          src += warp_stride;
+        }
+        cuda_async::cp_async_commit_group();
+      };
+
+      int load_slot = 0;
+      auto bump = [](int s) { return s + 1 == NUM_STAGES ? 0 : s + 1; };
+#pragma unroll
+      for (int s = 0; s < NUM_STAGES - 1; s++) {
+        issue_load(s, load_slot);
+        load_slot = bump(load_slot);
+      }
+
+      // Compute/store bases for this row (bumped per group below).
+      uint32_t* out_st = row_out;
+      float* scale_st = row_scale;
+
+      int comp_slot = 0;
+      for (int it = 0; it < num_iters; it++) {
+        issue_load(it + NUM_STAGES - 1, load_slot);
+        load_slot = bump(load_slot);
+        cuda_async::cp_async_wait_group<NUM_STAGES - 1>();
+
+        const scalar_t* stage = warp_smem + (size_t)comp_slot * STAGE_ELTS;
+        comp_slot = bump(comp_slot);
+        // Lane L owns 4 contiguous group elements {4L..4L+3}: one 64-bit smem
+        // load (float2) each for gate and up, vs 4x 32-bit before. lane L ->
+        // word L is the conflict-free 64-bit pattern, and float2 is 8B-aligned
+        // (stage is 512B-aligned, up half at +256B).
+        static_assert(ELTS_PER_LANE == 4,
+                      "expects GROUP_SIZE == 4 * WARP_SIZE");
+        union V {
+          float2 f2;
+          scalar_t s[ELTS_PER_LANE];
+        };
+        const float2* gate2 = reinterpret_cast<const float2*>(stage);
+        const float2* up2 = reinterpret_cast<const float2*>(stage + GROUP_SIZE);
+        const V gv{gate2[lane_id]};
+        const V uv{up2[lane_id]};
+        const scalar_t* gs = gv.s;
+        const scalar_t* us = uv.s;
+
+        float acts[ELTS_PER_LANE];
+        float thread_max = 0.0f;
+#pragma unroll
+        for (int e = 0; e < ELTS_PER_LANE; e++) {
+          acts[e] = (float)(scalar_t)situ_activation(
+              (float)gs[e], (float)us[e], beta, linear_beta, clamp_up, inv_beta,
+              inv_linear_beta);
+          thread_max = fmaxf(thread_max, fabsf(acts[e]));
+        }
+        const float absmax = fmaxf(warp_reduce_max(thread_max), 1e-30f);
+        const float scale = absmax * inv_fp8_max;
+        if (lane_id == 0) *scale_st = scale;
+        scale_st += NUM_WARPS;
+        const float inv_scale = __fdividef(1.0f, scale);
+
+        // 4 contiguous fp8 outputs -> one 32-bit coalesced store: lanes 0..31
+        // write out[0..127] of the group as 128 contiguous bytes.
+        union O {
+          uint32_t u;
+          fp8_type f[ELTS_PER_LANE];
+        };
+        O o;
+#pragma unroll
+        for (int e = 0; e < ELTS_PER_LANE; e++) {
+          o.f[e] = quant_to_fp8<fp8_type>(acts[e], inv_scale, FP8_MAX);
+        }
+        out_st[0] = o.u;
+        out_st += NUM_WARPS * GROUP_SIZE / 4;
+      }
+      // Drain before reusing smem slots for the next row.
+      cuda_async::cp_async_wait_group<0>();
+    }
+  }
+}
+
+// Scalar fallback for the group path (odd d or the otherwise-unreachable fp32
+// dispatch branch). Persistent grid; each block strides over valid rows, and
+// within a row warp `w` owns groups w, w+num_warps, ... (GROUP_SIZE % 32 == 0).
+template <typename scalar_t, typename fp8_type, int GROUP_SIZE>
+__global__ void situ_and_mul_quant_group_scalar_kernel(
+    fp8_type* __restrict__ out,          // [num_tokens, d]
+    float* __restrict__ scale_out,       // [num_tokens, num_groups]
+    const scalar_t* __restrict__ input,  // [num_tokens, 2, d]
+    const int d, const int num_groups, const float beta,
+    const float linear_beta, const int64_t num_rows,
+    const int64_t* __restrict__ valid_rows_ptr) {
+  static constexpr int ELTS_PER_LANE = GROUP_SIZE / WARP_SIZE;
+  const int tid = threadIdx.x;
+  const int warp_id = tid / WARP_SIZE;
+  const int lane_id = tid % WARP_SIZE;
+  const int num_warps = blockDim.x / WARP_SIZE;
+  const int64_t row_bound =
+      valid_rows_ptr != nullptr ? *valid_rows_ptr : num_rows;
+
+  const bool clamp_up = linear_beta > 0.0f;
+  // __fdividef reciprocal: single MUFU.RCP, no IEEE-div FCHK/CALL slow path
+  // (~2 ulp, folds into the pending accuracy eval).
+  const float inv_beta = __fdividef(1.0f, beta);
+  const float inv_linear_beta = clamp_up ? __fdividef(1.0f, linear_beta) : 0.0f;
+  // fp8_max is fixed by the output type -> compile-time reciprocal, no RCP.
+  static constexpr float FP8_MAX =
+      std::is_same_v<fp8_type, c10::Float8_e4m3fn> ? 448.0f : 224.0f;
+  static constexpr float inv_fp8_max = 1.0f / FP8_MAX;
+
+  for (int64_t row = blockIdx.x; row < row_bound; row += gridDim.x) {
+    const scalar_t* gate_ptr = input + row * 2 * (int64_t)d;
+    const scalar_t* up_ptr = gate_ptr + d;
+    fp8_type* out_ptr = out + row * (int64_t)d;
+    float* scale_row = scale_out + row * (int64_t)num_groups;
+
+    for (int g = warp_id; g < num_groups; g += num_warps) {
+      const int base = g * GROUP_SIZE;
+      float acts[ELTS_PER_LANE];
+      float thread_max = 0.0f;
+#pragma unroll
+      for (int e = 0; e < ELTS_PER_LANE; e++) {
+        const int idx = base + e * WARP_SIZE + lane_id;
+        const float gv = (float)VLLM_LDG(&gate_ptr[idx]);
+        const float uv = (float)VLLM_LDG(&up_ptr[idx]);
+        acts[e] = (float)(scalar_t)situ_activation(
+            gv, uv, beta, linear_beta, clamp_up, inv_beta, inv_linear_beta);
+        thread_max = fmaxf(thread_max, fabsf(acts[e]));
+      }
+      const float absmax = fmaxf(warp_reduce_max(thread_max), 1e-30f);
+      const float scale = absmax * inv_fp8_max;
+      if (lane_id == 0) scale_row[g] = scale;
+      const float inv_scale = __fdividef(1.0f, scale);
+#pragma unroll
+      for (int e = 0; e < ELTS_PER_LANE; e++) {
+        const int idx = base + e * WARP_SIZE + lane_id;
+        out_ptr[idx] = quant_to_fp8<fp8_type>(acts[e], inv_scale, FP8_MAX);
+      }
+    }
+  }
+
+  // Padding rows past *valid_rows are never streamed above; fill their scales
+  // with a finite value so masked-out rows don't feed NaN/Inf into the w2 GEMM.
+  const int64_t pad_start = row_bound * (int64_t)num_groups;
+  const int64_t pad_end = num_rows * (int64_t)num_groups;
+  for (int64_t i = pad_start + (int64_t)blockIdx.x * blockDim.x + tid;
+       i < pad_end; i += (int64_t)gridDim.x * blockDim.x) {
+    scale_out[i] = 1.0f;
   }
 }
 
@@ -519,10 +859,8 @@ __global__ void masked_situ_and_mul_kernel(
     scalar_t* out_ptr = out + row * d;
     const float g = (float)VLLM_LDG(&gate_ptr[idx]);
     const float u = (float)VLLM_LDG(&up_ptr[idx]);
-    const float gate_out = beta * tanhf(g * inv_beta) / (1.0f + expf(-g));
-    const float up_out =
-        clamp_up ? linear_beta * tanhf(u * inv_linear_beta) : u;
-    out_ptr[idx] = (scalar_t)(gate_out * up_out);
+    out_ptr[idx] = (scalar_t)situ_activation(g, u, beta, linear_beta, clamp_up,
+                                             inv_beta, inv_linear_beta);
   }
 }
 
@@ -620,7 +958,8 @@ void swigluoai_and_mul(torch::stable::Tensor& out,    // [..., d]
 // through), matching SituAndMul(linear_beta=None) on the Python side.
 void situ_and_mul(torch::stable::Tensor& out,    // [..., d]
                   torch::stable::Tensor& input,  // [..., 2 * d]
-                  double beta, double linear_beta) {
+                  double beta, double linear_beta,
+                  std::optional<torch::stable::Tensor> valid_rows) {
   int d = input.size(-1) / 2;
   int64_t num_tokens = input.numel() / input.size(-1);
   if (num_tokens == 0) {
@@ -628,6 +967,10 @@ void situ_and_mul(torch::stable::Tensor& out,    // [..., d]
   }
   dim3 grid(num_tokens);
   dim3 block(std::min(d, 1024));
+  const int64_t* valid_rows_ptr = nullptr;
+  if (valid_rows.has_value()) {
+    valid_rows_ptr = valid_rows->const_data_ptr<int64_t>();
+  }
   const torch::stable::accelerator::DeviceGuard device_guard(
       input.get_device_index());
   const cudaStream_t stream = get_current_cuda_stream();
@@ -635,7 +978,7 @@ void situ_and_mul(torch::stable::Tensor& out,    // [..., d]
       input.scalar_type(), "situ_and_mul_kernel", [&] {
         vllm::situ_and_mul_kernel<scalar_t><<<grid, block, 0, stream>>>(
             out.mutable_data_ptr<scalar_t>(), input.const_data_ptr<scalar_t>(),
-            d, (float)beta, (float)linear_beta);
+            d, (float)beta, (float)linear_beta, valid_rows_ptr);
       });
 }
 
@@ -662,6 +1005,112 @@ void masked_situ_and_mul(torch::stable::Tensor& out,    // [E, T, d]
             expert_num_tokens.const_data_ptr<int>(), max_num_tokens, d,
             (float)beta, (float)linear_beta);
       });
+}
+
+// Fused Kimi SITU activation + dynamic FP8 quantization. Produces the fp8
+// down-projection input (`out`) and its scale (`scale`, dequant = q * scale) in
+// one pass, replacing the separate situ_and_mul + quant_input kernels on the
+// Humming w2 path. `group_size == 128` selects k-major block-FP8 group scales
+// (scale [.., d / 128], matching humming quant_input(group_size=128, float32)).
+// `linear_beta <= 0` means "unset" (up passed through), matching
+// SituAndMul(linear_beta=None). `valid_rows` (int64 scalar tensor) is the
+// DeepEP v2 contiguous-layout valid row count; padding rows are skipped and
+// receive a benign scale.
+void situ_and_mul_quant(torch::stable::Tensor& out,    // [..., d]  (fp8)
+                        torch::stable::Tensor& scale,  // [..., 1 or d/128]
+                        torch::stable::Tensor& input,  // [..., 2 * d]
+                        double beta, double linear_beta, int64_t group_size,
+                        std::optional<torch::stable::Tensor> valid_rows) {
+  STD_TORCH_CHECK(
+      out.scalar_type() == torch::headeronly::ScalarType::Float8_e4m3fn ||
+          out.scalar_type() == torch::headeronly::ScalarType::Float8_e4m3fnuz,
+      "situ_and_mul_quant output must be FP8 e4m3");
+  STD_TORCH_CHECK(
+      input.scalar_type() == torch::headeronly::ScalarType::Half ||
+          input.scalar_type() == torch::headeronly::ScalarType::BFloat16,
+      "situ_and_mul_quant input must be FP16 or BF16");
+  STD_TORCH_CHECK(scale.scalar_type() == torch::headeronly::ScalarType::Float,
+                  "situ_and_mul_quant scale must be float32");
+  int d = input.size(-1) / 2;
+  int64_t num_tokens = input.numel() / input.size(-1);
+  if (num_tokens == 0) {
+    return;
+  }
+  const int64_t* valid_rows_ptr = nullptr;
+  if (valid_rows.has_value()) {
+    valid_rows_ptr = valid_rows->const_data_ptr<int64_t>();
+  }
+  // fp8_max (448 e4m3fn / 224 fnuz) is derived from fp8_type inside the kernel.
+  const torch::stable::accelerator::DeviceGuard device_guard(
+      input.get_device_index());
+  const cudaStream_t stream = get_current_cuda_stream();
+  static constexpr int THREADS = 256;
+  static constexpr int GROUP_STAGES = 3;   // warp-per-group cp.async depth
+  static constexpr int BLOCKS_PER_SM = 8;  // matches kernel __launch_bounds__
+  static constexpr int SM_COUNT = 132;     // H200 (GH100, 132 SMs)
+  // Fixed persistent grid so the kernel's grid stride is a compile-time
+  // constant.
+  static constexpr int GRID_DIM = SM_COUNT * BLOCKS_PER_SM;
+  static constexpr int SITU_D = 3072;  // fixed Kimi-K3 hidden dim (fused w2 in)
+
+  // Block-FP8 group path only: k-major float32 group scales [num_tokens,
+  // d / group_size], matching humming quant_input(group_size, float32).
+  STD_TORCH_CHECK(group_size == 128,
+                  "situ_and_mul_quant: only group_size 128 (block-FP8) "
+                  "supported, got ",
+                  group_size);
+  STD_TORCH_CHECK(d % group_size == 0, "situ_and_mul_quant: d (", d,
+                  ") must be divisible by group_size ", group_size);
+  {
+    const int num_groups = d / (int)group_size;
+    // Persistent grid: always launch the fixed GRID_DIM block pool so the
+    // kernel's grid stride is a constant; blocks past num_tokens just no-op.
+    dim3 grid(GRID_DIM);
+    VLLM_STABLE_DISPATCH_FLOATING_TYPES(
+        input.scalar_type(), "situ_and_mul_quant_group_kernel", [&] {
+          VLLM_STABLE_DISPATCH_FP8_TYPES(
+              out.scalar_type(), "situ_and_mul_quant_group_kernel_fp8", [&] {
+                // Warp-per-group pipelined kernel: one warp owns a whole
+                // 128-group, so the full-warp abs-max reduction is always safe
+                // (no partial-warp mask hazard) and any d % 128 == 0 works.
+                // Only 2-byte scalar_t is vectorized; the fp32 dispatch branch
+                // falls back to the scalar group kernel. Pipelined path only
+                // for the fixed hidden dim; other d (and the fp32 branch) fall
+                // through to the runtime scalar kernel.
+                if constexpr (sizeof(scalar_t) == 2) {
+                  if (d == SITU_D && (float)beta == vllm::SITU_BETA &&
+                      (float)linear_beta == vllm::SITU_LINEAR_BETA) {
+                    constexpr int D = SITU_D;
+                    constexpr int NUM_WARPS = THREADS / 32;
+                    constexpr int STAGE_ELTS = 2 * 128;  // gate + up per group
+                    auto kernel =
+                        &vllm::situ_and_mul_quant_group_pipelined_kernel<
+                            scalar_t, fp8_t, THREADS, GROUP_STAGES, 128,
+                            GRID_DIM, D>;
+                    size_t smem_bytes = (size_t)NUM_WARPS * GROUP_STAGES *
+                                        STAGE_ELTS * sizeof(scalar_t);
+                    dim3 block(THREADS);
+                    kernel<<<grid, block, smem_bytes, stream>>>(
+                        out.mutable_data_ptr<fp8_t>(),
+                        scale.mutable_data_ptr<float>(),
+                        input.const_data_ptr<scalar_t>(), num_tokens,
+                        valid_rows_ptr);
+                    return;
+                  }
+                }
+                const int num_warps = std::min(num_groups, 32);
+                dim3 block(num_warps * 32);
+                vllm::situ_and_mul_quant_group_scalar_kernel<scalar_t, fp8_t,
+                                                             128>
+                    <<<grid, block, 0, stream>>>(
+                        out.mutable_data_ptr<fp8_t>(),
+                        scale.mutable_data_ptr<float>(),
+                        input.const_data_ptr<scalar_t>(), d, num_groups,
+                        (float)beta, (float)linear_beta, num_tokens,
+                        valid_rows_ptr);
+              });
+        });
+  }
 }
 namespace vllm {
 

--- a/csrc/libtorch_stable/ops.h
+++ b/csrc/libtorch_stable/ops.h
@@ -534,8 +534,15 @@ void fatrelu_and_mul(torch::stable::Tensor& out, torch::stable::Tensor& input,
                      double threshold);
 void swigluoai_and_mul(torch::stable::Tensor& out, torch::stable::Tensor& input,
                        double alpha = 1.702, double limit = 7.0);
-void situ_and_mul(torch::stable::Tensor& out, torch::stable::Tensor& input,
-                  double beta = 1.0, double linear_beta = -1.0);
+void situ_and_mul(
+    torch::stable::Tensor& out, torch::stable::Tensor& input, double beta = 1.0,
+    double linear_beta = -1.0,
+    std::optional<torch::stable::Tensor> valid_rows = std::nullopt);
+void situ_and_mul_quant(
+    torch::stable::Tensor& out, torch::stable::Tensor& scale,
+    torch::stable::Tensor& input, double beta = 1.0, double linear_beta = -1.0,
+    int64_t group_size = 0,
+    std::optional<torch::stable::Tensor> valid_rows = std::nullopt);
 void masked_situ_and_mul(torch::stable::Tensor& out,
                          torch::stable::Tensor& input,
                          const torch::stable::Tensor& expert_num_tokens,

--- a/csrc/libtorch_stable/torch_bindings.cpp
+++ b/csrc/libtorch_stable/torch_bindings.cpp
@@ -616,7 +616,15 @@ STABLE_TORCH_LIBRARY_FRAGMENT(_C, ops) {
   // SituGLU implementation used in Kimi models.
   ops.def(
       "situ_and_mul(Tensor! out, Tensor input, float beta=1.0, float "
-      "linear_beta=-1.0) -> ()");
+      "linear_beta=-1.0, Tensor? valid_rows=None) -> ()");
+  // Fused SituGLU activation + dynamic FP8 quantization for the Humming w2 path
+  // (writes the fp8 down input and its float32 scale). group_size=0 ->
+  // per-token scale [.., 1]; group_size=128 -> k-major block-FP8 scale [..,
+  // d/128].
+  ops.def(
+      "situ_and_mul_quant(Tensor! out, Tensor! scale, Tensor input, "
+      "float beta=1.0, float linear_beta=-1.0, int group_size=0, "
+      "Tensor? valid_rows=None) -> ()");
   ops.def(
       "masked_situ_and_mul(Tensor! out, Tensor input, Tensor "
       "expert_num_tokens, float beta=1.0, float linear_beta=-1.0) -> ()");
@@ -837,6 +845,7 @@ STABLE_TORCH_LIBRARY_IMPL(_C, CUDA, ops) {
   ops.impl("fatrelu_and_mul", TORCH_BOX(&fatrelu_and_mul));
   ops.impl("swigluoai_and_mul", TORCH_BOX(&swigluoai_and_mul));
   ops.impl("situ_and_mul", TORCH_BOX(&situ_and_mul));
+  ops.impl("situ_and_mul_quant", TORCH_BOX(&situ_and_mul_quant));
   ops.impl("masked_situ_and_mul", TORCH_BOX(&masked_situ_and_mul));
   ops.impl("gelu_new", TORCH_BOX(&gelu_new));
   ops.impl("gelu_fast", TORCH_BOX(&gelu_fast));

--- a/tests/kernels/moe/test_situ_mul_fp8_quant.py
+++ b/tests/kernels/moe/test_situ_mul_fp8_quant.py
@@ -1,0 +1,184 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Correctness tests for the persistent cp.async-pipelined SITU + block-FP8
+quant kernel (``situ_and_mul_quant``).
+
+Mirrors ``test_silu_mul_fp8_quant_deep_gemm.py`` in structure: build a reference
+activation + block-FP8 quant, drive random per-row scale magnitudes, exercise
+the masked (``valid_rows``) contiguous layout, and compare per valid row.
+
+The kernel uses approximate device math (``tanh.approx.f32`` + ``__expf``), which
+cannot be reproduced bit-exactly in torch. It is therefore validated against the
+*ideal* FP8 quantizer of the exact fp64 activation: the approximation must be
+negligible on top of the unavoidable FP8 block-quant error (within 1 fp8 code
+for ~all elements, never off by more than 2).
+"""
+
+import pytest
+import torch
+
+from vllm.model_executor.layers.fused_moe.activation import situ_and_mul_quant
+from vllm.platforms import current_platform
+from vllm.utils.torch_utils import set_random_seed
+
+fp8_dtype = current_platform.fp8_dtype()
+DEVICE = current_platform.device_type
+FP8_MAX = torch.finfo(fp8_dtype).max
+
+# The kernel uses inline ``tanh.approx.f32`` PTX and fp8 e4m3 conversion, so it
+# is CUDA-only and needs SM89+ (Ada/Hopper). There is no Triton fallback.
+pytestmark = pytest.mark.skipif(
+    not current_platform.is_cuda() or not current_platform.has_device_capability(89),
+    reason="situ_and_mul_quant persistent kernel requires CUDA SM89+ (fp8 e4m3).",
+)
+
+# Kimi-K3 baked SITU params. Only (d=3072, beta=4.0, linear_beta=25.0,
+# group_size=128, fp16/bf16) routes to the persistent cp.async-pipelined kernel;
+# anything else falls back to the scalar group kernel.
+SITU_BETA = 4.0
+SITU_LINEAR_BETA = 25.0
+SITU_D = 3072
+GROUP_SIZE = 128
+
+# (num_tokens, valid_rows). valid_rows=None => all rows valid. 2048/4096 rows
+# span multiple grid-stride waves of the persistent grid (GRID_DIM = 132*8).
+CASES = [
+    (1, None),
+    (17, None),
+    (128, None),
+    (2048, None),
+    (4096, None),
+    (2048, 1500),  # DeepEP v2 contiguous padding
+    (2048, 1),
+    (4096, 4095),
+    (512, 0),  # whole tensor is padding
+]
+
+
+def token_random(num_tokens: int, twod: int, dtype: torch.dtype) -> torch.Tensor:
+    """Per-row random exponent so groups span many scale magnitudes."""
+    base = torch.randn(num_tokens, twod, dtype=torch.float32, device=DEVICE)
+    exps = torch.randint(1, 13, (num_tokens, 1), device=DEVICE).float()
+    return (base * (2.0**exps)).to(dtype)
+
+
+def ref_situ_block_fp8_quant(
+    inp: torch.Tensor, beta: float, linear_beta: float, group_size: int
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Ideal FP8 block-quant of the exact fp64 SITU activation.
+
+    The kernel rounds the activation to ``scalar_t`` before quantizing (it stores
+    ``(float)(scalar_t)situ(...)``), so the reference does the same before taking
+    the per-group absmax.
+    """
+    d = inp.shape[-1] // 2
+    gate, up = inp.double().chunk(2, dim=-1)
+    gate_out = beta * torch.tanh(gate / beta) * torch.sigmoid(gate)
+    up_out = linear_beta * torch.tanh(up / linear_beta) if linear_beta > 0 else up
+    act = (gate_out * up_out).to(inp.dtype).float()
+
+    m = act.shape[0]
+    ng = d // group_size
+    a = act.view(m, ng, group_size)
+    scale = a.abs().amax(dim=2).clamp_min(1e-30) / FP8_MAX
+    q = (a / scale.unsqueeze(2)).clamp(-FP8_MAX, FP8_MAX).to(fp8_dtype)
+    return q.view(m, d), scale
+
+
+def fp8_code_dist(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+    """Signed-magnitude fp8 code distance (valid for e4m3fn and e4m3fnuz)."""
+
+    def ordered(x: torch.Tensor) -> torch.Tensor:
+        x = x.view(torch.uint8).to(torch.int32)
+        return torch.where((x >> 7) == 1, -(x & 0x7F), x & 0x7F)
+
+    return (ordered(a) - ordered(b)).abs()
+
+
+@pytest.mark.parametrize("num_tokens,valid", CASES)
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.half])
+@torch.inference_mode()
+def test_situ_and_mul_quant_pipelined(
+    num_tokens: int, valid: int | None, dtype: torch.dtype
+) -> None:
+    set_random_seed(42)
+    d = SITU_D
+    inp = token_random(num_tokens, 2 * d, dtype)
+
+    # Sentinels: padding rows must keep their bytes (out) and get scale 1.0.
+    out = torch.full((num_tokens, d), 17.0, device=DEVICE).to(fp8_dtype)
+    scale = torch.full(
+        (num_tokens, d // GROUP_SIZE), -1.0, dtype=torch.float32, device=DEVICE
+    )
+    out_sentinel = out.clone()
+    valid_rows = (
+        None if valid is None else torch.tensor(valid, dtype=torch.int64, device=DEVICE)
+    )
+
+    situ_and_mul_quant(
+        out,
+        scale,
+        inp,
+        beta=SITU_BETA,
+        linear_beta=SITU_LINEAR_BETA,
+        group_size=GROUP_SIZE,
+        valid_rows=valid_rows,
+    )
+
+    # Padding contract: skipped rows keep their bytes; their scale becomes 1.0.
+    if valid is not None and valid < num_tokens:
+        assert torch.equal(scale[valid:], torch.ones_like(scale[valid:]))
+        assert torch.equal(
+            out[valid:].view(torch.uint8), out_sentinel[valid:].view(torch.uint8)
+        )
+
+    rows = num_tokens if valid is None else valid
+    if rows == 0:
+        return
+
+    ref_q, ref_s = ref_situ_block_fp8_quant(
+        inp[:rows], SITU_BETA, SITU_LINEAR_BETA, GROUP_SIZE
+    )
+
+    assert torch.isfinite(scale[:rows]).all()
+    assert not torch.isnan(out[:rows].float()).any()
+
+    # Scales: the approximate activation shifts the per-group absmax only
+    # marginally.
+    torch.testing.assert_close(scale[:rows], ref_s, rtol=3e-2, atol=1e-5)
+
+    # FP8 codes: the approximation must land within 1 code of the ideal quantizer
+    # for ~all elements, never off by more than 2.
+    dist = fp8_code_dist(out[:rows], ref_q)
+    assert dist.max().item() <= 2
+    assert (dist <= 1).float().mean().item() >= 0.99
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.half])
+@torch.inference_mode()
+def test_situ_and_mul_quant_pipelined_deterministic(dtype: torch.dtype) -> None:
+    """Two runs on the same input must be byte-identical."""
+    set_random_seed(0)
+    d = SITU_D
+    num_tokens = 2048
+    inp = token_random(num_tokens, 2 * d, dtype)
+
+    def run() -> tuple[torch.Tensor, torch.Tensor]:
+        out = torch.empty(num_tokens, d, dtype=fp8_dtype, device=DEVICE)
+        scale = torch.empty(
+            num_tokens, d // GROUP_SIZE, dtype=torch.float32, device=DEVICE
+        )
+        situ_and_mul_quant(
+            out,
+            scale,
+            inp,
+            beta=SITU_BETA,
+            linear_beta=SITU_LINEAR_BETA,
+            group_size=GROUP_SIZE,
+        )
+        return out, scale
+
+    out1, s1 = run()
+    out2, s2 = run()
+    assert torch.equal(out1.view(torch.uint8), out2.view(torch.uint8))
+    assert torch.equal(s1, s2)

--- a/vllm/model_executor/layers/fused_moe/activation.py
+++ b/vllm/model_executor/layers/fused_moe/activation.py
@@ -201,6 +201,7 @@ def apply_moe_activation(
     activation_config: ApplyMoEActivationConfig | None = None,
     topk_ids: torch.Tensor | None = None,
     expert_map: torch.Tensor | None = None,
+    valid_rows: torch.Tensor | None = None,
 ) -> torch.Tensor:
     """Apply MoE activation function.
 
@@ -256,6 +257,7 @@ def apply_moe_activation(
             -1.0
             if config.activation_situ_linear_beta is None
             else config.activation_situ_linear_beta,
+            valid_rows,
         )
     elif activation == MoEActivation.SWIGLUOAI:
         torch.ops._C.swigluoai_and_mul(output, input)
@@ -286,3 +288,42 @@ def apply_moe_activation(
         raise ValueError(f"Unsupported FusedMoe activation: {activation}")
 
     return output
+
+
+def situ_and_mul_quant(
+    output: torch.Tensor,
+    scale: torch.Tensor,
+    input: torch.Tensor,
+    *,
+    beta: float,
+    linear_beta: float | None,
+    group_size: int = 0,
+    valid_rows: torch.Tensor | None = None,
+) -> None:
+    """Fused Kimi SITU activation + dynamic FP8 quantization.
+
+    Writes the quantized fp8 down-projection input into ``output`` [M, d] and its
+    float32 scale into ``scale`` (dequant = q * scale), fusing the SITU
+    activation with the FP8 quant that Humming's w2 GEMM would otherwise perform
+    in a separate pass -- this avoids materializing (and rounding through) the
+    bf16 activation_output buffer.
+
+    ``group_size`` selects the quant granularity: ``0`` gives per-token scales
+    ``scale`` [M, 1]; ``128`` gives k-major block-FP8 group scales ``scale``
+    [M, d // 128], matching humming ``quant_input(group_size=128, float32)``.
+
+    ``linear_beta`` <= 0 (or None) means "unset" (up passed through), matching
+    ``SituAndMul(linear_beta=None)``. ``valid_rows`` (int64 scalar tensor) is the
+    DeepEP v2 contiguous-layout valid row count; padding rows are skipped and
+    receive a benign scale of 1.0. Kept in this module so that every
+    ``torch.ops._C.situ*`` call lives in one file.
+    """
+    torch.ops._C.situ_and_mul_quant(
+        output,
+        scale,
+        input,
+        beta,
+        -1.0 if linear_beta is None else linear_beta,
+        group_size,
+        valid_rows,
+    )


### PR DESCRIPTION
Adds a fused SITU-activation + block-FP8-quant CUDA kernel (`situ_and_mul_quant`) with a persistent cp.async-pipelined path and a scalar fallback, plus the `valid_rows` argument on `situ_and_mul`.

## Test
- `tests/kernels/moe/test_situ_mul_fp8_quant.py` (added): CUDA/SM89+, padding contract, scale `assert_close`, fp8 code distance ≤2 with (≤1).mean()≥0.99, determinism — passes.
- Standalone numeric harness on H200: 81/81 cases pass (ulp_max≤2, ≥85% bit-exact, SNR/relL2/cosine no worse than ideal FP8 quant).

AI assistance was used for this change; the submitter reviewed every changed line.