### PR TITLE
[Rust Frontend] Add multimodal processor output cache

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -5526,6 +5526,7 @@ dependencies = [
  "minijinja-contrib",
  "ndarray 0.17.2",
  "oss-harmony",
+ "parking_lot",
  "paste",
  "reqwest 0.13.4",
  "rmp-serde",

--- a/rust/src/chat/Cargo.toml
+++ b/rust/src/chat/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 [dependencies]
 anyhow.workspace = true
 asynk-strim-attr.workspace = true
+bytes.workspace = true
 easy-ext.workspace = true
 futures.workspace = true
 half.workspace = true
@@ -15,6 +16,7 @@ llm-multimodal.workspace = true
 minijinja.workspace = true
 minijinja-contrib.workspace = true
 openai-harmony.workspace = true
+parking_lot.workspace = true
 reqwest-0-13.workspace = true
 serde.workspace = true
 serde-json-fmt.workspace = true

--- a/rust/src/chat/src/backend/hf.rs
+++ b/rust/src/chat/src/backend/hf.rs
@@ -58,6 +58,7 @@ impl HfChatBackend {
                 },
                 tokenizer.clone(),
                 options.limit_mm_per_prompt.clone(),
+                options.mm_processor_cache_capacity,
             )?
         };
         let multimodal_render_info = resolve_multimodal_render_info(multimodal_model_info.as_ref());
@@ -233,6 +234,7 @@ mod tests {
                 chat_template: None,
                 default_chat_template_kwargs: HashMap::new(),
                 limit_mm_per_prompt: HashMap::new(),
+                mm_processor_cache_capacity: 0,
             },
             test_tokenizer(),
         )

--- a/rust/src/chat/src/backend/mod.rs
+++ b/rust/src/chat/src/backend/mod.rs
@@ -8,7 +8,9 @@ use serde_json::Value;
 use vllm_text::{DynTextBackend, TextBackend};
 
 use crate::error::Result;
-use crate::multimodal::{MmLimitPerPrompt, MultimodalModelInfo};
+use crate::multimodal::{
+    DEFAULT_MM_PROCESSOR_CACHE_CAPACITY, MmLimitPerPrompt, MultimodalModelInfo,
+};
 use crate::output::DynChatOutputProcessor;
 use crate::renderer::DynChatRenderer;
 use crate::request::ChatRequest;
