### PR TITLE
[Core] Add VLLM_POISON_DISCARDED_PAGES debug flag for sleep/wake correctness testing

### DIFF
--- a/tests/basic_correctness/test_mem.py
+++ b/tests/basic_correctness/test_mem.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import asyncio
+import os
 
 import pytest
 import torch
@@ -409,3 +410,40 @@ def test_deep_sleep_fp8_kvcache():
 
     # cmp output
     assert output[0].outputs[0].text == output2[0].outputs[0].text
+
+
+@create_new_process_for_each_test("fork" if current_platform.is_cuda() else "spawn")
+def test_discard_poison_pages():
+    """Test that VLLM_POISON_DISCARDED_PAGES makes wake_up() fill the
+    remapped pages of discarded allocations with 0xFF, so stale reads of
+    discarded content are detectable (supports SW3 regression checks,
+    RFC #48310). Offloaded allocations with a CPU backup must be restored,
+    not poisoned."""
+    os.environ["VLLM_POISON_DISCARDED_PAGES"] = "1"
+    try:
+        allocator = get_mem_allocator_instance()
+
+        with allocator.use_memory_pool("weights"):
+            weights = torch.ones(1024, 1024, device=DEVICE_TYPE)
+
+        with allocator.use_memory_pool("kv_cache"):
+            kv = torch.empty(512, 512, dtype=torch.uint8, device=DEVICE_TYPE)
+
+        # Offload weights (CPU backup), discard kv_cache (no backup).
+        allocator.sleep(offload_tags="weights")
+        allocator.wake_up()
+
+        # weights content is restored from the CPU backup, not poisoned.
+        assert torch.allclose(weights, torch.ones_like(weights))
+        # kv_cache pages were discarded and remapped: must be poisoned.
+        assert bool((kv == 0xFF).all())
+
+        # Negative control: without the flag the allocator does not poison
+        # remapped pages (contents are platform-dependent, typically zeroed
+        # by the driver).
+        os.environ.pop("VLLM_POISON_DISCARDED_PAGES")
+        allocator.sleep(offload_tags="weights")
+        allocator.wake_up()
+        assert not bool((kv == 0xFF).all())
+    finally:
+        os.environ.pop("VLLM_POISON_DISCARDED_PAGES", None)

--- a/vllm/device_allocator/__init__.py
+++ b/vllm/device_allocator/__init__.py
@@ -22,6 +22,22 @@ class AllocationData:
     is_asleep: bool = False
 
 
+def should_poison_discarded_pages() -> bool:
+    """Debug-only switch for sleep/wake correctness testing (RFC #48310 SW3).
+
+    When ``VLLM_POISON_DISCARDED_PAGES`` is set to ``1``/``true``,
+    ``wake_up()`` fills the freshly remapped pages of discarded allocations
+    (those without a CPU backup) with 0xFF, so stale reads of discarded
+    content become deterministically detectable instead of consuming
+    platform-dependent (possibly zeroed, possibly stale) memory.
+    Off by default; production behavior is unchanged. ``envs`` values are
+    resolved lazily on access, so tests can toggle the flag at runtime.
+    """
+    from vllm import envs
+
+    return envs.VLLM_POISON_DISCARDED_PAGES
+
+
 class MemAllocator(Protocol):
     def use_memory_pool(self, tag: str | None = None) -> AbstractContextManager: ...
 

--- a/vllm/device_allocator/cumem.py
+++ b/vllm/device_allocator/cumem.py
@@ -17,7 +17,11 @@ from typing import Any
 
 import torch
 
-from vllm.device_allocator import AllocationData, HandleType
+from vllm.device_allocator import (
+    AllocationData,
+    HandleType,
+    should_poison_discarded_pages,
+)
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
 from vllm.utils.system_utils import find_loaded_library
@@ -338,6 +342,8 @@ class CuMemAllocator:
         gc.collect()
         torch.accelerator.empty_cache()
 
+        poison_discarded = should_poison_discarded_pages()
+        poisoned_bytes = 0
         for ptr, data in self.pointer_to_data.items():
             if not data.is_asleep:
                 continue
