### PR TITLE
[ROCM][CI] Attention test speedup

### DIFF
--- a/tests/kernels/attention/test_attention.py
+++ b/tests/kernels/attention/test_attention.py
@@ -14,6 +14,8 @@ from vllm.platforms import current_platform
 from vllm.utils.mem_utils import get_max_shared_memory_bytes
 from vllm.utils.torch_utils import set_random_seed
 
+pytestmark = pytest.mark.skip_global_cleanup
+
 FLOAT32_BYTES = torch.finfo(torch.float).bits // 8
 # This will change depending on the compute capability.
 # - 512 as a buffer

--- a/tests/kernels/attention/test_cache.py
+++ b/tests/kernels/attention/test_cache.py
@@ -12,6 +12,8 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import scaled_deq
 from vllm.platforms import current_platform
 from vllm.utils.torch_utils import nvfp4_split_data_scale, set_random_seed
 
+pytestmark = pytest.mark.skip_global_cleanup
+
 COPYING_DIRECTION = [("cuda", "cpu"), ("cuda", "cuda"), ("cpu", "cuda")]
 DTYPES = [torch.bfloat16, torch.float]
 NUM_TOKENS = [42]  # Arbitrary values for testing

--- a/tests/kernels/attention/test_cutlass_mla_decode.py
+++ b/tests/kernels/attention/test_cutlass_mla_decode.py
@@ -11,6 +11,8 @@ from vllm.platforms import current_platform
 from vllm.triton_utils import triton
 from vllm.utils.platform_utils import num_compute_units
 
