### PR TITLE
[Bugfix] Set the MXFP4 persistent-kernel constraint on consumer Blackwell

### DIFF
--- a/tests/kernels/moe/test_gpt_oss_triton_kernels.py
+++ b/tests/kernels/moe/test_gpt_oss_triton_kernels.py
@@ -309,7 +309,7 @@ def test_equiv(num_token, a_dtype, w_dtype, tp, workspace_init):
         pc2,
     ) = init_compute_data(M, K, N, E, a_dtype, w_dtype, num_warps=8)
 
-    if current_platform.is_device_capability_family(100):
+    if current_platform.has_device_capability(100):
         constraints = {
             "is_persistent": True,
         }
@@ -371,3 +371,37 @@ def test_unit_shuffle():
     )
 
     assert_close(ref=out_ref, tri=out)
+
+
+@pytest.mark.skipif(not current_platform.is_cuda(), reason="native MXFP is a CUDA path")
+def test_swizzle_mxfp4_sets_persistent_for_native_mxfp():
+    """`matmul_ogs` rejects native MXFP unless the persistent kernel is on.
+
+    `has_native_mxfp()` is `cuda_capability_geq(10, 0)`, so it is true for
+    consumer Blackwell (sm120/sm121) as well as sm100. `_swizzle_mxfp4` is the
+    only place that sets the matching `is_persistent` constraint, so gating it
+    on the sm100 family alone leaves sm120 requiring a constraint that nothing
+    sets, and every native-MXFP matmul raises.
+    """
+    from triton_kernels import target_info
+
+    from vllm.model_executor.layers.quantization.utils.mxfp4_utils import (
+        _swizzle_mxfp4,
+    )
+
+    E, N, K = 4, 128, 256
+    w = torch.randn((E, N, K), dtype=torch.bfloat16, device="cuda")
+    w_quant, w_scale = downcast_to_mxfp(w, torch.uint8, axis=1)
+
+    opt_flags.reset_opt_flags_constraints()
+    try:
+        _swizzle_mxfp4(w_quant, w_scale)
+        constraints = opt_flags._opt_flags_constraints
+        if target_info.has_native_mxfp():
+            assert constraints.get("is_persistent"), (
+                "native MXFP requires the persistent kernel, but "
+                f"_swizzle_mxfp4 set {constraints} on capability "
+                f"{current_platform.get_device_capability()}"
+            )
+    finally:
+        opt_flags.reset_opt_flags_constraints()

--- a/vllm/model_executor/layers/quantization/utils/mxfp4_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/mxfp4_utils.py
@@ -87,7 +87,10 @@ def _swizzle_mxfp4(quant_tensor, scale, num_warps=8):
                 K = scale.shape[-1]
                 pad_k = -K % 4
                 scale = torch.nn.functional.pad(scale, (0, pad_k))
-        elif current_platform.is_device_capability_family(100):
+        elif current_platform.has_device_capability(100):
+            # Native MXFP requires the persistent kernel, and
+            # `has_native_mxfp()` is `cuda_capability_geq(10, 0)` -- so this
+            # must cover sm120/sm121 too, not just the sm100 family.
             constraints = {
                 "is_persistent": True,
                 "epilogue_subtile": 1,


### PR DESCRIPTION
## Purpose

`matmul_ogs` requires the persistent kernel whenever `has_native_mxfp()` is true:

```python
if w_scale is not None and w_scale.storage.layout.name is not None \
        and not opt_flags.is_persistent and target_info.has_native_mxfp():
    raise NotImplementedError(
        "Must use persistent kernel and be TMA-compliant for native MXFP")
```

`has_native_mxfp()` is `cuda_capability_geq(10, 0)`, so it holds for sm120/sm121 as well as sm100. But `_swizzle_mxfp4` — the only place that sets the matching constraint — gated on `is_device_capability_family(100)`, which excludes consumer Blackwell. On sm120 the constraint dict comes back empty and every native-MXFP matmul raises.

sm90 is unaffected (`has_native_mxfp()` is false there) and sm100 already matched, so only sm120/sm121 fell into the gap.

This gates on `has_device_capability(100)` instead, matching the distinction already documented for the TD gather path in `moe_use_td_hw_supported` (`fused_moe/utils.py`), which uses the inclusive check for the same reason.

The constraint in `test_equiv` duplicated the same flawed gate and is corrected alongside it.

## Test Plan

Adds a test that calls `_swizzle_mxfp4` — the only producer of this constraint — and asserts it sets `is_persistent` wherever `has_native_mxfp()` holds, so the two predicates cannot drift apart again. It allocates only small weights, so it also runs on memory-constrained parts.

```bash
pytest tests/kernels/moe/test_gpt_oss_triton_kernels.py::test_swizzle_mxfp4_sets_persistent_for_native_mxfp -v
pytest tests/kernels/moe/test_gpt_oss_triton_kernels.py -v
```

## Test Result

New test, on sm120:

```
before:  1 failed
  AssertionError: native MXFP requires the persistent kernel, but
  _swizzle_mxfp4 set {} on capability DeviceCapability(major=12, minor=0)

after:   1 passed
```

`test_equiv[*-bf16-mx4]`, on sm120:

```
before:  4 failed, 1 passed
  NotImplementedError: Must use persistent kernel and be TMA-compliant for native MXFP
  (vllm/third_party/triton_kernels/matmul_ogs.py:378)

after:   5 passed
```

I confirmed the persistent path is genuinely usable here rather than merely unblocked: the value and scale layouts resolve to `BlackwellMXValueLayout` / `BlackwellMXScaleLayout` and `test_equiv` validates output against its reference, so this is a dispatch gap rather than unsupported hardware.
