### PR TITLE
[Perf] Integrate flashinfer GEMM + allreduce fusion for Kimi K3

### DIFF
--- a/.buildkite/test_areas/distributed.yaml
+++ b/.buildkite/test_areas/distributed.yaml
@@ -246,7 +246,18 @@ steps:
     - pytest -v -s tests/v1/distributed/test_dbo.py
     - pytest -v -s tests/distributed/test_mnnvl_alltoall.py
 
-    
+- label: FlashInfer GEMM All-Reduce (2xB200)
+  key: flashinfer-gemm-allreduce-2xb200
+  timeout_in_minutes: 20
+  device: b200-k8s
+  working_dir: "/vllm-workspace/"
+  num_devices: 2
+  source_file_dependencies:
+    - vllm/model_executor/kernels/linear/cute_dsl/gemm_allreduce.py
+    - tests/kernels/test_flashinfer_gemm_allreduce.py
+  commands:
+    - pytest -v -s tests/kernels/test_flashinfer_gemm_allreduce.py
+
 
 - label: 2 Node Test (4 GPUs)
   key: 2-node-test-4-gpus

--- a/tests/kernels/test_flashinfer_gemm_allreduce.py
+++ b/tests/kernels/test_flashinfer_gemm_allreduce.py
@@ -111,9 +111,7 @@ def _worker(local_rank: int, world_size: int, master_port: int) -> None:
         assert op.compile() == len(op.bucket_sizes)
         assert op.compile() == 0
 
-        mismatched_dtype = (
-            torch.bfloat16 if dtype == torch.float16 else torch.float16
-        )
+        mismatched_dtype = torch.bfloat16 if dtype == torch.float16 else torch.float16
         mismatched_x = torch.empty(256, K, dtype=mismatched_dtype, device=device)
         assert not projection.should_run(mismatched_x)
 
@@ -125,9 +123,7 @@ def _worker(local_rank: int, world_size: int, master_port: int) -> None:
             torch.accelerator.synchronize(device)
             assert actual.dtype == dtype
             rtol, atol = _TOLERANCES[dtype]
-            torch.testing.assert_close(
-                actual.float(), expected, rtol=rtol, atol=atol
-            )
+            torch.testing.assert_close(actual.float(), expected, rtol=rtol, atol=atol)
 
         first_output = projection(x)
         first_output_snapshot = first_output.clone()

--- a/tests/kernels/test_flashinfer_gemm_allreduce.py
+++ b/tests/kernels/test_flashinfer_gemm_allreduce.py
@@ -85,7 +85,7 @@ def _worker(local_rank: int, world_size: int, master_port: int) -> None:
 
     group = dist.group.WORLD
     rank = dist.get_rank(group)
-    max_M, N, K = 384, 7168, 1536
+    max_M, N, K = 384, 7168, 6144
     generator = torch.Generator(device=device)
     generator.manual_seed(4000 + rank)
     for dtype in _SUPPORTED_DTYPES:
@@ -169,16 +169,16 @@ def _worker(local_rank: int, world_size: int, master_port: int) -> None:
     cleanup_dist_env_and_memory()
 
 
-@pytest.mark.distributed(num_gpus=8)
+@pytest.mark.distributed(num_gpus=2)
 @pytest.mark.skipif(
     not current_platform.is_device_capability_family(100)
     or not has_flashinfer_cutedsl_gemm_allreduce(),
     reason="FlashInfer GEMM-allreduce requires SM100-family GPUs and its kernel",
 )
 def test_flashinfer_gemm_allreduce(monkeypatch: pytest.MonkeyPatch) -> None:
-    world_size = 8
+    world_size = 2
     if torch.accelerator.device_count() < world_size:
-        pytest.skip("FlashInfer GEMM-allreduce requires eight GPUs")
+        pytest.skip("FlashInfer GEMM-allreduce requires two GPUs")
 
     monkeypatch.setenv("NCCL_CUMEM_ENABLE", "1")
     monkeypatch.setenv("NCCL_NVLS_ENABLE", "1")

