### PR TITLE
[Bugfix][Optimization] Zero packed KV blocks once from the backing sorage base

### DIFF
--- a/tests/v1/worker/test_kv_block_zeroer.py
+++ b/tests/v1/worker/test_kv_block_zeroer.py
@@ -145,29 +145,37 @@ def test_non_uniform_page_sizes():
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
-def test_packed_segment_zeros_only_its_last_block_page():
-    """A packed KV segment steps by block stride but clears only its page."""
+def test_packed_segment_zeros_whole_block_from_storage_base():
+    """A packed KV segment rooted at the backing storage base clears the
+    whole block stride (every interleaved layer), not just one layer's page.
+
+    This is the route-B behavior: ``seg_addrs`` starts at the storage base
+    (not the layer view's ``data_ptr``, which carries a per-block offset),
+    and ``seg_page_sizes`` equals the whole ``block_stride`` so a single
+    segment clears every layer in one launch.
+    """
     device = torch.device("cuda")
     num_blocks = 4
     block_stride_el = 12
-    page_size_el = 4
     page_offset_el = 3
+    page_size_el = 4
     backing = torch.ones(
         (num_blocks, block_stride_el), dtype=torch.int32, device=device
     )
 
     zeroer = KVBlockZeroer.__new__(KVBlockZeroer)
     zeroer.device = device
+    # Route B: segment rooted at the storage base, clearing the whole block.
     zeroer._meta = (
         torch.tensor(
-            [backing.data_ptr() + page_offset_el * backing.element_size()],
+            [backing.data_ptr()],
             dtype=torch.uint64,
             device=device,
         ),
         torch.tensor([block_stride_el], dtype=torch.int64, device=device),
-        torch.tensor([page_size_el], dtype=torch.int64, device=device),
+        torch.tensor([block_stride_el], dtype=torch.int64, device=device),
         1,
-        page_size_el,
+        block_stride_el,
         1,
     )
 
@@ -175,7 +183,78 @@ def test_packed_segment_zeros_only_its_last_block_page():
     torch.accelerator.synchronize()
 
     expected = torch.ones_like(backing)
