### PR TITLE
[Rust Frontend] Add MiniMax M2 append-think reasoning parser

### DIFF
--- a/rust/src/chat/src/lib.rs
+++ b/rust/src/chat/src/lib.rs
@@ -416,6 +416,6 @@ mod tests {
         )
         .unwrap_err();
 
-        expect_test::expect!["reasoning parser `definitely_missing_reasoning_parser` is not registered (choose from: cohere_cmd, deepseek_r1, deepseek_v3, deepseek_v4, gemma4, glm45, glm47, hy_v3, hy_v4, inkling, kimi, kimi_k2, kimi_k3, minimax_m2, minimax_m3, nemotron_v3, qwen3, seed_oss, step3, step3p5)"].assert_eq(&error.to_report_string());
+        expect_test::expect!["reasoning parser `definitely_missing_reasoning_parser` is not registered (choose from: cohere_cmd, deepseek_r1, deepseek_v3, deepseek_v4, gemma4, glm45, glm47, hy_v3, hy_v4, inkling, kimi, kimi_k2, kimi_k3, minimax_m2, minimax_m2_append_think, minimax_m3, nemotron_v3, qwen3, seed_oss, step3, step3p5)"].assert_eq(&error.to_report_string());
     }
 }

--- a/rust/src/chat/src/parser/reasoning/mod.rs
+++ b/rust/src/chat/src/parser/reasoning/mod.rs
@@ -8,9 +8,10 @@ use std::sync::{Arc, LazyLock};
 pub use vllm_parser::reasoning::{
     CohereCmdReasoningParser, DeepSeekR1ReasoningParser, DeepSeekV3ReasoningParser,
     DeepSeekV4ReasoningParser, Glm45ReasoningParser, Glm47ReasoningParser, KimiK2ReasoningParser,
-    KimiReasoningParser, MiniMaxM2ReasoningParser, MiniMaxM3ReasoningParser,
-    NemotronV3ReasoningParser, Qwen3ReasoningParser, ReasoningDelta, ReasoningError,
-    ReasoningParser, SeedOssReasoningParser, Step3ReasoningParser, Step3p5ReasoningParser,
+    KimiReasoningParser, MiniMaxM2AppendThinkReasoningParser, MiniMaxM2ReasoningParser,
+    MiniMaxM3ReasoningParser, NemotronV3ReasoningParser, Qwen3ReasoningParser, ReasoningDelta,
+    ReasoningError, ReasoningParser, SeedOssReasoningParser, Step3ReasoningParser,
+    Step3p5ReasoningParser,
 };
 use vllm_tokenizer::DynTokenizer;
 
