### PR TITLE
[Bugfix][Frontend] Abort realtime STT on disconnect; harden Anthropic tool JSON

### DIFF
--- a/tests/entrypoints/anthropic/test_anthropic_messages_conversion.py
+++ b/tests/entrypoints/anthropic/test_anthropic_messages_conversion.py
@@ -36,6 +36,8 @@ from vllm.entrypoints.generate.base.protocol import (
     DeltaFunctionCall,
     DeltaMessage,
     DeltaToolCall,
+    FunctionCall,
+    ToolCall,
 )
 from vllm.entrypoints.openai.chat_completion.protocol import (
     ChatCompletionResponse,
@@ -1448,6 +1450,103 @@ class TestMessagesFullConverter:
         assert len(result.content) == 1
         assert result.content[0].type == "text"
         assert result.content[0].text == ""
+
+    def test_malformed_tool_arguments_do_not_raise(self):
+        """Truncated tool JSON must not turn a completed generation into 500."""
+        generator = ChatCompletionResponse(
+            id="chatcmpl-tools",
+            model="test-model",
+            choices=[
+                ChatCompletionResponseChoice(
+                    index=0,
+                    message=ChatMessage(
+                        role="assistant",
+                        content=None,
+                        tool_calls=[
+                            ToolCall(
+                                id="call_weather",
+                                function=FunctionCall(
+                                    name="get_weather",
+                                    arguments='{"city":',
+                                ),
+                            )
+                        ],
+                    ),
+                    finish_reason="tool_calls",
+                )
+            ],
+            usage=UsageInfo(prompt_tokens=8, completion_tokens=4, total_tokens=12),
+        )
+
+        result = _make_full_converter().messages_full_converter(generator)
+
+        tool_blocks = [block for block in result.content if block.type == "tool_use"]
+        assert len(tool_blocks) == 1
+        assert tool_blocks[0].name == "get_weather"
+        assert tool_blocks[0].input == {}
+        assert result.stop_reason == "tool_use"
+
+    def test_non_object_tool_arguments_are_wrapped(self):
+        generator = ChatCompletionResponse(
+            id="chatcmpl-tools-list",
+            model="test-model",
+            choices=[
+                ChatCompletionResponseChoice(
+                    index=0,
+                    message=ChatMessage(
+                        role="assistant",
+                        content=None,
+                        tool_calls=[
+                            ToolCall(
+                                id="call_list",
+                                function=FunctionCall(
+                                    name="tag",
+                                    arguments='["a","b"]',
+                                ),
+                            )
+                        ],
+                    ),
+                    finish_reason="tool_calls",
+                )
+            ],
+            usage=UsageInfo(prompt_tokens=4, completion_tokens=2, total_tokens=6),
+        )
+
+        result = _make_full_converter().messages_full_converter(generator)
+
+        tool_blocks = [block for block in result.content if block.type == "tool_use"]
+        assert tool_blocks[0].input == {"value": ["a", "b"]}
+
+    def test_valid_object_tool_arguments_are_preserved(self):
+        generator = ChatCompletionResponse(
+            id="chatcmpl-tools-obj",
+            model="test-model",
+            choices=[
+                ChatCompletionResponseChoice(
+                    index=0,
+                    message=ChatMessage(
+                        role="assistant",
+                        content=None,
+                        tool_calls=[
+                            ToolCall(
+                                id="call_weather",
+                                function=FunctionCall(
+                                    name="get_weather",
+                                    arguments='{"city":"paris"}',
+                                ),
+                            )
+                        ],
+                    ),
+                    finish_reason="tool_calls",
+                )
+            ],
+            usage=UsageInfo(prompt_tokens=4, completion_tokens=2, total_tokens=6),
+        )
+
+        result = _make_full_converter().messages_full_converter(generator)
+
+        tool_blocks = [block for block in result.content if block.type == "tool_use"]
+        assert tool_blocks[0].input == {"city": "paris"}
 
 
 # ======================================================================

--- a/tests/entrypoints/speech_to_text/realtime/test_connection_abort.py
+++ b/tests/entrypoints/speech_to_text/realtime/test_connection_abort.py
@@ -1,0 +1,79 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from vllm.entrypoints.speech_to_text.realtime.connection import RealtimeConnection
+
+
+def _output(text: str = "hi", token_ids: list[int] | None = None):
+    return SimpleNamespace(
+        prompt_token_ids=[1],
+        outputs=[SimpleNamespace(text=text, token_ids=token_ids or [2])],
+    )
+
+
+async def _yield_one_then_hang():
+    yield _output()
+    await asyncio.Event().wait()
+    yield
+
+
+async def _never_finishes():
+    await asyncio.Event().wait()
+    yield
+
+
+def _make_connection(generate_agen):
+    engine_client = SimpleNamespace(
+        generate=Mock(return_value=generate_agen),
+        abort=AsyncMock(),
+    )
+    serving = SimpleNamespace(
+        engine_client=engine_client,
+        model_cls=SimpleNamespace(realtime_max_tokens=16),
+    )
+    websocket = SimpleNamespace(send_text=AsyncMock())
+    conn = RealtimeConnection(websocket, serving)
+    conn._is_connected = True
+    return conn, engine_client
+
+
+@pytest.mark.asyncio
+async def test_disconnect_mid_stream_aborts_engine_request():
+    conn, engine_client = _make_connection(_yield_one_then_hang())
+    conn._is_connected = False
+
+    await conn._run_generation(
+        streaming_input_gen=None,
+        input_stream=asyncio.Queue(),
+    )
+
+    engine_client.abort.assert_awaited()
+    aborted_id = engine_client.abort.await_args.args[0]
+    assert aborted_id.startswith(f"rt-{conn.connection_id}-")
+    generate_id = engine_client.generate.call_args.kwargs["request_id"]
+    assert aborted_id == generate_id
+
+
+@pytest.mark.asyncio
+async def test_cleanup_cancel_aborts_engine_request():
+    conn, engine_client = _make_connection(_never_finishes())
+    conn.generation_task = asyncio.create_task(
+        conn._run_generation(
+            streaming_input_gen=None,
+            input_stream=asyncio.Queue(),
+        )
+    )
+    await asyncio.sleep(0)
+
+    await conn.cleanup()
+
+    engine_client.abort.assert_awaited()
+    aborted_id = engine_client.abort.await_args.args[0]
+    generate_id = engine_client.generate.call_args.kwargs["request_id"]
+    assert aborted_id == generate_id

--- a/vllm/entrypoints/anthropic/serving.py
+++ b/vllm/entrypoints/anthropic/serving.py
@@ -95,6 +95,21 @@ def wrap_data_with_event(data: str, event: str):
     return f"event: {event}\ndata: {data}\n\n"
 
 
+def _parse_tool_use_input(arguments: str) -> dict[str, Any]:
+    """Parse tool-call arguments into an Anthropic tool_use input object.
+
+    Model output is often truncated or a non-object JSON value. Those must
+    not fail a completed generation.
+    """
+    try:
+        parsed = json.loads(arguments) if arguments else {}
+    except json.JSONDecodeError:
+        return {}
+    if isinstance(parsed, dict):
+        return parsed
+    return {"value": parsed}
+
+
 class AnthropicServingMessages(OpenAIServingChat):
     """Handler for Anthropic Messages API requests"""
 
@@ -665,7 +680,7 @@ class AnthropicServingMessages(OpenAIServingChat):
                 type="tool_use",
                 id=tool_call.id,
                 name=tool_call.function.name,
-                input=json.loads(tool_call.function.arguments),
+                input=_parse_tool_use_input(tool_call.function.arguments),
             )
             content += [anthropic_tool_call]
 