-    expected[-1, page_offset_el : page_offset_el + page_size_el] = 0
+    expected[-1, :] = 0
+    assert torch.equal(backing, expected)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_packed_slab_dedup_clears_whole_block():
+    """Multiple layers sharing a packed backing are zeroed exactly once.
+
+    The segment must start at the backing storage base (not each layer's
+    data_ptr, which carries the per-block byte offset) and its cleared span
+    must cover the whole block stride so every interleaved layer is cleared
+    in a single launch.
+    """
+    device = torch.device("cuda")
+    num_blocks = 4
+    page_bytes = 16  # bytes per layer per block
+    block_stride_bytes = 2 * page_bytes  # two layers interleaved per block
+
+    backing = torch.ones(
+        num_blocks * block_stride_bytes, dtype=torch.int8, device=device
+    )
+
+    # Mirror _reshape_attention_kv_cache's packing branch: each layer is a
+    # strided view into the shared backing with a per-block byte offset, and
+    # stride(0) spanning the whole slab.
+    def make_view(offset):
+        return torch.as_strided(
+            backing,
+            size=(num_blocks, page_bytes),
+            stride=(block_stride_bytes, 1),
+            storage_offset=offset,
+        )
+
+    layer0 = make_view(0)
+    layer1 = make_view(page_bytes)
+    assert layer0.data_ptr() != layer1.data_ptr()
+    assert layer0.stride(0) * layer0.element_size() == block_stride_bytes
+
+    spec = SlidingWindowSpec(
+        block_size=1,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.int8,
+        sliding_window=1,
+    )
+    zeroer = KVBlockZeroer(
+        device,
+        attn_groups_iter=[
+            AttentionGroup(_BlockFirstBackend, ["layer0", "layer1"], spec, 0)
+        ],
+        kernel_block_sizes=[1],
+        cache_dtype="auto",
+        static_forward_context={
+            "layer0": SimpleNamespace(kv_cache=layer0),
+            "layer1": SimpleNamespace(kv_cache=layer1),
+        },
+    )
+
+    assert zeroer._meta is not None
+    seg_addrs, seg_block_strides, seg_page_sizes, *_ = zeroer._meta
+    # Both layers alias one backing storage: dedup yields a single segment
+    # rooted at the storage base, clearing the whole block stride.
+    assert seg_addrs.numel() == 1
+    assert int(seg_addrs[0]) == backing.data_ptr()
+    assert seg_block_strides.tolist() == [block_stride_bytes // 4]
+    assert seg_page_sizes.tolist() == [block_stride_bytes // 4]
+
+    zeroer.zero_block_ids([num_blocks - 1])
+    torch.accelerator.synchronize()
+
+    expected = torch.ones_like(backing)
+    expected.view(num_blocks, block_stride_bytes)[-1, :] = 0
     assert torch.equal(backing, expected)
 
 

--- a/tests/v1/worker/test_kv_block_zeroer.py
+++ b/tests/v1/worker/test_kv_block_zeroer.py
@@ -157,8 +157,6 @@ def test_packed_segment_zeros_whole_block_from_storage_base():
     device = torch.device("cuda")
     num_blocks = 4
     block_stride_el = 12
-    page_offset_el = 3
-    page_size_el = 4
     backing = torch.ones(
         (num_blocks, block_stride_el), dtype=torch.int32, device=device
     )

--- a/vllm/v1/worker/utils.py
+++ b/vllm/v1/worker/utils.py
@@ -140,10 +140,10 @@ class KVBlockZeroer:
 
         if runner_only_attn_layers is None:
             runner_only_attn_layers = set()
-        # Overlaid layers (packed layouts) share a base address but may have
-        # different page sizes; keep the widest span per address so newly
-        # allocated blocks are fully zeroed for every overlaying group.
-        seen_ptrs: dict[int, int] = {}
+        # Overlaid layers (packed layouts) share a backing storage allocation;
+        # deduplicate on the storage base pointer so each packed slab is zeroed
+        # exactly once instead of once per aliased layer view.
+        seen_ptrs: set[int] = set()
         seg_addrs: list[int] = []
         seg_block_strides: list[int] = []
         seg_page_sizes: list[int] = []
@@ -164,7 +164,26 @@ class KVBlockZeroer:
                 kv = static_forward_context[layer_name].kv_cache
                 if not isinstance(kv, torch.Tensor):
                     continue
-                dp = kv.data_ptr()
+                # Packed block-first views (e.g. DeepSeek V4) are strided views
+                # into a shared block-interleaved backing allocation:
+                # ``kv.data_ptr()`` includes the layer's byte offset inside each
+                # block, while ``kv.stride(0) * element_size()`` is the
+                # whole slab's per-block stride. Starting the segment at the
+                # layer's data_ptr would make ``block_id * PAGE_SIZE_EL`` walk
+                # past the end of the backing allocation for the last blocks.
+                #
+                # Start segments at the backing storage base and deduplicate on
+                # the storage pointer so each packed slab is zeroed exactly once
+                # (instead of once per aliased layer view). Because the zeroed
+                # span is ``block_stride_bytes`` (the whole block for packed
+                # views, equal to the single-layer page size for standalone
+                # allocations), a single segment clears every interleaved layer.
+                # Standalone allocations have storage base == data_ptr(), so
+                # behavior is unchanged there.
+                dp = kv.untyped_storage().data_ptr()
+                if dp in seen_ptrs:
+                    continue
+                seen_ptrs.add(dp)
 
                 el = kv.element_size()
                 block_stride_bytes = kv.stride(0) * el
@@ -176,30 +195,16 @@ class KVBlockZeroer:
                     if kv.stride(d) * el > block_stride_bytes
                 ]
                 outer_strides = [kv.stride(d) * el for d in outer_dims]
-                inner_dims = [d for d in range(1, kv.ndim) if d not in outer_dims]
-                kernel_page_bytes = el + sum(
-                    (kv.shape[d] - 1) * kv.stride(d) * el for d in inner_dims
-                )
-                assert kernel_page_bytes % 4 == 0
                 logical_block_stride_bytes = block_stride_bytes * ratio
                 for outer in iprod(*(range(kv.shape[d]) for d in outer_dims)):
                     off_bytes = sum(i * s for i, s in zip(outer, outer_strides))
                     assert (dp + off_bytes) % 4 == 0
                     for virtual_index in range(ratio):
-                        addr = dp + off_bytes + virtual_index * block_stride_bytes
-                        if (idx := seen_ptrs.get(addr)) is not None:
-                            assert (
-                                seg_block_strides[idx]
-                                == logical_block_stride_bytes // 4
-                            )
-                            seg_page_sizes[idx] = max(
-                                seg_page_sizes[idx], kernel_page_bytes // 4
-                            )
-                            continue
-                        seen_ptrs[addr] = len(seg_addrs)
-                        seg_addrs.append(addr)
+                        seg_addrs.append(
+                            dp + off_bytes + virtual_index * block_stride_bytes
+                        )
                         seg_block_strides.append(logical_block_stride_bytes // 4)
-                        seg_page_sizes.append(kernel_page_bytes // 4)
+                        seg_page_sizes.append(block_stride_bytes // 4)
 
         if not seg_addrs:
             self._meta = None


### PR DESCRIPTION
## Problem

`KVBlockZeroer` builds one segment per aliased layer view of a packed
block-first KV cache (e.g. DeepSeek V4). Each segment starts at the layer
view's `data_ptr()`. Packed views are created by `_reshape_attention_kv_cache`:

    kv_cache = kv_raw_tensor.view(-1, block_stride)[:, offset : offset + page_bytes]

For such a view:

- `kv.data_ptr()` includes the layer's per-block byte `offset`
- `kv.stride(block_dim) * element_size()` is the whole slab's per-block
  stride, not this layer's page size

Starting a segment at `data_ptr()` therefore zeroes:

    backing_base + layer_offset + block_id * block_stride

which has two failure modes:

1. **Out-of-bounds write** — for `layer_offset > 0`, the last blocks walk past
   the end of the backing allocation (CUDA illegal memory access), reproduced
   as `block_id = num_blocks - 1` failing while `num_blocks - 2` is safe.
2. **Cross-layer stomp** — even in bounds, the cleared range is shifted by
   `layer_offset`, overwriting a neighbouring layer's KV (session corruption).

## Fix

Root every segment at the backing storage base and deduplicate on the storage
pointer so each packed slab is zeroed exactly once, and make the cleared span
cover the whole block stride:

1. `dp = kv.untyped_storage().data_ptr()` — strips the per-block layer offset.
2. deduplicate on `dp` (storage base) — one segment per packed slab.
3. `seg_page_sizes` uses `block_stride_bytes` instead of the single-layer
   `kernel_page_bytes` — a single segment clears every interleaved layer.

All three changes are required together: starting at the storage base without
widening the span would clear only the first layer, and widening the span
without rooting at the storage base would shift the cleared region.

## Correctness

| layout | storage base | span | dedup | result |
|---|---|---|---|---|
| packed block-first | != data_ptr | whole block | 1 seg / slab | clears all layers, no OOB |
| standalone allocation | == data_ptr | == page size | 1 seg / layer | unchanged |
| K/V-first (block_dim=1) | == data_ptr | == page size | K/V segments | unchanged |
| page-aligned (ROCm) | == data_ptr | == page size | unchanged | unchanged |

The key invariant is that `kv.stride(block_dim) * element_size()` always equals
the full byte span of one logical block: the sum of all layer pages for packed
views, and the single-layer page size for standalone allocations. Setting
`seg_page_sizes == seg_block_strides == block_stride_bytes // 4` therefore clears
exactly one whole block per segment.

## Performance

The kernel grid becomes `(n_blocks, n_segs, max_chunks)` where `max_chunks` grows
from `single_layer_page / blk_size` to `block_stride / blk_size`. Total kernel
programs are unchanged (`N_layers x small` -> `1 x large`), but the number of
kernel launches per zeroing step drops from `N_layers` to 1.

## Test

- `test_packed_slab_dedup_clears_whole_block` — two layers sharing a packed
  backing yield a single segment rooted at the storage base with `block_stride`
  as the cleared span; zeroing the last block clears the whole block.
- `test_packed_segment_zeros_whole_block_from_storage_base` (replaces
  `test_packed_segment_zeros_only_its_last_block_page`) — verifies a packed
  segment rooted at the storage base clears the full block stride, not a single
  layer's page.

## Relationship to #50276

#50276 (already merged) splits block stride from page span but keeps per-layer
segments starting at `data_ptr()`. This PR is a complementary alternative: it
collapses the per-layer segments of a packed slab into one whole-block segment
rooted at the storage base. This both removes the offset-based OOB/stomp hazard
and reduces zeroing launches from `N_layers` to 1. The two approaches are
mutually exclusive for packed views; this PR does not layer on top of #50276 but
replaces the per-layer segment construction for the packed case.
