### PR TITLE
[LoRA] Support per-request dynamic LoRA scale

### DIFF
--- a/tests/lora/test_punica_ops.py
+++ b/tests/lora/test_punica_ops.py
@@ -646,3 +646,69 @@ def test_add_lora_fused_moe_early_exit(device):
     assert torch.equal(y, y_snapshot), (
         "add_lora_fused_moe modified output tensor despite no_lora_flag_cpu=True"
     )
+
+
+@pytest.mark.parametrize("device", DEVICES)
+def test_lora_expand_per_request_scale(device):
+    """
+    Requests sharing a single adapter may each apply their own strength.
+
+    The batch below puts three requests on the same lora id, so the only
+    thing distinguishing them is `request_scales`; each token's output must
+    be the unscaled output times its own request's scale.
+    """
+    torch.set_default_device(device)
+    set_random_seed(0)
+
+    rank, hidden_size = 16, 256
+    req_lens = [5, 3, 4]
+    scales = [0.25, 1.0, 2.0]
+    num_tokens = sum(req_lens)
+
+    token_lora_mapping = torch.zeros(num_tokens, dtype=torch.int32, device=device)
+    token_to_req = torch.repeat_interleave(
+        torch.arange(len(req_lens), dtype=torch.int32),
+        torch.tensor(req_lens, dtype=torch.int32),
+    )
+
+    inputs = torch.rand(1, num_tokens, rank, dtype=torch.float32, device=device)
+    lora_weights = [
+        torch.rand(1, hidden_size, rank, dtype=torch.bfloat16, device=device)
+    ]
+
+    lora_meta = LoRAKernelMeta.make(
+        max_loras=1,
+        max_num_tokens=num_tokens,
+        device=DEVICE_TYPE,
+        max_num_reqs=len(req_lens),
+    )
+    lora_meta.prepare_tensors(token_lora_mapping)
+    meta_args = lora_meta.meta_args(token_nums=num_tokens, specialize_active_lora=False)
+
+    def expand(request_scales: torch.Tensor | None) -> torch.Tensor:
+        out = torch.zeros(num_tokens, hidden_size, dtype=torch.bfloat16, device=device)
+        kwargs = {}
+        if request_scales is not None:
+            lora_meta.prepare_request_scales(request_scales, token_to_req)
+            kwargs = {
+                "request_scales": lora_meta.request_scales,
+                "token_to_req": lora_meta.token_to_req,
+            }
+        with _dict_lock:
+            _LORA_B_PTR_DICT.clear()
+            triton_ops.lora_expand(
+                inputs, lora_weights, out, *meta_args, add_inputs=False, **kwargs
+            )
+        return out
+
+    unscaled = expand(None)
+    scaled = expand(torch.tensor(scales, dtype=torch.float32))
+
+    per_token = torch.repeat_interleave(
+        torch.tensor(scales, dtype=torch.float32, device=device),
+        torch.tensor(req_lens, device=device),
+    )
+    assert_close(scaled, (unscaled.float() * per_token[:, None]).to(scaled.dtype))
+
+    # An all-ones scale must be indistinguishable from not passing scales.
+    assert torch.equal(expand(torch.ones(len(req_lens))), unscaled)

--- a/vllm/config/lora.py
+++ b/vllm/config/lora.py
@@ -84,6 +84,15 @@ class LoRAConfig:
     experts (stored once with expert-dim 1) instead of per-expert. The shared
     factors are broadcast to the expert count at kernel time. Only meaningful for
     MoE models whose adapters use this layout; ignored otherwise."""
+    enable_per_request_lora_scale: bool = False
+    """If True, allow each request to carry its own `lora_scale` multiplier via
+    `LoRARequest.lora_scale`, applied on top of the adapter's own `alpha / r`.
+    Requests sharing a single adapter in the same batch may then use different
+    strengths without occupying separate adapter slots: the scale is kept as
+    per-request state (`[max_num_seqs]` floats) plus a token->request map, and
+    folded into the LoRA expand kernel. Adds a small per-token gather to the
+    expand kernel, hence opt-in. Not currently applied to fused-MoE LoRA
+    layers."""
 
     def compute_hash(self) -> str:
         """
@@ -105,6 +114,7 @@ class LoRAConfig:
         factors.append(self.enable_tower_connector_lora)
         factors.append(self.enable_mixed_moe_lora_format)
         factors.append(self.enable_moe_shared_loras)
