### PR TITLE
[Spec Decode] Honor positive dynamic K in autoregressive drafting

### DIFF
--- a/tests/v1/spec_decode/test_dynamic_sd_cug.py
+++ b/tests/v1/spec_decode/test_dynamic_sd_cug.py
@@ -16,6 +16,7 @@ from vllm.config import (
     VllmConfig,
 )
 from vllm.v1.worker.gpu import cudagraph_utils as gpu_cudagraph_utils
+from vllm.v1.worker.gpu.spec_decode.mtp.speculator import MTPSpeculator
 from vllm.v1.worker.utils import get_uniform_decode_token_count
 
 pytestmark = pytest.mark.cpu_test
@@ -149,6 +150,56 @@ def test_dynamic_sd_full_cudagraph_covers_all_uniform_decode_shapes(monkeypatch)
             assert desc.num_tokens == num_tokens
             assert desc.num_reqs == num_reqs
             assert desc.num_active_loras == 0
+
+
+def test_dynamic_sd_autoregressive_draft_decode_uses_fixed_query_len(monkeypatch):
+    max_num_seqs = 8
+    # The runtime schedule need not contain the configured upper-bound K;
+    # draft decode capture must still use fixed query length 1.
+    max_spec_tokens = 4
+
+    monkeypatch.setattr(
+        gpu_cudagraph_utils,
+        "get_pp_group",
+        lambda: SimpleNamespace(is_first_rank=True, is_last_rank=True),
+    )
+    vllm_config = _create_vllm_config_for_dsd(
+        max_num_seqs=max_num_seqs,
+        max_spec_tokens=max_spec_tokens,
+        num_spec_per_batch_size=[(1, 2, 3), (3, 4, 1), (5, 8, 0)],
+    )
+
+    speculator = object.__new__(MTPSpeculator)
+    speculator.vllm_config = vllm_config
+    speculator.device = torch.device("cpu")
+    speculator.num_speculative_steps = max_spec_tokens
+    speculator.init_cudagraph_manager(CUDAGraphMode.FULL_AND_PIECEWISE)
+
+    prefill_manager = speculator.prefill_cudagraph_manager
+    assert prefill_manager is not None
+    prefill_descs = prefill_manager._capture_descs[CUDAGraphMode.FULL]
+    assert {desc.uniform_token_count for desc in prefill_descs} == {1, 2, 4}
+
+    decode_manager = speculator.decode_cudagraph_manager
+    assert decode_manager is not None
+    decode_descs = decode_manager._capture_descs[CUDAGraphMode.FULL]
+    assert {desc.uniform_token_count for desc in decode_descs} == {1}
+
+    decode_manager._graphs_captured = True
+    for num_reqs in range(1, max_num_seqs + 1):
+        desc = decode_manager.dispatch(
+            num_reqs=num_reqs,
+            num_tokens=num_reqs,
+            uniform_token_count=1,
+            num_active_loras=0,
+        )
+        assert desc == gpu_cudagraph_utils.BatchExecutionDescriptor(
+            cg_mode=CUDAGraphMode.FULL,
+            num_tokens=num_reqs,
+            num_reqs=num_reqs,
+            uniform_token_count=1,
+            num_active_loras=0,
+        )
 
 
 def test_dynamic_sd_non_uniform_batch_falls_back_to_piecewise(monkeypatch):

