### PR TITLE
[Perf][Frontend] Render plain completion stream deltas from a template

### DIFF
--- a/tests/entrypoints/openai/completion/test_stream_frame_template.py
+++ b/tests/entrypoints/openai/completion/test_stream_frame_template.py
@@ -1,0 +1,81 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Frames rendered from the per-stream template must be byte-identical to the
+frames the response models would have produced."""
+
+import json
+
+import pytest
+
+from vllm.entrypoints.openai.completion.protocol import (
+    CompletionResponseStreamChoice,
+    CompletionStreamResponse,
+)
+from vllm.entrypoints.openai.completion.serving import _delta_frame_template
+
+CREATED = 1706000000
+
+
+def model_frame(request_id: str, model_name: str, index: int, text: str) -> str:
+    chunk = CompletionStreamResponse(
+        id=request_id,
+        object="text_completion",
+        created=CREATED,
+        model=model_name,
+        choices=[
+            CompletionResponseStreamChoice(
+                index=index,
+                text=text,
+                logprobs=None,
+                finish_reason=None,
+                stop_reason=None,
+                prompt_token_ids=None,
+                token_ids=None,
+            )
+        ],
+    )
+    return f"data: {chunk.model_dump_json(exclude_unset=True)}\n\n"
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "",
+        "Hello, world",
+        ' "quoted" and \\backslashed\\ ',
+        "line\nbreaks\r\ttabs",
+        "\x00\x01\x1f\x7f",
+        "unicode é 日本語 🚀 \U0001d549\U0010ffff",
+    ],
+)
+@pytest.mark.parametrize(
+    ("request_id", "model_name", "index"),
+    [
+        ("cmpl-abc123", "meta-llama/Llama-3.1-8B", 0),
+        ('id "with" quotes\\', "модель 🎯", 7),
+    ],
+)
+def test_template_frame_matches_model_frame(
+    request_id: str, model_name: str, index: int, text: str
+):
+    prefix, infix, suffix = _delta_frame_template(request_id, CREATED, model_name)
+    frame = f"{prefix}{index}{infix}{json.dumps(text, ensure_ascii=False)}{suffix}"
+    assert frame == model_frame(request_id, model_name, index, text)
+
+
+def test_template_is_none_when_sentinels_are_ambiguous():
+    assert _delta_frame_template("cmpl-987654321", CREATED, "m") is None
+
+
+def test_delta_chunk_fields_are_frozen():
+    """The template tracks field order and formatting, but not a new field the
+    generator starts populating per chunk; adding one must fail here."""
+    assert set(CompletionResponseStreamChoice.model_fields) == {
+        "index",
+        "text",
+        "logprobs",
+        "finish_reason",
+        "stop_reason",
+        "prompt_token_ids",
+        "token_ids",
+    }

--- a/vllm/entrypoints/openai/completion/serving.py
+++ b/vllm/entrypoints/openai/completion/serving.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import asyncio
+import json
 import time
 from collections.abc import AsyncGenerator, AsyncIterator
 from collections.abc import Sequence as GenericSequence
@@ -48,6 +49,47 @@ from vllm.utils.collection_utils import as_list
 from vllm.utils.serial_utils import numpy2base64
 
 logger = init_logger(__name__)
+
+_PROBE_TEXT = "zZ_vllm_sse_probe_Zz"
+_PROBE_INDEX = 987654321
+
+
+def _delta_frame_template(
+    request_id: str, created_time: int, model_name: str
+) -> tuple[str, str, str] | None:
+    """Split a probe chunk into the parts of a plain-delta SSE frame that are
+    constant for a stream, so only index and text are rendered per chunk.
+
+    Taking them from the serializer keeps frames byte-identical to
+    ``model_dump_json(exclude_unset=True)`` if the models gain fields.
+
+    Returns:
+        ``(prefix, infix, suffix)``, or None if the sentinels are ambiguous.
+    """
+    probe = CompletionStreamResponse(
+        id=request_id,
+        object="text_completion",
+        created=created_time,
+        model=model_name,
+        choices=[
+            CompletionResponseStreamChoice(
+                index=_PROBE_INDEX,
+                text=_PROBE_TEXT,
+                logprobs=None,
+                finish_reason=None,
+                stop_reason=None,
+                prompt_token_ids=None,
+                token_ids=None,
+            )
+        ],
+    )
+    frame = f"data: {probe.model_dump_json(exclude_unset=True)}\n\n"
+    index, text = str(_PROBE_INDEX), json.dumps(_PROBE_TEXT)
+    if frame.count(index) != 1 or frame.count(text) != 1:
+        return None
+    prefix, rest = frame.split(index, 1)
+    infix, suffix = rest.split(text, 1)
+    return prefix, infix, suffix
 
 
 class OpenAIServingCompletion(GenerateBaseServing):
@@ -307,6 +349,19 @@ class OpenAIServingCompletion(GenerateBaseServing):
 
         last_res: RequestOutput | None = None
         try:
+            # Requests that can only emit plain delta chunks render them from a
+            # per-stream template; everything else uses the model path below.
+            delta_template = None
+            if (
+                not request.echo
+                and request.logprobs is None
+                and not request.return_token_ids
+                and not include_continuous_usage
+            ):
+                delta_template = _delta_frame_template(
+                    request_id, created_time, model_name
+                )
+
             async for prompt_idx, res in result_generator:
                 last_res = res
                 prompt_token_ids = res.prompt_token_ids
@@ -400,6 +455,15 @@ class OpenAIServingCompletion(GenerateBaseServing):
                     stop_reason = output.stop_reason
 
                     self._raise_if_error(finish_reason, request_id)
+
+                    if delta_template is not None and finish_reason is None:
+                        prefix, infix, suffix = delta_template
+                        yield (
+                            f"{prefix}{i}{infix}"
+                            f"{json.dumps(delta_text, ensure_ascii=False)}"
+                            f"{suffix}"
+                        )
+                        continue
 
                     chunk = CompletionStreamResponse(
                         id=request_id,


### PR DESCRIPTION
Working with smaller models I've noticed I pay "high tax" on format in every stream response. 

`completion_stream_generator` builds a `CompletionStreamResponse` and a
`CompletionResponseStreamChoice` per streamed chunk and dumps them with
`model_dump_json`. Everything in that frame except the choice index and the
delta text is constant for the whole stream.

This builds the constant parts once per stream, by dumping a single probe chunk
through the same models and splitting it on sentinels, so frames stay
byte-identical if the models gain fields. Requests using `echo`, `logprobs`,
`return_token_ids` or continuous usage, and every terminal chunk, keep the
model path.

This shows higher throughput on smaller model, a small fix that saves much. 
Per-frame render cost drops from 7.50 to 0.82 us (Python 3.12, pydantic 2.13).

## Test Plan

```bash
pytest tests/entrypoints/openai/completion/test_stream_frame_template.py
pre-commit run --files vllm/entrypoints/openai/completion/serving.py \
  tests/entrypoints/openai/completion/test_stream_frame_template.py
```

Serving benchmark on 1xH200, `vllm/vllm-openai:nightly`, default
`stream_interval=1`:

```bash
vllm serve <model> --api-server-count 1 --max-num-seqs 512 --max-model-len 2048
vllm bench serve --dataset-name random --random-input-len 32 \
  --random-output-len 512 --ignore-eos --num-prompts 3000 --max-concurrency 256
```

API-server CPU is read from `/proc/<pid>/stat`; arms alternate, medians shown.

## Test Result
| model | output tok/s | API-server us/token | API-server cores, before |
| --- | --- | --- | --- |
| SmolLM2-360M | 34,715 -> 47,806 | 29.03 -> 21.11 | 1.008 |
| TinyLlama-1.1B | 34,538 -> 47,081 | 29.07 -> 21.37 | 1.004 |
| Qwen3-0.6B | 33,411 -> 45,061 | 30.21 -> 22.44 | 1.010 |
| Qwen3-1.7B | 33,522 -> 42,513 | 30.13 -> 22.22 | 1.010 |
| SmolLM2-1.7B | 28,893 -> 29,035 | 31.69 -> 22.26 | 0.916 |
| Qwen3-4B | 27,720 -> 27,769 | 31.54 -> 22.11 | 0.872 |
| Qwen3-30B-A3B-FP8 | 21,149 -> 21,195 | 31.49 -> 22.01 | 0.666 |
| gpt-oss-120b | 8,329 -> 8,112 | 32.38 -> 22.24 | 0.270 |

API-server CPU per streamed token falls 26-31% on every model. Throughput only
moves where the API server is the bottleneck: the four models whose API-server
process was already drawing ~1.00 core gain 27-38%, the rest are unchanged
(gpt-oss-120b is inside its 5% arm-to-arm spread).

Output is unchanged.
Unpatched: 33,968 tok/s, 29.70 us/token. Patched
with the template path disabled: 33,859 tok/s, 29.78 us/token.