--- a/vllm/entrypoints/speech_to_text/realtime/connection.py
+++ b/vllm/entrypoints/speech_to_text/realtime/connection.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import asyncio
+import contextlib
 import json
 from collections.abc import AsyncGenerator
 from http import HTTPStatus
@@ -208,6 +209,8 @@ class RealtimeConnection:
 
         prompt_token_ids_len: int = 0
         completion_tokens_len: int = 0
+        result_gen = None
+        should_abort = True
 
         try:
             # Create sampling params
@@ -248,6 +251,9 @@ class RealtimeConnection:
                     # finish because websocket connection was killed
                     break
 
+            if not self._is_connected:
+                return
+
             usage = UsageInfo(
                 prompt_tokens=prompt_token_ids_len,
                 completion_tokens=completion_tokens_len,
@@ -260,10 +266,24 @@ class RealtimeConnection:
             # Clear queue for next utterance
             while not self.audio_queue.empty():
                 self.audio_queue.get_nowait()
+            should_abort = False
 
+        except asyncio.CancelledError:
+            raise
         except Exception as e:
             logger.exception("Error in generation: %s", e)
             await self.send_error(sanitize_message(str(e)), "processing_error")
+        finally:
+            if result_gen is not None:
+                aclose = getattr(result_gen, "aclose", None)
+                if aclose is not None:
+                    with contextlib.suppress(Exception):
+                        await aclose()
+            if should_abort:
+                await asyncio.gather(
+                    self.serving.engine_client.abort(request_id),
+                    return_exceptions=True,
+                )
 
     async def send(
         self, event: SessionCreated | TranscriptionDelta | TranscriptionDone
@@ -282,8 +302,10 @@ class RealtimeConnection:
         # Signal audio stream to stop
         self.audio_queue.put_nowait(None)
 
-        # Cancel generation task if running
+        # Wait so _run_generation can abort the engine request.
         if self.generation_task and not self.generation_task.done():
             self.generation_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self.generation_task
 
         logger.debug("Connection cleanup complete: %s", self.connection_id)


### PR DESCRIPTION
## Purpose

Two frontend serving bugs on public API paths.

**Realtime STT abort.** `/v1/realtime` starts `engine_client.generate()` and, on websocket disconnect, only `break`s the consume loop. `cleanup()` cancelled the asyncio task but did not abort the engine request. Sibling transcription serving already calls `engine_client.abort(...)` on `CancelledError`. A client that drops the socket left GPU work running.

This path landed in #33187 (2026-01-30).

**Anthropic tool_use JSON.** Non-streaming `/v1/messages` conversion did `json.loads(tool_call.function.arguments)` with no guard. Truncated or non-object arguments (common when generation hits `max_tokens`) raised `JSONDecodeError` or a pydantic error and turned a completed generation into HTTP 500.

This path landed in #22627 (2025-10-23).

Not included: forwarding OpenAI stream `ErrorResponse` chunks through the Anthropic converter. That is already being fixed in #46162.

## Test Plan

```bash
PYTHONPATH=. python -m pytest \
  tests/entrypoints/speech_to_text/realtime/test_connection_abort.py \
  tests/entrypoints/anthropic/test_anthropic_messages_conversion.py::TestMessagesFullConverter \
  -q --noconftest
```

## Test Result

```text
Red (before the fix):
- test_disconnect_mid_stream_aborts_engine_request FAILED (abort not awaited)
- test_cleanup_cancel_aborts_engine_request FAILED (abort not awaited)
- test_malformed_tool_arguments_do_not_raise FAILED (JSONDecodeError)
- test_non_object_tool_arguments_are_wrapped FAILED (pydantic dict_type)

Green (after the fix): 6 passed
```

AI assistance was used to locate and implement these fixes. I reviewed every changed line and ran the tests above.

<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
</details>
