### PR TITLE
[Bugfix][Structured Output] Stop XGrammar token batches at termination

### DIFF
--- a/tests/v1/spec_decode/test_mtp_structured_output.py
+++ b/tests/v1/spec_decode/test_mtp_structured_output.py
@@ -262,6 +262,45 @@ def test_validate_tokens_then_bitmask_round_trip(backend):
     assert not grammar.is_terminated()
 
 
+def test_xgrammar_accept_tokens_stops_at_termination(capfd):
+    """Tokens after a terminating EOS do not reach the matcher."""
+    tokenizer, _, request, prompt = _make_manager_and_request("xgrammar")
+    grammar = request.structured_output_request.grammar
+
+    assert grammar.accept_tokens(request.request_id, prompt)
+
+    eos = tokenizer.eos_token_id
+    trailing = tokenizer.encode("\n")[0]
+    processed_before = grammar.num_processed_tokens
+
+    assert grammar.accept_tokens(request.request_id, [eos, trailing])
+    assert grammar.is_terminated()
+    assert grammar.num_processed_tokens == processed_before + 1
+    assert "trying to accept new token" not in capfd.readouterr().err
+
+    grammar.reset()
+    assert not grammar.is_terminated()
+    assert grammar.num_processed_tokens == 0
+
+
+def test_xgrammar_validate_tokens_stops_at_termination(capfd):
+    """Validation rolls back after reaching a terminating EOS."""
+    tokenizer, _, request, prompt = _make_manager_and_request("xgrammar")
+    grammar = request.structured_output_request.grammar
+
+    assert grammar.accept_tokens(request.request_id, prompt)
+
+    eos = tokenizer.eos_token_id
+    trailing = tokenizer.encode("\n")[0]
+
+    assert grammar.validate_tokens([eos, trailing]) == [eos]
+    assert "trying to accept new token" not in capfd.readouterr().err
+    assert not grammar.is_terminated()
+
+    assert grammar.accept_tokens(request.request_id, [eos])
+    assert grammar.is_terminated()
+
+
 class _MarkerReasoner:
     """Stub reasoner whose reasoning-end marker is a single fixed token."""
 

--- a/tests/v1/spec_decode/test_mtp_structured_output.py
+++ b/tests/v1/spec_decode/test_mtp_structured_output.py
@@ -300,7 +300,8 @@ def test_xgrammar_validate_tokens_stops_at_termination(capfd):
 
     assert grammar.validate_tokens([eos, trailing]) == [eos]
     assert "trying to accept new token" not in capfd.readouterr().err
-    assert not grammar.is_terminated()
+    # Check matcher state directly to verify validation rolled it back.
+    assert not grammar.matcher.is_terminated()
 
     assert grammar.accept_tokens(request.request_id, [eos])
     assert grammar.is_terminated()

--- a/tests/v1/spec_decode/test_mtp_structured_output.py
+++ b/tests/v1/spec_decode/test_mtp_structured_output.py
@@ -278,6 +278,11 @@ def test_xgrammar_accept_tokens_stops_at_termination(capfd):
     assert grammar.num_processed_tokens == processed_before + 1
     assert "trying to accept new token" not in capfd.readouterr().err
 
+    processed_after_eos = grammar.num_processed_tokens
+    assert grammar.accept_tokens(request.request_id, [trailing])
+    assert grammar.num_processed_tokens == processed_after_eos
+    assert "trying to accept new token" not in capfd.readouterr().err
+
     grammar.reset()
     assert not grammar.is_terminated()
     assert grammar.num_processed_tokens == 0
@@ -299,6 +304,9 @@ def test_xgrammar_validate_tokens_stops_at_termination(capfd):
 
     assert grammar.accept_tokens(request.request_id, [eos])
     assert grammar.is_terminated()
+
+    assert grammar.validate_tokens([trailing]) == []
+    assert "trying to accept new token" not in capfd.readouterr().err
 
 
 class _MarkerReasoner:

--- a/vllm/v1/structured_output/backend_xgrammar.py
+++ b/vllm/v1/structured_output/backend_xgrammar.py
@@ -164,6 +164,7 @@ class XgrammarGrammar(StructuredOutputGrammar):
             return False
         for token in tokens:
             if not self.matcher.accept_token(token):
