### PR TITLE
fix(anthropic): convert tool_reference items to template-safe text

### DIFF
--- a/tests/entrypoints/anthropic/test_anthropic_messages_conversion.py
+++ b/tests/entrypoints/anthropic/test_anthropic_messages_conversion.py
@@ -241,6 +241,22 @@ class TestToolResultContent:
         assert len(tool_msg) == 1
         assert tool_msg[0]["content"] == "line 1\nline 2"
 
+    def test_tool_result_tool_reference_becomes_text(self):
+        """A tool_reference item must be converted to a template-safe text
+        item, not passed through raw (which trips strict Jinja chat templates
+        and crashes the request). Regression for #52489."""
+        request = self._make_tool_result_request(
+            [
+                {"type": "text", "text": "done"},
+                {"type": "tool_reference", "tool_name": "search_web"},
+            ]
+        )
+        result = _convert(request)
+
+        tool_msg = [m for m in result.messages if m["role"] == "tool"]
+        assert len(tool_msg) == 1
+        assert tool_msg[0]["content"] == "done\n[tool reference: search_web]"
+
     def test_tool_result_with_image(self):
         """Image in tool_result should produce a follow-up user message."""
         request = self._make_tool_result_request(

--- a/vllm/entrypoints/anthropic/serving.py
+++ b/vllm/entrypoints/anthropic/serving.py
@@ -431,7 +431,7 @@ class AnthropicServingMessages(OpenAIServingChat):
                     ref_name = item.get("tool_name") or item.get("name")
                     if ref_name:
                         tool_reference.append(
-                            {"type": "tool_reference", "name": ref_name}
+                            {"type": "text", "text": f"[tool reference: {ref_name}]"}
                         )
             tool_text = "\n".join(text_parts)
 


### PR DESCRIPTION
Fixes vllm-project/vllm#52489

## Summary
`AnthropicServingMessages._convert_user_tool_result` converted `text` and `image` items inside a `tool_result` block into template-safe OpenAI content, but passed `tool_reference` items through **raw** (`{"type": "tool_reference", "name": ...}`). That raw dict went straight into a `tool`-role message's `content`, and strict Jinja chat templates (e.g. Qwen3's) hit their catch-all `raise_exception` branch — so any conversation containing a `tool_reference` block (common with Claude Code + multiple MCP servers, where the API's dynamic-tool-discovery lets a result reference another tool by name) failed on every subsequent request.

Changed `tool_reference` items to a template-safe `text` item — `{"type": "text", "text": "[tool reference: {name}]"}` — mirroring how `text`/`image` are already handled.

## Test
Added `test_tool_result_tool_reference_becomes_text` to `test_anthropic_messages_conversion.py`, asserting the converted `tool` message content is `done\n[tool reference: search_web]`. Conversion logic verified standalone (vLLM's full test env needs torch, unavailable here).
