### PR TITLE
[CI] Upgrade huggingface-hub to 1.28.0

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -8,7 +8,7 @@ tqdm
 blake3
 py-cpuinfo
 transformers >= 5.5.3
-huggingface_hub >= 1.27.0
+huggingface_hub >= 1.28.0
 tokenizers >= 0.21.1  # Required for fast incremental detokenization.
 safetensors >= 0.6.2  # MXFP4/MXFP6 dtype support (F8_E8M0, F4) added in 0.6.0: https://github.com/huggingface/safetensors/pull/611
 protobuf >= 5.29.6, !=6.30.*, !=6.31.*, !=6.32.*, !=6.33.0.*, !=6.33.1.*, !=6.33.2.*, !=6.33.3.*, !=6.33.4.* # Required by LlamaTokenizer, gRPC. CVE-2026-0994

--- a/requirements/test/cpu.txt
+++ b/requirements/test/cpu.txt
@@ -339,7 +339,7 @@ httpx==0.27.2
     #   schemathesis
 httpx-sse==0.4.3
     # via mcp
-huggingface-hub==1.27.0
+huggingface-hub==1.28.0
     # via
     #   -r requirements/test/../common.txt
     #   accelerate

--- a/requirements/test/cuda.txt
+++ b/requirements/test/cuda.txt
@@ -358,7 +358,7 @@ httpx==0.27.2
     #   schemathesis
 httpx-sse==0.4.3
     # via mcp
-huggingface-hub==1.27.0
+huggingface-hub==1.28.0
     # via
     #   -c requirements/common.txt
     #   -r requirements/test/../common.txt

--- a/requirements/test/rocm.txt
+++ b/requirements/test/rocm.txt
@@ -349,7 +349,7 @@ httpx==0.27.2
     #   schemathesis
 httpx-sse==0.4.3
     # via mcp
-huggingface-hub==1.27.0
+huggingface-hub==1.28.0
     # via
     #   -c requirements/common.txt
     #   -r requirements/test/../common.txt

--- a/requirements/test/xpu.txt
+++ b/requirements/test/xpu.txt
@@ -224,7 +224,7 @@ httpx==0.28.1
     #   schemathesis
 httpx-sse==0.4.3
     # via mcp
-huggingface-hub==1.27.0
+huggingface-hub==1.28.0
     # via
     #   -c requirements/common.txt
     #   -r requirements/test/../common.txt


### PR DESCRIPTION
Version bump for `huggingface_hub` version from 1.27.0 to 1.28.0