### PR TITLE
[KV Connector][Observability] Add lifecycle tracing for NIXL push and pull

### DIFF
--- a/docs/features/nixl_connector_usage.md
+++ b/docs/features/nixl_connector_usage.md
@@ -132,6 +132,34 @@ python tests/v1/kv_connector/nixl_integration/toy_proxy_server.py \
     - In bidirectional mode, the decoder caches KV blocks for multi-turn conversations. This TTL controls how long those blocks are held before being released. Unlike the prefiller lease, this TTL is not renewed via heartbeats.
     - Example: `--kv-transfer-config '{"kv_connector_extra_config": {"decoder_kv_blocks_ttl": 600}}'`
 
+## Connector lifecycle tracing
+
+Both `NixlConnector` (pull) and `NixlPushConnector` can emit structured
+control-plane and data-plane lifecycle records. Tracing is disabled by
+default. Enable deterministic request sampling on every producer and consumer
+with `kv_connector_lifecycle_trace_sample_rate` in
+`kv_connector_extra_config`:
+
+```bash
+vllm serve <MODEL> \
+  --kv-transfer-config '{
+    "kv_connector": "NixlConnector",
+    "kv_role": "kv_producer",
+    "kv_connector_extra_config": {
+      "kv_connector_lifecycle_trace_sample_rate": 0.01
+    }
+  }'
+```
+
+The value must be between `0.0` and `1.0`. Sampled records use the
+`KV_CONNECTOR_LIFECYCLE` log prefix and the `vllm-kv-connector-v1` schema.
+They include the connector, transfer mode, component, producer/consumer role,
+event, timestamps, and optional block counts. Request identifiers are never
+logged directly: records contain hashed request and request-group identifiers,
+and related IDs with different trailing vLLM random suffixes share a sampling
+decision. Wall timestamps may be compared across processes after clock
+normalization; monotonic timestamps are process-local.
+
 ## Bidirectional KV Transfer (Multi-turn)
 
 In standard disaggregated prefilling, KV cache flows in one direction: Prefill (P) computes the KV cache and Decode (D) reads from P. For multi-turn conversations this is wasteful — D already holds the KV cache corresponding to the generated tokens from prior turns, yet P must recompute it from scratch on every new turn. Bidirectional KV transfer lets P **pull** existing KV blocks from D via RDMA before computing only the new tokens, significantly reducing Time-To-First-Token (TTFT) for long-prefill such as **multi-turn heavy scenarios**.

--- a/tests/v1/kv_connector/unit/test_kv_connector_lifecycle.py
+++ b/tests/v1/kv_connector/unit/test_kv_connector_lifecycle.py
@@ -3,8 +3,18 @@
 
 from unittest.mock import MagicMock, patch
 
