### PR TITLE
[Core] Make the shm message-queue busy-wait window configurable

### DIFF
--- a/vllm/distributed/device_communicators/shm_broadcast.py
+++ b/vllm/distributed/device_communicators/shm_broadcast.py
@@ -3,6 +3,7 @@
 import copyreg
 import functools
 import io
+import math
 import os
 import pickle
 import shutil
@@ -121,6 +122,11 @@ class SpinCondition:
     await a notification on the zmq socket after a period of inactivity. This
     allows the readers to spin quickly, hence "SpinCondition".
 
+    `busy_loop_s` is how long a reader keeps spinning after its last successful
+    read before it parks; it defaults to VLLM_SHM_BROADCAST_BUSY_LOOP_S. Note
+    that a window longer than the gap between messages never expires, so the
+    reader spins for as long as traffic continues.
+
     To support clean shutdown, a separate thread in the reader's process must be
     able to wake the reader so that it can exit. A separate cancel() method is
     implemented with an in-process socket to allow this interruption.
@@ -131,7 +137,7 @@ class SpinCondition:
         is_reader: bool,
         context: zmq.Context,
         notify_address: str,
-        busy_loop_s: float = 1,
+        busy_loop_s: float | None = None,
     ):
         self.is_reader = is_reader
 
@@ -140,7 +146,18 @@ class SpinCondition:
             self.last_read = time.monotonic()
 
             # Time to keep busy-looping on the shm buffer before going idle
-            self.busy_loop_s = busy_loop_s
+            self.busy_loop_s = (
+                busy_loop_s
+                if busy_loop_s is not None
+                else envs.VLLM_SHM_BROADCAST_BUSY_LOOP_S
+            )
+            if not math.isfinite(self.busy_loop_s) or self.busy_loop_s < 0:
+                raise ValueError(
+                    "busy_loop_s must be finite and non-negative, got "
+                    f"{self.busy_loop_s!r} (VLLM_SHM_BROADCAST_BUSY_LOOP_S). "
+                    "An infinite window would keep the reader in sched_yield() "
+                    "permanently, so it would never park even when idle."
+                )
 
             # Readers subscribe to write notifications
             self.local_notify_socket: zmq.Socket = context.socket(SUB)

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
     VLLM_USE_MODELSCOPE: bool = False
     VLLM_USE_FASTOKENS: bool = False
     VLLM_RINGBUFFER_WARNING_INTERVAL: int = 60
+    VLLM_SHM_BROADCAST_BUSY_LOOP_S: float = 1.0
     VLLM_NCCL_SO_PATH: str | None = None
     LD_LIBRARY_PATH: str | None = None
     VLLM_ROCM_SLEEP_MEM_CHUNK_SIZE: int = 256
@@ -733,6 +734,19 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Interval in seconds to log a warning message when the ring buffer is full
     "VLLM_RINGBUFFER_WARNING_INTERVAL": lambda: int(
         os.environ.get("VLLM_RINGBUFFER_WARNING_INTERVAL", "60")
+    ),
+    # How long a shm message-queue reader keeps busy-polling the ring buffer
+    # after its last successful read before parking on the zmq notification
+    # socket. Spinning saves a wake-up on the next message; it costs a core held
+    # at max clock for the whole window.
+    #
+    # The default of 1s is longer than the gap between engine steps under load,
+    # so readers spin for the duration of a generation. That is usually the right
+    # trade on a discrete-GPU server. Lower it on packages where the CPU and GPU
+    # share a power/thermal budget (e.g. NVIDIA GB10), where a spinning core is
+    # taken directly out of the GPU's headroom.
+    "VLLM_SHM_BROADCAST_BUSY_LOOP_S": lambda: float(
+        os.environ.get("VLLM_SHM_BROADCAST_BUSY_LOOP_S", "1")
     ),
     # path to cudatoolkit home directory, under which should be bin, include,
     # and lib directories.
