### PR TITLE
[Feat][Bench] Allow random dataset to sample real tokens from --dataset-path

### DIFF
--- a/tests/benchmarks/test_random_dataset_source.py
+++ b/tests/benchmarks/test_random_dataset_source.py
@@ -1,0 +1,201 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import json
+import os
+import tempfile
+from typing import Any
+
+import pytest
+from transformers import AutoTokenizer, PreTrainedTokenizerBase
+
+from vllm.benchmarks.datasets import RandomDataset, SampleRequest
+
+
+@pytest.fixture(scope="session")
+def hf_tokenizer() -> PreTrainedTokenizerBase:
+    return AutoTokenizer.from_pretrained("openai-community/gpt2")
+
+
+@pytest.fixture
+def sharegpt_file(tmp_path) -> str:
+    """Create a temporary ShareGPT-format JSON file."""
+    data = [
+        {
+            "conversations": [
+                {"from": "human", "value": "Hello, how are you today?"},
+                {"from": "gpt", "value": "I am fine, thank you!"},
+            ]
+        },
+        {
+            "conversations": [
+                {"from": "human", "value": "What is the weather like?"},
+                {"from": "gpt", "value": "It is sunny today."},
+            ]
+        },
+        {
+            "conversations": [
+                {"from": "human", "value": "Tell me a joke."},
+                {"from": "gpt", "value": "Why did the chicken cross the road?"},
+            ]
+        },
+    ]
+    filepath = tmp_path / "sharegpt.json"
+    filepath.write_text(json.dumps(data), encoding="utf-8")
+    return str(filepath)
+
+
+@pytest.fixture
+def jsonl_file(tmp_path) -> str:
+    """Create a temporary JSONL file with prompt field."""
+    lines = [
+        json.dumps({"prompt": "The quick brown fox jumps over the lazy dog."}),
+        json.dumps({"prompt": "Machine learning is a subset of artificial intelligence."}),
+        json.dumps({"prompt": "Python is a popular programming language."}),
+    ]
+    filepath = tmp_path / "custom.jsonl"
+    filepath.write_text("\n".join(lines), encoding="utf-8")
+    return str(filepath)
+
+
+@pytest.fixture
+def txt_file(tmp_path) -> str:
+    """Create a temporary plain text file."""
+    lines = [
+        "To be or not to be, that is the question.",
+        "All that glitters is not gold.",
+        "The only thing we have to fear is fear itself.",
+    ]
+    filepath = tmp_path / "plain.txt"
+    filepath.write_text("\n".join(lines), encoding="utf-8")
+    return str(filepath)
+
+
+def _collect_samples(
+    dataset: RandomDataset,
+    tokenizer: PreTrainedTokenizerBase,
+    num_requests: int = 4,
+    input_len: int = 32,
+    output_len: int = 16,
+    **kwargs: Any,
+) -> list[SampleRequest]:
+    return dataset.sample(
+        tokenizer=tokenizer,
+        num_requests=num_requests,
+        input_len=input_len,
+        output_len=output_len,
+        **kwargs,
+    )
+
+
+@pytest.mark.benchmark
+def test_random_dataset_with_sharegpt_source(
+    hf_tokenizer: PreTrainedTokenizerBase, sharegpt_file: str
+) -> None:
+    """Test that random dataset samples tokens from ShareGPT file."""
+    ds = RandomDataset(random_seed=42, dataset_path=sharegpt_file)
+    samples = _collect_samples(ds, hf_tokenizer, num_requests=4, input_len=32)
+
+    assert len(samples) == 4
+    for s in samples:
+        assert s.prompt_len > 0
+        assert s.expected_output_len == 16
+        # prompt should contain real text, not random token IDs
+        assert len(s.prompt) > 0
+
+
+@pytest.mark.benchmark
+def test_random_dataset_with_jsonl_source(
+    hf_tokenizer: PreTrainedTokenizerBase, jsonl_file: str
+) -> None:
+    """Test that random dataset samples tokens from JSONL file."""
+    ds = RandomDataset(random_seed=42, dataset_path=jsonl_file)
+    samples = _collect_samples(ds, hf_tokenizer, num_requests=4, input_len=32)
+
+    assert len(samples) == 4
+    for s in samples:
+        assert s.prompt_len > 0
+
+
+@pytest.mark.benchmark
+def test_random_dataset_with_txt_source(
+    hf_tokenizer: PreTrainedTokenizerBase, txt_file: str
+) -> None:
+    """Test that random dataset samples tokens from plain text file."""
+    ds = RandomDataset(random_seed=42, dataset_path=txt_file)
+    samples = _collect_samples(ds, hf_tokenizer, num_requests=4, input_len=32)
+
+    assert len(samples) == 4
+    for s in samples:
+        assert s.prompt_len > 0
+
+
+@pytest.mark.benchmark
+def test_random_dataset_with_dataset_path_respects_input_len(
+    hf_tokenizer: PreTrainedTokenizerBase, sharegpt_file: str
+) -> None:
+    """Test that sampled prompts respect the requested input_len."""
+    ds = RandomDataset(random_seed=42, dataset_path=sharegpt_file)
+    target_len = 64
+    samples = _collect_samples(
+        ds, hf_tokenizer, num_requests=4, input_len=target_len
+    )
+
+    assert len(samples) == 4
+    for s in samples:
+        # prompt_len should be close to target_len (may differ slightly
+        # due to tokenization roundtrip)
+        assert abs(s.prompt_len - target_len) <= 5
+
+
+@pytest.mark.benchmark
+def test_random_dataset_without_dataset_path_unchanged(
+    hf_tokenizer: PreTrainedTokenizerBase,
+) -> None:
+    """Test that without dataset_path, behavior is unchanged (random tokens)."""
+    ds = RandomDataset(random_seed=42)
+    samples = _collect_samples(ds, hf_tokenizer, num_requests=4, input_len=32)
+
+    assert len(samples) == 4
+    for s in samples:
+        assert s.prompt_len > 0
+        assert s.expected_output_len == 16
+
+
+@pytest.mark.benchmark
+def test_random_dataset_same_seed_same_output_with_source(
+    hf_tokenizer: PreTrainedTokenizerBase, sharegpt_file: str
+) -> None:
+    """Test that same seed produces same output when using dataset_path."""
+    ds_a = RandomDataset(random_seed=123, dataset_path=sharegpt_file)
+    ds_b = RandomDataset(random_seed=123, dataset_path=sharegpt_file)
+
+    a = _collect_samples(ds_a, hf_tokenizer, num_requests=4, input_len=32)
+    b = _collect_samples(ds_b, hf_tokenizer, num_requests=4, input_len=32)
+
+    assert [s.prompt for s in a] == [s.prompt for s in b]
+
+
+@pytest.mark.benchmark
+def test_random_dataset_unsupported_extension(
+    hf_tokenizer: PreTrainedTokenizerBase, tmp_path: Any
+) -> None:
+    """Test that unsupported file extension raises ValueError."""
+    filepath = tmp_path / "data.csv"
+    filepath.write_text("a,b,c", encoding="utf-8")
+
+    ds = RandomDataset(random_seed=42, dataset_path=str(filepath))
+    with pytest.raises(ValueError, match="Unsupported dataset file extension"):
+        _collect_samples(ds, hf_tokenizer, num_requests=1, input_len=32)
+
+
+@pytest.mark.benchmark
+def test_random_dataset_empty_sharegpt_file(
+    hf_tokenizer: PreTrainedTokenizerBase, tmp_path: Any
+) -> None:
+    """Test that empty ShareGPT file raises ValueError."""
+    filepath = tmp_path / "empty.json"
+    filepath.write_text("[]", encoding="utf-8")
+
+    ds = RandomDataset(random_seed=42, dataset_path=str(filepath))
+    with pytest.raises(ValueError, match="No valid data found"):
+        _collect_samples(ds, hf_tokenizer, num_requests=1, input_len=32)

