### PR TITLE
[MooncakeStore] Report KV load tier in cache events

### DIFF
--- a/tests/v1/kv_connector/unit/test_mooncake_store_worker.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_worker.py
@@ -17,6 +17,7 @@ import pytest
 import torch
 
 from tests.v1.attention.utils import dense_kv_cache_views
+from vllm.distributed.kv_events import MEDIUM_CPU, MEDIUM_STORAGE
 from vllm.distributed.kv_transfer.kv_connector.v1.mooncake import (
     rdma_utils,
 )
@@ -117,6 +118,7 @@ def _make_store_recving_thread(
     *,
     tp_rank: int = 0,
     disk_offload_buffer_budget_bytes: int | None = None,
+    enable_kv_event: bool = False,
 ) -> mooncake_store_worker.KVCacheStoreRecvingThread:
     from vllm.v1.kv_cache_interface import FullAttentionSpec, KVCacheGroupSpec
 
@@ -139,6 +141,7 @@ def _make_store_recving_thread(
         ready_event=threading.Event(),
         coord=coord,
         disk_offload_buffer_budget_bytes=disk_offload_buffer_budget_bytes,
+        enable_kv_event=enable_kv_event,
     )
     thread.request_queue.task_done = MagicMock()
     return thread
@@ -1093,6 +1096,17 @@ def test_store_worker_get_block_ids_with_load_errors_delegates_to_recv_thread():
     recv_thread.get_and_clear_block_ids_with_load_errors.assert_called_once_with()
 
 
+def test_store_worker_get_kv_events_includes_receive_events():
+    recv_thread = MagicMock()
+    recv_thread.get_kv_events.return_value = ["loaded-event"]
+    w = _make_bare_worker(kv_role="kv_consumer")
+    w.enable_kv_events = True
+    w.kv_recv_threads = [recv_thread]
+
+    assert w.get_kv_events() == ["loaded-event"]
+    recv_thread.get_kv_events.assert_called_once_with()
+
+
 def test_store_sending_thread_passes_replicate_config_when_preferred_segment_set():
     store = MagicMock()
     store.batch_is_exist.side_effect = lambda keys: [0] * len(keys)
@@ -1476,6 +1490,101 @@ def test_recv_thread_logs_tier_summary_when_enabled(monkeypatch, caplog_vllm):
         and "bytes_by_tier={'memory': 256, 'disk': 256, 'unknown': 0}" in message
         for message in messages
     )
