### PR TITLE
Accept x-api-key header as auth fallback

### DIFF
--- a/vllm/entrypoints/serve/middleware/authenticate.py
+++ b/vllm/entrypoints/serve/middleware/authenticate.py
@@ -28,12 +28,15 @@ class AuthenticationMiddleware:
         self.api_tokens = [hashlib.sha256(t.encode("utf-8")).digest() for t in tokens]
 
     def verify_token(self, headers: Headers) -> bool:
+        param = None
         authorization_header_value = headers.get("Authorization")
-        if not authorization_header_value:
-            return False
-
-        scheme, _, param = authorization_header_value.partition(" ")
-        if scheme.lower() != "bearer":
+        if authorization_header_value:
+            scheme, _, bearer_param = authorization_header_value.partition(" ")
+            if scheme.lower() == "bearer":
+                param = bearer_param
+        if param is None:
+            param = headers.get("x-api-key")
+        if not param:
             return False
 
         param_hash = hashlib.sha256(param.encode("utf-8")).digest()
@@ -43,6 +46,7 @@ class AuthenticationMiddleware:
             token_match |= secrets.compare_digest(param_hash, token_hash)
 
         return token_match
+    
 
     def __call__(self, scope: Scope, receive: Receive, send: Send) -> Awaitable[None]:
         if (


### PR DESCRIPTION
## Purpose

This PR extends `AuthenticationMiddleware.verify_token` to accept an `x-api-key` header as an alternative to the `Authorization: Bearer <token>` scheme. Some clients and tooling (e.g. certain SDKs and API gateways) send credentials via `x-api-key` rather than a Bearer token, and previously those requests were rejected with a 401 even when a valid token was supplied.

The token resolution order is:
1. If `Authorization` is present and uses the `Bearer` scheme, use that token.
2. Otherwise, fall back to the `x-api-key` header if present.
3. If neither yields a token, authentication fails as before.

This also resolves a merge conflict from `AuthenticationMiddleware` having been relocated out of `vllm/entrypoints/serve/utils/server_utils.py` into its own module on `main`; the `x-api-key` fallback has been reapplied to the class in its new location.

## Test Plan

- Manually verified requests with:
  - Valid `Authorization: Bearer <token>` header → 200
  - Valid `x-api-key: <token>` header (no `Authorization` header) → 200
  - Invalid/missing token via either header → 401
  - `Authorization` header present but non-Bearer scheme, with a valid `x-api-key` → 200 (falls through correctly)
- Existing tests for `AuthenticationMiddleware` were run to confirm no regression in Bearer-token behavior.

## Test Result

- All existing authentication middleware tests pass.
- New manual verification confirms `x-api-key` requests are now correctly authenticated where they previously returned 401.

## (Optional) Documentation

No user-facing docs (e.g. `supported_models.md`) require updates, as this is an internal auth-handling change. If `x-api-key` support should be documented in the API reference, happy to add that in a follow-up.