### PR TITLE
[Bugfix] Keep GEMM workspace addresses stable once CUDA graphs may have captured them

### DIFF
--- a/vllm/model_executor/warmup/kernel_warmup.py
+++ b/vllm/model_executor/warmup/kernel_warmup.py
@@ -162,6 +162,15 @@ def kernel_warmup(worker: "Worker", *, process_local_only: bool = False):
 
     minimax_m3_msa_warmup(worker)
 
+    # Grow FlashInfer's shared GEMM workspace to its high-water mark now,
+    # while no CUDA graph has been captured: growing it later moves the
+    # buffer and leaves captured graphs replaying against freed memory
+    # (see presize_flashinfer_gemm_workspaces).
+    if has_flashinfer() and current_platform.has_device_capability(90):
+        from vllm.utils.flashinfer import presize_flashinfer_gemm_workspaces
+
+        presize_flashinfer_gemm_workspaces(worker.device)
+
     enable_flashinfer_autotune = (
         worker.vllm_config.kernel_config.enable_flashinfer_autotune
     )

--- a/vllm/utils/flashinfer.py
+++ b/vllm/utils/flashinfer.py
@@ -915,8 +915,15 @@ def presize_flashinfer_gemm_workspaces(
         return
     # Workspace names used by the GEMM lanes vLLM routes through
     # FlashInfer's autotuner (which may select the cuDNN runner).
+    # zero_init matters: cuDNN split-K plans keep completion semaphores in
+    # the workspace and spin forever on garbage values; a fresh cudaMalloc
+    # happens to hand back zeroed pages, but that is luck, not a contract.
     for name in ("bmm_fp8_workspace",):
-        _get_cache_buf(name, size, device)
+        try:
+            _get_cache_buf(name, size, device, zero_init=True)
+        except TypeError:
+            # older FlashInfer without the zero_init parameter
+            _get_cache_buf(name, size, device)
 
 
 def flashinfer_scaled_fp8_mm(

--- a/vllm/utils/flashinfer.py
+++ b/vllm/utils/flashinfer.py
@@ -884,6 +884,41 @@ def flashinfer_scaled_fp4_mm_out(
     return out
 
 
+def presize_flashinfer_gemm_workspaces(
+    device: torch.device, size: int = 64 * 1024 * 1024
+) -> None:
+    """Grow FlashInfer's shared GEMM workspace before any CUDA graph capture.
+
+    FlashInfer's cuDNN GEMM execute paths grow their shared cache workspace
+    with ``tensor.resize_()`` whenever an execution plan asks for more than
+    the current buffer (32 MiB by default). ``resize_()`` frees the old
+    storage and moves the buffer to a new device address, but launches
+    already captured into CUDA graphs keep the old raw pointer, so a
+    post-capture grow turns every subsequent replay into a use-after-free:
+    cuDNN kernels read scratch from, and write scratch over, whatever
+    tensors the allocator hands the freed block to. Observed as illegal
+    memory access / misaligned address faults and GPU wedges minutes into
+    serving (see issue #52540; a 256-byte overflow past the 32 MiB default
+    during capture was enough).
+
+    Pre-growing the shared buffer past any plan's realistic demand keeps
+    the address stable for the lifetime of the process. This guard is
+    needed until a FlashInfer release ships the allocation fix
+    (flashinfer-ai/flashinfer#4553); it is cheap (one buffer per device)
+    and a no-op when FlashInfer is absent.
+    """
+    if not has_flashinfer():
+        return
+    try:
+        from flashinfer.utils import _get_cache_buf
+    except ImportError:
+        return
+    # Workspace names used by the GEMM lanes vLLM routes through
+    # FlashInfer's autotuner (which may select the cuDNN runner).
+    for name in ("bmm_fp8_workspace",):
+        _get_cache_buf(name, size, device)
+
+
 def flashinfer_scaled_fp8_mm(
     a: torch.Tensor,
     b: torch.Tensor,

--- a/vllm/v1/attention/backends/mla/cutlass_mla.py
+++ b/vllm/v1/attention/backends/mla/cutlass_mla.py
@@ -79,6 +79,11 @@ class SM100Workspace:
         self._workspace_buf = torch.empty(
             initial_workspace_size, device="cuda", dtype=torch.uint8
         )
+        # Retired workspace generations. CUDA graphs capture the raw device
+        # pointer of whichever buffer was current at capture time, so a
+        # buffer may never be freed once a graph could have captured it;
+        # growing the workspace must keep every older generation alive.
+        self._retired_bufs: list[torch.Tensor] = []
 
         self._block_size = 128  # Forced to 128
 
@@ -101,7 +106,18 @@ class SM100Workspace:
         )
 
         if self._workspace_buf.shape[0] < workspace_size:
-            self._workspace_buf.resize_(workspace_size)
+            # Do NOT resize_() in place: resize_() frees the old storage,
+            # while launches already enqueued and CUDA graphs captured
+            # against the old device address keep dereferencing it. Replays
+            # would then read/write memory the allocator has reused for
+            # unrelated tensors. Allocate a new buffer and retire the old
+            # one instead; graphs captured against a retired buffer stay
+            # correct because its capture-time size was sufficient for the
+            # shapes baked into those graphs.
+            self._retired_bufs.append(self._workspace_buf)
+            self._workspace_buf = torch.empty(
+                workspace_size, device="cuda", dtype=torch.uint8
+            )
 
 
 g_sm100_workspace = SM100Workspace(128 * 1024 * 1024)  # 128MB

--- a/vllm/v1/attention/backends/mla/cutlass_mla.py
+++ b/vllm/v1/attention/backends/mla/cutlass_mla.py
@@ -115,7 +115,10 @@ class SM100Workspace:
             # correct because its capture-time size was sufficient for the
             # shapes baked into those graphs.
             self._retired_bufs.append(self._workspace_buf)
-            self._workspace_buf = torch.empty(
+            # zeros, not empty: split-KV workspaces carry semaphore/accum
+            # regions that kernels expect to start zeroed; a recycled dirty
+            # block from the caching allocator can hang or corrupt them.
+            self._workspace_buf = torch.zeros(
                 workspace_size, device="cuda", dtype=torch.uint8
             )
 


### PR DESCRIPTION
Related: #52540, #34948

## Purpose

Root-cause fix-out for the SM120 NVFP4 serving crashes in #52540 (and at least some reports in #34948): a **shared GEMM workspace that changes device address after CUDA graphs have captured launches against it** turns every subsequent replay into a use-after-free.

The defect that kills the #52540 configuration lives in FlashInfer: every cuDNN GEMM execute path in `flashinfer/gemm/gemm_base.py` grows its shared 32 MiB workspace with `tensor.resize_()` when an execution plan asks for more. `resize_()` frees the old storage and moves the buffer; launches already enqueued, and CUDA graphs captured earlier, keep dereferencing the old address, which the caching allocator immediately reuses for unrelated tensors. Fix filed upstream as flashinfer-ai/flashinfer#4553. Instrumented evidence from the failing machine (full matrix in #52540):

```
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  89%|████████▉ | 8/9
[F5WS 21:32:46] RESIZE old_ptr=0x7efadc000000 old=33554432 new=33554688
[F5WS 21:32:46] RESIZE done new_ptr=0x7efa8d200000
```

One cuDNN FP8 plan wanted 256 bytes more than the 32 MiB default, mid-capture; the eight piecewise graphs already captured kept the stale pointer, and the server died minutes into serving — a GPU coredump caught `cudnn_generated_fort_native_*` faulting on a "pointer" that was two int32s of unrelated tensor data (`0x27000013FF`).

This PR does two things on the vLLM side:

1. **Pre-grow FlashInfer's shared FP8 GEMM workspace during kernel warmup, before any capture** (`presize_flashinfer_gemm_workspaces` in `vllm/utils/flashinfer.py`, called from `kernel_warmup`). With the address fixed at its high-water mark before the first capture, the in-place grow in current FlashInfer releases never fires. This is a guard, not the root fix; it is cheap (one 64 MiB buffer per device on the FlashInfer FP8 path), and it protects every vLLM+FlashInfer user until a FlashInfer release carries flashinfer-ai/flashinfer#4553.

2. **Fix the same defect class in vLLM's own tree**: `SM100Workspace.ensure_size` in `vllm/v1/attention/backends/mla/cutlass_mla.py` grew its shared workspace with `resize_()` too. Growth now allocates a fresh buffer and retires the old one instead of freeing it, so graphs captured against an older generation keep a live, correct address (their capture-time size was sufficient for the shapes baked into them).

## Diagnosis trail (short form; full evidence in #52540)

- Same model FP8-quantized end-to-end: stable 35 h. NVFP4-mixed build: dies/wedges in ~16.5 min under 24-way load, graphs ON. Established by falsification: not the NVFP4 GEMM kernels (swapping/removing them changes nothing), not KV shape, not MTP/prefix-cache.
- GPU coredump-on-exception on the failing config names the faulting kernel: a cuDNN FP8 GEMM (`matMul_pointwise_pointwise`) reading garbage pointer arguments — the FP8 projections feeding the GDN/attention layers, not the NVFP4 GEMMs themselves.
- Instrumenting FlashInfer's eight `resize_` sites shows the workspace moving *during* vLLM's piecewise capture on this build; the FP8-only build happens to hit its workspace high-water mark before capture, which is why it never crashed. The quantization scheme was never the mechanism — it only determined *when* the first oversized cuDNN plan arrived.
- Instrumenting under `CUDA_LAUNCH_BLOCKING=1` attributed the *hang* mode to the same lane: CUDA error 702 in seconds, raised through `execute_cudnn_gemm_fp8_graph → execute_plan_at_index`. cuDNN split-K plans keep completion semaphores inside the workspace (the oversized request is exactly 32 MiB + 256 B); non-zeroed workspace memory makes the kernel spin forever. Hence the second commit of flashinfer-ai/flashinfer#4553 and `zero_init=True` in this PR's pre-size guard.
- With both workspace fixes applied, a third failure remained (~13.5 min): a GPU coredump caught a cuDNN sm120 GEMM kernel dereferencing pointer value `0x1` — pointer slots holding what look like GEMM dims/strides, consistent with cuDNN device-side parameter staging being rewritten while captured launches replay. **Excluding the cuDNN runner from the FlashInfer fp8/bf16 GEMM autotune lanes ran the same soak clean for the full 55 minutes (3.3× baseline MTTF, 2,708 completions, 0 errors) at ~22% higher throughput** (cublas/cutlass fp8 beat the tuned cuDNN config on this workload).
- FlashInfer `main` already gates cuDNN out of `bmm_fp8` auto-candidates on SM12x when override_shape is unavailable (citing "async CUDA fault escapes"); flashinfer 0.6.14 — what current vLLM images ship — predates that gate.
- Operator workaround available today with no patch: `VLLM_DISABLED_KERNELS=FlashInferFP8ScaledMMLinearKernel`, which falls back to `CutlassFP8ScaledMMLinearKernel`. Validated on the failing configuration (30-minute soak, graphs ON, clean; goldens byte-identical) — numbers in #52540.
- 50 temperature-0 classification goldens are byte-identical across every fixed configuration.

A question for maintainers beyond this PR: whether vLLM should avoid `FlashInferFP8ScaledMMLinearKernel` (or FlashInfer should avoid autotuning `Cudnn*GemmRunner`s) wherever the lane will be captured into CUDA graphs while the same cuDNN handle keeps serving eager executes, until the parameter-staging interaction is resolved upstream.

## Test Plan

- `presize_flashinfer_gemm_workspaces`: exercised on 2× RTX PRO 6000 Blackwell (SM120) with the #52540 reproducer; no behavioural change beyond the pre-allocation.
- `cutlass_mla.py`: mechanical change, growth path preserved; covered by existing CUTLASS MLA tests on SM100.

## Test Result

See validation numbers above; goldens byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WbnhJtzC1GpmDBiLQiboiD
