### PR TITLE
[Bugfix][Model] Skip quantizing undeclared Quark MTP layers

### DIFF
--- a/tests/model_executor/test_qwen3_5_quantization.py
+++ b/tests/model_executor/test_qwen3_5_quantization.py
@@ -76,3 +76,42 @@ def test_qwen3_5_mtp_lm_head_receives_quant_config():
         MockLMHead.assert_called_once()
         call_kwargs = MockLMHead.call_args.kwargs
         assert call_kwargs["quant_config"] is mock_quant_config
+
+
+def test_should_bypass_mtp_quant_when_quark_exclude_omits_mtp():
+    from vllm.model_executor.models.qwen3_5_mtp import _should_bypass_mtp_quant
+
+    quant_config = Mock()
+    quant_config.get_name.return_value = "quark"
+    hf_qc = {"exclude": ["self_attn.q_proj"], "layer_quant_config": {}}
+
+    assert _should_bypass_mtp_quant(quant_config, hf_qc) is True
+
+
+def test_should_not_bypass_mtp_quant_when_quark_declares_mtp():
+    from vllm.model_executor.models.qwen3_5_mtp import _should_bypass_mtp_quant
+
+    quant_config = Mock()
+    quant_config.get_name.return_value = "quark"
+    hf_qc = {
+        "exclude": [],
+        "layer_quant_config": {"model.mtp.fc": {"weight": {"dtype": "float16"}}},
+    }
+
+    assert _should_bypass_mtp_quant(quant_config, hf_qc) is False
+
+
+def test_should_bypass_mtp_quant_for_gptq_dynamic_marker():
+    from vllm.model_executor.models.qwen3_5_mtp import _should_bypass_mtp_quant
+
+    quant_config = Mock()
+    quant_config.get_name.return_value = "gptq"
+    hf_qc = {"dynamic": {"-:.*mtp.*": False}}
+
+    assert _should_bypass_mtp_quant(quant_config, hf_qc) is True
+
+
+def test_should_not_bypass_mtp_quant_with_no_quant_config():
+    from vllm.model_executor.models.qwen3_5_mtp import _should_bypass_mtp_quant
+
+    assert _should_bypass_mtp_quant(None, {"exclude": []}) is False

--- a/vllm/model_executor/models/qwen3_5_mtp.py
+++ b/vllm/model_executor/models/qwen3_5_mtp.py
@@ -58,11 +58,18 @@ def _should_bypass_mtp_quant(
     unquantized despite the base model using a quantization config."""
     if not quant_config:
         return False
+    # Workaround: mtp.fc is stored as BF16 in NVFP4 checkpoints but is
+    # missing from hf_quant_config.json exclude_modules. Force unquantized.
+    # Ref: https://github.com/vllm-project/vllm/pull/38650
+    # Ref: https://github.com/NVIDIA/Model-Optimizer/pull/1124
     if quant_config.get_name() == "modelopt_fp4":
         return True
     if not isinstance(hf_qc, dict):
         return False
 
+    # GPTQ: quantized checkpoints may exclude MTP from quantization via
+    # quantization_config.dynamic with "-:pattern" entries. When detected,
+    # disable quantization for MTP layers so they use unquantized params.
     dynamic = hf_qc.get("dynamic", {})
     if any(k.startswith("-:") and "mtp" in k for k in dynamic):
         return True

--- a/vllm/model_executor/models/qwen3_5_mtp.py
+++ b/vllm/model_executor/models/qwen3_5_mtp.py
@@ -50,6 +50,34 @@ from .utils import (
 logger = init_logger(__name__)
 
 
+def _should_bypass_mtp_quant(
+    quant_config: "QuantizationConfig | None",
+    hf_qc: object,
+) -> bool:
+    """Whether MTP decoder weights (mtp.fc, mtp.layers.*) should be built
+    unquantized despite the base model using a quantization config."""
+    if not quant_config:
+        return False
+    if quant_config.get_name() == "modelopt_fp4":
+        return True
+    if not isinstance(hf_qc, dict):
+        return False
+
+    dynamic = hf_qc.get("dynamic", {})
+    if any(k.startswith("-:") and "mtp" in k for k in dynamic):
+        return True
+
+    if quant_config.get_name() == "quark":
+        exclude = hf_qc.get("exclude") or []
+        layer_quant_config = hf_qc.get("layer_quant_config") or {}
+        mtp_declared = any("mtp" in str(e).lower() for e in exclude) or any(
+            "mtp" in str(k).lower() for k in layer_quant_config
+        )
+        return not mtp_declared
+
+    return False
+
+
 @support_torch_compile(
     dynamic_arg_dims={
         "input_ids": 0,
@@ -84,15 +112,10 @@ class Qwen3_5MultiTokenPredictor(nn.Module):
             config.hidden_size,
         )
 
-        # Workaround: mtp.fc is stored as BF16 in NVFP4 checkpoints but is
-        # missing from hf_quant_config.json exclude_modules. Force unquantized.
-        # Ref: https://github.com/vllm-project/vllm/pull/38650
-        # Ref: https://github.com/NVIDIA/Model-Optimizer/pull/1124
-        fc_quant = (
-            None
-            if (quant_config and quant_config.get_name() == "modelopt_fp4")
-            else quant_config
-        )
+        hf_qc = getattr(model_config.hf_config, "quantization_config", None)
+        bypass_mtp_quant = _should_bypass_mtp_quant(quant_config, hf_qc)
+
+        fc_quant = None if bypass_mtp_quant else quant_config
         self.fc = ColumnParallelLinear(
             self.config.hidden_size * 2,
             self.config.hidden_size,
@@ -103,16 +126,9 @@ class Qwen3_5MultiTokenPredictor(nn.Module):
             prefix=f"{prefix}.fc",
         )
 
-        # GPTQ: quantized checkpoints may exclude MTP from quantization via
-        # quantization_config.dynamic with "-:pattern" entries. When detected,
-        # disable quantization for MTP layers so they use unquantized params.
         original_quant = vllm_config.quant_config
-        if quant_config and quant_config.get_name() not in ("modelopt_fp4",):
-            hf_qc = getattr(model_config.hf_config, "quantization_config", None)
-            if isinstance(hf_qc, dict):
-                dynamic = hf_qc.get("dynamic", {})
-                if any(k.startswith("-:") and "mtp" in k for k in dynamic):
-                    vllm_config.quant_config = None
+        if bypass_mtp_quant:
+            vllm_config.quant_config = None
         self.layers = torch.nn.ModuleList(
             Qwen3_5DecoderLayer(
                 vllm_config,


### PR DESCRIPTION
## Purpose
Fixes loading a Quark-quantized checkpoint with speculative decoding (MTP) enabled crashes with `AssertionError: self.data.shape == loaded_weight.shape`

## Test Plan
Implemented trivial tests for checking this config launch

## Test Result
Tests pass on Strix Halo gfx1151

## Repro command:
```
 vllm bench throughput \
    --model amd-satre/Qwen3.6-27B-w_int4_a_bf16-gptq \
    --enforce-eager \
    --gpu-memory-utilization 0.6 \
    --max-model-len 1536 \
    --language-model-only \
    --dataset-name random \
    --random-input-len 256 --random-output-len 256 \
    --num-prompts 4 \
    --speculative-config '{"method": "mtp", "num_speculative_tokens": 1}'
```