### PR TITLE
[Bugfix][Frontend] Run the serve arg checks for `vllm launch` too

### DIFF
--- a/tests/entrypoints/openai/test_cli_args.py
+++ b/tests/entrypoints/openai/test_cli_args.py
@@ -214,6 +214,50 @@ def test_per_request_metrics_requires_log_stats(serve_parser):
         validate_parsed_serve_args(args)
 
 
+def _build_launch_render_parser():
+    """Mirror `vllm launch render`.
+
+    `vllm/entrypoints/cli/main.py` parses subcommands with ``dest="subparser"``,
+    and `LaunchSubcommandBase.add_cli_args` builds the component parser with
+    `make_arg_parser`, so a launch component carries serve args under
+    ``args.subparser == "launch"``.
+    """
+    vllm_parser = FlexibleArgumentParser()
+    subparsers = vllm_parser.add_subparsers(required=False, dest="subparser")
+    launch_parser = subparsers.add_parser("launch")
+    launch_subparsers = launch_parser.add_subparsers(
+        required=True, dest="launch_component"
+    )
+    render_parser = launch_subparsers.add_parser("render")
+    make_arg_parser(render_parser)
+    return vllm_parser
+
+
+@pytest.fixture
+def launch_render_parser():
+    return _build_launch_render_parser()
+
+
+def test_launch_render_validates_serve_args(launch_render_parser):
+    """`vllm launch render` reuses the serve parser, so it gets the serve checks"""
+    args = launch_render_parser.parse_args(
+        args=["launch", "render", "--enable-auto-tool-choice"]
+    )
+    assert args.subparser == "launch"
+    with pytest.raises(TypeError):
+        validate_parsed_serve_args(args)
+
+
+def test_subcommand_without_serve_args_skips_validation():
+    """A subcommand that does not use the serve parser is still skipped"""
+    vllm_parser = FlexibleArgumentParser()
+    subparsers = vllm_parser.add_subparsers(required=False, dest="subparser")
+    subparsers.add_parser("chat")
+    args = vllm_parser.parse_args(args=["chat"])
+
+    validate_parsed_serve_args(args)
+
+
 @pytest.mark.parametrize(
     "cli_args, expected_middleware",
     [

--- a/vllm/entrypoints/openai/cli_args.py
+++ b/vllm/entrypoints/openai/cli_args.py
@@ -412,7 +412,9 @@ def make_arg_parser(parser: FlexibleArgumentParser) -> FlexibleArgumentParser:
 
 def validate_parsed_serve_args(args: argparse.Namespace):
     """Quick checks for model serve args that raise prior to loading."""
-    if hasattr(args, "subparser") and args.subparser != "serve":
+    # `vllm launch <component>` builds its parser with make_arg_parser too (see
+    # LaunchSubcommandBase.add_cli_args), so its args are serve args as well.
+    if hasattr(args, "subparser") and args.subparser not in ("serve", "launch"):
         return
 
     # Ensure that the chat template is valid; raises if it likely isn't


### PR DESCRIPTION
## Purpose

`vllm launch render` silently skips every one of the pre-load serve argument checks, so an invalid flag combination is accepted at the CLI and only fails (or misbehaves) later.

`vllm/entrypoints/cli/main.py` registers subcommands with `dest="subparser"` and then calls `cmds[args.subparser].validate(args)`. `LaunchSubcommand.validate` calls `validate_parsed_serve_args(args)`, and `LaunchSubcommandBase.add_cli_args` builds the component parser with `make_arg_parser`, so `vllm launch render` genuinely accepts the full serve flag set. But the first line of the validator is:

```python
if hasattr(args, "subparser") and args.subparser != "serve":
    return
```

For `vllm launch render` `args.subparser` is `"launch"`, so the function returns before doing anything. Everything it guards is skipped:

- `validate_chat_template(args.chat_template)`
- `--enable-auto-tool-choice` requires `--tool-call-parser`
- `--enable-log-outputs` requires `--enable-log-requests`
- `--enable-per-request-metrics` conflicts with `--disable-log-stats`
- `validate_multi_port_external_lb_args` for `--data-parallel-multi-port-external-lb`

The `hasattr` half of the guard is still needed: `vllm/entrypoints/openai/api_server.py`'s `__main__` block parses with `make_arg_parser` and no subparser at all, and must be validated. Only the `!= "serve"` half is wrong now that `launch` exists.

This changes the CLI contract in the direction the code already intended, catching bad arguments at parse time instead of letting them through. `vllm serve` behaviour is unchanged, and a subcommand that does not build its parser from `make_arg_parser` is still skipped.

## Not a duplicate

No open or merged PR touches `validate_parsed_serve_args`'s subparser guard, and no open issue reports `vllm launch` skipping serve validation. The `launch` subcommand and its `render` component are recent, and the guard predates them, which is how the gap opened.

## Test Plan

Two tests added to `tests/entrypoints/openai/test_cli_args.py`, next to the existing serve-validation tests:

- `test_launch_render_validates_serve_args` builds the parser the way `vllm/entrypoints/cli/main.py` and `LaunchSubcommandBase.add_cli_args` do (`dest="subparser"`, nested `launch render` component built from `make_arg_parser`), asserts `args.subparser == "launch"`, and asserts `--enable-auto-tool-choice` with no `--tool-call-parser` raises `TypeError`.
- `test_subcommand_without_serve_args_skips_validation` pins the remaining purpose of the guard: a subcommand that does not carry serve args is still skipped and must not raise.

```
pytest tests/entrypoints/openai/test_cli_args.py -k "launch_render or without_serve_args"
```

## Test Result

I do not have a GPU or a vLLM build in my environment, so the pytest run above is left to CI. What I did run locally:

1. A standalone `argparse` harness that reproduces the exact wiring (root parser with `dest="subparser"`, a `serve` subparser and a nested `launch render` subparser, both built by the same `make_arg_parser` stub) plus the validator's guard and its first check:

```
serve --enable-auto-tool-choice           subparser=serve   before='TypeError: --enable-auto-tool-choice requires --tool-call-parser'  after='TypeError: ...'
launch render --enable-auto-tool-choice   subparser=launch  before='SKIPPED'                                                          after='TypeError: ...'
```

So `launch render` is skipped before the change and validated after, while `serve` is unaffected.

2. `ruff check` and `ruff format --diff` on both changed files. `ruff format` reports both already formatted, and `ruff check` reports exactly the same four pre-existing findings before and after the change (`PLR0402`, `RUF010`, `PIE807` in `cli_args.py`, `I001` in `test_cli_args.py`), none on a line this PR touches.

This is a CLI argument-validation change only. It does not touch sampling, kernels, model execution or output, so there are no accuracy or serving benchmark numbers to report.

## Essential Elements of an Effective PR Description Checklist

- [x] The purpose of the PR, such as "Fix some bug".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after.
- [x] (Optional) The necessary documentation update.

---

AI assistance was used in preparing this change. I reviewed the diff, ran the checks reported above, and I am responsible for its correctness.
