### PR TITLE
Integrate DeepGEMM NVFP4 MegaMoE with fused shared experts

### DIFF
--- a/tests/kernels/moe/test_fused_shared_expert_method.py
+++ b/tests/kernels/moe/test_fused_shared_expert_method.py
@@ -18,6 +18,7 @@ def _runner_with_fused_shared_method() -> tuple[MoERunner, MagicMock]:
     quant_method.mk_fuses_shared_experts = True
 
     raw_shared = MagicMock()
+    raw_shared.shard_sequence_parallel = False
     moe_config = MagicMock()
     moe_config.dp_size = 1
     moe_config.pcp_size = 1
@@ -58,7 +59,7 @@ def test_fused_shared_method_does_not_launch_shared_module_separately():
     passed_weights = runner.routed_experts.forward_modular.call_args.kwargs[
         "topk_weights"
     ]
-    torch.testing.assert_close(passed_weights, topk_weights * 2.5)
+    torch.testing.assert_close(passed_weights, topk_weights)
     assert shared_output is None
     assert output is fused_output
 

--- a/tests/kernels/moe/test_fused_shared_expert_method.py
+++ b/tests/kernels/moe/test_fused_shared_expert_method.py
@@ -1,0 +1,85 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import torch
+
+from vllm.model_executor.layers.fused_moe.runner.moe_runner import MoERunner
+from vllm.model_executor.layers.fused_moe.runner.shared_experts import SharedExperts
+
+
+def _runner_with_fused_shared_method() -> tuple[MoERunner, MagicMock]:
+    runner = object.__new__(MoERunner)
+    torch.nn.Module.__init__(runner)
+    quant_method = MagicMock()
+    quant_method.is_monolithic = False
+    quant_method.mk_fuses_shared_experts = True
+
+    raw_shared = MagicMock()
+    moe_config = MagicMock()
+    moe_config.dp_size = 1
+    moe_config.pcp_size = 1
+    moe_config.is_sequence_parallel = False
+    moe_config.moe_parallel_config.enable_eplb = False
+    moe_config.moe_parallel_config.use_fi_nvl_two_sided_kernels = False
+    runner.moe_config = moe_config
+    runner._shared_experts = SharedExperts(
+        raw_shared,
+        moe_config=moe_config,
+        enable_dbo=False,
+        mk_can_overlap_shared_experts=lambda: True,
+    )
+    runner.routed_experts = MagicMock()
+    runner.routed_experts.quant_method = quant_method
+    runner.router = MagicMock()
+    runner.routed_scaling_factor = 2.5
+    return runner, raw_shared
+
+
+def test_fused_shared_method_does_not_launch_shared_module_separately():
+    runner, raw_shared = _runner_with_fused_shared_method()
+    hidden_states = torch.randn(2, 8)
+    router_logits = torch.randn(2, 4)
+    topk_weights = torch.randn(2, 2)
+    topk_ids = torch.zeros(2, 2, dtype=torch.int32)
+    fused_output = torch.randn_like(hidden_states)
+    runner.router.select_experts.return_value = (topk_weights, topk_ids)
+    runner.routed_experts.forward_modular.return_value = fused_output
+
+    shared_output, output = runner._apply_quant_method(
+        hidden_states,
+        router_logits,
+        shared_experts_input=hidden_states,
+    )
+
+    raw_shared.assert_not_called()
+    passed_weights = runner.routed_experts.forward_modular.call_args.kwargs[
+        "topk_weights"
+    ]
+    torch.testing.assert_close(passed_weights, topk_weights * 2.5)
+    assert shared_output is None
+    assert output is fused_output
+
+
+def test_fused_shared_method_does_not_rescale_combined_output():
+    runner, _ = _runner_with_fused_shared_method()
+    fused_output = torch.randn(2, 8)
+
+    shared_output, output = runner._maybe_apply_routed_scale_to_output(
+        None, fused_output.clone()
+    )
+
+    assert shared_output is None
+    torch.testing.assert_close(output, fused_output)
+
+
+def test_fused_shared_method_uses_single_output_custom_op_schema():
+    runner, _ = _runner_with_fused_shared_method()
+    runner.routed_experts.quant_method = SimpleNamespace(
+        mk_fuses_shared_experts=True,
+    )
+    output = torch.randn(2, 8)
+
+    assert runner._maybe_combine(None, output) is output

--- a/tests/kernels/moe/test_fused_shared_expert_method.py
+++ b/tests/kernels/moe/test_fused_shared_expert_method.py
@@ -1,12 +1,18 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
+import pytest
 import torch
 
-from vllm.model_executor.layers.fused_moe.runner.moe_runner import MoERunner
+from vllm.model_executor.layers.fused_moe.fused_moe_method_base import (
+    FusedMoEMethodBase,
+)
+from vllm.model_executor.layers.fused_moe.runner.moe_runner import (
+    MoERunner,
+    _moe_forward,
+)
 from vllm.model_executor.layers.fused_moe.runner.shared_experts import SharedExperts
 
 
@@ -36,6 +42,9 @@ def _runner_with_fused_shared_method() -> tuple[MoERunner, MagicMock]:
     runner.routed_experts.quant_method = quant_method
     runner.router = MagicMock()
     runner.routed_scaling_factor = 2.5
+    runner.routed_output_transform = None
+    runner._raw_shared_experts = raw_shared
+    runner.enable_dbo = False
     return runner, raw_shared
 
 
@@ -78,9 +87,77 @@ def test_fused_shared_method_does_not_rescale_combined_output():
 
 def test_fused_shared_method_uses_single_output_custom_op_schema():
     runner, _ = _runner_with_fused_shared_method()
-    runner.routed_experts.quant_method = SimpleNamespace(
-        mk_fuses_shared_experts=True,
-    )
-    output = torch.randn(2, 8)
 
-    assert runner._maybe_combine(None, output) is output
+    with patch(
+        "vllm.model_executor.layers.fused_moe.runner.moe_runner."
+        "current_platform.is_cpu",
+        return_value=True,
+    ):
+        assert runner._select_forward() is _moe_forward
+
+
+@pytest.mark.parametrize(
+    "disabled_attribute",
+    ["shard_sequence_parallel", "use_fi_nvl_two_sided_kernels"],
+)
+def test_fused_shared_method_skips_separate_shared_when_overlap_is_disabled(
+    disabled_attribute,
+):
+    runner, raw_shared = _runner_with_fused_shared_method()
+    if disabled_attribute == "shard_sequence_parallel":
+        raw_shared.shard_sequence_parallel = True
+    else:
+        runner.moe_config.moe_parallel_config.use_fi_nvl_two_sided_kernels = True
+    hidden_states = torch.randn(2, 8)
+    runner.router.select_experts.return_value = (
+        torch.randn(2, 2),
+        torch.zeros(2, 2, dtype=torch.int32),
+    )
+    runner.routed_experts.forward_modular.return_value = torch.randn_like(hidden_states)
+
+    runner._apply_quant_method(
+        hidden_states,
+        torch.randn(2, 4),
+        shared_experts_input=hidden_states,
+    )
+
+    raw_shared.assert_not_called()
+    assert runner._shared_experts._output == [None, None]
+
+
+def test_replace_quant_method_rebinds_and_reselects_forward():
+    runner, raw_shared = _runner_with_fused_shared_method()
+    replacement = MagicMock()
+    replacement.mk_fuses_shared_experts = False
+    replacement.supports_dbo = True
+    selected_forward = object()
+    runner._select_forward = MagicMock(return_value=selected_forward)
+    runner.routed_experts._replace_quant_method.side_effect = lambda method: setattr(
+        runner.routed_experts, "quant_method", method
+    )
+
+    runner._replace_quant_method(replacement)
+
+    replacement.bind_shared_experts.assert_called_once_with(
+        raw_shared,
+        routed_output_transform=None,
+    )
+    replacement.bind_routed_scaling_factor.assert_called_once_with(2.5)
+    assert runner._forward_entry is selected_forward
+
+
+def test_runner_rejects_dbo_for_unsupported_method():
+    runner, _ = _runner_with_fused_shared_method()
+    runner.enable_dbo = True
+    runner.routed_experts.quant_method.supports_dbo = False
+
+    with pytest.raises(NotImplementedError, match="does not support DBO"):
+        runner._bind_quant_method()
+
+
+def test_fused_method_without_scaling_bind_fails_closed():
+    method = MagicMock(spec=FusedMoEMethodBase)
+    method.mk_fuses_shared_experts = True
+
+    with pytest.raises(NotImplementedError, match="routed_scaling_factor"):
+        FusedMoEMethodBase.bind_routed_scaling_factor(method, 2.0)

--- a/tests/kernels/moe/test_prepare_megamoe.py
+++ b/tests/kernels/moe/test_prepare_megamoe.py
@@ -122,7 +122,7 @@ def test_prepare_nvfp4_megamoe_inputs_cuda_graph_replay() -> None:
     with torch.cuda.graph(graph):
         run()
     graph.replay()
