### PR TITLE
[Performance][MRV2] Use uint16 for penalty output counts

### DIFF
--- a/tests/v1/worker/test_gpu_penalties.py
+++ b/tests/v1/worker/test_gpu_penalties.py
@@ -1,0 +1,226 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+
+from vllm.platforms import current_platform
+
+pytest.importorskip("triton")
+if current_platform.device_count() == 0:
+    pytest.skip(
+        "Accelerator required for Model Runner V2 penalty tests",
+        allow_module_level=True,
+    )
+
+from vllm.v1.worker.gpu.input_batch import post_update
+from vllm.v1.worker.gpu.sample.penalties import (
+    PenaltiesState,
+    apply_penalties,
+    bincount,
+)
+from vllm.v1.worker.gpu.states import RequestState
+
+DEVICE = torch.device(current_platform.device_type)
+
+
+@pytest.mark.parametrize(
+    ("max_model_len", "expected_dtype", "expected_width"),
+    [
+        (65_535, torch.uint16, 6),
+        (65_536, torch.int32, 5),
+    ],
+)
+def test_output_counts_use_narrowest_exact_dtype(
+    max_model_len: int, expected_dtype: torch.dtype, expected_width: int
+):
+    req_states = RequestState(
+        max_num_reqs=1,
+        max_model_len=max_model_len,
+        max_num_batched_tokens=1,
+        num_speculative_steps=0,
+        vocab_size=5,
+        device=DEVICE,
+    )
+
+    state = PenaltiesState(req_states)
+
+    assert state.output_bin_counts.dtype == expected_dtype
+    assert state.output_bin_counts.shape == (1, expected_width)
+
+
+@pytest.mark.parametrize(
+    ("count0", "count1"),
+    [(65_535, 0), (0, 65_535), (40_000, 7), (7, 65_528), (32_767, 32_768)],
+)
+def test_uint16_bincount_keeps_adjacent_counters_independent(count0: int, count1: int):
+    token_ids = torch.tensor([0] * count0 + [1] * count1, device=DEVICE)
+    all_token_ids = token_ids.unsqueeze(0).to(torch.int32)
+    prompt_bin_mask = torch.zeros((1, 1), dtype=torch.int32, device=DEVICE)
+    output_bin_counts = torch.zeros((1, 6), dtype=torch.uint16, device=DEVICE)
+    output_bin_counts_int32 = torch.zeros((1, 5), dtype=torch.int32, device=DEVICE)
+
+    for counts in (output_bin_counts, output_bin_counts_int32):
+        bincount(
+            expanded_idx_mapping=torch.tensor([0], dtype=torch.int32, device=DEVICE),
+            all_token_ids=all_token_ids,
+            prompt_len=torch.tensor([0], dtype=torch.int32, device=DEVICE),
+            prefill_len=torch.tensor(
+                [token_ids.numel()], dtype=torch.int32, device=DEVICE
+            ),
+            prompt_bin_mask=prompt_bin_mask,
+            output_bin_counts=counts,
+            max_prefill_len=token_ids.numel(),
+        )
+
+    expected = torch.tensor([count0, count1, 0, 0, 0, 0], dtype=torch.int64)
+    torch.testing.assert_close(output_bin_counts.cpu().to(torch.int64)[0], expected)
+    torch.testing.assert_close(
+        output_bin_counts_int32.cpu().to(torch.int64)[0], expected[:5]
+    )
+
+
+def test_uint16_bincount_handles_odd_vocab_last_token():
+    output_bin_counts = torch.zeros((1, 6), dtype=torch.uint16, device=DEVICE)
+
+    bincount(
+        expanded_idx_mapping=torch.tensor([0], dtype=torch.int32, device=DEVICE),
+        all_token_ids=torch.tensor([[4, 4, 4]], dtype=torch.int32, device=DEVICE),
+        prompt_len=torch.tensor([0], dtype=torch.int32, device=DEVICE),
+        prefill_len=torch.tensor([3], dtype=torch.int32, device=DEVICE),
+        prompt_bin_mask=torch.zeros((1, 1), dtype=torch.int32, device=DEVICE),
+        output_bin_counts=output_bin_counts,
+        max_prefill_len=3,
+    )
+
+    expected = torch.tensor([0, 0, 0, 0, 3, 0], dtype=torch.int64)
+    torch.testing.assert_close(output_bin_counts.cpu().to(torch.int64)[0], expected)
+
+
+def test_uint16_bincount_clears_only_reused_rows():
+    output_bin_counts = torch.tensor(
+        [[9, 8, 7, 6, 5, 4], [6, 5, 4, 3, 2, 1]],
+        dtype=torch.uint16,
+        device=DEVICE,
+    )
+    prompt_bin_mask = torch.tensor(
+        [[0x12345], [0x54321]], dtype=torch.int32, device=DEVICE
+    )
+
+    bincount(
+        expanded_idx_mapping=torch.tensor([1], dtype=torch.int32, device=DEVICE),
+        all_token_ids=torch.tensor(
+            [[4, 4, 4], [0, 1, 1]], dtype=torch.int32, device=DEVICE
+        ),
+        prompt_len=torch.tensor([0, 0], dtype=torch.int32, device=DEVICE),
+        prefill_len=torch.tensor([3, 3], dtype=torch.int32, device=DEVICE),
+        prompt_bin_mask=prompt_bin_mask,
+        output_bin_counts=output_bin_counts,
+        max_prefill_len=3,
+    )
+
+    expected_counts = torch.tensor(
+        [[9, 8, 7, 6, 5, 4], [1, 2, 0, 0, 0, 0]], dtype=torch.int64
+    )
+    torch.testing.assert_close(output_bin_counts.cpu().to(torch.int64), expected_counts)
+    torch.testing.assert_close(
+        prompt_bin_mask.cpu(), torch.tensor([[0x12345], [0]], dtype=torch.int32)
+    )
+
+
+def test_uint16_penalties_match_int32():
+    vocab_size = 257
+    num_tokens = 6
+    logits = torch.linspace(
+        -3.0, 3.0, steps=num_tokens * vocab_size, device=DEVICE
+    ).reshape(num_tokens, vocab_size)
+    logits_uint16 = logits.clone()
+    logits_int32 = logits.clone()
+    counts_int32 = (
+        torch.arange(2 * vocab_size, dtype=torch.int32, device=DEVICE)
+        .reshape(2, vocab_size)
+        .remainder(101)
+    )
+    counts_uint16 = torch.zeros((2, 258), dtype=torch.uint16, device=DEVICE)
+    counts_uint16[:, :vocab_size] = counts_int32
+    prompt_bin_mask = torch.tensor(
+        [[0x10101010] * 9, [0x01010101] * 9],
+        dtype=torch.int32,
+        device=DEVICE,
+    )
+    expanded_idx_mapping = torch.tensor(
+        [0, 0, 0, 1, 1, 1], dtype=torch.int32, device=DEVICE
+    )
+    token_ids = torch.tensor([3, 5, 7, 11, 13, 17], dtype=torch.int32, device=DEVICE)
+    local_pos = torch.tensor([0, 1, 2, 0, 1, 2], dtype=torch.int32, device=DEVICE)
+    repetition = torch.tensor([1.1, 0.9], device=DEVICE)
+    frequency = torch.tensor([0.5, -0.3], device=DEVICE)
+    presence = torch.tensor([0.8, -0.6], device=DEVICE)
+
+    for current_logits, counts in (
+        (logits_uint16, counts_uint16),
+        (logits_int32, counts_int32),
+    ):
+        apply_penalties(
+            current_logits,
+            expanded_idx_mapping,
+            token_ids,
+            local_pos,
+            repetition,
+            frequency,
+            presence,
+            prompt_bin_mask,
+            counts,
+        )
+
+    torch.testing.assert_close(logits_uint16, logits_int32, rtol=0, atol=0)
+
+
+def test_penalties_read_uint16_counts_without_truncation():
+    vocab_size = 5
+    logits = torch.zeros((1, vocab_size), device=DEVICE)
+    output_bin_counts = torch.tensor(
+        [[40_000, 7, 0, 0, 0, 0]], dtype=torch.uint16, device=DEVICE
+    )
+
+    apply_penalties(
+        logits=logits,
+        expanded_idx_mapping=torch.tensor([0], dtype=torch.int32, device=DEVICE),
+        token_ids=torch.tensor([0], dtype=torch.int32, device=DEVICE),
+        expanded_local_pos=torch.tensor([0], dtype=torch.int32, device=DEVICE),
+        repetition_penalty=torch.tensor([1.0], device=DEVICE),
+        frequency_penalty=torch.tensor([0.0001], device=DEVICE),
+        presence_penalty=torch.tensor([0.0], device=DEVICE),
+        prompt_bin_mask=torch.zeros((1, 1), dtype=torch.int32, device=DEVICE),
+        output_bin_counts=output_bin_counts,
+    )
+
+    expected = torch.tensor([[-4.0, -0.0007, 0.0, 0.0, 0.0]])
+    torch.testing.assert_close(logits.cpu(), expected)
+
+
+def test_post_update_increments_uint16_counts():
+    output_bin_counts = torch.tensor(
+        [[0, 40_000, 0, 0]], dtype=torch.uint16, device=DEVICE
+    )
+    output_bin_counts_int32 = output_bin_counts.to(torch.int32)
+
+    for counts in (output_bin_counts, output_bin_counts_int32):
+        post_update(
+            idx_mapping=torch.tensor([0], dtype=torch.int32, device=DEVICE),
+            num_computed_tokens=torch.zeros(1, dtype=torch.int32, device=DEVICE),
+            last_sampled_tokens=torch.zeros((1, 1), dtype=torch.int64, device=DEVICE),
+            output_bin_counts=counts,
+            sampled_tokens=torch.tensor([[1, 2, 1]], dtype=torch.int64, device=DEVICE),
+            num_sampled=torch.tensor([3], dtype=torch.int32, device=DEVICE),
+            num_rejected=torch.tensor([0], dtype=torch.int32, device=DEVICE),
+            query_start_loc=None,
+            all_token_ids=torch.zeros((1, 8), dtype=torch.int32, device=DEVICE),
+            total_len=torch.zeros(1, dtype=torch.int32, device=DEVICE),
+        )
+
+    expected = torch.tensor([0, 40_002, 1, 0], dtype=torch.int64)
+    torch.testing.assert_close(output_bin_counts.cpu().to(torch.int64)[0], expected)
+    torch.testing.assert_close(
+        output_bin_counts_int32.cpu().to(torch.int64)[0], expected
+    )