--- a/tests/v1/worker/test_gpu_autoregressive_speculator.py
+++ b/tests/v1/worker/test_gpu_autoregressive_speculator.py
@@ -334,6 +334,86 @@ def test_multi_step_decode_replays_captured_graph_as_expected(
     assert run_fullgraph.call_count == expected_graph_replays
 
 
+def test_propose_k0_runs_prefill_without_draft_decode(monkeypatch):
+    speculator = object.__new__(_TestSpeculator)
+    speculator.num_speculative_steps = 2
+    speculator.max_model_len = 32
+    speculator.max_num_reqs = 2
+    speculator.dp_size = 1
+    speculator.dp_rank = 0
+    speculator.supports_mm_inputs = False
+    speculator.hidden_states = torch.zeros(2, 3)
+    speculator.draft_tokens = torch.tensor([[11, 12], [21, 22]])
+    speculator.last_token_indices = torch.zeros(2, dtype=torch.int64)
+    speculator.current_draft_step = torch.tensor(0)
+    speculator.input_buffers = SimpleNamespace()
+    speculator.prefill_cudagraph_manager = None
+    speculator.decode_cudagraph_manager = None
+    speculator.use_fused_multi_step_decode = False
+    speculator._copy_request_inputs = Mock()
+    speculator._prepare_eplb_forward = Mock()
+    speculator.on_prefill_begin = Mock()
+    speculator.on_prefill_end = Mock()
+    speculator.on_multi_step_decode_begin = Mock()
+    speculator.on_multi_step_decode_end = Mock()
+    speculator._prefill = Mock()
+    speculator._multi_step_decode = Mock()
+    speculator._fused_multi_step_decode = Mock()
+
+    prepare_prefill = Mock()
+    prepare_decode = Mock()
+    monkeypatch.setattr(spec_module, "prepare_prefill_inputs", prepare_prefill)
+    monkeypatch.setattr(spec_module, "prepare_decode_inputs", prepare_decode)
+    monkeypatch.setattr(spec_module, "get_uniform_decode_token_count", Mock())
+    monkeypatch.setattr(
+        spec_module,
+        "dispatch_cg_and_sync_dp",
+        Mock(
+            return_value=(
+                BatchExecutionDescriptor(
+                    cg_mode=CUDAGraphMode.NONE,
+                    num_tokens=2,
+                    num_reqs=2,
+                ),
+                None,
+            )
+        ),
+    )
+
+    input_batch = SimpleNamespace(
+        num_tokens=2,
+        num_tokens_after_padding=2,
+        num_reqs=2,
+        num_scheduled_tokens=torch.ones(2, dtype=torch.int32),
+        seq_lens=torch.ones(2, dtype=torch.int32),
+        seq_lens_cpu_upper_bound=torch.ones(2, dtype=torch.int32),
+        idx_mapping=torch.arange(2),
+        has_prefill=False,
+    )
+    output = speculator.propose(
+        input_batch,
+        attn_metadata={},
+        slot_mappings={},
+        last_hidden_states=torch.ones(2, 3),
+        aux_hidden_states=None,
+        num_sampled=torch.ones(2, dtype=torch.int32),
+        num_rejected=torch.zeros(2, dtype=torch.int32),
+        last_sampled=torch.zeros(2, dtype=torch.int64),
+        next_prefill_tokens=torch.zeros(2, dtype=torch.int64),
+        temperature=torch.zeros(2),
+        seeds=torch.zeros(2, dtype=torch.int64),
+        num_speculative_tokens=0,
+    )
+
+    assert output.shape == (2, 0)
+    speculator._prefill.assert_called_once()
+    speculator.on_prefill_begin.assert_called_once_with(2)
+    speculator.on_prefill_end.assert_called_once_with(2)
+    prepare_decode.assert_not_called()
+    speculator._multi_step_decode.assert_not_called()
+    speculator._fused_multi_step_decode.assert_not_called()
+
+
 def test_update_draft_decode_metadata_updates_fa3_scheduler_metadata(
     monkeypatch,
 ):

--- a/tests/v1/worker/test_gpu_autoregressive_speculator.py
+++ b/tests/v1/worker/test_gpu_autoregressive_speculator.py
@@ -334,6 +334,225 @@ def test_multi_step_decode_replays_captured_graph_as_expected(
     assert run_fullgraph.call_count == expected_graph_replays
 
 
+def test_init_cudagraph_manager_creates_selected_fused_depths(monkeypatch):
+    created_managers = []
+
+    class FakeCudaGraphManager:
+        def __init__(self, *args, **kwargs):
+            self.kwargs = kwargs
+            self.use_breakable_cg = False
+            self.capture_fn = None
+            created_managers.append(self)
+
+        def capture(self, fn, *args, **kwargs):
+            self.capture_fn = fn
+
+    monkeypatch.setattr(spec_module, "SpeculatorCudaGraphManager", FakeCudaGraphManager)
+
+    speculator = object.__new__(_TestSpeculator)
+    speculator.vllm_config = SimpleNamespace(
+        speculative_config=SimpleNamespace(
+            num_speculative_tokens_per_batch_size=[
+                (1, 1, 4),
+                (2, 2, 2),
+                (3, 3, 1),
+                (4, 4, 0),
+            ]
+        )
+    )
+    speculator.device = torch.device("cpu")
+    speculator.num_speculative_steps = 4
+    speculator.use_fused_multi_step_decode = True
+    speculator.last_token_indices = torch.zeros(2, dtype=torch.int64)
+    speculator.idx_mapping = torch.zeros(2, dtype=torch.int64)
+    speculator.max_num_reqs = 2
+    speculator.model_state = object()
+    speculator.target_input_buffers = object()
+    speculator.block_tables = object()
+    speculator.target_attn_groups = []
+    speculator.kv_cache_config = object()
+    speculator.input_buffers = object()
+    speculator.attn_groups = []
+    speculator.on_prefill_begin = Mock()
+    speculator.on_prefill_end = Mock()
+    speculator.on_multi_step_decode_begin = Mock()
+    speculator.on_multi_step_decode_end = Mock()
+    speculator._prefill = Mock()
+    speculator._generate_fused_drafts = Mock()
+
+    speculator.init_cudagraph_manager(CUDAGraphMode.FULL_AND_PIECEWISE)
+    speculator.capture()
+
+    assert len(created_managers) == 3  # Prefill, K2 decode, K4 decode.
+    assert set(speculator.decode_cudagraph_managers) == {2, 4}
+    assert (
+        speculator.decode_cudagraph_manager is speculator.decode_cudagraph_managers[4]
+    )
+    assert all(
+        manager.kwargs["use_dynamic_decode_query_len"] is False
+        for manager in speculator.decode_cudagraph_managers.values()
+    )
+    for depth, manager in speculator.decode_cudagraph_managers.items():
+        assert manager.capture_fn is not None
+        manager.capture_fn()
+        assert speculator._generate_fused_drafts.call_args.kwargs == {
+            "num_speculative_tokens": depth
+        }
+
+
+@pytest.mark.parametrize(
+    ("selected_depth", "expected_depth", "manager_key"),
+    [(1, 1, None), (2, 2, 2), (4, 4, 4), (None, 4, 4)],
+)
+def test_propose_honors_positive_selected_depth(
+    monkeypatch, selected_depth, expected_depth, manager_key
+):
+    speculator = object.__new__(_TestSpeculator)
+    speculator.num_speculative_steps = 4
+    speculator.max_model_len = 32
+    speculator.max_num_reqs = 2
+    speculator.dp_size = 1
+    speculator.dp_rank = 0
+    speculator.supports_mm_inputs = False
+    speculator.hidden_states = torch.zeros(2, 3)
+    speculator.draft_tokens = torch.arange(8).reshape(2, 4)
+    speculator.last_token_indices = torch.zeros(2, dtype=torch.int64)
+    speculator.current_draft_step = torch.tensor(0)
+    speculator.input_buffers = SimpleNamespace()
+    speculator.prefill_cudagraph_manager = object()
+    reduced_manager = object()
+    max_manager = object()
+    speculator.decode_cudagraph_managers = {2: reduced_manager, 4: max_manager}
+    speculator.decode_cudagraph_manager = max_manager
+    speculator.use_fused_multi_step_decode = True
+    speculator._copy_request_inputs = Mock()
+    speculator._prepare_eplb_forward = Mock()
+    speculator.on_prefill_begin = Mock()
+    speculator.on_prefill_end = Mock()
+    speculator.on_multi_step_decode_begin = Mock()
+    speculator.on_multi_step_decode_end = Mock()
+    speculator._prefill = Mock()
+    speculator._multi_step_decode = Mock()
+    speculator._fused_multi_step_decode = Mock()
+
+    monkeypatch.setattr(spec_module, "prepare_prefill_inputs", Mock())
+    prepare_decode = Mock()
+    monkeypatch.setattr(spec_module, "prepare_decode_inputs", prepare_decode)
+    monkeypatch.setattr(spec_module, "get_uniform_decode_token_count", Mock())
+    dispatched_managers = []
+
+    def dispatch(manager, num_reqs, num_tokens, *args, **kwargs):
+        dispatched_managers.append(manager)
+        return (
+            BatchExecutionDescriptor(
+                cg_mode=CUDAGraphMode.NONE,
+                num_tokens=num_tokens,
+                num_reqs=num_reqs,
+            ),
+            None,
+        )
+
+    monkeypatch.setattr(spec_module, "dispatch_cg_and_sync_dp", dispatch)
+
+    input_batch = SimpleNamespace(
+        num_tokens=2,
+        num_tokens_after_padding=2,
+        num_reqs=2,
+        num_scheduled_tokens=torch.ones(2, dtype=torch.int32),
+        seq_lens=torch.ones(2, dtype=torch.int32),
+        seq_lens_cpu_upper_bound=torch.ones(2, dtype=torch.int32),
+        idx_mapping=torch.arange(2),
+        has_prefill=False,
+    )
+    output = speculator.propose(
+        input_batch,
+        attn_metadata={},
+        slot_mappings={},
+        last_hidden_states=torch.ones(2, 3),
+        aux_hidden_states=None,
+        num_sampled=torch.ones(2, dtype=torch.int32),
+        num_rejected=torch.zeros(2, dtype=torch.int32),
+        last_sampled=torch.zeros(2, dtype=torch.int64),
+        next_prefill_tokens=torch.zeros(2, dtype=torch.int64),
+        temperature=torch.zeros(2),
+        seeds=torch.zeros(2, dtype=torch.int64),
+        num_speculative_tokens=selected_depth,
+    )
+
+    assert output.shape == (2, expected_depth)
+    if manager_key is None:
+        assert dispatched_managers == [speculator.prefill_cudagraph_manager]
+        prepare_decode.assert_not_called()
+        speculator._fused_multi_step_decode.assert_not_called()
+    else:
+        expected_manager = speculator.decode_cudagraph_managers[manager_key]
+        assert dispatched_managers == [
+            speculator.prefill_cudagraph_manager,
+            expected_manager,
+        ]
+        prepare_decode.assert_called_once()
+        assert speculator._fused_multi_step_decode.call_args.args[-2:] == (
+            expected_depth,
+            expected_manager,
+        )
+
+
+@pytest.mark.parametrize("selected_depth", [2, 4])
+@pytest.mark.parametrize(
+    ("method_name", "cg_mode"),
+    [
+        ("_multi_step_decode", CUDAGraphMode.NONE),
+        ("_multi_step_decode", CUDAGraphMode.FULL),
+        ("_fused_multi_step_decode", CUDAGraphMode.NONE),
+        ("_fused_multi_step_decode", CUDAGraphMode.FULL),
+    ],
+)
+def test_selected_depth_controls_physical_draft_work(
+    selected_depth, method_name, cg_mode
+):
+    speculator = object.__new__(_TestSpeculator)
+    speculator.num_speculative_steps = 4
+    speculator.current_draft_step = torch.tensor(0)
+    speculator.input_buffers = SimpleNamespace(
+        positions=torch.arange(2),
+        query_start_loc=torch.arange(3),
+    )
+    speculator.idx_mapping = torch.arange(2)
+    speculator.attn_groups = []
+    speculator._generate_draft = Mock()
+    default_manager = SimpleNamespace(run_fullgraph=Mock())
+    selected_manager = SimpleNamespace(run_fullgraph=Mock())
+    speculator.decode_cudagraph_manager = default_manager
+    batch_desc = BatchExecutionDescriptor(
+        cg_mode=cg_mode,
+        num_tokens=2,
+        num_reqs=2,
+    )
+    kwargs = {"num_speculative_tokens": selected_depth}
+    if method_name == "_fused_multi_step_decode":
+        kwargs["decode_cudagraph_manager"] = selected_manager
+
+    getattr(speculator, method_name)(
+        num_reqs=2,
+        skip_attn=True,
+        batch_desc=batch_desc,
+        seq_lens_cpu_upper_bound=torch.ones(2, dtype=torch.int32),
+        num_tokens_across_dp=None,
+        **kwargs,
+    )
+
+    if cg_mode == CUDAGraphMode.NONE:
+        assert speculator._generate_draft.call_count == selected_depth - 1
+        selected_manager.run_fullgraph.assert_not_called()
+    elif method_name == "_multi_step_decode":
+        assert default_manager.run_fullgraph.call_count == selected_depth - 1
+        speculator._generate_draft.assert_not_called()
+    else:
+        selected_manager.run_fullgraph.assert_called_once_with(batch_desc)
+        default_manager.run_fullgraph.assert_not_called()
+        speculator._generate_draft.assert_not_called()
+
+
 def test_propose_k0_runs_prefill_without_draft_decode(monkeypatch):
     speculator = object.__new__(_TestSpeculator)
     speculator.num_speculative_steps = 2

--- a/tests/v1/worker/test_gpu_model_runner_v2_eplb.py
+++ b/tests/v1/worker/test_gpu_model_runner_v2_eplb.py
@@ -4,6 +4,7 @@
 
 from types import SimpleNamespace
 from typing import Any
+from unittest.mock import Mock
 
 import torch
 
@@ -201,3 +202,74 @@ def test_v2_sample_tokens_runs_eplb_on_non_last_pp_rank(monkeypatch):
     output = mrv2.GPUModelRunner.sample_tokens(runner, None)
     assert output in (EMPTY_MODEL_RUNNER_OUTPUT, None)
     assert events == ["receive", "postprocess_num_computed_tokens", "eplb"]
+
+
+def test_v2_sample_tokens_propagates_k0_and_hides_stale_drafts(monkeypatch):
+    runner = _make_runner(num_speculative_steps=2, _draft_workspace_lane=0)
+    input_batch = SimpleNamespace(
+        num_reqs=2,
+        req_ids=["req-0", "req-1"],
+        idx_mapping=torch.arange(2),
+        query_start_loc=torch.arange(3),
+    )
+    runner.execute_model_state = SimpleNamespace(
+        input_batch=input_batch,
+        attn_metadata={},
+        slot_mappings_by_layer={},
+        hidden_states=torch.zeros(2, 3),
+        aux_hidden_states=None,
+        finished_req_ids=set(),
+        ec_connector_output=None,
+        routed_experts=None,
+        num_spec_tokens_to_schedule=0,
+    )
+    runner.pcp_manager = None
+    runner.pp_handler = None
+    runner.sample = Mock(
+        return_value=(
+            SimpleNamespace(sampled_token_ids=torch.zeros(2, dtype=torch.int64)),
+            torch.ones(2, dtype=torch.int32),
+            torch.zeros(2, dtype=torch.int32),
+        )
+    )
+    runner.prompt_logprobs_worker = SimpleNamespace(
+        compute_prompt_logprobs=Mock(return_value={})
+    )
+    runner.model = SimpleNamespace(compute_logits=Mock())
+    runner.req_states = SimpleNamespace(
+        all_token_ids=SimpleNamespace(gpu=torch.zeros(2, 1, dtype=torch.int64)),
+        num_computed_tokens=SimpleNamespace(gpu=torch.zeros(2, dtype=torch.int32)),
+        prompt_len=SimpleNamespace(np=None),
+        last_sampled_tokens=torch.zeros(2, dtype=torch.int64),
+        next_prefill_tokens=torch.zeros(2, dtype=torch.int64),
+        draft_tokens=torch.tensor([[91, 92], [93, 94]]),
+    )
+    runner.main_stream = None
+    runner.output_copy_stream = None
+    runner.check_ep_fault = False
+    runner.postprocess_sampled = Mock()
+    runner.sampler = SimpleNamespace(
+        sampling_states=SimpleNamespace(
+            temperature=SimpleNamespace(gpu=torch.zeros(2)),
+            seeds=SimpleNamespace(gpu=torch.zeros(2, dtype=torch.int64)),
+        )
+    )
+    runner.speculator = SimpleNamespace(
+        supports_mm_inputs=False,
+        propose=Mock(return_value=torch.empty((2, 0), dtype=torch.int64)),
+    )
+    runner.adaptive_verification = None
+    runner.draft_tokens_handler = SimpleNamespace(set_draft_tokens=Mock())
+
+    monkeypatch.setattr(
+        mrv2.pcp,
+        "maybe_restore_pcp_for_sampling",
+        lambda _, hidden_states, batch: (hidden_states, batch),
+    )
+    monkeypatch.setattr(mrv2, "AsyncOutput", lambda **kwargs: kwargs)
+
+    mrv2.GPUModelRunner.sample_tokens(runner, None)
+
+    assert runner.speculator.propose.call_args.kwargs["num_speculative_tokens"] == 0
+    handled_drafts = runner.draft_tokens_handler.set_draft_tokens.call_args.args[1]
+    assert handled_drafts.shape == (2, 0)

--- a/tests/v1/worker/test_gpu_model_runner_v2_eplb.py
+++ b/tests/v1/worker/test_gpu_model_runner_v2_eplb.py
@@ -183,6 +183,7 @@ def test_v2_sample_tokens_runs_eplb_on_non_last_pp_rank(monkeypatch):
         ec_connector_output=None,
         routed_experts=None,
         num_tokens_across_dp=None,
+        num_spec_tokens_to_schedule=None,
     )
     runner.req_states = SimpleNamespace()
 

--- a/vllm/v1/worker/gpu/cudagraph_utils.py
+++ b/vllm/v1/worker/gpu/cudagraph_utils.py
@@ -108,6 +108,7 @@ class CudaGraphManager:
         decode_query_len: int,
         lora_capture_cases: list[int] | None = None,
         varlen_decode: bool = False,
+        use_dynamic_decode_query_len: bool = True,
     ):
         self.vllm_config = vllm_config
         self.device = device
