### PR TITLE
[Frontend] Add decoded-word repetition stopping

### DIFF
--- a/tests/v1/core/test_repetition_detection.py
+++ b/tests/v1/core/test_repetition_detection.py
@@ -107,6 +107,38 @@ class TestCheckSequenceRepetition:
         )
         assert check_sequence_repetition(token_ids, params)
 
+    def test_default_mode_does_not_match_gap_separated_occurrence(self):
+        """Test that the default preserves consecutive-only semantics."""
+        token_ids = [1, 2, 3, 90, 91, 1, 2, 3]
+        params = RepetitionDetectionParams(
+            max_pattern_size=3,
+            min_pattern_size=3,
+            min_count=2,
+        )
+        assert params.mode == "consecutive"
+        assert not check_sequence_repetition(token_ids, params)
+
+    def test_word_anywhere_mode_is_deferred_to_detokenizer(self):
+        """Test that decoded-word mode does not stop in the token scheduler."""
+        token_ids = [1, 2, 3, 1, 2, 3]
+        params = RepetitionDetectionParams(
+            max_pattern_size=3,
+            min_pattern_size=3,
+            min_count=2,
+            mode="word_anywhere",
+        )
+        assert not check_sequence_repetition(token_ids, params)
+
+    def test_invalid_repetition_mode_is_rejected(self):
+        """Test that unsupported matching modes cannot enter the scheduler."""
+        with pytest.raises(ValueError, match="consecutive.*word_anywhere"):
+            RepetitionDetectionParams(
+                max_pattern_size=3,
+                min_pattern_size=3,
+                min_count=2,
+                mode="invalid",  # type: ignore[arg-type]
+            )
+
 
 # ============================================================================
 # INTEGRATION TESTS - check_stop with repetition detection

--- a/tests/v1/engine/test_word_repetition_detection.py
+++ b/tests/v1/engine/test_word_repetition_detection.py
@@ -1,0 +1,129 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from vllm.sampling_params import (
+    RepetitionDetectionParams,
+    RequestOutputKind,
+    SamplingParams,
+)
+from vllm.v1.engine import EngineCoreOutput, EngineCoreRequest, FinishReason
+from vllm.v1.engine.detokenizer import (
+    REPETITION_DETECTED_STOP_REASON,
+    BaseIncrementalDetokenizer,
+    DetokenizerFinish,
+)
+from vllm.v1.engine.output_processor import OutputProcessor
+
+
+class _CharacterDetokenizer(BaseIncrementalDetokenizer):
+    def decode_next(self, next_token_id: int) -> str:
+        return chr(next_token_id)
+
+
+def _make_request() -> EngineCoreRequest:
+    return EngineCoreRequest(
+        request_id="test-internal",
+        external_req_id="test",
+        prompt_token_ids=[],
+        mm_features=None,
+        sampling_params=SamplingParams(
+            max_tokens=256,
+            output_kind=RequestOutputKind.FINAL_ONLY,
+            repetition_detection=RepetitionDetectionParams(
+                min_pattern_size=8,
+                max_pattern_size=8,
+                min_count=2,
+                mode="word_anywhere",
+            ),
+        ),
+        pooling_params=None,
+        arrival_time=0.0,
+        lora_request=None,
+        cache_salt=None,
+        data_parallel_rank=None,
+    )
+
+
+def _encode(text: str) -> list[int]:
+    return [ord(char) for char in text]
+
+
+def _repeated_text() -> str:
+    return (
+        "One, TWO three four five six seven eight. gap "
+        "one two three four five six seven eight!"
+    )
+
+
+def test_word_repetition_waits_for_last_word_boundary_and_preserves_raw_text():
+    request = _make_request()
+    detokenizer = _CharacterDetokenizer(request)
+    raw_text = _repeated_text()
+
+    assert detokenizer.update(_encode(raw_text), stop_terminated=False) is None
+
+    finish = detokenizer.update(_encode(" "), stop_terminated=False)
+    assert finish == DetokenizerFinish(
+        FinishReason.REPETITION,
+        REPETITION_DETECTED_STOP_REASON,
+    )
+    assert detokenizer.output_text == raw_text + " "
+
+
+def test_word_repetition_does_not_override_core_stop():
+    request = _make_request()
+    detokenizer = _CharacterDetokenizer(request)
+    raw_text = _repeated_text() + " "
+
+    finish = detokenizer.update(
+        _encode(raw_text + "Z"),
+        stop_terminated=True,
+    )
+
+    assert finish is None
+    assert detokenizer.output_text == raw_text
+
+
+def test_word_repetition_truncates_later_text_from_the_same_step():
+    request = _make_request()
+    detokenizer = _CharacterDetokenizer(request)
+    raw_text = _repeated_text() + " "
+
+    finish = detokenizer.update(
+        _encode(raw_text + "this text arrived in the same step"),
+        stop_terminated=False,
+    )
+
+    assert finish == DetokenizerFinish(
+        FinishReason.REPETITION,
+        REPETITION_DETECTED_STOP_REASON,
+    )
+    assert detokenizer.output_text == raw_text
+
+
+def test_output_processor_maps_word_repetition_and_aborts_core():
+    request = _make_request()
+    detokenizer = _CharacterDetokenizer(request)
+    output_processor = OutputProcessor(tokenizer=None, log_stats=False)
+    output_processor.add_request(request, prompt="")
+    output_processor.request_states[request.request_id].detokenizer = detokenizer
+    raw_text = _repeated_text() + " "
+
+    processed = output_processor.process_outputs(
+        [
+            EngineCoreOutput(
+                request_id=request.request_id,
+                new_token_ids=_encode(raw_text),
+            )
+        ]
+    )
+
+    assert processed.reqs_to_abort == [request.request_id]
+    assert len(processed.request_outputs) == 1
+    request_output = processed.request_outputs[0]
+    assert request_output.finished
+    completion = request_output.outputs[0]
+    assert completion.text == raw_text
+    assert completion.finish_reason == "repetition"
+    assert completion.stop_reason == REPETITION_DETECTED_STOP_REASON
+    assert not output_processor.has_unfinished_requests()

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -8,7 +8,7 @@ import math
 from dataclasses import field
 from enum import Enum, IntEnum
 from functools import cached_property
