### PR TITLE
[Bugfix][Elastic EP] Reject scale below the minimum data parallel size

### DIFF
--- a/vllm/entrypoints/serve/elastic_ep/api_router.py
+++ b/vllm/entrypoints/serve/elastic_ep/api_router.py
@@ -75,6 +75,8 @@ async def scale_elastic_ep(raw_request: Request):
             detail="Scale failed due to request drain timeout "
             f"after {drain_timeout} seconds",
         ) from e
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
     except Exception as e:
         logger.error("Scale failed: %s", e)
         raise HTTPException(status_code=500, detail="Scale failed") from e

--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -1637,9 +1637,21 @@ class DPLBAsyncMPClient(DPAsyncMPClient):
         )
         parallel_config = self.vllm_config.parallel_config
         num_experts = self.vllm_config.model_config.get_num_experts()
-        num_redundant_experts = (
+        num_physical_experts = (
             num_experts + parallel_config.eplb_config.num_redundant_experts
-        ) * new_data_parallel_size // cur_data_parallel_size - num_experts
+        )
+        num_redundant_experts = (
+            num_physical_experts * new_data_parallel_size // cur_data_parallel_size
+            - num_experts
+        )
+        if num_redundant_experts < 0:
+            # Scaling keeps physical experts per engine fixed, so below this
+            # size the logical experts no longer fit.
+            raise ValueError(
+                f"Cannot scale to data_parallel_size {new_data_parallel_size}, "
+                f"minimum is "
+                f"{-(-num_experts * cur_data_parallel_size // num_physical_experts)}"
+            )
         if new_data_parallel_size < cur_data_parallel_size:
             await self._prepare_scale_down_elastic_ep(new_data_parallel_size)
         else:


### PR DESCRIPTION
Fixes #30660.

Scaling keeps the per-engine physical expert count fixed, so any target below
`ceil(num_experts * cur_dp / num_physical_experts)` makes `num_redundant_experts`
negative. That request was accepted, then failed on the bare
`assert num_redundant >= 0` in `eplb/policy/default.py`, killing the engine core.

## Test Plan

Qwen3-30B-A3B on 4xH200, launched at DP2:

```bash
vllm serve Qwen/Qwen3-30B-A3B --data-parallel-backend ray --data-parallel-size 2 \
  --tensor-parallel-size 1 --enable-expert-parallel --enable-eplb \
  --enable-elastic-ep --api-server-count 1

curl -X POST localhost:8000/scale_elastic_ep -d '{"new_data_parallel_size": 1}'  # below minimum
curl -X POST localhost:8000/scale_elastic_ep -d '{"new_data_parallel_size": 4}'  # legal
```

```bash
pre-commit run --files vllm/v1/engine/core_client.py \
  vllm/entrypoints/serve/elastic_ep/api_router.py
```

## Test Result

Before: `DP2 -> DP1` was accepted, standby groups were created, the reconfiguration
was committed, and then `AssertionError` in `replicate_experts` took down the
engine core; the server was left unusable.

After: `DP2 -> DP1` is rejected with `Cannot scale to data_parallel_size 1, minimum
is 2`, the server stays alive and keeps serving (`/v1/completions` returns 200),
and `DP2 -> DP4` still returns `{"message":"Scaled to 4 data parallel engines"}`.
