### PR TITLE
[Bugfix][gpt-oss] Strip matched stop string from Harmony reasoning/content

### DIFF
--- a/tests/parser/test_harmony.py
+++ b/tests/parser/test_harmony.py
@@ -261,6 +261,42 @@ class TestParse:
         assert content == "The answer is 4."
         assert tool_calls is None
 
+    def test_stop_string_stripped_from_reasoning(self, harmony_parser, chat_request):
+        # Regression test for https://github.com/vllm-project/vllm/issues/52599:
+        # a stop string matched inside the analysis (reasoning) channel must be
+        # removed when include_stop_str_in_output is false, same as it would be
+        # for the final/content channel.
+        chat_request.stop = ["song"]
+        chat_request.include_stop_str_in_output = False
+        response = [assistant("Sure, here is a song", "analysis")]
+
+        reasoning, content, tool_calls = harmony_parser.parse(
+            "",
+            chat_request,
+            model_output_token_ids=get_model_output_tokens(response),
+        )
+
+        assert reasoning == "Sure, here is a "
+        assert content is None
+        assert tool_calls is None
+
+    def test_stop_string_kept_when_include_stop_str_in_output(
+        self, harmony_parser, chat_request
+    ):
+        chat_request.stop = ["song"]
+        chat_request.include_stop_str_in_output = True
+        response = [assistant("Sure, here is a song", "analysis")]
+
+        reasoning, content, tool_calls = harmony_parser.parse(
+            "",
+            chat_request,
+            model_output_token_ids=get_model_output_tokens(response),
+        )
+
+        assert reasoning == "Sure, here is a song"
+        assert content is None
+        assert tool_calls is None
+
     @pytest.mark.parametrize(
         "tool_args",
         [

--- a/vllm/parser/harmony.py
+++ b/vllm/parser/harmony.py
@@ -52,6 +52,7 @@ from vllm.tool_parsers.structural_tag_registry import (
     get_function_parameters,
     register_vllm_structural_tag,
 )
+from vllm.v1.engine.detokenizer import check_stop_strings
 
 if TYPE_CHECKING:
     from openai_harmony import Message, StreamableParser
@@ -232,6 +233,13 @@ class HarmonyParser(DelegatingParser):
 
         reasoning = "\n".join(reasoning_parts) or None
         content = "\n".join(content_parts) or None
+
+        if not request.include_stop_str_in_output:
+            stop = _normalize_stop(request.stop)
+            if stop:
+                reasoning = _strip_trailing_stop_string(reasoning, stop)
+                content = _strip_trailing_stop_string(content, stop)
+
         return reasoning, content, tool_calls or None
 
     def parse_delta(
@@ -385,6 +393,41 @@ class HarmonyParser(DelegatingParser):
         if constrain_index == -1:
             return recipient
         return recipient[:constrain_index].rstrip() or None
+
+
+def _normalize_stop(stop: str | list[str] | None) -> list[str]:
+    if stop is None:
+        return []
+    return [stop] if isinstance(stop, str) else list(stop)
+
+
+def _strip_trailing_stop_string(text: str | None, stop: list[str]) -> str | None:
+    """Remove a matched client stop string from Harmony-parsed channel text.
+
+    ``BaseIncrementalDetokenizer`` already excludes the stop string from the
+    character-level ``output_text`` when ``include_stop_str_in_output`` is
+    false, but Harmony reconstructs ``reasoning``/``content`` from the raw,
+    untruncated token stream (``output.token_ids`` still contains the
+    stop-matching token; see ``BaseIncrementalDetokenizer.update``'s
+    ``skipped_stop_token_id`` bookkeeping). That truncation therefore never
+    reaches whichever Harmony channel the stop string lands in. Reuse the
+    same matching logic here so both paths agree on what "excluded from
+    output" means, regardless of which channel absorbed the stop.
+    """
+    if not text:
+        return text
+    match = check_stop_strings(
+        output_text=text,
+        new_char_count=len(text),
+        stop=stop,
+        include_in_output=False,
+    )
+    if match is None:
+        return text
+    _, truncate_to = match
+    if truncate_to == -1:
+        return text
+    return text[:truncate_to] or None
 
 
 _JSON_CONSTRAINS = [" json", " <|constrain|>json"]


### PR DESCRIPTION
FIX #52599

## Problem

For a non-streaming GPT-OSS chat completion, when a client `stop` string is matched, `finish_reason=stop` / `stop_reason` are correctly reported, but with `include_stop_str_in_output=false` the matched stop string is still present in the returned `reasoning` (or `content`) text. Repro in #52599.

## Root cause

`BaseIncrementalDetokenizer.update()` (`vllm/v1/engine/detokenizer.py`) already excludes a matched stop string from the character-level `output_text` when `include_stop_str_in_output` is false — but it deliberately keeps the stop-matching token in `self.token_ids` (needed elsewhere for correct usage/logprobs accounting; see the `skipped_stop_token_id` bookkeeping in `update()`).

The chat serving layer (`vllm/entrypoints/openai/chat_completion/serving.py`) passes those untruncated `token_ids` straight into `HarmonyParser.parse()`, which reconstructs `reasoning`/`content` purely from token IDs via the Harmony streamable parser and never consults the truncated `output_text` at all. So the character-level stop-string truncation that every non-Harmony (text-based) reasoning parser inherits for free never reaches whichever Harmony channel the stop string lands in — this affects `content` too, not just `reasoning`; the issue happened to reproduce on `reasoning` because these prompts finish mid-analysis with `content: null`.

## Fix

`HarmonyParser.parse()` now reuses `check_stop_strings()` — the same matching/truncation function the detokenizer already uses — and applies it to `reasoning` and `content` after the Harmony channel split, so both channels honor `include_stop_str_in_output` the same way the plain-text path does.

## Testing

Added two tests to `tests/parser/test_harmony.py`:
- `test_stop_string_stripped_from_reasoning`: a stop string matched inside the `analysis` channel is stripped when `include_stop_str_in_output=False`.
- `test_stop_string_kept_when_include_stop_str_in_output`: unchanged when the flag is `True`.

I verified the core stop-matching/truncation logic standalone against vLLM's real, unmodified `check_stop_strings` (exercised the exact repro string from #52599, multi-stop earliest-match tie-breaking, and the `include_stop_str_in_output=True` passthrough case) — all correct. I was not able to run the full `tests/parser/test_harmony.py` suite in my environment (no network access to pull the `openai/gpt-oss-20b` tokenizer / `openai_harmony` / `xgrammar`), so the added tests are unverified against the real Harmony parser end-to-end — flagging this explicitly for review rather than claiming full green CI.

## Known limitation

This is scoped to the non-streaming `parse()` path, matching the reported repro. Streaming (`parse_delta()`) needs the equivalent of the detokenizer's `stop_buffer_length` buffering to avoid emitting a partial stop string before it's known to complete without more truncation; left as a follow-up rather than attempted here.

## AI assistance

This PR was drafted with AI assistance (Claude Code), based on tracing the actual vLLM 0.27.0 source after reproducing the issue on NIM and the official upstream image. Marked as draft pending review and a real test run.