-from typing import Annotated, Any
+from typing import Annotated, Any, Literal
 
 import msgspec
 from pydantic import BeforeValidator
@@ -175,6 +175,13 @@ class RepetitionDetectionParams:
     """Minimum number of times an N-gram pattern must repeat to trigger
     detection. Must be >= 2. Example: 3 for detecting a phrase repeated
     3 times. Must be used together with max_pattern_size."""
+
+    mode: Literal["consecutive", "word_anywhere"] = "consecutive"
+    """How matching occurrences are located. ``consecutive`` preserves the
+    original behavior and detects adjacent token N-grams at the end of the
+    output. ``word_anywhere`` detects repeated normalized word N-grams in
+    decoded output; pattern sizes are interpreted as word counts in that
+    mode."""
 
     def __post_init__(self):
         if (

--- a/vllm/v1/core/sched/utils.py
+++ b/vllm/v1/core/sched/utils.py
@@ -40,6 +40,10 @@ def check_sequence_repetition(
     min_pattern_size = params.min_pattern_size
     min_count = params.min_count
 
+    # Decoded-word repetition is detected by the frontend detokenizer.
+    if params.mode == "word_anywhere":
+        return False
+
     if min_pattern_size <= 0:
         min_pattern_size = 1
 

--- a/vllm/v1/engine/detokenizer.py
+++ b/vllm/v1/engine/detokenizer.py
@@ -2,7 +2,9 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import sys
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 
+import regex as re
 import tokenizers
 import tokenizers.decoders
 from packaging import version
@@ -10,15 +12,79 @@ from tokenizers import Tokenizer
 from transformers import TokenizersBackend
 
 from vllm.logger import init_logger
+from vllm.sampling_params import RepetitionDetectionParams
 from vllm.tokenizers import TokenizerLike
 from vllm.tokenizers.detokenizer_utils import (
     convert_prompt_ids_to_tokens,
     detokenize_incrementally,
 )
 from vllm.utils import length_from_prompt_token_ids_or_embeds
-from vllm.v1.engine import EngineCoreRequest
+from vllm.v1.engine import EngineCoreRequest, FinishReason
 
 logger = init_logger(__name__)
+
+_NON_WORD = re.compile(r"[^\w]+", flags=re.UNICODE)
+REPETITION_DETECTED_STOP_REASON = "repetition_detected"
+
+
+@dataclass(frozen=True)
+class DetokenizerFinish:
+    """A typed frontend finish signal emitted during detokenization."""
+
+    finish_reason: FinishReason
+    stop_reason: str
+
+
+class _WordRepetitionDetector:
+    """Incrementally count normalized word N-grams in decoded text."""
+
+    def __init__(self, params: RepetitionDetectionParams):
+        self._min_pattern_size = params.min_pattern_size or 1
+        self._max_pattern_size = params.max_pattern_size
+        self._min_count = params.min_count
+        self._words: list[str] = []
+        self._counts: dict[tuple[str, ...], int] = {}
+        self._word_start: int | None = None
+        self._text_offset = 0
+
+    def update(self, output_text: str) -> int | None:
+        """Return the end offset of the first newly completed repetition."""
+        for offset in range(self._text_offset, len(output_text)):
+            char = output_text[offset]
+            if not char.isspace():
+                if self._word_start is None:
+                    self._word_start = offset
+                continue
+
+            if self._word_start is None:
+                continue
+            word = _NON_WORD.sub(
+                "",
+                output_text[self._word_start : offset].casefold(),
+            )
+            self._word_start = None
+            if self._add_word(word):
+                self._text_offset = offset + 1
+                return self._text_offset
+
+        self._text_offset = len(output_text)
+        return None
+
+    def _add_word(self, word: str) -> bool:
+        self._words.append(word)
+        for pattern_size in range(
+            self._min_pattern_size,
+            min(self._max_pattern_size, len(self._words)) + 1,
+        ):
+            pattern = tuple(self._words[-pattern_size:])
+            if not all(pattern):
+                continue
+            count = self._counts.get(pattern, 0) + 1
+            if count >= self._min_count:
+                return True
+            self._counts[pattern] = count
+        return False
+
 
 # Only tokenizers >= 0.22.0 supports DecodeStream with native prefill
 # (ids parameter) used for FastIncrementalDetokenizer.
@@ -39,7 +105,11 @@ class IncrementalDetokenizer:
     def num_output_tokens(self) -> int:
         return len(self.token_ids)
 
-    def update(self, new_token_ids: list[int], stop_terminated: bool) -> str | None:
+    def update(
+        self,
+        new_token_ids: list[int],
+        stop_terminated: bool,
+    ) -> str | DetokenizerFinish | None:
         self.token_ids.extend(new_token_ids)
         return None
 
@@ -82,6 +152,15 @@ class BaseIncrementalDetokenizer(IncrementalDetokenizer, ABC):
         self.min_tokens = params.min_tokens
         self.include_stop_str_in_output = params.include_stop_str_in_output
 
+        repetition_params = params.repetition_detection
+        self.word_repetition_detector = (
+            _WordRepetitionDetector(repetition_params)
+            if repetition_params is not None
+            and repetition_params.mode == "word_anywhere"
+            and repetition_params.max_pattern_size > 0
+            else None
+        )
+
         # Number of chars to hold back when stop strings are to be excluded
         # from streamed output.
         if self.stop and not self.include_stop_str_in_output:
@@ -93,13 +172,17 @@ class BaseIncrementalDetokenizer(IncrementalDetokenizer, ABC):
         # Generation data
         self.output_text = ""
 
-    def update(self, new_token_ids: list[int], stop_terminated: bool) -> str | None:
+    def update(
+        self,
+        new_token_ids: list[int],
+        stop_terminated: bool,
+    ) -> str | DetokenizerFinish | None:
         """
         Update RequestState for the request_id by:
             1) Detokenize the new token ids incrementally.
-            2) Evaluate stop criteria.
+            2) Evaluate stop and repetition criteria.
 
-        Return matched stop string or None.
+        Return a matched stop string, typed finish signal, or None.
         """
         if not new_token_ids:
             # Skip detokenization if no new token ids.
@@ -140,7 +223,25 @@ class BaseIncrementalDetokenizer(IncrementalDetokenizer, ABC):
                 if truncate_to != -1:
                     self.output_text = self.output_text[:truncate_to]
 
-        return stop_string
+        if stop_string is not None:
+            return stop_string
+
+        repetition_end = None
+        if (
+            self.word_repetition_detector is not None
+            and not stop_terminated
+            and self.num_output_tokens() > self.min_tokens
+        ):
+            repetition_end = self.word_repetition_detector.update(self.output_text)
+
+        if repetition_end is not None:
+            self.output_text = self.output_text[:repetition_end]
+            return DetokenizerFinish(
+                FinishReason.REPETITION,
+                REPETITION_DETECTED_STOP_REASON,
+            )
+
+        return None
 
     @abstractmethod
     def decode_next(self, next_token_id: int) -> str:

--- a/vllm/v1/engine/output_processor.py
+++ b/vllm/v1/engine/output_processor.py
@@ -29,7 +29,7 @@ from vllm.tracing import (
 )
 from vllm.utils import length_from_prompt_token_ids_or_embeds
 from vllm.v1.engine import EngineCoreOutput, EngineCoreRequest, FinishReason
-from vllm.v1.engine.detokenizer import IncrementalDetokenizer
+from vllm.v1.engine.detokenizer import DetokenizerFinish, IncrementalDetokenizer
 from vllm.v1.engine.logprobs import LogprobsProcessor
 from vllm.v1.engine.parallel_sampling import ParentRequest
 from vllm.v1.metrics.stats import (
@@ -666,12 +666,15 @@ class OutputProcessor:
                         engine_core_output.new_sampling_mask
                     )
                 # 2) Detokenize the token ids into text and perform stop checks.
-                stop_string = req_state.detokenizer.update(
+                detokenizer_finish = req_state.detokenizer.update(
                     new_token_ids, finish_reason == FinishReason.STOP
                 )
-                if stop_string:
+                if isinstance(detokenizer_finish, DetokenizerFinish):
+                    finish_reason = detokenizer_finish.finish_reason
+                    stop_reason = detokenizer_finish.stop_reason
+                elif detokenizer_finish:
                     finish_reason = FinishReason.STOP
-                    stop_reason = stop_string
+                    stop_reason = detokenizer_finish
 
                 # 3) Compute sample and prompt logprobs for request,
                 # if required.


### PR DESCRIPTION
## Purpose

Some speech-generation models repeat the same decoded phrase after intervening text even when tokenizer segmentation, case, or punctuation differs. The existing repetition detector matches only adjacent token-ID N-grams at the sequence tail, so it cannot express this stopping policy.

This PR adds an opt-in `RepetitionDetectionParams(mode="word_anywhere")` mode that:

- interprets pattern sizes as decoded word counts;
- case-folds words and removes non-word characters for matching while preserving raw output text;
- incrementally counts completed word N-grams instead of rescanning the full output after every token;
- emits `FinishReason.REPETITION`, preserves the existing `repetition_detected` stop reason, aborts the unfinished EngineCore request, and truncates text that arrived after the first matching boundary in the same engine step.

The default remains `mode="consecutive"`, so existing token-level behavior is unchanged.

This does not duplicate #41539, which optimizes consecutive token-tail matching with rolling hashes, or #51036, which adds server-side defaults. Neither provides normalized decoded-word matching across non-adjacent occurrences.

This change was developed with AI assistance. The draft must receive human line-by-line review before it is marked ready.

## Test Plan

```bash
pre-commit run --files \
  vllm/sampling_params.py \
  vllm/v1/core/sched/utils.py \
  vllm/v1/engine/detokenizer.py \
  vllm/v1/engine/output_processor.py \
  tests/v1/core/test_repetition_detection.py \
  tests/v1/engine/test_word_repetition_detection.py

/opt/venv/bin/python -m pytest -q --confcutdir=tests/v1 \
  tests/v1/core/test_repetition_detection.py \
  tests/v1/engine/test_word_repetition_detection.py
```

For model-level validation, run the Nemotron Transcribe BF16 target on the fixed 448-clip ASR-LB stratified manifest twice with:

```text
mode=word_anywhere
min_pattern_size=8
max_pattern_size=8
min_count=2
max_num_seqs=512
max_num_batched_tokens=32768
```

## Test Result

- Official vLLM pre-commit suite: all applicable hooks passed, including Ruff, mypy, typos, SPDX, forbidden-import, and configuration checks.
- Focused tests: `26 passed`.
- Repeated model stress test: 448/448 clips completed in both runs; 439 stopped with `finish_reason="repetition"` and `stop_reason="repetition_detected"`, while 9 reached the configured length cap. RTFx was 155.05 and 153.62. Scored outputs were deterministic across both runs at 8.398% leaderboard macro WER.

The model test uses an early checkpoint that intentionally exhibits repeated tails; it validates stopping behavior and reproducibility, not general model quality or a throughput claim.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR is described, including why related open PRs are not duplicates.
- [x] Exact test commands are provided.
- [x] Unit, integration, lint, and model-level results are provided.
- [x] The new sampling parameter is documented inline; no supported-model documentation changes are required.
</details>