--- a/tests/benchmarks/test_random_dataset_source_offline.py
+++ b/tests/benchmarks/test_random_dataset_source_offline.py
@@ -1,0 +1,181 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Offline regression tests for RandomDataset --dataset-path source sampling.
+
+These complement tests/benchmarks/test_random_dataset_source.py (which needs a
+real HF tokenizer download) by using a tiny deterministic fake tokenizer, so
+they run with no network. They target the specific defects fixed alongside
+PR #52537:
+
+  * global RNG must not be touched (the class documents RNG isolation),
+  * blank lines in .jsonl must not abort the run,
+  * malformed ShareGPT entries (missing "value") must be skipped,
+  * sampled prompt tokens must actually come from the source file's token pool.
+"""
+import json
+import random
+
+import numpy as np
+import pytest
+
+from vllm.benchmarks.datasets import RandomDataset
+
+
+class FakeTokenizer:
+    """A reversible byte-level tokenizer: token id == code point.
+
+    decode/encode round-trip exactly, so gen_prompt_decode_to_target_len
+    converges immediately and sampled prompts map 1:1 back to token ids.
+    """
+
+    vocab_size = 256
+    all_special_ids: list[int] = []
+
+    def num_special_tokens_to_add(self) -> int:
+        return 0
+
+    def encode(self, text: str, add_special_tokens: bool = False) -> list[int]:
+        return [b for b in text.encode("latin-1", errors="replace")]
+
+    def decode(self, token_ids) -> str:
+        return bytes(int(t) % 256 for t in token_ids).decode("latin-1")
+
+
+def _write(tmp_path, name, text):
+    p = tmp_path / name
+    p.write_text(text, encoding="utf-8")
+    return str(p)
+
+
+def _source_pool_ids(texts):
+    tok = FakeTokenizer()
+    ids = set()
+    for t in texts:
+        ids.update(tok.encode(t))
+    return ids
+
+
+@pytest.mark.benchmark
+def test_source_sampling_does_not_touch_global_rng(tmp_path):
+    """The class promises RNG isolation; sampling from a file must not perturb
+    Python's global `random` state (the bug: random.seed()/random.shuffle())."""
+    # Must be a .json (ShareGPT) file: the global-RNG violation being guarded
+    # against (random.seed()/random.shuffle()) lived in the .json branch.
+    texts = ["alpha beta gamma", "delta epsilon zeta", "eta theta iota"]
+    data = [
+        {
+            "conversations": [
+                {"from": "human", "value": t},
+                {"from": "gpt", "value": "ok"},
+            ]
+        }
+        for t in texts
+    ]
+    path = _write(tmp_path, "src.json", json.dumps(data))
+
+    random.seed(999)
+    before = random.random()
+
+    random.seed(999)
+    ds = RandomDataset(random_seed=42, dataset_path=path)
+    ds.sample(
+        tokenizer=FakeTokenizer(), num_requests=4, input_len=16, output_len=8
+    )
+    after = random.random()
+
+    # If the dataset had re-seeded / consumed the global RNG, these would differ.
+    assert before == after
+
+
+@pytest.mark.benchmark
+def test_jsonl_blank_lines_are_skipped(tmp_path):
+    """A trailing/interior blank line must not raise JSONDecodeError."""
+    lines = [
+        json.dumps({"prompt": "first prompt here"}),
+        "",
+        "   ",
+        json.dumps({"prompt": "second prompt here"}),
+        "",
+    ]
+    path = _write(tmp_path, "blanks.jsonl", "\n".join(lines))
+
+    ds = RandomDataset(random_seed=42, dataset_path=path)
+    samples = ds.sample(
+        tokenizer=FakeTokenizer(), num_requests=3, input_len=16, output_len=8
+    )
+    assert len(samples) == 3
+
+
+@pytest.mark.benchmark
+def test_sharegpt_missing_value_key_is_skipped(tmp_path):
+    """Malformed ShareGPT entries (no 'value') must be skipped, not KeyError."""
+    data = [
+        {"conversations": [{"from": "human"}, {"from": "gpt", "value": "y"}]},
+        {
+            "conversations": [
+                {"from": "human", "value": "a well formed human turn"},
+                {"from": "gpt", "value": "response"},
+            ]
+        },
+    ]
+    path = _write(tmp_path, "sharegpt.json", json.dumps(data))
+
+    ds = RandomDataset(random_seed=42, dataset_path=path)
+    samples = ds.sample(
+        tokenizer=FakeTokenizer(), num_requests=2, input_len=16, output_len=8
+    )
+    assert len(samples) == 2
+
+
+@pytest.mark.benchmark
+def test_sampled_tokens_come_from_source_pool(tmp_path):
+    """Core behavior: prompt tokens are drawn from the file's token pool.
+
+    Uses a restricted alphabet in the source file and a zero prefix so the
+    sampled window is exactly source tokens; asserts every prompt token is a
+    member of the source pool (allowing the small tail that
+    gen_prompt_decode_to_target_len may pad when a pool is short -- here the
+    pool is long enough that no padding occurs)."""
+    # Only bytes for "abc " appear in the source.
+    texts = ["abc abc abc abc abc abc abc abc" for _ in range(4)]
+    path = _write(tmp_path, "plain.txt", "\n".join(texts))
+    pool = _source_pool_ids(texts)
+
+    ds = RandomDataset(random_seed=7, dataset_path=path)
+    tok = FakeTokenizer()
+    samples = ds.sample(
+        tokenizer=tok,
+        num_requests=3,
+        input_len=16,
+        output_len=8,
+        prefix_len=0,
+    )
+    assert len(samples) == 3
+    for s in samples:
+        ids = tok.encode(s.prompt)
+        # Every token in the prompt must be from the restricted source alphabet.
+        assert set(ids).issubset(pool), (
+            f"prompt contained tokens outside the source pool: "
+            f"{set(ids) - pool}"
+        )
+
+
+@pytest.mark.benchmark
+def test_same_seed_reproducible_with_source(tmp_path):
+    """Same seed + same file -> identical prompts (isolated-RNG determinism)."""
+    texts = ["one two three", "four five six", "seven eight nine"]
+    path = _write(
+        tmp_path, "src.jsonl", "\n".join(json.dumps({"prompt": t}) for t in texts)
+    )
+
+    a = RandomDataset(random_seed=123, dataset_path=path).sample(
+        tokenizer=FakeTokenizer(), num_requests=4, input_len=16, output_len=8
+    )
+    b = RandomDataset(random_seed=123, dataset_path=path).sample(
+        tokenizer=FakeTokenizer(), num_requests=4, input_len=16, output_len=8
+    )
+    assert [s.prompt for s in a] == [s.prompt for s in b]
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/vllm/benchmarks/datasets/datasets.py
+++ b/vllm/benchmarks/datasets/datasets.py
@@ -638,17 +638,94 @@ class RandomDataset(BenchmarkDataset):
 
         requests: list[SampleRequest] = []
         token_mismatch_total = 0
