### PR TITLE
[Perf] Backfill divergent local hybrid hits from the offloading connector

### DIFF
--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -5695,6 +5695,7 @@ def _create_hybrid_mamba_connector_scheduler(
     block_size: int = 16,
     num_blocks: int = 100,
     supports_divergent_hits: bool = True,
+    hybrid_backfill: tuple[int, int] = (0, 0),
 ) -> Scheduler:
     """FA + Mamba ("all" cache mode) scheduler with a MockKVConnector."""
     model_config = ModelConfig(
@@ -5726,6 +5727,7 @@ def _create_hybrid_mamba_connector_scheduler(
                 "matched_tokens": matched_tokens,
                 "is_async": False,
                 "supports_divergent_local_hybrid_hits": supports_divergent_hits,
+                "hybrid_backfill_tokens": hybrid_backfill,
             },
         ),
     )
@@ -5900,6 +5902,91 @@ def test_hybrid_fa_deeper_hit_respects_connector_lookup_policy(
 
     scheduler.add_request(replay)
     output = scheduler.schedule()
+    num_scheduled = output.num_scheduled_tokens[replay.request_id]
+    assert replay.num_tokens - num_scheduled == expected_num_computed
+
+
+@pytest.mark.parametrize(
+    "hybrid_backfill,expected_num_computed",
+    [
+        # The connector holds the full per-group set at the 48-token
+        # boundary: keep 32 local tokens and async-load the boundary block
+        # that restores the lagging Mamba state.
+        ((32, 16), 48),
+        # No backed boundary: reconcile to the locally-consistent one.
+        ((0, 0), 16),
+    ],
+)
+def test_hybrid_fa_deeper_hit_backfilled_by_connector(
+    hybrid_backfill: tuple[int, int], expected_num_computed: int
+):
+    """With no external tokens beyond a divergent FA-deeper local hit, a
+    capable connector can still back an intermediate boundary: the scheduler
+    keeps the deeper local prefix below that boundary and loads just the
+    boundary, instead of discarding the divergent hit and recomputing.
+    """
+    block_size = 16
+    scheduler = _create_hybrid_mamba_connector_scheduler(
+        matched_tokens=0,
+        supports_divergent_hits=True,
+        hybrid_backfill=hybrid_backfill,
+    )
+    manager = scheduler.kv_cache_manager
+    assert isinstance(manager.coordinator, HybridKVCacheCoordinator)
+
+    # Seed a 4-block prefix in both groups.
+    [fill] = create_requests(
+        num_requests=1,
+        num_tokens=4 * block_size,
+        max_tokens=1,
+        same_prompt=True,
+        block_size=block_size,
+        req_ids=["fill"],
+    )
+    computed_blocks, num_computed, _ = manager.get_computed_blocks(fill)
+    blocks = manager.allocate_slots(
+        fill, fill.num_tokens, num_computed, computed_blocks
+    )
+    mamba_ids = [b.block_id for b in blocks.blocks[1]]
+    manager.free(fill)
+
+    # Keep all FA blocks; evict every mamba state but block 0. FA reaches 4
+    # blocks, the mamba hit only reaches 1 -> diverged (FA > Mamba).
+    manager.block_pool.evict_blocks({mamba_ids[1], mamba_ids[2], mamba_ids[3]})
+
+    [replay] = create_requests(
+        num_requests=1,
+        num_tokens=6 * block_size,
+        max_tokens=1,
+        same_prompt=True,
+        block_size=block_size,
+        req_ids=["replay"],
+    )
+    _, per_group_hits = manager.coordinator.find_longest_cache_hit_per_group(
+        replay.block_hashes, replay.num_tokens - 1
+    )
+    assert per_group_hits == (4 * block_size, 1 * block_size)  # FA deeper
+
+    scheduler.add_request(replay)
+    output = scheduler.schedule()
+    if hybrid_backfill[1] > 0:
+        # The backfilled boundary is loaded asynchronously.
+        assert replay.status == RequestStatus.WAITING_FOR_REMOTE_KVS
+        assert replay.num_computed_tokens == expected_num_computed
+        recv_done = dataclasses.replace(
+            ModelRunnerOutput(
+                req_ids=[],
+                req_id_to_index={},
+                sampled_token_ids=[],
+                logprobs=None,
+                prompt_logprobs_dict={},
+                pooler_output=[],
+            ),
+            kv_connector_output=KVConnectorOutput(finished_recving=[replay.request_id]),
+        )
+        scheduler.update_from_output(output, recv_done)
+        output = scheduler.schedule()
+        assert replay.status == RequestStatus.RUNNING
     num_scheduled = output.num_scheduled_tokens[replay.request_id]
     assert replay.num_tokens - num_scheduled == expected_num_computed
 

--- a/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
+++ b/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
@@ -202,6 +202,71 @@ def test_partial_lookup_requires_every_cache_group():
     assert req_status.partial_tail_boundary is None
 
 
+def _make_backfill_request(
+    scheduler: OffloadingConnectorScheduler, num_tokens: int
+) -> MagicMock:
+    request = MagicMock()
+    request.request_id = "req"
+    request.kv_transfer_params = None
+    request.num_prompt_tokens = num_tokens
+    request.num_tokens = num_tokens
+    request.block_hashes = [BlockHash(f"h{i}".encode()) for i in range(num_tokens // 4)]
+    request.all_token_ids = list(range(num_tokens))
+    request.lora_request = None
+    request.skip_reading_prefix_cache = False
+    request.is_finished.return_value = False
+    scheduler.on_new_request(request)
+    return request
+
+
+def test_hybrid_backfill_returns_deepest_fully_backed_boundary():
+    scheduler = _make_partial_tail_scheduler()
+    assert scheduler.supports_hybrid_backfill
+    request = _make_backfill_request(scheduler, num_tokens=48)
+    req_status = scheduler._req_status["req"]
+    req_status.update_offload_keys()
+
+    # The deepest boundary (chunk 3) is missing its recurrent chunk; the
+    # boundary below it is offloaded in every group.
+    def lookup(key, req_context):
+        if get_offload_group_idx(key) == 1 and get_offload_block_hash(key) == b"h11":
+            return LookupResult.MISS
+        return LookupResult.HIT
+
+    scheduler.manager.lookup.side_effect = lookup
+    assert scheduler.get_hybrid_backfill_tokens(request, 48) == (16, 16)
+    assert req_status.num_locally_computed_tokens == 16
+
+
+def test_hybrid_backfill_misses_when_no_boundary_is_fully_backed():
+    scheduler = _make_partial_tail_scheduler()
+    request = _make_backfill_request(scheduler, num_tokens=48)
+    req_status = scheduler._req_status["req"]
+    req_status.update_offload_keys()
+    req_status.num_locally_computed_tokens = 48
+
+    def lookup(key, req_context):
+        if get_offload_group_idx(key) == 1:
+            return LookupResult.MISS
+        return LookupResult.HIT
+
+    scheduler.manager.lookup.side_effect = lookup
+    assert scheduler.get_hybrid_backfill_tokens(request, 48) == (0, 0)
+    assert req_status.num_locally_computed_tokens == 48
+
+
+def test_hybrid_backfill_skips_boundaries_being_loaded():
+    scheduler = _make_partial_tail_scheduler()
+    request = _make_backfill_request(scheduler, num_tokens=48)
+    req_status = scheduler._req_status["req"]
+    req_status.update_offload_keys()
+    scheduler.manager.lookup.return_value = LookupResult.HIT
+
+    assert scheduler._chunks_being_loaded is not None
+    scheduler._chunks_being_loaded.add(req_status.group_states[1].offload_keys[2])
+    assert scheduler.get_hybrid_backfill_tokens(request, 48) == (16, 16)
+
+
 def test_scheduler_reports_allocation_failure(request_runner):
     runner = request_runner(
         block_size=4,

--- a/tests/v1/kv_connector/unit/utils.py
+++ b/tests/v1/kv_connector/unit/utils.py
@@ -364,6 +364,7 @@ class MockKVConfig:
     is_async: bool = False
     num_defers_before_matching: int = 0
     supports_divergent_local_hybrid_hits: bool = False
+    hybrid_backfill_tokens: tuple[int, int] = (0, 0)
 
 
 class MockKVConnectorMetadata(KVConnectorMetadata):
@@ -392,6 +393,9 @@ class MockKVConnector(KVConnectorBase_V1):
             supports_divergent_local_hybrid_hits=extra_config.get(
                 "supports_divergent_local_hybrid_hits", False
             ),
+            hybrid_backfill_tokens=tuple(
+                extra_config.get("hybrid_backfill_tokens", (0, 0))
+            ),
         )
         self._defers_left: defaultdict[str, int] = defaultdict(
             lambda: self.config.num_defers_before_matching
@@ -410,6 +414,13 @@ class MockKVConnector(KVConnectorBase_V1):
             self._defers_left[request.request_id] -= 1
             return (None, False)
         return (self.config.matched_tokens, self.config.is_async)
+
+    def get_hybrid_backfill_tokens(
+        self,
+        request: Request,
+        num_computed_tokens: int,
+    ) -> tuple[int, int]:
+        return self.config.hybrid_backfill_tokens
 
     def update_state_after_alloc(
         self,

--- a/vllm/distributed/kv_transfer/kv_connector/v1/base.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/base.py
@@ -182,6 +182,37 @@ class KVConnectorBase_V1(ABC):
         """
         return False
 
+    def get_hybrid_backfill_tokens(
+        self,
+        request: "Request",
+        num_computed_tokens: int,
+    ) -> tuple[int, int]:
+        """Resolve a divergent local hybrid hit by backfilling external state.
+
+        Only consulted for connectors with
+        `supports_divergent_local_hybrid_hits` when the local per-group hits
+        diverged and `get_num_new_matched_tokens()` reported no external
+        tokens beyond the divergent hit. A connector holding the full
+        per-group state set at a boundary at or below `num_computed_tokens`
+        can keep most of the deeper local prefix and restore the lagging
+        recurrent state by loading just that boundary, instead of the
+        scheduler discarding the divergent hit and recomputing.
+
+        Args:
+            request: the request object.
+            num_computed_tokens: the number of locally computed tokens
+                backing the divergent hit (block-aligned).
+
+        Returns:
+            A `(num_local_tokens, num_external_tokens)` tuple: keep the local
+            prefix up to `num_local_tokens` and load `num_external_tokens`
+            beyond it asynchronously, making
+            `num_local_tokens + num_external_tokens` a resume boundary with
+            valid state in every group. `(0, 0)` if no boundary can be
+            backed.
+        """
+        return (0, 0)
+
     @property
     def prefer_cross_layer_blocks(self) -> bool:
         """

--- a/vllm/distributed/kv_transfer/kv_connector/v1/multi_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/multi_connector.py
@@ -409,6 +409,23 @@ class MultiConnector(KVConnectorBase_V1, SupportsHMA):
                 to_return = (toks, load_async)
         return to_return
 
+    def get_hybrid_backfill_tokens(
+        self,
+        request: "Request",
+        num_computed_tokens: int,
+    ) -> tuple[int, int]:
+        # Only consulted when no connector had matched tokens, so no
+        # connector has been assigned to this request yet.
+        for i, c in enumerate(self._connectors):
+            num_local, num_external = c.get_hybrid_backfill_tokens(
+                request, num_computed_tokens
+            )
+            if num_external > 0:
+                # The connector serving the backfill is assigned the request.
+                self._requests_to_connector[request.request_id] = i
+                return (num_local, num_external)
+        return (0, 0)
+
     def update_state_after_alloc(
         self, request: "Request", blocks: "KVCacheBlocks", num_external_tokens: int
     ):

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
@@ -534,6 +534,22 @@ class OffloadingConnectorScheduler:
             if config.requires_cow_source
         )
 
+        # Divergent local hybrid hits can be resolved by loading a single
+        # full per-group boundary chunk only when boundaries are common to
+        # all groups and every group resumes from that one chunk: recurrent
+        # groups have a one-chunk window, while wider sliding windows would
+        # need more chunks than the load path supplies and eagle groups have
+        # lookup semantics the boundary probe does not model.
+        tokens_per_chunk = {gc.tokens_per_chunk for gc in self.config.kv_group_configs}
+        self.supports_hybrid_backfill = (
+            len(tokens_per_chunk) == 1
+            and all(
+                (gc.sliding_window_size_in_chunks or 1) == 1
+                for gc in self.config.kv_group_configs
+            )
+            and not any(gc.is_eagle_group for gc in self.config.kv_group_configs)
+        )
+
         self._req_status: dict[ReqId, RequestOffloadState] = {}
         self._current_batch_load_jobs: dict[int, TransferJob] = {}
         self._current_batch_jobs_to_flush: set[int] = set()
@@ -989,6 +1005,49 @@ class OffloadingConnectorScheduler:
         self._touch(req_status)
 
         return num_hit_tokens, bool(num_hit_tokens)
+
+    def get_hybrid_backfill_tokens(
+        self, request: Request, num_computed_tokens: int
+    ) -> tuple[int, int]:
+        """Find the deepest full per-group boundary at or below a divergent hit.
+
+        Walks chunk boundaries downwards from `num_computed_tokens` and
+        returns `((boundary - 1) * tokens_per_chunk, tokens_per_chunk)` for
+        the deepest boundary whose chunk is offloaded in every group: the
+        scheduler keeps the local prefix below that boundary and loads just
+        the boundary chunk, which restores the recurrent state the divergent
+        local hit is missing. Returns `(0, 0)` when no boundary is fully
+        backed. Must be called after `get_num_new_matched_tokens()`, which
+        refreshes the per-group offload keys.
+        """
+        if not self.supports_hybrid_backfill or request.skip_reading_prefix_cache:
+            return (0, 0)
+        req_status = self._req_status.get(request.request_id)
+        if req_status is None:
+            return (0, 0)
+        tokens_per_chunk = self.config.kv_group_configs[0].tokens_per_chunk
+        for boundary in range(num_computed_tokens // tokens_per_chunk, 0, -1):
+            backed = True
+            for group_state in req_status.group_states:
+                if len(group_state.offload_keys) < boundary:
+                    backed = False
+                    break
+                key = group_state.offload_keys[boundary - 1]
+                being_loaded = (
+                    self._chunks_being_loaded is not None
+                    and key in self._chunks_being_loaded
+                )
+                if being_loaded or (
+                    self.manager.lookup(key, req_status.req_context)
+                    is not LookupResult.HIT
+                ):
+                    backed = False
+                    break
+            if backed:
+                num_local = (boundary - 1) * tokens_per_chunk
+                req_status.num_locally_computed_tokens = num_local
+                return (num_local, tokens_per_chunk)
+        return (0, 0)
 
     def update_state_after_alloc(
         self, request: Request, blocks: KVCacheBlocks, num_external_tokens: int

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading_connector.py
@@ -48,6 +48,13 @@ from vllm.v1.request import Request
 
 class OffloadingConnector(KVConnectorBase_V1, SupportsHMA):
     @property
+    def supports_divergent_local_hybrid_hits(self) -> bool:
+        # Divergent hits are resolved by a longer external hit or by
+        # get_hybrid_backfill_tokens(); the scheduler reconciles otherwise.
+        cs = self.connector_scheduler
+        return cs is not None and cs.supports_hybrid_backfill
+
+    @property
     def prefer_cross_layer_blocks(self) -> bool:
         # Cross-layer slabs have no per-layer refs to certify canonical mappings
         return not self._canonical_layout
@@ -149,6 +156,14 @@ class OffloadingConnector(KVConnectorBase_V1, SupportsHMA):
     ) -> tuple[int | None, bool]:
         assert self.connector_scheduler is not None
         return self.connector_scheduler.get_num_new_matched_tokens(
+            request, num_computed_tokens
+        )
+
+    def get_hybrid_backfill_tokens(
+        self, request: "Request", num_computed_tokens: int
+    ) -> tuple[int, int]:
+        assert self.connector_scheduler is not None
+        return self.connector_scheduler.get_hybrid_backfill_tokens(
             request, num_computed_tokens
         )
 

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -863,14 +863,34 @@ class Scheduler(SchedulerInterface):
                             num_external_computed_tokens = ext_tokens
 
                         if hit_diverged and num_external_computed_tokens == 0:
-                            # No external tokens back the deeper local hit, so its
-                            # resume boundary would have no valid Mamba state.
-                            # Reconcile to the boundary every group agrees on.
-                            (
-                                new_computed_blocks,
-                                num_new_local_computed_tokens,
-                                request.shared_prefix_boundary,
-                            ) = self.kv_cache_manager.get_computed_blocks(request)
+                            backfill_local, backfill_ext = (
+                                self.connector.get_hybrid_backfill_tokens(
+                                    request, block_aligned_local
+                                )
+                            )
+                            if backfill_ext > 0:
+                                # A full per-group boundary at or below the
+                                # divergent hit restores the lagging Mamba
+                                # state: keep the deeper local prefix and
+                                # load just that boundary externally.
+                                new_computed_blocks = (
+                                    self.kv_cache_manager.truncate_computed_blocks(
+                                        new_computed_blocks, backfill_local
+                                    )
+                                )
+                                num_new_local_computed_tokens = backfill_local
+                                num_external_computed_tokens = backfill_ext
+                                load_kv_async = True
+                            else:
+                                # No external tokens back the deeper local hit,
+                                # so its resume boundary would have no valid
+                                # Mamba state. Reconcile to the boundary every
+                                # group agrees on.
+                                (
+                                    new_computed_blocks,
+                                    num_new_local_computed_tokens,
+                                    request.shared_prefix_boundary,
+                                ) = self.kv_cache_manager.get_computed_blocks(request)
 
                         connector_prefix_cache_queries = (
                             request.num_tokens - num_new_local_computed_tokens


### PR DESCRIPTION
## Purpose

Addresses #52773.

With hybrid models (Mamba + full attention), per-group local prefix hits diverge under block pressure: the full-attention prefix survives deeper in HBM than the recurrent state, which can only resume at a boundary with a state snapshot. Today the offloading connector never sees the divergent hit (`supports_divergent_local_hybrid_hits` is `False`, #50344), so the resident full-attention KV above the common boundary is given up and re-fetched from the store; capable connectors reconcile to the common boundary whenever no external tokens lie beyond the deep hit (#48425), without asking whether the store can back an intermediate boundary. In the common write-through setup the store holds full per-group chunk sets — exactly the missing piece — but no path asks for it (measured ~80× cost per event on a revisit/fork workload, see the linked issue).

This PR adds a backfill path:

- **`KVConnectorBase_V1.get_hybrid_backfill_tokens(request, num_computed_tokens) -> (num_local, num_external)`** (optional, default `(0, 0)`): consulted only for connectors with `supports_divergent_local_hybrid_hits`, when the local hits diverged and `get_num_new_matched_tokens()` reported no external tokens beyond the divergent hit.
- **Scheduler** (`vllm/v1/core/sched/scheduler.py`): in the `hit_diverged and ext == 0` branch, if the connector reports a backed boundary, keep the local prefix below it (`truncate_computed_blocks`, whose Mamba-aware slicing already models the ragged groups) and async-load just the boundary chunk; otherwise reconcile exactly as before.
- **`OffloadingConnector`**: implements the hook with a boundary-walk probe over the per-group offload keys (deepest boundary whose chunk is `HIT` in every group; boundaries being loaded are skipped), and now opts into `supports_divergent_local_hybrid_hits` when every group resumes from a single chunk: uniform `tokens_per_chunk`, every sliding window ≤ 1 chunk (recurrent groups are modeled as one-chunk windows), no eagle groups. Configs outside that (wider SWA windows, eagle) keep today's behavior — the capability stays `False`.
- **`MultiConnector`**: forwards the probe; the first child reporting a backed boundary is assigned the request (the hook is only consulted when no child had matched tokens, so no child has been assigned yet).

The load itself reuses the existing external-load path unchanged (`update_state_after_alloc` computes the chunk set from the probe-adjusted bookkeeping); `get_hybrid_backfill_tokens` must be called after `get_num_new_matched_tokens()`, which is the order the scheduler uses.

Known minor: `update_num_hit_chunks` is recorded at the pre-backfill query, so per-group hit metrics do not count the backfilled boundary chunk.

## Test Plan

```bash
VLLM_USE_PRECOMPILED=1 uv pip install -e . --torch-backend=auto
.venv/bin/python -m pytest tests/v1/core/test_scheduler.py -k "hybrid" -v
.venv/bin/python -m pytest tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py -k "backfill or partial_lookup" -v
.venv/bin/python -m pytest tests/v1/kv_connector/unit/test_multi_connector.py -v
pre-commit run --files <changed files>
```

New tests:
- `test_hybrid_fa_deeper_hit_backfilled_by_connector` (core scheduler, both backfill-hit and backfill-miss parametrizations, including the async-load resume flow);
- `test_hybrid_backfill_returns_deepest_fully_backed_boundary`, `test_hybrid_backfill_misses_when_no_boundary_is_fully_backed`, `test_hybrid_backfill_skips_boundaries_being_loaded` (offloading probe).

## Test Result

- `tests/v1/core/test_scheduler.py -k "hybrid"`: **7 passed** (5 pre-existing divergence cases unchanged + 2 new).
- `offloading_connector/test_scheduler.py -k "backfill or partial_lookup"`: **5 passed**.
- `test_multi_connector.py`: **21 passed, 2 failed** — the same 2 failures (`test_multi_example_connector_consistency`, `test_multi_connector_mixed_hma_disables_hybrid_kv_cache`) reproduce identically on pristine `main` in this environment and are unrelated; the override-completeness guard `test_multi_connector_overrides_all_base_methods` passes with the new base method delegated.
- `pre-commit` hooks pass on all changed files.

Marked as **draft**: I plan to attach paired end-to-end numbers (hybrid revisit/fork workload, offloading on, backfill on/off) from our test rig, and I'm happy to split the base-API change from the offloading implementation if preferred.

---

*Disclosure per `AGENTS.md`: this PR was AI-assisted (Claude Code). I have reviewed every changed line and run the tests above. Duplicate-work check (2026-08-18): searched issues/PRs for `hit_diverged`, `get_computed_blocks_for_connector`, `supports_divergent_local_hybrid_hits`, "divergent hybrid mamba", "mamba offloading", "backfill mamba" — the correctness lineage (#48425, #50344, and open #46455 / #48195) reconciles or scopes divergent hits; no existing issue or PR consults the offload store below a divergent hit. This change affects scheduling only when the new probe reports a backed boundary; output correctness is covered by the resume-boundary invariant the existing divergence tests assert.*