+
+
+def test_recv_thread_emits_tiered_events_after_rotation_and_split(monkeypatch):
+    monkeypatch.delenv("VLLM_MOONCAKE_STORE_TIER_LOG", raising=False)
+    store = MagicMock()
+    store.batch_get_into_multi_buffers.side_effect = [[256, 256], [256]]
+    thread = _make_store_recving_thread(
+        store,
+        tp_rank=1,
+        disk_offload_buffer_budget_bytes=_DISK_OFFLOAD_BUDGET_FOR_SPLIT,
+        enable_kv_event=True,
+    )
+    req = _make_load_req("req-a", [b"a0", b"a1", b"a2"], token_len=48)
+    tier_by_key = {
+        "test-model@tp_rank:0@pcp0@dcp0@pp_rank:0@group:0@6130": "memory",
+        "test-model@tp_rank:0@pcp0@dcp0@pp_rank:0@group:0@6131": "disk",
+        "test-model@tp_rank:0@pcp0@dcp0@pp_rank:0@group:0@6132": "memory",
+    }
+    store.batch_get_replica_desc.side_effect = lambda keys: {
+        key: [_ReplicaDesc(tier_by_key[key])] for key in keys
+    }
+
+    thread._handle_request(req)
+
+    assert [
+        call.args[0] for call in store.batch_get_replica_desc.call_args_list
+    ] == [
+        [
+            "test-model@tp_rank:0@pcp0@dcp0@pp_rank:0@group:0@6131",
+            "test-model@tp_rank:0@pcp0@dcp0@pp_rank:0@group:0@6132",
+        ],
+        ["test-model@tp_rank:0@pcp0@dcp0@pp_rank:0@group:0@6130"],
+    ]
+    events = thread.get_kv_events()
+    assert [event.medium for event in events] == [
+        MEDIUM_STORAGE,
+        MEDIUM_CPU,
+        MEDIUM_CPU,
+    ]
+    assert [event.block_hashes[0] for event in events] == [
+        maybe_convert_block_hash(BlockHash(b"a1")),
+        maybe_convert_block_hash(BlockHash(b"a2")),
+        maybe_convert_block_hash(BlockHash(b"a0")),
+    ]
+
+
+def test_recv_thread_emits_unknown_tier_with_no_medium(monkeypatch):
+    monkeypatch.delenv("VLLM_MOONCAKE_STORE_TIER_LOG", raising=False)
+    store = MagicMock()
+    store.batch_get_into_multi_buffers.return_value = [256]
+    thread = _make_store_recving_thread(
+        store, disk_offload_buffer_budget_bytes=None, enable_kv_event=True
+    )
+    key = "test-model@tp_rank:0@pcp0@dcp0@pp_rank:0@group:0@6130"
+    store.batch_get_replica_desc.return_value = {key: []}
+
+    thread._handle_request(_make_load_req("req-a", [b"a0"], token_len=16))
+
+    assert thread.get_kv_events()[0].medium is None
+
+
+def test_recv_thread_does_not_emit_event_for_failed_load(monkeypatch):
+    monkeypatch.delenv("VLLM_MOONCAKE_STORE_TIER_LOG", raising=False)
+    store = MagicMock()
+    store.batch_get_into_multi_buffers.return_value = [256, -10]
+    thread = _make_store_recving_thread(
+        store, disk_offload_buffer_budget_bytes=None, enable_kv_event=True
+    )
+    keys = [
+        "test-model@tp_rank:0@pcp0@dcp0@pp_rank:0@group:0@6130",
+        "test-model@tp_rank:0@pcp0@dcp0@pp_rank:0@group:0@6131",
+    ]
+    store.batch_get_replica_desc.return_value = {
+        key: [_ReplicaDesc("memory")] for key in keys
+    }
+
+    thread._handle_request(_make_load_req("req-a", [b"a0", b"a1"], token_len=32))
+
+    events = thread.get_kv_events()
+    assert [event.block_hashes[0] for event in events] == [
+        maybe_convert_block_hash(BlockHash(b"a0"))
+    ]
+    assert [event.medium for event in events] == [MEDIUM_CPU]
+
+
+def test_recv_thread_skips_tier_lookup_when_events_and_logging_disabled(monkeypatch):
+    monkeypatch.delenv("VLLM_MOONCAKE_STORE_TIER_LOG", raising=False)
+    store = MagicMock()
+    store.batch_get_into_multi_buffers.return_value = [256]
+    thread = _make_store_recving_thread(store, disk_offload_buffer_budget_bytes=None)
+
+    thread._handle_request(_make_load_req("req-a", [b"a0"], token_len=16))
+
+    assert thread.get_kv_events() == []
+    store.batch_get_replica_desc.assert_not_called()
 
 
 def test_recv_thread_records_partial_failure_metrics(monkeypatch):
@@ -2210,7 +2319,6 @@ def test_store_sending_thread_delta_saves_only_new_swa_boundary_chunks():
 
 
 def test_store_sending_thread_kv_events_use_group_chunk_metadata():
