### PR TITLE
[Bugfix][KV Offload] Widen the eagle lookup query for non-sliding-window groups

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
@@ -757,9 +757,13 @@ class OffloadingConnectorScheduler:
                 )
 
                 # For eagle groups, query one extra chunk that will be popped.
-                # We only need to increase the query size for sliding window groups.
+                # This applies to every eagle group, not only sliding-window
+                # ones: the pop below is unconditional, so without widening the
+                # query a full-attention eagle group loses a chunk that the
+                # caller actually needed. With the all-groups eagle fallback
+                # above, that loss is taken once per group per lookup.
                 query_max = max_hit_size_tokens
-                if is_eagle_unverified and sliding_window_size_in_chunks is not None:
+                if is_eagle_unverified:
                     query_max = min(
                         max_hit_size_tokens + tokens_per_chunk,
                         len(offload_keys) * tokens_per_chunk,


### PR DESCRIPTION
## ⚠️ Draft: the measurement is solid, the mechanism is not fully pinned. Filing for maintainer input.

With `--kv-offloading-size` and `--speculative-config` both enabled, the host tier **writes and never reads back**: `GPU_to_CPU` climbs, `CPU_to_GPU` stays at exactly zero. We hit this in production and reproduced it under controls; I can identify a defect that contributes, but I have not proven it accounts for the whole effect, so this is a draft.

### Measurement

Hybrid GDN+GQA MoE, 4×GB200, DP=4 × TP=4, `--kv-offloading-size 256`, prefix caching on. The **only** difference between arms is `--speculative-config`:

| | GPU-tier hits | host-tier hits | CPU→GPU | re-send after flood |
|---|---|---|---|---|
| MTP **off** | 249,600 | **20,800** | **2.55 GB** | 0.82 s |
| MTP **on** | 75,456 | **0** | **0** | 2.05 s (full re-prefill) |

Both obvious confounds were closed:

- **Async-store / dwell** — MTP-on rerun under an identical protocol (10 probe sends, 180 s dwell, flood, re-send). `kv_offload_store_size_count` rose 160→176, so the probe was provably resident in host RAM, and 256,235 host queries were recorded. Still 0 hits.
- **Pool capacity** — arms equalised on fresh pools: MTP-off wrote 43.1 GB, MTP-on wrote **38.3 GB**, with an **identical store count of 160**. The failing arm wrote *less*. Probe was 22,421 tokens (10 chunks), well over the 2,096-token chunk.

GPU-tier prefix caching is unaffected throughout; only the host round-trip dies.

### The defect this PR addresses

`_lookup()` pops one chunk from every eagle group's result:

```python
if is_eagle_unverified:
    num_hit_chunks -= 1
```

but only widens the query the pop is meant to consume for sliding-window groups:

```python
# For eagle groups, query one extra chunk that will be popped.
# We only need to increase the query size for sliding window groups.
if is_eagle_unverified and sliding_window_size_in_chunks is not None:
    query_max = min(max_hit_size_tokens + tokens_per_chunk, ...)
```

For a full-attention eagle group the pop removes a chunk the caller needed rather than the extra one the comment describes. This PR widens the query for all eagle groups so the code matches its own stated intent.

### Why that is amplified — the fallback marks *every* group eagle

```python
use_eagle = (vllm_config.speculative_config is not None
             and vllm_config.speculative_config.use_eagle())
if use_eagle and not eagle_groups:
    eagle_groups = set(range(len(kv_cache_config.kv_cache_groups)))
```

When speculative decoding uses eagle but no group is individually tagged — the case for the MTP method we run — **all** groups are flagged, including the main model's attention groups, and the log duly reports `EAGLE/MTP draft attention groups [0, 1, 2, 3]`. The per-group shortfall is then taken once per group.

**Question for maintainers:** is that blanket fallback intended to apply draft-volatility semantics to the main model's KV? Narrowing it may be the better fix, or the necessary second half of one.

### What I have not established

A one-chunk-per-group shortfall should cost chunks, not *all* hits. On a 10-chunk probe with 4 groups I would expect a partial loss, yet the measurement is a hard zero. Two candidates remain, and they need different fixes:

1. the backend genuinely returns 0 because stored and queried keys diverge under eagle, or
2. it returns a real count and the pop plus the `new_num_hit_tokens < tokens_per_chunk → return 0` guard collapses it across the convergence loop.

Distinguishing them needs `num_hit_chunks` logged pre-pop on an eagle run. I don't currently have the GPUs to do that, so I'd rather file this with the evidence than sit on it. Happy to run the instrumentation when capacity frees, or to close this if a maintainer can say straight away which branch is right.

Note the effect is silent: you pay the store bandwidth and the pinned host RAM and get nothing back, with no error — so `--kv-offloading-size` and eagle/MTP are effectively mutually exclusive today.