+import msgspec
+import pytest
+
 from vllm.distributed.kv_transfer.kv_connector.v1.example_connector import (  # noqa: E501
     ExampleConnectorMetadata,
+)
+from vllm.distributed.kv_transfer.kv_connector.v1.lifecycle import (
+    KV_CONNECTOR_LIFECYCLE_LOG_PREFIX,
+    KVConnectorLifecycleEvent,
+    LoggingKVConnectorLifecycleSink,
+    NoOpKVConnectorLifecycleSink,
+    create_kv_connector_lifecycle_sink,
 )
 from vllm.distributed.kv_transfer.kv_transfer_state import (
     ensure_kv_transfer_initialized,
@@ -75,3 +85,126 @@ def test_kv_connector_mixin_clears_metadata():
     finally:
         # Ensure we clean up the global connector between tests
         ensure_kv_transfer_shutdown()
+
+
+def _logging_sink(sample_rate: float = 1.0) -> LoggingKVConnectorLifecycleSink:
+    return LoggingKVConnectorLifecycleSink(
+        connector="NixlConnector",
+        transfer_mode="pull",
+        component="worker",
+        sample_rate=sample_rate,
+    )
+
+
+def test_lifecycle_sink_is_disabled_by_default():
+    sink = create_kv_connector_lifecycle_sink(
+        create_vllm_config(), transfer_mode="pull", component="scheduler"
+    )
+
+    assert isinstance(sink, NoOpKVConnectorLifecycleSink)
+    with patch(
+        "vllm.distributed.kv_transfer.kv_connector.v1.lifecycle.logger.info"
+    ) as log:
+        sink.emit(
+            KVConnectorLifecycleEvent.TRANSFER_STAGED,
+            "private-request-id",
+            role="consumer",
+        )
+    log.assert_not_called()
+
+
+def test_lifecycle_log_is_structured_and_privacy_safe():
+    request_id = "request-private-aaaaaaaa"
+    remote_request_id = "request-private-bbbbbbbb"
+
+    with patch(
+        "vllm.distributed.kv_transfer.kv_connector.v1.lifecycle.logger.info"
+    ) as log:
+        _logging_sink().emit(
+            KVConnectorLifecycleEvent.TRANSFER_STARTED,
+            request_id,
+            role="consumer",
+            remote_request_id=remote_request_id,
+            block_count=7,
+        )
+
+    log.assert_called_once()
+    fmt, prefix, payload = log.call_args.args
+    assert fmt == "%s%s"
+    assert prefix == KV_CONNECTOR_LIFECYCLE_LOG_PREFIX
+    assert request_id not in payload
+    assert remote_request_id not in payload
+
+    record = msgspec.json.decode(payload)
+    assert record["schema"] == "vllm-kv-connector-v1"
+    assert record["event"] == "transfer_started"
+    assert record["connector"] == "NixlConnector"
+    assert record["transfer_mode"] == "pull"
+    assert record["component"] == "worker"
+    assert record["role"] == "consumer"
+    assert record["block_count"] == 7
+    assert record["request_id_hash"] != record["remote_request_id_hash"]
+    assert isinstance(record["wall_ns"], int)
+    assert isinstance(record["monotonic_ns"], int)
+
+
+def test_related_request_ids_share_sampling_and_group_hash():
+    first_id = "cmpl-shared-request-aaaaaaaa"
+    second_id = "cmpl-shared-request-bbbbbbbb"
+
+    with patch(
+        "vllm.distributed.kv_transfer.kv_connector.v1.lifecycle.logger.info"
+    ) as log:
+        sink = _logging_sink(sample_rate=0.5)
+        sink.emit(
+            KVConnectorLifecycleEvent.TRANSFER_STAGED,
+            first_id,
+            role="consumer",
+        )
+        sink.emit(
+            KVConnectorLifecycleEvent.TRANSFER_STAGED,
+            second_id,
+            role="consumer",
+        )
+
+    # Sampling is based on the shared ID after stripping the random suffix.
+    assert log.call_count in (0, 2)
+
+    with patch(
+        "vllm.distributed.kv_transfer.kv_connector.v1.lifecycle.logger.info"
+    ) as log:
+        sink = _logging_sink()
+        sink.emit(
+            KVConnectorLifecycleEvent.TRANSFER_STAGED,
+            first_id,
+            role="consumer",
+        )
+        sink.emit(
+            KVConnectorLifecycleEvent.TRANSFER_STAGED,
+            second_id,
+            role="consumer",
+        )
+
+    first = msgspec.json.decode(log.call_args_list[0].args[2])
+    second = msgspec.json.decode(log.call_args_list[1].args[2])
+    assert first["request_id_hash"] != second["request_id_hash"]
+    assert first["request_group_id_hash"] == second["request_group_id_hash"]
+
+
+@pytest.mark.parametrize("sample_rate", [-0.1, 1.1, float("nan")])
+def test_lifecycle_sink_rejects_invalid_sample_rate(sample_rate: float):
+    with pytest.raises(ValueError, match="must be between 0.0 and 1.0"):
+        _logging_sink(sample_rate=sample_rate)
+
+
+def test_factory_enables_configured_sink():
+    config = create_vllm_config(
+        kv_connector_extra_config={
+            "kv_connector_lifecycle_trace_sample_rate": 0.25,
+        }
+    )
+    sink = create_kv_connector_lifecycle_sink(
+        config, transfer_mode="pull", component="scheduler"
+    )
+
+    assert isinstance(sink, LoggingKVConnectorLifecycleSink)

--- a/tests/v1/kv_connector/unit/test_nixl_connector.py
+++ b/tests/v1/kv_connector/unit/test_nixl_connector.py
@@ -29,6 +29,9 @@ from vllm.distributed.kv_transfer.kv_connector.utils import (
 )
 from vllm.distributed.kv_transfer.kv_connector.v1 import nixl
 from vllm.distributed.kv_transfer.kv_connector.v1.base import KVConnectorRole
+from vllm.distributed.kv_transfer.kv_connector.v1.lifecycle import (
+    KVConnectorLifecycleEvent,
+)
 from vllm.distributed.kv_transfer.kv_connector.v1.metrics import KVConnectorStats
 from vllm.distributed.kv_transfer.kv_connector.v1.multi_connector import (
     MultiKVConnectorStats,
@@ -3285,8 +3288,17 @@ def test_handshake_decode_errors(default_vllm_config, dist_init, error_scenario)
             )
         )
         worker._read_blocks = MagicMock()  # type: ignore[method-assign]
+        worker._lifecycle_sink = MagicMock()
 
         worker._read_blocks_for_req(decode_req_id, meta)
+
+        worker._lifecycle_sink.emit.assert_called_once_with(
+            KVConnectorLifecycleEvent.TRANSFER_STARTED,
+            decode_req_id,
+            role="consumer",
+            remote_request_id=prefill_req_id,
+            block_count=3,
+        )
 
         # MLA: read once from rank 0 and broadcast to the other ranks.
         worker._read_blocks.assert_called_once()