+        factors.append(self.enable_per_request_lora_scale)
         # target_modules affects which modules get LoRA applied
         factors.append(
             tuple(sorted(self.target_modules)) if self.target_modules else None

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -618,6 +618,7 @@ class EngineArgs:
     specialize_active_lora: bool = LoRAConfig.specialize_active_lora
     enable_mixed_moe_lora_format: bool = LoRAConfig.enable_mixed_moe_lora_format
     enable_moe_shared_loras: bool = LoRAConfig.enable_moe_shared_loras
+    enable_per_request_lora_scale: bool = LoRAConfig.enable_per_request_lora_scale
 
     ray_workers_use_nsight: bool = ParallelConfig.ray_workers_use_nsight
     num_gpu_blocks_override: int | None = CacheConfig.num_gpu_blocks_override
@@ -1446,6 +1447,10 @@ class EngineArgs:
         lora_group.add_argument(
             "--enable-moe-shared-loras",
             **lora_kwargs["enable_moe_shared_loras"],
+        )
+        lora_group.add_argument(
+            "--enable-per-request-lora-scale",
+            **lora_kwargs["enable_per_request_lora_scale"],
         )
 
         # Observability arguments
@@ -2355,6 +2360,7 @@ class EngineArgs:
                 specialize_active_lora=self.specialize_active_lora,
                 enable_mixed_moe_lora_format=self.enable_mixed_moe_lora_format,
                 enable_moe_shared_loras=self.enable_moe_shared_loras,
+                enable_per_request_lora_scale=self.enable_per_request_lora_scale,
                 max_cpu_loras=self.max_cpu_loras
                 if self.max_cpu_loras and self.max_cpu_loras > 0
                 else None,

--- a/vllm/lora/layers/utils.py
+++ b/vllm/lora/layers/utils.py
@@ -37,9 +37,37 @@ class LoRAMapping:
     is_prefill: bool = False
     type: LoRAMappingType = LoRAMappingType.LANGUAGE
 
+    # Per-request LoRA strength. `index_mapping` / `prompt_mapping` say which
+    # adapter each token uses; these two say how strongly it is applied, so
+    # requests sharing one adapter can ask for different scales without
+    # consuming extra adapter slots.
+    #   request_scales[i]  -> scale for the i-th request in the batch
+    #   token_to_req[i]    -> request index of the i-th token of index_mapping
+    #   sample_to_req[i]   -> request index of the i-th entry of prompt_mapping
+    # All three are None when the feature is disabled, which is the default
+    # and reproduces stock behavior.
+    request_scales: tuple[float, ...] | None = None
+    token_to_req: tuple[int, ...] | None = None
+    sample_to_req: tuple[int, ...] | None = None
+
     def __post_init__(self):
         self.index_mapping = tuple(self.index_mapping)
         self.prompt_mapping = tuple(self.prompt_mapping)
+        if self.request_scales is not None:
+            self.request_scales = tuple(self.request_scales)
+            assert self.token_to_req is not None, (
+                "token_to_req is required alongside request_scales"
+            )
+            self.token_to_req = tuple(self.token_to_req)
+            assert len(self.token_to_req) == len(self.index_mapping)
+            if self.sample_to_req is not None:
+                self.sample_to_req = tuple(self.sample_to_req)
+                assert len(self.sample_to_req) == len(self.prompt_mapping)
+
+    @property
+    def has_request_scales(self) -> bool:
+        """True when any request asks for a scale other than the adapter's own."""
+        return self.request_scales is not None
 
 
 def _get_lora_device(base_layer: nn.Module) -> torch.device:

--- a/vllm/lora/ops/triton_ops/kernel_utils.py
+++ b/vllm/lora/ops/triton_ops/kernel_utils.py
@@ -131,6 +131,9 @@ def do_expand_kernel(
     # out ptr strides
     output_d0_stride,
     output_d1_stride,
+    # per-request lora scaling
+    request_scales_ptr,
+    token_to_req_ptr,
     # constants
     BLOCK_M: tl.constexpr,
     BLOCK_N: tl.constexpr,
@@ -141,6 +144,7 @@ def do_expand_kernel(
     CAST_TYPE: tl.constexpr,
     ADD_INPUTS: tl.constexpr,
     USE_GDC: tl.constexpr,
+    APPLY_REQUEST_SCALE: tl.constexpr,
 ):
     """
     Given an array of integers that identifies the rows of A, ram,
@@ -211,6 +215,17 @@ def do_expand_kernel(
         USE_GDC,
         base_k=0,
     )
+
+    # Apply the per-request LoRA strength. This is the only place the dynamic
+    # scale enters: `ram` already identifies the token rows this CTA owns, so
+    # a gather through token_to_req -> request_scales gives each row its own
+    # lambda. Folding it in here (rather than in shrink) keeps it out of the
+    # fp32 split-K accumulation path and applies it exactly once per token,
+    # whatever the slice/rank layout.
+    if APPLY_REQUEST_SCALE:
+        req_idx = tl.load(token_to_req_ptr + ram)
+        row_scale = tl.load(request_scales_ptr + req_idx)
+        accumulator = accumulator * row_scale[:, None]
 
     tiled_c = accumulator.to(cur_lora_ptr.dtype.element_ty)
     if SLICE_NUM == 1:

--- a/vllm/lora/ops/triton_ops/lora_expand_op.py
+++ b/vllm/lora/ops/triton_ops/lora_expand_op.py
@@ -42,6 +42,8 @@ def _lora_expand_kernel(
     output_d0_stride,
     output_d1_stride,  # 1
     output_hs_ptr,
+    request_scales_ptr,
+    token_to_req_ptr,
     BLOCK_M: tl.constexpr,
     BLOCK_N: tl.constexpr,
     BLOCK_K: tl.constexpr,
@@ -51,6 +53,7 @@ def _lora_expand_kernel(
     SLICE_NUM: tl.constexpr,
     SAME_STRIDE: tl.constexpr,
     USE_GDC: tl.constexpr,
+    APPLY_REQUEST_SCALE: tl.constexpr,
     launch_pdl: tl.constexpr,
 ):
     cta_n_num = tl.cdiv(N, BLOCK_N)
@@ -119,6 +122,9 @@ def _lora_expand_kernel(
         # out ptr strides
         output_d0_stride,
         output_d1_stride,
+        # per-request lora scaling
+        request_scales_ptr,
+        token_to_req_ptr,
         # constants
         BLOCK_M,
         BLOCK_N,
@@ -129,6 +135,7 @@ def _lora_expand_kernel(
         CAST_TYPE,
         ADD_INPUTS,
         USE_GDC,
+        APPLY_REQUEST_SCALE,
     )
 
 
@@ -146,6 +153,8 @@ def _lora_expand(
     num_active_loras: torch.Tensor,  # CPU tensor [1], number of active LoRAs
     offset_start: int = 0,
     add_inputs: bool = False,
+    request_scales: torch.Tensor | None = None,  # shape [num_reqs]
+    token_to_req: torch.Tensor | None = None,  # shape [num_tokens]
 ) -> None:
     """
     Args:
@@ -171,6 +180,13 @@ def _lora_expand(
             Defaults to 0.
         add_inputs (bool, optional): Whether to add the input tensor to the
             output tensor. Defaults to False.
+        request_scales (Optional[torch.Tensor]): Per-request LoRA strength
+            multipliers, shape [num_reqs]. When given (together with
+            token_to_req), each token's LoRA delta is additionally scaled by
+            request_scales[token_to_req[token]] before being written out.
+            This lets requests sharing one adapter use different strengths.
+        token_to_req (Optional[torch.Tensor]): int32 tensor of shape
+            [num_tokens] mapping each token to its request index.
     """
 
     assert no_lora_flag_cpu.numel() == 1
@@ -191,6 +207,14 @@ def _lora_expand(
     assert token_lora_mapping.size(0) == token_indices_sorted_by_lora_ids.size(0)
     assert lora_ids.size(0) == num_tokens_per_lora.size(0)
     assert lora_token_start_loc.size(0) == lora_ids.size(0) + 1
+
+    APPLY_REQUEST_SCALE = request_scales is not None and token_to_req is not None
+    if APPLY_REQUEST_SCALE:
+        assert token_to_req is not None  # narrow for type checkers
+        assert token_to_req.size(0) >= M, (
+            f"token_to_req covers {token_to_req.size(0)} tokens, need {M}"
+        )
+        token_to_req = token_to_req[:M]
 
     (
         slice_start_tensor,
@@ -266,6 +290,8 @@ def _lora_expand(
         output_tensor.stride(0),
         output_tensor.stride(1),
         hidden_sizes_tensor,
+        request_scales,
+        token_to_req,
         BLOCK_M,
         BLOCK_N,
         BLOCK_K,
@@ -275,6 +301,7 @@ def _lora_expand(
         NUM_SLICES,
         same_stride,
         use_gdc,
+        APPLY_REQUEST_SCALE,
         num_warps=NUM_WARPS,
         num_ctas=NUM_CTAS,
         num_stages=NUM_STAGES,
@@ -297,6 +324,8 @@ def _lora_expand_fake(
     num_active_loras: torch.Tensor,  # CPU tensor [1], number of active LoRAs
     offset_start: int = 0,
     add_inputs: bool = False,
+    request_scales: torch.Tensor | None = None,  # shape [num_reqs]
+    token_to_req: torch.Tensor | None = None,  # shape [num_tokens]
 ) -> None:
     return
 

--- a/vllm/lora/ops/triton_ops/lora_kernel_metadata.py
+++ b/vllm/lora/ops/triton_ops/lora_kernel_metadata.py
@@ -46,12 +46,30 @@ class LoRAKernelMeta:
     # Empty list means no specialization (use actual count).
     captured_lora_counts: list[int] = field(default_factory=list)
 
+    # ---- Per-request LoRA scaling (optional) ----------------------------
+    # Only allocated when the engine is started with
+    # `--enable-per-request-lora-scale`. Two requests in the same batch may
+    # share a LoRA adapter (same lora id, same A/B weights) while asking for
+    # different strengths. Following the persistent-batch pattern used by
+    # SamplingStates, the scale is kept as [max_num_reqs] per-request state
+    # and combined with a [max_num_tokens] token -> request index map, rather
+    # than materializing a per-token copy of the scale.
+    #
+    #   effective_scale(token) = base_scale * request_scales[token_to_req[token]]
+    #
+    # token_lora_mapping decides *which* adapter a token uses;
+    # request_scales decides *how strongly* it is applied. The two are
+    # orthogonal, so a single adapter slot serves any number of scales.
+    request_scales: torch.Tensor | None = None
+    token_to_req: torch.Tensor | None = None
+
     @staticmethod
     def make(
         max_loras: int,
         max_num_tokens: int,
         device: torch.device | str,
         captured_lora_counts: list[int] | None = None,
+        max_num_reqs: int | None = None,
     ) -> "LoRAKernelMeta":
         token_lora_mapping = torch.empty(
             max_num_tokens, dtype=torch.int32, device=device
@@ -85,6 +103,16 @@ class LoRAKernelMeta:
             [max_loras + 1], dtype=torch.int32, device="cpu"
         )
 
+        request_scales = None
+        token_to_req = None
+        if max_num_reqs is not None:
+            # Persistent per-request scale buffer. Defaults to 1.0 so any slot
+            # that is never written behaves exactly like stock vLLM.
+            request_scales = torch.ones(
+                max_num_reqs, dtype=torch.float32, device=device
+            )
+            token_to_req = torch.zeros(max_num_tokens, dtype=torch.int32, device=device)
+
         return LoRAKernelMeta(
             token_lora_mapping=token_lora_mapping,
             token_indices_sorted_by_lora_ids=token_indices_sorted_by_lora_ids,
@@ -97,7 +125,40 @@ class LoRAKernelMeta:
             captured_lora_counts=sorted(captured_lora_counts)
             if captured_lora_counts
             else [],
+            request_scales=request_scales,
+            token_to_req=token_to_req,
         )
+
+    @property
+    def has_request_scales(self) -> bool:
+        return self.request_scales is not None
+
+    def prepare_request_scales(
+        self,
+        request_scales: torch.Tensor,
+        token_to_req: torch.Tensor,
+    ) -> None:
+        """
+        Stage the per-request LoRA scales for the current forward pass.
+
+        Args:
+            request_scales: float32 CPU tensor of shape [num_reqs] holding
+                each request's scale multiplier.
+            token_to_req: int32 CPU tensor of shape [num_tokens] mapping every
+                token to the index of the request it belongs to.
+        """
+        assert self.request_scales is not None
+        assert self.token_to_req is not None
+
+        num_reqs = request_scales.size(0)
+        num_tokens = token_to_req.size(0)
+        assert num_reqs <= self.request_scales.size(0)
+        assert num_tokens <= self.token_to_req.size(0)
+
+        self.request_scales[:num_reqs].copy_(request_scales, non_blocking=True)
+        # Slots beyond num_reqs keep whatever they had; token_to_req never
+        # points at them, so they are unreachable this step.
+        self.token_to_req[:num_tokens].copy_(token_to_req, non_blocking=True)
 
     def _reset(self):
         self.active_lora_ids.fill_(-1)

--- a/vllm/lora/punica_wrapper/punica_gpu.py
+++ b/vllm/lora/punica_wrapper/punica_gpu.py
@@ -11,6 +11,7 @@ from typing import final
 
 import torch
 
+from vllm.logger import init_logger
 from vllm.lora.layers import LoRAMapping
 from vllm.lora.utils import get_captured_lora_counts
 from vllm.triton_utils import HAS_TRITON, triton
@@ -28,6 +29,8 @@ if HAS_TRITON:
 from vllm import _custom_ops as ops
 
 from .punica_base import PunicaWrapperBase
+
+logger = init_logger(__name__)
 
 
 @final
@@ -49,6 +52,13 @@ class PunicaWrapperGPU(PunicaWrapperBase):
 
         self.lora_config = kwargs["lora_config"]
         self.max_loras = self.lora_config.max_loras
+        # Per-request LoRA scaling: allocate the [max_num_reqs] scale buffer
+        # and the token -> request map only when the feature is on, so the
+        # default path allocates and launches exactly as before.
+        self.enable_per_request_lora_scale = getattr(
+            self.lora_config, "enable_per_request_lora_scale", False
+        )
+        scale_num_reqs = max_batches if self.enable_per_request_lora_scale else None
 
         # Compute captured LoRA counts for cudagraph specialization.
         captured_lora_counts = get_captured_lora_counts(
@@ -60,6 +70,7 @@ class PunicaWrapperGPU(PunicaWrapperBase):
             max_num_batched_tokens,
             device=device,
             captured_lora_counts=captured_lora_counts,
+            max_num_reqs=scale_num_reqs,
         )
 
         # When speculative decoding is enabled, max_num_samples is
@@ -71,7 +82,75 @@ class PunicaWrapperGPU(PunicaWrapperBase):
             max_num_batched_tokens,
             device=device,
             captured_lora_counts=captured_lora_counts,
+            max_num_reqs=scale_num_reqs,
         )
+
+        # Set for the duration of a step when the current batch actually
+        # carries non-default scales; lets the kernels skip the extra gather
+        # entirely on batches that don't use the feature.
+        self._request_scales_active = False
+
+    def _update_request_scales(self, mapping: LoRAMapping) -> None:
+        """Stage this step's per-request LoRA scales onto the GPU buffers."""
+        self._request_scales_active = False
+        if not self.enable_per_request_lora_scale:
+            if mapping.has_request_scales:
+                logger.warning_once(
+                    "A request specified a non-default LoRARequest.lora_scale, "
+                    "but the engine was not started with "
+                    "--enable-per-request-lora-scale. The scale is being "
+                    "ignored."
+                )
+            return
+
+        # Once the feature is on, the scale path stays on for every step. The
+        # kernel variant is picked by a tl.constexpr and gets baked into the
+        # cudagraph at capture time, so a step that silently dropped to the
+        # scale-free path would replay a graph that still reads these buffers
+        # while nothing refreshed them -- tokens would then pick up whatever
+        # request the previous step had left behind.
+        if not mapping.has_request_scales:
+            # An all-ones table makes the gather a no-op regardless of what
+            # token_to_req still holds from the previous step.
+            self.token_mapping_meta.request_scales.fill_(1.0)
+            self.prompt_mapping_meta.request_scales.fill_(1.0)
+            self._request_scales_active = True
+            return
+
+        assert mapping.request_scales is not None
+        assert mapping.token_to_req is not None
+
+        request_scales = torch.tensor(
+            mapping.request_scales, dtype=torch.float32, device="cpu"
+        )
+        token_to_req = torch.tensor(
+            mapping.token_to_req, dtype=torch.int32, device="cpu"
+        )
+        self.token_mapping_meta.prepare_request_scales(request_scales, token_to_req)
+
+        # The logits path indexes by sampled token, not by scheduled token, so
+        # it needs its own token -> request map. Fall back to identity when the
+        # caller didn't supply one (one sample per request).
+        if mapping.sample_to_req is not None:
+            sample_to_req = torch.tensor(
+                mapping.sample_to_req, dtype=torch.int32, device="cpu"
+            )
+        else:
+            sample_to_req = torch.arange(
+                len(mapping.prompt_mapping), dtype=torch.int32, device="cpu"
+            )
+        self.prompt_mapping_meta.prepare_request_scales(request_scales, sample_to_req)
+
+        self._request_scales_active = True
+
+    def _scale_args(self, meta: "LoRAKernelMeta") -> dict:
+        """kwargs to forward the per-request scale into a lora_expand call."""
+        if not self._request_scales_active:
+            return {}
+        return {
+            "request_scales": meta.request_scales,
+            "token_to_req": meta.token_to_req,
+        }
 
     def update_metadata(
         self,
@@ -89,6 +168,7 @@ class PunicaWrapperGPU(PunicaWrapperBase):
             # Prepare cuda kernel metadata tensors
             self.token_mapping_meta.prepare_tensors(self.token_lora_indices)
             self.prompt_mapping_meta.prepare_tensors(self.sampler_indices)
+            self._update_request_scales(mapping)
 
     def add_shrink(
         self,
@@ -167,6 +247,7 @@ class PunicaWrapperGPU(PunicaWrapperBase):
             ),
             offset_start=offset_start,
             add_inputs=add_inputs,
+            **self._scale_args(self.token_mapping_meta),
         )
 
         y = y.view_as(y_org)
@@ -201,6 +282,7 @@ class PunicaWrapperGPU(PunicaWrapperBase):
             ),
             offset_start=0,
             add_inputs=add_inputs,
+            **self._scale_args(self.token_mapping_meta),
         )
 
     def add_lora_linear(
@@ -324,6 +406,7 @@ class PunicaWrapperGPU(PunicaWrapperBase):
                 buffer.size(0), self.lora_config.specialize_active_lora
             ),
             add_inputs=True,
+            **self._scale_args(self.prompt_mapping_meta),
         )
         y = y.view_as(y_org)
 