@@ -354,6 +360,22 @@ class CuMemAllocator:
                         cpu_ptr = cpu_backup_tensor.data_ptr()
                         libcudart.cudaMemcpy(ptr, cpu_ptr, size_in_bytes)
                         data.cpu_backup_tensor = None
+                elif poison_discarded:
+                    # Debug aid for sleep/wake correctness tests (RFC #48310
+                    # SW3): this allocation was discarded without a CPU
+                    # backup, so create_and_map gave it fresh physical pages
+                    # whose contents are platform-dependent (the driver may
+                    # zero them). Fill with 0xFF (NaN in fp16/bf16/fp32) so
+                    # any stale read of the remapped pages becomes
+                    # deterministically detectable.
+                    libcudart.cudaMemset(ptr, 0xFF, handle[1])
+                    poisoned_bytes += handle[1]
+
+        if poison_discarded and poisoned_bytes > 0:
+            logger.info(
+                "CuMemAllocator: poisoned %.2f GiB of discarded pages on wake.",
+                poisoned_bytes / 1024**3,
+            )
 
     @contextmanager
     def use_memory_pool(self, tag: str | None = None):

--- a/vllm/device_allocator/xpumem.py
+++ b/vllm/device_allocator/xpumem.py
@@ -9,11 +9,18 @@ from typing import Any
 
 import torch
 
-from vllm.device_allocator import AllocationData, HandleType
+from vllm.device_allocator import (
+    AllocationData,
+    HandleType,
+    should_poison_discarded_pages,
+)
 from vllm.logger import init_logger
 from vllm.utils.torch_utils import PIN_MEMORY
 
 logger = init_logger(__name__)
+
+# Chunk size for the debug poison buffer (see wake_up).
+_XPU_POISON_CHUNK_BYTES = 256 * 1024 * 1024
 
 MEMCPY_HOST_TO_DEVICE = 0
 MEMCPY_DEVICE_TO_HOST = 1
@@ -263,6 +270,19 @@ class XpuMemAllocator:
             )
 
     def wake_up(self, tags: list[str] | None = None) -> None:
+        poison_discarded = should_poison_discarded_pages()
+        poison_buffer = None
+        if poison_discarded:
+            # One reusable pinned chunk for all poisoned allocations; a
+            # full-size buffer could exhaust pinned host memory on large
+            # KV caches.
+            poison_buffer = torch.full(
+                (_XPU_POISON_CHUNK_BYTES,),
+                0xFF,
+                dtype=torch.uint8,
+                device="cpu",
+                pin_memory=PIN_MEMORY,
+            )
         for ptr, data in self.pointer_to_data.items():
             if not data.is_asleep:
                 continue
@@ -273,6 +293,22 @@ class XpuMemAllocator:
 
             cpu_backup_tensor = data.cpu_backup_tensor
             if cpu_backup_tensor is None:
+                if poison_discarded:
+                    # See CuMemAllocator.wake_up: debug poison (0xFF) for
+                    # discarded pages, whose remapped contents are
+                    # platform-dependent (RFC #48310 SW3). Copy in chunks
+                    # through the reusable pinned buffer.
+                    device, size_in_bytes, _, _ = data.handle
+                    chunk = poison_buffer.numel()
+                    for offset in range(0, size_in_bytes, chunk):
+                        n = min(chunk, size_in_bytes - offset)
+                        _xpu_memcpy_sync(
+                            ptr + offset,
+                            poison_buffer.data_ptr(),
+                            n,
+                            MEMCPY_HOST_TO_DEVICE,
+                            device,
+                        )
                 continue
 
             device, size_in_bytes, _, _ = data.handle

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -95,6 +95,7 @@ if TYPE_CHECKING:
     MAX_JOBS: str | None = None
     NVCC_THREADS: str | None = None
     VLLM_USE_PRECOMPILED: bool = False
+    VLLM_POISON_DISCARDED_PAGES: bool = False
     VLLM_USE_PRECOMPILED_RUST: bool = False
     VLLM_SKIP_PRECOMPILED_VERSION_SUFFIX: bool = False
     VLLM_DOCKER_BUILD_CONTEXT: bool = False
