### PR TITLE
[Bugfix][KV Cache] Prevent negative external block allocation

### DIFF
--- a/tests/v1/core/test_single_type_kv_cache_manager.py
+++ b/tests/v1/core/test_single_type_kv_cache_manager.py
@@ -14,16 +14,59 @@ from vllm.v1.core.kv_cache_utils import (
 )
 from vllm.v1.core.single_type_kv_cache_manager import (
     ChunkedLocalAttentionManager,
+    FullAttentionManager,
     RSWAManager,
     SlidingWindowManager,
 )
 from vllm.v1.kv_cache_interface import (
     ChunkedLocalAttentionSpec,
+    FullAttentionSpec,
     RSWASpec,
     SlidingWindowSpec,
 )
 
 pytestmark = pytest.mark.cpu_test
+
+
+def test_external_computed_blocks_do_not_corrupt_free_pool():
+    block_size = 4
+    spec = FullAttentionSpec(
+        block_size=block_size,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.float32,
+    )
+    block_pool = BlockPool(
+        num_gpu_blocks=10,
+        enable_caching=False,
+        hash_block_size=block_size,
+    )
+    manager = FullAttentionManager(
+        spec,
+        block_pool=block_pool,
+        enable_caching=False,
+        kv_cache_group_id=0,
+        scheduler_block_size=block_size,
+    )
+    request_id = "request"
+    manager.allocate_new_blocks(
+        request_id,
+        num_tokens=3 * block_size,
+        num_tokens_main_model=3 * block_size,
+    )
+    num_free_blocks = block_pool.get_num_free_blocks()
+
+    # Speculative allocations can exceed the blocks implied by the eventual
+    # external computed-token count. This must not request a negative number
+    # of blocks, which inflates the free-queue counter.
+    manager.allocate_external_computed_blocks(
+        request_id,
+        num_local_computed_tokens=0,
+        num_external_computed_tokens=block_size,
+    )
+
+    assert block_pool.get_num_free_blocks() == num_free_blocks
+    assert len(manager.req_to_blocks[request_id]) == 3
 
 
 def get_sliding_window_manager(

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -317,9 +317,10 @@ class SingleTypeKVCacheManager(ABC):
             return
 
         req_blocks = self.req_to_blocks[request_id]
-        allocated_blocks = self.block_pool.get_new_blocks(
-            cdiv(num_total_computed_tokens, self.block_size) - len(req_blocks)
+        num_new_blocks = max(
+            0, cdiv(num_total_computed_tokens, self.block_size) - len(req_blocks)
         )
+        allocated_blocks = self.block_pool.get_new_blocks(num_new_blocks)
         req_blocks.extend(allocated_blocks)
         if self._record_new_block_ids:
             self.new_block_ids.extend(b.block_id for b in allocated_blocks)


### PR DESCRIPTION
## Summary

- Clamp external computed-block allocation at zero when a request already holds more blocks than its final computed-token count requires.
- Prevent a negative `get_new_blocks()` request from inflating `FreeKVCacheBlockQueue.num_free_blocks` without removing list entries.
- Add a regression test covering speculative over-allocation followed by a smaller external computed-token count.

## Root cause

`allocate_external_computed_blocks()` passed this value directly to the block pool:

```text
ceil(total_computed_tokens / block_size) - len(request_blocks)
```

After speculative allocation and rejection, `len(request_blocks)` can be larger, making the value negative. `BlockPool.get_new_blocks()` only rejects values larger than the free count, while `popleft_n()` subtracts the negative count and iterates `range(negative)`. The queue counter therefore increases even though no blocks are removed, and a later valid pop can walk beyond the linked-list tail.


## Test plan

- [x] `python3 -m pytest -q tests/v1/core/test_single_type_kv_cache_manager.py` — 12 passed
- [x] `git diff --check`
- [ ] Repeat the long-running Kimi-K3 external-KV workload on the source branch
- [ ] Human submitter review of every changed line before marking ready

