### PR TITLE
Fix TurboQuant get_kv_cache_shape crash with hybrid models on cache_dtype_str='auto'

### DIFF
--- a/vllm/v1/attention/backends/turboquant_attn.py
+++ b/vllm/v1/attention/backends/turboquant_attn.py
@@ -206,6 +206,12 @@ class TurboQuantAttentionBackend(AttentionBackend):
             TurboQuantConfig,
         )
 
+        if cache_dtype_str == "auto":
+            # Hybrid models (e.g. Qwen3.8) pass "auto" for layers with
+            # kv_quant_mode=NONE (linear attention layers that don't use
+            # standard KV cache). Fall back to turboquant_4bit_nc so the
+            # slot size matches the tensor already allocated with TQ sizing.
+            cache_dtype_str = "turboquant_4bit_nc"
         tq_config = TurboQuantConfig.from_cache_dtype(cache_dtype_str, head_size)
         return (num_blocks, num_kv_heads, block_size, tq_config.slot_size_aligned)
 


### PR DESCRIPTION
## Problem

When using `--kv-cache-dtype turboquant_*` with hybrid models (e.g. Qwen3.8-27B), vLLM crashes during engine initialization with:

```
ValueError: Unknown TurboQuant cache dtype: 'auto'. Valid presets: turboquant_k8v4, turboquant_4bit_nc, turboquant_k3v4_nc, turboquant_3bit_nc
```

## Root Cause

Hybrid models have both full-attention and linear-attention layers. In `gpu_model_runner.py:_reshape_kv_cache_tensors()`, layers with `kv_quant_mode=NONE` (e.g. linear attention layers in Qwen3.8 that don't use standard KV cache) pass `cache_dtype_str='auto'` to the attention backend's `get_kv_cache_shape()`.

The TurboQuant backend's `get_kv_cache_shape()` unconditionally calls `TurboQuantConfig.from_cache_dtype(cache_dtype_str)`, which rejects `'auto'` since it's not a valid TQ preset name.

## Fix

Fall back to `turboquant_4bit_nc` when `cache_dtype_str == 'auto'`. The underlying KV cache tensor was already allocated with TQ slot sizing, so using the turboquant slot size for the shape is correct.

## Reproduction

1. Launch Qwen3.8-27B with `--kv-cache-dtype turboquant_4bit_nc`
2. Engine crashes at startup with the ValueError above

## Files

- `vllm/v1/attention/backends/turboquant_attn.py`: 3-line fallback in `get_kv_cache_shape`
