### PR TITLE
[Kernel][XPU] Enable int8_w8a8 per-token MoE on the Triton backend for XPU

### DIFF
--- a/tests/quantization/test_int8_moe_oracle.py
+++ b/tests/quantization/test_int8_moe_oracle.py
@@ -34,10 +34,20 @@ INT8_MOE_SUPPORTED = (
     current_platform.is_cuda() and current_platform.has_device_capability((7, 5))
 ) or current_platform.is_rocm()
 
+# XPU supports the per-token scheme only; see TritonExperts._supports_quant_scheme.
+INT8_MOE_PER_TOKEN_SUPPORTED = INT8_MOE_SUPPORTED or current_platform.is_xpu()
+
 requires_int8_moe = pytest.mark.skipif(
     not INT8_MOE_SUPPORTED,
     reason="Requires a GPU with Triton INT8 MoE support (CUDA SM>=7.5 or ROCm)",
 )
+
+requires_int8_moe_per_token = pytest.mark.skipif(
+    not INT8_MOE_PER_TOKEN_SUPPORTED,
+    reason="Requires Triton INT8 MoE support (CUDA SM>=7.5, ROCm, or XPU)",
+)
+
+DEVICE = current_platform.device_type
 
 
 def _make_int8_moe_config(moe_backend: str = "auto") -> FusedMoEConfig:
@@ -53,7 +63,7 @@ def _make_int8_moe_config(moe_backend: str = "auto") -> FusedMoEConfig:
         moe_parallel_config=FusedMoEParallelConfig.make_no_parallel(),
         activation=MoEActivation.SILU,
         in_dtype=torch.bfloat16,
-        device="cuda",
+        device=DEVICE,
         routing_method=RoutingMethodType.Renormalize,
         moe_backend=moe_backend,
     )
@@ -78,6 +88,40 @@ def test_int8_dynamic_schemes_dispatch_to_triton(weight_key, activation_key):
     )
     assert backend == Int8MoeBackend.TRITON
     assert experts_cls is not None
+
+
+@requires_int8_moe_per_token
+def test_int8_per_token_scheme_dispatches_to_triton_on_every_device():
+    """The per-token scheme is the one INT8 MoE scheme XPU can also run.
+
+    Its activation quantization is a Triton kernel (per_token_quant_int8),
+    unlike the per-tensor schemes, which call ops.scaled_int8_quant -- a custom
+    op with no XPU implementation. Kept separate from the parametrized test
+    above so XPU exercises exactly the pair it supports.
+    """
+    config = _make_int8_moe_config()
+    backend, experts_cls = select_int8_moe_backend(
+        config,
+        weight_key=kInt8StaticChannelSym,
+        activation_key=kInt8DynamicTokenSym,
+    )
+    assert backend == Int8MoeBackend.TRITON
+    assert experts_cls is not None
+
+
+@pytest.mark.skipif(
+    not current_platform.is_xpu(), reason="XPU-specific scheme restriction"
+)
+def test_int8_per_tensor_scheme_unsupported_on_xpu():
+    """Pins the per-tensor exclusion on XPU: ops.scaled_int8_quant is missing
+    there, so the oracle must not offer this scheme rather than fail later."""
+    config = _make_int8_moe_config()
+    with pytest.raises(NotImplementedError):
+        select_int8_moe_backend(
+            config,
+            weight_key=kInt8StaticTensorSym,
+            activation_key=kInt8DynamicTensorSym,
+        )
 
 
 @requires_int8_moe

--- a/vllm/model_executor/layers/fused_moe/experts/triton_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/triton_moe.py
@@ -132,17 +132,24 @@ class TritonExperts(LoRAExpertsMixin, mk.FusedMoEExpertsModular):
             and current_platform.has_device_capability((7, 5))
         ) or current_platform.is_rocm()
 
+        # XPU reaches the same Triton kernel, but only the per-token activation
+        # scheme: its quantization step is a Triton kernel
+        # (per_token_quant_int8), whereas the per-tensor schemes call
+        # ops.scaled_int8_quant, which has no XPU implementation.
+        device_supports_per_token_int8 = (
+            device_supports_int8 or current_platform.is_xpu()
+        )
+
         supported: list[tuple[QuantKey | None, QuantKey | None]] = [(None, None)]
-        if device_supports_int8:
+        if device_supports_per_token_int8:
             # Activations are consumed as float and quantized to int8
             # dynamically inside the kernel, so only dynamic-activation int8
             # schemes are supported (static-activation int8 is not).
