### PR TITLE
[Bugfix] Encode special tokens found in text for MistralCommonBackend in multimodal processors

### DIFF
--- a/tests/tokenizers_/test_mistral.py
+++ b/tests/tokenizers_/test_mistral.py
@@ -9,13 +9,16 @@ import pytest
 from mistral_common.exceptions import InvalidMessageStructureException
 from mistral_common.guidance.grammar_factory import GrammarFactory
 from mistral_common.tokens.tokenizers.base import SpecialTokenPolicy, SpecialTokens
+from transformers.tokenization_mistral_common import MistralCommonBackend
 
 from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
 from vllm.tokenizers.mistral import (
     MistralTokenizer,
     _validate_apply_chat_template_args,
     validate_request_params,
+    with_placeholder_token_support,
 )
+from vllm.utils.mistral import is_transformers_mistral_common_tokenizer
 
 
 def test_validate_apply_chat_template_args():
@@ -2256,6 +2259,117 @@ def test_convert_ids_to_tokens_pre_args_tekken():
     ids = tokenizer.encode("Hello world !", add_special_tokens=False)
     tokens = tokenizer.convert_ids_to_tokens(ids, skip_special_tokens=True)
     assert len(tokens) > 0
+
+
+# ---------------------------------------------------------------------------
+# with_placeholder_token_support – dual-format checkpoints (HF tokenizer
+# files alongside mistral-common's tekken.json) resolve to transformers'
+# native `MistralCommonBackend` under the default tokenizer mode, which does
+# not encode special tokens (e.g. modality placeholders like "[IMG]") found
+# in plain text. HF multimodal processors rely on that encoding when
+# building dummy/templated inputs at engine startup, so vLLM must swap in a
+# tokenizer variant that performs it. Regression coverage for
+# `InputProcessingContext.get_hf_processor`'s handling of this case.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def pixtral_common_backend() -> MistralCommonBackend:
+    return MistralCommonBackend.from_pretrained(
+        "mistralai/Pixtral-12B-2409", mode="test"
+    )
+
+
+def test_is_transformers_mistral_common_tokenizer(
+    pixtral_common_backend: MistralCommonBackend,
+):
+    assert is_transformers_mistral_common_tokenizer(pixtral_common_backend)
+    assert not is_transformers_mistral_common_tokenizer(object())
+    assert not is_transformers_mistral_common_tokenizer(None)
+
+
+def test_stock_backend_does_not_encode_placeholder_from_text(
+    pixtral_common_backend: MistralCommonBackend,
+):
+    """Sanity-check the bug this fix addresses: mistral-common never folds
+    special tokens found in plain text back into their ids."""
+    image_token_id = pixtral_common_backend.convert_tokens_to_ids("[IMG]")
+    assert pixtral_common_backend.encode("[IMG]", add_special_tokens=False) != [
+        image_token_id
+    ]
+
+
+def test_with_placeholder_token_support_encodes_placeholder(
+    pixtral_common_backend: MistralCommonBackend,
+):
+    image_token_id = pixtral_common_backend.convert_tokens_to_ids("[IMG]")
+
+    patched = with_placeholder_token_support(pixtral_common_backend)
+
+    assert patched is not pixtral_common_backend
+    assert patched.encode("[IMG]", add_special_tokens=False) == [image_token_id]
+
+
+def test_with_placeholder_token_support_is_memoized(
+    pixtral_common_backend: MistralCommonBackend,
+):
+    first = with_placeholder_token_support(pixtral_common_backend)
+    second = with_placeholder_token_support(pixtral_common_backend)
+    assert first is second
+
+
+def test_with_placeholder_token_support_is_idempotent(
+    pixtral_common_backend: MistralCommonBackend,
+):
+    patched = with_placeholder_token_support(pixtral_common_backend)
+    assert with_placeholder_token_support(patched) is patched
+
+
+def test_with_placeholder_token_support_preserves_plain_text_encoding(
+    pixtral_common_backend: MistralCommonBackend,
+):
+    patched = with_placeholder_token_support(pixtral_common_backend)
+    text = "Hello world, nothing special here."
+    assert patched.encode(
+        text, add_special_tokens=False
+    ) == pixtral_common_backend.encode(text, add_special_tokens=False)
+
+
+def test_with_placeholder_token_support_handles_mixed_and_adjacent_placeholders(
+    pixtral_common_backend: MistralCommonBackend,
+):
+    image_token_id = pixtral_common_backend.convert_tokens_to_ids("[IMG]")
+    img_break_id = pixtral_common_backend.convert_tokens_to_ids("[IMG_BREAK]")
+    img_end_id = pixtral_common_backend.convert_tokens_to_ids("[IMG_END]")
+
+    patched = with_placeholder_token_support(pixtral_common_backend)
+
+    # "[IMG]" is a string-prefix of "[IMG_BREAK]"/"[IMG_END]"; the longer
+    # placeholders must not be shadowed by a naive prefix match.
+    adjacent_ids = patched.encode("[IMG][IMG_BREAK][IMG_END]", add_special_tokens=False)
+    assert adjacent_ids == [image_token_id, img_break_id, img_end_id]
+
+    # Placeholders interleaved with ordinary text still tokenize correctly,
+    # and the surrounding text is unaffected.
+    mixed_ids = patched.encode(
+        "Describe this image [IMG] please.", add_special_tokens=False
+    )
+    assert image_token_id in mixed_ids
+    prefix_ids = pixtral_common_backend.encode(
+        "Describe this image ", add_special_tokens=False
+    )
+    assert mixed_ids[: len(prefix_ids)] == prefix_ids
+
+
+def test_with_placeholder_token_support_respects_add_special_tokens(
+    pixtral_common_backend: MistralCommonBackend,
+):
+    image_token_id = pixtral_common_backend.convert_tokens_to_ids("[IMG]")
+    bos_id = pixtral_common_backend.tokenizer.instruct_tokenizer.tokenizer.bos_id
+
+    patched = with_placeholder_token_support(pixtral_common_backend)
+
+    assert patched.encode("[IMG]", add_special_tokens=True) == [bos_id, image_token_id]
 
 
 # ---------------------------------------------------------------------------