@@ -117,6 +118,9 @@ class CudaGraphManager:
         self.cudagraph_mode = cudagraph_mode
         self.decode_query_len = decode_query_len
         self.varlen_decode = varlen_decode
+        # Some graph managers have a fixed query shape even when DSD changes
+        # the target verification length.
+        self.use_dynamic_decode_query_len = use_dynamic_decode_query_len
 
         self.dp_size = vllm_config.parallel_config.data_parallel_size
         self.tp_size = vllm_config.parallel_config.tensor_parallel_size
@@ -195,7 +199,8 @@ class CudaGraphManager:
         # to capture graphs for all possible values during decode.
         speculative_config = self.vllm_config.speculative_config
         if (
-            speculative_config
+            self.use_dynamic_decode_query_len
+            and speculative_config
             and speculative_config.uses_dynamic_speculative_decoding()
         ):
             num_spec_per_batch_size = (

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -1695,6 +1695,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             finished_req_ids=finished_req_ids,
             ec_connector_output=ec_connector_output,
             routed_experts=routed_experts,
+            num_spec_tokens_to_schedule=scheduler_output.num_spec_tokens_to_schedule,
         )
 
         if not self.is_last_pp_rank:
@@ -1719,6 +1720,9 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         finished_req_ids = self.execute_model_state.finished_req_ids
         ec_connector_output = self.execute_model_state.ec_connector_output
         routed_experts = self.execute_model_state.routed_experts
