### PR TITLE
Amd cpu ci minimal reuse

### DIFF
--- a/.buildkite/hardware_tests/zen.yaml
+++ b/.buildkite/hardware_tests/zen.yaml
@@ -1,0 +1,28 @@
+group: Zen CPU
+depends_on: []
+steps:
+- label: Zen-CPU-Kernel Tests
+  # Reuse the shared CPU image (built by image-build-cpu) as the base for the zen
+  # image, so this waits for that build. run-zen-cpu-test.sh pulls it instead of
+  # recompiling vLLM on the scarce zen5 hardware (with a from-source fallback).
+  depends_on:
+  - image-build-cpu
+  soft_fail: false
+  device: zen5
+  no_plugin: true
+  source_file_dependencies:
+  - docker/Dockerfile.cpu
+  - docker/Dockerfile.zen
+  - .buildkite/scripts/hardware_ci/run-zen-cpu-test.sh
+  - vllm/model_executor/layers/utils.py
+  - vllm/model_executor/kernels/linear/zentorch_utils.py
+  - vllm/model_executor/kernels/linear/scaled_mm/zentorch.py
+  - vllm/model_executor/kernels/linear/mixed_precision/zentorch.py
+  - vllm/platforms/cpu.py
+  - vllm/platforms/zen_cpu.py
+  - vllm/platforms/__init__.py
+  - tests/model_executor/test_cpu_unquantized_gemm_dispatch.py
+  commands:
+    - |
+      bash .buildkite/scripts/hardware_ci/run-zen-cpu-test.sh 20m "
+      pytest -x -v -s tests/model_executor/test_cpu_unquantized_gemm_dispatch.py"

--- a/.buildkite/image_build/image_build.yaml
+++ b/.buildkite/image_build/image_build.yaml
@@ -81,6 +81,29 @@ steps:
         - exit_status: -10  # Agent was lost
           limit: 2
 
+  - label: ":docker: Build Zen CPU image"
+    key: image-build-zen-cpu
+    # Minimal confirmation build: run the zen image build on the generic x86
+    # premerge queue to verify it succeeds. Reuses the shared `-cpu` image as its
+    # base, so it must run after the CPU image build.
+    #
+    # No source_file_dependencies: this step always runs for this validation PR
+    # so the build is exercised regardless of which files changed.
+    depends_on:
+      - image-build-cpu
+    agents:
+      queue: small_cpu_queue_premerge
+    commands:
+    - .buildkite/image_build/image_build_zen_cpu.sh $REGISTRY $REPO $BUILDKITE_COMMIT
+    env:
+      DOCKER_BUILDKIT: "1"
+    retry:
+      automatic:
+        - exit_status: -1  # Agent was lost
+          limit: 2
+        - exit_status: -10  # Agent was lost
+          limit: 2
+
   - label: ":docker: Build HPU image"
     soft_fail: true
     depends_on: []

