### PR TITLE
[Core][Quantization] Support ModelOpt layer-wise mixed KV cache

### DIFF
--- a/docs/features/quantization/modelopt.md
+++ b/docs/features/quantization/modelopt.md
@@ -19,6 +19,22 @@ following `quantization.quant_algo` values:
 - `NVFP4`: ModelOpt NVFP4 checkpoints (use `quantization="modelopt_fp4"`).
 - `MXFP8`: ModelOpt MXFP8 checkpoints (use `quantization="modelopt_mxfp8"`).
 
+### Layer-wise mixed-precision KV cache
+
+ModelOpt checkpoints may select full FP8 K/V or full NVFP4 K/V independently
+for each attention layer. When `kv_cache_quant_algo` is `MIXED_PRECISION`, vLLM
+reads the versioned `kv_cache_quantized_layers` mapping and dispatches each
+listed layer to its existing FP8 or NVFP4 KV-cache implementation. Layers not
+listed in the mapping keep the model dtype.
+
+Keep `kv_cache_dtype="auto"` (the default) to use the checkpoint recipe. An
+explicit `--kv-cache-dtype` overrides the recipe for every layer, and
+`--kv-cache-dtype-skip-layers` still takes precedence for selected layers.
+
+This integration supports full FP8 K/V and full NVFP4 K/V layers. A format
+that mixes K and V within one layer, such as FP8 K with NVFP4 V, requires a
+separate attention-kernel implementation.
+
 !!! note
     For NVFP4 checkpoints, vLLM selects a GEMM kernel automatically at load
     time from the backends available on the current platform (CUTLASS,

--- a/tests/quantization/test_modelopt.py
+++ b/tests/quantization/test_modelopt.py
@@ -19,10 +19,12 @@ from vllm.model_executor.kernels.linear import (
     HummingNvFp4LinearKernel,
     MarlinNvFp4LinearKernel,
 )
+from vllm.model_executor.layers.attention import Attention
 from vllm.model_executor.layers.linear import UnquantizedLinearMethod
 from vllm.model_executor.layers.quantization.modelopt import (
     ModelOptFp8Config,
     ModelOptFp8LinearMethod,
+    ModelOptKVCacheMethod,
     ModelOptMixedPrecisionConfig,
     ModelOptMxFp8Config,
     ModelOptNvFp4Config,
@@ -70,11 +72,19 @@ def _mock_lm_head() -> Mock:
     return lm_head
 
 
-def _mixed_precision_config(quantized_layers: dict) -> ModelOptMixedPrecisionConfig:
+def _mixed_precision_config(
+    quantized_layers: dict,
+    *,
+    kv_cache_quant_method: str | None = None,
+    kv_cache_quantized_layers: dict | None = None,
+    kv_cache_schema_version: int | None = None,
+) -> ModelOptMixedPrecisionConfig:
     return ModelOptMixedPrecisionConfig(
-        kv_cache_quant_method=None,
+        kv_cache_quant_method=kv_cache_quant_method,
         exclude_modules=[],
         quantized_layers=quantized_layers,
+        kv_cache_quantized_layers=kv_cache_quantized_layers or {},
+        kv_cache_schema_version=kv_cache_schema_version,
         fp8_config=ModelOptFp8Config(
             quant_method="FP8",
             is_checkpoint_fp8_serialized=True,
@@ -98,6 +108,60 @@ def _mixed_precision_config(quantized_layers: dict) -> ModelOptMixedPrecisionCon
             exclude_modules=[],
         ),
     )
+
+
+def test_modelopt_mixed_precision_resolves_layerwise_kv_cache_dtype():
+    config = ModelOptMixedPrecisionConfig.from_config(
+        {
+            "quant_method": "modelopt",
+            "quant_algo": "MIXED_PRECISION",
+            "kv_cache_quant_algo": "MIXED_PRECISION",
+            "kv_cache_schema_version": 1,
+            "kv_cache_quantized_layers": {
+                "model.layers.0.self_attn": {"quant_algo": "FP8"},
+                "model.layers.1.self_attn": {"quant_algo": "NVFP4"},
+            },
+        }
+    )
+
+    assert config.get_kv_cache_dtype("model.layers.0.self_attn.attn") == "fp8_e4m3"
+    assert config.get_kv_cache_dtype("model.layers.1.self_attn.attn") == "nvfp4"
+    assert config.get_kv_cache_dtype("model.layers.2.self_attn.attn") is None
+
+    mapped_attention = Mock(spec=Attention)
+    mapped_attention.__class__ = Attention
+    assert isinstance(
+        config.get_quant_method(mapped_attention, "model.layers.0.self_attn.attn"),
+        ModelOptKVCacheMethod,
+    )
+    assert (
+        config.get_quant_method(mapped_attention, "model.layers.2.self_attn.attn")
+        is None
+    )
+
+
+@pytest.mark.parametrize(
+    ("schema_version", "quant_algo", "error"),
+    [
+        (2, "FP8", "kv_cache_schema_version=1"),
+        (1, "FP8_K_NVFP4_V", "Supported formats are"),
+    ],
+)
+def test_modelopt_mixed_precision_rejects_unsupported_kv_cache_config(
+    schema_version, quant_algo, error
+):
+    with pytest.raises(ValueError, match=error):
+        ModelOptMixedPrecisionConfig.from_config(
+            {
+                "quant_method": "modelopt",
+                "quant_algo": "MIXED_PRECISION",
+                "kv_cache_quant_algo": "MIXED_PRECISION",
+                "kv_cache_schema_version": schema_version,
+                "kv_cache_quantized_layers": {
+                    "model.layers.0.self_attn": {"quant_algo": quant_algo},
+                },
+            }
+        )
 
 
 def test_modelopt_nvfp4_quantizes_parallel_lm_head():
@@ -210,7 +274,12 @@ def test_modelopt_mixed_precision_composes_gemma4_mappers():
                 "quant_algo": "NVFP4",
                 "group_size": 16,
             },
-        }
+        },
+        kv_cache_quant_method="MIXED_PRECISION",
+        kv_cache_quantized_layers={
+            "model.language_model.layers.0.self_attn": {"quant_algo": "FP8"}
+        },
+        kv_cache_schema_version=1,
     )
 
     config.apply_vllm_mapper(
@@ -224,6 +293,10 @@ def test_modelopt_mixed_precision_composes_gemma4_mappers():
         "language_model.model.layers.1.moe.gate_up_proj",
     }
     assert config._resolve_quant_algo(expected_prefix) == "NVFP4"