+        num_spec_tokens_to_schedule = (
+            self.execute_model_state.num_spec_tokens_to_schedule
+        )
         self.execute_model_state = None
 
         if not self.is_last_pp_rank:
@@ -1838,8 +1842,11 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                     self.sampler.sampling_states.temperature.gpu,
                     self.sampler.sampling_states.seeds.gpu,
                     mm_inputs=mm_inputs,
+                    num_speculative_tokens=num_spec_tokens_to_schedule,
                 )
-            self.req_states.draft_tokens[input_batch.idx_mapping] = draft_tokens
+            self.req_states.draft_tokens[
+                input_batch.idx_mapping, : draft_tokens.shape[1]
+            ] = draft_tokens
             if self.adaptive_verification is not None:
                 self.adaptive_verification.record_confidences(
                     self.speculator.draft_token_confidence_probs, input_batch
@@ -1848,9 +1855,17 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         if self.num_speculative_steps > 0:
             # Spec-decode and diffusion LLMs both use draft tokens but the latter does
             # not have a speculator (i.e. self.speculator is None)
+            # When the speculator produced a narrow width (e.g. DSD K=0),
+            # only pass the active-width slice to the handler — stale columns
+            # in the persistent buffer would create phantom draft slots.
+            active_width = (
+                draft_tokens.shape[1]
+                if self.speculator is not None
+                else self.num_speculative_steps
+            )
             self.draft_tokens_handler.set_draft_tokens(
                 input_batch,
-                self.req_states.draft_tokens[input_batch.idx_mapping],
+                self.req_states.draft_tokens[input_batch.idx_mapping, :active_width],
             )
 
         # Post-step KV connector related operations.
@@ -1986,6 +2001,7 @@ class ExecuteModelState(NamedTuple):
     finished_req_ids: set[str]
     ec_connector_output: ECConnectorOutput | None
     routed_experts: RoutedExpertsTensors | None
+    num_spec_tokens_to_schedule: int | None = None
 
 
 class BatchReqState(NamedTuple):

--- a/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
@@ -142,6 +142,10 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
             self.device,
             cudagraph_mode,
             decode_query_len=1,
+            # Each autoregressive draft step processes exactly one token per
+            # request, regardless of the speculative token count selected by
+            # dynamic speculative decoding.
+            use_dynamic_decode_query_len=False,
         )
 
     def capture(self) -> None:

