### PR TITLE
[ROCm] Tune gfx1100 unified attention for long prefill

### DIFF
--- a/tests/kernels/attention/test_triton_unified_attention.py
+++ b/tests/kernels/attention/test_triton_unified_attention.py
@@ -12,6 +12,7 @@ from vllm.utils.torch_utils import set_random_seed
 from vllm.v1.attention.ops.triton_attention_helpers import (
     compute_tile_loop_bounds,
 )
+from vllm.v1.attention.ops import triton_unified_attention as triton_ua
 from vllm.v1.attention.ops.triton_unified_attention import unified_attention
 from vllm.v1.kv_cache_interface import KVQuantMode
 
@@ -34,6 +35,29 @@ NUM_BLOCKS = [32768, 2048]
 # 0: use 2D kernel for decode
 # 8: use 3D kernel for decode
 SEQ_THRESHOLD_3D_VALUES = [0, 8]
+
+
+@pytest.mark.parametrize(
+    ("is_gfx1100", "max_seqlen_q", "nq_per_kv", "expected"),
+    [
+        (True, 512, 4, (64, 16, True)),
+        (True, 8192, 5, (64, 8, True)),
+        (True, 8192, 7, (64, 8, True)),
+        (True, 512, 16, (64, 4, True)),
+        (True, 511, 4, (16, 4, False)),
+        (True, 8192, 17, (32, 1, False)),
+        (False, 8192, 4, (16, 4, False)),
+    ],
+)
+def test_select_query_block(
+    monkeypatch: pytest.MonkeyPatch,
+    is_gfx1100: bool,
+    max_seqlen_q: int,
+    nq_per_kv: int,
+    expected: tuple[int, int, bool],
+) -> None:
+    monkeypatch.setattr(triton_ua, "_is_gfx1100", lambda: is_gfx1100)
+    assert triton_ua._select_query_block(max_seqlen_q, nq_per_kv) == expected
 
 
 @triton.jit

--- a/vllm/v1/attention/ops/triton_unified_attention.py
+++ b/vllm/v1/attention/ops/triton_unified_attention.py
@@ -804,6 +804,31 @@ def _get_tile_size(
     return 16 if element_size >= 2 else 32
 
 
+def _is_gfx1100() -> bool:
+    if not current_platform.is_rocm():
+        return False
+    from vllm.platforms.rocm import on_gfx1100
+
+    return on_gfx1100()
+
+
+def _select_query_block(
+    max_seqlen_q: int, num_queries_per_kv: int
+) -> tuple[int, int, bool]:
+    tuned_gfx1100_prefill = (
+        max_seqlen_q >= 512 and num_queries_per_kv <= 16 and _is_gfx1100()
+    )
+    if tuned_gfx1100_prefill:
+        block_m = 64
+        block_q = block_m // triton.next_power_of_2(num_queries_per_kv)
+        return block_m, block_q, True
+
+    block_m = (
+        16 if num_queries_per_kv <= 16 else triton.next_power_of_2(num_queries_per_kv)
+    )
+    return block_m, block_m // num_queries_per_kv, False
+
+
 def unified_attention(
     q,
     k,
@@ -934,14 +959,20 @@ def unified_attention(
     num_queries_per_kv = num_query_heads // num_kv_heads
     head_size = q.shape[2]
 
-    BLOCK_M = (
-        16 if num_queries_per_kv <= 16 else triton.next_power_of_2(num_queries_per_kv)
+    BLOCK_M, BLOCK_Q, tuned_gfx1100_prefill = _select_query_block(
+        max_seqlen_q, num_queries_per_kv
     )
-    BLOCK_Q = BLOCK_M // num_queries_per_kv
 
     # Tuned launch parameters; ``None`` lets Triton pick its defaults.
     launch_num_warps: int | None = None
     launch_num_stages: int | None = None
+
+    # Long prefill performs many KV-tile iterations per query block. On
+    # gfx1100, grouping more query rows amortizes that loop and reduces the
+    # launch grid without changing the kernel's math. Keep decode and short
+    # prefill on their smaller block, where the wider block is slower.
+    if tuned_gfx1100_prefill:
+        launch_num_warps = 4
 
     # head_size 256 with many query rows per sequence (e.g. diffusion-gemma
     # bidirectional canvas passes) is prefill-shaped, but the decode-oriented


### PR DESCRIPTION
## Purpose

Use a wider query block for long unified-attention prefill on gfx1100, while
preserving the existing selection for decode, short prefill, and other
architectures.

Addresses #52585.

Live searches found no open PR matching #52585 or the gfx1100 unified-attention
topic.

AI assistance was used for investigation, implementation, validation, and
drafting. The human submitter reviewed every changed line and is responsible
for the change.

## Test Plan

```bash
ruff format --check vllm/v1/attention/ops/triton_unified_attention.py \
  tests/kernels/attention/test_triton_unified_attention.py
ruff check vllm/v1/attention/ops/triton_unified_attention.py \
  tests/kernels/attention/test_triton_unified_attention.py
/opt/venv/bin/python -m pytest --confcutdir=tests/kernels/attention -q \
  tests/kernels/attention/test_triton_unified_attention.py \
  -k test_select_query_block
```

Also compare baseline and patched real Triton kernels across BF16, FP16, and
FP8 KV, with short-sequence and numerical controls.

## Test Result

- Ruff formatting and lint passed.
- Focused selector test: 7 passed, 1874 deselected.
- On RX 7900 GRE/gfx1100, the patched kernel was 1.77-1.81x faster at 512
  tokens, 2.49-2.55x at 2048, and 2.84-3.50x at 8192.
- BF16, FP16, FP8-KV, and independent numerical controls passed; 1/64/511-token
  paths retained the original configuration.
- The issue reporter's four-model evaluation measured 1.1-1.3x TTFT gains with
  identical generated tokens. Local validation was component-level.

Made with [Cursor](https://cursor.com)