### PR TITLE
[Core] Support token-range cache salt regions in block hashing

### DIFF
--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -86,6 +86,8 @@ def make_request(
     mm_hashes: list[str] | None = None,
     cache_salt: str | None = None,
     prompt_embeds: torch.Tensor | None = None,
+    salt_regions: tuple[tuple[int, str], ...] | None = None,
+    salt_regions_required: bool = False,
 ):
     mm_features = []
     if mm_positions is not None:
@@ -110,6 +112,8 @@ def make_request(
         pooling_params=None,
         lora_request=None,
         cache_salt=cache_salt,
+        salt_regions=salt_regions,
+        salt_regions_required=salt_regions_required,
         block_hasher=get_request_block_hasher(block_size, hash_fn),
         prompt_embeds=prompt_embeds,
     )
@@ -546,9 +550,9 @@ def test_generate_block_hash_extra_keys_cache_salt():
 
     # salt is added for the first token
     extra_keys, _ = generate_block_hash_extra_keys(request, 0, 1, 0)
-    assert extra_keys == ("salt",)
+    assert extra_keys == (("cache_salt", "salt"),)
     extra_keys, _ = generate_block_hash_extra_keys(request, 0, 10, 0)
-    assert extra_keys == ("salt",)
+    assert extra_keys == (("cache_salt", "salt"),)
 
     # no salt added for other tokens
     extra_keys, _ = generate_block_hash_extra_keys(request, 1, 2, 0)
@@ -569,8 +573,74 @@ def test_generate_block_hash_extra_keys_cache_salt():
 
     # Test with no extra keys
     extra_keys, next_mm_idx = generate_block_hash_extra_keys(request_mm, 0, 5, 0)
-    assert extra_keys == (("hash1", 0), "salt")
+    assert extra_keys == (("hash1", 0), ("cache_salt", "salt"))
     assert next_mm_idx == 1
+
+
+def test_cache_salt_regions_preserve_boundaries():
+    map_at_zero = make_request("map", list(range(9)), salt_regions=((0, "root"),))
+    flat = make_request("flat", list(range(9)), cache_salt="root")
+    request = make_request(
+        "regions", list(range(9)), salt_regions=((1, "org"), (1, "user"))
+    )
+
+    assert map_at_zero.block_hashes == flat.block_hashes
+    extra_keys, _ = generate_block_hash_extra_keys(request, 0, 3, 0)
+    assert extra_keys == (
+        ("cache_salt", (1, "org")),
+        ("cache_salt", (1, "user")),
+    )
+
+
+@pytest.mark.parametrize(
+    ("regions", "expected"),
+    [
+        (((3, "org-a"), (6, "user-x")), (True, True, True)),
+        (((3, "org-a"), (6, "user-y")), (True, True, False)),
+        (((3, "org-b"), (6, "user-x")), (True, False, False)),
+    ],
+)
+def test_cache_salt_regions_three_tier_matrix(regions, expected):
+    tokens = list(range(9))
+    reference = make_request(
+        "reference", tokens, salt_regions=((3, "org-a"), (6, "user-x"))
+    )
+    candidate = make_request("candidate", tokens, salt_regions=regions)
+    equality = tuple(
+        a == b
+        for a, b in zip(reference.block_hashes, candidate.block_hashes, strict=True)
+    )
+    assert equality == expected
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"salt_regions": ((0, ""),)},
+        {"salt_regions": ((-1, "salt"),)},
+        {"salt_regions": ((6, "salt"),)},
+        {"salt_regions": ((3, "a"), (2, "b"))},
+        {"cache_salt": "flat", "salt_regions": ((0, "region"),)},
+        {"salt_regions_required": True},
+    ],
+)
+def test_cache_salt_regions_reject_invalid(kwargs):
+    with pytest.raises(ValueError):
+        make_request("invalid", list(range(6)), **kwargs)
+
+
+def test_cache_salt_domain_does_not_collide_with_lora_name():
+    salt_request = make_request("salt", list(range(3)), cache_salt="shared")
+    lora_request = make_request("lora", list(range(3)))
+    lora_request.lora_request = LoRARequest(
+        lora_name="shared", lora_int_id=1, lora_path="/path/to/lora"
+    )
+
+    salt_keys, _ = generate_block_hash_extra_keys(salt_request, 0, 3, 0)
+    lora_keys, _ = generate_block_hash_extra_keys(lora_request, 0, 3, 0)
+    assert salt_keys == (("cache_salt", "shared"),)
+    assert lora_keys == ("shared",)
+    assert salt_keys != lora_keys
 
 
 def test_generate_block_hash_extra_keys_prompt_embeds():

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -557,8 +557,17 @@ def generate_block_hash_extra_keys(
         request, start_token_idx, end_token_idx, start_mm_idx
     )
     lora_extra_keys: list[str] = _gen_lora_extra_hash_keys(request)
