### PR TITLE
fix: perf: use startswith(x, i) instead of string slicing to avoid O(N^2)

### DIFF
--- a/vllm/tool_parsers/gemma4_tool_parser.py
+++ b/vllm/tool_parsers/gemma4_tool_parser.py
@@ -141,7 +141,7 @@ def _parse_gemma4_args(args_str: str, *, partial: bool = False) -> dict:
             break
 
         # String value: <|"|>...<|"|>
-        if args_str[i:].startswith(STRING_DELIM):
+        if args_str.startswith(STRING_DELIM, i):
             i += len(STRING_DELIM)
             val_start = i
             end_pos = args_str.find(STRING_DELIM, i)
@@ -158,7 +158,7 @@ def _parse_gemma4_args(args_str: str, *, partial: bool = False) -> dict:
             obj_start = i + 1
             i += 1
             while i < n and depth > 0:
-                if args_str[i:].startswith(STRING_DELIM):
+                if args_str.startswith(STRING_DELIM, i):
                     # Skip over string contents to avoid counting { inside strings
                     i += len(STRING_DELIM)
                     next_delim = args_str.find(STRING_DELIM, i)
@@ -182,7 +182,7 @@ def _parse_gemma4_args(args_str: str, *, partial: bool = False) -> dict:
             arr_start = i + 1
             i += 1
             while i < n and depth > 0:
-                if args_str[i:].startswith(STRING_DELIM):
+                if args_str.startswith(STRING_DELIM, i):
                     i += len(STRING_DELIM)
                     next_delim = args_str.find(STRING_DELIM, i)
                     i = n if next_delim == -1 else next_delim + len(STRING_DELIM)
@@ -239,7 +239,7 @@ def _parse_gemma4_array(arr_str: str, *, partial: bool = False) -> list:
             break
 
         # String element
-        if arr_str[i:].startswith(STRING_DELIM):
+        if arr_str.startswith(STRING_DELIM, i):
             i += len(STRING_DELIM)
             end_pos = arr_str.find(STRING_DELIM, i)
             if end_pos == -1:
@@ -254,7 +254,7 @@ def _parse_gemma4_array(arr_str: str, *, partial: bool = False) -> list:
             obj_start = i + 1
             i += 1
             while i < n and depth > 0:
-                if arr_str[i:].startswith(STRING_DELIM):
+                if arr_str.startswith(STRING_DELIM, i):
                     i += len(STRING_DELIM)
                     nd = arr_str.find(STRING_DELIM, i)
                     i = nd + len(STRING_DELIM) if nd != -1 else n
@@ -275,7 +275,7 @@ def _parse_gemma4_array(arr_str: str, *, partial: bool = False) -> list:
             sub_start = i + 1
             i += 1
             while i < n and depth > 0:
-                if arr_str[i:].startswith(STRING_DELIM):
+                if arr_str.startswith(STRING_DELIM, i):
                     i += len(STRING_DELIM)
                     nd = arr_str.find(STRING_DELIM, i)
                     i = nd + len(STRING_DELIM) if nd != -1 else n


### PR DESCRIPTION
Fix: perf: use startswith(x, i) instead of string slicing to avoid O(N^2)