### PR TITLE
[KV Offload] Pack disk backend slots into a single flat buffer for O_DIRECT alignment

### DIFF
--- a/tests/v1/simple_kv_offload/test_disk_backend.py
+++ b/tests/v1/simple_kv_offload/test_disk_backend.py
@@ -65,25 +65,11 @@ def _wait_events(events, timeout=10.0):
     events[0][1].synchronize()
 
 
-@pytest.mark.parametrize(
-    ("direct_io_alignment", "use_page_cache", "expected_padded_total"),
-    [
-        (4096, False, 8192),
-        (512, False, 4608),
-        (4096, True, 4224),
-    ],
-)
-def test_padded_slot_round_trip_preserves_bytes(
-    tmp_path, direct_io_alignment, use_page_cache, expected_padded_total
-):
+def test_padded_slot_round_trip_preserves_bytes(tmp_path):
     """Store then load back through the padded slot path."""
-    backend, gpu = _make_disk_backend(
-        tmp_path,
-        direct_io_alignment=direct_io_alignment,
-        use_page_cache=use_page_cache,
-    )
+    backend, gpu = _make_disk_backend(tmp_path)
     try:
-        assert backend._padded_total == expected_padded_total
+        assert backend._padded_total == 8192
         assert backend._padded_total % backend._effective_alignment == 0
         assert (
             backend._store_buffer_caches["k"].data_ptr() % backend._effective_alignment

--- a/tests/v1/simple_kv_offload/test_disk_backend.py
+++ b/tests/v1/simple_kv_offload/test_disk_backend.py
@@ -1,0 +1,109 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Disk-backend unit tests for the padded-slot DMA path.
+
+Verifies that store-then-load round-trips preserve bytes when per-tensor bpb
+is not 4096-aligned, and that each slot uses a single iovec segment.
+
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+import torch
+
+from vllm.platforms import current_platform
+
+if not current_platform.is_cuda_alike():
+    pytest.skip("Requires CUDA or ROCm", allow_module_level=True)
+
+from vllm.v1.simple_kv_offload.disk_backend import DiskBackend
+
+NUM_BLOCKS = 4
+# k: 4096 bytes/block (aligned), v: 128 bytes/block (non-aligned)
+# total_bpb = 4224, padded_total = 8192 -> exercises trailing pad
+K_BPB = 4096
+V_BPB = 128
+
+
+def _make_disk_backend(tmp_path):
+    gpu = {
+        "k": torch.zeros(NUM_BLOCKS,  K_BPB, dtype=torch.int8, device="cuda"),
+        "v": torch.zeros(NUM_BLOCKS, V_BPB, dtype=torch.int8, device="cuda"),
+    }
+    low_pri, _ = torch.cuda.Stream.priority_range()
+    backend = DiskBackend()
+    backend.init(
+        gpu_caches=gpu,
+        device=gpu["k"].device,
+        load_stream=torch.cuda.Stream(priority=low_pri),
+        store_stream=torch.cuda.Stream(priority=low_pri),
+        disk_path=str(tmp_path / "disk.bin"),
+        num_disk_slots=NUM_BLOCKS,
+        num_buffer_slots=2,
+    )
+    return backend, gpu
+
+
+def _wait_events(events, timeout=10.0):
+    deadline = time.time() + timeout
+    while not events and time.time() < deadline:
+        time.sleep(0.0005)
+    assert events, "background copy was never enqueued"
+    events[0][1].synchronize()
+
+
+def test_padded_slot_round_trip_preserves_bytes(tmp_path):
+    """Store then load back through the padded slot path."""
+    backend, gpu = _make_disk_backend(tmp_path)
+    try:
+        # Fill with distinct non-zero data
+        gpu["k"].copy_(
+            torch.arange(NUM_BLOCKS * K_BPB, dtype=torch.int8)
+            .view(NUM_BLOCKS, K_BPB)
+            .cuda()
+        )
+        gpu["v"].copy_(
+            torch.arange(NUM_BLOCKS * V_BPB, dtype=torch.int8)
+            .view(NUM_BLOCKS, V_BPB)
+            .cuda()
+        )
+        expected_k = gpu["k"].clone()
+        expected_v = gpu["v"].clone()
+
+        # Store block 0 -> disk slot 0
+        store_events: list[tuple[int, torch.Event]] = []
+        backend.launch_copy(
+            src_blocks=[0],
+            dst_blocks=[0],
+            is_store=True,
+            event_idx=0,
+            events_list=store_events,
+        )
+        _wait_events(store_events)
+
+        # Zero GPU tensors to prove load copies back
+        gpu["k"].zero_()
+        gpu["v"].zero_()
+
+        # Load block 0 -> GPU slot 0
+        load_events: list[tuple[int, torch.Event]] = []
+        backend.launch_copy(
+            src_blocks=[0],
+            dst_blocks=[0],
+            is_store=False,
+            event_idx=0,
+            events_list=load_events,
+        )
+        _wait_events(load_events)
+
+        assert torch.all(gpu["k"][0] == expected_k[0])
+        assert torch.all(gpu["v"][0] == expected_v[0])
+
+        # Single iovec per slot (padded-slot invariant)
+        assert len(backend._store_slot_views[0]) == 1
+        assert len(backend._load_slot_views[0]) == 1
+    finally:
+        backend.shutdown()

--- a/tests/v1/simple_kv_offload/test_disk_backend.py
+++ b/tests/v1/simple_kv_offload/test_disk_backend.py
@@ -19,7 +19,10 @@ from vllm.platforms import current_platform
 if not current_platform.is_cuda_alike():
     pytest.skip("Requires CUDA or ROCm", allow_module_level=True)
 
-from vllm.v1.simple_kv_offload.disk_backend import DiskBackend
+from vllm.v1.simple_kv_offload.disk_backend import (
+    _DEFAULT_DIRECT_IO_ALIGNMENT,
+    DiskBackend,
+)
 
 NUM_BLOCKS = 4
 # k: 4096 bytes/block (aligned), v: 128 bytes/block (non-aligned)
@@ -28,9 +31,14 @@ K_BPB = 4096
 V_BPB = 128
 
 
-def _make_disk_backend(tmp_path):
+def _make_disk_backend(
+    tmp_path,
+    *,
+    direct_io_alignment=_DEFAULT_DIRECT_IO_ALIGNMENT,
+    use_page_cache=False,
+):
     gpu = {
-        "k": torch.zeros(NUM_BLOCKS,  K_BPB, dtype=torch.int8, device="cuda"),
+        "k": torch.zeros(NUM_BLOCKS, K_BPB, dtype=torch.int8, device="cuda"),
         "v": torch.zeros(NUM_BLOCKS, V_BPB, dtype=torch.int8, device="cuda"),
     }
     low_pri, _ = torch.cuda.Stream.priority_range()
@@ -43,6 +51,8 @@ def _make_disk_backend(tmp_path):
         disk_path=str(tmp_path / "disk.bin"),
         num_disk_slots=NUM_BLOCKS,
         num_buffer_slots=2,
+        use_page_cache=use_page_cache,
+        direct_io_alignment=direct_io_alignment,
     )
     return backend, gpu
 
