### PR TITLE
[Pooling] Use semantic task validation errors

### DIFF
--- a/vllm/entrypoints/pooling/pooling/serving.py
+++ b/vllm/entrypoints/pooling/pooling/serving.py
@@ -5,6 +5,7 @@ from typing import cast
 from fastapi.responses import JSONResponse, Response, StreamingResponse
 from typing_extensions import assert_never
 
+from vllm.exceptions import VLLMValidationError
 from vllm.logger import init_logger
 from vllm.outputs import PoolingRequestOutput
 from vllm.tasks import SupportedTask
@@ -60,7 +61,9 @@ class ServingPooling(PoolingBaseServing):
 
     def _verify_pooling_task(self, request: PoolingRequest) -> str:
         if getattr(request, "dimensions", None) is not None:
-            raise ValueError("dimensions is currently not supported")
+            raise VLLMValidationError(
+                "dimensions is currently not supported", parameter="dimensions"
+            )
 
         if request.task is None:
             request.task = self.pooling_task
@@ -74,22 +77,25 @@ class ServingPooling(PoolingBaseServing):
         # plugin task uses io_processor.parse_request to verify inputs
         if pooling_task != "plugin" and pooling_task != self.pooling_task:
             if pooling_task not in self.supported_tasks:
-                raise ValueError(
+                raise VLLMValidationError(
                     f"Unsupported task: {pooling_task!r} "
-                    f"Supported tasks: {self.supported_tasks}"
+                    f"Supported tasks: {self.supported_tasks}",
+                    parameter="task",
                 )
             else:
-                raise ValueError(
+                raise VLLMValidationError(
                     "Try switching the model's pooling_task "
-                    f"via --pooler-config.task {request.task}."
+                    f"via --pooler-config.task {request.task}.",
+                    parameter="task",
                 )
 
         if pooling_task == "plugin" and "plugin" not in self.io_processors:
-            raise ValueError(
+            raise VLLMValidationError(
                 "No IOProcessor plugin installed. Please refer "
                 "to the documentation and to the "
                 "'prithvi_geospatial_mae_io_processor' "
-                "offline inference example for more details."
+                "offline inference example for more details.",
+                parameter="task",
             )
 
         return pooling_task


### PR DESCRIPTION
## Purpose

Part of #48227. Replace raw `ValueError`s in `/pooling` task validation with structured `VLLMValidationError`s identifying the `dimensions` or `task` parameter.

## Main vs Branch

**Main:**
```text
dimensions: ValueError, parameter=None
unsupported task: ValueError, parameter=None
wrong configured task: ValueError, parameter=None
missing plugin: ValueError, parameter=None
```

**Branch:**

```text
dimensions: VLLMValidationError, parameter=dimensions
unsupported task: VLLMValidationError, parameter=task
wrong configured task: VLLMValidationError, parameter=task
missing plugin: VLLMValidationError, parameter=task
```

### AI Assistance
OpenAI Codex (GPT-5) assisted with drafting the change. I reviewed every changed line and personally ran the reported validation.