### PR TITLE
fix(deepseek_v4): gate head_dim==512 compressor path on has_cutedsl()

### DIFF
--- a/vllm/models/deepseek_v4/compressor.py
+++ b/vllm/models/deepseek_v4/compressor.py
@@ -21,6 +21,7 @@ from vllm.models.deepseek_v4.common.ops.save_partial_states import (
     save_partial_states,
 )
 from vllm.platforms import current_platform
+from vllm.utils.import_utils import has_cutedsl
 from vllm.v1.attention.backend import (
     AttentionBackend,
     AttentionCGSupport,
@@ -419,7 +420,7 @@ class DeepseekCompressor(nn.Module):
         # cutedsl (head=512) accepts the full-cache flags; triton (indexer/AMD)
         # does not, so the two callables have different signatures.
         compress_norm_rope_store_fn: Any
-        if current_platform.is_cuda() and self.head_dim == 512:
+        if current_platform.is_cuda() and self.head_dim == 512 and has_cutedsl():
             from .nvidia.ops.sparse_attn_compress_cutedsl import (
                 compress_norm_rope_store_cutedsl,
             )


### PR DESCRIPTION
Fixes vllm-project/vllm#52710

## Summary
`DeepseekCompressor`'s `head_dim == 512` CuTe DSL kernel path was selected unconditionally on CUDA:

```python
if current_platform.is_cuda() and self.head_dim == 512:
```

...which imports `sparse_attn_compress_cutedsl` even when the optional `cutlass` (CuTe DSL) package is not importable, failing at kernel dispatch on builds that don't ship it — e.g. an H200 (sm_90a) target. Every other DeepSeek V4 CUDA/DS kernel selection site gates on `has_cutedsl()` (cache_utils.py:412, fused_indexer_q.py:367/440), and `nvidia/ops/__init__.py` documents that leaf modules must only be imported under a `has_cutedsl()`/`is_cuda()` gate.

Added `has_cutedsl()` to the guard and the import, matching the established pattern, so the Triton fallback is used when CuTe DSL isn't available.

## Verification
- `has_cutedsl()` exists at `vllm/utils/import_utils.py:578` and is used the same way at the three sibling call sites.
- `compressor.py` parses cleanly (the module-level import is unconditional at line 24, consistent with how the other DSv4 files import it).
- Signed-off-by included.
