### PR TITLE
[Tests] Add regression test for Qwen3-VL video prompt outer vision wrapper (#46817)

### DIFF
--- a/tests/models/multimodal/processing/test_qwen3_vl.py
+++ b/tests/models/multimodal/processing/test_qwen3_vl.py
@@ -11,6 +11,7 @@ from typing import Any
 import numpy as np
 import pytest
 
+from vllm.model_executor.models.qwen3_vl import Qwen3VLMultiModalProcessor
 from vllm.multimodal import MULTIMODAL_REGISTRY
 
 from ...utils import build_model_context
@@ -92,6 +93,46 @@ def test_processor_num_frames_timestamp(
     assert len(video_phs) == 1, (
         f"Expected exactly 1 video placeholder, got {len(video_phs)}"
     )
+
+
+@pytest.mark.parametrize("model_id", [MODEL_ID])
+def test_processor_video_preserves_outer_vision_wrapper(model_id: str) -> None:
+    """Regression test for vllm-project/vllm#46817.
+
+    Transformers >= 5.10 expands only the inner ``<|video_pad|>`` token,
+    keeping the chat template's outer ``<|vision_start|>`` /
+    ``<|vision_end|>`` markers. vLLM must match that behavior instead of
+    replacing the whole ``<|vision_start|><|video_pad|><|vision_end|>``
+    triplet.
+    """
+    num_frames = 8
+    hf_processor_mm_kwargs: dict[str, Any] = {"num_frames": num_frames}
+
+    ctx = build_model_context(
+        model_id,
+        limit_mm_per_prompt={"image": 0, "video": 1},
+    )
+    processor = MULTIMODAL_REGISTRY.create_processor(ctx.model_config)
+    hf_processor = processor.info.get_hf_processor(**hf_processor_mm_kwargs)
+
+    if not Qwen3VLMultiModalProcessor._expands_only_video_token(hf_processor):
+        pytest.skip("Transformers < 5.10 expands the full video placeholder")
+
+    hf_config = processor.info.get_hf_config()
+    prompt = "<|vision_start|><|video_pad|><|vision_end|>"
+    mm_data = _build_video_mm_data(num_frames=num_frames)
+
+    processed = processor(
+        prompt,
+        mm_items=processor.info.parse_mm_data(mm_data),
+        hf_processor_mm_kwargs=hf_processor_mm_kwargs,
+    )
+
+    token_ids = processed["prompt_token_ids"]
+    assert token_ids[0] == hf_config.vision_start_token_id
+    assert token_ids[-1] == hf_config.vision_end_token_id
+    assert token_ids.count(hf_config.vision_start_token_id) == num_frames + 1
+    assert token_ids.count(hf_config.vision_end_token_id) == num_frames + 1
 
 
 @pytest.mark.parametrize("model_id", [MODEL_ID])


### PR DESCRIPTION
## Summary

Fixes #46817 by adding the missing regression test for Qwen3-VL video prompt tokenization.

## Context

Issue #46817 reported that vLLM's video prompt replacement dropped the outer `<|vision_start|>` / `<|vision_end|>` tokens emitted by the Qwen3-VL chat template, producing different `prompt_token_ids` than HuggingFace.

The actual behavior was fixed on `main` by #41359, which made video replacement conditional on the Transformers version:
- Transformers >= 5.10: replace only the inner `<|video_pad|>` token, preserving the outer wrapper.
- Older Transformers: keep the legacy full-placeholder replacement.

However, there was no regression test linked to #46817, so the issue stayed open.

## Changes

- Add `test_processor_video_preserves_outer_vision_wrapper` in `tests/models/multimodal/processing/test_qwen3_vl.py`.
- The test verifies that, for Transformers >= 5.10, the processed prompt preserves the outer vision wrapper and contains exactly `num_frames + 1` vision start/end tokens.

## Related

- Supersedes #46826 and #46957, which predate the conditional fix in #41359 and now have merge conflicts.
