### PR TITLE
[Frontend] Map unsupported reasoning_effort to nearest supported level

### DIFF
--- a/docs/features/reasoning_outputs.md
+++ b/docs/features/reasoning_outputs.md
@@ -352,6 +352,27 @@ print(response.choices[0].message.reasoning)
 print(response.choices[0].message.content)
 ```
 
+## Mapping Unsupported Reasoning Efforts
+
+Some chat templates accept only a subset of the reasoning effort ladder and raise a template error on anything else (for example, a template that supports only `low`, `medium`, and `xhigh`). Clients such as agent harnesses often send the full OpenAI-style range, so a mismatch fails the request at render time.
+
+Declare the levels the served model accepts with `--supported-reasoning-efforts`, and vLLM remaps any other requested value to the nearest supported level on the ladder `minimal < low < medium < high < xhigh < max`:
+
+```bash
+vllm serve Qwen/Qwen3.8-27B \
+  --supported-reasoning-efforts low medium xhigh \
+  --reasoning-effort-rounding down
+```
+
+`--reasoning-effort-rounding` controls the direction:
+
+- `down` (default): the highest supported level at or below the requested one; if nothing is at or below, the lowest supported level. With the set above, `high` → `medium`, `minimal` → `low`.
+- `up`: the lowest supported level at or above the requested one; if nothing is at or above, the highest supported level. With the set above, `high` → `xhigh`.
+
+`reasoning_effort: "none"` (reasoning disabled) always passes through untouched, so the mapping never turns thinking on or off. Each distinct remap is logged once as a warning. When `--supported-reasoning-efforts` is not set, requests are passed through unchanged (existing behavior).
+
+The mapping applies to the Chat Completions, Responses, and Anthropic Messages APIs.
+
 ## Suppressing Reasoning Output
 
 You can suppress reasoning content from API responses using the `include_reasoning` parameter. When set to `false`, reasoning tokens are still generated (so model quality is unaffected) but excluded from the response. This reduces network traffic without changing inference behavior.

--- a/tests/entrypoints/openai/test_supported_reasoning_efforts.py
+++ b/tests/entrypoints/openai/test_supported_reasoning_efforts.py
@@ -1,0 +1,171 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for --supported-reasoning-efforts normalization.
+
+Models whose chat templates accept only a subset of the reasoning effort
+ladder (e.g. low/medium/xhigh) raise at template render time when a client
+sends an unsupported value. `normalize_reasoning_effort` remaps such values
+to the nearest supported level in the configured rounding direction so the
+request succeeds instead.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from vllm.entrypoints.openai.chat_completion.batch_serving import (
+    OpenAIServingChatBatch,
+)
+from vllm.entrypoints.openai.chat_completion.protocol import (
+    BatchChatCompletionRequest,
+    ChatCompletionRequest,
+)
+from vllm.entrypoints.openai.chat_completion.serving import OpenAIServingChat
+from vllm.entrypoints.openai.reasoning_effort import (
+    normalize_reasoning_effort,
+    validate_supported_reasoning_efforts,
+)
+
+SUPPORTED = ["low", "medium", "xhigh"]
+
+
+class _ServingStub(SimpleNamespace):
+    """Just enough of OpenAIServingChat to exercise the normalization hooks."""
+
+    _normalize_request_reasoning_effort = (
+        OpenAIServingChat._normalize_request_reasoning_effort
+    )
+    _effective_chat_template_kwargs = OpenAIServingChat._effective_chat_template_kwargs
+
+
+class TestNormalizeReasoningEffort:
+    @pytest.mark.parametrize(
+        ("effort", "rounding", "expected"),
+        [
+            # In-range: down picks the highest supported level at or below.
+            ("high", "down", "medium"),
+            # In-range: up picks the lowest supported level at or above.
+            ("high", "up", "xhigh"),
+            # Below the supported range: both directions land on the floor.
+            ("minimal", "down", "low"),
+            ("minimal", "up", "low"),
+            # Above the supported range: both directions land on the ceiling.
+            ("max", "down", "xhigh"),
+            ("max", "up", "xhigh"),
+        ],
+    )
+    def test_unsupported_efforts_are_remapped(self, effort, rounding, expected):
+        assert normalize_reasoning_effort(effort, SUPPORTED, rounding) == expected
+
+    @pytest.mark.parametrize("effort", SUPPORTED)
+    def test_supported_efforts_pass_through(self, effort):
+        assert normalize_reasoning_effort(effort, SUPPORTED, "down") == effort
+        assert normalize_reasoning_effort(effort, SUPPORTED, "up") == effort
+
+    @pytest.mark.parametrize("effort", [None, "none"])
+    def test_none_always_passes_through(self, effort):
+        assert normalize_reasoning_effort(effort, SUPPORTED, "down") == effort
+        assert normalize_reasoning_effort(effort, SUPPORTED, "up") == effort
+
+    def test_no_supported_set_is_a_no_op(self):
+        assert normalize_reasoning_effort("high", None, "down") == "high"
+
+    def test_unordered_supported_set(self):
+        assert normalize_reasoning_effort("high", ["xhigh", "low"], "down") == "low"
+        assert normalize_reasoning_effort("high", ["xhigh", "low"], "up") == "xhigh"
+
+
+class TestValidateSupportedReasoningEfforts:
+    def test_none_and_valid_values_accepted(self):
+        validate_supported_reasoning_efforts(None)
+        validate_supported_reasoning_efforts(["low", "medium", "xhigh"])
+
+    @pytest.mark.parametrize("supported", [[], ["none"], ["medium", "extreme"]])
+    def test_invalid_values_rejected(self, supported):
+        with pytest.raises(ValueError):
+            validate_supported_reasoning_efforts(supported)
+
+
+class TestServingChatNormalization:
+    """The chat serving path applies the policy before rendering."""
+
+    def _effective_kwargs(self, request, supported, rounding):
+        serving = _ServingStub(
+            chat_template=None,
+            chat_template_content_format="auto",
+            default_chat_template_kwargs={},
+            supported_reasoning_efforts=supported,
+            reasoning_effort_rounding=rounding,
+        )
+        return serving._effective_chat_template_kwargs(request)
+
+    def test_request_and_template_kwargs_see_effective_effort(self):
+        request = ChatCompletionRequest(
+            model="test-model",
+            messages=[{"role": "user", "content": "Hello"}],
+            reasoning_effort="high",
+        )
+        kwargs = self._effective_kwargs(request, SUPPORTED, "down")
+        assert request.reasoning_effort == "medium"
+        assert kwargs["reasoning_effort"] == "medium"
+
+    def test_unset_policy_leaves_request_untouched(self):
+        request = ChatCompletionRequest(
+            model="test-model",
+            messages=[{"role": "user", "content": "Hello"}],
+            reasoning_effort="high",
+        )
+        kwargs = self._effective_kwargs(request, None, "down")
+        assert request.reasoning_effort == "high"
+        assert kwargs["reasoning_effort"] == "high"
+
+
+class TestServingChatBatchNormalization:
+    """The batch endpoint renders each conversation without going through
+    _effective_chat_template_kwargs, so it must apply the policy itself."""
+
+    @pytest.mark.asyncio
+    async def test_batch_items_are_normalized_before_rendering(self):
+        seen_efforts: list[str | None] = []
+
+        async def preprocess_chat(single_request, messages, **kwargs):
+            seen_efforts.append(single_request.reasoning_effort)
+            return [], [{"prompt_token_ids": [0]}]
+
+        async def _check_model(_request):
+            return None
+
+        renderer = SimpleNamespace(
+            use_harmony=False,
+            validate_chat_template=lambda **kwargs: None,
+            trust_request_chat_template=False,
+            parser=None,
+            chat_template=None,
+            chat_template_content_format="auto",
+            default_chat_template_kwargs={},
+            preprocess_chat=preprocess_chat,
+        )
+        serving = _ServingStub(
+            _check_model=_check_model,
+            _preflight=lambda: None,
+            online_renderer=renderer,
+            supported_reasoning_efforts=SUPPORTED,
+            reasoning_effort_rounding="down",
+        )
+        # reasoning_effort is not a declared field on the batch request; it
+        # reaches each item through OpenAIBaseModel's extra="allow".
+        request = BatchChatCompletionRequest(
+            model="test-model",
+            messages=[
+                [{"role": "user", "content": "one"}],
+                [{"role": "user", "content": "two"}],
+            ],
+            reasoning_effort="high",
+        )
+
+        result = await OpenAIServingChatBatch.render_batch_chat_request(
+            serving, request
+        )
+
+        assert not isinstance(result, dict)
+        assert seen_efforts == ["medium", "medium"]

--- a/vllm/entrypoints/anthropic/serving.py
+++ b/vllm/entrypoints/anthropic/serving.py
@@ -44,6 +44,7 @@ from vllm.entrypoints.openai.chat_completion.protocol import (
 )
 from vllm.entrypoints.openai.chat_completion.serving import OpenAIServingChat
 from vllm.entrypoints.openai.models.serving import OpenAIServingModels
+from vllm.entrypoints.openai.reasoning_effort import ReasoningEffortRounding
 from vllm.entrypoints.serve.engine.protocol import ErrorResponse, UsageInfo
 from vllm.entrypoints.serve.exception_handling.utils import sanitize_message
 from vllm.entrypoints.serve.utils.request_logger import RequestLogger
@@ -115,6 +116,8 @@ class AnthropicServingMessages(OpenAIServingChat):
         enable_prompt_tokens_details: bool = False,
         enable_force_include_usage: bool = False,
         default_chat_template_kwargs: dict[str, Any] | None = None,
+        supported_reasoning_efforts: list[str] | None = None,
+        reasoning_effort_rounding: ReasoningEffortRounding = "down",
     ):
         super().__init__(
             engine_client=engine_client,
@@ -131,6 +134,8 @@ class AnthropicServingMessages(OpenAIServingChat):
             enable_prompt_tokens_details=enable_prompt_tokens_details,
             enable_force_include_usage=enable_force_include_usage,
             default_chat_template_kwargs=default_chat_template_kwargs,
+            supported_reasoning_efforts=supported_reasoning_efforts,
+            reasoning_effort_rounding=reasoning_effort_rounding,
         )
         self.stop_reason_map = {
             "stop": "end_turn",

--- a/vllm/entrypoints/generate/api_router.py
+++ b/vllm/entrypoints/generate/api_router.py
@@ -118,6 +118,8 @@ async def init_generate_state(
             enable_force_include_usage=args.enable_force_include_usage,
             enable_log_outputs=args.enable_log_outputs,
             default_chat_template_kwargs=default_chat_template_kwargs,
+            supported_reasoning_efforts=args.supported_reasoning_efforts,
+            reasoning_effort_rounding=args.reasoning_effort_rounding,
         )
         if "generate" in supported_tasks
         else None
@@ -142,6 +144,8 @@ async def init_generate_state(
         enable_log_outputs=args.enable_log_outputs,
         enable_log_deltas=args.enable_log_deltas,
         enable_per_request_metrics=args.enable_per_request_metrics,
+        supported_reasoning_efforts=args.supported_reasoning_efforts,
+        reasoning_effort_rounding=args.reasoning_effort_rounding,
     )
     state.openai_serving_chat = (
         OpenAIServingChat(**_chat_kwargs) if "generate" in supported_tasks else None
@@ -181,6 +185,8 @@ async def init_generate_state(
             enable_prompt_tokens_details=args.enable_prompt_tokens_details,
             enable_force_include_usage=args.enable_force_include_usage,
             default_chat_template_kwargs=default_chat_template_kwargs,
+            supported_reasoning_efforts=args.supported_reasoning_efforts,
+            reasoning_effort_rounding=args.reasoning_effort_rounding,
         )
         if "generate" in supported_tasks
         else None

--- a/vllm/entrypoints/launchers/cli_args.py
+++ b/vllm/entrypoints/launchers/cli_args.py
@@ -20,6 +20,10 @@ from vllm.entrypoints.chat_utils import (
     validate_chat_template,
 )
 from vllm.entrypoints.openai.models.protocol import LoRAModulePath
+from vllm.entrypoints.openai.reasoning_effort import (
+    ReasoningEffortRounding,
+    validate_supported_reasoning_efforts,
+)
 from vllm.tool_parsers import ToolParserManager
 from vllm.utils.argparse_utils import FlexibleArgumentParser
 
@@ -96,6 +100,21 @@ class BaseFrontendArgs:
     with request values taking precedence. Useful for setting default
     behavior for reasoning models. Example: '{"enable_thinking": false}'
     to disable thinking mode by default for Qwen3/DeepSeek models."""
+    supported_reasoning_efforts: list[str] | None = None
+    """The reasoning effort levels the served model's chat template accepts,
+    e.g. `low medium xhigh` for models that reject the rest of the ladder.
+    When set, a request whose `reasoning_effort` is not in this set is
+    remapped to the nearest supported level per `--reasoning-effort-rounding`
+    instead of failing at template render time. The special value `none`
+    (reasoning disabled) always passes through and cannot be listed. When
+    unset (the default), efforts are passed through unchanged."""
+    reasoning_effort_rounding: ReasoningEffortRounding = "down"
+    """Direction used to resolve a `reasoning_effort` that is not in
+    `--supported-reasoning-efforts`, on the ladder minimal < low < medium <
+    high < xhigh < max. `down` picks the highest supported level not above
+    the requested one, falling back to the lowest supported level; `up`
+    picks the lowest supported level not below the requested one, falling
+    back to the highest supported level."""
     response_role: str = "assistant"
     """The role name to return if `request.add_generation_prompt=true`."""
     return_tokens_as_token_ids: bool = False
@@ -436,6 +455,8 @@ def validate_parsed_serve_args(args: argparse.Namespace):
 
     # Ensure that the chat template is valid; raises if it likely isn't
     validate_chat_template(args.chat_template)
+
+    validate_supported_reasoning_efforts(args.supported_reasoning_efforts)
 
     # Enable auto tool needs a tool call parser to be valid
     if args.enable_auto_tool_choice and not args.tool_call_parser:

--- a/vllm/entrypoints/openai/chat_completion/batch_serving.py
+++ b/vllm/entrypoints/openai/chat_completion/batch_serving.py
@@ -78,6 +78,9 @@ class OpenAIServingChatBatch(OpenAIServingChat):
 
         for messages in request.messages:
             single_request = request.to_chat_completion_request(messages)
+            # Batch items bypass _effective_chat_template_kwargs, so apply the
+            # reasoning_effort policy here before the template renders.
+            self._normalize_request_reasoning_effort(single_request)
             if renderer.use_harmony:
                 conversation, engine_prompts = renderer._make_request_with_harmony(
                     single_request, should_include_tools=tool_dicts is not None

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -43,6 +43,10 @@ from vllm.entrypoints.openai.chat_completion.protocol import (
     ChatMessage,
 )
 from vllm.entrypoints.openai.models.serving import OpenAIServingModels
+from vllm.entrypoints.openai.reasoning_effort import (
+    ReasoningEffortRounding,
+    normalize_reasoning_effort,
+)
 from vllm.entrypoints.serve.engine.protocol import (
     CompletionTokenUsageInfo,
     ErrorResponse,
@@ -138,6 +142,8 @@ class OpenAIServingChat(GenerateBaseServing):
         enable_log_deltas: bool = True,
         default_chat_template_kwargs: dict[str, Any] | None = None,
         enable_per_request_metrics: bool = False,
+        supported_reasoning_efforts: list[str] | None = None,
+        reasoning_effort_rounding: ReasoningEffortRounding = "down",
     ) -> None:
         super().__init__(
             engine_client=engine_client,
@@ -152,6 +158,10 @@ class OpenAIServingChat(GenerateBaseServing):
         self.chat_template_content_format: Final = chat_template_content_format
         self.trust_request_chat_template = trust_request_chat_template
         self.default_chat_template_kwargs = default_chat_template_kwargs or {}
+        self.supported_reasoning_efforts = supported_reasoning_efforts
+        self.reasoning_effort_rounding: ReasoningEffortRounding = (
+            reasoning_effort_rounding
+        )
         self.enable_log_outputs = enable_log_outputs
         self.enable_log_deltas = enable_log_deltas
 
@@ -186,9 +196,24 @@ class OpenAIServingChat(GenerateBaseServing):
         self.supports_code_interpreter = False
         self.python_tool = None
 
+    def _normalize_request_reasoning_effort(
+        self, request: ChatCompletionRequest
+    ) -> None:
+        """Apply --supported-reasoning-efforts to the request in place.
+
+        Must run before build_chat_params so the chat template only ever
+        sees a level it accepts.
+        """
+        request.reasoning_effort = normalize_reasoning_effort(
+            request.reasoning_effort,
+            self.supported_reasoning_efforts,
+            self.reasoning_effort_rounding,
+        )
+
     def _effective_chat_template_kwargs(
         self, request: ChatCompletionRequest
     ) -> dict[str, Any]:
+        self._normalize_request_reasoning_effort(request)
         return (
             request.build_chat_params(
                 self.chat_template,

--- a/vllm/entrypoints/openai/reasoning_effort.py
+++ b/vllm/entrypoints/openai/reasoning_effort.py
@@ -1,0 +1,85 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from typing import Literal, cast
+
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+ReasoningEffortRounding = Literal["down", "up"]
+
+ReasoningEffortValue = Literal[
+    "none", "minimal", "low", "medium", "high", "xhigh", "max"
+]
+
+REASONING_EFFORT_LADDER = ("minimal", "low", "medium", "high", "xhigh", "max")
+"""Reasoning effort levels ordered from least to most effort.
+
+The special value "none" disables reasoning entirely, so it is not part of
+the ladder and is never remapped.
+"""
+
+
+def validate_supported_reasoning_efforts(supported: list[str] | None) -> None:
+    """Validate the `--supported-reasoning-efforts` values.
+
+    Raises:
+        ValueError: If the list is empty or contains values outside
+            `REASONING_EFFORT_LADDER`.
+    """
+    if supported is None:
+        return
+    if not supported:
+        raise ValueError("--supported-reasoning-efforts must not be empty")
+    invalid = [effort for effort in supported if effort not in REASONING_EFFORT_LADDER]
+    if invalid:
+        raise ValueError(
+            f"Invalid --supported-reasoning-efforts values: {invalid}. "
+            f"Choose from {list(REASONING_EFFORT_LADDER)} ('none' always "
+            "passes through and cannot be listed)."
+        )
+
+
+def normalize_reasoning_effort(
+    effort: ReasoningEffortValue | None,
+    supported: list[str] | None,
+    rounding: ReasoningEffortRounding = "down",
+) -> ReasoningEffortValue | None:
+    """Map an unsupported reasoning effort to the nearest supported level.
+
+    Levels are compared on `REASONING_EFFORT_LADDER`. With `rounding="down"`,
+    the highest supported level at or below the requested one is chosen,
+    falling back to the lowest supported level when nothing is at or below.
+    With `rounding="up"`, the lowest supported level at or above the requested
+    one is chosen, falling back to the highest supported level.
+
+    `None` and `"none"` always pass through unchanged, as do values already
+    in `supported` and values outside the ladder. No-op when `supported` is
+    `None` (the default server configuration).
+    """
+    if not supported or effort is None or effort == "none" or effort in supported:
+        return effort
+    if effort not in REASONING_EFFORT_LADDER:
+        return effort
+    requested_idx = REASONING_EFFORT_LADDER.index(effort)
+    ordered = sorted(set(supported), key=REASONING_EFFORT_LADDER.index)
+    if rounding == "up":
+        candidates = [
+            e for e in ordered if REASONING_EFFORT_LADDER.index(e) >= requested_idx
+        ]
+        effective = candidates[0] if candidates else ordered[-1]
+    else:
+        candidates = [
+            e for e in ordered if REASONING_EFFORT_LADDER.index(e) <= requested_idx
+        ]
+        effective = candidates[-1] if candidates else ordered[0]
+    logger.warning_once(
+        "reasoning_effort=%r is not supported by this server "
+        "(--supported-reasoning-efforts=%s); using %r (rounding=%s).",
+        effort,
+        ",".join(ordered),
+        effective,
+        rounding,
+    )
+    return cast(ReasoningEffortValue, effective)

--- a/vllm/entrypoints/openai/responses/serving.py
+++ b/vllm/entrypoints/openai/responses/serving.py
@@ -33,6 +33,10 @@ from vllm.entrypoints.generate.base.protocol import (
 from vllm.entrypoints.generate.base.serving import GenerateBaseServing
 from vllm.entrypoints.mcp.tool_server import ToolServer
 from vllm.entrypoints.openai.models.serving import OpenAIServingModels
+from vllm.entrypoints.openai.reasoning_effort import (
+    ReasoningEffortRounding,
+    normalize_reasoning_effort,
+)
 from vllm.entrypoints.openai.responses.context import (
     ConversationContext,
     HarmonyContext,
@@ -111,6 +115,8 @@ class OpenAIServingResponses(GenerateBaseServing):
         enable_force_include_usage: bool = False,
         enable_log_outputs: bool = False,
         default_chat_template_kwargs: dict[str, Any] | None = None,
+        supported_reasoning_efforts: list[str] | None = None,
+        reasoning_effort_rounding: ReasoningEffortRounding = "down",
     ) -> None:
         super().__init__(
             engine_client=engine_client,
@@ -123,6 +129,10 @@ class OpenAIServingResponses(GenerateBaseServing):
         self.chat_template = chat_template
         self.chat_template_content_format: Final = chat_template_content_format
         self.chat_template_kwargs = default_chat_template_kwargs or {}
+        self.supported_reasoning_efforts = supported_reasoning_efforts
+        self.reasoning_effort_rounding: ReasoningEffortRounding = (
+            reasoning_effort_rounding
+        )
         self.enable_log_outputs = enable_log_outputs
 
         # Set up the unified parser - either a unified parser or fall back to
@@ -317,6 +327,15 @@ class OpenAIServingResponses(GenerateBaseServing):
         | ResponsesResponse
         | ErrorResponse
     ):
+        if request.reasoning is not None:
+            request.reasoning.effort = cast(
+                Any,
+                normalize_reasoning_effort(
+                    request.reasoning.effort,
+                    self.supported_reasoning_efforts,
+                    self.reasoning_effort_rounding,
+                ),
+            )
         error_check_ret = await self._check_model(request)
         if error_check_ret is not None:
             logger.error("Error with model %s", error_check_ret)


### PR DESCRIPTION
## Purpose

FIX #52738


Fixes the render-time failure when a client sends a `reasoning_effort` the
served model's chat template does not accept.

`ChatCompletionRequest.reasoning_effort` accepts the full ladder
(`none`/`minimal`/`low`/`medium`/`high`/`xhigh`/`max`), but some chat
templates validate against a subset and raise a Jinja error on anything
else. E.g. the official `Qwen/Qwen3.8-27B` template validates directly
against `('xhigh', 'medium', 'low')`, so `high` returns HTTP 400:
`Unexpected reasoning effort high. Supported types are xhigh (default),
medium, and low.` OpenAI-compatible clients and agent harnesses routinely
send `high` or `minimal`, so the request passes API validation and then
fails at template render time. Operators currently have to fork the
template or rewrite requests in a fronting proxy.

This PR adds two frontend flags:

- `--supported-reasoning-efforts low medium xhigh` — declares the levels the
  template accepts. Unset (default) = passthrough, exactly today's behavior.
- `--reasoning-effort-rounding {down,up}` (default `down`) — direction used
  to resolve an unsupported value on the ladder
  `minimal < low < medium < high < xhigh < max`:
  - `down`: highest supported level at or below the requested one; if
    nothing is at or below, the lowest supported level
    (`high` -> `medium`, `minimal` -> `low` with the example set).
  - `up`: lowest supported level at or above the requested one; if nothing
    is at or above, the highest supported level (`high` -> `xhigh`).

Design points:

- `none` (reasoning disabled) always passes through and cannot be listed in
  the supported set — the mapping never toggles thinking on or off.
- Applied at the serving layer so every client derivation path converges
  before the template renders: Chat Completions
  (`OpenAIServingChat._effective_chat_template_kwargs`, which also covers
  the Anthropic Messages API via `AnthropicServingMessages`), the Chat
  Completions batch endpoint (`render_batch_chat_request` renders each item
  outside that helper, so it calls the shared
  `_normalize_request_reasoning_effort` per item), and the Responses API
  (entry of `_create_responses`, covering both the template and Harmony
  paths).
- Each distinct (requested -> effective) remap is logged once via
  `logger.warning_once`.
- Flag values validated at startup in `validate_parsed_serve_args`.

In-tree precedent for the concept: the Harmony path keeps a private
`REASONING_EFFORT` mapping in `entrypoints/openai/parser/harmony_utils.py`
because GPT-OSS supports a subset. This PR makes the capability declarative
and general instead of per-model-family.

Files:

- `vllm/entrypoints/openai/reasoning_effort.py` (new) — ladder constant,
  `normalize_reasoning_effort()`, flag validation.
- `vllm/entrypoints/launchers/cli_args.py` — the two `BaseFrontendArgs`
  fields + startup validation.
- `vllm/entrypoints/openai/chat_completion/serving.py`,
  `vllm/entrypoints/openai/chat_completion/batch_serving.py`,
  `vllm/entrypoints/openai/responses/serving.py`,
  `vllm/entrypoints/anthropic/serving.py`,
  `vllm/entrypoints/generate/api_router.py` — constructor threading and the
  three normalization call sites.
- `tests/entrypoints/openai/test_supported_reasoning_efforts.py` (new).
- `docs/features/reasoning_outputs.md` — "Mapping Unsupported Reasoning
  Efforts" section.

## Not duplicating existing work

Searched open issues and PRs for reasoning-effort mapping/clamping before
writing this ("reasoning effort unsupported", "reasoning_effort map",
"supported reasoning efforts"). Closest matches are parser-internal effort
translations for a single model family (#39587 / #39597, nemotron_v3) and
the Harmony-private map noted above — none provide an operator-configurable,
model-agnostic mapping at the serving layer. Draft #38204 implemented the
`reasoning_effort` field itself (already merged functionality), not
subset handling.

## Test Plan

```bash
uv pip install pytest pytest-asyncio tblib  # tests/conftest.py needs these
pytest tests/entrypoints/openai/test_supported_reasoning_efforts.py -v
pytest tests/entrypoints/openai/test_reasoning_enable_thinking.py -v  # regression neighbor
pre-commit run --all-files
pre-commit run mypy-3.12 --all-files --hook-stage manual
```

The new test file covers: the full rounding matrix in both directions
(including floor/ceiling fallbacks), passthrough of supported values,
`none`/unset passthrough, unset-flag no-op, unordered supported sets, flag
validation errors, two serving-level tests asserting the effective
effort reaches both the request object and the rendered
`chat_template_kwargs`, and a batch-path test driving
`render_batch_chat_request` with an unsupported effort and asserting every
item is remapped before `preprocess_chat` sees it.

Manual E2E: serve `Qwen/Qwen3.8-27B` with
`--supported-reasoning-efforts low medium xhigh` and confirm a
`reasoning_effort="high"` chat request succeeds at `medium` (rounding=down)
/ `xhigh` (rounding=up), and that the same request returns 400 without the
flags. Note: use the official checkpoint for the control — some
third-party re-uploads ship modified templates that alias `high`→`xhigh`
themselves (`minimal` works as a control value on those).

## Test Result

Unit tests:

```
tests/entrypoints/openai/test_supported_reasoning_efforts.py
======================= 20 passed, 14 warnings in 5.36s ========================
tests/entrypoints/openai/test_reasoning_enable_thinking.py
======================= 14 passed, 14 warnings in 3.41s ========================
```

All 20 new tests pass (remapping in both directions across the ladder,
pass-through of supported values and `None`/`"none"`, no-op when unset,
unordered supported set, validation accept/reject, the ServingChat-level
normalization checks, and the batch-path check); the 14 regression-neighbor
tests pass. The warnings
are a pre-existing `torch.jit.script_method` deprecation from site-packages,
unrelated to this change.

CLI parsing smoke (space-separated `nargs="+"` form works; comma form is
rejected at startup with an actionable message):

```
comma form rejected as expected: Invalid --supported-reasoning-efforts
values: ['low,medium']. Choose from ['minimal', 'low', 'medium', 'high',
'xhigh', 'max'] ('none' always passes through and cannot be listed).
CLI smoke OK
```

Lint/typecheck: `pre-commit run --all-files` — every hook passed (ruff
check/format, typos, clang-format, markdownlint-cli2, actionlint,
pip-compile variants, mypy 3.10, SPDX headers, forbidden imports, and the
rest). `pre-commit run mypy-3.12 --all-files --hook-stage manual` — Passed.

Manual E2E on `Qwen/Qwen3.8-27B` (BF16, official checkpoint), commit
`f7d825c26`, single-GPU serve with `--max-model-len 16384
--max-num-seqs 64` (memory sizing only; neither flag touches the
reasoning-effort path):

- **Remap, rounding down** — flags `--supported-reasoning-efforts low
  medium xhigh`; request `reasoning_effort: "high"` → HTTP 200, normal
  completion. Log:
  `WARNING ... [reasoning_effort.py:77] reasoning_effort='high' is not
  supported by this server (--supported-reasoning-efforts=low,medium,xhigh);
  using 'medium' (rounding=down).`
- **Remap, rounding up** — same + `--reasoning-effort-rounding up` → HTTP
  200; log shows `using 'xhigh' (rounding=up)`. Corroboration that the
  remapped value reached the template: prompt_tokens 59 vs 17 in the
  down case (the `xhigh` reasoning-instructions block was injected).
- **Stock control** — no flags; the same `reasoning_effort: "high"`
  request → HTTP 400:
  `{"error":{"message":"Unexpected reasoning effort high. Supported types
  are xhigh (default), medium, and low.","type":"BadRequestError",
  "param":null,"code":400}}`. No remap warning logged with flags unset
  (grep count 0).

Supplementary run on a community re-quantization
(`unsloth/Qwen3.8-27B-NVFP4`): its modified template aliases
`high`→`xhigh` itself, so `minimal` was used as the failing value there —
stock 400 (`Unexpected reasoning effort minimal. ...`) → 200 with the
flags, remapped to `low` with the corresponding warning. This also shows
the feature composes with templates that do their own partial aliasing.

Net: the stock failure reproduces and this PR converts it 400 → 200, in
both rounding directions, with the documented warning format.

- [x] pytest: 19/19 new + 14/14 regression neighbor passed
- [x] pre-commit clean (all hooks incl. manual-stage mypy-3.12)
- [x] manual E2E on Qwen3.8 confirmed (400 → 200, both rounding modes)

No model evaluation is required: the change does not touch kernels,
sampling, or model output content. With the flags unset (the default) the
serving path is byte-identical to current behavior; with them set, the only
change is the value of `reasoning_effort` handed to the chat template.

## AI assistance disclosure

This PR was developed with AI assistance (Claude Fable 5, also credited via
commit trailer). The submitting human has reviewed every changed line and
run the tests listed above.

