### PR TITLE
[Bugfix] Surface TorchCodec video decode failures as client errors

### DIFF
--- a/docs/features/multimodal_inputs.md
+++ b/docs/features/multimodal_inputs.md
@@ -871,11 +871,19 @@ The following parameters only apply to the `torchcodec` backend:
 
 - `num_ffmpeg_threads`: Number of FFmpeg decoding threads. `0` (default) relies
   on the FFmpeg default, which is `min(cpu_count + 1, 16)`. This allows you to
-  control thread over-subscription.
+  control thread over-subscription. The default maximizes single-video decode
+  throughput and is the right choice when the server handles few concurrent
+  video requests (on a 16-core machine, decoding 768 frames of 1080p H.264
+  takes ~10 s at `0` vs ~49 s at `1`); on servers decoding many videos
+  concurrently, set `1` so each request uses one core instead of
+  oversubscribing all of them.
 - `seek_mode`: Seek mode for the decoder. `"exact"` (default) guarantees
   frame-accurate sampling by scanning the file when the decoder is created.
   `"approximate"` skips that scan for faster decoder creation, at the cost of
   relying on the file's metadata (which may yield less accurate seeking).
+  Files whose container metadata overstates the decodable frame count (common
+  with stream-copied cuts, e.g. `ffmpeg -c copy`) fail to decode in this mode;
+  vLLM reports this as a client error suggesting `"exact"`.
 
 ```bash
 # Example: TorchCodec with approximate seek mode and 4 FFmpeg threads

--- a/tests/multimodal/test_video.py
+++ b/tests/multimodal/test_video.py
@@ -1790,3 +1790,47 @@ def test_glm5next_read_frames_dense_walk_matches_stock(tmp_path):
         assert abs(round(float(np.asarray(frame).mean())) - idx) <= 1
     # One initial seek, then pure walking -- no re-seek churn.
     assert cap.seeks == 1
+
+
+def test_torchcodec_decode_failure_is_client_error(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """TorchCodec decode failures on user bytes must surface as ValueError
+    (-> HTTP 400), not RuntimeError (-> 500), mirroring the pynvvideocodec
+    backend. With seek_mode="approximate" the message must point the user
+    at "exact", since metadata-overstated frame counts are the common cause.
+    """
+    from vllm.multimodal.video_decoders.torchcodec import (
+        TorchCodecVideoBackendMixin,
+    )
+
+    monkeypatch.setattr(
+        "vllm.multimodal.video_decoders.torchcodec.check_torchcodec_available",
+        lambda: None,
+    )
+
+    def raise_runtime_error(data, **kwargs):
+        raise RuntimeError(
+            "Requested next frame while there are no more frames left to decode."
+        )
+
+    monkeypatch.setattr(
+        TorchCodecVideoBackendMixin,
+        "make_torchcodec_decoder",
+        staticmethod(raise_runtime_error),
+    )
+
+    with pytest.raises(
+        ValueError, match=r"Failed to decode video with the torchcodec backend"
+    ) as exc_info:
+        VideoBackend.load_bytes(b"fake video", num_frames=4, backend="torchcodec")
+    assert isinstance(exc_info.value.__cause__, RuntimeError)
+    assert "seek_mode" not in str(exc_info.value)
+
+    with pytest.raises(ValueError, match=r"retry with seek_mode='exact'"):
+        VideoBackend.load_bytes(
+            b"fake video",
+            num_frames=4,
+            backend="torchcodec",
+            seek_mode="approximate",
+        )

--- a/vllm/multimodal/video_decoders/torchcodec.py
+++ b/vllm/multimodal/video_decoders/torchcodec.py
@@ -38,25 +38,38 @@ def decode_torchcodec(
     device: str = "cpu",
 ) -> tuple[npt.NDArray | torch.Tensor, VideoSourceMetadata, list[int], list[int]]:
     check_torchcodec_available()
-    decoder = TorchCodecVideoBackendMixin.make_torchcodec_decoder(
-        data,
-        num_ffmpeg_threads=num_ffmpeg_threads,
-        seek_mode=seek_mode,
-        device=device,
-    )
-    check_frame_pixel_limit(
-        decoder.metadata.width or 0,
-        decoder.metadata.height or 0,
-    )
-    source = loader_cls._prepare_source(
-        TorchCodecVideoBackendMixin.get_torchcodec_metadata(decoder)
-    )
-    frame_idx = loader_cls.compute_frames_index_to_sample(
-        source=source, target=target, **sampling_kwargs
-    )
-    frames, valid = TorchCodecVideoBackendMixin.decode_torchcodec_frames(
-        decoder, frame_idx, device=device
-    )
+    # TorchCodec surfaces decode failures on user-supplied bytes as
+    # RuntimeError; convert to ValueError so the server returns a client
+    # error instead of a 500 (same pattern as the pynvvideocodec backend).
+    try:
+        decoder = TorchCodecVideoBackendMixin.make_torchcodec_decoder(
+            data,
+            num_ffmpeg_threads=num_ffmpeg_threads,
+            seek_mode=seek_mode,
+            device=device,
+        )
+        check_frame_pixel_limit(
+            decoder.metadata.width or 0,
+            decoder.metadata.height or 0,
+        )
+        source = loader_cls._prepare_source(
+            TorchCodecVideoBackendMixin.get_torchcodec_metadata(decoder)
+        )
+        frame_idx = loader_cls.compute_frames_index_to_sample(
+            source=source, target=target, **sampling_kwargs
+        )
+        frames, valid = TorchCodecVideoBackendMixin.decode_torchcodec_frames(
+            decoder, frame_idx, device=device
+        )
+    except RuntimeError as exc:
+        msg = f"Failed to decode video with the torchcodec backend: {exc}"
+        if seek_mode == "approximate":
+            msg += (
+                " This can happen with seek_mode='approximate' when the "
+                "file's container metadata overstates the decodable frame "
+                "count; retry with seek_mode='exact'."
+            )
+        raise ValueError(msg) from exc
     return frames, source, frame_idx, valid
 
 


### PR DESCRIPTION
## Purpose

TorchCodec raises `RuntimeError` when decoding user-supplied video bytes
fails. That exception type has no handler in the exception-handler registry
(`ValueError`/`VLLMError` map to 400; raw `RuntimeError` falls through to the
safety net), so the server returns **HTTP 500 with an ASGI traceback** for
what is a client-input problem.

The most common user-triggerable case: `seek_mode="approximate"` on a file
whose container metadata overstates the decodable frame count — e.g. any
stream-copied cut (`ffmpeg -c copy`). Frame sampling targets an index past
the real end and torchcodec raises `Requested next frame while there are no
more frames left to decode.` Reproduced end-to-end on a Qwen3.8-27B-FP8
server: request → 500.

This PR converts `RuntimeError` from the torchcodec branch of
`VideoBackend.load_bytes` to `ValueError` (chained with `from exc`), exactly
mirroring the existing pattern in the `pynvvideocodec` backend
(`raise ValueError("Invalid or unsupported video file.") from exc`). When
`seek_mode="approximate"` is in effect, the message additionally tells the
user to retry with `"exact"`:

```
HTTP 400
Failed to decode video with the torchcodec backend: Requested next frame
while there are no more frames left to decode. This can happen with
seek_mode='approximate' when the file's container metadata overstates the
decodable frame count; retry with seek_mode='exact'.
```

Bundled docs: the "Video Decoding Backend" section gains operational
guidance for the two TorchCodec knobs — when `num_ffmpeg_threads=0`
(default) beats `1` and vice versa, with measured numbers (768 frames of
1080p H.264 on 16 cores: ~10 s at `0` vs ~49 s at `1`), and the
approximate-mode metadata caveat with its new client-error behavior.

## Duplicate check

Searched open PRs/issues for torchcodec error handling and video decode
error mapping: no existing work. Related context: #46609 (torchcodec
backend introduction, where `seek_mode` exposure was discussed) and the
registry's own TODO to migrate raw-exception fallbacks to `VLLMError`.

## Test Plan

- New `test_torchcodec_decode_failure_is_client_error` in
  `tests/multimodal/test_video.py`: RuntimeError from the decoder surfaces
  as `ValueError` with the original exception chained; the seek-mode hint
  appears only when `seek_mode="approximate"`.
- `pytest tests/multimodal/test_video.py -k torchcodec_decode_failure -q`
- `pre-commit run --files <changed files>`

## Test Result

- `1 passed`; pre-commit all hooks pass (ruff, mypy, markdownlint, DCO).
- E2E on a live Qwen3.8-27B-FP8 server (torchcodec backend): per-request
  `media_io_kwargs: {"video": {"seek_mode": "approximate"}}` on a
  stream-copied 60 s cut now returns the HTTP 400 above (previously 500 +
  ASGI traceback); the same file decodes fine with default `exact`
  (16.5 s request, 35,149 prompt tokens); unrelated requests unaffected.

## AI Disclosure

Developed with AI assistance (Claude Fable 5). The human submitter has
reviewed every changed line and run the tests above.
