### PR TITLE
[Config] Unify indexer cache dtype under attention_config.indexer_kv_dtype

### DIFF
--- a/tests/evals/gsm8k/configs/DeepSeek-V4-Flash-DSpark-confidence-TP4.yaml
+++ b/tests/evals/gsm8k/configs/DeepSeek-V4-Flash-DSpark-confidence-TP4.yaml
@@ -15,7 +15,7 @@ server_args: >-
   --block-size 256
   --gpu-memory-utilization 0.5
   --kv-cache-dtype fp8
-  --attention_config.use_fp4_indexer_cache=True
+  --attention_config.indexer_kv_dtype=mxfp4
   --max-num-batched-tokens 16384
   --max-num-seqs 128
   --speculative-config '{"method":"dspark",

--- a/tests/evals/gsm8k/configs/moe-refactor/DeepSeek-V4-Flash-deepgemm-mega-moe.yaml
+++ b/tests/evals/gsm8k/configs/moe-refactor/DeepSeek-V4-Flash-deepgemm-mega-moe.yaml
@@ -2,4 +2,4 @@ model_name: "deepseek-ai/DeepSeek-V4-Flash"
 accuracy_threshold: 0.95
 num_questions: 1319
 num_fewshot: 5
-server_args: "--trust-remote-code --kv-cache-dtype fp8 --block-size 256 --enable-expert-parallel --tensor-parallel-size 2 --attention_config.use_fp4_indexer_cache=True --moe-backend deep_gemm_mega_moe --tokenizer-mode deepseek_v4 --tool-call-parser deepseek_v4 --enable-auto-tool-choice --reasoning-parser deepseek_v4 --speculative_config.method=mtp --speculative_config.num_speculative_tokens=2"
+server_args: "--trust-remote-code --kv-cache-dtype fp8 --block-size 256 --enable-expert-parallel --tensor-parallel-size 2 --attention_config.indexer_kv_dtype=mxfp4 --moe-backend deep_gemm_mega_moe --tokenizer-mode deepseek_v4 --tool-call-parser deepseek_v4 --enable-auto-tool-choice --reasoning-parser deepseek_v4 --speculative_config.method=mtp --speculative_config.num_speculative_tokens=2"

--- a/vllm/config/attention.py
+++ b/vllm/config/attention.py
@@ -7,10 +7,13 @@ from typing import Any, Literal
 from pydantic import field_validator
 
 from vllm.config.utils import config
+from vllm.logger import init_logger
 from vllm.v1.attention.backends.mla.prefill.registry import MLAPrefillBackendEnum
 from vllm.v1.attention.backends.registry import AttentionBackendEnum
 
-IndexerKVDType = Literal["bf16", "fp8", "mxfp4", "nvfp4"]
+logger = init_logger(__name__)
+
+IndexerKVDType = Literal["auto", "bf16", "fp8", "mxfp4", "nvfp4"]
 MiniMaxM3MSADecodeBackend = Literal["triton", "cutlass"]
 
 
@@ -65,12 +68,15 @@ class AttentionConfig:
     use_prefill_query_quantization: bool = False
     """If set, quantize query for attention in prefill."""
 
-    use_fp4_indexer_cache: bool = False
-    """If set, use fp4 indexer cache for dsv32 family model (not support yet)"""
+    use_fp4_indexer_cache: bool | None = None
+    """Deprecated alias for `indexer_kv_dtype`; use that instead. True maps to
+    `mxfp4`, False is a no-op (it selected the model default already)."""
 
-    indexer_kv_dtype: IndexerKVDType = "bf16"
-    """Data type for the sparse-attention indexer K cache. Quantized formats
-    (fp8, mxfp4, nvfp4) require indexer kernel support in the backend."""
+    indexer_kv_dtype: IndexerKVDType = "auto"
+    """Data type for the sparse-attention indexer K cache. "auto" picks the
+    model's default (bf16 for MiniMax M3, fp8 for the DeepSeek sparse
+    indexer). Quantized formats (fp8, mxfp4, nvfp4) require indexer kernel
+    support in the backend."""
 
     use_non_causal: bool = False
     """Whether to use non-causal (bidirectional) attention."""
@@ -114,6 +120,26 @@ class AttentionConfig:
             # layers still use the platform's normal automatic backend.
             self.backend = None
 
