### PR TITLE
[Bugfix][Frontend] Do not render tool strict flag in chat templates

### DIFF
--- a/tests/entrypoints/openai/test_render_parity.py
+++ b/tests/entrypoints/openai/test_render_parity.py
@@ -17,6 +17,7 @@ prompt cache salt, and truncation are out of scope for this file.
 
 from __future__ import annotations
 
+from copy import deepcopy
 from dataclasses import dataclass, field
 from typing import Any
 from unittest.mock import MagicMock
@@ -101,6 +102,7 @@ class CapturedRenderInputs:
 
     messages: list[Any]
     chat_params: ChatParams
+    tool_dicts: list[dict[str, Any]] | None
 
 
 class RenderCapture:
@@ -121,7 +123,8 @@ class RenderCapture:
             assert len(conversations) == 1
             self.captured = CapturedRenderInputs(
                 messages=list(conversations[0]),
-                chat_params=chat_params,
+                chat_params=deepcopy(chat_params),
+                tool_dicts=deepcopy(chat_params.chat_template_kwargs.get("tools")),
             )
             return [list(conversations[0])], [
                 tokens_input(prompt_token_ids=[0]),
@@ -400,6 +403,42 @@ class TestToolsRenderParity:
                 "tool_choice": "auto",
             },
         )
+
+    @pytest.mark.parametrize("strict", [False, True])
+    async def test_strict_is_not_passed_to_chat_template(
+        self, online_renderer, serving_responses, strict: bool
+    ):
+        """The server-only strict directive must not become model-visible."""
+        chat_tools, responses_tools = _weather_tools(
+            overrides={
+                "strict": strict,
+                "defer_loading": False,
+                "unrelated_extra": "should_be_ignored",
+            }
+        )
+        chat = await _capture_chat(
+            online_renderer,
+            ChatCompletionRequest(
+                model=_MODEL,
+                messages=_USER,
+                tools=chat_tools,
+                tool_choice="auto",
+            ),
+        )
+        responses = await _capture_responses(
+            serving_responses,
+            ResponsesRequest(
+                model=_MODEL,
+                input=_USER,
+                tools=responses_tools,
+                tool_choice="auto",
+            ),
+        )
+
+        for captured in (chat, responses):
+            assert captured.tool_dicts is not None
+            assert "strict" not in captured.tool_dicts[0]["function"]
+            assert captured.tool_dicts[0]["function"]["defer_loading"] is False
 
 
 @pytest.mark.asyncio

--- a/vllm/renderers/online_renderer.py
+++ b/vllm/renderers/online_renderer.py
@@ -60,6 +60,25 @@ def _reused_prompt_token_ids(request: Any) -> list[int] | None:
     return kv.pop("prompt_token_ids", None) or None
 
 
+def _strip_tool_strict(
+    tool_dicts: list[dict[str, Any]] | None,
+) -> list[dict[str, Any]] | None:
+    if tool_dicts is None:
+        return None
+
+    return [
+        {
+            **tool,
+            "function": {
+                key: value for key, value in tool["function"].items() if key != "strict"
+            },
+        }
+        if isinstance(tool.get("function"), dict)
+        else tool
+        for tool in tool_dicts
+    ]
+
+
 class OnlineRenderer:
     def __init__(
         self,
@@ -390,6 +409,7 @@ class OnlineRenderer:
     ) -> tuple[list[ConversationMessage], list[EngineInput]]:
         """Copied from GenerateBaseServing._preprocess_chat."""
         renderer = self.renderer
+        tool_dicts = _strip_tool_strict(tool_dicts)
         mm_config = self.model_config.multimodal_config
 
         default_template_kwargs = merge_kwargs(


### PR DESCRIPTION
## Summary

- Exclude the server-side `tools[].function.strict` directive from tool definitions passed to chat templates.
- Apply the sanitization in the shared renderer preprocessing path, covering Chat Completions and Responses.
- Preserve the existing optional-field parity test and add separate regressions for `strict: false` and `strict: true` at the template-render boundary.

Fixes #52741.

## Duplicate check

No open PR references #52741, and a search for strict tool/chat-template fixes found no existing fix for this behavior.

## Testing

- `.venv/bin/python -m pytest tests/entrypoints/openai/test_render_parity.py -q` — 17 passed.
- `.venv/bin/pre-commit run ruff-check --files vllm/renderers/online_renderer.py tests/entrypoints/openai/test_render_parity.py`.
- `.venv/bin/pre-commit run ruff-format --files vllm/renderers/online_renderer.py tests/entrypoints/openai/test_render_parity.py`.
- Installed commit hooks passed for the changed Python files, including Ruff, typos, mypy, SPDX, lazy-import, forbidden-import, CUDA API, configuration, and sign-off checks.

## Model evaluation

Live GPU validation used vLLM serving `Qwen/Qwen3-0.6B` on a local RTX 3050. Two `/tokenize` requests differing only in `tools[0].function.strict` (`false` versus `true`) returned identical 152-token prompts; the returned token strings contained no `strict` text.

The WSL test server used `VLLM_WSL2_ENABLE_PIN_MEMORY=1` and `VLLM_USE_FLASHINFER_SAMPLER=0` to enable WSL pinned memory and avoid an unrelated FlashInfer sampler JIT compiler/header mismatch. These are test-environment settings only.

## AI assistance

This PR was developed with AI assistance. I reviewed the changed lines, API coverage, and test results.