### PR TITLE
[XPU][Bugfix] Fix deepseek_v32 package import failure on XPU by adding stub classes

### DIFF
--- a/vllm/models/deepseek_v32/__init__.py
+++ b/vllm/models/deepseek_v32/__init__.py
@@ -14,7 +14,8 @@ if current_platform.is_rocm():
     from .amd.model import DeepseekV32ForCausalLM
     from .amd.mtp import DeepseekV32MTP
 elif current_platform.is_xpu():
-    raise NotImplementedError("deepseek_v32 does not yet support XPU.")
+    from .xpu.model import DeepseekV32ForCausalLM
+    from .xpu.mtp import DeepseekV32MTP
 else:
     # Covers Blackwell (sm100) and all other CUDA devices.
     from .nvidia.model import DeepseekV32ForCausalLM

--- a/vllm/models/deepseek_v32/xpu/__init__.py
+++ b/vllm/models/deepseek_v32/xpu/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project

--- a/vllm/models/deepseek_v32/xpu/model.py
+++ b/vllm/models/deepseek_v32/xpu/model.py
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from vllm.model_executor.models.deepseek_v2 import DeepseekV2ForCausalLM
+
+
+class DeepseekV32ForCausalLM(DeepseekV2ForCausalLM):
+    def __init__(self, *args, **kwargs):
+        raise NotImplementedError(
+            "deepseek_v32 does not yet support XPU. "
+            "A dedicated XPU implementation is pending."
+        )

--- a/vllm/models/deepseek_v32/xpu/mtp.py
+++ b/vllm/models/deepseek_v32/xpu/mtp.py
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import torch.nn as nn
+
+from vllm.model_executor.models.deepseek_v2 import DeepseekV2MixtureOfExperts
+
+
+class DeepseekV32MTP(nn.Module, DeepseekV2MixtureOfExperts):
+    def __init__(self, *args, **kwargs):
+        raise NotImplementedError(
+            "deepseek_v32 does not yet support XPU. "
+            "A dedicated XPU implementation is pending."
+        )


### PR DESCRIPTION
**Issue**
CI failure: https://buildkite.com/vllm/intel-ci/builds/9243/canvas?sid=01a016ac-e404-41d6-8c70-79f6c9395c83&tab=output
The XPU branch in `deepseek_v32/__init__.py` directly raised `NotImplementedError`, causing Python imports of any sub-module within the package (including platform-agnostic ones like `attention.py`) to fail.
`test_mla_short_prefill_indexer.py` attempted to access a class attribute via `from vllm.models.deepseek_v32.attention import DeepseekV32Attention`; however, because `__init__.py` was executed first, the unit test failed during the collection phase.

**Modification**
Added a `vllm/models/deepseek_v32/xpu/` stub directory (containing `model.py` and `mtp.py`), where the `__init__` methods of `DeepseekV32ForCausalLM` and `DeepseekV32MTP` raise `NotImplementedError`. Updated the XPU branch in `deepseek_v32/__init__.py` to import these stubs instead.

**Result**:
- The import phase proceeds normally; platform-agnostic modules (such as `attention.py`) remain accessible, and unit tests pass.
- Instantiating the model still triggers a clear "XPU not yet supported" error, ensuring the issue is not masked.

**Test**
pytest tests/model_executor/layers/test_mla_short_prefill_indexer.py
8 passed