### PR TITLE
[Rust Frontend] Add ERNIE 4.5 tool and reasoning parsers

### DIFF
--- a/rust/src/chat/src/lib.rs
+++ b/rust/src/chat/src/lib.rs
@@ -363,7 +363,7 @@ mod tests {
         )
         .unwrap_err();
 
-        expect_test::expect!["tool parser `definitely_missing_tool_parser` is not registered (choose from: deepseek_v3, deepseek_v31, deepseek_v32, deepseek_v4, gemma4, glm45, glm47, granite4, hermes, hy_v3, hy_v4, inkling, internlm, kimi_k2, kimi_k3, llama3_json, llama4_json, minimax_m2, minimax_m3, mistral, phi4_mini_json, qwen3_coder, qwen3_xml, seed_oss)"].assert_eq(&error.to_report_string());
+        expect_test::expect!["tool parser `definitely_missing_tool_parser` is not registered (choose from: deepseek_v3, deepseek_v31, deepseek_v32, deepseek_v4, ernie45, gemma4, glm45, glm47, granite4, hermes, hy_v3, hy_v4, inkling, internlm, kimi_k2, kimi_k3, llama3_json, llama4_json, minimax_m2, minimax_m3, mistral, phi4_mini_json, qwen3_coder, qwen3_xml, seed_oss)"].assert_eq(&error.to_report_string());
     }
 
     #[test]
@@ -374,6 +374,6 @@ mod tests {
         )
         .unwrap_err();
 
-        expect_test::expect!["reasoning parser `definitely_missing_reasoning_parser` is not registered (choose from: cohere_cmd, deepseek_r1, deepseek_v3, deepseek_v4, gemma4, glm45, glm47, hy_v3, hy_v4, inkling, kimi, kimi_k2, kimi_k3, minimax_m2, minimax_m3, nemotron_v3, qwen3, seed_oss, step3, step3p5)"].assert_eq(&error.to_report_string());
+        expect_test::expect!["reasoning parser `definitely_missing_reasoning_parser` is not registered (choose from: cohere_cmd, deepseek_r1, deepseek_v3, deepseek_v4, ernie45, gemma4, glm45, glm47, hy_v3, hy_v4, inkling, kimi, kimi_k2, kimi_k3, minimax_m2, minimax_m3, nemotron_v3, qwen3, seed_oss, step3, step3p5)"].assert_eq(&error.to_report_string());
     }
 }

--- a/rust/src/chat/src/parser/reasoning/mod.rs
+++ b/rust/src/chat/src/parser/reasoning/mod.rs
@@ -7,8 +7,8 @@ use std::sync::{Arc, LazyLock};
 
 pub use vllm_parser::reasoning::{
     CohereCmdReasoningParser, DeepSeekR1ReasoningParser, DeepSeekV3ReasoningParser,
-    DeepSeekV4ReasoningParser, Glm45ReasoningParser, Glm47ReasoningParser, KimiK2ReasoningParser,
-    KimiReasoningParser, MiniMaxM2ReasoningParser, MiniMaxM3ReasoningParser,
+    DeepSeekV4ReasoningParser, Ernie45ReasoningParser, Glm45ReasoningParser, Glm47ReasoningParser,
+    KimiK2ReasoningParser, KimiReasoningParser, MiniMaxM2ReasoningParser, MiniMaxM3ReasoningParser,
     NemotronV3ReasoningParser, Qwen3ReasoningParser, ReasoningDelta, ReasoningError,
     ReasoningParser, SeedOssReasoningParser, Step3ReasoningParser, Step3p5ReasoningParser,
 };
