### PR TITLE
[Core] Add configurable sleep to shm broadcast busy loop

### DIFF
--- a/tests/distributed/test_shm_broadcast.py
+++ b/tests/distributed/test_shm_broadcast.py
@@ -19,6 +19,7 @@ from vllm.distributed.device_communicators import shm_broadcast
 from vllm.distributed.device_communicators.shm_broadcast import (
     MessageQueue,
     ShmRingBuffer,
+    SpinCondition,
     _rebuild_tensor,
     _reduce_tensor,
     check_shm_free_space,
@@ -357,6 +358,49 @@ def worker_fn_test_busy_to_idle():
 
 def test_message_queue_busy_to_idle():
     distributed_run(worker_fn_test_busy_to_idle, 4)
+
+
+@pytest.mark.parametrize(
+    ("busy_sleep_s", "expected_sleep"),
+    [("0", None), ("0.00025", 0.00025)],
+)
+def test_spin_condition_busy_sleep(monkeypatch, busy_sleep_s, expected_sleep):
+    monkeypatch.setenv("VLLM_SHM_BROADCAST_BUSY_SLEEP_S", busy_sleep_s)
+    context = mock.MagicMock()
+
+    with (
+        mock.patch.object(shm_broadcast.zmq, "Poller") as poller_cls,
+        mock.patch.object(shm_broadcast.time, "monotonic", return_value=1.0),
+    ):
+        condition = SpinCondition(
+            is_reader=True,
+            context=context,
+            notify_address="inproc://test-spin-condition",
+        )
+        with (
+            mock.patch.object(shm_broadcast, "sched_yield") as sched_yield,
+            mock.patch.object(shm_broadcast.time, "sleep") as sleep,
+        ):
+            condition.wait()
+
+        sched_yield.assert_called_once_with()
+        poller_cls.return_value.poll.assert_not_called()
+        if expected_sleep is None:
+            sleep.assert_not_called()
+        else:
+            sleep.assert_called_once_with(expected_sleep)
+
+
+@pytest.mark.parametrize("busy_sleep_s", ["-0.001", "nan", "inf", "-inf"])
+def test_spin_condition_rejects_invalid_busy_sleep(monkeypatch, busy_sleep_s):
+    monkeypatch.setenv("VLLM_SHM_BROADCAST_BUSY_SLEEP_S", busy_sleep_s)
+
+    with pytest.raises(ValueError, match="finite and non-negative"):
+        SpinCondition(
+            is_reader=True,
+            context=mock.MagicMock(),
+            notify_address="inproc://test-spin-condition-invalid",
+        )
 
 
 @worker_fn_wrapper

--- a/vllm/distributed/device_communicators/shm_broadcast.py
+++ b/vllm/distributed/device_communicators/shm_broadcast.py
@@ -3,6 +3,7 @@
 import copyreg
 import functools
 import io
+import math
 import os
 import pickle
 import shutil
@@ -121,6 +122,9 @@ class SpinCondition:
     await a notification on the zmq socket after a period of inactivity. This
     allows the readers to spin quickly, hence "SpinCondition".
 
+    `busy_sleep_s` bounds the busy-loop polling frequency without changing when
+    the reader enters idle mode. Zero preserves continuous polling.
+
     To support clean shutdown, a separate thread in the reader's process must be
     able to wake the reader so that it can exit. A separate cancel() method is
     implemented with an in-process socket to allow this interruption.
@@ -132,6 +136,7 @@ class SpinCondition:
         context: zmq.Context,
         notify_address: str,
         busy_loop_s: float = 1,
+        busy_sleep_s: float | None = None,
     ):
         self.is_reader = is_reader
 
@@ -141,6 +146,17 @@ class SpinCondition:
 
             # Time to keep busy-looping on the shm buffer before going idle
             self.busy_loop_s = busy_loop_s
+            self.busy_sleep_s = (
+                busy_sleep_s
+                if busy_sleep_s is not None
+                else envs.VLLM_SHM_BROADCAST_BUSY_SLEEP_S
+            )
+            if not math.isfinite(self.busy_sleep_s) or self.busy_sleep_s < 0:
+                raise ValueError(
+                    "busy_sleep_s must be finite and non-negative, got "
+                    f"{self.busy_sleep_s!r} "
+                    "(VLLM_SHM_BROADCAST_BUSY_SLEEP_S)"
+                )
 
             # Readers subscribe to write notifications
             self.local_notify_socket: zmq.Socket = context.socket(SUB)
@@ -174,6 +190,7 @@ class SpinCondition:
 
             self.last_read = 0
             self.busy_loop_s = 0
+            self.busy_sleep_s = 0
             self.read_cancel_socket = None
             self.write_cancel_socket = None
             self.poller = None
@@ -202,6 +219,8 @@ class SpinCondition:
         current_time = time.monotonic()
         if current_time <= self.last_read + self.busy_loop_s:
             sched_yield()
+            if self.busy_sleep_s > 0:
+                time.sleep(self.busy_sleep_s)
         else:
             events = dict(self.poller.poll(timeout=timeout_ms))
 

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
     VLLM_USE_MODELSCOPE: bool = False
     VLLM_USE_FASTOKENS: bool = False
     VLLM_RINGBUFFER_WARNING_INTERVAL: int = 60
