### PR TITLE
[CI][ROCm] Prevent Git maintenance races during shallow fetches

### DIFF
--- a/.buildkite/scripts/ci-bake-rocm.sh
+++ b/.buildkite/scripts/ci-bake-rocm.sh
@@ -199,11 +199,13 @@ get_buildkite_target_repo_url() {
 
 git_fetch_with_timeout() {
     local timeout_secs="${ROCM_CACHE_GIT_FETCH_TIMEOUT:-60}"
+    local -a fetch_command=(git fetch --no-auto-maintenance)
 
+    # Detached maintenance can race a later shallow fetch on .git/shallow.
     if command -v timeout >/dev/null 2>&1; then
-        timeout "${timeout_secs}s" git fetch "$@"
+        timeout "${timeout_secs}s" "${fetch_command[@]}" "$@"
     else
-        git fetch "$@"
+        "${fetch_command[@]}" "$@"
     fi
 }
 

--- a/tests/tools/test_docker_build_metadata_args.py
+++ b/tests/tools/test_docker_build_metadata_args.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 HELPER = REPO_ROOT / ".buildkite" / "scripts" / "docker-build-metadata-args.sh"
+ROCM_CI_BAKE = REPO_ROOT / ".buildkite" / "scripts" / "ci-bake-rocm.sh"
 
 
 def run_helper(
@@ -165,7 +166,7 @@ def test_rocm_ci_base_bake_embeds_content_hash_label() -> None:
 
 
 def test_rocm_ci_base_metadata_inputs_cover_ci_base_files() -> None:
-    ci_bake = (REPO_ROOT / ".buildkite" / "scripts" / "ci-bake-rocm.sh").read_text()
+    ci_bake = ROCM_CI_BAKE.read_text()
 
     for expected in (
         "requirements/common.txt",
@@ -174,3 +175,35 @@ def test_rocm_ci_base_metadata_inputs_cover_ci_base_files() -> None:
         "docker/Dockerfile.rocm",
     ):
         assert expected in ci_bake
+
+
+def test_rocm_git_fetch_disables_automatic_maintenance(tmp_path: Path) -> None:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    git = fake_bin / "git"
+    git.write_text('#!/bin/sh\nprintf "%s\\n" "$@"\n')
+    git.chmod(0o755)
+
+    env = os.environ.copy()
+    env["PATH"] = f"{fake_bin}:{env['PATH']}"
+    result = subprocess.run(
+        [
+            "bash",
+            "-c",
+            'source "$1"; git_fetch_with_timeout --quiet origin HEAD',
+            "bash",
+            str(ROCM_CI_BAKE),
+        ],
+        check=True,
+        env=env,
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+
+    assert result.stdout.splitlines() == [
+        "fetch",
+        "--no-auto-maintenance",
+        "--quiet",
+        "origin",
+        "HEAD",
+    ]


### PR DESCRIPTION
The ROCm test-image build in [Buildkite build 84415](https://buildkite.com/vllm/ci/builds/84415/summary?jid=01a015b8-b7d5-453a-9aba-b7ea591fa5a9&tab=output#L86) failed before the Docker build with:

```text
Deepening history to reach a version tag
fatal: shallow file has changed since we read it
```

`ci-bake-rocm.sh` performs several shallow-history fetches in sequence. By default, `git fetch` may start automatic repository maintenance in a detached process. That maintenance can outlive the fetch that launched it and update `.git/shallow` while a later deepen operation is reading it, causing Git's consistency check to abort with exit status 128. The same [Buildkite step was retried on a different agent](https://buildkite.com/vllm/ci/builds/84415/summary?jid=01a015c3-9b1e-4b7c-b33b-d265fe7aabe6&tab=output) and passed the history-deepening operation, image build, and `AMD image smoke OK`, confirming that the original failure was transient rather than caused by the PR's dependency change. This change:

- adds `--no-auto-maintenance` to the centralized ROCm Git fetch helper;
- applies the protection to both its timeout and no-timeout paths; and
- preserves every fetch caller's existing arguments and failure behavior.