### PR TITLE
[Spec Decode] Fix skipped drafter draft token clearing

### DIFF
--- a/tests/v1/spec_decode/test_dflash_lookahead.py
+++ b/tests/v1/spec_decode/test_dflash_lookahead.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-from types import SimpleNamespace
+from types import MethodType, SimpleNamespace
 
 import torch
 
@@ -152,3 +152,26 @@ def test_dflash_drafter_window_reserves_bonus_token():
         speculative_config=SimpleNamespace(use_dflash=lambda: False),
     )
     assert input_fits_in_drafter(plain_runner, SimpleNamespace(max_seq_len=97))
+
+
+def test_skipped_drafter_returns_empty_draft_tokens():
+    runner = SimpleNamespace(
+        num_spec_tokens=NUM_SPECULATIVE_TOKENS,
+        input_batch=SimpleNamespace(req_ids=["req0", "req1"]),
+        _draft_token_ids=None,
+        _draft_token_req_ids=None,
+        _draft_probs=object(),
+        _draft_prob_req_ids=["old_req"],
+    )
+    runner._get_draft_token_ids_cpu = MethodType(
+        GPUModelRunner._get_draft_token_ids_cpu, runner
+    )
+
+    GPUModelRunner._set_empty_draft_token_ids(runner)
+    draft_token_ids = GPUModelRunner.take_draft_token_ids(runner)
+
+    assert draft_token_ids is not None
+    assert draft_token_ids.req_ids == ["req0", "req1"]
+    assert draft_token_ids.draft_token_ids == [[], []]
+    assert runner._draft_probs is None
+    assert runner._draft_prob_req_ids is None

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -4821,17 +4821,11 @@ class GPUModelRunner(
                 draft_after_bookkeeping = True
 
             if not input_fits_in_drafter:
-                # Zero out draft tokens so the scheduler doesn't schedule
-                # stale drafts from the previous step.
-                # For Nemotron-H: it is necessary to zero out the draft tokens,
-                # otherwise the stale tokens will corrupt Mamba recurrent
+                # Clear draft tokens so the scheduler doesn't schedule stale
+                # drafts from the previous step.
+                # For Nemotron-H: stale tokens will corrupt Mamba recurrent
                 # state and logprobs for sequences near max_model_len.
-                self._draft_token_ids = torch.zeros(
-                    1, device=self.device, dtype=torch.int32
-                ).expand(len(self.input_batch.req_ids), self.num_spec_tokens)
-                self._draft_probs = None
-                self._draft_prob_req_ids = None
-                self._copy_draft_token_ids_to_cpu(scheduler_output, zeros_only=True)
+                self._set_empty_draft_token_ids()
 
         with record_function_or_nullcontext("gpu_model_runner: bookkeep"):
             (
@@ -5008,9 +5002,13 @@ class GPUModelRunner(
         draft_token_ids, req_ids = self._get_draft_token_ids_cpu()
         return DraftTokenIds(req_ids, draft_token_ids)
 
-    def _copy_draft_token_ids_to_cpu(
-        self, scheduler_output: "SchedulerOutput", zeros_only: bool = False
-    ) -> None:
+    def _set_empty_draft_token_ids(self) -> None:
+        self._draft_token_ids = [[] for _ in self.input_batch.req_ids]
+        self._draft_probs = None
+        self._draft_prob_req_ids = None
+        self._draft_token_req_ids = self.input_batch.req_ids.copy()
+
+    def _copy_draft_token_ids_to_cpu(self, scheduler_output: "SchedulerOutput") -> None:
         if torch.is_tensor(self._draft_token_ids):
             assert isinstance(self._draft_token_ids, torch.Tensor)
             self.prev_num_spec_tokens = self._draft_token_ids.shape[1]
@@ -5034,20 +5032,16 @@ class GPUModelRunner(
         num_reqs = draft_token_ids.shape[0]
         num_spec_tokens = draft_token_ids.shape[1]
         with torch.cuda.stream(self.draft_token_ids_copy_stream):
-            if not zeros_only:
-                # Trigger async copy of draft token ids to cpu.
-                self.draft_token_ids_copy_stream.wait_stream(default_stream)
-                self.draft_token_ids_cpu[:num_reqs, :num_spec_tokens].copy_(
-                    draft_token_ids, non_blocking=True
-                )
-            else:
-                # No copy needed, just zero-out cpu tensor.
-                self.draft_token_ids_cpu[:num_reqs, :num_spec_tokens] = 0
+            # Trigger async copy of draft token ids to cpu.
+            self.draft_token_ids_copy_stream.wait_stream(default_stream)
+            self.draft_token_ids_cpu[:num_reqs, :num_spec_tokens].copy_(
+                draft_token_ids, non_blocking=True
+            )
             self.draft_token_ids_event.record()
 
     def _get_draft_token_ids_cpu(self) -> tuple[list[list[int]], list[str]]:
         if isinstance(self._draft_token_ids, list):
-            return self._draft_token_ids, self.input_batch.req_ids
+            return self._draft_token_ids, self._draft_token_req_ids or []
         req_ids = self._draft_token_req_ids
         if req_ids is None:
             return [], []


### PR DESCRIPTION
Closes #52756

## Summary
- return empty draft-token lists when the drafter is skipped because the batch exceeds the drafter max model length
- avoid treating token id 0 as a real speculative draft in the scheduler-facing output
- keep request ids tied to list-backed draft-token results

## Duplicate-work checks
- `gh issue view 52756 --repo vllm-project/vllm --comments`: no comments
- `gh pr list --repo vllm-project/vllm --state open --search "52756 in:body"`: no matching PRs
- `gh pr list --repo vllm-project/vllm --state open --search "MTP max_model_len zero token drafts"`: no duplicate PRs found; returned unrelated open PRs

## Tests
- `pre-commit run --files vllm/v1/worker/gpu_model_runner.py tests/v1/spec_decode/test_dflash_lookahead.py`: passed
- `.venv/bin/python -m pytest tests/v1/spec_decode/test_dflash_lookahead.py::test_skipped_drafter_returns_empty_draft_tokens -vv -x --tb=short`: test passed, then local macOS environment segfaulted during pytest teardown in `torch.accelerator.memory.empty_host_cache` (exit 139)

## Model evals
- Not run. This change only affects the already-skipped drafter path and does not change generation when the drafter is eligible to run; no GPU serving environment was available locally.

AI assistance was used to prepare this change.