### PR TITLE
[Bugfix][Frontend] Guard remaining before-validators against non-object JSON bodies

### DIFF
--- a/tests/entrypoints/unit_tests/test_non_object_body_validation.py
+++ b/tests/entrypoints/unit_tests/test_non_object_body_validation.py
@@ -1,0 +1,71 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Non-object JSON bodies must fail validation cleanly (4xx), not AttributeError (500).
+
+mode=before validators that call data.get(...) without an isinstance(data, dict)
+guard raise AttributeError for string/list/scalar bodies and surface as HTTP 500.
+
+This extends the chat completion coverage added in #51654 to the remaining
+request models whose before-validators were missing the same guard.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from vllm.entrypoints.openai.completion.protocol import CompletionRequest
+from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
+from vllm.entrypoints.pooling.classify.protocol import ClassificationChatRequest
+from vllm.entrypoints.pooling.embed.protocol import EmbeddingChatRequest
+from vllm.entrypoints.pooling.pooling.protocol import PoolingChatRequest
+from vllm.entrypoints.serve.tokenize.protocol import TokenizeChatRequest
+from vllm.entrypoints.speech_to_text.transcription.protocol import TranscriptionRequest
+from vllm.entrypoints.speech_to_text.translation.protocol import TranslationRequest
+from vllm.exceptions import VLLMValidationError
+
+pytestmark = pytest.mark.skip_global_cleanup
+
+REQUEST_MODELS = [
+    CompletionRequest,
+    ResponsesRequest,
+    EmbeddingChatRequest,
+    ClassificationChatRequest,
+    PoolingChatRequest,
+    TokenizeChatRequest,
+    TranscriptionRequest,
+    TranslationRequest,
+]
+
+
+@pytest.mark.parametrize("request_model", REQUEST_MODELS, ids=lambda m: m.__name__)
+@pytest.mark.parametrize(
+    "payload",
+    [
+        "this is not valid json{{{",
+        ["not", "an", "object"],
+        42,
+        None,
+        True,
+    ],
+)
+def test_request_models_reject_non_object_body(request_model, payload):
+    with pytest.raises(ValidationError):
+        request_model.model_validate(payload)
+
+
+def test_completion_request_still_validates_dict_bodies():
+    """The guard must not swallow real field-level errors on object bodies."""
+    with pytest.raises(VLLMValidationError, match="prompt"):
+        CompletionRequest.model_validate({"model": "qwen", "prompt": ""})
+
+
+def test_tokenize_chat_request_still_validates_dict_bodies():
+    with pytest.raises(VLLMValidationError, match="add_generation_prompt"):
+        TokenizeChatRequest.model_validate(
+            {
+                "model": "qwen",
+                "messages": [{"role": "user", "content": "hello"}],
+                "continue_final_message": True,
+                "add_generation_prompt": True,
+            }
+        )

--- a/vllm/entrypoints/openai/completion/protocol.py
+++ b/vllm/entrypoints/openai/completion/protocol.py
@@ -413,6 +413,8 @@ class CompletionRequest(OpenAIBaseModel):
     @model_validator(mode="before")
     @classmethod
     def validate_response_format(cls, data):
+        if not isinstance(data, dict):
+            return data
         response_format = data.get("response_format")
         if response_format is None:
             return data
@@ -444,6 +446,8 @@ class CompletionRequest(OpenAIBaseModel):
     @model_validator(mode="before")
     @classmethod
     def check_structured_outputs_count(cls, data):
+        if not isinstance(data, dict):
+            return data
         if data.get("structured_outputs", None) is None:
             return data
 
@@ -472,6 +476,8 @@ class CompletionRequest(OpenAIBaseModel):
     @model_validator(mode="before")
     @classmethod
     def check_logprobs(cls, data):