--- a/vllm/v1/worker/gpu/sample/penalties.py
+++ b/vllm/v1/worker/gpu/sample/penalties.py
@@ -35,10 +35,18 @@ class PenaltiesState:
             dtype=torch.int32,
             device=self.device,
         )
-        # TODO(woosuk): This tensor is rarely used but can be very large, taking up
-        # GBs of GPU memory. Optimize the memory usage.
+        # Two uint16 counts share one int32 atomic word during initialization.
+        # Fall back to int32 when a count could exceed the uint16 range.
+        use_uint16_counts = req_states.max_model_len <= torch.iinfo(torch.uint16).max
+        output_counts_dtype = torch.uint16 if use_uint16_counts else torch.int32
+        output_counts_width = (
+            cdiv(self.vocab_size, 2) * 2 if use_uint16_counts else self.vocab_size
+        )
         self.output_bin_counts = torch.zeros(
-            max_num_reqs, self.vocab_size, dtype=torch.int32, device=self.device
+            max_num_reqs,
+            output_counts_width,
+            dtype=output_counts_dtype,
+            device=self.device,
         )
 
         self._new_penalties_reqs: list[int] = []
@@ -144,7 +152,7 @@ def _penalties_kernel(
         output_bin_counts_ptr + req_state_idx * output_bin_counts_stride + block,
         mask=mask,
         other=0,
-    )
+    ).to(tl.int32)
 
     # Accumulate draft token counts from previous positions directly into
     # output_bin_counts (preserves its native tensor layout, avoiding an
