### PR TITLE
fix: propagate precompiled wheel variant lookup failure instead of falling back

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -924,25 +924,15 @@ class precompiled_wheel_utils:
                 )
                 commit = precompiled_wheel_utils.get_base_commit_in_main_branch()
             print(f"Using precompiled wheel commit {commit} with variant {variant}")
-            try_default = False
-            wheels, repo_url, download_filename = None, None, None
-            try:
-                wheels, repo_url = precompiled_wheel_utils.fetch_metadata_for_variant(
-                    commit, variant
-                )
-            except Exception as e:
-                logger.warning(
-                    "Failed to fetch precompiled wheel metadata for variant %s: %s",
-                    variant,
-                    e,
-                )
-                try_default = True  # try outside handler to keep the stacktrace simple
-            if try_default:
-                print("Trying the default variant from remote")
-                wheels, repo_url = precompiled_wheel_utils.fetch_metadata_for_variant(
-                    commit, None
-                )
-                # if this also fails, then we have nothing more to try / cache
+            wheels, repo_url = precompiled_wheel_utils.fetch_metadata_for_variant(
+                commit, variant
+            )
+            # Do not fall back to the root/default variant here: the root index
+            # may contain wheels for a different CUDA variant than the one
+            # selected (or auto-detected) above, and nothing downstream checks
+            # that compatibility. If the variant's metadata cannot be fetched,
+            # propagate the failure instead of silently installing a wheel built
+            # for the wrong CUDA version.
             assert wheels is not None and repo_url is not None, (
                 "Failed to fetch precompiled wheel metadata"
             )


### PR DESCRIPTION
Fixes vllm-project/vllm#52544

## Summary
For Python-only builds, when the precompiled-wheel metadata lookup for the selected CUDA variant fails, `setup.py` fell back to the root/default variant index. Nothing downstream checks that the fallback wheel matches the CUDA variant that was selected (or auto-detected) — the issue reporter hit exactly this: PyTorch CUDA 12.9 selected `cu129`, its metadata lookup failed, and the fallback picked a native artifact requiring CUDA 13.

The fix propagates the variant lookup failure instead of retrying the root index: once a variant is selected, only that variant's metadata is fetched. A wrong-CUDA wheel is worse than an install failure, because it fails far from the config that caused it.

## Verification
- `setup.py` parses cleanly (`ast.parse`).
- No other code path depends on the removed `try_default`/`download_filename` initializer — `download_filename` is still assigned in the wheel-selection branches that follow.
