### PR TITLE
[CI][Bugfix] Fix test_models_fse_init deepseek_v4 mock

### DIFF
--- a/tests/model_executor/layers/test_fused_shared_expert.py
+++ b/tests/model_executor/layers/test_fused_shared_expert.py
@@ -479,6 +479,8 @@ def test_models_fse_init(
         is_mm_prefix_lm=False,
         multimodal_config=None,
         quantization_config=None,
+        runner_type="generate",
+        is_moe=True,
     )
     vllm_config.parallel_config.enable_expert_parallel = False
     if model_type == "deepseek_v4":


### PR DESCRIPTION
## Purpose

`test_models_fse_init[*-deepseek_v4]` is currently red on `main`. It's a semantic conflict between two PRs that were each green on their own:

- #52401 made `DeepseekV4Attention.__init__` read `vllm_config.use_v2_model_runner`, which needs `model_config.runner_type` and `model_config.is_moe`.
- #51695 added this test with a `SimpleNamespace` mock that doesn't set those, so construction dies with `AttributeError: ... has no attribute 'runner_type'`.

Fix: add both attributes to the mock. Test-only, no runtime change.

## Test Plan

Run the affected test: `pytest tests/model_executor/layers/test_fused_shared_expert.py -k deepseek_v4`

## Test Result

Fix verified by tracing the `use_v2_model_runner` path; needs a GPU lane (model-executor / amd) to run the full test. Not a duplicate — no open PR touches this. AI assistance was used.