### PR TITLE
[Perf] Avoid FlashInfer MLA prefill GPU sync

### DIFF
--- a/tests/models/kimi_k3/test_mla_prefill_context.py
+++ b/tests/models/kimi_k3/test_mla_prefill_context.py
@@ -190,6 +190,7 @@ def _build_prefill_metadata(
     return MLACommonPrefillMetadata(
         block_table=block_table,
         query_start_loc=query_start_loc_cpu.to(device),
+        query_start_loc_cpu=query_start_loc_cpu,
         max_query_len=max(_QUERY_LENS),
         chunked_context=chunked_context,
         q_data_type=q_data_type,

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -1472,6 +1472,7 @@ class MLACommonPrefillMetadata:
 
     block_table: torch.Tensor
     query_start_loc: torch.Tensor
+    query_start_loc_cpu: torch.Tensor
     max_query_len: int
     chunked_context: ChunkedContextMetadata | None = None
     q_data_type: torch.dtype | None = None
@@ -2335,6 +2336,7 @@ class MLACommonMetadataBuilder(AttentionMetadataBuilder[M]):
             prefill_metadata = MLACommonPrefillMetadata(
                 block_table=block_table_tensor[reqs_start:, ...],
                 query_start_loc=prefill_query_start_loc,
+                query_start_loc_cpu=prefill_query_start_loc_cpu,
                 max_query_len=max_query_len,
                 chunked_context=chunked_context_metadata,
                 output_dtype=self.model_config.dtype,

--- a/vllm/model_executor/layers/attention/sparse_mla_attention.py
+++ b/vllm/model_executor/layers/attention/sparse_mla_attention.py
@@ -273,6 +273,10 @@ class SparseMLACommonMetadataBuilder(AttentionMetadataBuilder[T]):
         prefill_max_seq_len = 0
         prefill: MLACommonPrefillMetadata | None = None
         if num_prefills > 0 and self._prefill_backend is not None:
+            query_start_loc_cpu = common_attn_metadata.query_start_loc_cpu
+            prefill_query_start_loc_cpu = (
+                query_start_loc_cpu[num_decodes:] - query_start_loc_cpu[num_decodes]
+            )
             seq_lens_cpu = common_attn_metadata.seq_lens_cpu_upper_bound
             assert seq_lens_cpu is not None
             prefill_max_seq_len = int(
@@ -281,6 +285,7 @@ class SparseMLACommonMetadataBuilder(AttentionMetadataBuilder[T]):
             prefill = MLACommonPrefillMetadata(
                 block_table=common_attn_metadata.block_table_tensor[num_decodes:, ...],
                 query_start_loc=prefill_query_start_loc,
+                query_start_loc_cpu=prefill_query_start_loc_cpu,
                 max_query_len=prefill_max_query_len,
                 query_lens_cpu=prefill_query_lens_cpu,
                 chunked_context=self._build_chunked_context_fields(

--- a/vllm/v1/attention/backends/mla/prefill/flashinfer.py
+++ b/vllm/v1/attention/backends/mla/prefill/flashinfer.py
@@ -139,7 +139,7 @@ class FlashInferPrefillBackend(MLAPrefillBackend):
         prefill_metadata: "MLACommonPrefillMetadata",
     ) -> None:
         global_hyperparameters = self._resolve_global_hyperparameters()
-        qo_indptr = prefill_metadata.query_start_loc
+        qo_indptr = prefill_metadata.query_start_loc_cpu
         has_context = prefill_metadata.chunked_context is not None
         if self._prefill_main is None:
             self._prefill_main = BatchPrefillWithRaggedKVCacheWrapper(


### PR DESCRIPTION
## Purpose

Avoid a GPU-to-CPU synchronization in FlashInfer MLA prefill planning. FlashInfer's ragged prefill planner needs `qo_indptr` on the host and otherwise calls `.to("cpu")` on the CUDA `query_start_loc` tensor.

Thread the existing host-side prefill query offsets through `MLACommonPrefillMetadata` and pass them as `qo_indptr`. This keeps the values and planner behavior unchanged while avoiding the device-to-host copy and its synchronization.

This does not duplicate an existing PR. Searches for `FlashInfer MLA qo_indptr sync` and `GPU CPU sync FlashInfer prefill` found no matching fix. #51540 addresses a different synchronization in KDA/FLA chunk-index construction.

AI assistance was used to trace the synchronization, implement the change, and prepare tests. The human submitter reviewed every changed line and can explain and defend the change.

## Test Plan

```bash
.venv/bin/python -m pytest \
  tests/v1/attention/test_mla_context_chunks.py -q

.venv/bin/python -m pytest \
  tests/models/kimi_k3/test_mla_prefill_context.py -q

.venv/bin/pre-commit run --files \
  tests/models/kimi_k3/test_mla_prefill_context.py \
  vllm/model_executor/layers/attention/mla_attention.py \
  vllm/model_executor/layers/attention/sparse_mla_attention.py \
  vllm/v1/attention/backends/mla/prefill/flashinfer.py
```

## Test Result

- Nearby MLA chunk tests: **11 passed**.
- Kimi-K3 CUDA-only MLA tests: **9 skipped** because no CUDA device is available locally.
- All pre-commit hooks on changed files: **passed**.
- Model evaluations were not run because this changes only the device placement of planner metadata, not model execution or output values.
