### PR TITLE
test(openai): add validation test for auto-tool-choice parser requirement

### DIFF
--- a/tests/entrypoints/openai/test_cli_args.py
+++ b/tests/entrypoints/openai/test_cli_args.py
@@ -328,3 +328,12 @@ def test_lora_target_modules_default_none(serve_parser):
     """Test that lora-target-modules defaults to None"""
     args = serve_parser.parse_args(args=[])
     assert args.lora_target_modules is None
+
+
+def test_auto_tool_choice_validation(serve_parser):
+    """Test that enable-auto-tool-choice requires tool-call-parser during validation"""
+    args = serve_parser.parse_args(args=["--enable-auto-tool-choice"])
+    with pytest.raises(
+        TypeError, match="--enable-auto-tool-choice requires --tool-call-parser"
+    ):
+        validate_parsed_serve_args(args)


### PR DESCRIPTION
### Summary
Adds a unit test in `tests/entrypoints/openai/test_cli_args.py` to verify that enabling `--enable-auto-tool-choice` raises a `TypeError` if `--tool-call-parser` is missing during CLI validation.

### Why this is not duplicate work
Verified no existing PRs cover this CLI argument validation test case.

### Test Plan & Results
- [x] Ran `.venv/bin/pytest tests/entrypoints/openai/test_cli_args.py` (30/30 passed)
- [x] Ran `.venv/bin/ruff check tests/entrypoints/openai/test_cli_args.py` (0 errors)