### PR TITLE
[Core] Remove is_ec_consumer check to enable correct batch queue sampling in standalone v1

### DIFF
--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -214,10 +214,7 @@ class EngineCore:
             logger.debug("Batch queue is enabled with size %d", self.batch_queue_size)
             self.batch_queue = deque(maxlen=self.batch_queue_size)
 
-        self.is_ec_consumer = (
-            vllm_config.ec_transfer_config is None
-            or vllm_config.ec_transfer_config.is_ec_consumer
-        )
+
         self.is_pooling_model = vllm_config.model_config.runner_type == "pooling"
 
         self.request_block_hasher: Callable[[Request], list[BlockHash]] | None = None
@@ -654,8 +651,7 @@ class EngineCore:
                 exec_future = self.model_executor.execute_model(
                     scheduler_output, non_block=True
                 )
-            if self.is_ec_consumer:
-                model_executed = scheduler_output.total_num_scheduled_tokens > 0
+            model_executed = scheduler_output.total_num_scheduled_tokens > 0
 
             if self.is_pooling_model or not model_executed:
                 # No sampling required (no requests scheduled).


### PR DESCRIPTION


### Title
`fix(engine): remove is_ec_consumer check to enable correct batch queue sampling in standalone v1`

### Description

Fixes a bug in the `EngineCore` batch queue where standard engine configurations (e.g., `is_ec_consumer=False`) would silently skip token sampling. By unconditionally setting:

_`model_executed = scheduler_output.total_num_scheduled_tokens > 0`_

we eliminate the `is_ec_consumer` restriction, ensuring proper behavior for non-disaggregated standard generations (such as TPUs running standard workloads where inference and sampling stages are disjointed).

### AI Assistance (Required by `AGENTS.md`)
- **AI Tools Used:** Jetski 

### Non-Duplication
No open duplicate PRs were found via:
- `gh pr list --repo vllm-project/vllm --state open --search "batch queue in:body"`
- `gh pr list --repo vllm-project/vllm --state open --search "is_ec_consumer"`

### Test/Eval Commands
- `pytest tests/v1/engine/test_engine_core.py -v` - Passed without `CUDA` exceptions (x86 run logic validations passed).

### Model Evaluation
This PR strictly modifies internal sequencing parameters for inference pipeline scheduling. It does not manipulate numeric model outputs.