--- a/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
@@ -228,6 +228,7 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
         skip_attn_for_dummy_run: bool = False,
         mm_inputs: tuple[list[torch.Tensor], torch.Tensor] | None = None,
         is_profile: bool = False,
+        num_speculative_tokens: int | None = None,
     ) -> torch.Tensor:
         num_tokens = input_batch.num_tokens
         num_tokens_padded = input_batch.num_tokens_after_padding
@@ -315,6 +316,10 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
             )
         self.on_prefill_end(num_reqs)
 
+        # DSD K=0: prefill has been run to keep draft KV cache in sync with
+        # the target, but no speculative decode steps are needed.
+        if num_speculative_tokens is not None and num_speculative_tokens == 0:
+            return self.draft_tokens[:num_reqs, :0]
         if self.num_speculative_steps == 1:
             # Early exit.
             return self.draft_tokens[:num_reqs, :1]

--- a/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
@@ -42,6 +42,7 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
 
         self.prefill_cudagraph_manager: SpeculatorCudaGraphManager | None = None
         self.decode_cudagraph_manager: SpeculatorCudaGraphManager | None = None
+        self.decode_cudagraph_managers: dict[int, SpeculatorCudaGraphManager] = {}
         self.use_fused_multi_step_decode = False
 
     def load_model(self, target_model: nn.Module) -> None:
