### PR TITLE
[Rust Frontend] Add Hunyuan A13B reasoning parser

### DIFF
--- a/rust/src/chat/src/lib.rs
+++ b/rust/src/chat/src/lib.rs
@@ -415,6 +415,6 @@ mod tests {
         )
         .unwrap_err();
 
-        expect_test::expect!["reasoning parser `definitely_missing_reasoning_parser` is not registered (choose from: cohere_cmd, deepseek_r1, deepseek_v3, deepseek_v4, gemma4, glm45, hy_v3, inkling, kimi, kimi_k2, kimi_k3, minimax_m2, minimax_m3, nemotron_v3, qwen3, seed_oss, step3, step3p5)"].assert_eq(&error.to_report_string());
+        expect_test::expect!["reasoning parser `definitely_missing_reasoning_parser` is not registered (choose from: cohere_cmd, deepseek_r1, deepseek_v3, deepseek_v4, gemma4, glm45, hunyuan_a13b, hy_v3, inkling, kimi, kimi_k2, kimi_k3, minimax_m2, minimax_m3, nemotron_v3, qwen3, seed_oss, step3, step3p5)"].assert_eq(&error.to_report_string());
     }
 }

--- a/rust/src/chat/src/parser/reasoning/mod.rs
+++ b/rust/src/chat/src/parser/reasoning/mod.rs
@@ -7,10 +7,10 @@ use std::sync::{Arc, LazyLock};
 
 pub use vllm_parser::reasoning::{
     CohereCmdReasoningParser, DeepSeekR1ReasoningParser, DeepSeekV3ReasoningParser,
-    DeepSeekV4ReasoningParser, Glm45ReasoningParser, KimiK2ReasoningParser, KimiReasoningParser,
-    MiniMaxM2ReasoningParser, MiniMaxM3ReasoningParser, NemotronV3ReasoningParser,
-    Qwen3ReasoningParser, ReasoningDelta, ReasoningError, ReasoningParser, SeedOssReasoningParser,
-    Step3ReasoningParser, Step3p5ReasoningParser,
+    DeepSeekV4ReasoningParser, Glm45ReasoningParser, HunyuanA13BReasoningParser,
+    KimiK2ReasoningParser, KimiReasoningParser, MiniMaxM2ReasoningParser, MiniMaxM3ReasoningParser,
+    NemotronV3ReasoningParser, Qwen3ReasoningParser, ReasoningDelta, ReasoningError,
+    ReasoningParser, SeedOssReasoningParser, Step3ReasoningParser, Step3p5ReasoningParser,
 };
 use vllm_tokenizer::DynTokenizer;
 
