### PR TITLE
[DSv4 Perf] Adaptive topk width for dsv4, making #50004 back

### DIFF
--- a/tests/kernels/attention/test_flashmla_sparse.py
+++ b/tests/kernels/attention/test_flashmla_sparse.py
@@ -4,6 +4,63 @@ import pytest
 import torch
 
 
+def test_deepseek_v4_c128a_adaptive_width_has_capture_stable_stride():
+    from vllm.models.deepseek_v4.sparse_mla import build_c128a_topk_metadata
+
+    device = torch.device("cuda")
+    capacity_width = 512
+    global_decode_buffer = torch.empty(
+        (2, capacity_width), dtype=torch.int32, device=device
+    )
+    prefill_buffer = torch.empty_like(global_decode_buffer)
+    kwargs = dict(
+        positions=torch.tensor([255, 511, 383, 639], device=device),
+        compress_ratio=128,
+        num_decode_tokens=2,
+        token_to_req_indices=torch.tensor(
+            [0, 1, 0, 1], dtype=torch.int32, device=device
+        ),
+        block_table=torch.tensor([[3], [5]], dtype=torch.int32, device=device),
+        block_size=capacity_width,
+        slot_mapping=torch.arange(4, dtype=torch.int64, device=device),
+        global_decode_buffer=global_decode_buffer,
+        decode_lens_buffer=torch.empty(2, dtype=torch.int32, device=device),
+        prefill_buffer=prefill_buffer,
+    )
+    captured_decode, _, captured_prefill = build_c128a_topk_metadata(
+        max_compressed_tokens=256,
+        **kwargs,
+    )
+    assert captured_decode.shape == captured_prefill.shape == (2, 256)
+    assert captured_decode.stride(0) == captured_prefill.stride(0) == capacity_width
+
+    captured_rows = torch.empty((4, 4), dtype=torch.int32, device=device)
+    captured_rows[:2].copy_(captured_decode[:, :4])
+    captured_rows[2:].copy_(captured_prefill[:, :4])
+    torch.accelerator.synchronize()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        captured_rows[:2].copy_(captured_decode[:, :4])
+        captured_rows[2:].copy_(captured_prefill[:, :4])
+
+    global_decode_buffer.fill_(-99)
+    prefill_buffer.fill_(-99)
+    build_c128a_topk_metadata(
+        max_compressed_tokens=128,
+        **kwargs,
+    )
+    graph.replay()
+
+    assert captured_rows.cpu().tolist() == [
+        [1536, 1537, -1, -1],
+        [2560, 2561, 2562, 2563],
+        [0, 1, 2, -1],
+        [0, 1, 2, 3],
+    ]
+    assert torch.all(global_decode_buffer[:, 128:] == -99)
+    assert torch.all(prefill_buffer[:, 128:] == -99)
+
+
 def test_sparse_flashmla_metadata_smoke():
     import vllm.v1.attention.ops.flashmla as fm
 

--- a/vllm/models/deepseek_v4/sparse_mla.py
+++ b/vllm/models/deepseek_v4/sparse_mla.py
@@ -264,6 +264,8 @@ class DeepseekV4SparseMLAMetadataBuilder(
             ),
             self.c128a_max_compressed,
         )