@@ -462,6 +545,11 @@ class PunicaWrapperGPU(PunicaWrapperBase):
 
         if token_lora_mapping is None:
             token_lora_mapping = token_lora_mapping_meta
+        if self._request_scales_active:
+            logger.warning_once(
+                "Per-request LoRA scaling is not applied to fused-MoE LoRA "
+                "layers; those layers use the adapter's default strength."
+            )
         fused_moe_lora(
             y,
             x,

--- a/vllm/lora/request.py
+++ b/vllm/lora/request.py
@@ -36,9 +36,24 @@ class LoRARequest(
     `enable_mixed_moe_lora_format=True`; otherwise it is ignored and the
     on-disk format is inferred from the base model."""
 
+    lora_scale: float = 1.0
+    """Per-request multiplier applied on top of the adapter's own `alpha / r`
+    scaling. Two requests in the same batch may share the same `lora_int_id`
+    while using different `lora_scale` values: the scale is kept as
+    per-request state and applied inside the LoRA kernels, so a distinct
+    scale does not consume an extra adapter slot. `1.0` (the default)
+    reproduces the stock behavior exactly.
+
+    NOTE: This is deliberately *not* part of `__eq__` / `__hash__`, which key
+    on `lora_name` only. The adapter set passed to the LoRA manager is about
+    which weights to load; the scale is looked up per request index instead."""
+
     def __post_init__(self):
         if self.lora_int_id < 1:
             raise ValueError(f"id must be > 0, got {self.lora_int_id}")
+
+        if self.lora_scale < 0:
+            raise ValueError(f"lora_scale must be >= 0, got {self.lora_scale}")
 
         # Ensure lora_path is not empty
         assert self.lora_path, "lora_path cannot be empty"

--- a/vllm/lora/scale_inputs.py
+++ b/vllm/lora/scale_inputs.py
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Per-request LoRA scaling inputs.
+
+Two requests in the same batch may share a LoRA adapter (identical
+`lora_int_id`, identical A/B weights) while asking for different strengths via
+`LoRARequest.lora_scale`. Rather than expanding the scale to one float per
+token, we keep it as per-request state and pair it with a token -> request
+index map, mirroring how the sampler keeps `temperature` as `[max_num_reqs]`
+state:
+
+    request_scales = [0.3, 0.8, 1.2]        # one entry per request
+    token_to_req   = [0, 0, 0, 1, 1, 2]     # one entry per scheduled token
+
+    scale(token) = base_scale * request_scales[token_to_req[token]]
+
+For a 256-request / 32k-token batch that is ~1KB instead of ~128KB, and it
+keeps the scale orthogonal to `token_lora_mapping`, which continues to decide
+*which* adapter a token uses rather than how strongly it applies.
+"""
+
+from dataclasses import dataclass
+
+import numpy as np
+
+
+@dataclass
+class LoRAScaleInputs:
+    """Per-request LoRA scales and the index maps that reach them."""
+
+    # scale multiplier per request in the batch
+    request_scales: tuple[float, ...]
+    # scheduled-token index -> request index
+    token_to_req: tuple[int, ...]
+    # sampled-token index -> request index (used by the logits LoRA path)
+    sample_to_req: tuple[int, ...]
+
+
+def make_lora_scale_inputs(
+    request_scales: np.ndarray,
+    num_scheduled_tokens: np.ndarray,
+    num_sampled_tokens: np.ndarray,
+) -> LoRAScaleInputs | None:
+    """
+    Build the per-request scale inputs for one forward pass.
+
+    Returns None when every request uses the default strength of 1.0, so that
+    batches which don't use the feature take exactly the stock code path and
+    pay nothing for it.
+
+    Args:
+        request_scales: float array of shape [num_reqs], the per-request
+            multiplier as stored in the persistent batch.
+        num_scheduled_tokens: int array of shape [num_reqs].
+        num_sampled_tokens: int array of shape [num_reqs].
+    """
+    if request_scales.size == 0 or bool(np.all(request_scales == 1.0)):
+        return None
+
+    req_indices = np.arange(request_scales.size, dtype=np.int32)
+    return LoRAScaleInputs(
+        request_scales=tuple(request_scales.astype(np.float32).tolist()),
+        token_to_req=tuple(req_indices.repeat(num_scheduled_tokens).tolist()),
+        sample_to_req=tuple(req_indices.repeat(num_sampled_tokens).tolist()),
+    )

--- a/vllm/v1/worker/gpu/lora_utils.py
+++ b/vllm/v1/worker/gpu/lora_utils.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 
 from vllm.lora.request import LoRARequest
+from vllm.lora.scale_inputs import LoRAScaleInputs, make_lora_scale_inputs
 from vllm.lora.utils import get_captured_lora_counts
 
 if TYPE_CHECKING:
@@ -77,6 +78,10 @@ class LoraState:
     def __init__(self, max_num_reqs: int):
         self.lora_ids = np.zeros(max_num_reqs, dtype=np.int32)
         self.lora_ids.fill(NO_LORA_ID)
+        # Per-request LoRA strength, held as persistent batch state alongside
+        # lora_ids. Requests sharing one adapter can differ here, so a distinct
+        # strength costs no adapter slot. 1.0 == the adapter's own alpha/r.
+        self.lora_scales = np.ones(max_num_reqs, dtype=np.float32)
         # req_id -> lora_request
         self.lora_requests: dict[str, LoRARequest] = {}
 
@@ -86,8 +91,10 @@ class LoraState:
         if lora_request is not None:
             self.lora_requests[req_id] = lora_request
             self.lora_ids[req_index] = lora_request.lora_int_id
+            self.lora_scales[req_index] = lora_request.lora_scale
         else:
             self.lora_ids[req_index] = NO_LORA_ID
+            self.lora_scales[req_index] = 1.0
 
     def remove_request(self, req_id: str) -> None:
         self.lora_requests.pop(req_id, None)
@@ -97,12 +104,29 @@ class LoraState:
         req_ids: list[str],
         idx_mapping: np.ndarray,
         num_scheduled_tokens: np.ndarray,
-    ) -> tuple[tuple[int, ...], tuple[int, ...], set[LoRARequest]]:
+    ) -> tuple[
+        tuple[int, ...],
+        tuple[int, ...],
+        set[LoRARequest],
+        LoRAScaleInputs | None,
+    ]:
         lora_ids = self.lora_ids[idx_mapping]
         prompt_lora_mapping = tuple(lora_ids)
         token_lora_mapping = tuple(lora_ids.repeat(num_scheduled_tokens))
         active_lora_requests: set[LoRARequest] = self.get_activate_loras(req_ids)
