### PR TITLE
[Bugfix][AMD] A GPU-CPU KV transfer fault in OffloadingConnector takes the engine down instead of degrading the cache.

### DIFF
--- a/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
+++ b/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
@@ -2112,7 +2112,6 @@ def test_failed_store_is_not_published_as_cache(request_runner, async_scheduling
     job_id = next(iter(runner.connector_scheduler._jobs))
     runner.manager.complete_store.reset_mock()
 
-    # Step 1: one worker fails. The job is not complete yet.
     runner.connector_scheduler.update_connector_output(
         KVConnectorOutput(
             kv_connector_worker_meta=OffloadingWorkerMetadata(
@@ -2122,8 +2121,6 @@ def test_failed_store_is_not_published_as_cache(request_runner, async_scheduling
     )
     assert runner.manager.complete_store.call_count == 0
 
-    # Step 2: the other two succeed and the job completes. This batch carries
-    # no failure flag, so the verdict must come from the job's sticky state.
     runner.connector_scheduler.update_connector_output(
         KVConnectorOutput(
             kv_connector_worker_meta=OffloadingWorkerMetadata(

--- a/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
+++ b/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
@@ -2087,6 +2087,86 @@ def test_complete_store_waits_for_all_worker_acks(
 
 
 @pytest.mark.parametrize("async_scheduling", [True, False])
+def test_failed_store_is_not_published_as_cache(request_runner, async_scheduling: bool):
+    """A store that failed on any worker must not become loadable.
+
+    Its destination blocks were never written, so publishing them would serve
+    whatever the recycled blocks last held -- potentially another request's KV.
+    The failure is reported in an earlier step than the one that completes the
+    job, which is the case a per-step failure lookup would miss.
+    """
+    tokens_per_block = 4
+    blocks_per_chunk = 3
+    runner = request_runner(
+        blocks_per_chunk=blocks_per_chunk,
+        block_size=tokens_per_block,
+        num_gpu_blocks=100,
+        async_scheduling=async_scheduling,
+        worker_count=3,
+    )
+    runner.new_request(token_ids=[0] * (tokens_per_block * blocks_per_chunk))
+    runner.manager.prepare_store.side_effect = lambda keys, req_context: (
+        generate_store_output(keys)
+    )
+    runner.run(decoded_tokens=[0, 0], complete_transfers=False)
+    job_id = next(iter(runner.connector_scheduler._jobs))
+    runner.manager.complete_store.reset_mock()
+
+    # Step 1: one worker fails. The job is not complete yet.
+    runner.connector_scheduler.update_connector_output(
+        KVConnectorOutput(
+            kv_connector_worker_meta=OffloadingWorkerMetadata(
+                completed_jobs={job_id: 1}, failed_jobs={job_id}
+            )
+        )
+    )
+    assert runner.manager.complete_store.call_count == 0
+
+    # Step 2: the other two succeed and the job completes. This batch carries
+    # no failure flag, so the verdict must come from the job's sticky state.
+    runner.connector_scheduler.update_connector_output(
+        KVConnectorOutput(
+            kv_connector_worker_meta=OffloadingWorkerMetadata(
+                completed_jobs={job_id: 2}
+            )
+        )
+    )
+    assert runner.manager.complete_store.call_count == 1
+    assert runner.manager.complete_store.call_args.kwargs["success"] is False
+
+
+@pytest.mark.parametrize("async_scheduling", [True, False])
+def test_successful_store_is_published(request_runner, async_scheduling: bool):
+    """The success path still publishes, so the guard cannot pass vacuously."""
+    tokens_per_block = 4
+    blocks_per_chunk = 3
+    runner = request_runner(
+        blocks_per_chunk=blocks_per_chunk,
+        block_size=tokens_per_block,
+        num_gpu_blocks=100,
+        async_scheduling=async_scheduling,
+        worker_count=3,
+    )
+    runner.new_request(token_ids=[0] * (tokens_per_block * blocks_per_chunk))
+    runner.manager.prepare_store.side_effect = lambda keys, req_context: (
+        generate_store_output(keys)
+    )
+    runner.run(decoded_tokens=[0, 0], complete_transfers=False)
+    job_id = next(iter(runner.connector_scheduler._jobs))
+    runner.manager.complete_store.reset_mock()
+
+    runner.connector_scheduler.update_connector_output(
+        KVConnectorOutput(
+            kv_connector_worker_meta=OffloadingWorkerMetadata(
+                completed_jobs={job_id: 3}
+            )
+        )
+    )
+    assert runner.manager.complete_store.call_count == 1
+    assert runner.manager.complete_store.call_args.kwargs["success"] is True
+
+
+@pytest.mark.parametrize("async_scheduling", [True, False])
 def test_max_offload_tokens_validation(request_runner, async_scheduling: bool):
     """Validates max_offload_tokens: type coercion, boundary values, and capping.
 

--- a/tests/v1/kv_connector/unit/offloading_connector/test_worker.py
+++ b/tests/v1/kv_connector/unit/offloading_connector/test_worker.py
@@ -273,6 +273,88 @@ def test_start_kv_transfers_non_writer_still_submits_load():
     assert worker.build_connector_worker_meta() is None
 
 
+def _kv_cache_config(num_groups: int) -> KVCacheConfig:
+    return KVCacheConfig(
+        num_blocks=0,
+        kv_cache_tensors=[],
+        kv_cache_groups=[MagicMock() for _ in range(num_groups)],
+    )
+
+
+def _failed(job_id: int) -> list:
+    from vllm.v1.kv_offload.base import TransferResult
+
+    return [TransferResult(job_id=job_id, success=False)]
+
+
+def test_failed_store_is_dropped_and_still_completes():
+    """A failed store is a future cache miss, not an error.
+
+    It must still be marked completed, or the scheduler's per-job pending
+    count never reaches zero.
+    """
+    worker, _ = _make_worker(_kv_cache_config(1))
+    worker.prepare_store_kv(_store_metadata(11))
+    worker.start_kv_transfers(_empty_metadata())
+    worker.worker.get_finished.return_value = _failed(11)
+
+    finished_sending, finished_recving = worker.get_finished(set())
+
+    assert finished_sending == set()
+    assert finished_recving == set()
+    assert worker.get_block_ids_with_load_errors() == set()
+    meta = worker.build_connector_worker_meta()
+    assert meta is not None
+    assert meta.completed_jobs == {11: 1}
+
+
+def test_failed_load_reports_its_blocks_for_recomputation():
+    """A failed load leaves undefined KV in its destination blocks.
+
+    The request is still reported as finished (the base contract), and the
+    blocks are handed to the scheduler so it recomputes them.
+    """
+    worker, _ = _make_worker(_kv_cache_config(1))
+    metadata = OffloadingConnectorMetadata(
+        load_jobs={
+            12: TransferJob(
+                req_id="req",
+                src_spec=LoadStoreSpec(),
+                dst_spec=GPULoadStoreSpec(
+                    [3, 4, 5], group_sizes=(3,), block_indices=(0,)
+                ),
+            )
+        },
+        store_jobs={},
+    )
+    worker.start_kv_transfers(metadata)
+    worker.worker.get_finished.return_value = _failed(12)
+
+    _, finished_recving = worker.get_finished(set())
+
+    assert finished_recving == {"req"}
+    assert worker.get_block_ids_with_load_errors() == {3, 4, 5}
+    # Draining is one-shot: the scheduler must not see them twice.
+    assert worker.get_block_ids_with_load_errors() == set()
+    meta = worker.build_connector_worker_meta()
+    assert meta is not None
+    assert meta.completed_jobs == {12: 1}
+
+
+def test_failed_load_raises_on_hybrid_models():
+    """Block-level recovery assumes a single KV cache group.
+
+    Continuing would let the request read undefined KV, so a hybrid model
+    must fail loudly rather than silently return wrong output.
+    """
+    worker, _ = _make_worker(_kv_cache_config(2))
+    worker.start_kv_transfers(_load_metadata(13))
+    worker.worker.get_finished.return_value = _failed(13)
+
+    with pytest.raises(RuntimeError, match="multiple KV cache groups"):
+        worker.get_finished(set())
+
+
 def test_offloading_connector_worker_accepts_plugin_spec_default_layout():
     from vllm.distributed.kv_transfer.kv_connector.v1.offloading.worker import (
         OffloadingConnectorWorker,

--- a/tests/v1/kv_connector/unit/offloading_connector/test_worker.py
+++ b/tests/v1/kv_connector/unit/offloading_connector/test_worker.py
@@ -334,7 +334,6 @@ def test_failed_load_reports_its_blocks_for_recomputation():
 
     assert finished_recving == {"req"}
     assert worker.get_block_ids_with_load_errors() == {3, 4, 5}
-    # Draining is one-shot: the scheduler must not see them twice.
     assert worker.get_block_ids_with_load_errors() == set()
     meta = worker.build_connector_worker_meta()
     assert meta is not None

--- a/tests/v1/kv_offload/cpu/test_gpu_worker.py
+++ b/tests/v1/kv_offload/cpu/test_gpu_worker.py
@@ -161,6 +161,7 @@ def test_handler_shutdown_skips_transfers_after_event_sync_failure() -> None:
         ]
     )
     handler._transfer_events = {1: failed_event, 2: skipped_event}
+    handler._submit_failures = gpu_worker.deque()
     handler._stream_pool = [MagicMock()]
     handler._event_pool = [MagicMock()]
     handler._buffer_pool = [(MagicMock(), MagicMock(), MagicMock())]
@@ -178,6 +179,74 @@ def test_handler_shutdown_skips_transfers_after_event_sync_failure() -> None:
     assert not handler._buffer_pool
     assert not handler.src_tensors
     assert not handler.dst_tensors
+
+
+def _bare_handler(gpu_to_cpu: bool = True):
+    """Handler with only the state the failure paths touch."""
+    handler = gpu_worker.SingleDirectionOffloadingHandler.__new__(
+        gpu_worker.SingleDirectionOffloadingHandler
+    )
+    handler.gpu_to_cpu = gpu_to_cpu
+    handler._transfers = gpu_worker.deque()
+    handler._transfer_events = {}
+    handler._submit_failures = gpu_worker.deque()
+    handler._stream_pool = []
+    handler._event_pool = []
+    handler._buffer_pool = []
+    return handler
+
+
+def test_get_finished_reports_submit_failure_without_raising() -> None:
+    """A transfer that faulted at submit time still completes, as a failure.
+
+    The scheduler waits for every submitted job to complete, so a fault must be
+    reported rather than dropped or raised.
+    """
+    handler = _bare_handler()
+    handler._transfer_events[7] = MagicMock()
+    handler._submit_failures.append(7)
+
+    results = handler.get_finished()
+
+    assert [(r.job_id, r.success) for r in results] == [(7, False)]
+    assert not handler._transfer_events
+    assert handler.get_finished() == []
+
+
+def test_get_finished_reports_failure_when_event_query_raises() -> None:
+    """A device error latched after submit surfaces at poll time, not as a raise."""
+    handler = _bare_handler()
+    failing = MagicMock()
+    failing.end_event.query.side_effect = RuntimeError("device lost")
+    failing.job_id = 3
+    ready = MagicMock()
+    ready.job_id = 4
+    ready.end_event.query.return_value = True
+    ready.start_event.elapsed_time.return_value = 2.0
+    ready.num_bytes = 512
+    handler._transfers.extend([failing, ready])
+    handler._transfer_events = {3: failing.end_event, 4: ready.end_event}
+
+    results = handler.get_finished()
+
+    assert [(r.job_id, r.success) for r in results] == [(3, False), (4, True)]
+    assert not handler._transfers
+    assert not handler._transfer_events
+    # The faulted transfer's stream/events are dropped rather than pooled, so a
+    # latched device error cannot leak into an unrelated transfer.
+    assert handler._stream_pool == [ready.stream]
+
+
+def test_wait_swallows_synchronize_failure() -> None:
+    """wait() must not raise; the failure is reported by the next poll."""
+    handler = _bare_handler()
+    event = MagicMock()
+    event.synchronize.side_effect = RuntimeError("device lost")
+    handler._transfer_events[9] = event
+
+    handler.wait({9})
+
+    event.synchronize.assert_called_once_with()
 
 
 @pytest.mark.parametrize("device_sync_fails", [False, True])

--- a/tests/v1/kv_offload/cpu/test_gpu_worker.py
+++ b/tests/v1/kv_offload/cpu/test_gpu_worker.py
@@ -237,6 +237,22 @@ def test_get_finished_reports_failure_when_event_query_raises() -> None:
     assert handler._stream_pool == [ready.stream]
 
 
+def test_get_finished_propagates_non_device_errors() -> None:
+    """Only device faults are downgraded to a failed transfer.
+
+    A missing op or a bad argument is a programming error; swallowing it would
+    turn a loud, one-line diagnosis into a silently degraded cache.
+    """
+    handler = _bare_handler()
+    broken = MagicMock()
+    broken.job_id = 5
+    broken.end_event.query.side_effect = AttributeError("no such op")
+    handler._transfers.append(broken)
+
+    with pytest.raises(AttributeError, match="no such op"):
+        handler.get_finished()
+
+
 def test_wait_swallows_synchronize_failure() -> None:
     """wait() must not raise; the failure is reported by the next poll."""
     handler = _bare_handler()

--- a/tests/v1/kv_offload/cpu/test_gpu_worker.py
+++ b/tests/v1/kv_offload/cpu/test_gpu_worker.py
@@ -239,7 +239,6 @@ def test_submit_failure_is_not_reported_until_stream_drains(
     (transfer,) = handler._transfers
     assert (transfer.job_id, transfer.failed) == (7, True)
     assert handler._transfer_events == {7: end_event}
-    # Still under DMA: nothing may be handed to another transfer yet.
     assert not handler._stream_pool
     assert not handler._event_pool
     assert not handler._buffer_pool
@@ -253,8 +252,6 @@ def test_submit_failure_is_not_reported_until_stream_drains(
     assert [(r.job_id, r.success) for r in results] == [(7, False)]
     assert not handler._transfers
     assert not handler._transfer_events
-    # Drained, but the stream may carry a latched device error, so it and its
-    # events and descriptor buffers are dropped rather than pooled.
     assert not handler._stream_pool
     assert not handler._event_pool
     assert not handler._buffer_pool
@@ -329,9 +326,6 @@ def test_get_finished_reports_failure_when_event_query_raises() -> None:
     assert [(r.job_id, r.success) for r in results] == [(3, False), (4, True)]
     assert not handler._transfers
     assert not handler._transfer_events
-    # The faulted transfer's stream/events are dropped rather than pooled, so a
-    # latched device error cannot leak into an unrelated transfer. Its
-    # descriptor buffers may still be under DMA, so they are dropped too.
     assert handler._stream_pool == [ready.stream]
     assert handler._buffer_pool == [
         (ready.batch_src, ready.batch_dst, ready.batch_sizes)

--- a/tests/v1/kv_offload/cpu/test_gpu_worker.py
+++ b/tests/v1/kv_offload/cpu/test_gpu_worker.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import contextlib
 import logging
 import random
 import time
@@ -161,7 +162,6 @@ def test_handler_shutdown_skips_transfers_after_event_sync_failure() -> None:
         ]
     )
     handler._transfer_events = {1: failed_event, 2: skipped_event}
-    handler._submit_failures = gpu_worker.deque()
     handler._stream_pool = [MagicMock()]
     handler._event_pool = [MagicMock()]
     handler._buffer_pool = [(MagicMock(), MagicMock(), MagicMock())]
@@ -189,28 +189,124 @@ def _bare_handler(gpu_to_cpu: bool = True):
     handler.gpu_to_cpu = gpu_to_cpu
     handler._transfers = gpu_worker.deque()
     handler._transfer_events = {}
-    handler._submit_failures = gpu_worker.deque()
     handler._stream_pool = []
     handler._event_pool = []
     handler._buffer_pool = []
     return handler
 
 
-def test_get_finished_reports_submit_failure_without_raising() -> None:
-    """A transfer that faulted at submit time still completes, as a failure.
+def _submittable_handler(monkeypatch: pytest.MonkeyPatch, gpu_to_cpu: bool = True):
+    """Bare handler wired up far enough to run transfer_async off-device."""
+    handler = _bare_handler(gpu_to_cpu)
+    handler.layer_refs_per_group = [MagicMock()]
+    handler.src_blocks_per_chunk = 1
+    handler.dst_blocks_per_chunk = 1
+    handler._estimate_max_copy_ops = lambda group_sizes: 4
+    handler._fill_group_ops = lambda g_idx, **kwargs: (1, 128)
+    handler._swap_blocks_batch = MagicMock()
+    handler._buffer_pool = [tuple(torch.zeros(4, dtype=torch.int64) for _ in range(3))]
 
-    The scheduler waits for every submitted job to complete, so a fault must be
-    reported rather than dropped or raised.
+    platform = MagicMock()
+    platform.stream.return_value = contextlib.nullcontext()
+    monkeypatch.setattr(gpu_worker, "current_platform", platform)
+    return handler
+
+
+def _submit(handler, job_id: int) -> bool:
+    spec = GPULoadStoreSpec(block_ids=[0], group_sizes=[1], block_indices=[0])
+    return handler.transfer_async(job_id, spec, spec)
+
+
+def test_submit_failure_is_not_reported_until_stream_drains(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A submit fault leaves copies in flight, so the job completes only later.
+
+    swap_blocks_batch submits the descriptor list in chunks and the driver's
+    batch memcpy stops at the first failing copy, so earlier copies of the same
+    job may still be touching its blocks. Reporting the job before the stream
+    drains would let the scheduler reuse blocks that are still being written.
     """
-    handler = _bare_handler()
-    handler._transfer_events[7] = MagicMock()
-    handler._submit_failures.append(7)
+    handler = _submittable_handler(monkeypatch)
+    stream, start_event, end_event = MagicMock(), MagicMock(), MagicMock()
+    handler._stream_pool = [stream]
+    handler._event_pool = [end_event, start_event]
+    handler._swap_blocks_batch.side_effect = RuntimeError("failed at index 1")
 
+    assert _submit(handler, 7) is True
+
+    end_event.record.assert_called_once_with(stream)
+    (transfer,) = handler._transfers
+    assert (transfer.job_id, transfer.failed) == (7, True)
+    assert handler._transfer_events == {7: end_event}
+    # Still under DMA: nothing may be handed to another transfer yet.
+    assert not handler._stream_pool
+    assert not handler._event_pool
+    assert not handler._buffer_pool
+
+    end_event.query.return_value = False
+    assert handler.get_finished() == []
+
+    end_event.query.return_value = True
     results = handler.get_finished()
 
     assert [(r.job_id, r.success) for r in results] == [(7, False)]
+    assert not handler._transfers
     assert not handler._transfer_events
-    assert handler.get_finished() == []
+    # Drained, but the stream may carry a latched device error, so it and its
+    # events and descriptor buffers are dropped rather than pooled.
+    assert not handler._stream_pool
+    assert not handler._event_pool
+    assert not handler._buffer_pool
+    start_event.elapsed_time.assert_not_called()
+
+
+def test_submit_failure_still_fences_wait_and_next_submission(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The faulted job keeps ordering the work that follows it.
+
+    wait() is the store-flush fence and every submission chains onto the
+    previous transfer's end event; a faulted job that left neither would let
+    both run ahead of its in-flight copies.
+    """
+    handler = _submittable_handler(monkeypatch)
+    failed_stream, failed_start, failed_end = MagicMock(), MagicMock(), MagicMock()
+    handler._stream_pool = [failed_stream]
+    handler._event_pool = [failed_end, failed_start]
+    handler._swap_blocks_batch.side_effect = RuntimeError("failed at index 1")
+    _submit(handler, 7)
+
+    handler.wait({7})
+    failed_end.synchronize.assert_called_once_with()
+
+    next_stream = MagicMock()
+    handler._stream_pool = [next_stream]
+    handler._event_pool = [MagicMock(), MagicMock()]
+    handler._buffer_pool = [tuple(torch.zeros(4, dtype=torch.int64) for _ in range(3))]
+    handler._swap_blocks_batch.side_effect = None
+    _submit(handler, 8)
+
+    next_stream.wait_event.assert_called_once_with(failed_end)
+
+
+def test_submit_failure_propagates_when_the_end_event_cannot_be_recorded(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Without an end event the in-flight copies cannot be bounded.
+
+    The device is unrecoverable at that point, so failing loudly beats
+    reporting a completion the blocks have not actually reached.
+    """
+    handler = _submittable_handler(monkeypatch)
+    end_event = MagicMock()
+    end_event.record.side_effect = RuntimeError("device lost")
+    handler._stream_pool = [MagicMock()]
+    handler._event_pool = [end_event, MagicMock()]
+    handler._swap_blocks_batch.side_effect = RuntimeError("failed at index 1")
+
+    with pytest.raises(RuntimeError, match="device lost"):
+        _submit(handler, 7)
 
 
 def test_get_finished_reports_failure_when_event_query_raises() -> None:
@@ -221,6 +317,7 @@ def test_get_finished_reports_failure_when_event_query_raises() -> None:
     failing.job_id = 3
     ready = MagicMock()
     ready.job_id = 4
+    ready.failed = False
     ready.end_event.query.return_value = True
     ready.start_event.elapsed_time.return_value = 2.0
     ready.num_bytes = 512
@@ -233,8 +330,12 @@ def test_get_finished_reports_failure_when_event_query_raises() -> None:
     assert not handler._transfers
     assert not handler._transfer_events
     # The faulted transfer's stream/events are dropped rather than pooled, so a
-    # latched device error cannot leak into an unrelated transfer.
+    # latched device error cannot leak into an unrelated transfer. Its
+    # descriptor buffers may still be under DMA, so they are dropped too.
     assert handler._stream_pool == [ready.stream]
+    assert handler._buffer_pool == [
+        (ready.batch_src, ready.batch_dst, ready.batch_sizes)
+    ]
 
 
 def test_get_finished_propagates_non_device_errors() -> None:

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/common.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/common.py
@@ -83,11 +83,17 @@ class OffloadingWorkerMetadata(KVConnectorWorkerMetadata):
     """
 
     completed_jobs: dict[int, int] = field(default_factory=dict)
+    # Jobs whose transfer failed on at least one worker. A job appears here as
+    # well as in completed_jobs: it still completes, but its destination holds
+    # undefined data and must not be published as cache.
+    failed_jobs: set[int] = field(default_factory=set)
     transfer_stats: TransferStats = field(default_factory=TransferStats)
 
-    def mark_completed(self, job_id: int) -> None:
+    def mark_completed(self, job_id: int, success: bool = True) -> None:
         """Record a transfer job completion from this worker."""
         self.completed_jobs[job_id] = 1
+        if not success:
+            self.failed_jobs.add(job_id)
 
     def aggregate(
         self, other: "KVConnectorWorkerMetadata"
@@ -100,5 +106,6 @@ class OffloadingWorkerMetadata(KVConnectorWorkerMetadata):
 
         return OffloadingWorkerMetadata(
             completed_jobs=merged,
+            failed_jobs=self.failed_jobs | other.failed_jobs,
             transfer_stats=self.transfer_stats.aggregate(other.transfer_stats),
         )

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/common.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/common.py
@@ -83,9 +83,6 @@ class OffloadingWorkerMetadata(KVConnectorWorkerMetadata):
     """
 
     completed_jobs: dict[int, int] = field(default_factory=dict)
-    # Jobs whose transfer failed on at least one worker. A job appears here as
-    # well as in completed_jobs: it still completes, but its destination holds
-    # undefined data and must not be published as cache.
     failed_jobs: set[int] = field(default_factory=set)
     transfer_stats: TransferStats = field(default_factory=TransferStats)
 

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
@@ -77,8 +77,6 @@ class TransferJobStatus:
     # Offload keys this job covers; passed to manager.complete_*().
     keys: set[OffloadKey]
     is_store: bool
-    # Set when any worker reports its transfer failed. Sticky: pending_count
-    # can reach zero on a later step than the one carrying the failure.
     failed: bool = False
     # Store source blocks fenced after the request finishes.
     deferred_fence_block_ids: list[int] | None = None
@@ -1824,9 +1822,6 @@ class OffloadingConnectorScheduler:
 
             req_status = self._req_status[job_status.req_id]
             if job_status.is_store:
-                # A failed store never wrote its destination blocks. Publishing
-                # them would expose whatever the recycled blocks last held, so
-                # success=False removes and frees them instead.
                 if job_status.failed:
                     logger.warning(
                         "KV offload store job %d failed; dropping %d chunk(s) "
@@ -1840,10 +1835,6 @@ class OffloadingConnectorScheduler:
                     success=not job_status.failed,
                 )
             else:
-                # complete_load only drops the CPU-side ref count, which must
-                # happen either way or the source blocks stay pinned. A failed
-                # load's damage is on the GPU side and is reported separately
-                # via get_block_ids_with_load_errors().
                 self.manager.complete_load(job_status.keys, req_status.req_context)
                 if self._chunks_being_loaded:
                     self._chunks_being_loaded.difference_update(job_status.keys)

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
@@ -77,6 +77,9 @@ class TransferJobStatus:
     # Offload keys this job covers; passed to manager.complete_*().
     keys: set[OffloadKey]
     is_store: bool
+    # Set when any worker reports its transfer failed. Sticky: pending_count
+    # can reach zero on a later step than the one carrying the failure.
+    failed: bool = False
     # Store source blocks fenced after the request finishes.
     deferred_fence_block_ids: list[int] | None = None
     # Store source blocks fenced when the transfer is created.
@@ -1812,6 +1815,8 @@ class OffloadingConnectorScheduler:
                 )
                 continue
             job_status = self._jobs[job_id]
+            if job_id in meta.failed_jobs:
+                job_status.failed = True
             job_status.pending_count -= count
             if job_status.pending_count > 0:
                 continue
@@ -1819,8 +1824,26 @@ class OffloadingConnectorScheduler:
 
             req_status = self._req_status[job_status.req_id]
             if job_status.is_store:
-                self.manager.complete_store(job_status.keys, req_status.req_context)
+                # A failed store never wrote its destination blocks. Publishing
+                # them would expose whatever the recycled blocks last held, so
+                # success=False removes and frees them instead.
+                if job_status.failed:
+                    logger.warning(
+                        "KV offload store job %d failed; dropping %d chunk(s) "
+                        "from the CPU cache rather than publishing them.",
+                        job_id,
+                        len(job_status.keys),
+                    )
+                self.manager.complete_store(
+                    job_status.keys,
+                    req_status.req_context,
+                    success=not job_status.failed,
+                )
             else:
+                # complete_load only drops the CPU-side ref count, which must
+                # happen either way or the source blocks stay pinned. A failed
+                # load's damage is on the GPU side and is reported separately
+                # via get_block_ids_with_load_errors().
                 self.manager.complete_load(job_status.keys, req_status.req_context)
                 if self._chunks_being_loaded:
                     self._chunks_being_loaded.difference_update(job_status.keys)

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/worker.py
@@ -53,8 +53,21 @@ class OffloadingConnectorWorker:
             not self.spec.replicated_layout or self.spec.config.parallel.rank == 0
         )
 
+        # Block-level load-failure recovery reports GPU block IDs to the
+        # scheduler, whose _update_requests_with_invalid_blocks currently
+        # assumes a single KV cache group.
+        self._supports_load_failure_recovery = len(kv_cache_config.kv_cache_groups) <= 1
+
         # job_id -> req_id for in-flight loads.
         self._load_jobs: dict[int, ReqId] = {}
+
+        # job_id -> GPU block IDs written by an in-flight load. Needed to tell
+        # the scheduler which blocks to recompute when a load fails.
+        self._load_dst_block_ids: dict[int, list[int]] = {}
+
+        # GPU block IDs whose contents failed to load, drained by
+        # get_block_ids_with_load_errors().
+        self._invalid_block_ids: set[int] = set()
         self._unsubmitted_store_jobs: list[
             tuple[int, GPULoadStoreSpec, LoadStoreSpec]
         ] = []
@@ -242,6 +255,7 @@ class OffloadingConnectorWorker:
         for job_id, entry in metadata.load_jobs.items():
             self._load_jobs[job_id] = entry.req_id
             assert isinstance(entry.dst_spec, GPULoadStoreSpec)
+            self._load_dst_block_ids[job_id] = list(entry.dst_spec.block_ids)
             success = self.worker.submit_load(job_id, entry.src_spec, entry.dst_spec)
             assert success
 
@@ -272,10 +286,22 @@ class OffloadingConnectorWorker:
         assert self.worker is not None
         finished_recving: set[str] = set()
         for transfer_result in self.worker.get_finished():
-            # we currently do not support job failures
             job_id = transfer_result.job_id
-            assert transfer_result.success
             is_load = job_id in self._load_jobs
+            if not transfer_result.success:
+                self._handle_failed_transfer(job_id, is_load)
+                # A failed job must still be marked completed, or the
+                # scheduler's per-job pending count never reaches zero and
+                # the request is never resumed.
+                self._connector_worker_meta.mark_completed(job_id)
+                self._load_dst_block_ids.pop(job_id, None)
+                req_id = self._load_jobs.pop(job_id, None)
+                if req_id is not None:
+                    # The contract in KVConnectorBase_V1 requires a request to
+                    # be reported here even when its load failed; the invalid
+                    # blocks are reported alongside it.
+                    finished_recving.add(req_id)
+                continue
             if (
                 transfer_result.transfer_time is not None
                 and transfer_result.transfer_size is not None
@@ -290,11 +316,63 @@ class OffloadingConnectorWorker:
                 )
 
             self._connector_worker_meta.mark_completed(job_id)
+            self._load_dst_block_ids.pop(job_id, None)
             req_id = self._load_jobs.pop(job_id, None)
             if req_id is not None:
                 finished_recving.add(req_id)
 
         return set(), finished_recving
+
+    def _handle_failed_transfer(self, job_id: int, is_load: bool) -> None:
+        """Decide what a failed transfer costs.
+
+        A failed store is dropped: this connector is a best-effort cache
+        (``requires_kv_delivery`` is False), so the chunk is simply not
+        cached and the tokens are recomputed or re-stored later.
+
+        A failed load is not droppable. Its destination GPU blocks hold
+        undefined data while the scheduler has already advanced the request's
+        ``num_computed_tokens`` past them, so resuming the request would read
+        garbage KV. The blocks are reported to the scheduler for recomputation.
+        """
+        if not is_load:
+            logger.warning(
+                "KV offload store job %d failed; the chunk was not cached. "
+                "Serving is unaffected: the tokens will be recomputed or "
+                "re-stored on a later step.",
+                job_id,
+            )
+            return
+
+        block_ids = self._load_dst_block_ids.get(job_id)
+        if not self._supports_load_failure_recovery:
+            # Continuing would let the request read undefined KV, and there is
+            # no safe narrower recovery: block-level recomputation needs the
+            # single-group assumption the scheduler still makes.
+            raise RuntimeError(
+                f"KV offload load job {job_id} failed and its destination GPU "
+                "blocks now hold undefined data. Block-level recovery is not "
+                "available for models with multiple KV cache groups (hybrid "
+                "attention/recurrent models), so the engine cannot continue "
+                "safely. Disable KV offloading to avoid this failure mode."
+            )
+
+        if block_ids:
+            self._invalid_block_ids.update(block_ids)
+        logger.warning(
+            "KV offload load job %d failed; reporting %d GPU block(s) for "
+            "recomputation.",
+            job_id,
+            len(block_ids) if block_ids else 0,
+        )
+
+    def get_block_ids_with_load_errors(self) -> set[int]:
+        """Drain the GPU block IDs whose external load failed."""
+        if not self._invalid_block_ids:
+            return set()
+        invalid_block_ids = self._invalid_block_ids
+        self._invalid_block_ids = set()
+        return invalid_block_ids
 
     def build_connector_worker_meta(self) -> OffloadingWorkerMetadata | None:
         """Return completed transfer job IDs since the last call."""
@@ -307,6 +385,8 @@ class OffloadingConnectorWorker:
     def shutdown(self) -> None:
         self._unsubmitted_store_jobs.clear()
         self._load_jobs.clear()
+        self._load_dst_block_ids.clear()
+        self._invalid_block_ids.clear()
         self._connector_worker_meta = OffloadingWorkerMetadata()
         if self.worker is not None:
             self.worker.shutdown()

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/worker.py
@@ -292,8 +292,9 @@ class OffloadingConnectorWorker:
                 self._handle_failed_transfer(job_id, is_load)
                 # A failed job must still be marked completed, or the
                 # scheduler's per-job pending count never reaches zero and
-                # the request is never resumed.
-                self._connector_worker_meta.mark_completed(job_id)
+                # the request is never resumed. success=False tells the
+                # scheduler not to publish a failed store's blocks as cache.
+                self._connector_worker_meta.mark_completed(job_id, success=False)
                 self._load_dst_block_ids.pop(job_id, None)
                 req_id = self._load_jobs.pop(job_id, None)
                 if req_id is not None:

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/worker.py
@@ -53,20 +53,13 @@ class OffloadingConnectorWorker:
             not self.spec.replicated_layout or self.spec.config.parallel.rank == 0
         )
 
-        # Block-level load-failure recovery reports GPU block IDs to the
-        # scheduler, whose _update_requests_with_invalid_blocks currently
-        # assumes a single KV cache group.
         self._supports_load_failure_recovery = len(kv_cache_config.kv_cache_groups) <= 1
 
         # job_id -> req_id for in-flight loads.
         self._load_jobs: dict[int, ReqId] = {}
 
-        # job_id -> GPU block IDs written by an in-flight load. Needed to tell
-        # the scheduler which blocks to recompute when a load fails.
         self._load_dst_block_ids: dict[int, list[int]] = {}
 
-        # GPU block IDs whose contents failed to load, drained by
-        # get_block_ids_with_load_errors().
         self._invalid_block_ids: set[int] = set()
         self._unsubmitted_store_jobs: list[
             tuple[int, GPULoadStoreSpec, LoadStoreSpec]
@@ -290,17 +283,10 @@ class OffloadingConnectorWorker:
             is_load = job_id in self._load_jobs
             if not transfer_result.success:
                 self._handle_failed_transfer(job_id, is_load)
-                # A failed job must still be marked completed, or the
-                # scheduler's per-job pending count never reaches zero and
-                # the request is never resumed. success=False tells the
-                # scheduler not to publish a failed store's blocks as cache.
                 self._connector_worker_meta.mark_completed(job_id, success=False)
                 self._load_dst_block_ids.pop(job_id, None)
                 req_id = self._load_jobs.pop(job_id, None)
                 if req_id is not None:
-                    # The contract in KVConnectorBase_V1 requires a request to
-                    # be reported here even when its load failed; the invalid
-                    # blocks are reported alongside it.
                     finished_recving.add(req_id)
                 continue
             if (
@@ -347,9 +333,6 @@ class OffloadingConnectorWorker:
 
         block_ids = self._load_dst_block_ids.get(job_id)
         if not self._supports_load_failure_recovery:
-            # Continuing would let the request read undefined KV, and there is
-            # no safe narrower recovery: block-level recomputation needs the
-            # single-group assumption the scheduler still makes.
             raise RuntimeError(
                 f"KV offload load job {job_id} failed and its destination GPU "
                 "blocks now hold undefined data. Block-level recovery is not "

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading_connector.py
@@ -124,6 +124,11 @@ class OffloadingConnector(KVConnectorBase_V1, SupportsHMA):
 
         return self.connector_worker.get_finished(finished_req_ids)
 
+    def get_block_ids_with_load_errors(self) -> set[int]:
+        if self.connector_worker is None:
+            return set()
+        return self.connector_worker.get_block_ids_with_load_errors()
+
     def build_connector_worker_meta(self) -> OffloadingWorkerMetadata | None:
         if self.connector_worker is not None:
             return self.connector_worker.build_connector_worker_meta()

--- a/vllm/v1/kv_offload/cpu/gpu_worker.py
+++ b/vllm/v1/kv_offload/cpu/gpu_worker.py
@@ -329,6 +329,10 @@ class SingleDirectionOffloadingHandler:
         self._transfer_events: dict[int, torch.Event] = {}
         # queue of transfers (job_id, stream, event)
         self._transfers: deque[Transfer] = deque()
+        # jobs that failed before they could be queued on the transfer stream.
+        # They still have to be reported by get_finished(), or the scheduler
+        # would wait for a completion that never arrives.
+        self._submit_failures: deque[int] = deque()
         # list of CUDA streams available for re-use
         self._stream_pool: list[torch.cuda.Stream] = []
         # list of CUDA events available for re-use
@@ -653,16 +657,35 @@ class SingleDirectionOffloadingHandler:
         # writing; we must keep STREAM ordering so source reads are gated
         # by the transfer stream's wait_stream(compute) barrier.
         is_src_access_order_any = not self.gpu_to_cpu
-        with current_platform.stream(stream):
-            start_event.record(stream)
-            if op_idx > 0:
-                self._swap_blocks_batch(
-                    src,
-                    dst,
-                    sizes,
-                    is_src_access_order_any=is_src_access_order_any,
-                )
-            end_event.record(stream)
+        try:
+            with current_platform.stream(stream):
+                start_event.record(stream)
+                if op_idx > 0:
+                    self._swap_blocks_batch(
+                        src,
+                        dst,
+                        sizes,
+                        is_src_access_order_any=is_src_access_order_any,
+                    )
+                end_event.record(stream)
+        except Exception:
+            # A transfer fault must not take the engine down. Offloading is a
+            # best-effort cache (OffloadingConnector.requires_kv_delivery is
+            # False), so report the job as failed and let the connector decide:
+            # a failed store is dropped, a failed load is escalated so the
+            # affected blocks are recomputed.
+            logger.exception(
+                "KV offload %s transfer failed for job %d",
+                "GPU->CPU" if self.gpu_to_cpu else "CPU->GPU",
+                job_id,
+            )
+            # Deliberately not returning the stream/events to their pools: the
+            # stream may carry a latched device error, and reusing it would
+            # spread this failure to unrelated transfers. The pinned descriptor
+            # buffers are plain host memory and are safe to reuse.
+            self._buffer_pool.append((batch_src, batch_dst, batch_sizes))
+            self._submit_failures.append(job_id)
+            return True
 
         self._transfer_events[job_id] = end_event
         self._transfers.append(
@@ -683,19 +706,46 @@ class SingleDirectionOffloadingHandler:
 
     def get_finished(self) -> list[TransferResult]:
         results: list[TransferResult] = []
-        while self._transfers and self._transfers[0].end_event.query():
-            transfer = self._transfers.popleft()
-            transfer_time = (
-                transfer.start_event.elapsed_time(transfer.end_event) * 1e-3
-            )  # elapsed_time is in milliseconds
-            result = TransferResult(
-                job_id=transfer.job_id,
-                success=True,
-                transfer_size=transfer.num_bytes,
-                transfer_time=transfer_time,
-            )
+        while self._submit_failures:
+            job_id = self._submit_failures.popleft()
+            self._transfer_events.pop(job_id, None)
+            results.append(TransferResult(job_id=job_id, success=False))
 
-            results.append(result)
+        while self._transfers:
+            transfer = self._transfers[0]
+            try:
+                if not transfer.end_event.query():
+                    break
+                transfer_time = (
+                    transfer.start_event.elapsed_time(transfer.end_event) * 1e-3
+                )  # elapsed_time is in milliseconds
+            except Exception:
+                # A device error latched by this transfer (or by earlier work
+                # on its stream) surfaces here rather than at submit time.
+                # Same contract as the submit-time failure above.
+                logger.exception(
+                    "KV offload %s transfer failed for job %d while polling "
+                    "for completion",
+                    "GPU->CPU" if self.gpu_to_cpu else "CPU->GPU",
+                    transfer.job_id,
+                )
+                self._transfers.popleft()
+                self._transfer_events.pop(transfer.job_id, None)
+                self._buffer_pool.append(
+                    (transfer.batch_src, transfer.batch_dst, transfer.batch_sizes)
+                )
+                results.append(TransferResult(job_id=transfer.job_id, success=False))
+                continue
+
+            self._transfers.popleft()
+            results.append(
+                TransferResult(
+                    job_id=transfer.job_id,
+                    success=True,
+                    transfer_size=transfer.num_bytes,
+                    transfer_time=transfer_time,
+                )
+            )
             self._stream_pool.append(transfer.stream)
             self._event_pool.append(transfer.end_event)
             self._event_pool.append(transfer.start_event)
@@ -709,7 +759,17 @@ class SingleDirectionOffloadingHandler:
         for job_id in job_ids:
             event = self._transfer_events.get(job_id)
             if event is not None:
-                event.synchronize()
+                try:
+                    event.synchronize()
+                except Exception:
+                    # Leave the transfer queued: the next get_finished() poll
+                    # hits the same error and reports the job as failed, which
+                    # keeps failure handling in one place.
+                    logger.exception(
+                        "KV offload transfer for job %d failed while waiting "
+                        "for it to complete",
+                        job_id,
+                    )
 
     def shutdown(self) -> None:
         """Drain this direction and release its transfer-side resources."""
@@ -730,6 +790,7 @@ class SingleDirectionOffloadingHandler:
             self._transfers.popleft()
 
         self._transfer_events.clear()
+        self._submit_failures.clear()
         self._stream_pool.clear()
         self._event_pool.clear()
         self._buffer_pool.clear()

--- a/vllm/v1/kv_offload/cpu/gpu_worker.py
+++ b/vllm/v1/kv_offload/cpu/gpu_worker.py
@@ -668,7 +668,12 @@ class SingleDirectionOffloadingHandler:
                         is_src_access_order_any=is_src_access_order_any,
                     )
                 end_event.record(stream)
-        except Exception:
+        except RuntimeError:
+            # Device faults surface as RuntimeError (torch.AcceleratorError and
+            # the STD_TORCH_CHECK in swap_blocks_batch both derive from it).
+            # Deliberately not broader: a missing op or a bad argument is a
+            # programming error and must keep propagating, not be silently
+            # downgraded to a degraded cache.
             # A transfer fault must not take the engine down. Offloading is a
             # best-effort cache (OffloadingConnector.requires_kv_delivery is
             # False), so report the job as failed and let the connector decide:
@@ -719,7 +724,7 @@ class SingleDirectionOffloadingHandler:
                 transfer_time = (
                     transfer.start_event.elapsed_time(transfer.end_event) * 1e-3
                 )  # elapsed_time is in milliseconds
-            except Exception:
+            except RuntimeError:
                 # A device error latched by this transfer (or by earlier work
                 # on its stream) surfaces here rather than at submit time.
                 # Same contract as the submit-time failure above.
@@ -761,7 +766,7 @@ class SingleDirectionOffloadingHandler:
             if event is not None:
                 try:
                     event.synchronize()
-                except Exception:
+                except RuntimeError:
                     # Leave the transfer queued: the next get_finished() poll
                     # hits the same error and reports the job as failed, which
                     # keeps failure handling in one place.

--- a/vllm/v1/kv_offload/cpu/gpu_worker.py
+++ b/vllm/v1/kv_offload/cpu/gpu_worker.py
@@ -71,8 +71,6 @@ class Transfer:
     batch_src: torch.Tensor
     batch_dst: torch.Tensor
     batch_sizes: torch.Tensor
-    # Submitted but faulted: queued only so its stream can be drained before
-    # the job is reported. Carries no timing and never returns to the pools.
     failed: bool = False
 
 
@@ -668,31 +666,11 @@ class SingleDirectionOffloadingHandler:
                     )
                 end_event.record(stream)
         except RuntimeError:
-            # Device faults surface as RuntimeError (torch.AcceleratorError and
-            # the STD_TORCH_CHECK in swap_blocks_batch both derive from it).
-            # Deliberately not broader: a missing op or a bad argument is a
-            # programming error and must keep propagating, not be silently
-            # downgraded to a degraded cache.
             logger.exception(
                 "KV offload %s transfer failed for job %d",
                 "GPU->CPU" if self.gpu_to_cpu else "CPU->GPU",
                 job_id,
             )
-            # A transfer fault must not take the engine down: offloading is a
-            # best-effort cache (OffloadingConnector.requires_kv_delivery is
-            # False), so the job is reported as failed and the connector
-            # decides what to do. It cannot be reported yet, though. A batched
-            # copy can fail partway through - swap_blocks_batch checks each
-            # chunk of the descriptor list separately (ROCm caps a call at 8192
-            # descriptors) and hipMemcpyBatchAsync is itself a loop of async
-            # copies that breaks on the first failure - so copies submitted
-            # before the fault may still be reading the source blocks, writing
-            # the destination blocks and DMA-reading the pinned descriptors.
-            # Record the end event behind them and report the failure from
-            # get_finished() once the stream drains. Keeping the transfer
-            # queued also preserves the wait() fence and the ordering chain the
-            # next submission builds on. A failure to record leaves the
-            # in-flight copies unbounded and must propagate.
             end_event.record(stream)
             self._transfer_events[job_id] = end_event
             self._transfers.append(
@@ -741,9 +719,6 @@ class SingleDirectionOffloadingHandler:
                     else transfer.start_event.elapsed_time(transfer.end_event) * 1e-3
                 )
             except RuntimeError:
-                # A device error latched by this transfer (or by earlier work
-                # on its stream) surfaces here rather than at submit time.
-                # Same contract as the submit-time failure above.
                 logger.exception(
                     "KV offload %s transfer failed for job %d while polling "
                     "for completion",
@@ -758,10 +733,6 @@ class SingleDirectionOffloadingHandler:
             self._transfers.popleft()
             self._transfer_events.pop(transfer.job_id, None)
             if transfer.failed:
-                # Drained: the blocks are quiescent and the scheduler may reuse
-                # them. The stream, events and descriptor buffers are dropped
-                # rather than pooled, since the stream may carry a latched
-                # device error that would spread to an unrelated transfer.
                 results.append(TransferResult(job_id=transfer.job_id, success=False))
                 continue
 
@@ -788,9 +759,6 @@ class SingleDirectionOffloadingHandler:
                 try:
                     event.synchronize()
                 except RuntimeError:
-                    # Leave the transfer queued: the next get_finished() poll
-                    # hits the same error and reports the job as failed, which
-                    # keeps failure handling in one place.
                     logger.exception(
                         "KV offload transfer for job %d failed while waiting "
                         "for it to complete",

--- a/vllm/v1/kv_offload/cpu/gpu_worker.py
+++ b/vllm/v1/kv_offload/cpu/gpu_worker.py
@@ -71,6 +71,9 @@ class Transfer:
     batch_src: torch.Tensor
     batch_dst: torch.Tensor
     batch_sizes: torch.Tensor
+    # Submitted but faulted: queued only so its stream can be drained before
+    # the job is reported. Carries no timing and never returns to the pools.
+    failed: bool = False
 
 
 def compute_sub_block_ptrs(
@@ -329,10 +332,6 @@ class SingleDirectionOffloadingHandler:
         self._transfer_events: dict[int, torch.Event] = {}
         # queue of transfers (job_id, stream, event)
         self._transfers: deque[Transfer] = deque()
-        # jobs that failed before they could be queued on the transfer stream.
-        # They still have to be reported by get_finished(), or the scheduler
-        # would wait for a completion that never arrives.
-        self._submit_failures: deque[int] = deque()
         # list of CUDA streams available for re-use
         self._stream_pool: list[torch.cuda.Stream] = []
         # list of CUDA events available for re-use
@@ -674,22 +673,41 @@ class SingleDirectionOffloadingHandler:
             # Deliberately not broader: a missing op or a bad argument is a
             # programming error and must keep propagating, not be silently
             # downgraded to a degraded cache.
-            # A transfer fault must not take the engine down. Offloading is a
-            # best-effort cache (OffloadingConnector.requires_kv_delivery is
-            # False), so report the job as failed and let the connector decide:
-            # a failed store is dropped, a failed load is escalated so the
-            # affected blocks are recomputed.
             logger.exception(
                 "KV offload %s transfer failed for job %d",
                 "GPU->CPU" if self.gpu_to_cpu else "CPU->GPU",
                 job_id,
             )
-            # Deliberately not returning the stream/events to their pools: the
-            # stream may carry a latched device error, and reusing it would
-            # spread this failure to unrelated transfers. The pinned descriptor
-            # buffers are plain host memory and are safe to reuse.
-            self._buffer_pool.append((batch_src, batch_dst, batch_sizes))
-            self._submit_failures.append(job_id)
+            # A transfer fault must not take the engine down: offloading is a
+            # best-effort cache (OffloadingConnector.requires_kv_delivery is
+            # False), so the job is reported as failed and the connector
+            # decides what to do. It cannot be reported yet, though. A batched
+            # copy can fail partway through - swap_blocks_batch checks each
+            # chunk of the descriptor list separately (ROCm caps a call at 8192
+            # descriptors) and hipMemcpyBatchAsync is itself a loop of async
+            # copies that breaks on the first failure - so copies submitted
+            # before the fault may still be reading the source blocks, writing
+            # the destination blocks and DMA-reading the pinned descriptors.
+            # Record the end event behind them and report the failure from
+            # get_finished() once the stream drains. Keeping the transfer
+            # queued also preserves the wait() fence and the ordering chain the
+            # next submission builds on. A failure to record leaves the
+            # in-flight copies unbounded and must propagate.
+            end_event.record(stream)
+            self._transfer_events[job_id] = end_event
+            self._transfers.append(
+                Transfer(
+                    job_id=job_id,
+                    stream=stream,
+                    start_event=start_event,
+                    end_event=end_event,
+                    num_bytes=0,
+                    batch_src=batch_src,
+                    batch_dst=batch_dst,
+                    batch_sizes=batch_sizes,
+                    failed=True,
+                )
+            )
             return True
 
         self._transfer_events[job_id] = end_event
@@ -711,19 +729,17 @@ class SingleDirectionOffloadingHandler:
 
     def get_finished(self) -> list[TransferResult]:
         results: list[TransferResult] = []
-        while self._submit_failures:
-            job_id = self._submit_failures.popleft()
-            self._transfer_events.pop(job_id, None)
-            results.append(TransferResult(job_id=job_id, success=False))
-
         while self._transfers:
             transfer = self._transfers[0]
             try:
                 if not transfer.end_event.query():
                     break
                 transfer_time = (
-                    transfer.start_event.elapsed_time(transfer.end_event) * 1e-3
-                )  # elapsed_time is in milliseconds
+                    None
+                    if transfer.failed
+                    # elapsed_time is in milliseconds
+                    else transfer.start_event.elapsed_time(transfer.end_event) * 1e-3
+                )
             except RuntimeError:
                 # A device error latched by this transfer (or by earlier work
                 # on its stream) surfaces here rather than at submit time.
@@ -736,13 +752,19 @@ class SingleDirectionOffloadingHandler:
                 )
                 self._transfers.popleft()
                 self._transfer_events.pop(transfer.job_id, None)
-                self._buffer_pool.append(
-                    (transfer.batch_src, transfer.batch_dst, transfer.batch_sizes)
-                )
                 results.append(TransferResult(job_id=transfer.job_id, success=False))
                 continue
 
             self._transfers.popleft()
+            self._transfer_events.pop(transfer.job_id, None)
+            if transfer.failed:
+                # Drained: the blocks are quiescent and the scheduler may reuse
+                # them. The stream, events and descriptor buffers are dropped
+                # rather than pooled, since the stream may carry a latched
+                # device error that would spread to an unrelated transfer.
+                results.append(TransferResult(job_id=transfer.job_id, success=False))
+                continue
+
             results.append(
                 TransferResult(
                     job_id=transfer.job_id,
@@ -757,7 +779,6 @@ class SingleDirectionOffloadingHandler:
             self._buffer_pool.append(
                 (transfer.batch_src, transfer.batch_dst, transfer.batch_sizes)
             )
-            del self._transfer_events[transfer.job_id]
         return results
 
     def wait(self, job_ids: set[int]):
@@ -795,7 +816,6 @@ class SingleDirectionOffloadingHandler:
             self._transfers.popleft()
 
         self._transfer_events.clear()
-        self._submit_failures.clear()
         self._stream_pool.clear()
         self._event_pool.clear()
         self._buffer_pool.clear()


### PR DESCRIPTION
## Purpose

`swap_blocks_batch` raises synchronously inside `transfer_async` — `STD_TORCH_CHECK(result == hipSuccess, ...)` at `csrc/libtorch_stable/cache_kernels.cu:168` on the ROCm path, and the equivalent check at `:151` on the CUDA path. A device error latched by earlier work on the transfer stream surfaces the same way at `end_event.query()`.

Every call site is unguarded, so that exception reaches `execute_model` and kills the worker:

- V1 (`kv_connector_model_runner_mixin.py`) calls `start_load_kv` at `:95`, one line **above** the `try:` at `:96`.
- V2 (`v1/worker/gpu/kv_connector.py`) has no `try` at all in `pre_forward` (`:61`) or `post_forward` (`:77`).
- `gpu_model_runner.handle_preemptions`, which submits stores and waits on them, is also unguarded.

Meanwhile the failure channel that exists is dead code. `offloading/worker.py:359` carries the comment *"we currently do not support job failures"* above `assert transfer_result.success`, and the only producer of that result hardcodes `success=True` (`v1/kv_offload/cpu/gpu_worker.py:691`). `OffloadingConnector` also does not override `get_block_ids_with_load_errors`, so `base.py`'s empty-set default applies and the scheduler's `_handle_invalid_blocks` recovery is unreachable for this connector — even though the plumbing is already wired at `v1/worker/gpu/kv_connector.py:89`.

This is the wrong failure mode for this connector in particular. `offloading_connector.py:56` returns `requires_kv_delivery = False` with the comment *"a dropped save is just a future cache miss, so opt out of the producer-role default"*. It declares best-effort delivery and then aborts the engine when a transfer fails.

## What this changes

Faults are reported, not raised:

- **`transfer_async`** catches the fault, queues the job as a submit failure, and **still returns `True`**. Jobs must always complete: the scheduler's per-job pending count waits for `world_size` acks, so a job that silently disappears strands the request forever. The stream and events are deliberately *not* returned to their pools — a latched device error would otherwise leak into an unrelated transfer. The pinned descriptor buffers are plain host memory and are still recycled.
- **`get_finished`** drains submit failures and guards `end_event.query()` / `elapsed_time`, emitting `TransferResult(success=False)`.
- **`wait()`** no longer propagates a synchronize failure; the next poll reports it, keeping failure handling in one place.
- **A failed store is dropped** with a warning. The chunk is simply not cached — exactly what `requires_kv_delivery = False` already promises.
- **A failed load is escalated.** Its destination GPU blocks hold undefined data while the scheduler has already advanced `num_computed_tokens` past them, so resuming the request would read garbage KV. The blocks are reported through a newly implemented `get_block_ids_with_load_errors()` and the scheduler recomputes them. The request is still reported via `get_finished()`, as the base-class contract requires.

**Scope of the catch (second commit).** The handlers catch `RuntimeError`, not `Exception`. `torch.AcceleratorError` and `torch.cuda.CudaError` both derive from `RuntimeError`, as does the `STD_TORCH_CHECK` in `swap_blocks_batch`, so every genuine device fault is still caught — while an `AttributeError`, `TypeError` or `ValueError` keeps propagating instead of being silently downgraded to a degraded cache.

## Test Plan

1. run existing kv_offload in CI

## Test Result

8×MI355X (gfx950), ROCm 7.2, torch 2.12.0, with the compiled extensions on `sys.path`:
```
origin/main (12f64b39d2)   783 passed, 3 skipped, 0 failed  
this branch                790 passed, 3 skipped, 0 failed  
```


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

