### PR TITLE
[Revert][MM] Restore multimodal metadata device placement

### DIFF
--- a/vllm/model_executor/models/cohere2_vision.py
+++ b/vllm/model_executor/models/cohere2_vision.py
@@ -268,7 +268,7 @@ class Cohere2VisionMultiModalProcessor(
         num_patches = hf_inputs.get("num_patches", torch.empty(0))
         return dict(
             pixel_values=MultiModalFieldConfig.flat_from_sizes("image", num_patches),
-            num_patches=MultiModalFieldConfig.batched("image", keep_on_cpu=True),
+            num_patches=MultiModalFieldConfig.batched("image"),
             image_embeds=MultiModalFieldConfig.batched("image"),
         )
 

--- a/vllm/model_executor/models/deepseek_ocr.py
+++ b/vllm/model_executor/models/deepseek_ocr.py
@@ -320,9 +320,7 @@ class DeepseekOCRMultiModalProcessor(
         patches_per_image = torch.where(is_tiled, images_spatial_crop.prod(dim=-1), 0)
         return dict(
             pixel_values=MultiModalFieldConfig.batched("image"),
-            images_spatial_crop=MultiModalFieldConfig.batched(
-                "image", keep_on_cpu=True
-            ),
+            images_spatial_crop=MultiModalFieldConfig.batched("image"),
             images_crop=MultiModalFieldConfig.flat_from_sizes(
                 "image", patches_per_image
             ),

--- a/vllm/model_executor/models/deepseek_ocr2.py
+++ b/vllm/model_executor/models/deepseek_ocr2.py
@@ -191,9 +191,7 @@ class DeepseekOCR2MultiModalProcessor(
         patches_per_image = torch.where(is_tiled, images_spatial_crop.prod(dim=-1), 0)
         return dict(
             pixel_values=MultiModalFieldConfig.batched("image"),
-            images_spatial_crop=MultiModalFieldConfig.batched(
-                "image", keep_on_cpu=True
-            ),
+            images_spatial_crop=MultiModalFieldConfig.batched("image"),
             images_crop=MultiModalFieldConfig.flat_from_sizes(
                 "image", patches_per_image
             ),

--- a/vllm/model_executor/models/deepseek_vl2.py
+++ b/vllm/model_executor/models/deepseek_vl2.py
@@ -270,9 +270,7 @@ class DeepseekVL2MultiModalProcessor(
 
         return dict(
             pixel_values=MultiModalFieldConfig.flat_from_sizes("image", num_patches),
-            images_spatial_crop=MultiModalFieldConfig.batched(
-                "image", keep_on_cpu=True
-            ),
+            images_spatial_crop=MultiModalFieldConfig.batched("image"),
             image_embeds=MultiModalFieldConfig.batched("image"),
         )
 

--- a/vllm/model_executor/models/ernie45_vl.py
+++ b/vllm/model_executor/models/ernie45_vl.py
@@ -1246,11 +1246,11 @@ class Ernie4_5VLMultiModalProcessor(BaseMultiModalProcessor[Ernie4_5_VLProcessin
             pixel_values=MultiModalFieldConfig.flat_from_sizes(
                 "image", image_grid_sizes
             ),
-            image_grid_thw=MultiModalFieldConfig.batched("image", keep_on_cpu=True),
+            image_grid_thw=MultiModalFieldConfig.batched("image"),
             pixel_values_videos=MultiModalFieldConfig.flat_from_sizes(
                 "video", video_grid_sizes
             ),
-            video_grid_thw=MultiModalFieldConfig.batched("video", keep_on_cpu=True),
+            video_grid_thw=MultiModalFieldConfig.batched("video"),
         )
 
 

--- a/vllm/model_executor/models/fireredasr2.py
+++ b/vllm/model_executor/models/fireredasr2.py
@@ -260,7 +260,7 @@ class FireRedASR2MultiModalProcessor(
         return dict(
             input_features=MultiModalFieldConfig.batched("audio"),
             speech_lengths=MultiModalFieldConfig.batched("audio"),
-            fake_token_lengths=MultiModalFieldConfig.batched("audio", keep_on_cpu=True),
+            fake_token_lengths=MultiModalFieldConfig.batched("audio"),
         )
 
     def _get_prompt_updates(

--- a/vllm/model_executor/models/fireredlid.py
+++ b/vllm/model_executor/models/fireredlid.py
@@ -482,8 +482,8 @@ class FireRedLIDMultiModalProcessor(
     ) -> Mapping[str, MultiModalFieldConfig]:
         return dict(
             input_features=MultiModalFieldConfig.batched("audio"),
-            speech_lengths=MultiModalFieldConfig.batched("audio", keep_on_cpu=True),
-            fake_token_lengths=MultiModalFieldConfig.batched("audio", keep_on_cpu=True),
+            speech_lengths=MultiModalFieldConfig.batched("audio"),
+            fake_token_lengths=MultiModalFieldConfig.batched("audio"),
         )
 
     def _get_prompt_updates(

--- a/vllm/model_executor/models/funasr.py
+++ b/vllm/model_executor/models/funasr.py
@@ -779,7 +779,7 @@ class FunASRMultiModalProcessor(BaseMultiModalProcessor[FunASRProcessingInfo]):
         return dict(
             input_features=MultiModalFieldConfig.batched("audio"),
             speech_lengths=MultiModalFieldConfig.batched("audio"),
-            fake_token_lengths=MultiModalFieldConfig.batched("audio", keep_on_cpu=True),
+            fake_token_lengths=MultiModalFieldConfig.batched("audio"),
         )
 
     def _get_prompt_updates(

--- a/vllm/model_executor/models/funaudiochat.py
+++ b/vllm/model_executor/models/funaudiochat.py
@@ -695,9 +695,7 @@ class FunAudioChatMultiModalProcessor(
     ) -> Mapping[str, MultiModalFieldConfig]:
         return {
             "speech_ids": MultiModalFieldConfig.batched("audio"),
-            "speech_attention_mask": MultiModalFieldConfig.batched(
-                "audio", keep_on_cpu=True
-            ),
+            "speech_attention_mask": MultiModalFieldConfig.batched("audio"),
             "input_features": MultiModalFieldConfig.batched("audio"),
             "feature_attention_mask": MultiModalFieldConfig.batched("audio"),
             "feature_exist_mask": MultiModalFieldConfig.batched("audio"),

--- a/vllm/model_executor/models/glmasr.py
+++ b/vllm/model_executor/models/glmasr.py
@@ -625,13 +625,13 @@ def _glmasr_field_config(
             feature_attention_mask=MultiModalFieldConfig.flat_from_sizes(
                 "audio", chunk_counts, dim=0
             ),
-            chunk_counts=MultiModalFieldConfig.batched("audio", keep_on_cpu=True),
+            chunk_counts=MultiModalFieldConfig.batched("audio"),
         )
     return dict(
         audio_embeds=MultiModalFieldConfig.batched("audio"),
         input_features=MultiModalFieldConfig.batched("audio"),
         feature_attention_mask=MultiModalFieldConfig.batched("audio"),
-        chunk_counts=MultiModalFieldConfig.batched("audio", keep_on_cpu=True),
+        chunk_counts=MultiModalFieldConfig.batched("audio"),
     )
 
 

--- a/vllm/model_executor/models/granite4_vision.py
+++ b/vllm/model_executor/models/granite4_vision.py
@@ -398,7 +398,7 @@ class Granite4VisionMultiModalProcessor(
     ) -> Mapping[str, MultiModalFieldConfig]:
         return dict(
             pixel_values=MultiModalFieldConfig.batched("image"),
-            image_sizes=MultiModalFieldConfig.batched("image", keep_on_cpu=True),
+            image_sizes=MultiModalFieldConfig.batched("image"),
         )
 
 

--- a/vllm/model_executor/models/hyperclovax_vision.py
+++ b/vllm/model_executor/models/hyperclovax_vision.py
@@ -324,14 +324,10 @@ class HCXVisionMultiModalProcessor(BaseMultiModalProcessor[HCXVisionProcessingIn
     ) -> Mapping[str, MultiModalFieldConfig]:
         fields = dict(
             pixel_values_images=MultiModalFieldConfig.batched("image"),
-            image_sizes_images=MultiModalFieldConfig.batched("image", keep_on_cpu=True),
-            vision_query_lengths_images=MultiModalFieldConfig.batched(
-                "image", keep_on_cpu=True
-            ),
+            image_sizes_images=MultiModalFieldConfig.batched("image"),
+            vision_query_lengths_images=MultiModalFieldConfig.batched("image"),
             pixel_values_videos=MultiModalFieldConfig.batched("video"),
-            vision_query_lengths_videos=MultiModalFieldConfig.batched(
-                "video", keep_on_cpu=True
-            ),
+            vision_query_lengths_videos=MultiModalFieldConfig.batched("video"),
         )
 
         return fields

--- a/vllm/model_executor/models/isaac.py
+++ b/vllm/model_executor/models/isaac.py
@@ -440,7 +440,7 @@ class IsaacMultiModalProcessor(BaseMultiModalProcessor):
             "pixel_values": MultiModalFieldConfig.flat_from_sizes(
                 "image", image_grid_sizes
             ),
-            "image_grid_thw": MultiModalFieldConfig.batched("image", keep_on_cpu=True),
+            "image_grid_thw": MultiModalFieldConfig.batched("image"),
         }
 
     def _get_prompt_updates(

--- a/vllm/model_executor/models/kanana_v.py
+++ b/vllm/model_executor/models/kanana_v.py
@@ -561,8 +561,8 @@ class KananaVMultiModalProcessor(BaseMultiModalProcessor[KananaVProcessingInfo])
 
         mm_fields_config = dict(
             pixel_values=MultiModalFieldConfig.flat_from_sizes("image", pixel_sizes),
-            vision_grid_thw=MultiModalFieldConfig.batched("image", keep_on_cpu=True),
-            image_token_thw=MultiModalFieldConfig.batched("image", keep_on_cpu=True),
+            vision_grid_thw=MultiModalFieldConfig.batched("image"),
+            image_token_thw=MultiModalFieldConfig.batched("image"),
         )
         return mm_fields_config
 

--- a/vllm/model_executor/models/keye_vl1_5.py
+++ b/vllm/model_executor/models/keye_vl1_5.py
@@ -309,15 +309,13 @@ def _keye_field_config(
     return dict(
         pixel_values=MultiModalFieldConfig.flat_from_sizes("image", image_grid_sizes),
         image_embeds=MultiModalFieldConfig.flat_from_sizes("image", image_grid_sizes),
-        image_grid_thw=MultiModalFieldConfig.batched("image", keep_on_cpu=True),
+        image_grid_thw=MultiModalFieldConfig.batched("image"),
         pixel_values_videos=MultiModalFieldConfig.flat_from_sizes(
             "video", video_num_patches
         ),
         video_embeds=MultiModalFieldConfig.flat_from_sizes("video", video_num_patches),
-        video_grid_thw=MultiModalFieldConfig.flat_from_sizes(
-            "video", video_num_grids, keep_on_cpu=True
-        ),
-        num_frames=MultiModalFieldConfig.batched("video", keep_on_cpu=True),
+        video_grid_thw=MultiModalFieldConfig.flat_from_sizes("video", video_num_grids),
+        num_frames=MultiModalFieldConfig.batched("video"),
     )
 
 

--- a/vllm/model_executor/models/kimi_audio.py
+++ b/vllm/model_executor/models/kimi_audio.py
@@ -201,7 +201,7 @@ class KimiAudioDummyInputsBuilder(BaseDummyInputsBuilder[KimiAudioProcessingInfo
 # Field config for Kimi-Audio multimodal data
 _KIMIAUDIO_FIELD_CONFIG = {
     "whisper_input_features": MultiModalFieldConfig.batched("audio"),
-    "feature_attention_mask": MultiModalFieldConfig.batched("audio", keep_on_cpu=True),
+    "feature_attention_mask": MultiModalFieldConfig.batched("audio"),
 }
 
 

--- a/vllm/model_executor/models/kimi_vl.py
+++ b/vllm/model_executor/models/kimi_vl.py
@@ -251,7 +251,7 @@ class KimiVLMultiModalProcessor(BaseMultiModalProcessor[KimiVLProcessingInfo]):
             pixel_values=MultiModalFieldConfig.flat_from_sizes(
                 "image", image_grid_sizes
             ),
-            image_grid_hws=MultiModalFieldConfig.batched("image", keep_on_cpu=True),
+            image_grid_hws=MultiModalFieldConfig.batched("image"),
         )
 
     def _get_prompt_updates(

--- a/vllm/model_executor/models/llava_onevision2.py
+++ b/vllm/model_executor/models/llava_onevision2.py
@@ -431,20 +431,20 @@ def _create_field_factory(
             image_embeds=MultiModalFieldConfig.flat_from_sizes(
                 "image", image_embed_grid_sizes
             ),
-            image_grid_thw=MultiModalFieldConfig.batched("image", keep_on_cpu=True),
+            image_grid_thw=MultiModalFieldConfig.batched("image"),
             # OV2 first-class MM kwarg: per-patch (t,h,w)
             # positions required by the 3-D vision RoPE.
             patch_positions=MultiModalFieldConfig.flat_from_sizes(
-                "image", image_pixel_grid_sizes, keep_on_cpu=True
+                "image", image_pixel_grid_sizes
             ),
             pixel_values_videos=MultiModalFieldConfig.flat_from_sizes(
                 "video", video_patch_sizes
             ),
             video_grid_thw=MultiModalFieldConfig.flat_from_sizes(
-                "video", video_num_frames, keep_on_cpu=True
+                "video", video_num_frames
             ),
             patch_positions_videos=MultiModalFieldConfig.flat_from_sizes(
-                "video", video_patch_sizes, keep_on_cpu=True
+                "video", video_patch_sizes
             ),
             video_num_frames=MultiModalFieldConfig.batched("video", keep_on_cpu=True),
             frame_timestamps=MultiModalFieldConfig.batched("video", keep_on_cpu=True),

--- a/vllm/model_executor/models/mimo_v2_omni.py
+++ b/vllm/model_executor/models/mimo_v2_omni.py
@@ -893,21 +893,17 @@ class MiMoV2OmniMultiModalProcessor(BaseMultiModalProcessor[MiMoV2OmniProcessing
         merge_size = self.info.get_hf_config().vision_config.spatial_merge_size
         fields: dict[str, MultiModalFieldConfig] = dict(
             **_create_qwen2vl_field_factory(merge_size)(hf_inputs),
-            second_per_grid_ts=MultiModalFieldConfig.batched("video", keep_on_cpu=True),
-            video_start_times=MultiModalFieldConfig.batched("video", keep_on_cpu=True),
+            second_per_grid_ts=MultiModalFieldConfig.batched("video"),
+            video_start_times=MultiModalFieldConfig.batched("video"),
             audio_features=MultiModalFieldConfig.batched("audio"),
-            audio_token_lens=MultiModalFieldConfig.batched("audio", keep_on_cpu=True),
+            audio_token_lens=MultiModalFieldConfig.batched("audio"),
         )
         # video_audio fields: only present when video_audio content was processed
         if "video_audio_n_segs" in hf_inputs:
-            fields["video_audio_n_segs"] = MultiModalFieldConfig.batched(
-                "video", keep_on_cpu=True
-            )
+            fields["video_audio_n_segs"] = MultiModalFieldConfig.batched("video")
         # video_audio_seg_lens: list of per-video 1D tensors, batched("video")
         if "video_audio_seg_lens" in hf_inputs:
-            fields["video_audio_seg_lens"] = MultiModalFieldConfig.batched(
-                "video", keep_on_cpu=True
-            )
+            fields["video_audio_seg_lens"] = MultiModalFieldConfig.batched("video")
         if "va_audio_features" in hf_inputs:
             fields["va_audio_features"] = MultiModalFieldConfig.batched("va_audio")
         return fields

--- a/vllm/model_executor/models/minicpmv.py
+++ b/vllm/model_executor/models/minicpmv.py
@@ -472,12 +472,12 @@ def get_version_by_config(config: PretrainedConfig) -> tuple[int, ...]:
 def _minicpmv_field_config(hf_inputs: Mapping[str, torch.Tensor]):
     return dict(
         pixel_values=MultiModalFieldConfig.batched("image"),
-        image_sizes=MultiModalFieldConfig.batched("image", keep_on_cpu=True),
-        tgt_sizes=MultiModalFieldConfig.batched("image", keep_on_cpu=True),
+        image_sizes=MultiModalFieldConfig.batched("image"),
+        tgt_sizes=MultiModalFieldConfig.batched("image"),
         image_embeds=MultiModalFieldConfig.batched("image"),
         video_pixel_values=MultiModalFieldConfig.batched("video"),
-        video_image_sizes=MultiModalFieldConfig.batched("video", keep_on_cpu=True),
-        video_tgt_sizes=MultiModalFieldConfig.batched("video", keep_on_cpu=True),
+        video_image_sizes=MultiModalFieldConfig.batched("video"),
+        video_tgt_sizes=MultiModalFieldConfig.batched("video"),
         video_embeds=MultiModalFieldConfig.batched("video"),
     )
 

--- a/vllm/model_executor/models/minicpmv4_6.py
+++ b/vllm/model_executor/models/minicpmv4_6.py
@@ -75,17 +75,15 @@ from .vision import is_vit_use_data_parallel
 def _minicpmv4_6_field_config(hf_inputs: Mapping[str, torch.Tensor]):
     fields = dict(
         pixel_values=MultiModalFieldConfig.batched("image"),
-        tgt_sizes=MultiModalFieldConfig.batched("image", keep_on_cpu=True),
+        tgt_sizes=MultiModalFieldConfig.batched("image"),
         image_embeds=MultiModalFieldConfig.batched("image"),
         video_pixel_values=MultiModalFieldConfig.batched("video"),
-        video_image_sizes=MultiModalFieldConfig.batched("video", keep_on_cpu=True),
-        video_tgt_sizes=MultiModalFieldConfig.batched("video", keep_on_cpu=True),
+        video_image_sizes=MultiModalFieldConfig.batched("video"),
+        video_tgt_sizes=MultiModalFieldConfig.batched("video"),
         video_embeds=MultiModalFieldConfig.batched("video"),
     )
     if "use_vit_merger" in hf_inputs:
-        fields["use_vit_merger"] = MultiModalFieldConfig.batched(
-            "image", keep_on_cpu=True
-        )
+        fields["use_vit_merger"] = MultiModalFieldConfig.batched("image")
     return fields
 
 

--- a/vllm/model_executor/models/mllama4.py
+++ b/vllm/model_executor/models/mllama4.py
@@ -653,8 +653,8 @@ class Mllama4MultiModalProcessor(BaseMultiModalProcessor[Mllama4ProcessingInfo])
             pixel_values=MultiModalFieldConfig.flat_from_sizes(
                 "image", patches_per_image
             ),
-            patches_per_image=MultiModalFieldConfig.batched("image", keep_on_cpu=True),
-            aspect_ratios=MultiModalFieldConfig.batched("image", keep_on_cpu=True),
+            patches_per_image=MultiModalFieldConfig.batched("image"),
+            aspect_ratios=MultiModalFieldConfig.batched("image"),
         )
 
     def _get_prompt_updates(

--- a/vllm/model_executor/models/molmo.py
+++ b/vllm/model_executor/models/molmo.py
@@ -1208,10 +1208,8 @@ class MolmoMultiModalProcessor(BaseMultiModalProcessor[MolmoProcessingInfo]):
             images=MultiModalFieldConfig.flat_from_sizes("image", num_crops),
             image_masks=MultiModalFieldConfig.flat_from_sizes("image", num_crops),
             image_input_idx=MultiModalFieldConfig.flat_from_sizes("image", num_crops),
-            num_crops=MultiModalFieldConfig.batched("image", keep_on_cpu=True),
-            img_patch_id=MultiModalFieldConfig.shared(
-                "image", num_images, keep_on_cpu=True
-            ),
+            num_crops=MultiModalFieldConfig.batched("image"),
+            img_patch_id=MultiModalFieldConfig.shared("image", num_images),
         )
 
     def _get_prompt_updates(

--- a/vllm/model_executor/models/molmo2.py
+++ b/vllm/model_executor/models/molmo2.py
@@ -2127,30 +2127,26 @@ class Molmo2MultiModalProcessor(BaseMultiModalProcessor[Molmo2ProcessingInfo]):
             image_token_pooling=MultiModalFieldConfig.flat_from_sizes(
                 "image", image_num_pooled_patches
             ),
-            image_num_crops=MultiModalFieldConfig.batched("image", keep_on_cpu=True),
-            image_num_pooled_patches=MultiModalFieldConfig.batched(
-                "image", keep_on_cpu=True
-            ),
-            image_num_patches=MultiModalFieldConfig.batched("image", keep_on_cpu=True),
+            image_num_crops=MultiModalFieldConfig.batched("image"),
+            image_num_pooled_patches=MultiModalFieldConfig.batched("image"),
+            image_num_patches=MultiModalFieldConfig.batched("image"),
             image_tokens=MultiModalFieldConfig.flat_from_sizes(
                 "image", num_image_tokens
             ),
-            num_image_tokens=MultiModalFieldConfig.batched("image", keep_on_cpu=True),
+            num_image_tokens=MultiModalFieldConfig.batched("image"),
             pixel_values_videos=MultiModalFieldConfig.flat_from_sizes(
                 "video", video_num_crops
             ),
             video_token_pooling=MultiModalFieldConfig.flat_from_sizes(
                 "video", video_num_pooled_patches
             ),
-            video_num_crops=MultiModalFieldConfig.batched("video", keep_on_cpu=True),
-            video_num_pooled_patches=MultiModalFieldConfig.batched(
-                "video", keep_on_cpu=True
-            ),
-            video_num_patches=MultiModalFieldConfig.batched("video", keep_on_cpu=True),
+            video_num_crops=MultiModalFieldConfig.batched("video"),
+            video_num_pooled_patches=MultiModalFieldConfig.batched("video"),
+            video_num_patches=MultiModalFieldConfig.batched("video"),
             video_tokens=MultiModalFieldConfig.flat_from_sizes(
                 "video", num_video_tokens
             ),
-            num_video_tokens=MultiModalFieldConfig.batched("video", keep_on_cpu=True),
+            num_video_tokens=MultiModalFieldConfig.batched("video"),
         )
 
     def _get_prompt_updates(

--- a/vllm/model_executor/models/moss_transcribe_diarize.py
+++ b/vllm/model_executor/models/moss_transcribe_diarize.py
@@ -352,12 +352,9 @@ def _mtd_field_config(
             audio_feature_lengths=MultiModalFieldConfig.flat_from_sizes(
                 "audio",
                 audio_chunk_counts,
-                keep_on_cpu=True,
             ),
-            audio_chunk_counts=MultiModalFieldConfig.batched("audio", keep_on_cpu=True),
-            audio_token_lengths=MultiModalFieldConfig.batched(
-                "audio", keep_on_cpu=True
-            ),
+            audio_chunk_counts=MultiModalFieldConfig.batched("audio"),
+            audio_token_lengths=MultiModalFieldConfig.batched("audio"),
         )
     return fields
 

--- a/vllm/model_executor/models/muse_glimmer.py
+++ b/vllm/model_executor/models/muse_glimmer.py
@@ -378,16 +378,12 @@ class MuseGlimmerMultiModalProcessor(
         if "image_pixel_values" in hf_inputs:
             fields.update(
                 image_pixel_values=MultiModalFieldConfig.batched("image"),
-                image_feature_sizes=MultiModalFieldConfig.batched(
-                    "image", keep_on_cpu=True
-                ),
+                image_feature_sizes=MultiModalFieldConfig.batched("image"),
             )
         if "video_pixel_values" in hf_inputs:
             fields.update(
                 video_pixel_values=MultiModalFieldConfig.batched("video"),
-                video_feature_sizes=MultiModalFieldConfig.batched(
-                    "video", keep_on_cpu=True
-                ),
+                video_feature_sizes=MultiModalFieldConfig.batched("video"),
             )
         return fields
 

--- a/vllm/model_executor/models/nano_nemotron_vl.py
+++ b/vllm/model_executor/models/nano_nemotron_vl.py
@@ -386,12 +386,10 @@ class NanoNemotronVLMultiModalProcessor(
 
         return dict(
             pixel_values_flat=pixel_values_flat,
-            image_num_patches=MultiModalFieldConfig.batched("image", keep_on_cpu=True),
+            image_num_patches=MultiModalFieldConfig.batched("image"),
             image_embeds=MultiModalFieldConfig.batched("image"),
-            num_tokens_per_image=MultiModalFieldConfig.batched(
-                "image", keep_on_cpu=True
-            ),
-            imgs_sizes=MultiModalFieldConfig.batched("image", keep_on_cpu=True),
+            num_tokens_per_image=MultiModalFieldConfig.batched("image"),
+            imgs_sizes=MultiModalFieldConfig.batched("image"),
         )
 
     def _get_video_fields_config(self, hf_inputs: BatchFeature):
@@ -401,9 +399,9 @@ class NanoNemotronVLMultiModalProcessor(
             pixel_values_flat_video=MultiModalFieldConfig.flat_from_sizes(
                 "video", video_num_patches
             ),
-            video_num_patches=MultiModalFieldConfig.batched("video", keep_on_cpu=True),
-            frames_indices=MultiModalFieldConfig.batched("video", keep_on_cpu=True),
-            frame_duration_ms=MultiModalFieldConfig.batched("video", keep_on_cpu=True),
+            video_num_patches=MultiModalFieldConfig.batched("video"),
+            frames_indices=MultiModalFieldConfig.batched("video"),
+            frame_duration_ms=MultiModalFieldConfig.batched("video"),
         )
 
     def _get_audio_fields_config(self, hf_inputs: BatchFeature):

--- a/vllm/model_executor/models/ovis.py
+++ b/vllm/model_executor/models/ovis.py
@@ -386,7 +386,7 @@ class OvisMultiModalProcessor(BaseMultiModalProcessor[OvisProcessingInfo]):
     ) -> Mapping[str, MultiModalFieldConfig]:
         return dict(
             pixel_values=MultiModalFieldConfig.batched("image"),
-            grids=MultiModalFieldConfig.batched("image", keep_on_cpu=True),
+            grids=MultiModalFieldConfig.batched("image"),
             indicator_tokens=MultiModalFieldConfig.batched("image"),
         )
 

--- a/vllm/model_executor/models/paddleocr_vl.py
+++ b/vllm/model_executor/models/paddleocr_vl.py
@@ -279,7 +279,7 @@ class PaddleOCRVLMultiModalProcessor(
     ) -> Mapping[str, MultiModalFieldConfig]:
         return dict(
             pixel_values=MultiModalFieldConfig.batched("image"),
-            image_grid_thw=MultiModalFieldConfig.batched("image", keep_on_cpu=True),
+            image_grid_thw=MultiModalFieldConfig.batched("image"),
         )
 
     def _get_prompt_updates(

--- a/vllm/model_executor/models/phi4mm.py
+++ b/vllm/model_executor/models/phi4mm.py
@@ -918,7 +918,7 @@ class Phi4MMMultiModalProcessor(BaseMultiModalProcessor[Phi4MMProcessingInfo]):
             input_image_embeds=MultiModalFieldConfig.batched("image"),
             image_attention_mask=MultiModalFieldConfig.batched("image"),
             image_sizes=MultiModalFieldConfig.batched("image", keep_on_cpu=True),
-            num_img_tokens=MultiModalFieldConfig.batched("image", keep_on_cpu=True),
+            num_img_tokens=MultiModalFieldConfig.batched("image"),
             input_audio_embeds=MultiModalFieldConfig.batched("audio"),
         )
 

--- a/vllm/model_executor/models/qwen2_5_omni_thinker.py
+++ b/vllm/model_executor/models/qwen2_5_omni_thinker.py
@@ -301,12 +301,8 @@ def create_qwen2_5_omni_thinker_field_factory(
             input_audio_features=MultiModalFieldConfig.flat_from_sizes(
                 "audio", audio_feature_lengths, dim=1
             ),
-            feature_attention_mask=MultiModalFieldConfig.batched(
-                "audio", keep_on_cpu=True
-            ),
-            audio_feature_lengths=MultiModalFieldConfig.batched(
-                "audio", keep_on_cpu=True
-            ),
+            feature_attention_mask=MultiModalFieldConfig.batched("audio"),
+            audio_feature_lengths=MultiModalFieldConfig.batched("audio"),
             pixel_values=MultiModalFieldConfig.flat_from_sizes(
                 "image", image_pixel_grid_sizes
             ),
@@ -322,9 +318,7 @@ def create_qwen2_5_omni_thinker_field_factory(
             ),
             video_grid_thw=MultiModalFieldConfig.batched("video", keep_on_cpu=True),
             second_per_grid_ts=MultiModalFieldConfig.batched("video", keep_on_cpu=True),
-            use_audio_in_video=MultiModalFieldConfig.shared(
-                "video", num_videos, keep_on_cpu=True
-            ),
+            use_audio_in_video=MultiModalFieldConfig.shared("video", num_videos),
         )
 
     return _qwen2_5_omni_thinker_field_config
@@ -1037,11 +1031,7 @@ class Qwen2_5OmniConditionalGenerationMixin:
         audio_input: Qwen2_5OmniAudioFeatureInputs,
     ) -> torch.Tensor:
         input_features = audio_input["input_features"]
-        # audio_feature_lengths is keep_on_cpu; the audio tower derives
-        # device placement from feature_lens, so move it explicitly.
-        audio_feature_lengths = audio_input["audio_feature_lengths"].to(
-            input_features.device, non_blocking=True
-        )
+        audio_feature_lengths = audio_input["audio_feature_lengths"]
 
         audio_feat_lengths, audio_output_lengths = (
             self.audio_tower._get_feat_extract_output_lengths(audio_feature_lengths)

--- a/vllm/model_executor/models/qwen2_audio.py
+++ b/vllm/model_executor/models/qwen2_audio.py
@@ -130,7 +130,7 @@ def _qwen2audio_field_config(hf_inputs: Mapping[str, torch.Tensor]):
     return dict(
         audio_embeds=MultiModalFieldConfig.batched("audio"),
         input_features=MultiModalFieldConfig.batched("audio"),
-        feature_attention_mask=MultiModalFieldConfig.batched("audio", keep_on_cpu=True),
+        feature_attention_mask=MultiModalFieldConfig.batched("audio"),
     )
 
 

--- a/vllm/model_executor/models/qwen3_asr.py
+++ b/vllm/model_executor/models/qwen3_asr.py
@@ -254,8 +254,8 @@ def _qwen3asr_field_config(hf_inputs: Mapping[str, torch.Tensor]):
         input_audio_features=MultiModalFieldConfig.flat_from_sizes(
             "audio", audio_feature_lengths, dim=1
         ),
-        feature_attention_mask=MultiModalFieldConfig.batched("audio", keep_on_cpu=True),
-        audio_feature_lengths=MultiModalFieldConfig.batched("audio", keep_on_cpu=True),
+        feature_attention_mask=MultiModalFieldConfig.batched("audio"),
+        audio_feature_lengths=MultiModalFieldConfig.batched("audio"),
     )
 
 
@@ -459,11 +459,7 @@ class Qwen3ASRForConditionalGeneration(
         audio_input: Qwen2_5OmniAudioFeatureInputs,
     ) -> torch.Tensor:
         input_features = audio_input["input_features"]
-        # audio_feature_lengths is keep_on_cpu; the audio tower derives
-        # device placement from feature_lens, so move it explicitly.
-        audio_feature_lengths = audio_input["audio_feature_lengths"].to(
-            input_features.device, non_blocking=True
-        )
+        audio_feature_lengths = audio_input["audio_feature_lengths"]
 
         audio_output_lengths = _get_feat_extract_output_lengths(audio_feature_lengths)
 

--- a/vllm/model_executor/models/qwen3_omni_moe_thinker.py
+++ b/vllm/model_executor/models/qwen3_omni_moe_thinker.py
@@ -1553,11 +1553,7 @@ class Qwen3OmniMoeConditionalGenerationMixin(Qwen2_5OmniConditionalGenerationMix
         audio_input: Qwen2_5OmniAudioFeatureInputs,
     ) -> tuple[torch.Tensor, ...]:
         input_features = audio_input["input_features"]
-        # audio_feature_lengths is keep_on_cpu; the audio tower derives
-        # device placement from feature_lens, so move it explicitly.
-        audio_feature_lengths = audio_input["audio_feature_lengths"].to(
-            input_features.device, non_blocking=True
-        )
+        audio_feature_lengths = audio_input["audio_feature_lengths"]
 
         audio_output_lengths = _get_feat_extract_output_lengths(audio_feature_lengths)
 

--- a/vllm/model_executor/models/step3_vl.py
+++ b/vllm/model_executor/models/step3_vl.py
@@ -202,7 +202,7 @@ class Step3VLMultiModalProcessor(BaseMultiModalProcessor[Step3VLProcessingInfo])
             ),
             num_patches=MultiModalFieldConfig.batched("image", keep_on_cpu=True),
             patch_newline_mask=MultiModalFieldConfig.flat_from_sizes(
-                "image", num_patches, keep_on_cpu=True
+                "image", num_patches
             ),
         )
 

--- a/vllm/model_executor/models/transformers/multimodal.py
+++ b/vllm/model_executor/models/transformers/multimodal.py
@@ -300,17 +300,11 @@ class MultiModalProcessor(BaseMultiModalProcessor[MultiModalProcessingInfo]):
 
         # Keep these as batched, as they always have batch size as first dim
         if "audio" in modalities:
-            mm_fields["num_audio_tokens"] = MultiModalFieldConfig.batched(
-                "audio", keep_on_cpu=True
-            )
+            mm_fields["num_audio_tokens"] = MultiModalFieldConfig.batched("audio")
         if "image" in modalities:
-            mm_fields["image_grid_thw"] = MultiModalFieldConfig.batched(
-                "image", keep_on_cpu=True
-            )
+            mm_fields["image_grid_thw"] = MultiModalFieldConfig.batched("image")
             # TODO: route to "video" once the video modality is supported
-            mm_fields["video_grid_thw"] = MultiModalFieldConfig.batched(
-                "image", keep_on_cpu=True
-            )
+            mm_fields["video_grid_thw"] = MultiModalFieldConfig.batched("image")
             mm_fields["num_image_patches"] = MultiModalFieldConfig.batched(
                 "image", keep_on_cpu=True
             )
@@ -760,12 +754,6 @@ class MultiModalMixin(SupportsMultiModal, SupportsMRoPE):
             return None
 
         num_image_patches = kwargs.pop("num_image_patches")
-
-        # grid_thw fields are registered keep_on_cpu; restore the on-device
-        # placement that HF get_image_features implementations expect.
-        for key, value in kwargs.items():
-            if isinstance(value, torch.Tensor):
-                kwargs[key] = value.to(pixel_values.device, non_blocking=True)
 
         # The underlying HuggingFace `get_image_features` implementations
         # contain model-internal syncs (e.g. Idefics3 filters all-zero

--- a/vllm/model_executor/models/ultravox.py
+++ b/vllm/model_executor/models/ultravox.py
@@ -251,7 +251,7 @@ class UltravoxMultiModalProcessor(BaseMultiModalProcessor[UltravoxProcessingInfo
                 "audio", num_chunks, keep_on_cpu=True
             ),
             # num_chunks can convert audio_chunked to audio batch dimension
-            audio_num_chunks=MultiModalFieldConfig.batched("audio", keep_on_cpu=True),
+            audio_num_chunks=MultiModalFieldConfig.batched("audio"),
             audio_embeds=MultiModalFieldConfig.batched("audio"),
         )
 

--- a/vllm/models/inkling/common/mm_preprocess.py
+++ b/vllm/models/inkling/common/mm_preprocess.py
@@ -307,12 +307,12 @@ class InklingMultiModalProcessor(BaseMultiModalProcessor[InklingProcessingInfo])
         return dict(
             # Ragged per-image patches, grouped by num_patches.
             pixel_values=MultiModalFieldConfig.flat_from_sizes("image", num_patches),
-            num_patches=MultiModalFieldConfig.batched("image", keep_on_cpu=True),
+            num_patches=MultiModalFieldConfig.batched("image"),
             # Ragged per-audio frames, grouped by num_audio_tokens.
             input_audio_features=MultiModalFieldConfig.flat_from_sizes(
                 "audio", num_audio_tokens
             ),
-            num_audio_tokens=MultiModalFieldConfig.batched("audio", keep_on_cpu=True),
+            num_audio_tokens=MultiModalFieldConfig.batched("audio"),
         )
 
     def _get_prompt_updates(


### PR DESCRIPTION
## Summary

Reverts #52827 (`deeeae75d0e42199aaeb627ad66e38b28337d2bf`) in full.

## Why

After #52827 merged, two H200 paths reproducibly tripped the strict GPU/CPU synchronization guard:

- Samplers: `samplers/test_beam_search.py::test_beam_search_passes_multimodal_data[2-64-half]` at `qwen2_audio.py:429`
- Extended Generation 1: `models/multimodal/generation/test_vit_cudagraph.py::test_vit_cudagraph_image[ernie45_vl]` at `ernie45_vl.py:1747`

The Samplers failure reproduced on three different hosts:

- [#84532 original on h200-ci-3](https://buildkite.com/vllm/ci/builds/84532#01a01813-8b7f-4c4d-9809-47e7119e8b3b)
- [#84533 on h200-ci-4](https://buildkite.com/vllm/ci/builds/84533#01a01815-6dc2-41f1-948e-3e5ca98d033b)
- [#84532 confirmation retry on h200-ci-2](https://buildkite.com/vllm/ci/builds/84532#01a0182c-17bf-4848-8fbc-01272e48f266)

Nightly [#84555](https://buildkite.com/vllm/ci/builds/84555) independently exposed the Ernie failure.

## PR CI coverage

[PR #52827's exact-head Buildkite #84489](https://buildkite.com/vllm/ci/builds/84489) passed overall, but H200 Samplers plus NVIDIA/AMD Extended Generation 1 were blocked. Neither exact failing test ran before merge.

## Validation

Local checks:

- `uvx ruff check` on all 38 reverted Python files: passed
- `git diff --check origin/main...HEAD`: passed

Exact H200 rollback CI at head `f44666396dcd4ecf30fba0752b1ff96809a81b55`:

- [Samplers #84540](https://buildkite.com/vllm/ci/builds/84540): passed on `h200-ci-3`
  - exact Qwen2-Audio beam-search case passed
  - selected 25-test inventory ran twice, 25 passed / 0 failed both times
- [Extended Generation 1 #84559](https://buildkite.com/vllm/ci/builds/84559): passed on `h200-ci-3`
  - exact Ernie CUDAGraph case passed
  - selected job completed successfully

## Final disposition

Focused forward fix [PR #52881](https://github.com/vllm-project/vllm/pull/52881) merged as main commit `ee117307512f` and is now fully exact-validated by [Buildkite #84562](https://buildkite.com/vllm/ci/builds/84562):

- H200 Samplers passed on `h200-ci-2`; the exact Qwen2-Audio case passed twice, with 25/25 selected tests in each run
- H200 Extended Generation 1 passed on `h200-ci-4`; the exact Ernie case passed, and the job completed 22 passed / 26 skipped / 56 deselected

The forward fix is proven, so this validated rollback is retired and closed without merge.

## Model evaluation

No separate model evaluation was run. This is an exact revert restoring the previously passing device-placement behavior.

## Duplicate-work check

No existing fix or revert was found when this rollback was opened. PR #52881 was subsequently opened and merged as the focused forward fix.

AI assistance was used to investigate CI logs, prepare the exact revert, and draft this description. The submitter reviewed the changed scope and owns the result.