### PR TITLE
[CI] Register CPU CI "VLLM_CPU_CI_ENV" environment variable

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -51,6 +51,7 @@ if TYPE_CHECKING:
     VLLM_CPU_KVCACHE_SPACE: int | None = 0
     VLLM_CPU_OMP_THREADS_BIND: str = "auto"
     VLLM_CPU_NUM_OF_RESERVED_CPU: int | None = None
+    VLLM_CPU_CI_ENV: bool = False
     VLLM_CPU_ATTN_SPLIT_KV: bool = True
     VLLM_ZENTORCH_WEIGHT_PREPACK: bool = True
     VLLM_CPU_INT4_W4A8: bool = True
@@ -881,6 +882,8 @@ environment_variables: dict[str, Callable[[], Any]] = {
         if "VLLM_CPU_NUM_OF_RESERVED_CPU" in os.environ
         else None
     ),
+    # (CPU backend only) whether vLLM is running in a CI environment.
+    "VLLM_CPU_CI_ENV": lambda: bool(int(os.getenv("VLLM_CPU_CI_ENV", "0"))),
     # (CPU backend only) whether to enable attention spilt KV.
     "VLLM_CPU_ATTN_SPLIT_KV": lambda: bool(
         int(os.getenv("VLLM_CPU_ATTN_SPLIT_KV", "1"))

--- a/vllm/platforms/cpu.py
+++ b/vllm/platforms/cpu.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING
 
 import torch
 
+from vllm import envs
 from vllm.logger import init_logger
 from vllm.utils.cpu_resource_utils import (
     DEVICE_CONTROL_ENV_VAR,
@@ -203,10 +204,7 @@ class CpuPlatform(Platform):
             # cache. So use VLLM_CPU_CI_ENV to indicate the CI environment,
             # and just execute model with dynamo + eager mode to save time.
             # VLLM_CPU_CI_ENV is only used as an internal variable.
-            if os.environ.get("VLLM_CPU_CI_ENV", "0") != "0":
-                backend = "eager"
-            else:
-                backend = "inductor"
+            backend = "eager" if envs.VLLM_CPU_CI_ENV else "inductor"
 
             compilation_config.mode = CompilationMode.DYNAMO_TRACE_ONCE
             compilation_config.backend = backend


### PR DESCRIPTION
## Purpose

CPU CI intentionally sets `VLLM_CPU_CI_ENV`, and the CPU platform consumes it, but it is missing from `vllm.envs`. This causes false `Unknown vLLM environment variable detected: VLLM_CPU_CI_ENV` warnings and failures when strict environment validation is enabled. This PR registers it as a boolean in the CPU platform.

## Reproducer

```bash
VLLM_CPU_CI_ENV=1 .venv/bin/python -c \
  'from vllm import envs; envs.validate_environ(True)'
```

## Output on main

```text
ValueError: Unknown vLLM environment variable detected: VLLM_CPU_CI_ENV
```

## Output on this branch

```text
Exit code 0; no warning or exception.
```

## Test Plan and Results

```bash
env VLLM_CPU_CI_ENV=1 .venv/bin/python -c \
  'from vllm import envs; envs.validate_environ(True); assert envs.VLLM_CPU_CI_ENV is True'
.venv/bin/python -m pytest \
  tests/config/test_config_generation.py::test_unrecognized_env -q
```

Results: All validations passed.