+    VLLM_SHM_BROADCAST_BUSY_SLEEP_S: float = 0.0
     VLLM_NCCL_SO_PATH: str | None = None
     LD_LIBRARY_PATH: str | None = None
     VLLM_ROCM_SLEEP_MEM_CHUNK_SIZE: int = 256
@@ -733,6 +734,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Interval in seconds to log a warning message when the ring buffer is full
     "VLLM_RINGBUFFER_WARNING_INTERVAL": lambda: int(
         os.environ.get("VLLM_RINGBUFFER_WARNING_INTERVAL", "60")
+    ),
+    # Sleep duration between shared-memory checks while a reader is in its busy
+    # window. Zero preserves continuous polling.
+    "VLLM_SHM_BROADCAST_BUSY_SLEEP_S": lambda: float(
+        os.environ.get("VLLM_SHM_BROADCAST_BUSY_SLEEP_S", "0")
     ),
     # path to cudatoolkit home directory, under which should be bin, include,
     # and lib directories.
@@ -2219,6 +2225,7 @@ def compile_factors() -> dict[str, object]:
         "VLLM_RPC_BASE_PATH",
         "VLLM_USE_MODELSCOPE",
         "VLLM_RINGBUFFER_WARNING_INTERVAL",
+        "VLLM_SHM_BROADCAST_BUSY_SLEEP_S",
         "VLLM_DEBUG_DUMP_PATH",
         "VLLM_PORT",
         "VLLM_CACHE_ROOT",


### PR DESCRIPTION
## Summary

This adds a configurable, bounded sleep to the shared-memory reader's existing busy branch:

- `VLLM_SHM_BROADCAST_BUSY_SLEEP_S=0` is the default and preserves continuous polling.
- A positive finite value sleeps for that duration after `sched_yield()` on each busy-path check.
- Negative, NaN, and positive/negative infinity values fail at `SpinCondition` construction.
- The existing one-second busy/idle transition and ZMQ notification path are unchanged.

The variable is excluded from compile factors because it changes runtime scheduling, not generated code.

## Why this is not duplicating #52814

#52814 makes `busy_loop_s` configurable. With a short value, the reader leaves the busy branch and parks in ZMQ during active decode.

This PR controls a different dimension: the polling interval *inside* the busy branch. A positive value keeps the reader on the SHM polling path during the existing busy window, while bounding how frequently it checks. This provides an intermediate CPU/latency tradeoff for deployments that want to avoid a ZMQ park on every active decode step.

I described this distinction and the supporting measurements in [the #52814 discussion](https://github.com/vllm-project/vllm/pull/52814#issuecomment-5335995192) before opening this draft. The two controls are orthogonal and could coexist if maintainers find both useful.

## Validation

### Unit and repository checks

```console
VLLM_TARGET_DEVICE=cpu .venv/bin/python -m pytest \
  tests/distributed/test_shm_broadcast.py -q
# 35 passed
```

```console
.venv/bin/pre-commit run --files \
  vllm/distributed/device_communicators/shm_broadcast.py \
  vllm/envs.py \
  tests/distributed/test_shm_broadcast.py
# All applicable hooks passed, including ruff, mypy, env-default validation,
# forbidden-import checks, and SPDX checks.
```

The submitting human reviewed every changed line and ran the relevant test suite.

### Two-node GB10 deployment evidence

Full public report, including the method, complete metric tables, limitations, provenance hashes, and comparison plot: [matched C16 full bounded-sleep A/B](https://github.com/AlexLJC/deepseek-v4-flash-gb10/blob/096c42d42068ff96e41e576f6dfea347c2d472d3/experiments/spincondition-bounded-sleep/README.md), published in evidence commit [`096c42d`](https://github.com/AlexLJC/deepseek-v4-flash-gb10/commit/096c42d42068ff96e41e576f6dfea347c2d472d3).

The same wait-path intervention (`sched_yield()` followed by `time.sleep(0.00025)`) was tested as a read-only module overlay in a pinned two-node deployment:

- 2× NVIDIA GB10, TP=2 over dual RoCE
- DeepSeek-V4-Flash-0731, model revision `7872f01b1d1fe23eabc4c98b48bffcef5a386062`
- identical image, model, topology, and fixed C16 workload in both arms
- 16/16 top-level tasks completed in both arms

Observed results:

- steady head-only excess CPU: 1.9240 → 0.0252 cores (-98.69%)
- independent whole-node head CPU: -1.803 average cores
- head TSOC p95: 95.94 → 90.74 °C (-5.20 °C)
- matched-GPU-power head/worker TSOC gap: 10.271 → 7.418 °C (-27.77%)
- no request failure, preemption, engine restart, recorded GPU clock slowdown, or thermal guard intervention

This matched pair does **not** establish a throughput speedup or regression: the patched arm generated 7.1% more output tokens and ran at 11.8% lower mean active concurrency. The deployment result supports the CPU/thermal mechanism and absence of an obvious latency collapse, not a general performance effect size.

The deployment used a pinned downstream image rather than this exact upstream commit; correctness of this upstream diff is covered by the unit and repository checks above.

## AI assistance disclosure

OpenAI Codex assisted with implementation, test execution, and PR preparation. The human submitter reviewed every changed line, ran the relevant tests, and is responsible for the contribution.