-        return prompt_lora_mapping, token_lora_mapping, active_lora_requests
+        # One sampled token per request on this path, so the sample->request
+        # map is the identity that make_lora_scale_inputs derives from ones.
+        lora_scales = make_lora_scale_inputs(
+            self.lora_scales[idx_mapping],
+            num_scheduled_tokens,
+            np.ones(len(idx_mapping), dtype=np.int32),
+        )
+        return (
+            prompt_lora_mapping,
+            token_lora_mapping,
+            active_lora_requests,
+            lora_scales,
+        )
 
     def get_activate_loras(self, req_ids: list[str]) -> set[LoRARequest]:
         active_lora_requests: set[LoRARequest] = set()

--- a/vllm/v1/worker/gpu_input_batch.py
+++ b/vllm/v1/worker/gpu_input_batch.py
@@ -10,6 +10,7 @@ import torch
 
 from vllm.config.reasoning import ReasoningConfig
 from vllm.lora.request import LoRARequest
+from vllm.lora.scale_inputs import LoRAScaleInputs, make_lora_scale_inputs
 from vllm.multimodal.inputs import MultiModalFeatureSpec
 from vllm.pooling_params import PoolingParams
 from vllm.sampling_params import SamplingParams, SamplingType
@@ -258,6 +259,11 @@ class InputBatch:
 
         # lora related
         self.request_lora_mapping = np.zeros((self.max_num_reqs,), dtype=np.int64)
