### PR TITLE
test(sampling_params): add unit tests for from_optional and logit_bias validation

### DIFF
--- a/tests/test_sampling_params.py
+++ b/tests/test_sampling_params.py
@@ -49,3 +49,24 @@ def test_diffusion_accepts_top_k_top_p():
 def test_non_diffusion_models_unaffected():
     params = SamplingParams(temperature=0.7, top_k=10, seed=42)
     params.verify(MockModelConfig(), None, None, None)
+
+
+def test_from_optional_parsing():
+    """Test SamplingParams.from_optional default fallbacks and valid dict
+    logit_bias parsing."""
+    params = SamplingParams.from_optional(
+        temperature=None,
+        top_p=None,
+        presence_penalty=None,
+        logit_bias={"12": 2.5, 34: -1.0},
+    )
+    assert params.temperature == 1.0
+    assert params.top_p == 1.0
+    assert params.presence_penalty == 0.0
+    assert params.logit_bias == {12: 2.5, 34: -1.0}
+
+
+def test_invalid_logit_bias_key():
+    """Test that invalid non-integer keys in logit_bias raise VLLMValidationError."""
+    with pytest.raises(VLLMValidationError, match="logit_bias contains key"):
+        SamplingParams.from_optional(logit_bias={"invalid_token_id": 1.0})


### PR DESCRIPTION
### Summary
Adds unit tests in `tests/test_sampling_params.py` covering default value fallbacks in `SamplingParams.from_optional()` and validating `VLLMValidationError` behavior when non-integer keys are passed to `logit_bias`.

### Why this is not duplicate work
Verified no existing unit tests cover `SamplingParams.from_optional` fallback handling or invalid key parsing in `logit_bias`.

### Test Plan & Results
- [x] Ran `.venv/bin/pytest tests/test_sampling_params.py` (13/13 passed)
- [x] Ran `.venv/bin/ruff check tests/test_sampling_params.py` (0 errors)