### PR TITLE
[Bugfix] Skip Dynamic NTK scaling when served length is below trained length

### DIFF
--- a/tests/model_executor/layers/test_dynamic_ntk_scaling_rope.py
+++ b/tests/model_executor/layers/test_dynamic_ntk_scaling_rope.py
@@ -1,14 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""Unit tests for DynamicNTKScalingRotaryEmbedding.
+"""Tests for dynamic NTK scaling below and above the trained context length."""
 
-Regression tests for a bug where serving a model below its trained
-context length drove the Dynamic NTK base negative, producing a complex
-RoPE cache with huge magnitudes that silently discarded its imaginary
-part when cast to a real dtype (see GH issue about NomicBert NaN
-embeddings at max_model_len < max_trained_positions).
-"""
-
+import pytest
 import torch
 
 from vllm.model_executor.layers.rotary_embedding.dynamic_ntk_scaling_rope import (
@@ -29,57 +23,30 @@ def _make_rope(max_position_embeddings: int, max_trained_positions: int = 2048):
     )
 
 
-class TestDynamicNTKScalingRotaryEmbeddingBelowTrainedLength:
-    def test_served_below_trained_length_is_real_and_finite(self, default_vllm_config):
-        rope = _make_rope(max_position_embeddings=512, max_trained_positions=2048)
-        cache = rope._compute_cos_sin_cache()
-        assert not cache.is_complex()
-        assert torch.isfinite(cache).all()
-        assert cache.abs().max().item() <= 1.0
-
-    def test_served_below_trained_length_matches_unscaled_base(
-        self, default_vllm_config
-    ):
-        # Below the trained length, NTK scaling should not kick in: the
-        # cache should match plain RoPE with the original base.
-        rope = _make_rope(max_position_embeddings=512, max_trained_positions=2048)
-        plain_inv_freq = rope._compute_inv_freq(rope.base)
-        plain_cache = _reference_cache(rope.max_position_embeddings, plain_inv_freq)
-        assert torch.allclose(rope._compute_cos_sin_cache(), plain_cache)
-
-    def test_served_at_trained_length_is_real_and_finite(self, default_vllm_config):
-        rope = _make_rope(max_position_embeddings=2048, max_trained_positions=2048)
-        cache = rope._compute_cos_sin_cache()
-        assert not cache.is_complex()
-        assert torch.isfinite(cache).all()
-        assert cache.abs().max().item() <= 1.0
-
-    def test_served_above_trained_length_still_applies_ntk_scaling(
-        self, default_vllm_config
-    ):
-        # Extension behavior above the trained length must be unchanged: the
-        # cache should match the original (pre-guard) NTK formula exactly,
-        # not merely differ from plain, unscaled RoPE.
-        rope = _make_rope(max_position_embeddings=4096, max_trained_positions=2048)
-        cache = rope._compute_cos_sin_cache()
-        assert not cache.is_complex()
-        assert torch.isfinite(cache).all()
-
-        legacy_base = rope.base * (
-            (
-                rope.scaling_factor
-                * rope.max_position_embeddings
-                / rope.max_trained_positions
-            )
-            - (rope.scaling_factor - 1)
-        ) ** (rope.rotary_dim / (rope.rotary_dim - 2))
-        legacy_cache = _reference_cache(
-            rope.max_position_embeddings, rope._compute_inv_freq(legacy_base)
-        )
-        assert torch.allclose(cache, legacy_cache)
-
-
-def _reference_cache(max_position_embeddings: int, inv_freq: torch.Tensor):
+def _compute_cache(max_position_embeddings: int, inv_freq: torch.Tensor):
     t = torch.arange(max_position_embeddings, dtype=torch.float)
     freqs = torch.einsum("i,j -> ij", t, inv_freq)
     return torch.cat((freqs.cos(), freqs.sin()), dim=-1)
+
+
+@pytest.mark.parametrize("max_position_embeddings", [512, 2048])
+def test_no_scaling_at_or_below_trained_length(
+    default_vllm_config, max_position_embeddings
+):
+    rope = _make_rope(max_position_embeddings)
+    expected = _compute_cache(
+        max_position_embeddings, rope._compute_inv_freq(rope.base)
+    )
+    assert torch.allclose(rope._compute_cos_sin_cache(), expected)
+
+
+def test_scaling_above_trained_length(default_vllm_config):
+    rope = _make_rope(4096)
+    scaled_base = rope.base * (
+        rope.scaling_factor * rope.max_position_embeddings / rope.max_trained_positions
+        - (rope.scaling_factor - 1)
+    ) ** (rope.rotary_dim / (rope.rotary_dim - 2))
+    expected = _compute_cache(
+        rope.max_position_embeddings, rope._compute_inv_freq(scaled_base)
+    )
+    assert torch.allclose(rope._compute_cos_sin_cache(), expected)

--- a/tests/model_executor/layers/test_dynamic_ntk_scaling_rope.py
+++ b/tests/model_executor/layers/test_dynamic_ntk_scaling_rope.py
@@ -57,16 +57,26 @@ class TestDynamicNTKScalingRotaryEmbeddingBelowTrainedLength:
     def test_served_above_trained_length_still_applies_ntk_scaling(
         self, default_vllm_config
     ):
-        # Extension behavior above the trained length must be unchanged:
-        # the cache should differ from the plain, unscaled RoPE cache.
+        # Extension behavior above the trained length must be unchanged: the
+        # cache should match the original (pre-guard) NTK formula exactly,
+        # not merely differ from plain, unscaled RoPE.
         rope = _make_rope(max_position_embeddings=4096, max_trained_positions=2048)
         cache = rope._compute_cos_sin_cache()
         assert not cache.is_complex()
         assert torch.isfinite(cache).all()
 
-        plain_inv_freq = rope._compute_inv_freq(rope.base)
-        plain_cache = _reference_cache(rope.max_position_embeddings, plain_inv_freq)
-        assert not torch.allclose(cache, plain_cache)
+        legacy_base = rope.base * (
+            (
+                rope.scaling_factor
+                * rope.max_position_embeddings
+                / rope.max_trained_positions
+            )
+            - (rope.scaling_factor - 1)
+        ) ** (rope.rotary_dim / (rope.rotary_dim - 2))
+        legacy_cache = _reference_cache(
+            rope.max_position_embeddings, rope._compute_inv_freq(legacy_base)
+        )
+        assert torch.allclose(cache, legacy_cache)
 
 
 def _reference_cache(max_position_embeddings: int, inv_freq: torch.Tensor):

--- a/tests/model_executor/layers/test_dynamic_ntk_scaling_rope.py
+++ b/tests/model_executor/layers/test_dynamic_ntk_scaling_rope.py
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for DynamicNTKScalingRotaryEmbedding.
+
+Regression tests for a bug where serving a model below its trained
+context length drove the Dynamic NTK base negative, producing a complex
+RoPE cache with huge magnitudes that silently discarded its imaginary
+part when cast to a real dtype (see GH issue about NomicBert NaN
+embeddings at max_model_len < max_trained_positions).
+"""
+
+import torch
+
+from vllm.model_executor.layers.rotary_embedding.dynamic_ntk_scaling_rope import (
+    DynamicNTKScalingRotaryEmbedding,
+)
+
+
+def _make_rope(max_position_embeddings: int, max_trained_positions: int = 2048):
+    return DynamicNTKScalingRotaryEmbedding(
+        head_size=64,
+        rotary_dim=64,
+        max_position_embeddings=max_position_embeddings,
+        max_trained_positions=max_trained_positions,
+        base=1000.0,
+        is_neox_style=True,
+        scaling_factor=2.0,
+        dtype=torch.float32,
+    )
+
+
+class TestDynamicNTKScalingRotaryEmbeddingBelowTrainedLength:
+    def test_served_below_trained_length_is_real_and_finite(self, default_vllm_config):
+        rope = _make_rope(max_position_embeddings=512, max_trained_positions=2048)
+        cache = rope._compute_cos_sin_cache()
+        assert not cache.is_complex()
+        assert torch.isfinite(cache).all()
+        assert cache.abs().max().item() <= 1.0
+
+    def test_served_below_trained_length_matches_unscaled_base(
+        self, default_vllm_config
+    ):
+        # Below the trained length, NTK scaling should not kick in: the
+        # cache should match plain RoPE with the original base.
+        rope = _make_rope(max_position_embeddings=512, max_trained_positions=2048)
+        plain_inv_freq = rope._compute_inv_freq(rope.base)
+        plain_cache = _reference_cache(rope.max_position_embeddings, plain_inv_freq)
+        assert torch.allclose(rope._compute_cos_sin_cache(), plain_cache)
+
+    def test_served_at_trained_length_is_real_and_finite(self, default_vllm_config):
+        rope = _make_rope(max_position_embeddings=2048, max_trained_positions=2048)
+        cache = rope._compute_cos_sin_cache()
+        assert not cache.is_complex()
+        assert torch.isfinite(cache).all()
+        assert cache.abs().max().item() <= 1.0
+
+    def test_served_above_trained_length_still_applies_ntk_scaling(
+        self, default_vllm_config
+    ):
+        # Extension behavior above the trained length must be unchanged:
+        # the cache should differ from the plain, unscaled RoPE cache.
+        rope = _make_rope(max_position_embeddings=4096, max_trained_positions=2048)
+        cache = rope._compute_cos_sin_cache()
+        assert not cache.is_complex()
+        assert torch.isfinite(cache).all()
+
+        plain_inv_freq = rope._compute_inv_freq(rope.base)
+        plain_cache = _reference_cache(rope.max_position_embeddings, plain_inv_freq)
+        assert not torch.allclose(cache, plain_cache)
+
+
+def _reference_cache(max_position_embeddings: int, inv_freq: torch.Tensor):
+    t = torch.arange(max_position_embeddings, dtype=torch.float)
+    freqs = torch.einsum("i,j -> ij", t, inv_freq)
+    return torch.cat((freqs.cos(), freqs.sin()), dim=-1)

