### PR TITLE
[XPU] [AsyncTP] Support AsyncTP collective fusion on XPU for FP8 block quant models

### DIFF
--- a/.buildkite/intel_jobs/test-intel.yaml
+++ b/.buildkite/intel_jobs/test-intel.yaml
@@ -252,3 +252,31 @@ steps:
         bash .buildkite/scripts/hardware_ci/run-intel-test.sh
         'cd tests &&
         pytest -v -s compile/passes/distributed/test_sequence_parallelism.py::test_sequence_parallelism_pass_block_fp8'
+
+  - label: "XPU AsyncTP compile passes"
+    depends_on:
+      - image-build-xpu
+    timeout_in_minutes: 60
+    device: intel_gpu
+    agent_tags:
+      label: production
+      gpu: 2+
+      mem: 24+
+    no_plugin: true
+    env:
+      REGISTRY: "public.ecr.aws/q9t5s3a7"
+      REPO: "vllm-ci-test-repo"
+      VLLM_TEST_DEVICE: "xpu"
+    source_file_dependencies:
+      - vllm/compilation/
+      - vllm/model_executor/layers/quantization/
+      - tests/compile/passes/distributed/test_async_tp.py
+      - tests/compile/correctness_e2e/test_async_tp.py
+      - tests/utils.py
+      - .buildkite/intel_jobs/test-intel.yaml
+    commands:
+      - >-
+        bash .buildkite/scripts/hardware_ci/run-intel-test.sh
+        'cd tests &&
+        pytest -v -s compile/passes/distributed/test_async_tp.py::test_async_tp_pass_replace_xpu_block_fp8 &&
+        pytest -v -s compile/correctness_e2e/test_async_tp.py::test_async_tp_pass_xpu_block_fp8_correctness'

--- a/.buildkite/intel_jobs/test-intel.yaml
+++ b/.buildkite/intel_jobs/test-intel.yaml
@@ -227,3 +227,28 @@ steps:
         python3 examples/basic/offline_inference/generate.py --model INCModel/Qwen3-30B-A3B-Instruct-2507-MXFP4-CT-AutoRound --max-model-len 4096'
       # Temporarily disabled (multi-GPU/MXFP8 not yet supported with XPU Graph):
       # python3 examples/basic/offline_inference/generate.py --model INCModel/Qwen3-30B-A3B-Instruct-2507-MXFP8-CT-AutoRound -tp 2 --max-model-len 4096
+  - label: "XPU compile distributed passes"
+    depends_on:
+      - image-build-xpu
+    timeout_in_minutes: 60
+    device: intel_gpu
+    agent_tags:
+      label: production
+      gpu: 2+
+      mem: 16+
+    no_plugin: true
+    env:
+      REGISTRY: "public.ecr.aws/q9t5s3a7"
+      REPO: "vllm-ci-test-repo"
+      VLLM_TEST_DEVICE: "xpu"
+    source_file_dependencies:
+      - vllm/compilation/
+      - vllm/model_executor/layers/quantization/
+      - tests/compile/passes/distributed/test_sequence_parallelism.py
+      - tests/utils.py
+      - .buildkite/intel_jobs/test-intel.yaml
+    commands:
+      - >-
+        bash .buildkite/scripts/hardware_ci/run-intel-test.sh
+        'cd tests &&
+        pytest -v -s compile/passes/distributed/test_sequence_parallelism.py::test_sequence_parallelism_pass_block_fp8'