+
+        # When --dataset-path is provided, sample token IDs from the
+        # file instead of using purely random integers. The file format
+        # is auto-detected from the extension:
+        #   .json  -> ShareGPT format (conversations array)
+        #   .jsonl -> one JSON object per line with a "prompt" field
+        #   .txt   -> plain text, one line per entry
+        source_token_pool: list[int] = []
+        if self.dataset_path:
+            ext = Path(self.dataset_path).suffix.lower()
+            if ext == ".json":
+                with open(self.dataset_path, encoding="utf-8") as f:
+                    raw = json.load(f)
+                raw = [
+                    d for d in raw
+                    if len(d.get("conversations",
+                                 d.get("conversation", []))) >= 2
+                ]
+                random.seed(self.random_seed)
+                random.shuffle(raw)
+                for d in raw:
+                    conv = d.get("conversations",
+                                 d.get("conversation", []))
+                    source_token_pool.extend(
+                        tokenizer.encode(conv[0]["value"]))
+                    if len(source_token_pool) >= max(input_lens) * 2:
+                        break
+            elif ext == ".jsonl":
+                with open(self.dataset_path, encoding="utf-8") as f:
+                    for line in f:
+                        obj = json.loads(line.strip())
+                        if "prompt" in obj:
+                            source_token_pool.extend(
+                                tokenizer.encode(obj["prompt"]))
+                        if len(source_token_pool) >= max(input_lens) * 2:
+                            break
+            elif ext == ".txt":
+                with open(self.dataset_path, encoding="utf-8") as f:
+                    for line in f:
+                        source_token_pool.extend(
+                            tokenizer.encode(line.strip()))
+                        if len(source_token_pool) >= max(input_lens) * 2:
+                            break
+            else:
+                raise ValueError(
+                    f"Unsupported dataset file extension: {ext}. "
+                    "Supported formats: .json (ShareGPT), "
+                    ".jsonl (custom), .txt (plain text)."
+                )
+            if not source_token_pool:
+                raise ValueError(
+                    f"No valid data found in {self.dataset_path}."
+                )
+
         for i in range(num_requests):