@@ -55,10 +65,35 @@ def _wait_events(events, timeout=10.0):
     events[0][1].synchronize()
 
 
-def test_padded_slot_round_trip_preserves_bytes(tmp_path):
+@pytest.mark.parametrize(
+    ("direct_io_alignment", "use_page_cache", "expected_padded_total"),
+    [
+        (4096, False, 8192),
+        (512, False, 4608),
+        (4096, True, 4224),
+    ],
+)
+def test_padded_slot_round_trip_preserves_bytes(
+    tmp_path, direct_io_alignment, use_page_cache, expected_padded_total
+):
     """Store then load back through the padded slot path."""
-    backend, gpu = _make_disk_backend(tmp_path)
+    backend, gpu = _make_disk_backend(
+        tmp_path,
+        direct_io_alignment=direct_io_alignment,
+        use_page_cache=use_page_cache,
+    )
     try:
+        assert backend._padded_total == expected_padded_total
+        assert backend._padded_total % backend._effective_alignment == 0
+        assert (
+            backend._store_buffer_caches["k"].data_ptr() % backend._effective_alignment
+            == 0
+        )
+        assert (
+            backend._load_buffer_caches["k"].data_ptr() % backend._effective_alignment
+            == 0
+        )
+
         # Fill with distinct non-zero data
         gpu["k"].copy_(
             torch.arange(NUM_BLOCKS * K_BPB, dtype=torch.int8)

--- a/tests/v1/simple_kv_offload/test_disk_backend_config.py
+++ b/tests/v1/simple_kv_offload/test_disk_backend_config.py
@@ -4,10 +4,14 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pytest
 
+from vllm.distributed.kv_transfer.kv_connector.v1.base import KVConnectorRole
 from vllm.distributed.kv_transfer.kv_connector.v1.simple_cpu_offload_connector import (
     _DISK_ONLY_KEYS,
+    SimpleCPUOffloadConnector,
     _get_direct_io_alignment,
 )
 from vllm.v1.simple_kv_offload.disk_backend import (
@@ -24,11 +28,27 @@ def test_default_and_explicit_alignment():
     assert _get_direct_io_alignment({}) == _DEFAULT_DIRECT_IO_ALIGNMENT
     assert _get_direct_io_alignment({"direct_io_alignment": 3000}) == 3000
     assert get_padded_slot_size(total_bpb) == 8192
+    assert get_padded_slot_size(total_bpb, 512) == 4608
     assert get_padded_slot_size(total_bpb, 3000) == 6000
 
 
 def test_direct_io_alignment_is_disk_only():
     assert "direct_io_alignment" in _DISK_ONLY_KEYS
+
+
+def test_cpu_backend_ignores_invalid_direct_io_alignment():
+    vllm_config = SimpleNamespace(
+        cache_config=SimpleNamespace(enable_prefix_caching=False),
+        kv_transfer_config=SimpleNamespace(
+            kv_connector_extra_config={
+                "kv_offload_backend": "cpu",
+                "direct_io_alignment": 0,
+            }
+        ),
+        parallel_config=SimpleNamespace(world_size=1),
+    )
+
+    SimpleCPUOffloadConnector(vllm_config, KVConnectorRole.WORKER, None)
 
 
 @pytest.mark.parametrize("alignment", [0, -1])
@@ -56,6 +76,11 @@ def test_slot_capacity_uses_padded_size():
     assert get_num_disk_slots(capacity, total_bpb) == 1
     assert get_num_disk_slots(capacity, total_bpb) * padded_slot_size <= capacity
     assert get_num_disk_slots(capacity, total_bpb, use_page_cache=True) == 2
+
+
+def test_capacity_smaller_than_one_slot_raises():
+    with pytest.raises(ValueError, match="smaller than one disk slot"):
+        get_num_disk_slots(disk_capacity_bytes=4096, total_bpb=4224)
 
 
 def test_page_cache_mode_uses_raw_slot_size():

--- a/tests/v1/simple_kv_offload/test_disk_backend_config.py
+++ b/tests/v1/simple_kv_offload/test_disk_backend_config.py
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for disk KV offload alignment and capacity configuration."""
+
+from __future__ import annotations
+
+import pytest
+
+from vllm.distributed.kv_transfer.kv_connector.v1.simple_cpu_offload_connector import (
+    _DISK_ONLY_KEYS,
+    _get_direct_io_alignment,
+)
+from vllm.v1.simple_kv_offload.disk_backend import (
+    _DEFAULT_DIRECT_IO_ALIGNMENT,
+    _alloc_aligned,
+    get_num_disk_slots,
+    get_padded_slot_size,
+)
+
+
+def test_default_and_explicit_alignment():
+    total_bpb = 4224
+
+    assert _get_direct_io_alignment({}) == _DEFAULT_DIRECT_IO_ALIGNMENT
+    assert _get_direct_io_alignment({"direct_io_alignment": 3000}) == 3000
+    assert get_padded_slot_size(total_bpb) == 8192
+    assert get_padded_slot_size(total_bpb, 3000) == 6000
+
+
+def test_direct_io_alignment_is_disk_only():
+    assert "direct_io_alignment" in _DISK_ONLY_KEYS
+
+
+@pytest.mark.parametrize("alignment", [0, -1])
+def test_direct_io_alignment_must_be_positive(alignment):
+    with pytest.raises(ValueError, match="direct_io_alignment must be greater than 0"):
+        _get_direct_io_alignment({"direct_io_alignment": alignment})
+
+
+def test_staging_buffer_and_slot_offsets_use_selected_alignment():
+    total_bpb = 4224
+    alignment = 3000
+    padded_slot_size = get_padded_slot_size(total_bpb, alignment)
+    buffer = _alloc_aligned(2, padded_slot_size, alignment)
+
+    assert buffer.data_ptr() % alignment == 0
+    assert padded_slot_size % alignment == 0
+    assert all((slot * padded_slot_size) % alignment == 0 for slot in range(2))
+
+
+def test_slot_capacity_uses_padded_size():
+    total_bpb = 4224
+    capacity = 2 * total_bpb
+    padded_slot_size = get_padded_slot_size(total_bpb)
+
+    assert get_num_disk_slots(capacity, total_bpb) == 1
+    assert get_num_disk_slots(capacity, total_bpb) * padded_slot_size <= capacity
+    assert get_num_disk_slots(capacity, total_bpb, use_page_cache=True) == 2
+
+
+def test_page_cache_mode_uses_raw_slot_size():
+    total_bpb = 4224
+
+    assert get_padded_slot_size(total_bpb, 4096, use_page_cache=True) == total_bpb

--- a/tests/v1/simple_kv_offload/test_worker.py
+++ b/tests/v1/simple_kv_offload/test_worker.py
@@ -9,6 +9,7 @@ read partially written / stale blocks and silently corrupt the CPU cache.
 
 from __future__ import annotations
 
+import ctypes
 import time
 
 import pytest
@@ -19,11 +20,13 @@ from vllm.platforms import current_platform
 if not current_platform.is_cuda_alike():
     pytest.skip("Requires CUDA or ROCm", allow_module_level=True)
 
+import vllm.v1.simple_kv_offload.cuda_mem_ops as cuda_mem_ops
 from vllm.v1.simple_kv_offload.copy_backend import DmaCopyBackend
 from vllm.v1.simple_kv_offload.cuda_mem_ops import (
     CU_MEMCPY_SRC_ACCESS_ORDER_ANY,
     CU_MEMCPY_SRC_ACCESS_ORDER_STREAM,
     build_params,
+    copy_blocks,
     pin_tensor,
 )
 from vllm.v1.simple_kv_offload.metadata import SimpleCPUOffloadMetadata
@@ -188,3 +191,38 @@ def test_build_params_src_access_order():
         gpu, cpu, stream, src_access_order=CU_MEMCPY_SRC_ACCESS_ORDER_STREAM
     )
     assert ordered.attrs.srcAccessOrder == CU_MEMCPY_SRC_ACCESS_ORDER_STREAM
+
+
+def test_build_params_requires_explicit_copy_size_for_strided_rows():
+    """Strided disk views must provide payload sizes; normal copies must match."""
+    gpu = {"k": torch.zeros((4, 64), dtype=torch.int8, device="cuda")}
+    flat = torch.zeros((4, 128), dtype=torch.int8, device="cpu")
+    strided = {"k": flat[:, :64]}
+    stream = torch.cuda.Stream()
+
+    with pytest.raises(AssertionError, match="row strides must match"):
+        build_params(gpu, strided, stream)
+
+    params = build_params(gpu, strided, stream, copy_sizes=[64])
+    assert params.src_strides.tolist() == [64]
+    assert params.dst_strides.tolist() == [128]
+    assert params.copy_sizes.tolist() == [64]
+
+
+def test_copy_blocks_uses_explicit_payload_size(monkeypatch):
+    """Padded row strides must not change the payload copied by DMA."""
+    gpu = {"k": torch.zeros((4, 64), dtype=torch.int8, device="cuda")}
+    flat = torch.zeros((4, 128), dtype=torch.int8, device="cpu")
+    stream = torch.cuda.Stream()
+    params = build_params(gpu, {"k": flat[:, :64]}, stream, copy_sizes=[64])
+    copied_sizes = []
+
+    def record_copy(_dst, _src, sizes, count, *_args):
+        copied_sizes.extend((ctypes.c_uint64 * count).from_address(sizes))
+        return 0
+
+    monkeypatch.setattr(cuda_mem_ops, "_batch_memcpy_fn", record_copy)
+
+    copy_blocks([0, 1], [2, 3], params)
+
+    assert copied_sizes == [64, 64]

--- a/vllm/distributed/kv_transfer/kv_connector/v1/simple_cpu_offload_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/simple_cpu_offload_connector.py
@@ -18,6 +18,9 @@ from vllm.distributed.kv_transfer.kv_connector.v1.base import (
 from vllm.logger import init_logger
 from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.v1.outputs import KVConnectorOutput
+from vllm.v1.simple_kv_offload.disk_backend import (
+    _DEFAULT_DIRECT_IO_ALIGNMENT,
+)
 from vllm.v1.simple_kv_offload.manager import (
     SimpleCPUOffloadScheduler,
 )
@@ -48,7 +51,17 @@ _DISK_ONLY_KEYS = (
     "disk_capacity_bytes",
     "disk_buffer_slots",
     "use_page_cache",
+    "direct_io_alignment",
 )
+
+
+def _get_direct_io_alignment(extra_config: dict[str, Any]) -> int:
+    direct_io_alignment = int(
+        extra_config.get("direct_io_alignment", _DEFAULT_DIRECT_IO_ALIGNMENT)
+    )
+    if direct_io_alignment <= 0:
+        raise ValueError("direct_io_alignment must be greater than 0")
+    return direct_io_alignment
 
 
 class SimpleCPUOffloadConnector(KVConnectorBase_V1, SupportsHMA):
@@ -105,6 +118,7 @@ class SimpleCPUOffloadConnector(KVConnectorBase_V1, SupportsHMA):
         )
         disk_buffer_slots = max(1, int(extra_config.get("disk_buffer_slots", 2)))
         use_page_cache = bool(extra_config.get("use_page_cache", False))
+        direct_io_alignment = _get_direct_io_alignment(extra_config)
 
         if disk_mode:
             if disk_path is None:
@@ -157,6 +171,8 @@ class SimpleCPUOffloadConnector(KVConnectorBase_V1, SupportsHMA):
                 hash_block_size=hash_block_size,
                 lazy_offload=lazy_offload,
                 disk_capacity_bytes=disk_capacity_bytes if disk_mode else 0,
+                direct_io_alignment=direct_io_alignment,
+                use_page_cache=use_page_cache,
             )
         elif role == KVConnectorRole.WORKER:
             self.worker_handler = SimpleCPUOffloadWorker(
@@ -168,6 +184,7 @@ class SimpleCPUOffloadConnector(KVConnectorBase_V1, SupportsHMA):
                 disk_capacity_bytes=disk_capacity_bytes,
                 disk_buffer_slots=disk_buffer_slots,
                 use_page_cache=use_page_cache,
+                direct_io_alignment=direct_io_alignment,
             )
 
     # --- Worker-side methods ---

--- a/vllm/distributed/kv_transfer/kv_connector/v1/simple_cpu_offload_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/simple_cpu_offload_connector.py
@@ -118,9 +118,10 @@ class SimpleCPUOffloadConnector(KVConnectorBase_V1, SupportsHMA):
         )
         disk_buffer_slots = max(1, int(extra_config.get("disk_buffer_slots", 2)))
         use_page_cache = bool(extra_config.get("use_page_cache", False))
-        direct_io_alignment = _get_direct_io_alignment(extra_config)
+        direct_io_alignment = _DEFAULT_DIRECT_IO_ALIGNMENT
 
         if disk_mode:
+            direct_io_alignment = _get_direct_io_alignment(extra_config)
             if disk_path is None:
                 raise ValueError(
                     'kv_offload_backend="disk" requires disk_path to be set.'

--- a/vllm/v1/simple_kv_offload/cuda_mem_ops.py
+++ b/vllm/v1/simple_kv_offload/cuda_mem_ops.py
@@ -110,8 +110,9 @@ def _resolve_batch_memcpy():
 class BatchMemcpyParams(NamedTuple):
     src_bases: np.ndarray  # [num_layers] uint64 — data_ptr per layer
     dst_bases: np.ndarray  # [num_layers] uint64
-    src_bpb: np.ndarray  # [num_layers] uint64 - src bytes per block
-    dst_bpb: np.ndarray  # [num_layers] uint64 - dst bytes per block
+    src_strides: np.ndarray  # [num_layers] uint64 - source row strides
+    dst_strides: np.ndarray  # [num_layers] uint64 - destination row strides
+    copy_sizes: np.ndarray  # [num_layers] uint64 - logical bytes to copy
     num_layers: int
     # CUDA only: one attributes entry carrying srcAccessOrder. Unused on ROCm
     # (7.2.1 or 7.2.2) because the current runtime rejects numAttrs > 0.
@@ -128,6 +129,7 @@ def build_params(
     dst_caches: dict[str, torch.Tensor],
     stream: torch.cuda.Stream,
     src_access_order: int = CU_MEMCPY_SRC_ACCESS_ORDER_ANY,
+    copy_sizes: list[int] | None = None,
 ) -> BatchMemcpyParams:
     global _batch_memcpy_fn
     if _batch_memcpy_fn is None:
@@ -137,22 +139,37 @@ def build_params(
     src_tensors = list(src_caches.values())
     dst_tensors = list(dst_caches.values())
 
-    src_bases, dst_bases, src_bpb, dst_bpb = [], [], [], []
+    src_bases, dst_bases, src_strides, dst_strides = [], [], [], []
+    resolved_copy_sizes = []
     for s, d in zip(src_tensors, dst_tensors):
-        s_bpb = s.stride(0) * s.element_size()
-        d_bpb = d.stride(0) * d.element_size()
+        s_stride = s.stride(0) * s.element_size()
+        d_stride = d.stride(0) * d.element_size()
         src_bases.append(s.data_ptr())
         dst_bases.append(d.data_ptr())
-        src_bpb.append(s_bpb)
-        dst_bpb.append(d_bpb)
+        src_strides.append(s_stride)
+        dst_strides.append(d_stride)
+        resolved_copy_sizes.append(s_stride)
+
+    if copy_sizes is None:
+        assert src_strides == dst_strides, (
+            "source and destination row strides must match unless explicit "
+            "copy_sizes are provided"
+        )
+    else:
+        assert len(copy_sizes) == len(src_tensors)
+        for size, src_stride, dst_stride in zip(copy_sizes, src_strides, dst_strides):
+            assert 0 < size <= src_stride
+            assert size <= dst_stride
+        resolved_copy_sizes = copy_sizes
 
     attrs = _CUmemcpyAttributes(srcAccessOrder=src_access_order)
 
     return BatchMemcpyParams(
         src_bases=np.array(src_bases, dtype=np.uint64),
         dst_bases=np.array(dst_bases, dtype=np.uint64),
-        src_bpb=np.array(src_bpb, dtype=np.uint64),
-        dst_bpb=np.array(dst_bpb, dtype=np.uint64),
+        src_strides=np.array(src_strides, dtype=np.uint64),
+        dst_strides=np.array(dst_strides, dtype=np.uint64),
+        copy_sizes=np.array(resolved_copy_sizes, dtype=np.uint64),
         num_layers=len(src_tensors),
         attrs=attrs,
         attrs_idx=ctypes.c_size_t(0),
@@ -175,12 +192,12 @@ def copy_blocks(
     dst_ids = np.array(dst_block_ids, dtype=np.uint64)
 
     src_all = (
-        params.src_bases[:, None] + src_ids[None, :] * params.src_bpb[:, None]
+        params.src_bases[:, None] + src_ids[None, :] * params.src_strides[:, None]
     ).ravel()
     dst_all = (
-        params.dst_bases[:, None] + dst_ids[None, :] * params.dst_bpb[:, None]
+        params.dst_bases[:, None] + dst_ids[None, :] * params.dst_strides[:, None]
     ).ravel()
-    sz_all = np.repeat(np.minimum(params.src_bpb, params.dst_bpb), n)
+    sz_all = np.repeat(params.copy_sizes, n)
     total = n * params.num_layers
 
     # ROCm 7.2.1/7.2.2 rejects any call with numAttrs>0 (hipMemcpyBatchAsync

--- a/vllm/v1/simple_kv_offload/cuda_mem_ops.py
+++ b/vllm/v1/simple_kv_offload/cuda_mem_ops.py
@@ -110,7 +110,8 @@ def _resolve_batch_memcpy():
 class BatchMemcpyParams(NamedTuple):
     src_bases: np.ndarray  # [num_layers] uint64 — data_ptr per layer
     dst_bases: np.ndarray  # [num_layers] uint64
-    bpb: np.ndarray  # [num_layers] uint64 — bytes per block
+    src_bpb: np.ndarray  # [num_layers] uint64 - src bytes per block
+    dst_bpb: np.ndarray  # [num_layers] uint64 - dst bytes per block
     num_layers: int
     # CUDA only: one attributes entry carrying srcAccessOrder. Unused on ROCm
     # (7.2.1 or 7.2.2) because the current runtime rejects numAttrs > 0.
@@ -136,20 +137,22 @@ def build_params(
     src_tensors = list(src_caches.values())
     dst_tensors = list(dst_caches.values())
 
-    src_bases, dst_bases, bpb = [], [], []
+    src_bases, dst_bases, src_bpb, dst_bpb = [], [], [], []
     for s, d in zip(src_tensors, dst_tensors):
         s_bpb = s.stride(0) * s.element_size()
-        assert s_bpb == d.stride(0) * d.element_size()
+        d_bpb = d.stride(0) * d.element_size()
         src_bases.append(s.data_ptr())
         dst_bases.append(d.data_ptr())
-        bpb.append(s_bpb)
+        src_bpb.append(s_bpb)
+        dst_bpb.append(d_bpb)
 
     attrs = _CUmemcpyAttributes(srcAccessOrder=src_access_order)
 
     return BatchMemcpyParams(
         src_bases=np.array(src_bases, dtype=np.uint64),
         dst_bases=np.array(dst_bases, dtype=np.uint64),
-        bpb=np.array(bpb, dtype=np.uint64),
+        src_bpb=np.array(src_bpb, dtype=np.uint64),
+        dst_bpb=np.array(dst_bpb, dtype=np.uint64),
         num_layers=len(src_tensors),
         attrs=attrs,
         attrs_idx=ctypes.c_size_t(0),
@@ -172,12 +175,12 @@ def copy_blocks(
     dst_ids = np.array(dst_block_ids, dtype=np.uint64)
 
     src_all = (
-        params.src_bases[:, None] + src_ids[None, :] * params.bpb[:, None]
+        params.src_bases[:, None] + src_ids[None, :] * params.src_bpb[:, None]
     ).ravel()
     dst_all = (
-        params.dst_bases[:, None] + dst_ids[None, :] * params.bpb[:, None]
+        params.dst_bases[:, None] + dst_ids[None, :] * params.dst_bpb[:, None]
     ).ravel()
-    sz_all = np.repeat(params.bpb, n)
+    sz_all = np.repeat(np.minimum(params.src_bpb, params.dst_bpb), n)
     total = n * params.num_layers
 
     # ROCm 7.2.1/7.2.2 rejects any call with numAttrs>0 (hipMemcpyBatchAsync

--- a/vllm/v1/simple_kv_offload/disk_backend.py
+++ b/vllm/v1/simple_kv_offload/disk_backend.py
@@ -2,6 +2,10 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Disk I/O backend for GPU<->NVMe block transfers via pinned staging buffers.
 
+Each slot is one flat buffer holding all tensors back-to-back. The total 
+bytes per block is rounded up to 4096 for O_DIRECT (the default path); the 
+page-cache path doesn't need alignment but inherits the rounding.
+
 Uses separate IO threads for store and load so that loads (latency-critical)
 never block behind stores (background work). Each thread owns its own pinned
 staging buffers to avoid contention.
@@ -40,6 +44,8 @@ def _alloc_aligned(num_slots: int, bpb: int) -> torch.Tensor:
     one alignment unit and return an aligned view. The view keeps the backing
     storage alive.
     """
+    # Must stay zero-initialized: pad bytes are written to disk via pwritev.
+    # torch.empty would leak adjacent tensor data through the pad.
     nbytes = num_slots * bpb
     raw = torch.zeros(nbytes + _ALIGNMENT, dtype=torch.int8, device="cpu")
     offset = -raw.data_ptr() % _ALIGNMENT
@@ -77,6 +83,8 @@ class DiskBackend:
         self._load_slot_views: list[list[memoryview]] = []
         self._per_tensor_bpb: list[int] = []
         self._tensor_names: list[str] = []
+        self._tensor_offsets: list[int] = []
+        self._padded_total: int = 0
 
     def init(
         self,
@@ -86,49 +94,49 @@ class DiskBackend:
         store_stream: torch.cuda.Stream,
         disk_path: str,
         num_disk_slots: int,
-        total_block_bytes: int,
         num_buffer_slots: int = 2,
         use_page_cache: bool = False,
     ) -> None:
         self._load_stream = load_stream
         self._store_stream = store_stream
-        self._total_block_bytes = total_block_bytes
         self._num_buffer_slots = num_buffer_slots
         self._tensor_names = list(gpu_caches.keys())
         self._per_tensor_bpb = [
             t.stride(0) * t.element_size() for t in gpu_caches.values()
         ]
 
-        assert total_block_bytes % _ALIGNMENT == 0, (
-            f"total_block_bytes={total_block_bytes} not aligned to {_ALIGNMENT}"
-        )
+        total_bpb = sum(self._per_tensor_bpb)
+        self._padded_total = (total_bpb + _ALIGNMENT - 1) & ~(_ALIGNMENT - 1)
+        self._total_block_bytes = self._padded_total
 
-        # Separate buffer pools for store and load threads
+        self._tensor_offsets = []
+        cum = 0
+        for bpb in self._per_tensor_bpb:
+            self._tensor_offsets.append(cum)
+            cum += bpb
+
+        store_flat = _alloc_aligned(num_buffer_slots, self._padded_total)
+        pin_tensor(store_flat)
+        load_flat = _alloc_aligned(num_buffer_slots, self._padded_total)
+        pin_tensor(load_flat)
+
+        # Non-contiguous views: stride(0) = padded_total > bpb, so build_params 
+        # reports dst_bpb = padded_total. copy_blocks transfers min(src_bpb, 
+        # dst_bpb) = real_bpb bytes - only real data, not the trailing pad.
         self._store_buffer_caches = {}
         self._load_buffer_caches = {}
-        for name, gpu_t in gpu_caches.items():
-            bpb = gpu_t.stride(0) * gpu_t.element_size()
-            store_buf = _alloc_aligned(num_buffer_slots, bpb)
-            pin_tensor(store_buf)
-            self._store_buffer_caches[name] = store_buf
-            load_buf = _alloc_aligned(num_buffer_slots, bpb)
-            pin_tensor(load_buf)
-            self._load_buffer_caches[name] = load_buf
+        for i, name in enumerate(self._tensor_names):
+            off = self._tensor_offsets[i]
+            bpb = self._per_tensor_bpb[i]
+            self._store_buffer_caches[name] = store_flat[:, off : off + bpb]
+            self._load_buffer_caches[name] = load_flat[:, off : off + bpb]
 
-        # Pre-built iovec views per slot (avoid per-transfer .numpy() calls)
+        # One iovec segment per slot
         self._store_slot_views = [
-            [
-                memoryview(self._store_buffer_caches[name][slot].numpy())
-                for name in self._tensor_names
-            ]
-            for slot in range(num_buffer_slots)
+            [memoryview(store_flat[slot].numpy())] for slot in range(num_buffer_slots)
         ]
         self._load_slot_views = [
-            [
-                memoryview(self._load_buffer_caches[name][slot].numpy())
-                for name in self._tensor_names
-            ]
-            for slot in range(num_buffer_slots)
+            [memoryview(load_flat[slot].numpy())] for slot in range(num_buffer_slots)
         ]
 
         self._store_params = build_params(
@@ -157,16 +165,18 @@ class DiskBackend:
             flags |= O_DIRECT
         self._fd = os.open(disk_path, flags, 0o600)
         self._disk_path = disk_path
-        os.ftruncate(self._fd, num_disk_slots * total_block_bytes)
+        # ftruncate uses padded_total; the file may exceed the raw slot sum
+        # by up to num_disk_slots * (_ALIGNMENT - 1).
+        os.ftruncate(self._fd, num_disk_slots * self._padded_total)
 
         logger.info(
-            "DiskBackend: path=%s, slots=%d, total=%.2f GB, buf=%dx%d bytes"
-            " (page_cache=%s)",
+            "DiskBackend: path=%s, slots=%d, total=%.2f GB, "
+            "buf=%dx%d bytes (page_cache=%s)",
             disk_path,
             num_disk_slots,
-            (num_disk_slots * total_block_bytes) / (1024**3),
+            (num_disk_slots * self._padded_total) / (1024**3),
             num_buffer_slots,
-            total_block_bytes,
+            self._padded_total,
             use_page_cache,
         )
 

--- a/vllm/v1/simple_kv_offload/disk_backend.py
+++ b/vllm/v1/simple_kv_offload/disk_backend.py
@@ -63,7 +63,13 @@ def get_num_disk_slots(
     padded_slot_size = get_padded_slot_size(
         total_bpb, direct_io_alignment, use_page_cache
     )
-    return max(1, disk_capacity_bytes // padded_slot_size)
+    num_slots = disk_capacity_bytes // padded_slot_size
+    if num_slots < 1:
+        raise ValueError(
+            f"disk_capacity_bytes={disk_capacity_bytes} is smaller than one "
+            f"disk slot ({padded_slot_size} bytes)"
+        )
+    return num_slots
 
 
 def _alloc_aligned(num_slots: int, bpb: int, alignment: int) -> torch.Tensor:
@@ -167,8 +173,7 @@ class DiskBackend:
         pin_tensor(load_flat)
 
         # Non-contiguous views: stride(0) = padded_total > bpb, so build_params
-        # reports dst_bpb = padded_total. copy_blocks transfers min(src_bpb,
-        # dst_bpb) = real_bpb bytes - only real data, not the trailing pad.
+        # uses the padded stride for addressing and the real bpb for copying.
         self._store_buffer_caches = {}
         self._load_buffer_caches = {}
         for i, name in enumerate(self._tensor_names):
@@ -190,12 +195,14 @@ class DiskBackend:
             self._store_buffer_caches,
             store_stream,
             src_access_order=CU_MEMCPY_SRC_ACCESS_ORDER_STREAM,
+            copy_sizes=self._per_tensor_bpb,
         )
         self._load_params = build_params(
             self._load_buffer_caches,
             gpu_caches,
             load_stream,
             src_access_order=CU_MEMCPY_SRC_ACCESS_ORDER_ANY,
+            copy_sizes=self._per_tensor_bpb,
         )
 
         os.makedirs(os.path.dirname(disk_path) or ".", exist_ok=True)

--- a/vllm/v1/simple_kv_offload/disk_backend.py
+++ b/vllm/v1/simple_kv_offload/disk_backend.py
@@ -2,9 +2,9 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Disk I/O backend for GPU<->NVMe block transfers via pinned staging buffers.
 
-Each slot is one flat buffer holding all tensors back-to-back. The total 
-bytes per block is rounded up to 4096 for O_DIRECT (the default path); the 
-page-cache path doesn't need alignment but inherits the rounding.
+Each slot is one flat buffer holding all tensors back-to-back. The disk
+backend uses a configurable direct-I/O alignment, with 4096 bytes as the
+default. Page-cache mode uses the raw packed block size.
 
 Uses separate IO threads for store and load so that loads (latency-critical)
 never block behind stores (background work). Each thread owns its own pinned
@@ -34,11 +34,40 @@ from vllm.v1.simple_kv_offload.cuda_mem_ops import (
 logger = init_logger(__name__)
 
 O_DIRECT = getattr(os, "O_DIRECT", 0)
-_ALIGNMENT = 4096
+_DEFAULT_DIRECT_IO_ALIGNMENT = 4096
 
 
-def _alloc_aligned(num_slots: int, bpb: int) -> torch.Tensor:
-    """Allocate a staging buffer whose base address is O_DIRECT aligned.
+def _align_up(value: int, alignment: int) -> int:
+    return ((value + alignment - 1) // alignment) * alignment
+
+
+def get_padded_slot_size(
+    total_bpb: int,
+    direct_io_alignment: int = _DEFAULT_DIRECT_IO_ALIGNMENT,
+    use_page_cache: bool = False,
+) -> int:
+    """Return the on-disk slot size for a packed KV block."""
+    if direct_io_alignment <= 0:
+        raise ValueError("direct_io_alignment must be greater than 0")
+    effective_alignment = 1 if use_page_cache else direct_io_alignment
+    return _align_up(total_bpb, effective_alignment)
+
+
+def get_num_disk_slots(
+    disk_capacity_bytes: int,
+    total_bpb: int,
+    direct_io_alignment: int = _DEFAULT_DIRECT_IO_ALIGNMENT,
+    use_page_cache: bool = False,
+) -> int:
+    """Return the number of slots that fit in the configured capacity."""
+    padded_slot_size = get_padded_slot_size(
+        total_bpb, direct_io_alignment, use_page_cache
+    )
+    return max(1, disk_capacity_bytes // padded_slot_size)
+
+
+def _alloc_aligned(num_slots: int, bpb: int, alignment: int) -> torch.Tensor:
+    """Allocate a staging buffer whose base address meets ``alignment``.
 
     The CPU allocator only guarantees 64-byte alignment, so over-allocate by
     one alignment unit and return an aligned view. The view keeps the backing
@@ -47,8 +76,8 @@ def _alloc_aligned(num_slots: int, bpb: int) -> torch.Tensor:
     # Must stay zero-initialized: pad bytes are written to disk via pwritev.
     # torch.empty would leak adjacent tensor data through the pad.
     nbytes = num_slots * bpb
-    raw = torch.zeros(nbytes + _ALIGNMENT, dtype=torch.int8, device="cpu")
-    offset = -raw.data_ptr() % _ALIGNMENT
+    raw = torch.zeros(nbytes + alignment, dtype=torch.int8, device="cpu")
+    offset = -raw.data_ptr() % alignment
     return raw[offset : offset + nbytes].view(num_slots, bpb)
 
 
@@ -85,6 +114,8 @@ class DiskBackend:
         self._tensor_names: list[str] = []
         self._tensor_offsets: list[int] = []
         self._padded_total: int = 0
+        self._direct_io_alignment: int = _DEFAULT_DIRECT_IO_ALIGNMENT
+        self._effective_alignment: int = _DEFAULT_DIRECT_IO_ALIGNMENT
 
     def init(
         self,
@@ -96,7 +127,10 @@ class DiskBackend:
         num_disk_slots: int,
         num_buffer_slots: int = 2,
         use_page_cache: bool = False,
+        direct_io_alignment: int = _DEFAULT_DIRECT_IO_ALIGNMENT,
     ) -> None:
+        self._direct_io_alignment = direct_io_alignment
+        self._effective_alignment = 1 if use_page_cache else direct_io_alignment
         self._load_stream = load_stream
         self._store_stream = store_stream
         self._num_buffer_slots = num_buffer_slots
@@ -106,7 +140,11 @@ class DiskBackend:
         ]
 
         total_bpb = sum(self._per_tensor_bpb)
-        self._padded_total = (total_bpb + _ALIGNMENT - 1) & ~(_ALIGNMENT - 1)
+        self._padded_total = get_padded_slot_size(
+            total_bpb,
+            direct_io_alignment,
+            use_page_cache,
+        )
         self._total_block_bytes = self._padded_total
 
         self._tensor_offsets = []
@@ -115,13 +153,21 @@ class DiskBackend:
             self._tensor_offsets.append(cum)
             cum += bpb
 
-        store_flat = _alloc_aligned(num_buffer_slots, self._padded_total)
+        store_flat = _alloc_aligned(
+            num_buffer_slots,
+            self._padded_total,
+            self._effective_alignment,
+        )
         pin_tensor(store_flat)
-        load_flat = _alloc_aligned(num_buffer_slots, self._padded_total)
+        load_flat = _alloc_aligned(
+            num_buffer_slots,
+            self._padded_total,
+            self._effective_alignment,
+        )
         pin_tensor(load_flat)
 
-        # Non-contiguous views: stride(0) = padded_total > bpb, so build_params 
-        # reports dst_bpb = padded_total. copy_blocks transfers min(src_bpb, 
+        # Non-contiguous views: stride(0) = padded_total > bpb, so build_params
+        # reports dst_bpb = padded_total. copy_blocks transfers min(src_bpb,
         # dst_bpb) = real_bpb bytes - only real data, not the trailing pad.
         self._store_buffer_caches = {}
         self._load_buffer_caches = {}
@@ -165,8 +211,7 @@ class DiskBackend:
             flags |= O_DIRECT
         self._fd = os.open(disk_path, flags, 0o600)
         self._disk_path = disk_path
-        # ftruncate uses padded_total; the file may exceed the raw slot sum
-        # by up to num_disk_slots * (_ALIGNMENT - 1).
+        # ftruncate uses the padded slot size.
         os.ftruncate(self._fd, num_disk_slots * self._padded_total)
 
         logger.info(

--- a/vllm/v1/simple_kv_offload/manager.py
+++ b/vllm/v1/simple_kv_offload/manager.py
@@ -24,6 +24,10 @@ from vllm.v1.kv_cache_interface import (
     SlidingWindowSpec,
 )
 from vllm.v1.outputs import KVConnectorOutput
+from vllm.v1.simple_kv_offload.disk_backend import (
+    _DEFAULT_DIRECT_IO_ALIGNMENT,
+    get_num_disk_slots,
+)
 from vllm.v1.simple_kv_offload.metadata import (
     SimpleCPUOffloadMetadata,
     SimpleCPUOffloadWorkerMetadata,
@@ -76,6 +80,8 @@ class SimpleCPUOffloadScheduler:
         hash_block_size: int,
         lazy_offload: bool = False,
         disk_capacity_bytes: int = 0,
+        direct_io_alignment: int = _DEFAULT_DIRECT_IO_ALIGNMENT,
+        use_page_cache: bool = False,
     ):
         self.vllm_config = vllm_config
         self.kv_cache_config = kv_cache_config
@@ -83,6 +89,24 @@ class SimpleCPUOffloadScheduler:
         offload_capacity = (
             disk_capacity_bytes if disk_capacity_bytes > 0 else cpu_capacity_bytes
         )
+        if disk_capacity_bytes > 0:
+            assert kv_cache_config is not None
+            is_packed = any(
+                tensor.block_stride for tensor in kv_cache_config.kv_cache_tensors
+            )
+            gpu_total_bytes = (
+                kv_cache_config.kv_cache_tensors[0].size
+                if is_packed
+                else sum(tensor.size for tensor in kv_cache_config.kv_cache_tensors)
+            )
+            total_bytes_per_block = gpu_total_bytes // kv_cache_config.num_blocks
+            num_disk_slots = get_num_disk_slots(
+                disk_capacity_bytes,
+                total_bytes_per_block,
+                direct_io_alignment,
+                use_page_cache,
+            )
+            offload_capacity = num_disk_slots * total_bytes_per_block
         self.enable_kv_cache_events = (
             vllm_config.kv_events_config is not None
             and vllm_config.kv_events_config.enable_kv_cache_events

--- a/vllm/v1/simple_kv_offload/worker.py
+++ b/vllm/v1/simple_kv_offload/worker.py
@@ -194,7 +194,6 @@ class SimpleCPUOffloadWorker:
             self.store_stream,
             rank_path,
             num_disk_slots,
-            total_bytes_per_block,
             self.disk_buffer_slots,
             self.use_page_cache,
         )

--- a/vllm/v1/simple_kv_offload/worker.py
+++ b/vllm/v1/simple_kv_offload/worker.py
@@ -11,7 +11,12 @@ from vllm.logger import init_logger
 from vllm.utils.torch_utils import PIN_MEMORY
 from vllm.v1.simple_kv_offload.copy_backend import DmaCopyBackend
 from vllm.v1.simple_kv_offload.cuda_mem_ops import pin_tensor
-from vllm.v1.simple_kv_offload.disk_backend import DiskBackend
+from vllm.v1.simple_kv_offload.disk_backend import (
+    _DEFAULT_DIRECT_IO_ALIGNMENT,
+    DiskBackend,
+    get_num_disk_slots,
+    get_padded_slot_size,
+)
 from vllm.v1.simple_kv_offload.metadata import (
     SimpleCPUOffloadMetadata,
     SimpleCPUOffloadWorkerMetadata,
@@ -36,6 +41,7 @@ class SimpleCPUOffloadWorker:
         disk_capacity_bytes: int = 0,
         disk_buffer_slots: int = 2,
         use_page_cache: bool = False,
+        direct_io_alignment: int = _DEFAULT_DIRECT_IO_ALIGNMENT,
     ):
         self.vllm_config = vllm_config
         self.kv_cache_config = kv_cache_config
@@ -44,6 +50,7 @@ class SimpleCPUOffloadWorker:
         self.disk_capacity_bytes = disk_capacity_bytes
         self.disk_buffer_slots = disk_buffer_slots
         self.use_page_cache = use_page_cache
+        self.direct_io_alignment = direct_io_alignment
         self.disk_mode = kv_offload_backend == "disk"
 
         self.gpu_kv_caches: dict[str, torch.Tensor] | None = None
@@ -174,14 +181,24 @@ class SimpleCPUOffloadWorker:
         total_bytes_per_block: int,
         device: torch.device,
     ) -> None:
-        num_disk_slots = max(1, self.disk_capacity_bytes // total_bytes_per_block)
+        padded_block_bytes = get_padded_slot_size(
+            total_bytes_per_block,
+            self.direct_io_alignment,
+            self.use_page_cache,
+        )
+        num_disk_slots = get_num_disk_slots(
+            self.disk_capacity_bytes,
+            total_bytes_per_block,
+            self.direct_io_alignment,
+            self.use_page_cache,
+        )
         self.num_cpu_blocks = num_disk_slots
 
         logger.info(
             "SimpleCPUOffloadWorker [DISK]: %d tensors, %d disk slots (%.2f GB)",
             len(unique_gpu_caches),
             num_disk_slots,
-            (num_disk_slots * total_bytes_per_block) / (1024**3),
+            (num_disk_slots * padded_block_bytes) / (1024**3),
         )
 
         assert self.disk_path is not None
@@ -196,6 +213,7 @@ class SimpleCPUOffloadWorker:
             num_disk_slots,
             self.disk_buffer_slots,
             self.use_page_cache,
+            self.direct_io_alignment,
         )
 
     def _init_cpu_mode(


### PR DESCRIPTION
## Context

The disk KV offload backend uses O_DIRECT, which requires direct-I/O buffers, offsets, and transfer sizes to satisfy the underlying filesystem/device alignment requirements. The existing implementation aligned the base staging allocations, but individual per-tensor block views could still be misaligned when their bytes-per-block were not alignment-sized. This could cause O_DIRECT reads/writes to fail on some systems.

This PR fixes that by packing each KV block into a single aligned, padded staging slot, so every disk transfer has an aligned buffer, offset, and length regardless of the individual tensor sizes.

## Purpose

Improve disk-backed KV cache offloading by packing each KV block into one disk slot. This reduces each disk transfer to a single iovec while preserving the existing asynchronous GPU-to-disk transfer flow.

This PR:

- packs KV tensors back-to-back in a shared per-slot staging buffer;
- computes slot padding and disk capacity from the complete packed KV block;
- supports a configurable direct-I/O alignment through `kv_connector_extra_config.direct_io_alignment`, defaulting to 4096 bytes;
- keeps page-cache mode unpadded, because it does not require direct-I/O alignment; and
- copies only KV payload bytes between GPU memory and the staging buffer, while retaining zero-initialized trailing padding for disk I/O.

For the disk backend, configure the alignment alongside the existing disk settings:

```json
{
  "kv_connector": "SimpleCPUOffloadConnector",
  "kv_role": "kv_both",
  "kv_connector_extra_config": {
    "kv_offload_backend": "disk",
    "disk_path": "/mnt/nvme/kv-cache",
    "disk_capacity_bytes": 107374182400,
    "direct_io_alignment": 4096
  }
}
```

## Test Plan

```bash
.venv/bin/python -m pytest tests/v1/simple_kv_offload/test_disk_backend_config.py -v
.venv/bin/python -m pytest tests/v1/simple_kv_offload/test_disk_backend.py -v
.venv/bin/python -m pytest tests/v1/simple_kv_offload/test_worker.py -v
```

## Validation

The focused coverage exercises configurable slot alignment, padded-capacity accounting, page-cache sizing, single-iovec transfers, and store/load round trips. Model evaluation is not applicable because this change affects KV offload storage and transfer mechanics rather than model output.