--- a/vllm/multimodal/processing/context.py
+++ b/vllm/multimodal/processing/context.py
@@ -23,7 +23,10 @@ from vllm.tokenizers import TokenizerLike
 from vllm.transformers_utils.processor import cached_processor_from_config
 from vllm.utils.func_utils import get_allowed_kwarg_only_overrides
 from vllm.utils.jsontree import JSONTree, json_map_leaves
-from vllm.utils.mistral import is_mistral_tokenizer
+from vllm.utils.mistral import (
+    is_mistral_tokenizer,
+    is_transformers_mistral_common_tokenizer,
+)
 
 if TYPE_CHECKING:
     from transformers.configuration_utils import PretrainedConfig
@@ -197,6 +200,18 @@ class InputProcessingContext:
         tokenizer = self.tokenizer
         if is_mistral_tokenizer(tokenizer):
             tokenizer = tokenizer.transformers_tokenizer  # type: ignore[union-attr]
+        elif is_transformers_mistral_common_tokenizer(tokenizer):
+            # `AutoTokenizer` resolves "dual-format" checkpoints (HF
+            # tokenizer files alongside mistral-common's tekken.json) to
+            # transformers' `MistralCommonBackend`, which never encodes
+            # special placeholder tokens (e.g. "[IMG]") that appear in
+            # plain text. HF multimodal processors rely on that encoding
+            # when building dummy/templated inputs, so swap in a tokenizer
+            # variant that performs it. See
+            # `vllm.tokenizers.mistral.with_placeholder_token_support`.
+            from vllm.tokenizers.mistral import with_placeholder_token_support
+
+            tokenizer = with_placeholder_token_support(tokenizer)
 
         merged_kwargs = self.get_merged_mm_kwargs(kwargs)
         merged_kwargs.pop("tokenizer", None)

--- a/vllm/tokenizers/mistral.py
+++ b/vllm/tokenizers/mistral.py
@@ -5,6 +5,7 @@ from functools import cached_property
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast, overload
 