--- a/tests/compile/correctness_e2e/test_async_tp.py
+++ b/tests/compile/correctness_e2e/test_async_tp.py
@@ -98,6 +98,82 @@ def test_async_tp_pass_correctness(
 
 
 @create_new_process_for_each_test()
+@pytest.mark.parametrize("model_id", ["RedHatAI/Qwen3-32B-FP8-block"])
+@pytest.mark.parametrize("tp_size", [2])
+@pytest.mark.parametrize("async_tp_enabled", [True])
+@pytest.mark.parametrize("distributed_backend", ["mp"])
+@pytest.mark.skipif(
+    not current_platform.is_xpu(),
+    reason="XPU block FP8 AsyncTP correctness only runs on XPU",
+)
+def test_async_tp_pass_xpu_block_fp8_correctness(
+    model_id: str,
+    tp_size: int,
+    async_tp_enabled: bool,
+    distributed_backend: str,
+    num_gpus_available: int,
+    monkeypatch,
+):
+    model_info = HF_EXAMPLE_MODELS.find_hf_info(model_id)
+    model_info.check_transformers_version(on_fail="skip")
+    model_info.check_available_online(on_fail="skip")
+
+    pp_size = 1
+    if num_gpus_available < tp_size:
+        pytest.skip(f"Need at least {tp_size} x {pp_size} GPUs")
+
+    common_args = [
+        "--dtype",
+        "bfloat16",
+        "--max-model-len",
+        "2048",
+        "--max-num-seqs",
+        "8",
+    ]
+
+    compilation_config = {
+        "mode": CompilationMode.VLLM_COMPILE,
+        "compile_sizes": [2, 4, 8],
+        "splitting_ops": [],
+        "pass_config": {
+            "enable_sp": True,
+            "fuse_gemm_comms": async_tp_enabled,
+            # Qwen3-32B's hidden_size clears the SP heuristic's minimum, but
+            # actual test prompts are far shorter than the resulting token
+            # threshold. Force sp_min_token_num=1 so the block FP8 AsyncTP
+            # all-gather pattern actually fires for these small requests.
+            "sp_min_token_num": 1,
+        },
+    }
+
+    async_tp_args = [
+        *common_args,
+        "--tensor-parallel-size",
+        str(tp_size),
+        "--distributed-executor-backend",
+        distributed_backend,
+        "--compilation_config",
+        json.dumps(compilation_config),
+    ]
+
+    tp_args = [
+        *common_args,
+        "--tensor-parallel-size",
+        str(tp_size),
+        "--distributed-executor-backend",
+        "mp",
+    ]
+
+    compare_two_settings(
+        model_id,
+        async_tp_args,
+        tp_args,
+        method="generate",
+        force_v1_runner=True,
+    )
+
+
+@create_new_process_for_each_test()
 def test_async_tp_pass_nvfp4_correctness(num_gpus_available: int):
     if (
         not current_platform.is_cuda()

--- a/tests/compile/passes/distributed/test_async_tp.py
+++ b/tests/compile/passes/distributed/test_async_tp.py
@@ -227,7 +227,193 @@ class TestAGCutlassScaledMMModel(_BaseScaledMMModel):
         return [torch.ops.symm_mem.fused_all_gather_scaled_matmul.default]
 
 
+class TestXPUFp8GEMMRSModel(_BaseScaledMMModel):
+    def forward(self, input: torch.Tensor):
+        """
+        Forward pass implementing the scaled_mm + reduce scatter in the FX graph
+
+        """
+        fp8_input = input.to(FP8_DTYPE)
+        scale_a = torch.ones(input.shape[0], 1, dtype=torch.float32)
+        scaled_mm = torch.ops._xpu_C.fp8_gemm(
+            fp8_input, self.weight, self.dtype, scale_a, self.scale_b, None
+        )
+        reduce_scatter = tensor_model_parallel_reduce_scatter(scaled_mm, dim=0)
+        return reduce_scatter
+
+    def ops_in_model_before(self):
+        return [torch.ops.vllm.reduce_scatter.default]
+
+    def ops_in_model_after(self):
+        return [torch.ops.vllm.fused_xpu_fp8_matmul_reduce_scatter.default]
+
+
+class TestAGXPUFp8GEMMModel(_BaseScaledMMModel):
+    """XPU scaled_mm/xpu.py W8A8 all_gather(fp8, scale) + fp8_gemm."""
+
+    def forward(self, input: torch.Tensor):
+        """
+        Forward pass implementing the all gather + scaled_mm in the FX graph
+        """
+        # Reshape input
+        fp8_input = input.to(FP8_DTYPE)
+        all_gather = tensor_model_parallel_all_gather(fp8_input, dim=0)
+
+        scale_a = torch.ones(all_gather.shape[0], 1, dtype=torch.float32)
+        fp8_gemm = torch.ops._xpu_C.fp8_gemm(
+            all_gather, self.weight, self.dtype, scale_a, self.scale_b, None
+        )
+        return fp8_gemm
+
+    def ops_in_model_before(self):
+        return [torch.ops.vllm.all_gather.default]
+
+    def ops_in_model_after(self):
+        return [torch.ops.vllm.fused_all_gather_xpu_fp8_matmul.default]
+
+
+class TestAGXPUBlockFp8GEMMModel(torch.nn.Module):
+    """XPU BlockScaledMMLinearKernel.xpu.py all_gather(quant, scale) + fp8_gemm.
+
+    Block FP8 activation quant is always dynamic per-token-group (group
+    size 128), so both the fp8 activation and its block-scale are produced
+    locally per TP shard and must be all-gathered together before the GEMM.
+    """
+
+    GROUP_SIZE = 128
+
+    def __init__(self, hidden_size=128, dtype=torch.bfloat16):
+        super().__init__()
+        self.hidden_size = hidden_size
+        self.dtype = dtype
+        n_blocks = -(-hidden_size // self.GROUP_SIZE)
+        k_blocks = -(-hidden_size // self.GROUP_SIZE)
+        # weight is kept as [N, K] (not pre-transposed), unlike the static
+        # per-tensor XPU kernel.
+        self.weight = torch.empty([hidden_size, hidden_size], dtype=FP8_DTYPE)
+        # weight's block-scale, stored as [n_blocks, k_blocks] view.
+        self.weight_scale = torch.ones(n_blocks, k_blocks, dtype=torch.float32)
+
+    def forward(self, input: torch.Tensor):
+        from vllm.model_executor.layers.quantization.utils.fp8_utils import (
+            per_token_group_quant_fp8,
+        )
+
+        q_input, input_scale = per_token_group_quant_fp8(
+            input, group_size=self.GROUP_SIZE, dtype=FP8_DTYPE
+        )
+        all_gather_q = tensor_model_parallel_all_gather(q_input, dim=0)
+        all_gather_scale = tensor_model_parallel_all_gather(input_scale, dim=0)
+
+        fp8_gemm = torch.ops._xpu_C.fp8_gemm(
+            all_gather_q,
+            self.weight.t(),
+            self.dtype,
+            all_gather_scale,
+            self.weight_scale.t(),
+            torch.Tensor(),
+        )
+        return fp8_gemm
+
+    def ops_in_model_before(self):
+        return [torch.ops.vllm.all_gather.default]
+
+    def ops_in_model_after(self):
+        return [torch.ops.vllm.fused_all_gather_xpu_dynamic_scaled_fp8_matmul.default]
+
+
 @multi_gpu_test(num_gpus=2)
+@pytest.mark.parametrize(
+    "test_model",
+    [
+        TestXPUFp8GEMMRSModel,
+        TestAGXPUFp8GEMMModel,
+    ],
+)
+@pytest.mark.parametrize("batch_size", [8])
+@pytest.mark.parametrize("seq_len", [16])
+@pytest.mark.parametrize("hidden_size", [16])
+@pytest.mark.parametrize("dtype", [torch.bfloat16])
+@pytest.mark.parametrize("dynamic", [True, False])
+@pytest.mark.skipif(
+    envs.VLLM_TARGET_DEVICE not in ["xpu"],
+    reason="XPU FP8 AsyncTP patterns only run on XPU",
+)
+def test_async_tp_pass_replace_xpu_fp8(
+    test_model,
+    batch_size: int,
+    seq_len: int,
+    hidden_size: int,
+    dtype: torch.dtype,
+    dynamic: bool,
+):
+    """Test XPU static/dynamic FP8 GEMM + collective fusion patterns."""
+    num_processes = 2
+    distributed_init_method = get_file_store_init_method()
+    torch.multiprocessing.spawn(
+        async_tp_pass_on_test_model,
+        args=(
+            num_processes,
+            test_model,
+            batch_size,
+            seq_len,
+            hidden_size,
+            dtype,
+            dynamic,
+            distributed_init_method,
+        ),
+        nprocs=num_processes,
+    )
+
+
+@multi_gpu_test(num_gpus=2)
+@pytest.mark.parametrize(
+    "test_model",
+    [
+        TestAGXPUBlockFp8GEMMModel,
+    ],
+)
+@pytest.mark.parametrize("batch_size", [8])
+@pytest.mark.parametrize("seq_len", [16])
+# block quant requires hidden_size to be a multiple of the 128 group size
+@pytest.mark.parametrize("hidden_size", [128])
+@pytest.mark.parametrize("dtype", [torch.bfloat16])
+@pytest.mark.parametrize("dynamic", [True, False])
+@pytest.mark.skipif(
+    envs.VLLM_TARGET_DEVICE not in ["xpu"],
+    reason="XPU block FP8 AsyncTP patterns only run on XPU",
+)
+@pytest.mark.skipif(
+    not hasattr(torch.ops._C, "per_token_group_fp8_quant"),
+    reason="Requires per_token_group_fp8_quant",
+)
+def test_async_tp_pass_replace_xpu_block_fp8(
+    test_model,
+    batch_size: int,
+    seq_len: int,
+    hidden_size: int,
+    dtype: torch.dtype,
+    dynamic: bool,
+):
+    """Test XPU block FP8 GEMM + all_gather collective fusion pattern."""
+    num_processes = 2
+    distributed_init_method = get_file_store_init_method()
+    torch.multiprocessing.spawn(
+        async_tp_pass_on_test_model,
+        args=(
+            num_processes,
+            test_model,
+            batch_size,
+            seq_len,
+            hidden_size,
+            dtype,
+            dynamic,
+            distributed_init_method,
+        ),
+        nprocs=num_processes,
+    )
+
+
 @pytest.mark.parametrize(
     "test_model",
     [
@@ -333,6 +519,7 @@ def async_tp_pass_on_test_model(
 
     # initialize distributed
     init_distributed_environment(
+        backend=current_platform.dist_backend,
         world_size=world_size,
         rank=local_rank,
         distributed_init_method=distributed_init_method,

--- a/tests/compile/passes/distributed/test_sequence_parallelism.py
+++ b/tests/compile/passes/distributed/test_sequence_parallelism.py
@@ -30,6 +30,8 @@ from vllm.distributed.parallel_state import (
 )
 from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
+    kFp8Dynamic128Sym,
+    kFp8Static128BlockSym,
     kFp8StaticTensorSym,
 )
 from vllm.platforms import current_platform
@@ -161,6 +163,99 @@ class TestAllReduceRMSNormStaticQuantFP8Model(torch.nn.Module):
             ]
 
 
+class TestAllReduceRMSNormBlockQuantFP8Model(torch.nn.Module):
+    activation_quant_key = kFp8Dynamic128Sym
+    weight_quant_key = kFp8Static128BlockSym
+
+    def __init__(self, hidden_size=128, eps=1e-6):
+        super().__init__()
+        self.vllm_config = get_current_vllm_config()
+        self.hidden_size = hidden_size
+        self.eps = eps
+        self.norm = [RMSNorm(hidden_size, eps) for i in range(4)]
+        self.fp8_linear_layers = [
+            TestFP8Layer(
+                weight_shape=(hidden_size, hidden_size),
+                activation_quant_key=self.activation_quant_key,
+                weight_quant_key=self.weight_quant_key,
+                input_dtype=self.vllm_config.model_config.dtype,
+            )
+            for i in range(3)
+        ]
+
+    def forward(self, hidden_states):
+        # avoid having graph input be an arg to a pattern directly
+        z = torch.relu(hidden_states)
+        x = resid = tensor_model_parallel_all_reduce(z)
+        y = self.norm[0](x)
+
+        z2 = self.fp8_linear_layers[0](y)
+
+        x2 = tensor_model_parallel_all_reduce(z2)
+        y2, resid = self.norm[1](x2, resid)
+
+        z3 = self.fp8_linear_layers[1](y2)
+
+        x3 = tensor_model_parallel_all_reduce(z3)
+        y3, resid = self.norm[2](x3, resid)  # use resid here
+
+        z4 = self.fp8_linear_layers[2](y3)
+        x4 = tensor_model_parallel_all_reduce(z4)
+        y4, resid = self.norm[3](x4, resid)  # use resid here
+        return y4
+
+    def ops_in_model_after(self):
+        return [
+            torch.ops.vllm.all_gather.default,
+            torch.ops.vllm.reduce_scatter.default,
+        ]
+
+    def ops_count_after(self, op) -> int:
+        quant_enabled = any(
+            layer.is_quant_fp8_enabled() for layer in self.fp8_linear_layers
+        )
+        if op == torch.ops.vllm.all_gather.default:
+            if quant_enabled:
+                # 3 of the 4 layers' rms_norm outputs feed into block-FP8
+                # quant (quant + scale, each independently all_gather'd);
+                # the last layer's output (y4) is not quantized and matches
+                # the plain RMSNorm SP pattern (single all_gather).
+                # Total: 3*2 + 1*1 = 7.
+                return 7
+            # quant_fp8 CustomOp disabled: quantization decomposes into
+            # primitive ops instead of the fused per_token_group_fp8_quant
+            # op, so the block-FP8 SP pattern never matches; only the
+            # plain RMSNorm SP pattern matches (one all_gather per layer).
+            return 4
+        return 4
+
+    def ops_in_model_before(self):
+        return [
+            torch.ops.vllm.all_reduce.default,
+        ]
+
+    def ops_in_model(self):
+        quant_enabled = any(
+            layer.is_quant_fp8_enabled() for layer in self.fp8_linear_layers
+        )
+        if (
+            quant_enabled
+            and self.vllm_config.compilation_config.pass_config.fuse_norm_quant
+            and hasattr(torch.ops._C, "rms_norm_per_block_quant")
+        ):
+            return [torch.ops._C.rms_norm_per_block_quant.default]
+        quant_ops = (
+            [torch.ops._C.per_token_group_fp8_quant.default]
+            if quant_enabled
+            else [torch.ops.aten.clamp_min]
+        )
+        return [
+            torch.ops.vllm_ir.rms_norm,
+            torch.ops.vllm_ir.fused_add_rms_norm,
+            *quant_ops,
+        ]
+
+
 @multi_gpu_test(num_gpus=2)
 @pytest.mark.parametrize(
     "test_model_cls, custom_ops",
@@ -181,6 +276,58 @@ class TestAllReduceRMSNormStaticQuantFP8Model(torch.nn.Module):
 @pytest.mark.parametrize("dynamic", [False, True])
 @pytest.mark.skipif(envs.VLLM_TARGET_DEVICE not in ["cuda"], reason="Only test on CUDA")
 def test_sequence_parallelism_pass(
+    test_model_cls: type[torch.nn.Module],
+    custom_ops: str,
+    batch_size: int,
+    seq_len: int,
+    hidden_size: int,
+    dtype: torch.dtype,
+    fuse_norm_quant: bool,
+    dynamic: bool,
+):
+    num_processes = 2
+
+    def run_torch_spawn(fn, nprocs):
+        # need to use torch.mp.spawn otherwise will have problems with
+        # torch.distributed and cuda
+        torch.multiprocessing.spawn(
+            fn,
+            args=(
+                num_processes,
+                test_model_cls,
+                custom_ops,
+                batch_size,
+                seq_len,
+                hidden_size,
+                dtype,
+                fuse_norm_quant,
+                dynamic,
+            ),
+            nprocs=nprocs,
+        )
+
+    run_torch_spawn(sequence_parallelism_pass_on_test_model, num_processes)
+
+
+@multi_gpu_test(num_gpus=2)
+@pytest.mark.parametrize(
+    "test_model_cls, custom_ops",
+    [
+        (TestAllReduceRMSNormBlockQuantFP8Model, "+rms_norm,+quant_fp8"),
+        (TestAllReduceRMSNormBlockQuantFP8Model, "+rms_norm,-quant_fp8"),
+        (TestAllReduceRMSNormBlockQuantFP8Model, "-rms_norm,+quant_fp8"),
+        (TestAllReduceRMSNormBlockQuantFP8Model, "-rms_norm,-quant_fp8"),
+    ],
+)
+@pytest.mark.parametrize("batch_size", [8])
+@pytest.mark.parametrize("seq_len", [16])
+# block quant requires hidden_size to be a multiple of the 128 group size
+@pytest.mark.parametrize("hidden_size", [128])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("fuse_norm_quant", [True, False])
+@pytest.mark.parametrize("dynamic", [False, True])
+@pytest.mark.skipif(envs.VLLM_TARGET_DEVICE not in ["xpu"], reason="Only test on XPU")
+def test_sequence_parallelism_pass_block_fp8(
     test_model_cls: type[torch.nn.Module],
     custom_ops: str,
     batch_size: int,
@@ -337,7 +484,10 @@ def sequence_parallelism_pass_on_test_model(
         # In post-nodes, reduce scatter and all gather should be there,
         # all reduce should not
         for op in model.ops_in_model_after():
-            assert backend.op_count(op, before=False) == 4
+            expected_count = (
+                model.ops_count_after(op) if hasattr(model, "ops_count_after") else 4
+            )
+            assert backend.op_count(op, before=False) == expected_count
 
         for op in model.ops_in_model():
             assert backend.op_count(op, before=False) > 0

--- a/tests/models/registry.py
+++ b/tests/models/registry.py
@@ -499,7 +499,10 @@ _TEXT_GENERATION_EXAMPLE_MODELS = {
         },
     ),
     "Qwen2MoeForCausalLM": _HfExamplesInfo("Qwen/Qwen1.5-MoE-A2.7B-Chat"),
-    "Qwen3ForCausalLM": _HfExamplesInfo("Qwen/Qwen3-8B"),
+    "Qwen3ForCausalLM": _HfExamplesInfo(
+        "Qwen/Qwen3-8B",
+        extras={"fp8_block": "RedHatAI/Qwen3-32B-FP8-block"},
+    ),
     "Qwen3MoeForCausalLM": _HfExamplesInfo("Qwen/Qwen3-30B-A3B"),
     "Qwen3_5ForCausalLM": _HfExamplesInfo("codecho/Qwen3.5-0.8B-text-only"),
     "Qwen3_5MoeForCausalLM": _HfExamplesInfo(

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -2348,9 +2348,10 @@ class TestFP8Layer(torch.nn.Module):
         is_block_wise = act_scale_desc.group_shape.is_per_group()
         if is_block_wise:
             block_size = weight_scale_desc.group_shape.col
-            weight_scale_shape = weight_shape[0] // block_size
+            n_groups = -(-weight_shape[0] // block_size)  # ceil division
+            k_groups = -(-weight_shape[1] // block_size)  # ceil division
             self.weight_scale_inv = torch.rand(
-                (weight_scale_shape, weight_scale_shape),
+                (n_groups, k_groups),
                 dtype=torch.float32,
                 device=device,
             )

--- a/vllm/_xpu_ops.py
+++ b/vllm/_xpu_ops.py
@@ -42,6 +42,21 @@ if hasattr(torch.ops._xpu_C, "fp8_gemm"):
         return torch.empty((M, N), dtype=out_dtype, device=q_input.device)
 
 
+if hasattr(torch.ops._xpu_C, "fp8_gemm_out"):
+
+    @register_fake("_xpu_C::fp8_gemm_out")
+    def _fp8_gemm_out_fake(
+        out: torch.Tensor,
+        q_input: torch.Tensor,
+        q_weight: torch.Tensor,
+        out_dtype: torch.dtype,
+        input_scales: torch.Tensor,
+        weight_scale: torch.Tensor,
+        bias: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        return out
+
+
 if hasattr(torch.ops._xpu_C, "fp8_gemm_w8a16"):
 
     @register_fake("_xpu_C::fp8_gemm_w8a16")

--- a/vllm/compilation/passes/fusion/collective_fusion.py
+++ b/vllm/compilation/passes/fusion/collective_fusion.py
@@ -330,6 +330,304 @@ direct_register_custom_op(
 )
 
 
+def _to_scaled_mm_scales(
+    m: int, n: int, scale_a: torch.Tensor, scale_b: torch.Tensor
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Normalize fp8_gemm's scale shapes to what torch._scaled_mm expects.
+
+    fp8_gemm accepts scale_a as a singleton (per-tensor), [M, 1] (per-token),
+    or [M, k_blocks] (block-quantized); scale_b as a singleton, [N] or [1, N]
+    (per-channel), or [k_blocks, n_blocks] (block-quantized). Block-quantized
+    scales are already in the [M, k_blocks] / [k_blocks, n_blocks] layout
+    torch._scaled_mm's BlockWise mode expects, so they pass through as-is.
+    torch._scaled_mm additionally requires TensorWise scales to be singletons
+    on *both* sides, so a per-tensor scale on one operand is broadcast to
+    match a per-token/per-channel scale on the other.
+    """
+    a_blockwise = scale_a.dim() >= 2 and scale_a.shape[-1] > 1
+    b_blockwise = scale_b.dim() >= 2 and scale_b.shape[0] > 1
+    if a_blockwise or b_blockwise:
+        # Callers store block scales pre-made contiguous in this exact
+        # layout (see XPUFp8BlockScaledMMKernel/XPUMxFp8LinearKernel
+        # process_weights_after_loading), so no copy is needed here.
+        return scale_a, scale_b
+
+    a_scalar = scale_a.numel() == 1
+    b_scalar = scale_b.numel() == 1
+    if a_scalar and b_scalar:
+        return scale_a.reshape(1), scale_b.reshape(1, 1)
+    # expand() produces a stride-0 view, which torch._scaled_mm rejects for
+    # RowWise scales ("both should be contiguous"), so .contiguous() here
+    # is required, unlike the pre-contiguous block scales above.
+    scale_a = (
+        scale_a.reshape(-1, 1) if not a_scalar else scale_a.expand(m, 1).contiguous()
+    )
+    scale_b = (
+        scale_b.reshape(1, -1)
+        if not b_scalar
+        else scale_b.expand(n).reshape(1, n).contiguous()
+    )
+    return scale_a, scale_b
+
+
+def _xpu_fp8_mm_out(
+    A: torch.Tensor,
+    B: torch.Tensor,
+    *,
+    scale_a: torch.Tensor,
+    scale_b: torch.Tensor,
+    out: torch.Tensor,
+    bias: torch.Tensor | None = None,
+) -> None:
+    """FP8 GEMM used by the XPU AsyncTP fusions.
+
+    Prefers torch._scaled_mm (upstream native op; dispatches to TensorWise,
+    RowWise, or BlockWise-128x128 internally based on scale shape) and falls
+    back to the oneDNN _xpu_C.fp8_gemm[_out] custom op for scale
+    configurations it doesn't support -- currently MXFP8 (float8_e8m0fnu
+    scales with 32-element groups; torch._scaled_mm's BlockWise mode only
+    supports 128-element groups).
+    """
+    if scale_a.dtype != torch.float8_e8m0fnu:
+        # TODO: once torch._scaled_mm's BlockWise mode supports 32-element
+        # groups (currently hardcoded to 128), drop this dtype check and let
+        # MXFP8 go through the same torch._scaled_mm attempt below instead of
+        # skipping straight to the oneDNN fallback.
+        scale_a_mm, scale_b_mm = _to_scaled_mm_scales(
+            A.shape[0], B.shape[1], scale_a, scale_b
+        )
+        # The block-FP8 path applies bias outside the GEMM and passes an
+        # empty placeholder tensor here (created without a device, so it
+        # lands on CPU). oneDNN's fp8_gemm ignores it based on numel(), but
+        # torch._scaled_mm's device check runs before that, so normalize an
+        # empty bias to None -- which is the correct "no bias" spelling.
+        bias_mm = bias if bias is not None and bias.numel() > 0 else None
+        try:
+            torch._scaled_mm(
+                A,
+                B,
+                scale_a=scale_a_mm,
+                scale_b=scale_b_mm,
+                bias=bias_mm,
+                out_dtype=out.dtype,
+                out=out,
+            )
+            return
+        except RuntimeError as e:
+            # Pass str(e), not the exception object itself: warning_once
+            # dedupes via an lru_cache keyed on (msg, *args), and each
+            # exception instance has a distinct identity/hash, so passing
+            # the object would defeat the "once" behavior and spam a
+            # warning on every call.
+            logger.warning_once(
+                "torch._scaled_mm rejected this FP8 scale configuration "
+                "(%s); falling back to _xpu_C.fp8_gemm_out.",
+                str(e),
+            )
+    if hasattr(torch.ops._xpu_C, "fp8_gemm_out"):
+        torch.ops._xpu_C.fp8_gemm_out(out, A, B, None, scale_a, scale_b, bias)
+    else:
+        # Some vllm_xpu_kernels builds only ship the non-"_out" variant.
+        # Fall back to it and copy into `out` to preserve the in-place
+        # contract that callers (e.g. symmetric-memory pipelined
+        # all-gather/reduce-scatter) rely on.
+        out.copy_(torch.ops._xpu_C.fp8_gemm(A, B, out.dtype, scale_a, scale_b, bias))
+
+
+def fused_xpu_fp8_matmul_reduce_scatter_fake(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    input_scale: torch.Tensor,
+    weight_scale: torch.Tensor,
+    reduce_op: str,
+    orig_scatter_dim: int,
+    scatter_dim_after_maybe_reshape: int,
+    group_name: str,
+    output_shape: list[int],
+    out_dtype: torch.dtype | None = None,
+) -> torch.Tensor:
+    world_size = c10d._resolve_process_group(group_name).size()
+    result_shape = list(output_shape)
+    result_shape[orig_scatter_dim] //= world_size
+    return torch.empty(result_shape, dtype=out_dtype or torch.bfloat16, device=x.device)
+
+
+def fused_xpu_fp8_matmul_reduce_scatter(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    input_scale: torch.Tensor,
+    weight_scale: torch.Tensor,
+    reduce_op: str,
+    orig_scatter_dim: int,
+    scatter_dim_after_maybe_reshape: int,
+    group_name: str,
+    output_shape: list[int],
+    out_dtype: torch.dtype | None = None,
+) -> torch.Tensor:
+    return torch.distributed._symmetric_memory._fused_scaled_matmul_reduce_scatter_impl(
+        mm_out_op=_xpu_fp8_mm_out,
+        A=x,
+        B=weight,
+        A_scale=input_scale,
+        kwargs={
+            "scale_b": weight_scale,
+            "bias": None,
+        },
+        out_dtype=out_dtype,
+        reduce_op=reduce_op,
+        orig_scatter_dim=orig_scatter_dim,
+        scatter_dim_after_maybe_reshape=scatter_dim_after_maybe_reshape,
+        group_name=group_name,
+        output_shape=output_shape,
+    )
+
+
+def fused_all_gather_xpu_fp8_matmul_fake(
+    A_shard: torch.Tensor,
+    B: torch.Tensor,
+    A_scale: torch.Tensor,
+    B_scale: torch.Tensor,
+    gather_dim: int,
+    group_name: str,
+    out_dtype: torch.dtype | None = None,
+) -> torch.Tensor:
+    world_size = c10d._resolve_process_group(group_name).size()
+    output_shape = list(A_shard.shape)
+    output_shape[gather_dim] *= world_size
+    output_shape[-1] = B.shape[1]
+    return torch.empty(
+        output_shape, dtype=out_dtype or torch.bfloat16, device=A_shard.device
+    )
+
+
+def fused_all_gather_xpu_fp8_matmul(
+    A_shard: torch.Tensor,
+    B: torch.Tensor,
+    A_scale: torch.Tensor,
+    B_scale: torch.Tensor,
+    gather_dim: int,
+    group_name: str,
+    out_dtype: torch.dtype | None = None,
+) -> torch.Tensor:
+    _, outputs = torch.distributed._symmetric_memory._fused_all_gather_matmul_impl(
+        mm_out_op=_xpu_fp8_mm_out,
+        A_shard=A_shard,
+        Bs=[B],
+        A_scale=A_scale,
+        kwargs_list=[
+            {
+                "scale_b": B_scale,
+                "bias": None,
+            }
+        ],
+        out_dtypes=[out_dtype],
+        gather_dim=gather_dim,
+        group_name=group_name,
+        return_A=False,
+    )
+    return outputs[0]
+
+
+direct_register_custom_op(
+    op_name="fused_xpu_fp8_matmul_reduce_scatter",
+    op_func=fused_xpu_fp8_matmul_reduce_scatter,
+    fake_impl=fused_xpu_fp8_matmul_reduce_scatter_fake,
+)
+
+direct_register_custom_op(
+    op_name="fused_all_gather_xpu_fp8_matmul",
+    op_func=fused_all_gather_xpu_fp8_matmul,
+    fake_impl=fused_all_gather_xpu_fp8_matmul_fake,
+)
+
+
+def fused_all_gather_xpu_dynamic_scaled_fp8_matmul_fake(
+    A_shard: torch.Tensor,
+    B: torch.Tensor,
+    A_scale_shard: torch.Tensor,
+    B_scale: torch.Tensor,
+    bias: torch.Tensor | None,
+    gather_dim: int,
+    group_name: str,
+    out_dtype: torch.dtype | None = None,
+) -> torch.Tensor:
+    world_size = c10d._resolve_process_group(group_name).size()
+    output_shape = list(A_shard.shape)
+    output_shape[gather_dim] *= world_size
+    # B is [N, K] (block kernel does not pre-transpose the weight).
+    output_shape[-1] = B.shape[0]
+    return torch.empty(
+        output_shape, dtype=out_dtype or torch.bfloat16, device=A_shard.device
+    )
+
+
+def fused_all_gather_xpu_dynamic_scaled_fp8_matmul(
+    A_shard: torch.Tensor,
+    B: torch.Tensor,
+    A_scale_shard: torch.Tensor,
+    B_scale: torch.Tensor,
+    bias: torch.Tensor | None,
+    gather_dim: int,
+    group_name: str,
+    out_dtype: torch.dtype | None = None,
+) -> torch.Tensor:
+    # Dynamically-scaled FP8 activation quantization (per-token-group block
+    # FP8 with fp32 scales, or MXFP8 with e8m0 scales) computes the scale on
+    # each TP rank, so both the fp8 activation shard AND its scale shard must
+    # be all-gathered together before the GEMM (mirrors FlashInfer's FP4
+    # all-gather, which also jointly gathers data and scale). The scales are
+    # passed through untouched, so this op is agnostic to group size and
+    # scale dtype.
+    assert gather_dim == 0, (
+        "XPU dynamically-scaled FP8 async TP only supports gather_dim=0"
+    )
+    group = c10d._resolve_process_group(group_name)
+    world_size = group.size()
+    output = A_shard.new_empty(
+        A_shard.shape[0] * world_size,
+        B.shape[0],
+        dtype=out_dtype or torch.bfloat16,
+    )
+    output_shards = output.chunk(world_size)
+
+    A = A_shard.new_empty(A_shard.shape[0] * world_size, A_shard.shape[1])
+    A_scale = A_scale_shard.new_empty(
+        A_scale_shard.shape[0] * world_size,
+        A_scale_shard.shape[1],
+    )
+
+    def shard_consumer(shards: list[torch.Tensor], rank: int) -> None:
+        # B is [N, K]; .t() gives [K, N] view (no copy). B_scale is stored as
+        # an [n_blocks, k_blocks] view; .t() recovers the contiguous
+        # [k_blocks, n_blocks] buffer oneDNN expects (see
+        # XPUFp8BlockScaledMMKernel.apply_block_scaled_mm and
+        # XPUMxFp8LinearKernel.apply_weights).
+        _xpu_fp8_mm_out(
+            shards[0],
+            B.t(),
+            scale_a=shards[1],
+            scale_b=B_scale.t(),
+            out=output_shards[rank],
+            bias=bias,
+        )
+
+    torch.distributed._symmetric_memory._pipelined_multi_all_gather_and_consume(
+        [A_shard, A_scale_shard],
+        shard_consumer,
+        [A, A_scale],
+        group_name,
+        False,
+    )
+    return output
+
+
+direct_register_custom_op(
+    op_name="fused_all_gather_xpu_dynamic_scaled_fp8_matmul",
+    op_func=fused_all_gather_xpu_dynamic_scaled_fp8_matmul,
+    fake_impl=fused_all_gather_xpu_dynamic_scaled_fp8_matmul_fake,
+)
+
+
 class BasePattern:
     def __init__(self, dtype: torch.dtype, device: str | None) -> None:
         self.dtype = dtype
@@ -677,6 +975,196 @@ class AllGatherCutlassScaledMMPattern(BasePattern):
         )
 
 
+class XPUFp8GEMMReduceScatterPattern(BasePattern):
+    def get_inputs(self) -> list[torch.Tensor]:
+        input = torch.empty([16, 16], device=self.device, dtype=FP8_DTYPE)
+        mm_weight = torch.empty([16, 16], device=self.device, dtype=FP8_DTYPE)
+        scale_a = torch.empty([16, 1], device=self.device, dtype=torch.float32)
+        scale_b = torch.empty([1, 16], device=self.device, dtype=torch.float32)
+        return [input, mm_weight, scale_a, scale_b]
+
+    def register(self, pm_pass: PatternMatcherPass) -> None:
+        def pattern(
+            x: torch.Tensor,
+            weight: torch.Tensor,
+            input_scale: torch.Tensor,
+            weight_scale: torch.Tensor,
+        ) -> torch.Tensor:
+            fp8_gemm = torch.ops._xpu_C.fp8_gemm.default(
+                A=x,
+                B=weight,
+                out_dtype=self.dtype,
+                A_scale_=input_scale,
+                B_scale_=weight_scale,
+                bias_=None,
+            )
+            return torch.ops.vllm.reduce_scatter.default(
+                fp8_gemm,
+                dim=0,
+                world_size=self.tp_size,
+                group_name=self.tp.unique_name,
+            )
+
+        def replacement(
+            input: torch.Tensor,
+            mat2: torch.Tensor,
+            scale_a: torch.Tensor,
+            scale_b: torch.Tensor,
+        ) -> torch.Tensor:
+            output_shape = [*input.shape[:-1], mat2.shape[1]]
+            scatter_dim = 0
+            return torch.ops.vllm.fused_xpu_fp8_matmul_reduce_scatter.default(  # noqa
+                input,
+                mat2,
+                scale_a,
+                scale_b,
+                "sum",
+                scatter_dim,
+                scatter_dim,
+                self.tp.device_group.group_name,
+                output_shape,
+                self.dtype,
+            )
+
+        pm.register_replacement(
+            pattern, replacement, self.get_inputs(), pm.fwd_only, pm_pass
+        )
+
+
+class AllGatherXPUFp8GEMMPattern(BasePattern):
+    def get_inputs(self) -> list[torch.Tensor]:
+        x = torch.empty([8, 16], device=self.device, dtype=FP8_DTYPE)
+        # XPU weights are row_major (contiguous), unlike CUDA col_major.
+        weight = torch.empty([16, 16], device=self.device, dtype=FP8_DTYPE)
+        scale_a = torch.empty([8, 1], device=self.device, dtype=torch.float32)
+        scale_b = torch.empty([1, 16], device=self.device, dtype=torch.float32)
+        return [x, weight, scale_a, scale_b]
+
+    def register(self, pm_pass: PatternMatcherPass) -> None:
+        def pattern(
+            x: torch.Tensor,
+            weight: torch.Tensor,
+            scale_a: torch.Tensor,
+            scale_b: torch.Tensor,
+        ) -> torch.Tensor:
+            all_gather = torch.ops.vllm.all_gather.default(
+                x, dim=0, world_size=self.tp_size, group_name=self.tp.unique_name
+            )
+            fp8_gemm = torch.ops._xpu_C.fp8_gemm.default(
+                A=all_gather,
+                B=weight,
+                out_dtype=self.dtype,
+                A_scale_=scale_a,
+                B_scale_=scale_b,
+                bias_=None,
+            )
+            return fp8_gemm
+
+        def replacement(
+            x: torch.Tensor,
+            weight: torch.Tensor,
+            scale_a: torch.Tensor,
+            scale_b: torch.Tensor,
+        ) -> torch.Tensor:
+            return torch.ops.vllm.fused_all_gather_xpu_fp8_matmul.default(  # noqa
+                x,
+                weight,
+                scale_a,
+                scale_b,
+                0,
+                self.tp.device_group.group_name,
+                self.dtype,
+            )
+
+        pm.register_replacement(
+            pattern, replacement, self.get_inputs(), pm.fwd_only, pm_pass
+        )
+
+
+class AllGatherXPUDynamicScaledFp8GEMMPattern(BasePattern):
+    """All-gather + dynamically-scaled FP8 GEMM fusion for XPU.
+
+    A single pattern covers both dynamic FP8 activation quant schemes on XPU:
+    block FP8 (fp32 scales, group size 128) and MXFP8 (e8m0 scales, group size
+    32). Both quantize per token group on each TP rank, so both all-gather the
+    activation and its scale before calling `_xpu_C.fp8_gemm`, producing the
+    same subgraph. Everything that differs between them -- scale dtype, group
+    size (hence scale shape), and the bias spelling -- is a tensor argument,
+    and tensor arguments match as wildcards, so none of it takes part in
+    matching. The example inputs below therefore only need to be
+    self-consistent, and the fused op forwards scales and bias untouched.
+    """
+
+    def get_inputs(self) -> list[torch.Tensor]:
+        m, n, k, group_size = 8, 16, 128, 128
+        x = torch.empty([m, k], device=self.device, dtype=FP8_DTYPE)
+        # Weight is kept as [N, K] (not pre-transposed), unlike the static
+        # per-tensor XPU kernel.
+        weight = torch.empty([n, k], device=self.device, dtype=FP8_DTYPE)
+        # x's scale: one value per group -> [M, k_groups].
+        scale_a = torch.empty(
+            [m, k // group_size], device=self.device, dtype=torch.float32
+        )
+        # weight's scale, stored as an [n_groups, k_groups] view.
+        scale_b = torch.empty(
+            [1, k // group_size], device=self.device, dtype=torch.float32
+        )
+        # Matching the bias as a wildcard rather than a literal is what lets
+        # one pattern serve both schemes: block FP8 adds the bias outside the
+        # GEMM and always passes an empty tensor here, while MXFP8 passes the
+        # layer bias (None when absent) straight into the GEMM.
+        bias = torch.empty([n], device=self.device, dtype=self.dtype)
+        return [x, weight, scale_a, scale_b, bias]
+
+    def register(self, pm_pass: PatternMatcherPass) -> None:
+        def pattern(
+            x: torch.Tensor,
+            weight: torch.Tensor,
+            scale_a: torch.Tensor,
+            scale_b: torch.Tensor,
+            bias: torch.Tensor,
+        ) -> torch.Tensor:
+            all_gather_x = torch.ops.vllm.all_gather.default(
+                x, dim=0, world_size=self.tp_size, group_name=self.tp.unique_name
+            )
+            all_gather_scale = torch.ops.vllm.all_gather.default(
+                scale_a, dim=0, world_size=self.tp_size, group_name=self.tp.unique_name
+            )
+            fp8_gemm = torch.ops._xpu_C.fp8_gemm.default(
+                A=all_gather_x,
+                B=weight.t(),
+                out_dtype=self.dtype,
+                A_scale_=all_gather_scale,
+                B_scale_=scale_b.t(),
+                bias_=bias,
+            )
+            return fp8_gemm
+
+        def replacement(
+            x: torch.Tensor,
+            weight: torch.Tensor,
+            scale_a: torch.Tensor,
+            scale_b: torch.Tensor,
+            bias: torch.Tensor,
+        ) -> torch.Tensor:
+            return (
+                torch.ops.vllm.fused_all_gather_xpu_dynamic_scaled_fp8_matmul.default(  # noqa
+                    x,
+                    weight,
+                    scale_a,
+                    scale_b,
+                    bias,
+                    0,
+                    self.tp.device_group.group_name,
+                    self.dtype,
+                )
+            )
+
+        pm.register_replacement(
+            pattern, replacement, self.get_inputs(), pm.fwd_only, pm_pass
+        )
+
+
 class FlashInferBMMFP8ReduceScatterPattern(
     BasePattern, VllmPatternReplacement[..., torch.Tensor]
 ):
@@ -917,7 +1405,9 @@ class AsyncTPPass(VllmFusionPatternMatcherPass):
             AllGatherScaledMMPattern(self.model_dtype, self.device).register(
                 self.pm_pass
             )
-            if hasattr(torch.ops._C, "cutlass_scaled_mm"):
+            if current_platform.is_cuda() and hasattr(
+                torch.ops._C, "cutlass_scaled_mm"
+            ):
                 CutlassScaledMMReduceScatterPattern(
                     self.model_dtype, self.device
                 ).register(self.pm_pass)
@@ -971,6 +1461,24 @@ class AsyncTPPass(VllmFusionPatternMatcherPass):
                 # path; reduce-scatter needs a dedicated FP4 producer rather
                 # than the existing FP8-style helper.
 
+            if current_platform.is_xpu():
+                XPUFp8GEMMReduceScatterPattern(self.model_dtype, self.device).register(
+                    self.pm_pass
+                )
+                # Must be registered before AllGatherXPUFp8GEMMPattern: the
+                # static pattern matches A_scale_/B/B_scale_ as bare
+                # wildcards, so it also matches the dynamically-scaled graph
+                # and would replace it with the static op, which does not
+                # all-gather the activation scale. The reverse cannot happen
+                # (this pattern requires A_scale_ to be an all_gather node),
+                # so registration order alone resolves the overlap.
+                AllGatherXPUDynamicScaledFp8GEMMPattern(
+                    self.model_dtype, self.device
+                ).register(self.pm_pass)
+                AllGatherXPUFp8GEMMPattern(self.model_dtype, self.device).register(
+                    self.pm_pass
+                )
+
         self.dump_patterns(config, self.pm_pass)
 
     def is_applicable_for_range(self, compile_range: Range) -> bool:
@@ -986,4 +1494,4 @@ class AsyncTPPass(VllmFusionPatternMatcherPass):
     def __call__(self, graph: fx.Graph) -> None:
         self.matched_count = self.pm_pass.apply(graph)
         VllmPatternMatcherPass.match_table[self.pass_name] += self.matched_count
-        logger.debug("Replaced %s patterns", self.matched_count)
+        logger.info("Replaced %s patterns", self.matched_count)

--- a/vllm/compilation/passes/fusion/sequence_parallelism.py
+++ b/vllm/compilation/passes/fusion/sequence_parallelism.py
@@ -21,6 +21,7 @@ from vllm.distributed.parallel_state import (
 )
 from vllm.logger import init_logger
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
+    kFp8Dynamic128Sym,
     kFp8StaticTensorSym,
 )
 
@@ -372,6 +373,103 @@ class MiddleAllReduceRMSNormStaticFP8Pattern(_SequenceParallelPatternHelper):
         )
 
 
+class FirstAllReduceRMSNormBlockFP8Pattern(_SequenceParallelPatternHelper):
+    def __init__(
+        self,
+        epsilon: float,
+        dtype: torch.dtype,
+        device: str | None,
+    ) -> None:
+        super().__init__(epsilon, dtype, device)
+        self.quant_matcher = MatcherQuantFP8(kFp8Dynamic128Sym)
+
+    def get_inputs(self) -> list[torch.Tensor]:
+        return [self.empty([1, 8, 128]), self.empty([128])]
+
+    def register(self, pm_pass: PatternMatcherPass) -> None:
+        def pattern(
+            input: torch.Tensor,
+            weight: torch.Tensor,
+        ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+            all_reduce = self._all_reduce(input)
+            rms = vllm.ir.ops.rms_norm(all_reduce, weight, self.epsilon)
+            quant, scale = self.quant_matcher(rms)
+            return rms, all_reduce, quant, scale
+
+        def replacement(
+            input: torch.Tensor,
+            weight: torch.Tensor,
+        ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+            reduce_scatter = self._reduce_scatter(input)
+            rms = vllm.ir.ops.rms_norm(reduce_scatter, weight, self.epsilon)
+            quant, scale = self.quant_matcher(rms)
+            return (
+                rms,
+                reduce_scatter,
+                self._all_gather(quant),
+                self._all_gather(scale),
+            )
+
+        pm.register_replacement(
+            pattern, replacement, self.get_inputs(), pm.fwd_only, pm_pass
+        )
+
+
+class MiddleAllReduceRMSNormBlockFP8Pattern(_SequenceParallelPatternHelper):
+    def __init__(
+        self,
+        epsilon: float,
+        dtype: torch.dtype,
+        device: str | None,
+    ) -> None:
+        super().__init__(epsilon, dtype, device)
+        self.quant_matcher = MatcherQuantFP8(kFp8Dynamic128Sym)
+
+    def get_inputs(self) -> list[torch.Tensor]:
+        mm_1 = self.empty([8, 128])
+        residual = self.empty([8, 128])
+        rms_norm_weights = self.empty([128])
+        return [residual, mm_1, rms_norm_weights]
+
+    def register(self, pm_pass: PatternMatcherPass) -> None:
+        def pattern(
+            residual: torch.Tensor,
+            mm_1: torch.Tensor,
+            rms_norm_weights: torch.Tensor,
+        ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+            all_reduce = self._all_reduce(mm_1)
+            rms, residual_out = vllm.ir.ops.fused_add_rms_norm(
+                all_reduce, residual, rms_norm_weights, self.epsilon
+            )
+            quant, scale = self.quant_matcher(rms)
+            return rms, residual_out, quant, scale
+
+        def replacement(
+            residual: torch.Tensor,
+            mm_1: torch.Tensor,
+            rms_norm_weights: torch.Tensor,
+        ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+            reduce_scatter = self._reduce_scatter(mm_1)
+            local_len = reduce_scatter.size(0)
+            residual = residual[
+                self.tp_rank * local_len : self.tp_rank * local_len + local_len, ...
+            ]
+            rms, residual_out = vllm.ir.ops.fused_add_rms_norm(
+                reduce_scatter, residual, rms_norm_weights, self.epsilon
+            )
+            quant, scale = self.quant_matcher(rms)
+            return (
+                rms,
+                residual_out,
+                self._all_gather(quant),
+                self._all_gather(scale),
+            )
+
+        pm.register_replacement(
+            pattern, replacement, self.get_inputs(), pm.fwd_only, pm_pass
+        )
+
+
 class FirstAllReduceRMSNormStaticNVFP4Pattern(_SequenceParallelPatternHelper):
     def get_inputs(self) -> list[torch.Tensor]:
         input = self.empty([8, 16])
@@ -575,6 +673,14 @@ class SequenceParallelismPass(VllmPatternMatcherPass):
                     epsilon, self.model_dtype, self.device
                 ).register(self.patterns)
                 MiddleAllReduceRMSNormStaticNVFP4Pattern(
+                    epsilon, self.model_dtype, self.device
+                ).register(self.patterns)
+
+            if hasattr(torch.ops._C, "per_token_group_fp8_quant"):
+                FirstAllReduceRMSNormBlockFP8Pattern(
+                    epsilon, self.model_dtype, self.device
+                ).register(self.patterns)
+                MiddleAllReduceRMSNormBlockFP8Pattern(
                     epsilon, self.model_dtype, self.device
                 ).register(self.patterns)
 

--- a/vllm/compilation/passes/pass_manager.py
+++ b/vllm/compilation/passes/pass_manager.py
@@ -50,6 +50,8 @@ if current_platform.is_cuda_alike():
 
 if current_platform.is_cuda():
     from .fusion.allreduce_rms_fusion import AllReduceFusionPass
+
+if current_platform.is_cuda() or current_platform.is_xpu():
     from .fusion.collective_fusion import AsyncTPPass
 
 if current_platform.is_xpu():

--- a/vllm/platforms/xpu.py
+++ b/vllm/platforms/xpu.py
@@ -314,7 +314,6 @@ class XPUPlatform(Platform):
 
         pass_config = compilation_config.pass_config
         fusion_passes_to_disable = {
-            "fuse_gemm_comms": "Async TP",
             "fuse_allreduce_rms": "AllReduce + RMSNorm fusion",
             "fuse_attn_quant": "Attention + quant fusion",
             "fuse_act_padding": "Activation + padding fusion",


### PR DESCRIPTION
## Purpose

This PR extends AsyncTP (asynchronous tensor-parallel GEMM+collective fusion, originally added for per-channel static-scale FP8 in #52683) on XPU to **block-quantized** W8A8 FP8 GEMM (2D per-block `weight_scale_inv`, `block_structure=[128,128]`), on top of the existing block-FP8 sequence-parallelism (SP) support (#49009). Validated on `RedHatAI/Llama-3.1-8B-Instruct-FP8-block` with pure-prefill and mixed prefill+decode benchmarks (10 repeated runs per shape + significance testing) plus a GSM8K accuracy check.
 

## Test Setup

**Model**: `RedHatAI/Llama-3.1-8B-Instruct-FP8-block` (block W8A8 FP8, `block_structure=[128,128]`)
**Hardware**: 4× Intel Arc Pro B60 (`-tp 4`)
**SP threshold**: `(8 MiB × TP=4) / (hidden=4096 × 2 bytes)` = **4096 tokens**

Four arms are compared:

| Arm | `pass_config` | Purpose |
|---|---|---|
| `eager` | n/a (`--enforce-eager`) | no-compile baseline |
| `compile_nosp` | `{"enable_sp": false}` | plain-compile baseline, no SP, no AsyncTP |
| `asynctp_off` | `{"enable_sp": true}` | SP only (AsyncTP fusion off) |
| `asynctp_on` | `{"enable_sp": true, "fuse_gemm_comms": true}` | SP + AsyncTP |

### Server (replace `<PASS_CONFIG>` with one of the configs above)

```bash
python3 -m vllm.entrypoints.openai.api_server \
    --model RedHatAI/Llama-3.1-8B-Instruct-FP8-block \
    --trust-remote-code --dtype bfloat16 -tp 4 \
    --gpu-memory-util 0.9 \
    --max-num-batched-tokens 8192 --max-model-len 8192 \
    --no-enable-prefix-caching \
    --linear-backend xpu \
    --compilation-config '{"pass_config": <PASS_CONFIG>, "use_inductor_graph_partition": true}'
```

**Fusion-pass sanity check** (`server.log`, `Enabled custom fusions`):

| Arm | Logged fusions |
|---|---|
| `compile_nosp` | `norm_quant, act_quant` |
| `asynctp_off`  | `norm_quant, act_quant, sp` |
| `asynctp_on`   | `norm_quant, act_quant, sp, gemm_comms` |

This confirms `asynctp_off` isolates "SP only" from "SP + AsyncTP" (`asynctp_on`) as intended.

### Benchmark

```bash
python3 -m vllm.entrypoints.cli.main bench serve \
    --model RedHatAI/Llama-3.1-8B-Instruct-FP8-block \
    --dataset-name random \
    --random-input-len <IN> --random-output-len <OUT> \
    --num-prompt <N> \
    --request-rate inf --backend vllm \
    --ignore-eos --trust-remote-code --temperature 0
```

### Accuracy (GSM8K, 250 questions, 5-shot)

```bash
python3 -m lm_eval --model local-completions \
    --model_args "model=RedHatAI/Llama-3.1-8B-Instruct-FP8-block,base_url=http://localhost:8073/v1,tokenized_requests=False,num_concurrent=1" \
    --tasks gsm8k --num_fewshot 5 --limit 250
```

---

## Performance Results

### Pure prefill (`output_len=1`) — the regime where AsyncTP fires

These shapes push a single iteration's prefill token count past the 4096-token SP/AsyncTP threshold, so `fuse_gemm_comms` is active on (almost) every forward pass. Mean of 10 runs. `output_len=1` means there is no decode phase, so TPOT is not applicable here.

**Duration (s)**, lower is better:

| Shape | compile_nosp | asynctp_off | asynctp_on | Δ(on vs off) |
|---|---:|---:|---:|---:|
| 16 prompts × 4096 in | 9.11 | 8.25 | 7.75 | +6.1% |
| 16 prompts × 512 in  | 1.17 | 1.06 | 1.01 | +4.9% |
| 2 prompts × 4096 in  | 1.22 | 1.10 | 1.04 | +5.3% |

**Mean TTFT (ms)**, lower is better:

| Shape | compile_nosp | asynctp_off | asynctp_on | Δ(on vs off) |
|---|---:|---:|---:|---:|
| 16 prompts × 4096 in | 5121.10 | 4635.42 | 4358.36 | +6.0% |
| 16 prompts × 512 in  | 1097.29  | 996.52   | 942.25  | +5.4% |
| 2 prompts × 4096 in  | 930.29   | 835.03   | 793.89   | +4.9% |

**Output tok/s**, higher is better:

| Shape | compile_nosp | asynctp_off | asynctp_on | Δ(on vs off) |
|---|---:|---:|---:|---:|
| 16 prompts × 4096 in | 1.76  | 1.94  | 2.06  | +6.4% |
| 16 prompts × 512 in  | 13.71 | 15.10 | 15.89 | +5.2% |
| 2 prompts × 4096 in  | 1.64  | 1.82  | 1.92  | +5.5% |

(`Δ(on vs off)` isolates AsyncTP's own contribution on top of SP. Duration/TTFT: positive = `asynctp_on` faster; tok/s: positive = `asynctp_on` higher throughput. `compile_nosp` column is shown for reference — vs `compile_nosp`, the combined SP+AsyncTP gain is ~14–15% on Duration/TTFT and +15–18% on tok/s.)

Run-to-run std-dev is ≈0.1–1.5% of the mean here (large-batch prefill is compute-bound, so noise is much lower than in mixed workloads below), so these are clean, reproducible deltas, not noise. **SP alone captures +9–10% TTFT, and AsyncTP's GEMM-comm fusion adds a further, consistent +5–6% on top, for a combined ~14–15% TTFT/duration improvement and +15–18% output tok/s over `compile_nosp`.**

### Mixed prefill + decode

4 shapes covering prefill-heavy to decode-heavy workloads. Mean of 10 runs. `Δ(on vs off)` = relative change from `asynctp_off` to `asynctp_on`; for Duration/TTFT/TPOT positive % means `asynctp_on` is **faster** (less time), for tok/s positive % means `asynctp_on` is **higher throughput**.

**Duration (s)**, lower is better:

| Shape | compile_nosp | asynctp_off | asynctp_on | Δ(on vs off) |
|---|---:|---:|---:|---:|
| 32 prompts × 128 in × 64 out  | 2.12 | 2.05 | 2.02 | +1.6% |
| 16 prompts × 256 in × 128 out | 3.35 | 3.02 | 3.01 | +0.5% |
| 8 prompts × 512 in × 256 out  | 5.21 | 5.06 | 5.17 | −2.1% |
| 64 prompts × 64 in × 32 out   | 1.47 | 1.43 | 1.50 | −4.7% |

**Mean TTFT (ms)**, lower is better:

| Shape | compile_nosp | asynctp_off | asynctp_on | Δ(on vs off) |
|---|---:|---:|---:|---:|
| 32 prompts × 128 in × 64 out  | 504.92 | 494.42 | 496.84 | −0.5% |
| 16 prompts × 256 in × 128 out | 554.32 | 574.18 | 555.22 | +3.3% |
| 8 prompts × 512 in × 256 out  | 573.74  | 576.83  | 571.90 | +0.9% |
| 64 prompts × 64 in × 32 out   | 577.51 | 555.13 | 564.11 | −1.6% |

**Mean TPOT (ms)**, lower is better:

| Shape | compile_nosp | asynctp_off | asynctp_on | Δ(on vs off) |
|---|---:|---:|---:|---:|
| 32 prompts × 128 in × 64 out  | 25.17 | 24.31 | 23.81 | +2.0% |
| 16 prompts × 256 in × 128 out | 21.88 | 19.18 | 19.19 | −0.1% |
| 8 prompts × 512 in × 256 out  | 18.15 | 17.55 | 17.98 | −2.4% |
| 64 prompts × 64 in × 32 out   | 27.83 | 27.31 | 29.25 | −7.1% |

**Output tok/s**, higher is better:

| Shape | compile_nosp | asynctp_off | asynctp_on | Δ(on vs off) |
|---|---:|---:|---:|---:|
| 32 prompts × 128 in × 64 out  | 979.2  | 1015.1 | 1025.8 | +1.1% |
| 16 prompts × 256 in × 128 out | 619.4   | 685.4   | 692.2   | +1.0% |
| 8 prompts × 512 in × 256 out  | 396.1   | 405.8   | 398.5   | −1.8% |
| 64 prompts × 64 in × 32 out   | 1400.8 | 1434.4  | 1367.6  | −4.7% |

Across all 4 shapes and all 4 metrics, `asynctp_on` vs `asynctp_off` differences are all within **±5%** (mostly ±0–3%) with no consistent direction — `asynctp_on` is numerically slightly faster on `32:128:64` and `16:256:128`, and numerically slightly slower on `8:512:256` and `64:64:32`. This is expected, not a real regression: per-request prefill in these shapes (64–512 tokens) rarely reaches the 4096-token AsyncTP threshold, so `fuse_gemm_comms` barely fires (unlike the pure-prefill shapes above), and any apparent "slowdown" is inside run-to-run scheduling noise — per-run raw values for `8:512:256`/`64:64:32` overlap heavily between `asynctp_on` and `asynctp_off` (e.g. `8:512:256` duration: off=[4.72–5.64s], on=[4.69–5.70s]), and the per-arm std-dev (8–15% of the mean) is itself larger than any of the observed ±5% deltas. In short: AsyncTP causes no measurable performance cost in mixed prefill+decode, it simply doesn't have enough large-prefill work to fuse here.

---

## Accuracy (GSM8K, 250 questions, 5-shot)

| Arm | Accuracy |
|---|---:|
| `eager`          | 0.788 |
| `asynctp_off`    | 0.784 |
| `asynctp_on`     | 0.784 |
| `compile_nosp`   | 0.776 |

Standard error for `n=250`, `p≈0.78` is ≈ ±2.6pp. The 1.2pp spread across all four arms is within 1σ — no accuracy regression from SP or AsyncTP; `asynctp_on` matches `asynctp_off` exactly.

---

## Summary

- **Pure prefill (≥4096 tokens/iteration)**: SP alone +9–10% TTFT, AsyncTP adds a further +5–6% on top, ~14–15% combined TTFT/duration gain and +15–18% output tok/s over `compile_nosp`. Std-dev ≈0.1–1.5% of mean — clean, reproducible.
- **Mixed prefill+decode**: `asynctp_on` vs `asynctp_off` differs by at most ±5% (mostly ±0–3%) across 4 shapes on Duration/TTFT/TPOT/tok-s, with no consistent direction — well inside the 8–15% run-to-run noise band, i.e. no real win or loss.
- **Accuracy**: no regression (0.776–0.788 across all arms, within ±2.6pp SE); `asynctp_on` == `asynctp_off`.
- **Recommendation**: enable `enable_sp=true` and `fuse_gemm_comms=true` by default for this model/workload — clear win in large-batch/long-context prefill, no measurable downside in mixed workloads.

---





