### PR TITLE
docs: fix incorrect --custom-skip-chat-template flag reference

### DIFF
--- a/docs/benchmarking/cli.md
+++ b/docs/benchmarking/cli.md
@@ -205,7 +205,7 @@ vllm bench serve --port 9001 --save-result --save-detailed \
   --endpoint /v1/completions \
   --dataset-name custom \
   --dataset-path <path-to-your-data-jsonl> \
-  --custom-skip-chat-template \
+  --skip-chat-template \
   --num-prompts 80 \
   --max-concurrency 1 \
   --temperature=0.3 \
@@ -213,7 +213,7 @@ vllm bench serve --port 9001 --save-result --save-detailed \
   --result-dir "./log/"
 ```
 
-You can skip applying chat template if your data already has it by using `--custom-skip-chat-template`.
+You can skip applying chat template if your data already has it by using `--skip-chat-template`.
 
 #### Custom Audio Dataset
 


### PR DESCRIPTION
The flag is defined as --skip-chat-template in vllm/benchmarks/datasets/datasets.py, not --custom-skip-chat-template. Fixes #52587




## Purpose
Fixes a documentation bug where `docs/benchmarking/cli.md` referenced a nonexistent `--custom-skip-chat-template` flag. The correct flag, defined in `vllm/benchmarks/datasets/datasets.py`, is `--skip-chat-template`.

## Test Plan
Verified via `grep -rn "skip-chat-template" vllm/ benchmarks/` that the flag is defined as `--skip-chat-template` (argparse `add_argument`, `action="store_true"`) with no `custom-` prefix anywhere in the actual CLI code.

## Test Result
N/A — documentation-only change, no functional code modified. Confirmed via `git diff` that only the two incorrect flag references were updated.
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

