### PR TITLE
[ROCm] Enable fused AR draft metadata updates for DeepSeek V4

### DIFF
--- a/tests/v1/attention/test_deepseek_v4_rocm_metadata.py
+++ b/tests/v1/attention/test_deepseek_v4_rocm_metadata.py
@@ -1,0 +1,218 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from unittest.mock import patch
+
+import pytest
+import torch
+
+from vllm.models.deepseek_v4.amd import rocm as rocm_module
+from vllm.models.deepseek_v4.amd.rocm import (
+    DeepseekV4ROCMAiterMLASparseMetadataBuilder,
+    DeepseekV4ROCMAiterSparseSWAMetadata,
+    DeepseekV4ROCMAiterSparseSWAMetadataBuilder,
+)
+from vllm.v1.attention.backends.mla.sparse_swa import (
+    DeepseekSparseSWAMetadataBuilder,
+)
+from vllm.v1.attention.ops.rocm_aiter_mla_sparse import (
+    build_ragged_indices_from_dense_out,
+)
+
+
+def _build_ragged_reference(
+    indices: torch.Tensor,
+    lengths: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    lengths = lengths.clamp(min=0, max=indices.shape[-1]).to(torch.int32)
+    rows = [row[:length] for row, length in zip(indices, lengths.tolist())]
+    ragged = torch.cat(rows) if rows else torch.empty(0, dtype=torch.int32)
+    indptr = torch.zeros(len(rows) + 1, dtype=torch.int32)
+    torch.cumsum(lengths, dim=0, out=indptr[1:])
+    return ragged, indptr
+
+
+def _build_ragged_reference_out(
+    indices: torch.Tensor,
+    lengths: torch.Tensor,
+    out_indices: torch.Tensor,
+    out_indptr: torch.Tensor,
+) -> None:
+    ragged, indptr = _build_ragged_reference(indices, lengths)
+    out_indptr.copy_(indptr)
+    out_indices[: ragged.numel()].copy_(ragged)
+
+
+@pytest.mark.parametrize(
+    ("updated_indices", "updated_lens"),
+    [
+        (
+            [
+                [63, 64, 65, 66],
+                [127, 128, 129, 130],
+                [191, 192, 193, 194],
+                [255, 256, 257, 258],
+            ],
+            [4, 3, 1, 0],
+        ),
+        (
+            [
+                [60, 61, 62, 63],
+                [124, 125, 126, 127],
+                [188, 189, 190, 191],
+                [252, 253, 254, 255],
+            ],
+            [2, 0, 4, 0],
+        ),
+    ],
+)
+def test_rocm_swa_draft_update_refreshes_ragged_in_place(
+    updated_indices: list[list[int]],
+    updated_lens: list[int],
+):
+    builder = object.__new__(DeepseekV4ROCMAiterSparseSWAMetadataBuilder)
+    dense_indices = torch.zeros((4, 1, 4), dtype=torch.int32)
+    dense_lens = torch.zeros(4, dtype=torch.int32)
+    ragged_indices = torch.full((16,), -1, dtype=torch.int32)
+    ragged_indptr = torch.full((5,), -1, dtype=torch.int32)
+    metadata = DeepseekV4ROCMAiterSparseSWAMetadata(
+        block_table=torch.empty((4, 4), dtype=torch.int32),
+        slot_mapping=torch.empty(4, dtype=torch.int64),
+        block_size=64,
+        decode_swa_indices=dense_indices,
+        decode_swa_lens=dense_lens,
+        decode_swa_ragged_indices=ragged_indices,
+        decode_swa_ragged_indptr=ragged_indptr,
+        num_decodes=4,
+        num_decode_tokens=4,
+    )
+    ragged_indices_ptr = ragged_indices.data_ptr()
+    ragged_indptr_ptr = ragged_indptr.data_ptr()
+
+    def update_dense(_builder, updated_metadata):
+        updated_metadata.decode_swa_indices.copy_(
+            torch.tensor(updated_indices, dtype=torch.int32).view(4, 1, 4)
+        )
+        updated_metadata.decode_swa_lens.copy_(
+            torch.tensor(updated_lens, dtype=torch.int32)
+        )
+
+    with (
+        patch.object(
+            DeepseekSparseSWAMetadataBuilder,
+            "update_draft_decode_metadata",
+            update_dense,
+        ),
+        patch.object(
+            rocm_module,
+            "build_ragged_indices_from_dense_out",
+            _build_ragged_reference_out,
+        ),
+        patch.object(
+            rocm_module,
+            "build_ragged_indices_from_dense",
+            side_effect=AssertionError("allocating ragged builder must not be called"),
+        ),
+    ):
+        builder.update_draft_decode_metadata(metadata)
+
+    expected_indices, expected_indptr = _build_ragged_reference(
+        torch.tensor(updated_indices, dtype=torch.int32),
+        torch.tensor(updated_lens, dtype=torch.int32),
+    )
+    assert metadata.decode_swa_ragged_indices is ragged_indices
+    assert metadata.decode_swa_ragged_indptr is ragged_indptr
+    assert ragged_indices.data_ptr() == ragged_indices_ptr
+    assert ragged_indptr.data_ptr() == ragged_indptr_ptr
+    torch.testing.assert_close(
+        ragged_indices[: expected_indices.numel()], expected_indices
+    )
+    torch.testing.assert_close(ragged_indptr, expected_indptr)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires a GPU")
+@pytest.mark.parametrize(
+    "lengths",
+    [
+        [4, 3, 1, 0],
+        [2, 0, 4, 0],
+        [-1, 2, 5, 0],
+    ],
+)
+def test_build_ragged_indices_from_dense_out_matches_reference(
+    lengths: list[int],
+):
+    indices = torch.tensor(
+        [
+            [63, 64, 65, 66],
+            [127, 128, 129, 130],
+            [191, 192, 193, 194],
+            [255, 256, 257, 258],
+        ],
+        dtype=torch.int32,
+        device="cuda",
+    )
+    lens = torch.tensor(lengths, dtype=torch.int32, device="cuda")
+    out_indices = torch.full((indices.numel(),), -1, dtype=torch.int32, device="cuda")
+    out_indptr = torch.full(
+        (indices.shape[0] + 1,), -1, dtype=torch.int32, device="cuda"
+    )
+    indices_ptr = out_indices.data_ptr()
+    indptr_ptr = out_indptr.data_ptr()
+
+    build_ragged_indices_from_dense_out(indices, lens, out_indices, out_indptr)
+    expected_indices, expected_indptr = _build_ragged_reference(
+        indices.cpu(), torch.tensor(lengths, dtype=torch.int32)
+    )
+
+    assert out_indices.data_ptr() == indices_ptr
+    assert out_indptr.data_ptr() == indptr_ptr
+    torch.testing.assert_close(out_indptr.cpu(), expected_indptr)
+    nnz = int(expected_indptr[-1].item())
+    torch.testing.assert_close(out_indices[:nnz].cpu(), expected_indices[:nnz])
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires a GPU")
+@pytest.mark.parametrize("num_rows", [1, 63, 64, 65, 127, 128, 129, 256])
+def test_build_ragged_indices_from_dense_out_scan_sizes(num_rows: int):
+    row_width = 4
+    indices = torch.arange(
+        num_rows * row_width,
+        dtype=torch.int32,
+        device="cuda",
+    ).reshape(num_rows, row_width)
+    lengths_cpu = (torch.arange(num_rows, dtype=torch.int32) % (row_width + 2)) - 1
+    lens = lengths_cpu.to(device="cuda")
+    out_indices = torch.full((indices.numel(),), -1, dtype=torch.int32, device="cuda")
+    out_indptr = torch.full((num_rows + 1,), -1, dtype=torch.int32, device="cuda")
+
+    build_ragged_indices_from_dense_out(indices, lens, out_indices, out_indptr)
+    expected_indices, expected_indptr = _build_ragged_reference(
+        indices.cpu(), lengths_cpu
+    )
+
+    torch.testing.assert_close(out_indptr.cpu(), expected_indptr)
+    nnz = int(expected_indptr[-1].item())
+    torch.testing.assert_close(out_indices[:nnz].cpu(), expected_indices)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires a GPU")
+def test_build_ragged_indices_from_dense_out_empty_rows():
+    indices = torch.empty((0, 4), dtype=torch.int32, device="cuda")
+    lengths = torch.empty((0,), dtype=torch.int32, device="cuda")
+    out_indices = torch.empty((0,), dtype=torch.int32, device="cuda")
+    out_indptr = torch.full((1,), -1, dtype=torch.int32, device="cuda")
+
+    build_ragged_indices_from_dense_out(indices, lengths, out_indices, out_indptr)
+
+    torch.testing.assert_close(out_indptr.cpu(), torch.zeros(1, dtype=torch.int32))
+
+
+def test_rocm_swa_builder_enables_fused_draft_decode():
+    builder_cls = DeepseekV4ROCMAiterSparseSWAMetadataBuilder
+    assert builder_cls.supports_draft_decode_metadata_update
+
+
+def test_rocm_mla_sparse_builder_keeps_fused_draft_decode_disabled():
+    builder_cls = DeepseekV4ROCMAiterMLASparseMetadataBuilder
+    assert not builder_cls.supports_draft_decode_metadata_update

--- a/vllm/models/deepseek_v4/amd/rocm.py
+++ b/vllm/models/deepseek_v4/amd/rocm.py
@@ -32,6 +32,7 @@ from vllm.v1.attention.backends.mla.sparse_swa import (
 )
 from vllm.v1.attention.ops.rocm_aiter_mla_sparse import (
     build_ragged_indices_from_dense,
+    build_ragged_indices_from_dense_out,
     rocm_inv_rope_einsum,
     rocm_sparse_attn_decode,
     rocm_sparse_attn_prefill,
@@ -435,9 +436,7 @@ class DeepseekV4ROCMAiterMLASparseMetadataBuilder(DeepseekV4SparseMLAMetadataBui
 
 
 class DeepseekV4ROCMAiterSparseSWAMetadataBuilder(DeepseekSparseSWAMetadataBuilder):
-    # Keep fused multi-step decode disabled until update_draft_decode_metadata()
-    # also refreshes the ROCm-specific ragged SWA indices and indptrs.
-    supports_draft_decode_metadata_update = False
+    supports_draft_decode_metadata_update = True
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -495,6 +494,32 @@ class DeepseekV4ROCMAiterSparseSWAMetadataBuilder(DeepseekSparseSWAMetadataBuild
             **vars(base),
             decode_swa_ragged_indices=ragged_indices,
             decode_swa_ragged_indptr=ragged_indptr,
+        )
+
+    def update_draft_decode_metadata(
+        self,
+        metadata: DeepseekSparseSWAMetadata,
+    ) -> None:
+        super().update_draft_decode_metadata(metadata)
+        if metadata.num_decode_tokens == 0:
+            return
+        rocm_metadata = cast(DeepseekV4ROCMAiterSparseSWAMetadata, metadata)
+
+        assert rocm_metadata.decode_swa_indices is not None
+        assert rocm_metadata.decode_swa_lens is not None
+        assert rocm_metadata.decode_swa_ragged_indices is not None
+        assert rocm_metadata.decode_swa_ragged_indptr is not None
+
+        # FULL decode graphs capture kernel argument addresses. Pack directly
+        # into the persistent buffers returned by build(), without allocating
+        # temporary flat/indptr tensors or replacing their storage.
+        build_ragged_indices_from_dense_out(
+            rocm_metadata.decode_swa_indices.reshape(
+                rocm_metadata.num_decode_tokens, -1
+            ),
+            rocm_metadata.decode_swa_lens,
+            rocm_metadata.decode_swa_ragged_indices,
+            rocm_metadata.decode_swa_ragged_indptr,
         )
 
 

--- a/vllm/v1/attention/ops/rocm_aiter_mla_sparse.py
+++ b/vllm/v1/attention/ops/rocm_aiter_mla_sparse.py
@@ -1270,6 +1270,26 @@ def _validate_dsv4_sparse_dims(
 
 
 @triton.jit
+def _build_ragged_indptr_kernel(
+    lengths_ptr,
+    indptr_ptr,
+    num_rows,
+    max_width,
+    BLOCK_SIZE: tl.constexpr,
+):
+    offsets = tl.arange(0, BLOCK_SIZE)
+    mask = offsets < num_rows
+    lengths = tl.load(lengths_ptr + offsets, mask=mask, other=0).to(tl.int32)
+    # Keep this clamp in sync with _pack_dense_prefix_to_ragged_kernel so
+    # indptr and payload agree for out-of-range dense lengths.
+    lengths = tl.minimum(tl.maximum(lengths, 0), max_width)
+    inclusive_prefix = tl.cumsum(lengths, axis=0)
+
+    tl.store(indptr_ptr, 0)
+    tl.store(indptr_ptr + offsets + 1, inclusive_prefix, mask=mask)
+
+
+@triton.jit
 def _pack_dense_prefix_to_ragged_kernel(
     indices_ptr,
     lengths_ptr,
@@ -1285,6 +1305,9 @@ def _pack_dense_prefix_to_ragged_kernel(
     offsets = block_idx * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
 
     row_len = tl.load(lengths_ptr + row_idx)
+    # Keep this clamp in sync with _build_ragged_indptr_kernel so indptr and
+    # payload agree for out-of-range dense lengths.
+    row_len = tl.minimum(tl.maximum(row_len, 0), row_width)
     if block_idx * BLOCK_SIZE >= row_len:
         return
 
@@ -1300,6 +1323,72 @@ def _pack_dense_prefix_to_ragged_kernel(
 
     out_start = tl.load(indptr_ptr + row_idx)
     tl.store(out_ptr + out_start + offsets, vals, mask=mask)
+
+
+def build_ragged_indices_from_dense_out(
+    indices: torch.Tensor,
+    lengths: torch.Tensor,
+    out_indices: torch.Tensor,
+    out_indptr: torch.Tensor,
+    num_rows: int = -1,
+) -> None:
+    """Pack dense row prefixes directly into caller-owned output buffers.
+
+    This path performs no tensor-storage allocation, making it suitable for
+    metadata updates captured inside a FULL decode graph. Inputs and outputs
+    are intentionally required to already have the kernel's dtype/layout so
+    implicit ``to()`` or ``contiguous()`` temporaries cannot be introduced.
+    """
+    assert indices.dtype == torch.int32
+    assert indices.is_contiguous()
+    assert lengths.dtype == torch.int32 and lengths.ndim == 1
+    assert lengths.is_contiguous()
+    assert out_indices.dtype == torch.int32 and out_indices.ndim == 1
+    assert out_indices.is_contiguous()
+    assert out_indptr.dtype == torch.int32 and out_indptr.ndim == 1
+    assert out_indptr.is_contiguous()
+    assert (
+        indices.device == lengths.device
+        and indices.device == out_indices.device
+        and indices.device == out_indptr.device
+    )
+
+    indices = indices.reshape(indices.shape[0], -1)
+    num_dense_rows = indices.shape[0]
+    max_width = indices.shape[1]
+    assert lengths.numel() == num_dense_rows, (
+        f"Expected one length per row, got {lengths.shape} for indices {indices.shape}"
+    )
+    assert out_indptr.numel() >= num_dense_rows + 1
+    assert out_indices.numel() >= num_dense_rows * max_width
+
+    if num_dense_rows == 0:
+        out_indptr.zero_()
+        return
+
+    indptr_block_size = triton.next_power_of_2(num_dense_rows)
+    _build_ragged_indptr_kernel[(1,)](
+        lengths,
+        out_indptr,
+        num_dense_rows,
+        max_width,
+        BLOCK_SIZE=indptr_block_size,
+    )
+
+    if max_width > 0:
+        block_size = 128
+        _pack_dense_prefix_to_ragged_kernel[
+            (num_dense_rows, triton.cdiv(max_width, block_size))
+        ](
+            indices,
+            lengths,
+            out_indptr,
+            out_indices,
+            indices.stride(0),
+            int(num_rows),
+            max_width,
+            BLOCK_SIZE=block_size,
+        )
 
 
 def build_ragged_indices_from_dense(


### PR DESCRIPTION
Builds on vLLM PR #46849, which restores fused multi-step draft decode graphs for autoregressive speculative decoding when every attention backend can update step-dependent draft metadata in place. That PR left DeepSeek V4 ROCm sparse SWA disabled because the AMD path also materializes ROCm-specific ragged SWA indices and indptrs.

Enable the ROCm DeepSeek V4 AITER SparseSWA metadata builder for fused draft decode by refreshing its ragged SWA representation after the generic dense SWA update. The refresh writes directly into the persistent metadata buffers returned by build(), avoiding temporary ragged flat/indptr allocations so captured HIPGraph replay keeps stable tensor storage addresses. Add focused tests for the direct-to-buffer helper and in-place metadata update.

Validation used TP4 on MI355X against patched and control images built from vllm/main@c4e9692. Runtime logs confirmed the patched image used the fused speculator graph path, while control logged fallback because DEEPSEEK_SPARSE_SWA did not support fused multi-step draft decode metadata updates. Smoke, GSM8K, c16, and c128 runs completed with no HIPGraph/cudagraph replay errors, illegal memory access, stale metadata symptoms, or failed benchmark requests.

Serve command shape:
  VLLM_ROCM_USE_AITER=1 SAFETENSORS_FAST_GPU=1 \
  vllm serve deepseek-ai/DeepSeek-V4-Flash \
    --tensor-parallel-size 4 \
    --attention_backend ROCM_AITER_UNIFIED_ATTN \
    --compilation-config '{"mode":3,"cudagraph_mode":"FULL_DECODE_ONLY"}' \
    --speculative-config '{"method":"mtp","num_speculative_tokens":3,"attention_backend":"ROCM_AITER_UNIFIED_ATTN"}' \
    --kv-cache-dtype fp8 \
    --distributed-executor-backend mp \
    --max_model_len 4096 \
    --max-num-batched-tokens 8192 \
    --max_num_seqs 256 \
    --tokenizer-mode deepseek_v4 \
    --tool-call-parser deepseek_v4 \
    --trust-remote-code

Accuracy command shape:
  lm_eval --model local-completions \
    --tasks gsm8k \
    --num_fewshot 8 \
    --model_args model=deepseek-ai/DeepSeek-V4-Flash,base_url=http://localhost:<PORT>/v1/completions,num_concurrent=16,tokenized_requests=False

Accuracy results, full GSM8K 8-shot, no limit:
  patched flexible/strict: 0.9492 / 0.9500
  control flexible/strict: 0.9416 / 0.9424

Benchmark command shapes:
  vllm bench serve --model deepseek-ai/DeepSeek-V4-Flash \
    --dataset-name random \
    --random-input-len 512 \
    --random-output-len 1024 \
    --temperature 0 \
    --ignore-eos \
    --max-concurrency 16 \
    --num-prompts 160 \
    --num-warmups 16

  vllm bench serve --model deepseek-ai/DeepSeek-V4-Flash \
    --dataset-name random \
    --random-input-len 512 \
    --random-output-len 1024 \
    --temperature 0 \
    --ignore-eos \
    --max-concurrency 128 \
    --num-prompts 1024 \
    --num-warmups 128

Performance results, output throughput:
  c16 patched/control: 2000.58 / 1958.82 tok/s (+2.13%)
  c128 patched/control: 7852.55 / 7751.43 tok/s (+1.30%)