### PR TITLE
Expose LinearBase geometry on ParallelLMHead so lm_head can be quantized

### DIFF
--- a/vllm/model_executor/layers/vocab_parallel_embedding.py
+++ b/vllm/model_executor/layers/vocab_parallel_embedding.py
@@ -566,6 +566,19 @@ class ParallelLMHead(VocabParallelEmbedding):
         else:
             self.register_parameter("bias", None)
 
+        # Expose the LinearBase-shaped geometry that quantization schemes read off the layer.
+        # ParallelLMHead is the only quantizable projection in the model that does NOT derive
+        # from LinearBase, so schemes such as CompressedTensorsW8A16Fp8 raise
+        # `AttributeError: 'ParallelLMHead' object has no attribute 'output_partition_sizes'`
+        # when a checkpoint quantizes lm_head. These are derived from state the layer already
+        # tracks; nothing new is computed or stored.
+        self.output_partition_sizes = [self.num_embeddings_per_partition]
+        self.logical_widths = [self.num_embeddings_per_partition]
+        self.output_size_per_partition = self.num_embeddings_per_partition
+        self.input_size = self.embedding_dim
+        self.input_size_per_partition = self.embedding_dim
+        self.has_bias = bias
+
     def _register_bias(self):
         data = torch.empty(self.num_embeddings_per_partition, dtype=self.params_dtype)
         self.bias = Parameter(data, requires_grad=False)


### PR DESCRIPTION
## Problem

`ParallelLMHead` is the only quantizable projection in a model that does **not** derive from
`LinearBase`. It extends `VocabParallelEmbedding`, so it never defines the geometry attributes
that quantization schemes read off the layer.

Loading a `compressed-tensors` checkpoint that quantizes `lm_head` therefore fails:

```
AttributeError: 'ParallelLMHead' object has no attribute 'output_partition_sizes'
  vllm/model_executor/layers/quantization/utils/humming_utils.py:475
      shape_n_stacks = layer.output_partition_sizes
```

reached via `CompressedTensorsW8A16Fp8`. Working around it one attribute at a time also surfaces
`has_bias`, `logical_widths`, `input_size_per_partition` and `output_size_per_partition`.

## Fix

Set those attributes in `ParallelLMHead.__init__`, derived from state the layer already tracks
(`num_embeddings_per_partition`, `embedding_dim`, `bias`). No new tensors are allocated, nothing
is recomputed, and there is no behavior change when `lm_head` is unquantized.

## Why it's worth supporting

`lm_head` is read once per decoded token, so its precision costs bandwidth on every step. On
Qwen3.8-27B (vocab 248320 x 5120) measured with this change applied to v0.27.1:

| | BF16 `lm_head` | FP8 `lm_head` |
|---|---|---|
| weights on GPU | 17.17 GiB | **15.99 GiB** |
| throughput, batch 1 | 82.8 tok/s | **88.9 tok/s** |
| MMLU (n=1531) | 0.7884 | 0.7969 |
| refusal-set compliance (n=416) | 0.9832 | 0.9880 |

1.18 GiB saved and ~7% faster decode, with no quality regression.

## Testing — please read

- Validated on **v0.27.1** (not a source build of `main`): a mixed-precision `compressed-tensors`
  checkpoint with an FP8 `lm_head` fails to load without this change and loads and serves
  correctly with it. Full MMLU (1531 items) and a 416-item generation set ran to completion, with
  the numbers above.
- The diff here is against current `main` (`1f0e0bf`), where `humming_utils.py:475` still reads
  `layer.output_partition_sizes`, but **I have not built `main` from source or run the test
  suite** — I don't have the hardware to do so. Flagging that explicitly rather than implying
  otherwise; happy to add a unit test or adjust the approach if maintainers prefer the scheme
  side handle non-`LinearBase` layers instead.