+        if self.use_fp4_indexer_cache is not None:
+            logger.warning(
+                "use_fp4_indexer_cache is deprecated and will be removed in "
+                "v0.19. Use indexer_kv_dtype instead (True -> 'mxfp4')."
+            )
+            if self.use_fp4_indexer_cache:
+                if self.indexer_kv_dtype not in ("auto", "mxfp4"):
+                    raise ValueError(
+                        "use_fp4_indexer_cache=True conflicts with "
+                        f"indexer_kv_dtype={self.indexer_kv_dtype!r}. Set only "
+                        "indexer_kv_dtype."
+                    )
+                self.indexer_kv_dtype = "mxfp4"
+
+    def resolve_indexer_kv_dtype(self, default: IndexerKVDType) -> IndexerKVDType:
+        """Resolve `indexer_kv_dtype`, substituting `default` for "auto"."""
+        if self.indexer_kv_dtype == "auto":
+            return default
+        return self.indexer_kv_dtype
+
     def compute_hash(self) -> str:
         """
         Provide a hash that uniquely identifies all the configs
@@ -124,7 +150,8 @@ class AttentionConfig:
         """
         from vllm.config.utils import get_hash_factors, hash_factors
 
-        ignored_factors: set[str] = set()
+        # Folded into indexer_kv_dtype by __post_init__.
+        ignored_factors: set[str] = {"use_fp4_indexer_cache"}
         factors = get_hash_factors(self, ignored_factors)
         return hash_factors(factors)
 