@@ -25,6 +25,7 @@ pub mod names {
     pub const GEMMA4: &str = "gemma4";
     pub const INKLING: &str = "inkling";
     pub const GLM45: &str = "glm45";
+    pub const HUNYUAN_A13B: &str = "hunyuan_a13b";
     pub const HY_V3: &str = "hy_v3";
     pub const KIMI: &str = "kimi";
     pub const KIMI_K2: &str = "kimi_k2";
@@ -68,6 +69,7 @@ impl ReasoningParserFactory {
             .register_unified_dummy(names::GEMMA4)
             .register_unified_dummy(names::INKLING)
             .register_parser::<Glm45ReasoningParser>(names::GLM45)
+            .register_parser::<HunyuanA13BReasoningParser>(names::HUNYUAN_A13B)
             .register_unified_dummy(names::HY_V3)
             .register_parser::<KimiReasoningParser>(names::KIMI)
             .register_parser::<KimiK2ReasoningParser>(names::KIMI_K2)
@@ -93,6 +95,8 @@ impl ReasoningParserFactory {
             .register_pattern("glm-4.7", names::GLM45)
             .register_pattern("glm-4.6", names::GLM45)
             .register_pattern("glm-4.5", names::GLM45)
+            .register_pattern("hunyuan-a13b", names::HUNYUAN_A13B)
+            .register_pattern("hunyuan_a13b", names::HUNYUAN_A13B)
             .register_pattern("hy3", names::HY_V3)
             .register_pattern("kimi-k2", names::KIMI_K2)
             .register_pattern("kimi", names::KIMI)

--- a/rust/src/chat/src/parser/reasoning/tests.rs
+++ b/rust/src/chat/src/parser/reasoning/tests.rs
@@ -14,12 +14,14 @@ fn factory_contains_and_lists_registered_parsers() {
     assert!(factory.contains(names::DEEPSEEK_V4));
     assert!(factory.contains(names::SEED_OSS));
     assert!(factory.contains(names::STEP3P5));
+    assert!(factory.contains(names::HUNYUAN_A13B));
     assert!(factory.contains(names::MINIMAX_M3));
     assert!(factory.contains(names::GEMMA4));
     assert!(factory.list().contains(&names::QWEN3.to_string()));
     assert!(factory.list().contains(&names::DEEPSEEK_V4.to_string()));
     assert!(factory.list().contains(&names::SEED_OSS.to_string()));
     assert!(factory.list().contains(&names::STEP3P5.to_string()));
+    assert!(factory.list().contains(&names::HUNYUAN_A13B.to_string()));
     assert!(factory.list().contains(&names::MINIMAX_M3.to_string()));
     assert!(factory.list().contains(&names::GEMMA4.to_string()));
 }
@@ -99,6 +101,53 @@ fn factory_resolves_minimax_m3_before_generic_minimax() {
     assert_eq!(
         factory.resolve_name_for_model("mm-m3"),
         Some(names::MINIMAX_M3)
+    );
+}
+
+#[test]
+fn factory_routes_hunyuan_a13b_models() {
+    let factory = ReasoningParserFactory::new();
+    // The pattern is deliberately narrow. `resolve_name_for_model` is a
+    // case-insensitive substring scan, so a bare `hunyuan` would also claim
+    // HunyuanOCR and the dense Hunyuan-7B, neither of which has a thinking mode.
+    assert_eq!(
+        factory.resolve_name_for_model("tencent/Hunyuan-A13B-Instruct"),
+        Some(names::HUNYUAN_A13B)
+    );
+    assert_eq!(
+        factory.resolve_name_for_model("hunyuan_a13b"),
+        Some(names::HUNYUAN_A13B)
+    );
+    assert_eq!(factory.resolve_name_for_model("tencent/HunyuanOCR"), None);
+    assert_eq!(
+        factory.resolve_name_for_model("tencent/Hunyuan-7B-Instruct"),
+        None
+    );
+}
+
+#[test]
+fn factory_creates_hunyuan_a13b_without_reasoning_tokens() {
+    // Hunyuan's delimiters are not vocabulary tokens, so an empty vocabulary is
+    // enough to construct this parser: it never resolves a delimiter ID.
+    let tokenizer = Arc::new(TestTokenizer::new());
+    let factory = ReasoningParserFactory::new();
+
+    let mut parser = factory
+        .create(names::HUNYUAN_A13B, tokenizer)
+        .expect("hunyuan parser needs no reasoning delimiter tokens");
+
+    expect_test::expect![[r#"
+        ReasoningDelta {
+            reasoning: Some(
+                "reason",
+            ),
+            content: Some(
+                "answer",
+            ),
+        }
+    "#]]
+    .assert_debug_eq(
+        &parser.push("<think>\nreason\n</think>\n<answer>\nanswer\n</answer>").unwrap(),
     );
 }
 

--- a/rust/src/parser/src/reasoning/delimited.rs
+++ b/rust/src/parser/src/reasoning/delimited.rs
@@ -22,9 +22,18 @@ pub(crate) struct DelimitedReasoningParser {
     buffer: String,
     start_token: String,
     end_token: String,
-    start_token_id: u32,
-    end_token_id: u32,
+    /// Vocabulary ID of `start_token`, when the tokenizer has one. Families
+    /// whose delimiters are not single vocabulary tokens leave this `None` and
+    /// match on text alone.
+    start_token_id: Option<u32>,
+    /// Vocabulary ID of `end_token`, when the tokenizer has one.
+    end_token_id: Option<u32>,
     default_in_reasoning: bool,
+    /// Whether each section opens with a framing `\n` that is not part of its
+    /// text. See [`Self::strip_framing_newlines`].
+    strip_framing_newline: bool,
+    /// A delimiter was just consumed, so the next `\n` emitted is framing.
+    pending_framing_newline: bool,
 }
 
 impl DelimitedReasoningParser {
@@ -52,7 +61,48 @@ impl DelimitedReasoningParser {
                 token: end_token.clone(),
             })?;
 
-        Ok(Self {
+        Ok(Self::with_token_ids(
+            tokenizer,
+            start_token,
+            end_token,
+            Some(start_token_id),
+            Some(end_token_id),
+            default_in_reasoning,
+        ))
+    }
+
+    /// Create one delimited parser state machine that matches on text alone.
+    ///
+    /// Some families delimit reasoning with strings that are not vocabulary
+    /// tokens, so [`Self::new`] cannot resolve their IDs at all. Such a parser
+    /// has no prompt token boundary to inspect and therefore always starts from
+    /// `default_in_reasoning`.
+    pub(crate) fn new_text_only(
+        tokenizer: DynTokenizer,
+        start_token: impl Into<String>,
+        end_token: impl Into<String>,
+        default_in_reasoning: bool,
+    ) -> Self {
+        Self::with_token_ids(
+            tokenizer,
+            start_token.into(),
+            end_token.into(),
+            None,
+            None,
+            default_in_reasoning,
+        )
+    }
+
+    /// Build the state machine from already-resolved delimiter IDs.
+    fn with_token_ids(
+        tokenizer: DynTokenizer,
+        start_token: String,
+        end_token: String,
+        start_token_id: Option<u32>,
+        end_token_id: Option<u32>,
+        default_in_reasoning: bool,
+    ) -> Self {
+        Self {
             tokenizer,
             current_in_reasoning: default_in_reasoning,
             buffer: String::new(),
@@ -61,15 +111,40 @@ impl DelimitedReasoningParser {
             start_token_id,
             end_token_id,
             default_in_reasoning,
-        })
+            strip_framing_newline: false,
+            pending_framing_newline: false,
+        }
+    }
+
+    /// Drop the single `\n` that frames the start of every section.
+    ///
+    /// Some families put a newline immediately after each delimiter as protocol
+    /// framing rather than as text. Stripping it here rather than in the wrapper
+    /// keeps it correct when several sections are parsed out of one push: the
+    /// emitted [`ReasoningDelta`] concatenates them, so by the time a wrapper
+    /// sees it the per-section boundaries are gone.
+    pub(crate) fn strip_framing_newlines(mut self) -> Self {
+        self.strip_framing_newline = true;
+        self
     }
 
     /// Initialize the starting state from prompt token IDs.
+    ///
+    /// Text-only parsers have no delimiter IDs to look for, so they keep
+    /// `default_in_reasoning`.
     pub(crate) fn initialize(&mut self, prompt_token_ids: &[u32]) {
+        self.pending_framing_newline = false;
+
+        let Some((start_token_id, end_token_id)) = self.start_token_id.zip(self.end_token_id)
+        else {
+            self.current_in_reasoning = self.default_in_reasoning;
+            return;
+        };
+
         self.current_in_reasoning = last_reasoning_boundary(
             prompt_token_ids,
-            self.start_token_id,
-            self.end_token_id,
+            start_token_id,
+            end_token_id,
             self.tokenizer.as_ref(),
         )
         .unwrap_or(self.default_in_reasoning);
@@ -105,24 +180,41 @@ impl DelimitedReasoningParser {
         while !stable.is_empty() {
             if self.current_in_reasoning {
                 if let Some(end_idx) = stable.find(&self.end_token) {
-                    delta.push_reasoning(&stable[..end_idx]);
+                    let text = self.take_framing_newline(&stable[..end_idx]);
+                    delta.push_reasoning(text);
                     stable = &stable[end_idx + self.end_token.len()..];
                     self.current_in_reasoning = false;
+                    self.pending_framing_newline = self.strip_framing_newline;
                 } else {
-                    delta.push_reasoning(stable);
+                    delta.push_reasoning(self.take_framing_newline(stable));
                     break;
                 }
             } else if let Some(start_idx) = stable.find(&self.start_token) {
-                delta.push_content(&stable[..start_idx]);
+                let text = self.take_framing_newline(&stable[..start_idx]);
+                delta.push_content(text);
                 stable = &stable[start_idx + self.start_token.len()..];
                 self.current_in_reasoning = true;
+                self.pending_framing_newline = self.strip_framing_newline;
             } else {
-                delta.push_content(stable);
+                delta.push_content(self.take_framing_newline(stable));
                 break;
             }
         }
 
         delta
+    }
+
+    /// Drop a pending framing `\n` from the start of one emitted run.
+    ///
+    /// An empty run leaves the flag set: the delimiter landed at the end of a
+    /// push and its framing newline has not arrived yet.
+    fn take_framing_newline<'a>(&mut self, text: &'a str) -> &'a str {
+        if !self.pending_framing_newline || text.is_empty() {
+            return text;
+        }
+
+        self.pending_framing_newline = false;
+        text.strip_prefix('\n').unwrap_or(text)
     }
 
     /// Return the longest trailing suffix that could still complete a

--- a/rust/src/parser/src/reasoning/hunyuan_a13b.rs
+++ b/rust/src/parser/src/reasoning/hunyuan_a13b.rs
@@ -1,0 +1,548 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+use vllm_tokenizer::DynTokenizer;
+
+use super::{DelimitedReasoningParser, ReasoningDelta, ReasoningParser, Result};
+
+/// Opening delimiter of the reasoning section.
+const THINK_START: &str = "<think>";
+/// Reasoning ends where the answer section begins.
+///
+/// The leading newline belongs to the delimiter: Python matches
+/// `(.*?)\n</think>\n<answer>\n`, so the newline before `</think>` is framing
+/// rather than reasoning. The trailing newline is deliberately left out, see
+/// [`HunyuanA13BReasoningParser`].
+const ANSWER_START: &str = "\n</think>\n<answer>";
+/// Opening marker of the answer section, seen alone only when the prompt
+/// prefilled and closed the reasoning section.
+const ANSWER_OPEN: &str = "<answer>";
+/// Marker closing the answer section. Protocol framing, not content.
+const ANSWER_END: &str = "\n</answer>";
+
+/// Reasoning parser for Hunyuan A13B outputs.
+///
+/// Hunyuan A13B frames its output as `<think>\n` reasoning
+/// `\n</think>\n<answer>\n` content `\n</answer>`, making it the only family
+/// here that wraps its content in a section of its own. The shared delimited
+/// state machine does the reasoning split and drops the framing newline that
+/// opens each section; this wrapper suppresses the trailing `\n</answer>` and
+/// the bare `<answer>` of a prefilled prompt.
+///
+/// None of these delimiters is a vocabulary token: `<think>\n` tokenizes as
+/// `<th` + `ink` + `>Ċ`, which is why the Python parser hardcodes literal ID
+/// sequences such as `[14023, 771, 397]`. Matching text keeps the parser working
+/// across tokenizer revisions, at the cost of having no prompt token boundary to
+/// initialize from. That costs nothing here: with thinking enabled the chat
+/// template prefills no reasoning at all and the model emits `<think>\n` itself.
+///
+/// The delimiters end just before their framing newline on purpose. The shared
+/// machine holds back any buffered suffix that could still complete *either*
+/// delimiter, regardless of which one it is currently looking for, so a pair
+/// where one delimiter ends with the other's opening character cannot be
+/// matched: after `<think>\n` the trailing newline would be held back as a
+/// possible start of `\n</think>`, leaving `<think>` to be emitted as content.
+/// Ending both delimiters on `>` avoids the overlap, and costs only the single
+/// leading newline, which the shared machine strips per section via
+/// [`DelimitedReasoningParser::strip_framing_newlines`].
+// TODO: the Python parser also exposes `is_reasoning_end` and
+// `extract_content_ids` over token IDs. The Rust `ReasoningParser` trait has no
+// equivalent hook yet, so neither is ported here.
+pub struct HunyuanA13BReasoningParser {
+    inner: DelimitedReasoningParser,
+    /// A bare [`ANSWER_OPEN`] was stripped, so the next `\n` is framing. Only
+    /// the prefilled-prompt path needs this; every delimiter-driven section is
+    /// handled inside the shared machine.
+    pending_answer_open_newline: bool,
+    /// Content buffered until the stream has settled whether it opens with a
+    /// bare [`ANSWER_OPEN`]. `None` once that question is answered.
+    answer_open_probe: Option<String>,
+    /// Content suffix that could still grow into [`ANSWER_END`].
+    held_content: String,
+}
+
+impl HunyuanA13BReasoningParser {
+    /// Create a Hunyuan A13B parser backed by the shared delimited state
+    /// machine.
+    ///
+    /// Unlike its siblings this cannot fail: the delimiters are matched as text
+    /// and never resolved against the vocabulary.
+    pub fn new(tokenizer: DynTokenizer) -> Self {
+        Self {
+            inner: DelimitedReasoningParser::new_text_only(
+                tokenizer,
+                THINK_START,
+                ANSWER_START,
+                false,
+            )
+            .strip_framing_newlines(),
+            pending_answer_open_newline: false,
+            answer_open_probe: Some(String::new()),
+            held_content: String::new(),
+        }
+    }
+
+    /// Drop a prefilled `<answer>` marker and suppress the answer terminator.
+    fn process(&mut self, mut delta: ReasoningDelta) -> ReasoningDelta {
+        if let Some(content) = delta.content.take()
+            && let Some(mut content) = self.strip_leading_answer_open(content)
+        {
+            if self.pending_answer_open_newline {
+                self.pending_answer_open_newline = false;
+                if content.starts_with('\n') {
+                    content.remove(0);
+                }
+            }
+            delta.content = self.suppress_answer_end(&content);
+        }
+
+        delta
+    }
+
+    /// Drop a bare [`ANSWER_OPEN`] opening the stream.
+    ///
+    /// With `enable_thinking is false` the chat template prefills
+    /// `<think>\n\n</think>\n` and stops there, so the model body opens with an
+    /// `<answer>` that never reaches the shared machine as part of a delimiter.
+    /// It is protocol framing either way. The marker can be split across pushes,
+    /// so it needs its own hold-back: the shared machine releases `<a` as soon as
+    /// it stops being a possible `<think>`.
+    fn strip_leading_answer_open(&mut self, content: String) -> Option<String> {
+        let Some(probe) = self.answer_open_probe.as_mut() else {
+            return Some(content);
+        };
+        probe.push_str(&content);
+
+        if let Some(rest) = probe.strip_prefix(ANSWER_OPEN) {
+            let rest = rest.to_string();
+            self.answer_open_probe = None;
+            // Whatever follows the marker opens the answer section, so its
+            // first newline is framing just like the delimited path's.
+            self.pending_answer_open_newline = true;
+            return (!rest.is_empty()).then_some(rest);
+        }
+
+        if ANSWER_OPEN.starts_with(probe.as_str()) {
+            return None;
+        }
+
+        let settled = std::mem::take(probe);
+        self.answer_open_probe = None;
+        Some(settled)
+    }
+
+    /// Strip [`ANSWER_END`] from content, holding back any trailing suffix that
+    /// could still grow into it.
+    fn suppress_answer_end(&mut self, content: &str) -> Option<String> {
+        self.held_content.push_str(content);
+
+        let mut emitted = String::new();
+        // Only the marker itself is dropped; a stream that opens another
+        // `<think>` section afterwards keeps being parsed.
+        while let Some(idx) = self.held_content.find(ANSWER_END) {
+            emitted.push_str(&self.held_content[..idx]);
+            self.held_content.drain(..idx + ANSWER_END.len());
+        }
+
+        let stable_len = self.held_content.len() - partial_answer_end_len(&self.held_content);
+        emitted.push_str(&self.held_content[..stable_len]);
+        self.held_content.drain(..stable_len);
+
+        (!emitted.is_empty()).then_some(emitted)
+    }
+}
+
+impl ReasoningParser for HunyuanA13BReasoningParser {
+    fn create(tokenizer: DynTokenizer) -> Result<Box<dyn ReasoningParser>>
+    where
+        Self: Sized + 'static,
+    {
+        Ok(Box::new(Self::new(tokenizer)))
+    }
+
+    fn initialize(&mut self, prompt_token_ids: &[u32]) -> Result<()> {
+        self.inner.initialize(prompt_token_ids);
+        self.pending_answer_open_newline = false;
+        self.answer_open_probe = Some(String::new());
+        self.held_content.clear();
+        Ok(())
+    }
+
+    fn push(&mut self, delta: &str) -> Result<ReasoningDelta> {
+        let inner_delta = self.inner.push(delta);
+        Ok(self.process(inner_delta))
+    }
+
+    fn finish(&mut self) -> Result<ReasoningDelta> {
+        let inner_delta = self.inner.finish();
+        let mut delta = self.process(inner_delta);
+
+        // Nothing more can arrive, so an unresolved `<answer>` probe was
+        // ordinary content. It is necessarily the only content in this delta:
+        // while the probe holds, `process` emits none.
+        if let Some(probe) = self.answer_open_probe.take() {
+            delta.push_content(&probe);
+        }
+
+        // An unfinished `\n</answer>` was never framing, so emit it as content
+        // rather than swallowing it at end of stream.
+        let held = std::mem::take(&mut self.held_content);
+        delta.push_content(&held);
+
+        Ok(delta)
+    }
+}
+
+/// Return the longest trailing suffix that could still complete [`ANSWER_END`].
+fn partial_answer_end_len(text: &str) -> usize {
+    text.char_indices()
+        .map(|(idx, _)| idx)
+        .find(|idx| {
+            let suffix = &text[*idx..];
+            ANSWER_END.starts_with(suffix) && ANSWER_END != suffix
+        })
+        .map_or(0, |idx| text.len() - idx)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use expect_test::expect;
+    use vllm_tokenizer::test_utils::TestTokenizer;
+
+    use super::HunyuanA13BReasoningParser;
+    use crate::reasoning::{ReasoningDelta, ReasoningParser};
+
+    /// The behavioural spec, taken from
+    /// `tests/reasoning/test_hunyuan_reasoning_parser.py`.
+    const PYTHON_CASES: &[(&str, &str)] = &[
+        (
+            "simple",
+            "<think>\nThis is a reasoning section\n</think>\n<answer>\nThis is the rest\n</answer>",
+        ),
+        (
+            "complete reasoning, no answer body",
+            "<think>\nThis is a reasoning section\n</think>\n<answer>\n",
+        ),
+        (
+            "quick thought, empty reasoning",
+            "<think>\n\n</think>\n<answer>\nThis is the rest\n</answer>",
+        ),
+        ("no markers at all", "This is content"),
+        (
+            "multiple lines, unterminated answer",
+            "<think>\nThis\nThat\n</think>\n<answer>\nThis is the rest\nThat",
+        ),
+    ];
+
+    /// Cases the Python suite never exercises, where this parser deliberately
+    /// does something better than the Python one.
+    const ADAPTED_CASES: &[(&str, &str)] = &[
+        (
+            "prefilled prompt, body opens at <answer>",
+            "<answer>\nThis is the rest\n</answer>",
+        ),
+        (
+            "content that only looks like the opener",
+            "<abc>This is the rest",
+        ),
+        (
+            "text following a complete answer terminator",
+            "<think>\nreason\n</think>\n<answer>\nanswer\n</answer>trailing",
+        ),
+        (
+            // Python's state machine cycles response -> idle -> think, so a
+            // second round trip is a supported shape. Every section's framing
+            // newline has to go, not just the first one's.
+            "two complete round trips",
+            "<think>\na\n</think>\n<answer>\nb\n</answer><think>\nc\n</think>\n<answer>\nd\n</answer>",
+        ),
+    ];
+
+    /// Build a parser over an empty vocabulary: the delimiters are matched as
+    /// text, so no tokenizer entries are needed.
+    fn parser() -> HunyuanA13BReasoningParser {
+        HunyuanA13BReasoningParser::new(Arc::new(TestTokenizer::new()))
+    }
+
+    /// Push every chunk, flush, and drop the deltas that carry no text.
+    fn collect<S: AsRef<str>>(chunks: &[S]) -> Vec<ReasoningDelta> {
+        collect_with(parser(), chunks)
+    }
+
+    /// Push every chunk into an already-initialized parser, then flush.
+    fn collect_with<S: AsRef<str>>(
+        mut parser: HunyuanA13BReasoningParser,
+        chunks: &[S],
+    ) -> Vec<ReasoningDelta> {
+        let mut deltas: Vec<_> =
+            chunks.iter().map(|chunk| parser.push(chunk.as_ref()).unwrap()).collect();
+        deltas.push(parser.finish().unwrap());
+        deltas.retain(|delta| !delta.is_empty());
+        deltas
+    }
+
+    /// Concatenate the reasoning and content of every delta in a stream.
+    fn joined<S: AsRef<str>>(chunks: &[S]) -> (Option<String>, Option<String>) {
+        let mut reasoning: Option<String> = None;
+        let mut content: Option<String> = None;
+        for delta in collect(chunks) {
+            for (part, sink) in [
+                (delta.reasoning, &mut reasoning),
+                (delta.content, &mut content),
+            ] {
+                if let Some(text) = part {
+                    sink.get_or_insert_default().push_str(&text);
+                }
+            }
+        }
+        (reasoning, content)
+    }
+
+    /// Split `output` into chunks of at most `size` characters.
+    fn split(output: &str, size: usize) -> Vec<String> {
+        output
+            .chars()
+            .collect::<Vec<_>>()
+            .chunks(size)
+            .map(|chunk| chunk.iter().collect())
+            .collect()
+    }
+
+    #[test]
+    fn splits_every_python_case() {
+        let parsed: Vec<_> =
+            PYTHON_CASES.iter().map(|(name, output)| (name, joined(&[output]))).collect();
+
+        expect![[r#"
+            [
+                (
+                    "simple",
+                    (
+                        Some(
+                            "This is a reasoning section",
+                        ),
+                        Some(
+                            "This is the rest",
+                        ),
+                    ),
+                ),
+                (
+                    "complete reasoning, no answer body",
+                    (
+                        Some(
+                            "This is a reasoning section",
+                        ),
+                        None,
+                    ),
+                ),
+                (
+                    "quick thought, empty reasoning",
+                    (
+                        None,
+                        Some(
+                            "This is the rest",
+                        ),
+                    ),
+                ),
+                (
+                    "no markers at all",
+                    (
+                        None,
+                        Some(
+                            "This is content",
+                        ),
+                    ),
+                ),
+                (
+                    "multiple lines, unterminated answer",
+                    (
+                        Some(
+                            "This\nThat",
+                        ),
+                        Some(
+                            "This is the rest\nThat",
+                        ),
+                    ),
+                ),
+            ]
+        "#]]
+        .assert_debug_eq(&parsed);
+    }
+
+    #[test]
+    fn streaming_matches_single_push_for_every_python_case() {
+        // Chunk boundaries land inside the delimiters at these sizes, which is
+        // what the inner state machine's partial-suffix hold-back is for.
+        for (name, output) in PYTHON_CASES {
+            let whole = joined(&[output]);
+            for size in [1, 2, 3, 5, 7, 11] {
+                assert_eq!(
+                    joined(&split(output, size)),
+                    whole,
+                    "{name}, chunk size {size}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn holds_answer_start_split_across_pushes() {
+        expect![[r#"
+            [
+                ReasoningDelta {
+                    reasoning: Some(
+                        "reason",
+                    ),
+                    content: None,
+                },
+                ReasoningDelta {
+                    reasoning: None,
+                    content: Some(
+                        "answer",
+                    ),
+                },
+            ]
+        "#]]
+        .assert_debug_eq(&collect(&[
+            "<think>\nreason\n</think>\n<ans",
+            "wer>\nanswer\n</answer>",
+        ]));
+    }
+
+    #[test]
+    fn emits_incomplete_answer_end_at_finish() {
+        // `\n</ans` is held back in case `\n</answer>` completes, then released
+        // once the stream ends: it was ordinary content all along.
+        expect![[r#"
+            [
+                ReasoningDelta {
+                    reasoning: Some(
+                        "reason",
+                    ),
+                    content: Some(
+                        "answer",
+                    ),
+                },
+                ReasoningDelta {
+                    reasoning: None,
+                    content: Some(
+                        "\n</ans",
+                    ),
+                },
+            ]
+        "#]]
+        .assert_debug_eq(&collect(&[
+            "<think>\nreason\n</think>\n<answer>\nanswer",
+            "\n</ans",
+        ]));
+    }
+
+    #[test]
+    fn ignores_the_prompt_reasoning_boundary() {
+        // With no delimiter IDs to resolve there is no prompt boundary to read,
+        // so initialization always leaves the parser outside reasoning and the
+        // stream's own `<think>` is what opens it.
+        let mut parser = parser();
+        parser.initialize(&[1, 2, 3]).unwrap();
+
+        expect![[r#"
+            [
+                ReasoningDelta {
+                    reasoning: None,
+                    content: Some(
+                        "reason\n</think>\n<answer>\nanswer",
+                    ),
+                },
+            ]
+        "#]]
+        .assert_debug_eq(&collect_with(
+            parser,
+            &["reason\n</think>\n<answer>\nanswer"],
+        ));
+    }
+
+    #[test]
+    fn adapts_where_the_python_parser_leaks_framing() {
+        let parsed: Vec<_> =
+            ADAPTED_CASES.iter().map(|(name, output)| (name, joined(&[output]))).collect();
+
+        expect![[r#"
+            [
+                (
+                    "prefilled prompt, body opens at <answer>",
+                    (
+                        None,
+                        Some(
+                            "This is the rest",
+                        ),
+                    ),
+                ),
+                (
+                    "content that only looks like the opener",
+                    (
+                        None,
+                        Some(
+                            "<abc>This is the rest",
+                        ),
+                    ),
+                ),
+                (
+                    "text following a complete answer terminator",
+                    (
+                        Some(
+                            "reason",
+                        ),
+                        Some(
+                            "answertrailing",
+                        ),
+                    ),
+                ),
+                (
+                    "two complete round trips",
+                    (
+                        Some(
+                            "ac",
+                        ),
+                        Some(
+                            "bd",
+                        ),
+                    ),
+                ),
+            ]
+        "#]]
+        .assert_debug_eq(&parsed);
+    }
+
+    #[test]
+    fn streaming_matches_single_push_for_adapted_cases() {
+        for (name, output) in ADAPTED_CASES {
+            let whole = joined(&[output]);
+            for size in [1, 2, 3, 5, 7, 11] {
+                assert_eq!(
+                    joined(&split(output, size)),
+                    whole,
+                    "{name}, chunk size {size}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn emits_an_unresolved_answer_opener_at_finish() {
+        // `<ans` is held back in case `<answer>` completes, then released once
+        // the stream ends: it was ordinary content all along.
+        expect![[r#"
+            [
+                ReasoningDelta {
+                    reasoning: None,
+                    content: Some(
+                        "<ans",
+                    ),
+                },
+            ]
+        "#]]
+        .assert_debug_eq(&collect(&["<ans"]));
+    }
+}

--- a/rust/src/parser/src/reasoning/mod.rs
+++ b/rust/src/parser/src/reasoning/mod.rs
@@ -20,6 +20,7 @@
 mod cohere_cmd;
 mod deepseek_r1;
 mod delimited;
+mod hunyuan_a13b;
 mod hy_v3;
 mod kimi;
 mod minimax_m3;
@@ -33,6 +34,7 @@ use vllm_tokenizer::DynTokenizer;
 pub use self::cohere_cmd::CohereCmdReasoningParser;
 pub use self::deepseek_r1::DeepSeekR1ReasoningParser;
 pub(crate) use self::delimited::{DelimitedReasoningParser, last_reasoning_boundary};
+pub use self::hunyuan_a13b::HunyuanA13BReasoningParser;
 pub(crate) use self::hy_v3::HyV3ReasoningParser;
 pub use self::kimi::KimiReasoningParser;
 pub use self::minimax_m3::MiniMaxM3ReasoningParser;

--- a/rust/src/parser/src/reasoning/tests.rs
+++ b/rust/src/parser/src/reasoning/tests.rs
@@ -86,6 +86,82 @@ fn delimited_finish_flushes_buffer() {
 }
 
 #[test]
+fn delimited_text_only_needs_no_vocabulary_entries() {
+    // `new` resolves both delimiters against the vocabulary and fails when
+    // either is missing; `new_text_only` matches text and never looks.
+    let tokenizer = Arc::new(TestTokenizer::new());
+    assert!(
+        DelimitedReasoningParser::new(tokenizer.clone(), "<think>", "</think>", false).is_err()
+    );
+
+    let mut parser =
+        DelimitedReasoningParser::new_text_only(tokenizer, "<think>", "</think>", false);
+
+    let delta = parser.push("<think>reason</think>answer");
+    assert_eq!(delta.reasoning.as_deref(), Some("reason"));
+    assert_eq!(delta.content.as_deref(), Some("answer"));
+}
+
+#[test]
+fn delimited_text_only_ignores_the_prompt_boundary() {
+    // With no delimiter IDs there is nothing to look for in the prompt, so
+    // initialization always lands on `default_in_reasoning`.
+    let mut parser = DelimitedReasoningParser::new_text_only(
+        Arc::new(fake_tokenizer()),
+        "<think>",
+        "</think>",
+        false,
+    );
+    parser.initialize(&[THINK_START_ID]);
+
+    assert!(!parser.in_reasoning());
+    assert_eq!(parser.push("answer").content.as_deref(), Some("answer"));
+}
+
+#[test]
+fn delimited_strips_a_framing_newline_from_every_section() {
+    let mut parser =
+        DelimitedReasoningParser::new(Arc::new(fake_tokenizer()), "<think>", "</think>", false)
+            .unwrap()
+            .strip_framing_newlines();
+
+    // Both sections open with a framing newline, and both lose it even though
+    // one push produces them all: `ReasoningDelta` concatenates the runs, so a
+    // wrapper downstream could no longer tell where the second section began.
+    let delta = parser.push("<think>\na</think>\nb<think>\nc</think>\nd");
+    assert_eq!(delta.reasoning.as_deref(), Some("ac"));
+    assert_eq!(delta.content.as_deref(), Some("bd"));
+}
+
+#[test]
+fn delimited_holds_a_framing_newline_across_pushes() {
+    let mut parser =
+        DelimitedReasoningParser::new(Arc::new(fake_tokenizer()), "<think>", "</think>", false)
+            .unwrap()
+            .strip_framing_newlines();
+
+    // The delimiter ends one push and its framing newline opens the next, so
+    // the pending strip has to survive in between.
+    assert!(parser.push("<think>").is_empty());
+    assert_eq!(parser.push("\nreason").reasoning.as_deref(), Some("reason"));
+
+    // Only the framing newline goes; later ones are ordinary text.
+    assert_eq!(parser.push("\nmore").reasoning.as_deref(), Some("\nmore"));
+}
+
+#[test]
+fn delimited_keeps_section_text_that_does_not_open_with_a_newline() {
+    let mut parser =
+        DelimitedReasoningParser::new(Arc::new(fake_tokenizer()), "<think>", "</think>", false)
+            .unwrap()
+            .strip_framing_newlines();
+
+    let delta = parser.push("<think>reason</think>answer");
+    assert_eq!(delta.reasoning.as_deref(), Some("reason"));
+    assert_eq!(delta.content.as_deref(), Some("answer"));
+}
+
+#[test]
 fn qwen3_without_prompt_markers_expects_start_token() {
     let tokenizer = Arc::new(fake_tokenizer());
     let mut parser = Qwen3ReasoningParser::new(tokenizer).unwrap();


### PR DESCRIPTION
## Purpose

Adds the `hunyuan_a13b` reasoning parser to the Rust frontend, from the parser parity checklist in
#44280. Claimed in-thread before starting.

Hunyuan A13B frames its output differently from every reasoning family already ported here — the
content is wrapped in a section of its own:

```
<think>\n REASONING \n</think>\n<answer>\n CONTENT \n</answer>
```

This is an adaptation of `vllm/reasoning/hunyuan_a13b_reasoning_parser.py` rather than a line-by-line
port, as #44280 asks for. Two findings drove the design.

**1. The delimiters are not vocabulary tokens.** Verified against `tencent/Hunyuan-A13B-Instruct`
(127,957-entry byte-level BPE, empty `added_tokens_decoder`):

```python
from transformers import AutoTokenizer
t = AutoTokenizer.from_pretrained("tencent/Hunyuan-A13B-Instruct", trust_remote_code=True)
print(t.convert_tokens_to_ids("<think>"))   # None — not a vocab token
print(t.tokenize("<think>\n"))              # ['<th', 'ink', '>Ċ']
```

`</think>`, `<answer>` and `</answer>` are all absent too. That is why the Python parser hardcodes
`think_start_ids = [14023, 771, 397]` and eight more literal ID sequences, and it means
`DelimitedReasoningParser::new` cannot construct here at all: it resolves both delimiters through
`token_to_id` and returns `MissingToken` when either is missing.

So `delimited.rs` makes the resolved delimiter IDs `Option<u32>` and adds a `new_text_only`
constructor that skips resolution. `new` and all seven existing callers are untouched and keep passing
real IDs, so no existing parser changes behaviour. This is the same class of problem @rabrooks raised
for `hy_v3` in #44280 — that one was resolvable by reusing the plain `<think>`/`</think>` parser, which
is not an option here (aliasing Hunyuan to `qwen3` yields reasoning `\nR\n` and content
`\n<answer>\nC\n</answer>`, i.e. wrong against the Python spec).

Text matching is not merely a workaround for the missing IDs; it removes a class of upstream
fragility. The Python parser carries `think_start_ids_fast`, `response_start_ids_fast` and
`fast_think_ids` — *parallel* ID sequences for the very same strings — purely because BPE merges
differ by context (`>Ċ` vs `>ĊĊ`). Matching text makes all of that disappear, and it survives tokenizer
revisions, where nine pinned literal IDs would not.

`delimited.rs` gains one other opt-in, `strip_framing_newlines()`, described under "Framing newlines"
below.

Both `delimited.rs` changes are additive and default to the existing behaviour, but I'm happy to take
a different approach if you'd rather not touch that file — the parser is the part that matters.

**2. Prompt-boundary initialization is impossible here, and unnecessary.**
`last_reasoning_boundary` compares token IDs, so with no IDs there is nothing to inspect. It is also
not needed: the model's own `chat_template` has no thinking logic, and
`examples/tool_chat_template_hunyuan_a13b.jinja` prefills `<think>\n\n</think>\n` **only** when
`enable_thinking is false`. With thinking on, the prompt prefills nothing and the model emits
`<think>\n` itself, so text matching with `default_in_reasoning = false` is the faithful behaviour.
`preserve_special_tokens` stays `false` — these are ordinary text, not special tokens.

### Notes for review

- **Delimiter choice.** The parser uses `<think>` and `\n</think>\n<answer>`, stripping the single
  framing newline that opens each section. The obvious alternative — folding the
  newlines into the delimiters as `<think>\n` and `\n</think>\n<answer>\n` — does not work: the shared
  machine's `partial_suffix_len` holds back any buffered suffix that could complete *either*
  delimiter, regardless of which one it is currently looking for. A completed `<think>\n` therefore has
  its trailing newline held back as a possible start of `\n</think>`, and `<think>` alone is emitted as
  content, so reasoning is never entered. It reproduces only when a chunk boundary lands on the
  delimiter, which is why the tests re-feed every case at several chunk sizes. Ending both delimiters
  on `>` avoids the overlap entirely. No existing delimiter pair has it.
- **Framing newlines are stripped inside the shared machine**, via a new opt-in
  `DelimitedReasoningParser::strip_framing_newlines()` that defaults to off, so no existing parser is
  affected. Doing it in the wrapper instead is wrong, and there is a test for why: `ReasoningDelta`
  concatenates every run parsed out of one push, so once two `<think>`->`<answer>` round trips land in
  a single push the per-section boundaries are gone and only the first section's newline is reachable.
  That made `<think>\na\n</think>\n<answer>\nb\n</answer><think>\nc…` yield reasoning `"a\nc"` in one push
  but `"ac"` at every chunk size — a genuinely split-dependent result. Python's state machine cycles
  `response -> idle -> think`, so repeated round trips are a shape it supports and worth getting right.
  Stripping where the boundaries are still visible fixes it, and made the wrapper smaller.
- **Auto-detection is deliberately narrow.** `resolve_name_for_model` is a case-insensitive substring
  scan, so a bare `hunyuan` pattern would also claim `HunyuanOCR` and the dense `Hunyuan-7B-Instruct`,
  which has no thinking mode. `hunyuan-a13b` / `hunyuan_a13b` match the target and nothing else, which
  is the convention the registry already uses (`deepseek-v4`, `step-3p5`, `seed-oss`, `minimax-m3`,
  `kimi-k2`). A test asserts both the match and the two non-matches. My claim comment said I would add
  no matcher at all; on reflection the concern I had there was the bare substring, and a narrow pattern
  avoids it while letting `--reasoning-parser auto` work out of the box.
- **`\n</answer>` handling.** Only the marker is suppressed; a stream that opens another `<think>`
  section afterwards keeps parsing. An incomplete tail such as `\n</ans` at end of stream is emitted as
  content rather than swallowed.
- **One deliberate divergence from Python, on this roadmap's own terms.** With
  `enable_thinking is false`, `tool_chat_template_hunyuan_a13b.jinja` prefills `<think>\n\n</think>\n`
  and stops there, so the model body opens with a bare `<answer>` that is never part of a delimiter.
  Python leaks it into content (`content = "<answer>\nC"`) — its regex makes the `<think>` group
  optional and its token state machine starts in `idle`, so the opener falls through as content in
  both paths. This parser drops it: `reasoning: None, content: "C"`.

  #44280 says it may skip "options that mainly reflect Python frontend implementation details or
  Python-side workarounds", and prefers "adapting the current Rust design over line-by-line Python
  ports". This is that case. It also costs nothing in spec parity: **every case in
  `tests/reasoning/test_hunyuan_reasoning_parser.py` begins with `<think>\n`, or is the bare
  `"This is content"` case — none starts at `<answer>`**, so the prefill path is untested upstream and
  every ported case is byte-identical either way. Tests cover the fix, the split-across-pushes
  hold-back it needs, and content that merely looks like the opener (`<abc>…` passes through).

- **Text after a complete `\n</answer>` keeps streaming as content**, matching Python's streaming path.
  Python's non-streaming regex discards it instead, so the two Python paths disagree with each other;
  streaming is the right match for this trait. Pinned by a test.
- `rust/src/chat/src/lib.rs` is also touched by #52133 (the tool half). Different snapshot line, so a
  textual conflict is unlikely, but it is the one file both PRs edit.
- **`delimited.rs` cannot be split into a commit of its own.** I tried: `new_text_only` and
  `strip_framing_newlines` are `pub(crate)` with no non-test caller until the parser lands, so such a
  commit fails `clippy --all-targets -D warnings` on `dead_code` — `--all-targets` still builds the lib
  without `cfg(test)`, so the tests do not rescue it. The shared-machine change and its only caller
  therefore arrive together.
- **Slightly more permissive than Python at the delimiters.** Python's regexes require the newline —
  `<think>\n` and `\n</think>\n<answer>\n` — whereas this matches `<think>` and `\n</think>\n<answer>`
  and strips the following newline only when it is actually there. So `<think>reason` enters reasoning
  here and does not upstream. Every Python test case carries the newlines, so this changes no ported
  expectation; I preferred the lenient reading because a missing framing newline should not silently
  turn a whole reasoning block into content.
- Python's `is_reasoning_end` and `extract_content_ids` are not ported — the Rust `ReasoningParser`
  trait has no equivalent hooks. Flagged with a `TODO`, matching the existing note in
  `minimax_m2_append_think.rs`.

## Test Plan

```bash
cd rust
cargo nextest run -p vllm-parser
cargo nextest run -p vllm-chat
cargo clippy -p vllm-parser -p vllm-chat --all-targets -- -D warnings
cargo fmt --all -- --check
```

The Python suite's 18 parametrizations reduce to seven distinct outputs, five of them behaviourally
distinct; the new tests port those five. The two left out are literal variants of ported cases —
`COMPLETE_REASONING_WITH_SYMBOL` only appends `!` to `COMPLETE_REASONING`, and `REASONING_WITH_THINK`
is `MULTIPLE_LINES` on a single line. The Rust tests add streaming coverage that suite lacks: every
case is re-fed at chunk sizes 1, 2, 3, 5, 7 and 11 and must produce the identical reasoning/content
split, plus a delimiter split mid-sequence across pushes, an incomplete `\n</answer>` tail released at
`finish()`, and a prompt-boundary call that must not flip the initial state.

## Test Result

All on `origin/main` @ 8bdc70ec7 plus this branch, CPU-only, macOS aarch64.

```
$ cargo nextest run -p vllm-parser
     Summary [   0.403s] 435 tests run: 435 passed, 0 skipped

$ cargo nextest run -p vllm-chat
     Summary [   7.712s] 310 tests run: 310 passed, 0 skipped

$ cargo clippy -p vllm-parser -p vllm-chat --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 2.56s

$ cargo fmt --all -- --check
    (no output)
```

Baselines on `origin/main` @ 8bdc70ec7 are 422 (`vllm-parser`) and 308 (`vllm-chat`), so this adds 13
parser tests and 2 registry tests. I also ran the same four commands with the three `vllm-chat` files
reverted, leaving only the parser side: 435 / 308, clippy and fmt clean — `vllm-chat` back at its
baseline, which confirms no existing parser is affected by either `delimited.rs` change.

### Also green on a second platform

Same four commands on `aarch64-unknown-linux-gnu` (NVIDIA DGX Spark, GB10), measured before the
rebase, on base `49905ad94` (429 / 300 against that base's 416 / 298):

```
$ cargo nextest run -p vllm-parser
     Summary [   0.133s] 429 tests run: 429 passed, 0 skipped

$ cargo nextest run -p vllm-chat
     Summary [   9.899s] 300 tests run: 300 passed, 0 skipped

$ cargo clippy -p vllm-parser -p vllm-chat --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 13.84s

$ cargo fmt --all -- --check
    (no output)
```

Identical counts on macOS aarch64 and Linux aarch64 at that revision.

## Not a duplicate

- **`hy_v3` (#53054) is a different parser for a different model.** It landed after this PR opened
  and touches four of the same files, hence the rebase. HY3 is Tencent Hunyuan **v3**: a *unified*
  reasoning+tool parser whose delimiters are tokenizer-derived `<think{suffix}>` / `</think{suffix}>`,
  registered as `hy_v3` via `register_unified_dummy` on the pattern `hy3`. Hunyuan-**A13B** is an
  earlier generation with a different wire format — `<think>\n…\n</think>\n<answer>\n…\n</answer>` —
  a standalone `register_parser`, and the patterns `hunyuan-a13b` / `hunyuan_a13b`. Neither routes
  the other's models, and neither parser's tests change. The rebase adopts #53054's widened
  `DelimitedReasoningParser::new` signature (`&'static str` -> `impl Into<String>`) and threads it
  through the `new_text_only` / `with_token_ids` helpers this PR adds.
- `#44280` — read all 28 comments. No claim on `hunyuan_a13b`; mine is the only one.
- Searched open PRs for `hunyuan` (83 results across all states, 19 open). The only Hunyuan A13B parser
  work is #52133, the **tool** parser. I checked its file list: `parser/src/tool/json/hunyuan_a13b.rs`,
  `parser/src/tool/{json/,}mod.rs`, `chat/src/parser/tool/{mod,tests}.rs` and `chat/src/lib.rs` —
  nothing under `rust/src/parser/src/reasoning/`. The two are complementary halves.
- `grep -ri hunyuan rust/src/` on `origin/main` returns a single hit, an embedded template filename in
  `renderer/hf/format.rs`. No reasoning parser is registered.
- No other open PR touches `rust/src/parser/src/reasoning/delimited.rs`.

## Model evaluation

Not applicable, stated explicitly rather than omitted: this is a CPU-only text state machine in the
frontend's output path. It does not touch model execution, logits, sampling or kernels, and cannot
change generated tokens — it only decides how already-generated text is split between the `reasoning`
and `content` fields of the response. The behavioural contract is pinned by the ported Python test
cases above. **No live Hunyuan A13B serve was run, and I am not claiming one** — the model is 160.8 GB
and I do not have the hardware budget for it.

### Live serving check, with an explicitly labelled stand-in

I did run the parser end to end against a real engine, using **Qwen3-0.6B as a stand-in generator, not
Hunyuan A13B**. vLLM 0.27.1 engine, Rust frontend built from this branch, single GB10:

- `--reasoning-parser hunyuan_a13b` is accepted end to end — Python's `ReasoningParserManager` validates
  the name first, then the Rust registry constructs the parser and the server reaches ready.
  `/version` reports `{"version":"0.27.1","rust_frontend_version":"0.1.0"}` and `/v1/models` reports
  `"owned_by":"vllm-frontend-rs"`, so it is the Rust frontend answering.
- Startup logs `Auto-initialization of reasoning token IDs failed…`. **This is expected and benign** —
  the parser resolves no delimiter token IDs by design, which is the whole point above. The existing
  `minimax_m2_append_think` parser logs the same line for the same reason.
- A request carrying a `tools` array returns 200, so registration does not disturb tool parsing.

The one behaviour a stand-in can exercise is the `<answer>`-opener case from the divergence note, since
a small model will emit that shape on request. Same messages, `temperature 0`, 9 completion tokens in
both runs — only `--reasoning-parser` differs:

| | `qwen3` (control) | `hunyuan_a13b` |
|---|---|---|
| `reasoning` | `null` | `null` |
| `content` | `"<answer>\n4\n</answer>"` | `"4"` |

The control shows what the model actually generated; this parser strips the bare opener, the framing
newline and the trailing `\n</answer>`, which is the documented divergence from Python behaving as
described.

**What the stand-in cannot show:** Qwen3 emits `</think>\n\n<answer>` with two newlines, so it cannot
produce Hunyuan's single-newline frame, and the reasoning/content split for a complete
`<think>…</think><answer>…</answer>` response is covered by the unit tests only — including the
chunk-size sweep, which is stricter than a single live generation would be.

## AI assistance

AI assistance was used for this change (Claude Code): to locate the relevant files, draft the parser
and its tests, and draft this description. I ran the verification commands under Test Result myself,
and I also checked that the new tests fail when the behaviour they pin is broken: folding the framing
newline into the `\n</think>\n<answer>` delimiter fails three of them, removing the shared state
machine's newline stripping fails four, and dropping the `hunyuan-a13b` auto-detection pattern fails
exactly one registry test. The second-platform run and the serving check above were run with AI
assistance on my own machines. I reviewed every changed line and can explain and defend the design —
in particular the two findings in the review notes that shaped it: the `partial_suffix_len` delimiter
overlap, which surfaced as a real test failure and drove the delimiter choice, and the
multi-round-trip framing-newline bug, which surfaced as a chunk-size-dependent result and is why
newline stripping ended up in the shared machine rather than in this parser.