@@ -2219,6 +2233,7 @@ def compile_factors() -> dict[str, object]:
         "VLLM_RPC_BASE_PATH",
         "VLLM_USE_MODELSCOPE",
         "VLLM_RINGBUFFER_WARNING_INTERVAL",
+        "VLLM_SHM_BROADCAST_BUSY_LOOP_S",
         "VLLM_DEBUG_DUMP_PATH",
         "VLLM_PORT",
         "VLLM_CACHE_ROOT",


### PR DESCRIPTION
## Purpose

`SpinCondition` busy-waits for `busy_loop_s` after each read before parking on its zmq
notification socket, hardcoded to `1`. This makes that window configurable via
`VLLM_SHM_BROADCAST_BUSY_LOOP_S` and **keeps the default at `1`**, so behaviour is
unchanged for every existing deployment.

The right value is a property of the hardware, not of vLLM. On a discrete-GPU server the
current default is a good trade: a spinning core is thermal noise and the saved wake-up is
free latency. On packages where the CPU and GPU share one power and thermal budget, it is
not — the core held at max clock is taken out of the GPU's headroom.

The window also interacts with step rate in a way that is easy to miss: `1s` is far longer
than the gap between engine steps under load, so it never expires during a generation and
the reader spins from the first token to the last. The idle case it was added for (#19036)
is the only time it lapses.

## Evidence

Measured on 4× NVIDIA GB10 (DGX Spark), GLM-5.2, TP=4 + DCP=4, 8 concurrent decode
streams. `py-spy` attributes **98.3%** of the rank-0 worker's on-CPU samples and **99.9%**
of `EngineCore`'s to this busy-wait:

```
sched_yield        (vllm/distributed/utils.py:48)
wait               (shm_broadcast.py:203)   <- the busy_loop_s branch
acquire_read       (shm_broadcast.py)
dequeue            (shm_broadcast.py)
worker_busy_loop   (multiproc_executor.py)
```

Only rank 0's node is affected — remote workers take `MessageQueue.recv()` and block in
zmq — so the cost lands on the node that also runs the API server and the scheduler.

Two boots of one image, one env var apart:

| | `1` (default) | `0.002` |
| --- | --- | --- |
| rank-0 worker CPU | 385% | **290%** |
| `EngineCore` CPU | 98% | **0.5%** |
| package temperature | 90.9 °C | **76.9 °C** |
| per-step latency | 314.5 ms | 314.3 ms |
| spec-decode acceptance | 62.4% | 63.3% |
| aggregate throughput | 70.0 tok/s | ~70 tok/s |

Throughput is unchanged because this removes CPU spinning, not GPU work: one wake-up of
tens of microseconds against a ~310 ms step is not measurable. Before the change the
affected node ran 10–14 °C hotter than its peers; after, it was the coolest in the cluster.
GPU clocks were identical in both arms (2177 MHz, no throttle flags), so this is CPU-side.

`py-spy` after the change shows the threads `(idle)` in `poll (zmq/sugar/poll.py:106)`
during active decode, i.e. taking the park branch.

## Notes

- **No default change.** This PR is only the knob. Anything that wants the old behaviour
  gets it by doing nothing.
- Non-finite and negative values are rejected at construction. Infinity is the dangerous
  one: `current_time <= last_read + inf` is always true, so the reader would stay in
  `sched_yield()` permanently and never park **even when idle** — strictly worse than the
  1s it replaces, and silent.
- Added to `ignored_factors`: a runtime scheduling knob does not affect generated code, so
  toggling it should not invalidate the `torch.compile` cache.

## Test Plan

- Default path: `VLLM_SHM_BROADCAST_BUSY_LOOP_S` unset resolves to `1.0`, matching the
  constant it replaces; `SpinCondition` behaviour is unchanged.
- Override path: setting the var is picked up by readers, verified from `py-spy` stacks on
  a running 4-node deployment (`sched_yield` → `poll`).
- Rejection path: `inf`, `-inf`, `nan` and negative values raise `ValueError` at
  construction, via both the explicit argument and the env var.
