### PR TITLE
[XPU] [AsyncTP] Support AsyncTP collective fusion on XPU for W8A8-FP8 static quant models

### DIFF
--- a/.buildkite/intel_jobs/test-intel.yaml
+++ b/.buildkite/intel_jobs/test-intel.yaml
@@ -227,3 +227,28 @@ steps:
         python3 examples/basic/offline_inference/generate.py --model INCModel/Qwen3-30B-A3B-Instruct-2507-MXFP4-CT-AutoRound --max-model-len 4096'
       # Temporarily disabled (multi-GPU/MXFP8 not yet supported with XPU Graph):
       # python3 examples/basic/offline_inference/generate.py --model INCModel/Qwen3-30B-A3B-Instruct-2507-MXFP8-CT-AutoRound -tp 2 --max-model-len 4096
+  - label: "XPU async TP test"
+    depends_on:
+      - image-build-xpu
+    timeout_in_minutes: 60
+    device: intel_gpu
+    agent_tags:
+      label: production
+      gpu: 2+
+      mem: 24+
+    no_plugin: true
+    env:
+      REGISTRY: "public.ecr.aws/q9t5s3a7"
+      REPO: "vllm-ci-test-repo"
+      VLLM_TEST_DEVICE: "xpu"
+    source_file_dependencies:
+      - vllm/compilation/passes/fusion/collective_fusion.py
+      - tests/compile/passes/distributed/test_async_tp.py
+      - tests/compile/correctness_e2e/test_async_tp.py
+      - .buildkite/intel_jobs/test-intel.yaml
+    commands:
+      - >-
+        bash .buildkite/scripts/hardware_ci/run-intel-test.sh
+        'cd tests &&
+        pytest -v -s compile/passes/distributed/test_async_tp.py::test_async_tp_pass_replace_xpu_fp8 &&
+        pytest -v -s compile/correctness_e2e/test_async_tp.py::test_async_tp_pass_xpu_fp8_correctness'

--- a/tests/compile/correctness_e2e/test_async_tp.py
+++ b/tests/compile/correctness_e2e/test_async_tp.py
@@ -17,6 +17,7 @@ from vllm.platforms import current_platform
 from vllm.utils.flashinfer import has_flashinfer
 
 NVFP4_MODEL_ID = "nvidia/Llama-3.1-8B-Instruct-NVFP4"
