### PR TITLE
[Bugfix] Fix DeepSeek V4 mHC broadcast buffer for weight sync

### DIFF
--- a/tests/kernels/test_mhc_kernels.py
+++ b/tests/kernels/test_mhc_kernels.py
@@ -1,7 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from types import SimpleNamespace
+
 import pytest
 import torch
+import torch.nn as nn
 
 import vllm.model_executor.kernels.mhc  # noqa: F401
 from vllm.model_executor.kernels.mhc.tilelang import (
@@ -9,6 +12,10 @@ from vllm.model_executor.kernels.mhc.tilelang import (
     _torch_hc_prenorm_gemm,
 )
 from vllm.model_executor.layers.mhc import HAS_TILELANG_MHC
+from vllm.models.deepseek_v4.nvidia.model import (
+    DeepseekV4DecoderLayer,
+    DeepseekV4Model,
+)
 from vllm.platforms import current_platform
 from vllm.utils.torch_utils import set_random_seed
 
@@ -355,3 +362,57 @@ def test_hc_head_tilelang(num_tokens, hidden_size, hc_mult):
 
     out_ref = hc_head_ref(residual, fn, hc_scale, hc_base, rms_eps, hc_eps)
     torch.testing.assert_close(out, out_ref, atol=5e-2, rtol=1e-2)
+
+
+def _make_mhc_decoder_layer(hc_mult: int, hidden_size: int) -> DeepseekV4DecoderLayer:
+    layer = DeepseekV4DecoderLayer.__new__(DeepseekV4DecoderLayer)
+    nn.Module.__init__(layer)
+    layer.hc_mult = hc_mult
+    layer.hidden_size = hidden_size
+    mix_hc = (2 + hc_mult) * hc_mult
+    layer.hc_attn_fn = nn.Parameter(
+        torch.randn(mix_hc, hc_mult * hidden_size, dtype=torch.float32),
+        requires_grad=False,
+    )
+    layer.hc_attn_fn_broadcast = None
+    return layer
+
+
+def _patch_first_rank_pp_group(monkeypatch):
+    monkeypatch.setattr(
+        "vllm.models.deepseek_v4.nvidia.model.get_pp_group",
+        lambda: SimpleNamespace(is_first_rank=True),
+    )
+
+
+def test_deepseek_v4_mhc_broadcast_finalize_sums_hc_streams(monkeypatch):
+    """First finalize (at the end of load_weights) allocates
+    hc_attn_fn_broadcast as hc_attn_fn summed over hc streams."""
+    _patch_first_rank_pp_group(monkeypatch)
+    layer = _make_mhc_decoder_layer(hc_mult=2, hidden_size=8)
+    model = SimpleNamespace(start_layer=0, end_layer=1, layers=[layer])
+
+    DeepseekV4Model.finalize_mhc_broadcast_weights(model)
+
+    assert layer.hc_attn_fn_broadcast is not None
+    expected = layer.hc_attn_fn.detach().view(-1, 2, 8).sum(dim=1)
+    assert torch.equal(layer.hc_attn_fn_broadcast, expected)
+
+
+def test_deepseek_v4_mhc_broadcast_refit_refreshes_in_place(monkeypatch):
+    """Re-finalizing after a weight refit must copy into the existing
+    broadcast tensor so its address stays stable for captured CUDA graphs,
+    while picking up the new hc_attn_fn values."""
+    _patch_first_rank_pp_group(monkeypatch)
+    layer = _make_mhc_decoder_layer(hc_mult=2, hidden_size=8)
+    model = SimpleNamespace(start_layer=0, end_layer=1, layers=[layer])
+
+    DeepseekV4Model.finalize_mhc_broadcast_weights(model)
+    buffer = layer.hc_attn_fn_broadcast
+
+    layer.hc_attn_fn.add_(1.0)
+    DeepseekV4Model.finalize_mhc_broadcast_weights(model)
+
+    assert layer.hc_attn_fn_broadcast is buffer
+    expected = layer.hc_attn_fn.detach().view(-1, 2, 8).sum(dim=1)
+    assert torch.equal(layer.hc_attn_fn_broadcast, expected)

--- a/vllm/models/deepseek_v4/nvidia/model.py
+++ b/vllm/models/deepseek_v4/nvidia/model.py
@@ -1372,11 +1372,15 @@ class DeepseekV4Model(nn.Module, EagleModelMixin):
             return
         layer = self.layers[self.start_layer]
         if isinstance(layer, DeepseekV4DecoderLayer):
-            layer.hc_attn_fn_broadcast = (
+            broadcast = (
                 layer.hc_attn_fn.detach()
                 .view(-1, layer.hc_mult, layer.hidden_size)
                 .sum(dim=1)
             )
+            if layer.hc_attn_fn_broadcast is None:
+                layer.hc_attn_fn_broadcast = broadcast
+            else:
+                layer.hc_attn_fn_broadcast.copy_(broadcast)
 
 
 def _make_deepseek_v4_weights_mapper(expert_dtype: str) -> WeightsMapper:


### PR DESCRIPTION

## Purpose

Fix Stale broadcast weights after refit. finalize_mhc_broadcast_weights() rebound layer.hc_attn_fn_broadcast to a freshly-allocated tensor on every call. CUDA graphs captured against the original tensor's address keep replaying with the old pointer, so a weight refit (repeat load_weights() after capture, e.g. RL weight sync) left captured graphs reading stale broadcast weights. Fixed by allocating only when the buffer is None and otherwise copy_()-ing in place, keeping the address stable.

## Test Plan

Two unit tests added to tests/kernels/test_mhc_kernels.py:

1. test_deepseek_v4_mhc_broadcast_finalize_sums_hc_streams — first finalize allocates the buffer with the stream-summed values.
2. test_deepseek_v4_mhc_broadcast_refit_refreshes_in_place — after mutating hc_attn_fn and re-finalizing, the buffer is the same tensor object with updated values (the refit contract).
pytest tests/kernels/test_mhc_kernels.py -k mhc_broadcast -v
pytest tests/kernels/test_mhc_kernels.py -k "hc_head_tilelang or mhc_broadcast"

End to end tests on verl side with DSV4 training

## Test Result

- -k mhc_broadcast: 2 passed.
- Combined with the tilelang hc_head kernel tests (which flip
torch.set_default_device to CUDA earlier in the file): 10 passed.
- Full file collects all 53 tests cleanly.
- Mutation check: with the model.py fix reverted to HEAD, the refit test
fails on the buffer-identity assertion and the sums test still passes — the
pair pins both the pre-existing semantics and the new in-place contract.
- End to end tests on verl side with DSV4 training returned to normal training inference mismatch.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [X] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [X] The test plan, such as providing test command.
- [X] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