+        # Per-request LoRA strength, persistent-batch style: one float per
+        # request slot, indexed the same way as request_lora_mapping. Two
+        # requests can share a lora id here and still differ in strength.
+        # 1.0 means "just the adapter's own alpha/r", i.e. stock behavior.
+        self.request_lora_scale = np.ones((self.max_num_reqs,), dtype=np.float32)
         self.lora_id_to_request_ids: dict[int, set[str]] = {}
         self.lora_id_to_lora_request: dict[int, LoRARequest] = {}
 
@@ -492,11 +498,13 @@ class InputBatch:
                 self.lora_id_to_request_ids[lora_id] = set()
 
             self.request_lora_mapping[req_index] = lora_id
+            self.request_lora_scale[req_index] = request.lora_request.lora_scale
             self.lora_id_to_request_ids[lora_id].add(request.req_id)
             self.lora_id_to_lora_request[lora_id] = request.lora_request
         else:
             # No LoRA
             self.request_lora_mapping[req_index] = 0
+            self.request_lora_scale[req_index] = 1.0
 
         return req_index
 
@@ -556,6 +564,7 @@ class InputBatch:
                 del self.lora_id_to_request_ids[lora_id]
                 del self.lora_id_to_lora_request[lora_id]
             self.request_lora_mapping[req_index] = 0
