### PR TITLE
[Bugfix][Kernel] Canonicalize Marlin MoE token order

### DIFF
--- a/tests/kernels/moe/test_moe.py
+++ b/tests/kernels/moe/test_moe.py
@@ -38,6 +38,7 @@ from vllm.model_executor.layers.fused_moe.config import (
     int8_w8a16_moe_quant_config,
 )
 from vllm.model_executor.layers.fused_moe.experts.marlin_moe import (
+    _canonicalize_marlin_moe_token_order,
     batched_fused_marlin_moe,
     fused_marlin_moe,
 )
@@ -706,6 +707,79 @@ def test_fused_moe_wn16(
         torch_output = torch_moe(a, w1_ref, w2_ref, score, topk, expert_map=e_map)
 
     torch.testing.assert_close(triton_output, torch_output, atol=2e-2, rtol=0)
+
+
+def test_canonicalize_marlin_moe_token_order():
+    block_size_m = 4
+    num_valid_tokens = 9
+    num_tokens_post_padded = torch.tensor([12], dtype=torch.int32)
+
+    # The fourth block intentionally has the same expert ID as the final
+    # active block. Its contents are outside num_tokens_post_padded and must
+    # never leak into the active prefix.
+    expert_ids = torch.tensor(
+        [2, 2, 7, 7, -123],
+        dtype=torch.int32,
+    )
+
+    first_order = torch.tensor(
+        [
+            8, 3, 9, 1,
+            7, 4, 6, 9,
+            5, 9, 0, 2,
+            -2147483648, -100, 123456, 17,
+            -77, 42, 999999, -9,
+        ],
+        dtype=torch.int32,
+    )
+
+    second_order = torch.tensor(
+        [
+            9, 6, 4, 7,
+            1, 9, 3, 8,
+            2, 0, 9, 5,
+            314159, -2147483648, -1, 88,
+            7, -300, 111111, 22,
+        ],
+        dtype=torch.int32,
+    )
+
+    expected_active = torch.tensor(
+        [
+            1, 3, 4, 6,
+            7, 8, 9, 9,
+            0, 2, 5, 9,
+        ],
+        dtype=torch.int32,
+    )
+
+    first_canonical = _canonicalize_marlin_moe_token_order(
+        first_order,
+        expert_ids,
+        num_tokens_post_padded,
+        block_size_m,
+        num_valid_tokens,
+    )
+    second_canonical = _canonicalize_marlin_moe_token_order(
+        second_order,
+        expert_ids,
+        num_tokens_post_padded,
+        block_size_m,
+        num_valid_tokens,
+    )
+
+    torch.testing.assert_close(
+        first_canonical[:12],
+        expected_active,
+        atol=0,
+        rtol=0,
+    )
+    torch.testing.assert_close(
+        second_canonical[:12],
+        expected_active,
+        atol=0,
+        rtol=0,
+    )
 
 
 MARLIN_MOE_SCENARIOS = [

--- a/vllm/model_executor/layers/fused_moe/experts/marlin_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/marlin_moe.py
@@ -56,6 +56,75 @@ from vllm.platforms import current_platform
 from vllm.scalar_type import ScalarType, scalar_types
 
 
+def _canonicalize_marlin_moe_token_order(
+    sorted_token_ids: torch.Tensor,
+    expert_ids: torch.Tensor,
+    num_tokens_post_padded: torch.Tensor,
+    block_size_m: int,
+    num_valid_tokens: int,
+) -> torch.Tensor:
+    """Canonicalize routed token IDs within contiguous expert regions.
+
+    moe_align_block_size guarantees expert grouping but does not guarantee
+    token ordering within an expert. Marlin's multi-threadblock split-K
+    reduction can depend on physical block position, so equivalent routed
+    layouts need a common ordering before entering the kernel.
+
+    Alignment buffers may contain unspecified data after
+    num_tokens_post_padded. Keep that inactive tail strictly after the active
+    prefix so its contents cannot affect canonicalization.
+    """
+    block_experts = expert_ids.to(dtype=torch.int64)
+    block_positions = torch.arange(
+        expert_ids.numel(),
+        device=expert_ids.device,
+        dtype=torch.int64,
+    )
+    active_blocks = (
+        block_positions * block_size_m < num_tokens_post_padded
+    )
+
+    region_starts = torch.cat(
+        (
+            torch.ones_like(block_experts[:1], dtype=torch.bool),
+            (block_experts[1:] != block_experts[:-1])
+            | (active_blocks[1:] != active_blocks[:-1]),
+        ),
+        dim=0,
+    )
+    block_regions = (
+        torch.cumsum(region_starts.to(dtype=torch.int64), dim=0) - 1
+    )
+
+    slot_regions = torch.repeat_interleave(
+        block_regions,
+        block_size_m,
+    )[: sorted_token_ids.numel()]
+
+    slot_positions = torch.arange(
+        sorted_token_ids.numel(),
+        device=sorted_token_ids.device,
+        dtype=torch.int64,
+    )
+    active_slots = slot_positions < num_tokens_post_padded
+
+    token_ids = sorted_token_ids.to(dtype=torch.int64)
+    key_stride = num_valid_tokens + 1
+
+    # Valid token IDs are in [0, num_valid_tokens), with the padding sentinel
+    # at num_valid_tokens. Values in the inactive tail are unspecified, so do
+    # not let them contribute to the sort key.
+    token_key = torch.where(
+        active_slots,
+        token_ids,
+        torch.zeros_like(token_ids),
+    )
+    sort_key = slot_regions * key_stride + token_key
+
+    order = torch.argsort(sort_key)
+    return sorted_token_ids.index_select(0, order)
+
+
 def _fused_marlin_moe(
     hidden_states: torch.Tensor,
     w1: torch.Tensor,
@@ -344,6 +413,17 @@ def fused_marlin_moe(
         expert_map,
         ignore_invalid_experts=True,
     )
+
+    # A single-token decode cannot span multiple routed blocks for one expert,
+    # so keep it on the original fast path.
+    if topk_ids.shape[0] > 1:
+        sorted_token_ids = _canonicalize_marlin_moe_token_order(
+            sorted_token_ids,
+            expert_ids,
+            num_tokens_post_padded,
+            block_size_m,
+            topk_ids.numel(),
+        )
 
     assert activation is not None
     moe_output = _fused_marlin_moe(


### PR DESCRIPTION
## Purpose

Fixes #52525.

`moe_align_block_size()` guarantees expert grouping but does not guarantee the ordering of routed token IDs within an expert. For Marlin MoE, semantically equivalent within-expert orderings can select different physical block positions in the multi-threadblock split-K path and therefore follow different floating-point reduction trees.

The resulting BF16 differences are small, but they can propagate through later layers and affect autoregressive generation.

This change canonicalizes `sorted_token_ids` within each contiguous expert region before entering the Marlin MoE kernel.

The canonicalization:

- preserves expert assignment and `expert_ids`
- preserves `num_tokens_post_padded`
- keeps the inactive alignment-buffer tail from affecting the active prefix
- preserves the existing single-token decode fast path

The change is intentionally Marlin-specific because arbitrary within-expert ordering remains a valid contract for the general MoE alignment operation.

## Test Plan

- Add a focused regression test for two equivalent within-expert token orderings.
- Poison the inactive alignment-buffer tail with different arbitrary values and verify that it cannot affect the canonical active prefix.
- Validate the canonicalization helper at the routing-buffer size where the issue was isolated.
- Validate the underlying raw-vs-canonical Marlin behavior on SM120 hardware.

## Test Result

The regression case canonicalizes both equivalent layouts to the same active prefix:

`[1, 3, 4, 6, 7, 8, 9, 9, 0, 2, 5, 9]`

A same-forward Marlin W13 A/B experiment used identical input activations, quantized weights and scales, `expert_ids`, `num_tokens_post_padded`, top-k weights, launch parameters, and separately zeroed output/workspace buffers. The only changed input was the legal ordering of `sorted_token_ids`.

The originally isolated geometry was:

- M = 8192
- K = 4096
- N = 2048
- top_k = 6
- block_size_m = 64
- global_num_experts = 256
- local_num_experts = 128

Across 3 requests and 2 TP ranks, all 6 raw-vs-canonical comparisons produced different W13 tensors.

Observed numerical differences were small:

- max BF16 ULP distance: 4
- representative max absolute difference: 0.0078125
- representative RMS difference: ~1.50e-5
- non-finite values: 0

Canonicalizing the routed token order removed the captured W13 divergence and the downstream layer-0 divergence.

A GPU microbenchmark of the canonicalization helper on an NVIDIA RTX PRO 6000 Blackwell Max-Q with a 65,280-slot routing buffer averaged 0.226 ms/call over 200 iterations.

Additional checks:

- Python source compilation: PASS
- `git diff --check`: PASS
- canonicalization regression: PASS
- DCO: PASS

## AI assistance

AI tools were used during investigation and implementation. The experiments, measurements, code changes, and validation described above were reviewed and executed by the contributor on the target hardware.