### PR TITLE
[Bugfix][Core] Fail requests the KV cache pool can never hold instead of retrying them forever

### DIFF
--- a/tests/v1/core/test_async_scheduler.py
+++ b/tests/v1/core/test_async_scheduler.py
@@ -288,6 +288,7 @@ def test_abort_request_when_structured_output_fsm_cannot_advance():
     scheduler.finished_req_ids = set()
     scheduler.finished_req_ids_dict = None
     scheduler.grammar_compile_error_reqs = set()
+    scheduler.unservable_reqs = set()
     scheduler.vllm_config = Mock()
     scheduler.vllm_config.model_config.enable_return_routed_experts = False
     scheduler.enable_return_routed_experts = False

--- a/tests/v1/core/test_async_scheduler.py
+++ b/tests/v1/core/test_async_scheduler.py
@@ -297,6 +297,8 @@ def test_abort_request_when_structured_output_fsm_cannot_advance():
     scheduler.defer_block_free = False
     scheduler.make_stats = Mock(return_value=None)
     scheduler.max_model_len = 128
+    # Equal to max_model_len whenever the pool covers the whole window.
+    scheduler.max_servable_num_tokens = scheduler.max_model_len
 
     def free_request(req, delay_free_blocks=False):
         scheduler.finished_req_ids.add(req.request_id)