@@ -22,6 +22,7 @@ pub mod names {
     pub const DEEPSEEK_R1: &str = "deepseek_r1";
     pub const DEEPSEEK_V3: &str = "deepseek_v3";
     pub const DEEPSEEK_V4: &str = "deepseek_v4";
+    pub const ERNIE45: &str = "ernie45";
     pub const GLM45: &str = "glm45";
     pub const GLM47: &str = "glm47";
     pub const KIMI: &str = "kimi";
@@ -62,6 +63,7 @@ impl ReasoningParserFactory {
             .register_parser::<DeepSeekR1ReasoningParser>(names::DEEPSEEK_R1)
             .register_parser::<DeepSeekV3ReasoningParser>(names::DEEPSEEK_V3)
             .register_parser::<DeepSeekV4ReasoningParser>(names::DEEPSEEK_V4)
+            .register_parser::<Ernie45ReasoningParser>(names::ERNIE45)
             .register_parser::<Glm45ReasoningParser>(names::GLM45)
             .register_parser::<Glm47ReasoningParser>(names::GLM47)
             .register_parser::<KimiReasoningParser>(names::KIMI)
@@ -79,6 +81,9 @@ impl ReasoningParserFactory {
             .register_pattern("deepseek-v4", names::DEEPSEEK_V4)
             .register_pattern("deepseek_v4", names::DEEPSEEK_V4)
             .register_pattern("deepseek-v3", names::DEEPSEEK_V3)
+            // Only the ERNIE-4.5 thinking checkpoint has `<think>` tokens and a
+            // reasoning template; the `*-PT` text checkpoints have neither.
+            .register_pattern("ernie-4.5-21b-a3b-thinking", names::ERNIE45)
             .register_pattern("qwq", names::DEEPSEEK_R1)
             .register_pattern("qwen3", names::QWEN3)
             .register_pattern("glm-5", names::GLM47)

--- a/rust/src/chat/src/parser/reasoning/tests.rs
+++ b/rust/src/chat/src/parser/reasoning/tests.rs
@@ -88,6 +88,26 @@ fn factory_routes_seed_oss_models() {
 }
 
 #[test]
+fn factory_routes_ernie45_thinking_models_only() {
+    let factory = ReasoningParserFactory::new();
+    assert!(factory.contains(names::ERNIE45));
+    assert_eq!(
+        factory.resolve_name_for_model("baidu/ERNIE-4.5-21B-A3B-Thinking"),
+        Some(names::ERNIE45)
+    );
+    // The `*-PT` ERNIE text checkpoints have neither `<think>` tokens nor a
+    // reasoning template, so they must not resolve to the ERNIE parser.
+    assert_eq!(
+        factory.resolve_name_for_model("baidu/ERNIE-4.5-21B-A3B-PT"),
+        None
+    );
+    assert_eq!(
+        factory.resolve_name_for_model("baidu/ERNIE-4.5-0.3B-PT"),
+        None
+    );
+}
+
+#[test]
 fn factory_resolves_minimax_m3_before_generic_minimax() {
     let factory = ReasoningParserFactory::new();
     assert_eq!(

--- a/rust/src/chat/src/parser/tool/mod.rs
+++ b/rust/src/chat/src/parser/tool/mod.rs
@@ -7,10 +7,10 @@ use std::sync::{Arc, LazyLock};
 
 pub use vllm_parser::tool::{
     DeepSeekV3ToolParser, DeepSeekV4ToolParser, DeepSeekV31ToolParser, DeepSeekV32ToolParser,
-    Glm45MoeToolParser, Glm47MoeToolParser, Granite4ToolParser, HermesToolParser,
-    Internlm2ToolParser, KimiK2ToolParser, Llama3JsonToolParser, MinimaxM2ToolParser,
-    MinimaxM3ToolParser, MistralToolParser, Phi4MiniJsonToolParser, Qwen3CoderToolParser,
-    Qwen3XmlToolParser, SeedOssToolParser, ToolParser, ToolParserError,
+    Ernie45ToolParser, Glm45MoeToolParser, Glm47MoeToolParser, Granite4ToolParser,
+    HermesToolParser, Internlm2ToolParser, KimiK2ToolParser, Llama3JsonToolParser,
+    MinimaxM2ToolParser, MinimaxM3ToolParser, MistralToolParser, Phi4MiniJsonToolParser,
+    Qwen3CoderToolParser, Qwen3XmlToolParser, SeedOssToolParser, ToolParser, ToolParserError,
 };
 
 use crate::parser::ParserFactory;
@@ -22,6 +22,7 @@ pub mod names {
     pub const DEEPSEEK_V31: &str = "deepseek_v31";
     pub const DEEPSEEK_V32: &str = "deepseek_v32";
     pub const DEEPSEEK_V4: &str = "deepseek_v4";
+    pub const ERNIE45: &str = "ernie45";
     pub const GLM45: &str = "glm45";
     pub const GLM47: &str = "glm47";
     pub const GRANITE4: &str = "granite4";
@@ -66,6 +67,7 @@ impl ToolParserFactory {
             .register_parser::<DeepSeekV31ToolParser>(names::DEEPSEEK_V31)
             .register_parser::<DeepSeekV32ToolParser>(names::DEEPSEEK_V32)
             .register_parser::<DeepSeekV4ToolParser>(names::DEEPSEEK_V4)
+            .register_parser::<Ernie45ToolParser>(names::ERNIE45)
             .register_parser::<Glm45MoeToolParser>(names::GLM45)
             .register_parser::<Glm47MoeToolParser>(names::GLM47)
             .register_parser::<Granite4ToolParser>(names::GRANITE4)
@@ -106,6 +108,9 @@ impl ToolParserFactory {
             .register_pattern("deepseek-v3.2", names::DEEPSEEK_V32)
             .register_pattern("deepseek-v3.1", names::DEEPSEEK_V31)
             .register_pattern("deepseek-v3", names::DEEPSEEK_V3)
+            // Only the ERNIE-4.5 thinking checkpoint renders `<tool_call>` blocks;
+            // the `*-PT` text checkpoints use a plain `User:`/`Assistant:` template.
+            .register_pattern("ernie-4.5-21b-a3b-thinking", names::ERNIE45)
             .register_pattern("glm-5", names::GLM47)
             .register_pattern("glm-4.7", names::GLM47)
             .register_pattern("glm-4.6", names::GLM45)

--- a/rust/src/chat/src/parser/tool/tests.rs
+++ b/rust/src/chat/src/parser/tool/tests.rs
@@ -195,6 +195,15 @@ fn factory_new_resolves_default_patterns() {
         factory.resolve_name_for_model("ByteDance-Seed/Seed-OSS-36B-Instruct"),
         Some(names::SEED_OSS)
     );
+    assert_eq!(
+        factory.resolve_name_for_model("baidu/ERNIE-4.5-21B-A3B-Thinking"),
+        Some(names::ERNIE45)
+    );
+    // The `*-PT` ERNIE text checkpoints have no tool-call template.
+    assert_eq!(
+        factory.resolve_name_for_model("baidu/ERNIE-4.5-21B-A3B-PT"),
+        None
+    );
 
     // InternLM2 positive: both dashed and underscored versioned names route.
     assert_eq!(

--- a/rust/src/chat/src/renderer/hf/mod.rs
+++ b/rust/src/chat/src/renderer/hf/mod.rs
@@ -238,9 +238,11 @@ struct TemplateMessage {
     // as top-level request tools.
     tools: Option<Vec<TemplateTool>>,
     // Reasoning-capable HF templates are inconsistent on the exact field name,
-    // so expose both variants for compatibility.
+    // so expose all known variants for compatibility (`thoughts` is read by the
+    // ERNIE 4.5 thinking template).
     reasoning: Option<String>,
     reasoning_content: Option<String>,
+    thoughts: Option<String>,
     // Function-call-capable templates commonly expect assistant tool calls
     // under this OpenAI-compatible field name.
     tool_calls: Option<Vec<TemplateToolCall>>,
@@ -318,6 +320,7 @@ fn to_template_message(
             tools: None,
             reasoning: None,
             reasoning_content: None,
+            thoughts: None,
             tool_calls: None,
             tool_call_id: None,
         },
@@ -327,6 +330,7 @@ fn to_template_message(
             tools: tools.as_deref().map(to_template_tools),
             reasoning: None,
             reasoning_content: None,
+            thoughts: None,
             tool_calls: None,
             tool_call_id: None,
         },
@@ -336,6 +340,7 @@ fn to_template_message(
             tools: None,
             reasoning: None,
             reasoning_content: None,
+            thoughts: None,
             tool_calls: None,
             tool_call_id: None,
         },
@@ -350,7 +355,8 @@ fn to_template_message(
                 content,
                 tools: None,
                 reasoning: reasoning.clone(),
-                reasoning_content: reasoning,
+                reasoning_content: reasoning.clone(),
+                thoughts: reasoning,
                 tool_calls,
                 tool_call_id: None,
             }
@@ -364,6 +370,7 @@ fn to_template_message(
             tools: None,
             reasoning: None,
             reasoning_content: None,
+            thoughts: None,
             tool_calls: None,
             tool_call_id: Some(tool_call_id.clone()),
         },

--- a/rust/src/chat/tests/roundtrip.rs
+++ b/rust/src/chat/tests/roundtrip.rs
@@ -319,6 +319,22 @@ impl RoundtripCase {
         }
     }
 
+    /// ERNIE 4.5 `<tool_call>` JSON format with `<think>` reasoning tags and a
+    /// `<response>` wrapper around the final answer.
+    fn ernie45() -> Self {
+        Self {
+            model_id: "baidu/ERNIE-4.5-21B-A3B-Thinking",
+            // The template closes both the answer and the last tool call with a
+            // newline, then unconditionally appends the next generation prompt.
+            assistant_stop_suffix: "\n<|im_end|>\n\n<|im_start|>assistant\n<think>\n",
+            tool_call_parser: ParserSelection::Auto,
+            reasoning_parser: ParserSelection::Auto,
+            thinking_behavior: ThinkingBehavior::Always { value: true },
+            json_fmt: spaced_json_fmt(),
+            sort_json_keys: false,
+        }
+    }
+
     /// Nemotron V3 with `<think>` / `</think>` reasoning tags.
     fn nemotron_v3() -> Self {
         Self {
@@ -391,6 +407,7 @@ roundtrip_tests! {
     glm52 => [reasoning_and_content, tool_call_mix],
     seed_oss => [reasoning_and_content, tool_call_mix],
     step3p5 => [reasoning_and_content],
+    ernie45 => [reasoning_and_content, tool_call_mix],
     nemotron_v3 => [reasoning_and_content],
     gemma4 => [tool_call_mix], // Gemma4 strips reasoning in history if there's no tool call
     kimi_k25 => [tool_call_mix], // Kimi K2.5 strips reasoning in history

--- a/rust/src/parser/src/reasoning/ernie45.rs
+++ b/rust/src/parser/src/reasoning/ernie45.rs
@@ -1,0 +1,417 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+use vllm_tokenizer::{DecodedText, DynTokenizer};
+
+use super::{
+    DelimitedReasoningParser, DelimitedReasoningParserBuilder, ReasoningDelta, ReasoningParser,
+    Result,
+};
+
+/// Marker opening the final answer in ERNIE 4.5 thinking-model output.
+const RESPONSE_START: &str = "<response>";
+/// Marker closing the final answer in ERNIE 4.5 thinking-model output.
+const RESPONSE_END: &str = "</response>";
+
+/// Reasoning parser for the ERNIE 4.5 thinking models.
+///
+/// ERNIE 4.5 uses standard `<think>`/`</think>` delimiters with a `\n` on each
+/// side of both markers, and the `ERNIE-4.5-21B-A3B-Thinking` template wraps the
+/// final answer in `<response>`/`</response>` before any `<tool_call>` blocks:
+///
+/// ```text
+/// <think>
+/// {reasoning}
+/// </think>
+/// <response>
+/// {content}
+/// </response>
+///
+/// <tool_call>
+/// {"name": ..., "arguments": {...}}
+/// </tool_call>
+/// ```
+///
+/// The `<think>` framing is handled by the shared delimited state machine. This
+/// parser adds the `<response>` wrapper on top: the markers and the newlines
+/// framing them are dropped from content, while anything after `</response>` is
+/// passed through, so tool calls that follow the answer still reach the tool
+/// parser.
+pub struct Ernie45ReasoningParser {
+    inner: DelimitedReasoningParser,
+    /// Strips the `<response>`/`</response>` framing from content pieces.
+    response_frame: ResponseFrameFilter,
+}
+
+impl Ernie45ReasoningParser {
+    /// Create an ERNIE 4.5 parser backed by the shared delimited state machine.
+    pub fn new(tokenizer: DynTokenizer) -> Result<Self> {
+        Ok(Self {
+            inner: DelimitedReasoningParserBuilder::new(tokenizer, "<think>", "</think>")
+                .with_after_start("\n")
+                .with_before_end("\n")
+                .with_after_end("\n")
+                .build()?,
+            response_frame: ResponseFrameFilter::default(),
+        })
+    }
+
+    /// Filter the `<response>` framing out of one delta's content.
+    fn filter_content(
+        &mut self,
+        delta: ReasoningDelta,
+        was_in_reasoning: bool,
+        now_in_reasoning: bool,
+    ) -> ReasoningDelta {
+        // A `<think>...</think>` round-trip in one push still counts as a
+        // transition: the inner emits reasoning while ending in content mode.
+        let transitioned = !now_in_reasoning && (was_in_reasoning || delta.reasoning.is_some());
+
+        // Templates may emit more newlines between `</think>` and `<response>`
+        // than the single one the state machine already consumed.
+        if transitioned {
+            self.response_frame.expect_framing_newlines();
+        }
+
+        let content = delta.content.map(|content| self.response_frame.push(content));
+
+        ReasoningDelta {
+            reasoning: delta.reasoning,
+            content: content.filter(|piece| !piece.is_empty()),
+        }
+    }
+}
+
+impl ReasoningParser for Ernie45ReasoningParser {
+    fn create(tokenizer: DynTokenizer) -> Result<Box<dyn ReasoningParser>>
+    where
+        Self: Sized + 'static,
+    {
+        Ok(Box::new(Self::new(tokenizer)?))
+    }
+
+    fn initialize(&mut self, prompt_token_ids: &[u32]) -> Result<()> {
+        self.inner.initialize(prompt_token_ids)
+    }
+
+    fn push(&mut self, delta: DecodedText) -> Result<ReasoningDelta> {
+        let was = self.inner.in_reasoning();
+        let inner_delta = self.inner.push(delta);
+        let now = self.inner.in_reasoning();
+        Ok(self.filter_content(inner_delta, was, now))
+    }
+
+    fn finish(&mut self) -> Result<ReasoningDelta> {
+        let was = self.inner.in_reasoning();
+        let inner_delta = self.inner.finish();
+        let now = self.inner.in_reasoning();
+        let mut delta = self.filter_content(inner_delta, was, now);
+
+        // Held-back text that never completed a marker is literal content.
+        delta.push_content(self.response_frame.finish());
+        Ok(delta)
+    }
+}
+
+/// Incremental filter that removes the `<response>`/`</response>` answer framing
+/// from ERNIE 4.5 content.
+///
+/// Markers and their framing newlines may be split across pushes, so the filter
+/// holds back any text that could still complete a marker, plus a single
+/// trailing `\n` that could turn out to be the framing newline right before
+/// `</response>`.
+#[derive(Default)]
+struct ResponseFrameFilter {
+    /// Content held back until it can no longer complete a marker or the
+    /// framing newline before `</response>`.
+    pending: DecodedText,
+    /// Whether newlines at the start of the next content are framing (right
+    /// after `</think>`, `<response>`, or `</response>`) and should be dropped.
+    strip_leading_newlines: bool,
+}
+
+impl ResponseFrameFilter {
+    /// Treat newlines at the start of the upcoming content as framing.
+    fn expect_framing_newlines(&mut self) {
+        self.strip_leading_newlines = true;
+    }
+
+    /// Feed one content piece and return the content that is safe to emit.
+    fn push(&mut self, content: DecodedText) -> DecodedText {
+        self.pending.append(content);
+        let mut emitted = DecodedText::default();
+
+        loop {
+            if self.strip_leading_newlines {
+                let framing_len =
+                    self.pending.text.len() - self.pending.text.trim_start_matches('\n').len();
+                let _ = self.pending.drain_prefix(framing_len);
+                if self.pending.text.is_empty() {
+                    break;
+                }
+            }
+
+            match earliest_marker(&self.pending.text) {
+                Some((marker_start, marker)) => {
+                    let mut before_len = marker_start;
+                    if marker == RESPONSE_END && self.pending.text[..before_len].ends_with('\n') {
+                        // The single newline right before `</response>` is framing.
+                        before_len -= 1;
+                    }
+                    self.emit(before_len, &mut emitted);
+                    let _ = self.pending.drain_prefix(marker_start - before_len + marker.len());
+                    self.strip_leading_newlines = true;
+                }
+                None => {
+                    // Keep back a possible partial marker, plus the `\n` right
+                    // before it (or at the very end) that may precede
+                    // `</response>`.
+                    let mut stable_len =
+                        self.pending.text.len() - partial_marker_suffix_len(&self.pending.text);
+                    if self.pending.text[..stable_len].ends_with('\n') {
+                        stable_len -= 1;
+                    }
+                    self.emit(stable_len, &mut emitted);
+                    break;
+                }
+            }
+        }
+
+        emitted
+    }
+
+    /// Flush held-back content at end of stream.
+    fn finish(&mut self) -> DecodedText {
+        if self.strip_leading_newlines {
+            let framing_len =
+                self.pending.text.len() - self.pending.text.trim_start_matches('\n').len();
+            let _ = self.pending.drain_prefix(framing_len);
+        }
+        self.strip_leading_newlines = false;
+        self.pending.take()
+    }
+
+    /// Move the first `len` bytes of pending content into `emitted`, ending
+    /// framing-newline stripping once any content has been emitted.
+    fn emit(&mut self, len: usize, emitted: &mut DecodedText) {
+        if len == 0 {
+            return;
+        }
+        self.strip_leading_newlines = false;
+        emitted.append(self.pending.drain_prefix(len));
+    }
+}
+
+/// Find the earliest `<response>` or `</response>` marker in `text`.
+fn earliest_marker(text: &str) -> Option<(usize, &'static str)> {
+    [RESPONSE_START, RESPONSE_END]
+        .into_iter()
+        .filter_map(|marker| text.find(marker).map(|start| (start, marker)))
+        .min_by_key(|(start, _)| *start)
+}
+
+/// Return the length of the longest trailing suffix of `text` that could still
+/// complete a `<response>` or `</response>` marker.
+fn partial_marker_suffix_len(text: &str) -> usize {
+    text.char_indices()
+        .map(|(idx, _)| &text[idx..])
+        .filter(|suffix| {
+            [RESPONSE_START, RESPONSE_END]
+                .iter()
+                .any(|marker| marker.len() > suffix.len() && marker.starts_with(suffix))
+        })
+        .map(str::len)
+        .max()
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::Ernie45ReasoningParser;
+    use crate::reasoning::ReasoningParser;
+    use crate::reasoning::tests::{
+        THINK_END_ID, THINK_START_ID, content_str, fake_tokenizer, push_str, reasoning_str,
+    };
+    use crate::tool::test_utils::split_by_chars;
+
+    /// A parser whose prompt already opened reasoning, as the ERNIE templates do.
+    fn parser_in_reasoning() -> Ernie45ReasoningParser {
+        let mut parser = Ernie45ReasoningParser::new(Arc::new(fake_tokenizer())).unwrap();
+        parser.initialize(&[THINK_START_ID, u32::from(b'\n')]).unwrap();
+        parser
+    }
+
+    /// Push each chunk and concatenate the reasoning/content parts, including
+    /// whatever `finish()` flushes.
+    fn collect(parser: &mut Ernie45ReasoningParser, chunks: &[&str]) -> (String, String) {
+        let mut reasoning = String::new();
+        let mut content = String::new();
+        for chunk in chunks {
+            let delta = push_str(parser, chunk);
+            reasoning.push_str(reasoning_str(&delta).unwrap_or_default());
+            content.push_str(content_str(&delta).unwrap_or_default());
+        }
+        let delta = parser.finish().unwrap();
+        reasoning.push_str(reasoning_str(&delta).unwrap_or_default());
+        content.push_str(content_str(&delta).unwrap_or_default());
+        (reasoning, content)
+    }
+
+    const THINKING_OUTPUT: &str =
+        "Need compute 2 + 2 directly.\n</think>\n<response>\nThe answer is 4.\n</response>\n";
+
+    #[test]
+    fn picks_up_prompt_start_boundary() {
+        let mut parser = parser_in_reasoning();
+
+        let delta = push_str(&mut parser, "implicit reasoning</think>answer");
+        assert_eq!(reasoning_str(&delta), Some("implicit reasoning"));
+        assert_eq!(content_str(&delta), Some("answer"));
+    }
+
+    #[test]
+    fn respects_prompt_end_boundary() {
+        let mut parser = Ernie45ReasoningParser::new(Arc::new(fake_tokenizer())).unwrap();
+        // Prompt already closed reasoning with `</think>`.
+        parser.initialize(&[THINK_START_ID, THINK_END_ID]).unwrap();
+
+        let delta = push_str(&mut parser, "answer");
+        assert_eq!(delta.reasoning, None);
+        assert_eq!(content_str(&delta), Some("answer"));
+    }
+
+    #[test]
+    fn strips_think_and_response_framing_in_single_push() {
+        let mut parser = parser_in_reasoning();
+
+        let (reasoning, content) = collect(&mut parser, &[THINKING_OUTPUT]);
+        assert_eq!(reasoning, "Need compute 2 + 2 directly.");
+        assert_eq!(content, "The answer is 4.");
+    }
+
+    #[test]
+    fn strips_framing_across_arbitrary_chunk_boundaries() {
+        for chunk_chars in 1..=12 {
+            let mut parser = parser_in_reasoning();
+
+            let (reasoning, content) =
+                collect(&mut parser, &split_by_chars(THINKING_OUTPUT, chunk_chars));
+            assert_eq!(
+                reasoning, "Need compute 2 + 2 directly.",
+                "chunk size {chunk_chars}"
+            );
+            assert_eq!(content, "The answer is 4.", "chunk size {chunk_chars}");
+        }
+    }
+
+    #[test]
+    fn keeps_tool_calls_after_response_framing() {
+        // The template renders tool calls after `</response>`; they must reach
+        // the content stream (and thus the tool parser) untouched.
+        let output = "Need call the tools.\n</think>\n<response>\nI will call the tools.\n</response>\n\n\n<tool_call>\n{\"name\": \"add\", \"arguments\": {\"x\": 1}}\n</tool_call>\n";
+        for chunk_chars in [1, 3, 7, output.len()] {
+            let mut parser = parser_in_reasoning();
+
+            let (reasoning, content) = collect(&mut parser, &split_by_chars(output, chunk_chars));
+            assert_eq!(
+                reasoning, "Need call the tools.",
+                "chunk size {chunk_chars}"
+            );
+            assert_eq!(
+                content,
+                "I will call the tools.<tool_call>\n{\"name\": \"add\", \"arguments\": {\"x\": 1}}\n</tool_call>\n",
+                "chunk size {chunk_chars}"
+            );
+        }
+    }
+
+    #[test]
+    fn handles_answer_without_response_framing() {
+        // ERNIE also emits `abc\n</think>\ndef` without the response wrapper.
+        let mut parser = parser_in_reasoning();
+
+        let (reasoning, content) = collect(&mut parser, &["abc\n</think>\ndef\nDEF"]);
+        assert_eq!(reasoning, "abc");
+        assert_eq!(content, "def\nDEF");
+    }
+
+    #[test]
+    fn drops_all_framing_newlines_after_think_end() {
+        // The ERNIE-4.5-VL template renders `</think>\n\n` before content.
+        let mut parser = parser_in_reasoning();
+
+        let (reasoning, content) = collect(&mut parser, &["abc\n</think>\n\n", "def"]);
+        assert_eq!(reasoning, "abc");
+        assert_eq!(content, "def");
+    }
+
+    #[test]
+    fn preserves_newlines_inside_reasoning_and_content() {
+        let mut parser = parser_in_reasoning();
+
+        let (reasoning, content) = collect(
+            &mut parser,
+            &["line1\n\nline2\n\n</think>\n<response>\n\npara1\n\npara2\n\n</response>\n"],
+        );
+        // Only the framing newlines around the markers are dropped: the single
+        // `\n` right before `</think>` / `</response>`, and the run of newlines
+        // right after `</think>` / `<response>` / `</response>`.
+        assert_eq!(reasoning, "line1\n\nline2\n");
+        assert_eq!(content, "para1\n\npara2\n");
+    }
+
+    #[test]
+    fn holds_trailing_newline_until_response_end_is_ruled_out() {
+        let mut parser = parser_in_reasoning();
+
+        let first = push_str(&mut parser, "reason\n</think>\n<response>\nanswer\n");
+        assert_eq!(reasoning_str(&first), Some("reason"));
+        assert_eq!(content_str(&first), Some("answer"));
+
+        // The held `\n` is replayed once `</response>` does not follow.
+        let second = push_str(&mut parser, "more answer");
+        assert_eq!(content_str(&second), Some("\nmore answer"));
+    }
+
+    #[test]
+    fn finish_flushes_partial_markers_as_content() {
+        let mut parser = parser_in_reasoning();
+
+        let pushed = push_str(&mut parser, "reason\n</think>\n<response>\nanswer\n</resp");
+        assert_eq!(reasoning_str(&pushed), Some("reason"));
+        assert_eq!(content_str(&pushed), Some("answer"));
+
+        // Held-back text that never became a marker is literal content.
+        let flushed = parser.finish().unwrap();
+        assert_eq!(flushed.reasoning, None);
+        assert_eq!(content_str(&flushed), Some("\n</resp"));
+    }
+
+    #[test]
+    fn handles_empty_response_and_empty_input() {
+        let mut parser = parser_in_reasoning();
+
+        assert!(push_str(&mut parser, "").is_empty());
+        let (reasoning, content) = collect(
+            &mut parser,
+            &["reason\n</think>\n<response>\n</response>\n"],
+        );
+        assert_eq!(reasoning, "reason");
+        assert_eq!(content, "");
+    }
+
+    #[test]
+    fn handles_explicit_start_token() {
+        let mut parser = Ernie45ReasoningParser::new(Arc::new(fake_tokenizer())).unwrap();
+
+        // An explicit start delimiter must not leak into reasoning text.
+        let (reasoning, content) = collect(
+            &mut parser,
+            &["<think>\nreason\n</think>\n<response>\nanswer\n</response>"],
+        );
+        assert_eq!(reasoning, "reason");
+        assert_eq!(content, "answer");
+    }
+}

--- a/rust/src/parser/src/reasoning/mod.rs
+++ b/rust/src/parser/src/reasoning/mod.rs
@@ -21,6 +21,7 @@ mod cohere_cmd;
 mod deepseek_r1;
 mod deepseek_v3;
 mod delimited;
+mod ernie45;
 mod glm45;
 mod hy;
 mod kimi;
@@ -38,6 +39,7 @@ pub use self::deepseek_v3::DeepSeekV3ReasoningParser;
 pub(crate) use self::delimited::{
     DelimitedReasoningParser, DelimitedReasoningParserBuilder, last_reasoning_boundary,
 };
+pub use self::ernie45::Ernie45ReasoningParser;
 pub use self::glm45::Glm45ReasoningParser;
 pub(crate) use self::hy::HyReasoningParser;
 pub use self::kimi::KimiReasoningParser;

--- a/rust/src/parser/src/tool/json/ernie45.rs
+++ b/rust/src/parser/src/tool/json/ernie45.rs
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+use super::{JsonToolCallConfig, JsonToolCallParser, JsonToolCallWhitespace};
+use crate::tool::{Result, StructuralTagBuilder, Tool, ToolParser, ToolParserOutput};
+
+const ERNIE45_CONFIG: JsonToolCallConfig = JsonToolCallConfig {
+    parser_name: "ERNIE 4.5",
+    start_marker: "<tool_call>",
+    // The chat template separates the answer and each tool call with a blank
+    // line, so the framed marker keeps that framing out of the text stream.
+    framed_start_marker: Some("\n\n\n<tool_call>"),
+    end_marker: "</tool_call>",
+    // The Python parser matches `\s*` around the payload, so the newlines the
+    // template renders inside the markers are optional here too.
+    marker_whitespace: JsonToolCallWhitespace::Optional,
+    delimiter: None,
+    name_key: "name",
+    arguments_key: &["arguments"],
+};
+
+/// Tool parser for ERNIE 4.5 XML-wrapped JSON tool calls.
+///
+/// Example tool call content, as rendered by the ERNIE 4.5 chat template:
+///
+/// ```text
+/// <tool_call>
+/// {"name": "get_weather", "arguments": {"location": "Beijing"}}
+/// </tool_call>
+/// ```
+///
+/// Parallel calls are repeated `<tool_call>...</tool_call>` blocks. Arguments
+/// are already OpenAI-style JSON text, so they are streamed as raw argument
+/// deltas without schema conversion or JSON normalization.
+///
+/// The thinking-model framing that precedes tool calls (`</think>` and the
+/// `<response>...</response>` answer wrapper) is stripped by the `ernie45`
+/// reasoning parser, which runs before this parser in the combined pipeline.
+pub struct Ernie45ToolParser {
+    inner: JsonToolCallParser,
+}
+
+impl Ernie45ToolParser {
+    /// Create an ERNIE 4.5 tool parser.
+    fn new(_tools: &[Tool]) -> Self {
+        Self {
+            inner: JsonToolCallParser::new(ERNIE45_CONFIG),
+        }
+    }
+}
+
+impl ToolParser for Ernie45ToolParser {
+    fn create(tools: &[Tool]) -> Result<Box<dyn ToolParser>>
+    where
+        Self: Sized + 'static,
+    {
+        Ok(Box::new(Self::new(tools)))
+    }
+
+    fn structural_tag_builder(&self) -> Option<&dyn StructuralTagBuilder> {
+        // ERNIE 4.5 emits the same `<tool_call>{"name": ..., "arguments": ...}`
+        // shape that the Hermes structural tag constrains.
+        Some(xgrammar_structural_tag::Model::Hermes.builder())
+    }
+
+    fn parse_into(&mut self, chunk: &str, output: &mut ToolParserOutput) -> Result<()> {
+        self.inner.parse_into(chunk, output)
+    }
+
+    fn finish(&mut self) -> Result<ToolParserOutput> {
+        self.inner.finish()
+    }
+
+    fn reset(&mut self) -> String {
+        self.inner.reset()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use expect_test::expect;
+
+    use super::Ernie45ToolParser;
+    use crate::tool::ToolParserTestExt as _;
+    use crate::tool::test_utils::{collect_stream, split_by_chars, test_tools};
+
+    /// One tool call exactly as the ERNIE 4.5 chat template renders it.
+    fn build_tool_call(function_name: &str, arguments: &str) -> String {
+        format!(
+            "\n\n\n<tool_call>\n{{\"name\": \"{function_name}\", \"arguments\": {arguments}}}\n</tool_call>"
+        )
+    }
+
+    #[test]
+    fn ernie45_parse_complete_extracts_template_shaped_call() {
+        let mut parser = Ernie45ToolParser::new(&test_tools());
+        let output = parser
+            .parse_complete(&build_tool_call(
+                "get_weather",
+                r#"{"location": "Beijing"}"#,
+            ))
+            .unwrap();
+
+        assert_eq!(output.normal_text(), "");
+        assert_eq!(output.calls().len(), 1);
+        assert_eq!(output.calls()[0].name.as_deref(), Some("get_weather"));
+        assert_eq!(output.calls()[0].arguments, r#"{"location": "Beijing"}"#);
+    }
+
+    #[test]
+    fn ernie45_streaming_extracts_parallel_calls_without_leaking_framing() {
+        let input = format!(
+            "{}{}",
+            build_tool_call("get_weather", r#"{"location": "Shanghai"}"#),
+            build_tool_call("add", r#"{"x": 1, "y": 2}"#),
+        );
+        let chunks = split_by_chars(&input, 5);
+        let mut parser = Ernie45ToolParser::new(&test_tools());
+
+        let output = collect_stream(&mut parser, &chunks);
+
+        expect![[r#"
+            ToolParserOutput {
+                events: [
+                    ToolCall(
+                        ToolCallDelta {
+                            tool_index: 0,
+                            name: Some(
+                                "get_weather",
+                            ),
+                            arguments: "{\"location\": \"Shanghai\"}",
+                        },
+                    ),
+                    ToolCall(
+                        ToolCallDelta {
+                            tool_index: 1,
+                            name: Some(
+                                "add",
+                            ),
+                            arguments: "{\"x\": 1, \"y\": 2}",
+                        },
+                    ),
+                ],
+            }
+        "#]]
+        .assert_debug_eq(&output);
+    }
+
+    #[test]
+    fn ernie45_accepts_calls_without_framing_newlines() {
+        // The model does not always reproduce the template's framing.
+        let mut parser = Ernie45ToolParser::new(&test_tools());
+        let output = parser
+            .parse_complete(
+                r#"Checking.<tool_call>{"name":"get_weather","arguments":{"location":"Beijing"}}</tool_call>"#,
+            )
+            .unwrap();
+
+        assert_eq!(output.normal_text(), "Checking.");
+        assert_eq!(output.calls().len(), 1);
+        assert_eq!(output.calls()[0].arguments, r#"{"location":"Beijing"}"#);
+    }
+}

--- a/rust/src/parser/src/tool/json/mod.rs
+++ b/rust/src/parser/src/tool/json/mod.rs
@@ -3,6 +3,7 @@
 
 //! Shared parser core for JSON tool calls wrapped by text markers.
 
+pub use ernie45::Ernie45ToolParser;
 pub use granite4::Granite4ToolParser;
 pub use hermes::HermesToolParser;
 pub use internlm2::Internlm2ToolParser;
@@ -11,6 +12,7 @@ pub use mistral::MistralToolParser;
 pub use phi4mini::Phi4MiniJsonToolParser;
 pub use qwen::Qwen3XmlToolParser;
 
+mod ernie45;
 mod granite4;
 mod hermes;
 mod internlm2;

--- a/rust/src/parser/src/tool/mod.rs
+++ b/rust/src/parser/src/tool/mod.rs
@@ -26,8 +26,8 @@ pub use error::{Result, ToolParserError};
 pub use glm_xml::{Glm45MoeToolParser, Glm47MoeToolParser};
 pub(crate) use hy::{HyDialect, HyToolMarkers, HyToolParser};
 pub use json::{
-    Granite4ToolParser, HermesToolParser, Internlm2ToolParser, Llama3JsonToolParser,
-    MistralToolParser, Phi4MiniJsonToolParser, Qwen3XmlToolParser,
+    Ernie45ToolParser, Granite4ToolParser, HermesToolParser, Internlm2ToolParser,
+    Llama3JsonToolParser, MistralToolParser, Phi4MiniJsonToolParser, Qwen3XmlToolParser,
 };
 pub use kimi_k2::KimiK2ToolParser;
 pub use minimax_m2::MinimaxM2ToolParser;


### PR DESCRIPTION
## Purpose

Add the `ernie45` tool parser and `ernie45` reasoning parser to the Rust frontend, closing two items of the parser parity checklist in #44280 (claimed [here](https://github.com/vllm-project/vllm/issues/44280#issuecomment-5334022394)).

ERNIE 4.5 thinking models (`baidu/ERNIE-4.5-21B-A3B-Thinking`) prefill `<think>\n` in the generation prompt and emit

```text
{reasoning}\n</think>\n<response>\n{content}\n</response>\n\n\n<tool_call>\n{"name": ..., "arguments": {...}}\n</tool_call>\n
```

### Reasoning parser (`rust/src/parser/src/reasoning/ernie45.rs`)

Wraps the shared delimited `<think>`/`</think>` state machine with prompt-first initialization (falling back to `in_reasoning = true`, since the templates prefill `<think>` and the model only emits `</think>`), and strips exactly the framing the ERNIE templates add around the two sections:

- the single `\n` right before `</think>` is dropped from reasoning;
- newlines directly after `</think>` are dropped from content;
- a `<response>` marker and the newlines directly after it are dropped;
- a `</response>` marker, the single `\n` right before it, and the newlines directly after it are dropped.

Markers and framing newlines split across chunk boundaries are handled by holding back the ambiguous suffix (same approach as the Step3p5 parser's held newline). Unlike the Python parser, anything after `</response>` is kept, so `<tool_call>` blocks that follow the answer still reach the tool parser instead of being truncated.

### Tool parser

The ERNIE 4.5 tool-call shape (`<tool_call>{json}</tool_call>`, repeated blocks for parallel calls, optional whitespace around the JSON) is exactly the Hermes shape, so `Ernie45ToolParser` is registered as the Hermes JSON parser under the `ernie45` name (like the existing `llama4_json` → Llama3 JSON and DeepSeek V3 → Qwen3 reasoning aliases), with ERNIE-template-shaped tests. The think/response framing is owned by the reasoning parser, so the split between the two parsers stays clean.

### Registration and model matching

Both parsers are registered under `ernie45`. The model matcher is scoped to `ernie-4.5-21b-a3b-thinking`: the `ERNIE-4.5-*-PT` text checkpoints have no `<think>`/`<tool_call>` tokens and use a plain `User:`/`Assistant:` template, so auto-selecting the reasoning parser for them would fail at parser creation (`MissingToken`); the VL checkpoints ship only a sentencepiece tokenizer, which the Rust tokenizer backend does not load.

### Renderer: `thoughts`

The ERNIE thinking template reads assistant reasoning history from `message.thoughts` (not `reasoning`/`reasoning_content`), so `TemplateMessage` now exposes `thoughts` alongside the two existing variants. Without it the template drops reasoning from history, which is what the roundtrip fixture caught first.

### Roundtrip fixture

Adds `baidu/ERNIE-4.5-21B-A3B-Thinking` (ungated tokenizer/template) to `rust/src/chat/tests/roundtrip.rs` for both `reasoning_and_content` and `tool_call_mix`; the closed completion is parsed by the real output processor and re-rendered byte-for-byte.

## Not a duplicate

The earlier ERNIE 4.5 Rust PRs (#44310 tool parser, #45385 reasoning parser) were closed by their author on Aug 17 without landing; `gh pr list --state open --search "ernie"` / `"rust frontend ernie"` and the #44280 comments show no other open PR or claim for either item.

## Test Plan

```bash
cargo test --manifest-path rust/Cargo.toml -p vllm-parser --all-features
cargo test --manifest-path rust/Cargo.toml -p vllm-chat --all-features   # includes tests/roundtrip.rs (downloads the HF tokenizer)
cargo fmt --manifest-path rust/Cargo.toml --all -- --check
cargo clippy --manifest-path rust/Cargo.toml -p vllm-parser -p vllm-chat --all-targets --all-features --locked -- -D warnings
```

## Test Result

- `vllm-parser`: 432 passed (16 new ERNIE tests: framing removal across every chunk size 1..=12, held newlines, partial markers, tool calls after `</response>`, template-shaped tool calls).
- `vllm-chat`: 269 lib + 17 chat + 18 roundtrip passed, including the new `roundtrip_ernie45` (reasoning+content in both thinking modes, and reasoning+content+two parallel tool calls) with exact re-render equality.
- `cargo fmt --check` and `cargo clippy -D warnings` clean on the touched crates.

## Disclosure

AI assistance was used in preparing this PR.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>