+    assert (
+        config.get_kv_cache_dtype("language_model.model.layers.0.self_attn.attn")
+        == "fp8_e4m3"
+    )
 
 
 def test_modelopt_mixed_precision_infers_fused_gate_up_projection():

--- a/tests/quantization/test_modelopt.py
+++ b/tests/quantization/test_modelopt.py
@@ -141,6 +141,31 @@ def test_modelopt_mixed_precision_resolves_layerwise_kv_cache_dtype():
 
 
 @pytest.mark.parametrize(
+    ("quant_algo", "expected_dtype"),
+    [("FP8", "fp8_e4m3"), ("NVFP4", "nvfp4")],
+)
+def test_modelopt_mixed_precision_loads_uniform_layerwise_kv_cache(
+    quant_algo, expected_dtype
+):
+    config = ModelOptMixedPrecisionConfig.from_config(
+        {
+            "quant_method": "modelopt",
+            "quant_algo": "MIXED_PRECISION",
+            "kv_cache_quant_algo": "MIXED_PRECISION",
+            "kv_cache_schema_version": 1,
+            "kv_cache_quantized_layers": {
+                f"model.layers.{index}.self_attn": {"quant_algo": quant_algo}
+                for index in range(2)
+            },
+        }
+    )
+
+    assert config.quantized_layers == {}
+    assert config.get_kv_cache_dtype("model.layers.0.self_attn.attn") == expected_dtype
+    assert config.get_kv_cache_dtype("model.layers.1.self_attn.attn") == expected_dtype
+
+
+@pytest.mark.parametrize(
     ("schema_version", "quant_algo", "error"),
     [
         (2, "FP8", "kv_cache_schema_version=1"),

--- a/vllm/model_executor/layers/attention/attention.py
+++ b/vllm/model_executor/layers/attention/attention.py
@@ -272,6 +272,11 @@ class Attention(nn.Module, AttentionLayerBase):
         else:
             kv_cache_dtype = "auto"
 
+        if quant_config is not None and kv_cache_dtype == "auto":
+            checkpoint_kv_cache_dtype = quant_config.get_kv_cache_dtype(prefix)
+            if checkpoint_kv_cache_dtype is not None:
+                kv_cache_dtype = checkpoint_kv_cache_dtype
+
         # llm-compressor models declare an FP8 KV-cache scheme in their
         # checkpoint config. Honor it only when the user did not explicitly
         # pick a kv_cache_dtype; an explicit choice (e.g. bfloat16) must win.

--- a/vllm/model_executor/layers/quantization/base_config.py
+++ b/vllm/model_executor/layers/quantization/base_config.py
@@ -11,6 +11,7 @@ from torch import nn
 from transformers import PretrainedConfig
 
 if TYPE_CHECKING:
+    from vllm.config.cache import CacheDType
     from vllm.model_executor.layers.quantization import QuantizationMethods
     from vllm.model_executor.models.utils import WeightsMapper
 else:
@@ -225,6 +226,10 @@ class QuantizationConfig(ABC):
             re.compile(r"(?<!\.attn)\.([qkv])_zero_point$"): r".attn.\1_zero_point",
         }
         return WeightsMapper(orig_to_new_regex=orig_to_new_regex)
+
+    def get_kv_cache_dtype(self, prefix: str) -> "CacheDType | None":
+        """Return a checkpoint-selected KV-cache dtype for one layer."""
+        return None
 
     def apply_vllm_mapper(  # noqa: B027
         self, hf_to_vllm_mapper: "WeightsMapper"

--- a/vllm/model_executor/layers/quantization/modelopt.py
+++ b/vllm/model_executor/layers/quantization/modelopt.py
@@ -92,6 +92,7 @@ from vllm.model_executor.parameter import (
 from vllm.model_executor.utils import replace_parameter, set_weight_attrs
 
 if TYPE_CHECKING:
+    from vllm.config.cache import CacheDType
     from vllm.model_executor.models.utils import WeightsMapper
 
 logger = init_logger(__name__)
@@ -112,6 +113,11 @@ QUANT_ALGOS = [
     # MIXED_PRECISION,
     "MIXED_PRECISION",
 ]
+
+MODELOPT_MIXED_KV_CACHE_DTYPES = {
+    "FP8": "fp8_e4m3",
+    "NVFP4": "nvfp4",
+}
 
 
 class ModelOptKVCacheMethod(BaseKVCacheMethod):
@@ -296,15 +302,16 @@ class ModelOptQuantConfigBase(QuantizationConfig):
             # {"quant_algo": "...", "quant_method": "modelopt"}
             quant_method = config.get("quant_algo")
 
-            # "kv_cache_scheme" (a dict) instead of "kv_cache_quant_algo" (a string).
-            kv_cache_scheme = config.get("kv_cache_scheme")
-            if isinstance(kv_cache_scheme, dict) and (
-                kv_cache_scheme.get("type") == "float"
-                and kv_cache_scheme.get("num_bits") == 8
-            ):
-                kv_cache_quant_method = "FP8"
-            else:
-                kv_cache_quant_method = None
+            kv_cache_quant_method = config.get("kv_cache_quant_algo")
+            if kv_cache_quant_method is None:
+                # Compressed-tensors uses "kv_cache_scheme" (a dict) instead
+                # of "kv_cache_quant_algo" (a string).
+                kv_cache_scheme = config.get("kv_cache_scheme")
+                if isinstance(kv_cache_scheme, dict) and (
+                    kv_cache_scheme.get("type") == "float"
+                    and kv_cache_scheme.get("num_bits") == 8
+                ):
+                    kv_cache_quant_method = "FP8"
 
             # "ignore" is the key in config.json
             exclude_modules = config.get("ignore", [])
@@ -2145,9 +2152,9 @@ class ModelOptMixedPrecisionConfig(ModelOptQuantConfigBase):
 
     Supports checkpoints where different layers use different quantization
     algorithms (e.g., FP8 for dense layers and NVFP4 for MoE experts).
-    The per-layer algorithm is specified in the ``quantized_layers`` dict
-    inside ``config.json``'s ``quantization_config`` (preferred) or the
-    legacy ``hf_quant_config.json``.
+    Weight algorithms are specified in ``quantized_layers``. Layer-wise KV
+    cache algorithms are specified in the versioned
+    ``kv_cache_quantized_layers`` mapping.
     """
 
     def __init__(
@@ -2155,6 +2162,8 @@ class ModelOptMixedPrecisionConfig(ModelOptQuantConfigBase):
         kv_cache_quant_method: str | None,
         exclude_modules: list[str],
         quantized_layers: dict[str, dict[str, Any]],
+        kv_cache_quantized_layers: dict[str, dict[str, Any]],
+        kv_cache_schema_version: int | None,
         fp8_config: ModelOptFp8Config,
         nvfp4_config: ModelOptNvFp4Config,
         w4a16_nvfp4_config: ModelOptNvFp4Config,
@@ -2163,6 +2172,8 @@ class ModelOptMixedPrecisionConfig(ModelOptQuantConfigBase):
         super().__init__(exclude_modules)
         self.kv_cache_quant_method = kv_cache_quant_method
         self.quantized_layers = quantized_layers
+        self.kv_cache_quantized_layers = kv_cache_quantized_layers
+        self.kv_cache_schema_version = kv_cache_schema_version
         self.fp8_config = fp8_config
         self.nvfp4_config = nvfp4_config
         self.w4a16_nvfp4_config = w4a16_nvfp4_config
@@ -2205,17 +2216,55 @@ class ModelOptMixedPrecisionConfig(ModelOptQuantConfigBase):
         group_size: int | None,
         **kwargs: Any,
     ) -> "ModelOptMixedPrecisionConfig":
-        if "quantization" in original_config:
-            quantized_layers = original_config["quantization"].get(
-                "quantized_layers", {}
-            )
-        else:
-            quantized_layers = original_config.get("quantized_layers", {})
+        quantization_config = original_config.get("quantization", original_config)
 
-        if not quantized_layers:
+        quantized_layers = quantization_config.get("quantized_layers", {})
+        kv_cache_quantized_layers: dict[str, dict[str, Any]] = {}
+        kv_cache_schema_version = quantization_config.get("kv_cache_schema_version")
+
+        if kv_cache_quant_method == "MIXED_PRECISION":
+            if type(kv_cache_schema_version) is not int or kv_cache_schema_version != 1:
+                raise ValueError(
+                    "ModelOpt mixed KV cache requires kv_cache_schema_version=1"
+                )
+            raw_kv_layers = quantization_config.get("kv_cache_quantized_layers")
+            if not isinstance(raw_kv_layers, dict) or not raw_kv_layers:
+                raise ValueError(
+                    "ModelOpt mixed KV cache requires a non-empty "
+                    "'kv_cache_quantized_layers' mapping"
+                )
+            for layer_name, layer_info in raw_kv_layers.items():
+                if not isinstance(layer_name, str) or not layer_name:
+                    raise ValueError(
+                        "kv_cache_quantized_layers keys must be non-empty strings"
+                    )
+                if not isinstance(layer_info, dict):
+                    raise ValueError(
+                        f"KV-cache entry for {layer_name!r} must be a dictionary"
+                    )
+                quant_algo = layer_info.get("quant_algo")
+                if not isinstance(quant_algo, str):
+                    raise ValueError(
+                        f"KV-cache entry for {layer_name!r} requires a string "
+                        "'quant_algo'"
+                    )
+                quant_algo = quant_algo.upper()
+                if quant_algo not in MODELOPT_MIXED_KV_CACHE_DTYPES:
+                    raise ValueError(
+                        f"Unsupported ModelOpt layer-wise KV-cache format "
+                        f"{quant_algo!r} for {layer_name!r}. Supported formats are "
+                        f"{sorted(MODELOPT_MIXED_KV_CACHE_DTYPES)}."
+                    )
+                kv_cache_quantized_layers[layer_name] = {
+                    **layer_info,
+                    "quant_algo": quant_algo,
+                }
+
+        if not quantized_layers and not kv_cache_quantized_layers:
             raise ValueError(
                 "MIXED_PRECISION quant_algo requires a non-empty "
-                "'quantized_layers' mapping in the quantization config."
+                "'quantized_layers' or 'kv_cache_quantized_layers' mapping in "
+                "the quantization config."
             )
 
         # Determine group_size from the first NVFP4-family entry if not
@@ -2267,6 +2316,8 @@ class ModelOptMixedPrecisionConfig(ModelOptQuantConfigBase):
             kv_cache_quant_method=kv_cache_quant_method,
             exclude_modules=exclude_modules,
             quantized_layers=quantized_layers,
+            kv_cache_quantized_layers=kv_cache_quantized_layers,
+            kv_cache_schema_version=kv_cache_schema_version,
             fp8_config=fp8_config,
             nvfp4_config=nvfp4_config,
             w4a16_nvfp4_config=w4a16_nvfp4_config,
@@ -2351,6 +2402,28 @@ class ModelOptMixedPrecisionConfig(ModelOptQuantConfigBase):
 
         return None
 
+    def get_kv_cache_dtype(self, prefix: str) -> "CacheDType | None":
+        if self.kv_cache_quant_method != "MIXED_PRECISION":
+            return None
+        for candidate in self._kv_cache_layer_prefix_candidates(prefix):
+            layer_info = self.kv_cache_quantized_layers.get(candidate)
+            if layer_info is not None:
+                return cast(
+                    "CacheDType",
+                    MODELOPT_MIXED_KV_CACHE_DTYPES[layer_info["quant_algo"]],
+                )
+        return None
+
+    def _kv_cache_layer_prefix_candidates(self, prefix: str) -> tuple[str, ...]:
+        prefixes = [prefix]
+        if prefix.endswith(".attn"):
+            prefixes.append(prefix.removesuffix(".attn"))
+
+        candidates: list[str] = []
+        for layer_prefix in prefixes:
+            candidates.extend(self._quantized_layer_prefix_candidates(layer_prefix))
+        return tuple(dict.fromkeys(candidates))
+
     @staticmethod
     def _quantized_layer_prefix_candidates(prefix: str) -> tuple[str, ...]:
         candidates = [prefix]
@@ -2375,7 +2448,10 @@ class ModelOptMixedPrecisionConfig(ModelOptQuantConfigBase):
         """Return quantize-method based on layer."""
         # KV-cache quantization
         if isinstance(layer, Attention):
-            if self.kv_cache_quant_method:
+            if self.kv_cache_quant_method == "MIXED_PRECISION":
+                if self.get_kv_cache_dtype(prefix) is not None:
+                    return ModelOptKVCacheMethod(self)
+            elif self.kv_cache_quant_method:
                 return ModelOptKVCacheMethod(self)
             return None
 
@@ -2428,3 +2504,7 @@ class ModelOptMixedPrecisionConfig(ModelOptQuantConfigBase):
         super().apply_vllm_mapper(hf_to_vllm_mapper)
         if self.quantized_layers:
             self.quantized_layers = hf_to_vllm_mapper.apply_dict(self.quantized_layers)
+        if self.kv_cache_quantized_layers:
+            self.kv_cache_quantized_layers = hf_to_vllm_mapper.apply_dict(
+                self.kv_cache_quantized_layers
+            )

--- a/vllm/utils/torch_utils.py
+++ b/vllm/utils/torch_utils.py
@@ -65,6 +65,7 @@ TORCH_DTYPE_TO_NUMPY_DTYPE = {
 
 MODELOPT_TO_VLLM_KV_CACHE_DTYPE_MAP = {
     "fp8": "fp8_e4m3",
+    "mixed_precision": "auto",
     "nvfp4": "nvfp4",
 }
 


### PR DESCRIPTION
## Purpose

This is the vLLM consumer for
[NVIDIA/Model-Optimizer#2272](https://github.com/NVIDIA/Model-Optimizer/pull/2272).

The ModelOpt PR searches a layer-wise KV-cache recipe and exports the selected formats
in versioned `kv_cache_quantized_layers` checkpoint metadata. This PR reads that
metadata and selects the KV-cache dtype for each vLLM attention layer.

With this PR alone, a checkpoint produced by ModelOpt can mix:

- full FP8 K/V layers, using vLLM's existing FP8 KV implementation; and
- full NVFP4 K/V layers, using vLLM's existing NVFP4 KV implementation.

The same mixed-precision envelope also accepts a complete layer map whose entries are
uniformly all FP8 or all NVFP4. ModelOpt uses that form for standalone KV-only exports
so the checkpoint retains a valid top-level `quant_algo` and an explicit layer map.

There are no CUDA/C++ or attention-kernel changes here. FP8-K/NVFP4-V within a single
layer is intentionally rejected because that format requires the separate mixed-K/V
kernel implementation. The two full-K/V formats above do not require that kernel work.

The checkpoint recipe is used only when `kv_cache_dtype="auto"`. An explicit
`--kv-cache-dtype` continues to override every layer, and
`--kv-cache-dtype-skip-layers` continues to take precedence for selected layers. Layers
omitted from the checkpoint mapping remain in the model dtype.

This does not duplicate existing mixed-KV work:

- #41684 keeps selected token ranges in a high-precision sibling cache; it does not load
  a layer-wise ModelOpt format map.
- #49623 detects packed mixed cache specs; it does not parse checkpoint-selected
  per-layer KV dtypes.

This contribution was developed with AI assistance. The human submitter reviewed the
complete diff and remains responsible for the implementation and validation.

## Test Plan

- Validate ModelOpt schema-v1 parsing for full FP8 K/V and full NVFP4 K/V.
- Validate uniform all-FP8 and all-NVFP4 complete layer maps with no weight map.
- Verify Hugging Face-to-vLLM layer-name mapping, including the vLLM `.attn` suffix.
- Verify only mapped layers load KV scaling factors.
- Reject unknown schema versions and FP8-K/NVFP4-V entries without the required kernel
  integration.
- Run the changed-file pre-commit suite and a ModelOpt-exported checkpoint smoke on CUDA.

## Test Result

- Existing changed-file pre-commit suite: passed.
  - Ruff check and format
  - mypy (Python 3.10)
  - typos and Markdown lint
  - repository policy/configuration checks
- New uniform-map test: Ruff check and format passed; focused pytest awaits the PR CUDA
  environment.
- Python byte-compilation of all existing changed Python files: passed.
- Focused CUDA unit suite on NVIDIA GB300: 4 passed in 7.14 seconds
  (AWS-CMH Slurm job `3133718`). This covers FP8/NVFP4 layer resolution, omitted layers,
  schema/format rejection, and composed Gemma layer mapping.
- The focused pytest invocation is environment-blocked on the local macOS host: the
  CUDA-oriented vLLM test stack exits before collection in `xgrammar`'s
  `TVMFFIEnvRegisterCAPI` static initialization. No test assertion ran or failed.
- End-to-end ModelOpt-exported checkpoint smoke: pending; this PR remains a draft until
  that result is attached.
- Full CI requires the repository's `ready`, `ready-run-all-tests`, or `verified` label;
  the current pre-run failure is this label gate, not a code-test failure.

---

<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The current test results and explicit pending CUDA validation.
- [x] The necessary documentation update.

</details>
