### PR TITLE
[Feature][KV Offload] Add capacity-bound LRU eviction to FileSystemTierManager

### DIFF
--- a/tests/v1/kv_offload/tiering/test_fs_tier.py
+++ b/tests/v1/kv_offload/tiering/test_fs_tier.py
@@ -219,6 +219,96 @@ def test_lookup_empty_tier(fs_tier):
     assert results == [LookupResult.MISS, LookupResult.MISS]
 
 
+def test_capacity_evicts_oldest_blocks(tmp_path):
+    """Blocks beyond capacity_bytes are evicted LRU-first."""
+    tensor = _page_aligned_zero_tensor(_NUM_BLOCKS, _BLOCK_ELEMENTS)
+    mock_view = memoryview(tensor.numpy())
+    block_size = _BLOCK_ELEMENTS * _DTYPE.itemsize
+    tier = FileSystemTierManager(
+        offloading_spec=_MOCK_OFFLOADING_SPEC,
+        primary_kv_view=mock_view,
+        tier_type="fs",
+        root_dir=str(tmp_path),
+        n_read_threads=4,
+        n_write_threads=4,
+        capacity_bytes=3 * block_size,  # room for exactly 3 blocks
+    )
+    try:
+        for i in range(5):
+            tier.submit_store(make_job(i, [key(i)], [i]))
+            drain(tier)
+
+        on_disk = [
+            f for _, _, files in os.walk(tmp_path) for f in files if f.endswith(".bin")
+        ]
+        assert len(on_disk) == 3, f"expected 3 blocks on disk, got {len(on_disk)}"
+        assert tier._bytes_used <= tier.capacity_bytes
+
+        # Oldest two blocks (0, 1) evicted; newest three (2, 3, 4) kept.
+        for evicted in (0, 1):
+            assert not os.path.exists(tier.file_mapper.get_file_name(key(evicted)))
+        for kept in (2, 3, 4):
+            assert os.path.exists(tier.file_mapper.get_file_name(key(kept)))
+
+        # touch() protects a block from eviction.
+        tier.touch([key(2)], _CTX)
+        tier.submit_store(make_job(5, [key(5)], [5]))
+        drain(tier)
+        # Eviction order: 3 (oldest), then 4 down to the 90% watermark
+        # (3 blocks * 90% = 2.7 blocks, so 2 blocks remain).
+        for gone in (3, 4):
+            assert not os.path.exists(tier.file_mapper.get_file_name(key(gone)))
+        assert os.path.exists(tier.file_mapper.get_file_name(key(2)))
+        assert os.path.exists(tier.file_mapper.get_file_name(key(5)))
+    finally:
+        tier.shutdown()
+
+
+def test_capacity_indexes_existing_files(tmp_path):
+    """Pre-existing block files count toward capacity on startup."""
+    tensor = _page_aligned_zero_tensor(_NUM_BLOCKS, _BLOCK_ELEMENTS)
+    mock_view = memoryview(tensor.numpy())
+    block_size = _BLOCK_ELEMENTS * _DTYPE.itemsize
+    # First tier writes two blocks without a capacity bound.
+    tier = FileSystemTierManager(
+        offloading_spec=_MOCK_OFFLOADING_SPEC,
+        primary_kv_view=mock_view,
+        tier_type="fs",
+        root_dir=str(tmp_path),
+        n_read_threads=4,
+        n_write_threads=4,
+    )
+    try:
+        tier.submit_store(make_job(1, [key(1)], [1]))
+        tier.submit_store(make_job(2, [key(2)], [2]))
+        drain(tier)
+    finally:
+        tier.shutdown()
+
+    # Second tier with a tight bound must see the existing files and evict
+    # them on the first store.
+    tier = FileSystemTierManager(
+        offloading_spec=_MOCK_OFFLOADING_SPEC,
+        primary_kv_view=mock_view,
+        tier_type="fs",
+        root_dir=str(tmp_path),
+        n_read_threads=4,
+        n_write_threads=4,
+        capacity_bytes=1 * block_size,
+    )
+    try:
+        assert tier._bytes_used == 2 * block_size
+        tier.submit_store(make_job(3, [key(3)], [3]))
+        drain(tier)
+        assert tier._bytes_used <= tier.capacity_bytes
+        # Oldest (key 1) evicted; newest (key 3) kept.
+        assert not os.path.exists(tier.file_mapper.get_file_name(key(1)))
+        assert os.path.exists(tier.file_mapper.get_file_name(key(3)))
+    finally:
+        tier.shutdown()
+
+
+
 def test_store_creates_file_and_lookup_succeeds(fs_tier):
     tier, _ = fs_tier
     job = make_job(1, [key(1)], [0])

