### PR TITLE
[Bugfix][KV Offload] Widen eagle lookup query for non-sliding-window groups

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
@@ -756,10 +756,11 @@ class OffloadingConnectorScheduler:
                     group_config.sliding_window_size_in_chunks
                 )
 
-                # For eagle groups, query one extra chunk that will be popped.
-                # We only need to increase the query size for sliding window groups.
+                # For eagle groups, query one extra chunk that will be popped
+                # below via `num_hit_chunks -= 1`. That pop is unconditional,
+                # so the widening must be unconditional too.
                 query_max = max_hit_size_tokens
-                if is_eagle_unverified and sliding_window_size_in_chunks is not None:
+                if is_eagle_unverified:
                     query_max = min(
                         max_hit_size_tokens + tokens_per_chunk,
                         len(offload_keys) * tokens_per_chunk,


### PR DESCRIPTION
> **Draft — scope corrected after further investigation.** This is offered as an *internal
> consistency* fix, not as the cause of any particular symptom. An earlier revision of this
> description overstated the production evidence; corrections are at the bottom.

## The asymmetry

In `OffloadingConnectorScheduler.get_num_new_matched_tokens`, an eagle group's hit count is
decremented **unconditionally** once the group is verified:

```python
if is_eagle_unverified:
    num_hit_chunks -= 1
    eagle_verified.add(group_idx)
```

but the compensating query widening — whose own comment says it exists so that extra chunk
*can* be popped — is applied **only to sliding-window groups**:

```python
# For eagle groups, query one extra chunk that will be popped.
# We only need to increase the query size for sliding window groups.
query_max = max_hit_size_tokens
if is_eagle_unverified and sliding_window_size_in_chunks is not None:
    query_max = min(max_hit_size_tokens + tokens_per_chunk, ...)
```

For a **full-attention** eagle group the query is never widened, yet the pop still happens, so
the group returns one chunk fewer than it actually matched.

This is reachable in ordinary configurations, not just DeepSeek-V4. `is_eagle_group` has one
real writer (`_annotate_eagle_groups_deepseek_v4`, gated on `model_version == "deepseek_v4"`),
but when that produces nothing the fallback flags **every** group:

```python
if use_eagle and not eagle_groups:
    eagle_groups = set(range(len(kv_cache_config.kv_cache_groups)))
```

and `use_eagle()` is true for `method="mtp"`. So on any MTP model the full-attention group is
an eagle group, takes the non-widened path, and still pays the pop.

## The change

Make the widening unconditional so it matches the unconditional pop, and tie the two sites
together in the comment so they are less likely to drift apart again.

## Scope — what this does NOT claim

The decrement applies to an already-non-zero hit. A total backend miss returns earlier:

```python
if num_hit_chunks == 0:
    return 0          # this precedes the eagle pop
```

So this defect can cost a real hit one chunk, but it cannot turn a zero into a zero. I am
**not** claiming it explains any specific case of "loads never happen" — including our own,
where a simpler explanation is in play (see below).

## Corrections to the first revision of this description

- I wrote that `kv_offload_cpu_cache_usage_perc` "reads 0.0 across 1353 samples". **That was
  wrong.** Re-measured across all four workers: 1873 samples, **177 non-zero** (values around
  0.0008–0.009). I had read the last value and misreported it as the whole series. The gauge
  also nets out evictable blocks, so a low reading is expected for a healthy cache and is not
  evidence of anything.
- I implied this defect was the likely cause of `CPU_to_GPU == 0` on our deployment. That is
  not established. A simpler, MTP-independent explanation fits our numbers: with
  `--kv-offloading-size 128` per engine against 4x62–147 GiB of per-rank GPU KV, our CPU tier
  holds roughly 0.2–0.5x the tokens of the GPU tier in front of it — and the CPU tier is only
  ever queried about chunks the GPU tier missed. Under LRU that region is precisely what it
  cannot hold. We also see zero `lookup_async_delay` samples, consistent with a hard first-key
  miss rather than a clamped hit.

Happy to close this if the intended direction is to handle it via #50507's partial-tail path
(which currently excludes EAGLE with the note "EAGLE and DCP need additional hand-off
semantics"), or to add a test if you can point me at the right harness for multi-group
offload lookups.
