### PR TITLE
[Bugfix] Handle full event queue during ZMQ publisher shutdown

### DIFF
--- a/tests/distributed/test_events.py
+++ b/tests/distributed/test_events.py
@@ -209,6 +209,29 @@ def test_high_volume(publisher, subscriber):
     assert sorted(seqs) == seqs, "Sequence numbers should be in order"
 
 
+def test_shutdown_cleans_up_when_event_queue_is_full():
+    """Shutdown should clean up even if the event queue is full."""
+    from queue import Queue
+    from unittest.mock import Mock
+
+    from vllm.distributed.kv_events import ZmqEventPublisher
+
+    publisher = ZmqEventPublisher.__new__(ZmqEventPublisher)
+    publisher._running = True
+    publisher._event_queue = Queue(maxsize=1)
+    publisher._event_queue.put_nowait(create_test_events(1))
+    publisher._thread = Mock(spec=threading.Thread)
+    publisher._thread.is_alive.return_value = False
+    publisher._pub = Mock()
+    publisher._replay = Mock()
+    publisher.SHUTDOWN_TIMEOUT = 0
+
+    publisher.shutdown()
+
+    publisher._pub.close.assert_called_once_with(linger=0)
+    publisher._replay.close.assert_called_once_with(linger=0)
+
+
 def test_null_publisher():
     """Test that NullEventPublisher can be used without errors"""
     publisher = NullEventPublisher(DP_RANK)

--- a/vllm/distributed/kv_events.py
+++ b/vllm/distributed/kv_events.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import contextlib
 import queue
 import threading
 import time
@@ -379,7 +380,8 @@ class ZmqEventPublisher(EventPublisher):
     def shutdown(self) -> None:
         """Stop the publisher thread and clean up resources."""
         self._running = False
-        self._event_queue.put_nowait(None)
+        with contextlib.suppress(queue.Full):
+            self._event_queue.put_nowait(None)
 
         start = time.time()
         pending_items = True


### PR DESCRIPTION
## Purpose

`ZmqEventPublisher.shutdown()` sets `_running` to `False` and then uses
`put_nowait(None)` to wake the publisher thread. When a bounded event queue is
already full, that call raises `queue.Full`. The exception skips the thread
join and both ZMQ socket closes, so shutdown can fail precisely when the
publisher is under backpressure.

This change suppresses only `queue.Full` while enqueueing the wake-up sentinel.
The existing loop condition still drains queued events and exits after
`_running` becomes `False`, so the normal join and socket cleanup can complete.

I searched open and closed issues and pull requests for
`ZmqEventPublisher`, `queue.Full`, and shutdown/full-queue behavior on
2026-08-19 and found no existing report or implementation.

This PR was prepared with OpenAI Codex assistance. I reviewed every changed
line, understand and can explain the change, and personally ran the focused
regression test. Model evaluation is not applicable because this changes only
publisher shutdown cleanup and does not affect model output, accuracy, or
serving behavior.

## Test Plan

- Reproduce the failure with a bounded queue that is full before shutdown.
- Verify shutdown no longer raises and closes both PUB and replay sockets.
- Run the complete existing distributed event test file.
- Run the repository pre-commit hooks on the staged files.

## Test Result

Before the fix, the focused regression test failed at
`self._event_queue.put_nowait(None)` with `queue.Full` (`1 failed`).

After the fix:

```text
.venv/bin/python -m pytest --confcutdir=tests/distributed tests/distributed/test_events.py::test_shutdown_cleans_up_when_event_queue_is_full -vv
1 passed in 0.01s

.venv/bin/python -m pytest --confcutdir=tests/distributed tests/distributed/test_events.py -vv
11 passed in 4.21s

.venv/bin/pre-commit run
All applicable hooks passed, including Ruff, formatting, typos, mypy, SPDX,
forbidden imports, and configuration validation.

git commit
Sign-off Commit..........................................................Passed
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose and failure mode are described above.
- [x] The exact test commands are included.
- [x] Red and green test results are included.
- [x] No documentation update is needed because this restores cleanup behavior
      without changing a user-facing API.

</details>