-    torch.cuda.synchronize()
+    torch.accelerator.synchronize()
 
     expected_x, expected_sf = ops.scaled_fp4_quant(
         x_bf16, gscale, is_sf_swizzled_layout=False

--- a/tests/kernels/moe/test_prepare_megamoe.py
+++ b/tests/kernels/moe/test_prepare_megamoe.py
@@ -62,9 +62,7 @@ def test_prepare_nvfp4_megamoe_inputs(
     x_sf = torch.empty(
         (num_tokens, hidden_size // 64), dtype=torch.int32, device="cuda"
     )
-    staged_topk_ids = torch.empty(
-        (num_tokens, top_k), dtype=torch.int64, device="cuda"
-    )
+    staged_topk_ids = torch.empty((num_tokens, top_k), dtype=torch.int64, device="cuda")
     staged_topk_weights = torch.empty_like(topk_weights)
     prepare_nvfp4_megamoe_inputs(
         hidden_states,

--- a/tests/kernels/moe/test_prepare_megamoe.py
+++ b/tests/kernels/moe/test_prepare_megamoe.py
@@ -1,0 +1,138 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for DeepGEMM MegaMoE input staging."""
+
+import pytest
+import torch
+
+from vllm import _custom_ops as ops
+from vllm.model_executor.layers.fused_moe.prepare_megamoe import (
+    prepare_nvfp4_megamoe_inputs,
+)
+from vllm.platforms import current_platform
+
+if not current_platform.has_device_capability(100):
+    pytest.skip("NVFP4 MegaMoE staging requires SM100", allow_module_level=True)
+
+
+@pytest.mark.parametrize("num_tokens,hidden_size", [(1, 6144), (8, 128), (31, 128)])
+@pytest.mark.parametrize("global_scale_value", [0.0078125, 1.0, 128.0])
+@pytest.mark.parametrize("ids_dtype", [torch.int32, torch.int64])
+@torch.inference_mode()
+def test_prepare_nvfp4_megamoe_inputs(
+    num_tokens: int,
+    hidden_size: int,
+    global_scale_value: float,
+    ids_dtype: torch.dtype,
+) -> None:
+    top_k = 8
+    generator = torch.Generator(device="cuda").manual_seed(17)
+    hidden_states = torch.randn(
+        (num_tokens, hidden_size),
+        dtype=torch.bfloat16,
+        device="cuda",
+        generator=generator,
+    )
+    global_scale = torch.tensor(global_scale_value, dtype=torch.float32, device="cuda")
+    topk_ids = torch.randint(
+        0,
+        256,
+        (num_tokens, top_k),
+        dtype=ids_dtype,
+        device="cuda",
+        generator=generator,
+    )
+    topk_weights = torch.rand(
+        (num_tokens, top_k),
+        dtype=torch.float32,
+        device="cuda",
+        generator=generator,
+    )
+    is_padding = torch.arange(num_tokens, device="cuda") % 3 == 0
+
+    expected_x, expected_sf = ops.scaled_fp4_quant(
+        hidden_states,
+        global_scale,
+        is_sf_swizzled_layout=False,
+    )
+    expected_topk_ids = torch.where(is_padding[:, None], -1, topk_ids).to(torch.int32)
+    expected_topk_weights = torch.where(is_padding[:, None], 0.0, topk_weights)
+
+    x = torch.empty_like(expected_x)
+    x_sf = torch.empty(
+        (num_tokens, hidden_size // 64), dtype=torch.int32, device="cuda"
+    )
+    staged_topk_ids = torch.empty((num_tokens, top_k), dtype=torch.int32, device="cuda")
+    staged_topk_weights = torch.empty_like(topk_weights)
+    prepare_nvfp4_megamoe_inputs(
+        hidden_states,
+        global_scale,
+        topk_weights,
+        topk_ids,
+        x,
+        x_sf,
+        staged_topk_ids,
+        staged_topk_weights,
+        is_padding=is_padding,
+    )
+
+    torch.testing.assert_close(x, expected_x, rtol=0, atol=0)
+    torch.testing.assert_close(
+        x_sf,
+        expected_sf.contiguous().view(torch.uint8).view(torch.int32),
+        rtol=0,
+        atol=0,
+    )
+    torch.testing.assert_close(staged_topk_ids, expected_topk_ids, rtol=0, atol=0)
+    torch.testing.assert_close(
+        staged_topk_weights, expected_topk_weights, rtol=0, atol=0
+    )
+
+
+@torch.inference_mode()
+def test_prepare_nvfp4_megamoe_inputs_cuda_graph_replay() -> None:
+    num_tokens, hidden_size, top_k = 1, 6144, 8
+    x_bf16 = torch.randn((num_tokens, hidden_size), dtype=torch.bfloat16, device="cuda")
+    gscale = torch.tensor(128.0, dtype=torch.float32, device="cuda")
+    weights = torch.rand((num_tokens, top_k), device="cuda")
+    ids = torch.arange(top_k, dtype=torch.int32, device="cuda")[None]
+    x_fp4 = torch.empty(
+        (num_tokens, hidden_size // 2), dtype=torch.uint8, device="cuda"
+    )
+    x_sf = torch.empty(
+        (num_tokens, hidden_size // 64), dtype=torch.int32, device="cuda"
+    )
+    staged_ids = torch.empty_like(ids)
+    staged_weights = torch.empty_like(weights)
+
+    def run() -> None:
+        prepare_nvfp4_megamoe_inputs(
+            x_bf16,
+            gscale,
+            weights,
+            ids,
+            x_fp4,
+            x_sf,
+            staged_ids,
+            staged_weights,
+        )
+
+    run()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        run()
+    graph.replay()
+    torch.cuda.synchronize()
+
+    expected_x, expected_sf = ops.scaled_fp4_quant(
+        x_bf16, gscale, is_sf_swizzled_layout=False
+    )
+    torch.testing.assert_close(x_fp4, expected_x, rtol=0, atol=0)
+    torch.testing.assert_close(
+        x_sf,
+        expected_sf.contiguous().view(torch.uint8).view(torch.int32),
+        rtol=0,
+        atol=0,
+    )
+    torch.testing.assert_close(staged_ids, ids, rtol=0, atol=0)
+    torch.testing.assert_close(staged_weights, weights, rtol=0, atol=0)

--- a/tests/kernels/moe/test_prepare_megamoe.py
+++ b/tests/kernels/moe/test_prepare_megamoe.py
@@ -62,7 +62,9 @@ def test_prepare_nvfp4_megamoe_inputs(
     x_sf = torch.empty(
         (num_tokens, hidden_size // 64), dtype=torch.int32, device="cuda"
     )
-    staged_topk_ids = torch.empty((num_tokens, top_k), dtype=torch.int32, device="cuda")
+    staged_topk_ids = torch.empty(
+        (num_tokens, top_k), dtype=torch.int64, device="cuda"
+    )
     staged_topk_weights = torch.empty_like(topk_weights)
     prepare_nvfp4_megamoe_inputs(
         hidden_states,
@@ -102,7 +104,7 @@ def test_prepare_nvfp4_megamoe_inputs_cuda_graph_replay() -> None:
     x_sf = torch.empty(
         (num_tokens, hidden_size // 64), dtype=torch.int32, device="cuda"
     )
-    staged_ids = torch.empty_like(ids)
+    staged_ids = torch.empty(ids.shape, dtype=torch.int64, device="cuda")
     staged_weights = torch.empty_like(weights)
 
     def run() -> None:
@@ -134,5 +136,5 @@ def test_prepare_nvfp4_megamoe_inputs_cuda_graph_replay() -> None:
         rtol=0,
         atol=0,
     )
-    torch.testing.assert_close(staged_ids, ids, rtol=0, atol=0)
+    torch.testing.assert_close(staged_ids, ids.to(torch.int64), rtol=0, atol=0)
     torch.testing.assert_close(staged_weights, weights, rtol=0, atol=0)

--- a/tests/quantization/test_modelopt.py
+++ b/tests/quantization/test_modelopt.py
@@ -6,6 +6,7 @@ Run `pytest tests/quantization/test_modelopt.py`.
 """
 
 import os
+from types import SimpleNamespace
 from typing import Any, NoReturn
 from unittest.mock import MagicMock, Mock, patch
 
@@ -147,6 +148,19 @@ def test_modelopt_nvfp4_selects_deep_gemm_mega_moe():
     )
 
 
+def test_modelopt_nvfp4_excludes_deep_gemm_mega_moe():
+    prefix = "model.layers.3.mlp.experts"
+    config = ModelOptNvFp4Config(
+        is_checkpoint_nvfp4_serialized=True,
+        kv_cache_quant_algo=None,
+        exclude_modules=[prefix],
+    )
+    layer = _mock_routed_experts()
+    layer.moe_config.moe_backend = "deep_gemm_mega_moe"
+
+    assert config.get_quant_method(layer, prefix=prefix) is None
+
+
 def test_modelopt_nvfp4_mega_moe_does_not_fuse_shared_before_output_transform():
     method = object.__new__(ModelOptNvFp4MegaMoE)
     shared_experts = MagicMock()
@@ -173,6 +187,139 @@ def test_modelopt_w4a16_rejects_deep_gemm_mega_moe():
 
     with pytest.raises(ValueError, match="requires NVFP4 W4A4"):
         config.get_quant_method(layer, prefix="model.layers.3.mlp.experts")
+
+
+def test_modelopt_nvfp4_mega_moe_uses_inverse_activation_global_scale():
+    method = object.__new__(ModelOptNvFp4MegaMoE)
+    method.moe = SimpleNamespace(max_num_tokens=2)
+    method._shared_experts_layer = None
+    method._routed_scaling_factor = 1.0
+    method._scaled_fp4_quant = MagicMock(
+        return_value=(
+            torch.zeros((2, 4), dtype=torch.uint8),
+            torch.zeros((2, 4), dtype=torch.uint8),
+        )
+    )
+    method._symm_buffer = SimpleNamespace(
+        x=torch.empty((2, 4), dtype=torch.uint8),
+        x_sf=torch.empty((2, 1), dtype=torch.int32),
+        topk_idx=torch.empty((2, 1), dtype=torch.int32),
+        topk_weights=torch.empty((2, 1)),
+    )
+    method._deep_gemm = MagicMock()
+    layer = SimpleNamespace(
+        _deep_gemm_mega_a1_scale=torch.tensor(0.125),
+        _deep_gemm_mega_l1_weights=MagicMock(),
+        _deep_gemm_mega_l2_weights=MagicMock(),
+        _deep_gemm_mega_l1_alphas=MagicMock(),
+        _deep_gemm_mega_l2_alphas=MagicMock(),
+        _deep_gemm_mega_a2_scales=MagicMock(),
+        swiglu_limit=None,
+    )
+    x = torch.zeros((2, 4), dtype=torch.bfloat16)
+    topk_weights = torch.zeros((2, 1))
+    topk_ids = torch.zeros((2, 1), dtype=torch.int32)
+
+    method.apply(layer, x, topk_weights, topk_ids, None, None)
+
+    global_scale = method._scaled_fp4_quant.call_args.args[1]
+    torch.testing.assert_close(global_scale, torch.tensor(8.0))
+
+
+def test_modelopt_nvfp4_mega_moe_initializes_runtime_on_ep_group():
+    ep_group = SimpleNamespace(device_group=MagicMock())
+    deep_gemm = MagicMock()
+    symm_buffer = object()
+    deep_gemm.get_symm_buffer_for_mega_moe.return_value = symm_buffer
+
+    def make_method():
+        method = object.__new__(ModelOptNvFp4MegaMoE)
+        method.moe = SimpleNamespace(
+            num_experts=8,
+            max_num_tokens=16,
+            experts_per_token=2,
+            hidden_dim=64,
+            intermediate_size=32,
+        )
+        method._num_shared_experts = 1
+        return method
+
+    with (
+        patch("vllm.distributed.get_ep_group", return_value=ep_group),
+        patch("torch.accelerator.current_device_index", return_value=0),
+    ):
+        first = make_method()
+        second = make_method()
+        first._initialize_runtime(deep_gemm)
+        second._initialize_runtime(deep_gemm)
+
+    deep_gemm.get_symm_buffer_for_mega_moe.assert_called_once()
+    assert first._symm_buffer is symm_buffer
+    assert second._symm_buffer is symm_buffer
+    assert ep_group._modelopt_nvfp4_mega_moe_buffers
+
+
+def test_modelopt_nvfp4_mega_moe_finishes_replacement_setup():
+    method = object.__new__(ModelOptNvFp4MegaMoE)
+    method._shared_experts_layer = None
+    method._transform_shared_weights = MagicMock()
+    method._initialize_runtime = MagicMock()
+    layer = SimpleNamespace(_deep_gemm_mega_l1_weights=object())
+    deep_gemm = MagicMock()
+
+    with patch(
+        "vllm.utils.deep_gemm._import_deep_gemm",
+        return_value=deep_gemm,
+    ):
+        method.process_weights_after_loading(layer)
+
+    method._transform_shared_weights.assert_called_once_with(deep_gemm)
+    method._initialize_runtime.assert_called_once_with(deep_gemm)
+
+
+def test_modelopt_nvfp4_mega_moe_reuses_and_releases_shared_weights():
+    shared_experts = torch.nn.Module()
+    shared_experts.gate_up_proj = torch.nn.Linear(
+        4,
+        4,
+        bias=False,
+        dtype=torch.bfloat16,
+    )
+    shared_experts.down_proj = torch.nn.Linear(
+        2,
+        4,
+        bias=False,
+        dtype=torch.bfloat16,
+    )
+    deep_gemm = MagicMock()
+    transformed_l1 = torch.empty((4, 4), dtype=torch.bfloat16)
+    transformed_l2 = shared_experts.down_proj.weight.data
+    deep_gemm.transform_weights_for_mega_moe.return_value = (
+        transformed_l1,
+        transformed_l2,
+    )
+
+    def make_method():
+        method = object.__new__(ModelOptNvFp4MegaMoE)
+        method.moe = SimpleNamespace(hidden_dim=4, intermediate_size=2)
+        method._shared_experts_layer = shared_experts
+        method._shared_l1_weights = None
+        method._shared_l2_weights = None
+        method._num_shared_experts = 0
+        return method
+
+    first = make_method()
+    first._transform_shared_weights(deep_gemm)
+    second = make_method()
+    second._transform_shared_weights(deep_gemm)
+
+    deep_gemm.transform_weights_for_mega_moe.assert_called_once()
+    assert first._shared_l1_weights is transformed_l1
+    assert second._shared_l1_weights is transformed_l1
+    assert first._shared_l2_weights is transformed_l2
+    assert second._shared_l2_weights is transformed_l2
+    assert shared_experts.gate_up_proj.weight is None
+    assert shared_experts.down_proj.weight is None
 
 
 def test_modelopt_fp8_updates_weight_dims_after_transpose():

--- a/tests/quantization/test_modelopt.py
+++ b/tests/quantization/test_modelopt.py
@@ -72,6 +72,13 @@ def _mock_lm_head() -> Mock:
     return lm_head
 
 
+def _mock_routed_experts() -> RoutedExperts:
+    layer = object.__new__(RoutedExperts)
+    torch.nn.Module.__init__(layer)
+    layer.moe_config = MagicMock()
+    return layer
+
+
 def _mixed_precision_config(quantized_layers: dict) -> ModelOptMixedPrecisionConfig:
     return ModelOptMixedPrecisionConfig(
         kv_cache_quant_method=None,
@@ -123,7 +130,7 @@ def test_modelopt_nvfp4_selects_deep_gemm_mega_moe():
         kv_cache_quant_algo=None,
         exclude_modules=[],
     )
-    layer = MagicMock(spec=RoutedExperts)
+    layer = _mock_routed_experts()
     layer.moe_config.moe_backend = "deep_gemm_mega_moe"
     expected = MagicMock(spec=ModelOptNvFp4MegaMoE)
 
@@ -140,6 +147,20 @@ def test_modelopt_nvfp4_selects_deep_gemm_mega_moe():
     )
 
 
+def test_modelopt_nvfp4_mega_moe_does_not_fuse_shared_before_output_transform():
+    method = object.__new__(ModelOptNvFp4MegaMoE)
+    shared_experts = MagicMock()
+
+    method.bind_shared_experts(shared_experts)
+    assert method._shared_experts_layer is shared_experts
+
+    method.bind_shared_experts(
+        shared_experts,
+        routed_output_transform=MagicMock(),
+    )
+    assert method._shared_experts_layer is None
+
+
 def test_modelopt_w4a16_rejects_deep_gemm_mega_moe():
     config = ModelOptNvFp4Config(
         quant_method="W4A16_NVFP4",
@@ -147,7 +168,7 @@ def test_modelopt_w4a16_rejects_deep_gemm_mega_moe():
         kv_cache_quant_algo=None,
         exclude_modules=[],
     )
-    layer = MagicMock(spec=RoutedExperts)
+    layer = _mock_routed_experts()
     layer.moe_config.moe_backend = "deep_gemm_mega_moe"
 
     with pytest.raises(ValueError, match="requires NVFP4 W4A4"):

--- a/tests/quantization/test_modelopt.py
+++ b/tests/quantization/test_modelopt.py
@@ -19,6 +19,7 @@ from vllm.model_executor.kernels.linear import (
     HummingNvFp4LinearKernel,
     MarlinNvFp4LinearKernel,
 )
+from vllm.model_executor.layers.fused_moe.routed_experts import RoutedExperts
 from vllm.model_executor.layers.linear import UnquantizedLinearMethod
 from vllm.model_executor.layers.quantization.modelopt import (
     ModelOptFp8Config,
@@ -27,6 +28,7 @@ from vllm.model_executor.layers.quantization.modelopt import (
     ModelOptMxFp8Config,
     ModelOptNvFp4Config,
     ModelOptNvFp4LinearMethod,
+    ModelOptNvFp4MegaMoE,
     ModelOptNvFp4W4A16LinearMethod,
 )
 from vllm.model_executor.layers.vocab_parallel_embedding import (
@@ -113,6 +115,43 @@ def test_modelopt_nvfp4_quantizes_parallel_lm_head():
         method = config.get_quant_method(_mock_lm_head(), prefix="lm_head")
 
     assert isinstance(method, ModelOptNvFp4LinearMethod)
+
+
+def test_modelopt_nvfp4_selects_deep_gemm_mega_moe():
+    config = ModelOptNvFp4Config(
+        is_checkpoint_nvfp4_serialized=True,
+        kv_cache_quant_algo=None,
+        exclude_modules=[],
+    )
+    layer = MagicMock(spec=RoutedExperts)
+    layer.moe_config.moe_backend = "deep_gemm_mega_moe"
+    expected = MagicMock(spec=ModelOptNvFp4MegaMoE)
+
+    with patch(
+        "vllm.model_executor.layers.quantization.modelopt.ModelOptNvFp4MegaMoE",
+        return_value=expected,
+    ) as mega_moe_cls:
+        method = config.get_quant_method(layer, prefix="model.layers.3.mlp.experts")
+
+    assert method is expected
+    mega_moe_cls.assert_called_once_with(
+        quant_config=config,
+        moe_config=layer.moe_config,
+    )
+
+
+def test_modelopt_w4a16_rejects_deep_gemm_mega_moe():
+    config = ModelOptNvFp4Config(
+        quant_method="W4A16_NVFP4",
+        is_checkpoint_nvfp4_serialized=True,
+        kv_cache_quant_algo=None,
+        exclude_modules=[],
+    )
+    layer = MagicMock(spec=RoutedExperts)
+    layer.moe_config.moe_backend = "deep_gemm_mega_moe"
+
+    with pytest.raises(ValueError, match="requires NVFP4 W4A4"):
+        config.get_quant_method(layer, prefix="model.layers.3.mlp.experts")
 
 
 def test_modelopt_fp8_updates_weight_dims_after_transpose():

--- a/tests/quantization/test_modelopt.py
+++ b/tests/quantization/test_modelopt.py
@@ -20,6 +20,7 @@ from vllm.model_executor.kernels.linear import (
     HummingNvFp4LinearKernel,
     MarlinNvFp4LinearKernel,
 )
+from vllm.model_executor.layers.activation import SiluAndMul
 from vllm.model_executor.layers.fused_moe.routed_experts import RoutedExperts
 from vllm.model_executor.layers.linear import UnquantizedLinearMethod
 from vllm.model_executor.layers.quantization.modelopt import (
@@ -77,7 +78,28 @@ def _mock_routed_experts() -> RoutedExperts:
     layer = object.__new__(RoutedExperts)
     torch.nn.Module.__init__(layer)
     layer.moe_config = MagicMock()
+    layer.apply_router_weight_on_input = False
     return layer
+
+
+def _compatible_shared_experts() -> SimpleNamespace:
+    gate_up = SimpleNamespace(
+        weight=torch.empty((4, 4), dtype=torch.bfloat16),
+        bias=None,
+        quant_method=UnquantizedLinearMethod(),
+    )
+    down = SimpleNamespace(
+        weight=torch.empty((4, 2), dtype=torch.bfloat16),
+        bias=None,
+        quant_method=UnquantizedLinearMethod(),
+    )
+    return SimpleNamespace(
+        gate_up_proj=gate_up,
+        down_proj=down,
+        act_fn=object.__new__(SiluAndMul),
+        expert_gate=None,
+        shard_sequence_parallel=False,
+    )
 
 
 def _mixed_precision_config(quantized_layers: dict) -> ModelOptMixedPrecisionConfig:
@@ -161,9 +183,24 @@ def test_modelopt_nvfp4_excludes_deep_gemm_mega_moe():
     assert config.get_quant_method(layer, prefix=prefix) is None
 
 
+def test_modelopt_nvfp4_mega_moe_rejects_router_weight_on_input():
+    config = ModelOptNvFp4Config(
+        is_checkpoint_nvfp4_serialized=True,
+        kv_cache_quant_algo=None,
+        exclude_modules=[],
+    )
+    layer = _mock_routed_experts()
+    layer.moe_config.moe_backend = "deep_gemm_mega_moe"
+    layer.apply_router_weight_on_input = True
+
+    with pytest.raises(NotImplementedError, match="apply_router_weight_on_input"):
+        config.get_quant_method(layer, prefix="model.layers.3.mlp.experts")
+
+
 def test_modelopt_nvfp4_mega_moe_does_not_fuse_shared_before_output_transform():
     method = object.__new__(ModelOptNvFp4MegaMoE)
-    shared_experts = MagicMock()
+    method.moe = SimpleNamespace(hidden_dim=4, intermediate_size=2)
+    shared_experts = _compatible_shared_experts()
 
     method.bind_shared_experts(shared_experts)
     assert method._shared_experts_layer is shared_experts
@@ -172,6 +209,27 @@ def test_modelopt_nvfp4_mega_moe_does_not_fuse_shared_before_output_transform():
         shared_experts,
         routed_output_transform=MagicMock(),
     )
+    assert method._shared_experts_layer is None
+
+
+@pytest.mark.parametrize(
+    "attribute,value",
+    [
+        ("expert_gate", object()),
+        ("shard_sequence_parallel", True),
+    ],
+)
+def test_modelopt_nvfp4_mega_moe_falls_back_for_incompatible_shared_experts(
+    attribute: str,
+    value: object,
+):
+    method = object.__new__(ModelOptNvFp4MegaMoE)
+    method.moe = SimpleNamespace(hidden_dim=4, intermediate_size=2)
+    shared_experts = _compatible_shared_experts()
+    setattr(shared_experts, attribute, value)
+
+    method.bind_shared_experts(shared_experts)
+
     assert method._shared_experts_layer is None
 
 
@@ -189,17 +247,11 @@ def test_modelopt_w4a16_rejects_deep_gemm_mega_moe():
         config.get_quant_method(layer, prefix="model.layers.3.mlp.experts")
 
 
-def test_modelopt_nvfp4_mega_moe_uses_inverse_activation_global_scale():
+def test_modelopt_nvfp4_mega_moe_uses_cached_inverse_activation_global_scale():
     method = object.__new__(ModelOptNvFp4MegaMoE)
     method.moe = SimpleNamespace(max_num_tokens=2)
     method._shared_experts_layer = None
     method._routed_scaling_factor = 1.0
-    method._scaled_fp4_quant = MagicMock(
-        return_value=(
-            torch.zeros((2, 4), dtype=torch.uint8),
-            torch.zeros((2, 4), dtype=torch.uint8),
-        )
-    )
     method._symm_buffer = SimpleNamespace(
         x=torch.empty((2, 4), dtype=torch.uint8),
         x_sf=torch.empty((2, 1), dtype=torch.int32),
@@ -207,8 +259,10 @@ def test_modelopt_nvfp4_mega_moe_uses_inverse_activation_global_scale():
         topk_weights=torch.empty((2, 1)),
     )
     method._deep_gemm = MagicMock()
+    gscale = torch.tensor(8.0)
     layer = SimpleNamespace(
         _deep_gemm_mega_a1_scale=torch.tensor(0.125),
+        _deep_gemm_mega_a1_gscale=gscale,
         _deep_gemm_mega_l1_weights=MagicMock(),
         _deep_gemm_mega_l2_weights=MagicMock(),
         _deep_gemm_mega_l1_alphas=MagicMock(),
@@ -220,10 +274,14 @@ def test_modelopt_nvfp4_mega_moe_uses_inverse_activation_global_scale():
     topk_weights = torch.zeros((2, 1))
     topk_ids = torch.zeros((2, 1), dtype=torch.int32)
 
-    method.apply(layer, x, topk_weights, topk_ids, None, None)
+    with patch(
+        "vllm.model_executor.layers.quantization.modelopt.prepare_nvfp4_megamoe_inputs"
+    ) as prepare:
+        method.apply(layer, x, topk_weights, topk_ids, None, None)
 
-    global_scale = method._scaled_fp4_quant.call_args.args[1]
-    torch.testing.assert_close(global_scale, torch.tensor(8.0))
+    assert prepare.call_args.args[1] is gscale
+    assert prepare.call_args.args[4] is method._symm_buffer.x
+    assert prepare.call_args.args[5] is method._symm_buffer.x_sf
 
 
 def test_modelopt_nvfp4_mega_moe_initializes_runtime_on_ep_group():
@@ -264,12 +322,22 @@ def test_modelopt_nvfp4_mega_moe_finishes_replacement_setup():
     method._shared_experts_layer = None
     method._transform_shared_weights = MagicMock()
     method._initialize_runtime = MagicMock()
-    layer = SimpleNamespace(_deep_gemm_mega_l1_weights=object())
+    layer = SimpleNamespace(
+        _deep_gemm_mega_l1_weights=object(),
+        _deep_gemm_mega_a1_gscale=object(),
+    )
     deep_gemm = MagicMock()
 
-    with patch(
-        "vllm.utils.deep_gemm._import_deep_gemm",
-        return_value=deep_gemm,
+    with (
+        patch(
+            "vllm.utils.deep_gemm._import_deep_gemm",
+            return_value=deep_gemm,
+        ),
+        patch.object(
+            current_platform,
+            "is_device_capability_family",
+            return_value=True,
+        ),
     ):
         method.process_weights_after_loading(layer)
 

--- a/tests/quantization/test_modelopt.py
+++ b/tests/quantization/test_modelopt.py
@@ -255,7 +255,7 @@ def test_modelopt_nvfp4_mega_moe_uses_cached_inverse_activation_global_scale():
     method._symm_buffer = SimpleNamespace(
         x=torch.empty((2, 4), dtype=torch.uint8),
         x_sf=torch.empty((2, 1), dtype=torch.int32),
-        topk_idx=torch.empty((2, 1), dtype=torch.int32),
+        topk_idx=torch.empty((2, 1), dtype=torch.int64),
         topk_weights=torch.empty((2, 1)),
     )
     method._deep_gemm = MagicMock()

--- a/tests/quantization/test_modelopt.py
+++ b/tests/quantization/test_modelopt.py
@@ -87,11 +87,13 @@ def _compatible_shared_experts() -> SimpleNamespace:
         weight=torch.empty((4, 4), dtype=torch.bfloat16),
         bias=None,
         quant_method=UnquantizedLinearMethod(),
+        tp_size=1,
     )
     down = SimpleNamespace(
         weight=torch.empty((4, 2), dtype=torch.bfloat16),
         bias=None,
         quant_method=UnquantizedLinearMethod(),
+        tp_size=1,
     )
     return SimpleNamespace(
         gate_up_proj=gate_up,
@@ -227,6 +229,20 @@ def test_modelopt_nvfp4_mega_moe_falls_back_for_incompatible_shared_experts(
     method.moe = SimpleNamespace(hidden_dim=4, intermediate_size=2)
     shared_experts = _compatible_shared_experts()
     setattr(shared_experts, attribute, value)
+
+    method.bind_shared_experts(shared_experts)
+
+    assert method._shared_experts_layer is None
+
+
+@pytest.mark.parametrize("projection", ["gate_up_proj", "down_proj"])
+def test_modelopt_nvfp4_mega_moe_does_not_fuse_tp_sharded_shared_experts(
+    projection: str,
+):
+    method = object.__new__(ModelOptNvFp4MegaMoE)
+    method.moe = SimpleNamespace(hidden_dim=4, intermediate_size=2)
+    shared_experts = _compatible_shared_experts()
+    getattr(shared_experts, projection).tp_size = 2
 
     method.bind_shared_experts(shared_experts)
 

--- a/vllm/model_executor/layers/fused_moe/fused_moe_method_base.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe_method_base.py
@@ -51,6 +51,16 @@ class FusedMoEMethodBase(QuantizeMethodBase):
         return False
 
     @property
+    def supports_dbo(self) -> bool:
+        """Whether the method supports concurrent DBO microbatches."""
+        return True
+
+    @property
+    def requires_moe_quant_config(self) -> bool:
+        """Whether the runner must lazily build a modular quant config."""
+        return True
+
+    @property
     def output_is_reduced(self) -> bool:
         """Whether the method returns the final cross-rank expert result."""
         return self.moe_kernel is not None and self.moe_kernel.output_is_reduced()
@@ -66,7 +76,11 @@ class FusedMoEMethodBase(QuantizeMethodBase):
 
     def bind_routed_scaling_factor(self, routed_scaling_factor: float) -> None:
         """Bind the routed-output scale for methods that add shared output."""
-        return
+        if self.mk_fuses_shared_experts and routed_scaling_factor != 1.0:
+            raise NotImplementedError(
+                f"{type(self).__name__} fuses shared experts but does not "
+                "consume routed_scaling_factor."
+            )
 
     @abstractmethod
     def create_weights(

--- a/vllm/model_executor/layers/fused_moe/fused_moe_method_base.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe_method_base.py
@@ -47,14 +47,7 @@ class FusedMoEMethodBase(QuantizeMethodBase):
 
     @property
     def mk_fuses_shared_experts(self) -> bool:
-        """Whether the method returns routed + shared output in one kernel.
-
-        Most MoE methods either run shared experts on a separate stream or ask
-        the modular kernel to schedule them while dispatch/combine is in flight.
-        Cooperative mega-kernels are different: they consume the shared expert
-        weights and input directly, so the runner must not launch or add the
-        shared MLP a second time.
-        """
+        """Whether one kernel returns the combined routed and shared output."""
         return False
 
     @property
@@ -62,13 +55,17 @@ class FusedMoEMethodBase(QuantizeMethodBase):
         """Whether the method returns the final cross-rank expert result."""
         return self.moe_kernel is not None and self.moe_kernel.output_is_reduced()
 
-    def bind_shared_experts(self, shared_experts: torch.nn.Module | None) -> None:
-        """Bind the model's shared-expert module before post-load processing.
+    def bind_shared_experts(
+        self,
+        shared_experts: torch.nn.Module | None,
+        *,
+        routed_output_transform: torch.nn.Module | None = None,
+    ) -> None:
+        """Bind shared experts for methods that transform them after loading."""
+        return
 
-        This is a no-op for regular kernels. Cooperative mega-kernels override
-        it so shared weights can be transformed after checkpoint loading, at
-        the same lifecycle point as routed weights.
-        """
+    def bind_routed_scaling_factor(self, routed_scaling_factor: float) -> None:
+        """Bind the routed-output scale for methods that add shared output."""
         return
 
     @abstractmethod

--- a/vllm/model_executor/layers/fused_moe/fused_moe_method_base.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe_method_base.py
@@ -45,6 +45,32 @@ class FusedMoEMethodBase(QuantizeMethodBase):
             self.moe_kernel is not None and self.moe_kernel.can_overlap_shared_experts
         )
 
+    @property
+    def mk_fuses_shared_experts(self) -> bool:
+        """Whether the method returns routed + shared output in one kernel.
+
+        Most MoE methods either run shared experts on a separate stream or ask
+        the modular kernel to schedule them while dispatch/combine is in flight.
+        Cooperative mega-kernels are different: they consume the shared expert
+        weights and input directly, so the runner must not launch or add the
+        shared MLP a second time.
+        """
+        return False
+
+    @property
+    def output_is_reduced(self) -> bool:
+        """Whether the method returns the final cross-rank expert result."""
+        return self.moe_kernel is not None and self.moe_kernel.output_is_reduced()
+
+    def bind_shared_experts(self, shared_experts: torch.nn.Module | None) -> None:
+        """Bind the model's shared-expert module before post-load processing.
+
+        This is a no-op for regular kernels. Cooperative mega-kernels override
+        it so shared weights can be transformed after checkpoint loading, at
+        the same lifecycle point as routed weights.
+        """
+        return
+
     @abstractmethod
     def create_weights(
         self,

--- a/vllm/model_executor/layers/fused_moe/prepare_megamoe.py
+++ b/vllm/model_executor/layers/fused_moe/prepare_megamoe.py
@@ -1,0 +1,241 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Input staging kernels for DeepGEMM MegaMoE."""
+
+import torch
+
+from vllm.triton_utils import tl, triton
+
+
+@triton.jit
+def _reciprocal_approximate_ftz(x):
+    return tl.inline_asm_elementwise(
+        "rcp.approx.ftz.f32 $0, $1;",
+        constraints="=f,f",
+        args=[x],
+        dtype=tl.float32,
+        is_pure=True,
+        pack=1,
+    )
+
+
+@triton.jit
+def _fp32x2_to_fp4x2(x_lo, x_hi):
+    return tl.inline_asm_elementwise(
+        """
+        {
+            .reg .b8 packed;
+            cvt.rn.satfinite.e2m1x2.f32 packed, $1, $2;
+            cvt.u32.u8 $0, packed;
+        }
+        """,
+        constraints="=r,f,f",
+        args=[x_hi, x_lo],
+        dtype=tl.uint32,
+        is_pure=True,
+        pack=1,
+    ).to(tl.uint8)
+
+
+@triton.jit
+def _prepare_nvfp4_megamoe_inputs_kernel(
+    hidden_states,
+    input_global_scale,
+    x_fp4,
+    x_sf,
+    topk_ids,
+    topk_weights,
+    is_padding,
+    topk_idx_out,
+    topk_weights_out,
+    hidden_stride_m: tl.constexpr,
+    hidden_stride_k: tl.constexpr,
+    x_stride_m: tl.constexpr,
+    x_stride_k: tl.constexpr,
+    x_sf_stride_m: tl.constexpr,
+    x_sf_stride_k: tl.constexpr,
+    topk_ids_stride_m: tl.constexpr,
+    topk_ids_stride_k: tl.constexpr,
+    topk_weights_stride_m: tl.constexpr,
+    topk_weights_stride_k: tl.constexpr,
+    is_padding_stride_m: tl.constexpr,
+    topk_idx_stride_m: tl.constexpr,
+    topk_idx_stride_k: tl.constexpr,
+    topk_weights_out_stride_m: tl.constexpr,
+    topk_weights_out_stride_k: tl.constexpr,
+    top_k: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+    GROUP_K: tl.constexpr,
+    BLOCK_TOPK: tl.constexpr,
+) -> None:
+    token_id = tl.program_id(0)
+    k_block_id = tl.program_id(1)
+    k_offsets = k_block_id * BLOCK_K + tl.arange(0, BLOCK_K)
+    hidden = tl.load(
+        hidden_states + token_id * hidden_stride_m + k_offsets * hidden_stride_k
+    ).to(tl.float32)
+
+    num_groups: tl.constexpr = BLOCK_K // GROUP_K
+    hidden_groups = tl.reshape(hidden, [num_groups, GROUP_K])
+    amax = tl.max(tl.abs(hidden_groups), axis=1)
+    global_scale = tl.load(input_global_scale).to(tl.float32)
+    sf = global_scale * amax * _reciprocal_approximate_ftz(6.0)
+    sf_fp8 = sf.to(tl.float8e4nv)
+    rounded_sf = sf_fp8.to(tl.float32)
+    quant_scale = _reciprocal_approximate_ftz(
+        rounded_sf * _reciprocal_approximate_ftz(global_scale)
+    )
+    quant_scale = tl.where(rounded_sf == 0.0, 0.0, quant_scale)
+
+    scaled = tl.reshape(hidden_groups * quant_scale[:, None], [BLOCK_K])
+    scaled_pairs = tl.reshape(scaled, [BLOCK_K // 2, 2])
+    x_lo, x_hi = tl.split(scaled_pairs)
+    packed_fp4 = _fp32x2_to_fp4x2(x_lo, x_hi)
+    fp4_offsets = k_block_id * (BLOCK_K // 2) + tl.arange(0, BLOCK_K // 2)
+    tl.store(x_fp4 + token_id * x_stride_m + fp4_offsets * x_stride_k, packed_fp4)
+
+    sf_bytes = sf_fp8.to(tl.uint8, bitcast=True)
+    sf_quads = tl.reshape(sf_bytes, [num_groups // 4, 4]).to(tl.uint32)
+    byte_offsets = tl.arange(0, 4)
+    packed_sf = tl.sum(sf_quads << (byte_offsets[None, :] * 8), axis=1)
+    sf_offsets = k_block_id * (num_groups // 4) + tl.arange(0, num_groups // 4)
+    tl.store(x_sf + token_id * x_sf_stride_m + sf_offsets * x_sf_stride_k, packed_sf)
+
+    if k_block_id == 0:
+        topk_offsets = tl.arange(0, BLOCK_TOPK)
+        topk_mask = topk_offsets < top_k
+        token_is_padding = False
+        if is_padding is not None:
+            token_is_padding = tl.load(is_padding + token_id * is_padding_stride_m)
+
+        ids = tl.load(
+            topk_ids + token_id * topk_ids_stride_m + topk_offsets * topk_ids_stride_k,
+            mask=topk_mask,
+            other=0,
+        )
+        weights = tl.load(
+            topk_weights
+            + token_id * topk_weights_stride_m
+            + topk_offsets * topk_weights_stride_k,
+            mask=topk_mask,
+            other=0.0,
+        )
+        ids = tl.where(token_is_padding, -1, ids)
+        weights = tl.where(token_is_padding, 0.0, weights)
+        tl.store(
+            topk_idx_out
+            + token_id * topk_idx_stride_m
+            + topk_offsets * topk_idx_stride_k,
+            ids,
+            mask=topk_mask,
+        )
+        tl.store(
+            topk_weights_out
+            + token_id * topk_weights_out_stride_m
+            + topk_offsets * topk_weights_out_stride_k,
+            weights,
+            mask=topk_mask,
+        )
+
+
+def prepare_nvfp4_megamoe_inputs(
+    hidden_states: torch.Tensor,
+    input_global_scale: torch.Tensor,
+    topk_weights: torch.Tensor,
+    topk_ids: torch.Tensor,
+    x_fp4: torch.Tensor,
+    x_sf: torch.Tensor,
+    topk_idx_out: torch.Tensor,
+    topk_weights_out: torch.Tensor,
+    is_padding: torch.Tensor | None = None,
+) -> None:
+    """Quantize and stage one rank's NVFP4 MegaMoE inputs."""
+    if hidden_states.ndim != 2:
+        raise ValueError("hidden_states must be a 2D tensor.")
+    num_tokens, hidden_size = hidden_states.shape
+    if hidden_states.dtype != torch.bfloat16:
+        raise TypeError("hidden_states must have BF16 dtype.")
+    if hidden_size % 128 != 0:
+        raise ValueError("NVFP4 MegaMoE hidden_size must be a multiple of 128.")
+    if topk_ids.ndim != 2 or topk_weights.shape != topk_ids.shape:
+        raise ValueError("topk_weights and topk_ids must have the same 2D shape.")
+    if topk_ids.shape[0] != num_tokens:
+        raise ValueError("topk tensors must have one row per input token.")
+    if topk_ids.dtype not in (torch.int32, torch.int64):
+        raise TypeError("topk_ids must have int32 or int64 dtype.")
+    if topk_weights.dtype != torch.float32:
+        raise TypeError("topk_weights must have float32 dtype.")
+    if x_fp4.shape != (num_tokens, hidden_size // 2):
+        raise ValueError(f"Unexpected NVFP4 output shape: {x_fp4.shape}.")
+    if x_fp4.dtype != torch.uint8:
+        raise TypeError("NVFP4 output must have uint8 dtype.")
+    if x_sf.shape != (num_tokens, hidden_size // 64):
+        raise ValueError(f"Unexpected NVFP4 scale output shape: {x_sf.shape}.")
+    if x_sf.dtype != torch.int32:
+        raise TypeError("NVFP4 scale output must have int32 dtype.")
+    if topk_idx_out.shape != topk_ids.shape or topk_idx_out.dtype != torch.int32:
+        raise ValueError("topk_idx_out must match topk shape and have int32 dtype.")
+    if (
+        topk_weights_out.shape != topk_weights.shape
+        or topk_weights_out.dtype != torch.float32
+    ):
+        raise ValueError(
+            "topk_weights_out must match topk shape and have float32 dtype."
+        )
+    if input_global_scale.numel() != 1 or input_global_scale.dtype != torch.float32:
+        raise ValueError("input_global_scale must be a scalar float32 tensor.")
+    tensors = (
+        input_global_scale,
+        topk_weights,
+        topk_ids,
+        x_fp4,
+        x_sf,
+        topk_idx_out,
+        topk_weights_out,
+    )
+    if any(t.device != hidden_states.device for t in tensors):
+        raise ValueError("All MegaMoE staging tensors must be on the same device.")
+    if is_padding is not None and (
+        is_padding.shape != (num_tokens,)
+        or is_padding.dtype != torch.bool
+        or is_padding.device != hidden_states.device
+    ):
+        raise ValueError("is_padding must be a same-device bool tensor of shape [M].")
+    if num_tokens == 0:
+        return
+
+    top_k = topk_ids.shape[1]
+    block_k = 128
+    grid = (num_tokens, triton.cdiv(hidden_size, block_k))
+    padding_stride_m = is_padding.stride(0) if is_padding is not None else 0
+    _prepare_nvfp4_megamoe_inputs_kernel[grid](
+        hidden_states,
+        input_global_scale,
+        x_fp4,
+        x_sf,
+        topk_ids,
+        topk_weights,
+        is_padding,
+        topk_idx_out,
+        topk_weights_out,
+        hidden_states.stride(0),
+        hidden_states.stride(1),
+        x_fp4.stride(0),
+        x_fp4.stride(1),
+        x_sf.stride(0),
+        x_sf.stride(1),
+        topk_ids.stride(0),
+        topk_ids.stride(1),
+        topk_weights.stride(0),
+        topk_weights.stride(1),
+        padding_stride_m,
+        topk_idx_out.stride(0),
+        topk_idx_out.stride(1),
+        topk_weights_out.stride(0),
+        topk_weights_out.stride(1),
+        top_k,
+        BLOCK_K=block_k,
+        GROUP_K=16,
+        BLOCK_TOPK=triton.next_power_of_2(top_k),
+        num_warps=4,
+    )

--- a/vllm/model_executor/layers/fused_moe/prepare_megamoe.py
+++ b/vllm/model_executor/layers/fused_moe/prepare_megamoe.py
@@ -173,8 +173,8 @@ def prepare_nvfp4_megamoe_inputs(
         raise ValueError(f"Unexpected NVFP4 scale output shape: {x_sf.shape}.")
     if x_sf.dtype != torch.int32:
         raise TypeError("NVFP4 scale output must have int32 dtype.")
-    if topk_idx_out.shape != topk_ids.shape or topk_idx_out.dtype != torch.int32:
-        raise ValueError("topk_idx_out must match topk shape and have int32 dtype.")
+    if topk_idx_out.shape != topk_ids.shape or topk_idx_out.dtype != torch.int64:
+        raise ValueError("topk_idx_out must match topk shape and have int64 dtype.")
     if (
         topk_weights_out.shape != topk_weights.shape
         or topk_weights_out.dtype != torch.float32

--- a/vllm/model_executor/layers/fused_moe/routed_experts.py
+++ b/vllm/model_executor/layers/fused_moe/routed_experts.py
@@ -213,7 +213,10 @@ class RoutedExperts(PluggableLayer):
         )
 
     def _ensure_moe_quant_config_init(self):
-        if self.quant_method.moe_quant_config is None:
+        if (
+            self.quant_method.requires_moe_quant_config
+            and self.quant_method.moe_quant_config is None
+        ):
             # Note: the moe_quant_config can't be constructed until after
             # weight loading post processing.
             self.quant_method.moe_quant_config = (

--- a/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
+++ b/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
@@ -283,7 +283,11 @@ class MoERunner(MoERunnerInterface):
 
         # Cooperative mega-kernels need the raw shared module during the
         # post-load transform. Bind it before selecting the custom-op schema.
-        self._quant_method.bind_shared_experts(shared_experts)
+        self._quant_method.bind_shared_experts(
+            shared_experts,
+            routed_output_transform=routed_output_transform,
+        )
+        self._quant_method.bind_routed_scaling_factor(routed_scaling_factor)
 
         # Needed for string -> MoERunner layer lookup in custom ops.
         self.layer_name = layer_name
@@ -609,16 +613,6 @@ class MoERunner(MoERunnerInterface):
                 topk_indices_dtype=self._quant_method.topk_indices_dtype,
                 input_ids=input_ids,
             )
-
-            # A cooperative kernel returns routed + shared as one tensor, so
-            # the normal post-kernel routed-only scaling cannot distinguish
-            # the two contributions. Apply the factor to the routing weights
-            # before launching the kernel instead.
-            if (
-                self._quant_method.mk_fuses_shared_experts
-                and self.routed_scaling_factor != 1.0
-            ):
-                topk_weights = topk_weights * self.routed_scaling_factor
 
             fused_out = self.routed_experts.forward_modular(
                 x=hidden_states,

--- a/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
+++ b/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
@@ -281,6 +281,10 @@ class MoERunner(MoERunnerInterface):
                 mk_can_overlap_shared_experts=can_overlap,
             )
 
+        # Cooperative mega-kernels need the raw shared module during the
+        # post-load transform. Bind it before selecting the custom-op schema.
+        self._quant_method.bind_shared_experts(shared_experts)
+
         # Needed for string -> MoERunner layer lookup in custom ops.
         self.layer_name = layer_name
 
@@ -295,15 +299,21 @@ class MoERunner(MoERunnerInterface):
         return self.routed_experts.load_weights(weights)
 
     def _select_forward(self) -> Callable:
+        has_separate_shared_output = (
+            self._shared_experts is not None
+            and not self._quant_method.mk_fuses_shared_experts
+        )
         if current_platform.is_tpu() or current_platform.is_cpu():
             # TODO: Once the OOM issue for the TPU backend is resolved, we
             # will switch to using the moe_forward custom op.
             # Note: CPU doesn't require wrapped _forward_impl.
-            return _moe_forward if self._shared_experts is None else _moe_forward_shared
+            return (
+                _moe_forward if not has_separate_shared_output else _moe_forward_shared
+            )
 
         return (
             torch.ops.vllm.moe_forward
-            if self._shared_experts is None
+            if not has_separate_shared_output
             else torch.ops.vllm.moe_forward_shared
         )
 
@@ -393,7 +403,10 @@ class MoERunner(MoERunnerInterface):
         avoid overflow by dividing shared_output by the scale instead
         (the decoder layer compensates with matching divisions).
         """
-        if self.routed_scaling_factor != 1.0:
+        if (
+            self.routed_scaling_factor != 1.0
+            and not self._quant_method.mk_fuses_shared_experts
+        ):
             if fused_output.dtype != torch.float16 or shared_output is None:
                 fused_output *= self.routed_scaling_factor
             elif shared_output is not None:
@@ -402,10 +415,7 @@ class MoERunner(MoERunnerInterface):
 
     @property
     def _fused_output_is_reduced(self) -> bool:
-        return (
-            self._quant_method.moe_kernel is not None
-            and self._quant_method.moe_kernel.output_is_reduced()
-        )
+        return self._quant_method.output_is_reduced
 
     def _maybe_reduce_shared_expert_output(
         self,
@@ -600,6 +610,16 @@ class MoERunner(MoERunnerInterface):
                 input_ids=input_ids,
             )
 
+            # A cooperative kernel returns routed + shared as one tensor, so
+            # the normal post-kernel routed-only scaling cannot distinguish
+            # the two contributions. Apply the factor to the routing weights
+            # before launching the kernel instead.
+            if (
+                self._quant_method.mk_fuses_shared_experts
+                and self.routed_scaling_factor != 1.0
+            ):
+                topk_weights = topk_weights * self.routed_scaling_factor
+
             fused_out = self.routed_experts.forward_modular(
                 x=hidden_states,
                 topk_weights=topk_weights,
@@ -613,6 +633,8 @@ class MoERunner(MoERunnerInterface):
             SharedExpertsOrder.MULTI_STREAM_OVERLAPPED,
         )
 
+        if self._quant_method.mk_fuses_shared_experts:
+            return None, fused_out
         return (
             self._shared_experts.output if self._shared_experts is not None else None,
             fused_out,
@@ -821,7 +843,10 @@ class MoERunner(MoERunnerInterface):
         ):
             hidden_states = get_pcp_group().reduce_scatter(hidden_states, dim=0)
 
-        if self.shared_experts is not None:
+        if (
+            self.shared_experts is not None
+            and not self._quant_method.mk_fuses_shared_experts
+        ):
             assert shared_output is not None
             return shared_output, hidden_states
         else:

--- a/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
+++ b/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
@@ -262,6 +262,7 @@ class MoERunner(MoERunnerInterface):
         self.shared_expert_gate = shared_expert_gate
         self.routed_experts = routed_experts
         self.enable_dbo = enable_dbo
+        self._raw_shared_experts = shared_experts
 
         # When both gates are present and FSE is enabled, fuse their
         # weight matrices into [num_experts + num_shared, hidden] so one
@@ -281,13 +282,7 @@ class MoERunner(MoERunnerInterface):
                 mk_can_overlap_shared_experts=can_overlap,
             )
 
-        # Cooperative mega-kernels need the raw shared module during the
-        # post-load transform. Bind it before selecting the custom-op schema.
-        self._quant_method.bind_shared_experts(
-            shared_experts,
-            routed_output_transform=routed_output_transform,
-        )
-        self._quant_method.bind_routed_scaling_factor(routed_scaling_factor)
+        self._bind_quant_method()
 
         # Needed for string -> MoERunner layer lookup in custom ops.
         self.layer_name = layer_name
@@ -321,6 +316,17 @@ class MoERunner(MoERunnerInterface):
             else torch.ops.vllm.moe_forward_shared
         )
 
+    def _bind_quant_method(self) -> None:
+        self._quant_method.bind_shared_experts(
+            self._raw_shared_experts,
+            routed_output_transform=self.routed_output_transform,
+        )
+        self._quant_method.bind_routed_scaling_factor(self.routed_scaling_factor)
+        if self.enable_dbo and not self._quant_method.supports_dbo:
+            raise NotImplementedError(
+                f"{type(self._quant_method).__name__} does not support DBO."
+            )
+
     @property
     def shared_experts(self) -> SharedExperts | None:
         return self._shared_experts
@@ -328,6 +334,8 @@ class MoERunner(MoERunnerInterface):
     # TODO(bnell): Temporary hack. Get rid of this.
     def _replace_quant_method(self, quant_method: FusedMoEMethodBase):
         self.routed_experts._replace_quant_method(quant_method)
+        self._bind_quant_method()
+        self._forward_entry = self._select_forward()
 
     # TODO(bnell): Hack for elastic_ep. Get rid of this
     def _set_moe_config(self, new_moe_config: FusedMoEConfig):
@@ -577,7 +585,10 @@ class MoERunner(MoERunnerInterface):
         shared_experts_input: torch.Tensor | None,
         order: SharedExpertsOrder,
     ):
-        if self._shared_experts is not None:
+        if (
+            self._shared_experts is not None
+            and not self._quant_method.mk_fuses_shared_experts
+        ):
             assert shared_experts_input is not None
             self._shared_experts(shared_experts_input, order)
 
@@ -657,7 +668,10 @@ class MoERunner(MoERunnerInterface):
         # (Note: This code runs only when "overlapped mode" is on to allow
         #        parallel execution of shared experts with the RoutedExperts via
         #        separate cuda stream)
-        if self._shared_experts is not None:
+        if (
+            self._shared_experts is not None
+            and not self._quant_method.mk_fuses_shared_experts
+        ):
             assert shared_experts_input is not None
             self._shared_experts.maybe_sync_shared_experts_stream(shared_experts_input)
 

--- a/vllm/model_executor/layers/quantization/modelopt.py
+++ b/vllm/model_executor/layers/quantization/modelopt.py
@@ -9,6 +9,10 @@ from torch.nn.parameter import Parameter
 
 import vllm.envs as envs
 from vllm.config import get_current_vllm_config
+from vllm.forward_context import (
+    get_forward_context,
+    is_forward_context_available,
+)
 from vllm.logger import init_logger
 from vllm.model_executor.kernels.linear import (
     init_fp8_linear_kernel,
@@ -991,6 +995,23 @@ ModelOptFp8Config.FusedMoEMethodCls = ModelOptFp8MoEMethod
 ModelOptFp8Config.KVCacheMethodCls = ModelOptKVCacheMethod
 
 
+def _make_modelopt_nvfp4_moe_method(
+    quant_config: "ModelOptNvFp4Config",
+    layer: RoutedExperts,
+) -> FusedMoEMethodBase:
+    if layer.moe_config.moe_backend == "deep_gemm_mega_moe":
+        if quant_config.quant_method != "NVFP4":
+            raise ValueError("deep_gemm_mega_moe requires NVFP4 W4A4, not W4A16.")
+        return ModelOptNvFp4MegaMoE(
+            quant_config=quant_config,
+            moe_config=layer.moe_config,
+        )
+    return ModelOptNvFp4FusedMoE(
+        quant_config=quant_config,
+        moe_config=layer.moe_config,
+    )
+
+
 class ModelOptNvFp4Config(ModelOptQuantConfigBase):
     """Config class for ModelOpt FP4."""
 
@@ -1042,16 +1063,10 @@ class ModelOptNvFp4Config(ModelOptQuantConfigBase):
     ) -> "QuantizeMethodBase | None":
         # Pure-NVFP4 checkpoints use this config directly rather than
         # ModelOptMixedPrecisionConfig.
-        if (
-            isinstance(layer, RoutedExperts)
-            and layer.moe_config.moe_backend == "deep_gemm_mega_moe"
-        ):
-            if self.quant_method != "NVFP4":
-                raise ValueError("deep_gemm_mega_moe requires NVFP4 W4A4, not W4A16.")
-            return ModelOptNvFp4MegaMoE(
-                quant_config=self,
-                moe_config=layer.moe_config,
-            )
+        if isinstance(layer, RoutedExperts):
+            if self.is_layer_excluded(prefix):
+                return None
+            return _make_modelopt_nvfp4_moe_method(self, layer)
         return super().get_quant_method(layer, prefix)
 
     @classmethod
@@ -1678,9 +1693,6 @@ class ModelOptNvFp4MegaMoE(ModelOptNvFp4FusedMoE):
     loader while preventing the runner from dispatching the same tokens twice.
     """
 
-    _symm_buffer_cache: dict[tuple[object, ...], object] = {}
-    _synchronized_ep_groups: set[tuple[int, int]] = set()
-
     def __init__(
         self,
         quant_config: ModelOptNvFp4Config,
@@ -1698,6 +1710,9 @@ class ModelOptNvFp4MegaMoE(ModelOptNvFp4FusedMoE):
         self._shared_l2_weights: torch.Tensor | None = None
         self._num_shared_experts = 0
         self._routed_scaling_factor = 1.0
+        self._deep_gemm: Any = None
+        self._scaled_fp4_quant: Any = None
+        self._symm_buffer: Any = None
 
         parallel = moe_config.moe_parallel_config
         if not parallel.use_ep or parallel.ep_size <= 1:
@@ -1722,6 +1737,14 @@ class ModelOptNvFp4MegaMoE(ModelOptNvFp4FusedMoE):
     @property
     def supports_internal_mk(self) -> bool:
         return True
+
+    @property
+    def supports_dbo(self) -> bool:
+        return False
+
+    @property
+    def requires_moe_quant_config(self) -> bool:
+        return False
 
     @property
     def mk_can_overlap_shared_experts(self) -> bool:
@@ -1777,7 +1800,21 @@ class ModelOptNvFp4MegaMoE(ModelOptNvFp4FusedMoE):
         return packed.transpose(-1, -2).contiguous().transpose(-1, -2)
 
     def _transform_shared_weights(self, deep_gemm) -> None:
-        if self._shared_experts_layer is None:
+        if self._shared_experts_layer is None or self._shared_l1_weights is not None:
+            return
+
+        cached_l1 = getattr(
+            self._shared_experts_layer,
+            "_deep_gemm_mega_shared_l1_weights",
+            None,
+        )
+        if cached_l1 is not None:
+            shared_layer = cast(Any, self._shared_experts_layer)
+            self._shared_l1_weights = cached_l1
+            self._shared_l2_weights = shared_layer._deep_gemm_mega_shared_l2_weights
+            self._num_shared_experts = (
+                self._shared_l1_weights.shape[0] // 2 // self.moe.intermediate_size
+            )
             return
 
         gate_up = getattr(self._shared_experts_layer, "gate_up_proj", None)
@@ -1816,49 +1853,55 @@ class ModelOptNvFp4MegaMoE(ModelOptNvFp4FusedMoE):
                 shared_l1.contiguous(), shared_l2.contiguous()
             )
         )
+        shared_layer = cast(Any, self._shared_experts_layer)
+        shared_layer._deep_gemm_mega_shared_l1_weights = self._shared_l1_weights
+        shared_layer._deep_gemm_mega_shared_l2_weights = self._shared_l2_weights
+        gate_up.weight = None
+        down.weight = None
 
     def process_weights_after_loading(self, layer: RoutedExperts) -> None:
-        if hasattr(layer, "_deep_gemm_mega_l1_weights"):
-            return
-
         from vllm.utils.deep_gemm import _import_deep_gemm
 
         deep_gemm = _import_deep_gemm()
-        w13_scale = self._pack_e4m3_scales(layer.w13_weight_scale.data)
-        w2_scale = self._pack_e4m3_scales(layer.w2_weight_scale.data)
-        l1_weights, l2_weights = deep_gemm.transform_weights_for_mega_moe(
-            (layer.w13_weight.data.view(torch.int8).contiguous(), w13_scale),
-            (layer.w2_weight.data.view(torch.int8).contiguous(), w2_scale),
-        )
-        layer._deep_gemm_mega_l1_weights = l1_weights
-        layer._deep_gemm_mega_l2_weights = l2_weights
+        if not hasattr(layer, "_deep_gemm_mega_l1_weights"):
+            w13_scale = self._pack_e4m3_scales(layer.w13_weight_scale.data)
+            w2_scale = self._pack_e4m3_scales(layer.w2_weight_scale.data)
+            l1_weights, l2_weights = deep_gemm.transform_weights_for_mega_moe(
+                (layer.w13_weight.data.view(torch.int8).contiguous(), w13_scale),
+                (layer.w2_weight.data.view(torch.int8).contiguous(), w2_scale),
+            )
+            layer._deep_gemm_mega_l1_weights = l1_weights
+            layer._deep_gemm_mega_l2_weights = l2_weights
 
-        a1_scale = layer.w13_input_scale.data.max().float().reshape(())
-        layer._deep_gemm_mega_a1_scale = a1_scale
-        layer._deep_gemm_mega_l1_alphas = (
-            layer.w13_weight_scale_2.data.float().reshape(-1, 2).contiguous() * a1_scale
-        )
-        layer._deep_gemm_mega_l2_alphas = (
-            layer.w2_weight_scale_2.data.float().reshape(-1).contiguous()
-        )
-        a2_scale = layer.w2_input_scale.data.max().float().reshape(())
-        layer._deep_gemm_mega_a2_scales = (
-            torch.ones_like(layer._deep_gemm_mega_l2_alphas) * a2_scale
-        )
+            a1_scale = layer.w13_input_scale.data.max().float().reshape(())
+            layer._deep_gemm_mega_a1_scale = a1_scale
+            layer._deep_gemm_mega_l1_alphas = (
+                layer.w13_weight_scale_2.data.float().reshape(-1, 2).contiguous()
+                * a1_scale
+            )
+            layer._deep_gemm_mega_l2_alphas = (
+                layer.w2_weight_scale_2.data.float().reshape(-1).contiguous()
+            )
+            a2_scale = layer.w2_input_scale.data.max().float().reshape(())
+            layer._deep_gemm_mega_a2_scales = layer._deep_gemm_mega_l2_alphas.new_full(
+                layer._deep_gemm_mega_l2_alphas.shape,
+                a2_scale,
+            )
+
+            # The transformed L2 weight aliases its loader Parameter. The other
+            # transformed tensors own fresh storage, so dropping the loader-side
+            # Parameters releases only redundant memory.
+            layer.w13_weight = None
+            layer.w13_weight_scale = None
+            layer.w13_weight_scale_2 = None
+            layer.w13_input_scale = None
+            layer.w2_weight = None
+            layer.w2_weight_scale = None
+            layer.w2_weight_scale_2 = None
+            layer.w2_input_scale = None
 
         self._transform_shared_weights(deep_gemm)
-
-        # The transformed L2 weight aliases its loader Parameter. The other
-        # transformed tensors own fresh storage, so dropping the loader-side
-        # Parameters releases only redundant memory.
-        layer.w13_weight = None
-        layer.w13_weight_scale = None
-        layer.w13_weight_scale_2 = None
-        layer.w13_input_scale = None
-        layer.w2_weight = None
-        layer.w2_weight_scale = None
-        layer.w2_weight_scale_2 = None
-        layer.w2_input_scale = None
+        self._initialize_runtime(deep_gemm)
 
         logger.info_once(
             "Using DeepGEMM NVFP4 MegaMoE (fused_shared=%s).",
@@ -1871,32 +1914,13 @@ class ModelOptNvFp4MegaMoE(ModelOptNvFp4FusedMoE):
     ) -> FusedMoEQuantConfig | None:
         return None
 
-    def _synchronize_first_launch(self) -> None:
+    def _initialize_runtime(self, deep_gemm) -> None:
+        import vllm._custom_ops as ops
         from vllm.distributed import get_ep_group
 
         ep_group = get_ep_group()
         device = torch.accelerator.current_device_index()
-        key = (id(ep_group.cpu_group), device)
-        if key in self._synchronized_ep_groups:
-            return
-        torch.accelerator.synchronize()
-        # Use the device group with an explicit local device.  A NCCL-backed
-        # ``cpu_group`` may otherwise guess from the global rank, which is
-        # wrong on multi-node jobs (e.g. rank 4 owns local CUDA device 0).
-        torch.distributed.barrier(
-            group=ep_group.device_group,
-            device_ids=[device],
-        )
-        self._synchronized_ep_groups.add(key)
-
-    def _get_symm_buffer(self):
-        from vllm.distributed import get_ep_group
-        from vllm.utils.deep_gemm import _import_deep_gemm
-
-        group = get_ep_group().device_group
-        device = torch.accelerator.current_device_index()
         key = (
-            id(group),
             device,
             self.moe.num_experts,
             self.moe.max_num_tokens,
@@ -1905,11 +1929,14 @@ class ModelOptNvFp4MegaMoE(ModelOptNvFp4FusedMoE):
             self.moe.intermediate_size,
             self._num_shared_experts,
         )
-        symm_buffer = self._symm_buffer_cache.get(key)
+        cache = getattr(ep_group, "_modelopt_nvfp4_mega_moe_buffers", None)
+        if cache is None:
+            cache = {}
+            cast(Any, ep_group)._modelopt_nvfp4_mega_moe_buffers = cache
+        symm_buffer = cache.get(key)
         if symm_buffer is None:
-            deep_gemm = _import_deep_gemm()
             symm_buffer = deep_gemm.get_symm_buffer_for_mega_moe(
-                group,
+                ep_group.device_group,
                 self.moe.num_experts,
                 self.moe.max_num_tokens,
                 self.moe.experts_per_token,
@@ -1918,8 +1945,10 @@ class ModelOptNvFp4MegaMoE(ModelOptNvFp4FusedMoE):
                 num_shared_experts=self._num_shared_experts,
                 mma_type="fp4xfp4",
             )
-            self._symm_buffer_cache[key] = symm_buffer
-        return symm_buffer
+            cache[key] = symm_buffer
+        self._deep_gemm = deep_gemm
+        self._scaled_fp4_quant = ops.scaled_fp4_quant
+        self._symm_buffer = symm_buffer
 
     def apply(
         self,
@@ -1937,22 +1966,16 @@ class ModelOptNvFp4MegaMoE(ModelOptNvFp4FusedMoE):
             raise ValueError(
                 f"NVFP4 MegaMoE got M={num_tokens}, capacity={self.moe.max_num_tokens}."
             )
-        if self._shared_experts_layer is not None and shared_experts is None:
-            raise RuntimeError("Fused shared-expert module was not passed to MegaMoE.")
+        if self._symm_buffer is None or self._deep_gemm is None:
+            raise RuntimeError(
+                "NVFP4 MegaMoE runtime was not initialized after weight loading."
+            )
+        assert self._scaled_fp4_quant is not None
+        symm_buffer = self._symm_buffer
 
-        self._synchronize_first_launch()
-        symm_buffer = self._get_symm_buffer()
-
-        import vllm._custom_ops as ops
-        from vllm.forward_context import (
-            get_forward_context,
-            is_forward_context_available,
-        )
-        from vllm.utils.deep_gemm import _import_deep_gemm
-
-        x_fp4, x_scale = ops.scaled_fp4_quant(
+        x_fp4, x_scale = self._scaled_fp4_quant(
             x,
-            layer._deep_gemm_mega_a1_scale,
+            1.0 / layer._deep_gemm_mega_a1_scale,
             is_sf_swizzled_layout=False,
         )
         staged_topk_ids = topk_ids
@@ -1970,7 +1993,7 @@ class ModelOptNvFp4MegaMoE(ModelOptNvFp4FusedMoE):
         symm_buffer.topk_idx[:num_tokens].copy_(staged_topk_ids)
         symm_buffer.topk_weights[:num_tokens].copy_(topk_weights)
 
-        y = torch.empty_like(x, dtype=torch.bfloat16)
+        y = torch.empty_like(x)
         shared_kwargs = {}
         if self._shared_experts_layer is not None:
             if shared_experts_input is None:
@@ -1981,8 +2004,7 @@ class ModelOptNvFp4MegaMoE(ModelOptNvFp4FusedMoE):
                 "x_bf16": shared_experts_input,
             }
 
-        deep_gemm = _import_deep_gemm()
-        deep_gemm.fp4_fp4_mega_moe(
+        self._deep_gemm.fp4_fp4_mega_moe(
             y,
             layer._deep_gemm_mega_l1_weights,
             layer._deep_gemm_mega_l2_weights,
@@ -2759,23 +2781,14 @@ class ModelOptMixedPrecisionConfig(ModelOptQuantConfigBase):
                     moe_config=layer.moe_config,
                 )
             if quant_algo == "NVFP4":
-                if layer.moe_config.moe_backend == "deep_gemm_mega_moe":
-                    return ModelOptNvFp4MegaMoE(
-                        quant_config=self.nvfp4_config,
-                        moe_config=layer.moe_config,
-                    )
-                return ModelOptNvFp4FusedMoE(
-                    quant_config=self.nvfp4_config,
-                    moe_config=layer.moe_config,
+                return _make_modelopt_nvfp4_moe_method(
+                    self.nvfp4_config,
+                    layer,
                 )
             if quant_algo == "W4A16_NVFP4":
-                if layer.moe_config.moe_backend == "deep_gemm_mega_moe":
-                    raise ValueError(
-                        "deep_gemm_mega_moe requires NVFP4 W4A4, not W4A16."
-                    )
-                return ModelOptNvFp4FusedMoE(
-                    quant_config=self.w4a16_nvfp4_config,
-                    moe_config=layer.moe_config,
+                return _make_modelopt_nvfp4_moe_method(
+                    self.w4a16_nvfp4_config,
+                    layer,
                 )
             if quant_algo == "MXFP8":
                 return ModelOptMxFp8FusedMoE(

--- a/vllm/model_executor/layers/quantization/modelopt.py
+++ b/vllm/model_executor/layers/quantization/modelopt.py
@@ -1587,6 +1587,7 @@ class ModelOptNvFp4FusedMoE(FusedMoEMethodBase):
 
         # Setup modular kernel.
         self.moe_quant_config = self.get_fused_moe_quant_config(layer)
+        assert self.moe_quant_config is not None
         assert self.experts_cls is not None
         self.moe_kernel = make_nvfp4_moe_kernel(
             moe_quant_config=self.moe_quant_config,
@@ -1597,7 +1598,9 @@ class ModelOptNvFp4FusedMoE(FusedMoEMethodBase):
         )
         self.moe_kernel.fused_experts.process_weights_after_loading(layer)
 
-    def get_fused_moe_quant_config(self, layer: RoutedExperts) -> FusedMoEQuantConfig:
+    def get_fused_moe_quant_config(
+        self, layer: RoutedExperts
+    ) -> FusedMoEQuantConfig | None:
         return make_nvfp4_moe_quant_config(
             backend=self.nvfp4_backend,
             w13_scale=layer.w13_weight_scale,
@@ -1694,6 +1697,7 @@ class ModelOptNvFp4MegaMoE(ModelOptNvFp4FusedMoE):
         self._shared_l1_weights: torch.Tensor | None = None
         self._shared_l2_weights: torch.Tensor | None = None
         self._num_shared_experts = 0
+        self._routed_scaling_factor = 1.0
 
         parallel = moe_config.moe_parallel_config
         if not parallel.use_ep or parallel.ep_size <= 1:
@@ -1741,8 +1745,22 @@ class ModelOptNvFp4MegaMoE(ModelOptNvFp4FusedMoE):
     def supports_eplb(self) -> bool:
         return False
 
-    def bind_shared_experts(self, shared_experts: torch.nn.Module | None) -> None:
-        self._shared_experts_layer = shared_experts
+    def bind_shared_experts(
+        self,
+        shared_experts: torch.nn.Module | None,
+        *,
+        routed_output_transform: torch.nn.Module | None = None,
+    ) -> None:
+        # The generic runner applies this transform to routed output before
+        # adding shared output. Folding shared output into MegaMoE earlier
+        # would incorrectly transform both branches, so retain the regular
+        # shared-expert path for this model shape.
+        self._shared_experts_layer = (
+            shared_experts if routed_output_transform is None else None
+        )
+
+    def bind_routed_scaling_factor(self, routed_scaling_factor: float) -> None:
+        self._routed_scaling_factor = routed_scaling_factor
 
     @staticmethod
     def _pack_e4m3_scales(scale: torch.Tensor) -> torch.Tensor:
@@ -1974,6 +1992,11 @@ class ModelOptNvFp4MegaMoE(ModelOptNvFp4FusedMoE):
             l1_alphas=layer._deep_gemm_mega_l1_alphas,
             l2_alphas=layer._deep_gemm_mega_l2_alphas,
             a2_scales=layer._deep_gemm_mega_a2_scales,
+            routed_scaling_factor=(
+                self._routed_scaling_factor
+                if self._shared_experts_layer is not None
+                else 1.0
+            ),
             **shared_kwargs,
         )
         return y

--- a/vllm/model_executor/layers/quantization/modelopt.py
+++ b/vllm/model_executor/layers/quantization/modelopt.py
@@ -1037,6 +1037,23 @@ class ModelOptNvFp4Config(ModelOptQuantConfigBase):
     def get_supported_act_dtypes(self) -> list[torch.dtype]:
         return [torch.bfloat16, torch.half, torch.float8_e4m3fn]
 
+    def get_quant_method(
+        self, layer: torch.nn.Module, prefix: str
+    ) -> "QuantizeMethodBase | None":
+        # Pure-NVFP4 checkpoints use this config directly rather than
+        # ModelOptMixedPrecisionConfig.
+        if (
+            isinstance(layer, RoutedExperts)
+            and layer.moe_config.moe_backend == "deep_gemm_mega_moe"
+        ):
+            if self.quant_method != "NVFP4":
+                raise ValueError("deep_gemm_mega_moe requires NVFP4 W4A4, not W4A16.")
+            return ModelOptNvFp4MegaMoE(
+                quant_config=self,
+                moe_config=layer.moe_config,
+            )
+        return super().get_quant_method(layer, prefix)
+
     @classmethod
     def get_min_capability(cls) -> int:
         return 75
@@ -1647,6 +1664,319 @@ class ModelOptNvFp4FusedMoE(FusedMoEMethodBase):
             shared_experts=shared_experts,
             shared_experts_input=shared_experts_input,
         )
+
+
+class ModelOptNvFp4MegaMoE(ModelOptNvFp4FusedMoE):
+    """ModelOpt NVFP4 adapter for DeepGEMM's cooperative MegaMoE kernel.
+
+    Unlike regular modular experts, MegaMoE owns EP dispatch, both expert
+    GEMMs, combine, and (optionally) the BF16 shared MLP.  Keeping this as a
+    quant method lets vLLM reuse RoutedExperts' existing ModelOpt checkpoint
+    loader while preventing the runner from dispatching the same tokens twice.
+    """
+
+    _symm_buffer_cache: dict[tuple[object, ...], object] = {}
+    _synchronized_ep_groups: set[tuple[int, int]] = set()
+
+    def __init__(
+        self,
+        quant_config: ModelOptNvFp4Config,
+        moe_config: FusedMoEConfig,
+    ) -> None:
+        # Deliberately bypass ModelOptNvFp4FusedMoE.__init__: the regular NVFP4
+        # oracle selects a GEMM-only Experts implementation, while MegaMoE is a
+        # cooperative communication + compute kernel.
+        FusedMoEMethodBase.__init__(self, moe_config)
+        self.quant_config = quant_config
+        self.use_a16 = False
+        self.use_global_sf = True
+        self._shared_experts_layer: torch.nn.Module | None = None
+        self._shared_l1_weights: torch.Tensor | None = None
+        self._shared_l2_weights: torch.Tensor | None = None
+        self._num_shared_experts = 0
+
+        parallel = moe_config.moe_parallel_config
+        if not parallel.use_ep or parallel.ep_size <= 1:
+            raise ValueError(
+                "deep_gemm_mega_moe requires expert parallelism across at "
+                "least two ranks."
+            )
+        if parallel.tp_size != 1:
+            raise ValueError("deep_gemm_mega_moe requires TP=1 inside each EP rank.")
+        if parallel.enable_eplb:
+            raise NotImplementedError(
+                "NVFP4 deep_gemm_mega_moe does not support EPLB yet."
+            )
+        if moe_config.activation.value != "silu":
+            raise ValueError("NVFP4 deep_gemm_mega_moe currently requires SiLU.")
+        if moe_config.num_experts % parallel.ep_size != 0:
+            raise ValueError(
+                f"num_experts={moe_config.num_experts} must be divisible by "
+                f"EP size {parallel.ep_size}."
+            )
+
+    @property
+    def supports_internal_mk(self) -> bool:
+        return True
+
+    @property
+    def mk_can_overlap_shared_experts(self) -> bool:
+        return self._shared_experts_layer is not None
+
+    @property
+    def mk_fuses_shared_experts(self) -> bool:
+        return self._shared_experts_layer is not None
+
+    @property
+    def output_is_reduced(self) -> bool:
+        # MegaMoE combine returns the completed output to each token's origin
+        # rank, so the generic runner must not apply another cross-rank reduce.
+        return True
+
+    @property
+    def topk_indices_dtype(self) -> torch.dtype | None:
+        return torch.int32
+
+    @property
+    def supports_eplb(self) -> bool:
+        return False
+
+    def bind_shared_experts(self, shared_experts: torch.nn.Module | None) -> None:
+        self._shared_experts_layer = shared_experts
+
+    @staticmethod
+    def _pack_e4m3_scales(scale: torch.Tensor) -> torch.Tensor:
+        if scale.dtype != torch.float8_e4m3fn:
+            raise TypeError(f"Expected E4M3 block scales, got {scale.dtype}.")
+        if scale.shape[-1] % 4:
+            raise ValueError(
+                "DeepGEMM packs four E4M3 scales per int32; got trailing "
+                f"dimension {scale.shape[-1]}."
+            )
+        packed = scale.contiguous().view(torch.uint8).view(torch.int32)
+        # Preserve the public [E, N, K/64] shape with the N-major TMA stride
+        # expected by the NVFP4 MegaMoE kernel.
+        return packed.transpose(-1, -2).contiguous().transpose(-1, -2)
+
+    def _transform_shared_weights(self, deep_gemm) -> None:
+        if self._shared_experts_layer is None:
+            return
+
+        gate_up = getattr(self._shared_experts_layer, "gate_up_proj", None)
+        down = getattr(self._shared_experts_layer, "down_proj", None)
+        if gate_up is None or down is None:
+            raise TypeError(
+                "DeepGEMM fused shared experts require gate_up_proj and down_proj."
+            )
+
+        shared_l1 = gate_up.weight.data
+        shared_l2 = down.weight.data
+        if shared_l1.dtype != torch.bfloat16 or shared_l2.dtype != torch.bfloat16:
+            raise TypeError(
+                "DeepGEMM fused shared experts require BF16 weights; got "
+                f"{shared_l1.dtype} and {shared_l2.dtype}."
+            )
+        hidden = self.moe.hidden_dim
+        if shared_l1.ndim != 2 or shared_l1.shape[0] % 2:
+            raise ValueError(f"Unexpected shared L1 shape {tuple(shared_l1.shape)}.")
+        shared_intermediate = shared_l1.shape[0] // 2
+        if tuple(shared_l1.shape) != (2 * shared_intermediate, hidden) or tuple(
+            shared_l2.shape
+        ) != (hidden, shared_intermediate):
+            raise ValueError(
+                "DeepGEMM fused shared expert needs unsharded BF16 weights; got "
+                f"L1={tuple(shared_l1.shape)}, L2={tuple(shared_l2.shape)}."
+            )
+        if shared_intermediate % self.moe.intermediate_size:
+            raise ValueError(
+                f"shared intermediate {shared_intermediate} must be a multiple "
+                f"of routed intermediate {self.moe.intermediate_size}."
+            )
+        self._num_shared_experts = shared_intermediate // self.moe.intermediate_size
+        self._shared_l1_weights, self._shared_l2_weights = (
+            deep_gemm.transform_weights_for_mega_moe(
+                shared_l1.contiguous(), shared_l2.contiguous()
+            )
+        )
+
+    def process_weights_after_loading(self, layer: RoutedExperts) -> None:
+        if hasattr(layer, "_deep_gemm_mega_l1_weights"):
+            return
+
+        from vllm.utils.deep_gemm import _import_deep_gemm
+
+        deep_gemm = _import_deep_gemm()
+        w13_scale = self._pack_e4m3_scales(layer.w13_weight_scale.data)
+        w2_scale = self._pack_e4m3_scales(layer.w2_weight_scale.data)
+        l1_weights, l2_weights = deep_gemm.transform_weights_for_mega_moe(
+            (layer.w13_weight.data.view(torch.int8).contiguous(), w13_scale),
+            (layer.w2_weight.data.view(torch.int8).contiguous(), w2_scale),
+        )
+        layer._deep_gemm_mega_l1_weights = l1_weights
+        layer._deep_gemm_mega_l2_weights = l2_weights
+
+        a1_scale = layer.w13_input_scale.data.max().float().reshape(())
+        layer._deep_gemm_mega_a1_scale = a1_scale
+        layer._deep_gemm_mega_l1_alphas = (
+            layer.w13_weight_scale_2.data.float().reshape(-1, 2).contiguous() * a1_scale
+        )
+        layer._deep_gemm_mega_l2_alphas = (
+            layer.w2_weight_scale_2.data.float().reshape(-1).contiguous()
+        )
+        a2_scale = layer.w2_input_scale.data.max().float().reshape(())
+        layer._deep_gemm_mega_a2_scales = (
+            torch.ones_like(layer._deep_gemm_mega_l2_alphas) * a2_scale
+        )
+
+        self._transform_shared_weights(deep_gemm)
+
+        # The transformed L2 weight aliases its loader Parameter. The other
+        # transformed tensors own fresh storage, so dropping the loader-side
+        # Parameters releases only redundant memory.
+        layer.w13_weight = None
+        layer.w13_weight_scale = None
+        layer.w13_weight_scale_2 = None
+        layer.w13_input_scale = None
+        layer.w2_weight = None
+        layer.w2_weight_scale = None
+        layer.w2_weight_scale_2 = None
+        layer.w2_input_scale = None
+
+        logger.info_once(
+            "Using DeepGEMM NVFP4 MegaMoE (fused_shared=%s).",
+            self._shared_experts_layer is not None,
+            scope="global",
+        )
+
+    def get_fused_moe_quant_config(
+        self, layer: RoutedExperts
+    ) -> FusedMoEQuantConfig | None:
+        return None
+
+    def _synchronize_first_launch(self) -> None:
+        from vllm.distributed import get_ep_group
+
+        ep_group = get_ep_group()
+        device = torch.accelerator.current_device_index()
+        key = (id(ep_group.cpu_group), device)
+        if key in self._synchronized_ep_groups:
+            return
+        torch.accelerator.synchronize()
+        # Use the device group with an explicit local device.  A NCCL-backed
+        # ``cpu_group`` may otherwise guess from the global rank, which is
+        # wrong on multi-node jobs (e.g. rank 4 owns local CUDA device 0).
+        torch.distributed.barrier(
+            group=ep_group.device_group,
+            device_ids=[device],
+        )
+        self._synchronized_ep_groups.add(key)
+
+    def _get_symm_buffer(self):
+        from vllm.distributed import get_ep_group
+        from vllm.utils.deep_gemm import _import_deep_gemm
+
+        group = get_ep_group().device_group
+        device = torch.accelerator.current_device_index()
+        key = (
+            id(group),
+            device,
+            self.moe.num_experts,
+            self.moe.max_num_tokens,
+            self.moe.experts_per_token,
+            self.moe.hidden_dim,
+            self.moe.intermediate_size,
+            self._num_shared_experts,
+        )
+        symm_buffer = self._symm_buffer_cache.get(key)
+        if symm_buffer is None:
+            deep_gemm = _import_deep_gemm()
+            symm_buffer = deep_gemm.get_symm_buffer_for_mega_moe(
+                group,
+                self.moe.num_experts,
+                self.moe.max_num_tokens,
+                self.moe.experts_per_token,
+                self.moe.hidden_dim,
+                self.moe.intermediate_size,
+                num_shared_experts=self._num_shared_experts,
+                mma_type="fp4xfp4",
+            )
+            self._symm_buffer_cache[key] = symm_buffer
+        return symm_buffer
+
+    def apply(
+        self,
+        layer: RoutedExperts,
+        x: torch.Tensor,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+        shared_experts: SharedExperts | None,
+        shared_experts_input: torch.Tensor | None,
+    ) -> torch.Tensor:
+        if x.dtype != torch.bfloat16:
+            raise TypeError(f"NVFP4 MegaMoE expects BF16 input, got {x.dtype}.")
+        num_tokens = x.shape[0]
+        if num_tokens > self.moe.max_num_tokens:
+            raise ValueError(
+                f"NVFP4 MegaMoE got M={num_tokens}, capacity={self.moe.max_num_tokens}."
+            )
+        if self._shared_experts_layer is not None and shared_experts is None:
+            raise RuntimeError("Fused shared-expert module was not passed to MegaMoE.")
+
+        self._synchronize_first_launch()
+        symm_buffer = self._get_symm_buffer()
+
+        import vllm._custom_ops as ops
+        from vllm.forward_context import (
+            get_forward_context,
+            is_forward_context_available,
+        )
+        from vllm.utils.deep_gemm import _import_deep_gemm
+
+        x_fp4, x_scale = ops.scaled_fp4_quant(
+            x,
+            layer._deep_gemm_mega_a1_scale,
+            is_sf_swizzled_layout=False,
+        )
+        staged_topk_ids = topk_ids
+        if envs.VLLM_MOE_SKIP_PADDING and is_forward_context_available():
+            is_padding = get_forward_context().is_padding
+            if is_padding is not None:
+                staged_topk_ids = torch.where(
+                    is_padding[:num_tokens].unsqueeze(1), -1, topk_ids
+                )
+
+        symm_buffer.x[:num_tokens].copy_(x_fp4)
+        symm_buffer.x_sf[:num_tokens].copy_(
+            x_scale.contiguous().view(torch.uint8).view(torch.int32)
+        )
+        symm_buffer.topk_idx[:num_tokens].copy_(staged_topk_ids)
+        symm_buffer.topk_weights[:num_tokens].copy_(topk_weights)
+
+        y = torch.empty_like(x, dtype=torch.bfloat16)
+        shared_kwargs = {}
+        if self._shared_experts_layer is not None:
+            if shared_experts_input is None:
+                raise RuntimeError("Fused shared experts require their BF16 input.")
+            shared_kwargs = {
+                "shared_l1_weights": self._shared_l1_weights,
+                "shared_l2_weights": self._shared_l2_weights,
+                "x_bf16": shared_experts_input,
+            }
+
+        deep_gemm = _import_deep_gemm()
+        deep_gemm.fp4_fp4_mega_moe(
+            y,
+            layer._deep_gemm_mega_l1_weights,
+            layer._deep_gemm_mega_l2_weights,
+            symm_buffer,
+            activation_clamp=getattr(layer, "swiglu_limit", None),
+            fast_math=True,
+            l1_alphas=layer._deep_gemm_mega_l1_alphas,
+            l2_alphas=layer._deep_gemm_mega_l2_alphas,
+            a2_scales=layer._deep_gemm_mega_a2_scales,
+            **shared_kwargs,
+        )
+        return y
 
 
 ModelOptNvFp4Config.LinearMethodCls = ModelOptNvFp4LinearMethod
@@ -2406,11 +2736,20 @@ class ModelOptMixedPrecisionConfig(ModelOptQuantConfigBase):
                     moe_config=layer.moe_config,
                 )
             if quant_algo == "NVFP4":
+                if layer.moe_config.moe_backend == "deep_gemm_mega_moe":
+                    return ModelOptNvFp4MegaMoE(
+                        quant_config=self.nvfp4_config,
+                        moe_config=layer.moe_config,
+                    )
                 return ModelOptNvFp4FusedMoE(
                     quant_config=self.nvfp4_config,
                     moe_config=layer.moe_config,
                 )
             if quant_algo == "W4A16_NVFP4":
+                if layer.moe_config.moe_backend == "deep_gemm_mega_moe":
+                    raise ValueError(
+                        "deep_gemm_mega_moe requires NVFP4 W4A4, not W4A16."
+                    )
                 return ModelOptNvFp4FusedMoE(
                     quant_config=self.w4a16_nvfp4_config,
                     moe_config=layer.moe_config,

--- a/vllm/model_executor/layers/quantization/modelopt.py
+++ b/vllm/model_executor/layers/quantization/modelopt.py
@@ -19,6 +19,7 @@ from vllm.model_executor.kernels.linear import (
     init_mxfp8_linear_kernel,
     init_nvfp4_linear_kernel,
 )
+from vllm.model_executor.layers.activation import SiluAndMul
 from vllm.model_executor.layers.attention import Attention, MLAAttention
 from vllm.model_executor.layers.fused_moe import (
     FusedMoEConfig,
@@ -44,6 +45,9 @@ from vllm.model_executor.layers.fused_moe.oracle.nvfp4 import (
     make_nvfp4_moe_kernel,
     make_nvfp4_moe_quant_config,
     select_nvfp4_moe_backend,
+)
+from vllm.model_executor.layers.fused_moe.prepare_megamoe import (
+    prepare_nvfp4_megamoe_inputs,
 )
 from vllm.model_executor.layers.fusion.quant_activation import (
     expose_input_quant_key,
@@ -94,6 +98,7 @@ from vllm.model_executor.parameter import (
     PerTensorScaleParameter,
 )
 from vllm.model_executor.utils import replace_parameter, set_weight_attrs
+from vllm.platforms import current_platform
 
 if TYPE_CHECKING:
     from vllm.model_executor.models.utils import WeightsMapper
@@ -1002,6 +1007,11 @@ def _make_modelopt_nvfp4_moe_method(
     if layer.moe_config.moe_backend == "deep_gemm_mega_moe":
         if quant_config.quant_method != "NVFP4":
             raise ValueError("deep_gemm_mega_moe requires NVFP4 W4A4, not W4A16.")
+        if layer.apply_router_weight_on_input:
+            raise NotImplementedError(
+                "NVFP4 deep_gemm_mega_moe does not support "
+                "apply_router_weight_on_input=True."
+            )
         return ModelOptNvFp4MegaMoE(
             quant_config=quant_config,
             moe_config=layer.moe_config,
@@ -1711,7 +1721,6 @@ class ModelOptNvFp4MegaMoE(ModelOptNvFp4FusedMoE):
         self._num_shared_experts = 0
         self._routed_scaling_factor = 1.0
         self._deep_gemm: Any = None
-        self._scaled_fp4_quant: Any = None
         self._symm_buffer: Any = None
 
         parallel = moe_config.moe_parallel_config
@@ -1728,6 +1737,19 @@ class ModelOptNvFp4MegaMoE(ModelOptNvFp4FusedMoE):
             )
         if moe_config.activation.value != "silu":
             raise ValueError("NVFP4 deep_gemm_mega_moe currently requires SiLU.")
+        if moe_config.in_dtype != torch.bfloat16:
+            raise ValueError("NVFP4 deep_gemm_mega_moe requires BF16 activations.")
+        if moe_config.has_bias:
+            raise NotImplementedError(
+                "NVFP4 deep_gemm_mega_moe does not support expert bias."
+            )
+        if moe_config.is_lora_enabled:
+            raise NotImplementedError("NVFP4 deep_gemm_mega_moe does not support LoRA.")
+        if moe_config.hidden_dim % 256 or moe_config.intermediate_size % 256:
+            raise ValueError(
+                "NVFP4 deep_gemm_mega_moe requires hidden and intermediate "
+                "dimensions to be multiples of 256."
+            )
         if moe_config.num_experts % parallel.ep_size != 0:
             raise ValueError(
                 f"num_experts={moe_config.num_experts} must be divisible by "
@@ -1774,13 +1796,55 @@ class ModelOptNvFp4MegaMoE(ModelOptNvFp4FusedMoE):
         *,
         routed_output_transform: torch.nn.Module | None = None,
     ) -> None:
-        # The generic runner applies this transform to routed output before
-        # adding shared output. Folding shared output into MegaMoE earlier
-        # would incorrectly transform both branches, so retain the regular
-        # shared-expert path for this model shape.
-        self._shared_experts_layer = (
-            shared_experts if routed_output_transform is None else None
+        self._shared_experts_layer = None
+        if shared_experts is None or routed_output_transform is not None:
+            return
+
+        gate_up = getattr(shared_experts, "gate_up_proj", None)
+        down = getattr(shared_experts, "down_proj", None)
+        act_fn = getattr(shared_experts, "act_fn", None)
+        compatible = (
+            not getattr(shared_experts, "shard_sequence_parallel", False)
+            and getattr(shared_experts, "expert_gate", None) is None
+            and gate_up is not None
+            and down is not None
+            and getattr(gate_up, "bias", None) is None
+            and getattr(down, "bias", None) is None
+            and isinstance(
+                getattr(gate_up, "quant_method", None), UnquantizedLinearMethod
+            )
+            and isinstance(getattr(down, "quant_method", None), UnquantizedLinearMethod)
+            and isinstance(act_fn, SiluAndMul)
         )
+        if not compatible:
+            logger.info_once(
+                "Shared expert is not compatible with DeepGEMM fusion; "
+                "using the regular shared-expert path.",
+                scope="local",
+            )
+            return
+
+        gate_up_weight = getattr(gate_up, "weight", None)
+        down_weight = getattr(down, "weight", None)
+        hidden = self.moe.hidden_dim
+        if (
+            gate_up_weight is None
+            or down_weight is None
+            or gate_up_weight.dtype != torch.bfloat16
+            or down_weight.dtype != torch.bfloat16
+            or gate_up_weight.ndim != 2
+            or down_weight.ndim != 2
+            or gate_up_weight.shape[0] % 2
+        ):
+            return
+        shared_intermediate = gate_up_weight.shape[0] // 2
+        if (
+            tuple(gate_up_weight.shape) != (2 * shared_intermediate, hidden)
+            or tuple(down_weight.shape) != (hidden, shared_intermediate)
+            or shared_intermediate % self.moe.intermediate_size
+        ):
+            return
+        self._shared_experts_layer = shared_experts
 
     def bind_routed_scaling_factor(self, routed_scaling_factor: float) -> None:
         self._routed_scaling_factor = routed_scaling_factor
@@ -1863,6 +1927,23 @@ class ModelOptNvFp4MegaMoE(ModelOptNvFp4FusedMoE):
         from vllm.utils.deep_gemm import _import_deep_gemm
 
         deep_gemm = _import_deep_gemm()
+        required_apis = (
+            "transform_weights_for_mega_moe",
+            "get_symm_buffer_for_mega_moe",
+            "fp4_fp4_mega_moe",
+        )
+        if not envs.VLLM_USE_DEEP_GEMM:
+            raise RuntimeError(
+                "deep_gemm_mega_moe was selected while VLLM_USE_DEEP_GEMM=0."
+            )
+        if not current_platform.is_device_capability_family(100):
+            raise RuntimeError("NVFP4 deep_gemm_mega_moe requires SM100-family GPUs.")
+        if deep_gemm is None or any(
+            not hasattr(deep_gemm, api) for api in required_apis
+        ):
+            raise RuntimeError(
+                "Installed DeepGEMM does not provide the NVFP4 MegaMoE APIs."
+            )
         if not hasattr(layer, "_deep_gemm_mega_l1_weights"):
             w13_scale = self._pack_e4m3_scales(layer.w13_weight_scale.data)
             w2_scale = self._pack_e4m3_scales(layer.w2_weight_scale.data)
@@ -1874,7 +1955,12 @@ class ModelOptNvFp4MegaMoE(ModelOptNvFp4FusedMoE):
             layer._deep_gemm_mega_l2_weights = l2_weights
 
             a1_scale = layer.w13_input_scale.data.max().float().reshape(())
+            if not bool(torch.isfinite(a1_scale).item()) or a1_scale.item() <= 0:
+                raise ValueError(
+                    "NVFP4 MegaMoE activation scale must be positive and finite."
+                )
             layer._deep_gemm_mega_a1_scale = a1_scale
+            layer._deep_gemm_mega_a1_gscale = a1_scale.reciprocal()
             layer._deep_gemm_mega_l1_alphas = (
                 layer.w13_weight_scale_2.data.float().reshape(-1, 2).contiguous()
                 * a1_scale
@@ -1900,6 +1986,11 @@ class ModelOptNvFp4MegaMoE(ModelOptNvFp4FusedMoE):
             layer.w2_weight_scale_2 = None
             layer.w2_input_scale = None
 
+        if not hasattr(layer, "_deep_gemm_mega_a1_gscale"):
+            layer._deep_gemm_mega_a1_gscale = (
+                layer._deep_gemm_mega_a1_scale.reciprocal()
+            )
+
         self._transform_shared_weights(deep_gemm)
         self._initialize_runtime(deep_gemm)
 
@@ -1915,7 +2006,6 @@ class ModelOptNvFp4MegaMoE(ModelOptNvFp4FusedMoE):
         return None
 
     def _initialize_runtime(self, deep_gemm) -> None:
-        import vllm._custom_ops as ops
         from vllm.distributed import get_ep_group
 
         ep_group = get_ep_group()
@@ -1947,7 +2037,6 @@ class ModelOptNvFp4MegaMoE(ModelOptNvFp4FusedMoE):
             )
             cache[key] = symm_buffer
         self._deep_gemm = deep_gemm
-        self._scaled_fp4_quant = ops.scaled_fp4_quant
         self._symm_buffer = symm_buffer
 
     def apply(
@@ -1970,28 +2059,24 @@ class ModelOptNvFp4MegaMoE(ModelOptNvFp4FusedMoE):
             raise RuntimeError(
                 "NVFP4 MegaMoE runtime was not initialized after weight loading."
             )
-        assert self._scaled_fp4_quant is not None
         symm_buffer = self._symm_buffer
-
-        x_fp4, x_scale = self._scaled_fp4_quant(
-            x,
-            1.0 / layer._deep_gemm_mega_a1_scale,
-            is_sf_swizzled_layout=False,
-        )
-        staged_topk_ids = topk_ids
+        is_padding = None
         if envs.VLLM_MOE_SKIP_PADDING and is_forward_context_available():
             is_padding = get_forward_context().is_padding
             if is_padding is not None:
-                staged_topk_ids = torch.where(
-                    is_padding[:num_tokens].unsqueeze(1), -1, topk_ids
-                )
+                is_padding = is_padding[:num_tokens]
 
-        symm_buffer.x[:num_tokens].copy_(x_fp4)
-        symm_buffer.x_sf[:num_tokens].copy_(
-            x_scale.contiguous().view(torch.uint8).view(torch.int32)
+        prepare_nvfp4_megamoe_inputs(
+            x,
+            layer._deep_gemm_mega_a1_gscale,
+            topk_weights,
+            topk_ids,
+            symm_buffer.x[:num_tokens],
+            symm_buffer.x_sf[:num_tokens],
+            symm_buffer.topk_idx[:num_tokens],
+            symm_buffer.topk_weights[:num_tokens],
+            is_padding=is_padding,
         )
-        symm_buffer.topk_idx[:num_tokens].copy_(staged_topk_ids)
-        symm_buffer.topk_weights[:num_tokens].copy_(topk_weights)
 
         y = torch.empty_like(x)
         shared_kwargs = {}

--- a/vllm/model_executor/layers/quantization/modelopt.py
+++ b/vllm/model_executor/layers/quantization/modelopt.py
@@ -1005,6 +1005,8 @@ def _make_modelopt_nvfp4_moe_method(
     layer: RoutedExperts,
 ) -> FusedMoEMethodBase:
     if layer.moe_config.moe_backend == "deep_gemm_mega_moe":
+        # DeepSeek V4's model-level MegaMoE path constructs its own experts
+        # directly, so it never reaches this RoutedExperts quant-method path.
         if quant_config.quant_method != "NVFP4":
             raise ValueError("deep_gemm_mega_moe requires NVFP4 W4A4, not W4A16.")
         if layer.apply_router_weight_on_input:
@@ -1710,7 +1712,9 @@ class ModelOptNvFp4MegaMoE(ModelOptNvFp4FusedMoE):
     ) -> None:
         # Deliberately bypass ModelOptNvFp4FusedMoE.__init__: the regular NVFP4
         # oracle selects a GEMM-only Experts implementation, while MegaMoE is a
-        # cooperative communication + compute kernel.
+        # cooperative communication + compute kernel.  The inherited weight
+        # loader uses only quant_config, use_a16, and use_global_sf; experts_cls
+        # must remain unset because its presence marks the method monolithic.
         FusedMoEMethodBase.__init__(self, moe_config)
         self.quant_config = quant_config
         self.use_a16 = False

--- a/vllm/model_executor/layers/quantization/modelopt.py
+++ b/vllm/model_executor/layers/quantization/modelopt.py
@@ -1808,6 +1808,8 @@ class ModelOptNvFp4MegaMoE(ModelOptNvFp4FusedMoE):
             and getattr(shared_experts, "expert_gate", None) is None
             and gate_up is not None
             and down is not None
+            and getattr(gate_up, "tp_size", None) == 1
+            and getattr(down, "tp_size", None) == 1
             and getattr(gate_up, "bias", None) is None
             and getattr(down, "bias", None) is None
             and isinstance(


### PR DESCRIPTION
## Summary

Add a ModelOpt NVFP4 MegaMoE path backed by DeepGEMM, including fused BF16 shared-expert execution.

- Quantize NVFP4 activations and stage activation/scales/top-k directly into the symmetric buffer in one Triton launch.
- Transform routed NVFP4 weights/scales into the DeepGEMM layout.
- Fuse compatible BF16 shared experts; keep the ordinary shared path for unsupported modules.
- Keep symmetric-buffer allocation/rendezvous outside forward and CUDA Graph capture.
- Fail closed for unsupported router semantics, dtype, bias, LoRA, alignment, platform, DBO, or missing DeepGEMM APIs.
- Preserve the existing ModelOpt path unless `--moe-backend deep_gemm_mega_moe` is selected.

Requires a DeepGEMM build containing the NVFP4 MegaMoE APIs from the merged [deepseek-ai/DeepGEMM#409](https://github.com/deepseek-ai/DeepGEMM/pull/409).

### Why this is not a duplicate

The related open Kimi K3 and DeepSeek-V4 changes target model-specific paths; this PR is the only open change integrating NVFP4 MegaMoE with the ModelOpt/RoutedExperts path used by GLM-5.2.

### Design and review fixes

- Replaced `scaled_fp4_quant` plus temporary tensors and four `copy_` calls with direct-to-symmetric-buffer NVFP4 staging.
- Folded FP4 quantization, E4M3 scale packing, top-k conversion, and padding masking into one launch.
- Cached the reciprocal activation global scale outside forward.
- Added fail-closed handling for `apply_router_weight_on_input` and other unsupported configurations.
- Restricted shared fusion to modules whose semantics are preserved; otherwise shared execution remains unfused.
- Fixed the real startup contract found on GB300: router IDs may be `int32` or `int64`, while the symmetric `topk_idx` output is `int64`.
- Expanded contract, padding, dtype, H=6144, and CUDA Graph replay tests.

## Test Plan

### Environment

- 8x GB300, two hosts x four GPUs, DP8/EP8 and TP1.
- Model: `nvidia/GLM-5.2-NVFP4`.
- CUDA 13, PyTorch `2.13.0+cu130`, FlashInfer `0.6.15.post1`.
- vLLM V2 model runner with compilation mode 0 (no `torch.compile`).
- FULL CUDA Graph requested; sparse MLA selects `FULL_DECODE_ONLY` at runtime.
- Maximum sequences per rank: 1024; maximum batched tokens: 16,384; prefix caching disabled.
- Performance revision: `8d37d14`; current PR head: `70a04c5`. The later commits update tests, the runtime output-dtype contract check, and add a fail-closed guard for TP-sharded shared experts; they do not change the timed DP8/EP8, TP1 path.
- DeepGEMM revision: `0c067ed4` from the dependent PR.

### Serve recipe

```bash
vllm serve nvidia/GLM-5.2-NVFP4 \
  --tensor-parallel-size 1 \
  --data-parallel-size 8 \
  --enable-expert-parallel \
  --moe-backend deep_gemm_mega_moe \
  --trust-remote-code \
  --kv-cache-dtype fp8_e4m3 \
  --max-num-seqs 1024 \
  --max-num-batched-tokens 16384 \
  --no-enable-prefix-caching \
  --compilation-config '{"mode":0,"cudagraph_mode":"FULL"}'
```

For the FlashInfer baseline, replace `--moe-backend deep_gemm_mega_moe` with `--moe-backend auto --all2all-backend flashinfer_nvlink_one_sided`.

### Workload and measurement

- [NVIDIA SPEED-Bench](https://huggingface.co/datasets/nvidia/SPEED-Bench) `throughput_16k`, `low_entropy` category. Download it with:

  ```bash
  curl -LsSf https://raw.githubusercontent.com/NVIDIA-NeMo/Skills/refs/heads/main/nemo_skills/dataset/speed-bench/prepare.py | \
    python3 - --config throughput_16k --output_dir ./speed-bench
  ```

- Deterministically sample exact 128-token windows across source rows without replacement. Each point uses `8 * M` distinct prompts.
- ISL `128`, OSL `256`, `temperature=0`, `ignore_eos=true`.
- M/rank: `1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024`; global request concurrency is `8 * M`.
- Send exactly M requests directly to each rank endpoint. Warm each point with one short request per rank, then run two formal repeats. The final DeepGEMM M1024 point uses three repeats.
- For each repeat, measure the common steady-decode interval from the latest first-token timestamp to the earliest request-completion timestamp. Count streamed output tokens in that interval and report aggregate throughput across all eight ranks. The table reports the median repeat.
- Model loading, JIT compilation, backend autotuning, CUDA Graph capture, prefill, first-token latency, and drain are outside the measured window.

## Test Results

### D-only: SPEED-Bench low entropy, 128 input / 256 output, DEP8

| M/rank | FlashInfer baseline (tok/s) | DeepGEMM fused (tok/s) | Change |
| ---: | ---: | ---: | ---: |
| 1 | 532 | 560 | **+5.12%** |
| 2 | 982 | 1,030 | **+4.84%** |
| 4 | 1,778 | 1,860 | **+4.61%** |
| 8 | 3,227 | 3,404 | **+5.49%** |
| 16 | 6,182 | 6,533 | **+5.67%** |
| 32 | 11,787 | 12,422 | **+5.38%** |
| 64 | 22,040 | 23,606 | **+7.10%** |
| 128 | 41,878 | 44,571 | **+6.43%** |
| 256 | 68,145 | 76,152 | **+11.75%** |
| 512 | 96,883 | 108,828 | **+12.33%** |
| 1024 | 104,228 | 117,379 | **+12.62%** |


### P-only: random prompts, OSL=1, GB300 PCP8/EP8

| ISL | FlashInfer req/s | DeepGEMM req/s | Throughput gain | FlashInfer p50 TTFT | DeepGEMM p50 TTFT | p50 TTFT |
| ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 1K | 39.601 | 55.249 | **+39.51%** | 402.807 ms | 288.575 ms | **-28.36%** |
| 2K | 27.004 | 37.990 | **+40.68%** | 592.267 ms | 421.739 ms | **-28.79%** |
| 4K | 20.329 | 26.193 | **+28.84%** | 776.873 ms | 604.094 ms | **-22.24%** |
| 8K | 10.089 | 12.815 | **+27.01%** | 1539.304 ms | 1221.353 ms | **-20.66%** |

Every point completed all formal requests with zero failures. The initial sweep showed +38.12%/+41.91%/+29.93%/+28.72% throughput for 1K/2K/4K/8K; the repeat preserved the direction and magnitude at every point. Because `long_prefill_token_threshold=4096`, the 8K prompts were chunked; this flag was identical in both arms.

#### P-only serve recipe

```bash
vllm serve nvidia/GLM-5.2-NVFP4 \
  --tensor-parallel-size 1 \
  --prefill-context-parallel-size 8 \
  --enable-expert-parallel \
  --all2all-backend flashinfer_nvlink_one_sided \
  --moe-backend deep_gemm_mega_moe \
  --enforce-eager \
  --attention-backend FLASHINFER_MLA_SPARSE \
  --kv-cache-dtype fp8_e4m3 \
  --max-model-len 9216 \
  --max-num-seqs 32 \
  --max-num-batched-tokens 16384 \
  --long-prefill-token-threshold 4096 \
  --no-enable-prefix-caching
```

For the FlashInfer baseline, replace `--moe-backend deep_gemm_mega_moe` with `--moe-backend auto`; all other serving flags are identical.

### Routing-imbalance sensitivity

The imbalance factor `x` is the busiest destination rank's received routed slots divided by the mean received slots across the eight destination ranks:

```text
x = max(slots_received_by_rank) / mean(slots_received_by_rank)
```

Thus, `1x` is perfectly balanced, while `2x`, `4x`, and `7x` mean that the busiest rank receives 2, 4, or 7 times the average routed slots. 
| Destination imbalance | DG gain at M32 | DG gain at M64 |
| ---: | ---: | ---: |
| 1x | **+18.26%** | **+19.95%** |
| 2x | **+17.61%** | **+19.53%** |
| 4x | **+4.83%** | **+7.82%** |
| 7x | **-25.76%** | **-28.36%** |

## Accuracy

| Validation | Result |
| --- | --- |
| B300 dense PyTorch-reference UT | **PASS** on all eight ranks; relative output differences `1.49e-6` to `2.16e-6` with finite outputs and per-expert alpha/A2 scale paths |
| B300 full-size fusion-order test | Fused versus unfused output was exactly identical; deliberately wrong `(routed + shared) * 2.5` ordering differed by `0.2979`, validating `routed * 2.5 + shared` |
| Targeted GB300 integration smoke | **PASS**: M=1 `int32` IDs, M=8 `int64` IDs, and semantic guards |
| Targeted vLLM GPU tests | **16/16 passed** |
| DeepGEMM boundary/adversarial | **42/42 passed**, M/rank 1-2048, max rel-L2 `0.005421` |
| DeepGEMM random fuzz | **22/22 passed**, M/rank 3-3073, max rel-L2 `0.002655` |
| DeepGEMM shared-only | **10/10 passed**, max rel-L2 `0.001134` |
| Real GLM-5.2 MoE layer replays | **75/75 passed**; fused was closer to FP32 in 69/75 layers |
| Deterministic E2E prompts | **16/16 exact** for each arm across two runs |
| 700-repeat long-context probe | All three arms produced the same token sequence and content |
| Initial paired GSM8K canary, fixed 100 questions, 5-shot | FI **93%**, DG fused **93%**; invalid responses **0%** in both arms |
| GSM8K, 100 questions, 5-shot | FI **95%**, DG unfused **94%**, DG fused **95%**; invalid responses **0%** |


<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR.
- [x] The test plan and commands.
- [x] The model-evaluation and performance results.
- [ ] (Optional) Documentation updates.
</details>




## Contribution notes

- AI assistance was used during implementation, debugging, review, benchmark analysis, and preparation of this PR description. The human submitter must review and understand every changed line and verify the final commands and results before merge.