+        assert active_topk_width >= cm.max_seq_len // self.compress_ratio
+        assert active_topk_width % _C128A_TOPK_ALIGNMENT == 0
         block_size = self.kv_cache_spec.block_size // self.compress_ratio
         global_decode, decode_lens, prefill_local = build_c128a_topk_metadata(
             cm.positions[:num_total],
@@ -327,10 +329,19 @@ def build_c128a_topk_metadata(
     """
     num_tokens = positions.shape[0]
     num_prefill_tokens = num_tokens - num_decode_tokens
+    assert max_compressed_tokens % _C128A_TOPK_ALIGNMENT == 0
+    assert (
+        0
+        < max_compressed_tokens
+        <= min(global_decode_buffer.shape[1], prefill_buffer.shape[1])
+    )
+    assert global_decode_buffer.stride(-1) == prefill_buffer.stride(-1) == 1
 
     global_decode = global_decode_buffer[:num_decode_tokens, :max_compressed_tokens]
     decode_lens = decode_lens_buffer[:num_decode_tokens]
     prefill_local = prefill_buffer[:num_prefill_tokens, :max_compressed_tokens]
+    assert global_decode.stride(0) == global_decode_buffer.stride(0)
+    assert prefill_local.stride(0) == prefill_buffer.stride(0)
 
     if num_tokens == 0:
         return global_decode, decode_lens, prefill_local

--- a/vllm/models/deepseek_v4/sparse_mla.py
+++ b/vllm/models/deepseek_v4/sparse_mla.py
@@ -257,6 +257,13 @@ class DeepseekV4SparseMLAMetadataBuilder(
         assert cm.positions is not None, (
             "positions is required for C128A metadata build"
         )
+        active_topk_width = min(
+            max(
+                triton.next_power_of_2(max(cm.max_seq_len // self.compress_ratio, 1)),
+                _C128A_TOPK_ALIGNMENT,
+            ),
+            self.c128a_max_compressed,
+        )
         block_size = self.kv_cache_spec.block_size // self.compress_ratio
         global_decode, decode_lens, prefill_local = build_c128a_topk_metadata(
             cm.positions[:num_total],
@@ -269,7 +276,7 @@ class DeepseekV4SparseMLAMetadataBuilder(
             self.c128a_global_decode_buffer,
             self.c128a_decode_lens_buffer,
             self.c128a_prefill_buffer,
-            max_compressed_tokens=self.c128a_max_compressed,
+            max_compressed_tokens=active_topk_width,
         )
 
         result: dict[str, torch.Tensor | None] = {}
@@ -321,9 +328,9 @@ def build_c128a_topk_metadata(
     num_tokens = positions.shape[0]
     num_prefill_tokens = num_tokens - num_decode_tokens
 
-    global_decode = global_decode_buffer[:num_decode_tokens]
+    global_decode = global_decode_buffer[:num_decode_tokens, :max_compressed_tokens]
     decode_lens = decode_lens_buffer[:num_decode_tokens]
-    prefill_local = prefill_buffer[:num_prefill_tokens]
+    prefill_local = prefill_buffer[:num_prefill_tokens, :max_compressed_tokens]
 
     if num_tokens == 0:
         return global_decode, decode_lens, prefill_local


### PR DESCRIPTION
## Purpose

https://github.com/vllm-project/vllm/pull/50004 was reverted by https://github.com/vllm-project/vllm/pull/51318

This PR get the similar performance gain but doesn't hurt the accuracy

## Test

### Perf

E2E perf see https://github.com/vllm-project/vllm/pull/50004

Kernel level perf can be seen in this AI generated script

```bash
# SPDX-License-Identifier: Apache-2.0
# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
"""Benchmark adaptive-width DeepSeek-V4 C128A prefill metadata."""

import torch

from vllm.models.deepseek_v4.sparse_mla import build_c128a_topk_metadata
from vllm.triton_utils import triton

NUM_TOKENS = [512, 2048, 8192, 32768]
CONTEXT_LEN = 32768
COMPRESS_RATIO = 128
CAPACITY_WIDTH = 8192
ACTIVE_WIDTH = max(triton.next_power_of_2(CONTEXT_LEN // COMPRESS_RATIO), 128)


def benchmark(num_tokens: int, width: int) -> float:
    device = torch.device("cuda")
    positions = torch.arange(
        CONTEXT_LEN - num_tokens,
        CONTEXT_LEN,
        dtype=torch.int64,
        device=device,
    )
    global_decode_buffer = torch.empty(
        (1, CAPACITY_WIDTH), dtype=torch.int32, device=device
    )
    prefill_buffer = torch.empty(
        (num_tokens, CAPACITY_WIDTH), dtype=torch.int32, device=device
    )
    decode_lens_buffer = torch.empty(1, dtype=torch.int32, device=device)
    token_to_req_indices = torch.zeros(num_tokens, dtype=torch.int32, device=device)
    slot_mapping = torch.zeros(num_tokens, dtype=torch.int64, device=device)
    block_table = torch.zeros((1, 1), dtype=torch.int32, device=device)

    def run() -> None:
        build_c128a_topk_metadata(
            positions,
            COMPRESS_RATIO,
            0,
            token_to_req_indices,
            block_table,
            2,
            slot_mapping,
            global_decode_buffer,
            decode_lens_buffer,
            prefill_buffer,
            max_compressed_tokens=width,
        )

    run()
    return triton.testing.do_bench(run, warmup=100, rep=500, return_mode="median")


print(f"context={CONTEXT_LEN}, capacity={CAPACITY_WIDTH}, active={ACTIVE_WIDTH}")
print(f"{'tokens':>8} {'fixed us':>10} {'adaptive us':>12} {'speedup':>8}")
for num_tokens in NUM_TOKENS:
    fixed_ms = benchmark(num_tokens, CAPACITY_WIDTH)
    adaptive_ms = benchmark(num_tokens, ACTIVE_WIDTH)
    print(
        f"{num_tokens:>8} {fixed_ms * 1000:>10.2f} "
        f"{adaptive_ms * 1000:>12.2f} {fixed_ms / adaptive_ms:>7.2f}x"
    )

```

And we can get

```bash
context=32768, capacity=8192, active=256
  tokens   fixed us  adaptive us  speedup
     512       9.22         7.20    1.28x
    2048      15.39         7.20    2.14x
    8192      44.00        11.30    3.90x
   32768     150.56        25.79    5.84x
```

### Acc

GPT 5.6 sol helps doing the acc test as https://github.com/vllm-project/vllm/issues/52448 mentioned, results below:

- Hardware: 2 x NVIDIA B200 allocated by `chg` (physical GPUs 5 and 6).
- Model: `deepseek-ai/DeepSeek-V4-Flash-0731`, exact snapshot
  `7872f01b1d1fe23eabc4c98b48bffcef5a386062`.
- Trigger configuration: TP2, expert parallel, DSpark with 7 speculative
  tokens, greedy draft, prefix caching, breakable CUDA graphs, and
  `FULL_AND_PIECEWISE` graph mode.
- Load: concurrency 32, 8 warm-up waves followed by 8 measured waves, 512
  requests total. Each request used the issue payload, `temperature=0`, and
  `max_tokens=16384`.
- Issue hit definition: `finish_reason == "length"`, empty content, and no
  tool calls.
- Warm-up: 0/256 hits, 0 errors, 256/256 `tool_calls` finishes.
- Measured after the first 256 requests: 0/256 hits, 0 errors, 256/256
  `tool_calls` finishes.
- Total: 0/512 hits and 0/512 transport/server errors.
- Server error scan: zero CUDA, illegal-memory, assertion, graph-error, fatal,
  or traceback matches.

All 512 responses had non-empty content and tool calls using declared tool
names with JSON-decodable arguments. Tool-call count was 1 for 75 responses,
4 for 27 responses, and 6 for 410 responses. This validates absence of the
specific length-cap/empty-turn failure; it is not a full semantic task-accuracy
evaluation.

The prompt was 6,543 tokens and the largest prompt-plus-completion was 9,037
tokens. Therefore this run exercised logical C128A width 128 while retaining
the capacity row stride 640, rather than falling back to the full-width path.

[repro-52448-adaptive-stride-20260818.zip](https://github.com/user-attachments/files/31195408/repro-52448-adaptive-stride-20260818.zip)