+                self._is_terminated = self.matcher.is_terminated()
                 logger.error(
                     "Failed to advance FSM for request %s "
                     "for tokens %s. Please file an issue.",
@@ -172,7 +173,9 @@ class XgrammarGrammar(StructuredOutputGrammar):
                 )
                 return False
             self.num_processed_tokens += 1
-        self._is_terminated = self.matcher.is_terminated()
+            self._is_terminated = self.matcher.is_terminated()
+            if self._is_terminated:
+                break
         return True
 
     def validate_tokens(self, tokens: list[int]) -> list[int]:
@@ -185,6 +188,8 @@ class XgrammarGrammar(StructuredOutputGrammar):
         for token in tokens:
             if self.matcher.accept_token(token):
                 accepted_tokens.append(token)
+                if self.matcher.is_terminated():
+                    break
             else:
                 break
         if len(accepted_tokens) > 0:
@@ -204,8 +209,9 @@ class XgrammarGrammar(StructuredOutputGrammar):
         return self._is_terminated
 
     def reset(self):
-        self.num_processed_tokens = 0
         self.matcher.reset()
+        self.num_processed_tokens = 0
+        self._is_terminated = False
 
 
 # cf https://github.com/mlc-ai/xgrammar/blob/a32ac892676d2eedc0327416105b9b06edfb94b2/cpp/json_schema_converter.cc

--- a/vllm/v1/structured_output/backend_xgrammar.py
+++ b/vllm/v1/structured_output/backend_xgrammar.py
@@ -161,10 +161,9 @@ class XgrammarGrammar(StructuredOutputGrammar):
         Returns False if the FSM failed to advance.
         """
         if self._is_terminated:
-            return False
+            return True
         for token in tokens:
             if not self.matcher.accept_token(token):
-                self._is_terminated = self.matcher.is_terminated()
                 logger.error(
                     "Failed to advance FSM for request %s "
                     "for tokens %s. Please file an issue.",
@@ -184,6 +183,9 @@ class XgrammarGrammar(StructuredOutputGrammar):
 
         Returns the prefix list of tokens that are accepted by the FSM.
         """
+        if self._is_terminated:
+            return []
+
         accepted_tokens = []
         for token in tokens:
             if self.matcher.accept_token(token):

--- a/vllm/v1/structured_output/backend_xgrammar.py
+++ b/vllm/v1/structured_output/backend_xgrammar.py
@@ -157,8 +157,9 @@ class XgrammarGrammar(StructuredOutputGrammar):
     def accept_tokens(self, request_id: str, tokens: list[int]) -> bool:
         """Accepts a list of tokens and advances the FSM.
 
-        Returns True if the FSM was advanced successfully.
-        Returns False if the FSM failed to advance.
+        Returns True if all grammar-constrained tokens were accepted.
+        Tokens after termination are ignored. Returns False if the FSM
+        failed to advance.
         """
         if self._is_terminated:
             return True


### PR DESCRIPTION
## Purpose
Prevent XGrammar from receiving additional tokens after accepting a terminating stop token within the same batch.
Fixes https://github.com/vllm-project/vllm/issues/52767.

This covers two related problems:
1. `accept_tokens()` could return early after rejection without synchronizing LLM's cached `_is_terminated` state.
2. Batched speculative acceptance and validation could continue past a terminating token, producing XGrammar warnings and possible FSM state inconsistencies.

## Test Plan
Unit test:
```
pytest tests/v1/spec_decode/test_mtp_structured_output.py
```

Live model test:
```
vllm serve Qwen/Qwen3.8-27B     
--tensor-parallel-size 2     
--enable-auto-tool-choice     
--tool-call-parser qwen3_coder     
--reasoning-parser qwen3     
--mm-encoder-tp-mode data     
--speculative-config '{"method":"mtp","num_speculative_tokens":3}
```
| Scenario | How the bug was triggered | Before fix | After fix |
|---|---|---|---|
| Tokens after termination | Aligned EOS with MTP draft slot 1 or 2, leaving additional draft tokens after EOS | Matcher processed tokens after termination and emitted warnings | 20/20 requests returned HTTP 200 without matcher errors |
| Second advance after termination | Used strict JSON with `ignore_eos=true` to force another grammar advance after EOS | HTTP 500 | 5/5 requests returned HTTP 200 |
| Normal tool calling | Sent strict-tool requests using `tool_choice=auto` and `required` | Baseline behavior | 10/10 requests returned correct tool calls |