--- a/tests/kernels/test_flashinfer_gemm_allreduce.py
+++ b/tests/kernels/test_flashinfer_gemm_allreduce.py
@@ -1,0 +1,196 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import gc
+from types import SimpleNamespace
+from typing import cast
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
+from tests.utils import ensure_current_vllm_config
+from vllm.distributed import cleanup_dist_env_and_memory
+from vllm.distributed.parallel_state import (
+    init_distributed_environment,
+    initialize_model_parallel,
+)
+from vllm.platforms import current_platform
+from vllm.utils.flashinfer import has_flashinfer_cutedsl_gemm_allreduce
+from vllm.utils.network_utils import get_open_port
+from vllm.utils.system_utils import update_environment_variables
+
+_SUPPORTED_DTYPES = (torch.bfloat16,)
+_TOLERANCES = {
+    torch.bfloat16: (5e-2, 1.0),
+}
+
+
+def _random_tensor(
+    shape: tuple[int, ...],
+    dtype: torch.dtype,
+    device: torch.device,
+    generator: torch.Generator,
+) -> torch.Tensor:
+    return (
+        torch.randn(
+            shape,
+            dtype=torch.float32,
+            device=device,
+            generator=generator,
+        )
+        .mul_(0.25)
+        .to(dtype)
+    )
+
+
+def test_flashinfer_gemm_allreduce_bucket_sizes() -> None:
+    from vllm.model_executor.kernels.linear.cute_dsl.gemm_allreduce import (
+        gemm_ar_bucket_sizes,
+    )
+
+    assert gemm_ar_bucket_sizes(1) == (128,)
+    assert gemm_ar_bucket_sizes(128) == (128,)
+    assert gemm_ar_bucket_sizes(129) == (128, 256)
+    buckets = gemm_ar_bucket_sizes(16384)
+    assert len(buckets) == 128
+    assert buckets == tuple(range(128, 16385, 128))
+    with pytest.raises(ValueError, match="max_M >= 1"):
+        gemm_ar_bucket_sizes(0)
+
+
+def _worker(local_rank: int, world_size: int, master_port: int) -> None:
+    from vllm.model_executor.kernels.linear.cute_dsl.gemm_allreduce import (
+        get_or_create_cutedsl_fused_gemm_ar_workspace,
+        make_cutedsl_fused_gemm_ar,
+    )
+    from vllm.model_executor.layers.linear import LinearBase, UnquantizedLinearMethod
+
+    device = torch.device("cuda", local_rank)
+    torch.accelerator.set_device_index(device)
+    update_environment_variables(
+        {
+            "RANK": str(local_rank),
+            "LOCAL_RANK": str(local_rank),
+            "WORLD_SIZE": str(world_size),
+            "MASTER_ADDR": "localhost",
+            "MASTER_PORT": str(master_port),
+        }
+    )
+
+    init_distributed_environment()
+    with ensure_current_vllm_config():
+        initialize_model_parallel(tensor_model_parallel_size=world_size)
+
+    group = dist.group.WORLD
+    rank = dist.get_rank(group)
+    max_M, N, K = 384, 7168, 1536
+    generator = torch.Generator(device=device)
+    generator.manual_seed(4000 + rank)
+    for dtype in _SUPPORTED_DTYPES:
+        weight = _random_tensor((N, K), dtype, device, generator)
+        linear = cast(
+            LinearBase,
+            SimpleNamespace(
+                quant_method=UnquantizedLinearMethod(),
+                bias=None,
+                reduce_results=True,
+                weight=weight,
+            ),
+        )
+        projection = make_cutedsl_fused_gemm_ar(linear, max_M=max_M)
+        assert projection is not None
+        op = projection.workspace
+        assert (
+            get_or_create_cutedsl_fused_gemm_ar_workspace(
+                max_M=max_M, N=N, K=K, dtype=dtype
+            )
+            is op
+        )
+        assert op.compile() == len(op.bucket_sizes)
+        assert op.compile() == 0
+
+        mismatched_dtype = (
+            torch.bfloat16 if dtype == torch.float16 else torch.float16
+        )
+        mismatched_x = torch.empty(256, K, dtype=mismatched_dtype, device=device)
+        assert not projection.should_run(mismatched_x)
+
+        for M in (1, 127, 128, 129, 255, 256, 257):
+            x = _random_tensor((M, K), dtype, device, generator)
+            expected = torch.mm(x.float(), weight.float().T).to(dtype).float()
+            dist.all_reduce(expected, group=group)
+            actual = projection(x)
+            torch.accelerator.synchronize(device)
+            assert actual.dtype == dtype
+            rtol, atol = _TOLERANCES[dtype]
+            torch.testing.assert_close(
+                actual.float(), expected, rtol=rtol, atol=atol
+            )
+
+        first_output = projection(x)
+        first_output_snapshot = first_output.clone()
+        second_output = projection(-x)
+        torch.accelerator.synchronize(device)
+        assert first_output.data_ptr() != second_output.data_ptr()
+        torch.testing.assert_close(
+            first_output,
+            first_output_snapshot,
+            rtol=0,
+            atol=0,
+        )
+
+        if dtype == torch.bfloat16:
+            capture_stream = torch.cuda.Stream()
+            capture_stream.wait_stream(torch.cuda.current_stream())
+            graph_output = torch.empty((x.shape[0], N), dtype=dtype, device=device)
+            with torch.cuda.stream(capture_stream):
+                projection(x)
+                graph_output.copy_(projection(x))
+            capture_stream.synchronize()
+            dist.barrier(group=group)
+
+            graph = torch.cuda.CUDAGraph()
+            with torch.cuda.graph(graph, stream=capture_stream):
+                projection(x)
+                graph_output.copy_(projection(x))
+            torch.cuda.current_stream().wait_stream(capture_stream)
+            dist.barrier(group=group)
+            graph.replay()
+            torch.accelerator.synchronize(device)
+            torch.testing.assert_close(
+                graph_output.float(), expected, rtol=rtol, atol=atol
+            )
+            del capture_stream, graph, graph_output
+
+        dist.barrier(group=group)
+        del linear, mismatched_x, projection, op, weight, x
+        gc.collect()
+
+    gc.collect()
+    torch.accelerator.empty_cache()
+    cleanup_dist_env_and_memory()
+
+
+@pytest.mark.distributed(num_gpus=8)
+@pytest.mark.skipif(
+    not current_platform.is_device_capability_family(100)
+    or not has_flashinfer_cutedsl_gemm_allreduce(),
+    reason="FlashInfer GEMM-allreduce requires SM100-family GPUs and its kernel",
+)
+def test_flashinfer_gemm_allreduce(monkeypatch: pytest.MonkeyPatch) -> None:
+    world_size = 8
+    if torch.accelerator.device_count() < world_size:
+        pytest.skip("FlashInfer GEMM-allreduce requires eight GPUs")
+
+    monkeypatch.setenv("NCCL_CUMEM_ENABLE", "1")
+    monkeypatch.setenv("NCCL_NVLS_ENABLE", "1")
+    try:
+        mp.spawn(
+            _worker,
+            args=(world_size, get_open_port()),
+            nprocs=world_size,
+        )
+    finally:
+        cleanup_dist_env_and_memory()

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -146,6 +146,14 @@ def test_precompiled_install_flags_are_orthogonal() -> None:
         assert environment_variables["VLLM_USE_PRECOMPILED_RUST"]() is True
 
 
