### PR TITLE
Bump upper bound on setuptools pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [
     "cmake>=3.26.1",
     "ninja",
     "packaging>=24.2",
-    "setuptools>=77.0.3,<81.0.0",
+    "setuptools>=77.0.3,<85.0.0",
     "setuptools-scm>=8.0",
     "setuptools-rust>=1.9.0",
     "torch == 2.13.0",


### PR DESCRIPTION
## Purpose
Bumps the upper bound on setuptools to `<85.0.0`. Currently, setuptools is restricted to versions `<81.0.0`. However, versions `<=82.0.1` are subject to this [security advisory](https://github.com/pypa/setuptools/security/advisories/GHSA-h35f-9h28-mq5c). If setuptools is not updated, mac users may unintentionally package / upload sensitive files.

For backwards-compatibility with existing installs, the lower-bound is left untouched.

## Test Plan
CI passing should be sufficient.

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