+import regex as re
 from mistral_common.guidance.grammar_factory import GrammarFactory
 from mistral_common.guidance.tokenizer import from_mistral_tokenizer
 from mistral_common.protocol.instruct.request import (
@@ -204,6 +205,94 @@ def tekken_convert_tokens_to_string(
         ids = [_tekken_token_to_id(tokenizer, t) for t in tokens]
         return tokenizer.decode(ids, SpecialTokenPolicy.KEEP)
     return "".join(cast(Sequence[str], tokens))
+
+
+class _PlaceholderAwareMistralCommonBackend(MistralCommonBackend):
+    """`MistralCommonBackend` that recognizes special tokens (e.g. modality
+    placeholders such as ``"[IMG]"``) embedded in plain text.
+
+    mistral-common intentionally never encodes special tokens found inside
+    ordinary text: calling `encode("[IMG]")` tokenizes the literal characters
+    `[`, `IMG`, `]` rather than resolving to the placeholder's token id. This
+    is fine for user-authored prompts, but HF multimodal processors (e.g.
+    `PixtralProcessor`) build synthetic/templated text that already contains
+    those placeholder strings and expect the tokenizer to fold them back into
+    their special ids, the same way HF's own tokenizers handle "added
+    tokens". Without this, vLLM's dummy-input profiling for Mistral3/Pixtral
+    crashes because the placeholder count in the templated text no longer
+    matches the placeholder count in the tokenized ids.
+
+    Only use this class to tokenize trusted/internal text (e.g. the copy
+    handed to an HF processor), never to encode raw, user-supplied prompts.
+    """
+
+    @cached_property
+    def _placeholder_token_ids(self) -> dict[str, int]:
+        # `all_special_tokens` and `all_special_ids` are index-aligned.
+        return dict(zip(self.all_special_tokens, self.all_special_ids))
+
+    @cached_property
+    def _placeholder_pattern(self) -> "re.Pattern[str]":
+        # Sort longest-first so that a placeholder which is a prefix of
+        # another one (e.g. "[IMG]" vs "[IMG_BREAK]") is not shadowed.
+        placeholders = sorted(self._placeholder_token_ids, key=len, reverse=True)
+        return re.compile("(" + "|".join(re.escape(p) for p in placeholders) + ")")
+
+    def _text_to_ids(self, text: str, add_special_tokens: bool) -> list[int]:
+        raw_tokenizer = self.tokenizer.instruct_tokenizer.tokenizer
+
+        if not self._placeholder_token_ids:
+            token_ids = raw_tokenizer.encode(text, bos=False, eos=False)
+        else:
+            token_ids = []
+            # `re.split` with a capturing group returns the delimiters
+            # (placeholders) interleaved at the odd indices.
+            for i, chunk in enumerate(self._placeholder_pattern.split(text)):
+                if not chunk:
+                    continue
+                if i % 2:
+                    token_ids.append(self._placeholder_token_ids[chunk])
+                else:
+                    token_ids.extend(raw_tokenizer.encode(chunk, bos=False, eos=False))
+
+        if add_special_tokens:
+            token_ids = [raw_tokenizer.bos_id, *token_ids]
+            if self._mode == ValidationMode.finetuning:
+                token_ids.append(raw_tokenizer.eos_id)
+
+        return token_ids
+
+
+def with_placeholder_token_support(
+    tokenizer: "MistralCommonBackend",
+) -> "MistralCommonBackend":
+    """Return a variant of `tokenizer` that folds placeholder-like special
+    tokens (e.g. `"[IMG]"`) appearing in plain text back into their token
+    ids, which the stock `MistralCommonBackend` never does. See
+    `_PlaceholderAwareMistralCommonBackend` for the rationale.
+
+    The variant is memoized on `tokenizer` so repeated calls (e.g. from a
+    cache keyed on the tokenizer identity) return the same object.
+    """
+    if isinstance(tokenizer, _PlaceholderAwareMistralCommonBackend):
+        return tokenizer
+
+    cached_variant = tokenizer.__dict__.get("_placeholder_aware_variant")
+    if cached_variant is not None:
+        return cached_variant
+
+    variant = _PlaceholderAwareMistralCommonBackend(
+        tokenizer_path=tokenizer._tokenizer_path,
+        mode=tokenizer.mode,
+        model_max_length=tokenizer.model_max_length,
+        padding_side=tokenizer.padding_side,
+        truncation_side=tokenizer.truncation_side,
+        model_input_names=tokenizer.model_input_names,
+        clean_up_tokenization_spaces=tokenizer.clean_up_tokenization_spaces,
+    )
+
+    tokenizer.__dict__["_placeholder_aware_variant"] = variant
+    return variant
 
 
 class MistralTokenizer(TokenizerLike):

--- a/vllm/utils/mistral.py
+++ b/vllm/utils/mistral.py
@@ -11,6 +11,8 @@ from vllm.utils.import_utils import LazyLoader
 
 if TYPE_CHECKING:
     # if type checking, eagerly import the module
+    from transformers.tokenization_mistral_common import MistralCommonBackend
+
     import vllm.tokenizers.mistral as mt
 else:
     mt = LazyLoader("mt", globals(), "vllm.tokenizers.mistral")
@@ -26,6 +28,21 @@ def is_mistral_tokenizer(obj: TokenizerLike | None) -> TypeGuard[mt.MistralToken
         getattr(cls, "IS_MISTRAL_TOKENIZER", False)
         and isinstance(obj, mt.MistralTokenizer)
     )
+
+
+def is_transformers_mistral_common_tokenizer(
+    obj: TokenizerLike | None,
+) -> TypeGuard[MistralCommonBackend]:
+    """Return true if `obj` is transformers' native `MistralCommonBackend`.
+
+    `AutoTokenizer` resolves to this class (instead of vLLM's own
+    `MistralTokenizer` wrapper) for "dual-format" checkpoints that ship both
+    HF tokenizer files and mistral-common files (`tekken.json`/
+    `params.json`), which is common for some Mistral3/Pixtral checkpoints.
+    """
+    from transformers.tokenization_mistral_common import MistralCommonBackend
+
+    return isinstance(obj, MistralCommonBackend)
 
 
 def is_mistral_tool_parser(cls: type | None) -> bool:


### PR DESCRIPTION
## Purpose

Fixes #50706

vLLM crashes at engine startup for Mistral3/Pixtral models whose tokenizer resolves to transformers' `MistralCommonBackend`. Per transformers' `AutoTokenizer` resolution, this happens whenever `mistral-common` is installed (`is_mistral_common_available()`) and the model's `model_type` (`mistral`/`ministral`/`mistral3`/etc) is mapped to `MistralCommonBackend` in `TOKENIZER_MAPPING_NAMES` — whether or not the checkpoint ships more than one tokenizer format plays no part (h/t @hmellor for the correction). Affected checkpoints include e.g. `nvidia/Mistral-Medium-3.5-128B-NVFP4`, `mistralai/Mistral-Medium-3.5-128B`. `MistralCommonBackend` never encodes special tokens (e.g. `"[IMG]"`) found in plain text.

During dummy multimodal input profiling (run at engine startup to size the encoder budget), `PixtralProcessor` counts a mismatch between the placeholder in the templated text and the encoded ids and raises:

```
ValueError: Mismatch in `image` token count between text and `input_ids`. Got ids=[0] and text=[1].
ValueError: Failed to apply PixtralProcessor on data={'text': '[IMG]'} with kwargs={'truncation': False, 'return_tensors': 'pt'}
```

`InputProcessingContext.get_hf_processor` now swaps in a `MistralCommonBackend` subclass (`with_placeholder_token_support`) that resolves known special-token strings found in text back to their ids, scoped only to the tokenizer instance handed to HF processors — never used for general/user-prompt tokenization.

Conceptually related to but independently derived from:
- #50752 — fixes the same root cause on the default tokenizer-mode path (currently blocked on the contributor-gate CI check, not real test failures)
- #45525 — fixes the sibling issue (#45289) for `--tokenizer-mode mistral`

## Test Plan

- Unit tests: `pytest tests/tokenizers_/test_mistral.py -q` — 8 new tests against a real `mistralai/Pixtral-12B-2409` tokenizer, covering: bug repro (stock backend doesn't encode `[IMG]`), fix correctness, memoization/idempotency, plain-text passthrough (unaffected by the change), placeholder-prefix disambiguation (`[IMG]` vs `[IMG_BREAK]`/`[IMG_END]`), and `add_special_tokens` behavior.
- Manual end-to-end repro against a real affected checkpoint, exercising the same code path as engine-startup profiling:
  ```python
  from vllm.config import ModelConfig
  from vllm.multimodal import MULTIMODAL_REGISTRY

  model_config = ModelConfig(
      "unsloth/Mistral-Small-3.2-24B-Instruct-2506",
      tokenizer="unsloth/Mistral-Small-3.2-24B-Instruct-2506",
      revision="3ed8d341b53ea3d0e4194689905477688a6cf733",
      tokenizer_revision="3ed8d341b53ea3d0e4194689905477688a6cf733",
      max_model_len=8192,
  )
  processor = MULTIMODAL_REGISTRY.create_processor(model_config)
  mm_inputs = MULTIMODAL_REGISTRY.get_dummy_mm_inputs(
      model_config, mm_counts={"image": 1}, processor=processor,
  )
  ```
- `pre-commit run --files vllm/tokenizers/mistral.py vllm/utils/mistral.py vllm/multimodal/processing/context.py tests/tokenizers_/test_mistral.py`

## Test Result

- `tests/tokenizers_/test_mistral.py`: **69 passed, 2 skipped** (pre-existing, unrelated skips)
- Manual end-to-end repro against `unsloth/Mistral-Small-3.2-24B-Instruct-2506`: dummy multimodal input generation **crashes** with the exact `ValueError: Mismatch in image token count...` shown above **before** this fix (verified via `git stash`), and **succeeds** after.
- `pre-commit run` on all changed files: **clean** (ruff check/format, mypy, forbidden-imports check, SPDX headers, typos, etc.)