@@ -656,6 +657,13 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # If set, vllm will use the precompiled Rust frontend binary (vllm-rs).
     "VLLM_USE_PRECOMPILED_RUST": lambda: (
         os.environ.get("VLLM_USE_PRECOMPILED_RUST", "").strip().lower() in ("1", "true")
+    ),
+    # Debug-only switch for sleep/wake correctness testing (RFC #48310 SW3):
+    # poison remapped pages of discarded allocations on wake_up with 0xFF so
+    # stale reads are deterministically detectable.
+    "VLLM_POISON_DISCARDED_PAGES": lambda: (
+        os.environ.get("VLLM_POISON_DISCARDED_PAGES", "").strip().lower()
+        in ("1", "true")
     ),
     # If set, skip adding +precompiled suffix to version string
     "VLLM_SKIP_PRECOMPILED_VERSION_SUFFIX": lambda: bool(


### PR DESCRIPTION
## Summary

Adds a debug-only environment variable `VLLM_POISON_DISCARDED_PAGES`. When set to `1`/`true`, `wake_up()` fills the freshly remapped pages of discarded allocations (those without a CPU backup, e.g. dropped via `CuMemAllocator.discard()` from #52514) with `0xFF` (NaN in fp16/bf16/fp32), so stale reads of discarded content become deterministically detectable in correctness tests instead of silently consuming platform-dependent (possibly zeroed) pages.

This provides the poison mechanism required by the SW3 minimum regression check in RFC #48310 — "poison discarded pages; compare fixed-token logits/logprobs before and after wake". It is part of the SW2/SW3 regression-test work I claimed in https://github.com/vllm-project/vllm/issues/48310#issuecomment-5312693649: this PR delivers the poison mechanism together with allocator-level tests, and the SW3 model-level regression tests will build on it. Also relevant to the RL CI lane #45585.

## Design notes

- **Why in Python `wake_up()` instead of the C extension `create_and_map`:** the C extension has no tag/CPU-backup semantics, and `create_and_map` is also called on first allocation. Python-level `wake_up()` is the only place that can precisely identify "discarded allocations remapped without a backup".
- **Contents of remapped discarded pages are platform-dependent today** (the driver may zero them; on ROCm `create_and_map` explicitly zeroes since #44972). Poisoning turns "undefined / maybe zeroed" into a deterministic,
  test-detectable pattern.
- **Why not simply zero on CUDA like #44972 does on ROCm:** unconditional zeroing changes production wake semantics and adds a full write of the discarded bytes on every wake. Whether deterministic page contents should become the default CUDA behavior is the larger discussion on #48310; this PR keeps it opt-in and debug-only.
- **Why 0xFF:** it decodes as NaN in fp16/bf16/fp32, so a stale read propagates NaN loudly instead of producing plausible-looking values.
- Offloaded allocations with a CPU backup are restored as before and are never poisoned.
- Default off; production behavior is unchanged when the variable is unset. The flag is registered in `envs.py` with whitelist truthiness (`1`/`true`). When enabled, the added cost is one device-wide write of the discarded bytes (`cudaMemset` on CUDA/ROCm), acceptable for debug/test use.
- Implemented for both `CuMemAllocator` (CUDA/ROCm, via `cudaMemset`) and `XpuMemAllocator` (XPU, via chunked copies through one reusable 256 MB pinned buffer, so large KV caches do not exhaust pinned host memory).

## Tests

- New allocator-level test `tests/basic_correctness/test_mem.py::test_discard_poison_pages`: offloaded weights are restored (not poisoned), discarded kv pages are fully poisoned, plus a negative control round with the flag unset. The test loads no model (pure allocator level), so it adds no meaningful CI time. Verified on A10.
- ruff check + format pass.

## Caveats / CI coverage

- The new test runs in the default CUDA lane and in AMD CI, both of which run the whole `test_mem.py` (AMD MI300 "Basic Correctness"), so the CUDA and ROCm paths are covered.
- The XPU code path mirrors the existing `_xpu_memcpy_sync` usage in `sleep()`/`wake_up()` but is not exercised by CI (Intel CI only runs `test_mem.py::test_end_to_end`); flagging this explicitly — happy to adjust if XPU owners want additional validation.

cc @aoshen02 (RFC #48310)