### PR TITLE
[Test] Cover DSpark SM120 sparse MLA topk widths

### DIFF
--- a/tests/v1/attention/test_flashinfer_sparse_mla_sm120_api.py
+++ b/tests/v1/attention/test_flashinfer_sparse_mla_sm120_api.py
@@ -66,7 +66,7 @@ def test_v32_glm_sm120_backend_accepts_glm_block_size(
 
 def test_sm120_dsv4_capability_checks_exact_dispatch_shape(monkeypatch) -> None:
     fake_module = SimpleNamespace(
-        _DECODE_DSV4_DISPATCH=frozenset({(32, 128), (32, 192)})
+        _DECODE_DSV4_DISPATCH=frozenset({(32, 128), (32, 192), (32, 256)})
     )
     monkeypatch.setattr(fi_utils, "has_flashinfer_sparse_mla_sm120", lambda: True)
     monkeypatch.setattr(fi_utils, "_get_submodule", lambda _name: fake_module)
@@ -74,8 +74,8 @@ def test_sm120_dsv4_capability_checks_exact_dispatch_shape(monkeypatch) -> None:
 
     assert fi_utils.has_flashinfer_sparse_mla_sm120_config(32, 128)
     assert fi_utils.has_flashinfer_sparse_mla_sm120_config(32, 192)
-    assert not fi_utils.has_flashinfer_sparse_mla_sm120_config(32, 256)
-    assert not fi_utils.has_flashinfer_sparse_mla_sm120_config(16, 192)
+    assert fi_utils.has_flashinfer_sparse_mla_sm120_config(32, 256)
+    assert not fi_utils.has_flashinfer_sparse_mla_sm120_config(16, 256)
 
     fi_utils.has_flashinfer_sparse_mla_sm120_config.cache_clear()
 
@@ -85,10 +85,20 @@ def test_sm120_dsv4_required_topk_tracks_dspark_width() -> None:
         attention_config=SimpleNamespace(use_non_causal=False),
         speculative_config=SimpleNamespace(num_speculative_tokens=5),
     )
+    non_causal_no_spec = SimpleNamespace(
+        attention_config=SimpleNamespace(use_non_causal=True),
+        speculative_config=None,
+    )
     dspark = SimpleNamespace(
         attention_config=SimpleNamespace(use_non_causal=True),
         speculative_config=SimpleNamespace(num_speculative_tokens=5),
     )
+    dspark_wide = SimpleNamespace(
+        attention_config=SimpleNamespace(use_non_causal=True),
+        speculative_config=SimpleNamespace(num_speculative_tokens=65),
+    )
 
     assert _required_sm120_sparse_topk(causal, 128) == 128
+    assert _required_sm120_sparse_topk(non_causal_no_spec, 128) == 128
     assert _required_sm120_sparse_topk(dspark, 128) == 192
+    assert _required_sm120_sparse_topk(dspark_wide, 128) == 256


### PR DESCRIPTION
## Purpose

Add regression coverage for the SM120 FlashInfer DSV4 dispatch keys and DSpark SWA widths behind issue #50720. The current tests cover only 128 and 192. FlashInfer now ships 256 after flashinfer-ai/flashinfer#4380, and `_required_sm120_sparse_topk` can produce 256 when 65 or more speculative tokens push the padded width across the next 64-token boundary.

## Why not duplicate

#51538 merged the runtime fix and added the existing test file. #52499 fixes remaining spec-decode shape handling and does not touch these helper paths. This PR is test-only coverage, not a duplicate of either change.

## Test Plan

- `ruff check tests/v1/attention/test_flashinfer_sparse_mla_sm120_api.py`: passed
- `ruff format --check tests/v1/attention/test_flashinfer_sparse_mla_sm120_api.py`: passed
- `python -m py_compile tests/v1/attention/test_flashinfer_sparse_mla_sm120_api.py`: passed
- Focused pytest was not run because this checkout has no vLLM/CUDA environment.
- No hardware or model evaluation was required or performed because this PR changes tests only.

AI assistance was used to prepare this PR.