### PR TITLE
[Quantization] Remove the dead ocp_mx_scheme branch from moe_kernel_quantize_input

### DIFF
--- a/vllm/model_executor/layers/fused_moe/utils.py
+++ b/vllm/model_executor/layers/fused_moe/utils.py
@@ -280,25 +280,9 @@ def moe_kernel_quantize_input(
     per_act_token_quant: bool,
     block_shape: list[int] | None = None,
     is_scale_swizzled: bool = True,
-    ocp_mx_scheme: str | None = None,
     quantization_emulation: bool = False,
     mx_alignment: int = 0,
 ) -> tuple[torch.Tensor, torch.Tensor | None]:
-    # Handle OCP MX scheme that requires QDQ (quantize-dequantize) for emulation
-    if ocp_mx_scheme is not None:
-        if ocp_mx_scheme in {"w_mxfp4", "w_mxfp4_a_mxfp4"}:
-            pass  # No QDQ needed for these schemes
-        elif ocp_mx_scheme.endswith("a_fp8"):
-            # Perform QDQ (quantize and dequantize) on activation for emulation
-            # purpose, because there is no native kernel for weight in ocp_mx_scheme
-            # and activation in FP8. The implementation is based on existing
-            # non-emulation ops.
-            # TODO: Remove this `ocp_mx_scheme is not None` block and rely solely
-            # on `quantization_emulation`.
-            return _fp8_quantize_dequantize(A, A_scale)
-        # else: For other schemes (e.g., *_a_mxfp6_e3m2, *_a_mxfp6_e2m3),
-        # weights are already dequantized, and we proceed with normal
-        # activation quantization below.
     if quant_dtype == current_platform.fp8_dtype():
         if quantization_emulation:
             return _fp8_quantize_dequantize(A, A_scale)


### PR DESCRIPTION
## Purpose

Shortly, remove dead code.

`moe_kernel_quantize_input()` in `vllm/model_executor/layers/fused_moe/utils.py` carries an `ocp_mx_scheme: str | None = None` parameter and opens its body with a block that short-circuits `*_a_fp8` OCP MX schemes into `_fp8_quantize_dequantize` before the normal `quant_dtype` dispatch ever runs. Nothing reaches that block. This PR removes the parameter and the block.

This is the follow-up @fxmarty-amd asked for when introduced the `quantization_emulation` path that superseded the block, in #46142 (`e368415daa`):

> [r3452957212](https://github.com/vllm-project/vllm/pull/46142/files#r3452957212):
> "Yes I don't think this code block is needed"
> [r3453008225](https://github.com/vllm-project/vllm/pull/46142/files#r3453008225):
> "Let's address in an other PR."

This is the left TODO:

```python
# TODO: Remove this `ocp_mx_scheme is not None` block and rely solely
# on `quantization_emulation`.
```

and reconfirmed the ask in review on #43983 ([review 4904664996](https://github.com/vllm-project/vllm/pull/43983#pullrequestreview-4904664996)), linking `utils.py#L288-L301` — exactly the lines removed here.

### Why deleting it changes no behavior

The only arm with behavior was `.endswith("a_fp8")`, and the only **reachable** a_fp8 scheme is `w_mxfp4_a_fp8` — `w_mxfp6_e3m2_a_fp8` and `w_mxfp6_e2m3_a_fp8`, both raise `NotImplementedError` earlier, in `QuarkOCP_MX_MoEMethod.get_fused_moe_quant_config`.

For `w_mxfp4_a_fp8` the two paths are identical:

|  | deleted arm | surviving dispatch |
|---|---|---|
| condition | `ocp_mx_scheme.endswith("a_fp8")` | `quant_dtype == current_platform.fp8_dtype()` and `quantization_emulation` |
| action | `return _fp8_quantize_dequantize(A, A_scale)` | `return _fp8_quantize_dequantize(A, A_scale)` |

`_fp8_quantize_dequantize` takes only `A` and `A_scale`, so nothing else was being bypassed. `OCP_MXQuantizationEmulationTritonExperts.__init__` sets both inputs (`quantization_emulation = True`, `_quant_dtype = current_platform.fp8_dtype()`), and `TritonExperts.apply` forwards them.

## Test Plan

### Unit test
```bash
python -m pytest tests/kernels/moe/test_ocp_mx_moe.py -q
python -m pytest tests/kernels/moe/test_cutlass_moe.py -q
pre-commit run --files vllm/model_executor/layers/fused_moe/utils.py
```

### End-to-end test
Same as what tested in https://github.com/vllm-project/vllm/pull/43983
- ROCm, MI325
- Model: amd/gpt-oss-120b-w-mxfp4-a-fp8
- MXFP4 emulation MoE backend --moe-backend emulation

## Test Result

Coming soon.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

