### PR TITLE
[Build] Add InstantTensor to CUDA dependencies

### DIFF
--- a/requirements/cuda.txt
+++ b/requirements/cuda.txt
@@ -23,6 +23,7 @@ nvidia-cudnn-frontend>=1.19.1
 nvtx==0.2.15
 # Required for faster safetensors model loading
 fastsafetensors >= 0.3.3
+instanttensor >= 0.1.9
 
 # QuACK and Cutlass DSL for FA4 (cute-DSL implementation)
 nvidia-cutlass-dsl[cu13]==4.6.2

--- a/requirements/test/cuda.txt
+++ b/requirements/test/cuda.txt
@@ -406,7 +406,9 @@ inflect==5.6.2
 iniconfig==2.0.0
     # via pytest
 instanttensor==0.1.9
-    # via -r requirements/test/cuda.in
+    # via
+    #   -c requirements/cuda.txt
+    #   -r requirements/test/cuda.in
 interegular==0.3.3
     # via lm-format-enforcer
 isodate==0.7.2


### PR DESCRIPTION
## Purpose

Add InstantTensor `>=0.1.9` to the default CUDA dependencies and regenerate
the CUDA test lockfile to record the production constraint.

InstantTensor is ready to ship with CUDA installs and only depends on Torch,
which vLLM already requires. This does not enable the InstantTensor loader by
default; loader selection remains unchanged.

This does not duplicate an existing PR. I searched open PRs for InstantTensor
and CUDA dependency changes. #37309 is a non-merge CI experiment that enables
the loader by default and does not add InstantTensor to the production CUDA
requirements.

## Test Plan

Run the focused pre-commit hooks for both changed requirements files.

## Test Result

`/home/mgoin/code/vllm/.venv/bin/pre-commit run --files requirements/cuda.txt requirements/test/cuda.txt` passed, including `pip-compile` dependency resolution and lockfile consistency.

`git diff --check` passed.

Model evaluations are not applicable because this only changes package
installation; model behavior and loader defaults are unchanged.

AI assistance was used to prepare this change and PR. The human submitter must
review every changed line and understand and defend the change end-to-end.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR.
- [x] The test plan.
- [x] The test results.
- [x] Documentation updates are not needed for this dependency-only change.
</details>