@@ -122,6 +123,7 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
             )
 
     def init_cudagraph_manager(self, cudagraph_mode: CUDAGraphMode) -> None:
+        self.decode_cudagraph_managers = {}
         # Initialize cudagraph manager for draft prefill (draft position 0).
         self.prefill_cudagraph_manager = SpeculatorCudaGraphManager(
             self.vllm_config,
@@ -136,16 +138,33 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
         else:
             cudagraph_mode = CUDAGraphMode.NONE
 
-        # Initialize cudagraph manager for draft decodes (draft positions > 0).
-        self.decode_cudagraph_manager = SpeculatorCudaGraphManager(
-            self.vllm_config,
-            self.device,
-            cudagraph_mode,
-            decode_query_len=1,
-            # Each autoregressive draft step processes exactly one token per
-            # request, regardless of the speculative token count selected by
-            # dynamic speculative decoding.
-            use_dynamic_decode_query_len=False,
+        draft_depths = {self.num_speculative_steps}
+        speculative_config = self.vllm_config.speculative_config
+        assert speculative_config is not None
+        schedule = speculative_config.num_speculative_tokens_per_batch_size
+        if getattr(self, "use_fused_multi_step_decode", False) and schedule:
+            draft_depths.update(
+                depth
+                for _, _, depth in schedule
+                if 1 < depth < self.num_speculative_steps
+            )
+
+        for draft_depth in sorted(draft_depths):
+            if draft_depth <= 1:
+                continue
+            self.decode_cudagraph_managers[draft_depth] = SpeculatorCudaGraphManager(
+                self.vllm_config,
+                self.device,
+                cudagraph_mode,
+                decode_query_len=1,
+                # Each autoregressive draft step processes exactly one token per
+                # request, regardless of the speculative token count selected by
+                # dynamic speculative decoding.
+                use_dynamic_decode_query_len=False,
+            )
+
+        self.decode_cudagraph_manager = self.decode_cudagraph_managers.get(
+            self.num_speculative_steps
         )
 
     def capture(self) -> None:
@@ -182,24 +201,30 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
         if self.num_speculative_steps == 1:
             return
 
-        self.on_multi_step_decode_begin(self.max_num_reqs)
-        # Capture either the fused decode loop or one decode step per graph.
-        assert self.decode_cudagraph_manager is not None
-        decode_fn = (
-            self._generate_fused_drafts
-            if self.use_fused_multi_step_decode
-            else self._generate_draft
-        )
-        self.decode_cudagraph_manager.capture(
-            decode_fn,
-            self.model_state,
-            self.input_buffers,
-            self.block_tables,
-            self.attn_groups,
-            self.kv_cache_config,
-            progress_bar_desc="Capturing decode CUDA graphs",
-        )
-        self.on_multi_step_decode_end(self.max_num_reqs)
+        for draft_depth, manager in self.decode_cudagraph_managers.items():
+            self.on_multi_step_decode_begin(self.max_num_reqs)
+            if self.use_fused_multi_step_decode:
+                decode_fn = lambda *args, _depth=draft_depth, **kwargs: (
+                    self._generate_fused_drafts(
+                        *args,
+                        **kwargs,
+                        num_speculative_tokens=_depth,
+                    )
+                )
+                desc = f"Capturing K{draft_depth} decode CUDA graphs"
+            else:
+                decode_fn = self._generate_draft
+                desc = "Capturing decode CUDA graphs"
+            manager.capture(
+                decode_fn,
+                self.model_state,
+                self.input_buffers,
+                self.block_tables,
+                self.attn_groups,
+                self.kv_cache_config,
+                progress_bar_desc=desc,
+            )
+            self.on_multi_step_decode_end(self.max_num_reqs)
 
     @torch.inference_mode()
     def propose(
@@ -320,7 +345,12 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
         # the target, but no speculative decode steps are needed.
         if num_speculative_tokens is not None and num_speculative_tokens == 0:
             return self.draft_tokens[:num_reqs, :0]
-        if self.num_speculative_steps == 1:
+        active_num_speculative_tokens = (
+            self.num_speculative_steps
+            if num_speculative_tokens is None
+            else num_speculative_tokens
+        )
+        if active_num_speculative_tokens == 1:
             # Early exit.
             return self.draft_tokens[:num_reqs, :1]
 
@@ -337,8 +367,13 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
 
         # Each request produces exactly 1 token per draft generation step,
         # enabling FULL graph replay.
+        decode_cudagraph_manager = (
+            self.decode_cudagraph_managers[active_num_speculative_tokens]
+            if self.use_fused_multi_step_decode
+            else self.decode_cudagraph_manager
+        )
         decode_batch_desc, num_tokens_across_dp = dispatch_cg_and_sync_dp(
-            self.decode_cudagraph_manager,
+            decode_cudagraph_manager,
             num_reqs,
             num_reqs,
             uniform_token_count=1,
@@ -349,21 +384,21 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
 
         self.on_multi_step_decode_begin(num_reqs)
         # Generate the remaining num_speculative_steps - 1 draft tokens.
-        decode_fn = (
-            self._fused_multi_step_decode
-            if self.use_fused_multi_step_decode
-            else self._multi_step_decode
-        )
-        decode_fn(
+        decode_args = (
             num_reqs,
             dummy_run and skip_attn_for_dummy_run,
             decode_batch_desc,
             num_tokens_across_dp,
             input_batch.seq_lens_cpu_upper_bound,
+            active_num_speculative_tokens,
         )
+        if self.use_fused_multi_step_decode:
+            self._fused_multi_step_decode(*decode_args, decode_cudagraph_manager)
+        else:
+            self._multi_step_decode(*decode_args)
         self.on_multi_step_decode_end(num_reqs)
 
-        return self.draft_tokens[:num_reqs]
+        return self.draft_tokens[:num_reqs, :active_num_speculative_tokens]
 
     @torch.inference_mode()
     def _run_model(
@@ -471,14 +506,17 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
         batch_desc: BatchExecutionDescriptor,
         num_tokens_across_dp: torch.Tensor | None,
         seq_lens_cpu_upper_bound: torch.Tensor,
+        num_speculative_tokens: int | None = None,
     ) -> None:
+        if num_speculative_tokens is None:
+            num_speculative_tokens = self.num_speculative_steps
         positions = self.input_buffers.positions[:num_reqs]
         query_start_loc = self.input_buffers.query_start_loc[: num_reqs + 1]
         idx_mapping = self.idx_mapping[:num_reqs]
 
         attn_metadata = None
         slot_mappings_by_layer = None
-        for step in range(1, self.num_speculative_steps):
+        for step in range(1, num_speculative_tokens):
             # Rebuild every step when positions advance, or just once
             # on the first step when positions are constant (Gemma4 MTP).
             if not skip_attn and (self.advance_draft_positions or step == 1):
@@ -521,7 +559,11 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
         batch_desc: BatchExecutionDescriptor,
         num_tokens_across_dp: torch.Tensor | None,
         seq_lens_cpu_upper_bound: torch.Tensor,
+        num_speculative_tokens: int | None = None,
+        decode_cudagraph_manager: SpeculatorCudaGraphManager | None = None,
     ) -> None:
+        if num_speculative_tokens is None:
+            num_speculative_tokens = self.num_speculative_steps
         positions = self.input_buffers.positions[:num_reqs]
         query_start_loc = self.input_buffers.query_start_loc[: num_reqs + 1]
         idx_mapping = self.idx_mapping[:num_reqs]
@@ -548,8 +590,10 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
             )
 
         if batch_desc.cg_mode == CUDAGraphMode.FULL:
-            assert self.decode_cudagraph_manager is not None
-            self.decode_cudagraph_manager.run_fullgraph(batch_desc)
+            if decode_cudagraph_manager is None:
+                decode_cudagraph_manager = self.decode_cudagraph_manager
+            assert decode_cudagraph_manager is not None
+            decode_cudagraph_manager.run_fullgraph(batch_desc)
             return
 
         self._generate_fused_drafts(
@@ -559,6 +603,7 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
             slot_mappings_by_layer,
             num_tokens_across_dp,
             batch_desc.cg_mode,
+            num_speculative_tokens=num_speculative_tokens,
         )
 
     def _generate_fused_drafts(
@@ -569,7 +614,10 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
         slot_mappings: dict[str, torch.Tensor] | None,
         num_tokens_across_dp: torch.Tensor | None,
         cudagraph_runtime_mode: CUDAGraphMode = CUDAGraphMode.NONE,
+        num_speculative_tokens: int | None = None,
     ) -> None:
+        if num_speculative_tokens is None:
+            num_speculative_tokens = self.num_speculative_steps
         idx_mapping = self.idx_mapping[:num_reqs]
         positions = self.input_buffers.positions[:num_reqs]
         query_start_loc = self.input_buffers.query_start_loc[: num_reqs + 1]
@@ -579,7 +627,7 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
             else []
         )
 
-        for step in range(1, self.num_speculative_steps):
+        for step in range(1, num_speculative_tokens):
             self.current_draft_step.fill_(step)
             self._generate_draft(
                 num_reqs,
@@ -590,7 +638,7 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
                 cudagraph_runtime_mode,
             )
             if (
-                step < self.num_speculative_steps - 1
+                step < num_speculative_tokens - 1
                 and attn_metadata is not None
                 and self.advance_draft_positions
             ):

--- a/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
@@ -327,6 +327,7 @@ class DFlashSpeculator(DraftModelSpeculator):
         skip_attn_for_dummy_run: bool = False,
         mm_inputs: tuple[list[torch.Tensor], torch.Tensor] | None = None,
         is_profile: bool = False,
+        num_speculative_tokens: int | None = None,
     ) -> torch.Tensor:
         num_reqs = input_batch.num_reqs
         num_target_tokens = input_batch.num_tokens

--- a/vllm/v1/worker/gpu/spec_decode/multi_module_mtp/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/multi_module_mtp/speculator.py
@@ -155,6 +155,7 @@ class MultiModuleMTPSpeculator(DraftModelSpeculator):
         skip_attn_for_dummy_run: bool = False,
         mm_inputs: tuple[list[torch.Tensor], torch.Tensor] | None = None,
         is_profile: bool = False,
+        num_speculative_tokens: int | None = None,
     ) -> torch.Tensor:
         num_reqs = input_batch.num_reqs
         seq_lens_cpu_upper_bound = input_batch.seq_lens_cpu_upper_bound