+pytestmark = pytest.mark.skip_global_cleanup
+
 
 def cal_diff(
     x: torch.Tensor,

--- a/tests/kernels/attention/test_flashmla.py
+++ b/tests/kernels/attention/test_flashmla.py
@@ -16,6 +16,8 @@ from vllm.v1.attention.ops.flashmla import (
     is_flashmla_dense_supported,
 )
 
+pytestmark = pytest.mark.skip_global_cleanup
+
 
 def cal_diff(
     x: torch.Tensor, y: torch.Tensor, name: str, use_fp8: bool = False

--- a/tests/kernels/attention/test_merge_attn_states.py
+++ b/tests/kernels/attention/test_merge_attn_states.py
@@ -15,6 +15,14 @@ from vllm.v1.attention.ops.triton_merge_attn_states import (
     merge_attn_states as merge_attn_states_triton,
 )
 
+pytestmark = [
+    pytest.mark.skip_global_cleanup,
+    pytest.mark.skipif(
+        not current_platform.is_cuda_alike(),
+        reason="merge_attn_states kernels require CUDA or ROCm.",
+    ),
+]
+
 
 # Naive PyTorch Implements section 2.2 of https://www.arxiv.org/pdf/2501.01005
 # can be used to combine partial attention results (in the split-KV case)
@@ -153,12 +161,6 @@ def test_merge_attn_states(
     input_dtype: torch.dtype,
     use_fp8: bool,
 ):
-    if not current_platform.is_cuda():
-        pytest.skip(
-            "Currently only support compare triton merge_attn_states "
-            "with custom cuda merge_attn_states kernel"
-        )
-
     NUM_TOKENS = num_tokens
     NUM_HEADS = num_query_heads
     HEAD_SIZE = head_size

--- a/tests/kernels/attention/test_prefix_prefill.py
+++ b/tests/kernels/attention/test_prefix_prefill.py
@@ -17,6 +17,8 @@ from vllm.v1.attention.ops.chunked_prefill_paged_decode import (
 )
 from vllm.v1.attention.ops.prefix_prefill import context_attention_fwd
 
+pytestmark = pytest.mark.skip_global_cleanup
+
 NUM_HEADS = [64]
 NUM_QUERIES_PER_KV = [1, 64]
 HEAD_SIZES = [24, 128]

--- a/tests/kernels/attention/test_triton_decode_attention.py
+++ b/tests/kernels/attention/test_triton_decode_attention.py
@@ -8,6 +8,8 @@ from vllm.platforms import current_platform
 from vllm.utils.math_utils import cdiv
 from vllm.v1.attention.ops.triton_decode_attention import decode_attention_fwd
 
+pytestmark = pytest.mark.skip_global_cleanup
+
 DEVICE_TYPE = current_platform.device_type
 
 

--- a/tests/kernels/attention/test_triton_unified_attention.py
+++ b/tests/kernels/attention/test_triton_unified_attention.py
@@ -11,6 +11,8 @@ from vllm.utils.torch_utils import set_random_seed
 from vllm.v1.attention.ops.triton_unified_attention import unified_attention
 from vllm.v1.kv_cache_interface import KVQuantMode
 
+pytestmark = pytest.mark.skip_global_cleanup
+
 DEVICE_TYPE = current_platform.device_type
 
 NUM_HEADS = [(4, 4), (8, 2), (5, 1)]

--- a/tests/kernels/attention/test_triton_unified_attention_diffkv.py
+++ b/tests/kernels/attention/test_triton_unified_attention_diffkv.py
@@ -21,6 +21,8 @@ from vllm.v1.attention.ops.triton_unified_attention_diffkv import (
     unified_attention_diffkv,
 )
 
+pytestmark = pytest.mark.skip_global_cleanup
+
 DEVICE_TYPE = current_platform.device_type
 
 # (num_query_heads, num_kv_heads): MHA, GQA, and the num_kv_heads==1


### PR DESCRIPTION
## Purpose

Two independent problems make `tests/kernels/attention` far slower than the work it actually performs, and both are addressed here.

**1. `test_merge_attn_states.py` skips its entire matrix on ROCm without reason.**

The test gates all 2592 parametrized cases behind an "only CUDA supports the custom merge_attn_states kernel" check. That is no longer accurate: the kernel source is not CUDA-gated in the build, so it is compiled for ROCm as well, and the op is registered and produces correct results there. The same file already exercises the native kernel on ROCm through its `both_empty` case, which passes today so the wide skip contradicts a test sitting next to it.

The platform check moves from the test body to a module-level condition that accepts CUDA and ROCm. This unlocks 2592 cases of real kernel coverage on ROCm.

Because the check was evaluated inside the test body, every skipped case still paid full setup and teardown, so the group was spending minutes to decide not to test anything.

**2. Pure kernel modules pay a global cleanup after every single test.**

An autouse fixture tears down the distributed environment and empties the allocator caches after each test. The modules touched here do not build an engine and do not initialize distributed state, so there is nothing for that teardown to clean — but it still costs a garbage collection and a cache flush per test, which dominates the group's runtime.

These modules are marked with the existing `skip_global_cleanup` marker, the same mechanism already used at module level elsewhere in the test suite.

Module selection is deliberately conservative. On ROCm the global cleanup also refreshes AITER class-level state that `monkeypatch` does not restore, so every module that touches environment variables or AITER, plus one that patches platform classes, is intentionally left untouched. Nothing is given up by that: the largest modules account for nearly all of the group's runtime.

## Test Plan

Full `tests/kernels/attention` run before and after the change, on a single MI300, same flags and same GPU in both cases. The result was then confirmed a second time with a default environment, to rule out any influence of the flags used while measuring. `test_merge_attn_states.py` was additionally measured on its own, and the unlocked cases were verified independently against the Triton reference path.

## Test Result

Whole group, single MI300:

| | Before | After |
|---|---|---|
| Wall time | 46:34 | 10:08 |
| Passed | 3207 | 5808 |
| Skipped | 3703 | 1111 |
| Failed | 0 | 0 |

The group is 4.6x faster while running 2601 more tests, with no failures.

`test_merge_attn_states.py` alone goes from 7:23 (6 passed, 2592 skipped) to 0:30 with all 2598 cases passing, fp8 variants included.

All numbers above are from a local MI300. A speedup is expected in CI as well, since the removed per-test cost is not hardware specific, but the magnitude there is not measured here.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

