### PR TITLE
[Build] Install infiniband-diags for DeepEP v2

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -640,6 +640,7 @@ RUN apt-get update -y \
         python${PYTHON_VERSION}-dev \
         python${PYTHON_VERSION}-venv \
         libibverbs-dev \
+        infiniband-diags \
     && rm -rf /var/lib/apt/lists/* \
     && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python${PYTHON_VERSION} 1 \
     && update-alternatives --set python3 /usr/bin/python${PYTHON_VERSION} \


### PR DESCRIPTION
## Summary

The default vLLM image does not include `ibstat`, which is used by the
DeepEP v2 revision pinned by vLLM for RDMA capability and bandwidth
detection.

When `ibstat` is unavailable, the standard multi-node path can fail during
automatic SM-count calculation instead of recovering safely.

Install `infiniband-diags`, which provides `ibstat`.

## Duplicate-work check

No existing vLLM PR or issue addressing this missing runtime dependency was
found.

## Validation

- Manually patched the image to install `infiniband-diags`.
- Verified that the standard DeepEP v2 workload succeeds with the patched
  image.

No model evaluation is applicable because this change only adds a required
runtime dependency.

## AI assistance and human accountability

OpenAI Codex assisted with investigating the issue and drafting this
change. The human submitter reviewed the changed line and verified the
fix manually.