### PR TITLE
[XPU][Bugfix] Defer Inductor compile-time autotuning to avoid fatal profile_run abort

### DIFF
--- a/vllm/platforms/xpu.py
+++ b/vllm/platforms/xpu.py
@@ -354,6 +354,23 @@ class XPUPlatform(Platform):
                 "weight offloading is enabled."
             )
 
+        # Inductor's compile-time autotuning (triton.autotune_at_compile_time,
+        # enabled by default under AOT compile) benchmarks each generated
+        # Triton kernel once at compile time using synthetic random inputs.
+        # Kernels whose index is derived from floating-point intermediate
+        # data (e.g. RoPE/MLA position or offset arithmetic) get a genuinely
+        # randomized index at that point, which can be out of range and trip
+        # the tl.device_assert bounds check Inductor emits for indirect
+        # indexing. On XPU a failed device-side assert is fatal to the whole
+        # process (unlike CPU/CUDA), aborting profile_run with an opaque,
+        # contentless "Failed to run autotuning code block:" error. Defer
+        # autotuning to the first real runtime call, where indices are
+        # always in range. See https://github.com/pytorch/pytorch/issues/194018.
+        if compilation_config.mode != CompilationMode.NONE:
+            compilation_config.inductor_compile_config.setdefault(
+                "triton.autotune_at_compile_time", False
+            )
+
         # check and update parallel config
         parallel_config = vllm_config.parallel_config
         # Only override worker_cls if it's still the default "auto"

--- a/xpu_autotune_repro.py
+++ b/xpu_autotune_repro.py
@@ -1,0 +1,93 @@
+"""
+Minimal reproduction of: torch.compile aborts during Inductor's compile-time
+autotuning on Intel XPU, with an opaque "Failed to run autotuning code
+block:" error, mimicking vLLM's `profile_run`/`_dummy_run` AOT compile path.
+
+Root cause: with `triton.autotune_at_compile_time` enabled (the default
+whenever `V.aot_compilation` is True, e.g. under `torch.compile(...).aot_
+compile(...)`, which is exactly what vLLM's compilation wrapper calls during
+profile_run), Inductor benchmarks each generated Triton kernel once, at
+*compile time*, using synthetic example tensors instead of real runtime data
+(torch._dynamo.testing.rand_strided). For plain integer/bool graph inputs,
+rand_strided zero-fills the tensor -- so a kernel that only indexes directly
+with a graph-input index tensor will NOT trip this bug. But any kernel that
+computes an index from *floating-point* intermediate data (as RoPE/MLA
+position/offset arithmetic commonly does) gets a genuinely randomized
+(torch.randn-based) float buffer, and any downstream integer index derived
+from it can be wildly out of range. Inductor still emits a
+`tl.device_assert` bounds check for that kernel (since it cannot statically
+prove the real runtime range), and this random out-of-range access is fed to
+that kernel purely for the sake of finding good launch configs.
+
+On CUDA a bad device access here typically raises a catchable Python
+exception. On XPU it hits the Level-Zero driver as a fatal error (observed
+here as `UR_RESULT_ERROR_OUT_OF_RESOURCES`, and as a full process abort/core
+dump when `TRITON_DEBUG=1` enables the assert message itself), which
+`generate_and_run_autotune_block()` cannot cleanly recover from.
+
+Usage:
+    python repro.py            # reproduces the crash
+                                # (triton.autotune_at_compile_time enabled)
+    python repro.py --fixed    # applies the proposed mitigation:
+                                # triton.autotune_at_compile_time = False
+                                # (defers autotuning to the first real call,
+                                # where the index is always in-range)
+
+    # Optionally set TRITON_DEBUG=1 to make the underlying device_assert
+    # message itself visible (this tends to fully abort/core-dump the
+    # process instead of raising a catchable Python exception):
+    TRITON_DEBUG=1 python repro.py
+"""
+
+import argparse
+
+import torch
+import torch._inductor.config as inductor_config
+
+parser = argparse.ArgumentParser()
+parser.add_argument(
+    "--fixed",
+    action="store_true",
+    help="apply the proposed fix (defer compile-time autotuning to runtime)",
+)
+args = parser.parse_args()
+
+device = "xpu"
+VOCAB, DIM, N = 128, 256, 64
+table = torch.randn(VOCAB, DIM, device=device)
+
+
+def gather_fn(pos: torch.Tensor) -> torch.Tensor:
+    # Index computed from a float tensor, mimicking RoPE/MLA position/offset
+    # arithmetic. At real runtime `pos` is guaranteed in [0, 1), so `idx` is
+    # always in [0, VOCAB) -- but Inductor cannot prove that statically, so
+    # it still emits a tl.device_assert bounds check in the generated kernel.
+    idx = (pos * float(VOCAB)).floor().long()
+    gathered = table.index_select(0, idx)
+    return gathered * 2.0 + 1.0
+
+
+inductor_config.triton.autotune_at_compile_time = not args.fixed
+print(f"[repro] triton.autotune_at_compile_time = "
+      f"{inductor_config.triton.autotune_at_compile_time}")
+
+pos = torch.rand(N, device=device)  # always in [0, 1) -> idx always valid at runtime
+
+with torch._dynamo.config.patch(enable_aot_compile=True):
+    compiled = torch.compile(gather_fn, fullgraph=True)
+
+with torch.no_grad():
+    out = compiled(pos)
+    torch.xpu.synchronize()
+    print("[repro] regular compiled call OK")
+
+    # Mirrors vllm/compilation/wrapper.py's aot_compile() path used during
+    # profile_run: self._compiled_callable.aot_compile((args, kwargs))
+    aot_fn = compiled.aot_compile(((pos,), {}))
+    torch.xpu.synchronize()
+    print("[repro] aot_compile() returned OK")
+
+    result = aot_fn(pos)
+    torch.xpu.synchronize()
+
+print("[repro] SUCCESS: no crash.")