--- a/tests/v1/core/test_kv_pool_unservable_requests.py
+++ b/tests/v1/core/test_kv_pool_unservable_requests.py
@@ -1,0 +1,257 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Requests the KV cache pool can never hold (#52520).
+
+`_check_enough_kv_cache_memory` sizes the pool from each spec's
+`max_memory_usage_bytes`, but `BlockPool` permanently reserves one block as the
+null block, so a pool built at exactly that minimum is one block short of one
+`max_model_len` request. Runtime admission used its own incremental estimate and
+admitted such a request anyway: it prefilled to ~99 % of the pool, was
+descheduled with that work discarded, and was never scheduled again -- a stall
+whose only signal is a `waiting` gauge.
+
+`Scheduler.max_servable_num_tokens` now derives that limit from the same
+`kv_cache_utils` helper the startup check uses, and fails an over-long request at
+admission instead of retrying it.
+"""
+
+import pytest
+import torch
+
+from vllm.config import (
+    CacheConfig,
+    ModelConfig,
+    SchedulerConfig,
+    SpeculativeConfig,
+    VllmConfig,
+)
+from vllm.utils.math_utils import cdiv
+from vllm.v1.core.sched.scheduler import Scheduler
+from vllm.v1.core.single_type_kv_cache_manager import register_all_kvcache_specs
+from vllm.v1.kv_cache_interface import (
+    FullAttentionSpec,
+    KVCacheConfig,
+    KVCacheGroupSpec,
+    MambaSpec,
+)
+from vllm.v1.outputs import ModelRunnerOutput
+from vllm.v1.request import RequestStatus
+from vllm.v1.structured_output import StructuredOutputManager
+
+from .utils import create_requests
+
+pytestmark = pytest.mark.cpu_test
+
+# Shape of the deployment the stall was reported on (hybrid GDN + full attention,
+# MTP depth 3, `--mamba-cache-mode align`), scaled down to unit-test sizes.
+BLOCK_SIZE = 16
+MAX_MODEL_LEN = 64 * BLOCK_SIZE  # 1024
+NUM_SPEC_BLOCKS = 3
+MAX_NUM_BATCHED_TOKENS = 16 * BLOCK_SIZE  # 256; forces a chunked prefill
+
+# Blocks the startup check demands: `cdiv(max_model_len, block_size)` for the
+# full-attention group plus `2 + num_speculative_blocks` for the mamba group in
+# align mode (`MambaSpec.max_memory_usage_bytes`).
+MAMBA_BLOCKS = 2 + NUM_SPEC_BLOCKS
+STARTUP_MIN_BLOCKS = cdiv(MAX_MODEL_LEN, BLOCK_SIZE) + MAMBA_BLOCKS  # 69
+
+# One of those blocks is the null block, so a request can use at most
+# `STARTUP_MIN_BLOCKS - 1 - MAMBA_BLOCKS` blocks of attention KV.
+SERVABLE_LEN = (STARTUP_MIN_BLOCKS - 1 - MAMBA_BLOCKS) * BLOCK_SIZE  # 1008
+
+
+def _full_attention_spec() -> FullAttentionSpec:
+    return FullAttentionSpec(
+        block_size=BLOCK_SIZE, num_kv_heads=1, head_size=1, dtype=torch.float32
+    )
+
+
+def _mamba_spec() -> MambaSpec:
+    return MambaSpec(
+        block_size=BLOCK_SIZE,
+        shapes=((1, 1),),
+        dtypes=(torch.float32,),
+        mamba_cache_mode="align",
+        num_speculative_blocks=NUM_SPEC_BLOCKS,
+        # Hybrid pools pad every group's page up to a common size; the bound
+        # helpers require that uniformity.
+        page_size_padded=_full_attention_spec().page_size_bytes,
+    )
+
+
+def _make_scheduler(num_blocks: int) -> Scheduler:
+    model_config = ModelConfig(
+        model="facebook/opt-125m",
+        trust_remote_code=True,
+        dtype="float16",
+        seed=42,
+        skip_tokenizer_init=True,
+        max_model_len=MAX_MODEL_LEN,
+    )
+    vllm_config = VllmConfig(
+        scheduler_config=SchedulerConfig(
+            max_num_seqs=1,
+            max_num_batched_tokens=MAX_NUM_BATCHED_TOKENS,
+            max_model_len=MAX_MODEL_LEN,
+            enable_chunked_prefill=True,
+            is_encoder_decoder=False,
+            watermark=0.0,
+        ),
+        model_config=model_config,
+        cache_config=CacheConfig(
+            block_size=BLOCK_SIZE,
+            enable_prefix_caching=True,
+            mamba_cache_mode="align",
+        ),
+        speculative_config=SpeculativeConfig(
+            model="ngram",
+            method="ngram",
+            num_speculative_tokens=NUM_SPEC_BLOCKS,
+            prompt_lookup_max=NUM_SPEC_BLOCKS,
+            prompt_lookup_min=1,
+        ),
+    )
+    vllm_config.cache_config.num_gpu_blocks = num_blocks
+    kv_cache_config = KVCacheConfig(
+        num_blocks=num_blocks,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(["full_attn"], _full_attention_spec()),
+            KVCacheGroupSpec(["mamba"], _mamba_spec()),
+        ],
+    )
+    register_all_kvcache_specs(vllm_config)
+    return Scheduler(
+        vllm_config=vllm_config,
+        kv_cache_config=kv_cache_config,
+        structured_output_manager=StructuredOutputManager(vllm_config),
+        block_size=BLOCK_SIZE,
+        hash_block_size=BLOCK_SIZE,
+        log_stats=True,
+    )
+
+
+def _model_output(scheduler_output, sample: bool) -> ModelRunnerOutput:
+    req_ids = list(scheduler_output.num_scheduled_tokens)
+    return ModelRunnerOutput(
+        req_ids=req_ids,
+        req_id_to_index={req_id: i for i, req_id in enumerate(req_ids)},
+        sampled_token_ids=[[1000] if sample else [] for _ in req_ids],
+        logprobs=None,
+        prompt_logprobs_dict={},
+        pooler_output=[],
+    )
+
+
+def _run(scheduler: Scheduler, request, max_steps: int = 64) -> int:
+    """Step until the request finishes; return the peak computed token count."""
+    peak = 0
+    for _ in range(max_steps):
+        scheduler_output = scheduler.schedule()
+        peak = max(peak, request.num_computed_tokens)
+        scheduler.update_from_output(
+            scheduler_output,
+            _model_output(
+                scheduler_output,
+                request.num_computed_tokens >= request.num_prompt_tokens,
+            ),
+        )
+        if request.is_finished():
+            break
+    return peak
+
+
+def test_max_servable_num_tokens_reserves_the_null_block():
+    """The bound must exclude the null block and the mamba group's own blocks."""
+    scheduler = _make_scheduler(STARTUP_MIN_BLOCKS)
+    assert scheduler.max_servable_num_tokens == SERVABLE_LEN
+    # A pool built at the startup minimum cannot serve the whole window: that
+    # asymmetry is what admission has to see.
+    assert scheduler.max_servable_num_tokens < MAX_MODEL_LEN
+    # One more block covers it, and then the bound must not bite at all.
+    assert _make_scheduler(STARTUP_MIN_BLOCKS + 1).max_servable_num_tokens >= (
+        MAX_MODEL_LEN
+    )
+
+
+def test_unservable_request_is_failed_not_prefilled_and_retried():
+    """A request past the bound must never be scheduled, and must not linger.
+
+    Before the fix it was admitted, chunk-prefilled to `SERVABLE_LEN` tokens,
+    descheduled when the last chunk could not be allocated, and then refused by
+    the same gate on every later step -- zero output tokens, forever.
+    """
+    scheduler = _make_scheduler(STARTUP_MIN_BLOCKS)
+    [request] = create_requests(
+        num_requests=1,
+        num_tokens=MAX_MODEL_LEN - 1,
+        max_tokens=1,
+        block_size=BLOCK_SIZE,
+    )
+    scheduler.add_request(request)
+
+    scheduler_output = scheduler.schedule()
+    assert not scheduler_output.num_scheduled_tokens
+    assert request.num_computed_tokens == 0
+
+    scheduler.update_from_output(
+        scheduler_output, _model_output(scheduler_output, False)
+    )
+    assert request.status == RequestStatus.FINISHED_IGNORED
+    assert request.num_preemptions == 0
+    assert not scheduler.has_unfinished_requests()
+
+
+def test_request_at_the_bound_is_failed_because_it_needs_an_output_slot():
+    """`max_servable_num_tokens` is a sequence length, not a prompt length."""
+    scheduler = _make_scheduler(STARTUP_MIN_BLOCKS)
+    [request] = create_requests(
+        num_requests=1,
+        num_tokens=SERVABLE_LEN,
+        max_tokens=1,
+        block_size=BLOCK_SIZE,
+    )
+    scheduler.add_request(request)
+
+    scheduler_output = scheduler.schedule()
+    assert not scheduler_output.num_scheduled_tokens
+    scheduler.update_from_output(
+        scheduler_output, _model_output(scheduler_output, False)
+    )
+    assert request.status == RequestStatus.FINISHED_IGNORED
+
+
+def test_servable_request_at_the_same_pool_still_runs():
+    """The bound must not reject a request the pool can actually hold."""
+    scheduler = _make_scheduler(STARTUP_MIN_BLOCKS)
+    [request] = create_requests(
+        num_requests=1,
+        num_tokens=SERVABLE_LEN - 1,
+        max_tokens=1,
+        block_size=BLOCK_SIZE,
+    )
+    scheduler.add_request(request)
+
+    peak = _run(scheduler, request)
+    assert peak == SERVABLE_LEN - 1
+    assert request.num_preemptions == 0
+    assert request.num_output_tokens == 1
+    assert request.status == RequestStatus.FINISHED_LENGTH_CAPPED
+
+
+def test_pool_with_headroom_serves_the_whole_window():
+    """One block of headroom restores the pre-fix behaviour exactly."""
+    scheduler = _make_scheduler(STARTUP_MIN_BLOCKS + 1)
+    [request] = create_requests(
+        num_requests=1,
+        num_tokens=MAX_MODEL_LEN - 1,
+        max_tokens=1,
+        block_size=BLOCK_SIZE,
+    )
+    scheduler.add_request(request)
+
+    peak = _run(scheduler, request)
+    assert peak == MAX_MODEL_LEN - 1
+    assert request.num_preemptions == 0
+    assert request.num_output_tokens == 1
+    assert request.status == RequestStatus.FINISHED_LENGTH_CAPPED

--- a/tests/v1/core/test_kv_pool_unservable_requests.py
+++ b/tests/v1/core/test_kv_pool_unservable_requests.py
@@ -11,8 +11,10 @@ descheduled with that work discarded, and was never scheduled again -- a stall
 whose only signal is a `waiting` gauge.
 
 `Scheduler.max_servable_num_tokens` now derives that limit from the same
-`kv_cache_utils` helper the startup check uses, and fails an over-long request at
-admission instead of retrying it.
+`kv_cache_utils` helper the startup check uses. It bounds a request from both
+ends: a prompt already past it is failed at admission instead of being retried,
+and a generate request that would grow past it stops there as a length cap
+instead of being preempted at that token into a queue it can no longer leave.
 """
 
 import pytest
@@ -255,3 +257,71 @@ def test_pool_with_headroom_serves_the_whole_window():
     assert request.num_preemptions == 0
     assert request.num_output_tokens == 1
     assert request.status == RequestStatus.FINISHED_LENGTH_CAPPED
+
+
+# The decode case. A prompt this long clears the frontend's
+# `prompt + max_tokens <= max_model_len` check and admission's
+# `prompt + 1 <= max_servable_num_tokens` check, and then generation walks the
+# sequence past the ceiling: there are only `SERVABLE_LEN - DECODE_PROMPT_LEN`
+# output slots under it, out of `DECODE_MAX_TOKENS` asked for.
+DECODE_PROMPT_LEN = SERVABLE_LEN - 8  # 1000
+DECODE_MAX_TOKENS = MAX_MODEL_LEN - DECODE_PROMPT_LEN  # 24
+
+
+def test_generation_stops_at_the_bound_instead_of_stalling_mid_decode():
+    """A generate request must not be preempted into a queue it cannot leave.
+
+    Both length checks pass, so the request runs. At output token 9 the
+    sequence would need a block the pool does not have. Unfixed, it is
+    preempted there -- and is then longer than the pool can re-prefill, so it
+    is never scheduled again: output frozen mid-answer, one preemption, and
+    `waiting` non-empty forever. The pool's ceiling is a length cap, so the
+    request must stop on it with the tokens it produced.
+    """
+    scheduler = _make_scheduler(STARTUP_MIN_BLOCKS)
+    [request] = create_requests(
+        num_requests=1,
+        num_tokens=DECODE_PROMPT_LEN,
+        max_tokens=DECODE_MAX_TOKENS,
+        ignore_eos=True,
+        block_size=BLOCK_SIZE,
+    )
+    # Precisely the case the admission gate lets through.
+    assert request.num_tokens + 1 <= scheduler.max_servable_num_tokens
+    assert request.num_tokens + DECODE_MAX_TOKENS > scheduler.max_servable_num_tokens
+    scheduler.add_request(request)
+
+    peak = _run(scheduler, request)
+
+    assert request.status == RequestStatus.FINISHED_LENGTH_CAPPED
+    assert request.num_tokens == SERVABLE_LEN
+    assert request.num_output_tokens == SERVABLE_LEN - DECODE_PROMPT_LEN
+    assert request.num_preemptions == 0
+    assert peak <= SERVABLE_LEN
+    assert not scheduler.has_unfinished_requests()
+
+
+def test_generation_is_not_capped_when_the_pool_covers_the_window():
+    """The cap must not shorten an answer the pool can actually hold.
+
+    Same request, one block of headroom: it must produce every token it asked
+    for, so the bound cannot be silently truncating generation in the normal
+    case.
+    """
+    scheduler = _make_scheduler(STARTUP_MIN_BLOCKS + 1)
+    assert scheduler.max_servable_num_tokens >= MAX_MODEL_LEN
+    [request] = create_requests(
+        num_requests=1,
+        num_tokens=DECODE_PROMPT_LEN,
+        max_tokens=DECODE_MAX_TOKENS,
+        ignore_eos=True,
+        block_size=BLOCK_SIZE,
+    )
+    scheduler.add_request(request)
+
+    _run(scheduler, request)
+
+    assert request.status == RequestStatus.FINISHED_LENGTH_CAPPED
+    assert request.num_output_tokens == DECODE_MAX_TOKENS
+    assert request.num_tokens == MAX_MODEL_LEN
+    assert request.num_preemptions == 0

--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -3278,6 +3278,7 @@ def test_abort_request_when_structured_output_fsm_cannot_advance():
     scheduler.finished_req_ids = set()
     scheduler.finished_req_ids_dict = None
     scheduler.grammar_compile_error_reqs = set()
+    scheduler.unservable_reqs = set()
     scheduler.vllm_config = Mock()
     scheduler.vllm_config.model_config.enable_return_routed_experts = False
     scheduler.enable_return_routed_experts = False

--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -3287,6 +3287,8 @@ def test_abort_request_when_structured_output_fsm_cannot_advance():
     scheduler.defer_block_free = False
     scheduler.make_stats = Mock(return_value=None)
     scheduler.max_model_len = 128
+    # Equal to max_model_len whenever the pool covers the whole window.
+    scheduler.max_servable_num_tokens = scheduler.max_model_len
 
     def free_request(req: Request, delay_free_blocks: bool = False):
         scheduler.finished_req_ids.add(req.request_id)

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -1973,6 +1973,44 @@ def _estimate_max_model_len_from_groups(
         vllm_config.model_config.max_model_len = original_max
 
 
+def max_servable_num_tokens(
+    vllm_config: VllmConfig,
+    kv_cache_groups: list[KVCacheGroupSpec],
+    num_blocks: int,
+) -> int | None:
+    """
+    The longest sequence a pool of `num_blocks` blocks can hold for one request.
+
+    `BlockPool` permanently reserves one block as the null block, so only
+    `num_blocks - 1` blocks are ever available to a request.
+
+    This is the same bound `_check_enough_kv_cache_memory` reports as "the
+    estimated maximum model length", evaluated against the block count the pool
+    was actually built with. Sharing one function between the startup pool sizer
+    and the runtime admission gate is what keeps them from drifting; when they
+    drift, the engine admits requests that no future pool state can hold
+    (#52520). #40946 did the same for SWA / chunked-local attention.
+
+    Returns `None` when the groups cannot be priced per block, i.e. exactly when
+    the pool itself was not sized per block, so this never invents a bound the
+    startup check did not apply.
+    """
+    if not kv_cache_groups:
+        return None
+    if (
+        len(kv_cache_groups) > 1
+        and len({g.kv_cache_spec.page_size_bytes for g in kv_cache_groups}) > 1
+        and not _use_packed_kv_cache_config(vllm_config, kv_cache_groups)
+    ):
+        return None
+    usable_blocks = max(num_blocks - 1, 0)
+    return _estimate_max_model_len_from_groups(
+        vllm_config,
+        kv_cache_groups,
+        usable_blocks * _pool_bytes_per_block(vllm_config, kv_cache_groups),
+    )
+
+
 def _auto_fit_max_model_len(
     vllm_config: VllmConfig,
     projected_groups_per_worker: list[list[KVCacheGroupSpec]],

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -302,13 +302,16 @@ class Scheduler(SchedulerInterface):
         # Longest sequence this pool can hold for one request, from the same
         # per-spec bounds the startup check uses. Normally >= max_model_len,
         # because that check refuses to size a pool that cannot serve one
-        # max_model_len request. When it is smaller, a request beyond it can
-        # never be scheduled at any future time, however much drains, so it is
-        # failed at admission (see `add_request`) rather than retried forever
-        # (#52520). Falsy means there is no per-block bound to enforce -- `None`
-        # for layouts the startup check cannot price either, `0` for a pool with
-        # no usable blocks -- and the frontend's `max_model_len` check stands
-        # alone, exactly as before.
+        # max_model_len request. When it is smaller, a sequence beyond it can
+        # never be scheduled at any future time, however much drains, so it
+        # bounds a request from both ends rather than being retried forever
+        # (#52520): a prompt already past it is failed at admission (see
+        # `add_request`), and a generate request that would grow past it stops
+        # there as a length cap (see `_update_request_with_output`). Falsy
+        # means there is no per-block bound to enforce -- `None` for layouts
+        # the startup check cannot price either, `0` for a pool with no usable
+        # blocks -- and the frontend's `max_model_len` check stands alone,
+        # exactly as before.
         self.max_servable_num_tokens: int = (
             max_servable_num_tokens(
                 vllm_config, kv_cache_config.kv_cache_groups, kv_cache_config.num_blocks
@@ -319,11 +322,13 @@ class Scheduler(SchedulerInterface):
             logger.error(
                 "The KV cache pool (%d blocks) can hold at most %d tokens for a "
                 "single request, which is less than max_model_len (%d). Requests "
-                "longer than %d tokens will be rejected. Increase "
-                "`gpu_memory_utilization` or decrease `max_model_len`.",
+                "longer than %d tokens will be rejected, and generation stops at "
+                "%d tokens. Increase `gpu_memory_utilization` or decrease "
+                "`max_model_len`.",
                 kv_cache_config.num_blocks,
                 self.max_servable_num_tokens,
                 self.max_model_len,
+                self.max_servable_num_tokens,
                 self.max_servable_num_tokens,
             )
 
@@ -2243,7 +2248,16 @@ class Scheduler(SchedulerInterface):
 
             # Check for stop and update request state.
             # This must be called before we make the EngineCoreOutput.
-            stopped = check_stop(request, self.max_model_len)
+            # The length cap is `max_servable_num_tokens`, not `max_model_len`:
+            # they are equal unless the pool cannot cover the whole window, and
+            # when they differ, growing past the pool's ceiling costs the
+            # request a block that no future pool state has. It would be
+            # preempted at that token and then be too long to re-prefill --
+            # #52520 again, reached through decode instead of prefill. Stopping
+            # here returns the tokens already streamed with `finish_reason:
+            # length`, exactly as if `max_model_len` had been set to what the
+            # pool can serve.
+            stopped = check_stop(request, self.max_servable_num_tokens)
             if stopped:
                 del new_token_ids[num_new:]  # Trim new tokens if needed.
                 break

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -37,7 +37,7 @@ from vllm.v1.core.encoder_cache_manager import (
 )
 from vllm.v1.core.kv_cache_manager import KVCacheBlocks, KVCacheManager
 from vllm.v1.core.kv_cache_metrics import KVCacheMetricsCollector
-from vllm.v1.core.kv_cache_utils import KVCacheBlock
+from vllm.v1.core.kv_cache_utils import KVCacheBlock, max_servable_num_tokens
 from vllm.v1.core.sched.interface import PauseState, SchedulerInterface
 from vllm.v1.core.sched.output import (
     CachedRequestData,
@@ -211,6 +211,10 @@ class Scheduler(SchedulerInterface):
         # update_from_output.
         self.grammar_compile_error_reqs: set[str] = set()
 
+        # Requests longer than `max_servable_num_tokens` (below), finished as
+        # per-request length errors in update_from_output.
+        self.unservable_reqs: set[str] = set()
+
         # Encoder-related.
         # Calculate encoder cache size if applicable
         supports_mm_inputs = mm_registry.supports_multimodal_inputs(
@@ -294,6 +298,34 @@ class Scheduler(SchedulerInterface):
         # kv_cache_manager is constructed so block_pool is available.
         if self.connector is not None:
             self.connector.bind_gpu_block_pool(self.kv_cache_manager.block_pool)
+
+        # Longest sequence this pool can hold for one request, from the same
+        # per-spec bounds the startup check uses. Normally >= max_model_len,
+        # because that check refuses to size a pool that cannot serve one
+        # max_model_len request. When it is smaller, a request beyond it can
+        # never be scheduled at any future time, however much drains, so it is
+        # failed at admission (see `add_request`) rather than retried forever
+        # (#52520). Falsy means there is no per-block bound to enforce -- `None`
+        # for layouts the startup check cannot price either, `0` for a pool with
+        # no usable blocks -- and the frontend's `max_model_len` check stands
+        # alone, exactly as before.
+        self.max_servable_num_tokens: int = (
+            max_servable_num_tokens(
+                vllm_config, kv_cache_config.kv_cache_groups, kv_cache_config.num_blocks
+            )
+            or self.max_model_len
+        )
+        if self.max_servable_num_tokens < self.max_model_len:
+            logger.error(
+                "The KV cache pool (%d blocks) can hold at most %d tokens for a "
+                "single request, which is less than max_model_len (%d). Requests "
+                "longer than %d tokens will be rejected. Increase "
+                "`gpu_memory_utilization` or decrease `max_model_len`.",
+                kv_cache_config.num_blocks,
+                self.max_servable_num_tokens,
+                self.max_model_len,
+                self.max_servable_num_tokens,
+            )
 
         self.use_pp = self.parallel_config.pipeline_parallel_size > 1
         self.use_v2_model_runner = vllm_config.use_v2_model_runner
@@ -2055,6 +2087,25 @@ class Scheduler(SchedulerInterface):
                     )
                 )
 
+        if self.unservable_reqs:
+            # Requests the pool can never hold. FINISHED_IGNORED is upstream's
+            # status for "prompt longer than the model's length cap"; the
+            # actionable maximum servable length is logged in `add_request`.
+            ignored_reqs = self.finish_requests(
+                self.unservable_reqs, RequestStatus.FINISHED_IGNORED
+            )
+            self.unservable_reqs.clear()
+            for request in ignored_reqs:
+                outputs[request.client_index].append(
+                    EngineCoreOutput(
+                        request_id=request.request_id,
+                        new_token_ids=[],
+                        finish_reason=request.get_finished_reason(),
+                        events=request.take_events(),
+                        trace_headers=request.trace_headers,
+                    )
+                )
+
         # KV Connector: update state for finished KV Transfers.
         if kv_connector_output:
             self._update_from_kv_xfer_finished(kv_connector_output)
@@ -2298,6 +2349,22 @@ class Scheduler(SchedulerInterface):
         """Returns the fraction of the KV cache currently in use (0.0-1.0)."""
         return self.kv_cache_manager.usage
 
+    def _is_unservable(self, request: Request) -> bool:
+        """Whether no future pool state can ever hold this request.
+
+        Mirrors the frontend's `max_model_len` validation: a generate request
+        also needs a slot for the token it will produce, so a prompt exactly at
+        the bound is already too long.
+        """
+        if self.max_servable_num_tokens >= self.max_model_len:
+            # The common case: the pool covers the whole window, so the
+            # frontend's `max_model_len` check is the only bound that bites.
+            return False
+        num_tokens = request.num_tokens
+        if request.pooling_params is None:
+            num_tokens += 1
+        return num_tokens > self.max_servable_num_tokens
+
     def add_request(self, request: Request) -> None:
         existing = self.requests.get(request.request_id)
         if existing is not None:
@@ -2313,6 +2380,19 @@ class Scheduler(SchedulerInterface):
                 # Streaming-input session finished.
                 self.finish_requests(request.request_id, RequestStatus.FINISHED_ABORTED)
         else:
+            if self._is_unservable(request):
+                logger.error(
+                    "Request %s (%d tokens) needs more KV cache blocks than the "
+                    "whole pool holds; no future pool state can schedule it. The "
+                    "maximum servable length is %d tokens. Failing the request "
+                    "instead of retrying it.",
+                    request.request_id,
+                    request.num_tokens,
+                    self.max_servable_num_tokens,
+                )
+                self.requests[request.request_id] = request
+                self.unservable_reqs.add(request.request_id)
+                return
             if request.resumable:
                 request.streaming_queue = deque()
             self._enqueue_waiting_request(request)
@@ -2477,7 +2557,9 @@ class Scheduler(SchedulerInterface):
             + len(self.skipped_waiting)
             - self.num_waiting_for_streaming_input
         )
-        return num_waiting + len(self.running)
+        # `unservable_reqs` are in no queue: they are finished by the next
+        # `update_from_output`, which must still be reached.
+        return num_waiting + len(self.running) + len(self.unservable_reqs)
 
     def has_finished_requests(self) -> bool:
         if self.finished_req_ids:


### PR DESCRIPTION
## Purpose

Fixes #52520.

### The symptom

On a hybrid Mamba + full-attention model with `--mamba-cache-mode align`, a request
whose length is near the KV pool ceiling is **accepted**, chunk-prefilled to ~99 % of
the pool, descheduled when the last chunk cannot be allocated — and then never
scheduled again. Zero output tokens, the whole prefill discarded, and the only
observable is `vllm:num_requests_waiting_by_reason{reason="capacity"} = 1`, which is
indistinguishable from a healthy server that is momentarily full. The HTTP request
never returns.

The engine boots happily into this state: `_check_enough_kv_cache_memory` passes.

### The mechanism

Two bounds describe the same quantity — how many blocks one `max_model_len` request
can hold at once — and they are computed by different code that does not agree.

**Startup** sizes the pool from each spec's `max_memory_usage_bytes`
(`vllm/v1/core/kv_cache_utils.py:2189-2198`). For a hybrid Mamba model in align mode
that is `cdiv(max_model_len, block_size)` blocks for the attention group plus
`2 + num_speculative_blocks` for the Mamba group
(`vllm/v1/kv_cache_interface.py:687-696`). It compares that against **all** the
blocks the pool will have. But `BlockPool` permanently reserves one block as the null
block (`vllm/v1/core/block_pool.py:188-191`), so only `num_blocks - 1` are ever
available to a request. A pool built at exactly the startup minimum is one usable
block short of one `max_model_len` request, and startup does not notice.

**Runtime admission** (`vllm/v1/core/kv_cache_manager.py:475-491`, reached with
`scheduler_reserve_full_isl` — default `True`) asks the coordinator for the same
quantity, but through the per-step allocators. For the Mamba align group that path
returns `1 + num_speculative_blocks` on a first prefill
(`vllm/v1/core/single_type_kv_cache_manager.py:1529-1540`), one block below the peak
the spec itself states, because a later step allocates the next state block before
`remove_skipped_blocks` retires the one from two steps ago. So admission asks for one
block *less* than the pool is short by, and admits.

The request then chunk-prefills until the final chunk needs the block that does not
exist. It is the only running request, so it preempts itself
(`vllm/v1/core/sched/scheduler.py:676-688`): `num_computed_tokens` back to 0, all
blocks freed, requeued. On the next step the same gate now also has to count the
blocks the discarded prefill left in the prefix cache as evictable, so it refuses —
and keeps refusing. The request is stuck, and the prefill is gone.

Measured on unmodified `main` at `4d2a68d64d9e05921ed5c4099146e768a92d71d5`, CPU only,
no model weights: hybrid full-attention + Mamba(align), `block_size=16`,
`max_model_len=1024`, `num_speculative_blocks=3`, `max_num_batched_tokens=256`. The
startup bound is `cdiv(1024,16)=64 + (2+3)=5 = 69` blocks, and
`get_kv_cache_configs` accepts a 69-block pool:

```text
pool of 69 blocks: startup check accepts=True (num_blocks=69)
  pool=69 blocks, free at start=68 (one block is BlockPool's null block)
    step   0 scheduled=  256 computed=  256 free= 48 status=RUNNING preemptions=0
    step   1 scheduled=  256 computed=  512 free= 31 status=RUNNING preemptions=0
    step   2 scheduled=  256 computed=  768 free= 15 status=RUNNING preemptions=0
    step   3 scheduled=  240 computed= 1008 free=  0 status=RUNNING preemptions=0
    step   4 scheduled=    0 computed=    0 free= 68 status=PREEMPTED preemptions=1
    step   5 scheduled=    0 computed=    0 free= 68 status=PREEMPTED preemptions=1
    ... 19 more identical steps ...
  VERDICT prompt=1023: finished=False computed=0 preemptions=1 status=PREEMPTED

pool of 70 blocks: startup check accepts=True (num_blocks=70)
    step   3 scheduled=  240 computed= 1008 free=  1 status=RUNNING preemptions=0
    step   4 scheduled=   15 computed= 1023 free=  0 status=RUNNING preemptions=0
  VERDICT prompt=1023: finished=False computed=1023 preemptions=0 status=RUNNING
```

One block of headroom is the entire difference. Note that the prefill dies at exactly
1008 tokens, which is `(69 - 1 - 5) * 16` — the sequence length the pool can actually
serve.

### The fix

One function computes the bound, and it is the function the startup error message
already uses:

- `max_servable_num_tokens(vllm_config, kv_cache_groups, num_blocks)` in
  `kv_cache_utils.py` — the longest sequence a pool of `num_blocks` blocks can hold
  for one request. It is `_estimate_max_model_len_from_groups` (the helper behind
  "the estimated maximum model length" that `_check_enough_kv_cache_memory` prints)
  evaluated against `num_blocks - 1` blocks, i.e. against the capacity `BlockPool`
  will actually hand out. It returns `None` for group layouts that cannot be priced
  per block — exactly the layouts whose pool was not sized per block either — so it
  never invents a bound the startup check did not apply.
- `Scheduler` evaluates it once at construction. When it is below `max_model_len` the
  configuration cannot serve its own window, which is logged at `ERROR` with the
  number the operator needs. A request past the bound can never be scheduled at any
  future time, however much drains, so `add_request` fails it immediately instead of
  queueing it: no prefill is spent, nothing is preempted, and the client gets a
  terminal response rather than a request that never returns.

So there is one bound with two call sites, which is the point:
`_estimate_max_model_len_from_groups` is called by the startup check
(`kv_cache_utils.py:2234`, via `_check_enough_kv_cache_memory`) and now by
`max_servable_num_tokens`, which is what the scheduler admits against. Neither side
can grow its own formula without the other seeing it.

The failure uses `RequestStatus.FINISHED_IGNORED`, which `vllm/v1/request.py` already
documents as the status for "requests whose prompt lengths are longer than the
model's length cap", mapping to `finish_reason="length"`. `FinishReason.ERROR` is
documented as a *retryable* internal error always converted to a 500, which is the
wrong contract here. Returning a literal 400 would mean exposing the pool-derived
bound to `input_processor._validate_prompt_len`, where `max_model_len` is validated;
happy to do that in a follow-up if maintainers prefer it — it is a frontend/engine-core
plumbing change and I kept it out of this PR.

Behaviour is unchanged whenever the pool covers `max_model_len`, which is every
correctly-sized deployment: the bound is then `>= max_model_len`, `_is_unservable`
short-circuits on the first comparison, and nothing is rejected. The 70-block row
above is byte-for-byte identical before and after.

### Relationship to #47272 — scoped around it, not a duplicate

I read #47272 ("Reserve the KV null block when validating `max_model_len`") before
writing any code, and this PR is deliberately scoped around it.

- **#47272 owns the capacity side.** It subtracts one block from the memory the
  startup check validates against, so a pool that cannot serve `max_model_len` is
  refused at boot with the existing message naming the estimated maximum model
  length. That is the right place for it and this PR does not touch that code path.
  Applied to the reproduction above, #47272 makes the 69-block pool illegal at
  startup — which is a better outcome than anything the scheduler can do, and is why
  I am not proposing an alternative to it.
- **This PR owns the request side.** It makes the runtime bound the same function as
  the startup bound, and gives the engine an answer for a request it cannot serve
  other than retrying it. That is needed independently of #47272, because the
  scheduler currently has *no* concept of "this request can never be scheduled": it
  only distinguishes "not now". If #47272 lands, this PR's check becomes dormant on
  correctly-sized pools (bound `>= max_model_len`) and remains the backstop for the
  paths #47272 does not cover — notably `_auto_fit_max_model_len`, which runs before
  #47272's reservation and can still land on the boundary.
- The two compose cleanly and neither subsumes the other. **Please do not merge this
  instead of #47272.**

Other prior art I checked: **#40946** (merged) is the design precedent — it fixed the
same class of defect (startup pool sizing and runtime admission using different
formulas) for SWA/chunked-local by putting the bound in one method called from both
sites, and this PR follows that shape. **#35541** (closed not-planned/stale) asked for
"abort requests that can never fit in the KV cache block pool with a clear error
rather than hanging indefinitely" — this is that, for the mechanism above. **#40384**
is why the numbers here are stated in blocks and tokens rather than inverted from the
`GPU KV cache size` log line, which on a hybrid model is
`num_blocks // len(kv_cache_groups) * min_block_size`.

### Scope of the claim

The field trace in #52520 came from a **downstream fork build** on a hybrid Qwen3.5
model (261,794-token request, `--enable-prefix-caching --mamba-cache-mode align`, MTP
depth 3, pool within ~1 % of the window; 63 full re-prefills over 656 s with zero
output tokens). The mechanism above is upstream code, and everything in this PR is
demonstrated on **stock `main` at `4d2a68d64d9e05921ed5c4099146e768a92d71d5`** by the
CPU-only unit test below — no GPU, no model weights, no fork code involved.

One part of the original report I could **not** reproduce on `main` and am therefore
not claiming: `vllm:num_preemptions_total` staying at `0.0` across the re-prefills.
On `main` the self-preemption path does increment `request.num_preemptions` and record
`EngineCoreEventType.PREEMPTED`, which `IterationStats` counts into
`vllm:num_preemptions_total`. So there is no accounting fix here, and I am not filing
one. (With this PR the point is moot for this defect: nothing is preempted, because
nothing is admitted, and the operator gets two `ERROR` lines naming the limit.)

### The decode case, added in the second commit

Review raised it and I measured it on the same stock-`main` harness: the admission
gate bounds a request on `num_tokens + 1`, but a generate request grows to
`prompt + max_tokens`. With `block_size` 16, `max_model_len` 1024 and the 69-block
pool above (`max_servable_num_tokens` 1008), `prompt=1000, max_tokens=24` clears the
frontend (`1000 + 24 <= 1024`, `vllm/renderers/params.py:210,442`) and clears
admission (`1000 + 1 <= 1008`), and then reaches 1009 tokens at output token 9. On
`main` it is preempted there, is now too long to re-prefill, and the next **3987
scheduler steps schedule zero tokens, produce no output and leave all 68 blocks
free** — the same terminal state as the prefill case, reached through decode.

Bounding admission on `num_tokens + max_tokens` would close it, but would refuse
requests that stop well before the wall: on that same pool, `max_tokens=8` runs to
completion in 12 steps. So the ceiling is applied where it belongs, as a length cap:
`check_stop` takes `max_servable_num_tokens` instead of `max_model_len`. Those are
equal on every pool that covers its window — `_estimate_max_model_len_from_groups`
searches with `right = original_max` (`vllm/v1/core/kv_cache_utils.py:1960`), and the
scheduler falls back to `max_model_len` when there is no per-block bound — so the
common path is unchanged. Where they differ the request stops on the ceiling and
returns its tokens with `finish_reason: length`, exactly as if `max_model_len` had
been set to what the pool can serve.

That is one bound with three call sites: startup sizing, admission, and the length
cap.

The spec-decode lookahead can also reach past the ceiling, because the running path
asks for `1 + len(spec_token_ids)` slots. Measured on stock `main` with drafts
injected: it preempts twice and then finishes, because preemption clears
`spec_token_ids` and the retry decodes into the cap. Bounded and self-correcting, so
`sched/scheduler.py:605` is left alone.

## Test Plan

```bash
pytest tests/v1/core/test_kv_pool_unservable_requests.py
# surrounding suite, unchanged behaviour:
pytest tests/v1/core/
```

`tests/v1/core/test_kv_pool_unservable_requests.py` is CPU-only
(`pytestmark = pytest.mark.cpu_test`), built the same way as
`tests/v1/core/test_mamba_align_chunk_split.py`: a real `Scheduler` over a hand-built
hybrid `KVCacheConfig`, driven with `schedule()` / `update_from_output()`. No model
weights, no GPU. Seven cases:

1. `test_max_servable_num_tokens_reserves_the_null_block` — the bound is
   `(69 - 1 - 5) * 16 = 1008` at the startup minimum, and `>= max_model_len` with one
   block of headroom.
2. `test_unservable_request_is_failed_not_prefilled_and_retried` — the regression
   test. A 1023-token request on the 69-block pool: nothing is scheduled, it is
   finished as `FINISHED_IGNORED`, `num_computed_tokens == 0`,
   `num_preemptions == 0`, and no unfinished request is left behind.
3. `test_request_at_the_bound_is_failed_because_it_needs_an_output_slot` — the bound
   is a sequence length, so a prompt of exactly 1008 is already too long (it was the
   one length that prefilled fully on `main` and then stalled on its first decode
   step).
4. `test_servable_request_at_the_same_pool_still_runs` — 1007 tokens on the *same*
   69-block pool prefills fully, decodes, and finishes. The bound must not
   over-reject.
5. `test_pool_with_headroom_serves_the_whole_window` — 1023 tokens on a 70-block pool
   behaves exactly as before this PR.
6. `test_generation_stops_at_the_bound_instead_of_stalling_mid_decode` — the decode
   regression test. `prompt=1000, max_tokens=24` on the 69-block pool clears both
   length checks, then must finish `FINISHED_LENGTH_CAPPED` at 1008 tokens with
   `num_preemptions == 0` and nothing left unfinished.
7. `test_generation_is_not_capped_when_the_pool_covers_the_window` — the same request
   with one block of headroom must still produce all 24 tokens, so the length cap
   cannot silently truncate generation on the common path.

## Test Result

The new file, checked out on top of unmodified `main` at `4d2a68d6` (the fix reverted,
the test kept), fails:

```text
$ git checkout HEAD -- vllm/ && pytest tests/v1/core/test_kv_pool_unservable_requests.py -q
FAILED test_max_servable_num_tokens_reserves_the_null_block
  - AttributeError: 'Scheduler' object has no attribute 'max_servable_num_tokens'
FAILED test_unservable_request_is_failed_not_prefilled_and_retried
  - AssertionError: assert not {'0': 256}
FAILED test_request_at_the_bound_is_failed_because_it_needs_an_output_slot
  - AssertionError: assert not {'0': 256}
FAILED test_generation_stops_at_the_bound_instead_of_stalling_mid_decode
  - AttributeError: 'Scheduler' object has no attribute 'max_servable_num_tokens'
FAILED test_generation_is_not_capped_when_the_pool_covers_the_window
  - AttributeError: 'Scheduler' object has no attribute 'max_servable_num_tokens'
5 failed, 2 passed, 14 warnings in 4.81s
```

`{'0': 256}` is `main` admitting the unservable request and scheduling the first
256-token prefill chunk of the sequence it will then throw away. The two that pass
before and after are the two "must still work" directions — they are there to catch
over-rejection and over-capping, and they must never have gone red.

Reverting only the one-line length cap and keeping everything else isolates the
decode case:

```text
$ sed -i 's/self.max_servable_num_tokens)/self.max_model_len)/' <the check_stop call>
$ pytest tests/v1/core/test_kv_pool_unservable_requests.py -q
FAILED test_generation_stops_at_the_bound_instead_of_stalling_mid_decode
  - assert <RequestStatus.PREEMPTED: 6> == <RequestStatus.FINISHED_LENGTH_CAPPED: 8>
1 failed, 6 passed, 14 warnings in 4.92s
```

With the fix:

```text
$ pytest tests/v1/core/test_kv_pool_unservable_requests.py -q
.......                                                                  [100%]
7 passed, 14 warnings in 4.71s
```

Surrounding suite, same command on `4d2a68d6` and on this branch:

```text
main @ 4d2a68d6 : 2 failed, 495 passed, 2 errors in 348.75s
this branch     : 2 failed, 502 passed, 2 errors in 375.92s
```

The same two failures and the same two setup errors occur on both, all environmental
in my CPU-only sandbox and unrelated to this change: failures in
`test_scheduler.py::test_async_scheduling_pp_allows_rescheduling_with_output_placeholders`
and `test_reset_prefix_cache_e2e.py::test_reset_prefix_cache_e2e`, and setup errors on
`test_concurrent_partial_prefill` and `test_prefix_cache_stats_is_recorded` — all four
need a GPU-backed engine core. The +7 are the new tests.

Two existing tests build a `Scheduler` with `object.__new__` and set its attributes by
hand; they each gain one line for the new `unservable_reqs` set and one for
`max_servable_num_tokens`
(`tests/v1/core/test_scheduler.py`, `tests/v1/core/test_async_scheduler.py`).

Lint gates on the changed files:

```text
$ ruff check <changed files>          # 0.14.0, as pinned in .pre-commit-config.yaml
All checks passed!
$ ruff format --check <changed files>
5 files already formatted
$ typos --force-exclude <changed files>
(clean)
$ python tools/pre_commit/mypy.py 3.12 <changed files>   # mypy 1.20.2
Success: no issues found in 2 source files
Success: no issues found in 3 source files
```

---

AI assistance was used to investigate and draft this change; every changed line was
reviewed, and the reproduction, the tests and the lint gates were run locally as
described above.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. — none needed: no new model, flag, or user-facing configuration.
</details>
