### PR TITLE
[Core][Bugfix] Fix async scheduling stale output and dual-scheduling race in resumable streaming sessions

### DIFF
--- a/tests/v1/streaming_input/test_scheduler_streaming.py
+++ b/tests/v1/streaming_input/test_scheduler_streaming.py
@@ -13,6 +13,7 @@ from vllm.multimodal.inputs import (
     PlaceholderRange,
 )
 from vllm.sampling_params import SamplingParams
+from vllm.v1.core.sched.async_scheduler import AsyncScheduler
 from vllm.v1.core.sched.scheduler import Scheduler
 from vllm.v1.engine import FinishReason
 from vllm.v1.kv_cache_interface import (
@@ -73,6 +74,40 @@ def create_scheduler() -> Scheduler:
         ],
     )
     return Scheduler(
+        vllm_config=vllm_config,
+        kv_cache_config=kv_cache_config,
+        log_stats=True,
+        structured_output_manager=StructuredOutputManager(vllm_config),
+        block_size=16,
+        hash_block_size=16,
+    )
+
+
+def create_async_scheduler() -> AsyncScheduler:
+    vllm_config = VllmConfig(device_config=DeviceConfig("cpu"))
+    vllm_config.model_config = MagicMock()
+    vllm_config.model_config.skip_tokenizer_init = True
+    vllm_config.model_config.is_multimodal_model = False
+    vllm_config.model_config.is_encoder_decoder = False
+    vllm_config.model_config.is_diffusion = False
+    vllm_config.model_config.max_model_len = 1024
+    vllm_config.model_config.enable_return_routed_experts = False
+    vllm_config.cache_config = MagicMock()
+    vllm_config.cache_config.num_gpu_blocks = 1000
+    vllm_config.cache_config.enable_prefix_caching = False
+    kv_cache_config = KVCacheConfig(
+        num_blocks=1000,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["layer"],
+                FullAttentionSpec(
+                    block_size=16, num_kv_heads=1, head_size=1, dtype=torch.float32
+                ),
+            )
+        ],
+    )
+    return AsyncScheduler(
         vllm_config=vllm_config,
         kv_cache_config=kv_cache_config,
         log_stats=True,
@@ -577,3 +612,73 @@ class TestStreamingScheduler(unittest.TestCase):
             cached_state_cycle1["prompt_token_ids"]
             is not cached_state_cycle3["prompt_token_ids"]
         ), "Cached states from different cycles should be independent objects."
+
+    def test_streaming_async_stale_in_flight_tokens(self):
+        """Test that in-flight tokens from a finished turn in AsyncScheduler
+        are cleanly marked as stale and dropped without causing placeholder
+        underflow or dual-scheduling."""
+        scheduler = create_async_scheduler()
+
+        req = DummyRequest(
+            request_id="session_stale_async",
+            prompt_token_ids=[1, 2, 3],
+            resumable=True,
+            max_tokens=10,
+        )
+        scheduler.add_request(req)
+
+        # Dispatch step A (Turn 1 Decode 1)
+        out_a = scheduler.schedule()
+        req.is_prefill_chunk = False
+        scheduler._update_after_schedule(out_a)
+
+        # Pre-schedule step B into async pipeline (Turn 1 Decode 2)
+        out_b = scheduler.schedule()
+        req.is_prefill_chunk = False
+        scheduler._update_after_schedule(out_b)
+
+        assert req.num_in_flight_tokens > 0
+        assert req.num_output_placeholders > 0
+
+        # Enqueue Turn 2
+        turn2 = DummyRequest(
+            request_id="session_stale_async",
+            prompt_token_ids=[4, 5],
+            resumable=True,
+            max_tokens=10,
+        )
+        scheduler.add_request(turn2)
+
+        # Step A returns with stop token, completing Turn 1
+        req.num_computed_tokens = 3
+        mro_a = ModelRunnerOutput(
+            req_ids=["session_stale_async"],
+            req_id_to_index={"session_stale_async": 0},
+            sampled_token_ids=[[STOP_TOKEN]],
+            logprobs=None,
+            prompt_logprobs_dict={"session_stale_async": None},
+            pooler_output=[],
+        )
+        scheduler.update_from_output(out_a, mro_a)
+
+        # In-flight tokens must be marked stale, placeholders reset
+        assert req.drop_stale_output is True
+        assert req.num_stale_output_tokens == req.num_in_flight_tokens
+        assert req.num_output_placeholders == 0
+
+        # Step B returns late. Output must be dropped and not underflow placeholders
+        mro_b = ModelRunnerOutput(
+            req_ids=["session_stale_async"],
+            req_id_to_index={"session_stale_async": 0},
+            sampled_token_ids=[[100]],
+            logprobs=None,
+            prompt_logprobs_dict={"session_stale_async": None},
+            pooler_output=[],
+        )
+        scheduler.update_from_output(out_b, mro_b)
+        assert req.num_output_placeholders == 0
+
+        # Next scheduling cycle schedules Turn 2 cleanly
+        out_c = scheduler.schedule()
+        assert "session_stale_async" in out_c.num_scheduled_tokens
+        assert req.status == RequestStatus.RUNNING

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -787,6 +787,13 @@ class Scheduler(SchedulerInterface):
                 request = request_queue.peek_request()
                 request_id = request.request_id
 