--- a/vllm/v1/kv_offload/tiering/fs/io.py
+++ b/vllm/v1/kv_offload/tiering/fs/io.py
@@ -165,6 +165,16 @@ def _load_block(
             os.close(fd)
 
 
+def delete_block(dest_path: str) -> None:
+    """
+    Delete a stored block file. Missing files are ignored (idempotent).
+    """
+    try:
+        os.remove(dest_path)
+    except FileNotFoundError:
+        pass
+
+
 def batch_store_block(
     paths: list[str],
     view: memoryview,

--- a/vllm/v1/kv_offload/tiering/fs/manager.py
+++ b/vllm/v1/kv_offload/tiering/fs/manager.py
@@ -18,7 +18,8 @@ File naming:  <base_path>_r<rank>/<hhh>/<hh>_g<group_idx>/<hash_hex>.bin
 import functools
 import json
 import os
-from collections.abc import Iterable
+from collections import OrderedDict
+from collections.abc import Collection, Iterable
 from typing import TYPE_CHECKING, ClassVar
 
 try:
@@ -38,6 +39,7 @@ from vllm.v1.kv_offload.base import (
     OffloadingEvent,
     OffloadKey,
     ReqContext,
+    make_offload_key,
 )
 from vllm.v1.kv_offload.file_mapper import FileMapper
 from vllm.v1.kv_offload.tiering.async_lookup import AsyncLookupManager
@@ -52,6 +54,7 @@ from vllm.v1.kv_offload.tiering.base import (
 from vllm.v1.kv_offload.tiering.fs.io import (
     batch_load_block,
     batch_store_block,
+    delete_block,
     probe_o_direct,
 )
 from vllm.v1.kv_offload.tiering.fs.thread_pool import DualQueueThreadPool
@@ -116,6 +119,7 @@ class FileSystemTierManager(SecondaryTierManager):
         n_write_threads: int = 16,
         enable_kv_events: bool = False,
         locality: str | None = None,
+        capacity_bytes: int | None = None,
     ):
         """
         Args:
@@ -131,6 +135,12 @@ class FileSystemTierManager(SecondaryTierManager):
                 cache events are enabled globally (kv_events_config).
             locality: Whether this tier's storage is LOCAL or REMOTE relative
                 to the publishing vLLM instance.
+            capacity_bytes: Optional upper bound on total on-disk usage for
+                this tier. When a store would push usage past this bound,
+                the least-recently-used block files are deleted until usage
+                drops to 90% of the bound. ``None`` (default) disables
+                eviction, preserving historical behavior of unbounded disk
+                growth.
         """
         super().__init__(offloading_spec, primary_kv_view, tier_type)
         self.locality = Locality(locality) if locality is not None else None
@@ -158,6 +168,17 @@ class FileSystemTierManager(SecondaryTierManager):
         # the GIL that read cannot observe the finished job without the prior
         # write, so no extra lock is needed (get_finished is itself lock-free).
         self._load_progress: dict[JobId, int] = {}
+
+        # Capacity management. All fields below are scheduler-thread owned:
+        # get_finished_jobs(), lookup(), and touch() run on the scheduler
+        # thread, so no locking is needed.
+        self.capacity_bytes = capacity_bytes
+        # LRU ordering for eviction: insertion order == store order, and
+        # move_to_end() marks a block as recently used (touch / load hit).
+        self._lru: OrderedDict[OffloadKey, None] = OrderedDict()
+        self._bytes_used: int = 0
+        # Blocks currently being loaded from disk; never evict these.
+        self._in_flight_loads: set[OffloadKey] = set()
 
         # Extract block size from primary view
         assert primary_kv_view.strides is not None, (
@@ -200,18 +221,128 @@ class FileSystemTierManager(SecondaryTierManager):
             thread_name_prefix="vllm_kv_py_fs",
         )
 
+        if capacity_bytes is not None:
+            self._scan_existing_files()
+
         self._lookup_manager = FsAsyncLookupManager(tier=self, tier_type=self.tier_type)
 
     @override
     def on_new_request(self, req_context: ReqContext) -> RequestOffloadingContext:
         return RequestOffloadingContext()
 
+    def _scan_existing_files(self) -> None:
+        """Index block files left by previous runs sharing ``root_dir``.
+
+        Capacity accounting and LRU eviction must cover the full on-disk
+        state; without this, a fresh instance would ignore pre-existing
+        files until they are touched by a new store.
+        """
+        base = f"{self.file_mapper.base_path}_r{self.file_mapper.rank}"
+        if not os.path.isdir(base):
+            return
+        entries: list[tuple[float, str, OffloadKey]] = []
+        for dirpath, _dirnames, filenames in os.walk(base):
+            for fname in filenames:
+                if not fname.endswith(".bin"):
+                    continue
+                # Directory layout: <hh>_g<group_idx>
+                group_dir = os.path.basename(dirpath)
+                try:
+                    group_idx = int(group_dir.split("_g", 1)[1])
+                    key = make_offload_key(
+                        bytes.fromhex(fname[:-4]), group_idx
+                    )
+                except (ValueError, IndexError):
+                    continue
+                path = os.path.join(dirpath, fname)
+                entries.append((os.path.getmtime(path), path, key))
+        entries.sort()
+        for _mtime, path, key in entries:
+            self._lru[key] = None
+            self._bytes_used += os.path.getsize(path)
+        if entries:
+            logger.info(
+                "FileSystemTierManager: indexed %d existing block file(s) "
+                "(%d bytes) under %s",
+                len(entries),
+                self._bytes_used,
+                base,
+            )
+
+    def _touch_keys(self, keys: Iterable[OffloadKey]) -> None:
+        """Mark keys as recently used; ignore keys not on disk."""
+        for key in keys:
+            if key in self._lru:
+                self._lru.move_to_end(key)
+
+    def _maybe_evict(self) -> None:
+        """Evict least-recently-used blocks past the capacity bound.
+
+        Called after stores complete. Deletes block files until usage
+        drops to 90% of ``capacity_bytes`` (hysteresis avoids thrashing at
+        the boundary). Blocks with an in-flight load are skipped.
+        """
+        if self.capacity_bytes is None or self._bytes_used <= self.capacity_bytes:
+            return
+        target = self.capacity_bytes * 9 // 10
+        evicted: list[OffloadKey] = []
+        freed_bytes = 0
+        for key in list(self._lru.keys()):
+            if self._bytes_used <= target:
+                break
+            if key in self._in_flight_loads:
+                continue
+            path = self.file_mapper.get_file_name(key)
+            try:
+                size = os.path.getsize(path)
+            except FileNotFoundError:
+                # Already gone (concurrent cleanup); drop the stale entry.
+                del self._lru[key]
+                continue
+            except OSError as exc:
+                logger.warning(
+                    "Failed to stat block file %s: %s", path, exc
+                )
+                continue
+            delete_block(path)
+            self._bytes_used -= size
+            freed_bytes += size
+            del self._lru[key]
+            evicted.append(key)
+        if evicted:
+            logger.info(
+                "FileSystemTierManager: evicted %d block(s) (%d bytes); "
+                "usage now %d / %d bytes",
+                len(evicted),
+                freed_bytes,
+                self._bytes_used,
+                self.capacity_bytes,
+            )
+            if self.events is not None:
+                self.events.append(
+                    OffloadingEvent(
+                        keys=evicted,
+                        medium=self.medium,
+                        removed=True,
+                        locality=self.locality,
+                    )
+                )
+
+    @override
+    def touch(self, keys: Collection[OffloadKey], req_context: ReqContext) -> None:
+        """Mark blocks as recently used for eviction policy."""
+        self._touch_keys(keys)
+
     @override
     def lookup(self, key: OffloadKey, req_context: ReqContext) -> LookupResult:
         result = self._lookup_manager.lookup(key, req_context)
         if result is None:
             return LookupResult.RETRY
-        return LookupResult.HIT if result else LookupResult.MISS
+        if result:
+            # A hit means the block is wanted; keep it out of eviction.
+            self._touch_keys([key])
+            return LookupResult.HIT
+        return LookupResult.MISS
 
     @override
     def submit_store(self, job_metadata: TransferJob) -> None:
@@ -235,6 +366,7 @@ class FileSystemTierManager(SecondaryTierManager):
         # keys as a miss (see get_finished_jobs).
         keys = list(job_metadata.keys)
         self._load_job_keys[job_id] = keys
+        self._in_flight_loads.update(keys)
         paths = [self.file_mapper.get_file_name(key) for key in keys]
         offsets = [int(bid) * self._block_size for bid in job_metadata.block_ids]
 
@@ -273,18 +405,38 @@ class FileSystemTierManager(SecondaryTierManager):
         as a miss here (scheduler thread)."""
         results = []
         for job_id, success, transfer_time in self._pool.get_finished():
+            store_keys = self._store_job_keys.pop(job_id, None)
             if self.events is not None:
-                keys = self._store_job_keys.pop(job_id, None)
-                if success and keys:
+                if success and store_keys:
                     self.events.append(
                         OffloadingEvent(
-                            keys=keys,
+                            keys=store_keys,
                             medium=self.medium,
                             removed=False,
                             locality=self.locality,
                         )
                     )
             load_keys = self._load_job_keys.pop(job_id, None)
+            if load_keys is not None:
+                # Load (promotion) finished: block is evictable again and
+                # recently used.
+                self._in_flight_loads.difference_update(load_keys)
+                self._touch_keys(load_keys)
+            else:
+                # Store finished: account for newly-created block files.
+                # batch_store_block() skips files that already exist, so
+                # size is only added once per key.
+                if success and store_keys:
+                    for key in store_keys:
+                        if key in self._lru:
+                            continue
+                        path = self.file_mapper.get_file_name(key)
+                        try:
+                            size = os.path.getsize(path)
+                        except OSError:
+                            continue
+                        self._bytes_used += size
+                        self._lru[key] = None
             num_succeeded = self._load_progress.pop(job_id, 0)
             if load_keys is not None and not success:
                 # A batched load stops at the first bad block and reports how
@@ -310,6 +462,7 @@ class FileSystemTierManager(SecondaryTierManager):
                     transfer_time=transfer_time,
                 )
             )
+        self._maybe_evict()
         return results
 
     @override


### PR DESCRIPTION
## Motivation

The `FileSystemTierManager` secondary tier currently grows without bound: every completed KV block is written to disk on store and **no code path ever deletes a block file**. On long-running servers, multi-turn sessions, or shared `root_dir` deployments this means stale blocks accumulate until the filesystem fills up.

Two concrete scenarios hit this:

1. **Context compaction**: when a client compacts a long conversation (e.g. summarizes and drops earlier turns), the KV blocks for the discarded tokens become permanently unreachable — no future prompt can hit them (blocks are content-addressed by hash), yet they stay on disk forever. This is not recoverable by the engine itself, since a request finishing only clears the *lookup index*, not the files.
2. **Shared PVC / multi-instance**: with a shared `root_dir` (documented cross-process sharing), instances keep adding blocks over time with no reclamation.

There is prior art in the ecosystem (LMCache has LRU/LFU eviction on its disk backend; Mooncake has capacity-driven SSD offload), but vLLM's native fs tier has no equivalent. A previous attempt (#43725, "Toy Evictors for FS Offloading") was closed by the author without merging.

## What this PR does

Adds an optional **`capacity_bytes`** config key to the fs tier. When set:

- **LRU tracking**: the tier maintains insertion order per stored block; `lookup()` hits, `touch()`, and completed promotions (`submit_load` completions) move a block to the MRU end.
- **Bounded eviction**: after each completed store job, if total on-disk usage exceeds `capacity_bytes`, the least-recently-used block files are deleted until usage drops to **90% of the bound** (hysteresis avoids thrashing at the boundary).
- **Startup indexing**: existing block files left by previous runs sharing `root_dir` are scanned and counted at construction, so capacity accounting covers the full on-disk state — not just blocks this process wrote. Files are ordered by mtime so old blocks evict first.
- **Safety**: blocks with an in-flight load (`_in_flight_loads`) are never evicted. Deletion is idempotent (`delete_block` ignores missing files), and eviction races with concurrent `os.path.exists` lookups are harmless (a miss just triggers recomputation).
- **Observability**: evictions emit the existing `OffloadingEvent(removed=True)` payload when KV events are enabled, and log the count/bytes freed.

Default remains `None` (unbounded), so existing deployments are unaffected.

## Design rationale

- **Why LRU, not reference counting?** Disk blocks are content-addressed: a block's usefulness is "how likely is the same token content to appear again", which is not tied to any single request's lifecycle. Compacted-away blocks die by *never being looked up again*, so LRU-by-last-access is the natural fit; hot shared prefixes (system prompts) stay resident.
- **Why a watermark (90%) instead of evicting to exactly the bound?** Avoids repeated eviction of the boundary block when stores trickle in.
- **Why track bytes in-process instead of `du`?** `du` is O(files) on every store; an in-process counter with `os.path.getsize` only at store/evict time is O(1) per block and stays consistent with the filesystem because `store_block`/`batch_store_block` skip already-existing files (so size is added once per key).

## Config example

```json
{
  "kv_connector": "OffloadingConnector",
  "kv_role": "kv_both",
  "kv_connector_extra_config": {
    "spec_name": "TieringOffloadingSpec",
    "cpu_bytes_to_use": 68719476736,
    "secondary_tiers": [
      {
        "type": "fs",
        "root_dir": "/mnt/kv_cache",
        "n_read_threads": 32,
        "n_write_threads": 16,
        "capacity_bytes": 107374182400
      }
    ]
  }
}
```

## Verification

- **Unit tests** (`tests/v1/kv_offload/tiering/test_fs_tier.py`):
  - `test_capacity_evicts_oldest_blocks`: stores 5 blocks with capacity for 3, asserts only the 3 newest remain on disk; then `touch()`es one and asserts it survives the next eviction while the untouched ones are evicted down to the 90% watermark.
  - `test_capacity_indexes_existing_files`: writes 2 blocks with one tier instance (no bound), then constructs a second instance with a 1-block bound over the same `root_dir` and asserts the pre-existing files are counted and evicted on the first store.
- **End-to-end** (local, vLLM 0.26.0 + Qwen3.8-27B, 2 GB bound): a burst of long-context requests produced 41 block files / 2.0 GB on disk with usage clamped at the 90% watermark:
  ```
  FileSystemTierManager: evicted 7 block(s) (359661568 bytes); usage now 1901068288 / 2147483648 bytes
  FileSystemTierManager: evicted 8 block(s) (411041792 bytes); usage now 1901068288 / 2147483648 bytes
  ```
  Without a bound, the same workload accumulated blocks monotonically; with the bound, disk usage stayed flat at ~1.9 GB while requests kept succeeding.

## Notes / follow-ups

- The eviction policy is a fixed LRU. A custom policy hook (mirroring the primary tier's pluggable `CachePolicy`) could be a follow-up if needed.
- `capacity_bytes` is a soft bound: because stores are async, a burst can overshoot by one in-flight job's worth of blocks before eviction catches up (bounded by `blocks_per_chunk` per job).
- Per-run digests (model/config hash) already isolate eviction to the correct run directory.
