### PR TITLE
[Bugfix] Honor stop strings in beam search

### DIFF
--- a/tests/samplers/test_beam_search_offline.py
+++ b/tests/samplers/test_beam_search_offline.py
@@ -1,0 +1,143 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""CPU-only unit tests for offline beam search."""
+
+import pytest
+
+from vllm import CompletionOutput, RequestOutput
+from vllm.entrypoints.generate.beam_search.offline import BeamSearchOfflineMixin
+from vllm.entrypoints.generate.beam_search.utils import check_beam_search_stop
+from vllm.inputs import EncoderDecoderInput, tokens_input
+from vllm.logprobs import Logprob
+from vllm.sampling_params import BeamSearchParams
+
+pytestmark = pytest.mark.cpu_test
+
+
+class _Tokenizer:
+    eos_token_id = 0
+
+    def decode(self, token_ids: list[int]) -> str:
+        return " ".join(str(token_id) for token_id in token_ids)
+
+
+class _Renderer:
+    def get_tokenizer(self) -> _Tokenizer:
+        return _Tokenizer()
+
+
+class _OfflineBeamSearch(BeamSearchOfflineMixin):
+    renderer = _Renderer()
+
+    def __init__(self, token_logprobs: dict[int, float] | None = None) -> None:
+        if token_logprobs is None:
+            token_logprobs = {11: -0.1}
+        self.logprobs = {
+            token_id: Logprob(logprob=logprob)
+            for token_id, logprob in token_logprobs.items()
+        }
+        self.num_calls = 0
+
+    def _preprocess_cmpl(self, prompts):
+        return [
+            {
+                "type": "token",
+                "prompt": prompt,
+                "prompt_token_ids": [1],
+            }
+            for prompt in prompts
+        ]
+
+    def _render_and_run_requests(self, prompts, *args, **kwargs):
+        self.num_calls += 1
+        return [
+            RequestOutput(
+                request_id="test-request",
+                prompt=prompt.get("prompt"),
+                prompt_token_ids=prompt["prompt_token_ids"],
+                prompt_logprobs=None,
+                outputs=[
+                    CompletionOutput(
+                        index=0,
+                        text="",
+                        token_ids=[],
+                        cumulative_logprob=None,
+                        logprobs=[self.logprobs],
+                        finish_reason=None,
+                    )
+                ],
+                finished=True,
+            )
+            for prompt in prompts
+        ]
+
+
+@pytest.mark.parametrize(
+    ("stop", "include_stop", "expected_text", "expected_tokens", "expected_calls"),
+    [
+        ("1", True, "1 1", [1, 11], 1),
+        ("11 11", False, "1 ", [1, 11, 11], 2),
+    ],
+)
+def test_offline_beam_search_stops_on_stop_strings(
+    stop: str,
+    include_stop: bool,
+    expected_text: str,
+    expected_tokens: list[int],
+    expected_calls: int,
+) -> None:
+    params = BeamSearchParams(
+        beam_width=1,
+        max_tokens=3,
+        stop=[stop],
+        include_stop_str_in_output=include_stop,
+    )
+    serving = _OfflineBeamSearch()
+
+    outputs = serving.beam_search(["prompt"], params)
+
+    sequence = outputs[0].sequences[0]
+    assert sequence.text == expected_text
+    assert sequence.tokens == expected_tokens
+    assert sequence.finish_reason == "stop"
+    assert sequence.stop_reason == stop
+    assert serving.num_calls == expected_calls
+
+
+def test_stop_string_completes_only_matching_offline_beam() -> None:
+    params = BeamSearchParams(
+        beam_width=2,
+        max_tokens=2,
+        stop=["11 11"],
+    )
+    serving = _OfflineBeamSearch({11: -0.1, 12: -0.2})
+
+    outputs = serving.beam_search(["prompt"], params)
+
+    stopped = [
+        sequence for sequence in outputs[0].sequences if sequence.stop_reason == "11 11"
+    ]
+    active = [
+        sequence for sequence in outputs[0].sequences if sequence.stop_reason is None
+    ]
+    assert len(stopped) == 1
+    assert len(active) == 1
+    assert stopped[0].tokens == [1, 11, 11]
+    assert stopped[0].finish_reason == "stop"
+    assert serving.num_calls == 2
+
+
+def test_stop_check_uses_decoder_prompt_length() -> None:
+    prompt = EncoderDecoderInput(
+        type="enc_dec",
+        encoder_prompt=tokens_input([99], prompt="encoder"),
+        decoder_prompt=tokens_input([1, 2], prompt="decoder"),
+    )
+    token_ids = [1, 2, 11]
+
+    assert check_beam_search_stop(_Tokenizer(), prompt, token_ids, ["2"], False) is None
+    stop_result = check_beam_search_stop(_Tokenizer(), prompt, token_ids, ["11"], False)
+
+    assert stop_result is not None
+    assert stop_result.output_text == ""
+    assert stop_result.stop_reason == "11"

--- a/tests/samplers/test_beam_search_online.py
+++ b/tests/samplers/test_beam_search_online.py
@@ -5,8 +5,14 @@ import pytest
 
 from vllm import CompletionOutput, RequestOutput
 from vllm.entrypoints.generate.beam_search.online import BeamSearchOnlineMixin
+from vllm.entrypoints.openai.chat_completion.protocol import (
+    ChatCompletionRequest,
+)
+from vllm.entrypoints.openai.completion.protocol import CompletionRequest
 from vllm.logprobs import Logprob
 from vllm.sampling_params import BeamSearchParams
+
+pytestmark = pytest.mark.cpu_test
 
 
 class _Tokenizer:
@@ -22,7 +28,23 @@ class _Renderer:
 
 
 class _EngineClient:
+    def __init__(self, token_logprobs: dict[int, float] | None = None) -> None:
+        if token_logprobs is None:
+            token_logprobs = {
+                11: -1.0,
+                12: -2.0,
+                13: -3.0,
+                14: -4.0,
+                _Tokenizer.eos_token_id: -0.1,
+            }
+        self.logprobs = {
+            token_id: Logprob(logprob=logprob)
+            for token_id, logprob in token_logprobs.items()
+        }
+        self.num_calls = 0
+
     async def generate(self, prompt, *args, **kwargs):
+        self.num_calls += 1
         yield RequestOutput(
             request_id=kwargs.get("request_id", "test-request"),
             prompt=prompt.get("prompt"),
@@ -34,15 +56,7 @@ class _EngineClient:
                     text="",
                     token_ids=[],
                     cumulative_logprob=None,
-                    logprobs=[
-                        {
-                            11: Logprob(logprob=-1.0),
-                            12: Logprob(logprob=-2.0),
-                            13: Logprob(logprob=-3.0),
-                            14: Logprob(logprob=-4.0),
-                            _Tokenizer.eos_token_id: Logprob(logprob=-0.1),
-                        }
-                    ],
+                    logprobs=[self.logprobs],
                     finish_reason=None,
                 )
             ],
@@ -52,7 +66,9 @@ class _EngineClient:
 
 class _Serving(BeamSearchOnlineMixin):
     renderer = _Renderer()
-    engine_client = _EngineClient()
+
+    def __init__(self, engine_client: _EngineClient | None = None) -> None:
+        self.engine_client = engine_client or _EngineClient()
 
 
 @pytest.mark.asyncio
@@ -72,3 +88,99 @@ async def test_beam_search_handles_extra_logprob_candidates() -> None:
     assert outputs[0].outputs[0].finish_reason == "stop"
     assert outputs[0].outputs[0].token_ids == []
     assert outputs[0].outputs[0].cumulative_logprob == pytest.approx(-0.1)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("stop", "include_stop", "expected_text", "expected_ids"),
+    [
+        ("1", True, "1", [11]),
+        ("11 11", False, "", [11, 11]),
+    ],
+)
+async def test_beam_search_stops_on_stop_strings(
+    stop: str,
+    include_stop: bool,
+    expected_text: str,
+    expected_ids: list[int],
+) -> None:
+    prompt = {
+        "type": "token",
+        "prompt": "prompt",
+        "prompt_token_ids": [1],
+    }
+    params = BeamSearchParams(
+        beam_width=1,
+        max_tokens=3,
+        stop=[stop],
+        include_stop_str_in_output=include_stop,
+    )
+    serving = _Serving(_EngineClient({11: -0.1}))
+
+    outputs = [
+        output async for output in serving.beam_search(prompt, "request", params)
+    ]
+
+    output = outputs[0].outputs[0]
+    assert output.text == expected_text
+    assert output.token_ids == expected_ids
+    assert output.finish_reason == "stop"
+    assert output.stop_reason == stop
+    assert serving.engine_client.num_calls == len(expected_ids)
+
+
+@pytest.mark.asyncio
+async def test_stop_string_completes_only_matching_online_beam() -> None:
+    prompt = {
+        "type": "token",
+        "prompt": "prompt",
+        "prompt_token_ids": [1],
+    }
+    params = BeamSearchParams(
+        beam_width=2,
+        max_tokens=2,
+        stop=["11 11"],
+    )
+    serving = _Serving(_EngineClient({11: -0.1, 12: -0.2}))
+
+    outputs = [
+        output async for output in serving.beam_search(prompt, "request", params)
+    ]
+
+    stopped = [output for output in outputs[0].outputs if output.stop_reason == "11 11"]
+    active = [output for output in outputs[0].outputs if output.stop_reason is None]
+    assert len(stopped) == 1
+    assert len(active) == 1
+    assert stopped[0].token_ids == [11, 11]
+    assert stopped[0].finish_reason == "stop"
+    assert active[0].finish_reason == "length"
+    assert serving.engine_client.num_calls == 3
+
+
+@pytest.mark.parametrize(
+    ("beam_request", "expected_stop"),
+    [
+        (
+            CompletionRequest(model="test-model", prompt="hello", stop="STOP"),
+            ["STOP"],
+        ),
+        (
+            ChatCompletionRequest(
+                model="test-model",
+                messages=[{"role": "user", "content": "hello"}],
+                stop=["STOP", "END"],
+            ),
+            ["STOP", "END"],
+        ),
+    ],
+)
+def test_openai_beam_search_params_forward_stop_strings(
+    beam_request: CompletionRequest | ChatCompletionRequest,
+    expected_stop: list[str],
+) -> None:
+    params = beam_request.to_beam_search_params(
+        max_tokens=3,
+        default_sampling_params={},
+    )
+
+    assert params.stop_strings == expected_stop

--- a/vllm/entrypoints/generate/beam_search/offline.py
+++ b/vllm/entrypoints/generate/beam_search/offline.py
@@ -25,6 +25,7 @@ from .utils import (
     BeamSearchInstance,
     BeamSearchOutput,
     BeamSearchSequence,
+    check_beam_search_stop,
     create_sort_beams_key_function,
 )
 
@@ -82,6 +83,8 @@ class BeamSearchOfflineMixin(OfflineInferenceMixin):
         temperature = params.temperature
         ignore_eos = params.ignore_eos
         length_penalty = params.length_penalty
+        include_stop_str_in_output = params.include_stop_str_in_output
+        stop_strings = params.stop_strings
 
         tokenizer = self.renderer.get_tokenizer()
         eos_token_id = tokenizer.eos_token_id
@@ -164,6 +167,9 @@ class BeamSearchOfflineMixin(OfflineInferenceMixin):
                         base_sampling_params=base_sampling_params,
                         eos_token_id=eos_token_id,
                         ignore_eos=ignore_eos,
+                        tokenizer=tokenizer,
+                        stop_strings=stop_strings,
+                        include_stop_str_in_output=include_stop_str_in_output,
                         beam_width=beam_width,
                         sort_beams_key=sort_beams_key,
                         structured_output_backend=structured_output_backend,
@@ -185,7 +191,8 @@ class BeamSearchOfflineMixin(OfflineInferenceMixin):
             best_beams = sorted_completed[:beam_width]
 
             for beam in best_beams:
-                beam.text = tokenizer.decode(beam.tokens)
+                if beam.text is None:
+                    beam.text = tokenizer.decode(beam.tokens)
 
             outputs.append(BeamSearchOutput(sequences=best_beams))
 
@@ -197,6 +204,9 @@ class BeamSearchOfflineMixin(OfflineInferenceMixin):
         base_sampling_params: SamplingParams,
         eos_token_id: int | None,
         ignore_eos: bool,
+        tokenizer: TokenizerLike,
+        stop_strings: list[str],
+        include_stop_str_in_output: bool,
         beam_width: int,
         sort_beams_key: Callable,
         structured_output_backend: StructuredOutputBackend | None,
@@ -316,8 +326,31 @@ class BeamSearchOfflineMixin(OfflineInferenceMixin):
 
                         if token_id == eos_token_id and not ignore_eos:
                             instance.completed.append(new_beam)
-                        else:
-                            instance_new_beams.append(new_beam)
+                            continue
+
+                        if stop_strings:
+                            stop_result = check_beam_search_stop(
+                                tokenizer,
+                                new_beam.orig_prompt,
+                                new_beam.tokens,
+                                stop_strings,
+                                include_stop_str_in_output,
+                            )
+                            if stop_result is not None:
+                                full_text = tokenizer.decode(new_beam.tokens)
+                                if stop_result.removed_char_count:
+                                    # Offline beam text includes the prompt, so
+                                    # apply the generated-text suffix trim to it.
+                                    full_text = full_text[
+                                        : -stop_result.removed_char_count
+                                    ]
+                                new_beam.text = full_text
+                                new_beam.finish_reason = "stop"
+                                new_beam.stop_reason = stop_result.stop_reason
+                                instance.completed.append(new_beam)
+                                continue
+
+                        instance_new_beams.append(new_beam)
             sorted_beams = sorted(
                 instance_new_beams,
                 key=sort_beams_key,
@@ -325,7 +358,7 @@ class BeamSearchOfflineMixin(OfflineInferenceMixin):
             )
             instance.beams = sorted_beams[:beam_width]
 
-        return False
+        return not any(instance.beams for instance in instances_batch)
 
     def _init_beam_search_structured_output(
         self,

--- a/vllm/entrypoints/generate/beam_search/online.py
+++ b/vllm/entrypoints/generate/beam_search/online.py
@@ -16,7 +16,11 @@ from vllm.sampling_params import BeamSearchParams, SamplingParams
 from vllm.utils import random_uuid
 from vllm.utils.async_utils import collect_from_async_generator
 
-from .utils import BeamSearchSequence, create_sort_beams_key_function
+from .utils import (
+    BeamSearchSequence,
+    check_beam_search_stop,
+    create_sort_beams_key_function,
+)
 
 
 class BeamSearchOnlineMixin(ABC):
@@ -40,6 +44,7 @@ class BeamSearchOnlineMixin(ABC):
         temperature = params.temperature
         length_penalty = params.length_penalty
         include_stop_str_in_output = params.include_stop_str_in_output
+        stop_strings = params.stop_strings
 
         tokenizer = self.renderer.get_tokenizer()
         eos_token_id = tokenizer.eos_token_id
@@ -146,6 +151,28 @@ class BeamSearchOnlineMixin(ABC):
                                 )
                             )
                         else:
+                            if stop_strings:
+                                candidate_tokens = current_beam.tokens + [token_id]
+                                stop_result = check_beam_search_stop(
+                                    tokenizer,
+                                    prompt,
+                                    candidate_tokens,
+                                    stop_strings,
+                                    include_stop_str_in_output,
+                                )
+                                if stop_result is not None:
+                                    completed.append(
+                                        BeamSearchSequence(
+                                            orig_prompt=prompt,
+                                            tokens=candidate_tokens,
+                                            logprobs=current_beam.logprobs + [logprobs],
+                                            cum_logprob=candidate_logprob,
+                                            text=stop_result.output_text,
+                                            finish_reason="stop",
+                                            stop_reason=stop_result.stop_reason,
+                                        )
+                                    )
+                                    continue
                             candidates.append(
                                 (
                                     candidate_logprob,
@@ -192,6 +219,10 @@ class BeamSearchOnlineMixin(ABC):
         best_beams = sorted_completed[:beam_width]
 
         for beam in best_beams:
+            # A stop string can end inside the final token. That token ID is retained
+            # for logprobs, so preserve the truncated text instead of re-decoding it.
+            if beam.text is not None:
+                continue
             if beam.tokens[-1] == eos_token_id and not ignore_eos:
                 # Skip the eos token in the text.
                 tokens = beam.tokens[tokenized_length:-1]

--- a/vllm/entrypoints/generate/beam_search/utils.py
+++ b/vllm/entrypoints/generate/beam_search/utils.py
@@ -13,6 +13,8 @@ from vllm.inputs import (
 )
 from vllm.logprobs import Logprob
 from vllm.lora.request import LoRARequest
+from vllm.tokenizers import TokenizerLike
+from vllm.v1.engine.detokenizer import check_stop_strings
 
 
 @dataclass
@@ -97,6 +99,44 @@ class BeamSearchSequence:
             encoder_prompt=prompt["encoder_prompt"],
             decoder_prompt=new_dec_prompt,
         )
+
+
+@dataclass(frozen=True)
+class BeamSearchStopResult:
+    output_text: str
+    stop_reason: str
+    removed_char_count: int
+
+
+def check_beam_search_stop(
+    tokenizer: TokenizerLike,
+    prompt: TokensInput | MultiModalInput | EncoderDecoderInput,
+    token_ids: list[int],
+    stop_strings: list[str],
+    include_stop_str_in_output: bool,
+) -> BeamSearchStopResult | None:
+    """Check stop strings against the generated portion of a beam."""
+    decoder_prompt = prompt if prompt["type"] != "enc_dec" else prompt["decoder_prompt"]
+    prompt_length = len(decoder_prompt["prompt_token_ids"])
+    output_text = tokenizer.decode(token_ids[prompt_length:])
+    stop = check_stop_strings(
+        output_text,
+        len(output_text),
+        stop_strings,
+        include_stop_str_in_output,
+    )
+    if stop is None:
+        return None
+
+    stop_reason, truncate_to = stop
+    if truncate_to == -1:
+        return BeamSearchStopResult(output_text, stop_reason, 0)
+
+    return BeamSearchStopResult(
+        output_text=output_text[:truncate_to],
+        stop_reason=stop_reason,
+        removed_char_count=len(output_text) - truncate_to,
+    )
 
 
 @dataclass

--- a/vllm/entrypoints/openai/chat_completion/protocol.py
+++ b/vllm/entrypoints/openai/chat_completion/protocol.py
@@ -30,7 +30,6 @@ from vllm.entrypoints.openai.engine.protocol import (
     FunctionDefinition,
     OpenAIBaseModel,
     PerRequestMetrics,
-    StopParam,
     StreamOptions,
     ToolCall,
     UsageInfo,
@@ -47,6 +46,7 @@ from vllm.sampling_params import (
     RepetitionDetectionParams,
     RequestOutputKind,
     SamplingParams,
+    StopParam,
     StructuredOutputsParams,
     ThinkingTokenBudget,
 )
@@ -649,6 +649,7 @@ class ChatCompletionRequest(OpenAIBaseModel):
             temperature=temperature,
             length_penalty=self.length_penalty,
             include_stop_str_in_output=self.include_stop_str_in_output,
+            stop=self.stop,
         )
 
     def extract_structured_outputs(self) -> StructuredOutputsParams | None:

--- a/vllm/entrypoints/openai/completion/protocol.py
+++ b/vllm/entrypoints/openai/completion/protocol.py
@@ -14,7 +14,6 @@ from vllm.entrypoints.openai.engine.protocol import (
     AnyResponseFormat,
     OpenAIBaseModel,
     PerRequestMetrics,
-    StopParam,
     StreamOptions,
     UsageInfo,
     structured_outputs_from_response_format,
@@ -30,6 +29,7 @@ from vllm.sampling_params import (
     RepetitionDetectionParams,
     RequestOutputKind,
     SamplingParams,
+    StopParam,
     StructuredOutputsParams,
     ThinkingTokenBudget,
 )
@@ -301,6 +301,7 @@ class CompletionRequest(OpenAIBaseModel):
             temperature=temperature,
             length_penalty=self.length_penalty,
             include_stop_str_in_output=self.include_stop_str_in_output,
+            stop=self.stop,
         )
 
     def extract_structured_outputs(self) -> StructuredOutputsParams | None:

--- a/vllm/entrypoints/openai/engine/protocol.py
+++ b/vllm/entrypoints/openai/engine/protocol.py
@@ -6,7 +6,7 @@
 import json
 import time
 from http import HTTPStatus
-from typing import Annotated, Any, ClassVar, Literal, TypeAlias
+from typing import Any, ClassVar, Literal, TypeAlias
 
 import regex as re
 from pydantic import (
@@ -17,7 +17,6 @@ from pydantic import (
     model_validator,
 )
 
-import vllm.envs as envs
 from vllm.config.utils import replace
 from vllm.entrypoints.chat_utils import make_tool_call_id
 from vllm.exceptions import VLLMServerError, VLLMValidationError
@@ -27,10 +26,6 @@ from vllm.utils import random_uuid
 from vllm.utils.import_utils import resolve_obj_by_qualname
 
 logger = init_logger(__name__)
-
-StopParam: TypeAlias = (
-    str | Annotated[list[str], Field(max_length=envs.VLLM_MAX_STOP_STRINGS)] | None
-)
 
 
 class OpenAIBaseModel(BaseModel):

--- a/vllm/entrypoints/openai/responses/protocol.py
+++ b/vllm/entrypoints/openai/responses/protocol.py
@@ -60,13 +60,14 @@ from vllm.entrypoints.chat_utils import (
     ChatCompletionMessageParam,
     ChatTemplateContentFormatOption,
 )
-from vllm.entrypoints.openai.engine.protocol import OpenAIBaseModel, StopParam
+from vllm.entrypoints.openai.engine.protocol import OpenAIBaseModel
 from vllm.exceptions import VLLMValidationError
 from vllm.logger import init_logger
 from vllm.renderers import ChatParams, TokenizeParams, merge_kwargs
 from vllm.sampling_params import (
     RequestOutputKind,
     SamplingParams,
+    StopParam,
     StructuredOutputsParams,
 )
 from vllm.utils import random_uuid

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -8,10 +8,10 @@ import math
 from dataclasses import field
 from enum import Enum, IntEnum
 from functools import cached_property
-from typing import Annotated, Any
+from typing import Annotated, Any, TypeAlias
 
 import msgspec
-from pydantic import BeforeValidator
+from pydantic import BeforeValidator, Field
 from pydantic.dataclasses import dataclass
 
 import vllm.envs as envs
@@ -75,6 +75,10 @@ ThinkingTokenBudget = Annotated[
     int | None,
     BeforeValidator(validate_thinking_token_budget),
 ]
+
+StopParam: TypeAlias = (
+    str | Annotated[list[str], Field(max_length=envs.VLLM_MAX_STOP_STRINGS)] | None
+)
 
 
 class SamplingType(IntEnum):
@@ -1258,6 +1262,17 @@ class BeamSearchParams(
     length_penalty: float = 1.0
     include_stop_str_in_output: bool = False
     structured_outputs: StructuredOutputsParams | None = None
+    stop: StopParam = None
+
+    @property
+    def stop_strings(self) -> list[str]:
+        if self.stop is None:
+            return []
+        if isinstance(self.stop, str):
+            return [self.stop]
+        return self.stop
 
     def __post_init__(self) -> None:
         _verify_num_sequences(self.beam_width, "beam_width")
+        if any(not stop_str for stop_str in self.stop_strings):
+            raise VLLMValidationError("stop cannot contain an empty string.")


### PR DESCRIPTION
## Purpose

When `use_beam_search=True`, stop strings from the Chat Completions and Completions APIs were not propagated to `BeamSearchParams`. In addition, the beam-search loops only completed beams on EOS, so a requested stop string was ignored and generation continued until EOS or `max_tokens`.

This PR:

- propagates `stop` from both `ChatCompletionRequest` and `CompletionRequest`;
- adds stop-string support to the shared `BeamSearchParams` contract;
- applies the same stop matching behavior to online and offline beam search;
- reuses the existing stop-string selection semantics, including overlapping
  stop strings and matches spanning token boundaries;
- supports stop strings that end inside a token;
- preserves the triggering token IDs and logprobs while truncating only the
  returned text, matching the regular detokenizer contract;
- preserves the existing offline contract where `BeamSearchSequence.text`
  includes the prompt; and
- keeps the no-stop path free of candidate detokenization overhead.

### Behavior before and after

For example, assume a beam decodes to `"answer STOP trailing text"` and the request specifies `stop=["STOP"]`.

| Behavior | Before this PR | After this PR |
| --- | --- | --- |
| Stop parameter | Dropped while building `BeamSearchParams` | Propagated to online and offline beam search |
| Termination | Beam continues until EOS or `max_tokens` | Beam completes as soon as `STOP` is matched |
| Text with `include_stop_str_in_output=False` | May contain `STOP` and text generated after it | Returns `"answer "` |
| Text with `include_stop_str_in_output=True` | May contain text generated after `STOP` | Returns `"answer STOP"` |
| `finish_reason` | Usually `"length"` or an unrelated EOS stop | `"stop"` |
| `stop_reason` | `None` or an unrelated token ID | `"STOP"` |
| Triggering token IDs and logprobs | Generation continues past the match | Preserved through the token that completes the match |

The same behavior applies when a stop string spans multiple tokens or ends in
the middle of a decoded token. Stop matching only examines generated text, so
a matching string in the prompt does not terminate the beam.

### Duplicate-work check

I searched the open issues and PRs using `beam search stop`, `beam_search stop`, `stop strings beam`, and `include_stop_str_in_output beam`. I did not find an open PR implementing this fix. #36285 also modifies online beam search, but it adds structured-output support and does not address stop strings, so this PR is not a duplicate.

## Test Plan

The regression tests use fake renderers and engine clients. They do not load a model or require a GPU. `--confcutdir` keeps the focused unit-test run isolated from repository-wide model/GPU fixtures.

```bash
uv venv --python 3.12
source .venv/bin/activate
uv pip install -r requirements/cpu.txt pytest pytest-asyncio

.venv/bin/python -m pytest \
  --confcutdir=tests/samplers \
  tests/samplers/test_beam_search_offline.py \
  tests/samplers/test_beam_search_online.py -v
```

The tests cover:

- online and offline stop-string termination;
- stop strings spanning multiple tokens;
- stop strings ending inside a token;
- `include_stop_str_in_output=True` and `False`;
- termination before `max_tokens`;
- preservation of triggering token IDs;
- `finish_reason` and `stop_reason`; and
- propagation from both Chat Completions and Completions requests.

Static checks were also run on all changed Python files:

- `ruff check`
- `ruff format --check`
- the Python 3.12 mypy pre-commit hook
- the typos pre-commit hook
- Python AST parsing
- `git diff --check`

## Test Result

```text
============================== 7 passed in 5.81s ===============================
```

All listed static checks passed.

The original issue was also reproduced before the change and confirmed fixed after the change by the submitter in a GPU environment. The expected observable result is the before/after behavior documented above; model execution and beam scores before the stop match remain unchanged.

### Model evaluation

No model-quality evaluation was run because this change does not modify model execution, logits, beam scores, or candidate token selection. Stop matching is performed after candidate logprobs have already been returned and only changes whether a candidate is moved to the completed-beam set. The affected output contract is covered by the CPU-only behavioral regression tests above.

### Documentation

No documentation update is required. This restores the documented `stop` behavior for beam-search requests without introducing a new API.
