### PR TITLE
[Bugfix][Compile] Warn when compile_ranges_endpoints exceed max_num_batched_tokens (#52471)

### DIFF
--- a/tests/compile/test_compile_ranges.py
+++ b/tests/compile/test_compile_ranges.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import logging
 from typing import Any
 
 import torch
@@ -108,9 +109,11 @@ def test_compile_ranges(disable_vllm_compile_cache):
         assert post_grad_range_checker.num_calls == 6
 
 
-def test_compile_config_get_compile_ranges():
+def _compilation_config_with_endpoints(
+    endpoints: list[int],
+) -> CompilationConfig:
     compilation_config = CompilationConfig(
-        compile_ranges_endpoints=[8, 32],
+        compile_ranges_endpoints=endpoints,
     )
     VllmConfig(
         scheduler_config=SchedulerConfig(
@@ -120,11 +123,66 @@ def test_compile_config_get_compile_ranges():
         ),
         compilation_config=compilation_config,
     )
+    return compilation_config
+
+
+def _no_ignored_compile_ranges_warning(caplog_vllm) -> None:
+    assert not any(
+        record.levelno == logging.WARNING
+        and "compile_ranges_endpoints" in record.getMessage()
+        and "ignored" in record.getMessage()
+        for record in caplog_vllm.records
+    )
+
+
+def test_compile_config_get_compile_ranges():
+    compilation_config = _compilation_config_with_endpoints([8, 32])
     assert compilation_config.get_compile_ranges() == [
         Range(start=1, end=8),
         Range(start=9, end=32),
         Range(start=33, end=8192),
     ]
+
+
+def test_compile_ranges_endpoints_above_cap_warns(caplog_vllm):
+    with caplog_vllm.at_level(logging.WARNING, logger="vllm.config.vllm"):
+        compilation_config = _compilation_config_with_endpoints([8, 8192, 16384])
+    assert compilation_config.compile_ranges_endpoints == [8, 8192]
+    warning_records = [
+        record
+        for record in caplog_vllm.records
+        if record.levelno == logging.WARNING
+        and "compile_ranges_endpoints" in record.getMessage()
+    ]
+    assert len(warning_records) == 1
+    message = warning_records[0].getMessage()
+    assert "[16384]" in message
+    assert "max_num_batched_tokens=8192" in message
+
+
+def test_compile_ranges_endpoints_all_valid_does_not_warn(caplog_vllm):
+    with caplog_vllm.at_level(logging.WARNING, logger="vllm.config.vllm"):
+        compilation_config = _compilation_config_with_endpoints([8, 32])
+    _no_ignored_compile_ranges_warning(caplog_vllm)
+    assert compilation_config.get_compile_ranges() == [
+        Range(start=1, end=8),
+        Range(start=9, end=32),
+        Range(start=33, end=8192),
+    ]
+
+
+def test_compile_ranges_endpoint_equal_to_cap_is_noop(caplog_vllm):
+    with caplog_vllm.at_level(logging.WARNING, logger="vllm.config.vllm"):
+        compilation_config = _compilation_config_with_endpoints([8192])
+    _no_ignored_compile_ranges_warning(caplog_vllm)
+    assert compilation_config.compile_ranges_endpoints == [8192]
+
+
+def test_compile_ranges_endpoint_equal_to_one_is_noop(caplog_vllm):
+    with caplog_vllm.at_level(logging.WARNING, logger="vllm.config.vllm"):
+        compilation_config = _compilation_config_with_endpoints([1])
+    _no_ignored_compile_ranges_warning(caplog_vllm)
+    assert compilation_config.compile_ranges_endpoints == [8192]
 
 
 class PostGradStaticShapeChecker(InductorPass):

--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -586,6 +586,10 @@ class CompilationConfig:
     Compile sizes are also used single element ranges,
     the range is represented as [compile_sizes[i], compile_sizes[i]].
 
+    Extra endpoints must be in (1, max_num_batched_tokens). 1 and
+    max_num_batched_tokens are ignored as redundant; values above the
+    cap are ignored with a warning.
+
     If a range overlaps with the compile size, graph for compile size
     will be prioritized, i.e. if we have a range [1, 8] and a compile size 4,
     graph for compile size 4 will be compiled and used instead of the graph

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -2133,12 +2133,28 @@ class VllmConfig:
                         compile_range_end,
                     )
 
+        # User endpoints are extra split points in (1, max_num_batched_tokens).
+        # 1 and the cap are redundant with the auto-added last range; values
+        # above the cap cannot be compiled.
         if compilation_config.compile_ranges_endpoints is not None:
+            skipped_endpoints: list[int] = []
             for x in compilation_config.compile_ranges_endpoints:
                 assert isinstance(x, int)
                 assert x > 0, f"Invalid compile range endpoint: {x}"
-                if compile_range_end is not None and x < compile_range_end and x > 1:
+                if compile_range_end is not None and 1 < x < compile_range_end:
                     computed_compile_ranges_endpoints.append(x)
+                elif compile_range_end is not None and x > compile_range_end:
+                    skipped_endpoints.append(x)
+            if skipped_endpoints:
+                # #52471: do not silently drop endpoints above the batch-token cap.
+                logger.warning(
+                    "compile_ranges_endpoints values %s are greater than "
+                    "max_num_batched_tokens=%d and will be ignored. "
+                    "Raise --max-num-batched-tokens to compile ranges "
+                    "above this cap.",
+                    skipped_endpoints,
+                    compile_range_end,
+                )
         compilation_config.compile_ranges_endpoints = sorted(
             computed_compile_ranges_endpoints
         )


### PR DESCRIPTION
## Purpose

User `compile_ranges_endpoints` above `max_num_batched_tokens` were dropped with no message, so raising that flag alone looked like it compiled larger ranges. Warn at config init and point at `--max-num-batched-tokens`. Fixes the silent-skip part of #52471 (suggested fix (a)).

No open PR currently addresses `compile_ranges_endpoints`.

This is a startup-time config warning only. No runtime scheduler, compile, or model path changes, so no model evals.

## Test Plan

- [x] `.venv/bin/python -m pytest tests/compile/test_compile_ranges.py -v`

## Test Result

8 passed (5 CPU cases for keep / warn / no-op, plus the 3 existing GPU tests in that file).

## AI assistance

AI assistance was used. I reviewed every changed line and ran the tests above.
