### PR TITLE
[ROCm][CI] Avoid forcing FlashAttention in the ColPali pooling test

### DIFF
--- a/tests/models/multimodal/pooling/test_colpali.py
+++ b/tests/models/multimodal/pooling/test_colpali.py
@@ -19,6 +19,7 @@ from vllm.entrypoints.chat_utils import (
     ChatCompletionContentPartTextParam,
 )
 from vllm.entrypoints.pooling.scoring.typing import ScoreMultiModalParam
+from vllm.platforms import current_platform
 
 from ....conftest import VllmRunner
 
@@ -215,6 +216,7 @@ def _run_multimodal_text_query_image_docs_test(
         _make_image_mm_param(red_image),
         _make_image_mm_param(blue_image),
     ]
+    attention_backend = "FLASH_ATTN" if current_platform.is_cuda() else None
 
     with vllm_runner(
         model,
@@ -223,7 +225,7 @@ def _run_multimodal_text_query_image_docs_test(
         max_model_len=4096,
         enforce_eager=True,
         gpu_memory_utilization=GPU_MEMORY_UTILIZATION,
-        attention_backend="FLASH_ATTN",
+        attention_backend=attention_backend,
         kernel_config={"enable_flashinfer_autotune": False},
     ) as vllm_model:
         assert vllm_model.llm.llm_engine.vllm_config.use_v2_model_runner


### PR DESCRIPTION
PR #52050 added a CUDA-specific forced `FLASH_ATTN` configuration to a cross-platform ColPali test, which then failed on both [MI300](https://buildkite.com/vllm/amd-ci/builds/12112/list?jid=01a00c92-9c7e-4a47-a086-8b869348cac4&tab=output) and [MI355](https://buildkite.com/vllm/amd-ci/builds/12112/list?jid=01a00c92-9ca9-4012-8b7d-a9860d54a4d8&tab=output) because ROCm intentionally does not report a FlashAttention version. This keeps the intended CUDA regression coverage while allowing ROCm to select its supported attention backend.

- Detect the active platform in the ColPali pooling test
- Force the FlashAttention backend only on CUDA
- Preserve V2 multimodal pooling coverage while using the default ROCm backend