--- a/vllm/models/deepseek_v4/attention.py
+++ b/vllm/models/deepseek_v4/attention.py
@@ -56,6 +56,7 @@ from vllm.utils.multi_stream_utils import (
 from vllm.v1.attention.backend import AttentionBackend, AttentionMetadata
 from vllm.v1.attention.backends.mla.indexer import (
     DeepseekV4IndexerBackend,
+    dsa_indexer_uses_fp4,
     get_max_prefill_buffer_size,
 )
 from vllm.v1.attention.backends.mla.sparse_swa import DeepseekV4SWACache
@@ -805,7 +806,7 @@ class DeepseekV4Indexer(nn.Module):
         self.q_lora_rank = q_lora_rank  # 1536
         self.compress_ratio = compress_ratio
         self.eager_scratch_pool = eager_scratch_pool
-        self.use_fp4_kv = self.vllm_config.attention_config.use_fp4_indexer_cache
+        self.use_fp4_kv = dsa_indexer_uses_fp4(vllm_config)
         logger.info_once(
             "Using %s indexer cache for Lightning Indexer.",
             "MXFP4" if self.use_fp4_kv else "FP8",

--- a/vllm/models/minimax_m3/nvidia/model.py
+++ b/vllm/models/minimax_m3/nvidia/model.py
@@ -498,7 +498,9 @@ class MiniMaxM3SparseAttention(nn.Module, AttentionLayerBase):
         set_default_quant_scales(self, register_buffer=True)
         # Indexer side-cache dtype, mirroring --kv-cache-dtype for the main
         # cache (--attention-config '{"indexer_kv_dtype": ...}').
-        self.indexer_kv_dtype = vllm_config.attention_config.indexer_kv_dtype
+        self.indexer_kv_dtype = vllm_config.attention_config.resolve_indexer_kv_dtype(
+            "bf16"
+        )
 
         # Shared top-k buffer: the indexer writes the selected blocks into it and
         # the attend impl reads them back (so nothing crosses the eager break as a

--- a/vllm/v1/attention/backends/mla/indexer.py
+++ b/vllm/v1/attention/backends/mla/indexer.py
@@ -40,6 +40,28 @@ from vllm.v1.kv_cache_interface import KVCacheSpec, MLAAttentionSpec
 
 logger = init_logger(__name__)
 
+# The DSA indexer K cache is always quantized; "auto" means fp8 (V3.2 layout)
+# and mxfp4 is the opt-in Blackwell path.
+DSA_INDEXER_KV_DTYPES = ("fp8", "mxfp4")
+
+
+def dsa_indexer_uses_fp4(vllm_config: VllmConfig) -> bool:
+    """Whether the DeepSeek sparse indexer should use the MXFP4 K cache."""
+    kv_dtype = vllm_config.attention_config.resolve_indexer_kv_dtype("fp8")
+    if kv_dtype not in DSA_INDEXER_KV_DTYPES:
+        raise ValueError(
+            f"indexer_kv_dtype={kv_dtype!r} is not supported by the DeepSeek "
+            f"sparse indexer (expected one of {DSA_INDEXER_KV_DTYPES})."
+        )
+    use_fp4 = kv_dtype == "mxfp4"
+    if use_fp4 and not current_platform.is_device_capability_family(100):
+        raise ValueError(
+            "indexer_kv_dtype='mxfp4' requires Blackwell datacenter GPUs "
+            "(sm_10x, e.g. B200/GB200); sm_120 (consumer Blackwell) and "
+            "earlier architectures are not supported."
+        )
+    return use_fp4
+
 
 @triton.jit
 def _prepare_uniform_decode_kernel(
@@ -526,18 +548,7 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
             if self.vllm_config.speculative_config
             else 0
         )
-        self.use_fp4_indexer_cache = (
-            self.vllm_config.attention_config.use_fp4_indexer_cache
-        )
-
-        assert (
-            current_platform.is_device_capability_family(100)
-            or not self.use_fp4_indexer_cache
-        ), (
-            "use_fp4_indexer_cache requires Blackwell datacenter GPUs "
-            "(sm_10x, e.g. B200/GB200); sm_120 (consumer Blackwell) and "
-            "earlier architectures are not supported."
-        )
+        self.use_fp4_indexer_cache = dsa_indexer_uses_fp4(self.vllm_config)
 
         next_n = self.num_speculative_tokens + 1
         self.decode_threshold = next_n
@@ -546,7 +557,7 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
         self.supports_varlen = _supports_varlen_paged_mqa_logits()
         logger.info_once(
             "DSA indexer decode path: use_flattening=%s supports_varlen=%s "
-            "(next_n=%d, use_fp4_indexer_cache=%s)",
+            "(next_n=%d, use_fp4_cache=%s)",
             self.use_flattening,
             self.supports_varlen,
             next_n,


### PR DESCRIPTION
## Purpose

The sparse-attention indexer picked its K-cache dtype through two unrelated knobs:

| flag | type | read by |
| --- | --- | --- |
| `attention_config.use_fp4_indexer_cache` | `bool` | DeepSeek V3.2/V4 only |
| `attention_config.indexer_kv_dtype` | enum | MiniMax M3 only |

Because each model read only one of them, passing both was accepted and quietly
resolved in favor of the bool on the DeepSeek path. A config asking for an fp8
indexer cache (`--attention_config.indexer_kv_dtype fp8`) alongside
`--attention_config.use_fp4_indexer_cache=True` ran MXFP4, with no warning. I hit
exactly this in a local DSV4 recipe whose "fp8 indexer" arm had in fact been
running MXFP4 for its whole history.

This PR makes `indexer_kv_dtype` the single knob and deprecates
`use_fp4_indexer_cache`.

## Changes

**`vllm/config/attention.py`**
- `indexer_kv_dtype` gains an `"auto"` default, resolved per model by the new
  `resolve_indexer_kv_dtype(default)`. The old `"bf16"` default was never
  meaningful for DeepSeek, whose indexer cache is always quantized; `"auto"`
  means fp8 there and bf16 for M3, preserving both models' current behavior.
- `use_fp4_indexer_cache` becomes `bool | None = None`. When set it logs a
  deprecation warning (removal in v0.19) and maps `True -> "mxfp4"`. `False` is
  a no-op because it already selected the model default. Conflicting values now
  raise instead of one silently winning.
- The deprecated field is excluded from `compute_hash`, so
  `use_fp4_indexer_cache=True` and `indexer_kv_dtype=mxfp4` share a compile
  cache entry rather than splitting it.

**`vllm/v1/attention/backends/mla/indexer.py`**
- New `dsa_indexer_uses_fp4(vllm_config)` centralizes resolution + validation for
  the DeepSeek path, so the model side and the metadata builder cannot disagree.
  It rejects dtypes the DSA indexer has no kernels for (`bf16`, `nvfp4`) instead
  of failing later in kernel selection, and turns the existing Blackwell
  `assert` into a `ValueError` so the check survives `python -O`.

**Callers** — `models/deepseek_v4/attention.py` and
`models/minimax_m3/nvidia/model.py` go through the shared helpers. DSV4 now
validates at model construction too, not only at backend build.

**Configs** — the two tracked gsm8k eval configs move to
`--attention_config.indexer_kv_dtype=mxfp4`.

## Backward compatibility

`--attention_config.use_fp4_indexer_cache=True` keeps working and keeps
selecting MXFP4; it just warns. All three CLI spellings were exercised
(`--attention_config.indexer_kv_dtype=mxfp4`, the deprecated flag, and JSON
`--attention-config '{"indexer_kv_dtype": "nvfp4"}'`).

The one intentional behavior change: a config passing **both** flags with
different values used to silently take the bool, and now raises. That
combination was always a contradiction; on the DeepSeek path it produced a cache
dtype the config did not ask for.

## Not a duplicate

Per the duplicate-work checks in `AGENTS.md`:

```
gh pr list --repo vllm-project/vllm --state open --search "indexer_kv_dtype"
gh pr list --repo vllm-project/vllm --state open --search "use_fp4_indexer_cache"
gh pr list --repo vllm-project/vllm --state open --search "deprecate indexer cache"
gh pr list --repo vllm-project/vllm --state open --search "unify indexer dtype attention config"
```

Nearest open PRs, all adjacent rather than overlapping — none touches
`vllm/config/attention.py` or unifies the two knobs:

- #51209 (IndexCache for DeepSeek-V4) — touches `models/deepseek_v4/attention.py`,
  the one file in common, but adds a feature; no config-surface change.
- #47665 (MiniMax-M3 fp8 index cache on the Triton indexer) — *consumes*
  `indexer_kv_dtype`, does not change how it is selected.
- #48558 (MXFP4 indexer cache for GLM-5.2 / DSA) — kernel + `deepseek_v2.py`.

If #51209 lands first the overlap is a small context conflict in
`DeepseekV4Indexer.__init__`, trivially rebasable.

## Testing

```
pre-commit run --files <changed files>          # all hooks pass, incl. mypy
.venv/bin/python -m pytest tests/config/test_config_generation.py \
                          tests/engine/test_arg_utils.py -q
# 98 passed, 1 failed
```

The single failure is `test_config_generation.py::test_ray_runtime_env`
(`ModuleNotFoundError`, ray not installed); confirmed pre-existing by rerunning
it on a clean stash of `main`.

Config-resolution matrix verified directly (default -> `auto`; deprecated
`True` -> `mxfp4` + warning; deprecated `False` -> `auto`; conflict -> raises;
`auto` -> fp8/bf16 per model; hashes of the deprecated and new spellings match).

## Model evaluation

Real serving run on the DeepSeek path this change is riskiest for — TP8 over
2x GB300 (8 GPUs), DSpark speculative decoding (7 tokens, greedy),
`--attention-config.backend FLASHINFER_MLA`, `--kv-cache-dtype fp8`,
`cudagraph_mode FULL_DECODE_ONLY`, driven by the **new** flag
`--attention_config.indexer_kv_dtype=mxfp4`.

Engine log confirms the unified flag drives both consumers to the MXFP4 path:

```
attention_config=AttentionConfig(..., use_fp4_indexer_cache=None, indexer_kv_dtype='mxfp4', ...)
[attention.py:810] Using MXFP4 indexer cache for Lightning Indexer.
[indexer.py:558] DSA indexer decode path: use_flattening=False supports_varlen=True (next_n=8, use_fp4_cache=True)
```

aime25, 4 epochs, n=120, 0 request errors, temperature 1.0 / top_p 0.95,
thinking enabled, max_tokens 150000:

| metric | value |
| --- | --- |
| exact_match | 1.0000 |
| pass@4 | 1.0000 |

Caveat worth stating plainly: aime25 is saturated for this checkpoint, so this
result confirms the MXFP4 path is intact end-to-end but cannot by itself
distinguish it from fp8 or from the pre-change build. The stronger evidence for
"no behavior change" is that `"auto"` resolves to each model's previous default
and the resolution matrix above is exhaustive over the flag combinations.

## AI assistance

AI assistance (Claude Code) was used for this change. I reviewed every changed
line, ran the tests and the multi-node eval above myself, and can defend the
change end-to-end.