+        self.request_lora_scale[req_index] = 1.0
 
         if self.is_pooling_model:
             self.pooling_params.pop(req_id, None)
@@ -655,6 +664,10 @@ class InputBatch:
         self.request_lora_mapping[i1], self.request_lora_mapping[i2] = (
             self.request_lora_mapping[i2],
             self.request_lora_mapping[i1],
+        )
+        self.request_lora_scale[i1], self.request_lora_scale[i2] = (
+            self.request_lora_scale[i2],
+            self.request_lora_scale[i1],
         )
 
         if self.is_pooling_model:
@@ -786,6 +799,9 @@ class InputBatch:
             self.block_table.move_row(last_req_index, empty_index)
 
             self.request_lora_mapping[empty_index] = self.request_lora_mapping[
+                last_req_index
+            ]
+            self.request_lora_scale[empty_index] = self.request_lora_scale[
                 last_req_index
             ]
 
@@ -1004,7 +1020,12 @@ class InputBatch:
 
     def make_lora_inputs(
         self, num_scheduled_tokens: np.ndarray, num_sampled_tokens: np.ndarray
-    ) -> tuple[tuple[int, ...], tuple[int, ...], set[LoRARequest]]:
+    ) -> tuple[
+        tuple[int, ...],
+        tuple[int, ...],
+        set[LoRARequest],
+        LoRAScaleInputs | None,
+    ]:
         """
         Given the num_scheduled_tokens for each request in the batch, return
         datastructures used to activate the current LoRAs.
@@ -1015,6 +1036,9 @@ class InputBatch:
             2. token_lora_mapping: A tuple of size np.sum(num_scheduled_tokens)
                where, token_lora_mapping[i] is the LoRA id to use for ith token.
             3. lora_requests: Set of relevant LoRA requests.
+            4. lora_scales: Per-request LoRA strengths plus the token/sample to
+               request index maps, or None if every request in the batch uses
+               the adapter's default strength.
         """
 
         req_lora_mapping = self.request_lora_mapping[: self.num_reqs]
@@ -1025,7 +1049,18 @@ class InputBatch:
             self.lora_id_to_lora_request.values()
         )
 
-        return prompt_lora_mapping, token_lora_mapping, active_lora_requests
+        lora_scales = make_lora_scale_inputs(
+            self.request_lora_scale[: self.num_reqs],
+            num_scheduled_tokens,
+            num_sampled_tokens,
+        )
+
+        return (
+            prompt_lora_mapping,
+            token_lora_mapping,
+            active_lora_requests,
+            lora_scales,
+        )
 
     def set_async_sampled_token_ids(
         self,

--- a/vllm/v1/worker/lora_model_runner_mixin.py
+++ b/vllm/v1/worker/lora_model_runner_mixin.py
@@ -17,6 +17,7 @@ from vllm.config.lora import LoRAConfig
 from vllm.logger import init_logger
 from vllm.lora.layers import LoRAMapping, LoRAMappingType
 from vllm.lora.request import LoRARequest
+from vllm.lora.scale_inputs import LoRAScaleInputs
 from vllm.lora.worker_manager import LRUCacheWorkerLoRAManager
 from vllm.model_executor.models import supports_lora
 from vllm.v1.worker.gpu_input_batch import InputBatch as GPUInputBatch
@@ -66,6 +67,7 @@ class LoRAModelRunnerMixin:
         prompt_lora_mapping: tuple[int, ...],
         token_lora_mapping: tuple[int, ...],
         lora_requests: set[LoRARequest],
+        lora_scales: LoRAScaleInputs | None = None,
         mapping_type: LoRAMappingType = LoRAMappingType.LANGUAGE,
     ) -> None:
         self._ensure_lora_enabled()
@@ -79,6 +81,9 @@ class LoRAModelRunnerMixin:
             prompt_lora_mapping,
             is_prefill=True,
             type=mapping_type,
+            request_scales=lora_scales.request_scales if lora_scales else None,
+            token_to_req=lora_scales.token_to_req if lora_scales else None,
+            sample_to_req=lora_scales.sample_to_req if lora_scales else None,
         )
         self.lora_manager.set_active_adapters(lora_requests, lora_mapping)
 
@@ -99,11 +104,16 @@ class LoRAModelRunnerMixin:
         prompt_lora_mapping: tuple[int, ...]  # of size np.sum(num_sampled_tokens)
         token_lora_mapping: tuple[int, ...]  # of size np.sum(num_scheduled_tokens)
         lora_requests: set[LoRARequest]
-        prompt_lora_mapping, token_lora_mapping, lora_requests = (
+        lora_scales: LoRAScaleInputs | None
+        prompt_lora_mapping, token_lora_mapping, lora_requests, lora_scales = (
             input_batch.make_lora_inputs(num_scheduled_tokens, num_sampled_tokens)
         )
         return self._set_active_loras(
-            prompt_lora_mapping, token_lora_mapping, lora_requests, mapping_type
+            prompt_lora_mapping,
+            token_lora_mapping,
+            lora_requests,
+            lora_scales,
+            mapping_type,
         )
 
     @contextmanager
@@ -240,10 +250,26 @@ class LoRAModelRunnerMixin:
                 for lora_id in range(1, effective_num_loras + 1)
             }
 