--- a/tests/v1/kv_connector/unit/test_nixl_push_connector.py
+++ b/tests/v1/kv_connector/unit/test_nixl_push_connector.py
@@ -32,6 +32,9 @@ from unittest.mock import MagicMock, patch
 import msgspec
 import pytest
 
+from vllm.distributed.kv_transfer.kv_connector.v1.lifecycle import (
+    KVConnectorLifecycleEvent,
+)
 from vllm.distributed.kv_transfer.kv_connector.v1.nixl.metadata import (
     PUSH_REG_NOTIF_PREFIX,
     NixlAgentMetadata,
@@ -121,6 +124,7 @@ class TestPushScheduler:
         """D scheduler stashes registration data + arms watchdog deadline."""
         sched = make_nixl_push_scheduler()
         _stub_sw_clipping(sched)
+        sched._lifecycle_sink = MagicMock()
 
         request = _make_request(request_id="req-d-1")
         blocks = _BlocksMock(block_ids=([10, 11, 12],))
@@ -144,12 +148,20 @@ class TestPushScheduler:
         assert request.kv_transfer_params["do_remote_prefill"] is False
         # Tracked as awaiting a recv.
         assert request.request_id in sched._reqs_need_recv
+        sched._lifecycle_sink.emit.assert_called_once_with(
+            KVConnectorLifecycleEvent.REGISTRATION_STAGED,
+            request.request_id,
+            role="consumer",
+            remote_request_id="prefill-req-d-1",
+            block_count=3,
+        )
 
     def test_p_side_request_finished_stages_blocks(self):
         """P scheduler pushes blocks into both _finished_request_blocks (lease)
         and _newly_finished_push_blocks (metadata for next step)."""
         sched = make_nixl_push_scheduler()
         _stub_sw_clipping(sched)
+        sched._lifecycle_sink = MagicMock()
 
         request = _make_request(request_id="req-p-1", is_d_side=False)
         block_ids = ([20, 21, 22, 23],)
@@ -163,6 +175,12 @@ class TestPushScheduler:
         assert request.request_id in sched._finished_request_blocks
         assert request.request_id in sched._newly_finished_push_blocks
         assert request.request_id in sched._reqs_need_send  # lease armed
+        sched._lifecycle_sink.emit.assert_called_once_with(
+            KVConnectorLifecycleEvent.TRANSFER_STAGED,
+            request.request_id,
+            role="producer",
+            block_count=4,
+        )
 
     def test_build_connector_meta_drains_both_sides(self):
         """meta.push_registrations and meta.push_finished_blocks are filled
@@ -390,6 +408,7 @@ class TestPushWriterMatching:
     def test_handle_push_reg_matches_existing_finished_blocks(self):
         """PUSH_REG arrives second (P finished first): match + fire."""
         w = _StubWriterWorker.fresh()
+        w._lifecycle_sink = MagicMock()
         # P had already finished; its blocks were stashed via metadata.
         w._push_finished_blocks["req-A"] = ([200, 201, 202],)
 
@@ -406,6 +425,19 @@ class TestPushWriterMatching:
         # Finished blocks consumed.
         assert "req-A" not in w._push_finished_blocks
         assert w._pending_d_registrations == {}
+        w._lifecycle_sink.emit.assert_any_call(
+            KVConnectorLifecycleEvent.REGISTRATION_RECEIVED,
+            "req-A",
+            role="producer",
+            block_count=3,
+        )
+        w._lifecycle_sink.emit.assert_any_call(
+            KVConnectorLifecycleEvent.BLOCKS_MATCHED,
+            "req-A",
+            role="producer",
+            remote_request_id="req-A",
+            block_count=3,
+        )
 
     def test_handle_push_reg_stashes_when_no_finished_blocks_yet(self):
         """PUSH_REG arrives first (D registered first): stash, no fire."""

--- a/vllm/distributed/kv_transfer/kv_connector/v1/lifecycle.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/lifecycle.py
@@ -1,0 +1,222 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Privacy-safe lifecycle events for KV connectors.
+
+The logging sink is intentionally opt-in and stateless. Request identifiers
+are hashed before they leave the process, and deterministic sampling groups
+request IDs that differ only by vLLM's trailing random suffix.
+"""
+
+import hashlib
+import math
+import time
+from abc import ABC, abstractmethod
+from enum import Enum
+from typing import TYPE_CHECKING, Literal
+
+import msgspec
+import regex as re
+
+from vllm.logger import init_logger
+
+if TYPE_CHECKING:
+    from vllm.config import VllmConfig
+
+logger = init_logger(__name__)
+
+KV_CONNECTOR_LIFECYCLE_TRACE_SAMPLE_RATE = "kv_connector_lifecycle_trace_sample_rate"
+KV_CONNECTOR_LIFECYCLE_LOG_PREFIX = "KV_CONNECTOR_LIFECYCLE "
+_SCHEMA = "vllm-kv-connector-v1"
+_RANDOM_SUFFIX_RE = re.compile(r"-[0-9a-f]{8}$", re.IGNORECASE)
+
+KVConnectorLifecycleComponent = Literal["scheduler", "worker"]
+KVConnectorLifecycleRole = Literal["producer", "consumer"]
+
+
+class KVConnectorLifecycleEvent(str, Enum):
+    """Connector transitions shared by control-plane and data-plane adapters."""
+
+    TRANSFER_STAGED = "transfer_staged"
+    REGISTRATION_STAGED = "registration_staged"
+    REGISTRATION_QUEUED = "registration_queued"
+    REGISTRATION_SENT = "registration_sent"
+    REGISTRATION_RECEIVED = "registration_received"
+    REGISTRATION_FAILED = "registration_failed"
+    BLOCKS_MATCHED = "blocks_matched"
+    TRANSFER_STARTED = "transfer_started"
+    TRANSFER_COMPLETED = "transfer_completed"
+    TRANSFER_FAILED = "transfer_failed"
+
+
+class _KVConnectorLifecycleLogRecord(
+    msgspec.Struct,
+    omit_defaults=True,  # type: ignore[call-arg]
+    gc=False,  # type: ignore[call-arg]
+):
+    schema: str
+    event: KVConnectorLifecycleEvent
+    wall_ns: int
+    monotonic_ns: int
+    connector: str
+    transfer_mode: str
+    component: KVConnectorLifecycleComponent
+    role: KVConnectorLifecycleRole
+    request_id_hash: str
+    request_group_id_hash: str
+    remote_request_id_hash: str | None = None
+    block_count: int | None = None
+
+
+def _request_group_id(request_id: str) -> str:
+    return _RANDOM_SUFFIX_RE.sub("", request_id)
+
+
+def _hash_request_id(request_id: str) -> str:
+    return hashlib.blake2b(
+        request_id.encode("utf-8"),
+        digest_size=8,
+        person=b"vllm-kv-trace",
+        usedforsecurity=False,
+    ).hexdigest()
+
+
+def _is_sampled(request_id: str, sample_rate: float) -> bool:
+    if sample_rate <= 0.0:
+        return False
+    if sample_rate >= 1.0:
+        return True
+    digest = hashlib.blake2b(
+        _request_group_id(request_id).encode("utf-8"),
+        digest_size=8,
+        person=b"vllm-kv-sample",
+        usedforsecurity=False,
+    ).digest()
+    return int.from_bytes(digest, "big") / (1 << 64) < sample_rate
+
+
+class KVConnectorLifecycleSink(ABC):
+    """Typed sink implemented by connector lifecycle exporters."""
+
+    @abstractmethod
+    def emit(
+        self,
+        event: KVConnectorLifecycleEvent,
+        request_id: str,
+        *,
+        role: KVConnectorLifecycleRole,
+        remote_request_id: str | None = None,
+        block_count: int | None = None,
+    ) -> None:
+        """Emit a single request transition."""
+
+
+class NoOpKVConnectorLifecycleSink(KVConnectorLifecycleSink):
+    """Disabled sink used to avoid conditionals in connector adapters."""
+
+    def emit(
+        self,
+        event: KVConnectorLifecycleEvent,
+        request_id: str,
+        *,
+        role: KVConnectorLifecycleRole,
+        remote_request_id: str | None = None,
+        block_count: int | None = None,
+    ) -> None:
+        return
+
+
+class LoggingKVConnectorLifecycleSink(KVConnectorLifecycleSink):
+    """Emit sampled, structured lifecycle events through the vLLM logger."""
+
+    def __init__(
+        self,
+        *,
+        connector: str,
+        transfer_mode: str,
+        component: KVConnectorLifecycleComponent,
+        sample_rate: float,
+    ) -> None:
+        if not math.isfinite(sample_rate) or not 0.0 <= sample_rate <= 1.0:
+            raise ValueError(
+                f"{KV_CONNECTOR_LIFECYCLE_TRACE_SAMPLE_RATE} must be between "
+                f"0.0 and 1.0, got {sample_rate}"
+            )
+        self._connector = connector
+        self._transfer_mode = transfer_mode
+        self._component = component
+        self._sample_rate = sample_rate
+
+    def emit(
+        self,
+        event: KVConnectorLifecycleEvent,
+        request_id: str,
+        *,
+        role: KVConnectorLifecycleRole,
+        remote_request_id: str | None = None,
+        block_count: int | None = None,
+    ) -> None:
+        if not _is_sampled(request_id, self._sample_rate):
+            return
+
+        group_id = _request_group_id(request_id)
+        record = _KVConnectorLifecycleLogRecord(
+            schema=_SCHEMA,
+            event=event,
+            wall_ns=time.time_ns(),
+            monotonic_ns=time.monotonic_ns(),
+            connector=self._connector,
+            transfer_mode=self._transfer_mode,
+            component=self._component,
+            role=role,
+            request_id_hash=_hash_request_id(request_id),
+            request_group_id_hash=_hash_request_id(group_id),
+            remote_request_id_hash=(
+                _hash_request_id(remote_request_id)
+                if remote_request_id is not None
+                else None
+            ),
+            block_count=block_count,
+        )
+        logger.info(
+            "%s%s",
+            KV_CONNECTOR_LIFECYCLE_LOG_PREFIX,
+            msgspec.json.encode(record).decode("utf-8"),
+        )
+
+
+_NO_OP_SINK = NoOpKVConnectorLifecycleSink()
+
+
+def create_kv_connector_lifecycle_sink(
+    vllm_config: "VllmConfig",
+    *,
+    transfer_mode: str,
+    component: KVConnectorLifecycleComponent,
+) -> KVConnectorLifecycleSink:
+    """Create the configured connector lifecycle sink.
+
+    ``sample_rate=0`` is the default and returns a shared stateless no-op sink.
+    """
+    config = vllm_config.kv_transfer_config
+    if config is None:
+        return _NO_OP_SINK
+
+    raw_sample_rate = config.get_from_extra_config(
+        KV_CONNECTOR_LIFECYCLE_TRACE_SAMPLE_RATE, 0.0
+    )
+    try:
+        sample_rate = float(raw_sample_rate)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f"{KV_CONNECTOR_LIFECYCLE_TRACE_SAMPLE_RATE} must be a number, "
+            f"got {raw_sample_rate!r}"
+        ) from exc
+    if sample_rate == 0.0:
+        return _NO_OP_SINK
+
+    return LoggingKVConnectorLifecycleSink(
+        connector=config.kv_connector or "unknown",
+        transfer_mode=transfer_mode,
+        component=component,
+        sample_rate=sample_rate,
+    )

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_scheduler.py
@@ -19,6 +19,11 @@ from vllm.distributed.kv_transfer.kv_connector.v1.base import (
     KVConnectorHandshakeMetadata,
     KVConnectorMetadata,
 )
