### PR TITLE
[Bugfix][PaliGemma] Don't inverse-scale image embeddings after Gemma normalizer moved to embed time

### DIFF
--- a/tests/models/multimodal/test_paligemma_image_embed_scale.py
+++ b/tests/models/multimodal/test_paligemma_image_embed_scale.py
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit test for PaliGemma image-embedding scaling (issue #52667).
+
+Gemma applies its ``sqrt(hidden_size)`` normalizer to *text* embeddings inside
+``GemmaModel.embed_input_ids`` and consumes the merged ``inputs_embeds`` as-is in
+``forward``. PaliGemma must therefore hand its projected image features to the
+language model unscaled — the previous ``* hidden_size**-0.5`` left image rows at
+``1/hidden_size`` of the intended magnitude relative to text.
+
+This exercises the ``image_embeds`` pass-through path, which needs no model
+weights: ``embed_multimodal`` must return user-provided image embeddings
+unchanged.
+"""
+
+import torch
+
+from vllm.model_executor.models.paligemma import (
+    PaliGemmaForConditionalGeneration,
+)
+
+
+def test_image_embeds_are_not_rescaled():
+    # Bypass __init__: the image_embeds path only uses two pure instance methods
+    # (_parse_and_validate_image_input, _process_image_input) and no weights.
+    model = PaliGemmaForConditionalGeneration.__new__(PaliGemmaForConditionalGeneration)
+
+    image_embeds = torch.randn(4, 16)
+    out = model.embed_multimodal(image_embeds=image_embeds)
+
+    assert isinstance(out, torch.Tensor)
+    assert torch.equal(out, image_embeds), (
+        "image embeddings must pass through unscaled; a residual inverse scale "
+        "(hidden_size**-0.5) mismatches Gemma's text-side sqrt(hidden_size) "
+        "normalizer"
+    )

--- a/vllm/model_executor/models/paligemma.py
+++ b/vllm/model_executor/models/paligemma.py
@@ -378,8 +378,15 @@ class PaliGemmaForConditionalGeneration(
         if image_input is None:
             return []
         vision_embeddings = self._process_image_input(image_input)
-        # https://github.com/huggingface/transformers/blob/main/src/transformers/models/paligemma/modeling_paligemma.py#L294 # noqa
-        vision_embeddings = vision_embeddings * (self.config.hidden_size**-0.5)
+        # NOTE: image features are intentionally *not* rescaled here. Gemma
+        # applies its ``sqrt(hidden_size)`` embedding normalizer inside
+        # ``GemmaModel.embed_input_ids`` (the text path); ``GemmaModel.forward``
+        # consumes the merged ``inputs_embeds`` as-is. The former inverse scale
+        # (``* hidden_size**-0.5``) compensated for a normalizer that used to run
+        # in ``forward``; after that normalization moved to embed time it left
+        # image rows at ``1/hidden_size`` of the intended magnitude relative to
+        # text. This matches HF Transformers, which scales text and leaves the
+        # projected image features unscaled.
         return vision_embeddings
 
     def forward(


### PR DESCRIPTION
## Purpose

Fixes #52667.

`PaliGemmaForConditionalGeneration.embed_multimodal` scaled projected image features by `hidden_size**-0.5` before merging them into Gemma's `inputs_embeds`:

```python
vision_embeddings = vision_embeddings * (self.config.hidden_size**-0.5)
```

That inverse scale used to compensate for Gemma's `sqrt(hidden_size)` normalizer **when it ran inside `GemmaModel.forward`**. #36787 ("Make Gemma and Gemma 2 accept `inputs_embeds` like Gemma 3") moved that normalization to the text embed path:

- `GemmaModel.embed_input_ids` now returns `self.embed_tokens(input_ids) * self.normalizer` (`normalizer = hidden_size**0.5`) — text is scaled at embed time.
- `GemmaModel.forward` consumes the merged `inputs_embeds` **as-is** (`if inputs_embeds is not None: hidden_states = inputs_embeds`) — no compensating multiply.

So after #36787, text rows enter the LM at `×sqrt(H)` while image rows enter at `÷sqrt(H)` — image features end up ~`1/H` of their intended magnitude relative to text. The issue reports the effect as image cosine ~0.90 vs HF, rising to ~0.99 once the line is removed.

## Fix

Return the projected image features **unscaled**, matching HF Transformers (which scales text and leaves the projected image features unscaled) and the post-#36787 Gemma text path. `image_embeds` inputs (user-supplied pre-projected embeds) are likewise no longer wrongly divided.

`ColPaliModel` (`colpali.py`) subclasses `PaliGemmaForConditionalGeneration` and does not override `embed_multimodal`, so this one-line change also fixes the `vidore/colpali-*` retrieval models.

## Test

Adds `tests/models/multimodal/test_paligemma_image_embed_scale.py` — a weight-free unit test that pins the `image_embeds` pass-through contract (`embed_multimodal` must return user image embeddings unchanged).

**Note on local verification:** vLLM is too heavy to build/run in my environment, so I verified the fix by tracing the three code legs (`paligemma.py:382`, `gemma.py:295` embed-time scale, `gemma.py:306` forward passthrough) against `main` and confirming the ColPali inheritance; the numeric A/B is in #52667. Happy to add a Transformers-parity logits test if you'd prefer that over (or alongside) the unit test — just point me at the right harness/marker.