### PR TITLE
[Bugfix][ROCm][Disagg] Fix MiniMax-M3 WideEP non-contiguous MoRIIO KV registration

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_connector.py
@@ -1772,7 +1772,19 @@ class MoRIIOConnectorWorker:
             if layer_name not in self.layer_name_to_local_kv_cache_metadata:
                 self.layer_name_to_local_kv_cache_metadata[layer_name] = []
 
-            moriio_mem_metadata = self.moriio_wrapper.register_local_tensor(kv_cache)
+            if kv_cache.is_contiguous():
+                reg_tensor = kv_cache
+            else:
+                cache_u8 = kv_cache.view(torch.uint8)
+                total_bytes = (
+                    kv_cache.shape[0] * kv_cache.stride(0) * kv_cache.element_size()
+                )
+                reg_tensor = torch.as_strided(
+                    cache_u8, (total_bytes,), (1,), cache_u8.storage_offset()
+                )
+            moriio_mem_metadata = self.moriio_wrapper.register_local_tensor(
+                reg_tensor
+            )
             self.layer_name_to_local_kv_cache_metadata[layer_name].append(
                 moriio_mem_metadata
             )


### PR DESCRIPTION
## Purpose

MoRIIO KV registration requires a contiguous tensor. MiniMax-M3 (and similar paged FP8 KV layouts) expose a **non-contiguous** local `kv_cache`, so `register_local_tensor(kv_cache)` fails with `input tensor must be contiguous`.

Using `.contiguous()` is incorrect: it registers a **copy**, not the RDMA-backed storage, so health can pass while KV transfer is wrong and accuracy collapses.

This change registers a contiguous `uint8` 1-D `as_strided` view over the same storage span so MoRIIO binds the real KV memory without copying.

## Changes

`vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_connector.py` (`register_kv_caches`):

- Contiguous caches: register unchanged.
- Non-contiguous caches: register `as_strided` over `shape[0] * stride(0) * element_size()` bytes at `storage_offset()`.

No other connector, engine, or harness changes.

## Test Plan

MoRIIO **1P1D wide-EP** (EP8/DP8, WRITE) disaggregated serving, `ROUTER_TYPE=proxy`, `RUN_AFTER_HEALTH=accuracy`, image `vllm/vllm-openai-rocm:nightly`.

### MiniMax-M3-MXFP8 — wide-EP 1P1D

```bash
export VLLM_ROCM_USE_AITER=1
export VLLM_ROCM_USE_AITER_MOE=1
export VLLM_ROCM_USE_AITER_RMSNORM=1
export VLLM_ROCM_USE_AITER_FP8BMM=false
```

```bash
# PREFILL — wide-EP (EP8/DP8)
vllm serve /data/models2/MiniMax-M3-MXFP8 \
    --host $PREFILL_IP --port 8100 \
    --trust-remote-code --attention-backend TRITON_ATTN --block-size 128 \
    --language-model-only --kv-cache-dtype fp8 \
    --data-parallel-size 8 --enable-expert-parallel \
    --enforce-eager --moe-backend aiter --linear-backend emulation \
    --max-num-batched-tokens 32768 --gpu-memory-utilization 0.85 \
    --kv-transfer-config '{"kv_connector":"MoRIIOConnector","kv_role":"kv_producer",
      "kv_connector_extra_config":{"proxy_ip":"$PREFILL_IP","proxy_ping_port":"36367",
      "http_port":"8100","handshake_port":"6301","notify_port":"61005"}}'
```

```bash
# DECODE — wide-EP (EP8/DP8)
vllm serve /data/models2/MiniMax-M3-MXFP8 \
    --host $DECODE_IP --port 8200 \
    --trust-remote-code --attention-backend TRITON_ATTN --block-size 128 \
    --language-model-only --kv-cache-dtype fp8 \
    --data-parallel-size 8 --enable-expert-parallel \
    --enforce-eager --moe-backend aiter --linear-backend emulation \
    --max-num-batched-tokens 32768 --gpu-memory-utilization 0.85 \
    --kv-transfer-config '{"kv_connector":"MoRIIOConnector","kv_role":"kv_consumer",
      "kv_connector_extra_config":{"proxy_ip":"$PREFILL_IP","proxy_ping_port":"36367",
      "http_port":"8200","handshake_port":"7301","notify_port":"62005"}}'
```

### GSM8K evaluation

```bash
lm_eval --model local-completions \
    --tasks gsm8k \
    --model_args "model=/data/models2/MiniMax-M3-MXFP8,base_url=http://127.0.0.1:10001/v1/completions,num_concurrent=64,max_retries=3,tokenized_requests=False,trust_remote_code=True,timeout=7200" \
    --limit 250
```

## Test Result

MiniMax-M3-MXFP8, MoRIIO 1P1D wide-EP (proxy). GSM8K flexible-extract, threshold 0.85.

| Variant | Health | GSM8K exact_match |
|---------|--------|-------------------|
| No fix (register non-contiguous tensor directly) | Fail (`input tensor must be contiguous`) | — |
| `.contiguous()` copy | Pass | 0.0 |
| This fix (`as_strided` view) | Pass | **0.920** (PASS) |
