### PR TITLE
[Bugfix][Core] Make the attention-head / TP divisibility error actionable

### DIFF
--- a/tests/config/test_head_divisibility_error.py
+++ b/tests/config/test_head_divisibility_error.py
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for the attention-head / tensor-parallel divisibility error message."""
+
+import json
+
+import pytest
+
+from vllm.config import ModelConfig, ParallelConfig
+
+
+def _make_model_config(tmp_path, num_attention_heads: int = 64) -> ModelConfig:
+    """Build a ModelConfig from a minimal local Llama config (no download)."""
+    config_dict = {
+        "architectures": ["LlamaForCausalLM"],
+        "model_type": "llama",
+        "hidden_size": 1024,
+        "intermediate_size": 4096,
+        "num_hidden_layers": 2,
+        "num_attention_heads": num_attention_heads,
+        "num_key_value_heads": num_attention_heads,
+        "vocab_size": 32000,
+        "max_position_embeddings": 8192,
+    }
+    (tmp_path / "config.json").write_text(json.dumps(config_dict))
+    return ModelConfig(model=str(tmp_path), runner="generate", max_model_len=1024)
+
+
+def test_head_divisibility_error_is_actionable(tmp_path):
+    """A TP size that does not divide the attention heads should raise an
+    actionable error: list the valid `--tensor-parallel-size` values and
+    suggest pipeline parallelism (which shards by layers) when supported."""
+    model_config = _make_model_config(tmp_path, num_attention_heads=64)
+
+    with pytest.raises(ValueError) as exc_info:
+        model_config.verify_with_parallel_config(ParallelConfig(tensor_parallel_size=3))
+
+    message = str(exc_info.value)
+    assert "Total number of attention heads (64)" in message
+    assert "must be divisible by tensor parallel size (3)" in message
+    assert (
+        "`--tensor-parallel-size` values are valid: [1, 2, 4, 8, 16, 32, 64]" in message
+    )
+    # Llama implements SupportsPP, so the suggestion should be offered.
+    assert "consider `--pipeline-parallel-size` instead" in message
+
+
+def test_head_divisibility_error_valid_tp_size_passes(tmp_path):
+    """A divisor TP size should not raise."""
+    model_config = _make_model_config(tmp_path, num_attention_heads=64)
+    # 64 % 4 == 0 -> no error.
+    model_config.verify_with_parallel_config(ParallelConfig(tensor_parallel_size=4))

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -1372,11 +1372,27 @@ class ModelConfig:
         total_num_attention_heads = self.model_arch_config.total_num_attention_heads
         tensor_parallel_size = parallel_config.tensor_parallel_size
         if total_num_attention_heads % tensor_parallel_size != 0:
-            raise ValueError(
-                f"Total number of attention heads ({total_num_attention_heads})"
-                " must be divisible by tensor parallel size "
-                f"({tensor_parallel_size})."
+            valid_tp_sizes = [
+                size
+                for size in range(1, total_num_attention_heads + 1)
+                if total_num_attention_heads % size == 0
+            ]
+            message = (
+                f"Total number of attention heads ({total_num_attention_heads}) "
+                "must be divisible by tensor parallel size "
+                f"({tensor_parallel_size}). Tensor parallelism shards "
+                "attention heads across ranks, so only the following "
+                "`--tensor-parallel-size` values are valid: "
+                f"{valid_tp_sizes}."
             )
+            if self.registry.is_pp_supported_model(self.architectures, self):
+                message += (
+                    f" To use {tensor_parallel_size} GPUs, consider "
+                    "`--pipeline-parallel-size` instead, which shards the "
+                    "model by layers and does not require attention-head "
+                    "divisibility."
+                )
+            raise ValueError(message)
 
         if parallel_config.enable_expert_parallel:
             self._verify_with_expert_parallelism()


### PR DESCRIPTION
## Purpose

Make the attention-head / tensor-parallel divisibility error actionable.

Serving e.g. `deepseek-ai/DeepSeek-V4-Flash-0731` with `--tensor-parallel-size 3` fails with:

```
Value error, Total number of attention heads (64) must be divisible by tensor parallel size (3).
```

The message states the constraint but not *why* or *what to do instead*, which is what caused the
confusion reported in #52435: users assume the expert-count check is the real blocker, when in fact
64 attention heads simply cannot be sharded across 3 TP ranks.

**Scope note:** this is a different code path from #52446. #52446 fixes the *expert-parallel*
divisibility assert (`n_physical_experts % ep_size`) in `vllm/models/deepseek_v4/nvidia/model.py`;
this PR only improves the attention-head message in `ModelConfig.verify_with_parallel_config`.

## Change

`vllm/config/model.py::ModelConfig.verify_with_parallel_config` now raises an error that:

- explains that tensor parallelism shards attention heads across ranks,
- lists the valid `--tensor-parallel-size` values (the divisors of the head count),
- and, when the model supports pipeline parallelism, suggests `--pipeline-parallel-size`
  (which shards by layers and has no head-divisibility constraint).

## Test Plan

```bash
pytest tests/config/test_head_divisibility_error.py -v
```

## Test Result

<!-- TODO: paste local pytest output -->

## Notes

- Complements the earlier expert-parallel fix (#52446); does not replace it.
- AI-assisted; reviewed by me. DCO `Signed-off-by:` present.