### PR TITLE
[Bugfix][Frontend] Keep vLLM MCP x-session-id over client headers

### DIFF
--- a/tests/entrypoints/openai/responses/test_mcp_tools.py
+++ b/tests/entrypoints/openai/responses/test_mcp_tools.py
@@ -16,6 +16,7 @@ import vllm.entrypoints.mcp.tool_server as tool_server_module
 from tests.utils import RemoteOpenAIServer
 from vllm.entrypoints.mcp.tool_server import (
     MCPToolServer,
+    _build_request_headers,
     init_tool_server,
     post_process_tools_description,
 )
@@ -158,6 +159,41 @@ class TestMCPToolServerUnit:
         post_process_tools_description(result)
 
         assert result.tools == [included]
+
+    def test_build_request_headers_sets_session_id_without_client_headers(self):
+        assert _build_request_headers("sess-1") == {"x-session-id": "sess-1"}
+        assert _build_request_headers("sess-1", None) == {"x-session-id": "sess-1"}
+
+    def test_build_request_headers_forwards_non_session_headers(self):
+        headers = {"Authorization": "Bearer token", "X-Custom": "ok"}
+        result = _build_request_headers("sess-1", headers)
+        assert result["Authorization"] == "Bearer token"
+        assert result["X-Custom"] == "ok"
+        assert result["x-session-id"] == "sess-1"
+        assert headers == {"Authorization": "Bearer token", "X-Custom": "ok"}
+
+    @pytest.mark.parametrize(
+        "client_key",
+        ["x-session-id", "X-Session-ID", "X-Session-Id", "X-SESSION-ID"],
+    )
+    def test_build_request_headers_keeps_vllm_session_id(self, client_key: str):
+        result = _build_request_headers(
+            "vllm-session",
+            {client_key: "attacker-session", "Authorization": "Bearer token"},
+        )
+        assert result["x-session-id"] == "vllm-session"
+        assert result["Authorization"] == "Bearer token"
+        assert client_key not in result or client_key == "x-session-id"
+
+    def test_build_request_headers_single_httpx_session_id(self):
+        httpx = pytest.importorskip("httpx")
+        built = _build_request_headers(
+            "vllm-session",
+            {"X-Session-ID": "attacker-session"},
+        )
+        encoded = httpx.Headers(built)
+        assert encoded.get("x-session-id") == "vllm-session"
+        assert encoded.multi_items() == [("x-session-id", "vllm-session")]
 
     def test_builtin_tools_consistency(self):
         """MCP_BUILTIN_TOOLS must match BUILTIN_TOOL_TO_MCP_SERVER_LABEL values."""

--- a/vllm/entrypoints/mcp/tool_server.py
+++ b/vllm/entrypoints/mcp/tool_server.py
@@ -55,6 +55,21 @@ def trim_schema(schema: dict) -> dict:
     return schema
 
 
+def _build_request_headers(
+    session_id: str, headers: dict[str, str] | None = None
+) -> dict[str, str]:
+    # Forward client MCP headers, then force vLLM's session id so a client
+    # cannot overwrite it (HTTP header names are case-insensitive).
+    request_headers: dict[str, str] = {}
+    if headers is not None:
+        request_headers.update(headers)
+        for key in list(request_headers):
+            if key.lower() == "x-session-id":
+                del request_headers[key]
+    request_headers["x-session-id"] = session_id
+    return request_headers
+
+
 def post_process_tools_description(
     list_tools_result: "ListToolsResult",
 ) -> "ListToolsResult":
@@ -183,9 +198,7 @@ class MCPToolServer(ToolServer):
         from mcp.client.sse import sse_client
 
         url = self.urls.get(tool_name)
-        request_headers = {"x-session-id": session_id}
-        if headers is not None:
-            request_headers.update(headers)
+        request_headers = _build_request_headers(session_id, headers)
         if not url:
             raise KeyError(f"Tool '{tool_name}' is not supported")
         async with (


### PR DESCRIPTION
## Purpose

`MCPToolServer.new_session` always set `x-session-id` to vLLM's request id, then copied Responses API MCP `headers` on top. Those headers are client-controlled (`openai.types.responses.tool.Mcp.headers`). A client could replace the session id.

Header passthrough itself is intentional ([#24628](https://github.com/vllm-project/vllm/pull/24628), 2025-09-22). The overwrite order is not. `httpx.Headers` is case-insensitive, so a mixed-case client key (`X-Session-ID`) does not replace the dict entry. It is sent as a second value and becomes `vllm-session, attacker-session`.

This landed in [#24628](https://github.com/vllm-project/vllm/pull/24628) and has been present for 328 days.

**Failure path.** `/v1/responses` with an MCP tool that includes `headers: {"x-session-id": "..."}` or `{"X-Session-ID": "..."}`. `init_tool_sessions` forwards those headers with the request id. The outbound SSE client then talks to the MCP server under the client's session id (or a comma-joined pair). `cleanup_session` later calls `cleanup_session` on that same MCP session.

**Fix.** Copy client headers, drop every case variant of `x-session-id`, then set vLLM's value last. Other headers still pass through.

This is not a duplicate of [#52519](https://github.com/vllm-project/vllm/pull/52519) (realtime abort + Anthropic tool JSON) or [#46162](https://github.com/vllm-project/vllm/pull/46162) (Anthropic stream errors).

## Test Plan

```bash
PYTHONPATH=. python -m pytest \
  tests/entrypoints/openai/responses/test_mcp_tools.py::TestMCPToolServerUnit \
  -q --noconftest
```

## Test Result

```text
Red (before the fix):
- test_build_request_headers_keeps_vllm_session_id[x-session-id] FAILED
- test_build_request_headers_keeps_vllm_session_id[X-Session-ID] FAILED
- test_build_request_headers_keeps_vllm_session_id[X-Session-Id] FAILED
- test_build_request_headers_keeps_vllm_session_id[X-SESSION-ID] FAILED
- test_build_request_headers_single_httpx_session_id FAILED
  (httpx.get returned "vllm-session, attacker-session")

Green (after the fix): 9 passed
```

AI assistance was used to locate and implement this fix. I reviewed every changed line and ran the tests above.

<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
</details>
