### PR TITLE
[CI][Bugfix] Complete DeepSeek-V4 FSE test fixture contract

### DIFF
--- a/tests/model_executor/layers/test_fused_shared_expert.py
+++ b/tests/model_executor/layers/test_fused_shared_expert.py
@@ -479,6 +479,8 @@ def test_models_fse_init(
         is_mm_prefix_lm=False,
         multimodal_config=None,
         quantization_config=None,
+        runner_type="generate",
+        is_moe=True,
     )
     vllm_config.parallel_config.enable_expert_parallel = False
     if model_type == "deepseek_v4":

--- a/tests/model_executor/layers/test_fused_shared_expert.py
+++ b/tests/model_executor/layers/test_fused_shared_expert.py
@@ -537,7 +537,8 @@ def test_models_fse_init(
                 )
 
                 vllm_config.speculative_config = SimpleNamespace(
-                    draft_model_config=SimpleNamespace(hf_config=config)
+                    draft_model_config=SimpleNamespace(hf_config=config),
+                    method="mtp",
                 )
                 mtp = DeepSeekV4MTP(vllm_config=vllm_config)
         assert model.is_fused_shared_expert_enabled is (fse_enabled and not exclude)


### PR DESCRIPTION
## Purpose

Complete the test-fixture fix for the DeepSeek-V4 fused-shared-expert regression on `main`.

This builds directly on #52829 by @tdoublep. Their exact commit `038d308c4` is preserved as the first commit in this PR, retaining its original authorship. Buildkite #84493 showed that the original `runner_type` / `is_moe` additions clear the first `SimpleNamespace` contract error, but the test then fails one layer later because its speculative-config mock lacks `method`.

## Change

- Preserve #52829's `runner_type="generate"` and `is_moe=True` model-config fields.
- Add `method="mtp"` to the later speculative-config mock used to construct `DeepSeekV4MTP`.

`"mtp"` mirrors the resolved production `SpeculativeConfig` for this path and satisfies the direct method checks in `VllmConfig.use_v2_model_runner` without weakening the fixture semantics.

## Duplicate-work check

This intentionally supersedes #52829 rather than competing with unrelated work. Kevin requested a replacement after #52829's Buildkite validation reproduced the regression with the next missing fixture field. The original author's commit and credit are preserved here, and the failure/follow-up were documented on #52829 before opening this PR.

## Validation

Passed locally:

```text
.venv/bin/python -m compileall -q tests/model_executor/layers/test_fused_shared_expert.py
uvx ruff check tests/model_executor/layers/test_fused_shared_expert.py
git diff --check
```

The relevant GPU test is:

```text
pytest tests/model_executor/layers/test_fused_shared_expert.py -k 'fse_init and deepseek_v4'
```

This host has no GPU, so the targeted pytest requires Buildkite validation. This is test-only and does not affect model output, accuracy, or serving; model evaluation is not applicable.

AI assistance was used to trace the failure, prepare the follow-up fixture field, and draft this PR. Kevin Luu reviewed the requested scope and owns the submission.