--- a/vllm/model_executor/layers/rotary_embedding/dynamic_ntk_scaling_rope.py
+++ b/vllm/model_executor/layers/rotary_embedding/dynamic_ntk_scaling_rope.py
@@ -55,14 +55,21 @@ class DynamicNTKScalingRotaryEmbedding(RotaryEmbedding):
         # maximum length before applying the rope scaling.
         # Thus, the maximum length after applying the rope scaling is
         # self.max_position_embeddings * self.scaling_factor.
-        base = self.base * (
-            (
-                self.scaling_factor
-                * self.max_position_embeddings
-                / self.max_trained_positions
-            )
-            - (self.scaling_factor - 1)
-        ) ** (self.rotary_dim / (self.rotary_dim - 2))
+        if self.max_position_embeddings <= self.max_trained_positions:
+            # Serving at or below the trained length is ordinary truncation:
+            # keep the original base. Applying the NTK formula here can drive
+            # its base negative, producing a complex (and effectively
+            # unbounded) cache once raised to a fractional power.
+            base = self.base
+        else:
+            base = self.base * (
+                (
+                    self.scaling_factor
+                    * self.max_position_embeddings
+                    / self.max_trained_positions
+                )
+                - (self.scaling_factor - 1)
+            ) ** (self.rotary_dim / (self.rotary_dim - 2))
         inv_freq = self._compute_inv_freq(base)
         t = torch.arange(self.max_position_embeddings, dtype=torch.float)
 