+            # Dummy/capture runs must exercise the *same* kernel variant the
+            # real requests will use. APPLY_REQUEST_SCALE is a tl.constexpr, so
+            # a capture taken without scales bakes the scale-free kernel into
+            # the cudagraph and every later replay ignores lora_scale. Feed an
+            # all-ones scale here: numerically a no-op, but it selects the
+            # scale-aware variant.
+            dummy_scales = None
+            if lora_config.enable_per_request_lora_scale:
+                req_idx = np.arange(num_reqs, dtype=np.int32)
+                dummy_scales = LoRAScaleInputs(
+                    request_scales=(1.0,) * num_reqs,
+                    token_to_req=tuple(req_idx.repeat(num_scheduled_tokens).tolist()),
+                    sample_to_req=tuple(req_idx.repeat(num_sampled_tokens).tolist()),
+                )
+
             self._set_active_loras(
                 tuple(sample_lora_mapping),
                 tuple(token_lora_mapping),
                 lora_requests,
+                dummy_scales,
                 mapping_type,
             )
 

--- a/vllm/v1/worker/tpu_input_batch.py
+++ b/vllm/v1/worker/tpu_input_batch.py
@@ -497,7 +497,7 @@ class InputBatch:
 
     def make_lora_inputs(
         self, num_scheduled_tokens: np.ndarray, num_sampled_tokens: np.ndarray
-    ) -> tuple[tuple[int, ...], tuple[int, ...], set[LoRARequest]]:
+    ) -> tuple[tuple[int, ...], tuple[int, ...], set[LoRARequest], None]:
         """
         Given the num_scheduled_tokens for each request in the batch, return
         datastructures used to activate the current LoRAs.
@@ -507,6 +507,8 @@ class InputBatch:
             2. token_lora_mapping: A tuple of size np.sum(num_scheduled_tokens)
                where, token_lora_mapping[i] is the LoRA id to use for ith token.
             3. lora_requests: Set of relevant LoRA requests.
+            4. Always None: per-request LoRA scaling is a GPU-kernel feature
+               and is not implemented for TPU.
         """
 
         req_lora_mapping = self.request_lora_mapping[: self.num_reqs]
@@ -516,7 +518,7 @@ class InputBatch:
             self.lora_id_to_lora_request.values()
         )
 
-        return prompt_lora_mapping, token_lora_mapping, active_lora_requests
+        return prompt_lora_mapping, token_lora_mapping, active_lora_requests, None
 
     @property
     def num_reqs(self) -> int:


### PR DESCRIPTION
## What does this PR do?

Implements #52733 — per-request dynamic LoRA scale. Requests sharing one
adapter in the same continuous-batching batch may each apply a different LoRA
strength, and that strength can vary per request without baking separate
adapter copies (one slot per scale).

### Design

Mirrors `SamplingStates`: a per-request scale buffer `[max_num_reqs]` plus a
`token_to_req` gather map, passed into the Punica `lora_expand` kernel.
Effective scale for a token is `base_scale * request_scales[token_to_req[token_idx]]`.
No per-token scale memory (1 KB per request vs ~128 KB per batch for a
per-token array), and CUDA-graph compatible — the scale-aware kernel variant
selected at capture is kept consistent with the runtime buffer that is
refreshed every step.

Gated behind `--enable-per-request-lora-scale` (off by default). When off,
allocation and kernel launches are identical to today (zero overhead).

### API surface

- `LoRAConfig.enable_per_request_lora_scale: bool = False`
- CLI flag `--enable-per-request-lora-scale`
- `LoRARequest.lora_scale: float = 1.0` — per-request multiplier on top of
  the adapter's own `alpha / r`. `1.0` reproduces stock behavior exactly.
  Deliberately **not** part of `__eq__` / `__hash__` (which key on
  `lora_name`), so a distinct scale does not consume an extra adapter slot.

### Two latent bugs fixed while wiring this through

1. **CUDA graph captured the scale-free variant.** Kernel specialization is
   via `tl.constexpr`, so the variant picked at capture is baked into the
   graph. Capture ran without scales, so at replay `lora_scale` never took
   effect. Fix: capture now supplies an all-ones `LoRAScaleInputs` when the
   feature is on, so the scale-aware variant is captured
   (`lora_model_runner_mixin.py::maybe_select_dummy_loras`).
2. **All-ones buffer not refreshed.** `make_lora_scale_inputs` returned
   `None` when every request's scale was `1.0`, so `_update_request_scales`
   early-exited and the runtime buffer was not refreshed; replay then read a
   stale `token_to_req` left over from the previous step — cross-request
   cross-talk. Fix: when the feature is on the scale path stays on every
   step; an all-ones table makes the gather a no-op regardless of stale
   `token_to_req` (`punica_gpu.py::_update_request_scales`).

### Scope

Applies to the Punica expand path (linear LoRA layers). Not applied to
fused-MoE LoRA layers — those keep the adapter's default strength, and a
warning is logged once.

## Why is this not duplicating an existing PR?

Per the AGENTS.md duplicate checks (`gh pr list --search "52733 in:body"` and
`--search "per-request lora scale in:title"`), no open PR addresses this.
The issue itself proposes this direction and notes "Happy to open a PR".

## Test commands and results

Added `test_lora_expand_per_request_scale` to the existing
`tests/lora/test_punica_ops.py` suite (parametrized over devices). It puts
three requests on one adapter with scales `[0.25, 1.0, 2.0]` and asserts:
- each token's output equals the unscaled output times its own request's
  scale;
- an all-ones scale table is indistinguishable from not passing scales at
  all (guards the no-op / stock-behavior invariant).

```bash
.venv/bin/python -m pytest tests/lora/test_punica_ops.py \
  -k test_lora_expand_per_request_scale -v
```

GPU kernel equivalence vs a reference implementation was verified offline
with real ASR LoRA weights before this PR.

## Model evaluation results

A/B evaluation on a real ASR LoRA adapter (the motivating workload): A path
= current workaround (bake one adapter copy per scale, one slot per preset),
B path = this PR (one adapter + per-request scale).

| Condition | CN mean \|B-A\| | EN mean \|B-A\| |
| --- | --- | --- |
| off (noise floor, neither path uses scale) | 0.022% | — |
| 1.0 scale, pre-fix | 17.184% | — |
| 1.0 scale, post-fix | 0.038% | 0.028% |
| 0.7 scale | 0.000% | — |
| 0.9 scale | 0.060% | — |
| mixed-scale batch (0.5/0.7/0.9/1.0, 8-way concurrent) | 0.21%* | — |

\* Excluding 6 short utterances where the A path's `0.5` preset returned
empty (an A-path-only anomaly, reproduced in serial single-shot, unrelated
to this PR).