-    cache_salt_keys: list[str] = (
-        [request.cache_salt] if (start_token_idx == 0 and request.cache_salt) else []
+    cache_salt_keys: list[tuple[str, Any]] = (
+        [("cache_salt", request.cache_salt)]
+        if start_token_idx == 0 and request.cache_salt
+        else [
+            (
+                "cache_salt",
+                salt if offset == start_token_idx else (offset - start_token_idx, salt),
+            )
+            for offset, salt in request.salt_regions or ()
+            if start_token_idx <= offset < end_token_idx
+        ]
     )
     prompt_embeds_keys = _gen_prompt_embeds_extra_hash_keys(
         request, start_token_idx, end_token_idx

--- a/vllm/v1/request.py
+++ b/vllm/v1/request.py
@@ -175,6 +175,10 @@ class Request:
         self.spec_token_ids: list[int] = []
         self.num_computed_tokens = 0
         self.cache_salt: str | None = cache_salt
+        # Like cache_salt, salt_regions are expected to be derived by a
+        # trusted serving layer, not accepted raw from untrusted clients.
+        # The first transition must precede the first principal-specific
+        # token; the checks below cannot verify placement.
         if cache_salt is not None and salt_regions is not None:
             raise ValueError("cache_salt and salt_regions are mutually exclusive")
         if salt_regions_required and not salt_regions:

--- a/vllm/v1/request.py
+++ b/vllm/v1/request.py
@@ -70,6 +70,8 @@ class Request:
         mm_features: list[MultiModalFeatureSpec] | None = None,
         lora_request: "LoRARequest | None" = None,
         cache_salt: str | None = None,
+        salt_regions: tuple[tuple[int, str], ...] | None = None,
+        salt_regions_required: bool = False,
         priority: int = 0,
         trace_headers: Mapping[str, str] | None = None,
         block_hasher: Callable[["Request"], list["BlockHash"]] | None = None,
@@ -173,6 +175,26 @@ class Request:
         self.spec_token_ids: list[int] = []
         self.num_computed_tokens = 0
         self.cache_salt: str | None = cache_salt
+        if cache_salt is not None and salt_regions is not None:
+            raise ValueError("cache_salt and salt_regions are mutually exclusive")
+        if salt_regions_required and not salt_regions:
+            raise ValueError("salt_regions are required but missing")
+        if salt_regions and (
+            any(
+                type(offset) is not int
+                or not 0 <= offset < self.num_prompt_tokens
+                or not isinstance(salt, str)
+                or not salt
+                for offset, salt in salt_regions
+            )
+            or any(
+                a[0] > b[0]
+                for a, b in zip(salt_regions, salt_regions[1:], strict=False)
+            )
+        ):
+            raise ValueError("salt_regions must be sorted and contain valid entries")
+        self.salt_regions = salt_regions
+        self.salt_regions_required = salt_regions_required
 
         # Multi-modal related
         self.mm_features = mm_features or []


### PR DESCRIPTION
## Purpose

Supersedes #37961 (same goal; that PR mixed core, propagation and API
changes into one 19-file diff, so I split it up).

`cache_salt` is all-or-nothing: one salt per request. Tenants sharing a
long system/tool prefix either get isolation (per-tenant salt, shared
prefix recomputed per tenant) or reuse (shared salt, no isolation).
RFC #16016 (option B) proposed per-token-range salts.

This PR adds only the core contract:

- `Request.salt_regions`: `(token_offset, salt)` transitions, mutually
  exclusive with `cache_salt`. Bad input (unsorted, out of range, empty
  salt) is rejected, not clamped.
- Block hashing binds each block to the salt region(s) covering it; a
  mid-block transition enters that block's extra keys with a
  block-relative offset and propagates through the parent hash chain.
- Salt keys are typed as `("cache_salt", ...)` so a salt can't collide
  with a LoRA name — same encoding as #51899, extended with
  `("cache_salt", (relative_offset, salt))` for in-block boundaries. If
  #51899 lands first I'll rebase on it.

Flat `cache_salt` hashes are unchanged; a single region at offset 0
hashes identically to the flat salt. On SWA/Mamba groups the
sparse-retention default from #52216 doesn't pin every region boundary,
so intermediate-region reuse depends on retained checkpoints; hash
isolation is exact either way.

Engine propagation and the chat-API mapping (`cache_salt_map`) are
implemented and tested, split into follow-up PRs. Nothing here touches
the API surface.

## Test Plan

```bash
pytest tests/v1/core/test_kv_cache_utils.py
```

## Test Result

87 passed (75 existing + 12 new: flat regression, region@0 == flat,
org/user/session isolation matrix, mid-block and same-block transitions,
LoRA/salt collision, rejection cases). pre-commit clean.

---

@njhill could you sanity-check one core invariant: a salt transition
affects the boundary block and then propagates through the parent-hash
chain, while the flat `cache_salt` path stays byte-identical? Core-only,
~35 lines plus tests; API and propagation are split out on purpose.