+def test_flashinfer_gemm_allreduce_defaults_enabled() -> None:
+    name = "VLLM_USE_FLASHINFER_GEMM_ALLREDUCE"
+    with patch.dict(os.environ, {}, clear=True):
+        assert environment_variables[name]() is True
+    with patch.dict(os.environ, {name: "0"}, clear=True):
+        assert environment_variables[name]() is False
+
+
 def test_rust_bench_auto_path_missing_fails_fast() -> None:
     with (
         patch.dict(os.environ, {"VLLM_USE_RUST_BENCH": "1"}, clear=True),

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -146,14 +146,6 @@ def test_precompiled_install_flags_are_orthogonal() -> None:
         assert environment_variables["VLLM_USE_PRECOMPILED_RUST"]() is True
 
 
-def test_flashinfer_gemm_allreduce_defaults_enabled() -> None:
-    name = "VLLM_USE_FLASHINFER_GEMM_ALLREDUCE"
-    with patch.dict(os.environ, {}, clear=True):
-        assert environment_variables[name]() is True
-    with patch.dict(os.environ, {name: "0"}, clear=True):
-        assert environment_variables[name]() is False
-
-
 def test_rust_bench_auto_path_missing_fails_fast() -> None:
     with (
         patch.dict(os.environ, {"VLLM_USE_RUST_BENCH": "1"}, clear=True),

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -209,6 +209,7 @@ if TYPE_CHECKING:
     VLLM_KIMI_K3_SHARD_SP_SHARED_EXPERT: bool = False
     VLLM_KIMI_K3_AUX_ATTN_RES_STREAM: bool = False
     VLLM_KIMI_K3_GEMM_RS: bool = False
+    VLLM_USE_FLASHINFER_GEMM_ALLREDUCE: bool = False
     VLLM_BLOCKSCALE_FP8_GEMM_FLASHINFER: bool = True
     VLLM_USE_FLASHINFER_MOE_INT4: bool = False
     VLLM_FLASHINFER_AUTOTUNE_CACHE_DIR: str | None = None
@@ -1609,6 +1610,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Use the SM100 BF16 GEMM-RS kernel for eligible Kimi-K3 sequence-parallel
     # row-parallel projections. All TP ranks must belong to one NVLink domain.
     "VLLM_KIMI_K3_GEMM_RS": lambda: bool(int(os.getenv("VLLM_KIMI_K3_GEMM_RS", "0"))),
+    # Use FlashInfer's SM100 BF16 GEMM with fused tensor-parallel all-reduce
+    # for eligible row-parallel projections.
+    "VLLM_USE_FLASHINFER_GEMM_ALLREDUCE": lambda: bool(
+        int(os.getenv("VLLM_USE_FLASHINFER_GEMM_ALLREDUCE", "0"))
+    ),
     # Allow use of FlashInfer FP8 block-scale GEMM for linear layers.
     # This uses TensorRT-LLM kernels and requires SM90+ (Hopper).
     "VLLM_BLOCKSCALE_FP8_GEMM_FLASHINFER": lambda: bool(

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -209,7 +209,7 @@ if TYPE_CHECKING:
     VLLM_KIMI_K3_SHARD_SP_SHARED_EXPERT: bool = False
     VLLM_KIMI_K3_AUX_ATTN_RES_STREAM: bool = False
     VLLM_KIMI_K3_GEMM_RS: bool = False
-    VLLM_USE_FLASHINFER_GEMM_ALLREDUCE: bool = False
+    VLLM_USE_FLASHINFER_GEMM_ALLREDUCE: bool = True
     VLLM_BLOCKSCALE_FP8_GEMM_FLASHINFER: bool = True
     VLLM_USE_FLASHINFER_MOE_INT4: bool = False
     VLLM_FLASHINFER_AUTOTUNE_CACHE_DIR: str | None = None
@@ -1613,7 +1613,7 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Use FlashInfer's SM100 BF16 GEMM with fused tensor-parallel all-reduce
     # for eligible row-parallel projections.
     "VLLM_USE_FLASHINFER_GEMM_ALLREDUCE": lambda: bool(
-        int(os.getenv("VLLM_USE_FLASHINFER_GEMM_ALLREDUCE", "0"))
+        int(os.getenv("VLLM_USE_FLASHINFER_GEMM_ALLREDUCE", "1"))
     ),
     # Allow use of FlashInfer FP8 block-scale GEMM for linear layers.
     # This uses TensorRT-LLM kernels and requires SM90+ (Hopper).

--- a/vllm/model_executor/kernels/linear/cute_dsl/gemm_allreduce.py
+++ b/vllm/model_executor/kernels/linear/cute_dsl/gemm_allreduce.py
@@ -130,7 +130,7 @@ class _CuteDSLFusedGemmARWorkspace:
         self.world_size = tp_group.world_size
         self.device = torch.device("cuda", torch.accelerator.current_device_index())
 
-        assert self.world_size == 8
+        assert self.world_size in (2, 4, 8)
         assert dist.get_world_size() == self.world_size
         assert dtype in _DTYPE_CONFIGS
         (

--- a/vllm/model_executor/kernels/linear/cute_dsl/gemm_allreduce.py
+++ b/vllm/model_executor/kernels/linear/cute_dsl/gemm_allreduce.py
@@ -1,0 +1,442 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""FlashInfer GEMM with a fused tensor-parallel all-reduce.
+
+FlashInfer's two-shot all-reduce requires the tokens dimension to be
+divisible by 128. Dispatches are padded to the next 128-token
+specialization.
+"""
+
+from __future__ import annotations
+
+import weakref
+from dataclasses import dataclass
+from typing import Any
+
+import cutlass
+import cutlass.cute as cute
+import cutlass.torch as cutlass_torch
+import cutlass.utils as cutlass_utils
+import torch
+import torch.distributed as dist
+import torch.distributed._symmetric_memory as symm_mem
+from cutlass.cute.runtime import from_dlpack
+
+try:
+    from cuda.bindings import driver as cuda
+except ImportError:
+    from cuda import cuda
+
+from vllm.distributed import get_tp_group
+from vllm.logger import init_logger
+from vllm.model_executor.layers.linear import LinearBase, UnquantizedLinearMethod
+from vllm.utils.flashinfer import get_flashinfer_cutedsl_gemm_allreduce
+
+logger = init_logger(__name__)
+
+_BUCKET_STEP = 128
+_2CTA_MMA_TILER_M = 256
+_2CTA_CLUSTER_SHAPE_MN = (2, 1)
+_1CTA_MMA_TILER_M = 128
+_1CTA_CLUSTER_SHAPE_MN = (1, 1)
+_DTYPE_CONFIGS: dict[
+    torch.dtype,
+    tuple[
+        type[cutlass.Numeric],
+        type[cutlass.Numeric],
+        type[cutlass.Numeric],
+        torch.dtype,
+        int,
+        int,
+    ],
+] = {
+    torch.bfloat16: (
+        cutlass.BFloat16,
+        cutlass.Float32,
+        cutlass.BFloat16,
+        torch.bfloat16,
+        8,
+        256,
+    ),
+}
+
+
+def _as_cute_tensor(
+    tensor: torch.Tensor,
+    dtype: type[cutlass.Numeric],
+    *,
+    leading_dim: int | None = None,
+) -> cute.Tensor:
+    result = from_dlpack(tensor, assumed_align=16)
+    result.element_type = dtype
+    if leading_dim is None:
+        return result.mark_layout_dynamic()
+    return result.mark_layout_dynamic(leading_dim=leading_dim)
+
+
+@dataclass
+class CuteDSLFusedGemmAR:
+    workspace: _CuteDSLFusedGemmARWorkspace
+    weight: torch.Tensor
+    weight_cute: cute.Tensor
+
+    def should_run(self, x: torch.Tensor) -> bool:
+        return self.workspace.should_run(x)
+
+    def __call__(self, x: torch.Tensor) -> torch.Tensor:
+        return self.workspace(x, self.weight, self.weight_cute)
+
+
+@dataclass
+class _CuteDSLFusedGemmARBucket:
+    M: int
+    use_2cta_instrs: bool
+    mma_tiler_mn: tuple[int, int]
+    cluster_shape_mn: tuple[int, int]
+    input_cute: cute.Tensor
+    output_cute: cute.Tensor
+    output_mc_cute: cute.Tensor
+    flags: torch.Tensor
+    flags_cute: cute.Tensor
+    flags_mc_cute: cute.Tensor
+    compiled: Any = None
+
+
+def gemm_ar_bucket_sizes(max_M: int) -> tuple[int, ...]:
+    if max_M < 1:
+        raise ValueError(f"Fused GEMM-AR requires max_M >= 1, got {max_M}")
+
+    aligned_max = (max_M + _BUCKET_STEP - 1) // _BUCKET_STEP * _BUCKET_STEP
+    return tuple(range(_BUCKET_STEP, aligned_max + 1, _BUCKET_STEP))
+
+
+def _bucket_kernel_config(
+    M: int, mma_tiler_n: int
+) -> tuple[bool, tuple[int, int], tuple[int, int]]:
+    if M % _2CTA_MMA_TILER_M == 0:
+        return (
+            True,
+            (_2CTA_MMA_TILER_M, mma_tiler_n),
+            _2CTA_CLUSTER_SHAPE_MN,
+        )
+    return False, (_1CTA_MMA_TILER_M, mma_tiler_n), _1CTA_CLUSTER_SHAPE_MN
+
+
+class _CuteDSLFusedGemmARWorkspace:
+    def __init__(self, *, max_M: int, N: int, K: int, dtype: torch.dtype) -> None:
+        tp_group = get_tp_group()
+        self.group = tp_group.device_group
+        self.world_size = tp_group.world_size
+        self.device = torch.device("cuda", torch.accelerator.current_device_index())
+
+        assert self.world_size == 8
+        assert dist.get_world_size() == self.world_size
+        assert dtype in _DTYPE_CONFIGS
+        (
+            self.ab_dtype,
+            self.acc_dtype,
+            self.output_dtype,
+            self.torch_output_dtype,
+            k_alignment,
+            self.mma_tiler_n,
+        ) = _DTYPE_CONFIGS[dtype]
+        assert N % self.mma_tiler_n == 0
+        assert K % k_alignment == 0
+
+        self.bucket_sizes = gemm_ar_bucket_sizes(max_M)
+        self.max_M = self.bucket_sizes[-1]
+        self.N = N
+        self.K = K
+        self.dtype = dtype
+
+        self.input = torch.empty(
+            (self.max_M, K),
+            dtype=dtype,
+            device=self.device,
+        )
+        self.output = symm_mem.empty(
+            (self.max_M, N, 1),
+            dtype=self.torch_output_dtype,
+            device=self.device,
+        )
+        self.output_handle = symm_mem.rendezvous(
+            self.output, group=self.group.group_name
+        )
+        if self.output_handle.multicast_ptr == 0:
+            raise RuntimeError("GEMM-allreduce requires NVLink multicast memory")
+        self.output_mc_alias = cutlass_torch.as_tensor(
+            self.output_handle.multicast_ptr,
+            self.output.shape,
+            self.output.dtype,
+        )
+        self.generation_barrier = torch.zeros(
+            1,
+            dtype=torch.int32,
+            device=self.device,
+        )
+        major, minor = torch.cuda.get_device_capability(self.device)
+        self.kernel_cls = get_flashinfer_cutedsl_gemm_allreduce()
+        self.sm_version = f"sm_{major}{minor}"
+
+        num_sms = torch.cuda.get_device_properties(self.device).multi_processor_count
+        bucket_configs = {
+            M: _bucket_kernel_config(M, self.mma_tiler_n) for M in self.bucket_sizes
+        }
+        bucket_flag_sizes = {}
+        for M, (use_2cta, mma_tiler, cluster_shape) in bucket_configs.items():
+            cta_tile_m = mma_tiler[0] // (2 if use_2cta else 1)
+            num_clusters_m = (M + cta_tile_m * cluster_shape[0] - 1) // (
+                cta_tile_m * cluster_shape[0]
+            )
+            num_clusters_n = (N + mma_tiler[1] * cluster_shape[1] - 1) // (
+                mma_tiler[1] * cluster_shape[1]
+            )
+            bucket_flag_sizes[M] = (
+                num_clusters_m * num_clusters_n * cluster_shape[0] * cluster_shape[1]
+                + num_sms
+            )
+        self.flags = symm_mem.empty(
+            sum(bucket_flag_sizes.values()),
+            dtype=torch.int32,
+            device=self.device,
+        )
+        self.flags.zero_()
+        self.flags_handle = symm_mem.rendezvous(self.flags, group=self.group.group_name)
+        if self.flags_handle.multicast_ptr == 0:
+            raise RuntimeError("GEMM-allreduce requires NVLink multicast memory")
+        self.flags_mc_alias = cutlass_torch.as_tensor(
+            self.flags_handle.multicast_ptr,
+            self.flags.shape,
+            self.flags.dtype,
+        )
+
+        flag_offset = 0
+        self.buckets = {}
+        for M, flag_size in bucket_flag_sizes.items():
+            self.buckets[M] = self._make_bucket(
+                M, *bucket_configs[M], flag_offset, flag_size
+            )
+            flag_offset += flag_size
+        _fused_gemm_ar_workspaces.add(self)
+
+    def _make_bucket(
+        self,
+        M: int,
+        use_2cta_instrs: bool,
+        mma_tiler_mn: tuple[int, int],
+        cluster_shape_mn: tuple[int, int],
+        flag_offset: int,
+        flag_size: int,
+    ) -> _CuteDSLFusedGemmARBucket:
+        flags = self.flags[flag_offset : flag_offset + flag_size]
+        flags_mc_alias = self.flags_mc_alias[flag_offset : flag_offset + flag_size]
+        return _CuteDSLFusedGemmARBucket(
+            M=M,
+            use_2cta_instrs=use_2cta_instrs,
+            mma_tiler_mn=mma_tiler_mn,
+            cluster_shape_mn=cluster_shape_mn,
+            input_cute=_as_cute_tensor(
+                self.input[:M].unsqueeze(-1),
+                self.ab_dtype,
+                leading_dim=1,
+            ),
+            output_cute=_as_cute_tensor(
+                self.output[:M],
+                self.output_dtype,
+                leading_dim=1,
+            ),
+            output_mc_cute=_as_cute_tensor(
+                self.output_mc_alias[:M],
+                self.output_dtype,
+                leading_dim=1,
+            ),
+            flags=flags,
+            flags_cute=_as_cute_tensor(flags, cutlass.Int32),
+            flags_mc_cute=_as_cute_tensor(
+                flags_mc_alias,
+                cutlass.Int32,
+            ),
+        )
+
+    def _compile_buckets(
+        self,
+        kernel_cls: Any,
+        sm_version: str,
+        compile_weight_cute: cute.Tensor,
+        stream: Any,
+    ) -> None:
+        for bucket in self.buckets.values():
+            if bucket.compiled is not None:
+                continue
+            max_clusters = cutlass_utils.HardwareInfo().get_max_active_clusters(
+                bucket.cluster_shape_mn[0] * bucket.cluster_shape_mn[1]
+            )
+            kernel = kernel_cls(
+                self.acc_dtype,
+                bucket.use_2cta_instrs,
+                bucket.mma_tiler_mn,
+                bucket.cluster_shape_mn,
+                True,
+                all_reduce="two_shot",
+                sm_version=sm_version,
+            )
+            bucket.compiled = cute.compile(
+                kernel,
+                bucket.input_cute,
+                compile_weight_cute,
+                bucket.output_cute,
+                max_clusters,
+                stream,
+                c_mc=bucket.output_mc_cute,
+                barrier_flag=bucket.flags_cute,
+                barrier_flag_mc=bucket.flags_mc_cute,
+            )
+
+    def compile(self) -> int:
+        uncompiled = sum(bucket.compiled is None for bucket in self.buckets.values())
+        if uncompiled == 0:
+            return 0
+
+        compile_weight = torch.empty(
+            (self.N, self.K), dtype=self.dtype, device=self.device
+        )
+        compile_weight_cute = _as_cute_tensor(
+            compile_weight.unsqueeze(-1), self.ab_dtype, leading_dim=1
+        )
+        stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
+        self._compile_buckets(
+            self.kernel_cls,
+            self.sm_version,
+            compile_weight_cute,
+            stream,
+        )
+        torch.accelerator.synchronize(self.device)
+        return uncompiled
+
+    def make_weight_projection(self, weight: torch.Tensor) -> CuteDSLFusedGemmAR | None:
+        if (
+            weight.shape != (self.N, self.K)
+            or weight.dtype != self.dtype
+            or weight.device != self.device
+            or not weight.is_contiguous()
+        ):
+            return None
+        weight_cute = _as_cute_tensor(
+            weight.unsqueeze(-1), self.ab_dtype, leading_dim=1
+        )
+        return CuteDSLFusedGemmAR(self, weight, weight_cute)
+
+    def should_run(self, x: torch.Tensor) -> bool:
+        if not (
+            0 < x.shape[0] <= self.max_M
+            and x.shape[1] == self.K
+            and x.dtype == self.dtype
+            and x.device == self.device
+            and x.is_contiguous()
+        ):
+            return False
+        return self._bucket_for_M(x.shape[0]).compiled is not None
+
+    def _bucket_for_M(self, M: int) -> _CuteDSLFusedGemmARBucket:
+        return next(bucket for size, bucket in self.buckets.items() if size >= M)
+
+    def __call__(
+        self,
+        x: torch.Tensor,
+        weight: torch.Tensor,
+        weight_cute: cute.Tensor,
+    ) -> torch.Tensor:
+        M = x.shape[0]
+        assert self.should_run(x)
+        assert weight.shape == (self.N, self.K)
+        bucket = self._bucket_for_M(M)
+        assert bucket.compiled is not None
+
+        self.input[:M].copy_(x)
+        if bucket.M > M:
+            self.input[M : bucket.M].zero_()
+
+        bucket.flags.zero_()
+        dist.all_reduce(self.generation_barrier, group=self.group)
+        stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
+        bucket.compiled(
+            bucket.input_cute,
+            weight_cute,
+            bucket.output_cute,
+            stream,
+            c_mc=bucket.output_mc_cute,
+            barrier_flag=bucket.flags_cute,
+            barrier_flag_mc=bucket.flags_mc_cute,
+        )
+        return self.output[:M, :, 0].clone()
+
+
+_fused_gemm_ar_workspaces: weakref.WeakSet[_CuteDSLFusedGemmARWorkspace] = (
+    weakref.WeakSet()
+)
+_fused_gemm_ar_workspace_cache: weakref.WeakValueDictionary[
+    tuple[int, int, int, int, torch.dtype], _CuteDSLFusedGemmARWorkspace
+] = weakref.WeakValueDictionary()
+
+
+def _get_compatible_weight(linear: LinearBase) -> torch.Tensor | None:
+    if not isinstance(linear.quant_method, UnquantizedLinearMethod):
+        return None
+    if getattr(linear, "bias", None) is not None or not getattr(
+        linear, "reduce_results", False
+    ):
+        return None
+    weight = linear.weight
+    incompatible_weight = (
+        weight.ndim != 2
+        or weight.dtype not in _DTYPE_CONFIGS
+        or not weight.is_contiguous()
+    )
+    if incompatible_weight:
+        return None
+    return weight
+
+
+def get_or_create_cutedsl_fused_gemm_ar_workspace(
+    *, max_M: int, N: int, K: int, dtype: torch.dtype
+) -> _CuteDSLFusedGemmARWorkspace:
+    aligned_max_M = gemm_ar_bucket_sizes(max_M)[-1]
+    device_index = torch.accelerator.current_device_index()
+    key = (device_index, aligned_max_M, N, K, dtype)
+    workspace = _fused_gemm_ar_workspace_cache.get(key)
+    if workspace is None:
+        workspace = _CuteDSLFusedGemmARWorkspace(max_M=max_M, N=N, K=K, dtype=dtype)
+        _fused_gemm_ar_workspace_cache[key] = workspace
+    return workspace
+
+
+def make_cutedsl_fused_gemm_ar(
+    linear: LinearBase, *, max_M: int
+) -> CuteDSLFusedGemmAR | None:
+    weight = _get_compatible_weight(linear)
+    if weight is None:
+        return None
+    N, K = map(int, weight.shape)
+    _, _, _, _, k_alignment, mma_tiler_n = _DTYPE_CONFIGS[weight.dtype]
+    if N % mma_tiler_n != 0 or K % k_alignment != 0:
+        return None
+    try:
+        workspace = get_or_create_cutedsl_fused_gemm_ar_workspace(
+            max_M=max_M, N=N, K=K, dtype=weight.dtype
+        )
+    except (
+        AttributeError,
+        ImportError,
+        AssertionError,
+        RuntimeError,
+        TypeError,
+        ValueError,
+    ) as error:
+        logger.warning_once("CuTe DSL fused GEMM-AR initialization failed: %s", error)
+        return None
+    return workspace.make_weight_projection(weight)
+
+
+def warmup_cutedsl_fused_gemm_ar() -> int:
+    return sum(workspace.compile() for workspace in list(_fused_gemm_ar_workspaces))

--- a/vllm/model_executor/warmup/kernel_warmup.py
+++ b/vllm/model_executor/warmup/kernel_warmup.py
@@ -6,6 +6,7 @@ This is useful specifically for JIT'ed kernels as we don't want JIT'ing to
 happen during model execution.
 """
 
+import sys
 import time
 from typing import TYPE_CHECKING
 
@@ -95,6 +96,17 @@ def _warmup_ll_bf16_router_gemm(model: torch.nn.Module) -> None:
     )
 
 
+def _warmup_cutedsl_fused_gemm_ar() -> None:
+    module = sys.modules.get(
+        "vllm.model_executor.kernels.linear.cute_dsl.gemm_allreduce"
+    )
+    if module is None:
+        return
+    compiled = module.warmup_cutedsl_fused_gemm_ar()
+    if compiled:
+        logger.info_once("Warmed up %d CuTe DSL fused GEMM-AR variants.", compiled)
+
+
 def kernel_warmup(worker: "Worker", *, process_local_only: bool = False):
     from vllm.model_executor.warmup.minimax_m3_msa_warmup import (
         minimax_m3_msa_warmup,
@@ -145,6 +157,8 @@ def kernel_warmup(worker: "Worker", *, process_local_only: bool = False):
 
     if current_platform.has_device_capability(90):
         _warmup_ll_bf16_router_gemm(worker.get_model())
+
+    _warmup_cutedsl_fused_gemm_ar()
 
     if worker.vllm_config.kernel_config.enable_cutedsl_warmup:
         # TODO(roberto): Remove after registered CuTeDSL warmups are migrated

--- a/vllm/models/kimi_k3/nvidia/kda.py
+++ b/vllm/models/kimi_k3/nvidia/kda.py
@@ -51,6 +51,7 @@ from vllm.v1.worker.workspace import current_workspace_manager
 logger = init_logger(__name__)
 
 _KDA_GATE_LOGBOUND_MIN = -5.0
+_FUSED_GEMM_AR_MIN_TOKENS = 256
 
 
 def a_log_weight_loader(
@@ -320,6 +321,7 @@ class KimiK3DeltaAttention(GatedDeltaNetAttention):
         vllm_config: VllmConfig,
         prefix: str = "",
         run_gemm_rs: bool = False,
+        use_cutedsl_fused_gemm_ar: bool = False,
     ) -> None:
         super().__init__(config, vllm_config, prefix)
         self.use_recoverssm = self.cache_config.use_kda_recoverssm
@@ -501,6 +503,22 @@ class KimiK3DeltaAttention(GatedDeltaNetAttention):
                     "GEMM-RS is disabled for %s due to an incompatible projection.",
                     prefix,
                 )
+        self.cutedsl_fused_gemm_ar = None
+        if use_cutedsl_fused_gemm_ar:
+            from vllm.model_executor.kernels.linear.cute_dsl.gemm_allreduce import (
+                make_cutedsl_fused_gemm_ar,
+            )
+
+            self.cutedsl_fused_gemm_ar = make_cutedsl_fused_gemm_ar(
+                self.o_proj,
+                max_M=vllm_config.scheduler_config.max_num_batched_tokens,
+            )
+            if self.cutedsl_fused_gemm_ar is None:
+                logger.warning_once(
+                    "Fused GEMM-AR is disabled for %s due to an incompatible "
+                    "projection.",
+                    prefix,
+                )
         compilation_config = vllm_config.compilation_config
         if prefix in compilation_config.static_forward_context:
             raise ValueError(f"Duplicate layer name: {prefix}")
@@ -547,6 +565,12 @@ class KimiK3DeltaAttention(GatedDeltaNetAttention):
             gemm_rs = get_gemm_rs()
             if gemm_rs.should_run(core_attn_out):
                 return gemm_rs(core_attn_out, self.o_proj.weight)
+        if (
+            self.cutedsl_fused_gemm_ar is not None
+            and core_attn_out.shape[0] >= _FUSED_GEMM_AR_MIN_TOKENS
+            and self.cutedsl_fused_gemm_ar.should_run(core_attn_out)
+        ):
+            return self.cutedsl_fused_gemm_ar(core_attn_out)
         return self.o_proj(core_attn_out)[0]
 
     @eager_break_during_capture

--- a/vllm/models/kimi_k3/nvidia/mla.py
+++ b/vllm/models/kimi_k3/nvidia/mla.py
@@ -101,6 +101,7 @@ if TYPE_CHECKING:
     from vllm.model_executor.layers.attention.mla_attention import MLACommonMetadata
 
 logger = init_logger(__name__)
+_FUSED_GEMM_AR_MIN_TOKENS = 256
 
 # Below this many tokens, overlap the g_proj GEMM on the aux stream with the
 # attention front-end (the GEMM is small and launch-bound, so the overlap
@@ -135,6 +136,7 @@ class MultiHeadLatentAttention(nn.Module, AttentionLayerBase):
         use_rope: bool = False,
         non_causal_multi_token_decode: bool = False,
         run_gemm_rs: bool = False,
+        use_cutedsl_fused_gemm_ar: bool = False,
     ) -> None:
         super().__init__()
         self.hidden_size = hidden_size
@@ -279,6 +281,25 @@ class MultiHeadLatentAttention(nn.Module, AttentionLayerBase):
             if not self.run_gemm_rs:
                 logger.warning_once(
                     "GEMM-RS is disabled for %s due to an incompatible projection.",
+                    prefix,
+                )
+        self.cutedsl_fused_gemm_ar = None
+        if use_cutedsl_fused_gemm_ar:
+            from vllm.model_executor.kernels.linear.cute_dsl.gemm_allreduce import (
+                make_cutedsl_fused_gemm_ar,
+            )
+
+            self.cutedsl_fused_gemm_ar = make_cutedsl_fused_gemm_ar(
+                self.o_proj,
+                max_M=(
+                    get_current_vllm_config()
+                    .scheduler_config.max_num_batched_tokens
+                ),
+            )
+            if self.cutedsl_fused_gemm_ar is None:
+                logger.warning_once(
+                    "Fused GEMM-AR is disabled for %s due to an incompatible "
+                    "projection.",
                     prefix,
                 )
 
@@ -560,6 +581,13 @@ class MultiHeadLatentAttention(nn.Module, AttentionLayerBase):
             gemm_rs = get_gemm_rs()
             if gemm_rs.should_run(attn_out):
                 return gemm_rs(attn_out, self.o_proj.weight)
+
+        if (
+            self.cutedsl_fused_gemm_ar is not None
+            and attn_out.shape[0] >= _FUSED_GEMM_AR_MIN_TOKENS
+            and self.cutedsl_fused_gemm_ar.should_run(attn_out)
+        ):
+            return self.cutedsl_fused_gemm_ar(attn_out)
 
         return self.o_proj(attn_out)[0]
 

--- a/vllm/models/kimi_k3/nvidia/mla.py
+++ b/vllm/models/kimi_k3/nvidia/mla.py
@@ -292,8 +292,7 @@ class MultiHeadLatentAttention(nn.Module, AttentionLayerBase):
             self.cutedsl_fused_gemm_ar = make_cutedsl_fused_gemm_ar(
                 self.o_proj,
                 max_M=(
-                    get_current_vllm_config()
-                    .scheduler_config.max_num_batched_tokens
+                    get_current_vllm_config().scheduler_config.max_num_batched_tokens
                 ),
             )
             if self.cutedsl_fused_gemm_ar is None:

--- a/vllm/models/kimi_k3/nvidia/model.py
+++ b/vllm/models/kimi_k3/nvidia/model.py
@@ -210,9 +210,13 @@ def should_use_fused_gemm_ar(
 
         enabled = has_flashinfer_cutedsl_gemm_allreduce()
 
-    logger.info_once(
-        "CuTe DSL fused GEMM-AR is %s.", "enabled" if enabled else "disabled"
-    )
+    if enabled:
+        logger.info_once(
+            "CuTe DSL fused GEMM-AR is enabled. To disable it, set "
+            "VLLM_USE_FLASHINFER_GEMM_ALLREDUCE=0."
+        )
+    else:
+        logger.info_once("CuTe DSL fused GEMM-AR is disabled.")
     return enabled
 
 

--- a/vllm/models/kimi_k3/nvidia/model.py
+++ b/vllm/models/kimi_k3/nvidia/model.py
@@ -189,6 +189,33 @@ def maybe_init_gemm_rs(vllm_config: VllmConfig, use_sequence_parallel: bool) -> 
     return True
 
 
+def should_use_fused_gemm_ar(
+    vllm_config: VllmConfig, use_sequence_parallel: bool
+) -> bool:
+    if not envs.VLLM_USE_FLASHINFER_GEMM_ALLREDUCE:
+        return False
+
+    parallel_config = vllm_config.parallel_config
+    tp_size = parallel_config.tensor_parallel_size
+    enabled = (
+        not use_sequence_parallel
+        and not parallel_config.use_ubatching
+        and current_platform.is_cuda()
+        and current_platform.is_device_capability_family(100)
+        and tp_size > 1
+        and torch.distributed.get_world_size() == tp_size
+    )
+    if enabled:
+        from vllm.utils.flashinfer import has_flashinfer_cutedsl_gemm_allreduce
+
+        enabled = has_flashinfer_cutedsl_gemm_allreduce()
+
+    logger.info_once(
+        "CuTe DSL fused GEMM-AR is %s.", "enabled" if enabled else "disabled"
+    )
+    return enabled
+
+
 class KimiMLP(nn.Module):
     """Dense / shared-expert MLP, optionally TP-sharded under sequence parallel.
 
@@ -836,6 +863,7 @@ class KimiDecoderLayer(nn.Module):
         prefix: str = "",
         aux_stream: torch.cuda.Stream | None = None,
         run_gemm_rs: bool = False,
+        use_fused_gemm_ar: bool = False,
     ) -> None:
         super().__init__()
         self.hidden_size = config.hidden_size
@@ -871,6 +899,7 @@ class KimiDecoderLayer(nn.Module):
                     vllm_config,
                     prefix=f"{prefix}.self_attn",
                     run_gemm_rs=run_gemm_rs,
+                    use_cutedsl_fused_gemm_ar=use_fused_gemm_ar,
                 )
                 self._self_attn_writes_output = False
             else:
@@ -908,6 +937,7 @@ class KimiDecoderLayer(nn.Module):
                 prefix=f"{prefix}.self_attn",
                 aux_stream=aux_stream,
                 run_gemm_rs=run_gemm_rs,
+                use_cutedsl_fused_gemm_ar=use_fused_gemm_ar,
             )
             self._self_attn_writes_output = False
 
@@ -1118,6 +1148,9 @@ class KimiLinearModel(nn.Module, EagleModelMixin, SupportsQuant):
         # GEMM-RS uses NCCL symmetric-memory multicast, which requires all TP
         # ranks to belong to one NVLink domain.
         self.run_gemm_rs = maybe_init_gemm_rs(vllm_config, self.use_sequence_parallel)
+        self.use_fused_gemm_ar = should_use_fused_gemm_ar(
+            vllm_config, self.use_sequence_parallel
+        )
 
         if get_pp_group().is_first_rank:
             self.embed_tokens = VocabParallelEmbedding(
@@ -1140,6 +1173,7 @@ class KimiLinearModel(nn.Module, EagleModelMixin, SupportsQuant):
                 prefix,
                 aux_stream=aux_stream,
                 run_gemm_rs=self.run_gemm_rs,
+                use_fused_gemm_ar=self.use_fused_gemm_ar,
             )
 
         self.start_layer, self.end_layer, self.layers = make_layers(

--- a/vllm/utils/flashinfer.py
+++ b/vllm/utils/flashinfer.py
@@ -262,6 +262,23 @@ def has_flashinfer_cutedsl() -> bool:
 
 
 @functools.cache
+def has_flashinfer_cutedsl_gemm_allreduce() -> bool:
+    """Return whether FlashInfer exposes the SM100 GEMM-AR kernel."""
+    if not has_flashinfer_cutedsl():
+        return False
+    module = _get_submodule("flashinfer.cute_dsl.gemm_allreduce_two_shot")
+    return module is not None and hasattr(module, "PersistentDenseGemmKernel")
+
+
+def get_flashinfer_cutedsl_gemm_allreduce() -> Any:
+    """Return FlashInfer's SM100 persistent GEMM-AR kernel class."""
+    module = _get_submodule("flashinfer.cute_dsl.gemm_allreduce_two_shot")
+    if module is None or not hasattr(module, "PersistentDenseGemmKernel"):
+        return _missing()
+    return module.PersistentDenseGemmKernel
+
+
+@functools.cache
 def has_flashinfer_trtllm_fused_moe() -> bool:
     """Return `True` if FlashInfer TRTLLM fused MoE is available."""
     if not has_flashinfer_moe():
@@ -1067,6 +1084,8 @@ __all__ = [
     "has_flashinfer_nvlink_one_sided",
     "has_flashinfer_cutlass_fused_moe",
     "has_flashinfer_cutedsl_grouped_gemm_nt_masked",
+    "has_flashinfer_cutedsl_gemm_allreduce",
+    "get_flashinfer_cutedsl_gemm_allreduce",
     "has_flashinfer_cutedsl_moe_nvfp4",
     "has_flashinfer_b12x_moe",
     "has_flashinfer_b12x_gemm",


### PR DESCRIPTION
## Purpose
Integrate the flashinfer cutedsl GEMM + allreduce fused kernel for Kimi K3 (o_proj and allreduce in MLA and KDA attention). This is only enabled when num_tokens is >= 256.

Microbenchmark (8x B300, N = 7168, K = 1536):
| M | unfused (us) | fused (us) | speedup |
|---:|---:|---:|---:|
| 128 | 54.1 | 69.7 | 0.78x |
| 256 | 75.3 | 71.9 | 1.05x |
| 512 | 97.0 | 78.4 | 1.24x |
| 1024 | 133.9 | 99.4 | 1.35x |
| 1536 | 169.8 | 122.6 | 1.38x |
| 2048 | 195.7 | 140.1 | 1.40x |
| 2560 | 221.9 | 154.6 | 1.44x |
| 3072 | 255.2 | 172.8 | 1.48x |
| 3584 | 289.9 | 192.7 | 1.50x |
| 4096 | 319.6 | 213.1 | 1.50x |
| 4608 | 342.9 | 228.2 | 1.50x |
| 5120 | 371.0 | 248.4 | 1.49x |
| 5632 | 398.4 | 269.8 | 1.48x |
| 6144 | 448.1 | 290.9 | 1.54x |
| 6656 | 463.7 | 301.8 | 1.54x |
| 7168 | 481.4 | 321.9 | 1.50x |
| 7680 | 436.7 | 340.2 | 1.28x |
| 8192 | 481.6 | 359.5 | 1.34x |
| 8704 | 479.5 | 374.6 | 1.28x |
| 9216 | 509.1 | 392.8 | 1.30x |
| 9728 | 538.4 | 412.1 | 1.31x |
| 10240 | 568.3 | 431.7 | 1.32x |
| 10752 | 581.9 | 444.1 | 1.31x |
| 11264 | 592.7 | 461.4 | 1.28x |
| 11776 | 626.8 | 481.0 | 1.30x |
| 12288 | 643.7 | 502.3 | 1.28x |
| 12800 | 667.6 | 514.7 | 1.30x |
| 13312 | 701.6 | 533.9 | 1.31x |
| 13824 | 716.5 | 553.1 | 1.30x |
| 14336 | 744.1 | 572.6 | 1.30x |
| 14848 | 755.3 | 584.7 | 1.29x |
| 15360 | 786.4 | 605.5 | 1.30x |
| 15872 | 817.9 | 622.1 | 1.31x |
| 16384 | 832.6 | 642.3 | 1.30x |

End-to-end 32k/1k fixed seqlen:
Base config:
```
VLLM_USE_V2_MODEL_RUNNER=1 \
VLLM_ALLREDUCE_USE_FLASHINFER=1 \
vllm serve ~/models/Kimi-K3 \
  --tensor-parallel-size 8 \
  --load-format fastsafetensors \
  --no-enable-flashinfer-autotune \
  --trust-remote-code \
  --language-model-only \
  --attention-config '{"mla_prefill_backend":"TRTLLM_RAGGED","use_prefill_query_quantization":true}' \
  --kv-cache-dtype fp8
```
<img width="1485" height="1059" alt="image" src="https://github.com/user-attachments/assets/22da5df2-8195-461d-b392-c91067633c5d" />

## Test Plan

## Test Result
Kimi K3 GSM8k:
```
VLLM_USE_V2_MODEL_RUNNER=1 \
VLLM_ALLREDUCE_USE_FLASHINFER=1 \
VLLM_USE_FLASHINFER_GEMM_ALLREDUCE=1 \
vllm serve ~/models/Kimi-K3 \
  --tensor-parallel-size 8 \
  --load-format fastsafetensors \
  --no-enable-flashinfer-autotune \
  --trust-remote-code \
  --language-model-only \
  --attention-config '{"mla_prefill_backend":"TRTLLM_RAGGED","use_prefill_query_quantization":true}' \
  --kv-cache-dtype fp8

|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9666|±  |0.0049|
|     |       |strict-match    |     5|exact_match|↑  |0.9659|±  |0.0050|
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

