### PR TITLE
[Helm] Support custom affinity configuration

### DIFF
--- a/docs/deployment/frameworks/helm.md
+++ b/docs/deployment/frameworks/helm.md
@@ -52,6 +52,7 @@ The following table describes configurable parameters of the chart in `values.ya
 
 | Key | Type | Default | Description |
 | --- | ---- | ------- | ----------- |
+| affinity | object | {} | Pod affinity configuration. Takes precedence over gpuModels when non-empty. |
 | autoscaling | object | {"enabled":false,"maxReplicas":100,"minReplicas":1,"targetCPUUtilizationPercentage":80} | Autoscaling configuration |
 | autoscaling.enabled | bool | false | Enable autoscaling |
 | autoscaling.maxReplicas | int | 100 | Maximum replicas |
@@ -74,7 +75,7 @@ The following table describes configurable parameters of the chart in `values.ya
 | extraInit.s3modelpath | string | "relative_s3_model_path/opt-125m" | (Optional) Path of the model on S3 |
 | extraInit.awsEc2MetadataDisabled | bool | true | (Optional) Disable AWS EC2 metadata service |
 | extraPorts | list | [] | Additional ports configuration |
-| gpuModels | list | ["TYPE_GPU_USED"] | Type of gpu used |
+| gpuModels | list | [] | Legacy GPU product selector used only when affinity is empty and both NVIDIA GPU requests and limits are greater than zero. |
 | image | object | {"command":["vllm","serve","/data/","--served-model-name","opt-125m","--host","0.0.0.0","--port","8000"],"repository":"vllm/vllm-openai","tag":"latest"} | Image configuration |
 | image.command | list | ["vllm","serve","/data/","--served-model-name","opt-125m","--host","0.0.0.0","--port","8000"] | Container launch command |
 | image.repository | string | "vllm/vllm-openai" | Image repository |

--- a/examples/deployment/chart-helm/Chart.yaml
+++ b/examples/deployment/chart-helm/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.2
+version: 0.0.3
 
 maintainers:
   - name: mfournioux

--- a/examples/deployment/chart-helm/README.md
+++ b/examples/deployment/chart-helm/README.md
@@ -2,6 +2,28 @@
 
 This directory contains a Helm chart for deploying the vllm application. The chart includes configurations for deployment, autoscaling, resource management, and more.
 
+## Scheduling
+
+Set `affinity` to configure the Pod affinity rules directly. When it is non-empty,
+it is rendered as-is and takes precedence over `gpuModels`. `gpuModels` remains
+available as a legacy fallback: when `affinity` is empty and both NVIDIA GPU
+requests and limits are greater than zero, it creates a required node affinity
+rule for `nvidia.com/gpu.product`. Both settings default to empty.
+
+```yaml
+affinity:
+  podAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchLabels:
+            app: model-cache
+        topologyKey: kubernetes.io/hostname
+```
+
+GPU-requesting deployments (where both NVIDIA GPU requests and limits are
+greater than zero) continue to set `runtimeClassName: nvidia` independently of
+these affinity settings.
+
 ## Files
 
 - Chart.yaml: Defines the chart metadata including name, version, and maintainers.

--- a/examples/deployment/chart-helm/templates/deployment.yaml
+++ b/examples/deployment/chart-helm/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{- $gpuEnabled := and (gt (int (index .Values.resources.requests "nvidia.com/gpu")) 0) (gt (int (index .Values.resources.limits "nvidia.com/gpu")) 0) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -113,8 +114,13 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if and (gt (int (index .Values.resources.requests "nvidia.com/gpu")) 0) (gt (int (index .Values.resources.limits "nvidia.com/gpu")) 0) }}
+      {{- if $gpuEnabled }}
       runtimeClassName: nvidia
+      {{- end }}
+      {{- if .Values.affinity }}
+      affinity:
+        {{- toYaml .Values.affinity | nindent 8 }}
+      {{- else if and $gpuEnabled .Values.gpuModels }}
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/examples/deployment/chart-helm/tests/deployment_test.yaml
+++ b/examples/deployment/chart-helm/tests/deployment_test.yaml
@@ -2,6 +2,112 @@ suite: test deployment
 templates:
   - deployment.yaml
 tests:
+  - it: should prefer custom affinity over legacy gpuModels
+    set:
+      gpuModels:
+        - TYPE_GPU_USED
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app: model-cache
+              topologyKey: kubernetes.io/hostname
+      resources:
+        requests:
+          nvidia.com/gpu: 1
+        limits:
+          nvidia.com/gpu: 1
+    asserts:
+      - equal:
+          path: spec.template.spec.affinity.podAffinity.requiredDuringSchedulingIgnoredDuringExecution[0].labelSelector.matchLabels
+          value:
+            app: model-cache
+      - notExists:
+          path: spec.template.spec.affinity.nodeAffinity
+      - equal:
+          path: spec.template.spec.runtimeClassName
+          value: nvidia
+
+  - it: should create legacy node affinity when gpuModels is set without custom affinity
+    set:
+      gpuModels:
+        - TYPE_GPU_USED
+      resources:
+        requests:
+          nvidia.com/gpu: 1
+        limits:
+          nvidia.com/gpu: 1
+    asserts:
+      - equal:
+          path: spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].key
+          value: nvidia.com/gpu.product
+      - equal:
+          path: spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].values
+          value:
+            - TYPE_GPU_USED
+
+  - it: should not create legacy node affinity without an active GPU request
+    set:
+      affinity: {}
+      gpuModels:
+        - TYPE_GPU_USED
+      resources:
+        requests:
+          nvidia.com/gpu: 0
+        limits:
+          nvidia.com/gpu: 0
+    asserts:
+      - notExists:
+          path: spec.template.spec.affinity
+
+  - it: should not enable GPU scheduling when the GPU limit is zero
+    set:
+      affinity: {}
+      gpuModels:
+        - TYPE_GPU_USED
+      resources:
+        requests:
+          nvidia.com/gpu: 1
+        limits:
+          nvidia.com/gpu: 0
+    asserts:
+      - notExists:
+          path: spec.template.spec.affinity
+      - notExists:
+          path: spec.template.spec.runtimeClassName
+
+  - it: should render custom affinity without GPU scheduling
+    set:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node-type
+                    operator: In
+                    values:
+                      - cpu
+      resources:
+        requests:
+          nvidia.com/gpu: 0
+        limits:
+          nvidia.com/gpu: 0
+    asserts:
+      - equal:
+          path: spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].key
+          value: node-type
+      - notExists:
+          path: spec.template.spec.runtimeClassName
+
+  - it: should not create affinity when affinity and gpuModels are empty
+    set:
+      affinity: {}
+      gpuModels: []
+    asserts:
+      - notExists:
+          path: spec.template.spec.affinity
+
   - it: should use configured labels for the deployment selector and pods
     set:
       labels:

--- a/examples/deployment/chart-helm/values.schema.json
+++ b/examples/deployment/chart-helm/values.schema.json
@@ -98,6 +98,9 @@
                 "type": "string"
             }
         },
+        "affinity": {
+            "type": "object"
+        },
         "autoscaling": {
             "type": "object",
             "properties": {
@@ -318,7 +321,6 @@
         "extraContainers",
         "extraInit",
         "extraPorts",
-        "gpuModels",
         "image",
         "labels",
         "livenessProbe",

--- a/examples/deployment/chart-helm/values.yaml
+++ b/examples/deployment/chart-helm/values.yaml
@@ -43,8 +43,10 @@ resources:
     nvidia.com/gpu: 1
 
 # -- Type of gpu used
-gpuModels:
-  - "TYPE_GPU_USED"
+gpuModels: []
+
+# -- Pod affinity configuration. Takes precedence over gpuModels when set.
+affinity: {}
 
 # -- Autoscaling configuration
 autoscaling:


### PR DESCRIPTION
Assisted-by: Codex



## Purpose

Fixes #38308.

The Helm chart previously supported scheduling only through `gpuModels` , which renders a GPU-product-specific `nodeAffinity`.
This prevented users from configuring generic `nodeAffinity`, `podAffinity`, or `podAntiAffinity`
without selecting a GPU product label.

This PR adds a first-class `affinity` value.
A non-empty custom affinity is rendered as-is and takes precedence over `gpuModels`.
When `affinity` is empty, the existing `gpuModels` fallback remains available for deployments with
positive NVIDIA GPU requests and limits.

This does not duplicate an open PR.
No open PR was found for #38308 or Helm affinity configuration.
#38310 addressed the same issue but was closed because of merge conflicts.

Compared with #38310, this PR:

- Updates the implementation for the current `examples/deployment/chart-helm` layout.
- Adds `affinity` to the values schema and documents its precedence and legacy fallback behavior.
- Keeps `runtimeClassName: nvidia` independent of affinity selection.
- Adds regression coverage for custom-affinity precedence, legacy fallback,
  CPU-only custom affinity, and GPU request/limit edge cases.

## Test Plan

- Run pre-commit on all changed files.
- Run Helm lint and unit tests.
- Run `git diff --check`.
- Manually validate scheduling on a three-node CPU-only Kubernetes cluster with the same custom `nodeAffinity` and `podAntiAffinity` values before and after the change.

## Test Result

- `.venv/bin/pre-commit run --files <changed files>`
  - Passed
- `helm lint examples/deployment/chart-helm`
  - Passed (one informational icon recommendation)
- `helm unittest examples/deployment/chart-helm`
  - Passed: 5 test suites, 16 tests
- `git diff --check`
  - Passed

### Kubernetes scheduling validation

The attached before/after screenshot was captured on a three-node CPU-only Kubernetes cluster:

#### Before


<img width="1102" height="102" alt="스크린샷 2026-08-17 오후 9 56 35" src="https://github.com/user-attachments/assets/a1ef6d37-4d35-4744-a99c-e1ffa9eb19e5" />


#### After


<img width="1071" height="69" alt="스크린샷 2026-08-17 오후 10 07 40" src="https://github.com/user-attachments/assets/9165fd33-b834-46b6-8a1a-c02d95c35537" />



- Before: the legacy chart ignored custom affinity;
the peer Pod and vLLM Pod were both scheduled on `k8s-worker1`.
- After: the peer Pod remained on `k8s-worker1`, while the vLLM Pod was scheduled on `k8s-worker2`.
- All displayed Pods were `Running`.



## Model Evaluation

N/A — this is a Kubernetes scheduling/chart configuration change. It does not change model output, accuracy, or the vLLM serving runtime.

## AI Assistance

AI assistance (Codex) was used for implementation and test development.
The human submitter reviewed every changed line and ran the validation commands listed above.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR
will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after,
or e2e results
- [x] (Optional) The necessary documentation update, such as updating
`supported_models.md` and `examples` for a new model.
</details>