### PR TITLE
[Bugfix][KV Connector] Select standard KV backend for Mooncake topology

### DIFF
--- a/tests/v1/kv_connector/unit/test_transfer_topology_sharded.py
+++ b/tests/v1/kv_connector/unit/test_transfer_topology_sharded.py
@@ -22,6 +22,17 @@ class _FakeAttentionBackend:
         return (num_blocks, num_kv_heads, block_size, 2 * head_size)
 
 
+class _FakeIndexerBackend:
+    @staticmethod
+    def get_kv_cache_shape(
+        num_blocks: int,
+        block_size: int,
+        num_kv_heads: int,
+        head_size: int,
+    ) -> tuple[int, int, int]:
+        return (num_blocks, block_size, head_size)
+
+
 def _make_topology(
     *,
     tp_rank: int = 1,
@@ -38,6 +49,21 @@ def _make_topology(
         total_num_kv_heads=total_num_kv_heads,
         attn_backends=[_FakeAttentionBackend],
     )
+
+
+def test_standard_topology_skips_nonstandard_indexer_backend() -> None:
+    topology = TransferTopology(
+        tp_rank=0,
+        tp_size=4,
+        block_size=16,
+        engine_id="local-engine",
+        is_mla=False,
+        is_mamba=False,
+        total_num_kv_heads=8,
+        attn_backends=[_FakeIndexerBackend, _FakeAttentionBackend],
+    )
+
+    assert topology.local_physical_heads == 2
 
 
 def test_legacy_register_remote_engine_uses_pp_rank_zero() -> None:

--- a/vllm/distributed/kv_transfer/kv_connector/utils.py
+++ b/vllm/distributed/kv_transfer/kv_connector/utils.py
@@ -432,12 +432,30 @@ class TransferTopology:
         attn_backend = self.attn_backends[0]
         if not self.is_mamba:
             _MOCK_BLOCK_SIZE = 16
-            kv_cache_shape: tuple[int, ...] = attn_backend.get_kv_cache_shape(
-                num_blocks=1,
-                block_size=_MOCK_BLOCK_SIZE,
-                num_kv_heads=1,
-                head_size=1,
-            )
+            backend_shapes = [
+                (
+                    backend,
+                    backend.get_kv_cache_shape(
+                        num_blocks=1,
+                        block_size=_MOCK_BLOCK_SIZE,
+                        num_kv_heads=1,
+                        head_size=1,
+                    ),
+                )
+                for backend in self.attn_backends
+            ]
+            if self.is_mla:
+                kv_cache_shape = backend_shapes[0][1]
+            else:
+                standard_backends = [
+                    item for item in backend_shapes if len(item[1]) == 4
+                ]
+                assert standard_backends, (
+                    "Attention KV cache layout must be standardized as "
+                    "[num_blocks, num_kv_heads, block_size, content_size], "
+                    f"got shapes {[shape for _, shape in backend_shapes]}."
+                )
+                attn_backend, kv_cache_shape = standard_backends[0]
             logger.debug("Test kv_cache_shape: %s", kv_cache_shape)
             assert kv_cache_shape[0] == 1, (
                 "KV cache layout must be blocks-first; expected mocked "


### PR DESCRIPTION
## Purpose

Fix Mooncake transfer-topology construction when a model exposes multiple attention backends and a nonstandard sparse/indexer KV layout appears before the standard attention KV layout.

`TransferTopology` previously derived the KV cache shape from `attn_backends[0]`. For PP stages that include both a sparse/indexer backend and a standard attention backend, the first backend can return a nonstandard 3D layout such as `(num_blocks, block_size, head_size)`. Mooncake then fails startup even though a standard 4D attention KV cache layout is also available.

This change probes all candidate backends and, for non-MLA attention, selects the first standard 4D layout:

```text
[num_blocks, num_kv_heads, block_size, content_size]
```

MLA keeps the previous first-backend behavior because its cache layout is not the standard 4D attention layout.

## Duplicate-work check

I searched open and closed PRs for:

- `Mooncake standard KV backend sparse indexer PP`
- `select standard cache backend Mooncake`

I did not find another PR addressing this backend-selection defect. Existing Mooncake PRs I found cover stale completion handling, heterogeneous GQA head mapping, PP/PCP metadata, or RDMA/device discovery, not standard KV backend selection from mixed attention backend lists.

## Test

End-to-end internal validation:

Testbed:
- Base image: vLLM v0.26.0 image with the internal MiniMax-M3 W4AFP8 changes applied.
- Hardware: two H20 nodes, each with 8 GPUs.
- Model: custom-quantized MiniMax-M3-W4AFP8.
- Deployment: disaggregated Prefill/Decode with Mooncake RDMA KV transfer.
- Prefill topology: one 8-GPU Prefill node using PP2+TP4+EP.
- Decode topology: one 8-GPU Decode node using DP8+TP1+EP.
- This Prefill setup exposes both the sparse/indexer backend and the standard attention KV backend on PP stages.

A/B validation:
- Before this fix, Mooncake selected the sparse/indexer layout when building the transfer topology, so PP2 Prefill startup failed.
- After this fix, Mooncake selected the standard 4D attention KV layout, and PP2+TP4 Prefill started successfully.
- The fixed deployment then completed the 64k and 128k Prefill workloads with 40/40 successful requests.

The same backend-selection issue should also apply to the official MiniMax-M3 model because it exposes the same kind of mixed sparse/indexer and standard attention backend list in PP stages. I did not run that official-model
end-to-end validation here because it requires a larger multi-node deployment than the two-node MiniMax-M3-W4AFP8 setup used above.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR is described.
- [x] Duplicate-work check is included.
- [x] Test commands are included.
- [x] Test results are included.
- [x] No documentation update is required; behavior is corrected without a
      user-facing configuration change.
</details>
