### PR TITLE
[Bugfix][MoE] Fall back from monolithic NVFP4 for simulated routing

### DIFF
--- a/tests/kernels/moe/test_routed_experts_capture_monolithic.py
+++ b/tests/kernels/moe/test_routed_experts_capture_monolithic.py
@@ -666,6 +666,8 @@ def _make_nvfp4_monolithic_experts(
     hidden_size: int,
     intermediate_size: int,
     device: torch.device,
+    routing_method: RoutingMethodType = RoutingMethodType.DeepSeekV3,
+    original_routing_method: RoutingMethodType | None = None,
 ) -> tuple[
     TrtLlmNvFp4ExpertsMonolithic,
     torch.Tensor,  # w13 (packed nvfp4 uint8)
@@ -700,7 +702,9 @@ def _make_nvfp4_monolithic_experts(
         in_dtype=torch.bfloat16,
         activation=MoEActivation.SILU,
         device=device,
-        routing_method=RoutingMethodType.DeepSeekV3,
+        routing_method=routing_method,
+        router_logits_dtype=torch.float32,
+        original_routing_method=original_routing_method,
         max_num_tokens=16,
     )
 
@@ -776,6 +780,8 @@ def _run_nvfp4_monolithic(
     router_logits: torch.Tensor,
     num_experts: int,
     routing_bias: torch.Tensor,
+    n_group: int = _DSV3_N_GROUP,
+    topk_group: int = _DSV3_TOPK_GROUP,
 ) -> torch.Tensor:
     """The monolithic NVFP4 apply expects packed fp4 hidden states + the
     matching fp8 per-block scale stored in the ``a1q_scale`` slot."""
@@ -792,27 +798,67 @@ def _run_nvfp4_monolithic(
         expert_map=None,
         a1q_scale=hidden_states_scale,
         apply_router_weight_on_input=False,
-        num_expert_group=_DSV3_N_GROUP,
-        topk_group=_DSV3_TOPK_GROUP,
+        num_expert_group=n_group,
+        topk_group=topk_group,
         e_score_correction_bias=routing_bias,
         routed_scaling_factor=1.0,
     )
 
 
-@pytest.mark.parametrize("num_tokens", [2, 7, 16])
-@pytest.mark.parametrize("top_k", [2, 4])
+@pytest.mark.parametrize(
+    (
+        "num_tokens",
+        "top_k",
+        "routing_method",
+        "original_routing_method",
+        "n_group",
+        "topk_group",
+    ),
+    [
+        pytest.param(2, 2, RoutingMethodType.DeepSeekV3, None, 4, 2, id="m2-k2"),
+        pytest.param(7, 2, RoutingMethodType.DeepSeekV3, None, 4, 2, id="m7-k2"),
+        pytest.param(16, 2, RoutingMethodType.DeepSeekV3, None, 4, 2, id="m16-k2"),
+        pytest.param(2, 4, RoutingMethodType.DeepSeekV3, None, 4, 2, id="m2-k4"),
+        pytest.param(7, 4, RoutingMethodType.DeepSeekV3, None, 4, 2, id="m7-k4"),
+        pytest.param(16, 4, RoutingMethodType.DeepSeekV3, None, 4, 2, id="m16-k4"),
+        pytest.param(
+            2,
+            4,
+            RoutingMethodType.Simulated,
+            RoutingMethodType.DeepSeekV3,
+            1,
+            1,
+            id="simulated-dsv3-single-group",
+        ),
+    ],
+)
 def test_trtllm_nvfp4_monolithic_routing_replay_records_valid_experts(
     num_tokens: int,
     top_k: int,
+    routing_method: RoutingMethodType,
+    original_routing_method: RoutingMethodType | None,
+    n_group: int,
+    topk_group: int,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """End-to-end: ``TrtLlmNvFp4ExpertsMonolithic`` captures valid expert IDs
     on the DSV3 routing path."""
-    if top_k > _DSV3_N_GROUP * _DSV3_TOPK_GROUP:
+    if n_group > 1 and top_k > n_group * topk_group:
         pytest.skip(
             f"DSV3 requires top_k <= n_group * topk_group "
-            f"({_DSV3_N_GROUP * _DSV3_TOPK_GROUP})"
+            f"({n_group * topk_group})"
         )
+    import vllm.envs as envs
     from flashinfer import fp4_quantize
+
+    strategy = (
+        "uniform_random" if routing_method == RoutingMethodType.Simulated else ""
+    )
+    monkeypatch.setitem(
+        envs.environment_variables,
+        "VLLM_MOE_ROUTING_SIMULATION_STRATEGY",
+        lambda: strategy,
+    )
 
     torch.manual_seed(0)
     device = torch.device("cuda:0")
@@ -828,6 +874,8 @@ def test_trtllm_nvfp4_monolithic_routing_replay_records_valid_experts(
         hidden_size=hidden_size,
         intermediate_size=intermediate_size,
         device=device,
+        routing_method=routing_method,
+        original_routing_method=original_routing_method,
     )
     # The apply() reads w1/w2 from its args, but we keep them on the experts
     # for convenience of the helper.
@@ -862,6 +910,8 @@ def test_trtllm_nvfp4_monolithic_routing_replay_records_valid_experts(
         router_logits=router_logits,
         num_experts=num_experts,
         routing_bias=routing_bias,
+        n_group=n_group,
+        topk_group=topk_group,
     )
 
     assert len(captured) == 1

--- a/tests/kernels/moe/test_routing_simulator.py
+++ b/tests/kernels/moe/test_routing_simulator.py
@@ -75,6 +75,123 @@ def test_basic_functionality(
         )
 
 
+def test_uniform_strategy_generates_monolithic_logits(device):
+    router_logits = torch.full(
+        (16, 32),
+        7.0,
+        dtype=torch.bfloat16,
+        device=device,
+    )
+    original_logits = router_logits.clone()
+
+    simulated_logits = RoutingSimulator.simulate_monolithic_logits(
+        router_logits=router_logits,
+        strategy_name="uniform_random",
+    )
+
+    assert simulated_logits.shape == router_logits.shape
+    assert simulated_logits.device == router_logits.device
+    assert simulated_logits.dtype == router_logits.dtype
+    assert torch.all((simulated_logits >= 0) & (simulated_logits < 1))
+    assert torch.equal(router_logits, original_logits)
+
+
+def test_normal_strategy_does_not_generate_monolithic_logits(device):
+    router_logits = torch.zeros((16, 32), device=device)
+
+    with pytest.raises(NotImplementedError):
+        RoutingSimulator.simulate_monolithic_logits(
+            router_logits=router_logits,
+            strategy_name="normal_routing",
+        )
+
+
+@pytest.mark.parametrize(
+    "strategy,expected",
+    [("uniform_random", True), ("normal_routing", False)],
+)
+def test_nvfp4_monolithic_supports_uniform_simulation_only(
+    monkeypatch,
+    strategy: str,
+    expected: bool,
+):
+    import vllm.envs as envs
+    from vllm.model_executor.layers.fused_moe.config import RoutingMethodType
+    from vllm.model_executor.layers.fused_moe.experts.trtllm_nvfp4_moe import (
+        TrtLlmNvFp4ExpertsMonolithic,
+    )
+
+    env_name = "VLLM_MOE_ROUTING_SIMULATION_STRATEGY"
+    monkeypatch.setitem(
+        envs.environment_variables,
+        env_name,
+        lambda: strategy,
+    )
+
+    assert (
+        TrtLlmNvFp4ExpertsMonolithic._supports_routing_method(
+            RoutingMethodType.Simulated,
+            weight_key=None,
+            activation_key=None,
+        )
+        is expected
+    )
+
+
+@pytest.mark.parametrize(
+    "router_kwargs,expected_method",
+    [
+        ({}, "RenormalizeNaive"),
+        ({"renormalize": False}, "Default"),
+        (
+            {
+                "use_grouped_topk": True,
+                "num_expert_group": 4,
+                "topk_group": 2,
+                "scoring_func": "sigmoid",
+                "e_score_correction_bias": torch.zeros(16),
+            },
+            "DeepSeekV3",
+        ),
+    ],
+)
+def test_simulator_preserves_original_routing_method(
+    monkeypatch,
+    router_kwargs,
+    expected_method: str,
+):
+    import vllm.envs as envs
+    from vllm.model_executor.layers.fused_moe.config import RoutingMethodType
+    from vllm.model_executor.layers.fused_moe.router.router_factory import (
+        create_fused_moe_router,
+        create_non_simulated_fused_moe_router,
+    )
+
+    env_name = "VLLM_MOE_ROUTING_SIMULATION_STRATEGY"
+    monkeypatch.setitem(
+        envs.environment_variables,
+        env_name,
+        lambda: "uniform_random",
+    )
+
+    non_simulated_router = create_non_simulated_fused_moe_router(
+        top_k=2,
+        global_num_experts=16,
+        **router_kwargs,
+    )
+    router = create_fused_moe_router(
+        top_k=2,
+        global_num_experts=16,
+        **router_kwargs,
+    )
+
+    assert non_simulated_router.routing_method_type == RoutingMethodType[
+        expected_method
+    ]
+    assert router.routing_method_type == RoutingMethodType.Simulated
+    assert router.original_routing_method_type == RoutingMethodType[expected_method]
+
+
 def test_routing_strategy_integration(monkeypatch, device):
     """Test that the routing strategy environment variable works with
     FusedMoEFactory."""

--- a/vllm/model_executor/layers/fused_moe/config.py
+++ b/vllm/model_executor/layers/fused_moe/config.py
@@ -1331,6 +1331,9 @@ class FusedMoEConfig:
 
     max_capture_size: int = 0
 
+    # Routing method before RoutingSimulatorRouter overrides it with Simulated.
+    original_routing_method: RoutingMethodType | None = None
+
     # Set by __post_init__
     intermediate_size_per_partition: int = -1
     rocm_aiter_fmoe_enabled: bool = False

--- a/vllm/model_executor/layers/fused_moe/experts/trtllm_nvfp4_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/trtllm_nvfp4_moe.py
@@ -4,6 +4,7 @@
 
 import torch
 
+import vllm.envs as envs
 import vllm.model_executor.layers.fused_moe.modular_kernel as mk
 from vllm.logger import init_logger
 from vllm.model_executor.layers.fused_moe.activation import MoEActivation
@@ -486,6 +487,9 @@ class TrtLlmNvFp4ExpertsMonolithic(
         weight_key: QuantKey | None,
         activation_key: QuantKey | None,
     ) -> bool:
+        if routing_method_type == RoutingMethodType.Simulated:
+            return envs.VLLM_MOE_ROUTING_SIMULATION_STRATEGY == "uniform_random"
+
         # NOTE(rob): this is a conservative list.
         return routing_method_type in [
             RoutingMethodType.DeepSeekV3,
@@ -495,7 +499,6 @@ class TrtLlmNvFp4ExpertsMonolithic(
             RoutingMethodType.SigmoidRenorm,
             RoutingMethodType.Sigmoid,
             RoutingMethodType.MiniMax2,
-            RoutingMethodType.Simulated,
         ]
 
     @staticmethod
@@ -524,16 +527,22 @@ class TrtLlmNvFp4ExpertsMonolithic(
     ) -> torch.Tensor | UnfinalizedMoEOutput:
         import flashinfer
 
+        routing_method_type = self.routing_method_type
+        is_simulated = routing_method_type == RoutingMethodType.Simulated
+        if is_simulated:
+            routing_method_type = self.moe_config.original_routing_method
+            assert routing_method_type is not None
+
         assert self._supports_activation(activation)
         assert a1q_scale is not None or self.per_token_activation
         assert self.quant_config.w1_scale is not None
         assert self.quant_config.w2_scale is not None
         assert (
             apply_router_weight_on_input
-            and self.routing_method_type == RoutingMethodType.Llama4
+            and routing_method_type == RoutingMethodType.Llama4
         ) or (
             not apply_router_weight_on_input
-            and self.routing_method_type != RoutingMethodType.Llama4
+            and routing_method_type != RoutingMethodType.Llama4
         )
 
         # Per-token: input is unquantized, quantize it here (see modular apply).
@@ -555,6 +564,25 @@ class TrtLlmNvFp4ExpertsMonolithic(
             num_tokens=num_tokens,
             device=hidden_states.device,
         )
+
+        if is_simulated:
+            from vllm.model_executor.layers.fused_moe.router.routing_simulator_router import (  # noqa: E501
+                RoutingSimulator,
+            )
+
+            router_logits = RoutingSimulator.simulate_monolithic_logits(
+                router_logits=router_logits,
+                strategy_name=envs.VLLM_MOE_ROUTING_SIMULATION_STRATEGY,
+            )
+            if routing_method_type in (
+                RoutingMethodType.DeepSeekV3,
+                RoutingMethodType.MiniMax2,
+            ):
+                assert e_score_correction_bias is not None
+                e_score_correction_bias = torch.zeros_like(e_score_correction_bias)
+            else:
+                e_score_correction_bias = None
+
         # Invoke kernel.
         # NOTE: Activation padding and output
         # truncation are handled by the MoE runner's
@@ -585,7 +613,7 @@ class TrtLlmNvFp4ExpertsMonolithic(
             local_expert_offset=self.ep_rank * self.local_num_experts,
             local_num_experts=self.local_num_experts,
             routed_scaling_factor=routed_scaling_factor,
-            routing_method_type=self.routing_method_type,
+            routing_method_type=routing_method_type,
             do_finalize=not defer,
             activation_type=activation_to_flashinfer_int(activation),
             per_token_scale=per_token_scale,

--- a/vllm/model_executor/layers/fused_moe/experts/trtllm_nvfp4_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/trtllm_nvfp4_moe.py
@@ -17,6 +17,9 @@ from vllm.model_executor.layers.fused_moe.config import (
 from vllm.model_executor.layers.fused_moe.moe_output import (
     UnfinalizedMoEOutput,
 )
+from vllm.model_executor.layers.fused_moe.router.routing_simulator_router import (
+    RoutingSimulator,
+)
 from vllm.model_executor.layers.fused_moe.topk_weight_and_reduce import (
     TopKWeightAndReduceNoOP,
 )
@@ -508,6 +511,27 @@ class TrtLlmNvFp4ExpertsMonolithic(
     ) -> bool:
         return router_logits_dtype in [torch.bfloat16, torch.float32]
 
+    @staticmethod
+    def _simulate_routing(
+        routing_method_type: RoutingMethodType,
+        router_logits: torch.Tensor,
+        e_score_correction_bias: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        router_logits = RoutingSimulator.simulate_monolithic_logits(
+            router_logits=router_logits,
+            strategy_name=envs.VLLM_MOE_ROUTING_SIMULATION_STRATEGY,
+        )
+        if routing_method_type in (
+            RoutingMethodType.DeepSeekV3,
+            RoutingMethodType.MiniMax2,
+        ):
+            assert e_score_correction_bias is not None
+            e_score_correction_bias = torch.zeros_like(e_score_correction_bias)
+        else:
+            e_score_correction_bias = None
+
+        return router_logits, e_score_correction_bias
+
     def apply(
         self,
         hidden_states: torch.Tensor,
@@ -566,22 +590,11 @@ class TrtLlmNvFp4ExpertsMonolithic(
         )
 
         if is_simulated:
-            from vllm.model_executor.layers.fused_moe.router.routing_simulator_router import (  # noqa: E501
-                RoutingSimulator,
+            router_logits, e_score_correction_bias = self._simulate_routing(
+                routing_method_type,
+                router_logits,
+                e_score_correction_bias,
             )
-
-            router_logits = RoutingSimulator.simulate_monolithic_logits(
-                router_logits=router_logits,
-                strategy_name=envs.VLLM_MOE_ROUTING_SIMULATION_STRATEGY,
-            )
-            if routing_method_type in (
-                RoutingMethodType.DeepSeekV3,
-                RoutingMethodType.MiniMax2,
-            ):
-                assert e_score_correction_bias is not None
-                e_score_correction_bias = torch.zeros_like(e_score_correction_bias)
-            else:
-                e_score_correction_bias = None
 
         # Invoke kernel.
         # NOTE: Activation padding and output

--- a/vllm/model_executor/layers/fused_moe/layer.py
+++ b/vllm/model_executor/layers/fused_moe/layer.py
@@ -355,6 +355,7 @@ def FusedMoEFactory(
         activation=moe_activation,
         device=vllm_config.device_config.device,
         routing_method=router.routing_method_type,  # Not ideal
+        original_routing_method=router.original_routing_method_type,
         swiglu_limit=swiglu_limit,
         swiglu_alpha=swiglu_alpha,
         swiglu_beta=swiglu_beta,

--- a/vllm/model_executor/layers/fused_moe/modular_kernel.py
+++ b/vllm/model_executor/layers/fused_moe/modular_kernel.py
@@ -571,6 +571,15 @@ class FusedMoEExperts(ABC):
             moe_config.routing_method, weight_key, activation_key
         ):
             return False, _make_reason(f"routing method {moe_config.routing_method}")
+        elif (
+            moe_config.original_routing_method is not None
+            and not cls._supports_routing_method(
+                moe_config.original_routing_method, weight_key, activation_key
+            )
+        ):
+            return False, _make_reason(
+                f"original routing method {moe_config.original_routing_method}"
+            )
         elif not cls._supports_router_logits_dtype(
             moe_config.router_logits_dtype,
             moe_config.routing_method,

--- a/vllm/model_executor/layers/fused_moe/router/fused_moe_router.py
+++ b/vllm/model_executor/layers/fused_moe/router/fused_moe_router.py
@@ -31,6 +31,11 @@ class FusedMoERouter(ABC):
     def routing_method_type(self) -> RoutingMethodType:
         raise NotImplementedError
 
+    @property
+    def original_routing_method_type(self) -> RoutingMethodType:
+        """Routing method before any routing simulation override."""
+        return self.routing_method_type
+
     @abstractmethod
     def _select_experts(
         self,

--- a/vllm/model_executor/layers/fused_moe/router/fused_moe_router.py
+++ b/vllm/model_executor/layers/fused_moe/router/fused_moe_router.py
@@ -32,9 +32,9 @@ class FusedMoERouter(ABC):
         raise NotImplementedError
 
     @property
-    def original_routing_method_type(self) -> RoutingMethodType:
+    def original_routing_method_type(self) -> RoutingMethodType | None:
         """Routing method before any routing simulation override."""
-        return self.routing_method_type
+        return None
 
     @abstractmethod
     def _select_experts(

--- a/vllm/model_executor/layers/fused_moe/router/router_factory.py
+++ b/vllm/model_executor/layers/fused_moe/router/router_factory.py
@@ -37,7 +37,7 @@ from vllm.model_executor.layers.fused_moe.router.zero_expert_router import (
 )
 
 
-def create_fused_moe_router(
+def create_non_simulated_fused_moe_router(
     # common parameters
     top_k: int,
     global_num_experts: int,
@@ -66,14 +66,13 @@ def create_fused_moe_router(
     the provided parameters.
 
     The selection logic follows this priority order:
-    1. RoutingSimulatorRouter - if VLLM_MOE_ROUTING_SIMULATION_STRATEGY env var is set
-    2. ZeroExpertRouter - if zero_expert_type is not None
-    3. GroupedTopKRouter - if use_grouped_topk is True and the grouping is not
+    1. ZeroExpertRouter - if zero_expert_type is not None
+    2. GroupedTopKRouter - if use_grouped_topk is True and the grouping is not
        degenerate (at most one group, with topk_group <= 1)
-    4. CustomRoutingRouter - if custom_routing_function is not None
-    5. FusedTopKBiasRouter - if e_score_correction_bias is not None
-    6. AiterSharedRoutedFusedMoERouter - if num_fused_shared_experts > 0
-    7. FusedTopKRouter - default fallback
+    3. CustomRoutingRouter - if custom_routing_function is not None
+    4. FusedTopKBiasRouter - if e_score_correction_bias is not None
+    5. AiterSharedRoutedFusedMoERouter - if num_fused_shared_experts > 0
+    6. FusedTopKRouter - default fallback
 
     Common arguments:
         top_k: Number of experts to select per token
@@ -110,14 +109,6 @@ def create_fused_moe_router(
     Returns:
         An instance of the appropriate FusedMoERouter subclass
     """
-
-    routing_strategy = envs.VLLM_MOE_ROUTING_SIMULATION_STRATEGY
-    if routing_strategy != "":
-        return RoutingSimulatorRouter(
-            top_k=top_k,
-            global_num_experts=global_num_experts,
-            eplb_state=eplb_state,
-        )
 
     if zero_expert_type is not None:
         assert num_logical_experts is not None, (
@@ -233,4 +224,57 @@ def create_fused_moe_router(
         eplb_state=eplb_state,
         renormalize=renormalize,
         scoring_func=scoring_func,
+    )
+
+
+def create_fused_moe_router(
+    # common parameters
+    top_k: int,
+    global_num_experts: int,
+    renormalize: bool = True,
+    # grouped topk parameters
+    use_grouped_topk: bool = False,
+    num_expert_group: int | None = None,
+    topk_group: int | None = None,
+    scoring_func: str = "softmax",
+    num_fused_shared_experts: int = 0,
+    shared_expert_weight: float = 1.0,
+    # grouped topk + fused topk bias parameters
+    routed_scaling_factor: float = 1.0,
+    e_score_correction_bias: torch.Tensor | None = None,
+    # custom routing parameters
+    custom_routing_function: Callable | None = None,
+    # eplb parameters
+    eplb_state: EplbLayerState | None = None,
+    # zero expert parameters
+    zero_expert_type: str | None = None,
+    num_logical_experts: int | None = None,
+    hash_indices_table: torch.Tensor | None = None,
+) -> FusedMoERouter:
+    """Create the configured router, overriding it when simulation is enabled."""
+    router = create_non_simulated_fused_moe_router(
+        top_k=top_k,
+        global_num_experts=global_num_experts,
+        renormalize=renormalize,
+        use_grouped_topk=use_grouped_topk,
+        num_expert_group=num_expert_group,
+        topk_group=topk_group,
+        scoring_func=scoring_func,
+        num_fused_shared_experts=num_fused_shared_experts,
+        shared_expert_weight=shared_expert_weight,
+        routed_scaling_factor=routed_scaling_factor,
+        e_score_correction_bias=e_score_correction_bias,
+        custom_routing_function=custom_routing_function,
+        eplb_state=eplb_state,
+        zero_expert_type=zero_expert_type,
+        num_logical_experts=num_logical_experts,
+        hash_indices_table=hash_indices_table,
+    )
+    if envs.VLLM_MOE_ROUTING_SIMULATION_STRATEGY == "":
+        return router
+    return RoutingSimulatorRouter(
+        top_k=top_k,
+        global_num_experts=global_num_experts,
+        original_routing_method_type=router.routing_method_type,
+        eplb_state=eplb_state,
     )

--- a/vllm/model_executor/layers/fused_moe/router/routing_simulator_router.py
+++ b/vllm/model_executor/layers/fused_moe/router/routing_simulator_router.py
@@ -17,6 +17,18 @@ logger = init_logger(__name__)
 class RoutingStrategy(ABC):
     """Base class for token-to-expert routing strategies."""
 
+    def generate_monolithic_logits(
+        self,
+        router_logits: torch.Tensor,
+    ) -> torch.Tensor | None:
+        """Generate synthetic logits for a monolithic MoE implementation.
+
+        Returning ``None`` indicates that the strategy requires precomputed
+        expert IDs and weights and cannot yet use a logits-only monolithic
+        implementation.
+        """
+        return None
+
     @abstractmethod
     def route_tokens(
         self,
@@ -119,6 +131,20 @@ class DistributionBasedRouting(RoutingStrategy):
         topk_weights = self._generate_weights(num_tokens, top_k, hidden_states.device)
 
         return topk_weights, topk_ids
+
+    def generate_monolithic_logits(
+        self,
+        router_logits: torch.Tensor,
+    ) -> torch.Tensor | None:
+        """Generate distribution-specific synthetic router logits."""
+        if self.distribution == "uniform":
+            return torch.rand(
+                router_logits.shape,
+                dtype=router_logits.dtype,
+                device=router_logits.device,
+            )
+
+        return None
 
     def _sample_expert_ids(
         self,
@@ -258,6 +284,40 @@ class RoutingSimulator:
         """
         return list(cls._routing_strategies.keys())
 
+    @classmethod
+    def get_strategy(cls, strategy_name: str) -> RoutingStrategy:
+        """Return a registered routing strategy by name."""
+        if strategy_name not in cls._routing_strategies:
+            raise ValueError(
+                f"Unknown routing strategy: {strategy_name}. "
+                f"Available strategies: {list(cls._routing_strategies.keys())}"
+            )
+        return RoutingSimulator._routing_strategies[strategy_name]
+
+    @classmethod
+    def simulate_monolithic_logits(
+        cls,
+        router_logits: torch.Tensor,
+        strategy_name: str,
+    ) -> torch.Tensor:
+        """Generate synthetic logits for a registered routing strategy."""
+        strategy = RoutingSimulator.get_strategy(strategy_name)
+        logger.warning_once(
+            "Simulating MoE routing using a %s strategy. "
+            "This should only be used for performance testing. "
+            "Model outputs will not be valid.",
+            strategy_name,
+        )
+
+        simulated_logits = strategy.generate_monolithic_logits(router_logits)
+        if simulated_logits is None:
+            raise NotImplementedError(
+                f"Routing strategy {strategy_name!r} does not yet support "
+                "monolithic logits generation."
+            )
+
+        return simulated_logits
+
     @staticmethod
     def simulate_routing(
         hidden_states: torch.Tensor,
@@ -279,12 +339,7 @@ class RoutingSimulator:
         Returns:
             tuple of (topk_weights, topk_ids)
         """
-        if strategy_name not in RoutingSimulator._routing_strategies:
-            raise ValueError(
-                f"Unknown routing strategy: {strategy_name}. "
-                f"Available strategies: "
-                f"{list(RoutingSimulator._routing_strategies.keys())}"
-            )
+        strategy = RoutingSimulator.get_strategy(strategy_name)
         logger.warning_once(
             "Simulating MoE routing using a %s strategy. "
             "This should only be used for performance testing. "
@@ -292,7 +347,6 @@ class RoutingSimulator:
             strategy_name,
         )
 
-        strategy = RoutingSimulator._routing_strategies[strategy_name]
         return strategy.route_tokens(
             hidden_states=hidden_states,
             router_logits=router_logits,
@@ -308,6 +362,7 @@ class RoutingSimulatorRouter(BaseRouter):
         self,
         top_k: int,
         global_num_experts: int,
+        original_routing_method_type: RoutingMethodType,
         eplb_state: EplbLayerState | None = None,
     ):
         super().__init__(
@@ -315,10 +370,15 @@ class RoutingSimulatorRouter(BaseRouter):
             global_num_experts=global_num_experts,
             eplb_state=eplb_state,
         )
+        self._original_routing_method_type = original_routing_method_type
 
     @property
     def routing_method_type(self) -> RoutingMethodType:
         return RoutingMethodType.Simulated
+
+    @property
+    def original_routing_method_type(self) -> RoutingMethodType:
+        return self._original_routing_method_type
 
     def _compute_routing(
         self,


### PR DESCRIPTION
Setting `VLLM_MOE_ROUTING_SIMULATION_STRATEGY=uniform_random` makes `RoutingSimulatorRouter` advertise the vLLM-only routing method `Simulated` (enum 102). The monolithic TRT-LLM NVFP4 backend bypasses `router.select_experts()` and forwards this enum to FlashInfer, which does not implement it and raises an exception.

Remove `Simulated` from the monolithic backend's supported routing methods. This lets backend selection fall back to `TrtLlmNvFp4ExpertsRouted`, where vLLM computes the simulated top-k expert IDs and weights before invoking FlashInfer.

Reproduction:

```bash
export VLLM_MOE_ROUTING_SIMULATION_STRATEGY=uniform_random

vllm serve \
  --model nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4 \
  --tensor-parallel-size 4
```

Previous error:

```text
RuntimeError: Unimplemented routing method InvalidRountingMethod of enum 102
```



## Purpose

Fix simulated MoE routing with the monolithic TRT-LLM NVFP4 backend. `Simulated` routing is now rejected by the monolithic path, allowing vLLM to fall back to the routed implementation instead of passing unsupported enum 102 to FlashInfer.

## Test Plan

```bash
export VLLM_MOE_ROUTING_SIMULATION_STRATEGY=uniform_random

vllm serve \
  --model nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4 \
  --tensor-parallel-size 4
```

## Test Result

before fix - vllm raises an exception ("Unimplemented routing method InvalidRountingMethod of enum 102")
after - no exception 