### PR TITLE
[Bugfix] Restore model info caching for package backends

### DIFF
--- a/tests/models/test_registry.py
+++ b/tests/models/test_registry.py
@@ -173,6 +173,36 @@ def test_lazy_modelinfo_package_hash_includes_submodules(tmp_path):
     assert first_hash != second_hash
 
 
+def test_lazy_modelinfo_package_attempts_cache_load(monkeypatch):
+    cached_model_info = object()
+    loaded_hashes = []
+
+    def fake_load_cache(self, module_hash):
+        loaded_hashes.append(module_hash)
+        return cached_model_info
+
+    monkeypatch.setattr(
+        _LazyRegisteredModel,
+        "_load_modelinfo_from_cache",
+        fake_load_cache,
+    )
+    monkeypatch.setattr(
+        "vllm.model_executor.models.registry._run_in_subprocess",
+        lambda _: pytest.fail("Package-backed model should use the cache path"),
+    )
+
+    registered_model = _LazyRegisteredModel(
+        module_name="vllm.model_executor.models.transformers",
+        class_name="TransformersForCausalLM",
+    )
+
+    result = registered_model.inspect_model_cls()
+
+    assert result is cached_model_info
+    assert len(loaded_hashes) == 1
+    assert loaded_hashes[0]
+
+
 def test_hf_registry_coverage():
     untested_archs = (
         ModelRegistry.get_supported_archs() - HF_EXAMPLE_MODELS.get_supported_archs()

--- a/vllm/model_executor/models/registry.py
+++ b/vllm/model_executor/models/registry.py
@@ -1000,9 +1000,10 @@ class _LazyRegisteredModel(_BaseRegisteredModel):
         # hardware-isolated ``vllm.models.<name>`` layout) live outside
         # ``vllm/model_executor/models``. Resolve the module spec directly
         # so the file-hash cache stays warm for them.
+        model_path: Path | None = None
         if self.module_name.startswith("vllm.model_executor.models."):
             model_path = Path(__file__).parent / f"{self.module_name.split('.')[-1]}.py"
-        else:
+        if model_path is None or not model_path.exists():
             try:
                 spec = importlib.util.find_spec(self.module_name)
             except (ImportError, ValueError):


### PR DESCRIPTION
## Purpose

This PR only restores ModelInfo caching for package backends. It does not attempt to resolve the overall startup-time gap between the Transformers backend and native vLLM. Other startup costs discussed in #50128 are outside this PR's scope.

Related to #50128.

After #26906 changed the Transformers backend from `transformers.py` to a package, the ModelInfo cache continued looking for the removed file. `module_hash` therefore remained `None`, skipping cache reads and writes.

This PR falls back to `importlib.util.find_spec()` when the flat file is absent, allowing package backends to use the existing cache logic.

## Test Plan

Run unit tests:

```bash
uvx ruff check \
  vllm/model_executor/models/registry.py \
  tests/models/test_registry.py

python -m pytest -q --confcutdir=tests/models \
  tests/models/test_registry.py -k lazy_modelinfo
```

Start the server twice in separate processes with the same cache directory:

```bash
VLLM_CACHE_ROOT=/tmp/vllm-modelinfo-cache \
VLLM_LOGGING_LEVEL=DEBUG \
vllm serve Qwen/Qwen3-0.6B \
  --model-impl transformers \
  --enforce-eager
```

For each run, measure from process start to the first successful `/health` response. Stop the first server before starting the second.

## Test Result

```text
ruff: all checks passed
pytest: 3 passed
```

RTX 4080 SUPER:

```text
first startup:  49.286 s
second startup: 34.683 s
```

The first run created:

```text
vllm-model_executor-models-transformers-TransformersForCausalLM.json
```

The second run logged:

```text
Loaded model info for class
vllm.model_executor.models.transformers.TransformersForCausalLM from cache
```

Registry inspection decreased from `10.755 s` to `0.003 s`.

## AI assistance

OpenAI Codex assisted with implementation and testing. I reviewed and validated the changes.