### PR TITLE
[ROCm][Bugfix] Ignore redundant qzeros in symmetric RDNAHybridW4A16

### DIFF
--- a/tests/kernels/quantization/test_rdna_hybrid_w4a16.py
+++ b/tests/kernels/quantization/test_rdna_hybrid_w4a16.py
@@ -277,7 +277,7 @@ def _build_dummy_layer(
 
 @pytest.mark.parametrize("group_size", SUPPORTED_GROUP_SIZES)
 def test_rdna_hybrid_w4a16_process_weights_symmetric_repack(group_size, dist_init):
-    """uint4b8 (symmetric): w_q -> [N, K//8] int8 ExLlama shuffle, no zp param."""
+    """uint4b8 (symmetric) repacks to ExLlama int8 [N, K//2] and drops qzeros."""
     if not torch.cuda.is_available():
         pytest.skip("CUDA/HIP device not available")
 
@@ -296,8 +296,16 @@ def test_rdna_hybrid_w4a16_process_weights_symmetric_repack(group_size, dist_ini
     w_int4_kn = torch.randint(0, 16, (K, N), device=device, dtype=torch.int32)
     w_ckpt_nk8 = _pack_int4_along_k_to_ckpt(w_int4_kn)
     scales_ckpt_nkg = 0.05 * torch.rand((N, K // G), device=device, dtype=torch.float16)
+    # GPTQ stores symmetric zero point 8 as packed (8 - 1) nibbles.
+    redundant_qzeros = torch.full(
+        (K // G, N // 8), 0x77777777, device=device, dtype=torch.int32
+    )
 
     layer = _build_dummy_layer(w_ckpt_nk8, scales_ckpt_nkg, zeros_ckpt=None)
+    layer.register_parameter(
+        "weight_zero_point",
+        torch.nn.Parameter(redundant_qzeros, requires_grad=False),
+    )
 
     config = MPLinearLayerConfig(
         full_weight_shape=(K, N),
@@ -312,10 +320,12 @@ def test_rdna_hybrid_w4a16_process_weights_symmetric_repack(group_size, dist_ini
         config,
         w_q_param_name="weight_packed",
         w_s_param_name="weight_scale",
-        w_zp_param_name=None,
+        w_zp_param_name="weight_zero_point",
         w_gidx_param_name=None,
     )
     kernel.process_weights_after_loading(layer)
+
+    assert layer.weight_zero_point is None
 
     # Skinny weight is stored once as int8 [N, K//2]; the Triton path
     # reinterprets it as int32 [N, K//8] via a view (no separate parameter).

--- a/vllm/model_executor/kernels/linear/mixed_precision/rdna_hybrid_w4a16.py
+++ b/vllm/model_executor/kernels/linear/mixed_precision/rdna_hybrid_w4a16.py
@@ -528,6 +528,9 @@ class RDNAHybridW4A16LinearKernel(MPLinearKernel):
             )
             w_zp = zp_unpacked.to(c.act_type).contiguous()
             self._transform_param(layer, self.w_zp_name, lambda x: w_zp)
+        elif self.w_zp_name is not None:
+            # Symmetric GPTQ checkpoints may still contain redundant qzeros.
+            layer.register_parameter(self.w_zp_name, None)
 
         self._transform_param(layer, self.w_q_name, lambda x: w_q_skinny)
         self._transform_param(layer, self.w_s_name, lambda x: w_s_skinny)


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Symmetric GPTQ `uint4b8` uses a fixed zero point of 8, but some checkpoints still contain redundant packed `qzeros`. `RDNAHybridW4A16LinearKernel` previously passed this tensor to the kernel, causing startup failures such as:

```text
AssertionError: zp shape mismatch: torch.Size([40, 4352]) vs (34816, 40)
```

This PR drops redundant `qzeros` after loading symmetric GPTQ weights and adds regression coverage. The existing asymmetric zero-point path is unchanged.

## Duplicate-work check

Open PR searches for `RDNAHybridW4A16LinearKernel qzeros` and `symmetric qzeros ROCm W4A16` found no duplicate. PRs #47770 and #48998 only address `TritonW4A16LinearKernel`; neither changes the RDNA hybrid kernel.

## Test Plan

| Component | Value |
| --- | --- |
| GPU | AMD Radeon 8060S (gfx1151) |
| Memory | 128 GB unified memory (96 GiB VRAM) |
| Operating system | Ubuntu 24.04.4 LTS |
| ROCm | 7.2.3 |

I ran the focused and complete hybrid W4A16 tests, applicable pre-commit hooks, and an end-to-end before/after serving test with the official `Qwen/Qwen3.5-27B-GPTQ-Int4` checkpoint.

<details>
<summary>Test commands</summary>

```bash
VLLM_ROCM_USE_AITER=0 VLLM_ENABLE_V1_MULTIPROCESSING=0 \
.venv/bin/vllm serve ~/models/Qwen3.5-27B-GPTQ-Int4 \
  --language-model-only --attention-backend ROCM_ATTN \
  --max-model-len 2048 --max-num-seqs 1 \
  --gpu-memory-utilization 0.3 --enforce-eager --port 8001
```

</details>

## Test Result

| Revision | Result |
| --- | --- |
| Before this PR | Startup failed during the profiling forward pass with the `qzeros` shape mismatch above |
| With this PR | Engine startup completed and the Chat Completions API generated 32 tokens successfully |

- Focused weight-processing tests: 6 passed, 77 deselected, 14 warnings
- Complete hybrid W4A16 test file: 83 passed, 14 warnings
- Applicable pre-commit hooks: passed
- `git diff --check`: passed

## AI assistance

OpenAI Codex assisted with this change. I reviewed and understand every submitted line and ran the validation reported above.

No documentation update is required because this change does not alter any user-facing API or configuration.

---

<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] Purpose and failure mode documented.
- [x] Duplicate PRs checked.
- [x] Test commands and results included.
- [x] End-to-end model serving validated.
- [x] Documentation impact considered.
- [x] AI assistance disclosed.

</details>

