### PR TITLE
fix(fp8): lazy evaluate tp_size default in validate_fp8_block_shape

### DIFF
--- a/tests/quantization/test_fp8.py
+++ b/tests/quantization/test_fp8.py
@@ -478,3 +478,26 @@ def test_kv_cache_dtype_skip_layers(vllm_runner, monkeypatch):
                 assert layer.self_attn.attn.kv_cache_dtype == expected
 
         llm.apply_model(check_layers)
+
+
+def test_validate_fp8_block_shape():
+    """Test validate_fp8_block_shape validation rules for tensor parallel shapes."""
+    from vllm.model_executor.layers.quantization.utils.fp8_utils import (
+        validate_fp8_block_shape,
+    )
+
+    layer = torch.nn.Module()
+    layer.tp_size = 2
+
+    # Should raise ValueError when input_size_per_partition is not divisible by block_k
+    with pytest.raises(
+        ValueError, match="is not divisible by weight quantization block_k"
+    ):
+        validate_fp8_block_shape(
+            layer=layer,
+            input_size=200,
+            output_size=512,
+            input_size_per_partition=100,
+            output_partition_sizes=[256],
+            block_size=[128, 64],  # 100 % 64 != 0 -> raises ValueError
+        )

--- a/vllm/model_executor/layers/quantization/utils/fp8_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/fp8_utils.py
@@ -1209,7 +1209,9 @@ def validate_fp8_block_shape(
         )
         return
 
-    tp_size = getattr(layer, "tp_size", get_tensor_model_parallel_world_size())
+    tp_size = getattr(layer, "tp_size", None)
+    if tp_size is None:
+        tp_size = get_tensor_model_parallel_world_size()
     block_n, block_k = block_size[0], block_size[1]
 
     # Required by row parallel


### PR DESCRIPTION
### Summary
Fixes eager evaluation of `get_tensor_model_parallel_world_size()` in `validate_fp8_block_shape` when `layer.tp_size` is present, preventing crashes when parallel state is not initialized. Also adds a unit test in `tests/quantization/test_fp8.py`.

### Why this is not duplicate work
Verified no existing PR addresses eager default evaluation in `validate_fp8_block_shape`.

### Test Plan & Results
- [x] Ran `.venv/bin/pytest tests/quantization/test_fp8.py -k test_validate_fp8_block_shape` (1/1 passed)
- [x] Ran `.venv/bin/ruff check vllm/model_executor/layers/quantization/utils/fp8_utils.py` (0 errors)
