### PR TITLE
[Bugfix][Kernel] Fix no-op num_blocks division in get_moe_wna16_block_config

### DIFF
--- a/tests/kernels/moe/test_moe.py
+++ b/tests/kernels/moe/test_moe.py
@@ -41,6 +41,9 @@ from vllm.model_executor.layers.fused_moe.experts.marlin_moe import (
     batched_fused_marlin_moe,
     fused_marlin_moe,
 )
+from vllm.model_executor.layers.fused_moe.fused_moe import (
+    get_moe_wna16_block_config,
+)
 from vllm.model_executor.layers.fused_moe.utils import (
     moe_use_td_hw_supported,
 )
@@ -218,6 +221,23 @@ FUSED_MOE_WN16_MNK_FACTORS = [
     (32, 2048, 128),
     (222, 2048, 1024),
 ]
+
+
+def test_moe_wna16_block_config_updates_num_blocks_before_resizing():
+    config = get_moe_wna16_block_config(
+        config={},
+        use_moe_wna16_cuda=True,
+        num_valid_tokens=1,
+        size_k=1024,
+        size_n=8192,
+        num_experts=8,
+        group_size=128,
+        real_top_k=1,
+        block_size_m=16,
+    )
+
+    assert config == {"BLOCK_SIZE_N": 128, "BLOCK_SIZE_K": 256}
+
 
 vllm_config = VllmConfig()
 

--- a/vllm/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe.py
@@ -1248,8 +1248,8 @@ def get_moe_wna16_block_config(
         num_blocks = num_m_blocks * num_n_blocks * num_k_blocks
 
         if size_k % 256 == 0 and num_blocks >= 256 and block_size_k < 256:
-            block_size_k = 256
             num_blocks = num_blocks // (256 // block_size_k)
+            block_size_k = 256
 
         if (
             num_m_blocks <= 16


### PR DESCRIPTION



## Purpose

Fixes #52590.

In `get_moe_wna16_block_config`, the 256-block branch updates
`block_size_k` to `256` before using it to calculate the divisor:

```python
block_size_k = 256
num_blocks = num_blocks // (256 // block_size_k)
```

As a result, the divisor is always `1`, so `num_blocks` is not reduced as
intended. For affected shapes, this can keep `num_blocks` above the later
threshold and select an incorrect `BLOCK_SIZE_N` for the MoE WNA16 kernel.

This change computes the adjusted `num_blocks` using the original
`block_size_k` first, then updates `block_size_k` to `256`. A regression test
was added to verify the corrected block configuration.

## Test Plan

Run the targeted regression test:

```bash
.venv/bin/python -m pytest tests/kernels/moe/test_moe.py \
  -k moe_wna16_block_config_updates_num_blocks_before_resizing -v
```

Additional validation was performed on a remote NVIDIA T4 host. More detailed
kernel and performance testing is still in progress.

## Test Result

- Targeted T4 regression test: `1 passed, 1108 deselected`
- No model download or model-evaluation result is claimed by this change.
- No performance improvement claim is made yet; additional T4 benchmarking is
  being conducted.
- No documentation update is required because this is an internal kernel
  configuration fix.

## AI Assistance Disclosure

AI assistance was used to inspect issue #52590, implement the code change, and
add the regression test. The submitting human is responsible for reviewing
every changed line and validating the change end-to-end.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR and the linked issue are stated.
- [x] The test plan and test command are provided.
- [x] The current test result is reported.
- [x] Documentation impact was considered; no documentation update is needed.
</details>