@@ -32,6 +33,7 @@ pub mod names {
     pub const KIMI_K2: &str = "kimi_k2";
     pub const KIMI_K3: &str = "kimi_k3";
     pub const MINIMAX_M2: &str = "minimax_m2";
+    pub const MINIMAX_M2_APPEND_THINK: &str = "minimax_m2_append_think";
     pub const MINIMAX_M3: &str = "minimax_m3";
     pub const NEMOTRON_V3: &str = "nemotron_v3";
     pub const QWEN3: &str = "qwen3";
@@ -77,6 +79,7 @@ impl ReasoningParserFactory {
             .register_parser::<KimiK2ReasoningParser>(names::KIMI_K2)
             .register_unified_dummy(names::KIMI_K3)
             .register_parser::<MiniMaxM2ReasoningParser>(names::MINIMAX_M2)
+            .register_parser::<MiniMaxM2AppendThinkReasoningParser>(names::MINIMAX_M2_APPEND_THINK)
             .register_parser::<MiniMaxM3ReasoningParser>(names::MINIMAX_M3)
             .register_parser::<NemotronV3ReasoningParser>(names::NEMOTRON_V3)
             .register_parser::<Qwen3ReasoningParser>(names::QWEN3)

--- a/rust/src/chat/src/parser/reasoning/tests.rs
+++ b/rust/src/chat/src/parser/reasoning/tests.rs
@@ -15,12 +15,14 @@ fn factory_contains_and_lists_registered_parsers() {
     assert!(factory.contains(names::SEED_OSS));
     assert!(factory.contains(names::STEP3P5));
     assert!(factory.contains(names::MINIMAX_M3));
+    assert!(factory.contains(names::MINIMAX_M2_APPEND_THINK));
     assert!(factory.contains(names::GEMMA4));
     assert!(factory.list().contains(&names::QWEN3.to_string()));
     assert!(factory.list().contains(&names::DEEPSEEK_V4.to_string()));
     assert!(factory.list().contains(&names::SEED_OSS.to_string()));
     assert!(factory.list().contains(&names::STEP3P5.to_string()));
     assert!(factory.list().contains(&names::MINIMAX_M3.to_string()));
+    assert!(factory.list().contains(&names::MINIMAX_M2_APPEND_THINK.to_string()));
     assert!(factory.list().contains(&names::GEMMA4.to_string()));
 }
 
@@ -122,4 +124,17 @@ fn factory_distinguishes_glm_reasoning_framing() {
     for model in ["zai-org/GLM-4.7-Flash", "zai-org/GLM-5.2-FP8"] {
         assert_eq!(factory.resolve_name_for_model(model), Some(names::GLM47));
     }
+}
+
+#[test]
+fn factory_creates_minimax_m2_append_think_by_exact_name_only() {
+    let tokenizer = Arc::new(TestTokenizer::new());
+    let factory = ReasoningParserFactory::new();
+    let parser = factory.create(names::MINIMAX_M2_APPEND_THINK, tokenizer).unwrap();
+
+    assert!(parser.preserve_special_tokens());
+    assert_eq!(
+        factory.resolve_name_for_model("MiniMaxAI/MiniMax-M2"),
+        Some(names::MINIMAX_M2)
+    );
 }

--- a/rust/src/parser/src/reasoning/minimax_m2_append_think.rs
+++ b/rust/src/parser/src/reasoning/minimax_m2_append_think.rs
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+use vllm_tokenizer::{DecodedText, DynTokenizer};
+
+use super::{ReasoningDelta, ReasoningParser, Result};
+
+const THINK_START: &str = "<think>";
+
+/// Compatibility parser that preserves MiniMax M2 reasoning markup as content.
+///
+/// MiniMax M2 emits `</think>` without a matching opening token. This parser
+/// prepends `<think>` to the first non-empty output delta and otherwise leaves
+/// the generated text untouched. An empty generated stream stays empty because
+/// the Rust parser is shared by streaming and collected responses.
+pub struct MiniMaxM2AppendThinkReasoningParser {
+    prepended_start: bool,
+}
+
+impl Default for MiniMaxM2AppendThinkReasoningParser {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl MiniMaxM2AppendThinkReasoningParser {
+    /// Create a parser with no request-scoped output state.
+    pub fn new() -> Self {
+        Self {
+            prepended_start: false,
+        }
+    }
+}
+
+impl ReasoningParser for MiniMaxM2AppendThinkReasoningParser {
+    fn create(_tokenizer: DynTokenizer) -> Result<Box<dyn ReasoningParser>>
+    where
+        Self: Sized + 'static,
+    {
+        Ok(Box::new(Self::new()))
+    }
+
+    fn initialize(&mut self, _prompt_token_ids: &[u32]) -> Result<()> {
+        self.prepended_start = false;
+        Ok(())
+    }
+
+    fn preserve_special_tokens(&self) -> bool {
+        true
+    }
+
+    fn push(&mut self, delta: DecodedText) -> Result<ReasoningDelta> {
+        if delta.is_empty() {
+            return Ok(ReasoningDelta::default());
+        }
+
+        let mut output = ReasoningDelta::default();
+        if !self.prepended_start {
+            output.push_content(DecodedText::unattributed(THINK_START));
+            self.prepended_start = true;
+        }
+        output.push_content(delta);
+        Ok(output)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use vllm_tokenizer::test_utils::TestTokenizer;
+
+    use super::MiniMaxM2AppendThinkReasoningParser;
+    use crate::reasoning::ReasoningParser;
+    use crate::reasoning::tests::{content_str, push_str};
+
+    #[test]
+    fn prepends_think_once_and_preserves_output_as_content() {
+        let mut parser = MiniMaxM2AppendThinkReasoningParser::new();
+
+        let first = push_str(&mut parser, "reasoning</think>");
+        let second = push_str(&mut parser, "answer");
+
+        assert_eq!(content_str(&first), Some("<think>reasoning</think>"));
+        assert_eq!(content_str(&second), Some("answer"));
+    }
+
+    #[test]
+    fn ignores_empty_deltas_until_output_arrives() {
+        let mut parser = MiniMaxM2AppendThinkReasoningParser::new();
+
+        assert!(push_str(&mut parser, "").is_empty());
+        assert_eq!(
+            content_str(&push_str(&mut parser, "answer")),
+            Some("<think>answer")
+        );
+    }
+
+    #[test]
+    fn empty_stream_finishes_without_synthetic_content() {
+        let mut parser = MiniMaxM2AppendThinkReasoningParser::new();
+
+        assert!(push_str(&mut parser, "").is_empty());
+        assert!(parser.finish().unwrap().is_empty());
+    }
+
+    #[test]
+    fn initialize_resets_request_scoped_prefix_state() {
+        let mut parser = MiniMaxM2AppendThinkReasoningParser::new();
+        assert_eq!(
+            content_str(&push_str(&mut parser, "first")),
+            Some("<think>first")
+        );
+
+        parser.initialize(&[]).unwrap();
+
+        assert_eq!(
+            content_str(&push_str(&mut parser, "second")),
+            Some("<think>second")
+        );
+    }
+
+    #[test]
+    fn factory_creation_preserves_special_tokens() {
+        let tokenizer = Arc::new(TestTokenizer::new());
+        let parser = MiniMaxM2AppendThinkReasoningParser::create(tokenizer).unwrap();
+        assert!(parser.preserve_special_tokens());
+    }
+}

--- a/rust/src/parser/src/reasoning/mod.rs
+++ b/rust/src/parser/src/reasoning/mod.rs
@@ -24,6 +24,7 @@ mod delimited;
 mod glm45;
 mod hy;
 mod kimi;
+mod minimax_m2_append_think;
 mod minimax_m3;
 mod qwen3;
 mod seed_oss;
@@ -41,6 +42,7 @@ pub(crate) use self::delimited::{
 pub use self::glm45::Glm45ReasoningParser;
 pub(crate) use self::hy::HyReasoningParser;
 pub use self::kimi::KimiReasoningParser;
+pub use self::minimax_m2_append_think::MiniMaxM2AppendThinkReasoningParser;
 pub use self::minimax_m3::MiniMaxM3ReasoningParser;
 pub use self::qwen3::Qwen3ReasoningParser;
 pub use self::seed_oss::SeedOssReasoningParser;


### PR DESCRIPTION
## Summary

- add the explicit `minimax_m2_append_think` Rust reasoning parser
- prepend `<think>` once while preserving all non-empty generated output as visible content
- keep an empty generated stream empty because the Rust parser is shared by streaming and collected responses
- preserve special tokens and keep automatic MiniMax model routing on the normal parser
- cover parser lifecycle, empty deltas and streams, factory registration, and parser-name diagnostics

## Duplicate-work check

This does not duplicate an existing PR. Before implementation I checked:

- roadmap issue #44280 and its comments
- open PRs referencing `44280`
- open PR searches for `minimax_m2_append_think` and MiniMax M2 append-think parser terms

No overlapping Rust implementation or claim was found. The item was claimed in #44280 before implementation.

## Tests

- `cargo test --manifest-path rust/Cargo.toml -p vllm-parser --lib` — 435 passed
- `cargo test --manifest-path rust/Cargo.toml -p vllm-chat --lib` — 279 passed
- `cargo clippy --manifest-path rust/Cargo.toml -p vllm-parser -p vllm-chat --all-targets -- -D warnings` — passed
- `uv tool run pre-commit run --files <changed files>` — passed

## Full-model serving regression

A CPU-only end-to-end serving regression was run with the locally built PR Rust binary and the full `allenai/Olmo-3-7B-Instruct` weights (13.59 GiB), using `--reasoning-parser minimax_m2_append_think`. A different model was intentionally used because the parser is selected explicitly and MiniMax M2.5 itself is approximately 434 GiB across 125 weight shards.

- Rust frontend, Python engine, tokenizer/template loading, and OpenAI HTTP serving all started successfully.
- Non-streaming output preserved generated text as content and prepended exactly one marker: `content = "<think>hello world"`, `reasoning = null`.
- Streaming reconstruction produced `content = "<think>hello world"`, empty reasoning, one `<think>` prefix, and `finish_reason = "stop"`.

A model-quality evaluation is not applicable because this change does not affect model execution, logits, or sampling; the full-model run validates parser integration and HTTP behavior.

## AI assistance

AI assistance was used to analyze the parser architecture, implement the change, and run validation. The human submitter reviewed the changed lines and is responsible for understanding and defending the change end-to-end.

