### PR TITLE
[Model][torch.compile] Support torch.compile for SigLIP embeddings

### DIFF
--- a/tests/models/multimodal/pooling/test_siglip.py
+++ b/tests/models/multimodal/pooling/test_siglip.py
@@ -7,6 +7,8 @@ import pytest
 import torch
 from transformers import SiglipModel
 
+from vllm.model_executor.models.siglip import SiglipEmbeddingModel
+
 from ....conftest import IMAGE_ASSETS, HfRunner, PromptImageInput, VllmRunner
 from ...utils import check_embeddings_close
 
@@ -28,6 +30,118 @@ MODELS = [
     # Different image embedding dim than text_config.hidden_size
     "google/siglip2-giant-opt-patch16-384",
 ]
+
+
+def _reference_flip_sequences_by_position_ids(
+    features: torch.Tensor,
+    position_ids: torch.Tensor,
+) -> torch.Tensor:
+    if len(features) <= 1:
+        return features
+
+    boundary_mask = position_ids[1:] <= position_ids[:-1]
+    boundary_mid = torch.where(boundary_mask)[0] + 1
+    boundary_indices = torch.cat(
+        [
+            torch.zeros(1, dtype=boundary_mid.dtype, device=features.device),
+            boundary_mid,
+            torch.full(
+                (1,),
+                len(features),
+                dtype=boundary_mid.dtype,
+                device=features.device,
+            ),
+        ]
+    )
+
+    lengths = boundary_indices[1:] - boundary_indices[:-1]
+    starts = boundary_indices[:-1]
+    ends = boundary_indices[1:]
+    sequence_ids = torch.arange(
+        len(lengths), dtype=boundary_mid.dtype, device=features.device
+    ).repeat_interleave(lengths)
+    current_positions = torch.arange(
+        len(features), dtype=boundary_mid.dtype, device=features.device
+    )
+    flip_indices = starts[sequence_ids] + ends[sequence_ids] - (1 + current_positions)
+    return features[flip_indices]
+
+
+def _flip_sequences_by_position_ids(
+    features: torch.Tensor,
+    position_ids: torch.Tensor,
+) -> torch.Tensor:
+    return SiglipEmbeddingModel._flip_sequences_by_position_ids(
+        None, features, position_ids
+    )
+
+
+@pytest.mark.parametrize(
+    "position_ids",
+    [
+        [],
+        [0],
+        [0, 1, 2, 3],
+        [0, 1, 0, 1, 2],
+        [3, 2, 1, 0, 2, 1, 0],
+        [0, 0, 0],
+    ],
+)
+@pytest.mark.skip_global_cleanup
+def test_flip_sequences_by_position_ids_matches_reference(
+    position_ids: list[int],
+) -> None:
+    position_ids_tensor = torch.tensor(position_ids, dtype=torch.long)
+    features = torch.arange(len(position_ids) * 3, dtype=torch.float32).reshape(
+        len(position_ids), 3
+    )
+
+    actual = _flip_sequences_by_position_ids(features, position_ids_tensor)
+    expected = _reference_flip_sequences_by_position_ids(features, position_ids_tensor)
+
+    torch.testing.assert_close(actual, expected)
+
+
+@pytest.mark.skip_global_cleanup
+def test_flip_sequences_by_position_ids_matches_reference_randomized() -> None:
+    generator = torch.Generator().manual_seed(0)
+
+    for _ in range(100):
+        remaining_tokens = 64
+        sequence_lengths = []
+        while remaining_tokens:
+            sequence_length = int(
+                torch.randint(
+                    1,
+                    min(remaining_tokens, 8) + 1,
+                    (1,),
+                    generator=generator,
+                )
+            )
+            sequence_lengths.append(sequence_length)
+            remaining_tokens -= sequence_length
+
+        position_ids = torch.cat([torch.arange(length) for length in sequence_lengths])
+        features = torch.randn(position_ids.numel(), 5, generator=generator)
+
+        actual = _flip_sequences_by_position_ids(features, position_ids)
+        expected = _reference_flip_sequences_by_position_ids(features, position_ids)
+
+        torch.testing.assert_close(actual, expected)
+
+
+@pytest.mark.skipif(not hasattr(torch, "compile"), reason="requires torch.compile")
+@pytest.mark.skip_global_cleanup
+def test_flip_sequences_by_position_ids_supports_torch_compile() -> None:
+    position_ids = torch.tensor([0, 1, 2, 0, 1, 0], dtype=torch.long)
+    features = torch.randn(position_ids.numel(), 4)
+
+    compiled_flip = torch.compile(_flip_sequences_by_position_ids, fullgraph=True)
+
+    actual = compiled_flip(features, position_ids)
+    expected = _reference_flip_sequences_by_position_ids(features, position_ids)
+
+    torch.testing.assert_close(actual, expected)
 
 
 def _run_test(

--- a/vllm/model_executor/models/siglip.py
+++ b/vllm/model_executor/models/siglip.py
@@ -15,6 +15,7 @@ from transformers import (
     SiglipVisionConfig,
 )
 
+from vllm.compilation.decorators import support_torch_compile
 from vllm.config import VllmConfig
 from vllm.config.multimodal import BaseDummyOptions
 from vllm.distributed import divide, get_tensor_model_parallel_world_size
@@ -54,9 +55,7 @@ from vllm.multimodal.processing import (
     TimingContext,
 )
 from vllm.sequence import IntermediateTensors
-from vllm.utils.gpu_sync_debug import gpu_sync_allowed
 from vllm.utils.tensor_schema import TensorSchema, TensorShape
-from vllm.utils.torch_utils import async_tensor_h2d
 
 from .clip import dual_encoder_has_text_tokens, merge_dual_encoder_text_and_vision
 from .interfaces import MultiModalEmbeddings, SupportsMultiModal, SupportsQuant
@@ -887,6 +886,7 @@ class SiglipTextEmbeddings(nn.Module):
 
 
 # Assume EOS token corresponds to CLS token in text model
+@support_torch_compile
 @default_pooling_type(seq_pooling_type="CLS")
 @MULTIMODAL_REGISTRY.register_processor(
     SiglipMultiModalProcessor,
@@ -980,38 +980,36 @@ class SiglipEmbeddingModel(nn.Module, SupportsMultiModal, SupportsQuant):
         SigLIP position_ids are reversed within each sequence. This method detects
         sequence boundaries and flips each sequence individually.
         """
-        if len(features) == 1:
+        num_tokens = features.shape[0]
+        if num_tokens <= 1:
             return features
 
-        # Detect sequence boundaries where position_ids decrease
-        position_diffs = position_ids[1:] - position_ids[:-1]
-        boundary_mask = position_diffs <= 0
+        token_indices = torch.arange(num_tokens, device=features.device)
+        boundary_mask = position_ids[1:] <= position_ids[:-1]
 
-        with gpu_sync_allowed():
-            boundary_mid_cpu = torch.where(boundary_mask.cpu())[0] + 1
-
-        zero = torch.zeros(1, dtype=boundary_mid_cpu.dtype)
-        end = torch.full((1,), len(features), dtype=boundary_mid_cpu.dtype)
-        boundary_indices_cpu = torch.cat([zero, boundary_mid_cpu, end])
-
-        # For each sequence [start, end), position i flips to: start + end - 1 - i
-        lengths_cpu = boundary_indices_cpu[1:] - boundary_indices_cpu[:-1]
-        starts_cpu = boundary_indices_cpu[:-1]
-        ends_cpu = boundary_indices_cpu[1:]
-
-        # Assign sequence ID to each element
-        sequence_ids_cpu = torch.arange(
-            len(lengths_cpu), dtype=boundary_mid_cpu.dtype
-        ).repeat_interleave(lengths_cpu)
-
-        # Calculate flipped indices for all positions at once
-        current_positions_cpu = torch.arange(
-            len(features), dtype=boundary_mid_cpu.dtype
+        segment_starts = torch.cat(
+            (
+                torch.ones(1, dtype=torch.bool, device=position_ids.device),
+                boundary_mask,
+            )
         )
-        flip_indices_cpu = (
-            starts_cpu[sequence_ids_cpu] + ends_cpu[sequence_ids_cpu]
-        ) - (1 + current_positions_cpu)
-        flip_indices = async_tensor_h2d(flip_indices_cpu, features.device)
+        segment_ends = torch.cat(
+            (
+                boundary_mask,
+                torch.ones(1, dtype=torch.bool, device=position_ids.device),
+            )
+        )
+
+        rows = token_indices[:, None]
+        columns = token_indices[None, :]
+        starts = torch.where(
+            segment_starts[None, :] & (columns <= rows), columns, 0
+        ).amax(dim=1)
+        ends = torch.where(
+            segment_ends[None, :] & (columns >= rows), columns, num_tokens - 1
+        ).amin(dim=1)
+
+        flip_indices = starts + ends - token_indices
 
         return features[flip_indices]
 


### PR DESCRIPTION
Closes #52662

## Summary
- mark SiglipEmbeddingModel as supporting torch.compile
- replace the CPU/value-dependent sequence flip with fixed-shape tensor indexing
- add parity coverage plus a fullgraph torch.compile smoke test for the flip helper

## Duplicate-work checks
- gh issue view 52662 --repo vllm-project/vllm --comments: no comments
- gh pr list --repo vllm-project/vllm --state open --search '52662 in:body': no open PRs
- gh pr list --repo vllm-project/vllm --state open --search 'SiglipEmbeddingModel torch.compile _flip_sequences_by_position_ids': no open PRs

## Tests
- .venv/bin/python -m pytest tests/models/multimodal/pooling/test_siglip.py::test_flip_sequences_by_position_ids_matches_reference tests/models/multimodal/pooling/test_siglip.py::test_flip_sequences_by_position_ids_matches_reference_randomized tests/models/multimodal/pooling/test_siglip.py::test_flip_sequences_by_position_ids_supports_torch_compile -vv -x --tb=short: 8 passed, 15 warnings
- pre-commit run --files vllm/model_executor/models/siglip.py tests/models/multimodal/pooling/test_siglip.py: passed

## Model evals
Not run. This preserves the SigLIP sequence-flip semantics and adds compile coverage for the changed helper; no GPU/Neuron model-eval environment is available locally.

## AI assistance
AI assistance was used. The human submitter should review every changed line and the test results before merge.