### PR TITLE
fix: remove uninterpolated {e} from mistral tool parser log message

### DIFF
--- a/vllm/tool_parsers/mistral_tool_parser.py
+++ b/vllm/tool_parsers/mistral_tool_parser.py
@@ -323,7 +323,7 @@ class MistralToolParser(ToolParser):
                     )[0]
                     tool_calls = json.loads(raw_tool_call)
                 except (IndexError, json.JSONDecodeError):
-                    logger.exception("Error in extracting tool call from response: {e}")
+                    logger.exception("Error in extracting tool call from response.")
                     # If raw decoding and decoding post regex rule fails, then just
                     # return content.
                     return ExtractedToolCallInformation(


### PR DESCRIPTION
Fix: fix: remove uninterpolated {e} from mistral tool parser log message