+from vllm.distributed.kv_transfer.kv_connector.v1.lifecycle import (
+    KVConnectorLifecycleSink,
+    NoOpKVConnectorLifecycleSink,
+    create_kv_connector_lifecycle_sink,
+)
 from vllm.distributed.kv_transfer.kv_connector.v1.nixl.metadata import (
     GET_META_MSG,
     HeartbeatInfo,
@@ -55,6 +60,8 @@ class NixlBaseConnectorScheduler:
     # pull (READ) producer from a push (WRITE) one. Overridden by the push
     # scheduler.
     _TRANSFER_MODE: str = "pull"
+    # Class default keeps light-weight ``__new__`` test doubles disabled.
+    _lifecycle_sink: KVConnectorLifecycleSink = NoOpKVConnectorLifecycleSink()
 
     def __init__(
         self,
@@ -66,6 +73,11 @@ class NixlBaseConnectorScheduler:
         self.block_size = vllm_config.cache_config.block_size
         self.engine_id: EngineId = engine_id
         self.kv_cache_config = kv_cache_config
+        self._lifecycle_sink = create_kv_connector_lifecycle_sink(
+            vllm_config,
+            transfer_mode=self._TRANSFER_MODE,
+            component="scheduler",
+        )
         self.side_channel_host = envs.VLLM_NIXL_SIDE_CHANNEL_HOST
         self.side_channel_port = (
             envs.VLLM_NIXL_SIDE_CHANNEL_PORT

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_worker.py
@@ -31,6 +31,12 @@ from vllm.distributed.kv_transfer.kv_connector.utils import (
     kv_postprocess_layout_on_receive,
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.base import CopyBlocksOp
+from vllm.distributed.kv_transfer.kv_connector.v1.lifecycle import (
+    KVConnectorLifecycleEvent,
+    KVConnectorLifecycleSink,
+    NoOpKVConnectorLifecycleSink,
+    create_kv_connector_lifecycle_sink,
+)
 from vllm.distributed.kv_transfer.kv_connector.v1.metrics import KVConnectorStats
 from vllm.distributed.kv_transfer.kv_connector.v1.nixl.metadata import (
     GET_META_MSG,
@@ -95,6 +101,8 @@ class NixlBaseConnectorWorker:
     # (WRITE) connector and a pull (READ) connector never handshake together.
     # Overridden by NixlPushConnectorWorker.
     _TRANSFER_MODE: str = "pull"
+    # Class default keeps light-weight ``__new__`` test doubles disabled.
+    _lifecycle_sink: KVConnectorLifecycleSink = NoOpKVConnectorLifecycleSink()
 
     def _compute_desc_ids(
         self,
@@ -272,6 +280,11 @@ class NixlBaseConnectorWorker:
         if vllm_config.kv_transfer_config is None:
             raise ValueError("kv_transfer_config must be set for NixlConnector")
         self.kv_transfer_config = vllm_config.kv_transfer_config
+        self._lifecycle_sink = create_kv_connector_lifecycle_sink(
+            vllm_config,
+            transfer_mode=self._TRANSFER_MODE,
+            component="worker",
+        )
 
         self.nixl_backends = vllm_config.kv_transfer_config.get_from_extra_config(
             "backends", ["UCX"]
@@ -2064,6 +2077,7 @@ class NixlBaseConnectorWorker:
         assert self.transfer_topo is not None
         done_sending = self._get_new_notifs()
         done_recving = self._pop_done_transfers(self._recving_transfers)
+        expired_sending = set[ReqId]()
 
         # Drain queue of requests where handshake or transfer setup failed.
         failed_recv_reqs = set[ReqId]()
@@ -2094,6 +2108,19 @@ class NixlBaseConnectorWorker:
             meta = self._recving_metadata.pop(req_id, None)
             assert meta is not None, f"{req_id} not found in recving_metadata list"
 
+            assert meta.remote is not None
+            self._lifecycle_sink.emit(
+                (
+                    KVConnectorLifecycleEvent.TRANSFER_FAILED
+                    if req_id in failed_recv_reqs
+                    else KVConnectorLifecycleEvent.TRANSFER_COMPLETED
+                ),
+                req_id,
+                role="consumer",
+                remote_request_id=meta.remote.request_id,
+                block_count=sum(len(group) for group in meta.local_block_ids),
+            )
+
             # Skip KV sync and post-processing for failed requests
             if req_id in failed_recv_reqs:
                 logger.warning(
@@ -2102,7 +2129,6 @@ class NixlBaseConnectorWorker:
                 )
                 continue
 
-            assert meta.remote is not None
             if self.use_host_buffer:
                 self.sync_recved_kv_to_device(req_id, meta)
 
@@ -2174,6 +2200,18 @@ class NixlBaseConnectorWorker:
             self._reqs_to_process.remove(req_id)
             del self._reqs_to_send[req_id]
             done_sending.add(req_id)
+            expired_sending.add(req_id)
+
+        for req_id in done_sending:
+            self._lifecycle_sink.emit(
+                (
+                    KVConnectorLifecycleEvent.TRANSFER_FAILED
+                    if req_id in expired_sending
+                    else KVConnectorLifecycleEvent.TRANSFER_COMPLETED
+                ),
+                req_id,
+                role="producer",
+            )
 
         return done_sending, done_recving
 

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/pull_scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/pull_scheduler.py
@@ -6,6 +6,9 @@ import time
 from typing import TYPE_CHECKING, Any
 
 from vllm.distributed.kv_transfer.kv_connector.utils import BlockIds
+from vllm.distributed.kv_transfer.kv_connector.v1.lifecycle import (
+    KVConnectorLifecycleEvent,
+)
 from vllm.distributed.kv_transfer.kv_connector.v1.nixl.base_scheduler import (
     NixlBaseConnectorScheduler,
 )
@@ -165,6 +168,13 @@ class NixlPullConnectorScheduler(NixlBaseConnectorScheduler):
                         request,
                         local_block_ids,
                     )
+                    self._lifecycle_sink.emit(
+                        KVConnectorLifecycleEvent.TRANSFER_STAGED,
+                        request.request_id,
+                        role="consumer",
+                        remote_request_id=params["remote_request_id"],
+                        block_count=sum(len(group) for group in local_block_ids),
+                    )
 
                 else:
                     logger.warning(
@@ -265,6 +275,13 @@ class NixlPullConnectorScheduler(NixlBaseConnectorScheduler):
             block_ids = self.get_exchange_clipped_blocks(block_ids)
 
             remote_num_tokens = request.num_computed_tokens
+
+            self._lifecycle_sink.emit(
+                KVConnectorLifecycleEvent.TRANSFER_STAGED,
+                request.request_id,
+                role="producer",
+                block_count=sum(len(group) for group in block_ids),
+            )
 
         return delay_free_blocks, dict(
             do_remote_prefill=is_p_node,

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/pull_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/pull_worker.py
@@ -5,6 +5,9 @@
 import time
 from typing import TYPE_CHECKING
 
+from vllm.distributed.kv_transfer.kv_connector.v1.lifecycle import (
+    KVConnectorLifecycleEvent,
+)
 from vllm.distributed.kv_transfer.kv_connector.v1.nixl.base_worker import (
     NixlBaseConnectorWorker,
 )
@@ -139,6 +142,14 @@ class NixlPullConnectorWorker(NixlBaseConnectorWorker):
             self.xfer_stats.record_kv_expired_req()
             self._handle_failed_transfer(req_id, None)
             return
+
+        self._lifecycle_sink.emit(
+            KVConnectorLifecycleEvent.TRANSFER_STARTED,
+            req_id,
+            role="consumer",
+            remote_request_id=meta.remote.request_id,
+            block_count=sum(len(group) for group in meta.local_block_ids),
+        )
 
         plan = self.tp_mappings[engine_id]
         remote_info = self.transfer_topo.get_engine_info(engine_id)

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/push_scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/push_scheduler.py
@@ -31,6 +31,9 @@ from vllm.distributed.kv_transfer.kv_connector.utils import BlockIds
 from vllm.distributed.kv_transfer.kv_connector.v1.base import (
     KVConnectorMetadata,
 )
+from vllm.distributed.kv_transfer.kv_connector.v1.lifecycle import (
+    KVConnectorLifecycleEvent,
+)
 from vllm.distributed.kv_transfer.kv_connector.v1.nixl.base_scheduler import (
     NixlBaseConnectorScheduler,
 )
@@ -193,6 +196,13 @@ class NixlPushConnectorScheduler(NixlBaseConnectorScheduler):
         self._push_registration_deadlines[request.request_id] = (
             time.perf_counter() + self._push_registration_timeout
         )
+        self._lifecycle_sink.emit(
+            KVConnectorLifecycleEvent.REGISTRATION_STAGED,
+            request.request_id,
+            role="consumer",
+            remote_request_id=params.get("remote_request_id"),
+            block_count=sum(len(group) for group in local_block_ids),
+        )
         # In push mode D doesn't know P's blocks; P determines them
         # from the registration. We still track the request as
         # needing recv so the engine waits for P's WRITE completion.
@@ -280,6 +290,12 @@ class NixlPushConnectorScheduler(NixlBaseConnectorScheduler):
             # registrations (via NIXL notifications).
             self._finished_request_blocks[request.request_id] = block_ids
             self._newly_finished_push_blocks[request.request_id] = block_ids
+            self._lifecycle_sink.emit(
+                KVConnectorLifecycleEvent.TRANSFER_STAGED,
+                request.request_id,
+                role="producer",
+                block_count=sum(len(group) for group in block_ids),
+            )
 
         return delay_free_blocks, dict(
             do_remote_prefill=True,
@@ -326,6 +342,11 @@ class NixlPushConnectorScheduler(NixlBaseConnectorScheduler):
                 "after %.1fs without a push completion",
                 rid,
                 self._push_registration_timeout,
+            )
+            self._lifecycle_sink.emit(
+                KVConnectorLifecycleEvent.REGISTRATION_FAILED,
+                rid,
+                role="consumer",
             )
 
         # D side: package pending registrations for D workers to send out.

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/push_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/push_worker.py
@@ -41,6 +41,9 @@ from typing import TYPE_CHECKING, Any
 import msgspec
 
 from vllm.distributed.kv_transfer.kv_connector.utils import BlockIds
+from vllm.distributed.kv_transfer.kv_connector.v1.lifecycle import (
+    KVConnectorLifecycleEvent,
+)
 from vllm.distributed.kv_transfer.kv_connector.v1.nixl.base_worker import (
     NixlBaseConnectorWorker,
 )
@@ -180,6 +183,14 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
         if metadata.push_registrations:
             for req_id, reg_data in metadata.push_registrations.items():
                 self._reg_send_inbox.put((req_id, reg_data))
+                self._lifecycle_sink.emit(
+                    KVConnectorLifecycleEvent.REGISTRATION_QUEUED,
+                    req_id,
+                    role="consumer",
+                    block_count=sum(
+                        len(group) for group in reg_data["local_block_ids"]
+                    ),
+                )
             self._push_writer_wake.set()
 
         # --- P-side: newly finished blocks awaiting a D registration match ---
@@ -239,6 +250,13 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
                         break
                     matched = self._pop_matching_registration(rid)
                     if matched is not None:
+                        self._lifecycle_sink.emit(
+                            KVConnectorLifecycleEvent.BLOCKS_MATCHED,
+                            rid,
+                            role="producer",
+                            remote_request_id=matched["request_id"],
+                            block_count=sum(len(group) for group in blocks),
+                        )
                         self._do_start_push_kv(rid, blocks, matched)
                     else:
                         self._push_finished_blocks[rid] = blocks
@@ -285,9 +303,23 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
             logger.warning("PUSH_REG notif missing request_id; dropping")
             return
 
+        self._lifecycle_sink.emit(
+            KVConnectorLifecycleEvent.REGISTRATION_RECEIVED,
+            rid,
+            role="producer",
+            block_count=sum(len(group) for group in reg_data["local_block_ids"]),
+        )
+
         match = self._pop_matching_finished_blocks(rid)
         if match is not None:
             fin_id, blocks = match
+            self._lifecycle_sink.emit(
+                KVConnectorLifecycleEvent.BLOCKS_MATCHED,
+                fin_id,
+                role="producer",
+                remote_request_id=rid,
+                block_count=sum(len(group) for group in blocks),
+            )
             self._do_start_push_kv(fin_id, blocks, reg_data)
         else:
             self._pending_d_registrations[rid] = reg_data
@@ -331,6 +363,11 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
                 self._log_failure(
                     failure_type="push_reg_handshake_failed", req_id=rid, error=e
                 )
+                self._lifecycle_sink.emit(
+                    KVConnectorLifecycleEvent.REGISTRATION_FAILED,
+                    rid,
+                    role="consumer",
+                )
                 self._handle_failed_transfer(rid, None)
                 return
             # Re-queue for the writer to send now that the handshake is done.
@@ -352,7 +389,13 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
                 req_id,
             )
             self._handle_failed_transfer(req_id, None)
+            self._lifecycle_sink.emit(
+                KVConnectorLifecycleEvent.REGISTRATION_FAILED,
+                req_id,
+                role="consumer",
+            )
             return
+        send_succeeded = True
         for rank, agent_name in agents.items():
             try:
                 self.nixl_wrapper.send_notif(agent_name, notif_msg=notif_msg)
@@ -363,6 +406,17 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
                     error=e,
                     remote_rank=rank,
                 )
+                send_succeeded = False
+        self._lifecycle_sink.emit(
+            (
+                KVConnectorLifecycleEvent.REGISTRATION_SENT
+                if send_succeeded
+                else KVConnectorLifecycleEvent.REGISTRATION_FAILED
+            ),
+            req_id,
+            role="consumer",
+            block_count=sum(len(group) for group in reg_data["local_block_ids"]),
+        )
         logger.debug(
             "Sent PUSH_REG for %s to engine %s (%dB)", req_id, engine_id, len(notif_msg)
         )
@@ -476,6 +530,13 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
             ),
         )
 
+        self._lifecycle_sink.emit(
+            KVConnectorLifecycleEvent.TRANSFER_STARTED,
+            request_id,
+            role="producer",
+            remote_request_id=decode_request_id,
+            block_count=sum(len(group) for group in logical_local),
+        )
         t0 = time.perf_counter()
         self._xfer_blocks_for_req(req_id=request_id, meta=push_meta)
         elapsed_ms = (time.perf_counter() - t0) * 1000.0
@@ -780,6 +841,11 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
             self._reqs_to_process.discard(req_id)
             self.consumer_notification_counts_by_req.pop(req_id, None)
             done_sending.add(req_id)
+            self._lifecycle_sink.emit(
+                KVConnectorLifecycleEvent.TRANSFER_COMPLETED,
+                req_id,
+                role="producer",
+            )
 
         # Tell the writer to drop any state it still holds for any
         # request that just finished (push completed) or expired


### PR DESCRIPTION
## Purpose

Add opt-in, privacy-safe lifecycle tracing for both NIXL transfer modes:

- `NixlConnector` pull: KV availability, READ staging/start, and producer/consumer completion or failure.
- `NixlPushConnector` push: KV availability, registration stage/queue/send/receive, explicit prefill-to-decode block matching, WRITE start, and producer/consumer completion or failure.
- A connector-generic typed sink and versioned `vllm-kv-connector-v1` structured-log schema that future connector adapters can reuse.
- Deterministic sampling by the stable request-group ID so related vLLM IDs share a decision.
- Hashed request, request-group, and remote-request correlation fields. The lifecycle records contain no raw request IDs, hostnames, engine IDs, process IDs, or request IDs in Prometheus labels.
- A shared stateless no-op sink when tracing is disabled (the default), with no per-request trace state to clean up.
- NIXL usage documentation for the opt-in `kv_connector_lifecycle_trace_sample_rate` setting.

This intentionally does not add frontend, EngineCore, scheduler-queue, or token-level spans. I searched open vLLM PRs for NIXL/KV-connector lifecycle tracing and found no PR implementing these connector transitions. The closest work is #44402 (fine-grained core request timing), #32573 (token-level OpenTelemetry tracing), and #43005 (server-span context propagation); this PR complements those by covering NIXL control/data-plane internals.

AI assistance was used to review the handoff, inspect current upstream code, implement the change, and prepare tests and documentation. I reviewed the resulting changes and am opening this as a draft for further human review.

## Test Plan

- Verify disabled/enabled sink behavior, deterministic related-ID sampling, hashed structured output, configuration validation, and timestamp/schema fields.
- Verify pull emits a request-correlated transfer-start transition.
- Verify push emits registration staging, producer availability, registration receipt, and explicit prefill/decode block-match correlation.
- Run all changed-file pre-commit hooks and mypy for Python 3.10 and 3.12.
- Run focused unit tests in upstream CI.

## Test Result

Passed locally:

```text
changed-file pre-commit hooks: passed
mypy Python 3.10: passed
mypy Python 3.12: passed
Python compile checks: passed
standalone schema/privacy/sampling checks: passed
git diff --check: passed
```

The focused pytest files were not run locally because this macOS checkout's project resolver attempts to resolve an unavailable Linux CPU Torch build. The tests are included for upstream CI, and this limitation is why the PR remains a draft.

Model evaluations were not run because this is opt-in observability code and does not change model outputs, scheduling decisions, or KV-transfer behavior. No performance claim is made; tracing is disabled by default and selects a stateless no-op sink.