+        if not isinstance(data, dict):
+            return data
         if data.get("logprob_token_ids") and data.get("use_beam_search"):
             raise VLLMValidationError(
                 "`logprob_token_ids` is not supported with beam search.",
@@ -532,6 +538,8 @@ class CompletionRequest(OpenAIBaseModel):
     @model_validator(mode="before")
     @classmethod
     def validate_stream_options(cls, data):
+        if not isinstance(data, dict):
+            return data
         if data.get("stream_options") and not data.get("stream"):
             raise VLLMValidationError(
                 "Stream options can only be defined when `stream=True`.",
@@ -543,6 +551,8 @@ class CompletionRequest(OpenAIBaseModel):
     @model_validator(mode="before")
     @classmethod
     def validate_prompt_and_prompt_embeds(cls, data):
+        if not isinstance(data, dict):
+            return data
         prompt = data.get("prompt")
         prompt_embeds = data.get("prompt_embeds")
 
@@ -562,6 +572,8 @@ class CompletionRequest(OpenAIBaseModel):
     @model_validator(mode="before")
     @classmethod
     def validate_prompt_list_length(cls, data):
+        if not isinstance(data, dict):
+            return data
         max_prompts = envs.VLLM_MAX_COMPLETION_PROMPTS
 
         prompt = data.get("prompt")

--- a/vllm/entrypoints/openai/responses/protocol.py
+++ b/vllm/entrypoints/openai/responses/protocol.py
@@ -467,6 +467,8 @@ class ResponsesRequest(OpenAIBaseModel):
     @model_validator(mode="before")
     @classmethod
     def validate_background(cls, data):
+        if not isinstance(data, dict):
+            return data
         if not data.get("background"):
             return data
         if not data.get("store", True):
@@ -479,6 +481,8 @@ class ResponsesRequest(OpenAIBaseModel):
     @model_validator(mode="before")
     @classmethod
     def validate_prompt(cls, data):
+        if not isinstance(data, dict):
+            return data
         if data.get("prompt") is not None:
             raise VLLMValidationError(
                 "prompt template is not supported", parameter="prompt"
@@ -499,6 +503,8 @@ class ResponsesRequest(OpenAIBaseModel):
 
         Invalid structures are left for Pydantic to reject.
         """
+        if not isinstance(data, dict):
+            return data
         input_data = data.get("input")
 
         # Early return for None, strings, or bytes

--- a/vllm/entrypoints/pooling/base/protocol.py
+++ b/vllm/entrypoints/pooling/base/protocol.py
@@ -239,6 +239,8 @@ class ChatRequestOptionsMixin(OpenAIBaseModel):
     @model_validator(mode="before")
     @classmethod
     def check_generation_prompt(cls, data):
+        if not isinstance(data, dict):
+            return data
         if data.get("continue_final_message") and data.get("add_generation_prompt"):
             raise VLLMValidationError(
                 "Cannot set both `continue_final_message` and "

--- a/vllm/entrypoints/serve/tokenize/protocol.py
+++ b/vllm/entrypoints/serve/tokenize/protocol.py
@@ -120,6 +120,8 @@ class TokenizeChatRequest(OpenAIBaseModel):
     @model_validator(mode="before")
     @classmethod
     def check_generation_prompt(cls, data):
+        if not isinstance(data, dict):
+            return data
         if data.get("continue_final_message") and data.get("add_generation_prompt"):
             raise VLLMValidationError(
                 "Cannot set both `continue_final_message` and "

--- a/vllm/entrypoints/speech_to_text/transcription/protocol.py
+++ b/vllm/entrypoints/speech_to_text/transcription/protocol.py
@@ -285,6 +285,8 @@ class TranscriptionRequest(OpenAIBaseModel):
     @model_validator(mode="before")
     @classmethod
     def validate_transcription_request(cls, data):
+        if not isinstance(data, dict):
+            return data
         if isinstance(data.get("file"), str):
             raise HTTPException(
                 status_code=HTTPStatus.UNPROCESSABLE_ENTITY,

--- a/vllm/entrypoints/speech_to_text/translation/protocol.py
+++ b/vllm/entrypoints/speech_to_text/translation/protocol.py
@@ -271,6 +271,8 @@ class TranslationRequest(OpenAIBaseModel):
     @model_validator(mode="before")
     @classmethod
     def validate_stream_options(cls, data):
+        if not isinstance(data, dict):
+            return data
         stream_opts = ["stream_include_usage", "stream_continuous_usage_stats"]
         stream = data.get("stream", False)
         if any(bool(data.get(so, False)) for so in stream_opts) and not stream:


### PR DESCRIPTION
## Purpose

`mode="before"` model validators call `data.get(...)` directly. When a client sends a JSON body that is not an object (a list, string, number or bool), `data` is not a dict and the validator raises `AttributeError: 'list' object has no attribute 'get'`, which surfaces as **HTTP 500** instead of a 422 validation error.

#51654 ("Fix chat completion 500 on non-object JSON bodies", 48bada6) fixed this for `chat_completion/protocol.py` by adding an `isinstance(data, dict)` guard to each before-validator. That fix did not cover the identical pattern in the other entrypoints. This PR applies the same guard, with the same idiom and placement, to the 13 validators that were missed:

- `vllm/entrypoints/openai/completion/protocol.py` (6): `validate_response_format`, `check_structured_outputs_count`, `check_logprobs`, `validate_stream_options`, `validate_prompt_and_prompt_embeds`, `validate_prompt_list_length`
- `vllm/entrypoints/openai/responses/protocol.py` (3): `validate_background`, `validate_prompt`, `input_item_parsing`
- `vllm/entrypoints/pooling/base/protocol.py` (1): `check_generation_prompt` (in `ChatRequestOptionsMixin`, covering the embed / classify / pooling chat requests)
- `vllm/entrypoints/serve/tokenize/protocol.py` (1): `check_generation_prompt`
- `vllm/entrypoints/speech_to_text/transcription/protocol.py` (1): `validate_transcription_request`
- `vllm/entrypoints/speech_to_text/translation/protocol.py` (1): `validate_stream_options`

I swept all of `vllm/entrypoints/**` for `mode="before"` validators. The remaining ones already have the guard (`openai/run_batch.py`, `pooling/embed/protocol.py`, `responses/protocol.py::check_tool_usage`); `cohere/protocol.py` uses a `field_validator`, which receives the field value rather than the request body, so it is not affected.

### Why this is not duplicating an existing PR

- **#51654** is the merged precedent this PR extends; it deliberately scoped itself to chat completions.
- **#42961** ("Reject non-object JSON bodies with HTTP 400", open since 2026-05-18, no activity since 2026-06-08) addresses the same symptom at a different layer — a body-type check in the `validate_json_request` dependency in `serve/utils/api_utils.py`, returning 400. This PR instead completes the validator-level approach that was merged in #51654, keeping the status code consistent at 422 with the rest of pydantic validation. The two are complementary: if #42961 lands, these guards remain correct and still protect callers that construct these models directly (batch/offline paths, which do not pass through the HTTP dependency).
- **#44537** ("Reject non-object structured_outputs with HTTP 400") concerns a non-object value in the `structured_outputs` *field* of chat completions, not the request body, and does not overlap with these files.

## Test Plan

```bash
pytest tests/entrypoints/unit_tests/test_non_object_body_validation.py -v
pytest tests/entrypoints/openai/chat_completion/test_non_object_body_validation.py -v
pytest tests/entrypoints/pooling/embed/test_protocol.py -v
pre-commit run --all-files
```

An out-of-tree reproducer additionally mounted each affected model on a minimal FastAPI app (model as the request-body parameter, as the entrypoints do) and drove it with `TestClient` to observe the real HTTP status mapping.

## Test Result

New test file, before vs. after the source change:

| | Result |
|---|---|
| Before | `40 failed, 2 passed` |
| After | `42 passed` |

Model-level (`Model.model_validate(payload)` for `[1,2,3]`, `"a string"`, `42`, `None`, `True` across the affected request classes): **40/40 `AttributeError` before → 0/40 after** (all now `pydantic.ValidationError`).

HTTP-level via FastAPI `TestClient`: **32/40 HTTP 500 before → 0 after**. The 8 `null`-body cases already returned 422, because FastAPI rejects a null body before the validators run.

No regressions in the sibling suites. Two failures in `completion/test_prompt_validation.py` (`test_empty_prompt`, `test_out_of_vocab_token_ids`) reproduce identically on unmodified `main` on this machine — they require a live engine and are unrelated.

Model evals were not run: this change only converts crashes into the 422 they should already have been, and does not affect generation, accuracy, or serving behaviour on any valid request.

Note on environment: I developed this on a CPU-only Windows host without `uv`, so `uvloop` was stubbed locally to collect the tests and `pre-commit` hooks beyond `ruff` (mypy, typos, SPDX) were not run here. `ruff check` and `ruff format --check` pass on all changed files.

## AI Assistance Disclosure

This change was developed with AI assistance (noted in the commit trailer per AGENTS.md). I reviewed every changed line, verified each guarded validator against the current tree, and ran the tests and reproducers above.