@@ -227,6 +235,7 @@ def _bincount_kernel(
     output_bin_counts_ptr,
     output_bin_counts_stride,
     BLOCK_SIZE: tl.constexpr,
+    PACKED_OUTPUT_COUNTS: tl.constexpr,
 ):
     token_idx = tl.program_id(0)
     block_idx = tl.program_id(1)
@@ -258,13 +267,20 @@ def _bincount_kernel(
         output_tokens = tl.load(
             all_token_ids_ptr + req_state_idx * all_token_ids_stride + block, mask=mask
         )
-        tl.atomic_add(
+        if PACKED_OUTPUT_COUNTS:
+            # Store even/odd token counts in the low/high uint16 lane.
+            # Counts below 2**16 cannot carry into the adjacent lane.
+            output_idx = output_tokens // 2
+            increment = 1 << ((output_tokens & 1) * 16)
+        else:
+            output_idx = output_tokens
+            increment = 1
+        output_ptr = (
             output_bin_counts_ptr
             + req_state_idx * output_bin_counts_stride
-            + output_tokens,
-            1,
-            mask=mask,
+            + output_idx
         )
+        tl.atomic_add(output_ptr, increment, mask=mask)
 
 
 def bincount(
@@ -276,10 +292,16 @@ def bincount(
     output_bin_counts: torch.Tensor,
     max_prefill_len: int,
 ) -> None:
+    packed_output_counts = output_bin_counts.dtype == torch.uint16
+    bincount_output = (
+        output_bin_counts.view(torch.int32)
+        if packed_output_counts
+        else output_bin_counts
+    )
     # Use index_fill_ instead of `tensor[idx] = 0` to avoid sync.
     idx_long = expanded_idx_mapping.long()
     prompt_bin_mask.index_fill_(0, idx_long, 0)
-    output_bin_counts.index_fill_(0, idx_long, 0)
+    bincount_output.index_fill_(0, idx_long, 0)
     num_tokens = expanded_idx_mapping.shape[0]
     BLOCK_SIZE = 1024
     num_blocks = triton.cdiv(max_prefill_len, BLOCK_SIZE)
@@ -291,9 +313,10 @@ def bincount(
         prefill_len,
         prompt_bin_mask,
         prompt_bin_mask.stride(0),
-        output_bin_counts,
-        output_bin_counts.stride(0),
+        bincount_output,
+        bincount_output.stride(0),
         BLOCK_SIZE=BLOCK_SIZE,
+        PACKED_OUTPUT_COUNTS=packed_output_counts,
     )
 
 


### PR DESCRIPTION
## Purpose

MRV2 stores generated-token counts in a persistent
`[max_num_reqs, vocab_size]` int32 tensor. When `max_model_len <= 65535`, each
count fits exactly in uint16.

This change:

- uses uint16 counts for those configurations and keeps int32 for longer contexts;
- pads odd vocab sizes so two uint16 counters can share one int32 atomic word;
- casts counts to int32 before applying penalties.

There is no API or sampling-semantics change.

For Qwen3.5-9B with `max_num_seqs=256`, the count state drops from 242.5 MiB
to 121.25 MiB. On an L40S, available KV cache increased from 18.86 GiB to
18.97 GiB, and KV capacity increased from 435,665 to 438,272 tokens.

## Not a duplicate

- #47540 optimizes persistent penalty statistics in MRV1.
- #49697 is a broad P800 MRV2 port with Torch fallbacks.
- #34213 removes `expanded_local_pos` from the MRV2 penalty path.

None compresses MRV2 output counts.

## Previous GPU validation

```text
/tmp/vllm-test-venv/bin/python -m pytest \
  tests/v1/worker/test_gpu_penalties.py \
  tests/v1/worker/test_gpu_input_batch.py \
  tests/v1/worker/test_gpu_input_batch_v2.py \
  --confcutdir=tests/v1/worker -v
25 passed in 22.29s
```

Ruff, Ruff format, mypy 3.12, typos, SPDX, filename, forbidden-import,
`torch.cuda` API, and boolean-context checks passed.

The GPU regression suite was rerun against main at `5c9ff536`. Qwen3.5-9B was
also tested on an L40S with MRV2 explicitly enabled. Baseline and candidate
returned the same text, finish reason, and token usage with presence, frequency,
and repetition penalties enabled. A 100-sample GSM8K run scored 0.87 vs. 0.88, with no invalid outputs;
this is a small regression check, not a full accuracy evaluation.

## Maintenance check — 2026-09-13

Checked against main `fa1b3b1922`: the patch merges cleanly, and the upstream
penalty implementation and `post_update` kernels are unchanged from the PR's
baseline. Python 3.12 syntax, Ruff 0.14.0 check/format and `git diff --check`
passed on the merged source. Open-PR search for `penalty uint16` found no other match.

This is a memory-footprint improvement; no throughput speedup is claimed.
No GPU was available for this update. The GPU results above remain historical,
on `5c9ff536`; they were not rerun on current main. The PR code is unchanged.

AI assistance was used for implementation and validation.