--- a/vllm/v1/worker/gpu/spec_decode/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/speculator.py
@@ -65,6 +65,7 @@ class BaseSpeculator(ABC):
         skip_attn_for_dummy_run: bool = False,
         mm_inputs: tuple[list[torch.Tensor], torch.Tensor] | None = None,
         is_profile: bool = False,
+        num_speculative_tokens: int | None = None,
     ) -> torch.Tensor:
         pass
 


### PR DESCRIPTION
# STACKED / DEPENDENT PR

Depends on:

- #49652 - fixed-query-length autoregressive draft CUDA graph capture
- #51575 - runtime K propagation, K0 behavior, and active-width publication

This branch currently contains those prerequisite commits solely so the positive-K follow-on can be built and validated before they merge.

The unique contribution of this PR is commit `4d9b59acd5213a93c7389a9a1c7195c73f1f5a89`, and that commit changes only:

- `vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py`
- `tests/v1/worker/test_gpu_autoregressive_speculator.py`

## Problem

For positive dynamic K below the configured maximum, MRV2 can receive the scheduler-selected K while `AutoRegressiveSpeculator` still physically executes the configured maximum amount of autoregressive draft work.

## Solution

- Reuse #51575's runtime `num_speculative_tokens` value.
- K1 stops after draft prefill.
- Non-fused execution performs exactly K-1 post-prefill draft forwards.
- Fused execution captures and selects a graph for each required positive depth.
- The configured maximum remains the default/static graph.
- Return exactly K draft tokens.