-            supported += [
-                # per-channel weight + dynamic per-token activation
-                (kInt8StaticChannelSym, kInt8DynamicTokenSym),
-                # per-tensor weight + dynamic per-tensor activation
-                (kInt8StaticTensorSym, kInt8DynamicTensorSym),
-            ]
+            # per-channel weight + dynamic per-token activation
+            supported.append((kInt8StaticChannelSym, kInt8DynamicTokenSym))
+        if device_supports_int8:
+            # per-tensor weight + dynamic per-tensor activation
+            supported.append((kInt8StaticTensorSym, kInt8DynamicTensorSym))
         if current_platform.supports_fp8():
             supported += [
                 (kFp8Static128BlockSym, kFp8Dynamic128Sym),


### PR DESCRIPTION
Reopening. Withdrawn on 2026-08-18 to finish an independent review pass; that pass is done. Rebased onto current `main` (`4b7cb949a9`), one signed commit, +59/−8 across 2 files.

## Bug

`int8_w8a8` MoE is unsupported on XPU by omission. `TritonExperts._supports_quant_scheme` (`experts/triton_moe.py:132-135`) gates every int8 scheme on

```python
device_supports_int8 = (
    current_platform.is_cuda() and current_platform.has_device_capability((7, 5))
) or current_platform.is_rocm()
```

and there is no XPU int8 experts class either (`XPUExpertsWNA16` accepts int4 keys only), so `select_int8_moe_backend` raises. `oracle/int8.py` has no platform branch at all — the priority list is `[TRITON, HUMMING, CPU]` on every device — and `TritonExperts._supports_current_device()` already returns true for XPU.

## Reproduce

```
vllm serve soyrsoyr/deepseek-moe-16b-chat-W8A8-GPTQ \
  --quantization compressed-tensors --moe-backend triton \
  --enforce-eager --trust-remote-code
```

On `main`, Intel Arc Pro B70, the engine does not start:

```
ValueError: Int8 MoE backend TRITON does not support the deployment configuration
since kernel does not support quantization scheme
QuantKey(i8, scale(f32, static, per_channel), ...)
```

The checkpoint's experts genuinely carry this scheme: `quant_method: compressed-tensors`, `format: int-quantized`, weights `{num_bits: 8, type: int, strategy: channel, group_size: null, symmetric: true, dynamic: false}`, activations `{num_bits: 8, type: int, strategy: token, dynamic: true, symmetric: true}`, `n_routed_experts: 64`, `ignore: ["lm_head"]` only — no experts excluded. Most published W8A8 MoE checkpoints put every expert in `ignore` and would give a green run that never touches this kernel.

`--trust-remote-code` is needed because the repo carries an `auto_map`. Its `configuration_deepseek.py` and `modeling_deepseek.py` are byte-identical (SHA-256) to the ones in `deepseek-ai/deepseek-moe-16b-chat`, so this executes DeepSeek's own published code.

## Change

Enable only `(kInt8StaticChannelSym, kInt8DynamicTokenSym)` on XPU. Per-tensor stays refused: its activation step calls `ops.scaled_int8_quant`, which has no XPU implementation, whereas per-token uses the Triton `per_token_quant_int8` (`int8_utils.py:95-113`). A test pins that the per-tensor pair keeps being rejected.

The CUDA/ROCm gate is untouched — `device_supports_int8` still keys the per-tensor entry, and the new `device_supports_per_token_int8` only widens the per-token entry by `or current_platform.is_xpu()`.

## Result

With this PR, same command: engine starts, `Using TRITON Int8 MoE backend out of potential backends: ['TRITON', 'HUMMING', 'CPU']`, and `"What is 15 plus 27?"` → `"15 plus 27 is 42."`. A spy on `triton_moe.invoke_fused_moe_triton_kernel` counts **918 of 918** launches with `use_int8_w8a8=True`, so nothing silently falls back.

Accuracy, `lm_eval==0.4.12`, `gsm8k`, 5-shot, full 1319 questions, `seed=42`, `batch_size auto`, identical `--model_args` on both sides:

| | vLLM | `flexible-extract` | `strict-match` |
|---|---|---|---|
| Intel Arc Pro B70, **this PR** | `0.27.2rc1.dev154+g5fd7a8883` | **0.2085** ± 0.0112 | 0.0000 |
| NVIDIA L40S, **stock `vllm/vllm-openai:v0.27.0`, unpatched** | `0.27.0` | **0.2123** ± 0.0113 | 0.0000 |

Δ `flexible-extract` = **−0.0038**, inside the standard error of either run. The CUDA row is a genuine reference rather than a self-comparison: on CUDA this scheme is already supported on `main`, so the stock image runs the same Triton kernel with the same quant scheme and no patch at all.

`strict-match` is 0.0000 on **both** platforms. That is this checkpoint's tokenizer emitting raw BPE markers (`Ġ`, `Ċ`) into decoded text, which breaks the `#### <number>` format `strict-match` requires — not an XPU numerical problem. It is why `flexible-extract` is the row to read.

Tests: `tests/quantization/test_int8_moe_oracle.py` extended, no new file — B70 **2 passed, 4 skipped** (the skips are the CUDA/ROCm-gated cases). `ruff check` and `ruff format --check` clean on both changed files with ruff 0.14.0.

## Duplicate check

Independent of #52652 (tensor-descriptor path for `fused_moe_kernel_gptq_awq`): different kernel, different scheme, no shared lines. #51515 also touches `experts/triton_moe.py` but rewrites the expert-assignment call inside `TritonExperts.apply`; no overlap with `_supports_quant_scheme`, and its diff applies cleanly over this branch. No open PR touches `_supports_quant_scheme`.

---

AI assistance was used (Claude Code) for implementation and testing. Every changed line was reviewed, and all numbers above were produced on Intel Arc Pro B70 and NVIDIA L40S hardware on 2026-08-20.