-    from vllm.v1.core.kv_cache_utils import BlockHash, maybe_convert_block_hash
     from vllm.v1.kv_cache_interface import (
         FullAttentionSpec,
         KVCacheGroupSpec,

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
@@ -34,7 +34,7 @@ from vllm.distributed import (
     get_tensor_model_parallel_rank,
     get_tensor_model_parallel_world_size,
 )
-from vllm.distributed.kv_events import BlockStored
+from vllm.distributed.kv_events import MEDIUM_CPU, MEDIUM_STORAGE, BlockStored
 from vllm.distributed.kv_transfer.kv_connector.v1.mooncake import rdma_utils
 from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.coordinator import (  # noqa: E501
     ExternalCachedBlockPool,
@@ -323,7 +323,7 @@ def _get_replica_tiers_by_key(store: Any, keys: list[str]) -> dict[str, str]:
         replica_descs_by_key = store.batch_get_replica_desc(keys)
     except Exception as e:
         logger.warning(
-            "Failed to get Mooncake replica descriptors for tier logging "
+            "Failed to get Mooncake replica descriptors for tier classification "
             "(batch_keys=%d, error=%s); marking tiers unknown",
             len(keys),
             e,
@@ -340,6 +340,14 @@ def _get_replica_tiers_by_key(store: Any, keys: list[str]) -> dict[str, str]:
                 replica_descs = None
         tiers_by_key[key] = _classify_replica_tier(replica_descs)
     return tiers_by_key
+
+
+def _medium_for_replica_tier(tier: str) -> str | None:
+    if tier == "memory":
+        return MEDIUM_CPU
+    if tier == "disk":
+        return MEDIUM_STORAGE
+    return None
 
 
 def _log_mooncake_load_tier_summary(
@@ -1131,6 +1139,7 @@ class KVCacheStoreRecvingThread(KVTransferThread):
         tp_rank: int,
         ready_event: threading.Event,
         disk_offload_buffer_budget_bytes: int | None = None,
+        enable_kv_event: bool = False,
         record_operation: Callable[..., None] | None = None,
         request_queue: queue.Queue[Any] | None = None,
     ):
@@ -1156,6 +1165,7 @@ class KVCacheStoreRecvingThread(KVTransferThread):
             )
         )
         self.coord = coord
+        self.enable_kv_event = enable_kv_event
 
     def _add_load_error_block_ids(self, block_ids: list[int]) -> None:
         with self._invalid_block_ids_lock:
@@ -1184,6 +1194,7 @@ class KVCacheStoreRecvingThread(KVTransferThread):
         size_list: list[list[int]] = []
         key_list: list[str] = []
         block_id_list: list[int] = []
+        event_info_list: list[tuple[BlockHash, int, int, int]] = []
         for g_idx, db in enumerate(self.token_databases):
             mask = load_mask_per_group[g_idx]
             chunks: list[tuple[int, int]] = []
@@ -1194,6 +1205,7 @@ class KVCacheStoreRecvingThread(KVTransferThread):
                 if chunk_idx >= len(mask) or not mask[chunk_idx]:
                     continue
                 key_list.append(db.key_for(block_hash))
+                event_info_list.append((block_hash, start, end, g_idx))
                 chunks.append((start, end))
             g_addrs, g_sizes, g_block_ids = db.prepare_values(
                 chunks, req_meta.block_ids[g_idx]
@@ -1208,8 +1220,11 @@ class KVCacheStoreRecvingThread(KVTransferThread):
         addr_list_c = _rotate_list(addr_list, rotation)
         size_list_c = _rotate_list(size_list, rotation)
         block_id_list_c = _rotate_list(block_id_list, rotation)
+        event_info_list_c = _rotate_list(event_info_list, rotation)
 
-        load_batches = [(key_list_c, addr_list_c, size_list_c, block_id_list_c)]
+        load_batches = [
+            (key_list_c, addr_list_c, size_list_c, block_id_list_c, event_info_list_c)
+        ]
         if self.usable_disk_offload_buffer_budget_bytes is not None:
             total_staging_bytes = sum(
                 _estimate_disk_offload_staging_bytes(size) for size in size_list_c
@@ -1250,21 +1265,37 @@ class KVCacheStoreRecvingThread(KVTransferThread):
                     batch_block_ids = block_id_list_c[
                         block_id_offset:next_block_id_offset
                     ]
+                    batch_event_infos = event_info_list_c[
+                        block_id_offset:next_block_id_offset
+                    ]
                     load_batches.append(
-                        (batch_keys, batch_addrs, batch_sizes, batch_block_ids)
+                        (
+                            batch_keys,
+                            batch_addrs,
+                            batch_sizes,
+                            batch_block_ids,
+                            batch_event_infos,
+                        )
                     )
                     block_id_offset = next_block_id_offset
 
         current_batch_keys: list[str] = key_list_c
         current_batch_block_ids: list[int] = block_id_list_c
         batch_bytes = 0
+        prev_event_hash_per_group: dict[int, Any] = {}
         try:
-            for batch_keys, batch_addrs, batch_sizes, batch_block_ids in load_batches:
+            for (
+                batch_keys,
+                batch_addrs,
+                batch_sizes,
+                batch_block_ids,
+                batch_event_infos,
+            ) in load_batches:
                 current_batch_keys = batch_keys
                 current_batch_block_ids = batch_block_ids
                 batch_bytes = _sum_batch_bytes(batch_sizes)
                 tiers_by_key: dict[str, str] | None = None
-                if envs.VLLM_MOONCAKE_STORE_TIER_LOG:
+                if self.enable_kv_event or envs.VLLM_MOONCAKE_STORE_TIER_LOG:
                     tiers_by_key = _get_replica_tiers_by_key(self.store, batch_keys)
                 # Reset so the recorded RPC duration excludes tier lookup.
                 load_get_start = time.perf_counter()
@@ -1275,6 +1306,37 @@ class KVCacheStoreRecvingThread(KVTransferThread):
                     _log_mooncake_load_tier_summary(
                         req_id, batch_keys, res, tiers_by_key
                     )
+                if self.enable_kv_event:
+                    loaded_events: list[BlockStored] = []
+                    for key, value, (block_hash, start, end, g_idx) in zip(
+                        batch_keys, res, batch_event_infos, strict=True
+                    ):
+                        if value < 0:
+                            continue
+                        event_hash = maybe_convert_block_hash(block_hash)
+                        loaded_events.append(
+                            BlockStored(
+                                block_hashes=[event_hash],
+                                parent_block_hash=prev_event_hash_per_group.get(g_idx),
+                                token_ids=(
+                                    req_meta.token_ids[start:end]
+                                    if req_meta.token_ids is not None
+                                    else None
+                                ),
+                                block_size=self.token_databases[g_idx].block_size,
+                                lora_id=None,
+                                medium=_medium_for_replica_tier(
+                                    tiers_by_key.get(key, "unknown")
+                                    if tiers_by_key is not None
+                                    else "unknown"
+                                ),
+                                lora_name=None,
+                                group_idx=g_idx,
+                            )
+                        )
+                        prev_event_hash_per_group[g_idx] = event_hash
+                    if loaded_events:
+                        self.update_kv_event(loaded_events)
                 failed = [
                     (key, value, block_id)
                     for key, value, block_id in zip(
@@ -1730,6 +1792,7 @@ class MooncakeStoreWorker:
                 self.tp_rank,
                 ready_event_recving,
                 disk_offload_buffer_budget_bytes=self.disk_offload_buffer_budget_bytes,
+                enable_kv_event=self.enable_kv_events,
                 record_operation=self._record_kv_connector_operation,
                 request_queue=self.recv_request_queue,
             )
@@ -1987,9 +2050,15 @@ class MooncakeStoreWorker:
         return hit_length
 
     def get_kv_events(self) -> list[BlockStored]:
-        if self.enable_kv_events and self.kv_send_thread is not None:
-            return self.kv_send_thread.get_kv_events()
-        return []
+        if not self.enable_kv_events:
+            return []
+
+        events: list[BlockStored] = []
+        if self.kv_send_thread is not None:
+            events.extend(self.kv_send_thread.get_kv_events())
+        for recv_thread in self.kv_recv_threads:
+            events.extend(recv_thread.get_kv_events())
+        return events
 
     def close(self) -> None:
         """Release the MooncakeDistributedStore handle on teardown.


### PR DESCRIPTION
## Purpose

Report the actual MooncakeStore replica tier in KV cache events.

Mooncake already exposes whether a loaded replica is memory-backed or disk-backed, but this information was not propagated to `BlockStored` events. This change maps:

* memory-backed replica → `CPU`
* disk-backed replica → `STORAGE`
* unknown tier → `None`

Successful events are emitted only for blocks that actually load successfully. Scheduler lookup and connector protocol behavior are unchanged.

## Test Plan

Run the focused MooncakeStore worker tests:

```bash
python -m pytest \
  tests/v1/kv_connector/unit/test_mooncake_store_worker.py \
  -v \
  --confcutdir=tests/v1/kv_connector/unit \
  -k "test_recv_thread_emits_tiered_events_after_rotation_and_split or test_recv_thread_emits_unknown_tier_with_no_medium or test_recv_thread_does_not_emit_event_for_failed_load or test_recv_thread_skips_tier_lookup_when_events_and_logging_disabled"
```

Also run an end-to-end MooncakeStore smoke test on the DGX/A100 setup to exercise the real replica-tier lookup path.

## Test Results

### Focused unit tests

```text
4 passed, 112 deselected in 7.02s
```

Validated:

* memory-backed replicas map to `CPU`
* disk-backed replicas map to `STORAGE`
* unknown tier leaves `medium` unset
* failed loads do not emit successful `BlockStored` events
* replica-tier lookup is skipped when both KV events and tier logging are disabled
* block hashes remain correctly aligned through rotation and disk-budget splitting

### Integration smoke test

Ran vLLM with MooncakeStore on an A100 using a 256 MB embedded Mooncake segment.

A real Mooncake-backed reload reported:

```text
batch_keys=35
memory_keys=35
disk_keys=0
unknown_keys=0
success_keys=35
failed_keys=0
bytes_by_tier={'memory': 82575360, 'disk': 0, 'unknown': 0}
```

This confirms that the runtime replica metadata path correctly identifies real memory-backed loads.

Disk persistence was also exercised successfully, but a disk-only reload could not be observed with the embedded-store setup because the in-memory replica remains available. A true disk-backed reload would require a standalone-store configuration.

The focused unit tests directly validate the disk-replica → `STORAGE` event mapping.