### PR TITLE
[Performance] Vectorize EPLB packing across MoE layers

### DIFF
--- a/benchmarks/eplb/benchmark_eplb_policy.py
+++ b/benchmarks/eplb/benchmark_eplb_policy.py
@@ -1,0 +1,60 @@
+"""Benchmark the batched EPLB policy against layer-by-layer packing."""
+
+from __future__ import annotations
+
+import argparse
+import statistics
+import time
+
+import torch
+
+from vllm.distributed.eplb.policy.batched import BatchedEplbPolicy
+from vllm.distributed.eplb.policy.default import DefaultEplbPolicy
+
+
+def measure(fn, warmup: int, repeats: int) -> float:
+    for _ in range(warmup):
+        fn()
+    timings = []
+    for _ in range(repeats):
+        start = time.perf_counter()
+        fn()
+        timings.append((time.perf_counter() - start) * 1000)
+    return statistics.median(timings)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--warmup", type=int, default=10)
+    parser.add_argument("--repeats", type=int, default=100)
+    args = parser.parse_args()
+    generator = torch.Generator().manual_seed(7)
+
+    for layers, experts, physical, groups, nodes, ranks in (
+        (1, 8, 12, 4, 1, 4),
+        (16, 64, 72, 8, 2, 8),
+        (58, 256, 288, 8, 1, 8),
+        (58, 256, 288, 8, 4, 32),
+        (58, 256, 288, 8, 18, 144),
+    ):
+        weight = torch.randint(0, 1000, (layers, experts), generator=generator)
+        arguments = (weight, physical, groups, nodes, ranks)
+        old_ms = measure(
+            lambda arguments=arguments: DefaultEplbPolicy.rebalance_experts(*arguments),
+            args.warmup,
+            args.repeats,
+        )
+        new_ms = measure(
+            lambda arguments=arguments: BatchedEplbPolicy.rebalance_experts(*arguments),
+            args.warmup,
+            args.repeats,
+        )
+        print(
+            f"layers={layers:2d} experts={experts:3d} ranks={ranks:3d} "
+            f"old={old_ms:8.3f} ms new={new_ms:8.3f} ms "
+            f"speedup={old_ms / new_ms:6.2f}x"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/distributed/test_eplb_algo.py
+++ b/tests/distributed/test_eplb_algo.py
@@ -5,11 +5,75 @@ import numpy as np
 import pytest
 import torch
 
+from vllm.config.parallel import EPLBConfig
 from vllm.distributed.eplb.eplb_state import (
     _compute_eplb_load_stats,  # pyright: ignore[reportPrivateUsage]
     compute_logical_maps,
 )
+from vllm.distributed.eplb.policy import EPLB_POLICIES
+from vllm.distributed.eplb.policy.batched import BatchedEplbPolicy
 from vllm.distributed.eplb.policy.default import DefaultEplbPolicy
+
+
+def test_batched_policy_is_selectable_with_async_eplb():
+    config = EPLBConfig(policy="batched", use_async=True)
+
+    assert config.policy == "batched"
+    assert EPLB_POLICIES[config.policy] is BatchedEplbPolicy
+
+
+@pytest.mark.parametrize(
+    "num_layers,num_groups,num_packs",
+    [(1, 8, 1), (1, 8, 8), (3, 16, 4), (16, 72, 8), (58, 288, 8)],
+)
+@pytest.mark.parametrize("distribution", ["random", "equal", "zeros"])
+def test_batched_balanced_packing_matches_reference(
+    num_layers: int,
+    num_groups: int,
+    num_packs: int,
+    distribution: str,
+):
+    rng = np.random.default_rng(7)
+    if distribution == "random":
+        weight = rng.integers(0, 1000, size=(num_layers, num_groups))
+    elif distribution == "equal":
+        weight = np.full((num_layers, num_groups), 17)
+    else:
+        weight = np.zeros((num_layers, num_groups))
+
+    expected = DefaultEplbPolicy.balanced_packing(weight, num_packs)
+    actual = BatchedEplbPolicy.balanced_packing(weight, num_packs)
+
+    np.testing.assert_array_equal(actual[0], expected[0])
+    np.testing.assert_array_equal(actual[1], expected[1])
+
+
+@pytest.mark.parametrize(
+    "layers,experts,physical,groups,nodes,ranks",
+    [
+        (1, 8, 12, 4, 1, 4),
+        (16, 64, 72, 8, 2, 8),
+        (58, 256, 288, 8, 1, 8),
+        (58, 256, 288, 8, 4, 32),
+        (58, 256, 288, 8, 18, 144),
+    ],
+)
+def test_batched_rebalance_matches_reference(
+    layers: int,
+    experts: int,
+    physical: int,
+    groups: int,
+    nodes: int,
+    ranks: int,
+):
+    generator = torch.Generator().manual_seed(11)
+    weight = torch.randint(0, 1000, (layers, experts), generator=generator)
+    arguments = (weight, physical, groups, nodes, ranks)
+
+    expected = DefaultEplbPolicy.rebalance_experts(*arguments)
+    actual = BatchedEplbPolicy.rebalance_experts(*arguments)
+
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
 
 
 def test_eplb_load_stats_reduce_across_ranks():
@@ -263,27 +327,36 @@ def test_global_load_balance_fallback():
     assert torch.sum(logcnt) == num_replicas
 
 
+@pytest.mark.parametrize("policy_name", ["batched", "default"])
 @pytest.mark.parametrize("device", ["cpu", "cuda"])
-def test_device_compatibility(device):
-    """Test device compatibility"""
+def test_policy_device_compatibility(policy_name: str, device: str):
     if device == "cuda" and not torch.cuda.is_available():
         pytest.skip("CUDA not available")
 
-    weight = torch.tensor([[10, 20, 30, 40]], device=device)
-    num_replicas = 6
-    num_groups = 2
-    num_nodes = 1
-    num_gpus = 2
-
-    phy2log = DefaultEplbPolicy.rebalance_experts(
-        weight, num_replicas, num_groups, num_nodes, num_gpus
+    weight_cpu = torch.tensor(
+        [
+            [10, 20, 30, 40, 50, 60, 70, 80],
+            [80, 70, 60, 50, 40, 30, 20, 10],
+            [10, 80, 20, 70, 30, 60, 40, 50],
+        ]
     )
-    _, logcnt = compute_logical_maps(phy2log, weight.shape[-1])
+    expected = DefaultEplbPolicy.rebalance_experts(weight_cpu, 12, 4, 1, 4)
 
-    # Function will convert to CPU internally, but should handle different
-    # device inputs normally
-    assert phy2log.shape == (1, 6)
-    assert logcnt.shape == (1, 4)
+    policy = EPLB_POLICIES[policy_name]
+    phy2log = policy.rebalance_experts(
+        weight_cpu.to(device),
+        12,
+        4,
+        1,
+        4,
+        old_global_expert_indices=expected,
+    )
+    _, logcnt = compute_logical_maps(phy2log, weight_cpu.shape[-1])
+
+    assert phy2log.device.type == "cpu"
+    assert phy2log.shape == (3, 12)
+    assert logcnt.shape == (3, 8)
+    torch.testing.assert_close(phy2log, expected, rtol=0, atol=0)
 
 
 def test_additional_cases():

--- a/vllm/config/parallel.py
+++ b/vllm/config/parallel.py
@@ -36,7 +36,7 @@ _NUMACTL_CPUSET_PATTERN = re.compile(r"^\d+(?:-\d+)?(?:,\d+(?:-\d+)?)*$")
 ExpertPlacementStrategy = Literal["linear", "round_robin"]
 DistributedExecutorBackend = Literal["ray", "mp", "uni", "external_launcher"]
 DataParallelBackend = Literal["ray", "mp"]
-EPLBPolicyOption = Literal["default"]
+EPLBPolicyOption = Literal["batched", "default"]
 DCPCommBackend = Literal["ag_rs", "a2a"]
 EPLBCommunicatorBackend = Literal["torch_nccl", "torch_gloo", "nixl", "pynccl"]
 All2AllBackend = Literal[
@@ -101,8 +101,10 @@ class EPLBConfig:
 
     @model_validator(mode="after")
     def _validate_eplb_config(self) -> Self:
-        if self.use_async and self.policy != "default":
-            raise ValueError("Async EPLB is only supported with the default policy.")
+        if self.use_async and self.policy not in ("batched", "default"):
+            raise ValueError(
+                "Async EPLB is only supported with the default and batched policies."
+            )
         if self.use_async and self.communicator in ("torch_nccl", "pynccl"):
             raise ValueError(
                 f"{self.communicator} communicator is incompatible with "

--- a/vllm/distributed/eplb/policy/__init__.py
+++ b/vllm/distributed/eplb/policy/__init__.py
@@ -5,15 +5,17 @@ from typing import get_args
 from vllm.config.parallel import EPLBPolicyOption
 
 from .abstract import AbstractEplbPolicy
+from .batched import BatchedEplbPolicy
 from .default import DefaultEplbPolicy
 
-EPLB_POLICIES = {"default": DefaultEplbPolicy}
+EPLB_POLICIES = {"batched": BatchedEplbPolicy, "default": DefaultEplbPolicy}
 
 # Ensure that the EPLB_POLICIES keys match the EPLBPolicyOption values
 assert set(EPLB_POLICIES.keys()) == set(get_args(EPLBPolicyOption))
 
 __all__ = [
     "AbstractEplbPolicy",
+    "BatchedEplbPolicy",
     "DefaultEplbPolicy",
     "EPLB_POLICIES",
 ]

--- a/vllm/distributed/eplb/policy/batched.py
+++ b/vllm/distributed/eplb/policy/batched.py
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import numpy as np
+
+from .default import DefaultEplbPolicy
+
+
+class BatchedEplbPolicy(DefaultEplbPolicy):
+    """DeepSeek EPLB policy with packing vectorized across layers."""
+
+    @classmethod
+    def balanced_packing(
+        cls, weight: np.ndarray, num_packs: int
+    ) -> tuple[np.ndarray, np.ndarray]:
+        num_layers, num_groups = weight.shape
+        assert num_groups % num_packs == 0
+        groups_per_pack = num_groups // num_packs
+
+        if groups_per_pack == 1:
+            pack_index = np.tile(np.arange(num_groups, dtype=np.int64), (num_layers, 1))
+            return pack_index, np.zeros_like(pack_index)
+
+        indices = np.argsort(-weight, axis=-1)
+        pack_index = np.full((num_layers, num_groups), -1, dtype=np.int64)
+        rank_in_pack = np.full_like(pack_index, -1)
+        pack_weights = np.zeros((num_layers, num_packs), dtype=np.float64)
+        pack_items = np.zeros((num_layers, num_packs), dtype=np.int64)
+
+        if num_layers == 1:
+            return super().balanced_packing(weight, num_packs)
+
+        layers = np.arange(num_layers)
+        for group_idx in range(num_groups):
+            groups = indices[:, group_idx]
+            packs = np.argmin(pack_weights, axis=1)
+
+            pack_index[layers, groups] = packs
+            rank_in_pack[layers, groups] = pack_items[layers, packs]
+            pack_weights[layers, packs] += weight[layers, groups]
+            pack_items[layers, packs] += 1
+            full = pack_items[layers, packs] == groups_per_pack
+            pack_weights[layers[full], packs[full]] = np.inf
+
+        return pack_index, rank_in_pack


### PR DESCRIPTION
## Purpose

Add an opt-in `batched` EPLB policy that vectorizes balanced packing across independent MoE layers on CPU.

The existing `default` policy and implementation remain unchanged. The new policy subclasses `DefaultEplbPolicy` and overrides only `balanced_packing`. It preserves the default policy's greedy order, tie-breaking, placement, hierarchical/global behavior, and previous-slot preservation.

The policy can be selected with:

```json
{
  "policy": "batched"
}
```

It supports both synchronous and asynchronous EPLB. This change does not modify load collection, distributed synchronization, expert-weight migration, routing kernels, or inference execution.

I searched existing open vLLM work for batched/vectorized EPLB packing and did not find a duplicate PR.

## Test Plan

Run the existing EPLB algorithm test suite, extended with:

- exact differential tests against `DefaultEplbPolicy`;
- random, equal, and zero-weight inputs;
- single-layer and multi-layer cases;
- hierarchical and global placement;
- simulated 8-, 32-, and 144-rank configurations;
- CPU and CUDA input tensors;
- previous-slot preservation;
- asynchronous policy selection through the policy registry.

```bash
LD_LIBRARY_PATH=/usr/lib/wsl/lib \
  .venv/bin/python -m pytest \
  --noconftest tests/distributed/test_eplb_algo.py -q
```

Run lint and formatting checks:

```bash
.venv/bin/ruff check \
  vllm/distributed/eplb/policy/batched.py \
  vllm/distributed/eplb/policy/__init__.py \
  vllm/config/parallel.py \
  tests/distributed/test_eplb_algo.py \
  benchmarks/eplb/benchmark_eplb_policy.py

.venv/bin/ruff format --check \
  vllm/distributed/eplb/policy/batched.py \
  vllm/distributed/eplb/policy/__init__.py \
  vllm/config/parallel.py \
  tests/distributed/test_eplb_algo.py \
  benchmarks/eplb/benchmark_eplb_policy.py
```

Benchmark complete `rebalance_experts` calls:

```bash
.venv/bin/python benchmarks/eplb/benchmark_eplb_policy.py \
  --warmup 10 \
  --repeats 100
```

## Test Result

EPLB algorithm tests on an NVIDIA GeForce RTX 4060:

```text
39 passed in 5.27s
```

The CUDA tests verify that the default and batched policies accept CUDA load tensors, execute CPU planning, preserve previous slots, return CPU mappings, and produce exactly identical placements.

Lint and formatting:

```text
All checks passed!
5 files already formatted
```

CPU benchmark results:

| Configuration | Default | Batched | Speedup |
|---|---:|---:|---:|
| 1 layer, 8 experts, 4 ranks | 0.080 ms | 0.087 ms | 0.92x |
| 16 layers, 64 experts, 8 ranks | 1.896 ms | 0.543 ms | 3.49x |
| 58 layers, 256 experts, 8 ranks | 23.573 ms | 4.442 ms | 5.31x |
| 58 layers, 256 experts, 32 ranks | 24.009 ms | 2.261 ms | 10.62x |
| 58 layers, 256 experts, 144 ranks | 23.975 ms | 4.811 ms | 4.98x |

The single-layer batched policy delegates to the default implementation. The primary benefit is for models with many homogeneous MoE layers.

No documentation update is required because this adds an EPLB policy rather than model support or a change to the default behavior.

AI assistance was used during implementation, test development, and benchmark preparation. I reviewed and validated all changes.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results.
- [x] Documentation impact was considered; no documentation update is required.
</details>

