### PR TITLE
[Bugfix][ROCm] Match gemm_with_dynamic_quant_fake argument order to the real op

### DIFF
--- a/tests/kernels/quantization/test_quant_op_schema.py
+++ b/tests/kernels/quantization/test_quant_op_schema.py
@@ -74,6 +74,36 @@ def test_group_fp8_quant_schema():
     )
 
 
+def test_gemm_with_dynamic_quant_x_scales_schema():
+    """MXFP4 GEMM with a caller-supplied activation scale."""
+    # this import statement is needed to ensure the op is registered
+    from aiter.ops.triton.quant import dynamic_mxfp4_quant
+
+    import vllm.model_executor.kernels.linear.mxfp4.aiter  # noqa: F401
+
+    torch.manual_seed(0)
+    M, K, N = 128, 4096, 4096
+    x = torch.randn((M, K), dtype=torch.bfloat16, device="cuda")
+    weight = (torch.randn((N, K), dtype=torch.float32, device="cuda") * 0.02).to(
+        torch.bfloat16
+    )
+
+    x_fp4, x_scales = dynamic_mxfp4_quant(x)
+    weight_fp4, weight_scale = dynamic_mxfp4_quant(weight)
+
+    opcheck(
+        torch.ops.vllm.gemm_with_dynamic_quant,
+        (
+            x_fp4,
+            weight_fp4,
+            weight_scale.T.contiguous(),
+            False,
+            torch.bfloat16,
+            x_scales,
+        ),
+    )
+
+
 @pytest.mark.parametrize("dynamic", [True, False])
 def test_per_tensor_quant_matches_native(dynamic):
     """Wrapper output matches the native scaled_fp8_quant reference."""

--- a/vllm/model_executor/kernels/linear/mxfp4/aiter.py
+++ b/vllm/model_executor/kernels/linear/mxfp4/aiter.py
@@ -107,9 +107,9 @@ if is_aiter_found_and_supported():
         x: torch.Tensor,
         weight: torch.Tensor,
         weight_scale: torch.Tensor,
-        x_scales: torch.Tensor = None,
         rocm_use_aiter_fp4_asm_gemm: bool = False,
         out_dtype: torch.dtype | None = torch.bfloat16,
+        x_scales: torch.Tensor | None = None,
     ) -> torch.Tensor:
         return torch.empty(
             (*x.shape[:-1], weight.shape[0]), dtype=out_dtype, device=x.device


### PR DESCRIPTION
## Purpose
Fixes a parameter-order mismatch between `gemm_with_dynamic_quant` and its fake implementation in `vllm/model_executor/kernels/linear/mxfp4/aiter.py`. The last three arguments are declared in different orders:

```python
# real
(x, weight, weight_scale, rocm_use_aiter_fp4_asm_gemm, out_dtype, x_scales)

# fake (before this PR)
(x, weight, weight_scale, x_scales, rocm_use_aiter_fp4_asm_gemm, out_dtype)
```

Because `direct_register_custom_op` derives the schema from the real implementation, passing `x_scales` as the sixth argument mis-binds it to `out_dtype` during fake/meta execution and causes the fake kernel to fail. This PR reorders the fake’s parameters to match the real op.

## Test Plan

Adds `test_gemm_with_dynamic_quant_x_scales_schema`, which calls the op with all six arguments via `opcheck`. ROCm + AITER only.

```bash
pytest -q tests/kernels/quantization/test_quant_op_schema.py
```

## Test Result

The test passed locally on MI355X.
