### PR TITLE
[Bugfix] Restore vllm.transformers_utils.tokenizer shim for lm-format-enforcer

### DIFF
--- a/tests/transformers_utils/test_tokenizer_shim.py
+++ b/tests/transformers_utils/test_tokenizer_shim.py
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for the vllm.transformers_utils.tokenizer backward-compat shim (#52614)."""
+
+import pytest
+
+
+def test_mistral_tokenizer_legacy_import_path():
+    """The pre-#35024 import path used by lm-format-enforcer must keep working
+    and resolve to the same class object (it is used for isinstance checks)."""
+    with pytest.warns(DeprecationWarning):
+        from vllm.transformers_utils.tokenizer import MistralTokenizer as legacy
+
+    from vllm.tokenizers.mistral import MistralTokenizer
+
+    assert legacy is MistralTokenizer
+
+
+def test_shim_rejects_unknown_attributes():
+    import vllm.transformers_utils.tokenizer as shim_module
+
+    with pytest.raises(AttributeError):
+        _ = shim_module.does_not_exist

--- a/vllm/transformers_utils/tokenizer.py
+++ b/vllm/transformers_utils/tokenizer.py
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Backward-compatibility shim for third-party integrations.
+
+`vllm.transformers_utils.tokenizer` was removed in #35024, but
+`lm-format-enforcer==0.11.3` (pinned in requirements/common.txt) still imports
+`MistralTokenizer` from this module, which breaks the lm-format-enforcer
+structured-output backend (see #52614).
+
+Keep this shim until lm-format-enforcer is updated to import from
+`vllm.tokenizers.mistral` directly.
+"""
+
+import warnings
+
+
+def __getattr__(name: str):
+    # Keep until lm-format-enforcer is updated
+    if name == "MistralTokenizer":
+        from vllm.tokenizers.mistral import MistralTokenizer
+
+        warnings.warn(
+            "`vllm.transformers_utils.tokenizer.MistralTokenizer` "
+            "has been moved to `vllm.tokenizers.mistral.MistralTokenizer`. "
+            "The old name will be removed in a future version.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
+        return MistralTokenizer
+
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")


### PR DESCRIPTION


## Purpose

Fix #52614.

PR #35024 removed `vllm/transformers_utils/tokenizer.py` after lm-eval dropped its usage. However, `lm-format-enforcer==0.11.3` — pinned in `requirements/common.txt` — still does `from vllm.transformers_utils.tokenizer import MistralTokenizer` at the top of `lmformatenforcer.integrations.vllm`. That raises `ImportError`, so any structured-output request against the lm-format-enforcer backend fails with HTTP 500 (the backend module itself becomes unloadable).

This PR restores `vllm/transformers_utils/tokenizer.py` as a minimal lazy `__getattr__` shim that re-exports `MistralTokenizer` from its new home (`vllm.tokenizers.mistral`) with a `DeprecationWarning` — the same pattern the removed module itself used for lm-eval before its removal. Keep until lm-format-enforcer updates its import and vLLM pins the new release.

Known remaining gap (out of scope here): lm-format-enforcer 0.11.3 also imports the pre-5.0 `PreTrainedTokenizerBase` spelling from transformers; that is fixed in upstream lm-format-enforcer `main` but unreleased, so fully restoring the LMFE backend on transformers >= 5 additionally requires the next lm-format-enforcer release (no vLLM-side action possible for that import; the break this PR fixes is the only vLLM-side one).

## Test Plan

```
pytest tests/transformers_utils/test_tokenizer_shim.py -v
```

The legacy-path test executes the exact import line that broke (`from vllm.transformers_utils.tokenizer import MistralTokenizer`) and asserts it resolves to the same class object (LMFE does an `isinstance` check against it). An end-to-end LMFE import test is intentionally not included — see "Known remaining gap" above; it would exercise a third-party break, not this shim.

## Test Result

Unit tests:

```
tests/transformers_utils/test_tokenizer_shim.py::test_mistral_tokenizer_legacy_import_path PASSED
tests/transformers_utils/test_tokenizer_shim.py::test_shim_rejects_unknown_attributes PASSED
============================== 2 passed in 2.20s ==============================
```

Before/after at the real consumer (`import lmformatenforcer.integrations.vllm`, the exact failure point of #52614):

| | without this shim | with this shim |
|---|---|---|
| lm-format-enforcer 0.11.3 (pinned) | `ImportError` at its line 4 (`vllm.transformers_utils.tokenizer`) | passes the vLLM import; then hits the known transformers-5 issue on LMFE's own side (see gap note) |
| lm-format-enforcer @ main (has the unreleased transformers fix) | `ImportError` at line 4 | **import succeeds** |

End-to-end through vLLM's production path (CPU, offline tokenizer): with this shim, `LMFormatEnforcerBackend` constructs, `compile_grammar` returns a grammar, and token allowlisting works (`accept_tokens('{') == True`, then narrows to `"`-leading tokens for the required property). Without the shim the backend construction raises `ImportError` at the tokenizer-data build (lazy-load trigger of `lmformatenforcer.integrations.vllm`).

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. (N/A — compatibility restore, no user-facing feature change)
</details>