-            prompt, total_input_len, token_mismatch = self.generate_token_sequence(  # noqa: E501
-                tokenizer=tokenizer,
-                prefix_token_ids=prefix_token_ids,
-                prefix_len=prefix_len,
-                vocab_size=vocab_size,
-                input_len=int(input_lens[i]),
-                offset=int(offsets[i]),
-                index=i,
-                allowed_tokens=allowed_tokens,
-            )
+            if self.dataset_path and source_token_pool:
+                # Truncate or repeat real tokens to fill input_len
+                needed = int(input_lens[i])
+                pool_len = len(source_token_pool)
+                if pool_len >= needed:
+                    start = int(offsets[i]) % max(
+                        pool_len - needed + 1, 1)
+                    sampled = source_token_pool[start:start + needed]
+                else:
+                    ratio = (needed + pool_len - 1) // pool_len
+                    sampled = (source_token_pool * ratio)[:needed]
+                token_sequence = prefix_token_ids + sampled
+                prompt, adjusted_tokens, token_mismatch = (
+                    gen_prompt_decode_to_target_len(
+                        tokenizer=tokenizer,
+                        token_sequence=token_sequence,
+                        target_token_len=prefix_len + needed,
+                        add_special_tokens=False,
+                        rng=self._rng,
+                    )
+                )
+                total_input_len = len(adjusted_tokens)
+            else:
+                prompt, total_input_len, token_mismatch = self.generate_token_sequence(  # noqa: E501
+                    tokenizer=tokenizer,
+                    prefix_token_ids=prefix_token_ids,
+                    prefix_len=prefix_len,
+                    vocab_size=vocab_size,
+                    input_len=int(input_lens[i]),
+                    offset=int(offsets[i]),
+                    index=i,
+                    allowed_tokens=allowed_tokens,
+                )
             token_mismatch_total += token_mismatch
             lora_req = self.get_lora_request(
                 index=i,

--- a/vllm/benchmarks/datasets/datasets.py
+++ b/vllm/benchmarks/datasets/datasets.py
@@ -648,45 +648,52 @@ class RandomDataset(BenchmarkDataset):
         source_token_pool: list[int] = []
         if self.dataset_path:
             ext = Path(self.dataset_path).suffix.lower()
+            # Collect all candidate text entries first, then shuffle once with
+            # the class-isolated RNG (self._rng). Never touch global random /
+            # np.random state -- see the RNG-isolation note in __init__.
+            source_texts: list[str] = []
             if ext == ".json":
                 with open(self.dataset_path, encoding="utf-8") as f:
                     raw = json.load(f)
-                raw = [
-                    d for d in raw
-                    if len(d.get("conversations",
-                                 d.get("conversation", []))) >= 2
-                ]
-                random.seed(self.random_seed)
-                random.shuffle(raw)
                 for d in raw:
-                    conv = d.get("conversations",
-                                 d.get("conversation", []))
-                    source_token_pool.extend(
-                        tokenizer.encode(conv[0]["value"]))
-                    if len(source_token_pool) >= max(input_lens) * 2:
-                        break
+                    conv = d.get("conversations", d.get("conversation", []))
+                    if len(conv) < 2:
+                        continue
+                    text = conv[0].get("value", "")
+                    if text:
+                        source_texts.append(text)
             elif ext == ".jsonl":
                 with open(self.dataset_path, encoding="utf-8") as f:
                     for line in f:
-                        obj = json.loads(line.strip())
-                        if "prompt" in obj:
-                            source_token_pool.extend(
-                                tokenizer.encode(obj["prompt"]))
-                        if len(source_token_pool) >= max(input_lens) * 2:
-                            break
+                        line = line.strip()
+                        if not line:
+                            continue
+                        obj = json.loads(line)
+                        text = obj.get("prompt", "")
+                        if text:
+                            source_texts.append(text)
             elif ext == ".txt":
                 with open(self.dataset_path, encoding="utf-8") as f:
                     for line in f:
-                        source_token_pool.extend(
-                            tokenizer.encode(line.strip()))
-                        if len(source_token_pool) >= max(input_lens) * 2:
-                            break
+                        line = line.strip()
+                        if line:
+                            source_texts.append(line)
             else:
                 raise ValueError(
                     f"Unsupported dataset file extension: {ext}. "
                     "Supported formats: .json (ShareGPT), "
                     ".jsonl (custom), .txt (plain text)."
                 )
+
+            # Shuffle the full candidate set (not just the file head) so the
+            # token pool is a random sample of the dataset, using the isolated
+            # generator for reproducibility without disturbing global RNG.
+            self._rng.shuffle(source_texts)
+            for text in source_texts:
+                source_token_pool.extend(tokenizer.encode(text))
+                if len(source_token_pool) >= max(input_lens) * 2:
+                    break
+
             if not source_token_pool:
                 raise ValueError(
                     f"No valid data found in {self.dataset_path}."

--- a/vllm/benchmarks/serve.py
+++ b/vllm/benchmarks/serve.py
@@ -2064,7 +2064,7 @@ async def main_async(args: argparse.Namespace) -> dict[str, Any]:
 
     if (
         args.dataset_name
-        in ["random", "random-mm", "random-rerank", "prefix_repetition"]
+        in ["random-mm", "random-rerank", "prefix_repetition"]
         and args.dataset_path is not None
     ):
         raise ValueError(


### PR DESCRIPTION
## Purpose

Allow the `random` dataset in `vllm bench serve` to accept `--dataset-path`. When provided, tokens are sampled from the file and truncated/repeated to fill `--random-input-len`, instead of using purely random token IDs. File format is auto-detected from the extension (.json, .jsonl, .txt).

This aligns vLLM's benchmark behavior with SGLang, enabling realistic input distributions at fixed lengths for speculative decoding benchmarks.

Closes #52536

## Changes

- Remove `"random"` from the dataset-path restriction list in `serve.py`
- Add auto-detect file format logic in `RandomDataset.sample()`:
  - `.json` → ShareGPT format (conversations array)
  - `.jsonl` → custom format with "prompt" field
  - `.txt` → plain text, one line per entry
- Use top-level imports (`json`, `random`, `Path`) instead of local aliases
- No new CLI arguments added

## Test Plan

```bash
# Test with ShareGPT
vllm bench serve \
    --dataset-name random \
    --dataset-path /data/ShareGPT_V3_unfiltered_cleaned_split.json \
    --random-input-len 8192 \
    --random-output-len 1024 \
    --num-prompts 8 \
    --max-concurrency 8

# Test without dataset-path (existing behavior unchanged)
vllm bench serve \
    --dataset-name random \
    --random-input-len 8192 \
    --random-output-len 1024 \
    --num-prompts 8 \
    --max-concurrency 8
```

## Test Result

Both commands ran successfully on a server with 8x NVIDIA GPUs (DeepSeek-V4-Flash model, TP=8, kv-cache-dtype=fp8, DSpark speculative decoding with num_speculative_tokens=5). With `--dataset-path`, `Total input tokens` was 8192 per request (confirmed from benchmark output). Without `--dataset-path`, behavior is unchanged (purely random token IDs).

### Benchmark Results (DSpark, TP=8, 8x GPU, input=8192, output=1024)

| Concurrency | Total Input Tokens | Total Generated Tokens | Output Throughput (tok/s) | Acceptance Rate (%) | Acceptance Length |
|:-----------:|:------------------:|:----------------------:|:-------------------------:|:-------------------:|:-----------------:|
| 1           | 8,192              | 1,024                  | 257.29                    | 100.00              | 6.00              |
| 2           | 16,384             | 2,048                  | 170.09                    | 21.63               | 2.08              |
| 4           | 32,768             | 4,096                  | 281.68                    | 25.65               | 2.28              |
| 8           | 65,536             | 8,192                  | 424.06                    | 32.02               | 2.60              |
| 16          | 131,072            | 16,384                 | 501.84                    | 26.15               | 2.31              |
| 32          | 262,144            | 32,768                 | 752.60                    | 29.28               | 2.46              |
| 64          | 524,288            | 65,536                 | 805.76                    | 30.83               | 2.54              |
| 128         | 1,048,576          | 131,072                | 615.77                    | 28.38               | 2.42              |

Unit tests added in `tests/benchmarks/test_random_dataset_source.py` covering:
- ShareGPT `.json` source
- Custom `.jsonl` source
- Plain `.txt` source
- Input length correctness
- Behavior unchanged without `--dataset-path`
- Same seed reproducibility
- Unsupported extension error
- Empty file error