--- a/vllm/model_executor/layers/rotary_embedding/dynamic_ntk_scaling_rope.py
+++ b/vllm/model_executor/layers/rotary_embedding/dynamic_ntk_scaling_rope.py
@@ -56,10 +56,7 @@ class DynamicNTKScalingRotaryEmbedding(RotaryEmbedding):
         # Thus, the maximum length after applying the rope scaling is
         # self.max_position_embeddings * self.scaling_factor.
         if self.max_position_embeddings <= self.max_trained_positions:
-            # Serving at or below the trained length is ordinary truncation:
-            # keep the original base. Applying the NTK formula here can drive
-            # its base negative, producing a complex (and effectively
-            # unbounded) cache once raised to a fractional power.
+            # Dynamic NTK scaling is only needed beyond the trained context length.
             base = self.base
         else:
             base = self.base * (


### PR DESCRIPTION
## Purpose

Fixes #52665.

Dynamic NTK scaling in `dynamic_ntk_scaling_rope.py` unconditionally applies its context-extension formula even when the served `max_position_embeddings` is *below* the checkpoint's `max_trained_positions`. Reducing the served length below the trained length is ordinary truncation, not context extension, but the formula

```
inner = scaling_factor * served / trained - (scaling_factor - 1)
base = original_base * inner ** (rotary_dim / (rotary_dim - 2))
```

goes negative in that regime. Raising a negative `base` to a fractional power produces a complex result, which is then silently cast to a real dtype (discarding the imaginary part) and leaves a cache with values on the order of `1e38`. This eventually surfaces as NaN outputs.

Concretely, for `nomic-ai/nomic-embed-text-v1` served with `--max-model-len 512` and `scaling_factor=2`:

```
inner = 2 * 512 / 2048 - 1 = -0.5
base = 1000 * (-0.5) ** (64 / 62)  # complex
```

## Fix

Guard the NTK formula behind `max_position_embeddings > max_trained_positions`. At or below the trained length, the original base is used unchanged, matching plain RoPE and the reference Nomic implementation. Extension behavior above the trained length is untouched — the existing formula already evaluates to the original base at equality, so the branch boundary is continuous.

## Test Plan

Added regression tests in `tests/model_executor/layers/test_dynamic_ntk_scaling_rope.py` covering served length below/at/above the trained length, each asserting the cache matches the exact expected formula (unscaled base below/at, legacy NTK formula above).

```bash
.venv/bin/python -m pytest tests/model_executor/layers/test_dynamic_ntk_scaling_rope.py -v
# 3 passed
ruff check vllm/model_executor/layers/rotary_embedding/dynamic_ntk_scaling_rope.py tests/model_executor/layers/test_dynamic_ntk_scaling_rope.py
ruff format --check vllm/model_executor/layers/rotary_embedding/dynamic_ntk_scaling_rope.py tests/model_executor/layers/test_dynamic_ntk_scaling_rope.py
# All checks passed / already formatted
```

## Model evaluation

An end-to-end serving eval of `nomic-ai/nomic-embed-text-v1` wasn't completed: vLLM's engine bootstrap fails on this local CPU/macOS sandbox before the model loads, for reasons unrelated to this change. Verification instead relies on the regression tests above (which reproduce the exact reported symptom pre-fix and pass post-fix) and the issue's own module-level CPU repro.

## Not a duplicate

Confirmed open PR #41301 (whose actual diff is a whitespace-only change) does not fix this issue.

## AI assistance disclosure

This PR was authored with AI assistance (Claude Code). The changes were reviewed and tested as described above before submission.