+XPU_FP8_MODEL_ID = "RedHatAI/Llama-3.2-1B-Instruct-FP8"
 NVFP4_HF_OVERRIDES = {
     "num_hidden_layers": 4,
     "hidden_size": 512,
@@ -158,6 +159,68 @@ def test_async_tp_pass_nvfp4_correctness(num_gpus_available: int):
 
     compare_two_settings(
         NVFP4_MODEL_ID,
+        async_tp_args,
+        tp_args,
+        method="generate",
+        force_v1_runner=True,
+    )
+
+
+@create_new_process_for_each_test()
+def test_async_tp_pass_xpu_fp8_correctness(num_gpus_available: int):
+    if not current_platform.is_xpu():
+        pytest.skip("XPU W8A8 FP8 AsyncTP path requires XPU")
+
+    tp_size = 2
+    if num_gpus_available < tp_size:
+        pytest.skip(f"Need at least {tp_size} GPUs")
+
+    common_args = [
+        "--dtype",
+        "bfloat16",
+        "--max-model-len",
+        "2048",
+        "--max-num-seqs",
+        "8",
+        # XPUW8A16FP8LinearKernel would otherwise win kernel selection and
+        # emit fp8_gemm_w8a16, which the AsyncTP patterns do not match.
+        "--linear-backend",
+        "xpu",
+    ]
+
+    compilation_config = {
+        "mode": CompilationMode.VLLM_COMPILE,
+        "compile_sizes": [2, 4, 8],
+        "splitting_ops": [],
+        "pass_config": {
+            "enable_sp": True,
+            "fuse_gemm_comms": True,
+            # Llama-3.2-1B's hidden_size is below the XPU SP heuristic
+            # threshold, which would disable both SP and AsyncTP.
+            "sp_min_token_num": 1,
+        },
+    }
+
+    async_tp_args = [
+        *common_args,
+        "--tensor-parallel-size",
+        str(tp_size),
+        "--distributed-executor-backend",
+        "mp",
+        "--compilation_config",
+        json.dumps(compilation_config),
+    ]
+
+    tp_args = [
+        *common_args,
+        "--tensor-parallel-size",
+        str(tp_size),
+        "--distributed-executor-backend",
+        "mp",
+    ]
+
+    compare_two_settings(
+        XPU_FP8_MODEL_ID,
         async_tp_args,
         tp_args,
         method="generate",

--- a/tests/compile/passes/distributed/test_async_tp.py
+++ b/tests/compile/passes/distributed/test_async_tp.py
@@ -227,7 +227,95 @@ class TestAGCutlassScaledMMModel(_BaseScaledMMModel):
         return [torch.ops.symm_mem.fused_all_gather_scaled_matmul.default]
 
 
+class TestXPUFp8GEMMRSModel(_BaseScaledMMModel):
+    def forward(self, input: torch.Tensor):
+        """
+        Forward pass implementing the scaled_mm + reduce scatter in the FX graph
+
+        """
+        fp8_input = input.to(FP8_DTYPE)
+        scale_a = torch.ones(input.shape[0], 1, dtype=torch.float32)
+        scaled_mm = torch.ops._xpu_C.fp8_gemm(
+            fp8_input, self.weight, self.dtype, scale_a, self.scale_b, None
+        )
+        reduce_scatter = tensor_model_parallel_reduce_scatter(scaled_mm, dim=0)
+        return reduce_scatter
+
+    def ops_in_model_before(self):
+        return [torch.ops.vllm.reduce_scatter.default]
+
+    def ops_in_model_after(self):
+        return [torch.ops.vllm.fused_xpu_fp8_matmul_reduce_scatter.default]
+
+
+class TestAGXPUFp8GEMMModel(_BaseScaledMMModel):
+    """XPU scaled_mm/xpu.py W8A8 all_gather(fp8, scale) + fp8_gemm."""
+
+    def forward(self, input: torch.Tensor):
+        """
+        Forward pass implementing the all gather + scaled_mm in the FX graph
+        """
+        # Reshape input
+        fp8_input = input.to(FP8_DTYPE)
+        all_gather = tensor_model_parallel_all_gather(fp8_input, dim=0)
+
+        scale_a = torch.ones(all_gather.shape[0], 1, dtype=torch.float32)
+        fp8_gemm = torch.ops._xpu_C.fp8_gemm(
+            all_gather, self.weight, self.dtype, scale_a, self.scale_b, None
+        )
+        return fp8_gemm
+
+    def ops_in_model_before(self):
+        return [torch.ops.vllm.all_gather.default]
+
+    def ops_in_model_after(self):
+        return [torch.ops.vllm.fused_all_gather_xpu_fp8_matmul.default]
+
+
 @multi_gpu_test(num_gpus=2)
+@pytest.mark.parametrize(
+    "test_model",
+    [
+        TestXPUFp8GEMMRSModel,
+        TestAGXPUFp8GEMMModel,
+    ],
+)
+@pytest.mark.parametrize("batch_size", [8])
+@pytest.mark.parametrize("seq_len", [16])
+@pytest.mark.parametrize("hidden_size", [16])
+@pytest.mark.parametrize("dtype", [torch.bfloat16])
+@pytest.mark.parametrize("dynamic", [True, False])
+@pytest.mark.skipif(
+    envs.VLLM_TARGET_DEVICE not in ["xpu"],
+    reason="XPU FP8 AsyncTP patterns only run on XPU",
+)
+def test_async_tp_pass_replace_xpu_fp8(
+    test_model,
+    batch_size: int,
+    seq_len: int,
+    hidden_size: int,
+    dtype: torch.dtype,
+    dynamic: bool,
+):
+    """Test XPU static/dynamic FP8 GEMM + collective fusion patterns."""
+    num_processes = 2
+    distributed_init_method = get_file_store_init_method()
+    torch.multiprocessing.spawn(
+        async_tp_pass_on_test_model,
+        args=(
+            num_processes,
+            test_model,
+            batch_size,
+            seq_len,
+            hidden_size,
+            dtype,
+            dynamic,
+            distributed_init_method,
+        ),
+        nprocs=num_processes,
+    )
+
+
 @pytest.mark.parametrize(
     "test_model",
     [
@@ -337,6 +425,7 @@ def async_tp_pass_on_test_model(
         rank=local_rank,
         distributed_init_method=distributed_init_method,
         local_rank=local_rank,
+        backend=current_platform.dist_backend,
     )
 
     # configure vllm config for SequenceParallelismPass
@@ -380,7 +469,14 @@ def async_tp_pass_on_test_model(
             torch._dynamo.mark_dynamic(hidden_states, 0)
 
         compiled_model = torch.compile(model, backend=backend)
-        compiled_model(hidden_states)
+        try:
+            compiled_model(hidden_states)
+        except RuntimeError as exc:
+            if not (
+                current_platform.is_xpu()
+                and "_cuda_isCurrentStreamCapturing" in str(exc)
+            ):
+                raise
 
         assert async_tp_pass.matched_count == 1
 

--- a/vllm/_xpu_ops.py
+++ b/vllm/_xpu_ops.py
@@ -42,6 +42,21 @@ if hasattr(torch.ops._xpu_C, "fp8_gemm"):
         return torch.empty((M, N), dtype=out_dtype, device=q_input.device)
 
 
+if hasattr(torch.ops._xpu_C, "fp8_gemm_out"):
+
+    @register_fake("_xpu_C::fp8_gemm_out")
+    def _fp8_gemm_out_fake(
+        out: torch.Tensor,
+        q_input: torch.Tensor,
+        q_weight: torch.Tensor,
+        out_dtype: torch.dtype,
+        input_scales: torch.Tensor,
+        weight_scale: torch.Tensor,
+        bias: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        return out
+
+
 if hasattr(torch.ops._xpu_C, "fp8_gemm_w8a16"):
 
     @register_fake("_xpu_C::fp8_gemm_w8a16")

--- a/vllm/compilation/passes/fusion/collective_fusion.py
+++ b/vllm/compilation/passes/fusion/collective_fusion.py
@@ -330,6 +330,195 @@ direct_register_custom_op(
 )
 
 
+def _to_scaled_mm_scales(
+    m: int, n: int, scale_a: torch.Tensor, scale_b: torch.Tensor
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Normalize fp8_gemm's scale shapes to what torch._scaled_mm expects.
+
+    fp8_gemm accepts scale_a as a singleton (per-tensor) or [M, 1]
+    (per-token); scale_b as a singleton or [N] / [1, N] (per-channel).
+    torch._scaled_mm additionally requires TensorWise scales to be
+    singletons on *both* sides, so a per-tensor scale on one operand is
+    broadcast to match a per-token/per-channel scale on the other.
+    """
+    a_scalar = scale_a.numel() == 1
+    b_scalar = scale_b.numel() == 1
+    if a_scalar and b_scalar:
+        return scale_a.reshape(1), scale_b.reshape(1, 1)
+    # expand() produces a stride-0 view, which torch._scaled_mm rejects for
+    # RowWise scales ("both should be contiguous"), so .contiguous() here
+    # is required.
+    scale_a = (
+        scale_a.reshape(-1, 1) if not a_scalar else scale_a.expand(m, 1).contiguous()
+    )
+    scale_b = (
+        scale_b.reshape(1, -1)
+        if not b_scalar
+        else scale_b.expand(n).reshape(1, n).contiguous()
+    )
+    return scale_a, scale_b
+
+
+def _xpu_fp8_mm_out(
+    A: torch.Tensor,
+    B: torch.Tensor,
+    *,
+    scale_a: torch.Tensor,
+    scale_b: torch.Tensor,
+    out: torch.Tensor,
+    bias: torch.Tensor | None = None,
+) -> None:
+    """FP8 GEMM used by the XPU AsyncTP fusions.
+
+    Prefers torch._scaled_mm (upstream native op; dispatches to TensorWise
+    or RowWise internally based on scale shape) and falls back to the
+    oneDNN _xpu_C.fp8_gemm[_out] custom op for scale configurations it
+    doesn't support.
+    """
+    scale_a_mm, scale_b_mm = _to_scaled_mm_scales(
+        A.shape[0], B.shape[1], scale_a, scale_b
+    )
+    # An empty placeholder bias (created without a device, so it lands on
+    # CPU) means "no bias". oneDNN's fp8_gemm ignores it based on numel(),
+    # but torch._scaled_mm's device check runs before that, so normalize an
+    # empty bias to None -- which is the correct "no bias" spelling.
+    bias_mm = bias if bias is not None and bias.numel() > 0 else None
+    try:
+        torch._scaled_mm(
+            A,
+            B,
+            scale_a=scale_a_mm,
+            scale_b=scale_b_mm,
+            bias=bias_mm,
+            out_dtype=out.dtype,
+            out=out,
+        )
+        return
+    except RuntimeError as e:
+        # Pass str(e), not the exception object itself: warning_once
+        # dedupes via an lru_cache keyed on (msg, *args), and each
+        # exception instance has a distinct identity/hash, so passing
+        # the object would defeat the "once" behavior and spam a warning
+        # on every call.
+        logger.warning_once(
+            "torch._scaled_mm rejected this FP8 scale configuration "
+            "(%s); falling back to _xpu_C.fp8_gemm_out.",
+            str(e),
+        )
+    # Some vllm_xpu_kernels builds only ship the non-"_out" variant.
+    # Fall back to it and copy into `out` to preserve the in-place
+    # contract that callers (e.g. symmetric-memory pipelined
+    # all-gather/reduce-scatter) rely on.
+    out.copy_(torch.ops._xpu_C.fp8_gemm(A, B, out.dtype, scale_a, scale_b, bias))
+
+
+def fused_xpu_fp8_matmul_reduce_scatter_fake(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    input_scale: torch.Tensor,
+    weight_scale: torch.Tensor,
+    reduce_op: str,
+    orig_scatter_dim: int,
+    scatter_dim_after_maybe_reshape: int,
+    group_name: str,
+    output_shape: list[int],
+    out_dtype: torch.dtype | None = None,
+) -> torch.Tensor:
+    world_size = c10d._resolve_process_group(group_name).size()
+    result_shape = list(output_shape)
+    result_shape[orig_scatter_dim] //= world_size
+    return torch.empty(result_shape, dtype=out_dtype or torch.bfloat16, device=x.device)
+
+
+def fused_xpu_fp8_matmul_reduce_scatter(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    input_scale: torch.Tensor,
+    weight_scale: torch.Tensor,
+    reduce_op: str,
+    orig_scatter_dim: int,
+    scatter_dim_after_maybe_reshape: int,
+    group_name: str,
+    output_shape: list[int],
+    out_dtype: torch.dtype | None = None,
+) -> torch.Tensor:
+    return torch.distributed._symmetric_memory._fused_scaled_matmul_reduce_scatter_impl(
+        mm_out_op=_xpu_fp8_mm_out,
+        A=x,
+        B=weight,
+        A_scale=input_scale,
+        kwargs={
+            "scale_b": weight_scale,
+            "bias": None,
+        },
+        out_dtype=out_dtype,
+        reduce_op=reduce_op,
+        orig_scatter_dim=orig_scatter_dim,
+        scatter_dim_after_maybe_reshape=scatter_dim_after_maybe_reshape,
+        group_name=group_name,
+        output_shape=output_shape,
+    )
+
+
+def fused_all_gather_xpu_fp8_matmul_fake(
+    A_shard: torch.Tensor,
+    B: torch.Tensor,
+    A_scale: torch.Tensor,
+    B_scale: torch.Tensor,
+    gather_dim: int,
+    group_name: str,
+    out_dtype: torch.dtype | None = None,
+) -> torch.Tensor:
+    world_size = c10d._resolve_process_group(group_name).size()
+    output_shape = list(A_shard.shape)
+    output_shape[gather_dim] *= world_size
+    output_shape[-1] = B.shape[1]
+    return torch.empty(
+        output_shape, dtype=out_dtype or torch.bfloat16, device=A_shard.device
+    )
+
+
+def fused_all_gather_xpu_fp8_matmul(
+    A_shard: torch.Tensor,
+    B: torch.Tensor,
+    A_scale: torch.Tensor,
+    B_scale: torch.Tensor,
+    gather_dim: int,
+    group_name: str,
+    out_dtype: torch.dtype | None = None,
+) -> torch.Tensor:
+    _, outputs = torch.distributed._symmetric_memory._fused_all_gather_matmul_impl(
+        mm_out_op=_xpu_fp8_mm_out,
+        A_shard=A_shard,
+        Bs=[B],
+        A_scale=A_scale,
+        kwargs_list=[
+            {
+                "scale_b": B_scale,
+                "bias": None,
+            }
+        ],
+        out_dtypes=[out_dtype],
+        gather_dim=gather_dim,
+        group_name=group_name,
+        return_A=False,
+    )
+    return outputs[0]
+
+
+direct_register_custom_op(
+    op_name="fused_xpu_fp8_matmul_reduce_scatter",
+    op_func=fused_xpu_fp8_matmul_reduce_scatter,
+    fake_impl=fused_xpu_fp8_matmul_reduce_scatter_fake,
+)
+
+direct_register_custom_op(
+    op_name="fused_all_gather_xpu_fp8_matmul",
+    op_func=fused_all_gather_xpu_fp8_matmul,
+    fake_impl=fused_all_gather_xpu_fp8_matmul_fake,
+)
+
+
 class BasePattern:
     def __init__(self, dtype: torch.dtype, device: str | None) -> None:
         self.dtype = dtype
@@ -677,6 +866,112 @@ class AllGatherCutlassScaledMMPattern(BasePattern):
         )
 
 
+class XPUFp8GEMMReduceScatterPattern(BasePattern):
+    def get_inputs(self) -> list[torch.Tensor]:
+        input = torch.empty([16, 16], device=self.device, dtype=FP8_DTYPE)
+        mm_weight = torch.empty([16, 16], device=self.device, dtype=FP8_DTYPE)
+        scale_a = torch.empty([16, 1], device=self.device, dtype=torch.float32)
+        scale_b = torch.empty([1, 16], device=self.device, dtype=torch.float32)
+        return [input, mm_weight, scale_a, scale_b]
+
+    def register(self, pm_pass: PatternMatcherPass) -> None:
+        def pattern(
+            x: torch.Tensor,
+            weight: torch.Tensor,
+            input_scale: torch.Tensor,
+            weight_scale: torch.Tensor,
+        ) -> torch.Tensor:
+            fp8_gemm = torch.ops._xpu_C.fp8_gemm.default(
+                A=x,
+                B=weight,
+                out_dtype=self.dtype,
+                A_scale_=input_scale,
+                B_scale_=weight_scale,
+                bias_=None,
+            )
+            return torch.ops.vllm.reduce_scatter.default(
+                fp8_gemm,
+                dim=0,
+                world_size=self.tp_size,
+                group_name=self.tp.unique_name,
+            )
+
+        def replacement(
+            input: torch.Tensor,
+            mat2: torch.Tensor,
+            scale_a: torch.Tensor,
+            scale_b: torch.Tensor,
+        ) -> torch.Tensor:
+            output_shape = [*input.shape[:-1], mat2.shape[1]]
+            scatter_dim = 0
+            return torch.ops.vllm.fused_xpu_fp8_matmul_reduce_scatter.default(  # noqa
+                input,
+                mat2,
+                scale_a,
+                scale_b,
+                "sum",
+                scatter_dim,
+                scatter_dim,
+                self.tp.device_group.group_name,
+                output_shape,
+                self.dtype,
+            )
+
+        pm.register_replacement(
+            pattern, replacement, self.get_inputs(), pm.fwd_only, pm_pass
+        )
+
+
+class AllGatherXPUFp8GEMMPattern(BasePattern):
+    def get_inputs(self) -> list[torch.Tensor]:
+        x = torch.empty([8, 16], device=self.device, dtype=FP8_DTYPE)
+        # XPU weights are row_major (contiguous), unlike CUDA col_major.
+        weight = torch.empty([16, 16], device=self.device, dtype=FP8_DTYPE)
+        scale_a = torch.empty([8, 1], device=self.device, dtype=torch.float32)
+        scale_b = torch.empty([1, 16], device=self.device, dtype=torch.float32)
+        return [x, weight, scale_a, scale_b]
+
+    def register(self, pm_pass: PatternMatcherPass) -> None:
+        def pattern(
+            x: torch.Tensor,
+            weight: torch.Tensor,
+            scale_a: torch.Tensor,
+            scale_b: torch.Tensor,
+        ) -> torch.Tensor:
+            all_gather = torch.ops.vllm.all_gather.default(
+                x, dim=0, world_size=self.tp_size, group_name=self.tp.unique_name
+            )
+            fp8_gemm = torch.ops._xpu_C.fp8_gemm.default(
+                A=all_gather,
+                B=weight,
+                out_dtype=self.dtype,
+                A_scale_=scale_a,
+                B_scale_=scale_b,
+                bias_=None,
+            )
+            return fp8_gemm
+
+        def replacement(
+            x: torch.Tensor,
+            weight: torch.Tensor,
+            scale_a: torch.Tensor,
+            scale_b: torch.Tensor,
+        ) -> torch.Tensor:
+            return torch.ops.vllm.fused_all_gather_xpu_fp8_matmul.default(  # noqa
+                x,
+                weight,
+                scale_a,
+                scale_b,
+                0,
+                self.tp.device_group.group_name,
+                self.dtype,
+            )
+
+        pm.register_replacement(
+            pattern, replacement, self.get_inputs(), pm.fwd_only, pm_pass
+        )
+
+
 class FlashInferBMMFP8ReduceScatterPattern(
     BasePattern, VllmPatternReplacement[..., torch.Tensor]
 ):
@@ -971,6 +1266,14 @@ class AsyncTPPass(VllmFusionPatternMatcherPass):
                 # path; reduce-scatter needs a dedicated FP4 producer rather
                 # than the existing FP8-style helper.
 
+            if current_platform.is_xpu():
+                XPUFp8GEMMReduceScatterPattern(self.model_dtype, self.device).register(
+                    self.pm_pass
+                )
+                AllGatherXPUFp8GEMMPattern(self.model_dtype, self.device).register(
+                    self.pm_pass
+                )
+
         self.dump_patterns(config, self.pm_pass)
 
     def is_applicable_for_range(self, compile_range: Range) -> bool:
@@ -986,4 +1289,4 @@ class AsyncTPPass(VllmFusionPatternMatcherPass):
     def __call__(self, graph: fx.Graph) -> None:
         self.matched_count = self.pm_pass.apply(graph)
         VllmPatternMatcherPass.match_table[self.pass_name] += self.matched_count
-        logger.debug("Replaced %s patterns", self.matched_count)
+        logger.info("Replaced %s patterns", self.matched_count)

--- a/vllm/compilation/passes/pass_manager.py
+++ b/vllm/compilation/passes/pass_manager.py
@@ -50,6 +50,8 @@ if current_platform.is_cuda_alike():
 
 if current_platform.is_cuda():
     from .fusion.allreduce_rms_fusion import AllReduceFusionPass
+
+if current_platform.is_cuda() or current_platform.is_xpu():
     from .fusion.collective_fusion import AsyncTPPass
 
 if current_platform.is_xpu():

--- a/vllm/platforms/xpu.py
+++ b/vllm/platforms/xpu.py
@@ -314,7 +314,6 @@ class XPUPlatform(Platform):
 
         pass_config = compilation_config.pass_config
         fusion_passes_to_disable = {
-            "fuse_gemm_comms": "Async TP",
             "fuse_allreduce_rms": "AllReduce + RMSNorm fusion",
             "fuse_attn_quant": "Attention + quant fusion",
             "fuse_act_padding": "Activation + padding fusion",


### PR DESCRIPTION
## Purpose

Add AsyncTP support for XPU FP8 static GEMM, extending the existing SP (sequence-parallel) pass. When a prefill batch clears the SP token threshold, GEMM ops and their surrounding all-reduce / reduce-scatter collectives are fused into a single kernel, hiding communication latency behind compute.

This PR also documents a required correctness flag (`--linear-backend xpu`): without it, the AsyncTP pattern matcher replaces 0 ops on current vLLM and the arm silently degrades to SP-only.

---

## Test Setup

**Model**: `RedHatAI/Meta-Llama-3.1-8B-Instruct-FP8`  
**Hardware**: 4× Intel Arc Pro B60

Four arms are compared:

| Arm | Server command suffix | Purpose |
|---|---|---|
| `eager` | `--enforce-eager` | no-compile baseline |
| `compile_nosp` | `--compilation-config '{"pass_config":{"enable_sp":false}}'` | plain-compile baseline |
| `asynctp_off` | `--compilation-config '{"pass_config":{"enable_sp":true},"use_inductor_graph_partition":true}'` | SP only (AsyncTP off) |
| `asynctp_on` | `--compilation-config '{"pass_config":{"fuse_gemm_comms":true},"use_inductor_graph_partition":true}'` | SP + AsyncTP |

---

## Commands

### Server (replace `<COMPILATION_CONFIG>` with one of the four configs above)

```bash
VLLM_ALLOW_LONG_MAX_MODEL_LEN=1 VLLM_WORKER_MULTIPROC_METHOD=spawn \
python3 -m vllm.entrypoints.openai.api_server \
    --model RedHatAI/Meta-Llama-3.1-8B-Instruct-FP8 \
    --trust-remote-code \
    --dtype bfloat16 \
    -tp 4 \
    --gpu-memory-util 0.9 \
    --max-num-batched-tokens 8192 \
    --max-model-len 8192 \
    --no-enable-prefix-caching \
    --linear-backend xpu \
    <COMPILATION_CONFIG>
```

### Benchmark

```bash
python3 -m vllm.entrypoints.cli.main bench serve \
    --model RedHatAI/Meta-Llama-3.1-8B-Instruct-FP8 \
    --dataset-name random \
    --random-input-len 4096 \
    --random-output-len 1 \
    --num-prompt 16 \
    --request-rate inf \
    --backend vllm \
    --ignore-eos \
    --trust-remote-code \
    --temperature 0
```

For the mixed prefill+decode shape, change `--random-input-len 256 --random-output-len 128 --num-prompt 16`.

### Accuracy (GSM8K)

Accuracy is measured per arm. Start the server with the arm's compilation config,
then run lm_eval while the server is running. Repeat for each arm.

**Step 1 — start server** (shown for `asynctp_on`; substitute config for other arms):

```bash
VLLM_ALLOW_LONG_MAX_MODEL_LEN=1 VLLM_WORKER_MULTIPROC_METHOD=spawn \
python3 -m vllm.entrypoints.openai.api_server \
    --model RedHatAI/Meta-Llama-3.1-8B-Instruct-FP8 \
    --trust-remote-code --dtype bfloat16 -tp 4 \
    --gpu-memory-util 0.9 --max-model-len 8192 \
    --no-enable-prefix-caching --linear-backend xpu \
    --compilation-config '{"pass_config":{"enable_sp":true,"fuse_gemm_comms":true},"use_inductor_graph_partition":true}'
```

| Arm | `--compilation-config` / flag |
|---|---|
| `asynctp_on` | `{"pass_config":{"enable_sp":true,"fuse_gemm_comms":true},"use_inductor_graph_partition":true}` |
| `asynctp_off` | `{"pass_config":{"enable_sp":true},"use_inductor_graph_partition":true}` |
| `compile_nosp` | `{"pass_config":{"enable_sp":false},"use_inductor_graph_partition":true}` |
| `eager` | `--enforce-eager` (no `--compilation-config`) |

**Step 2 — evaluate** (same command for all arms):

```bash
python3 -m lm_eval --model local-completions \
    --model_args "model=RedHatAI/Meta-Llama-3.1-8B-Instruct-FP8,base_url=http://localhost:8073/v1,tokenized_requests=False,num_concurrent=1" \
    --tasks gsm8k --num_fewshot 5 --limit 250
```

---

## Important: `--linear-backend xpu` is required

---

## Performance Results

**AsyncTP pattern check**: range `(1, 4095)` → 0 patterns (decode range); range `(4096, 8192)` → **128 patterns** (prefill range). SP threshold for this model = `(8 MiB × TP=4) / (hidden=4096 × sizeof(fp8)=1)` = **4096 tokens**.

### Pure prefill — `output_len=1`, mean TTFT (ms), mean of 2 runs

Gain = (compile_nosp − asynctp_on) / compile_nosp; positive = asynctp_on is faster.

| Shape | asynctp_on | asynctp_off | compile_nosp | eager | **TTFT gain (on vs nosp)** | AsyncTP-only gain |
|---|---:|---:|---:|---:|---:|---:|
| 16 prompts × 4096 in | 6935 | 7090 | 7602 | 7931 | **+8.8%** | +2.2% |
| 16 prompts × 512 in  | 1181 | 1218 | 1320 | 1401 | **+10.5%** | +3.1% |
| 2 prompts × 4096 in  | 1025 | 1013 | 1133 | 1179 | **+9.5%** | ~0% |

SP contributes ~7–8 pp of the ~9–11% TTFT gain; AsyncTP adds ~2–3 pp on top.

### Mixed prefill + decode — mean of 2 runs

| Shape | asynctp_on | asynctp_off | compile_nosp | eager | **Gain (on vs nosp)** |
|---|---:|---:|---:|---:|---:|
| **Duration (s)** ↓ lower is better | | | | | |
| 16 prompts × 256 in × 128 out | 3.5 | 3.4 | 4.2 | 4.8 | **+17.7%** |
| **Output tok/s** ↑ higher is better | | | | | |
| 16 prompts × 256 in × 128 out | 605 | 614 | 494 | 425 | **+22.5%** |
| **TPOT (ms)** ↓ lower is better | | | | | |
| 16 prompts × 256 in × 128 out | 21.2 | 20.4 | 27.8 | 31.7 | **+23.6%** |

Mean TTFT appears higher for asynctp_on vs compile_nosp on this shape — this is a **queueing artifact**: higher throughput means requests queue behind faster-completing peers. Duration and throughput are the reliable metrics.

---

## Accuracy (GSM8K, 250 questions)

| Arm | Accuracy |
|---|---:|
| asynctp_off (SP on, AsyncTP off) | 0.768 |
| eager | 0.748 |
| asynctp_on (SP + AsyncTP) | 0.736 |
| compile_nosp | 0.736 |

Standard error ≈ ±2.7 pp. `asynctp_on == compile_nosp` at 0.736. The 3.2 pp spread across all arms is within 1.2 σ — no statistically significant regression.

---