### PR TITLE
[Bugfix][ROCm][Model Runner V2] Capture FULL CUDA graphs on the graph_capture stream

### DIFF
--- a/tests/v1/cudagraph/test_cudagraph_manager.py
+++ b/tests/v1/cudagraph/test_cudagraph_manager.py
@@ -83,9 +83,11 @@ def test_full_capture_sets_graph_pool_id_before_cuda_graph(monkeypatch):
     def create_forward_fn(desc, warmup):
         return lambda _mode: None
 
+    capture_stream = MagicMock(name="graph_capture_stream")
+
     @contextmanager
     def fake_graph_capture(*args, **kwargs):
-        yield SimpleNamespace(stream=MagicMock())
+        yield SimpleNamespace(stream=capture_stream)
 
     fake_offloader = MagicMock()
 
@@ -109,3 +111,5 @@ def test_full_capture_sets_graph_pool_id_before_cuda_graph(monkeypatch):
         manager.capture(create_forward_fn)
 
     mock_cuda_graph.assert_called_once()
+    _args, kwargs = mock_cuda_graph.call_args
+    assert kwargs["stream"] is capture_stream

--- a/tests/v1/cudagraph/test_cudagraph_manager.py
+++ b/tests/v1/cudagraph/test_cudagraph_manager.py
@@ -46,12 +46,16 @@ def _create_vllm_config() -> MagicMock:
     return vllm_config
 
 
-def test_full_capture_sets_graph_pool_id_before_cuda_graph(monkeypatch):
+@pytest.mark.parametrize("is_rocm", [False, True])
+def test_full_capture_sets_graph_pool_id_before_cuda_graph(monkeypatch, is_rocm):
     """FULL capture must set graph_pool_id before entering torch.cuda.graph().
 
     NCCL symmetric memory checks this global during graph capture; without
     it, capture fails with:
     AssertionError: graph_pool_id is not set under graph capture
+
+    ROCm also records onto graph_capture()'s stream; CUDA leaves stream=
+    unset so PyTorch keeps its default capture stream.
     """
     graph_pool = object()
     monkeypatch.setattr(
@@ -63,6 +67,11 @@ def test_full_capture_sets_graph_pool_id_before_cuda_graph(monkeypatch):
         gpu_cudagraph_utils.current_platform,
         "get_global_graph_pool",
         lambda: graph_pool,
+    )
+    monkeypatch.setattr(
+        gpu_cudagraph_utils.current_platform,
+        "is_rocm",
+        lambda: is_rocm,
     )
 
     manager = gpu_cudagraph_utils.CudaGraphManager(
@@ -112,4 +121,7 @@ def test_full_capture_sets_graph_pool_id_before_cuda_graph(monkeypatch):
 
     mock_cuda_graph.assert_called_once()
     _args, kwargs = mock_cuda_graph.call_args
-    assert kwargs["stream"] is capture_stream
+    if is_rocm:
+        assert kwargs["stream"] is capture_stream
+    else:
+        assert kwargs.get("stream") is None

--- a/vllm/v1/worker/gpu/cudagraph_utils.py
+++ b/vllm/v1/worker/gpu/cudagraph_utils.py
@@ -362,11 +362,13 @@ class CudaGraphManager:
                             set_graph_pool_id(self.pool)
                         else:
                             set_graph_pool_id(current_platform.graph_pool_handle())
-                        # Capture on graph_capture()'s stream. Omitting stream=
-                        # makes torch.cuda.graph() switch to a private side
-                        # stream, so TP allreduce is recorded off the
-                        # communicator capture context.
-                        with torch.cuda.graph(graph, self.pool, stream=cap_ctx.stream):
+                        # ROCm: record on graph_capture()'s stream so TP
+                        # allreduce is captured in the communicator context.
+                        # CUDA keeps PyTorch's default capture stream.
+                        capture_stream = (
+                            cap_ctx.stream if current_platform.is_rocm() else None
+                        )
+                        with torch.cuda.graph(graph, self.pool, stream=capture_stream):
                             forward_fn(CUDAGraphMode.NONE)
                             # Join offloader's copy stream after forward to avoid
                             # unjoined stream error. The last layer's start_prefetch

--- a/vllm/v1/worker/gpu/cudagraph_utils.py
+++ b/vllm/v1/worker/gpu/cudagraph_utils.py
@@ -318,7 +318,7 @@ class CudaGraphManager:
                 because attention backends may mutate or lazily initialize
                 metadata during warmup.
         """
-        with graph_capture(device=self.device):
+        with graph_capture(device=self.device) as cap_ctx:
             # Capture in order: PIECEWISE first, then FULL. PIECEWISE has larger
             # activations so FULL activations should fit in already allocated
             # buffers in the graph pool.
@@ -362,7 +362,11 @@ class CudaGraphManager:
                             set_graph_pool_id(self.pool)
                         else:
                             set_graph_pool_id(current_platform.graph_pool_handle())
-                        with torch.cuda.graph(graph, self.pool):
+                        # Capture on graph_capture()'s stream. Omitting stream=
+                        # makes torch.cuda.graph() switch to a private side
+                        # stream, so TP allreduce is recorded off the
+                        # communicator capture context.
+                        with torch.cuda.graph(graph, self.pool, stream=cap_ctx.stream):
                             forward_fn(CUDAGraphMode.NONE)
                             # Join offloader's copy stream after forward to avoid
                             # unjoined stream error. The last layer's start_prefetch


### PR DESCRIPTION
## Summary
- MRV2 FULL graph capture called `torch.cuda.graph(graph, pool)` without `stream=`. On ROCm, PyTorch then records onto a private side stream instead of the stream `graph_capture()` bound custom allreduce / aiter to.
- CUDAGraphWrapper and the custom-allreduce tests already pass that stream. This makes `CudaGraphManager` do the same **on ROCm only**: `stream=cap_ctx.stream`. CUDA keeps PyTorch's default capture stream.
- This is not a duplicate of open PRs around FULL capture (e.g. #51700 DBO microbatch graphs, #51966 GLM MTP capture). Those do not fix the missing `stream=` argument on MRV2 FULL capture.

## Test plan
- [x] `.venv/bin/python -m pytest tests/v1/cudagraph/test_cudagraph_manager.py tests/v1/cudagraph/test_breakable_cudagraph.py -q` — 16 passed (CUDA and ROCm `stream=` cases)
- [ ] Serving / TP allreduce replay on ROCm FULL graphs (decode after capture)

Serving eval was not completed here: this host's FlyDSL MoE first-touch currently memory-faults before graph capture, independent of this change.

## AI assistance
AI assistance was used to investigate the capture-stream mismatch and to draft this patch. A human reviewed the changed lines and ran the unit tests above.