### PR DESCRIPTION
## Purpose

On Intel XPU, serving a model with `torch.compile` enabled (the default `VLLM_COMPILE` path) can abort during startup's `profile_run()` -> `_dummy_run()` -> AOT `standalone_compile`, with an opaque, contentless error:

```
torch._inductor.exc.InductorError: RuntimeError: Failed to run autotuning code block:
```

Root cause (filed upstream: https://github.com/pytorch/pytorch/issues/194018): Inductor's compile-time autotuning (`triton.autotune_at_compile_time`, enabled by default whenever `V.aot_compilation` is set -- which is exactly the path `vllm/compilation/wrapper.py`'s `aot_compile()` uses during `profile_run`) benchmarks each generated Triton kernel once at compile time using synthetic random inputs (`torch._dynamo.testing.rand_strided`). Kernels whose index is derived from floating-point intermediate data (RoPE/MLA position or offset arithmetic is a common pattern in MLA architectures such as DeepSeek-V2/V3/GLM) get a genuinely randomized index at that point, which can be out of range and trip the `tl.device_assert` bounds check Inductor emits for indirect indexing (`assert_indirect_indexing=True` by default). On CPU/CUDA this is generally recoverable; on XPU a failed device-side assert is fatal to the Level-Zero driver context, killing the whole worker process and surfacing only the opaque message above.

This is not an XPU-only codegen bug -- the graph/codegen path is identical across backends -- but XPU's fatal handling of the underlying device fault makes it the only backend where this currently surfaces as a hard crash. A proper fix belongs in PyTorch Inductor (clamp/mask the synthesized index tensors, or relax the assert during the autotune-benchmarking exec block); this PR is the vLLM-side mitigation until that lands upstream.

**Fix**: default `triton.autotune_at_compile_time` to `False` on XPU whenever compilation is enabled, in `XPUPlatform.check_and_update_config`, following the same `inductor_compile_config.setdefault(...)` pattern already used a few lines above for `use_static_cuda_launcher`. This defers autotuning to the first real runtime call, where indices are always in range, so kernel launch configs are still tuned -- just slightly later. `setdefault()` preserves any explicit user override.

## Test Plan

Standalone, self-contained repro (`xpu_autotune_repro.py`, included in this PR) that mirrors `vllm/compilation/wrapper.py`'s `aot_compile()` call with a kernel doing float-derived indirect indexing (mimicking RoPE/MLA gather arithmetic):

```bash
python xpu_autotune_repro.py            # exercises the bug (autotune_at_compile_time=True)
python xpu_autotune_repro.py --fixed    # applies the fix (autotune_at_compile_time=False)
```

Full source of `xpu_autotune_repro.py`:

```python
"""
Minimal reproduction of: torch.compile aborts during Inductor's compile-time
autotuning on Intel XPU, with an opaque "Failed to run autotuning code
block:" error, mimicking vLLM's `profile_run`/`_dummy_run` AOT compile path.

Root cause: with `triton.autotune_at_compile_time` enabled (the default
whenever `V.aot_compilation` is True, e.g. under `torch.compile(...).aot_
compile(...)`, which is exactly what vLLM's compilation wrapper calls during
profile_run), Inductor benchmarks each generated Triton kernel once, at
*compile time*, using synthetic example tensors instead of real runtime data
(torch._dynamo.testing.rand_strided). For plain integer/bool graph inputs,
rand_strided zero-fills the tensor -- so a kernel that only indexes directly
with a graph-input index tensor will NOT trip this bug. But any kernel that
computes an index from *floating-point* intermediate data (as RoPE/MLA
position/offset arithmetic commonly does) gets a genuinely randomized
(torch.randn-based) float buffer, and any downstream integer index derived
from it can be wildly out of range. Inductor still emits a
`tl.device_assert` bounds check for that kernel (since it cannot statically
prove the real runtime range), and this random out-of-range access is fed to
that kernel purely for the sake of finding good launch configs.

On CUDA a bad device access here typically raises a catchable Python
exception. On XPU it hits the Level-Zero driver as a fatal error (observed
here as `UR_RESULT_ERROR_OUT_OF_RESOURCES`, and as a full process abort/core
dump when `TRITON_DEBUG=1` enables the assert message itself), which
`generate_and_run_autotune_block()` cannot cleanly recover from.

Usage:
    python repro.py            # reproduces the crash
                                # (triton.autotune_at_compile_time enabled)
    python repro.py --fixed    # applies the proposed mitigation:
                                # triton.autotune_at_compile_time = False
                                # (defers autotuning to the first real call,
                                # where the index is always in-range)

    # Optionally set TRITON_DEBUG=1 to make the underlying device_assert
    # message itself visible (this tends to fully abort/core-dump the
    # process instead of raising a catchable Python exception):
    TRITON_DEBUG=1 python repro.py
"""

import argparse

import torch
import torch._inductor.config as inductor_config

parser = argparse.ArgumentParser()
parser.add_argument(
    "--fixed",
    action="store_true",
    help="apply the proposed fix (defer compile-time autotuning to runtime)",
)
args = parser.parse_args()

device = "xpu"
VOCAB, DIM, N = 128, 256, 64
table = torch.randn(VOCAB, DIM, device=device)


def gather_fn(pos: torch.Tensor) -> torch.Tensor:
    # Index computed from a float tensor, mimicking RoPE/MLA position/offset
    # arithmetic. At real runtime `pos` is guaranteed in [0, 1), so `idx` is
    # always in [0, VOCAB) -- but Inductor cannot prove that statically, so
    # it still emits a tl.device_assert bounds check in the generated kernel.
    idx = (pos * float(VOCAB)).floor().long()
    gathered = table.index_select(0, idx)
    return gathered * 2.0 + 1.0


inductor_config.triton.autotune_at_compile_time = not args.fixed
print(f"[repro] triton.autotune_at_compile_time = "
      f"{inductor_config.triton.autotune_at_compile_time}")

pos = torch.rand(N, device=device)  # always in [0, 1) -> idx always valid at runtime

with torch._dynamo.config.patch(enable_aot_compile=True):
    compiled = torch.compile(gather_fn, fullgraph=True)

with torch.no_grad():
    out = compiled(pos)
    torch.xpu.synchronize()
    print("[repro] regular compiled call OK")

    # Mirrors vllm/compilation/wrapper.py's aot_compile() path used during
    # profile_run: self._compiled_callable.aot_compile((args, kwargs))
    aot_fn = compiled.aot_compile(((pos,), {}))
    torch.xpu.synchronize()
    print("[repro] aot_compile() returned OK")

    result = aot_fn(pos)
    torch.xpu.synchronize()

print("[repro] SUCCESS: no crash.")
```

Additionally, exercised the actual patched `XPUPlatform.check_and_update_config` directly against a real `VllmConfig` to confirm the config mutation takes effect exactly as vLLM would apply it.

**Not yet run**: a full `vllm serve` / gsm8k end-to-end comparison on the original reported model (GLM-5.2-FP8, MLA, TP=8) -- that model/hardware configuration wasn't available in the environment used to prepare this PR. The reporter's original eager-mode gsm8k run (`--limit 50`) scored 0.94/0.94 (strict/flexible), matching the GPU reference; the compile+deferred-autotune gsm8k comparison is still needed before merge and will be added by the PR author.

## Test Result

Run on real Intel Arc Pro B60 XPU hardware (8x, torch 2.14.0+xpu, triton 3.8.0):

```
=== BUGGY (autotune_at_compile_time=True, the default under aot_compile) ===
torch._inductor.exc.InductorError: RuntimeError: Failed to run autotuning code block:
level_zero backend failed with error: 40 (UR_RESULT_ERROR_OUT_OF_RESOURCES)

=== FIXED (autotune_at_compile_time=False, this PR) ===
[repro] regular compiled call OK
[repro] aot_compile() returned OK
[repro] SUCCESS: no crash.
```
 
