### PR TITLE
[Bugfix] Pad the MiniMax-M3 decode index tile to a power of two

### DIFF
--- a/tests/kernels/attention/test_minimax_m3.py
+++ b/tests/kernels/attention/test_minimax_m3.py
@@ -563,15 +563,19 @@ def test_msa_indexer_impl_matches_triton(topk, index_dtype, monkeypatch):
     ],
 )
 @pytest.mark.parametrize("num_padded_reqs", [0, 2])
+# num_idx_heads == num_kv_heads, which is not a power of two for every TP
+# split (e.g. 96 query heads over 6 KV heads). The decode score kernel tiles
+# num_idx_heads * BLOCK_SIZE_Q lanes, so those counts must not break it.
+@pytest.mark.parametrize("num_idx_heads", [2, 3, 6])
 def test_decode_index_topk_correctness(
     decode_query_len: int,
     max_decode_query_len: int,
     num_padded_reqs: int,
+    num_idx_heads: int,
 ):
     topk = 6
     init_blocks = 0
     local_blocks = 1
-    num_idx_heads = 2
     head_dim = 16
     active_seq_lens = torch.tensor((7, 129, 1025), device="cuda", dtype=torch.int32)
     q_lens = torch.full_like(active_seq_lens, decode_query_len)

--- a/vllm/models/minimax_m3/common/ops/index_topk.py
+++ b/vllm/models/minimax_m3/common/ops/index_topk.py
@@ -318,13 +318,17 @@ def _decode_index_score_kernel(
     num_kv_chunks,
     USE_PDL: tl.constexpr,
 ):
-    BLOCK_SIZE_HQ: tl.constexpr = num_idx_heads * BLOCK_SIZE_Q
+    # ``tl.arange`` requires a power-of-two extent, so tile to the next power
+    # of two and mask the trailing lanes instead of assuming the product is
+    # already one. num_idx_heads == num_kv_heads, which is only a power of two
+    # for some TP splits (e.g. 96 query heads over 6 KV heads).
+    BLOCK_SIZE_HQ: tl.constexpr = triton.next_power_of_2(num_idx_heads * BLOCK_SIZE_Q)
     pid_r = tl.program_id(0)
     pid_c = tl.program_id(1)
     hq_offsets = tl.arange(0, BLOCK_SIZE_HQ)
     h_offsets = hq_offsets // BLOCK_SIZE_Q
     q_offsets = hq_offsets % BLOCK_SIZE_Q
-    q_mask = q_offsets < decode_query_len
+    q_mask = (q_offsets < decode_query_len) & (h_offsets < num_idx_heads)
     q_ids = pid_r * decode_query_len + q_offsets
 
     if USE_PDL:


### PR DESCRIPTION
## Purpose

Fixes #49157.

`_decode_index_score_kernel` derives its lane tile directly from the head count:

```python
BLOCK_SIZE_HQ: tl.constexpr = num_idx_heads * BLOCK_SIZE_Q
hq_offsets = tl.arange(0, BLOCK_SIZE_HQ)
```

`tl.arange` requires a power-of-two extent, so decode fails to compile whenever `num_idx_heads * BLOCK_SIZE_Q` is not one:

```
ValueError: arange's range must be a power of 2
```

`num_idx_heads == num_kv_heads`, which is not a power of two for every TP split — e.g. 96 query heads over 6 KV heads. The prefill kernel is unaffected because it puts the head dimension in the program grid, so the head count never becomes a `tl.arange` extent there.

This rounds the tile up to the next power of two and bounds the head dimension in the existing `q_mask`, which already guards every load, score and store indexed by `hq_offsets`. The trailing lanes are masked out, so results for the real heads are unchanged.

## Test Plan

`test_decode_index_topk_correctness` hardcoded `num_idx_heads = 2`, which is a power of two, so it could never reach this path. It is now parametrized over `[2, 3, 6]` and checks the kernel against the reference implementation already in that file.

```bash
pytest tests/kernels/attention/test_minimax_m3.py::test_decode_index_topk_correctness -v
```

## Test Result

| | failed | passed |
|---|---|---|
| before | 12 | 6 |
| after | **0** | **18** |

The 12 failures are exactly the `num_idx_heads` 3 and 6 cases; the `2` cases pass either way.

Full-file run, comparing the same commit with and without the kernel change:

```
fixed by this patch (12):
  test_decode_index_topk_correctness[3-0-1-1] … [3-2-4-4]
  test_decode_index_topk_correctness[6-0-1-1] … [6-2-4-4]

broken by this patch:
  (none)
```

I also checked that the padded lanes do not perturb results: for `num_idx_heads` in {3, 5, 6, 12}, decode scores are bit-identical to an unpadded run over the same inputs (max abs diff exactly 0), and `decode_query_len > 1` (spec decode, where `BLOCK_SIZE_Q > 1` widens the product) compiles and runs for the same head counts.

Tested on sm120. The remaining failures in that file are pre-existing and unrelated — they come from `tl.make_block_ptr` having been removed in newer Triton (`NotImplementedError: Block pointers have been removed in favor of the tensor descriptor API`), and the failure set is identical with and without this change.
