### PR TITLE
Bump setuptools to a CVE-2025-47273-fixed release across build/platform/test requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [
     "cmake>=3.26.1",
     "ninja",
     "packaging>=24.2",
-    "setuptools>=77.0.3,<81.0.0",
+    "setuptools>=78.1.1,<81.0.0",
     "setuptools-scm>=8.0",
     "setuptools-rust>=1.9.0",
     "torch == 2.13.0",

--- a/requirements/build/cpu.txt
+++ b/requirements/build/cpu.txt
@@ -1,7 +1,7 @@
 cmake>=3.26.1
 ninja
 packaging>=24.2
-setuptools==77.0.3 # this version can reuse CMake build dir
+setuptools==78.1.1 # bumped for CVE-2025-47273 (GHSA-5rjg-fvgr-3xxf); please confirm this still reuses the CMake build dir as intended, or pick another >=78.1.1 release that does
 setuptools-scm>=8
 setuptools-rust>=1.9.0
 torch==2.13.0+cpu; platform_machine == "x86_64" or platform_machine == "s390x" or platform_machine == "aarch64"

--- a/requirements/build/cuda.txt
+++ b/requirements/build/cuda.txt
@@ -2,7 +2,7 @@
 cmake>=3.26.1
 ninja
 packaging>=24.2
-setuptools>=77.0.3,<81.0.0
+setuptools>=78.1.1,<81.0.0
 setuptools-scm>=8
 setuptools-rust>=1.9.0
 torch==2.13.0

--- a/requirements/build/rocm.txt
+++ b/requirements/build/rocm.txt
@@ -9,7 +9,7 @@ torchaudio==2.11.0+rocm7.14.0
 triton==3.7.1+git0263a6a6
 cmake>=3.26.1,<4
 packaging>=26.2
-setuptools>=77.0.3,<80.0.0
+setuptools>=78.1.1,<80.0.0
 setuptools-scm>=8
 setuptools-rust>=1.9.0
 wheel

--- a/requirements/build/rust.txt
+++ b/requirements/build/rust.txt
@@ -1,5 +1,5 @@
 # Dependencies for building Rust artifacts through setuptools-rust.
-setuptools>=77.0.3,<81.0.0
+setuptools>=78.1.1,<81.0.0
 setuptools-scm>=9.2.0
 setuptools-rust>=1.9.0
 wheel

--- a/requirements/build/tpu.txt
+++ b/requirements/build/tpu.txt
@@ -1,7 +1,7 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
 cmake>=3.26.1
 ninja
-setuptools>=77.0.3,<81.0.0
+setuptools>=78.1.1,<81.0.0
 setuptools-scm>=8
 setuptools-rust>=1.9.0
 torch==2.13.0+cpu

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -36,7 +36,7 @@ mistral_common[image] >= 1.11.6
 opencv-python-headless >= 4.13.0    # required for video IO
 pyyaml
 six>=1.16.0; python_version > '3.11' # transitive dependency of pandas that needs to be the latest version for python 3.12
-setuptools>=77.0.3,<81.0.0; python_version > '3.11' # Setuptools is used by triton, we need to ensure a modern version is installed for 3.12+ so that it does not try to import distutils, which was removed in 3.12
+setuptools>=78.1.1,<81.0.0; python_version > '3.11' # Setuptools is used by triton, we need to ensure a modern version is installed for 3.12+ so that it does not try to import distutils, which was removed in 3.12
 einops # Required for Qwen2-VL.
 compressed-tensors == 0.17.0 # required for compressed-tensors
 depyf==0.20.0 # required for profiling and debugging with compilation config

--- a/requirements/cpu.txt
+++ b/requirements/cpu.txt
@@ -1,7 +1,7 @@
 # Common dependencies
 -r common.txt
 
-setuptools==77.0.3 # this version can reuse CMake build dir
+setuptools==78.1.1 # bumped for CVE-2025-47273 (GHSA-5rjg-fvgr-3xxf); please confirm this still reuses the CMake build dir as intended, or pick another >=78.1.1 release that does
 
 numba == 0.65.0; platform_machine != "s390x" # Required for N-gram speculative decoding
 

--- a/requirements/rocm.txt
+++ b/requirements/rocm.txt
@@ -13,7 +13,7 @@ peft
 pytest-asyncio
 tensorizer==2.10.1
 packaging>=24.2
-setuptools>=77.0.3,<80.0.0
+setuptools>=78.1.1,<80.0.0
 setuptools-scm>=8
 setuptools-rust>=1.9.0
 runai-model-streamer[s3,gcs,azure]==0.15.7

--- a/requirements/test/cpu.txt
+++ b/requirements/test/cpu.txt
@@ -1020,7 +1020,7 @@ sentry-sdk==2.63.0
     # via fastapi-cloud-cli
 setproctitle==1.3.7
     # via -r requirements/test/../common.txt
-setuptools==77.0.3
+setuptools==78.1.1
     # via
     #   -r requirements/test/../common.txt
     #   model-hosting-container-standards

--- a/requirements/test/cuda.txt
+++ b/requirements/test/cuda.txt
@@ -1117,7 +1117,7 @@ sentry-sdk==2.63.0
     # via fastapi-cloud-cli
 setproctitle==1.3.7
     # via -r requirements/test/../common.txt
-setuptools==77.0.3
+setuptools==78.1.1
     # via
     #   -c requirements/common.txt
     #   -r requirements/test/../common.txt

--- a/requirements/tpu.txt
+++ b/requirements/tpu.txt
@@ -9,7 +9,7 @@ wheel
 jinja2>=3.1.6
 ray[default]
 ray[data]
-setuptools==78.1.0
+setuptools==78.1.1
 setuptools-rust>=1.9.0
 nixl==0.3.0
 tpu-inference==0.28.0

--- a/requirements/xpu.txt
+++ b/requirements/xpu.txt
@@ -8,7 +8,7 @@ cmake>=3.26.1
 packaging>=24.2
 setuptools-scm>=8
 setuptools-rust>=1.9.0
-setuptools>=77.0.3,<81.0.0
+setuptools>=78.1.1,<81.0.0
 wheel
 jinja2>=3.1.6
 datasets # for benchmark scripts


### PR DESCRIPTION
## Summary

Several requirement files pin or permit setuptools releases below the `78.1.1` floor that fixes [CVE-2025-47273](https://nvd.nist.gov/vuln/detail/CVE-2025-47273) ([GHSA-5rjg-fvgr-3xxf](https://github.com/advisories/GHSA-5rjg-fvgr-3xxf)), a path traversal in setuptools' package-index/archive handling:

- `pyproject.toml`'s PEP 517 `build-system.requires` and several `requirements/build/*.txt` files allow `setuptools>=77.0.3` with no lower bound at the fixed release
- `requirements/build/cpu.txt` and `requirements/cpu.txt` pin the exact vulnerable `setuptools==77.0.3`
- `requirements/tpu.txt` pins `setuptools==78.1.0`, one patch release short of the fix
- The generated test locks `requirements/test/cpu.txt` and `requirements/test/cuda.txt` also resolve to `setuptools==77.0.3`

This bumps every affected pin/lower-bound to `78.1.1`. Other parts of the repo (`docker/Dockerfile.ppc64le`, `build_vllm_ppc64le.sh`, `requirements/test/rocm.txt`, `requirements/test/xpu.txt`) already use a setuptools version at or above this floor, so this brings the rest of the requirement set in line with that existing practice.

This is a MODERATE-severity supply-chain issue per the project's own [severity guide](https://github.com/vllm-project/vllm/blob/main/SECURITY.md) (build-time, requires a malicious package index/archive to be exercised during a build step; no RCE or privileged-access path demonstrated), which is why this is a plain PR rather than a private security advisory.

**Note on `requirements/build/cpu.txt` / `requirements/cpu.txt`:** the prior exact pin carried a comment that `setuptools==77.0.3` "can reuse CMake build dir". I don't have a way to independently confirm whether `78.1.1` preserves that specific behavior, so I've flagged it inline for maintainer judgment — if it doesn't, please pick another `setuptools` release `>=78.1.1` that does.

## Test plan
- [x] Confirmed no remaining `setuptools==77.0.3` / `setuptools==78.1.0` / unbounded `setuptools>=77.0.3` reference anywhere in `pyproject.toml` or `requirements/`
- [ ] Maintainer: confirm `setuptools==78.1.1` still supports the CMake build-dir reuse the prior pin's comment referenced
- [ ] Maintainer: confirm the generated test locks (`requirements/test/cpu.txt`, `requirements/test/cuda.txt`) don't need a full `uv pip compile` regeneration instead of the direct edit here