Across CN (12 test sets) + EN (19 test sets), `|B-A|` is at the off-path
noise floor; 10/19 EN test sets are byte-identical. Wall-clock: B/A within
±2% (noise; A and B ran on different GPUs). Startup: A 197.8s vs B 196.5s
(Δ = −1.3s, noise) — neither path pre-bakes adapter copies at startup.

<details>
<summary>Per-test-set WER breakdown (click to expand)</summary>

Character-error-rate %, A path = baked-per-scale adapter, B path = this PR.
Datasets are internal ASR test sets (the motivating workload is a real ASR
LoRA adapter); the point is A/B parity on the same sets, not absolute WER.

CN, scale = 1.0 (post-fix):

| testset | A | B | B−A |
| --- | --- | --- | --- |
| SPEECHIO_ASR_ZH00006 | 10.36 | 10.41 | +0.05 |
| SPEECHIO_ASR_ZH00007 | 10.03 | 10.06 | +0.03 |
| cidian_cn_zhpure8_vs_tencent_test_20 | 12.75 | 12.75 | +0.00 |
| cidian_cn_zhpure8_vs_tencent_test_20_dili_record_20 | 13.92 | 14.00 | +0.08 |
| cidian_cn_zhpure8_vs_tencent_test_dili_original_50 | 8.09 | 8.04 | −0.05 |
| cidian_cn_zhpure8_vs_tencent_test_dili_record_50 | 9.10 | 9.13 | +0.03 |
| cidiantongchuan_smoke_case_2603_10 | 13.58 | 13.56 | −0.02 |
| cn_ydnote_log_201907_100 | 11.93 | 11.83 | −0.10 |
| kiddict_test_185 | 9.82 | 9.82 | +0.00 |
| mc_fanyiguan_cn_202008_1400 | 5.41 | 5.45 | +0.04 |
| mc_kiddict_cn_202008_1000 | 17.28 | 17.24 | −0.04 |
| mc_mdict_cn_202008_1350 | 6.31 | 6.29 | −0.02 |
| **mean \|B−A\|** | | | **0.038** |

CN, scale = off (noise floor, neither path uses the scale path):

| testset | A | B | B−A |
| --- | --- | --- | --- |
| SPEECHIO_ASR_ZH00006 | 5.85 | 5.82 | −0.03 |
| SPEECHIO_ASR_ZH00007 | 6.10 | 6.12 | +0.02 |
| cidian_cn_zhpure8_vs_tencent_test_20 | 4.00 | 4.08 | +0.08 |
| cidian_cn_zhpure8_vs_tencent_test_20_dili_record_20 | 5.50 | 5.50 | +0.00 |
| cidian_cn_zhpure8_vs_tencent_test_dili_original_50 | 6.74 | 6.74 | +0.00 |
| cidian_cn_zhpure8_vs_tencent_test_dili_record_50 | 7.11 | 7.11 | +0.00 |
| cidiantongchuan_smoke_case_2603_10 | 11.19 | 11.17 | −0.02 |
| cn_ydnote_log_201907_100 | 9.47 | 9.53 | +0.06 |
| kiddict_test_185 | 8.59 | 8.59 | +0.00 |
| mc_fanyiguan_cn_202008_1400 | 4.53 | 4.52 | −0.01 |
| mc_kiddict_cn_202008_1000 | 14.15 | 14.12 | −0.03 |
| mc_mdict_cn_202008_1350 | 5.59 | 5.60 | +0.01 |
| **mean \|B−A\|** | | | **0.022** |

EN, scale = 1.0:

| testset | A | B | B−A |
| --- | --- | --- | --- |
| cidian-08_1349 | 24.55 | 24.50 | −0.05 |
| cidian_en_zhpure8_vs_tencent_test_dili_original_50 | 7.06 | 7.09 | +0.03 |
| cidian_en_zhpure8_vs_tencent_test_dili_record_50 | 8.26 | 8.20 | −0.06 |
| cidian_tongchuan_downloads16 | 6.43 | 6.43 | +0.00 |
| cidian_tongchuan_downloads18_waifang | 5.84 | 5.70 | −0.14 |
| cidian_tongchuan_tests30 | 16.02 | 16.02 | +0.00 |
| cidiantongchuan_guojicidian_wer0_1000 | 1.70 | 1.71 | +0.01 |
| cidiantongchuan_smoke_case_2603_15 | 10.25 | 10.25 | +0.00 |
| cn_accent_en_202111_121 | 1.49 | 1.49 | +0.00 |
| en_shortaudio_liutao_201906_1000 | 12.04 | 12.05 | +0.01 |
| fanyidan_en_202008_1000 | 21.69 | 21.69 | +0.00 |
| guojicidian_dev | 3.76 | 3.76 | +0.00 |
| guojicidian_v2 | 3.01 | 2.93 | −0.08 |
| librispeech_test_clean_2620 | 1.88 | 1.90 | +0.02 |
| librispeech_test_other_2939 | 3.71 | 3.70 | −0.01 |
| mc_fanyiguan_short_202111_1886 | 22.21 | 22.18 | −0.03 |
| realsi_837 | 13.08 | 13.02 | −0.06 |
| realsi_long_10 | 12.89 | 12.87 | −0.02 |
| test_jsonl | 2.12 | 2.11 | −0.01 |
| **mean \|B−A\|** | | | **0.028** |

CN kiddict_test_185, multi-scale (185 utts/scale):

| scale | A | B | B−A |
| --- | --- | --- | --- |
| 0.7 | 8.85 | 8.85 | +0.00 |
| 0.9 | 9.17 | 9.11 | −0.06 |
| 1.0 | 9.82 | 9.82 | +0.00 |
| **mean \|B−A\|** | | | **0.030** |

CN kiddict_test_185, mixed-scale batch (8-way concurrent, scale cycles
[0.5, 0.7, 0.9, 1.0] per utt; 179 utts after excluding 6 A-path 0.5
empties):

| path | WER | wall-clock |
| --- | --- | --- |
| A | 9.76% | 15.1s |
| B | 9.55% | 15.8s |
| \|B−A\| | 0.21% | +0.7s (noise) |

</details>

Flexibility: the A path rejects a non-preset scale (`0.6 not in preset
LORA_SCALES=[0.5,0.7,0.9,1.0]`); the B path accepts any continuous value.

## AI assistance disclosure

This change was developed with AI assistance (Claude). Every changed line
was reviewed and the relevant tests / evaluations were run by the human
submitter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
