### PR TITLE
[Bugfix][KV Offload] Do not let a recurrent group's unhashed block truncate the load boundary

### DIFF
--- a/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
+++ b/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
@@ -36,7 +36,12 @@ from vllm.distributed.kv_transfer.kv_connector.v1.offloading.scheduler import (
     is_store_reachable_swa_chunk,
 )
 from vllm.v1.core.kv_cache_manager import KVCacheBlocks
-from vllm.v1.core.kv_cache_utils import BlockHash, KVCacheBlock, KVCacheBlockCopy
+from vllm.v1.core.kv_cache_utils import (
+    BlockHash,
+    KVCacheBlock,
+    KVCacheBlockCopy,
+    make_block_hash_with_group_id,
+)
 from vllm.v1.core.sched.output import (
     KVConnectorBlockState,
     SchedulerOutput,
@@ -270,6 +275,64 @@ def test_partial_lookup_returns_exact_boundary_and_group_load_keys():
     assert dst_spec.group_sizes == [2, 1]
     assert dst_spec.block_indices == [0, 1]
     assert req_status.partial_tail_boundary is None
+
+
+def test_recurrent_group_unhashed_block_does_not_truncate_load_boundary():
+    """A recurrent group may hold unhashed blocks inside the computed prefix.
+
+    A recurrent (Mamba / GDN) group has no per-token KV: it carries a fixed-size
+    state, so most positions point at the null sentinel and the one real block
+    holding the state is legitimately not full-and-cached. Sliding-window groups
+    are similar -- neither is required to retain the whole prefix, so a non-null,
+    unhashed block can sit *below* the locally-computed mark. Scanning the
+    block list from index 0 treated such a block as the start of the freshly
+    allocated region, dragging the load boundary below that mark -- which loads the
+    wrong keys into the wrong destination blocks, and asserts on the way.
+
+    Geometry: tokens_per_block = tokens_per_chunk = 16, blocks_per_chunk = 1.
+    16 tokens are already computed (block 0) and 16 are loaded (block 1), so the
+    fresh region must start at index 1. The Mamba group's block 0 is non-null and
+    unhashed and must be ignored rather than taken as the boundary.
+    """
+    scheduler = _make_partial_tail_scheduler()
+
+    request = MagicMock()
+    request.request_id = "req"
+    request.kv_transfer_params = None
+    request.num_prompt_tokens = 64
+    request.num_tokens = 64
+    request.block_hashes = [BlockHash(f"b{i}".encode()) for i in range(16)]
+    request.all_token_ids = list(range(64))
+    request.lora_request = None
+    request.is_finished.return_value = False
+    scheduler.on_new_request(request)
+
+    req_status = scheduler._req_status["req"]
+    req_status.num_locally_computed_tokens = 16
+    req_status.update_offload_keys()
+
+    full_blocks = [KVCacheBlock(31), KVCacheBlock(32)]
+    mamba_blocks = [KVCacheBlock(41), KVCacheBlock(42)]
+    full_blocks[0].set_block_hash(
+        make_block_hash_with_group_id(BlockHash(b"h0"), 0), 16
+    )
+    # Both Mamba blocks are non-null and unhashed -- the shape a recurrent group
+    # produces for a prefix it does not retain.
+    for b in mamba_blocks:
+        assert b.block_hash is None and not b.is_null
+
+    scheduler.update_state_after_alloc(
+        request,
+        KVCacheBlocks((full_blocks, mamba_blocks)),
+        num_external_tokens=16,
+    )
+
+    [load_job] = scheduler._current_batch_load_jobs.values()
+    loaded = list(load_job.dst_spec.block_ids)
+    # The fresh region starts at index 1, so the sparse group's block 0 (id 41) is
+    # not a load destination. Before the fix the boundary collapsed to 0.
+    assert 41 not in loaded
+    assert 42 in loaded
 
 
 def test_partial_lookup_requires_every_cache_group():

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
@@ -1024,18 +1024,23 @@ class OffloadingConnectorScheduler:
             num_gpu_blocks = cdiv(num_cached_tokens, tokens_per_block)
 
             assert len(group_blocks) >= num_gpu_blocks
-            num_locally_computed_gpu_blocks = num_gpu_blocks
-            # Skip null placeholder blocks (used for sliding window or mamba padding).
-            for i, block in enumerate(group_blocks[:num_gpu_blocks]):
+            # ``load_start_gpu_block_idx``: the index in ``group_blocks`` where the
+            # load region begins -- a slice bound, not a count of computed blocks.
+            # Scan from the computed boundary, not 0: sparse groups (Mamba,
+            # SWA) legitimately hold non-null unhashed blocks below it.
+            # Skip nulls (sentinel / out-of-retention padding).
+            first_fresh_gpu_block_idx = cdiv(
+                num_locally_computed_tokens, tokens_per_block
+            )
+            load_start_gpu_block_idx = num_gpu_blocks
+            for i in range(first_fresh_gpu_block_idx, num_gpu_blocks):
+                block = group_blocks[i]
                 if not block.is_null and block.block_hash is None:
-                    num_locally_computed_gpu_blocks = i
+                    load_start_gpu_block_idx = i
                     break
 
-            assert (
-                num_locally_computed_tokens
-                <= num_locally_computed_gpu_blocks * tokens_per_block
-            )
-            num_pending_gpu_blocks = num_gpu_blocks - num_locally_computed_gpu_blocks
+            assert num_locally_computed_tokens % tokens_per_block == 0
+            num_pending_gpu_blocks = num_gpu_blocks - load_start_gpu_block_idx
 
             if group_config.sliding_window_size_in_chunks is not None:
                 assert (
@@ -1048,7 +1053,7 @@ class OffloadingConnectorScheduler:
             num_chunks = cdiv(num_cached_tokens, tokens_per_chunk)
             if num_pending_gpu_blocks:
                 start_chunk_idx = (
-                    num_locally_computed_gpu_blocks // self.config.blocks_per_chunk
+                    load_start_gpu_block_idx // self.config.blocks_per_chunk
                 )
                 end_chunk_idx = num_chunks - (partial_tail_boundary is not None)
                 assert len(offload_keys) >= end_chunk_idx
@@ -1062,12 +1067,10 @@ class OffloadingConnectorScheduler:
 
             dst_block_ids.extend(
                 block.block_id
-                for block in group_blocks[
-                    num_locally_computed_gpu_blocks:num_gpu_blocks
-                ]
+                for block in group_blocks[load_start_gpu_block_idx:num_gpu_blocks]
             )
             group_sizes.append(num_pending_gpu_blocks)
-            block_indices.append(num_locally_computed_gpu_blocks)
+            block_indices.append(load_start_gpu_block_idx)
 
             # Skip prefix-hit chunks for block-level policy; for
             # request-level, next_stored_chunk_idx stays at 0 so all


### PR DESCRIPTION
[`update_state_after_alloc`](https://github.com/vllm-project/vllm/blob/7ca49fbe4bab019e55d57cdc4b7fd3d55c67c1a6/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py#L993) scans [the allocated block list](https://github.com/vllm-project/vllm/blob/7ca49fbe4bab019e55d57cdc4b7fd3d55c67c1a6/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py#L1027-L1032) for the first block that is `not is_null and block_hash is None` and treats that index as the start of the freshly allocated region.

This PR also renames that value from `num_locally_computed_gpu_blocks` to **`load_start_gpu_block_idx`**. It is not a count of computed blocks — it is the index in `group_blocks` where the load region begins, used only as a slice bound. The old name is actively misleading: in `test_partial_lookup_returns_exact_boundary_and_group_load_keys` it is `1` while `num_locally_computed_tokens` is `0`. The `_gpu_block_idx` suffix follows the sibling store path (`_build_store_jobs`), which already calls its equivalent `start_gpu_block_idx` and feeds the same `block_indices` field; the `load_` prefix keeps the two unambiguous now that both are visible in one file. The store path is left untouched.

**The assertion that fires is [`scheduler.py#L1034-L1037`](https://github.com/vllm-project/vllm/blob/7ca49fbe4bab019e55d57cdc4b7fd3d55c67c1a6/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py#L1034-L1037)**, reached from [`Scheduler.schedule`](https://github.com/vllm-project/vllm/blob/7ca49fbe4bab019e55d57cdc4b7fd3d55c67c1a6/vllm/v1/core/sched/scheduler.py#L1069).

The scan started at **index 0** — inside the region already reported as locally computed, where every block is computed by definition. For a **recurrent (Mamba / GDN) group** that is not merely redundant but wrong. Such a group has no per-token KV at all: it carries a fixed-size state, which is why `get_sliding_window_size_in_chunks()` returns 1 for `MambaSpec` (["Mamba depends on a single state"](https://github.com/vllm-project/vllm/blob/7ca49fbe4bab019e55d57cdc4b7fd3d55c67c1a6/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py#L122)). Most positions in its block table point at the shared null sentinel, and the one real block holding the state is legitimately **not full-and-cached** — non-null, unhashed, sitting below the computed mark.

```
legend   [H] hashed   [·] null placeholder   [U] non-null, UNHASHED   [F] fresh

recurrent group (GDN/Mamba, window = 1 chunk), 21 chunks computed + 1 loaded:

  idx      0    1    2    3    4   ...   20   21
         [H]  [H]  [·]  [U]  [·]  ...   [·]  [F]
                         ^
BEFORE   scan starts at 0, stops here          boundary = 3
         |<-------- claimed computed: 21 ------------>|
         assert 21 <= 3   ✗  AssertionError
         load region would be blocks 3..21  ->  19 wrong destinations, wrong keys

AFTER    scan starts at first_fresh = 21 ------------>^
         boundary = 21,  assert 21 <= 21  ✓
         load region = block 21 only  ->  matches the 1-chunk hit
```

For a full-attention group this is a **no-op**: every token has KV, every block below the boundary is full-and-cached, so the old scan skipped them anyway. The existing assert now holds by construction (`nlcgb >= cdiv(nlct, tpb)` ⟹ `nlct <= nlcgb * tpb`); it is kept as a guard against other causes rather than deleted.

## Reproduction

4-node GB200, Qwen3.5-family hybrid GDN+GQA (4 KV cache groups, 3 recurrent), MTP, TP=4 x DP=4, 200 GiB host tier, `--num-gpu-blocks-override 259`. Under sustained load the leader crashed after **47,142 requests**:

```
  File "vllm/v1/core/sched/scheduler.py", line 963, in schedule
    self.connector.update_state_after_alloc(
  File ".../kv_connector/v1/offloading/scheduler.py", line 832, in update_state_after_alloc
    num_locally_computed_tokens
AssertionError

leader exit=1 | other three exit=137 (gang teardown)
```

The captured 3h22m window on the crashing rank makes the trigger unambiguous. It saw **22 lookups that hit offloaded tokens, but only 4 that were true partial hits** (`num_locally_computed_tokens > 0`) — and all four arrived in the last 36 seconds:

| time | external tokens | locally computed | outcome |
|---|---|---|---|
| 00:57 – 04:18 | 18 lookups | **0** | fine — assert reads `0 <= X` |
| 04:18:45 | 4256 | 8512 | ok |
| 04:18:52 | 2128 | 4256 | ok |
| 04:19:07 | 2128 | 10640 | ok |
| 04:19:21 | 4256 | 10640 | **AssertionError, same second** |

**Why this is easy to miss.** It needs `num_external_tokens > 0` **and** `num_locally_computed_tokens > 0`. Tests that flood to full eviction before re-sending produce `num_computed_tokens == 0` — 18 of the 22 lookups above — where the assert reads `0 <= X` and cannot fire. The rank sat clean for 3h21m under exactly that pattern before the first partial hits appeared.

### Reproduced on a build that carries the #49146 clamp

The assert is **not** masked by [#49146](https://github.com/vllm-project/vllm/pull/49146)'s `num_allocated_chunks` clamp (`94ed0bf4e0`, in `main`). A build composed as `#49146 clamp + #52771, without this fix` was put under sustained production traffic and asserted **three times across two independent clusters**, with a fault-free lifetime of roughly **20 minutes / ~850 requests**:

```
vllm/v1/core/sched/scheduler.py:963                     schedule
vllm/.../kv_connector/v1/offloading/scheduler.py:840    update_state_after_alloc
AssertionError
```

Both tracebacks are this same assertion. The line numbers above come from the deployed vLLM-0.26.0-based image, not from `main` (where it is [L1034-L1037](https://github.com/vllm-project/vllm/blob/7ca49fbe4bab019e55d57cdc4b7fd3d55c67c1a6/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py#L1034-L1037)): within that tree it sits at 832 without the #49146 clamp and at 840 with it, the clamp inserting exactly 8 lines above.

Across four builds under the same workload and config, the correlation is with **this fix**, not the clamp and not #52771:

| build | #49146 clamp | #52771 | this fix | fault-free lifetime |
|---|---|---|---|---|
| A | ✓ | — | — | 22–70 min, 3 asserts |
| B | — | ✓ | — | 10 / 30 / 40 / 88 min, ≥4 asserts |
| C | ✓ | ✓ | — | ~20 min, 3 asserts |
| D | ✓ | — | ✓ | **336 min, zero asserts** |

Every build lacking this fix asserts — including **two** that carry the clamp (A and C); the only build carrying this fix is the only one that holds. Memory was never implicated (no `OOMKilled`; peak well under limit).

A separate note on reproducing it: a synthetic driver that holds the hit *shape* constant does not surface this. On a smaller same-family deployment I drove **12,000 consecutive requests at a 100% true-partial-hit rate** with no assert — but every request had an identical `num_locally_computed_tokens`, so it probed one boundary alignment repeatedly. The production crashes arise under organically varied prefix lengths, which is what walks the boundary across block offsets.

### Why the boundary is exact, and why the null-skip stays

The caller block-aligns the local hit before handing it to the connector ([`scheduler.py`](https://github.com/vllm-project/vllm/blob/7ca49fbe4bab019e55d57cdc4b7fd3d55c67c1a6/vllm/v1/core/sched/scheduler.py#L830-L840)), so `num_locally_computed_tokens % tokens_per_block == 0` and `first_fresh_gpu_block` is exact. The existing assert then reduces to `boundary >= first_fresh_gpu_block` — this fix makes it hold by construction rather than detecting the violation after the fact.

The null-skipping loop is **retained and is not redundant.** With `num_locally_computed_tokens == 0` a group's block table can begin with the shared null sentinel, and the load must start at the first real block. [`test_partial_lookup_returns_exact_boundary_and_group_load_keys`](https://github.com/vllm-project/vllm/blob/7ca49fbe4bab019e55d57cdc4b7fd3d55c67c1a6/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py) (from #50507) pins this on a Mamba hybrid: replacing the loop with a plain `= first_fresh_gpu_block` makes it emit `[31, 32, 0, 41]` — writing loaded KV into null block `0`, which is shared across every request. Verified by running it both ways.

## Relationship to #52735 / #52771

**This is independent of the drafter-annotation defect, and of the abort fix.** Three arms, all at current `main` (which already carries the [#49146](https://github.com/vllm-project/vllm/pull/49146) `num_allocated_chunks` clamp, commit `94ed0bf4e0`), running the regression test below:

| arm | #49146 clamp | #52771 | this fix | `offloading_connector/` suite |
|---|---|---|---|---|
| A | ✓ (in `main`) | — | — | regression test **fails** |
| B | ✓ | ✓ | — | **1 failed**, 254 passed |
| C | ✓ | ✓ | ✓ | **255 passed, 0 failed** |

Arms B and C were run back-to-back in a single GPU allocation, toggling only this hunk, so the environment is identical; the one failure in B is this PR's regression test and nothing else. Every test that passes without the fix still passes with it.

Arm B is the decisive one: with #52771 (`44a3045ec1`) cherry-picked on top of `main`, the all-groups drafter fallback removed and no group marked as a drafter — so the volatile-tail pop never runs — the boundary assert still fires. The assert is not gated on `is_eagle_group` anywhere.

#52771 is also **complementary**: by restoring real loads it raises how often `num_external_tokens > 0`, and therefore how often this path is reached. It is the right fix for the annotation defect and should land; this is the crash underneath it.

*(This PR previously also carried a competing fix for #52735 — removing the eagle query-widen, `required_window += 1` and the volatile-tail pop. I have dropped all of it in favour of #52771, which was filed first, targets the root cause rather than the symptom, and additionally fixes a store-side hole mine did not. What remains here is only the boundary fix.)*

## Tests

`test_recurrent_group_unhashed_block_does_not_truncate_load_boundary` plants exactly that block — non-null, unhashed, below the boundary — and asserts the **destination blocks** are correct (`41 not in loaded`, `42 in loaded`), not merely that nothing raised. Verified to **fail against unpatched `main`** and pass with this change.

Full `tests/v1/kv_connector/unit/offloading_connector/` suite green on an aarch64 GB200 node.