This contains no policy, EMA, thresholds, optimistic-depth policy, or workload-specific tuning.

## Validation

### Unit and static

- Focused positive-K tests: 13 passed.
- Adjacent autoregressive speculator suite: 31 passed.
- #51575 K0/lifetime regression: passed.
- Ruff check and format: passed.
- `git diff --check`: passed.

### Hardware

Validated this exact candidate (`4d9b59acd5213a93c7389a9a1c7195c73f1f5a89`) with official Qwen3.8-27B FP8 weights on an RTX PRO 6000 Blackwell using BF16 KV, MRV2, `FULL_AND_PIECEWISE`, the normal Qwen3.8 chat template/parser stack, and `/v1/chat/completions`:

- At configured/default K4, the scheduler selected K4, the default K4 fused graph replayed, three post-prefill draft forwards executed (four total draft generations), and the published draft shape was `[1, 4]`.
- At reduced positive K3, the scheduler selected K3, a physically distinct K3 fused graph replayed, two post-prefill draft forwards executed (three total draft generations), and the published draft shape was `[2, 3]`.
- Published output storage did not alias proposer-owned storage.
- Both normal chat-completions requests completed correctly.
- CUDA graph capture and replay completed without CUDA, OOM, Xid, GSP, or NVRM faults.
- The candidate worktree remained clean at the exact submitted HEAD.

As secondary cross-architecture evidence, the same candidate was previously validated with MiMo 7B through the generic `AutoRegressiveSpeculator` path. External tracing exercised K3, K2, K1, and prerequisite K0 behavior, confirmed depth-specific physical work and publication widths, and completed a basic generation/lifecycle smoke without graph, lifecycle, or driver failure.

The bug was discovered during local Qwen3.8 performance work; this PR is intentionally limited to generic positive-K execution semantics. 

After #49652 and #51575 merge, this branch will be rebased so the PR diff contains only the two-file positive-K follow-on.

## AI assistance disclosure

OpenAI Codex assisted with implementation, testing, and PR preparation. John reviewed the mechanism and validation and is responsible for the submission.