--- a/.buildkite/image_build/image_build_zen_cpu.sh
+++ b/.buildkite/image_build/image_build_zen_cpu.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+#
+# Build the AMD Zen CPU image (vLLM + zentorch) as a two-step layered build:
+#   1. a CPU base image (vLLM installed) built from docker/Dockerfile.cpu
+#   2. docker/Dockerfile.zen --target vllm-zen-test -> zen image on top
+#
+# The image is (re)built from source every time, mirroring
+# .buildkite/scripts/hardware_ci/run-cpu-test.sh. It is not pushed to a registry.
+#
+# See docker/Dockerfile.zen for the build workflow this mirrors.
+set -e
+
+if [[ $# -lt 3 ]]; then
+  echo "Usage: $0 <registry> <repo> <commit>"
+  exit 1
+fi
+
+REGISTRY=$1
+REPO=$2
+BUILDKITE_COMMIT=$3
+
+# Local image tags (not pushed).
+BASE_IMAGE="$REGISTRY/$REPO:$BUILDKITE_COMMIT-cpu-base-for-zen"
+IMAGE="$REGISTRY/$REPO:$BUILDKITE_COMMIT-zen-cpu"
+
+# ZENTORCH_VERSION is optional; when unset the Dockerfile falls back to
+# installing zentorch via `vllm[zen]`.
+ZENTORCH_VERSION=${ZENTORCH_VERSION:-}
+
+# Step 1: build the CPU base image that Dockerfile.zen layers on.
+echo "--- :docker: Building CPU base image"
+docker build --file docker/Dockerfile.cpu \
+  --platform linux/amd64 \
+  --build-arg max_jobs=16 \
+  --build-arg buildkite_commit="$BUILDKITE_COMMIT" \
+  --build-arg VLLM_CPU_X86=true \
+  --tag "$BASE_IMAGE" \
+  --target vllm-openai \
+  --progress plain .
+
+# Step 2: build the zen test image on top of the CPU base.
+echo "--- :docker: Building Zen test image"
+docker build --file docker/Dockerfile.zen \
+  --platform linux/amd64 \
+  --build-arg BASE_IMAGE="$BASE_IMAGE" \
+  ${ZENTORCH_VERSION:+--build-arg ZENTORCH_VERSION="$ZENTORCH_VERSION"} \
+  --tag "$IMAGE" \
+  --target vllm-zen-test \
+  --progress plain .

--- a/.buildkite/image_build/image_build_zen_cpu.sh
+++ b/.buildkite/image_build/image_build_zen_cpu.sh
@@ -2,12 +2,16 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 #
-# Build the AMD Zen CPU image (vLLM + zentorch) as a two-step layered build:
-#   1. a CPU base image (vLLM installed) built from docker/Dockerfile.cpu
-#   2. docker/Dockerfile.zen --target vllm-zen-test -> zen image on top
+# Build the AMD Zen CPU image (vLLM + zentorch) by layering docker/Dockerfile.zen
+# on top of a CPU base image that already has vLLM installed.
 #
-# The image is (re)built from source every time, mirroring
-# .buildkite/scripts/hardware_ci/run-cpu-test.sh. It is not pushed to a registry.
+# To avoid recompiling vLLM from source, prefer reusing the shared CPU image that
+# the image-build-cpu step already builds and publishes for this commit
+# (`<repo>:<commit>-cpu`). It lives in public ECR, which allows anonymous pulls,
+# so no registry credentials are required. If the pull fails (e.g. the image
+# isn't published yet), fall back to building the base from docker/Dockerfile.cpu.
+#
+# The zen image is not pushed to a registry.
 #
 # See docker/Dockerfile.zen for the build workflow this mirrors.
 set -e
@@ -21,24 +25,33 @@ REGISTRY=$1
 REPO=$2
 BUILDKITE_COMMIT=$3
 
-# Local image tags (not pushed).
-BASE_IMAGE="$REGISTRY/$REPO:$BUILDKITE_COMMIT-cpu-base-for-zen"
+# The shared CPU image published by image-build-cpu (public ECR, anonymous pull).
+SHARED_CPU_IMAGE="$REGISTRY/$REPO:$BUILDKITE_COMMIT-cpu"
+# Local tags (not pushed).
+FALLBACK_BASE_IMAGE="zen-cpu-base:$BUILDKITE_COMMIT"
 IMAGE="$REGISTRY/$REPO:$BUILDKITE_COMMIT-zen-cpu"
 
 # ZENTORCH_VERSION is optional; when unset the Dockerfile falls back to
 # installing zentorch via `vllm[zen]`.
 ZENTORCH_VERSION=${ZENTORCH_VERSION:-}
 
-# Step 1: build the CPU base image that Dockerfile.zen layers on.
-echo "--- :docker: Building CPU base image"
-docker build --file docker/Dockerfile.cpu \
-  --platform linux/amd64 \
-  --build-arg max_jobs=16 \
-  --build-arg buildkite_commit="$BUILDKITE_COMMIT" \
-  --build-arg VLLM_CPU_X86=true \
-  --tag "$BASE_IMAGE" \
-  --target vllm-openai \
-  --progress plain .
+# Step 1: obtain the CPU base image that Dockerfile.zen layers on. Prefer pulling
+# the published `-cpu` image; fall back to building it from source if unavailable.
+if docker pull "$SHARED_CPU_IMAGE"; then
+  echo "--- :docker: Using published CPU image as base: $SHARED_CPU_IMAGE"
+  BASE_IMAGE="$SHARED_CPU_IMAGE"
+else
+  echo "--- :docker: Published CPU image unavailable; building base from source"
+  docker build --file docker/Dockerfile.cpu \
+    --platform linux/amd64 \
+    --build-arg max_jobs=16 \
+    --build-arg buildkite_commit="$BUILDKITE_COMMIT" \
+    --build-arg VLLM_CPU_X86=true \
+    --tag "$FALLBACK_BASE_IMAGE" \
+    --target vllm-openai \
+    --progress plain .
+  BASE_IMAGE="$FALLBACK_BASE_IMAGE"
+fi
 
 # Step 2: build the zen test image on top of the CPU base.
 echo "--- :docker: Building Zen test image"

--- a/.buildkite/scripts/hardware_ci/run-zen-cpu-test.sh
+++ b/.buildkite/scripts/hardware_ci/run-zen-cpu-test.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# Run the AMD Zen CPU kernel tests on the zen5 hardware. This builds the zen test
+# image by layering docker/Dockerfile.zen on a CPU base, then runs the given test
+# command inside the container with NUMA/cpuset pinning.
+#
+# To spare the scarce zen5 box from recompiling vLLM, prefer reusing the shared
+# <repo>:<commit>-cpu image that image-build-cpu publishes to public ECR (anonymous
+# pull, no credentials needed) as the base; fall back to building it from source.
+# This mirrors .buildkite/image_build/image_build_zen_cpu.sh.
+set -euox pipefail
+
+# allow to bind to different cores
+CORE_RANGE=${CORE_RANGE:-0-47}
+NUMA_NODE=${NUMA_NODE:-0}
+IMAGE_NAME="zen-cpu-test-$NUMA_NODE"
+FALLBACK_BASE_IMAGE="zen-cpu-base-$NUMA_NODE"
+TIMEOUT_VAL=$1
+TEST_COMMAND=$2
+
+# The shared CPU image published by image-build-cpu. Only resolvable when the
+# Buildkite registry env vars are present (i.e. in CI, not local runs).
+SHARED_CPU_IMAGE=""
+if [ -n "${REGISTRY:-}" ] && [ -n "${REPO:-}" ] && [ -n "${BUILDKITE_COMMIT:-}" ]; then
+    SHARED_CPU_IMAGE="$REGISTRY/$REPO:$BUILDKITE_COMMIT-cpu"
+fi
+
+# Step 1: obtain the CPU base image that Dockerfile.zen layers on. Prefer pulling
+# the published `-cpu` image; fall back to building it from source if unavailable.
+if [ -n "$SHARED_CPU_IMAGE" ] && docker pull "$SHARED_CPU_IMAGE"; then
+    echo "--- :docker: Using published CPU image as base: $SHARED_CPU_IMAGE"
+    BASE_IMAGE="$SHARED_CPU_IMAGE"
+else
+    echo "--- :docker: Published CPU image unavailable; building base from source"
+    docker build --progress plain --tag "$FALLBACK_BASE_IMAGE" \
+        --target vllm-openai -f docker/Dockerfile.cpu .
+    BASE_IMAGE="$FALLBACK_BASE_IMAGE"
+fi
+
+# Step 2: build the zen test image on top of the CPU base.
+echo "--- :docker: Building Zen test image"
+docker build --progress plain --tag "$IMAGE_NAME" \
+    --build-arg BASE_IMAGE="$BASE_IMAGE" \
+    --target vllm-zen-test -f docker/Dockerfile.zen .
+
+# Run the image, setting --shm-size=4g for tensor parallel.
+docker run --rm --cpuset-cpus="$CORE_RANGE" --cpuset-mems="$NUMA_NODE" -v ~/.cache/huggingface:/root/.cache/huggingface --privileged=true -e HF_TOKEN -e VLLM_CPU_KVCACHE_SPACE=16 -e VLLM_CPU_CI_ENV=1 -e VLLM_CPU_SIM_MULTI_NUMA=1 --shm-size=4g "$IMAGE_NAME" \
+        timeout "$TIMEOUT_VAL" bash -c "set -euox pipefail; echo \"--- Print packages\"; pip list; echo \"--- Running tests\"; ${TEST_COMMAND}"

--- a/docker/Dockerfile.cpu
+++ b/docker/Dockerfile.cpu
@@ -9,7 +9,6 @@
 #
 # Build targets:
 #   vllm-openai (default): used for serving deployment
-#   vllm-openai-zen: vLLM from source + zentorch from PyPI via vllm[zen]
 #   vllm-test: used for CI tests
 #   vllm-dev: used for development
 #
@@ -407,21 +406,5 @@ LABEL ai.vllm.build.python-version="${PYTHON_VERSION:-3.12}"
 # stage above adds examples/ for testing only, so without this the published
 # vllm-openai-cpu image would not ship examples/*.jinja.
 COPY examples examples
-
-ENTRYPOINT ["vllm", "serve"]
-
-
-######################### ZEN CPU PYPI IMAGE #########################
-FROM vllm-openai AS vllm-openai-zen
-
-ARG TARGETARCH
-
-RUN if [ "$TARGETARCH" != "amd64" ]; then \
-        echo "ERROR: vllm-openai-amd only supports --platform=linux/amd64"; \
-        exit 1; \
-    fi
-
-RUN --mount=type=cache,target=/root/.cache/uv \
-    uv pip install "vllm[zen]"
 
 ENTRYPOINT ["vllm", "serve"]

--- a/docker/Dockerfile.zen
+++ b/docker/Dockerfile.zen
@@ -1,0 +1,97 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+# This Dockerfile builds AMD Zen CPU images for vLLM with zentorch.
+# It layers on top of the CPU image produced by docker/Dockerfile.cpu.
+#
+# Supported platforms:
+#   - linux/amd64 (Zen2 and newer; Zen5 is the canonical CI target)
+#
+# Build targets:
+#   vllm-openai-zen (default): vLLM + zentorch for serving
+#   vllm-zen-test            : vllm-openai-zen + test deps for CI
+#
+# Build workflow (see .buildkite/image_build/image_build_zen_cpu.sh):
+#   1. Obtain a CPU base image that already has vLLM installed. In CI this is the
+#      shared `<repo>:<commit>-cpu` image (docker/Dockerfile.cpu --target
+#      vllm-test); either the vllm-test or vllm-openai target works as the base
+#      since both install vLLM into the same venv this stage extends.
+#   2. docker build -f docker/Dockerfile.zen --build-arg BASE_IMAGE=<base>:<tag> \
+#                    --target vllm-zen-test -t <out>:<tag> .
+
+ARG BASE_IMAGE
+ARG PYTHON_VERSION=3.12
+ARG ZENTORCH_VERSION
+
+######################### ZEN OPENAI IMAGE #########################
+FROM ${BASE_IMAGE} AS vllm-openai-zen
+
+ARG TARGETARCH
+ARG ZENTORCH_VERSION
+
+RUN if [ "${TARGETARCH}" != "amd64" ]; then \
+        echo "ERROR: Dockerfile.zen requires --platform=linux/amd64"; \
+        exit 1; \
+    fi
+
+WORKDIR /vllm-workspace
+
+RUN --mount=type=cache,target=/root/.cache/uv \
+    if [ -n "${ZENTORCH_VERSION}" ]; then \
+        uv pip install "zentorch==${ZENTORCH_VERSION}"; \
+    else \
+        uv pip install "vllm[zen]"; \
+    fi
+
+LABEL org.opencontainers.image.title="vLLM Zen CPU"
+LABEL org.opencontainers.image.description="vLLM with zentorch for AMD Zen CPUs"
+LABEL org.opencontainers.image.vendor="vLLM Project"
+LABEL org.opencontainers.image.source="https://github.com/vllm-project/vllm"
+LABEL ai.vllm.build.target-arch="${TARGETARCH}"
+LABEL ai.vllm.build.python-version="${PYTHON_VERSION}"
+LABEL ai.vllm.build.zentorch-version="${ZENTORCH_VERSION:-unpinned}"
+
+ENTRYPOINT ["vllm", "serve"]
+
+######################### ZEN TEST IMAGE #########################
+FROM vllm-openai-zen AS vllm-zen-test
+
+WORKDIR /vllm-workspace
+
+COPY requirements/test/cuda.in requirements/test/zen.in
+
+RUN sed -i '/mamba_ssm/d'                  requirements/test/zen.in && \
+    sed -i 's/^torch==.*/torch==2.11.0/g'  requirements/test/zen.in && \
+    sed -i 's/torchaudio.*/torchaudio/g'   requirements/test/zen.in && \
+    sed -i 's/torchvision.*/torchvision/g' requirements/test/zen.in && \
+    # zentorch parity: keep sentence-transformers pinned where vllm-test-deps did.
+    sed -i 's/^sentence-transformers.*/sentence-transformers==5.3.0/g' requirements/test/zen.in && \
+    uv pip compile requirements/test/zen.in \
+       -o requirements/test/zen.txt \
+       --index-strategy unsafe-best-match --torch-backend cpu
+
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv pip install -r requirements/test/zen.txt
+
+# Reassert zentorch's torch in case test-deps moved it.
+RUN --mount=type=cache,target=/root/.cache/uv \
+    if [ -n "${ZENTORCH_VERSION}" ]; then \
+        uv pip install --force-reinstall --no-deps "zentorch==${ZENTORCH_VERSION}"; \
+    else \
+        uv pip install --force-reinstall --no-deps "vllm[zen]"; \
+    fi
+
+ADD ./tests/ ./tests/
+ADD ./examples/ ./examples/
+ADD ./benchmarks/ ./benchmarks/
+ADD ./vllm/collect_env.py .
+ADD ./docker/ ./docker/
+ADD ./.buildkite/ ./.buildkite/
+
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv pip install -e tests/vllm_test_utils
+
+ENV HF_XET_HIGH_PERFORMANCE=1
+ENV HF_HUB_DOWNLOAD_TIMEOUT=60
+
+ENTRYPOINT []

--- a/docker/Dockerfile.zen
+++ b/docker/Dockerfile.zen
@@ -58,6 +58,7 @@ FROM vllm-openai-zen AS vllm-zen-test
 
 WORKDIR /vllm-workspace
 
+COPY requirements/common.txt requirements/common.txt
 COPY requirements/test/cuda.in requirements/test/zen.in
 
 RUN sed -i '/mamba_ssm/d'                  requirements/test/zen.in && \

--- a/docker/Dockerfile.zen
+++ b/docker/Dockerfile.zen
@@ -62,7 +62,7 @@ COPY requirements/common.txt requirements/common.txt
 COPY requirements/test/cuda.in requirements/test/zen.in
 
 RUN sed -i '/mamba_ssm/d'                  requirements/test/zen.in && \
-    sed -i 's/^torch==.*/torch==2.11.0/g'  requirements/test/zen.in && \
+    sed -i 's/^torch==.*/torch==2.13.0/g'  requirements/test/zen.in && \
     sed -i 's/torchaudio.*/torchaudio/g'   requirements/test/zen.in && \
     sed -i 's/torchvision.*/torchvision/g' requirements/test/zen.in && \
     # zentorch parity: keep sentence-transformers pinned where vllm-test-deps did.
@@ -72,7 +72,7 @@ RUN sed -i '/mamba_ssm/d'                  requirements/test/zen.in && \
        --index-strategy unsafe-best-match --torch-backend cpu
 
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv pip install -r requirements/test/zen.txt
+    uv pip install -r requirements/test/zen.txt --torch-backend cpu
 
 # Reassert zentorch's torch in case test-deps moved it.
 RUN --mount=type=cache,target=/root/.cache/uv \


### PR DESCRIPTION

## Purpose
Add AMD Zen CPU CI infrastructure and fix test compatibility for the AMD Zen CPU platform.
This PR:
1. Adds Buildkite CI steps for AMD Zen CPUs mirroring the existing CPU tests.
2. Adds a `vllm-zen-test` Docker build target for AMD Zen CPU test images.
3. Adds AMD CPU test runner script.

## Test Plan
Run the following on an AMD Zen CPU machine:
```
# Kernel tests
bash .buildkite/scripts/hardware_ci/run-zen-cpu-test.sh 20m \
  "pytest -x -v -s tests/model_executor/test_cpu_unquantized_gemm_dispatch.py"
```

## Test Result
```
tests/model_executor/test_cpu_unquantized_gemm_dispatch.py::test_dispatch_cpu_unquantized_gemm_uses_zentorch_on_zen PASSED [50%]
tests/model_executor/test_cpu_unquantized_gemm_dispatch.py::test_dispatch_cpu_unquantized_gemm_zen_remove_weight PASSED [100%]
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [X] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [X] The test plan, such as providing test command.
- [X] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>