+                if (
+                    request.status == RequestStatus.RUNNING
+                    or request_id in num_scheduled_tokens
+                ):
+                    request_queue.pop_request()
+                    continue
+
                 # try to promote blocked statuses while traversing skipped queue.
                 if self._is_blocked_waiting_status(
                     request.status
@@ -1491,6 +1498,10 @@ class Scheduler(SchedulerInterface):
         session.num_prompt_tokens = len(session.prompt_token_ids)
         session.arrival_time = update.arrival_time
         session.sampling_params = update.sampling_params
+        # Mark remaining in-flight tokens from the prior turn as stale.
+        session.drop_stale_output = True
+        session.num_stale_output_tokens = session.num_in_flight_tokens
+        session.num_output_placeholders = 0
         if session.status == RequestStatus.WAITING_FOR_STREAMING_REQ:
             self.num_waiting_for_streaming_input -= 1
         session.status = RequestStatus.WAITING


### PR DESCRIPTION


## Purpose
Fixes #52693.

Fixes an `EngineDeadError` in `AsyncScheduler` when multi-turn resumable streaming sessions run with async batch queuing (`batch_queue_size > 1`).

### Root Cause
1. **Stale In-Flight Output Delivery in `AsyncScheduler`**: When a streaming session finishes a turn and transitions to the next turn (`_update_request_as_session`), in-flight batches from the prior turn may still be running in the GPU pipeline. When returned, they are not marked as stale, causing `_update_request_with_output` to decrement `request.num_output_placeholders` below zero (`assert request.num_output_placeholders >= 0` -> `AssertionError`) and corrupting the new turn with stale tokens.
2. **Dual-Scheduling on Waiting Queue**: If a session is in `self.running` and simultaneously present in the waiting queue during pipelined continuation, it can be scheduled by both the running loop and waiting loop in the same `schedule()` step.

### Solution
1. In `_update_request_as_session`, mark existing in-flight tokens from the previous turn as stale and drop them:
   ```python
   session.drop_stale_output = True
   session.num_stale_output_tokens = session.num_in_flight_tokens
   session.num_output_placeholders = 0
   ```
2. In `schedule()`, safely drop duplicate entries from the waiting queue if the request has already been claimed by the running loop in the current step.
3. Added regression unit test `test_streaming_async_stale_in_flight_tokens` in `tests/v1/streaming_input/test_scheduler_streaming.py`.

## Test Plan
1. **Unit tests**:
   ```bash
   .venv/bin/pytest tests/v1/streaming_input/test_scheduler_streaming.py -v
   ```
2. **Code style & format checks**:
   ```bash
   .venv/bin/ruff check vllm/v1/core/sched/scheduler.py tests/v1/streaming_input/test_scheduler_streaming.py
   .venv/bin/ruff format --check vllm/v1/core/sched/scheduler.py tests/v1/streaming_input/test_scheduler_streaming.py
   ```
3. **E2E CUDA async pipelined streaming verification** on RTX 4090.

## Test Result
1. **Unit Test Output**:
   ```text
   tests/v1/streaming_input/test_scheduler_streaming.py::TestStreamingScheduler::test_add_request PASSED [ 11%]
   tests/v1/streaming_input/test_scheduler_streaming.py::TestStreamingScheduler::test_process_streaming_requests_with_finish_session PASSED [ 22%]
   tests/v1/streaming_input/test_scheduler_streaming.py::TestStreamingScheduler::test_streaming_async_stale_in_flight_tokens PASSED [ 33%]
   tests/v1/streaming_input/test_scheduler_streaming.py::TestStreamingScheduler::test_streaming_e2e_lifecycle PASSED [ 44%]
   tests/v1/streaming_input/test_scheduler_streaming.py::TestStreamingScheduler::test_streaming_request_session_update PASSED [ 55%]
   tests/v1/streaming_input/test_scheduler_streaming.py::TestStreamingScheduler::test_update_request_as_session PASSED [ 66%]
   tests/v1/streaming_input/test_scheduler_streaming.py::TestStreamingScheduler::test_update_request_as_session_max_token PASSED [ 77%]
   tests/v1/streaming_input/test_scheduler_streaming.py::TestStreamingScheduler::test_update_request_as_session_with_multimodal PASSED [ 88%]
   tests/v1/streaming_input/test_scheduler_streaming.py::TestStreamingScheduler::test_update_request_as_session_with_output_tokens PASSED [100%]
   ======================== 9 passed in 2.37s ========================
   ```

2. **Linter & Format Output**:
   ```text
   All checks passed!
   2 files already formatted
   ```

3. **E2E Results**:
   Verified that multi-turn streaming inputs with 1-step stops and continuous async generation complete smoothly without `AssertionError` or `EngineDeadError`.

---
*AI Assistance Disclosure: AI assistance was used for drafting tests and formatting the PR description. All code logic and test executions have been human-reviewed and verified.*