### PR TITLE
[Bugfix] Truncate all full-attention groups to the shared prefix-cache hit

### DIFF
--- a/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
+++ b/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
@@ -1484,6 +1484,85 @@ def test_hybrid_partial_hit_with_eagle_stays_within_group_blocks():
     assert manager.allocate_slots(req1, 4, num_computed, computed_blocks) is not None
 
 
+def test_dspark_miss_does_not_poison_next_prefix_lookup():
+    """A DSpark miss must not retain draft blocks past the joint hybrid hit."""
+    hash_block_size = 2
+    block_size = 8
+    kv_cache_config = KVCacheConfig(
+        num_blocks=64,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["target"],
+                FullAttentionSpec(
+                    block_size=hash_block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                ),
+            ),
+            KVCacheGroupSpec(
+                ["draft"],
+                FullAttentionSpec(
+                    block_size=hash_block_size,
+                    num_kv_heads=1,
+                    head_size=2,
+                    dtype=torch.float32,
+                ),
+                is_eagle_group=True,
+            ),
+            KVCacheGroupSpec(
+                ["mamba"],
+                MambaSpec(
+                    block_size=block_size,
+                    shapes=(1, 1),
+                    dtypes=(torch.float32,),
+                    mamba_cache_mode="align",
+                ),
+            ),
+        ],
+    )
+    manager = make_kv_cache_manager(
+        kv_cache_config=kv_cache_config,
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=hash_block_size,
+        scheduler_block_size=block_size,
+        dcp_world_size=4,
+        use_eagle=True,
+        retention_interval=0,
+    )
+
+    def run_request(request_id: str, num_tokens: int) -> int:
+        request = make_request(
+            request_id, list(range(num_tokens)), hash_block_size, sha256
+        )
+        computed_blocks, num_computed, _ = manager.get_computed_blocks(request)
+        assert (
+            manager.allocate_slots(
+                request,
+                num_tokens - num_computed,
+                num_computed,
+                computed_blocks,
+            )
+            is not None
+        )
+        request.num_computed_tokens = num_tokens
+        manager.free(request)
+        manager.new_step_starts()
+        return num_computed
+
+    # Seed a six-token prefix; the first request has nothing to reuse.
+    assert run_request("first", 6) == 0
+    # The draft group finds stale candidate blocks, but EAGLE and Mamba
+    # reconciliation reduce the joint hit to zero. Those blocks must not be
+    # attached to this request.
+    assert run_request("second", 8) == 0
+    # The second request populated eight tokens correctly. EAGLE rewinds one
+    # two-token hash unit, so the next joint prefix hit is six tokens.
+    assert run_request("third", 10) == 6
+
+
 def test_hybrid_sliding_window_group_disables_partial_hash_hits():
     hash_block_size = 2
     sliding_window_block_size = 2 * hash_block_size

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -867,14 +867,14 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
             if is_simple_hybrid:
                 break
 
-        # Truncate full attention blocks to final hit_length (if present)
-        first_group = self.attention_groups[0]
-        if isinstance(first_group.spec, FullAttentionSpec):
-            group_block_size = self.single_type_managers[
-                first_group.group_ids[0]
-            ].block_size
+        # Truncate every full-attention group (target and draft) blocks
+        # to final hit_length.
+        for group in self.attention_groups:
+            if not isinstance(group.spec, FullAttentionSpec):
+                continue
+            group_block_size = self.single_type_managers[group.group_ids[0]].block_size
             num_blocks = cdiv(hit_length, group_block_size)
-            for group_id in first_group.group_ids:
+            for group_id in group.group_ids:
                 if (blks := hit_blocks_by_group[group_id]) is not None:
                     del blks[num_blocks:]
                     hit_length_by_group[group_id] = hit_length


### PR DESCRIPTION
## Purpose
Hybrid prefix lookup iteratively reconciles target attention, draft attention, and Mamba hits. A later group can reduce the final hit length due to eagle block drop, but currently the cleanup only truncated the first full-attention group based on the hit length and fails to account for the draft model full attention group. This results in corrupted prefix caching behavior:

Kimi K3 DCP + Dspark:
```
vllm serve ~/models/Kimi-K3 \
  --tensor-parallel-size 8 \
  -dcp 8 \
  --load-format fastsafetensors \
  --no-enable-flashinfer-autotune \
  --trust-remote-code \
  --language-model-only \
  --attention-config '{"mla_prefill_backend":"TRTLLM_RAGGED","use_prefill_query_quantization":true}' \
  --kv-cache-dtype fp8 \
  --speculative-config '{"model":"Inferact/Kimi-K3-DSpark","method":"dspark","num_speculative_tokens":4,"rejection_sample_method":"standard"}' \
  --enable-prompt-tokens-details \
  --prefix-match-unit 128

prompt_length=10000, cache_hit_length=0
prompt_length=20000, cache_hit_length=0
prompt_length=30000, cache_hit_length=0
prompt_length=50000, cache_hit_length=0
prompt_length=100000, cache_hit_length=0
prompt_length=200000, cache_hit_length=0
cache_hit_lengths=[0, 0, 0, 0, 0, 0]
```

After the fix:
```
prompt_length=10000, cache_hit_length=0
prompt_length=20000, cache_hit_length=0
prompt_length=30000, cache_hit_length=9984
prompt_length=50000, cache_hit_length=9984
prompt_length=100000, cache_hit_length=29952
prompt_length=200000, cache_hit_length=98304
cache_hit_lengths=[0, 0, 9984, 9984, 29952, 98304]
```

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