@@ -59,7 +61,7 @@ impl<T> ChatTextBackend for T where T: ChatBackend + TextBackend + ?Sized {}
 pub type DynChatTextBackend = Arc<dyn ChatTextBackend>;
 
 /// Frontend-side chat backend loading options.
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LoadModelBackendsOptions {
     /// Which chat renderer implementation to use.
     pub renderer: RendererSelection,
@@ -77,6 +79,22 @@ pub struct LoadModelBackendsOptions {
     /// Maximum number of input items allowed per prompt for each modality.
     /// Unspecified modalities are unlimited.
     pub limit_mm_per_prompt: MmLimitPerPrompt,
+    /// Maximum process-local multimodal processor-cache size in bytes.
+    pub mm_processor_cache_capacity: usize,
+}
+
+impl Default for LoadModelBackendsOptions {
+    fn default() -> Self {
+        Self {
+            renderer: RendererSelection::default(),
+            language_model_only: false,
+            chat_template_content_format: ChatTemplateContentFormatOption::default(),
+            chat_template: None,
+            default_chat_template_kwargs: HashMap::new(),
+            limit_mm_per_prompt: HashMap::new(),
+            mm_processor_cache_capacity: DEFAULT_MM_PROCESSOR_CACHE_CAPACITY,
+        }
+    }
 }
 
 /// Shared backends loaded from a model id.

--- a/rust/src/chat/src/lib.rs
+++ b/rust/src/chat/src/lib.rs
@@ -313,6 +313,13 @@ impl ChatLlm {
         self.processor.backend.multimodal_model_info().is_some()
     }
 
+    /// Clear process-local multimodal processor outputs.
+    pub fn clear_mm_cache(&self) {
+        if let Some(info) = self.processor.backend.multimodal_model_info() {
+            info.clear_processor_cache();
+        }
+    }
+
     /// Prepare media for an already-tokenized request.
     pub async fn prepare_media(
         &self,

--- a/rust/src/chat/src/multimodal.rs
+++ b/rust/src/chat/src/multimodal.rs
@@ -37,6 +37,7 @@ use crate::renderer::RenderedPrompt;
 use crate::request::{ChatContent, ChatContentPart, ChatMessage, ChatRequest};
 
 mod audio;
+mod cache;
 mod expand;
 mod image;
 mod item;
@@ -44,6 +45,9 @@ mod tensor;
 mod video;
 
 use self::expand::expand_prompt_token_ids;
+
+/// Default processor-cache capacity, matching Python's 4 GiB default.
+pub const DEFAULT_MM_PROCESSOR_CACHE_CAPACITY: usize = 4 * 1024 * 1024 * 1024;
 
 /// Resolved multimodal support for one loaded model.
 #[derive(Clone)]
@@ -53,6 +57,7 @@ pub struct MultimodalModelInfo {
     video: Option<ModalitySupport>,
     audio: Option<AudioModalitySupport>,
     media_connector: Arc<MediaConnector>,
+    processor_cache: Arc<cache::ProcessorCache>,
     /// Maximum number of input items allowed per prompt for each modality.
     limit_mm_per_prompt: MmLimitPerPrompt,
 }
@@ -354,6 +359,7 @@ impl MultimodalModelInfo {
         files: MultimodalConfigFiles<'_>,
         tokenizer: DynTokenizer,
         limit_mm_per_prompt: MmLimitPerPrompt,
+        processor_cache_capacity: usize,
     ) -> Result<Option<Self>> {
         let config = match files.config {
             Some(path) => {
@@ -391,6 +397,7 @@ impl MultimodalModelInfo {
             preprocessor_config,
             video_preprocessor_config,
             limit_mm_per_prompt,
+            processor_cache_capacity,
         )
     }
 
@@ -401,6 +408,7 @@ impl MultimodalModelInfo {
         preprocessor_config: PreProcessorConfig,
         video_preprocessor_config: PreProcessorConfig,
         limit_mm_per_prompt: MmLimitPerPrompt,
+        processor_cache_capacity: usize,
     ) -> Result<Option<Self>> {
         let (image, video) = Self::resolve_vision_lanes(
             &context,
@@ -429,6 +437,7 @@ impl MultimodalModelInfo {
             video,
             audio,
             media_connector,
+            processor_cache: Arc::new(cache::ProcessorCache::new(processor_cache_capacity)),
             limit_mm_per_prompt,
         }))
     }
@@ -545,6 +554,10 @@ impl MultimodalModelInfo {
             Modality::Audio => self.audio.as_ref()?.placeholder.token.as_str().into(),
             Modality::ImageEmbeds => None,
         }
+    }
+
+    pub(crate) fn clear_processor_cache(&self) {
+        self.processor_cache.clear();
     }
 }
 
@@ -707,19 +720,37 @@ impl MultimodalModelInfo {
             return Ok(Vec::new());
         }
         self.validate_mm_limits(&media_parts)?;
+        let cache_generation = self.processor_cache.generation();
         let fetched = self.fetch_media(media_parts).await?;
 
         let mut prepared = Vec::new();
         if !fetched.images.is_empty() {
-            prepared
-                .push(self.prepare_images(fetched.images, fetched.image_uuids, model_dtype).await?);
+            prepared.push(
+                self.prepare_images(
+                    fetched.images,
+                    fetched.image_uuids,
+                    model_dtype,
+                    cache_generation,
+                )
+                .await?,
+            );
         }
         if !fetched.videos.is_empty() {
-            prepared
-                .push(self.prepare_videos(fetched.videos, fetched.video_uuids, model_dtype).await?);
+            prepared.push(
+                self.prepare_videos(
+                    fetched.videos,
+                    fetched.video_uuids,
+                    model_dtype,
+                    cache_generation,
+                )
+                .await?,
+            );
         }
         if !fetched.audios.is_empty() {
-            prepared.push(self.prepare_audios(fetched.audios, fetched.audio_uuids).await?);
+            prepared.push(
+                self.prepare_audios(fetched.audios, fetched.audio_uuids, cache_generation)
+                    .await?,
+            );
         }
 
         let mut ranges = expand_prompt_token_ids(prompt_token_ids, &prepared)?;
@@ -880,6 +911,16 @@ mod tests {
         tokenizer: TestTokenizer,
         limit_mm_per_prompt: MmLimitPerPrompt,
     ) -> MultimodalModelInfo {
+        test_info_with_limits_and_cache(model_type, config, tokenizer, limit_mm_per_prompt, 0)
+    }
+
+    fn test_info_with_limits_and_cache(
+        model_type: &str,
+        config: serde_json::Value,
+        tokenizer: TestTokenizer,
+        limit_mm_per_prompt: MmLimitPerPrompt,
+        processor_cache_capacity: usize,
+    ) -> MultimodalModelInfo {
         let context = MultimodalModelContext {
             model_id: format!("{model_type}-test"),
             model_type: Some(model_type.to_string()),
@@ -892,6 +933,7 @@ mod tests {
             PreProcessorConfig::default(),
             PreProcessorConfig::default(),
             limit_mm_per_prompt,
+            processor_cache_capacity,
         )
         .unwrap()
         .unwrap_or_else(|| panic!("{model_type} multimodal support should resolve"))
@@ -927,6 +969,143 @@ mod tests {
 
     pub(super) fn qwen3_vl_info() -> MultimodalModelInfo {
         test_info("qwen3_vl", qwen3_vl_config(), qwen3_vl_tokenizer())
+    }
+
+    fn tiny_png() -> Vec<u8> {
+        vec![
+            0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x48,
+            0x44, 0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x04, 0x00, 0x00,
+            0x00, 0xb5, 0x1c, 0x0c, 0x02, 0x00, 0x00, 0x00, 0x0b, 0x49, 0x44, 0x41, 0x54, 0x78,
+            0xda, 0x63, 0x64, 0xf8, 0x0f, 0x00, 0x01, 0x05, 0x01, 0x01, 0x27, 0x18, 0xe3, 0x66,
+            0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4e, 0x44, 0xae, 0x42, 0x60, 0x82,
+        ]
+    }
+
+    fn image_data_part(uuid: &str) -> MediaContentPart {
+        image_data_part_with_bytes(tiny_png(), uuid)
+    }
+
+    fn second_tiny_png() -> Vec<u8> {
+        vec![
+            0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x48,
+            0x44, 0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x02, 0x00, 0x00,
+            0x00, 0x90, 0x77, 0x53, 0xde, 0x00, 0x00, 0x00, 0x0c, 0x49, 0x44, 0x41, 0x54, 0x78,
+            0x9c, 0x63, 0xf8, 0xcf, 0xc0, 0x00, 0x00, 0x03, 0x01, 0x01, 0x00, 0xc9, 0xfe, 0x92,
+            0xef, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4e, 0x44, 0xae, 0x42, 0x60, 0x82,
+        ]
+    }
+
+    fn image_data_part_with_bytes(data: Vec<u8>, uuid: &str) -> MediaContentPart {
+        MediaContentPart::ImageData {
+            data,
+            mime_type: Some("image/png".to_string()),
+            uuid: Some(uuid.to_string()),
+            detail: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn repeated_image_reuses_cached_processor_output_without_reusing_uuid() {
+        let info = test_info_with_limits_and_cache(
+            "qwen3_vl",
+            qwen3_vl_config(),
+            qwen3_vl_tokenizer(),
+            HashMap::new(),
+            64 * 1024 * 1024,
+        );
+        let mut first_prompt = vec![QWEN3_IMAGE_PAD_ID];
+        let first = info
+            .prepare_multimodal(
+                vec![image_data_part("first")],
+                &mut first_prompt,
+                ModelDtype::Float16,
+            )
+            .await
+            .unwrap();
+        let after_first = info.processor_cache.snapshot();
+        assert_eq!(after_first.len, 1);
+        assert_eq!(after_first.hits, 0);
+        assert_eq!(after_first.misses, 1);
+
+        let mut second_prompt = vec![QWEN3_IMAGE_PAD_ID];
+        let second = info
+            .prepare_multimodal(
+                vec![image_data_part("second")],
+                &mut second_prompt,
+                ModelDtype::Float16,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(first_prompt, second_prompt);
+        assert_eq!(first[0].data, second[0].data);
+        assert!(second[0].data.is_some());
+        assert_eq!(first[0].identifier, "first");
+        assert_eq!(second[0].identifier, "second");
+        let after_second = info.processor_cache.snapshot();
+        assert_eq!(after_second.len, 1);
+        assert_eq!(after_second.hits, 1);
+        assert_eq!(after_second.misses, 1);
+
+        info.clear_processor_cache();
+        let after_clear = info.processor_cache.snapshot();
+        assert_eq!(after_clear.generation, 1);
+        assert_eq!(after_clear.len, 0);
+
+        let mut third_prompt = vec![QWEN3_IMAGE_PAD_ID];
+        info.prepare_multimodal(
+            vec![image_data_part("third")],
+            &mut third_prompt,
+            ModelDtype::Float16,
+        )
+        .await
+        .unwrap();
+        let after_third = info.processor_cache.snapshot();
+        assert_eq!(after_third.hits, 1);
+        assert_eq!(after_third.misses, 2);
+    }
+
+    #[tokio::test]
+    async fn mixed_image_hits_and_misses_preserve_request_order() {
+        let info = test_info_with_limits_and_cache(
+            "qwen3_vl",
+            qwen3_vl_config(),
+            qwen3_vl_tokenizer(),
+            HashMap::new(),
+            64 * 1024 * 1024,
+        );
+        let mut seed_prompt = vec![QWEN3_IMAGE_PAD_ID];
+        let seed = info
+            .prepare_multimodal(
+                vec![image_data_part("seed")],
+                &mut seed_prompt,
+                ModelDtype::Float16,
+            )
+            .await
+            .unwrap();
+
+        let mut mixed_prompt = vec![QWEN3_IMAGE_PAD_ID, QWEN3_IMAGE_PAD_ID];
+        let mixed = info
+            .prepare_multimodal(
+                vec![
+                    image_data_part("cached"),
+                    image_data_part_with_bytes(second_tiny_png(), "new"),
+                ],
+                &mut mixed_prompt,
+                ModelDtype::Float16,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(mixed.len(), 2);
+        assert_eq!(mixed[0].identifier, "cached");
+        assert_eq!(mixed[1].identifier, "new");
+        assert!(mixed[0].mm_position.offset < mixed[1].mm_position.offset);
+        assert_eq!(mixed[0].data, seed[0].data);
+        let snapshot = info.processor_cache.snapshot();
+        assert_eq!(snapshot.len, 2);
+        assert_eq!(snapshot.hits, 1);
+        assert_eq!(snapshot.misses, 2);
     }
 
     #[test]

--- a/rust/src/chat/src/multimodal/audio.rs
+++ b/rust/src/chat/src/multimodal/audio.rs
@@ -20,28 +20,90 @@ impl MultimodalModelInfo {
         &self,
         clips: Vec<Arc<AudioClip>>,
         uuids: Vec<Option<String>>,
+        cache_generation: u64,
     ) -> Result<PreparedMedia> {
         let support = self.audio.as_ref().ok_or_else(|| Error::UnsupportedModality {
             modality: Modality::Audio.to_string(),
         })?;
-        let preprocessed = self.preprocess_audios(support, &clips).await?;
-        let replacements = support.spec.prompt_replacements_for(&self.context, &preprocessed)?;
-        if replacements.len() != clips.len() {
+        if uuids.len() != clips.len() {
             bail_multimodal!(
-                "number of audio prompt replacements {} does not match number of audio clips {}",
-                replacements.len(),
+                "number of audio UUIDs {} does not match number of audio clips {}",
+                uuids.len(),
                 clips.len()
             );
         }
 
-        let hashes = clips.iter().map(|clip| clip.hash.clone()).collect();
-        let items = item::build_batched_items(
-            &support.spec,
-            preprocessed,
-            hashes,
-            uuids,
-            ModelDtype::Float32,
-        )?;
+        let len = clips.len();
+        let mut replacements = vec![None; len];
+        let mut items = (0..len).map(|_| None).collect::<Vec<_>>();
+        let mut missing_indices = Vec::new();
+        let mut missing_clips = Vec::new();
+        let mut missing_uuids = Vec::new();
+
+        for (index, (clip, uuid)) in clips.into_iter().zip(uuids).enumerate() {
+            match self.processor_cache.get(Modality::Audio, &clip.hash, ModelDtype::Float32, 0) {
+                Some(cached) => {
+                    replacements[index] = Some(cached.replacement);
+                    items[index] = Some(super::PreparedItem {
+                        data: cached.data,
+                        hash: clip.hash.clone(),
+                        uuid,
+                    });
+                }
+                None => {
+                    missing_indices.push(index);
+                    missing_clips.push(clip);
+                    missing_uuids.push(uuid);
+                }
+            }
+        }
+
+        if !missing_clips.is_empty() {
+            let preprocessed = self.preprocess_audios(support, &missing_clips).await?;
+            let missing_replacements =
+                support.spec.prompt_replacements_for(&self.context, &preprocessed)?;
+            if missing_replacements.len() != missing_clips.len() {
+                bail_multimodal!(
+                    "number of audio prompt replacements {} does not match number of audio clips {}",
+                    missing_replacements.len(),
+                    missing_clips.len()
+                );
+            }
+
+            let hashes = missing_clips.iter().map(|clip| clip.hash.clone()).collect();
+            let missing_items = item::build_batched_items(
+                &support.spec,
+                preprocessed,
+                hashes,
+                missing_uuids,
+                ModelDtype::Float32,
+            )?;
+
+            for ((index, item), replacement) in
+                missing_indices.into_iter().zip(missing_items).zip(missing_replacements)
+            {
+                self.processor_cache.insert(
+                    cache_generation,
+                    Modality::Audio,
+                    &item.hash,
+                    ModelDtype::Float32,
+                    0,
+                    &item.data,
+                    &replacement,
+                );
+                replacements[index] = Some(replacement);
+                items[index] = Some(item);
+            }
+        }
+
+        let replacements = replacements
+            .into_iter()
+            .collect::<Option<Vec<_>>>()
+            .ok_or_else(|| multimodal!("audio processor cache merge left a missing replacement"))?;
+        let items = items
+            .into_iter()
+            .collect::<Option<Vec<_>>>()
+            .ok_or_else(|| multimodal!("audio processor cache merge left a missing item"))?;
 
         Ok(PreparedMedia {
             modality: Modality::Audio,
@@ -108,12 +170,17 @@ mod tests {
             PreProcessorConfig::default(),
             PreProcessorConfig::default(),
             HashMap::new(),
+            0,
         )
         .unwrap()
         .expect("Inkling multimodal support")
     }
 
     fn qwen3_asr_info() -> MultimodalModelInfo {
+        qwen3_asr_info_with_cache(0)
+    }
+
+    fn qwen3_asr_info_with_cache(processor_cache_capacity: usize) -> MultimodalModelInfo {
         let context = MultimodalModelContext {
             model_id: "Qwen/Qwen3-ASR-1.7B".to_string(),
             model_type: Some("qwen3_asr".to_string()),
@@ -128,6 +195,7 @@ mod tests {
             PreProcessorConfig::default(),
             PreProcessorConfig::default(),
             HashMap::new(),
+            processor_cache_capacity,
         )
         .unwrap()
         .expect("Qwen3-ASR multimodal support")
@@ -250,7 +318,14 @@ mod tests {
             .await
             .unwrap();
 
-        let prepared = info.prepare_audios(fetched.audios, fetched.audio_uuids).await.unwrap();
+        let prepared = info
+            .prepare_audios(
+                fetched.audios,
+                fetched.audio_uuids,
+                info.processor_cache.generation(),
+            )
+            .await
+            .unwrap();
 
         assert_eq!(prepared.replacements.len(), 1);
         assert!(
@@ -280,6 +355,53 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn repeated_audio_reuses_cached_processor_output() {
+        let info = qwen3_asr_info_with_cache(64 * 1024 * 1024);
+        let wav = wav_i16_mono(16_000, &[0; 1_600]);
+
+        let fetched = info
+            .fetch_media(vec![MediaContentPart::AudioData {
+                data: wav.clone(),
+                mime_type: Some("audio/wav".to_string()),
+                uuid: Some("first".to_string()),
+            }])
+            .await
+            .unwrap();
+        let first = info
+            .prepare_audios(
+                fetched.audios,
+                fetched.audio_uuids,
+                info.processor_cache.generation(),
+            )
+            .await
+            .unwrap();
+
+        let fetched = info
+            .fetch_media(vec![MediaContentPart::AudioData {
+                data: wav,
+                mime_type: Some("audio/wav".to_string()),
+                uuid: Some("second".to_string()),
+            }])
+            .await
+            .unwrap();
+        let second = info
+            .prepare_audios(
+                fetched.audios,
+                fetched.audio_uuids,
+                info.processor_cache.generation(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(first.items[0].data, second.items[0].data);
+        assert_eq!(first.items[0].uuid.as_deref(), Some("first"));
+        assert_eq!(second.items[0].uuid.as_deref(), Some("second"));
+        let snapshot = info.processor_cache.snapshot();
+        assert_eq!(snapshot.hits, 1);
+        assert_eq!(snapshot.misses, 1);
+    }
+
+    #[tokio::test]
     async fn inkling_tracker_and_processor_use_standard_audio_key() {
         let info = inkling_info(serde_json::json!(1024));
         let wav = wav_i16_mono(16_000, &[0; 1_600]);
@@ -293,7 +415,14 @@ mod tests {
             .await
             .unwrap();
 
-        let prepared = info.prepare_audios(fetched.audios, fetched.audio_uuids).await.unwrap();
+        let prepared = info
+            .prepare_audios(
+                fetched.audios,
+                fetched.audio_uuids,
+                info.processor_cache.generation(),
+            )
+            .await
+            .unwrap();
 
         assert_eq!(prepared.replacements.len(), 1);
         assert_eq!(

--- a/rust/src/chat/src/multimodal/cache.rs
+++ b/rust/src/chat/src/multimodal/cache.rs
@@ -1,0 +1,494 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+//! Process-local cache for multimodal processor outputs.
+
+use std::collections::{BTreeMap, HashMap};
+use std::mem::size_of;
+
+use bytes::Bytes;
+use llm_multimodal::{Modality, PromptReplacement};
+use parking_lot::Mutex;
+use vllm_engine_core_client::protocol::dtype::ModelDtype;
+use vllm_engine_core_client::protocol::multimodal::{MmFieldElem, MmKwargValue, MmKwargsItem};
+use vllm_engine_core_client::protocol::tensor::{WireArrayData, WireTensor};
+
+#[derive(Clone)]
+pub(super) struct CachedProcessorOutput {
+    pub(super) data: MmKwargsItem,
+    pub(super) replacement: PromptReplacement,
+}
+
+#[derive(Clone, PartialEq, Eq, Hash)]
+struct CacheKey {
+    modality: Modality,
+    hash: String,
+    dtype: &'static str,
+    variant: u8,
+}
+
+impl CacheKey {
+    fn new(modality: Modality, hash: &str, dtype: ModelDtype, variant: u8) -> Self {
+        Self {
+            modality,
+            hash: hash.to_string(),
+            dtype: dtype.as_str(),
+            variant,
+        }
+    }
+}
+
+struct CacheEntry {
+    output: CachedProcessorOutput,
+    weight: usize,
+    stamp: u64,
+}
+
+struct WeightedLru {
+    capacity: usize,
+    weight: usize,
+    clock: u64,
+    entries: HashMap<CacheKey, CacheEntry>,
+    order: BTreeMap<u64, CacheKey>,
+    hits: u64,
+    misses: u64,
+}
+
+impl WeightedLru {
+    fn new(capacity: usize) -> Self {
+        Self {
+            capacity,
+            weight: 0,
+            clock: 0,
+            entries: HashMap::new(),
+            order: BTreeMap::new(),
+            hits: 0,
+            misses: 0,
+        }
+    }
+
+    fn next_stamp(&mut self) -> u64 {
+        if self.clock == u64::MAX {
+            let old_order = std::mem::take(&mut self.order);
+            for (stamp, key) in old_order.into_values().enumerate() {
+                let stamp = stamp as u64;
+                self.entries
+                    .get_mut(&key)
+                    .expect("LRU order and entries must stay aligned")
+                    .stamp = stamp;
+                self.order.insert(stamp, key);
+            }
+            self.clock = self.entries.len() as u64;
+        }
+        let stamp = self.clock;
+        self.clock += 1;
+        stamp
+    }
+
+    fn get(&mut self, key: &CacheKey) -> Option<CachedProcessorOutput> {
+        if !self.entries.contains_key(key) {
+            self.misses += 1;
+            return None;
+        }
+
+        let stamp = self.next_stamp();
+        let entry = self.entries.get_mut(key).expect("cache entry was checked above");
+        self.order.remove(&entry.stamp);
+        entry.stamp = stamp;
+        self.order.insert(stamp, key.clone());
+        self.hits += 1;
+        Some(entry.output.clone())
+    }
+
+    fn insert(&mut self, key: CacheKey, output: CachedProcessorOutput, weight: usize) {
+        if self.capacity == 0 || weight > self.capacity {
+            return;
+        }
+
+        if let Some(old) = self.entries.remove(&key) {
+            self.order.remove(&old.stamp);
+            self.weight -= old.weight;
+        }
+
+        while self.weight.saturating_add(weight) > self.capacity {
+            let Some((_, oldest_key)) = self.order.pop_first() else {
+                break;
+            };
+            let oldest = self
+                .entries
+                .remove(&oldest_key)
+                .expect("LRU order and entries must stay aligned");
+            self.weight -= oldest.weight;
+        }
+
+        let stamp = self.next_stamp();
+        self.weight += weight;
+        self.order.insert(stamp, key.clone());
+        self.entries.insert(
+            key,
+            CacheEntry {
+                output,
+                weight,
+                stamp,
+            },
+        );
+    }
+
+    fn clear(&mut self) {
+        self.entries.clear();
+        self.order.clear();
+        self.weight = 0;
+    }
+}
+
+struct CacheState {
+    generation: u64,
+    lru: WeightedLru,
+}
+
+pub(super) struct ProcessorCache {
+    state: Mutex<CacheState>,
+}
+
+impl ProcessorCache {
+    pub(super) fn new(capacity: usize) -> Self {
+        Self {
+            state: Mutex::new(CacheState {
+                generation: 0,
+                lru: WeightedLru::new(capacity),
+            }),
+        }
+    }
+
+    pub(super) fn generation(&self) -> u64 {
+        self.state.lock().generation
+    }
+
+    pub(super) fn get(
+        &self,
+        modality: Modality,
+        hash: &str,
+        dtype: ModelDtype,
+        variant: u8,
+    ) -> Option<CachedProcessorOutput> {
+        self.state.lock().lru.get(&CacheKey::new(modality, hash, dtype, variant))
+    }
+
+    pub(super) fn insert(
+        &self,
+        generation: u64,
+        modality: Modality,
+        hash: &str,
+        dtype: ModelDtype,
+        variant: u8,
+        data: &MmKwargsItem,
+        replacement: &PromptReplacement,
+    ) {
+        let capacity = {
+            let state = self.state.lock();
+            if state.generation != generation || state.lru.capacity == 0 {
+                return;
+            }
+            state.lru.capacity
+        };
+
+        let Some(weight) = item_weight(data) else {
+            return;
+        };
+        if weight > capacity {
+            return;
+        }
+
+        let Some(data) = detached_item(data) else {
+            return;
+        };
+        let output = CachedProcessorOutput {
+            data,
+            replacement: replacement.clone(),
+        };
+        let key = CacheKey::new(modality, hash, dtype, variant);
+
+        let mut state = self.state.lock();
+        if state.generation == generation {
+            state.lru.insert(key, output, weight);
+        }
+    }
+
+    pub(super) fn clear(&self) {
+        let mut state = self.state.lock();
+        state.generation = state.generation.wrapping_add(1);
+        state.lru.clear();
+    }
+
+    #[cfg(test)]
+    pub(super) fn snapshot(&self) -> CacheSnapshot {
+        let state = self.state.lock();
+        CacheSnapshot {
+            generation: state.generation,
+            len: state.lru.entries.len(),
+            weight: state.lru.weight,
+            hits: state.lru.hits,
+            misses: state.lru.misses,
+        }
+    }
+}
+
+fn item_weight(item: &MmKwargsItem) -> Option<usize> {
+    let mut weight = 0usize;
+    for elem in item.values() {
+        if let Some(value) = &elem.data {
+            weight = weight.saturating_add(value_weight(value)?);
+        }
+    }
+    Some(weight.max(1))
+}
+
+fn value_weight(value: &MmKwargValue) -> Option<usize> {
+    match value {
+        MmKwargValue::Tensor(tensor) => match &tensor.data {
+            WireArrayData::RawView(bytes) => Some(bytes.len()),
+            WireArrayData::AuxIndex(_) => None,
+        },
+        MmKwargValue::Int(_) => Some(size_of::<i64>()),
+        MmKwargValue::Float(_) => Some(size_of::<f64>()),
+        MmKwargValue::List(values) => values.iter().try_fold(0usize, |weight, value| {
+            Some(weight.saturating_add(value_weight(value)?))
+        }),
+    }
+}
+
+fn detached_item(item: &MmKwargsItem) -> Option<MmKwargsItem> {
+    let mut detached = MmKwargsItem::new();
+    for (key, elem) in item {
+        let data = match &elem.data {
+            Some(value) => Some(detached_value(value)?),
+            None => None,
+        };
+        detached.insert(
+            key.clone(),
+            MmFieldElem {
+                data,
+                field: elem.field.clone(),
+            },
+        );
+    }
+    Some(detached)
+}
+
+fn detached_value(value: &MmKwargValue) -> Option<MmKwargValue> {
+    match value {
+        MmKwargValue::Tensor(tensor) => {
+            let WireArrayData::RawView(bytes) = &tensor.data else {
+                return None;
+            };
+            let tensor = WireTensor {
+                dtype: tensor.dtype.clone(),
+                shape: tensor.shape.clone(),
+                data: WireArrayData::RawView(Bytes::copy_from_slice(bytes)),
+            };
+            Some(MmKwargValue::Tensor(tensor))
+        }
+        MmKwargValue::Int(value) => Some(MmKwargValue::Int(*value)),
+        MmKwargValue::Float(value) => Some(MmKwargValue::Float(*value)),
+        MmKwargValue::List(values) => {
+            let mut detached = Vec::with_capacity(values.len());
+            for value in values {
+                detached.push(detached_value(value)?);
+            }
+            Some(MmKwargValue::List(detached))
+        }
+    }
+}
+
+#[cfg(test)]
+#[derive(Debug, PartialEq, Eq)]
+pub(super) struct CacheSnapshot {
+    pub(super) generation: u64,
+    pub(super) len: usize,
+    pub(super) weight: usize,
+    pub(super) hits: u64,
+    pub(super) misses: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use llm_multimodal::PromptReplacement;
+    use vllm_engine_core_client::protocol::multimodal::{MmBatchedField, MmField};
+
+    use super::*;
+
+    fn output(bytes: &'static [u8]) -> (MmKwargsItem, PromptReplacement) {
+        let mut data = MmKwargsItem::new();
+        data.insert(
+            "pixel_values".to_string(),
+            MmFieldElem {
+                data: Some(MmKwargValue::Tensor(WireTensor::from_raw_bytes(
+                    "uint8",
+                    vec![bytes.len()],
+                    Bytes::from_static(bytes),
+                ))),
+                field: MmField::Batched(MmBatchedField { keep_on_cpu: false }),
+            },
+        );
+        (
+            data,
+            PromptReplacement::repeated(Modality::Image, "<image>", 7, 2),
+        )
+    }
+
+    fn insert(cache: &ProcessorCache, hash: &str, bytes: &'static [u8]) {
+        let (data, replacement) = output(bytes);
+        cache.insert(
+            cache.generation(),
+            Modality::Image,
+            hash,
+            ModelDtype::Float16,
+            0,
+            &data,
+            &replacement,
+        );
+    }
+
+    #[test]
+    fn hit_refreshes_weighted_lru_order() {
+        let cache = ProcessorCache::new(8);
+        insert(&cache, "a", b"aaaa");
+        insert(&cache, "b", b"bbbb");
+
+        assert!(cache.get(Modality::Image, "a", ModelDtype::Float16, 0).is_some());
+        insert(&cache, "c", b"cccc");
+
+        assert!(cache.get(Modality::Image, "a", ModelDtype::Float16, 0).is_some());
+        assert!(cache.get(Modality::Image, "b", ModelDtype::Float16, 0).is_none());
+        assert!(cache.get(Modality::Image, "c", ModelDtype::Float16, 0).is_some());
+        assert_eq!(cache.snapshot().weight, 8);
+    }
+
+    #[test]
+    fn oversized_and_disabled_entries_are_not_admitted() {
+        let cache = ProcessorCache::new(3);
+        insert(&cache, "large", b"four");
+        assert_eq!(cache.snapshot().len, 0);
+
+        let disabled = ProcessorCache::new(0);
+        insert(&disabled, "small", b"x");
+        assert_eq!(disabled.snapshot().len, 0);
+    }
+
+    #[test]
+    fn keys_separate_modality_dtype_and_variant() {
+        let cache = ProcessorCache::new(16);
+        insert(&cache, "same", b"data");
+
+        assert!(cache.get(Modality::Image, "same", ModelDtype::Float16, 0).is_some());
+        assert!(cache.get(Modality::Video, "same", ModelDtype::Float16, 0).is_none());
+        assert!(cache.get(Modality::Image, "same", ModelDtype::Float32, 0).is_none());
+        assert!(cache.get(Modality::Image, "same", ModelDtype::Float16, 1).is_none());
+    }
+
+    #[test]
+    fn clear_rejects_in_flight_insert_from_old_generation() {
+        let cache = ProcessorCache::new(16);
+        let old_generation = cache.generation();
+        let (data, replacement) = output(b"data");
+
+        cache.clear();
+        cache.insert(
+            old_generation,
+            Modality::Image,
+            "stale",
+            ModelDtype::Float16,
+            0,
+            &data,
+            &replacement,
+        );
+
+        assert_eq!(
+            cache.snapshot(),
+            CacheSnapshot {
+                generation: 1,
+                len: 0,
+                weight: 0,
+                hits: 0,
+                misses: 0,
+            }
+        );
+    }
+
+    #[test]
+    fn cached_tensor_owns_only_its_exact_bytes() {
+        let backing = Bytes::from_static(b"0123456789");
+        let slice = backing.slice(2..6);
+        let source_ptr = slice.as_ptr();
+        let mut data = MmKwargsItem::new();
+        data.insert(
+            "pixel_values".to_string(),
+            MmFieldElem {
+                data: Some(MmKwargValue::Tensor(WireTensor::from_raw_bytes(
+                    "uint8",
+                    vec![4],
+                    slice,
+                ))),
+                field: MmField::Batched(MmBatchedField { keep_on_cpu: false }),
+            },
+        );
+        let replacement = PromptReplacement::repeated(Modality::Image, "<image>", 7, 2);
+        let cache = ProcessorCache::new(8);
+        cache.insert(
+            0,
+            Modality::Image,
+            "image",
+            ModelDtype::Float16,
+            0,
+            &data,
+            &replacement,
+        );
+
+        let cached = cache.get(Modality::Image, "image", ModelDtype::Float16, 0).unwrap();
+        let MmKwargValue::Tensor(tensor) = cached.data["pixel_values"].data.as_ref().unwrap()
+        else {
+            panic!("expected tensor");
+        };
+        let WireArrayData::RawView(bytes) = &tensor.data else {
+            panic!("expected raw bytes");
+        };
+        assert_eq!(bytes.as_ref(), b"2345");
+        assert_ne!(bytes.as_ptr(), source_ptr);
+        assert_eq!(cache.snapshot().weight, 4);
+    }
+
+    #[test]
+    fn concurrent_access_keeps_weight_bounded() {
+        let cache = Arc::new(ProcessorCache::new(32));
+        let threads = (0..8)
+            .map(|thread| {
+                let cache = Arc::clone(&cache);
+                std::thread::spawn(move || {
+                    for item in 0..100 {
+                        let hash = format!("{thread}-{item}");
+                        let (data, replacement) = output(b"data");
+                        cache.insert(
+                            cache.generation(),
+                            Modality::Image,
+                            &hash,
+                            ModelDtype::Float16,
+                            0,
+                            &data,
+                            &replacement,
+                        );
+                        let _ = cache.get(Modality::Image, &hash, ModelDtype::Float16, 0);
+                    }
+                })
+            })
+            .collect::<Vec<_>>();
+
+        for thread in threads {
+            thread.join().unwrap();
+        }
+        let snapshot = cache.snapshot();
+        assert!(snapshot.weight <= 32);
+        assert!(snapshot.len <= 8);
+    }
+}

--- a/rust/src/chat/src/multimodal/image.rs
+++ b/rust/src/chat/src/multimodal/image.rs
@@ -6,7 +6,7 @@
 
 use std::sync::Arc;
 
-use llm_multimodal::{ImageFrame, Modality, PreprocessedEncoderInputs};
+use llm_multimodal::{ImageDetail, ImageFrame, Modality, PreprocessedEncoderInputs};
 use vllm_engine_core_client::protocol::dtype::ModelDtype;
 
 use super::{ModalitySupport, MultimodalModelInfo, PreparedMedia, item};
@@ -23,22 +23,95 @@ impl MultimodalModelInfo {
         frames: Vec<Arc<ImageFrame>>,
         uuids: Vec<Option<String>>,
         model_dtype: ModelDtype,
+        cache_generation: u64,
     ) -> Result<PreparedMedia> {
         let support = self.image.as_ref().ok_or_else(|| Error::UnsupportedModality {
             modality: Modality::Image.to_string(),
         })?;
-        let preprocessed = self.preprocess_images(support, &frames).await?;
-        let replacements = support.spec.prompt_replacements_for(&self.context, &preprocessed)?;
-        if replacements.len() != frames.len() {
+        if uuids.len() != frames.len() {
             bail_multimodal!(
-                "number of image prompt replacements {} does not match number of images {}",
-                replacements.len(),
+                "number of image UUIDs {} does not match number of images {}",
+                uuids.len(),
                 frames.len()
             );
         }
-        let hashes = frames.iter().map(|frame| frame.hash.clone()).collect();
-        let items =
-            item::build_batched_items(&support.spec, preprocessed, hashes, uuids, model_dtype)?;
+
+        let len = frames.len();
+        let mut replacements = vec![None; len];
+        let mut items = (0..len).map(|_| None).collect::<Vec<_>>();
+        let mut missing_indices = Vec::new();
+        let mut missing_frames = Vec::new();
+        let mut missing_uuids = Vec::new();
+        let mut missing_variants = Vec::new();
+
+        for (index, (frame, uuid)) in frames.into_iter().zip(uuids).enumerate() {
+            let variant = image_detail_variant(frame.detail);
+            match self.processor_cache.get(Modality::Image, &frame.hash, model_dtype, variant) {
+                Some(cached) => {
+                    replacements[index] = Some(cached.replacement);
+                    items[index] = Some(super::PreparedItem {
+                        data: cached.data,
+                        hash: frame.hash.clone(),
+                        uuid,
+                    });
+                }
+                None => {
+                    missing_indices.push(index);
+                    missing_frames.push(frame);
+                    missing_uuids.push(uuid);
+                    missing_variants.push(variant);
+                }
+            }
+        }
+
+        if !missing_frames.is_empty() {
+            let preprocessed = self.preprocess_images(support, &missing_frames).await?;
+            let missing_replacements =
+                support.spec.prompt_replacements_for(&self.context, &preprocessed)?;
+            if missing_replacements.len() != missing_frames.len() {
+                bail_multimodal!(
+                    "number of image prompt replacements {} does not match number of images {}",
+                    missing_replacements.len(),
+                    missing_frames.len()
+                );
+            }
+            let hashes = missing_frames.iter().map(|frame| frame.hash.clone()).collect();
+            let missing_items = item::build_batched_items(
+                &support.spec,
+                preprocessed,
+                hashes,
+                missing_uuids,
+                model_dtype,
+            )?;
+
+            for (((index, item), replacement), variant) in missing_indices
+                .into_iter()
+                .zip(missing_items)
+                .zip(missing_replacements)
+                .zip(missing_variants)
+            {
+                self.processor_cache.insert(
+                    cache_generation,
+                    Modality::Image,
+                    &item.hash,
+                    model_dtype,
+                    variant,
+                    &item.data,
+                    &replacement,
+                );
+                replacements[index] = Some(replacement);
+                items[index] = Some(item);
+            }
+        }
+
+        let replacements = replacements
+            .into_iter()
+            .collect::<Option<Vec<_>>>()
+            .ok_or_else(|| multimodal!("image processor cache merge left a missing replacement"))?;
+        let items = items
+            .into_iter()
+            .collect::<Option<Vec<_>>>()
+            .ok_or_else(|| multimodal!("image processor cache merge left a missing item"))?;
 
         Ok(PreparedMedia {
             modality: Modality::Image,
@@ -67,5 +140,13 @@ impl MultimodalModelInfo {
         tokio::task::spawn_blocking(move || Ok(processor.preprocess(&images, &config)?))
             .await
             .map_err(|error| multimodal!("image preprocessing task failed: {error}"))?
+    }
+}
+
+fn image_detail_variant(detail: ImageDetail) -> u8 {
+    match detail {
+        ImageDetail::Auto => 0,
+        ImageDetail::Low => 1,
+        ImageDetail::High => 2,
     }
 }

--- a/rust/src/chat/src/multimodal/video.rs
+++ b/rust/src/chat/src/multimodal/video.rs
@@ -37,14 +37,34 @@ impl MultimodalModelInfo {
         clips: Vec<Arc<VideoClip>>,
         uuids: Vec<Option<String>>,
         model_dtype: ModelDtype,
+        cache_generation: u64,
     ) -> Result<PreparedMedia> {
         let support = self.video.as_ref().ok_or_else(|| Error::UnsupportedModality {
             modality: Modality::Video.to_string(),
         })?;
+        if uuids.len() != clips.len() {
+            bail_multimodal!(
+                "number of video UUIDs {} does not match number of video clips {}",
+                uuids.len(),
+                clips.len()
+            );
+        }
         let mut replacements = Vec::with_capacity(clips.len());
         let mut items = Vec::with_capacity(clips.len());
 
         for (clip, uuid) in izip!(&clips, uuids) {
+            if let Some(cached) =
+                self.processor_cache.get(Modality::Video, &clip.hash, model_dtype, 0)
+            {
+                replacements.push(cached.replacement);
+                items.push(PreparedItem {
+                    data: cached.data,
+                    hash: clip.hash.clone(),
+                    uuid,
+                });
+                continue;
+            }
+
             let preprocessed = self.preprocess_video_clip(support, Arc::clone(clip)).await?;
             let mut clip_replacements =
                 support.spec.prompt_replacements_for(&self.context, &preprocessed)?;
@@ -54,14 +74,20 @@ impl MultimodalModelInfo {
                     clip_replacements.len()
                 );
             }
-            replacements.push(clip_replacements.pop().unwrap());
-            items.push(build_video_item(
-                support,
-                preprocessed,
-                clip.hash.clone(),
-                uuid,
+            let replacement = clip_replacements.pop().unwrap();
+            let item =
+                build_video_item(support, preprocessed, clip.hash.clone(), uuid, model_dtype)?;
+            self.processor_cache.insert(
+                cache_generation,
+                Modality::Video,
+                &item.hash,
                 model_dtype,
-            )?);
+                0,
+                &item.data,
+                &replacement,
+            );
+            replacements.push(replacement);
+            items.push(item);
         }
 
         Ok(PreparedMedia {
@@ -208,6 +234,7 @@ mod tests {
                 files,
                 Arc::new(qwen3_vl_tokenizer()),
                 std::collections::HashMap::new(),
+                0,
             )
         };
 

--- a/rust/src/cmd/src/cli.rs
+++ b/rust/src/cmd/src/cli.rs
@@ -16,14 +16,14 @@ use std::time::Duration;
 
 use clap::{Args, Parser, Subcommand};
 use educe::Educe;
-use serde::de::DeserializeOwned;
+use serde::de::{DeserializeOwned, Error as _};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use serde_with::{DefaultOnNull, OneOrMany, serde_as};
 use thiserror_ext::AsReport as _;
 use uuid::Uuid;
 use vllm_chat::ReasoningParserFactory;
-use vllm_chat::multimodal::MmLimitPerPrompt;
+use vllm_chat::multimodal::{DEFAULT_MM_PROCESSOR_CACHE_CAPACITY, MmLimitPerPrompt};
 use vllm_engine_core_client::TransportMode;
 use vllm_managed_engine::ManagedEngineConfig;
 use vllm_managed_engine::cli::{ManagedEngineArgs, repartition_managed_engine_args};
@@ -262,6 +262,21 @@ pub struct SharedRuntimeArgs {
     #[serde(default)]
     pub limit_mm_per_prompt: MmLimitPerPrompt,
 
+    /// Process-local multi-modal processor-cache capacity, configured in GiB.
+    #[arg(
+        long = "mm-processor-cache-gb",
+        value_name = "GIB",
+        default_value = "4",
+        allow_negative_numbers = true,
+        value_parser = parse_mm_processor_cache_gb
+    )]
+    #[serde(
+        default = "default_mm_processor_cache_capacity",
+        rename = "mm_processor_cache_gb",
+        deserialize_with = "deserialize_mm_processor_cache_gb"
+    )]
+    pub mm_processor_cache_capacity: usize,
+
     /// The format to render message content within a chat template.
     ///
     /// * "auto" detects the format from the template
@@ -436,6 +451,14 @@ impl SharedRuntimeArgs {
         })
     }
 
+    fn mm_processor_cache_gb_arg(&self) -> Option<String> {
+        if self.mm_processor_cache_capacity == DEFAULT_MM_PROCESSOR_CACHE_CAPACITY {
+            return None;
+        }
+        let gib = self.mm_processor_cache_capacity as f64 / (1024 * 1024 * 1024) as f64;
+        Some(gib.to_string())
+    }
+
     /// Apply fallback logic for API key configuration from env variables.
     fn apply_env_api_key_fallback(&mut self) {
         if self.api_key.is_empty()
@@ -490,6 +513,7 @@ impl SharedRuntimeArgs {
             chat_template: self.chat_template,
             default_chat_template_kwargs: self.default_chat_template_kwargs,
             limit_mm_per_prompt: self.limit_mm_per_prompt,
+            mm_processor_cache_capacity: self.mm_processor_cache_capacity,
             chat_template_content_format: self.chat_template_content_format,
             max_logprobs: self.max_logprobs,
             api_server_options,
@@ -544,6 +568,7 @@ impl SharedRuntimeArgs {
             chat_template: self.chat_template,
             default_chat_template_kwargs: self.default_chat_template_kwargs,
             limit_mm_per_prompt: self.limit_mm_per_prompt,
+            mm_processor_cache_capacity: self.mm_processor_cache_capacity,
             chat_template_content_format: self.chat_template_content_format,
             max_logprobs: self.max_logprobs,
             api_server_options,
@@ -603,6 +628,33 @@ fn default_cors_wildcard() -> JsonStringList {
 
 fn default_py_bootstrap_parser_selection() -> ParserSelection {
     ParserSelection::None
+}
+
+fn default_mm_processor_cache_capacity() -> usize {
+    DEFAULT_MM_PROCESSOR_CACHE_CAPACITY
+}
+
+fn parse_mm_processor_cache_gb(value: &str) -> Result<usize, String> {
+    let value = value.parse::<f64>().map_err(|error| format!("invalid cache size: {error}"))?;
+    mm_processor_cache_bytes(value)
+}
+
+fn deserialize_mm_processor_cache_gb<'de, D>(deserializer: D) -> Result<usize, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    mm_processor_cache_bytes(f64::deserialize(deserializer)?).map_err(D::Error::custom)
+}
+
+fn mm_processor_cache_bytes(value: f64) -> Result<usize, String> {
+    if !value.is_finite() || value < 0.0 {
+        return Err("mm_processor_cache_gb must be a finite, non-negative number".to_string());
+    }
+    let bytes = value * (1024 * 1024 * 1024) as f64;
+    if bytes > usize::MAX as f64 {
+        return Err("mm_processor_cache_gb exceeds the platform address space".to_string());
+    }
+    Ok(bytes as usize)
 }
 
 /// Minimal profiler configuration parsed from `--profiler-config`.
@@ -765,6 +817,7 @@ impl ServeArgs {
             self.runtime.shutdown_timeout,
             handshake_port,
             self.runtime.limit_mm_per_prompt_json(),
+            self.runtime.mm_processor_cache_gb_arg(),
         )
     }
 }

--- a/rust/src/cmd/src/cli/tests.rs
+++ b/rust/src/cmd/src/cli/tests.rs
@@ -100,6 +100,7 @@ fn serve_args_forward_python_flags_with_separator() {
                         chat_template: None,
                         default_chat_template_kwargs: None,
                         limit_mm_per_prompt: {},
+                        mm_processor_cache_capacity: 4294967296,
                         chat_template_content_format: Auto,
                         enable_log_requests: false,
                         enable_prompt_tokens_details: false,
@@ -800,6 +801,7 @@ fn frontend_args_accept_json() {
                         chat_template: None,
                         default_chat_template_kwargs: None,
                         limit_mm_per_prompt: {},
+                        mm_processor_cache_capacity: 4294967296,
                         chat_template_content_format: Auto,
                         enable_log_requests: false,
                         enable_prompt_tokens_details: false,
@@ -1177,6 +1179,85 @@ fn serve_args_reject_unsupported_modality_in_limit_mm_per_prompt() {
 }
 
 #[test]
+fn serve_args_configure_and_forward_processor_cache_capacity() {
+    let cli = Cli::try_parse_from([
+        "vllm-rs",
+        "serve",
+        "Qwen/Qwen3-0.6B",
+        "--mm-processor-cache-gb",
+        "0.5",
+    ])
+    .unwrap();
+
+    let Command::Serve(args) = cli.command else {
+        panic!("expected serve args");
+    };
+    let frontend = args.to_frontend_config("tcp://127.0.0.1:29550".to_string());
+    assert_eq!(frontend.mm_processor_cache_capacity, 512 * 1024 * 1024);
+
+    let engine = args.to_managed_engine_config(5555);
+    assert!(
+        engine
+            .python_args
+            .windows(2)
+            .any(|args| args == ["--mm-processor-cache-gb", "0.5"])
+    );
+}
+
+#[test]
+fn frontend_args_json_configures_processor_cache_capacity() {
+    let cli = Cli::try_parse_from([
+        "vllm-rs",
+        "frontend",
+        "--listen-fd",
+        "3",
+        "--input-address",
+        "ipc:///tmp/input.sock",
+        "--output-address",
+        "ipc:///tmp/output.sock",
+        "--args-json",
+        r#"{"model_tag":"Qwen/Qwen3-0.6B","mm_processor_cache_gb":0.25}"#,
+    ])
+    .unwrap();
+
+    let Command::Frontend(args) = cli.command else {
+        panic!("expected frontend args");
+    };
+    assert_eq!(
+        args.into_config().mm_processor_cache_capacity,
+        256 * 1024 * 1024
+    );
+}
+
+#[test]
+fn processor_cache_capacity_rejects_negative_values() {
+    let error = Cli::try_parse_from([
+        "vllm-rs",
+        "serve",
+        "Qwen/Qwen3-0.6B",
+        "--mm-processor-cache-gb",
+        "-1",
+    ])
+    .unwrap_err();
+    assert!(error.to_string().contains("must be a finite, non-negative number"));
+
+    let error = Cli::try_parse_from([
+        "vllm-rs",
+        "frontend",
+        "--listen-fd",
+        "3",
+        "--input-address",
+        "ipc:///tmp/input.sock",
+        "--output-address",
+        "ipc:///tmp/output.sock",
+        "--args-json",
+        r#"{"model_tag":"Qwen/Qwen3-0.6B","mm_processor_cache_gb":-1}"#,
+    ])
+    .unwrap_err();
+    assert!(error.to_string().contains("must be a finite, non-negative number"));
+}
+
+#[test]
 fn serve_args_reject_flags_before_model() {
     let error = Cli::try_parse_from(["vllm-rs", "serve", "--python", "python3", "Qwen/Qwen3-0.6B"])
         .unwrap_err();
@@ -1391,6 +1472,7 @@ fn serve_args_accept_handshake_aliases() {
                         chat_template: None,
                         default_chat_template_kwargs: None,
                         limit_mm_per_prompt: {},
+                        mm_processor_cache_capacity: 4294967296,
                         chat_template_content_format: Auto,
                         enable_log_requests: false,
                         enable_prompt_tokens_details: false,
@@ -1536,6 +1618,7 @@ fn serve_frontend_config_uses_dp_address_as_advertised_host() {
             chat_template: None,
             default_chat_template_kwargs: None,
             limit_mm_per_prompt: {},
+            mm_processor_cache_capacity: 4294967296,
             chat_template_content_format: Auto,
             max_logprobs: None,
             api_server_options: ApiServerOptions {
@@ -1622,6 +1705,7 @@ fn serve_frontend_config_keeps_tcp_transport_for_non_local_only_topology() {
             chat_template: None,
             default_chat_template_kwargs: None,
             limit_mm_per_prompt: {},
+            mm_processor_cache_capacity: 4294967296,
             chat_template_content_format: Auto,
             max_logprobs: None,
             api_server_options: ApiServerOptions {
@@ -1728,6 +1812,7 @@ fn frontend_config_uses_external_coordinator_when_coordinator_address_is_present
             chat_template: None,
             default_chat_template_kwargs: None,
             limit_mm_per_prompt: {},
+            mm_processor_cache_capacity: 4294967296,
             chat_template_content_format: Auto,
             max_logprobs: None,
             api_server_options: ApiServerOptions {

--- a/rust/src/cmd/src/cli/unsupported.rs
+++ b/rust/src/cmd/src/cli/unsupported.rs
@@ -308,10 +308,6 @@ pub struct EngineUnsupportedArgs {
     #[arg(long)]
     pub mm_processor_kwargs: Option<Unsupported>,
 
-    /// The size (in GiB) of the multi-modal processor cache.
-    #[arg(long)]
-    pub mm_processor_cache_gb: Option<Unsupported>,
-
     /// Type of cache to use for the multi-modal preprocessor/mapper.
     #[arg(long)]
     pub mm_processor_cache_type: Option<Unsupported>,

--- a/rust/src/managed-engine/src/cli.rs
+++ b/rust/src/managed-engine/src/cli.rs
@@ -92,6 +92,7 @@ impl ManagedEngineArgs {
         shutdown_timeout: u64,
         handshake_port: u16,
         limit_mm_per_prompt: Option<String>,
+        mm_processor_cache_gb: Option<String>,
     ) -> ManagedEngineConfig {
         let mut python_args = self.python_args;
         // Manually forward some args to the Python engine.
@@ -130,6 +131,10 @@ impl ManagedEngineArgs {
         if let Some(limit_mm_per_prompt) = limit_mm_per_prompt {
             python_args.push("--limit-mm-per-prompt".to_string());
             python_args.push(limit_mm_per_prompt);
+        }
+        if let Some(mm_processor_cache_gb) = mm_processor_cache_gb {
+            python_args.push("--mm-processor-cache-gb".to_string());
+            python_args.push(mm_processor_cache_gb);
         }
 
         ManagedEngineConfig {

--- a/rust/src/server/examples/external_engine_openai_qwen.rs
+++ b/rust/src/server/examples/external_engine_openai_qwen.rs
@@ -73,6 +73,7 @@ async fn main() -> Result<()> {
         chat_template: None,
         default_chat_template_kwargs: None,
         limit_mm_per_prompt: HashMap::new(),
+        mm_processor_cache_capacity: vllm_chat::multimodal::DEFAULT_MM_PROCESSOR_CACHE_CAPACITY,
         chat_template_content_format: ChatTemplateContentFormatOption::Auto,
         max_logprobs: None,
         api_server_options: ApiServerOptions::default(),

--- a/rust/src/server/src/config.rs
+++ b/rust/src/server/src/config.rs
@@ -190,6 +190,8 @@ pub struct Config {
     /// Maximum number of input items allowed per prompt for each modality.
     /// Unspecified modalities are unlimited.
     pub limit_mm_per_prompt: MmLimitPerPrompt,
+    /// Maximum process-local multimodal processor-cache size in bytes.
+    pub mm_processor_cache_capacity: usize,
     /// How to serialize `message.content` for chat-template rendering.
     pub chat_template_content_format: ChatTemplateContentFormatOption,
     /// Optional maximum number of top log probabilities accepted by the

--- a/rust/src/server/src/grpc/tests.rs
+++ b/rust/src/server/src/grpc/tests.rs
@@ -257,6 +257,7 @@ fn multimodal_backend() -> Arc<dyn ChatTextBackend> {
         },
         Arc::new(TestTokenizer::new().with_regular_token("<|image_pad|>", QWEN_IMAGE_TOKEN_ID)),
         Default::default(),
+        0,
     )
     .expect("load multimodal info")
     .expect("qwen multimodal info is registered");

--- a/rust/src/server/src/lib.rs
+++ b/rust/src/server/src/lib.rs
@@ -105,6 +105,7 @@ async fn build_state(config: &Config) -> Result<Arc<AppState>> {
                 .clone()
                 .unwrap_or_default(),
             limit_mm_per_prompt: config.limit_mm_per_prompt.clone(),
+            mm_processor_cache_capacity: config.mm_processor_cache_capacity,
         },
     )
     .await

--- a/rust/src/server/src/render.rs
+++ b/rust/src/server/src/render.rs
@@ -62,6 +62,7 @@ async fn build_state(config: &RenderConfig) -> Result<Arc<RenderState>> {
             chat_template_content_format: config.chat_template_content_format,
             default_chat_template_kwargs: config.default_chat_template_kwargs.clone(),
             limit_mm_per_prompt: Default::default(),
+            mm_processor_cache_capacity: 0,
         },
     )
     .await

--- a/rust/src/server/src/routes/cache.rs
+++ b/rust/src/server/src/routes/cache.rs
@@ -42,6 +42,7 @@ pub async fn reset_prefix_cache(
 
 /// Reset the multi-modal cache.
 pub async fn reset_mm_cache(State(state): State<Arc<AppState>>) -> Result<StatusCode, ApiError> {
+    state.chat.clear_mm_cache();
     state
         .engine_core_client()
         .reset_mm_cache()

--- a/rust/src/server/src/routes/tests.rs
+++ b/rust/src/server/src/routes/tests.rs
@@ -584,6 +584,7 @@ fn qwen_multimodal_model_info_with_limits(
         },
         Arc::new(fake_chat_tokenizer()),
         limit_mm_per_prompt,
+        0,
     )
     .expect("load multimodal info")
     .expect("qwen multimodal info is registered");


### PR DESCRIPTION



## Purpose

The Rust frontend currently preprocesses every image, audio clip, and video on every request, even when the same media content was processed previously. Repeated multimodal requests therefore rebuild identical model inputs and prompt replacements.

 Add a process-local weighted LRU cache for multimodal processor outputs. Cache keys include the modality, media hash, model dtype,and image detail variant. Cache hits retain the current request UUID while reusing the processed tensors and prompt replacement.

Images and audio process only cache misses as a batch, while preserving the original request order when cached and uncached items are mixed. Video items reuse the same cache through their per-clip processing path.

  The cache:

  - accounts for the bytes held by cached tensor data;
  - rejects entries larger than the configured capacity;
  - detaches admitted tensor buffers from batch-owned storage;
  - avoids admitting unresolved auxiliary-frame data;
  - prevents requests started before a reset from repopulating the cache;
  - defaults to 4 GiB and can be disabled with `--mm-processor-cache-gb 0`;
  - is cleared together with the engine cache by `/reset_mm_cache`.

## Test Plan

```
cargo fmt --all -- --check
cargo sort --workspace --check
cargo deny check bans
cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
cargo nextest run --workspace --all-features --locked --no-fail-fast

 cargo nextest run -p vllm-chat \
    repeated_image_reuses_cached_processor_output_without_reusing_uuid \
    --no-capture
```

## Test Result

- Rust formatting, dependency, lint, and workspace checks passed. The workspace test run completed with 1,561 passed and 11 skipped.

- End-to-end Qwen2-VL configuration:

  - 896×896 RGB PNG;
  - Rust processor cache enabled with a 4 GiB capacity;
  - backend processor cache disabled;
  - identical image content for cold and hot requests;
  - different UUIDs to prevent backend encoder identity reuse.

  Observed results:

```
   Request       Latency
  ━━━━━━━━━  ━━━━━━━━━━━━
   Warmup     0.862634 s
  ─────────  ────────────
   Cold       0.890814 s
  ─────────  ────────────
   Hot        0.244554 s
```

  The hot request saved 0.646260 seconds, reducing end-to-end latency by approximately 72.5%, or a 3.64× speedup.

  A repeated comparison produced:
```

   Request       Latency
  ━━━━━━━━━  ━━━━━━━━━━━━
   Cold       0.921750 s
  ─────────  ────────────
   Hot        0.175460 s
```

  The repeated hot request reduced latency by approximately 81.0%.

  Cached and uncached requests returned identical results:

  - HTTP status: 200;
  - generated content: "The";
  - prompt tokens: 1,051;
  - completion tokens: 1.

  The results confirm that repeated media avoids processor preprocessing while preserving the processed inputs, prompt expansion, token accounting, request identity, and generated output. 

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

